### PR TITLE
chore(notebook-cloud): script and document the preview deploy

### DIFF
--- a/apps/notebook-cloud/DEPLOY.md
+++ b/apps/notebook-cloud/DEPLOY.md
@@ -1,0 +1,45 @@
+# Deploying to preview.runt.run
+
+`preview.runt.run` is the hosted prototype: this Worker plus its Durable Object
+(`NOTEBOOK_ROOMS`), `DEPLOYMENT_ENV=prototype`, on the `preview.runt.run` custom
+domain. It runs real endpoints and real room logic (`runtimed` compiled to WASM),
+and the live demos run against it, so treat it as practically production.
+
+## Deploy
+
+From `apps/notebook-cloud`:
+
+```bash
+pnpm run deploy
+```
+
+That runs `pnpm run build` (compiles `runtimed` to WASM, builds the renderer
+plugins, bundles the viewer with Vite, copies assets) and then `wrangler deploy`.
+The top-level `wrangler.toml` is the prototype config (custom domain
+`preview.runt.run`, `DEPLOYMENT_ENV=prototype`), so there is no `--env` flag.
+
+## Verify
+
+```bash
+pnpm run deploy:check
+```
+
+`curl`s `https://preview.runt.run/api/health`. Expect `status: ok`,
+`deployment_env: prototype`, and both auth providers (`anaconda_api_key`, `oidc`)
+`configured`. `wrangler deploy` also prints the new Version ID.
+
+## Prerequisites
+
+- `wrangler` authenticated to the Cloudflare account that owns `runt.run`.
+  `wrangler whoami` should show `workers (write)`, `d1 (write)`, and
+  `workers_routes (write)`.
+- A Rust toolchain and `cargo xtask` for the WASM build.
+
+## Scope
+
+`pnpm run deploy` ships only the main rooms Worker (`wrangler.toml`), which carries
+the room logic and the viewer assets. The sibling Workers,
+`wrangler.output-document.toml` (the output-document iframe) and
+`wrangler.renderer-assets.toml` (the renderer assets Worker), change rarely and
+deploy independently with `wrangler deploy -c <file>`. Deploy those only when their
+own inputs change.

--- a/apps/notebook-cloud/package.json
+++ b/apps/notebook-cloud/package.json
@@ -7,6 +7,8 @@
     "renderer-plugins": "cargo xtask renderer-plugins",
     "build:viewer": "vp build -c vite.config.ts && node scripts/copy-viewer-assets.mjs",
     "build": "pnpm run wasm && pnpm run renderer-plugins && pnpm run build:viewer",
+    "deploy": "pnpm run build && wrangler deploy",
+    "deploy:check": "curl -fsS https://preview.runt.run/api/health",
     "pretypecheck": "cargo xtask wasm-ensure",
     "typecheck": "tsc -p tsconfig.json --noEmit",
     "test": "pnpm run wasm && node --import tsx --test test/*.test.ts test/*.test.mjs",


### PR DESCRIPTION
Formalizes the `preview.runt.run` deploy, which until now was an undocumented `pnpm run build` + `wrangler deploy` by hand.

- `pnpm run deploy` in `apps/notebook-cloud`: builds (wasm + renderer plugins + viewer) then `wrangler deploy`. The top-level `wrangler.toml` is the prototype config (custom domain `preview.runt.run`, `DEPLOYMENT_ENV=prototype`), so no `--env` flag.
- `pnpm run deploy:check`: curls `/api/health` to confirm `status: ok` and `deployment_env: prototype` after a deploy.
- `DEPLOY.md`: the procedure, prerequisites (wrangler authed to the `runt.run` Cloudflare account), and scope (this ships only the main rooms Worker; the `output-document` and `renderer-assets` sibling Workers deploy separately and rarely).

`preview.runt.run` is a practically-production prototype the live demos run against, so the guide says to treat deploys with care.
