### PR TITLE
fix(notebook-cloud): revalidate un-hashed renderer assets instead of immutable

### DIFF
--- a/apps/notebook-cloud/src/renderer-assets-worker.ts
+++ b/apps/notebook-cloud/src/renderer-assets-worker.ts
@@ -28,7 +28,7 @@ const rendererAssetsWorker: ExportedHandler<RendererAssetsEnv> = {
     const assetUrl = new URL(request.url);
     assetUrl.pathname = assetPathname;
     const response = await env.ASSETS.fetch(new Request(assetUrl, request));
-    return withRendererAssetCors(new Response(response.body, response), { immutable: true });
+    return withRendererAssetCors(new Response(response.body, response), { revalidate: true });
   },
 };
 
@@ -70,14 +70,20 @@ function json(value: unknown, status = 200): Response {
 
 function withRendererAssetCors(
   response: Response,
-  options: { immutable?: boolean } = {},
+  options: { revalidate?: boolean } = {},
 ): Response {
   response.headers.set("Access-Control-Allow-Origin", "*");
   response.headers.set("Access-Control-Allow-Methods", "GET, HEAD, OPTIONS");
   response.headers.set("Access-Control-Allow-Headers", "Content-Type");
   response.headers.set("Timing-Allow-Origin", "*");
-  if (options.immutable && response.ok) {
-    response.headers.set("Cache-Control", "public, max-age=31536000, immutable");
+  // Renderer assets ship under stable, un-hashed filenames (runtimed_wasm_bg.wasm,
+  // runtimed_wasm.js, isolated-renderer.js), so each load must revalidate against
+  // the etag. `immutable` here pinned a stale WASM in every browser for a year
+  // across deploys, skewing fresh viewer JS against an old WASM (a missing
+  // encode_interaction_presence export). If these ever get content-hashed
+  // filenames, immutable becomes safe again.
+  if (options.revalidate && response.ok) {
+    response.headers.set("Cache-Control", "public, max-age=0, must-revalidate");
   }
   return response;
 }


### PR DESCRIPTION
The renderer-assets Worker served every asset (`runtimed_wasm_bg.wasm`, `runtimed_wasm.js`, `isolated-renderer.js`) with `Cache-Control: public, max-age=31536000, immutable`. Those filenames carry no content hash, so `immutable` pinned the old WASM in every browser for a year. After a deploy the viewer JS revalidates and updates (it is served `max-age=0, must-revalidate`), but the WASM never refetches, so fresh JS calls a WASM export the stale module lacks: `encode_interaction_presence is not a function`. Only an empty-cache reload recovered it, which an external viewer will not know to do.

Serve the un-hashed renderer assets with `max-age=0, must-revalidate` so each load revalidates against the etag. 304s keep it cheap, and the next deploy then propagates to every client rather than being pinned out.

Follow-up (separate): content-hash the renderer asset filenames (WASM + plugins) so `immutable` is correct again and even already-cached clients pick up new content on the next deploy.
