### PR TITLE
feat(runtimed): cloud-transport spawn path + principal-derived doc actor (Phase 3c, code only)

### DIFF
--- a/crates/notebook-cloud-transport/Cargo.toml
+++ b/crates/notebook-cloud-transport/Cargo.toml
@@ -20,4 +20,4 @@ tokio-tungstenite = { version = "0.26", features = ["native-tls"] }
 tracing = "0.1"
 
 [dev-dependencies]
-tokio = { workspace = true, features = ["macros", "rt-multi-thread"] }
+tokio = { workspace = true, features = ["macros", "rt-multi-thread", "test-util"] }

--- a/crates/notebook-cloud-transport/src/lib.rs
+++ b/crates/notebook-cloud-transport/src/lib.rs
@@ -86,6 +86,40 @@ pub enum CloudAuth {
     Dev { token: String, user: String },
 }
 
+impl CloudAuth {
+    /// Return a copy of this auth with its credential replaced by `token`,
+    /// preserving the variant (and the `Dev` user label). Used by the
+    /// token-refresher path so a reconnect re-auths with a freshly-minted token
+    /// without changing the auth *kind* the room expects.
+    fn with_token(&self, token: String) -> Self {
+        match self {
+            CloudAuth::OidcBearer { .. } => CloudAuth::OidcBearer { token },
+            CloudAuth::AnacondaApiKey { .. } => CloudAuth::AnacondaApiKey { token },
+            CloudAuth::Dev { user, .. } => CloudAuth::Dev {
+                token,
+                user: user.clone(),
+            },
+        }
+    }
+}
+
+/// A closure the transport calls *before each connect* to obtain a fresh
+/// credential, replacing the static token in [`CloudWsConfig::auth`].
+///
+/// The cloud auth token is static for a single short session today, but a
+/// long-lived runtime peer outlives its OIDC token's expiry: every reconnect
+/// (idle eviction, blip) must re-auth, and a reconnect that re-presents an
+/// expired token is rejected at the upgrade, so `reconnect_with_backoff` would
+/// burn all its attempts and give up. A refresher lets the agent mint a fresh
+/// token per connect. `None` (the default) keeps the static-token behavior. The
+/// closure is `async` (refresh is typically a network round-trip) and its error
+/// surfaces as a connect error so the backoff loop retries.
+pub type TokenRefresher = Arc<
+    dyn Fn() -> std::pin::Pin<Box<dyn std::future::Future<Output = std::io::Result<String>> + Send>>
+        + Send
+        + Sync,
+>;
+
 /// Connection parameters for a cloud room. Immutable for the life of the
 /// transport, so [`CloudWsFrameTransport::connect`] can be called repeatedly on
 /// reconnect.
@@ -333,16 +367,36 @@ pub struct CloudWsFrameTransport {
     /// Principal from the most recent `cloud_room_ready`. Set on first connect;
     /// reconnects to the same room re-observe the same principal.
     principal: Arc<std::sync::OnceLock<String>>,
+    /// Optional per-connect token refresher. `None` keeps the static token from
+    /// `config.auth`. When set, `connect` calls it before each dial and re-auths
+    /// with the returned token so a long-lived peer survives token expiry across
+    /// reconnects.
+    refresher: Option<TokenRefresher>,
 }
 
 impl CloudWsFrameTransport {
-    /// Build a transport for `config`.
+    /// Build a transport for `config` with the static token in `config.auth`.
     pub fn new(config: CloudWsConfig) -> Self {
         let ws_url = build_ws_url(&config.cloud_url, &config.notebook_id);
         Self {
             config,
             ws_url,
             principal: Arc::new(std::sync::OnceLock::new()),
+            refresher: None,
+        }
+    }
+
+    /// Build a transport that mints a fresh credential before every connect via
+    /// `refresher`, replacing the token in `config.auth` (the variant and any
+    /// `Dev` user label are preserved). Use for long-lived runtime peers whose
+    /// OIDC token would otherwise expire mid-session and fail every reconnect.
+    pub fn with_token_refresher(config: CloudWsConfig, refresher: TokenRefresher) -> Self {
+        let ws_url = build_ws_url(&config.cloud_url, &config.notebook_id);
+        Self {
+            config,
+            ws_url,
+            principal: Arc::new(std::sync::OnceLock::new()),
+            refresher: Some(refresher),
         }
     }
 
@@ -358,10 +412,26 @@ impl CloudWsFrameTransport {
         self.principal.get().map(String::as_str)
     }
 
-    /// Apply the auth headers for `config.auth` to the upgrade request.
+    /// Resolve the credential to present on the next connect: the refresher's
+    /// fresh token (re-wrapped in `config.auth`'s variant) if one is configured,
+    /// else the static `config.auth` unchanged.
+    async fn effective_auth(&self) -> std::io::Result<CloudAuth> {
+        match &self.refresher {
+            Some(refresh) => {
+                let token = refresh().await.map_err(|e| {
+                    std::io::Error::new(e.kind(), format!("token refresh failed: {e}"))
+                })?;
+                Ok(self.config.auth.with_token(token))
+            }
+            None => Ok(self.config.auth.clone()),
+        }
+    }
+
+    /// Apply the auth headers for `auth` to the upgrade request.
     fn apply_auth_headers(
         &self,
         request: &mut tokio_tungstenite::tungstenite::handshake::client::Request,
+        auth: &CloudAuth,
     ) -> anyhow::Result<()> {
         let h = request.headers_mut();
         // No Sec-WebSocket-Protocol: the credential rides Authorization /
@@ -370,7 +440,7 @@ impl CloudWsFrameTransport {
             HeaderName::from_static("x-scope"),
             HeaderValue::from_str(&self.config.scope)?,
         );
-        match &self.config.auth {
+        match auth {
             CloudAuth::Dev { token, user } => {
                 h.insert(
                     HeaderName::from_static("x-notebook-cloud-dev-token"),
@@ -405,12 +475,13 @@ impl CloudWsFrameTransport {
     /// and the room principal. The [`FrameTransport::connect`] impl delegates
     /// here and caches the principal.
     async fn connect_cloud(&self) -> std::io::Result<(CloudWsSource, CloudWsSink, String)> {
+        let auth = self.effective_auth().await?;
         let mut request = self
             .ws_url
             .as_str()
             .into_client_request()
             .map_err(|e| std::io::Error::other(format!("build upgrade request: {e}")))?;
-        self.apply_auth_headers(&mut request)
+        self.apply_auth_headers(&mut request, &auth)
             .map_err(|e| std::io::Error::other(format!("apply auth headers: {e}")))?;
 
         info!(
@@ -682,6 +753,85 @@ mod tests {
             },
         });
         assert!(t.clean_eof_is_recoverable());
+    }
+
+    // -- token-refresher tests --------------------------------------------
+
+    #[test]
+    fn with_token_preserves_variant_and_dev_user() {
+        assert!(matches!(
+            CloudAuth::OidcBearer { token: "old".into() }.with_token("new".into()),
+            CloudAuth::OidcBearer { token } if token == "new"
+        ));
+        assert!(matches!(
+            CloudAuth::AnacondaApiKey { token: "old".into() }.with_token("new".into()),
+            CloudAuth::AnacondaApiKey { token } if token == "new"
+        ));
+        // Dev keeps its user label, swaps only the token.
+        match (CloudAuth::Dev {
+            token: "old".into(),
+            user: "alice".into(),
+        })
+        .with_token("new".into())
+        {
+            CloudAuth::Dev { token, user } => {
+                assert_eq!(token, "new");
+                assert_eq!(user, "alice");
+            }
+            _ => panic!("expected Dev"),
+        }
+    }
+
+    fn test_config() -> CloudWsConfig {
+        CloudWsConfig {
+            cloud_url: "https://preview.runt.run".into(),
+            notebook_id: "abc".into(),
+            scope: "runtime_peer".into(),
+            auth: CloudAuth::OidcBearer {
+                token: "static-tok".into(),
+            },
+        }
+    }
+
+    #[tokio::test]
+    async fn effective_auth_uses_static_token_without_refresher() {
+        let t = CloudWsFrameTransport::new(test_config());
+        match t.effective_auth().await.unwrap() {
+            CloudAuth::OidcBearer { token } => assert_eq!(token, "static-tok"),
+            _ => panic!("expected OidcBearer"),
+        }
+    }
+
+    #[tokio::test]
+    async fn effective_auth_uses_refreshed_token_when_set() {
+        let refresher: TokenRefresher =
+            Arc::new(|| Box::pin(async { Ok("fresh-tok".to_string()) }));
+        let t = CloudWsFrameTransport::with_token_refresher(test_config(), refresher);
+        match t.effective_auth().await.unwrap() {
+            // Variant preserved (still OIDC), token replaced with the fresh one.
+            CloudAuth::OidcBearer { token } => assert_eq!(token, "fresh-tok"),
+            _ => panic!("expected OidcBearer"),
+        }
+    }
+
+    #[tokio::test]
+    async fn effective_auth_surfaces_refresher_error() {
+        let refresher: TokenRefresher = Arc::new(|| {
+            Box::pin(async {
+                Err(std::io::Error::new(
+                    std::io::ErrorKind::PermissionDenied,
+                    "token endpoint said no",
+                ))
+            })
+        });
+        let t = CloudWsFrameTransport::with_token_refresher(test_config(), refresher);
+        let err = t
+            .effective_auth()
+            .await
+            .expect_err("refresher error surfaces");
+        // Kind is preserved so the agent can distinguish auth failures; the
+        // backoff loop treats any connect error as retryable.
+        assert_eq!(err.kind(), std::io::ErrorKind::PermissionDenied);
     }
 
     // -- ready-wait helper tests ------------------------------------------

--- a/crates/notebook-cloud-transport/src/lib.rs
+++ b/crates/notebook-cloud-transport/src/lib.rs
@@ -41,6 +41,7 @@
 
 use std::collections::VecDeque;
 use std::sync::Arc;
+use std::time::Duration;
 
 use futures_util::stream::{SplitSink, SplitStream};
 use futures_util::{SinkExt, StreamExt};
@@ -56,6 +57,19 @@ use tracing::{debug, info, warn};
 /// First-byte constant for the session-control channel (`cloud_room_ready`
 /// arrives here). Re-export of the wire constant for local readability.
 const SESSION_CONTROL: u8 = notebook_wire::frame_types::SESSION_CONTROL;
+
+/// How long [`CloudWsFrameTransport::connect`] waits for the room to reach the
+/// `cloud_room_ready` / `cloud_frame_rejected` state after a successful WS
+/// upgrade, before giving up with a `TimedOut` connect error.
+///
+/// Without this bound a room that completes the upgrade but never sends a
+/// terminal control frame and never closes the socket would hang `connect`
+/// forever. Because every reconnect attempt calls `connect` with no per-attempt
+/// timeout of its own, that hang would also wedge the whole
+/// `reconnect_with_backoff` recovery path. Returning a connect error instead
+/// lets the agent's backoff loop retry (or, after its bounded attempts, exit
+/// cleanly) rather than block indefinitely on one wedged room.
+const READY_WAIT_TIMEOUT: Duration = Duration::from_secs(30);
 
 type WsStream = WebSocketStream<MaybeTlsStream<TcpStream>>;
 
@@ -178,6 +192,57 @@ fn classify_ready_control(payload: &[u8]) -> ReadyControl {
             ReadyControl::Rejected(reason)
         }
         _ => ReadyControl::Other,
+    }
+}
+
+/// Read frames from `source` until the room reaches a terminal ready state,
+/// returning the authenticated principal from `cloud_room_ready`.
+///
+/// Data frames that arrive before the room is ready are pushed onto `buffered`
+/// so the caller can replay them to the agent after the handshake — the
+/// connect-time wait never drops a frame. A `cloud_frame_rejected` is surfaced
+/// as a `PermissionDenied` error (the room refusing the attach over a control
+/// frame rather than an HTTP status); a clean close before ready is an
+/// `UnexpectedEof`.
+///
+/// This helper has no deadline of its own — [`CloudWsFrameTransport::connect`]
+/// wraps it in [`READY_WAIT_TIMEOUT`] so a room that upgrades the WS but never
+/// sends a terminal control frame can't hang the connect forever. It is generic
+/// over [`FrameSource`] so the timeout and rejection paths are unit-testable
+/// against a mock source.
+async fn wait_for_ready<S: FrameSource>(
+    source: &mut S,
+    buffered: &mut VecDeque<TypedNotebookFrame>,
+) -> std::io::Result<String> {
+    loop {
+        match source.recv_frame().await {
+            Some(Ok(frame)) if frame.frame_type as u8 == SESSION_CONTROL => {
+                match classify_ready_control(&frame.payload) {
+                    ReadyControl::Ready(principal) => return Ok(principal),
+                    ReadyControl::Rejected(reason) => {
+                        return Err(std::io::Error::new(
+                            std::io::ErrorKind::PermissionDenied,
+                            format!("room rejected attach before ready: {reason}"),
+                        ));
+                    }
+                    ReadyControl::Other => {
+                        debug!(
+                            "[cloud-transport] control frame before ready ({} bytes): {}",
+                            frame.payload.len(),
+                            String::from_utf8_lossy(&frame.payload)
+                        );
+                    }
+                }
+            }
+            Some(Ok(frame)) => buffered.push_back(frame),
+            Some(Err(e)) => return Err(e),
+            None => {
+                return Err(std::io::Error::new(
+                    std::io::ErrorKind::UnexpectedEof,
+                    "connection closed before cloud_room_ready",
+                ));
+            }
+        }
     }
 }
 
@@ -375,42 +440,32 @@ impl CloudWsFrameTransport {
             pending: VecDeque::new(),
         };
 
-        // Read up to `cloud_room_ready`, surfacing the principal. Buffer any
-        // data frames that arrive first so the agent loop sees them after the
-        // ready handshake without loss. A `cloud_frame_rejected` during this
-        // window is the room refusing the attach (auth/ACL) over a control
-        // frame rather than an HTTP status; surface its reason rather than
-        // hanging until the socket closes.
-        let principal = loop {
-            match source.recv_frame().await {
-                Some(Ok(frame)) if frame.frame_type as u8 == SESSION_CONTROL => {
-                    match classify_ready_control(&frame.payload) {
-                        ReadyControl::Ready(principal) => break principal,
-                        ReadyControl::Rejected(reason) => {
-                            return Err(std::io::Error::new(
-                                std::io::ErrorKind::PermissionDenied,
-                                format!("room rejected attach before ready: {reason}"),
-                            ));
-                        }
-                        ReadyControl::Other => {
-                            debug!(
-                                "[cloud-transport] control frame before ready ({} bytes): {}",
-                                frame.payload.len(),
-                                String::from_utf8_lossy(&frame.payload)
-                            );
-                        }
-                    }
-                }
-                Some(Ok(frame)) => source.pending.push_back(frame),
-                Some(Err(e)) => return Err(e),
-                None => {
-                    return Err(std::io::Error::new(
-                        std::io::ErrorKind::UnexpectedEof,
-                        "connection closed before cloud_room_ready",
-                    ));
-                }
+        // Read up to `cloud_room_ready`, surfacing the principal — but bound the
+        // wait. A room that upgrades the WS yet never sends a terminal control
+        // frame and never closes would otherwise hang `connect` (and, through
+        // `reconnect_with_backoff`, the whole recovery path) forever. On timeout
+        // return a `TimedOut` connect error so the agent retries rather than
+        // blocks. Data frames that arrive before ready are buffered in
+        // `source.pending` and replayed to the agent after the handshake.
+        let mut buffered = VecDeque::new();
+        let principal = match tokio::time::timeout(
+            READY_WAIT_TIMEOUT,
+            wait_for_ready(&mut source, &mut buffered),
+        )
+        .await
+        {
+            Ok(result) => result?,
+            Err(_elapsed) => {
+                return Err(std::io::Error::new(
+                    std::io::ErrorKind::TimedOut,
+                    format!(
+                        "room did not send cloud_room_ready within {}s",
+                        READY_WAIT_TIMEOUT.as_secs()
+                    ),
+                ));
             }
         };
+        source.pending = buffered;
 
         info!("[cloud-transport] room ready; principal={principal}");
         let sink = CloudWsSink { sink };
@@ -627,5 +682,141 @@ mod tests {
             },
         });
         assert!(t.clean_eof_is_recoverable());
+    }
+
+    // -- ready-wait helper tests ------------------------------------------
+    //
+    // `wait_for_ready` is the inner loop `connect` wraps in `READY_WAIT_TIMEOUT`.
+    // Testing it (and the timeout) against a mock `FrameSource` exercises the
+    // hang/rejection/buffering paths without a live room.
+
+    /// A scripted [`FrameSource`]: yields a queue of frames, then either ends
+    /// the stream (`None`) or, if `hang` is set, blocks forever — modelling a
+    /// room that upgraded the WS but never sends a terminal control frame.
+    struct ScriptedSource {
+        frames: VecDeque<std::io::Result<TypedNotebookFrame>>,
+        hang: bool,
+    }
+
+    impl ScriptedSource {
+        fn yielding(frames: Vec<std::io::Result<TypedNotebookFrame>>) -> Self {
+            Self {
+                frames: frames.into(),
+                hang: false,
+            }
+        }
+
+        /// Yields `frames`, then hangs forever instead of ending the stream.
+        fn then_hang(frames: Vec<std::io::Result<TypedNotebookFrame>>) -> Self {
+            Self {
+                frames: frames.into(),
+                hang: true,
+            }
+        }
+    }
+
+    impl FrameSource for ScriptedSource {
+        async fn recv_frame(&mut self) -> Option<std::io::Result<TypedNotebookFrame>> {
+            if let Some(frame) = self.frames.pop_front() {
+                return Some(frame);
+            }
+            if self.hang {
+                std::future::pending::<()>().await;
+            }
+            None
+        }
+    }
+
+    fn control_frame(json: serde_json::Value) -> TypedNotebookFrame {
+        TypedNotebookFrame {
+            frame_type: NotebookFrameType::SessionControl,
+            payload: serde_json::to_vec(&json).unwrap(),
+        }
+    }
+
+    fn data_frame(payload: &[u8]) -> TypedNotebookFrame {
+        TypedNotebookFrame {
+            frame_type: NotebookFrameType::AutomergeSync,
+            payload: payload.to_vec(),
+        }
+    }
+
+    #[tokio::test]
+    async fn wait_for_ready_returns_principal_and_buffers_pre_ready_data() {
+        // A data frame arrives before `cloud_room_ready`; it must be buffered
+        // (replayed to the agent later), not dropped, and the principal parsed.
+        let mut source = ScriptedSource::yielding(vec![
+            Ok(data_frame(b"early sync bytes")),
+            Ok(control_frame(serde_json::json!({
+                "type": "cloud_room_ready",
+                "actor_label": "anaconda:alice/agent:runt:7f3a",
+            }))),
+        ]);
+        let mut buffered = VecDeque::new();
+        let principal = wait_for_ready(&mut source, &mut buffered).await.unwrap();
+        assert_eq!(principal, "anaconda:alice");
+        assert_eq!(buffered.len(), 1, "pre-ready data frame is buffered");
+        assert_eq!(buffered[0].payload, b"early sync bytes");
+    }
+
+    #[tokio::test]
+    async fn wait_for_ready_surfaces_rejection() {
+        let mut source = ScriptedSource::yielding(vec![Ok(control_frame(serde_json::json!({
+            "type": "cloud_frame_rejected",
+            "reason": "principal lacks runtime_peer ACL row",
+        })))]);
+        let mut buffered = VecDeque::new();
+        let err = wait_for_ready(&mut source, &mut buffered)
+            .await
+            .expect_err("rejection is an error");
+        assert_eq!(err.kind(), std::io::ErrorKind::PermissionDenied);
+    }
+
+    #[tokio::test]
+    async fn wait_for_ready_clean_eof_before_ready_is_unexpected_eof() {
+        let mut source = ScriptedSource::yielding(vec![]);
+        let mut buffered = VecDeque::new();
+        let err = wait_for_ready(&mut source, &mut buffered)
+            .await
+            .expect_err("EOF before ready is an error");
+        assert_eq!(err.kind(), std::io::ErrorKind::UnexpectedEof);
+    }
+
+    /// The keystone gap-1 test: a room that upgrades the WS but never sends a
+    /// terminal control frame and never closes must NOT hang `connect`. The
+    /// `READY_WAIT_TIMEOUT` wrapper turns the hang into a `TimedOut` error so
+    /// `reconnect_with_backoff` can retry. Uses paused time so the test is
+    /// instant and deterministic.
+    #[tokio::test(start_paused = true)]
+    async fn ready_wait_times_out_on_a_silent_room() {
+        // Sends one non-terminal control frame, then hangs forever.
+        let mut source = ScriptedSource::then_hang(vec![Ok(control_frame(serde_json::json!({
+            "type": "cloud_frame_accepted",
+        })))]);
+        let mut buffered = VecDeque::new();
+
+        let result = tokio::time::timeout(
+            READY_WAIT_TIMEOUT,
+            wait_for_ready(&mut source, &mut buffered),
+        )
+        .await;
+        assert!(
+            result.is_err(),
+            "a room that never sends cloud_room_ready must time out, not hang"
+        );
+
+        // And the connect-time mapping turns that elapsed into a TimedOut io
+        // error (the shape `reconnect_with_backoff` treats as a failed connect).
+        let mapped: std::io::Result<String> = match result {
+            Ok(inner) => inner,
+            Err(_elapsed) => Err(std::io::Error::new(
+                std::io::ErrorKind::TimedOut,
+                "room did not send cloud_room_ready",
+            )),
+        };
+        assert_eq!(
+            mapped.expect_err("timed out").kind(),
+            std::io::ErrorKind::TimedOut
+        );
     }
 }

--- a/crates/runtimed/Cargo.toml
+++ b/crates/runtimed/Cargo.toml
@@ -26,6 +26,7 @@ nteract-telemetry = { path = "../nteract-telemetry" }
 nteract-markdown-wasm = { path = "../nteract-markdown-wasm" }
 notebook-protocol = { path = "../notebook-protocol" }
 notebook-wire = { path = "../notebook-wire" }
+notebook-cloud-transport = { path = "../notebook-cloud-transport" }
 nteract-identity = { path = "../nteract-identity" }
 tokio = { workspace = true }
 serde = { workspace = true }

--- a/crates/runtimed/src/runtime_agent.rs
+++ b/crates/runtimed/src/runtime_agent.rs
@@ -1789,6 +1789,7 @@ mod tests {
     use crate::output_prep::queue_command_channels;
     use crate::protocol::CompletionItem;
     use anyhow::Result;
+    use notebook_protocol::connection::TypedNotebookFrame;
     use notebook_protocol::protocol::{BlobDurability, LaunchedEnvConfig};
     use std::path::PathBuf;
     use std::time::Duration;
@@ -1850,6 +1851,112 @@ mod tests {
         assert_eq!(
             reconnect_floor_delay(true, Some(Duration::from_secs(1)), Duration::from_secs(1)),
             None
+        );
+    }
+
+    // -- reconnect_with_backoff against a mock transport ------------------
+    //
+    // 3a made the reconnect *mechanism* generic over `FrameTransport`; 3b
+    // verifies it: a transport whose `connect` fails N times then succeeds must
+    // recover (within the bounded attempts), and one that always fails must give
+    // up so a genuinely-gone room lets the agent exit rather than spin forever.
+
+    /// Empty source: always clean-EOF. Enough to satisfy the `(Source, Sink)`
+    /// return type; these tests exercise `connect`, not frame flow.
+    #[derive(Debug)]
+    struct NullSource;
+    impl FrameSource for NullSource {
+        async fn recv_frame(&mut self) -> Option<std::io::Result<TypedNotebookFrame>> {
+            None
+        }
+    }
+
+    /// Sink that drops every frame.
+    #[derive(Debug)]
+    struct NullSink;
+    impl FrameSink for NullSink {
+        async fn send_frame(&mut self, _: NotebookFrameType, _: &[u8]) -> std::io::Result<()> {
+            Ok(())
+        }
+    }
+
+    /// A `FrameTransport` whose `connect` fails the first `fail_before` calls
+    /// (with a `ConnectionRefused` io error, the shape a dial failure takes),
+    /// then succeeds. Counts total connect attempts.
+    struct FlakyTransport {
+        fail_before: u32,
+        attempts: std::sync::atomic::AtomicU32,
+        recoverable: bool,
+    }
+
+    impl FlakyTransport {
+        fn new(fail_before: u32) -> Self {
+            Self {
+                fail_before,
+                attempts: std::sync::atomic::AtomicU32::new(0),
+                recoverable: true,
+            }
+        }
+        fn attempts(&self) -> u32 {
+            self.attempts.load(std::sync::atomic::Ordering::SeqCst)
+        }
+    }
+
+    impl FrameTransport for FlakyTransport {
+        type Source = NullSource;
+        type Sink = NullSink;
+
+        async fn connect(&self) -> std::io::Result<(Self::Source, Self::Sink)> {
+            let n = self
+                .attempts
+                .fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+            if n < self.fail_before {
+                Err(std::io::Error::new(
+                    std::io::ErrorKind::ConnectionRefused,
+                    "mock dial refused",
+                ))
+            } else {
+                Ok((NullSource, NullSink))
+            }
+        }
+
+        fn clean_eof_is_recoverable(&self) -> bool {
+            self.recoverable
+        }
+    }
+
+    /// Fails fewer times than `MAX_ATTEMPTS` (10), so backoff recovers. Paused
+    /// time so the exponential sleeps don't make the test slow.
+    #[tokio::test(start_paused = true)]
+    async fn reconnect_with_backoff_recovers_after_transient_failures() {
+        let transport = FlakyTransport::new(3);
+        let result = reconnect_with_backoff(&transport).await;
+        assert!(result.is_ok(), "should recover after 3 transient failures");
+        // 3 failed + 1 success.
+        assert_eq!(transport.attempts(), 4);
+    }
+
+    /// Fails on the last possible attempt boundary: 9 failures then success on
+    /// the 10th (== MAX_ATTEMPTS) still recovers.
+    #[tokio::test(start_paused = true)]
+    async fn reconnect_with_backoff_recovers_on_final_attempt() {
+        let transport = FlakyTransport::new(9);
+        assert!(reconnect_with_backoff(&transport).await.is_ok());
+        assert_eq!(transport.attempts(), 10);
+    }
+
+    /// A transport that always fails exhausts MAX_ATTEMPTS (10) and returns the
+    /// last error, so the agent can exit rather than spin forever.
+    #[tokio::test(start_paused = true)]
+    async fn reconnect_with_backoff_gives_up_after_max_attempts() {
+        let transport = FlakyTransport::new(u32::MAX);
+        let err = reconnect_with_backoff(&transport)
+            .await
+            .expect_err("always-failing transport gives up");
+        assert_eq!(transport.attempts(), 10, "exactly MAX_ATTEMPTS tries");
+        assert!(
+            err.to_string().contains("mock dial refused"),
+            "last error is preserved: {err}"
         );
     }
 

--- a/crates/runtimed/src/runtime_agent.rs
+++ b/crates/runtimed/src/runtime_agent.rs
@@ -53,13 +53,38 @@ use crate::protocol::QueueEntry;
 mod echo_suppression;
 use echo_suppression::EchoSuppressor;
 
-/// Minimum interval between clean-EOF reconnect cycles on a recoverable
-/// transport. `reconnect_with_backoff` only delays between *failed* connects;
-/// this floor stops a sink that accepts a connection and then immediately
-/// closes cleanly (a flapping/evicting cloud room) from spinning a reconnect
-/// storm at network-RTT rate. Unused by the UDS transport (which tears down on
-/// clean EOF rather than reconnecting).
-const CLEAN_EOF_RECONNECT_FLOOR: std::time::Duration = std::time::Duration::from_secs(1);
+/// Minimum interval between reconnect cycles on a recoverable transport,
+/// covering *both* recoverable-failure arms: a clean EOF and a stream framing
+/// error. `reconnect_with_backoff` only delays between *failed* connects, so a
+/// room that accepts the connection and then immediately ends the stream every
+/// cycle — by closing cleanly (clean-EOF arm) or by erroring the stream
+/// (framing-error arm) — would otherwise spin a reconnect storm at network-RTT
+/// rate, a self-inflicted DoS on the room. The floor throttles the combined
+/// reconnect rate regardless of which failure mode recurs. Unused by the UDS
+/// transport (which tears down on clean EOF, and whose framing-error reconnect
+/// is gated out of the floor by `clean_eof_is_recoverable() == false`).
+const RECOVERABLE_RECONNECT_FLOOR: std::time::Duration = std::time::Duration::from_secs(1);
+
+/// How long to sleep before a reconnect to enforce [`RECOVERABLE_RECONNECT_FLOOR`].
+///
+/// Pure so the flap-floor policy is unit-testable away from the agent's
+/// `select!` loop. Returns `None` (reconnect immediately) when the transport is
+/// not recoverable — keeping the UDS path's framing-error reconnect byte-for-byte
+/// unchanged — or when enough time has already elapsed since the last
+/// recoverable reconnect. Otherwise returns the remaining time to wait out.
+fn reconnect_floor_delay(
+    recoverable: bool,
+    since_last_reconnect: Option<std::time::Duration>,
+    floor: std::time::Duration,
+) -> Option<std::time::Duration> {
+    if !recoverable {
+        return None;
+    }
+    match since_last_reconnect {
+        Some(since) if since < floor => Some(floor - since),
+        _ => None,
+    }
+}
 
 /// Shared context for the runtime agent (no kernel -- kernel is owned locally).
 struct RuntimeAgentContext {
@@ -136,11 +161,13 @@ pub async fn run_runtime_agent(
     let mut kernel_state = KernelState::new(state.clone());
     let mut seen_execution_ids = HashSet::new();
     let mut echo_suppressor = EchoSuppressor::default();
-    // Timestamp of the last clean-EOF reconnect, used to enforce a floor
-    // between reconnect cycles on a recoverable (cloud) transport so a flapping
-    // sink can't drive a reconnect storm. Only set/read on that path; `None` on
-    // the UDS transport, which never reconnects on clean EOF.
-    let mut last_clean_reconnect: Option<tokio::time::Instant> = None;
+    // Timestamp of the last recoverable reconnect (clean EOF *or* framing
+    // error), used to enforce a floor between reconnect cycles on a recoverable
+    // (cloud) transport so a flapping sink can't drive a reconnect storm. Set
+    // after every recoverable reconnect arm; stays `None` on the UDS transport,
+    // whose framing-error reconnect is gated out of the floor and which never
+    // reconnects on clean EOF.
+    let mut last_recoverable_reconnect: Option<tokio::time::Instant> = None;
     let mut lifecycle_rx: Option<mpsc::UnboundedReceiver<LifecycleSignal>> = None;
     let mut work_rx: Option<mpsc::Receiver<WorkCommand>> = None;
 
@@ -543,6 +570,20 @@ pub async fn run_runtime_agent(
                              (kernel stays running)",
                             e
                         );
+                        // Flap floor. `reconnect_with_backoff` only sleeps
+                        // between *failed* connects, so a cloud room that
+                        // accepts the connection and then immediately errors the
+                        // stream every cycle would spin a reconnect storm at
+                        // network-RTT rate. Gated on the recoverable transport so
+                        // the UDS framing-error reconnect is byte-for-byte
+                        // unchanged. (lifecycle-analysis: cloud DoS-avoidance)
+                        if let Some(wait) = reconnect_floor_delay(
+                            transport.clean_eof_is_recoverable(),
+                            last_recoverable_reconnect.map(|t| t.elapsed()),
+                            RECOVERABLE_RECONNECT_FLOOR,
+                        ) {
+                            tokio::time::sleep(wait).await;
+                        }
                         // Drop the old source before reconnecting so its
                         // background reader task exits cleanly.
                         drop(frame_source);
@@ -558,6 +599,11 @@ pub async fn run_runtime_agent(
                                 // everything the kernel produced while we
                                 // were disconnected.
                                 let _ = state_kick_tx.send(());
+                                // Track for the flap floor (recoverable only;
+                                // the UDS path leaves this `None`).
+                                if transport.clean_eof_is_recoverable() {
+                                    last_recoverable_reconnect = Some(tokio::time::Instant::now());
+                                }
                                 info!("[runtime-agent] Reconnected to daemon");
                                 continue;
                             }
@@ -588,13 +634,15 @@ pub async fn run_runtime_agent(
                         // accepts the connection and then immediately closes
                         // cleanly every time (a flapping/evicting cloud room)
                         // would otherwise spin a reconnect storm at network-RTT
-                        // rate. If the previous clean reconnect was very recent,
-                        // wait out the floor before redialing.
-                        if let Some(last) = last_clean_reconnect {
-                            let since = last.elapsed();
-                            if since < CLEAN_EOF_RECONNECT_FLOOR {
-                                tokio::time::sleep(CLEAN_EOF_RECONNECT_FLOOR - since).await;
-                            }
+                        // rate. Shared with the framing-error arm via
+                        // `reconnect_floor_delay` so the combined reconnect rate
+                        // is throttled regardless of which failure mode recurs.
+                        if let Some(wait) = reconnect_floor_delay(
+                            transport.clean_eof_is_recoverable(),
+                            last_recoverable_reconnect.map(|t| t.elapsed()),
+                            RECOVERABLE_RECONNECT_FLOOR,
+                        ) {
+                            tokio::time::sleep(wait).await;
                         }
                         warn!(
                             "[runtime-agent] Sync sink closed cleanly — reconnecting \
@@ -607,7 +655,7 @@ pub async fn run_runtime_agent(
                                 frame_sink = new_sink;
                                 coordinator_sync_state = automerge::sync::State::new();
                                 let _ = state_kick_tx.send(());
-                                last_clean_reconnect = Some(tokio::time::Instant::now());
+                                last_recoverable_reconnect = Some(tokio::time::Instant::now());
                                 info!("[runtime-agent] Reconnected after clean close");
                                 continue;
                             }
@@ -1743,6 +1791,67 @@ mod tests {
     use anyhow::Result;
     use notebook_protocol::protocol::{BlobDurability, LaunchedEnvConfig};
     use std::path::PathBuf;
+    use std::time::Duration;
+
+    // -- reconnect flap-floor policy --------------------------------------
+    //
+    // `reconnect_floor_delay` is the shared throttle for both recoverable
+    // reconnect arms (clean EOF and framing error). The UDS path must never be
+    // delayed; the cloud path must be throttled when reconnects recur inside the
+    // floor.
+
+    #[test]
+    fn floor_never_delays_a_non_recoverable_transport() {
+        // The UDS path (clean_eof_is_recoverable == false): even a reconnect one
+        // nanosecond ago must not delay, so its framing-error reconnect is
+        // byte-for-byte unchanged.
+        assert_eq!(
+            reconnect_floor_delay(false, Some(Duration::from_nanos(1)), Duration::from_secs(1)),
+            None
+        );
+        assert_eq!(
+            reconnect_floor_delay(false, None, Duration::from_secs(1)),
+            None
+        );
+    }
+
+    #[test]
+    fn floor_does_not_delay_first_recoverable_reconnect() {
+        // No prior reconnect recorded -> no wait (the first failure reconnects
+        // immediately; the floor only throttles *recurring* flaps).
+        assert_eq!(
+            reconnect_floor_delay(true, None, Duration::from_secs(1)),
+            None
+        );
+    }
+
+    #[test]
+    fn floor_delays_a_recurring_recoverable_flap() {
+        // A recoverable reconnect 200ms ago, 1s floor -> wait out the remaining
+        // 800ms before redialing.
+        assert_eq!(
+            reconnect_floor_delay(
+                true,
+                Some(Duration::from_millis(200)),
+                Duration::from_secs(1),
+            ),
+            Some(Duration::from_millis(800))
+        );
+    }
+
+    #[test]
+    fn floor_does_not_delay_once_floor_has_elapsed() {
+        // Last reconnect comfortably older than the floor -> reconnect now.
+        assert_eq!(
+            reconnect_floor_delay(true, Some(Duration::from_secs(5)), Duration::from_secs(1)),
+            None
+        );
+        // Exactly at the floor is also "elapsed" (not strictly less than).
+        assert_eq!(
+            reconnect_floor_delay(true, Some(Duration::from_secs(1)), Duration::from_secs(1)),
+            None
+        );
+    }
 
     /// Minimal mock kernel for testing queue/state logic without ZeroMQ.
     struct MockKernel;

--- a/crates/runtimed/src/runtime_agent.rs
+++ b/crates/runtimed/src/runtime_agent.rs
@@ -109,17 +109,111 @@ pub async fn run_runtime_agent(
         socket_path.display()
     );
 
-    // -- 1. Connect to daemon socket ----------------------------------------
-
-    // The sync wire is abstracted behind `FrameTransport`: the daemon uses the
-    // UDS (Windows named-pipe) transport, while a hosted runtime peer will swap
-    // in a cloud-WebSocket transport without touching the loop below. `connect`
-    // owns the transport-specific dial + handshake.
+    // The daemon socket transport. The sync wire is abstracted behind
+    // `FrameTransport`; the cloud-WebSocket path swaps in a different transport
+    // (`run_cloud_runtime_agent`) without touching the agent loop below.
     let transport =
         UdsFrameTransport::new(&socket_path, &notebook_id, &runtime_agent_id, &blob_root);
+
+    // The UDS actor label is the daemon-supplied `runtime_agent_id`, resolved
+    // up front and independent of the (just-connected) transport. This keeps
+    // the desktop/daemon path byte-for-byte unchanged: the resolver returns the
+    // exact value the bootstrap used inline before the cloud-path extraction.
+    run_runtime_agent_on_transport(transport, notebook_id, blob_root, move |_| {
+        Ok(runtime_agent_id)
+    })
+    .await
+}
+
+/// Run the runtime agent against a hosted cloud room over a WebSocket transport.
+///
+/// The daemon-managed kernel is unchanged; only the sync wire differs from
+/// [`run_runtime_agent`]. The cloud room only reveals its authenticated
+/// principal in the `cloud_room_ready` handshake, so the doc-actor label is
+/// resolved *after* connect, as `<principal>/<operator>:<nonce>`:
+///
+/// - **principal** — `transport.principal()`, the authenticated identity the
+///   room's `validate_room_notebook_change_actors` requires every change to be
+///   authored under (decision #6); authoring under anything else is silently
+///   dropped by the room.
+/// - **operator** — a human-readable role suffix (e.g. `agent:runt`) so the
+///   room can tell which of a principal's agents authored a change.
+/// - **nonce** — a per-process random suffix. Reusing one actor label across
+///   separate doc instances collides at `(actor, seq 1)` → Automerge
+///   `DuplicateSeqNumber` when the room syncs the prior change back, exactly the
+///   hazard the `runt-cloud-peer` spike documented.
+///
+/// CODE-ONLY (Phase 3c): this builds and unit-tests the spawn path behind the
+/// transport gate; the live cross-machine re-proof (a preview room + the
+/// explicit `runtime_peer` ACL row, decision #9) is deferred — see the decision
+/// log's NEEDS-US note.
+pub async fn run_cloud_runtime_agent(
+    config: notebook_cloud_transport::CloudWsConfig,
+    operator: String,
+    blob_root: PathBuf,
+) -> anyhow::Result<()> {
+    let notebook_id = config.notebook_id.clone();
+    info!(
+        "[runtime-agent] Starting cloud runtime_agent notebook_id={} url={} scope={}",
+        notebook_id,
+        notebook_cloud_transport::build_ws_url(&config.cloud_url, &notebook_id),
+        config.scope,
+    );
+
+    let transport = notebook_cloud_transport::CloudWsFrameTransport::new(config);
+
+    run_runtime_agent_on_transport(transport, notebook_id, blob_root, move |t| {
+        let principal = t.principal().ok_or_else(|| {
+            anyhow::anyhow!("cloud transport has no principal after connect (no cloud_room_ready)")
+        })?;
+        Ok(cloud_actor_label(principal, &operator))
+    })
+    .await
+}
+
+/// Build the cloud doc-actor label `<principal>/<operator>:<nonce>`.
+///
+/// Split out so the label scheme is unit-testable without a live room. The
+/// nonce makes the label unique per process (see [`run_cloud_runtime_agent`]
+/// for why reuse is unsafe).
+fn cloud_actor_label(principal: &str, operator: &str) -> String {
+    let nonce = uuid::Uuid::new_v4().simple().to_string();
+    format!("{principal}/{operator}:{}", &nonce[..8])
+}
+
+/// Run the runtime agent over an arbitrary [`FrameTransport`].
+///
+/// The desktop/daemon path ([`run_runtime_agent`]) and the cloud path
+/// ([`run_cloud_runtime_agent`]) both funnel here; only the transport and the
+/// doc-actor label differ. Everything below — the kernel drive, the queue, the
+/// RuntimeStateDoc writes, the lifecycle handling, and the reconnect/resync
+/// dance — is identical across transports by construction.
+///
+/// `resolve_actor` produces the Automerge actor label the agent authors its
+/// RuntimeStateDoc under, given the *connected* transport. It runs after
+/// `connect()` because a cloud transport only learns its room principal from
+/// the `cloud_room_ready` handshake; the UDS path ignores the transport and
+/// returns the daemon-supplied id. The actor label matters for the cloud room:
+/// its `validate_room_notebook_change_actors` drops any change whose principal
+/// differs from the authenticated one, so a cloud agent must author under
+/// `<principal>/<operator>` (decision #6). Authoring under the wrong actor is
+/// silent — the room discards every change and convergence stalls.
+async fn run_runtime_agent_on_transport<T, F>(
+    transport: T,
+    notebook_id: String,
+    blob_root: PathBuf,
+    resolve_actor: F,
+) -> anyhow::Result<()>
+where
+    T: FrameTransport,
+    F: FnOnce(&T) -> anyhow::Result<String>,
+{
+    // -- 1. Connect ---------------------------------------------------------
+
+    // `connect` owns the transport-specific dial + handshake/auth.
     let (mut frame_source, mut frame_sink) = transport.connect().await?;
 
-    info!("[runtime-agent] Connected to daemon, handshake sent");
+    info!("[runtime-agent] Connected, handshake sent");
 
     // The transport hands back a cancel-safe `FrameSource` (backed by a
     // dedicated `FramedReader` actor) so the busy `select!` below stays
@@ -128,6 +222,14 @@ pub async fn run_runtime_agent(
     // captured in production logs as `frame too large: 538976288 bytes`.
 
     // -- 2. Bootstrap RuntimeStateDoc ---------------------------------------
+
+    // Resolve the doc-actor label now that the transport is connected (a cloud
+    // transport's principal is known only post-handshake).
+    let runtime_agent_id = resolve_actor(&transport)?;
+    info!(
+        "[runtime-agent] Bootstrapping notebook_id={} as actor {}",
+        notebook_id, runtime_agent_id
+    );
 
     let state_doc = RuntimeStateDoc::try_new_with_actor(&runtime_agent_id)
         .map_err(|e| anyhow::anyhow!("create runtime-agent state doc: {e}"))?;
@@ -1958,6 +2060,72 @@ mod tests {
             err.to_string().contains("mock dial refused"),
             "last error is preserved: {err}"
         );
+    }
+
+    // -- cloud doc-actor label (Phase 3c) ---------------------------------
+
+    #[test]
+    fn cloud_actor_label_has_principal_operator_and_nonce() {
+        let label = cloud_actor_label("anaconda:alice", "agent:runt");
+        // <principal>/<operator>:<8-hex-nonce>
+        let (prefix, nonce) = label.rsplit_once(':').expect("has nonce suffix");
+        assert_eq!(prefix, "anaconda:alice/agent:runt");
+        assert_eq!(nonce.len(), 8, "8-char nonce: {label}");
+        assert!(nonce.chars().all(|c| c.is_ascii_hexdigit()));
+        // The principal (which itself contains a colon) is preserved ahead of
+        // the operator, so the room's principal check sees the right identity.
+        assert!(label.starts_with("anaconda:alice/"));
+    }
+
+    #[test]
+    fn cloud_actor_label_is_unique_per_call() {
+        // Reusing a label across doc instances collides at (actor, seq 1) ->
+        // Automerge DuplicateSeqNumber; the nonce must differ per call.
+        let a = cloud_actor_label("p", "op");
+        let b = cloud_actor_label("p", "op");
+        assert_ne!(a, b);
+    }
+
+    /// The cloud actor resolver (the closure `run_cloud_runtime_agent` passes
+    /// into `run_runtime_agent_on_transport`) must error rather than silently
+    /// author under a wrong actor when the transport never observed a
+    /// `cloud_room_ready` principal. Exercise that resolver shape directly
+    /// against a fresh (unconnected) cloud transport.
+    #[test]
+    fn cloud_actor_resolver_errors_without_principal() {
+        use notebook_cloud_transport::{CloudAuth, CloudWsConfig, CloudWsFrameTransport};
+        let transport = CloudWsFrameTransport::new(CloudWsConfig {
+            cloud_url: "https://preview.runt.run".into(),
+            notebook_id: "abc".into(),
+            scope: "runtime_peer".into(),
+            auth: CloudAuth::OidcBearer { token: "t".into() },
+        });
+        let operator = "agent:runt".to_string();
+        // Mirror the resolver body in run_cloud_runtime_agent.
+        let resolved: anyhow::Result<String> = (|t: &CloudWsFrameTransport| {
+            let principal = t
+                .principal()
+                .ok_or_else(|| anyhow::anyhow!("cloud transport has no principal after connect"))?;
+            Ok(cloud_actor_label(principal, &operator))
+        })(&transport);
+        assert!(
+            resolved.is_err(),
+            "no principal before connect -> resolver errors, not a bogus actor"
+        );
+    }
+
+    /// The UDS resolver is a pure pass-through of the daemon-supplied id,
+    /// independent of the transport — the property that keeps the desktop path
+    /// byte-for-byte unchanged after the cloud-path extraction.
+    #[test]
+    fn uds_actor_resolver_returns_daemon_id_verbatim() {
+        let id = "runtime-agent:nb-42".to_string();
+        let resolver = {
+            let id = id.clone();
+            move |_t: &FlakyTransport| -> anyhow::Result<String> { Ok(id) }
+        };
+        let resolved = resolver(&FlakyTransport::new(0)).unwrap();
+        assert_eq!(resolved, id);
     }
 
     /// Minimal mock kernel for testing queue/state logic without ZeroMQ.

--- a/docs/handoffs/16-decisions-log.md
+++ b/docs/handoffs/16-decisions-log.md
@@ -279,23 +279,80 @@ OIDC token actually expires and the refresher mints a new one. Fold this into
 the 3c cross-machine re-proof (same creds/deploy). Nothing in 3b changes the
 static-token path, so this is a forward-looking validation, not a regression risk.
 
-## Phase 3 remaining plan (3c+)
+## Phase 3c (CODE ONLY): daemon spawn path + doc-actor identity
 
-Ordered by the lifecycle analysis. 3a (req #1) and 3b (req #2) are done. Remaining, in dependency order:
+29. **Premise (b) of the original 3c plan — "swap the daemon's stripping receive
+    for `receive_sync_message_with_changes`" — was a misreading; the agent is
+    ALREADY consumer-side, and the swap would be a regression. Dropped.** The
+    plan assumed the agent's receive path
+    (`runtime_agent.rs` RuntimeStateSync arm → `receive_sync_and_foreign_comms_recovering`)
+    *strips* incoming changes the way the server-toward-viewer
+    `RuntimeStateDoc::receive_sync_message` (doc.rs:2980) does. It does not. Reading
+    `receive_sync_and_foreign_comms` (doc.rs:3127-3219): it calls **raw**
+    `self.doc.sync().receive_sync_message` (doc.rs:3140), which *applies* every
+    incoming change to the main doc, and then additionally computes a
+    *foreign-comms* fork purely for kernel-echo suppression (the doc comment at
+    3120-3122 states it outright: "The main doc still absorbs every applied change
+    (including kernel echoes)"). So the agent already has the consumer semantics a
+    cloud peer needs. Swapping it for plain `receive_sync_message_with_changes`
+    would *lose* the per-change `rt:kernel:` echo filter and re-introduce the
+    widget-amplification loop that method was written to break — a regression, not
+    a fix. Verified by code-read + the existing echo-suppression tests. Net: 3c's
+    real surface is only premise (a), the doc-actor identity.
 
-- **3c: daemon spawn path + doc-actor identity + consumer-side receive (the integration).**
-  Add a `run_runtime_agent`-equivalent (or a parameter) that builds a `CloudWsFrameTransport`
-  instead of `UdsFrameTransport`. Two agent-loop changes gated on this path: (a) author the
-  RuntimeStateDoc (and NotebookDoc if synced) under the `cloud_room_ready` principal
-  (`transport.principal()`), as `<principal>/<operator>`, not the daemon's `runtime_agent_id`,
-  else the room's `validate_room_notebook_change_actors` drops every change (decision #6).
-  (b) Apply incoming RuntimeStateSync with `receive_sync_message_with_changes` (consumer
-  semantics) rather than the daemon's `receive_sync_and_foreign_comms_recovering` (which strips
-  incoming changes). Gate (a)/(b) on a transport-kind discriminant so the UDS path is untouched.
-  This is where the live cross-machine re-proof runs: spawn the daemon's real `runtime_agent`
-  against a preview room as `runtime_peer` (needs the explicit `runtime_peer` ACL row,
-  decision #9) and confirm a cloud-submitted cell runs on the daemon-managed kernel and renders
-  in the viewer, through the *real* agent, not the spike.
+30. **The spawn path is a generic inner `run_runtime_agent_on_transport<T, F>`
+    that both entry points funnel through; the transport-kind discriminant is a
+    `resolve_actor: FnOnce(&T) -> Result<String>` closure, not a runtime enum or a
+    trait method.** `run_runtime_agent` (UDS) passes `move |_| Ok(runtime_agent_id)`
+    — the resolver ignores the transport and returns the daemon-supplied id, the
+    exact value the bootstrap used inline before, so the desktop/daemon path is
+    byte-for-byte unchanged (verified: full runtimed suite green, 884→888 only by
+    added tests). `run_cloud_runtime_agent` builds a `CloudWsFrameTransport` and
+    passes a resolver that reads `transport.principal()` *after* connect. Why a
+    closure, not an enum discriminant in the loop: the only thing that actually
+    differs by transport is the actor label, and it's needed exactly once at
+    bootstrap; a closure localises that one difference without threading a
+    `TransportKind` through the 1400-line loop or widening `FrameTransport`.
+    Alternative considered: resolve the actor *before* connect — impossible for
+    cloud, the principal is only known from `cloud_room_ready`, which is why the
+    resolver runs post-`connect()`.
+
+31. **Cloud doc-actor label is `<principal>/<operator>:<nonce>` via
+    `cloud_actor_label`.** Principal from `transport.principal()` (the room's
+    authenticated identity; `validate_room_notebook_change_actors` drops changes
+    authored under anything else — decision #6). Operator is a caller-supplied
+    role suffix (e.g. `agent:runt`). The nonce is a per-process random suffix
+    because reusing one actor label across separate doc instances collides at
+    `(actor, seq 1)` → Automerge `DuplicateSeqNumber` when the room syncs the prior
+    change back (the exact hazard the `runt-cloud-peer` spike documented). The
+    resolver *errors* if the principal is absent rather than authoring under a bogus
+    actor, since a wrong actor fails silently (the room discards every change).
+    Unit-tested: label format/uniqueness, the no-principal error path, and the UDS
+    pass-through property.
+
+Phase 3c verification: `cargo test -p runtimed` 888 lib (was 884) + integration
+suites green (UDS byte-for-byte unchanged); `cargo test -p xtask` 28 (bump-targets
+guard green — `notebook-cloud-transport` was already registered, now also a
+`runtimed` dep); `cargo xtask lint --fix` clean; clippy `-D warnings` clean.
+
+**NEEDS US (3c):** the live cross-machine re-proof. `run_cloud_runtime_agent` is
+built and unit-tested behind the transport gate, but nothing yet *calls* it from a
+CLI/daemon command, and it has never run against a real room. To close req #2/#3
+end-to-end an interactive session with creds must: (1) deploy a preview room (or
+use an existing one) and grant the agent's principal the explicit `runtime_peer`
+ACL row (decision #9); (2) wire a CLI subcommand (e.g. `runtimed cloud-runtime-agent
+--cloud-url --notebook-id --operator`, plus a `CloudAuth` source) — trivial, but
+left out here since it can't be verified headlessly; (3) spawn it as `runtime_peer`
+and confirm a cloud-submitted cell runs on the daemon-managed kernel and renders in
+the viewer, through the *real* agent (not the `runt-cloud-peer` spike); (4) exercise
+the 3b token-refresher against an actually-expiring token. None of this is possible
+without preview deploy + staging creds, which this autonomous session does not have.
+The code path is additive and gated, so it cannot affect the desktop/daemon path.
+
+## Phase 3 remaining plan (3d+)
+
+Ordered by the lifecycle analysis. 3a (req #1), 3b (req #2), and 3c CODE (doc-actor
+identity; live re-proof is NEEDS-US) are done. Remaining, in dependency order:
 
 - **3d: cloud-room DurableObject watchdog (reqs #3, #7; the safety net the daemon can't
   provide).** TypeScript in `apps/notebook-cloud/`. Thread peer **scope** through

--- a/docs/handoffs/16-decisions-log.md
+++ b/docs/handoffs/16-decisions-log.md
@@ -229,18 +229,59 @@ Phase 3b warm-up verification: `cargo test -p notebook-cloud-transport` 16;
 `cargo xtask lint --fix` clean; clippy `-D warnings` clean on both crates. No new
 workspace crate (no bump-targets change).
 
-## Phase 3 remaining plan (3b+)
+## Phase 3b: WS reconnect/re-auth + full-resync on cloud reconnect (req #2)
 
-Ordered by the lifecycle analysis. 3a (req #1) is done. Remaining, in dependency order:
+26. **The reconnect *mechanism* was already complete after 3a; 3b adds the
+    re-auth seam and the missing test coverage.** `reconnect_with_backoff` is
+    generic over `FrameTransport` and the cloud `connect()` re-dials + re-reads
+    `cloud_room_ready`; both reconnect arms (clean-EOF and framing-error) already
+    reset `coordinator_sync_state` and fire `state_kick_tx` (verified by
+    inspection at `runtime_agent.rs` — the kick drives a full RuntimeStateDoc
+    re-send on *every* recoverable reconnect, cloud included, because the kick is
+    transport-agnostic). So 3b is two concrete deliverables, not a rewrite:
+    a fresh-token seam and unit tests for the backoff loop.
 
-- **3b: WS reconnect/re-auth + full-resync on cloud reconnect (req #2).**
-  `reconnect_with_backoff` is already generic over `FrameTransport`, and the cloud `connect()`
-  re-dials, re-auths, and re-reads `cloud_room_ready`, so the *mechanism* exists. What's
-  missing is verifying the resync kick (`state_kick_tx`) drives a full RuntimeStateDoc re-send
-  after a cloud reconnect, and that re-auth uses a *fresh* token if the original expired (the
-  `CloudAuth` is currently a static token; a token-provider closure may be needed for
-  long-lived sessions). Unit-test the reconnect arm with a mock `FrameTransport` whose
-  `connect` fails N times then succeeds.
+27. **Re-auth uses an optional `TokenRefresher` closure, not a widened
+    `CloudAuth`.** `CloudAuth` holds a *static* token, fine for a short session
+    but wrong for a long-lived peer: its OIDC token expires mid-session, and a
+    reconnect that re-presents the expired token is rejected at the upgrade, so
+    `reconnect_with_backoff` would burn all 10 attempts and give up. Fix:
+    `CloudWsFrameTransport::with_token_refresher(config, refresher)` takes an
+    `async` closure (`TokenRefresher = Arc<dyn Fn() -> Future<io::Result<String>>>`)
+    that the transport calls *before each connect* via `effective_auth()`; the
+    returned token is re-wrapped in the configured auth variant by
+    `CloudAuth::with_token` (preserving the variant and any `Dev` user label).
+    `None` (the default `new()`) keeps the static-token behavior byte-for-byte.
+    Alternative considered: store an `Arc<Mutex<String>>` the agent mutates —
+    rejected; a pull-on-connect closure has no lock-ordering hazard and keeps the
+    refresh policy (cache, retry, endpoint) entirely on the agent side. The
+    closure's error surfaces as a connect error (kind preserved) so the backoff
+    loop treats it as a retryable failed connect. Wiring this into a daemon spawn
+    path is 3c; this PR ships the seam + tests only.
+
+28. **`reconnect_with_backoff` is unit-tested with a mock `FlakyTransport`.** A
+    `FrameTransport` whose `connect` fails the first N calls (with
+    `ConnectionRefused`) then succeeds, counting attempts. Three tests under
+    `start_paused` time (so the exponential sleeps are instant): recovers after 3
+    transient failures (4 total attempts), recovers on the final allowed attempt
+    (9 fail → success on the 10th), and gives up after exactly `MAX_ATTEMPTS`
+    (10) with the last error preserved so a genuinely-gone room lets the agent
+    exit rather than spin forever.
+
+Phase 3b verification: `cargo test -p notebook-cloud-transport` 20 (was 16);
+`cargo test -p runtimed` 884 lib (was 881) + integration suites green (UDS
+unchanged); `cargo xtask lint --fix` clean; clippy `-D warnings` clean on both.
+No new workspace crate.
+
+**NEEDS US (3b):** the token-refresher seam is unit-tested but has no live
+re-auth proof — that needs a long-lived session against a preview room where an
+OIDC token actually expires and the refresher mints a new one. Fold this into
+the 3c cross-machine re-proof (same creds/deploy). Nothing in 3b changes the
+static-token path, so this is a forward-looking validation, not a regression risk.
+
+## Phase 3 remaining plan (3c+)
+
+Ordered by the lifecycle analysis. 3a (req #1) and 3b (req #2) are done. Remaining, in dependency order:
 
 - **3c: daemon spawn path + doc-actor identity + consumer-side receive (the integration).**
   Add a `run_runtime_agent`-equivalent (or a parameter) that builds a `CloudWsFrameTransport`

--- a/docs/handoffs/16-decisions-log.md
+++ b/docs/handoffs/16-decisions-log.md
@@ -182,6 +182,53 @@ Phase 3a verification: `cargo test -p runtimed` passes 944 (UDS default unchange
 `cargo test -p notebook-protocol` 89; `cargo test -p notebook-cloud-transport` 12; clippy
 clean across all three; `cargo fmt --check` clean.
 
+## Phase 3b warm-up: two connect-hardening gaps pullfrog flagged on #3411
+
+24. **Bounded ready-wait timeout in `CloudWsFrameTransport::connect`
+    (`READY_WAIT_TIMEOUT`, 30s).** The connect-time `cloud_room_ready` wait
+    blocked on `recv_frame()` with no deadline: a room that completes the WS
+    upgrade but never sends `cloud_room_ready`/`cloud_frame_rejected` and never
+    closes would hang `connect` forever — and since `reconnect_with_backoff`
+    calls `connect()` with no per-attempt timeout of its own, the whole recovery
+    path would wedge on one silent room. Fix: the ready loop is extracted into a
+    `wait_for_ready<S: FrameSource>` helper (no deadline of its own, so it's
+    unit-testable against a mock source) that `connect` wraps in
+    `tokio::time::timeout(READY_WAIT_TIMEOUT, …)`; on elapse it returns a
+    `TimedOut` io error, which `reconnect_with_backoff` already treats as a
+    failed connect and retries. Alternative considered: a per-frame idle timeout
+    rather than a total deadline — rejected as more complex and unnecessary, since
+    a room mid-handshake either reaches a terminal control frame promptly or is
+    wedged. Extracting the helper also fixed a latent bug: the old loop pushed
+    pre-ready data frames back into `source.pending` while *reading via*
+    `source.recv_frame()` (which pops `pending` first), so the buffer now uses a
+    separate deque assigned into `pending` only after ready. 4 new unit tests
+    (timeout under `start_paused`, rejection, clean-EOF-before-ready, pre-ready
+    data buffering); `notebook-cloud-transport` now 16 tests.
+
+25. **Flap floor extended to the framing-error reconnect arm
+    (`RECOVERABLE_RECONNECT_FLOOR`, renamed from `CLEAN_EOF_RECONNECT_FLOOR`).**
+    Phase 3a (decision #23) added the 1s reconnect floor only to the clean-EOF
+    (`None`) arm. The framing-error (`Some(Err)`) arm plus `reconnect_with_backoff`
+    only sleep between *failed* connects, so a cloud room that accepts the
+    connection and then errors the stream every cycle would spin reconnects at RTT
+    rate (a self-inflicted DoS on the room) — the same hazard #23 fixed for clean
+    EOF, on the other arm. Fix: a pure `reconnect_floor_delay(recoverable,
+    since_last_reconnect, floor) -> Option<Duration>` helper, called by *both*
+    arms; the timestamp variable is renamed `last_recoverable_reconnect` and set
+    after every recoverable reconnect. The helper returns `None` immediately when
+    `!recoverable`, so the UDS framing-error path is byte-for-byte unchanged (no
+    sleep, never records a timestamp) — verified by the 944→881-lib runtimed suite
+    staying green and a dedicated `floor_never_delays_a_non_recoverable_transport`
+    test. Alternative considered: a separate accept-then-immediate-error counter
+    per arm — rejected; a single shared floor on the combined reconnect rate is
+    simpler and is exactly the throttle wanted regardless of which failure mode
+    recurs. 4 new unit tests for the policy.
+
+Phase 3b warm-up verification: `cargo test -p notebook-cloud-transport` 16;
+`cargo test -p runtimed` 881 lib + integration suites green (UDS unchanged);
+`cargo xtask lint --fix` clean; clippy `-D warnings` clean on both crates. No new
+workspace crate (no bump-targets change).
+
 ## Phase 3 remaining plan (3b+)
 
 Ordered by the lifecycle analysis. 3a (req #1) is done. Remaining, in dependency order:


### PR DESCRIPTION
**Stacked on #3414 → #3413.** Until those merge, this PR's diff includes their commits; it narrows to the single 3c commit once they land. Review the last commit.

Phase 3c (**CODE ONLY**) of #16: the daemon spawn path that runs the *real* `runtime_agent` over a cloud-WebSocket transport instead of the UDS socket.

## What this adds

- `run_cloud_runtime_agent(config, operator, blob_root)` — builds a `CloudWsFrameTransport` and runs the daemon's existing agent against a hosted room.
- A generic inner `run_runtime_agent_on_transport<T, F>` that **both** entry points funnel through. The kernel drive, queue, RuntimeStateDoc writes, lifecycle handling, and reconnect/resync are identical across transports.
- The only per-transport difference — the doc-actor label — is localised in a `resolve_actor: FnOnce(&T) -> Result<String>` closure run **after** connect (a cloud room's principal is only known from `cloud_room_ready`).
  - **UDS** passes `|_| Ok(runtime_agent_id)` — the daemon-supplied id verbatim, so the desktop/daemon path is **byte-for-byte unchanged**.
  - **Cloud** resolves `<principal>/<operator>:<nonce>` via `cloud_actor_label`. The principal satisfies the room's `validate_room_notebook_change_actors` (decision #6); the nonce avoids the `(actor, seq 1)` → `DuplicateSeqNumber` collision the spike documented; the resolver errors rather than authoring under a bogus actor when no principal is present.

## Correction to the planned 3c surface

The original plan had a premise (b): swap the agent's "stripping" receive for `receive_sync_message_with_changes`. **That was a misreading and is dropped.** The agent's receive path (`receive_sync_and_foreign_comms_recovering`) already calls **raw** `receive_sync_message` (applies all changes) and computes a foreign-comms fork purely for kernel-echo suppression — the doc comment states "The main doc still absorbs every applied change". It is *already* consumer-side; swapping to plain `receive_sync_message_with_changes` would **lose** the `rt:kernel:` echo filter (a regression). So 3c reduces to the doc-actor identity (premise a). Full reasoning in decision log #29.

## STATUS

- **State:** CODE complete + unit-tested behind the transport gate. UDS path byte-for-byte unchanged.
- **Tests:** `runtimed` 888 lib (was 884, +4: label format/uniqueness, no-principal error, UDS pass-through) + integration suites green. `xtask` 28 (bump-targets guard green; `notebook-cloud-transport` already registered, now also a `runtimed` dep).
- **Lint:** `cargo xtask lint --fix` clean; clippy `-D warnings` clean.
- **NEEDS US (live re-proof — cannot run headlessly):** Nothing calls `run_cloud_runtime_agent` from a CLI yet, and it has never run against a real room. An interactive session with creds must: (1) deploy/obtain a preview room + grant the agent's principal the explicit `runtime_peer` ACL row (decision #9); (2) wire a CLI subcommand + `CloudAuth` source (trivial, omitted here as unverifiable headlessly); (3) spawn as `runtime_peer` and confirm a cloud-submitted cell runs on the daemon kernel and renders in the viewer, through the *real* agent (not the spike); (4) exercise the 3b token-refresher against an actually-expiring token. The path is additive + gated; it cannot affect the desktop/daemon path.
- **Decision log:** entries #29–#31 in `docs/handoffs/16-decisions-log.md`.
