### PR TITLE
feat(notebook-cloud): runtime_peer-gone DurableObject watchdog (Phase 3d, code only)

### DIFF
--- a/apps/notebook-cloud/src/cloudflare-types.ts
+++ b/apps/notebook-cloud/src/cloudflare-types.ts
@@ -62,6 +62,12 @@ export interface DurableObjectStorage {
     limit?: number;
     reverse?: boolean;
   }): Promise<Map<string, T>>;
+  // Alarm API (Cloudflare-provided). Optional here so the existing fake
+  // storage in tests need not implement it; the runtime_peer-gone watchdog
+  // feature-detects these before arming.
+  setAlarm?(scheduledTime: number | Date): Promise<void>;
+  getAlarm?(): Promise<number | null>;
+  deleteAlarm?(): Promise<void>;
 }
 
 export interface D1Database {

--- a/apps/notebook-cloud/src/notebook-room.ts
+++ b/apps/notebook-cloud/src/notebook-room.ts
@@ -52,6 +52,18 @@ interface PeerAttachment {
 
 const MAX_STORED_FRAMES = 500;
 
+/// Grace window after the last `runtime_peer` leaves before the room reconciles
+/// its in-flight state (lifecycle-analysis reqs #3/#7). Tolerates a transient
+/// disconnect/reconnect (idle eviction, network blip) without terminalizing a
+/// kernel that is about to come back: if a `runtime_peer` rejoins inside the
+/// window the alarm is disarmed.
+const RUNTIME_PEER_GONE_GRACE_MS = 30_000;
+
+/// Storage key holding the notebook id whose `runtime_peer` departure armed the
+/// reconciliation alarm. Persisted so a DO that hibernates between the alarm
+/// being set and firing still knows which room to reconcile.
+const RUNTIME_PEER_WATCH_KEY = "runtime_peer_gone_watch";
+
 export class NotebookRoom {
   private readonly peers = new Map<string, Peer>();
   private readonly pendingRemovals = new Map<string, { notebookId: string; peer: Peer }>();
@@ -99,6 +111,11 @@ export class NotebookRoom {
 
     this.acceptPeerSocket(notebookId, peer);
     this.peers.set(peer.id, peer);
+    // A runtime_peer (re)joining cancels any pending reconciliation alarm: the
+    // kernel host is back, so its in-flight state must not be terminalized.
+    if (identity.scope === "runtime_peer") {
+      this.refreshRuntimePeerWatch(notebookId);
+    }
     cloudLog("info", "room.connection.accepted", {
       notebook_id: notebookId,
       peer_id: peer.id,
@@ -671,6 +688,100 @@ export class NotebookRoom {
       room_peer_count: this.peers.size,
       timestamp: new Date().toISOString(),
     });
+
+    // A runtime_peer departure is the one failure the daemon can't self-correct
+    // (its death IS the trigger). Arm the reconciliation watchdog if it left no
+    // runtime_peer behind.
+    if (peer.identity.scope === "runtime_peer") {
+      this.refreshRuntimePeerWatch(notebookId);
+    }
+  }
+
+  /// Whether any currently-attached peer is a `runtime_peer`.
+  private hasRuntimePeer(): boolean {
+    for (const peer of this.peers.values()) {
+      if (peer.identity.scope === "runtime_peer") {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  /// Arm or disarm the runtime_peer-gone reconciliation alarm to match current
+  /// membership: arm (grace window) when no `runtime_peer` is attached, disarm
+  /// when one is present. Called when a `runtime_peer` joins or leaves. A no-op
+  /// where the storage backend doesn't expose the alarm API (e.g. test fakes).
+  private refreshRuntimePeerWatch(notebookId: string): void {
+    const storage = this.state.storage;
+    if (!storage.setAlarm || !storage.deleteAlarm) {
+      return;
+    }
+    this.state.waitUntil(
+      (async () => {
+        try {
+          if (this.hasRuntimePeer()) {
+            await storage.deleteAlarm?.();
+            await storage.delete(RUNTIME_PEER_WATCH_KEY);
+            return;
+          }
+          await storage.put(RUNTIME_PEER_WATCH_KEY, notebookId);
+          await storage.setAlarm?.(Date.now() + RUNTIME_PEER_GONE_GRACE_MS);
+        } catch (error) {
+          cloudLog("warn", "room.runtime_peer_watch.refresh_failed", {
+            notebook_id: notebookId,
+            error: errorMessage(error),
+          });
+        }
+      })(),
+    );
+  }
+
+  /// DurableObject alarm handler. Fires `RUNTIME_PEER_GONE_GRACE_MS` after the
+  /// last `runtime_peer` left. If one has since rejoined, it's a no-op (the blip
+  /// recovered). Otherwise it reconciles the room's authoritative RuntimeStateDoc
+  /// — terminalizing orphaned executions and flipping a phantom-live kernel to
+  /// Error — and broadcasts the corrected state to the surviving peers.
+  async alarm(): Promise<void> {
+    const storage = this.state.storage;
+    const notebookId = await storage.get<string>(RUNTIME_PEER_WATCH_KEY);
+    if (!notebookId) {
+      return;
+    }
+    await storage.delete(RUNTIME_PEER_WATCH_KEY);
+
+    if (this.hasRuntimePeer()) {
+      cloudLog("info", "room.runtime_peer_watch.recovered", {
+        notebook_id: notebookId,
+        counter: "runtime_peer_gone_recovered",
+        counter_delta: 1,
+      });
+      return;
+    }
+
+    try {
+      const result = await this.materializerFor(notebookId).reconcileRuntimePeerGone(
+        "runtime peer left the room and did not return within the grace window",
+      );
+      if (result.changed) {
+        this.deliverRoomHostFrames(notebookId, result);
+        this.state.waitUntil(
+          this.materializerFor(notebookId)
+            .checkpoint()
+            .catch(() => undefined),
+        );
+      }
+      cloudLog("info", "room.runtime_peer_watch.reconciled", {
+        notebook_id: notebookId,
+        changed: result.changed,
+        counter: "runtime_peer_gone_reconciled",
+        counter_delta: 1,
+      });
+    } catch (error) {
+      cloudLog("error", "room.runtime_peer_watch.reconcile_failed", {
+        notebook_id: notebookId,
+        error: errorMessage(error),
+      });
+    }
   }
 }
 

--- a/apps/notebook-cloud/src/room-materializer.ts
+++ b/apps/notebook-cloud/src/room-materializer.ts
@@ -62,6 +62,14 @@ export class RoomMaterializer {
     });
   }
 
+  /// Reconcile the authoritative RuntimeStateDoc after the room's runtime_peer
+  /// has departed without returning. Terminalizes in-flight executions and flips
+  /// a phantom-live kernel to Error, returning the sync frames to broadcast to
+  /// the surviving peers. See `RoomHostHandle::reconcile_runtime_peer_gone`.
+  async reconcileRuntimePeerGone(reason: string): Promise<RoomHostFrameResult> {
+    return this.withHost((host) => normalizeResult(host.reconcile_runtime_peer_gone(reason)));
+  }
+
   async receiveFrame(peer: RoomPeer, frame: TypedFrame): Promise<RoomHostFrameResult> {
     const canWriteAllNotebookChanges = peer.identity.scope === "owner";
     const encoded = encodeTypedFrame(frame.type, frame.payload);

--- a/apps/notebook-cloud/test/notebook-room.test.ts
+++ b/apps/notebook-cloud/test/notebook-room.test.ts
@@ -509,6 +509,118 @@ describe("NotebookRoom materialized sync persistence", () => {
   });
 });
 
+describe("NotebookRoom runtime_peer-gone watchdog", () => {
+  function peerWithScope(id: string, scope: string): PeerForTest {
+    const identity = authenticateDevRequest(
+      new Request(
+        `https://cloud.test/n/demo/sync?user=${id}&operator=desktop:${id}&scope=${scope}`,
+      ),
+    );
+    return {
+      id,
+      socket: new FakeSocket().asCloudflareWebSocket(),
+      identity,
+      connectedAt: "2026-06-05T00:00:00.000Z",
+    };
+  }
+
+  it("arms the alarm when the last runtime_peer leaves and reconciles on fire", async () => {
+    const state = alarmCapableState();
+    const room = new NotebookRoom(state.state, {} as Env);
+    const harness = roomHarness(room);
+
+    // A reconcile-recording fake materializer stands in for the wasm host.
+    let reconcileCalls = 0;
+    const reconciled: RoomHostFrameResult = {
+      changed: true,
+      notebook_changed: false,
+      runtime_state_changed: true,
+      outbound: [],
+    };
+    harness.materializers.set("demo", {
+      receiveFrame: async () => noopMaterializedResult(),
+      checkpoint: async () => undefined,
+      removePeer: async () => undefined,
+      reconcileRuntimePeerGone: async () => {
+        reconcileCalls += 1;
+        return reconciled;
+      },
+    } as never);
+
+    const runtimePeer = peerWithScope("rt", "runtime_peer");
+    harness.peers.set(runtimePeer.id, runtimePeer);
+    harness.removePeer("demo", runtimePeer);
+    await state.drain();
+
+    // Departure with no runtime_peer left -> alarm armed.
+    assert.equal(await state.getAlarm(), state.now + 30_000);
+    assert.equal(reconcileCalls, 0, "reconcile waits for the grace alarm to fire");
+
+    // Fire the alarm: still no runtime_peer -> reconcile runs.
+    await (room as unknown as { alarm(): Promise<void> }).alarm();
+    await state.drain();
+    assert.equal(reconcileCalls, 1, "alarm reconciles the orphaned room");
+  });
+
+  it("disarms (no reconcile) when a runtime_peer rejoins within the grace window", async () => {
+    const state = alarmCapableState();
+    const room = new NotebookRoom(state.state, {} as Env);
+    const harness = roomHarness(room);
+    let reconcileCalls = 0;
+    harness.materializers.set("demo", {
+      receiveFrame: async () => noopMaterializedResult(),
+      checkpoint: async () => undefined,
+      removePeer: async () => undefined,
+      reconcileRuntimePeerGone: async () => {
+        reconcileCalls += 1;
+        return noopMaterializedResult();
+      },
+    } as never);
+
+    const runtimePeer = peerWithScope("rt", "runtime_peer");
+    harness.peers.set(runtimePeer.id, runtimePeer);
+    harness.removePeer("demo", runtimePeer);
+    await state.drain();
+    assert.equal(await state.getAlarm(), state.now + 30_000, "armed after departure");
+
+    // A fresh runtime_peer rejoins before the alarm; the watch key is cleared so
+    // a late alarm becomes a no-op.
+    const rejoined = peerWithScope("rt2", "runtime_peer");
+    harness.peers.set(rejoined.id, rejoined);
+    harness.refreshRuntimePeerWatch?.("demo");
+    await state.drain();
+    assert.equal(await state.getAlarm(), null, "rejoin disarmed the alarm");
+
+    await (room as unknown as { alarm(): Promise<void> }).alarm();
+    await state.drain();
+    assert.equal(reconcileCalls, 0, "no reconcile after a recovered blip");
+  });
+
+  it("a fired alarm is a no-op when a runtime_peer is present", async () => {
+    const state = alarmCapableState();
+    const room = new NotebookRoom(state.state, {} as Env);
+    const harness = roomHarness(room);
+    let reconcileCalls = 0;
+    harness.materializers.set("demo", {
+      receiveFrame: async () => noopMaterializedResult(),
+      checkpoint: async () => undefined,
+      removePeer: async () => undefined,
+      reconcileRuntimePeerGone: async () => {
+        reconcileCalls += 1;
+        return noopMaterializedResult();
+      },
+    } as never);
+
+    // Watch key set (as if armed), but a runtime_peer is attached when it fires.
+    await state.state.storage.put("runtime_peer_gone_watch", "demo");
+    harness.peers.set("rt", peerWithScope("rt", "runtime_peer"));
+
+    await (room as unknown as { alarm(): Promise<void> }).alarm();
+    await state.drain();
+    assert.equal(reconcileCalls, 0, "present runtime_peer suppresses reconcile");
+  });
+});
+
 type PeerForTest = {
   id: string;
   socket: CloudflareWebSocket;
@@ -523,8 +635,10 @@ interface RoomHarness {
     {
       receiveFrame(): Promise<RoomHostFrameResult>;
       checkpoint(): Promise<void>;
+      reconcileRuntimePeerGone?(reason: string): Promise<RoomHostFrameResult>;
     }
   >;
+  refreshRuntimePeerWatch?(notebookId: string): void;
   handleMessage(
     notebookId: string,
     peer: PeerForTest,
@@ -534,6 +648,7 @@ interface RoomHarness {
   removePeer(notebookId: string, peer: PeerForTest): void;
   peerForSocket(socket: CloudflareWebSocket): PeerForTest | undefined;
   broadcastFrame(notebookId: string, frame: Uint8Array, excludePeerId?: string): void;
+  hasRuntimePeer(): boolean;
 }
 
 function roomHarness(room: NotebookRoom): RoomHarness {
@@ -553,6 +668,58 @@ function fakeState(): DurableObjectState {
       list: async <T>() => new Map(values as Map<string, T>),
     },
     waitUntil: () => undefined,
+  };
+}
+
+/// A fake DurableObjectState with the alarm API and a deterministic clock, plus
+/// a `drain()` that awaits everything passed to `waitUntil` (so the watchdog's
+/// fire-and-forget arm/disarm work completes before assertions). `now` is fixed
+/// so the armed alarm time is predictable in tests.
+function alarmCapableState(): {
+  state: DurableObjectState;
+  now: number;
+  getAlarm(): Promise<number | null>;
+  drain(): Promise<void>;
+} {
+  const values = new Map<string, unknown>();
+  const pending: Promise<unknown>[] = [];
+  let alarmAt: number | null = null;
+  const now = 1_000_000;
+  const state: DurableObjectState = {
+    id: { toString: () => "room-id" },
+    storage: {
+      get: async <T>(key: string) => values.get(key) as T | undefined,
+      put: async <T>(key: string, value: T) => {
+        values.set(key, value);
+      },
+      delete: async (key: string) => values.delete(key),
+      list: async <T>() => new Map(values as Map<string, T>),
+      setAlarm: async (scheduledTime: number | Date) => {
+        alarmAt = typeof scheduledTime === "number" ? scheduledTime : scheduledTime.getTime();
+      },
+      getAlarm: async () => alarmAt,
+      deleteAlarm: async () => {
+        alarmAt = null;
+      },
+    },
+    waitUntil: (promise: Promise<unknown>) => {
+      pending.push(promise.catch(() => undefined));
+    },
+  };
+  // The room reads Date.now() to compute the alarm time; pin it for the test.
+  const realNow = Date.now;
+  Date.now = () => now;
+  return {
+    state,
+    now,
+    getAlarm: async () => alarmAt,
+    drain: async () => {
+      while (pending.length > 0) {
+        const batch = pending.splice(0, pending.length);
+        await Promise.all(batch);
+      }
+      Date.now = realNow;
+    },
   };
 }
 

--- a/crates/notebook-cloud-transport/Cargo.toml
+++ b/crates/notebook-cloud-transport/Cargo.toml
@@ -20,4 +20,4 @@ tokio-tungstenite = { version = "0.26", features = ["native-tls"] }
 tracing = "0.1"
 
 [dev-dependencies]
-tokio = { workspace = true, features = ["macros", "rt-multi-thread"] }
+tokio = { workspace = true, features = ["macros", "rt-multi-thread", "test-util"] }

--- a/crates/notebook-cloud-transport/src/lib.rs
+++ b/crates/notebook-cloud-transport/src/lib.rs
@@ -86,6 +86,40 @@ pub enum CloudAuth {
     Dev { token: String, user: String },
 }
 
+impl CloudAuth {
+    /// Return a copy of this auth with its credential replaced by `token`,
+    /// preserving the variant (and the `Dev` user label). Used by the
+    /// token-refresher path so a reconnect re-auths with a freshly-minted token
+    /// without changing the auth *kind* the room expects.
+    fn with_token(&self, token: String) -> Self {
+        match self {
+            CloudAuth::OidcBearer { .. } => CloudAuth::OidcBearer { token },
+            CloudAuth::AnacondaApiKey { .. } => CloudAuth::AnacondaApiKey { token },
+            CloudAuth::Dev { user, .. } => CloudAuth::Dev {
+                token,
+                user: user.clone(),
+            },
+        }
+    }
+}
+
+/// A closure the transport calls *before each connect* to obtain a fresh
+/// credential, replacing the static token in [`CloudWsConfig::auth`].
+///
+/// The cloud auth token is static for a single short session today, but a
+/// long-lived runtime peer outlives its OIDC token's expiry: every reconnect
+/// (idle eviction, blip) must re-auth, and a reconnect that re-presents an
+/// expired token is rejected at the upgrade, so `reconnect_with_backoff` would
+/// burn all its attempts and give up. A refresher lets the agent mint a fresh
+/// token per connect. `None` (the default) keeps the static-token behavior. The
+/// closure is `async` (refresh is typically a network round-trip) and its error
+/// surfaces as a connect error so the backoff loop retries.
+pub type TokenRefresher = Arc<
+    dyn Fn() -> std::pin::Pin<Box<dyn std::future::Future<Output = std::io::Result<String>> + Send>>
+        + Send
+        + Sync,
+>;
+
 /// Connection parameters for a cloud room. Immutable for the life of the
 /// transport, so [`CloudWsFrameTransport::connect`] can be called repeatedly on
 /// reconnect.
@@ -333,16 +367,36 @@ pub struct CloudWsFrameTransport {
     /// Principal from the most recent `cloud_room_ready`. Set on first connect;
     /// reconnects to the same room re-observe the same principal.
     principal: Arc<std::sync::OnceLock<String>>,
+    /// Optional per-connect token refresher. `None` keeps the static token from
+    /// `config.auth`. When set, `connect` calls it before each dial and re-auths
+    /// with the returned token so a long-lived peer survives token expiry across
+    /// reconnects.
+    refresher: Option<TokenRefresher>,
 }
 
 impl CloudWsFrameTransport {
-    /// Build a transport for `config`.
+    /// Build a transport for `config` with the static token in `config.auth`.
     pub fn new(config: CloudWsConfig) -> Self {
         let ws_url = build_ws_url(&config.cloud_url, &config.notebook_id);
         Self {
             config,
             ws_url,
             principal: Arc::new(std::sync::OnceLock::new()),
+            refresher: None,
+        }
+    }
+
+    /// Build a transport that mints a fresh credential before every connect via
+    /// `refresher`, replacing the token in `config.auth` (the variant and any
+    /// `Dev` user label are preserved). Use for long-lived runtime peers whose
+    /// OIDC token would otherwise expire mid-session and fail every reconnect.
+    pub fn with_token_refresher(config: CloudWsConfig, refresher: TokenRefresher) -> Self {
+        let ws_url = build_ws_url(&config.cloud_url, &config.notebook_id);
+        Self {
+            config,
+            ws_url,
+            principal: Arc::new(std::sync::OnceLock::new()),
+            refresher: Some(refresher),
         }
     }
 
@@ -358,10 +412,26 @@ impl CloudWsFrameTransport {
         self.principal.get().map(String::as_str)
     }
 
-    /// Apply the auth headers for `config.auth` to the upgrade request.
+    /// Resolve the credential to present on the next connect: the refresher's
+    /// fresh token (re-wrapped in `config.auth`'s variant) if one is configured,
+    /// else the static `config.auth` unchanged.
+    async fn effective_auth(&self) -> std::io::Result<CloudAuth> {
+        match &self.refresher {
+            Some(refresh) => {
+                let token = refresh().await.map_err(|e| {
+                    std::io::Error::new(e.kind(), format!("token refresh failed: {e}"))
+                })?;
+                Ok(self.config.auth.with_token(token))
+            }
+            None => Ok(self.config.auth.clone()),
+        }
+    }
+
+    /// Apply the auth headers for `auth` to the upgrade request.
     fn apply_auth_headers(
         &self,
         request: &mut tokio_tungstenite::tungstenite::handshake::client::Request,
+        auth: &CloudAuth,
     ) -> anyhow::Result<()> {
         let h = request.headers_mut();
         // No Sec-WebSocket-Protocol: the credential rides Authorization /
@@ -370,7 +440,7 @@ impl CloudWsFrameTransport {
             HeaderName::from_static("x-scope"),
             HeaderValue::from_str(&self.config.scope)?,
         );
-        match &self.config.auth {
+        match auth {
             CloudAuth::Dev { token, user } => {
                 h.insert(
                     HeaderName::from_static("x-notebook-cloud-dev-token"),
@@ -405,12 +475,13 @@ impl CloudWsFrameTransport {
     /// and the room principal. The [`FrameTransport::connect`] impl delegates
     /// here and caches the principal.
     async fn connect_cloud(&self) -> std::io::Result<(CloudWsSource, CloudWsSink, String)> {
+        let auth = self.effective_auth().await?;
         let mut request = self
             .ws_url
             .as_str()
             .into_client_request()
             .map_err(|e| std::io::Error::other(format!("build upgrade request: {e}")))?;
-        self.apply_auth_headers(&mut request)
+        self.apply_auth_headers(&mut request, &auth)
             .map_err(|e| std::io::Error::other(format!("apply auth headers: {e}")))?;
 
         info!(
@@ -682,6 +753,85 @@ mod tests {
             },
         });
         assert!(t.clean_eof_is_recoverable());
+    }
+
+    // -- token-refresher tests --------------------------------------------
+
+    #[test]
+    fn with_token_preserves_variant_and_dev_user() {
+        assert!(matches!(
+            CloudAuth::OidcBearer { token: "old".into() }.with_token("new".into()),
+            CloudAuth::OidcBearer { token } if token == "new"
+        ));
+        assert!(matches!(
+            CloudAuth::AnacondaApiKey { token: "old".into() }.with_token("new".into()),
+            CloudAuth::AnacondaApiKey { token } if token == "new"
+        ));
+        // Dev keeps its user label, swaps only the token.
+        match (CloudAuth::Dev {
+            token: "old".into(),
+            user: "alice".into(),
+        })
+        .with_token("new".into())
+        {
+            CloudAuth::Dev { token, user } => {
+                assert_eq!(token, "new");
+                assert_eq!(user, "alice");
+            }
+            _ => panic!("expected Dev"),
+        }
+    }
+
+    fn test_config() -> CloudWsConfig {
+        CloudWsConfig {
+            cloud_url: "https://preview.runt.run".into(),
+            notebook_id: "abc".into(),
+            scope: "runtime_peer".into(),
+            auth: CloudAuth::OidcBearer {
+                token: "static-tok".into(),
+            },
+        }
+    }
+
+    #[tokio::test]
+    async fn effective_auth_uses_static_token_without_refresher() {
+        let t = CloudWsFrameTransport::new(test_config());
+        match t.effective_auth().await.unwrap() {
+            CloudAuth::OidcBearer { token } => assert_eq!(token, "static-tok"),
+            _ => panic!("expected OidcBearer"),
+        }
+    }
+
+    #[tokio::test]
+    async fn effective_auth_uses_refreshed_token_when_set() {
+        let refresher: TokenRefresher =
+            Arc::new(|| Box::pin(async { Ok("fresh-tok".to_string()) }));
+        let t = CloudWsFrameTransport::with_token_refresher(test_config(), refresher);
+        match t.effective_auth().await.unwrap() {
+            // Variant preserved (still OIDC), token replaced with the fresh one.
+            CloudAuth::OidcBearer { token } => assert_eq!(token, "fresh-tok"),
+            _ => panic!("expected OidcBearer"),
+        }
+    }
+
+    #[tokio::test]
+    async fn effective_auth_surfaces_refresher_error() {
+        let refresher: TokenRefresher = Arc::new(|| {
+            Box::pin(async {
+                Err(std::io::Error::new(
+                    std::io::ErrorKind::PermissionDenied,
+                    "token endpoint said no",
+                ))
+            })
+        });
+        let t = CloudWsFrameTransport::with_token_refresher(test_config(), refresher);
+        let err = t
+            .effective_auth()
+            .await
+            .expect_err("refresher error surfaces");
+        // Kind is preserved so the agent can distinguish auth failures; the
+        // backoff loop treats any connect error as retryable.
+        assert_eq!(err.kind(), std::io::ErrorKind::PermissionDenied);
     }
 
     // -- ready-wait helper tests ------------------------------------------

--- a/crates/notebook-cloud-transport/src/lib.rs
+++ b/crates/notebook-cloud-transport/src/lib.rs
@@ -41,6 +41,7 @@
 
 use std::collections::VecDeque;
 use std::sync::Arc;
+use std::time::Duration;
 
 use futures_util::stream::{SplitSink, SplitStream};
 use futures_util::{SinkExt, StreamExt};
@@ -56,6 +57,19 @@ use tracing::{debug, info, warn};
 /// First-byte constant for the session-control channel (`cloud_room_ready`
 /// arrives here). Re-export of the wire constant for local readability.
 const SESSION_CONTROL: u8 = notebook_wire::frame_types::SESSION_CONTROL;
+
+/// How long [`CloudWsFrameTransport::connect`] waits for the room to reach the
+/// `cloud_room_ready` / `cloud_frame_rejected` state after a successful WS
+/// upgrade, before giving up with a `TimedOut` connect error.
+///
+/// Without this bound a room that completes the upgrade but never sends a
+/// terminal control frame and never closes the socket would hang `connect`
+/// forever. Because every reconnect attempt calls `connect` with no per-attempt
+/// timeout of its own, that hang would also wedge the whole
+/// `reconnect_with_backoff` recovery path. Returning a connect error instead
+/// lets the agent's backoff loop retry (or, after its bounded attempts, exit
+/// cleanly) rather than block indefinitely on one wedged room.
+const READY_WAIT_TIMEOUT: Duration = Duration::from_secs(30);
 
 type WsStream = WebSocketStream<MaybeTlsStream<TcpStream>>;
 
@@ -178,6 +192,57 @@ fn classify_ready_control(payload: &[u8]) -> ReadyControl {
             ReadyControl::Rejected(reason)
         }
         _ => ReadyControl::Other,
+    }
+}
+
+/// Read frames from `source` until the room reaches a terminal ready state,
+/// returning the authenticated principal from `cloud_room_ready`.
+///
+/// Data frames that arrive before the room is ready are pushed onto `buffered`
+/// so the caller can replay them to the agent after the handshake — the
+/// connect-time wait never drops a frame. A `cloud_frame_rejected` is surfaced
+/// as a `PermissionDenied` error (the room refusing the attach over a control
+/// frame rather than an HTTP status); a clean close before ready is an
+/// `UnexpectedEof`.
+///
+/// This helper has no deadline of its own — [`CloudWsFrameTransport::connect`]
+/// wraps it in [`READY_WAIT_TIMEOUT`] so a room that upgrades the WS but never
+/// sends a terminal control frame can't hang the connect forever. It is generic
+/// over [`FrameSource`] so the timeout and rejection paths are unit-testable
+/// against a mock source.
+async fn wait_for_ready<S: FrameSource>(
+    source: &mut S,
+    buffered: &mut VecDeque<TypedNotebookFrame>,
+) -> std::io::Result<String> {
+    loop {
+        match source.recv_frame().await {
+            Some(Ok(frame)) if frame.frame_type as u8 == SESSION_CONTROL => {
+                match classify_ready_control(&frame.payload) {
+                    ReadyControl::Ready(principal) => return Ok(principal),
+                    ReadyControl::Rejected(reason) => {
+                        return Err(std::io::Error::new(
+                            std::io::ErrorKind::PermissionDenied,
+                            format!("room rejected attach before ready: {reason}"),
+                        ));
+                    }
+                    ReadyControl::Other => {
+                        debug!(
+                            "[cloud-transport] control frame before ready ({} bytes): {}",
+                            frame.payload.len(),
+                            String::from_utf8_lossy(&frame.payload)
+                        );
+                    }
+                }
+            }
+            Some(Ok(frame)) => buffered.push_back(frame),
+            Some(Err(e)) => return Err(e),
+            None => {
+                return Err(std::io::Error::new(
+                    std::io::ErrorKind::UnexpectedEof,
+                    "connection closed before cloud_room_ready",
+                ));
+            }
+        }
     }
 }
 
@@ -375,42 +440,32 @@ impl CloudWsFrameTransport {
             pending: VecDeque::new(),
         };
 
-        // Read up to `cloud_room_ready`, surfacing the principal. Buffer any
-        // data frames that arrive first so the agent loop sees them after the
-        // ready handshake without loss. A `cloud_frame_rejected` during this
-        // window is the room refusing the attach (auth/ACL) over a control
-        // frame rather than an HTTP status; surface its reason rather than
-        // hanging until the socket closes.
-        let principal = loop {
-            match source.recv_frame().await {
-                Some(Ok(frame)) if frame.frame_type as u8 == SESSION_CONTROL => {
-                    match classify_ready_control(&frame.payload) {
-                        ReadyControl::Ready(principal) => break principal,
-                        ReadyControl::Rejected(reason) => {
-                            return Err(std::io::Error::new(
-                                std::io::ErrorKind::PermissionDenied,
-                                format!("room rejected attach before ready: {reason}"),
-                            ));
-                        }
-                        ReadyControl::Other => {
-                            debug!(
-                                "[cloud-transport] control frame before ready ({} bytes): {}",
-                                frame.payload.len(),
-                                String::from_utf8_lossy(&frame.payload)
-                            );
-                        }
-                    }
-                }
-                Some(Ok(frame)) => source.pending.push_back(frame),
-                Some(Err(e)) => return Err(e),
-                None => {
-                    return Err(std::io::Error::new(
-                        std::io::ErrorKind::UnexpectedEof,
-                        "connection closed before cloud_room_ready",
-                    ));
-                }
+        // Read up to `cloud_room_ready`, surfacing the principal — but bound the
+        // wait. A room that upgrades the WS yet never sends a terminal control
+        // frame and never closes would otherwise hang `connect` (and, through
+        // `reconnect_with_backoff`, the whole recovery path) forever. On timeout
+        // return a `TimedOut` connect error so the agent retries rather than
+        // blocks. Data frames that arrive before ready are buffered in
+        // `source.pending` and replayed to the agent after the handshake.
+        let mut buffered = VecDeque::new();
+        let principal = match tokio::time::timeout(
+            READY_WAIT_TIMEOUT,
+            wait_for_ready(&mut source, &mut buffered),
+        )
+        .await
+        {
+            Ok(result) => result?,
+            Err(_elapsed) => {
+                return Err(std::io::Error::new(
+                    std::io::ErrorKind::TimedOut,
+                    format!(
+                        "room did not send cloud_room_ready within {}s",
+                        READY_WAIT_TIMEOUT.as_secs()
+                    ),
+                ));
             }
         };
+        source.pending = buffered;
 
         info!("[cloud-transport] room ready; principal={principal}");
         let sink = CloudWsSink { sink };
@@ -627,5 +682,141 @@ mod tests {
             },
         });
         assert!(t.clean_eof_is_recoverable());
+    }
+
+    // -- ready-wait helper tests ------------------------------------------
+    //
+    // `wait_for_ready` is the inner loop `connect` wraps in `READY_WAIT_TIMEOUT`.
+    // Testing it (and the timeout) against a mock `FrameSource` exercises the
+    // hang/rejection/buffering paths without a live room.
+
+    /// A scripted [`FrameSource`]: yields a queue of frames, then either ends
+    /// the stream (`None`) or, if `hang` is set, blocks forever — modelling a
+    /// room that upgraded the WS but never sends a terminal control frame.
+    struct ScriptedSource {
+        frames: VecDeque<std::io::Result<TypedNotebookFrame>>,
+        hang: bool,
+    }
+
+    impl ScriptedSource {
+        fn yielding(frames: Vec<std::io::Result<TypedNotebookFrame>>) -> Self {
+            Self {
+                frames: frames.into(),
+                hang: false,
+            }
+        }
+
+        /// Yields `frames`, then hangs forever instead of ending the stream.
+        fn then_hang(frames: Vec<std::io::Result<TypedNotebookFrame>>) -> Self {
+            Self {
+                frames: frames.into(),
+                hang: true,
+            }
+        }
+    }
+
+    impl FrameSource for ScriptedSource {
+        async fn recv_frame(&mut self) -> Option<std::io::Result<TypedNotebookFrame>> {
+            if let Some(frame) = self.frames.pop_front() {
+                return Some(frame);
+            }
+            if self.hang {
+                std::future::pending::<()>().await;
+            }
+            None
+        }
+    }
+
+    fn control_frame(json: serde_json::Value) -> TypedNotebookFrame {
+        TypedNotebookFrame {
+            frame_type: NotebookFrameType::SessionControl,
+            payload: serde_json::to_vec(&json).unwrap(),
+        }
+    }
+
+    fn data_frame(payload: &[u8]) -> TypedNotebookFrame {
+        TypedNotebookFrame {
+            frame_type: NotebookFrameType::AutomergeSync,
+            payload: payload.to_vec(),
+        }
+    }
+
+    #[tokio::test]
+    async fn wait_for_ready_returns_principal_and_buffers_pre_ready_data() {
+        // A data frame arrives before `cloud_room_ready`; it must be buffered
+        // (replayed to the agent later), not dropped, and the principal parsed.
+        let mut source = ScriptedSource::yielding(vec![
+            Ok(data_frame(b"early sync bytes")),
+            Ok(control_frame(serde_json::json!({
+                "type": "cloud_room_ready",
+                "actor_label": "anaconda:alice/agent:runt:7f3a",
+            }))),
+        ]);
+        let mut buffered = VecDeque::new();
+        let principal = wait_for_ready(&mut source, &mut buffered).await.unwrap();
+        assert_eq!(principal, "anaconda:alice");
+        assert_eq!(buffered.len(), 1, "pre-ready data frame is buffered");
+        assert_eq!(buffered[0].payload, b"early sync bytes");
+    }
+
+    #[tokio::test]
+    async fn wait_for_ready_surfaces_rejection() {
+        let mut source = ScriptedSource::yielding(vec![Ok(control_frame(serde_json::json!({
+            "type": "cloud_frame_rejected",
+            "reason": "principal lacks runtime_peer ACL row",
+        })))]);
+        let mut buffered = VecDeque::new();
+        let err = wait_for_ready(&mut source, &mut buffered)
+            .await
+            .expect_err("rejection is an error");
+        assert_eq!(err.kind(), std::io::ErrorKind::PermissionDenied);
+    }
+
+    #[tokio::test]
+    async fn wait_for_ready_clean_eof_before_ready_is_unexpected_eof() {
+        let mut source = ScriptedSource::yielding(vec![]);
+        let mut buffered = VecDeque::new();
+        let err = wait_for_ready(&mut source, &mut buffered)
+            .await
+            .expect_err("EOF before ready is an error");
+        assert_eq!(err.kind(), std::io::ErrorKind::UnexpectedEof);
+    }
+
+    /// The keystone gap-1 test: a room that upgrades the WS but never sends a
+    /// terminal control frame and never closes must NOT hang `connect`. The
+    /// `READY_WAIT_TIMEOUT` wrapper turns the hang into a `TimedOut` error so
+    /// `reconnect_with_backoff` can retry. Uses paused time so the test is
+    /// instant and deterministic.
+    #[tokio::test(start_paused = true)]
+    async fn ready_wait_times_out_on_a_silent_room() {
+        // Sends one non-terminal control frame, then hangs forever.
+        let mut source = ScriptedSource::then_hang(vec![Ok(control_frame(serde_json::json!({
+            "type": "cloud_frame_accepted",
+        })))]);
+        let mut buffered = VecDeque::new();
+
+        let result = tokio::time::timeout(
+            READY_WAIT_TIMEOUT,
+            wait_for_ready(&mut source, &mut buffered),
+        )
+        .await;
+        assert!(
+            result.is_err(),
+            "a room that never sends cloud_room_ready must time out, not hang"
+        );
+
+        // And the connect-time mapping turns that elapsed into a TimedOut io
+        // error (the shape `reconnect_with_backoff` treats as a failed connect).
+        let mapped: std::io::Result<String> = match result {
+            Ok(inner) => inner,
+            Err(_elapsed) => Err(std::io::Error::new(
+                std::io::ErrorKind::TimedOut,
+                "room did not send cloud_room_ready",
+            )),
+        };
+        assert_eq!(
+            mapped.expect_err("timed out").kind(),
+            std::io::ErrorKind::TimedOut
+        );
     }
 }

--- a/crates/runtime-doc/src/doc.rs
+++ b/crates/runtime-doc/src/doc.rs
@@ -143,6 +143,21 @@ pub struct KernelState {
     /// "scaffolded but unset" (same convention as `error_reason`).
     #[serde(default)]
     pub error_details: Option<String>,
+    /// Liveness heartbeat: ISO-8601 timestamp the runtime peer was last
+    /// known present on the sync link, refreshed by the room as it observes
+    /// the peer. `None` when absent (no peer has reported in, a pre-field doc,
+    /// or explicitly cleared — the setter writes a CRDT `Null`, unlike the
+    /// empty-string `error_reason`/`error_details` convention).
+    ///
+    /// This is the model half of lifecycle requirement #4(b): it lets a
+    /// cloud room (and viewers) distinguish "kernel alive, peer reporting"
+    /// from "peer hasn't been seen since `last_seen`" — the staleness signal
+    /// the room-side watchdog (Phase 3d) reads to decide a `runtime_peer` has
+    /// gone away, without needing a new terminal `RuntimeLifecycle` variant.
+    /// It carries no authority by itself; it is a fact the room stamps and
+    /// the watchdog interprets.
+    #[serde(default)]
+    pub last_seen: Option<String>,
 }
 
 impl Default for KernelState {
@@ -157,6 +172,7 @@ impl Default for KernelState {
             lifecycle: RuntimeLifecycle::NotStarted,
             error_reason: None,
             error_details: None,
+            last_seen: None,
         }
     }
 }
@@ -1123,6 +1139,28 @@ impl RuntimeStateDoc {
         }
         self.doc
             .put(&kernel, "runtime_agent_id", runtime_agent_id)?;
+        Ok(())
+    }
+
+    /// Stamp the runtime peer liveness heartbeat (`kernel/last_seen`).
+    ///
+    /// `Some(ts)` records an ISO-8601 timestamp the peer was last observed;
+    /// `None` clears it (writes a CRDT `Null`, so `read_state().kernel.last_seen`
+    /// reads back `None`). This is a pure liveness fact — it carries no
+    /// lifecycle authority. The room-side watchdog (Phase 3d) refreshes it as it
+    /// sees the peer and reads it back to decide a `runtime_peer` has gone stale.
+    /// Idempotent: re-stamping the current value is a no-op so it doesn't churn
+    /// the doc heads on every observation.
+    pub fn set_last_seen(&mut self, timestamp: Option<&str>) -> Result<(), RuntimeStateError> {
+        let kernel = self.scaffold_map("kernel")?;
+        let current = automunge::read_str_if_present(&self.doc, &kernel, "last_seen");
+        if current.as_deref() == timestamp {
+            return Ok(());
+        }
+        match timestamp {
+            Some(ts) => self.doc.put(&kernel, "last_seen", ts)?,
+            None => self.doc.put(&kernel, "last_seen", ScalarValue::Null)?,
+        }
         Ok(())
     }
 
@@ -2766,6 +2804,7 @@ impl RuntimeStateDoc {
                         }
                     });
                 let error_details = automunge::read_str_if_present(&self.doc, k, "error_details");
+                let last_seen = automunge::read_str_if_present(&self.doc, k, "last_seen");
                 KernelState {
                     status: status.to_string(),
                     starting_phase: starting_phase.to_string(),
@@ -2776,6 +2815,7 @@ impl RuntimeStateDoc {
                     lifecycle,
                     error_reason,
                     error_details,
+                    last_seen,
                 }
             })
             .unwrap_or_default();
@@ -3879,6 +3919,81 @@ mod tests {
 
         doc.set_last_saved(None).unwrap();
         assert_eq!(doc.read_state().last_saved, None);
+    }
+
+    #[test]
+    fn last_seen_defaults_to_none_on_a_fresh_doc() {
+        // Not part of the frozen genesis scaffold: a fresh doc has no
+        // last_seen, so viewers/the watchdog see "no peer has reported in".
+        let doc = RuntimeStateDoc::new();
+        assert_eq!(doc.read_state().kernel.last_seen, None);
+    }
+
+    #[test]
+    fn set_last_seen_roundtrips_and_clears_to_none() {
+        let mut doc = RuntimeStateDoc::new();
+        doc.set_last_seen(Some("2026-06-05T12:00:00Z")).unwrap();
+        assert_eq!(
+            doc.read_state().kernel.last_seen.as_deref(),
+            Some("2026-06-05T12:00:00Z")
+        );
+
+        // A later observation moves the timestamp forward.
+        doc.set_last_seen(Some("2026-06-05T12:00:05Z")).unwrap();
+        assert_eq!(
+            doc.read_state().kernel.last_seen.as_deref(),
+            Some("2026-06-05T12:00:05Z")
+        );
+
+        // Clearing reads back as None (CRDT Null, not an empty string).
+        doc.set_last_seen(None).unwrap();
+        assert_eq!(doc.read_state().kernel.last_seen, None);
+    }
+
+    #[test]
+    fn set_last_seen_is_idempotent_no_head_churn() {
+        // The watchdog/peer stamps last_seen frequently; re-stamping the same
+        // value must not advance the doc heads (no spurious sync rounds).
+        let mut doc = RuntimeStateDoc::new();
+        doc.set_last_seen(Some("2026-06-05T12:00:00Z")).unwrap();
+        let heads_before = doc.doc_mut().get_heads();
+        doc.set_last_seen(Some("2026-06-05T12:00:00Z")).unwrap();
+        let heads_after = doc.doc_mut().get_heads();
+        assert_eq!(heads_before, heads_after, "re-stamp must not change heads");
+    }
+
+    #[test]
+    fn last_seen_is_runtime_peer_writable_but_blocked_for_editor() {
+        // last_seen lives under `state.kernel`, so the existing kernel-ownership
+        // policy governs it: a runtime_peer may write it, an editor/owner sync
+        // may not (it is part of the daemon/runtime-owned kernel snapshot). This
+        // pins that a liveness stamp can't be forged over an editor sync.
+        use crate::policy::{
+            runtime_state_policy_snapshot, validate_runtime_state_sync_scope,
+            RuntimeStateWriteScope,
+        };
+        let before = RuntimeStateDoc::new();
+        let mut after = RuntimeStateDoc::new();
+        after.set_last_seen(Some("2026-06-05T12:00:00Z")).unwrap();
+
+        let snap_before = runtime_state_policy_snapshot(&before);
+        let snap_after = runtime_state_policy_snapshot(&after);
+
+        // runtime_peer is allowed to stamp liveness.
+        assert!(validate_runtime_state_sync_scope(
+            &snap_before,
+            &snap_after,
+            RuntimeStateWriteScope::RuntimePeer,
+        )
+        .is_ok());
+
+        // editor sync may not touch the kernel snapshot (incl. last_seen).
+        assert!(validate_runtime_state_sync_scope(
+            &snap_before,
+            &snap_after,
+            RuntimeStateWriteScope::Editor,
+        )
+        .is_err());
     }
 
     #[test]

--- a/crates/runtimed-wasm/src/lib.rs
+++ b/crates/runtimed-wasm/src/lib.rs
@@ -25,7 +25,8 @@ use nteract_identity::{ActorLabel, ConnectionScope, Operator, Principal};
 use runtime_doc::{
     diff_output_ids_in_place, output_ids_for_execution, runtime_state_policy_snapshot,
     validate_runtime_state_sync_scope, ExecutionState, ExecutionViewChangeset,
-    ExecutionViewProjector, RuntimeState, RuntimeStateDoc, RuntimeStateWriteScope,
+    ExecutionViewProjector, RuntimeLifecycle, RuntimeState, RuntimeStateDoc,
+    RuntimeStateWriteScope,
 };
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
@@ -525,6 +526,40 @@ impl RoomHostHandle {
         self.runtime_peer_states.remove(peer_id);
     }
 
+    /// Reconcile the authoritative RuntimeStateDoc after the room's
+    /// `runtime_peer` has departed and not returned within the grace period.
+    ///
+    /// This is the room-side safety net the daemon structurally cannot provide:
+    /// when the runtime peer (the daemon) vanishes, it is the very actor that
+    /// would otherwise terminalize in-flight work, so no surviving participant
+    /// and no daemon-side code can correct the doc (lifecycle-analysis reqs #3,
+    /// #7). Left alone, running/queued executions spin forever and the kernel
+    /// shows a phantom-live status to every viewer.
+    ///
+    /// Concretely it: marks all in-flight (`running`/`queued`) executions
+    /// failed, clears the queue, and — if the kernel still reads as live
+    /// (`Running`/a starting phase) — flips lifecycle to `Error` with an
+    /// `error_details` note. It deliberately does NOT touch an already-terminal
+    /// kernel (`Error`/`Shutdown`/`NotStarted`), so a clean shutdown that raced
+    /// the disconnect is not relabeled.
+    ///
+    /// Authoring here is *direct* on the room host's `state_doc`, which does not
+    /// pass through `validate_runtime_state_sync_scope` (that gates only incoming
+    /// peer sync); the room host is the authoritative writer for this document,
+    /// so no policy relaxation is required (see #16 decision log #32).
+    ///
+    /// The Worker is expected to call this from a DurableObject `alarm()` armed
+    /// when the last `runtime_peer` leaves and disarmed if one rejoins within the
+    /// grace window — so a transient blip reconnects rather than reconciles.
+    /// `reason` is a short human string folded into `error_details`. Returns the
+    /// outbound sync frames to broadcast to remaining peers (empty if nothing
+    /// changed — the call is idempotent, so a second alarm is a safe no-op).
+    pub fn reconcile_runtime_peer_gone(&mut self, reason: &str) -> Result<JsValue, JsError> {
+        let result = self.reconcile_runtime_peer_gone_inner(reason)?;
+        serialize_to_js(&result)
+            .map_err(|e| JsError::new(&format!("serialize reconcile result: {e}")))
+    }
+
     /// Generate current sync frames for a peer.
     ///
     /// The Worker calls this immediately after accepting a socket and after the
@@ -986,6 +1021,72 @@ impl RoomHostHandle {
         }
         Ok(())
     }
+
+    /// Native-testable core of [`Self::reconcile_runtime_peer_gone`]. Returns the
+    /// result struct directly (the public method wraps it for the WASM boundary)
+    /// so the reconciliation logic can be unit-tested with plain `cargo test`.
+    fn reconcile_runtime_peer_gone_inner(
+        &mut self,
+        reason: &str,
+    ) -> Result<RoomHostFrameResult, JsError> {
+        let heads_before = self.state_doc.get_heads();
+
+        // 1. Terminalize in-flight executions (running + queued) and clear the
+        //    queue, so viewers stop seeing perpetually-spinning cells and the
+        //    idempotency guard in handle_execute_cell no longer suppresses
+        //    re-runs of the orphaned work.
+        self.state_doc
+            .mark_inflight_executions_failed()
+            .map_err(|e| JsError::new(&format!("reconcile executions: {e}")))?;
+        self.state_doc
+            .set_queue(None, &[])
+            .map_err(|e| JsError::new(&format!("reconcile queue: {e}")))?;
+
+        // 2. Flip a still-live kernel to Error. Leave an already-terminal kernel
+        //    (Error/Shutdown/NotStarted) untouched so a clean shutdown that raced
+        //    the disconnect is not relabeled. "Live" = Running or any starting
+        //    phase the dead peer last published.
+        let lifecycle = self.state_doc.read_state().kernel.lifecycle;
+        if lifecycle_is_live(&lifecycle) {
+            let details = format!("runtime peer disconnected: {reason}");
+            self.state_doc
+                .set_lifecycle_with_error_details(&RuntimeLifecycle::Error, None, Some(&details))
+                .map_err(|e| JsError::new(&format!("reconcile lifecycle: {e}")))?;
+        }
+
+        let changed = self.state_doc.get_heads() != heads_before;
+        let mut result = RoomHostFrameResult {
+            changed,
+            notebook_changed: false,
+            runtime_state_changed: changed,
+            outbound: Vec::new(),
+        };
+        // Broadcast the reconciled state to every remaining peer. Passing an
+        // empty `changed_peer_id` means "exclude no one" — the departed peer is
+        // already gone from `runtime_peer_states`, so this reaches exactly the
+        // survivors (viewers/editors) that need the corrected doc.
+        if changed {
+            self.queue_runtime_state_sync_for_other_peers("", &mut result.outbound)?;
+        }
+        Ok(result)
+    }
+}
+
+/// Whether a kernel lifecycle still reads as "alive" — i.e. a viewer would see
+/// a running or starting kernel. Used by the disconnect watchdog to decide
+/// whether to flip to `Error` (only meaningful from a live state; an already
+/// terminal `Error`/`Shutdown`/`NotStarted` is left as-is).
+fn lifecycle_is_live(lifecycle: &RuntimeLifecycle) -> bool {
+    matches!(
+        lifecycle,
+        RuntimeLifecycle::Running(_)
+            | RuntimeLifecycle::AwaitingTrust
+            | RuntimeLifecycle::AwaitingEnvBuild
+            | RuntimeLifecycle::Resolving
+            | RuntimeLifecycle::PreparingEnv
+            | RuntimeLifecycle::Launching
+            | RuntimeLifecycle::Connecting
+    )
 }
 
 fn room_peer_sync_state(can_write: bool) -> sync::State {
@@ -3336,6 +3437,121 @@ mod tests {
         assert!(!seeded_again);
         assert_eq!(host.doc.cell_count(), 1);
         assert!(host.doc.get_cell("cell-second").is_none());
+    }
+
+    // -- runtime_peer-gone reconciliation (Phase 3d watchdog core) --------
+
+    use runtime_doc::KernelActivity;
+
+    /// Build a host whose RuntimeStateDoc looks like a live runtime peer left
+    /// mid-flight: kernel Running(Busy), one running + one queued execution.
+    fn host_with_inflight_work() -> RoomHostHandle {
+        let mut host = RoomHostHandle::create_empty("demo", "system/schema:notebook-cloud-room")
+            .expect("create room host");
+        let sd = &mut host.state_doc;
+        sd.set_lifecycle(&RuntimeLifecycle::Running(KernelActivity::Busy))
+            .unwrap();
+        sd.create_execution_with_source("exec-running", "x = 1", 0)
+            .unwrap();
+        sd.set_execution_running("exec-running").unwrap();
+        sd.create_execution_with_source("exec-queued", "y = 2", 1)
+            .unwrap();
+        sd.set_queue(
+            Some(&runtime_doc::QueueEntry {
+                execution_id: "exec-running".into(),
+            }),
+            &[runtime_doc::QueueEntry {
+                execution_id: "exec-queued".into(),
+            }],
+        )
+        .unwrap();
+        host
+    }
+
+    #[test]
+    fn reconcile_runtime_peer_gone_terminalizes_inflight_and_errors_live_kernel() {
+        let mut host = host_with_inflight_work();
+
+        let result = host
+            .reconcile_runtime_peer_gone_inner("daemon dropped")
+            .expect("reconcile ok");
+        assert!(result.changed, "reconciliation changed the doc");
+        assert!(result.runtime_state_changed);
+
+        let state = host.state_doc.read_state();
+        // Both in-flight executions are now terminal (error), not spinning.
+        assert_eq!(state.executions["exec-running"].status, "error");
+        assert_eq!(state.executions["exec-queued"].status, "error");
+        // Queue drained so the idempotency guard can't suppress re-runs.
+        assert!(state.queue.executing.is_none());
+        assert!(state.queue.queued.is_empty());
+        // Phantom-live kernel flipped to Error with a diagnostic note.
+        assert_eq!(state.kernel.lifecycle, RuntimeLifecycle::Error);
+        assert_eq!(
+            state.kernel.error_details.as_deref(),
+            Some("runtime peer disconnected: daemon dropped")
+        );
+    }
+
+    #[test]
+    fn reconcile_runtime_peer_gone_is_idempotent() {
+        let mut host = host_with_inflight_work();
+        let first = host
+            .reconcile_runtime_peer_gone_inner("blip")
+            .expect("first reconcile");
+        assert!(first.changed);
+
+        // A second alarm (e.g. the grace timer re-firing) is a safe no-op:
+        // everything is already terminal, so nothing changes and no frames are
+        // broadcast.
+        let second = host
+            .reconcile_runtime_peer_gone_inner("blip")
+            .expect("second reconcile");
+        assert!(!second.changed, "second reconcile is a no-op");
+        assert!(second.outbound.is_empty());
+    }
+
+    #[test]
+    fn reconcile_runtime_peer_gone_does_not_relabel_a_clean_shutdown() {
+        // A clean shutdown that raced the disconnect: kernel already Shutdown,
+        // no in-flight work. Reconciliation must leave the terminal lifecycle
+        // intact rather than rewriting it to Error.
+        let mut host = RoomHostHandle::create_empty("demo", "system/schema:notebook-cloud-room")
+            .expect("create room host");
+        host.state_doc
+            .set_lifecycle(&RuntimeLifecycle::Shutdown)
+            .unwrap();
+
+        let result = host
+            .reconcile_runtime_peer_gone_inner("late disconnect")
+            .expect("reconcile ok");
+        assert!(!result.changed, "nothing to reconcile on a clean shutdown");
+        assert_eq!(
+            host.state_doc.read_state().kernel.lifecycle,
+            RuntimeLifecycle::Shutdown,
+            "a clean shutdown is not relabeled to Error"
+        );
+    }
+
+    #[test]
+    fn reconcile_broadcasts_to_remaining_peers() {
+        let mut host = host_with_inflight_work();
+        // A surviving viewer peer is registered for runtime-state sync.
+        host.runtime_peer_states
+            .insert("viewer-1".to_string(), room_peer_sync_state(false));
+
+        let result = host
+            .reconcile_runtime_peer_gone_inner("gone")
+            .expect("reconcile ok");
+        assert!(result.changed);
+        assert!(
+            result
+                .outbound
+                .iter()
+                .any(|f| f.peer_id == "viewer-1"
+                    && f.frame_type == frame_types::RUNTIME_STATE_SYNC),
+            "the reconciled state is broadcast to the surviving viewer"
+        );
     }
 
     #[test]

--- a/crates/runtimed/Cargo.toml
+++ b/crates/runtimed/Cargo.toml
@@ -26,6 +26,7 @@ nteract-telemetry = { path = "../nteract-telemetry" }
 nteract-markdown-wasm = { path = "../nteract-markdown-wasm" }
 notebook-protocol = { path = "../notebook-protocol" }
 notebook-wire = { path = "../notebook-wire" }
+notebook-cloud-transport = { path = "../notebook-cloud-transport" }
 nteract-identity = { path = "../nteract-identity" }
 tokio = { workspace = true }
 serde = { workspace = true }

--- a/crates/runtimed/src/runtime_agent.rs
+++ b/crates/runtimed/src/runtime_agent.rs
@@ -1789,6 +1789,7 @@ mod tests {
     use crate::output_prep::queue_command_channels;
     use crate::protocol::CompletionItem;
     use anyhow::Result;
+    use notebook_protocol::connection::TypedNotebookFrame;
     use notebook_protocol::protocol::{BlobDurability, LaunchedEnvConfig};
     use std::path::PathBuf;
     use std::time::Duration;
@@ -1850,6 +1851,112 @@ mod tests {
         assert_eq!(
             reconnect_floor_delay(true, Some(Duration::from_secs(1)), Duration::from_secs(1)),
             None
+        );
+    }
+
+    // -- reconnect_with_backoff against a mock transport ------------------
+    //
+    // 3a made the reconnect *mechanism* generic over `FrameTransport`; 3b
+    // verifies it: a transport whose `connect` fails N times then succeeds must
+    // recover (within the bounded attempts), and one that always fails must give
+    // up so a genuinely-gone room lets the agent exit rather than spin forever.
+
+    /// Empty source: always clean-EOF. Enough to satisfy the `(Source, Sink)`
+    /// return type; these tests exercise `connect`, not frame flow.
+    #[derive(Debug)]
+    struct NullSource;
+    impl FrameSource for NullSource {
+        async fn recv_frame(&mut self) -> Option<std::io::Result<TypedNotebookFrame>> {
+            None
+        }
+    }
+
+    /// Sink that drops every frame.
+    #[derive(Debug)]
+    struct NullSink;
+    impl FrameSink for NullSink {
+        async fn send_frame(&mut self, _: NotebookFrameType, _: &[u8]) -> std::io::Result<()> {
+            Ok(())
+        }
+    }
+
+    /// A `FrameTransport` whose `connect` fails the first `fail_before` calls
+    /// (with a `ConnectionRefused` io error, the shape a dial failure takes),
+    /// then succeeds. Counts total connect attempts.
+    struct FlakyTransport {
+        fail_before: u32,
+        attempts: std::sync::atomic::AtomicU32,
+        recoverable: bool,
+    }
+
+    impl FlakyTransport {
+        fn new(fail_before: u32) -> Self {
+            Self {
+                fail_before,
+                attempts: std::sync::atomic::AtomicU32::new(0),
+                recoverable: true,
+            }
+        }
+        fn attempts(&self) -> u32 {
+            self.attempts.load(std::sync::atomic::Ordering::SeqCst)
+        }
+    }
+
+    impl FrameTransport for FlakyTransport {
+        type Source = NullSource;
+        type Sink = NullSink;
+
+        async fn connect(&self) -> std::io::Result<(Self::Source, Self::Sink)> {
+            let n = self
+                .attempts
+                .fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+            if n < self.fail_before {
+                Err(std::io::Error::new(
+                    std::io::ErrorKind::ConnectionRefused,
+                    "mock dial refused",
+                ))
+            } else {
+                Ok((NullSource, NullSink))
+            }
+        }
+
+        fn clean_eof_is_recoverable(&self) -> bool {
+            self.recoverable
+        }
+    }
+
+    /// Fails fewer times than `MAX_ATTEMPTS` (10), so backoff recovers. Paused
+    /// time so the exponential sleeps don't make the test slow.
+    #[tokio::test(start_paused = true)]
+    async fn reconnect_with_backoff_recovers_after_transient_failures() {
+        let transport = FlakyTransport::new(3);
+        let result = reconnect_with_backoff(&transport).await;
+        assert!(result.is_ok(), "should recover after 3 transient failures");
+        // 3 failed + 1 success.
+        assert_eq!(transport.attempts(), 4);
+    }
+
+    /// Fails on the last possible attempt boundary: 9 failures then success on
+    /// the 10th (== MAX_ATTEMPTS) still recovers.
+    #[tokio::test(start_paused = true)]
+    async fn reconnect_with_backoff_recovers_on_final_attempt() {
+        let transport = FlakyTransport::new(9);
+        assert!(reconnect_with_backoff(&transport).await.is_ok());
+        assert_eq!(transport.attempts(), 10);
+    }
+
+    /// A transport that always fails exhausts MAX_ATTEMPTS (10) and returns the
+    /// last error, so the agent can exit rather than spin forever.
+    #[tokio::test(start_paused = true)]
+    async fn reconnect_with_backoff_gives_up_after_max_attempts() {
+        let transport = FlakyTransport::new(u32::MAX);
+        let err = reconnect_with_backoff(&transport)
+            .await
+            .expect_err("always-failing transport gives up");
+        assert_eq!(transport.attempts(), 10, "exactly MAX_ATTEMPTS tries");
+        assert!(
+            err.to_string().contains("mock dial refused"),
+            "last error is preserved: {err}"
         );
     }
 

--- a/crates/runtimed/src/runtime_agent.rs
+++ b/crates/runtimed/src/runtime_agent.rs
@@ -841,8 +841,44 @@ where
                         NotebookFrameType::RuntimeStateSync,
                         &encoded,
                     ).await {
-                        warn!("[runtime-agent] Failed to send RuntimeStateSync: {}", e);
-                        break;
+                        // A writer send error over a recoverable (cloud) sink is
+                        // a blip, not the daemon going away: tearing down here
+                        // would kill a healthy kernel over a transient WS error
+                        // (lifecycle-analysis req #6). Reconnect and resync — the
+                        // delta that just failed to send is durable in the local
+                        // doc, and the fresh sync state + resync kick re-send it,
+                        // so Automerge's own resync IS the replay. The UDS path
+                        // keeps the historical teardown (break).
+                        if !transport.clean_eof_is_recoverable() {
+                            warn!("[runtime-agent] Closing after RuntimeStateSync send failure: {}", e);
+                            break;
+                        }
+                        warn!(
+                            "[runtime-agent] RuntimeStateSync send failed: {} — reconnecting \
+                             (kernel stays running)",
+                            e
+                        );
+                        drop(frame_source);
+                        match reconnect_after_writer_error(
+                            &transport,
+                            &mut last_recoverable_reconnect,
+                        ).await {
+                            Ok((new_source, new_sink)) => {
+                                frame_source = new_source;
+                                frame_sink = new_sink;
+                                coordinator_sync_state = automerge::sync::State::new();
+                                let _ = state_kick_tx.send(());
+                                info!("[runtime-agent] Reconnected after send failure");
+                                continue;
+                            }
+                            Err(reconnect_err) => {
+                                error!(
+                                    "[runtime-agent] Reconnect failed after retries: {}",
+                                    reconnect_err
+                                );
+                                break;
+                            }
+                        }
                     }
                 }
             }
@@ -851,8 +887,44 @@ where
             Some(envelope) = async_response_rx.recv() => {
                 inflight_sync = None;
                 if let Err(e) = send_runtime_agent_response_envelope(&mut frame_sink, envelope).await {
-                    warn!("[runtime-agent] Failed to send async response: {}", e);
-                    break;
+                    // Same recoverable-transport policy as the RuntimeStateSync
+                    // arm: a cloud writer blip must not tear down a healthy
+                    // kernel (req #6). Unlike a state delta, this response is not
+                    // re-derived by resync, so it is lost across the reconnect —
+                    // acceptable: the SyncEnvironment effect is already in the
+                    // RuntimeStateDoc (env progress/state), which the resync kick
+                    // re-sends; only the one-shot reply envelope is dropped. UDS
+                    // keeps the historical teardown.
+                    if !transport.clean_eof_is_recoverable() {
+                        warn!("[runtime-agent] Closing after async response send failure: {}", e);
+                        break;
+                    }
+                    warn!(
+                        "[runtime-agent] Async response send failed: {} — reconnecting \
+                         (kernel stays running)",
+                        e
+                    );
+                    drop(frame_source);
+                    match reconnect_after_writer_error(
+                        &transport,
+                        &mut last_recoverable_reconnect,
+                    ).await {
+                        Ok((new_source, new_sink)) => {
+                            frame_source = new_source;
+                            frame_sink = new_sink;
+                            coordinator_sync_state = automerge::sync::State::new();
+                            let _ = state_kick_tx.send(());
+                            info!("[runtime-agent] Reconnected after async response send failure");
+                            continue;
+                        }
+                        Err(reconnect_err) => {
+                            error!(
+                                "[runtime-agent] Reconnect failed after retries: {}",
+                                reconnect_err
+                            );
+                            break;
+                        }
+                    }
                 }
             }
         }
@@ -921,6 +993,32 @@ async fn reconnect_with_backoff<T: FrameTransport>(
     Err(last_err
         .map(anyhow::Error::from)
         .unwrap_or_else(|| anyhow::anyhow!("reconnect gave up with no last error")))
+}
+
+/// Reconnect a *recoverable* transport after a writer-side send error,
+/// applying the shared flap floor and recording the reconnect time.
+///
+/// Used by the outbound (writer) `select!` arms. The read arms inline their
+/// own reconnect (they additionally rebuild echo-suppression/comm-forward
+/// state), so this stays a writer-only helper: floor → `reconnect_with_backoff`
+/// → stamp `last_recoverable_reconnect`. Callers must have already checked
+/// `transport.clean_eof_is_recoverable()`, since the UDS path tears down on a
+/// writer error rather than reconnecting (lifecycle-analysis req #6). Returns
+/// the fresh `(Source, Sink)` or the give-up error from `reconnect_with_backoff`.
+async fn reconnect_after_writer_error<T: FrameTransport>(
+    transport: &T,
+    last_recoverable_reconnect: &mut Option<tokio::time::Instant>,
+) -> anyhow::Result<(T::Source, T::Sink)> {
+    if let Some(wait) = reconnect_floor_delay(
+        transport.clean_eof_is_recoverable(),
+        last_recoverable_reconnect.map(|t| t.elapsed()),
+        RECOVERABLE_RECONNECT_FLOOR,
+    ) {
+        tokio::time::sleep(wait).await;
+    }
+    let pair = reconnect_with_backoff(transport).await?;
+    *last_recoverable_reconnect = Some(tokio::time::Instant::now());
+    Ok(pair)
 }
 
 async fn queue_synced_executions<K: KernelConnection>(
@@ -2002,6 +2100,11 @@ mod tests {
         fn attempts(&self) -> u32 {
             self.attempts.load(std::sync::atomic::Ordering::SeqCst)
         }
+        /// Set the clean-EOF/recoverable discriminant (default `true`).
+        fn with_recoverable(mut self, recoverable: bool) -> Self {
+            self.recoverable = recoverable;
+            self
+        }
     }
 
     impl FrameTransport for FlakyTransport {
@@ -2060,6 +2163,52 @@ mod tests {
             err.to_string().contains("mock dial refused"),
             "last error is preserved: {err}"
         );
+    }
+
+    // -- writer-error recovery (Phase 3f req #6) --------------------------
+    //
+    // On a recoverable transport, a writer send error must reconnect + stamp the
+    // flap-floor timestamp (so it shares the read arms' throttle), not tear the
+    // kernel down. The agent loop checks `clean_eof_is_recoverable()` before
+    // calling the helper; these tests cover the recover path and that the stamp
+    // is recorded for the floor.
+
+    #[tokio::test(start_paused = true)]
+    async fn reconnect_after_writer_error_recovers_and_stamps() {
+        let transport = FlakyTransport::new(2); // 2 transient failures, then ok
+        let mut last: Option<tokio::time::Instant> = None;
+        let result = reconnect_after_writer_error(&transport, &mut last).await;
+        assert!(result.is_ok(), "recoverable writer error reconnects");
+        assert_eq!(transport.attempts(), 3, "2 failed + 1 success");
+        assert!(
+            last.is_some(),
+            "a successful writer-error reconnect stamps the flap-floor timestamp"
+        );
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn reconnect_after_writer_error_propagates_give_up() {
+        // Even on a recoverable transport, an always-failing dial gives up after
+        // MAX_ATTEMPTS so the agent can exit rather than spin; the timestamp is
+        // left unstamped since no reconnect succeeded.
+        let transport = FlakyTransport::new(u32::MAX);
+        let mut last: Option<tokio::time::Instant> = None;
+        let err = reconnect_after_writer_error(&transport, &mut last)
+            .await
+            .expect_err("always-failing transport gives up");
+        assert!(err.to_string().contains("mock dial refused"));
+        assert_eq!(transport.attempts(), 10);
+        assert!(last.is_none(), "no stamp when no reconnect succeeded");
+    }
+
+    /// The UDS discriminant (`recoverable == false`) is what the agent loop
+    /// checks *before* calling the helper, so a UDS writer error never reaches
+    /// the reconnect path — it breaks the loop. Pin that the discriminant the
+    /// loop branches on is wired through the mock the way the agent reads it.
+    #[test]
+    fn non_recoverable_transport_reports_clean_eof_not_recoverable() {
+        let transport = FlakyTransport::new(0).with_recoverable(false);
+        assert!(!transport.clean_eof_is_recoverable());
     }
 
     // -- cloud doc-actor label (Phase 3c) ---------------------------------

--- a/crates/runtimed/src/runtime_agent.rs
+++ b/crates/runtimed/src/runtime_agent.rs
@@ -53,13 +53,38 @@ use crate::protocol::QueueEntry;
 mod echo_suppression;
 use echo_suppression::EchoSuppressor;
 
-/// Minimum interval between clean-EOF reconnect cycles on a recoverable
-/// transport. `reconnect_with_backoff` only delays between *failed* connects;
-/// this floor stops a sink that accepts a connection and then immediately
-/// closes cleanly (a flapping/evicting cloud room) from spinning a reconnect
-/// storm at network-RTT rate. Unused by the UDS transport (which tears down on
-/// clean EOF rather than reconnecting).
-const CLEAN_EOF_RECONNECT_FLOOR: std::time::Duration = std::time::Duration::from_secs(1);
+/// Minimum interval between reconnect cycles on a recoverable transport,
+/// covering *both* recoverable-failure arms: a clean EOF and a stream framing
+/// error. `reconnect_with_backoff` only delays between *failed* connects, so a
+/// room that accepts the connection and then immediately ends the stream every
+/// cycle — by closing cleanly (clean-EOF arm) or by erroring the stream
+/// (framing-error arm) — would otherwise spin a reconnect storm at network-RTT
+/// rate, a self-inflicted DoS on the room. The floor throttles the combined
+/// reconnect rate regardless of which failure mode recurs. Unused by the UDS
+/// transport (which tears down on clean EOF, and whose framing-error reconnect
+/// is gated out of the floor by `clean_eof_is_recoverable() == false`).
+const RECOVERABLE_RECONNECT_FLOOR: std::time::Duration = std::time::Duration::from_secs(1);
+
+/// How long to sleep before a reconnect to enforce [`RECOVERABLE_RECONNECT_FLOOR`].
+///
+/// Pure so the flap-floor policy is unit-testable away from the agent's
+/// `select!` loop. Returns `None` (reconnect immediately) when the transport is
+/// not recoverable — keeping the UDS path's framing-error reconnect byte-for-byte
+/// unchanged — or when enough time has already elapsed since the last
+/// recoverable reconnect. Otherwise returns the remaining time to wait out.
+fn reconnect_floor_delay(
+    recoverable: bool,
+    since_last_reconnect: Option<std::time::Duration>,
+    floor: std::time::Duration,
+) -> Option<std::time::Duration> {
+    if !recoverable {
+        return None;
+    }
+    match since_last_reconnect {
+        Some(since) if since < floor => Some(floor - since),
+        _ => None,
+    }
+}
 
 /// Shared context for the runtime agent (no kernel -- kernel is owned locally).
 struct RuntimeAgentContext {
@@ -136,11 +161,13 @@ pub async fn run_runtime_agent(
     let mut kernel_state = KernelState::new(state.clone());
     let mut seen_execution_ids = HashSet::new();
     let mut echo_suppressor = EchoSuppressor::default();
-    // Timestamp of the last clean-EOF reconnect, used to enforce a floor
-    // between reconnect cycles on a recoverable (cloud) transport so a flapping
-    // sink can't drive a reconnect storm. Only set/read on that path; `None` on
-    // the UDS transport, which never reconnects on clean EOF.
-    let mut last_clean_reconnect: Option<tokio::time::Instant> = None;
+    // Timestamp of the last recoverable reconnect (clean EOF *or* framing
+    // error), used to enforce a floor between reconnect cycles on a recoverable
+    // (cloud) transport so a flapping sink can't drive a reconnect storm. Set
+    // after every recoverable reconnect arm; stays `None` on the UDS transport,
+    // whose framing-error reconnect is gated out of the floor and which never
+    // reconnects on clean EOF.
+    let mut last_recoverable_reconnect: Option<tokio::time::Instant> = None;
     let mut lifecycle_rx: Option<mpsc::UnboundedReceiver<LifecycleSignal>> = None;
     let mut work_rx: Option<mpsc::Receiver<WorkCommand>> = None;
 
@@ -543,6 +570,20 @@ pub async fn run_runtime_agent(
                              (kernel stays running)",
                             e
                         );
+                        // Flap floor. `reconnect_with_backoff` only sleeps
+                        // between *failed* connects, so a cloud room that
+                        // accepts the connection and then immediately errors the
+                        // stream every cycle would spin a reconnect storm at
+                        // network-RTT rate. Gated on the recoverable transport so
+                        // the UDS framing-error reconnect is byte-for-byte
+                        // unchanged. (lifecycle-analysis: cloud DoS-avoidance)
+                        if let Some(wait) = reconnect_floor_delay(
+                            transport.clean_eof_is_recoverable(),
+                            last_recoverable_reconnect.map(|t| t.elapsed()),
+                            RECOVERABLE_RECONNECT_FLOOR,
+                        ) {
+                            tokio::time::sleep(wait).await;
+                        }
                         // Drop the old source before reconnecting so its
                         // background reader task exits cleanly.
                         drop(frame_source);
@@ -558,6 +599,11 @@ pub async fn run_runtime_agent(
                                 // everything the kernel produced while we
                                 // were disconnected.
                                 let _ = state_kick_tx.send(());
+                                // Track for the flap floor (recoverable only;
+                                // the UDS path leaves this `None`).
+                                if transport.clean_eof_is_recoverable() {
+                                    last_recoverable_reconnect = Some(tokio::time::Instant::now());
+                                }
                                 info!("[runtime-agent] Reconnected to daemon");
                                 continue;
                             }
@@ -588,13 +634,15 @@ pub async fn run_runtime_agent(
                         // accepts the connection and then immediately closes
                         // cleanly every time (a flapping/evicting cloud room)
                         // would otherwise spin a reconnect storm at network-RTT
-                        // rate. If the previous clean reconnect was very recent,
-                        // wait out the floor before redialing.
-                        if let Some(last) = last_clean_reconnect {
-                            let since = last.elapsed();
-                            if since < CLEAN_EOF_RECONNECT_FLOOR {
-                                tokio::time::sleep(CLEAN_EOF_RECONNECT_FLOOR - since).await;
-                            }
+                        // rate. Shared with the framing-error arm via
+                        // `reconnect_floor_delay` so the combined reconnect rate
+                        // is throttled regardless of which failure mode recurs.
+                        if let Some(wait) = reconnect_floor_delay(
+                            transport.clean_eof_is_recoverable(),
+                            last_recoverable_reconnect.map(|t| t.elapsed()),
+                            RECOVERABLE_RECONNECT_FLOOR,
+                        ) {
+                            tokio::time::sleep(wait).await;
                         }
                         warn!(
                             "[runtime-agent] Sync sink closed cleanly — reconnecting \
@@ -607,7 +655,7 @@ pub async fn run_runtime_agent(
                                 frame_sink = new_sink;
                                 coordinator_sync_state = automerge::sync::State::new();
                                 let _ = state_kick_tx.send(());
-                                last_clean_reconnect = Some(tokio::time::Instant::now());
+                                last_recoverable_reconnect = Some(tokio::time::Instant::now());
                                 info!("[runtime-agent] Reconnected after clean close");
                                 continue;
                             }
@@ -1743,6 +1791,67 @@ mod tests {
     use anyhow::Result;
     use notebook_protocol::protocol::{BlobDurability, LaunchedEnvConfig};
     use std::path::PathBuf;
+    use std::time::Duration;
+
+    // -- reconnect flap-floor policy --------------------------------------
+    //
+    // `reconnect_floor_delay` is the shared throttle for both recoverable
+    // reconnect arms (clean EOF and framing error). The UDS path must never be
+    // delayed; the cloud path must be throttled when reconnects recur inside the
+    // floor.
+
+    #[test]
+    fn floor_never_delays_a_non_recoverable_transport() {
+        // The UDS path (clean_eof_is_recoverable == false): even a reconnect one
+        // nanosecond ago must not delay, so its framing-error reconnect is
+        // byte-for-byte unchanged.
+        assert_eq!(
+            reconnect_floor_delay(false, Some(Duration::from_nanos(1)), Duration::from_secs(1)),
+            None
+        );
+        assert_eq!(
+            reconnect_floor_delay(false, None, Duration::from_secs(1)),
+            None
+        );
+    }
+
+    #[test]
+    fn floor_does_not_delay_first_recoverable_reconnect() {
+        // No prior reconnect recorded -> no wait (the first failure reconnects
+        // immediately; the floor only throttles *recurring* flaps).
+        assert_eq!(
+            reconnect_floor_delay(true, None, Duration::from_secs(1)),
+            None
+        );
+    }
+
+    #[test]
+    fn floor_delays_a_recurring_recoverable_flap() {
+        // A recoverable reconnect 200ms ago, 1s floor -> wait out the remaining
+        // 800ms before redialing.
+        assert_eq!(
+            reconnect_floor_delay(
+                true,
+                Some(Duration::from_millis(200)),
+                Duration::from_secs(1),
+            ),
+            Some(Duration::from_millis(800))
+        );
+    }
+
+    #[test]
+    fn floor_does_not_delay_once_floor_has_elapsed() {
+        // Last reconnect comfortably older than the floor -> reconnect now.
+        assert_eq!(
+            reconnect_floor_delay(true, Some(Duration::from_secs(5)), Duration::from_secs(1)),
+            None
+        );
+        // Exactly at the floor is also "elapsed" (not strictly less than).
+        assert_eq!(
+            reconnect_floor_delay(true, Some(Duration::from_secs(1)), Duration::from_secs(1)),
+            None
+        );
+    }
 
     /// Minimal mock kernel for testing queue/state logic without ZeroMQ.
     struct MockKernel;

--- a/crates/runtimed/src/runtime_agent.rs
+++ b/crates/runtimed/src/runtime_agent.rs
@@ -109,17 +109,111 @@ pub async fn run_runtime_agent(
         socket_path.display()
     );
 
-    // -- 1. Connect to daemon socket ----------------------------------------
-
-    // The sync wire is abstracted behind `FrameTransport`: the daemon uses the
-    // UDS (Windows named-pipe) transport, while a hosted runtime peer will swap
-    // in a cloud-WebSocket transport without touching the loop below. `connect`
-    // owns the transport-specific dial + handshake.
+    // The daemon socket transport. The sync wire is abstracted behind
+    // `FrameTransport`; the cloud-WebSocket path swaps in a different transport
+    // (`run_cloud_runtime_agent`) without touching the agent loop below.
     let transport =
         UdsFrameTransport::new(&socket_path, &notebook_id, &runtime_agent_id, &blob_root);
+
+    // The UDS actor label is the daemon-supplied `runtime_agent_id`, resolved
+    // up front and independent of the (just-connected) transport. This keeps
+    // the desktop/daemon path byte-for-byte unchanged: the resolver returns the
+    // exact value the bootstrap used inline before the cloud-path extraction.
+    run_runtime_agent_on_transport(transport, notebook_id, blob_root, move |_| {
+        Ok(runtime_agent_id)
+    })
+    .await
+}
+
+/// Run the runtime agent against a hosted cloud room over a WebSocket transport.
+///
+/// The daemon-managed kernel is unchanged; only the sync wire differs from
+/// [`run_runtime_agent`]. The cloud room only reveals its authenticated
+/// principal in the `cloud_room_ready` handshake, so the doc-actor label is
+/// resolved *after* connect, as `<principal>/<operator>:<nonce>`:
+///
+/// - **principal** — `transport.principal()`, the authenticated identity the
+///   room's `validate_room_notebook_change_actors` requires every change to be
+///   authored under (decision #6); authoring under anything else is silently
+///   dropped by the room.
+/// - **operator** — a human-readable role suffix (e.g. `agent:runt`) so the
+///   room can tell which of a principal's agents authored a change.
+/// - **nonce** — a per-process random suffix. Reusing one actor label across
+///   separate doc instances collides at `(actor, seq 1)` → Automerge
+///   `DuplicateSeqNumber` when the room syncs the prior change back, exactly the
+///   hazard the `runt-cloud-peer` spike documented.
+///
+/// CODE-ONLY (Phase 3c): this builds and unit-tests the spawn path behind the
+/// transport gate; the live cross-machine re-proof (a preview room + the
+/// explicit `runtime_peer` ACL row, decision #9) is deferred — see the decision
+/// log's NEEDS-US note.
+pub async fn run_cloud_runtime_agent(
+    config: notebook_cloud_transport::CloudWsConfig,
+    operator: String,
+    blob_root: PathBuf,
+) -> anyhow::Result<()> {
+    let notebook_id = config.notebook_id.clone();
+    info!(
+        "[runtime-agent] Starting cloud runtime_agent notebook_id={} url={} scope={}",
+        notebook_id,
+        notebook_cloud_transport::build_ws_url(&config.cloud_url, &notebook_id),
+        config.scope,
+    );
+
+    let transport = notebook_cloud_transport::CloudWsFrameTransport::new(config);
+
+    run_runtime_agent_on_transport(transport, notebook_id, blob_root, move |t| {
+        let principal = t.principal().ok_or_else(|| {
+            anyhow::anyhow!("cloud transport has no principal after connect (no cloud_room_ready)")
+        })?;
+        Ok(cloud_actor_label(principal, &operator))
+    })
+    .await
+}
+
+/// Build the cloud doc-actor label `<principal>/<operator>:<nonce>`.
+///
+/// Split out so the label scheme is unit-testable without a live room. The
+/// nonce makes the label unique per process (see [`run_cloud_runtime_agent`]
+/// for why reuse is unsafe).
+fn cloud_actor_label(principal: &str, operator: &str) -> String {
+    let nonce = uuid::Uuid::new_v4().simple().to_string();
+    format!("{principal}/{operator}:{}", &nonce[..8])
+}
+
+/// Run the runtime agent over an arbitrary [`FrameTransport`].
+///
+/// The desktop/daemon path ([`run_runtime_agent`]) and the cloud path
+/// ([`run_cloud_runtime_agent`]) both funnel here; only the transport and the
+/// doc-actor label differ. Everything below — the kernel drive, the queue, the
+/// RuntimeStateDoc writes, the lifecycle handling, and the reconnect/resync
+/// dance — is identical across transports by construction.
+///
+/// `resolve_actor` produces the Automerge actor label the agent authors its
+/// RuntimeStateDoc under, given the *connected* transport. It runs after
+/// `connect()` because a cloud transport only learns its room principal from
+/// the `cloud_room_ready` handshake; the UDS path ignores the transport and
+/// returns the daemon-supplied id. The actor label matters for the cloud room:
+/// its `validate_room_notebook_change_actors` drops any change whose principal
+/// differs from the authenticated one, so a cloud agent must author under
+/// `<principal>/<operator>` (decision #6). Authoring under the wrong actor is
+/// silent — the room discards every change and convergence stalls.
+async fn run_runtime_agent_on_transport<T, F>(
+    transport: T,
+    notebook_id: String,
+    blob_root: PathBuf,
+    resolve_actor: F,
+) -> anyhow::Result<()>
+where
+    T: FrameTransport,
+    F: FnOnce(&T) -> anyhow::Result<String>,
+{
+    // -- 1. Connect ---------------------------------------------------------
+
+    // `connect` owns the transport-specific dial + handshake/auth.
     let (mut frame_source, mut frame_sink) = transport.connect().await?;
 
-    info!("[runtime-agent] Connected to daemon, handshake sent");
+    info!("[runtime-agent] Connected, handshake sent");
 
     // The transport hands back a cancel-safe `FrameSource` (backed by a
     // dedicated `FramedReader` actor) so the busy `select!` below stays
@@ -128,6 +222,14 @@ pub async fn run_runtime_agent(
     // captured in production logs as `frame too large: 538976288 bytes`.
 
     // -- 2. Bootstrap RuntimeStateDoc ---------------------------------------
+
+    // Resolve the doc-actor label now that the transport is connected (a cloud
+    // transport's principal is known only post-handshake).
+    let runtime_agent_id = resolve_actor(&transport)?;
+    info!(
+        "[runtime-agent] Bootstrapping notebook_id={} as actor {}",
+        notebook_id, runtime_agent_id
+    );
 
     let state_doc = RuntimeStateDoc::try_new_with_actor(&runtime_agent_id)
         .map_err(|e| anyhow::anyhow!("create runtime-agent state doc: {e}"))?;
@@ -1958,6 +2060,72 @@ mod tests {
             err.to_string().contains("mock dial refused"),
             "last error is preserved: {err}"
         );
+    }
+
+    // -- cloud doc-actor label (Phase 3c) ---------------------------------
+
+    #[test]
+    fn cloud_actor_label_has_principal_operator_and_nonce() {
+        let label = cloud_actor_label("anaconda:alice", "agent:runt");
+        // <principal>/<operator>:<8-hex-nonce>
+        let (prefix, nonce) = label.rsplit_once(':').expect("has nonce suffix");
+        assert_eq!(prefix, "anaconda:alice/agent:runt");
+        assert_eq!(nonce.len(), 8, "8-char nonce: {label}");
+        assert!(nonce.chars().all(|c| c.is_ascii_hexdigit()));
+        // The principal (which itself contains a colon) is preserved ahead of
+        // the operator, so the room's principal check sees the right identity.
+        assert!(label.starts_with("anaconda:alice/"));
+    }
+
+    #[test]
+    fn cloud_actor_label_is_unique_per_call() {
+        // Reusing a label across doc instances collides at (actor, seq 1) ->
+        // Automerge DuplicateSeqNumber; the nonce must differ per call.
+        let a = cloud_actor_label("p", "op");
+        let b = cloud_actor_label("p", "op");
+        assert_ne!(a, b);
+    }
+
+    /// The cloud actor resolver (the closure `run_cloud_runtime_agent` passes
+    /// into `run_runtime_agent_on_transport`) must error rather than silently
+    /// author under a wrong actor when the transport never observed a
+    /// `cloud_room_ready` principal. Exercise that resolver shape directly
+    /// against a fresh (unconnected) cloud transport.
+    #[test]
+    fn cloud_actor_resolver_errors_without_principal() {
+        use notebook_cloud_transport::{CloudAuth, CloudWsConfig, CloudWsFrameTransport};
+        let transport = CloudWsFrameTransport::new(CloudWsConfig {
+            cloud_url: "https://preview.runt.run".into(),
+            notebook_id: "abc".into(),
+            scope: "runtime_peer".into(),
+            auth: CloudAuth::OidcBearer { token: "t".into() },
+        });
+        let operator = "agent:runt".to_string();
+        // Mirror the resolver body in run_cloud_runtime_agent.
+        let resolved: anyhow::Result<String> = (|t: &CloudWsFrameTransport| {
+            let principal = t
+                .principal()
+                .ok_or_else(|| anyhow::anyhow!("cloud transport has no principal after connect"))?;
+            Ok(cloud_actor_label(principal, &operator))
+        })(&transport);
+        assert!(
+            resolved.is_err(),
+            "no principal before connect -> resolver errors, not a bogus actor"
+        );
+    }
+
+    /// The UDS resolver is a pure pass-through of the daemon-supplied id,
+    /// independent of the transport — the property that keeps the desktop path
+    /// byte-for-byte unchanged after the cloud-path extraction.
+    #[test]
+    fn uds_actor_resolver_returns_daemon_id_verbatim() {
+        let id = "runtime-agent:nb-42".to_string();
+        let resolver = {
+            let id = id.clone();
+            move |_t: &FlakyTransport| -> anyhow::Result<String> { Ok(id) }
+        };
+        let resolved = resolver(&FlakyTransport::new(0)).unwrap();
+        assert_eq!(resolved, id);
     }
 
     /// Minimal mock kernel for testing queue/state logic without ZeroMQ.

--- a/docs/handoffs/16-decisions-log.md
+++ b/docs/handoffs/16-decisions-log.md
@@ -279,23 +279,80 @@ OIDC token actually expires and the refresher mints a new one. Fold this into
 the 3c cross-machine re-proof (same creds/deploy). Nothing in 3b changes the
 static-token path, so this is a forward-looking validation, not a regression risk.
 
-## Phase 3 remaining plan (3c+)
+## Phase 3c (CODE ONLY): daemon spawn path + doc-actor identity
 
-Ordered by the lifecycle analysis. 3a (req #1) and 3b (req #2) are done. Remaining, in dependency order:
+29. **Premise (b) of the original 3c plan — "swap the daemon's stripping receive
+    for `receive_sync_message_with_changes`" — was a misreading; the agent is
+    ALREADY consumer-side, and the swap would be a regression. Dropped.** The
+    plan assumed the agent's receive path
+    (`runtime_agent.rs` RuntimeStateSync arm → `receive_sync_and_foreign_comms_recovering`)
+    *strips* incoming changes the way the server-toward-viewer
+    `RuntimeStateDoc::receive_sync_message` (doc.rs:2980) does. It does not. Reading
+    `receive_sync_and_foreign_comms` (doc.rs:3127-3219): it calls **raw**
+    `self.doc.sync().receive_sync_message` (doc.rs:3140), which *applies* every
+    incoming change to the main doc, and then additionally computes a
+    *foreign-comms* fork purely for kernel-echo suppression (the doc comment at
+    3120-3122 states it outright: "The main doc still absorbs every applied change
+    (including kernel echoes)"). So the agent already has the consumer semantics a
+    cloud peer needs. Swapping it for plain `receive_sync_message_with_changes`
+    would *lose* the per-change `rt:kernel:` echo filter and re-introduce the
+    widget-amplification loop that method was written to break — a regression, not
+    a fix. Verified by code-read + the existing echo-suppression tests. Net: 3c's
+    real surface is only premise (a), the doc-actor identity.
 
-- **3c: daemon spawn path + doc-actor identity + consumer-side receive (the integration).**
-  Add a `run_runtime_agent`-equivalent (or a parameter) that builds a `CloudWsFrameTransport`
-  instead of `UdsFrameTransport`. Two agent-loop changes gated on this path: (a) author the
-  RuntimeStateDoc (and NotebookDoc if synced) under the `cloud_room_ready` principal
-  (`transport.principal()`), as `<principal>/<operator>`, not the daemon's `runtime_agent_id`,
-  else the room's `validate_room_notebook_change_actors` drops every change (decision #6).
-  (b) Apply incoming RuntimeStateSync with `receive_sync_message_with_changes` (consumer
-  semantics) rather than the daemon's `receive_sync_and_foreign_comms_recovering` (which strips
-  incoming changes). Gate (a)/(b) on a transport-kind discriminant so the UDS path is untouched.
-  This is where the live cross-machine re-proof runs: spawn the daemon's real `runtime_agent`
-  against a preview room as `runtime_peer` (needs the explicit `runtime_peer` ACL row,
-  decision #9) and confirm a cloud-submitted cell runs on the daemon-managed kernel and renders
-  in the viewer, through the *real* agent, not the spike.
+30. **The spawn path is a generic inner `run_runtime_agent_on_transport<T, F>`
+    that both entry points funnel through; the transport-kind discriminant is a
+    `resolve_actor: FnOnce(&T) -> Result<String>` closure, not a runtime enum or a
+    trait method.** `run_runtime_agent` (UDS) passes `move |_| Ok(runtime_agent_id)`
+    — the resolver ignores the transport and returns the daemon-supplied id, the
+    exact value the bootstrap used inline before, so the desktop/daemon path is
+    byte-for-byte unchanged (verified: full runtimed suite green, 884→888 only by
+    added tests). `run_cloud_runtime_agent` builds a `CloudWsFrameTransport` and
+    passes a resolver that reads `transport.principal()` *after* connect. Why a
+    closure, not an enum discriminant in the loop: the only thing that actually
+    differs by transport is the actor label, and it's needed exactly once at
+    bootstrap; a closure localises that one difference without threading a
+    `TransportKind` through the 1400-line loop or widening `FrameTransport`.
+    Alternative considered: resolve the actor *before* connect — impossible for
+    cloud, the principal is only known from `cloud_room_ready`, which is why the
+    resolver runs post-`connect()`.
+
+31. **Cloud doc-actor label is `<principal>/<operator>:<nonce>` via
+    `cloud_actor_label`.** Principal from `transport.principal()` (the room's
+    authenticated identity; `validate_room_notebook_change_actors` drops changes
+    authored under anything else — decision #6). Operator is a caller-supplied
+    role suffix (e.g. `agent:runt`). The nonce is a per-process random suffix
+    because reusing one actor label across separate doc instances collides at
+    `(actor, seq 1)` → Automerge `DuplicateSeqNumber` when the room syncs the prior
+    change back (the exact hazard the `runt-cloud-peer` spike documented). The
+    resolver *errors* if the principal is absent rather than authoring under a bogus
+    actor, since a wrong actor fails silently (the room discards every change).
+    Unit-tested: label format/uniqueness, the no-principal error path, and the UDS
+    pass-through property.
+
+Phase 3c verification: `cargo test -p runtimed` 888 lib (was 884) + integration
+suites green (UDS byte-for-byte unchanged); `cargo test -p xtask` 28 (bump-targets
+guard green — `notebook-cloud-transport` was already registered, now also a
+`runtimed` dep); `cargo xtask lint --fix` clean; clippy `-D warnings` clean.
+
+**NEEDS US (3c):** the live cross-machine re-proof. `run_cloud_runtime_agent` is
+built and unit-tested behind the transport gate, but nothing yet *calls* it from a
+CLI/daemon command, and it has never run against a real room. To close req #2/#3
+end-to-end an interactive session with creds must: (1) deploy a preview room (or
+use an existing one) and grant the agent's principal the explicit `runtime_peer`
+ACL row (decision #9); (2) wire a CLI subcommand (e.g. `runtimed cloud-runtime-agent
+--cloud-url --notebook-id --operator`, plus a `CloudAuth` source) — trivial, but
+left out here since it can't be verified headlessly; (3) spawn it as `runtime_peer`
+and confirm a cloud-submitted cell runs on the daemon-managed kernel and renders in
+the viewer, through the *real* agent (not the `runt-cloud-peer` spike); (4) exercise
+the 3b token-refresher against an actually-expiring token. None of this is possible
+without preview deploy + staging creds, which this autonomous session does not have.
+The code path is additive and gated, so it cannot affect the desktop/daemon path.
+
+## Phase 3 remaining plan (3d+)
+
+Ordered by the lifecycle analysis. 3a (req #1), 3b (req #2), and 3c CODE (doc-actor
+identity; live re-proof is NEEDS-US) are done. Remaining, in dependency order:
 
 - **3d: cloud-room DurableObject watchdog (reqs #3, #7; the safety net the daemon can't
   provide).** TypeScript in `apps/notebook-cloud/`. Thread peer **scope** through

--- a/docs/handoffs/16-decisions-log.md
+++ b/docs/handoffs/16-decisions-log.md
@@ -229,18 +229,59 @@ Phase 3b warm-up verification: `cargo test -p notebook-cloud-transport` 16;
 `cargo xtask lint --fix` clean; clippy `-D warnings` clean on both crates. No new
 workspace crate (no bump-targets change).
 
-## Phase 3 remaining plan (3b+)
+## Phase 3b: WS reconnect/re-auth + full-resync on cloud reconnect (req #2)
 
-Ordered by the lifecycle analysis. 3a (req #1) is done. Remaining, in dependency order:
+26. **The reconnect *mechanism* was already complete after 3a; 3b adds the
+    re-auth seam and the missing test coverage.** `reconnect_with_backoff` is
+    generic over `FrameTransport` and the cloud `connect()` re-dials + re-reads
+    `cloud_room_ready`; both reconnect arms (clean-EOF and framing-error) already
+    reset `coordinator_sync_state` and fire `state_kick_tx` (verified by
+    inspection at `runtime_agent.rs` — the kick drives a full RuntimeStateDoc
+    re-send on *every* recoverable reconnect, cloud included, because the kick is
+    transport-agnostic). So 3b is two concrete deliverables, not a rewrite:
+    a fresh-token seam and unit tests for the backoff loop.
 
-- **3b: WS reconnect/re-auth + full-resync on cloud reconnect (req #2).**
-  `reconnect_with_backoff` is already generic over `FrameTransport`, and the cloud `connect()`
-  re-dials, re-auths, and re-reads `cloud_room_ready`, so the *mechanism* exists. What's
-  missing is verifying the resync kick (`state_kick_tx`) drives a full RuntimeStateDoc re-send
-  after a cloud reconnect, and that re-auth uses a *fresh* token if the original expired (the
-  `CloudAuth` is currently a static token; a token-provider closure may be needed for
-  long-lived sessions). Unit-test the reconnect arm with a mock `FrameTransport` whose
-  `connect` fails N times then succeeds.
+27. **Re-auth uses an optional `TokenRefresher` closure, not a widened
+    `CloudAuth`.** `CloudAuth` holds a *static* token, fine for a short session
+    but wrong for a long-lived peer: its OIDC token expires mid-session, and a
+    reconnect that re-presents the expired token is rejected at the upgrade, so
+    `reconnect_with_backoff` would burn all 10 attempts and give up. Fix:
+    `CloudWsFrameTransport::with_token_refresher(config, refresher)` takes an
+    `async` closure (`TokenRefresher = Arc<dyn Fn() -> Future<io::Result<String>>>`)
+    that the transport calls *before each connect* via `effective_auth()`; the
+    returned token is re-wrapped in the configured auth variant by
+    `CloudAuth::with_token` (preserving the variant and any `Dev` user label).
+    `None` (the default `new()`) keeps the static-token behavior byte-for-byte.
+    Alternative considered: store an `Arc<Mutex<String>>` the agent mutates —
+    rejected; a pull-on-connect closure has no lock-ordering hazard and keeps the
+    refresh policy (cache, retry, endpoint) entirely on the agent side. The
+    closure's error surfaces as a connect error (kind preserved) so the backoff
+    loop treats it as a retryable failed connect. Wiring this into a daemon spawn
+    path is 3c; this PR ships the seam + tests only.
+
+28. **`reconnect_with_backoff` is unit-tested with a mock `FlakyTransport`.** A
+    `FrameTransport` whose `connect` fails the first N calls (with
+    `ConnectionRefused`) then succeeds, counting attempts. Three tests under
+    `start_paused` time (so the exponential sleeps are instant): recovers after 3
+    transient failures (4 total attempts), recovers on the final allowed attempt
+    (9 fail → success on the 10th), and gives up after exactly `MAX_ATTEMPTS`
+    (10) with the last error preserved so a genuinely-gone room lets the agent
+    exit rather than spin forever.
+
+Phase 3b verification: `cargo test -p notebook-cloud-transport` 20 (was 16);
+`cargo test -p runtimed` 884 lib (was 881) + integration suites green (UDS
+unchanged); `cargo xtask lint --fix` clean; clippy `-D warnings` clean on both.
+No new workspace crate.
+
+**NEEDS US (3b):** the token-refresher seam is unit-tested but has no live
+re-auth proof — that needs a long-lived session against a preview room where an
+OIDC token actually expires and the refresher mints a new one. Fold this into
+the 3c cross-machine re-proof (same creds/deploy). Nothing in 3b changes the
+static-token path, so this is a forward-looking validation, not a regression risk.
+
+## Phase 3 remaining plan (3c+)
+
+Ordered by the lifecycle analysis. 3a (req #1) and 3b (req #2) are done. Remaining, in dependency order:
 
 - **3c: daemon spawn path + doc-actor identity + consumer-side receive (the integration).**
   Add a `run_runtime_agent`-equivalent (or a parameter) that builds a `CloudWsFrameTransport`

--- a/docs/handoffs/16-decisions-log.md
+++ b/docs/handoffs/16-decisions-log.md
@@ -349,10 +349,66 @@ the 3b token-refresher against an actually-expiring token. None of this is possi
 without preview deploy + staging creds, which this autonomous session does not have.
 The code path is additive and gated, so it cannot affect the desktop/daemon path.
 
-## Phase 3 remaining plan (3d+)
+## Phase 3e: liveness model (`last_seen`) — the headless half of req #4
 
-Ordered by the lifecycle analysis. 3a (req #1), 3b (req #2), and 3c CODE (doc-actor
-identity; live re-proof is NEEDS-US) are done. Remaining, in dependency order:
+32. **3e is reordered ahead of 3d, and split: the headless model half
+    (`last_seen`) lands now; the `Disconnected` variant + the policy relaxation
+    defer to land *with* 3d under live verification.** The original plan put 3d
+    (watchdog) before 3e and called 3e the thing that "gates 3d being legal." Two
+    findings reshaped that:
+    - **The watchdog's own write path does NOT go through the
+      `validate_runtime_state_sync_scope` policy, so the policy relaxation is not
+      actually on 3d's critical path.** `validate_runtime_state_sync_scope`
+      (policy.rs:115) and its `validate_comm_state_only_runtime_delta` deadlock
+      (policy.rs:403-405) gate only *incoming peer sync frames* — they run in
+      `RoomHostHandle::receive_runtime_state_sync` (`runtimed-wasm/src/lib.rs:715`)
+      before applying a peer's sync message. A DO-internal `alarm()` watchdog that
+      authors *directly* on the room host's `state_doc` (the recommended 3d design,
+      and the only place the net can live since the daemon's death is the trigger)
+      bypasses that check entirely. The relaxation matters only for an alternative
+      "Owner peer pushes the reconciliation" design — which 3d should avoid for
+      exactly this reason. So 3e's policy half is deferred, not blocking.
+    - **A new `RuntimeLifecycle::Disconnected` variant has a ~28-Rust-file + TS
+      blast radius and its payoff is viewer-facing UX**, verifiable only against a
+      deployed viewer (NEEDS US). Landing it unattended-and-unverified is higher
+      risk than the watchdog needs. The lifecycle analysis explicitly sanctions a
+      `last_seen` timestamp as the *alternative* form of req #4(b); that is the
+      low-risk, fully-headless piece the watchdog actually reads.
+
+33. **`last_seen: Option<String>` on `KernelState` (doc.rs), with a `set_last_seen`
+    setter and `read_state` wiring.** ISO-8601 timestamp the runtime peer was last
+    observed present, for the watchdog's staleness decision and for viewers to tell
+    "peer reporting" from "peer silent since T". Design points:
+    - **Not added to the frozen genesis scaffold** (`RUNTIME_STATE_GENESIS_V2_BYTES`),
+      so a fresh doc reads `None` and the `runtime_state_genesis_artifact_matches_scaffold`
+      test stays green — no genesis re-bake, no schema-version bump. Purely additive
+      on the serde model (`#[serde(default)]`), so `..Default::default()` call sites
+      in `runtimed-node`/`runtimed-py` are unaffected.
+    - **Clears to CRDT `Null` → reads back `None`** (like `last_saved`), *not* the
+      empty-string "scaffolded but unset" convention of `error_reason`/`error_details`,
+      because a liveness field has no meaningful "" state.
+    - **Idempotent**: re-stamping the current value is a no-op (no head churn), since
+      a watchdog/peer stamps it frequently and must not trigger spurious sync rounds.
+    - **No policy change needed yet**: `last_seen` lives under `state.kernel`, so the
+      existing kernel-ownership rules already make it `runtime_peer`-writable and
+      editor-blocked — pinned by a `last_seen_is_runtime_peer_writable_but_blocked_for_editor`
+      test. The runtime peer stamps its own liveness; the room-host watchdog writes
+      directly (bypassing the sync policy per #32).
+    5 unit tests; runtime-doc 215 (was 211) + genesis tests green; dependent crates
+    (`runtimed` 888, `notebook-sync`, `runtimed-py`, `runtimed-node`) green; clippy clean.
+
+**NEEDS US (3e deferred halves):** (1) the `RuntimeLifecycle::Disconnected` variant —
+defer to land with 3d so its viewer UX is validated against a live deployed viewer in
+the same pass (the watchdog can already express "stale" via `last_seen` + flipping to
+the existing `Error`/`Shutdown` terminal states in the meantime); (2) the
+`policy.rs:403-405` relaxation — only needed if 3d is ever built as an Owner-peer-push
+rather than a DO-internal watchdog; the recommended DO-internal design needs no policy
+change. Decide (2) when 3d's mechanism is chosen.
+
+## Phase 3 remaining plan (3d, 3f)
+
+Ordered by the lifecycle analysis. 3a (req #1), 3b (req #2), 3c CODE (doc-actor
+identity), and 3e model half (`last_seen`) are done. Remaining, in dependency order:
 
 - **3d: cloud-room DurableObject watchdog (reqs #3, #7; the safety net the daemon can't
   provide).** TypeScript in `apps/notebook-cloud/`. Thread peer **scope** through
@@ -361,12 +417,13 @@ identity; live re-proof is NEEDS-US) are done. Remaining, in dependency order:
   reconciliation mutator (it has none), and use a DO `alarm()` with a grace period to
   terminalize running/queued executions and flip lifecycle when a `runtime_peer` departs.
 
-- **3e: policy relaxation (req #4; gates 3d being legal).** `crates/runtime-doc/src/policy.rs:403-405`
-  blocks editor/owner from writing `state.kernel` ("daemon-owned"). The watchdog (room host)
-  needs a *narrow* authority to terminalize lifecycle on `runtime_peer` departure. Recommended:
-  both (a) a scoped relaxation for the lifecycle-to-terminal transition, and (b) a model-level
-  `Disconnected` `RuntimeLifecycle` / `last_seen` on `KernelState`
-  (`crates/runtime-doc/src/types.rs:272`) so viewers distinguish gone-but-recoverable from dead.
+  3d note: prefer the DO-internal `alarm()` watchdog authoring directly on the room
+  host's `state_doc`. That write path does **not** go through `validate_runtime_state_sync_scope`
+  (which gates only incoming peer sync, `runtimed-wasm/src/lib.rs:715`), so it needs no
+  policy relaxation (decision #32). The `last_seen` model field it reads is already done
+  (decision #33). The remaining 3e halves (the `Disconnected` variant, and the
+  policy.rs:403-405 relaxation if an Owner-peer-push design is chosen instead) land *with*
+  3d under live verification.
 
 - **3f: inbound request channel (req #5) + terminal-delta buffering (req #6).** Route
   interrupt/restart `RuntimeAgentRequest`s to the cloud agent (hosted REQUEST dispatch), and

--- a/docs/handoffs/16-decisions-log.md
+++ b/docs/handoffs/16-decisions-log.md
@@ -4,6 +4,35 @@ A trail of the non-obvious calls behind making the daemon's `runtime_agent`
 transport-agnostic, so a future reader understands *why*. One entry per
 decision: what, the alternative, why.
 
+## PR stack status (2026-06-05)
+
+Phases 1–3a merged via #3411 (squashed into `main`). The work below is a stack of
+six PRs against `main`, each on the `quillaid/desktop` fork, base-chained in order
+(each stacked on the previous; review the *last* commit of each until the lower ones
+merge). All are pure-Rust or Rust+TS, fully unit-tested, with the desktop/UDS path
+left byte-for-byte unchanged. Every PR carries a STATUS section.
+
+| PR | Branch | Phase | What | NEEDS US |
+|----|--------|-------|------|----------|
+| #3413 | `quod/16-phase3b-connect-hardening` | 3b warm-up | cloud ready-wait timeout + framing-error flap floor (2 pullfrog gaps) | none |
+| #3414 | `quod/16-phase3b-reconnect-reauth` | 3b | `TokenRefresher` re-auth seam + `reconnect_with_backoff` tests | live re-auth proof |
+| #3417 | `quod/16-phase3c-spawn-path` | 3c CODE | `run_cloud_runtime_agent` spawn path + principal-derived doc actor | live cross-machine re-proof; CLI wiring |
+| #3418 | `quod/16-phase3e-policy-model` | 3e model | `kernel.last_seen` liveness heartbeat | `Disconnected` variant + policy relaxation (defer w/ 3d) |
+| #3419 | `quod/16-phase3f-writer-recovery` | 3f req #6 | writer-error reconnects instead of killing the kernel | — (req #5 inbound channel needs 3d) |
+| #3420 | `quod/16-phase3d-room-watchdog` | 3d CODE | DO `runtime_peer`-gone watchdog + `reconcile_runtime_peer_gone` | worker deploy + live peer-drop re-proof |
+
+CI: all Rust checks (Clippy, Rust Tests, Lint, runtimed-node) green on every PR. A
+**Browser E2E (Playwright)** flake intermittently fails #3414/#3417 — it's a frontend
+job unrelated to these Rust/TS-cloud changes (the shared base #3413 and sibling #3418
+passed it); needs a maintainer rerun (fork PRs can't self-rerun). The 4
+`room-materializer.test.ts` failures on #3420 are a pre-existing environmental baseline
+(reproduced on clean `origin/main`).
+
+**Only remaining headless-incomplete item:** 3f req #5 (inbound request channel) — it
+needs the 3d worker's hosted REQUEST dispatch + a live room, so it's NEEDS US, not
+buildable here. Everything else in the #16 plan is code-complete behind transport gates;
+what's left is the set of NEEDS-US live/deploy steps consolidated below per phase.
+
 ## Design
 
 1. **Make `runtime_agent` transport-agnostic; do not reimplement the kernel drive.**

--- a/docs/handoffs/16-decisions-log.md
+++ b/docs/handoffs/16-decisions-log.md
@@ -448,26 +448,73 @@ cloud agent. Detection of the kernel-side *effect* already survives (decision/re
 analysis); only the trigger path is missing, and it can't be built or verified
 without the worker (3d) + a live room. Build it alongside 3d.
 
-## Phase 3 remaining plan (3d, 3f req #5)
+## Phase 3d (CODE): cloud-room DurableObject watchdog
 
-Ordered by the lifecycle analysis. 3a (req #1), 3b (req #2), 3c CODE (doc-actor
-identity), 3e model half (`last_seen`), and 3f req #6 (writer-error recovery) are
-done. Remaining (both need the cloud worker + live verification = NEEDS US):
+36. **3d's DO-internal watchdog is built and unit-tested; the deploy + the
+    live peer-drop re-proof are NEEDS US.** Implements the safety net the daemon
+    structurally cannot provide (reqs #3, #7): when the room's `runtime_peer`
+    (the daemon) vanishes, the room itself terminalizes the orphaned state. Three
+    layers, each verifiable headlessly:
+    - **Rust (`runtimed-wasm`): `RoomHostHandle::reconcile_runtime_peer_gone(reason)`**
+      — the reconciliation mutator `RoomHostHandle` previously lacked. Marks all
+      in-flight (`running`/`queued`) executions failed, clears the queue, and flips
+      a *still-live* kernel (`Running`/any starting phase) to `Error` with an
+      `error_details` note — leaving an already-terminal `Error`/`Shutdown`/`NotStarted`
+      untouched so a clean shutdown that raced the disconnect isn't relabeled. Then
+      broadcasts the corrected state to surviving peers. Authoring is **direct** on
+      the room host's `state_doc`, which doesn't pass through
+      `validate_runtime_state_sync_scope` (decision #32), so no policy relaxation is
+      needed. Native-testable via `reconcile_runtime_peer_gone_inner` (rlib `cargo
+      test`, no wasm/node): 4 tests (terminalize+error, idempotent no-op,
+      clean-shutdown-not-relabeled, broadcast-to-survivors).
+    - **TS materializer**: `reconcileRuntimePeerGone(reason)` forwards to the wasm
+      mutator and normalizes the result.
+    - **TS DurableObject (`notebook-room.ts`)**: a `runtime_peer`-departure watchdog.
+      `removePeer` and the attach path now branch on `peer.identity.scope`; when the
+      last `runtime_peer` leaves, `refreshRuntimePeerWatch` arms a DO `alarm()`
+      `RUNTIME_PEER_GONE_GRACE_MS` (30s) out and persists the notebook id under
+      `RUNTIME_PEER_WATCH_KEY`; a `runtime_peer` rejoining inside the window disarms
+      it. `alarm()` re-checks membership (no-op if a peer returned), else reconciles
+      and broadcasts. The grace window is what makes a transient blip recover rather
+      than terminalize. The `DurableObjectStorage` type gained optional
+      `setAlarm`/`getAlarm`/`deleteAlarm` (Cloudflare-provided; optional so test
+      fakes need not implement them, and the watchdog feature-detects before arming).
+      3 node tests (arm+fire reconciles, rejoin disarms, present-peer fired-alarm
+      no-op) with an alarm-capable fake state.
 
-- **3d: cloud-room DurableObject watchdog (reqs #3, #7; the safety net the daemon can't
-  provide).** TypeScript in `apps/notebook-cloud/`. Thread peer **scope** through
-  `removePeer` → `room-materializer.removePeer` → `RoomHostHandle.remove_peer`
-  (`notebook-room.ts:635`, `runtimed-wasm/src/lib.rs:523`), give `RoomHostHandle` a
-  reconciliation mutator (it has none), and use a DO `alarm()` with a grace period to
-  terminalize running/queued executions and flip lifecycle when a `runtime_peer` departs.
+37. **Scope threading was simpler than the plan anticipated: the DO already had
+    `peer.identity.scope` at every `removePeer`/attach site, so it did NOT need to be
+    threaded through `room-materializer.removePeer` → `RoomHostHandle.remove_peer`.**
+    The original plan (and lifecycle-analysis req #3 bullet 1) assumed the watchdog
+    had to learn the departing peer's scope by passing it down through those layers,
+    because `removePeer(peerId)` is scope-blind. But the *decision* — "was that a
+    runtime_peer? then arm the watchdog" — is made in the DO, which holds the full
+    `Peer` (incl. `identity.scope`). The sync-state cleanup in `remove_peer(peer_id)`
+    genuinely only needs the id, so it's left unchanged. Avoiding the unnecessary
+    signature churn through two layers keeps the diff smaller and the wasm boundary
+    stable.
 
-  3d note: prefer the DO-internal `alarm()` watchdog authoring directly on the room
-  host's `state_doc`. That write path does **not** go through `validate_runtime_state_sync_scope`
-  (which gates only incoming peer sync, `runtimed-wasm/src/lib.rs:715`), so it needs no
-  policy relaxation (decision #32). The `last_seen` model field it reads is already done
-  (decision #33). The remaining 3e halves (the `Disconnected` variant, and the
-  policy.rs:403-405 relaxation if an Owner-peer-push design is chosen instead) land *with*
-  3d under live verification.
+Phase 3d verification: `cargo test -p runtimed-wasm` 26 (was 22, +4 reconciliation);
+`node --import tsx --test test/notebook-room.test.ts` 19 (+3 watchdog);
+`test/room-materializer.test.ts` 25 pass / 4 fail — the 4 failures are a
+**pre-existing environmental baseline** (published-snapshot fixtures; reproduced on a
+clean `origin/main` worktree, unrelated to this change); `tsc --noEmit` clean; clippy
+`-D warnings` clean.
+
+**NEEDS US (3d):** (1) deploy the worker to preview (the `alarm()` handler + the
+`DurableObjectStorage` alarm methods only execute on a real Cloudflare DO; the unit
+tests use a fake clock/storage). (2) Live peer-drop re-proof: with a real runtime_peer
+attached to a preview room running a cell, kill the peer, and confirm after the 30s
+grace the viewer sees the spinning cell go to error and the kernel flip to Error —
+and that a reconnect *within* 30s does NOT terminalize. (3) Tune `RUNTIME_PEER_GONE_GRACE_MS`
+against real reconnect latencies. None of this is possible without the preview deploy +
+creds this session lacks. The code is gated behind the alarm API feature-detect, so a
+storage backend without alarms (or the desktop/UDS path) is unaffected.
+
+## Phase 3 remaining (3f req #5 only)
+
+3a (req #1), 3b (req #2), 3c CODE (doc-actor identity), 3d CODE (watchdog), 3e model
+half (`last_seen`), and 3f req #6 (writer-error recovery) are done. Remaining:
 
 - **3f req #5: inbound request channel.** Route interrupt/restart
   `RuntimeAgentRequest`s to the cloud agent via the 3d DurableObject hosted REQUEST

--- a/docs/handoffs/16-decisions-log.md
+++ b/docs/handoffs/16-decisions-log.md
@@ -405,10 +405,54 @@ the existing `Error`/`Shutdown` terminal states in the meantime); (2) the
 rather than a DO-internal watchdog; the recommended DO-internal design needs no policy
 change. Decide (2) when 3d's mechanism is chosen.
 
-## Phase 3 remaining plan (3d, 3f)
+## Phase 3f req #6: writer-error recovery (the headless half of 3f)
+
+34. **3f is split: req #6 (writer-error must not kill the kernel on a recoverable
+    transport) lands now; req #5 (inbound request channel) defers — it needs the
+    3d worker.** req #5 routes interrupt/restart `RuntimeAgentRequest`s from the
+    cloud room to the agent, which requires a hosted REQUEST dispatch on the
+    DurableObject (3d, NEEDS US). req #6 is pure Rust in `runtime_agent` and is the
+    last place a transient cloud blip still destroys a healthy kernel after 3a:
+    the two outbound (writer) `select!` arms — the `state_changed_rx`
+    RuntimeStateSync send and the `async_response_rx` reply send — `break` the loop
+    (→ kernel shutdown) on a single `send_frame` error.
+
+35. **On a recoverable transport, a writer send error reconnects + resyncs instead
+    of `break`ing; the UDS path keeps the historical teardown byte-for-byte.** A
+    new writer-only helper `reconnect_after_writer_error` applies the shared flap
+    floor, calls `reconnect_with_backoff`, and stamps `last_recoverable_reconnect`
+    (so writer-triggered reconnects share the read arms' throttle). Both writer
+    arms now branch on `transport.clean_eof_is_recoverable()`: `false` (UDS) →
+    `break` exactly as before; `true` (cloud) → drop source, reconnect, reset
+    `coordinator_sync_state`, kick `state_kick_tx`, continue. Why no explicit
+    buffer-and-replay (the analysis's "buffer the change and replay"): the failed
+    RuntimeStateSync delta is *durable in the local doc*, and the fresh sync state
+    + resync kick re-send it on reconnect — **Automerge's own resync IS the replay**,
+    the same mechanism the framing-error arm has always relied on (decision #22/3a).
+    The one genuinely-lost item is the one-shot `async_response` reply envelope
+    (not re-derived by resync), but its *effect* (env progress/state from
+    SyncEnvironment) is in the RuntimeStateDoc and does resync; only the reply
+    envelope is dropped — acceptable, and documented at the site. A dedicated
+    egress buffer was considered and rejected as redundant with Automerge resync
+    and a new source of ordering bugs. 3 unit tests on the helper (recover+stamp,
+    give-up propagation, the UDS discriminant the loop branches on); the read arms
+    are left byte-for-byte unchanged.
+
+Phase 3f(req #6) verification: `cargo test -p runtimed` 891 lib (was 888) +
+integration suites green (UDS unchanged); `cargo xtask lint --fix` clean; clippy
+`-D warnings` clean.
+
+**NEEDS US (3f req #5):** the inbound request channel — needs the 3d DurableObject
+hosted REQUEST dispatch to deliver interrupt/restart `RuntimeAgentRequest`s to the
+cloud agent. Detection of the kernel-side *effect* already survives (decision/req
+analysis); only the trigger path is missing, and it can't be built or verified
+without the worker (3d) + a live room. Build it alongside 3d.
+
+## Phase 3 remaining plan (3d, 3f req #5)
 
 Ordered by the lifecycle analysis. 3a (req #1), 3b (req #2), 3c CODE (doc-actor
-identity), and 3e model half (`last_seen`) are done. Remaining, in dependency order:
+identity), 3e model half (`last_seen`), and 3f req #6 (writer-error recovery) are
+done. Remaining (both need the cloud worker + live verification = NEEDS US):
 
 - **3d: cloud-room DurableObject watchdog (reqs #3, #7; the safety net the daemon can't
   provide).** TypeScript in `apps/notebook-cloud/`. Thread peer **scope** through
@@ -425,9 +469,7 @@ identity), and 3e model half (`last_seen`) are done. Remaining, in dependency or
   policy.rs:403-405 relaxation if an Owner-peer-push design is chosen instead) land *with*
   3d under live verification.
 
-- **3f: inbound request channel (req #5) + terminal-delta buffering (req #6).** Route
-  interrupt/restart `RuntimeAgentRequest`s to the cloud agent (hosted REQUEST dispatch), and
-  don't `break` the agent loop on a single writer error (`runtime_agent.rs` outbound arm);
-  buffer and replay across a blip. 3f's req #6 is partly addressed by 3a (the loop no longer
-  tears down on a clean close), but the writer-error `break` in the `state_changed_rx` arm
-  remains.
+- **3f req #5: inbound request channel.** Route interrupt/restart
+  `RuntimeAgentRequest`s to the cloud agent via the 3d DurableObject hosted REQUEST
+  dispatch. req #6 (don't tear the kernel down on a writer error) is DONE
+  (decisions #34–#35); req #5's trigger path needs the worker + a live room.

--- a/docs/handoffs/16-decisions-log.md
+++ b/docs/handoffs/16-decisions-log.md
@@ -182,6 +182,53 @@ Phase 3a verification: `cargo test -p runtimed` passes 944 (UDS default unchange
 `cargo test -p notebook-protocol` 89; `cargo test -p notebook-cloud-transport` 12; clippy
 clean across all three; `cargo fmt --check` clean.
 
+## Phase 3b warm-up: two connect-hardening gaps pullfrog flagged on #3411
+
+24. **Bounded ready-wait timeout in `CloudWsFrameTransport::connect`
+    (`READY_WAIT_TIMEOUT`, 30s).** The connect-time `cloud_room_ready` wait
+    blocked on `recv_frame()` with no deadline: a room that completes the WS
+    upgrade but never sends `cloud_room_ready`/`cloud_frame_rejected` and never
+    closes would hang `connect` forever — and since `reconnect_with_backoff`
+    calls `connect()` with no per-attempt timeout of its own, the whole recovery
+    path would wedge on one silent room. Fix: the ready loop is extracted into a
+    `wait_for_ready<S: FrameSource>` helper (no deadline of its own, so it's
+    unit-testable against a mock source) that `connect` wraps in
+    `tokio::time::timeout(READY_WAIT_TIMEOUT, …)`; on elapse it returns a
+    `TimedOut` io error, which `reconnect_with_backoff` already treats as a
+    failed connect and retries. Alternative considered: a per-frame idle timeout
+    rather than a total deadline — rejected as more complex and unnecessary, since
+    a room mid-handshake either reaches a terminal control frame promptly or is
+    wedged. Extracting the helper also fixed a latent bug: the old loop pushed
+    pre-ready data frames back into `source.pending` while *reading via*
+    `source.recv_frame()` (which pops `pending` first), so the buffer now uses a
+    separate deque assigned into `pending` only after ready. 4 new unit tests
+    (timeout under `start_paused`, rejection, clean-EOF-before-ready, pre-ready
+    data buffering); `notebook-cloud-transport` now 16 tests.
+
+25. **Flap floor extended to the framing-error reconnect arm
+    (`RECOVERABLE_RECONNECT_FLOOR`, renamed from `CLEAN_EOF_RECONNECT_FLOOR`).**
+    Phase 3a (decision #23) added the 1s reconnect floor only to the clean-EOF
+    (`None`) arm. The framing-error (`Some(Err)`) arm plus `reconnect_with_backoff`
+    only sleep between *failed* connects, so a cloud room that accepts the
+    connection and then errors the stream every cycle would spin reconnects at RTT
+    rate (a self-inflicted DoS on the room) — the same hazard #23 fixed for clean
+    EOF, on the other arm. Fix: a pure `reconnect_floor_delay(recoverable,
+    since_last_reconnect, floor) -> Option<Duration>` helper, called by *both*
+    arms; the timestamp variable is renamed `last_recoverable_reconnect` and set
+    after every recoverable reconnect. The helper returns `None` immediately when
+    `!recoverable`, so the UDS framing-error path is byte-for-byte unchanged (no
+    sleep, never records a timestamp) — verified by the 944→881-lib runtimed suite
+    staying green and a dedicated `floor_never_delays_a_non_recoverable_transport`
+    test. Alternative considered: a separate accept-then-immediate-error counter
+    per arm — rejected; a single shared floor on the combined reconnect rate is
+    simpler and is exactly the throttle wanted regardless of which failure mode
+    recurs. 4 new unit tests for the policy.
+
+Phase 3b warm-up verification: `cargo test -p notebook-cloud-transport` 16;
+`cargo test -p runtimed` 881 lib + integration suites green (UDS unchanged);
+`cargo xtask lint --fix` clean; clippy `-D warnings` clean on both crates. No new
+workspace crate (no bump-targets change).
+
 ## Phase 3 remaining plan (3b+)
 
 Ordered by the lifecycle analysis. 3a (req #1) is done. Remaining, in dependency order:


### PR DESCRIPTION
**Stacked on #3419 → #3418 → #3417 → #3414 → #3413.** Until those merge this PR's diff includes their commits; it narrows to the single 3d commit once they land. Review the last commit.

Phase 3d (**CODE ONLY**) of #16: the cloud-room DurableObject watchdog — the safety net the daemon structurally cannot provide (lifecycle-analysis reqs #3, #7). When the room's `runtime_peer` (the daemon) vanishes, the room *itself* terminalizes the orphaned state, instead of leaving viewers with perpetually-spinning cells and a phantom-live kernel.

## Three layers (each verifiable headlessly)

- **`RoomHostHandle::reconcile_runtime_peer_gone(reason)` (runtimed-wasm)** — the reconciliation mutator the handle previously lacked. Marks in-flight (`running`/`queued`) executions failed, clears the queue, flips a *still-live* kernel to `Error` (leaving an already-terminal `Error`/`Shutdown`/`NotStarted` alone, so a clean shutdown that raced the disconnect isn't relabeled), then broadcasts to survivors. Authors **directly** on the room host's `state_doc`, which bypasses `validate_runtime_state_sync_scope` — so **no policy relaxation is needed**. Native-testable via `_inner` (4 `cargo test`s).
- **`RoomMaterializer.reconcileRuntimePeerGone`** — forwards to the wasm mutator + normalizes.
- **`NotebookRoom` watchdog** — `removePeer`/attach branch on `peer.identity.scope`; the last `runtime_peer` leaving arms a DO `alarm()` 30s out (`RUNTIME_PEER_GONE_GRACE_MS`) and persists the notebook id; a `runtime_peer` rejoining inside the window disarms it; `alarm()` reconciles only if none returned. `DurableObjectStorage` gained optional `setAlarm`/`getAlarm`/`deleteAlarm` (Cloudflare-provided; optional so test fakes need not implement them, and the watchdog feature-detects). 3 node tests with an alarm-capable fake state.

## Scope threading was simpler than planned (decision #37)

The plan assumed scope had to be threaded through `room-materializer.removePeer` → `RoomHostHandle.remove_peer`. It didn't: the DO already holds `peer.identity.scope` at every `removePeer`/attach site, and the decision ("was that a runtime_peer? arm the watchdog") is made there. The wasm `remove_peer(peer_id)` sync-cleanup genuinely only needs the id, so it's unchanged — smaller diff, stable wasm boundary.

## STATUS

- **State:** CODE complete + unit-tested. Gated behind the alarm-API feature-detect, so storage backends without alarms (and the desktop/UDS path) are unaffected.
- **Tests:** `runtimed-wasm` 26 (was 22, +4 reconciliation). `notebook-room.test.ts` 19 (+3 watchdog). `tsc --noEmit` clean; clippy `-D warnings` clean.
- **Pre-existing baseline:** `room-materializer.test.ts` is 25 pass / **4 fail** — those 4 failures (published-snapshot fixtures) reproduce on a clean `origin/main` worktree and are **unrelated to this change**; not introduced here.
- **NEEDS US:** (1) deploy the worker to preview — the `alarm()` handler + storage-alarm methods only execute on a real Cloudflare DO (tests use a fake clock/storage). (2) Live peer-drop re-proof: kill an attached runtime_peer mid-execution against a preview room and confirm after 30s the viewer sees the cell error + kernel flip to Error, and that a reconnect *within* 30s does NOT terminalize. (3) Tune `RUNTIME_PEER_GONE_GRACE_MS` against real reconnect latencies. None possible without preview deploy + creds.
- **Decision log:** entries #36–#37 in `docs/handoffs/16-decisions-log.md`.
