### PR TITLE
fix(runtimed): type captured environment disk state

### DIFF
--- a/crates/runtimed/src/notebook_sync_server/metadata.rs
+++ b/crates/runtimed/src/notebook_sync_server/metadata.rs
@@ -1647,25 +1647,62 @@ pub(crate) fn captured_env_for_runtime(
     }
 }
 
-/// Check whether a captured env exists on disk at the unified-hash path.
-/// Returns the cache path + python path if present.
-pub(crate) fn unified_env_on_disk(captured: &CapturedEnv) -> Option<(PathBuf, PathBuf)> {
-    unified_env_on_disk_in(
+/// Typed on-disk lifecycle state for a captured unified environment.
+///
+/// `Missing` preserves the historical fallback path: metadata with an env_id
+/// but no matching unified directory is ambiguous (GC'd capture vs. fresh
+/// inline-deps notebook). `Partial` means the derived directory exists but the
+/// expected Python executable is absent, so callers must route it through the
+/// backend's captured repair path. `Usable` is the same cache-hit candidate the
+/// old `unified_env_on_disk(...).is_some()` predicate accepted.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) enum CapturedEnvDiskState {
+    Missing {
+        env_path: PathBuf,
+        python_path: PathBuf,
+    },
+    Partial {
+        env_path: PathBuf,
+        python_path: PathBuf,
+    },
+    Usable {
+        env_path: PathBuf,
+        python_path: PathBuf,
+    },
+}
+
+impl CapturedEnvDiskState {
+    pub(crate) fn env_path(&self) -> &Path {
+        match self {
+            Self::Missing { env_path, .. }
+            | Self::Partial { env_path, .. }
+            | Self::Usable { env_path, .. } => env_path,
+        }
+    }
+
+    pub(crate) fn is_captured_route(&self) -> bool {
+        matches!(self, Self::Partial { .. } | Self::Usable { .. })
+    }
+}
+
+/// Resolve the typed on-disk state at the captured env's unified-hash path.
+pub(crate) fn captured_env_disk_state(captured: &CapturedEnv) -> CapturedEnvDiskState {
+    captured_env_disk_state_in(
         captured,
         &kernel_env::uv::default_cache_dir_uv(),
         &kernel_env::conda::default_cache_dir_conda(),
     )
 }
 
-/// Test-friendly form of [`unified_env_on_disk`] that accepts explicit
+/// Test-friendly form of [`captured_env_disk_state`] that accepts explicit
 /// cache dirs instead of using the channel defaults. The production call
 /// site always passes the defaults; tests pass tmpdirs.
-fn unified_env_on_disk_in(
+pub(crate) fn captured_env_disk_state_in(
     captured: &CapturedEnv,
     uv_cache_dir: &Path,
     conda_cache_dir: &Path,
-) -> Option<(PathBuf, PathBuf)> {
-    match captured {
+) -> CapturedEnvDiskState {
+    let (env_path, python_path) = match captured {
         CapturedEnv::Uv { deps, env_id } => {
             let hash = kernel_env::uv::compute_unified_env_hash(deps, env_id);
             let venv_path = uv_cache_dir.join(&hash);
@@ -1675,11 +1712,7 @@ fn unified_env_on_disk_in(
             #[cfg(not(target_os = "windows"))]
             let python_path = venv_path.join("bin").join("python");
 
-            if python_path.exists() {
-                Some((venv_path, python_path))
-            } else {
-                None
-            }
+            (venv_path, python_path)
         }
         CapturedEnv::Conda { deps, env_id } => {
             let hash = kernel_env::conda::compute_unified_env_hash(deps, env_id);
@@ -1690,11 +1723,24 @@ fn unified_env_on_disk_in(
             #[cfg(not(target_os = "windows"))]
             let python_path = env_path.join("bin").join("python");
 
-            if python_path.exists() {
-                Some((env_path, python_path))
-            } else {
-                None
-            }
+            (env_path, python_path)
+        }
+    };
+
+    if !env_path.exists() {
+        CapturedEnvDiskState::Missing {
+            env_path,
+            python_path,
+        }
+    } else if python_path.exists() {
+        CapturedEnvDiskState::Usable {
+            env_path,
+            python_path,
+        }
+    } else {
+        CapturedEnvDiskState::Partial {
+            env_path,
+            python_path,
         }
     }
 }
@@ -1723,12 +1769,9 @@ pub(crate) fn should_preserve_env_on_eviction(
     }
     for runtime in [CapturedEnvRuntime::Uv, CapturedEnvRuntime::Conda] {
         if let Some(captured) = captured_env_for_runtime(metadata, runtime) {
-            if let Some((venv, _)) =
-                unified_env_on_disk_in(&captured, uv_cache_dir, conda_cache_dir)
-            {
-                if venv == env_path {
-                    return true;
-                }
+            let disk_state = captured_env_disk_state_in(&captured, uv_cache_dir, conda_cache_dir);
+            if disk_state.is_captured_route() && disk_state.env_path() == env_path {
+                return true;
             }
         }
     }
@@ -1843,7 +1886,7 @@ pub(crate) fn captured_env_source_override(
 /// path using legacy hashing. Same deps still dedup across notebooks; they
 /// just lose per-notebook env_id isolation for that rebuild.
 fn is_captured(captured: &CapturedEnv) -> bool {
-    unified_env_on_disk(captured).is_some()
+    captured_env_disk_state(captured).is_captured_route()
 }
 
 /// Like `captured_env_source_override` but also returns the full
@@ -1856,12 +1899,28 @@ fn resolve_captured_env_override(
     Option<notebook_protocol::connection::EnvSource>,
     Option<CapturedEnv>,
 ) {
+    resolve_captured_env_override_in(
+        metadata_snapshot,
+        &kernel_env::uv::default_cache_dir_uv(),
+        &kernel_env::conda::default_cache_dir_conda(),
+    )
+}
+
+pub(crate) fn resolve_captured_env_override_in(
+    metadata_snapshot: Option<&NotebookMetadataSnapshot>,
+    uv_cache_dir: &Path,
+    conda_cache_dir: &Path,
+) -> (
+    Option<notebook_protocol::connection::EnvSource>,
+    Option<CapturedEnv>,
+) {
     use notebook_protocol::connection::{EnvSource, PackageManager};
     let Some(snap) = metadata_snapshot else {
         return (None, None);
     };
     if let Some(captured) = captured_env_for_runtime(Some(snap), CapturedEnvRuntime::Uv) {
-        if is_captured(&captured) {
+        if captured_env_disk_state_in(&captured, uv_cache_dir, conda_cache_dir).is_captured_route()
+        {
             return (
                 Some(EnvSource::Prewarmed(PackageManager::Uv)),
                 Some(captured),
@@ -1869,7 +1928,8 @@ fn resolve_captured_env_override(
         }
     }
     if let Some(captured) = captured_env_for_runtime(Some(snap), CapturedEnvRuntime::Conda) {
-        if is_captured(&captured) {
+        if captured_env_disk_state_in(&captured, uv_cache_dir, conda_cache_dir).is_captured_route()
+        {
             return (
                 Some(EnvSource::Prewarmed(PackageManager::Conda)),
                 Some(captured),
@@ -1917,20 +1977,22 @@ pub(crate) async fn acquire_prewarmed_env_with_capture(
         crate::inline_env::RuntimeDocProgressHandler::new(room.state.clone()),
     );
 
-    // Reopen path: if the notebook has an env_id and the unified-hash env
-    // exists on disk, route through prepare_environment_unified for an
-    // instant cache hit. Captured deps + env_id → same env across reopens.
+    // Reopen/repair path: if the notebook has an env_id and the unified-hash
+    // env directory is present on disk, route through prepare_environment_unified.
+    // Usable dirs are the instant cache-hit path; partial dirs enter the
+    // backend's captured repair path. Captured deps + env_id → same env across
+    // reopens.
     //
     // Uses the FULL dep-shape from metadata (requires-python, prerelease,
     // channels, python pin) so the hash matches what the capture step wrote,
     // even after the user edits one of those resolver-affecting fields.
     //
-    // `is_captured` checks for the env on disk — deps-present-but-disk-absent
-    // falls through to the pool-take + capture path. That covers both fresh
-    // notebooks (empty deps) and GC'd captured envs (non-empty deps with no
-    // on-disk presence). The GC'd case accepts a rebuild via the normal
-    // inline path rather than routing through unified hashing, to avoid
-    // conflating "captured" with "user added inline deps before first launch."
+    // `is_captured` accepts Partial and Usable disk states. Missing falls
+    // through to the pool-take + capture path. That covers both fresh notebooks
+    // (empty deps) and GC'd captured envs (non-empty deps with no on-disk
+    // presence). The GC'd case accepts a rebuild via the normal inline path
+    // rather than routing through unified hashing, to avoid conflating
+    // "captured" with "user added inline deps before first launch."
     if let Some(captured) = captured_env_for_runtime(metadata_snapshot, runtime) {
         if is_captured(&captured) {
             match &captured {

--- a/crates/runtimed/src/notebook_sync_server/tests.rs
+++ b/crates/runtimed/src/notebook_sync_server/tests.rs
@@ -6520,7 +6520,7 @@ fn captured_env_source_override_returns_none_for_fresh_notebook_empty_deps() {
 
 /// Given a tmpdir pretending to be the UV cache, materialise a fake
 /// venv at `{cache}/{hash}/bin/python` for the given captured env so
-/// `unified_env_on_disk_in` finds it.
+/// `captured_env_disk_state_in` reports it as usable.
 fn materialise_fake_uv_venv(
     deps: &kernel_env::UvDependencies,
     env_id: &str,
@@ -6535,6 +6535,193 @@ fn materialise_fake_uv_venv(
     std::fs::create_dir_all(python_path.parent().unwrap()).unwrap();
     std::fs::write(&python_path, b"#!/bin/sh\n").unwrap();
     venv_path
+}
+
+fn materialise_fake_conda_env(
+    deps: &kernel_env::CondaDependencies,
+    env_id: &str,
+    cache_dir: &Path,
+) -> PathBuf {
+    let hash = kernel_env::conda::compute_unified_env_hash(deps, env_id);
+    let env_path = cache_dir.join(&hash);
+    #[cfg(target_os = "windows")]
+    let python_path = env_path.join("python.exe");
+    #[cfg(not(target_os = "windows"))]
+    let python_path = env_path.join("bin").join("python");
+    std::fs::create_dir_all(python_path.parent().unwrap()).unwrap();
+    std::fs::write(&python_path, b"#!/bin/sh\n").unwrap();
+    env_path
+}
+
+fn materialise_partial_uv_venv(
+    deps: &kernel_env::UvDependencies,
+    env_id: &str,
+    cache_dir: &Path,
+) -> PathBuf {
+    let hash = kernel_env::uv::compute_unified_env_hash(deps, env_id);
+    let venv_path = cache_dir.join(&hash);
+    std::fs::create_dir_all(&venv_path).unwrap();
+    venv_path
+}
+
+fn materialise_partial_conda_env(
+    deps: &kernel_env::CondaDependencies,
+    env_id: &str,
+    cache_dir: &Path,
+) -> PathBuf {
+    let hash = kernel_env::conda::compute_unified_env_hash(deps, env_id);
+    let env_path = cache_dir.join(&hash);
+    std::fs::create_dir_all(&env_path).unwrap();
+    env_path
+}
+
+#[test]
+fn captured_env_disk_state_classifies_uv_missing_partial_usable() {
+    let tmp = tempfile::tempdir().unwrap();
+    let uv_cache = tmp.path().join("uv");
+    let conda_cache = tmp.path().join("conda");
+    std::fs::create_dir_all(&uv_cache).unwrap();
+    std::fs::create_dir_all(&conda_cache).unwrap();
+
+    let deps = kernel_env::UvDependencies {
+        dependencies: vec!["pandas".to_string()],
+        requires_python: Some(">=3.11".to_string()),
+        prerelease: None,
+    };
+    let env_id = "uv-disk-state";
+    let captured = CapturedEnv::Uv {
+        deps: deps.clone(),
+        env_id: env_id.to_string(),
+    };
+
+    let missing = captured_env_disk_state_in(&captured, &uv_cache, &conda_cache);
+    assert!(matches!(missing, CapturedEnvDiskState::Missing { .. }));
+    assert!(!missing.is_captured_route());
+
+    let partial_path = materialise_partial_uv_venv(&deps, env_id, &uv_cache);
+    let partial = captured_env_disk_state_in(&captured, &uv_cache, &conda_cache);
+    assert!(matches!(partial, CapturedEnvDiskState::Partial { .. }));
+    assert_eq!(partial.env_path(), partial_path.as_path());
+    assert!(partial.is_captured_route());
+
+    let usable_path = materialise_fake_uv_venv(&deps, env_id, &uv_cache);
+    let usable = captured_env_disk_state_in(&captured, &uv_cache, &conda_cache);
+    assert!(matches!(usable, CapturedEnvDiskState::Usable { .. }));
+    assert_eq!(usable.env_path(), usable_path.as_path());
+    assert!(usable.is_captured_route());
+}
+
+#[test]
+fn captured_env_disk_state_classifies_conda_missing_partial_usable() {
+    let tmp = tempfile::tempdir().unwrap();
+    let uv_cache = tmp.path().join("uv");
+    let conda_cache = tmp.path().join("conda");
+    std::fs::create_dir_all(&uv_cache).unwrap();
+    std::fs::create_dir_all(&conda_cache).unwrap();
+
+    let deps = kernel_env::CondaDependencies {
+        dependencies: vec!["scipy".to_string()],
+        channels: vec!["conda-forge".to_string()],
+        python: Some("3.11".to_string()),
+        env_id: None,
+    };
+    let env_id = "conda-disk-state";
+    let captured = CapturedEnv::Conda {
+        deps: deps.clone(),
+        env_id: env_id.to_string(),
+    };
+
+    let missing = captured_env_disk_state_in(&captured, &uv_cache, &conda_cache);
+    assert!(matches!(missing, CapturedEnvDiskState::Missing { .. }));
+    assert!(!missing.is_captured_route());
+
+    let partial_path = materialise_partial_conda_env(&deps, env_id, &conda_cache);
+    let partial = captured_env_disk_state_in(&captured, &uv_cache, &conda_cache);
+    assert!(matches!(partial, CapturedEnvDiskState::Partial { .. }));
+    assert_eq!(partial.env_path(), partial_path.as_path());
+    assert!(partial.is_captured_route());
+
+    let usable_path = materialise_fake_conda_env(&deps, env_id, &conda_cache);
+    let usable = captured_env_disk_state_in(&captured, &uv_cache, &conda_cache);
+    assert!(matches!(usable, CapturedEnvDiskState::Usable { .. }));
+    assert_eq!(usable.env_path(), usable_path.as_path());
+    assert!(usable.is_captured_route());
+}
+
+#[test]
+fn captured_env_source_override_in_routes_uv_partial_and_usable_but_not_missing() {
+    use notebook_protocol::connection::{EnvSource, PackageManager};
+
+    let tmp = tempfile::tempdir().unwrap();
+    let uv_cache = tmp.path().join("uv");
+    let conda_cache = tmp.path().join("conda");
+    std::fs::create_dir_all(&uv_cache).unwrap();
+    std::fs::create_dir_all(&conda_cache).unwrap();
+
+    let mut snap = NotebookMetadataSnapshot::default();
+    snap.runt.env_id = Some("uv-override-disk-state".to_string());
+    snap.runt.uv = Some(notebook_doc::metadata::UvInlineMetadata {
+        dependencies: vec!["pandas".to_string()],
+        requires_python: Some(">=3.11".to_string()),
+        prerelease: None,
+    });
+
+    let missing = resolve_captured_env_override_in(Some(&snap), &uv_cache, &conda_cache);
+    assert_eq!(missing.0, None);
+    assert!(missing.1.is_none());
+
+    let captured = captured_env_for_runtime(Some(&snap), CapturedEnvRuntime::Uv).unwrap();
+    let CapturedEnv::Uv { deps, env_id } = captured else {
+        unreachable!("runtime-specific lookup returned UV capture");
+    };
+
+    materialise_partial_uv_venv(&deps, &env_id, &uv_cache);
+    let partial = resolve_captured_env_override_in(Some(&snap), &uv_cache, &conda_cache);
+    assert_eq!(partial.0, Some(EnvSource::Prewarmed(PackageManager::Uv)));
+    assert!(matches!(partial.1, Some(CapturedEnv::Uv { .. })));
+
+    materialise_fake_uv_venv(&deps, &env_id, &uv_cache);
+    let usable = resolve_captured_env_override_in(Some(&snap), &uv_cache, &conda_cache);
+    assert_eq!(usable.0, Some(EnvSource::Prewarmed(PackageManager::Uv)));
+    assert!(matches!(usable.1, Some(CapturedEnv::Uv { .. })));
+}
+
+#[test]
+fn captured_env_source_override_in_routes_conda_partial_and_usable_but_not_missing() {
+    use notebook_protocol::connection::{EnvSource, PackageManager};
+
+    let tmp = tempfile::tempdir().unwrap();
+    let uv_cache = tmp.path().join("uv");
+    let conda_cache = tmp.path().join("conda");
+    std::fs::create_dir_all(&uv_cache).unwrap();
+    std::fs::create_dir_all(&conda_cache).unwrap();
+
+    let mut snap = NotebookMetadataSnapshot::default();
+    snap.runt.env_id = Some("conda-override-disk-state".to_string());
+    snap.runt.conda = Some(notebook_doc::metadata::CondaInlineMetadata {
+        dependencies: vec!["scipy".to_string()],
+        channels: vec!["conda-forge".to_string()],
+        python: Some("3.11".to_string()),
+    });
+
+    let missing = resolve_captured_env_override_in(Some(&snap), &uv_cache, &conda_cache);
+    assert_eq!(missing.0, None);
+    assert!(missing.1.is_none());
+
+    let captured = captured_env_for_runtime(Some(&snap), CapturedEnvRuntime::Conda).unwrap();
+    let CapturedEnv::Conda { deps, env_id } = captured else {
+        unreachable!("runtime-specific lookup returned Conda capture");
+    };
+
+    materialise_partial_conda_env(&deps, &env_id, &conda_cache);
+    let partial = resolve_captured_env_override_in(Some(&snap), &uv_cache, &conda_cache);
+    assert_eq!(partial.0, Some(EnvSource::Prewarmed(PackageManager::Conda)));
+    assert!(matches!(partial.1, Some(CapturedEnv::Conda { .. })));
+
+    materialise_fake_conda_env(&deps, &env_id, &conda_cache);
+    let usable = resolve_captured_env_override_in(Some(&snap), &uv_cache, &conda_cache);
+    assert_eq!(usable.0, Some(EnvSource::Prewarmed(PackageManager::Conda)));
+    assert!(matches!(usable.1, Some(CapturedEnv::Conda { .. })));
 }
 
 #[test]
@@ -6900,24 +7087,6 @@ async fn rename_env_dir_noop_when_no_captured_metadata() {
 
     assert_eq!(returned, some_path);
     assert!(some_path.exists());
-}
-
-/// Given a tmpdir pretending to be the Conda cache, materialise a
-/// fake env at `{cache}/{hash}/bin/python`.
-fn materialise_fake_conda_env(
-    deps: &kernel_env::CondaDependencies,
-    env_id: &str,
-    cache_dir: &Path,
-) -> PathBuf {
-    let hash = kernel_env::conda::compute_unified_env_hash(deps, env_id);
-    let env_path = cache_dir.join(&hash);
-    #[cfg(target_os = "windows")]
-    let python_path = env_path.join("python.exe");
-    #[cfg(not(target_os = "windows"))]
-    let python_path = env_path.join("bin").join("python");
-    std::fs::create_dir_all(python_path.parent().unwrap()).unwrap();
-    std::fs::write(&python_path, b"#!/bin/sh\n").unwrap();
-    env_path
 }
 
 /// Regression: conda-only notebook with env_id set must not route

--- a/crates/runtimed/src/requests/launch_kernel.rs
+++ b/crates/runtimed/src/requests/launch_kernel.rs
@@ -26,17 +26,16 @@ fn overlay_env_vars(overlay: &Arc<ShellEnvOverlay>) -> std::collections::HashMap
     overlay.build_kernel_env_vars(&daemon_path)
 }
 use crate::notebook_sync_server::{
-    acquire_prewarmed_env_with_capture, build_launched_config, captured_env_for_runtime,
-    captured_env_source_override, check_and_broadcast_sync_state, check_inline_deps,
-    extract_pixi_toml_deps, format_conda_env_yml_build_details, get_inline_conda_channels,
-    get_inline_conda_deps, get_inline_conda_python, get_inline_uv_deps, get_inline_uv_prerelease,
-    get_inline_uv_requires_python, missing_conda_env_yml_decision,
+    acquire_prewarmed_env_with_capture, build_launched_config, captured_env_disk_state,
+    captured_env_for_runtime, captured_env_source_override, check_and_broadcast_sync_state,
+    check_inline_deps, extract_pixi_toml_deps, format_conda_env_yml_build_details,
+    get_inline_conda_channels, get_inline_conda_deps, get_inline_conda_python, get_inline_uv_deps,
+    get_inline_uv_prerelease, get_inline_uv_requires_python, missing_conda_env_yml_decision,
     project_environment_build_approved, promote_inline_deps_to_project,
     publish_environment_launch_error, publish_kernel_state_presence, reset_starting_state,
     reset_starting_state_with_outcome, resolve_metadata_snapshot,
     send_runtime_agent_request_with_kernel_ports, try_conda_pool_for_inline_deps,
-    try_uv_pool_for_inline_deps, unified_env_on_disk, CapturedEnvRuntime, NotebookRoom,
-    ResetOutcome,
+    try_uv_pool_for_inline_deps, CapturedEnvRuntime, NotebookRoom, ResetOutcome,
 };
 use crate::protocol::NotebookResponse;
 use crate::requests::guarded;
@@ -1477,11 +1476,11 @@ pub(crate) async fn handle(
     let captured_env_for_config = match resolved_env_source.as_str() {
         "uv:prewarmed" => {
             captured_env_for_runtime(metadata_snapshot.as_ref(), CapturedEnvRuntime::Uv)
-                .filter(|c| unified_env_on_disk(c).is_some())
+                .filter(|c| captured_env_disk_state(c).is_captured_route())
         }
         "conda:prewarmed" => {
             captured_env_for_runtime(metadata_snapshot.as_ref(), CapturedEnvRuntime::Conda)
-                .filter(|c| unified_env_on_disk(c).is_some())
+                .filter(|c| captured_env_disk_state(c).is_captured_route())
         }
         _ => None,
     };

--- a/docs/adr/cleanup-punchlist.md
+++ b/docs/adr/cleanup-punchlist.md
@@ -90,7 +90,7 @@ Severity legend:
 | ID | Smell | Severity | Where |
 |----|-------|----------|-------|
 | KE-1 | Captured env has no user-initiated rebuild/reset surface. Daemon lifecycle owns automatic repair, but lacks a `ResetNotebookEnvironment { RebuildSame | RefreshDefaults }` request for manual recovery and defaults refresh. | Design | `crates/runtimed/src/requests/`, `apps/notebook/src/components/DependencyHeader.tsx` |
-| CEL-1 | Captured environment lifecycle ADR requires typed disk states (`Missing`, `Partial`, `Usable`), but current source-resolution still uses the boolean-ish `unified_env_on_disk(...) -> Option<(PathBuf, PathBuf)>` path and filters launch config on `.is_some()`. This makes partial-dir routing and repair look accepted before it is implemented. | Design | `crates/runtimed/src/notebook_sync_server/metadata.rs`, `crates/runtimed/src/requests/launch_kernel.rs`, `docs/adr/captured-environment-lifecycle.md` |
+| ~~CEL-1~~ | **Done** in quill/lab1/miles/cel1-env-state. Captured unified env disk state is now typed as `Missing`, `Partial`, or `Usable`; source-resolution, launch-config filtering, and eviction preservation consume the typed state instead of probing `unified_env_on_disk(...).is_some()`. `Missing` preserves the previous fallback path, while both `Partial` and `Usable` route through captured prewarmed/unified handling so partial dirs reach captured repair and usable dirs remain cache hits. Guarded by UV and Conda tests for Missing/Partial/Usable disk states. | Done | `crates/runtimed/src/notebook_sync_server/metadata.rs`, `crates/runtimed/src/requests/launch_kernel.rs`, `docs/adr/captured-environment-lifecycle.md` |
 
 ## Blob storage
 
@@ -114,10 +114,10 @@ Severity legend:
 
 **Status legend:** Done = landed; Refuted = examined and rejected with rationale; Inline / Targeted / Design = open.
 
-- **Done:** WP-1, WP-2, WP-3, WP-5, WP-9, EP-2, EP-7, EP-12, BS-1, BS-8, BS-11, SE-1. Twelve landed across #2813, cleanup/inline-pass, targeted cleanup stacks, and the SE-1 read-side fix.
+- **Done:** WP-1, WP-2, WP-3, WP-5, WP-9, EP-2, EP-7, EP-12, BS-1, BS-8, BS-11, SE-1, CEL-1. Thirteen landed across #2813, cleanup/inline-pass, targeted cleanup stacks, the SE-1 read-side fix, and CEL-1 typed captured-env disk state.
 - **Refuted:** EP-4 (log levels are correct per `.claude/rules/logging.md`), EP-13 (warn/debug asymmetry matches the actual severity of `Full` vs `Closed`).
 - **Targeted PRs (one per smell):** WP-6, WP-7, WP-11, WP-12, 3D-1, 3D-2, EP-1, EP-8, EP-10, EP-11, BS-3, BS-7, TMD-1, TMD-2, MSL-1, MSL-3, FSB-1, FSB-2, HCA-1. Nineteen open.
-- **Design (resolve in ADR or memo first):** WP-4, WP-8, WP-10, 3D-3, 3D-5, 3D-6, 3D-7, 3D-8, EP-3, EP-5, EP-6, EP-9, BS-2, BS-4, BS-5, BS-6, BS-9, BS-10, BS-12, BS-13, MSL-2, MSL-4, HCA-2, HCA-3, HCA-4, HCA-5, HCA-6, KE-1, CEL-1. Twenty-nine open.
+- **Design (resolve in ADR or memo first):** WP-4, WP-8, WP-10, 3D-3, 3D-5, 3D-6, 3D-7, 3D-8, EP-3, EP-5, EP-6, EP-9, BS-2, BS-4, BS-5, BS-6, BS-9, BS-10, BS-12, BS-13, MSL-2, MSL-4, HCA-2, HCA-3, HCA-4, HCA-5, HCA-6, KE-1. Twenty-eight open.
 
 ## Next steps
 


### PR DESCRIPTION
## Summary
- introduce typed captured environment disk states: Missing, Partial, Usable
- route source overrides, launch-config captured env selection, and eviction preservation through typed disk state instead of unified_env_on_disk().is_some()
- keep Missing on the historical fallback path while Partial and Usable enter captured/prewarmed handling
- mark CEL-1 done in the ADR cleanup punchlist

## Tests
- cargo xtask wasm
- cargo test -p runtimed captured_env -- --nocapture
- cargo test -p runtimed launch_kernel -- --nocapture
- cargo xtask lint --fix