### PR TITLE
feat(runtimed): launch-on-attach for the cloud runtime agent (Phase B3)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7589,6 +7589,7 @@ dependencies = [
  "loro_fractional_index",
  "nbformat",
  "nix 0.31.2",
+ "notebook-cloud-transport",
  "notebook-doc",
  "notebook-protocol",
  "notebook-sync",

--- a/crates/runtimed/src/lib.rs
+++ b/crates/runtimed/src/lib.rs
@@ -68,6 +68,7 @@ pub mod user_error;
 pub(crate) mod uv_project;
 #[doc(hidden)]
 pub mod warm_env;
+pub mod workstation;
 
 pub fn trusted_packages_db_path() -> std::path::PathBuf {
     runt_workspace::daemon_base_dir().join("trusted-packages.sqlite")

--- a/crates/runtimed/src/main.rs
+++ b/crates/runtimed/src/main.rs
@@ -469,7 +469,9 @@ async fn main() -> anyhow::Result<()> {
                         eprintln!("[cloud-runtime-agent] Config error: {}", e);
                         e
                     })?;
-            runtimed::runtime_agent::run_cloud_runtime_agent(config, operator, blob_root)
+            // Attach-only for now: the launch-on-attach trigger is wired by the
+            // allocate-runtime-for-room path (Phase B4), not this bare CLI entry.
+            runtimed::runtime_agent::run_cloud_runtime_agent(config, operator, blob_root, None)
                 .await
                 .map_err(|e| {
                     eprintln!("[cloud-runtime-agent] Fatal: {}", e);

--- a/crates/runtimed/src/main.rs
+++ b/crates/runtimed/src/main.rs
@@ -139,6 +139,33 @@ enum Commands {
         blob_root: PathBuf,
     },
 
+    /// Run a runtime agent attached to a hosted cloud room over WebSocket
+    /// (internal/automation). The daemon-managed kernel is unchanged; only the
+    /// sync wire differs from `runtime-agent`. The credential is read from the
+    /// environment (RUNT_CLOUD_TOKEN), never argv, so it can't leak into the
+    /// process command line.
+    #[command(hide = true, name = "cloud-runtime-agent")]
+    CloudRuntimeAgent {
+        /// Base URL of the notebook cloud (https/http; swapped to wss/ws).
+        #[arg(long, default_value = "https://preview.runt.run")]
+        cloud_url: String,
+        /// Notebook id to attach to (room is `/n/<id>/sync`).
+        #[arg(long)]
+        notebook_id: String,
+        /// Connection scope (a workstation runtime attaches as runtime_peer).
+        #[arg(long, default_value = "runtime_peer")]
+        scope: String,
+        /// Auth kind; the token itself comes from RUNT_CLOUD_TOKEN.
+        #[arg(long, value_enum, default_value_t = runtimed::workstation::CloudAuthKind::Oidc)]
+        auth_kind: runtimed::workstation::CloudAuthKind,
+        /// Operator suffix for the doc actor label (`<principal>/<operator>`).
+        #[arg(long, default_value = "agent:runt")]
+        operator: String,
+        /// Blob store root path.
+        #[arg(long)]
+        blob_root: PathBuf,
+    },
+
     /// Warm a pool environment (internal, spawned by daemon warming loops).
     /// Reads JSON config from stdin, writes JSON events to stdout.
     #[command(hide = true, name = "warm-env")]
@@ -422,6 +449,33 @@ async fn main() -> anyhow::Result<()> {
             eprintln!("[runtime-agent] Fatal: {}", e);
             e
         }),
+        Some(Commands::CloudRuntimeAgent {
+            cloud_url,
+            notebook_id,
+            scope,
+            auth_kind,
+            operator,
+            blob_root,
+        }) => {
+            let cli_args = runtimed::workstation::CloudAgentArgs {
+                cloud_url,
+                notebook_id,
+                scope,
+                auth_kind,
+            };
+            let config =
+                runtimed::workstation::build_cloud_config(&cli_args, |k| std::env::var(k).ok())
+                    .map_err(|e| {
+                        eprintln!("[cloud-runtime-agent] Config error: {}", e);
+                        e
+                    })?;
+            runtimed::runtime_agent::run_cloud_runtime_agent(config, operator, blob_root)
+                .await
+                .map_err(|e| {
+                    eprintln!("[cloud-runtime-agent] Fatal: {}", e);
+                    e
+                })
+        }
         Some(Commands::WarmEnv) => {
             runtimed::warm_env::run().await;
             Ok(())

--- a/crates/runtimed/src/runtime_agent.rs
+++ b/crates/runtimed/src/runtime_agent.rs
@@ -119,9 +119,15 @@ pub async fn run_runtime_agent(
     // up front and independent of the (just-connected) transport. This keeps
     // the desktop/daemon path byte-for-byte unchanged: the resolver returns the
     // exact value the bootstrap used inline before the cloud-path extraction.
-    run_runtime_agent_on_transport(transport, notebook_id, blob_root, move |_| {
-        Ok(runtime_agent_id)
-    })
+    run_runtime_agent_on_transport(
+        transport,
+        notebook_id,
+        blob_root,
+        move |_| Ok(runtime_agent_id),
+        // The daemon/UDS path never launches on attach: the daemon drives launch
+        // via an inbound `LaunchKernel` RPC. Always `None` here.
+        None,
+    )
     .await
 }
 
@@ -143,7 +149,15 @@ pub async fn run_runtime_agent(
 ///   `DuplicateSeqNumber` when the room syncs the prior change back, exactly the
 ///   hazard the `runt-cloud-peer` spike documented.
 ///
-/// CODE-ONLY (Phase 3c): this builds and unit-tests the spawn path behind the
+/// `initial_launch`, when `Some`, is a [`RuntimeAgentRequest::LaunchKernel`] the
+/// agent applies *once* right after bootstrap, so the workstation endpoint can
+/// *start* a runtime in env X without waiting for an inbound `LaunchKernel` RPC
+/// — that inbound channel is req #5, Deferred (decision 38). `None` keeps the
+/// historical attach-only behavior (the agent waits for an RPC that, over the
+/// cloud transport, does not yet arrive). Build it with
+/// [`crate::workstation::build_current_python_launch`].
+///
+/// CODE-ONLY (Phase 3c/3b): this builds and unit-tests the spawn path behind the
 /// transport gate; the live cross-machine re-proof (a preview room + the
 /// explicit `runtime_peer` ACL row, decision #9) is deferred and tracked in the
 /// decision log.
@@ -151,23 +165,33 @@ pub async fn run_cloud_runtime_agent(
     config: notebook_cloud_transport::CloudWsConfig,
     operator: String,
     blob_root: PathBuf,
+    initial_launch: Option<RuntimeAgentRequest>,
 ) -> anyhow::Result<()> {
     let notebook_id = config.notebook_id.clone();
     info!(
-        "[runtime-agent] Starting cloud runtime_agent notebook_id={} url={} scope={}",
+        "[runtime-agent] Starting cloud runtime_agent notebook_id={} url={} scope={} launch_on_attach={}",
         notebook_id,
         notebook_cloud_transport::build_ws_url(&config.cloud_url, &notebook_id),
         config.scope,
+        initial_launch.is_some(),
     );
 
     let transport = notebook_cloud_transport::CloudWsFrameTransport::new(config);
 
-    run_runtime_agent_on_transport(transport, notebook_id, blob_root, move |t| {
-        let principal = t.principal().ok_or_else(|| {
-            anyhow::anyhow!("cloud transport has no principal after connect (no cloud_room_ready)")
-        })?;
-        Ok(cloud_actor_label(principal, &operator))
-    })
+    run_runtime_agent_on_transport(
+        transport,
+        notebook_id,
+        blob_root,
+        move |t| {
+            let principal = t.principal().ok_or_else(|| {
+                anyhow::anyhow!(
+                    "cloud transport has no principal after connect (no cloud_room_ready)"
+                )
+            })?;
+            Ok(cloud_actor_label(principal, &operator))
+        },
+        initial_launch,
+    )
     .await
 }
 
@@ -203,6 +227,7 @@ async fn run_runtime_agent_on_transport<T, F>(
     notebook_id: String,
     blob_root: PathBuf,
     resolve_actor: F,
+    initial_launch: Option<RuntimeAgentRequest>,
 ) -> anyhow::Result<()>
 where
     T: FrameTransport,
@@ -291,6 +316,44 @@ where
     // terminal events). u64 wraparound is a non-issue in practice.
     let sync_generation = std::sync::Arc::new(std::sync::atomic::AtomicU64::new(0));
     let mut inflight_sync: Option<tokio::task::JoinHandle<()>> = None;
+
+    // -- 3b. Launch-on-attach (cloud only) ----------------------------------
+    //
+    // The workstation endpoint can hand the agent an initial `LaunchKernel` to
+    // apply right after bootstrap, so it *starts* a runtime in env X without
+    // waiting for an inbound RPC (req #5, Deferred — decision 38). Gated on
+    // `clean_eof_is_recoverable()`, the recoverable/cloud-transport discriminant:
+    // the daemon/UDS path drives launch via its own RPC and must never launch on
+    // attach, so even a (never-passed) `Some` here is ignored on UDS. The launch
+    // runs through the *same* `handle_runtime_agent_request` path an inbound RPC
+    // would, so the kernel drive, queue release, and command-receiver install are
+    // identical — only the trigger differs.
+    if let Some(launch) = initial_launch {
+        if transport.clean_eof_is_recoverable() {
+            info!("[runtime-agent] Applying launch-on-attach LaunchKernel");
+            let (response, new_cmd_rx) = handle_runtime_agent_request(
+                launch,
+                &ctx,
+                &mut kernel,
+                &mut kernel_state,
+                &mut seen_execution_ids,
+            )
+            .await;
+            if let Some(rx) = new_cmd_rx {
+                lifecycle_rx = Some(rx.lifecycle_rx);
+                work_rx = Some(rx.work_rx);
+            }
+            interrupt_handle = kernel.as_ref().and_then(|k| k.interrupt_handle());
+            if let RuntimeAgentResponse::Error { error } = response {
+                warn!("[runtime-agent] Launch-on-attach failed: {}", error);
+            }
+        } else {
+            warn!(
+                "[runtime-agent] Ignoring launch-on-attach on a non-recoverable transport \
+                 (daemon-driven launch only)"
+            );
+        }
+    }
 
     info!("[runtime-agent] Infrastructure ready, entering main loop");
 
@@ -2209,6 +2272,26 @@ mod tests {
     fn non_recoverable_transport_reports_clean_eof_not_recoverable() {
         let transport = FlakyTransport::new(0).with_recoverable(false);
         assert!(!transport.clean_eof_is_recoverable());
+    }
+
+    /// Launch-on-attach is gated on the same `clean_eof_is_recoverable()`
+    /// discriminant (decision 38): the bootstrap apply runs the `LaunchKernel`
+    /// only when the transport reports recoverable (cloud). A non-recoverable
+    /// (UDS) transport reports `false`, so the daemon path never launches on
+    /// attach even if a `Some(initial_launch)` were ever passed. Pin both arms
+    /// of the discriminant the gate reads.
+    #[test]
+    fn launch_on_attach_gate_follows_recoverable_discriminant() {
+        let cloud_like = FlakyTransport::new(0).with_recoverable(true);
+        assert!(
+            cloud_like.clean_eof_is_recoverable(),
+            "a recoverable (cloud) transport applies launch-on-attach"
+        );
+        let uds_like = FlakyTransport::new(0).with_recoverable(false);
+        assert!(
+            !uds_like.clean_eof_is_recoverable(),
+            "a non-recoverable (UDS) transport ignores launch-on-attach"
+        );
     }
 
     // -- cloud doc-actor label (Phase 3c) ---------------------------------

--- a/crates/runtimed/src/workstation/cloud_agent_cli.rs
+++ b/crates/runtimed/src/workstation/cloud_agent_cli.rs
@@ -1,0 +1,196 @@
+//! Argument/environment → cloud-agent config mapping for the
+//! `runtimed cloud-runtime-agent` subcommand.
+//!
+//! `run_cloud_runtime_agent` had no non-test caller (decision 31). This module
+//! is the invocable entry: it maps CLI flags plus environment variables to a
+//! [`CloudWsConfig`] + [`CloudAuth`] that the subcommand hands to
+//! [`run_cloud_runtime_agent`](crate::runtime_agent::run_cloud_runtime_agent).
+//!
+//! Security (ADR "Security constraints"): the credential is read from the
+//! environment, never from argv, so it can't leak into a long-running process's
+//! command line / `ps` output. The flags carry only non-secret routing
+//! (URL, notebook id, scope, operator, auth *kind*).
+//!
+//! The mapping is pure and unit-tested; the actual dial is deferred to a live
+//! preview room (see `docs/handoffs/16-workstation-endpoint.md`).
+
+use anyhow::{anyhow, Context, Result};
+use notebook_cloud_transport::{CloudAuth, CloudWsConfig};
+
+/// Environment variable carrying the cloud credential (never passed on argv).
+pub const CLOUD_TOKEN_ENV: &str = "RUNT_CLOUD_TOKEN";
+/// Optional dev-user label for the `dev` auth kind.
+pub const CLOUD_DEV_USER_ENV: &str = "RUNT_CLOUD_DEV_USER";
+
+/// How the runtime peer authenticates on the WebSocket upgrade. Mirrors
+/// [`CloudAuth`]'s variants as a flag value, kept separate so the secret token
+/// stays out of argv — only the *kind* is a flag.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, clap::ValueEnum)]
+pub enum CloudAuthKind {
+    /// OIDC / dev-validated bearer (`Authorization: Bearer`).
+    #[value(name = "oidc")]
+    Oidc,
+    /// Anaconda API key (bearer + provider-selector header).
+    #[value(name = "anaconda-key")]
+    AnacondaKey,
+    /// Dev token (`X-Notebook-Cloud-Dev-Token`) + user label.
+    #[value(name = "dev")]
+    Dev,
+}
+
+/// Non-secret arguments for the `cloud-runtime-agent` subcommand. The token is
+/// intentionally absent — it is read from [`CLOUD_TOKEN_ENV`].
+#[derive(Debug, Clone)]
+pub struct CloudAgentArgs {
+    /// Base URL of the notebook cloud (https/http; scheme swapped to wss/ws).
+    pub cloud_url: String,
+    /// Notebook id; the room is `/n/<id>/sync`.
+    pub notebook_id: String,
+    /// Connection scope (`runtime_peer` for a workstation runtime).
+    pub scope: String,
+    /// Auth kind; the token itself comes from the environment.
+    pub auth_kind: CloudAuthKind,
+}
+
+/// Resolve the credential from the environment and build the cloud config.
+///
+/// `env` is the lookup (injected so the mapping is testable without touching the
+/// process environment); production passes `|k| std::env::var(k).ok()`.
+///
+/// Errors if the token env var is unset/empty, or if the `dev` kind is selected
+/// without a [`CLOUD_DEV_USER_ENV`] label.
+pub fn build_cloud_config(
+    args: &CloudAgentArgs,
+    env: impl Fn(&str) -> Option<String>,
+) -> Result<CloudWsConfig> {
+    let token = env(CLOUD_TOKEN_ENV)
+        .map(|t| t.trim().to_string())
+        .filter(|t| !t.is_empty())
+        .with_context(|| {
+            format!("cloud credential not found; set {CLOUD_TOKEN_ENV} (never passed on argv)")
+        })?;
+
+    let auth = match args.auth_kind {
+        CloudAuthKind::Oidc => CloudAuth::OidcBearer { token },
+        CloudAuthKind::AnacondaKey => CloudAuth::AnacondaApiKey { token },
+        CloudAuthKind::Dev => {
+            let user = env(CLOUD_DEV_USER_ENV)
+                .map(|u| u.trim().to_string())
+                .filter(|u| !u.is_empty())
+                .ok_or_else(|| {
+                    anyhow!("dev auth requires a user label; set {CLOUD_DEV_USER_ENV}")
+                })?;
+            CloudAuth::Dev { token, user }
+        }
+    };
+
+    Ok(CloudWsConfig {
+        cloud_url: args.cloud_url.clone(),
+        notebook_id: args.notebook_id.clone(),
+        scope: args.scope.clone(),
+        auth,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::collections::HashMap;
+
+    fn args(kind: CloudAuthKind) -> CloudAgentArgs {
+        CloudAgentArgs {
+            cloud_url: "https://preview.runt.run".into(),
+            notebook_id: "nb-123".into(),
+            scope: "runtime_peer".into(),
+            auth_kind: kind,
+        }
+    }
+
+    fn env_from(pairs: &[(&str, &str)]) -> impl Fn(&str) -> Option<String> {
+        let map: HashMap<String, String> = pairs
+            .iter()
+            .map(|(k, v)| (k.to_string(), v.to_string()))
+            .collect();
+        move |k: &str| map.get(k).cloned()
+    }
+
+    #[test]
+    fn oidc_kind_builds_oidc_bearer_with_env_token() {
+        let cfg = build_cloud_config(
+            &args(CloudAuthKind::Oidc),
+            env_from(&[(CLOUD_TOKEN_ENV, "tok-oidc")]),
+        )
+        .expect("build");
+        assert_eq!(cfg.notebook_id, "nb-123");
+        assert_eq!(cfg.scope, "runtime_peer");
+        assert!(matches!(
+            cfg.auth,
+            CloudAuth::OidcBearer { token } if token == "tok-oidc"
+        ));
+    }
+
+    #[test]
+    fn anaconda_kind_builds_api_key_auth() {
+        let cfg = build_cloud_config(
+            &args(CloudAuthKind::AnacondaKey),
+            env_from(&[(CLOUD_TOKEN_ENV, "tok-key")]),
+        )
+        .expect("build");
+        assert!(matches!(
+            cfg.auth,
+            CloudAuth::AnacondaApiKey { token } if token == "tok-key"
+        ));
+    }
+
+    #[test]
+    fn dev_kind_requires_user_label() {
+        // With the user label: builds a Dev auth.
+        let cfg = build_cloud_config(
+            &args(CloudAuthKind::Dev),
+            env_from(&[(CLOUD_TOKEN_ENV, "tok-dev"), (CLOUD_DEV_USER_ENV, "alice")]),
+        )
+        .expect("build");
+        assert!(matches!(
+            cfg.auth,
+            CloudAuth::Dev { token, user } if token == "tok-dev" && user == "alice"
+        ));
+
+        // Without it: a clear error rather than a bogus actor downstream.
+        let err = build_cloud_config(
+            &args(CloudAuthKind::Dev),
+            env_from(&[(CLOUD_TOKEN_ENV, "tok-dev")]),
+        )
+        .expect_err("must require user");
+        assert!(err.to_string().contains(CLOUD_DEV_USER_ENV));
+    }
+
+    #[test]
+    fn missing_token_is_an_error_naming_the_env_var() {
+        let err = build_cloud_config(&args(CloudAuthKind::Oidc), env_from(&[]))
+            .expect_err("must require token");
+        assert!(err.to_string().contains(CLOUD_TOKEN_ENV));
+    }
+
+    #[test]
+    fn blank_or_whitespace_token_is_rejected() {
+        let err = build_cloud_config(
+            &args(CloudAuthKind::Oidc),
+            env_from(&[(CLOUD_TOKEN_ENV, "   ")]),
+        )
+        .expect_err("whitespace token must be rejected");
+        assert!(err.to_string().contains(CLOUD_TOKEN_ENV));
+    }
+
+    #[test]
+    fn token_is_trimmed() {
+        let cfg = build_cloud_config(
+            &args(CloudAuthKind::Oidc),
+            env_from(&[(CLOUD_TOKEN_ENV, "  tok-trim\n")]),
+        )
+        .expect("build");
+        assert!(matches!(
+            cfg.auth,
+            CloudAuth::OidcBearer { token } if token == "tok-trim"
+        ));
+    }
+}

--- a/crates/runtimed/src/workstation/environments.rs
+++ b/crates/runtimed/src/workstation/environments.rs
@@ -1,0 +1,184 @@
+//! `list_environments`: what compute this workstation can offer.
+//!
+//! A projection over the daemon's existing pool state, **not** a new enumerator
+//! (decision 39). `PoolDoc::read_state()` already publishes available/warming/
+//! health per env kind (synced to peers over `PoolStateSync`); this maps that to
+//! a stable [`WorkstationEnvironment`] list the endpoint — and, later, the
+//! hosted workstation-target API or the Content-rail catalog — can render.
+//!
+//! Kept as a pure function over [`PoolState`] ([`environments_from_pool_state`])
+//! plus a thin daemon-facing wrapper ([`list_environments`]), so the projection
+//! is unit-testable without a live daemon.
+
+use notebook_doc::pool_state::{PoolState, RuntimePoolState};
+use serde::{Deserialize, Serialize};
+
+/// The environment backend a workstation environment is drawn from.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum EnvKind {
+    Uv,
+    Conda,
+    Pixi,
+}
+
+impl EnvKind {
+    fn as_str(self) -> &'static str {
+        match self {
+            EnvKind::Uv => "uv",
+            EnvKind::Conda => "conda",
+            EnvKind::Pixi => "pixi",
+        }
+    }
+}
+
+/// How nteract should treat the environment for execution, per the ADR's
+/// `environment_policy` (Decision 5). Prewarmed pool envs are daemon-built and
+/// reproducible, so they are `ManagedProject`. The other variants exist so a
+/// provider adapter (Outerbounds current Python, JupyterHub kernelspec) can
+/// project its own envs through the same shape later.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum EnvironmentPolicy {
+    CurrentPython,
+    Kernelspec,
+    ManagedProject,
+    Unknown,
+}
+
+/// One environment a workstation can allocate a runtime in.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct WorkstationEnvironment {
+    /// Stable selector for `allocate_runtime_for_room` (e.g. `pool:uv`).
+    pub id: String,
+    /// The backend (uv/conda/pixi).
+    pub kind: EnvKind,
+    /// Number of prewarmed instances ready to take immediately.
+    pub available: u64,
+    /// Number currently being prepared.
+    pub warming: u64,
+    /// Execution-treatment policy for the target.
+    pub environment_policy: EnvironmentPolicy,
+    /// Human-readable health note, `None` when the pool is healthy. Carried
+    /// straight through from [`RuntimePoolState::error`] so a workstation can
+    /// surface "uv pool failing: <pkg>" instead of silently offering a broken
+    /// target.
+    pub health: Option<String>,
+}
+
+/// Project a single pool kind into a workstation environment, if that kind
+/// offers anything. A kind with nothing available, nothing warming, a zero
+/// target, and no error is omitted (`None`) — the daemon simply isn't offering
+/// that backend. A kind reporting an *error* is included even at zero
+/// availability so the condition is visible rather than hidden.
+fn environment_for_kind(kind: EnvKind, state: &RuntimePoolState) -> Option<WorkstationEnvironment> {
+    let offers_nothing =
+        state.available == 0 && state.warming == 0 && state.pool_size == 0 && state.error.is_none();
+    if offers_nothing {
+        return None;
+    }
+    Some(WorkstationEnvironment {
+        id: format!("pool:{}", kind.as_str()),
+        kind,
+        available: state.available,
+        warming: state.warming,
+        // Prewarmed pools are daemon-built reproducible environments.
+        environment_policy: EnvironmentPolicy::ManagedProject,
+        health: state.error.clone(),
+    })
+}
+
+/// Pure projection of a [`PoolState`] snapshot into the workstation environment
+/// list. Order is stable (uv, conda, pixi).
+pub fn environments_from_pool_state(state: &PoolState) -> Vec<WorkstationEnvironment> {
+    [
+        environment_for_kind(EnvKind::Uv, &state.uv),
+        environment_for_kind(EnvKind::Conda, &state.conda),
+        environment_for_kind(EnvKind::Pixi, &state.pixi),
+    ]
+    .into_iter()
+    .flatten()
+    .collect()
+}
+
+/// List the environments this daemon can offer, by projecting the live
+/// daemon-authoritative pool doc. Reuses the existing pool state; does not
+/// re-walk disk or re-inspect pools (decision 39).
+pub async fn list_environments(daemon: &crate::daemon::Daemon) -> Vec<WorkstationEnvironment> {
+    let state = {
+        let doc = daemon.pool_doc.read().await;
+        doc.read_state()
+    };
+    environments_from_pool_state(&state)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn pool(available: u64, warming: u64, pool_size: u64) -> RuntimePoolState {
+        RuntimePoolState {
+            available,
+            warming,
+            pool_size,
+            ..Default::default()
+        }
+    }
+
+    #[test]
+    fn projects_each_nonempty_kind_in_stable_order() {
+        let state = PoolState {
+            uv: pool(3, 1, 4),
+            conda: pool(0, 2, 2),
+            pixi: pool(0, 0, 0),
+        };
+        let envs = environments_from_pool_state(&state);
+        // uv (offering) + conda (warming) ; pixi omitted (offers nothing).
+        assert_eq!(envs.len(), 2);
+        assert_eq!(envs[0].id, "pool:uv");
+        assert_eq!(envs[0].kind, EnvKind::Uv);
+        assert_eq!(envs[0].available, 3);
+        assert_eq!(envs[0].warming, 1);
+        assert_eq!(
+            envs[0].environment_policy,
+            EnvironmentPolicy::ManagedProject
+        );
+        assert!(envs[0].health.is_none());
+        assert_eq!(envs[1].id, "pool:conda");
+        assert_eq!(envs[1].available, 0);
+        assert_eq!(envs[1].warming, 2);
+    }
+
+    #[test]
+    fn empty_pool_state_offers_nothing() {
+        let envs = environments_from_pool_state(&PoolState::default());
+        assert!(envs.is_empty());
+    }
+
+    #[test]
+    fn unhealthy_kind_is_surfaced_even_at_zero_availability() {
+        let mut uv = pool(0, 0, 0);
+        uv.error = Some("uv pool failing: numpy".into());
+        uv.error_kind = Some("invalid_package".into());
+        let state = PoolState {
+            uv,
+            ..Default::default()
+        };
+        let envs = environments_from_pool_state(&state);
+        assert_eq!(envs.len(), 1, "an erroring pool must be visible");
+        assert_eq!(envs[0].id, "pool:uv");
+        assert_eq!(envs[0].health.as_deref(), Some("uv pool failing: numpy"));
+    }
+
+    #[test]
+    fn a_kind_with_only_a_target_is_offered() {
+        // pool_size > 0 but nothing ready yet (cold start): still an offer.
+        let state = PoolState {
+            uv: pool(0, 0, 2),
+            ..Default::default()
+        };
+        let envs = environments_from_pool_state(&state);
+        assert_eq!(envs.len(), 1);
+        assert_eq!(envs[0].available, 0);
+    }
+}

--- a/crates/runtimed/src/workstation/launch_on_attach.rs
+++ b/crates/runtimed/src/workstation/launch_on_attach.rs
@@ -1,0 +1,154 @@
+//! Launch-on-attach: let a cloud runtime agent *start* a kernel right after it
+//! attaches, without waiting for an inbound `LaunchKernel` RPC.
+//!
+//! Why this exists (decision 38): the agent's steady state waits for an inbound
+//! `RuntimeAgentRequest::LaunchKernel` before starting a kernel
+//! (`runtime_agent.rs`). Over the daemon UDS that frame comes from the daemon.
+//! Over the cloud transport it must come from the room — and that inbound
+//! channel is req #5, **Deferred** (needs the 3d worker + a live room). So a
+//! cloud agent spawned today *attaches but is never told to launch*. The ADR
+//! says the workstation endpoint *allocates **and starts*** a runtime in env X;
+//! launch-on-attach is how "start" happens headlessly while req #5 is deferred:
+//! resolve env X up front and hand the agent an *initial* launch request it
+//! applies after bootstrap.
+//!
+//! This module builds that initial request for the ADR's first-class
+//! `current_python` environment policy (Decision 5): launch the kernel against
+//! an explicit interpreter the connector already has, with no daemon-managed env
+//! pool, package mutation disabled, and the target labelled as current Python.
+//! The builder is pure and unit-tested; the actual kernel launch (and the live
+//! attach) is the deferred proof.
+
+use std::collections::HashMap;
+use std::path::PathBuf;
+
+use notebook_protocol::connection::EnvSource;
+use notebook_protocol::protocol::{KernelPorts, LaunchedEnvConfig, RuntimeAgentRequest};
+
+/// Inputs for a `current_python` launch-on-attach request.
+#[derive(Debug, Clone)]
+pub struct CurrentPythonLaunch {
+    /// The Python interpreter to launch the kernel with (the connector's /
+    /// provider workspace's current Python). Required — `current_python` means
+    /// "use the interpreter you already have", so there is no pool fallback.
+    pub python_path: PathBuf,
+    /// Notebook path, if the room maps to a file on the workstation.
+    pub notebook_path: Option<String>,
+    /// Extra environment variables for the kernel process.
+    pub env_vars: HashMap<String, String>,
+}
+
+/// The wire env-source label for a current-Python launch.
+///
+/// `current_python` is not one of the daemon's pool/inline/project sources, so
+/// it has no canonical [`EnvSource`] variant; it round-trips through
+/// `EnvSource::Unknown` (which `package_manager()` maps to the UV family by its
+/// `uv:` prefix, the historical default — and crucially *not* to a pool take).
+pub const CURRENT_PYTHON_ENV_SOURCE: &str = "uv:current_python";
+
+/// Build the initial `LaunchKernel` request for a current-Python target.
+///
+/// Package mutation stays disabled (no inline/pool deps in the config), matching
+/// the ADR: "package-management controls stay disabled unless the provider
+/// adapter explicitly advertises safe package mutation."
+pub fn build_current_python_launch(
+    launch: &CurrentPythonLaunch,
+    kernel_ports: KernelPorts,
+) -> RuntimeAgentRequest {
+    let launched_config = LaunchedEnvConfig {
+        // No pool env, no inline deps: the kernel runs against python_path as-is.
+        python_path: Some(launch.python_path.clone()),
+        ..Default::default()
+    };
+
+    RuntimeAgentRequest::LaunchKernel {
+        kernel_type: "python".to_string(),
+        env_source: EnvSource::parse(CURRENT_PYTHON_ENV_SOURCE),
+        notebook_path: launch.notebook_path.clone(),
+        launched_config,
+        kernel_ports,
+        env_vars: launch.env_vars.clone(),
+        // current_python does not redact (no daemon-managed secret env overlay).
+        redact_env_values_in_outputs: false,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use notebook_protocol::connection::PackageManager;
+
+    fn ports() -> KernelPorts {
+        KernelPorts {
+            stdin: 9000,
+            control: 9001,
+            hb: 9002,
+            shell: 9003,
+            iopub: 9004,
+        }
+    }
+
+    fn launch() -> CurrentPythonLaunch {
+        CurrentPythonLaunch {
+            python_path: PathBuf::from("/opt/ws/venv/bin/python"),
+            notebook_path: Some("/home/ws/analysis.ipynb".into()),
+            env_vars: HashMap::from([("FOO".to_string(), "bar".to_string())]),
+        }
+    }
+
+    #[test]
+    fn builds_python_launch_against_explicit_interpreter() {
+        let req = build_current_python_launch(&launch(), ports());
+        let RuntimeAgentRequest::LaunchKernel {
+            kernel_type,
+            env_source,
+            notebook_path,
+            launched_config,
+            kernel_ports,
+            env_vars,
+            redact_env_values_in_outputs,
+        } = req
+        else {
+            panic!("expected LaunchKernel");
+        };
+        assert_eq!(kernel_type, "python");
+        assert_eq!(env_source.as_str(), CURRENT_PYTHON_ENV_SOURCE);
+        assert_eq!(notebook_path.as_deref(), Some("/home/ws/analysis.ipynb"));
+        assert_eq!(
+            launched_config.python_path,
+            Some(PathBuf::from("/opt/ws/venv/bin/python"))
+        );
+        assert_eq!(kernel_ports.iopub, 9004);
+        assert_eq!(env_vars.get("FOO").map(String::as_str), Some("bar"));
+        assert!(!redact_env_values_in_outputs);
+    }
+
+    #[test]
+    fn carries_no_pool_or_inline_deps() {
+        // current_python must not drag in a pool take or inline build: the
+        // config has only the explicit interpreter, no venv_path / deps.
+        let req = build_current_python_launch(&launch(), ports());
+        let RuntimeAgentRequest::LaunchKernel {
+            launched_config, ..
+        } = req
+        else {
+            panic!("expected LaunchKernel");
+        };
+        assert!(launched_config.venv_path.is_none());
+        assert!(launched_config.uv_deps.is_none());
+        assert!(launched_config.conda_deps.is_none());
+        assert!(launched_config.pixi_deps.is_none());
+        assert!(launched_config.prewarmed_packages.is_empty());
+    }
+
+    #[test]
+    fn env_source_label_routes_to_uv_family_not_a_pool_take() {
+        // The Unknown("uv:current_python") label maps to the UV package-manager
+        // family by prefix (historical default) but is NOT EnvSource::Prewarmed,
+        // so the agent's launch path won't try to claim a pooled env for it.
+        let src = EnvSource::parse(CURRENT_PYTHON_ENV_SOURCE);
+        assert!(matches!(src, EnvSource::Unknown(_)));
+        assert!(!matches!(src, EnvSource::Prewarmed(_)));
+        assert_eq!(src.package_manager(), Some(PackageManager::Uv));
+    }
+}

--- a/crates/runtimed/src/workstation/mod.rs
+++ b/crates/runtimed/src/workstation/mod.rs
@@ -19,5 +19,10 @@
 //! pieces are headless-buildable vs. deferred to a live preview deploy.
 
 pub mod cloud_agent_cli;
+pub mod environments;
 
 pub use cloud_agent_cli::{build_cloud_config, CloudAgentArgs, CloudAuthKind};
+pub use environments::{
+    environments_from_pool_state, list_environments, EnvKind, EnvironmentPolicy,
+    WorkstationEnvironment,
+};

--- a/crates/runtimed/src/workstation/mod.rs
+++ b/crates/runtimed/src/workstation/mod.rs
@@ -20,9 +20,13 @@
 
 pub mod cloud_agent_cli;
 pub mod environments;
+pub mod launch_on_attach;
 
 pub use cloud_agent_cli::{build_cloud_config, CloudAgentArgs, CloudAuthKind};
 pub use environments::{
     environments_from_pool_state, list_environments, EnvKind, EnvironmentPolicy,
     WorkstationEnvironment,
+};
+pub use launch_on_attach::{
+    build_current_python_launch, CurrentPythonLaunch, CURRENT_PYTHON_ENV_SOURCE,
 };

--- a/crates/runtimed/src/workstation/mod.rs
+++ b/crates/runtimed/src/workstation/mod.rs
@@ -1,0 +1,23 @@
+//! Workstation endpoint: the daemon-side capability to offer compute to a
+//! hosted cloud room.
+//!
+//! A *workstation* (the product noun from
+//! `docs/adr/remote-workstation-doc-agents.md`) is an endpoint you pick compute
+//! from. It does two things:
+//!
+//! 1. **lists the environments it has** ([`list_environments`], a projection over
+//!    the daemon's existing [`pool_state`](notebook_doc::pool_state) — not a new
+//!    enumerator), and
+//! 2. on demand, **allocates and starts a runtime in env X for room Y**, driving
+//!    [`run_cloud_runtime_agent`](crate::runtime_agent::run_cloud_runtime_agent)
+//!    as the attach mechanism.
+//!
+//! This module is the daemon-side half. It is additive and gated behind the
+//! cloud transport; the desktop/UDS path is unaffected.
+//!
+//! See `docs/handoffs/16-workstation-endpoint.md` for the full scope and which
+//! pieces are headless-buildable vs. deferred to a live preview deploy.
+
+pub mod cloud_agent_cli;
+
+pub use cloud_agent_cli::{build_cloud_config, CloudAgentArgs, CloudAuthKind};

--- a/docs/handoffs/16-decisions-log.md
+++ b/docs/handoffs/16-decisions-log.md
@@ -519,3 +519,57 @@ half (`last_seen`), and 3f req #6 (writer-error recovery) are done. Remaining:
   `RuntimeAgentRequest`s to the cloud agent via the 3d DurableObject hosted REQUEST
   dispatch. req #6 (don't tear the kernel down on a writer error) is DONE
   (decisions #34–#35); req #5's trigger path needs the worker + a live room.
+
+## Workstation endpoint (the second half of #16): scoping
+
+The first half (transport-agnostic `runtime_agent` + `run_cloud_runtime_agent`)
+is merged (#3426). This is the daemon-side **workstation endpoint**: list the
+environments it has, and allocate/start a runtime in env X for room Y, driving
+`run_cloud_runtime_agent`. Full scope: `docs/handoffs/16-workstation-endpoint.md`.
+
+38. **Endpoint "start a runtime" is designed as launch-on-attach (option A), not
+    wait-for-req-#5 (option B).** The cloud agent attaches as a `runtime_peer` and
+    then *waits for an inbound `RuntimeAgentRequest::LaunchKernel`* before it starts
+    a kernel (`runtime_agent.rs:1082`). Over the daemon UDS that frame comes from the
+    daemon; over the cloud transport it must come from the room — and that inbound
+    channel is req #5, **Deferred** (needs the 3d worker + a live room, decision 34).
+    So a cloud agent spawned today *attaches but is never told to launch*. The ADR
+    says the endpoint *allocates **and starts*** a runtime in env X. The only way to
+    honor "start" headlessly while req #5 is deferred is to resolve env X up front
+    (reusing the launcher) and hand the agent an *initial* `KernelLaunchConfig` it
+    applies right after bootstrap. Alternative (B, attach-only until req #5) was
+    rejected as not meeting "start" and leaving the endpoint un-demonstrable
+    headlessly. Why still safe: land launch-on-attach as a separate gated commit
+    *after* the lower-risk CLI + list-environments pieces, mirroring the
+    decision-22 recoverable-transport gate so the UDS/desktop path is byte-for-byte
+    unchanged. Until it lands, the CLI subcommand attaches only.
+
+39. **list-environments is a projection over the existing `PoolDoc`, not a new
+    enumerator.** `PoolDoc::read_state()` (`pool_state.rs:248`) already publishes
+    available/warming/health per env kind (synced to peers over PoolStateSync). The
+    endpoint maps that to a `WorkstationEnvironment` list. Alternative: a fresh disk
+    walk / pool inspection — rejected, it would duplicate `update_pool_doc`
+    (`daemon.rs:5423`) and drift from the authoritative state. Captured/inline named
+    envs (the `runt env list` cache-dir enumeration, `runt/src/main.rs:4126`) are a
+    second, optional projection behind the same `WorkstationEnvironment` shape so it
+    can later back both the workstation-target API and the Content-rail catalog
+    (ADR decision 8).
+
+40. **The missing invocable caller for `run_cloud_runtime_agent` is closed with a
+    hidden `runtimed cloud-runtime-agent` subcommand**, mirroring the internal
+    `runtime-agent` subcommand (`main.rs:126`). Auth token comes from the
+    environment (`RUNT_CLOUD_TOKEN` + an auth-kind selector), never argv — the ADR
+    security constraint ("never put API keys in URLs/argv for the long-running
+    process"). Alternative: a `runt` (user-facing) subcommand — deferred; the first
+    need is an internal/automation entry the control plane and the deferred live
+    proof drive, matching how `runtime-agent` is shaped.
+
+41. **Deferred (workstation endpoint): the live attach re-proof.** Spawning
+    `runtimed cloud-runtime-agent` against a real preview room (with the
+    `runtime_peer` ACL row, decision 9) and confirming a cell runs on the
+    daemon-managed kernel and renders in the viewer needs staging creds + a deployed
+    worker this autonomous session does not have. Exact run steps are in
+    `16-workstation-endpoint.md` ("Deferred — needs us"). Not attempted headlessly.
+    The hosted-side pieces (workstation registry D1 + routes, doc-agent control
+    channel, room target-selection APIs) are Worker build items (ADR sequence
+    3–9), out of scope for this daemon-side headless slice.

--- a/docs/handoffs/16-workstation-endpoint.md
+++ b/docs/handoffs/16-workstation-endpoint.md
@@ -1,0 +1,254 @@
+# Workstation endpoint on the daemon (#16, second half)
+
+**Status:** Draft / scoping, 2026-06-06. Branch `quod/16-workstation-endpoint`.
+
+This is the second half of #16. The first half — making `runtime_agent`
+transport-agnostic, with `run_cloud_runtime_agent` as the cloud-attach path — is
+merged (#3426, Phases 1–3f). This half builds the **workstation endpoint**: the
+daemon capability + small control surface that *lists the environments it has*
+and, on demand, *allocates and starts a runtime in env X for room Y*, driving
+`run_cloud_runtime_agent` as the attach mechanism.
+
+Read first: `docs/adr/remote-workstation-doc-agents.md` ("Production shape"),
+`docs/handoffs/16-decisions-log.md`, `docs/handoffs/16-lifecycle-analysis.md`.
+
+## The shape the ADR asks for
+
+> A workstation is an endpoint you pick compute from: it *lists the environments
+> it has* and, on demand, *allocates and starts a runtime in env X for room Y*.
+> That is a daemon capability plus a small control surface (the "receiver"),
+> built on the existing env pool + launcher, not a reimplementation.
+> `run_cloud_runtime_agent` is the attach mechanism the endpoint drives.
+
+So the endpoint has two operations:
+
+1. **list-environments** — what compute this daemon can offer.
+2. **allocate-runtime-for-room** — pick env X, attach a runtime to cloud room Y.
+
+Both must reuse, not reimplement, the existing env pool and launcher.
+
+## Existing machinery this builds on (file:line)
+
+### Env pool + environment listing
+
+- `runtimed_client::PooledEnv` / `EnvType` (`crates/runtimed-client/src/lib.rs:92,112`)
+  — the in-memory "an environment" representation (`Uv|Conda|Pixi`, venv path,
+  python path, prewarmed packages).
+- `Daemon` holds `uv_pool` / `conda_pool` / `pixi_pool: Mutex<Pool>`
+  (`crates/runtimed/src/daemon.rs:1097-1099`) and a daemon-authoritative
+  `pool_doc: Arc<RwLock<PoolDoc>>` (`:1110`).
+- `PoolState` / `RuntimePoolState` (`crates/notebook-doc/src/pool_state.rs:42,67`)
+  — per-kind snapshot (available/warming/pool_size/health), read via
+  `PoolDoc::read_state()` (`:248`). This is the **already-published** "what
+  environments are ready" surface, synced to peers over `PoolStateSync` (0x06).
+- `Daemon::update_pool_doc` (`crates/runtimed/src/daemon.rs:5423`) recomputes it
+  from each pool's `stats()`.
+- Cached/captured envs on disk: enumerated by `runt env list`
+  (`crates/runt/src/main.rs:4126`) over `get_env_cache_dirs()` (`:4044`) — UV,
+  Conda, Pixi, inline-envs, tools. Captured-env metadata helpers live in
+  `crates/runtimed/src/notebook_sync_server/metadata.rs:1594+`
+  (`captured_env_for_runtime`, `captured_env_disk_state`).
+
+**Reuse:** list-environments is a *projection* over `PoolDoc::read_state()` (the
+prewarmed pools, with health) plus optionally the cache-dir enumeration (named
+captured/inline envs). No new pool, no new disk walk semantics.
+
+### The launcher / env resolution
+
+- Entry: `requests/launch_kernel.rs::handle` (`crates/runtimed/src/requests/launch_kernel.rs:43`).
+  Resolves kernel type + `env_source` (auto-detect project files → captured env →
+  inline deps → PEP 723 → prewarmed pool), acquires/builds the env, then assembles
+  a `LaunchedEnvConfig` (`build_launched_config`, around `:1487`) and spawns the
+  agent.
+- Pool acquisition: `Daemon::take_uv_env` / `take_conda_env`
+  (`crates/runtimed/src/daemon.rs:3397,3488`) → `(PooledEnv, PoolLeaseGuard)`.
+- Agent subprocess spawn: `RuntimeAgentHandle::spawn`
+  (`crates/runtimed/src/runtime_agent_handle.rs:44`) execs
+  `runtimed runtime-agent --notebook-id … --runtime-agent-id … --blob-root … --socket …`
+  in its own process group, with orphan-reaping manifest.
+- The agent then receives `RuntimeAgentRequest::LaunchKernel { kernel_type,
+  env_source, launched_config, env_vars }` over its transport
+  (`runtime_agent.rs:1082`) and launches the kernel via `KernelLaunchConfig`.
+
+**Reuse:** "allocate a runtime in env X" is the same env-resolution +
+`LaunchedEnvConfig` assembly, but the *transport* the agent attaches over is the
+cloud WS (`run_cloud_runtime_agent`), not the daemon UDS.
+
+### The cloud attach path
+
+- `run_cloud_runtime_agent(config: CloudWsConfig, operator: String, blob_root)`
+  (`crates/runtimed/src/runtime_agent.rs:150`). Builds a
+  `notebook_cloud_transport::CloudWsFrameTransport` and funnels into the shared
+  `run_runtime_agent_on_transport`. Resolves the doc-actor label *after* connect
+  from `transport.principal()` (the room's `cloud_room_ready` principal).
+- `CloudWsConfig { cloud_url, notebook_id, scope, auth: CloudAuth }`
+  (`crates/notebook-cloud-transport/src/lib.rs:127`). `CloudAuth` =
+  `OidcBearer | AnacondaApiKey | Dev { token, user }` (`:78`). Optional
+  `TokenRefresher` for long-lived re-auth (`:117`).
+- **It has no non-test caller today** (decision 31, deferred-3c): nothing on a
+  CLI/daemon path invokes it. That is the first gap to close.
+
+### Daemon control surfaces (where a new endpoint fits)
+
+- Notebook RPC: `NotebookRequest` enum
+  (`crates/notebook-protocol/src/protocol.rs:474`), dispatched in
+  `requests/mod.rs::handle_notebook_request` (`crates/runtimed/src/requests/mod.rs:156`),
+  per-request handler modules under `requests/`.
+- Kernel RPC: `RuntimeAgentRequest` (`protocol.rs:822`).
+- CLI: `runtimed` subcommands in `crates/runtimed/src/main.rs:50` (incl. the
+  hidden internal `runtime-agent` at `:126`); `runt` subcommands in
+  `crates/runt/src/main.rs:90`.
+- Frame types incl. `SessionControl` (0x07) in `crates/notebook-wire/src/lib.rs`.
+
+## The crux that bounds headless scope
+
+The cloud agent attaches as a `runtime_peer` and then **waits for an inbound
+`RuntimeAgentRequest::LaunchKernel`** to actually start a kernel
+(`runtime_agent.rs:1082`). Over the daemon UDS that frame comes from the daemon.
+Over the **cloud** transport it must come from the room — and that inbound
+request channel is **req #5, Deferred** (it needs the 3d DurableObject hosted
+REQUEST dispatch + a live room; decision 34). So a cloud agent spawned today
+*attaches but is never told to launch a kernel*.
+
+Two ways to make the endpoint genuinely *start* a runtime in env X:
+
+- **(A) launch-on-attach.** The endpoint resolves env X up front (reusing the
+  launcher) and hands the agent an *initial* `KernelLaunchConfig` it applies
+  right after bootstrap, instead of waiting for an RPC. This makes
+  "allocate and start in env X" real over the cloud transport **without** req #5,
+  and it is headless-testable (config assembly + the apply-on-bootstrap branch).
+- **(B) wait for req #5.** Endpoint only *attaches*; the launch trigger arrives
+  later over the (not-yet-built) inbound channel.
+
+**Decision (see log, decision 38):** design for (A) as the endpoint's
+"start a runtime" semantics — the ADR says *allocate **and start***, and (A) is
+the only way to honor "start" headlessly while req #5 is deferred. But land it as
+a clearly-separated, gated, well-tested commit *after* the two lower-risk pieces
+(CLI wiring + list-environments), because it touches the load-bearing agent loop.
+Until (A) lands, the CLI subcommand attaches only (kernel launch deferred), which
+is still the missing invocable caller `run_cloud_runtime_agent` needs.
+
+## Proposed surface
+
+A new daemon module `crates/runtimed/src/workstation/` (sibling to `requests/`),
+plus one CLI subcommand. Kept additive and gated; the desktop/UDS path is
+untouched.
+
+### 1. `list_environments` (headless-buildable, unit-testable)
+
+```rust
+/// One environment a workstation can offer compute from.
+pub struct WorkstationEnvironment {
+    pub id: String,                 // stable selector, e.g. "pool:uv", "captured:<hash>"
+    pub kind: EnvKind,              // Uv | Conda | Pixi
+    pub source: EnvironmentSource,  // Prewarmed { available, warming } | Captured { path, .. }
+    pub environment_policy: EnvironmentPolicy, // current_python | kernelspec | managed_project | unknown
+    pub health: Option<String>,     // from RuntimePoolState.error / error_kind
+}
+
+pub fn list_environments(daemon: &Daemon) -> Vec<WorkstationEnvironment>;
+```
+
+- Prewarmed entries come straight from `daemon.pool_doc.read().read_state()`
+  (`PoolState` → one `WorkstationEnvironment` per non-empty kind, carrying
+  `available`/`warming`/health).
+- Captured/inline entries (optional, second commit) project the cache-dir
+  enumeration. Kept behind the same shape so it can later back both the
+  workstation-target API and the Content-rail catalog (ADR decision 8).
+- Pure read; no mutation; trivially unit-testable with a seeded `PoolDoc`.
+
+### 2. CLI: `runtimed cloud-runtime-agent` (headless-buildable, unit-testable)
+
+The invocable caller `run_cloud_runtime_agent` is missing (decision 31). Add a
+hidden/internal subcommand mirroring `runtime-agent`:
+
+```
+runtimed cloud-runtime-agent \
+  --cloud-url https://preview.runt.run \
+  --notebook-id <id> \
+  --scope runtime_peer \
+  --operator agent:runt \
+  --blob-root <path>
+# auth from env: RUNT_CLOUD_TOKEN (+ RUNT_CLOUD_AUTH_KIND = oidc|anaconda-key|dev,
+#   RUNT_CLOUD_DEV_USER for dev) — never on argv (ADR security constraint).
+```
+
+It builds `CloudWsConfig` + `CloudAuth` from flags/env and calls
+`run_cloud_runtime_agent`. The arg→config mapping (incl. auth-kind selection and
+the "token never on argv" rule) is pure and unit-tested. This is the concrete
+"receiver" entry an external control plane (or the deferred live proof) drives.
+
+### 3. `allocate_runtime_for_room` (env-selection + spawn wiring)
+
+```rust
+pub struct RoomTarget { pub cloud_url: String, pub notebook_id: String,
+                        pub scope: String, pub operator: String }
+
+/// Resolve env `env_id` via the existing launcher, then attach a cloud runtime
+/// to room Y. With launch-on-attach (commit C) it also starts the kernel in
+/// that env; without it, it attaches only (launch deferred to req #5).
+pub async fn allocate_runtime_for_room(
+    daemon: &Arc<Daemon>, env_id: &str, target: RoomTarget, auth: CloudAuth,
+) -> Result<...>;
+```
+
+Env resolution reuses the `launch_kernel` env path (extract the
+`env_source → LaunchedEnvConfig` step; do not duplicate pool acquisition). The
+spawn reuses `run_cloud_runtime_agent`. Behind the transport gate.
+
+## Headless-buildable vs Deferred
+
+**Headless-buildable now (Phase B):**
+
+- `list_environments` + `WorkstationEnvironment` (pool projection). Unit-tested.
+- `runtimed cloud-runtime-agent` CLI: arg/env → `CloudWsConfig`/`CloudAuth`.
+  Unit-tested. Makes `run_cloud_runtime_agent` invocable.
+- launch-on-attach (commit C): the agent applies an initial `KernelLaunchConfig`
+  after bootstrap on a recoverable transport. Unit-tested; gated; UDS unchanged.
+- `allocate_runtime_for_room`: env selection + spawn wiring. Unit-tested with a
+  seeded daemon/pool; the *attach itself* is not exercised (no live room).
+
+**Deferred — needs us (live verification / infra we do not have):**
+
+- **Live attach re-proof.** Spawn `runtimed cloud-runtime-agent` against a real
+  preview room with the explicit `runtime_peer` ACL row (decision 9), confirm a
+  cloud-submitted (or launch-on-attach) cell runs on the daemon-managed kernel and
+  renders in the viewer. Requires staging creds + a deployed worker. **Do not
+  attempt headlessly.** Exact steps to run: (1) deploy/choose a preview room;
+  (2) `POST /api/n/:id/acl {subject_kind:"principal", subject:<principal>,
+  scope:"runtime_peer"}`; (3) `RUNT_CLOUD_TOKEN=… runtimed cloud-runtime-agent
+  --cloud-url … --notebook-id … --scope runtime_peer --operator agent:runt`;
+  (4) run a cell, confirm output in the viewer; (5) exercise the 3b
+  token-refresher against an expiring token.
+- **req #5 inbound request channel** (interrupt/restart/launch over cloud) —
+  needs the 3d worker + live room. If launch-on-attach (A) lands, the *first*
+  launch no longer needs req #5, but interrupt/restart still do.
+- **The doc-agent control channel** (`WS /api/workstations/:id/control`), the
+  hosted **workstation registry** (D1 tables, `POST /api/workstations/register`),
+  and **room target selection** (`/api/n/:id/workstation-target*`) — these are
+  Worker/hosted-side build items (ADR implementation sequence steps 3–9), not
+  daemon-side, and out of scope for this headless slice.
+
+## Test plan (headless)
+
+- `list_environments`: seed a `PoolDoc` with known uv/conda/pixi state → assert
+  the projected `WorkstationEnvironment` list (counts, kinds, health passthrough,
+  empty-kind omission).
+- CLI config: each auth-kind flag/env combo → expected `CloudAuth` variant;
+  missing token → error; token never appears in the built argv.
+- launch-on-attach: the apply-on-bootstrap branch fires only on a recoverable
+  transport and is a no-op on UDS (mirror the decision-22 gate); unit-test the
+  discriminant + that the UDS path is byte-for-byte unchanged.
+- Full `cargo test -p runtimed` stays green (UDS path unchanged); clippy `-D
+  warnings`; `cargo xtask lint --fix`.
+
+## PR stacking
+
+One branch + draft PR per coherent chunk, each with a STATUS section:
+
+1. `cloud-runtime-agent` CLI + arg/config tests (closes the missing-caller gap).
+2. `list_environments` + `WorkstationEnvironment`.
+3. launch-on-attach in the agent loop (gated, tested).
+4. `allocate_runtime_for_room` glue.
+
+Stacked on `main`. Keep the decision log + each STATUS current.


### PR DESCRIPTION
## STATUS — Phase B3: launch-on-attach (headless, complete)

Stacked on #3429 (B2 list_environments). This is the keystone that lets the
workstation endpoint **start** a runtime, not just attach.

### The problem
The agent's steady state waits for an inbound `RuntimeAgentRequest::LaunchKernel`
before starting a kernel. Over the daemon UDS that comes from the daemon; over
the **cloud** transport it must come from the room — and that inbound channel is
**req #5, Deferred** (needs the 3d worker + a live room). So a cloud agent spawned
today *attaches but is never told to launch*. The ADR says the endpoint
*allocates **and starts*** a runtime in env X (decision 38).

### What's here
- `workstation::launch_on_attach::build_current_python_launch` — builds an
  initial `LaunchKernel` for the ADR's first-class `current_python` policy
  (Decision 5): an explicit interpreter, **no** daemon env pool, package mutation
  disabled, labelled as current Python. Pure + unit-tested.
- `run_cloud_runtime_agent` / `run_runtime_agent_on_transport` gain an optional
  `initial_launch`, applied once after bootstrap through the **same**
  `handle_runtime_agent_request` path an inbound RPC uses (identical kernel drive,
  queue release, command-receiver install — only the trigger differs).

### Safety
The apply is gated on `clean_eof_is_recoverable()` — the recoverable/cloud
discriminant (same gate as decisions 22/35). The UDS/daemon path passes `None`
and would ignore a `Some` regardless, so it is **byte-for-byte unchanged**. The
bare cloud CLI entry passes `None` (attach-only); the launch trigger is wired by
`allocate_runtime_for_room` (B4).

### Tests
4 new lib tests (3 builder: explicit interpreter, no pool/inline deps leak,
env-source label routes to uv family but not Prewarmed; 1 gate discriminant).
`runtimed --lib` 909 green; integration 51 green; `tokio_mutex_lint` +
`tokio_select_cancel_safe` green; clippy `-D warnings` clean; `lint --fix` clean.

### Deferred — needs us
The live kernel launch + attach against a real preview room (staging creds +
deployed worker + `runtime_peer` ACL row). Steps in
`docs/handoffs/16-workstation-endpoint.md`.
