### PR TITLE
fix(notebook): preserve editor view on in-place execute

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7589,6 +7589,7 @@ dependencies = [
  "loro_fractional_index",
  "nbformat",
  "nix 0.31.2",
+ "notebook-cloud-transport",
  "notebook-doc",
  "notebook-protocol",
  "notebook-sync",

--- a/apps/notebook/src/components/CodeCell.tsx
+++ b/apps/notebook/src/components/CodeCell.tsx
@@ -73,6 +73,8 @@ interface CodeCellProps {
   onToggleSourceHidden?: (hidden: boolean) => void;
   /** Callback to toggle outputs visibility (JupyterLab convention) */
   onToggleOutputsHidden?: (hidden: boolean) => void;
+  /** Executes without moving focus to another cell or following the notebook tail. */
+  onExecuteInPlace?: () => void;
   /** Number of consecutive fully-hidden cells in this group (including this one) */
   hiddenGroupCount?: number;
   /** Callback to expand all cells in a hidden group */
@@ -328,6 +330,7 @@ export const CodeCell = memo(function CodeCell({
   isDragging,
   onToggleSourceHidden,
   onToggleOutputsHidden,
+  onExecuteInPlace,
   hiddenGroupCount,
   onExpandHiddenGroup,
   hiddenGroupCellIds,
@@ -468,6 +471,13 @@ export const CodeCell = memo(function CodeCell({
     onExecute();
   }, [canExecute, onExecute]);
 
+  const handleExecuteInPlace = useCallback(() => {
+    if (!canExecute) {
+      return;
+    }
+    (onExecuteInPlace ?? onExecute)();
+  }, [canExecute, onExecute, onExecuteInPlace]);
+
   const handleHiddenDisclosureKeyDown = useCallback(
     (event: React.KeyboardEvent) => {
       if (
@@ -495,6 +505,7 @@ export const CodeCell = memo(function CodeCell({
     onFocusPrevious: onFocusPrevious ?? (() => {}),
     onFocusNext: handleFocusNextOrCreate,
     onExecute: canExecute ? handleExecute : undefined,
+    onExecuteInPlace: canExecute ? handleExecuteInPlace : undefined,
     onExecuteAndInsert:
       canExecute && onInsertCellAfter
         ? () => {

--- a/apps/notebook/src/components/NotebookView.tsx
+++ b/apps/notebook/src/components/NotebookView.tsx
@@ -625,6 +625,17 @@ function NotebookViewContent({
     return () => window.cancelAnimationFrame(frame);
   }, [focusCell, hiddenGroups, materializeVersion, outputStructureVersion]);
 
+  const cancelTailScrollFrame = useCallback(() => {
+    if (tailScrollFrameRef.current === null) return;
+    window.cancelAnimationFrame(tailScrollFrameRef.current);
+    tailScrollFrameRef.current = null;
+  }, []);
+
+  const suppressTailFollowForInPlaceExecution = useCallback(() => {
+    tailPinnedRef.current = false;
+    cancelTailScrollFrame();
+  }, [cancelTailScrollFrame]);
+
   // Prevent horizontal scroll drift (can happen during text selection) and
   // remember whether the user is already reading at the notebook tail.
   useEffect(() => {
@@ -686,12 +697,9 @@ function NotebookViewContent({
 
   useEffect(() => {
     return () => {
-      if (tailScrollFrameRef.current !== null) {
-        window.cancelAnimationFrame(tailScrollFrameRef.current);
-        tailScrollFrameRef.current = null;
-      }
+      cancelTailScrollFrame();
     };
-  }, []);
+  }, [cancelTailScrollFrame]);
 
   // If outputs or trailing cells arrive while the user is already at the
   // notebook tail, keep the tail anchored so last-cell outputs do not grow
@@ -845,6 +853,10 @@ function NotebookViewContent({
             onExecuteCell(cell.id);
           }
         };
+        const executeCellInPlaceOrHiddenGroup = () => {
+          suppressTailFollowForInPlaceExecution();
+          executeCellOrHiddenGroup();
+        };
 
         return (
           <CodeCell
@@ -863,6 +875,7 @@ function NotebookViewContent({
             outputDimmed={outputFocusedCellId !== null && outputFocusedCellId !== cell.id}
             onOutputFocusChange={(focused) => handleOutputFocusChange(cell.id, focused)}
             onExecute={executeCellOrHiddenGroup}
+            onExecuteInPlace={executeCellInPlaceOrHiddenGroup}
             onInterrupt={onInterruptKernel}
             onDelete={canMutateCells ? () => onDeleteCell(cell.id) : undefined}
             onFocusPrevious={onFocusPrevious}
@@ -976,6 +989,7 @@ function NotebookViewContent({
     [
       runtime,
       focusInteractionTarget,
+      suppressTailFollowForInPlaceExecution,
       onExecuteCell,
       onInterruptKernel,
       onDeleteCell,

--- a/apps/notebook/src/components/__tests__/notebook-view-capabilities-source.test.ts
+++ b/apps/notebook/src/components/__tests__/notebook-view-capabilities-source.test.ts
@@ -55,6 +55,19 @@ describe("NotebookView shell capabilities", () => {
     );
   });
 
+  it("routes in-place code execution away from tail-follow scrolling", () => {
+    const sourceText = readFileSync(
+      join(process.cwd(), "apps/notebook/src/components/NotebookView.tsx"),
+      "utf8",
+    );
+
+    expect(sourceText).toMatch(
+      /const suppressTailFollowForInPlaceExecution = useCallback\(\(\) => \{[\s\S]*tailPinnedRef\.current = false;[\s\S]*cancelTailScrollFrame\(\);[\s\S]*\},/,
+    );
+    expect(sourceText).toMatch(/onExecute=\{executeCellOrHiddenGroup\}/);
+    expect(sourceText).toMatch(/onExecuteInPlace=\{executeCellInPlaceOrHiddenGroup\}/);
+  });
+
   it("does not create cells from a transient empty sync state", () => {
     const sourceText = readFileSync(
       join(process.cwd(), "apps/notebook/src/components/NotebookView.tsx"),

--- a/apps/notebook/src/hooks/__tests__/useCellKeyboardNavigation.test.ts
+++ b/apps/notebook/src/hooks/__tests__/useCellKeyboardNavigation.test.ts
@@ -1,0 +1,70 @@
+// @vitest-environment jsdom
+import { renderHook } from "@testing-library/react";
+import type { EditorView, KeyBinding } from "@codemirror/view";
+import { describe, expect, it, vi } from "vite-plus/test";
+import { useCellKeyboardNavigation } from "../useCellKeyboardNavigation";
+
+function bindingFor(bindings: KeyBinding[], key: string): KeyBinding {
+  const binding = bindings.find((candidate) => candidate.key === key);
+  expect(binding).toBeDefined();
+  return binding!;
+}
+
+describe("useCellKeyboardNavigation", () => {
+  it("routes Shift-Enter through execute and then focuses the next cell", () => {
+    const onExecute = vi.fn();
+    const onFocusNext = vi.fn();
+
+    const { result } = renderHook(() =>
+      useCellKeyboardNavigation({
+        onFocusPrevious: vi.fn(),
+        onFocusNext,
+        onExecute,
+      }),
+    );
+
+    expect(bindingFor(result.current, "Shift-Enter").run({} as EditorView)).toBe(true);
+
+    expect(onExecute).toHaveBeenCalledTimes(1);
+    expect(onFocusNext).toHaveBeenCalledWith("start");
+  });
+
+  it("routes Ctrl-Enter and Mod-Enter through in-place execute when provided", () => {
+    const onExecute = vi.fn();
+    const onExecuteInPlace = vi.fn();
+    const onFocusNext = vi.fn();
+
+    const { result } = renderHook(() =>
+      useCellKeyboardNavigation({
+        onFocusPrevious: vi.fn(),
+        onFocusNext,
+        onExecute,
+        onExecuteInPlace,
+      }),
+    );
+
+    expect(bindingFor(result.current, "Ctrl-Enter").run({} as EditorView)).toBe(true);
+    expect(bindingFor(result.current, "Mod-Enter").run({} as EditorView)).toBe(true);
+
+    expect(onExecuteInPlace).toHaveBeenCalledTimes(2);
+    expect(onExecute).not.toHaveBeenCalled();
+    expect(onFocusNext).not.toHaveBeenCalled();
+  });
+
+  it("falls back to execute for in-place keys when no in-place callback exists", () => {
+    const onExecute = vi.fn();
+
+    const { result } = renderHook(() =>
+      useCellKeyboardNavigation({
+        onFocusPrevious: vi.fn(),
+        onFocusNext: vi.fn(),
+        onExecute,
+      }),
+    );
+
+    expect(bindingFor(result.current, "Ctrl-Enter").run({} as EditorView)).toBe(true);
+    expect(bindingFor(result.current, "Mod-Enter").run({} as EditorView)).toBe(true);
+
+    expect(onExecute).toHaveBeenCalledTimes(2);
+  });
+});

--- a/apps/notebook/src/hooks/useCellKeyboardNavigation.ts
+++ b/apps/notebook/src/hooks/useCellKeyboardNavigation.ts
@@ -6,6 +6,7 @@ interface UseCellKeyboardNavigationOptions {
   onFocusPrevious: (cursorPosition: "start" | "end") => void;
   onFocusNext: (cursorPosition: "start" | "end") => void;
   onExecute?: () => void;
+  onExecuteInPlace?: () => void;
   onExecuteAndInsert?: () => void;
   onDelete?: () => void;
   /** Cell ID for debug logging */
@@ -24,6 +25,7 @@ export function useCellKeyboardNavigation({
   onFocusPrevious,
   onFocusNext,
   onExecute,
+  onExecuteInPlace,
   onExecuteAndInsert,
   onDelete,
   cellId,
@@ -32,6 +34,7 @@ export function useCellKeyboardNavigation({
   const onFocusPreviousRef = useRef(onFocusPrevious);
   const onFocusNextRef = useRef(onFocusNext);
   const onExecuteRef = useRef(onExecute);
+  const onExecuteInPlaceRef = useRef(onExecuteInPlace);
   const onExecuteAndInsertRef = useRef(onExecuteAndInsert);
   const onDeleteRef = useRef(onDelete);
   const cellIdRef = useRef(cellId);
@@ -40,6 +43,7 @@ export function useCellKeyboardNavigation({
   onFocusPreviousRef.current = onFocusPrevious;
   onFocusNextRef.current = onFocusNext;
   onExecuteRef.current = onExecute;
+  onExecuteInPlaceRef.current = onExecuteInPlace;
   onExecuteAndInsertRef.current = onExecuteAndInsert;
   onDeleteRef.current = onDelete;
   cellIdRef.current = cellId;
@@ -107,14 +111,14 @@ export function useCellKeyboardNavigation({
             {
               key: "Mod-Enter",
               run: () => {
-                onExecuteRef.current?.();
+                (onExecuteInPlaceRef.current ?? onExecuteRef.current)?.();
                 return true;
               },
             },
             {
               key: "Ctrl-Enter",
               run: () => {
-                onExecuteRef.current?.();
+                (onExecuteInPlaceRef.current ?? onExecuteRef.current)?.();
                 return true;
               },
             },
@@ -133,6 +137,6 @@ export function useCellKeyboardNavigation({
         : []),
     ],
     // Only recreate if the presence of optional callbacks changes
-    [!!onExecute, !!onExecuteAndInsert, !!onDelete],
+    [!!onExecute, !!onExecuteInPlace, !!onExecuteAndInsert, !!onDelete],
   );
 }


### PR DESCRIPTION
## Summary

- split Ctrl/Mod-Enter into an explicit in-place execution path
- suppress pending tail-follow scrolling before in-place execution so final-cell output growth keeps the editor visible
- add focused keyboard-routing and NotebookView scroll-path regression coverage

Closes #3424

## Verification

- `pnpm test:run apps/notebook/src/hooks/__tests__/useCellKeyboardNavigation.test.ts apps/notebook/src/components/__tests__/notebook-view-capabilities-source.test.ts`
- `cargo xtask lint --fix`
