### PR TITLE
fix(notebook): hide read-only cell affordances

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7589,6 +7589,7 @@ dependencies = [
  "loro_fractional_index",
  "nbformat",
  "nix 0.31.2",
+ "notebook-cloud-transport",
  "notebook-doc",
  "notebook-protocol",
  "notebook-sync",

--- a/apps/notebook/src/components/CodeCell.tsx
+++ b/apps/notebook/src/components/CodeCell.tsx
@@ -388,6 +388,8 @@ export const CodeCell = memo(function CodeCell({
   // Fully collapsed when source is hidden AND there's nothing else to show
   // (outputs explicitly hidden, or no outputs at all).
   const bothHidden = isSourceHidden && (isOutputsHidden || outputs.length === 0);
+  const canRevealHiddenContent = !readOnly;
+  const visibleOutputCount = isOutputsHidden ? 0 : outputs.length;
 
   // Auto-clear expand/focus when the cell has no visible outputs to
   // operate on. Previously also gated on `!hasIsolatedOutput`, which made
@@ -595,14 +597,19 @@ export const CodeCell = memo(function CodeCell({
     [onNavigateToCell],
   );
 
-  const hasCurrentLine =
-    !isSourceEmpty ||
-    outputs.length > 0 ||
+  const hasExecutionReadout =
     executionCount !== null ||
     isExecuting ||
     isQueued ||
+    isGroupExecuting ||
     isExecutionErrored ||
-    isSourceHidden;
+    submittedByActorLabel !== null;
+  const showExecutionControl = canExecute || hasExecutionReadout;
+  const hasCurrentLine =
+    !isSourceEmpty ||
+    visibleOutputCount > 0 ||
+    hasExecutionReadout ||
+    (isSourceHidden && canRevealHiddenContent);
   const currentLine = hasCurrentLine ? (
     <CodeCellCurrentLine
       languageLabel={languageLabel}
@@ -617,6 +624,10 @@ export const CodeCell = memo(function CodeCell({
     />
   ) : null;
 
+  if (readOnly && bothHidden && !hasExecutionReadout) {
+    return null;
+  }
+
   return (
     <>
       <CellContainer
@@ -629,103 +640,99 @@ export const CodeCell = memo(function CodeCell({
         outputDimmed={outputDimmed}
         onFocus={onFocus}
         gutterContent={
-          <CompactExecutionButton
-            count={executionCount}
-            isExecuting={isExecuting || isGroupExecuting}
-            isQueued={isQueued}
-            isErrored={isExecutionErrored}
-            submittedByActorLabel={submittedByActorLabel}
-            isCellFocused={isFocused}
-            canExecute={canExecute}
-            onExecute={handleExecute}
-            onInterrupt={onInterrupt}
-            className={cn(
-              bothHidden &&
-                !isFocused &&
-                !isExecuting &&
-                !isGroupExecuting &&
-                !isQueued &&
-                !isExecutionErrored &&
-                "opacity-0 group-hover:opacity-70",
-            )}
-          />
+          showExecutionControl ? (
+            <CompactExecutionButton
+              count={executionCount}
+              isExecuting={isExecuting || isGroupExecuting}
+              isQueued={isQueued}
+              isErrored={isExecutionErrored}
+              submittedByActorLabel={submittedByActorLabel}
+              isCellFocused={isFocused}
+              canExecute={canExecute}
+              onExecute={handleExecute}
+              onInterrupt={onInterrupt}
+              className={cn(
+                bothHidden &&
+                  !isFocused &&
+                  !isExecuting &&
+                  !isGroupExecuting &&
+                  !isQueued &&
+                  !isExecutionErrored &&
+                  "opacity-0 group-hover:opacity-70",
+              )}
+            />
+          ) : null
         }
         rightGutterContent={rightGutterContent}
-        stateLaneClassName={isSourceHidden ? "pt-2 sm:pt-2" : undefined}
+        stateLaneClassName={isSourceHidden && canRevealHiddenContent ? "pt-2 sm:pt-2" : undefined}
         dragHandleProps={dragHandleProps}
         isDragging={isDragging}
         codeContent={
           <>
             {/* Source visibility toggle + Editor */}
             {bothHidden ? (
-              <div className="mt-0.5" onKeyDown={handleHiddenDisclosureKeyDown}>
-                {hiddenGroupCount && hiddenGroupCount > 1 ? (
-                  <HiddenGroupDisclosure
-                    count={hiddenGroupCount}
-                    items={hiddenGroupItems ?? []}
-                    disabled={readOnly}
-                    pulsing={isExecuting || isGroupExecuting}
-                    onRevealAll={() => {
-                      if (readOnly) return;
-                      if (onExpandHiddenGroup) {
-                        onExpandHiddenGroup();
-                      } else {
+              canRevealHiddenContent ? (
+                <div className="mt-0.5" onKeyDown={handleHiddenDisclosureKeyDown}>
+                  {hiddenGroupCount && hiddenGroupCount > 1 ? (
+                    <HiddenGroupDisclosure
+                      count={hiddenGroupCount}
+                      items={hiddenGroupItems ?? []}
+                      pulsing={isExecuting || isGroupExecuting}
+                      onRevealAll={() => {
+                        if (onExpandHiddenGroup) {
+                          onExpandHiddenGroup();
+                        } else {
+                          onToggleSourceHidden?.(false);
+                          onToggleOutputsHidden?.(false);
+                        }
+                      }}
+                      onRevealCell={onExpandHiddenGroupCell}
+                      alert={
+                        hiddenGroupErrorCount
+                          ? hiddenGroupErrorCount === 1
+                            ? "1 error"
+                            : `${hiddenGroupErrorCount} errors`
+                          : undefined
+                      }
+                    />
+                  ) : (
+                    <HiddenCellDisclosure
+                      icon={Code2}
+                      pulsing={isExecuting || isGroupExecuting}
+                      onClick={() => {
                         onToggleSourceHidden?.(false);
                         onToggleOutputsHidden?.(false);
+                      }}
+                      title="Show cell"
+                      label="Cell hidden"
+                      focusTarget
+                      alert={
+                        hiddenGroupErrorCount
+                          ? hiddenGroupErrorCount === 1
+                            ? "1 error"
+                            : `${hiddenGroupErrorCount} errors`
+                          : undefined
                       }
-                    }}
-                    onRevealCell={
-                      onExpandHiddenGroupCell
-                        ? (cellId) => {
-                            if (readOnly) return;
-                            onExpandHiddenGroupCell(cellId);
-                          }
-                        : undefined
-                    }
-                    alert={
-                      hiddenGroupErrorCount
-                        ? hiddenGroupErrorCount === 1
-                          ? "1 error"
-                          : `${hiddenGroupErrorCount} errors`
-                        : undefined
-                    }
-                  />
-                ) : (
-                  <HiddenCellDisclosure
-                    icon={Code2}
-                    disabled={readOnly}
-                    pulsing={isExecuting || isGroupExecuting}
-                    onClick={() => {
-                      if (readOnly) return;
-                      onToggleSourceHidden?.(false);
-                      onToggleOutputsHidden?.(false);
-                    }}
-                    title="Show cell"
-                    label="Cell hidden"
-                    focusTarget
-                    alert={
-                      hiddenGroupErrorCount
-                        ? hiddenGroupErrorCount === 1
-                          ? "1 error"
-                          : `${hiddenGroupErrorCount} errors`
-                        : undefined
-                    }
-                  />
-                )}
-              </div>
+                    />
+                  )}
+                </div>
+              ) : (
+                currentLine
+              )
             ) : isSourceHidden ? (
               <>
-                <div className="mt-0.5" onKeyDown={handleHiddenDisclosureKeyDown}>
-                  <HiddenCellDisclosure
-                    icon={Code2}
-                    disabled={readOnly}
-                    onClick={() => onToggleSourceHidden?.(false)}
-                    title="Show input"
-                    label="Input hidden"
-                    detail={sourcePreview}
-                    focusTarget
-                  />
-                </div>
+                {canRevealHiddenContent ? (
+                  <div className="mt-0.5" onKeyDown={handleHiddenDisclosureKeyDown}>
+                    <HiddenCellDisclosure
+                      icon={Code2}
+                      onClick={() => onToggleSourceHidden?.(false)}
+                      title="Show input"
+                      label="Input hidden"
+                      detail={sourcePreview}
+                      focusTarget
+                    />
+                  </div>
+                ) : null}
                 {currentLine}
               </>
             ) : (
@@ -747,16 +754,17 @@ export const CodeCell = memo(function CodeCell({
         }
         outputContent={
           isOutputsHidden && outputs.length > 0 ? (
-            <div className={cn("mt-0.5", cellOutputInnerInset)}>
-              <HiddenCellDisclosure
-                icon={Eye}
-                disabled={readOnly}
-                onClick={() => onToggleOutputsHidden?.(false)}
-                title="Show outputs"
-                label={outputs.length === 1 ? "Output hidden" : "Outputs hidden"}
-                detail={outputs.length > 1 ? `${outputs.length} outputs` : undefined}
-              />
-            </div>
+            canRevealHiddenContent ? (
+              <div className={cn("mt-0.5", cellOutputInnerInset)}>
+                <HiddenCellDisclosure
+                  icon={Eye}
+                  onClick={() => onToggleOutputsHidden?.(false)}
+                  title="Show outputs"
+                  label={outputs.length === 1 ? "Output hidden" : "Outputs hidden"}
+                  detail={outputs.length > 1 ? `${outputs.length} outputs` : undefined}
+                />
+              </div>
+            ) : null
           ) : (
             <OutputArea
               outputs={outputs}
@@ -792,7 +800,7 @@ export const CodeCell = memo(function CodeCell({
             </button>
           ) : undefined
         }
-        hideOutput={outputs.length === 0 || bothHidden}
+        hideOutput={outputs.length === 0 || bothHidden || (readOnly && isOutputsHidden)}
       />
 
       {/* History Search Dialog (Ctrl+R) */}

--- a/apps/notebook/src/components/NotebookView.tsx
+++ b/apps/notebook/src/components/NotebookView.tsx
@@ -804,31 +804,37 @@ function NotebookViewContent({
           (cell.metadata?.jupyter as { outputs_hidden?: boolean })?.outputs_hidden === true;
         const bothHidden = isSourceHidden && isOutputsHidden;
         const hasSourceText = cell.source.trim().length > 0;
-
-        rightGutterContent = (
-          <div className="flex flex-col gap-0.5">
-            {canMutateCells &&
-              onSetCellSourceHidden &&
-              !bothHidden &&
-              (hasSourceText || isSourceHidden) && (
-                <button
-                  type="button"
-                  tabIndex={-1}
-                  onClick={() => onSetCellSourceHidden(cell.id, !isSourceHidden)}
-                  className={cn(
-                    "flex items-center justify-center rounded p-1 transition-colors hover:text-foreground",
-                    isSourceHidden ? "text-muted-foreground/70" : "text-muted-foreground/40",
-                  )}
-                  title={isSourceHidden ? "Show input" : "Hide input"}
-                >
-                  <Code2 className="h-3.5 w-3.5" />
-                </button>
+        const sourceToggleButton =
+          canMutateCells &&
+          onSetCellSourceHidden &&
+          !bothHidden &&
+          (hasSourceText || isSourceHidden) ? (
+            <button
+              type="button"
+              tabIndex={-1}
+              onClick={() => onSetCellSourceHidden(cell.id, !isSourceHidden)}
+              className={cn(
+                "flex items-center justify-center rounded p-1 transition-colors hover:text-foreground",
+                isSourceHidden ? "text-muted-foreground/70" : "text-muted-foreground/40",
               )}
-            {!isSourceHidden && deleteButton}
-          </div>
-        );
+              title={isSourceHidden ? "Show input" : "Hide input"}
+            >
+              <Code2 className="h-3.5 w-3.5" />
+            </button>
+          ) : null;
+        const visibleDeleteButton = !isSourceHidden ? deleteButton : null;
+
+        rightGutterContent =
+          sourceToggleButton || visibleDeleteButton ? (
+            <div className="flex flex-col gap-0.5">
+              {sourceToggleButton}
+              {visibleDeleteButton}
+            </div>
+          ) : undefined;
       } else {
-        rightGutterContent = <div className="flex flex-col gap-0.5">{deleteButton}</div>;
+        rightGutterContent = deleteButton ? (
+          <div className="flex flex-col gap-0.5">{deleteButton}</div>
+        ) : undefined;
       }
 
       if (cell.cell_type === "code") {

--- a/apps/notebook/src/components/__tests__/code-cell-output-focus.test.tsx
+++ b/apps/notebook/src/components/__tests__/code-cell-output-focus.test.tsx
@@ -25,6 +25,7 @@ vi.mock("@/components/cell/CellContainer", () => ({
     outputRightGutterContent,
     outputFocused,
     outputDimmed,
+    hideOutput,
   }: {
     codeContent?: React.ReactNode;
     gutterContent?: React.ReactNode;
@@ -32,11 +33,12 @@ vi.mock("@/components/cell/CellContainer", () => ({
     outputRightGutterContent?: React.ReactNode;
     outputFocused?: boolean;
     outputDimmed?: boolean;
+    hideOutput?: boolean;
   }) => (
     <div data-output-dimmed={String(outputDimmed)} data-output-focused={String(outputFocused)}>
       {gutterContent}
       {codeContent}
-      {outputContent}
+      {hideOutput ? null : outputContent}
       {outputRightGutterContent}
     </div>
   ),
@@ -491,6 +493,99 @@ describe("CodeCell output focus", () => {
 
     expect(queryByTestId("editor")).toBeNull();
     expect(footer?.textContent?.replace(/\s+/g, "")).toContain("Python/run4");
+  });
+
+  it("hides source reveal affordances in read-only mode while keeping visible outputs", () => {
+    mockOutputs = [
+      {
+        output_type: "stream",
+        name: "stdout",
+        text: "visible output\n",
+      },
+    ];
+
+    const { getByTestId, queryByTitle } = render(
+      <CodeCell
+        cell={makeCell({ metadata: { jupyter: { source_hidden: true } } })}
+        readOnly
+        onFocus={() => {}}
+        onExecute={() => {}}
+        onInterrupt={() => {}}
+        onToggleSourceHidden={() => {}}
+      />,
+    );
+
+    expect(queryByTitle("Show input")).toBeNull();
+    expect(getByTestId("output")).toBeTruthy();
+  });
+
+  it("hides output reveal affordances and the output row in read-only mode", () => {
+    mockOutputs = [
+      {
+        output_type: "stream",
+        name: "stdout",
+        text: "hidden output\n",
+      },
+    ];
+
+    const { queryByTestId, queryByTitle } = render(
+      <CodeCell
+        cell={makeCell({ metadata: { jupyter: { outputs_hidden: true } } })}
+        readOnly
+        onFocus={() => {}}
+        onExecute={() => {}}
+        onInterrupt={() => {}}
+        onToggleOutputsHidden={() => {}}
+      />,
+    );
+
+    expect(queryByTitle("Show outputs")).toBeNull();
+    expect(queryByTestId("output")).toBeNull();
+  });
+
+  it("omits fully hidden read-only cells when there is no runtime state to show", () => {
+    mockOutputs = [];
+
+    const { container, queryByTestId, queryByTitle } = render(
+      <CodeCell
+        cell={makeCell({
+          metadata: { jupyter: { source_hidden: true, outputs_hidden: true } },
+        })}
+        readOnly
+        onFocus={() => {}}
+        onExecute={() => {}}
+        onInterrupt={() => {}}
+        onToggleSourceHidden={() => {}}
+        onToggleOutputsHidden={() => {}}
+      />,
+    );
+
+    expect(container.firstChild).toBeNull();
+    expect(queryByTitle("Show cell")).toBeNull();
+    expect(queryByTestId("execute-button")).toBeNull();
+  });
+
+  it("keeps runtime readout for fully hidden read-only cells after execution", () => {
+    mockOutputs = [];
+    mockExecution = { execution_count: 8, submitted_by_actor_label: null };
+
+    const { container, queryByTitle } = render(
+      <CodeCell
+        cell={makeCell({
+          metadata: { jupyter: { source_hidden: true, outputs_hidden: true } },
+        })}
+        readOnly
+        onFocus={() => {}}
+        onExecute={() => {}}
+        onInterrupt={() => {}}
+        onToggleSourceHidden={() => {}}
+        onToggleOutputsHidden={() => {}}
+      />,
+    );
+
+    expect(queryByTitle("Show cell")).toBeNull();
+    expect(container.querySelector('[data-slot="code-cell-current-line"]')).not.toBeNull();
+    expect(container.textContent?.replace(/\s+/g, "")).toContain("Python/run8");
   });
 
   it("omits output chrome for short stream output", () => {

--- a/src/components/cell/CellContainer.tsx
+++ b/src/components/cell/CellContainer.tsx
@@ -113,9 +113,10 @@ export const CellContainer = forwardRef<HTMLDivElement, CellContainerProps>(
     const outputRibbonColor = isFocused ? colors.outputRibbon.focused : colors.outputRibbon.default;
     const bgColor = isFocused ? colors.background.focused : undefined;
 
-    // Use segmented ribbon when codeContent is provided
-    const useSegmentedRibbon = codeContent !== undefined;
+    const hasCodeContent =
+      codeContent !== undefined && codeContent !== null && codeContent !== false;
     const hasOutput = outputContent !== undefined && outputContent !== null;
+    const useSegmentedRibbon = codeContent !== undefined || hasOutput;
 
     return (
       <div
@@ -154,32 +155,34 @@ export const CellContainer = forwardRef<HTMLDivElement, CellContainerProps>(
         {useSegmentedRibbon ? (
           <div className="flex min-w-0 flex-1 flex-col">
             {/* Code row - ribbon + content + right gutter */}
-            <div data-slot="cell-code-row" className="relative flex" onMouseDown={onFocus}>
-              <div
-                {...dragHandleProps}
-                data-slot="cell-ribbon"
-                className={cn(
-                  "w-1 transition-colors duration-150",
-                  ribbonColor,
-                  dragHandleProps && "cursor-grab hover:brightness-125 touch-none",
-                  isDragging && "cursor-grabbing",
-                )}
-              />
-              <div
-                data-slot="cell-code-content"
-                className={cn(
-                  "min-w-0 flex-1 pt-1.5",
-                  cellContentColumnInset,
-                  rightGutterContent ? "pr-14" : "pr-3",
-                  hasOutput && !hideOutput ? "pb-1.5" : "pb-3",
-                )}
-              >
-                {codeContent}
+            {hasCodeContent ? (
+              <div data-slot="cell-code-row" className="relative flex" onMouseDown={onFocus}>
+                <div
+                  {...dragHandleProps}
+                  data-slot="cell-ribbon"
+                  className={cn(
+                    "w-1 transition-colors duration-150",
+                    ribbonColor,
+                    dragHandleProps && "cursor-grab hover:brightness-125 touch-none",
+                    isDragging && "cursor-grabbing",
+                  )}
+                />
+                <div
+                  data-slot="cell-code-content"
+                  className={cn(
+                    "min-w-0 flex-1 pt-1.5",
+                    cellContentColumnInset,
+                    rightGutterContent ? "pr-14" : "pr-3",
+                    hasOutput && !hideOutput ? "pb-1.5" : "pb-3",
+                  )}
+                >
+                  {codeContent}
+                </div>
+                <CellActionOverlay dataSlot="cell-action-overlay" visible={isFocused}>
+                  {rightGutterContent}
+                </CellActionOverlay>
               </div>
-              <CellActionOverlay dataSlot="cell-action-overlay" visible={isFocused}>
-                {rightGutterContent}
-              </CellActionOverlay>
-            </div>
+            ) : null}
             {/* Output row - ribbon + content + right gutter
                 onMouseDown sets visual focus (ribbon/bg) without stealing editor focus */}
             {hasOutput && (
@@ -207,6 +210,7 @@ export const CellContainer = forwardRef<HTMLDivElement, CellContainerProps>(
                     // ribbon plus this slab forms a three-sided frame that
                     // reads as active without the card-like ring aesthetic.
                     outputFocused && "border-y border-primary/40 bg-primary/5",
+                    !hasCodeContent && "pt-2",
                   )}
                 >
                   {outputContent}

--- a/src/components/cell/__tests__/CellContainer.test.tsx
+++ b/src/components/cell/__tests__/CellContainer.test.tsx
@@ -55,6 +55,21 @@ describe("CellContainer", () => {
     expect(outputContent).toHaveClass("pr-14");
   });
 
+  it("renders output-only cells without an empty code row", () => {
+    const { container } = render(
+      <CellContainer
+        id="output-only-cell"
+        cellType="code"
+        codeContent={null}
+        outputContent={<div>visible output</div>}
+      />,
+    );
+
+    expect(container.querySelector('[data-slot="cell-code-row"]')).toBeNull();
+    expect(container.querySelector('[data-slot="cell-output-row"]')).not.toBeNull();
+    expect(container).toHaveTextContent("visible output");
+  });
+
   it("keeps right edge controls hidden until hover or focus for unfocused cells", () => {
     const { container } = render(
       <CellContainer


### PR DESCRIPTION
## Summary
- Hide disabled hidden-source/output reveal affordances when notebook cells are read-only.
- Avoid rendering quiet fully hidden read-only cells unless there is runtime state to show.
- Stop reserving empty right-gutter/source-row space when read-only chrome is omitted.

Closes #3425

## Verification
- `cargo xtask lint --fix`
- `pnpm test:run apps/notebook/src/components/__tests__/code-cell-output-focus.test.tsx src/components/cell/__tests__/CellContainer.test.tsx apps/notebook/src/components/__tests__/notebook-view-capabilities-source.test.ts`
- `cargo xtask wasm`
- `pnpm test:run`
- Browser smoke at `http://localhost:5711/` with no console errors
