### PR TITLE
fix(notebook): omit hidden read-only cell chrome

### DIFF
--- a/apps/notebook/src/components/CodeCell.tsx
+++ b/apps/notebook/src/components/CodeCell.tsx
@@ -635,7 +635,7 @@ export const CodeCell = memo(function CodeCell({
     />
   ) : null;
 
-  if (readOnly && bothHidden && !hasExecutionReadout) {
+  if (readOnly && bothHidden) {
     return null;
   }
 

--- a/apps/notebook/src/components/__tests__/code-cell-output-focus.test.tsx
+++ b/apps/notebook/src/components/__tests__/code-cell-output-focus.test.tsx
@@ -565,11 +565,11 @@ describe("CodeCell output focus", () => {
     expect(queryByTestId("execute-button")).toBeNull();
   });
 
-  it("keeps runtime readout for fully hidden read-only cells after execution", () => {
+  it("omits fully hidden read-only cells after execution", () => {
     mockOutputs = [];
     mockExecution = { execution_count: 8, submitted_by_actor_label: null };
 
-    const { container, queryByTitle } = render(
+    const { container, queryByTestId, queryByTitle } = render(
       <CodeCell
         cell={makeCell({
           metadata: { jupyter: { source_hidden: true, outputs_hidden: true } },
@@ -583,9 +583,9 @@ describe("CodeCell output focus", () => {
       />,
     );
 
+    expect(container.firstChild).toBeNull();
     expect(queryByTitle("Show cell")).toBeNull();
-    expect(container.querySelector('[data-slot="code-cell-current-line"]')).not.toBeNull();
-    expect(container.textContent?.replace(/\s+/g, "")).toContain("Python/run8");
+    expect(queryByTestId("execute-button")).toBeNull();
   });
 
   it("omits output chrome for short stream output", () => {

--- a/src/components/cell/ReadOnlyNotebook.tsx
+++ b/src/components/cell/ReadOnlyNotebook.tsx
@@ -18,6 +18,8 @@ export interface ReadOnlyNotebookCellData {
   outputs?: readonly JupyterOutput[];
   executionId?: string | null;
   executionCount?: number | null;
+  sourceHidden?: boolean;
+  outputsHidden?: boolean;
 }
 
 export interface ReadOnlyNotebookProps {
@@ -80,6 +82,8 @@ export function ReadOnlyNotebook({
                 cell.language,
                 cell.executionCount,
                 cell.outputs?.length ?? 0,
+                cell.sourceHidden,
+                cell.outputsHidden,
               ]}
               fallback={(error) =>
                 renderCellError
@@ -94,6 +98,8 @@ export function ReadOnlyNotebook({
                 language={cell.language}
                 outputs={cell.outputs}
                 executionCount={cell.executionCount}
+                sourceHidden={cell.sourceHidden}
+                outputsHidden={cell.outputsHidden}
                 priority={priority}
                 hostContext={hostContext}
                 displayMode={displayMode}

--- a/src/components/cell/ReadOnlyNotebookCell.tsx
+++ b/src/components/cell/ReadOnlyNotebookCell.tsx
@@ -25,6 +25,8 @@ export interface ReadOnlyNotebookCellProps {
   language?: SupportedLanguage | null;
   outputs?: readonly JupyterOutput[];
   executionCount?: number | null;
+  sourceHidden?: boolean;
+  outputsHidden?: boolean;
   priority?: readonly string[];
   hostContext?: NteractEmbedHostContextPatch;
   displayMode?: "notebook" | "report";
@@ -47,6 +49,8 @@ export function ReadOnlyNotebookCell({
   language = "plain",
   outputs = [],
   executionCount = null,
+  sourceHidden = false,
+  outputsHidden = false,
   priority,
   hostContext,
   displayMode = "notebook",
@@ -61,6 +65,11 @@ export function ReadOnlyNotebookCell({
   resolveTracebackExecutionTarget,
   onNavigateToTracebackCell,
 }: ReadOnlyNotebookCellProps) {
+  const isCodeCell = cellType === "code";
+  const shouldHideSource = isCodeCell && sourceHidden;
+  const shouldHideOutputs = isCodeCell && outputsHidden;
+  const fullyHidden = shouldHideSource && (shouldHideOutputs || outputs.length === 0);
+  const showCellSource = showSource && !shouldHideSource;
   const codeContent = useMemo(
     () =>
       renderReadOnlyCellSource({
@@ -75,10 +84,13 @@ export function ReadOnlyNotebookCell({
       }),
     [cellType, hostContext, id, language, lineWrapping, priority, source, sourceClassName],
   );
-  const outputArray = useMemo(() => [...outputs], [outputs]);
+  const outputArray = useMemo(
+    () => (shouldHideOutputs ? [] : [...outputs]),
+    [outputs, shouldHideOutputs],
+  );
 
   const outputContent =
-    outputs.length > 0 ? (
+    outputArray.length > 0 ? (
       <OutputArea
         cellId={id}
         executionCount={executionCount}
@@ -96,8 +108,10 @@ export function ReadOnlyNotebookCell({
       />
     ) : null;
 
+  if (fullyHidden) return null;
+
   if (displayMode === "report") {
-    if (!showSource && !outputContent) return null;
+    if (!showCellSource && !outputContent) return null;
 
     return (
       <article
@@ -107,7 +121,7 @@ export function ReadOnlyNotebookCell({
         data-cell-type={cellType}
         data-slot="read-only-report-cell"
       >
-        {showSource ? (
+        {showCellSource ? (
           <div className="min-w-0" data-slot="read-only-cell-source">
             {codeContent}
           </div>
@@ -125,7 +139,7 @@ export function ReadOnlyNotebookCell({
     <CellContainer
       id={id}
       cellType={cellType}
-      codeContent={showSource ? codeContent : null}
+      codeContent={showCellSource ? codeContent : null}
       outputContent={outputContent}
       gutterContent={cellType === "code" ? <ExecutionCount count={executionCount} /> : null}
       className={className}

--- a/src/components/cell/__tests__/ReadOnlyNotebook.test.tsx
+++ b/src/components/cell/__tests__/ReadOnlyNotebook.test.tsx
@@ -18,12 +18,14 @@ vi.mock("../ReadOnlyNotebookCell", () => ({
     lineWrapping,
     onNavigateToTracebackCell,
     outputClassName,
+    outputsHidden,
     outputs,
     priority,
     resolveTracebackExecutionTarget,
     showSource,
     source,
     sourceClassName,
+    sourceHidden,
   }: {
     cellType: string;
     className?: string;
@@ -36,12 +38,14 @@ vi.mock("../ReadOnlyNotebookCell", () => ({
     lineWrapping?: boolean;
     onNavigateToTracebackCell?: unknown;
     outputClassName?: string;
+    outputsHidden?: boolean;
     outputs?: readonly JupyterOutput[];
     priority?: readonly string[];
     resolveTracebackExecutionTarget?: unknown;
     showSource?: boolean;
     source: string;
     sourceClassName?: string;
+    sourceHidden?: boolean;
   }) => {
     if (id === "throws") {
       throwAttempts.count += 1;
@@ -62,9 +66,11 @@ vi.mock("../ReadOnlyNotebookCell", () => ({
         data-has-traceback-resolver={String(Boolean(resolveTracebackExecutionTarget))}
         data-output-class-name={outputClassName ?? ""}
         data-output-count={outputs?.length ?? 0}
+        data-outputs-hidden={String(outputsHidden)}
         data-priority={priority?.join(",") ?? ""}
         data-show-source={String(showSource)}
         data-source-class-name={sourceClassName ?? ""}
+        data-source-hidden={String(sourceHidden)}
         data-testid="read-only-cell"
       >
         {id}:{source}
@@ -175,6 +181,25 @@ describe("ReadOnlyNotebook", () => {
     );
 
     expect(screen.getByTestId("read-only-cell")).toHaveAttribute("data-line-wrapping", "false");
+  });
+
+  it("passes per-cell hidden metadata to read-only cells", () => {
+    render(
+      <ReadOnlyNotebook
+        cells={[
+          {
+            id: "hidden-code",
+            cellType: "code",
+            source: "setup()",
+            sourceHidden: true,
+            outputsHidden: true,
+          },
+        ]}
+      />,
+    );
+
+    expect(screen.getByTestId("read-only-cell")).toHaveAttribute("data-source-hidden", "true");
+    expect(screen.getByTestId("read-only-cell")).toHaveAttribute("data-outputs-hidden", "true");
   });
 
   it("supports report display mode with local code visibility", () => {

--- a/src/components/cell/__tests__/ReadOnlyNotebookCell.test.tsx
+++ b/src/components/cell/__tests__/ReadOnlyNotebookCell.test.tsx
@@ -252,6 +252,48 @@ describe("ReadOnlyNotebookCell", () => {
     expect(screen.queryByTestId("output-area")).toBeNull();
   });
 
+  it("omits fully hidden code cells without notebook chrome", () => {
+    render(
+      <ReadOnlyNotebookCell
+        id="hidden-code"
+        cellType="code"
+        source="setup()"
+        sourceHidden
+        executionCount={2}
+        outputs={[]}
+      />,
+    );
+
+    expect(document.querySelector('[data-slot="cell-container"]')).toBeNull();
+    expect(document.querySelector('[data-slot="execution-count"]')).toBeNull();
+    expect(screen.queryByTestId("readonly-codemirror")).toBeNull();
+    expect(screen.queryByTestId("output-area")).toBeNull();
+  });
+
+  it("omits fully hidden code cells even when hidden outputs exist", () => {
+    render(
+      <ReadOnlyNotebookCell
+        id="hidden-code-with-output"
+        cellType="code"
+        source="setup()"
+        sourceHidden
+        outputsHidden
+        executionCount={3}
+        outputs={[
+          {
+            output_id: "hidden-code-stdout",
+            output_type: "stream",
+            name: "stdout",
+            text: "hidden\n",
+          },
+        ]}
+      />,
+    );
+
+    expect(document.querySelector('[data-slot="cell-container"]')).toBeNull();
+    expect(screen.queryByTestId("output-area")).toBeNull();
+  });
+
   it("keeps code output props stable across unrelated parent rerenders", () => {
     const outputs: JupyterOutput[] = [
       {

--- a/src/components/notebook/__tests__/view-model.test.ts
+++ b/src/components/notebook/__tests__/view-model.test.ts
@@ -8,6 +8,10 @@ import {
   notebookViewCellsToTracebackTargets,
   type NotebookViewCell,
 } from "../view-model";
+import type { SupportedLanguage } from "@/components/editor/languages";
+
+const resolveTestLanguage = (language: string | null | undefined): SupportedLanguage | null =>
+  (language ?? "plain") as SupportedLanguage;
 
 describe("notebook shell view model", () => {
   it("projects shared notebook view cells into read-only render cells", () => {
@@ -41,7 +45,7 @@ describe("notebook shell view model", () => {
       },
     ];
 
-    expect(notebookViewCellsToReadOnlyCells(cells, (language) => language ?? "plain")).toEqual([
+    expect(notebookViewCellsToReadOnlyCells(cells, resolveTestLanguage)).toEqual([
       {
         id: "code-1",
         cellType: "code",
@@ -87,6 +91,54 @@ describe("notebook shell view model", () => {
     ]);
   });
 
+  it("projects Jupyter hidden metadata into read-only render cells", () => {
+    const cells: NotebookViewCell[] = [
+      {
+        id: "hidden-code",
+        cellType: "code",
+        source: "setup()",
+        language: "python",
+        executionId: null,
+        executionCount: 2,
+        outputs: [],
+        metadata: { jupyter: { source_hidden: true, outputs_hidden: true } },
+      },
+      {
+        id: "visible-markdown",
+        cellType: "markdown",
+        source: "# Visible",
+        language: null,
+        executionId: null,
+        executionCount: null,
+        outputs: [],
+        metadata: { jupyter: { source_hidden: true, outputs_hidden: true } },
+      },
+    ];
+
+    expect(notebookViewCellsToReadOnlyCells(cells, resolveTestLanguage)).toEqual([
+      {
+        id: "hidden-code",
+        cellType: "code",
+        source: "setup()",
+        language: "python",
+        outputs: [],
+        executionId: null,
+        executionCount: 2,
+        sourceHidden: true,
+        outputsHidden: true,
+      },
+      {
+        id: "visible-markdown",
+        cellType: "markdown",
+        source: "# Visible",
+        language: "plain",
+        outputs: [],
+        executionId: null,
+        executionCount: null,
+      },
+    ]);
+  });
+
   it("lets host adapters override outline status labels", () => {
     const outline = notebookViewCellsToOutlineItems(
       [
@@ -127,7 +179,7 @@ describe("notebook shell view model", () => {
     ];
 
     const viewModel = createNotebookViewModel(cells, {
-      resolveLanguage: (language) => language ?? "plain",
+      resolveLanguage: resolveTestLanguage,
     });
 
     expect(viewModel.cells).toBe(cells);

--- a/src/components/notebook/view-model.ts
+++ b/src/components/notebook/view-model.ts
@@ -93,6 +93,8 @@ export function notebookViewCellToReadOnlyCell(
   cell: NotebookViewCell,
   resolveLanguage: NotebookViewLanguageResolver,
 ): ReadOnlyNotebookCellData {
+  const { sourceHidden, outputsHidden } = readOnlyHiddenFlags(cell);
+
   return {
     id: cell.id,
     cellType: cell.cellType,
@@ -101,6 +103,26 @@ export function notebookViewCellToReadOnlyCell(
     outputs: cell.outputs,
     executionId: cell.executionId,
     executionCount: cell.executionCount,
+    ...(sourceHidden ? { sourceHidden } : {}),
+    ...(outputsHidden ? { outputsHidden } : {}),
+  };
+}
+
+function readOnlyHiddenFlags(cell: NotebookViewCell): {
+  sourceHidden: boolean;
+  outputsHidden: boolean;
+} {
+  if (cell.cellType !== "code") {
+    return { sourceHidden: false, outputsHidden: false };
+  }
+
+  const jupyter = cell.metadata?.jupyter as
+    | { source_hidden?: boolean; outputs_hidden?: boolean }
+    | undefined;
+
+  return {
+    sourceHidden: jupyter?.source_hidden === true,
+    outputsHidden: jupyter?.outputs_hidden === true,
   };
 }
 


### PR DESCRIPTION
## Summary

- omit fully hidden read-only code cells instead of leaving execution/status chrome behind
- carry Jupyter `source_hidden` and `outputs_hidden` metadata into the shared read-only notebook renderer
- cover both editable-read-only `CodeCell` and shared `ReadOnlyNotebookCell` behavior with focused tests

## Verification

- `cargo xtask lint --fix`
- `pnpm test:run apps/notebook/src/components/__tests__/code-cell-output-focus.test.tsx src/components/cell/__tests__/ReadOnlyNotebook.test.tsx src/components/cell/__tests__/ReadOnlyNotebookCell.test.tsx src/components/notebook/__tests__/view-model.test.ts`
