### PR TITLE
refactor(notebook): share document toolbar adapter

### DIFF
--- a/apps/notebook-cloud/test/viewer-render-props.test.ts
+++ b/apps/notebook-cloud/test/viewer-render-props.test.ts
@@ -128,23 +128,18 @@ test("cloud viewer routes notebook header controls through the shared shell chro
   const cssPath = new URL("../viewer/index.css", import.meta.url);
   const cssText = readFileSync(cssPath, "utf8");
 
-  assert.match(sourceText, /NotebookCommandToolbar,/);
-  assert.match(sourceText, /NotebookDocumentHeader,/);
-  assert.match(sourceText, /NotebookToolbarFrame,/);
+  assert.match(sourceText, /NotebookDocumentToolbar,/);
+  assert.match(sourceText, /shouldShowNotebookDocumentCommandToolbar,/);
   assert.match(
     sourceText,
-    /const showCloudCommandToolbar =\s+shouldShowCloudNotebookCommandToolbar\(shellCapabilities\) \|\| editAccessPending/,
+    /const showCloudCommandToolbar = shouldShowNotebookDocumentCommandToolbar\(shellCapabilities, \{[\s\S]*reserve: editAccessPending,[\s\S]*\}\)/,
   );
   assert.match(
     sourceText,
-    /<NotebookToolbarFrame className="z-20">[\s\S]*<NotebookDocumentHeader[\s\S]*\{showCloudCommandToolbar \? \([\s\S]*<NotebookCommandToolbar/,
+    /<NotebookDocumentToolbar[\s\S]*frameClassName="z-20"[\s\S]*headerClassName="cloud-room-toolbar"[\s\S]*commandToolbar=\{\{[\s\S]*addAfterCellId: toolbarAddAfterCellId/,
   );
-  assert.match(sourceText, /<NotebookDocumentHeader[\s\S]*capabilities=\{shellCapabilities\}/);
-  assert.match(sourceText, /<NotebookCommandToolbar[\s\S]*capabilities=\{shellCapabilities\}/);
-  assert.match(
-    sourceText,
-    /function shouldShowCloudNotebookCommandToolbar\(capabilities: NotebookShellCapabilities\): boolean \{[\s\S]*capabilities\.canEditStructure[\s\S]*capabilities\.canExecute[\s\S]*capabilities\.canManagePackages/,
-  );
+  assert.match(sourceText, /<NotebookDocumentToolbar[\s\S]*capabilities=\{shellCapabilities\}/);
+  assert.doesNotMatch(sourceText, /function shouldShowCloudNotebookCommandToolbar/);
   assert.doesNotMatch(sourceText, /toolbarClassName="cloud-report-toolbar"/);
   assert.match(sourceText, /sharingControls=\{[\s\S]*<CloudSharingControls/);
   assert.match(sourceText, /from "\.\/sharing-controls"/);

--- a/apps/notebook-cloud/test/viewer-shared-cell-surface.test.ts
+++ b/apps/notebook-cloud/test/viewer-shared-cell-surface.test.ts
@@ -98,7 +98,7 @@ test("cloud command toolbar inserts below the focused cell before falling back t
   );
   assert.match(
     sourceText,
-    /<NotebookCommandToolbar[\s\S]*addAfterCellId=\{toolbarAddAfterCellId\}/,
+    /<NotebookDocumentToolbar[\s\S]*commandToolbar=\{\{[\s\S]*addAfterCellId: toolbarAddAfterCellId/,
   );
 });
 
@@ -265,10 +265,10 @@ test("cloud edit mode chrome renders through the shared shell component", () => 
   assert.match(sourceText, /disabled=\{accessPending\}/);
   assert.match(
     sourceText,
-    /const showCloudCommandToolbar =\s+shouldShowCloudNotebookCommandToolbar\(shellCapabilities\) \|\| editAccessPending/,
+    /const showCloudCommandToolbar = shouldShowNotebookDocumentCommandToolbar\(shellCapabilities, \{[\s\S]*reserve: editAccessPending,[\s\S]*\}\)/,
   );
-  assert.match(sourceText, /\{showCloudCommandToolbar \? \(/);
-  assert.match(sourceText, /addCellControlsDisabled=\{editAccessPending\}/);
+  assert.match(sourceText, /reserveCommandToolbar=\{editAccessPending\}/);
+  assert.match(sourceText, /addCellControlsDisabled: editAccessPending/);
   assert.doesNotMatch(sourceText, /CloudNotebookEditModePlaceholder/);
   assert.doesNotMatch(sourceText, /CloudNotebookCommandToolbarPlaceholder/);
   assert.doesNotMatch(cssText, /cloud-edit-mode-placeholder/);

--- a/apps/notebook-cloud/viewer/index.tsx
+++ b/apps/notebook-cloud/viewer/index.tsx
@@ -24,14 +24,13 @@ import type { NteractEmbedHostContextPatch } from "@/components/isolated/host-co
 import { NotebookNotice } from "@/components/notebook/NotebookNotice";
 import type { NotebookRailPanelId } from "@/components/notebook-rail";
 import {
-  NotebookCommandToolbar,
-  NotebookDocumentHeader,
+  NotebookDocumentToolbar,
   NotebookEditModeButton,
   navigateNotebookOutlineItem,
   NotebookDocumentRail,
   NotebookDocumentShell,
   NotebookPackageSummaryPanel,
-  NotebookToolbarFrame,
+  shouldShowNotebookDocumentCommandToolbar,
   type NotebookEnvironmentManager,
   type NotebookInteractionMode,
   type NotebookInteractionModeProjection,
@@ -1092,57 +1091,55 @@ function NotebookViewer({
     />
   );
 
-  const showCloudCommandToolbar =
-    shouldShowCloudNotebookCommandToolbar(shellCapabilities) || editAccessPending;
+  const showCloudCommandToolbar = shouldShowNotebookDocumentCommandToolbar(shellCapabilities, {
+    reserve: editAccessPending,
+  });
 
   const toolbar = (
-    <NotebookToolbarFrame className="z-20">
-      <NotebookDocumentHeader
-        capabilities={shellCapabilities}
-        className="cloud-room-toolbar"
-        presence={<CloudNotebookTitle />}
-        utilityControls={
-          <CloudPresenceStatus connectionError={connectionError} store={presenceStore} />
-        }
-        authControls={
-          shouldShowCloudHeaderSignIn(authState) ? (
-            <CloudNotebookSignInButton authConfig={authConfig} authState={authState} />
-          ) : null
-        }
-        sharingControls={
-          <CloudSharingControls
-            aclEndpoint={config.aclEndpoint}
-            invitesEndpoint={config.invitesEndpoint}
-            accessRequestsEndpoint={config.accessRequestsEndpoint}
-            authState={authState}
-            publicLink={publicNotebookLink}
-          />
-        }
-        editControls={
-          <CloudNotebookEditModeButton
-            authState={authState}
-            interaction={shellCapabilities.interaction ?? null}
-            accessLevel={shellCapabilities.access.level}
-            accessPending={editAccessPending}
-            onModeChange={setSelectedInteractionMode}
-            onRequestEditAccess={requestCloudEditAccess}
-          />
-        }
-        identityControls={null}
-      />
-      {showCloudCommandToolbar ? (
-        <NotebookCommandToolbar
-          capabilities={shellCapabilities}
-          runtime={toolbarRuntime}
-          environmentManager={toolbarEnvironmentManager}
-          environmentPanelOpen={activeRailPanel === "packages" && !railCollapsed}
-          addCellControlsDisabled={editAccessPending}
-          addAfterCellId={toolbarAddAfterCellId}
-          onAddCell={handleCloudAddCell}
-          onTogglePackages={handleTogglePackagesRail}
+    <NotebookDocumentToolbar
+      capabilities={shellCapabilities}
+      frameClassName="z-20"
+      headerClassName="cloud-room-toolbar"
+      presence={<CloudNotebookTitle />}
+      utilityControls={
+        <CloudPresenceStatus connectionError={connectionError} store={presenceStore} />
+      }
+      authControls={
+        shouldShowCloudHeaderSignIn(authState) ? (
+          <CloudNotebookSignInButton authConfig={authConfig} authState={authState} />
+        ) : null
+      }
+      sharingControls={
+        <CloudSharingControls
+          aclEndpoint={config.aclEndpoint}
+          invitesEndpoint={config.invitesEndpoint}
+          accessRequestsEndpoint={config.accessRequestsEndpoint}
+          authState={authState}
+          publicLink={publicNotebookLink}
         />
-      ) : null}
-    </NotebookToolbarFrame>
+      }
+      editControls={
+        <CloudNotebookEditModeButton
+          authState={authState}
+          interaction={shellCapabilities.interaction ?? null}
+          accessLevel={shellCapabilities.access.level}
+          accessPending={editAccessPending}
+          onModeChange={setSelectedInteractionMode}
+          onRequestEditAccess={requestCloudEditAccess}
+        />
+      }
+      identityControls={null}
+      reserveCommandToolbar={editAccessPending}
+      commandToolbar={{
+        runtime: toolbarRuntime,
+        environmentManager: toolbarEnvironmentManager,
+        environmentPanelOpen: activeRailPanel === "packages" && !railCollapsed,
+        addCellControlsDisabled: editAccessPending,
+        addAfterCellId: toolbarAddAfterCellId,
+        onAddCell: handleCloudAddCell,
+        onTogglePackages: handleTogglePackagesRail,
+      }}
+    />
   );
   const notebookHasReadableSnapshot =
     notebookCellIds.length > 0 ||
@@ -1392,10 +1389,6 @@ function CloudNotebookSignInButton({
       <span>{copy.label}</span>
     </button>
   );
-}
-
-function shouldShowCloudNotebookCommandToolbar(capabilities: NotebookShellCapabilities): boolean {
-  return capabilities.canEditStructure || capabilities.canExecute || capabilities.canManagePackages;
 }
 
 function initialCloudRailCollapsed(): boolean {

--- a/src/components/notebook/NotebookDocumentToolbar.tsx
+++ b/src/components/notebook/NotebookDocumentToolbar.tsx
@@ -1,0 +1,72 @@
+import type { ReactNode } from "react";
+import type { NotebookShellCapabilities } from "./capabilities";
+import { NotebookCommandToolbar, type NotebookCommandToolbarProps } from "./NotebookCommandToolbar";
+import { NotebookDocumentHeader, type NotebookDocumentHeaderProps } from "./NotebookDocumentHeader";
+import { NotebookToolbarFrame } from "./NotebookToolbarFrame";
+
+type NotebookDocumentHeaderSlots = Omit<NotebookDocumentHeaderProps, "capabilities" | "className">;
+
+export interface NotebookDocumentToolbarProps extends NotebookDocumentHeaderSlots {
+  capabilities: NotebookShellCapabilities;
+  frameClassName?: string;
+  headerClassName?: string;
+  commandToolbar?: Omit<NotebookCommandToolbarProps, "capabilities"> | null;
+  reserveCommandToolbar?: boolean;
+  notices?: ReactNode;
+}
+
+export function shouldShowNotebookDocumentCommandToolbar(
+  capabilities: Pick<
+    NotebookShellCapabilities,
+    "canEditStructure" | "canExecute" | "canManagePackages"
+  >,
+  { reserve = false }: { reserve?: boolean } = {},
+): boolean {
+  return (
+    reserve ||
+    capabilities.canEditStructure ||
+    capabilities.canExecute ||
+    capabilities.canManagePackages
+  );
+}
+
+export function NotebookDocumentToolbar({
+  capabilities,
+  frameClassName,
+  headerClassName,
+  commandToolbar,
+  reserveCommandToolbar = false,
+  notices,
+  presence,
+  utilityControls,
+  runtimeControls,
+  codeControls,
+  sharingControls,
+  editControls,
+  authControls,
+  identityControls,
+}: NotebookDocumentToolbarProps) {
+  const showCommandToolbar =
+    Boolean(commandToolbar) &&
+    shouldShowNotebookDocumentCommandToolbar(capabilities, { reserve: reserveCommandToolbar });
+
+  return (
+    <NotebookToolbarFrame className={frameClassName} notices={notices}>
+      <NotebookDocumentHeader
+        capabilities={capabilities}
+        className={headerClassName}
+        presence={presence}
+        utilityControls={utilityControls}
+        runtimeControls={runtimeControls}
+        codeControls={codeControls}
+        sharingControls={sharingControls}
+        editControls={editControls}
+        authControls={authControls}
+        identityControls={identityControls}
+      />
+      {showCommandToolbar ? (
+        <NotebookCommandToolbar capabilities={capabilities} {...commandToolbar} />
+      ) : null}
+    </NotebookToolbarFrame>
+  );
+}

--- a/src/components/notebook/__tests__/NotebookDocumentToolbar.test.tsx
+++ b/src/components/notebook/__tests__/NotebookDocumentToolbar.test.tsx
@@ -1,0 +1,124 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vite-plus/test";
+import {
+  NotebookDocumentToolbar,
+  shouldShowNotebookDocumentCommandToolbar,
+} from "../NotebookDocumentToolbar";
+import type { NotebookShellCapabilities } from "../capabilities";
+
+function capabilities(
+  overrides: Partial<NotebookShellCapabilities> = {},
+): NotebookShellCapabilities {
+  return {
+    canRead: true,
+    canEditMarkdown: false,
+    canEditCells: false,
+    canEditStructure: false,
+    canRequestEdit: false,
+    canExecute: false,
+    canToggleCode: false,
+    canViewPackages: true,
+    canManagePackages: false,
+    canManageSharing: false,
+    access: {
+      level: "viewer",
+      source: "cloud",
+      isPublic: true,
+      actorLabel: "anonymous",
+      identityLabel: null,
+    },
+    auth: {
+      canSignIn: true,
+      canUseAuthenticatedIdentity: false,
+      needsAttention: false,
+    },
+    runtime: {
+      canWriteRuntimeState: false,
+      connected: false,
+      source: "cloud",
+      actorLabel: null,
+      identityLabel: null,
+    },
+    ...overrides,
+  };
+}
+
+describe("NotebookDocumentToolbar", () => {
+  it("renders header slots inside the shared toolbar frame", () => {
+    const { container } = render(
+      <NotebookDocumentToolbar
+        capabilities={capabilities()}
+        frameClassName="test-frame"
+        headerClassName="test-header"
+        presence={<span>2 here now, editing</span>}
+        utilityControls={<button type="button">Status</button>}
+        notices={<p>Syncing</p>}
+      />,
+    );
+
+    expect(container.querySelector("[data-slot='notebook-toolbar-frame']")).toHaveClass(
+      "test-frame",
+    );
+    expect(container.querySelector("[data-slot='notebook-document-header']")).toHaveClass(
+      "test-header",
+    );
+    expect(screen.getByText("2 here now, editing")).toBeVisible();
+    expect(screen.getByRole("button", { name: "Status" })).toBeVisible();
+    expect(screen.getByText("Syncing")).toBeVisible();
+  });
+
+  it("owns shared command-toolbar visibility policy", () => {
+    expect(shouldShowNotebookDocumentCommandToolbar(capabilities())).toBe(false);
+    expect(
+      shouldShowNotebookDocumentCommandToolbar(
+        capabilities({
+          canEditStructure: true,
+        }),
+      ),
+    ).toBe(true);
+    expect(shouldShowNotebookDocumentCommandToolbar(capabilities(), { reserve: true })).toBe(true);
+  });
+
+  it("renders command controls when capabilities or reserved pending state require them", () => {
+    const onAddCell = vi.fn();
+    const { rerender } = render(
+      <NotebookDocumentToolbar
+        capabilities={capabilities()}
+        commandToolbar={{
+          addAfterCellId: "cell-1",
+          onAddCell,
+        }}
+      />,
+    );
+
+    expect(screen.queryByTestId("add-code-cell-button")).toBeNull();
+
+    rerender(
+      <NotebookDocumentToolbar
+        capabilities={capabilities()}
+        reserveCommandToolbar
+        commandToolbar={{
+          addCellControlsDisabled: true,
+          addAfterCellId: "cell-1",
+          onAddCell,
+        }}
+      />,
+    );
+
+    expect(screen.getByTestId("add-code-cell-button")).toBeDisabled();
+
+    rerender(
+      <NotebookDocumentToolbar
+        capabilities={capabilities({
+          canEditStructure: true,
+        })}
+        commandToolbar={{
+          addAfterCellId: "cell-1",
+          onAddCell,
+        }}
+      />,
+    );
+
+    expect(screen.getByTestId("add-code-cell-button")).toBeVisible();
+  });
+});

--- a/src/components/notebook/index.ts
+++ b/src/components/notebook/index.ts
@@ -85,6 +85,11 @@ export {
   type NotebookCommandToolbarUpdateAction,
   type NotebookEnvironmentManager,
 } from "./NotebookCommandToolbar";
+export {
+  NotebookDocumentToolbar,
+  shouldShowNotebookDocumentCommandToolbar,
+  type NotebookDocumentToolbarProps,
+} from "./NotebookDocumentToolbar";
 export { NotebookToolbarFrame, type NotebookToolbarFrameProps } from "./NotebookToolbarFrame";
 export {
   NotebookIdentityBadge,


### PR DESCRIPTION
## Summary

- add a shared `NotebookDocumentToolbar` adapter that composes the toolbar frame, document header, command toolbar, notices, and command-toolbar visibility policy
- route the cloud notebook viewer through that shared adapter instead of composing frame/header/command toolbar locally
- update source-shape coverage and add focused shared-toolbar tests

## Verification

- `cargo xtask lint --fix`
- `pnpm --dir apps/notebook-cloud typecheck`
- `pnpm --dir apps/notebook exec tsc -b --pretty false`
- `pnpm test:run src/components/notebook/__tests__/NotebookDocumentToolbar.test.tsx src/components/notebook/__tests__/NotebookDocumentHeader.test.tsx src/components/notebook/__tests__/NotebookCommandToolbar.test.tsx`
- `pnpm exec node --import tsx --test test/viewer-render-props.test.ts test/viewer-shared-cell-surface.test.ts` from `apps/notebook-cloud`

## Review status

- External `pr-review` completed with `verdict=clear`.
- GitHub CI completed successfully.
