### PR TITLE
chore: ignore generated artifact bundles

### DIFF
--- a/.ignore
+++ b/.ignore
@@ -1,0 +1,8 @@
+# Generated renderer/runtime artifacts. Keep source files searchable; hide the
+# minified bundles and binary snapshots that swamp local code search.
+/apps/notebook/src/renderer-plugins/
+/crates/runt-mcp/assets/plugins/
+/apps/elements/public/wasm/sift_wasm.js
+/apps/elements/public/wasm/sift_wasm_bg.wasm
+/packages/runtimed/tests/fixtures/**/*.bin
+/packages/runtimed/tests/fixtures/**/blobs/

--- a/.rgignore
+++ b/.rgignore
@@ -1,0 +1,8 @@
+# Generated renderer/runtime artifacts. Keep source files searchable; hide the
+# minified bundles and binary snapshots that swamp local code search.
+/apps/notebook/src/renderer-plugins/
+/crates/runt-mcp/assets/plugins/
+/apps/elements/public/wasm/sift_wasm.js
+/apps/elements/public/wasm/sift_wasm_bg.wasm
+/packages/runtimed/tests/fixtures/**/*.bin
+/packages/runtimed/tests/fixtures/**/blobs/


### PR DESCRIPTION
## Summary

- add repo-level `.rgignore` and `.ignore`
- hide generated renderer/runtime bundles and binary fixture payloads from local search
- keep renderer and Sift source files searchable

## Verification

- `rg --files | rg '^(apps/notebook/src/renderer-plugins|crates/runt-mcp/assets/plugins|apps/elements/public/wasm/sift_wasm|packages/runtimed/tests/fixtures/.+\.(bin|arrow))'` exits with no matches
- `cargo xtask lint --fix`
