### PR TITLE
fix(notebook): preserve projection during reconnect bootstrap

### DIFF
--- a/apps/notebook/src/hooks/useAutomergeNotebook.ts
+++ b/apps/notebook/src/hooks/useAutomergeNotebook.ts
@@ -17,6 +17,7 @@ import {
   cellSnapshotsToNotebookCellsSync,
 } from "../lib/materialize-cells";
 import {
+  getCellIdsSnapshot,
   replaceNotebookCells,
   resetNotebookCells,
   updateCellById,
@@ -31,6 +32,10 @@ import { cloneNotebookFile, openNotebookFile, saveNotebook } from "../lib/notebo
 import { setNotebookHandle } from "../lib/notebook-metadata";
 import { resetPoolState } from "../lib/pool-state";
 import { resetRuntimeState, useRuntimeState } from "../lib/runtime-state";
+import {
+  notebookReadyIdentity,
+  shouldPreserveBootstrapProjection,
+} from "../lib/bootstrap-preservation";
 import { startNotebookSyncStoreBridge } from "../lib/notebook-sync-store-bridge";
 import type { JupyterOutput, NotebookCell } from "../types";
 import init, {
@@ -114,6 +119,7 @@ export function useNotebook() {
   const [localActor, setLocalActor] = useState(actorLabelRef.current);
   const [connectionScope, setConnectionScope] = useState<string | null>(null);
   const canWriteNotebookRef = useRef(true);
+  const readyNotebookIdentityRef = useRef<string | null>(null);
 
   const [handleHost] = useState(
     () =>
@@ -307,14 +313,27 @@ export function useNotebook() {
         const connectionScope = trigger.payload.connection_scope ?? null;
         setConnectionScope(connectionScope);
         canWriteNotebookRef.current = scopeAllowsNotebookWrite(connectionScope);
+        const nextNotebookIdentity = notebookReadyIdentity(trigger.payload);
+        const preserveProjection = shouldPreserveBootstrapProjection({
+          previousIdentity: readyNotebookIdentityRef.current,
+          nextIdentity: nextNotebookIdentity,
+          visibleCellCount: getCellIdsSnapshot().length,
+        });
+        readyNotebookIdentityRef.current = nextNotebookIdentity;
         storeBridge.resetReadiness();
         refreshBlobPort();
-        resetNotebookCells();
-        resetRuntimeState();
-        resetRuntimeStoresProjection();
+        if (preserveProjection) {
+          logger.info(
+            "[automerge-notebook] preserving notebook projection across same-room rebootstrap",
+          );
+        } else {
+          resetNotebookCells();
+          resetRuntimeState();
+          resetRuntimeStoresProjection();
+          outputCacheRef.current.clear();
+        }
         resetPoolState();
         setCanAcceptCellMutations(false);
-        outputCacheRef.current.clear();
         setIsLoading(true);
         setLoadError(null);
       },

--- a/apps/notebook/src/lib/__tests__/bootstrap-preservation.test.ts
+++ b/apps/notebook/src/lib/__tests__/bootstrap-preservation.test.ts
@@ -1,0 +1,62 @@
+import { describe, expect, it } from "vite-plus/test";
+import {
+  notebookReadyIdentity,
+  shouldPreserveBootstrapProjection,
+} from "../bootstrap-preservation";
+
+describe("bootstrap projection preservation", () => {
+  it("uses notebook_id as the preferred ready identity", () => {
+    expect(
+      notebookReadyIdentity({
+        notebook_id: "room-1",
+        notebook_path: "/tmp/notebook.ipynb",
+      }),
+    ).toBe("id:room-1");
+  });
+
+  it("falls back to notebook_path when no notebook id is present", () => {
+    expect(
+      notebookReadyIdentity({
+        notebook_path: "/tmp/notebook.ipynb",
+      }),
+    ).toBe("path:/tmp/notebook.ipynb");
+  });
+
+  it("does not invent an identity for empty ready payloads", () => {
+    expect(notebookReadyIdentity({})).toBeNull();
+  });
+
+  it("preserves projected notebook state for a same-notebook reconnect with visible cells", () => {
+    expect(
+      shouldPreserveBootstrapProjection({
+        previousIdentity: "id:room-1",
+        nextIdentity: "id:room-1",
+        visibleCellCount: 3,
+      }),
+    ).toBe(true);
+  });
+
+  it("clears projected notebook state for first load, identity changes, or empty projections", () => {
+    expect(
+      shouldPreserveBootstrapProjection({
+        previousIdentity: null,
+        nextIdentity: "id:room-1",
+        visibleCellCount: 3,
+      }),
+    ).toBe(false);
+    expect(
+      shouldPreserveBootstrapProjection({
+        previousIdentity: "id:room-1",
+        nextIdentity: "id:room-2",
+        visibleCellCount: 3,
+      }),
+    ).toBe(false);
+    expect(
+      shouldPreserveBootstrapProjection({
+        previousIdentity: "id:room-1",
+        nextIdentity: "id:room-1",
+        visibleCellCount: 0,
+      }),
+    ).toBe(false);
+  });
+});

--- a/apps/notebook/src/lib/__tests__/notebook-sync-store-bridge.test.ts
+++ b/apps/notebook/src/lib/__tests__/notebook-sync-store-bridge.test.ts
@@ -347,28 +347,29 @@ describe("startNotebookSyncStoreBridge", () => {
     bridge.stop();
   });
 
-  it("characterizes the blank reconnect state when cells are cleared before initial sync returns", async () => {
-    let visibleCellIds = ["rendered-cell"];
+  it("waits for fresh initial sync after reconnect readiness reset", async () => {
     const { bridge, materializeCells, setIsLoading, subjects } = startBridge();
 
     subjects.initialSyncComplete$.next();
     await flushMicrotasks();
 
     expect(materializeCells).toHaveBeenCalledTimes(1);
-    expect(visibleCellIds).toEqual(["rendered-cell"]);
 
     bridge.resetReadiness();
-    visibleCellIds = [];
-    setIsLoading(true);
     materializeCells.mockClear();
     setIsLoading.mockClear();
 
     subjects.sessionStatus$.next(streamingStatus());
     await flushMicrotasks();
 
-    expect(visibleCellIds).toEqual([]);
     expect(materializeCells).not.toHaveBeenCalled();
     expect(setIsLoading).not.toHaveBeenCalled();
+
+    subjects.initialSyncComplete$.next();
+    await flushMicrotasks();
+
+    expect(materializeCells).toHaveBeenCalledTimes(1);
+    expect(setIsLoading).toHaveBeenLastCalledWith(true);
 
     bridge.stop();
   });

--- a/apps/notebook/src/lib/__tests__/notebook-sync-store-bridge.test.ts
+++ b/apps/notebook/src/lib/__tests__/notebook-sync-store-bridge.test.ts
@@ -347,6 +347,32 @@ describe("startNotebookSyncStoreBridge", () => {
     bridge.stop();
   });
 
+  it("characterizes the blank reconnect state when cells are cleared before initial sync returns", async () => {
+    let visibleCellIds = ["rendered-cell"];
+    const { bridge, materializeCells, setIsLoading, subjects } = startBridge();
+
+    subjects.initialSyncComplete$.next();
+    await flushMicrotasks();
+
+    expect(materializeCells).toHaveBeenCalledTimes(1);
+    expect(visibleCellIds).toEqual(["rendered-cell"]);
+
+    bridge.resetReadiness();
+    visibleCellIds = [];
+    setIsLoading(true);
+    materializeCells.mockClear();
+    setIsLoading.mockClear();
+
+    subjects.sessionStatus$.next(streamingStatus());
+    await flushMicrotasks();
+
+    expect(visibleCellIds).toEqual([]);
+    expect(materializeCells).not.toHaveBeenCalled();
+    expect(setIsLoading).not.toHaveBeenCalled();
+
+    bridge.stop();
+  });
+
   it("ignores in-flight materializeCells result if stopped before it resolves", async () => {
     const materialize = deferred();
     const materializeCells = vi.fn(() => materialize.promise);

--- a/apps/notebook/src/lib/bootstrap-preservation.ts
+++ b/apps/notebook/src/lib/bootstrap-preservation.ts
@@ -1,0 +1,30 @@
+import type { DaemonReadyPayload } from "@nteract/notebook-host";
+
+export function notebookReadyIdentity(
+  payload: Pick<DaemonReadyPayload, "notebook_id" | "notebook_path">,
+): string | null {
+  if (typeof payload.notebook_id === "string" && payload.notebook_id.length > 0) {
+    return `id:${payload.notebook_id}`;
+  }
+  if (typeof payload.notebook_path === "string" && payload.notebook_path.length > 0) {
+    return `path:${payload.notebook_path}`;
+  }
+  return null;
+}
+
+export function shouldPreserveBootstrapProjection({
+  previousIdentity,
+  nextIdentity,
+  visibleCellCount,
+}: {
+  previousIdentity: string | null;
+  nextIdentity: string | null;
+  visibleCellCount: number;
+}): boolean {
+  return (
+    previousIdentity !== null &&
+    nextIdentity !== null &&
+    previousIdentity === nextIdentity &&
+    visibleCellCount > 0
+  );
+}


### PR DESCRIPTION
## Summary

- Preserve desktop notebook cell/output/runtime projections across same-room reconnect bootstraps.
- Clear projections as before on first load, notebook identity changes, or when there is no visible notebook projection to preserve.
- Add a pure bootstrap-preservation policy test and a bridge characterization for the blank reconnect state.

## Verification

- `pnpm test:run apps/notebook/src/lib/__tests__/bootstrap-preservation.test.ts apps/notebook/src/lib/__tests__/notebook-sync-store-bridge.test.ts`
- `pnpm --dir apps/notebook exec tsc -b --pretty false`
- `pnpm --dir apps/notebook-cloud exec node --import tsx --test test/viewer-shared-cell-surface.test.ts`
- `cargo xtask lint --fix`

## Notes

This keeps the guard in the desktop bootstrap/materialization path rather than shared `NotebookView` or the cell store because empty notebooks are valid. Cloud already protects its live-viewer adapter before projecting empty live handles into the shared notebook stores.
