### PR TITLE
fix(runtimed): launch current_python kernels without a pool

### DIFF
--- a/crates/runtimed/src/jupyter_kernel.rs
+++ b/crates/runtimed/src/jupyter_kernel.rs
@@ -379,6 +379,7 @@ impl KernelConnection for JupyterKernel {
         let env_source = config.env_source;
         let notebook_path = config.notebook_path;
         let env = config.pooled_env;
+        let direct_python_path = config.direct_python_path;
         let launched_config = config.launched_config;
         let bootstrap_dx = launched_config.feature_flags.bootstrap_dx;
         let env_path = env.as_ref().map(|e| e.venv_path.clone());
@@ -742,6 +743,42 @@ impl KernelConnection for JupyterKernel {
                             // vendor into; inject the daemon-side launcher via
                             // PYTHONPATH so `-m nteract_kernel_launcher`
                             // resolves without touching sys.path[0].
+                            let dir = crate::launcher_cache::launcher_cache_dir().await?;
+                            cmd.env("PYTHONPATH", &dir);
+                        }
+                        cmd
+                    }
+                    "uv:current_python" => {
+                        // current_python: launch directly against a user-owned
+                        // interpreter, no pool take and no VIRTUAL_ENV/PATH
+                        // overlay. Reachable only over the cloud launch-on-attach
+                        // path; direct_python_path is set when the launched env
+                        // carries a python_path but no venv_path.
+                        let python_path = direct_python_path.as_ref().ok_or_else(|| {
+                            anyhow::anyhow!(
+                                "uv:current_python requires a direct python_path (none was plumbed through)"
+                            )
+                        })?;
+                        info!(
+                            "[jupyter-kernel] Starting Python kernel with current python at {:?}",
+                            python_path
+                        );
+                        let launcher_module = if bootstrap_dx {
+                            "nteract_kernel_launcher"
+                        } else {
+                            "ipykernel_launcher"
+                        };
+                        let mut cmd = tokio::process::Command::new(python_path);
+                        cmd.args(["-Xfrozen_modules=off", "-m", launcher_module, "-f"]);
+                        cmd.arg(&connection_file_path);
+                        cmd.stdout(Stdio::null());
+                        cmd.stderr(Stdio::piped());
+                        if bootstrap_dx {
+                            // The user's interpreter may predate the launcher;
+                            // inject it via PYTHONPATH (same pattern as the
+                            // pyproject and pool arms) so
+                            // `-m nteract_kernel_launcher` resolves without
+                            // touching sys.path[0].
                             let dir = crate::launcher_cache::launcher_cache_dir().await?;
                             cmd.env("PYTHONPATH", &dir);
                         }

--- a/crates/runtimed/src/kernel_connection.rs
+++ b/crates/runtimed/src/kernel_connection.rs
@@ -46,6 +46,9 @@ pub struct KernelLaunchConfig {
     pub redact_env_values_in_outputs: bool,
     /// Prewarmed pool environment, if one was claimed.
     pub pooled_env: Option<PooledEnv>,
+    /// Direct interpreter path for a no-pool launch (e.g. current_python):
+    /// set only when the launched env carries a python_path but no venv_path.
+    pub direct_python_path: Option<PathBuf>,
 }
 
 /// Shared references that the kernel needs but does not own.

--- a/crates/runtimed/src/runtime_agent.rs
+++ b/crates/runtimed/src/runtime_agent.rs
@@ -205,6 +205,22 @@ fn cloud_actor_label(principal: &str, operator: &str) -> String {
     format!("{principal}/{operator}:{}", &nonce[..8])
 }
 
+/// Carry the interpreter path through to `launch()` for a no-pool launch.
+///
+/// `current_python` (and any prepares-own-env source) sets `python_path` with no
+/// `venv_path`, so no `pooled_env` is built and the launcher's
+/// `uv:current_python` arm needs the path directly. A pooled/inline/project env
+/// has a `venv_path`, so this returns `None` and the pooled path is used.
+fn direct_python_path_for(
+    launched_config: &notebook_protocol::protocol::LaunchedEnvConfig,
+) -> Option<PathBuf> {
+    if launched_config.venv_path.is_none() {
+        launched_config.python_path.clone()
+    } else {
+        None
+    }
+}
+
 /// Run the runtime agent over an arbitrary [`FrameTransport`].
 ///
 /// The desktop/daemon path ([`run_runtime_agent`]) and the cloud path
@@ -1172,6 +1188,11 @@ async fn handle_runtime_agent_request(
                     })
             });
 
+            // current_python carries only a python_path (no venv_path), so no
+            // pooled_env is built above; carry the path through for the
+            // launcher's direct-launch arm.
+            let direct_python_path = direct_python_path_for(&launched_config);
+
             let shared = KernelSharedRefs {
                 state: ctx.state.clone(),
                 blob_store: ctx.blob_store.clone(),
@@ -1190,6 +1211,7 @@ async fn handle_runtime_agent_request(
                 env_vars: env_vars.into_iter().collect(),
                 redact_env_values_in_outputs,
                 pooled_env,
+                direct_python_path,
             };
 
             let launch_started = std::time::Instant::now();
@@ -1284,6 +1306,11 @@ async fn handle_runtime_agent_request(
                     })
             });
 
+            // current_python carries only a python_path (no venv_path), so no
+            // pooled_env is built above; carry the path through for the
+            // launcher's direct-launch arm.
+            let direct_python_path = direct_python_path_for(&launched_config);
+
             let shared = KernelSharedRefs {
                 state: ctx.state.clone(),
                 blob_store: ctx.blob_store.clone(),
@@ -1302,6 +1329,7 @@ async fn handle_runtime_agent_request(
                 env_vars: env_vars.into_iter().collect(),
                 redact_env_values_in_outputs,
                 pooled_env,
+                direct_python_path,
             };
 
             // Mark stale executions as failed in RuntimeStateDoc.
@@ -2056,6 +2084,37 @@ mod tests {
     use notebook_protocol::protocol::{BlobDurability, LaunchedEnvConfig};
     use std::path::PathBuf;
     use std::time::Duration;
+
+    // -- direct_python_path_for (B3: current_python launch plumbing) --------
+    //
+    // current_python sets python_path with no venv_path, so the interpreter
+    // path must be carried to launch() separately from the pooled env; a
+    // pooled/project env (venv_path set) must NOT carry it.
+
+    #[test]
+    fn direct_python_path_carried_only_without_venv() {
+        let current_python = LaunchedEnvConfig {
+            python_path: Some(PathBuf::from("/tmp/k/bin/python")),
+            venv_path: None,
+            ..LaunchedEnvConfig::default()
+        };
+        assert_eq!(
+            direct_python_path_for(&current_python),
+            Some(PathBuf::from("/tmp/k/bin/python")),
+            "current_python must carry python_path to the direct-launch arm"
+        );
+
+        let pooled = LaunchedEnvConfig {
+            python_path: Some(PathBuf::from("/opt/env/bin/python")),
+            venv_path: Some(PathBuf::from("/opt/env")),
+            ..LaunchedEnvConfig::default()
+        };
+        assert_eq!(
+            direct_python_path_for(&pooled),
+            None,
+            "a venv-backed env must not carry direct_python_path"
+        );
+    }
 
     // -- reconnect flap-floor policy --------------------------------------
     //


### PR DESCRIPTION
Makes `current_python` kernels launchable over a cloud `runtime_peer` attach. Until now a workstation could dial into a cloud room and attach, but the kernel never came up.

## Diagnosis

`current_python` sets only `python_path` (no `venv_path`) on `LaunchedEnvConfig`, so the runtime agent built no `pooled_env`, and `JupyterKernel::launch` matched `env_source` by literal string and fell through to the pool-required `_ =>` arm. That arm errors `Python kernel requires a pooled environment for env_source: uv:current_python` because there is no pool. The interpreter path was dropped before `launch()` ever saw it. Reproduced live against `preview.runt.run`: attach succeeds, then `LaunchKernel` fails in ~2ms with `env_path=None`.

## The fix

- `KernelLaunchConfig::direct_python_path: Option<PathBuf>`, set only when `venv_path` is `None` (extracted into `direct_python_path_for`, used by both the LaunchKernel and RestartKernel arms).
- A `"uv:current_python"` arm in `JupyterKernel::launch`, before the pool-required `_ =>`, that runs `ipykernel_launcher` / `nteract_kernel_launcher` directly against the interpreter, with no pool take and no `VIRTUAL_ENV`/PATH overlay. It mirrors the existing `uv:pyproject` arm, including the `bootstrap_dx` PYTHONPATH injection so the launcher resolves even if the user's interpreter predates it.

## Why it can't regress a shipping path

Reachable only over the cloud launch-on-attach path, which is gated on `transport.clean_eof_is_recoverable()` (true for cloud, false for UDS). The desktop/UDS path is byte-for-byte unchanged. `direct_python_path` is `None` for every pooled/inline/project source (they always carry a `venv_path`), so the new arm matches only `current_python` and the pool-required fallback is untouched.

## Verification

- `cargo xtask lint --fix`: clean.
- `cargo test -p runtimed --lib`: 912 passed, 0 failed, including the new `direct_python_path_carried_only_without_venv` (asserts the path is carried only when there's no venv).
- The `tests/integration.rs` suite needs a live daemon (`wait_for_daemon`) that the local sandbox doesn't run; those are unaffected by this change and expected to pass in CI.

## Draft because

The launcher fix is verifiable in unit tests, but the end-to-end proof, attaching the daemon's `cloud-runtime-agent` to a real preview room with an ipykernel-equipped `--python-path` and watching `kernel.lifecycle` reach `Running`, is the next step and the other half of #3437. Holding as draft until that live re-prove lands.
