### PR TITLE
test(runtime): allow CommsDoc pipe frames

### DIFF
--- a/crates/runtimed/tests/integration.rs
+++ b/crates/runtimed/tests/integration.rs
@@ -3289,13 +3289,14 @@ async fn test_pipe_mode_only_pipes_allowed_frame_types() {
     );
 
     // Every piped frame must have a valid type byte from the forwarded set:
-    // AutomergeSync, Broadcast, Presence, RuntimeStateSync, PoolStateSync,
-    // or SessionControl — never Request or Response.
+    // AutomergeSync, Broadcast, Presence, RuntimeStateSync, CommsDocSync,
+    // PoolStateSync, or SessionControl — never Request or Response.
     let allowed_types = [
         frame_types::AUTOMERGE_SYNC,
         frame_types::BROADCAST,
         frame_types::PRESENCE,
         frame_types::RUNTIME_STATE_SYNC,
+        frame_types::COMMS_DOC_SYNC,
         frame_types::POOL_STATE_SYNC,
         frame_types::SESSION_CONTROL,
     ];
@@ -3303,7 +3304,7 @@ async fn test_pipe_mode_only_pipes_allowed_frame_types() {
         assert!(!frame.is_empty(), "frame {} should not be empty", i);
         assert!(
             allowed_types.contains(&frame[0]),
-            "frame {} has unexpected type byte 0x{:02x} — only AUTOMERGE_SYNC, BROADCAST, PRESENCE, RUNTIME_STATE_SYNC, POOL_STATE_SYNC, and SESSION_CONTROL are piped",
+            "frame {} has unexpected type byte 0x{:02x} — only AUTOMERGE_SYNC, BROADCAST, PRESENCE, RUNTIME_STATE_SYNC, COMMS_DOC_SYNC, POOL_STATE_SYNC, and SESSION_CONTROL are piped",
             i,
             frame[0]
         );


### PR DESCRIPTION
## Summary

- allow the daemon CLI pipe-mode test to accept the new CommsDoc sync frame (`0x09`)
- keep the guard explicit so Request, Response, and PutBlob frames are still rejected from the debug pipe

## Context

#3440 added the fourth CommsDoc sync stream and merged successfully, but its post-merge Linux Rust Tests run failed because `test_pipe_mode_only_pipes_allowed_frame_types` still listed only the pre-split sync frame set.

## Verification

- `cargo test -p runtimed --test integration`
- `cargo xtask lint --fix`
