### PR TITLE
fix: use markdown engine anchors for notebook outline

### DIFF
--- a/apps/notebook-cloud/src/runtimed-wasm.generated.d.ts
+++ b/apps/notebook-cloud/src/runtimed-wasm.generated.d.ts
@@ -36,6 +36,7 @@ declare module "../../notebook/src/wasm/runtimed-wasm/runtimed_wasm.js" {
     principal: string,
     fallbackOperator: string,
   ): Uint8Array;
+  export function project_markdown_json(source: string): string;
 
   export class NotebookHandle {
     constructor(notebookId: string);

--- a/apps/notebook-cloud/test/live-sync.test.ts
+++ b/apps/notebook-cloud/test/live-sync.test.ts
@@ -172,6 +172,39 @@ describe("cloud live sync", () => {
     assert.deepEqual(calls, []);
   });
 
+  it("tolerates deployed WASM handles without CommsDoc sync methods", () => {
+    const originalWarn = console.warn;
+    const warnings: unknown[] = [];
+    console.warn = (...args: unknown[]) => {
+      warnings.push(args);
+    };
+
+    try {
+      const wasmHandle = {
+        receive_frame: () => [],
+        flush_local_changes: () => undefined,
+        cancel_last_flush: () => undefined,
+        flush_runtime_state_sync: () => undefined,
+        cancel_last_runtime_state_flush: () => undefined,
+        generate_runtime_state_sync_reply: () => undefined,
+        reset_sync_state: () => undefined,
+        cell_count: () => 0,
+        get_heads_hex: () => [],
+        get_dependency_fingerprint: () => undefined,
+        resolve_comm_state: () => undefined,
+      } as unknown as Parameters<typeof syncableCloudHandle>[0];
+      const handle = syncableCloudHandle(wasmHandle);
+
+      assert.equal(handle.flush_comms_doc_sync(), null);
+      assert.equal(handle.generate_comms_doc_sync_reply(), null);
+      assert.doesNotThrow(() => handle.cancel_last_comms_doc_flush());
+    } finally {
+      console.warn = originalWarn;
+    }
+
+    assert.equal(warnings.length, 1);
+  });
+
   it("notifies disconnect when a send sees a closing socket before the close event", async () => {
     const fake = installFakeWebSocket();
     const disconnects: string[] = [];

--- a/apps/notebook-cloud/test/notebook-view-store-bridge.test.ts
+++ b/apps/notebook-cloud/test/notebook-view-store-bridge.test.ts
@@ -1,18 +1,25 @@
 import assert from "node:assert/strict";
 import { afterEach, describe, it } from "node:test";
-import { updateCellById } from "@/components/notebook/state/cell-store";
+import { updateCellSourceById } from "@/components/notebook/state/cell-store";
 import { createNotebookViewModelFromNotebookCells } from "@/components/notebook/state/view-model-store";
+import { setMarkdownProjectionProjector } from "@/lib/markdown-projection";
 import {
   projectCloudCellsIntoNotebookViewStores,
   resetCloudViewStoreProjection,
 } from "../viewer/notebook-view-store-bridge.ts";
 
 describe("cloud NotebookView store bridge", () => {
+  let restoreMarkdownProjectionProjector: (() => void) | undefined;
+
   afterEach(() => {
+    restoreMarkdownProjectionProjector?.();
+    restoreMarkdownProjectionProjector = undefined;
     resetCloudViewStoreProjection();
   });
 
   it("keeps outline projection tied to the shared NotebookView store after local source edits", () => {
+    restoreMarkdownProjectionProjector = setMarkdownProjectionProjector(testMarkdownProjector);
+
     projectCloudCellsIntoNotebookViewStores([
       {
         id: "intro",
@@ -28,15 +35,73 @@ describe("cloud NotebookView store bridge", () => {
 
     assert.deepEqual(outlineTitlesFromStore(), ["Original title"]);
 
-    updateCellById("intro", (cell) => ({
-      ...cell,
-      source: "# Updated title\n\nBody",
-    }));
+    updateCellSourceById("intro", "# Updated title\n\nBody");
 
     assert.deepEqual(outlineTitlesFromStore(), ["Updated title"]);
+  });
+
+  it("reuses markdown projections for unchanged cloud cell sources", () => {
+    let projectCalls = 0;
+    restoreMarkdownProjectionProjector = setMarkdownProjectionProjector((source) => {
+      projectCalls += 1;
+      return testMarkdownProjector(source);
+    });
+
+    const cell = {
+      id: "intro",
+      cellType: "markdown" as const,
+      source: "# Stable title",
+      language: null,
+      executionId: null,
+      executionCount: null,
+      outputs: [],
+      metadata: {},
+    };
+
+    projectCloudCellsIntoNotebookViewStores([cell]);
+    projectCloudCellsIntoNotebookViewStores([cell]);
+
+    assert.equal(projectCalls, 1);
+    assert.deepEqual(outlineTitlesFromStore(), ["Stable title"]);
   });
 });
 
 function outlineTitlesFromStore(): string[] {
   return createNotebookViewModelFromNotebookCells().outlineItems.map((item) => item.title);
+}
+
+function testMarkdownProjector(source: string): string {
+  const title =
+    source
+      .replace(/^#+\s*/, "")
+      .split(/\r?\n/, 1)[0]
+      ?.trim() || "Untitled";
+  const slug = title
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/^-+|-+$/g, "");
+  return JSON.stringify({
+    version: 1,
+    engine: "test",
+    byteLength: source.length,
+    utf16Length: source.length,
+    measurement: {
+      estimatedHeight: 24,
+      confidence: "high",
+      width: 720,
+    },
+    anchors: [
+      {
+        anchorId: `anchor:${slug}`,
+        blockId: "block:0",
+        level: 1,
+        slug,
+        sourceSpanByte: [0, source.length],
+        sourceSpanUtf16: [0, source.length],
+        title,
+      },
+    ],
+    blocks: [],
+    runs: [],
+  });
 }

--- a/apps/notebook-cloud/viewer/live-sync.ts
+++ b/apps/notebook-cloud/viewer/live-sync.ts
@@ -441,6 +441,7 @@ const consoleSyncLogger = {
 };
 
 export function syncableCloudHandle(handle: NotebookHandle): SyncableHandle {
+  const commsSync = cloudCommsDocSyncMethods(handle);
   return {
     receive_frame: (bytes) =>
       handle.receive_frame(bytes) as ReturnType<SyncableHandle["receive_frame"]>,
@@ -449,9 +450,9 @@ export function syncableCloudHandle(handle: NotebookHandle): SyncableHandle {
     flush_runtime_state_sync: () => handle.flush_runtime_state_sync() ?? null,
     cancel_last_runtime_state_flush: () => handle.cancel_last_runtime_state_flush(),
     generate_runtime_state_sync_reply: () => handle.generate_runtime_state_sync_reply() ?? null,
-    flush_comms_doc_sync: () => handle.flush_comms_doc_sync() ?? null,
-    cancel_last_comms_doc_flush: () => handle.cancel_last_comms_doc_flush(),
-    generate_comms_doc_sync_reply: () => handle.generate_comms_doc_sync_reply() ?? null,
+    flush_comms_doc_sync: commsSync.flush_comms_doc_sync,
+    cancel_last_comms_doc_flush: commsSync.cancel_last_comms_doc_flush,
+    generate_comms_doc_sync_reply: commsSync.generate_comms_doc_sync_reply,
     // notebook-cloud does not host or display daemon pool state. The shared
     // SyncEngine flushes pool sync opportunistically for Desktop, so the cloud
     // adapter intentionally presents PoolDoc as absent instead of sending a
@@ -471,5 +472,41 @@ export function syncableCloudHandle(handle: NotebookHandle): SyncableHandle {
             text_paths?: string[][];
           }
         | undefined,
+  };
+}
+
+type CloudCommsDocSyncMethods = Pick<
+  SyncableHandle,
+  "flush_comms_doc_sync" | "cancel_last_comms_doc_flush" | "generate_comms_doc_sync_reply"
+>;
+
+function cloudCommsDocSyncMethods(handle: NotebookHandle): CloudCommsDocSyncMethods {
+  const candidate = handle as NotebookHandle &
+    Partial<
+      Pick<
+        NotebookHandle,
+        "flush_comms_doc_sync" | "cancel_last_comms_doc_flush" | "generate_comms_doc_sync_reply"
+      >
+    >;
+
+  if (
+    typeof candidate.flush_comms_doc_sync === "function" &&
+    typeof candidate.cancel_last_comms_doc_flush === "function" &&
+    typeof candidate.generate_comms_doc_sync_reply === "function"
+  ) {
+    return {
+      flush_comms_doc_sync: () => candidate.flush_comms_doc_sync?.() ?? null,
+      cancel_last_comms_doc_flush: () => candidate.cancel_last_comms_doc_flush?.(),
+      generate_comms_doc_sync_reply: () => candidate.generate_comms_doc_sync_reply?.() ?? null,
+    };
+  }
+
+  console.warn(
+    "[notebook-cloud] runtimed WASM handle is missing CommsDoc sync methods; widget state sync is disabled for this connection",
+  );
+  return {
+    flush_comms_doc_sync: () => null,
+    cancel_last_comms_doc_flush: () => undefined,
+    generate_comms_doc_sync_reply: () => null,
   };
 }

--- a/apps/notebook-cloud/viewer/notebook-view-store-bridge.ts
+++ b/apps/notebook-cloud/viewer/notebook-view-store-bridge.ts
@@ -4,6 +4,7 @@ import {
   type NotebookStoreCell,
   type NotebookStoreOutput,
 } from "@/components/notebook/state/cell-store";
+import { projectMarkdownPlan } from "@/lib/markdown-projection";
 import {
   deleteExecutions,
   setCellExecutionPointer,
@@ -106,6 +107,7 @@ function resolvedCellToNotebookCell(
       id: cell.id,
       source: cell.source,
       metadata,
+      markdownProjection: projectMarkdownPlan(cell.source) ?? undefined,
     };
   }
 

--- a/apps/notebook/src/components/__tests__/markdown-cell-theme.test.tsx
+++ b/apps/notebook/src/components/__tests__/markdown-cell-theme.test.tsx
@@ -228,6 +228,7 @@ function makeTaskCell(): MarkdownCellType {
       confidence: "high",
       width: 720,
     },
+    anchors: [],
     blocks: [
       {
         blockId: "tasks",

--- a/apps/notebook/src/hooks/useCrdtBridge.tsx
+++ b/apps/notebook/src/hooks/useCrdtBridge.tsx
@@ -24,7 +24,7 @@ import {
   remoteChangesFromTextAttributions,
 } from "../lib/crdt-editor-bridge";
 import { logger } from "../lib/logger";
-import { updateCellById } from "@/components/notebook/state/cell-store";
+import { updateCellSourceById } from "@/components/notebook/state/cell-store";
 import { subscribeBroadcast } from "../lib/notebook-frame-bus";
 import type { NotebookHandle } from "../wasm/runtimed-wasm/runtimed_wasm.js";
 
@@ -109,7 +109,7 @@ export function useCrdtBridge(cellId: string): {
       cellId,
       canWriteSource: () => ctxRef.current.canWriteSource?.(cellId) ?? true,
       onSourceChanged: (source: string) => {
-        updateCellById(cellId, (c) => ({ ...c, source }));
+        updateCellSourceById(cellId, source);
       },
       onSyncNeeded: () => {
         ctxRef.current.onSyncNeeded();

--- a/apps/notebook/src/lib/__tests__/materialize-cells.test.ts
+++ b/apps/notebook/src/lib/__tests__/materialize-cells.test.ts
@@ -33,6 +33,7 @@ beforeEach(() => {
         confidence: "medium",
         width: 720,
       },
+      anchors: [],
       blocks: [],
       runs: [],
     }),
@@ -520,6 +521,7 @@ describe("cellSnapshotsToNotebookCells", () => {
           confidence: "high",
           width: 720,
         },
+        anchors: [],
         blocks: [
           {
             blockId: "tasks",

--- a/apps/notebook/src/lib/__tests__/notebook-cells.test.ts
+++ b/apps/notebook/src/lib/__tests__/notebook-cells.test.ts
@@ -7,9 +7,11 @@ import {
   replaceNotebookCells,
   resetNotebookCells,
   updateCellById,
+  updateCellSourceById,
   updateNotebookCells,
   useMaterializeVersion,
 } from "../notebook-cells";
+import { setMarkdownProjectionProjector } from "../markdown-projection";
 
 const codeCell = (id: string, source = ""): NotebookCell => ({
   cell_type: "code",
@@ -27,7 +29,11 @@ const markdownCell = (id: string, source = ""): NotebookCell => ({
   metadata: {},
 });
 
+let restoreMarkdownProjectionProjector: (() => void) | undefined;
+
 afterEach(() => {
+  restoreMarkdownProjectionProjector?.();
+  restoreMarkdownProjectionProjector = undefined;
   resetNotebookCells();
 });
 
@@ -105,6 +111,7 @@ describe("updateCellById", () => {
           byteLength: 8,
           utf16Length: 8,
           measurement: { estimatedHeight: 24, confidence: "high", width: 720 },
+          anchors: [],
           blocks: [],
           runs: [],
         },
@@ -118,6 +125,40 @@ describe("updateCellById", () => {
     const cell = getCellById("a");
     expect(cell?.source).toBe("- [x] old");
     expect(cell?.cell_type === "markdown" ? cell.markdownProjection : null).toBeUndefined();
+  });
+
+  it("refreshes markdown projections when updating source through the source helper", () => {
+    restoreMarkdownProjectionProjector = setMarkdownProjectionProjector((source) =>
+      JSON.stringify({
+        version: 1,
+        engine: "test",
+        byteLength: source.length,
+        utf16Length: source.length,
+        measurement: { estimatedHeight: 24, confidence: "high", width: 720 },
+        anchors: [
+          {
+            anchorId: "anchor:updated",
+            blockId: "block:0",
+            level: 1,
+            slug: "updated",
+            sourceSpanByte: [0, source.length],
+            sourceSpanUtf16: [0, source.length],
+            title: "Updated",
+          },
+        ],
+        blocks: [],
+        runs: [],
+      }),
+    );
+    replaceNotebookCells([markdownCell("a", "# Old")]);
+
+    updateCellSourceById("a", "# Updated");
+
+    const cell = getCellById("a");
+    expect(cell?.source).toBe("# Updated");
+    expect(cell?.cell_type === "markdown" ? cell.markdownProjection?.anchors[0]?.title : null).toBe(
+      "Updated",
+    );
   });
 
   it("is a no-op for non-existent IDs", () => {

--- a/apps/notebook/src/lib/__tests__/notebook-view-model.test.ts
+++ b/apps/notebook/src/lib/__tests__/notebook-view-model.test.ts
@@ -1,6 +1,12 @@
 import { afterEach, describe, expect, it } from "vite-plus/test";
-import { replaceNotebookCells, resetNotebookCells, updateCellById } from "../notebook-cells";
+import {
+  replaceNotebookCells,
+  resetNotebookCells,
+  updateCellById,
+  updateCellSourceById,
+} from "../notebook-cells";
 import { createNotebookViewModelFromNotebookCells } from "../notebook-view-model";
+import { setMarkdownProjectionProjector } from "../markdown-projection";
 import type { NotebookCell } from "../../types";
 
 const codeCell = (id: string, source = "", executionCount: number | null = null): NotebookCell => ({
@@ -17,22 +23,25 @@ const markdownCell = (id: string, source = ""): NotebookCell => ({
   id,
   source,
   metadata: {},
+  markdownProjection: testMarkdownProjection(source),
 });
 
+let restoreMarkdownProjectionProjector: (() => void) | undefined;
+
 afterEach(() => {
+  restoreMarkdownProjectionProjector?.();
+  restoreMarkdownProjectionProjector = undefined;
   resetNotebookCells();
 });
 
 describe("createNotebookViewModelFromNotebookCells", () => {
   it("projects outline headings from the shared NotebookView cell store", () => {
+    restoreMarkdownProjectionProjector = setMarkdownProjectionProjector(testMarkdownProjector);
     replaceNotebookCells([markdownCell("intro", "# Original title")]);
 
     expect(outlineTitles()).toEqual(["Original title"]);
 
-    updateCellById("intro", (cell) => ({
-      ...cell,
-      source: "# Updated title\n\nBody",
-    }));
+    updateCellSourceById("intro", "# Updated title\n\nBody");
 
     expect(outlineTitles()).toEqual(["Updated title"]);
   });
@@ -52,4 +61,37 @@ describe("createNotebookViewModelFromNotebookCells", () => {
 
 function outlineTitles(): string[] {
   return createNotebookViewModelFromNotebookCells().outlineItems.map((item) => item.title);
+}
+
+function testMarkdownProjection(source: string): NonNullable<Extract<NotebookCell, { cell_type: "markdown" }>["markdownProjection"]> {
+  return JSON.parse(testMarkdownProjector(source));
+}
+
+function testMarkdownProjector(source: string): string {
+  const title = source.replace(/^#+\s*/, "").split(/\r?\n/, 1)[0]?.trim() || "Untitled";
+  const slug = title.toLowerCase().replace(/[^a-z0-9]+/g, "-").replace(/^-+|-+$/g, "");
+  return JSON.stringify({
+    version: 1,
+    engine: "test",
+    byteLength: source.length,
+    utf16Length: source.length,
+    measurement: {
+      estimatedHeight: 24,
+      confidence: "high",
+      width: 720,
+    },
+    anchors: [
+      {
+        anchorId: `anchor:${slug}`,
+        blockId: "block:0",
+        level: 1,
+        slug,
+        sourceSpanByte: [0, source.length],
+        sourceSpanUtf16: [0, source.length],
+        title,
+      },
+    ],
+    blocks: [],
+    runs: [],
+  });
 }

--- a/apps/notebook/src/lib/notebook-cells.ts
+++ b/apps/notebook/src/lib/notebook-cells.ts
@@ -6,6 +6,7 @@ export {
   resetNotebookCells,
   subscribeIds,
   updateCellById,
+  updateCellSourceById,
   updateNotebookCells,
   useCell,
   useCellIds,

--- a/apps/notebook/src/lib/notebook-controller.ts
+++ b/apps/notebook/src/lib/notebook-controller.ts
@@ -1,6 +1,6 @@
 import type { SyncEngine } from "runtimed";
 import { logger } from "./logger";
-import { getNotebookCellsSnapshot, updateCellById } from "./notebook-cells";
+import { getNotebookCellsSnapshot, updateCellSourceById } from "./notebook-cells";
 import type { NotebookCell } from "../types";
 
 export type NotebookControllerCellType = "code" | "markdown" | "raw";
@@ -119,7 +119,7 @@ export function createNotebookController<THandle extends NotebookControllerHandl
       const updated = handle.update_source(cellId, source);
       if (!updated) return;
 
-      updateCellById(cellId, (cell) => ({ ...cell, source }));
+      updateCellSourceById(cellId, source);
       afterMutation?.(handle, "source");
       syncAfterMutation(engine, "source");
     },

--- a/crates/nteract-markdown-wasm/src/lib.rs
+++ b/crates/nteract-markdown-wasm/src/lib.rs
@@ -1,5 +1,6 @@
 use nteract_markdown_engine::{
-    project_markdown, MeasurementConfidence, MeasurementPlan, NodeKind, ProjectedNode, TableAlign,
+    project_markdown, MarkdownAnchor, MarkdownPlan, MeasurementConfidence, NodeKind, ProjectedNode,
+    TableAlign,
 };
 use std::sync::Mutex;
 
@@ -61,7 +62,7 @@ pub extern "C" fn nteract_markdown_result_len() -> usize {
 
 pub fn project_to_json(source: &str) -> String {
     match project_markdown(source) {
-        Ok(plan) => render_wasm_plan(source, &plan.blocks, &plan.measurement),
+        Ok(plan) => render_wasm_plan(source, &plan),
         Err(error) => error_to_json(&error.to_string()),
     }
 }
@@ -73,20 +74,22 @@ fn error_to_json(message: &str) -> String {
     output
 }
 
-fn render_wasm_plan(
-    source: &str,
-    blocks: &[ProjectedNode],
-    measurement: &MeasurementPlan,
-) -> String {
+fn render_wasm_plan(source: &str, plan: &MarkdownPlan) -> String {
     let position_index = PositionIndex::new(source);
     let mut output_blocks = Vec::new();
     let mut output_runs = Vec::new();
 
-    for (block_index, block) in blocks.iter().enumerate() {
+    for (block_index, block) in plan.blocks.iter().enumerate() {
         let (wasm_block, mut runs) = collect_block(source, &position_index, block_index, block);
         output_blocks.push(wasm_block);
         output_runs.append(&mut runs);
     }
+
+    let output_anchors = plan
+        .anchors
+        .iter()
+        .map(|anchor| WasmAnchor::new(&position_index, anchor))
+        .collect::<Vec<_>>();
 
     let mut output = String::new();
     output.push_str("{\"version\":1,\"engine\":\"rust-wasm\",\"byteLength\":");
@@ -95,12 +98,20 @@ fn render_wasm_plan(
     output.push_str(&position_index.utf16_len.to_string());
     output.push_str(",\"measurement\":{");
     output.push_str("\"estimatedHeight\":");
-    output.push_str(&measurement.estimated_height.to_string());
+    output.push_str(&plan.measurement.estimated_height.to_string());
     output.push_str(",\"confidence\":");
-    push_json_string(&mut output, confidence_label(measurement.confidence));
+    push_json_string(&mut output, confidence_label(plan.measurement.confidence));
     output.push_str(",\"width\":");
-    output.push_str(&measurement.width.to_string());
+    output.push_str(&plan.measurement.width.to_string());
     output.push('}');
+    output.push_str(",\"anchors\":[");
+    for (index, anchor) in output_anchors.iter().enumerate() {
+        if index > 0 {
+            output.push(',');
+        }
+        anchor.push_json(&mut output);
+    }
+    output.push(']');
     output.push_str(",\"blocks\":[");
     for (index, block) in output_blocks.iter().enumerate() {
         if index > 0 {
@@ -925,6 +936,52 @@ struct WasmBlockMeasurement {
     basis: String,
     confidence: &'static str,
     estimated_height: usize,
+}
+
+struct WasmAnchor {
+    anchor_id: String,
+    block_id: String,
+    level: u8,
+    slug: String,
+    source_span_byte: [usize; 2],
+    source_span_utf16: [usize; 2],
+    title: String,
+}
+
+impl WasmAnchor {
+    fn new(position_index: &PositionIndex, anchor: &MarkdownAnchor) -> Self {
+        Self {
+            anchor_id: anchor.id.clone(),
+            block_id: anchor.block_id.clone(),
+            level: anchor.level,
+            slug: anchor.slug.clone(),
+            source_span_byte: [anchor.span.start, anchor.span.end],
+            source_span_utf16: [
+                position_index.byte_to_utf16(anchor.span.start),
+                position_index.byte_to_utf16(anchor.span.end),
+            ],
+            title: anchor.title.clone(),
+        }
+    }
+
+    fn push_json(&self, output: &mut String) {
+        output.push('{');
+        push_json_key_string(output, "anchorId", &self.anchor_id);
+        output.push(',');
+        push_json_key_string(output, "blockId", &self.block_id);
+        output.push(',');
+        output.push_str("\"level\":");
+        output.push_str(&self.level.to_string());
+        output.push(',');
+        push_json_key_string(output, "slug", &self.slug);
+        output.push(',');
+        push_json_key_span(output, "sourceSpanByte", self.source_span_byte);
+        output.push(',');
+        push_json_key_span(output, "sourceSpanUtf16", self.source_span_utf16);
+        output.push(',');
+        push_json_key_string(output, "title", &self.title);
+        output.push('}');
+    }
 }
 
 impl WasmBlock {

--- a/packages/runtimed/src/index.ts
+++ b/packages/runtimed/src/index.ts
@@ -139,7 +139,6 @@ export {
   notebookHeadingAnchorHref,
   notebookHeadingAnchorId,
   notebookOutlineItemHref,
-  parseMarkdownHeadings,
   projectNotebookOutline,
   resolveNotebookOutlineContextItemId,
   resolveNotebookOutlineSelection,
@@ -147,11 +146,12 @@ export {
   type NotebookOutlineHrefTarget,
   type NotebookOutlineItem,
   type NotebookOutlineItemKind,
+  type NotebookOutlineMarkdownAnchor,
+  type NotebookOutlineMarkdownProjection,
   type NotebookOutlineProjection,
   type NotebookOutlineSelectionInput,
   type NotebookOutlineSourceCell,
   type NotebookOutlineTreeNode,
-  type ParsedNotebookHeading,
   type ProjectNotebookOutlineOptions,
 } from "./notebook-outline";
 

--- a/packages/runtimed/src/notebook-outline.ts
+++ b/packages/runtimed/src/notebook-outline.ts
@@ -14,6 +14,7 @@ export interface NotebookOutlineSourceCell {
   cellType?: string | null;
   execution_count?: number | null;
   metadata?: NotebookOutlineSourceMetadata | null;
+  markdownProjection?: NotebookOutlineMarkdownProjection | null;
 }
 
 export type NotebookOutlineSourceMetadata = Record<string, unknown> & {
@@ -21,6 +22,16 @@ export type NotebookOutlineSourceMetadata = Record<string, unknown> & {
   heading?: unknown;
   name?: unknown;
 };
+
+export interface NotebookOutlineMarkdownProjection {
+  anchors?: readonly NotebookOutlineMarkdownAnchor[] | null;
+}
+
+export interface NotebookOutlineMarkdownAnchor {
+  slug: string;
+  title: string;
+  level: number;
+}
 
 export interface NotebookOutlineItem {
   id: string;
@@ -48,6 +59,7 @@ export interface NotebookOutlineTreeNode {
 
 export interface ProjectNotebookOutlineOptions<TCell extends NotebookOutlineSourceCell> {
   getStatusLabel?: (cell: TCell) => string | null | undefined;
+  getMarkdownAnchors?: (cell: TCell) => readonly NotebookOutlineMarkdownAnchor[] | null | undefined;
   fallbackToCells?: boolean;
   hrefTarget?: NotebookOutlineHrefTarget;
 }
@@ -56,11 +68,6 @@ export interface NotebookOutlineSelectionInput {
   selectedItemId?: string | null;
   selectedCellId?: string | null;
   cellIds?: readonly string[];
-}
-
-export interface ParsedNotebookHeading {
-  title: string;
-  level: number;
 }
 
 const MAX_OUTLINE_TITLE_LENGTH = 96;
@@ -72,13 +79,12 @@ export function projectNotebookOutline<TCell extends NotebookOutlineSourceCell>(
   const fallbackToCells = options.fallbackToCells ?? true;
   const hrefTarget = options.hrefTarget ?? "cell";
   const headings: NotebookOutlineItem[] = [];
-  const anchorCounts = new Map<string, number>();
 
   for (const cell of cells) {
     if (cellKind(cell) !== "markdown") continue;
-    const parsed = parseMarkdownHeadings(cell.source ?? "");
+    const parsed = markdownHeadingAnchorsForOutline(cell, options);
     parsed.forEach((heading, index) => {
-      const anchor = nextHeadingAnchor(heading.title, anchorCounts);
+      const anchor = cleanHeadingAnchorSlug(heading.slug) || slugifyNotebookHeading(heading.title);
       const cellAnchorId = notebookCellAnchorId(cell.id);
       const headingAnchorId = notebookHeadingAnchorId(cell.id, anchor);
       headings.push({
@@ -124,39 +130,6 @@ export function projectNotebookOutline<TCell extends NotebookOutlineSourceCell>(
       };
     }),
   };
-}
-
-export function parseMarkdownHeadings(source: string): ParsedNotebookHeading[] {
-  const headings: ParsedNotebookHeading[] = [];
-  let fencedBy: string | null = null;
-
-  for (const rawLine of source.split(/\r?\n/)) {
-    const fence = rawLine.match(/^ {0,3}(`{3,}|~{3,})/);
-    if (fence) {
-      const marker = fence[1][0];
-      if (fencedBy === marker) {
-        fencedBy = null;
-      } else if (fencedBy === null) {
-        fencedBy = marker;
-      }
-      continue;
-    }
-
-    if (fencedBy !== null) continue;
-
-    const match = rawLine.match(/^ {0,3}(#{1,6})(?:\s+|$)(.*?)\s*$/);
-    if (!match) continue;
-
-    const title = cleanOutlineTitle(match[2].replace(/\s+#+\s*$/, ""));
-    if (!title) continue;
-
-    headings.push({
-      title,
-      level: match[1].length,
-    });
-  }
-
-  return headings;
 }
 
 export function deriveNotebookOutlineItems<TCell extends NotebookOutlineSourceCell>(
@@ -272,11 +245,28 @@ export function resolveNotebookOutlineContextItemId(
   return contextItem?.id ?? null;
 }
 
-function nextHeadingAnchor(title: string, anchorCounts: Map<string, number>): string {
-  const base = slugifyNotebookHeading(title);
-  const count = anchorCounts.get(base) ?? 0;
-  anchorCounts.set(base, count + 1);
-  return count === 0 ? base : `${base}-${count}`;
+function markdownHeadingAnchorsForOutline<TCell extends NotebookOutlineSourceCell>(
+  cell: TCell,
+  options: ProjectNotebookOutlineOptions<TCell>,
+): NotebookOutlineMarkdownAnchor[] {
+  const anchors = options.getMarkdownAnchors?.(cell) ?? cell.markdownProjection?.anchors ?? [];
+  return anchors.flatMap((anchor) => {
+    if (!anchor || typeof anchor !== "object") return [];
+    const title = typeof anchor.title === "string" ? cleanOutlineTitle(anchor.title) : "";
+    const level = normalizeMarkdownHeadingLevel(anchor.level);
+    if (!title || level === null) return [];
+    return [{ title, level, slug: cleanHeadingAnchorSlug(anchor.slug) }];
+  });
+}
+
+function normalizeMarkdownHeadingLevel(level: unknown): number | null {
+  if (typeof level !== "number") return null;
+  if (!Number.isInteger(level)) return null;
+  return Math.min(6, Math.max(1, level));
+}
+
+function cleanHeadingAnchorSlug(slug: unknown): string {
+  return typeof slug === "string" ? slug.trim() : "";
 }
 
 function notebookOutlineHref(

--- a/packages/runtimed/tests/notebook-outline.test.ts
+++ b/packages/runtimed/tests/notebook-outline.test.ts
@@ -6,40 +6,16 @@ import {
   notebookHeadingAnchorHref,
   notebookHeadingAnchorId,
   notebookOutlineItemHref,
-  parseMarkdownHeadings,
   projectNotebookOutline,
   resolveNotebookOutlineSelection,
   resolveNotebookOutlineContextItemId,
   slugifyNotebookHeading,
 } from "../src/notebook-outline";
 
-describe("parseMarkdownHeadings", () => {
-  it("extracts ATX headings and ignores fenced code blocks", () => {
-    expect(
-      parseMarkdownHeadings(
-        [
-          "# Load data",
-          "",
-          "```md",
-          "# Not a heading",
-          "```",
-          "## Clean columns ##",
-          "    # indented code",
-          "### `Model` run",
-        ].join("\n"),
-      ),
-    ).toEqual([
-      { title: "Load data", level: 1 },
-      { title: "Clean columns", level: 2 },
-      { title: "Model run", level: 3 },
-    ]);
-  });
-});
-
 describe("projectNotebookOutline", () => {
-  it("returns markdown headings before cell fallbacks", () => {
+  it("returns projected markdown headings before cell fallbacks", () => {
     const projection = projectNotebookOutline([
-      { id: "a", cell_type: "markdown", source: "# Load data\ntext" },
+      markdownCell("a", "# Load data\ntext", [{ title: "Load data", level: 1, slug: "load-data" }]),
       { id: "b", cell_type: "code", source: "df.head()", execution_count: 3 },
     ]);
 
@@ -62,17 +38,38 @@ describe("projectNotebookOutline", () => {
     });
   });
 
-  it("assigns deterministic duplicate heading anchors across cells", () => {
+  it("uses markdown engine duplicate heading anchors", () => {
     const projection = projectNotebookOutline([
-      { id: "a", cell_type: "markdown", source: "# Results\n## Results!" },
-      { id: "b", cell_type: "markdown", source: "# Results" },
+      markdownCell("a", "# Results\n## Results!", [
+        { title: "Results", level: 1, slug: "results" },
+        { title: "Results!", level: 2, slug: "results-2" },
+      ]),
+      markdownCell("b", "# Results", [{ title: "Results", level: 1, slug: "results" }]),
     ]);
 
     expect(projection.items.map((item) => item.anchor)).toEqual([
       "results",
-      "results-1",
       "results-2",
+      "results",
     ]);
+    expect(projection.items.map((item) => item.headingAnchorId)).toEqual([
+      "notebook-cell-a-heading-results",
+      "notebook-cell-a-heading-results-2",
+      "notebook-cell-b-heading-results",
+    ]);
+  });
+
+  it("does not parse markdown source when no projection anchors are available", () => {
+    const projection = projectNotebookOutline([
+      { id: "a", cell_type: "markdown", source: "# Intro" },
+    ]);
+
+    expect(projection.source).toBe("cells");
+    expect(projection.items[0]).toMatchObject({
+      id: "a:cell",
+      title: "Intro",
+      kind: "cell",
+    });
   });
 
   it("falls back to scrollable cell summaries when there are no headings", () => {
@@ -174,7 +171,11 @@ describe("projectNotebookOutline", () => {
 
   it("can project heading hrefs when a host exposes heading anchors", () => {
     const projection = projectNotebookOutline(
-      [{ id: "cell:1", cell_type: "markdown", source: "# Load data" }],
+      [
+        markdownCell("cell:1", "# Load data", [
+          { title: "Load data", level: 1, slug: "load-data" },
+        ]),
+      ],
       { hrefTarget: "heading" },
     );
 
@@ -187,7 +188,10 @@ describe("projectNotebookOutline", () => {
 
   it("keeps multiple markdown headings in one cell on the cell href by default", () => {
     const projection = projectNotebookOutline([
-      { id: "a", cell_type: "markdown", source: "# Load data\n\n## Clean columns" },
+      markdownCell("a", "# Load data\n\n## Clean columns", [
+        { title: "Load data", level: 1, slug: "load-data" },
+        { title: "Clean columns", level: 2, slug: "clean-columns" },
+      ]),
     ]);
 
     expect(projection.items.map((item) => item.href)).toEqual([
@@ -221,7 +225,7 @@ describe("notebook outline anchors", () => {
 
   it("resolves an outline item href for cell or heading targets", () => {
     const item = projectNotebookOutline([
-      { id: "cell:1", cell_type: "markdown", source: "# Load data" },
+      markdownCell("cell:1", "# Load data", [{ title: "Load data", level: 1, slug: "load-data" }]),
     ]).items[0];
 
     expect(notebookOutlineItemHref(item)).toBe("#notebook-cell-cell_3a_1");
@@ -234,8 +238,13 @@ describe("notebook outline anchors", () => {
 describe("resolveNotebookOutlineSelection", () => {
   it("prefers a valid pinned item over the focused cell fallback", () => {
     const items = projectNotebookOutline([
-      { id: "a", cell_type: "markdown", source: "# Load data\n## Load details" },
-      { id: "b", cell_type: "markdown", source: "# Clean columns" },
+      markdownCell("a", "# Load data\n## Load details", [
+        { title: "Load data", level: 1, slug: "load-data" },
+        { title: "Load details", level: 2, slug: "load-details" },
+      ]),
+      markdownCell("b", "# Clean columns", [
+        { title: "Clean columns", level: 1, slug: "clean-columns" },
+      ]),
     ]).items;
 
     expect(
@@ -248,7 +257,10 @@ describe("resolveNotebookOutlineSelection", () => {
 
   it("falls back to the first item for the focused cell", () => {
     const items = projectNotebookOutline([
-      { id: "a", cell_type: "markdown", source: "# Load data\n## Load details" },
+      markdownCell("a", "# Load data\n## Load details", [
+        { title: "Load data", level: 1, slug: "load-data" },
+        { title: "Load details", level: 2, slug: "load-details" },
+      ]),
     ]).items;
 
     expect(resolveNotebookOutlineSelection(items, { selectedCellId: "a" })).toBe("a:heading:0");
@@ -256,9 +268,11 @@ describe("resolveNotebookOutlineSelection", () => {
 
   it("resolves focused code cells to the nearest preceding heading when cell order is available", () => {
     const items = projectNotebookOutline([
-      { id: "intro", cell_type: "markdown", source: "# Load data" },
+      markdownCell("intro", "# Load data", [{ title: "Load data", level: 1, slug: "load-data" }]),
       { id: "load", cell_type: "code", source: "df = pandas.read_csv(path)" },
-      { id: "clean-heading", cell_type: "markdown", source: "## Clean columns" },
+      markdownCell("clean-heading", "## Clean columns", [
+        { title: "Clean columns", level: 2, slug: "clean-columns" },
+      ]),
       { id: "clean", cell_type: "code", source: "df = df.dropna()" },
     ]).items;
 
@@ -275,7 +289,10 @@ describe("resolveNotebookOutlineSelection", () => {
 
   it("keeps following code cells in the deepest trailing heading from a multi-heading cell", () => {
     const items = projectNotebookOutline([
-      { id: "intro", cell_type: "markdown", source: "# Load data\n\n## CSV import" },
+      markdownCell("intro", "# Load data\n\n## CSV import", [
+        { title: "Load data", level: 1, slug: "load-data" },
+        { title: "CSV import", level: 2, slug: "csv-import" },
+      ]),
       { id: "load", cell_type: "code", source: "df = pandas.read_csv(path)" },
     ]).items;
 
@@ -291,9 +308,13 @@ describe("resolveNotebookOutlineSelection", () => {
 describe("buildNotebookOutlineTree", () => {
   it("nests headings by markdown level without losing document order", () => {
     const items = projectNotebookOutline([
-      { id: "a", cell_type: "markdown", source: "# Load data\n\n## CSV\n\n### Schema" },
-      { id: "b", cell_type: "markdown", source: "## Warehouse" },
-      { id: "c", cell_type: "markdown", source: "# Model" },
+      markdownCell("a", "# Load data\n\n## CSV\n\n### Schema", [
+        { title: "Load data", level: 1, slug: "load-data" },
+        { title: "CSV", level: 2, slug: "csv" },
+        { title: "Schema", level: 3, slug: "schema" },
+      ]),
+      markdownCell("b", "## Warehouse", [{ title: "Warehouse", level: 2, slug: "warehouse" }]),
+      markdownCell("c", "# Model", [{ title: "Model", level: 1, slug: "model" }]),
     ]).items;
 
     const tree = buildNotebookOutlineTree(items);
@@ -303,3 +324,16 @@ describe("buildNotebookOutlineTree", () => {
     expect(tree[0].children[0].children.map((node) => node.item.title)).toEqual(["Schema"]);
   });
 });
+
+function markdownCell(
+  id: string,
+  source: string,
+  anchors: readonly { title: string; level: number; slug: string }[],
+) {
+  return {
+    id,
+    cell_type: "markdown" as const,
+    source,
+    markdownProjection: { anchors },
+  };
+}

--- a/src/components/markdown/__tests__/ProjectedMarkdownView.test.tsx
+++ b/src/components/markdown/__tests__/ProjectedMarkdownView.test.tsx
@@ -10,6 +10,7 @@ function plan(overrides: Partial<MarkdownProjectionPlan> = {}): MarkdownProjecti
     byteLength: 0,
     utf16Length: 0,
     measurement: { estimatedHeight: 120, confidence: "high", width: 720 },
+    anchors: [],
     blocks: [],
     runs: [],
     ...overrides,

--- a/src/components/notebook/__tests__/view-model.test.ts
+++ b/src/components/notebook/__tests__/view-model.test.ts
@@ -9,6 +9,7 @@ import {
   type NotebookViewCell,
 } from "../view-model";
 import type { SupportedLanguage } from "@/components/editor/languages";
+import { setMarkdownProjectionProjector } from "@/lib/markdown-projection";
 
 const resolveTestLanguage = (language: string | null | undefined): SupportedLanguage | null =>
   (language ?? "plain") as SupportedLanguage;
@@ -69,16 +70,10 @@ describe("notebook shell view model", () => {
 
   it("projects shared notebook view cells into outline items", () => {
     const outline = notebookViewCellsToOutlineItems([
-      {
-        id: "intro",
-        cellType: "markdown",
-        source: "# Intro\n\n## Setup",
-        language: null,
-        executionId: null,
-        executionCount: null,
-        outputs: [],
-        metadata: {},
-      },
+      markdownViewCell("intro", "# Intro\n\n## Setup", [
+        { title: "Intro", level: 1, slug: "intro" },
+        { title: "Setup", level: 2, slug: "setup" },
+      ]),
     ]);
 
     expect(outline.map((item) => [item.id, item.cellId, item.title, item.level])).toEqual([
@@ -89,6 +84,33 @@ describe("notebook shell view model", () => {
       "#notebook-cell-intro-heading-intro",
       "#notebook-cell-intro-heading-setup",
     ]);
+  });
+
+  it("projects missing markdownProjection through the host markdown projector", () => {
+    const restore = setMarkdownProjectionProjector((source) =>
+      JSON.stringify(testMarkdownProjection(source, [{ title: "Intro", level: 1, slug: "intro" }])),
+    );
+
+    try {
+      const outline = notebookViewCellsToOutlineItems([
+        {
+          id: "intro",
+          cellType: "markdown",
+          source: "# Intro",
+          language: null,
+          executionId: null,
+          executionCount: null,
+          outputs: [],
+          metadata: {},
+        },
+      ]);
+
+      expect(outline.map((item) => [item.id, item.title, item.anchor])).toEqual([
+        ["intro:heading:0", "Intro", "intro"],
+      ]);
+    } finally {
+      restore();
+    }
   });
 
   it("projects Jupyter hidden metadata into read-only render cells", () => {
@@ -301,16 +323,10 @@ describe("notebook shell view model", () => {
 
   it("projects outline headings to markdown heading anchors by cell", () => {
     const outlineItems = notebookViewCellsToOutlineItems([
-      {
-        id: "intro",
-        cellType: "markdown",
-        source: "# Intro\n\n## Setup",
-        language: null,
-        executionId: null,
-        executionCount: null,
-        outputs: [],
-        metadata: {},
-      },
+      markdownViewCell("intro", "# Intro\n\n## Setup", [
+        { title: "Intro", level: 1, slug: "intro" },
+        { title: "Setup", level: 2, slug: "setup" },
+      ]),
     ]);
 
     expect(notebookOutlineItemsToMarkdownHeadingAnchors(outlineItems).get("intro")).toEqual([
@@ -331,3 +347,49 @@ describe("notebook shell view model", () => {
     ]);
   });
 });
+
+function markdownViewCell(
+  id: string,
+  source: string,
+  anchors: readonly { title: string; level: number; slug: string }[],
+): NotebookViewCell {
+  return {
+    id,
+    cellType: "markdown",
+    source,
+    language: null,
+    executionId: null,
+    executionCount: null,
+    outputs: [],
+    metadata: {},
+    markdownProjection: testMarkdownProjection(source, anchors),
+  };
+}
+
+function testMarkdownProjection(
+  source: string,
+  anchors: readonly { title: string; level: number; slug: string }[],
+) {
+  return {
+    version: 1 as const,
+    engine: "test",
+    byteLength: source.length,
+    utf16Length: source.length,
+    measurement: {
+      estimatedHeight: 32,
+      confidence: "high",
+      width: 720,
+    },
+    anchors: anchors.map((anchor, index) => ({
+      anchorId: `anchor:${anchor.slug}`,
+      blockId: `block:${index}`,
+      level: anchor.level,
+      slug: anchor.slug,
+      sourceSpanByte: [0, source.length] as [number, number],
+      sourceSpanUtf16: [0, source.length] as [number, number],
+      title: anchor.title,
+    })),
+    blocks: [],
+    runs: [],
+  };
+}

--- a/src/components/notebook/__tests__/view-model.test.ts
+++ b/src/components/notebook/__tests__/view-model.test.ts
@@ -113,6 +113,30 @@ describe("notebook shell view model", () => {
     }
   });
 
+  it("treats attached empty markdownProjection anchors as authoritative", () => {
+    let calls = 0;
+    const restore = setMarkdownProjectionProjector((source) => {
+      calls += 1;
+      return JSON.stringify(
+        testMarkdownProjection(source, [{ title: "Intro", level: 1, slug: "intro" }]),
+      );
+    });
+
+    try {
+      const outline = notebookViewCellsToOutlineItems([markdownViewCell("intro", "# Intro", [])]);
+
+      expect(calls).toBe(0);
+      expect(outline).toHaveLength(1);
+      expect(outline[0]).toMatchObject({
+        id: "intro:cell",
+        kind: "cell",
+        headingAnchorId: null,
+      });
+    } finally {
+      restore();
+    }
+  });
+
   it("projects Jupyter hidden metadata into read-only render cells", () => {
     const cells: NotebookViewCell[] = [
       {

--- a/src/components/notebook/index.ts
+++ b/src/components/notebook/index.ts
@@ -152,6 +152,7 @@ export {
   resetNotebookCells,
   subscribeIds,
   updateCellById,
+  updateCellSourceById,
   updateNotebookCells,
   useCell,
   useCellIds,

--- a/src/components/notebook/state/cell-store.ts
+++ b/src/components/notebook/state/cell-store.ts
@@ -1,5 +1,5 @@
 import { useMemo, useSyncExternalStore } from "react";
-import type { MarkdownProjectionPlan } from "../../../lib/markdown-projection";
+import { projectMarkdownPlan, type MarkdownProjectionPlan } from "../../../lib/markdown-projection";
 
 export type NotebookCellMetadata = Record<string, unknown>;
 
@@ -307,6 +307,20 @@ export function updateCellById(
   if (updated.source !== cell.source) {
     emitSourceChange();
   }
+}
+
+export function updateCellSourceById(id: string, source: string): void {
+  updateCellById(id, (cell) => {
+    if (cell.cell_type !== "markdown") {
+      return { ...cell, source };
+    }
+
+    return {
+      ...cell,
+      source,
+      markdownProjection: projectMarkdownPlan(source) ?? undefined,
+    };
+  });
 }
 
 /**

--- a/src/components/notebook/state/view-model-store.ts
+++ b/src/components/notebook/state/view-model-store.ts
@@ -46,6 +46,7 @@ export function notebookCellToViewCell(cell: NotebookStoreCell): NotebookViewCel
     executionCount: cell.cell_type === "code" ? cell.execution_count : null,
     outputs: cell.cell_type === "code" ? cell.outputs : [],
     metadata: cell.metadata,
+    markdownProjection: cell.cell_type === "markdown" ? cell.markdownProjection : undefined,
   };
 }
 

--- a/src/components/notebook/view-model.ts
+++ b/src/components/notebook/view-model.ts
@@ -1,6 +1,7 @@
 import type { JupyterOutput } from "@/components/cell/jupyter-output";
 import type { ReadOnlyNotebookCellData } from "@/components/cell/ReadOnlyNotebook";
 import type { SupportedLanguage } from "@/components/editor/languages";
+import { projectMarkdownPlan, type MarkdownProjectionPlan } from "../../lib/markdown-projection";
 import {
   notebookMetadataToPackageViewModel as projectNotebookPackageViewModel,
   type NotebookPackageViewModel,
@@ -26,6 +27,7 @@ export interface NotebookViewCell {
   executionCount: number | null;
   outputs: JupyterOutput[];
   metadata: Record<string, unknown>;
+  markdownProjection?: MarkdownProjectionPlan;
 }
 
 export interface NotebookTracebackCellTarget {
@@ -132,8 +134,16 @@ export function notebookViewCellsToOutlineItems(
 ): NotebookOutlineItem[] {
   return projectNotebookOutline(cells, {
     hrefTarget: "heading",
+    getMarkdownAnchors: notebookViewCellMarkdownAnchors,
     getStatusLabel: options.getStatusLabel ?? notebookViewCellOutlineStatusLabel,
   }).items;
+}
+
+function notebookViewCellMarkdownAnchors(cell: NotebookViewCell) {
+  // Live adapters attach markdownProjection during materialization/source edits.
+  // This Rust/WASM fallback keeps older host adapters correct without reviving
+  // a second heading parser; projectMarkdownPlan is source-key cached.
+  return cell.markdownProjection?.anchors ?? projectMarkdownPlan(cell.source)?.anchors ?? null;
 }
 
 export function notebookViewCellsToTracebackTargets(

--- a/src/components/notebook/view-model.ts
+++ b/src/components/notebook/view-model.ts
@@ -141,9 +141,14 @@ export function notebookViewCellsToOutlineItems(
 
 function notebookViewCellMarkdownAnchors(cell: NotebookViewCell) {
   // Live adapters attach markdownProjection during materialization/source edits.
+  // Treat an attached projection as authoritative, including an empty anchor
+  // list for headingless markdown, so outline projection stays O(cells) and
+  // does not reparse markdown in the common path.
+  if (cell.markdownProjection) return cell.markdownProjection.anchors;
+
   // This Rust/WASM fallback keeps older host adapters correct without reviving
   // a second heading parser; projectMarkdownPlan is source-key cached.
-  return cell.markdownProjection?.anchors ?? projectMarkdownPlan(cell.source)?.anchors ?? null;
+  return projectMarkdownPlan(cell.source)?.anchors ?? null;
 }
 
 export function notebookViewCellsToTracebackTargets(

--- a/src/lib/__tests__/markdown-projection.test.ts
+++ b/src/lib/__tests__/markdown-projection.test.ts
@@ -6,6 +6,7 @@ import {
   canRenderMarkdownProjectionInHost,
   findMarkdownProjectionAtSourcePosition,
   projectMarkdownPlan,
+  setMarkdownProjectionProjector,
 } from "../markdown-projection";
 
 function readMarkdownFixture(name: string): string {
@@ -44,6 +45,77 @@ describe("markdown projection", () => {
       { checked: false, text: "waiting" },
       { checked: undefined, text: "regular" },
     ]);
+  });
+
+  it("projects Rust markdown engine heading anchors for outline consumers", () => {
+    const plan = projectMarkdownPlan(
+      [
+        "Intro",
+        "=====",
+        "",
+        "```md",
+        "# Not an outline heading",
+        "```",
+        "",
+        "## Intro",
+      ].join("\n"),
+    );
+
+    expect(
+      plan?.anchors.map((anchor) => ({
+        slug: anchor.slug,
+        title: anchor.title,
+        level: anchor.level,
+      })),
+    ).toEqual([
+      { slug: "intro", title: "Intro", level: 1 },
+      { slug: "intro-2", title: "Intro", level: 2 },
+    ]);
+  });
+
+  it("reuses immutable cached projections for identical source", () => {
+    let calls = 0;
+    const restore = setMarkdownProjectionProjector((source) => {
+      calls += 1;
+      return JSON.stringify({
+        version: 1,
+        engine: "test",
+        byteLength: source.length,
+        utf16Length: source.length,
+        measurement: {
+          estimatedHeight: 24,
+          confidence: "high",
+          width: 720,
+        },
+        anchors: [
+          {
+            anchorId: "anchor:cached",
+            blockId: "block:0",
+            level: 1,
+            slug: "cached",
+            sourceSpanByte: [0, source.length],
+            sourceSpanUtf16: [0, source.length],
+            title: "Cached",
+          },
+        ],
+        blocks: [],
+        runs: [],
+      });
+    });
+
+    try {
+      const first = projectMarkdownPlan("# Cached");
+      const second = projectMarkdownPlan("# Cached");
+
+      expect(calls).toBe(1);
+      expect(second).toBe(first);
+      expect(Object.isFrozen(first)).toBe(true);
+      expect(Object.isFrozen(first?.anchors)).toBe(true);
+      expect(Object.isFrozen(first?.blocks)).toBe(true);
+      expect(Object.isFrozen(first?.runs)).toBe(true);
+    } finally {
+      restore();
+    }
   });
 
   it("projects inline and display math without markdown delimiters", () => {

--- a/src/lib/__tests__/markdown-projection.test.ts
+++ b/src/lib/__tests__/markdown-projection.test.ts
@@ -113,6 +113,8 @@ describe("markdown projection", () => {
       expect(Object.isFrozen(first?.anchors)).toBe(true);
       expect(Object.isFrozen(first?.blocks)).toBe(true);
       expect(Object.isFrozen(first?.runs)).toBe(true);
+      expect(Object.isFrozen(first?.measurement)).toBe(true);
+      expect(Object.isFrozen(first?.anchors[0])).toBe(true);
     } finally {
       restore();
     }

--- a/src/lib/markdown-projection.ts
+++ b/src/lib/markdown-projection.ts
@@ -5,7 +5,10 @@ export const MARKDOWN_PROJECTION_MIME_TYPE =
 
 type MarkdownProjectionProjector = (source: string) => string;
 
+const MARKDOWN_PROJECTION_CACHE_LIMIT = 128;
+
 let markdownProjectionProjector: MarkdownProjectionProjector = project_markdown_json;
+const markdownProjectionCache = new Map<string, MarkdownProjectionPlan>();
 
 export interface MarkdownProjectionMeasurement {
   estimatedHeight: number;
@@ -27,6 +30,16 @@ export interface MarkdownProjectionBlock {
   sourceSpanUtf16: [number, number];
   syntaxSpans: unknown[];
   text: string;
+}
+
+export interface MarkdownProjectionAnchor {
+  anchorId: string;
+  blockId: string;
+  level: number;
+  slug: string;
+  sourceSpanByte: [number, number];
+  sourceSpanUtf16: [number, number];
+  title: string;
 }
 
 export interface MarkdownProjectionRun {
@@ -61,6 +74,7 @@ export interface MarkdownProjectionPlan {
   utf16Length: number;
   error?: string;
   measurement: MarkdownProjectionMeasurement;
+  anchors: MarkdownProjectionAnchor[];
   blocks: MarkdownProjectionBlock[];
   runs: MarkdownProjectionRun[];
 }
@@ -76,24 +90,55 @@ export function setMarkdownProjectionProjector(
 ): () => void {
   const previousProjector = markdownProjectionProjector;
   markdownProjectionProjector = projector;
+  markdownProjectionCache.clear();
   return () => {
     markdownProjectionProjector = previousProjector;
+    markdownProjectionCache.clear();
   };
 }
 
 export function projectMarkdownPlan(source: string): MarkdownProjectionPlan | null {
   if (!source.trim()) return null;
+  const cached = markdownProjectionCache.get(source);
+  if (cached) {
+    markdownProjectionCache.delete(source);
+    markdownProjectionCache.set(source, cached);
+    return cached;
+  }
 
   try {
     const json = markdownProjectionProjector(source);
-    const plan = JSON.parse(json) as MarkdownProjectionPlan;
+    const plan = normalizeMarkdownProjectionPlan(JSON.parse(json) as MarkdownProjectionPlan);
     if (plan.error) {
       return null;
     }
-    return plan;
+    return cacheMarkdownProjectionPlan(source, plan);
   } catch {
     return null;
   }
+}
+
+function cacheMarkdownProjectionPlan(
+  source: string,
+  plan: MarkdownProjectionPlan,
+): MarkdownProjectionPlan {
+  const cachedPlan = freezeMarkdownProjectionPlan(plan);
+  markdownProjectionCache.set(source, cachedPlan);
+  if (markdownProjectionCache.size <= MARKDOWN_PROJECTION_CACHE_LIMIT) return cachedPlan;
+
+  const oldestSource = markdownProjectionCache.keys().next().value;
+  if (oldestSource !== undefined) {
+    markdownProjectionCache.delete(oldestSource);
+  }
+  return cachedPlan;
+}
+
+function freezeMarkdownProjectionPlan(plan: MarkdownProjectionPlan): MarkdownProjectionPlan {
+  Object.freeze(plan.anchors);
+  Object.freeze(plan.blocks);
+  Object.freeze(plan.runs);
+  Object.freeze(plan);
+  return plan;
 }
 
 function normalizeSourcePosition(plan: MarkdownProjectionPlan, position: number): number {
@@ -151,7 +196,12 @@ export function markdownProjectionPlanFromMimeData(data: unknown): MarkdownProje
     return null;
   }
 
-  return plan;
+  return normalizeMarkdownProjectionPlan(plan);
+}
+
+function normalizeMarkdownProjectionPlan(plan: MarkdownProjectionPlan): MarkdownProjectionPlan {
+  if (Array.isArray(plan.anchors)) return plan;
+  return { ...plan, anchors: [] };
 }
 
 export function projectedMarkdownPreviewHeight(

--- a/src/lib/markdown-projection.ts
+++ b/src/lib/markdown-projection.ts
@@ -11,72 +11,72 @@ let markdownProjectionProjector: MarkdownProjectionProjector = project_markdown_
 const markdownProjectionCache = new Map<string, MarkdownProjectionPlan>();
 
 export interface MarkdownProjectionMeasurement {
-  estimatedHeight: number;
-  confidence: "low" | "medium" | "high" | string;
-  width: number;
+  readonly estimatedHeight: number;
+  readonly confidence: "low" | "medium" | "high" | string;
+  readonly width: number;
 }
 
 export interface MarkdownProjectionBlock {
-  anchorSlug?: string;
-  blockId: string;
-  blockIndex: number;
-  codeLanguage?: string;
-  codeMeta?: string;
-  element: string;
-  kind: string;
-  measurement: MarkdownProjectionMeasurement & { basis?: string };
-  ordered?: boolean;
-  sourceSpanByte: [number, number];
-  sourceSpanUtf16: [number, number];
-  syntaxSpans: unknown[];
-  text: string;
+  readonly anchorSlug?: string;
+  readonly blockId: string;
+  readonly blockIndex: number;
+  readonly codeLanguage?: string;
+  readonly codeMeta?: string;
+  readonly element: string;
+  readonly kind: string;
+  readonly measurement: MarkdownProjectionMeasurement & { readonly basis?: string };
+  readonly ordered?: boolean;
+  readonly sourceSpanByte: readonly [number, number];
+  readonly sourceSpanUtf16: readonly [number, number];
+  readonly syntaxSpans: readonly unknown[];
+  readonly text: string;
 }
 
 export interface MarkdownProjectionAnchor {
-  anchorId: string;
-  blockId: string;
-  level: number;
-  slug: string;
-  sourceSpanByte: [number, number];
-  sourceSpanUtf16: [number, number];
-  title: string;
+  readonly anchorId: string;
+  readonly blockId: string;
+  readonly level: number;
+  readonly slug: string;
+  readonly sourceSpanByte: readonly [number, number];
+  readonly sourceSpanUtf16: readonly [number, number];
+  readonly title: string;
 }
 
 export interface MarkdownProjectionRun {
-  blockId: string;
-  imageAlt?: string;
-  imageSrc?: string;
-  imageTitle?: string;
-  inlineId: string;
-  listItemIndex: number | null;
-  listItemChecked?: boolean;
-  listItemDepth?: number;
-  listItemOrdered?: boolean;
-  listItemPath?: string;
-  href?: string;
-  title?: string;
-  renderedHtml?: string;
-  renderedText: string;
-  renderedTextUtf16: [number, number];
-  semantic: string;
-  sourceSpanByte: [number, number];
-  sourceSpanUtf16: [number, number];
-  tableCellAlign?: "none" | "left" | "right" | "center" | string;
-  tableCellHeader?: boolean;
-  tableCellIndex?: number;
-  tableRowIndex?: number;
+  readonly blockId: string;
+  readonly imageAlt?: string;
+  readonly imageSrc?: string;
+  readonly imageTitle?: string;
+  readonly inlineId: string;
+  readonly listItemIndex: number | null;
+  readonly listItemChecked?: boolean;
+  readonly listItemDepth?: number;
+  readonly listItemOrdered?: boolean;
+  readonly listItemPath?: string;
+  readonly href?: string;
+  readonly title?: string;
+  readonly renderedHtml?: string;
+  readonly renderedText: string;
+  readonly renderedTextUtf16: readonly [number, number];
+  readonly semantic: string;
+  readonly sourceSpanByte: readonly [number, number];
+  readonly sourceSpanUtf16: readonly [number, number];
+  readonly tableCellAlign?: "none" | "left" | "right" | "center" | string;
+  readonly tableCellHeader?: boolean;
+  readonly tableCellIndex?: number;
+  readonly tableRowIndex?: number;
 }
 
 export interface MarkdownProjectionPlan {
-  version: 1;
-  engine: string;
-  byteLength: number;
-  utf16Length: number;
-  error?: string;
-  measurement: MarkdownProjectionMeasurement;
-  anchors: MarkdownProjectionAnchor[];
-  blocks: MarkdownProjectionBlock[];
-  runs: MarkdownProjectionRun[];
+  readonly version: 1;
+  readonly engine: string;
+  readonly byteLength: number;
+  readonly utf16Length: number;
+  readonly error?: string;
+  readonly measurement: MarkdownProjectionMeasurement;
+  readonly anchors: readonly MarkdownProjectionAnchor[];
+  readonly blocks: readonly MarkdownProjectionBlock[];
+  readonly runs: readonly MarkdownProjectionRun[];
 }
 
 export interface MarkdownProjectionSourceMatch {
@@ -134,6 +134,18 @@ function cacheMarkdownProjectionPlan(
 }
 
 function freezeMarkdownProjectionPlan(plan: MarkdownProjectionPlan): MarkdownProjectionPlan {
+  Object.freeze(plan.measurement);
+  for (const anchor of plan.anchors) {
+    Object.freeze(anchor);
+  }
+  for (const block of plan.blocks) {
+    Object.freeze(block.measurement);
+    Object.freeze(block.syntaxSpans);
+    Object.freeze(block);
+  }
+  for (const run of plan.runs) {
+    Object.freeze(run);
+  }
   Object.freeze(plan.anchors);
   Object.freeze(plan.blocks);
   Object.freeze(plan.runs);
@@ -147,7 +159,7 @@ function normalizeSourcePosition(plan: MarkdownProjectionPlan, position: number)
 }
 
 function spanContainsPosition(
-  span: [number, number],
+  span: readonly [number, number],
   position: number,
 ): boolean {
   const [start, end] = span;
@@ -155,7 +167,7 @@ function spanContainsPosition(
   return position >= start && position <= end;
 }
 
-function spanLength(span: [number, number]): number {
+function spanLength(span: readonly [number, number]): number {
   return Math.max(0, span[1] - span[0]);
 }
 


### PR DESCRIPTION
## Summary
- expose Rust markdown engine heading anchors through the WASM markdown projection JSON
- make the shared notebook outline projection consume projected anchors instead of reparsing markdown in TypeScript
- keep markdown projections stable with a bounded source-keyed LRU cache, readonly/frozen cached plans, cloud/source-edit projection reuse, and a Rust/WASM fallback only when host adapters have not attached a projection
- tolerate stale/mismatched cloud viewer WASM handles that do not expose CommsDoc sync methods so preview live sync does not fail with `flush_comms_doc_sync is not a function`

## Validation
- cargo xtask lint --fix
- pnpm test:run
- pnpm test:run -- src/lib/__tests__/markdown-projection.test.ts src/components/notebook/__tests__/view-model.test.ts
- pnpm --filter notebook-cloud typecheck
- pnpm --dir apps/notebook exec tsc -b
- pnpm --filter notebook-cloud exec node --import tsx --test test/live-sync.test.ts
- pnpm --filter notebook-cloud exec node --import tsx --test test/notebook-view-store-bridge.test.ts
- pnpm --dir apps/notebook build
- pnpm --dir apps/elements build
- pnpm --dir apps/notebook-cloud build:viewer
- cargo xtask wasm
- PATH="$HOME/.deno/bin:$PATH" deno test --allow-read --allow-env --no-check crates/runtimed-wasm/tests
- cargo test -p nteract-markdown-wasm -p nteract-markdown-engine
- pr-review https://github.com/nteract/nteract/pull/3447 --max-turns 120 (clear; report: .context/reviews/pr-3447-rebased-final2.json)