### PR TITLE
fix(py): project CommsDoc widget state

### DIFF
--- a/crates/notebook-sync/src/handle.rs
+++ b/crates/notebook-sync/src/handle.rs
@@ -170,13 +170,22 @@ impl DocHandle {
         Ok(notebook_doc::actor_label_from_id(state.doc.get_actor()))
     }
 
-    /// Read the current runtime state from the synced RuntimeStateDoc.
+    /// Read the current runtime state from synced runtime documents.
     ///
     /// Returns the latest snapshot of kernel status, queue, env sync,
-    /// and last_saved as seen by this client's Automerge replica.
+    /// last_saved, and projected widget comms as seen by this client's
+    /// Automerge replicas. RuntimeStateDoc owns comm topology, while CommsDoc
+    /// owns mutable widget state; this returns the client-facing projection.
     pub fn get_runtime_state(&self) -> Result<RuntimeState, SyncError> {
         let state = self.doc.lock().map_err(|_| SyncError::LockPoisoned)?;
-        Ok(state.state_doc.read_state())
+        let mut runtime_state = state.state_doc.read_state();
+        let comm_states = state.comms_doc.get_comms();
+        for (comm_id, comm_state) in comm_states {
+            if let Some(entry) = runtime_state.comms.get_mut(&comm_id) {
+                entry.state = comm_state;
+            }
+        }
+        Ok(runtime_state)
     }
 
     // =====================================================================

--- a/crates/notebook-sync/src/tests.rs
+++ b/crates/notebook-sync/src/tests.rs
@@ -894,6 +894,56 @@ mod tests {
     }
 
     #[test]
+    fn get_runtime_state_projects_comms_doc_state_onto_runtime_topology() {
+        let (handle, shared, _changed_rx, _cmd_rx) = test_handle_with_shared();
+
+        {
+            let mut st = shared.lock().unwrap();
+            st.state_doc
+                .put_comm(
+                    "comm-1",
+                    "jupyter.widget",
+                    "@jupyter-widgets/controls",
+                    "IntSliderModel",
+                    &serde_json::json!({"legacy": true}),
+                    3,
+                )
+                .unwrap();
+            st.state_doc
+                .put_comm(
+                    "legacy-only",
+                    "jupyter.widget",
+                    "@jupyter-widgets/controls",
+                    "ButtonModel",
+                    &serde_json::json!({"description": "fallback"}),
+                    4,
+                )
+                .unwrap();
+            st.comms_doc
+                .put_comm_state(
+                    "comm-1",
+                    &serde_json::json!({"value": 7, "description": "probe"}),
+                )
+                .unwrap();
+            st.comms_doc
+                .put_comm_state("orphan", &serde_json::json!({"value": 404}))
+                .unwrap();
+        }
+
+        let state = handle.get_runtime_state().unwrap();
+
+        assert_eq!(
+            state.comms["comm-1"].state,
+            serde_json::json!({"value": 7, "description": "probe"})
+        );
+        assert_eq!(
+            state.comms["legacy-only"].state,
+            serde_json::json!({"description": "fallback"})
+        );
+        assert!(!state.comms.contains_key("orphan"));
+    }
+
+    #[test]
     fn get_cell_execution_count_falls_back_to_notebook_doc() {
         let (handle, _shared, _rx, _cmd_rx) = test_handle_with_shared();
 

--- a/crates/runtimed-py/src/output.rs
+++ b/crates/runtimed-py/src/output.rs
@@ -1250,7 +1250,7 @@ impl PyCommDocEntry {
     }
 }
 
-/// Full runtime state snapshot from the daemon's RuntimeStateDoc.
+/// Full runtime state snapshot projected from the daemon's runtime documents.
 #[pyclass(name = "RuntimeState", get_all, skip_from_py_object)]
 #[derive(Clone, Debug)]
 pub struct PyRuntimeState {
@@ -1266,7 +1266,8 @@ pub struct PyRuntimeState {
     pub last_saved: Option<String>,
     /// Execution lifecycle entries keyed by execution_id.
     pub executions: std::collections::HashMap<String, PyExecutionState>,
-    /// Active comm channels keyed by comm_id.
+    /// Active comm channels keyed by comm_id. Topology comes from
+    /// RuntimeStateDoc; mutable widget state is projected from CommsDoc.
     pub comms: std::collections::HashMap<String, PyCommDocEntry>,
     /// Daemon-observed project-file context, serialised as a JSON
     /// string. Shape mirrors the Rust `ProjectContext` tagged enum so

--- a/python/runtimed/src/runtimed/_notebook.py
+++ b/python/runtimed/src/runtimed/_notebook.py
@@ -75,8 +75,9 @@ class Notebook:
     def _widgets(self) -> dict:
         """Private snapshot of active ipywidget comms keyed by comm_id.
 
-        This reads from RuntimeStateDoc via the local CRDT replica. It is for
-        tests and diagnostics, not a stable Python widget API.
+        This reads the local CRDT projection of RuntimeStateDoc topology plus
+        CommsDoc state. It is for tests and diagnostics, not a stable Python
+        widget API.
         """
         return {
             cid: entry


### PR DESCRIPTION
## Summary

- Project CommsDoc widget state into notebook-sync runtime snapshots.
- Keep RuntimeStateDoc comm topology as the gate, preserving legacy embedded state fallback.
- Update Python-facing docs/comments and cover the projection with a notebook-sync unit test.

## Main CI failure

Fixes the current `main` `runtimed-py Integration Tests` failure in run 27067297980:

`TestWidgetRuntimeState::test_private_widget_snapshot_reads_runtime_state_comms` timed out waiting for widget comm state after the CommsDoc split.

## Verification

- `cargo xtask artifacts status`
- `cargo test -p notebook-sync get_runtime_state_projects_comms_doc_state_onto_runtime_topology`
- `cargo build -p runtimed`
- `cd crates/runtimed-py && VIRTUAL_ENV=../../.venv uv run --active --directory ../../python/runtimed maturin develop`
- `cd python/runtimed && RUNTIMED_INTEGRATION_TEST=1 RUNTIMED_BINARY="$(git rev-parse --show-toplevel)/target/debug/runtimed" RUNTIMED_LOG_LEVEL=debug RUNTIMED_WORKSPACE_PATH="$(git rev-parse --show-toplevel)" RUNTIMED_TEST_UV_POOL_SIZE=1 RUNTIMED_TEST_CONDA_POOL_SIZE=0 RUNTIMED_INTEGRATION_LOG_DIR="$(git rev-parse --show-toplevel)/python/runtimed/integration-logs" VIRTUAL_ENV="$(git rev-parse --show-toplevel)/.venv" uv run pytest tests/test_daemon_integration.py::TestWidgetRuntimeState::test_private_widget_snapshot_reads_runtime_state_comms -vv -s`
- `cargo test -p notebook-sync`
- `cargo test -p runtimed-py --lib --no-default-features`
- `cargo xtask lint --fix`
- `git diff --check`
