### PR TITLE
docs(cloud): clarify preview deploy runbook

### DIFF
--- a/apps/notebook-cloud/DEPLOY.md
+++ b/apps/notebook-cloud/DEPLOY.md
@@ -20,6 +20,12 @@ main Worker with `wrangler.toml`. The top-level `wrangler.toml` is the prototype
 config (custom domain `preview.runt.run`, `DEPLOYMENT_ENV=prototype`), so there
 is no `--env` flag.
 
+Keep the renderer-assets deploy ahead of the main Worker. The viewer loads
+content-hashed runtime WASM from the main Worker's
+`/assets/runtime-wasm-assets.json`, and compatibility copies are also posted to
+the renderer-assets Worker. Shipping only the main Worker can leave browser tabs
+running new viewer JavaScript against stale sidecar WASM.
+
 ## Verify
 
 ```bash
@@ -36,6 +42,11 @@ pnpm run deploy:check
   `wrangler whoami` should show `workers (write)`, `d1 (write)`, and
   `workers_routes (write)`.
 - A Rust toolchain and `cargo xtask` for the WASM build.
+- `wrangler.toml` keeps the Anaconda API-key userinfo URL on the same staging
+  origin as the OIDC issuer:
+  `https://auth.stage.anaconda.com/api/auth/sessions/whoami`. A production
+  `anaconda.com` whoami endpoint rejects staging-minted API keys even though the
+  OIDC path still works.
 
 ## Scope
 

--- a/apps/notebook-cloud/README.md
+++ b/apps/notebook-cloud/README.md
@@ -434,17 +434,31 @@ pnpm --workspace-root exec wrangler d1 migrations apply nteract-notebook-cloud-p
   --remote
 ```
 
-Deploy with:
+Deploy changed notebook-cloud Worker assets with:
 
 ```bash
 printf "%s" "$NOTEBOOK_CLOUD_DEV_TOKEN" \
   | pnpm --workspace-root exec wrangler secret put NOTEBOOK_CLOUD_DEV_TOKEN \
       --config apps/notebook-cloud/wrangler.toml
-pnpm --dir apps/notebook-cloud build
-pnpm --workspace-root exec wrangler deploy --config apps/notebook-cloud/wrangler.renderer-assets.toml
-pnpm --workspace-root exec wrangler deploy --config apps/notebook-cloud/wrangler.output-document.toml
-pnpm --workspace-root exec wrangler deploy --config apps/notebook-cloud/wrangler.toml
+pnpm --dir apps/notebook-cloud run deploy
 ```
+
+`pnpm run deploy` builds the viewer and runtime WASM assets, deploys
+`wrangler.renderer-assets.toml`, then deploys `wrangler.toml`. Keep that order:
+the viewer reads the content-hashed runtime WASM manifest from the main Worker,
+and the renderer-assets Worker carries compatibility copies for sidecar loading.
+Deploy the output document Worker separately only when `dist-output-document` or
+`wrangler.output-document.toml` changes:
+
+```bash
+pnpm --workspace-root exec wrangler deploy --config apps/notebook-cloud/wrangler.output-document.toml
+```
+
+The preview config intentionally validates Anaconda API keys against
+`https://auth.stage.anaconda.com/api/auth/sessions/whoami`, matching the staging
+OIDC issuer. Pointing that value at production `anaconda.com` makes
+staging-minted keys fail with `Anaconda API key validation failed` while OIDC
+continues to work.
 
 ## Operational observability
 

--- a/apps/notebook-cloud/scripts/hosted-render-smoke.mjs
+++ b/apps/notebook-cloud/scripts/hosted-render-smoke.mjs
@@ -33,7 +33,8 @@ import { catalogApiUrlForViewer, isRenderCacheApiUrl } from "./hosted-render-smo
 const DEFAULT_URL = "https://preview.runt.run/n/topic-viz/topic-viz";
 const DEFAULT_RENDERER_ASSET_ORIGIN = "https://nteract-notebook-cloud-assets.rgbkrk.workers.dev";
 const DEFAULT_OUTPUT_DOCUMENT_ORIGIN = "https://preview.runtusercontent.com";
-const DEFAULT_CATALOG_OWNER_PRINCIPAL = "user:anaconda:fe0f6c3a-f7c7-4c04-9b8d-77e596da1375";
+const DEFAULT_CATALOG_OWNER_PRINCIPAL =
+  "account:user%3Aanaconda:email:b0204af7084bdb0f271f1fe243bea5973fe07e0264939605e1570ecb1604b3f0";
 const DEFAULT_LATEST_REVISION_ACTOR_LABEL =
   "user:anaconda:fdb3dc7d-c369-4a39-bf7d-e35b77a0bdd0/agent:runt-publish";
 
@@ -43,7 +44,7 @@ const expectedRendererAssetOrigin =
 const expectedOutputDocumentOrigin =
   process.env.NOTEBOOK_CLOUD_EXPECTED_OUTPUT_DOCUMENT_ORIGIN ?? DEFAULT_OUTPUT_DOCUMENT_ORIGIN;
 const expectedSourceText =
-  process.env.NOTEBOOK_CLOUD_EXPECTED_SOURCE_TEXT ?? "from datasets import load_dataset";
+  process.env.NOTEBOOK_CLOUD_EXPECTED_SOURCE_TEXT ?? "import plotly.graph_objects as go";
 const expectedExecutionCount = process.env.NOTEBOOK_CLOUD_EXPECTED_EXECUTION_COUNT ?? null;
 const requireRenderedCellMarker = process.env.NOTEBOOK_CLOUD_REQUIRE_RENDERED_CELL_MARKER !== "0";
 const expectedPresenceTitle = process.env.NOTEBOOK_CLOUD_EXPECTED_PRESENCE_TITLE ?? "participant";


### PR DESCRIPTION
## Summary
- refresh the default hosted smoke expectations for the current `topic-viz` preview fixture
- document the preview deploy order now that runtime WASM assets are content-hashed
- call out the staging Anaconda API-key whoami endpoint so redeploys do not regress API-key auth

## Verification
- `pnpm --filter notebook-cloud exec node --test test/hosted-smoke-runtime-wasm.test.mjs test/hosted-smoke-catalog.test.mjs test/deploy-config.test.mjs`
- `pnpm --filter notebook-cloud test`
- `pnpm --filter notebook-cloud typecheck`
- `pnpm --dir apps/notebook-cloud run smoke:hosted`
- `cargo xtask lint --fix`

## Preview deploy notes
Preview is already deployed from the merged hashed-runtime-WASM path plus #3450's staging API-key URL. Live checks saw `/assets/runtime-wasm-assets.json` return `runtimed_wasm.2a4d49a928ef9f29.js` and `runtimed_wasm_bg.7fdf1423d1b81908.wasm`; the same-origin copies are revalidated and the renderer-assets Worker copies are immutable.
