### PR TITLE
fix(cloud): keep runtime peer execution sync live

### DIFF
--- a/apps/notebook-cloud/src/notebook-room.ts
+++ b/apps/notebook-cloud/src/notebook-room.ts
@@ -72,12 +72,14 @@ export class NotebookRoom {
   private framePersistQueue: Promise<void> = Promise.resolve();
   private broadcastDepth = 0;
   private readonly materializers = new Map<string, RoomMaterializer>();
+  private readonly restoredPeersReady: Promise<void>;
 
   constructor(
     private readonly state: DurableObjectState,
     private readonly env: Env,
   ) {
-    this.restoreHibernatedPeers();
+    this.restoredPeersReady = this.restoreHibernatedPeers();
+    this.state.waitUntil(this.restoredPeersReady);
   }
 
   async fetch(request: Request): Promise<Response> {
@@ -98,6 +100,8 @@ export class NotebookRoom {
     } catch (error) {
       return json({ error: String(error) }, 401);
     }
+
+    await this.restoredPeersReady;
 
     const pair = new WebSocketPair();
     const client = pair[0];
@@ -176,6 +180,7 @@ export class NotebookRoom {
       return;
     }
 
+    await this.restoredPeersReady;
     await this.handleMessage(attachment.notebookId, peer, message);
   }
 
@@ -187,26 +192,37 @@ export class NotebookRoom {
     this.removeAttachedPeer(socket);
   }
 
-  private restoreHibernatedPeers(): void {
+  private async restoreHibernatedPeers(): Promise<void> {
     const sockets = this.state.getWebSockets?.() ?? [];
+    const restored: Array<{ notebookId: string; peer: Peer }> = [];
     for (const socket of sockets) {
       const attachment = socketAttachment(socket);
       if (!attachment) {
         continue;
       }
 
-      this.peers.set(attachment.peerId, {
+      const peer = {
         id: attachment.peerId,
         socket,
         identity: attachment.identity,
         connectedAt: attachment.connectedAt,
-      });
+      };
+      this.peers.set(attachment.peerId, peer);
+      restored.push({ notebookId: attachment.notebookId, peer });
     }
     if (sockets.length > 0) {
       cloudLog("info", "room.hibernation.restored_peers", {
         restored_peer_count: this.peers.size,
       });
     }
+    await Promise.all(
+      restored.map(async ({ notebookId, peer }) => {
+        await this.syncPeerFromRoomHost(notebookId, peer);
+        if (peer.identity.scope === "runtime_peer") {
+          this.refreshRuntimePeerWatch(notebookId);
+        }
+      }),
+    );
   }
 
   private acceptPeerSocket(notebookId: string, peer: Peer): void {

--- a/apps/notebook-cloud/test/notebook-room.test.ts
+++ b/apps/notebook-cloud/test/notebook-room.test.ts
@@ -282,6 +282,35 @@ describe("NotebookRoom peer lifecycle", () => {
     );
     assert.equal(staleSocket.closed, true);
   });
+
+  it("re-registers hibernated peers with the room host sync state", async () => {
+    const identity = authenticateDevRequest(
+      new Request(
+        "https://cloud.test/n/demo/sync?user=runtime&operator=runtime:py&scope=runtime_peer",
+      ),
+    );
+    const socket = new FakeSocket();
+    socket.serializeAttachment({
+      notebookId: "demo",
+      peerId: "runtime-peer",
+      identity,
+      connectedAt: "2026-06-06T00:00:00.000Z",
+    });
+    const state = hibernatedState([socket.asCloudflareWebSocket()]);
+    const room = new NotebookRoom(state.state, {} as Env);
+
+    await state.drain();
+
+    assert.equal(
+      roomHarness(room).peerForSocket(socket.asCloudflareWebSocket())?.id,
+      "runtime-peer",
+      "the hibernated socket is restored into the peer map",
+    );
+    assert(
+      socket.sent.some((frame) => frame[0] === FrameType.RUNTIME_STATE_SYNC),
+      "restored peers receive RuntimeStateDoc sync so future ExecuteCell fanout can target them",
+    );
+  });
 });
 
 describe("NotebookRoom materialized sync persistence", () => {
@@ -668,6 +697,39 @@ function fakeState(): DurableObjectState {
       list: async <T>() => new Map(values as Map<string, T>),
     },
     waitUntil: () => undefined,
+  };
+}
+
+function hibernatedState(sockets: CloudflareWebSocket[]): {
+  state: DurableObjectState;
+  drain(): Promise<void>;
+} {
+  const values = new Map<string, unknown>();
+  const pending: Promise<unknown>[] = [];
+  return {
+    state: {
+      id: { toString: () => "room-id" },
+      storage: {
+        get: async <T>(key: string) => values.get(key) as T | undefined,
+        put: async <T>(key: string, value: T) => {
+          values.set(key, value);
+        },
+        delete: async (key: string) => values.delete(key),
+        list: async <T>() => new Map(values as Map<string, T>),
+        deleteAlarm: async () => undefined,
+        setAlarm: async () => undefined,
+      },
+      getWebSockets: () => sockets,
+      waitUntil: (promise: Promise<unknown>) => {
+        pending.push(promise.catch(() => undefined));
+      },
+    },
+    drain: async () => {
+      while (pending.length > 0) {
+        const batch = pending.splice(0, pending.length);
+        await Promise.all(batch);
+      }
+    },
   };
 }
 

--- a/crates/runtimed-wasm/src/lib.rs
+++ b/crates/runtimed-wasm/src/lib.rs
@@ -3943,6 +3943,47 @@ mod tests {
     }
 
     #[test]
+    fn hosted_execute_cell_fans_out_runtime_state_to_runtime_peer() {
+        let mut host = RoomHostHandle::create_empty("demo", "system/schema:notebook-cloud-room")
+            .expect("create room host");
+        host.seed_initial_code_cell_if_empty("cell-1")
+            .expect("seed code cell");
+        host.doc
+            .update_source("cell-1", "print('from owner')")
+            .expect("set source");
+
+        // Register a runtime_peer the same way cloud_room_ready + sync_peer do:
+        // the initial sync advances that peer's room-host sync state, so a
+        // later ExecuteCell should fan out only the new queued execution.
+        let mut initial = Vec::new();
+        host.queue_current_sync_for_peer("runtime-peer", false, true, true, &mut initial)
+            .expect("initial runtime peer sync");
+        assert!(
+            initial
+                .iter()
+                .any(|f| f.peer_id == "runtime-peer"
+                    && f.frame_type == frame_types::RUNTIME_STATE_SYNC),
+            "initial sync registers the runtime peer for RuntimeStateDoc updates"
+        );
+
+        let result = host
+            .handle_execute_cell(
+                &json!({ "action": "execute_cell", "cell_id": "cell-1" }),
+                "owner-peer",
+                "user:anaconda:alice/browser:cloud",
+            )
+            .expect("dispatch ok");
+
+        assert!(result.runtime_state_changed);
+        assert!(
+            result.outbound.iter().any(|f| {
+                f.peer_id == "runtime-peer" && f.frame_type == frame_types::RUNTIME_STATE_SYNC
+            }),
+            "queued execution should be broadcast to the registered runtime peer"
+        );
+    }
+
+    #[test]
     fn hosted_execute_cell_honors_client_supplied_execution_id() {
         let mut host = RoomHostHandle::create_empty("demo", "system/schema:notebook-cloud-room")
             .expect("create room host");

--- a/crates/runtimed/src/jupyter_kernel.rs
+++ b/crates/runtimed/src/jupyter_kernel.rs
@@ -323,7 +323,7 @@ pub struct JupyterKernel {
     pub env_path: Option<PathBuf>,
     /// Session ID for Jupyter protocol.
     session_id: String,
-    /// Automerge actor ID for kernel writes (e.g. "rt:kernel:a1b2c3d4").
+    /// Automerge actor ID for kernel writes.
     kernel_actor_id: String,
     /// Connection info for the kernel.
     connection_info: Option<ConnectionInfo>,
@@ -1211,7 +1211,10 @@ impl KernelConnection for JupyterKernel {
 
         // Fresh session_id for ZMQ connections
         let session_id = Uuid::new_v4().to_string();
-        let kernel_actor_id = format!("rt:kernel:{}", &session_id[..8]);
+        let kernel_actor_id = match shared.kernel_actor_principal.as_deref() {
+            Some(principal) => format!("{principal}/runtime:kernel:{}", &session_id[..8]),
+            None => format!("rt:kernel:{}", &session_id[..8]),
+        };
 
         // ── ZMQ connections and background tasks ─────────────────────────
 

--- a/crates/runtimed/src/kernel_connection.rs
+++ b/crates/runtimed/src/kernel_connection.rs
@@ -69,6 +69,12 @@ pub struct KernelSharedRefs {
     pub presence: Arc<RwLock<PresenceState>>,
     /// Broadcast channel for presence frames.
     pub presence_tx: broadcast::Sender<(String, Vec<u8>)>,
+    /// Principal prefix for kernel-authored RuntimeStateDoc changes.
+    ///
+    /// Cloud rooms require every actor to be a durable
+    /// `<principal>/<operator>` label. The desktop/UDS path leaves this unset
+    /// and keeps the legacy `rt:kernel:*` actor prefix.
+    pub kernel_actor_principal: Option<String>,
 }
 
 /// Internal abstraction over the Jupyter ZeroMQ IO boundary.

--- a/crates/runtimed/src/runtime_agent.rs
+++ b/crates/runtimed/src/runtime_agent.rs
@@ -221,7 +221,7 @@ fn is_kernel_authored_actor(actor: &automerge::ActorId, principal: Option<&str>)
     let Some(principal) = principal else {
         return false;
     };
-    let Ok(label) = std::str::from_utf8(&bytes) else {
+    let Ok(label) = std::str::from_utf8(bytes) else {
         return false;
     };
     let Some((actor_principal, operator)) = label.split_once('/') else {

--- a/crates/runtimed/src/runtime_agent.rs
+++ b/crates/runtimed/src/runtime_agent.rs
@@ -95,6 +95,7 @@ struct RuntimeAgentContext {
     broadcast_tx: broadcast::Sender<notebook_protocol::protocol::NotebookBroadcast>,
     presence: Arc<RwLock<PresenceState>>,
     presence_tx: broadcast::Sender<(String, Vec<u8>)>,
+    kernel_actor_principal: Option<String>,
 }
 
 /// Run the runtime agent, connecting to the daemon socket as a peer.
@@ -207,6 +208,28 @@ fn cloud_actor_label(principal: &str, operator: &str) -> String {
     format!("{principal}/{operator}:{}", &nonce[..8])
 }
 
+fn kernel_actor_principal_from_runtime_actor(actor_label: &str) -> Option<&str> {
+    actor_label.split_once('/').map(|(principal, _)| principal)
+}
+
+fn is_kernel_authored_actor(actor: &automerge::ActorId, principal: Option<&str>) -> bool {
+    let bytes = actor.to_bytes();
+    if bytes.starts_with(b"rt:kernel:") {
+        return true;
+    }
+
+    let Some(principal) = principal else {
+        return false;
+    };
+    let Ok(label) = std::str::from_utf8(&bytes) else {
+        return false;
+    };
+    let Some((actor_principal, operator)) = label.split_once('/') else {
+        return false;
+    };
+    actor_principal == principal && operator.starts_with("runtime:kernel:")
+}
+
 /// Carry the interpreter path through to `launch()` for a no-pool launch.
 ///
 /// `current_python` (and any prepares-own-env source) sets `python_path` with no
@@ -273,6 +296,8 @@ where
         "[runtime-agent] Bootstrapping notebook_id={} as actor {}",
         notebook_id, runtime_agent_id
     );
+    let kernel_actor_principal =
+        kernel_actor_principal_from_runtime_actor(&runtime_agent_id).map(str::to_string);
 
     let state_doc = RuntimeStateDoc::try_new_with_actor(&runtime_agent_id)
         .map_err(|e| anyhow::anyhow!("create runtime-agent state doc: {e}"))?;
@@ -305,6 +330,7 @@ where
         broadcast_tx: broadcast_tx.clone(),
         presence,
         presence_tx,
+        kernel_actor_principal,
     };
 
     // -- Local variables owned by the select! loop (no mutex) ---------------
@@ -652,7 +678,12 @@ where
                                         match comms_doc.receive_sync_and_foreign_comms_recovering(
                                             &mut comms_sync_state,
                                             msg,
-                                            |actor| !actor.to_bytes().starts_with(b"rt:kernel:"),
+                                            |actor| {
+                                                !is_kernel_authored_actor(
+                                                    actor,
+                                                    ctx.kernel_actor_principal.as_deref(),
+                                                )
+                                            },
                                             "runtime-agent-comms-receive",
                                         ) {
                                             Ok(view) if !view.applied_actors.is_empty() => {
@@ -813,6 +844,25 @@ where
                                 // (source comes from execution entries), but it may be
                                 // useful for completions context in the future.
                                 debug!("[runtime-agent] Received NotebookDoc sync frame (ignored for now)");
+                            }
+
+                            NotebookFrameType::SessionControl => {
+                                if let Ok(control) =
+                                    serde_json::from_slice::<serde_json::Value>(&typed_frame.payload)
+                                {
+                                    if control.get("type").and_then(|v| v.as_str())
+                                        == Some("cloud_frame_rejected")
+                                    {
+                                        warn!(
+                                            "[runtime-agent] Cloud room rejected frame: frame_type={:?} reason={}",
+                                            control.get("frame_type"),
+                                            control
+                                                .get("reason")
+                                                .and_then(|v| v.as_str())
+                                                .unwrap_or("(no reason given)")
+                                        );
+                                    }
+                                }
                             }
 
                             _ => {
@@ -1005,8 +1055,12 @@ where
                             );
                             break;
                         }
-                    };
+                };
                 if let Some(encoded) = encoded {
+                    debug!(
+                        "[runtime-agent] Sending RuntimeStateSync to coordinator ({} bytes)",
+                        encoded.len()
+                    );
                     if let Err(e) = frame_sink.send_frame(
                         NotebookFrameType::RuntimeStateSync,
                         &encoded,
@@ -1355,6 +1409,7 @@ async fn handle_runtime_agent_request(
                 broadcast_tx: ctx.broadcast_tx.clone(),
                 presence: ctx.presence.clone(),
                 presence_tx: ctx.presence_tx.clone(),
+                kernel_actor_principal: ctx.kernel_actor_principal.clone(),
             };
             let launch_kernel_type = kernel_type.clone();
             let launch_env_source = env_source.as_str().to_string();
@@ -1474,6 +1529,7 @@ async fn handle_runtime_agent_request(
                 broadcast_tx: ctx.broadcast_tx.clone(),
                 presence: ctx.presence.clone(),
                 presence_tx: ctx.presence_tx.clone(),
+                kernel_actor_principal: ctx.kernel_actor_principal.clone(),
             };
             let launch_kernel_type = kernel_type.clone();
             let launch_env_source = env_source.as_str().to_string();
@@ -2573,6 +2629,39 @@ mod tests {
         assert_ne!(a, b);
     }
 
+    #[test]
+    fn kernel_actor_principal_tracks_cloud_actor_principal() {
+        let actor = "user:anaconda:alice/agent:runt:12345678";
+        assert_eq!(
+            kernel_actor_principal_from_runtime_actor(actor),
+            Some("user:anaconda:alice")
+        );
+        assert_eq!(
+            kernel_actor_principal_from_runtime_actor("runtime-agent:local"),
+            None
+        );
+    }
+
+    #[test]
+    fn kernel_authored_actor_recognizes_legacy_and_cloud_kernel_labels() {
+        let legacy = automerge::ActorId::from(b"rt:kernel:deadbeef".as_slice());
+        assert!(is_kernel_authored_actor(&legacy, None));
+
+        let cloud =
+            automerge::ActorId::from(b"user:anaconda:alice/runtime:kernel:deadbeef".as_slice());
+        assert!(is_kernel_authored_actor(
+            &cloud,
+            Some("user:anaconda:alice")
+        ));
+        assert!(!is_kernel_authored_actor(&cloud, Some("user:anaconda:bob")));
+
+        let agent = automerge::ActorId::from(b"user:anaconda:alice/agent:runt:12345678".as_slice());
+        assert!(!is_kernel_authored_actor(
+            &agent,
+            Some("user:anaconda:alice")
+        ));
+    }
+
     /// The cloud actor resolver (the closure `run_cloud_runtime_agent` passes
     /// into `run_runtime_agent_on_transport`) must error rather than silently
     /// author under a wrong actor when the transport never observed a
@@ -2704,6 +2793,7 @@ mod tests {
             broadcast_tx: broadcast_tx.clone(),
             presence,
             presence_tx,
+            kernel_actor_principal: None,
         };
         let state = KernelState::new(handle.clone());
         (ctx, state, handle)


### PR DESCRIPTION
## Summary

- Re-register hibernated notebook-cloud WebSocket peers with the room-host sync state before accepting fresh traffic, so restored `runtime_peer` sockets continue receiving `RuntimeStateDoc` fanout.
- Author cloud kernel RuntimeStateDoc changes under the authenticated room principal (`<principal>/runtime:kernel:*`) instead of the legacy local-only `rt:kernel:*` label, which the cloud room rejects.
- Keep runtime-agent comm echo suppression compatible with both legacy desktop kernel actors and cloud kernel actors, and log `cloud_frame_rejected` session-control frames for future diagnosis.

## Live Preview Smoke

Deployed preview build used for smoke:

- renderer-assets Worker version: `7a69d71c-ebd8-4d1e-862a-dae81b2b3abb`
- main Worker version: `8d066107-b476-4b27-9846-9e963e25073e`

Good live sessions:

- Short-delay execution: https://preview.runt.run/n/01KTF89BY3F20PA0BE2GX4EFYD/lab2-dualpeer
- Idle runtime peer execution after ~70s: https://preview.runt.run/n/01KTF8BSV6PJVHE11N2EH95NJN/lab2-dualpeer

```text
        preview.runt.run / NotebookRoom DO
   +------------------------------------------+
   |  Automerge NotebookDoc + RuntimeStateDoc |
   |                                          |
   |  owner/browser peer  <---- sync ---->  runtime_peer
   |       queues cell                  launches current_python
   |       sees done                    writes outputs + done
   +------------------------------------------+
                    |
                    v
          Python kernel on lab2
```

## Verification

- `cargo xtask lint --fix`
- `pnpm --filter notebook-cloud exec node --import tsx --test test/notebook-room.test.ts`
- `pnpm --filter notebook-cloud typecheck`
- `cargo test -p runtimed`
- `cargo test -p runtimed-wasm hosted_execute_cell_fans_out_runtime_state_to_runtime_peer -- --nocapture`
- Live API-key runtime peer smoke against `preview.runt.run`: short-delay and idle execution both reached `status=done`.

## Notes

`apps/notebook/src/renderer-plugins/isolated-renderer.js` is dirty locally from asset builds and intentionally not included in this PR.
