### PR TITLE
fix(markdown): require host projector initialization

### DIFF
--- a/apps/notebook/src/hooks/useAutomergeNotebook.ts
+++ b/apps/notebook/src/hooks/useAutomergeNotebook.ts
@@ -11,7 +11,6 @@ import {
   refreshBlobResolver,
 } from "../lib/blob-port";
 import { logger } from "../lib/logger";
-import { setMarkdownProjectionProjector } from "@/lib/markdown-projection";
 import {
   type CellSnapshot,
   cellSnapshotsToNotebookCells,
@@ -38,12 +37,12 @@ import {
   shouldPreserveBootstrapProjection,
 } from "../lib/bootstrap-preservation";
 import { startNotebookSyncStoreBridge } from "../lib/notebook-sync-store-bridge";
-import type { JupyterOutput, NotebookCell } from "../types";
-import init, {
+import {
   encode_heartbeat_presence,
+  ensureNotebookWasmReady,
   NotebookHandle,
-  project_markdown_json,
-} from "../wasm/runtimed-wasm/runtimed_wasm.js";
+} from "../lib/runtimed-wasm";
+import type { JupyterOutput, NotebookCell } from "../types";
 
 /**
  * Matches `notebook_doc::presence::DEFAULT_HEARTBEAT_MS`.
@@ -52,8 +51,7 @@ import init, {
  */
 const PRESENCE_HEARTBEAT_INTERVAL_MS = 15_000;
 
-const wasmReady: Promise<void> = init().then(() => {
-  setMarkdownProjectionProjector(project_markdown_json);
+const wasmReady: Promise<void> = ensureNotebookWasmReady().then(() => {
   logger.info("[automerge-notebook] WASM initialized");
 });
 

--- a/apps/notebook/src/hooks/useAutomergeNotebook.ts
+++ b/apps/notebook/src/hooks/useAutomergeNotebook.ts
@@ -51,9 +51,15 @@ import type { JupyterOutput, NotebookCell } from "../types";
  */
 const PRESENCE_HEARTBEAT_INTERVAL_MS = 15_000;
 
-const wasmReady: Promise<void> = ensureNotebookWasmReady().then(() => {
-  logger.info("[automerge-notebook] WASM initialized");
-});
+let loggedWasmReady = false;
+
+function waitForNotebookWasmReady(): Promise<void> {
+  return ensureNotebookWasmReady().then(() => {
+    if (loggedWasmReady) return;
+    loggedWasmReady = true;
+    logger.info("[automerge-notebook] WASM initialized");
+  });
+}
 
 function scopeAllowsNotebookWrite(scope: string | null): boolean {
   return scope === null || scope === "editor" || scope === "owner";
@@ -129,7 +135,7 @@ export function useNotebook() {
         createHandle: (actorLabel) => NotebookHandle.create_empty_with_actor(actorLabel),
         getBlobPort,
         publishHandle: setNotebookHandle,
-        ready: wasmReady,
+        ready: waitForNotebookWasmReady,
         refreshBlobPort,
         slot: handleRef,
       }),

--- a/apps/notebook/src/hooks/useAutomergeNotebook.ts
+++ b/apps/notebook/src/hooks/useAutomergeNotebook.ts
@@ -11,6 +11,7 @@ import {
   refreshBlobResolver,
 } from "../lib/blob-port";
 import { logger } from "../lib/logger";
+import { setMarkdownProjectionProjector } from "@/lib/markdown-projection";
 import {
   type CellSnapshot,
   cellSnapshotsToNotebookCells,
@@ -41,6 +42,7 @@ import type { JupyterOutput, NotebookCell } from "../types";
 import init, {
   encode_heartbeat_presence,
   NotebookHandle,
+  project_markdown_json,
 } from "../wasm/runtimed-wasm/runtimed_wasm.js";
 
 /**
@@ -51,6 +53,7 @@ import init, {
 const PRESENCE_HEARTBEAT_INTERVAL_MS = 15_000;
 
 const wasmReady: Promise<void> = init().then(() => {
+  setMarkdownProjectionProjector(project_markdown_json);
   logger.info("[automerge-notebook] WASM initialized");
 });
 

--- a/apps/notebook/src/lib/__tests__/markdown-projection.test.ts
+++ b/apps/notebook/src/lib/__tests__/markdown-projection.test.ts
@@ -1,4 +1,4 @@
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 vi.mock("../../wasm/runtimed-wasm/runtimed_wasm.js", () => ({
   project_markdown_json: vi.fn(() => {
@@ -14,8 +14,18 @@ describe("markdown projection", () => {
     module = await import("../markdown-projection");
   });
 
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
   it("can use a host-initialized markdown projector", () => {
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+
     expect(module.projectMarkdownPlan("# Title")).toBeNull();
+    expect(warnSpy).toHaveBeenCalledTimes(1);
+    expect(warnSpy.mock.calls[0]?.[0]).toContain(
+      "markdown projector is not initialized",
+    );
 
     const restore = module.setMarkdownProjectionProjector((source) =>
       JSON.stringify({
@@ -67,5 +77,6 @@ describe("markdown projection", () => {
 
     restore();
     expect(module.projectMarkdownPlan("# Title")).toBeNull();
+    expect(warnSpy).toHaveBeenCalledTimes(1);
   });
 });

--- a/apps/notebook/src/lib/__tests__/markdown-projection.test.ts
+++ b/apps/notebook/src/lib/__tests__/markdown-projection.test.ts
@@ -16,6 +16,7 @@ describe("markdown projection", () => {
 
   afterEach(() => {
     vi.restoreAllMocks();
+    vi.unstubAllGlobals();
   });
 
   it("can use a host-initialized markdown projector", () => {
@@ -76,6 +77,14 @@ describe("markdown projection", () => {
     expect(module.canRenderMarkdownProjectionInHost(projected)).toBe(true);
 
     restore();
+    expect(module.projectMarkdownPlan("# Title")).toBeNull();
+    expect(warnSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it("keeps the missing-projector fallback safe without a process global", () => {
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+    vi.stubGlobal("process", undefined);
+
     expect(module.projectMarkdownPlan("# Title")).toBeNull();
     expect(warnSpy).toHaveBeenCalledTimes(1);
   });

--- a/apps/notebook/src/lib/__tests__/markdown-task-source.test.ts
+++ b/apps/notebook/src/lib/__tests__/markdown-task-source.test.ts
@@ -1,8 +1,10 @@
 import { readFileSync } from "node:fs";
 import { join } from "node:path";
-import initMarkdownWasm from "../../wasm/runtimed-wasm/runtimed_wasm.js";
+import initMarkdownWasm, {
+  project_markdown_json,
+} from "../../wasm/runtimed-wasm/runtimed_wasm.js";
 import { beforeAll, describe, expect, it } from "vite-plus/test";
-import { projectMarkdownPlan } from "../markdown-projection";
+import { projectMarkdownPlan, setMarkdownProjectionProjector } from "../markdown-projection";
 import { toggleMarkdownTaskMarker } from "../markdown-task-source";
 
 describe("toggleMarkdownTaskMarker", () => {
@@ -16,6 +18,7 @@ describe("toggleMarkdownTaskMarker", () => {
         wasmBytes.byteOffset + wasmBytes.byteLength,
       ),
     });
+    setMarkdownProjectionProjector(project_markdown_json);
   });
 
   it("uses projected WASM task spans to update literal markdown source", () => {

--- a/apps/notebook/src/lib/runtimed-wasm.ts
+++ b/apps/notebook/src/lib/runtimed-wasm.ts
@@ -1,0 +1,17 @@
+import { setMarkdownProjectionProjector } from "@/lib/markdown-projection";
+import init, {
+  encode_heartbeat_presence,
+  NotebookHandle,
+  project_markdown_json,
+} from "../wasm/runtimed-wasm/runtimed_wasm.js";
+
+let notebookWasmReady: Promise<void> | undefined;
+
+export function ensureNotebookWasmReady(): Promise<void> {
+  notebookWasmReady ??= init().then(() => {
+    setMarkdownProjectionProjector(project_markdown_json);
+  });
+  return notebookWasmReady;
+}
+
+export { encode_heartbeat_presence, NotebookHandle };

--- a/apps/notebook/src/lib/runtimed-wasm.ts
+++ b/apps/notebook/src/lib/runtimed-wasm.ts
@@ -8,9 +8,14 @@ import init, {
 let notebookWasmReady: Promise<void> | undefined;
 
 export function ensureNotebookWasmReady(): Promise<void> {
-  notebookWasmReady ??= init().then(() => {
-    setMarkdownProjectionProjector(project_markdown_json);
-  });
+  notebookWasmReady ??= init()
+    .then(() => {
+      setMarkdownProjectionProjector(project_markdown_json);
+    })
+    .catch((error: unknown) => {
+      notebookWasmReady = undefined;
+      throw error;
+    });
   return notebookWasmReady;
 }
 

--- a/apps/notebook/src/main.tsx
+++ b/apps/notebook/src/main.tsx
@@ -10,6 +10,7 @@ import { setKernelCompletionHost } from "./lib/kernel-completion";
 import { logger, setLoggerHost } from "./lib/logger";
 import { setMetadataTransport } from "./lib/notebook-metadata";
 import { setOpenUrlHost } from "./lib/open-url";
+import { ensureNotebookWasmReady } from "./lib/runtimed-wasm";
 
 // Register built-in widget components
 import "@/components/widgets/controls";
@@ -123,6 +124,7 @@ async function boot() {
   };
 
   void attachTauriDevLogMirror();
+  await ensureNotebookWasmReady();
 
   createRoot(document.getElementById("root")!).render(
     <StrictMode>

--- a/apps/notebook/src/main.tsx
+++ b/apps/notebook/src/main.tsx
@@ -124,7 +124,12 @@ async function boot() {
   };
 
   void attachTauriDevLogMirror();
-  await ensureNotebookWasmReady();
+  void ensureNotebookWasmReady().catch((error: unknown) => {
+    logger.warn(
+      "[main] failed to initialize runtimed WASM during app boot; notebook controller will retry",
+      error,
+    );
+  });
 
   createRoot(document.getElementById("root")!).render(
     <StrictMode>

--- a/apps/notebook/src/main.tsx
+++ b/apps/notebook/src/main.tsx
@@ -124,12 +124,14 @@ async function boot() {
   };
 
   void attachTauriDevLogMirror();
-  void ensureNotebookWasmReady().catch((error: unknown) => {
+  try {
+    await ensureNotebookWasmReady();
+  } catch (error: unknown) {
     logger.warn(
-      "[main] failed to initialize runtimed WASM during app boot; notebook controller will retry",
+      "[main] failed to initialize runtimed WASM during app boot; rendering app shell without preinitialized notebook WASM",
       error,
     );
-  });
+  }
 
   createRoot(document.getElementById("root")!).render(
     <StrictMode>

--- a/apps/notebook/src/renderer-plugins/isolated-renderer.js
+++ b/apps/notebook/src/renderer-plugins/isolated-renderer.js
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:d6684f4ad4d3b575624dd83a4ad4cb6a3aa4948ad768fd28905796460ee97706
-size 1540619
+oid sha256:ecd9b8b33bbc89f86d071e54fef4e82177ca92a2e3c24b2837a940d8462d9d0f
+size 1515348

--- a/packages/runtimed/src/notebook-handle-host.ts
+++ b/packages/runtimed/src/notebook-handle-host.ts
@@ -34,7 +34,7 @@ export interface NotebookHandleHostOptions<THandle extends HostedNotebookHandle>
   publishHandle: (handle: THandle | null) => void;
 
   /** Optional readiness gate, commonly WASM initialization. */
-  ready?: Promise<void>;
+  ready?: Promise<void> | (() => Promise<void>);
 
   /** Optional current blob port provider. */
   getBlobPort?: () => number | null;
@@ -60,7 +60,7 @@ export class NotebookHandleHost<THandle extends HostedNotebookHandle = HostedNot
   readonly #getBlobPort?: () => number | null;
   readonly #refreshBlobPort?: () => Promise<number | null>;
   readonly #mimePriority: readonly string[];
-  #ready: Promise<void>;
+  readonly #ready: () => Promise<void>;
 
   constructor(options: NotebookHandleHostOptions<THandle>) {
     this.#slot = options.slot;
@@ -70,7 +70,8 @@ export class NotebookHandleHost<THandle extends HostedNotebookHandle = HostedNot
     this.#getBlobPort = options.getBlobPort;
     this.#refreshBlobPort = options.refreshBlobPort;
     this.#mimePriority = options.mimePriority ?? DEFAULT_MIME_PRIORITY;
-    this.#ready = options.ready ?? Promise.resolve();
+    const ready = options.ready ?? Promise.resolve();
+    this.#ready = typeof ready === "function" ? ready : () => ready;
   }
 
   get current(): THandle | null {
@@ -78,7 +79,7 @@ export class NotebookHandleHost<THandle extends HostedNotebookHandle = HostedNot
   }
 
   async bootstrap(isCancelled: () => boolean = () => false): Promise<boolean> {
-    const ready = this.#ready;
+    const ready = this.#ready();
     await ready;
     if (isCancelled()) return false;
 

--- a/packages/runtimed/tests/notebook-handle-host.test.ts
+++ b/packages/runtimed/tests/notebook-handle-host.test.ts
@@ -93,6 +93,33 @@ describe("NotebookHandleHost", () => {
     expect(slot.current).toBeNull();
   });
 
+  it("calls a readiness factory for each bootstrap attempt", async () => {
+    const calls: string[] = [];
+    const handle = createHandle("ready", calls);
+    const slot: NotebookHandleSlot = { current: null };
+    const ready = vi
+      .fn<() => Promise<void>>()
+      .mockRejectedValueOnce(new Error("wasm init failed"))
+      .mockResolvedValueOnce(undefined);
+
+    const host = new NotebookHandleHost({
+      actorLabel: () => "human:test",
+      createHandle: vi.fn(() => handle),
+      publishHandle: vi.fn((publishedHandle) =>
+        calls.push(publishedHandle ? "publish:ready" : "publish:null"),
+      ),
+      ready,
+      slot,
+    });
+
+    await expect(host.bootstrap()).rejects.toThrow("wasm init failed");
+    await expect(host.bootstrap()).resolves.toBe(true);
+
+    expect(ready).toHaveBeenCalledTimes(2);
+    expect(slot.current).toBe(handle);
+    expect(calls).toEqual(["publish:null", "mime:ready", "publish:ready"]);
+  });
+
   it("does not clear a newer bootstrap that replaces it during blob-port refresh", async () => {
     const calls: string[] = [];
     const blobPortResolvers: Array<(port: number | null) => void> = [];

--- a/src/components/outputs/__tests__/media-router.test.tsx
+++ b/src/components/outputs/__tests__/media-router.test.tsx
@@ -10,7 +10,9 @@ import { render, screen, waitFor } from "@testing-library/react";
 import { readFileSync } from "node:fs";
 import { join } from "node:path";
 import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vite-plus/test";
-import initMarkdownWasm from "../../../../apps/notebook/src/wasm/runtimed-wasm/runtimed_wasm.js";
+import initMarkdownWasm, {
+  project_markdown_json,
+} from "../../../../apps/notebook/src/wasm/runtimed-wasm/runtimed_wasm.js";
 import {
   MARKDOWN_PROJECTION_MIME_TYPE,
   setMarkdownProjectionProjector,
@@ -31,6 +33,7 @@ beforeAll(async () => {
       wasmBytes.byteOffset + wasmBytes.byteLength,
     ),
   });
+  setMarkdownProjectionProjector(project_markdown_json);
 });
 
 function withMarkdownProjection({

--- a/src/lib/__tests__/markdown-projection.test.ts
+++ b/src/lib/__tests__/markdown-projection.test.ts
@@ -1,4 +1,6 @@
-import initMarkdownWasm from "../../../apps/notebook/src/wasm/runtimed-wasm/runtimed_wasm.js";
+import initMarkdownWasm, {
+  project_markdown_json,
+} from "../../../apps/notebook/src/wasm/runtimed-wasm/runtimed_wasm.js";
 import { readFileSync } from "node:fs";
 import { join } from "node:path";
 import { beforeAll, describe, expect, it } from "vite-plus/test";
@@ -27,6 +29,7 @@ describe("markdown projection", () => {
         wasmBytes.byteOffset + wasmBytes.byteLength,
       ),
     });
+    setMarkdownProjectionProjector(project_markdown_json);
   });
 
   it("projects GFM task state from literal markdown source", () => {

--- a/src/lib/markdown-projection.ts
+++ b/src/lib/markdown-projection.ts
@@ -125,7 +125,9 @@ export function projectMarkdownPlan(source: string): MarkdownProjectionPlan | nu
 function warnMissingMarkdownProjectionProjector(): void {
   if (warnedMissingMarkdownProjectionProjector) return;
   warnedMissingMarkdownProjectionProjector = true;
-  if (process.env.NODE_ENV === "production") return;
+  const isProduction =
+    typeof process !== "undefined" && process.env?.NODE_ENV === "production";
+  if (isProduction) return;
 
   console.warn(
     "[markdown-projection] markdown projector is not initialized; host must call setMarkdownProjectionProjector() before projection.",

--- a/src/lib/markdown-projection.ts
+++ b/src/lib/markdown-projection.ts
@@ -7,6 +7,7 @@ const MARKDOWN_PROJECTION_CACHE_LIMIT = 128;
 
 let markdownProjectionProjector: MarkdownProjectionProjector | null = null;
 const markdownProjectionCache = new Map<string, MarkdownProjectionPlan>();
+let warnedMissingMarkdownProjectionProjector = false;
 
 export interface MarkdownProjectionMeasurement {
   readonly estimatedHeight: number;
@@ -97,7 +98,10 @@ export function setMarkdownProjectionProjector(
 
 export function projectMarkdownPlan(source: string): MarkdownProjectionPlan | null {
   if (!source.trim()) return null;
-  if (!markdownProjectionProjector) return null;
+  if (!markdownProjectionProjector) {
+    warnMissingMarkdownProjectionProjector();
+    return null;
+  }
 
   const cached = markdownProjectionCache.get(source);
   if (cached) {
@@ -116,6 +120,16 @@ export function projectMarkdownPlan(source: string): MarkdownProjectionPlan | nu
   } catch {
     return null;
   }
+}
+
+function warnMissingMarkdownProjectionProjector(): void {
+  if (warnedMissingMarkdownProjectionProjector) return;
+  warnedMissingMarkdownProjectionProjector = true;
+  if (process.env.NODE_ENV === "production") return;
+
+  console.warn(
+    "[markdown-projection] markdown projector is not initialized; host must call setMarkdownProjectionProjector() before projection.",
+  );
 }
 
 function cacheMarkdownProjectionPlan(

--- a/src/lib/markdown-projection.ts
+++ b/src/lib/markdown-projection.ts
@@ -1,5 +1,3 @@
-import { project_markdown_json } from "../../apps/notebook/src/wasm/runtimed-wasm/runtimed_wasm.js";
-
 export const MARKDOWN_PROJECTION_MIME_TYPE =
   "application/vnd.nteract.markdown+json";
 
@@ -7,7 +5,7 @@ type MarkdownProjectionProjector = (source: string) => string;
 
 const MARKDOWN_PROJECTION_CACHE_LIMIT = 128;
 
-let markdownProjectionProjector: MarkdownProjectionProjector = project_markdown_json;
+let markdownProjectionProjector: MarkdownProjectionProjector | null = null;
 const markdownProjectionCache = new Map<string, MarkdownProjectionPlan>();
 
 export interface MarkdownProjectionMeasurement {
@@ -99,6 +97,8 @@ export function setMarkdownProjectionProjector(
 
 export function projectMarkdownPlan(source: string): MarkdownProjectionPlan | null {
   if (!source.trim()) return null;
+  if (!markdownProjectionProjector) return null;
+
   const cached = markdownProjectionCache.get(source);
   if (cached) {
     markdownProjectionCache.delete(source);


### PR DESCRIPTION
## Summary

- Remove the shared markdown projection module's default import of desktop-generated `runtimed-wasm` glue.
- Register the Rust/WASM markdown projector explicitly from the desktop notebook host after `runtimed-wasm` initialization; cloud already registers through `viewer/runtimed-wasm-client.ts`.
- Update WASM-backed markdown tests to install `project_markdown_json` explicitly.
- Rebuild the stable isolated renderer bundle so it no longer pulls in `runtimed_wasm` glue through the shared markdown projection import.

## Why

This addresses the leaky shared dependency called out in the projection audit and reduces generated/LFS churn in the isolated renderer path. Rebuilding `isolated-renderer` before this change pulled in the notebook app's `runtimed_wasm.js`, emitted a huge `import.meta` warning, and dirtied the LFS pointer. After this change, the isolated renderer bundle contains no `runtimed_wasm` / `project_markdown_json` strings and the warning is gone.

The LFS pointer update is intentional: it is the rebuilt stable isolated renderer artifact after removing that dependency. Size moves from `1540619` bytes to `1515348` bytes.

## Verification

- `cargo xtask renderer-plugins --only isolated-renderer`
  - no `EMPTY_IMPORT_META` / `import.meta` warning in rebuild output
  - `rg "runtimed_wasm|project_markdown_json|wasm_bindgen|import\.meta\.url" apps/notebook/src/renderer-plugins/isolated-renderer.js` finds no matches
- `pnpm test:run src/lib/__tests__/markdown-projection.test.ts apps/notebook/src/lib/__tests__/markdown-task-source.test.ts apps/notebook/src/lib/__tests__/markdown-projection.test.ts src/components/outputs/__tests__/media-router.test.tsx`
- `pnpm --dir apps/notebook build`
- `pnpm --filter notebook-cloud typecheck`
- `cargo xtask lint --fix`
