### PR TITLE
feat(cloud): enable owner execution with runtime peers

### DIFF
--- a/apps/notebook-cloud/src/notebook-room.ts
+++ b/apps/notebook-cloud/src/notebook-room.ts
@@ -72,12 +72,14 @@ export class NotebookRoom {
   private framePersistQueue: Promise<void> = Promise.resolve();
   private broadcastDepth = 0;
   private readonly materializers = new Map<string, RoomMaterializer>();
+  private readonly restoredPeersReady: Promise<void>;
 
   constructor(
     private readonly state: DurableObjectState,
     private readonly env: Env,
   ) {
-    this.restoreHibernatedPeers();
+    this.restoredPeersReady = this.restoreHibernatedPeers();
+    this.state.waitUntil(this.restoredPeersReady);
   }
 
   async fetch(request: Request): Promise<Response> {
@@ -98,6 +100,8 @@ export class NotebookRoom {
     } catch (error) {
       return json({ error: String(error) }, 401);
     }
+
+    await this.restoredPeersReady;
 
     const pair = new WebSocketPair();
     const client = pair[0];
@@ -176,6 +180,7 @@ export class NotebookRoom {
       return;
     }
 
+    await this.restoredPeersReady;
     await this.handleMessage(attachment.notebookId, peer, message);
   }
 
@@ -187,26 +192,37 @@ export class NotebookRoom {
     this.removeAttachedPeer(socket);
   }
 
-  private restoreHibernatedPeers(): void {
+  private async restoreHibernatedPeers(): Promise<void> {
     const sockets = this.state.getWebSockets?.() ?? [];
+    const restored: Array<{ notebookId: string; peer: Peer }> = [];
     for (const socket of sockets) {
       const attachment = socketAttachment(socket);
       if (!attachment) {
         continue;
       }
 
-      this.peers.set(attachment.peerId, {
+      const peer = {
         id: attachment.peerId,
         socket,
         identity: attachment.identity,
         connectedAt: attachment.connectedAt,
-      });
+      };
+      this.peers.set(attachment.peerId, peer);
+      restored.push({ notebookId: attachment.notebookId, peer });
     }
     if (sockets.length > 0) {
       cloudLog("info", "room.hibernation.restored_peers", {
         restored_peer_count: this.peers.size,
       });
     }
+    await Promise.all(
+      restored.map(async ({ notebookId, peer }) => {
+        await this.syncPeerFromRoomHost(notebookId, peer);
+        if (peer.identity.scope === "runtime_peer") {
+          this.refreshRuntimePeerWatch(notebookId);
+        }
+      }),
+    );
   }
 
   private acceptPeerSocket(notebookId: string, peer: Peer): void {

--- a/apps/notebook-cloud/src/notebook-room.ts
+++ b/apps/notebook-cloud/src/notebook-room.ts
@@ -142,6 +142,7 @@ export class NotebookRoom {
       display_name: identity.metadata.displayName,
       email: identity.metadata.email,
       room_peer_count: this.peers.size,
+      runtime_peer_count: this.runtimePeerCount(),
       timestamp: peer.connectedAt,
     });
 
@@ -152,7 +153,9 @@ export class NotebookRoom {
         notebook_id: notebookId,
         peer_id: peer.id,
         actor_label: identity.actorLabel,
+        connection_scope: identity.scope,
         room_peer_count: this.peers.size,
+        runtime_peer_count: this.runtimePeerCount(),
         timestamp: peer.connectedAt,
       },
       peer.id,
@@ -702,7 +705,9 @@ export class NotebookRoom {
       notebook_id: notebookId,
       peer_id: peer.id,
       actor_label: peer.identity.actorLabel,
+      connection_scope: peer.identity.scope,
       room_peer_count: this.peers.size,
+      runtime_peer_count: this.runtimePeerCount(),
       timestamp: new Date().toISOString(),
     });
 
@@ -721,12 +726,17 @@ export class NotebookRoom {
   /// notebook-scoped implicitly. If a DO ever hosts more than one notebook, both
   /// this check and the watch key must be keyed per notebook id.
   private hasRuntimePeer(): boolean {
+    return this.runtimePeerCount() > 0;
+  }
+
+  private runtimePeerCount(): number {
+    let count = 0;
     for (const peer of this.peers.values()) {
       if (peer.identity.scope === "runtime_peer") {
-        return true;
+        count += 1;
       }
     }
-    return false;
+    return count;
   }
 
   /// Arm or disarm the runtime_peer-gone reconciliation alarm to match current

--- a/apps/notebook-cloud/src/protocol.ts
+++ b/apps/notebook-cloud/src/protocol.ts
@@ -29,6 +29,7 @@ export type SessionControlMessage =
       display_name?: string;
       email?: string;
       room_peer_count: number;
+      runtime_peer_count?: number;
       timestamp: string;
     }
   | {
@@ -52,7 +53,9 @@ export type SessionControlMessage =
       notebook_id: string;
       peer_id: string;
       actor_label: string;
+      connection_scope?: string;
       room_peer_count: number;
+      runtime_peer_count?: number;
       timestamp: string;
     };
 

--- a/apps/notebook-cloud/test/live-sync.test.ts
+++ b/apps/notebook-cloud/test/live-sync.test.ts
@@ -233,6 +233,77 @@ describe("cloud live sync", () => {
     }
   });
 
+  it("sends notebook requests as cloud request frames and resolves on room acceptance", async () => {
+    const fake = installFakeWebSocket();
+    try {
+      const transport = new CloudWebSocketTransport(new URL("wss://example.test/n/room/sync"), []);
+      const socket = fake.socket;
+      socket.open();
+      socket.ready("peer-1");
+      await transport.ready;
+
+      const response = transport.sendRequest(
+        { type: "execute_cell", cell_id: "cell-1" },
+        { required_heads: ["head-1"] },
+      );
+      await nextMicrotask();
+
+      assert.equal(socket.sent.length, 1);
+      const frame = socket.sent[0];
+      assert.ok(frame instanceof Uint8Array);
+      assert.equal(frame[0], FrameType.REQUEST);
+      const envelope = JSON.parse(new TextDecoder().decode(frame.slice(1))) as {
+        action: string;
+        cell_id: string;
+        id: string;
+        required_heads: string[];
+      };
+      assert.equal(envelope.action, "execute_cell");
+      assert.equal(envelope.cell_id, "cell-1");
+      assert.deepEqual(envelope.required_heads, ["head-1"]);
+      assert.equal(typeof envelope.id, "string");
+
+      socket.control({
+        type: "cloud_frame_accepted",
+        notebook_id: "room",
+        peer_id: "peer-1",
+        frame_type: FrameType.REQUEST,
+        byte_length: frame.byteLength - 1,
+        timestamp: "2026-06-06T00:00:00.000Z",
+      });
+
+      assert.deepEqual(await response, { result: "ok" });
+    } finally {
+      fake.restore();
+    }
+  });
+
+  it("rejects notebook requests when the cloud room rejects the request frame", async () => {
+    const fake = installFakeWebSocket();
+    try {
+      const transport = new CloudWebSocketTransport(new URL("wss://example.test/n/room/sync"), []);
+      const socket = fake.socket;
+      socket.open();
+      socket.ready("peer-1");
+      await transport.ready;
+
+      const response = transport.sendRequest({ type: "execute_cell", cell_id: "cell-1" });
+      await nextMicrotask();
+      socket.control({
+        type: "cloud_frame_rejected",
+        notebook_id: "room",
+        peer_id: "peer-1",
+        frame_type: FrameType.REQUEST,
+        reason: "viewer cannot write request frames",
+        timestamp: "2026-06-06T00:00:00.000Z",
+      });
+
+      await assert.rejects(response, /viewer cannot write request frames/);
+    } finally {
+      fake.restore();
+    }
+  });
+
   it("notifies disconnect when WebSocket.send throws", async () => {
     const fake = installFakeWebSocket();
     const disconnects: string[] = [];
@@ -338,15 +409,19 @@ class FakeWebSocket extends EventTarget {
   binaryType: BinaryType = "arraybuffer";
   readyState = FakeWebSocket.CONNECTING;
   throwOnSend = false;
+  sent: Uint8Array[] = [];
 
   constructor() {
     super();
     FakeWebSocket.instances.push(this);
   }
 
-  send(): void {
+  send(data: unknown): void {
     if (this.throwOnSend) {
       throw new Error("synthetic send failure");
+    }
+    if (data instanceof Uint8Array) {
+      this.sent.push(data);
     }
   }
 
@@ -361,17 +436,20 @@ class FakeWebSocket extends EventTarget {
   }
 
   ready(peerId: string): void {
-    const payload = new TextEncoder().encode(
-      JSON.stringify({
-        type: "cloud_room_ready",
-        protocol: "v4",
-        notebook_id: "room",
-        peer_id: peerId,
-        actor_label: `user:dev:alice/desktop:${peerId}`,
-        connection_scope: "editor",
-        timestamp: "2026-05-24T00:00:00.000Z",
-      }),
-    );
+    this.control({
+      type: "cloud_room_ready",
+      protocol: "v4",
+      notebook_id: "room",
+      peer_id: peerId,
+      actor_label: `user:dev:alice/desktop:${peerId}`,
+      connection_scope: "editor",
+      room_peer_count: 1,
+      timestamp: "2026-05-24T00:00:00.000Z",
+    });
+  }
+
+  control(value: unknown): void {
+    const payload = new TextEncoder().encode(JSON.stringify(value));
     const frame = new Uint8Array(payload.byteLength + 1);
     frame[0] = FrameType.SESSION_CONTROL;
     frame.set(payload, 1);

--- a/apps/notebook-cloud/test/notebook-room.test.ts
+++ b/apps/notebook-cloud/test/notebook-room.test.ts
@@ -282,6 +282,35 @@ describe("NotebookRoom peer lifecycle", () => {
     );
     assert.equal(staleSocket.closed, true);
   });
+
+  it("re-registers hibernated peers with the room host sync state", async () => {
+    const identity = authenticateDevRequest(
+      new Request(
+        "https://cloud.test/n/demo/sync?user=runtime&operator=runtime:py&scope=runtime_peer",
+      ),
+    );
+    const socket = new FakeSocket();
+    socket.serializeAttachment({
+      notebookId: "demo",
+      peerId: "runtime-peer",
+      identity,
+      connectedAt: "2026-06-06T00:00:00.000Z",
+    });
+    const state = hibernatedState([socket.asCloudflareWebSocket()]);
+    const room = new NotebookRoom(state.state, {} as Env);
+
+    await state.drain();
+
+    assert.equal(
+      roomHarness(room).peerForSocket(socket.asCloudflareWebSocket())?.id,
+      "runtime-peer",
+      "the hibernated socket is restored into the peer map",
+    );
+    assert(
+      socket.sent.some((frame) => frame[0] === FrameType.RUNTIME_STATE_SYNC),
+      "restored peers receive RuntimeStateDoc sync so future ExecuteCell fanout can target them",
+    );
+  });
 });
 
 describe("NotebookRoom materialized sync persistence", () => {
@@ -668,6 +697,39 @@ function fakeState(): DurableObjectState {
       list: async <T>() => new Map(values as Map<string, T>),
     },
     waitUntil: () => undefined,
+  };
+}
+
+function hibernatedState(sockets: CloudflareWebSocket[]): {
+  state: DurableObjectState;
+  drain(): Promise<void>;
+} {
+  const values = new Map<string, unknown>();
+  const pending: Promise<unknown>[] = [];
+  return {
+    state: {
+      id: { toString: () => "room-id" },
+      storage: {
+        get: async <T>(key: string) => values.get(key) as T | undefined,
+        put: async <T>(key: string, value: T) => {
+          values.set(key, value);
+        },
+        delete: async (key: string) => values.delete(key),
+        list: async <T>() => new Map(values as Map<string, T>),
+        deleteAlarm: async () => undefined,
+        setAlarm: async () => undefined,
+      },
+      getWebSockets: () => sockets,
+      waitUntil: (promise: Promise<unknown>) => {
+        pending.push(promise.catch(() => undefined));
+      },
+    },
+    drain: async () => {
+      while (pending.length > 0) {
+        const batch = pending.splice(0, pending.length);
+        await Promise.all(batch);
+      }
+    },
   };
 }
 

--- a/apps/notebook-cloud/test/notebook-room.test.ts
+++ b/apps/notebook-cloud/test/notebook-room.test.ts
@@ -276,10 +276,9 @@ describe("NotebookRoom peer lifecycle", () => {
     assert.equal(healthySocket.sent.length, 2);
     assert.deepEqual([...healthySocket.sent[0]], [FrameType.AUTOMERGE_SYNC, 42]);
     assert.equal(healthySocket.sent[1][0], FrameType.SESSION_CONTROL);
-    assert.equal(
-      decodeJsonPayload<Record<string, unknown>>(healthySocket.sent[1].slice(1)).type,
-      "cloud_peer_left",
-    );
+    const peerLeft = decodeJsonPayload<Record<string, unknown>>(healthySocket.sent[1].slice(1));
+    assert.equal(peerLeft.type, "cloud_peer_left");
+    assert.equal(peerLeft.connection_scope, "editor");
     assert.equal(staleSocket.closed, true);
   });
 

--- a/apps/notebook-cloud/test/viewer-presence.test.ts
+++ b/apps/notebook-cloud/test/viewer-presence.test.ts
@@ -2,6 +2,7 @@ import { describe, it } from "node:test";
 import assert from "node:assert/strict";
 import {
   cloudFriendlyPeerLabel,
+  cloudPresenceHasRuntimePeer,
   cloudVisiblePeerLabel,
   cloudViewerPresenceDisplay,
   initialCloudViewerPresence,
@@ -30,6 +31,7 @@ describe("cloud viewer presence", () => {
         actorLabel: state.actorLabel,
         ownPeerLabel: state.ownPeerLabel,
         roomPeerCount: state.roomPeerCount,
+        runtimePeerCount: state.runtimePeerCount,
       },
       {
         connection: "connected",
@@ -37,6 +39,7 @@ describe("cloud viewer presence", () => {
         actorLabel: "anonymous:viewer:session-a/desktop:browser",
         ownPeerLabel: "Anonymous",
         roomPeerCount: 1,
+        runtimePeerCount: 0,
       },
     );
     assert.equal(cloudViewerPresenceDisplay(state).label, "1 here now");
@@ -46,6 +49,7 @@ describe("cloud viewer presence", () => {
       notebook_id: "demo",
       peer_id: "peer-b",
       actor_label: "anonymous:viewer:session-b/desktop:browser",
+      connection_scope: "viewer",
       room_peer_count: 2,
       timestamp: "2026-05-23T00:00:01.000Z",
     });
@@ -65,6 +69,7 @@ describe("cloud viewer presence", () => {
       notebook_id: "demo",
       peer_id: "peer-b",
       actor_label: "anonymous:viewer:session-b/desktop:browser",
+      connection_scope: "viewer",
       room_peer_count: 1,
       timestamp: "2026-05-23T00:00:02.000Z",
     });
@@ -148,6 +153,7 @@ describe("cloud viewer presence", () => {
       notebook_id: "demo",
       peer_id: "peer-b",
       actor_label: "user:anaconda:bob/browser:tab",
+      connection_scope: "editor",
       room_peer_count: 2,
       timestamp: "2026-05-23T00:00:01.000Z",
     });
@@ -156,6 +162,7 @@ describe("cloud viewer presence", () => {
       notebook_id: "demo",
       peer_id: "peer-c",
       actor_label: "anonymous:viewer:session-c/browser",
+      connection_scope: "viewer",
       room_peer_count: 3,
       timestamp: "2026-05-23T00:00:02.000Z",
     });
@@ -175,6 +182,61 @@ describe("cloud viewer presence", () => {
       ],
     );
     assert.equal(display.hiddenCount, 0);
+  });
+
+  it("detects attached runtime peers from session-control scope", () => {
+    let state = reduceCloudViewerPresenceMessage(initialCloudViewerPresence(), {
+      type: "cloud_room_ready",
+      protocol: "v4",
+      notebook_id: "demo",
+      peer_id: "peer-owner",
+      actor_label: "user:anaconda:alice/browser:tab",
+      connection_scope: "owner",
+      room_peer_count: 1,
+      runtime_peer_count: 0,
+      timestamp: "2026-05-23T00:00:00.000Z",
+    });
+    assert.equal(cloudPresenceHasRuntimePeer(state), false);
+
+    state = reduceCloudViewerPresenceMessage(state, {
+      type: "cloud_peer_joined",
+      notebook_id: "demo",
+      peer_id: "peer-runtime",
+      actor_label: "user:anaconda:alice/agent:runt-cloud-peer",
+      connection_scope: "runtime_peer",
+      room_peer_count: 2,
+      runtime_peer_count: 1,
+      timestamp: "2026-05-23T00:00:01.000Z",
+    });
+    assert.equal(cloudPresenceHasRuntimePeer(state), true);
+
+    state = reduceCloudViewerPresenceMessage(state, {
+      type: "cloud_peer_left",
+      notebook_id: "demo",
+      peer_id: "peer-runtime",
+      actor_label: "user:anaconda:alice/agent:runt-cloud-peer",
+      connection_scope: "runtime_peer",
+      room_peer_count: 1,
+      runtime_peer_count: 0,
+      timestamp: "2026-05-23T00:00:02.000Z",
+    });
+    assert.equal(cloudPresenceHasRuntimePeer(state), false);
+  });
+
+  it("detects runtime peers already present when this browser joins", () => {
+    const state = reduceCloudViewerPresenceMessage(initialCloudViewerPresence(), {
+      type: "cloud_room_ready",
+      protocol: "v4",
+      notebook_id: "demo",
+      peer_id: "peer-owner",
+      actor_label: "user:anaconda:alice/browser:tab",
+      connection_scope: "owner",
+      room_peer_count: 2,
+      runtime_peer_count: 1,
+      timestamp: "2026-05-23T00:00:00.000Z",
+    });
+
+    assert.equal(cloudPresenceHasRuntimePeer(state), true);
   });
 
   it("falls back to readable cloud peer labels instead of raw actor labels", () => {

--- a/apps/notebook-cloud/test/viewer-shell-capabilities.test.ts
+++ b/apps/notebook-cloud/test/viewer-shell-capabilities.test.ts
@@ -92,22 +92,24 @@ test("cloud shell capabilities wait for host mutation support before activating 
 
 test("cloud shell capabilities surface execution only when a runtime is available", () => {
   const withoutRuntime = cloudNotebookShellCapabilities({
-    authState: authState("oidc", "editor"),
-    connectionScope: "editor",
+    authState: authState("oidc", "owner"),
+    connectionScope: "owner",
     hasCodeCells: true,
     selectedMode: "edit",
   });
   assert.equal(withoutRuntime.runtime.executionAvailable, false);
+  assert.equal(withoutRuntime.runtime.connected, false);
   assert.equal(withoutRuntime.canExecute, false);
 
   const withRuntime = cloudNotebookShellCapabilities({
-    authState: authState("oidc", "editor"),
-    connectionScope: "editor",
+    authState: authState("oidc", "owner"),
+    connectionScope: "owner",
     hasCodeCells: true,
     selectedMode: "edit",
     runtimeAvailable: true,
   });
   assert.equal(withRuntime.runtime.executionAvailable, true);
+  assert.equal(withRuntime.runtime.connected, true);
   assert.equal(withRuntime.canExecute, true);
 
   // A live runtime is visible to viewers, but viewing is not execution authority.
@@ -118,7 +120,22 @@ test("cloud shell capabilities surface execution only when a runtime is availabl
     runtimeAvailable: true,
   });
   assert.equal(viewerWithRuntime.runtime.executionAvailable, true);
+  assert.equal(viewerWithRuntime.runtime.connected, true);
   assert.equal(viewerWithRuntime.canExecute, false);
+
+  // Runtime presence is visible to editors too, but the room host grants
+  // execution-intent authority to owner scope until an explicit execute scope
+  // is defined.
+  const editorWithRuntime = cloudNotebookShellCapabilities({
+    authState: authState("oidc", "editor"),
+    connectionScope: "editor",
+    hasCodeCells: true,
+    selectedMode: "edit",
+    runtimeAvailable: true,
+  });
+  assert.equal(editorWithRuntime.runtime.executionAvailable, true);
+  assert.equal(editorWithRuntime.runtime.connected, true);
+  assert.equal(editorWithRuntime.canExecute, false);
 });
 
 test("cloud shell capabilities keep user-selected view mode read-only even with editor access", () => {

--- a/apps/notebook-cloud/viewer/index.tsx
+++ b/apps/notebook-cloud/viewer/index.tsx
@@ -51,7 +51,7 @@ import { useWidgetStoreRequired } from "@/components/widgets/widget-store-contex
 import { useTheme } from "@/hooks/useTheme";
 import { ErrorBoundary } from "@/lib/error-boundary";
 import { EnvironmentSummary } from "@/components/environment";
-import type { NotebookOutlineItem } from "runtimed";
+import { NotebookClient, type NotebookOutlineItem } from "runtimed";
 import { createNotebookCloudBlobResolver } from "../src/blob-resolver";
 import {
   clearCloudPrototypeDevAuth,
@@ -87,6 +87,7 @@ import { cloudViewerLoadingPolicy } from "./loading-policy";
 import { markCloudViewerLoadMilestone } from "./load-milestones";
 import { CLOUD_VIEWER_PRIORITY } from "./mime-policy";
 import {
+  cloudPresenceHasRuntimePeer,
   type CloudViewerPresencePeer,
   type CloudViewerPresenceStore,
   cloudViewerPresenceDisplay,
@@ -670,6 +671,12 @@ function NotebookViewer({
     preloadSiftWasm,
     widgetStore,
   });
+  const presenceSnapshot = useSyncExternalStore(
+    presenceStore.subscribe,
+    presenceStore.getSnapshot,
+    presenceStore.getSnapshot,
+  );
+  const runtimePeerAvailable = cloudPresenceHasRuntimePeer(presenceSnapshot);
   const outputHostContext = useMemo<NteractEmbedHostContextPatch>(
     () => ({
       nteract: {
@@ -770,6 +777,7 @@ function NotebookViewer({
         selectedMode: selectedInteractionMode,
         canAcceptCellMutations,
         editAccessRequestPending,
+        runtimeAvailable: runtimePeerAvailable,
         hostCapabilities: config.hostCapabilities,
       }),
     [
@@ -780,6 +788,7 @@ function NotebookViewer({
       connectionActorLabel,
       connectionScope,
       editAccessRequestPending,
+      runtimePeerAvailable,
       selectedInteractionMode,
     ],
   );
@@ -880,6 +889,30 @@ function NotebookViewer({
     },
     [cloudNotebookController],
   );
+  const handleCloudExecuteCell = useCallback((cellId: string) => {
+    const liveRuntime = liveRuntimeRef.current;
+    if (!liveRuntime) {
+      console.warn("[notebook-cloud] cannot execute cell without a live room connection");
+      return;
+    }
+
+    void (async () => {
+      const delivered = await liveRuntime.engine.flushAndWait();
+      if (!delivered) {
+        console.warn("[notebook-cloud] execute cell request skipped; notebook sync failed");
+        return;
+      }
+
+      const client = new NotebookClient({
+        transport: liveRuntime.transport,
+        logger: console,
+        getRequiredHeads: () => liveRuntime.handle.get_heads_hex(),
+      });
+      await client.executeCell(cellId);
+    })().catch((error: unknown) => {
+      console.warn("[notebook-cloud] execute cell request failed", error);
+    });
+  }, []);
   const handleCloudSetCellSourceHidden = useCallback(
     (cellId: string, hidden: boolean) => {
       cloudNotebookController.setCellSourceHidden(cellId, hidden);
@@ -1213,7 +1246,7 @@ function NotebookViewer({
             runtime={notebookLanguageRef.current === "deno" ? "deno" : "python"}
             sessionRuntimeState={connectionError ? "error" : "ready"}
             onFocusCell={setFocusedCellId}
-            onExecuteCell={() => {}}
+            onExecuteCell={handleCloudExecuteCell}
             onInterruptKernel={() => {}}
             onDeleteCell={handleCloudDeleteCell}
             onAddCell={handleCloudAddCell}

--- a/apps/notebook-cloud/viewer/live-sync.ts
+++ b/apps/notebook-cloud/viewer/live-sync.ts
@@ -56,6 +56,13 @@ export interface CloudSyncConnectOptions {
 type FrameListener = Parameters<NotebookTransport["onFrame"]>[0];
 
 const LIVE_SYNC_READY_TIMEOUT_MS = 30_000;
+const CLOUD_REQUEST_TIMEOUT_MS = 30_000;
+
+interface PendingFrameAck {
+  reject: (error: Error) => void;
+  resolve: () => void;
+  timeoutId: ReturnType<typeof setTimeout>;
+}
 
 export function cloudSyncAuthFromLocalStorage(): CloudSyncAuth {
   return cloudSyncAuthFromPrototypeAuthState(cloudPrototypeAuthFromWindow());
@@ -203,6 +210,9 @@ export class CloudWebSocketTransport implements NotebookTransport {
   private socket: WebSocket;
   private listeners = new Set<FrameListener>();
   private queuedFrames: number[][] = [];
+  // Hosted room accept/reject controls currently carry only the frame type, not
+  // a request id, so pending acknowledgements are matched FIFO per frame type.
+  private pendingFrameAcks = new Map<number, PendingFrameAck[]>();
   private readySettled = false;
   private readyResolved = false;
   private closed = false;
@@ -287,17 +297,39 @@ export class CloudWebSocketTransport implements NotebookTransport {
   }
 
   async sendTypedRequest(
-    _frameType: FrameTypeValue,
-    _payload: Uint8Array,
+    frameType: FrameTypeValue,
+    payload: Uint8Array,
     _id: string,
-    _timeoutMs: number,
-    _timeoutLabel?: string,
+    timeoutMs: number,
+    timeoutLabel = "cloud request",
   ): Promise<NotebookResponse> {
-    throw new Error("cloud viewer transport does not support request/response frames yet");
+    if (frameType !== FrameType.REQUEST) {
+      throw new Error(
+        `cloud viewer transport does not support typed request frame 0x${frameType.toString(16)}`,
+      );
+    }
+
+    const pending = this.registerFrameAck(frameType, timeoutMs, timeoutLabel);
+    try {
+      await this.sendFrame(frameType, payload);
+      await pending.promise;
+      return { result: "ok" };
+    } catch (error) {
+      pending.cancel();
+      throw error;
+    }
   }
 
-  async sendRequest(_request: unknown, _options?: NotebookRequestOptions): Promise<unknown> {
-    throw new Error("cloud viewer transport does not support notebook requests yet");
+  async sendRequest(request: unknown, options?: NotebookRequestOptions): Promise<unknown> {
+    const envelope = notebookRequestEnvelope(request, options);
+    const payload = new TextEncoder().encode(JSON.stringify(envelope));
+    return this.sendTypedRequest(
+      FrameType.REQUEST,
+      payload,
+      envelope.id,
+      CLOUD_REQUEST_TIMEOUT_MS,
+      envelope.action,
+    );
   }
 
   onFrame(callback: FrameListener): () => void {
@@ -327,6 +359,13 @@ export class CloudWebSocketTransport implements NotebookTransport {
       this.onControl?.(control);
       if (control.type === "cloud_room_ready") {
         this.readyResolve(control);
+      } else if (control.type === "cloud_frame_accepted") {
+        this.resolveFrameAck(control.frame_type);
+      } else if (control.type === "cloud_frame_rejected") {
+        this.rejectFrameAck(
+          control.frame_type,
+          new Error(`cloud room rejected frame: ${control.reason}`),
+        );
       }
       return;
     }
@@ -374,10 +413,107 @@ export class CloudWebSocketTransport implements NotebookTransport {
     this.closed = true;
     this.listeners.clear();
     this.queuedFrames = [];
+    this.rejectPendingFrameAcks(reason);
     if (this.readyResolved && !this.manualDisconnect) {
       this.onDisconnect?.(reason);
     }
   }
+
+  private registerFrameAck(
+    frameType: FrameTypeValue,
+    timeoutMs: number,
+    timeoutLabel: string,
+  ): { cancel: () => void; promise: Promise<void> } {
+    let pending!: PendingFrameAck;
+    const promise = new Promise<void>((resolve, reject) => {
+      const timeoutId = setTimeout(() => {
+        this.removeFrameAck(frameType, pending);
+        reject(new Error(`${timeoutLabel} timed out waiting for cloud room frame acceptance`));
+      }, timeoutMs);
+      pending = { reject, resolve, timeoutId };
+      const queue = this.pendingFrameAcks.get(frameType) ?? [];
+      queue.push(pending);
+      this.pendingFrameAcks.set(frameType, queue);
+    });
+    promise.catch(() => undefined);
+
+    return {
+      cancel: () => this.removeFrameAck(frameType, pending),
+      promise,
+    };
+  }
+
+  private resolveFrameAck(frameType: number): void {
+    const pending = this.shiftFrameAck(frameType);
+    if (!pending) return;
+    clearTimeout(pending.timeoutId);
+    pending.resolve();
+  }
+
+  private rejectFrameAck(frameType: number | undefined, error: Error): void {
+    if (frameType === undefined) {
+      this.rejectPendingFrameAcks(error);
+      return;
+    }
+
+    const pending = this.shiftFrameAck(frameType);
+    if (!pending) return;
+    clearTimeout(pending.timeoutId);
+    pending.reject(error);
+  }
+
+  private shiftFrameAck(frameType: number): PendingFrameAck | undefined {
+    const queue = this.pendingFrameAcks.get(frameType);
+    const pending = queue?.shift();
+    if (!queue || queue.length === 0) {
+      this.pendingFrameAcks.delete(frameType);
+    }
+    return pending;
+  }
+
+  private removeFrameAck(frameType: number, pending: PendingFrameAck): void {
+    const queue = this.pendingFrameAcks.get(frameType);
+    if (!queue) return;
+    const index = queue.indexOf(pending);
+    if (index === -1) return;
+    queue.splice(index, 1);
+    clearTimeout(pending.timeoutId);
+    if (queue.length === 0) {
+      this.pendingFrameAcks.delete(frameType);
+    }
+  }
+
+  private rejectPendingFrameAcks(error: Error): void {
+    for (const queue of this.pendingFrameAcks.values()) {
+      for (const pending of queue) {
+        clearTimeout(pending.timeoutId);
+        pending.reject(error);
+      }
+    }
+    this.pendingFrameAcks.clear();
+  }
+}
+
+function notebookRequestEnvelope(
+  request: unknown,
+  options?: NotebookRequestOptions,
+): { action: string; id: string; required_heads?: string[]; [key: string]: unknown } {
+  if (!isRecord(request) || typeof request.type !== "string") {
+    throw new Error("cloud viewer notebook request must include a string type");
+  }
+
+  const { type, ...rest } = request;
+  const requiredHeads = options?.required_heads?.filter((head) => head.length > 0);
+  return {
+    id: crypto.randomUUID(),
+    action: type,
+    ...(requiredHeads?.length ? { required_heads: requiredHeads } : {}),
+    ...rest,
+  };
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null;
 }
 
 export function syncUrl(syncEndpoint: string, sessionId: string, auth: CloudSyncAuth): URL {

--- a/apps/notebook-cloud/viewer/presence.ts
+++ b/apps/notebook-cloud/viewer/presence.ts
@@ -1,4 +1,5 @@
 import type { SessionControlMessage } from "../src/protocol";
+import type { ConnectionScope } from "../src/auth-shared";
 import { notebookActorIdentityFromProjection, notebookActorProjectionFromLabel } from "runtimed";
 
 export type CloudViewerPresenceConnection = "connecting" | "connected" | "disconnected";
@@ -10,6 +11,7 @@ export interface CloudViewerPresenceState {
   ownPeerLabel: string | null;
   peers: CloudViewerPresencePeer[];
   roomPeerCount: number | null;
+  runtimePeerCount: number;
 }
 
 export interface CloudViewerPresenceDisplay {
@@ -23,6 +25,7 @@ export interface CloudViewerPresenceDisplay {
 export interface CloudViewerPresencePeer {
   id: string;
   label: string;
+  connectionScope: ConnectionScope | null;
   kind: "self" | "peer" | "anonymous" | "unknown";
   status: "active" | "idle" | "offline";
   count?: number;
@@ -72,6 +75,7 @@ export function initialCloudViewerPresence(): CloudViewerPresenceState {
     ownPeerLabel: null,
     peers: [],
     roomPeerCount: null,
+    runtimePeerCount: 0,
   };
 }
 
@@ -112,10 +116,15 @@ export function reduceCloudViewerPresenceMessage(
               displayName: message.display_name,
               email: message.email,
               actorLabel: message.actor_label,
+              connectionScope: message.connection_scope,
               kind: "self",
             }),
           ],
           roomPeerCount: safeRoomPeerCount(message.room_peer_count),
+          runtimePeerCount: safeRuntimePeerCount(
+            message.runtime_peer_count,
+            message.connection_scope === "runtime_peer" ? 1 : 0,
+          ),
         },
         message.room_peer_count,
       );
@@ -129,10 +138,15 @@ export function reduceCloudViewerPresenceMessage(
             cloudPresencePeerFromMessage({
               peerId: message.peer_id,
               actorLabel: message.actor_label,
+              connectionScope: message.connection_scope ?? null,
               kind: "peer",
             }),
           ),
           roomPeerCount: safeRoomPeerCount(message.room_peer_count),
+          runtimePeerCount: safeRuntimePeerCount(
+            message.runtime_peer_count,
+            state.runtimePeerCount + (message.connection_scope === "runtime_peer" ? 1 : 0),
+          ),
         },
         message.room_peer_count,
       );
@@ -143,6 +157,10 @@ export function reduceCloudViewerPresenceMessage(
           connection: "connected",
           peers: state.peers.filter((peer) => peer.id !== message.peer_id),
           roomPeerCount: safeRoomPeerCount(message.room_peer_count),
+          runtimePeerCount: safeRuntimePeerCount(
+            message.runtime_peer_count,
+            state.runtimePeerCount - (message.connection_scope === "runtime_peer" ? 1 : 0),
+          ),
         },
         message.room_peer_count,
       );
@@ -156,18 +174,21 @@ function cloudPresencePeerFromMessage({
   displayName,
   email,
   actorLabel,
+  connectionScope,
   kind,
 }: {
   peerId: string;
   displayName?: string | null;
   email?: string | null;
   actorLabel?: string | null;
+  connectionScope?: string | null;
   kind: "self" | "peer";
 }): CloudViewerPresencePeer {
   const label = cloudFriendlyPeerLabel({ displayName, email, actorLabel });
   return {
     id: peerId,
     label,
+    connectionScope: normalizePresenceConnectionScope(connectionScope),
     kind: label === "Anonymous" ? "anonymous" : kind === "self" ? "self" : "peer",
     status: "active",
   };
@@ -197,6 +218,7 @@ function withRoomPeerCount(
     return {
       id: `unknown-${ordinal}`,
       label: "Anonymous",
+      connectionScope: null,
       kind: "unknown",
       status: state.connection === "connected" ? "active" : "idle",
     };
@@ -231,6 +253,7 @@ export function cloudViewerPresenceDisplay(
         {
           id: "joining",
           label: "Joining room",
+          connectionScope: null,
           kind: "unknown",
           status: "idle",
         },
@@ -255,6 +278,7 @@ export function cloudViewerPresenceDisplay(
             id: "anonymous-group",
             label:
               anonymousCount === 1 ? "Anonymous viewer" : `${anonymousCount} anonymous viewers`,
+            connectionScope: null,
             kind: "anonymous" as const,
             status: "active" as const,
             count: anonymousCount,
@@ -270,6 +294,13 @@ export function cloudViewerPresenceDisplay(
     peers: visiblePeers,
     hiddenCount,
   };
+}
+
+export function cloudPresenceHasRuntimePeer(state: CloudViewerPresenceState): boolean {
+  return (
+    state.runtimePeerCount > 0 ||
+    state.peers.some((peer) => peer.connectionScope === "runtime_peer")
+  );
 }
 
 export interface CloudFriendlyPeerLabelInput {
@@ -317,6 +348,25 @@ function safeRoomPeerCount(value: number): number {
   return Number.isFinite(value) && value > 0 ? Math.floor(value) : 1;
 }
 
+function safeRuntimePeerCount(value: number | undefined, fallback: number): number {
+  const count = value ?? fallback;
+  return Number.isFinite(count) && count > 0 ? Math.floor(count) : 0;
+}
+
 function looksLikeRawIdentityLabel(value: string): boolean {
   return /^(anonymous|user):/.test(value);
+}
+
+function normalizePresenceConnectionScope(
+  value: string | null | undefined,
+): ConnectionScope | null {
+  switch (value) {
+    case "viewer":
+    case "editor":
+    case "runtime_peer":
+    case "owner":
+      return value;
+    default:
+      return null;
+  }
 }

--- a/apps/notebook-cloud/viewer/shell-capabilities.ts
+++ b/apps/notebook-cloud/viewer/shell-capabilities.ts
@@ -29,10 +29,17 @@ export interface CloudNotebookShellCapabilityInput {
   editAccessRequestPending?: boolean;
   /**
    * Whether an execution runtime is attached to the room. The hosted prototype
-   * has no kernel provider yet, so this defaults false and run controls stay
-   * hidden. Flip it on once a runtime peer can execute the room's cells.
+   * uses this as runtime status only; execution controls also require
+   * canSubmitExecutionRequests so runtime presence is not confused with
+   * execution authority.
    */
   runtimeAvailable?: boolean;
+  /**
+   * Whether this browser connection may create execution intent in the hosted
+   * room. Today the room host grants that to owners only; future execute-scope
+   * policy can replace this without changing the shared shell projection.
+   */
+  canSubmitExecutionRequests?: boolean;
   /**
    * Host-provided room capabilities. Sharing is a room/host concern, not a
    * notebook-local affordance, so owner access alone is not enough to show it.
@@ -51,6 +58,7 @@ export function cloudNotebookShellCapabilities({
   canAcceptCellMutations = true,
   editAccessRequestPending = false,
   runtimeAvailable = false,
+  canSubmitExecutionRequests = connectionScope === "owner",
   hostCapabilities,
 }: CloudNotebookShellCapabilityInput): NotebookShellCapabilities {
   const interaction = projectCloudNotebookEditAccess({
@@ -80,7 +88,7 @@ export function cloudNotebookShellCapabilities({
   };
   const runtime = {
     canWriteRuntimeState: isRuntimePeer,
-    connected: isRuntimePeer,
+    connected: isRuntimePeer || runtimeAvailable,
     executionAvailable: runtimeAvailable,
     source: "cloud" as const,
     actorLabel: isRuntimePeer ? connectionActorLabel : null,
@@ -111,6 +119,7 @@ export function cloudNotebookShellCapabilities({
     },
     execution: {
       available: runtimeAvailable,
+      canSubmit: canSubmitExecutionRequests,
       requiresDocumentEditPermission: true,
     },
     packages: {

--- a/crates/runtimed-wasm/src/lib.rs
+++ b/crates/runtimed-wasm/src/lib.rs
@@ -3943,6 +3943,47 @@ mod tests {
     }
 
     #[test]
+    fn hosted_execute_cell_fans_out_runtime_state_to_runtime_peer() {
+        let mut host = RoomHostHandle::create_empty("demo", "system/schema:notebook-cloud-room")
+            .expect("create room host");
+        host.seed_initial_code_cell_if_empty("cell-1")
+            .expect("seed code cell");
+        host.doc
+            .update_source("cell-1", "print('from owner')")
+            .expect("set source");
+
+        // Register a runtime_peer the same way cloud_room_ready + sync_peer do:
+        // the initial sync advances that peer's room-host sync state, so a
+        // later ExecuteCell should fan out only the new queued execution.
+        let mut initial = Vec::new();
+        host.queue_current_sync_for_peer("runtime-peer", false, true, true, &mut initial)
+            .expect("initial runtime peer sync");
+        assert!(
+            initial
+                .iter()
+                .any(|f| f.peer_id == "runtime-peer"
+                    && f.frame_type == frame_types::RUNTIME_STATE_SYNC),
+            "initial sync registers the runtime peer for RuntimeStateDoc updates"
+        );
+
+        let result = host
+            .handle_execute_cell(
+                &json!({ "action": "execute_cell", "cell_id": "cell-1" }),
+                "owner-peer",
+                "user:anaconda:alice/browser:cloud",
+            )
+            .expect("dispatch ok");
+
+        assert!(result.runtime_state_changed);
+        assert!(
+            result.outbound.iter().any(|f| {
+                f.peer_id == "runtime-peer" && f.frame_type == frame_types::RUNTIME_STATE_SYNC
+            }),
+            "queued execution should be broadcast to the registered runtime peer"
+        );
+    }
+
+    #[test]
     fn hosted_execute_cell_honors_client_supplied_execution_id() {
         let mut host = RoomHostHandle::create_empty("demo", "system/schema:notebook-cloud-room")
             .expect("create room host");

--- a/crates/runtimed/src/jupyter_kernel.rs
+++ b/crates/runtimed/src/jupyter_kernel.rs
@@ -323,7 +323,7 @@ pub struct JupyterKernel {
     pub env_path: Option<PathBuf>,
     /// Session ID for Jupyter protocol.
     session_id: String,
-    /// Automerge actor ID for kernel writes (e.g. "rt:kernel:a1b2c3d4").
+    /// Automerge actor ID for kernel writes.
     kernel_actor_id: String,
     /// Connection info for the kernel.
     connection_info: Option<ConnectionInfo>,
@@ -1211,7 +1211,10 @@ impl KernelConnection for JupyterKernel {
 
         // Fresh session_id for ZMQ connections
         let session_id = Uuid::new_v4().to_string();
-        let kernel_actor_id = format!("rt:kernel:{}", &session_id[..8]);
+        let kernel_actor_id = match shared.kernel_actor_principal.as_deref() {
+            Some(principal) => format!("{principal}/runtime:kernel:{}", &session_id[..8]),
+            None => format!("rt:kernel:{}", &session_id[..8]),
+        };
 
         // ── ZMQ connections and background tasks ─────────────────────────
 

--- a/crates/runtimed/src/kernel_connection.rs
+++ b/crates/runtimed/src/kernel_connection.rs
@@ -69,6 +69,12 @@ pub struct KernelSharedRefs {
     pub presence: Arc<RwLock<PresenceState>>,
     /// Broadcast channel for presence frames.
     pub presence_tx: broadcast::Sender<(String, Vec<u8>)>,
+    /// Principal prefix for kernel-authored RuntimeStateDoc changes.
+    ///
+    /// Cloud rooms require every actor to be a durable
+    /// `<principal>/<operator>` label. The desktop/UDS path leaves this unset
+    /// and keeps the legacy `rt:kernel:*` actor prefix.
+    pub kernel_actor_principal: Option<String>,
 }
 
 /// Internal abstraction over the Jupyter ZeroMQ IO boundary.

--- a/crates/runtimed/src/runtime_agent.rs
+++ b/crates/runtimed/src/runtime_agent.rs
@@ -221,7 +221,7 @@ fn is_kernel_authored_actor(actor: &automerge::ActorId, principal: Option<&str>)
     let Some(principal) = principal else {
         return false;
     };
-    let Ok(label) = std::str::from_utf8(&bytes) else {
+    let Ok(label) = std::str::from_utf8(bytes) else {
         return false;
     };
     let Some((actor_principal, operator)) = label.split_once('/') else {

--- a/crates/runtimed/src/runtime_agent.rs
+++ b/crates/runtimed/src/runtime_agent.rs
@@ -95,6 +95,7 @@ struct RuntimeAgentContext {
     broadcast_tx: broadcast::Sender<notebook_protocol::protocol::NotebookBroadcast>,
     presence: Arc<RwLock<PresenceState>>,
     presence_tx: broadcast::Sender<(String, Vec<u8>)>,
+    kernel_actor_principal: Option<String>,
 }
 
 /// Run the runtime agent, connecting to the daemon socket as a peer.
@@ -207,6 +208,28 @@ fn cloud_actor_label(principal: &str, operator: &str) -> String {
     format!("{principal}/{operator}:{}", &nonce[..8])
 }
 
+fn kernel_actor_principal_from_runtime_actor(actor_label: &str) -> Option<&str> {
+    actor_label.split_once('/').map(|(principal, _)| principal)
+}
+
+fn is_kernel_authored_actor(actor: &automerge::ActorId, principal: Option<&str>) -> bool {
+    let bytes = actor.to_bytes();
+    if bytes.starts_with(b"rt:kernel:") {
+        return true;
+    }
+
+    let Some(principal) = principal else {
+        return false;
+    };
+    let Ok(label) = std::str::from_utf8(&bytes) else {
+        return false;
+    };
+    let Some((actor_principal, operator)) = label.split_once('/') else {
+        return false;
+    };
+    actor_principal == principal && operator.starts_with("runtime:kernel:")
+}
+
 /// Carry the interpreter path through to `launch()` for a no-pool launch.
 ///
 /// `current_python` (and any prepares-own-env source) sets `python_path` with no
@@ -273,6 +296,8 @@ where
         "[runtime-agent] Bootstrapping notebook_id={} as actor {}",
         notebook_id, runtime_agent_id
     );
+    let kernel_actor_principal =
+        kernel_actor_principal_from_runtime_actor(&runtime_agent_id).map(str::to_string);
 
     let state_doc = RuntimeStateDoc::try_new_with_actor(&runtime_agent_id)
         .map_err(|e| anyhow::anyhow!("create runtime-agent state doc: {e}"))?;
@@ -305,6 +330,7 @@ where
         broadcast_tx: broadcast_tx.clone(),
         presence,
         presence_tx,
+        kernel_actor_principal,
     };
 
     // -- Local variables owned by the select! loop (no mutex) ---------------
@@ -652,7 +678,12 @@ where
                                         match comms_doc.receive_sync_and_foreign_comms_recovering(
                                             &mut comms_sync_state,
                                             msg,
-                                            |actor| !actor.to_bytes().starts_with(b"rt:kernel:"),
+                                            |actor| {
+                                                !is_kernel_authored_actor(
+                                                    actor,
+                                                    ctx.kernel_actor_principal.as_deref(),
+                                                )
+                                            },
                                             "runtime-agent-comms-receive",
                                         ) {
                                             Ok(view) if !view.applied_actors.is_empty() => {
@@ -813,6 +844,25 @@ where
                                 // (source comes from execution entries), but it may be
                                 // useful for completions context in the future.
                                 debug!("[runtime-agent] Received NotebookDoc sync frame (ignored for now)");
+                            }
+
+                            NotebookFrameType::SessionControl => {
+                                if let Ok(control) =
+                                    serde_json::from_slice::<serde_json::Value>(&typed_frame.payload)
+                                {
+                                    if control.get("type").and_then(|v| v.as_str())
+                                        == Some("cloud_frame_rejected")
+                                    {
+                                        warn!(
+                                            "[runtime-agent] Cloud room rejected frame: frame_type={:?} reason={}",
+                                            control.get("frame_type"),
+                                            control
+                                                .get("reason")
+                                                .and_then(|v| v.as_str())
+                                                .unwrap_or("(no reason given)")
+                                        );
+                                    }
+                                }
                             }
 
                             _ => {
@@ -1005,8 +1055,12 @@ where
                             );
                             break;
                         }
-                    };
+                };
                 if let Some(encoded) = encoded {
+                    debug!(
+                        "[runtime-agent] Sending RuntimeStateSync to coordinator ({} bytes)",
+                        encoded.len()
+                    );
                     if let Err(e) = frame_sink.send_frame(
                         NotebookFrameType::RuntimeStateSync,
                         &encoded,
@@ -1355,6 +1409,7 @@ async fn handle_runtime_agent_request(
                 broadcast_tx: ctx.broadcast_tx.clone(),
                 presence: ctx.presence.clone(),
                 presence_tx: ctx.presence_tx.clone(),
+                kernel_actor_principal: ctx.kernel_actor_principal.clone(),
             };
             let launch_kernel_type = kernel_type.clone();
             let launch_env_source = env_source.as_str().to_string();
@@ -1474,6 +1529,7 @@ async fn handle_runtime_agent_request(
                 broadcast_tx: ctx.broadcast_tx.clone(),
                 presence: ctx.presence.clone(),
                 presence_tx: ctx.presence_tx.clone(),
+                kernel_actor_principal: ctx.kernel_actor_principal.clone(),
             };
             let launch_kernel_type = kernel_type.clone();
             let launch_env_source = env_source.as_str().to_string();
@@ -2573,6 +2629,39 @@ mod tests {
         assert_ne!(a, b);
     }
 
+    #[test]
+    fn kernel_actor_principal_tracks_cloud_actor_principal() {
+        let actor = "user:anaconda:alice/agent:runt:12345678";
+        assert_eq!(
+            kernel_actor_principal_from_runtime_actor(actor),
+            Some("user:anaconda:alice")
+        );
+        assert_eq!(
+            kernel_actor_principal_from_runtime_actor("runtime-agent:local"),
+            None
+        );
+    }
+
+    #[test]
+    fn kernel_authored_actor_recognizes_legacy_and_cloud_kernel_labels() {
+        let legacy = automerge::ActorId::from(b"rt:kernel:deadbeef".as_slice());
+        assert!(is_kernel_authored_actor(&legacy, None));
+
+        let cloud =
+            automerge::ActorId::from(b"user:anaconda:alice/runtime:kernel:deadbeef".as_slice());
+        assert!(is_kernel_authored_actor(
+            &cloud,
+            Some("user:anaconda:alice")
+        ));
+        assert!(!is_kernel_authored_actor(&cloud, Some("user:anaconda:bob")));
+
+        let agent = automerge::ActorId::from(b"user:anaconda:alice/agent:runt:12345678".as_slice());
+        assert!(!is_kernel_authored_actor(
+            &agent,
+            Some("user:anaconda:alice")
+        ));
+    }
+
     /// The cloud actor resolver (the closure `run_cloud_runtime_agent` passes
     /// into `run_runtime_agent_on_transport`) must error rather than silently
     /// author under a wrong actor when the transport never observed a
@@ -2704,6 +2793,7 @@ mod tests {
             broadcast_tx: broadcast_tx.clone(),
             presence,
             presence_tx,
+            kernel_actor_principal: None,
         };
         let state = KernelState::new(handle.clone());
         (ctx, state, handle)

--- a/docs/adr/hosted-room-authorization.md
+++ b/docs/adr/hosted-room-authorization.md
@@ -132,6 +132,22 @@ grant different write surfaces. Treat them as capability sets:
 | `runtime_peer` | viewer + write kernel lifecycle, comm topology, output routing, and progress/output state for accepted executions + upload output blobs; cannot create execution intent or rewrite trust/environment/path/project metadata |
 | `owner` | editor + publish revisions + mutate ACLs; may hold separate `runtime_peer` capability through an explicit ACL row when it needs runtime progress authorship |
 
+Execution intent is a separate authority from runtime-state authorship. A
+runtime peer may consume queued executions and write lifecycle/output state, but
+it must not create new execution intent. In the current browser-hosted
+implementation, the cloud viewer surfaces run controls only when:
+
+1. a live `runtime_peer` is attached to the room; and
+2. the browser connection is scoped as `owner`.
+
+This is an interim policy, not the final shape. The long-term model should add
+an explicit execute capability/scope so principals that own both a document
+editing connection and a runtime-peer connection can be granted execution intent
+without conflating `editor`, `runtime_peer`, and `owner`. Local-only kernels
+should continue to author runtime state under a local principal; when a local
+kernel is promoted into a hosted room, it should adopt the authenticated room
+principal/operator it uses for that connection.
+
 The provider gives a maximum capability set for the credential. The ACL gives
 one or more room grants. A connection also has a requested role. Anonymous
 browser viewers may omit the role and default to `viewer`. Authenticated native

--- a/docs/adr/typed-frame-v4-wire-protocol.md
+++ b/docs/adr/typed-frame-v4-wire-protocol.md
@@ -233,6 +233,18 @@ The same envelope shape covers the runtime-agent subprotocol (`RuntimeAgentReque
 
 `PutBlob` (0x08) also correlates with `Response` frames using the same id mechanism, even though `PutBlob` is a different type byte. The relay's `sendTypedRequest(frameType, payload, id, timeoutMs)` is the generic path; `sendRequest` is the JSON-request wrapper, and the blob-upload code uses `sendTypedRequest` directly.
 
+The hosted cloud room currently has one narrower request path: browser
+`execute_cell` requests are sent as `Request` frames to the Durable Object room
+host, and the room host materializes execution intent into `RuntimeStateDoc`.
+That path acknowledges frame acceptance or rejection through `SessionControl`
+(`cloud_frame_accepted` / `cloud_frame_rejected`) and does not yet emit a
+correlated `Response` envelope. Browser clients therefore treat frame acceptance
+as "the room accepted the execution-intent request"; the durable execution
+result is still observed through `RuntimeStateDoc`. A future hosted protocol
+pass should add correlated `Response` frames for hosted `Request` handling so
+the cloud transport fully matches the desktop/daemon request contract and can
+return `cell_queued` / `guard_rejected` details directly.
+
 ## Decision 10: Back-pressure is bounded by the reader actor, not the wire
 
 There is no flow-control field on the wire. No window, no credits, no rate limit. Back-pressure is structural:

--- a/packages/runtimed/src/notebook-shell-capabilities.ts
+++ b/packages/runtimed/src/notebook-shell-capabilities.ts
@@ -87,6 +87,7 @@ export interface NotebookShellControlPolicy {
 
 export interface NotebookShellExecutionPolicy {
   available: boolean;
+  canSubmit?: boolean;
   requiresDocumentEditPermission?: boolean;
   requiresDocumentMutationSupport?: boolean;
 }
@@ -330,6 +331,7 @@ export function projectNotebookShellCapabilities({
   const canRead = accessCapabilities.level !== "none";
   const canExecute =
     executionAvailable &&
+    (execution?.canSubmit ?? true) &&
     (!execution?.requiresDocumentEditPermission || hasDocumentEditPermission) &&
     (!execution?.requiresDocumentMutationSupport || canMutateFullDocument);
   const canToggleCode = controls?.canToggleCode ?? true;

--- a/packages/runtimed/tests/notebook-shell-capabilities.test.ts
+++ b/packages/runtimed/tests/notebook-shell-capabilities.test.ts
@@ -139,6 +139,31 @@ describe("projectNotebookShellCapabilities", () => {
     expect(capabilities.canExecute).toBe(true);
   });
 
+  it("keeps runtime availability visible when execution submission is not allowed", () => {
+    const interaction = projectNotebookRoomEditAccess({
+      accessLevel: "editor",
+      requestedScope: "editor",
+      selectedMode: "edit",
+      canAcceptDocumentMutations: true,
+      canRequestEdit: true,
+    });
+
+    const capabilities = projectNotebookShellCapabilities({
+      interaction,
+      access: access({ level: "editor" }),
+      runtime: runtime({ connected: true, executionAvailable: true }),
+      execution: {
+        available: true,
+        canSubmit: false,
+        requiresDocumentEditPermission: true,
+      },
+    });
+
+    expect(capabilities.runtime.connected).toBe(true);
+    expect(capabilities.runtime.executionAvailable).toBe(true);
+    expect(capabilities.canExecute).toBe(false);
+  });
+
   it("applies sharing requirements for authenticated cloud hosts", () => {
     const interaction = projectNotebookRoomEditAccess({
       accessLevel: "owner",


### PR DESCRIPTION
## Summary
- surface attached runtime peers to the cloud viewer via room session-control presence
- enable owner-scoped browser execution by sending hosted `execute_cell` requests through `NotebookClient`
- keep runtime availability visible separately from execution authority, with editors/viewers still unable to submit execution intent
- document the interim owner-only policy and the hosted request-ack gap in ADRs

## Stacking
This is stacked on #3452 (`qu/lab2/runtime-peer-execution-pickup`). The new commit is `ca7f3d8d feat(cloud): allow owner execution through runtime peers`; GitHub may show the #3452 commits until that PR lands.

## Verification
- `pnpm --filter notebook-cloud exec node --import tsx --test test/live-sync.test.ts test/viewer-presence.test.ts test/viewer-shell-capabilities.test.ts test/notebook-room.test.ts`
- `pnpm test:run packages/runtimed/tests/notebook-shell-capabilities.test.ts`
- `pnpm --filter notebook-cloud typecheck`
- `cargo xtask lint --fix`

## Reviewer Notes
@pullfrog please pay particular attention to the hosted request path: browser `execute_cell` currently completes on `cloud_frame_accepted` / `cloud_frame_rejected` session controls because the Durable Object room does not yet emit correlated `Response` frames for hosted requests. The ADR calls this out as intentional interim behavior; durable execution completion still comes through `RuntimeStateDoc`.

Also note the authorization shape: controls are owner-only while a runtime peer is attached. This avoids showing execute controls to editor connections that the current materializer would reject, and leaves room for a future explicit execute scope.