### PR TITLE
test(cloud): add hosted runtime peer smoke

### DIFF
--- a/apps/notebook-cloud/README.md
+++ b/apps/notebook-cloud/README.md
@@ -558,82 +558,35 @@ but never the stored token value.
 Live runtime-peer smoke with preview API-key credentials:
 
 ```bash
-# Run from the repo root after building the two smoke binaries:
-# cargo build --release -p runtimed -p runt-cloud-peer
-#
-# Requires NTERACT_CLOUD_URL and NTERACT_API_KEY in the environment.
-# On lab2, they are available in ${PREVIEW_RUNT_ENV:-$HOME/preview.runt.run/.env}.
-env_file="${PREVIEW_RUNT_ENV:-$HOME/preview.runt.run/.env}"
-if [ -f "$env_file" ]; then
-  set -a
-  . "$env_file"
-  set +a
-fi
-auth_headers=(
-  -H "Authorization: Bearer $NTERACT_API_KEY"
-  -H "X-Notebook-Cloud-Auth-Provider: anaconda-api-key"
-  -H "X-Scope: owner"
-)
-
-create_json="$(
-  curl -fsS -X POST "$NTERACT_CLOUD_URL/api/n" \
-    "${auth_headers[@]}" \
-    -H "Content-Type: application/json" \
-    --data '{"vanity_name":"lab2-dualpeer"}'
-)"
-notebook_id="$(printf "%s" "$create_json" | jq -r '.notebook_id')"
-owner_principal="$(
-  curl -fsS "$NTERACT_CLOUD_URL/api/n/$notebook_id/acl" "${auth_headers[@]}" \
-    | jq -r '.acl[] | select(.scope == "owner" and .subject_kind == "principal") | .subject' \
-    | head -1
-)"
-curl -fsS -X POST "$NTERACT_CLOUD_URL/api/n/$notebook_id/acl" \
-  "${auth_headers[@]}" \
-  -H "Content-Type: application/json" \
-  --data "$(
-    jq -n --arg subject "$owner_principal" \
-      '{subject_kind:"principal", subject:$subject, scope:"runtime_peer"}'
-  )"
-
-# Keep long-lived runtime peers in tmux. A short-lived shell or command runner
-# may clean up background children after the command exits, which makes later
-# execution requests look like room/runtime failures.
-python_path="${PYTHON_PATH:-$(command -v python3 || command -v python)}"
-tmux new-session -d -s "preview-runtime-$notebook_id" \
-  "bash -lc 'set -a; . \"$env_file\"; set +a; \
-    mkdir -p ~/rp-blobs ~/dualpeer-runs; \
-    RUNT_CLOUD_TOKEN=\"\$NTERACT_API_KEY\" RUST_LOG=info \
-      $(pwd)/target/release/runtimed cloud-runtime-agent \
-        --auth-kind anaconda-key \
-        --cloud-url \"\$NTERACT_CLOUD_URL\" \
-        --notebook-id \"$notebook_id\" \
-        --scope runtime_peer \
-        --python-path \"$python_path\" \
-        --blob-root ~/rp-blobs \
-        > ~/dualpeer-runs/compute-$notebook_id.log 2>&1'"
-
-token_file="$(mktemp)"
-trap 'rm -f "$token_file"' EXIT
-printf "%s" "$NTERACT_API_KEY" > "$token_file"
-
-$(pwd)/target/release/runt-cloud-peer \
-  --auth-mode anaconda-api-key \
-  --token-file "$token_file" \
-  --cloud-url "$NTERACT_CLOUD_URL" \
-  --notebook-id "$notebook_id" \
-  --scope owner \
-  --add-cell "print('preview runtime peer smoke')" \
-  --run-cell \
-  --seconds 35
+cargo xtask artifacts ensure sift,renderer
+cargo build --release -p runtimed -p runt-cloud-peer
+NTERACT_CLOUD_URL=https://preview.runt.run \
+pnpm --dir apps/notebook-cloud smoke:hosted:runtime-peer
 ```
 
-The owner peer should observe the new execution move from `queued` to `done`;
-the runtime log should show the kernel launch and an `execute_request`.
-`runt-cloud-peer` uses `--seconds` to control how long the peer remains
-attached. Do not use the old `--timeout` flag in smoke scripts. Rooms created
-with the API-key path are private; anonymous hosted render smokes may return a
-catalog 404 unless the browser context has a credential for the owning
-principal.
+The smoke script reads `NTERACT_API_KEY` from the environment. On lab2 it also
+loads `${PREVIEW_RUNT_ENV:-$HOME/preview.runt.run/.env}` when present. It
+creates a private room, grants `runtime_peer` to the owner principal, starts the
+real `runtimed cloud-runtime-agent`, then runs `runt-cloud-peer` as an owner
+that adds a cell and sends hosted `execute_cell`. The JSON result includes the
+viewer URL, timings, and log paths under `.context/smokes/`. A healthy run
+observes `queued` and `done`, and the runtime log shows a kernel launch plus an
+`execute_request`. The artifact ensure step rebuilds the gitignored sift
+WASM/renderer outputs that `runtimed` embeds and catches unhydrated stable
+renderer LFS bundles before `cargo build` fails. Set
+`NOTEBOOK_CLOUD_RUNTIME_PEER_PYTHON` when you need a specific interpreter;
+otherwise the script prefers lab2's `~/k/bin/python` before falling back to a
+system Python that can import `ipykernel`.
+
+Set `NOTEBOOK_CLOUD_KEEP_RUNTIME_PEER=1` to leave the runtime peer alive after
+the smoke for manual browser/OIDC inspection. For truly long-lived manual peers,
+run the command inside tmux; short-lived shells or agent command runners may
+clean up background children after the command exits, which makes later
+execution requests look like room/runtime failures. `runt-cloud-peer` uses
+`--seconds` to control how long the owner peer remains attached. Do not use the
+old `--timeout` flag in smoke scripts. Rooms created with the API-key path are
+private; anonymous hosted render smokes may return a catalog 404 unless the
+browser context has a credential for the owning principal.
 
 Snapshot and blob stubs:
 

--- a/apps/notebook-cloud/README.md
+++ b/apps/notebook-cloud/README.md
@@ -555,6 +555,86 @@ The copied browser diagnostic should include the requested principal/scope,
 connected actor/scope when available, and the last WebSocket connection error,
 but never the stored token value.
 
+Live runtime-peer smoke with preview API-key credentials:
+
+```bash
+# Run from the repo root after building the two smoke binaries:
+# cargo build --release -p runtimed -p runt-cloud-peer
+#
+# Requires NTERACT_CLOUD_URL and NTERACT_API_KEY in the environment.
+# On lab2, they are available in ${PREVIEW_RUNT_ENV:-$HOME/preview.runt.run/.env}.
+env_file="${PREVIEW_RUNT_ENV:-$HOME/preview.runt.run/.env}"
+if [ -f "$env_file" ]; then
+  set -a
+  . "$env_file"
+  set +a
+fi
+auth_headers=(
+  -H "Authorization: Bearer $NTERACT_API_KEY"
+  -H "X-Notebook-Cloud-Auth-Provider: anaconda-api-key"
+  -H "X-Scope: owner"
+)
+
+create_json="$(
+  curl -fsS -X POST "$NTERACT_CLOUD_URL/api/n" \
+    "${auth_headers[@]}" \
+    -H "Content-Type: application/json" \
+    --data '{"vanity_name":"lab2-dualpeer"}'
+)"
+notebook_id="$(printf "%s" "$create_json" | jq -r '.notebook_id')"
+owner_principal="$(
+  curl -fsS "$NTERACT_CLOUD_URL/api/n/$notebook_id/acl" "${auth_headers[@]}" \
+    | jq -r '.acl[] | select(.scope == "owner" and .subject_kind == "principal") | .subject' \
+    | head -1
+)"
+curl -fsS -X POST "$NTERACT_CLOUD_URL/api/n/$notebook_id/acl" \
+  "${auth_headers[@]}" \
+  -H "Content-Type: application/json" \
+  --data "$(
+    jq -n --arg subject "$owner_principal" \
+      '{subject_kind:"principal", subject:$subject, scope:"runtime_peer"}'
+  )"
+
+# Keep long-lived runtime peers in tmux. A short-lived shell or command runner
+# may clean up background children after the command exits, which makes later
+# execution requests look like room/runtime failures.
+python_path="${PYTHON_PATH:-$(command -v python3 || command -v python)}"
+tmux new-session -d -s "preview-runtime-$notebook_id" \
+  "bash -lc 'set -a; . \"$env_file\"; set +a; \
+    mkdir -p ~/rp-blobs ~/dualpeer-runs; \
+    RUNT_CLOUD_TOKEN=\"\$NTERACT_API_KEY\" RUST_LOG=info \
+      $(pwd)/target/release/runtimed cloud-runtime-agent \
+        --auth-kind anaconda-key \
+        --cloud-url \"\$NTERACT_CLOUD_URL\" \
+        --notebook-id \"$notebook_id\" \
+        --scope runtime_peer \
+        --python-path \"$python_path\" \
+        --blob-root ~/rp-blobs \
+        > ~/dualpeer-runs/compute-$notebook_id.log 2>&1'"
+
+token_file="$(mktemp)"
+trap 'rm -f "$token_file"' EXIT
+printf "%s" "$NTERACT_API_KEY" > "$token_file"
+
+$(pwd)/target/release/runt-cloud-peer \
+  --auth-mode anaconda-api-key \
+  --token-file "$token_file" \
+  --cloud-url "$NTERACT_CLOUD_URL" \
+  --notebook-id "$notebook_id" \
+  --scope owner \
+  --add-cell "print('preview runtime peer smoke')" \
+  --run-cell \
+  --seconds 35
+```
+
+The owner peer should observe the new execution move from `queued` to `done`;
+the runtime log should show the kernel launch and an `execute_request`.
+`runt-cloud-peer` uses `--seconds` to control how long the peer remains
+attached. Do not use the old `--timeout` flag in smoke scripts. Rooms created
+with the API-key path are private; anonymous hosted render smokes may return a
+catalog 404 unless the browser context has a credential for the owning
+principal.
+
 Snapshot and blob stubs:
 
 ```bash

--- a/apps/notebook-cloud/package.json
+++ b/apps/notebook-cloud/package.json
@@ -20,6 +20,7 @@
     "smoke": "node --import tsx scripts/smoke.mjs",
     "smoke:hosted": "node scripts/hosted-render-smoke.mjs",
     "smoke:hosted:live": "node scripts/hosted-live-smoke.mjs",
+    "smoke:hosted:runtime-peer": "node scripts/hosted-runtime-peer-smoke.mjs",
     "smoke:hosted:collab": "node --import tsx scripts/hosted-collab-smoke.mjs",
     "smoke:hosted:install": "playwright install chromium",
     "smoke:hosted:source-room": "node scripts/hosted-source-room-smoke.mjs",

--- a/apps/notebook-cloud/scripts/hosted-runtime-peer-smoke.mjs
+++ b/apps/notebook-cloud/scripts/hosted-runtime-peer-smoke.mjs
@@ -1,0 +1,622 @@
+import { spawn } from "node:child_process";
+import { closeSync, createWriteStream, openSync, readFileSync } from "node:fs";
+import { access, mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+import { notebookCloudBaseUrl, notebookCloudWorkspaceRoot } from "./local-dev.mjs";
+
+const appDir = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
+const workspaceRoot = notebookCloudWorkspaceRoot({ cwd: appDir });
+
+await loadOptionalEnvFile();
+
+const baseUrl = notebookCloudBaseUrl();
+const apiKey = process.env.NTERACT_API_KEY ?? process.env.NOTEBOOK_CLOUD_PUBLISH_BEARER_TOKEN;
+const vanityName = process.env.NOTEBOOK_CLOUD_RUNTIME_PEER_SMOKE_VANITY ?? "lab2-dualpeer";
+const source =
+  process.env.NOTEBOOK_CLOUD_RUNTIME_PEER_SMOKE_CODE ?? "print('preview runtime peer smoke')";
+const seconds = parsePositiveInteger(
+  process.env.NOTEBOOK_CLOUD_RUNTIME_PEER_SMOKE_SECONDS,
+  "NOTEBOOK_CLOUD_RUNTIME_PEER_SMOKE_SECONDS",
+  35,
+);
+const readyTimeoutMs = parsePositiveInteger(
+  process.env.NOTEBOOK_CLOUD_RUNTIME_PEER_READY_TIMEOUT_MS,
+  "NOTEBOOK_CLOUD_RUNTIME_PEER_READY_TIMEOUT_MS",
+  20_000,
+);
+const keepRuntimePeer = process.env.NOTEBOOK_CLOUD_KEEP_RUNTIME_PEER === "1";
+const runId = new Date().toISOString().replace(/[-:.]/g, "").replace("T", "-").slice(0, 15);
+const smokeRoot = path.resolve(
+  workspaceRoot,
+  ".context",
+  "smokes",
+  "notebook-cloud-runtime-peer",
+  runId,
+);
+const blobRoot = path.join(smokeRoot, "blobs");
+const computeLogPath = path.join(smokeRoot, "runtime-peer.log");
+const ownerLogPath = path.join(smokeRoot, "owner-peer.log");
+const runtimedBin = path.resolve(
+  workspaceRoot,
+  process.env.NOTEBOOK_CLOUD_RUNTIMED_BIN ?? "target/release/runtimed",
+);
+const cloudPeerBin = path.resolve(
+  workspaceRoot,
+  process.env.NOTEBOOK_CLOUD_RUNT_CLOUD_PEER_BIN ?? "target/release/runt-cloud-peer",
+);
+
+const timingsMs = {};
+const startedAt = performance.now();
+let runtimePeer;
+let runtimeKeptAlive = false;
+let tempDir;
+let tokenFile;
+
+main().catch((error) => {
+  console.error(error instanceof Error ? error.message : String(error));
+  process.exitCode = 1;
+});
+
+async function main() {
+  try {
+    requireApiKey();
+    await assertBinaryExists(runtimedBin, "runtimed");
+    await assertBinaryExists(cloudPeerBin, "runt-cloud-peer");
+    const pythonPath = await resolvePythonPath();
+    await mkdir(blobRoot, { recursive: true });
+    tempDir = await mkdtemp(path.join(os.tmpdir(), "nteract-runtime-peer-smoke-"));
+    tokenFile = path.join(tempDir, "api-key");
+    await writeFile(tokenFile, apiKey, { mode: 0o600 });
+
+    const room = await timed("create_room_and_grant_runtime_peer", async () => {
+      const created = await createNotebookRoom();
+      await grantRuntimePeer(created.notebookId);
+      return created;
+    });
+
+    runtimePeer = await timed("runtime_peer_ready", () =>
+      startRuntimePeer({ notebookId: room.notebookId, pythonPath }),
+    );
+
+    const owner = await timed("owner_execute_cell", () =>
+      runOwnerPeerWithRuntimeGuard({ notebookId: room.notebookId }),
+    );
+    const combinedOwnerLog = `${owner.stdout}\n${owner.stderr}`;
+    assert(
+      /status=queued\b/.test(combinedOwnerLog),
+      `owner peer did not observe queued execution; see ${ownerLogPath}`,
+    );
+    assert(
+      /status=done\b/.test(combinedOwnerLog),
+      `owner peer did not observe done execution; see ${ownerLogPath}`,
+    );
+    assert(
+      /Sent execute_request|Queued execution/.test(runtimePeer.output()),
+      `runtime peer did not log kernel execution; see ${computeLogPath}`,
+    );
+
+    if (keepRuntimePeer) {
+      runtimeKeptAlive = true;
+      detachRuntimePeer(runtimePeer);
+    } else {
+      await stopRuntimePeer(runtimePeer.child);
+    }
+
+    console.log(
+      JSON.stringify(
+        {
+          ok: true,
+          baseUrl,
+          notebookId: room.notebookId,
+          vanityName,
+          viewerUrl: viewerUrl(room.notebookId, vanityName),
+          source,
+          checks: [
+            "preview_api_key_room_created",
+            "runtime_peer_acl_granted",
+            "runtime_peer_current_python_ready",
+            "owner_execute_cell_request_sent",
+            "runtime_state_observed_queued",
+            "runtime_state_observed_done",
+            "kernel_execute_request_logged",
+          ],
+          timings_ms: {
+            ...timingsMs,
+            total: elapsedMs(startedAt),
+          },
+          runtimePeer: {
+            pid: runtimeKeptAlive ? runtimePeer.child.pid : null,
+            keptAlive: runtimeKeptAlive,
+            logPath: computeLogPath,
+          },
+          ownerPeer: {
+            logPath: ownerLogPath,
+          },
+        },
+        null,
+        2,
+      ),
+    );
+  } finally {
+    if (!runtimeKeptAlive && runtimePeer?.child) {
+      await stopRuntimePeer(runtimePeer.child).catch(() => {});
+    }
+    await cleanupTemp();
+  }
+}
+
+async function loadOptionalEnvFile() {
+  const envFile =
+    process.env.PREVIEW_RUNT_ENV ??
+    process.env.NOTEBOOK_CLOUD_ENV_FILE ??
+    path.join(os.homedir(), "preview.runt.run", ".env");
+  try {
+    const raw = await readFile(envFile, "utf8");
+    for (const line of raw.split(/\r?\n/)) {
+      const trimmed = line.trim();
+      if (!trimmed || trimmed.startsWith("#")) continue;
+      const match = trimmed.replace(/^export\s+/, "").match(/^([A-Za-z_][A-Za-z0-9_]*)=(.*)$/);
+      if (!match) continue;
+      const [, key, rawValue] = match;
+      if (process.env[key]) continue;
+      process.env[key] = rawValue.replace(/^["']|["']$/g, "").trim();
+    }
+  } catch (error) {
+    if (error?.code !== "ENOENT") {
+      throw error;
+    }
+  }
+}
+
+function requireApiKey() {
+  if (!apiKey) {
+    throw new Error(
+      "NTERACT_API_KEY or NOTEBOOK_CLOUD_PUBLISH_BEARER_TOKEN is required for hosted runtime-peer smoke",
+    );
+  }
+}
+
+async function assertBinaryExists(binaryPath, name) {
+  try {
+    await access(binaryPath);
+  } catch {
+    throw new Error(
+      `Missing ${name} binary at ${binaryPath}. Run \`cargo xtask artifacts ensure sift,renderer && cargo build --release -p runtimed -p runt-cloud-peer\` first, or set NOTEBOOK_CLOUD_${name.toUpperCase().replaceAll("-", "_")}_BIN.`,
+    );
+  }
+}
+
+async function resolvePythonPath() {
+  const explicit = process.env.NOTEBOOK_CLOUD_RUNTIME_PEER_PYTHON ?? process.env.PYTHON_PATH;
+  if (explicit) {
+    await assertPythonCanLaunchKernel(explicit);
+    return explicit;
+  }
+  const candidates = [
+    path.join(os.homedir(), "k", "bin", "python"),
+    await which("python3"),
+    await which("python"),
+  ].filter(Boolean);
+  for (const candidate of new Set(candidates)) {
+    if (await pythonCanLaunchKernel(candidate)) {
+      return candidate;
+    }
+  }
+  throw new Error(
+    "No Python with ipykernel was found. Set NOTEBOOK_CLOUD_RUNTIME_PEER_PYTHON to a kernel-capable interpreter.",
+  );
+}
+
+function which(command) {
+  return new Promise((resolve) => {
+    const child = spawn("sh", ["-lc", `command -v ${quoteShell(command)}`], {
+      stdio: ["ignore", "pipe", "ignore"],
+    });
+    let stdout = "";
+    child.stdout.setEncoding("utf8");
+    child.stdout.on("data", (chunk) => {
+      stdout += chunk;
+    });
+    child.on("close", (code) => {
+      resolve(code === 0 ? stdout.trim() : null);
+    });
+    child.on("error", () => resolve(null));
+  });
+}
+
+async function assertPythonCanLaunchKernel(pythonPath) {
+  if (await pythonCanLaunchKernel(pythonPath)) return;
+  throw new Error(
+    `${pythonPath} cannot import ipykernel. Set NOTEBOOK_CLOUD_RUNTIME_PEER_PYTHON to a kernel-capable interpreter.`,
+  );
+}
+
+async function pythonCanLaunchKernel(pythonPath) {
+  try {
+    await access(pythonPath);
+  } catch {
+    return false;
+  }
+  return new Promise((resolve) => {
+    const child = spawn(
+      pythonPath,
+      [
+        "-c",
+        "import importlib.util; raise SystemExit(0 if importlib.util.find_spec('ipykernel') else 1)",
+      ],
+      {
+        stdio: ["ignore", "ignore", "ignore"],
+      },
+    );
+    const timeout = setTimeout(() => {
+      child.kill("SIGTERM");
+      resolve(false);
+    }, 5_000);
+    child.on("error", () => {
+      clearTimeout(timeout);
+      resolve(false);
+    });
+    child.on("close", (code) => {
+      clearTimeout(timeout);
+      resolve(code === 0);
+    });
+  });
+}
+
+async function createNotebookRoom() {
+  const response = await fetch(new URL("/api/n", baseUrl), {
+    method: "POST",
+    headers: {
+      ...apiKeyHeaders("owner"),
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify({ vanity_name: vanityName }),
+  });
+  const body = await response.json().catch(async () => ({ error: await response.text() }));
+  assertResponse(response, body, "create notebook room", 201);
+  const notebookId = body.notebook_id;
+  assert(
+    typeof notebookId === "string" && notebookId.length > 0,
+    "room create missing notebook_id",
+  );
+  return { notebookId };
+}
+
+async function grantRuntimePeer(notebookId) {
+  const acl = await fetchJson(`/api/n/${encodeURIComponent(notebookId)}/acl`);
+  const owner = acl.acl?.find(
+    (entry) => entry.scope === "owner" && entry.subject_kind === "principal",
+  );
+  assert(owner?.subject, "room ACL did not include owner principal to grant runtime_peer");
+
+  const response = await fetch(new URL(`/api/n/${encodeURIComponent(notebookId)}/acl`, baseUrl), {
+    method: "POST",
+    headers: {
+      ...apiKeyHeaders("owner"),
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify({
+      subject_kind: "principal",
+      subject: owner.subject,
+      scope: "runtime_peer",
+    }),
+  });
+  const body = await response.json().catch(async () => ({ error: await response.text() }));
+  assertResponse(response, body, "grant runtime_peer", 201);
+}
+
+async function fetchJson(pathname) {
+  const response = await fetch(new URL(pathname, baseUrl), {
+    headers: apiKeyHeaders("owner"),
+  });
+  const body = await response.json().catch(async () => ({ error: await response.text() }));
+  assertResponse(response, body, `GET ${pathname}`, 200);
+  return body;
+}
+
+function apiKeyHeaders(scope) {
+  return {
+    Authorization: `Bearer ${apiKey}`,
+    "X-Notebook-Cloud-Auth-Provider": "anaconda-api-key",
+    "X-Scope": scope,
+  };
+}
+
+function startRuntimePeer({ notebookId, pythonPath }) {
+  return new Promise((resolve, reject) => {
+    const logFd = openSync(computeLogPath, "a");
+    let settled = false;
+    let exitRecord = null;
+    let resolveExited;
+    const exited = new Promise((resolveExit) => {
+      resolveExited = resolveExit;
+    });
+    const recordExit = (exit) => {
+      if (exitRecord) return;
+      exitRecord = exit;
+      resolveExited(exit);
+    };
+    let child;
+    try {
+      child = spawn(
+        runtimedBin,
+        [
+          "cloud-runtime-agent",
+          "--auth-kind",
+          "anaconda-key",
+          "--cloud-url",
+          baseUrl,
+          "--notebook-id",
+          notebookId,
+          "--scope",
+          "runtime_peer",
+          "--python-path",
+          pythonPath,
+          "--blob-root",
+          blobRoot,
+        ],
+        {
+          cwd: workspaceRoot,
+          detached: keepRuntimePeer,
+          env: {
+            ...process.env,
+            RUNT_CLOUD_TOKEN: apiKey,
+            RUST_LOG: process.env.RUST_LOG ?? "info",
+          },
+          stdio: ["ignore", logFd, logFd],
+        },
+      );
+    } catch (error) {
+      closeSync(logFd);
+      reject(error);
+      return;
+    }
+    closeSync(logFd);
+
+    const poll = setInterval(async () => {
+      if (settled) return;
+      const output = await readFile(computeLogPath, "utf8").catch(() => "");
+      if (!output.includes("Infrastructure ready, entering main loop")) return;
+      settled = true;
+      clearInterval(poll);
+      clearTimeout(timeout);
+      resolve({
+        child,
+        exited,
+        exitRecord: () => exitRecord,
+        output: () => readFileSync(computeLogPath, "utf8"),
+      });
+    }, 250);
+
+    const timeout = setTimeout(() => {
+      if (settled) return;
+      settled = true;
+      clearInterval(poll);
+      child.kill("SIGTERM");
+      reject(
+        new Error(
+          `runtime peer did not become ready within ${readyTimeoutMs}ms; see ${computeLogPath}`,
+        ),
+      );
+    }, readyTimeoutMs);
+    child.on("error", (error) => {
+      recordExit({ error });
+      if (settled) return;
+      settled = true;
+      clearInterval(poll);
+      clearTimeout(timeout);
+      reject(error);
+    });
+    child.on("exit", (code, signal) => {
+      recordExit({ code, signal });
+      if (settled) return;
+      settled = true;
+      clearInterval(poll);
+      clearTimeout(timeout);
+      reject(
+        new Error(
+          `runtime peer exited before ready (code=${code}, signal=${signal}); see ${computeLogPath}`,
+        ),
+      );
+    });
+  });
+}
+
+function detachRuntimePeer(peer) {
+  peer.child.unref();
+}
+
+async function runOwnerPeerWithRuntimeGuard({ notebookId }) {
+  const existingExit = runtimePeer.exitRecord();
+  if (existingExit) {
+    throw new Error(runtimePeerExitMessage(existingExit));
+  }
+  const ownerResult = runOwnerPeer({ notebookId })
+    .then((owner) => ({ type: "owner", owner }))
+    .catch((error) => ({ type: "owner_error", error }));
+  const runtimeExit = runtimePeer.exited.then((exit) => ({ type: "runtime_exit", exit }));
+  const result = await Promise.race([ownerResult, runtimeExit]);
+  if (result.type === "runtime_exit") {
+    throw new Error(runtimePeerExitMessage(result.exit));
+  }
+  if (result.type === "owner_error") {
+    throw result.error;
+  }
+  const exit = runtimePeer.exitRecord();
+  if (exit) {
+    throw new Error(runtimePeerExitMessage(exit));
+  }
+  return result.owner;
+}
+
+function runtimePeerExitMessage(exit) {
+  if (exit.error) {
+    return `runtime peer exited during owner execution: ${exit.error.message}; see ${computeLogPath}`;
+  }
+  return `runtime peer exited during owner execution (code=${exit.code}, signal=${exit.signal}); see ${computeLogPath}`;
+}
+
+async function runOwnerPeer({ notebookId }) {
+  return runCommand(
+    cloudPeerBin,
+    [
+      "--auth-mode",
+      "anaconda-api-key",
+      "--token-file",
+      tokenFile,
+      "--cloud-url",
+      baseUrl,
+      "--notebook-id",
+      notebookId,
+      "--scope",
+      "owner",
+      "--add-cell",
+      source,
+      "--run-cell",
+      "--seconds",
+      String(seconds),
+    ],
+    {
+      cwd: workspaceRoot,
+      logPath: ownerLogPath,
+      completeWhen: /status=done\b/,
+      timeoutMs: seconds * 1000 + 20_000,
+      env: {
+        ...process.env,
+        RUST_LOG: process.env.RUST_LOG ?? "info",
+      },
+    },
+  );
+}
+
+function runCommand(command, args, { completeWhen, cwd, env, logPath, timeoutMs }) {
+  return new Promise((resolve, reject) => {
+    const log = createWriteStream(logPath, { flags: "a" });
+    const child = spawn(command, args, {
+      cwd,
+      env,
+      stdio: ["ignore", "pipe", "pipe"],
+    });
+    let stdout = "";
+    let stderr = "";
+    let completedEarly = false;
+    let settled = false;
+    let timeout;
+    const finish = (callback) => {
+      if (settled) return;
+      settled = true;
+      clearTimeout(timeout);
+      log.end();
+      callback();
+    };
+    const maybeCompleteEarly = () => {
+      if (!completeWhen || completedEarly) return;
+      if (!completeWhen.test(`${stdout}\n${stderr}`)) return;
+      completedEarly = true;
+      child.kill("SIGTERM");
+    };
+    timeout = setTimeout(() => {
+      child.kill("SIGTERM");
+      finish(() =>
+        reject(
+          new Error(`${path.basename(command)} timed out after ${timeoutMs}ms; see ${logPath}`),
+        ),
+      );
+    }, timeoutMs);
+    child.stdout.setEncoding("utf8");
+    child.stderr.setEncoding("utf8");
+    child.stdout.on("data", (chunk) => {
+      if (settled) return;
+      stdout += chunk;
+      log.write(chunk);
+      maybeCompleteEarly();
+    });
+    child.stderr.on("data", (chunk) => {
+      if (settled) return;
+      stderr += chunk;
+      log.write(chunk);
+      maybeCompleteEarly();
+    });
+    child.on("error", (error) => {
+      finish(() => reject(error));
+    });
+    child.on("close", (code) => {
+      finish(() => {
+        if (code === 0 || completedEarly) {
+          resolve({ stdout, stderr });
+          return;
+        }
+        reject(new Error(`${path.basename(command)} exited with ${code}; see ${logPath}`));
+      });
+    });
+  });
+}
+
+async function stopRuntimePeer(child) {
+  if (child.exitCode !== null || child.signalCode !== null) {
+    return;
+  }
+  child.kill("SIGTERM");
+  await new Promise((resolve) => {
+    const timer = setTimeout(() => {
+      child.kill("SIGKILL");
+      resolve();
+    }, 5_000);
+    child.once("exit", () => {
+      clearTimeout(timer);
+      resolve();
+    });
+  });
+}
+
+async function cleanupTemp() {
+  if (tempDir) {
+    await rm(tempDir, { recursive: true, force: true });
+  }
+}
+
+async function timed(name, fn) {
+  const started = performance.now();
+  try {
+    return await fn();
+  } finally {
+    timingsMs[name] = elapsedMs(started);
+  }
+}
+
+function assertResponse(response, body, label, expectedStatus) {
+  assert(
+    response.status === expectedStatus,
+    `${label} failed: HTTP ${response.status} ${JSON.stringify(body).slice(0, 500)}`,
+  );
+}
+
+function viewerUrl(notebookId, name) {
+  return new URL(`/n/${encodeURIComponent(notebookId)}/${encodeURIComponent(name)}`, baseUrl).href;
+}
+
+function parsePositiveInteger(value, name, fallback) {
+  if (value == null || value === "") return fallback;
+  const parsed = Number(value);
+  if (!Number.isInteger(parsed) || parsed <= 0) {
+    throw new Error(`${name} must be a positive integer`);
+  }
+  return parsed;
+}
+
+function elapsedMs(started) {
+  return Math.max(0, Math.round((performance.now() - started) * 100) / 100);
+}
+
+function quoteShell(value) {
+  return `'${value.replaceAll("'", "'\\''")}'`;
+}
+
+function assert(condition, message) {
+  if (!condition) {
+    throw new Error(message);
+  }
+}


### PR DESCRIPTION
## Summary
- adds `smoke:hosted:runtime-peer`, an API-key backed preview smoke that creates a private room, grants `runtime_peer`, launches `runtimed cloud-runtime-agent`, runs `runt-cloud-peer` as owner, and asserts `queued -> done` plus kernel execution logs
- keeps API keys out of argv for the owner peer via `--token-file`, validates the chosen Python can import `ipykernel`, exits as soon as terminal state is observed, and writes smoke logs under `.context/smokes/`
- supports detached keep-alive runtime peers for manual browser inspection, and replaces the long manual shell runbook with the package script

## Stack / merge note
- this smoke is intended to become the repeatable acceptance check for the runtime-peer execution stack in #3454
- current `origin/main` binaries do not include #3454, so they can launch a kernel and observe `queued/running` but not the final `done`; the live verification below points the script at #3454-built binaries

## Verification
- `cargo xtask artifacts ensure sift,renderer`
- `node --check apps/notebook-cloud/scripts/hosted-runtime-peer-smoke.mjs`
- `pnpm --filter notebook-cloud typecheck`
- `cargo build --release -p runtimed -p runt-cloud-peer`
- `cargo xtask lint --fix`
- live preview smoke using #3454 binaries:
  `NTERACT_CLOUD_URL=https://preview.runt.run NOTEBOOK_CLOUD_RUNTIMED_BIN=/home/ubuntu/codex/nteract-3454-smoke/target/release/runtimed NOTEBOOK_CLOUD_RUNT_CLOUD_PEER_BIN=/home/ubuntu/codex/nteract-3454-smoke/target/release/runt-cloud-peer pnpm --dir apps/notebook-cloud smoke:hosted:runtime-peer`
  passed with room `01KTFDJHYJRKFVAREG48NTBPNG`, viewer https://preview.runt.run/n/01KTFDJHYJRKFVAREG48NTBPNG/lab2-dualpeer, total 10.3s, owner execution 1.5s
- live keep-alive diagram smoke passed with detached runtime peer PID 202426, room `01KTFDPPPY5PNFGSVQ1CXMWN2X`, viewer https://preview.runt.run/n/01KTFDPPPY5PNFGSVQ1CXMWN2X/lab2-runtime-map-2
