### PR TITLE
build(artifacts): align runtime artifact recovery path

### DIFF
--- a/.github/actions/build-runtime-artifacts/action.yml
+++ b/.github/actions/build-runtime-artifacts/action.yml
@@ -4,10 +4,10 @@ description: >-
   embeds via include_bytes!. These outputs are gitignored; CI rebuilds
   them on every workflow run.
 
-  Idempotent: pnpm install --frozen-lockfile / wasm-pack install / cargo xtask wasm tolerate
-  a re-run. Caller is responsible for setting up Rust toolchain + rust-cache
-  before invoking; this action only adds Node, pnpm, wasm-pack, and runs the
-  build.
+  Idempotent: pnpm install --frozen-lockfile / wasm-pack install /
+  cargo xtask artifacts ensure runtime,sift,renderer tolerate a re-run. Caller
+  is responsible for setting up Rust toolchain + rust-cache before invoking;
+  this action only adds Node, pnpm, wasm-pack, and runs the build.
 
   Pass skip-wasm: true when pre-built WASM artifacts have already been
   downloaded from an earlier job (the build-wasm pattern). The downloaded
@@ -102,7 +102,7 @@ runs:
         fi
         echo "C:\\Program Files\\LLVM\\bin" >> "$GITHUB_PATH"
 
-    - name: Build wasm + renderer plugins
+    - name: Build runtime, sift, and renderer artifacts
       if: inputs.skip-wasm != 'true'
       shell: bash
-      run: cargo xtask wasm
+      run: cargo xtask artifacts ensure runtime,sift,renderer

--- a/crates/runtimed/build.rs
+++ b/crates/runtimed/build.rs
@@ -3,7 +3,8 @@ use std::path::{Path, PathBuf};
 fn main() {
     // Renderer plugin bundles live under `apps/notebook/src/renderer-plugins/`.
     // Stable bundles (plotly, vega, leaflet, markdown) are LFS-tracked;
-    // sift.{js,css} is gitignored and rebuilt via `cargo xtask wasm`.
+    // sift.{js,css} is gitignored and rebuilt via
+    // `cargo xtask artifacts ensure sift,renderer`.
     // sift_wasm.wasm is embedded directly from `crates/sift-wasm/pkg/`.
     // Probe each path before `include_bytes!` so a missing file points at
     // the right recovery command instead of a generic "file not found".
@@ -28,7 +29,8 @@ fn main() {
                  are LFS-tracked - run `git lfs pull` if your checkout has pointer \
                  files only.\n\
                  Volatile bundles (sift.js, sift.css) are gitignored - run \
-                 `cargo xtask wasm` from the workspace root to rebuild.",
+                 `cargo xtask artifacts ensure sift,renderer` from the \
+                 workspace root to rebuild.",
                 path.display(),
             );
         }
@@ -39,7 +41,8 @@ fn main() {
     if !sift_wasm.exists() {
         panic!(
             "Missing sift WASM binary: {}\n\n\
-             Run `cargo xtask wasm` from the workspace root to rebuild it.",
+             Run `cargo xtask artifacts ensure sift,renderer` from the \
+             workspace root to rebuild it.",
             sift_wasm.display(),
         );
     }

--- a/crates/xtask/src/main.rs
+++ b/crates/xtask/src/main.rs
@@ -3272,9 +3272,9 @@ fn run_wasm_pack(needs_c_toolchain: bool, cmd: &str, args: &[&str]) {
 /// Called from the top of every entry point that compiles `runtimed`,
 /// `notebook`, or runs the dev daemon, so a fresh clone can go straight to
 /// `cargo xtask build` / `dev` / `dev-daemon` / `notebook` without an
-/// explicit `cargo xtask wasm` step. `runtimed`'s `build.rs` panics with a
-/// "run `cargo xtask wasm`" message if you bypass xtask and invoke `cargo
-/// build` directly.
+/// explicit `cargo xtask artifacts ensure ...` step. `runtimed`'s `build.rs`
+/// panics with a scoped `cargo xtask artifacts ensure ...` recovery command if
+/// you bypass xtask and invoke `cargo build` directly.
 /// Make sure build artifacts on disk match the current source tree.
 ///
 /// Two tiers, matching each artifact's churn profile:

--- a/docs/adr/generated-runtime-artifacts.md
+++ b/docs/adr/generated-runtime-artifacts.md
@@ -78,8 +78,8 @@ Volatile artifacts stay gitignored and are regenerated:
 
 The Sift renderer bundle embeds wasm-bindgen glue from `sift-wasm`. Rebuilding
 `sift-wasm` without rebuilding `sift.js` can leave the plugin importing
-nonexistent `__wbg_*` names. `cargo xtask wasm sift` and
-`cargo xtask artifacts ensure sift,renderer` preserve that pairing.
+nonexistent `__wbg_*` names. `cargo xtask artifacts ensure sift,renderer`
+preserves that pairing.
 
 ## Decision 4: Fingerprints and semantic checks define freshness
 


### PR DESCRIPTION
## Summary
- stack on #3456: make the generated-artifact ADR policy executable in the shared CI action
- switch the runtime artifact action from the legacy `cargo xtask wasm` wrapper to `cargo xtask artifacts ensure runtime,sift,renderer`
- update `runtimed` build-script diagnostics to point direct Cargo builds at the scoped artifact recovery command

## Verification
- `cargo xtask artifacts status runtime,sift,renderer`
- `cargo test -p xtask parse_artifact_command -- --nocapture`
- `cargo xtask lint --fix`

## Notes
This is intentionally opened against `main` because GitHub PR bases must live in the upstream repo. The branch is logically stacked on #3456; after #3456 lands, rebase this PR so the visible diff is only commit `1fcc21c9`.