### PR TITLE
feat(notebook): show workstations in the document rail

### DIFF
--- a/apps/elements/components/cloud-notebook-shell-example.tsx
+++ b/apps/elements/components/cloud-notebook-shell-example.tsx
@@ -34,6 +34,7 @@ import {
   NotebookIdentityBadge,
   NotebookPackageSummaryPanel,
   NotebookPresenceStatus,
+  NotebookWorkstationsPanel,
   notebookActorIdentityFromAccess,
   type NotebookCommandRuntimeState,
   type NotebookCommandToolbarStatus,
@@ -256,7 +257,11 @@ const workstationFlowRows = [
 
 export function CloudNotebookShellExample() {
   return (
-    <ElementsNotebookEnvironment scenarioId="cloud-workstation-ready" initialRailCollapsed>
+    <ElementsNotebookEnvironment
+      scenarioId="cloud-workstation-ready"
+      initialActivePanelId="workstations"
+      initialRailCollapsed={false}
+    >
       <CloudNotebookShellExampleContent />
     </ElementsNotebookEnvironment>
   );
@@ -275,6 +280,14 @@ function CloudNotebookShellExampleContent() {
       viewModel={scenario.viewModel}
       activePanelId={railState.activePanelId}
       collapsed={railState.collapsed}
+      workstationsSummary={
+        shellCapabilities.runtime.executionAvailable
+          ? "Ready"
+          : shellCapabilities.runtime.connected
+            ? "Attached"
+            : "Offline"
+      }
+      workstationsPanel={<NotebookWorkstationsPanel capabilities={shellCapabilities} />}
       packagesPanel={
         <NotebookPackageSummaryPanel
           packages={scenario.viewModel.packages}

--- a/apps/notebook-cloud/viewer/index.tsx
+++ b/apps/notebook-cloud/viewer/index.tsx
@@ -30,6 +30,7 @@ import {
   NotebookDocumentRail,
   NotebookDocumentShell,
   NotebookPackageSummaryPanel,
+  NotebookWorkstationsPanel,
   shouldShowNotebookDocumentCommandToolbar,
   type NotebookEnvironmentManager,
   type NotebookInteractionMode,
@@ -1069,6 +1070,14 @@ function NotebookViewer({
       collapsed={railCollapsed}
       selectedOutlineItemId={selectedOutlineItemId}
       packagesSummary={null}
+      workstationsSummary={
+        shellCapabilities.runtime.executionAvailable
+          ? "Ready"
+          : shellCapabilities.runtime.connected
+            ? "Attached"
+            : "Offline"
+      }
+      workstationsPanel={<NotebookWorkstationsPanel capabilities={shellCapabilities} />}
       packagesPanel={
         <NotebookPackageSummaryPanel
           packages={notebookViewModel.packages}

--- a/apps/notebook/src/App.tsx
+++ b/apps/notebook/src/App.tsx
@@ -38,6 +38,7 @@ import {
   KernelLaunchErrorBanner,
   NotebookDocumentRail,
   NotebookDocumentShell,
+  NotebookWorkstationsPanel,
   PoolErrorBanner,
   shouldShowKernelLaunchErrorBanner,
   TrustDialog,
@@ -1479,10 +1480,18 @@ function AppContent() {
               selectedOutlineItemId={selectedOutlineItemId}
               selectedOutlineCellId={focusedCellId}
               packagesSummary={railPackageSummary}
+              workstationsSummary={
+                shellCapabilities.runtime.executionAvailable
+                  ? "Ready"
+                  : shellCapabilities.runtime.connected
+                    ? "Attached"
+                    : "Offline"
+              }
               onActivePanelChange={handleRailPanelChange}
               onCollapsedChange={setRailCollapsed}
               onSelectOutlineItem={handleSelectOutlineItem}
               onNavigateOutlineItem={handleNavigateOutlineItem}
+              workstationsPanel={<NotebookWorkstationsPanel capabilities={shellCapabilities} />}
               packagesPanel={
                 <NotebookPackagesPanel readOnly={!shellCapabilities.canManagePackages}>
                   {runtime === "python" && hasUvDependencies && hasCondaDependencies && (

--- a/src/components/notebook-rail/NotebookRail.tsx
+++ b/src/components/notebook-rail/NotebookRail.tsx
@@ -1,4 +1,4 @@
-import { ListTree, Package } from "lucide-react";
+import { Cpu, ListTree, Package } from "lucide-react";
 import { useMemo, type DragEvent, type MouseEvent, type ReactNode } from "react";
 import {
   buildNotebookOutlineTree,
@@ -15,13 +15,14 @@ import {
 } from "@/components/rail";
 import { cn } from "@/lib/utils";
 
-export type NotebookRailPanelId = "outline" | "packages";
+export type NotebookRailPanelId = "outline" | "packages" | "workstations";
 
 export const NOTEBOOK_RAIL_TAKEOVER_MEDIA_QUERY = RAIL_TAKEOVER_MEDIA_QUERY;
 export const NOTEBOOK_RAIL_TAKEOVER_STAGE_CLASS_NAME = RAIL_TAKEOVER_STAGE_CLASS_NAME;
 export const NOTEBOOK_RAIL_TAKEOVER_PANEL_CLASS_NAMES = RAIL_TAKEOVER_PANEL_CLASS_NAMES;
 const NOTEBOOK_RAIL_OUTLINE_PANEL_CLASS_NAME = "w-[clamp(15rem,20vw,18rem)] min-w-60";
 const NOTEBOOK_RAIL_PACKAGES_PANEL_CLASS_NAME = "w-[clamp(15rem,20vw,17rem)] min-w-60";
+const NOTEBOOK_RAIL_WORKSTATIONS_PANEL_CLASS_NAME = "w-[clamp(16rem,22vw,19rem)] min-w-64";
 
 export interface NotebookRailProps {
   activePanelId: NotebookRailPanelId;
@@ -33,6 +34,8 @@ export interface NotebookRailProps {
   selectedOutlineCellId?: string | null;
   packagesSummary?: string | null;
   packagesPanel: ReactNode;
+  workstationsSummary?: string | null;
+  workstationsPanel?: ReactNode;
   onActivePanelChange: (panelId: NotebookRailPanelId) => void;
   onCollapsedChange: (collapsed: boolean) => void;
   onSelectOutlineItem?: (item: NotebookOutlineItem) => void;
@@ -41,7 +44,7 @@ export interface NotebookRailProps {
   className?: string;
 }
 
-const railButtons: Array<RailItem<NotebookRailPanelId>> = [
+const baseRailButtons: Array<RailItem<NotebookRailPanelId>> = [
   { id: "outline", label: "Outline", icon: ListTree },
   { id: "packages", label: "Packages", icon: Package },
 ];
@@ -56,6 +59,8 @@ export function NotebookRail({
   selectedOutlineCellId = null,
   packagesSummary = null,
   packagesPanel,
+  workstationsSummary = null,
+  workstationsPanel,
   onActivePanelChange,
   onCollapsedChange,
   onSelectOutlineItem,
@@ -63,12 +68,27 @@ export function NotebookRail({
   getOutlineItemHref,
   className,
 }: NotebookRailProps) {
-  const title = activePanelId === "outline" ? "Outline" : "Packages";
-  const summary = activePanelId === "packages" ? packagesSummary : null;
+  const railButtons = workstationsPanel
+    ? [...baseRailButtons, { id: "workstations" as const, label: "Workstations", icon: Cpu }]
+    : baseRailButtons;
+  const title =
+    activePanelId === "packages"
+      ? "Packages"
+      : activePanelId === "workstations"
+        ? "Workstations"
+        : "Outline";
+  const summary =
+    activePanelId === "packages"
+      ? packagesSummary
+      : activePanelId === "workstations"
+        ? workstationsSummary
+        : null;
   const panelClassName =
     activePanelId === "packages"
       ? NOTEBOOK_RAIL_PACKAGES_PANEL_CLASS_NAME
-      : NOTEBOOK_RAIL_OUTLINE_PANEL_CLASS_NAME;
+      : activePanelId === "workstations"
+        ? NOTEBOOK_RAIL_WORKSTATIONS_PANEL_CLASS_NAME
+        : NOTEBOOK_RAIL_OUTLINE_PANEL_CLASS_NAME;
 
   return (
     <Rail
@@ -98,8 +118,10 @@ export function NotebookRail({
           onNavigateItem={onNavigateOutlineItem}
           getItemHref={getOutlineItemHref}
         />
-      ) : (
+      ) : activePanelId === "packages" ? (
         packagesPanel
+      ) : (
+        workstationsPanel
       )}
     </Rail>
   );

--- a/src/components/notebook-rail/__tests__/NotebookRail.test.tsx
+++ b/src/components/notebook-rail/__tests__/NotebookRail.test.tsx
@@ -94,6 +94,66 @@ describe("NotebookRail", () => {
     expect(onCollapsedChange).toHaveBeenCalledWith(false);
   });
 
+  it("does not show the workstations rail item until the host supplies a panel", () => {
+    render(
+      <NotebookRail
+        activePanelId="outline"
+        collapsed={false}
+        outlineItems={outlineItems}
+        packagesPanel={<NotebookPackagesPanel>Packages</NotebookPackagesPanel>}
+        onActivePanelChange={vi.fn()}
+        onCollapsedChange={vi.fn()}
+      />,
+    );
+
+    expect(screen.queryByRole("button", { name: "Workstations" })).not.toBeInTheDocument();
+  });
+
+  it("switches to the host-provided workstations panel", () => {
+    const onActivePanelChange = vi.fn();
+    const onCollapsedChange = vi.fn();
+
+    render(
+      <NotebookRail
+        activePanelId="outline"
+        collapsed={false}
+        outlineItems={outlineItems}
+        packagesPanel={<NotebookPackagesPanel>Packages</NotebookPackagesPanel>}
+        workstationsSummary="Ready"
+        workstationsPanel={<div data-testid="host-workstations-content">runtime target</div>}
+        onActivePanelChange={onActivePanelChange}
+        onCollapsedChange={onCollapsedChange}
+      />,
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "Workstations" }));
+    expect(onActivePanelChange).toHaveBeenCalledWith("workstations");
+    expect(onCollapsedChange).toHaveBeenCalledWith(false);
+  });
+
+  it("renders the active workstations panel summary and host content", () => {
+    const { container } = render(
+      <NotebookRail
+        activePanelId="workstations"
+        collapsed={false}
+        outlineItems={outlineItems}
+        packagesPanel={<NotebookPackagesPanel>Packages</NotebookPackagesPanel>}
+        workstationsSummary="Attached"
+        workstationsPanel={<div data-testid="host-workstations-content">runtime target</div>}
+        onActivePanelChange={vi.fn()}
+        onCollapsedChange={vi.fn()}
+      />,
+    );
+
+    expect(screen.getByRole("heading", { name: "Workstations" })).toBeVisible();
+    expect(screen.getByText("Attached")).toBeVisible();
+    expect(screen.getByTestId("host-workstations-content")).toHaveTextContent("runtime target");
+    expect(container.querySelector('[data-slot="notebook-rail-panel"]')).toHaveClass(
+      "w-[clamp(16rem,22vw,19rem)]",
+      "min-w-64",
+    );
+  });
+
   it("keeps the active panel title primary when package metadata is present", () => {
     render(
       <NotebookRail

--- a/src/components/notebook/NotebookDocumentRail.tsx
+++ b/src/components/notebook/NotebookDocumentRail.tsx
@@ -13,6 +13,8 @@ export interface NotebookDocumentRailProps {
   selectedOutlineCellId?: string | null;
   packagesSummary?: string | null;
   packagesPanel: ReactNode;
+  workstationsSummary?: string | null;
+  workstationsPanel?: ReactNode;
   onActivePanelChange: (panelId: NotebookRailPanelId) => void;
   onCollapsedChange: (collapsed: boolean) => void;
   onSelectOutlineItem?: (item: NotebookOutlineItem) => void;
@@ -30,6 +32,8 @@ export function NotebookDocumentRail({
   selectedOutlineCellId = null,
   packagesSummary,
   packagesPanel,
+  workstationsSummary,
+  workstationsPanel,
   onActivePanelChange,
   onCollapsedChange,
   onSelectOutlineItem,
@@ -47,6 +51,8 @@ export function NotebookDocumentRail({
       selectedOutlineCellId={selectedOutlineCellId}
       packagesSummary={packagesSummary === undefined ? viewModel.packages.summary : packagesSummary}
       packagesPanel={packagesPanel}
+      workstationsSummary={workstationsSummary}
+      workstationsPanel={workstationsPanel}
       onActivePanelChange={onActivePanelChange}
       onCollapsedChange={onCollapsedChange}
       onSelectOutlineItem={onSelectOutlineItem}

--- a/src/components/notebook/NotebookWorkstationsPanel.tsx
+++ b/src/components/notebook/NotebookWorkstationsPanel.tsx
@@ -1,0 +1,178 @@
+import { CircleAlert, CircleCheck, Cloud, Cpu, Monitor, UserRound } from "lucide-react";
+import type { LucideIcon } from "lucide-react";
+import type { NotebookShellCapabilities } from "./capabilities";
+import { cn } from "@/lib/utils";
+
+export interface NotebookWorkstationsPanelProps {
+  capabilities: NotebookShellCapabilities;
+  className?: string;
+}
+
+export function NotebookWorkstationsPanel({
+  capabilities,
+  className,
+}: NotebookWorkstationsPanelProps) {
+  const status = workstationStatus(capabilities);
+  const source = workstationSource(capabilities.runtime.source);
+  const principalLabel =
+    capabilities.runtime.actor?.principal.label ??
+    capabilities.access.actor?.principal.label ??
+    capabilities.runtime.identityLabel ??
+    capabilities.access.identityLabel ??
+    source.defaultPrincipalLabel;
+  const operatorLabel =
+    capabilities.runtime.actor?.operator.label ??
+    (capabilities.runtime.connected ? "Runtime" : "Not attached");
+
+  return (
+    <div className={cn("space-y-3", className)} data-testid="notebook-workstations-panel">
+      <section className="rounded-md border bg-muted/20 p-3">
+        <div className="flex min-w-0 items-start gap-3">
+          <span
+            className={cn(
+              "flex size-8 shrink-0 items-center justify-center rounded-md border",
+              status.iconClassName,
+            )}
+          >
+            <status.icon className="size-4" aria-hidden="true" />
+          </span>
+          <div className="min-w-0 flex-1">
+            <div className="flex min-w-0 items-center justify-between gap-2">
+              <h3 className="truncate text-sm font-semibold">{status.title}</h3>
+              <span
+                className={cn(
+                  "shrink-0 rounded px-1.5 py-0.5 text-[10px] font-medium",
+                  status.badgeClassName,
+                )}
+              >
+                {status.badge}
+              </span>
+            </div>
+            <p className="mt-1 text-xs leading-5 text-muted-foreground">{status.detail}</p>
+          </div>
+        </div>
+      </section>
+
+      <section className="space-y-2" aria-label="Runtime attachment details">
+        <WorkstationDetail icon={source.icon} label="Source" value={source.label} />
+        <WorkstationDetail icon={UserRound} label="Principal" value={principalLabel} />
+        <WorkstationDetail icon={Cpu} label="Operator" value={operatorLabel} />
+        <WorkstationDetail
+          icon={capabilities.runtime.canWriteRuntimeState ? CircleCheck : CircleAlert}
+          label="Runtime state"
+          value={capabilities.runtime.canWriteRuntimeState ? "Writable" : "Read-only"}
+        />
+      </section>
+    </div>
+  );
+}
+
+function WorkstationDetail({
+  icon: Icon,
+  label,
+  value,
+}: {
+  icon: LucideIcon;
+  label: string;
+  value: string;
+}) {
+  return (
+    <div className="flex min-w-0 items-center gap-2 rounded-md border px-2.5 py-2 text-xs">
+      <Icon className="size-3.5 shrink-0 text-muted-foreground" aria-hidden="true" />
+      <span className="shrink-0 text-muted-foreground">{label}</span>
+      <span className="min-w-0 flex-1 truncate text-right font-medium text-foreground">
+        {value}
+      </span>
+    </div>
+  );
+}
+
+function workstationStatus(capabilities: NotebookShellCapabilities): {
+  title: string;
+  detail: string;
+  badge: string;
+  icon: LucideIcon;
+  iconClassName: string;
+  badgeClassName: string;
+} {
+  if (capabilities.runtime.executionAvailable && capabilities.canExecute) {
+    return {
+      title: workstationSource(capabilities.runtime.source).readyTitle,
+      detail: "Execution requests are enabled for this notebook.",
+      badge: "Ready",
+      icon: CircleCheck,
+      iconClassName: "border-emerald-500/30 bg-emerald-500/10 text-emerald-700",
+      badgeClassName: "bg-emerald-500/10 text-emerald-700",
+    };
+  }
+  if (capabilities.runtime.executionAvailable) {
+    return {
+      title: "Runtime available",
+      detail: "A runtime is available, but this connection cannot request execution.",
+      badge: "Limited",
+      icon: Cpu,
+      iconClassName: "border-sky-500/30 bg-sky-500/10 text-sky-700",
+      badgeClassName: "bg-sky-500/10 text-sky-700",
+    };
+  }
+  if (capabilities.runtime.connected) {
+    return {
+      title: "Runtime peer attached",
+      detail: "Runtime state is connected without executable cell controls.",
+      badge: "Attached",
+      icon: Cpu,
+      iconClassName: "border-sky-500/30 bg-sky-500/10 text-sky-700",
+      badgeClassName: "bg-sky-500/10 text-sky-700",
+    };
+  }
+
+  return {
+    title: capabilities.runtime.source === "local" ? "Local runtime unavailable" : "No workstation",
+    detail:
+      capabilities.runtime.source === "local"
+        ? "The local daemon is not exposing an executable runtime."
+        : "No runtime peer is attached to this room.",
+    badge: "Offline",
+    icon: CircleAlert,
+    iconClassName: "border-muted bg-background text-muted-foreground",
+    badgeClassName: "bg-muted text-muted-foreground",
+  };
+}
+
+function workstationSource(source: NotebookShellCapabilities["runtime"]["source"]): {
+  label: string;
+  readyTitle: string;
+  defaultPrincipalLabel: string;
+  icon: LucideIcon;
+} {
+  switch (source) {
+    case "local":
+      return {
+        label: "Local",
+        readyTitle: "Local runtime ready",
+        defaultPrincipalLabel: "Local principal",
+        icon: Monitor,
+      };
+    case "cloud":
+      return {
+        label: "Cloud",
+        readyTitle: "Room workstation ready",
+        defaultPrincipalLabel: "Room principal",
+        icon: Cloud,
+      };
+    case "fixture":
+      return {
+        label: "Fixture",
+        readyTitle: "Fixture runtime ready",
+        defaultPrincipalLabel: "Fixture principal",
+        icon: Cpu,
+      };
+    default:
+      return {
+        label: "Unknown",
+        readyTitle: "Runtime ready",
+        defaultPrincipalLabel: "Unknown principal",
+        icon: Cpu,
+      };
+  }
+}

--- a/src/components/notebook/__tests__/NotebookDocumentRail.test.tsx
+++ b/src/components/notebook/__tests__/NotebookDocumentRail.test.tsx
@@ -77,4 +77,23 @@ describe("NotebookDocumentRail", () => {
 
     expect(screen.getByRole("link", { name: "Intro" })).toHaveAttribute("aria-current", "location");
   });
+
+  it("forwards the host workstation panel", () => {
+    render(
+      <NotebookDocumentRail
+        viewModel={viewModel}
+        activePanelId="workstations"
+        collapsed={false}
+        packagesPanel={<p>Package details</p>}
+        workstationsSummary="Ready"
+        workstationsPanel={<p>Runtime target</p>}
+        onActivePanelChange={() => {}}
+        onCollapsedChange={() => {}}
+      />,
+    );
+
+    expect(screen.getByRole("heading", { name: "Workstations" })).toBeVisible();
+    expect(screen.getByText("Ready")).toBeVisible();
+    expect(screen.getByText("Runtime target")).toBeVisible();
+  });
 });

--- a/src/components/notebook/__tests__/NotebookWorkstationsPanel.test.tsx
+++ b/src/components/notebook/__tests__/NotebookWorkstationsPanel.test.tsx
@@ -1,0 +1,86 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vite-plus/test";
+import type { NotebookShellCapabilities } from "../capabilities";
+import { readOnlyNotebookShellCapabilities } from "../capabilities";
+import { NotebookWorkstationsPanel } from "../NotebookWorkstationsPanel";
+
+const localReadyCapabilities: NotebookShellCapabilities = {
+  ...readOnlyNotebookShellCapabilities,
+  canExecute: true,
+  access: {
+    ...readOnlyNotebookShellCapabilities.access,
+    level: "owner",
+    source: "local",
+    actorLabel: "local:kyle/desktop:main",
+    identityLabel: "Kyle",
+    actor: {
+      actorLabel: "local:kyle/desktop:main",
+      principal: {
+        id: "local:kyle",
+        label: "Kyle",
+        source: { provider: "local", namespace: "local" },
+      },
+      operator: { id: "desktop:main", kind: "desktop", label: "Desktop" },
+      scope: "owner",
+      status: "active",
+    },
+  },
+  runtime: {
+    canWriteRuntimeState: true,
+    connected: true,
+    executionAvailable: true,
+    source: "local",
+    actorLabel: "local:kyle/runtime:python",
+    identityLabel: "Kyle",
+    actor: {
+      actorLabel: "local:kyle/runtime:python",
+      principal: {
+        id: "local:kyle",
+        label: "Kyle",
+        source: { provider: "local", namespace: "local" },
+      },
+      operator: { id: "runtime:python", kind: "runtime", label: "Python runtime" },
+      scope: "runtime_peer",
+      status: "active",
+    },
+  },
+};
+
+describe("NotebookWorkstationsPanel", () => {
+  it("renders a local executable runtime with runtime attribution", () => {
+    render(<NotebookWorkstationsPanel capabilities={localReadyCapabilities} />);
+
+    expect(screen.getByRole("heading", { name: "Local runtime ready" })).toBeVisible();
+    expect(screen.getByText("Ready")).toBeVisible();
+    expect(screen.getByText("Execution requests are enabled for this notebook.")).toBeVisible();
+    expect(screen.getByText("Local")).toBeVisible();
+    expect(screen.getByText("Kyle")).toBeVisible();
+    expect(screen.getByText("Python runtime")).toBeVisible();
+    expect(screen.getByText("Writable")).toBeVisible();
+  });
+
+  it("renders cloud rooms without runtime peers as offline workstations", () => {
+    const capabilities: NotebookShellCapabilities = {
+      ...readOnlyNotebookShellCapabilities,
+      access: {
+        ...readOnlyNotebookShellCapabilities.access,
+        source: "cloud",
+        identityLabel: "Kyle",
+      },
+      runtime: {
+        ...readOnlyNotebookShellCapabilities.runtime,
+        source: "cloud",
+      },
+    };
+
+    render(<NotebookWorkstationsPanel capabilities={capabilities} />);
+
+    expect(screen.getByRole("heading", { name: "No workstation" })).toBeVisible();
+    expect(screen.getByText("Offline")).toBeVisible();
+    expect(screen.getByText("No runtime peer is attached to this room.")).toBeVisible();
+    expect(screen.getByText("Cloud")).toBeVisible();
+    expect(screen.getByText("Kyle")).toBeVisible();
+    expect(screen.getByText("Not attached")).toBeVisible();
+    expect(screen.getByText("Read-only")).toBeVisible();
+  });
+});

--- a/src/components/notebook/index.ts
+++ b/src/components/notebook/index.ts
@@ -138,6 +138,10 @@ export {
   NotebookPackageSummaryPanel,
   type NotebookPackageSummaryPanelProps,
 } from "./NotebookPackageSummaryPanel";
+export {
+  NotebookWorkstationsPanel,
+  type NotebookWorkstationsPanelProps,
+} from "./NotebookWorkstationsPanel";
 export { NotebookDocumentRail, type NotebookDocumentRailProps } from "./NotebookDocumentRail";
 export { NotebookReadOnlyView, type NotebookReadOnlyViewProps } from "./NotebookReadOnlyView";
 export {


### PR DESCRIPTION
## Summary
- add a shared Workstations rail panel backed by existing `NotebookShellCapabilities.runtime`
- expose a Workstations panel slot in `NotebookRail` / `NotebookDocumentRail`
- wire the status-only panel into both desktop and cloud notebook shells
- cover the optional rail item, document rail forwarding, and local/cloud status projections with tests

## Verification
- `pnpm test:run src/components/notebook-rail/__tests__/NotebookRail.test.tsx src/components/notebook/__tests__/NotebookDocumentRail.test.tsx src/components/notebook/__tests__/NotebookWorkstationsPanel.test.tsx`
- `pnpm --dir apps/notebook exec tsc -b`
- `pnpm --filter notebook-cloud typecheck`
- `cargo xtask lint --fix`

## Notes
This is intentionally status-only. It does not add provider selection, attachment tickets, or connect/disconnect actions; it makes the rail space real across desktop and cloud so later workstation attachment work has a shared component boundary.