### PR TITLE
fix(notebook): project local runtime as runtime operator

### DIFF
--- a/apps/notebook/src/lib/__tests__/desktop-shell-capabilities.test.ts
+++ b/apps/notebook/src/lib/__tests__/desktop-shell-capabilities.test.ts
@@ -66,7 +66,7 @@ describe("desktopNotebookShellCapabilities", () => {
       canWriteRuntimeState: true,
       connected: true,
       source: "local",
-      actorLabel: "local:kyle/desktop:window",
+      actorLabel: "local:kyle/runtime:local",
     });
     expect(capabilities.access.actor).toMatchObject({
       principal: {
@@ -78,7 +78,7 @@ describe("desktopNotebookShellCapabilities", () => {
     });
     expect(capabilities.runtime.actor).toMatchObject({
       principal: { label: "Kyle" },
-      operator: { kind: "desktop" },
+      operator: { kind: "runtime", label: "Local" },
       scope: "runtime_peer",
     });
   });

--- a/apps/notebook/src/lib/desktop-shell-capabilities.ts
+++ b/apps/notebook/src/lib/desktop-shell-capabilities.ts
@@ -5,6 +5,7 @@ import {
   notebookRoomAccessLevelFromConnectionScope,
   projectNotebookShellCapabilities,
   projectNotebookRoomEditAccess,
+  splitNotebookActorPrincipalOperator,
   type NotebookShellAccessLevel,
   type NotebookShellAccessSource,
   type NotebookShellCapabilities,
@@ -61,7 +62,12 @@ export function desktopNotebookShellCapabilities({
     // gates this further by document write authority.
     executionAvailable: sessionReady,
     source,
-    actorLabel: canWriteRuntimeState ? localActor : null,
+    actorLabel: desktopRuntimeActorLabel({
+      canWriteRuntimeState,
+      isRuntimePeer,
+      localActor,
+      source,
+    }),
     identityLabel: null,
   };
   return projectNotebookShellCapabilities({
@@ -94,6 +100,28 @@ export function desktopNotebookShellCapabilities({
       requiredSources: ["cloud"],
     },
   });
+}
+
+function desktopRuntimeActorLabel({
+  canWriteRuntimeState,
+  isRuntimePeer,
+  localActor,
+  source,
+}: {
+  canWriteRuntimeState: boolean;
+  isRuntimePeer: boolean;
+  localActor: string | null;
+  source: NotebookShellAccessSource;
+}): string | null {
+  if (!canWriteRuntimeState || !localActor) {
+    return null;
+  }
+  if (isRuntimePeer || source !== "local") {
+    return localActor;
+  }
+
+  const [principal] = splitNotebookActorPrincipalOperator(localActor);
+  return `${principal}/runtime:local`;
 }
 
 function desktopAccessLevelFromConnectionScope(


### PR DESCRIPTION
## Summary
- keep local runtime authorship under the local principal while projecting a `runtime:local` operator
- preserve explicit remote `runtime_peer` actor labels for cloud/JupyterHub-style runtime peers
- update desktop shell capability tests so local runtime attribution no longer looks like Desktop authored runtime state

## Verification
- `pnpm test:run apps/notebook/src/lib/__tests__/desktop-shell-capabilities.test.ts`
- `pnpm --dir apps/notebook exec tsc -b`
- `cargo xtask lint --fix`

## Notes
This is a small code follow-up to the runtime-principal-promotion ADR (#3458): local kernels keep a local principal, but runtime state is attributed to a runtime operator rather than the desktop operator.