### PR TITLE
perf(cloud): project live runtime updates incrementally

### DIFF
--- a/apps/notebook-cloud/viewer/cloud-viewer-session.ts
+++ b/apps/notebook-cloud/viewer/cloud-viewer-session.ts
@@ -32,6 +32,13 @@ import { createOutputResolutionCache, type ResolvedCell } from "./render-resolut
 import { loadSnapshotPairHandle } from "./runtimed-wasm-client";
 import { projectCloudWidgetComms } from "./widget-comm-projection";
 import type { CloudAuthRenewalState, ViewerStatus } from "./notice-types";
+import {
+  applyExecutionViewChangeset,
+  applyOutputChangeset,
+  resetRuntimeStoresProjection,
+} from "../../notebook/src/lib/project-runtime-stores";
+import { resetPoolState, setPoolState } from "../../notebook/src/lib/pool-state";
+import { resetRuntimeState, setRuntimeState } from "../../notebook/src/lib/runtime-state";
 
 export interface CloudViewerConfig {
   notebookId: string;
@@ -409,6 +416,7 @@ export function useCloudViewerSession({
       if (disposed || sequence !== materializeSequence) return;
       notebookLanguageRef.current = materialized.notebookLanguage;
       setNotebookMetadata(materialized.metadata);
+      applyExecutionViewChangeset(liveRuntime.handle.project_execution_view_changeset?.());
 
       await projectCloudWidgetComms(
         widgetStore,
@@ -498,8 +506,21 @@ export function useCloudViewerSession({
           liveRuntime.engine.cellChanges$.subscribe(() => {
             materializeLiveCellsSafely(liveRuntime);
           }),
-          liveRuntime.engine.runtimeState$.subscribe(() => {
-            materializeLiveCellsSafely(liveRuntime);
+          liveRuntime.engine.runtimeState$.subscribe((state) => {
+            setRuntimeState(state);
+          }),
+          liveRuntime.engine.executionViewChanges$.subscribe((changeset) => {
+            applyExecutionViewChangeset(changeset);
+          }),
+          liveRuntime.engine.outputIdChanges$.subscribe(({ changed, removed_ids }) => {
+            void applyOutputChangeset(changed, removed_ids, { blobResolver }).catch(
+              (error: unknown) => {
+                console.warn("[notebook-cloud] output store projection failed", error);
+              },
+            );
+          }),
+          liveRuntime.engine.poolState$.subscribe((state) => {
+            setPoolState(state);
           }),
           { unsubscribe: stopCursorDispatch },
         ];
@@ -534,6 +555,9 @@ export function useCloudViewerSession({
       materializeLiveRuntimeRef.current = null;
       disposeCurrentRuntime();
       resetCloudViewStoreProjection();
+      resetRuntimeState();
+      resetRuntimeStoresProjection();
+      resetPoolState();
       livePresenceStore = null;
       presenceStore.reduceConnection("disconnected");
       setConnectionPeerId(null);

--- a/apps/notebook/src/lib/__tests__/project-runtime-stores.test.ts
+++ b/apps/notebook/src/lib/__tests__/project-runtime-stores.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, describe, expect, it } from "vite-plus/test";
+import { afterEach, describe, expect, it, vi } from "vite-plus/test";
 import {
   getCellExecutionId,
   getExecutionById,
@@ -8,6 +8,7 @@ import {
 import { getOutputById } from "../notebook-outputs";
 import {
   applyExecutionViewChangeset,
+  applyOutputChangeset,
   resetRuntimeStoresProjection,
   seedOutputStoresFromHandle,
 } from "../project-runtime-stores";
@@ -126,6 +127,40 @@ describe("applyExecutionViewChangeset", () => {
     expect(getOutputById("out-notebook")).toEqual({
       output_id: "out-notebook",
       output_type: "stream",
+    });
+  });
+});
+
+describe("applyOutputChangeset", () => {
+  it("uses a supplied blob resolver for manifest-backed outputs", async () => {
+    const fetch = vi.fn(async () => new Response("hello from cloud"));
+    const blobResolver = {
+      url: vi.fn((ref: { blob: string }) => `https://example.test/blob/${ref.blob}`),
+      fetch,
+    };
+
+    await applyOutputChangeset(
+      [
+        [
+          "out-1",
+          {
+            output_id: "out-1",
+            output_type: "stream",
+            name: "stdout",
+            text: { blob: "blob-1", size: 16 },
+          },
+        ],
+      ],
+      [],
+      { blobResolver },
+    );
+
+    expect(fetch).toHaveBeenCalledWith({ blob: "blob-1", size: 16 });
+    expect(getOutputById("out-1")).toEqual({
+      output_id: "out-1",
+      output_type: "stream",
+      name: "stdout",
+      text: "hello from cloud",
     });
   });
 });

--- a/apps/notebook/src/lib/project-runtime-stores.ts
+++ b/apps/notebook/src/lib/project-runtime-stores.ts
@@ -39,6 +39,18 @@ import {
   setOutput,
 } from "@/components/notebook/state/output-store";
 
+export interface ApplyOutputChangesetOptions {
+  /**
+   * Host-provided resolver for callers that already own blob access.
+   *
+   * Desktop leaves this unset and falls back to the blob-port store. Cloud
+   * passes its authenticated HTTP resolver so runtime-state projection does
+   * not depend on desktop host discovery.
+   */
+  blobResolver?: HostBlobResolver | null;
+  refreshBlobResolver?: () => Promise<HostBlobResolver | null>;
+}
+
 /**
  * Apply the cross-document execution materialized-view changeset emitted by
  * WASM.
@@ -140,6 +152,7 @@ export function seedOutputStoresFromHandle(
 export async function applyOutputChangeset(
   changed: Array<[string, unknown]>,
   removed_ids: string[],
+  options: ApplyOutputChangesetOptions = {},
 ): Promise<void> {
   if (removed_ids.length > 0) {
     deleteOutputs(removed_ids);
@@ -149,9 +162,12 @@ export async function applyOutputChangeset(
   // Stream/display-update manifests with text blob refs need host blob access.
   // Fetch it on demand so a race between the first manifest and resolver
   // discovery doesn't drop outputs on the floor.
-  let blobResolver = getBlobResolver();
+  let blobResolver =
+    "blobResolver" in options ? options.blobResolver ?? null : getBlobResolver();
   if (blobResolver === null && changed.some(([, raw]) => isOutputManifest(raw))) {
-    blobResolver = await refreshBlobResolver();
+    blobResolver = options.refreshBlobResolver
+      ? await options.refreshBlobResolver()
+      : await refreshBlobResolver();
   }
 
   for (const [output_id, raw] of changed) {


### PR DESCRIPTION
## Summary

- Stops cloud live `runtimeState$` updates from triggering full notebook view materialization.
- Wires cloud live sync into the same narrow runtime stores desktop uses: runtime state, execution view changes, output id changes, and pool state.
- Lets `applyOutputChangeset` accept a host-provided blob resolver so cloud can resolve manifest-backed output updates through its authenticated HTTP resolver without depending on the desktop blob-port store.

## Why

The cloud viewer was still using full `materializeCloudNotebookView(...)` passes for live runtime changes. For output-heavy notebooks, that means runtime/output updates can re-read and re-resolve the full cell list. This PR keeps initial/full cell materialization for notebook cell changes, but runtime-state churn now projects through stable per-runtime/per-execution/per-output stores.

## Verification

- `pnpm test:run apps/notebook/src/lib/__tests__/project-runtime-stores.test.ts`
- `pnpm --filter notebook-cloud typecheck`
- `pnpm --dir apps/notebook exec tsc -b`
- `cargo xtask lint --fix`
