### PR TITLE
docs(adr): define live projection policy

### DIFF
--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -61,6 +61,7 @@ These entries define the center of gravity for the system:
 | [Execution Liveness](execution-liveness.md) | Design memo | Divergence-detection framing; not a recovery decision yet. |
 | [Tokio Mutex Discipline](tokio-mutex-discipline.md) | Draft | Async lock and cancel-safety invariants. |
 | [Frontend Sync Bridge and Stable DOM Order](frontend-sync-bridge.md) | Draft | React/store projection and iframe-preserving cell order. |
+| [Live Notebook Projection Policy](live-notebook-projection-policy.md) | Draft | Full materialization fallback boundaries and narrow live store projections. |
 | [MCP Session Lifecycle and Daemon Supervision](mcp-session-lifecycle.md) | Draft | MCP proxy, daemon, and session lifetime boundaries. |
 | [MCP Resource Addressing](mcp-resource-addressing.md) | Draft | Local `nteract://` MCP resource namespace. |
 

--- a/docs/adr/live-notebook-projection-policy.md
+++ b/docs/adr/live-notebook-projection-policy.md
@@ -1,0 +1,75 @@
+# Live Notebook Projection Policy
+
+**Status:** Draft
+
+## Context
+
+nteract hosts increasingly share the same notebook surfaces while connecting to
+different sources of truth:
+
+- desktop uses a local daemon and a live `SyncEngine`;
+- cloud can render pinned snapshots and then attach to a hosted room;
+- Elements and tests mount shared notebook shells with fixture or scenario data.
+
+The shared React surface reads stable notebook, execution, output, runtime, and
+pool stores. Those stores are intentionally narrower than a fully materialized
+notebook view. A full materialization is still useful for bootstrap and
+structural changes, but it is too expensive for hot runtime traffic. Output
+heavy notebooks can produce frequent runtime-state, execution, and output
+changes without changing cell order or source.
+
+The projection rule needs to be explicit so host adapters do not silently drift
+back to "serialize and resolve the whole notebook" for every live update.
+
+## Decision
+
+Live hosts should treat full notebook materialization as a bounded fallback, not
+the default projection path.
+
+Full materialization is appropriate when:
+
+- a notebook first becomes interactive;
+- a pinned cloud snapshot is rendered;
+- the cell list has structural changes such as add, remove, or reorder;
+- a changeset is missing or marks a field that cannot be projected through a
+  narrow accessor.
+
+Runtime-state, execution-view, output-id, pool-state, presence, and broadcast
+updates must project through stable narrow stores. They should not re-read,
+re-resolve, or replace the entire cell list.
+
+Cell chrome updates may update the cell store for the touched cells only when
+the changeset can be classified incrementally. Output-only changes should update
+the output store and leave the cell store stable.
+
+Host-specific blob access is a projection dependency, not a reason to fork the
+projection semantics. Shared projection helpers may accept a host-provided blob
+resolver so desktop can use the daemon blob port while cloud can use an
+authenticated HTTP/R2 resolver.
+
+## Consequences
+
+The desired steady-state cost is proportional to the update:
+
+- runtime/execution changes update runtime and execution stores;
+- output payload changes update only changed output ids;
+- source or metadata edits update only touched cell records;
+- structural changes still pay the full materialization cost.
+
+This preserves iframe stability, output subscriptions, and rail/view-model
+subscriptions for both desktop and cloud. It also gives performance reviews a
+clear failure mode: a live runtime/output event that calls full notebook
+materialization is a regression unless it is explicitly classified as a
+fallback.
+
+## Non-Goals
+
+This ADR does not require every host to implement all incremental paths at once.
+It records the target policy and fallback boundaries. Hosts may temporarily keep
+full cell materialization for structural or unclassified notebook changes while
+moving runtime/output hot paths to narrow projections.
+
+This ADR also does not change the cell execution pipeline, output transport, or
+runtime control-plane ordering invariants. Those remain governed by
+[Cell Execution Pipeline and Control-Plane Separation](execution-pipeline.md).
+


### PR DESCRIPTION
## Summary

- Adds a draft ADR for live notebook projection policy.
- Records full materialization as a bounded fallback for bootstrap, snapshots, structural changes, and unclassified changesets.
- Records runtime/execution/output/pool/presence/broadcast updates as stable narrow-store projections, with host-provided blob resolver support as the shared boundary.

## Why

This documents the performance invariant behind the cloud live projection work: output-heavy runtime churn should not cause full cell-list re-read/re-resolution. It also gives future desktop/cloud/Elements projection changes a reviewable policy instead of leaving the rule implicit in adapters.

## Verification

- `cargo xtask lint --fix`
