### PR TITLE
refactor(runtimed): reuse projection cache helpers

### DIFF
--- a/packages/runtimed/src/notebook-actor-projection.ts
+++ b/packages/runtimed/src/notebook-actor-projection.ts
@@ -4,6 +4,7 @@ import type {
   NotebookShellAuthCapabilities,
   NotebookShellRuntimeCapabilities,
 } from "./notebook-shell-capabilities";
+import { getBoundedCacheValue, setBoundedCacheValue, stableCacheKey } from "./projection-cache";
 
 export type ParsedNotebookActorKind = "agent" | "runtime" | "system";
 
@@ -470,31 +471,6 @@ function stableNotebookActorOperator(
   const operator = Object.freeze({ id, kind, label });
   setBoundedCacheValue(OPERATOR_CACHE, cacheKey, operator, ACTOR_PART_CACHE_LIMIT);
   return operator;
-}
-
-function getBoundedCacheValue<K, V>(cache: Map<K, V>, key: K): V | undefined {
-  const cached = cache.get(key);
-  if (cached === undefined) return undefined;
-
-  cache.delete(key);
-  cache.set(key, cached);
-  return cached;
-}
-
-function setBoundedCacheValue<K, V>(cache: Map<K, V>, key: K, value: V, limit: number): void {
-  if (cache.has(key)) {
-    cache.delete(key);
-  } else if (cache.size >= limit) {
-    const oldestKey = cache.keys().next().value;
-    if (oldestKey !== undefined) {
-      cache.delete(oldestKey);
-    }
-  }
-  cache.set(key, value);
-}
-
-function stableCacheKey(parts: readonly unknown[]): string {
-  return JSON.stringify(parts);
 }
 
 function withAuthStatus(


### PR DESCRIPTION
## Summary

- Reuses `projection-cache.ts` from `notebook-actor-projection.ts` instead of keeping local LRU/cache-key helper copies.
- Leaves actor projection behavior otherwise unchanged.

## Why

This closes a low-priority projection audit cleanup: actor projections and other runtimed projections should share the same bounded-cache utility instead of drifting on key and eviction behavior.

## Verification

- `pnpm test:run packages/runtimed/tests/notebook-actor-projection.test.ts packages/runtimed/tests/projection-cache.test.ts`
- `cargo xtask lint --fix`

Note: I also accidentally ran `pnpm test:run packages/runtimed/tests/snapshot-widget-comms.test.ts` while on this `origin/main`-based branch; that file only exists on #3463, so the runner correctly reported no matching files. It is not a failure for this branch.
