### PR TITLE
feat(cloud): list notebooks for authenticated principals

### DIFF
--- a/apps/notebook-cloud/src/index.ts
+++ b/apps/notebook-cloud/src/index.ts
@@ -30,6 +30,7 @@ import {
   getNotebookRow,
   getNotebookCatalog,
   grantNotebookAclRow,
+  listNotebooksForPrincipal,
   recordBlob,
   recordRevision,
   revokeNotebookAclRow,
@@ -162,6 +163,11 @@ const NOTEBOOK_CLOUD_ROUTES: readonly WorkerRoute[] = [
     match: exactPath("/api/n"),
     methods: ["POST"],
     handler: (_match, request, env) => routeCreateNotebook(request, env),
+  },
+  {
+    match: exactPath("/api/n"),
+    methods: ["GET"],
+    handler: (_match, request, env) => routeListNotebooks(request, env),
   },
   {
     match: routePath("/api/n/:notebookId", { trailingSlash: "optional" }),
@@ -552,6 +558,68 @@ async function routeCreateNotebook(request: Request, env: Env): Promise<Response
     },
     201,
   );
+}
+
+const DEFAULT_NOTEBOOK_LIST_LIMIT = 100;
+const MAX_NOTEBOOK_LIST_LIMIT = 500;
+
+async function routeListNotebooks(request: Request, env: Env): Promise<Response> {
+  if (request.method !== "GET") {
+    return json({ error: "method not allowed" }, 405);
+  }
+  if (!env.DB) {
+    return json({ error: "D1 binding DB is not configured" }, 503);
+  }
+
+  const identity = await authenticateRequestOrResponse(request, env);
+  if (identity instanceof Response) {
+    return identity;
+  }
+  if (isAnonymousViewer(identity)) {
+    return json({ error: "sign in to list notebooks" }, 401);
+  }
+
+  const limit = parseNotebookListLimit(request);
+  if (limit instanceof Response) {
+    return limit;
+  }
+
+  const notebooks = await listNotebooksForPrincipal(env, identity.principal, limit);
+  return json({
+    ok: true,
+    notebooks: notebooks.map((notebook) => {
+      const notebookPathId = encodeURIComponent(notebook.id);
+      const apiBasePath = `/api/n/${notebookPathId}`;
+      return {
+        notebook_id: notebook.id,
+        title: notebook.title,
+        owner_principal: notebook.owner_principal,
+        scope: notebook.scope,
+        created_at: notebook.created_at,
+        updated_at: notebook.updated_at,
+        latest_revision_id: notebook.latest_revision_id,
+        viewer_url: viewerUrlForRequest(request, notebook.id, notebook.title),
+        endpoints: {
+          catalog: apiBasePath,
+          acl: `${apiBasePath}/acl`,
+          access_requests: `${apiBasePath}/access-requests`,
+        },
+      };
+    }),
+  });
+}
+
+function parseNotebookListLimit(request: Request): number | Response {
+  const value = new URL(request.url).searchParams.get("limit");
+  if (value === null || value.trim() === "") {
+    return DEFAULT_NOTEBOOK_LIST_LIMIT;
+  }
+
+  const limit = Number(value);
+  if (!Number.isInteger(limit) || limit < 1) {
+    return json({ error: "limit must be a positive integer" }, 400);
+  }
+  return Math.min(limit, MAX_NOTEBOOK_LIST_LIMIT);
 }
 
 async function readCreateNotebookPayload(

--- a/apps/notebook-cloud/src/index.ts
+++ b/apps/notebook-cloud/src/index.ts
@@ -136,6 +136,11 @@ const NOTEBOOK_CLOUD_ROUTES: readonly WorkerRoute[] = [
     handler: (_match, request, env) => homeViewer(request, env),
   },
   {
+    match: exactPath("/n", "/n/"),
+    methods: ["GET"],
+    handler: (_match, request, env) => notebookListViewer(request, env),
+  },
+  {
     match: exactPath("/oidc"),
     methods: ["GET"],
     handler: (_match, request, env) => oidcCallbackViewer(request, env),
@@ -2450,6 +2455,10 @@ interface ViewerShellConfig extends Record<string, unknown> {
 
 function homeViewer(request: Request, env: Env): Response {
   return viewerShell("nteract", env, authConfigForRequest(request, env), null);
+}
+
+function notebookListViewer(request: Request, env: Env): Response {
+  return viewerShell("nteract cloud notebooks", env, authConfigForRequest(request, env), null);
 }
 
 function oidcCallbackViewer(request: Request, env: Env): Response {

--- a/apps/notebook-cloud/src/storage.ts
+++ b/apps/notebook-cloud/src/storage.ts
@@ -49,6 +49,10 @@ export interface NotebookAclRow {
   created_by_actor_label: string;
 }
 
+export interface ListedNotebookRow extends NotebookRow {
+  scope: NotebookAclRow["scope"];
+}
+
 export interface NotebookAclInput {
   notebookId: string;
   subjectKind: NotebookAclRow["subject_kind"];
@@ -379,6 +383,63 @@ export async function getNotebookAclRowsForPrincipal(
   )
     .bind(notebookId, principal, principal)
     .all<NotebookAclRow>();
+  return rows.results ?? [];
+}
+
+export async function listNotebooksForPrincipal(
+  env: Env,
+  principal: string,
+  limit: number,
+): Promise<ListedNotebookRow[]> {
+  if (!env.DB) {
+    return [];
+  }
+
+  await ensureCatalogSchema(env);
+  const rows = await env.DB.prepare(
+    `SELECT n.id,
+            n.owner_principal,
+            n.title,
+            n.created_at,
+            n.updated_at,
+            n.latest_revision_id,
+            CASE MAX(
+              CASE a.scope
+                WHEN 'owner' THEN 4
+                WHEN 'editor' THEN 3
+                WHEN 'runtime_peer' THEN 2
+                WHEN 'viewer' THEN 1
+                ELSE 0
+              END
+            )
+              WHEN 4 THEN 'owner'
+              WHEN 3 THEN 'editor'
+              WHEN 2 THEN 'runtime_peer'
+              ELSE 'viewer'
+            END AS scope
+       FROM notebooks n
+       JOIN notebook_acl a
+         ON a.notebook_id = n.id
+      WHERE a.subject_kind = 'principal'
+        AND (
+          a.subject = ?
+          OR a.subject IN (
+            SELECT canonical_principal
+              FROM principal_account_links
+             WHERE transport_principal = ?
+          )
+        )
+      GROUP BY n.id,
+               n.owner_principal,
+               n.title,
+               n.created_at,
+               n.updated_at,
+               n.latest_revision_id
+      ORDER BY n.updated_at DESC, n.created_at DESC, n.id DESC
+      LIMIT ?`,
+  )
+    .bind(principal, principal, limit)
+    .all<ListedNotebookRow>();
   return rows.results ?? [];
 }
 

--- a/apps/notebook-cloud/test/worker-routes.test.ts
+++ b/apps/notebook-cloud/test/worker-routes.test.ts
@@ -88,7 +88,8 @@ describe("Worker artifact routes", () => {
   it("reports Anaconda API key readiness without exposing configured values", async () => {
     const env = fakeEnv({
       NOTEBOOK_CLOUD_ANACONDA_API_KEY_PRINCIPAL_NAMESPACE: "user:anaconda",
-      NOTEBOOK_CLOUD_ANACONDA_API_KEY_USERINFO_URL: "https://anaconda.com/api/auth/sessions/whoami",
+      NOTEBOOK_CLOUD_ANACONDA_API_KEY_USERINFO_URL:
+        "https://auth.stage.anaconda.com/api/auth/sessions/whoami",
     });
 
     const response = await worker.fetch(
@@ -656,6 +657,139 @@ describe("Worker artifact routes", () => {
           row.scope === "owner",
       ),
       true,
+    );
+  });
+
+  it("lists notebooks visible to the authenticated principal", async () => {
+    const env = fakeEnv();
+    seedNotebook(env, "old-owned");
+    seedNotebook(env, "new-owned");
+    seedNotebook(env, "editor-shared");
+    seedNotebook(env, "hidden");
+    const newOwned = env.DB.notebooks.get("new-owned");
+    const editorShared = env.DB.notebooks.get("editor-shared");
+    assert.ok(newOwned);
+    assert.ok(editorShared);
+    newOwned.updated_at = "2026-05-24T00:00:00.000Z";
+    editorShared.title = "Editor Shared";
+    editorShared.updated_at = "2026-05-23T00:00:00.000Z";
+    seedAcl(env, { notebookId: "old-owned", subject: "user:dev:alice", scope: "viewer" });
+    seedAcl(env, { notebookId: "old-owned", subject: "user:dev:alice", scope: "owner" });
+    seedAcl(env, { notebookId: "new-owned", subject: "user:dev:alice", scope: "owner" });
+    seedAcl(env, { notebookId: "editor-shared", subject: "user:dev:alice", scope: "editor" });
+    seedAcl(env, { notebookId: "hidden", subject: "user:dev:bob", scope: "owner" });
+
+    const response = await worker.fetch(
+      new Request("http://localhost/api/n?limit=2", {
+        headers: {
+          "X-User": "alice",
+          "X-Operator": "desktop:test",
+          "X-Scope": "viewer",
+        },
+      }),
+      env,
+      fakeContext(),
+    );
+
+    assert.equal(response.status, 200);
+    const body = (await response.json()) as {
+      notebooks: Array<{
+        endpoints: Record<string, string>;
+        notebook_id: string;
+        scope: NotebookAclRow["scope"];
+        title: string | null;
+        viewer_url: string;
+      }>;
+      ok: boolean;
+    };
+    assert.equal(body.ok, true);
+    assert.deepEqual(
+      body.notebooks.map((notebook) => [notebook.notebook_id, notebook.scope]),
+      [
+        ["new-owned", "owner"],
+        ["editor-shared", "editor"],
+      ],
+    );
+    assert.equal(body.notebooks[1]?.title, "Editor Shared");
+    assert.equal(body.notebooks[1]?.viewer_url, "http://localhost/n/editor-shared/Editor%20Shared");
+    assert.equal(body.notebooks[1]?.endpoints.catalog, "/api/n/editor-shared");
+  });
+
+  it("requires sign-in before listing notebooks", async () => {
+    const env = fakeEnv();
+    seedNotebook(env, "public-demo");
+    seedAcl(env, {
+      notebookId: "public-demo",
+      subjectKind: "public",
+      subject: "anonymous",
+      scope: "viewer",
+    });
+
+    const response = await worker.fetch(
+      new Request("http://localhost/api/n?viewer_session=anon-a"),
+      env,
+      fakeContext(),
+    );
+
+    assert.equal(response.status, 401);
+    assert.deepEqual(await response.json(), { error: "sign in to list notebooks" });
+  });
+
+  it("lists notebooks through canonical Anaconda account ACLs", async (t) => {
+    const token = anacondaApiKeyToken({ jti: "list-notebooks-canonical-account" });
+    const env = fakeEnv(anacondaApiKeyEnv());
+    t.mock.method(globalThis, "fetch", async () =>
+      jsonResponse(
+        anacondaWhoami({
+          email: "rgbkrk@gmail.com",
+          firstName: "Kyle",
+          lastName: "Kelley",
+          userId: "fdb3dc7d-c369-4a39-bf7d-e35b77a0bdd0",
+          scopes: ["cloud:read"],
+        }),
+      ),
+    );
+    const accountPrincipal = await canonicalAccountPrincipalForProfile({
+      provider: "anaconda-api-key",
+      principalNamespace: "user:anaconda",
+      email: "rgbkrk@gmail.com",
+      emailVerified: true,
+    });
+    assert.ok(accountPrincipal);
+    seedNotebook(env, "canonical-list-demo");
+    const notebook = env.DB.notebooks.get("canonical-list-demo");
+    assert.ok(notebook);
+    notebook.owner_principal = accountPrincipal;
+    seedAcl(env, {
+      notebookId: "canonical-list-demo",
+      subject: accountPrincipal,
+      scope: "owner",
+    });
+
+    const response = await worker.fetch(
+      new Request("https://cloud.test/api/n", {
+        headers: {
+          Authorization: `Bearer ${token}`,
+          "X-Notebook-Cloud-Auth-Provider": "anaconda-api-key",
+          "X-Operator": "browser:tab",
+        },
+      }),
+      env,
+      fakeContext(),
+    );
+
+    assert.equal(response.status, 200);
+    const body = (await response.json()) as {
+      notebooks: Array<{ notebook_id: string; scope: NotebookAclRow["scope"] }>;
+    };
+    assert.deepEqual(
+      body.notebooks.map((listedNotebook) => [listedNotebook.notebook_id, listedNotebook.scope]),
+      [["canonical-list-demo", "owner"]],
+    );
+    assert.equal(
+      env.DB.accountLinks.get("user:anaconda:fdb3dc7d-c369-4a39-bf7d-e35b77a0bdd0")
+        ?.canonical_principal,
+      accountPrincipal,
     );
   });
 
@@ -3006,7 +3140,8 @@ function anacondaApiKeyEnv(): {
 } {
   return {
     NOTEBOOK_CLOUD_ANACONDA_API_KEY_PRINCIPAL_NAMESPACE: "user:anaconda",
-    NOTEBOOK_CLOUD_ANACONDA_API_KEY_USERINFO_URL: "https://anaconda.com/api/auth/sessions/whoami",
+    NOTEBOOK_CLOUD_ANACONDA_API_KEY_USERINFO_URL:
+      "https://auth.stage.anaconda.com/api/auth/sessions/whoami",
   };
 }
 
@@ -3795,6 +3930,47 @@ class FakeD1Statement implements D1PreparedStatement {
           .slice(0, limit) as T[],
       );
     }
+    if (this.query.includes("FROM notebooks n") && this.query.includes("JOIN notebook_acl a")) {
+      const [principal, linkedPrincipal, limitValue] = this.values as [string, string, number];
+      const linked = this.db.accountLinks.get(linkedPrincipal)?.canonical_principal;
+      const subjects = new Set([principal, ...(linked ? [linked] : [])]);
+      const byNotebook = new Map<
+        string,
+        NotebookRow & { scope: NotebookAclRow["scope"]; scopeRank: number }
+      >();
+
+      for (const row of this.db.acl) {
+        if (row.subject_kind !== "principal" || !subjects.has(row.subject)) {
+          continue;
+        }
+        const notebook = this.db.notebooks.get(row.notebook_id);
+        if (!notebook) {
+          continue;
+        }
+        const rank = scopeRank(row.scope);
+        const existing = byNotebook.get(notebook.id);
+        if (!existing || rank > existing.scopeRank) {
+          byNotebook.set(notebook.id, {
+            ...notebook,
+            scope: row.scope,
+            scopeRank: rank,
+          });
+        }
+      }
+
+      const limit = Number.isFinite(limitValue) ? limitValue : Number.POSITIVE_INFINITY;
+      return okResult(
+        [...byNotebook.values()]
+          .sort(
+            (left, right) =>
+              right.updated_at.localeCompare(left.updated_at) ||
+              right.created_at.localeCompare(left.created_at) ||
+              right.id.localeCompare(left.id),
+          )
+          .slice(0, limit)
+          .map(({ scopeRank: _scopeRank, ...row }) => row) as T[],
+      );
+    }
     if (this.query.includes("FROM notebook_acl")) {
       const notebookId = this.values[0] as string;
       if (
@@ -3852,6 +4028,19 @@ class FakeD1Statement implements D1PreparedStatement {
       );
     }
     return okResult([]);
+  }
+}
+
+function scopeRank(scope: NotebookAclRow["scope"]): number {
+  switch (scope) {
+    case "owner":
+      return 4;
+    case "editor":
+      return 3;
+    case "runtime_peer":
+      return 2;
+    case "viewer":
+      return 1;
   }
 }
 

--- a/apps/notebook-cloud/test/worker-routes.test.ts
+++ b/apps/notebook-cloud/test/worker-routes.test.ts
@@ -174,6 +174,18 @@ describe("Worker artifact routes", () => {
     assert.doesNotMatch(html, /topic-viz.*render/);
   });
 
+  it("serves the notebook list page at /n", async () => {
+    const env = fakeEnv();
+
+    const response = await worker.fetch(new Request("http://localhost/n"), env, fakeContext());
+
+    assert.equal(response.status, 200);
+    const html = await response.text();
+    assert.match(html, /<title>nteract cloud notebooks<\/title>/);
+    assert.match(html, /notebook-cloud-viewer\.js/);
+    assert.doesNotMatch(html, /nteract-cloud-viewer-config/);
+  });
+
   it("serves the viewer runtimed WASM asset through the Worker assets binding", async () => {
     const seenPaths: string[] = [];
     const env = fakeEnv({

--- a/apps/notebook-cloud/viewer/index.css
+++ b/apps/notebook-cloud/viewer/index.css
@@ -315,6 +315,270 @@ body {
   background: color-mix(in srgb, #b42318 8%, var(--background));
 }
 
+.cloud-notebook-list-page {
+  display: grid;
+  grid-template-rows: auto auto minmax(0, 1fr);
+  height: 100%;
+  min-height: 100vh;
+  overflow: auto;
+  background: var(--background);
+  color: var(--foreground);
+}
+
+.cloud-notebook-list-header {
+  display: flex;
+  align-items: end;
+  justify-content: space-between;
+  gap: 1rem;
+  border-bottom: 1px solid var(--border);
+  padding: clamp(1rem, 4vw, 2rem);
+}
+
+.cloud-notebook-list-header h1,
+.cloud-notebook-list-header p {
+  margin: 0;
+}
+
+.cloud-notebook-list-header h1 {
+  margin-top: 0.25rem;
+  font-size: clamp(2rem, 5vw, 3.5rem);
+  font-weight: 740;
+  letter-spacing: 0;
+  line-height: 1;
+}
+
+.cloud-notebook-list-header p,
+.cloud-notebook-list-brand {
+  color: color-mix(in srgb, var(--foreground) 62%, transparent);
+  font-size: 0.875rem;
+  line-height: 1.35;
+}
+
+.cloud-notebook-list-brand {
+  text-decoration: none;
+}
+
+.cloud-notebook-list-brand:hover {
+  color: var(--foreground);
+}
+
+.cloud-notebook-list-actions {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: flex-end;
+  gap: 0.5rem;
+}
+
+.cloud-notebook-list-actions button,
+.cloud-notebook-list-actions .cloud-sign-in-button {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.375rem;
+  min-height: 2.25rem;
+  border: 1px solid color-mix(in srgb, var(--foreground) 16%, transparent);
+  border-radius: 6px;
+  padding-inline: 0.75rem;
+  color: var(--foreground);
+  background: color-mix(in srgb, var(--background) 94%, var(--foreground) 6%);
+  font-size: 0.875rem;
+}
+
+.cloud-notebook-list-actions button:hover,
+.cloud-notebook-list-actions .cloud-sign-in-button:hover {
+  background: color-mix(in srgb, var(--background) 86%, var(--foreground) 10%);
+}
+
+.cloud-notebook-list-actions button:disabled {
+  cursor: progress;
+  opacity: 0.62;
+}
+
+.cloud-notebook-list-actions svg {
+  width: 1rem;
+  height: 1rem;
+}
+
+.cloud-notebook-list-banner {
+  border-bottom: 1px solid color-mix(in srgb, var(--foreground) 12%, transparent);
+  padding: 0.625rem clamp(1rem, 4vw, 2rem);
+  color: color-mix(in srgb, var(--foreground) 74%, transparent);
+  font-size: 0.875rem;
+}
+
+.cloud-notebook-list-banner[data-kind="error"] {
+  color: #b42318;
+  background: color-mix(in srgb, #b42318 6%, var(--background));
+}
+
+.cloud-notebook-list-content {
+  display: grid;
+  align-content: start;
+  padding: clamp(0.75rem, 3vw, 1.5rem) clamp(1rem, 4vw, 2rem) 2rem;
+}
+
+.cloud-notebook-list {
+  display: grid;
+  margin: 0;
+  padding: 0;
+  list-style: none;
+  border-top: 1px solid var(--border);
+}
+
+.cloud-notebook-list-row {
+  display: grid;
+  grid-template-columns: 2rem minmax(0, 1fr) auto minmax(10rem, auto) auto;
+  align-items: center;
+  gap: 0.75rem;
+  min-height: 4rem;
+  border-bottom: 1px solid var(--border);
+  color: var(--foreground);
+  text-decoration: none;
+}
+
+.cloud-notebook-list-row:hover {
+  background: color-mix(in srgb, var(--background) 94%, var(--foreground) 5%);
+}
+
+.cloud-notebook-list-icon {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 2rem;
+  height: 2rem;
+  color: color-mix(in srgb, #0f766e 82%, var(--foreground));
+}
+
+.cloud-notebook-list-icon svg,
+.cloud-notebook-list-updated svg,
+.cloud-notebook-list-open {
+  width: 1rem;
+  height: 1rem;
+}
+
+.cloud-notebook-list-main {
+  display: grid;
+  min-width: 0;
+  gap: 0.1875rem;
+}
+
+.cloud-notebook-list-title,
+.cloud-notebook-list-id {
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.cloud-notebook-list-title {
+  font-size: 0.9375rem;
+  font-weight: 650;
+  line-height: 1.2;
+}
+
+.cloud-notebook-list-id {
+  color: color-mix(in srgb, var(--foreground) 54%, transparent);
+  font-family:
+    ui-monospace, SFMono-Regular, "SF Mono", Consolas, "Liberation Mono", Menlo, monospace;
+  font-size: 0.75rem;
+  line-height: 1.2;
+}
+
+.cloud-notebook-list-scope {
+  border: 1px solid color-mix(in srgb, var(--foreground) 14%, transparent);
+  border-radius: 999px;
+  padding: 0.1875rem 0.5rem;
+  color: color-mix(in srgb, var(--foreground) 68%, transparent);
+  background: color-mix(in srgb, var(--background) 92%, var(--foreground) 7%);
+  font-size: 0.75rem;
+  font-weight: 650;
+  line-height: 1.2;
+}
+
+.cloud-notebook-list-scope[data-scope="owner"] {
+  border-color: color-mix(in srgb, #0f766e 38%, transparent);
+  color: #0f766e;
+  background: color-mix(in srgb, #0f766e 7%, var(--background));
+}
+
+.cloud-notebook-list-scope[data-scope="editor"] {
+  border-color: color-mix(in srgb, #2563eb 34%, transparent);
+  color: #2563eb;
+  background: color-mix(in srgb, #2563eb 6%, var(--background));
+}
+
+.cloud-notebook-list-updated {
+  display: inline-flex;
+  align-items: center;
+  justify-content: flex-end;
+  gap: 0.375rem;
+  color: color-mix(in srgb, var(--foreground) 58%, transparent);
+  font-size: 0.8125rem;
+  white-space: nowrap;
+}
+
+.cloud-notebook-list-open {
+  color: color-mix(in srgb, var(--foreground) 48%, transparent);
+}
+
+.cloud-notebook-list-state {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.625rem;
+  width: fit-content;
+  max-width: 100%;
+  border-left: 2px solid color-mix(in srgb, var(--foreground) 24%, transparent);
+  padding: 0.75rem 1rem;
+  color: color-mix(in srgb, var(--foreground) 68%, transparent);
+  background: color-mix(in srgb, var(--background) 96%, var(--foreground) 4%);
+  font-size: 0.9375rem;
+}
+
+.cloud-notebook-list-state[data-kind="error"] {
+  border-color: color-mix(in srgb, #b42318 54%, transparent);
+  color: #b42318;
+  background: color-mix(in srgb, #b42318 6%, var(--background));
+}
+
+.cloud-notebook-list-state svg {
+  width: 1.125rem;
+  height: 1.125rem;
+  flex: 0 0 auto;
+}
+
+@media (max-width: 780px) {
+  .cloud-notebook-list-header {
+    align-items: start;
+    flex-direction: column;
+  }
+
+  .cloud-notebook-list-actions {
+    justify-content: flex-start;
+  }
+
+  .cloud-notebook-list-row {
+    grid-template-columns: 2rem minmax(0, 1fr) auto;
+    min-height: 4.5rem;
+    gap: 0.5rem;
+    padding-block: 0.625rem;
+  }
+
+  .cloud-notebook-list-scope,
+  .cloud-notebook-list-updated {
+    grid-column: 2 / -1;
+    justify-self: start;
+  }
+
+  .cloud-notebook-list-updated {
+    margin-top: -0.25rem;
+  }
+
+  .cloud-notebook-list-open {
+    grid-column: 3;
+    grid-row: 1;
+  }
+}
+
 .cloud-home {
   display: grid;
   min-height: 100vh;

--- a/apps/notebook-cloud/viewer/index.tsx
+++ b/apps/notebook-cloud/viewer/index.tsx
@@ -10,7 +10,10 @@ import {
 import { createRoot } from "react-dom/client";
 import {
   AlertCircle,
+  BookOpen,
   Check,
+  Clock,
+  ExternalLink,
   KeyRound,
   Loader2,
   LogIn,
@@ -130,6 +133,33 @@ interface ViewerRuntime {
   config: CloudViewerConfig;
 }
 
+interface CloudNotebookListItem {
+  notebook_id: string;
+  title: string | null;
+  owner_principal: string;
+  scope: "viewer" | "editor" | "runtime_peer" | "owner";
+  created_at: string;
+  updated_at: string;
+  latest_revision_id: string | null;
+  viewer_url: string;
+  endpoints: {
+    catalog: string;
+    acl: string;
+    access_requests: string;
+  };
+}
+
+interface CloudNotebookListResponse {
+  ok: boolean;
+  notebooks: CloudNotebookListItem[];
+}
+
+type CloudNotebookListState =
+  | { kind: "loading" }
+  | { kind: "ready"; notebooks: CloudNotebookListItem[] }
+  | { kind: "signed_out" }
+  | { kind: "error"; message: string };
+
 type ViewerRuntimeState =
   | { kind: "ready"; runtime: ViewerRuntime }
   | { kind: "error"; message: string };
@@ -223,6 +253,10 @@ function isOidcCallbackPath(): boolean {
 function isHomePath(): boolean {
   const pathname = window.location.pathname.replace(/\/+$/, "");
   return pathname === "" || pathname === "/index.html";
+}
+
+function isNotebookListPath(): boolean {
+  return window.location.pathname.replace(/\/+$/, "") === "/n";
 }
 
 function useCloudPrototypeAuth(authConfig: CloudViewerAuthConfig): {
@@ -324,11 +358,15 @@ function shouldRefreshStoredOidcToken(): boolean {
 function App() {
   const [authConfig] = useState<CloudViewerAuthConfig>(() => loadAuthConfig());
   const [runtimeState] = useState<ViewerRuntimeState | null>(() =>
-    isOidcCallbackPath() || isHomePath() ? null : loadViewerRuntime(),
+    isOidcCallbackPath() || isHomePath() || isNotebookListPath() ? null : loadViewerRuntime(),
   );
 
   if (isHomePath()) {
     return <CloudHomeView authConfig={authConfig} />;
+  }
+
+  if (isNotebookListPath()) {
+    return <CloudNotebookListView authConfig={authConfig} />;
   }
 
   if (isOidcCallbackPath()) {
@@ -371,6 +409,195 @@ function CloudNotebookProviders({
       </CloudWidgetStoreProvider>
     </IsolatedRendererProvider>
   );
+}
+
+function CloudNotebookListView({ authConfig }: { authConfig: CloudViewerAuthConfig }) {
+  const { resolvedTheme } = useTheme(CLOUD_VIEWER_THEME_STORAGE_KEY);
+  const { authState, authRenewal, refreshAuthState } = useCloudPrototypeAuth(authConfig);
+  const [listState, setListState] = useState<CloudNotebookListState>({ kind: "loading" });
+  const [refreshIndex, setRefreshIndex] = useState(0);
+  const signedIn = authState.mode === "dev" || authState.mode === "oidc";
+
+  useEffect(() => {
+    applyDocumentTheme(resolvedTheme);
+  }, [resolvedTheme]);
+
+  useEffect(() => {
+    if (!signedIn) {
+      setListState({ kind: "signed_out" });
+      return;
+    }
+
+    const controller = new AbortController();
+    setListState({ kind: "loading" });
+    void (async () => {
+      try {
+        const response = await fetchWithCloudPrototypeAuth(
+          "/api/n?limit=100",
+          { headers: { Accept: "application/json" }, signal: controller.signal },
+          authState,
+        );
+        if (controller.signal.aborted) return;
+        if (!response.ok) {
+          throw await cloudResponseError(response, "Unable to list notebooks");
+        }
+        const body = (await response.json()) as unknown;
+        if (!isCloudNotebookListResponse(body)) {
+          throw new Error("Unable to list notebooks: response shape was invalid");
+        }
+        setListState({ kind: "ready", notebooks: body.notebooks });
+      } catch (error) {
+        if (controller.signal.aborted) return;
+        setListState({
+          kind: "error",
+          message: error instanceof Error ? error.message : String(error),
+        });
+      }
+    })();
+
+    return () => {
+      controller.abort();
+    };
+  }, [authState, refreshIndex, signedIn]);
+
+  const refreshList = () => {
+    setRefreshIndex((value) => value + 1);
+  };
+
+  const signOut = () => {
+    clearCloudPrototypeDevAuth(window.localStorage);
+    refreshAuthState();
+  };
+
+  const headerDetail =
+    authState.mode === "oidc" || authState.mode === "dev"
+      ? (authState.user ?? "Signed in")
+      : authState.mode === "oidc_expired"
+        ? "Session expired"
+        : "Signed out";
+
+  return (
+    <main className="cloud-notebook-list-page">
+      <header className="cloud-notebook-list-header">
+        <div>
+          <a className="cloud-notebook-list-brand" href="/">
+            nteract
+          </a>
+          <h1>Notebooks</h1>
+          <p>{headerDetail}</p>
+        </div>
+        <div className="cloud-notebook-list-actions">
+          <button
+            type="button"
+            disabled={!signedIn || listState.kind === "loading"}
+            onClick={refreshList}
+          >
+            <RotateCcw aria-hidden="true" />
+            Refresh
+          </button>
+          <CloudNotebookSignInButton authConfig={authConfig} authState={authState} />
+          {signedIn ? (
+            <button type="button" onClick={signOut}>
+              <LogOut aria-hidden="true" />
+              Sign out
+            </button>
+          ) : null}
+        </div>
+      </header>
+
+      {authRenewal.kind !== "idle" ? (
+        <div
+          className="cloud-notebook-list-banner"
+          data-kind={authRenewal.kind === "failed" ? "error" : "info"}
+          role={authRenewal.kind === "failed" ? "alert" : "status"}
+        >
+          {authRenewal.message}
+        </div>
+      ) : null}
+
+      <section className="cloud-notebook-list-content" aria-label="Notebook list">
+        {listState.kind === "loading" ? (
+          <div className="cloud-notebook-list-state" data-kind="loading" role="status">
+            <Loader2 className="cloud-home-status-spinner" aria-hidden="true" />
+            <span>Loading notebooks</span>
+          </div>
+        ) : listState.kind === "signed_out" ? (
+          <div className="cloud-notebook-list-state" data-kind="signed-out">
+            <KeyRound aria-hidden="true" />
+            <span>Sign in to view notebooks.</span>
+          </div>
+        ) : listState.kind === "error" ? (
+          <div className="cloud-notebook-list-state" data-kind="error" role="alert">
+            <AlertCircle aria-hidden="true" />
+            <span>{listState.message}</span>
+          </div>
+        ) : listState.notebooks.length === 0 ? (
+          <div className="cloud-notebook-list-state" data-kind="empty">
+            <BookOpen aria-hidden="true" />
+            <span>No notebooks yet.</span>
+          </div>
+        ) : (
+          <ul className="cloud-notebook-list" aria-label="Notebook rooms">
+            {listState.notebooks.map((notebook) => (
+              <li key={notebook.notebook_id}>
+                <a className="cloud-notebook-list-row" href={notebook.viewer_url}>
+                  <span className="cloud-notebook-list-icon" aria-hidden="true">
+                    <BookOpen />
+                  </span>
+                  <span className="cloud-notebook-list-main">
+                    <span className="cloud-notebook-list-title">
+                      {notebook.title?.trim() || notebook.notebook_id}
+                    </span>
+                    <span className="cloud-notebook-list-id">{notebook.notebook_id}</span>
+                  </span>
+                  <span className="cloud-notebook-list-scope" data-scope={notebook.scope}>
+                    {formatNotebookScope(notebook.scope)}
+                  </span>
+                  <span className="cloud-notebook-list-updated">
+                    <Clock aria-hidden="true" />
+                    {formatNotebookUpdatedAt(notebook.updated_at)}
+                  </span>
+                  <ExternalLink className="cloud-notebook-list-open" aria-hidden="true" />
+                </a>
+              </li>
+            ))}
+          </ul>
+        )}
+      </section>
+    </main>
+  );
+}
+
+function isCloudNotebookListResponse(value: unknown): value is CloudNotebookListResponse {
+  if (!value || typeof value !== "object") {
+    return false;
+  }
+  const candidate = value as Record<string, unknown>;
+  return candidate.ok === true && Array.isArray(candidate.notebooks);
+}
+
+function formatNotebookScope(scope: CloudNotebookListItem["scope"]): string {
+  switch (scope) {
+    case "owner":
+      return "owner";
+    case "editor":
+      return "editor";
+    case "runtime_peer":
+      return "runtime";
+    case "viewer":
+      return "viewer";
+  }
+}
+
+function formatNotebookUpdatedAt(value: string): string {
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) {
+    return "unknown";
+  }
+  return new Intl.DateTimeFormat(undefined, {
+    dateStyle: "medium",
+    timeStyle: "short",
+  }).format(date);
 }
 
 function CloudHomeView({ authConfig }: { authConfig: CloudViewerAuthConfig }) {
@@ -452,7 +679,7 @@ function CloudHomeView({ authConfig }: { authConfig: CloudViewerAuthConfig }) {
           ) : null}
 
           <div className="cloud-home-actions">
-            <a href="/n/topic-viz/topic-viz">Open topic viz</a>
+            <a href="/n">View notebooks</a>
             {signedIn ? (
               <button
                 type="button"

--- a/apps/notebook-cloud/viewer/index.tsx
+++ b/apps/notebook-cloud/viewer/index.tsx
@@ -495,7 +495,9 @@ function CloudNotebookListView({ authConfig }: { authConfig: CloudViewerAuthConf
             <RotateCcw aria-hidden="true" />
             Refresh
           </button>
-          <CloudNotebookSignInButton authConfig={authConfig} authState={authState} />
+          {signedIn ? null : (
+            <CloudNotebookSignInButton authConfig={authConfig} authState={authState} />
+          )}
           {signedIn ? (
             <button type="button" onClick={signOut}>
               <LogOut aria-hidden="true" />


### PR DESCRIPTION
## Summary
- add authenticated `GET /api/n` for notebooks visible to the caller via principal ACLs
- include viewer URLs and API endpoint links for each listed notebook
- reuse canonical account ACL links so OIDC/API-key transports list the same account notebooks
- add `/n` as a lightweight cloud notebook listing page using the shared viewer/auth shell
- align notebook-cloud API-key test fixtures with the staging whoami URL

## Validation
- `pnpm --filter notebook-cloud exec node --import tsx --test test/worker-routes.test.ts`
- `pnpm --filter notebook-cloud typecheck`
- `pnpm --filter notebook-cloud run build:viewer`
- `cargo xtask lint --fix`
- deployed preview before the `/n` page commit: assets Worker `3f53f875-7712-49d6-b51c-3c95353e746f`, main Worker `d6e97664-81b4-4cc5-92f2-ecc0e6e31649`
- live smoke before the `/n` page commit: `GET https://preview.runt.run/api/n?limit=10` with `~/preview.runt.run/.env` API key returned `ok: true` and 10 owner notebooks
- live smoke before the `/n` page commit: anonymous `GET /api/n?viewer_session=anon-smoke` returned `401` / `sign in to list notebooks`

## Review
- `uv run pr-review https://github.com/nteract/nteract/pull/3465 --max-turns 120 --out .context/reviews/pr-3465.json` returned `infra_uncertain`: Bedrock credentials refreshed to expired credentials, so no second-model findings were available.
