### PR TITLE
test(notebook): trace local execution performance

### DIFF
--- a/apps/notebook/e2e/execution-performance.spec.ts
+++ b/apps/notebook/e2e/execution-performance.spec.ts
@@ -1,0 +1,81 @@
+import { expect, test } from "@playwright/test";
+import { writeFile } from "node:fs/promises";
+import {
+  enableExecutionPerformanceTracing,
+  ensureCodeCell,
+  executeCell,
+  getExecutionPerformanceSnapshot,
+  markExecutionPerformance,
+  openNotebookRoom,
+  resetExecutionPerformanceTracing,
+  setCellSource,
+  waitForKernelStatus,
+  waitForOutputContaining,
+  type ExecutionPerformanceSnapshot,
+  type ExecutionPerformanceTrace,
+} from "./helpers";
+
+function formatTrace(trace: ExecutionPerformanceTrace) {
+  const first = trace.marks[0]?.t ?? trace.startedAt;
+  return trace.marks.map((mark) => ({
+    phase: mark.name,
+    ms: Math.round((mark.t - first) * 10) / 10,
+    cellId: mark.cellId,
+    executionId: mark.executionId,
+    outputId: mark.outputId,
+    detail: mark.detail,
+  }));
+}
+
+function latestTrace(snapshot: ExecutionPerformanceSnapshot): ExecutionPerformanceTrace {
+  const trace = snapshot.traces.at(-1);
+  if (!trace) {
+    throw new Error(`No execution performance traces found: ${JSON.stringify(snapshot)}`);
+  }
+  return trace;
+}
+
+test.describe("browser execution performance tracing", () => {
+  test("captures local execute latency phases from click to visible output", async ({
+    page,
+  }, testInfo) => {
+    await enableExecutionPerformanceTracing(page);
+
+    const notebookId = crypto.randomUUID();
+    await openNotebookRoom(page, notebookId);
+    await waitForKernelStatus(page, "idle", 120_000);
+
+    const cell = await ensureCodeCell(page);
+    const marker = `execution performance ${crypto.randomUUID()}`;
+    await setCellSource(cell, `print(${JSON.stringify(marker)})`);
+
+    await resetExecutionPerformanceTracing(page);
+    await executeCell(cell);
+    await waitForOutputContaining(cell, marker, 60_000);
+    await markExecutionPerformance(page, "playwright.output.visible");
+
+    const snapshot = await getExecutionPerformanceSnapshot(page);
+    const trace = latestTrace(snapshot);
+    const formatted = formatTrace(trace);
+    const artifact = JSON.stringify({ notebookId, trace: formatted, snapshot }, null, 2);
+    const artifactPath = testInfo.outputPath("execution-performance.json");
+
+    await writeFile(artifactPath, artifact);
+    await testInfo.attach("execution-performance.json", {
+      path: artifactPath,
+      contentType: "application/json",
+    });
+    console.info(`[execution-performance]\n${JSON.stringify(formatted, null, 2)}`);
+
+    const phases = new Set(trace.marks.map((mark) => mark.name));
+    expect(phases).toContain("app.execute.invoke");
+    expect(phases).toContain("sync.required_heads.captured");
+    expect(phases).toContain("sync.flush.dispatched.start");
+    expect(phases).toContain("client.execute.request.start");
+    expect(phases).toContain("client.execute.response");
+    expect(phases).toContain("playwright.output.visible");
+
+    const response = trace.marks.find((mark) => mark.name === "client.execute.response");
+    expect(response?.detail?.result).toBe("cell_queued");
+  });
+});

--- a/apps/notebook/e2e/helpers.ts
+++ b/apps/notebook/e2e/helpers.ts
@@ -1,5 +1,28 @@
 import { expect, type Locator, type Page } from "@playwright/test";
 
+export interface ExecutionPerformanceMark {
+  name: string;
+  t: number;
+  traceId: string | null;
+  cellId?: string;
+  executionId?: string;
+  outputId?: string;
+  detail?: Record<string, unknown>;
+}
+
+export interface ExecutionPerformanceTrace {
+  traceId: string;
+  cellId: string;
+  startedAt: number;
+  marks: ExecutionPerformanceMark[];
+}
+
+export interface ExecutionPerformanceSnapshot {
+  enabled: boolean;
+  marks: ExecutionPerformanceMark[];
+  traces: ExecutionPerformanceTrace[];
+}
+
 export async function waitForNotebookReady(page: Page, path = "/") {
   await page.goto(path);
   await expect(page.getByTestId("notebook-toolbar")).toBeVisible({ timeout: 30_000 });
@@ -125,6 +148,66 @@ export async function waitForCodeCellContaining(page: Page, text: string, timeou
 
 export async function executeCell(cell: Locator) {
   await cell.getByTestId("execute-button").click();
+}
+
+export async function enableExecutionPerformanceTracing(page: Page) {
+  await page.addInitScript(() => {
+    (
+      window as unknown as { __NTERACT_EXECUTION_PERF_ENABLED?: boolean }
+    ).__NTERACT_EXECUTION_PERF_ENABLED = true;
+  });
+}
+
+export async function resetExecutionPerformanceTracing(page: Page) {
+  await page.evaluate(() => {
+    const api = (
+      window as unknown as {
+        __nteractExecutionPerf?: {
+          enable: () => void;
+          reset: () => void;
+        };
+      }
+    ).__nteractExecutionPerf;
+    api?.enable();
+    api?.reset();
+  });
+}
+
+export async function markExecutionPerformance(
+  page: Page,
+  name: string,
+  detail?: Record<string, unknown>,
+) {
+  await page.evaluate(
+    ({ markName, markDetail }) => {
+      (
+        window as unknown as {
+          __nteractExecutionPerf?: {
+            mark: (name: string, detail?: Record<string, unknown>) => void;
+          };
+        }
+      ).__nteractExecutionPerf?.mark(markName, markDetail);
+    },
+    { markName: name, markDetail: detail },
+  );
+}
+
+export async function getExecutionPerformanceSnapshot(
+  page: Page,
+): Promise<ExecutionPerformanceSnapshot> {
+  return await page.evaluate(() => {
+    const api = (
+      window as unknown as {
+        __nteractExecutionPerf?: {
+          snapshot: () => ExecutionPerformanceSnapshot;
+        };
+      }
+    ).__nteractExecutionPerf;
+    if (!api) {
+      return { enabled: false, marks: [], traces: [] };
+    }
+    return api.snapshot();
+  });
 }
 
 export async function waitForOutputContaining(cell: Locator, text: string, timeout = 60_000) {

--- a/apps/notebook/src/App.tsx
+++ b/apps/notebook/src/App.tsx
@@ -78,6 +78,12 @@ import { getTrustApprovalHandoffDisplayStatus, KERNEL_STATUS } from "./lib/kerne
 import { useNotebookActionPolicy } from "./lib/notebook-action-policy";
 import { useObservable } from "./lib/use-observable";
 import { logger } from "./lib/logger";
+import {
+  attachExecutionPerformanceId,
+  installExecutionPerformanceApi,
+  markExecutionPerformance,
+  startExecutionPerformanceTrace,
+} from "./lib/execution-performance";
 import { getNotebookCellsSnapshot } from "@/components/notebook/state/cell-store";
 import { useNotebookQueueProjection } from "@/components/notebook/state/execution-store";
 import { useNotebookViewModel } from "@/components/notebook/state/view-model-store";
@@ -545,8 +551,18 @@ function AppContent() {
     () =>
       new NotebookClient({
         transport: host.transport,
-        getRequiredHeads: () => getHandle()?.get_heads_hex() ?? [],
-        flushBeforeRequiredHeadsRequest: () => getEngine()?.flush(),
+        getRequiredHeads: () => {
+          const heads = getHandle()?.get_heads_hex() ?? [];
+          markExecutionPerformance("sync.required_heads.captured", {
+            headCount: heads.length,
+          });
+          return heads;
+        },
+        flushBeforeRequiredHeadsRequest: () => {
+          markExecutionPerformance("sync.flush.dispatched.start");
+          getEngine()?.flush();
+          markExecutionPerformance("sync.flush.dispatched.end");
+        },
       }),
     [host, getHandle, getEngine],
   );
@@ -578,6 +594,10 @@ function AppContent() {
 
   // Derive values from daemon kernel
   const envSource = kernelInfo.envSource ?? null;
+
+  useEffect(() => {
+    installExecutionPerformanceApi();
+  }, []);
 
   useEffect(() => {
     if (lifecycle.lifecycle !== "AwaitingEnvBuild") {
@@ -983,10 +1003,54 @@ function AppContent() {
     return undefined;
   }, [runtimeState.project_context]);
 
+  const executeCellWithPerf = useCallback(
+    async (cellId: string) => {
+      markExecutionPerformance("client.execute.request.start", { cellId });
+      const response = await executeCell(cellId);
+      if (response.result === "cell_queued") {
+        attachExecutionPerformanceId(cellId, response.execution_id);
+        markExecutionPerformance("client.execute.response", {
+          cellId,
+          executionId: response.execution_id,
+          result: response.result,
+        });
+      } else {
+        markExecutionPerformance("client.execute.response", {
+          cellId,
+          result: response.result,
+        });
+      }
+      return response;
+    },
+    [executeCell],
+  );
+
+  const executeCellGuardedWithPerf = useCallback(
+    async (cellId: string, provenance: Parameters<typeof executeCellGuarded>[1]) => {
+      markExecutionPerformance("client.execute_guarded.request.start", { cellId });
+      const response = await executeCellGuarded(cellId, provenance);
+      if (response.result === "cell_queued") {
+        attachExecutionPerformanceId(cellId, response.execution_id);
+        markExecutionPerformance("client.execute_guarded.response", {
+          cellId,
+          executionId: response.execution_id,
+          result: response.result,
+        });
+      } else {
+        markExecutionPerformance("client.execute_guarded.response", {
+          cellId,
+          result: response.result,
+        });
+      }
+      return response;
+    },
+    [executeCellGuarded],
+  );
+
   const {
     envBuildCreating,
     handleEnvBuildCreate,
-    handleExecuteCell,
+    handleExecuteCell: handleExecuteCellAction,
     handleRestartAndRunAll,
     handleRestartKernel,
     handleRunAllCells,
@@ -1020,8 +1084,8 @@ function AppContent() {
     checkTrust,
     approveTrust,
     launchKernel,
-    executeCell,
-    executeCellGuarded,
+    executeCell: executeCellWithPerf,
+    executeCellGuarded: executeCellGuardedWithPerf,
     shutdownKernel,
     syncEnvironment,
     approveProjectEnvironment,
@@ -1031,6 +1095,16 @@ function AppContent() {
     resetDismissedEnvBuildDetails,
     showEnvBuildDialog,
   });
+
+  const handleExecuteCell = useCallback(
+    (cellId: string) => {
+      startExecutionPerformanceTrace(cellId, { source: "NotebookView" });
+      void Promise.resolve(handleExecuteCellAction(cellId)).finally(() => {
+        markExecutionPerformance("app.execute.handler.settled", { cellId });
+      });
+    },
+    [handleExecuteCellAction],
+  );
 
   const handleEnvBuildDialogOpenChange = useCallback(
     (open: boolean) => {

--- a/apps/notebook/src/hooks/useDaemonKernel.ts
+++ b/apps/notebook/src/hooks/useDaemonKernel.ts
@@ -36,6 +36,7 @@ import {
   resetRuntimeState,
   useRuntimeState,
 } from "../lib/runtime-state";
+import { markExecutionPerformance } from "../lib/execution-performance";
 
 // ── Hook types ──────────────────────────────────────────────────────
 
@@ -168,6 +169,21 @@ export function useDaemonKernel({
       }
     }
     if (executingChanged || queuedChanged) {
+      const prevQueuedIds = new Set(prev.queued.map((entry) => entry.execution_id));
+      for (const entry of queueState.queued) {
+        if (!prevQueuedIds.has(entry.execution_id)) {
+          markExecutionPerformance("runtime.queue.queued", {
+            executionId: entry.execution_id,
+            cellId: getCellIdForExecutionId(entry.execution_id) ?? undefined,
+          });
+        }
+      }
+      if (executingChanged && queueState.executing) {
+        markExecutionPerformance("runtime.queue.executing", {
+          executionId: queueState.executing.execution_id,
+          cellId: getCellIdForExecutionId(queueState.executing.execution_id) ?? undefined,
+        });
+      }
       callbacksRef.current.onQueueChange?.(queueState);
     }
   }, [queueState]);
@@ -188,6 +204,11 @@ export function useDaemonKernel({
       const cellId = getCellIdForExecutionId(t.execution_id);
       if (!cellId) continue;
       if (t.kind === "started") {
+        markExecutionPerformance("runtime.execution.started", {
+          cellId,
+          executionId: t.execution_id,
+          executionCount: t.execution_count,
+        });
         // Only forward when the kernel has actually reported the count
         // (arrives via execute_input, after the queued→running transition).
         // Materialization reads execution_count from RuntimeState directly,
@@ -196,6 +217,11 @@ export function useDaemonKernel({
           callbacksRef.current.onExecutionCount(cellId, t.execution_count);
         }
       } else {
+        markExecutionPerformance(`runtime.execution.${t.kind}`, {
+          cellId,
+          executionId: t.execution_id,
+          executionCount: t.execution_count,
+        });
         callbacksRef.current.onExecutionDone(cellId);
       }
     }

--- a/apps/notebook/src/lib/execution-performance.ts
+++ b/apps/notebook/src/lib/execution-performance.ts
@@ -35,6 +35,9 @@ interface ExecutionPerformanceWindow extends Window {
 }
 
 const STORAGE_KEY = "nteract:execution-performance";
+const MAX_MARKS = 10_000;
+const MAX_TRACES = 50;
+const MAX_MARKS_PER_TRACE = 2_000;
 
 let sequence = 0;
 let marks: ExecutionPerformanceMark[] = [];
@@ -42,6 +45,7 @@ const traces = new Map<string, ExecutionPerformanceTrace>();
 const activeTraceByCellId = new Map<string, string>();
 const traceByExecutionId = new Map<string, string>();
 let latestTraceId: string | null = null;
+let enabledCache: boolean | null = null;
 
 function now(): number {
   return typeof performance !== "undefined" ? performance.now() : Date.now();
@@ -74,11 +78,13 @@ function setLocalStorageEnabled(win: ExecutionPerformanceWindow, enabled: boolea
 function isEnabled(): boolean {
   const win = getWindow();
   if (!win) return false;
-  return (
-    win.__NTERACT_EXECUTION_PERF_ENABLED === true ||
-    localStorageEnabled(win) ||
-    import.meta.env.VITE_E2E === "1"
-  );
+  if (win.__NTERACT_EXECUTION_PERF_ENABLED === true) {
+    enabledCache = true;
+    return true;
+  }
+  if (enabledCache !== null) return enabledCache;
+  enabledCache = localStorageEnabled(win);
+  return enabledCache;
 }
 
 function cloneMark(mark: ExecutionPerformanceMark): ExecutionPerformanceMark {
@@ -146,10 +152,42 @@ function appendMark(
 
   if (traceId) {
     const trace = traces.get(traceId);
-    if (trace) trace.marks.push(mark);
+    if (trace) {
+      trace.marks.push(mark);
+      pruneTraceMarks(trace);
+    }
   }
 
+  pruneGlobalMarks();
   return mark;
+}
+
+function pruneGlobalMarks(): void {
+  if (marks.length <= MAX_MARKS) return;
+  marks.splice(0, marks.length - MAX_MARKS);
+}
+
+function pruneTraceMarks(trace: ExecutionPerformanceTrace): void {
+  if (trace.marks.length <= MAX_MARKS_PER_TRACE) return;
+  trace.marks.splice(0, trace.marks.length - MAX_MARKS_PER_TRACE);
+}
+
+function pruneTraces(): void {
+  while (traces.size > MAX_TRACES) {
+    const oldestTraceId = traces.keys().next().value;
+    if (!oldestTraceId) return;
+    const oldestTrace = traces.get(oldestTraceId);
+    traces.delete(oldestTraceId);
+    if (oldestTrace) {
+      if (activeTraceByCellId.get(oldestTrace.cellId) === oldestTraceId) {
+        activeTraceByCellId.delete(oldestTrace.cellId);
+      }
+      for (const [executionId, traceId] of traceByExecutionId) {
+        if (traceId === oldestTraceId) traceByExecutionId.delete(executionId);
+      }
+    }
+    if (latestTraceId === oldestTraceId) latestTraceId = null;
+  }
 }
 
 export function installExecutionPerformanceApi(): void {
@@ -159,10 +197,12 @@ export function installExecutionPerformanceApi(): void {
   win.__nteractExecutionPerf = {
     enable() {
       win.__NTERACT_EXECUTION_PERF_ENABLED = true;
+      enabledCache = true;
       setLocalStorageEnabled(win, true);
     },
     disable() {
       win.__NTERACT_EXECUTION_PERF_ENABLED = false;
+      enabledCache = false;
       setLocalStorageEnabled(win, false);
     },
     reset() {
@@ -196,6 +236,7 @@ export function startExecutionPerformanceTrace(
   });
   activeTraceByCellId.set(cellId, traceId);
   latestTraceId = traceId;
+  pruneTraces();
   appendMark("app.execute.invoke", { ...detail, cellId, traceId });
   return traceId;
 }

--- a/apps/notebook/src/lib/execution-performance.ts
+++ b/apps/notebook/src/lib/execution-performance.ts
@@ -1,0 +1,216 @@
+export interface ExecutionPerformanceMark {
+  name: string;
+  t: number;
+  traceId: string | null;
+  cellId?: string;
+  executionId?: string;
+  outputId?: string;
+  detail?: Record<string, unknown>;
+}
+
+export interface ExecutionPerformanceTrace {
+  traceId: string;
+  cellId: string;
+  startedAt: number;
+  marks: ExecutionPerformanceMark[];
+}
+
+export interface ExecutionPerformanceSnapshot {
+  enabled: boolean;
+  marks: ExecutionPerformanceMark[];
+  traces: ExecutionPerformanceTrace[];
+}
+
+interface ExecutionPerformanceApi {
+  enable(): void;
+  disable(): void;
+  reset(): void;
+  snapshot(): ExecutionPerformanceSnapshot;
+  mark(name: string, detail?: Record<string, unknown>): void;
+}
+
+interface ExecutionPerformanceWindow extends Window {
+  __NTERACT_EXECUTION_PERF_ENABLED?: boolean;
+  __nteractExecutionPerf?: ExecutionPerformanceApi;
+}
+
+const STORAGE_KEY = "nteract:execution-performance";
+
+let sequence = 0;
+let marks: ExecutionPerformanceMark[] = [];
+const traces = new Map<string, ExecutionPerformanceTrace>();
+const activeTraceByCellId = new Map<string, string>();
+const traceByExecutionId = new Map<string, string>();
+let latestTraceId: string | null = null;
+
+function now(): number {
+  return typeof performance !== "undefined" ? performance.now() : Date.now();
+}
+
+function getWindow(): ExecutionPerformanceWindow | null {
+  return typeof window === "undefined" ? null : (window as ExecutionPerformanceWindow);
+}
+
+function localStorageEnabled(win: ExecutionPerformanceWindow): boolean {
+  try {
+    return win.localStorage?.getItem(STORAGE_KEY) === "1";
+  } catch {
+    return false;
+  }
+}
+
+function setLocalStorageEnabled(win: ExecutionPerformanceWindow, enabled: boolean): void {
+  try {
+    if (enabled) {
+      win.localStorage?.setItem(STORAGE_KEY, "1");
+    } else {
+      win.localStorage?.removeItem(STORAGE_KEY);
+    }
+  } catch {
+    // Storage can be unavailable in restricted contexts; the window flag is enough.
+  }
+}
+
+function isEnabled(): boolean {
+  const win = getWindow();
+  if (!win) return false;
+  return (
+    win.__NTERACT_EXECUTION_PERF_ENABLED === true ||
+    localStorageEnabled(win) ||
+    import.meta.env.VITE_E2E === "1"
+  );
+}
+
+function cloneMark(mark: ExecutionPerformanceMark): ExecutionPerformanceMark {
+  return {
+    ...mark,
+    detail: mark.detail ? { ...mark.detail } : undefined,
+  };
+}
+
+function buildSnapshot(): ExecutionPerformanceSnapshot {
+  const clonedMarks = marks.map(cloneMark);
+  return {
+    enabled: isEnabled(),
+    marks: clonedMarks,
+    traces: Array.from(traces.values()).map((trace) => ({
+      traceId: trace.traceId,
+      cellId: trace.cellId,
+      startedAt: trace.startedAt,
+      marks: trace.marks.map(cloneMark),
+    })),
+  };
+}
+
+function resolveTraceId(detail: Record<string, unknown> | undefined): string | null {
+  const explicit = detail?.traceId;
+  if (typeof explicit === "string") return explicit;
+
+  const executionId = detail?.executionId;
+  if (typeof executionId === "string") {
+    const traceId = traceByExecutionId.get(executionId);
+    if (traceId) return traceId;
+  }
+
+  const cellId = detail?.cellId;
+  if (typeof cellId === "string") {
+    const traceId = activeTraceByCellId.get(cellId);
+    if (traceId) return traceId;
+  }
+
+  return latestTraceId;
+}
+
+function appendMark(
+  name: string,
+  detail: Record<string, unknown> | undefined,
+): ExecutionPerformanceMark | null {
+  if (!isEnabled()) return null;
+  installExecutionPerformanceApi();
+
+  const traceId = resolveTraceId(detail);
+  const cellId = typeof detail?.cellId === "string" ? detail.cellId : undefined;
+  const executionId =
+    typeof detail?.executionId === "string" ? detail.executionId : undefined;
+  const outputId = typeof detail?.outputId === "string" ? detail.outputId : undefined;
+  const mark: ExecutionPerformanceMark = {
+    name,
+    t: now(),
+    traceId,
+    cellId,
+    executionId,
+    outputId,
+    detail,
+  };
+  marks.push(mark);
+
+  if (traceId) {
+    const trace = traces.get(traceId);
+    if (trace) trace.marks.push(mark);
+  }
+
+  return mark;
+}
+
+export function installExecutionPerformanceApi(): void {
+  const win = getWindow();
+  if (!win || win.__nteractExecutionPerf) return;
+
+  win.__nteractExecutionPerf = {
+    enable() {
+      win.__NTERACT_EXECUTION_PERF_ENABLED = true;
+      setLocalStorageEnabled(win, true);
+    },
+    disable() {
+      win.__NTERACT_EXECUTION_PERF_ENABLED = false;
+      setLocalStorageEnabled(win, false);
+    },
+    reset() {
+      marks = [];
+      traces.clear();
+      activeTraceByCellId.clear();
+      traceByExecutionId.clear();
+      latestTraceId = null;
+    },
+    snapshot: buildSnapshot,
+    mark(name: string, detail?: Record<string, unknown>) {
+      appendMark(name, detail);
+    },
+  };
+}
+
+export function startExecutionPerformanceTrace(
+  cellId: string,
+  detail: Record<string, unknown> = {},
+): string | null {
+  if (!isEnabled()) return null;
+  installExecutionPerformanceApi();
+
+  const traceId = `execute-${++sequence}`;
+  const startedAt = now();
+  traces.set(traceId, {
+    traceId,
+    cellId,
+    startedAt,
+    marks: [],
+  });
+  activeTraceByCellId.set(cellId, traceId);
+  latestTraceId = traceId;
+  appendMark("app.execute.invoke", { ...detail, cellId, traceId });
+  return traceId;
+}
+
+export function attachExecutionPerformanceId(cellId: string, executionId: string): void {
+  if (!isEnabled()) return;
+  const traceId = activeTraceByCellId.get(cellId) ?? latestTraceId;
+  if (!traceId) return;
+  traceByExecutionId.set(executionId, traceId);
+  appendMark("client.execute.execution_id", { cellId, executionId, traceId });
+}
+
+export function markExecutionPerformance(
+  name: string,
+  detail?: Record<string, unknown>,
+): void {
+  appendMark(name, detail);
+}

--- a/apps/notebook/src/lib/project-runtime-stores.ts
+++ b/apps/notebook/src/lib/project-runtime-stores.ts
@@ -38,6 +38,7 @@ import {
   resetNotebookOutputs,
   setOutput,
 } from "@/components/notebook/state/output-store";
+import { markExecutionPerformance } from "./execution-performance";
 
 export interface ApplyOutputChangesetOptions {
   /**
@@ -67,6 +68,11 @@ export function applyExecutionViewChangeset(
 
   for (const [execution_id, snapshot] of changeset.execution_upserts ?? []) {
     setExecution(execution_id, snapshot);
+    markExecutionPerformance(`runtime.execution.snapshot.${snapshot.status}`, {
+      executionId: execution_id,
+      outputCount: snapshot.output_ids.length,
+      executionCount: snapshot.execution_count,
+    });
   }
 
   const removedExecutionIds = changeset.removed_execution_ids ?? [];
@@ -174,6 +180,7 @@ export async function applyOutputChangeset(
     const sync = tryResolveSync(raw, blobResolver);
     if (sync) {
       setOutput(output_id, sync);
+      markExecutionPerformance("runtime.output.applied", { outputId: output_id });
       continue;
     }
     if (blobResolver === null) {
@@ -186,6 +193,7 @@ export async function applyOutputChangeset(
     try {
       const resolved = await resolveManifest(raw, blobResolver);
       setOutput(output_id, resolved);
+      markExecutionPerformance("runtime.output.applied", { outputId: output_id });
     } catch (err) {
       logger.warn(
         `[outputs-store] Failed to resolve output ${output_id}:`,

--- a/packages/runtimed/src/sync-engine.ts
+++ b/packages/runtimed/src/sync-engine.ts
@@ -246,9 +246,11 @@ export interface SyncEngineOptions {
   /**
    * Maximum time to wait for outbound sync frame delivery.
    *
-   * Cell execution calls flushAndWait() before sending ExecuteCell. Keeping
-   * this bounded prevents a stuck host transport from permanently consuming
-   * an execute click without ever sending the request.
+   * Save paths call flushAndWait(); execute paths normally fire a flush and
+   * attach the current notebook heads as `required_heads` so the daemon can
+   * wait until the document has caught up before it queues execution. Keeping
+   * this bounded prevents a stuck host transport from permanently blocking a
+   * caller that does need a delivery acknowledgement.
    */
   flushDeliveryTimeoutMs?: number;
 }


### PR DESCRIPTION
## Summary
- add a gated browser execution-performance trace API for local notebook execution
- mark phases across execute invocation, required-head capture, sync flush dispatch, daemon response, runtime-state projection, output projection, and visible output
- add a Playwright/dev-daemon/Vite E2E harness that writes and attaches `execution-performance.json` without enforcing fragile duration thresholds
- update the SyncEngine flush timeout comment to describe the current execute model (`required_heads` gate rather than `flushAndWait`)

## First measurement
Latest local E2E run on lab2 measured a trivial hot Python execution at about 272ms from execute invocation to Playwright-observed visible output. In that run: required-head capture + flush dispatch completed around 1ms, `cell_queued` response returned around 107ms, output projection landed around 153ms, and done projection around 198ms.

## Validation
- `pnpm --filter notebook-ui exec tsc -b --pretty false`
- `pnpm --filter notebook-ui test:e2e:browser -- --project=chromium execution-performance.spec.ts`
- `cargo xtask lint --fix`

Note: the E2E wrapper intentionally SIGTERMs the Vite dev process after Playwright exits; pnpm logs that dev script SIGTERM even though the wrapper command exits 0 and the test passes.