### PR TITLE
perf(notebook): tighten execution projection timing

### DIFF
--- a/apps/notebook/e2e/execution-performance.spec.ts
+++ b/apps/notebook/e2e/execution-performance.spec.ts
@@ -15,6 +15,16 @@ import {
   type ExecutionPerformanceTrace,
 } from "./helpers";
 
+const REQUIRED_TRACE_PHASES = [
+  "app.execute.invoke",
+  "sync.required_heads.captured",
+  "sync.flush.dispatched.start",
+  "client.execute.request.start",
+  "client.execute.response",
+  "react.outputs.committed",
+  "playwright.output.visible",
+];
+
 function formatTrace(trace: ExecutionPerformanceTrace) {
   const first = trace.marks[0]?.t ?? trace.startedAt;
   return trace.marks.map((mark) => ({
@@ -27,18 +37,38 @@ function formatTrace(trace: ExecutionPerformanceTrace) {
   }));
 }
 
-function latestTrace(snapshot: ExecutionPerformanceSnapshot): ExecutionPerformanceTrace {
-  const trace = snapshot.traces.at(-1);
-  if (!trace) {
+function executionTraces(snapshot: ExecutionPerformanceSnapshot): ExecutionPerformanceTrace[] {
+  const traces = snapshot.traces.filter((trace) =>
+    trace.marks.some((mark) => mark.name === "client.execute.request.start"),
+  );
+  if (traces.length === 0) {
     throw new Error(`No execution performance traces found: ${JSON.stringify(snapshot)}`);
   }
-  return trace;
+  return traces;
+}
+
+function phaseOffset(trace: ExecutionPerformanceTrace, phase: string): number | null {
+  const first = trace.marks[0]?.t ?? trace.startedAt;
+  const mark = trace.marks.find((candidate) => candidate.name === phase);
+  return mark ? Math.round((mark.t - first) * 10) / 10 : null;
+}
+
+function summarizeTrace(trace: ExecutionPerformanceTrace, iteration: number) {
+  return {
+    iteration,
+    traceId: trace.traceId,
+    executionId: trace.marks.find((mark) => mark.executionId)?.executionId ?? null,
+    requestMs: phaseOffset(trace, "client.execute.request.start"),
+    responseMs: phaseOffset(trace, "client.execute.response"),
+    outputAppliedMs: phaseOffset(trace, "runtime.output.applied"),
+    reactOutputCommittedMs: phaseOffset(trace, "react.outputs.committed"),
+    visibleMs: phaseOffset(trace, "playwright.output.visible"),
+    doneMs: phaseOffset(trace, "runtime.execution.snapshot.done"),
+  };
 }
 
 test.describe("browser execution performance tracing", () => {
-  test("captures local execute latency phases from click to visible output", async ({
-    page,
-  }, testInfo) => {
+  test("captures local execute latency phases across warm runs", async ({ page }, testInfo) => {
     await enableExecutionPerformanceTracing(page);
 
     const notebookId = crypto.randomUUID();
@@ -46,18 +76,28 @@ test.describe("browser execution performance tracing", () => {
     await waitForKernelStatus(page, "idle", 120_000);
 
     const cell = await ensureCodeCell(page);
-    const marker = `execution performance ${crypto.randomUUID()}`;
-    await setCellSource(cell, `print(${JSON.stringify(marker)})`);
 
     await resetExecutionPerformanceTracing(page);
-    await executeCell(cell);
-    await waitForOutputContaining(cell, marker, 60_000);
-    await markExecutionPerformance(page, "playwright.output.visible");
+    const markers: string[] = [];
+    for (let iteration = 0; iteration < 3; iteration += 1) {
+      const marker = `execution performance ${iteration} ${crypto.randomUUID()}`;
+      markers.push(marker);
+      await setCellSource(cell, `print(${JSON.stringify(marker)})`);
+      await executeCell(cell);
+      await waitForOutputContaining(cell, marker, 60_000);
+      await markExecutionPerformance(page, "playwright.output.visible", { iteration });
+      await waitForKernelStatus(page, "idle", 60_000);
+    }
 
     const snapshot = await getExecutionPerformanceSnapshot(page);
-    const trace = latestTrace(snapshot);
-    const formatted = formatTrace(trace);
-    const artifact = JSON.stringify({ notebookId, trace: formatted, snapshot }, null, 2);
+    const traces = executionTraces(snapshot).slice(-markers.length);
+    expect(traces).toHaveLength(markers.length);
+
+    const formatted = traces.map((trace, iteration) => ({
+      summary: summarizeTrace(trace, iteration),
+      trace: formatTrace(trace),
+    }));
+    const artifact = JSON.stringify({ notebookId, markers, traces: formatted, snapshot }, null, 2);
     const artifactPath = testInfo.outputPath("execution-performance.json");
 
     await writeFile(artifactPath, artifact);
@@ -67,15 +107,19 @@ test.describe("browser execution performance tracing", () => {
     });
     console.info(`[execution-performance]\n${JSON.stringify(formatted, null, 2)}`);
 
-    const phases = new Set(trace.marks.map((mark) => mark.name));
-    expect(phases).toContain("app.execute.invoke");
-    expect(phases).toContain("sync.required_heads.captured");
-    expect(phases).toContain("sync.flush.dispatched.start");
-    expect(phases).toContain("client.execute.request.start");
-    expect(phases).toContain("client.execute.response");
-    expect(phases).toContain("playwright.output.visible");
+    for (const trace of traces) {
+      const phases = new Set(trace.marks.map((mark) => mark.name));
+      for (const phase of REQUIRED_TRACE_PHASES) {
+        expect(phases).toContain(phase);
+      }
 
-    const response = trace.marks.find((mark) => mark.name === "client.execute.response");
-    expect(response?.detail?.result).toBe("cell_queued");
+      const request = trace.marks.find((mark) => mark.name === "client.execute.request.start");
+      expect(request?.executionId).toEqual(expect.any(String));
+      expect(request?.detail?.clientGeneratedExecutionId).toBe(true);
+
+      const response = trace.marks.find((mark) => mark.name === "client.execute.response");
+      expect(response?.detail?.result).toBe("cell_queued");
+      expect(response?.executionId).toBe(request?.executionId);
+    }
   });
 });

--- a/apps/notebook/src/App.tsx
+++ b/apps/notebook/src/App.tsx
@@ -5,6 +5,8 @@ import {
   notebookCellAnchorId,
   resolveNotebookOutlineSelection,
   NotebookClient,
+  type ExecuteCellOptions,
+  type NotebookResponse,
   type NotebookOutlineItem,
   putBlob,
   type SessionStatus,
@@ -153,6 +155,36 @@ async function sendMessage(message: unknown): Promise<void> {
   } catch (e) {
     logger.error("[widget] send_comm_message failed:", e);
   }
+}
+
+function createClientExecutionId(): string {
+  return globalThis.crypto.randomUUID();
+}
+
+function markClientExecuteResponse(
+  phase: string,
+  cellId: string,
+  response: NotebookResponse,
+  detail: Record<string, unknown> = {},
+  alreadyAttachedExecutionId?: string,
+): void {
+  const responseDetail: Record<string, unknown> = {
+    cellId,
+    result: response.result,
+    ...detail,
+  };
+
+  if (response.result === "cell_queued") {
+    responseDetail.executionId = response.execution_id;
+    if (response.execution_id !== alreadyAttachedExecutionId) {
+      attachExecutionPerformanceId(cellId, response.execution_id);
+    }
+  } else if (response.result === "execution_id_rejected") {
+    responseDetail.executionId = response.execution_id;
+    responseDetail.reason = response.reason;
+  }
+
+  markExecutionPerformance(phase, responseDetail);
 }
 
 // ── Output widget manifest resolution ─────────────────────────────────
@@ -1005,19 +1037,37 @@ function AppContent() {
 
   const executeCellWithPerf = useCallback(
     async (cellId: string) => {
-      markExecutionPerformance("client.execute.request.start", { cellId });
-      const response = await executeCell(cellId);
-      if (response.result === "cell_queued") {
-        attachExecutionPerformanceId(cellId, response.execution_id);
-        markExecutionPerformance("client.execute.response", {
+      const executionId = createClientExecutionId();
+      const options: ExecuteCellOptions = { executionId };
+      markExecutionPerformance("client.execute.request.start", {
+        cellId,
+        executionId,
+        clientGeneratedExecutionId: true,
+      });
+      attachExecutionPerformanceId(cellId, executionId);
+
+      let response = await executeCell(cellId, options);
+      markClientExecuteResponse(
+        "client.execute.response",
+        cellId,
+        response,
+        { clientGeneratedExecutionId: true },
+        executionId,
+      );
+
+      if (response.result === "execution_id_rejected") {
+        logger.warn(
+          "[App] client-generated execution_id rejected; retrying with daemon-generated id",
+          response.reason,
+        );
+        markExecutionPerformance("client.execute.retry_without_execution_id", {
           cellId,
-          executionId: response.execution_id,
-          result: response.result,
+          executionId,
+          reason: response.reason,
         });
-      } else {
-        markExecutionPerformance("client.execute.response", {
-          cellId,
-          result: response.result,
+        response = await executeCell(cellId);
+        markClientExecuteResponse("client.execute.retry_response", cellId, response, {
+          retryWithoutClientExecutionId: true,
         });
       }
       return response;
@@ -1027,19 +1077,37 @@ function AppContent() {
 
   const executeCellGuardedWithPerf = useCallback(
     async (cellId: string, provenance: Parameters<typeof executeCellGuarded>[1]) => {
-      markExecutionPerformance("client.execute_guarded.request.start", { cellId });
-      const response = await executeCellGuarded(cellId, provenance);
-      if (response.result === "cell_queued") {
-        attachExecutionPerformanceId(cellId, response.execution_id);
-        markExecutionPerformance("client.execute_guarded.response", {
+      const executionId = createClientExecutionId();
+      const options: ExecuteCellOptions = { executionId };
+      markExecutionPerformance("client.execute_guarded.request.start", {
+        cellId,
+        executionId,
+        clientGeneratedExecutionId: true,
+      });
+      attachExecutionPerformanceId(cellId, executionId);
+
+      let response = await executeCellGuarded(cellId, provenance, options);
+      markClientExecuteResponse(
+        "client.execute_guarded.response",
+        cellId,
+        response,
+        { clientGeneratedExecutionId: true },
+        executionId,
+      );
+
+      if (response.result === "execution_id_rejected") {
+        logger.warn(
+          "[App] client-generated guarded execution_id rejected; retrying with daemon-generated id",
+          response.reason,
+        );
+        markExecutionPerformance("client.execute_guarded.retry_without_execution_id", {
           cellId,
-          executionId: response.execution_id,
-          result: response.result,
+          executionId,
+          reason: response.reason,
         });
-      } else {
-        markExecutionPerformance("client.execute_guarded.response", {
-          cellId,
-          result: response.result,
+        response = await executeCellGuarded(cellId, provenance);
+        markClientExecuteResponse("client.execute_guarded.retry_response", cellId, response, {
+          retryWithoutClientExecutionId: true,
         });
       }
       return response;

--- a/apps/notebook/src/components/CodeCell.tsx
+++ b/apps/notebook/src/components/CodeCell.tsx
@@ -30,6 +30,7 @@ import {
 } from "@/components/notebook/state/cell-ui-state";
 import { onEditorRegistered, onEditorUnregistered } from "../lib/cursor-registry";
 import { registerCellEditor, unregisterCellEditor } from "../lib/editor-registry";
+import { markExecutionPerformance } from "../lib/execution-performance";
 import { kernelCompletionExtension } from "../lib/kernel-completion";
 import {
   getCellIdForExecutionId,
@@ -365,6 +366,7 @@ export const CodeCell = memo(function CodeCell({
   const outputs = useCellOutputs(cell.id);
   const executionId = useCellExecutionId(cell.id);
   const execution = useExecution(executionId);
+  const previousOutputCountRef = useRef(outputs.length);
   const executionCount = execution?.execution_count ?? null;
   const submittedByActorLabel = execution?.submitted_by_actor_label ?? null;
   const isExecutionErrored = execution?.success === false || execution?.status === "error";
@@ -406,6 +408,20 @@ export const CodeCell = memo(function CodeCell({
       }
     }
   }, [isOutputsHidden, onOutputFocusChange, outputFocused, outputs.length, showOutputChrome]);
+
+  useEffect(() => {
+    const previousOutputCount = previousOutputCountRef.current;
+    previousOutputCountRef.current = outputs.length;
+    if (outputs.length <= previousOutputCount) return;
+
+    const latestOutput = outputs[outputs.length - 1];
+    markExecutionPerformance("react.outputs.committed", {
+      cellId: cell.id,
+      executionId: executionId ?? undefined,
+      outputCount: outputs.length,
+      outputId: latestOutput?.output_id,
+    });
+  }, [cell.id, executionId, outputs]);
 
   // Register EditorView with the cursor registry for remote cursor rendering.
   // We use a ref + polling approach because the EditorView is created async

--- a/apps/notebook/src/hooks/useDaemonKernel.ts
+++ b/apps/notebook/src/hooks/useDaemonKernel.ts
@@ -14,6 +14,7 @@ import {
   deriveEnvSyncState,
   deriveKernelInfo,
   deriveQueueState,
+  type ExecuteCellOptions,
   type GuardedNotebookProvenance,
   type KernelStatus,
   type NotebookClient,
@@ -290,13 +291,14 @@ export function useDaemonKernel({
   );
 
   const executeCell = useCallback(
-    (cellId: string) => client.executeCell(cellId) as Promise<NotebookResponse>,
+    (cellId: string, options?: ExecuteCellOptions) =>
+      client.executeCell(cellId, options) as Promise<NotebookResponse>,
     [client],
   );
 
   const executeCellGuarded = useCallback(
-    (cellId: string, provenance: GuardedNotebookProvenance) =>
-      client.executeCellGuarded(cellId, provenance) as Promise<NotebookResponse>,
+    (cellId: string, provenance: GuardedNotebookProvenance, options?: ExecuteCellOptions) =>
+      client.executeCellGuarded(cellId, provenance, options) as Promise<NotebookResponse>,
     [client],
   );
 

--- a/packages/runtimed/src/sync-engine.ts
+++ b/packages/runtimed/src/sync-engine.ts
@@ -687,23 +687,13 @@ export class SyncEngine {
               );
 
               this._runtimeState$.next(state);
+              // Publish output payloads before execution view pointers so a
+              // cell render that follows a new output_id can read the payload
+              // from the output store on its first pass.
+              this.emitOutputIdChanges(e.output_changeset);
               this.emitExecutionViewChanges(e.execution_view_changeset);
               if (transitions.length > 0) {
                 this._executionTransitions$.next(transitions);
-              }
-
-              // Per-output-id projection. Feeds the outputs store so single
-              // output appends only notify their own `<Output>` subscriber.
-              // Manifests arrive already narrowed from WASM — the store
-              // writes them in directly.
-              const changeset = e.output_changeset;
-              const changedPairs = changeset?.changed ?? [];
-              const removedOutputIds = changeset?.removed ?? [];
-              if (changedPairs.length > 0 || removedOutputIds.length > 0) {
-                this._outputIdChanges$.next({
-                  changed: changedPairs,
-                  removed_ids: removedOutputIds,
-                });
               }
 
               // ── Comm state projection ──────────────────────────────
@@ -1034,6 +1024,13 @@ export class SyncEngine {
     const removals = changeset.removed_execution_ids?.length ?? 0;
     if (cellChanges === 0 && upserts === 0 && removals === 0 && !changeset.queue) return;
     this._executionViewChanges$.next(changeset);
+  }
+
+  private emitOutputIdChanges(changeset: FrameEvent["output_changeset"] | undefined): void {
+    const changed = changeset?.changed ?? [];
+    const removed_ids = changeset?.removed ?? [];
+    if (changed.length === 0 && removed_ids.length === 0) return;
+    this._outputIdChanges$.next({ changed, removed_ids });
   }
 
   // ── Outbound sync ────────────────────────────────────────────────

--- a/packages/runtimed/tests/notebook-client.test.ts
+++ b/packages/runtimed/tests/notebook-client.test.ts
@@ -103,6 +103,37 @@ describe("NotebookClient", () => {
     );
   });
 
+  it("passes caller-provided execution ids on daemon-managed execute requests", async () => {
+    const { client, flush, sendRequest } = stubClientWithHeads(["head-a"]);
+    const executionId = "11111111-1111-4111-8111-111111111111";
+
+    await client.executeCell("cell-1", { executionId });
+
+    expect(flush).toHaveBeenCalledOnce();
+    expect(sendRequest).toHaveBeenCalledWith(
+      { type: "execute_cell", cell_id: "cell-1", execution_id: executionId },
+      { required_heads: ["head-a"] },
+    );
+  });
+
+  it("passes caller-provided execution ids on guarded execute requests", async () => {
+    const { client, sendRequest } = stubClient();
+    const executionId = "22222222-2222-4222-8222-222222222222";
+
+    await client.executeCellGuarded(
+      "cell-1",
+      { observed_heads: ["head-a", "head-b"] },
+      { executionId },
+    );
+
+    expect(sendRequest).toHaveBeenCalledWith({
+      type: "execute_cell_guarded",
+      cell_id: "cell-1",
+      execution_id: executionId,
+      observed_heads: ["head-a", "head-b"],
+    });
+  });
+
   it("attaches required heads to daemon-managed run-all requests", async () => {
     const { client, flush, sendRequest } = stubClientWithHeads(["head-a", "head-b"]);
 

--- a/packages/runtimed/tests/sync-engine.test.ts
+++ b/packages/runtimed/tests/sync-engine.test.ts
@@ -80,12 +80,14 @@ function presenceEvent(payload: unknown): FrameEvent {
 function runtimeStateSyncEvent(
   state: RuntimeState,
   executionViewChangeset?: FrameEvent["execution_view_changeset"],
+  outputChangeset?: FrameEvent["output_changeset"],
 ): FrameEvent {
   return {
     type: "runtime_state_sync_applied",
     changed: true,
     state,
     execution_view_changeset: executionViewChangeset,
+    output_changeset: outputChangeset,
   };
 }
 
@@ -916,6 +918,61 @@ describe("SyncEngine", () => {
           },
         },
       ]);
+      engine.stop();
+    });
+
+    it("emits output payload changes before runtime execution view changes", () => {
+      const state = makeRuntimeState({
+        "exec-1": { status: "running", execution_count: 1, success: null },
+      });
+      const executionChanges: NonNullable<FrameEvent["execution_view_changeset"]> = {
+        execution_upserts: [
+          [
+            "exec-1",
+            {
+              execution_count: 1,
+              status: "running",
+              success: null,
+              output_ids: ["out-1"],
+            },
+          ],
+        ],
+        cell_pointer_changes: [["cell-1", "exec-1"]],
+      };
+      const outputChanges: NonNullable<FrameEvent["output_changeset"]> = {
+        changed: [["out-1", { output_type: "stream", name: "stdout", text: "ready" }]],
+        removed: [],
+      };
+      (handle.receive_frame as ReturnType<typeof vi.fn>).mockReturnValue([
+        runtimeStateSyncEvent(state, executionChanges, outputChanges),
+      ]);
+
+      const engine = createEngine();
+      engine.start();
+
+      const order: string[] = [];
+      const receivedOutputs: Array<{ changed: Array<[string, unknown]>; removed_ids: string[] }> =
+        [];
+      const receivedExecutions: NonNullable<FrameEvent["execution_view_changeset"]>[] = [];
+      engine.outputIdChanges$.subscribe((changeset) => {
+        order.push("outputs");
+        receivedOutputs.push(changeset);
+      });
+      engine.executionViewChanges$.subscribe((changeset) => {
+        order.push("execution");
+        receivedExecutions.push(changeset);
+      });
+
+      transport.deliver(Array.from([0x05, 1]));
+
+      expect(order).toEqual(["outputs", "execution"]);
+      expect(receivedOutputs).toEqual([
+        {
+          changed: outputChanges.changed,
+          removed_ids: [],
+        },
+      ]);
+      expect(receivedExecutions).toEqual([executionChanges]);
       engine.stop();
     });
 


### PR DESCRIPTION
## Summary
- stack on #3467 to let the frontend propose execution UUIDs while the daemon still validates/rejects them
- add a React output commit mark and expand the browser perf spec to three warm executions
- emit output-id payload changes before execution-view pointer changes so cells can render newly referenced outputs on the first pass

## Notes
This PR is intentionally stacked on #3467 (`qu/lab2/local-execution-perf`). Since that parent branch is on the fork, this draft PR targets `main`; the incremental commit is `834026fc`.

## Verification
- `pnpm test:run packages/runtimed/tests/sync-engine.test.ts packages/runtimed/tests/notebook-client.test.ts`
- `pnpm --filter notebook-ui exec tsc -b --pretty false`
- `pnpm --filter notebook-ui test:e2e:browser -- --project=chromium execution-performance.spec.ts`
- `cargo xtask lint --fix`

## Perf sample
Latest warm browser run, iteration 2: request 0.1ms, response 33.5ms, output applied 92.2ms, React output commit 98.0ms, Playwright visible 138.5ms.