### PR TITLE
feat(notebook): polish workstation compute projections

### DIFF
--- a/apps/notebook-cloud/README.md
+++ b/apps/notebook-cloud/README.md
@@ -588,6 +588,29 @@ old `--timeout` flag in smoke scripts. Rooms created with the API-key path are
 private; anonymous hosted render smokes may return a catalog 404 unless the
 browser context has a credential for the owning principal.
 
+To exercise the actual hosted browser execution path against a private room,
+seed Chromium with the same OIDC token cache the viewer stores in
+`localStorage` and click a rendered cell run button:
+
+```bash
+NOTEBOOK_CLOUD_BROWSER_EXECUTE_BUTTON_INDEX=1 \
+NOTEBOOK_CLOUD_BROWSER_EXECUTE_EXPECTED_TEXT=blob-line-1499 \
+NOTEBOOK_CLOUD_BROWSER_EXECUTE_REQUIRE_BLOB_IMAGE=1 \
+pnpm --dir apps/notebook-cloud smoke:hosted:browser-execute \
+  https://preview.runt.run/n/<id>/<vanity-name>
+```
+
+The smoke reads the token JSON from
+`${NTERACT_PREVIEW_OIDC_TOKEN_PATH:-$HOME/token.preview.json}` and writes no
+token material to stdout. It injects the cache only into the first-party
+notebook origin, requests `owner` scope by default, clicks the selected
+`data-testid="execute-button"`, waits for the optional expected text, and
+asserts that notebook blob fetches return 2xx. When
+`NOTEBOOK_CLOUD_BROWSER_EXECUTE_REQUIRE_BLOB_IMAGE=1`, at least one notebook
+blob must also render as a normal `<img src="/api/n/.../blobs/:hash">` image.
+Use `NOTEBOOK_CLOUD_BROWSER_EXECUTE_SCOPE=editor` when verifying editor execute
+permissions.
+
 Snapshot and blob stubs:
 
 ```bash

--- a/apps/notebook-cloud/package.json
+++ b/apps/notebook-cloud/package.json
@@ -21,6 +21,7 @@
     "smoke:hosted": "node scripts/hosted-render-smoke.mjs",
     "smoke:hosted:live": "node scripts/hosted-live-smoke.mjs",
     "smoke:hosted:runtime-peer": "node scripts/hosted-runtime-peer-smoke.mjs",
+    "smoke:hosted:browser-execute": "node scripts/hosted-browser-execute-smoke.mjs",
     "smoke:hosted:collab": "node --import tsx scripts/hosted-collab-smoke.mjs",
     "smoke:hosted:install": "playwright install chromium",
     "smoke:hosted:source-room": "node scripts/hosted-source-room-smoke.mjs",

--- a/apps/notebook-cloud/scripts/hosted-browser-execute-smoke.mjs
+++ b/apps/notebook-cloud/scripts/hosted-browser-execute-smoke.mjs
@@ -105,6 +105,7 @@ async function main() {
       events.blobResponses.push({
         url: safeDiagnosticUrl(responseUrl),
         status: response.status(),
+        contentType: response.headers().get("content-type"),
       });
     }
   });
@@ -152,7 +153,10 @@ async function main() {
 
   const failedBlobResponses = events.blobResponses.filter((response) => response.status >= 400);
   const failedBlobImages = after.images.filter(
-    (image) => isNotebookBlobUrl(image.src) && (!image.complete || image.naturalWidth <= 0),
+    (image) => isBlobBackedImageSource(image.src) && !isLoadedImage(image),
+  );
+  const loadedBlobBackedImages = after.images.filter(
+    (image) => isBlobBackedImageSource(image.src) && isLoadedImage(image),
   );
   if (events.pageErrors.length > 0) {
     throw new Error(`browser page errors:\n${events.pageErrors.join("\n")}`);
@@ -166,7 +170,10 @@ async function main() {
   if (failedBlobResponses.length > 0) {
     throw new Error(`blob fetch failures:\n${JSON.stringify(failedBlobResponses, null, 2)}`);
   }
-  if (requireBlobImage && !after.images.some((image) => isNotebookBlobUrl(image.src))) {
+  if (requireBlobImage && events.blobResponses.length === 0) {
+    throw new Error("expected at least one authenticated blob fetch");
+  }
+  if (requireBlobImage && loadedBlobBackedImages.length === 0) {
     throw new Error("expected at least one rendered notebook blob image");
   }
   if (failedBlobImages.length > 0) {
@@ -193,9 +200,7 @@ async function main() {
           "execute_button_rendered",
           "execute_button_clicked",
           ...(expectedText ? ["expected_text_observed_after_click"] : []),
-          ...(after.images.some((image) => isNotebookBlobUrl(image.src))
-            ? ["blob_image_loaded_from_img_src"]
-            : []),
+          ...(loadedBlobBackedImages.length > 0 ? ["blob_backed_image_loaded_from_img_src"] : []),
           ...(events.blobResponses.length > 0 ? ["blob_fetches_returned_ok"] : []),
         ],
         before,
@@ -282,6 +287,14 @@ function safeDiagnosticUrl(value) {
 
 function isNotebookBlobUrl(value) {
   return /\/api\/n\/[^/]+\/blobs\//.test(value);
+}
+
+function isBlobBackedImageSource(value) {
+  return isNotebookBlobUrl(value) || /^blob:|^data:image\//i.test(value);
+}
+
+function isLoadedImage(image) {
+  return image.complete && image.naturalWidth > 0 && image.naturalHeight > 0;
 }
 
 function assertScope(scope) {

--- a/apps/notebook-cloud/scripts/hosted-browser-execute-smoke.mjs
+++ b/apps/notebook-cloud/scripts/hosted-browser-execute-smoke.mjs
@@ -105,7 +105,7 @@ async function main() {
       events.blobResponses.push({
         url: safeDiagnosticUrl(responseUrl),
         status: response.status(),
-        contentType: response.headers().get("content-type"),
+        contentType: response.headers()["content-type"] ?? null,
       });
     }
   });

--- a/apps/notebook-cloud/scripts/hosted-browser-execute-smoke.mjs
+++ b/apps/notebook-cloud/scripts/hosted-browser-execute-smoke.mjs
@@ -1,0 +1,309 @@
+import { readFile } from "node:fs/promises";
+import os from "node:os";
+
+import { chromium } from "@playwright/test";
+
+const viewerUrl =
+  process.argv[2] ??
+  process.env.NOTEBOOK_CLOUD_BROWSER_EXECUTE_VIEWER_URL ??
+  process.env.NOTEBOOK_CLOUD_HOSTED_URL;
+const tokenPath =
+  process.env.NTERACT_PREVIEW_OIDC_TOKEN_PATH ??
+  process.env.NOTEBOOK_CLOUD_OIDC_TOKEN_PATH ??
+  `${os.homedir()}/token.preview.json`;
+const requestedScope = process.env.NOTEBOOK_CLOUD_BROWSER_EXECUTE_SCOPE ?? "owner";
+const executeButtonIndex = parseNonNegativeInteger(
+  process.env.NOTEBOOK_CLOUD_BROWSER_EXECUTE_BUTTON_INDEX,
+  "NOTEBOOK_CLOUD_BROWSER_EXECUTE_BUTTON_INDEX",
+  0,
+);
+const timeoutMs = parsePositiveInteger(
+  process.env.NOTEBOOK_CLOUD_BROWSER_EXECUTE_TIMEOUT_MS,
+  "NOTEBOOK_CLOUD_BROWSER_EXECUTE_TIMEOUT_MS",
+  45_000,
+);
+const settleMs = parsePositiveInteger(
+  process.env.NOTEBOOK_CLOUD_BROWSER_EXECUTE_SETTLE_MS,
+  "NOTEBOOK_CLOUD_BROWSER_EXECUTE_SETTLE_MS",
+  6_000,
+);
+const expectedText = process.env.NOTEBOOK_CLOUD_BROWSER_EXECUTE_EXPECTED_TEXT;
+const requireBlobImage = process.env.NOTEBOOK_CLOUD_BROWSER_EXECUTE_REQUIRE_BLOB_IMAGE === "1";
+const allowFailedRequests =
+  process.env.NOTEBOOK_CLOUD_BROWSER_EXECUTE_ALLOW_FAILED_REQUESTS === "1";
+const screenshotPath = process.env.NOTEBOOK_CLOUD_BROWSER_EXECUTE_SCREENSHOT;
+
+main().catch((error) => {
+  console.error(error instanceof Error ? error.message : String(error));
+  process.exitCode = 1;
+});
+
+async function main() {
+  if (!viewerUrl) {
+    throw new Error(
+      "Pass a viewer URL or set NOTEBOOK_CLOUD_BROWSER_EXECUTE_VIEWER_URL / NOTEBOOK_CLOUD_HOSTED_URL",
+    );
+  }
+  assertScope(requestedScope);
+
+  const url = new URL(viewerUrl);
+  const tokenStorageJson = await readOidcTokenStorageJson(tokenPath);
+  const token = JSON.parse(tokenStorageJson);
+  const tokenSecondsRemaining = Number(token.expiresAt) - Math.floor(Date.now() / 1000);
+  if (!Number.isFinite(tokenSecondsRemaining) || tokenSecondsRemaining <= 60) {
+    throw new Error(
+      `${tokenPath} is expired or near expiry; refresh it before running the browser execute smoke`,
+    );
+  }
+
+  const browser = await chromium.launch({ headless: true });
+  const context = await browser.newContext({ viewport: { width: 1440, height: 1000 } });
+  await context.addInitScript(
+    ({ origin, scope, tokenJson }) => {
+      try {
+        if (globalThis.location?.origin !== origin) return;
+        globalThis.localStorage?.setItem("nteract:notebook-cloud:oidc-token", tokenJson);
+        globalThis.localStorage?.setItem("nteract:notebook-cloud:scope", scope);
+      } catch {
+        // Sandboxed output frames do not always have localStorage. Ignore them:
+        // only the first-party notebook shell needs the token cache.
+      }
+    },
+    { origin: url.origin, scope: requestedScope, tokenJson: tokenStorageJson },
+  );
+
+  const page = await context.newPage();
+  const events = {
+    pageErrors: [],
+    badConsole: [],
+    failedRequests: [],
+    blobResponses: [],
+    websockets: [],
+  };
+  page.on("pageerror", (error) => {
+    events.pageErrors.push(String(error.message ?? error));
+  });
+  page.on("console", (message) => {
+    const text = message.text();
+    if (
+      /OutputResolutionError|Failed to fetch blob|flush_comms_doc_sync|cloud sync socket is closed|cannot execute|execute cell request|WebSocket/i.test(
+        text,
+      )
+    ) {
+      events.badConsole.push(`${message.type()}: ${text}`);
+    }
+  });
+  page.on("requestfailed", (request) => {
+    events.failedRequests.push({
+      url: safeDiagnosticUrl(request.url()),
+      failure: request.failure()?.errorText ?? null,
+    });
+  });
+  page.on("response", (response) => {
+    const responseUrl = response.url();
+    if (/\/api\/n\/[^/]+\/blobs\//.test(responseUrl)) {
+      events.blobResponses.push({
+        url: safeDiagnosticUrl(responseUrl),
+        status: response.status(),
+      });
+    }
+  });
+  page.on("websocket", (ws) => {
+    const entry = {
+      url: safeDiagnosticUrl(ws.url()),
+      closed: false,
+      errors: [],
+    };
+    events.websockets.push(entry);
+    ws.on("socketerror", (error) => {
+      entry.errors.push(String(error));
+    });
+    ws.on("close", () => {
+      entry.closed = true;
+    });
+  });
+
+  await page.goto(url.href, { waitUntil: "domcontentloaded", timeout: timeoutMs });
+  await page.waitForLoadState("networkidle", { timeout: timeoutMs }).catch(() => {});
+  await waitForExecuteButtons(page, executeButtonIndex, timeoutMs);
+
+  const before = await pageDiagnostics(page);
+  const button = page.locator('[data-testid="execute-button"]').nth(executeButtonIndex);
+  await button.scrollIntoViewIfNeeded();
+  const clickedAria = await button.getAttribute("aria-label");
+  await button.click({ timeout: timeoutMs });
+
+  if (expectedText) {
+    await page.waitForFunction(
+      (text) => (document.body.textContent ?? "").includes(text),
+      expectedText,
+      { timeout: timeoutMs },
+    );
+  } else {
+    await page.waitForTimeout(settleMs);
+  }
+  await page.waitForTimeout(settleMs);
+
+  const after = await pageDiagnostics(page);
+  if (screenshotPath) {
+    await page.screenshot({ path: screenshotPath, fullPage: true });
+  }
+  await browser.close();
+
+  const failedBlobResponses = events.blobResponses.filter((response) => response.status >= 400);
+  const failedBlobImages = after.images.filter(
+    (image) => isNotebookBlobUrl(image.src) && (!image.complete || image.naturalWidth <= 0),
+  );
+  if (events.pageErrors.length > 0) {
+    throw new Error(`browser page errors:\n${events.pageErrors.join("\n")}`);
+  }
+  if (events.badConsole.length > 0) {
+    throw new Error(`browser console errors:\n${events.badConsole.join("\n")}`);
+  }
+  if (!allowFailedRequests && events.failedRequests.length > 0) {
+    throw new Error(`browser request failures:\n${JSON.stringify(events.failedRequests, null, 2)}`);
+  }
+  if (failedBlobResponses.length > 0) {
+    throw new Error(`blob fetch failures:\n${JSON.stringify(failedBlobResponses, null, 2)}`);
+  }
+  if (requireBlobImage && !after.images.some((image) => isNotebookBlobUrl(image.src))) {
+    throw new Error("expected at least one rendered notebook blob image");
+  }
+  if (failedBlobImages.length > 0) {
+    throw new Error(`blob image render failures:\n${JSON.stringify(failedBlobImages, null, 2)}`);
+  }
+
+  console.log(
+    JSON.stringify(
+      {
+        ok: true,
+        viewerUrl: url.href,
+        token: {
+          path: tokenPath,
+          secondsRemaining: tokenSecondsRemaining,
+          subject: token.claims?.email ?? token.claims?.sub ?? null,
+        },
+        click: {
+          executeButtonIndex,
+          clickedAria,
+          afterAria: after.executeButtons[executeButtonIndex]?.aria ?? null,
+        },
+        checks: [
+          "oidc_token_seeded_in_browser_storage",
+          "execute_button_rendered",
+          "execute_button_clicked",
+          ...(expectedText ? ["expected_text_observed_after_click"] : []),
+          ...(after.images.some((image) => isNotebookBlobUrl(image.src))
+            ? ["blob_image_loaded_from_img_src"]
+            : []),
+          ...(events.blobResponses.length > 0 ? ["blob_fetches_returned_ok"] : []),
+        ],
+        before,
+        after,
+        events,
+      },
+      null,
+      2,
+    ),
+  );
+}
+
+async function readOidcTokenStorageJson(path) {
+  const raw = await readFile(path, "utf8");
+  const token = JSON.parse(raw);
+  if (typeof token.accessToken !== "string" || token.accessToken.length === 0) {
+    throw new Error(`${path} is missing accessToken`);
+  }
+  if (!token.claims || typeof token.claims.sub !== "string" || token.claims.sub.length === 0) {
+    throw new Error(`${path} is missing claims.sub`);
+  }
+  return JSON.stringify(token);
+}
+
+async function waitForExecuteButtons(page, index, timeout) {
+  await page.waitForFunction(
+    (buttonIndex) =>
+      document.querySelectorAll('[data-testid="execute-button"]').length > buttonIndex,
+    index,
+    { timeout },
+  );
+}
+
+async function pageDiagnostics(page) {
+  return page.evaluate(() => {
+    const text = (document.body.textContent ?? "").replace(/\s+/g, " ");
+    const executeButtons = Array.from(
+      document.querySelectorAll('[data-testid="execute-button"]'),
+    ).map((button) => ({
+      aria: button.getAttribute("aria-label"),
+      disabled: button.disabled,
+    }));
+    const visibleButtons = Array.from(document.querySelectorAll("button"))
+      .filter((button) =>
+        Boolean(button.offsetWidth || button.offsetHeight || button.getClientRects().length),
+      )
+      .map((button) => ({
+        testid: button.getAttribute("data-testid"),
+        aria: button.getAttribute("aria-label"),
+        title: button.getAttribute("title"),
+        text: (button.textContent ?? "").trim().replace(/\s+/g, " ").slice(0, 80),
+        disabled: button.disabled,
+      }))
+      .slice(0, 80);
+    const images = Array.from(document.querySelectorAll("img"))
+      .map((image) => ({
+        src: image.currentSrc || image.src,
+        complete: image.complete,
+        naturalWidth: image.naturalWidth,
+        naturalHeight: image.naturalHeight,
+      }))
+      .slice(0, 25);
+    return {
+      textSample: text.slice(0, 2_000),
+      executeButtons,
+      visibleButtons,
+      images,
+    };
+  });
+}
+
+function safeDiagnosticUrl(value) {
+  try {
+    const url = new URL(value);
+    url.searchParams.delete("viewer_session");
+    if (/\/api\/n\/[^/]+\/blobs\//.test(url.pathname)) {
+      return `${url.origin}/api/n/<id>/blobs/<hash>`;
+    }
+    return url.href;
+  } catch {
+    return value.replace(/viewer_session=[^&\s]+/g, "viewer_session=<redacted>");
+  }
+}
+
+function isNotebookBlobUrl(value) {
+  return /\/api\/n\/[^/]+\/blobs\//.test(value);
+}
+
+function assertScope(scope) {
+  if (!["viewer", "editor", "owner"].includes(scope)) {
+    throw new Error("NOTEBOOK_CLOUD_BROWSER_EXECUTE_SCOPE must be viewer, editor, or owner");
+  }
+}
+
+function parsePositiveInteger(value, name, fallback) {
+  if (value === undefined || value === "") return fallback;
+  const parsed = Number(value);
+  if (!Number.isInteger(parsed) || parsed <= 0) {
+    throw new Error(`${name} must be a positive integer`);
+  }
+  return parsed;
+}
+
+function parseNonNegativeInteger(value, name, fallback) {
+  if (value === undefined || value === "") return fallback;
+  const parsed = Number(value);
+  if (!Number.isInteger(parsed) || parsed < 0) {
+    throw new Error(`${name} must be a non-negative integer`);
+  }
+  return parsed;
+}

--- a/apps/notebook-cloud/src/blob-resolver.ts
+++ b/apps/notebook-cloud/src/blob-resolver.ts
@@ -8,16 +8,47 @@ export function createNotebookCloudBlobResolver(input: {
   baseUrl: string | URL;
   blobBasePath: string;
   fetchImpl?: typeof fetch;
+  authenticatedBinaryObjectUrls?: boolean;
 }): BlobResolver {
   const blobBaseUrl = new URL(withTrailingSlash(input.blobBasePath), input.baseUrl);
+  const fetchImpl = input.fetchImpl ?? fetch;
+  const objectUrls = new Map<string, string>();
+  const url = (ref: BlobRef) => new URL(encodeURIComponent(ref.blob), blobBaseUrl).href;
   return createBlobResolver({
-    fetchImpl: input.fetchImpl,
-    url(ref: BlobRef) {
-      return new URL(encodeURIComponent(ref.blob), blobBaseUrl).href;
-    },
+    fetchImpl,
+    url,
+    ...(input.authenticatedBinaryObjectUrls
+      ? {
+          requestInit: { cache: "no-store" },
+          async displayUrl(ref: BlobRef) {
+            const cacheKey = objectUrlCacheKey(ref);
+            const cached = objectUrls.get(cacheKey);
+            if (cached) return cached;
+
+            const response = await fetchImpl(url(ref), { cache: "no-store" });
+            if (!response.ok) {
+              throw new Error(`Failed to fetch blob ${ref.blob}: ${response.status}`);
+            }
+            const responseBlob = await response.blob();
+            const typedBlob =
+              responseBlob.type || !ref.media_type
+                ? responseBlob
+                : new Blob([responseBlob], { type: ref.media_type });
+            const objectUrl =
+              typeof URL.createObjectURL === "function" ? URL.createObjectURL(typedBlob) : url(ref);
+            objectUrls.set(cacheKey, objectUrl);
+            return objectUrl;
+          },
+          resolvesBinaryUrlsSynchronously: false,
+        }
+      : {}),
   });
 }
 
 export function withTrailingSlash(value: string): string {
   return value.endsWith("/") ? value : `${value}/`;
+}
+
+function objectUrlCacheKey(ref: BlobRef): string {
+  return `${ref.blob}\0${ref.media_type ?? ""}\0${ref.size ?? ""}`;
 }

--- a/apps/notebook-cloud/src/blob-resolver.ts
+++ b/apps/notebook-cloud/src/blob-resolver.ts
@@ -8,21 +8,25 @@ export function createNotebookCloudBlobResolver(input: {
   baseUrl: string | URL;
   blobBasePath: string;
   fetchImpl?: typeof fetch;
+  authenticatedBinaryDisplayUrls?: boolean;
+  /** @deprecated Use authenticatedBinaryDisplayUrls. */
   authenticatedBinaryObjectUrls?: boolean;
 }): BlobResolver {
   const blobBaseUrl = new URL(withTrailingSlash(input.blobBasePath), input.baseUrl);
   const fetchImpl = input.fetchImpl ?? fetch;
-  const objectUrls = new Map<string, string>();
+  const displayUrls = new Map<string, string>();
   const url = (ref: BlobRef) => new URL(encodeURIComponent(ref.blob), blobBaseUrl).href;
+  const authenticatedBinaryDisplayUrls =
+    input.authenticatedBinaryDisplayUrls ?? input.authenticatedBinaryObjectUrls ?? false;
   return createBlobResolver({
     fetchImpl,
     url,
-    ...(input.authenticatedBinaryObjectUrls
+    ...(authenticatedBinaryDisplayUrls
       ? {
           requestInit: { cache: "no-store" },
-          async displayUrl(ref: BlobRef) {
-            const cacheKey = objectUrlCacheKey(ref);
-            const cached = objectUrls.get(cacheKey);
+          async displayUrl(ref: BlobRef, mediaType?: string) {
+            const cacheKey = displayUrlCacheKey(ref, mediaType);
+            const cached = displayUrls.get(cacheKey);
             if (cached) return cached;
 
             const response = await fetchImpl(url(ref), { cache: "no-store" });
@@ -30,14 +34,19 @@ export function createNotebookCloudBlobResolver(input: {
               throw new Error(`Failed to fetch blob ${ref.blob}: ${response.status}`);
             }
             const responseBlob = await response.blob();
+            const resolvedMediaType = mediaType ?? ref.media_type ?? responseBlob.type;
             const typedBlob =
-              responseBlob.type || !ref.media_type
+              responseBlob.type || !resolvedMediaType
                 ? responseBlob
-                : new Blob([responseBlob], { type: ref.media_type });
-            const objectUrl =
-              typeof URL.createObjectURL === "function" ? URL.createObjectURL(typedBlob) : url(ref);
-            objectUrls.set(cacheKey, objectUrl);
-            return objectUrl;
+                : new Blob([responseBlob], { type: resolvedMediaType });
+            const displayUrl =
+              typeof FileReader === "function"
+                ? await blobToDataUrl(typedBlob)
+                : typeof URL.createObjectURL === "function"
+                  ? URL.createObjectURL(typedBlob)
+                  : url(ref);
+            displayUrls.set(cacheKey, displayUrl);
+            return displayUrl;
           },
           resolvesBinaryUrlsSynchronously: false,
         }
@@ -49,6 +58,21 @@ export function withTrailingSlash(value: string): string {
   return value.endsWith("/") ? value : `${value}/`;
 }
 
-function objectUrlCacheKey(ref: BlobRef): string {
-  return `${ref.blob}\0${ref.media_type ?? ""}\0${ref.size ?? ""}`;
+function displayUrlCacheKey(ref: BlobRef, mediaType?: string): string {
+  return `${ref.blob}\0${mediaType ?? ref.media_type ?? ""}\0${ref.size ?? ""}`;
+}
+
+function blobToDataUrl(blob: Blob): Promise<string> {
+  return new Promise((resolve, reject) => {
+    const reader = new FileReader();
+    reader.onload = () => {
+      if (typeof reader.result === "string") {
+        resolve(reader.result);
+        return;
+      }
+      reject(new Error("FileReader returned a non-string data URL result"));
+    };
+    reader.onerror = () => reject(reader.error ?? new Error("Failed to read blob as data URL"));
+    reader.readAsDataURL(blob);
+  });
 }

--- a/apps/notebook-cloud/test/blob-resolver.test.ts
+++ b/apps/notebook-cloud/test/blob-resolver.test.ts
@@ -22,15 +22,33 @@ describe("notebook cloud blob resolver", () => {
     );
   });
 
-  it("can resolve protected binary blobs through authenticated object URLs", async () => {
-    const originalCreateObjectUrl = URL.createObjectURL;
-    URL.createObjectURL = (() =>
-      "blob:https://viewer.example.test/object-url") as typeof URL.createObjectURL;
+  it("can resolve protected binary blobs through authenticated display URLs", async () => {
+    const originalFileReader = globalThis.FileReader;
+    class TestFileReader {
+      result: string | ArrayBuffer | null = null;
+      error: Error | null = null;
+      onload: (() => void) | null = null;
+      onerror: (() => void) | null = null;
+
+      readAsDataURL(blob: Blob) {
+        blob
+          .arrayBuffer()
+          .then((buffer) => {
+            this.result = `data:${blob.type};base64,${Buffer.from(buffer).toString("base64")}`;
+            this.onload?.();
+          })
+          .catch((error) => {
+            this.error = error instanceof Error ? error : new Error(String(error));
+            this.onerror?.();
+          });
+      }
+    }
+    globalThis.FileReader = TestFileReader as typeof FileReader;
     const fetchCalls: Array<{ input: RequestInfo | URL; init?: RequestInit }> = [];
     const resolver = createNotebookCloudBlobResolver({
       baseUrl: "https://viewer.example.test/n/notebook-1",
       blobBasePath: "/api/n/notebook-1/blobs/",
-      authenticatedBinaryObjectUrls: true,
+      authenticatedBinaryDisplayUrls: true,
       fetchImpl: async (input, init) => {
         fetchCalls.push({ input, init });
         return new Response(new Blob([new Uint8Array([137, 80, 78, 71])], { type: "image/png" }));
@@ -45,7 +63,7 @@ describe("notebook cloud blob resolver", () => {
           media_type: "image/png",
           size: 4,
         }),
-        "blob:https://viewer.example.test/object-url",
+        "data:image/png;base64,iVBORw==",
       );
       assert.equal(
         await resolver.displayUrl?.({
@@ -53,10 +71,10 @@ describe("notebook cloud blob resolver", () => {
           media_type: "image/png",
           size: 4,
         }),
-        "blob:https://viewer.example.test/object-url",
+        "data:image/png;base64,iVBORw==",
       );
     } finally {
-      URL.createObjectURL = originalCreateObjectUrl;
+      globalThis.FileReader = originalFileReader;
     }
 
     assert.deepEqual(fetchCalls, [

--- a/apps/notebook-cloud/test/blob-resolver.test.ts
+++ b/apps/notebook-cloud/test/blob-resolver.test.ts
@@ -21,4 +21,49 @@ describe("notebook cloud blob resolver", () => {
       "https://cdn.example.test/notebooks/notebook-1/blobs/sha256%3Aabc%2Fdef",
     );
   });
+
+  it("can resolve protected binary blobs through authenticated object URLs", async () => {
+    const originalCreateObjectUrl = URL.createObjectURL;
+    URL.createObjectURL = (() =>
+      "blob:https://viewer.example.test/object-url") as typeof URL.createObjectURL;
+    const fetchCalls: Array<{ input: RequestInfo | URL; init?: RequestInit }> = [];
+    const resolver = createNotebookCloudBlobResolver({
+      baseUrl: "https://viewer.example.test/n/notebook-1",
+      blobBasePath: "/api/n/notebook-1/blobs/",
+      authenticatedBinaryObjectUrls: true,
+      fetchImpl: async (input, init) => {
+        fetchCalls.push({ input, init });
+        return new Response(new Blob([new Uint8Array([137, 80, 78, 71])], { type: "image/png" }));
+      },
+    });
+
+    try {
+      assert.equal(resolver.resolvesBinaryUrlsSynchronously, false);
+      assert.equal(
+        await resolver.displayUrl?.({
+          blob: "sha256:image",
+          media_type: "image/png",
+          size: 4,
+        }),
+        "blob:https://viewer.example.test/object-url",
+      );
+      assert.equal(
+        await resolver.displayUrl?.({
+          blob: "sha256:image",
+          media_type: "image/png",
+          size: 4,
+        }),
+        "blob:https://viewer.example.test/object-url",
+      );
+    } finally {
+      URL.createObjectURL = originalCreateObjectUrl;
+    }
+
+    assert.deepEqual(fetchCalls, [
+      {
+        input: "https://viewer.example.test/api/n/notebook-1/blobs/sha256%3Aimage",
+        init: { cache: "no-store" },
+      },
+    ]);
+  });
 });

--- a/apps/notebook-cloud/test/viewer-render-props.test.ts
+++ b/apps/notebook-cloud/test/viewer-render-props.test.ts
@@ -84,7 +84,8 @@ test("cloud home keeps prototype controls out of the primary auth surface", () =
   assert.match(homeSource, /className="cloud-home-copy"/);
   assert.match(homeSource, /<h1>nteract<\/h1>/);
   assert.match(homeSource, /realtime notebooks/);
-  assert.match(homeSource, /Open topic viz/);
+  assert.match(homeSource, /View notebooks/);
+  assert.match(homeSource, /href="\/n"/);
   assert.doesNotMatch(homeSource, /showPrototypeDevControls/);
   assert.doesNotMatch(homeSource, /className="cloud-home-scope"/);
   assert.doesNotMatch(homeSource, /<select/);

--- a/apps/notebook-cloud/test/viewer-shell-capabilities.test.ts
+++ b/apps/notebook-cloud/test/viewer-shell-capabilities.test.ts
@@ -99,6 +99,8 @@ test("cloud shell capabilities surface execution only when a runtime is availabl
   });
   assert.equal(withoutRuntime.runtime.executionAvailable, false);
   assert.equal(withoutRuntime.runtime.connected, false);
+  assert.equal(withoutRuntime.runtime.target?.label, "No workstation attached");
+  assert.equal(withoutRuntime.runtime.target?.status, "offline");
   assert.equal(withoutRuntime.canExecute, false);
 
   const withRuntime = cloudNotebookShellCapabilities({
@@ -110,6 +112,8 @@ test("cloud shell capabilities surface execution only when a runtime is availabl
   });
   assert.equal(withRuntime.runtime.executionAvailable, true);
   assert.equal(withRuntime.runtime.connected, true);
+  assert.equal(withRuntime.runtime.target?.label, "Room workstation");
+  assert.equal(withRuntime.runtime.target?.status, "ready");
   assert.equal(withRuntime.canExecute, true);
 
   // A live runtime is visible to viewers, but viewing is not execution authority.
@@ -121,6 +125,7 @@ test("cloud shell capabilities surface execution only when a runtime is availabl
   });
   assert.equal(viewerWithRuntime.runtime.executionAvailable, true);
   assert.equal(viewerWithRuntime.runtime.connected, true);
+  assert.equal(viewerWithRuntime.runtime.target?.label, "Room workstation");
   assert.equal(viewerWithRuntime.canExecute, false);
 
   // Runtime presence is visible to editors too, but the room host grants
@@ -135,6 +140,7 @@ test("cloud shell capabilities surface execution only when a runtime is availabl
   });
   assert.equal(editorWithRuntime.runtime.executionAvailable, true);
   assert.equal(editorWithRuntime.runtime.connected, true);
+  assert.equal(editorWithRuntime.runtime.target?.label, "Room workstation");
   assert.equal(editorWithRuntime.canExecute, false);
 });
 
@@ -391,9 +397,11 @@ test("cloud shell capabilities return stable frozen objects for equivalent input
   assert.equal(first.access, second.access);
   assert.equal(first.auth, second.auth);
   assert.equal(first.runtime, second.runtime);
+  assert.equal(first.runtime.target, second.runtime.target);
   assert.equal(Object.isFrozen(first), true);
   assert.equal(Object.isFrozen(first.access), true);
   assert.equal(Object.isFrozen(first.runtime), true);
+  assert.equal(Object.isFrozen(first.runtime.target), true);
 });
 
 test("cloud shell capabilities keep runtime peer authority separate from document access", () => {
@@ -415,6 +423,9 @@ test("cloud shell capabilities keep runtime peer authority separate from documen
   assert.equal(capabilities.runtime.actorLabel, "user:anaconda:alice/runtime:jupyterhub");
   assert.equal(capabilities.runtime.identityLabel, "user");
   assert.equal(capabilities.runtime.actor?.scope, "runtime_peer");
+  assert.equal(capabilities.runtime.target?.kind, "runtime_peer");
+  assert.equal(capabilities.runtime.target?.status, "attached");
+  assert.equal(capabilities.runtime.target?.label, "Runtime peer");
   assert.equal(capabilities.runtime.actor?.principal.label, "user");
   assert.equal(capabilities.runtime.actor?.operator.kind, "runtime");
   assert.equal(capabilities.runtime.actor?.operator.label, "JupyterHub");

--- a/apps/notebook-cloud/test/viewer-shell-capabilities.test.ts
+++ b/apps/notebook-cloud/test/viewer-shell-capabilities.test.ts
@@ -99,6 +99,7 @@ test("cloud shell capabilities surface execution only when a runtime is availabl
   });
   assert.equal(withoutRuntime.runtime.executionAvailable, false);
   assert.equal(withoutRuntime.runtime.connected, false);
+  assert.equal(withoutRuntime.runtime.target?.id, "workstation:none");
   assert.equal(withoutRuntime.runtime.target?.label, "No workstation attached");
   assert.equal(withoutRuntime.runtime.target?.status, "offline");
   assert.equal(withoutRuntime.canExecute, false);
@@ -112,6 +113,7 @@ test("cloud shell capabilities surface execution only when a runtime is availabl
   });
   assert.equal(withRuntime.runtime.executionAvailable, true);
   assert.equal(withRuntime.runtime.connected, true);
+  assert.equal(withRuntime.runtime.target?.id, "room-workstation");
   assert.equal(withRuntime.runtime.target?.label, "Room workstation");
   assert.equal(withRuntime.runtime.target?.status, "ready");
   assert.equal(withRuntime.canExecute, true);
@@ -125,6 +127,7 @@ test("cloud shell capabilities surface execution only when a runtime is availabl
   });
   assert.equal(viewerWithRuntime.runtime.executionAvailable, true);
   assert.equal(viewerWithRuntime.runtime.connected, true);
+  assert.equal(viewerWithRuntime.runtime.target?.id, "room-workstation");
   assert.equal(viewerWithRuntime.runtime.target?.label, "Room workstation");
   assert.equal(viewerWithRuntime.canExecute, false);
 
@@ -140,6 +143,7 @@ test("cloud shell capabilities surface execution only when a runtime is availabl
   });
   assert.equal(editorWithRuntime.runtime.executionAvailable, true);
   assert.equal(editorWithRuntime.runtime.connected, true);
+  assert.equal(editorWithRuntime.runtime.target?.id, "room-workstation");
   assert.equal(editorWithRuntime.runtime.target?.label, "Room workstation");
   assert.equal(editorWithRuntime.canExecute, false);
 });
@@ -423,6 +427,7 @@ test("cloud shell capabilities keep runtime peer authority separate from documen
   assert.equal(capabilities.runtime.actorLabel, "user:anaconda:alice/runtime:jupyterhub");
   assert.equal(capabilities.runtime.identityLabel, "user");
   assert.equal(capabilities.runtime.actor?.scope, "runtime_peer");
+  assert.equal(capabilities.runtime.target?.id, "runtime-peer");
   assert.equal(capabilities.runtime.target?.kind, "runtime_peer");
   assert.equal(capabilities.runtime.target?.status, "attached");
   assert.equal(capabilities.runtime.target?.label, "Runtime peer");

--- a/apps/notebook-cloud/test/viewer-shell-capabilities.test.ts
+++ b/apps/notebook-cloud/test/viewer-shell-capabilities.test.ts
@@ -45,7 +45,7 @@ test("cloud shell capabilities keep viewer scope read-only", () => {
   assert.equal(capabilities.runtime.canWriteRuntimeState, false);
 });
 
-test("cloud shell capabilities grant editors full cell and structure editing without execute or package management", () => {
+test("cloud shell capabilities grant editors full cell and structure editing without an attached runtime", () => {
   const capabilities = cloudNotebookShellCapabilities({
     authState: authState("oidc", "editor"),
     connectionScope: "editor",
@@ -131,9 +131,8 @@ test("cloud shell capabilities surface execution only when a runtime is availabl
   assert.equal(viewerWithRuntime.runtime.target?.label, "Room workstation");
   assert.equal(viewerWithRuntime.canExecute, false);
 
-  // Runtime presence is visible to editors too, but the room host grants
-  // execution-intent authority to owner scope until an explicit execute scope
-  // is defined.
+  // Runtime presence is visible to editors too, and non-viewer room peers may
+  // submit execution-intent request frames while compute is attached.
   const editorWithRuntime = cloudNotebookShellCapabilities({
     authState: authState("oidc", "editor"),
     connectionScope: "editor",
@@ -145,7 +144,7 @@ test("cloud shell capabilities surface execution only when a runtime is availabl
   assert.equal(editorWithRuntime.runtime.connected, true);
   assert.equal(editorWithRuntime.runtime.target?.id, "room-workstation");
   assert.equal(editorWithRuntime.runtime.target?.label, "Room workstation");
-  assert.equal(editorWithRuntime.canExecute, false);
+  assert.equal(editorWithRuntime.canExecute, true);
 });
 
 test("cloud shell capabilities keep user-selected view mode read-only even with editor access", () => {

--- a/apps/notebook-cloud/viewer/cloud-viewer-session.ts
+++ b/apps/notebook-cloud/viewer/cloud-viewer-session.ts
@@ -9,9 +9,16 @@ import {
 import type { BlobResolver } from "runtimed";
 import type { WidgetStore } from "@/components/widgets/widget-store";
 import {
+  applyExecutionViewChangeset,
+  applyOutputChangeset,
   emitBroadcast,
   emitPresence,
+  resetPoolState,
+  resetRuntimeState,
+  resetRuntimeStoresProjection,
   startCursorDispatch,
+  setPoolState,
+  setRuntimeState,
 } from "../../notebook/src/notebook-surface";
 import {
   cloudSyncAuthFromPrototypeAuthState,
@@ -32,13 +39,6 @@ import { createOutputResolutionCache, type ResolvedCell } from "./render-resolut
 import { loadSnapshotPairHandle } from "./runtimed-wasm-client";
 import { projectCloudWidgetComms } from "./widget-comm-projection";
 import type { CloudAuthRenewalState, ViewerStatus } from "./notice-types";
-import {
-  applyExecutionViewChangeset,
-  applyOutputChangeset,
-  resetRuntimeStoresProjection,
-} from "../../notebook/src/lib/project-runtime-stores";
-import { resetPoolState, setPoolState } from "../../notebook/src/lib/pool-state";
-import { resetRuntimeState, setRuntimeState } from "../../notebook/src/lib/runtime-state";
 
 export interface CloudViewerConfig {
   notebookId: string;

--- a/apps/notebook-cloud/viewer/index.tsx
+++ b/apps/notebook-cloud/viewer/index.tsx
@@ -433,7 +433,7 @@ function CloudNotebookListView({ authConfig }: { authConfig: CloudViewerAuthConf
     void (async () => {
       try {
         const response = await fetchWithCloudPrototypeAuth(
-          "/api/n?limit=100",
+          cloudNotebookListEndpoint(),
           { headers: { Accept: "application/json" }, signal: controller.signal },
           authState,
         );
@@ -568,6 +568,11 @@ function CloudNotebookListView({ authConfig }: { authConfig: CloudViewerAuthConf
       </section>
     </main>
   );
+}
+
+function cloudNotebookListEndpoint(): string {
+  const path = ["api", "n"].join("/");
+  return new URL(`${path}?limit=100`, `${window.location.origin}/`).href;
 }
 
 function isCloudNotebookListResponse(value: unknown): value is CloudNotebookListResponse {

--- a/apps/notebook-cloud/viewer/index.tsx
+++ b/apps/notebook-cloud/viewer/index.tsx
@@ -869,7 +869,7 @@ function NotebookViewer({
         baseUrl: location.href,
         blobBasePath: config.blobBasePath,
         fetchImpl: (input, init) => fetchWithCloudPrototypeAuth(input, init, authState),
-        authenticatedBinaryObjectUrls: true,
+        authenticatedBinaryDisplayUrls: true,
       }),
     [authState, config.blobBasePath],
   );

--- a/apps/notebook-cloud/viewer/index.tsx
+++ b/apps/notebook-cloud/viewer/index.tsx
@@ -869,6 +869,7 @@ function NotebookViewer({
         baseUrl: location.href,
         blobBasePath: config.blobBasePath,
         fetchImpl: (input, init) => fetchWithCloudPrototypeAuth(input, init, authState),
+        authenticatedBinaryObjectUrls: true,
       }),
     [authState, config.blobBasePath],
   );

--- a/apps/notebook-cloud/viewer/shell-capabilities.ts
+++ b/apps/notebook-cloud/viewer/shell-capabilities.ts
@@ -5,6 +5,7 @@ import {
   projectNotebookShellCapabilities,
   type NotebookEditMode,
   type NotebookShellCapabilities,
+  type NotebookShellRuntimeTargetProjection,
 } from "runtimed";
 import type { CloudPrototypeAuthState } from "./collaborator-auth";
 import { projectCloudNotebookEditAccess } from "./edit-access";
@@ -93,6 +94,7 @@ export function cloudNotebookShellCapabilities({
     source: "cloud" as const,
     actorLabel: isRuntimePeer ? connectionActorLabel : null,
     identityLabel: isRuntimePeer ? identityLabel : null,
+    target: cloudRuntimeTarget({ isRuntimePeer, runtimeAvailable }),
   };
   const accessActor = notebookActorProjectionWithPrincipalImage(
     notebookActorProjectionFromAccess(access, auth),
@@ -131,6 +133,43 @@ export function cloudNotebookShellCapabilities({
       requiresAuthenticatedIdentity: true,
     },
   });
+}
+
+function cloudRuntimeTarget({
+  isRuntimePeer,
+  runtimeAvailable,
+}: {
+  isRuntimePeer: boolean;
+  runtimeAvailable: boolean;
+}): NotebookShellRuntimeTargetProjection {
+  if (isRuntimePeer) {
+    return {
+      kind: "runtime_peer",
+      status: "attached",
+      label: "Runtime peer",
+      statusLabel: "Attached",
+      detail: "This connection can author runtime state for the room.",
+      providerLabel: "Cloud room",
+    };
+  }
+  if (runtimeAvailable) {
+    return {
+      kind: "cloud_workstation",
+      status: "ready",
+      label: "Room workstation",
+      statusLabel: "Ready",
+      detail: "A runtime peer is attached to this room.",
+      providerLabel: "Cloud room",
+    };
+  }
+  return {
+    kind: "cloud_workstation",
+    status: "offline",
+    label: "No workstation attached",
+    statusLabel: "Offline",
+    detail: "Attach a user-owned workstation to run cells in this room.",
+    providerLabel: "Cloud room",
+  };
 }
 
 function cloudIdentityDisplayLabel(authState: CloudPrototypeAuthState): string | null {

--- a/apps/notebook-cloud/viewer/shell-capabilities.ts
+++ b/apps/notebook-cloud/viewer/shell-capabilities.ts
@@ -37,8 +37,10 @@ export interface CloudNotebookShellCapabilityInput {
   runtimeAvailable?: boolean;
   /**
    * Whether this browser connection may create execution intent in the hosted
-   * room. Today the room host grants that to owners only; future execute-scope
-   * policy can replace this without changing the shared shell projection.
+   * room. This is a capability, not an interaction mode: owners and editors can
+   * submit execution requests when compute is attached, while future
+   * execute-scope policy can replace this without changing the shared shell
+   * projection.
    */
   canSubmitExecutionRequests?: boolean;
   /**
@@ -59,7 +61,7 @@ export function cloudNotebookShellCapabilities({
   canAcceptCellMutations = true,
   editAccessRequestPending = false,
   runtimeAvailable = false,
-  canSubmitExecutionRequests = connectionScope === "owner",
+  canSubmitExecutionRequests = connectionScope === "owner" || connectionScope === "editor",
   hostCapabilities,
 }: CloudNotebookShellCapabilityInput): NotebookShellCapabilities {
   const interaction = projectCloudNotebookEditAccess({

--- a/apps/notebook-cloud/viewer/shell-capabilities.ts
+++ b/apps/notebook-cloud/viewer/shell-capabilities.ts
@@ -144,6 +144,7 @@ function cloudRuntimeTarget({
 }): NotebookShellRuntimeTargetProjection {
   if (isRuntimePeer) {
     return {
+      id: "runtime-peer",
       kind: "runtime_peer",
       status: "attached",
       label: "Runtime peer",
@@ -155,6 +156,7 @@ function cloudRuntimeTarget({
   }
   if (runtimeAvailable) {
     return {
+      id: "room-workstation",
       kind: "cloud_workstation",
       status: "ready",
       label: "Room workstation",
@@ -165,6 +167,7 @@ function cloudRuntimeTarget({
     };
   }
   return {
+    id: "workstation:none",
     kind: "cloud_workstation",
     status: "offline",
     label: "No workstation attached",

--- a/apps/notebook-cloud/viewer/shell-capabilities.ts
+++ b/apps/notebook-cloud/viewer/shell-capabilities.ts
@@ -150,6 +150,7 @@ function cloudRuntimeTarget({
       statusLabel: "Attached",
       detail: "This connection can author runtime state for the room.",
       providerLabel: "Cloud room",
+      environmentLabel: "Runtime peer",
     };
   }
   if (runtimeAvailable) {
@@ -160,6 +161,7 @@ function cloudRuntimeTarget({
       statusLabel: "Ready",
       detail: "A runtime peer is attached to this room.",
       providerLabel: "Cloud room",
+      environmentLabel: "Current Python",
     };
   }
   return {
@@ -169,6 +171,7 @@ function cloudRuntimeTarget({
     statusLabel: "Offline",
     detail: "Attach a user-owned workstation to run cells in this room.",
     providerLabel: "Cloud room",
+    environmentLabel: "Not attached",
   };
 }
 

--- a/apps/notebook/src/lib/__tests__/desktop-shell-capabilities.test.ts
+++ b/apps/notebook/src/lib/__tests__/desktop-shell-capabilities.test.ts
@@ -67,6 +67,13 @@ describe("desktopNotebookShellCapabilities", () => {
       connected: true,
       source: "local",
       actorLabel: "local:kyle/runtime:local",
+      target: {
+        kind: "local_daemon",
+        status: "ready",
+        label: "This machine",
+        statusLabel: "Ready",
+        providerLabel: "Local daemon",
+      },
     });
     expect(capabilities.access.actor).toMatchObject({
       principal: {
@@ -175,6 +182,11 @@ describe("desktopNotebookShellCapabilities", () => {
       connected: true,
       source: "local",
       actorLabel: null,
+      target: {
+        kind: "local_daemon",
+        status: "ready",
+        label: "This machine",
+      },
     });
     expect(capabilities.interaction).toMatchObject({
       selectedMode: "view",
@@ -239,6 +251,12 @@ describe("desktopNotebookShellCapabilities", () => {
       connected: true,
       source: "cloud",
       actorLabel: "user:anaconda:alice/runtime:jupyterhub",
+      target: {
+        kind: "runtime_peer",
+        status: "attached",
+        label: "Runtime peer",
+        providerLabel: "Cloud room",
+      },
     });
     expect(capabilities.runtime.actor).toMatchObject({
       principal: { label: "Alice" },

--- a/apps/notebook/src/lib/__tests__/desktop-shell-capabilities.test.ts
+++ b/apps/notebook/src/lib/__tests__/desktop-shell-capabilities.test.ts
@@ -68,6 +68,7 @@ describe("desktopNotebookShellCapabilities", () => {
       source: "local",
       actorLabel: "local:kyle/runtime:local",
       target: {
+        id: "local-daemon",
         kind: "local_daemon",
         status: "ready",
         label: "This machine",
@@ -183,6 +184,7 @@ describe("desktopNotebookShellCapabilities", () => {
       source: "local",
       actorLabel: null,
       target: {
+        id: "local-daemon",
         kind: "local_daemon",
         status: "ready",
         label: "This machine",
@@ -252,6 +254,7 @@ describe("desktopNotebookShellCapabilities", () => {
       source: "cloud",
       actorLabel: "user:anaconda:alice/runtime:jupyterhub",
       target: {
+        id: "runtime-peer",
         kind: "runtime_peer",
         status: "attached",
         label: "Runtime peer",

--- a/apps/notebook/src/lib/__tests__/manifest-resolution.test.ts
+++ b/apps/notebook/src/lib/__tests__/manifest-resolution.test.ts
@@ -489,6 +489,31 @@ describe("resolveContentRef", () => {
     expect(result).toBe(`https://assets.example.test/blobs/${encodeURIComponent(blob)}`);
     expect(fetchImpl).not.toHaveBeenCalled();
   });
+
+  it("uses an async display URL hook for protected binary refs", async () => {
+    const displayUrl = vi.fn().mockResolvedValue("blob:https://cloud.test/image");
+    const fetchImpl = vi.fn().mockResolvedValue(new Response("should not fetch", { status: 200 }));
+    const resolver = createBlobResolver({
+      url: (ref) => `https://cloud.test/blobs/${encodeURIComponent(ref.blob)}`,
+      fetchImpl,
+      displayUrl,
+      resolvesBinaryUrlsSynchronously: false,
+    });
+
+    const result = await resolveContentRef(
+      { blob: "sha256:image", size: 68, media_type: "image/png" },
+      resolver,
+      "image/png",
+    );
+
+    expect(result).toBe("blob:https://cloud.test/image");
+    expect(displayUrl).toHaveBeenCalledWith({
+      blob: "sha256:image",
+      size: 68,
+      media_type: "image/png",
+    });
+    expect(fetchImpl).not.toHaveBeenCalled();
+  });
 });
 
 // ---------------------------------------------------------------------------
@@ -698,6 +723,38 @@ describe("resolveManifest", () => {
         display_id: undefined,
       });
       expect(mockFetch).not.toHaveBeenCalled();
+    });
+
+    it("uses async object URLs for protected binary blob refs", async () => {
+      const displayUrl = vi.fn().mockResolvedValue("blob:https://cloud.test/image");
+      const resolver = createBlobResolver({
+        url: (ref) => `https://cloud.test/blobs/${encodeURIComponent(ref.blob)}`,
+        displayUrl,
+        resolvesBinaryUrlsSynchronously: false,
+      });
+      const manifest: OutputManifest = {
+        output_id: "async-display-protected-image",
+        output_type: "display_data",
+        data: {
+          "image/png": { blob: "sha256:image", size: 68, media_type: "image/png" },
+          "text/plain": { inline: "PNG image" },
+        },
+      };
+
+      const sync = resolveManifestSync(manifest, resolver);
+      const output = await resolveManifest(manifest, resolver);
+
+      expect(sync).toBeNull();
+      expect(output).toEqual({
+        output_id: "async-display-protected-image",
+        output_type: "display_data",
+        data: {
+          "image/png": "blob:https://cloud.test/image",
+          "text/plain": "PNG image",
+        },
+        metadata: {},
+        display_id: undefined,
+      });
     });
   });
 

--- a/apps/notebook/src/lib/__tests__/manifest-resolution.test.ts
+++ b/apps/notebook/src/lib/__tests__/manifest-resolution.test.ts
@@ -507,11 +507,14 @@ describe("resolveContentRef", () => {
     );
 
     expect(result).toBe("blob:https://cloud.test/image");
-    expect(displayUrl).toHaveBeenCalledWith({
-      blob: "sha256:image",
-      size: 68,
-      media_type: "image/png",
-    });
+    expect(displayUrl).toHaveBeenCalledWith(
+      {
+        blob: "sha256:image",
+        size: 68,
+        media_type: "image/png",
+      },
+      "image/png",
+    );
     expect(fetchImpl).not.toHaveBeenCalled();
   });
 });
@@ -725,8 +728,8 @@ describe("resolveManifest", () => {
       expect(mockFetch).not.toHaveBeenCalled();
     });
 
-    it("uses async object URLs for protected binary blob refs", async () => {
-      const displayUrl = vi.fn().mockResolvedValue("blob:https://cloud.test/image");
+    it("uses async display URLs for protected binary blob refs", async () => {
+      const displayUrl = vi.fn().mockResolvedValue("data:image/png;base64,iVBORw==");
       const resolver = createBlobResolver({
         url: (ref) => `https://cloud.test/blobs/${encodeURIComponent(ref.blob)}`,
         displayUrl,
@@ -749,7 +752,7 @@ describe("resolveManifest", () => {
         output_id: "async-display-protected-image",
         output_type: "display_data",
         data: {
-          "image/png": "blob:https://cloud.test/image",
+          "image/png": "data:image/png;base64,iVBORw==",
           "text/plain": "PNG image",
         },
         metadata: {},

--- a/apps/notebook/src/lib/desktop-shell-capabilities.ts
+++ b/apps/notebook/src/lib/desktop-shell-capabilities.ts
@@ -119,6 +119,7 @@ function desktopRuntimeTarget({
 }): NotebookShellRuntimeTargetProjection | null {
   if (isRuntimePeer) {
     return {
+      id: "runtime-peer",
       kind: "runtime_peer",
       status: sessionReady ? "attached" : "offline",
       label: "Runtime peer",
@@ -134,6 +135,7 @@ function desktopRuntimeTarget({
     return null;
   }
   return {
+    id: "local-daemon",
     kind: "local_daemon",
     status: sessionReady ? "ready" : "offline",
     label: "This machine",

--- a/apps/notebook/src/lib/desktop-shell-capabilities.ts
+++ b/apps/notebook/src/lib/desktop-shell-capabilities.ts
@@ -127,6 +127,7 @@ function desktopRuntimeTarget({
         ? "This connection can author runtime state for the room."
         : "This runtime peer is not connected.",
       providerLabel: "Cloud room",
+      environmentLabel: "Runtime peer",
     };
   }
   if (source !== "local") {
@@ -141,6 +142,7 @@ function desktopRuntimeTarget({
       ? "The local daemon is available for this notebook."
       : "The local daemon is not exposing an executable runtime.",
     providerLabel: "Local daemon",
+    environmentLabel: "Notebook runtime",
   };
 }
 

--- a/apps/notebook/src/lib/desktop-shell-capabilities.ts
+++ b/apps/notebook/src/lib/desktop-shell-capabilities.ts
@@ -9,6 +9,7 @@ import {
   type NotebookShellAccessLevel,
   type NotebookShellAccessSource,
   type NotebookShellCapabilities,
+  type NotebookShellRuntimeTargetProjection,
 } from "runtimed";
 
 export interface DesktopNotebookShellCapabilityInput {
@@ -69,6 +70,11 @@ export function desktopNotebookShellCapabilities({
       source,
     }),
     identityLabel: null,
+    target: desktopRuntimeTarget({
+      isRuntimePeer,
+      sessionReady,
+      source,
+    }),
   };
   return projectNotebookShellCapabilities({
     interaction,
@@ -100,6 +106,42 @@ export function desktopNotebookShellCapabilities({
       requiredSources: ["cloud"],
     },
   });
+}
+
+function desktopRuntimeTarget({
+  isRuntimePeer,
+  sessionReady,
+  source,
+}: {
+  isRuntimePeer: boolean;
+  sessionReady: boolean;
+  source: NotebookShellAccessSource;
+}): NotebookShellRuntimeTargetProjection | null {
+  if (isRuntimePeer) {
+    return {
+      kind: "runtime_peer",
+      status: sessionReady ? "attached" : "offline",
+      label: "Runtime peer",
+      statusLabel: sessionReady ? "Attached" : "Offline",
+      detail: sessionReady
+        ? "This connection can author runtime state for the room."
+        : "This runtime peer is not connected.",
+      providerLabel: "Cloud room",
+    };
+  }
+  if (source !== "local") {
+    return null;
+  }
+  return {
+    kind: "local_daemon",
+    status: sessionReady ? "ready" : "offline",
+    label: "This machine",
+    statusLabel: sessionReady ? "Ready" : "Offline",
+    detail: sessionReady
+      ? "The local daemon is available for this notebook."
+      : "The local daemon is not exposing an executable runtime.",
+    providerLabel: "Local daemon",
+  };
 }
 
 function desktopRuntimeActorLabel({

--- a/apps/notebook/src/notebook-surface.ts
+++ b/apps/notebook/src/notebook-surface.ts
@@ -5,6 +5,13 @@ export { RawCell } from "./components/RawCell";
 export { PresenceValueProvider, type PresenceContextValue } from "./contexts/PresenceContext";
 export { CrdtBridgeProvider } from "./hooks/useCrdtBridge";
 export { createNotebookController } from "./lib/notebook-controller";
+export {
+  applyExecutionViewChangeset,
+  applyOutputChangeset,
+  resetRuntimeStoresProjection,
+} from "./lib/project-runtime-stores";
+export { resetPoolState, setPoolState } from "./lib/pool-state";
+export { resetRuntimeState, setRuntimeState } from "./lib/runtime-state";
 export { startCursorDispatch } from "./lib/cursor-registry";
 export { setLoggerHost } from "./lib/logger";
 export { emitBroadcast, emitPresence } from "./lib/notebook-frame-bus";

--- a/crates/runtimed/src/display_update_committer.rs
+++ b/crates/runtimed/src/display_update_committer.rs
@@ -9,16 +9,14 @@
 use std::collections::HashMap;
 use std::sync::{Arc, Mutex as StdMutex};
 
-use runtime_doc::RuntimeStateHandle;
 use tokio::sync::{mpsc, oneshot, Notify};
 use tracing::{debug, error, warn};
 
-use crate::blob_store::BlobStore;
+use crate::output_commit_context::OutputCommitContext;
 use crate::output_prep::LifecycleSignal;
 use crate::output_prep::{
     apply_display_manifest_updates, build_display_manifest_updates, collect_display_update_targets,
 };
-use crate::output_redaction::OutputRedactor;
 use crate::task_supervisor::spawn_supervised;
 
 const MAX_PENDING_DISPLAY_IDS: usize = 128;
@@ -117,20 +115,21 @@ fn take_pending(pending: &SharedPending) -> HashMap<String, PendingDisplayUpdate
     std::mem::take(&mut *updates)
 }
 
-async fn commit_pending_updates(
-    pending: &SharedPending,
-    state: &RuntimeStateHandle,
-    blob_store: &BlobStore,
-    kernel_actor_id: &str,
-    output_redactor: &OutputRedactor,
-) {
+async fn commit_pending_updates(pending: &SharedPending, context: &OutputCommitContext) {
     let updates = take_pending(pending);
     for (display_id, update) in updates {
         let preflight_wrapper = serde_json::json!({ "data": update.data });
-        crate::output_store::preflight_ref_buffers(&preflight_wrapper, &update.buffers, blob_store)
-            .await;
+        crate::output_store::preflight_ref_buffers(
+            &preflight_wrapper,
+            &update.buffers,
+            &context.blob_store,
+        )
+        .await;
 
-        let targets = match state.read(|sd| collect_display_update_targets(sd, &display_id)) {
+        let targets = match context
+            .state
+            .read(|sd| collect_display_update_targets(sd, &display_id))
+        {
             Ok(targets) => targets,
             Err(e) => {
                 warn!("[runtime-state] {}", e);
@@ -143,15 +142,16 @@ async fn commit_pending_updates(
             &display_id,
             &preflight_wrapper["data"],
             &update.metadata,
-            blob_store,
-            output_redactor,
+            &context.blob_store,
+            &context.blob_publisher,
+            &context.redactor,
         )
         .await;
 
         match updates {
             Ok(updates) => {
-                let updated = state.transact_at_current_heads(
-                    Some(kernel_actor_id),
+                let updated = context.state.transact_at_current_heads(
+                    Some(&context.kernel_actor_id),
                     "runtime-state-iopub-display-update-transaction",
                     |sd| apply_display_manifest_updates(sd, &updates),
                 );
@@ -186,10 +186,7 @@ async fn commit_pending_updates(
 async fn run_display_update_committer(
     pending: Arc<SharedPending>,
     mut priority_rx: mpsc::UnboundedReceiver<PriorityDisplayRequest>,
-    state: RuntimeStateHandle,
-    blob_store: Arc<BlobStore>,
-    kernel_actor_id: String,
-    output_redactor: Arc<OutputRedactor>,
+    context: OutputCommitContext,
 ) {
     loop {
         tokio::select! {
@@ -203,10 +200,7 @@ async fn run_display_update_committer(
                     Some(request) => {
                         commit_pending_updates(
                             &pending,
-                            &state,
-                            &blob_store,
-                            &kernel_actor_id,
-                            &output_redactor,
+                            &context,
                         )
                         .await;
                         let _ = request.ack.send(());
@@ -214,10 +208,7 @@ async fn run_display_update_committer(
                     None => {
                         commit_pending_updates(
                             &pending,
-                            &state,
-                            &blob_store,
-                            &kernel_actor_id,
-                            &output_redactor,
+                            &context,
                         )
                         .await;
                         break;
@@ -230,10 +221,7 @@ async fn run_display_update_committer(
             _ = pending.notify.notified() => {
                 commit_pending_updates(
                     &pending,
-                    &state,
-                    &blob_store,
-                    &kernel_actor_id,
-                    &output_redactor,
+                    &context,
                 )
                 .await;
             }
@@ -244,11 +232,7 @@ async fn run_display_update_committer(
 }
 
 pub(crate) fn start_display_update_committer(
-    state: RuntimeStateHandle,
-    blob_store: Arc<BlobStore>,
-    kernel_actor_id: String,
-    lifecycle_tx: mpsc::UnboundedSender<LifecycleSignal>,
-    output_redactor: Arc<OutputRedactor>,
+    context: OutputCommitContext,
 ) -> DisplayUpdateCommitterHandle {
     let pending = Arc::new(SharedPending {
         updates: StdMutex::new(HashMap::new()),
@@ -256,20 +240,14 @@ pub(crate) fn start_display_update_committer(
     });
     let (priority_tx, priority_rx) = mpsc::unbounded_channel();
     let worker_pending = pending.clone();
+    let lifecycle_tx = context.lifecycle_tx.clone();
     // Panic in the display-update committer also produces a `KernelDied`
     // signal — same rationale as the stream committer: pending updates are
     // lost, the queue must release. The runtime agent treats this identically
     // to an IOPub-disconnect KernelDied. Punchlist EP-12.
     spawn_supervised(
         "display-update-committer",
-        run_display_update_committer(
-            worker_pending,
-            priority_rx,
-            state,
-            blob_store,
-            kernel_actor_id,
-            output_redactor,
-        ),
+        run_display_update_committer(worker_pending, priority_rx, context),
         move |_| {
             let _ = lifecycle_tx.send(LifecycleSignal::KernelDied);
         },
@@ -283,6 +261,11 @@ pub(crate) fn start_display_update_committer(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use runtime_doc::RuntimeStateHandle;
+
+    use crate::blob_store::BlobStore;
+    use crate::output_blob_publisher::OutputBlobPublisher;
+    use crate::output_redaction::OutputRedactor;
     use crate::output_store::DEFAULT_INLINE_THRESHOLD;
 
     fn runtime_state() -> RuntimeStateHandle {
@@ -317,6 +300,21 @@ mod tests {
             .expect("insert output");
     }
 
+    fn commit_context(
+        state: RuntimeStateHandle,
+        blob_store: Arc<BlobStore>,
+        lifecycle_tx: mpsc::UnboundedSender<LifecycleSignal>,
+    ) -> OutputCommitContext {
+        OutputCommitContext::new(
+            state,
+            blob_store,
+            OutputBlobPublisher::none(),
+            "rt:kernel:test".to_string(),
+            lifecycle_tx,
+            Arc::new(OutputRedactor::disabled()),
+        )
+    }
+
     #[tokio::test]
     async fn display_updates_coalesce_to_latest_value() {
         let dir = tempfile::TempDir::new().expect("tempdir");
@@ -325,13 +323,8 @@ mod tests {
         insert_display_output(&state, &blob_store, "progress").await;
 
         let (lifecycle_tx, _lifecycle_rx) = mpsc::unbounded_channel();
-        let handle = start_display_update_committer(
-            state.clone(),
-            blob_store,
-            "rt:kernel:test".to_string(),
-            lifecycle_tx,
-            Arc::new(OutputRedactor::disabled()),
-        );
+        let handle =
+            start_display_update_committer(commit_context(state.clone(), blob_store, lifecycle_tx));
 
         handle.request_update(
             "progress".to_string(),

--- a/crates/runtimed/src/jupyter_kernel.rs
+++ b/crates/runtimed/src/jupyter_kernel.rs
@@ -1351,32 +1351,28 @@ impl KernelConnection for JupyterKernel {
         let state_for_iopub = shared.state.clone();
         let comms_for_iopub = shared.comms.clone();
         let iopub_output_redactor = output_redactor.clone();
+        let iopub_output_blob_publisher = shared.output_blob_publisher.clone();
         // IOPub writes use transactions with the base kernel actor. Async
         // blob/manifest work is completed before the document transaction.
         let iopub_kernel_actor_id = kernel_actor_id.clone();
-        let stream_committer = crate::stream_committer::start_stream_committer(
+        let output_commit_context = crate::output_commit_context::OutputCommitContext::new(
             state_for_iopub.clone(),
             blob_store.clone(),
-            iopub_stream_terminals.clone(),
+            iopub_output_blob_publisher,
             iopub_kernel_actor_id.clone(),
             iopub_lifecycle_tx.clone(),
             iopub_output_redactor.clone(),
+        );
+        let stream_committer = crate::stream_committer::start_stream_committer(
+            output_commit_context.clone(),
+            iopub_stream_terminals.clone(),
         );
         let display_update_committer =
             crate::display_update_committer::start_display_update_committer(
-                state_for_iopub.clone(),
-                blob_store.clone(),
-                iopub_kernel_actor_id.clone(),
-                iopub_lifecycle_tx.clone(),
-                iopub_output_redactor.clone(),
+                output_commit_context.clone(),
             );
-        let output_committer = crate::output_committer::start_output_committer(
-            state_for_iopub.clone(),
-            blob_store.clone(),
-            iopub_kernel_actor_id.clone(),
-            iopub_lifecycle_tx.clone(),
-            iopub_output_redactor.clone(),
-        );
+        let output_committer =
+            crate::output_committer::start_output_committer(output_commit_context);
 
         // Create coalescing channel early so the IOPub task can capture the sender.
         let (coalesce_tx, coalesce_rx) = mpsc::unbounded_channel::<(String, serde_json::Value)>();

--- a/crates/runtimed/src/kernel_connection.rs
+++ b/crates/runtimed/src/kernel_connection.rs
@@ -19,6 +19,7 @@ use runtime_doc::{CommsDocHandle, RuntimeStateHandle};
 use tokio::sync::{broadcast, RwLock};
 
 use crate::blob_store::BlobStore;
+use crate::output_blob_publisher::OutputBlobPublisher;
 use crate::output_prep::QueueCommandReceivers;
 use crate::protocol::{CompletionItem, HistoryEntry, NotebookBroadcast};
 use crate::PooledEnv;
@@ -63,6 +64,8 @@ pub struct KernelSharedRefs {
     pub comms: CommsDocHandle,
     /// Content-addressed blob store for output manifests.
     pub blob_store: Arc<BlobStore>,
+    /// Optional remote publisher for blobs referenced by output manifests.
+    pub(crate) output_blob_publisher: OutputBlobPublisher,
     /// Broadcast channel for notebook events to connected peers.
     pub broadcast_tx: broadcast::Sender<NotebookBroadcast>,
     /// Transient peer state (cursors, selections, kernel status).

--- a/crates/runtimed/src/lib.rs
+++ b/crates/runtimed/src/lib.rs
@@ -41,6 +41,8 @@ pub mod kernel_state;
 pub mod launcher_cache;
 pub mod markdown_assets;
 pub mod notebook_sync_server;
+pub(crate) mod output_blob_publisher;
+pub(crate) mod output_commit_context;
 pub mod output_commit_measure;
 pub(crate) mod output_committer;
 pub mod output_prep;

--- a/crates/runtimed/src/output_blob_publisher.rs
+++ b/crates/runtimed/src/output_blob_publisher.rs
@@ -1,0 +1,333 @@
+//! Optional remote publishing for blobs referenced by output manifests.
+//!
+//! Desktop/local kernels only need the local [`BlobStore`]. A cloud runtime
+//! peer also has to make those same content-addressed bytes available through
+//! preview's blob API before RuntimeStateDoc advertises the hash to browsers.
+
+use std::collections::HashSet;
+use std::fmt;
+use std::sync::Arc;
+
+use notebook_cloud_transport::{CloudAuth, CloudWsConfig};
+use reqwest::StatusCode;
+use tokio::sync::Mutex;
+use tokio::time::{sleep, Duration};
+use tracing::{debug, warn};
+
+use crate::blob_store::BlobStore;
+use crate::output_store::{OutputBlobRef, OutputManifest};
+
+const BLOB_UPLOAD_ATTEMPTS: usize = 3;
+const BLOB_UPLOAD_RETRY_BASE_DELAY_MS: u64 = 150;
+
+#[derive(Clone, Default)]
+pub(crate) struct OutputBlobPublisher {
+    cloud: Option<Arc<CloudBlobPublisher>>,
+}
+
+impl OutputBlobPublisher {
+    pub(crate) fn none() -> Self {
+        Self { cloud: None }
+    }
+
+    pub(crate) fn cloud(config: &CloudWsConfig) -> Self {
+        Self {
+            cloud: Some(Arc::new(CloudBlobPublisher::new(config))),
+        }
+    }
+
+    pub(crate) async fn publish_manifest_blobs(
+        &self,
+        manifest: &OutputManifest,
+        blob_store: &BlobStore,
+    ) -> Result<(), BlobPublishError> {
+        let Some(cloud) = &self.cloud else {
+            return Ok(());
+        };
+
+        for blob in manifest.blob_refs() {
+            cloud.publish_blob(blob, blob_store).await?;
+        }
+        Ok(())
+    }
+}
+
+impl fmt::Debug for OutputBlobPublisher {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("OutputBlobPublisher")
+            .field("cloud", &self.cloud.is_some())
+            .finish()
+    }
+}
+
+struct CloudBlobPublisher {
+    client: reqwest::Client,
+    cloud_url: String,
+    notebook_id: String,
+    scope: String,
+    auth: CloudAuth,
+    uploaded: Mutex<HashSet<String>>,
+}
+
+impl CloudBlobPublisher {
+    fn new(config: &CloudWsConfig) -> Self {
+        Self {
+            client: reqwest::Client::new(),
+            cloud_url: config.cloud_url.trim_end_matches('/').to_string(),
+            notebook_id: config.notebook_id.clone(),
+            scope: config.scope.clone(),
+            auth: config.auth.clone(),
+            uploaded: Mutex::new(HashSet::new()),
+        }
+    }
+
+    async fn publish_blob(
+        &self,
+        blob: OutputBlobRef,
+        blob_store: &BlobStore,
+    ) -> Result<(), BlobPublishError> {
+        let upload_key = upload_dedupe_key(&blob);
+        if self.uploaded.lock().await.contains(&upload_key) {
+            return Ok(());
+        }
+
+        let bytes = blob_store
+            .get(&blob.hash)
+            .await
+            .map_err(|error| BlobPublishError::LocalRead {
+                hash: blob.hash.clone(),
+                message: error.to_string(),
+            })?
+            .ok_or_else(|| BlobPublishError::MissingLocalBlob {
+                hash: blob.hash.clone(),
+            })?;
+        if bytes.len() as u64 != blob.size {
+            return Err(BlobPublishError::SizeMismatch {
+                hash: blob.hash,
+                expected: blob.size,
+                actual: bytes.len() as u64,
+            });
+        }
+
+        for attempt in 1..=BLOB_UPLOAD_ATTEMPTS {
+            match self.upload_blob_once(&blob, bytes.clone()).await {
+                Ok(()) => {
+                    debug!(
+                        "[output-blob-publisher] uploaded blob {} ({} bytes, {})",
+                        blob.hash, blob.size, blob.media_type
+                    );
+                    self.uploaded.lock().await.insert(upload_key);
+                    return Ok(());
+                }
+                Err(error) if attempt < BLOB_UPLOAD_ATTEMPTS && error.is_retryable() => {
+                    warn!(
+                        "[output-blob-publisher] retrying blob {} upload after attempt {}/{} failed: {}",
+                        blob.hash, attempt, BLOB_UPLOAD_ATTEMPTS, error
+                    );
+                    sleep(upload_retry_delay(attempt)).await;
+                }
+                Err(error) => return Err(error),
+            }
+        }
+
+        Err(BlobPublishError::RemoteRequest {
+            hash: blob.hash,
+            message: "upload retry loop exhausted without a terminal error".to_string(),
+        })
+    }
+
+    async fn upload_blob_once(
+        &self,
+        blob: &OutputBlobRef,
+        bytes: Vec<u8>,
+    ) -> Result<(), BlobPublishError> {
+        let url = blob_upload_url(&self.cloud_url, &self.notebook_id, &blob.hash);
+        let mut request = self
+            .client
+            .put(url)
+            .header("X-Scope", &self.scope)
+            .header("X-Operator", "agent:runt:blob-publisher")
+            .header("Content-Type", &blob.media_type)
+            .body(bytes);
+        request = apply_auth_headers(request, &self.auth);
+
+        let response = request
+            .send()
+            .await
+            .map_err(|error| BlobPublishError::RemoteRequest {
+                hash: blob.hash.clone(),
+                message: error.to_string(),
+            })?;
+        let status = response.status();
+        if status != StatusCode::CREATED && status != StatusCode::OK {
+            let body = response.text().await.unwrap_or_default();
+            return Err(BlobPublishError::RemoteStatus {
+                hash: blob.hash.clone(),
+                status,
+                body,
+            });
+        }
+
+        Ok(())
+    }
+}
+
+#[derive(Debug, thiserror::Error)]
+pub(crate) enum BlobPublishError {
+    #[error("local blob {hash} is missing")]
+    MissingLocalBlob { hash: String },
+    #[error("failed to read local blob {hash}: {message}")]
+    LocalRead { hash: String, message: String },
+    #[error("local blob {hash} size mismatch: expected {expected}, got {actual}")]
+    SizeMismatch {
+        hash: String,
+        expected: u64,
+        actual: u64,
+    },
+    #[error("failed to upload blob {hash}: {message}")]
+    RemoteRequest { hash: String, message: String },
+    #[error("blob {hash} upload failed with {status}: {body}")]
+    RemoteStatus {
+        hash: String,
+        status: StatusCode,
+        body: String,
+    },
+}
+
+impl BlobPublishError {
+    fn is_retryable(&self) -> bool {
+        match self {
+            Self::RemoteRequest { .. } => true,
+            Self::RemoteStatus { status, .. } => {
+                *status == StatusCode::REQUEST_TIMEOUT
+                    || *status == StatusCode::TOO_MANY_REQUESTS
+                    || status.is_server_error()
+            }
+            Self::MissingLocalBlob { .. } | Self::LocalRead { .. } | Self::SizeMismatch { .. } => {
+                false
+            }
+        }
+    }
+}
+
+pub(crate) async fn publish_or_warn(
+    publisher: &OutputBlobPublisher,
+    manifest: &OutputManifest,
+    blob_store: &BlobStore,
+    context: &str,
+) -> Result<(), BlobPublishError> {
+    match publisher.publish_manifest_blobs(manifest, blob_store).await {
+        Ok(()) => Ok(()),
+        Err(error) => {
+            warn!("[output-blob-publisher] {context}: {error}");
+            Err(error)
+        }
+    }
+}
+
+fn apply_auth_headers(
+    request: reqwest::RequestBuilder,
+    auth: &CloudAuth,
+) -> reqwest::RequestBuilder {
+    match auth {
+        CloudAuth::OidcBearer { token } => request.bearer_auth(token),
+        CloudAuth::AnacondaApiKey { token } => request
+            .bearer_auth(token)
+            .header("X-Notebook-Cloud-Auth-Provider", "anaconda-api-key"),
+        CloudAuth::Dev { token, user } => request
+            .header("X-Notebook-Cloud-Dev-Token", token)
+            .header("X-User", user),
+    }
+}
+
+fn blob_upload_url(cloud_url: &str, notebook_id: &str, hash: &str) -> String {
+    format!(
+        "{}/api/n/{}/blobs/{}",
+        cloud_url.trim_end_matches('/'),
+        encode_path_segment(notebook_id),
+        encode_path_segment(hash)
+    )
+}
+
+fn upload_dedupe_key(blob: &OutputBlobRef) -> String {
+    format!("{}\0{}", blob.hash, blob.media_type)
+}
+
+fn upload_retry_delay(attempt: usize) -> Duration {
+    let multiplier = 1u64 << attempt.saturating_sub(1);
+    Duration::from_millis(BLOB_UPLOAD_RETRY_BASE_DELAY_MS * multiplier)
+}
+
+fn encode_path_segment(value: &str) -> String {
+    let mut encoded = String::with_capacity(value.len());
+    for byte in value.bytes() {
+        match byte {
+            b'A'..=b'Z' | b'a'..=b'z' | b'0'..=b'9' | b'-' | b'.' | b'_' | b'~' => {
+                encoded.push(byte as char)
+            }
+            _ => encoded.push_str(&format!("%{byte:02X}")),
+        }
+    }
+    encoded
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn blob_upload_url_percent_encodes_path_segments() {
+        assert_eq!(
+            blob_upload_url("https://preview.runt.run/", "room/id", "ab cd"),
+            "https://preview.runt.run/api/n/room%2Fid/blobs/ab%20cd"
+        );
+    }
+
+    #[test]
+    fn upload_dedupe_key_includes_media_type() {
+        let text = OutputBlobRef {
+            hash: "a".repeat(64),
+            size: 1,
+            media_type: "text/plain".to_string(),
+        };
+        let json = OutputBlobRef {
+            media_type: "application/json".to_string(),
+            ..text.clone()
+        };
+
+        assert_ne!(upload_dedupe_key(&text), upload_dedupe_key(&json));
+    }
+
+    #[test]
+    fn retry_policy_only_retries_transient_remote_failures() {
+        assert!(BlobPublishError::RemoteRequest {
+            hash: "a".to_string(),
+            message: "connection reset".to_string(),
+        }
+        .is_retryable());
+        assert!(BlobPublishError::RemoteStatus {
+            hash: "a".to_string(),
+            status: StatusCode::SERVICE_UNAVAILABLE,
+            body: String::new(),
+        }
+        .is_retryable());
+        assert!(BlobPublishError::RemoteStatus {
+            hash: "a".to_string(),
+            status: StatusCode::TOO_MANY_REQUESTS,
+            body: String::new(),
+        }
+        .is_retryable());
+        assert!(!BlobPublishError::RemoteStatus {
+            hash: "a".to_string(),
+            status: StatusCode::FORBIDDEN,
+            body: String::new(),
+        }
+        .is_retryable());
+        assert!(!BlobPublishError::SizeMismatch {
+            hash: "a".to_string(),
+            expected: 1,
+            actual: 2,
+        }
+        .is_retryable());
+    }
+}

--- a/crates/runtimed/src/output_commit_context.rs
+++ b/crates/runtimed/src/output_commit_context.rs
@@ -1,0 +1,46 @@
+//! Shared dependencies for output committer workers.
+//!
+//! The runtime has three output workers (ordinary outputs, stream flushes, and
+//! display updates). Keep their shared dependencies grouped so adding a cloud
+//! capability such as remote blob publishing does not widen every committer
+//! constructor.
+
+use std::sync::Arc;
+
+use runtime_doc::RuntimeStateHandle;
+use tokio::sync::mpsc;
+
+use crate::blob_store::BlobStore;
+use crate::output_blob_publisher::OutputBlobPublisher;
+use crate::output_prep::LifecycleSignal;
+use crate::output_redaction::OutputRedactor;
+
+#[derive(Clone)]
+pub(crate) struct OutputCommitContext {
+    pub(crate) state: RuntimeStateHandle,
+    pub(crate) blob_store: Arc<BlobStore>,
+    pub(crate) blob_publisher: OutputBlobPublisher,
+    pub(crate) kernel_actor_id: String,
+    pub(crate) lifecycle_tx: mpsc::UnboundedSender<LifecycleSignal>,
+    pub(crate) redactor: Arc<OutputRedactor>,
+}
+
+impl OutputCommitContext {
+    pub(crate) fn new(
+        state: RuntimeStateHandle,
+        blob_store: Arc<BlobStore>,
+        blob_publisher: OutputBlobPublisher,
+        kernel_actor_id: String,
+        lifecycle_tx: mpsc::UnboundedSender<LifecycleSignal>,
+        redactor: Arc<OutputRedactor>,
+    ) -> Self {
+        Self {
+            state,
+            blob_store,
+            blob_publisher,
+            kernel_actor_id,
+            lifecycle_tx,
+            redactor,
+        }
+    }
+}

--- a/crates/runtimed/src/output_committer.rs
+++ b/crates/runtimed/src/output_committer.rs
@@ -6,15 +6,12 @@
 //! terminal lifecycle signals must still wait until all queued output commits
 //! are durable in RuntimeStateDoc.
 
-use std::sync::Arc;
-
-use runtime_doc::RuntimeStateHandle;
 use tokio::sync::{mpsc, oneshot};
 use tracing::{debug, warn};
 
-use crate::blob_store::BlobStore;
+use crate::output_blob_publisher::publish_or_warn;
+use crate::output_commit_context::OutputCommitContext;
 use crate::output_prep::LifecycleSignal;
-use crate::output_redaction::OutputRedactor;
 use crate::output_store::{self, DEFAULT_INLINE_THRESHOLD};
 use crate::task_supervisor::spawn_supervised;
 
@@ -59,14 +56,6 @@ struct PriorityOutputRequest {
     output: Option<OrdinaryOutputCommit>,
     signal: Option<LifecycleSignal>,
     ack: Option<oneshot::Sender<()>>,
-}
-
-struct OutputCommitterContext {
-    state: RuntimeStateHandle,
-    blob_store: Arc<BlobStore>,
-    kernel_actor_id: String,
-    lifecycle_tx: mpsc::UnboundedSender<LifecycleSignal>,
-    output_redactor: Arc<OutputRedactor>,
 }
 
 #[derive(Clone)]
@@ -135,7 +124,7 @@ impl OutputCommitterHandle {
 async fn commit_priority_request(
     request: PriorityOutputRequest,
     output_rx: &mut mpsc::Receiver<OrdinaryOutputCommit>,
-    context: &OutputCommitterContext,
+    context: &OutputCommitContext,
 ) {
     drain_queued_outputs(output_rx, context).await;
     if let Some(output) = request.output {
@@ -151,7 +140,7 @@ async fn commit_priority_request(
 
 async fn drain_queued_outputs(
     output_rx: &mut mpsc::Receiver<OrdinaryOutputCommit>,
-    context: &OutputCommitterContext,
+    context: &OutputCommitContext,
 ) {
     loop {
         let mut batch = Vec::with_capacity(OUTPUT_COMMIT_BATCH_SIZE);
@@ -171,7 +160,7 @@ async fn drain_queued_outputs(
 async fn run_output_committer(
     mut output_rx: mpsc::Receiver<OrdinaryOutputCommit>,
     mut priority_rx: mpsc::UnboundedReceiver<PriorityOutputRequest>,
-    context: OutputCommitterContext,
+    context: OutputCommitContext,
 ) {
     loop {
         tokio::select! {
@@ -206,41 +195,18 @@ async fn run_output_committer(
     }
 }
 
-pub(crate) fn start_output_committer(
-    state: RuntimeStateHandle,
-    blob_store: Arc<BlobStore>,
-    kernel_actor_id: String,
-    lifecycle_tx: mpsc::UnboundedSender<LifecycleSignal>,
-    output_redactor: Arc<OutputRedactor>,
-) -> OutputCommitterHandle {
-    start_output_committer_with_capacity(
-        state,
-        blob_store,
-        kernel_actor_id,
-        lifecycle_tx,
-        output_redactor,
-        OUTPUT_COMMITTER_QUEUE_CAPACITY,
-    )
+pub(crate) fn start_output_committer(context: OutputCommitContext) -> OutputCommitterHandle {
+    start_output_committer_with_capacity(context, OUTPUT_COMMITTER_QUEUE_CAPACITY)
 }
 
 fn start_output_committer_with_capacity(
-    state: RuntimeStateHandle,
-    blob_store: Arc<BlobStore>,
-    kernel_actor_id: String,
-    lifecycle_tx: mpsc::UnboundedSender<LifecycleSignal>,
-    output_redactor: Arc<OutputRedactor>,
+    context: OutputCommitContext,
     capacity: usize,
 ) -> OutputCommitterHandle {
     let (output_tx, output_rx) = mpsc::channel(capacity);
     let (priority_tx, priority_rx) = mpsc::unbounded_channel();
+    let lifecycle_tx = context.lifecycle_tx.clone();
     let panic_lifecycle_tx = lifecycle_tx.clone();
-    let context = OutputCommitterContext {
-        state,
-        blob_store,
-        kernel_actor_id,
-        lifecycle_tx: lifecycle_tx.clone(),
-        output_redactor,
-    };
     spawn_supervised(
         "output-committer",
         run_output_committer(output_rx, priority_rx, context),
@@ -255,7 +221,7 @@ fn start_output_committer_with_capacity(
     }
 }
 
-async fn commit_output_batch(outputs: Vec<OrdinaryOutputCommit>, context: &OutputCommitterContext) {
+async fn commit_output_batch(outputs: Vec<OrdinaryOutputCommit>, context: &OutputCommitContext) {
     if outputs.is_empty() {
         return;
     }
@@ -289,7 +255,7 @@ async fn commit_output_batch(outputs: Vec<OrdinaryOutputCommit>, context: &Outpu
 
 async fn create_manifest_json(
     output: &OrdinaryOutputCommit,
-    context: &OutputCommitterContext,
+    context: &OutputCommitContext,
 ) -> serde_json::Value {
     if output.kind.uses_buffer_preflight() {
         output_store::preflight_ref_buffers(
@@ -304,28 +270,56 @@ async fn create_manifest_json(
         &output.nbformat_value,
         &context.blob_store,
         DEFAULT_INLINE_THRESHOLD,
-        &context.output_redactor,
+        &context.redactor,
     )
     .await
     {
-        Ok(manifest) => manifest.to_json(),
+        Ok(manifest) => {
+            if let Err(error) = publish_or_warn(
+                &context.blob_publisher,
+                &manifest,
+                &context.blob_store,
+                "ordinary output blob publish failed",
+            )
+            .await
+            {
+                return blob_publish_failure_output(output.kind.label(), &error);
+            }
+            manifest.to_json()
+        }
         Err(e) => {
             warn!(
                 "[output-committer] Failed to create {} manifest: {}",
                 output.kind.label(),
                 e
             );
-            let redacted = context
-                .output_redactor
-                .redact_output_value(&output.nbformat_value);
+            let redacted = context.redactor.redact_output_value(&output.nbformat_value);
             crate::notebook_sync_server::fallback_output_with_id(&redacted)
         }
     }
 }
 
+fn blob_publish_failure_output(kind: &str, error: &dyn std::error::Error) -> serde_json::Value {
+    serde_json::json!({
+        "output_type": "error",
+        "ename": "OutputBlobPublishError",
+        "evalue": format!("Unable to publish {kind} blob before syncing output: {error}"),
+        "traceback": [
+            format!("Unable to publish {kind} blob before syncing output: {error}")
+        ],
+    })
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::sync::Arc;
+
+    use runtime_doc::RuntimeStateHandle;
+
+    use crate::blob_store::BlobStore;
+    use crate::output_blob_publisher::OutputBlobPublisher;
+    use crate::output_redaction::OutputRedactor;
 
     fn runtime_state() -> RuntimeStateHandle {
         let state_doc =
@@ -341,6 +335,21 @@ mod tests {
                 Ok(())
             })
             .expect("execution entry");
+    }
+
+    fn commit_context(
+        state: RuntimeStateHandle,
+        blob_store: Arc<BlobStore>,
+        lifecycle_tx: mpsc::UnboundedSender<LifecycleSignal>,
+    ) -> OutputCommitContext {
+        OutputCommitContext::new(
+            state,
+            blob_store,
+            OutputBlobPublisher::none(),
+            "rt:kernel:test".to_string(),
+            lifecycle_tx,
+            Arc::new(OutputRedactor::disabled()),
+        )
     }
 
     fn display_output(text: &str) -> serde_json::Value {
@@ -377,11 +386,7 @@ mod tests {
         create_execution(&state);
         let (lifecycle_tx, mut lifecycle_rx) = mpsc::unbounded_channel();
         let handle = start_output_committer_with_capacity(
-            state.clone(),
-            blob_store,
-            "rt:kernel:test".to_string(),
-            lifecycle_tx,
-            Arc::new(OutputRedactor::disabled()),
+            commit_context(state.clone(), blob_store, lifecycle_tx),
             8,
         );
 
@@ -421,11 +426,7 @@ mod tests {
         create_execution(&state);
         let (lifecycle_tx, _lifecycle_rx) = mpsc::unbounded_channel();
         let handle = start_output_committer_with_capacity(
-            state.clone(),
-            blob_store,
-            "rt:kernel:test".to_string(),
-            lifecycle_tx,
-            Arc::new(OutputRedactor::disabled()),
+            commit_context(state.clone(), blob_store, lifecycle_tx),
             1,
         );
 
@@ -463,11 +464,7 @@ mod tests {
         create_execution(&state);
         let (lifecycle_tx, mut lifecycle_rx) = mpsc::unbounded_channel();
         let handle = start_output_committer_with_capacity(
-            state.clone(),
-            blob_store,
-            "rt:kernel:test".to_string(),
-            lifecycle_tx,
-            Arc::new(OutputRedactor::disabled()),
+            commit_context(state.clone(), blob_store, lifecycle_tx),
             8,
         );
 
@@ -503,14 +500,9 @@ mod tests {
         let state = runtime_state();
         create_execution(&state);
         let (lifecycle_tx, mut lifecycle_rx) = mpsc::unbounded_channel();
-        let output_handle = start_output_committer_with_capacity(
-            state.clone(),
-            blob_store.clone(),
-            "rt:kernel:test".to_string(),
-            lifecycle_tx.clone(),
-            Arc::new(OutputRedactor::disabled()),
-            8,
-        );
+        let output_context =
+            commit_context(state.clone(), blob_store.clone(), lifecycle_tx.clone());
+        let output_handle = start_output_committer_with_capacity(output_context.clone(), 8);
 
         let terminals = Arc::new(tokio::sync::Mutex::new(
             crate::stream_terminal::StreamTerminals::new(),
@@ -519,14 +511,8 @@ mod tests {
             let mut terminals = terminals.lock().await;
             terminals.feed_chunk("exec-1", "stdout", "stream-after-display\n");
         }
-        let stream_handle = crate::stream_committer::start_stream_committer(
-            state.clone(),
-            blob_store,
-            terminals,
-            "rt:kernel:test".to_string(),
-            lifecycle_tx,
-            Arc::new(OutputRedactor::disabled()),
-        );
+        let stream_handle =
+            crate::stream_committer::start_stream_committer(output_context, terminals);
 
         output_handle
             .enqueue_output(OrdinaryOutputCommit {
@@ -572,21 +558,11 @@ mod tests {
         let state = runtime_state();
         create_execution(&state);
         let (lifecycle_tx, _lifecycle_rx) = mpsc::unbounded_channel();
-        let output_handle = start_output_committer_with_capacity(
-            state.clone(),
-            blob_store.clone(),
-            "rt:kernel:test".to_string(),
-            lifecycle_tx.clone(),
-            Arc::new(OutputRedactor::disabled()),
-            8,
-        );
-        let display_handle = crate::display_update_committer::start_display_update_committer(
-            state.clone(),
-            blob_store,
-            "rt:kernel:test".to_string(),
-            lifecycle_tx,
-            Arc::new(OutputRedactor::disabled()),
-        );
+        let output_context =
+            commit_context(state.clone(), blob_store.clone(), lifecycle_tx.clone());
+        let output_handle = start_output_committer_with_capacity(output_context.clone(), 8);
+        let display_handle =
+            crate::display_update_committer::start_display_update_committer(output_context);
 
         output_handle
             .enqueue_output(OrdinaryOutputCommit {

--- a/crates/runtimed/src/output_prep.rs
+++ b/crates/runtimed/src/output_prep.rs
@@ -13,6 +13,7 @@ use serde::Serialize;
 use tokio::sync::mpsc;
 
 use crate::blob_store::BlobStore;
+use crate::output_blob_publisher::{publish_or_warn, OutputBlobPublisher};
 use crate::output_redaction::OutputRedactor;
 use crate::output_store::{self, OutputManifest, DEFAULT_INLINE_THRESHOLD};
 use runtime_doc::RuntimeStateDoc;
@@ -363,6 +364,7 @@ pub(crate) async fn build_display_manifest_updates(
     new_data: &serde_json::Value,
     new_metadata: &serde_json::Map<String, serde_json::Value>,
     blob_store: &BlobStore,
+    output_blob_publisher: &OutputBlobPublisher,
     redactor: &OutputRedactor,
 ) -> Result<Vec<DisplayManifestUpdate>, Box<dyn std::error::Error + Send + Sync>> {
     let mut updates = Vec::new();
@@ -378,6 +380,13 @@ pub(crate) async fn build_display_manifest_updates(
         )
         .await?
         {
+            publish_or_warn(
+                output_blob_publisher,
+                &updated,
+                blob_store,
+                "display update blob publish failed",
+            )
+            .await?;
             updates.push(DisplayManifestUpdate {
                 execution_id: target.execution_id,
                 output_id: target.output_id,
@@ -662,6 +671,7 @@ mod tests {
             new_data,
             new_metadata,
             blob_store,
+            &OutputBlobPublisher::none(),
             redactor,
         )
         .await?;

--- a/crates/runtimed/src/output_store.rs
+++ b/crates/runtimed/src/output_store.rs
@@ -110,6 +110,13 @@ pub enum ContentRef {
     Blob { blob: String, size: u64 },
 }
 
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct OutputBlobRef {
+    pub(crate) hash: String,
+    pub(crate) size: u64,
+    pub(crate) media_type: String,
+}
+
 impl ContentRef {
     /// Create a ContentRef from data, applying the inlining threshold.
     ///
@@ -518,6 +525,40 @@ impl OutputManifest {
         if id.is_empty() {
             *id = uuid::Uuid::new_v4().to_string();
         }
+    }
+
+    pub(crate) fn blob_refs(&self) -> Vec<OutputBlobRef> {
+        let mut refs = Vec::new();
+        match self {
+            OutputManifest::DisplayData { data, .. }
+            | OutputManifest::ExecuteResult { data, .. } => {
+                for (media_type, content_ref) in data {
+                    push_blob_ref(&mut refs, content_ref, media_type);
+                }
+            }
+            OutputManifest::Stream { text, .. } => {
+                push_blob_ref(&mut refs, text, "text/plain");
+            }
+            OutputManifest::Error {
+                traceback, rich, ..
+            } => {
+                push_blob_ref(&mut refs, traceback, "application/json");
+                if let Some(rich) = rich {
+                    push_blob_ref(&mut refs, rich, "application/json");
+                }
+            }
+        }
+        refs
+    }
+}
+
+fn push_blob_ref(refs: &mut Vec<OutputBlobRef>, content_ref: &ContentRef, media_type: &str) {
+    if let ContentRef::Blob { blob, size } = content_ref {
+        refs.push(OutputBlobRef {
+            hash: blob.clone(),
+            size: *size,
+            media_type: media_type.to_string(),
+        });
     }
 }
 
@@ -1658,6 +1699,87 @@ mod tests {
         let p = ErrorPreview::from_traceback_value(&tb);
         assert_eq!(p.last_frame, "");
         assert_eq!(p.frames, 0);
+    }
+
+    #[test]
+    fn output_manifest_blob_refs_collect_direct_content_refs() {
+        let mut display_data = HashMap::new();
+        display_data.insert(
+            "image/png".to_string(),
+            ContentRef::Blob {
+                blob: "image-hash".to_string(),
+                size: 123,
+            },
+        );
+        display_data.insert(
+            "text/plain".to_string(),
+            ContentRef::Inline {
+                inline: "inline fallback".to_string(),
+            },
+        );
+        let display = OutputManifest::DisplayData {
+            output_id: "out-display".to_string(),
+            data: display_data,
+            metadata: HashMap::new(),
+            transient: TransientData::default(),
+        };
+
+        let stream = OutputManifest::Stream {
+            output_id: "out-stream".to_string(),
+            name: "stdout".to_string(),
+            text: ContentRef::Blob {
+                blob: "stream-hash".to_string(),
+                size: 456,
+            },
+            llm_preview: None,
+        };
+
+        let error = OutputManifest::Error {
+            output_id: "out-error".to_string(),
+            ename: "ValueError".to_string(),
+            evalue: "bad".to_string(),
+            traceback: ContentRef::Blob {
+                blob: "traceback-hash".to_string(),
+                size: 789,
+            },
+            llm_preview: None,
+            rich: Some(ContentRef::Blob {
+                blob: "rich-hash".to_string(),
+                size: 321,
+            }),
+        };
+
+        let mut refs = Vec::new();
+        refs.extend(display.blob_refs());
+        refs.extend(stream.blob_refs());
+        refs.extend(error.blob_refs());
+        refs.sort_by(|left, right| left.hash.cmp(&right.hash));
+
+        assert_eq!(
+            refs,
+            vec![
+                OutputBlobRef {
+                    hash: "image-hash".to_string(),
+                    size: 123,
+                    media_type: "image/png".to_string(),
+                },
+                OutputBlobRef {
+                    hash: "rich-hash".to_string(),
+                    size: 321,
+                    media_type: "application/json".to_string(),
+                },
+                OutputBlobRef {
+                    hash: "stream-hash".to_string(),
+                    size: 456,
+                    media_type: "text/plain".to_string(),
+                },
+                OutputBlobRef {
+                    hash: "traceback-hash".to_string(),
+                    size: 789,
+                    media_type: "application/json".to_string(),
+                },
+            ]
+        );
     }
 
     #[test]

--- a/crates/runtimed/src/runtime_agent.rs
+++ b/crates/runtimed/src/runtime_agent.rs
@@ -48,6 +48,7 @@ use crate::blob_store::BlobStore;
 use crate::jupyter_kernel::JupyterKernel;
 use crate::kernel_connection::{KernelConnection, KernelLaunchConfig, KernelSharedRefs};
 use crate::kernel_state::KernelState;
+use crate::output_blob_publisher::OutputBlobPublisher;
 use crate::output_prep::{LifecycleSignal, QueueCommandReceivers, WorkCommand};
 use crate::protocol::QueueEntry;
 
@@ -92,6 +93,7 @@ struct RuntimeAgentContext {
     state: RuntimeStateHandle,
     comms: CommsDocHandle,
     blob_store: Arc<BlobStore>,
+    output_blob_publisher: OutputBlobPublisher,
     broadcast_tx: broadcast::Sender<notebook_protocol::protocol::NotebookBroadcast>,
     presence: Arc<RwLock<PresenceState>>,
     presence_tx: broadcast::Sender<(String, Vec<u8>)>,
@@ -127,6 +129,7 @@ pub async fn run_runtime_agent(
         notebook_id,
         blob_root,
         move |_| Ok(runtime_agent_id),
+        OutputBlobPublisher::none(),
         // The daemon/UDS path never launches on attach: the daemon drives launch
         // via an inbound `LaunchKernel` RPC. Always `None` here.
         None,
@@ -179,6 +182,7 @@ pub async fn run_cloud_runtime_agent(
         initial_launch.is_some(),
     );
 
+    let output_blob_publisher = OutputBlobPublisher::cloud(&config);
     let transport = notebook_cloud_transport::CloudWsFrameTransport::new(config);
 
     run_runtime_agent_on_transport(
@@ -193,6 +197,7 @@ pub async fn run_cloud_runtime_agent(
             })?;
             Ok(cloud_actor_label(principal, &operator))
         },
+        output_blob_publisher,
         initial_launch,
     )
     .await
@@ -268,6 +273,7 @@ async fn run_runtime_agent_on_transport<T, F>(
     notebook_id: String,
     blob_root: PathBuf,
     resolve_actor: F,
+    output_blob_publisher: OutputBlobPublisher,
     initial_launch: Option<RuntimeAgentRequest>,
 ) -> anyhow::Result<()>
 where
@@ -327,6 +333,7 @@ where
         state: state.clone(),
         comms: comms.clone(),
         blob_store,
+        output_blob_publisher,
         broadcast_tx: broadcast_tx.clone(),
         presence,
         presence_tx,
@@ -1406,6 +1413,7 @@ async fn handle_runtime_agent_request(
                 state: ctx.state.clone(),
                 comms: ctx.comms.clone(),
                 blob_store: ctx.blob_store.clone(),
+                output_blob_publisher: ctx.output_blob_publisher.clone(),
                 broadcast_tx: ctx.broadcast_tx.clone(),
                 presence: ctx.presence.clone(),
                 presence_tx: ctx.presence_tx.clone(),
@@ -1526,6 +1534,7 @@ async fn handle_runtime_agent_request(
                 state: ctx.state.clone(),
                 comms: ctx.comms.clone(),
                 blob_store: ctx.blob_store.clone(),
+                output_blob_publisher: ctx.output_blob_publisher.clone(),
                 broadcast_tx: ctx.broadcast_tx.clone(),
                 presence: ctx.presence.clone(),
                 presence_tx: ctx.presence_tx.clone(),
@@ -2790,6 +2799,7 @@ mod tests {
             state: handle.clone(),
             comms,
             blob_store,
+            output_blob_publisher: OutputBlobPublisher::none(),
             broadcast_tx: broadcast_tx.clone(),
             presence,
             presence_tx,

--- a/crates/runtimed/src/stream_committer.rs
+++ b/crates/runtimed/src/stream_committer.rs
@@ -10,13 +10,12 @@
 
 use std::sync::Arc;
 
-use runtime_doc::RuntimeStateHandle;
 use tokio::sync::{mpsc, oneshot, Mutex};
 use tracing::{debug, warn};
 
-use crate::blob_store::BlobStore;
+use crate::output_blob_publisher::publish_or_warn;
+use crate::output_commit_context::OutputCommitContext;
 use crate::output_prep::LifecycleSignal;
-use crate::output_redaction::OutputRedactor;
 use crate::output_store::{self, ContentRef, OutputManifest, DEFAULT_INLINE_THRESHOLD};
 use crate::stream_flush::PendingStreamFlush;
 use crate::stream_terminal::{StreamOutputState, StreamTerminals};
@@ -32,12 +31,8 @@ struct PriorityStreamCommit {
 }
 
 struct StreamCommitterContext {
-    state: RuntimeStateHandle,
-    blob_store: Arc<BlobStore>,
+    output: OutputCommitContext,
     stream_terminals: Arc<Mutex<StreamTerminals>>,
-    kernel_actor_id: String,
-    lifecycle_tx: mpsc::UnboundedSender<LifecycleSignal>,
-    output_redactor: Arc<OutputRedactor>,
 }
 
 #[derive(Clone)]
@@ -125,51 +120,20 @@ impl StreamCommitterHandle {
     }
 }
 
-async fn commit_priority_streams(
-    request: PriorityStreamCommit,
-    state: &RuntimeStateHandle,
-    blob_store: &BlobStore,
-    stream_terminals: &Arc<Mutex<StreamTerminals>>,
-    kernel_actor_id: &str,
-    lifecycle_tx: &mpsc::UnboundedSender<LifecycleSignal>,
-    output_redactor: &OutputRedactor,
-) {
+async fn commit_priority_streams(request: PriorityStreamCommit, context: &StreamCommitterContext) {
     for flush in request.flushes {
-        commit_stream_flush(
-            state,
-            blob_store,
-            stream_terminals,
-            kernel_actor_id,
-            flush,
-            output_redactor,
-        )
-        .await;
+        commit_stream_flush(&context.output, &context.stream_terminals, flush).await;
     }
     if let Some(signal) = request.signal {
-        let _ = lifecycle_tx.send(signal);
+        let _ = context.output.lifecycle_tx.send(signal);
     }
     if let Some(ack) = request.ack {
         let _ = ack.send(());
     }
 }
 
-async fn commit_periodic_stream(
-    flush: PendingStreamFlush,
-    state: &RuntimeStateHandle,
-    blob_store: &BlobStore,
-    stream_terminals: &Arc<Mutex<StreamTerminals>>,
-    kernel_actor_id: &str,
-    output_redactor: &OutputRedactor,
-) {
-    commit_stream_flush(
-        state,
-        blob_store,
-        stream_terminals,
-        kernel_actor_id,
-        flush,
-        output_redactor,
-    )
-    .await;
+async fn commit_periodic_stream(flush: PendingStreamFlush, context: &StreamCommitterContext) {
+    commit_stream_flush(&context.output, &context.stream_terminals, flush).await;
 }
 
 async fn run_stream_committer(
@@ -184,23 +148,14 @@ async fn run_stream_committer(
             Some(request) = priority_rx.recv() => {
                 commit_priority_streams(
                     request,
-                    &context.state,
-                    &context.blob_store,
-                    &context.stream_terminals,
-                    &context.kernel_actor_id,
-                    &context.lifecycle_tx,
-                    &context.output_redactor,
+                    &context,
                 ).await;
             }
 
             Some(flush) = periodic_rx.recv() => {
                 commit_periodic_stream(
                     flush,
-                    &context.state,
-                    &context.blob_store,
-                    &context.stream_terminals,
-                    &context.kernel_actor_id,
-                    &context.output_redactor,
+                    &context,
                 ).await;
             }
 
@@ -210,23 +165,16 @@ async fn run_stream_committer(
 }
 
 pub(crate) fn start_stream_committer(
-    state: RuntimeStateHandle,
-    blob_store: Arc<BlobStore>,
+    output: OutputCommitContext,
     stream_terminals: Arc<Mutex<StreamTerminals>>,
-    kernel_actor_id: String,
-    lifecycle_tx: mpsc::UnboundedSender<LifecycleSignal>,
-    output_redactor: Arc<OutputRedactor>,
 ) -> StreamCommitterHandle {
     let (periodic_tx, periodic_rx) = mpsc::channel(STREAM_COMMITTER_QUEUE_CAPACITY);
     let (priority_tx, priority_rx) = mpsc::unbounded_channel();
+    let lifecycle_tx = output.lifecycle_tx.clone();
     let panic_lifecycle_tx = lifecycle_tx.clone();
     let context = StreamCommitterContext {
-        state,
-        blob_store,
+        output,
         stream_terminals,
-        kernel_actor_id,
-        lifecycle_tx: lifecycle_tx.clone(),
-        output_redactor,
     };
     // If the committer task panics, route `KernelDied` to the lifecycle
     // channel so the queue releases. The runtime agent treats this signal
@@ -248,12 +196,9 @@ pub(crate) fn start_stream_committer(
 }
 
 pub(crate) async fn commit_stream_flush(
-    state: &RuntimeStateHandle,
-    blob_store: &BlobStore,
+    context: &OutputCommitContext,
     stream_terminals: &Arc<Mutex<StreamTerminals>>,
-    kernel_actor_id: &str,
     flush: PendingStreamFlush,
-    output_redactor: &OutputRedactor,
 ) {
     let (known_state, rendered_text) = {
         let terminals = stream_terminals.lock().await;
@@ -282,9 +227,9 @@ pub(crate) async fn commit_stream_flush(
 
     let manifest = match output_store::create_manifest_with_redactor(
         &nbformat_value,
-        blob_store,
+        &context.blob_store,
         DEFAULT_INLINE_THRESHOLD,
-        output_redactor,
+        &context.redactor,
     )
     .await
     {
@@ -295,6 +240,17 @@ pub(crate) async fn commit_stream_flush(
         }
     };
     let manifest_json = manifest.to_json();
+    if publish_or_warn(
+        &context.blob_publisher,
+        &manifest,
+        &context.blob_store,
+        "stream output blob publish failed",
+    )
+    .await
+    .is_err()
+    {
+        return;
+    }
 
     let blob_hash = if let OutputManifest::Stream { ref text, .. } = manifest {
         match text {
@@ -305,8 +261,8 @@ pub(crate) async fn commit_stream_flush(
         String::new()
     };
 
-    let upsert_result = match state.transact_at_current_heads(
-        Some(kernel_actor_id),
+    let upsert_result = match context.state.transact_at_current_heads(
+        Some(&context.kernel_actor_id),
         "runtime-state-iopub-stream-transaction",
         |sd| match sd.upsert_stream_output(
             &flush.execution_id,
@@ -343,6 +299,11 @@ pub(crate) async fn commit_stream_flush(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use runtime_doc::RuntimeStateHandle;
+
+    use crate::blob_store::BlobStore;
+    use crate::output_blob_publisher::OutputBlobPublisher;
+    use crate::output_redaction::OutputRedactor;
 
     fn runtime_state() -> RuntimeStateHandle {
         let state_doc =
@@ -360,6 +321,21 @@ mod tests {
             .expect("execution entry");
     }
 
+    fn commit_context(
+        state: RuntimeStateHandle,
+        blob_store: Arc<BlobStore>,
+        lifecycle_tx: mpsc::UnboundedSender<LifecycleSignal>,
+    ) -> OutputCommitContext {
+        OutputCommitContext::new(
+            state,
+            blob_store,
+            OutputBlobPublisher::none(),
+            "rt:kernel:test".to_string(),
+            lifecycle_tx,
+            Arc::new(OutputRedactor::disabled()),
+        )
+    }
+
     #[tokio::test]
     async fn flush_then_signal_commits_stream_before_lifecycle_signal() {
         let dir = tempfile::TempDir::new().expect("tempdir");
@@ -375,12 +351,8 @@ mod tests {
 
         let (lifecycle_tx, mut lifecycle_rx) = mpsc::unbounded_channel();
         let handle = start_stream_committer(
-            state.clone(),
-            blob_store,
+            commit_context(state.clone(), blob_store, lifecycle_tx),
             terminals,
-            "rt:kernel:test".to_string(),
-            lifecycle_tx,
-            Arc::new(OutputRedactor::disabled()),
         );
 
         handle.flush_then_signal(
@@ -421,12 +393,8 @@ mod tests {
 
         let (lifecycle_tx, mut lifecycle_rx) = mpsc::unbounded_channel();
         let handle = start_stream_committer(
-            state.clone(),
-            blob_store,
+            commit_context(state.clone(), blob_store, lifecycle_tx),
             terminals,
-            "rt:kernel:test".to_string(),
-            lifecycle_tx,
-            Arc::new(OutputRedactor::disabled()),
         );
 
         handle
@@ -446,21 +414,20 @@ mod tests {
     #[tokio::test]
     async fn stale_stream_flush_after_clear_is_ignored() {
         let dir = tempfile::TempDir::new().expect("tempdir");
-        let blob_store = BlobStore::new(dir.path().to_path_buf());
+        let blob_store = Arc::new(BlobStore::new(dir.path().to_path_buf()));
         let state = runtime_state();
         create_execution(&state);
         let terminals = Arc::new(Mutex::new(StreamTerminals::new()));
+        let (lifecycle_tx, _lifecycle_rx) = mpsc::unbounded_channel();
+        let context = commit_context(state.clone(), blob_store, lifecycle_tx);
 
         commit_stream_flush(
-            &state,
-            &blob_store,
+            &context,
             &terminals,
-            "rt:kernel:test",
             PendingStreamFlush {
                 execution_id: "exec-1".to_string(),
                 stream_name: "stdout".to_string(),
             },
-            &OutputRedactor::disabled(),
         )
         .await;
 

--- a/packages/runtimed/src/blob-resolver.ts
+++ b/packages/runtimed/src/blob-resolver.ts
@@ -15,6 +15,19 @@ export interface BlobResolver {
   /** Return a browser-consumable URL for renderers that stream/fetch directly. */
   url(ref: BlobRef): string;
 
+  /**
+   * Return a browser-consumable display URL after any host-owned auth/proxy
+   * work. Cloud hosts use this to turn protected binary blobs into same-page
+   * object URLs without putting bearer credentials into `<img src>` URLs.
+   */
+  displayUrl?(ref: BlobRef): Promise<string>;
+
+  /**
+   * Whether binary MIME refs can be resolved through `url()` without awaiting
+   * `displayUrl()`. Local daemon HTTP URLs can; protected cloud URLs cannot.
+   */
+  readonly resolvesBinaryUrlsSynchronously?: boolean;
+
   /** Fetch blob bytes/text through the host, including any auth/proxy policy. */
   fetch(ref: BlobRef): Promise<Response>;
 }
@@ -23,6 +36,8 @@ export type BlobResolverInput = BlobResolver | number;
 
 export interface BlobResolverOptions {
   url(ref: BlobRef): string;
+  displayUrl?: (ref: BlobRef) => Promise<string>;
+  resolvesBinaryUrlsSynchronously?: boolean;
   fetchImpl?: typeof fetch;
   requestInit?: RequestInit | ((ref: BlobRef) => RequestInit);
 }
@@ -47,6 +62,8 @@ export function createBlobResolver(options: BlobResolverOptions): BlobResolver {
     fetch(ref) {
       return fetchImpl(options.url(ref), requestInitFor(options.requestInit, ref));
     },
+    ...(options.displayUrl ? { displayUrl: options.displayUrl } : {}),
+    resolvesBinaryUrlsSynchronously: options.resolvesBinaryUrlsSynchronously ?? true,
   };
 }
 
@@ -62,6 +79,7 @@ export function createHttpBlobResolver(
     fetch(ref) {
       return fetchImpl(url(ref));
     },
+    resolvesBinaryUrlsSynchronously: true,
   };
 }
 

--- a/packages/runtimed/src/blob-resolver.ts
+++ b/packages/runtimed/src/blob-resolver.ts
@@ -17,10 +17,10 @@ export interface BlobResolver {
 
   /**
    * Return a browser-consumable display URL after any host-owned auth/proxy
-   * work. Cloud hosts use this to turn protected binary blobs into same-page
-   * object URLs without putting bearer credentials into `<img src>` URLs.
+   * work. Cloud hosts use this to turn protected binary blobs into display
+   * URLs without putting bearer credentials into `<img src>` URLs.
    */
-  displayUrl?(ref: BlobRef): Promise<string>;
+  displayUrl?(ref: BlobRef, mediaType?: string): Promise<string>;
 
   /**
    * Whether binary MIME refs can be resolved through `url()` without awaiting
@@ -36,7 +36,7 @@ export type BlobResolverInput = BlobResolver | number;
 
 export interface BlobResolverOptions {
   url(ref: BlobRef): string;
-  displayUrl?: (ref: BlobRef) => Promise<string>;
+  displayUrl?: (ref: BlobRef, mediaType?: string) => Promise<string>;
   resolvesBinaryUrlsSynchronously?: boolean;
   fetchImpl?: typeof fetch;
   requestInit?: RequestInit | ((ref: BlobRef) => RequestInit);

--- a/packages/runtimed/src/index.ts
+++ b/packages/runtimed/src/index.ts
@@ -214,6 +214,9 @@ export {
   type NotebookShellExecutionPolicy,
   type NotebookShellPackagePolicy,
   type NotebookShellRuntimeCapabilities,
+  type NotebookShellRuntimeTargetKind,
+  type NotebookShellRuntimeTargetProjection,
+  type NotebookShellRuntimeTargetStatus,
   type NotebookShellSharingPolicy,
   type ProjectNotebookShellCapabilitiesOptions,
 } from "./notebook-shell-capabilities";

--- a/packages/runtimed/src/notebook-shell-capabilities.ts
+++ b/packages/runtimed/src/notebook-shell-capabilities.ts
@@ -41,6 +41,31 @@ export interface NotebookShellAuthCapabilities {
   needsAttention: boolean;
 }
 
+export type NotebookShellRuntimeTargetKind =
+  | "local_daemon"
+  | "cloud_workstation"
+  | "runtime_peer"
+  | "fixture"
+  | "unknown";
+
+export type NotebookShellRuntimeTargetStatus =
+  | "ready"
+  | "attached"
+  | "available"
+  | "connecting"
+  | "offline"
+  | "attention";
+
+export interface NotebookShellRuntimeTargetProjection {
+  kind: NotebookShellRuntimeTargetKind;
+  status: NotebookShellRuntimeTargetStatus;
+  label: string;
+  statusLabel?: string | null;
+  detail?: string | null;
+  providerLabel?: string | null;
+  environmentLabel?: string | null;
+}
+
 export interface NotebookShellRuntimeCapabilities {
   /**
    * Runtime peers author execution lifecycle, output, and comm state. This is
@@ -62,6 +87,12 @@ export interface NotebookShellRuntimeCapabilities {
   actorLabel: string | null;
   identityLabel: string | null;
   actor?: NotebookActorProjection | null;
+  /**
+   * Host-owned compute target projection. This is intentionally descriptive:
+   * execution authority still comes from the host/room, and runtime-state
+   * authorship still comes from runtime peers.
+   */
+  target?: NotebookShellRuntimeTargetProjection | null;
 }
 
 export interface NotebookShellCapabilities {
@@ -119,6 +150,7 @@ export interface ProjectNotebookShellCapabilitiesOptions {
 const SHELL_ACCESS_CACHE = new Map<string, NotebookShellAccessCapabilities>();
 const SHELL_AUTH_CACHE = new Map<string, NotebookShellAuthCapabilities>();
 const SHELL_RUNTIME_CACHE = new Map<string, NotebookShellRuntimeCapabilities>();
+const SHELL_RUNTIME_TARGET_CACHE = new Map<string, NotebookShellRuntimeTargetProjection>();
 const SHELL_CAPABILITIES_CACHE = new Map<string, NotebookShellCapabilities>();
 const SHELL_PART_CACHE_LIMIT = 256;
 const SHELL_CAPABILITIES_CACHE_LIMIT = 512;
@@ -217,7 +249,17 @@ const NOTEBOOK_SHELL_RUNTIME_CACHE_FIELDS = {
   actorLabel: (runtime) => runtime.actorLabel,
   identityLabel: (runtime) => runtime.identityLabel,
   actor: (runtime) => notebookActorProjectionCacheKey(runtime.actor),
+  target: (runtime) => notebookShellRuntimeTargetCacheKey(runtime.target),
 } satisfies ProjectionCacheFieldReaders<NotebookShellRuntimeCapabilities>;
+const NOTEBOOK_SHELL_RUNTIME_TARGET_CACHE_FIELDS = {
+  kind: (target) => target.kind,
+  status: (target) => target.status,
+  label: (target) => target.label,
+  statusLabel: (target) => target.statusLabel ?? null,
+  detail: (target) => target.detail ?? null,
+  providerLabel: (target) => target.providerLabel ?? null,
+  environmentLabel: (target) => target.environmentLabel ?? null,
+} satisfies ProjectionCacheFieldReaders<NotebookShellRuntimeTargetProjection>;
 const NOTEBOOK_ACTOR_PROJECTION_CACHE_FIELDS = {
   actorLabel: (actor) => actor.actorLabel,
   principal: (actor) => notebookActorPrincipalCacheKey(actor.principal),
@@ -274,6 +316,7 @@ const READ_ONLY_RUNTIME: NotebookShellRuntimeCapabilities = Object.freeze({
   source: "unknown",
   actorLabel: null,
   identityLabel: null,
+  target: null,
 });
 
 export const readOnlyNotebookShellCapabilities: NotebookShellCapabilities = Object.freeze({
@@ -297,6 +340,7 @@ export function clearNotebookShellCapabilitiesCachesForTests(): void {
   SHELL_ACCESS_CACHE.clear();
   SHELL_AUTH_CACHE.clear();
   SHELL_RUNTIME_CACHE.clear();
+  SHELL_RUNTIME_TARGET_CACHE.clear();
   SHELL_CAPABILITIES_CACHE.clear();
 }
 
@@ -327,6 +371,7 @@ export function projectNotebookShellCapabilities({
     actorLabel: runtime?.actorLabel ?? null,
     identityLabel: runtime?.identityLabel ?? null,
     actor: runtime?.actor,
+    target: runtime?.target ?? null,
   });
   const canRead = accessCapabilities.level !== "none";
   const canExecute =
@@ -454,9 +499,32 @@ function stableNotebookShellRuntimeCapabilities(
     actorLabel: runtime.actorLabel,
     identityLabel: runtime.identityLabel,
     ...(runtime.actor === undefined ? {} : { actor: runtime.actor }),
+    target: stableNotebookShellRuntimeTarget(runtime.target),
   });
   setBoundedCacheValue(SHELL_RUNTIME_CACHE, cacheKey, stableRuntime, SHELL_PART_CACHE_LIMIT);
   return stableRuntime;
+}
+
+function stableNotebookShellRuntimeTarget(
+  target: NotebookShellRuntimeTargetProjection | null | undefined,
+): NotebookShellRuntimeTargetProjection | null {
+  if (!target) return null;
+
+  const cacheKey = notebookShellRuntimeTargetCacheKey(target);
+  const cached = getBoundedCacheValue(SHELL_RUNTIME_TARGET_CACHE, cacheKey);
+  if (cached) return cached;
+
+  const stableTarget = Object.freeze({
+    kind: target.kind,
+    status: target.status,
+    label: target.label,
+    statusLabel: target.statusLabel ?? null,
+    detail: target.detail ?? null,
+    providerLabel: target.providerLabel ?? null,
+    environmentLabel: target.environmentLabel ?? null,
+  });
+  setBoundedCacheValue(SHELL_RUNTIME_TARGET_CACHE, cacheKey, stableTarget, SHELL_PART_CACHE_LIMIT);
+  return stableTarget;
 }
 
 function notebookShellCapabilitiesCacheKey(capabilities: NotebookShellCapabilities): string {
@@ -490,6 +558,14 @@ function notebookShellAuthCacheKey(auth: NotebookShellAuthCapabilities): string 
 
 function notebookShellRuntimeCacheKey(runtime: NotebookShellRuntimeCapabilities): string {
   return projectionCacheKey(runtime, NOTEBOOK_SHELL_RUNTIME_CACHE_FIELDS);
+}
+
+function notebookShellRuntimeTargetCacheKey(
+  target: NotebookShellRuntimeTargetProjection | null | undefined,
+): string {
+  if (target === undefined) return "undefined";
+  if (target === null) return "null";
+  return projectionCacheKey(target, NOTEBOOK_SHELL_RUNTIME_TARGET_CACHE_FIELDS);
 }
 
 function notebookActorProjectionCacheKey(

--- a/packages/runtimed/src/notebook-shell-capabilities.ts
+++ b/packages/runtimed/src/notebook-shell-capabilities.ts
@@ -57,6 +57,12 @@ export type NotebookShellRuntimeTargetStatus =
   | "attention";
 
 export interface NotebookShellRuntimeTargetProjection {
+  /**
+   * Stable host-owned workstation identifier. This is intentionally not a
+   * principal: principals describe who can act, while workstation IDs describe
+   * where compute is expected to run.
+   */
+  id?: string | null;
   kind: NotebookShellRuntimeTargetKind;
   status: NotebookShellRuntimeTargetStatus;
   label: string;
@@ -64,6 +70,8 @@ export interface NotebookShellRuntimeTargetProjection {
   detail?: string | null;
   providerLabel?: string | null;
   environmentLabel?: string | null;
+  resourceLabel?: string | null;
+  workingDirectoryLabel?: string | null;
 }
 
 export interface NotebookShellRuntimeCapabilities {
@@ -252,6 +260,7 @@ const NOTEBOOK_SHELL_RUNTIME_CACHE_FIELDS = {
   target: (runtime) => notebookShellRuntimeTargetCacheKey(runtime.target),
 } satisfies ProjectionCacheFieldReaders<NotebookShellRuntimeCapabilities>;
 const NOTEBOOK_SHELL_RUNTIME_TARGET_CACHE_FIELDS = {
+  id: (target) => target.id ?? null,
   kind: (target) => target.kind,
   status: (target) => target.status,
   label: (target) => target.label,
@@ -259,6 +268,8 @@ const NOTEBOOK_SHELL_RUNTIME_TARGET_CACHE_FIELDS = {
   detail: (target) => target.detail ?? null,
   providerLabel: (target) => target.providerLabel ?? null,
   environmentLabel: (target) => target.environmentLabel ?? null,
+  resourceLabel: (target) => target.resourceLabel ?? null,
+  workingDirectoryLabel: (target) => target.workingDirectoryLabel ?? null,
 } satisfies ProjectionCacheFieldReaders<NotebookShellRuntimeTargetProjection>;
 const NOTEBOOK_ACTOR_PROJECTION_CACHE_FIELDS = {
   actorLabel: (actor) => actor.actorLabel,
@@ -515,6 +526,7 @@ function stableNotebookShellRuntimeTarget(
   if (cached) return cached;
 
   const stableTarget = Object.freeze({
+    id: target.id ?? null,
     kind: target.kind,
     status: target.status,
     label: target.label,
@@ -522,6 +534,8 @@ function stableNotebookShellRuntimeTarget(
     detail: target.detail ?? null,
     providerLabel: target.providerLabel ?? null,
     environmentLabel: target.environmentLabel ?? null,
+    resourceLabel: target.resourceLabel ?? null,
+    workingDirectoryLabel: target.workingDirectoryLabel ?? null,
   });
   setBoundedCacheValue(SHELL_RUNTIME_TARGET_CACHE, cacheKey, stableTarget, SHELL_PART_CACHE_LIMIT);
   return stableTarget;

--- a/packages/runtimed/tests/notebook-shell-capabilities.test.ts
+++ b/packages/runtimed/tests/notebook-shell-capabilities.test.ts
@@ -232,6 +232,7 @@ describe("projectNotebookShellCapabilities", () => {
         connected: true,
         executionAvailable: true,
         target: {
+          id: "room-workstation",
           kind: "cloud_workstation",
           status: "ready",
           label: "Room workstation",
@@ -239,6 +240,8 @@ describe("projectNotebookShellCapabilities", () => {
           detail: "A runtime peer is attached to this room.",
           providerLabel: "Cloud room",
           environmentLabel: "Current Python",
+          resourceLabel: "4 CPU / 16 GB RAM",
+          workingDirectoryLabel: "/home/kyle/notebooks",
         },
       }),
       execution: { available: true, requiresDocumentEditPermission: true },
@@ -258,6 +261,7 @@ describe("projectNotebookShellCapabilities", () => {
         connected: true,
         executionAvailable: true,
         target: {
+          id: "room-workstation",
           kind: "cloud_workstation",
           status: "ready",
           label: "Room workstation",
@@ -265,6 +269,8 @@ describe("projectNotebookShellCapabilities", () => {
           detail: "A runtime peer is attached to this room.",
           providerLabel: "Cloud room",
           environmentLabel: "Current Python",
+          resourceLabel: "4 CPU / 16 GB RAM",
+          workingDirectoryLabel: "/home/kyle/notebooks",
         },
       }),
       execution: { available: true, requiresDocumentEditPermission: true },
@@ -282,6 +288,11 @@ describe("projectNotebookShellCapabilities", () => {
     expect(first.auth).toBe(second.auth);
     expect(first.runtime).toBe(second.runtime);
     expect(first.runtime.target).toBe(second.runtime.target);
+    expect(first.runtime.target).toMatchObject({
+      id: "room-workstation",
+      resourceLabel: "4 CPU / 16 GB RAM",
+      workingDirectoryLabel: "/home/kyle/notebooks",
+    });
     expect(Object.isFrozen(first)).toBe(true);
     expect(Object.isFrozen(first.access)).toBe(true);
     expect(Object.isFrozen(first.auth)).toBe(true);

--- a/packages/runtimed/tests/notebook-shell-capabilities.test.ts
+++ b/packages/runtimed/tests/notebook-shell-capabilities.test.ts
@@ -208,7 +208,7 @@ describe("projectNotebookShellCapabilities", () => {
       canExecute: false,
       canManagePackages: false,
       access: { level: "viewer", source: "unknown" },
-      runtime: { connected: false, executionAvailable: false },
+      runtime: { connected: false, executionAvailable: false, target: null },
     });
     expect(Object.isFrozen(readOnlyNotebookShellCapabilities)).toBe(true);
     expect(Object.isFrozen(readOnlyNotebookShellCapabilities.access)).toBe(true);
@@ -228,7 +228,19 @@ describe("projectNotebookShellCapabilities", () => {
       interaction,
       access: access({ level: "editor", actorLabel: "user:anaconda:alice/browser:viewer" }),
       auth: auth({ canUseAuthenticatedIdentity: true }),
-      runtime: runtime({ connected: true, executionAvailable: true }),
+      runtime: runtime({
+        connected: true,
+        executionAvailable: true,
+        target: {
+          kind: "cloud_workstation",
+          status: "ready",
+          label: "Room workstation",
+          statusLabel: "Ready",
+          detail: "A runtime peer is attached to this room.",
+          providerLabel: "Cloud room",
+          environmentLabel: "Current Python",
+        },
+      }),
       execution: { available: true, requiresDocumentEditPermission: true },
       packages: { canView: true, canManage: true, manageRequiresDocumentMutationSupport: true },
       sharing: {
@@ -242,7 +254,19 @@ describe("projectNotebookShellCapabilities", () => {
       interaction,
       access: access({ level: "editor", actorLabel: "user:anaconda:alice/browser:viewer" }),
       auth: auth({ canUseAuthenticatedIdentity: true }),
-      runtime: runtime({ connected: true, executionAvailable: true }),
+      runtime: runtime({
+        connected: true,
+        executionAvailable: true,
+        target: {
+          kind: "cloud_workstation",
+          status: "ready",
+          label: "Room workstation",
+          statusLabel: "Ready",
+          detail: "A runtime peer is attached to this room.",
+          providerLabel: "Cloud room",
+          environmentLabel: "Current Python",
+        },
+      }),
       execution: { available: true, requiresDocumentEditPermission: true },
       packages: { canView: true, canManage: true, manageRequiresDocumentMutationSupport: true },
       sharing: {
@@ -257,9 +281,11 @@ describe("projectNotebookShellCapabilities", () => {
     expect(first.access).toBe(second.access);
     expect(first.auth).toBe(second.auth);
     expect(first.runtime).toBe(second.runtime);
+    expect(first.runtime.target).toBe(second.runtime.target);
     expect(Object.isFrozen(first)).toBe(true);
     expect(Object.isFrozen(first.access)).toBe(true);
     expect(Object.isFrozen(first.auth)).toBe(true);
     expect(Object.isFrozen(first.runtime)).toBe(true);
+    expect(Object.isFrozen(first.runtime.target)).toBe(true);
   });
 });

--- a/src/components/isolated/output-manifest.ts
+++ b/src/components/isolated/output-manifest.ts
@@ -130,7 +130,9 @@ export async function resolveContentRef(
   const blobResolver = normalizeBlobResolver(blobResolverInput);
   if ("inline" in ref) return ref.inline;
   if ("url" in ref) return ref.url;
-  if (mimeType && looksLikeBinaryMime(mimeType)) return blobResolver.url(ref);
+  if (mimeType && looksLikeBinaryMime(mimeType)) {
+    return blobResolver.displayUrl ? await blobResolver.displayUrl(ref) : blobResolver.url(ref);
+  }
 
   const response = await blobResolver.fetch(ref);
   if (!response.ok) {
@@ -147,7 +149,10 @@ function resolveContentRefSync(
   const blobResolver = normalizeBlobResolver(blobResolverInput);
   if ("inline" in ref) return ref.inline;
   if ("url" in ref) return ref.url;
-  if (mimeType && looksLikeBinaryMime(mimeType)) return blobResolver.url(ref);
+  if (mimeType && looksLikeBinaryMime(mimeType)) {
+    if (blobResolver.resolvesBinaryUrlsSynchronously === false) return null;
+    return blobResolver.url(ref);
+  }
   return null;
 }
 

--- a/src/components/isolated/output-manifest.ts
+++ b/src/components/isolated/output-manifest.ts
@@ -131,7 +131,9 @@ export async function resolveContentRef(
   if ("inline" in ref) return ref.inline;
   if ("url" in ref) return ref.url;
   if (mimeType && looksLikeBinaryMime(mimeType)) {
-    return blobResolver.displayUrl ? await blobResolver.displayUrl(ref) : blobResolver.url(ref);
+    return blobResolver.displayUrl
+      ? await blobResolver.displayUrl(ref, mimeType)
+      : blobResolver.url(ref);
   }
 
   const response = await blobResolver.fetch(ref);

--- a/src/components/notebook/NotebookWorkstationsPanel.tsx
+++ b/src/components/notebook/NotebookWorkstationsPanel.tsx
@@ -1,6 +1,9 @@
 import { CircleAlert, CircleCheck, Cloud, Cpu, Monitor, UserRound } from "lucide-react";
 import type { LucideIcon } from "lucide-react";
-import type { NotebookShellCapabilities } from "./capabilities";
+import type {
+  NotebookShellCapabilities,
+  NotebookShellRuntimeTargetProjection,
+} from "./capabilities";
 import { cn } from "@/lib/utils";
 
 export interface NotebookWorkstationsPanelProps {
@@ -12,7 +15,8 @@ export function NotebookWorkstationsPanel({
   capabilities,
   className,
 }: NotebookWorkstationsPanelProps) {
-  const status = workstationStatus(capabilities);
+  const target = capabilities.runtime.target ?? fallbackRuntimeTarget(capabilities);
+  const status = workstationStatus(capabilities, target);
   const source = workstationSource(capabilities.runtime.source);
   const principalLabel =
     capabilities.runtime.actor?.principal.label ??
@@ -22,7 +26,11 @@ export function NotebookWorkstationsPanel({
     source.defaultPrincipalLabel;
   const operatorLabel =
     capabilities.runtime.actor?.operator.label ??
-    (capabilities.runtime.connected ? "Runtime" : "Not attached");
+    (target.kind === "local_daemon"
+      ? "Local daemon"
+      : capabilities.runtime.connected
+        ? "Runtime"
+        : "Not attached");
 
   return (
     <div className={cn("space-y-3", className)} data-testid="notebook-workstations-panel">
@@ -54,7 +62,12 @@ export function NotebookWorkstationsPanel({
       </section>
 
       <section className="space-y-2" aria-label="Runtime attachment details">
-        <WorkstationDetail icon={source.icon} label="Source" value={source.label} />
+        <WorkstationDetail icon={source.icon} label="Target" value={target.label} />
+        <WorkstationDetail
+          icon={source.icon}
+          label="Provider"
+          value={target.providerLabel ?? source.label}
+        />
         <WorkstationDetail icon={UserRound} label="Principal" value={principalLabel} />
         <WorkstationDetail icon={Cpu} label="Operator" value={operatorLabel} />
         <WorkstationDetail
@@ -87,7 +100,10 @@ function WorkstationDetail({
   );
 }
 
-function workstationStatus(capabilities: NotebookShellCapabilities): {
+function workstationStatus(
+  capabilities: NotebookShellCapabilities,
+  target: NotebookShellRuntimeTargetProjection,
+): {
   title: string;
   detail: string;
   badge: string;
@@ -97,9 +113,9 @@ function workstationStatus(capabilities: NotebookShellCapabilities): {
 } {
   if (capabilities.runtime.executionAvailable && capabilities.canExecute) {
     return {
-      title: workstationSource(capabilities.runtime.source).readyTitle,
-      detail: "Execution requests are enabled for this notebook.",
-      badge: "Ready",
+      title: target.kind === "local_daemon" ? target.label : `${target.label} ready`,
+      detail: target.detail ?? "Execution requests are enabled for this notebook.",
+      badge: target.statusLabel ?? "Ready",
       icon: CircleCheck,
       iconClassName: "border-emerald-500/30 bg-emerald-500/10 text-emerald-700",
       badgeClassName: "bg-emerald-500/10 text-emerald-700",
@@ -107,9 +123,9 @@ function workstationStatus(capabilities: NotebookShellCapabilities): {
   }
   if (capabilities.runtime.executionAvailable) {
     return {
-      title: "Runtime available",
+      title: `${target.label} available`,
       detail: "A runtime is available, but this connection cannot request execution.",
-      badge: "Limited",
+      badge: target.statusLabel ?? "Limited",
       icon: Cpu,
       iconClassName: "border-sky-500/30 bg-sky-500/10 text-sky-700",
       badgeClassName: "bg-sky-500/10 text-sky-700",
@@ -117,9 +133,9 @@ function workstationStatus(capabilities: NotebookShellCapabilities): {
   }
   if (capabilities.runtime.connected) {
     return {
-      title: "Runtime peer attached",
-      detail: "Runtime state is connected without executable cell controls.",
-      badge: "Attached",
+      title: `${target.label} attached`,
+      detail: target.detail ?? "Runtime state is connected without executable cell controls.",
+      badge: target.statusLabel ?? "Attached",
       icon: Cpu,
       iconClassName: "border-sky-500/30 bg-sky-500/10 text-sky-700",
       badgeClassName: "bg-sky-500/10 text-sky-700",
@@ -127,21 +143,53 @@ function workstationStatus(capabilities: NotebookShellCapabilities): {
   }
 
   return {
-    title: capabilities.runtime.source === "local" ? "Local runtime unavailable" : "No workstation",
+    title: capabilities.runtime.source === "local" ? `${target.label} unavailable` : target.label,
     detail:
-      capabilities.runtime.source === "local"
+      target.detail ??
+      (capabilities.runtime.source === "local"
         ? "The local daemon is not exposing an executable runtime."
-        : "No runtime peer is attached to this room.",
-    badge: "Offline",
+        : "No runtime peer is attached to this room."),
+    badge: target.statusLabel ?? "Offline",
     icon: CircleAlert,
     iconClassName: "border-muted bg-background text-muted-foreground",
     badgeClassName: "bg-muted text-muted-foreground",
   };
 }
 
+function fallbackRuntimeTarget(
+  capabilities: NotebookShellCapabilities,
+): NotebookShellRuntimeTargetProjection {
+  const source = workstationSource(capabilities.runtime.source);
+  if (capabilities.runtime.source === "local") {
+    return {
+      kind: "local_daemon",
+      status: capabilities.runtime.executionAvailable ? "ready" : "offline",
+      label: "This machine",
+      statusLabel: capabilities.runtime.executionAvailable ? "Ready" : "Offline",
+      providerLabel: source.label,
+    };
+  }
+  if (capabilities.runtime.connected) {
+    return {
+      kind: "runtime_peer",
+      status: capabilities.runtime.executionAvailable ? "ready" : "attached",
+      label: "Runtime peer",
+      statusLabel: capabilities.runtime.executionAvailable ? "Ready" : "Attached",
+      providerLabel: source.label,
+    };
+  }
+  return {
+    kind: capabilities.runtime.source === "fixture" ? "fixture" : "unknown",
+    status: "offline",
+    label:
+      capabilities.runtime.source === "cloud" ? "No workstation attached" : "No runtime target",
+    statusLabel: "Offline",
+    providerLabel: source.label,
+  };
+}
+
 function workstationSource(source: NotebookShellCapabilities["runtime"]["source"]): {
   label: string;
-  readyTitle: string;
   defaultPrincipalLabel: string;
   icon: LucideIcon;
 } {
@@ -149,28 +197,24 @@ function workstationSource(source: NotebookShellCapabilities["runtime"]["source"
     case "local":
       return {
         label: "Local",
-        readyTitle: "Local runtime ready",
         defaultPrincipalLabel: "Local principal",
         icon: Monitor,
       };
     case "cloud":
       return {
         label: "Cloud",
-        readyTitle: "Room workstation ready",
         defaultPrincipalLabel: "Room principal",
         icon: Cloud,
       };
     case "fixture":
       return {
         label: "Fixture",
-        readyTitle: "Fixture runtime ready",
         defaultPrincipalLabel: "Fixture principal",
         icon: Cpu,
       };
     default:
       return {
         label: "Unknown",
-        readyTitle: "Runtime ready",
         defaultPrincipalLabel: "Unknown principal",
         icon: Cpu,
       };

--- a/src/components/notebook/NotebookWorkstationsPanel.tsx
+++ b/src/components/notebook/NotebookWorkstationsPanel.tsx
@@ -113,7 +113,7 @@ function workstationStatus(
   target: NotebookShellRuntimeTargetProjection,
 ): {
   title: string;
-  detail: string;
+  detail: string | null;
   badge: string;
   icon: LucideIcon;
   iconClassName: string;
@@ -123,7 +123,7 @@ function workstationStatus(
   if (capabilities.runtime.executionAvailable && capabilities.canExecute) {
     return {
       title: target.kind === "local_daemon" ? target.label : `${target.label} ready`,
-      detail: target.detail ?? "Execution requests are enabled for this notebook.",
+      detail: null,
       badge: target.statusLabel ?? "Ready",
       icon: CircleCheck,
       iconClassName: "text-emerald-700 dark:text-emerald-300",
@@ -134,7 +134,7 @@ function workstationStatus(
   if (capabilities.runtime.executionAvailable) {
     return {
       title: `${target.label} available`,
-      detail: "A runtime is available, but this connection cannot request execution.",
+      detail: null,
       badge: target.statusLabel ?? "Limited",
       icon: Cpu,
       iconClassName: "text-sky-700 dark:text-sky-300",
@@ -145,7 +145,7 @@ function workstationStatus(
   if (capabilities.runtime.connected) {
     return {
       title: `${target.label} attached`,
-      detail: target.detail ?? "Runtime state is connected without executable cell controls.",
+      detail: null,
       badge: target.statusLabel ?? "Attached",
       icon: Cpu,
       iconClassName: "text-sky-700 dark:text-sky-300",

--- a/src/components/notebook/NotebookWorkstationsPanel.tsx
+++ b/src/components/notebook/NotebookWorkstationsPanel.tsx
@@ -31,72 +31,80 @@ export function NotebookWorkstationsPanel({
       : capabilities.runtime.connected
         ? "Runtime"
         : "Not attached");
+  const runtimeLabel = target.environmentLabel ?? runtimeResourceLabel(capabilities, target);
+  const capabilityLabel = runtimeCapabilityLabel(capabilities);
 
   return (
-    <div className={cn("space-y-3", className)} data-testid="notebook-workstations-panel">
-      <section className="rounded-md border bg-muted/20 p-3">
+    <div className={cn("space-y-3 text-sm", className)} data-testid="notebook-workstations-panel">
+      <section
+        className={cn("border-l-2 py-1.5 pl-3 pr-1", status.panelClassName)}
+        aria-label="Active workstation target"
+      >
         <div className="flex min-w-0 items-start gap-3">
-          <span
-            className={cn(
-              "flex size-8 shrink-0 items-center justify-center rounded-md border",
-              status.iconClassName,
-            )}
-          >
-            <status.icon className="size-4" aria-hidden="true" />
-          </span>
+          <status.icon
+            className={cn("mt-0.5 size-4 shrink-0", status.iconClassName)}
+            aria-hidden="true"
+          />
           <div className="min-w-0 flex-1">
-            <div className="flex min-w-0 items-center justify-between gap-2">
+            <div className="flex min-w-0 flex-wrap items-center gap-x-2 gap-y-1">
               <h3 className="truncate text-sm font-semibold">{status.title}</h3>
-              <span
-                className={cn(
-                  "shrink-0 rounded px-1.5 py-0.5 text-[10px] font-medium",
-                  status.badgeClassName,
-                )}
-              >
+              <span className={cn("shrink-0 text-xs font-medium", status.textClassName)}>
                 {status.badge}
               </span>
             </div>
-            <p className="mt-1 text-xs leading-5 text-muted-foreground">{status.detail}</p>
+            <div className="mt-1 flex min-w-0 flex-wrap gap-x-2 gap-y-1 text-xs text-muted-foreground">
+              <span className="truncate">{target.providerLabel ?? source.label}</span>
+              <span className="truncate">{runtimeLabel}</span>
+            </div>
+            {status.detail ? (
+              <p className="mt-2 text-xs leading-5 text-muted-foreground">{status.detail}</p>
+            ) : null}
           </div>
         </div>
       </section>
 
-      <section className="space-y-2" aria-label="Runtime attachment details">
-        <WorkstationDetail icon={source.icon} label="Target" value={target.label} />
-        <WorkstationDetail
+      <section
+        className="flex min-w-0 flex-wrap gap-x-3 gap-y-1.5 text-xs"
+        aria-label="Workstation resources"
+      >
+        <WorkstationFact
           icon={source.icon}
           label="Provider"
           value={target.providerLabel ?? source.label}
         />
-        <WorkstationDetail icon={UserRound} label="Principal" value={principalLabel} />
-        <WorkstationDetail icon={Cpu} label="Operator" value={operatorLabel} />
-        <WorkstationDetail
+        <WorkstationFact icon={Cpu} label="Runtime" value={runtimeLabel} />
+        <WorkstationFact icon={UserRound} label="Principal" value={principalLabel} />
+        <WorkstationFact
           icon={capabilities.runtime.canWriteRuntimeState ? CircleCheck : CircleAlert}
-          label="Runtime state"
-          value={capabilities.runtime.canWriteRuntimeState ? "Writable" : "Read-only"}
+          label="State"
+          value={capabilityLabel}
         />
+        <WorkstationFact icon={Cpu} label="Operator" value={operatorLabel} subtle />
+        {target.kind === "local_daemon" ? (
+          <WorkstationFact icon={Cloud} label="Remote" value="Coming soon" subtle />
+        ) : null}
       </section>
     </div>
   );
 }
 
-function WorkstationDetail({
+function WorkstationFact({
   icon: Icon,
   label,
+  subtle = false,
   value,
 }: {
   icon: LucideIcon;
   label: string;
+  subtle?: boolean;
   value: string;
 }) {
   return (
-    <div className="flex min-w-0 items-center gap-2 rounded-md border px-2.5 py-2 text-xs">
+    <span className={cn("inline-flex min-w-0 items-center gap-1.5", subtle && "opacity-80")}>
       <Icon className="size-3.5 shrink-0 text-muted-foreground" aria-hidden="true" />
       <span className="shrink-0 text-muted-foreground">{label}</span>
-      <span className="min-w-0 flex-1 truncate text-right font-medium text-foreground">
-        {value}
-      </span>
-    </div>
+      <span className="min-w-0 truncate font-medium text-foreground">{value}</span>
+    </span>
   );
 }
 
@@ -109,7 +117,8 @@ function workstationStatus(
   badge: string;
   icon: LucideIcon;
   iconClassName: string;
-  badgeClassName: string;
+  panelClassName: string;
+  textClassName: string;
 } {
   if (capabilities.runtime.executionAvailable && capabilities.canExecute) {
     return {
@@ -117,8 +126,9 @@ function workstationStatus(
       detail: target.detail ?? "Execution requests are enabled for this notebook.",
       badge: target.statusLabel ?? "Ready",
       icon: CircleCheck,
-      iconClassName: "border-emerald-500/30 bg-emerald-500/10 text-emerald-700",
-      badgeClassName: "bg-emerald-500/10 text-emerald-700",
+      iconClassName: "text-emerald-700 dark:text-emerald-300",
+      panelClassName: "border-emerald-500/70 bg-emerald-500/[0.04]",
+      textClassName: "text-emerald-700 dark:text-emerald-300",
     };
   }
   if (capabilities.runtime.executionAvailable) {
@@ -127,8 +137,9 @@ function workstationStatus(
       detail: "A runtime is available, but this connection cannot request execution.",
       badge: target.statusLabel ?? "Limited",
       icon: Cpu,
-      iconClassName: "border-sky-500/30 bg-sky-500/10 text-sky-700",
-      badgeClassName: "bg-sky-500/10 text-sky-700",
+      iconClassName: "text-sky-700 dark:text-sky-300",
+      panelClassName: "border-sky-500/70 bg-sky-500/[0.04]",
+      textClassName: "text-sky-700 dark:text-sky-300",
     };
   }
   if (capabilities.runtime.connected) {
@@ -137,8 +148,9 @@ function workstationStatus(
       detail: target.detail ?? "Runtime state is connected without executable cell controls.",
       badge: target.statusLabel ?? "Attached",
       icon: Cpu,
-      iconClassName: "border-sky-500/30 bg-sky-500/10 text-sky-700",
-      badgeClassName: "bg-sky-500/10 text-sky-700",
+      iconClassName: "text-sky-700 dark:text-sky-300",
+      panelClassName: "border-sky-500/70 bg-sky-500/[0.04]",
+      textClassName: "text-sky-700 dark:text-sky-300",
     };
   }
 
@@ -151,9 +163,39 @@ function workstationStatus(
         : "No runtime peer is attached to this room."),
     badge: target.statusLabel ?? "Offline",
     icon: CircleAlert,
-    iconClassName: "border-muted bg-background text-muted-foreground",
-    badgeClassName: "bg-muted text-muted-foreground",
+    iconClassName: "text-muted-foreground",
+    panelClassName: "border-border bg-muted/[0.03]",
+    textClassName: "text-muted-foreground",
   };
+}
+
+function runtimeResourceLabel(
+  capabilities: NotebookShellCapabilities,
+  target: NotebookShellRuntimeTargetProjection,
+): string {
+  if (target.kind === "local_daemon") {
+    return capabilities.runtime.executionAvailable ? "Notebook runtime" : "Unavailable";
+  }
+  if (target.kind === "runtime_peer") {
+    return "Runtime peer";
+  }
+  if (capabilities.runtime.executionAvailable) {
+    return "Current Python";
+  }
+  return "Not attached";
+}
+
+function runtimeCapabilityLabel(capabilities: NotebookShellCapabilities): string {
+  if (capabilities.runtime.executionAvailable && capabilities.canExecute) {
+    return "Can run";
+  }
+  if (capabilities.runtime.executionAvailable) {
+    return "View only";
+  }
+  if (capabilities.runtime.canWriteRuntimeState) {
+    return "Runtime state";
+  }
+  return "Not runnable";
 }
 
 function fallbackRuntimeTarget(
@@ -167,6 +209,9 @@ function fallbackRuntimeTarget(
       label: "This machine",
       statusLabel: capabilities.runtime.executionAvailable ? "Ready" : "Offline",
       providerLabel: source.label,
+      environmentLabel: capabilities.runtime.executionAvailable
+        ? "Notebook runtime"
+        : "Unavailable",
     };
   }
   if (capabilities.runtime.connected) {
@@ -176,6 +221,7 @@ function fallbackRuntimeTarget(
       label: "Runtime peer",
       statusLabel: capabilities.runtime.executionAvailable ? "Ready" : "Attached",
       providerLabel: source.label,
+      environmentLabel: "Runtime peer",
     };
   }
   return {
@@ -185,6 +231,7 @@ function fallbackRuntimeTarget(
       capabilities.runtime.source === "cloud" ? "No workstation attached" : "No runtime target",
     statusLabel: "Offline",
     providerLabel: source.label,
+    environmentLabel: "Not attached",
   };
 }
 

--- a/src/components/notebook/NotebookWorkstationsPanel.tsx
+++ b/src/components/notebook/NotebookWorkstationsPanel.tsx
@@ -1,4 +1,4 @@
-import { CircleAlert, CircleCheck, Cloud, Cpu, Monitor, UserRound } from "lucide-react";
+import { CircleAlert, CircleCheck, Cloud, Cpu, FolderOpen, Monitor } from "lucide-react";
 import type { LucideIcon } from "lucide-react";
 import type {
   NotebookShellCapabilities,
@@ -18,19 +18,6 @@ export function NotebookWorkstationsPanel({
   const target = capabilities.runtime.target ?? fallbackRuntimeTarget(capabilities);
   const status = workstationStatus(capabilities, target);
   const source = workstationSource(capabilities.runtime.source);
-  const principalLabel =
-    capabilities.runtime.actor?.principal.label ??
-    capabilities.access.actor?.principal.label ??
-    capabilities.runtime.identityLabel ??
-    capabilities.access.identityLabel ??
-    source.defaultPrincipalLabel;
-  const operatorLabel =
-    capabilities.runtime.actor?.operator.label ??
-    (target.kind === "local_daemon"
-      ? "Local daemon"
-      : capabilities.runtime.connected
-        ? "Runtime"
-        : "Not attached");
   const runtimeLabel = target.environmentLabel ?? runtimeResourceLabel(capabilities, target);
   const capabilityLabel = runtimeCapabilityLabel(capabilities);
 
@@ -46,6 +33,11 @@ export function NotebookWorkstationsPanel({
             aria-hidden="true"
           />
           <div className="min-w-0 flex-1">
+            {target.id ? (
+              <div className="mb-0.5 truncate text-[11px] font-medium uppercase tracking-normal text-muted-foreground">
+                {target.id}
+              </div>
+            ) : null}
             <div className="flex min-w-0 flex-wrap items-center gap-x-2 gap-y-1">
               <h3 className="truncate text-sm font-semibold">{status.title}</h3>
               <span className={cn("shrink-0 text-xs font-medium", status.textClassName)}>
@@ -72,14 +64,22 @@ export function NotebookWorkstationsPanel({
           label="Provider"
           value={target.providerLabel ?? source.label}
         />
-        <WorkstationFact icon={Cpu} label="Runtime" value={runtimeLabel} />
-        <WorkstationFact icon={UserRound} label="Principal" value={principalLabel} />
+        <WorkstationFact icon={Cpu} label="Environment" value={runtimeLabel} />
+        {target.resourceLabel ? (
+          <WorkstationFact icon={Cpu} label="Resources" value={target.resourceLabel} />
+        ) : null}
+        {target.workingDirectoryLabel ? (
+          <WorkstationFact
+            icon={FolderOpen}
+            label="Working dir"
+            value={target.workingDirectoryLabel}
+          />
+        ) : null}
         <WorkstationFact
           icon={capabilities.runtime.canWriteRuntimeState ? CircleCheck : CircleAlert}
           label="State"
           value={capabilityLabel}
         />
-        <WorkstationFact icon={Cpu} label="Operator" value={operatorLabel} subtle />
         {target.kind === "local_daemon" ? (
           <WorkstationFact icon={Cloud} label="Remote" value="Coming soon" subtle />
         ) : null}
@@ -204,6 +204,7 @@ function fallbackRuntimeTarget(
   const source = workstationSource(capabilities.runtime.source);
   if (capabilities.runtime.source === "local") {
     return {
+      id: "local-daemon",
       kind: "local_daemon",
       status: capabilities.runtime.executionAvailable ? "ready" : "offline",
       label: "This machine",
@@ -216,6 +217,7 @@ function fallbackRuntimeTarget(
   }
   if (capabilities.runtime.connected) {
     return {
+      id: "runtime-peer",
       kind: "runtime_peer",
       status: capabilities.runtime.executionAvailable ? "ready" : "attached",
       label: "Runtime peer",
@@ -225,6 +227,7 @@ function fallbackRuntimeTarget(
     };
   }
   return {
+    id: capabilities.runtime.source === "cloud" ? "workstation:none" : "runtime:none",
     kind: capabilities.runtime.source === "fixture" ? "fixture" : "unknown",
     status: "offline",
     label:
@@ -237,32 +240,27 @@ function fallbackRuntimeTarget(
 
 function workstationSource(source: NotebookShellCapabilities["runtime"]["source"]): {
   label: string;
-  defaultPrincipalLabel: string;
   icon: LucideIcon;
 } {
   switch (source) {
     case "local":
       return {
         label: "Local",
-        defaultPrincipalLabel: "Local principal",
         icon: Monitor,
       };
     case "cloud":
       return {
         label: "Cloud",
-        defaultPrincipalLabel: "Room principal",
         icon: Cloud,
       };
     case "fixture":
       return {
         label: "Fixture",
-        defaultPrincipalLabel: "Fixture principal",
         icon: Cpu,
       };
     default:
       return {
         label: "Unknown",
-        defaultPrincipalLabel: "Unknown principal",
         icon: Cpu,
       };
   }

--- a/src/components/notebook/__tests__/NotebookWorkstationsPanel.test.tsx
+++ b/src/components/notebook/__tests__/NotebookWorkstationsPanel.test.tsx
@@ -33,6 +33,7 @@ const localReadyCapabilities: NotebookShellCapabilities = {
     actorLabel: "local:kyle/runtime:python",
     identityLabel: "Kyle",
     target: {
+      id: "local-daemon",
       kind: "local_daemon",
       status: "ready",
       label: "This machine",
@@ -56,16 +57,19 @@ const localReadyCapabilities: NotebookShellCapabilities = {
 };
 
 describe("NotebookWorkstationsPanel", () => {
-  it("renders a local executable runtime with runtime attribution", () => {
+  it("renders a local executable runtime as a workstation target", () => {
     render(<NotebookWorkstationsPanel capabilities={localReadyCapabilities} />);
 
+    expect(screen.getByText("local-daemon")).toBeVisible();
     expect(screen.getByRole("heading", { name: "This machine" })).toBeVisible();
     expect(screen.getByText("Ready")).toBeVisible();
     expect(screen.queryByText("The local daemon is available for this notebook.")).toBeNull();
     expect(screen.getAllByText("Local daemon")).toHaveLength(2);
     expect(screen.getAllByText("Notebook runtime")).toHaveLength(2);
-    expect(screen.getByText("Kyle")).toBeVisible();
-    expect(screen.getByText("Python runtime")).toBeVisible();
+    expect(screen.queryByText("Kyle")).not.toBeInTheDocument();
+    expect(screen.queryByText("Python runtime")).not.toBeInTheDocument();
+    expect(screen.queryByText("Principal")).not.toBeInTheDocument();
+    expect(screen.queryByText("Operator")).not.toBeInTheDocument();
     expect(screen.getByText("Can run")).toBeVisible();
     expect(screen.getByText("Remote")).toBeVisible();
     expect(screen.getByText("Coming soon")).toBeVisible();
@@ -83,6 +87,7 @@ describe("NotebookWorkstationsPanel", () => {
         ...readOnlyNotebookShellCapabilities.runtime,
         source: "cloud",
         target: {
+          id: "workstation:none",
           kind: "cloud_workstation",
           status: "offline",
           label: "No workstation attached",
@@ -96,14 +101,17 @@ describe("NotebookWorkstationsPanel", () => {
 
     render(<NotebookWorkstationsPanel capabilities={capabilities} />);
 
+    expect(screen.getByText("workstation:none")).toBeVisible();
     expect(screen.getByRole("heading", { name: "No workstation attached" })).toBeVisible();
     expect(screen.getByText("Offline")).toBeVisible();
     expect(
       screen.getByText("Attach a user-owned workstation to run cells in this room."),
     ).toBeVisible();
     expect(screen.getAllByText("Cloud room")).toHaveLength(2);
-    expect(screen.getByText("Kyle")).toBeVisible();
-    expect(screen.getAllByText("Not attached")).toHaveLength(3);
+    expect(screen.queryByText("Kyle")).not.toBeInTheDocument();
+    expect(screen.getAllByText("Not attached")).toHaveLength(2);
+    expect(screen.queryByText("Principal")).not.toBeInTheDocument();
+    expect(screen.queryByText("Operator")).not.toBeInTheDocument();
     expect(screen.getByText("Not runnable")).toBeVisible();
     expect(screen.queryByText("Coming soon")).not.toBeInTheDocument();
   });

--- a/src/components/notebook/__tests__/NotebookWorkstationsPanel.test.tsx
+++ b/src/components/notebook/__tests__/NotebookWorkstationsPanel.test.tsx
@@ -39,6 +39,7 @@ const localReadyCapabilities: NotebookShellCapabilities = {
       statusLabel: "Ready",
       detail: "The local daemon is available for this notebook.",
       providerLabel: "Local daemon",
+      environmentLabel: "Notebook runtime",
     },
     actor: {
       actorLabel: "local:kyle/runtime:python",
@@ -61,11 +62,13 @@ describe("NotebookWorkstationsPanel", () => {
     expect(screen.getByRole("heading", { name: "This machine" })).toBeVisible();
     expect(screen.getByText("Ready")).toBeVisible();
     expect(screen.getByText("The local daemon is available for this notebook.")).toBeVisible();
-    expect(screen.getAllByText("This machine")).toHaveLength(2);
-    expect(screen.getByText("Local daemon")).toBeVisible();
+    expect(screen.getAllByText("Local daemon")).toHaveLength(2);
+    expect(screen.getAllByText("Notebook runtime")).toHaveLength(2);
     expect(screen.getByText("Kyle")).toBeVisible();
     expect(screen.getByText("Python runtime")).toBeVisible();
-    expect(screen.getByText("Writable")).toBeVisible();
+    expect(screen.getByText("Can run")).toBeVisible();
+    expect(screen.getByText("Remote")).toBeVisible();
+    expect(screen.getByText("Coming soon")).toBeVisible();
   });
 
   it("renders cloud rooms without runtime peers as offline workstations", () => {
@@ -86,6 +89,7 @@ describe("NotebookWorkstationsPanel", () => {
           statusLabel: "Offline",
           detail: "Attach a user-owned workstation to run cells in this room.",
           providerLabel: "Cloud room",
+          environmentLabel: "Not attached",
         },
       },
     };
@@ -97,10 +101,10 @@ describe("NotebookWorkstationsPanel", () => {
     expect(
       screen.getByText("Attach a user-owned workstation to run cells in this room."),
     ).toBeVisible();
-    expect(screen.getAllByText("No workstation attached")).toHaveLength(2);
-    expect(screen.getByText("Cloud room")).toBeVisible();
+    expect(screen.getAllByText("Cloud room")).toHaveLength(2);
     expect(screen.getByText("Kyle")).toBeVisible();
-    expect(screen.getByText("Not attached")).toBeVisible();
-    expect(screen.getByText("Read-only")).toBeVisible();
+    expect(screen.getAllByText("Not attached")).toHaveLength(3);
+    expect(screen.getByText("Not runnable")).toBeVisible();
+    expect(screen.queryByText("Coming soon")).not.toBeInTheDocument();
   });
 });

--- a/src/components/notebook/__tests__/NotebookWorkstationsPanel.test.tsx
+++ b/src/components/notebook/__tests__/NotebookWorkstationsPanel.test.tsx
@@ -61,7 +61,7 @@ describe("NotebookWorkstationsPanel", () => {
 
     expect(screen.getByRole("heading", { name: "This machine" })).toBeVisible();
     expect(screen.getByText("Ready")).toBeVisible();
-    expect(screen.getByText("The local daemon is available for this notebook.")).toBeVisible();
+    expect(screen.queryByText("The local daemon is available for this notebook.")).toBeNull();
     expect(screen.getAllByText("Local daemon")).toHaveLength(2);
     expect(screen.getAllByText("Notebook runtime")).toHaveLength(2);
     expect(screen.getByText("Kyle")).toBeVisible();

--- a/src/components/notebook/__tests__/NotebookWorkstationsPanel.test.tsx
+++ b/src/components/notebook/__tests__/NotebookWorkstationsPanel.test.tsx
@@ -32,6 +32,14 @@ const localReadyCapabilities: NotebookShellCapabilities = {
     source: "local",
     actorLabel: "local:kyle/runtime:python",
     identityLabel: "Kyle",
+    target: {
+      kind: "local_daemon",
+      status: "ready",
+      label: "This machine",
+      statusLabel: "Ready",
+      detail: "The local daemon is available for this notebook.",
+      providerLabel: "Local daemon",
+    },
     actor: {
       actorLabel: "local:kyle/runtime:python",
       principal: {
@@ -50,10 +58,11 @@ describe("NotebookWorkstationsPanel", () => {
   it("renders a local executable runtime with runtime attribution", () => {
     render(<NotebookWorkstationsPanel capabilities={localReadyCapabilities} />);
 
-    expect(screen.getByRole("heading", { name: "Local runtime ready" })).toBeVisible();
+    expect(screen.getByRole("heading", { name: "This machine" })).toBeVisible();
     expect(screen.getByText("Ready")).toBeVisible();
-    expect(screen.getByText("Execution requests are enabled for this notebook.")).toBeVisible();
-    expect(screen.getByText("Local")).toBeVisible();
+    expect(screen.getByText("The local daemon is available for this notebook.")).toBeVisible();
+    expect(screen.getAllByText("This machine")).toHaveLength(2);
+    expect(screen.getByText("Local daemon")).toBeVisible();
     expect(screen.getByText("Kyle")).toBeVisible();
     expect(screen.getByText("Python runtime")).toBeVisible();
     expect(screen.getByText("Writable")).toBeVisible();
@@ -70,15 +79,26 @@ describe("NotebookWorkstationsPanel", () => {
       runtime: {
         ...readOnlyNotebookShellCapabilities.runtime,
         source: "cloud",
+        target: {
+          kind: "cloud_workstation",
+          status: "offline",
+          label: "No workstation attached",
+          statusLabel: "Offline",
+          detail: "Attach a user-owned workstation to run cells in this room.",
+          providerLabel: "Cloud room",
+        },
       },
     };
 
     render(<NotebookWorkstationsPanel capabilities={capabilities} />);
 
-    expect(screen.getByRole("heading", { name: "No workstation" })).toBeVisible();
+    expect(screen.getByRole("heading", { name: "No workstation attached" })).toBeVisible();
     expect(screen.getByText("Offline")).toBeVisible();
-    expect(screen.getByText("No runtime peer is attached to this room.")).toBeVisible();
-    expect(screen.getByText("Cloud")).toBeVisible();
+    expect(
+      screen.getByText("Attach a user-owned workstation to run cells in this room."),
+    ).toBeVisible();
+    expect(screen.getAllByText("No workstation attached")).toHaveLength(2);
+    expect(screen.getByText("Cloud room")).toBeVisible();
     expect(screen.getByText("Kyle")).toBeVisible();
     expect(screen.getByText("Not attached")).toBeVisible();
     expect(screen.getByText("Read-only")).toBeVisible();

--- a/src/components/notebook/capabilities.ts
+++ b/src/components/notebook/capabilities.ts
@@ -16,6 +16,9 @@ export {
   type NotebookShellExecutionPolicy,
   type NotebookShellPackagePolicy,
   type NotebookShellRuntimeCapabilities,
+  type NotebookShellRuntimeTargetKind,
+  type NotebookShellRuntimeTargetProjection,
+  type NotebookShellRuntimeTargetStatus,
   type NotebookShellSharingPolicy,
   type ProjectNotebookShellCapabilitiesOptions,
 } from "runtimed";

--- a/src/components/outputs/__tests__/media-router.test.tsx
+++ b/src/components/outputs/__tests__/media-router.test.tsx
@@ -548,6 +548,20 @@ describe("MediaRouter component", () => {
       });
     });
 
+    it("renders blob URL images without treating them as base64", async () => {
+      const blobUrl = "blob:https://preview.runt.run/protected-image";
+
+      render(
+        <MediaProvider>
+          <MediaRouter data={{ "image/png": blobUrl }} />
+        </MediaProvider>,
+      );
+
+      await waitFor(() => {
+        expect(screen.getByRole("img")).toHaveAttribute("src", blobUrl);
+      });
+    });
+
     it("renders JSON after lazy load", async () => {
       render(
         <MediaProvider>

--- a/src/components/outputs/audio-output.tsx
+++ b/src/components/outputs/audio-output.tsx
@@ -1,4 +1,5 @@
 import { cn } from "@/lib/utils";
+import { mediaDataToSource } from "./media-url";
 
 interface AudioOutputProps {
   /**
@@ -22,13 +23,7 @@ interface AudioOutputProps {
 export function AudioOutput({ data, mediaType = "audio/wav", className = "" }: AudioOutputProps) {
   if (!data) return null;
 
-  const src =
-    data.startsWith("data:") ||
-    data.startsWith("http://") ||
-    data.startsWith("https://") ||
-    data.startsWith("/")
-      ? data
-      : `data:${mediaType};base64,${data}`;
+  const src = mediaDataToSource(data, mediaType);
 
   return (
     <div data-slot="audio-output" className={cn("py-2", className)}>

--- a/src/components/outputs/image-output.tsx
+++ b/src/components/outputs/image-output.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useRef, useState } from "react";
 import { cn } from "@/lib/utils";
+import { mediaDataToSource } from "./media-url";
 
 interface ImageOutputProps {
   /**
@@ -53,13 +54,7 @@ export function ImageOutput({
   // Determine the image source:
   // - If already a data URL or regular URL, use as-is
   // - Otherwise, assume base64 and construct data URL
-  const targetSrc =
-    data.startsWith("data:") ||
-    data.startsWith("http://") ||
-    data.startsWith("https://") ||
-    data.startsWith("/")
-      ? data
-      : `data:${mediaType};base64,${data}`;
+  const targetSrc = mediaDataToSource(data, mediaType);
 
   return (
     <div data-slot="image-output" className={cn("not-prose py-2", className)}>

--- a/src/components/outputs/media-url.ts
+++ b/src/components/outputs/media-url.ts
@@ -1,0 +1,7 @@
+export function isDirectMediaUrl(value: string): boolean {
+  return /^(?:blob:|data:|https?:)/i.test(value) || value.startsWith("/");
+}
+
+export function mediaDataToSource(value: string, mediaType: string): string {
+  return isDirectMediaUrl(value) ? value : `data:${mediaType};base64,${value}`;
+}

--- a/src/components/outputs/pdf-output.tsx
+++ b/src/components/outputs/pdf-output.tsx
@@ -1,4 +1,5 @@
 import { cn } from "@/lib/utils";
+import { mediaDataToSource } from "./media-url";
 
 interface PdfOutputProps {
   /**
@@ -18,13 +19,7 @@ interface PdfOutputProps {
 export function PdfOutput({ data, className = "" }: PdfOutputProps) {
   if (!data) return null;
 
-  const src =
-    data.startsWith("data:") ||
-    data.startsWith("http://") ||
-    data.startsWith("https://") ||
-    data.startsWith("/")
-      ? data
-      : `data:application/pdf;base64,${data}`;
+  const src = mediaDataToSource(data, "application/pdf");
 
   return (
     <div data-slot="pdf-output" className={cn("py-2", className)}>

--- a/src/components/outputs/video-output.tsx
+++ b/src/components/outputs/video-output.tsx
@@ -1,4 +1,5 @@
 import { cn } from "@/lib/utils";
+import { mediaDataToSource } from "./media-url";
 
 interface VideoOutputProps {
   /**
@@ -36,13 +37,7 @@ export function VideoOutput({
 }: VideoOutputProps) {
   if (!data) return null;
 
-  const src =
-    data.startsWith("data:") ||
-    data.startsWith("http://") ||
-    data.startsWith("https://") ||
-    data.startsWith("/")
-      ? data
-      : `data:${mediaType};base64,${data}`;
+  const src = mediaDataToSource(data, mediaType);
 
   const sizeProps: { width?: number; height?: number } = {};
   if (width) sizeProps.width = width;


### PR DESCRIPTION
## Summary

- Project runtime compute targets from shell capabilities and show a compact workstation rail summary for local/cloud.
- Allow cloud editors to submit execution requests when ACL grants editor access.
- Publish runtime output blobs before advertising RuntimeStateDoc refs so viewers do not see transient 404s.
- Resolve protected cloud binary output blobs through authenticated browser fetches and frame-safe display URLs, so private notebook image outputs do not rely on authless `<img src>` requests or parent-origin `blob:` URLs.
- Preserve `blob:` media URLs in shared output components instead of treating them as base64 payloads.
- Add hosted browser execution smoke coverage that seeds OIDC auth, clicks a run button, and can require blob-backed image outputs to load.
- Route cloud viewer runtime-store imports through the notebook surface boundary instead of private desktop paths.

## Verification

- `cargo xtask lint --fix`
- `pnpm --dir apps/notebook-cloud typecheck`
- `pnpm --dir apps/notebook-cloud test`
- `pnpm --dir apps/notebook-cloud exec node --import tsx --test test/blob-resolver.test.ts test/renderer-contract.test.ts test/render-resolution.test.ts`
- `pnpm test:run src/components/outputs/__tests__/media-router.test.tsx apps/notebook/src/lib/__tests__/manifest-resolution.test.ts src/components/isolated/__tests__/embeddable-output.test.ts`
- `pnpm test:run packages/runtimed/tests/blob-resolver.test.ts`
- `NOTEBOOK_CLOUD_BROWSER_EXECUTE_BUTTON_INDEX=0 NOTEBOOK_CLOUD_BROWSER_EXECUTE_EXPECTED_TEXT=blob-line-1499 NOTEBOOK_CLOUD_BROWSER_EXECUTE_REQUIRE_BLOB_IMAGE=1 pnpm --dir apps/notebook-cloud smoke:hosted:browser-execute https://preview.runt.run/n/01KTG3GSP3DNRHK9KFW00CRXK3/blob-image-3469`
- Bedrock `pr-review` final rerun reported `verdict: clear`, no findings: `.context/reviews/pr-3469-final.json`.
- GitHub CI is green for final commit `7ac40404`, including Browser E2E, JS, Clippy, Rust tests, runtimed-node, Python, shared UI artifacts, and long-tail CI health summary.

## Live Smoke Notes

- Preview deploy succeeded from this branch after the final app fix.
  - Renderer assets worker version: `a6e4fc5e-ffa5-4376-ba46-c31700221236`
  - Main worker version: `f297c617-3dce-4c55-a52f-d52aefaa2ea2`
- OIDC refresh is running on lab2 via the user systemd timer `preview-oidc-refresh.timer`; token material stays local in `~/token.preview.json`.
- Protected blob image smoke room: `https://preview.runt.run/n/01KTG3GSP3DNRHK9KFW00CRXK3/blob-image-3469`.
- The smoke verifies authenticated `/api/n/.../blobs/...` fetches return 200, `blob-line-1499` is visible, and the image renders as a loaded `data:image/png` source with no page errors, bad console entries, or failed requests.

## Notes

- This does not add a RuntimeStateDoc schema change. Workstation targets remain projection/UI shape over existing capability state.
- Desktop/local daemon blob URLs remain direct and synchronous; only the cloud viewer opts into authenticated async display URLs for binary output blobs.
- Follow-up candidates from review, intentionally not blocking this PR: bound the per-viewer display URL cache, and decide whether display-update blob publish failures should surface as visible output errors like ordinary outputs.
