### PR TITLE
fix(cloud): handle output frame links

### DIFF
--- a/apps/notebook-cloud/viewer/index.tsx
+++ b/apps/notebook-cloud/viewer/index.tsx
@@ -77,6 +77,7 @@ import {
   NotebookView,
   PresenceValueProvider,
   setLoggerHost,
+  setOpenUrlHost,
   type PresenceContextValue,
 } from "../../notebook/src/notebook-surface";
 import {
@@ -123,6 +124,14 @@ setLoggerHost({
   info: () => {},
   warn: (message: string, ...args: unknown[]) => console.warn(message, ...args),
   error: (message: string, ...args: unknown[]) => console.error(message, ...args),
+});
+
+setOpenUrlHost({
+  externalLinks: {
+    async open(url: string): Promise<void> {
+      window.open(url, "_blank", "noopener,noreferrer");
+    },
+  },
 });
 
 interface CloudViewerAuthConfig {

--- a/apps/notebook/src/lib/open-url.ts
+++ b/apps/notebook/src/lib/open-url.ts
@@ -2,7 +2,9 @@ import type { NotebookHost } from "@nteract/notebook-host";
 
 const ALLOWED_PROTOCOLS = new Set(["http:", "https:", "mailto:", "tel:"]);
 
-let _host: NotebookHost | null = null;
+type ExternalLinkHost = Pick<NotebookHost, "externalLinks">;
+
+let _host: ExternalLinkHost | null = null;
 
 /**
  * Register the `NotebookHost` instance for `openUrl`. Called once from
@@ -11,7 +13,7 @@ let _host: NotebookHost | null = null;
  * (`openUrl(url)`) untouched so the migration to host-based URL opening
  * doesn't need to thread a host parameter through every markdown cell.
  */
-export function setOpenUrlHost(host: NotebookHost | null): void {
+export function setOpenUrlHost(host: ExternalLinkHost | null): void {
   _host = host;
 }
 

--- a/apps/notebook/src/notebook-surface.ts
+++ b/apps/notebook/src/notebook-surface.ts
@@ -7,4 +7,5 @@ export { CrdtBridgeProvider } from "./hooks/useCrdtBridge";
 export { createNotebookController } from "./lib/notebook-controller";
 export { startCursorDispatch } from "./lib/cursor-registry";
 export { setLoggerHost } from "./lib/logger";
+export { setOpenUrlHost } from "./lib/open-url";
 export { emitBroadcast, emitPresence } from "./lib/notebook-frame-bus";

--- a/src/components/isolated/__tests__/frame-html.test.ts
+++ b/src/components/isolated/__tests__/frame-html.test.ts
@@ -93,6 +93,12 @@ describe("generateFrameHtml", () => {
     expect(source).toContain("{ capture: true }");
   });
 
+  it("intercepts iframe link clicks during capture phase", () => {
+    expect(source).toMatch(/document\.addEventListener\(\s*'click'/);
+    expect(source).toContain("sendRpc('nteract/linkClick'");
+    expect(source).toContain("{ capture: true }");
+  });
+
   it("keeps the iframe bootstrap script parseable", () => {
     const scripts = Array.from(html.matchAll(/<script>([\s\S]*?)<\/script>/g), (match) => match[1]);
 

--- a/src/components/isolated/frame.html
+++ b/src/components/isolated/frame.html
@@ -796,16 +796,24 @@
         resizeObserver.observe(document.body);
 
         // --- Link Click Interception ---
-        document.addEventListener("click", function (e) {
-          const link = e.target.closest("a");
-          if (link && link.href) {
-            e.preventDefault();
-            sendRpc("nteract/linkClick", {
-              url: link.href,
-              newTab: e.metaKey || e.ctrlKey,
-            });
-          }
-        });
+        document.addEventListener(
+          "click",
+          function (e) {
+            var target =
+              e.target && e.target.nodeType === Node.ELEMENT_NODE
+                ? e.target
+                : e.target && e.target.parentElement;
+            var link = target && target.closest ? target.closest("a") : null;
+            if (link && link.href) {
+              e.preventDefault();
+              sendRpc("nteract/linkClick", {
+                url: link.href,
+                newTab: e.metaKey || e.ctrlKey,
+              });
+            }
+          },
+          { capture: true },
+        );
 
         // --- Mouse Down Forwarding ---
         // Notify parent that the iframe received a click so it can


### PR DESCRIPTION
## Summary

- route sandboxed output-frame link clicks through the existing parent `nteract/linkClick` message path during capture
- initialize the cloud viewer's external-link host so parent-handled output links open in a browser tab
- keep the output iframe sandbox unchanged, including no `allow-same-origin` and no top-navigation tokens

## Verification

- `cargo xtask lint --fix`
- `pnpm test:run src/components/isolated/__tests__/frame-html.test.ts src/components/isolated/__tests__/frame-html-jsonrpc.test.ts apps/notebook/src/lib/__tests__/open-url.test.ts src/components/isolated/__tests__/frame-config.test.ts src/components/isolated/__tests__/isolated-frame.test.ts`
- `pnpm --dir apps/notebook-cloud typecheck`

## Notes

- This handles legitimate link-click navigation without allowing untrusted output code to navigate the parent frame.
