### PR TITLE
fix(notebook): stabilize execution progress line height

### DIFF
--- a/src/components/cell/CodeCellCurrentLine.tsx
+++ b/src/components/cell/CodeCellCurrentLine.tsx
@@ -425,7 +425,7 @@ export function CodeCellCurrentLine({
       data-execution-label={countLabel ?? undefined}
       className={cn(
         "mt-1.5 flex items-center gap-1.5 text-[11px] leading-none text-muted-foreground/60",
-        isCompactIdle ? "min-h-3.5" : isQuietResting ? "min-h-4" : "min-h-5",
+        isCompactIdle ? "min-h-3.5" : "min-h-4",
         className,
       )}
     >

--- a/src/components/cell/__tests__/CodeCellCurrentLine.test.tsx
+++ b/src/components/cell/__tests__/CodeCellCurrentLine.test.tsx
@@ -166,6 +166,8 @@ describe("CodeCellCurrentLine", () => {
       let signal = container.querySelector('[data-slot="code-cell-current-line-signal"]');
 
       expect(footer).toHaveAttribute("data-execution-visual-state", "running");
+      expect(footer).toHaveClass("min-h-4");
+      expect(footer).not.toHaveClass("min-h-5");
       expect(status).toHaveTextContent("Python/running");
       expect(rule).toHaveAttribute("data-execution-signal", "active");
       expect(signal).toHaveClass("animate-exec-signal-build");
@@ -189,6 +191,8 @@ describe("CodeCellCurrentLine", () => {
       signal = container.querySelector('[data-slot="code-cell-current-line-signal"]');
 
       expect(rule).toHaveAttribute("data-execution-signal", "settling");
+      expect(footer).toHaveClass("min-h-4");
+      expect(footer).not.toHaveClass("min-h-5");
       expect(signal).toHaveClass("animate-exec-signal-settle");
       expect(
         rule?.querySelector('[data-slot="code-cell-current-line-resting-rule"]'),
@@ -199,6 +203,8 @@ describe("CodeCellCurrentLine", () => {
       });
 
       rule = container.querySelector('[data-slot="code-cell-current-line-rule"]');
+      expect(footer).toHaveClass("min-h-4");
+      expect(footer).not.toHaveClass("min-h-5");
       expect(rule).not.toHaveAttribute("data-execution-signal");
       expect(rule?.querySelector("svg")).toBeNull();
     } finally {


### PR DESCRIPTION
## Summary

- Stabilize the code-cell current-line height while the execution progress wave is active or settling.
- Add regression coverage that verifies the animated execution state does not switch to the taller row height.

## Verification

- `cargo xtask lint --fix`
- `pnpm test:run src/components/cell/__tests__/CodeCellCurrentLine.test.tsx`
- `pnpm test:run apps/notebook/src/components/__tests__/code-cell-output-focus.test.tsx`
