### PR TITLE
fix(notebook-cloud): recover stale room host checkpoints

### DIFF
--- a/apps/notebook-cloud/README.md
+++ b/apps/notebook-cloud/README.md
@@ -146,6 +146,26 @@ catalog check to a specific exported snapshot set. Set
 `NOTEBOOK_CLOUD_REQUIRE_SIFT_WASM=0` when the target notebook does not include a
 Sift output.
 
+To verify the live-room path for an already-published notebook, seed Chromium
+with the OIDC token cache and require that the authenticated sync socket stays
+open after cells and output payloads materialize:
+
+```bash
+NOTEBOOK_CLOUD_LIVE_ROOM_MIN_CELLS=20 \
+NOTEBOOK_CLOUD_LIVE_ROOM_REQUIRE_BLOB_FETCH=1 \
+pnpm --dir apps/notebook-cloud smoke:hosted:live-room \
+  https://preview.runt.run/n/topic-viz/topic-viz
+```
+
+This smoke reads the token JSON from
+`${NTERACT_PREVIEW_OIDC_TOKEN_PATH:-$HOME/token.preview.json}` and writes no
+token material to stdout. It is meant for old/live-room regressions rather than
+renderer bundle checks: it fails on `cloud sync socket` churn, output resolution
+errors, failed notebook blob responses, missing cells, or a closed final room
+socket. Sandboxed output frames must not read localStorage; the smoke tracks
+that denial as a benign iframe error because only the first-party viewer shell
+needs the browser token cache.
+
 `publish:live` exports a real synced notebook session through `@runtimed/node`,
 uploads its `NotebookDoc` + `RuntimeStateDoc` + `CommsDoc` snapshot set, walks
 the exported output and widget manifests for blob refs, uploads the matching

--- a/apps/notebook-cloud/package.json
+++ b/apps/notebook-cloud/package.json
@@ -20,6 +20,7 @@
     "smoke": "node --import tsx scripts/smoke.mjs",
     "smoke:hosted": "node scripts/hosted-render-smoke.mjs",
     "smoke:hosted:live": "node scripts/hosted-live-smoke.mjs",
+    "smoke:hosted:live-room": "node scripts/hosted-live-room-smoke.mjs",
     "smoke:hosted:runtime-peer": "node scripts/hosted-runtime-peer-smoke.mjs",
     "smoke:hosted:browser-execute": "node scripts/hosted-browser-execute-smoke.mjs",
     "smoke:hosted:collab": "node --import tsx scripts/hosted-collab-smoke.mjs",

--- a/apps/notebook-cloud/scripts/hosted-live-room-smoke.mjs
+++ b/apps/notebook-cloud/scripts/hosted-live-room-smoke.mjs
@@ -1,0 +1,368 @@
+import { readFile } from "node:fs/promises";
+import os from "node:os";
+
+import { chromium } from "@playwright/test";
+
+const DEFAULT_URL = "https://preview.runt.run/n/topic-viz/topic-viz";
+const viewerUrl =
+  process.argv[2] ??
+  process.env.NOTEBOOK_CLOUD_LIVE_ROOM_VIEWER_URL ??
+  process.env.NOTEBOOK_CLOUD_HOSTED_URL ??
+  DEFAULT_URL;
+const tokenPath =
+  process.env.NTERACT_PREVIEW_OIDC_TOKEN_PATH ??
+  process.env.NOTEBOOK_CLOUD_OIDC_TOKEN_PATH ??
+  `${os.homedir()}/token.preview.json`;
+const requestedScope = process.env.NOTEBOOK_CLOUD_LIVE_ROOM_SCOPE ?? "editor";
+const timeoutMs = parsePositiveInteger(
+  process.env.NOTEBOOK_CLOUD_LIVE_ROOM_TIMEOUT_MS,
+  "NOTEBOOK_CLOUD_LIVE_ROOM_TIMEOUT_MS",
+  60_000,
+);
+const settleMs = parsePositiveInteger(
+  process.env.NOTEBOOK_CLOUD_LIVE_ROOM_SETTLE_MS,
+  "NOTEBOOK_CLOUD_LIVE_ROOM_SETTLE_MS",
+  2_000,
+);
+const minCells = parseNonNegativeInteger(
+  process.env.NOTEBOOK_CLOUD_LIVE_ROOM_MIN_CELLS,
+  "NOTEBOOK_CLOUD_LIVE_ROOM_MIN_CELLS",
+  1,
+);
+const expectedText =
+  process.env.NOTEBOOK_CLOUD_LIVE_ROOM_EXPECTED_TEXT ?? "import plotly.graph_objects as go";
+const requireResolved = process.env.NOTEBOOK_CLOUD_LIVE_ROOM_REQUIRE_RESOLVED !== "0";
+const requireOpenSocket = process.env.NOTEBOOK_CLOUD_LIVE_ROOM_REQUIRE_OPEN_SOCKET !== "0";
+const requireBlobFetch = process.env.NOTEBOOK_CLOUD_LIVE_ROOM_REQUIRE_BLOB_FETCH === "1";
+const screenshotPath = process.env.NOTEBOOK_CLOUD_LIVE_ROOM_SCREENSHOT;
+
+main().catch((error) => {
+  console.error(error instanceof Error ? error.message : String(error));
+  process.exitCode = 1;
+});
+
+async function main() {
+  assertScope(requestedScope);
+  const url = new URL(viewerUrl);
+  const tokenStorageJson = await readOidcTokenStorageJson(tokenPath);
+  const token = JSON.parse(tokenStorageJson);
+  const tokenSecondsRemaining = Number(token.expiresAt) - Math.floor(Date.now() / 1000);
+  if (!Number.isFinite(tokenSecondsRemaining) || tokenSecondsRemaining <= 60) {
+    throw new Error(`${tokenPath} is expired or near expiry; refresh it before running the smoke`);
+  }
+
+  const browser = await chromium.launch({
+    headless: process.env.NOTEBOOK_CLOUD_HEADED !== "1",
+    timeout: timeoutMs,
+  });
+  const context = await browser.newContext({ viewport: { width: 1440, height: 1200 } });
+  await context.addInitScript(
+    ({ origin, scope, tokenJson }) => {
+      try {
+        if (globalThis.location?.origin !== origin) return;
+        globalThis.localStorage?.setItem("nteract:notebook-cloud:oidc-token", tokenJson);
+        globalThis.localStorage?.setItem("nteract:notebook-cloud:scope", scope);
+      } catch {
+        // Sandboxed output frames must deny localStorage. Only the first-party
+        // notebook shell needs the seeded browser token.
+      }
+    },
+    { origin: url.origin, scope: requestedScope, tokenJson: tokenStorageJson },
+  );
+
+  const page = await context.newPage();
+  const events = {
+    pageErrors: [],
+    benignPageErrors: [],
+    badConsole: [],
+    failedRequests: [],
+    blobResponses: [],
+    websockets: [],
+  };
+
+  page.on("pageerror", (error) => {
+    const text = String(error.message ?? error);
+    if (isBenignPageError(text)) {
+      events.benignPageErrors.push(text);
+      return;
+    }
+    events.pageErrors.push(text);
+  });
+  page.on("console", (message) => {
+    const text = message.text();
+    if (isFatalConsoleMessage(text)) {
+      events.badConsole.push(`${message.type()}: ${text}`);
+    }
+  });
+  page.on("requestfailed", (request) => {
+    if (!isRelevantRequestUrl(request.url())) {
+      return;
+    }
+    events.failedRequests.push({
+      url: safeDiagnosticUrl(request.url()),
+      failure: request.failure()?.errorText ?? null,
+    });
+  });
+  page.on("response", (response) => {
+    const responseUrl = response.url();
+    if (/\/api\/n\/[^/]+\/blobs\//.test(responseUrl)) {
+      events.blobResponses.push({
+        url: safeDiagnosticUrl(responseUrl),
+        status: response.status(),
+        contentType: response.headers()["content-type"] ?? null,
+      });
+    }
+  });
+  page.on("websocket", (ws) => {
+    if (!isRoomSyncWebSocket(ws.url())) {
+      return;
+    }
+    const entry = {
+      url: safeDiagnosticUrl(ws.url()),
+      sent: 0,
+      received: 0,
+      closed: false,
+      errors: [],
+    };
+    events.websockets.push(entry);
+    ws.on("framesent", () => {
+      entry.sent += 1;
+    });
+    ws.on("framereceived", () => {
+      entry.received += 1;
+    });
+    ws.on("socketerror", (error) => {
+      entry.errors.push(String(error));
+    });
+    ws.on("close", () => {
+      entry.closed = true;
+    });
+  });
+
+  await page.goto(url.href, { waitUntil: "domcontentloaded", timeout: timeoutMs });
+  if (expectedText) {
+    await page.waitForFunction(
+      (text) => (document.body.textContent ?? "").includes(text),
+      expectedText,
+      { timeout: timeoutMs },
+    );
+  }
+  if (minCells > 0) {
+    await page.waitForFunction(
+      (expected) => document.querySelectorAll("[data-cell-id]").length >= expected,
+      minCells,
+      { timeout: timeoutMs },
+    );
+  }
+  if (requireResolved) {
+    await page.waitForFunction(
+      () => !/Loading notebook|resolving output payloads/i.test(document.body.textContent ?? ""),
+      undefined,
+      { timeout: timeoutMs },
+    );
+  }
+  await page.waitForTimeout(settleMs);
+
+  const diagnostics = await pageDiagnostics(page);
+  if (screenshotPath) {
+    await page.screenshot({ path: screenshotPath, fullPage: true });
+  }
+  await browser.close();
+
+  const failures = [];
+  const failedBlobResponses = events.blobResponses.filter((response) => response.status >= 400);
+  const activeSockets = events.websockets.filter((socket) => !socket.closed);
+  const erroredSockets = events.websockets.filter((socket) => socket.errors.length > 0);
+  if (events.pageErrors.length > 0) {
+    failures.push({ kind: "page-errors", errors: events.pageErrors });
+  }
+  if (events.badConsole.length > 0) {
+    failures.push({ kind: "console-errors", errors: events.badConsole });
+  }
+  if (events.failedRequests.length > 0) {
+    failures.push({ kind: "request-failures", requests: events.failedRequests });
+  }
+  if (failedBlobResponses.length > 0) {
+    failures.push({ kind: "blob-failures", responses: failedBlobResponses });
+  }
+  if (erroredSockets.length > 0) {
+    failures.push({ kind: "websocket-errors", websockets: erroredSockets });
+  }
+  if (events.websockets.length === 0) {
+    failures.push({ kind: "websocket-missing", text: "no room sync WebSocket was observed" });
+  }
+  if (requireOpenSocket && activeSockets.length === 0) {
+    failures.push({
+      kind: "websocket-closed",
+      text: "no room sync WebSocket remained open after notebook materialization",
+      websockets: events.websockets,
+    });
+  }
+  if (requireBlobFetch && events.blobResponses.length === 0) {
+    failures.push({ kind: "blob-missing", text: "no notebook blob responses were observed" });
+  }
+  if (diagnostics.cellCount < minCells) {
+    failures.push({
+      kind: "cell-count",
+      expected: minCells,
+      actual: diagnostics.cellCount,
+    });
+  }
+  if (requireResolved && diagnostics.loading) {
+    failures.push({
+      kind: "loading-state",
+      text: "notebook was still loading or resolving output payloads after the timeout",
+    });
+  }
+
+  const result = {
+    ok: failures.length === 0,
+    viewerUrl: url.href,
+    token: {
+      path: tokenPath,
+      secondsRemaining: tokenSecondsRemaining,
+      subject: token.claims?.email ?? token.claims?.sub ?? null,
+    },
+    checks: {
+      requestedScope,
+      expectedText: expectedText || null,
+      minCells,
+      requireResolved,
+      requireOpenSocket,
+      requireBlobFetch,
+      screenshotPath: screenshotPath ?? null,
+    },
+    diagnostics,
+    events,
+    failures,
+  };
+
+  if (failures.length > 0) {
+    throw new Error(`hosted live room smoke failed:\n${JSON.stringify(result, null, 2)}`);
+  }
+  console.log(JSON.stringify(result, null, 2));
+}
+
+async function readOidcTokenStorageJson(path) {
+  const raw = await readFile(path, "utf8");
+  const token = JSON.parse(raw);
+  if (typeof token.accessToken !== "string" || token.accessToken.length === 0) {
+    throw new Error(`${path} is missing accessToken`);
+  }
+  if (!token.claims || typeof token.claims.sub !== "string" || token.claims.sub.length === 0) {
+    throw new Error(`${path} is missing claims.sub`);
+  }
+  return JSON.stringify(token);
+}
+
+async function pageDiagnostics(page) {
+  return page.evaluate(() => {
+    const compactUrl = (value) => {
+      if (!value) return value;
+      if (value.startsWith("data:")) {
+        const mediaType = value.slice(0, value.indexOf(","));
+        return `${mediaType},<${value.length} chars>`;
+      }
+      return value.length > 240 ? `${value.slice(0, 240)}...` : value;
+    };
+    const text = (document.body.textContent ?? "").replace(/\s+/g, " ");
+    const cellCount = document.querySelectorAll("[data-cell-id]").length;
+    const iframes = Array.from(document.querySelectorAll("iframe[sandbox]"))
+      .map((iframe) => ({
+        src: compactUrl(iframe.getAttribute("src")),
+        width: iframe.clientWidth,
+        height: iframe.clientHeight,
+      }))
+      .slice(0, 30);
+    const images = Array.from(document.querySelectorAll("img"))
+      .map((image) => ({
+        src: compactUrl(image.currentSrc || image.src),
+        complete: image.complete,
+        naturalWidth: image.naturalWidth,
+        naturalHeight: image.naturalHeight,
+      }))
+      .slice(0, 30);
+    return {
+      cellCount,
+      iframeCount: iframes.length,
+      imageCount: images.length,
+      loading: /Loading notebook|resolving output payloads/i.test(text),
+      textSample: text.slice(0, 2_000),
+      iframes,
+      images,
+    };
+  });
+}
+
+function isRoomSyncWebSocket(value) {
+  try {
+    const url = new URL(value);
+    return url.pathname.endsWith("/sync");
+  } catch {
+    return false;
+  }
+}
+
+function isRelevantRequestUrl(value) {
+  try {
+    const url = new URL(value);
+    return (
+      url.pathname.includes("/api/n/") ||
+      url.pathname.includes("/assets/") ||
+      url.pathname.includes("/renderer-assets/") ||
+      url.hostname.includes("runtusercontent")
+    );
+  } catch {
+    return false;
+  }
+}
+
+function isFatalConsoleMessage(text) {
+  return /OutputResolutionError|Unable to resolve output|Failed to fetch blob|flush_comms_doc_sync|cloud sync socket|room\.peer_sync|sync to relay failed|runtime state sync to relay failed|comms doc sync to relay failed/i.test(
+    text,
+  );
+}
+
+function isBenignPageError(text) {
+  // Output iframes are intentionally sandboxed away from browser credentials.
+  return /Failed to read the 'localStorage' property from 'Window': The document is sandboxed/i.test(
+    text,
+  );
+}
+
+function safeDiagnosticUrl(value) {
+  try {
+    const url = new URL(value);
+    url.searchParams.delete("viewer_session");
+    if (/\/api\/n\/[^/]+\/blobs\//.test(url.pathname)) {
+      return `${url.origin}/api/n/<id>/blobs/<hash>`;
+    }
+    return url.href;
+  } catch {
+    return value.replace(/viewer_session=[^&\s]+/g, "viewer_session=<redacted>");
+  }
+}
+
+function assertScope(scope) {
+  if (!["viewer", "editor", "owner"].includes(scope)) {
+    throw new Error("NOTEBOOK_CLOUD_LIVE_ROOM_SCOPE must be viewer, editor, or owner");
+  }
+}
+
+function parsePositiveInteger(value, name, fallback) {
+  if (value === undefined || value === "") return fallback;
+  const parsed = Number(value);
+  if (!Number.isInteger(parsed) || parsed <= 0) {
+    throw new Error(`${name} must be a positive integer`);
+  }
+  return parsed;
+}
+
+function parseNonNegativeInteger(value, name, fallback) {
+  if (value === undefined || value === "") return fallback;
+  const parsed = Number(value);
+  if (!Number.isInteger(parsed) || parsed < 0) {
+    throw new Error(`${name} must be a non-negative integer`);
+  }
+  return parsed;
+}

--- a/apps/notebook-cloud/src/room-materializer.ts
+++ b/apps/notebook-cloud/src/room-materializer.ts
@@ -57,7 +57,15 @@ export class RoomMaterializer {
   ) {}
 
   async syncPeer(peer: RoomPeer): Promise<RoomHostFrameResult> {
-    return this.withHost((host) => normalizeResult(host.sync_peer(peer.id, peer.identity.scope)));
+    try {
+      return await this.syncPeerWithCurrentHost(peer);
+    } catch (error) {
+      const recovered = await this.recoverHostFromLatestPublishedSnapshot("sync_peer", error);
+      if (!recovered) {
+        throw error;
+      }
+      return this.syncPeerWithCurrentHost(peer);
+    }
   }
 
   async removePeer(peerId: string): Promise<void> {
@@ -138,6 +146,10 @@ export class RoomMaterializer {
       () => undefined,
     );
     return run;
+  }
+
+  private async syncPeerWithCurrentHost(peer: RoomPeer): Promise<RoomHostFrameResult> {
+    return this.withHost((host) => normalizeResult(host.sync_peer(peer.id, peer.identity.scope)));
   }
 
   private async loadHost(): Promise<RoomHostHandle> {
@@ -269,6 +281,83 @@ export class RoomMaterializer {
       });
       throw error;
     }
+  }
+
+  private async recoverHostFromLatestPublishedSnapshot(
+    operation: string,
+    cause: unknown,
+  ): Promise<boolean> {
+    const run = this.operationQueue.then(async () =>
+      this.recoverHostFromLatestPublishedSnapshotNow(operation, cause),
+    );
+    this.operationQueue = run.then(
+      () => undefined,
+      () => undefined,
+    );
+    return run;
+  }
+
+  private async recoverHostFromLatestPublishedSnapshotNow(
+    operation: string,
+    cause: unknown,
+  ): Promise<boolean> {
+    const startedAt = Date.now();
+    const published = await this.loadLatestPublishedSnapshotPairForCheckpoint();
+    if (!published) {
+      cloudLog("warn", "room.materializer.recovery_skipped", {
+        notebook_id: this.notebookId,
+        operation,
+        reason: "latest_published_snapshot_unavailable",
+        error: errorMessage(cause),
+        counter: "materializer_recovery_skipped",
+        counter_delta: 1,
+      });
+      return false;
+    }
+
+    try {
+      const host = await loadRoomHostSnapshot(
+        published.notebookBytes,
+        published.runtimeStateBytes,
+        published.commsDocBytes,
+      );
+      this.markLoadedPublishedSnapshot(published.revisionId, host);
+      await this.clearCheckpoint();
+      this.hostReady = Promise.resolve(host);
+      cloudLog("warn", "room.materializer.recovered_from_published_snapshot", {
+        notebook_id: this.notebookId,
+        operation,
+        published_revision_id: published.revisionId,
+        duration_ms: durationMs(startedAt),
+        notebook_byte_length: published.notebookBytes.byteLength,
+        runtime_state_byte_length: published.runtimeStateBytes.byteLength,
+        error: errorMessage(cause),
+        counter: "materializer_recovered_from_published_snapshot",
+        counter_delta: 1,
+      });
+      return true;
+    } catch (recoveryError) {
+      cloudLog("warn", "room.materializer.recovery_failed", {
+        notebook_id: this.notebookId,
+        operation,
+        published_revision_id: published.revisionId,
+        duration_ms: durationMs(startedAt),
+        error: errorMessage(recoveryError),
+        original_error: errorMessage(cause),
+        counter: "materializer_recovery_failed",
+        counter_delta: 1,
+      });
+      return false;
+    }
+  }
+
+  private async clearCheckpoint(): Promise<void> {
+    await Promise.all([
+      this.state.storage.delete(CHECKPOINT_NOTEBOOK_KEY),
+      this.state.storage.delete(CHECKPOINT_RUNTIME_STATE_KEY),
+      this.state.storage.delete(CHECKPOINT_COMMS_DOC_KEY),
+      this.state.storage.delete(CHECKPOINT_META_KEY),
+    ]);
   }
 
   private async loadCheckpoint(): Promise<{

--- a/apps/notebook-cloud/test/room-materializer.test.ts
+++ b/apps/notebook-cloud/test/room-materializer.test.ts
@@ -1085,6 +1085,76 @@ describe("RoomMaterializer", () => {
     );
   });
 
+  it("recovers from a checkpoint host that fails initial peer sync", async () => {
+    const state = fakeState();
+    const checkpointSnapshot = await createNotebookRoomSnapshot(
+      "demo",
+      "checkpoint-cell",
+      "Unreachable checkpoint edit\n",
+    );
+    const publishedSnapshot = await createNotebookRoomSnapshot(
+      "demo",
+      "published-cell",
+      "Recovered published snapshot\n",
+    );
+    await Promise.all([
+      state.storage.put(
+        "room-host:notebook-doc",
+        arrayBufferFromBytes(checkpointSnapshot.notebookBytes),
+      ),
+      state.storage.put(
+        "room-host:runtime-state-doc",
+        arrayBufferFromBytes(checkpointSnapshot.runtimeStateBytes),
+      ),
+      state.storage.put("room-host:checkpoint", {
+        version: 4,
+        notebook_heads: checkpointSnapshot.notebookHeads,
+        runtime_state_heads: checkpointSnapshot.runtimeStateHeads,
+        saved_at: "2026-05-28T00:00:00.000Z",
+        published_revision_id: "revision-current",
+        published_notebook_heads: publishedSnapshot.notebookHeads,
+        published_runtime_state_heads: publishedSnapshot.runtimeStateHeads,
+      }),
+    ]);
+
+    const env = fakePublishedSnapshotEnv({
+      notebookId: "demo",
+      revisionId: "revision-current",
+      actorLabel: "user:dev:publisher/agent:runt-publish",
+      notebookBytes: publishedSnapshot.notebookBytes,
+      runtimeStateBytes: publishedSnapshot.runtimeStateBytes,
+    });
+
+    const reloaded = new RoomMaterializer("demo", state, env);
+    const checkpointHost = await (
+      reloaded as unknown as {
+        loadHost(): Promise<{ sync_peer: (peerId: string, connectionScope: string) => unknown }>;
+      }
+    ).loadHost();
+    checkpointHost.sync_peer = () => {
+      throw new Error("recursive use of an object detected which would lead to unsafe aliasing");
+    };
+
+    const viewer = NotebookHandle.create_bootstrap("user:dev:bob/desktop:b");
+    await syncMaterializerWithClient(
+      reloaded,
+      {
+        id: "peer-viewer",
+        identity: authenticateDevRequest(
+          new Request("https://cloud.test/n/demo/sync?user=bob&operator=desktop:b&scope=viewer"),
+        ),
+      },
+      viewer,
+    );
+
+    const cells = JSON.parse(viewer.get_cells_json()) as Array<{ id: string; source: string }>;
+    assert.deepEqual(
+      cells.map((cell) => [cell.id, cell.source]),
+      [["published-cell", "Recovered published snapshot\n"]],
+    );
+    assert.deepEqual([...(await state.storage.list({ prefix: "room-host:" })).keys()], []);
+  });
+
   it("rejects runtime peer execution creation over runtime-state sync", async () => {
     const state = fakeState();
     const materializer = new RoomMaterializer("demo", state, {} as Env);


### PR DESCRIPTION
## Summary

- recover live room materialization when an existing Room Durable Object checkpoint fails initial peer sync
- reload the latest published snapshot pair, clear the bad room-host checkpoint keys, and retry the peer sync once
- add a hosted live-room Playwright smoke for already-published notebooks like `topic-viz`

## Why

`topic-viz` had valid published notebook/runtime snapshots, but the live room repeatedly closed its sync socket from a stale room-host checkpoint. Local snapshot sync succeeded, so the failure was isolated to the DO checkpoint path. The recovery keeps old published notebooks reachable without requiring manual checkpoint deletion.

The smoke seeds OIDC only into the first-party viewer shell. Sandboxed output frames must not read `localStorage`; the smoke treats that denial as a benign iframe security boundary while still failing on cloud sync churn, output resolution failures, blob 404s, missing cells, or a closed room socket.

## Verification

- `node --check apps/notebook-cloud/scripts/hosted-live-room-smoke.mjs`
- `pnpm --dir apps/notebook-cloud run typecheck`
- `pnpm --dir apps/notebook-cloud exec node --import tsx --test test/room-materializer.test.ts`
- `pnpm --dir apps/notebook-cloud run test` (503 tests, before the smoke-only commit)
- `cargo xtask lint --fix`
- deployed preview:
  - renderer-assets version `97cf0441-dc8b-4eb0-b92b-8eb6329a61b3`
  - main Worker version `2d4a5d51-7d84-4088-ab59-8934361af343`
- hosted smoke against `https://preview.runt.run/n/topic-viz/topic-viz`:
  - 23 cells
  - 16 sandboxed frames
  - 3 rendered images
  - 17 notebook blob responses, all `200`
  - one editor sync WebSocket remained open
