### PR TITLE
perf(notebook): stabilize rail panel width

### DIFF
--- a/src/components/notebook-rail/NotebookRail.tsx
+++ b/src/components/notebook-rail/NotebookRail.tsx
@@ -20,9 +20,7 @@ export type NotebookRailPanelId = "outline" | "packages" | "workstations";
 export const NOTEBOOK_RAIL_TAKEOVER_MEDIA_QUERY = RAIL_TAKEOVER_MEDIA_QUERY;
 export const NOTEBOOK_RAIL_TAKEOVER_STAGE_CLASS_NAME = RAIL_TAKEOVER_STAGE_CLASS_NAME;
 export const NOTEBOOK_RAIL_TAKEOVER_PANEL_CLASS_NAMES = RAIL_TAKEOVER_PANEL_CLASS_NAMES;
-const NOTEBOOK_RAIL_OUTLINE_PANEL_CLASS_NAME = "w-[clamp(15rem,20vw,18rem)] min-w-60";
-const NOTEBOOK_RAIL_PACKAGES_PANEL_CLASS_NAME = "w-[clamp(15rem,20vw,17rem)] min-w-60";
-const NOTEBOOK_RAIL_WORKSTATIONS_PANEL_CLASS_NAME = "w-[clamp(16rem,22vw,19rem)] min-w-64";
+const NOTEBOOK_RAIL_PANEL_CLASS_NAME = "w-[clamp(16rem,20vw,18rem)] min-w-64";
 
 export interface NotebookRailProps {
   activePanelId: NotebookRailPanelId;
@@ -83,13 +81,6 @@ export function NotebookRail({
       : activePanelId === "workstations"
         ? workstationsSummary
         : null;
-  const panelClassName =
-    activePanelId === "packages"
-      ? NOTEBOOK_RAIL_PACKAGES_PANEL_CLASS_NAME
-      : activePanelId === "workstations"
-        ? NOTEBOOK_RAIL_WORKSTATIONS_PANEL_CLASS_NAME
-        : NOTEBOOK_RAIL_OUTLINE_PANEL_CLASS_NAME;
-
   return (
     <Rail
       activePanelId={activePanelId}
@@ -98,7 +89,7 @@ export function NotebookRail({
       panelEyebrow="Notebook"
       panelTitle={title}
       panelSummary={summary}
-      panelClassName={panelClassName}
+      panelClassName={NOTEBOOK_RAIL_PANEL_CLASS_NAME}
       className={className}
       dataTestId="notebook-rail"
       collapseButtonSlot="notebook-rail-collapse-button"

--- a/src/components/notebook-rail/__tests__/NotebookRail.test.tsx
+++ b/src/components/notebook-rail/__tests__/NotebookRail.test.tsx
@@ -149,7 +149,7 @@ describe("NotebookRail", () => {
     expect(screen.getByText("Attached")).toBeVisible();
     expect(screen.getByTestId("host-workstations-content")).toHaveTextContent("runtime target");
     expect(container.querySelector('[data-slot="notebook-rail-panel"]')).toHaveClass(
-      "w-[clamp(16rem,22vw,19rem)]",
+      "w-[clamp(16rem,20vw,18rem)]",
       "min-w-64",
     );
   });
@@ -269,14 +269,14 @@ describe("NotebookRail", () => {
       screen.getByTestId("notebook-rail").querySelector('[data-slot="notebook-rail-panel"]'),
     ).toBeInTheDocument();
     expect(container.querySelector('[data-slot="notebook-rail-panel"]')).toHaveClass(
-      "w-[clamp(15rem,20vw,18rem)]",
-      "min-w-60",
+      "w-[clamp(16rem,20vw,18rem)]",
+      "min-w-64",
       ...NOTEBOOK_RAIL_TAKEOVER_PANEL_CLASS_NAMES.split(" "),
     );
   });
 
-  it("gives package details enough room until the rail owns the viewport", () => {
-    const { container } = render(
+  it("keeps package and workstation panel widths stable while switching panels", () => {
+    const { container, rerender } = render(
       <NotebookRail
         activePanelId="packages"
         collapsed={false}
@@ -287,10 +287,29 @@ describe("NotebookRail", () => {
       />,
     );
 
-    expect(container.querySelector('[data-slot="notebook-rail-panel"]')).toHaveClass(
-      "w-[clamp(15rem,20vw,17rem)]",
-      "min-w-60",
+    const packagesPanel = container.querySelector('[data-slot="notebook-rail-panel"]');
+    const panelWidthClass = "w-[clamp(16rem,20vw,18rem)]";
+    expect(packagesPanel).toHaveClass(
+      panelWidthClass,
+      "min-w-64",
       ...NOTEBOOK_RAIL_TAKEOVER_PANEL_CLASS_NAMES.split(" "),
+    );
+
+    rerender(
+      <NotebookRail
+        activePanelId="workstations"
+        collapsed={false}
+        outlineItems={outlineItems}
+        packagesPanel={<NotebookPackagesPanel>Packages</NotebookPackagesPanel>}
+        workstationsPanel={<div>Runtime target</div>}
+        onActivePanelChange={vi.fn()}
+        onCollapsedChange={vi.fn()}
+      />,
+    );
+
+    expect(container.querySelector('[data-slot="notebook-rail-panel"]')).toHaveClass(
+      panelWidthClass,
+      "min-w-64",
     );
   });
 


### PR DESCRIPTION
## Summary

- use one stable responsive width for shared notebook rail panels
- keep Outline, Packages, and Workstations from resizing the notebook stage when switching panels
- update rail tests so stable panel width is an explicit contract

## Why

Repeatedly toggling the Workstations and Packages rail buttons on output-heavy notebooks like `topic-viz` forced the notebook stage to resize. Before this change, Packages measured `272px` wide and Workstations measured `304px` wide at the same viewport, so every alternating click forced stage width changes and visible layout churn.

This is intentionally a narrow fix. The longer-tail render costs are still real and probably belong in a later text-measurement/deferred-rendering pass rather than a broad rail layout rewrite.

## Preview probe

Deployed to preview before opening this PR and measured `https://preview.runt.run/n/topic-viz/topic-viz` with the Playwright rail probe.

Before:

- panel widths: `304px` / `272px`
- stage widths: `1087px` / `1119px`
- click p95: `41.6ms`
- click-time layout-shift total: `23.1599`

After:

- panel width: `288px`
- stage width: `1103px`
- click p95: `33.4ms`
- click-time layout-shift total: `0.6370`

The remaining first Workstations mount still has one ~65ms long task, which is now separated from the repeated stage-resize churn.

## Verification

- `pnpm test:run src/components/notebook-rail/__tests__/NotebookRail.test.tsx`
- `pnpm --dir apps/notebook-cloud run typecheck`
- `cargo xtask lint --fix`
- deployed preview:
  - renderer-assets version `24f0ee3a-b131-4dea-affc-6c02d2b04085`
  - main Worker version `19160272-3bca-4220-b7f5-8d3a6aef39ce`
- `NOTEBOOK_CLOUD_LIVE_ROOM_MIN_CELLS=20 NOTEBOOK_CLOUD_LIVE_ROOM_REQUIRE_BLOB_FETCH=1 pnpm --dir apps/notebook-cloud smoke:hosted:live-room https://preview.runt.run/n/topic-viz/topic-viz`
