### PR TITLE
fix(notebook-cloud): publish nested arrow blobs

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -415,7 +415,7 @@ jobs:
         run: pnpm --filter @nteract/sift test
 
       - name: Run JS benchmarks
-        run: vp test bench --run apps/notebook/src/lib/__tests__/
+        run: pnpm test:bench
 
   browser-e2e:
     name: Browser E2E (Playwright)

--- a/apps/notebook-cloud/README.md
+++ b/apps/notebook-cloud/README.md
@@ -662,7 +662,8 @@ The smoke reads the token JSON from
 `${NTERACT_PREVIEW_OIDC_TOKEN_PATH:-$HOME/token.preview.json}` and writes no
 token material to stdout. It injects the cache only into the first-party
 notebook origin, requests `owner` scope by default, clicks the selected
-`data-testid="execute-button"`, waits for the optional expected text, and
+`data-testid="execute-button"`, waits for that button's execution ordinal to
+advance, waits for the optional expected text, and
 asserts that notebook blob fetches return 2xx. When
 `NOTEBOOK_CLOUD_BROWSER_EXECUTE_REQUIRE_BLOB_IMAGE=1`, at least one notebook
 blob must also render as a normal `<img src="/api/n/.../blobs/:hash">` image.

--- a/apps/notebook-cloud/README.md
+++ b/apps/notebook-cloud/README.md
@@ -166,6 +166,44 @@ socket. Sandboxed output frames must not read localStorage; the smoke tracks
 that denial as a benign iframe error because only the first-party viewer shell
 needs the browser token cache.
 
+For long-tail notebook rendering sweeps, use `smoke:hosted:live-rooms`. By
+default it reads the same token cache, lists the most recent notebooks visible
+to that principal through `/api/n?limit=5`, and runs the live-room smoke against
+each URL with permissive expectations so empty or sparse notebooks still count:
+
+```bash
+pnpm --dir apps/notebook-cloud smoke:hosted:live-rooms
+```
+
+Increase the catalog sweep size or save per-notebook screenshots when chasing
+old-notebook regressions:
+
+```bash
+NOTEBOOK_CLOUD_LIVE_ROOM_MATRIX_LIMIT=20 \
+NOTEBOOK_CLOUD_LIVE_ROOM_MATRIX_SCREENSHOT_DIR=.context/live-room-matrix \
+pnpm --dir apps/notebook-cloud smoke:hosted:live-rooms
+```
+
+Pass an explicit matrix when a notebook needs stricter output assertions. URL
+strings are accepted with `|` or newline separators; JSON object entries can set
+per-notebook page/frame text, visible iframe, image, and blob requirements:
+
+```bash
+NOTEBOOK_CLOUD_LIVE_ROOM_MATRIX_URLS='[
+  {
+    "label": "topic-viz",
+    "url": "https://preview.runt.run/n/topic-viz/topic-viz",
+    "expectedText": "import plotly.graph_objects as go",
+    "expectedFrameTexts": ["PROBLEM_MARKDOWN"],
+    "minCells": 20,
+    "minVisibleIframes": 2,
+    "minImages": 3,
+    "requireBlobFetch": true,
+    "requireImagesLoaded": true
+  }
+]' pnpm --dir apps/notebook-cloud smoke:hosted:live-rooms
+```
+
 `publish:live` exports a real synced notebook session through `@runtimed/node`,
 uploads its `NotebookDoc` + `RuntimeStateDoc` + `CommsDoc` snapshot set, walks
 the exported output and widget manifests for blob refs, uploads the matching

--- a/apps/notebook-cloud/README.md
+++ b/apps/notebook-cloud/README.md
@@ -646,6 +646,20 @@ old `--timeout` flag in smoke scripts. Rooms created with the API-key path are
 private; anonymous hosted render smokes may return a catalog 404 unless the
 browser context has a credential for the owning principal.
 
+Use the combined runtime/browser smoke when you want the full preview remote
+compute path in one command. It creates one API-key room per requested browser
+scope, keeps that room's runtime peer alive, clicks execution through Chromium
+for `owner` and `editor` scope by default, then stops each peer it started:
+
+```bash
+NTERACT_CLOUD_URL=https://preview.runt.run \
+pnpm --dir apps/notebook-cloud smoke:hosted:runtime-browser-execute
+```
+
+Set `NOTEBOOK_CLOUD_RUNTIME_BROWSER_EXECUTE_SCOPES=owner` for a single-scope
+run, or set `NOTEBOOK_CLOUD_RUNTIME_BROWSER_EXECUTE_CODE` when you need a fixed
+source/output marker for a trace.
+
 To exercise the actual hosted browser execution path against a private room,
 seed Chromium with the same OIDC token cache the viewer stores in
 `localStorage` and click a rendered cell run button:

--- a/apps/notebook-cloud/package.json
+++ b/apps/notebook-cloud/package.json
@@ -21,6 +21,7 @@
     "smoke:hosted": "node scripts/hosted-render-smoke.mjs",
     "smoke:hosted:live": "node scripts/hosted-live-smoke.mjs",
     "smoke:hosted:live-room": "node scripts/hosted-live-room-smoke.mjs",
+    "smoke:hosted:live-rooms": "node scripts/hosted-live-room-matrix-smoke.mjs",
     "smoke:hosted:runtime-peer": "node scripts/hosted-runtime-peer-smoke.mjs",
     "smoke:hosted:browser-execute": "node scripts/hosted-browser-execute-smoke.mjs",
     "smoke:hosted:collab": "node --import tsx scripts/hosted-collab-smoke.mjs",

--- a/apps/notebook-cloud/package.json
+++ b/apps/notebook-cloud/package.json
@@ -24,6 +24,7 @@
     "smoke:hosted:live-rooms": "node scripts/hosted-live-room-matrix-smoke.mjs",
     "smoke:hosted:runtime-peer": "node scripts/hosted-runtime-peer-smoke.mjs",
     "smoke:hosted:browser-execute": "node scripts/hosted-browser-execute-smoke.mjs",
+    "smoke:hosted:runtime-browser-execute": "node scripts/hosted-runtime-browser-execute-smoke.mjs",
     "smoke:hosted:collab": "node --import tsx scripts/hosted-collab-smoke.mjs",
     "smoke:hosted:install": "playwright install chromium",
     "smoke:hosted:source-room": "node scripts/hosted-source-room-smoke.mjs",

--- a/apps/notebook-cloud/scripts/cli-args.mjs
+++ b/apps/notebook-cloud/scripts/cli-args.mjs
@@ -1,0 +1,9 @@
+export function firstPositionalArg(args = process.argv.slice(2)) {
+  for (const arg of args) {
+    if (arg === "--" || arg.trim() === "") {
+      continue;
+    }
+    return arg;
+  }
+  return undefined;
+}

--- a/apps/notebook-cloud/scripts/hosted-browser-execute-smoke.mjs
+++ b/apps/notebook-cloud/scripts/hosted-browser-execute-smoke.mjs
@@ -2,9 +2,10 @@ import { readFile } from "node:fs/promises";
 import os from "node:os";
 
 import { chromium } from "@playwright/test";
+import { firstPositionalArg } from "./cli-args.mjs";
 
 const viewerUrl =
-  process.argv[2] ??
+  firstPositionalArg() ??
   process.env.NOTEBOOK_CLOUD_BROWSER_EXECUTE_VIEWER_URL ??
   process.env.NOTEBOOK_CLOUD_HOSTED_URL;
 const tokenPath =

--- a/apps/notebook-cloud/scripts/hosted-browser-execute-smoke.mjs
+++ b/apps/notebook-cloud/scripts/hosted-browser-execute-smoke.mjs
@@ -27,6 +27,11 @@ const settleMs = parsePositiveInteger(
   "NOTEBOOK_CLOUD_BROWSER_EXECUTE_SETTLE_MS",
   6_000,
 );
+const preClickSettleMs = parseNonNegativeInteger(
+  process.env.NOTEBOOK_CLOUD_BROWSER_EXECUTE_PRE_CLICK_SETTLE_MS,
+  "NOTEBOOK_CLOUD_BROWSER_EXECUTE_PRE_CLICK_SETTLE_MS",
+  2_000,
+);
 const expectedText = process.env.NOTEBOOK_CLOUD_BROWSER_EXECUTE_EXPECTED_TEXT;
 const requireBlobImage = process.env.NOTEBOOK_CLOUD_BROWSER_EXECUTE_REQUIRE_BLOB_IMAGE === "1";
 const allowFailedRequests =
@@ -134,12 +139,18 @@ async function main() {
     await page.goto(url.href, { waitUntil: "domcontentloaded", timeout: timeoutMs });
     await page.waitForLoadState("networkidle", { timeout: timeoutMs }).catch(() => {});
     await waitForExecuteButtons(page, executeButtonIndex, timeoutMs);
+    if (preClickSettleMs > 0) {
+      await page.waitForTimeout(preClickSettleMs);
+    }
 
     const before = await pageDiagnostics(page);
     const button = page.locator('[data-testid="execute-button"]').nth(executeButtonIndex);
     await button.scrollIntoViewIfNeeded();
     const clickedAria = await button.getAttribute("aria-label");
-    const beforeExecutionOrdinal = executionOrdinal(clickedAria);
+    const beforeExecutionOrdinal = maxExecutionOrdinal(
+      executionOrdinal(clickedAria),
+      before.maxExecutionOrdinal,
+    );
     await button.click({ timeout: timeoutMs });
     await waitForExecutionOrdinalAdvance(
       page,
@@ -171,7 +182,10 @@ async function main() {
     const loadedBlobBackedImages = after.images.filter(
       (image) => isBlobBackedImageSource(image.src) && isLoadedImage(image),
     );
-    const afterExecutionOrdinal = executionOrdinal(after.executeButtons[executeButtonIndex]?.aria);
+    const afterExecutionOrdinal = maxExecutionOrdinal(
+      executionOrdinal(after.executeButtons[executeButtonIndex]?.aria),
+      after.maxExecutionOrdinal,
+    );
     if (events.pageErrors.length > 0) {
       throw new Error(`browser page errors:\n${events.pageErrors.join("\n")}`);
     }
@@ -219,6 +233,7 @@ async function main() {
             afterAria: after.executeButtons[executeButtonIndex]?.aria ?? null,
             beforeExecutionOrdinal,
             afterExecutionOrdinal,
+            preClickSettleMs,
           },
           checks: [
             "oidc_token_seeded_in_browser_storage",
@@ -300,6 +315,13 @@ async function pageDiagnostics(page) {
         disabled: button.disabled,
       }))
       .slice(0, 80);
+    const maxExecutionOrdinal = maxOrdinal(
+      [
+        ...executeButtons.flatMap((button) => [button.aria]),
+        ...visibleButtons.flatMap((button) => [button.aria, button.title, button.text]),
+        text,
+      ].flatMap(executionOrdinals),
+    );
     const images = Array.from(document.querySelectorAll("img"))
       .map((image) => ({
         src: image.currentSrc || image.src,
@@ -312,8 +334,20 @@ async function pageDiagnostics(page) {
       textSample: text.slice(0, 2_000),
       executeButtons,
       visibleButtons,
+      maxExecutionOrdinal,
       images,
     };
+
+    function executionOrdinals(value) {
+      if (!value) return [];
+      return Array.from(value.matchAll(/last execution\s+(\d+)|last run\s+(\d+)/gi))
+        .map((match) => Number(match[1] ?? match[2]))
+        .filter(Number.isInteger);
+    }
+
+    function maxOrdinal(values) {
+      return values.length > 0 ? Math.max(...values) : null;
+    }
   });
 }
 
@@ -338,10 +372,15 @@ function isBenignPageError(text) {
 }
 
 function executionOrdinal(value) {
-  const match = value?.match(/last execution\s+(\d+)/i);
+  const match = value?.match(/last execution\s+(\d+)|last run\s+(\d+)/i);
   if (!match) return null;
-  const parsed = Number(match[1]);
+  const parsed = Number(match[1] ?? match[2]);
   return Number.isInteger(parsed) ? parsed : null;
+}
+
+function maxExecutionOrdinal(...values) {
+  const ordinals = values.filter(Number.isInteger);
+  return ordinals.length > 0 ? Math.max(...ordinals) : null;
 }
 
 function executionOrdinalAdvanced(before, after) {

--- a/apps/notebook-cloud/scripts/hosted-browser-execute-smoke.mjs
+++ b/apps/notebook-cloud/scripts/hosted-browser-execute-smoke.mjs
@@ -3,6 +3,7 @@ import os from "node:os";
 
 import { chromium } from "@playwright/test";
 import { firstPositionalArg } from "./cli-args.mjs";
+import { saveSmokeScreenshot, smokeOutputPath } from "./smoke-paths.mjs";
 
 const viewerUrl =
   firstPositionalArg() ??
@@ -37,7 +38,7 @@ const expectedText = process.env.NOTEBOOK_CLOUD_BROWSER_EXECUTE_EXPECTED_TEXT;
 const requireBlobImage = process.env.NOTEBOOK_CLOUD_BROWSER_EXECUTE_REQUIRE_BLOB_IMAGE === "1";
 const allowFailedRequests =
   process.env.NOTEBOOK_CLOUD_BROWSER_EXECUTE_ALLOW_FAILED_REQUESTS === "1";
-const screenshotPath = process.env.NOTEBOOK_CLOUD_BROWSER_EXECUTE_SCREENSHOT;
+const screenshotPath = smokeOutputPath(process.env.NOTEBOOK_CLOUD_BROWSER_EXECUTE_SCREENSHOT);
 
 main().catch((error) => {
   console.error(error instanceof Error ? error.message : String(error));
@@ -173,7 +174,7 @@ async function main() {
 
     const after = await pageDiagnostics(page);
     if (screenshotPath) {
-      await page.screenshot({ path: screenshotPath, fullPage: true });
+      await saveSmokeScreenshot(page, screenshotPath);
     }
 
     const failedBlobResponses = events.blobResponses.filter((response) => response.status >= 400);

--- a/apps/notebook-cloud/scripts/hosted-browser-execute-smoke.mjs
+++ b/apps/notebook-cloud/scripts/hosted-browser-execute-smoke.mjs
@@ -57,160 +57,189 @@ async function main() {
   }
 
   const browser = await chromium.launch({ headless: true });
-  const context = await browser.newContext({ viewport: { width: 1440, height: 1000 } });
-  await context.addInitScript(
-    ({ origin, scope, tokenJson }) => {
-      try {
-        if (globalThis.location?.origin !== origin) return;
-        globalThis.localStorage?.setItem("nteract:notebook-cloud:oidc-token", tokenJson);
-        globalThis.localStorage?.setItem("nteract:notebook-cloud:scope", scope);
-      } catch {
-        // Sandboxed output frames do not always have localStorage. Ignore them:
-        // only the first-party notebook shell needs the token cache.
-      }
-    },
-    { origin: url.origin, scope: requestedScope, tokenJson: tokenStorageJson },
-  );
-
-  const page = await context.newPage();
-  const events = {
-    pageErrors: [],
-    badConsole: [],
-    failedRequests: [],
-    blobResponses: [],
-    websockets: [],
-  };
-  page.on("pageerror", (error) => {
-    events.pageErrors.push(String(error.message ?? error));
-  });
-  page.on("console", (message) => {
-    const text = message.text();
-    if (
-      /OutputResolutionError|Failed to fetch blob|flush_comms_doc_sync|cloud sync socket is closed|cannot execute|execute cell request|WebSocket/i.test(
-        text,
-      )
-    ) {
-      events.badConsole.push(`${message.type()}: ${text}`);
-    }
-  });
-  page.on("requestfailed", (request) => {
-    events.failedRequests.push({
-      url: safeDiagnosticUrl(request.url()),
-      failure: request.failure()?.errorText ?? null,
-    });
-  });
-  page.on("response", (response) => {
-    const responseUrl = response.url();
-    if (/\/api\/n\/[^/]+\/blobs\//.test(responseUrl)) {
-      events.blobResponses.push({
-        url: safeDiagnosticUrl(responseUrl),
-        status: response.status(),
-        contentType: response.headers()["content-type"] ?? null,
-      });
-    }
-  });
-  page.on("websocket", (ws) => {
-    const entry = {
-      url: safeDiagnosticUrl(ws.url()),
-      closed: false,
-      errors: [],
-    };
-    events.websockets.push(entry);
-    ws.on("socketerror", (error) => {
-      entry.errors.push(String(error));
-    });
-    ws.on("close", () => {
-      entry.closed = true;
-    });
-  });
-
-  await page.goto(url.href, { waitUntil: "domcontentloaded", timeout: timeoutMs });
-  await page.waitForLoadState("networkidle", { timeout: timeoutMs }).catch(() => {});
-  await waitForExecuteButtons(page, executeButtonIndex, timeoutMs);
-
-  const before = await pageDiagnostics(page);
-  const button = page.locator('[data-testid="execute-button"]').nth(executeButtonIndex);
-  await button.scrollIntoViewIfNeeded();
-  const clickedAria = await button.getAttribute("aria-label");
-  await button.click({ timeout: timeoutMs });
-
-  if (expectedText) {
-    await page.waitForFunction(
-      (text) => (document.body.textContent ?? "").includes(text),
-      expectedText,
-      { timeout: timeoutMs },
-    );
-  } else {
-    await page.waitForTimeout(settleMs);
-  }
-  await page.waitForTimeout(settleMs);
-
-  const after = await pageDiagnostics(page);
-  if (screenshotPath) {
-    await page.screenshot({ path: screenshotPath, fullPage: true });
-  }
-  await browser.close();
-
-  const failedBlobResponses = events.blobResponses.filter((response) => response.status >= 400);
-  const failedBlobImages = after.images.filter(
-    (image) => isBlobBackedImageSource(image.src) && !isLoadedImage(image),
-  );
-  const loadedBlobBackedImages = after.images.filter(
-    (image) => isBlobBackedImageSource(image.src) && isLoadedImage(image),
-  );
-  if (events.pageErrors.length > 0) {
-    throw new Error(`browser page errors:\n${events.pageErrors.join("\n")}`);
-  }
-  if (events.badConsole.length > 0) {
-    throw new Error(`browser console errors:\n${events.badConsole.join("\n")}`);
-  }
-  if (!allowFailedRequests && events.failedRequests.length > 0) {
-    throw new Error(`browser request failures:\n${JSON.stringify(events.failedRequests, null, 2)}`);
-  }
-  if (failedBlobResponses.length > 0) {
-    throw new Error(`blob fetch failures:\n${JSON.stringify(failedBlobResponses, null, 2)}`);
-  }
-  if (requireBlobImage && events.blobResponses.length === 0) {
-    throw new Error("expected at least one authenticated blob fetch");
-  }
-  if (requireBlobImage && loadedBlobBackedImages.length === 0) {
-    throw new Error("expected at least one rendered notebook blob image");
-  }
-  if (failedBlobImages.length > 0) {
-    throw new Error(`blob image render failures:\n${JSON.stringify(failedBlobImages, null, 2)}`);
-  }
-
-  console.log(
-    JSON.stringify(
-      {
-        ok: true,
-        viewerUrl: url.href,
-        token: {
-          path: tokenPath,
-          secondsRemaining: tokenSecondsRemaining,
-          subject: token.claims?.email ?? token.claims?.sub ?? null,
-        },
-        click: {
-          executeButtonIndex,
-          clickedAria,
-          afterAria: after.executeButtons[executeButtonIndex]?.aria ?? null,
-        },
-        checks: [
-          "oidc_token_seeded_in_browser_storage",
-          "execute_button_rendered",
-          "execute_button_clicked",
-          ...(expectedText ? ["expected_text_observed_after_click"] : []),
-          ...(loadedBlobBackedImages.length > 0 ? ["blob_backed_image_loaded_from_img_src"] : []),
-          ...(events.blobResponses.length > 0 ? ["blob_fetches_returned_ok"] : []),
-        ],
-        before,
-        after,
-        events,
+  try {
+    const context = await browser.newContext({ viewport: { width: 1440, height: 1000 } });
+    await context.addInitScript(
+      ({ origin, scope, tokenJson }) => {
+        try {
+          if (globalThis.location?.origin !== origin) return;
+          globalThis.localStorage?.setItem("nteract:notebook-cloud:oidc-token", tokenJson);
+          globalThis.localStorage?.setItem("nteract:notebook-cloud:scope", scope);
+        } catch {
+          // Sandboxed output frames do not always have localStorage. Ignore them:
+          // only the first-party notebook shell needs the token cache.
+        }
       },
-      null,
-      2,
-    ),
-  );
+      { origin: url.origin, scope: requestedScope, tokenJson: tokenStorageJson },
+    );
+
+    const page = await context.newPage();
+    const events = {
+      pageErrors: [],
+      benignPageErrors: [],
+      badConsole: [],
+      failedRequests: [],
+      blobResponses: [],
+      websockets: [],
+    };
+    page.on("pageerror", (error) => {
+      const text = String(error.message ?? error);
+      if (isBenignPageError(text)) {
+        events.benignPageErrors.push(text);
+        return;
+      }
+      events.pageErrors.push(text);
+    });
+    page.on("console", (message) => {
+      const text = message.text();
+      if (
+        /OutputResolutionError|Failed to fetch blob|flush_comms_doc_sync|cloud sync socket is closed|cannot execute|execute cell request|WebSocket/i.test(
+          text,
+        )
+      ) {
+        events.badConsole.push(`${message.type()}: ${text}`);
+      }
+    });
+    page.on("requestfailed", (request) => {
+      events.failedRequests.push({
+        url: safeDiagnosticUrl(request.url()),
+        failure: request.failure()?.errorText ?? null,
+      });
+    });
+    page.on("response", (response) => {
+      const responseUrl = response.url();
+      if (/\/api\/n\/[^/]+\/blobs\//.test(responseUrl)) {
+        events.blobResponses.push({
+          url: safeDiagnosticUrl(responseUrl),
+          status: response.status(),
+          contentType: response.headers()["content-type"] ?? null,
+        });
+      }
+    });
+    page.on("websocket", (ws) => {
+      const entry = {
+        url: safeDiagnosticUrl(ws.url()),
+        closed: false,
+        errors: [],
+      };
+      events.websockets.push(entry);
+      ws.on("socketerror", (error) => {
+        entry.errors.push(String(error));
+      });
+      ws.on("close", () => {
+        entry.closed = true;
+      });
+    });
+
+    await page.goto(url.href, { waitUntil: "domcontentloaded", timeout: timeoutMs });
+    await page.waitForLoadState("networkidle", { timeout: timeoutMs }).catch(() => {});
+    await waitForExecuteButtons(page, executeButtonIndex, timeoutMs);
+
+    const before = await pageDiagnostics(page);
+    const button = page.locator('[data-testid="execute-button"]').nth(executeButtonIndex);
+    await button.scrollIntoViewIfNeeded();
+    const clickedAria = await button.getAttribute("aria-label");
+    const beforeExecutionOrdinal = executionOrdinal(clickedAria);
+    await button.click({ timeout: timeoutMs });
+    await waitForExecutionOrdinalAdvance(
+      page,
+      executeButtonIndex,
+      beforeExecutionOrdinal,
+      timeoutMs,
+    );
+
+    if (expectedText) {
+      await page.waitForFunction(
+        (text) => (document.body.textContent ?? "").includes(text),
+        expectedText,
+        { timeout: timeoutMs },
+      );
+    } else {
+      await page.waitForTimeout(settleMs);
+    }
+    await page.waitForTimeout(settleMs);
+
+    const after = await pageDiagnostics(page);
+    if (screenshotPath) {
+      await page.screenshot({ path: screenshotPath, fullPage: true });
+    }
+
+    const failedBlobResponses = events.blobResponses.filter((response) => response.status >= 400);
+    const failedBlobImages = after.images.filter(
+      (image) => isBlobBackedImageSource(image.src) && !isLoadedImage(image),
+    );
+    const loadedBlobBackedImages = after.images.filter(
+      (image) => isBlobBackedImageSource(image.src) && isLoadedImage(image),
+    );
+    const afterExecutionOrdinal = executionOrdinal(after.executeButtons[executeButtonIndex]?.aria);
+    if (events.pageErrors.length > 0) {
+      throw new Error(`browser page errors:\n${events.pageErrors.join("\n")}`);
+    }
+    if (events.badConsole.length > 0) {
+      throw new Error(`browser console errors:\n${events.badConsole.join("\n")}`);
+    }
+    if (!allowFailedRequests && events.failedRequests.length > 0) {
+      throw new Error(
+        `browser request failures:\n${JSON.stringify(events.failedRequests, null, 2)}`,
+      );
+    }
+    if (!executionOrdinalAdvanced(beforeExecutionOrdinal, afterExecutionOrdinal)) {
+      throw new Error(
+        `execute button did not advance from ${clickedAria ?? "null"} to ${
+          after.executeButtons[executeButtonIndex]?.aria ?? "null"
+        }`,
+      );
+    }
+    if (failedBlobResponses.length > 0) {
+      throw new Error(`blob fetch failures:\n${JSON.stringify(failedBlobResponses, null, 2)}`);
+    }
+    if (requireBlobImage && events.blobResponses.length === 0) {
+      throw new Error("expected at least one authenticated blob fetch");
+    }
+    if (requireBlobImage && loadedBlobBackedImages.length === 0) {
+      throw new Error("expected at least one rendered notebook blob image");
+    }
+    if (failedBlobImages.length > 0) {
+      throw new Error(`blob image render failures:\n${JSON.stringify(failedBlobImages, null, 2)}`);
+    }
+
+    console.log(
+      JSON.stringify(
+        {
+          ok: true,
+          viewerUrl: url.href,
+          token: {
+            path: tokenPath,
+            secondsRemaining: tokenSecondsRemaining,
+            subject: token.claims?.email ?? token.claims?.sub ?? null,
+          },
+          click: {
+            executeButtonIndex,
+            clickedAria,
+            afterAria: after.executeButtons[executeButtonIndex]?.aria ?? null,
+            beforeExecutionOrdinal,
+            afterExecutionOrdinal,
+          },
+          checks: [
+            "oidc_token_seeded_in_browser_storage",
+            "execute_button_rendered",
+            "execute_button_clicked",
+            "execution_count_advanced_after_click",
+            ...(expectedText ? ["expected_text_observed_after_click"] : []),
+            ...(loadedBlobBackedImages.length > 0 ? ["blob_backed_image_loaded_from_img_src"] : []),
+            ...(events.blobResponses.length > 0 ? ["blob_fetches_returned_ok"] : []),
+          ],
+          before,
+          after,
+          events,
+        },
+        null,
+        2,
+      ),
+    );
+  } finally {
+    await browser.close().catch(() => {});
+  }
 }
 
 async function readOidcTokenStorageJson(path) {
@@ -230,6 +259,22 @@ async function waitForExecuteButtons(page, index, timeout) {
     (buttonIndex) =>
       document.querySelectorAll('[data-testid="execute-button"]').length > buttonIndex,
     index,
+    { timeout },
+  );
+}
+
+async function waitForExecutionOrdinalAdvance(page, index, beforeOrdinal, timeout) {
+  await page.waitForFunction(
+    ({ buttonIndex, previous }) => {
+      const aria = document
+        .querySelectorAll('[data-testid="execute-button"]')
+        [buttonIndex]?.getAttribute("aria-label");
+      const match = aria?.match(/last execution\s+(\d+)/i);
+      if (!match) return false;
+      const next = Number(match[1]);
+      return Number.isInteger(next) && (previous === null || next > previous);
+    },
+    { buttonIndex: index, previous: beforeOrdinal },
     { timeout },
   );
 }
@@ -283,6 +328,24 @@ function safeDiagnosticUrl(value) {
   } catch {
     return value.replace(/viewer_session=[^&\s]+/g, "viewer_session=<redacted>");
   }
+}
+
+function isBenignPageError(text) {
+  // Output iframes are intentionally sandboxed away from browser credentials.
+  return /Failed to read the 'localStorage' property from 'Window': The document is sandboxed/i.test(
+    text,
+  );
+}
+
+function executionOrdinal(value) {
+  const match = value?.match(/last execution\s+(\d+)/i);
+  if (!match) return null;
+  const parsed = Number(match[1]);
+  return Number.isInteger(parsed) ? parsed : null;
+}
+
+function executionOrdinalAdvanced(before, after) {
+  return after !== null && (before === null || after > before);
 }
 
 function isNotebookBlobUrl(value) {

--- a/apps/notebook-cloud/scripts/hosted-collab-smoke.mjs
+++ b/apps/notebook-cloud/scripts/hosted-collab-smoke.mjs
@@ -15,6 +15,7 @@ import { summarizeCollabPerformanceTimings } from "./hosted-collab-smoke-perform
 import { performanceBudgetFailures } from "./hosted-render-smoke-performance.mjs";
 import { isRenderCacheApiUrl } from "./hosted-render-smoke-routes.mjs";
 import { firstPositionalArg } from "./cli-args.mjs";
+import { saveSmokeScreenshot, smokeOutputPath } from "./smoke-paths.mjs";
 
 const appDir = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
 const requestedBaseUrl = notebookCloudBaseUrl();
@@ -22,7 +23,7 @@ const devAuthToken = process.env.NOTEBOOK_CLOUD_DEV_TOKEN;
 const providedViewerUrl = firstPositionalArg() ?? process.env.NOTEBOOK_CLOUD_COLLAB_VIEWER_URL;
 const timeoutMs = Number(process.env.NOTEBOOK_CLOUD_SMOKE_TIMEOUT_MS ?? 60_000);
 const convergenceRounds = Number(process.env.NOTEBOOK_CLOUD_COLLAB_ROUNDS ?? 4);
-const screenshotPath = process.env.NOTEBOOK_CLOUD_SMOKE_SCREENSHOT;
+const screenshotPath = smokeOutputPath(process.env.NOTEBOOK_CLOUD_SMOKE_SCREENSHOT);
 const forbidRenderCacheRequests = process.env.NOTEBOOK_CLOUD_FORBID_RENDER_CACHE_REQUESTS !== "0";
 const timingsMs = {};
 const editableMarkdownCellSelector = '[data-slot="cell-container"][data-cell-type="markdown"]';
@@ -240,7 +241,7 @@ ${bobMarker}
     failures.push(...performanceBudgetFailures(performanceDiagnostics, performanceBudgets));
 
     if (screenshotPath) {
-      await alice.page.screenshot({ path: screenshotPath, fullPage: true });
+      await saveSmokeScreenshot(alice.page, screenshotPath);
       checks.push("screenshot_saved");
     }
 

--- a/apps/notebook-cloud/scripts/hosted-collab-smoke.mjs
+++ b/apps/notebook-cloud/scripts/hosted-collab-smoke.mjs
@@ -14,11 +14,12 @@ import {
 import { summarizeCollabPerformanceTimings } from "./hosted-collab-smoke-performance.mjs";
 import { performanceBudgetFailures } from "./hosted-render-smoke-performance.mjs";
 import { isRenderCacheApiUrl } from "./hosted-render-smoke-routes.mjs";
+import { firstPositionalArg } from "./cli-args.mjs";
 
 const appDir = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
 const requestedBaseUrl = notebookCloudBaseUrl();
 const devAuthToken = process.env.NOTEBOOK_CLOUD_DEV_TOKEN;
-const providedViewerUrl = process.argv[2] ?? process.env.NOTEBOOK_CLOUD_COLLAB_VIEWER_URL;
+const providedViewerUrl = firstPositionalArg() ?? process.env.NOTEBOOK_CLOUD_COLLAB_VIEWER_URL;
 const timeoutMs = Number(process.env.NOTEBOOK_CLOUD_SMOKE_TIMEOUT_MS ?? 60_000);
 const convergenceRounds = Number(process.env.NOTEBOOK_CLOUD_COLLAB_ROUNDS ?? 4);
 const screenshotPath = process.env.NOTEBOOK_CLOUD_SMOKE_SCREENSHOT;

--- a/apps/notebook-cloud/scripts/hosted-live-room-matrix-smoke.mjs
+++ b/apps/notebook-cloud/scripts/hosted-live-room-matrix-smoke.mjs
@@ -1,0 +1,231 @@
+import { spawn } from "node:child_process";
+import { mkdir, readFile } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+import {
+  entryLabel,
+  parseLiveRoomMatrixEntries,
+  safeScreenshotName,
+  smokeEnvForMatrixEntry,
+} from "./hosted-live-room-matrix.mjs";
+
+const DEFAULT_BASE_URL = "https://preview.runt.run";
+const scriptPath = fileURLToPath(new URL("./hosted-live-room-smoke.mjs", import.meta.url));
+const appDir = path.dirname(path.dirname(scriptPath));
+const baseUrl =
+  process.env.NOTEBOOK_CLOUD_LIVE_ROOM_MATRIX_BASE_URL ??
+  process.env.NTERACT_CLOUD_URL ??
+  process.env.NOTEBOOK_CLOUD_URL ??
+  DEFAULT_BASE_URL;
+const explicitMatrix = process.env.NOTEBOOK_CLOUD_LIVE_ROOM_MATRIX_URLS;
+const limit = parsePositiveInteger(
+  process.env.NOTEBOOK_CLOUD_LIVE_ROOM_MATRIX_LIMIT,
+  "NOTEBOOK_CLOUD_LIVE_ROOM_MATRIX_LIMIT",
+  5,
+);
+const concurrency = parsePositiveInteger(
+  process.env.NOTEBOOK_CLOUD_LIVE_ROOM_MATRIX_CONCURRENCY,
+  "NOTEBOOK_CLOUD_LIVE_ROOM_MATRIX_CONCURRENCY",
+  2,
+);
+const tokenPath =
+  process.env.NTERACT_PREVIEW_OIDC_TOKEN_PATH ??
+  process.env.NOTEBOOK_CLOUD_OIDC_TOKEN_PATH ??
+  `${os.homedir()}/token.preview.json`;
+const screenshotDir = process.env.NOTEBOOK_CLOUD_LIVE_ROOM_MATRIX_SCREENSHOT_DIR;
+
+main().catch((error) => {
+  console.error(error instanceof Error ? error.message : String(error));
+  process.exitCode = 1;
+});
+
+async function main() {
+  const entries =
+    explicitMatrix === undefined
+      ? await listNotebookEntries({ baseUrl, tokenPath, limit })
+      : parseLiveRoomMatrixEntries(explicitMatrix).slice(0, limit);
+
+  if (entries.length === 0) {
+    throw new Error("hosted live room matrix smoke found no notebooks to check");
+  }
+  if (screenshotDir) {
+    await mkdir(screenshotDir, { recursive: true });
+  }
+
+  const startedAt = Date.now();
+  const results = await runWithConcurrency(entries, concurrency, runEntry);
+  const failures = results.filter((result) => !result.ok);
+  const summary = {
+    ok: failures.length === 0,
+    baseUrl,
+    source: explicitMatrix === undefined ? "catalog" : "env",
+    limit,
+    concurrency,
+    checked: results.length,
+    failed: failures.length,
+    durationMs: Date.now() - startedAt,
+    results,
+  };
+
+  if (failures.length > 0) {
+    throw new Error(`hosted live room matrix smoke failed:\n${JSON.stringify(summary, null, 2)}`);
+  }
+  console.log(JSON.stringify(summary, null, 2));
+}
+
+async function listNotebookEntries({ baseUrl, tokenPath, limit }) {
+  const tokenStorageJson = await readFile(tokenPath, "utf8");
+  const token = JSON.parse(tokenStorageJson);
+  if (typeof token.accessToken !== "string" || token.accessToken.length === 0) {
+    throw new Error(`${tokenPath} is missing accessToken`);
+  }
+  const tokenSecondsRemaining = Number(token.expiresAt) - Math.floor(Date.now() / 1000);
+  if (!Number.isFinite(tokenSecondsRemaining) || tokenSecondsRemaining <= 60) {
+    throw new Error(`${tokenPath} is expired or near expiry; refresh it before running the smoke`);
+  }
+
+  const url = new URL("/api/n", baseUrl);
+  url.searchParams.set("limit", String(limit));
+  const response = await fetch(url, {
+    headers: { Authorization: `Bearer ${token.accessToken}` },
+  });
+  if (!response.ok) {
+    throw new Error(`/api/n returned ${response.status} while listing notebooks for matrix smoke`);
+  }
+
+  const body = await response.json();
+  if (body?.ok !== true || !Array.isArray(body.notebooks)) {
+    throw new Error("/api/n response shape was invalid for matrix smoke");
+  }
+
+  return body.notebooks
+    .filter(
+      (notebook) => typeof notebook?.viewer_url === "string" && notebook.viewer_url.length > 0,
+    )
+    .map((notebook) => ({
+      url: notebook.viewer_url,
+      notebookId: notebook.notebook_id,
+      title: notebook.title,
+      scope: notebook.scope,
+      updatedAt: notebook.updated_at,
+      latestRevisionId: notebook.latest_revision_id,
+    }));
+}
+
+async function runEntry(entry, index) {
+  const label = entryLabel(entry, index);
+  const startedAt = Date.now();
+  const env = smokeEnvForMatrixEntry(entry, process.env);
+  if (screenshotDir) {
+    env.NOTEBOOK_CLOUD_LIVE_ROOM_SCREENSHOT = path.join(
+      screenshotDir,
+      safeScreenshotName(label, index),
+    );
+  }
+
+  const child = spawn(process.execPath, [scriptPath, entry.url], {
+    cwd: appDir,
+    env,
+    stdio: ["ignore", "pipe", "pipe"],
+  });
+
+  let stdout = "";
+  let stderr = "";
+  child.stdout.setEncoding("utf8");
+  child.stderr.setEncoding("utf8");
+  child.stdout.on("data", (chunk) => {
+    stdout += chunk;
+  });
+  child.stderr.on("data", (chunk) => {
+    stderr += chunk;
+  });
+
+  const exitCode = await new Promise((resolve) => {
+    child.on("error", (error) => {
+      stderr += `${error.stack ?? error.message}\n`;
+      resolve(1);
+    });
+    child.on("close", (code) => {
+      resolve(code ?? 1);
+    });
+  });
+  const durationMs = Date.now() - startedAt;
+
+  if (exitCode !== 0) {
+    return {
+      ok: false,
+      label,
+      url: entry.url,
+      durationMs,
+      exitCode,
+      stderr: stderr.trim(),
+      stdout: trimLongText(stdout.trim()),
+    };
+  }
+
+  let result;
+  try {
+    result = JSON.parse(stdout.trim());
+  } catch (error) {
+    return {
+      ok: false,
+      label,
+      url: entry.url,
+      durationMs,
+      exitCode,
+      stderr: stderr.trim(),
+      stdout: trimLongText(stdout.trim()),
+      error: `unable to parse hosted live room smoke JSON: ${
+        error instanceof Error ? error.message : String(error)
+      }`,
+    };
+  }
+
+  return {
+    ok: true,
+    label,
+    url: entry.url,
+    durationMs,
+    cellCount: result.diagnostics?.cellCount ?? null,
+    iframeCount: result.diagnostics?.iframeCount ?? null,
+    visibleIframeCount: result.diagnostics?.visibleIframeCount ?? null,
+    imageCount: result.diagnostics?.imageCount ?? null,
+    blobResponseCount: result.events?.blobResponses?.length ?? null,
+    websocketCount: result.events?.websockets?.length ?? null,
+    activeWebsocketCount: Array.isArray(result.events?.websockets)
+      ? result.events.websockets.filter((socket) => !socket.closed).length
+      : null,
+    failures: result.failures ?? [],
+  };
+}
+
+async function runWithConcurrency(items, maxConcurrent, worker) {
+  const results = Array.from({ length: items.length });
+  let nextIndex = 0;
+
+  async function runNext() {
+    while (nextIndex < items.length) {
+      const index = nextIndex;
+      nextIndex += 1;
+      results[index] = await worker(items[index], index);
+    }
+  }
+
+  await Promise.all(Array.from({ length: Math.min(maxConcurrent, items.length) }, () => runNext()));
+  return results;
+}
+
+function parsePositiveInteger(value, name, fallback) {
+  if (value === undefined || value === "") return fallback;
+  const parsed = Number(value);
+  if (!Number.isInteger(parsed) || parsed <= 0) {
+    throw new Error(`${name} must be a positive integer`);
+  }
+  return parsed;
+}
+
+function trimLongText(value) {
+  return value.length > 6_000 ? `${value.slice(0, 6_000)}...` : value;
+}

--- a/apps/notebook-cloud/scripts/hosted-live-room-matrix.mjs
+++ b/apps/notebook-cloud/scripts/hosted-live-room-matrix.mjs
@@ -1,0 +1,149 @@
+export function parseLiveRoomMatrixEntries(value) {
+  const trimmed = (value ?? "").trim();
+  if (!trimmed) {
+    return [];
+  }
+
+  if (trimmed.startsWith("[")) {
+    const parsed = JSON.parse(trimmed);
+    if (!Array.isArray(parsed)) {
+      throw new Error("NOTEBOOK_CLOUD_LIVE_ROOM_MATRIX_URLS JSON must be an array");
+    }
+    return parsed.map((entry, index) => normalizeMatrixEntry(entry, index));
+  }
+
+  return trimmed
+    .split(/\n|\|/)
+    .map((entry) => entry.trim())
+    .filter(Boolean)
+    .map((url, index) => normalizeMatrixEntry(url, index));
+}
+
+export function normalizeMatrixEntry(entry, index = 0) {
+  if (typeof entry === "string") {
+    assertUrl(entry, `matrix entry ${index + 1}`);
+    return { url: entry };
+  }
+
+  if (!isRecord(entry)) {
+    throw new Error(`matrix entry ${index + 1} must be a URL string or object`);
+  }
+
+  if (typeof entry.url !== "string" || entry.url.length === 0) {
+    throw new Error(`matrix entry ${index + 1} is missing url`);
+  }
+  assertUrl(entry.url, `matrix entry ${index + 1}`);
+
+  return {
+    ...entry,
+    url: entry.url,
+  };
+}
+
+export function smokeEnvForMatrixEntry(entry, baseEnv = process.env) {
+  const env = {
+    ...baseEnv,
+    NOTEBOOK_CLOUD_LIVE_ROOM_EXPECTED_TEXT: "",
+    NOTEBOOK_CLOUD_LIVE_ROOM_EXPECTED_PAGE_TEXTS: "",
+    NOTEBOOK_CLOUD_LIVE_ROOM_EXPECTED_FRAME_TEXTS: "",
+    NOTEBOOK_CLOUD_LIVE_ROOM_MIN_CELLS: baseEnv.NOTEBOOK_CLOUD_LIVE_ROOM_MATRIX_MIN_CELLS ?? "0",
+    NOTEBOOK_CLOUD_LIVE_ROOM_MIN_VISIBLE_IFRAMES:
+      baseEnv.NOTEBOOK_CLOUD_LIVE_ROOM_MATRIX_MIN_VISIBLE_IFRAMES ?? "0",
+    NOTEBOOK_CLOUD_LIVE_ROOM_MIN_IMAGES: baseEnv.NOTEBOOK_CLOUD_LIVE_ROOM_MATRIX_MIN_IMAGES ?? "0",
+    NOTEBOOK_CLOUD_LIVE_ROOM_REQUIRE_BLOB_FETCH:
+      baseEnv.NOTEBOOK_CLOUD_LIVE_ROOM_MATRIX_REQUIRE_BLOB_FETCH ?? "0",
+    NOTEBOOK_CLOUD_LIVE_ROOM_REQUIRE_IMAGES_LOADED:
+      baseEnv.NOTEBOOK_CLOUD_LIVE_ROOM_MATRIX_REQUIRE_IMAGES_LOADED ?? "0",
+  };
+
+  setOptionalString(env, "NOTEBOOK_CLOUD_LIVE_ROOM_SCOPE", entry.scope);
+  setOptionalString(env, "NOTEBOOK_CLOUD_LIVE_ROOM_EXPECTED_TEXT", entry.expectedText);
+  setOptionalTexts(env, "NOTEBOOK_CLOUD_LIVE_ROOM_EXPECTED_PAGE_TEXTS", entry.expectedPageTexts);
+  setOptionalTexts(env, "NOTEBOOK_CLOUD_LIVE_ROOM_EXPECTED_FRAME_TEXTS", entry.expectedFrameTexts);
+  setOptionalInteger(env, "NOTEBOOK_CLOUD_LIVE_ROOM_MIN_CELLS", entry.minCells);
+  setOptionalInteger(env, "NOTEBOOK_CLOUD_LIVE_ROOM_MIN_VISIBLE_IFRAMES", entry.minVisibleIframes);
+  setOptionalInteger(env, "NOTEBOOK_CLOUD_LIVE_ROOM_MIN_IMAGES", entry.minImages);
+  setOptionalBoolean(env, "NOTEBOOK_CLOUD_LIVE_ROOM_REQUIRE_RESOLVED", entry.requireResolved);
+  setOptionalBoolean(env, "NOTEBOOK_CLOUD_LIVE_ROOM_REQUIRE_OPEN_SOCKET", entry.requireOpenSocket);
+  setOptionalBoolean(env, "NOTEBOOK_CLOUD_LIVE_ROOM_REQUIRE_BLOB_FETCH", entry.requireBlobFetch);
+  setOptionalBoolean(
+    env,
+    "NOTEBOOK_CLOUD_LIVE_ROOM_REQUIRE_IMAGES_LOADED",
+    entry.requireImagesLoaded,
+  );
+
+  return env;
+}
+
+export function entryLabel(entry, index = 0) {
+  if (typeof entry.label === "string" && entry.label.trim()) {
+    return entry.label.trim();
+  }
+  if (typeof entry.notebookId === "string" && entry.notebookId.trim()) {
+    return entry.notebookId.trim();
+  }
+  try {
+    const url = new URL(entry.url);
+    const parts = url.pathname.split("/").filter(Boolean);
+    return parts[1] ?? `notebook-${index + 1}`;
+  } catch {
+    return `notebook-${index + 1}`;
+  }
+}
+
+export function safeScreenshotName(label, index = 0) {
+  const compact = label
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/^-+|-+$/g, "")
+    .slice(0, 80);
+  return `${String(index + 1).padStart(2, "0")}-${compact || "notebook"}.png`;
+}
+
+function setOptionalString(env, name, value) {
+  if (typeof value === "string") {
+    env[name] = value;
+  }
+}
+
+function setOptionalTexts(env, name, value) {
+  if (Array.isArray(value) && value.every((entry) => typeof entry === "string")) {
+    env[name] = JSON.stringify(value);
+    return;
+  }
+  if (typeof value === "string") {
+    env[name] = value;
+  }
+}
+
+function setOptionalInteger(env, name, value) {
+  if (value === undefined) {
+    return;
+  }
+  if (!Number.isInteger(value) || value < 0) {
+    throw new Error(`${name} override must be a non-negative integer`);
+  }
+  env[name] = String(value);
+}
+
+function setOptionalBoolean(env, name, value) {
+  if (value === undefined) {
+    return;
+  }
+  if (typeof value !== "boolean") {
+    throw new Error(`${name} override must be a boolean`);
+  }
+  env[name] = value ? "1" : "0";
+}
+
+function assertUrl(value, label) {
+  try {
+    new URL(value);
+  } catch {
+    throw new Error(`${label} must be an absolute URL`);
+  }
+}
+
+function isRecord(value) {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}

--- a/apps/notebook-cloud/scripts/hosted-live-room-smoke.mjs
+++ b/apps/notebook-cloud/scripts/hosted-live-room-smoke.mjs
@@ -2,10 +2,11 @@ import { readFile } from "node:fs/promises";
 import os from "node:os";
 
 import { chromium } from "@playwright/test";
+import { firstPositionalArg } from "./cli-args.mjs";
 
 const DEFAULT_URL = "https://preview.runt.run/n/topic-viz/topic-viz";
 const viewerUrl =
-  process.argv[2] ??
+  firstPositionalArg() ??
   process.env.NOTEBOOK_CLOUD_LIVE_ROOM_VIEWER_URL ??
   process.env.NOTEBOOK_CLOUD_HOSTED_URL ??
   DEFAULT_URL;

--- a/apps/notebook-cloud/scripts/hosted-live-room-smoke.mjs
+++ b/apps/notebook-cloud/scripts/hosted-live-room-smoke.mjs
@@ -31,9 +31,25 @@ const minCells = parseNonNegativeInteger(
 );
 const expectedText =
   process.env.NOTEBOOK_CLOUD_LIVE_ROOM_EXPECTED_TEXT ?? "import plotly.graph_objects as go";
+const expectedPageTexts = parseExpectedTexts(
+  "NOTEBOOK_CLOUD_LIVE_ROOM_EXPECTED_PAGE_TEXTS",
+  expectedText ? [expectedText] : [],
+);
+const expectedFrameTexts = parseExpectedTexts("NOTEBOOK_CLOUD_LIVE_ROOM_EXPECTED_FRAME_TEXTS", []);
+const minVisibleIframes = parseNonNegativeInteger(
+  process.env.NOTEBOOK_CLOUD_LIVE_ROOM_MIN_VISIBLE_IFRAMES,
+  "NOTEBOOK_CLOUD_LIVE_ROOM_MIN_VISIBLE_IFRAMES",
+  0,
+);
+const minImages = parseNonNegativeInteger(
+  process.env.NOTEBOOK_CLOUD_LIVE_ROOM_MIN_IMAGES,
+  "NOTEBOOK_CLOUD_LIVE_ROOM_MIN_IMAGES",
+  0,
+);
 const requireResolved = process.env.NOTEBOOK_CLOUD_LIVE_ROOM_REQUIRE_RESOLVED !== "0";
 const requireOpenSocket = process.env.NOTEBOOK_CLOUD_LIVE_ROOM_REQUIRE_OPEN_SOCKET !== "0";
 const requireBlobFetch = process.env.NOTEBOOK_CLOUD_LIVE_ROOM_REQUIRE_BLOB_FETCH === "1";
+const requireImagesLoaded = process.env.NOTEBOOK_CLOUD_LIVE_ROOM_REQUIRE_IMAGES_LOADED === "1";
 const screenshotPath = process.env.NOTEBOOK_CLOUD_LIVE_ROOM_SCREENSHOT;
 
 main().catch((error) => {
@@ -55,192 +71,222 @@ async function main() {
     headless: process.env.NOTEBOOK_CLOUD_HEADED !== "1",
     timeout: timeoutMs,
   });
-  const context = await browser.newContext({ viewport: { width: 1440, height: 1200 } });
-  await context.addInitScript(
-    ({ origin, scope, tokenJson }) => {
-      try {
-        if (globalThis.location?.origin !== origin) return;
-        globalThis.localStorage?.setItem("nteract:notebook-cloud:oidc-token", tokenJson);
-        globalThis.localStorage?.setItem("nteract:notebook-cloud:scope", scope);
-      } catch {
-        // Sandboxed output frames must deny localStorage. Only the first-party
-        // notebook shell needs the seeded browser token.
+
+  try {
+    const context = await browser.newContext({ viewport: { width: 1440, height: 1200 } });
+    await context.addInitScript(
+      ({ origin, scope, tokenJson }) => {
+        try {
+          if (globalThis.location?.origin !== origin) return;
+          globalThis.localStorage?.setItem("nteract:notebook-cloud:oidc-token", tokenJson);
+          globalThis.localStorage?.setItem("nteract:notebook-cloud:scope", scope);
+        } catch {
+          // Sandboxed output frames must deny localStorage. Only the first-party
+          // notebook shell needs the seeded browser token.
+        }
+      },
+      { origin: url.origin, scope: requestedScope, tokenJson: tokenStorageJson },
+    );
+
+    const page = await context.newPage();
+    const events = {
+      pageErrors: [],
+      benignPageErrors: [],
+      badConsole: [],
+      failedRequests: [],
+      blobResponses: [],
+      websockets: [],
+    };
+
+    page.on("pageerror", (error) => {
+      const text = String(error.message ?? error);
+      if (isBenignPageError(text)) {
+        events.benignPageErrors.push(text);
+        return;
       }
-    },
-    { origin: url.origin, scope: requestedScope, tokenJson: tokenStorageJson },
-  );
-
-  const page = await context.newPage();
-  const events = {
-    pageErrors: [],
-    benignPageErrors: [],
-    badConsole: [],
-    failedRequests: [],
-    blobResponses: [],
-    websockets: [],
-  };
-
-  page.on("pageerror", (error) => {
-    const text = String(error.message ?? error);
-    if (isBenignPageError(text)) {
-      events.benignPageErrors.push(text);
-      return;
-    }
-    events.pageErrors.push(text);
-  });
-  page.on("console", (message) => {
-    const text = message.text();
-    if (isFatalConsoleMessage(text)) {
-      events.badConsole.push(`${message.type()}: ${text}`);
-    }
-  });
-  page.on("requestfailed", (request) => {
-    if (!isRelevantRequestUrl(request.url())) {
-      return;
-    }
-    events.failedRequests.push({
-      url: safeDiagnosticUrl(request.url()),
-      failure: request.failure()?.errorText ?? null,
+      events.pageErrors.push(text);
     });
-  });
-  page.on("response", (response) => {
-    const responseUrl = response.url();
-    if (/\/api\/n\/[^/]+\/blobs\//.test(responseUrl)) {
-      events.blobResponses.push({
-        url: safeDiagnosticUrl(responseUrl),
-        status: response.status(),
-        contentType: response.headers()["content-type"] ?? null,
+    page.on("console", (message) => {
+      const text = message.text();
+      if (isFatalConsoleMessage(text)) {
+        events.badConsole.push(`${message.type()}: ${text}`);
+      }
+    });
+    page.on("requestfailed", (request) => {
+      if (!isRelevantRequestUrl(request.url())) {
+        return;
+      }
+      events.failedRequests.push({
+        url: safeDiagnosticUrl(request.url()),
+        failure: request.failure()?.errorText ?? null,
+      });
+    });
+    page.on("response", (response) => {
+      const responseUrl = response.url();
+      if (/\/api\/n\/[^/]+\/blobs\//.test(responseUrl)) {
+        events.blobResponses.push({
+          url: safeDiagnosticUrl(responseUrl),
+          status: response.status(),
+          contentType: response.headers()["content-type"] ?? null,
+        });
+      }
+    });
+    page.on("websocket", (ws) => {
+      if (!isRoomSyncWebSocket(ws.url())) {
+        return;
+      }
+      const entry = {
+        url: safeDiagnosticUrl(ws.url()),
+        sent: 0,
+        received: 0,
+        closed: false,
+        errors: [],
+      };
+      events.websockets.push(entry);
+      ws.on("framesent", () => {
+        entry.sent += 1;
+      });
+      ws.on("framereceived", () => {
+        entry.received += 1;
+      });
+      ws.on("socketerror", (error) => {
+        entry.errors.push(String(error));
+      });
+      ws.on("close", () => {
+        entry.closed = true;
+      });
+    });
+
+    await page.goto(url.href, { waitUntil: "domcontentloaded", timeout: timeoutMs });
+    if (expectedPageTexts.length > 0) {
+      await waitForPageTexts(page, expectedPageTexts);
+    }
+    if (minCells > 0) {
+      await page.waitForFunction(
+        (expected) => document.querySelectorAll("[data-cell-id]").length >= expected,
+        minCells,
+        { timeout: timeoutMs },
+      );
+    }
+    if (requireResolved) {
+      await page.waitForFunction(
+        () => !/Loading notebook|resolving output payloads/i.test(document.body.textContent ?? ""),
+        undefined,
+        { timeout: timeoutMs },
+      );
+    }
+    const frameTextMatches =
+      expectedFrameTexts.length > 0 ? await waitForFrameTexts(page, expectedFrameTexts) : {};
+    await page.waitForTimeout(settleMs);
+
+    const diagnostics = await pageDiagnostics(page);
+    if (screenshotPath) {
+      await page.screenshot({ path: screenshotPath, fullPage: true });
+    }
+
+    const failures = [];
+    const failedBlobResponses = events.blobResponses.filter((response) => response.status >= 400);
+    const activeSockets = events.websockets.filter((socket) => !socket.closed);
+    const erroredSockets = events.websockets.filter((socket) => socket.errors.length > 0);
+    if (events.pageErrors.length > 0) {
+      failures.push({ kind: "page-errors", errors: events.pageErrors });
+    }
+    if (events.badConsole.length > 0) {
+      failures.push({ kind: "console-errors", errors: events.badConsole });
+    }
+    if (events.failedRequests.length > 0) {
+      failures.push({ kind: "request-failures", requests: events.failedRequests });
+    }
+    if (failedBlobResponses.length > 0) {
+      failures.push({ kind: "blob-failures", responses: failedBlobResponses });
+    }
+    if (erroredSockets.length > 0) {
+      failures.push({ kind: "websocket-errors", websockets: erroredSockets });
+    }
+    if (events.websockets.length === 0) {
+      failures.push({ kind: "websocket-missing", text: "no room sync WebSocket was observed" });
+    }
+    if (requireOpenSocket && activeSockets.length === 0) {
+      failures.push({
+        kind: "websocket-closed",
+        text: "no room sync WebSocket remained open after notebook materialization",
+        websockets: events.websockets,
       });
     }
-  });
-  page.on("websocket", (ws) => {
-    if (!isRoomSyncWebSocket(ws.url())) {
-      return;
+    if (requireBlobFetch && events.blobResponses.length === 0) {
+      failures.push({ kind: "blob-missing", text: "no notebook blob responses were observed" });
     }
-    const entry = {
-      url: safeDiagnosticUrl(ws.url()),
-      sent: 0,
-      received: 0,
-      closed: false,
-      errors: [],
+    if (diagnostics.cellCount < minCells) {
+      failures.push({
+        kind: "cell-count",
+        expected: minCells,
+        actual: diagnostics.cellCount,
+      });
+    }
+    if (diagnostics.visibleIframeCount < minVisibleIframes) {
+      failures.push({
+        kind: "visible-iframe-count",
+        expected: minVisibleIframes,
+        actual: diagnostics.visibleIframeCount,
+        iframes: diagnostics.iframes,
+      });
+    }
+    if (diagnostics.imageCount < minImages) {
+      failures.push({
+        kind: "image-count",
+        expected: minImages,
+        actual: diagnostics.imageCount,
+        images: diagnostics.images,
+      });
+    }
+    if (requireImagesLoaded && diagnostics.unloadedImages.length > 0) {
+      failures.push({
+        kind: "image-load",
+        text: "one or more rendered images did not finish loading",
+        images: diagnostics.unloadedImages,
+      });
+    }
+    if (requireResolved && diagnostics.loading) {
+      failures.push({
+        kind: "loading-state",
+        text: "notebook was still loading or resolving output payloads after the timeout",
+      });
+    }
+
+    const result = {
+      ok: failures.length === 0,
+      viewerUrl: url.href,
+      token: {
+        path: tokenPath,
+        secondsRemaining: tokenSecondsRemaining,
+        subject: token.claims?.email ?? token.claims?.sub ?? null,
+      },
+      checks: {
+        requestedScope,
+        expectedPageTexts,
+        expectedFrameTexts,
+        minCells,
+        minVisibleIframes,
+        minImages,
+        requireResolved,
+        requireOpenSocket,
+        requireBlobFetch,
+        requireImagesLoaded,
+        screenshotPath: screenshotPath ?? null,
+      },
+      diagnostics,
+      frameTextMatches,
+      events,
+      failures,
     };
-    events.websockets.push(entry);
-    ws.on("framesent", () => {
-      entry.sent += 1;
-    });
-    ws.on("framereceived", () => {
-      entry.received += 1;
-    });
-    ws.on("socketerror", (error) => {
-      entry.errors.push(String(error));
-    });
-    ws.on("close", () => {
-      entry.closed = true;
-    });
-  });
 
-  await page.goto(url.href, { waitUntil: "domcontentloaded", timeout: timeoutMs });
-  if (expectedText) {
-    await page.waitForFunction(
-      (text) => (document.body.textContent ?? "").includes(text),
-      expectedText,
-      { timeout: timeoutMs },
-    );
+    if (failures.length > 0) {
+      throw new Error(`hosted live room smoke failed:\n${JSON.stringify(result, null, 2)}`);
+    }
+    console.log(JSON.stringify(result, null, 2));
+  } finally {
+    await browser.close().catch(() => {});
   }
-  if (minCells > 0) {
-    await page.waitForFunction(
-      (expected) => document.querySelectorAll("[data-cell-id]").length >= expected,
-      minCells,
-      { timeout: timeoutMs },
-    );
-  }
-  if (requireResolved) {
-    await page.waitForFunction(
-      () => !/Loading notebook|resolving output payloads/i.test(document.body.textContent ?? ""),
-      undefined,
-      { timeout: timeoutMs },
-    );
-  }
-  await page.waitForTimeout(settleMs);
-
-  const diagnostics = await pageDiagnostics(page);
-  if (screenshotPath) {
-    await page.screenshot({ path: screenshotPath, fullPage: true });
-  }
-  await browser.close();
-
-  const failures = [];
-  const failedBlobResponses = events.blobResponses.filter((response) => response.status >= 400);
-  const activeSockets = events.websockets.filter((socket) => !socket.closed);
-  const erroredSockets = events.websockets.filter((socket) => socket.errors.length > 0);
-  if (events.pageErrors.length > 0) {
-    failures.push({ kind: "page-errors", errors: events.pageErrors });
-  }
-  if (events.badConsole.length > 0) {
-    failures.push({ kind: "console-errors", errors: events.badConsole });
-  }
-  if (events.failedRequests.length > 0) {
-    failures.push({ kind: "request-failures", requests: events.failedRequests });
-  }
-  if (failedBlobResponses.length > 0) {
-    failures.push({ kind: "blob-failures", responses: failedBlobResponses });
-  }
-  if (erroredSockets.length > 0) {
-    failures.push({ kind: "websocket-errors", websockets: erroredSockets });
-  }
-  if (events.websockets.length === 0) {
-    failures.push({ kind: "websocket-missing", text: "no room sync WebSocket was observed" });
-  }
-  if (requireOpenSocket && activeSockets.length === 0) {
-    failures.push({
-      kind: "websocket-closed",
-      text: "no room sync WebSocket remained open after notebook materialization",
-      websockets: events.websockets,
-    });
-  }
-  if (requireBlobFetch && events.blobResponses.length === 0) {
-    failures.push({ kind: "blob-missing", text: "no notebook blob responses were observed" });
-  }
-  if (diagnostics.cellCount < minCells) {
-    failures.push({
-      kind: "cell-count",
-      expected: minCells,
-      actual: diagnostics.cellCount,
-    });
-  }
-  if (requireResolved && diagnostics.loading) {
-    failures.push({
-      kind: "loading-state",
-      text: "notebook was still loading or resolving output payloads after the timeout",
-    });
-  }
-
-  const result = {
-    ok: failures.length === 0,
-    viewerUrl: url.href,
-    token: {
-      path: tokenPath,
-      secondsRemaining: tokenSecondsRemaining,
-      subject: token.claims?.email ?? token.claims?.sub ?? null,
-    },
-    checks: {
-      requestedScope,
-      expectedText: expectedText || null,
-      minCells,
-      requireResolved,
-      requireOpenSocket,
-      requireBlobFetch,
-      screenshotPath: screenshotPath ?? null,
-    },
-    diagnostics,
-    events,
-    failures,
-  };
-
-  if (failures.length > 0) {
-    throw new Error(`hosted live room smoke failed:\n${JSON.stringify(result, null, 2)}`);
-  }
-  console.log(JSON.stringify(result, null, 2));
 }
 
 async function readOidcTokenStorageJson(path) {
@@ -274,18 +320,33 @@ async function pageDiagnostics(page) {
         height: iframe.clientHeight,
       }))
       .slice(0, 30);
-    const images = Array.from(document.querySelectorAll("img"))
+    const allImages = Array.from(document.querySelectorAll("img")).map((image) => ({
+      src: compactUrl(image.currentSrc || image.src),
+      complete: image.complete,
+      naturalWidth: image.naturalWidth,
+      naturalHeight: image.naturalHeight,
+    }));
+    const emptyImageCount = allImages.filter((image) => !image.src).length;
+    const images = allImages
+      .filter((image) => image.src)
       .map((image) => ({
-        src: compactUrl(image.currentSrc || image.src),
-        complete: image.complete,
-        naturalWidth: image.naturalWidth,
-        naturalHeight: image.naturalHeight,
+        ...image,
       }))
       .slice(0, 30);
+    const visibleIframeCount = iframes.filter(
+      (iframe) => iframe.width > 0 && iframe.height > 0,
+    ).length;
+    const unloadedImages = images.filter(
+      (image) => !image.complete || image.naturalWidth <= 0 || image.naturalHeight <= 0,
+    );
     return {
       cellCount,
       iframeCount: iframes.length,
+      visibleIframeCount,
+      zeroSizedIframeCount: iframes.length - visibleIframeCount,
       imageCount: images.length,
+      emptyImageCount,
+      unloadedImages,
       loading: /Loading notebook|resolving output payloads/i.test(text),
       textSample: text.slice(0, 2_000),
       iframes,
@@ -365,4 +426,82 @@ function parseNonNegativeInteger(value, name, fallback) {
     throw new Error(`${name} must be a non-negative integer`);
   }
   return parsed;
+}
+
+function parseExpectedTexts(envName, fallback) {
+  const value = process.env[envName];
+  if (value === undefined) {
+    return fallback;
+  }
+  const trimmed = value.trim();
+  if (!trimmed) {
+    return [];
+  }
+  if (trimmed.startsWith("[")) {
+    const parsed = JSON.parse(trimmed);
+    if (!Array.isArray(parsed) || !parsed.every((entry) => typeof entry === "string")) {
+      throw new Error(`${envName} JSON must be an array of strings`);
+    }
+    return parsed;
+  }
+  return trimmed
+    .split("|")
+    .map((entry) => entry.trim())
+    .filter(Boolean);
+}
+
+async function waitForPageTexts(page, expectedTexts) {
+  const deadline = Date.now() + timeoutMs;
+  const matches = new Map(expectedTexts.map((text) => [text, false]));
+
+  while (Date.now() < deadline) {
+    const text = await page
+      .locator("body")
+      .innerText({ timeout: 1_000 })
+      .catch(() => "");
+    for (const expectedText of expectedTexts) {
+      if (text.includes(expectedText)) {
+        matches.set(expectedText, true);
+      }
+    }
+
+    if (Array.from(matches.values()).every(Boolean)) {
+      return Object.fromEntries(matches);
+    }
+    await page.waitForTimeout(250);
+  }
+
+  const missing = Array.from(matches.entries())
+    .filter(([, found]) => !found)
+    .map(([text]) => text);
+  throw new Error(`Timed out waiting for live room page text: ${missing.join(", ")}`);
+}
+
+async function waitForFrameTexts(page, expectedTexts) {
+  const deadline = Date.now() + timeoutMs;
+  const matches = new Map(expectedTexts.map((text) => [text, false]));
+
+  while (Date.now() < deadline) {
+    for (const frame of page.frames().filter((frame) => frame !== page.mainFrame())) {
+      const text = await frame
+        .locator("body")
+        .innerText({ timeout: 1_000 })
+        .catch(() => "");
+      for (const expectedText of expectedTexts) {
+        if (text.includes(expectedText)) {
+          matches.set(expectedText, true);
+        }
+      }
+    }
+
+    if (Array.from(matches.values()).every(Boolean)) {
+      return Object.fromEntries(matches);
+    }
+    await page.waitForTimeout(250);
+  }
+
+  const missing = Array.from(matches.entries())
+    .filter(([, found]) => !found)
+    .map(([text]) => text);
+  throw new Error(`Timed out waiting for live room output frame text: ${missing.join(", ")}`);
 }

--- a/apps/notebook-cloud/scripts/hosted-live-room-smoke.mjs
+++ b/apps/notebook-cloud/scripts/hosted-live-room-smoke.mjs
@@ -3,6 +3,7 @@ import os from "node:os";
 
 import { chromium } from "@playwright/test";
 import { firstPositionalArg } from "./cli-args.mjs";
+import { saveSmokeScreenshot, smokeOutputPath } from "./smoke-paths.mjs";
 
 const DEFAULT_URL = "https://preview.runt.run/n/topic-viz/topic-viz";
 const viewerUrl =
@@ -51,7 +52,7 @@ const requireResolved = process.env.NOTEBOOK_CLOUD_LIVE_ROOM_REQUIRE_RESOLVED !=
 const requireOpenSocket = process.env.NOTEBOOK_CLOUD_LIVE_ROOM_REQUIRE_OPEN_SOCKET !== "0";
 const requireBlobFetch = process.env.NOTEBOOK_CLOUD_LIVE_ROOM_REQUIRE_BLOB_FETCH === "1";
 const requireImagesLoaded = process.env.NOTEBOOK_CLOUD_LIVE_ROOM_REQUIRE_IMAGES_LOADED === "1";
-const screenshotPath = process.env.NOTEBOOK_CLOUD_LIVE_ROOM_SCREENSHOT;
+const screenshotPath = smokeOutputPath(process.env.NOTEBOOK_CLOUD_LIVE_ROOM_SCREENSHOT);
 
 main().catch((error) => {
   console.error(error instanceof Error ? error.message : String(error));
@@ -182,7 +183,7 @@ async function main() {
 
     const diagnostics = await pageDiagnostics(page);
     if (screenshotPath) {
-      await page.screenshot({ path: screenshotPath, fullPage: true });
+      await saveSmokeScreenshot(page, screenshotPath);
     }
 
     const failures = [];

--- a/apps/notebook-cloud/scripts/hosted-live-smoke-env.mjs
+++ b/apps/notebook-cloud/scripts/hosted-live-smoke-env.mjs
@@ -23,6 +23,17 @@ export function smokeEnvForPublishResult(env, publishResult) {
     publishResult.runtimeStateDocId,
     "runtimeStateDocId",
   );
+  setOptionalDefaultEnv(
+    smokeEnv,
+    "NOTEBOOK_CLOUD_EXPECTED_CATALOG_OWNER_PRINCIPAL",
+    publishResult.ownerPrincipal,
+  );
+  setOptionalDefaultEnv(
+    smokeEnv,
+    "NOTEBOOK_CLOUD_EXPECTED_LATEST_REVISION_ACTOR_LABEL",
+    publishResult.latestRevisionActorLabel,
+  );
+  applyLivePresetSmokeDefaults(smokeEnv, env, publishResult);
 
   if (!hasOwn(smokeEnv, "NOTEBOOK_CLOUD_EXPECTED_RENDERER_ASSET_ORIGIN")) {
     const origin = new URL(publishResult.viewerUrl).origin;
@@ -57,6 +68,64 @@ function setRequiredDefaultEnv(env, name, value, fieldName) {
     throw new Error(`publish-live did not provide ${fieldName}; cannot pin catalog assertion`);
   }
   env[name] = value;
+}
+
+function setOptionalDefaultEnv(env, name, value) {
+  if (hasOwn(env, name) || value === undefined || value === null) {
+    return;
+  }
+  env[name] = value;
+}
+
+function applyLivePresetSmokeDefaults(smokeEnv, env, publishResult) {
+  const preset =
+    publishResult.preset === "source-notebook"
+      ? env.NOTEBOOK_CLOUD_LIVE_PRESET
+      : publishResult.preset;
+  const defaults = livePresetSmokeDefaults(preset);
+  if (!defaults) {
+    return;
+  }
+
+  for (const [name, value] of Object.entries(defaults)) {
+    setOptionalDefaultEnv(smokeEnv, name, value);
+  }
+}
+
+function livePresetSmokeDefaults(preset) {
+  if (preset === "mathnet") {
+    return {
+      NOTEBOOK_CLOUD_EXPECTED_SOURCE_TEXT: "ShadenA/MathNet",
+      NOTEBOOK_CLOUD_EXPECTED_PAGE_TEXTS: JSON.stringify([
+        "MathNet via notebook-cloud",
+        "Loaded 25 rows",
+      ]),
+      NOTEBOOK_CLOUD_EXPECTED_FRAME_TEXTS: "",
+      NOTEBOOK_CLOUD_EXPECTED_PRESENCE_TITLE: "",
+      NOTEBOOK_CLOUD_REQUIRE_SIFT_WASM: "0",
+      NOTEBOOK_CLOUD_SMOKE_THEME_MODES: "",
+    };
+  }
+  if (preset === "html-output") {
+    return {
+      NOTEBOOK_CLOUD_EXPECTED_SOURCE_TEXT: "html-output-origin-probe",
+      NOTEBOOK_CLOUD_EXPECTED_PAGE_TEXTS: JSON.stringify(["HTML output document origin smoke"]),
+      NOTEBOOK_CLOUD_EXPECTED_FRAME_TEXTS: JSON.stringify(["Hello from HTML output document"]),
+      NOTEBOOK_CLOUD_EXPECTED_PRESENCE_TITLE: "",
+      NOTEBOOK_CLOUD_REQUIRE_SIFT_WASM: "0",
+    };
+  }
+  if (preset === "lets-edit") {
+    return {
+      NOTEBOOK_CLOUD_EXPECTED_SOURCE_TEXT: "Let's edit",
+      NOTEBOOK_CLOUD_EXPECTED_PAGE_TEXTS: JSON.stringify(["Let's edit", "Scratch space"]),
+      NOTEBOOK_CLOUD_EXPECTED_FRAME_TEXTS: "",
+      NOTEBOOK_CLOUD_EXPECTED_PRESENCE_TITLE: "",
+      NOTEBOOK_CLOUD_REQUIRE_SIFT_WASM: "0",
+      NOTEBOOK_CLOUD_SMOKE_THEME_MODES: "",
+    };
+  }
+  return null;
 }
 
 function hasOwn(object, key) {

--- a/apps/notebook-cloud/scripts/hosted-render-smoke.mjs
+++ b/apps/notebook-cloud/scripts/hosted-render-smoke.mjs
@@ -29,6 +29,7 @@ import {
 } from "./hosted-render-smoke-performance.mjs";
 import { checkRuntimeWasmHints } from "./hosted-render-smoke-runtime-wasm.mjs";
 import { catalogApiUrlForViewer, isRenderCacheApiUrl } from "./hosted-render-smoke-routes.mjs";
+import { firstPositionalArg } from "./cli-args.mjs";
 
 const DEFAULT_URL = "https://preview.runt.run/n/topic-viz/topic-viz";
 const DEFAULT_RENDERER_ASSET_ORIGIN = "https://nteract-notebook-cloud-assets.rgbkrk.workers.dev";
@@ -38,7 +39,7 @@ const DEFAULT_CATALOG_OWNER_PRINCIPAL =
 const DEFAULT_LATEST_REVISION_ACTOR_LABEL =
   "user:anaconda:fdb3dc7d-c369-4a39-bf7d-e35b77a0bdd0/agent:runt-publish";
 
-const targetUrl = process.argv[2] ?? process.env.NOTEBOOK_CLOUD_HOSTED_URL ?? DEFAULT_URL;
+const targetUrl = firstPositionalArg() ?? process.env.NOTEBOOK_CLOUD_HOSTED_URL ?? DEFAULT_URL;
 const expectedRendererAssetOrigin =
   process.env.NOTEBOOK_CLOUD_EXPECTED_RENDERER_ASSET_ORIGIN ?? DEFAULT_RENDERER_ASSET_ORIGIN;
 const expectedOutputDocumentOrigin =

--- a/apps/notebook-cloud/scripts/hosted-render-smoke.mjs
+++ b/apps/notebook-cloud/scripts/hosted-render-smoke.mjs
@@ -30,6 +30,7 @@ import {
 import { checkRuntimeWasmHints } from "./hosted-render-smoke-runtime-wasm.mjs";
 import { catalogApiUrlForViewer, isRenderCacheApiUrl } from "./hosted-render-smoke-routes.mjs";
 import { firstPositionalArg } from "./cli-args.mjs";
+import { smokeOutputPath } from "./smoke-paths.mjs";
 
 const DEFAULT_URL = "https://preview.runt.run/n/topic-viz/topic-viz";
 const DEFAULT_RENDERER_ASSET_ORIGIN = "https://nteract-notebook-cloud-assets.rgbkrk.workers.dev";
@@ -118,7 +119,7 @@ const expectedThemeModes = parseExpectedTexts("NOTEBOOK_CLOUD_SMOKE_THEME_MODES"
   "dark",
   "system-dark",
 ]);
-const screenshotPath = process.env.NOTEBOOK_CLOUD_SMOKE_SCREENSHOT;
+const screenshotPath = smokeOutputPath(process.env.NOTEBOOK_CLOUD_SMOKE_SCREENSHOT);
 const timeoutMs = Number(process.env.NOTEBOOK_CLOUD_SMOKE_TIMEOUT_MS ?? 60_000);
 const targetOrigin = new URL(targetUrl).origin;
 const expectedRuntimeWasmOrigin =

--- a/apps/notebook-cloud/scripts/hosted-runtime-browser-execute-smoke.mjs
+++ b/apps/notebook-cloud/scripts/hosted-runtime-browser-execute-smoke.mjs
@@ -1,6 +1,6 @@
 import { spawn } from "node:child_process";
 import path from "node:path";
-import { fileURLToPath } from "node:url";
+import { fileURLToPath, pathToFileURL } from "node:url";
 
 const appDir = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
 const runtimePeerScript = path.join(appDir, "scripts", "hosted-runtime-peer-smoke.mjs");
@@ -13,10 +13,12 @@ const source =
     .slice(0, 15)}')`;
 const scopes = parseScopes(process.env.NOTEBOOK_CLOUD_RUNTIME_BROWSER_EXECUTE_SCOPES);
 
-main().catch((error) => {
-  console.error(error instanceof Error ? error.message : String(error));
-  process.exitCode = 1;
-});
+if (isMainModule()) {
+  main().catch((error) => {
+    console.error(error instanceof Error ? error.message : String(error));
+    process.exitCode = 1;
+  });
+}
 
 async function main() {
   const runs = [];
@@ -105,7 +107,7 @@ async function runScope(scope) {
   }
 }
 
-function browserRunSummary(run, scope) {
+export function browserRunSummary(run, scope) {
   return {
     scope,
     clickedAria: run.click?.clickedAria ?? null,
@@ -116,7 +118,7 @@ function browserRunSummary(run, scope) {
   };
 }
 
-function assertBrowserRunAdvanced(run) {
+export function assertBrowserRunAdvanced(run) {
   if (!Number.isInteger(run.afterExecutionOrdinal) || run.afterExecutionOrdinal < 2) {
     throw new Error(
       `browser execute smoke for ${run.scope} did not advance past the runtime-peer seed execution: ${stringify(
@@ -162,7 +164,7 @@ function runProcess(command, args, options) {
   });
 }
 
-function parseJsonOutput(stdout, label) {
+export function parseJsonOutput(stdout, label) {
   const trimmed = stdout.trim();
   try {
     return JSON.parse(trimmed);
@@ -205,7 +207,7 @@ async function processExists(pid) {
   }
 }
 
-function parseScopes(value) {
+export function parseScopes(value) {
   const raw = value ?? "owner,editor";
   const parsed = raw
     .split(/,|\s+/)
@@ -234,4 +236,8 @@ function sleep(ms) {
 
 function stringify(value) {
   return JSON.stringify(value, null, 2);
+}
+
+function isMainModule() {
+  return process.argv[1] ? import.meta.url === pathToFileURL(process.argv[1]).href : false;
 }

--- a/apps/notebook-cloud/scripts/hosted-runtime-browser-execute-smoke.mjs
+++ b/apps/notebook-cloud/scripts/hosted-runtime-browser-execute-smoke.mjs
@@ -1,0 +1,237 @@
+import { spawn } from "node:child_process";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const appDir = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
+const runtimePeerScript = path.join(appDir, "scripts", "hosted-runtime-peer-smoke.mjs");
+const browserExecuteScript = path.join(appDir, "scripts", "hosted-browser-execute-smoke.mjs");
+const source =
+  process.env.NOTEBOOK_CLOUD_RUNTIME_BROWSER_EXECUTE_CODE ??
+  `print('preview runtime browser execute smoke ${new Date()
+    .toISOString()
+    .replace(/[-:.]/g, "")
+    .slice(0, 15)}')`;
+const scopes = parseScopes(process.env.NOTEBOOK_CLOUD_RUNTIME_BROWSER_EXECUTE_SCOPES);
+
+main().catch((error) => {
+  console.error(error instanceof Error ? error.message : String(error));
+  process.exitCode = 1;
+});
+
+async function main() {
+  const runs = [];
+  for (const scope of scopes) {
+    runs.push(await runScope(scope));
+  }
+
+  console.log(
+    JSON.stringify(
+      {
+        ok: true,
+        source,
+        scopes,
+        checks: [
+          "runtime_peer_browser_execute_passed_for_requested_scopes",
+          "runtime_peers_stopped_after_browser_smokes",
+        ],
+        runs,
+      },
+      null,
+      2,
+    ),
+  );
+}
+
+async function runScope(scope) {
+  let runtimePeerPid = null;
+
+  try {
+    const runtime = await runJsonScript("runtime-peer", runtimePeerScript, [], {
+      ...process.env,
+      NOTEBOOK_CLOUD_KEEP_RUNTIME_PEER: "1",
+      NOTEBOOK_CLOUD_RUNTIME_PEER_SMOKE_CODE: source,
+    });
+    runtimePeerPid = runtime.runtimePeer?.pid ?? null;
+
+    if (!runtime.ok || typeof runtime.viewerUrl !== "string" || !runtime.viewerUrl) {
+      throw new Error(`runtime-peer smoke returned an invalid result:\n${stringify(runtime)}`);
+    }
+    if (!Number.isInteger(runtimePeerPid)) {
+      throw new Error(
+        `runtime-peer smoke did not return a kept-alive peer pid:\n${stringify(runtime)}`,
+      );
+    }
+
+    const browser = await runJsonScript(
+      "browser-execute",
+      browserExecuteScript,
+      [runtime.viewerUrl],
+      {
+        ...process.env,
+        NOTEBOOK_CLOUD_BROWSER_EXECUTE_EXPECTED_TEXT: source,
+        NOTEBOOK_CLOUD_BROWSER_EXECUTE_SCOPE: scope,
+      },
+    );
+    const browserSummary = browserRunSummary(browser, scope);
+    assertBrowserRunAdvanced(browserSummary);
+
+    await stopProcess(runtimePeerPid);
+    const runtimePeerStopped = true;
+    runtimePeerPid = null;
+
+    return {
+      scope,
+      viewerUrl: runtime.viewerUrl,
+      checks: [
+        "runtime_peer_smoke_passed",
+        "runtime_peer_kept_alive_for_browser",
+        "browser_execute_smoke_passed",
+        ...(runtimePeerStopped ? ["runtime_peer_stopped_after_browser_smoke"] : []),
+      ],
+      runtimePeer: {
+        notebookId: runtime.notebookId,
+        vanityName: runtime.vanityName,
+        pid: runtime.runtimePeer?.pid ?? null,
+        stopped: runtimePeerStopped,
+        logPath: runtime.runtimePeer?.logPath ?? null,
+        timings_ms: runtime.timings_ms ?? null,
+      },
+      browserRun: browserSummary,
+    };
+  } finally {
+    if (Number.isInteger(runtimePeerPid)) {
+      await stopProcess(runtimePeerPid);
+    }
+  }
+}
+
+function browserRunSummary(run, scope) {
+  return {
+    scope,
+    clickedAria: run.click?.clickedAria ?? null,
+    afterAria: run.click?.afterAria ?? null,
+    beforeExecutionOrdinal: run.click?.beforeExecutionOrdinal ?? null,
+    afterExecutionOrdinal: run.click?.afterExecutionOrdinal ?? null,
+    checks: run.checks ?? [],
+  };
+}
+
+function assertBrowserRunAdvanced(run) {
+  if (!Number.isInteger(run.afterExecutionOrdinal) || run.afterExecutionOrdinal < 2) {
+    throw new Error(
+      `browser execute smoke for ${run.scope} did not advance past the runtime-peer seed execution: ${stringify(
+        run,
+      )}`,
+    );
+  }
+}
+
+async function runJsonScript(label, script, args, env) {
+  const result = await runProcess(process.execPath, [script, ...args], { cwd: appDir, env });
+  if (result.exitCode !== 0) {
+    throw new Error(
+      `${label} smoke failed with exit code ${result.exitCode}\nSTDERR:\n${result.stderr}\nSTDOUT:\n${result.stdout}`,
+    );
+  }
+  return parseJsonOutput(result.stdout, label);
+}
+
+function runProcess(command, args, options) {
+  return new Promise((resolve) => {
+    const child = spawn(command, args, {
+      ...options,
+      stdio: ["ignore", "pipe", "pipe"],
+    });
+    let stdout = "";
+    let stderr = "";
+    child.stdout.setEncoding("utf8");
+    child.stderr.setEncoding("utf8");
+    child.stdout.on("data", (chunk) => {
+      stdout += chunk;
+    });
+    child.stderr.on("data", (chunk) => {
+      stderr += chunk;
+    });
+    child.on("error", (error) => {
+      stderr += `${error.stack ?? error.message}\n`;
+      resolve({ exitCode: 1, stdout, stderr });
+    });
+    child.on("close", (code) => {
+      resolve({ exitCode: code ?? 1, stdout, stderr });
+    });
+  });
+}
+
+function parseJsonOutput(stdout, label) {
+  const trimmed = stdout.trim();
+  try {
+    return JSON.parse(trimmed);
+  } catch {
+    const start = trimmed.indexOf("{");
+    const end = trimmed.lastIndexOf("}");
+    if (start >= 0 && end > start) {
+      try {
+        return JSON.parse(trimmed.slice(start, end + 1));
+      } catch {
+        // Fall through to the clearer diagnostic below.
+      }
+    }
+  }
+  throw new Error(`${label} smoke did not emit parseable JSON:\n${trimmed}`);
+}
+
+async function stopProcess(pid) {
+  if (!(await processExists(pid))) {
+    return;
+  }
+  signalProcess(pid, "SIGTERM");
+  for (let attempt = 0; attempt < 20; attempt += 1) {
+    if (!(await processExists(pid))) {
+      return;
+    }
+    await sleep(100);
+  }
+  if (await processExists(pid)) {
+    signalProcess(pid, "SIGKILL");
+  }
+}
+
+async function processExists(pid) {
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+function parseScopes(value) {
+  const raw = value ?? "owner,editor";
+  const parsed = raw
+    .split(/,|\s+/)
+    .map((scope) => scope.trim())
+    .filter(Boolean);
+  const scopes = parsed.length > 0 ? parsed : ["owner", "editor"];
+  for (const scope of scopes) {
+    if (!["owner", "editor"].includes(scope)) {
+      throw new Error("NOTEBOOK_CLOUD_RUNTIME_BROWSER_EXECUTE_SCOPES must contain owner or editor");
+    }
+  }
+  return scopes;
+}
+
+function signalProcess(pid, signal) {
+  try {
+    process.kill(pid, signal);
+  } catch {
+    // The peer may exit between existence checks and signal delivery.
+  }
+}
+
+function sleep(ms) {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+function stringify(value) {
+  return JSON.stringify(value, null, 2);
+}

--- a/apps/notebook-cloud/scripts/publish-live.mjs
+++ b/apps/notebook-cloud/scripts/publish-live.mjs
@@ -3,7 +3,7 @@ import { access, readFile } from "node:fs/promises";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 
-import { collectBlobRefs } from "../src/blob-refs.ts";
+import { collectArrowStreamManifestBlobRefs, collectBlobRefs } from "../src/blob-refs.ts";
 import { createLiveNotebookFixture } from "./live-notebook-fixture.mjs";
 import {
   canonicalViewerUrl,
@@ -48,6 +48,7 @@ try {
     snapshot.commsDocBytes,
   );
   const blobRefs = collectBlobRefs({ cells, runtimeState, commsState });
+  await expandArrowManifestBlobRefs(blobRefs, snapshot);
   const headsHash = headsDigest(snapshot.notebookHeads);
   const runtimeHeadsHash = headsDigest(snapshot.runtimeStateHeads);
   const commsHeadsHash = headsDigest(snapshot.commsDocHeads);
@@ -176,6 +177,24 @@ async function uploadLiveBlob(ref, snapshot) {
     bytes,
     ref.media_type ?? "application/octet-stream",
   );
+}
+
+async function expandArrowManifestBlobRefs(blobRefs, snapshot) {
+  for (const ref of Object.values(blobRefs)) {
+    if (ref.media_type !== "application/vnd.nteract.arrow-stream-manifest+json") {
+      continue;
+    }
+    const bytes = await readLocalBlob(ref.blob, snapshot);
+    const manifest = new TextDecoder().decode(bytes);
+    const childRefs = collectArrowStreamManifestBlobRefs(manifest);
+    for (const childRef of Object.values(childRefs)) {
+      blobRefs[childRef.blob] = {
+        blob: childRef.blob,
+        size: blobRefs[childRef.blob]?.size ?? childRef.size,
+        media_type: blobRefs[childRef.blob]?.media_type ?? childRef.media_type,
+      };
+    }
+  }
 }
 
 async function readLocalBlob(hash, snapshot) {

--- a/apps/notebook-cloud/scripts/publish-live.mjs
+++ b/apps/notebook-cloud/scripts/publish-live.mjs
@@ -13,6 +13,7 @@ import {
 import { notebookCloudBaseUrl } from "./local-dev.mjs";
 import { publishIdentityHeaders } from "./publish-auth.mjs";
 import { loadRuntimedNode } from "./runtimed-node-loader.mjs";
+import { summarizeCatalog } from "./hosted-render-smoke-catalog.mjs";
 
 const rt = loadRuntimedNode();
 
@@ -85,13 +86,14 @@ try {
   );
 
   const catalog = await fetchJson(`/api/n/${encodeURIComponent(notebookId)}`);
+  const catalogSummary = summarizeCatalog(catalog);
+  const latestRevision = catalog.revisions?.find(
+    (revision) => revision.id === catalogSummary.latestRevisionId,
+  );
   assert(
-    catalog.revisions?.some(
-      (revision) =>
-        revision.notebook_heads_hash === headsHash &&
-        revision.runtime_heads_hash === runtimeHeadsHash &&
-        revision.comms_heads_hash === commsHeadsHash,
-    ),
+    latestRevision?.notebook_heads_hash === headsHash &&
+      latestRevision?.runtime_heads_hash === runtimeHeadsHash &&
+      latestRevision?.comms_heads_hash === commsHeadsHash,
     "published catalog did not include the snapshot triplet",
   );
 
@@ -110,6 +112,8 @@ try {
         headsHash,
         runtimeHeadsHash,
         commsHeadsHash,
+        ownerPrincipal: catalogSummary.ownerPrincipal,
+        latestRevisionActorLabel: catalogSummary.latestRevisionActorLabel,
         cells: Array.isArray(cells) ? cells.length : null,
         blobs: Object.keys(blobRefs).length,
         checks: [

--- a/apps/notebook-cloud/scripts/smoke-paths.mjs
+++ b/apps/notebook-cloud/scripts/smoke-paths.mjs
@@ -1,0 +1,15 @@
+import { mkdir } from "node:fs/promises";
+import path from "node:path";
+
+export function smokeOutputPath(value, env = process.env) {
+  if (!value) return undefined;
+  if (path.isAbsolute(value)) return value;
+  return path.resolve(env.INIT_CWD || process.cwd(), value);
+}
+
+export async function saveSmokeScreenshot(page, screenshotPath) {
+  if (!screenshotPath) return false;
+  await mkdir(path.dirname(screenshotPath), { recursive: true });
+  await page.screenshot({ path: screenshotPath, fullPage: true });
+  return true;
+}

--- a/apps/notebook-cloud/src/blob-refs.ts
+++ b/apps/notebook-cloud/src/blob-refs.ts
@@ -14,6 +14,12 @@ export function collectBlobUrls(value: unknown, resolver: BlobResolver): Record<
   );
 }
 
+export function collectArrowStreamManifestBlobRefs(content: string): Record<string, BlobRef> {
+  const refs: Record<string, BlobRef> = {};
+  visitArrowStreamManifest(content, refs);
+  return refs;
+}
+
 function visitBlobRefs(value: unknown, refs: Record<string, BlobRef>): void {
   if (Array.isArray(value)) {
     for (const item of value) {
@@ -34,6 +40,8 @@ function visitBlobRefs(value: unknown, refs: Record<string, BlobRef>): void {
   const arrowManifestRef = record[ARROW_STREAM_MANIFEST_MIME];
   if (isInlineContentRef(arrowManifestRef)) {
     visitArrowStreamManifest(arrowManifestRef.inline, refs);
+  } else if (isRecord(arrowManifestRef)) {
+    addArrowManifestPointerRef(arrowManifestRef, refs);
   }
 
   for (const item of Object.values(record)) {
@@ -100,6 +108,9 @@ function visitArrowStreamManifest(content: string, refs: Record<string, BlobRef>
   }
   if (typeof manifest !== "object" || manifest === null) return;
   const record = manifest as Record<string, unknown>;
+  if (addArrowManifestPointerRef(record, refs)) {
+    return;
+  }
   const chunks = record.chunks;
 
   addManifestBlobRef(record, refs);
@@ -133,8 +144,37 @@ function addManifestBlobRef(value: unknown, refs: Record<string, BlobRef>): void
   mergeBlobRef(refs, {
     blob: hash,
     size: typeof value.size === "number" ? value.size : undefined,
-    media_type: typeof value.media_type === "string" ? value.media_type : undefined,
+    media_type:
+      typeof value.media_type === "string"
+        ? value.media_type
+        : typeof value.content_type === "string"
+          ? value.content_type
+          : undefined,
   });
+}
+
+function addArrowManifestPointerRef(
+  value: Record<string, unknown>,
+  refs: Record<string, BlobRef>,
+): boolean {
+  if (!isArrowManifestPointer(value)) return false;
+  const blob = typeof value.blob === "string" ? value.blob : value.hash;
+  if (typeof blob !== "string") return false;
+  mergeBlobRef(refs, {
+    blob,
+    size: typeof value.size === "number" ? value.size : undefined,
+    media_type: ARROW_STREAM_MANIFEST_MIME,
+  });
+  return true;
+}
+
+function isArrowManifestPointer(value: Record<string, unknown>): boolean {
+  return (
+    (typeof value.blob === "string" || typeof value.hash === "string") &&
+    !Array.isArray(value.chunks) &&
+    !Array.isArray(value.blobs) &&
+    !isRecord(value.coalesced)
+  );
 }
 
 function isRecord(value: unknown): value is Record<string, unknown> {

--- a/apps/notebook-cloud/src/blob-resolver.ts
+++ b/apps/notebook-cloud/src/blob-resolver.ts
@@ -1,5 +1,7 @@
 import { createBlobResolver, type BlobRef, type BlobResolver } from "runtimed";
 
+const BLOB_FETCH_RETRY_DELAYS_MS = [150, 500];
+
 export function notebookCloudBlobBasePath(notebookId: string): string {
   return `/api/n/${encodeURIComponent(notebookId)}/blobs/`;
 }
@@ -16,10 +18,12 @@ export function createNotebookCloudBlobResolver(input: {
   const fetchImpl = input.fetchImpl ?? fetch;
   const displayUrls = new Map<string, string>();
   const url = (ref: BlobRef) => new URL(encodeURIComponent(ref.blob), blobBaseUrl).href;
+  const fetchWithBlobRetries: typeof fetch = (request, init) =>
+    fetchBlobWithRetries(fetchImpl, request, init);
   const authenticatedBinaryDisplayUrls =
     input.authenticatedBinaryDisplayUrls ?? input.authenticatedBinaryObjectUrls ?? false;
   return createBlobResolver({
-    fetchImpl,
+    fetchImpl: fetchWithBlobRetries,
     url,
     ...(authenticatedBinaryDisplayUrls
       ? {
@@ -29,7 +33,7 @@ export function createNotebookCloudBlobResolver(input: {
             const cached = displayUrls.get(cacheKey);
             if (cached) return cached;
 
-            const response = await fetchImpl(url(ref), { cache: "no-store" });
+            const response = await fetchBlobWithRetries(fetchImpl, url(ref), { cache: "no-store" });
             if (!response.ok) {
               throw new Error(`Failed to fetch blob ${ref.blob}: ${response.status}`);
             }
@@ -56,6 +60,55 @@ export function createNotebookCloudBlobResolver(input: {
 
 export function withTrailingSlash(value: string): string {
   return value.endsWith("/") ? value : `${value}/`;
+}
+
+async function fetchBlobWithRetries(
+  fetchImpl: typeof fetch,
+  input: RequestInfo | URL,
+  init?: RequestInit,
+): Promise<Response> {
+  let lastError: unknown = null;
+
+  for (let attempt = 0; attempt <= BLOB_FETCH_RETRY_DELAYS_MS.length; attempt += 1) {
+    try {
+      const response = await fetchImpl(input, init);
+      if (!shouldRetryBlobResponse(response) || attempt === BLOB_FETCH_RETRY_DELAYS_MS.length) {
+        return response;
+      }
+      await cancelResponseBody(response);
+    } catch (error) {
+      lastError = error;
+      if (attempt === BLOB_FETCH_RETRY_DELAYS_MS.length) {
+        throw error;
+      }
+    }
+
+    await sleep(BLOB_FETCH_RETRY_DELAYS_MS[attempt]);
+  }
+
+  throw lastError instanceof Error ? lastError : new Error(String(lastError));
+}
+
+function shouldRetryBlobResponse(response: Response): boolean {
+  return (
+    response.status === 404 ||
+    response.status === 409 ||
+    response.status === 425 ||
+    response.status === 429 ||
+    response.status >= 500
+  );
+}
+
+async function cancelResponseBody(response: Response): Promise<void> {
+  try {
+    await response.body?.cancel();
+  } catch {
+    // Best effort; a failed cancel should not mask the retryable response.
+  }
+}
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
 }
 
 function displayUrlCacheKey(ref: BlobRef, mediaType?: string): string {

--- a/apps/notebook-cloud/test/blob-refs.test.ts
+++ b/apps/notebook-cloud/test/blob-refs.test.ts
@@ -1,6 +1,6 @@
 import { describe, it } from "node:test";
 import assert from "node:assert/strict";
-import { collectBlobRefs } from "../src/blob-refs.ts";
+import { collectArrowStreamManifestBlobRefs, collectBlobRefs } from "../src/blob-refs.ts";
 
 const ARROW_STREAM_MANIFEST_MIME = "application/vnd.nteract.arrow-stream-manifest+json";
 
@@ -59,5 +59,41 @@ describe("cloud blob ref collection", () => {
     assert.ok(refs["coalesced-hash"]);
     assert.ok(refs["segment-hash"]);
     assert.equal(refs["schema-fingerprint"], undefined);
+  });
+
+  it("collects Arrow manifest pointer refs and marks them as manifest blobs", () => {
+    const refs = collectBlobRefs({
+      data: {
+        [ARROW_STREAM_MANIFEST_MIME]: {
+          inline: JSON.stringify({
+            blob: "manifest-hash",
+            size: 1615,
+          }),
+        },
+      },
+    });
+
+    assert.equal(refs["manifest-hash"]?.blob, "manifest-hash");
+    assert.equal(refs["manifest-hash"]?.size, 1615);
+    assert.equal(refs["manifest-hash"]?.media_type, ARROW_STREAM_MANIFEST_MIME);
+  });
+
+  it("collects child refs from a resolved Arrow manifest blob", () => {
+    const refs = collectArrowStreamManifestBlobRefs(
+      JSON.stringify({
+        chunks: [
+          {
+            hash: "arrow-chunk",
+            size: 4096,
+            content_type: "application/vnd.apache.arrow.stream",
+          },
+        ],
+        complete: true,
+      }),
+    );
+
+    assert.equal(refs["arrow-chunk"]?.blob, "arrow-chunk");
+    assert.equal(refs["arrow-chunk"]?.size, 4096);
+    assert.equal(refs["arrow-chunk"]?.media_type, "application/vnd.apache.arrow.stream");
   });
 });

--- a/apps/notebook-cloud/test/blob-resolver.test.ts
+++ b/apps/notebook-cloud/test/blob-resolver.test.ts
@@ -22,6 +22,50 @@ describe("notebook cloud blob resolver", () => {
     );
   });
 
+  it("retries transient hosted blob misses before returning the response", async () => {
+    const statuses = [404, 200];
+    const fetchCalls: Array<{ input: RequestInfo | URL; init?: RequestInit }> = [];
+    const resolver = createNotebookCloudBlobResolver({
+      baseUrl: "https://viewer.example.test/n/notebook-1",
+      blobBasePath: "/api/n/notebook-1/blobs/",
+      fetchImpl: async (input, init) => {
+        fetchCalls.push({ input, init });
+        const status = statuses.shift() ?? 500;
+        return new Response(status === 200 ? "ready" : "missing", { status });
+      },
+    });
+
+    const response = await resolver.fetch({ blob: "sha256:late" });
+
+    assert.equal(response.status, 200);
+    assert.equal(await response.text(), "ready");
+    assert.equal(fetchCalls.length, 2);
+    assert.deepEqual(
+      fetchCalls.map((call) => call.input),
+      [
+        "https://viewer.example.test/api/n/notebook-1/blobs/sha256%3Alate",
+        "https://viewer.example.test/api/n/notebook-1/blobs/sha256%3Alate",
+      ],
+    );
+  });
+
+  it("returns the final hosted blob miss after retry attempts are exhausted", async () => {
+    let fetchCount = 0;
+    const resolver = createNotebookCloudBlobResolver({
+      baseUrl: "https://viewer.example.test/n/notebook-1",
+      blobBasePath: "/api/n/notebook-1/blobs/",
+      fetchImpl: async () => {
+        fetchCount += 1;
+        return new Response("missing", { status: 404 });
+      },
+    });
+
+    const response = await resolver.fetch({ blob: "sha256:missing" });
+
+    assert.equal(response.status, 404);
+    assert.equal(fetchCount, 3);
+  });
+
   it("can resolve protected binary blobs through authenticated display URLs", async () => {
     const originalFileReader = globalThis.FileReader;
     class TestFileReader {

--- a/apps/notebook-cloud/test/cli-args.test.mjs
+++ b/apps/notebook-cloud/test/cli-args.test.mjs
@@ -1,0 +1,32 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+
+import { firstPositionalArg } from "../scripts/cli-args.mjs";
+
+describe("notebook-cloud smoke CLI args", () => {
+  it("returns the first positional argument", () => {
+    assert.equal(
+      firstPositionalArg(["https://preview.runt.run/n/id/name"]),
+      "https://preview.runt.run/n/id/name",
+    );
+  });
+
+  it("ignores npm/pnpm separator arguments before the URL", () => {
+    assert.equal(
+      firstPositionalArg(["--", "https://preview.runt.run/n/topic-viz/topic-viz"]),
+      "https://preview.runt.run/n/topic-viz/topic-viz",
+    );
+  });
+
+  it("ignores empty arguments", () => {
+    assert.equal(
+      firstPositionalArg(["", "--", "  ", "https://preview.runt.run/n/id/name"]),
+      "https://preview.runt.run/n/id/name",
+    );
+  });
+
+  it("returns undefined when no positional argument is present", () => {
+    assert.equal(firstPositionalArg([]), undefined);
+    assert.equal(firstPositionalArg(["--", ""]), undefined);
+  });
+});

--- a/apps/notebook-cloud/test/hosted-live-room-matrix.test.mjs
+++ b/apps/notebook-cloud/test/hosted-live-room-matrix.test.mjs
@@ -1,0 +1,104 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+
+import {
+  entryLabel,
+  parseLiveRoomMatrixEntries,
+  safeScreenshotName,
+  smokeEnvForMatrixEntry,
+} from "../scripts/hosted-live-room-matrix.mjs";
+
+describe("hosted live room matrix smoke helpers", () => {
+  it("parses pipe and newline separated URL lists", () => {
+    assert.deepEqual(
+      parseLiveRoomMatrixEntries(
+        "https://preview.runt.run/n/one/notebook | https://preview.runt.run/n/two/notebook\nhttps://preview.runt.run/n/three/notebook",
+      ),
+      [
+        { url: "https://preview.runt.run/n/one/notebook" },
+        { url: "https://preview.runt.run/n/two/notebook" },
+        { url: "https://preview.runt.run/n/three/notebook" },
+      ],
+    );
+  });
+
+  it("parses JSON object entries with per-notebook expectations", () => {
+    assert.deepEqual(
+      parseLiveRoomMatrixEntries(
+        JSON.stringify([
+          {
+            url: "https://preview.runt.run/n/topic-viz/topic-viz",
+            label: "topic-viz",
+            expectedPageTexts: ["MathNet topic visualization"],
+            expectedFrameTexts: ["PROBLEM_MARKDOWN"],
+            minCells: 20,
+            minVisibleIframes: 2,
+            minImages: 3,
+            requireBlobFetch: true,
+            requireImagesLoaded: true,
+          },
+        ]),
+      ),
+      [
+        {
+          url: "https://preview.runt.run/n/topic-viz/topic-viz",
+          label: "topic-viz",
+          expectedPageTexts: ["MathNet topic visualization"],
+          expectedFrameTexts: ["PROBLEM_MARKDOWN"],
+          minCells: 20,
+          minVisibleIframes: 2,
+          minImages: 3,
+          requireBlobFetch: true,
+          requireImagesLoaded: true,
+        },
+      ],
+    );
+  });
+
+  it("builds permissive catalog-sweep defaults", () => {
+    const env = smokeEnvForMatrixEntry(
+      { url: "https://preview.runt.run/n/empty/notebook" },
+      {
+        NOTEBOOK_CLOUD_LIVE_ROOM_MATRIX_MIN_CELLS: "0",
+        NOTEBOOK_CLOUD_LIVE_ROOM_MATRIX_REQUIRE_BLOB_FETCH: "0",
+      },
+    );
+
+    assert.equal(env.NOTEBOOK_CLOUD_LIVE_ROOM_EXPECTED_TEXT, "");
+    assert.equal(env.NOTEBOOK_CLOUD_LIVE_ROOM_EXPECTED_PAGE_TEXTS, "");
+    assert.equal(env.NOTEBOOK_CLOUD_LIVE_ROOM_EXPECTED_FRAME_TEXTS, "");
+    assert.equal(env.NOTEBOOK_CLOUD_LIVE_ROOM_MIN_CELLS, "0");
+    assert.equal(env.NOTEBOOK_CLOUD_LIVE_ROOM_REQUIRE_BLOB_FETCH, "0");
+  });
+
+  it("applies strict per-entry output expectations", () => {
+    const env = smokeEnvForMatrixEntry(
+      {
+        url: "https://preview.runt.run/n/topic-viz/topic-viz",
+        expectedText: "import plotly.graph_objects as go",
+        expectedFrameTexts: ["PROBLEM_MARKDOWN"],
+        minCells: 20,
+        minVisibleIframes: 2,
+        minImages: 3,
+        requireBlobFetch: true,
+        requireImagesLoaded: true,
+      },
+      {},
+    );
+
+    assert.equal(env.NOTEBOOK_CLOUD_LIVE_ROOM_EXPECTED_TEXT, "import plotly.graph_objects as go");
+    assert.equal(env.NOTEBOOK_CLOUD_LIVE_ROOM_EXPECTED_FRAME_TEXTS, '["PROBLEM_MARKDOWN"]');
+    assert.equal(env.NOTEBOOK_CLOUD_LIVE_ROOM_MIN_CELLS, "20");
+    assert.equal(env.NOTEBOOK_CLOUD_LIVE_ROOM_MIN_VISIBLE_IFRAMES, "2");
+    assert.equal(env.NOTEBOOK_CLOUD_LIVE_ROOM_MIN_IMAGES, "3");
+    assert.equal(env.NOTEBOOK_CLOUD_LIVE_ROOM_REQUIRE_BLOB_FETCH, "1");
+    assert.equal(env.NOTEBOOK_CLOUD_LIVE_ROOM_REQUIRE_IMAGES_LOADED, "1");
+  });
+
+  it("derives stable labels and screenshot filenames", () => {
+    const entry = { url: "https://preview.runt.run/n/01ABC/notebook" };
+
+    assert.equal(entryLabel(entry, 0), "01ABC");
+    assert.equal(safeScreenshotName("Topic Viz / Old Output", 2), "03-topic-viz-old-output.png");
+  });
+});

--- a/apps/notebook-cloud/test/hosted-live-smoke-env.test.mjs
+++ b/apps/notebook-cloud/test/hosted-live-smoke-env.test.mjs
@@ -15,6 +15,8 @@ describe("hosted live smoke environment", () => {
         headsHash: "heads-notebook",
         runtimeHeadsHash: "heads-runtime",
         runtimeStateDocId: "runtime-state-doc",
+        ownerPrincipal: "user:dev:live-publish",
+        latestRevisionActorLabel: "user:dev:live-publish/agent:publish-live",
       },
     );
 
@@ -34,6 +36,11 @@ describe("hosted live smoke environment", () => {
       smokeEnv.NOTEBOOK_CLOUD_EXPECTED_LATEST_REVISION_RUNTIME_STATE_DOC_ID,
       "runtime-state-doc",
     );
+    assert.equal(smokeEnv.NOTEBOOK_CLOUD_EXPECTED_CATALOG_OWNER_PRINCIPAL, "user:dev:live-publish");
+    assert.equal(
+      smokeEnv.NOTEBOOK_CLOUD_EXPECTED_LATEST_REVISION_ACTOR_LABEL,
+      "user:dev:live-publish/agent:publish-live",
+    );
     assert.equal(
       Object.hasOwn(smokeEnv, "NOTEBOOK_CLOUD_EXPECTED_RENDER_SOURCE"),
       false,
@@ -44,8 +51,12 @@ describe("hosted live smoke environment", () => {
   it("does not override explicit hosted smoke expectation env values", () => {
     const smokeEnv = smokeEnvForPublishResult(
       {
+        NOTEBOOK_CLOUD_LIVE_PRESET: "mathnet",
         NOTEBOOK_CLOUD_EXPECTED_LATEST_REVISION_NOTEBOOK_HEADS_HASH: "",
         NOTEBOOK_CLOUD_EXPECTED_LATEST_REVISION_RUNTIME_HEADS_HASH: "override-runtime",
+        NOTEBOOK_CLOUD_EXPECTED_CATALOG_OWNER_PRINCIPAL: "override-owner",
+        NOTEBOOK_CLOUD_EXPECTED_LATEST_REVISION_ACTOR_LABEL: "override-actor",
+        NOTEBOOK_CLOUD_EXPECTED_PAGE_TEXTS: "override-page",
         NOTEBOOK_CLOUD_EXPECTED_RENDERER_ASSET_ORIGIN: "https://assets.example.test",
       },
       {
@@ -53,6 +64,9 @@ describe("hosted live smoke environment", () => {
         headsHash: "heads-notebook",
         runtimeHeadsHash: "heads-runtime",
         runtimeStateDocId: "runtime-state-doc",
+        ownerPrincipal: "user:dev:live-publish",
+        latestRevisionActorLabel: "user:dev:live-publish/agent:publish-live",
+        preset: "source-notebook",
       },
     );
 
@@ -61,6 +75,9 @@ describe("hosted live smoke environment", () => {
       smokeEnv.NOTEBOOK_CLOUD_EXPECTED_LATEST_REVISION_RUNTIME_HEADS_HASH,
       "override-runtime",
     );
+    assert.equal(smokeEnv.NOTEBOOK_CLOUD_EXPECTED_CATALOG_OWNER_PRINCIPAL, "override-owner");
+    assert.equal(smokeEnv.NOTEBOOK_CLOUD_EXPECTED_LATEST_REVISION_ACTOR_LABEL, "override-actor");
+    assert.equal(smokeEnv.NOTEBOOK_CLOUD_EXPECTED_PAGE_TEXTS, "override-page");
     assert.equal(
       smokeEnv.NOTEBOOK_CLOUD_EXPECTED_RENDERER_ASSET_ORIGIN,
       "https://assets.example.test",
@@ -79,6 +96,49 @@ describe("hosted live smoke environment", () => {
     );
 
     assert.equal(smokeEnv.NOTEBOOK_CLOUD_EXPECTED_RENDERER_ASSET_ORIGIN, "http://127.0.0.1:8787");
+  });
+
+  it("uses mathnet live fixture smoke expectations for generated live publishes", () => {
+    const smokeEnv = smokeEnvForPublishResult(
+      {},
+      {
+        viewerUrl: "https://preview.runt.run/n/live-source/source",
+        headsHash: "heads-notebook",
+        runtimeHeadsHash: "heads-runtime",
+        runtimeStateDocId: "runtime-state-doc",
+        preset: "mathnet",
+      },
+    );
+
+    assert.equal(smokeEnv.NOTEBOOK_CLOUD_EXPECTED_SOURCE_TEXT, "ShadenA/MathNet");
+    assert.equal(
+      smokeEnv.NOTEBOOK_CLOUD_EXPECTED_PAGE_TEXTS,
+      JSON.stringify(["MathNet via notebook-cloud", "Loaded 25 rows"]),
+    );
+    assert.equal(smokeEnv.NOTEBOOK_CLOUD_EXPECTED_FRAME_TEXTS, "");
+    assert.equal(smokeEnv.NOTEBOOK_CLOUD_EXPECTED_PRESENCE_TITLE, "");
+    assert.equal(smokeEnv.NOTEBOOK_CLOUD_REQUIRE_SIFT_WASM, "0");
+    assert.equal(smokeEnv.NOTEBOOK_CLOUD_SMOKE_THEME_MODES, "");
+  });
+
+  it("uses the requested live preset for source-room publishes", () => {
+    const smokeEnv = smokeEnvForPublishResult(
+      { NOTEBOOK_CLOUD_LIVE_PRESET: "html-output" },
+      {
+        viewerUrl: "https://preview.runt.run/n/live-source/source",
+        headsHash: "heads-notebook",
+        runtimeHeadsHash: "heads-runtime",
+        runtimeStateDocId: "runtime-state-doc",
+        preset: "source-notebook",
+      },
+    );
+
+    assert.equal(smokeEnv.NOTEBOOK_CLOUD_EXPECTED_SOURCE_TEXT, "html-output-origin-probe");
+    assert.equal(
+      smokeEnv.NOTEBOOK_CLOUD_EXPECTED_FRAME_TEXTS,
+      JSON.stringify(["Hello from HTML output document"]),
+    );
+    assert.equal(smokeEnv.NOTEBOOK_CLOUD_EXPECTED_PRESENCE_TITLE, "");
   });
 
   it("rejects publish results without exported snapshot heads unless expectations are explicit", () => {

--- a/apps/notebook-cloud/test/hosted-runtime-browser-execute-smoke.test.mjs
+++ b/apps/notebook-cloud/test/hosted-runtime-browser-execute-smoke.test.mjs
@@ -1,0 +1,77 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+
+import {
+  assertBrowserRunAdvanced,
+  browserRunSummary,
+  parseJsonOutput,
+  parseScopes,
+} from "../scripts/hosted-runtime-browser-execute-smoke.mjs";
+
+describe("hosted runtime/browser execute smoke helpers", () => {
+  it("parses default and explicit browser scopes", () => {
+    assert.deepEqual(parseScopes(undefined), ["owner", "editor"]);
+    assert.deepEqual(parseScopes("owner,editor"), ["owner", "editor"]);
+    assert.deepEqual(parseScopes("owner editor"), ["owner", "editor"]);
+    assert.deepEqual(parseScopes(" owner "), ["owner"]);
+  });
+
+  it("rejects unsupported scopes", () => {
+    assert.throws(() => parseScopes("viewer"), /owner or editor/);
+    assert.throws(() => parseScopes("owner,viewer"), /owner or editor/);
+  });
+
+  it("extracts JSON from child stdout with surrounding logs", () => {
+    assert.deepEqual(parseJsonOutput('{"ok":true}', "child"), { ok: true });
+    assert.deepEqual(parseJsonOutput('log before\n{"ok":true,"value":7}\nlog after', "child"), {
+      ok: true,
+      value: 7,
+    });
+  });
+
+  it("throws on child stdout without parseable JSON", () => {
+    assert.throws(() => parseJsonOutput("not json", "child"), /parseable JSON/);
+  });
+
+  it("summarizes browser execute results for reports", () => {
+    assert.deepEqual(
+      browserRunSummary(
+        {
+          click: {
+            clickedAria: "Run cell",
+            afterAria: "Run cell again; last execution 2",
+            beforeExecutionOrdinal: 1,
+            afterExecutionOrdinal: 2,
+          },
+          checks: ["execute_button_clicked"],
+        },
+        "owner",
+      ),
+      {
+        scope: "owner",
+        clickedAria: "Run cell",
+        afterAria: "Run cell again; last execution 2",
+        beforeExecutionOrdinal: 1,
+        afterExecutionOrdinal: 2,
+        checks: ["execute_button_clicked"],
+      },
+    );
+  });
+
+  it("requires browser execution to advance past the seeded runtime-peer run", () => {
+    assert.doesNotThrow(() =>
+      assertBrowserRunAdvanced({
+        scope: "owner",
+        afterExecutionOrdinal: 2,
+      }),
+    );
+    assert.throws(
+      () =>
+        assertBrowserRunAdvanced({
+          scope: "editor",
+          afterExecutionOrdinal: 1,
+        }),
+      /did not advance/,
+    );
+  });
+});

--- a/apps/notebook-cloud/test/smoke-paths.test.mjs
+++ b/apps/notebook-cloud/test/smoke-paths.test.mjs
@@ -1,0 +1,52 @@
+import assert from "node:assert/strict";
+import { mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { describe, it } from "node:test";
+
+import { saveSmokeScreenshot, smokeOutputPath } from "../scripts/smoke-paths.mjs";
+
+describe("notebook-cloud smoke paths", () => {
+  it("returns undefined for absent output paths", () => {
+    assert.equal(smokeOutputPath(undefined), undefined);
+    assert.equal(smokeOutputPath(""), undefined);
+  });
+
+  it("preserves absolute output paths", () => {
+    const absolute = path.join(os.tmpdir(), "notebook-cloud-smoke.png");
+    assert.equal(smokeOutputPath(absolute, { INIT_CWD: "/ignored" }), absolute);
+  });
+
+  it("resolves relative output paths against INIT_CWD when available", () => {
+    assert.equal(
+      smokeOutputPath(".context/smoke.png", { INIT_CWD: "/workspace" }),
+      path.resolve("/workspace", ".context/smoke.png"),
+    );
+  });
+
+  it("falls back to process.cwd() for relative output paths", () => {
+    assert.equal(smokeOutputPath(".context/smoke.png", {}), path.resolve(".context/smoke.png"));
+  });
+
+  it("creates screenshot parent directories before capture", async () => {
+    const root = await mkdtemp(path.join(os.tmpdir(), "notebook-cloud-smoke-"));
+    try {
+      const screenshotPath = path.join(root, "nested", "smoke.png");
+      let capturedPath = null;
+      await saveSmokeScreenshot(
+        {
+          async screenshot(options) {
+            capturedPath = options.path;
+            await writeFile(options.path, "captured");
+          },
+        },
+        screenshotPath,
+      );
+
+      assert.equal(capturedPath, screenshotPath);
+      assert.equal(await readFile(screenshotPath, "utf8"), "captured");
+    } finally {
+      await rm(root, { force: true, recursive: true });
+    }
+  });
+});

--- a/apps/notebook/src/renderer-plugins/plotly.js
+++ b/apps/notebook/src/renderer-plugins/plotly.js
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:2c550d0b2e91a4daeea0100463b783423017e9febae6a2b697d8a62cc7617f22
-size 4631336
+oid sha256:62d57f3d16b277223cde9407dbc1365580baa01af0db277011589b5b88f43546
+size 4631877

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "notebook:dev": "pnpm --dir apps/notebook dev",
     "test": "vp test",
     "test:run": "vp test run",
+    "test:bench": "vp test bench --run --dir apps/notebook/src/lib/__tests__",
     "test:e2e:browser": "pnpm --filter notebook-ui test:e2e:browser",
     "test:e2e:browser:portless": "pnpm --filter notebook-ui test:e2e:browser:portless",
     "test:e2e": "wdio run e2e/wdio.conf.js",

--- a/src/components/cell/__tests__/OutputArea.test.tsx
+++ b/src/components/cell/__tests__/OutputArea.test.tsx
@@ -538,7 +538,7 @@ describe("OutputArea iframe theme sync", () => {
     expect(frame.getAttribute("data-scroll-passthrough")).toBe("false");
   });
 
-  it("keeps interactive plugin iframe outputs on the wheel-boundary path", () => {
+  it("puts Plotly outputs on the click-to-engage path so the page wheels through the chart", () => {
     const plotlyOutput: JupyterOutput[] = [
       {
         output_id: "plotly-output",
@@ -549,14 +549,19 @@ describe("OutputArea iframe theme sync", () => {
     ];
 
     const { getByTestId } = render(<OutputArea outputs={plotlyOutput} isolated />);
+    const frame = getByTestId("isolated-frame");
+    const activationWell = frame.parentElement as HTMLElement;
 
-    expect(getByTestId("isolated-frame").getAttribute("data-scroll-passthrough")).toBe("false");
-    expect(getByTestId("isolated-frame").getAttribute("data-allow-wheel-boundary-scroll")).toBe(
-      "true",
-    );
-    expect(getByTestId("isolated-frame").getAttribute("data-forward-wheel-boundary-scroll")).toBe(
-      "true",
-    );
+    expect(frame.getAttribute("data-scroll-passthrough")).toBe("true");
+    expect(frame.getAttribute("data-allow-wheel-boundary-scroll")).toBe("false");
+    expect(frame.getAttribute("data-forward-wheel-boundary-scroll")).toBe("false");
+
+    fireEvent.pointerDown(activationWell);
+
+    expect(activationWell.getAttribute("data-frame-interaction-active")).toBe("true");
+    expect(frame.getAttribute("data-scroll-passthrough")).toBe("false");
+    expect(frame.getAttribute("data-allow-wheel-boundary-scroll")).toBe("false");
+    expect(frame.getAttribute("data-forward-wheel-boundary-scroll")).toBe("false");
   });
 
   it("puts parquet iframe outputs on scroll passthrough so the page wheels through sift", () => {

--- a/src/components/isolated/__tests__/output-lane-policy.test.ts
+++ b/src/components/isolated/__tests__/output-lane-policy.test.ts
@@ -9,6 +9,7 @@ import {
   hasWidgetOutputs,
   outputAllowsScrollPassthrough,
   outputSegmentLane,
+  outputUsesPlotly,
   outputUsesSift,
   outputUsesVega,
   outputUsesWheelOwningFrame,
@@ -146,9 +147,24 @@ describe("output lane policy", () => {
     ).toBe("dom");
   });
 
-  it("classifies interactive iframe outputs separately", () => {
+  it("routes Plotly charts onto standalone click-to-engage frames", () => {
+    const output = displayOutput("plotly-output", {
+      "application/vnd.plotly.v1+json": {},
+    });
+
+    expect(outputUsesPlotly(output)).toBe(true);
+    expect(outputUsesWheelOwningFrame(output)).toBe(true);
+    expect(outputAllowsScrollPassthrough(output)).toBe(true);
+    expect(outputSegmentLane(output)).toBe("plotly-frame");
+  });
+
+  it("classifies generic interactive iframe outputs separately", () => {
     expect(
-      outputSegmentLane(displayOutput("plotly-output", { "application/vnd.plotly.v1+json": {} })),
+      outputSegmentLane(
+        displayOutput("widget-output", {
+          "application/vnd.jupyter.widget-view+json": { model_id: "widget" },
+        }),
+      ),
     ).toBe("interactive-frame");
   });
 
@@ -164,9 +180,12 @@ describe("output lane policy", () => {
     expect(outputSegmentLane(output)).toBe("vega-frame");
   });
 
-  it("keeps Vega/Altair charts standalone instead of coalescing with sibling document outputs", () => {
+  it("keeps pan/zoom charts standalone instead of coalescing with sibling document outputs", () => {
     withMarkdownProjection("isolated");
     const markdown = displayOutput("markdown-1", { "text/markdown": "# heading" });
+    const plotly = displayOutput("plotly-1", {
+      "application/vnd.plotly.v1+json": { data: [] },
+    });
     const vegaOne = displayOutput("vega-1", {
       "application/vnd.vegalite.v5+json": { mark: "circle" },
     });
@@ -174,11 +193,17 @@ describe("output lane policy", () => {
       "application/vnd.vega.v5+json": { mark: "bar" },
     });
 
-    const segments = splitOutputSegments([markdown, vegaOne, vegaTwo]);
+    const segments = splitOutputSegments([markdown, plotly, vegaOne, vegaTwo]);
 
-    expect(segments.map((segment) => segment.lane)).toEqual(["dom", "vega-frame", "vega-frame"]);
+    expect(segments.map((segment) => segment.lane)).toEqual([
+      "dom",
+      "plotly-frame",
+      "vega-frame",
+      "vega-frame",
+    ]);
     expect(segments.map((segment) => segment.outputs.map((output) => output.output_id))).toEqual([
       ["markdown-1"],
+      ["plotly-1"],
       ["vega-1"],
       ["vega-2"],
     ]);

--- a/src/components/isolated/output-lane-policy.ts
+++ b/src/components/isolated/output-lane-policy.ts
@@ -9,7 +9,13 @@ import {
   projectMarkdownPlan,
 } from "../../lib/markdown-projection";
 
-export type OutputLane = "dom" | "static-frame" | "interactive-frame" | "sift-frame" | "vega-frame";
+export type OutputLane =
+  | "dom"
+  | "static-frame"
+  | "interactive-frame"
+  | "sift-frame"
+  | "vega-frame"
+  | "plotly-frame";
 
 export interface OutputSegment {
   lane: OutputLane;
@@ -33,6 +39,10 @@ const SCROLL_PASSTHROUGH_MIME_TYPES = new Set([
   "application/vnd.apache.parquet",
   "application/vnd.apache.arrow.stream",
   "application/vnd.nteract.arrow-stream-manifest+json",
+  // Plotly figures often contain pan/zoom surfaces. Let notebook scrolling
+  // pass through by default, then hand pointer/wheel ownership to the iframe
+  // after an explicit click.
+  "application/vnd.plotly.v1+json",
 ]);
 
 const SIFT_MIME_TYPES = new Set([
@@ -88,17 +98,29 @@ export function outputUsesVega(
   return mimeType !== null && isVegaMimeType(mimeType);
 }
 
+export function outputUsesPlotly(
+  output: JupyterOutput,
+  priority: readonly string[] = DEFAULT_PRIORITY,
+): boolean {
+  const mimeType = selectedOutputMimeType(output, priority);
+  return mimeType === "application/vnd.plotly.v1+json";
+}
+
 /**
  * Outputs whose iframe must own the wheel once the user engages it: Sift's
- * crossfilter tables scroll internally, Vega/Altair charts pan and zoom. While
- * engaged the wheel-boundary forwarding is locked so the page does not steal
- * the gesture (the source of unintended Altair zoom-while-scrolling).
+ * crossfilter tables scroll internally, and chart surfaces like Vega/Altair
+ * and Plotly pan or zoom. While engaged the wheel-boundary forwarding is
+ * locked so the page does not steal the gesture.
  */
 export function outputUsesWheelOwningFrame(
   output: JupyterOutput,
   priority: readonly string[] = DEFAULT_PRIORITY,
 ): boolean {
-  return outputUsesSift(output, priority) || outputUsesVega(output, priority);
+  return (
+    outputUsesSift(output, priority) ||
+    outputUsesVega(output, priority) ||
+    outputUsesPlotly(output, priority)
+  );
 }
 
 export function outputUsesWidget(
@@ -161,15 +183,16 @@ export function outputSegmentLane(
   if (!outputNeedsIsolation(output, priority)) return "dom";
   if (outputUsesSift(output, priority)) return "sift-frame";
   if (outputUsesVega(output, priority)) return "vega-frame";
+  if (outputUsesPlotly(output, priority)) return "plotly-frame";
   if (outputAllowsScrollPassthrough(output, priority)) return "static-frame";
   return "interactive-frame";
 }
 
 function laneStandsAlone(lane: OutputLane): boolean {
-  // Sift tables and Vega/Altair charts each own their wheel once engaged, so
-  // they must never coalesce with neighbors: a shared iframe would lock the
-  // wheel boundary over sibling document outputs too.
-  return lane === "sift-frame" || lane === "vega-frame";
+  // Wheel-owning interactive outputs must never coalesce with neighbors:
+  // a shared iframe would lock the wheel boundary over sibling document
+  // outputs too.
+  return lane === "sift-frame" || lane === "vega-frame" || lane === "plotly-frame";
 }
 
 export function splitOutputSegments(

--- a/src/isolated-renderer/__tests__/plotly-renderer.test.tsx
+++ b/src/isolated-renderer/__tests__/plotly-renderer.test.tsx
@@ -48,6 +48,7 @@ describe("Plotly renderer plugin", () => {
   afterEach(() => {
     cleanup();
     vi.clearAllMocks();
+    vi.unstubAllGlobals();
   });
 
   it("uses Plotly.react for display updates instead of remounting the chart", () => {
@@ -133,5 +134,28 @@ describe("Plotly renderer plugin", () => {
     expect(plotlyMocks.newPlot).toHaveBeenCalledTimes(1);
     expect(plotlyMocks.react).toHaveBeenCalledTimes(1);
     expect(plotlyMocks.react.mock.calls[0][1].data).toEqual(nextFigure.data);
+  });
+
+  it("requests a host resize after Plotly completes its async render", async () => {
+    const Renderer = installPlotlyRenderer();
+    const postMessage = vi.spyOn(window.parent, "postMessage").mockImplementation(() => {});
+    vi.stubGlobal("requestAnimationFrame", (callback: FrameRequestCallback) => {
+      callback(0);
+      return 0;
+    });
+
+    plotlyMocks.newPlot.mockReturnValueOnce(Promise.resolve());
+
+    render(<Renderer data={firstFigure} mimeType="application/vnd.plotly.v1+json" />);
+    await Promise.resolve();
+    await Promise.resolve();
+
+    expect(postMessage).toHaveBeenCalledWith(
+      {
+        type: "resize",
+        payload: { height: expect.any(Number) },
+      },
+      "*",
+    );
   });
 });

--- a/src/isolated-renderer/plotly-renderer.tsx
+++ b/src/isolated-renderer/plotly-renderer.tsx
@@ -9,6 +9,7 @@
 import Plotly from "plotly.js-dist-min";
 import { useCallback, useEffect, useMemo, useRef } from "react";
 import { cn } from "@/lib/utils";
+import { measureDocumentHeight } from "./layout-measure";
 
 // --- Theme helpers ---
 
@@ -67,6 +68,23 @@ interface RendererProps {
 }
 
 const DEFAULT_UI_REVISION = "nteract-display-update";
+
+function requestHostResize(): void {
+  const height = measureDocumentHeight();
+  window.parent.postMessage(
+    {
+      type: "resize",
+      payload: { height },
+    },
+    "*",
+  );
+}
+
+function scheduleHostResize(): void {
+  requestAnimationFrame(() => {
+    requestAnimationFrame(requestHostResize);
+  });
+}
 
 // --- PlotlyRenderer component ---
 
@@ -146,12 +164,11 @@ function PlotlyRenderer({ data: rawData }: RendererProps) {
       frames: data.frames as Plotly.Frame[],
     };
 
-    if (plottedElementRef.current === el) {
-      Plotly.react(el, figure);
-    } else {
-      Plotly.newPlot(el, figure);
-      plottedElementRef.current = el;
-    }
+    const plotPromise =
+      plottedElementRef.current === el ? Plotly.react(el, figure) : Plotly.newPlot(el, figure);
+    plottedElementRef.current = el;
+
+    void Promise.resolve(plotPromise).then(scheduleHostResize, scheduleHostResize);
   }, [data, userLayout]);
 
   useEffect(() => {

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,6 +1,9 @@
 import { defineConfig, type Plugin } from "vite-plus";
+import { configDefaults } from "vitest/config";
 import path from "path";
 import { rawLibPlugin } from "./apps/notebook/vite-plugin-raw-lib";
+
+const ignoredDiagnosticWorkspaces = [".context/**", "**/.context/**"];
 
 /** Stub virtual:renderer-plugin/* modules for tests (real builds use the Vite plugin). */
 function rendererPluginStub(): Plugin {
@@ -50,8 +53,12 @@ export default defineConfig({
       "packages/**/tests/**/*.test.{ts,tsx}",
       "plugins/nteract/pi/**/*.test.{ts,tsx}",
     ],
+    exclude: [...configDefaults.exclude, ...ignoredDiagnosticWorkspaces],
     globals: true,
     setupFiles: ["./src/test-setup.ts"],
+  },
+  benchmark: {
+    exclude: [...configDefaults.exclude, ...ignoredDiagnosticWorkspaces],
   },
   resolve: {
     alias: {


### PR DESCRIPTION
## Summary
- collect Arrow stream manifest pointer blobs and expand their nested child chunk refs during `publish:live` uploads
- retry transient hosted blob fetch misses so blob/materialization races do not permanently fail outputs
- add stricter live-room smoke diagnostics plus catalog matrix tooling for old hosted notebooks
- harden browser-execution smoke so a click must advance the run button execution ordinal, not merely observe stale output text
- add `smoke:hosted:runtime-browser-execute`, a one-command preview smoke that creates fresh runtime-peer rooms for owner/editor scopes, clicks execution through Chromium, and stops each peer it starts
- make Plotly isolated output frames click-to-engage so notebook scrolling passes through charts until explicit interaction, then request a host resize after Plotly finishes async render
- accept npm/pnpm `--` separators in hosted smoke URL arguments
- add root `test:bench` / CI benchmark discovery that avoids copied PR-review worktrees under `.context/`
- normalize hosted smoke screenshot paths so `.context/...` artifacts land under the caller workspace when scripts run via `pnpm --dir`
- align live publish/source-room smoke expectations with the actual published catalog owner, latest revision actor, and live fixture preset instead of hard-coded topic-viz defaults

## Preview verification
- deployed preview.runt.run after the Plotly/frame update
  - renderer-assets worker version `e2f7f7e8-5a58-4fcb-89a4-8783c61ca342`
  - main worker version `2d5c5295-7222-4e99-a777-9adf50e8a4bc`
- original topic-viz loads and renders: https://preview.runt.run/n/topic-viz/topic-viz
  - hosted render smoke passed
  - strict live-room smoke passed: 23 cells, 8 visible iframes, 3 loaded images, 17 blob responses all 200, open websocket
  - exact npm separator form passed: `pnpm run smoke:hosted:live-room -- https://preview.runt.run/n/topic-viz/topic-viz`
- fresh topic-viz rerun from remote compute loads and renders: https://preview.runt.run/n/01KTGV6DV0099C3JBEP2SN54DB/topic-viz-rerun
  - strict live-room smoke passed: 24 cells, 9 visible iframes, 3 loaded images, 33 blob responses all 200, open websocket
- runtime/browser execute composite passed with fresh owner/editor rooms
  - owner: https://preview.runt.run/n/01KTH16DG5B72EZQZYPMJYASGH/lab2-dualpeer (`last execution 2`)
  - editor: https://preview.runt.run/n/01KTH174G3ZV8VGH3P9SYVX8EW/lab2-dualpeer (`last execution 2`)
- source-room smoke passed after latest commit, publishing an existing local live notebook room to preview and then rendering it from the hosted snapshot catalog
  - generated source notebook: `a31020ab-f845-48ad-a7ef-87f92369993f`
  - published notebook: https://preview.runt.run/n/01KTH2H0VHEX5BWJYHMJNKEA7R/notebook
  - preset: `mathnet`, 3 cells, 5 blobs, catalog owner/actor/head assertions pinned to the publish result
  - log: `.context/preview-smoke/source-room-fixed-source-text-20260607T124314Z.log`
- final strict mixed live-room matrix passed from this branch against preview
  - original topic-viz: 23 cells, 8 visible iframes, 3 images, 17 blob responses, 1 active websocket
  - topic-viz rerun: 24 cells, 9 visible iframes, 3 images, 33 blob responses, 1 active websocket
  - runtime browser editor room: 2 cells, 1 active websocket
  - source-room mathnet publish: 3 cells, 2 visible iframes, 11 blob responses, 1 active websocket
  - screenshots: `.context/preview-smoke/final-matrix-20260607T1305Z/`

## Checks
- `cargo xtask artifacts ensure sift,renderer`
- `cargo build --release -p runtimed -p runt-cloud-peer`
- `pnpm --dir apps/notebook-cloud run typecheck`
- `pnpm exec node --import tsx --test test/blob-refs.test.ts test/blob-resolver.test.ts test/cli-args.test.mjs test/hosted-live-room-matrix.test.mjs test/hosted-runtime-browser-execute-smoke.test.mjs`
- `pnpm test:run src/components/cell/__tests__/OutputArea.test.tsx src/components/isolated/__tests__/output-lane-policy.test.ts src/isolated-renderer/__tests__/plotly-renderer.test.tsx`
- `pnpm exec vp test run`
- `pnpm --filter @nteract/sift test`
- `pnpm test:bench`
- `node --test apps/notebook-cloud/test/smoke-paths.test.mjs apps/notebook-cloud/test/cli-args.test.mjs`
- `node --test apps/notebook-cloud/test/hosted-live-smoke-env.test.mjs apps/notebook-cloud/test/hosted-smoke-catalog.test.mjs apps/notebook-cloud/test/smoke-paths.test.mjs apps/notebook-cloud/test/cli-args.test.mjs`
- `node --check apps/notebook-cloud/scripts/publish-live.mjs && node --check apps/notebook-cloud/scripts/hosted-live-smoke-env.mjs && node --check apps/notebook-cloud/scripts/hosted-live-smoke.mjs && node --check apps/notebook-cloud/scripts/hosted-source-room-smoke.mjs`
- `cargo xtask lint --fix`
- `pnpm --dir apps/notebook-cloud run deploy`
- `pnpm --dir apps/notebook-cloud run deploy:check`
- `pnpm --dir apps/notebook-cloud smoke:hosted:runtime-peer` with `NOTEBOOK_CLOUD_KEEP_RUNTIME_PEER=1`
- `pnpm --dir apps/notebook-cloud smoke:hosted:browser-execute` on the kept-alive runtime-peer room with owner and editor scopes
- `pnpm --dir apps/notebook-cloud smoke:hosted:runtime-browser-execute` with owner/editor default scopes
- strict hosted/live-room smokes on original topic-viz and fresh topic-viz rerun
- catalog matrix smoke with `/api/n?limit=2`
- source-room smoke against preview with `RUNTIMED_DEV=1 RUNTIMED_WORKSPACE_PATH=/home/ubuntu/codex/nteract NOTEBOOK_CLOUD_LIVE_PRESET=mathnet NOTEBOOK_CLOUD_SOURCE_ROOM_SMOKE_TIMEOUT_MS=900000 pnpm --dir apps/notebook-cloud run smoke:hosted:source-room`
- strict final mixed matrix against preview with explicit topic-viz, rerun, runtime editor, and source-room entries

## Notes
- Catalog matrix defaults are intentionally permissive for broad sweeps; use explicit JSON entries for strict image/blob/frame expectations.
- Local benchmark discovery can include stale `.context/pr-review-workspaces` when benchmark paths are passed as broad positional filters; use `pnpm test:bench`, which scans `apps/notebook/src/lib/__tests__` with `--dir`.
- `pr-review doctor` still fails on this box because AWS Bedrock credentials refresh as expired; no repo-local reviewer result is attached.
