### PR TITLE
feat(markdown): refine document typography

### DIFF
--- a/apps/elements/app/global.css
+++ b/apps/elements/app/global.css
@@ -10,6 +10,7 @@
 @source "../../../src/components/cell/**/*.{ts,tsx}";
 @source "../../../src/components/editor/**/*.{ts,tsx}";
 @source "../../../src/components/isolated/**/*.{ts,tsx}";
+@source "../../../src/components/markdown/**/*.{ts,tsx}";
 @source "../../../src/components/notebook-rail/**/*.{ts,tsx}";
 @source "../../../src/components/notebook/**/*.{ts,tsx}";
 @source "../../../src/components/outputs/**/*.{ts,tsx}";

--- a/apps/elements/components/markdown-typography-example.tsx
+++ b/apps/elements/components/markdown-typography-example.tsx
@@ -1,0 +1,286 @@
+"use client";
+
+import { BookOpenText, Link2, Pilcrow, Table2 } from "lucide-react";
+import { useCallback } from "react";
+import { ProjectedMarkdownView } from "@/components/markdown/ProjectedMarkdownView";
+import type {
+  MarkdownProjectionBlock,
+  MarkdownProjectionPlan,
+  MarkdownProjectionRun,
+} from "../../../src/lib/markdown-projection";
+import { NotebookPaletteToggle } from "./notebook-palette-toggle";
+
+const measurement = { estimatedHeight: 36, confidence: "high", width: 760 } as const;
+const emptySpan = [0, 0] as const;
+
+function block(
+  blockIndex: number,
+  blockId: string,
+  kind: MarkdownProjectionBlock["kind"],
+  element: string,
+  text: string,
+  overrides: Partial<MarkdownProjectionBlock> = {},
+): MarkdownProjectionBlock {
+  return {
+    blockId,
+    blockIndex,
+    element,
+    kind,
+    measurement,
+    sourceSpanByte: emptySpan,
+    sourceSpanUtf16: emptySpan,
+    syntaxSpans: [],
+    text,
+    ...overrides,
+  };
+}
+
+function run(
+  blockId: string,
+  inlineId: string,
+  renderedText: string,
+  overrides: Partial<MarkdownProjectionRun> = {},
+): MarkdownProjectionRun {
+  return {
+    blockId,
+    inlineId,
+    listItemIndex: null,
+    renderedText,
+    renderedTextUtf16: [0, renderedText.length],
+    semantic: "text",
+    sourceSpanByte: emptySpan,
+    sourceSpanUtf16: emptySpan,
+    ...overrides,
+  };
+}
+
+const markdownPlan: MarkdownProjectionPlan = {
+  version: 1,
+  engine: "elements-fixture",
+  byteLength: 0,
+  utf16Length: 0,
+  measurement: { estimatedHeight: 720, confidence: "high", width: 760 },
+  anchors: [
+    {
+      anchorId: "elements-markdown-claim",
+      blockId: "claim",
+      level: 2,
+      slug: "claim",
+      sourceSpanByte: emptySpan,
+      sourceSpanUtf16: emptySpan,
+      title: "Claim",
+    },
+  ],
+  blocks: [
+    block(0, "title", "heading", "h1", "Discrete diffusion notebook"),
+    block(
+      1,
+      "lead",
+      "paragraph",
+      "p",
+      "A compact research note that links sources, states a model, and keeps code close to the claim.",
+    ),
+    block(2, "claim", "heading", "h2", "Claim", { anchorSlug: "claim" }),
+    block(
+      3,
+      "claim-body",
+      "blockquote",
+      "blockquote",
+      "Local perturbations preserve topic topology when the denoising schedule is bounded.",
+    ),
+    block(4, "evidence", "heading", "h2", "Evidence table"),
+    block(5, "table", "table", "table", "metric baseline candidate delta"),
+    block(6, "checklist-heading", "heading", "h2", "Experiment checklist"),
+    block(7, "checklist", "list", "ul", "tasks"),
+    block(8, "math", "math", "div", "\\mathbb{E}[L_t] \\leq \\epsilon + \\lambda\\|A_t-A_0\\|_2"),
+    block(
+      9,
+      "code",
+      "code",
+      "pre",
+      "from topicdiff import schedule\nschedule.fit(k=8, prior='sparse')",
+      {
+        codeLanguage: "python",
+      },
+    ),
+    block(
+      10,
+      "closing",
+      "paragraph",
+      "p",
+      "The rendered markdown should feel like a paper margin and a runnable lab bench at the same time.",
+    ),
+  ],
+  runs: [
+    run("title", "title-text", "Discrete diffusion notebook"),
+    run("lead", "lead-0", "A compact research note that links "),
+    run("lead", "lead-link", "source material", {
+      href: "https://example.com/source-material",
+      title: "Source material",
+    }),
+    run("lead", "lead-1", ", states a "),
+    run("lead", "lead-code", "latent transition model", { semantic: "inline-code" }),
+    run("lead", "lead-2", ", and keeps code close to the claim."),
+    run("claim", "claim-text", "Claim"),
+    run("claim-body", "claim-body-text", "Local perturbations preserve topic topology when the "),
+    run("claim-body", "claim-body-strong", "denoising schedule", { semantic: "strong" }),
+    run("claim-body", "claim-body-tail", " is bounded."),
+    run("evidence", "evidence-text", "Evidence table"),
+    run("table", "table-h0", "metric", {
+      tableCellHeader: true,
+      tableCellIndex: 0,
+      tableRowIndex: 0,
+    }),
+    run("table", "table-h1", "baseline", {
+      tableCellHeader: true,
+      tableCellIndex: 1,
+      tableRowIndex: 0,
+    }),
+    run("table", "table-h2", "candidate", {
+      tableCellHeader: true,
+      tableCellIndex: 2,
+      tableRowIndex: 0,
+    }),
+    run("table", "table-r1c0", "topic stability", { tableCellIndex: 0, tableRowIndex: 1 }),
+    run("table", "table-r1c1", "0.72", {
+      tableCellAlign: "right",
+      tableCellIndex: 1,
+      tableRowIndex: 1,
+    }),
+    run("table", "table-r1c2", "0.84", {
+      tableCellAlign: "right",
+      tableCellIndex: 2,
+      tableRowIndex: 1,
+    }),
+    run("table", "table-r2c0", "review latency", { tableCellIndex: 0, tableRowIndex: 2 }),
+    run("table", "table-r2c1", "18m", {
+      tableCellAlign: "right",
+      tableCellIndex: 1,
+      tableRowIndex: 2,
+    }),
+    run("table", "table-r2c2", "11m", {
+      tableCellAlign: "right",
+      tableCellIndex: 2,
+      tableRowIndex: 2,
+    }),
+    run("checklist-heading", "checklist-heading-text", "Experiment checklist"),
+    run("checklist", "task-0", "Reproduce the baseline paper", {
+      listItemChecked: true,
+      listItemIndex: 0,
+      listItemPath: "0",
+      semantic: "list-item",
+    }),
+    run("checklist", "task-1a", "Compare against the ", {
+      listItemChecked: false,
+      listItemIndex: 1,
+      listItemPath: "1",
+      semantic: "list-item",
+    }),
+    run("checklist", "task-1b", "interactive notebook", {
+      href: "https://example.com/notebook",
+      listItemIndex: 1,
+      listItemPath: "1",
+      semantic: "list-item",
+    }),
+    run("checklist", "task-2", "Promote surprising failures into follow-up cells", {
+      listItemIndex: 2,
+      listItemPath: "2",
+      semantic: "list-item",
+    }),
+    run("math", "math-source", "\\mathbb{E}[L_t] \\leq \\epsilon + \\lambda\\|A_t-A_0\\|_2", {
+      semantic: "math-source",
+    }),
+    run("closing", "closing-text", "The rendered markdown should feel like a "),
+    run("closing", "closing-em", "paper margin", { semantic: "emphasis" }),
+    run("closing", "closing-tail", " and a runnable lab bench at the same time."),
+  ],
+};
+
+const auditRows = [
+  {
+    icon: Link2,
+    label: "Link affordance",
+    detail: "Always visible underline, stronger decoration on hover and focus.",
+  },
+  {
+    icon: Pilcrow,
+    label: "Document rhythm",
+    detail: "Section spacing, subdued list markers, and legible paragraph measure.",
+  },
+  {
+    icon: Table2,
+    label: "Dense evidence",
+    detail: "Tables use notebook tokens without becoming heavy spreadsheet chrome.",
+  },
+  {
+    icon: BookOpenText,
+    label: "Research voice",
+    detail: "Cream switches markdown to the serif document font used by output frames.",
+  },
+];
+
+export function MarkdownTypographyExample() {
+  const handleLinkClick = useCallback((url: string) => {
+    window.open(url, "_blank", "noopener,noreferrer");
+  }, []);
+
+  return (
+    <div className="not-prose space-y-6" data-elements-slot="markdown-typography">
+      <div className="flex flex-wrap items-center justify-between gap-3">
+        <div>
+          <h2 className="text-sm font-semibold text-fd-foreground">Markdown document surface</h2>
+          <p className="mt-1 text-xs leading-5 text-fd-muted-foreground">
+            Production projected markdown rendered with a dense notebook-style fixture.
+          </p>
+        </div>
+        <NotebookPaletteToggle />
+      </div>
+
+      <section className="grid gap-4 min-[1500px]:grid-cols-[minmax(0,1fr)_320px]">
+        <article className="min-w-0 border border-border bg-background px-7 py-6 text-foreground shadow-sm max-sm:pr-5 max-sm:pl-14">
+          <ProjectedMarkdownView plan={markdownPlan} onLinkClick={handleLinkClick} />
+        </article>
+
+        <aside className="grid content-start gap-3 border border-border bg-muted/20 p-4 text-foreground">
+          {auditRows.map((row) => {
+            const Icon = row.icon;
+            return (
+              <div key={row.label} className="grid grid-cols-[auto_minmax(0,1fr)] gap-3">
+                <Icon className="mt-0.5 size-4 text-muted-foreground" aria-hidden="true" />
+                <div className="min-w-0">
+                  <div className="text-sm font-semibold">{row.label}</div>
+                  <div className="mt-1 text-xs leading-5 text-muted-foreground">{row.detail}</div>
+                </div>
+              </div>
+            );
+          })}
+        </aside>
+      </section>
+
+      <section className="grid gap-4 min-[1500px]:grid-cols-2">
+        <article
+          className="min-w-0 border border-border bg-background px-6 py-5 text-foreground max-sm:pr-5 max-sm:pl-14"
+          data-color-theme="classic"
+        >
+          <div className="mb-3 font-mono text-[11px] text-muted-foreground">classic tokens</div>
+          <ProjectedMarkdownView
+            colorTheme="classic"
+            plan={markdownPlan}
+            onLinkClick={handleLinkClick}
+          />
+        </article>
+        <article
+          className="min-w-0 border border-border bg-background px-6 py-5 text-foreground max-sm:pr-5 max-sm:pl-14"
+          data-color-theme="cream"
+        >
+          <div className="mb-3 font-mono text-[11px] text-muted-foreground">cream tokens</div>
+          <ProjectedMarkdownView
+            colorTheme="cream"
+            plan={markdownPlan}
+            onLinkClick={handleLinkClick}
+          />
+        </article>
+      </section>
+    </div>
+  );
+}

--- a/apps/elements/content/docs/index.mdx
+++ b/apps/elements/content/docs/index.mdx
@@ -46,6 +46,7 @@ concepts and which boundaries still need a notebook-semantic wrapper.
 - [Editor surfaces](/docs/editor-surfaces)
 - [Runtime surfaces](/docs/runtime-surfaces)
 - [Search surfaces](/docs/search-surfaces)
+- [Markdown typography](/docs/markdown-typography)
 - [Output renderers](/docs/output-renderers)
 - [Output isolation surfaces](/docs/isolated-output-surfaces)
 - [Read-only notebook surfaces](/docs/read-only-notebook-surfaces)

--- a/apps/elements/content/docs/markdown-typography.mdx
+++ b/apps/elements/content/docs/markdown-typography.mdx
@@ -1,0 +1,27 @@
+---
+title: Markdown typography
+description: Visual fixtures for notebook markdown cells and markdown-rich documents.
+---
+
+import { MarkdownTypographyExample } from "@/components/markdown-typography-example";
+
+Markdown should read like an interactive research document: links need visible
+affordance before hover, tables need density without spreadsheet noise, and the
+document font should carry enough authority for proofs, notes, and experiment
+logs.
+
+<MarkdownTypographyExample />
+
+## What is real here
+
+This page renders the production `ProjectedMarkdownView` from
+`src/components/markdown/ProjectedMarkdownView.tsx` with the same projected plan
+shape that notebook markdown cells receive from the markdown engine. Link,
+heading, table, task list, math, inline code, and fenced-code styling all come
+from the shared markdown component path.
+
+## Boundary
+
+The page does not boot a notebook document, daemon, markdown WASM projector, or
+isolated renderer iframe. It owns deterministic fixture projection data so the
+visual surface can be reviewed quickly in Elements.

--- a/apps/elements/tsconfig.json
+++ b/apps/elements/tsconfig.json
@@ -17,6 +17,7 @@
         "./components/isolated/iframe-libraries.ts"
       ],
       "@/components/isolated/*": ["../../src/components/isolated/*"],
+      "@/components/markdown/*": ["../../src/components/markdown/*"],
       "@/components/notebook": ["../../src/components/notebook/index.ts"],
       "@/components/notebook/*": ["../../src/components/notebook/*"],
       "@/components/notebook-rail": ["../../src/components/notebook-rail/index.ts"],

--- a/src/components/isolated/frame.html
+++ b/src/components/isolated/frame.html
@@ -37,6 +37,7 @@
         --text-secondary: #666666;
         --border-color: #e0e0e0;
         --accent-color: #3b82f6;
+        --link-underline-color: color-mix(in oklch, var(--accent-color) 55%, transparent);
         --error-color: #ef4444;
         --success-color: #22c55e;
         --color-background-primary: var(--bg-primary);
@@ -62,6 +63,7 @@
         --text-secondary: #a0a0a0;
         --border-color: #333333;
         --accent-color: #60a5fa;
+        --link-underline-color: color-mix(in oklch, var(--accent-color) 60%, transparent);
       }
 
       [data-color-theme="cream"] {
@@ -237,11 +239,15 @@
       /* Links */
       a {
         color: var(--accent-color);
-        text-decoration: none;
+        font-weight: 500;
+        text-decoration-line: underline;
+        text-decoration-color: var(--link-underline-color);
+        text-decoration-thickness: 1px;
+        text-underline-offset: 0.22em;
       }
 
       a:hover {
-        text-decoration: underline;
+        text-decoration-color: currentColor;
       }
 
       /* Error styling */

--- a/src/components/markdown/ProjectedMarkdownView.tsx
+++ b/src/components/markdown/ProjectedMarkdownView.tsx
@@ -12,6 +12,14 @@ import { useColorTheme, useDarkMode } from "@/lib/dark-mode";
 import { katexStrict } from "@/lib/katex-options";
 import { cn } from "@/lib/utils";
 import type { MarkdownHeadingAnchor } from "@/components/outputs/markdown-heading-anchors";
+import {
+  markdownBlockquoteClassName,
+  markdownDocumentClassName,
+  markdownHeadingClassName,
+  markdownInlineCodeClassName,
+  markdownLinkClassName,
+  markdownListMarkerClassName,
+} from "./markdown-typography";
 
 import "katex/dist/katex.min.css";
 
@@ -19,6 +27,7 @@ interface ProjectedMarkdownViewProps {
   plan: MarkdownProjectionPlan;
   className?: string;
   activeSourcePosition?: number;
+  colorTheme?: "classic" | "cream";
   headingAnchors?: readonly MarkdownHeadingAnchor[];
   onLinkClick?: (url: string) => void;
   onTaskCheckedChange?: (run: MarkdownProjectionRun, checked: boolean) => void;
@@ -28,13 +37,14 @@ export function ProjectedMarkdownView({
   plan,
   className,
   activeSourcePosition,
+  colorTheme: colorThemeOverride,
   headingAnchors = [],
   onLinkClick,
   onTaskCheckedChange,
 }: ProjectedMarkdownViewProps) {
   const isDark = useDarkMode();
   const rawTheme = useColorTheme();
-  const colorTheme = (rawTheme === "cream" ? "cream" : "classic") as "classic" | "cream";
+  const colorTheme = colorThemeOverride ?? (rawTheme === "cream" ? "cream" : "classic");
   const runsByBlock = new Map<string, MarkdownProjectionRun[]>();
   for (const run of plan.runs) {
     const runs = runsByBlock.get(run.blockId);
@@ -52,13 +62,7 @@ export function ProjectedMarkdownView({
   const activeInlineId = sourceMatch?.run?.inlineId;
 
   return (
-    <div
-      data-slot="projected-markdown-output"
-      className={cn(
-        "not-prose select-text py-2 text-base leading-[1.65] text-foreground font-[var(--output-document-font)] [font-kerning:normal] [text-rendering:optimizeLegibility] [&>*:first-child]:mt-0 [&>*:last-child]:mb-0 [&_kbd]:rounded-sm [&_kbd]:border [&_kbd]:border-border [&_kbd]:bg-muted/60 [&_kbd]:px-1.5 [&_kbd]:py-0.5 [&_kbd]:font-[var(--output-ui-font)] [&_kbd]:text-[0.82em] [&_mark]:rounded-sm [&_mark]:bg-amber-200/70 [&_mark]:px-1 dark:[&_mark]:bg-amber-500/25 [&_sub]:text-[0.75em] [&_sup]:text-[0.75em]",
-        className,
-      )}
-    >
+    <div data-slot="projected-markdown-output" className={cn(markdownDocumentClassName, className)}>
       {plan.blocks.map((block) => (
         <ProjectedMarkdownBlock
           key={block.blockId}
@@ -109,7 +113,7 @@ function ProjectedMarkdownBlock({
         data-nteract-outline-item-id={headingAnchor?.itemId}
         data-source-active={activeBlockId === block.blockId ? "true" : undefined}
         className={cn(
-          headingClass(block.element),
+          markdownHeadingClassName(block.element),
           activeBlockId === block.blockId && sourceActiveBlockClass,
         )}
       >
@@ -165,7 +169,7 @@ function ProjectedMarkdownBlock({
       <blockquote
         data-source-active={activeBlockId === block.blockId ? "true" : undefined}
         className={cn(
-          "my-4 border-l-4 border-border pl-4 text-muted-foreground italic",
+          markdownBlockquoteClassName,
           activeBlockId === block.blockId && sourceActiveBlockClass,
         )}
       >
@@ -242,15 +246,6 @@ function headingTag(element: string): "h1" | "h2" | "h3" | "h4" | "h5" | "h6" {
   return "h6";
 }
 
-function headingClass(element: string) {
-  if (element === "h1") return "mt-6 mb-4 text-[1.875rem] leading-tight font-bold";
-  if (element === "h2") return "mt-[1.35rem] mb-3 text-2xl leading-tight font-bold";
-  if (element === "h3") return "mt-[1.2rem] mb-2.5 text-xl leading-tight font-semibold";
-  if (element === "h4") return "mt-4 mb-2 text-lg leading-tight font-semibold";
-  if (element === "h5") return "mt-3.5 mb-1.5 text-base leading-tight font-semibold";
-  return "mt-3 mb-1.5 text-sm leading-tight font-semibold text-muted-foreground";
-}
-
 interface ProjectedListItem {
   checked?: boolean;
   children: ProjectedListItem[];
@@ -284,6 +279,7 @@ function ProjectedList({
       className={cn(
         "my-3 ml-6 leading-relaxed",
         ordered ? "list-decimal" : "list-disc",
+        markdownListMarkerClassName,
         allItemsAreTasks && "ml-0 list-none",
         activeBlock && sourceActiveBlockClass,
       )}
@@ -669,7 +665,7 @@ function renderRun(run: MarkdownProjectionRun, onLinkClick?: (url: string) => vo
       <a
         href={run.href}
         title={run.title}
-        className="text-primary underline-offset-2 hover:underline"
+        className={markdownLinkClassName}
         onClick={(event) => {
           event.preventDefault();
           onLinkClick?.(run.href ?? "");
@@ -832,14 +828,5 @@ function renderLatex(latex: string, displayMode: boolean): string | null {
 }
 
 function InlineCode({ children, className }: { children: string; className?: string }) {
-  return (
-    <code
-      className={cn(
-        "rounded-sm bg-muted/75 px-1.5 py-0.5 font-mono text-[0.9em] text-foreground",
-        className,
-      )}
-    >
-      {children}
-    </code>
-  );
+  return <code className={cn(markdownInlineCodeClassName, className)}>{children}</code>;
 }

--- a/src/components/markdown/__tests__/ProjectedMarkdownView.test.tsx
+++ b/src/components/markdown/__tests__/ProjectedMarkdownView.test.tsx
@@ -254,11 +254,52 @@ describe("ProjectedMarkdownView", () => {
     expect(screen.getByText("First paragraph")).toHaveClass("my-3", "leading-relaxed");
     expect(screen.getByRole("list")).toHaveClass("my-3", "ml-6", "list-disc");
     expect(screen.getByText("quoted").closest("blockquote")).toHaveClass(
-      "border-l-4",
-      "border-border",
+      "border-l-[3px]",
+      "border-primary/30",
       "text-muted-foreground",
     );
     expect(screen.getByText("quoted").closest("blockquote")).not.toHaveClass("bg-muted/[0.22]");
+  });
+
+  it("renders links with visible affordance before hover", () => {
+    render(
+      <ProjectedMarkdownView
+        plan={plan({
+          blocks: [
+            {
+              blockId: "p0",
+              blockIndex: 0,
+              element: "p",
+              kind: "paragraph",
+              measurement: { estimatedHeight: 32, confidence: "high", width: 720 },
+              sourceSpanByte: [0, 24],
+              sourceSpanUtf16: [0, 24],
+              syntaxSpans: [],
+              text: "Read the paper",
+            },
+          ],
+          runs: [
+            {
+              blockId: "p0",
+              href: "https://example.com/paper",
+              inlineId: "link",
+              listItemIndex: null,
+              renderedText: "paper",
+              renderedTextUtf16: [0, 5],
+              semantic: "text",
+              sourceSpanByte: [9, 14],
+              sourceSpanUtf16: [9, 14],
+            },
+          ],
+        })}
+      />,
+    );
+
+    expect(screen.getByRole("link", { name: "paper" })).toHaveClass(
+      "underline",
+      "decoration-primary/45",
+      "underline-offset-4",
+    );
   });
 
   it("does not trust projected math commands that can shape host DOM", () => {
@@ -848,6 +889,32 @@ describe("ProjectedMarkdownView", () => {
 
     expect(screen.getByText("datasets")).toBeInTheDocument();
     expect(document.querySelector("pre code span")).not.toBeNull();
+  });
+
+  it("lets callers pin static code blocks to the cream highlighter palette", () => {
+    render(
+      <ProjectedMarkdownView
+        colorTheme="cream"
+        plan={plan({
+          blocks: [
+            {
+              blockId: "code",
+              blockIndex: 0,
+              codeLanguage: "python",
+              element: "pre",
+              kind: "code",
+              measurement: { estimatedHeight: 72, confidence: "high", width: 720 },
+              sourceSpanByte: [0, 20],
+              sourceSpanUtf16: [0, 20],
+              syntaxSpans: [],
+              text: "print('cream')",
+            },
+          ],
+        })}
+      />,
+    );
+
+    expect(document.querySelector("pre")).toHaveStyle({ backgroundColor: "#f0ede7" });
   });
 
   it("renders projected inline HTML as plain text", () => {

--- a/src/components/markdown/markdown-typography.ts
+++ b/src/components/markdown/markdown-typography.ts
@@ -1,0 +1,24 @@
+export const markdownDocumentClassName =
+  "not-prose select-text py-2 text-base leading-[1.65] text-foreground font-[var(--output-document-font)] [font-kerning:normal] [hyphens:auto] [text-rendering:optimizeLegibility] [&>*:first-child]:mt-0 [&>*:last-child]:mb-0 [&_kbd]:rounded-sm [&_kbd]:border [&_kbd]:border-border [&_kbd]:bg-muted/60 [&_kbd]:px-1.5 [&_kbd]:py-0.5 [&_kbd]:font-[var(--output-ui-font)] [&_kbd]:text-[0.82em] [&_mark]:rounded-sm [&_mark]:bg-amber-200/70 [&_mark]:px-1 dark:[&_mark]:bg-amber-500/25 [&_sub]:text-[0.75em] [&_sup]:text-[0.75em]";
+
+export const markdownLinkClassName =
+  "rounded-[2px] font-medium text-primary underline decoration-primary/45 decoration-1 underline-offset-4 transition-[background-color,color,text-decoration-color] hover:bg-primary/5 hover:decoration-primary focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/40";
+
+export const markdownInlineCodeClassName =
+  "rounded-sm bg-muted/75 px-1.5 py-0.5 font-mono text-[0.9em] text-foreground";
+
+export const markdownBlockquoteClassName =
+  "my-4 border-l-[3px] border-primary/30 pl-4 text-muted-foreground italic";
+
+export const markdownListMarkerClassName = "marker:text-muted-foreground marker:font-medium";
+
+export function markdownHeadingClassName(element: string) {
+  if (element === "h1") return "mt-6 mb-4 text-[1.875rem] leading-tight font-bold";
+  if (element === "h2") {
+    return "mt-[1.35rem] mb-3 border-b border-border/70 pb-1.5 text-2xl leading-tight font-bold";
+  }
+  if (element === "h3") return "mt-[1.2rem] mb-2.5 text-xl leading-tight font-semibold";
+  if (element === "h4") return "mt-4 mb-2 text-lg leading-tight font-semibold";
+  if (element === "h5") return "mt-3.5 mb-1.5 text-base leading-tight font-semibold";
+  return "mt-3 mb-1.5 text-sm leading-tight font-semibold text-muted-foreground";
+}

--- a/src/components/outputs/__tests__/markdown-output.test.tsx
+++ b/src/components/outputs/__tests__/markdown-output.test.tsx
@@ -64,4 +64,14 @@ describe("MarkdownOutput heading anchors", () => {
       "cell-a:heading:1",
     );
   });
+
+  it("renders links with a visible default underline", () => {
+    render(<MarkdownOutput content={"Read the [paper](https://example.com/paper)."} />);
+
+    expect(screen.getByRole("link", { name: "paper" })).toHaveClass(
+      "underline",
+      "decoration-primary/45",
+      "underline-offset-4",
+    );
+  });
 });

--- a/src/components/outputs/markdown-output.tsx
+++ b/src/components/outputs/markdown-output.tsx
@@ -11,6 +11,14 @@ import remarkMath from "remark-math";
 import { useColorTheme, useDarkMode } from "@/lib/dark-mode";
 import { katexStrict } from "@/lib/katex-options";
 import { cn } from "@/lib/utils";
+import {
+  markdownBlockquoteClassName,
+  markdownDocumentClassName,
+  markdownHeadingClassName,
+  markdownInlineCodeClassName,
+  markdownLinkClassName,
+  markdownListMarkerClassName,
+} from "../markdown/markdown-typography";
 
 import "katex/dist/katex.min.css";
 
@@ -179,7 +187,7 @@ export function MarkdownOutput({
   }
 
   return (
-    <div data-slot="markdown-output" className={cn("not-prose py-2", className)}>
+    <div data-slot="markdown-output" className={cn(markdownDocumentClassName, className)}>
       <ReactMarkdown
         remarkPlugins={remarkPlugins}
         rehypePlugins={rehypePlugins}
@@ -216,10 +224,7 @@ export function MarkdownOutput({
 
             // Inline code
             return (
-              <code
-                className="rounded bg-gray-100 dark:bg-gray-800 px-1 py-0.5 text-sm text-gray-800 dark:text-gray-200"
-                {...props}
-              >
+              <code className={markdownInlineCodeClassName} {...props}>
                 {children}
               </code>
             );
@@ -230,7 +235,7 @@ export function MarkdownOutput({
             return (
               <a
                 href={href}
-                className="text-blue-600 dark:text-blue-400 hover:text-blue-800 dark:hover:text-blue-300 hover:underline"
+                className={markdownLinkClassName}
                 rel="noopener noreferrer"
                 target="_blank"
                 {...props}
@@ -243,9 +248,9 @@ export function MarkdownOutput({
           // Tables
           table({ children, ...props }) {
             return (
-              <div className="my-4 overflow-x-auto">
+              <div className="my-4 overflow-x-auto border-y border-border">
                 <table
-                  className="min-w-full border-collapse border border-gray-300 dark:border-gray-700 bg-white dark:bg-gray-900 text-sm"
+                  className="min-w-full border-collapse font-[var(--output-ui-font)] text-sm leading-normal"
                   {...props}
                 >
                   {children}
@@ -255,21 +260,21 @@ export function MarkdownOutput({
           },
           thead({ children, ...props }) {
             return (
-              <thead className="bg-gray-50 dark:bg-gray-800" {...props}>
+              <thead className="bg-muted/55" {...props}>
                 {children}
               </thead>
             );
           },
           tbody({ children, ...props }) {
             return (
-              <tbody className="divide-y divide-gray-200 dark:divide-gray-700" {...props}>
+              <tbody className="divide-y divide-border" {...props}>
                 {children}
               </tbody>
             );
           },
           tr({ children, ...props }) {
             return (
-              <tr className="hover:bg-gray-50 dark:hover:bg-gray-800" {...props}>
+              <tr className="odd:bg-muted/[0.04]" {...props}>
                 {children}
               </tr>
             );
@@ -277,7 +282,7 @@ export function MarkdownOutput({
           th({ children, ...props }) {
             return (
               <th
-                className="border border-gray-300 dark:border-gray-700 px-3 py-2 text-left font-semibold text-gray-900 dark:text-gray-100"
+                className="border-r border-border px-3 py-2 text-left font-semibold text-foreground last:border-r-0"
                 {...props}
               >
                 {children}
@@ -287,7 +292,7 @@ export function MarkdownOutput({
           td({ children, ...props }) {
             return (
               <td
-                className="border border-gray-300 dark:border-gray-700 px-3 py-2 text-gray-700 dark:text-gray-300"
+                className="border-r border-t border-border px-3 py-2 align-top text-muted-foreground first:text-foreground last:border-r-0"
                 {...props}
               >
                 {children}
@@ -299,7 +304,7 @@ export function MarkdownOutput({
           h1({ children, ...props }) {
             return (
               <h1
-                className="mb-4 mt-6 text-2xl font-bold"
+                className={markdownHeadingClassName("h1")}
                 {...props}
                 {...headingAttributes(1, children)}
               >
@@ -310,7 +315,7 @@ export function MarkdownOutput({
           h2({ children, ...props }) {
             return (
               <h2
-                className="mb-3 mt-5 text-xl font-bold"
+                className={markdownHeadingClassName("h2")}
                 {...props}
                 {...headingAttributes(2, children)}
               >
@@ -321,7 +326,7 @@ export function MarkdownOutput({
           h3({ children, ...props }) {
             return (
               <h3
-                className="mb-2 mt-4 text-lg font-semibold"
+                className={markdownHeadingClassName("h3")}
                 {...props}
                 {...headingAttributes(3, children)}
               >
@@ -332,7 +337,7 @@ export function MarkdownOutput({
           h4({ children, ...props }) {
             return (
               <h4
-                className="mb-2 mt-3 text-base font-semibold"
+                className={markdownHeadingClassName("h4")}
                 {...props}
                 {...headingAttributes(4, children)}
               >
@@ -343,7 +348,7 @@ export function MarkdownOutput({
           h5({ children, ...props }) {
             return (
               <h5
-                className="mb-1 mt-2 text-sm font-semibold"
+                className={markdownHeadingClassName("h5")}
                 {...props}
                 {...headingAttributes(5, children)}
               >
@@ -354,7 +359,7 @@ export function MarkdownOutput({
           h6({ children, ...props }) {
             return (
               <h6
-                className="mb-1 mt-2 text-sm font-medium"
+                className={markdownHeadingClassName("h6")}
                 {...props}
                 {...headingAttributes(6, children)}
               >
@@ -375,14 +380,23 @@ export function MarkdownOutput({
           // Lists
           ul({ children, ...props }) {
             return (
-              <ul className="my-2 ml-6 list-disc" {...props}>
+              <ul
+                className={cn("my-3 ml-6 list-disc leading-relaxed", markdownListMarkerClassName)}
+                {...props}
+              >
                 {children}
               </ul>
             );
           },
           ol({ children, ...props }) {
             return (
-              <ol className="my-2 ml-6 list-decimal" {...props}>
+              <ol
+                className={cn(
+                  "my-3 ml-6 list-decimal leading-relaxed",
+                  markdownListMarkerClassName,
+                )}
+                {...props}
+              >
                 {children}
               </ol>
             );
@@ -398,10 +412,7 @@ export function MarkdownOutput({
           // Blockquotes
           blockquote({ children, ...props }) {
             return (
-              <blockquote
-                className="my-4 border-l-4 border-gray-300 dark:border-gray-600 pl-4 italic text-gray-600 dark:text-gray-400"
-                {...props}
-              >
+              <blockquote className={markdownBlockquoteClassName} {...props}>
                 {children}
               </blockquote>
             );

--- a/src/isolated-renderer/styles.css
+++ b/src/isolated-renderer/styles.css
@@ -8,6 +8,7 @@
 
 /* Source paths for Tailwind to scan for isolated iframe class names */
 @source "../components/outputs/**/*.{ts,tsx}";
+@source "../components/markdown/**/*.{ts,tsx}";
 @source "../components/widgets/**/*.{ts,tsx}";
 @source "../components/ui/**/*.{ts,tsx}";
 @source "./**/*.{ts,tsx}";
@@ -66,6 +67,7 @@
   --input: oklch(0.922 0 0);
   --ring: oklch(0.708 0 0);
   --radius: 0.625rem;
+  --markdown-link-underline: color-mix(in oklch, var(--primary) 48%, transparent);
 }
 
 /* Dark mode theme variables (matching main app) */
@@ -90,6 +92,7 @@
   --border: oklch(1 0 0 / 10%);
   --input: oklch(1 0 0 / 15%);
   --ring: oklch(0.556 0 0);
+  --markdown-link-underline: color-mix(in oklch, var(--primary) 56%, transparent);
 }
 
 /* Base styles */
@@ -133,7 +136,11 @@ img {
 /* Links */
 a {
   color: oklch(0.546 0.245 262.881);
-  text-decoration: none;
+  font-weight: 500;
+  text-decoration-line: underline;
+  text-decoration-color: var(--markdown-link-underline);
+  text-decoration-thickness: 1px;
+  text-underline-offset: 0.22em;
 }
 
 .dark a,
@@ -142,7 +149,7 @@ a {
 }
 
 a:hover {
-  text-decoration: underline;
+  text-decoration-color: currentColor;
 }
 
 /* Error styling */

--- a/src/styles/cream-theme.css
+++ b/src/styles/cream-theme.css
@@ -35,6 +35,7 @@
   --border: #d8cec3;
   --input: #d8cec3;
   --ring: #955f3b;
+  --output-document-font: KaTeX_Main, Georgia, "Times New Roman", serif;
 
   /* ── Gruvbox green (idle status, success) ── */
   --color-green-50: #f4f3e6;
@@ -173,6 +174,7 @@
   --border: rgba(255, 255, 255, 0.1);
   --input: rgba(255, 255, 255, 0.15);
   --ring: #d4896a;
+  --output-document-font: KaTeX_Main, Georgia, "Times New Roman", serif;
 
   /* ── Gruvbox green (dark) ── */
   --color-green-50: #2a2a0a;

--- a/src/styles/notebook-tokens.css
+++ b/src/styles/notebook-tokens.css
@@ -52,6 +52,9 @@
   --input: oklch(0.922 0 0);
   --ring: oklch(0.708 0 0);
   --radius: 0.625rem;
+  --output-ui-font: system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
+  --output-mono-font: ui-monospace, SFMono-Regular, "SF Mono", Menlo, Consolas, monospace;
+  --output-document-font: var(--output-ui-font);
 }
 
 .dark {


### PR DESCRIPTION
## Summary

- Adds shared markdown typography classes for projected markdown and isolated markdown outputs.
- Gives links visible default affordance with the new underline treatment and keeps the hover highlight behavior.
- Adds an Elements `Markdown typography` page with production-backed projected markdown fixtures for visual testing.
- Defines document font tokens for the main app and lets cream markdown samples use the cream static code highlighter palette.

## Verification

- `cargo xtask lint --fix`
- `pnpm test:run src/components/markdown/__tests__/ProjectedMarkdownView.test.tsx src/components/outputs/__tests__/markdown-output.test.tsx src/components/isolated/__tests__/frame-html.test.ts`
- `pnpm elements:build`
- Browser visual check: `http://localhost:5176/docs/markdown-typography` at desktop and narrow viewport
