### PR TITLE
feat(markdown): explore richer document typography

### DIFF
--- a/apps/elements/components/markdown-typography-example.tsx
+++ b/apps/elements/components/markdown-typography-example.tsx
@@ -229,6 +229,7 @@ const markdownPlan: MarkdownProjectionPlan = {
       semantic: "list-item",
     }),
     run("checklist", "task-2", "Promote surprising failures into follow-up cells", {
+      listItemChecked: false,
       listItemIndex: 2,
       listItemPath: "2",
       semantic: "list-item",

--- a/apps/elements/components/markdown-typography-example.tsx
+++ b/apps/elements/components/markdown-typography-example.tsx
@@ -334,8 +334,8 @@ export function MarkdownTypographyExample() {
         <NotebookPaletteToggle />
       </div>
 
-      <section className="grid gap-4 min-[1500px]:grid-cols-[minmax(0,1fr)_320px]">
-        <article className="min-w-0 border border-border bg-background px-7 py-6 text-foreground shadow-sm max-sm:pr-5 max-sm:pl-14">
+      <section className="space-y-4">
+        <article className="mx-auto min-w-0 max-w-[980px] border border-border bg-background px-7 py-6 text-foreground shadow-sm max-sm:pr-5 max-sm:pl-14">
           <ProjectedMarkdownView
             headingAnchors={headingAnchors}
             plan={markdownPlan}
@@ -343,20 +343,28 @@ export function MarkdownTypographyExample() {
           />
         </article>
 
-        <aside className="grid content-start gap-3 border border-border bg-muted/20 p-4 text-foreground">
-          {auditRows.map((row) => {
-            const Icon = row.icon;
-            return (
-              <div key={row.label} className="grid grid-cols-[auto_minmax(0,1fr)] gap-3">
-                <Icon className="mt-0.5 size-4 text-muted-foreground" aria-hidden="true" />
-                <div className="min-w-0">
-                  <div className="text-sm font-semibold">{row.label}</div>
-                  <div className="mt-1 text-xs leading-5 text-muted-foreground">{row.detail}</div>
+        <details className={markdownDetailsClassName}>
+          <summary className={markdownSummaryClassName}>
+            <span aria-hidden="true" className={markdownSummaryIndicatorClassName}>
+              ›
+            </span>
+            <span className="min-w-0">Typography audit notes</span>
+          </summary>
+          <aside className="grid gap-3 md:grid-cols-2 xl:grid-cols-3">
+            {auditRows.map((row) => {
+              const Icon = row.icon;
+              return (
+                <div key={row.label} className="grid grid-cols-[auto_minmax(0,1fr)] gap-3">
+                  <Icon className="mt-0.5 size-4 text-muted-foreground" aria-hidden="true" />
+                  <div className="min-w-0">
+                    <div className="text-sm font-semibold">{row.label}</div>
+                    <div className="mt-1 text-xs leading-5 text-muted-foreground">{row.detail}</div>
+                  </div>
                 </div>
-              </div>
-            );
-          })}
-        </aside>
+              );
+            })}
+          </aside>
+        </details>
       </section>
 
       <section className="border border-border bg-background px-7 py-6 text-foreground shadow-sm max-sm:pr-5 max-sm:pl-14">

--- a/apps/elements/components/markdown-typography-example.tsx
+++ b/apps/elements/components/markdown-typography-example.tsx
@@ -96,8 +96,9 @@ const markdownPlan: MarkdownProjectionPlan = {
     block(9, "checklist-heading", "heading", "h2", "Experiment checklist"),
     block(10, "checklist", "list", "ul", "tasks"),
     block(11, "math", "math", "div", "\\mathbb{E}[L_t] \\leq \\epsilon + \\lambda\\|A_t-A_0\\|_2"),
+    block(12, "bound", "paragraph", "p", "where beta controls the experimental tolerance."),
     block(
-      12,
+      13,
       "code",
       "code",
       "pre",
@@ -106,9 +107,9 @@ const markdownPlan: MarkdownProjectionPlan = {
         codeLanguage: "python",
       },
     ),
-    block(13, "rule", "thematic-break", "hr", ""),
+    block(14, "rule", "thematic-break", "hr", ""),
     block(
-      14,
+      15,
       "closing",
       "paragraph",
       "p",
@@ -226,6 +227,9 @@ const markdownPlan: MarkdownProjectionPlan = {
     run("math", "math-source", "\\mathbb{E}[L_t] \\leq \\epsilon + \\lambda\\|A_t-A_0\\|_2", {
       semantic: "math-source",
     }),
+    run("bound", "bound-0", "where "),
+    run("bound", "bound-beta", "\\beta", { semantic: "math-source" }),
+    run("bound", "bound-1", " controls the experimental tolerance."),
     run("closing", "closing-text", "The rendered markdown should feel like a "),
     run("closing", "closing-em", "paper margin", { semantic: "emphasis" }),
     run("closing", "closing-tail", " and a runnable lab bench at the same time."),

--- a/apps/elements/components/markdown-typography-example.tsx
+++ b/apps/elements/components/markdown-typography-example.tsx
@@ -3,6 +3,15 @@
 import { BookOpenText, Image, Link2, Pilcrow, Table2 } from "lucide-react";
 import { useCallback } from "react";
 import { ProjectedMarkdownView } from "@/components/markdown/ProjectedMarkdownView";
+import {
+  markdownDetailsBodyClassName,
+  markdownDetailsClassName,
+  markdownInlineCodeClassName,
+  markdownLinkClassName,
+  markdownParagraphClassName,
+  markdownSummaryClassName,
+  markdownSummaryIndicatorClassName,
+} from "@/components/markdown/markdown-typography";
 import type {
   MarkdownProjectionBlock,
   MarkdownProjectionPlan,
@@ -300,6 +309,11 @@ const auditRows = [
     label: "Research voice",
     detail: "Cream switches markdown to the serif document font used by output frames.",
   },
+  {
+    icon: BookOpenText,
+    label: "Appendix motion",
+    detail: "Native disclosure blocks read as compact experimental appendices.",
+  },
 ];
 
 export function MarkdownTypographyExample() {
@@ -342,6 +356,34 @@ export function MarkdownTypographyExample() {
             );
           })}
         </aside>
+      </section>
+
+      <section className="border border-border bg-background px-7 py-6 text-foreground shadow-sm max-sm:pr-5 max-sm:pl-14">
+        <div className="mb-4 font-mono text-[11px] text-muted-foreground">
+          shared native markdown affordance
+        </div>
+        <details className={markdownDetailsClassName} open>
+          <summary className={markdownSummaryClassName}>
+            <span aria-hidden="true" className={markdownSummaryIndicatorClassName}>
+              ›
+            </span>
+            <span className="min-w-0">Appendix: surprising failure modes</span>
+          </summary>
+          <div className={markdownDetailsBodyClassName}>
+            <p className={markdownParagraphClassName}>
+              Keep compact digressions close to the claim: failed priors, odd notebook states, and{" "}
+              <code className={markdownInlineCodeClassName}>seed=13</code> observations can hide in
+              a native disclosure block without losing their place in the paper-like flow.
+            </p>
+            <p className={markdownParagraphClassName}>
+              The appendix can still carry a{" "}
+              <a href="https://example.com/appendix" className={markdownLinkClassName}>
+                visible citation
+              </a>{" "}
+              and should feel tactile before the reader opens it.
+            </p>
+          </div>
+        </details>
       </section>
 
       <section className="grid gap-4 min-[1500px]:grid-cols-2">

--- a/apps/elements/components/markdown-typography-example.tsx
+++ b/apps/elements/components/markdown-typography-example.tsx
@@ -232,6 +232,44 @@ const markdownPlan: MarkdownProjectionPlan = {
   ],
 };
 
+const headingAnchors = [
+  {
+    anchor: "discrete-diffusion-notebook",
+    headingAnchorId: "elements-markdown-heading-discrete-diffusion-notebook",
+    itemId: "elements-markdown:title",
+    level: 1,
+    title: "Discrete diffusion notebook",
+  },
+  {
+    anchor: "claim",
+    headingAnchorId: "elements-markdown-heading-claim",
+    itemId: "elements-markdown:claim",
+    level: 2,
+    title: "Claim",
+  },
+  {
+    anchor: "evidence-table",
+    headingAnchorId: "elements-markdown-heading-evidence-table",
+    itemId: "elements-markdown:evidence",
+    level: 2,
+    title: "Evidence table",
+  },
+  {
+    anchor: "observation-ledger",
+    headingAnchorId: "elements-markdown-heading-observation-ledger",
+    itemId: "elements-markdown:ledger",
+    level: 3,
+    title: "Observation ledger",
+  },
+  {
+    anchor: "experiment-checklist",
+    headingAnchorId: "elements-markdown-heading-experiment-checklist",
+    itemId: "elements-markdown:checklist",
+    level: 2,
+    title: "Experiment checklist",
+  },
+] as const;
+
 const auditRows = [
   {
     icon: Link2,
@@ -240,8 +278,8 @@ const auditRows = [
   },
   {
     icon: Pilcrow,
-    label: "Document rhythm",
-    detail: "Section spacing, subdued list markers, and legible paragraph measure.",
+    label: "Anchorable sections",
+    detail: "Headings expose quiet permalink anchors from the notebook outline metadata.",
   },
   {
     icon: Table2,
@@ -279,7 +317,11 @@ export function MarkdownTypographyExample() {
 
       <section className="grid gap-4 min-[1500px]:grid-cols-[minmax(0,1fr)_320px]">
         <article className="min-w-0 border border-border bg-background px-7 py-6 text-foreground shadow-sm max-sm:pr-5 max-sm:pl-14">
-          <ProjectedMarkdownView plan={markdownPlan} onLinkClick={handleLinkClick} />
+          <ProjectedMarkdownView
+            headingAnchors={headingAnchors}
+            plan={markdownPlan}
+            onLinkClick={handleLinkClick}
+          />
         </article>
 
         <aside className="grid content-start gap-3 border border-border bg-muted/20 p-4 text-foreground">
@@ -306,6 +348,7 @@ export function MarkdownTypographyExample() {
           <div className="mb-3 font-mono text-[11px] text-muted-foreground">classic tokens</div>
           <ProjectedMarkdownView
             colorTheme="classic"
+            headingAnchors={headingAnchors}
             plan={markdownPlan}
             onLinkClick={handleLinkClick}
           />
@@ -317,6 +360,7 @@ export function MarkdownTypographyExample() {
           <div className="mb-3 font-mono text-[11px] text-muted-foreground">cream tokens</div>
           <ProjectedMarkdownView
             colorTheme="cream"
+            headingAnchors={headingAnchors}
             plan={markdownPlan}
             onLinkClick={handleLinkClick}
           />

--- a/apps/elements/components/markdown-typography-example.tsx
+++ b/apps/elements/components/markdown-typography-example.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { BookOpenText, Link2, Pilcrow, Table2 } from "lucide-react";
+import { BookOpenText, Image, Link2, Pilcrow, Table2 } from "lucide-react";
 import { useCallback } from "react";
 import { ProjectedMarkdownView } from "@/components/markdown/ProjectedMarkdownView";
 import type {
@@ -90,11 +90,14 @@ const markdownPlan: MarkdownProjectionPlan = {
     ),
     block(4, "evidence", "heading", "h2", "Evidence table"),
     block(5, "table", "table", "table", "metric baseline candidate delta"),
-    block(6, "checklist-heading", "heading", "h2", "Experiment checklist"),
-    block(7, "checklist", "list", "ul", "tasks"),
-    block(8, "math", "math", "div", "\\mathbb{E}[L_t] \\leq \\epsilon + \\lambda\\|A_t-A_0\\|_2"),
+    block(6, "ledger", "heading", "h3", "Observation ledger"),
+    block(7, "nested-list", "list", "ol", "notes", { ordered: true }),
+    block(8, "figure", "paragraph", "p", "Residual topology sketch"),
+    block(9, "checklist-heading", "heading", "h2", "Experiment checklist"),
+    block(10, "checklist", "list", "ul", "tasks"),
+    block(11, "math", "math", "div", "\\mathbb{E}[L_t] \\leq \\epsilon + \\lambda\\|A_t-A_0\\|_2"),
     block(
-      9,
+      12,
       "code",
       "code",
       "pre",
@@ -103,8 +106,9 @@ const markdownPlan: MarkdownProjectionPlan = {
         codeLanguage: "python",
       },
     ),
+    block(13, "rule", "thematic-break", "hr", ""),
     block(
-      10,
+      14,
       "closing",
       "paragraph",
       "p",
@@ -163,6 +167,38 @@ const markdownPlan: MarkdownProjectionPlan = {
       tableCellIndex: 2,
       tableRowIndex: 2,
     }),
+    run("ledger", "ledger-text", "Observation ledger"),
+    run("nested-list", "nested-0", "Treat the schedule as a bounded operator", {
+      listItemIndex: 0,
+      listItemOrdered: true,
+      listItemPath: "0",
+      semantic: "list-item",
+    }),
+    run("nested-list", "nested-0-0", "Measure local topic neighborhoods after every prior update", {
+      listItemIndex: 0,
+      listItemOrdered: false,
+      listItemPath: "0.0",
+      semantic: "list-item",
+    }),
+    run("nested-list", "nested-1a", "Escalate drift into a ", {
+      listItemIndex: 1,
+      listItemOrdered: true,
+      listItemPath: "1",
+      semantic: "list-item",
+    }),
+    run("nested-list", "nested-1b", "follow-up cell", {
+      href: "https://example.com/follow-up",
+      listItemIndex: 1,
+      listItemOrdered: true,
+      listItemPath: "1",
+      semantic: "list-item",
+    }),
+    run("figure", "figure-image", "Residual topology sketch", {
+      imageAlt: "Residual topology sketch",
+      imageSrc: "/fixtures/widget-buffer-url-image.svg",
+      imageTitle: "Residual topology sketch",
+      semantic: "image",
+    }),
     run("checklist-heading", "checklist-heading-text", "Experiment checklist"),
     run("checklist", "task-0", "Reproduce the baseline paper", {
       listItemChecked: true,
@@ -211,6 +247,11 @@ const auditRows = [
     icon: Table2,
     label: "Dense evidence",
     detail: "Tables use notebook tokens without becoming heavy spreadsheet chrome.",
+  },
+  {
+    icon: Image,
+    label: "Figure rhythm",
+    detail: "Images sit in the document flow with a quiet boundary and reusable output tokens.",
   },
   {
     icon: BookOpenText,

--- a/apps/elements/content/docs/markdown-typography.mdx
+++ b/apps/elements/content/docs/markdown-typography.mdx
@@ -8,8 +8,8 @@ import { MarkdownTypographyExample } from "@/components/markdown-typography-exam
 Markdown should read like an interactive research document: links need visible
 affordance before hover, tables need density without spreadsheet noise, and the
 document font should carry enough authority for proofs, notes, and experiment
-logs. Heading anchors and figure captions should feel available without turning
-the page into application chrome.
+logs. Heading anchors, figure captions, and native disclosure blocks should
+feel available without turning the page into application chrome.
 
 <MarkdownTypographyExample />
 
@@ -18,8 +18,8 @@ the page into application chrome.
 This page renders the production `ProjectedMarkdownView` from
 `src/components/markdown/ProjectedMarkdownView.tsx` with the same projected plan
 shape that notebook markdown cells receive from the markdown engine. Link,
-heading anchor, figure, table, task list, math, inline code, and fenced-code
-styling all come from the shared markdown component path.
+heading anchor, figure, table, task list, math, inline code, fenced-code, and
+disclosure styling all come from the shared markdown component path.
 
 ## Boundary
 

--- a/apps/elements/content/docs/markdown-typography.mdx
+++ b/apps/elements/content/docs/markdown-typography.mdx
@@ -8,7 +8,8 @@ import { MarkdownTypographyExample } from "@/components/markdown-typography-exam
 Markdown should read like an interactive research document: links need visible
 affordance before hover, tables need density without spreadsheet noise, and the
 document font should carry enough authority for proofs, notes, and experiment
-logs.
+logs. Heading anchors and figure captions should feel available without turning
+the page into application chrome.
 
 <MarkdownTypographyExample />
 
@@ -17,8 +18,8 @@ logs.
 This page renders the production `ProjectedMarkdownView` from
 `src/components/markdown/ProjectedMarkdownView.tsx` with the same projected plan
 shape that notebook markdown cells receive from the markdown engine. Link,
-heading, table, task list, math, inline code, and fenced-code styling all come
-from the shared markdown component path.
+heading anchor, figure, table, task list, math, inline code, and fenced-code
+styling all come from the shared markdown component path.
 
 ## Boundary
 

--- a/apps/elements/public/fixtures/widget-buffer-url-image.svg
+++ b/apps/elements/public/fixtures/widget-buffer-url-image.svg
@@ -4,5 +4,5 @@
   <rect x="26" y="22" width="54" height="54" rx="8" fill="#10b981"/>
   <circle cx="151" cy="61" r="25" fill="#0ea5e9"/>
   <path d="M178 82 L225 40" stroke="#111827" stroke-width="7" stroke-linecap="round"/>
-  <text x="22" y="98" font-family="ui-sans-serif, system-ui, sans-serif" font-size="13" font-weight="700" fill="#111827">bufferPaths URL -> DataView</text>
+  <text x="22" y="98" font-family="ui-sans-serif, system-ui, sans-serif" font-size="13" font-weight="700" fill="#111827">Residual topology sketch</text>
 </svg>

--- a/src/components/editor/static-highlight.tsx
+++ b/src/components/editor/static-highlight.tsx
@@ -186,6 +186,7 @@ interface StaticCodeBlockProps {
   isDark?: boolean;
   colorTheme?: ColorTheme;
   className?: string;
+  style?: CSSProperties;
 }
 
 /**
@@ -202,6 +203,7 @@ export function StaticCodeBlock({
   isDark = false,
   colorTheme = "classic",
   className,
+  style,
 }: StaticCodeBlockProps) {
   const colors = getBlockColors(isDark, colorTheme);
   const nodes = highlight(code, language, isDark, colorTheme);
@@ -221,6 +223,7 @@ export function StaticCodeBlock({
         margin: 0,
         overflow: "auto",
         whiteSpace: "pre",
+        ...style,
       }}
     >
       <code>{nodes}</code>

--- a/src/components/isolated/__tests__/frame-html.test.ts
+++ b/src/components/isolated/__tests__/frame-html.test.ts
@@ -165,8 +165,8 @@ describe("generateFrameHtml", () => {
       expect(html).not.toMatch(
         /\.katex-display\s*\{[^}]*border-top: 1px solid var\(--border-color\)/,
       );
-      expect(html).toContain("scrollbar-width: none");
-      expect(html).toContain(".katex-display::-webkit-scrollbar");
+      expect(html).toContain("overflow-x: hidden");
+      expect(html).not.toContain(".katex-display::-webkit-scrollbar");
       expect(html).toContain("font-family: var(--output-mono-font)");
       expect(html).toContain("--output-document-font: var(--output-ui-font)");
     });

--- a/src/components/isolated/__tests__/frame-html.test.ts
+++ b/src/components/isolated/__tests__/frame-html.test.ts
@@ -165,6 +165,8 @@ describe("generateFrameHtml", () => {
       expect(html).not.toMatch(
         /\.katex-display\s*\{[^}]*border-top: 1px solid var\(--border-color\)/,
       );
+      expect(html).toContain("scrollbar-width: none");
+      expect(html).toContain(".katex-display::-webkit-scrollbar");
       expect(html).toContain("font-family: var(--output-mono-font)");
       expect(html).toContain("--output-document-font: var(--output-ui-font)");
     });

--- a/src/components/isolated/__tests__/frame-html.test.ts
+++ b/src/components/isolated/__tests__/frame-html.test.ts
@@ -151,6 +151,9 @@ describe("generateFrameHtml", () => {
       expect(html).toContain(':is([data-slot="markdown-output"], [data-slot="html-output"]) h3');
       expect(html).toContain(':is([data-slot="markdown-output"], [data-slot="html-output"]) table');
       expect(html).not.toContain("h2::after");
+      expect(html).toMatch(
+        /:is\(\[data-slot="markdown-output"\], \[data-slot="html-output"\]\) em\s*\{\s*color: var\(--text-primary\);/,
+      );
       expect(html).toContain(
         ':is([data-slot="markdown-output"], [data-slot="html-output"]) details',
       );

--- a/src/components/isolated/__tests__/frame-html.test.ts
+++ b/src/components/isolated/__tests__/frame-html.test.ts
@@ -168,7 +168,8 @@ describe("generateFrameHtml", () => {
       expect(html).not.toMatch(
         /\.katex-display\s*\{[^}]*border-top: 1px solid var\(--border-color\)/,
       );
-      expect(html).toContain("overflow-x: hidden");
+      expect(html).toMatch(/\.katex-display\s*\{[^}]*overflow-x: clip/);
+      expect(html).not.toMatch(/\.katex-display\s*\{[^}]*overflow-x: hidden/);
       expect(html).not.toContain(".katex-display::-webkit-scrollbar");
       expect(html).toContain("font-family: var(--output-mono-font)");
       expect(html).toContain("--output-document-font: var(--output-ui-font)");

--- a/src/components/isolated/__tests__/frame-html.test.ts
+++ b/src/components/isolated/__tests__/frame-html.test.ts
@@ -150,6 +150,7 @@ describe("generateFrameHtml", () => {
       expect(html).toContain('[data-slot="markdown-output"], [data-slot="html-output"]');
       expect(html).toContain(':is([data-slot="markdown-output"], [data-slot="html-output"]) h3');
       expect(html).toContain(':is([data-slot="markdown-output"], [data-slot="html-output"]) table');
+      expect(html).not.toContain("h2::after");
       expect(html).toContain(
         ':is([data-slot="markdown-output"], [data-slot="html-output"]) details',
       );
@@ -160,6 +161,9 @@ describe("generateFrameHtml", () => {
       expect(html).toContain("li.task-list-item");
       expect(html).toContain(
         ':is([data-slot="markdown-output"], [data-slot="html-output"]) button',
+      );
+      expect(html).not.toMatch(
+        /\.katex-display\s*\{[^}]*border-top: 1px solid var\(--border-color\)/,
       );
       expect(html).toContain("font-family: var(--output-mono-font)");
       expect(html).toContain("--output-document-font: var(--output-ui-font)");

--- a/src/components/isolated/__tests__/frame-html.test.ts
+++ b/src/components/isolated/__tests__/frame-html.test.ts
@@ -151,6 +151,12 @@ describe("generateFrameHtml", () => {
       expect(html).toContain(':is([data-slot="markdown-output"], [data-slot="html-output"]) h3');
       expect(html).toContain(':is([data-slot="markdown-output"], [data-slot="html-output"]) table');
       expect(html).toContain(
+        ':is([data-slot="markdown-output"], [data-slot="html-output"]) details',
+      );
+      expect(html).toContain(
+        ':is([data-slot="markdown-output"], [data-slot="html-output"]) summary::before',
+      );
+      expect(html).toContain(
         ':is([data-slot="markdown-output"], [data-slot="html-output"]) button',
       );
       expect(html).toContain("font-family: var(--output-mono-font)");

--- a/src/components/isolated/__tests__/frame-html.test.ts
+++ b/src/components/isolated/__tests__/frame-html.test.ts
@@ -156,6 +156,8 @@ describe("generateFrameHtml", () => {
       expect(html).toContain(
         ':is([data-slot="markdown-output"], [data-slot="html-output"]) summary::before',
       );
+      expect(html).toContain("ul.contains-task-list");
+      expect(html).toContain("li.task-list-item");
       expect(html).toContain(
         ':is([data-slot="markdown-output"], [data-slot="html-output"]) button',
       );

--- a/src/components/isolated/frame.html
+++ b/src/components/isolated/frame.html
@@ -467,14 +467,8 @@
 
       :is([data-slot="markdown-output"], [data-slot="html-output"]) .katex-display {
         margin: 1.25rem 0;
-        overflow-x: auto;
-        scrollbar-width: none;
+        overflow-x: hidden;
         text-align: center;
-      }
-
-      :is([data-slot="markdown-output"], [data-slot="html-output"])
-        .katex-display::-webkit-scrollbar {
-        display: none;
       }
 
       /* Links */

--- a/src/components/isolated/frame.html
+++ b/src/components/isolated/frame.html
@@ -347,6 +347,30 @@
         line-height: 1.5rem;
       }
 
+      :is([data-slot="markdown-output"], [data-slot="html-output"]) a[data-footnote-ref],
+      :is([data-slot="markdown-output"], [data-slot="html-output"]) a.data-footnote-ref {
+        display: inline-flex;
+        min-width: 1rem;
+        justify-content: center;
+        margin: 0 0.125rem;
+        padding: 0 0.25rem;
+        transform: translateY(-0.22em);
+        border: 1px solid color-mix(in oklch, var(--accent-color) 24%, transparent);
+        border-radius: 999px;
+        background: color-mix(in oklch, var(--accent-color) 8%, transparent);
+        color: var(--accent-color);
+        font-family: var(--output-ui-font);
+        font-size: 0.68em;
+        line-height: 1rem;
+        text-decoration: none;
+      }
+
+      :is([data-slot="markdown-output"], [data-slot="html-output"]) a[data-footnote-ref]:hover,
+      :is([data-slot="markdown-output"], [data-slot="html-output"]) a.data-footnote-ref:hover {
+        background: color-mix(in oklch, var(--accent-color) 12%, transparent);
+        text-decoration: none;
+      }
+
       :is([data-slot="markdown-output"], [data-slot="html-output"]) .katex-display {
         margin: 1.25rem 0;
         padding: 1rem;

--- a/src/components/isolated/frame.html
+++ b/src/components/isolated/frame.html
@@ -253,6 +253,80 @@
         text-decoration-thickness: 2px;
       }
 
+      :is([data-slot="markdown-output"], [data-slot="html-output"]) details {
+        margin: 1.25rem 0;
+        overflow: hidden;
+        border: 1px solid color-mix(in oklch, var(--border-color) 85%, transparent);
+        border-radius: 0.375rem;
+        background: color-mix(in oklch, var(--bg-secondary) 32%, transparent);
+        box-shadow: 0 1px 2px color-mix(in oklch, var(--text-primary) 10%, transparent);
+      }
+
+      :is([data-slot="markdown-output"], [data-slot="html-output"]) details[open] {
+        background: color-mix(in oklch, var(--bg-secondary) 40%, transparent);
+      }
+
+      :is([data-slot="markdown-output"], [data-slot="html-output"]) summary {
+        display: flex;
+        align-items: center;
+        gap: 0.5rem;
+        padding: 0.75rem 1rem;
+        border-bottom: 1px solid transparent;
+        color: var(--text-primary);
+        cursor: pointer;
+        font-family: var(--output-ui-font);
+        font-size: 0.875rem;
+        font-weight: 600;
+        line-height: 1.25rem;
+        list-style: none;
+      }
+
+      :is([data-slot="markdown-output"], [data-slot="html-output"]) details[open] > summary {
+        border-bottom-color: color-mix(in oklch, var(--border-color) 70%, transparent);
+      }
+
+      :is([data-slot="markdown-output"], [data-slot="html-output"])
+        summary::-webkit-details-marker {
+        display: none;
+      }
+
+      :is([data-slot="markdown-output"], [data-slot="html-output"]) summary::before {
+        display: inline-flex;
+        width: 1.25rem;
+        height: 1.25rem;
+        flex: none;
+        align-items: center;
+        justify-content: center;
+        border: 1px solid color-mix(in oklch, var(--accent-color) 28%, transparent);
+        border-radius: 999px;
+        background: color-mix(in oklch, var(--accent-color) 8%, transparent);
+        color: var(--accent-color);
+        content: "›";
+        font-family: var(--output-ui-font);
+        font-size: 0.75rem;
+        line-height: 1;
+        transition: transform 120ms ease;
+      }
+
+      :is([data-slot="markdown-output"], [data-slot="html-output"])
+        details[open]
+        > summary::before {
+        transform: rotate(90deg);
+      }
+
+      :is([data-slot="markdown-output"], [data-slot="html-output"]) details > :not(summary) {
+        margin-right: 1rem;
+        margin-left: 1rem;
+      }
+
+      :is([data-slot="markdown-output"], [data-slot="html-output"]) details > summary + * {
+        margin-top: 0.75rem;
+      }
+
+      :is([data-slot="markdown-output"], [data-slot="html-output"]) details > :last-child {
+        margin-bottom: 1rem;
+      }
+
       :is([data-slot="markdown-output"], [data-slot="html-output"]) table,
       :is([data-slot="markdown-output"], [data-slot="html-output"]) button,
       :is([data-slot="markdown-output"], [data-slot="html-output"]) input,

--- a/src/components/isolated/frame.html
+++ b/src/components/isolated/frame.html
@@ -265,7 +265,7 @@
       }
 
       :is([data-slot="markdown-output"], [data-slot="html-output"]) em {
-        color: var(--text-secondary);
+        color: var(--text-primary);
       }
 
       :is([data-slot="markdown-output"], [data-slot="html-output"]) del {

--- a/src/components/isolated/frame.html
+++ b/src/components/isolated/frame.html
@@ -232,10 +232,9 @@
 
       :is([data-slot="markdown-output"], [data-slot="html-output"]) blockquote {
         margin: 1.25rem 0;
-        padding: 0.75rem 1rem 0.75rem 1.25rem;
-        border-left: 3px solid color-mix(in oklch, var(--accent-color) 52%, transparent);
-        background: color-mix(in oklch, var(--bg-secondary) 62%, transparent);
-        color: var(--text-secondary);
+        padding: 0.375rem 0.5rem 0.375rem 1.25rem;
+        border-left: 2px solid color-mix(in oklch, var(--text-primary) 36%, transparent);
+        color: color-mix(in oklch, var(--text-primary) 80%, var(--text-secondary));
         font-style: italic;
       }
 
@@ -467,7 +466,7 @@
 
       :is([data-slot="markdown-output"], [data-slot="html-output"]) .katex-display {
         margin: 1.25rem 0;
-        overflow-x: hidden;
+        overflow-x: clip;
         text-align: center;
       }
 

--- a/src/components/isolated/frame.html
+++ b/src/components/isolated/frame.html
@@ -149,6 +149,31 @@
         content: "";
       }
 
+      :is([data-slot="markdown-output"], [data-slot="html-output"]) h1 > a[href^="#"],
+      :is([data-slot="markdown-output"], [data-slot="html-output"]) h2 > a[href^="#"],
+      :is([data-slot="markdown-output"], [data-slot="html-output"]) h3 > a[href^="#"],
+      :is([data-slot="markdown-output"], [data-slot="html-output"]) h4 > a[href^="#"],
+      :is([data-slot="markdown-output"], [data-slot="html-output"]) h5 > a[href^="#"],
+      :is([data-slot="markdown-output"], [data-slot="html-output"]) h6 > a[href^="#"] {
+        display: inline-flex;
+        margin-left: 0.5rem;
+        transform: translateY(-0.08em);
+        color: color-mix(in oklch, var(--text-secondary) 42%, transparent);
+        font-family: var(--output-ui-font);
+        font-size: 0.58em;
+        font-weight: 500;
+        text-decoration: none;
+      }
+
+      :is([data-slot="markdown-output"], [data-slot="html-output"]) h1 > a[href^="#"]:hover,
+      :is([data-slot="markdown-output"], [data-slot="html-output"]) h2 > a[href^="#"]:hover,
+      :is([data-slot="markdown-output"], [data-slot="html-output"]) h3 > a[href^="#"]:hover,
+      :is([data-slot="markdown-output"], [data-slot="html-output"]) h4 > a[href^="#"]:hover,
+      :is([data-slot="markdown-output"], [data-slot="html-output"]) h5 > a[href^="#"]:hover,
+      :is([data-slot="markdown-output"], [data-slot="html-output"]) h6 > a[href^="#"]:hover {
+        color: var(--accent-color);
+      }
+
       :is([data-slot="markdown-output"], [data-slot="html-output"]) h3 {
         margin: 1.5rem 0 0.625rem;
         font-size: 1.25rem;
@@ -294,6 +319,22 @@
         border-radius: 0.125rem;
         background: color-mix(in oklch, var(--bg-secondary) 38%, transparent);
         box-shadow: 0 1px 2px color-mix(in oklch, var(--text-primary) 10%, transparent);
+      }
+
+      :is([data-slot="markdown-output"], [data-slot="html-output"]) figure {
+        margin: 1.25rem 0;
+      }
+
+      :is([data-slot="markdown-output"], [data-slot="html-output"]) figure > img {
+        margin-bottom: 0;
+      }
+
+      :is([data-slot="markdown-output"], [data-slot="html-output"]) figcaption {
+        margin-top: 0.5rem;
+        color: var(--text-secondary);
+        font-family: var(--output-ui-font);
+        font-size: 0.75rem;
+        line-height: 1.25rem;
       }
 
       :is([data-slot="markdown-output"], [data-slot="html-output"]) section[data-footnotes] {

--- a/src/components/isolated/frame.html
+++ b/src/components/isolated/frame.html
@@ -347,6 +347,17 @@
         line-height: 1.5rem;
       }
 
+      :is([data-slot="markdown-output"], [data-slot="html-output"]) .katex-display {
+        margin: 1.25rem 0;
+        padding: 1rem;
+        overflow-x: auto;
+        border-top: 1px solid var(--border-color);
+        border-bottom: 1px solid var(--border-color);
+        border-radius: 0.125rem;
+        background: color-mix(in oklch, var(--bg-secondary) 46%, transparent);
+        text-align: center;
+      }
+
       /* Links */
       a {
         color: var(--accent-color);

--- a/src/components/isolated/frame.html
+++ b/src/components/isolated/frame.html
@@ -132,21 +132,8 @@
       }
 
       :is([data-slot="markdown-output"], [data-slot="html-output"]) h2 {
-        position: relative;
         margin: 1.75rem 0 0.75rem;
-        padding-bottom: 0.5rem;
-        border-bottom: 1px solid var(--border-color);
         font-size: 1.5rem;
-      }
-
-      :is([data-slot="markdown-output"], [data-slot="html-output"]) h2::after {
-        position: absolute;
-        bottom: -1px;
-        left: 0;
-        width: 4rem;
-        height: 1px;
-        background: color-mix(in oklch, var(--accent-color) 55%, transparent);
-        content: "";
       }
 
       :is([data-slot="markdown-output"], [data-slot="html-output"]) h1 > a[href^="#"],
@@ -480,12 +467,7 @@
 
       :is([data-slot="markdown-output"], [data-slot="html-output"]) .katex-display {
         margin: 1.25rem 0;
-        padding: 1rem;
         overflow-x: auto;
-        border-top: 1px solid var(--border-color);
-        border-bottom: 1px solid var(--border-color);
-        border-radius: 0.125rem;
-        background: color-mix(in oklch, var(--bg-secondary) 46%, transparent);
         text-align: center;
       }
 

--- a/src/components/isolated/frame.html
+++ b/src/components/isolated/frame.html
@@ -210,6 +210,39 @@
         margin: 0.25rem 0;
       }
 
+      :is([data-slot="markdown-output"], [data-slot="html-output"]) ul.contains-task-list,
+      :is([data-slot="markdown-output"], [data-slot="html-output"]) ol.contains-task-list {
+        margin: 1rem 0;
+        padding: 0.5rem;
+        border: 1px solid color-mix(in oklch, var(--border-color) 76%, transparent);
+        border-radius: 0.375rem;
+        background: color-mix(in oklch, var(--bg-secondary) 30%, transparent);
+        list-style: none;
+      }
+
+      :is([data-slot="markdown-output"], [data-slot="html-output"]) li.task-list-item {
+        display: grid;
+        grid-template-columns: auto minmax(0, 1fr);
+        gap: 0.5rem;
+        align-items: start;
+        margin: 0.25rem 0;
+        padding: 0.375rem 0.5rem;
+        border-radius: 0.125rem;
+      }
+
+      :is([data-slot="markdown-output"], [data-slot="html-output"]) li.task-list-item:hover {
+        background: color-mix(in oklch, var(--bg-secondary) 62%, transparent);
+      }
+
+      :is([data-slot="markdown-output"], [data-slot="html-output"])
+        li.task-list-item
+        > input[type="checkbox"] {
+        width: 1rem;
+        height: 1rem;
+        margin: 0.18em 0 0;
+        accent-color: var(--accent-color);
+      }
+
       :is([data-slot="markdown-output"], [data-slot="html-output"]) blockquote {
         margin: 1.25rem 0;
         padding: 0.75rem 1rem 0.75rem 1.25rem;

--- a/src/components/isolated/frame.html
+++ b/src/components/isolated/frame.html
@@ -108,7 +108,7 @@
       :is([data-slot="markdown-output"], [data-slot="html-output"]) {
         font-family: var(--output-document-font);
         font-size: 1rem;
-        line-height: 1.65;
+        line-height: 1.68;
         font-kerning: normal;
         text-rendering: optimizeLegibility;
       }
@@ -121,22 +121,36 @@
       :is([data-slot="markdown-output"], [data-slot="html-output"]) h6 {
         color: var(--text-primary);
         font-family: var(--output-document-font);
-        font-weight: 700;
+        font-weight: 600;
         line-height: 1.2;
       }
 
       :is([data-slot="markdown-output"], [data-slot="html-output"]) h1 {
-        margin: 1.5rem 0 1rem;
-        font-size: 1.875rem;
+        margin: 1.75rem 0 1rem;
+        font-size: 2rem;
+        line-height: 1.08;
       }
 
       :is([data-slot="markdown-output"], [data-slot="html-output"]) h2 {
-        margin: 1.35rem 0 0.75rem;
+        position: relative;
+        margin: 1.75rem 0 0.75rem;
+        padding-bottom: 0.5rem;
+        border-bottom: 1px solid var(--border-color);
         font-size: 1.5rem;
       }
 
+      :is([data-slot="markdown-output"], [data-slot="html-output"]) h2::after {
+        position: absolute;
+        bottom: -1px;
+        left: 0;
+        width: 4rem;
+        height: 1px;
+        background: color-mix(in oklch, var(--accent-color) 55%, transparent);
+        content: "";
+      }
+
       :is([data-slot="markdown-output"], [data-slot="html-output"]) h3 {
-        margin: 1.2rem 0 0.625rem;
+        margin: 1.5rem 0 0.625rem;
         font-size: 1.25rem;
       }
 
@@ -172,9 +186,10 @@
       }
 
       :is([data-slot="markdown-output"], [data-slot="html-output"]) blockquote {
-        margin: 1rem 0;
-        padding-left: 1rem;
-        border-left: 4px solid var(--border-color);
+        margin: 1.25rem 0;
+        padding: 0.75rem 1rem 0.75rem 1.25rem;
+        border-left: 3px solid color-mix(in oklch, var(--accent-color) 52%, transparent);
+        background: color-mix(in oklch, var(--bg-secondary) 62%, transparent);
         color: var(--text-secondary);
         font-style: italic;
       }
@@ -188,6 +203,29 @@
       :is([data-slot="markdown-output"], [data-slot="html-output"]) pre,
       :is([data-slot="markdown-output"], [data-slot="html-output"]) code {
         font-family: var(--output-mono-font);
+      }
+
+      :is([data-slot="markdown-output"], [data-slot="html-output"]) :not(pre) > code {
+        padding: 0.125rem 0.375rem;
+        border: 1px solid var(--border-color);
+        border-radius: 0.125rem;
+        background: color-mix(in oklch, var(--bg-secondary) 72%, transparent);
+        color: var(--text-primary);
+        font-size: 0.88em;
+      }
+
+      :is([data-slot="markdown-output"], [data-slot="html-output"]) strong {
+        color: var(--text-primary);
+        font-weight: 600;
+      }
+
+      :is([data-slot="markdown-output"], [data-slot="html-output"]) em {
+        color: var(--text-secondary);
+      }
+
+      :is([data-slot="markdown-output"], [data-slot="html-output"]) del {
+        color: var(--text-secondary);
+        text-decoration-thickness: 2px;
       }
 
       :is([data-slot="markdown-output"], [data-slot="html-output"]) table,
@@ -218,11 +256,25 @@
         font-size: 0.875rem;
       }
 
+      :is([data-slot="markdown-output"], [data-slot="html-output"]) table {
+        margin: 1.25rem 0;
+        border: 1px solid var(--border-color);
+        border-radius: 0.125rem;
+        background: var(--bg-primary);
+        box-shadow: 0 1px 2px color-mix(in oklch, var(--text-primary) 10%, transparent);
+        overflow: hidden;
+      }
+
       th,
       td {
         border: 1px solid var(--border-color);
         padding: 4px 8px;
         text-align: left;
+      }
+
+      :is([data-slot="markdown-output"], [data-slot="html-output"]) th,
+      :is([data-slot="markdown-output"], [data-slot="html-output"]) td {
+        padding: 0.625rem 0.75rem;
       }
 
       th {
@@ -234,6 +286,24 @@
       img {
         max-width: 100%;
         height: auto;
+      }
+
+      :is([data-slot="markdown-output"], [data-slot="html-output"]) img {
+        margin: 1.25rem 0;
+        border: 1px solid var(--border-color);
+        border-radius: 0.125rem;
+        background: color-mix(in oklch, var(--bg-secondary) 38%, transparent);
+        box-shadow: 0 1px 2px color-mix(in oklch, var(--text-primary) 10%, transparent);
+      }
+
+      :is([data-slot="markdown-output"], [data-slot="html-output"]) section[data-footnotes] {
+        margin-top: 2rem;
+        padding-top: 1rem;
+        border-top: 1px solid var(--border-color);
+        color: var(--text-secondary);
+        font-family: var(--output-ui-font);
+        font-size: 0.875rem;
+        line-height: 1.5rem;
       }
 
       /* Links */

--- a/src/components/isolated/frame.html
+++ b/src/components/isolated/frame.html
@@ -468,7 +468,13 @@
       :is([data-slot="markdown-output"], [data-slot="html-output"]) .katex-display {
         margin: 1.25rem 0;
         overflow-x: auto;
+        scrollbar-width: none;
         text-align: center;
+      }
+
+      :is([data-slot="markdown-output"], [data-slot="html-output"])
+        .katex-display::-webkit-scrollbar {
+        display: none;
       }
 
       /* Links */

--- a/src/components/markdown/ProjectedMarkdownView.tsx
+++ b/src/components/markdown/ProjectedMarkdownView.tsx
@@ -14,11 +14,23 @@ import { cn } from "@/lib/utils";
 import type { MarkdownHeadingAnchor } from "@/components/outputs/markdown-heading-anchors";
 import {
   markdownBlockquoteClassName,
+  markdownDeleteClassName,
   markdownDocumentClassName,
+  markdownEmphasisClassName,
+  markdownImageClassName,
   markdownHeadingClassName,
   markdownInlineCodeClassName,
   markdownLinkClassName,
   markdownListMarkerClassName,
+  markdownParagraphClassName,
+  markdownStrongClassName,
+  markdownTableCellClassName,
+  markdownTableClassName,
+  markdownTableHeadClassName,
+  markdownTableHeaderCellClassName,
+  markdownTableRowClassName,
+  markdownTableWrapperClassName,
+  markdownThematicBreakClassName,
 } from "./markdown-typography";
 
 import "katex/dist/katex.min.css";
@@ -179,7 +191,7 @@ function ProjectedMarkdownBlock({
   }
 
   if (block.kind === "thematic-break") {
-    return <hr className="my-6 border-border" />;
+    return <hr className={markdownThematicBreakClassName} />;
   }
 
   if (block.kind === "table") {
@@ -203,7 +215,7 @@ function ProjectedMarkdownBlock({
       <p
         data-source-active={activeBlockId === block.blockId ? "true" : undefined}
         className={cn(
-          "my-3 leading-relaxed",
+          markdownParagraphClassName,
           activeBlockId === block.blockId && sourceActiveBlockClass,
         )}
       >
@@ -546,19 +558,16 @@ function ProjectedTable({
     <div
       data-slot="projected-markdown-table"
       data-source-active={activeBlock ? "true" : undefined}
-      className={cn(
-        "my-4 overflow-x-auto border-y border-border",
-        activeBlock && sourceActiveBlockClass,
-      )}
+      className={cn(markdownTableWrapperClassName, activeBlock && sourceActiveBlockClass)}
     >
-      <table className="min-w-full border-collapse font-[var(--output-ui-font)] text-sm leading-normal">
+      <table className={markdownTableClassName}>
         {hasHeader ? (
-          <thead>
+          <thead className={markdownTableHeadClassName}>
             <tr>
               {headerRow.cells.map((cell) => (
                 <th
                   key={cell.key}
-                  className="border-b border-r border-border bg-muted/55 px-3 py-2 text-left font-semibold text-foreground last:border-r-0"
+                  className={markdownTableHeaderCellClassName}
                   style={tableCellStyle(cell.align)}
                 >
                   {renderRuns(cell.runs, onLinkClick, activeInlineId)}
@@ -569,11 +578,11 @@ function ProjectedTable({
         ) : null}
         <tbody>
           {(hasHeader ? bodyRows : rows).map((row) => (
-            <tr key={row.key} className="odd:bg-muted/[0.04]">
+            <tr key={row.key} className={markdownTableRowClassName}>
               {row.cells.map((cell) => (
                 <td
                   key={cell.key}
-                  className="border-r border-t border-border px-3 py-2 align-top text-muted-foreground first:text-foreground last:border-r-0"
+                  className={markdownTableCellClassName}
                   style={tableCellStyle(cell.align)}
                 >
                   {renderRuns(cell.runs, onLinkClick, activeInlineId)}
@@ -676,9 +685,9 @@ function renderRun(run: MarkdownProjectionRun, onLinkClick?: (url: string) => vo
     );
   }
 
-  if (run.semantic === "strong") return <strong>{text}</strong>;
-  if (run.semantic === "emphasis") return <em>{text}</em>;
-  if (run.semantic === "delete") return <del>{text}</del>;
+  if (run.semantic === "strong") return <strong className={markdownStrongClassName}>{text}</strong>;
+  if (run.semantic === "emphasis") return <em className={markdownEmphasisClassName}>{text}</em>;
+  if (run.semantic === "delete") return <del className={markdownDeleteClassName}>{text}</del>;
   if (run.semantic === "inline-code") return <InlineCode>{text}</InlineCode>;
   if (run.semantic === "math-source") return <ProjectedMath latex={text} />;
   if (run.semantic === "code-block") return text;
@@ -699,7 +708,7 @@ function ProjectedImage({ run }: { run: MarkdownProjectionRun }) {
       src={src}
       alt={alt}
       title={run.imageTitle}
-      className="my-4 max-w-full h-auto rounded-sm"
+      className={markdownImageClassName}
       loading="lazy"
     />
   );

--- a/src/components/markdown/ProjectedMarkdownView.tsx
+++ b/src/components/markdown/ProjectedMarkdownView.tsx
@@ -14,6 +14,10 @@ import { cn } from "@/lib/utils";
 import type { MarkdownHeadingAnchor } from "@/components/outputs/markdown-heading-anchors";
 import {
   markdownBlockquoteClassName,
+  markdownCodeBlockCopyButtonClassName,
+  markdownCodeBlockLabelClassName,
+  markdownCodeBlockShellClassName,
+  markdownCodeBlockToolbarClassName,
   markdownDeleteClassName,
   markdownDisplayMathClassName,
   markdownDocumentClassName,
@@ -827,8 +831,22 @@ function ProjectedCodeBlock({
     }
   };
 
+  const languageLabel = codeBlockLanguageLabel(language);
+
   return (
-    <div className="group/codeblock relative my-3">
+    <div className={markdownCodeBlockShellClassName}>
+      <div className={markdownCodeBlockToolbarClassName}>
+        <span className={markdownCodeBlockLabelClassName}>{languageLabel}</span>
+        <button
+          type="button"
+          aria-label={copied ? "Copied code" : "Copy code"}
+          className={markdownCodeBlockCopyButtonClassName}
+          title={copied ? "Copied" : "Copy code"}
+          onClick={copyCode}
+        >
+          {copied ? <Check className="size-3" /> : <Copy className="size-3" />}
+        </button>
+      </div>
       <StaticCodeBlock
         code={code}
         colorTheme={colorTheme}
@@ -836,17 +854,14 @@ function ProjectedCodeBlock({
         language={language}
         className="max-w-full"
       />
-      <button
-        type="button"
-        aria-label={copied ? "Copied code" : "Copy code"}
-        className="absolute top-2 right-2 z-10 rounded border border-border bg-background p-1.5 text-muted-foreground opacity-0 shadow-sm transition-opacity group-hover/codeblock:opacity-100 hover:bg-muted hover:text-foreground focus-visible:opacity-100 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/40"
-        title={copied ? "Copied" : "Copy code"}
-        onClick={copyCode}
-      >
-        {copied ? <Check className="size-3" /> : <Copy className="size-3" />}
-      </button>
     </div>
   );
+}
+
+function codeBlockLanguageLabel(language: string | undefined): string {
+  const trimmed = language?.trim();
+  if (!trimmed) return "code";
+  return trimmed;
 }
 
 function ProjectedMath({ displayMode = false, latex }: { displayMode?: boolean; latex: string }) {

--- a/src/components/markdown/ProjectedMarkdownView.tsx
+++ b/src/components/markdown/ProjectedMarkdownView.tsx
@@ -859,7 +859,7 @@ function ProjectedCodeBlock({
           className={markdownCodeBlockLabelClassName}
           title={languageLabel === "code" ? "Code block" : `${languageLabel} code block`}
         >
-          code
+          {languageLabel}
         </span>
         <button
           type="button"

--- a/src/components/markdown/ProjectedMarkdownView.tsx
+++ b/src/components/markdown/ProjectedMarkdownView.tsx
@@ -17,6 +17,9 @@ import {
   markdownDeleteClassName,
   markdownDocumentClassName,
   markdownEmphasisClassName,
+  markdownFigureCaptionClassName,
+  markdownFigureClassName,
+  markdownHeadingAnchorClassName,
   markdownImageClassName,
   markdownHeadingClassName,
   markdownInlineCodeClassName,
@@ -130,6 +133,15 @@ function ProjectedMarkdownBlock({
         )}
       >
         {renderRuns(runs, onLinkClick, activeInlineId)}
+        {headingAnchor?.headingAnchorId ? (
+          <a
+            aria-label={`Link to ${block.text}`}
+            className={markdownHeadingAnchorClassName}
+            href={`#${headingAnchor.headingAnchorId}`}
+          >
+            #
+          </a>
+        ) : null}
       </Heading>
     );
   }
@@ -211,6 +223,17 @@ function ProjectedMarkdownBlock({
   }
 
   if (block.kind === "paragraph") {
+    const figureRun = imageOnlyRun(runs);
+    if (figureRun) {
+      return (
+        <ProjectedFigure
+          active={activeBlockId === block.blockId}
+          activeInlineId={activeInlineId}
+          run={figureRun}
+        />
+      );
+    }
+
     return (
       <p
         data-source-active={activeBlockId === block.blockId ? "true" : undefined}
@@ -694,6 +717,41 @@ function renderRun(run: MarkdownProjectionRun, onLinkClick?: (url: string) => vo
   if (run.semantic === "link-label") return text;
 
   return text;
+}
+
+function imageOnlyRun(runs: MarkdownProjectionRun[]): MarkdownProjectionRun | null {
+  const visibleRuns = runs.filter((run) => run.semantic !== "isolated-placeholder");
+  if (visibleRuns.length !== 1) return null;
+  const [run] = visibleRuns;
+  return run.semantic === "image" && run.imageSrc ? run : null;
+}
+
+function ProjectedFigure({
+  active,
+  activeInlineId,
+  run,
+}: {
+  active: boolean;
+  activeInlineId?: string;
+  run: MarkdownProjectionRun;
+}) {
+  const image = <ProjectedImage run={run} />;
+  const title = run.imageTitle?.trim();
+  return (
+    <figure
+      data-source-active={active ? "true" : undefined}
+      className={cn(markdownFigureClassName, active && sourceActiveBlockClass)}
+    >
+      {activeInlineId === run.inlineId ? (
+        <span data-source-active-run="true" className={sourceActiveRunClass}>
+          {image}
+        </span>
+      ) : (
+        image
+      )}
+      {title ? <figcaption className={markdownFigureCaptionClassName}>{title}</figcaption> : null}
+    </figure>
+  );
 }
 
 function ProjectedImage({ run }: { run: MarkdownProjectionRun }) {

--- a/src/components/markdown/ProjectedMarkdownView.tsx
+++ b/src/components/markdown/ProjectedMarkdownView.tsx
@@ -16,6 +16,7 @@ import {
   markdownBlockquoteClassName,
   markdownCodeBlockCopyButtonClassName,
   markdownCodeBlockLabelClassName,
+  markdownCodeBlockPreStyle,
   markdownCodeBlockShellClassName,
   markdownCodeBlockToolbarClassName,
   markdownDeleteClassName,
@@ -598,6 +599,7 @@ function ProjectedTable({
 
   const [headerRow, ...bodyRows] = rows;
   const hasHeader = headerRow?.cells.some((cell) => cell.header);
+  const columnAlign = tableColumnAlignments(rows);
 
   return (
     <div
@@ -613,7 +615,7 @@ function ProjectedTable({
                 <th
                   key={cell.key}
                   className={markdownTableHeaderCellClassName}
-                  style={tableCellStyle(cell.align)}
+                  style={tableCellStyle(columnAlign.get(cell.cellIndex))}
                 >
                   {renderRuns(cell.runs, onLinkClick, activeInlineId)}
                 </th>
@@ -628,7 +630,7 @@ function ProjectedTable({
                 <td
                   key={cell.key}
                   className={markdownTableCellClassName}
-                  style={tableCellStyle(cell.align)}
+                  style={tableCellStyle(columnAlign.get(cell.cellIndex))}
                 >
                   {renderRuns(cell.runs, onLinkClick, activeInlineId)}
                 </td>
@@ -663,11 +665,51 @@ function groupTableRuns(runs: MarkdownProjectionRun[]) {
     key: rowIndex,
     cells: Array.from(cells, ([cellIndex, runs]) => ({
       align: runs.find((run) => run.tableCellAlign)?.tableCellAlign,
+      cellIndex,
       header: runs.some((run) => run.tableCellHeader),
       key: `${rowIndex}:${cellIndex}`,
       runs,
     })),
   }));
+}
+
+function tableColumnAlignments(rows: ReturnType<typeof groupTableRuns>) {
+  const alignments = new Map<number, MarkdownProjectionRun["tableCellAlign"]>();
+
+  for (const row of rows) {
+    for (const cell of row.cells) {
+      if (cell.align) {
+        alignments.set(cell.cellIndex, cell.align);
+      }
+    }
+  }
+
+  for (const row of rows.slice(1)) {
+    for (const cell of row.cells) {
+      if (alignments.has(cell.cellIndex)) continue;
+      const columnCells = rows
+        .slice(1)
+        .flatMap((bodyRow) =>
+          bodyRow.cells.filter((bodyCell) => bodyCell.cellIndex === cell.cellIndex),
+        );
+      if (
+        columnCells.length > 0 &&
+        columnCells.every((bodyCell) => isNumericTableCell(bodyCell.runs))
+      ) {
+        alignments.set(cell.cellIndex, "right");
+      }
+    }
+  }
+
+  return alignments;
+}
+
+function isNumericTableCell(runs: MarkdownProjectionRun[]) {
+  const text = runs
+    .map((run) => run.renderedText)
+    .join("")
+    .trim();
+  return /^[-+]?(?:[$]\s*)?\d[\d,]*(?:\.\d+)?(?:\s?(?:%|[a-zA-Z]+))?$/.test(text);
 }
 
 function tableCellStyle(align: MarkdownProjectionRun["tableCellAlign"]): CSSProperties | undefined {
@@ -851,6 +893,7 @@ function ProjectedCodeBlock({
 
   return (
     <div
+      data-slot="markdown-code-block"
       className={markdownCodeBlockShellClassName}
       data-code-language={languageLabel === "code" ? undefined : languageLabel}
     >
@@ -877,6 +920,7 @@ function ProjectedCodeBlock({
         isDark={isDark}
         language={language}
         className="max-w-full"
+        style={markdownCodeBlockPreStyle}
       />
     </div>
   );

--- a/src/components/markdown/ProjectedMarkdownView.tsx
+++ b/src/components/markdown/ProjectedMarkdownView.tsx
@@ -33,6 +33,11 @@ import {
   markdownListMarkerClassName,
   markdownParagraphClassName,
   markdownStrongClassName,
+  markdownTaskCheckboxClassName,
+  markdownTaskCheckboxGlyphClassName,
+  markdownTaskContentClassName,
+  markdownTaskListClassName,
+  markdownTaskListItemClassName,
   markdownTableCellClassName,
   markdownTableClassName,
   markdownTableHeadClassName,
@@ -318,10 +323,13 @@ function ProjectedList({
     <List
       data-source-active={activeBlock ? "true" : undefined}
       className={cn(
-        "my-3 ml-6 leading-relaxed",
-        ordered ? "list-decimal" : "list-disc",
-        markdownListMarkerClassName,
-        allItemsAreTasks && "ml-0 list-none",
+        allItemsAreTasks
+          ? markdownTaskListClassName
+          : cn(
+              "my-3 ml-6 leading-relaxed",
+              ordered ? "list-decimal" : "list-disc",
+              markdownListMarkerClassName,
+            ),
         activeBlock && sourceActiveBlockClass,
       )}
     >
@@ -330,6 +338,7 @@ function ProjectedList({
           key={item.key}
           item={item}
           activeInlineId={activeInlineId}
+          taskProtocol={allItemsAreTasks}
           onLinkClick={onLinkClick}
           onTaskCheckedChange={onTaskCheckedChange}
         />
@@ -341,11 +350,13 @@ function ProjectedList({
 function ProjectedListItem({
   item,
   activeInlineId,
+  taskProtocol,
   onLinkClick,
   onTaskCheckedChange,
 }: {
   item: ProjectedListItem;
   activeInlineId?: string;
+  taskProtocol: boolean;
   onLinkClick?: (url: string) => void;
   onTaskCheckedChange?: (run: MarkdownProjectionRun, checked: boolean) => void;
 }) {
@@ -380,12 +391,20 @@ function ProjectedListItem({
         "group/task my-1",
         item.checked !== undefined && "list-none",
         item.checked !== undefined && item.children.length === 0
-          ? "flex min-w-0 items-start gap-2"
+          ? taskProtocol
+            ? markdownTaskListItemClassName
+            : "flex min-w-0 items-start gap-2"
           : null,
       )}
     >
       {item.checked !== undefined && item.children.length > 0 ? (
-        <div className="flex min-w-0 items-start gap-2">{content}</div>
+        <div
+          className={cn(
+            taskProtocol ? markdownTaskListItemClassName : "flex min-w-0 items-start gap-2",
+          )}
+        >
+          {content}
+        </div>
       ) : (
         content
       )}
@@ -505,10 +524,7 @@ function TaskCheckbox({
 
   return (
     <label
-      className={cn(
-        "relative mt-[0.34em] inline-grid size-4 shrink-0 place-items-center",
-        interactive && "cursor-pointer",
-      )}
+      className={cn(markdownTaskCheckboxClassName, interactive && "cursor-pointer")}
       data-slot="projected-markdown-task-checkbox"
       data-state={checked ? "checked" : "unchecked"}
     >
@@ -525,7 +541,7 @@ function TaskCheckbox({
       <span
         aria-hidden="true"
         className={cn(
-          "pointer-events-none grid size-3.5 place-items-center rounded-sm border transition-colors peer-focus-visible:ring-2 peer-focus-visible:ring-ring/40 peer-focus-visible:ring-offset-1 peer-disabled:opacity-100",
+          markdownTaskCheckboxGlyphClassName,
           checked
             ? "border-primary bg-primary text-primary-foreground"
             : "border-border bg-background",
@@ -546,7 +562,7 @@ function ProjectedTaskContent({
   children: ReactNode;
 }) {
   return (
-    <span className={cn("min-w-0 leading-relaxed", checked === true && "text-muted-foreground")}>
+    <span className={cn(markdownTaskContentClassName, checked === true && "text-muted-foreground")}>
       {children}
     </span>
   );

--- a/src/components/markdown/ProjectedMarkdownView.tsx
+++ b/src/components/markdown/ProjectedMarkdownView.tsx
@@ -15,14 +15,16 @@ import type { MarkdownHeadingAnchor } from "@/components/outputs/markdown-headin
 import {
   markdownBlockquoteClassName,
   markdownDeleteClassName,
+  markdownDisplayMathClassName,
   markdownDocumentClassName,
   markdownEmphasisClassName,
   markdownFigureCaptionClassName,
   markdownFigureClassName,
   markdownHeadingAnchorClassName,
-  markdownImageClassName,
   markdownHeadingClassName,
+  markdownImageClassName,
   markdownInlineCodeClassName,
+  markdownInlineMathClassName,
   markdownLinkClassName,
   markdownListMarkerClassName,
   markdownParagraphClassName,
@@ -852,7 +854,7 @@ function ProjectedMath({ displayMode = false, latex }: { displayMode?: boolean; 
   if (!html) {
     if (displayMode) {
       return (
-        <div className="my-4 overflow-x-auto">
+        <div className={markdownDisplayMathClassName}>
           <InlineCode className="block px-3 py-2">{latex}</InlineCode>
         </div>
       );
@@ -866,7 +868,7 @@ function ProjectedMath({ displayMode = false, latex }: { displayMode?: boolean; 
       <div
         data-slot="projected-markdown-math"
         data-display-mode="true"
-        className="my-4 overflow-x-auto px-1 py-1 text-center [&_.katex-display]:my-0"
+        className={markdownDisplayMathClassName}
         dangerouslySetInnerHTML={{ __html: html }}
       />
     );
@@ -876,7 +878,7 @@ function ProjectedMath({ displayMode = false, latex }: { displayMode?: boolean; 
     <span
       data-slot="projected-markdown-math"
       data-display-mode="false"
-      className="inline align-baseline [&_.katex]:text-[1.03em]"
+      className={markdownInlineMathClassName}
       dangerouslySetInnerHTML={{ __html: html }}
     />
   );

--- a/src/components/markdown/ProjectedMarkdownView.tsx
+++ b/src/components/markdown/ProjectedMarkdownView.tsx
@@ -850,9 +850,17 @@ function ProjectedCodeBlock({
   const languageLabel = codeBlockLanguageLabel(language);
 
   return (
-    <div className={markdownCodeBlockShellClassName}>
+    <div
+      className={markdownCodeBlockShellClassName}
+      data-code-language={languageLabel === "code" ? undefined : languageLabel}
+    >
       <div className={markdownCodeBlockToolbarClassName}>
-        <span className={markdownCodeBlockLabelClassName}>{languageLabel}</span>
+        <span
+          className={markdownCodeBlockLabelClassName}
+          title={languageLabel === "code" ? "Code block" : `${languageLabel} code block`}
+        >
+          code
+        </span>
         <button
           type="button"
           aria-label={copied ? "Copied code" : "Copy code"}

--- a/src/components/markdown/__tests__/ProjectedMarkdownView.test.tsx
+++ b/src/components/markdown/__tests__/ProjectedMarkdownView.test.tsx
@@ -99,11 +99,8 @@ describe("ProjectedMarkdownView", () => {
       "[&>*:last-child]:mb-0",
     );
     expect(screen.getByRole("heading", { level: 1 })).toHaveClass("text-[2rem]", "font-semibold");
-    expect(screen.getByRole("heading", { level: 2 })).toHaveClass(
-      "text-2xl",
-      "font-semibold",
-      "after:bg-primary/50",
-    );
+    expect(screen.getByRole("heading", { level: 2 })).toHaveClass("text-2xl", "font-semibold");
+    expect(screen.getByRole("heading", { level: 2 })).not.toHaveClass("after:bg-primary/50");
     expect(screen.getByRole("heading", { level: 3 })).toHaveClass("text-xl", "font-semibold");
     expect(screen.getByRole("heading", { level: 4 })).toHaveClass("text-lg", "font-semibold");
   });
@@ -219,6 +216,8 @@ describe("ProjectedMarkdownView", () => {
       "my-5",
       "text-center",
       "overflow-x-auto",
+    );
+    expect(document.querySelector(".katex-display")?.parentElement).not.toHaveClass(
       "border-y",
       "bg-muted/[0.16]",
     );
@@ -972,7 +971,8 @@ describe("ProjectedMarkdownView", () => {
       />,
     );
 
-    expect(screen.getByText("code")).toHaveClass("uppercase", "tracking-[0.08em]");
+    expect(screen.getByText("code")).toHaveClass("text-muted-foreground/80");
+    expect(screen.getByText("code")).not.toHaveClass("uppercase", "tracking-[0.08em]");
     expect(screen.getByRole("button", { name: "Copy code" })).toHaveClass(
       "inline-flex",
       "border",
@@ -1004,7 +1004,12 @@ describe("ProjectedMarkdownView", () => {
     );
 
     expect(screen.getByText("datasets")).toBeInTheDocument();
-    expect(screen.getByText("python")).toHaveClass("uppercase", "tracking-[0.08em]");
+    expect(screen.getByText("code")).toHaveAttribute("title", "python code block");
+    expect(screen.getByText("code").closest("[data-code-language]")).toHaveAttribute(
+      "data-code-language",
+      "python",
+    );
+    expect(screen.queryByText("python")).toBeNull();
     expect(document.querySelector("pre code span")).not.toBeNull();
   });
 
@@ -1221,6 +1226,45 @@ describe("ProjectedMarkdownView", () => {
     expect(image).toHaveClass("border", "shadow-sm");
     expect(image.closest("figure")).toHaveClass("my-5");
     expect(screen.getByText("Daily plot")).toHaveClass("text-xs", "text-muted-foreground");
+  });
+
+  it("does not promote image alt text into a figure caption", () => {
+    render(
+      <ProjectedMarkdownView
+        plan={plan({
+          blocks: [
+            {
+              blockId: "image",
+              blockIndex: 0,
+              element: "p",
+              kind: "paragraph",
+              measurement: { estimatedHeight: 120, confidence: "low", width: 720 },
+              sourceSpanByte: [0, 42],
+              sourceSpanUtf16: [0, 42],
+              syntaxSpans: [],
+              text: "Plot alt",
+            },
+          ],
+          runs: [
+            {
+              blockId: "image",
+              imageAlt: "Plot alt",
+              imageSrc: "attachment:plot.png",
+              inlineId: "img0",
+              listItemIndex: null,
+              renderedText: "Plot alt",
+              renderedTextUtf16: [0, 8],
+              semantic: "image",
+              sourceSpanByte: [0, 42],
+              sourceSpanUtf16: [0, 42],
+            },
+          ],
+        })}
+      />,
+    );
+
+    expect(screen.getByRole("img", { name: "Plot alt" })).toBeInTheDocument();
+    expect(document.querySelector("figcaption")).toBeNull();
   });
 
   it("does not render projected images with unsafe sources", () => {

--- a/src/components/markdown/__tests__/ProjectedMarkdownView.test.tsx
+++ b/src/components/markdown/__tests__/ProjectedMarkdownView.test.tsx
@@ -108,6 +108,56 @@ describe("ProjectedMarkdownView", () => {
     expect(screen.getByRole("heading", { level: 4 })).toHaveClass("text-lg", "font-semibold");
   });
 
+  it("renders heading anchors when outline metadata is available", () => {
+    render(
+      <ProjectedMarkdownView
+        headingAnchors={[
+          {
+            itemId: "cell-a:heading:0",
+            title: "Claim",
+            level: 2,
+            anchor: "claim",
+            headingAnchorId: "notebook-cell-cell-a-heading-claim",
+          },
+        ]}
+        plan={plan({
+          blocks: [
+            {
+              anchorSlug: "claim",
+              blockId: "claim",
+              blockIndex: 0,
+              element: "h2",
+              kind: "heading",
+              measurement: { estimatedHeight: 40, confidence: "high", width: 720 },
+              sourceSpanByte: [0, 8],
+              sourceSpanUtf16: [0, 8],
+              syntaxSpans: [],
+              text: "Claim",
+            },
+          ],
+          runs: [
+            {
+              blockId: "claim",
+              inlineId: "claim-text",
+              listItemIndex: null,
+              renderedText: "Claim",
+              renderedTextUtf16: [0, 5],
+              semantic: "text",
+              sourceSpanByte: [0, 5],
+              sourceSpanUtf16: [0, 5],
+            },
+          ],
+        })}
+      />,
+    );
+
+    const heading = screen.getByRole("heading", { level: 2 });
+    const anchor = screen.getByRole("link", { name: "Link to Claim" });
+    expect(heading).toHaveAttribute("id", "notebook-cell-cell-a-heading-claim");
+    expect(anchor).toHaveAttribute("href", "#notebook-cell-cell-a-heading-claim");
+    expect(anchor).toHaveClass("text-muted-foreground/40", "hover:text-primary");
+  });
+
   it("renders projected inline and display math with KaTeX", () => {
     render(
       <ProjectedMarkdownView
@@ -1110,6 +1160,8 @@ describe("ProjectedMarkdownView", () => {
     expect(image).toHaveAttribute("src", "attachment:plot.png");
     expect(image).toHaveAttribute("title", "Daily plot");
     expect(image).toHaveClass("border", "shadow-sm");
+    expect(image.closest("figure")).toHaveClass("my-5");
+    expect(screen.getByText("Daily plot")).toHaveClass("text-xs", "text-muted-foreground");
   });
 
   it("does not render projected images with unsafe sources", () => {

--- a/src/components/markdown/__tests__/ProjectedMarkdownView.test.tsx
+++ b/src/components/markdown/__tests__/ProjectedMarkdownView.test.tsx
@@ -215,9 +215,10 @@ describe("ProjectedMarkdownView", () => {
     expect(document.querySelector(".katex-display")?.parentElement).toHaveClass(
       "my-5",
       "text-center",
+      "overflow-x-hidden",
+    );
+    expect(document.querySelector(".katex-display")?.parentElement).not.toHaveClass(
       "overflow-x-auto",
-      "[scrollbar-width:none]",
-      "[&::-webkit-scrollbar]:hidden",
     );
     expect(document.querySelector(".katex-display")?.parentElement).not.toHaveClass(
       "border-y",

--- a/src/components/markdown/__tests__/ProjectedMarkdownView.test.tsx
+++ b/src/components/markdown/__tests__/ProjectedMarkdownView.test.tsx
@@ -215,10 +215,11 @@ describe("ProjectedMarkdownView", () => {
     expect(document.querySelector(".katex-display")?.parentElement).toHaveClass(
       "my-5",
       "text-center",
-      "overflow-x-hidden",
+      "overflow-x-clip",
     );
     expect(document.querySelector(".katex-display")?.parentElement).not.toHaveClass(
       "overflow-x-auto",
+      "overflow-x-hidden",
     );
     expect(document.querySelector(".katex-display")?.parentElement).not.toHaveClass(
       "border-y",
@@ -309,11 +310,11 @@ describe("ProjectedMarkdownView", () => {
     expect(screen.getByText("First paragraph")).toHaveClass("my-3", "leading-relaxed");
     expect(screen.getByRole("list")).toHaveClass("my-3", "ml-6", "list-disc");
     expect(screen.getByText("quoted").closest("blockquote")).toHaveClass(
-      "border-l-[3px]",
-      "border-primary/45",
-      "bg-muted/[0.20]",
-      "text-muted-foreground",
+      "border-l-2",
+      "border-foreground/35",
+      "text-foreground/80",
     );
+    expect(screen.getByText("quoted").closest("blockquote")).not.toHaveClass("bg-muted/[0.20]");
   });
 
   it("renders links with visible affordance before hover", () => {
@@ -854,7 +855,6 @@ describe("ProjectedMarkdownView", () => {
               semantic: "table-cell",
               sourceSpanByte: [11, 16],
               sourceSpanUtf16: [11, 16],
-              tableCellAlign: "right",
               tableCellHeader: true,
               tableCellIndex: 1,
               tableRowIndex: 0,
@@ -893,6 +893,9 @@ describe("ProjectedMarkdownView", () => {
 
     expect(screen.getByRole("table")).toBeInTheDocument();
     expect(screen.getByRole("columnheader", { name: "metric" })).toBeInTheDocument();
+    expect(screen.getByRole("columnheader", { name: "value" })).toHaveStyle({
+      textAlign: "right",
+    });
     expect(screen.getByRole("cell", { name: "128" })).toHaveStyle({ textAlign: "right" });
     expect(screen.getByRole("table").parentElement).toHaveClass(
       "rounded-sm",
@@ -979,8 +982,16 @@ describe("ProjectedMarkdownView", () => {
     expect(screen.getByText("code")).not.toHaveClass("uppercase", "tracking-[0.08em]");
     expect(screen.getByRole("button", { name: "Copy code" })).toHaveClass(
       "inline-flex",
-      "border",
-      "bg-background/80",
+      "border-transparent",
+      "bg-transparent",
+    );
+    expect(screen.getByText("code").closest('[data-slot="markdown-code-block"]')).toHaveClass(
+      "border-l-2",
+      "bg-muted/[0.14]",
+    );
+    expect(screen.getByText("code").closest('[data-slot="markdown-code-block"]')).not.toHaveClass(
+      "rounded-md",
+      "shadow-sm",
     );
   });
 

--- a/src/components/markdown/__tests__/ProjectedMarkdownView.test.tsx
+++ b/src/components/markdown/__tests__/ProjectedMarkdownView.test.tsx
@@ -216,12 +216,11 @@ describe("ProjectedMarkdownView", () => {
     expect(document.querySelectorAll(".katex").length).toBeGreaterThanOrEqual(2);
     expect(document.querySelector(".katex-display")).not.toBeNull();
     expect(document.querySelector(".katex-display")?.parentElement).toHaveClass(
+      "my-5",
       "text-center",
       "overflow-x-auto",
-      "px-1",
-    );
-    expect(document.querySelector(".katex-display")?.parentElement).not.toHaveClass(
-      "bg-muted/[0.18]",
+      "border-y",
+      "bg-muted/[0.16]",
     );
     expect(document.querySelector(".katex-display")?.parentElement).toHaveAttribute(
       "data-display-mode",

--- a/src/components/markdown/__tests__/ProjectedMarkdownView.test.tsx
+++ b/src/components/markdown/__tests__/ProjectedMarkdownView.test.tsx
@@ -564,6 +564,62 @@ describe("ProjectedMarkdownView", () => {
     expect(onTaskCheckedChange).toHaveBeenCalledWith(taskRun, true);
   });
 
+  it("frames all-task projected lists as lab protocols", () => {
+    render(
+      <ProjectedMarkdownView
+        plan={plan({
+          blocks: [
+            {
+              blockId: "list",
+              blockIndex: 0,
+              element: "ul",
+              kind: "list",
+              measurement: { estimatedHeight: 48, confidence: "high", width: 720 },
+              sourceSpanByte: [0, 24],
+              sourceSpanUtf16: [0, 24],
+              syntaxSpans: [],
+              text: "done waiting",
+            },
+          ],
+          runs: [
+            {
+              blockId: "list",
+              inlineId: "done",
+              listItemChecked: true,
+              listItemIndex: 0,
+              renderedText: "done",
+              renderedTextUtf16: [0, 4],
+              semantic: "list-item",
+              sourceSpanByte: [0, 10],
+              sourceSpanUtf16: [0, 10],
+            },
+            {
+              blockId: "list",
+              inlineId: "waiting",
+              listItemChecked: false,
+              listItemIndex: 1,
+              renderedText: "waiting",
+              renderedTextUtf16: [0, 7],
+              semantic: "list-item",
+              sourceSpanByte: [11, 24],
+              sourceSpanUtf16: [11, 24],
+            },
+          ],
+        })}
+      />,
+    );
+
+    expect(screen.getByRole("list")).toHaveClass("rounded-md", "border", "p-2");
+    expect(screen.getByRole("list")).not.toHaveClass("list-disc");
+    expect(screen.getByText("waiting").closest("li")).toHaveClass(
+      "grid",
+      "grid-cols-[auto_minmax(0,1fr)]",
+    );
+    expect(
+      document.querySelector('[data-slot="projected-markdown-task-checkbox"] span'),
+    ).toHaveClass("size-4");
+  });
+
   it("keeps list markers available for mixed task and regular lists", () => {
     render(
       <ProjectedMarkdownView

--- a/src/components/markdown/__tests__/ProjectedMarkdownView.test.tsx
+++ b/src/components/markdown/__tests__/ProjectedMarkdownView.test.tsx
@@ -216,6 +216,8 @@ describe("ProjectedMarkdownView", () => {
       "my-5",
       "text-center",
       "overflow-x-auto",
+      "[scrollbar-width:none]",
+      "[&::-webkit-scrollbar]:hidden",
     );
     expect(document.querySelector(".katex-display")?.parentElement).not.toHaveClass(
       "border-y",

--- a/src/components/markdown/__tests__/ProjectedMarkdownView.test.tsx
+++ b/src/components/markdown/__tests__/ProjectedMarkdownView.test.tsx
@@ -469,7 +469,8 @@ describe("ProjectedMarkdownView", () => {
       document.querySelector('[data-slot="projected-markdown-task-checkbox"] span'),
     ).toHaveClass("bg-primary");
     expect(screen.getByText("important").tagName).toBe("EM");
-    expect(screen.getByText("important")).toHaveClass("text-muted-foreground");
+    expect(screen.getByText("important")).toHaveClass("text-foreground");
+    expect(screen.getByText("important")).not.toHaveClass("text-muted-foreground");
     expect(screen.getByText("removed").tagName).toBe("DEL");
     expect(screen.getByText("removed")).toHaveClass("decoration-destructive/55");
   });

--- a/src/components/markdown/__tests__/ProjectedMarkdownView.test.tsx
+++ b/src/components/markdown/__tests__/ProjectedMarkdownView.test.tsx
@@ -94,12 +94,16 @@ describe("ProjectedMarkdownView", () => {
     );
 
     expect(container.querySelector('[data-slot="projected-markdown-output"]')).toHaveClass(
-      "leading-[1.65]",
+      "leading-[1.68]",
       "[&>*:first-child]:mt-0",
       "[&>*:last-child]:mb-0",
     );
-    expect(screen.getByRole("heading", { level: 1 })).toHaveClass("text-[1.875rem]", "font-bold");
-    expect(screen.getByRole("heading", { level: 2 })).toHaveClass("text-2xl", "font-bold");
+    expect(screen.getByRole("heading", { level: 1 })).toHaveClass("text-[2rem]", "font-semibold");
+    expect(screen.getByRole("heading", { level: 2 })).toHaveClass(
+      "text-2xl",
+      "font-semibold",
+      "after:bg-primary/50",
+    );
     expect(screen.getByRole("heading", { level: 3 })).toHaveClass("text-xl", "font-semibold");
     expect(screen.getByRole("heading", { level: 4 })).toHaveClass("text-lg", "font-semibold");
   });
@@ -255,10 +259,10 @@ describe("ProjectedMarkdownView", () => {
     expect(screen.getByRole("list")).toHaveClass("my-3", "ml-6", "list-disc");
     expect(screen.getByText("quoted").closest("blockquote")).toHaveClass(
       "border-l-[3px]",
-      "border-primary/30",
+      "border-primary/45",
+      "bg-muted/[0.20]",
       "text-muted-foreground",
     );
-    expect(screen.getByText("quoted").closest("blockquote")).not.toHaveClass("bg-muted/[0.22]");
   });
 
   it("renders links with visible affordance before hover", () => {
@@ -414,7 +418,9 @@ describe("ProjectedMarkdownView", () => {
       document.querySelector('[data-slot="projected-markdown-task-checkbox"] span'),
     ).toHaveClass("bg-primary");
     expect(screen.getByText("important").tagName).toBe("EM");
+    expect(screen.getByText("important")).toHaveClass("text-muted-foreground");
     expect(screen.getByText("removed").tagName).toBe("DEL");
+    expect(screen.getByText("removed")).toHaveClass("decoration-destructive/55");
   });
 
   it("lets editable projections toggle task markers without changing output semantics", () => {
@@ -780,10 +786,12 @@ describe("ProjectedMarkdownView", () => {
     expect(screen.getByRole("table")).toBeInTheDocument();
     expect(screen.getByRole("columnheader", { name: "metric" })).toBeInTheDocument();
     expect(screen.getByRole("cell", { name: "128" })).toHaveStyle({ textAlign: "right" });
-    expect(screen.getByRole("table").parentElement).toHaveClass("border-y");
-    expect(screen.getByRole("table").parentElement).not.toHaveClass("rounded-md");
-    expect(screen.getByRole("table").parentElement).not.toHaveClass("bg-background/80");
-    expect(screen.getByRole("row", { name: "rows 128" })).toHaveClass("odd:bg-muted/[0.04]");
+    expect(screen.getByRole("table").parentElement).toHaveClass(
+      "rounded-sm",
+      "border",
+      "shadow-sm",
+    );
+    expect(screen.getByRole("row", { name: "rows 128" })).toHaveClass("odd:bg-muted/[0.05]");
     expect(screen.getByRole("table").parentElement).toHaveAttribute(
       "data-slot",
       "projected-markdown-table",
@@ -835,7 +843,7 @@ describe("ProjectedMarkdownView", () => {
     );
 
     expect(screen.getByText("value").tagName).toBe("CODE");
-    expect(screen.getByText("value")).toHaveClass("bg-muted/75", "font-mono");
+    expect(screen.getByText("value")).toHaveClass("border", "bg-muted/70", "font-mono");
   });
 
   it("keeps projected code block copy controls reachable without hover", () => {
@@ -1101,6 +1109,7 @@ describe("ProjectedMarkdownView", () => {
     const image = screen.getByRole("img", { name: "Plot alt" });
     expect(image).toHaveAttribute("src", "attachment:plot.png");
     expect(image).toHaveAttribute("title", "Daily plot");
+    expect(image).toHaveClass("border", "shadow-sm");
   });
 
   it("does not render projected images with unsafe sources", () => {
@@ -1191,5 +1200,6 @@ describe("ProjectedMarkdownView", () => {
       "Before focus",
     );
     expect(container.querySelector('[data-source-active-run="true"]')).toHaveTextContent("focus");
+    expect(screen.getByText("focus")).toHaveClass("font-semibold");
   });
 });

--- a/src/components/markdown/__tests__/ProjectedMarkdownView.test.tsx
+++ b/src/components/markdown/__tests__/ProjectedMarkdownView.test.tsx
@@ -1006,12 +1006,13 @@ describe("ProjectedMarkdownView", () => {
     );
 
     expect(screen.getByText("datasets")).toBeInTheDocument();
-    expect(screen.getByText("code")).toHaveAttribute("title", "python code block");
-    expect(screen.getByText("code").closest("[data-code-language]")).toHaveAttribute(
+    expect(screen.getByText("python")).toHaveAttribute("title", "python code block");
+    expect(screen.getByText("python")).toHaveClass("text-muted-foreground/80");
+    expect(screen.getByText("python")).not.toHaveClass("uppercase", "tracking-[0.08em]");
+    expect(screen.getByText("python").closest("[data-code-language]")).toHaveAttribute(
       "data-code-language",
       "python",
     );
-    expect(screen.queryByText("python")).toBeNull();
     expect(document.querySelector("pre code span")).not.toBeNull();
   });
 

--- a/src/components/markdown/__tests__/ProjectedMarkdownView.test.tsx
+++ b/src/components/markdown/__tests__/ProjectedMarkdownView.test.tsx
@@ -895,7 +895,7 @@ describe("ProjectedMarkdownView", () => {
     expect(screen.getByText("value")).toHaveClass("border", "bg-muted/70", "font-mono");
   });
 
-  it("keeps projected code block copy controls reachable without hover", () => {
+  it("renders projected code blocks with visible lab bench controls", () => {
     render(
       <ProjectedMarkdownView
         plan={plan({
@@ -916,8 +916,11 @@ describe("ProjectedMarkdownView", () => {
       />,
     );
 
+    expect(screen.getByText("code")).toHaveClass("uppercase", "tracking-[0.08em]");
     expect(screen.getByRole("button", { name: "Copy code" })).toHaveClass(
-      "focus-visible:opacity-100",
+      "inline-flex",
+      "border",
+      "bg-background/80",
     );
   });
 
@@ -945,6 +948,7 @@ describe("ProjectedMarkdownView", () => {
     );
 
     expect(screen.getByText("datasets")).toBeInTheDocument();
+    expect(screen.getByText("python")).toHaveClass("uppercase", "tracking-[0.08em]");
     expect(document.querySelector("pre code span")).not.toBeNull();
   });
 

--- a/src/components/markdown/markdown-typography.ts
+++ b/src/components/markdown/markdown-typography.ts
@@ -51,6 +51,20 @@ export const markdownDetailsBodyClassName =
 
 export const markdownListMarkerClassName = "marker:text-primary/65 marker:font-semibold";
 
+export const markdownTaskListClassName =
+  "my-4 ml-0 list-none space-y-1 rounded-md border border-border/70 bg-muted/[0.12] p-2";
+
+export const markdownTaskListItemClassName =
+  "group/task grid min-w-0 grid-cols-[auto_minmax(0,1fr)] items-start gap-2 rounded-sm px-2 py-1.5 transition-colors hover:bg-muted/35";
+
+export const markdownTaskCheckboxClassName =
+  "relative mt-[0.18em] inline-grid size-5 shrink-0 place-items-center";
+
+export const markdownTaskCheckboxGlyphClassName =
+  "pointer-events-none grid size-4 place-items-center rounded-sm border transition-colors peer-focus-visible:ring-2 peer-focus-visible:ring-ring/40 peer-focus-visible:ring-offset-1 peer-disabled:opacity-100";
+
+export const markdownTaskContentClassName = "min-w-0 leading-relaxed";
+
 export const markdownThematicBreakClassName = "my-7 border-0 border-t border-border/70";
 
 export const markdownTableWrapperClassName =

--- a/src/components/markdown/markdown-typography.ts
+++ b/src/components/markdown/markdown-typography.ts
@@ -1,5 +1,5 @@
 export const markdownDocumentClassName =
-  "not-prose select-text py-2 text-base leading-[1.68] text-foreground font-[var(--output-document-font)] [font-kerning:normal] [hyphens:auto] [text-rendering:optimizeLegibility] selection:bg-primary/15 selection:text-foreground [&>*:first-child]:mt-0 [&>*:last-child]:mb-0 [&_abbr]:cursor-help [&_abbr]:decoration-dotted [&_abbr]:underline-offset-4 [&_figcaption]:mt-2 [&_figcaption]:font-[var(--output-ui-font)] [&_figcaption]:text-xs [&_figcaption]:leading-5 [&_figcaption]:text-muted-foreground [&_kbd]:rounded-sm [&_kbd]:border [&_kbd]:border-border [&_kbd]:bg-muted/60 [&_kbd]:px-1.5 [&_kbd]:py-0.5 [&_kbd]:font-[var(--output-ui-font)] [&_kbd]:text-[0.82em] [&_.katex-display]:my-5 [&_.katex-display]:overflow-x-auto [&_.katex-display]:text-center [&_.katex-display]:[scrollbar-width:none] [&_.katex-display::-webkit-scrollbar]:hidden [&_mark]:rounded-sm [&_mark]:bg-amber-200/70 [&_mark]:px-1 dark:[&_mark]:bg-amber-500/25 [&_small]:font-[var(--output-ui-font)] [&_small]:text-[0.82em] [&_small]:leading-normal [&_sub]:text-[0.75em] [&_sup]:text-[0.75em]";
+  "not-prose select-text py-2 text-base leading-[1.68] text-foreground font-[var(--output-document-font)] [font-kerning:normal] [hyphens:auto] [text-rendering:optimizeLegibility] selection:bg-primary/15 selection:text-foreground [&>*:first-child]:mt-0 [&>*:last-child]:mb-0 [&_abbr]:cursor-help [&_abbr]:decoration-dotted [&_abbr]:underline-offset-4 [&_figcaption]:mt-2 [&_figcaption]:font-[var(--output-ui-font)] [&_figcaption]:text-xs [&_figcaption]:leading-5 [&_figcaption]:text-muted-foreground [&_kbd]:rounded-sm [&_kbd]:border [&_kbd]:border-border [&_kbd]:bg-muted/60 [&_kbd]:px-1.5 [&_kbd]:py-0.5 [&_kbd]:font-[var(--output-ui-font)] [&_kbd]:text-[0.82em] [&_.katex-display]:my-5 [&_.katex-display]:overflow-x-hidden [&_.katex-display]:text-center [&_mark]:rounded-sm [&_mark]:bg-amber-200/70 [&_mark]:px-1 dark:[&_mark]:bg-amber-500/25 [&_small]:font-[var(--output-ui-font)] [&_small]:text-[0.82em] [&_small]:leading-normal [&_sub]:text-[0.75em] [&_sup]:text-[0.75em]";
 
 export const markdownLinkClassName =
   "rounded-[2px] font-medium text-primary underline decoration-primary/45 decoration-1 underline-offset-4 transition-[background-color,color,text-decoration-color] hover:bg-primary/5 hover:decoration-primary focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/40";
@@ -21,7 +21,7 @@ export const markdownCodeBlockCopyButtonClassName =
 export const markdownParagraphClassName = "my-3 leading-relaxed [text-wrap:pretty]";
 
 export const markdownDisplayMathClassName =
-  "my-5 overflow-x-auto text-center [scrollbar-width:none] [&::-webkit-scrollbar]:hidden [&_.katex-display]:my-0";
+  "my-5 overflow-x-hidden text-center [&_.katex-display]:my-0";
 
 export const markdownInlineMathClassName =
   "inline align-baseline text-foreground [&_.katex]:text-[1.03em]";

--- a/src/components/markdown/markdown-typography.ts
+++ b/src/components/markdown/markdown-typography.ts
@@ -7,6 +7,18 @@ export const markdownLinkClassName =
 export const markdownInlineCodeClassName =
   "rounded-sm border border-border/70 bg-muted/70 px-1.5 py-0.5 font-mono text-[0.88em] text-foreground break-words";
 
+export const markdownCodeBlockShellClassName =
+  "group/codeblock my-4 overflow-hidden rounded-md border border-border/75 bg-muted/[0.14] shadow-sm";
+
+export const markdownCodeBlockToolbarClassName =
+  "flex min-h-8 items-center justify-between gap-3 border-b border-border/70 px-3 py-1.5 font-[var(--output-ui-font)] text-[11px] leading-none text-muted-foreground";
+
+export const markdownCodeBlockLabelClassName =
+  "truncate font-medium uppercase tracking-[0.08em] text-muted-foreground";
+
+export const markdownCodeBlockCopyButtonClassName =
+  "inline-flex size-6 shrink-0 items-center justify-center rounded border border-border bg-background/80 text-muted-foreground shadow-sm transition-colors hover:bg-muted hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/40";
+
 export const markdownParagraphClassName = "my-3 leading-relaxed [text-wrap:pretty]";
 
 export const markdownDisplayMathClassName =

--- a/src/components/markdown/markdown-typography.ts
+++ b/src/components/markdown/markdown-typography.ts
@@ -42,23 +42,35 @@ export const markdownTableCellClassName =
 export const markdownImageClassName =
   "my-5 h-auto max-w-full rounded-sm border border-border/80 bg-muted/15 shadow-sm";
 
+export const markdownFigureClassName = "my-5";
+
+export const markdownFigureCaptionClassName =
+  "mt-2 font-[var(--output-ui-font)] text-xs leading-5 text-muted-foreground";
+
 export const markdownFootnotesClassName =
   "mt-8 border-t border-border/70 pt-4 font-[var(--output-ui-font)] text-sm leading-6 text-muted-foreground";
 
 export const markdownFootnoteBackrefClassName =
   "ml-1 font-[var(--output-ui-font)] text-xs no-underline hover:bg-transparent";
 
+export const markdownHeadingAnchorClassName =
+  "ml-2 inline-flex translate-y-[-0.08em] rounded-[2px] font-[var(--output-ui-font)] text-[0.58em] font-medium text-muted-foreground/40 no-underline decoration-transparent transition-colors hover:bg-primary/5 hover:text-primary focus-visible:text-primary focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/40";
+
 export function markdownHeadingClassName(element: string) {
   if (element === "h1") {
-    return "mt-7 mb-4 text-[2rem] leading-[1.08] font-semibold [text-wrap:balance]";
+    return "group/markdown-heading scroll-mt-16 mt-7 mb-4 text-[2rem] leading-[1.08] font-semibold [text-wrap:balance]";
   }
   if (element === "h2") {
-    return "relative mt-7 mb-3 border-b border-border/70 pb-2 text-2xl leading-tight font-semibold [text-wrap:balance] after:absolute after:bottom-[-1px] after:left-0 after:h-px after:w-16 after:bg-primary/50 after:content-['']";
+    return "group/markdown-heading relative scroll-mt-16 mt-7 mb-3 border-b border-border/70 pb-2 text-2xl leading-tight font-semibold [text-wrap:balance] after:absolute after:bottom-[-1px] after:left-0 after:h-px after:w-16 after:bg-primary/50 after:content-['']";
   }
   if (element === "h3") {
-    return "mt-6 mb-2.5 text-xl leading-tight font-semibold [text-wrap:balance]";
+    return "group/markdown-heading scroll-mt-16 mt-6 mb-2.5 text-xl leading-tight font-semibold [text-wrap:balance]";
   }
-  if (element === "h4") return "mt-4 mb-2 text-lg leading-tight font-semibold";
-  if (element === "h5") return "mt-3.5 mb-1.5 text-base leading-tight font-semibold";
-  return "mt-3 mb-1.5 text-sm leading-tight font-semibold text-muted-foreground";
+  if (element === "h4") {
+    return "group/markdown-heading scroll-mt-16 mt-4 mb-2 text-lg leading-tight font-semibold";
+  }
+  if (element === "h5") {
+    return "group/markdown-heading scroll-mt-16 mt-3.5 mb-1.5 text-base leading-tight font-semibold";
+  }
+  return "group/markdown-heading scroll-mt-16 mt-3 mb-1.5 text-sm leading-tight font-semibold text-muted-foreground";
 }

--- a/src/components/markdown/markdown-typography.ts
+++ b/src/components/markdown/markdown-typography.ts
@@ -28,7 +28,7 @@ export const markdownInlineMathClassName =
 
 export const markdownStrongClassName = "font-semibold text-foreground";
 
-export const markdownEmphasisClassName = "italic text-muted-foreground";
+export const markdownEmphasisClassName = "italic text-foreground";
 
 export const markdownDeleteClassName =
   "text-muted-foreground decoration-destructive/55 decoration-2";

--- a/src/components/markdown/markdown-typography.ts
+++ b/src/components/markdown/markdown-typography.ts
@@ -1,5 +1,5 @@
 export const markdownDocumentClassName =
-  "not-prose select-text py-2 text-base leading-[1.68] text-foreground font-[var(--output-document-font)] [font-kerning:normal] [hyphens:auto] [text-rendering:optimizeLegibility] selection:bg-primary/15 selection:text-foreground [&>*:first-child]:mt-0 [&>*:last-child]:mb-0 [&_abbr]:cursor-help [&_abbr]:decoration-dotted [&_abbr]:underline-offset-4 [&_figcaption]:mt-2 [&_figcaption]:font-[var(--output-ui-font)] [&_figcaption]:text-xs [&_figcaption]:leading-5 [&_figcaption]:text-muted-foreground [&_kbd]:rounded-sm [&_kbd]:border [&_kbd]:border-border [&_kbd]:bg-muted/60 [&_kbd]:px-1.5 [&_kbd]:py-0.5 [&_kbd]:font-[var(--output-ui-font)] [&_kbd]:text-[0.82em] [&_.katex-display]:my-5 [&_.katex-display]:overflow-x-auto [&_.katex-display]:rounded-sm [&_.katex-display]:border-y [&_.katex-display]:border-border/70 [&_.katex-display]:bg-muted/[0.16] [&_.katex-display]:px-4 [&_.katex-display]:py-4 [&_.katex-display]:text-center [&_mark]:rounded-sm [&_mark]:bg-amber-200/70 [&_mark]:px-1 dark:[&_mark]:bg-amber-500/25 [&_small]:font-[var(--output-ui-font)] [&_small]:text-[0.82em] [&_small]:leading-normal [&_sub]:text-[0.75em] [&_sup]:text-[0.75em]";
+  "not-prose select-text py-2 text-base leading-[1.68] text-foreground font-[var(--output-document-font)] [font-kerning:normal] [hyphens:auto] [text-rendering:optimizeLegibility] selection:bg-primary/15 selection:text-foreground [&>*:first-child]:mt-0 [&>*:last-child]:mb-0 [&_abbr]:cursor-help [&_abbr]:decoration-dotted [&_abbr]:underline-offset-4 [&_figcaption]:mt-2 [&_figcaption]:font-[var(--output-ui-font)] [&_figcaption]:text-xs [&_figcaption]:leading-5 [&_figcaption]:text-muted-foreground [&_kbd]:rounded-sm [&_kbd]:border [&_kbd]:border-border [&_kbd]:bg-muted/60 [&_kbd]:px-1.5 [&_kbd]:py-0.5 [&_kbd]:font-[var(--output-ui-font)] [&_kbd]:text-[0.82em] [&_.katex-display]:my-5 [&_.katex-display]:overflow-x-auto [&_.katex-display]:text-center [&_mark]:rounded-sm [&_mark]:bg-amber-200/70 [&_mark]:px-1 dark:[&_mark]:bg-amber-500/25 [&_small]:font-[var(--output-ui-font)] [&_small]:text-[0.82em] [&_small]:leading-normal [&_sub]:text-[0.75em] [&_sup]:text-[0.75em]";
 
 export const markdownLinkClassName =
   "rounded-[2px] font-medium text-primary underline decoration-primary/45 decoration-1 underline-offset-4 transition-[background-color,color,text-decoration-color] hover:bg-primary/5 hover:decoration-primary focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/40";
@@ -13,8 +13,7 @@ export const markdownCodeBlockShellClassName =
 export const markdownCodeBlockToolbarClassName =
   "flex min-h-8 items-center justify-between gap-3 border-b border-border/70 px-3 py-1.5 font-[var(--output-ui-font)] text-[11px] leading-none text-muted-foreground";
 
-export const markdownCodeBlockLabelClassName =
-  "truncate font-medium uppercase tracking-[0.08em] text-muted-foreground";
+export const markdownCodeBlockLabelClassName = "truncate font-medium text-muted-foreground/80";
 
 export const markdownCodeBlockCopyButtonClassName =
   "inline-flex size-6 shrink-0 items-center justify-center rounded border border-border bg-background/80 text-muted-foreground shadow-sm transition-colors hover:bg-muted hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/40";
@@ -22,7 +21,7 @@ export const markdownCodeBlockCopyButtonClassName =
 export const markdownParagraphClassName = "my-3 leading-relaxed [text-wrap:pretty]";
 
 export const markdownDisplayMathClassName =
-  "my-5 overflow-x-auto rounded-sm border-y border-border/70 bg-muted/[0.16] px-4 py-4 text-center [&_.katex-display]:my-0";
+  "my-5 overflow-x-auto text-center [&_.katex-display]:my-0";
 
 export const markdownInlineMathClassName =
   "inline align-baseline text-foreground [&_.katex]:text-[1.03em]";
@@ -108,7 +107,7 @@ export function markdownHeadingClassName(element: string) {
     return "group/markdown-heading scroll-mt-16 mt-7 mb-4 text-[2rem] leading-[1.08] font-semibold [text-wrap:balance]";
   }
   if (element === "h2") {
-    return "group/markdown-heading relative scroll-mt-16 mt-7 mb-3 border-b border-border/70 pb-2 text-2xl leading-tight font-semibold [text-wrap:balance] after:absolute after:bottom-[-1px] after:left-0 after:h-px after:w-16 after:bg-primary/50 after:content-['']";
+    return "group/markdown-heading scroll-mt-16 mt-7 mb-3 text-2xl leading-tight font-semibold [text-wrap:balance]";
   }
   if (element === "h3") {
     return "group/markdown-heading scroll-mt-16 mt-6 mb-2.5 text-xl leading-tight font-semibold [text-wrap:balance]";

--- a/src/components/markdown/markdown-typography.ts
+++ b/src/components/markdown/markdown-typography.ts
@@ -1,5 +1,5 @@
 export const markdownDocumentClassName =
-  "not-prose select-text py-2 text-base leading-[1.68] text-foreground font-[var(--output-document-font)] [font-kerning:normal] [hyphens:auto] [text-rendering:optimizeLegibility] selection:bg-primary/15 selection:text-foreground [&>*:first-child]:mt-0 [&>*:last-child]:mb-0 [&_abbr]:cursor-help [&_abbr]:decoration-dotted [&_abbr]:underline-offset-4 [&_figcaption]:mt-2 [&_figcaption]:font-[var(--output-ui-font)] [&_figcaption]:text-xs [&_figcaption]:leading-5 [&_figcaption]:text-muted-foreground [&_kbd]:rounded-sm [&_kbd]:border [&_kbd]:border-border [&_kbd]:bg-muted/60 [&_kbd]:px-1.5 [&_kbd]:py-0.5 [&_kbd]:font-[var(--output-ui-font)] [&_kbd]:text-[0.82em] [&_mark]:rounded-sm [&_mark]:bg-amber-200/70 [&_mark]:px-1 dark:[&_mark]:bg-amber-500/25 [&_small]:font-[var(--output-ui-font)] [&_small]:text-[0.82em] [&_small]:leading-normal [&_sub]:text-[0.75em] [&_sup]:text-[0.75em]";
+  "not-prose select-text py-2 text-base leading-[1.68] text-foreground font-[var(--output-document-font)] [font-kerning:normal] [hyphens:auto] [text-rendering:optimizeLegibility] selection:bg-primary/15 selection:text-foreground [&>*:first-child]:mt-0 [&>*:last-child]:mb-0 [&_abbr]:cursor-help [&_abbr]:decoration-dotted [&_abbr]:underline-offset-4 [&_figcaption]:mt-2 [&_figcaption]:font-[var(--output-ui-font)] [&_figcaption]:text-xs [&_figcaption]:leading-5 [&_figcaption]:text-muted-foreground [&_kbd]:rounded-sm [&_kbd]:border [&_kbd]:border-border [&_kbd]:bg-muted/60 [&_kbd]:px-1.5 [&_kbd]:py-0.5 [&_kbd]:font-[var(--output-ui-font)] [&_kbd]:text-[0.82em] [&_.katex-display]:my-5 [&_.katex-display]:overflow-x-auto [&_.katex-display]:rounded-sm [&_.katex-display]:border-y [&_.katex-display]:border-border/70 [&_.katex-display]:bg-muted/[0.16] [&_.katex-display]:px-4 [&_.katex-display]:py-4 [&_.katex-display]:text-center [&_mark]:rounded-sm [&_mark]:bg-amber-200/70 [&_mark]:px-1 dark:[&_mark]:bg-amber-500/25 [&_small]:font-[var(--output-ui-font)] [&_small]:text-[0.82em] [&_small]:leading-normal [&_sub]:text-[0.75em] [&_sup]:text-[0.75em]";
 
 export const markdownLinkClassName =
   "rounded-[2px] font-medium text-primary underline decoration-primary/45 decoration-1 underline-offset-4 transition-[background-color,color,text-decoration-color] hover:bg-primary/5 hover:decoration-primary focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/40";
@@ -8,6 +8,12 @@ export const markdownInlineCodeClassName =
   "rounded-sm border border-border/70 bg-muted/70 px-1.5 py-0.5 font-mono text-[0.88em] text-foreground break-words";
 
 export const markdownParagraphClassName = "my-3 leading-relaxed [text-wrap:pretty]";
+
+export const markdownDisplayMathClassName =
+  "my-5 overflow-x-auto rounded-sm border-y border-border/70 bg-muted/[0.16] px-4 py-4 text-center [&_.katex-display]:my-0";
+
+export const markdownInlineMathClassName =
+  "inline align-baseline text-foreground [&_.katex]:text-[1.03em]";
 
 export const markdownStrongClassName = "font-semibold text-foreground";
 

--- a/src/components/markdown/markdown-typography.ts
+++ b/src/components/markdown/markdown-typography.ts
@@ -1,5 +1,7 @@
+import type { CSSProperties } from "react";
+
 export const markdownDocumentClassName =
-  "not-prose select-text py-2 text-base leading-[1.68] text-foreground font-[var(--output-document-font)] [font-kerning:normal] [hyphens:auto] [text-rendering:optimizeLegibility] selection:bg-primary/15 selection:text-foreground [&>*:first-child]:mt-0 [&>*:last-child]:mb-0 [&_abbr]:cursor-help [&_abbr]:decoration-dotted [&_abbr]:underline-offset-4 [&_figcaption]:mt-2 [&_figcaption]:font-[var(--output-ui-font)] [&_figcaption]:text-xs [&_figcaption]:leading-5 [&_figcaption]:text-muted-foreground [&_kbd]:rounded-sm [&_kbd]:border [&_kbd]:border-border [&_kbd]:bg-muted/60 [&_kbd]:px-1.5 [&_kbd]:py-0.5 [&_kbd]:font-[var(--output-ui-font)] [&_kbd]:text-[0.82em] [&_.katex-display]:my-5 [&_.katex-display]:overflow-x-hidden [&_.katex-display]:text-center [&_mark]:rounded-sm [&_mark]:bg-amber-200/70 [&_mark]:px-1 dark:[&_mark]:bg-amber-500/25 [&_small]:font-[var(--output-ui-font)] [&_small]:text-[0.82em] [&_small]:leading-normal [&_sub]:text-[0.75em] [&_sup]:text-[0.75em]";
+  "not-prose select-text py-2 text-base leading-[1.68] text-foreground font-[var(--output-document-font)] [font-kerning:normal] [hyphens:auto] [text-rendering:optimizeLegibility] selection:bg-primary/15 selection:text-foreground [&>*:first-child]:mt-0 [&>*:last-child]:mb-0 [&_abbr]:cursor-help [&_abbr]:decoration-dotted [&_abbr]:underline-offset-4 [&_figcaption]:mt-2 [&_figcaption]:font-[var(--output-ui-font)] [&_figcaption]:text-xs [&_figcaption]:leading-5 [&_figcaption]:text-muted-foreground [&_kbd]:rounded-sm [&_kbd]:border [&_kbd]:border-border [&_kbd]:bg-muted/60 [&_kbd]:px-1.5 [&_kbd]:py-0.5 [&_kbd]:font-[var(--output-ui-font)] [&_kbd]:text-[0.82em] [&_.katex-display]:my-5 [&_.katex-display]:overflow-x-clip [&_.katex-display]:text-center [&_mark]:rounded-sm [&_mark]:bg-amber-200/70 [&_mark]:px-1 dark:[&_mark]:bg-amber-500/25 [&_small]:font-[var(--output-ui-font)] [&_small]:text-[0.82em] [&_small]:leading-normal [&_sub]:text-[0.75em] [&_sup]:text-[0.75em]";
 
 export const markdownLinkClassName =
   "rounded-[2px] font-medium text-primary underline decoration-primary/45 decoration-1 underline-offset-4 transition-[background-color,color,text-decoration-color] hover:bg-primary/5 hover:decoration-primary focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/40";
@@ -8,20 +10,25 @@ export const markdownInlineCodeClassName =
   "rounded-sm border border-border/70 bg-muted/70 px-1.5 py-0.5 font-mono text-[0.88em] text-foreground break-words";
 
 export const markdownCodeBlockShellClassName =
-  "group/codeblock my-4 overflow-hidden rounded-md border border-border/75 bg-muted/[0.14] shadow-sm";
+  "group/codeblock my-4 overflow-hidden border-l-2 border-border bg-muted/[0.14]";
 
 export const markdownCodeBlockToolbarClassName =
-  "flex min-h-8 items-center justify-between gap-3 border-b border-border/70 px-3 py-1.5 font-[var(--output-ui-font)] text-[11px] leading-none text-muted-foreground";
+  "flex min-h-7 items-center justify-between gap-3 px-3 pt-1.5 pb-0.5 font-[var(--output-ui-font)] text-[11px] leading-none text-muted-foreground";
 
 export const markdownCodeBlockLabelClassName = "truncate font-medium text-muted-foreground/80";
 
 export const markdownCodeBlockCopyButtonClassName =
-  "inline-flex size-6 shrink-0 items-center justify-center rounded border border-border bg-background/80 text-muted-foreground shadow-sm transition-colors hover:bg-muted hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/40";
+  "inline-flex size-6 shrink-0 items-center justify-center rounded-sm border border-transparent bg-transparent text-muted-foreground transition-colors hover:border-border/70 hover:bg-background/70 hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/40";
+
+export const markdownCodeBlockPreStyle = {
+  borderRadius: 0,
+  padding: "0.5rem 1rem 0.875rem",
+} satisfies CSSProperties;
 
 export const markdownParagraphClassName = "my-3 leading-relaxed [text-wrap:pretty]";
 
 export const markdownDisplayMathClassName =
-  "my-5 overflow-x-hidden text-center [&_.katex-display]:my-0";
+  "my-5 overflow-x-clip text-center [&_.katex-display]:my-0";
 
 export const markdownInlineMathClassName =
   "inline align-baseline text-foreground [&_.katex]:text-[1.03em]";
@@ -34,7 +41,7 @@ export const markdownDeleteClassName =
   "text-muted-foreground decoration-destructive/55 decoration-2";
 
 export const markdownBlockquoteClassName =
-  "relative my-5 border-l-[3px] border-primary/45 bg-muted/[0.20] py-3 pr-4 pl-5 text-[0.98em] leading-[1.72] text-muted-foreground italic";
+  "relative my-5 border-l-2 border-foreground/35 py-1.5 pr-2 pl-5 text-[1.01em] leading-[1.72] text-foreground/80 italic";
 
 export const markdownDetailsClassName =
   "group/details my-5 overflow-hidden rounded-md border border-border/75 bg-muted/[0.14] shadow-sm open:bg-muted/[0.18] [&>:not(summary)]:mx-4 [&>:not(summary)]:my-3 [&>:last-child]:mb-4 [&>summary+*]:mt-3";

--- a/src/components/markdown/markdown-typography.ts
+++ b/src/components/markdown/markdown-typography.ts
@@ -37,6 +37,18 @@ export const markdownDeleteClassName =
 export const markdownBlockquoteClassName =
   "relative my-5 border-l-[3px] border-primary/45 bg-muted/[0.20] py-3 pr-4 pl-5 text-[0.98em] leading-[1.72] text-muted-foreground italic";
 
+export const markdownDetailsClassName =
+  "group/details my-5 overflow-hidden rounded-md border border-border/75 bg-muted/[0.14] shadow-sm open:bg-muted/[0.18] [&>:not(summary)]:mx-4 [&>:not(summary)]:my-3 [&>:last-child]:mb-4 [&>summary+*]:mt-3";
+
+export const markdownSummaryClassName =
+  "flex cursor-pointer list-none items-center gap-2 border-b border-transparent px-4 py-3 font-[var(--output-ui-font)] text-sm leading-5 font-semibold text-foreground transition-colors hover:bg-muted/45 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/40 group-open/details:border-border/65 [&::-webkit-details-marker]:hidden";
+
+export const markdownSummaryIndicatorClassName =
+  "inline-flex size-5 shrink-0 items-center justify-center rounded-full border border-primary/25 bg-primary/6 font-[var(--output-ui-font)] text-[12px] leading-none text-primary transition-transform group-open/details:rotate-90";
+
+export const markdownDetailsBodyClassName =
+  "px-4 pt-1 pb-4 text-[0.96em] leading-relaxed [&>*:first-child]:mt-0 [&>*:last-child]:mb-0";
+
 export const markdownListMarkerClassName = "marker:text-primary/65 marker:font-semibold";
 
 export const markdownThematicBreakClassName = "my-7 border-0 border-t border-border/70";

--- a/src/components/markdown/markdown-typography.ts
+++ b/src/components/markdown/markdown-typography.ts
@@ -1,5 +1,5 @@
 export const markdownDocumentClassName =
-  "not-prose select-text py-2 text-base leading-[1.68] text-foreground font-[var(--output-document-font)] [font-kerning:normal] [hyphens:auto] [text-rendering:optimizeLegibility] selection:bg-primary/15 selection:text-foreground [&>*:first-child]:mt-0 [&>*:last-child]:mb-0 [&_abbr]:cursor-help [&_abbr]:decoration-dotted [&_abbr]:underline-offset-4 [&_figcaption]:mt-2 [&_figcaption]:font-[var(--output-ui-font)] [&_figcaption]:text-xs [&_figcaption]:leading-5 [&_figcaption]:text-muted-foreground [&_kbd]:rounded-sm [&_kbd]:border [&_kbd]:border-border [&_kbd]:bg-muted/60 [&_kbd]:px-1.5 [&_kbd]:py-0.5 [&_kbd]:font-[var(--output-ui-font)] [&_kbd]:text-[0.82em] [&_.katex-display]:my-5 [&_.katex-display]:overflow-x-auto [&_.katex-display]:text-center [&_mark]:rounded-sm [&_mark]:bg-amber-200/70 [&_mark]:px-1 dark:[&_mark]:bg-amber-500/25 [&_small]:font-[var(--output-ui-font)] [&_small]:text-[0.82em] [&_small]:leading-normal [&_sub]:text-[0.75em] [&_sup]:text-[0.75em]";
+  "not-prose select-text py-2 text-base leading-[1.68] text-foreground font-[var(--output-document-font)] [font-kerning:normal] [hyphens:auto] [text-rendering:optimizeLegibility] selection:bg-primary/15 selection:text-foreground [&>*:first-child]:mt-0 [&>*:last-child]:mb-0 [&_abbr]:cursor-help [&_abbr]:decoration-dotted [&_abbr]:underline-offset-4 [&_figcaption]:mt-2 [&_figcaption]:font-[var(--output-ui-font)] [&_figcaption]:text-xs [&_figcaption]:leading-5 [&_figcaption]:text-muted-foreground [&_kbd]:rounded-sm [&_kbd]:border [&_kbd]:border-border [&_kbd]:bg-muted/60 [&_kbd]:px-1.5 [&_kbd]:py-0.5 [&_kbd]:font-[var(--output-ui-font)] [&_kbd]:text-[0.82em] [&_.katex-display]:my-5 [&_.katex-display]:overflow-x-auto [&_.katex-display]:text-center [&_.katex-display]:[scrollbar-width:none] [&_.katex-display::-webkit-scrollbar]:hidden [&_mark]:rounded-sm [&_mark]:bg-amber-200/70 [&_mark]:px-1 dark:[&_mark]:bg-amber-500/25 [&_small]:font-[var(--output-ui-font)] [&_small]:text-[0.82em] [&_small]:leading-normal [&_sub]:text-[0.75em] [&_sup]:text-[0.75em]";
 
 export const markdownLinkClassName =
   "rounded-[2px] font-medium text-primary underline decoration-primary/45 decoration-1 underline-offset-4 transition-[background-color,color,text-decoration-color] hover:bg-primary/5 hover:decoration-primary focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/40";
@@ -21,7 +21,7 @@ export const markdownCodeBlockCopyButtonClassName =
 export const markdownParagraphClassName = "my-3 leading-relaxed [text-wrap:pretty]";
 
 export const markdownDisplayMathClassName =
-  "my-5 overflow-x-auto text-center [&_.katex-display]:my-0";
+  "my-5 overflow-x-auto text-center [scrollbar-width:none] [&::-webkit-scrollbar]:hidden [&_.katex-display]:my-0";
 
 export const markdownInlineMathClassName =
   "inline align-baseline text-foreground [&_.katex]:text-[1.03em]";

--- a/src/components/markdown/markdown-typography.ts
+++ b/src/components/markdown/markdown-typography.ts
@@ -1,23 +1,63 @@
 export const markdownDocumentClassName =
-  "not-prose select-text py-2 text-base leading-[1.65] text-foreground font-[var(--output-document-font)] [font-kerning:normal] [hyphens:auto] [text-rendering:optimizeLegibility] [&>*:first-child]:mt-0 [&>*:last-child]:mb-0 [&_kbd]:rounded-sm [&_kbd]:border [&_kbd]:border-border [&_kbd]:bg-muted/60 [&_kbd]:px-1.5 [&_kbd]:py-0.5 [&_kbd]:font-[var(--output-ui-font)] [&_kbd]:text-[0.82em] [&_mark]:rounded-sm [&_mark]:bg-amber-200/70 [&_mark]:px-1 dark:[&_mark]:bg-amber-500/25 [&_sub]:text-[0.75em] [&_sup]:text-[0.75em]";
+  "not-prose select-text py-2 text-base leading-[1.68] text-foreground font-[var(--output-document-font)] [font-kerning:normal] [hyphens:auto] [text-rendering:optimizeLegibility] selection:bg-primary/15 selection:text-foreground [&>*:first-child]:mt-0 [&>*:last-child]:mb-0 [&_abbr]:cursor-help [&_abbr]:decoration-dotted [&_abbr]:underline-offset-4 [&_figcaption]:mt-2 [&_figcaption]:font-[var(--output-ui-font)] [&_figcaption]:text-xs [&_figcaption]:leading-5 [&_figcaption]:text-muted-foreground [&_kbd]:rounded-sm [&_kbd]:border [&_kbd]:border-border [&_kbd]:bg-muted/60 [&_kbd]:px-1.5 [&_kbd]:py-0.5 [&_kbd]:font-[var(--output-ui-font)] [&_kbd]:text-[0.82em] [&_mark]:rounded-sm [&_mark]:bg-amber-200/70 [&_mark]:px-1 dark:[&_mark]:bg-amber-500/25 [&_small]:font-[var(--output-ui-font)] [&_small]:text-[0.82em] [&_small]:leading-normal [&_sub]:text-[0.75em] [&_sup]:text-[0.75em]";
 
 export const markdownLinkClassName =
   "rounded-[2px] font-medium text-primary underline decoration-primary/45 decoration-1 underline-offset-4 transition-[background-color,color,text-decoration-color] hover:bg-primary/5 hover:decoration-primary focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/40";
 
 export const markdownInlineCodeClassName =
-  "rounded-sm bg-muted/75 px-1.5 py-0.5 font-mono text-[0.9em] text-foreground";
+  "rounded-sm border border-border/70 bg-muted/70 px-1.5 py-0.5 font-mono text-[0.88em] text-foreground break-words";
+
+export const markdownParagraphClassName = "my-3 leading-relaxed [text-wrap:pretty]";
+
+export const markdownStrongClassName = "font-semibold text-foreground";
+
+export const markdownEmphasisClassName = "italic text-muted-foreground";
+
+export const markdownDeleteClassName =
+  "text-muted-foreground decoration-destructive/55 decoration-2";
 
 export const markdownBlockquoteClassName =
-  "my-4 border-l-[3px] border-primary/30 pl-4 text-muted-foreground italic";
+  "relative my-5 border-l-[3px] border-primary/45 bg-muted/[0.20] py-3 pr-4 pl-5 text-[0.98em] leading-[1.72] text-muted-foreground italic";
 
-export const markdownListMarkerClassName = "marker:text-muted-foreground marker:font-medium";
+export const markdownListMarkerClassName = "marker:text-primary/65 marker:font-semibold";
+
+export const markdownThematicBreakClassName = "my-7 border-0 border-t border-border/70";
+
+export const markdownTableWrapperClassName =
+  "my-5 overflow-x-auto rounded-sm border border-border/80 bg-background shadow-sm";
+
+export const markdownTableClassName =
+  "min-w-full border-collapse font-[var(--output-ui-font)] text-sm leading-normal";
+
+export const markdownTableHeadClassName = "bg-muted/65";
+
+export const markdownTableRowClassName = "odd:bg-muted/[0.05] hover:bg-muted/[0.09]";
+
+export const markdownTableHeaderCellClassName =
+  "border-b border-r border-border/80 px-3 py-2.5 text-left font-semibold text-foreground last:border-r-0";
+
+export const markdownTableCellClassName =
+  "border-r border-t border-border/70 px-3 py-2.5 align-top text-muted-foreground first:text-foreground last:border-r-0";
+
+export const markdownImageClassName =
+  "my-5 h-auto max-w-full rounded-sm border border-border/80 bg-muted/15 shadow-sm";
+
+export const markdownFootnotesClassName =
+  "mt-8 border-t border-border/70 pt-4 font-[var(--output-ui-font)] text-sm leading-6 text-muted-foreground";
+
+export const markdownFootnoteBackrefClassName =
+  "ml-1 font-[var(--output-ui-font)] text-xs no-underline hover:bg-transparent";
 
 export function markdownHeadingClassName(element: string) {
-  if (element === "h1") return "mt-6 mb-4 text-[1.875rem] leading-tight font-bold";
-  if (element === "h2") {
-    return "mt-[1.35rem] mb-3 border-b border-border/70 pb-1.5 text-2xl leading-tight font-bold";
+  if (element === "h1") {
+    return "mt-7 mb-4 text-[2rem] leading-[1.08] font-semibold [text-wrap:balance]";
   }
-  if (element === "h3") return "mt-[1.2rem] mb-2.5 text-xl leading-tight font-semibold";
+  if (element === "h2") {
+    return "relative mt-7 mb-3 border-b border-border/70 pb-2 text-2xl leading-tight font-semibold [text-wrap:balance] after:absolute after:bottom-[-1px] after:left-0 after:h-px after:w-16 after:bg-primary/50 after:content-['']";
+  }
+  if (element === "h3") {
+    return "mt-6 mb-2.5 text-xl leading-tight font-semibold [text-wrap:balance]";
+  }
   if (element === "h4") return "mt-4 mb-2 text-lg leading-tight font-semibold";
   if (element === "h5") return "mt-3.5 mb-1.5 text-base leading-tight font-semibold";
   return "mt-3 mb-1.5 text-sm leading-tight font-semibold text-muted-foreground";

--- a/src/components/markdown/markdown-typography.ts
+++ b/src/components/markdown/markdown-typography.ts
@@ -59,6 +59,9 @@ export const markdownFootnotesClassName =
 export const markdownFootnoteBackrefClassName =
   "ml-1 font-[var(--output-ui-font)] text-xs no-underline hover:bg-transparent";
 
+export const markdownFootnoteRefClassName =
+  "mx-0.5 inline-flex min-w-4 translate-y-[-0.22em] justify-center rounded-full border border-primary/20 bg-primary/6 px-1 font-[var(--output-ui-font)] text-[0.68em] leading-4 text-primary no-underline decoration-transparent hover:bg-primary/10 hover:decoration-transparent";
+
 export const markdownHeadingAnchorClassName =
   "ml-2 inline-flex translate-y-[-0.08em] rounded-[2px] font-[var(--output-ui-font)] text-[0.58em] font-medium text-muted-foreground/40 no-underline decoration-transparent transition-colors hover:bg-primary/5 hover:text-primary focus-visible:text-primary focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/40";
 

--- a/src/components/outputs/__tests__/markdown-output.test.tsx
+++ b/src/components/outputs/__tests__/markdown-output.test.tsx
@@ -114,6 +114,11 @@ describe("MarkdownOutput heading anchors", () => {
 
     const footnotes = document.querySelector("section[data-footnotes]");
     expect(footnotes).toHaveClass("border-t", "font-[var(--output-ui-font)]", "text-sm");
+    expect(screen.getByRole("link", { name: "1" })).toHaveClass(
+      "rounded-full",
+      "bg-primary/6",
+      "no-underline",
+    );
     expect(screen.getByText("↩")).toHaveClass("text-xs", "no-underline");
   });
 

--- a/src/components/outputs/__tests__/markdown-output.test.tsx
+++ b/src/components/outputs/__tests__/markdown-output.test.tsx
@@ -97,6 +97,18 @@ describe("MarkdownOutput heading anchors", () => {
     );
   });
 
+  it("frames display math as a document equation object", () => {
+    const { container } = render(<MarkdownOutput content={"$$\n\\\\int_0^1 x dx\n$$"} />);
+
+    const displayMath = document.querySelector(".katex-display");
+    expect(displayMath).not.toBeNull();
+    expect(container.querySelector('[data-slot="markdown-output"]')).toHaveClass(
+      "[&_.katex-display]:my-5",
+      "[&_.katex-display]:border-y",
+      "[&_.katex-display]:bg-muted/[0.16]",
+    );
+  });
+
   it("styles GFM footnotes as a compact document apparatus", () => {
     render(<MarkdownOutput content={"Claim with a note.[^1]\n\n[^1]: Detailed citation."} />);
 

--- a/src/components/outputs/__tests__/markdown-output.test.tsx
+++ b/src/components/outputs/__tests__/markdown-output.test.tsx
@@ -74,4 +74,30 @@ describe("MarkdownOutput heading anchors", () => {
       "underline-offset-4",
     );
   });
+
+  it("uses the shared evidence table treatment", () => {
+    render(<MarkdownOutput content={"| metric | value |\n| --- | ---: |\n| rows | 128 |"} />);
+
+    expect(screen.getByRole("table").parentElement).toHaveClass(
+      "rounded-sm",
+      "border",
+      "shadow-sm",
+    );
+    expect(screen.getByRole("columnheader", { name: "metric" })).toHaveClass(
+      "border-border/80",
+      "py-2.5",
+    );
+    expect(screen.getByRole("cell", { name: "128" })).toHaveClass(
+      "border-border/70",
+      "text-muted-foreground",
+    );
+  });
+
+  it("styles GFM footnotes as a compact document apparatus", () => {
+    render(<MarkdownOutput content={"Claim with a note.[^1]\n\n[^1]: Detailed citation."} />);
+
+    const footnotes = document.querySelector("section[data-footnotes]");
+    expect(footnotes).toHaveClass("border-t", "font-[var(--output-ui-font)]", "text-sm");
+    expect(screen.getByText("↩")).toHaveClass("text-xs", "no-underline");
+  });
 });

--- a/src/components/outputs/__tests__/markdown-output.test.tsx
+++ b/src/components/outputs/__tests__/markdown-output.test.tsx
@@ -109,6 +109,14 @@ describe("MarkdownOutput heading anchors", () => {
     );
   });
 
+  it("renders fenced code with a visible language and copy rail", () => {
+    render(<MarkdownOutput content={"```python\nprint('hi')\n```"} />);
+
+    expect(screen.getByText("python")).toHaveClass("uppercase", "tracking-[0.08em]");
+    expect(screen.getByTitle("Copy code")).toHaveClass("inline-flex", "bg-background/80");
+    expect(screen.getByText("print")).toBeInTheDocument();
+  });
+
   it("styles GFM footnotes as a compact document apparatus", () => {
     render(<MarkdownOutput content={"Claim with a note.[^1]\n\n[^1]: Detailed citation."} />);
 

--- a/src/components/outputs/__tests__/markdown-output.test.tsx
+++ b/src/components/outputs/__tests__/markdown-output.test.tsx
@@ -55,13 +55,17 @@ describe("MarkdownOutput heading anchors", () => {
       />,
     );
 
-    expect(screen.getByRole("heading", { name: "Load data" })).toHaveAttribute(
+    expect(screen.getByRole("heading", { name: /Load data/ })).toHaveAttribute(
       "id",
       "notebook-cell-cell-a-heading-load-data",
     );
-    expect(screen.getByRole("heading", { name: "Clean columns" })).toHaveAttribute(
+    expect(screen.getByRole("heading", { name: /Clean columns/ })).toHaveAttribute(
       "data-nteract-outline-item-id",
       "cell-a:heading:1",
+    );
+    expect(screen.getByRole("link", { name: "Link to Load data" })).toHaveAttribute(
+      "href",
+      "#notebook-cell-cell-a-heading-load-data",
     );
   });
 
@@ -99,5 +103,22 @@ describe("MarkdownOutput heading anchors", () => {
     const footnotes = document.querySelector("section[data-footnotes]");
     expect(footnotes).toHaveClass("border-t", "font-[var(--output-ui-font)]", "text-sm");
     expect(screen.getByText("↩")).toHaveClass("text-xs", "no-underline");
+  });
+
+  it("styles raw figure captions with the shared document treatment", () => {
+    render(
+      <MarkdownOutput
+        content={
+          '<figure><img src="https://example.com/plot.png" alt="Plot"><figcaption>Figure 1. Residual topology.</figcaption></figure>'
+        }
+      />,
+    );
+
+    expect(screen.getByRole("figure")).toHaveClass("my-5");
+    expect(screen.getByRole("img", { name: "Plot" })).toHaveClass("border", "shadow-sm");
+    expect(screen.getByText("Figure 1. Residual topology.")).toHaveClass(
+      "font-[var(--output-ui-font)]",
+      "text-xs",
+    );
   });
 });

--- a/src/components/outputs/__tests__/markdown-output.test.tsx
+++ b/src/components/outputs/__tests__/markdown-output.test.tsx
@@ -91,6 +91,9 @@ describe("MarkdownOutput heading anchors", () => {
       "border-border/80",
       "py-2.5",
     );
+    expect(screen.getByRole("columnheader", { name: "value" })).toHaveStyle({
+      textAlign: "right",
+    });
     expect(screen.getByRole("cell", { name: "128" })).toHaveClass(
       "border-border/70",
       "text-muted-foreground",
@@ -112,11 +115,12 @@ describe("MarkdownOutput heading anchors", () => {
     expect(displayMath).not.toBeNull();
     expect(container.querySelector('[data-slot="markdown-output"]')).toHaveClass(
       "[&_.katex-display]:my-5",
-      "[&_.katex-display]:overflow-x-hidden",
+      "[&_.katex-display]:overflow-x-clip",
       "[&_.katex-display]:text-center",
     );
     expect(container.querySelector('[data-slot="markdown-output"]')).not.toHaveClass(
       "[&_.katex-display]:overflow-x-auto",
+      "[&_.katex-display]:overflow-x-hidden",
     );
     expect(container.querySelector('[data-slot="markdown-output"]')).not.toHaveClass(
       "[&_.katex-display]:border-y",
@@ -130,7 +134,15 @@ describe("MarkdownOutput heading anchors", () => {
     expect(screen.getByText("python")).toHaveAttribute("title", "python code block");
     expect(screen.getByText("python")).toHaveClass("text-muted-foreground/80");
     expect(screen.getByText("python")).not.toHaveClass("uppercase", "tracking-[0.08em]");
-    expect(screen.getByTitle("Copy code")).toHaveClass("inline-flex", "bg-background/80");
+    expect(screen.getByTitle("Copy code")).toHaveClass("inline-flex", "bg-transparent");
+    expect(screen.getByText("python").closest('[data-slot="markdown-code-block"]')).toHaveClass(
+      "border-l-2",
+      "bg-muted/[0.14]",
+    );
+    expect(screen.getByText("python").closest('[data-slot="markdown-code-block"]')).not.toHaveClass(
+      "rounded-md",
+      "shadow-sm",
+    );
     expect(screen.getByText("print")).toBeInTheDocument();
   });
 

--- a/src/components/outputs/__tests__/markdown-output.test.tsx
+++ b/src/components/outputs/__tests__/markdown-output.test.tsx
@@ -105,6 +105,8 @@ describe("MarkdownOutput heading anchors", () => {
     expect(container.querySelector('[data-slot="markdown-output"]')).toHaveClass(
       "[&_.katex-display]:my-5",
       "[&_.katex-display]:overflow-x-auto",
+      "[&_.katex-display]:[scrollbar-width:none]",
+      "[&_.katex-display::-webkit-scrollbar]:hidden",
       "[&_.katex-display]:text-center",
     );
     expect(container.querySelector('[data-slot="markdown-output"]')).not.toHaveClass(

--- a/src/components/outputs/__tests__/markdown-output.test.tsx
+++ b/src/components/outputs/__tests__/markdown-output.test.tsx
@@ -118,9 +118,9 @@ describe("MarkdownOutput heading anchors", () => {
   it("renders fenced code with a visible language and copy rail", () => {
     render(<MarkdownOutput content={"```python\nprint('hi')\n```"} />);
 
-    expect(screen.getByText("code")).toHaveAttribute("title", "python code block");
-    expect(screen.getByText("code")).toHaveClass("text-muted-foreground/80");
-    expect(screen.queryByText("python")).toBeNull();
+    expect(screen.getByText("python")).toHaveAttribute("title", "python code block");
+    expect(screen.getByText("python")).toHaveClass("text-muted-foreground/80");
+    expect(screen.getByText("python")).not.toHaveClass("uppercase", "tracking-[0.08em]");
     expect(screen.getByTitle("Copy code")).toHaveClass("inline-flex", "bg-background/80");
     expect(screen.getByText("print")).toBeInTheDocument();
   });

--- a/src/components/outputs/__tests__/markdown-output.test.tsx
+++ b/src/components/outputs/__tests__/markdown-output.test.tsx
@@ -146,4 +146,28 @@ describe("MarkdownOutput heading anchors", () => {
       "text-xs",
     );
   });
+
+  it("styles native disclosure blocks as compact appendices", () => {
+    render(
+      <MarkdownOutput
+        content={
+          "<details open><summary>Failure appendix</summary><p>Keep failed priors near the claim.</p></details>"
+        }
+      />,
+    );
+
+    expect(screen.getByText("Failure appendix").closest("details")).toHaveClass(
+      "group/details",
+      "rounded-md",
+      "shadow-sm",
+      "[&>:not(summary)]:mx-4",
+    );
+    expect(screen.getByText("Failure appendix").closest("summary")).toHaveClass(
+      "cursor-pointer",
+      "font-[var(--output-ui-font)]",
+      "group-open/details:border-border/65",
+    );
+    expect(screen.getByText("›")).toHaveClass("group-open/details:rotate-90");
+    expect(screen.getByText("Keep failed priors near the claim.")).toHaveClass("my-3");
+  });
 });

--- a/src/components/outputs/__tests__/markdown-output.test.tsx
+++ b/src/components/outputs/__tests__/markdown-output.test.tsx
@@ -117,6 +117,24 @@ describe("MarkdownOutput heading anchors", () => {
     expect(screen.getByText("print")).toBeInTheDocument();
   });
 
+  it("frames GFM task lists as compact protocol blocks", () => {
+    render(<MarkdownOutput content={"- [x] Reproduce baseline\n- [ ] Compare candidate"} />);
+
+    expect(document.querySelector("ul.contains-task-list")).toHaveClass(
+      "rounded-md",
+      "border",
+      "p-2",
+    );
+    expect(screen.getByText("Compare candidate").closest("li")).toHaveClass(
+      "grid",
+      "grid-cols-[auto_minmax(0,1fr)]",
+      "task-list-item",
+    );
+    expect(document.querySelector('[data-slot="markdown-task-checkbox"] span')).toHaveClass(
+      "size-4",
+    );
+  });
+
   it("styles GFM footnotes as a compact document apparatus", () => {
     render(<MarkdownOutput content={"Claim with a note.[^1]\n\n[^1]: Detailed citation."} />);
 

--- a/src/components/outputs/__tests__/markdown-output.test.tsx
+++ b/src/components/outputs/__tests__/markdown-output.test.tsx
@@ -97,6 +97,14 @@ describe("MarkdownOutput heading anchors", () => {
     );
   });
 
+  it("keeps emphasis italic without lowering text contrast", () => {
+    render(<MarkdownOutput content={"The note should feel like a *paper margin*."} />);
+
+    expect(screen.getByText("paper margin").tagName).toBe("EM");
+    expect(screen.getByText("paper margin")).toHaveClass("italic", "text-foreground");
+    expect(screen.getByText("paper margin")).not.toHaveClass("text-muted-foreground");
+  });
+
   it("renders display math plainly in the document flow", () => {
     const { container } = render(<MarkdownOutput content={"$$\n\\\\int_0^1 x dx\n$$"} />);
 

--- a/src/components/outputs/__tests__/markdown-output.test.tsx
+++ b/src/components/outputs/__tests__/markdown-output.test.tsx
@@ -104,10 +104,11 @@ describe("MarkdownOutput heading anchors", () => {
     expect(displayMath).not.toBeNull();
     expect(container.querySelector('[data-slot="markdown-output"]')).toHaveClass(
       "[&_.katex-display]:my-5",
-      "[&_.katex-display]:overflow-x-auto",
-      "[&_.katex-display]:[scrollbar-width:none]",
-      "[&_.katex-display::-webkit-scrollbar]:hidden",
+      "[&_.katex-display]:overflow-x-hidden",
       "[&_.katex-display]:text-center",
+    );
+    expect(container.querySelector('[data-slot="markdown-output"]')).not.toHaveClass(
+      "[&_.katex-display]:overflow-x-auto",
     );
     expect(container.querySelector('[data-slot="markdown-output"]')).not.toHaveClass(
       "[&_.katex-display]:border-y",

--- a/src/components/outputs/__tests__/markdown-output.test.tsx
+++ b/src/components/outputs/__tests__/markdown-output.test.tsx
@@ -97,13 +97,17 @@ describe("MarkdownOutput heading anchors", () => {
     );
   });
 
-  it("frames display math as a document equation object", () => {
+  it("renders display math plainly in the document flow", () => {
     const { container } = render(<MarkdownOutput content={"$$\n\\\\int_0^1 x dx\n$$"} />);
 
     const displayMath = document.querySelector(".katex-display");
     expect(displayMath).not.toBeNull();
     expect(container.querySelector('[data-slot="markdown-output"]')).toHaveClass(
       "[&_.katex-display]:my-5",
+      "[&_.katex-display]:overflow-x-auto",
+      "[&_.katex-display]:text-center",
+    );
+    expect(container.querySelector('[data-slot="markdown-output"]')).not.toHaveClass(
       "[&_.katex-display]:border-y",
       "[&_.katex-display]:bg-muted/[0.16]",
     );
@@ -112,7 +116,9 @@ describe("MarkdownOutput heading anchors", () => {
   it("renders fenced code with a visible language and copy rail", () => {
     render(<MarkdownOutput content={"```python\nprint('hi')\n```"} />);
 
-    expect(screen.getByText("python")).toHaveClass("uppercase", "tracking-[0.08em]");
+    expect(screen.getByText("code")).toHaveAttribute("title", "python code block");
+    expect(screen.getByText("code")).toHaveClass("text-muted-foreground/80");
+    expect(screen.queryByText("python")).toBeNull();
     expect(screen.getByTitle("Copy code")).toHaveClass("inline-flex", "bg-background/80");
     expect(screen.getByText("print")).toBeInTheDocument();
   });

--- a/src/components/outputs/markdown-output.tsx
+++ b/src/components/outputs/markdown-output.tsx
@@ -16,10 +16,13 @@ import {
   markdownDeleteClassName,
   markdownDocumentClassName,
   markdownEmphasisClassName,
+  markdownFigureCaptionClassName,
+  markdownFigureClassName,
   markdownFootnoteBackrefClassName,
   markdownFootnotesClassName,
-  markdownImageClassName,
+  markdownHeadingAnchorClassName,
   markdownHeadingClassName,
+  markdownImageClassName,
   markdownInlineCodeClassName,
   markdownLinkClassName,
   markdownListMarkerClassName,
@@ -188,6 +191,24 @@ export function MarkdownOutput({
     };
   };
 
+  const renderHeadingAnchor = (
+    attributes: ReturnType<typeof headingAttributes>,
+    children: ReactNode,
+  ) => {
+    const id = (attributes as { id?: string }).id;
+    if (!id) return null;
+
+    return (
+      <a
+        aria-label={`Link to ${normalizeHeadingText(textFromReactNode(children))}`}
+        className={markdownHeadingAnchorClassName}
+        href={`#${id}`}
+      >
+        #
+      </a>
+    );
+  };
+
   if (!content) {
     return null;
   }
@@ -318,68 +339,56 @@ export function MarkdownOutput({
 
           // Headings
           h1({ children, ...props }) {
+            const attributes = headingAttributes(1, children);
             return (
-              <h1
-                className={markdownHeadingClassName("h1")}
-                {...props}
-                {...headingAttributes(1, children)}
-              >
+              <h1 className={markdownHeadingClassName("h1")} {...props} {...attributes}>
                 {children}
+                {renderHeadingAnchor(attributes, children)}
               </h1>
             );
           },
           h2({ children, ...props }) {
+            const attributes = headingAttributes(2, children);
             return (
-              <h2
-                className={markdownHeadingClassName("h2")}
-                {...props}
-                {...headingAttributes(2, children)}
-              >
+              <h2 className={markdownHeadingClassName("h2")} {...props} {...attributes}>
                 {children}
+                {renderHeadingAnchor(attributes, children)}
               </h2>
             );
           },
           h3({ children, ...props }) {
+            const attributes = headingAttributes(3, children);
             return (
-              <h3
-                className={markdownHeadingClassName("h3")}
-                {...props}
-                {...headingAttributes(3, children)}
-              >
+              <h3 className={markdownHeadingClassName("h3")} {...props} {...attributes}>
                 {children}
+                {renderHeadingAnchor(attributes, children)}
               </h3>
             );
           },
           h4({ children, ...props }) {
+            const attributes = headingAttributes(4, children);
             return (
-              <h4
-                className={markdownHeadingClassName("h4")}
-                {...props}
-                {...headingAttributes(4, children)}
-              >
+              <h4 className={markdownHeadingClassName("h4")} {...props} {...attributes}>
                 {children}
+                {renderHeadingAnchor(attributes, children)}
               </h4>
             );
           },
           h5({ children, ...props }) {
+            const attributes = headingAttributes(5, children);
             return (
-              <h5
-                className={markdownHeadingClassName("h5")}
-                {...props}
-                {...headingAttributes(5, children)}
-              >
+              <h5 className={markdownHeadingClassName("h5")} {...props} {...attributes}>
                 {children}
+                {renderHeadingAnchor(attributes, children)}
               </h5>
             );
           },
           h6({ children, ...props }) {
+            const attributes = headingAttributes(6, children);
             return (
-              <h6
-                className={markdownHeadingClassName("h6")}
-                {...props}
-                {...headingAttributes(6, children)}
-              >
+              <h6 className={markdownHeadingClassName("h6")} {...props} {...attributes}>
                 {children}
+                {renderHeadingAnchor(attributes, children)}
               </h6>
             );
           },
@@ -443,6 +452,22 @@ export function MarkdownOutput({
           img({ src, alt, ...props }) {
             if (!src) return null;
             return <img src={src} alt={alt || ""} className={markdownImageClassName} {...props} />;
+          },
+
+          figure({ children, ...props }) {
+            return (
+              <figure className={markdownFigureClassName} {...props}>
+                {children}
+              </figure>
+            );
+          },
+
+          figcaption({ children, ...props }) {
+            return (
+              <figcaption className={markdownFigureCaptionClassName} {...props}>
+                {children}
+              </figcaption>
+            );
           },
 
           strong({ children, ...props }) {

--- a/src/components/outputs/markdown-output.tsx
+++ b/src/components/outputs/markdown-output.tsx
@@ -13,6 +13,10 @@ import { katexStrict } from "@/lib/katex-options";
 import { cn } from "@/lib/utils";
 import {
   markdownBlockquoteClassName,
+  markdownCodeBlockCopyButtonClassName,
+  markdownCodeBlockLabelClassName,
+  markdownCodeBlockShellClassName,
+  markdownCodeBlockToolbarClassName,
   markdownDeleteClassName,
   markdownDocumentClassName,
   markdownEmphasisClassName,
@@ -87,6 +91,7 @@ function CodeBlock({ children, language = "", enableCopy = true, isDark = false 
   const [copied, setCopied] = useState(false);
   const rawTheme = useColorTheme();
   const colorTheme = (rawTheme === "cream" ? "cream" : "classic") as "classic" | "cream";
+  const languageLabel = codeBlockLanguageLabel(language);
 
   const handleCopy = async () => {
     try {
@@ -99,25 +104,34 @@ function CodeBlock({ children, language = "", enableCopy = true, isDark = false 
   };
 
   return (
-    <div className="group/codeblock relative">
+    <div className={markdownCodeBlockShellClassName}>
+      <div className={markdownCodeBlockToolbarClassName}>
+        <span className={markdownCodeBlockLabelClassName}>{languageLabel}</span>
+        {enableCopy && (
+          <button
+            onClick={handleCopy}
+            className={markdownCodeBlockCopyButtonClassName}
+            title={copied ? "Copied!" : "Copy code"}
+            type="button"
+          >
+            {copied ? <Check className="h-3 w-3" /> : <Copy className="h-3 w-3" />}
+          </button>
+        )}
+      </div>
       <StaticCodeBlock
         code={children}
         language={language}
         isDark={isDark}
         colorTheme={colorTheme}
       />
-      {enableCopy && (
-        <button
-          onClick={handleCopy}
-          className="absolute top-2 right-2 z-10 rounded border border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-800 p-1.5 text-gray-600 dark:text-gray-400 opacity-0 shadow-sm transition-opacity group-hover/codeblock:opacity-100 hover:bg-gray-50 dark:hover:bg-gray-700 hover:text-gray-800 dark:hover:text-gray-200"
-          title={copied ? "Copied!" : "Copy code"}
-          type="button"
-        >
-          {copied ? <Check className="h-3 w-3" /> : <Copy className="h-3 w-3" />}
-        </button>
-      )}
     </div>
   );
+}
+
+function codeBlockLanguageLabel(language: string | undefined): string {
+  const trimmed = language?.trim();
+  if (!trimmed) return "code";
+  return trimmed;
 }
 
 function textFromReactNode(node: ReactNode): string {

--- a/src/components/outputs/markdown-output.tsx
+++ b/src/components/outputs/markdown-output.tsx
@@ -15,6 +15,7 @@ import {
   markdownBlockquoteClassName,
   markdownCodeBlockCopyButtonClassName,
   markdownCodeBlockLabelClassName,
+  markdownCodeBlockPreStyle,
   markdownCodeBlockShellClassName,
   markdownCodeBlockToolbarClassName,
   markdownDeleteClassName,
@@ -112,6 +113,7 @@ function CodeBlock({ children, language = "", enableCopy = true, isDark = false 
 
   return (
     <div
+      data-slot="markdown-code-block"
       className={markdownCodeBlockShellClassName}
       data-code-language={languageLabel === "code" ? undefined : languageLabel}
     >
@@ -138,6 +140,7 @@ function CodeBlock({ children, language = "", enableCopy = true, isDark = false 
         language={language}
         isDark={isDark}
         colorTheme={colorTheme}
+        style={markdownCodeBlockPreStyle}
       />
     </div>
   );

--- a/src/components/outputs/markdown-output.tsx
+++ b/src/components/outputs/markdown-output.tsx
@@ -36,6 +36,10 @@ import {
   markdownStrongClassName,
   markdownSummaryClassName,
   markdownSummaryIndicatorClassName,
+  markdownTaskCheckboxClassName,
+  markdownTaskCheckboxGlyphClassName,
+  markdownTaskListClassName,
+  markdownTaskListItemClassName,
   markdownTableCellClassName,
   markdownTableClassName,
   markdownTableHeadClassName,
@@ -427,22 +431,31 @@ export function MarkdownOutput({
           },
 
           // Lists
-          ul({ children, ...props }) {
+          ul({ children, className, ...props }) {
+            const classNames = className?.split(/\s+/) ?? [];
+            const isTaskList = classNames.includes("contains-task-list");
             return (
               <ul
-                className={cn("my-3 ml-6 list-disc leading-relaxed", markdownListMarkerClassName)}
+                className={cn(
+                  isTaskList ? markdownTaskListClassName : "my-3 ml-6 list-disc leading-relaxed",
+                  !isTaskList && markdownListMarkerClassName,
+                  className,
+                )}
                 {...props}
               >
                 {children}
               </ul>
             );
           },
-          ol({ children, ...props }) {
+          ol({ children, className, ...props }) {
+            const classNames = className?.split(/\s+/) ?? [];
+            const isTaskList = classNames.includes("contains-task-list");
             return (
               <ol
                 className={cn(
-                  "my-3 ml-6 list-decimal leading-relaxed",
-                  markdownListMarkerClassName,
+                  isTaskList ? markdownTaskListClassName : "my-3 ml-6 list-decimal leading-relaxed",
+                  !isTaskList && markdownListMarkerClassName,
+                  className,
                 )}
                 {...props}
               >
@@ -450,11 +463,50 @@ export function MarkdownOutput({
               </ol>
             );
           },
-          li({ children, ...props }) {
+          li({ children, className, ...props }) {
+            const classNames = className?.split(/\s+/) ?? [];
+            const isTaskItem = classNames.includes("task-list-item");
             return (
-              <li className="my-1" {...props}>
+              <li
+                className={cn(isTaskItem ? markdownTaskListItemClassName : "my-1", className)}
+                {...props}
+              >
                 {children}
               </li>
+            );
+          },
+          input({ type, checked, className, ...props }) {
+            if (type !== "checkbox") {
+              return <input type={type} className={className} {...props} />;
+            }
+
+            const isChecked = Boolean(checked);
+            return (
+              <span
+                className={markdownTaskCheckboxClassName}
+                data-slot="markdown-task-checkbox"
+                data-state={isChecked ? "checked" : "unchecked"}
+              >
+                <input
+                  {...props}
+                  type="checkbox"
+                  checked={isChecked}
+                  readOnly
+                  disabled
+                  className={cn("peer sr-only", className)}
+                />
+                <span
+                  aria-hidden="true"
+                  className={cn(
+                    markdownTaskCheckboxGlyphClassName,
+                    isChecked
+                      ? "border-primary bg-primary text-primary-foreground"
+                      : "border-border bg-background",
+                  )}
+                >
+                  {isChecked ? <Check className="size-2.5 stroke-[3]" /> : null}
+                </span>
+              </span>
             );
           },
 

--- a/src/components/outputs/markdown-output.tsx
+++ b/src/components/outputs/markdown-output.tsx
@@ -111,9 +111,17 @@ function CodeBlock({ children, language = "", enableCopy = true, isDark = false 
   };
 
   return (
-    <div className={markdownCodeBlockShellClassName}>
+    <div
+      className={markdownCodeBlockShellClassName}
+      data-code-language={languageLabel === "code" ? undefined : languageLabel}
+    >
       <div className={markdownCodeBlockToolbarClassName}>
-        <span className={markdownCodeBlockLabelClassName}>{languageLabel}</span>
+        <span
+          className={markdownCodeBlockLabelClassName}
+          title={languageLabel === "code" ? "Code block" : `${languageLabel} code block`}
+        >
+          code
+        </span>
         {enableCopy && (
           <button
             onClick={handleCopy}

--- a/src/components/outputs/markdown-output.tsx
+++ b/src/components/outputs/markdown-output.tsx
@@ -13,11 +13,25 @@ import { katexStrict } from "@/lib/katex-options";
 import { cn } from "@/lib/utils";
 import {
   markdownBlockquoteClassName,
+  markdownDeleteClassName,
   markdownDocumentClassName,
+  markdownEmphasisClassName,
+  markdownFootnoteBackrefClassName,
+  markdownFootnotesClassName,
+  markdownImageClassName,
   markdownHeadingClassName,
   markdownInlineCodeClassName,
   markdownLinkClassName,
   markdownListMarkerClassName,
+  markdownParagraphClassName,
+  markdownStrongClassName,
+  markdownTableCellClassName,
+  markdownTableClassName,
+  markdownTableHeadClassName,
+  markdownTableHeaderCellClassName,
+  markdownTableRowClassName,
+  markdownTableWrapperClassName,
+  markdownThematicBreakClassName,
 } from "../markdown/markdown-typography";
 
 import "katex/dist/katex.min.css";
@@ -231,14 +245,25 @@ export function MarkdownOutput({
           },
 
           // Links open in new tab
-          a({ href, children, ...props }) {
+          a({ href, children, className, ...props }) {
+            const linkProps = props as typeof props & {
+              "data-footnote-backref"?: string | boolean;
+            };
+            const isFootnoteBackref =
+              linkProps["data-footnote-backref"] !== undefined ||
+              className?.split(/\s+/).includes("data-footnote-backref");
+            const isDocumentAnchor = href?.startsWith("#") ?? false;
             return (
               <a
-                href={href}
-                className={markdownLinkClassName}
-                rel="noopener noreferrer"
-                target="_blank"
                 {...props}
+                href={href}
+                className={cn(
+                  markdownLinkClassName,
+                  isFootnoteBackref && markdownFootnoteBackrefClassName,
+                  className,
+                )}
+                rel={isDocumentAnchor ? undefined : "noopener noreferrer"}
+                target={isDocumentAnchor ? undefined : "_blank"}
               >
                 {children}
               </a>
@@ -248,11 +273,8 @@ export function MarkdownOutput({
           // Tables
           table({ children, ...props }) {
             return (
-              <div className="my-4 overflow-x-auto border-y border-border">
-                <table
-                  className="min-w-full border-collapse font-[var(--output-ui-font)] text-sm leading-normal"
-                  {...props}
-                >
+              <div className={markdownTableWrapperClassName}>
+                <table className={markdownTableClassName} {...props}>
                   {children}
                 </table>
               </div>
@@ -260,7 +282,7 @@ export function MarkdownOutput({
           },
           thead({ children, ...props }) {
             return (
-              <thead className="bg-muted/55" {...props}>
+              <thead className={markdownTableHeadClassName} {...props}>
                 {children}
               </thead>
             );
@@ -274,27 +296,21 @@ export function MarkdownOutput({
           },
           tr({ children, ...props }) {
             return (
-              <tr className="odd:bg-muted/[0.04]" {...props}>
+              <tr className={markdownTableRowClassName} {...props}>
                 {children}
               </tr>
             );
           },
           th({ children, ...props }) {
             return (
-              <th
-                className="border-r border-border px-3 py-2 text-left font-semibold text-foreground last:border-r-0"
-                {...props}
-              >
+              <th className={markdownTableHeaderCellClassName} {...props}>
                 {children}
               </th>
             );
           },
           td({ children, ...props }) {
             return (
-              <td
-                className="border-r border-t border-border px-3 py-2 align-top text-muted-foreground first:text-foreground last:border-r-0"
-                {...props}
-              >
+              <td className={markdownTableCellClassName} {...props}>
                 {children}
               </td>
             );
@@ -371,7 +387,7 @@ export function MarkdownOutput({
           // Paragraphs
           p({ children, ...props }) {
             return (
-              <p className="my-2 leading-relaxed" {...props}>
+              <p className={markdownParagraphClassName} {...props}>
                 {children}
               </p>
             );
@@ -420,13 +436,52 @@ export function MarkdownOutput({
 
           // Horizontal rule
           hr({ ...props }) {
-            return <hr className="my-6 border-t border-gray-300 dark:border-gray-600" {...props} />;
+            return <hr className={markdownThematicBreakClassName} {...props} />;
           },
 
           // Images
           img({ src, alt, ...props }) {
             if (!src) return null;
-            return <img src={src} alt={alt || ""} className="my-4 max-w-full h-auto" {...props} />;
+            return <img src={src} alt={alt || ""} className={markdownImageClassName} {...props} />;
+          },
+
+          strong({ children, ...props }) {
+            return (
+              <strong className={markdownStrongClassName} {...props}>
+                {children}
+              </strong>
+            );
+          },
+
+          em({ children, ...props }) {
+            return (
+              <em className={markdownEmphasisClassName} {...props}>
+                {children}
+              </em>
+            );
+          },
+
+          del({ children, ...props }) {
+            return (
+              <del className={markdownDeleteClassName} {...props}>
+                {children}
+              </del>
+            );
+          },
+
+          section({ children, className, ...props }) {
+            const sectionProps = props as typeof props & {
+              "data-footnotes"?: string | boolean;
+            };
+            const isFootnotes = sectionProps["data-footnotes"] !== undefined;
+            return (
+              <section
+                className={cn(isFootnotes && markdownFootnotesClassName, className)}
+                {...props}
+              >
+                {children}
+              </section>
+            );
           },
         }}
       >

--- a/src/components/outputs/markdown-output.tsx
+++ b/src/components/outputs/markdown-output.tsx
@@ -20,6 +20,7 @@ import {
   markdownFigureClassName,
   markdownFootnoteBackrefClassName,
   markdownFootnotesClassName,
+  markdownFootnoteRefClassName,
   markdownHeadingAnchorClassName,
   markdownHeadingClassName,
   markdownImageClassName,
@@ -269,10 +270,15 @@ export function MarkdownOutput({
           a({ href, children, className, ...props }) {
             const linkProps = props as typeof props & {
               "data-footnote-backref"?: string | boolean;
+              "data-footnote-ref"?: string | boolean;
             };
+            const classNames = className?.split(/\s+/) ?? [];
             const isFootnoteBackref =
               linkProps["data-footnote-backref"] !== undefined ||
-              className?.split(/\s+/).includes("data-footnote-backref");
+              classNames.includes("data-footnote-backref");
+            const isFootnoteRef =
+              linkProps["data-footnote-ref"] !== undefined ||
+              classNames.includes("data-footnote-ref");
             const isDocumentAnchor = href?.startsWith("#") ?? false;
             return (
               <a
@@ -280,6 +286,7 @@ export function MarkdownOutput({
                 href={href}
                 className={cn(
                   markdownLinkClassName,
+                  isFootnoteRef && markdownFootnoteRefClassName,
                   isFootnoteBackref && markdownFootnoteBackrefClassName,
                   className,
                 )}

--- a/src/components/outputs/markdown-output.tsx
+++ b/src/components/outputs/markdown-output.tsx
@@ -18,6 +18,7 @@ import {
   markdownCodeBlockShellClassName,
   markdownCodeBlockToolbarClassName,
   markdownDeleteClassName,
+  markdownDetailsClassName,
   markdownDocumentClassName,
   markdownEmphasisClassName,
   markdownFigureCaptionClassName,
@@ -33,6 +34,8 @@ import {
   markdownListMarkerClassName,
   markdownParagraphClassName,
   markdownStrongClassName,
+  markdownSummaryClassName,
+  markdownSummaryIndicatorClassName,
   markdownTableCellClassName,
   markdownTableClassName,
   markdownTableHeadClassName,
@@ -512,6 +515,25 @@ export function MarkdownOutput({
               <del className={markdownDeleteClassName} {...props}>
                 {children}
               </del>
+            );
+          },
+
+          details({ children, ...props }) {
+            return (
+              <details className={markdownDetailsClassName} {...props}>
+                {children}
+              </details>
+            );
+          },
+
+          summary({ children, ...props }) {
+            return (
+              <summary className={markdownSummaryClassName} {...props}>
+                <span aria-hidden="true" className={markdownSummaryIndicatorClassName}>
+                  ›
+                </span>
+                <span className="min-w-0">{children}</span>
+              </summary>
             );
           },
 

--- a/src/components/outputs/markdown-output.tsx
+++ b/src/components/outputs/markdown-output.tsx
@@ -120,7 +120,7 @@ function CodeBlock({ children, language = "", enableCopy = true, isDark = false 
           className={markdownCodeBlockLabelClassName}
           title={languageLabel === "code" ? "Code block" : `${languageLabel} code block`}
         >
-          code
+          {languageLabel}
         </span>
         {enableCopy && (
           <button


### PR DESCRIPTION
## Summary

- Explores a bolder shared markdown typography layer: stronger heading hierarchy, permalink heading anchors, richer quote/table/image treatment, plain display math, citation-like footnote styling, quiet copyable code-block chrome, native disclosure appendices, lab-protocol task lists, and more deliberate inline emphasis.
- Keeps projected markdown and sandboxed markdown output aligned through the shared markdown typography constants.
- Extends the Elements markdown typography page with nested evidence, anchorable headings, a neutral figure-style image, native disclosure specimen, lab-protocol checklist, a full-width reading specimen, and the existing classic/cream token comparison.
- Updates static isolated-frame markdown/html defaults so raw HTML output keeps the same document direction.

## Verification

- `cargo xtask lint --fix`
- `pnpm test:run src/components/markdown/__tests__/ProjectedMarkdownView.test.tsx src/components/outputs/__tests__/markdown-output.test.tsx src/components/isolated/__tests__/frame-html.test.ts`
- `pnpm elements:build`
- HTTP checks for `/docs/markdown-typography` and `/fixtures/widget-buffer-url-image.svg`

## Notes

- This is intentionally draft/exploratory so individual typography ideas can be kept, trimmed, or reverted after visual review.
