### PR TITLE
test(notebook-cloud): harden hosted smoke diagnostics

### DIFF
--- a/apps/notebook-cloud/scripts/hosted-live-room-matrix-smoke.mjs
+++ b/apps/notebook-cloud/scripts/hosted-live-room-matrix-smoke.mjs
@@ -2,7 +2,7 @@ import { spawn } from "node:child_process";
 import { mkdir, readFile } from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
-import { fileURLToPath } from "node:url";
+import { fileURLToPath, pathToFileURL } from "node:url";
 
 import {
   entryLabel,
@@ -38,10 +38,23 @@ const tokenPath =
 const screenshotDir = process.env.NOTEBOOK_CLOUD_LIVE_ROOM_MATRIX_SCREENSHOT_DIR;
 const reportPath = smokeJsonReportPath("hosted-live-room-matrix-smoke");
 
-main().catch((error) => {
-  console.error(error instanceof Error ? error.message : String(error));
-  process.exitCode = 1;
-});
+if (isMainModule()) {
+  main().catch(async (error) => {
+    console.error(error instanceof Error ? error.message : String(error));
+    if (!smokeReportAlreadyWritten(error)) {
+      await writeSmokeJsonReport(buildMatrixFailureReport(error), reportPath).catch(
+        (writeError) => {
+          console.error(
+            `[notebook-cloud-smoke] failed to write JSON failure report: ${
+              writeError instanceof Error ? writeError.message : String(writeError)
+            }`,
+          );
+        },
+      );
+    }
+    process.exitCode = 1;
+  });
+}
 
 async function main() {
   const entries =
@@ -73,7 +86,11 @@ async function main() {
 
   await writeSmokeJsonReport(summary, reportPath);
   if (failures.length > 0) {
-    throw new Error(`hosted live room matrix smoke failed:\n${JSON.stringify(summary, null, 2)}`);
+    const error = new Error(
+      `hosted live room matrix smoke failed:\n${JSON.stringify(summary, null, 2)}`,
+    );
+    error.smokeReportAlreadyWritten = true;
+    throw error;
   }
   console.log(JSON.stringify(summary, null, 2));
 }
@@ -231,4 +248,30 @@ function parsePositiveInteger(value, name, fallback) {
 
 function trimLongText(value) {
   return value.length > 6_000 ? `${value.slice(0, 6_000)}...` : value;
+}
+
+export function buildMatrixFailureReport(error) {
+  return {
+    ok: false,
+    baseUrl,
+    source: explicitMatrix === undefined ? "catalog" : "env",
+    limit,
+    concurrency,
+    checked: 0,
+    failed: 1,
+    results: [],
+    error: {
+      name: error instanceof Error ? error.name : "Error",
+      message: error instanceof Error ? error.message : String(error),
+      stack: error instanceof Error ? error.stack : null,
+    },
+  };
+}
+
+function smokeReportAlreadyWritten(error) {
+  return Boolean(error && typeof error === "object" && error.smokeReportAlreadyWritten === true);
+}
+
+function isMainModule() {
+  return process.argv[1] ? import.meta.url === pathToFileURL(process.argv[1]).href : false;
 }

--- a/apps/notebook-cloud/scripts/hosted-render-smoke-routes.mjs
+++ b/apps/notebook-cloud/scripts/hosted-render-smoke-routes.mjs
@@ -39,3 +39,7 @@ export function pinnedNotebookViewerUrl(viewerUrl) {
   const [, notebookId, headsHash] = match;
   return { origin: parsed.origin, notebookId, headsHash };
 }
+
+export function defaultPresenceTitleForViewerUrl(viewerUrl) {
+  return pinnedNotebookViewerUrl(viewerUrl) === null ? "participant" : "";
+}

--- a/apps/notebook-cloud/scripts/hosted-render-smoke.mjs
+++ b/apps/notebook-cloud/scripts/hosted-render-smoke.mjs
@@ -1,5 +1,6 @@
 import { mkdir } from "node:fs/promises";
 import path from "node:path";
+import { pathToFileURL } from "node:url";
 
 import { chromium } from "@playwright/test";
 
@@ -30,8 +31,8 @@ import {
 import { checkRuntimeWasmHints } from "./hosted-render-smoke-runtime-wasm.mjs";
 import {
   catalogApiUrlForViewer,
+  defaultPresenceTitleForViewerUrl,
   isRenderCacheApiUrl,
-  pinnedNotebookViewerUrl,
 } from "./hosted-render-smoke-routes.mjs";
 import { firstPositionalArg } from "./cli-args.mjs";
 import { smokeJsonReportPath, smokeOutputPath, writeSmokeJsonReport } from "./smoke-paths.mjs";
@@ -45,7 +46,6 @@ const DEFAULT_LATEST_REVISION_ACTOR_LABEL =
   "user:anaconda:fdb3dc7d-c369-4a39-bf7d-e35b77a0bdd0/agent:runt-publish";
 
 const targetUrl = firstPositionalArg() ?? process.env.NOTEBOOK_CLOUD_HOSTED_URL ?? DEFAULT_URL;
-const isPinnedSnapshotUrl = pinnedNotebookViewerUrl(targetUrl) !== null;
 const expectedRendererAssetOrigin =
   process.env.NOTEBOOK_CLOUD_EXPECTED_RENDERER_ASSET_ORIGIN ?? DEFAULT_RENDERER_ASSET_ORIGIN;
 const expectedOutputDocumentOrigin =
@@ -55,7 +55,7 @@ const expectedSourceText =
 const expectedExecutionCount = process.env.NOTEBOOK_CLOUD_EXPECTED_EXECUTION_COUNT ?? null;
 const requireRenderedCellMarker = process.env.NOTEBOOK_CLOUD_REQUIRE_RENDERED_CELL_MARKER !== "0";
 const expectedPresenceTitle =
-  process.env.NOTEBOOK_CLOUD_EXPECTED_PRESENCE_TITLE ?? (isPinnedSnapshotUrl ? "" : "participant");
+  process.env.NOTEBOOK_CLOUD_EXPECTED_PRESENCE_TITLE ?? defaultPresenceTitleForViewerUrl(targetUrl);
 const expectedPageTexts = parseExpectedTexts("NOTEBOOK_CLOUD_EXPECTED_PAGE_TEXTS", [
   "MathNet topic visualization",
   "Loading the slice",
@@ -163,10 +163,12 @@ const siftLoadMilestoneMatches = {};
 const smokeStartedAt = performance.now();
 const timingsMs = {};
 
-main().catch((error) => {
-  console.error(error instanceof Error ? error.message : String(error));
-  process.exitCode = 1;
-});
+if (isMainModule()) {
+  main().catch((error) => {
+    console.error(error instanceof Error ? error.message : String(error));
+    process.exitCode = 1;
+  });
+}
 
 async function main() {
   const browser = await chromium.launch({
@@ -625,7 +627,7 @@ async function main() {
   }
 }
 
-function buildFailureReport(error) {
+export function buildFailureReport(error) {
   const reportFailures =
     error instanceof SmokeFailure
       ? error.failures
@@ -1192,10 +1194,14 @@ async function saveScreenshot(page) {
   screenshotSaved = true;
 }
 
-class SmokeFailure extends Error {
+export class SmokeFailure extends Error {
   constructor(failures) {
     super(`Hosted render smoke failed:\n${JSON.stringify(failures, null, 2)}`);
     this.name = "SmokeFailure";
     this.failures = failures;
   }
+}
+
+function isMainModule() {
+  return process.argv[1] ? import.meta.url === pathToFileURL(process.argv[1]).href : false;
 }

--- a/apps/notebook-cloud/test/hosted-live-room-matrix.test.mjs
+++ b/apps/notebook-cloud/test/hosted-live-room-matrix.test.mjs
@@ -7,6 +7,7 @@ import {
   safeScreenshotName,
   smokeEnvForMatrixEntry,
 } from "../scripts/hosted-live-room-matrix.mjs";
+import { buildMatrixFailureReport } from "../scripts/hosted-live-room-matrix-smoke.mjs";
 
 describe("hosted live room matrix smoke helpers", () => {
   it("parses pipe and newline separated URL lists", () => {
@@ -100,5 +101,18 @@ describe("hosted live room matrix smoke helpers", () => {
 
     assert.equal(entryLabel(entry, 0), "01ABC");
     assert.equal(safeScreenshotName("Topic Viz / Old Output", 2), "03-topic-viz-old-output.png");
+  });
+
+  it("builds ok:false reports for pre-summary failures", () => {
+    const report = buildMatrixFailureReport(new Error("token expired"));
+
+    assert.equal(report.ok, false);
+    assert.equal(report.baseUrl, "https://preview.runt.run");
+    assert.equal(report.source, "catalog");
+    assert.equal(report.checked, 0);
+    assert.equal(report.failed, 1);
+    assert.deepEqual(report.results, []);
+    assert.equal(report.error.name, "Error");
+    assert.equal(report.error.message, "token expired");
   });
 });

--- a/apps/notebook-cloud/test/hosted-render-smoke-report.test.mjs
+++ b/apps/notebook-cloud/test/hosted-render-smoke-report.test.mjs
@@ -1,0 +1,25 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+
+import { buildFailureReport, SmokeFailure } from "../scripts/hosted-render-smoke.mjs";
+
+describe("hosted render smoke failure reports", () => {
+  it("builds ok:false reports for ordinary smoke errors", () => {
+    const report = buildFailureReport(new Error("source text timed out"));
+
+    assert.equal(report.ok, false);
+    assert.equal(report.targetUrl, "https://preview.runt.run/n/topic-viz/topic-viz");
+    assert.equal(report.error.name, "Error");
+    assert.equal(report.error.message, "source text timed out");
+    assert.deepEqual(report.failures, [{ kind: "smoke-error", text: "source text timed out" }]);
+  });
+
+  it("preserves structured SmokeFailure entries", () => {
+    const failures = [{ kind: "page-text", text: "missing topic heading" }];
+    const report = buildFailureReport(new SmokeFailure(failures));
+
+    assert.equal(report.ok, false);
+    assert.equal(report.error.name, "SmokeFailure");
+    assert.equal(report.failures, failures);
+  });
+});

--- a/apps/notebook-cloud/test/hosted-smoke-routes.test.mjs
+++ b/apps/notebook-cloud/test/hosted-smoke-routes.test.mjs
@@ -3,6 +3,7 @@ import { describe, it } from "node:test";
 
 import {
   catalogApiUrlForViewer,
+  defaultPresenceTitleForViewerUrl,
   isRenderCacheApiUrl,
   notebookViewerUrl,
   pinnedNotebookViewerUrl,
@@ -43,6 +44,14 @@ describe("hosted render smoke routes", () => {
       notebookId: "foo",
       headsHash: "heads",
     });
+  });
+
+  it("expects live-room presence only for live viewer URLs by default", () => {
+    assert.equal(
+      defaultPresenceTitleForViewerUrl("https://example.com/n/foo/notebook"),
+      "participant",
+    );
+    assert.equal(defaultPresenceTitleForViewerUrl("https://example.com/n/foo/r/heads"), "");
   });
 
   it("returns null for non-viewer URLs", () => {


### PR DESCRIPTION
## Summary
- write an ok:false JSON report when hosted live-room matrix smoke fails before building its normal summary
- keep existing detailed matrix summaries from being overwritten for per-room failures
- make hosted render smoke import-safe and unit-test its ok:false failure report shape
- add direct coverage for pinned snapshot vs live-room presence defaults

## Verification
- pnpm --dir apps/notebook-cloud exec node --test test/hosted-smoke-routes.test.mjs test/hosted-render-smoke-report.test.mjs test/hosted-live-room-matrix.test.mjs test/smoke-paths.test.mjs
- cargo xtask lint --fix
- NOTEBOOK_CLOUD_SMOKE_REPORT=<tmp>/matrix-failure.json NOTEBOOK_CLOUD_OIDC_TOKEN_PATH=<tmp>/missing-token.json pnpm --dir apps/notebook-cloud smoke:hosted:live-rooms exits 1 and writes ok:false report

Follow-up from Pullfrog notes on #3476.