### PR TITLE
feat(notebook-cloud): polish notebook home dashboard

### DIFF
--- a/.agents/skills/frontend-dev/SKILL.md
+++ b/.agents/skills/frontend-dev/SKILL.md
@@ -25,16 +25,23 @@ description: Frontend development, design exploration for UI and Elements surfac
 
 Use this mode when the user asks to iterate on UI, including notebook UI,
 Elements docs, rail/sidebar surfaces, toolbar chrome, cell affordances, runtime
-state language, or says the goal is to make the design "very fluid with a
-natural language."
+state language, or says the goal is to make the design feel fluid with natural
+grouping.
 
 ### Working Shape
 
 - Start a task branch early and treat it as an exploratory design branch.
 - Bring up the dev daemon and Vite unless the user only wants discussion.
 - Prefer real fixture notebooks and existing Elements scenarios over synthetic empty states.
-- If the production app is hard to drive, prototype the visual language in `apps/elements`,
-  then pull only the durable parts back into the main app.
+- If the production app is hard to drive, prototype the visual language in
+  `apps/elements`, then pull only the durable parts back into the main app.
+- Add or update an Elements page when a new surface needs product/design review:
+  create the fixture component in `apps/elements/components/*-example.tsx`,
+  document it in `apps/elements/content/docs/*.mdx`, and link it from
+  `apps/elements/app/page.tsx` plus `apps/elements/content/docs/index.mdx`.
+- Treat Elements fixtures as stable review artifacts: keep data deterministic,
+  avoid live network dependencies, and cover dense, empty, error, and narrow
+  viewport states when the surface needs them.
 - Commit each promising design state as a separate conventional commit so the user can
   review, cherry-pick, or backtrack.
 - Do not rush to PR until there is a tangible visual direction the user likes.
@@ -45,12 +52,19 @@ natural language."
 - Use color as subtle state and focus language, not decoration.
 - Favor fluid separators, ribbons, inline controls, and calm state vocabulary over raised
   pills, bubbles, boxed badges, or noisy status text.
+- Use shared shadcn/nteract primitives from `src/components/ui` where they fit;
+  add new primitives through the repo shadcn workflow instead of one-off
+  component copies.
 - Avoid duplicating identity/mode/status labels when another nearby control already carries
   that meaning.
 - Keep desktop-local identity quiet; reserve explicit auth/account chrome for cloud surfaces.
 - For cloud, separate app-level controls from notebook-level controls:
   presence, connection, sharing, auth, and view/edit mode belong in cloud/app chrome;
   execution, runtime/package language, and cell insertion belong in notebook chrome.
+- For product-surface PRs and docs, describe nteract in concrete system terms:
+  live documents, explicit runtime state, workstation/compute attachment, and
+  collaboration mechanics. Avoid named comparisons to other products in PR
+  descriptions or shipped docs.
 
 ### Visual Verification
 
@@ -59,6 +73,52 @@ natural language."
 - Inspect common states: ready, queued, running, completed, failed, hidden input/output,
   markdown-heavy notebooks, and package/outline rail panels.
 - If motion is involved, verify fast-path behavior so short executions do not flicker.
+
+## Hosted Product Surface Work
+
+Use this subsection for hosted notebook home, sharing, workstation, auth/session,
+and public-notebook polish. These surfaces are app chrome around notebooks; they
+should not fork cell, output, rail, toolbar, or execution UI.
+
+### Product Shape
+
+- Prototype in `apps/elements` first when the visual or interaction model is
+  still uncertain, then promote only stable pieces into `apps/notebook-cloud`.
+- Keep `/n` useful as a notebook home, not just a file list: continuation,
+  ownership/access state, created/open flows, and workstation/runtime readiness
+  should read together.
+- Treat notebook titles as first-class product data. Untitled notebooks must
+  degrade cleanly, but a dashboard full of IDs is a signal that title capture,
+  rename, or cleanup tooling needs attention.
+- Share previews and OG metadata must be safe by default. Private notebooks
+  should not leak content through server-rendered metadata; public notebooks
+  should use explicit published/revision-safe facts.
+- Workstation state belongs to host/app chrome until it becomes the active
+  notebook runtime. Runtime controls stay in the shared notebook toolbar.
+
+### App-Shell Latency
+
+- Avoid first-frame empty states when the route already owns the data. Prefer
+  server bootstrap or retained state for app-shell data such as `/n` lists and
+  sharing ledgers.
+- Do not solve app-shell data freshness by overusing Automerge when the source
+  of truth is an ACL/catalog/session resource. Use Automerge for notebook and
+  runtime documents; use host APIs for catalog, auth, sharing, and account data.
+- If browser auth is localStorage-only, the Worker cannot server-render
+  authenticated HTML on first navigation. A first-party session/cookie layer can
+  bootstrap app-owned pages, but room WebSocket credentials should remain
+  explicit/ticketed and output frames must stay on the separate isolated origin.
+
+### Projection Discipline
+
+- Derive dashboard/list/sidebar summaries in pure projection helpers outside
+  component render bodies. React should consume stable arrays/objects rather
+  than recreating ad hoc projections in JSX.
+- When adding new API facts for UI, keep them structured and host-owned. Avoid
+  parsing principal strings, display labels, or notebook IDs in React except as
+  compatibility fallback.
+- Capture product/architecture decisions in `.context/` during exploration and
+  graduate them to ADRs when they become durable.
 
 ## Hot Reload
 

--- a/apps/elements/app/page.tsx
+++ b/apps/elements/app/page.tsx
@@ -7,6 +7,7 @@ import {
   FileCode2,
   Frame,
   IdCard,
+  LayoutDashboard,
   ListPlus,
   PackageCheck,
   Palette,
@@ -49,6 +50,12 @@ const catalogGroups = [
         description: "Presence, sync, workstations, sharing, mode, and auth.",
         href: "/docs/cloud-notebook-shell",
         icon: Cloud,
+      },
+      {
+        title: "Cloud dashboard",
+        description: "Notebook home, continuation, workstation context, and sharing previews.",
+        href: "/docs/cloud-dashboard",
+        icon: LayoutDashboard,
       },
       {
         title: "Compute placement",

--- a/apps/elements/components/cloud-dashboard-example.tsx
+++ b/apps/elements/components/cloud-dashboard-example.tsx
@@ -3,7 +3,6 @@
 import {
   ArrowRight,
   BookOpen,
-  CheckCircle2,
   Clock3,
   Cpu,
   Database,
@@ -14,19 +13,15 @@ import {
   Link2,
   LockKeyhole,
   MoreHorizontal,
-  Radio,
   RefreshCw,
   Search,
   Share2,
   UserRound,
-  UsersRound,
-  Zap,
   type LucideIcon,
 } from "lucide-react";
 import { cn } from "@/lib/utils";
 
 type NotebookAccess = "owner" | "editor" | "viewer";
-type NotebookComputeState = "ready" | "available" | "offline";
 
 interface DashboardNotebook {
   id: string;
@@ -34,10 +29,8 @@ interface DashboardNotebook {
   access: NotebookAccess;
   updatedAt: string;
   summary: string;
-  latestRevision: "live" | "published" | "draft";
-  compute: NotebookComputeState;
+  latestRevision: "published" | "draft";
   public: boolean;
-  people: number;
 }
 
 interface DashboardMetric {
@@ -54,10 +47,8 @@ const notebooks = [
     access: "owner",
     updatedAt: "18 minutes ago",
     summary: "Embeddings, clustering, Plotly charts, and narrative markdown.",
-    latestRevision: "live",
-    compute: "ready",
+    latestRevision: "draft",
     public: true,
-    people: 2,
   },
   {
     id: "01KTHAZR",
@@ -66,9 +57,7 @@ const notebooks = [
     updatedAt: "42 minutes ago",
     summary: "Remote workstation lifecycle with queued execution probes.",
     latestRevision: "draft",
-    compute: "available",
     public: false,
-    people: 1,
   },
   {
     id: "01KTEYJH",
@@ -77,9 +66,7 @@ const notebooks = [
     updatedAt: "Yesterday",
     summary: "Shared cloud room, Python kernel, and browser editor checks.",
     latestRevision: "published",
-    compute: "offline",
     public: false,
-    people: 3,
   },
   {
     id: "01KSQKEP",
@@ -88,9 +75,7 @@ const notebooks = [
     updatedAt: "May 31",
     summary: "Long document outline, tables, callouts, and heading anchors.",
     latestRevision: "published",
-    compute: "offline",
     public: true,
-    people: 0,
   },
 ] satisfies readonly DashboardNotebook[];
 
@@ -104,8 +89,8 @@ function projectDashboard(source: readonly DashboardNotebook[]) {
   const editableCount = source.filter(
     (notebook) => notebook.access === "owner" || notebook.access === "editor",
   ).length;
+  const ownedCount = source.filter((notebook) => notebook.access === "owner").length;
   const publicCount = source.filter((notebook) => notebook.public).length;
-  const runnableCount = source.filter((notebook) => notebook.compute === "ready").length;
 
   return {
     continueNotebook: source[0]!,
@@ -118,10 +103,10 @@ function projectDashboard(source: readonly DashboardNotebook[]) {
         icon: BookOpen,
       },
       {
-        label: "Runnable now",
-        value: String(runnableCount),
-        detail: "selected workstation ready",
-        icon: Zap,
+        label: "Owned",
+        value: String(ownedCount),
+        detail: "can manage access",
+        icon: UserRound,
       },
       {
         label: "Public links",
@@ -174,7 +159,8 @@ function CloudDashboardFrame() {
             Good morning, Kyle
           </h2>
           <p className="mt-1 max-w-2xl text-sm leading-6 text-fd-muted-foreground">
-            Continue recent work, open shared notebooks, and attach compute when the room is ready.
+            Continue recent work, open shared notebooks, and choose compute when a notebook needs
+            it.
           </p>
         </div>
         <div className="flex flex-wrap gap-2">
@@ -215,8 +201,7 @@ function CloudDashboardFrame() {
             </div>
             <div className="mt-4 flex flex-wrap gap-x-4 gap-y-2 text-xs text-fd-muted-foreground">
               <InlineFact icon={Clock3} label={continued.updatedAt} />
-              <InlineFact icon={Radio} label={computeLabel(continued.compute)} />
-              <InlineFact icon={UsersRound} label={`${continued.people} active`} />
+              <InlineFact icon={UserRound} label={continued.access} />
               <InlineFact
                 icon={continued.public ? Globe2 : LockKeyhole}
                 label={shareLabel(continued)}
@@ -261,7 +246,8 @@ function CloudDashboardFrame() {
                   Signed in
                 </h3>
                 <p className="mt-1 text-sm leading-5 text-fd-muted-foreground">
-                  Owner and editor notebooks can create rooms, manage access, and attach compute.
+                  Owner and editor notebooks can manage access and request compute from a
+                  workstation.
                 </p>
               </div>
             </div>
@@ -283,8 +269,7 @@ function CloudDashboardFrame() {
               <WorkstationFact icon={Database} label="Current Python" />
             </div>
             <div className="mt-4 inline-flex items-center gap-1.5 text-xs font-medium text-emerald-700 dark:text-emerald-300">
-              <CheckCircle2 className="size-3.5" aria-hidden="true" />
-              Default compute target
+              Default workstation candidate
             </div>
           </section>
         </aside>
@@ -355,10 +340,6 @@ function NotebookDashboardRow({ notebook }: { notebook: DashboardNotebook }) {
           </span>
           <span className="mt-2 flex flex-wrap gap-x-3 gap-y-1">
             <NotebookScope access={notebook.access} />
-            <span className="inline-flex items-center gap-1.5 text-xs text-fd-muted-foreground">
-              <Radio className="size-3.5" aria-hidden="true" />
-              {computeLabel(notebook.compute)}
-            </span>
             <span className="inline-flex items-center gap-1.5 text-xs text-fd-muted-foreground">
               {notebook.public ? (
                 <Globe2 className="size-3.5" aria-hidden="true" />
@@ -469,20 +450,9 @@ function DashboardPrinciples() {
   );
 }
 
-function computeLabel(state: NotebookComputeState): string {
-  switch (state) {
-    case "ready":
-      return "ready";
-    case "available":
-      return "available";
-    case "offline":
-      return "offline";
-  }
-}
-
 function shareLabel(notebook: DashboardNotebook): string {
   if (notebook.public) {
-    return notebook.latestRevision === "live" ? "public latest" : "public revision";
+    return notebook.latestRevision === "published" ? "public revision" : "public draft";
   }
   return notebook.latestRevision === "published" ? "private revision" : "private draft";
 }

--- a/apps/elements/components/cloud-dashboard-example.tsx
+++ b/apps/elements/components/cloud-dashboard-example.tsx
@@ -1,0 +1,488 @@
+"use client";
+
+import {
+  ArrowRight,
+  BookOpen,
+  CheckCircle2,
+  Clock3,
+  Cpu,
+  Database,
+  FilePlus2,
+  Globe2,
+  HardDrive,
+  LayoutDashboard,
+  Link2,
+  LockKeyhole,
+  MoreHorizontal,
+  Radio,
+  RefreshCw,
+  Search,
+  Share2,
+  UserRound,
+  UsersRound,
+  Zap,
+  type LucideIcon,
+} from "lucide-react";
+import { cn } from "@/lib/utils";
+
+type NotebookAccess = "owner" | "editor" | "viewer";
+type NotebookComputeState = "ready" | "available" | "offline";
+
+interface DashboardNotebook {
+  id: string;
+  title: string;
+  access: NotebookAccess;
+  updatedAt: string;
+  summary: string;
+  latestRevision: "live" | "published" | "draft";
+  compute: NotebookComputeState;
+  public: boolean;
+  people: number;
+}
+
+interface DashboardMetric {
+  label: string;
+  value: string;
+  detail: string;
+  icon: LucideIcon;
+}
+
+const notebooks = [
+  {
+    id: "01KTFZYC",
+    title: "Topic visualization",
+    access: "owner",
+    updatedAt: "18 minutes ago",
+    summary: "Embeddings, clustering, Plotly charts, and narrative markdown.",
+    latestRevision: "live",
+    compute: "ready",
+    public: true,
+    people: 2,
+  },
+  {
+    id: "01KTHAZR",
+    title: "Runtime peer smoke",
+    access: "owner",
+    updatedAt: "42 minutes ago",
+    summary: "Remote workstation lifecycle with queued execution probes.",
+    latestRevision: "draft",
+    compute: "available",
+    public: false,
+    people: 1,
+  },
+  {
+    id: "01KTEYJH",
+    title: "Lab dual peer",
+    access: "editor",
+    updatedAt: "Yesterday",
+    summary: "Shared cloud room, Python kernel, and browser editor checks.",
+    latestRevision: "published",
+    compute: "offline",
+    public: false,
+    people: 3,
+  },
+  {
+    id: "01KSQKEP",
+    title: "Markdown harness",
+    access: "viewer",
+    updatedAt: "May 31",
+    summary: "Long document outline, tables, callouts, and heading anchors.",
+    latestRevision: "published",
+    compute: "offline",
+    public: true,
+    people: 0,
+  },
+] satisfies readonly DashboardNotebook[];
+
+const dashboard = projectDashboard(notebooks);
+
+function projectDashboard(source: readonly DashboardNotebook[]) {
+  const sorted = [...source].sort((left, right) => {
+    const accessOrder = accessRank(right.access) - accessRank(left.access);
+    return accessOrder || left.title.localeCompare(right.title);
+  });
+  const editableCount = source.filter(
+    (notebook) => notebook.access === "owner" || notebook.access === "editor",
+  ).length;
+  const publicCount = source.filter((notebook) => notebook.public).length;
+  const runnableCount = source.filter((notebook) => notebook.compute === "ready").length;
+
+  return {
+    continueNotebook: source[0]!,
+    notebooks: sorted,
+    metrics: [
+      {
+        label: "Visible notebooks",
+        value: String(source.length),
+        detail: `${editableCount} editable`,
+        icon: BookOpen,
+      },
+      {
+        label: "Runnable now",
+        value: String(runnableCount),
+        detail: "selected workstation ready",
+        icon: Zap,
+      },
+      {
+        label: "Public links",
+        value: String(publicCount),
+        detail: "metadata safe to share",
+        icon: Globe2,
+      },
+    ] satisfies readonly DashboardMetric[],
+  };
+}
+
+function accessRank(access: NotebookAccess): number {
+  switch (access) {
+    case "owner":
+      return 3;
+    case "editor":
+      return 2;
+    case "viewer":
+      return 1;
+  }
+}
+
+export function CloudDashboardExample() {
+  return (
+    <div className="not-prose space-y-6" data-elements-slot="cloud-dashboard">
+      <section className="overflow-hidden rounded-lg border border-fd-border bg-fd-background">
+        <CloudDashboardFrame />
+      </section>
+
+      <section className="grid gap-4 lg:grid-cols-[minmax(0,1fr)_22rem]">
+        <SharePreview notebook={dashboard.continueNotebook} />
+        <DashboardPrinciples />
+      </section>
+    </div>
+  );
+}
+
+function CloudDashboardFrame() {
+  const continued = dashboard.continueNotebook;
+
+  return (
+    <div className="min-h-[44rem] bg-fd-background text-fd-foreground">
+      <header className="flex flex-col gap-4 border-b border-fd-border px-4 py-4 md:flex-row md:items-end md:justify-between md:px-6">
+        <div className="min-w-0">
+          <div className="flex items-center gap-2 text-xs font-medium uppercase tracking-normal text-fd-muted-foreground">
+            <LayoutDashboard className="size-3.5" aria-hidden="true" />
+            Notebook home
+          </div>
+          <h2 className="mt-2 text-2xl font-semibold tracking-normal md:text-3xl">
+            Good morning, Kyle
+          </h2>
+          <p className="mt-1 max-w-2xl text-sm leading-6 text-fd-muted-foreground">
+            Continue recent work, open shared notebooks, and attach compute when the room is ready.
+          </p>
+        </div>
+        <div className="flex flex-wrap gap-2">
+          <DashboardButton icon={Search} label="Search" />
+          <DashboardButton icon={RefreshCw} label="Refresh" />
+          <DashboardButton icon={FilePlus2} label="New notebook" intent="primary" />
+        </div>
+      </header>
+
+      <main className="grid gap-5 px-4 py-5 md:px-6 lg:grid-cols-[minmax(0,1fr)_19rem]">
+        <section className="grid gap-5">
+          <section
+            className="border-l-2 border-emerald-500/70 bg-gradient-to-r from-emerald-500/[0.08] via-fd-background to-fd-background py-4 pl-4 pr-3"
+            aria-labelledby="cloud-dashboard-continue"
+          >
+            <div className="flex flex-col gap-4 md:flex-row md:items-end md:justify-between">
+              <div className="min-w-0">
+                <p className="text-xs font-medium uppercase tracking-normal text-emerald-700 dark:text-emerald-300">
+                  Continue
+                </p>
+                <h3
+                  id="cloud-dashboard-continue"
+                  className="mt-1 truncate text-xl font-semibold tracking-normal"
+                >
+                  {continued.title}
+                </h3>
+                <p className="mt-2 max-w-2xl text-sm leading-6 text-fd-muted-foreground">
+                  {continued.summary}
+                </p>
+              </div>
+              <a
+                href="#cloud-dashboard-notebooks"
+                className="inline-flex h-9 shrink-0 items-center justify-center gap-1.5 rounded-md bg-fd-foreground px-3 text-sm font-medium text-fd-background"
+              >
+                Open
+                <ArrowRight className="size-4" aria-hidden="true" />
+              </a>
+            </div>
+            <div className="mt-4 flex flex-wrap gap-x-4 gap-y-2 text-xs text-fd-muted-foreground">
+              <InlineFact icon={Clock3} label={continued.updatedAt} />
+              <InlineFact icon={Radio} label={computeLabel(continued.compute)} />
+              <InlineFact icon={UsersRound} label={`${continued.people} active`} />
+              <InlineFact
+                icon={continued.public ? Globe2 : LockKeyhole}
+                label={shareLabel(continued)}
+              />
+            </div>
+          </section>
+
+          <section className="grid gap-3 sm:grid-cols-3" aria-label="Notebook summary">
+            {dashboard.metrics.map((metric) => (
+              <DashboardMetricCell key={metric.label} metric={metric} />
+            ))}
+          </section>
+
+          <section id="cloud-dashboard-notebooks" aria-label="Notebook list">
+            <div className="mb-2 flex items-center justify-between gap-3">
+              <h3 className="text-sm font-semibold">Notebooks</h3>
+              <button
+                type="button"
+                className="inline-flex size-8 items-center justify-center rounded-md text-fd-muted-foreground hover:bg-fd-muted hover:text-fd-foreground"
+                aria-label="Notebook list options"
+              >
+                <MoreHorizontal className="size-4" aria-hidden="true" />
+              </button>
+            </div>
+            <ol className="divide-y divide-fd-border border-y border-fd-border">
+              {dashboard.notebooks.map((notebook) => (
+                <NotebookDashboardRow key={notebook.id} notebook={notebook} />
+              ))}
+            </ol>
+          </section>
+        </section>
+
+        <aside className="grid content-start gap-5">
+          <section
+            className="border-l-2 border-fd-border py-1 pl-4"
+            aria-labelledby="cloud-dashboard-account"
+          >
+            <div className="flex items-start gap-2">
+              <UserRound className="mt-0.5 size-4 text-fd-muted-foreground" aria-hidden="true" />
+              <div className="min-w-0">
+                <h3 id="cloud-dashboard-account" className="text-sm font-semibold">
+                  Signed in
+                </h3>
+                <p className="mt-1 text-sm leading-5 text-fd-muted-foreground">
+                  Owner and editor notebooks can create rooms, manage access, and attach compute.
+                </p>
+              </div>
+            </div>
+          </section>
+
+          <section
+            className="border-l-2 border-emerald-500/70 py-1 pl-4"
+            aria-labelledby="cloud-dashboard-workstation"
+          >
+            <p className="font-mono text-[0.68rem] uppercase tracking-normal text-fd-muted-foreground">
+              ws-lab2
+            </p>
+            <h3 id="cloud-dashboard-workstation" className="mt-1 text-base font-semibold">
+              Lab workstation
+            </h3>
+            <div className="mt-3 grid gap-2 text-sm text-fd-muted-foreground">
+              <WorkstationFact icon={Cpu} label="8 CPU" />
+              <WorkstationFact icon={HardDrive} label="31 GiB RAM" />
+              <WorkstationFact icon={Database} label="Current Python" />
+            </div>
+            <div className="mt-4 inline-flex items-center gap-1.5 text-xs font-medium text-emerald-700 dark:text-emerald-300">
+              <CheckCircle2 className="size-3.5" aria-hidden="true" />
+              Default compute target
+            </div>
+          </section>
+        </aside>
+      </main>
+    </div>
+  );
+}
+
+function DashboardButton({
+  icon: Icon,
+  label,
+  intent = "secondary",
+}: {
+  icon: LucideIcon;
+  label: string;
+  intent?: "primary" | "secondary";
+}) {
+  return (
+    <button
+      type="button"
+      className={cn(
+        "inline-flex h-9 items-center justify-center gap-1.5 rounded-md border px-3 text-sm font-medium",
+        intent === "primary"
+          ? "border-fd-foreground bg-fd-foreground text-fd-background"
+          : "border-fd-border bg-fd-background text-fd-foreground hover:bg-fd-muted/60",
+      )}
+    >
+      <Icon className="size-4" aria-hidden="true" />
+      {label}
+    </button>
+  );
+}
+
+function InlineFact({ icon: Icon, label }: { icon: LucideIcon; label: string }) {
+  return (
+    <span className="inline-flex items-center gap-1.5">
+      <Icon className="size-3.5" aria-hidden="true" />
+      {label}
+    </span>
+  );
+}
+
+function DashboardMetricCell({ metric }: { metric: DashboardMetric }) {
+  const Icon = metric.icon;
+  return (
+    <div className="border-l-2 border-fd-border py-2 pl-3">
+      <div className="flex items-center gap-2 text-xs font-medium uppercase tracking-normal text-fd-muted-foreground">
+        <Icon className="size-3.5" aria-hidden="true" />
+        {metric.label}
+      </div>
+      <p className="mt-2 text-2xl font-semibold tracking-normal">{metric.value}</p>
+      <p className="mt-1 text-xs text-fd-muted-foreground">{metric.detail}</p>
+    </div>
+  );
+}
+
+function NotebookDashboardRow({ notebook }: { notebook: DashboardNotebook }) {
+  return (
+    <li>
+      <a
+        href="#cloud-dashboard-notebooks"
+        className="grid min-h-16 grid-cols-[minmax(0,1fr)_auto] gap-x-3 gap-y-2 py-3 text-fd-foreground no-underline hover:bg-fd-muted/40"
+      >
+        <span className="min-w-0 px-2 md:px-3">
+          <span className="block truncate text-sm font-semibold">{notebook.title}</span>
+          <span className="mt-1 block truncate text-xs text-fd-muted-foreground">
+            {notebook.id} · {notebook.summary}
+          </span>
+          <span className="mt-2 flex flex-wrap gap-x-3 gap-y-1">
+            <NotebookScope access={notebook.access} />
+            <span className="inline-flex items-center gap-1.5 text-xs text-fd-muted-foreground">
+              <Radio className="size-3.5" aria-hidden="true" />
+              {computeLabel(notebook.compute)}
+            </span>
+            <span className="inline-flex items-center gap-1.5 text-xs text-fd-muted-foreground">
+              {notebook.public ? (
+                <Globe2 className="size-3.5" aria-hidden="true" />
+              ) : (
+                <LockKeyhole className="size-3.5" aria-hidden="true" />
+              )}
+              {shareLabel(notebook)}
+            </span>
+          </span>
+        </span>
+        <span className="inline-flex items-center justify-end gap-1.5 pr-2 text-xs text-fd-muted-foreground md:pr-3">
+          <Clock3 className="size-3.5" aria-hidden="true" />
+          {notebook.updatedAt}
+        </span>
+      </a>
+    </li>
+  );
+}
+
+function NotebookScope({ access }: { access: NotebookAccess }) {
+  return (
+    <span
+      className={cn(
+        "inline-flex h-6 items-center justify-center rounded-md border px-2 text-xs font-medium",
+        access === "owner"
+          ? "border-emerald-500/30 bg-emerald-500/[0.07] text-emerald-700 dark:text-emerald-300"
+          : access === "editor"
+            ? "border-sky-500/30 bg-sky-500/[0.07] text-sky-700 dark:text-sky-300"
+            : "border-fd-border bg-fd-muted/40 text-fd-muted-foreground",
+      )}
+    >
+      {access}
+    </span>
+  );
+}
+
+function WorkstationFact({ icon: Icon, label }: { icon: LucideIcon; label: string }) {
+  return (
+    <span className="inline-flex items-center gap-2">
+      <Icon className="size-3.5" aria-hidden="true" />
+      {label}
+    </span>
+  );
+}
+
+function SharePreview({ notebook }: { notebook: DashboardNotebook }) {
+  return (
+    <section className="overflow-hidden rounded-lg border border-fd-border bg-fd-background">
+      <div className="border-b border-fd-border px-4 py-3">
+        <div className="flex items-center gap-2 text-xs font-medium uppercase tracking-normal text-fd-muted-foreground">
+          <Share2 className="size-3.5" aria-hidden="true" />
+          Share preview
+        </div>
+      </div>
+      <div className="grid gap-4 p-4 md:grid-cols-[minmax(0,1fr)_15rem]">
+        <div className="grid aspect-[1.91/1] content-between overflow-hidden rounded-md border border-fd-border bg-gradient-to-br from-fd-background via-fd-muted/40 to-emerald-500/[0.12] p-5">
+          <div>
+            <p className="font-mono text-[0.68rem] uppercase tracking-normal text-fd-muted-foreground">
+              nteract notebook
+            </p>
+            <h3 className="mt-2 line-clamp-2 text-2xl font-semibold tracking-normal">
+              {notebook.title}
+            </h3>
+            <p className="mt-3 line-clamp-2 max-w-xl text-sm leading-6 text-fd-muted-foreground">
+              {notebook.summary}
+            </p>
+          </div>
+          <div className="flex items-center justify-between gap-3 text-xs text-fd-muted-foreground">
+            <span>{notebook.id}</span>
+            <span className="inline-flex items-center gap-1.5">
+              {notebook.public ? (
+                <Globe2 className="size-3.5" aria-hidden="true" />
+              ) : (
+                <LockKeyhole className="size-3.5" aria-hidden="true" />
+              )}
+              {shareLabel(notebook)}
+            </span>
+          </div>
+        </div>
+        <div className="grid content-start gap-3 text-sm leading-6 text-fd-muted-foreground">
+          <p>
+            Public metadata can use catalog-safe facts first. Content-derived previews should come
+            only from an explicit published revision.
+          </p>
+          <div className="inline-flex w-max items-center gap-1.5 rounded-md border border-fd-border px-2 py-1 text-xs font-medium text-fd-foreground">
+            <Link2 className="size-3.5" aria-hidden="true" />
+            Revision-aware image
+          </div>
+        </div>
+      </div>
+    </section>
+  );
+}
+
+function DashboardPrinciples() {
+  return (
+    <section className="rounded-lg border border-fd-border bg-fd-background p-4">
+      <div className="flex items-center gap-2 text-xs font-medium uppercase tracking-normal text-fd-muted-foreground">
+        <LayoutDashboard className="size-3.5" aria-hidden="true" />
+        Dashboard rules
+      </div>
+      <ul className="mt-3 grid gap-2 text-sm leading-6 text-fd-muted-foreground">
+        <li>Use the dashboard for app state, identity, sharing, and workstation selection.</li>
+        <li>Keep notebook cells, execution controls, rail panels, and output rendering shared.</li>
+        <li>Show private notebook metadata cautiously; public previews need published intent.</li>
+      </ul>
+    </section>
+  );
+}
+
+function computeLabel(state: NotebookComputeState): string {
+  switch (state) {
+    case "ready":
+      return "ready";
+    case "available":
+      return "available";
+    case "offline":
+      return "offline";
+  }
+}
+
+function shareLabel(notebook: DashboardNotebook): string {
+  if (notebook.public) {
+    return notebook.latestRevision === "live" ? "public latest" : "public revision";
+  }
+  return notebook.latestRevision === "published" ? "private revision" : "private draft";
+}

--- a/apps/elements/content/docs/cloud-dashboard.mdx
+++ b/apps/elements/content/docs/cloud-dashboard.mdx
@@ -1,0 +1,29 @@
+---
+title: Cloud dashboard
+description: Hosted notebook home, continuation, workstation context, and share-preview states.
+---
+
+import { CloudDashboardExample } from "@/components/cloud-dashboard-example";
+
+The hosted dashboard is app-level product chrome. It should help a signed-in
+user continue recent notebook work, inspect visible notebooks, and understand
+whether compute is ready without becoming another notebook shell.
+
+This fixture uses the current list endpoint shape plus deterministic workstation
+and sharing facts. It keeps the extra facts illustrative until the production
+API has stable projections for them.
+
+<CloudDashboardExample />
+
+## Current read
+
+- `/n` should become a notebook home, not only a file list.
+- The first action should be continuing recent work; the full notebook list
+  stays close behind it.
+- Workstation readiness is room/app context. It can summarize the selected
+  default target without owning notebook execution controls.
+- Share previews should be revision-aware and safe by default. Private
+  notebooks should not leak content through metadata; public notebooks can use
+  explicit published data.
+- The dashboard can use host-owned app chrome while notebook pages continue to
+  use the shared document shell, rail, toolbar, and cell/output surfaces.

--- a/apps/elements/content/docs/index.mdx
+++ b/apps/elements/content/docs/index.mdx
@@ -35,6 +35,7 @@ concepts and which boundaries still need a notebook-semantic wrapper.
 
 - [Notebook shell capabilities](/docs/notebook-shell-capabilities)
 - [Cloud notebook shell](/docs/cloud-notebook-shell)
+- [Cloud dashboard](/docs/cloud-dashboard)
 - [Compute placement](/docs/compute-placement)
 - [Identity and environment surfaces](/docs/identity-environment-surfaces)
 - [Notebook toolbar surfaces](/docs/notebook-toolbar-surfaces)

--- a/apps/notebook-cloud/src/index.ts
+++ b/apps/notebook-cloud/src/index.ts
@@ -29,6 +29,7 @@ import {
   getNotebookAclRows,
   getNotebookRow,
   getNotebookCatalog,
+  getPublicPublishedNotebookRow,
   grantNotebookAclRow,
   listNotebooksForPrincipal,
   recordBlob,
@@ -2487,8 +2488,7 @@ async function viewer(
   env: Env,
   headsHash?: string,
 ): Promise<Response> {
-  const escaped = escapeHtml(notebookId);
-  const title = headsHash ? `${escaped} @ ${escapeHtml(headsHash)}` : escaped;
+  const shellMetadata = await publicViewerShellMetadata(env, notebookId, headsHash);
   const notebookApiBasePath = `/api/n/${encodeURIComponent(notebookId)}`;
   const runtimeWasmAssets = await runtimeWasmAssetNames(env);
   const config = {
@@ -2511,12 +2511,7 @@ async function viewer(
     runtimedWasmModulePath: runtimedWasmAssetPath(env, runtimeWasmAssets.module),
     runtimedWasmPath: runtimedWasmAssetPath(env, runtimeWasmAssets.wasm),
   };
-  return viewerShell(
-    `nteract cloud notebook ${title}`,
-    env,
-    authConfigForRequest(request, env),
-    config,
-  );
+  return viewerShell(shellMetadata, env, authConfigForRequest(request, env), config);
 }
 
 interface ViewerShellConfig extends Record<string, unknown> {
@@ -2527,34 +2522,100 @@ interface ViewerShellConfig extends Record<string, unknown> {
 }
 
 function homeViewer(request: Request, env: Env): Response {
-  return viewerShell("nteract", env, authConfigForRequest(request, env), null);
-}
-
-function notebookListViewer(request: Request, env: Env): Response {
-  return viewerShell("nteract cloud notebooks", env, authConfigForRequest(request, env), null);
-}
-
-function oidcCallbackViewer(request: Request, env: Env): Response {
   return viewerShell(
-    "nteract cloud notebook sign-in",
+    { title: "nteract", description: "A hosted nteract notebook workspace." },
     env,
     authConfigForRequest(request, env),
     null,
   );
 }
 
+function notebookListViewer(request: Request, env: Env): Response {
+  return viewerShell(
+    {
+      title: "nteract cloud notebooks",
+      description: "Open, create, and manage hosted nteract notebooks.",
+    },
+    env,
+    authConfigForRequest(request, env),
+    null,
+  );
+}
+
+function oidcCallbackViewer(request: Request, env: Env): Response {
+  return viewerShell(
+    {
+      title: "nteract cloud notebook sign-in",
+      description: "Complete hosted notebook sign-in.",
+    },
+    env,
+    authConfigForRequest(request, env),
+    null,
+  );
+}
+
+interface ViewerShellMetadata {
+  title: string;
+  description: string;
+}
+
+async function publicViewerShellMetadata(
+  env: Env,
+  notebookId: string,
+  headsHash?: string,
+): Promise<ViewerShellMetadata> {
+  const generic = genericNotebookShellMetadata(notebookId, headsHash);
+  if (!env.DB) {
+    return generic;
+  }
+
+  const row = await getPublicPublishedNotebookRow(env, notebookId);
+  if (!row?.latest_revision_id) {
+    return generic;
+  }
+
+  const displayTitle = row.title?.trim() || `Notebook ${shortNotebookId(notebookId)}`;
+  const revisionPart = headsHash
+    ? `revision ${shortNotebookId(headsHash)}`
+    : `published revision ${shortNotebookId(row.latest_revision_id)}`;
+  return {
+    title: `nteract notebook: ${displayTitle}`,
+    description: `${displayTitle} is a public nteract notebook at ${revisionPart}.`,
+  };
+}
+
+function genericNotebookShellMetadata(notebookId: string, headsHash?: string): ViewerShellMetadata {
+  const suffix = headsHash ? ` @ ${headsHash}` : "";
+  return {
+    title: `nteract cloud notebook ${notebookId}${suffix}`,
+    description:
+      "A hosted nteract notebook. Private notebook metadata is shown after access is verified.",
+  };
+}
+
+function shortNotebookId(value: string): string {
+  return value.length <= 12 ? value : value.slice(0, 12);
+}
+
 function viewerShell(
-  title: string,
+  metadata: ViewerShellMetadata,
   env: Env,
   authConfig: unknown,
   config: ViewerShellConfig | null,
 ): Response {
+  const title = escapeHtml(metadata.title);
+  const description = escapeHtml(metadata.description);
   const html = `<!doctype html>
 <html lang="en">
 <head>
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <title>${title}</title>
+  <meta name="description" content="${description}" />
+  <meta property="og:title" content="${title}" />
+  <meta property="og:description" content="${description}" />
+  <meta property="og:type" content="article" />
+  <meta name="twitter:card" content="summary" />
   <style id="nteract-cloud-viewer-theme-surface">${viewerThemeFirstPaintStyle()}</style>
   <script>${viewerThemeBootstrapScript()}</script>
   ${viewerResourceHints(config)}

--- a/apps/notebook-cloud/src/index.ts
+++ b/apps/notebook-cloud/src/index.ts
@@ -508,6 +508,13 @@ async function routeCreateNotebook(request: Request, env: Env): Promise<Response
   if (vanityName instanceof Response) {
     return vanityName;
   }
+  const title = optionalPayloadString(payload, ["title"], {
+    field: "title",
+    maxLength: 160,
+  });
+  if (title instanceof Response) {
+    return title;
+  }
   const sourceNotebookId = optionalPayloadString(
     payload,
     ["source_notebook_id", "sourceNotebookId"],
@@ -524,12 +531,15 @@ async function routeCreateNotebook(request: Request, env: Env): Promise<Response
   if (sourceNotebookName instanceof Response) {
     return sourceNotebookName;
   }
+  const notebookTitle = title ?? sourceNotebookName;
 
   const notebookId = await createUniqueNotebookId(env);
   if (!notebookId) {
     return json({ error: "could not allocate notebook id" }, 500);
   }
-  const notebookCreation = await createNotebookWithOwnerAcl(env, notebookId, identity);
+  const notebookCreation = await createNotebookWithOwnerAcl(env, notebookId, identity, {
+    title: notebookTitle,
+  });
   if (!notebookCreation.created) {
     return json({ error: "could not allocate notebook id" }, 500);
   }
@@ -543,12 +553,13 @@ async function routeCreateNotebook(request: Request, env: Env): Promise<Response
     counter_delta: 1,
   });
 
-  const viewerUrl = viewerUrlForRequest(request, notebookId, vanityName);
+  const viewerUrl = viewerUrlForRequest(request, notebookId, vanityName ?? notebookTitle);
   const apiBasePath = `/api/n/${encodeURIComponent(notebookId)}`;
   return json(
     {
       ok: true,
       notebook_id: notebookId,
+      title: notebookTitle,
       vanity_name: vanityName,
       viewer_url: viewerUrl,
       source_notebook_id: sourceNotebookId,

--- a/apps/notebook-cloud/src/index.ts
+++ b/apps/notebook-cloud/src/index.ts
@@ -36,6 +36,7 @@ import {
   revokeNotebookAclRow,
   runtimeStateSnapshotKey,
   snapshotKey,
+  updateNotebookTitle,
   type NotebookAclRow,
   type NotebookAccessRequestRow,
   type NotebookAccessRequestStatus,
@@ -178,6 +179,12 @@ const NOTEBOOK_CLOUD_ROUTES: readonly WorkerRoute[] = [
     match: routePath("/api/n/:notebookId", { trailingSlash: "optional" }),
     methods: ["GET"],
     handler: ({ params }, request, env) => routeCatalog(request, env, params.notebookId),
+  },
+  {
+    match: routePath("/api/n/:notebookId", { trailingSlash: "optional" }),
+    methods: ["PATCH"],
+    handler: ({ params }, request, env) =>
+      routeUpdateNotebookMetadata(request, env, params.notebookId),
   },
   {
     match: routePath("/api/n/:notebookId/acl", { trailingSlash: "optional" }),
@@ -1710,6 +1717,61 @@ async function routeCatalog(request: Request, env: Env, notebookId: string): Pro
   }
 
   return json(catalog);
+}
+
+async function routeUpdateNotebookMetadata(
+  request: Request,
+  env: Env,
+  notebookId: string,
+): Promise<Response> {
+  const originRejection = rejectUntrustedMutationOrigin(request, env);
+  if (originRejection) {
+    return originRejection;
+  }
+  if (!env.DB) {
+    return json({ error: "D1 binding DB is not configured" }, 503);
+  }
+
+  const identity = await authenticateAndAuthorizeOrResponse(request, env, notebookId, "editor");
+  if (identity instanceof Response) {
+    return identity;
+  }
+
+  const payload = await readCreateNotebookPayload(request);
+  if (payload instanceof Response) {
+    return payload;
+  }
+  if (!Object.hasOwn(payload, "title")) {
+    return json({ error: "title is required" }, 400);
+  }
+  const title = optionalPayloadString(payload, ["title"], {
+    field: "title",
+    maxLength: 160,
+  });
+  if (title instanceof Response) {
+    return title;
+  }
+
+  const notebook = await updateNotebookTitle(env, notebookId, title);
+  if (!notebook) {
+    return json({ error: "notebook not found" }, 404);
+  }
+  cloudLog("info", "notebook.metadata.updated", {
+    notebook_id: notebookId,
+    principal: identity.principal,
+    actor_label: identity.actorLabel,
+    title_present: title !== null,
+    counter: "notebook_metadata_updates",
+    counter_delta: 1,
+  });
+
+  return json({
+    ok: true,
+    notebook_id: notebook.id,
+    title: notebook.title,
+    updated_at: notebook.updated_at,
+    viewer_url: viewerUrlForRequest(request, notebook.id, notebook.title),
+  });
 }
 
 async function validateSnapshotPair(options: {

--- a/apps/notebook-cloud/src/storage.ts
+++ b/apps/notebook-cloud/src/storage.ts
@@ -350,6 +350,31 @@ export async function getNotebookRow(env: Env, notebookId: string): Promise<Note
     .first<NotebookRow>();
 }
 
+export async function updateNotebookTitle(
+  env: Env,
+  notebookId: string,
+  title: string | null,
+): Promise<NotebookRow | null> {
+  if (!env.DB) {
+    return null;
+  }
+
+  await ensureCatalogSchema(env);
+  const updatedAt = new Date().toISOString();
+  const result = await env.DB.prepare(
+    `UPDATE notebooks
+        SET title = ?,
+            updated_at = ?
+      WHERE id = ?`,
+  )
+    .bind(title, updatedAt, notebookId)
+    .run();
+  if (d1Changes(result) === 0) {
+    return null;
+  }
+  return await getNotebookRow(env, notebookId);
+}
+
 export async function getNotebookAclRowsForPrincipal(
   env: Env,
   notebookId: string,

--- a/apps/notebook-cloud/src/storage.ts
+++ b/apps/notebook-cloud/src/storage.ts
@@ -552,6 +552,7 @@ export async function createNotebookWithOwnerAcl(
   env: Env,
   notebookId: string,
   identity: AuthenticatedConnection,
+  options: { title?: string | null } = {},
 ): Promise<CreateNotebookWithOwnerAclResult> {
   if (!env.DB) {
     return { ownerPrincipal: identity.principal, created: true };
@@ -563,10 +564,10 @@ export async function createNotebookWithOwnerAcl(
     (await getCanonicalPrincipalForTransport(env, identity.principal)) ?? identity.principal;
   const [notebookInsertResult] = await env.DB.batch([
     env.DB.prepare(
-      `INSERT INTO notebooks (id, owner_principal, created_at, updated_at)
-         VALUES (?, ?, ?, ?)
+      `INSERT INTO notebooks (id, owner_principal, title, created_at, updated_at)
+         VALUES (?, ?, ?, ?, ?)
          ON CONFLICT(id) DO NOTHING`,
-    ).bind(notebookId, ownerSubject, now, now),
+    ).bind(notebookId, ownerSubject, options.title ?? null, now, now),
     notebookOwnerAclInsert(env, {
       notebookId,
       subject: ownerSubject,

--- a/apps/notebook-cloud/src/storage.ts
+++ b/apps/notebook-cloud/src/storage.ts
@@ -350,6 +350,36 @@ export async function getNotebookRow(env: Env, notebookId: string): Promise<Note
     .first<NotebookRow>();
 }
 
+export async function getPublicPublishedNotebookRow(
+  env: Env,
+  notebookId: string,
+): Promise<NotebookRow | null> {
+  if (!env.DB) {
+    return null;
+  }
+
+  await ensureCatalogSchema(env);
+  return await env.DB.prepare(
+    `SELECT n.id,
+            n.owner_principal,
+            n.title,
+            n.created_at,
+            n.updated_at,
+            n.latest_revision_id
+       FROM notebooks n
+       JOIN notebook_acl a
+         ON a.notebook_id = n.id
+      WHERE n.id = ?
+        AND n.latest_revision_id IS NOT NULL
+        AND a.subject_kind = 'public'
+        AND a.subject = 'anonymous'
+        AND a.scope = 'viewer'
+      LIMIT 1`,
+  )
+    .bind(notebookId)
+    .first<NotebookRow>();
+}
+
 export async function updateNotebookTitle(
   env: Env,
   notebookId: string,

--- a/apps/notebook-cloud/test/notebook-dashboard.test.ts
+++ b/apps/notebook-cloud/test/notebook-dashboard.test.ts
@@ -1,0 +1,84 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+import {
+  cloudNotebookDisplayTitle,
+  cloudNotebookShortId,
+  projectCloudNotebookDashboard,
+  type CloudNotebookListItem,
+} from "../viewer/notebook-dashboard";
+
+describe("cloud notebook dashboard projection", () => {
+  it("sorts by recency and derives dashboard summary counts", () => {
+    const oldViewer = notebook({
+      id: "viewer-old",
+      scope: "viewer",
+      updatedAt: "2026-05-20T00:00:00.000Z",
+      latestRevisionId: "published-old",
+    });
+    const newOwner = notebook({
+      id: "owner-new",
+      scope: "owner",
+      updatedAt: "2026-06-07T15:00:00.000Z",
+      latestRevisionId: null,
+    });
+    const editor = notebook({
+      id: "editor-mid",
+      scope: "editor",
+      updatedAt: "2026-06-01T12:00:00.000Z",
+      latestRevisionId: "published-mid",
+    });
+
+    const model = projectCloudNotebookDashboard([oldViewer, newOwner, editor]);
+
+    assert.equal(model.continueNotebook?.notebook_id, "owner-new");
+    assert.deepEqual(
+      model.notebooks.map((item) => item.notebook_id),
+      ["owner-new", "editor-mid", "viewer-old"],
+    );
+    assert.deepEqual(
+      model.metrics.map((metric) => [metric.label, metric.value, metric.detail]),
+      [
+        ["Visible notebooks", "3", "2 editable"],
+        ["Owned", "1", "can manage access"],
+        ["Published", "2", "revision metadata"],
+      ],
+    );
+  });
+
+  it("keeps notebook identity navigable when titles are missing", () => {
+    const untitled = notebook({
+      id: "01KTHB58DSJWERSEWHD3EJD74P",
+      title: "   ",
+      scope: "owner",
+      updatedAt: "2026-06-07T15:00:00.000Z",
+      latestRevisionId: null,
+    });
+
+    assert.equal(cloudNotebookDisplayTitle(untitled), "Untitled notebook");
+    assert.equal(cloudNotebookShortId(untitled.notebook_id), "01KTHB58...D74P");
+  });
+});
+
+function notebook(input: {
+  id: string;
+  title?: string | null;
+  scope: CloudNotebookListItem["scope"];
+  updatedAt: string;
+  latestRevisionId: string | null;
+}): CloudNotebookListItem {
+  return {
+    notebook_id: input.id,
+    title: input.title ?? null,
+    owner_principal: "user:dev:alice",
+    scope: input.scope,
+    created_at: "2026-05-01T00:00:00.000Z",
+    updated_at: input.updatedAt,
+    latest_revision_id: input.latestRevisionId,
+    viewer_url: `/n/${input.id}/notebook`,
+    endpoints: {
+      catalog: `/api/n/${input.id}`,
+      acl: `/api/n/${input.id}/acl`,
+      access_requests: `/api/n/${input.id}/access-requests`,
+    },
+  };
+}

--- a/apps/notebook-cloud/test/notebook-list-cache.test.ts
+++ b/apps/notebook-cloud/test/notebook-list-cache.test.ts
@@ -1,0 +1,112 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+import {
+  CLOUD_NOTEBOOK_LIST_CACHE_STORAGE_KEY,
+  CLOUD_NOTEBOOK_LIST_CACHE_TTL_MS,
+  clearCachedCloudNotebookList,
+  readCachedCloudNotebookList,
+  writeCachedCloudNotebookList,
+} from "../viewer/notebook-list-cache";
+import type { CloudPrototypeAuthState } from "../viewer/collaborator-auth";
+import type { CloudNotebookListItem } from "../viewer/notebook-dashboard";
+
+describe("cloud notebook list cache", () => {
+  it("round-trips notebooks for the same browser identity", () => {
+    const storage = new MemoryStorage();
+    const auth = oidcAuth("user-a");
+    const notebooks = [notebook("nb-a")];
+
+    writeCachedCloudNotebookList(storage, auth, notebooks, 1_000);
+
+    assert.deepEqual(readCachedCloudNotebookList(storage, auth, 2_000), notebooks);
+  });
+
+  it("does not reuse cached catalog rows for another identity", () => {
+    const storage = new MemoryStorage();
+    writeCachedCloudNotebookList(storage, oidcAuth("user-a"), [notebook("nb-a")], 1_000);
+
+    assert.equal(readCachedCloudNotebookList(storage, oidcAuth("user-b"), 2_000), null);
+  });
+
+  it("expires retained catalog rows", () => {
+    const storage = new MemoryStorage();
+    const auth = oidcAuth("user-a");
+    writeCachedCloudNotebookList(storage, auth, [notebook("nb-a")], 1_000);
+
+    assert.equal(
+      readCachedCloudNotebookList(storage, auth, 1_000 + CLOUD_NOTEBOOK_LIST_CACHE_TTL_MS + 1),
+      null,
+    );
+  });
+
+  it("rejects malformed cached rows", () => {
+    const storage = new MemoryStorage();
+    storage.setItem(
+      CLOUD_NOTEBOOK_LIST_CACHE_STORAGE_KEY,
+      JSON.stringify({
+        authKey: "oidc:user-a",
+        savedAt: 1_000,
+        notebooks: [{ notebook_id: "nb-a" }],
+      }),
+    );
+
+    assert.equal(readCachedCloudNotebookList(storage, oidcAuth("user-a"), 2_000), null);
+  });
+
+  it("clears retained catalog rows", () => {
+    const storage = new MemoryStorage();
+    const auth = oidcAuth("user-a");
+    writeCachedCloudNotebookList(storage, auth, [notebook("nb-a")], 1_000);
+
+    clearCachedCloudNotebookList(storage);
+
+    assert.equal(readCachedCloudNotebookList(storage, auth, 2_000), null);
+  });
+});
+
+function oidcAuth(subject: string): CloudPrototypeAuthState {
+  return {
+    mode: "oidc",
+    token: "token",
+    user: subject,
+    oidcClaims: {
+      sub: subject,
+    },
+    requestedScope: "viewer",
+    problem: null,
+  };
+}
+
+function notebook(id: string): CloudNotebookListItem {
+  return {
+    notebook_id: id,
+    title: null,
+    owner_principal: "user:dev:alice",
+    scope: "owner",
+    created_at: "2026-05-01T00:00:00.000Z",
+    updated_at: "2026-06-01T00:00:00.000Z",
+    latest_revision_id: null,
+    viewer_url: `/n/${id}/notebook`,
+    endpoints: {
+      catalog: `/api/n/${id}`,
+      acl: `/api/n/${id}/acl`,
+      access_requests: `/api/n/${id}/access-requests`,
+    },
+  };
+}
+
+class MemoryStorage {
+  private values = new Map<string, string>();
+
+  getItem(key: string): string | null {
+    return this.values.get(key) ?? null;
+  }
+
+  removeItem(key: string): void {
+    this.values.delete(key);
+  }
+
+  setItem(key: string, value: string): void {
+    this.values.set(key, value);
+  }
+}

--- a/apps/notebook-cloud/test/worker-routes.test.ts
+++ b/apps/notebook-cloud/test/worker-routes.test.ts
@@ -643,10 +643,12 @@ describe("Worker artifact routes", () => {
       notebook_id: string;
       source_notebook_id: string;
       source_notebook_name: string;
+      title: string;
       vanity_name: string;
       viewer_url: string;
     };
     assert.match(body.notebook_id, /^[0-9A-HJKMNP-TV-Z]{26}$/);
+    assert.equal(body.title, "Markdown Harness");
     assert.equal(body.vanity_name, "markdown-harness");
     assert.equal(body.source_notebook_id, "332dd3e3-b1d5-4d16-8ad6-16919b3157d1");
     assert.equal(body.source_notebook_name, "Markdown Harness");
@@ -661,6 +663,7 @@ describe("Worker artifact routes", () => {
     });
     assert.ok(accountPrincipal);
     assert.equal(env.DB.notebooks.get(body.notebook_id)?.owner_principal, accountPrincipal);
+    assert.equal(env.DB.notebooks.get(body.notebook_id)?.title, "Markdown Harness");
     assert.equal(
       env.DB.acl.some(
         (row) =>
@@ -670,6 +673,37 @@ describe("Worker artifact routes", () => {
       ),
       true,
     );
+  });
+
+  it("uses a notebook title as the initial vanity URL when creating from the cloud home", async () => {
+    const env = fakeEnv();
+
+    const response = await worker.fetch(
+      new Request("http://localhost/api/n", {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          "X-Operator": "browser:tab",
+          "X-Scope": "owner",
+          "X-User": "alice",
+        },
+        body: JSON.stringify({ title: "Exploration Notes" }),
+      }),
+      env,
+      fakeContext(),
+    );
+
+    assert.equal(response.status, 201);
+    const body = (await response.json()) as {
+      notebook_id: string;
+      title: string;
+      vanity_name: string | null;
+      viewer_url: string;
+    };
+    assert.equal(body.title, "Exploration Notes");
+    assert.equal(body.vanity_name, null);
+    assert.equal(env.DB.notebooks.get(body.notebook_id)?.title, "Exploration Notes");
+    assert.equal(body.viewer_url, `http://localhost/n/${body.notebook_id}/Exploration%20Notes`);
   });
 
   it("lists notebooks visible to the authenticated principal", async () => {
@@ -3624,14 +3658,17 @@ class FakeD1Statement implements D1PreparedStatement {
       }
       return okResult(undefined, { changes: 0 });
     } else if (this.query.includes("INSERT INTO notebooks")) {
-      const [id, ownerPrincipal, createdAtOrUpdatedAt, maybeUpdatedAt] = this.values as [
-        string,
-        string,
-        string,
-        string | undefined,
-      ];
-      const createdAt = maybeUpdatedAt ? createdAtOrUpdatedAt : undefined;
-      const updatedAt = maybeUpdatedAt ?? createdAtOrUpdatedAt;
+      const [id, ownerPrincipal, maybeTitleOrCreatedAt, createdAtOrUpdatedAt, maybeUpdatedAt] = this
+        .values as [string, string, string | null, string | undefined, string | undefined];
+      const hasTitleColumn = this.query.includes(" title,");
+      const title = hasTitleColumn ? maybeTitleOrCreatedAt : null;
+      const createdAtSource = hasTitleColumn ? createdAtOrUpdatedAt : maybeTitleOrCreatedAt;
+      const updatedAtSource = hasTitleColumn ? maybeUpdatedAt : createdAtOrUpdatedAt;
+      const createdAt = updatedAtSource ? createdAtSource : undefined;
+      const updatedAt = updatedAtSource ?? createdAtSource;
+      if (!updatedAt) {
+        throw new Error("fake notebook insert did not receive an updated_at value");
+      }
       const existing = this.db.notebooks.get(id);
       if (existing && this.query.includes("DO NOTHING")) {
         return okResult(undefined, { changes: 0 });
@@ -3639,7 +3676,7 @@ class FakeD1Statement implements D1PreparedStatement {
       this.db.notebooks.set(id, {
         id,
         owner_principal: existing?.owner_principal ?? ownerPrincipal,
-        title: existing?.title ?? null,
+        title: existing?.title ?? title,
         created_at: existing?.created_at ?? createdAt ?? updatedAt,
         updated_at: updatedAt,
         latest_revision_id: existing?.latest_revision_id ?? null,

--- a/apps/notebook-cloud/test/worker-routes.test.ts
+++ b/apps/notebook-cloud/test/worker-routes.test.ts
@@ -706,6 +706,70 @@ describe("Worker artifact routes", () => {
     assert.equal(body.viewer_url, `http://localhost/n/${body.notebook_id}/Exploration%20Notes`);
   });
 
+  it("renames notebook titles for editors", async () => {
+    const env = fakeEnv();
+    seedNotebook(env, "rename-demo");
+    seedAcl(env, { notebookId: "rename-demo", subject: "user:dev:alice", scope: "editor" });
+
+    const response = await worker.fetch(
+      new Request("http://localhost/api/n/rename-demo", {
+        method: "PATCH",
+        headers: {
+          "Content-Type": "application/json",
+          "X-Operator": "browser:tab",
+          "X-Scope": "editor",
+          "X-User": "alice",
+        },
+        body: JSON.stringify({ title: "Renamed Notebook" }),
+      }),
+      env,
+      fakeContext(),
+    );
+
+    assert.equal(response.status, 200);
+    const body = (await response.json()) as {
+      notebook_id: string;
+      ok: boolean;
+      title: string | null;
+      updated_at: string;
+      viewer_url: string;
+    };
+    assert.equal(body.ok, true);
+    assert.equal(body.notebook_id, "rename-demo");
+    assert.equal(body.title, "Renamed Notebook");
+    assert.equal(env.DB.notebooks.get("rename-demo")?.title, "Renamed Notebook");
+    assert.equal(env.DB.notebooks.get("rename-demo")?.updated_at, body.updated_at);
+    assert.equal(body.viewer_url, "http://localhost/n/rename-demo/Renamed%20Notebook");
+  });
+
+  it("rejects notebook title updates from viewers", async () => {
+    const env = fakeEnv();
+    seedNotebook(env, "viewer-rename-demo");
+    seedAcl(env, {
+      notebookId: "viewer-rename-demo",
+      subject: "user:dev:alice",
+      scope: "viewer",
+    });
+
+    const response = await worker.fetch(
+      new Request("http://localhost/api/n/viewer-rename-demo", {
+        method: "PATCH",
+        headers: {
+          "Content-Type": "application/json",
+          "X-Operator": "browser:tab",
+          "X-Scope": "viewer",
+          "X-User": "alice",
+        },
+        body: JSON.stringify({ title: "Not Allowed" }),
+      }),
+      env,
+      fakeContext(),
+    );
+
+    assert.equal(response.status, 403);
+    assert.equal(env.DB.notebooks.get("viewer-rename-demo")?.title, null);
+  });
+
   it("lists notebooks visible to the authenticated principal", async () => {
     const env = fakeEnv();
     seedNotebook(env, "old-owned");
@@ -3729,6 +3793,15 @@ class FakeD1Statement implements D1PreparedStatement {
         existing.latest_revision_id = revisionId;
         existing.updated_at = updatedAt;
       }
+    } else if (this.query.includes("UPDATE notebooks") && this.query.includes("SET title")) {
+      const [title, updatedAt, notebookId] = this.values as [string | null, string, string];
+      const existing = this.db.notebooks.get(notebookId);
+      if (!existing) {
+        return okResult(undefined, { changes: 0 });
+      }
+      existing.title = title;
+      existing.updated_at = updatedAt;
+      return okResult(undefined, { changes: 1 });
     } else if (this.query.includes("UPDATE notebooks") && this.query.includes("owner_principal")) {
       const [canonicalPrincipal, updatedAt, transportPrincipal] = this.values as [
         string,

--- a/apps/notebook-cloud/test/worker-routes.test.ts
+++ b/apps/notebook-cloud/test/worker-routes.test.ts
@@ -174,6 +174,57 @@ describe("Worker artifact routes", () => {
     assert.doesNotMatch(html, /topic-viz.*render/);
   });
 
+  it("uses catalog-safe metadata for public published notebook viewers", async () => {
+    const env = fakeEnv();
+    seedNotebook(env, "public-meta-demo");
+    const notebook = env.DB.notebooks.get("public-meta-demo");
+    assert.ok(notebook);
+    notebook.title = "Public & Safe <Notebook>";
+    notebook.latest_revision_id = "revision-public-metadata";
+    seedAcl(env, {
+      notebookId: "public-meta-demo",
+      subjectKind: "public",
+      subject: "anonymous",
+      scope: "viewer",
+    });
+
+    const response = await worker.fetch(
+      new Request("http://localhost/n/public-meta-demo/public-title"),
+      env,
+      fakeContext(),
+    );
+
+    assert.equal(response.status, 200);
+    const html = await response.text();
+    assert.match(html, /<title>nteract notebook: Public &amp; Safe &lt;Notebook&gt;<\/title>/);
+    assert.match(
+      html,
+      /<meta property="og:title" content="nteract notebook: Public &amp; Safe &lt;Notebook&gt;" \/>/,
+    );
+    assert.match(html, /published revision revision-pub/);
+  });
+
+  it("keeps private notebook titles out of server-rendered viewer metadata", async () => {
+    const env = fakeEnv();
+    seedNotebook(env, "private-meta-demo");
+    const notebook = env.DB.notebooks.get("private-meta-demo");
+    assert.ok(notebook);
+    notebook.title = "Secret Research Plan";
+    notebook.latest_revision_id = "revision-private-metadata";
+
+    const response = await worker.fetch(
+      new Request("http://localhost/n/private-meta-demo/secret-plan"),
+      env,
+      fakeContext(),
+    );
+
+    assert.equal(response.status, 200);
+    const html = await response.text();
+    assert.match(html, /<title>nteract cloud notebook private-meta-demo<\/title>/);
+    assert.match(html, /Private notebook metadata is shown after access is verified\./);
+    assert.doesNotMatch(html, /Secret Research Plan|revision-private-metadata/);
+  });
+
   it("serves the notebook list page at /n", async () => {
     const env = fakeEnv();
 
@@ -3993,6 +4044,22 @@ class FakeD1Statement implements D1PreparedStatement {
         );
       }
       return (this.db.invites.get(this.values[0] as string) as T | undefined) ?? null;
+    }
+    if (
+      this.query.includes("FROM notebooks n") &&
+      this.query.includes("JOIN notebook_acl a") &&
+      this.query.includes("a.subject_kind = 'public'")
+    ) {
+      const notebookId = this.values[0] as string;
+      const notebook = this.db.notebooks.get(notebookId);
+      const publicViewer = this.db.acl.some(
+        (row) =>
+          row.notebook_id === notebookId &&
+          row.subject_kind === "public" &&
+          row.subject === "anonymous" &&
+          row.scope === "viewer",
+      );
+      return (notebook?.latest_revision_id && publicViewer ? notebook : null) as T | null;
     }
     if (this.query.includes("FROM notebooks")) {
       return (this.db.notebooks.get(this.values[0] as string) as T | undefined) ?? null;

--- a/apps/notebook-cloud/viewer/index.css
+++ b/apps/notebook-cloud/viewer/index.css
@@ -696,15 +696,13 @@ body {
   min-height: 4.75rem;
   border-bottom: 1px solid var(--border);
   color: var(--foreground);
-  text-decoration: none;
 }
 
 .cloud-notebook-list-row:hover {
   background: color-mix(in srgb, var(--background) 94%, var(--foreground) 5%);
 }
 
-.cloud-notebook-list-updated svg,
-.cloud-notebook-list-open {
+.cloud-notebook-list-updated svg {
   width: 1rem;
   height: 1rem;
 }
@@ -713,6 +711,8 @@ body {
   display: grid;
   min-width: 0;
   gap: 0.1875rem;
+  color: inherit;
+  text-decoration: none;
 }
 
 .cloud-notebook-list-title,
@@ -760,8 +760,69 @@ body {
   white-space: nowrap;
 }
 
-.cloud-notebook-list-open {
-  color: color-mix(in srgb, var(--foreground) 48%, transparent);
+.cloud-notebook-list-row-actions {
+  display: inline-flex;
+  align-items: center;
+  justify-content: flex-end;
+  gap: 0.25rem;
+}
+
+.cloud-notebook-list-icon-button,
+.cloud-notebook-list-rename-form button {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 2rem;
+  height: 2rem;
+  border: 0;
+  border-radius: 6px;
+  color: color-mix(in srgb, var(--foreground) 54%, transparent);
+  background: transparent;
+  cursor: pointer;
+  text-decoration: none;
+}
+
+.cloud-notebook-list-icon-button:hover,
+.cloud-notebook-list-rename-form button:hover {
+  color: var(--foreground);
+  background: color-mix(in srgb, var(--foreground) 8%, transparent);
+}
+
+.cloud-notebook-list-icon-button:disabled,
+.cloud-notebook-list-rename-form button:disabled {
+  cursor: default;
+  opacity: 0.58;
+}
+
+.cloud-notebook-list-icon-button svg,
+.cloud-notebook-list-rename-form button svg {
+  width: 1rem;
+  height: 1rem;
+}
+
+.cloud-notebook-list-rename-form {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto auto;
+  align-items: center;
+  gap: 0.375rem;
+  min-height: 4.75rem;
+  border-bottom: 1px solid var(--border);
+}
+
+.cloud-notebook-list-rename-form input {
+  min-width: 0;
+  height: 2.25rem;
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  padding-inline: 0.625rem;
+  color: var(--foreground);
+  background: color-mix(in srgb, var(--background) 96%, var(--foreground) 4%);
+  font: inherit;
+}
+
+.cloud-notebook-list-rename-form input:focus {
+  outline: 2px solid color-mix(in srgb, #0f766e 42%, transparent);
+  outline-offset: 1px;
 }
 
 .cloud-notebook-list-state {
@@ -836,9 +897,15 @@ body {
     margin-top: -0.25rem;
   }
 
-  .cloud-notebook-list-open {
+  .cloud-notebook-list-row-actions {
     grid-column: 2;
     grid-row: 1;
+  }
+
+  .cloud-notebook-list-rename-form {
+    grid-template-columns: minmax(0, 1fr) auto auto;
+    min-height: 4.5rem;
+    padding-block: 0.625rem;
   }
 }
 

--- a/apps/notebook-cloud/viewer/index.css
+++ b/apps/notebook-cloud/viewer/index.css
@@ -417,6 +417,208 @@ body {
   padding: clamp(0.75rem, 3vw, 1.5rem) clamp(1rem, 4vw, 2rem) 2rem;
 }
 
+.cloud-dashboard {
+  display: grid;
+  gap: 1.25rem;
+  width: min(100%, 72rem);
+}
+
+.cloud-dashboard-continue {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto;
+  gap: 1rem;
+  align-items: end;
+  border-left: 2px solid color-mix(in srgb, #10b981 70%, transparent);
+  padding: 1rem 0 1rem 1rem;
+  background: linear-gradient(
+    90deg,
+    color-mix(in srgb, #10b981 7%, var(--background)) 0%,
+    color-mix(in srgb, var(--background) 98%, transparent) 68%,
+    transparent 100%
+  );
+}
+
+.cloud-dashboard-continue-main {
+  min-width: 0;
+}
+
+.cloud-dashboard-continue-main p,
+.cloud-dashboard-continue-main h2 {
+  margin: 0;
+}
+
+.cloud-dashboard-continue-main p {
+  color: #0f766e;
+  font-size: 0.75rem;
+  font-weight: 700;
+  letter-spacing: 0;
+  line-height: 1.2;
+  text-transform: uppercase;
+}
+
+.cloud-dashboard-continue-main h2 {
+  margin-top: 0.25rem;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  font-size: clamp(1.25rem, 3vw, 1.875rem);
+  font-weight: 720;
+  line-height: 1.1;
+}
+
+.cloud-dashboard-continue-id {
+  display: block;
+  margin-top: 0.375rem;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  color: color-mix(in srgb, var(--foreground) 54%, transparent);
+  font-family:
+    ui-monospace, SFMono-Regular, "SF Mono", Consolas, "Liberation Mono", Menlo, monospace;
+  font-size: 0.75rem;
+  line-height: 1.2;
+}
+
+.cloud-dashboard-continue-facts {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.375rem 1rem;
+  margin-top: 0.75rem;
+  color: color-mix(in srgb, var(--foreground) 60%, transparent);
+  font-size: 0.8125rem;
+}
+
+.cloud-dashboard-continue-facts span,
+.cloud-notebook-list-row-facts span,
+.cloud-dashboard-summary-item span {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.375rem;
+}
+
+.cloud-dashboard-continue-facts svg,
+.cloud-notebook-list-row-facts svg,
+.cloud-dashboard-summary-item svg {
+  width: 0.875rem;
+  height: 0.875rem;
+  flex: 0 0 auto;
+}
+
+.cloud-dashboard-primary-link {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.375rem;
+  min-height: 2.25rem;
+  border-radius: 6px;
+  padding-inline: 0.875rem;
+  color: var(--background);
+  background: var(--foreground);
+  font-size: 0.875rem;
+  font-weight: 650;
+  text-decoration: none;
+}
+
+.cloud-dashboard-primary-link svg {
+  width: 0.9375rem;
+  height: 0.9375rem;
+}
+
+.cloud-dashboard-summary {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 0.75rem;
+}
+
+.cloud-dashboard-summary-item {
+  border-left: 2px solid color-mix(in srgb, var(--foreground) 16%, transparent);
+  padding: 0.625rem 0 0.625rem 0.875rem;
+}
+
+.cloud-dashboard-summary-item span {
+  color: color-mix(in srgb, var(--foreground) 58%, transparent);
+  font-size: 0.75rem;
+  font-weight: 700;
+  letter-spacing: 0;
+  line-height: 1.25;
+  text-transform: uppercase;
+}
+
+.cloud-dashboard-summary-item strong {
+  display: block;
+  margin-top: 0.5rem;
+  font-size: 1.75rem;
+  font-weight: 720;
+  line-height: 1;
+}
+
+.cloud-dashboard-summary-item p {
+  margin: 0.375rem 0 0;
+  color: color-mix(in srgb, var(--foreground) 58%, transparent);
+  font-size: 0.8125rem;
+  line-height: 1.35;
+}
+
+.cloud-dashboard-grid {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) 18rem;
+  gap: 1.5rem;
+  align-items: start;
+}
+
+.cloud-dashboard-section-heading {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+  margin-bottom: 0.625rem;
+}
+
+.cloud-dashboard-section-heading h2,
+.cloud-dashboard-aside h2,
+.cloud-dashboard-aside p {
+  margin: 0;
+}
+
+.cloud-dashboard-section-heading h2 {
+  font-size: 1rem;
+  font-weight: 700;
+  line-height: 1.2;
+}
+
+.cloud-dashboard-aside {
+  display: grid;
+  gap: 1.25rem;
+}
+
+.cloud-dashboard-aside section {
+  border-left: 2px solid color-mix(in srgb, var(--foreground) 16%, transparent);
+  padding-left: 0.875rem;
+}
+
+.cloud-dashboard-aside-kicker {
+  color: color-mix(in srgb, var(--foreground) 54%, transparent);
+  font-size: 0.6875rem;
+  font-weight: 700;
+  letter-spacing: 0;
+  line-height: 1.25;
+  text-transform: uppercase;
+}
+
+.cloud-dashboard-aside h2 {
+  margin-top: 0.25rem;
+  font-size: 1rem;
+  font-weight: 700;
+  line-height: 1.25;
+}
+
+.cloud-dashboard-aside section > p:not(.cloud-dashboard-aside-kicker) {
+  margin-top: 0.5rem;
+  color: color-mix(in srgb, var(--foreground) 62%, transparent);
+  font-size: 0.875rem;
+  line-height: 1.45;
+}
+
 .cloud-notebook-list {
   display: grid;
   margin: 0;
@@ -427,10 +629,10 @@ body {
 
 .cloud-notebook-list-row {
   display: grid;
-  grid-template-columns: 2rem minmax(0, 1fr) auto minmax(10rem, auto) auto;
+  grid-template-columns: 2rem minmax(0, 1fr) minmax(10rem, auto) auto;
   align-items: center;
   gap: 0.75rem;
-  min-height: 4rem;
+  min-height: 4.75rem;
   border-bottom: 1px solid var(--border);
   color: var(--foreground);
   text-decoration: none;
@@ -484,9 +686,18 @@ body {
   line-height: 1.2;
 }
 
+.cloud-notebook-list-row-facts {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.375rem 0.875rem;
+  margin-top: 0.5rem;
+  color: color-mix(in srgb, var(--foreground) 58%, transparent);
+  font-size: 0.75rem;
+}
+
 .cloud-notebook-list-scope {
   border: 1px solid color-mix(in srgb, var(--foreground) 14%, transparent);
-  border-radius: 999px;
+  border-radius: 6px;
   padding: 0.1875rem 0.5rem;
   color: color-mix(in srgb, var(--foreground) 68%, transparent);
   background: color-mix(in srgb, var(--background) 92%, var(--foreground) 7%);
@@ -556,6 +767,19 @@ body {
     justify-content: flex-start;
   }
 
+  .cloud-dashboard-continue,
+  .cloud-dashboard-grid {
+    grid-template-columns: minmax(0, 1fr);
+  }
+
+  .cloud-dashboard-primary-link {
+    width: fit-content;
+  }
+
+  .cloud-dashboard-summary {
+    grid-template-columns: minmax(0, 1fr);
+  }
+
   .cloud-notebook-list-row {
     grid-template-columns: 2rem minmax(0, 1fr) auto;
     min-height: 4.5rem;
@@ -563,7 +787,6 @@ body {
     padding-block: 0.625rem;
   }
 
-  .cloud-notebook-list-scope,
   .cloud-notebook-list-updated {
     grid-column: 2 / -1;
     justify-self: start;

--- a/apps/notebook-cloud/viewer/index.css
+++ b/apps/notebook-cloud/viewer/index.css
@@ -411,6 +411,67 @@ body {
   background: color-mix(in srgb, #b42318 6%, var(--background));
 }
 
+.cloud-new-notebook-form {
+  display: grid;
+  grid-template-columns: auto minmax(14rem, 24rem) auto auto;
+  gap: 0.5rem;
+  align-items: center;
+  border-bottom: 1px solid color-mix(in srgb, var(--foreground) 12%, transparent);
+  padding: 0.75rem clamp(1rem, 4vw, 2rem);
+  background: color-mix(in srgb, var(--background) 97%, var(--foreground) 3%);
+}
+
+.cloud-new-notebook-form label {
+  color: color-mix(in srgb, var(--foreground) 60%, transparent);
+  font-size: 0.75rem;
+  font-weight: 700;
+  letter-spacing: 0;
+  text-transform: uppercase;
+}
+
+.cloud-new-notebook-form input {
+  width: 100%;
+  min-width: 0;
+  height: 2.25rem;
+  border: 1px solid color-mix(in srgb, var(--foreground) 16%, transparent);
+  border-radius: 6px;
+  padding-inline: 0.625rem;
+  color: var(--foreground);
+  background: var(--background);
+  font: inherit;
+  font-size: 0.875rem;
+}
+
+.cloud-new-notebook-form input:focus-visible {
+  outline: 2px solid color-mix(in srgb, #0f766e 42%, transparent);
+  outline-offset: 2px;
+}
+
+.cloud-new-notebook-form button {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.375rem;
+  min-height: 2.25rem;
+  border: 1px solid color-mix(in srgb, var(--foreground) 16%, transparent);
+  border-radius: 6px;
+  padding-inline: 0.75rem;
+  color: var(--foreground);
+  background: var(--background);
+  font-size: 0.875rem;
+  font-weight: 650;
+}
+
+.cloud-new-notebook-form button[type="submit"] {
+  color: var(--background);
+  background: var(--foreground);
+}
+
+.cloud-new-notebook-form button svg {
+  width: 0.9375rem;
+  height: 0.9375rem;
+}
+
 .cloud-notebook-list-content {
   display: grid;
   align-content: start;
@@ -629,9 +690,9 @@ body {
 
 .cloud-notebook-list-row {
   display: grid;
-  grid-template-columns: 2rem minmax(0, 1fr) minmax(10rem, auto) auto;
+  grid-template-columns: minmax(0, 1fr) minmax(10rem, auto) auto;
   align-items: center;
-  gap: 0.75rem;
+  gap: 1rem;
   min-height: 4.75rem;
   border-bottom: 1px solid var(--border);
   color: var(--foreground);
@@ -642,16 +703,6 @@ body {
   background: color-mix(in srgb, var(--background) 94%, var(--foreground) 5%);
 }
 
-.cloud-notebook-list-icon {
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  width: 2rem;
-  height: 2rem;
-  color: color-mix(in srgb, #0f766e 82%, var(--foreground));
-}
-
-.cloud-notebook-list-icon svg,
 .cloud-notebook-list-updated svg,
 .cloud-notebook-list-open {
   width: 1rem;
@@ -695,27 +746,8 @@ body {
   font-size: 0.75rem;
 }
 
-.cloud-notebook-list-scope {
-  border: 1px solid color-mix(in srgb, var(--foreground) 14%, transparent);
-  border-radius: 6px;
-  padding: 0.1875rem 0.5rem;
-  color: color-mix(in srgb, var(--foreground) 68%, transparent);
-  background: color-mix(in srgb, var(--background) 92%, var(--foreground) 7%);
-  font-size: 0.75rem;
-  font-weight: 650;
-  line-height: 1.2;
-}
-
-.cloud-notebook-list-scope[data-scope="owner"] {
-  border-color: color-mix(in srgb, #0f766e 38%, transparent);
-  color: #0f766e;
-  background: color-mix(in srgb, #0f766e 7%, var(--background));
-}
-
-.cloud-notebook-list-scope[data-scope="editor"] {
-  border-color: color-mix(in srgb, #2563eb 34%, transparent);
-  color: #2563eb;
-  background: color-mix(in srgb, #2563eb 6%, var(--background));
+.cloud-notebook-list-row-facts [data-state="published"] {
+  color: color-mix(in srgb, #0f766e 84%, var(--foreground));
 }
 
 .cloud-notebook-list-updated {
@@ -767,6 +799,14 @@ body {
     justify-content: flex-start;
   }
 
+  .cloud-new-notebook-form {
+    grid-template-columns: minmax(0, 1fr) auto auto;
+  }
+
+  .cloud-new-notebook-form label {
+    grid-column: 1 / -1;
+  }
+
   .cloud-dashboard-continue,
   .cloud-dashboard-grid {
     grid-template-columns: minmax(0, 1fr);
@@ -781,14 +821,14 @@ body {
   }
 
   .cloud-notebook-list-row {
-    grid-template-columns: 2rem minmax(0, 1fr) auto;
+    grid-template-columns: minmax(0, 1fr) auto;
     min-height: 4.5rem;
-    gap: 0.5rem;
+    gap: 0.5rem 0.75rem;
     padding-block: 0.625rem;
   }
 
   .cloud-notebook-list-updated {
-    grid-column: 2 / -1;
+    grid-column: 1 / -1;
     justify-self: start;
   }
 
@@ -797,7 +837,7 @@ body {
   }
 
   .cloud-notebook-list-open {
-    grid-column: 3;
+    grid-column: 2;
     grid-row: 1;
   }
 }

--- a/apps/notebook-cloud/viewer/index.tsx
+++ b/apps/notebook-cloud/viewer/index.tsx
@@ -117,6 +117,11 @@ import {
   type CloudNotebookDashboardModel,
   type CloudNotebookListItem,
 } from "./notebook-dashboard";
+import {
+  clearCachedCloudNotebookList,
+  readCachedCloudNotebookList,
+  writeCachedCloudNotebookList,
+} from "./notebook-list-cache";
 import type { CloudNotebookAccessRequest } from "./sharing-client";
 import { CloudSharingControls } from "./sharing-controls";
 import { cloudResponseError } from "./cloud-response";
@@ -442,7 +447,9 @@ function CloudNotebookProviders({
 function CloudNotebookListView({ authConfig }: { authConfig: CloudViewerAuthConfig }) {
   const { resolvedTheme } = useTheme(CLOUD_VIEWER_THEME_STORAGE_KEY);
   const { authState, authRenewal, refreshAuthState } = useCloudPrototypeAuth(authConfig);
-  const [listState, setListState] = useState<CloudNotebookListState>({ kind: "loading" });
+  const [listState, setListState] = useState<CloudNotebookListState>(() =>
+    initialCloudNotebookListState(authState),
+  );
   const [refreshIndex, setRefreshIndex] = useState(0);
   const [createState, setCreateState] = useState<"idle" | "starting">("idle");
   const [createError, setCreateError] = useState<string | null>(null);
@@ -463,12 +470,16 @@ function CloudNotebookListView({ authConfig }: { authConfig: CloudViewerAuthConf
 
   useEffect(() => {
     if (!signedIn) {
+      clearCachedCloudNotebookListFromWindow();
       setListState({ kind: "signed_out" });
       return;
     }
 
     const controller = new AbortController();
-    setListState({ kind: "loading" });
+    const cachedNotebooks = readCachedCloudNotebookListFromWindow(authState);
+    setListState(
+      cachedNotebooks ? { kind: "ready", notebooks: cachedNotebooks } : { kind: "loading" },
+    );
     void (async () => {
       try {
         const response = await fetchWithCloudPrototypeAuth(
@@ -484,6 +495,7 @@ function CloudNotebookListView({ authConfig }: { authConfig: CloudViewerAuthConf
         if (!isCloudNotebookListResponse(body)) {
           throw new Error("Unable to list notebooks: response shape was invalid");
         }
+        writeCachedCloudNotebookListToWindow(authState, body.notebooks);
         setListState({ kind: "ready", notebooks: body.notebooks });
       } catch (error) {
         if (controller.signal.aborted) return;
@@ -605,18 +617,20 @@ function CloudNotebookListView({ authConfig }: { authConfig: CloudViewerAuthConf
         if (current.kind !== "ready") {
           return current;
         }
+        const notebooks = current.notebooks.map((notebook) =>
+          notebook.notebook_id === notebookId
+            ? {
+                ...notebook,
+                title: body.title ?? null,
+                updated_at: body.updated_at ?? notebook.updated_at,
+                viewer_url: body.viewer_url ?? notebook.viewer_url,
+              }
+            : notebook,
+        );
+        writeCachedCloudNotebookListToWindow(authState, notebooks);
         return {
           kind: "ready",
-          notebooks: current.notebooks.map((notebook) =>
-            notebook.notebook_id === notebookId
-              ? {
-                  ...notebook,
-                  title: body.title ?? null,
-                  updated_at: body.updated_at ?? notebook.updated_at,
-                  viewer_url: body.viewer_url ?? notebook.viewer_url,
-                }
-              : notebook,
-          ),
+          notebooks,
         };
       });
       setRenameState(null);
@@ -628,6 +642,7 @@ function CloudNotebookListView({ authConfig }: { authConfig: CloudViewerAuthConf
   };
 
   const signOut = () => {
+    clearCachedCloudNotebookListFromWindow();
     clearCloudPrototypeDevAuth(window.localStorage);
     refreshAuthState();
   };
@@ -1014,6 +1029,45 @@ function cloudAuthWithScope(
         ...authState,
         requestedScope,
       };
+}
+
+function initialCloudNotebookListState(authState: CloudPrototypeAuthState): CloudNotebookListState {
+  const cachedNotebooks = readCachedCloudNotebookListFromWindow(authState);
+  return cachedNotebooks ? { kind: "ready", notebooks: cachedNotebooks } : { kind: "loading" };
+}
+
+function readCachedCloudNotebookListFromWindow(
+  authState: CloudPrototypeAuthState,
+): CloudNotebookListItem[] | null {
+  const storage = cloudNotebookListCacheStorage();
+  return storage ? readCachedCloudNotebookList(storage, authState) : null;
+}
+
+function writeCachedCloudNotebookListToWindow(
+  authState: CloudPrototypeAuthState,
+  notebooks: CloudNotebookListItem[],
+): void {
+  const storage = cloudNotebookListCacheStorage();
+  if (!storage) {
+    return;
+  }
+  writeCachedCloudNotebookList(storage, authState, notebooks);
+}
+
+function clearCachedCloudNotebookListFromWindow(): void {
+  const storage = cloudNotebookListCacheStorage();
+  if (!storage) {
+    return;
+  }
+  clearCachedCloudNotebookList(storage);
+}
+
+function cloudNotebookListCacheStorage(): Storage | null {
+  try {
+    return window.sessionStorage;
+  } catch {
+    return null;
+  }
 }
 
 function defaultCloudNotebookTitle(now = new Date()): string {

--- a/apps/notebook-cloud/viewer/index.tsx
+++ b/apps/notebook-cloud/viewer/index.tsx
@@ -21,6 +21,7 @@ import {
   Loader2,
   LogIn,
   LogOut,
+  PencilLine,
   Radio,
   RotateCcw,
   Share2,
@@ -168,11 +169,24 @@ interface CloudNotebookCreateResponse {
   viewer_url?: string;
 }
 
+interface CloudNotebookUpdateResponse {
+  ok: boolean;
+  notebook_id?: string;
+  title?: string | null;
+  updated_at?: string;
+  viewer_url?: string;
+}
+
 type CloudNotebookListState =
   | { kind: "loading" }
   | { kind: "ready"; notebooks: CloudNotebookListItem[] }
   | { kind: "signed_out" }
   | { kind: "error"; message: string };
+
+interface CloudNotebookRenameState {
+  notebookId: string;
+  title: string;
+}
 
 type ViewerRuntimeState =
   | { kind: "ready"; runtime: ViewerRuntime }
@@ -434,6 +448,9 @@ function CloudNotebookListView({ authConfig }: { authConfig: CloudViewerAuthConf
   const [createError, setCreateError] = useState<string | null>(null);
   const [createFormOpen, setCreateFormOpen] = useState(false);
   const [createTitle, setCreateTitle] = useState(() => defaultCloudNotebookTitle());
+  const [renameState, setRenameState] = useState<CloudNotebookRenameState | null>(null);
+  const [renameSavingId, setRenameSavingId] = useState<string | null>(null);
+  const [renameError, setRenameError] = useState<string | null>(null);
   const signedIn = authState.mode === "dev" || authState.mode === "oidc";
   const dashboardModel = useMemo(
     () => (listState.kind === "ready" ? projectCloudNotebookDashboard(listState.notebooks) : null),
@@ -538,6 +555,78 @@ function CloudNotebookListView({ authConfig }: { authConfig: CloudViewerAuthConf
     }
   };
 
+  const openRenameForm = useCallback((notebook: CloudNotebookListItem) => {
+    setRenameError(null);
+    setRenameState({
+      notebookId: notebook.notebook_id,
+      title: notebook.title?.trim() ?? "",
+    });
+  }, []);
+
+  const closeRenameForm = useCallback(() => {
+    if (renameSavingId) {
+      return;
+    }
+    setRenameError(null);
+    setRenameState(null);
+  }, [renameSavingId]);
+
+  const saveNotebookTitle = async (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    if (!signedIn || !renameState || renameSavingId) {
+      return;
+    }
+
+    const notebookId = renameState.notebookId;
+    const nextTitle = renameState.title.trim();
+    try {
+      setRenameError(null);
+      setRenameSavingId(notebookId);
+      const response = await fetchWithCloudPrototypeAuth(
+        cloudNotebookCatalogEndpoint(notebookId),
+        {
+          method: "PATCH",
+          headers: {
+            Accept: "application/json",
+            "Content-Type": "application/json",
+          },
+          body: JSON.stringify({ title: nextTitle || null }),
+        },
+        authState,
+      );
+      if (!response.ok) {
+        throw await cloudResponseError(response, "Unable to rename notebook");
+      }
+      const body = (await response.json()) as CloudNotebookUpdateResponse;
+      if (body.ok !== true || body.notebook_id !== notebookId) {
+        throw new Error("Unable to rename notebook: response shape was invalid");
+      }
+      setListState((current) => {
+        if (current.kind !== "ready") {
+          return current;
+        }
+        return {
+          kind: "ready",
+          notebooks: current.notebooks.map((notebook) =>
+            notebook.notebook_id === notebookId
+              ? {
+                  ...notebook,
+                  title: body.title ?? null,
+                  updated_at: body.updated_at ?? notebook.updated_at,
+                  viewer_url: body.viewer_url ?? notebook.viewer_url,
+                }
+              : notebook,
+          ),
+        };
+      });
+      setRenameState(null);
+    } catch (error) {
+      setRenameError(error instanceof Error ? error.message : String(error));
+    } finally {
+      setRenameSavingId(null);
+    }
+  };
+
   const signOut = () => {
     clearCloudPrototypeDevAuth(window.localStorage);
     refreshAuthState();
@@ -607,6 +696,11 @@ function CloudNotebookListView({ authConfig }: { authConfig: CloudViewerAuthConf
           {createError}
         </div>
       ) : null}
+      {renameError ? (
+        <div className="cloud-notebook-list-banner" data-kind="error" role="alert">
+          {renameError}
+        </div>
+      ) : null}
       {createFormOpen ? (
         <form className="cloud-new-notebook-form" onSubmit={createNotebook}>
           <label htmlFor="cloud-new-notebook-title">Notebook title</label>
@@ -654,7 +748,17 @@ function CloudNotebookListView({ authConfig }: { authConfig: CloudViewerAuthConf
             <span>No notebooks yet.</span>
           </div>
         ) : dashboardModel ? (
-          <CloudNotebookDashboard model={dashboardModel} />
+          <CloudNotebookDashboard
+            model={dashboardModel}
+            renameState={renameState}
+            renameSavingId={renameSavingId}
+            onOpenRename={openRenameForm}
+            onCancelRename={closeRenameForm}
+            onRenameTitleChange={(title) =>
+              setRenameState((current) => (current ? { ...current, title } : current))
+            }
+            onSaveRename={saveNotebookTitle}
+          />
         ) : (
           <div className="cloud-notebook-list-state" data-kind="error" role="alert">
             <AlertCircle aria-hidden="true" />
@@ -666,7 +770,23 @@ function CloudNotebookListView({ authConfig }: { authConfig: CloudViewerAuthConf
   );
 }
 
-function CloudNotebookDashboard({ model }: { model: CloudNotebookDashboardModel }) {
+function CloudNotebookDashboard({
+  model,
+  renameState,
+  renameSavingId,
+  onOpenRename,
+  onCancelRename,
+  onRenameTitleChange,
+  onSaveRename,
+}: {
+  model: CloudNotebookDashboardModel;
+  renameState: CloudNotebookRenameState | null;
+  renameSavingId: string | null;
+  onOpenRename: (notebook: CloudNotebookListItem) => void;
+  onCancelRename: () => void;
+  onRenameTitleChange: (title: string) => void;
+  onSaveRename: (event: FormEvent<HTMLFormElement>) => void;
+}) {
   const continued = model.continueNotebook;
 
   return (
@@ -719,7 +839,17 @@ function CloudNotebookDashboard({ model }: { model: CloudNotebookDashboardModel 
           <ul className="cloud-notebook-list">
             {model.notebooks.map((notebook) => (
               <li key={notebook.notebook_id}>
-                <CloudNotebookDashboardRow notebook={notebook} />
+                <CloudNotebookDashboardRow
+                  notebook={notebook}
+                  renameTitle={
+                    renameState?.notebookId === notebook.notebook_id ? renameState.title : null
+                  }
+                  renameSaving={renameSavingId === notebook.notebook_id}
+                  onOpenRename={onOpenRename}
+                  onCancelRename={onCancelRename}
+                  onRenameTitleChange={onRenameTitleChange}
+                  onSaveRename={onSaveRename}
+                />
               </li>
             ))}
           </ul>
@@ -764,10 +894,58 @@ const cloudNotebookDashboardMetricIcons = {
   published: Zap,
 } satisfies Record<CloudNotebookDashboardMetric["icon"], typeof BookOpen>;
 
-function CloudNotebookDashboardRow({ notebook }: { notebook: CloudNotebookListItem }) {
+function CloudNotebookDashboardRow({
+  notebook,
+  renameTitle,
+  renameSaving,
+  onOpenRename,
+  onCancelRename,
+  onRenameTitleChange,
+  onSaveRename,
+}: {
+  notebook: CloudNotebookListItem;
+  renameTitle: string | null;
+  renameSaving: boolean;
+  onOpenRename: (notebook: CloudNotebookListItem) => void;
+  onCancelRename: () => void;
+  onRenameTitleChange: (title: string) => void;
+  onSaveRename: (event: FormEvent<HTMLFormElement>) => void;
+}) {
+  if (renameTitle !== null) {
+    return (
+      <form className="cloud-notebook-list-rename-form" onSubmit={onSaveRename}>
+        <input
+          aria-label={`Notebook title for ${cloudNotebookShortId(notebook.notebook_id)}`}
+          type="text"
+          value={renameTitle}
+          maxLength={160}
+          placeholder="Untitled notebook"
+          disabled={renameSaving}
+          onChange={(event) => onRenameTitleChange(event.currentTarget.value)}
+        />
+        <button type="submit" disabled={renameSaving} title="Save title" aria-label="Save title">
+          {renameSaving ? (
+            <Loader2 className="cloud-home-status-spinner" aria-hidden="true" />
+          ) : (
+            <Check aria-hidden="true" />
+          )}
+        </button>
+        <button
+          type="button"
+          disabled={renameSaving}
+          title="Cancel rename"
+          aria-label="Cancel rename"
+          onClick={onCancelRename}
+        >
+          <X aria-hidden="true" />
+        </button>
+      </form>
+    );
+  }
+
   return (
-    <a className="cloud-notebook-list-row" href={notebook.viewer_url}>
-      <span className="cloud-notebook-list-main">
+    <div className="cloud-notebook-list-row">
+      <a className="cloud-notebook-list-main" href={notebook.viewer_url}>
         <span className="cloud-notebook-list-title">{cloudNotebookDisplayTitle(notebook)}</span>
         <span className="cloud-notebook-list-id">{cloudNotebookShortId(notebook.notebook_id)}</span>
         <span className="cloud-notebook-list-row-facts">
@@ -784,13 +962,33 @@ function CloudNotebookDashboardRow({ notebook }: { notebook: CloudNotebookListIt
             {notebook.latest_revision_id ? "published revision" : "not published"}
           </span>
         </span>
-      </span>
+      </a>
       <span className="cloud-notebook-list-updated">
         <Clock aria-hidden="true" />
         {formatNotebookUpdatedAt(notebook.updated_at)}
       </span>
-      <ExternalLink className="cloud-notebook-list-open" aria-hidden="true" />
-    </a>
+      <span className="cloud-notebook-list-row-actions">
+        {canRenameCloudNotebook(notebook) ? (
+          <button
+            type="button"
+            className="cloud-notebook-list-icon-button"
+            title="Rename notebook"
+            aria-label={`Rename ${cloudNotebookDisplayTitle(notebook)}`}
+            onClick={() => onOpenRename(notebook)}
+          >
+            <PencilLine aria-hidden="true" />
+          </button>
+        ) : null}
+        <a
+          className="cloud-notebook-list-icon-button"
+          href={notebook.viewer_url}
+          title="Open notebook"
+          aria-label={`Open ${cloudNotebookDisplayTitle(notebook)}`}
+        >
+          <ExternalLink aria-hidden="true" />
+        </a>
+      </span>
+    </div>
   );
 }
 
@@ -800,6 +998,10 @@ function cloudNotebookListEndpoint(): string {
 
 function cloudNotebookCollectionEndpoint(): string {
   return new URL("api/n", `${window.location.origin}/`).href;
+}
+
+function cloudNotebookCatalogEndpoint(notebookId: string): string {
+  return new URL(`api/n/${encodeURIComponent(notebookId)}`, `${window.location.origin}/`).href;
 }
 
 function defaultCloudNotebookTitle(now = new Date()): string {
@@ -821,6 +1023,10 @@ function isCloudNotebookListResponse(value: unknown): value is CloudNotebookList
   }
   const candidate = value as Record<string, unknown>;
   return candidate.ok === true && Array.isArray(candidate.notebooks);
+}
+
+function canRenameCloudNotebook(notebook: CloudNotebookListItem): boolean {
+  return notebook.scope === "owner" || notebook.scope === "editor";
 }
 
 function formatNotebookScope(scope: CloudNotebookListItem["scope"]): string {

--- a/apps/notebook-cloud/viewer/index.tsx
+++ b/apps/notebook-cloud/viewer/index.tsx
@@ -14,13 +14,18 @@ import {
   Check,
   Clock,
   ExternalLink,
+  FilePlus2,
+  Globe2,
   KeyRound,
   Loader2,
   LogIn,
   LogOut,
+  Radio,
   RotateCcw,
+  Share2,
   UserRound,
   X,
+  Zap,
 } from "lucide-react";
 import { IsolatedRendererProvider } from "@/components/isolated/isolated-renderer-context";
 import type { NteractEmbedHostContextPatch } from "@/components/isolated/host-context";
@@ -102,6 +107,14 @@ import type { ResolvedCell } from "./render-resolution";
 import { CloudNotebookNotices, cloudNotebookHasNotices } from "./notices";
 import type { CloudAuthRenewalState, ViewerStatus } from "./notice-types";
 import { rendererAssetBasePathForProvider } from "./renderer-assets";
+import {
+  cloudNotebookDisplayTitle,
+  cloudNotebookShortId,
+  projectCloudNotebookDashboard,
+  type CloudNotebookDashboardMetric,
+  type CloudNotebookDashboardModel,
+  type CloudNotebookListItem,
+} from "./notebook-dashboard";
 import type { CloudNotebookAccessRequest } from "./sharing-client";
 import { CloudSharingControls } from "./sharing-controls";
 import { cloudResponseError } from "./cloud-response";
@@ -143,25 +156,14 @@ interface ViewerRuntime {
   config: CloudViewerConfig;
 }
 
-interface CloudNotebookListItem {
-  notebook_id: string;
-  title: string | null;
-  owner_principal: string;
-  scope: "viewer" | "editor" | "runtime_peer" | "owner";
-  created_at: string;
-  updated_at: string;
-  latest_revision_id: string | null;
-  viewer_url: string;
-  endpoints: {
-    catalog: string;
-    acl: string;
-    access_requests: string;
-  };
-}
-
 interface CloudNotebookListResponse {
   ok: boolean;
   notebooks: CloudNotebookListItem[];
+}
+
+interface CloudNotebookCreateResponse {
+  ok: boolean;
+  viewer_url?: string;
 }
 
 type CloudNotebookListState =
@@ -426,7 +428,13 @@ function CloudNotebookListView({ authConfig }: { authConfig: CloudViewerAuthConf
   const { authState, authRenewal, refreshAuthState } = useCloudPrototypeAuth(authConfig);
   const [listState, setListState] = useState<CloudNotebookListState>({ kind: "loading" });
   const [refreshIndex, setRefreshIndex] = useState(0);
+  const [createState, setCreateState] = useState<"idle" | "starting">("idle");
+  const [createError, setCreateError] = useState<string | null>(null);
   const signedIn = authState.mode === "dev" || authState.mode === "oidc";
+  const dashboardModel = useMemo(
+    () => (listState.kind === "ready" ? projectCloudNotebookDashboard(listState.notebooks) : null),
+    [listState],
+  );
 
   useEffect(() => {
     applyDocumentTheme(resolvedTheme);
@@ -474,6 +482,39 @@ function CloudNotebookListView({ authConfig }: { authConfig: CloudViewerAuthConf
     setRefreshIndex((value) => value + 1);
   };
 
+  const createNotebook = async () => {
+    if (!signedIn || createState === "starting") {
+      return;
+    }
+    try {
+      setCreateError(null);
+      setCreateState("starting");
+      const response = await fetchWithCloudPrototypeAuth(
+        cloudNotebookCollectionEndpoint(),
+        {
+          method: "POST",
+          headers: {
+            Accept: "application/json",
+            "Content-Type": "application/json",
+          },
+          body: JSON.stringify({}),
+        },
+        authState,
+      );
+      if (!response.ok) {
+        throw await cloudResponseError(response, "Unable to create notebook");
+      }
+      const body = (await response.json()) as CloudNotebookCreateResponse;
+      if (body.ok !== true || typeof body.viewer_url !== "string") {
+        throw new Error("Unable to create notebook: response shape was invalid");
+      }
+      window.location.assign(body.viewer_url);
+    } catch (error) {
+      setCreateState("idle");
+      setCreateError(error instanceof Error ? error.message : String(error));
+    }
+  };
+
   const signOut = () => {
     clearCloudPrototypeDevAuth(window.localStorage);
     refreshAuthState();
@@ -493,7 +534,7 @@ function CloudNotebookListView({ authConfig }: { authConfig: CloudViewerAuthConf
           <a className="cloud-notebook-list-brand" href="/">
             nteract
           </a>
-          <h1>Notebooks</h1>
+          <h1>Notebook home</h1>
           <p>{headerDetail}</p>
         </div>
         <div className="cloud-notebook-list-actions">
@@ -504,6 +545,18 @@ function CloudNotebookListView({ authConfig }: { authConfig: CloudViewerAuthConf
           >
             <RotateCcw aria-hidden="true" />
             Refresh
+          </button>
+          <button
+            type="button"
+            disabled={!signedIn || createState === "starting"}
+            onClick={createNotebook}
+          >
+            {createState === "starting" ? (
+              <Loader2 className="cloud-home-status-spinner" aria-hidden="true" />
+            ) : (
+              <FilePlus2 aria-hidden="true" />
+            )}
+            {createState === "starting" ? "Creating" : "New notebook"}
           </button>
           {signedIn ? null : (
             <CloudNotebookSignInButton authConfig={authConfig} authState={authState} />
@@ -524,6 +577,11 @@ function CloudNotebookListView({ authConfig }: { authConfig: CloudViewerAuthConf
           role={authRenewal.kind === "failed" ? "alert" : "status"}
         >
           {authRenewal.message}
+        </div>
+      ) : null}
+      {createError ? (
+        <div className="cloud-notebook-list-banner" data-kind="error" role="alert">
+          {createError}
         </div>
       ) : null}
 
@@ -548,41 +606,155 @@ function CloudNotebookListView({ authConfig }: { authConfig: CloudViewerAuthConf
             <BookOpen aria-hidden="true" />
             <span>No notebooks yet.</span>
           </div>
+        ) : dashboardModel ? (
+          <CloudNotebookDashboard model={dashboardModel} />
         ) : (
-          <ul className="cloud-notebook-list" aria-label="Notebook rooms">
-            {listState.notebooks.map((notebook) => (
-              <li key={notebook.notebook_id}>
-                <a className="cloud-notebook-list-row" href={notebook.viewer_url}>
-                  <span className="cloud-notebook-list-icon" aria-hidden="true">
-                    <BookOpen />
-                  </span>
-                  <span className="cloud-notebook-list-main">
-                    <span className="cloud-notebook-list-title">
-                      {notebook.title?.trim() || notebook.notebook_id}
-                    </span>
-                    <span className="cloud-notebook-list-id">{notebook.notebook_id}</span>
-                  </span>
-                  <span className="cloud-notebook-list-scope" data-scope={notebook.scope}>
-                    {formatNotebookScope(notebook.scope)}
-                  </span>
-                  <span className="cloud-notebook-list-updated">
-                    <Clock aria-hidden="true" />
-                    {formatNotebookUpdatedAt(notebook.updated_at)}
-                  </span>
-                  <ExternalLink className="cloud-notebook-list-open" aria-hidden="true" />
-                </a>
-              </li>
-            ))}
-          </ul>
+          <div className="cloud-notebook-list-state" data-kind="error" role="alert">
+            <AlertCircle aria-hidden="true" />
+            <span>Unable to project notebook dashboard.</span>
+          </div>
         )}
       </section>
     </main>
   );
 }
 
+function CloudNotebookDashboard({ model }: { model: CloudNotebookDashboardModel }) {
+  const continued = model.continueNotebook;
+
+  return (
+    <div className="cloud-dashboard">
+      {continued ? (
+        <section className="cloud-dashboard-continue" aria-labelledby="cloud-dashboard-continue">
+          <div className="cloud-dashboard-continue-main">
+            <p>Continue</p>
+            <h2 id="cloud-dashboard-continue">{cloudNotebookDisplayTitle(continued)}</h2>
+            <span className="cloud-dashboard-continue-id">
+              {cloudNotebookShortId(continued.notebook_id)}
+            </span>
+            <div className="cloud-dashboard-continue-facts">
+              <span>
+                <Clock aria-hidden="true" />
+                {formatNotebookUpdatedAt(continued.updated_at)}
+              </span>
+              <span>
+                <UserRound aria-hidden="true" />
+                {formatNotebookScope(continued.scope)}
+              </span>
+              <span>
+                {continued.latest_revision_id ? (
+                  <Globe2 aria-hidden="true" />
+                ) : (
+                  <Radio aria-hidden="true" />
+                )}
+                {continued.latest_revision_id ? "published revision" : "live room"}
+              </span>
+            </div>
+          </div>
+          <a className="cloud-dashboard-primary-link" href={continued.viewer_url}>
+            Open
+            <ExternalLink aria-hidden="true" />
+          </a>
+        </section>
+      ) : null}
+
+      <section className="cloud-dashboard-summary" aria-label="Notebook summary">
+        {model.metrics.map((metric) => (
+          <CloudNotebookDashboardMetric key={metric.label} metric={metric} />
+        ))}
+      </section>
+
+      <section className="cloud-dashboard-grid">
+        <section aria-label="Notebook rooms">
+          <div className="cloud-dashboard-section-heading">
+            <h2>Notebooks</h2>
+          </div>
+          <ul className="cloud-notebook-list">
+            {model.notebooks.map((notebook) => (
+              <li key={notebook.notebook_id}>
+                <CloudNotebookDashboardRow notebook={notebook} />
+              </li>
+            ))}
+          </ul>
+        </section>
+        <aside className="cloud-dashboard-aside" aria-label="Notebook workspace">
+          <section>
+            <p className="cloud-dashboard-aside-kicker">Compute</p>
+            <h2>Workstations</h2>
+            <p>
+              Workstation status appears inside each notebook room once a compute target is
+              selected.
+            </p>
+          </section>
+          <section>
+            <p className="cloud-dashboard-aside-kicker">Sharing</p>
+            <h2>Public previews</h2>
+            <p>Published notebooks can expose safe metadata and revision-aware preview images.</p>
+          </section>
+        </aside>
+      </section>
+    </div>
+  );
+}
+
+function CloudNotebookDashboardMetric({ metric }: { metric: CloudNotebookDashboardMetric }) {
+  const Icon = cloudNotebookDashboardMetricIcons[metric.icon];
+  return (
+    <div className="cloud-dashboard-summary-item">
+      <span>
+        <Icon aria-hidden="true" />
+        {metric.label}
+      </span>
+      <strong>{metric.value}</strong>
+      <p>{metric.detail}</p>
+    </div>
+  );
+}
+
+const cloudNotebookDashboardMetricIcons = {
+  notebooks: BookOpen,
+  owned: UserRound,
+  published: Zap,
+} satisfies Record<CloudNotebookDashboardMetric["icon"], typeof BookOpen>;
+
+function CloudNotebookDashboardRow({ notebook }: { notebook: CloudNotebookListItem }) {
+  return (
+    <a className="cloud-notebook-list-row" href={notebook.viewer_url}>
+      <span className="cloud-notebook-list-icon" aria-hidden="true">
+        <BookOpen />
+      </span>
+      <span className="cloud-notebook-list-main">
+        <span className="cloud-notebook-list-title">{cloudNotebookDisplayTitle(notebook)}</span>
+        <span className="cloud-notebook-list-id">{cloudNotebookShortId(notebook.notebook_id)}</span>
+        <span className="cloud-notebook-list-row-facts">
+          <span className="cloud-notebook-list-scope" data-scope={notebook.scope}>
+            {formatNotebookScope(notebook.scope)}
+          </span>
+          <span>
+            {notebook.latest_revision_id ? (
+              <Share2 aria-hidden="true" />
+            ) : (
+              <Radio aria-hidden="true" />
+            )}
+            {notebook.latest_revision_id ? "published revision" : "live room"}
+          </span>
+        </span>
+      </span>
+      <span className="cloud-notebook-list-updated">
+        <Clock aria-hidden="true" />
+        {formatNotebookUpdatedAt(notebook.updated_at)}
+      </span>
+      <ExternalLink className="cloud-notebook-list-open" aria-hidden="true" />
+    </a>
+  );
+}
+
 function cloudNotebookListEndpoint(): string {
-  const path = ["api", "n"].join("/");
-  return new URL(`${path}?limit=100`, `${window.location.origin}/`).href;
+  return new URL("api/n?limit=100", `${window.location.origin}/`).href;
+}
+
+function cloudNotebookCollectionEndpoint(): string {
+  return new URL("api/n", `${window.location.origin}/`).href;
 }
 
 function isCloudNotebookListResponse(value: unknown): value is CloudNotebookListResponse {

--- a/apps/notebook-cloud/viewer/index.tsx
+++ b/apps/notebook-cloud/viewer/index.tsx
@@ -539,7 +539,7 @@ function CloudNotebookListView({ authConfig }: { authConfig: CloudViewerAuthConf
           },
           body: JSON.stringify({ title }),
         },
-        authState,
+        cloudAuthWithScope(authState, "owner"),
       );
       if (!response.ok) {
         throw await cloudResponseError(response, "Unable to create notebook");
@@ -592,7 +592,7 @@ function CloudNotebookListView({ authConfig }: { authConfig: CloudViewerAuthConf
           },
           body: JSON.stringify({ title: nextTitle || null }),
         },
-        authState,
+        cloudAuthWithScope(authState, "editor"),
       );
       if (!response.ok) {
         throw await cloudResponseError(response, "Unable to rename notebook");
@@ -1002,6 +1002,18 @@ function cloudNotebookCollectionEndpoint(): string {
 
 function cloudNotebookCatalogEndpoint(notebookId: string): string {
   return new URL(`api/n/${encodeURIComponent(notebookId)}`, `${window.location.origin}/`).href;
+}
+
+function cloudAuthWithScope(
+  authState: CloudPrototypeAuthState,
+  requestedScope: NonNullable<CloudPrototypeAuthState["requestedScope"]>,
+): CloudPrototypeAuthState {
+  return authState.requestedScope === requestedScope
+    ? authState
+    : {
+        ...authState,
+        requestedScope,
+      };
 }
 
 function defaultCloudNotebookTitle(now = new Date()): string {

--- a/apps/notebook-cloud/viewer/index.tsx
+++ b/apps/notebook-cloud/viewer/index.tsx
@@ -5,6 +5,7 @@ import {
   useRef,
   useState,
   useSyncExternalStore,
+  type FormEvent,
   type ReactNode,
 } from "react";
 import { createRoot } from "react-dom/client";
@@ -163,6 +164,7 @@ interface CloudNotebookListResponse {
 
 interface CloudNotebookCreateResponse {
   ok: boolean;
+  title?: string | null;
   viewer_url?: string;
 }
 
@@ -430,6 +432,8 @@ function CloudNotebookListView({ authConfig }: { authConfig: CloudViewerAuthConf
   const [refreshIndex, setRefreshIndex] = useState(0);
   const [createState, setCreateState] = useState<"idle" | "starting">("idle");
   const [createError, setCreateError] = useState<string | null>(null);
+  const [createFormOpen, setCreateFormOpen] = useState(false);
+  const [createTitle, setCreateTitle] = useState(() => defaultCloudNotebookTitle());
   const signedIn = authState.mode === "dev" || authState.mode === "oidc";
   const dashboardModel = useMemo(
     () => (listState.kind === "ready" ? projectCloudNotebookDashboard(listState.notebooks) : null),
@@ -482,10 +486,29 @@ function CloudNotebookListView({ authConfig }: { authConfig: CloudViewerAuthConf
     setRefreshIndex((value) => value + 1);
   };
 
-  const createNotebook = async () => {
+  const openCreateForm = () => {
+    if (!signedIn) {
+      return;
+    }
+    setCreateError(null);
+    setCreateTitle(defaultCloudNotebookTitle());
+    setCreateFormOpen(true);
+  };
+
+  const closeCreateForm = () => {
+    if (createState === "starting") {
+      return;
+    }
+    setCreateError(null);
+    setCreateFormOpen(false);
+  };
+
+  const createNotebook = async (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
     if (!signedIn || createState === "starting") {
       return;
     }
+    const title = createTitle.trim() || defaultCloudNotebookTitle();
     try {
       setCreateError(null);
       setCreateState("starting");
@@ -497,7 +520,7 @@ function CloudNotebookListView({ authConfig }: { authConfig: CloudViewerAuthConf
             Accept: "application/json",
             "Content-Type": "application/json",
           },
-          body: JSON.stringify({}),
+          body: JSON.stringify({ title }),
         },
         authState,
       );
@@ -522,7 +545,7 @@ function CloudNotebookListView({ authConfig }: { authConfig: CloudViewerAuthConf
 
   const headerDetail =
     authState.mode === "oidc" || authState.mode === "dev"
-      ? (authState.user ?? "Signed in")
+      ? "Signed in"
       : authState.mode === "oidc_expired"
         ? "Session expired"
         : "Signed out";
@@ -549,7 +572,7 @@ function CloudNotebookListView({ authConfig }: { authConfig: CloudViewerAuthConf
           <button
             type="button"
             disabled={!signedIn || createState === "starting"}
-            onClick={createNotebook}
+            onClick={openCreateForm}
           >
             {createState === "starting" ? (
               <Loader2 className="cloud-home-status-spinner" aria-hidden="true" />
@@ -583,6 +606,30 @@ function CloudNotebookListView({ authConfig }: { authConfig: CloudViewerAuthConf
         <div className="cloud-notebook-list-banner" data-kind="error" role="alert">
           {createError}
         </div>
+      ) : null}
+      {createFormOpen ? (
+        <form className="cloud-new-notebook-form" onSubmit={createNotebook}>
+          <label htmlFor="cloud-new-notebook-title">Notebook title</label>
+          <input
+            id="cloud-new-notebook-title"
+            type="text"
+            value={createTitle}
+            maxLength={160}
+            disabled={createState === "starting"}
+            onChange={(event) => setCreateTitle(event.currentTarget.value)}
+          />
+          <button type="submit" disabled={createState === "starting"}>
+            {createState === "starting" ? (
+              <Loader2 className="cloud-home-status-spinner" aria-hidden="true" />
+            ) : (
+              <FilePlus2 aria-hidden="true" />
+            )}
+            Create
+          </button>
+          <button type="button" disabled={createState === "starting"} onClick={closeCreateForm}>
+            Cancel
+          </button>
+        </form>
       ) : null}
 
       <section className="cloud-notebook-list-content" aria-label="Notebook list">
@@ -647,7 +694,7 @@ function CloudNotebookDashboard({ model }: { model: CloudNotebookDashboardModel 
                 ) : (
                   <Radio aria-hidden="true" />
                 )}
-                {continued.latest_revision_id ? "published revision" : "live room"}
+                {continued.latest_revision_id ? "published revision" : "not published"}
               </span>
             </div>
           </div>
@@ -720,23 +767,21 @@ const cloudNotebookDashboardMetricIcons = {
 function CloudNotebookDashboardRow({ notebook }: { notebook: CloudNotebookListItem }) {
   return (
     <a className="cloud-notebook-list-row" href={notebook.viewer_url}>
-      <span className="cloud-notebook-list-icon" aria-hidden="true">
-        <BookOpen />
-      </span>
       <span className="cloud-notebook-list-main">
         <span className="cloud-notebook-list-title">{cloudNotebookDisplayTitle(notebook)}</span>
         <span className="cloud-notebook-list-id">{cloudNotebookShortId(notebook.notebook_id)}</span>
         <span className="cloud-notebook-list-row-facts">
-          <span className="cloud-notebook-list-scope" data-scope={notebook.scope}>
+          <span>
+            <UserRound aria-hidden="true" />
             {formatNotebookScope(notebook.scope)}
           </span>
-          <span>
+          <span data-state={notebook.latest_revision_id ? "published" : "unpublished"}>
             {notebook.latest_revision_id ? (
               <Share2 aria-hidden="true" />
             ) : (
               <Radio aria-hidden="true" />
             )}
-            {notebook.latest_revision_id ? "published revision" : "live room"}
+            {notebook.latest_revision_id ? "published revision" : "not published"}
           </span>
         </span>
       </span>
@@ -755,6 +800,19 @@ function cloudNotebookListEndpoint(): string {
 
 function cloudNotebookCollectionEndpoint(): string {
   return new URL("api/n", `${window.location.origin}/`).href;
+}
+
+function defaultCloudNotebookTitle(now = new Date()): string {
+  const date = new Intl.DateTimeFormat(undefined, {
+    month: "short",
+    day: "numeric",
+    year: "numeric",
+  }).format(now);
+  const time = new Intl.DateTimeFormat(undefined, {
+    hour: "numeric",
+    minute: "2-digit",
+  }).format(now);
+  return `Notebook ${date} ${time}`;
 }
 
 function isCloudNotebookListResponse(value: unknown): value is CloudNotebookListResponse {

--- a/apps/notebook-cloud/viewer/notebook-dashboard.ts
+++ b/apps/notebook-cloud/viewer/notebook-dashboard.ts
@@ -1,0 +1,101 @@
+export interface CloudNotebookListItem {
+  notebook_id: string;
+  title: string | null;
+  owner_principal: string;
+  scope: "viewer" | "editor" | "runtime_peer" | "owner";
+  created_at: string;
+  updated_at: string;
+  latest_revision_id: string | null;
+  viewer_url: string;
+  endpoints: {
+    catalog: string;
+    acl: string;
+    access_requests: string;
+  };
+}
+
+export interface CloudNotebookDashboardMetric {
+  label: string;
+  value: string;
+  detail: string;
+  icon: "notebooks" | "owned" | "published";
+}
+
+export interface CloudNotebookDashboardModel {
+  continueNotebook: CloudNotebookListItem | null;
+  metrics: readonly CloudNotebookDashboardMetric[];
+  notebooks: readonly CloudNotebookListItem[];
+}
+
+export function projectCloudNotebookDashboard(
+  notebooks: readonly CloudNotebookListItem[],
+): CloudNotebookDashboardModel {
+  const sorted = [...notebooks].sort((left, right) => {
+    const leftTime = Date.parse(left.updated_at);
+    const rightTime = Date.parse(right.updated_at);
+    const timeOrder =
+      (Number.isNaN(rightTime) ? 0 : rightTime) - (Number.isNaN(leftTime) ? 0 : leftTime);
+    return (
+      timeOrder ||
+      notebookScopeRank(right.scope) - notebookScopeRank(left.scope) ||
+      left.notebook_id.localeCompare(right.notebook_id)
+    );
+  });
+  const editableCount = notebooks.filter(
+    (notebook) => notebook.scope === "owner" || notebook.scope === "editor",
+  ).length;
+  const ownerCount = notebooks.filter((notebook) => notebook.scope === "owner").length;
+  const publishedCount = notebooks.filter((notebook) =>
+    Boolean(notebook.latest_revision_id),
+  ).length;
+
+  return {
+    continueNotebook: sorted[0] ?? null,
+    notebooks: sorted,
+    metrics: [
+      {
+        label: "Visible notebooks",
+        value: String(notebooks.length),
+        detail: `${editableCount} editable`,
+        icon: "notebooks",
+      },
+      {
+        label: "Owned",
+        value: String(ownerCount),
+        detail: "can manage access",
+        icon: "owned",
+      },
+      {
+        label: "Published",
+        value: String(publishedCount),
+        detail: "revision metadata",
+        icon: "published",
+      },
+    ],
+  };
+}
+
+export function cloudNotebookDisplayTitle(notebook: CloudNotebookListItem): string {
+  return notebook.title?.trim() || "Untitled notebook";
+}
+
+export function cloudNotebookShortId(notebookId: string): string {
+  const trimmed = notebookId.trim();
+  if (trimmed.length <= 12) {
+    return trimmed;
+  }
+  return `${trimmed.slice(0, 8)}...${trimmed.slice(-4)}`;
+}
+
+function notebookScopeRank(scope: CloudNotebookListItem["scope"]): number {
+  switch (scope) {
+    case "owner":
+      return 4;
+    case "editor":
+      return 3;
+    case "runtime_peer":
+      return 2;
+    case "viewer":
+      return 1;
+  }
+}

--- a/apps/notebook-cloud/viewer/notebook-list-cache.ts
+++ b/apps/notebook-cloud/viewer/notebook-list-cache.ts
@@ -1,0 +1,115 @@
+import type { CloudPrototypeAuthState } from "./collaborator-auth";
+import type { CloudNotebookListItem } from "./notebook-dashboard";
+
+export const CLOUD_NOTEBOOK_LIST_CACHE_STORAGE_KEY =
+  "nteract:notebook-cloud:notebook-list-cache:v1";
+export const CLOUD_NOTEBOOK_LIST_CACHE_TTL_MS = 10 * 60 * 1000;
+
+export interface CloudNotebookListCacheStorage {
+  getItem(key: string): string | null;
+  removeItem(key: string): void;
+  setItem(key: string, value: string): void;
+}
+
+interface CachedCloudNotebookList {
+  authKey: string;
+  notebooks: CloudNotebookListItem[];
+  savedAt: number;
+}
+
+export function readCachedCloudNotebookList(
+  storage: Pick<CloudNotebookListCacheStorage, "getItem">,
+  authState: CloudPrototypeAuthState,
+  now = Date.now(),
+): CloudNotebookListItem[] | null {
+  const authKey = cloudNotebookListCacheAuthKey(authState);
+  if (!authKey) {
+    return null;
+  }
+
+  const raw = storage.getItem(CLOUD_NOTEBOOK_LIST_CACHE_STORAGE_KEY);
+  if (!raw) {
+    return null;
+  }
+
+  let parsed: Partial<CachedCloudNotebookList>;
+  try {
+    parsed = JSON.parse(raw) as Partial<CachedCloudNotebookList>;
+  } catch {
+    return null;
+  }
+
+  if (
+    parsed.authKey !== authKey ||
+    !Number.isFinite(parsed.savedAt) ||
+    now - Number(parsed.savedAt) > CLOUD_NOTEBOOK_LIST_CACHE_TTL_MS ||
+    !Array.isArray(parsed.notebooks) ||
+    !parsed.notebooks.every(isCachedCloudNotebookListItem)
+  ) {
+    return null;
+  }
+
+  return parsed.notebooks;
+}
+
+export function writeCachedCloudNotebookList(
+  storage: Pick<CloudNotebookListCacheStorage, "setItem">,
+  authState: CloudPrototypeAuthState,
+  notebooks: CloudNotebookListItem[],
+  now = Date.now(),
+): void {
+  const authKey = cloudNotebookListCacheAuthKey(authState);
+  if (!authKey) {
+    return;
+  }
+
+  storage.setItem(
+    CLOUD_NOTEBOOK_LIST_CACHE_STORAGE_KEY,
+    JSON.stringify({
+      authKey,
+      notebooks,
+      savedAt: now,
+    } satisfies CachedCloudNotebookList),
+  );
+}
+
+export function clearCachedCloudNotebookList(
+  storage: Pick<CloudNotebookListCacheStorage, "removeItem">,
+): void {
+  storage.removeItem(CLOUD_NOTEBOOK_LIST_CACHE_STORAGE_KEY);
+}
+
+export function cloudNotebookListCacheAuthKey(authState: CloudPrototypeAuthState): string | null {
+  if (authState.mode === "oidc" && authState.oidcClaims?.sub) {
+    return `oidc:${authState.oidcClaims.sub}`;
+  }
+  if (authState.mode === "dev" && authState.user) {
+    return `dev:${authState.user}`;
+  }
+  return null;
+}
+
+function isCachedCloudNotebookListItem(value: unknown): value is CloudNotebookListItem {
+  if (!value || typeof value !== "object") {
+    return false;
+  }
+  const candidate = value as Partial<CloudNotebookListItem>;
+  return (
+    typeof candidate.notebook_id === "string" &&
+    (candidate.title === null || typeof candidate.title === "string") &&
+    typeof candidate.owner_principal === "string" &&
+    isNotebookScope(candidate.scope) &&
+    typeof candidate.created_at === "string" &&
+    typeof candidate.updated_at === "string" &&
+    (candidate.latest_revision_id === null || typeof candidate.latest_revision_id === "string") &&
+    typeof candidate.viewer_url === "string" &&
+    Boolean(candidate.endpoints) &&
+    typeof candidate.endpoints?.catalog === "string" &&
+    typeof candidate.endpoints?.acl === "string" &&
+    typeof candidate.endpoints?.access_requests === "string"
+  );
+}
+
+function isNotebookScope(value: unknown): value is CloudNotebookListItem["scope"] {
+  return value === "viewer" || value === "editor" || value === "runtime_peer" || value === "owner";
+}


### PR DESCRIPTION
## Summary

- Reworks `/n` into a notebook home with continuation, summary counts, notebook rows, and create/open actions.
- Adds a pure dashboard projection helper with focused tests for recency, counts, and untitled notebook fallback.
- Retains the last successful `/n` catalog in top-level `sessionStorage`, keyed by the browser auth identity with a short TTL, so revisits render immediately while `/api/n` refreshes.
- Adds title-aware notebook creation for the cloud home and hosted publish fallback, while keeping untitled notebooks valid.
- Adds catalog title rename from `/n` for editor/owner notebooks, with the app-shell mutation requesting the required scope instead of inheriting the notebook viewer scope.
- Adds private-safe notebook share metadata: generic server HTML by default, public/published title and revision OG metadata only after an explicit public viewer ACL is present.
- Adds an Elements catalog surface for reviewing the hosted dashboard direction and updates the frontend skill with hosted product-surface guidance.

## Preview

- Refreshed `https://preview.runt.run/n` from this branch.
- Main Worker version: `259b6c21-955c-48b1-a0ec-83d2a0f89d15`
- Renderer assets Worker version: `4da254ba-5cab-468d-aae4-38d423d2a386`
- Live smoke: `/n` rendered `Notebook home`, found notebook chrome, and produced no Playwright console/page errors.
- Retained-state smoke: `/n` wrote 88 catalog rows into top-level `sessionStorage`; a reload with `/api/n?limit=100` delayed by three seconds still rendered cached notebook rows in 260ms, including `/lets-edit`.
- Mutation smoke: created a temporary titled notebook while localStorage requested `editor`, renamed it from `/n`, verified the updated title appeared, then removed the temporary smoke notebook from the preview catalog.
- Viewport smoke: 1920, 1440, 820, and 390px all had no horizontal overflow, no email text in page content, no smoke notebook after cleanup, and no stale `live room` text.
- Canary smoke: `https://preview.runt.run/n/01KSQKEPFJVHV4T4ZDYS9V7T80/lets-edit` loaded with notebook chrome and zero Playwright console/page errors.
- Metadata smoke: `topic-viz` and `lets-edit` now emit public notebook title/revision `<title>`, description, OG title/description, `og:type`, and Twitter card metadata from catalog-safe public facts.

Screenshots after cleanup:

- Wide desktop: https://img.runt.run/2026/06/07/c3285ce2a035.png
- Desktop: https://img.runt.run/2026/06/07/7c3a219f3da2.png
- Tablet: https://img.runt.run/2026/06/07/8bb5ddb6195c.png
- Mobile: https://img.runt.run/2026/06/07/7ab916a81a87.png

## Validation

- `cargo xtask lint --fix`
- `pnpm --dir apps/notebook-cloud typecheck`
- `pnpm --dir apps/notebook-cloud exec node --import tsx --test test/worker-routes.test.ts`
- `pnpm --dir apps/notebook-cloud exec node --import tsx --test test/notebook-list-cache.test.ts test/notebook-dashboard.test.ts test/viewer-render-props.test.ts`
- `pnpm --dir apps/elements build`
- `curl -fsS https://preview.runt.run/api/health`
- `curl -fsS https://preview.runt.run/n/topic-viz/topic-viz` metadata inspection
- `curl -fsS https://preview.runt.run/n/01KSQKEPFJVHV4T4ZDYS9V7T80/lets-edit` metadata inspection
- Live Playwright smoke against `https://preview.runt.run/n` at 1920, 1440, 820, and 390px
- Live Playwright smoke against `https://preview.runt.run/n` with delayed `/api/n?limit=100` to verify retained catalog paint
- Live Playwright smoke against `https://preview.runt.run/n/01KSQKEPFJVHV4T4ZDYS9V7T80/lets-edit`
- GitHub CI is green for head `447672e1`.

## Preview Catalog Cleanup

- Set `topic-viz` title to `Topic Visualization` without changing `updated_at`.
- Set `01KSQKEPFJVHV4T4ZDYS9V7T80` (`/lets-edit`) title to `Let's Edit` without changing `updated_at`.
- Removed the temporary title-rename smoke notebook after verifying it had no revisions.

## Notes

- Rebased onto `origin/main` at `f97e45bf`.
- The auth display intentionally stays generic on `/n` so screenshots and public review artifacts do not expose account identifiers.
- The retained catalog is app-shell state on the top-level preview origin only; it is not a room credential, does not change WebSocket auth, and remains unavailable to isolated output frames on the separate output origin.
- Untitled notebooks remain valid; the current preview catalog still has many recent untitled scratch notebooks, which should be cleaned up with explicit keep/delete rules rather than inferred from this PR.
- Cookie/session bootstrap is intentionally left for a follow-up ADR/PR: app-shell cookies need a signed short-lived server session and must not become ambient credentials for room WebSockets or output frames.