### PR TITLE
refactor(markdown): share document surface primitives

### DIFF
--- a/apps/notebook/e2e/markdown-parity.spec.ts
+++ b/apps/notebook/e2e/markdown-parity.spec.ts
@@ -63,7 +63,10 @@ test.describe("markdown parity", () => {
     expect(copyText.clipboard).toContain("Selectable paragraph");
 
     await page.getByLabel("Outline").click();
-    await page.getByRole("link", { name: "Deep parity section" }).click();
+    await page
+      .getByTestId("notebook-outline-panel")
+      .getByRole("link", { name: "Deep parity section", exact: true })
+      .click();
 
     const deepHeading = renderedMarkdown.getByRole("heading", { name: "Deep parity section" });
     await expect

--- a/apps/notebook/e2e/notebook-rail-outline.spec.ts
+++ b/apps/notebook/e2e/notebook-rail-outline.spec.ts
@@ -34,7 +34,11 @@ test.describe("notebook rail outline", () => {
     await expect(page.getByTestId("notebook-rail")).toHaveAttribute("data-collapsed", "true");
     await page.getByLabel("Outline").click();
 
-    const validateHeading = page.getByRole("link", { name: "Validate ranges" });
+    const outlinePanel = page.getByTestId("notebook-outline-panel");
+    const validateHeading = outlinePanel.getByRole("link", {
+      name: "Validate ranges",
+      exact: true,
+    });
     await expect(validateHeading).toBeVisible();
     await expect(page.locator('li[data-outline-level="2"] li[data-outline-level="3"]')).toHaveCount(
       1,
@@ -75,7 +79,10 @@ test.describe("notebook rail outline", () => {
     const beforeClickY = (await childHeading.boundingBox())?.y ?? Infinity;
 
     await page.getByLabel("Outline").click();
-    await page.getByRole("link", { name: "Deep child" }).click();
+    await page
+      .getByTestId("notebook-outline-panel")
+      .getByRole("link", { name: "Deep child", exact: true })
+      .click();
 
     await expect
       .poll(async () => page.evaluate(() => window.location.hash))

--- a/src/components/markdown/MarkdownCodeBlock.tsx
+++ b/src/components/markdown/MarkdownCodeBlock.tsx
@@ -1,0 +1,87 @@
+import { Check, Copy } from "lucide-react";
+import { useState } from "react";
+import { StaticCodeBlock, type ColorTheme } from "@/components/editor/static-highlight";
+import {
+  markdownCodeBlockCopyButtonClassName,
+  markdownCodeBlockLabelClassName,
+  markdownCodeBlockPreStyle,
+  markdownCodeBlockShellClassName,
+  markdownCodeBlockToolbarClassName,
+} from "./markdown-typography";
+
+interface MarkdownCodeBlockProps {
+  code: string;
+  language?: string;
+  colorTheme: ColorTheme;
+  isDark?: boolean;
+  enableCopy?: boolean;
+  preClassName?: string;
+  copyResetMs?: number;
+  copyErrorMessage?: string;
+}
+
+export function MarkdownCodeBlock({
+  code,
+  language,
+  colorTheme,
+  isDark = false,
+  enableCopy = true,
+  preClassName,
+  copyResetMs = 2000,
+  copyErrorMessage = "Failed to copy markdown code block:",
+}: MarkdownCodeBlockProps) {
+  const [copied, setCopied] = useState(false);
+  const languageLabel = markdownCodeBlockLanguageLabel(language);
+
+  const copyCode = async () => {
+    try {
+      await navigator.clipboard.writeText(code);
+      setCopied(true);
+      setTimeout(() => setCopied(false), copyResetMs);
+    } catch (error) {
+      console.error(copyErrorMessage, error);
+    }
+  };
+
+  return (
+    <div
+      data-slot="markdown-code-block"
+      className={markdownCodeBlockShellClassName}
+      data-code-language={languageLabel === "code" ? undefined : languageLabel}
+    >
+      <div className={markdownCodeBlockToolbarClassName}>
+        <span
+          className={markdownCodeBlockLabelClassName}
+          title={languageLabel === "code" ? "Code block" : `${languageLabel} code block`}
+        >
+          {languageLabel}
+        </span>
+        {enableCopy && (
+          <button
+            type="button"
+            aria-label={copied ? "Copied code" : "Copy code"}
+            className={markdownCodeBlockCopyButtonClassName}
+            title={copied ? "Copied" : "Copy code"}
+            onClick={copyCode}
+          >
+            {copied ? <Check className="size-3" /> : <Copy className="size-3" />}
+          </button>
+        )}
+      </div>
+      <StaticCodeBlock
+        code={code}
+        colorTheme={colorTheme}
+        isDark={isDark}
+        language={language}
+        className={preClassName}
+        style={markdownCodeBlockPreStyle}
+      />
+    </div>
+  );
+}
+
+export function markdownCodeBlockLanguageLabel(language: string | undefined): string {
+  const trimmed = language?.trim();
+  if (!trimmed) return "code";
+  return trimmed;
+}

--- a/src/components/markdown/MarkdownFigure.tsx
+++ b/src/components/markdown/MarkdownFigure.tsx
@@ -1,0 +1,22 @@
+import type { ComponentPropsWithoutRef } from "react";
+import { cn } from "@/lib/utils";
+import {
+  markdownFigureCaptionClassName,
+  markdownFigureClassName,
+  markdownImageClassName,
+} from "./markdown-typography";
+
+export function MarkdownFigure({ className, ...props }: ComponentPropsWithoutRef<"figure">) {
+  return <figure className={cn(markdownFigureClassName, className)} {...props} />;
+}
+
+export function MarkdownImage({ className, ...props }: ComponentPropsWithoutRef<"img">) {
+  return <img className={cn(markdownImageClassName, className)} {...props} />;
+}
+
+export function MarkdownFigureCaption({
+  className,
+  ...props
+}: ComponentPropsWithoutRef<"figcaption">) {
+  return <figcaption className={cn(markdownFigureCaptionClassName, className)} {...props} />;
+}

--- a/src/components/markdown/MarkdownHeading.tsx
+++ b/src/components/markdown/MarkdownHeading.tsx
@@ -1,0 +1,41 @@
+import type { HTMLAttributes, ReactNode } from "react";
+import { cn } from "@/lib/utils";
+import { markdownHeadingAnchorClassName, markdownHeadingClassName } from "./markdown-typography";
+
+export type MarkdownHeadingElement = "h1" | "h2" | "h3" | "h4" | "h5" | "h6";
+
+interface MarkdownHeadingProps extends HTMLAttributes<HTMLHeadingElement> {
+  anchorHref?: string;
+  anchorLabel?: string;
+  children: ReactNode;
+  element: MarkdownHeadingElement;
+}
+
+export function MarkdownHeading({
+  anchorHref,
+  anchorLabel,
+  children,
+  className,
+  element: Heading,
+  ...props
+}: MarkdownHeadingProps) {
+  return (
+    <Heading className={cn(markdownHeadingClassName(Heading), className)} {...props}>
+      {children}
+      {anchorHref && anchorLabel ? (
+        <a aria-label={anchorLabel} className={markdownHeadingAnchorClassName} href={anchorHref}>
+          #
+        </a>
+      ) : null}
+    </Heading>
+  );
+}
+
+export function markdownHeadingElement(element: string): MarkdownHeadingElement {
+  if (element === "h1") return "h1";
+  if (element === "h2") return "h2";
+  if (element === "h3") return "h3";
+  if (element === "h4") return "h4";
+  if (element === "h5") return "h5";
+  return "h6";
+}

--- a/src/components/markdown/MarkdownTable.tsx
+++ b/src/components/markdown/MarkdownTable.tsx
@@ -1,0 +1,50 @@
+import type { ComponentPropsWithoutRef } from "react";
+import { cn } from "@/lib/utils";
+import {
+  markdownTableCellClassName,
+  markdownTableClassName,
+  markdownTableHeadClassName,
+  markdownTableHeaderCellClassName,
+  markdownTableRowClassName,
+  markdownTableWrapperClassName,
+} from "./markdown-typography";
+
+export function MarkdownTableFrame({
+  children,
+  className,
+  ...props
+}: ComponentPropsWithoutRef<"div">) {
+  return (
+    <div className={cn(markdownTableWrapperClassName, className)} {...props}>
+      {children}
+    </div>
+  );
+}
+
+export function MarkdownTableElement({ className, ...props }: ComponentPropsWithoutRef<"table">) {
+  return <table className={cn(markdownTableClassName, className)} {...props} />;
+}
+
+export function MarkdownTableHead({ className, ...props }: ComponentPropsWithoutRef<"thead">) {
+  return <thead className={cn(markdownTableHeadClassName, className)} {...props} />;
+}
+
+export function MarkdownTableBody({ className, ...props }: ComponentPropsWithoutRef<"tbody">) {
+  return <tbody className={className} {...props} />;
+}
+
+export function MarkdownTableHeaderRow(props: ComponentPropsWithoutRef<"tr">) {
+  return <tr {...props} />;
+}
+
+export function MarkdownTableRow({ className, ...props }: ComponentPropsWithoutRef<"tr">) {
+  return <tr className={cn(markdownTableRowClassName, className)} {...props} />;
+}
+
+export function MarkdownTableHeaderCell({ className, ...props }: ComponentPropsWithoutRef<"th">) {
+  return <th className={cn(markdownTableHeaderCellClassName, className)} {...props} />;
+}
+
+export function MarkdownTableCell({ className, ...props }: ComponentPropsWithoutRef<"td">) {
+  return <td className={cn(markdownTableCellClassName, className)} {...props} />;
+}

--- a/src/components/markdown/MarkdownTask.tsx
+++ b/src/components/markdown/MarkdownTask.tsx
@@ -1,0 +1,101 @@
+import { Check } from "lucide-react";
+import type { ComponentPropsWithoutRef, ReactNode } from "react";
+import { cn } from "@/lib/utils";
+import {
+  markdownTaskCheckboxClassName,
+  markdownTaskCheckboxGlyphClassName,
+  markdownTaskContentClassName,
+} from "./markdown-typography";
+
+type MarkdownTaskCheckboxInputProps = Omit<
+  ComponentPropsWithoutRef<"input">,
+  "checked" | "className" | "onChange" | "readOnly" | "tabIndex" | "type"
+>;
+
+interface MarkdownTaskCheckboxProps {
+  checked: boolean;
+  className?: string;
+  glyphClassName?: string;
+  inputClassName?: string;
+  inputProps?: MarkdownTaskCheckboxInputProps;
+  label?: string;
+  onToggle?: () => void;
+  slot?: string;
+}
+
+export function MarkdownTaskCheckbox({
+  checked,
+  className,
+  glyphClassName,
+  inputClassName,
+  inputProps,
+  label,
+  onToggle,
+  slot = "markdown-task-checkbox",
+}: MarkdownTaskCheckboxProps) {
+  const interactive = Boolean(onToggle);
+  const actionLabel = interactive
+    ? checked
+      ? "Mark task incomplete"
+      : "Mark task complete"
+    : checked
+      ? "Completed task"
+      : "Incomplete task";
+  const ariaLabel = label ? `${actionLabel}: ${label}` : inputProps?.["aria-label"];
+  const Wrapper = interactive ? "label" : "span";
+
+  return (
+    <Wrapper
+      className={cn(markdownTaskCheckboxClassName, interactive && "cursor-pointer", className)}
+      data-slot={slot}
+      data-state={checked ? "checked" : "unchecked"}
+    >
+      <input
+        {...inputProps}
+        type="checkbox"
+        checked={checked}
+        disabled={!interactive}
+        readOnly={!interactive}
+        tabIndex={interactive ? 0 : -1}
+        aria-label={ariaLabel}
+        className={cn("peer sr-only", inputClassName)}
+        onChange={interactive ? onToggle : undefined}
+      />
+      <span
+        aria-hidden="true"
+        className={cn(
+          markdownTaskCheckboxGlyphClassName,
+          checked
+            ? "border-primary bg-primary text-primary-foreground"
+            : "border-border bg-background",
+          interactive && "group-hover/task:border-primary/70",
+          glyphClassName,
+        )}
+      >
+        {checked ? <Check className="size-2.5 stroke-[3]" /> : null}
+      </span>
+    </Wrapper>
+  );
+}
+
+export function MarkdownTaskContent({
+  checked,
+  children,
+  className,
+}: {
+  checked: boolean | undefined;
+  children: ReactNode;
+  className?: string;
+}) {
+  return (
+    <span
+      className={cn(
+        markdownTaskContentClassName,
+        checked === true && "text-muted-foreground",
+        className,
+      )}
+    >
+      {children}
+    </span>
+  );
+}

--- a/src/components/markdown/MarkdownText.tsx
+++ b/src/components/markdown/MarkdownText.tsx
@@ -1,0 +1,32 @@
+import type { ComponentPropsWithoutRef } from "react";
+import { cn } from "@/lib/utils";
+import {
+  markdownBlockquoteClassName,
+  markdownDeleteClassName,
+  markdownEmphasisClassName,
+  markdownInlineCodeClassName,
+  markdownStrongClassName,
+} from "./markdown-typography";
+
+export function MarkdownBlockquote({
+  className,
+  ...props
+}: ComponentPropsWithoutRef<"blockquote">) {
+  return <blockquote className={cn(markdownBlockquoteClassName, className)} {...props} />;
+}
+
+export function MarkdownInlineCode({ className, ...props }: ComponentPropsWithoutRef<"code">) {
+  return <code className={cn(markdownInlineCodeClassName, className)} {...props} />;
+}
+
+export function MarkdownStrong({ className, ...props }: ComponentPropsWithoutRef<"strong">) {
+  return <strong className={cn(markdownStrongClassName, className)} {...props} />;
+}
+
+export function MarkdownEmphasis({ className, ...props }: ComponentPropsWithoutRef<"em">) {
+  return <em className={cn(markdownEmphasisClassName, className)} {...props} />;
+}
+
+export function MarkdownDelete({ className, ...props }: ComponentPropsWithoutRef<"del">) {
+  return <del className={cn(markdownDeleteClassName, className)} {...props} />;
+}

--- a/src/components/markdown/ProjectedMarkdownView.tsx
+++ b/src/components/markdown/ProjectedMarkdownView.tsx
@@ -11,6 +11,7 @@ import { katexStrict } from "@/lib/katex-options";
 import { cn } from "@/lib/utils";
 import type { MarkdownHeadingAnchor } from "@/components/outputs/markdown-heading-anchors";
 import { MarkdownCodeBlock } from "./MarkdownCodeBlock";
+import { MarkdownFigure, MarkdownFigureCaption, MarkdownImage } from "./MarkdownFigure";
 import {
   MarkdownTableBody,
   MarkdownTableCell,
@@ -28,11 +29,8 @@ import {
   markdownDisplayMathClassName,
   markdownDocumentClassName,
   markdownEmphasisClassName,
-  markdownFigureCaptionClassName,
-  markdownFigureClassName,
   markdownHeadingAnchorClassName,
   markdownHeadingClassName,
-  markdownImageClassName,
   markdownInlineCodeClassName,
   markdownInlineMathClassName,
   markdownLinkClassName,
@@ -764,9 +762,9 @@ function ProjectedFigure({
   const image = <ProjectedImage run={run} />;
   const title = run.imageTitle?.trim();
   return (
-    <figure
+    <MarkdownFigure
       data-source-active={active ? "true" : undefined}
-      className={cn(markdownFigureClassName, active && sourceActiveBlockClass)}
+      className={cn(active && sourceActiveBlockClass)}
     >
       {activeInlineId === run.inlineId ? (
         <span data-source-active-run="true" className={sourceActiveRunClass}>
@@ -775,8 +773,8 @@ function ProjectedFigure({
       ) : (
         image
       )}
-      {title ? <figcaption className={markdownFigureCaptionClassName}>{title}</figcaption> : null}
-    </figure>
+      {title ? <MarkdownFigureCaption>{title}</MarkdownFigureCaption> : null}
+    </MarkdownFigure>
   );
 }
 
@@ -787,15 +785,7 @@ function ProjectedImage({ run }: { run: MarkdownProjectionRun }) {
     return alt ? <span>{alt}</span> : null;
   }
 
-  return (
-    <img
-      src={src}
-      alt={alt}
-      title={run.imageTitle}
-      className={markdownImageClassName}
-      loading="lazy"
-    />
-  );
+  return <MarkdownImage src={src} alt={alt} title={run.imageTitle} loading="lazy" />;
 }
 
 function safeImageSrc(src: string | undefined): string | null {

--- a/src/components/markdown/ProjectedMarkdownView.tsx
+++ b/src/components/markdown/ProjectedMarkdownView.tsx
@@ -13,6 +13,16 @@ import { cn } from "@/lib/utils";
 import type { MarkdownHeadingAnchor } from "@/components/outputs/markdown-heading-anchors";
 import { MarkdownCodeBlock } from "./MarkdownCodeBlock";
 import {
+  MarkdownTableBody,
+  MarkdownTableCell,
+  MarkdownTableElement,
+  MarkdownTableFrame,
+  MarkdownTableHead,
+  MarkdownTableHeaderCell,
+  MarkdownTableHeaderRow,
+  MarkdownTableRow,
+} from "./MarkdownTable";
+import {
   markdownBlockquoteClassName,
   markdownDeleteClassName,
   markdownDisplayMathClassName,
@@ -34,12 +44,6 @@ import {
   markdownTaskContentClassName,
   markdownTaskListClassName,
   markdownTaskListItemClassName,
-  markdownTableCellClassName,
-  markdownTableClassName,
-  markdownTableHeadClassName,
-  markdownTableHeaderCellClassName,
-  markdownTableRowClassName,
-  markdownTableWrapperClassName,
   markdownThematicBreakClassName,
 } from "./markdown-typography";
 
@@ -600,44 +604,42 @@ function ProjectedTable({
   const columnAlign = tableColumnAlignments(rows);
 
   return (
-    <div
+    <MarkdownTableFrame
       data-slot="projected-markdown-table"
       data-source-active={activeBlock ? "true" : undefined}
-      className={cn(markdownTableWrapperClassName, activeBlock && sourceActiveBlockClass)}
+      className={cn(activeBlock && sourceActiveBlockClass)}
     >
-      <table className={markdownTableClassName}>
+      <MarkdownTableElement>
         {hasHeader ? (
-          <thead className={markdownTableHeadClassName}>
-            <tr>
+          <MarkdownTableHead>
+            <MarkdownTableHeaderRow>
               {headerRow.cells.map((cell) => (
-                <th
+                <MarkdownTableHeaderCell
                   key={cell.key}
-                  className={markdownTableHeaderCellClassName}
                   style={tableCellStyle(columnAlign.get(cell.cellIndex))}
                 >
                   {renderRuns(cell.runs, onLinkClick, activeInlineId)}
-                </th>
+                </MarkdownTableHeaderCell>
               ))}
-            </tr>
-          </thead>
+            </MarkdownTableHeaderRow>
+          </MarkdownTableHead>
         ) : null}
-        <tbody>
+        <MarkdownTableBody>
           {(hasHeader ? bodyRows : rows).map((row) => (
-            <tr key={row.key} className={markdownTableRowClassName}>
+            <MarkdownTableRow key={row.key}>
               {row.cells.map((cell) => (
-                <td
+                <MarkdownTableCell
                   key={cell.key}
-                  className={markdownTableCellClassName}
                   style={tableCellStyle(columnAlign.get(cell.cellIndex))}
                 >
                   {renderRuns(cell.runs, onLinkClick, activeInlineId)}
-                </td>
+                </MarkdownTableCell>
               ))}
-            </tr>
+            </MarkdownTableRow>
           ))}
-        </tbody>
-      </table>
-    </div>
+        </MarkdownTableBody>
+      </MarkdownTableElement>
+    </MarkdownTableFrame>
   );
 }
 

--- a/src/components/markdown/ProjectedMarkdownView.tsx
+++ b/src/components/markdown/ProjectedMarkdownView.tsx
@@ -24,19 +24,21 @@ import {
 } from "./MarkdownTable";
 import { MarkdownTaskCheckbox, MarkdownTaskContent } from "./MarkdownTask";
 import {
-  markdownBlockquoteClassName,
-  markdownDeleteClassName,
+  MarkdownBlockquote,
+  MarkdownDelete,
+  MarkdownEmphasis,
+  MarkdownInlineCode,
+  MarkdownStrong,
+} from "./MarkdownText";
+import {
   markdownDisplayMathClassName,
   markdownDocumentClassName,
-  markdownEmphasisClassName,
   markdownHeadingAnchorClassName,
   markdownHeadingClassName,
-  markdownInlineCodeClassName,
   markdownInlineMathClassName,
   markdownLinkClassName,
   markdownListMarkerClassName,
   markdownParagraphClassName,
-  markdownStrongClassName,
   markdownTaskListClassName,
   markdownTaskListItemClassName,
   markdownThematicBreakClassName,
@@ -199,15 +201,12 @@ function ProjectedMarkdownBlock({
 
   if (block.kind === "blockquote") {
     return (
-      <blockquote
+      <MarkdownBlockquote
         data-source-active={activeBlockId === block.blockId ? "true" : undefined}
-        className={cn(
-          markdownBlockquoteClassName,
-          activeBlockId === block.blockId && sourceActiveBlockClass,
-        )}
+        className={cn(activeBlockId === block.blockId && sourceActiveBlockClass)}
       >
         {renderRuns(runs, onLinkClick, activeInlineId)}
-      </blockquote>
+      </MarkdownBlockquote>
     );
   }
 
@@ -732,10 +731,10 @@ function renderRun(run: MarkdownProjectionRun, onLinkClick?: (url: string) => vo
     );
   }
 
-  if (run.semantic === "strong") return <strong className={markdownStrongClassName}>{text}</strong>;
-  if (run.semantic === "emphasis") return <em className={markdownEmphasisClassName}>{text}</em>;
-  if (run.semantic === "delete") return <del className={markdownDeleteClassName}>{text}</del>;
-  if (run.semantic === "inline-code") return <InlineCode>{text}</InlineCode>;
+  if (run.semantic === "strong") return <MarkdownStrong>{text}</MarkdownStrong>;
+  if (run.semantic === "emphasis") return <MarkdownEmphasis>{text}</MarkdownEmphasis>;
+  if (run.semantic === "delete") return <MarkdownDelete>{text}</MarkdownDelete>;
+  if (run.semantic === "inline-code") return <MarkdownInlineCode>{text}</MarkdownInlineCode>;
   if (run.semantic === "math-source") return <ProjectedMath latex={text} />;
   if (run.semantic === "code-block") return text;
   if (run.semantic === "link-label") return text;
@@ -824,12 +823,12 @@ function ProjectedMath({ displayMode = false, latex }: { displayMode?: boolean; 
     if (displayMode) {
       return (
         <div className={markdownDisplayMathClassName}>
-          <InlineCode className="block px-3 py-2">{latex}</InlineCode>
+          <MarkdownInlineCode className="block px-3 py-2">{latex}</MarkdownInlineCode>
         </div>
       );
     }
 
-    return <InlineCode>{latex}</InlineCode>;
+    return <MarkdownInlineCode>{latex}</MarkdownInlineCode>;
   }
 
   if (displayMode) {
@@ -863,8 +862,4 @@ function renderLatex(latex: string, displayMode: boolean): string | null {
   } catch {
     return null;
   }
-}
-
-function InlineCode({ children, className }: { children: string; className?: string }) {
-  return <code className={cn(markdownInlineCodeClassName, className)}>{children}</code>;
 }

--- a/src/components/markdown/ProjectedMarkdownView.tsx
+++ b/src/components/markdown/ProjectedMarkdownView.tsx
@@ -12,6 +12,7 @@ import { cn } from "@/lib/utils";
 import type { MarkdownHeadingAnchor } from "@/components/outputs/markdown-heading-anchors";
 import { MarkdownCodeBlock } from "./MarkdownCodeBlock";
 import { MarkdownFigure, MarkdownFigureCaption, MarkdownImage } from "./MarkdownFigure";
+import { MarkdownHeading, markdownHeadingElement } from "./MarkdownHeading";
 import {
   MarkdownTableBody,
   MarkdownTableCell,
@@ -33,8 +34,6 @@ import {
 import {
   markdownDisplayMathClassName,
   markdownDocumentClassName,
-  markdownHeadingAnchorClassName,
-  markdownHeadingClassName,
   markdownInlineMathClassName,
   markdownLinkClassName,
   markdownListMarkerClassName,
@@ -128,29 +127,21 @@ function ProjectedMarkdownBlock({
   onTaskCheckedChange,
 }: ProjectedMarkdownBlockProps) {
   if (block.kind === "heading") {
-    const Heading = headingTag(block.element);
     return (
-      <Heading
+      <MarkdownHeading
+        element={markdownHeadingElement(block.element)}
         id={headingAnchor?.headingAnchorId}
+        anchorHref={
+          headingAnchor?.headingAnchorId ? `#${headingAnchor.headingAnchorId}` : undefined
+        }
+        anchorLabel={headingAnchor?.headingAnchorId ? `Link to ${block.text}` : undefined}
         data-nteract-heading-anchor={headingAnchor?.headingAnchorId}
         data-nteract-outline-item-id={headingAnchor?.itemId}
         data-source-active={activeBlockId === block.blockId ? "true" : undefined}
-        className={cn(
-          markdownHeadingClassName(block.element),
-          activeBlockId === block.blockId && sourceActiveBlockClass,
-        )}
+        className={cn(activeBlockId === block.blockId && sourceActiveBlockClass)}
       >
         {renderRuns(runs, onLinkClick, activeInlineId)}
-        {headingAnchor?.headingAnchorId ? (
-          <a
-            aria-label={`Link to ${block.text}`}
-            className={markdownHeadingAnchorClassName}
-            href={`#${headingAnchor.headingAnchorId}`}
-          >
-            #
-          </a>
-        ) : null}
-      </Heading>
+      </MarkdownHeading>
     );
   }
 
@@ -278,15 +269,6 @@ function headingAnchorForBlock(
     if (block.anchorSlug && anchor.anchor === block.anchorSlug) return true;
     return anchor.title === block.text && `h${anchor.level}` === block.element;
   });
-}
-
-function headingTag(element: string): "h1" | "h2" | "h3" | "h4" | "h5" | "h6" {
-  if (element === "h1") return "h1";
-  if (element === "h2") return "h2";
-  if (element === "h3") return "h3";
-  if (element === "h4") return "h4";
-  if (element === "h5") return "h5";
-  return "h6";
 }
 
 interface ProjectedListItem {

--- a/src/components/markdown/ProjectedMarkdownView.tsx
+++ b/src/components/markdown/ProjectedMarkdownView.tsx
@@ -1,7 +1,6 @@
-import { Check, Copy } from "lucide-react";
-import { Fragment, useState, type CSSProperties, type ReactNode } from "react";
+import { Check } from "lucide-react";
+import { Fragment, type CSSProperties, type ReactNode } from "react";
 import katex from "katex";
-import { StaticCodeBlock } from "@/components/editor/static-highlight";
 import type {
   MarkdownProjectionBlock,
   MarkdownProjectionPlan,
@@ -12,13 +11,9 @@ import { useColorTheme, useDarkMode } from "@/lib/dark-mode";
 import { katexStrict } from "@/lib/katex-options";
 import { cn } from "@/lib/utils";
 import type { MarkdownHeadingAnchor } from "@/components/outputs/markdown-heading-anchors";
+import { MarkdownCodeBlock } from "./MarkdownCodeBlock";
 import {
   markdownBlockquoteClassName,
-  markdownCodeBlockCopyButtonClassName,
-  markdownCodeBlockLabelClassName,
-  markdownCodeBlockPreStyle,
-  markdownCodeBlockShellClassName,
-  markdownCodeBlockToolbarClassName,
   markdownDeleteClassName,
   markdownDisplayMathClassName,
   markdownDocumentClassName,
@@ -179,11 +174,14 @@ function ProjectedMarkdownBlock({
         data-source-active={activeBlockId === block.blockId ? "true" : undefined}
         className={cn(activeBlockId === block.blockId && sourceActiveBlockClass)}
       >
-        <ProjectedCodeBlock
+        <MarkdownCodeBlock
           code={block.text}
           colorTheme={colorTheme}
           isDark={isDark}
           language={block.codeLanguage}
+          preClassName="max-w-full"
+          copyResetMs={1800}
+          copyErrorMessage="Failed to copy projected markdown code block:"
         />
       </div>
     );
@@ -864,72 +862,6 @@ function safeImageSrc(src: string | undefined): string | null {
   } catch {
     return null;
   }
-}
-
-function ProjectedCodeBlock({
-  code,
-  colorTheme,
-  isDark,
-  language,
-}: {
-  code: string;
-  colorTheme: "classic" | "cream";
-  isDark: boolean;
-  language?: string;
-}) {
-  const [copied, setCopied] = useState(false);
-
-  const copyCode = async () => {
-    try {
-      await navigator.clipboard.writeText(code);
-      setCopied(true);
-      setTimeout(() => setCopied(false), 1800);
-    } catch (error) {
-      console.error("Failed to copy projected markdown code block:", error);
-    }
-  };
-
-  const languageLabel = codeBlockLanguageLabel(language);
-
-  return (
-    <div
-      data-slot="markdown-code-block"
-      className={markdownCodeBlockShellClassName}
-      data-code-language={languageLabel === "code" ? undefined : languageLabel}
-    >
-      <div className={markdownCodeBlockToolbarClassName}>
-        <span
-          className={markdownCodeBlockLabelClassName}
-          title={languageLabel === "code" ? "Code block" : `${languageLabel} code block`}
-        >
-          {languageLabel}
-        </span>
-        <button
-          type="button"
-          aria-label={copied ? "Copied code" : "Copy code"}
-          className={markdownCodeBlockCopyButtonClassName}
-          title={copied ? "Copied" : "Copy code"}
-          onClick={copyCode}
-        >
-          {copied ? <Check className="size-3" /> : <Copy className="size-3" />}
-        </button>
-      </div>
-      <StaticCodeBlock
-        code={code}
-        colorTheme={colorTheme}
-        isDark={isDark}
-        language={language}
-        className="max-w-full"
-        style={markdownCodeBlockPreStyle}
-      />
-    </div>
-  );
-}
-
-function codeBlockLanguageLabel(language: string | undefined): string {
-  const trimmed = language?.trim();
-  if (!trimmed) return "code";
-  return trimmed;
 }
 
 function ProjectedMath({ displayMode = false, latex }: { displayMode?: boolean; latex: string }) {

--- a/src/components/markdown/ProjectedMarkdownView.tsx
+++ b/src/components/markdown/ProjectedMarkdownView.tsx
@@ -1,4 +1,3 @@
-import { Check } from "lucide-react";
 import { Fragment, type CSSProperties, type ReactNode } from "react";
 import katex from "katex";
 import type {
@@ -22,6 +21,7 @@ import {
   MarkdownTableHeaderRow,
   MarkdownTableRow,
 } from "./MarkdownTable";
+import { MarkdownTaskCheckbox, MarkdownTaskContent } from "./MarkdownTask";
 import {
   markdownBlockquoteClassName,
   markdownDeleteClassName,
@@ -39,9 +39,6 @@ import {
   markdownListMarkerClassName,
   markdownParagraphClassName,
   markdownStrongClassName,
-  markdownTaskCheckboxClassName,
-  markdownTaskCheckboxGlyphClassName,
-  markdownTaskContentClassName,
   markdownTaskListClassName,
   markdownTaskListItemClassName,
   markdownThematicBreakClassName,
@@ -516,44 +513,13 @@ function TaskCheckbox({
   label: string;
   onToggle?: () => void;
 }) {
-  const interactive = Boolean(onToggle);
-  const actionLabel = interactive
-    ? checked
-      ? "Mark task incomplete"
-      : "Mark task complete"
-    : checked
-      ? "Completed task"
-      : "Incomplete task";
-
   return (
-    <label
-      className={cn(markdownTaskCheckboxClassName, interactive && "cursor-pointer")}
-      data-slot="projected-markdown-task-checkbox"
-      data-state={checked ? "checked" : "unchecked"}
-    >
-      <input
-        type="checkbox"
-        checked={checked}
-        disabled={!interactive}
-        readOnly={!interactive}
-        tabIndex={interactive ? 0 : -1}
-        aria-label={`${actionLabel}: ${label}`}
-        className="peer sr-only"
-        onChange={interactive ? onToggle : undefined}
-      />
-      <span
-        aria-hidden="true"
-        className={cn(
-          markdownTaskCheckboxGlyphClassName,
-          checked
-            ? "border-primary bg-primary text-primary-foreground"
-            : "border-border bg-background",
-          interactive && "group-hover/task:border-primary/70",
-        )}
-      >
-        {checked ? <Check className="size-2.5 stroke-[3]" /> : null}
-      </span>
-    </label>
+    <MarkdownTaskCheckbox
+      checked={checked}
+      label={label}
+      onToggle={onToggle}
+      slot="projected-markdown-task-checkbox"
+    />
   );
 }
 
@@ -564,11 +530,7 @@ function ProjectedTaskContent({
   checked: boolean | undefined;
   children: ReactNode;
 }) {
-  return (
-    <span className={cn(markdownTaskContentClassName, checked === true && "text-muted-foreground")}>
-      {children}
-    </span>
-  );
+  return <MarkdownTaskContent checked={checked}>{children}</MarkdownTaskContent>;
 }
 
 function ProjectedTable({

--- a/src/components/markdown/__tests__/MarkdownCodeBlock.test.tsx
+++ b/src/components/markdown/__tests__/MarkdownCodeBlock.test.tsx
@@ -1,0 +1,56 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vite-plus/test";
+import { MarkdownCodeBlock } from "../MarkdownCodeBlock";
+
+describe("MarkdownCodeBlock", () => {
+  beforeEach(() => {
+    Object.assign(navigator, {
+      clipboard: {
+        writeText: vi.fn().mockResolvedValue(undefined),
+      },
+    });
+  });
+
+  it("renders the shared markdown code block affordance", () => {
+    render(<MarkdownCodeBlock code="print('hi')" language="python" colorTheme="classic" />);
+
+    expect(screen.getByText("python")).toHaveAttribute("title", "python code block");
+    expect(screen.getByText("python")).toHaveClass("text-muted-foreground/80");
+    expect(screen.getByText("python").closest('[data-slot="markdown-code-block"]')).toHaveClass(
+      "border-l-2",
+      "bg-muted/[0.14]",
+    );
+    expect(screen.getByText("python").closest("[data-code-language]")).toHaveAttribute(
+      "data-code-language",
+      "python",
+    );
+    expect(screen.getByRole("button", { name: "Copy code" })).toHaveClass(
+      "inline-flex",
+      "bg-transparent",
+    );
+    expect(screen.getByText("print")).toBeInTheDocument();
+  });
+
+  it("falls back to a plain code label without language metadata", () => {
+    render(<MarkdownCodeBlock code="echo hello" colorTheme="classic" />);
+
+    expect(screen.getByText("code")).toHaveAttribute("title", "Code block");
+    expect(
+      screen.getByText("code").closest('[data-slot="markdown-code-block"]'),
+    ).not.toHaveAttribute("data-code-language");
+  });
+
+  it("can hide copy controls for read-only output contexts", () => {
+    render(<MarkdownCodeBlock code="echo hello" colorTheme="classic" enableCopy={false} />);
+
+    expect(screen.queryByRole("button", { name: "Copy code" })).toBeNull();
+  });
+
+  it("copies the raw code text", async () => {
+    render(<MarkdownCodeBlock code="print('copy me')" colorTheme="classic" />);
+
+    fireEvent.click(screen.getByRole("button", { name: "Copy code" }));
+
+    expect(navigator.clipboard.writeText).toHaveBeenCalledWith("print('copy me')");
+  });
+});

--- a/src/components/markdown/__tests__/MarkdownFigure.test.tsx
+++ b/src/components/markdown/__tests__/MarkdownFigure.test.tsx
@@ -1,0 +1,26 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vite-plus/test";
+import { MarkdownFigure, MarkdownFigureCaption, MarkdownImage } from "../MarkdownFigure";
+
+describe("MarkdownFigure", () => {
+  it("renders the shared document image and caption treatment", () => {
+    render(
+      <MarkdownFigure>
+        <MarkdownImage src="attachment:plot.png" alt="Residual topology sketch" />
+        <MarkdownFigureCaption>Residual topology sketch</MarkdownFigureCaption>
+      </MarkdownFigure>,
+    );
+
+    expect(screen.getByRole("figure")).toHaveClass("my-5");
+    expect(screen.getByRole("img", { name: "Residual topology sketch" })).toHaveClass(
+      "rounded-sm",
+      "border",
+      "shadow-sm",
+    );
+    expect(screen.getByText("Residual topology sketch")).toHaveClass(
+      "font-[var(--output-ui-font)]",
+      "text-xs",
+      "text-muted-foreground",
+    );
+  });
+});

--- a/src/components/markdown/__tests__/MarkdownHeading.test.tsx
+++ b/src/components/markdown/__tests__/MarkdownHeading.test.tsx
@@ -1,0 +1,29 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vite-plus/test";
+import { MarkdownHeading, markdownHeadingElement } from "../MarkdownHeading";
+
+describe("MarkdownHeading", () => {
+  it("renders shared heading rhythm and permalink anchors", () => {
+    render(
+      <MarkdownHeading anchorHref="#claim" anchorLabel="Link to Claim" element="h2" id="claim">
+        Claim
+      </MarkdownHeading>,
+    );
+
+    expect(screen.getByRole("heading", { level: 2, name: /Claim/ })).toHaveClass(
+      "group/markdown-heading",
+      "text-2xl",
+      "font-semibold",
+    );
+    expect(screen.getByRole("link", { name: "Link to Claim" })).toHaveAttribute("href", "#claim");
+    expect(screen.getByRole("link", { name: "Link to Claim" })).toHaveClass(
+      "text-muted-foreground/40",
+      "hover:text-primary",
+    );
+  });
+
+  it("normalizes unknown projected heading elements to h6", () => {
+    expect(markdownHeadingElement("h1")).toBe("h1");
+    expect(markdownHeadingElement("aside")).toBe("h6");
+  });
+});

--- a/src/components/markdown/__tests__/MarkdownTable.test.tsx
+++ b/src/components/markdown/__tests__/MarkdownTable.test.tsx
@@ -1,0 +1,55 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vite-plus/test";
+import {
+  MarkdownTableBody,
+  MarkdownTableCell,
+  MarkdownTableElement,
+  MarkdownTableFrame,
+  MarkdownTableHead,
+  MarkdownTableHeaderCell,
+  MarkdownTableHeaderRow,
+  MarkdownTableRow,
+} from "../MarkdownTable";
+
+describe("MarkdownTable", () => {
+  it("renders the shared document table frame and cells", () => {
+    render(
+      <MarkdownTableFrame data-slot="test-table">
+        <MarkdownTableElement>
+          <MarkdownTableHead>
+            <MarkdownTableHeaderRow>
+              <MarkdownTableHeaderCell>metric</MarkdownTableHeaderCell>
+              <MarkdownTableHeaderCell style={{ textAlign: "right" }}>
+                candidate
+              </MarkdownTableHeaderCell>
+            </MarkdownTableHeaderRow>
+          </MarkdownTableHead>
+          <MarkdownTableBody>
+            <MarkdownTableRow>
+              <MarkdownTableCell>topic stability</MarkdownTableCell>
+              <MarkdownTableCell style={{ textAlign: "right" }}>0.84</MarkdownTableCell>
+            </MarkdownTableRow>
+          </MarkdownTableBody>
+        </MarkdownTableElement>
+      </MarkdownTableFrame>,
+    );
+
+    expect(screen.getByRole("table").parentElement).toHaveClass(
+      "rounded-sm",
+      "border",
+      "shadow-sm",
+    );
+    expect(screen.getByRole("table")).toHaveClass("font-[var(--output-ui-font)]", "text-sm");
+    expect(screen.getByRole("columnheader", { name: "metric" })).toHaveClass(
+      "border-border/80",
+      "font-semibold",
+    );
+    expect(screen.getByRole("columnheader", { name: "candidate" })).toHaveStyle({
+      textAlign: "right",
+    });
+    expect(screen.getByRole("row", { name: "topic stability 0.84" })).toHaveClass(
+      "odd:bg-muted/[0.05]",
+    );
+    expect(screen.getByRole("cell", { name: "0.84" })).toHaveClass("text-muted-foreground");
+  });
+});

--- a/src/components/markdown/__tests__/MarkdownTask.test.tsx
+++ b/src/components/markdown/__tests__/MarkdownTask.test.tsx
@@ -1,0 +1,46 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vite-plus/test";
+import { MarkdownTaskCheckbox, MarkdownTaskContent } from "../MarkdownTask";
+
+describe("MarkdownTask", () => {
+  it("renders read-only task checkboxes with shared document styling", () => {
+    render(<MarkdownTaskCheckbox checked />);
+
+    const checkbox = screen.getByRole("checkbox");
+    expect(checkbox).toBeChecked();
+    expect(checkbox).toBeDisabled();
+    expect(checkbox).toHaveClass("sr-only");
+    expect(document.querySelector('[data-slot="markdown-task-checkbox"]')).toHaveClass(
+      "inline-grid",
+      "place-items-center",
+    );
+    expect(document.querySelector('[data-slot="markdown-task-checkbox"] span')).toHaveClass(
+      "bg-primary",
+      "text-primary-foreground",
+    );
+  });
+
+  it("exposes interactive task checkboxes with action labels", () => {
+    const onToggle = vi.fn();
+    render(<MarkdownTaskCheckbox checked={false} label="Compare candidate" onToggle={onToggle} />);
+
+    const checkbox = screen.getByRole("checkbox", {
+      name: "Mark task complete: Compare candidate",
+    });
+    expect(checkbox).not.toBeChecked();
+    expect(checkbox).toBeEnabled();
+
+    fireEvent.click(checkbox);
+
+    expect(onToggle).toHaveBeenCalledOnce();
+  });
+
+  it("softens completed task content", () => {
+    render(<MarkdownTaskContent checked>Reproduce baseline</MarkdownTaskContent>);
+
+    expect(screen.getByText("Reproduce baseline")).toHaveClass(
+      "leading-relaxed",
+      "text-muted-foreground",
+    );
+  });
+});

--- a/src/components/markdown/__tests__/MarkdownText.test.tsx
+++ b/src/components/markdown/__tests__/MarkdownText.test.tsx
@@ -1,0 +1,37 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vite-plus/test";
+import {
+  MarkdownBlockquote,
+  MarkdownDelete,
+  MarkdownEmphasis,
+  MarkdownInlineCode,
+  MarkdownStrong,
+} from "../MarkdownText";
+
+describe("MarkdownText", () => {
+  it("renders shared blockquote styling", () => {
+    render(<MarkdownBlockquote>Document claim</MarkdownBlockquote>);
+
+    expect(screen.getByText("Document claim")).toHaveClass(
+      "border-l-2",
+      "border-foreground/35",
+      "italic",
+    );
+  });
+
+  it("renders shared inline semantic text styling", () => {
+    render(
+      <p>
+        <MarkdownStrong>important</MarkdownStrong>
+        <MarkdownEmphasis>paper margin</MarkdownEmphasis>
+        <MarkdownDelete>removed</MarkdownDelete>
+        <MarkdownInlineCode>seed=13</MarkdownInlineCode>
+      </p>,
+    );
+
+    expect(screen.getByText("important")).toHaveClass("font-semibold", "text-foreground");
+    expect(screen.getByText("paper margin")).toHaveClass("italic", "text-foreground");
+    expect(screen.getByText("removed")).toHaveClass("decoration-destructive/55");
+    expect(screen.getByText("seed=13")).toHaveClass("border", "bg-muted/70", "font-mono");
+  });
+});

--- a/src/components/outputs/markdown-output.tsx
+++ b/src/components/outputs/markdown-output.tsx
@@ -10,6 +10,7 @@ import { useColorTheme, useDarkMode } from "@/lib/dark-mode";
 import { katexStrict } from "@/lib/katex-options";
 import { cn } from "@/lib/utils";
 import { MarkdownCodeBlock } from "../markdown/MarkdownCodeBlock";
+import { MarkdownFigure, MarkdownFigureCaption, MarkdownImage } from "../markdown/MarkdownFigure";
 import {
   MarkdownTableBody,
   MarkdownTableCell,
@@ -26,14 +27,11 @@ import {
   markdownDetailsClassName,
   markdownDocumentClassName,
   markdownEmphasisClassName,
-  markdownFigureCaptionClassName,
-  markdownFigureClassName,
   markdownFootnoteBackrefClassName,
   markdownFootnotesClassName,
   markdownFootnoteRefClassName,
   markdownHeadingAnchorClassName,
   markdownHeadingClassName,
-  markdownImageClassName,
   markdownInlineCodeClassName,
   markdownLinkClassName,
   markdownListMarkerClassName,
@@ -439,23 +437,15 @@ export function MarkdownOutput({
           // Images
           img({ src, alt, ...props }) {
             if (!src) return null;
-            return <img src={src} alt={alt || ""} className={markdownImageClassName} {...props} />;
+            return <MarkdownImage src={src} alt={alt || ""} {...props} />;
           },
 
           figure({ children, ...props }) {
-            return (
-              <figure className={markdownFigureClassName} {...props}>
-                {children}
-              </figure>
-            );
+            return <MarkdownFigure {...props}>{children}</MarkdownFigure>;
           },
 
           figcaption({ children, ...props }) {
-            return (
-              <figcaption className={markdownFigureCaptionClassName} {...props}>
-                {children}
-              </figcaption>
-            );
+            return <MarkdownFigureCaption {...props}>{children}</MarkdownFigureCaption>;
           },
 
           strong({ children, ...props }) {

--- a/src/components/outputs/markdown-output.tsx
+++ b/src/components/outputs/markdown-output.tsx
@@ -11,6 +11,7 @@ import { katexStrict } from "@/lib/katex-options";
 import { cn } from "@/lib/utils";
 import { MarkdownCodeBlock } from "../markdown/MarkdownCodeBlock";
 import { MarkdownFigure, MarkdownFigureCaption, MarkdownImage } from "../markdown/MarkdownFigure";
+import { MarkdownHeading } from "../markdown/MarkdownHeading";
 import {
   MarkdownTableBody,
   MarkdownTableCell,
@@ -34,8 +35,6 @@ import {
   markdownFootnoteBackrefClassName,
   markdownFootnotesClassName,
   markdownFootnoteRefClassName,
-  markdownHeadingAnchorClassName,
-  markdownHeadingClassName,
   markdownLinkClassName,
   markdownListMarkerClassName,
   markdownParagraphClassName,
@@ -158,22 +157,17 @@ export function MarkdownOutput({
     };
   };
 
-  const renderHeadingAnchor = (
+  const headingAnchorProps = (
     attributes: ReturnType<typeof headingAttributes>,
     children: ReactNode,
   ) => {
     const id = (attributes as { id?: string }).id;
-    if (!id) return null;
+    if (!id) return {};
 
-    return (
-      <a
-        aria-label={`Link to ${normalizeHeadingText(textFromReactNode(children))}`}
-        className={markdownHeadingAnchorClassName}
-        href={`#${id}`}
-      >
-        #
-      </a>
-    );
+    return {
+      anchorHref: `#${id}`,
+      anchorLabel: `Link to ${normalizeHeadingText(textFromReactNode(children))}`,
+    };
   };
 
   if (!content) {
@@ -297,55 +291,79 @@ export function MarkdownOutput({
           h1({ children, ...props }) {
             const attributes = headingAttributes(1, children);
             return (
-              <h1 className={markdownHeadingClassName("h1")} {...props} {...attributes}>
+              <MarkdownHeading
+                element="h1"
+                {...props}
+                {...attributes}
+                {...headingAnchorProps(attributes, children)}
+              >
                 {children}
-                {renderHeadingAnchor(attributes, children)}
-              </h1>
+              </MarkdownHeading>
             );
           },
           h2({ children, ...props }) {
             const attributes = headingAttributes(2, children);
             return (
-              <h2 className={markdownHeadingClassName("h2")} {...props} {...attributes}>
+              <MarkdownHeading
+                element="h2"
+                {...props}
+                {...attributes}
+                {...headingAnchorProps(attributes, children)}
+              >
                 {children}
-                {renderHeadingAnchor(attributes, children)}
-              </h2>
+              </MarkdownHeading>
             );
           },
           h3({ children, ...props }) {
             const attributes = headingAttributes(3, children);
             return (
-              <h3 className={markdownHeadingClassName("h3")} {...props} {...attributes}>
+              <MarkdownHeading
+                element="h3"
+                {...props}
+                {...attributes}
+                {...headingAnchorProps(attributes, children)}
+              >
                 {children}
-                {renderHeadingAnchor(attributes, children)}
-              </h3>
+              </MarkdownHeading>
             );
           },
           h4({ children, ...props }) {
             const attributes = headingAttributes(4, children);
             return (
-              <h4 className={markdownHeadingClassName("h4")} {...props} {...attributes}>
+              <MarkdownHeading
+                element="h4"
+                {...props}
+                {...attributes}
+                {...headingAnchorProps(attributes, children)}
+              >
                 {children}
-                {renderHeadingAnchor(attributes, children)}
-              </h4>
+              </MarkdownHeading>
             );
           },
           h5({ children, ...props }) {
             const attributes = headingAttributes(5, children);
             return (
-              <h5 className={markdownHeadingClassName("h5")} {...props} {...attributes}>
+              <MarkdownHeading
+                element="h5"
+                {...props}
+                {...attributes}
+                {...headingAnchorProps(attributes, children)}
+              >
                 {children}
-                {renderHeadingAnchor(attributes, children)}
-              </h5>
+              </MarkdownHeading>
             );
           },
           h6({ children, ...props }) {
             const attributes = headingAttributes(6, children);
             return (
-              <h6 className={markdownHeadingClassName("h6")} {...props} {...attributes}>
+              <MarkdownHeading
+                element="h6"
+                {...props}
+                {...attributes}
+                {...headingAnchorProps(attributes, children)}
+              >
                 {children}
-                {renderHeadingAnchor(attributes, children)}
-              </h6>
+              </MarkdownHeading>
             );
           },
 

--- a/src/components/outputs/markdown-output.tsx
+++ b/src/components/outputs/markdown-output.tsx
@@ -12,6 +12,15 @@ import { katexStrict } from "@/lib/katex-options";
 import { cn } from "@/lib/utils";
 import { MarkdownCodeBlock } from "../markdown/MarkdownCodeBlock";
 import {
+  MarkdownTableBody,
+  MarkdownTableCell,
+  MarkdownTableElement,
+  MarkdownTableFrame,
+  MarkdownTableHead,
+  MarkdownTableHeaderCell,
+  MarkdownTableRow,
+} from "../markdown/MarkdownTable";
+import {
   markdownBlockquoteClassName,
   markdownDeleteClassName,
   markdownDetailsClassName,
@@ -36,12 +45,6 @@ import {
   markdownTaskCheckboxGlyphClassName,
   markdownTaskListClassName,
   markdownTaskListItemClassName,
-  markdownTableCellClassName,
-  markdownTableClassName,
-  markdownTableHeadClassName,
-  markdownTableHeaderCellClassName,
-  markdownTableRowClassName,
-  markdownTableWrapperClassName,
   markdownThematicBreakClassName,
 } from "../markdown/markdown-typography";
 
@@ -271,47 +274,29 @@ export function MarkdownOutput({
           // Tables
           table({ children, ...props }) {
             return (
-              <div className={markdownTableWrapperClassName}>
-                <table className={markdownTableClassName} {...props}>
-                  {children}
-                </table>
-              </div>
+              <MarkdownTableFrame>
+                <MarkdownTableElement {...props}>{children}</MarkdownTableElement>
+              </MarkdownTableFrame>
             );
           },
           thead({ children, ...props }) {
-            return (
-              <thead className={markdownTableHeadClassName} {...props}>
-                {children}
-              </thead>
-            );
+            return <MarkdownTableHead {...props}>{children}</MarkdownTableHead>;
           },
           tbody({ children, ...props }) {
             return (
-              <tbody className="divide-y divide-border" {...props}>
+              <MarkdownTableBody className="divide-y divide-border" {...props}>
                 {children}
-              </tbody>
+              </MarkdownTableBody>
             );
           },
           tr({ children, ...props }) {
-            return (
-              <tr className={markdownTableRowClassName} {...props}>
-                {children}
-              </tr>
-            );
+            return <MarkdownTableRow {...props}>{children}</MarkdownTableRow>;
           },
           th({ children, ...props }) {
-            return (
-              <th className={markdownTableHeaderCellClassName} {...props}>
-                {children}
-              </th>
-            );
+            return <MarkdownTableHeaderCell {...props}>{children}</MarkdownTableHeaderCell>;
           },
           td({ children, ...props }) {
-            return (
-              <td className={markdownTableCellClassName} {...props}>
-                {children}
-              </td>
-            );
+            return <MarkdownTableCell {...props}>{children}</MarkdownTableCell>;
           },
 
           // Headings

--- a/src/components/outputs/markdown-output.tsx
+++ b/src/components/outputs/markdown-output.tsx
@@ -1,7 +1,6 @@
-import { Check, Copy } from "lucide-react";
-import { type ReactNode, useState } from "react";
+import { Check } from "lucide-react";
+import { type ReactNode } from "react";
 import ReactMarkdown, { type Options as ReactMarkdownOptions } from "react-markdown";
-import { StaticCodeBlock } from "@/components/editor/static-highlight";
 import type { MarkdownHeadingAnchor } from "./markdown-heading-anchors";
 import type { Options as RehypeKatexOptions } from "rehype-katex";
 import rehypeKatex from "rehype-katex";
@@ -11,13 +10,9 @@ import remarkMath from "remark-math";
 import { useColorTheme, useDarkMode } from "@/lib/dark-mode";
 import { katexStrict } from "@/lib/katex-options";
 import { cn } from "@/lib/utils";
+import { MarkdownCodeBlock } from "../markdown/MarkdownCodeBlock";
 import {
   markdownBlockquoteClassName,
-  markdownCodeBlockCopyButtonClassName,
-  markdownCodeBlockLabelClassName,
-  markdownCodeBlockPreStyle,
-  markdownCodeBlockShellClassName,
-  markdownCodeBlockToolbarClassName,
   markdownDeleteClassName,
   markdownDetailsClassName,
   markdownDocumentClassName,
@@ -88,70 +83,6 @@ function isInIframe(): boolean {
   }
 }
 
-interface CodeBlockProps {
-  children: string;
-  language?: string;
-  enableCopy?: boolean;
-  isDark?: boolean;
-}
-
-function CodeBlock({ children, language = "", enableCopy = true, isDark = false }: CodeBlockProps) {
-  const [copied, setCopied] = useState(false);
-  const rawTheme = useColorTheme();
-  const colorTheme = (rawTheme === "cream" ? "cream" : "classic") as "classic" | "cream";
-  const languageLabel = codeBlockLanguageLabel(language);
-
-  const handleCopy = async () => {
-    try {
-      await navigator.clipboard.writeText(children);
-      setCopied(true);
-      setTimeout(() => setCopied(false), 2000);
-    } catch (err) {
-      console.error("Failed to copy code:", err);
-    }
-  };
-
-  return (
-    <div
-      data-slot="markdown-code-block"
-      className={markdownCodeBlockShellClassName}
-      data-code-language={languageLabel === "code" ? undefined : languageLabel}
-    >
-      <div className={markdownCodeBlockToolbarClassName}>
-        <span
-          className={markdownCodeBlockLabelClassName}
-          title={languageLabel === "code" ? "Code block" : `${languageLabel} code block`}
-        >
-          {languageLabel}
-        </span>
-        {enableCopy && (
-          <button
-            onClick={handleCopy}
-            className={markdownCodeBlockCopyButtonClassName}
-            title={copied ? "Copied!" : "Copy code"}
-            type="button"
-          >
-            {copied ? <Check className="h-3 w-3" /> : <Copy className="h-3 w-3" />}
-          </button>
-        )}
-      </div>
-      <StaticCodeBlock
-        code={children}
-        language={language}
-        isDark={isDark}
-        colorTheme={colorTheme}
-        style={markdownCodeBlockPreStyle}
-      />
-    </div>
-  );
-}
-
-function codeBlockLanguageLabel(language: string | undefined): string {
-  const trimmed = language?.trim();
-  if (!trimmed) return "code";
-  return trimmed;
-}
-
 function textFromReactNode(node: ReactNode): string {
   if (node == null || typeof node === "boolean") return "";
   if (typeof node === "string" || typeof node === "number") return String(node);
@@ -186,6 +117,8 @@ export function MarkdownOutput({
   headingAnchors = [],
 }: MarkdownOutputProps) {
   const isDark = useDarkMode();
+  const rawTheme = useColorTheme();
+  const colorTheme = rawTheme === "cream" ? "cream" : "classic";
   let headingCursor = 0;
 
   const takeHeadingAnchor = (level: number, children: ReactNode): MarkdownHeadingAnchor | null => {
@@ -284,9 +217,14 @@ export function MarkdownOutput({
 
             if (isBlockCode) {
               return (
-                <CodeBlock language={language} enableCopy={enableCopyCode} isDark={isDark}>
-                  {codeContent}
-                </CodeBlock>
+                <MarkdownCodeBlock
+                  code={codeContent}
+                  language={language}
+                  enableCopy={enableCopyCode}
+                  isDark={isDark}
+                  colorTheme={colorTheme}
+                  copyErrorMessage="Failed to copy code:"
+                />
               );
             }
 

--- a/src/components/outputs/markdown-output.tsx
+++ b/src/components/outputs/markdown-output.tsx
@@ -1,4 +1,3 @@
-import { Check } from "lucide-react";
 import { type ReactNode } from "react";
 import ReactMarkdown, { type Options as ReactMarkdownOptions } from "react-markdown";
 import type { MarkdownHeadingAnchor } from "./markdown-heading-anchors";
@@ -20,6 +19,7 @@ import {
   MarkdownTableHeaderCell,
   MarkdownTableRow,
 } from "../markdown/MarkdownTable";
+import { MarkdownTaskCheckbox } from "../markdown/MarkdownTask";
 import {
   markdownBlockquoteClassName,
   markdownDeleteClassName,
@@ -41,8 +41,6 @@ import {
   markdownStrongClassName,
   markdownSummaryClassName,
   markdownSummaryIndicatorClassName,
-  markdownTaskCheckboxClassName,
-  markdownTaskCheckboxGlyphClassName,
   markdownTaskListClassName,
   markdownTaskListItemClassName,
   markdownThematicBreakClassName,
@@ -416,31 +414,11 @@ export function MarkdownOutput({
 
             const isChecked = Boolean(checked);
             return (
-              <span
-                className={markdownTaskCheckboxClassName}
-                data-slot="markdown-task-checkbox"
-                data-state={isChecked ? "checked" : "unchecked"}
-              >
-                <input
-                  {...props}
-                  type="checkbox"
-                  checked={isChecked}
-                  readOnly
-                  disabled
-                  className={cn("peer sr-only", className)}
-                />
-                <span
-                  aria-hidden="true"
-                  className={cn(
-                    markdownTaskCheckboxGlyphClassName,
-                    isChecked
-                      ? "border-primary bg-primary text-primary-foreground"
-                      : "border-border bg-background",
-                  )}
-                >
-                  {isChecked ? <Check className="size-2.5 stroke-[3]" /> : null}
-                </span>
-              </span>
+              <MarkdownTaskCheckbox
+                checked={isChecked}
+                inputClassName={className}
+                inputProps={props}
+              />
             );
           },
 

--- a/src/components/outputs/markdown-output.tsx
+++ b/src/components/outputs/markdown-output.tsx
@@ -22,21 +22,23 @@ import {
 } from "../markdown/MarkdownTable";
 import { MarkdownTaskCheckbox } from "../markdown/MarkdownTask";
 import {
-  markdownBlockquoteClassName,
-  markdownDeleteClassName,
+  MarkdownBlockquote,
+  MarkdownDelete,
+  MarkdownEmphasis,
+  MarkdownInlineCode,
+  MarkdownStrong,
+} from "../markdown/MarkdownText";
+import {
   markdownDetailsClassName,
   markdownDocumentClassName,
-  markdownEmphasisClassName,
   markdownFootnoteBackrefClassName,
   markdownFootnotesClassName,
   markdownFootnoteRefClassName,
   markdownHeadingAnchorClassName,
   markdownHeadingClassName,
-  markdownInlineCodeClassName,
   markdownLinkClassName,
   markdownListMarkerClassName,
   markdownParagraphClassName,
-  markdownStrongClassName,
   markdownSummaryClassName,
   markdownSummaryIndicatorClassName,
   markdownTaskListClassName,
@@ -228,11 +230,7 @@ export function MarkdownOutput({
             }
 
             // Inline code
-            return (
-              <code className={markdownInlineCodeClassName} {...props}>
-                {children}
-              </code>
-            );
+            return <MarkdownInlineCode {...props}>{children}</MarkdownInlineCode>;
           },
 
           // Links open in new tab
@@ -422,11 +420,7 @@ export function MarkdownOutput({
 
           // Blockquotes
           blockquote({ children, ...props }) {
-            return (
-              <blockquote className={markdownBlockquoteClassName} {...props}>
-                {children}
-              </blockquote>
-            );
+            return <MarkdownBlockquote {...props}>{children}</MarkdownBlockquote>;
           },
 
           // Horizontal rule
@@ -449,27 +443,15 @@ export function MarkdownOutput({
           },
 
           strong({ children, ...props }) {
-            return (
-              <strong className={markdownStrongClassName} {...props}>
-                {children}
-              </strong>
-            );
+            return <MarkdownStrong {...props}>{children}</MarkdownStrong>;
           },
 
           em({ children, ...props }) {
-            return (
-              <em className={markdownEmphasisClassName} {...props}>
-                {children}
-              </em>
-            );
+            return <MarkdownEmphasis {...props}>{children}</MarkdownEmphasis>;
           },
 
           del({ children, ...props }) {
-            return (
-              <del className={markdownDeleteClassName} {...props}>
-                {children}
-              </del>
-            );
+            return <MarkdownDelete {...props}>{children}</MarkdownDelete>;
           },
 
           details({ children, ...props }) {


### PR DESCRIPTION
## Summary

- Add shared `MarkdownCodeBlock`, `MarkdownFigure`, `MarkdownHeading`, `MarkdownTable`, `MarkdownTask`, and `MarkdownText` primitives for document-style markdown surfaces.
- Wire projected markdown and sandboxed markdown output rendering through the shared primitives.
- Add focused coverage for code labels/copy controls, figure image/caption styling, heading anchors, table frame/cell styling, task checkbox/content behavior, and text semantics.

## Validation

- `pnpm test:run src/components/markdown/__tests__/MarkdownCodeBlock.test.tsx src/components/markdown/__tests__/MarkdownFigure.test.tsx src/components/markdown/__tests__/MarkdownHeading.test.tsx src/components/markdown/__tests__/MarkdownTable.test.tsx src/components/markdown/__tests__/MarkdownTask.test.tsx src/components/markdown/__tests__/MarkdownText.test.tsx src/components/markdown/__tests__/ProjectedMarkdownView.test.tsx src/components/outputs/__tests__/markdown-output.test.tsx`
- `cargo xtask lint --fix`
- `pnpm elements:build`
- Browser smoke check on the Elements markdown typography fixture
