### PR TITLE
fix(markdown): widen document fixture and scope outline links

### DIFF
--- a/apps/elements/app/docs/[[...slug]]/page.tsx
+++ b/apps/elements/app/docs/[[...slug]]/page.tsx
@@ -39,13 +39,15 @@ export default async function Page({ params }: PageProps) {
     notFound();
   }
 
+  const pagePath = slug.join("/");
+  const isReadingFixturePage = pagePath === "markdown-typography";
   const MdxContent = page.data.body;
 
   return (
-    <DocsPage toc={page.data.toc}>
+    <DocsPage full={isReadingFixturePage} toc={isReadingFixturePage ? [] : page.data.toc}>
       <DocsTitle>{page.data.title}</DocsTitle>
       {page.data.description ? <DocsDescription>{page.data.description}</DocsDescription> : null}
-      <DocsBody>
+      <DocsBody className={isReadingFixturePage ? "max-w-none" : undefined}>
         <MdxContent
           components={getMDXComponents({
             a: createRelativeLink(source, page),

--- a/apps/notebook/e2e/markdown-parity.spec.ts
+++ b/apps/notebook/e2e/markdown-parity.spec.ts
@@ -63,7 +63,10 @@ test.describe("markdown parity", () => {
     expect(copyText.clipboard).toContain("Selectable paragraph");
 
     await page.getByLabel("Outline").click();
-    await page.getByRole("link", { name: "Deep parity section" }).click();
+    await page
+      .getByTestId("notebook-outline-panel")
+      .getByRole("link", { name: "Deep parity section", exact: true })
+      .click();
 
     const deepHeading = renderedMarkdown.getByRole("heading", { name: "Deep parity section" });
     await expect

--- a/apps/notebook/e2e/notebook-rail-outline.spec.ts
+++ b/apps/notebook/e2e/notebook-rail-outline.spec.ts
@@ -34,7 +34,11 @@ test.describe("notebook rail outline", () => {
     await expect(page.getByTestId("notebook-rail")).toHaveAttribute("data-collapsed", "true");
     await page.getByLabel("Outline").click();
 
-    const validateHeading = page.getByRole("link", { name: "Validate ranges" });
+    const outlinePanel = page.getByTestId("notebook-outline-panel");
+    const validateHeading = outlinePanel.getByRole("link", {
+      name: "Validate ranges",
+      exact: true,
+    });
     await expect(validateHeading).toBeVisible();
     await expect(page.locator('li[data-outline-level="2"] li[data-outline-level="3"]')).toHaveCount(
       1,
@@ -75,7 +79,10 @@ test.describe("notebook rail outline", () => {
     const beforeClickY = (await childHeading.boundingBox())?.y ?? Infinity;
 
     await page.getByLabel("Outline").click();
-    await page.getByRole("link", { name: "Deep child" }).click();
+    await page
+      .getByTestId("notebook-outline-panel")
+      .getByRole("link", { name: "Deep child", exact: true })
+      .click();
 
     await expect
       .poll(async () => page.evaluate(() => window.location.hash))

--- a/src/components/markdown/MarkdownCodeBlock.tsx
+++ b/src/components/markdown/MarkdownCodeBlock.tsx
@@ -1,0 +1,84 @@
+import { Check, Copy } from "lucide-react";
+import { useState } from "react";
+import { StaticCodeBlock, type ColorTheme } from "@/components/editor/static-highlight";
+
+import {
+  markdownCodeBlockCopyButtonClassName,
+  markdownCodeBlockLabelClassName,
+  markdownCodeBlockPreStyle,
+  markdownCodeBlockShellClassName,
+  markdownCodeBlockToolbarClassName,
+} from "./markdown-typography";
+
+interface MarkdownCodeBlockProps {
+  code: string;
+  colorTheme?: ColorTheme;
+  enableCopy?: boolean;
+  isDark?: boolean;
+  language?: string;
+  preClassName?: string;
+}
+
+export function MarkdownCodeBlock({
+  code,
+  colorTheme = "classic",
+  enableCopy = true,
+  isDark = false,
+  language,
+  preClassName,
+}: MarkdownCodeBlockProps) {
+  const [copied, setCopied] = useState(false);
+  const languageLabel = markdownCodeBlockLanguageLabel(language);
+
+  const copyCode = async () => {
+    try {
+      await navigator.clipboard.writeText(code);
+      setCopied(true);
+      setTimeout(() => setCopied(false), 1800);
+    } catch (error) {
+      console.error("Failed to copy markdown code block:", error);
+    }
+  };
+
+  return (
+    <div
+      data-slot="markdown-code-block"
+      className={markdownCodeBlockShellClassName}
+      data-code-language={languageLabel === "code" ? undefined : languageLabel}
+    >
+      <div className={markdownCodeBlockToolbarClassName}>
+        <span
+          className={markdownCodeBlockLabelClassName}
+          title={languageLabel === "code" ? "Code block" : `${languageLabel} code block`}
+        >
+          {languageLabel}
+        </span>
+        {enableCopy ? (
+          <button
+            type="button"
+            aria-label={copied ? "Copied code" : "Copy code"}
+            className={markdownCodeBlockCopyButtonClassName}
+            title={copied ? "Copied" : "Copy code"}
+            onClick={copyCode}
+          >
+            {copied ? <Check className="size-3" /> : <Copy className="size-3" />}
+          </button>
+        ) : null}
+      </div>
+      <StaticCodeBlock
+        code={code}
+        colorTheme={colorTheme}
+        isDark={isDark}
+        language={language}
+        className={preClassName}
+        style={markdownCodeBlockPreStyle}
+      />
+    </div>
+  );
+}
+
+export function markdownCodeBlockLanguageLabel(language: string | undefined): string {
+  const trimmed = language?.trim();
+  if (!trimmed) return "code";
+  return trimmed;
+}

--- a/src/components/markdown/ProjectedMarkdownView.tsx
+++ b/src/components/markdown/ProjectedMarkdownView.tsx
@@ -1,7 +1,6 @@
-import { Check, Copy } from "lucide-react";
-import { Fragment, useState, type CSSProperties, type ReactNode } from "react";
+import { Check } from "lucide-react";
+import { Fragment, type CSSProperties, type ReactNode } from "react";
 import katex from "katex";
-import { StaticCodeBlock } from "@/components/editor/static-highlight";
 import type {
   MarkdownProjectionBlock,
   MarkdownProjectionPlan,
@@ -12,13 +11,9 @@ import { useColorTheme, useDarkMode } from "@/lib/dark-mode";
 import { katexStrict } from "@/lib/katex-options";
 import { cn } from "@/lib/utils";
 import type { MarkdownHeadingAnchor } from "@/components/outputs/markdown-heading-anchors";
+import { MarkdownCodeBlock } from "./MarkdownCodeBlock";
 import {
   markdownBlockquoteClassName,
-  markdownCodeBlockCopyButtonClassName,
-  markdownCodeBlockLabelClassName,
-  markdownCodeBlockPreStyle,
-  markdownCodeBlockShellClassName,
-  markdownCodeBlockToolbarClassName,
   markdownDeleteClassName,
   markdownDisplayMathClassName,
   markdownDocumentClassName,
@@ -877,59 +872,15 @@ function ProjectedCodeBlock({
   isDark: boolean;
   language?: string;
 }) {
-  const [copied, setCopied] = useState(false);
-
-  const copyCode = async () => {
-    try {
-      await navigator.clipboard.writeText(code);
-      setCopied(true);
-      setTimeout(() => setCopied(false), 1800);
-    } catch (error) {
-      console.error("Failed to copy projected markdown code block:", error);
-    }
-  };
-
-  const languageLabel = codeBlockLanguageLabel(language);
-
   return (
-    <div
-      data-slot="markdown-code-block"
-      className={markdownCodeBlockShellClassName}
-      data-code-language={languageLabel === "code" ? undefined : languageLabel}
-    >
-      <div className={markdownCodeBlockToolbarClassName}>
-        <span
-          className={markdownCodeBlockLabelClassName}
-          title={languageLabel === "code" ? "Code block" : `${languageLabel} code block`}
-        >
-          {languageLabel}
-        </span>
-        <button
-          type="button"
-          aria-label={copied ? "Copied code" : "Copy code"}
-          className={markdownCodeBlockCopyButtonClassName}
-          title={copied ? "Copied" : "Copy code"}
-          onClick={copyCode}
-        >
-          {copied ? <Check className="size-3" /> : <Copy className="size-3" />}
-        </button>
-      </div>
-      <StaticCodeBlock
-        code={code}
-        colorTheme={colorTheme}
-        isDark={isDark}
-        language={language}
-        className="max-w-full"
-        style={markdownCodeBlockPreStyle}
-      />
-    </div>
+    <MarkdownCodeBlock
+      code={code}
+      colorTheme={colorTheme}
+      isDark={isDark}
+      language={language}
+      preClassName="max-w-full"
+    />
   );
-}
-
-function codeBlockLanguageLabel(language: string | undefined): string {
-  const trimmed = language?.trim();
-  if (!trimmed) return "code";
-  return trimmed;
 }
 
 function ProjectedMath({ displayMode = false, latex }: { displayMode?: boolean; latex: string }) {

--- a/src/components/markdown/__tests__/ProjectedMarkdownView.test.tsx
+++ b/src/components/markdown/__tests__/ProjectedMarkdownView.test.tsx
@@ -897,11 +897,8 @@ describe("ProjectedMarkdownView", () => {
       textAlign: "right",
     });
     expect(screen.getByRole("cell", { name: "128" })).toHaveStyle({ textAlign: "right" });
-    expect(screen.getByRole("table").parentElement).toHaveClass(
-      "rounded-sm",
-      "border",
-      "shadow-sm",
-    );
+    expect(screen.getByRole("table").parentElement).toHaveClass("border-y", "border-border/80");
+    expect(screen.getByRole("table").parentElement).not.toHaveClass("rounded-sm", "shadow-sm");
     expect(screen.getByRole("row", { name: "rows 128" })).toHaveClass("odd:bg-muted/[0.05]");
     expect(screen.getByRole("table").parentElement).toHaveAttribute(
       "data-slot",

--- a/src/components/markdown/__tests__/ProjectedMarkdownView.test.tsx
+++ b/src/components/markdown/__tests__/ProjectedMarkdownView.test.tsx
@@ -310,9 +310,9 @@ describe("ProjectedMarkdownView", () => {
     expect(screen.getByText("First paragraph")).toHaveClass("my-3", "leading-relaxed");
     expect(screen.getByRole("list")).toHaveClass("my-3", "ml-6", "list-disc");
     expect(screen.getByText("quoted").closest("blockquote")).toHaveClass(
-      "border-l-2",
-      "border-foreground/35",
-      "text-foreground/80",
+      "border-l-[3px]",
+      "border-primary/35",
+      "text-foreground/90",
     );
     expect(screen.getByText("quoted").closest("blockquote")).not.toHaveClass("bg-muted/[0.20]");
   });

--- a/src/components/markdown/markdown-typography.ts
+++ b/src/components/markdown/markdown-typography.ts
@@ -74,7 +74,7 @@ export const markdownTaskContentClassName = "min-w-0 leading-relaxed";
 export const markdownThematicBreakClassName = "my-7 border-0 border-t border-border/70";
 
 export const markdownTableWrapperClassName =
-  "my-5 overflow-x-auto rounded-sm border border-border/80 bg-background shadow-sm";
+  "my-5 overflow-x-auto border-y border-border/80 bg-background";
 
 export const markdownTableClassName =
   "min-w-full border-collapse font-[var(--output-ui-font)] text-sm leading-normal";

--- a/src/components/markdown/markdown-typography.ts
+++ b/src/components/markdown/markdown-typography.ts
@@ -41,7 +41,7 @@ export const markdownDeleteClassName =
   "text-muted-foreground decoration-destructive/55 decoration-2";
 
 export const markdownBlockquoteClassName =
-  "relative my-5 border-l-2 border-foreground/35 py-1.5 pr-2 pl-5 text-[1.01em] leading-[1.72] text-foreground/80 italic";
+  "relative my-5 border-l-[3px] border-primary/35 py-1.5 pr-2 pl-5 text-[1.02em] leading-[1.75] text-foreground/90 italic [&_strong]:text-foreground";
 
 export const markdownDetailsClassName =
   "group/details my-5 overflow-hidden rounded-md border border-border/75 bg-muted/[0.14] shadow-sm open:bg-muted/[0.18] [&>:not(summary)]:mx-4 [&>:not(summary)]:my-3 [&>:last-child]:mb-4 [&>summary+*]:mt-3";

--- a/src/components/outputs/__tests__/markdown-output.test.tsx
+++ b/src/components/outputs/__tests__/markdown-output.test.tsx
@@ -82,11 +82,8 @@ describe("MarkdownOutput heading anchors", () => {
   it("uses the shared evidence table treatment", () => {
     render(<MarkdownOutput content={"| metric | value |\n| --- | ---: |\n| rows | 128 |"} />);
 
-    expect(screen.getByRole("table").parentElement).toHaveClass(
-      "rounded-sm",
-      "border",
-      "shadow-sm",
-    );
+    expect(screen.getByRole("table").parentElement).toHaveClass("border-y", "border-border/80");
+    expect(screen.getByRole("table").parentElement).not.toHaveClass("rounded-sm", "shadow-sm");
     expect(screen.getByRole("columnheader", { name: "metric" })).toHaveClass(
       "border-border/80",
       "py-2.5",

--- a/src/components/outputs/markdown-output.tsx
+++ b/src/components/outputs/markdown-output.tsx
@@ -1,7 +1,6 @@
-import { Check, Copy } from "lucide-react";
-import { type ReactNode, useState } from "react";
+import { Check } from "lucide-react";
+import { type ReactNode } from "react";
 import ReactMarkdown, { type Options as ReactMarkdownOptions } from "react-markdown";
-import { StaticCodeBlock } from "@/components/editor/static-highlight";
 import type { MarkdownHeadingAnchor } from "./markdown-heading-anchors";
 import type { Options as RehypeKatexOptions } from "rehype-katex";
 import rehypeKatex from "rehype-katex";
@@ -11,13 +10,9 @@ import remarkMath from "remark-math";
 import { useColorTheme, useDarkMode } from "@/lib/dark-mode";
 import { katexStrict } from "@/lib/katex-options";
 import { cn } from "@/lib/utils";
+import { MarkdownCodeBlock } from "../markdown/MarkdownCodeBlock";
 import {
   markdownBlockquoteClassName,
-  markdownCodeBlockCopyButtonClassName,
-  markdownCodeBlockLabelClassName,
-  markdownCodeBlockPreStyle,
-  markdownCodeBlockShellClassName,
-  markdownCodeBlockToolbarClassName,
   markdownDeleteClassName,
   markdownDetailsClassName,
   markdownDocumentClassName,
@@ -96,60 +91,18 @@ interface CodeBlockProps {
 }
 
 function CodeBlock({ children, language = "", enableCopy = true, isDark = false }: CodeBlockProps) {
-  const [copied, setCopied] = useState(false);
   const rawTheme = useColorTheme();
   const colorTheme = (rawTheme === "cream" ? "cream" : "classic") as "classic" | "cream";
-  const languageLabel = codeBlockLanguageLabel(language);
-
-  const handleCopy = async () => {
-    try {
-      await navigator.clipboard.writeText(children);
-      setCopied(true);
-      setTimeout(() => setCopied(false), 2000);
-    } catch (err) {
-      console.error("Failed to copy code:", err);
-    }
-  };
 
   return (
-    <div
-      data-slot="markdown-code-block"
-      className={markdownCodeBlockShellClassName}
-      data-code-language={languageLabel === "code" ? undefined : languageLabel}
-    >
-      <div className={markdownCodeBlockToolbarClassName}>
-        <span
-          className={markdownCodeBlockLabelClassName}
-          title={languageLabel === "code" ? "Code block" : `${languageLabel} code block`}
-        >
-          {languageLabel}
-        </span>
-        {enableCopy && (
-          <button
-            onClick={handleCopy}
-            className={markdownCodeBlockCopyButtonClassName}
-            title={copied ? "Copied!" : "Copy code"}
-            type="button"
-          >
-            {copied ? <Check className="h-3 w-3" /> : <Copy className="h-3 w-3" />}
-          </button>
-        )}
-      </div>
-      <StaticCodeBlock
-        code={children}
-        language={language}
-        isDark={isDark}
-        colorTheme={colorTheme}
-        style={markdownCodeBlockPreStyle}
-      />
-    </div>
+    <MarkdownCodeBlock
+      code={children}
+      colorTheme={colorTheme}
+      enableCopy={enableCopy}
+      isDark={isDark}
+      language={language}
+    />
   );
-}
-
-function codeBlockLanguageLabel(language: string | undefined): string {
-  const trimmed = language?.trim();
-  if (!trimmed) return "code";
-  return trimmed;
 }
 
 function textFromReactNode(node: ReactNode): string {


### PR DESCRIPTION
## Summary

- Let the Elements markdown typography fixture use the full document width by hiding the right page rail on that focused reading surface.
- Tune blockquotes toward a more document-native treatment with a stronger rule and better text contrast.
- Flatten evidence tables into the document flow by removing the raised card wrapper while keeping numeric alignment and dense borders.
- Share the fenced-code block chrome between projected markdown and markdown output so the language label, copy control, and highlighter stay aligned.
- Scope outline Playwright link clicks to the outline panel so heading permalink anchors do not collide with same-named outline entries.

## Validation

- `pnpm test:run src/components/markdown/__tests__/ProjectedMarkdownView.test.tsx src/components/outputs/__tests__/markdown-output.test.tsx`
- `pnpm elements:build`
- `pnpm --dir apps/notebook test:e2e:browser -- --project=chromium --workers=1 e2e/notebook-rail-outline.spec.ts e2e/markdown-parity.spec.ts:27`
- `cargo xtask lint --fix`
