### PR TITLE
fix(notebook-cloud): cap app session display names

### DIFF
--- a/apps/notebook-cloud/src/app-session.ts
+++ b/apps/notebook-cloud/src/app-session.ts
@@ -24,6 +24,7 @@ interface CloudAppSessionPayload {
 }
 
 export const NOTEBOOK_CLOUD_APP_SESSION_COOKIE_NAME = "__Host-nteract_cloud_app_session";
+export const NOTEBOOK_CLOUD_APP_SESSION_DISPLAY_NAME_MAX_LENGTH = 128;
 export const NOTEBOOK_CLOUD_APP_SESSION_MAX_AGE_SECONDS = 6 * 60 * 60;
 export const NOTEBOOK_CLOUD_APP_SESSION_SECRET_MIN_LENGTH = 32;
 
@@ -41,6 +42,7 @@ export async function createCloudAppSessionCookie(
   if (identity.metadata.provider !== "oidc") {
     throw new Error("app sessions require OIDC identity");
   }
+  const displayName = appSessionDisplayName(identity.metadata.displayName);
   const payload: CloudAppSessionPayload = {
     v: 1,
     provider: "oidc",
@@ -48,7 +50,7 @@ export async function createCloudAppSessionCookie(
     ns: identity.metadata.principalNamespace,
     iat: nowSeconds,
     exp: nowSeconds + NOTEBOOK_CLOUD_APP_SESSION_MAX_AGE_SECONDS,
-    ...(identity.metadata.displayName ? { display_name: identity.metadata.displayName } : {}),
+    ...(displayName ? { display_name: displayName } : {}),
   };
   const value = await signCloudAppSession(env, payload);
   return `${NOTEBOOK_CLOUD_APP_SESSION_COOKIE_NAME}=${value}; Path=/; Max-Age=${NOTEBOOK_CLOUD_APP_SESSION_MAX_AGE_SECONDS}; HttpOnly; Secure; SameSite=Lax`;
@@ -145,6 +147,10 @@ function appSessionSecret(env: AppSessionEnvironment): string | null {
     return null;
   }
   return secret;
+}
+
+function appSessionDisplayName(value: string | undefined): string | undefined {
+  return value?.slice(0, NOTEBOOK_CLOUD_APP_SESSION_DISPLAY_NAME_MAX_LENGTH);
 }
 
 function cookieValue(header: string | null, name: string): string | null {

--- a/apps/notebook-cloud/test/app-session.test.ts
+++ b/apps/notebook-cloud/test/app-session.test.ts
@@ -2,6 +2,7 @@ import assert from "node:assert/strict";
 import { describe, it } from "node:test";
 import {
   NOTEBOOK_CLOUD_APP_SESSION_COOKIE_NAME,
+  NOTEBOOK_CLOUD_APP_SESSION_DISPLAY_NAME_MAX_LENGTH,
   NOTEBOOK_CLOUD_APP_SESSION_MAX_AGE_SECONDS,
   clearCloudAppSessionCookie,
   createCloudAppSessionCookie,
@@ -52,6 +53,31 @@ describe("cloud app session cookies", () => {
       expiresAt: 2_000 + NOTEBOOK_CLOUD_APP_SESSION_MAX_AGE_SECONDS,
       displayName: "OIDC User",
     });
+  });
+
+  it("caps the display name signed into the cookie", async () => {
+    const displayName = "A".repeat(NOTEBOOK_CLOUD_APP_SESSION_DISPLAY_NAME_MAX_LENGTH + 50);
+    const cookie = await createCloudAppSessionCookie(
+      { NOTEBOOK_CLOUD_APP_SESSION_SECRET: SESSION_SECRET },
+      oidcIdentity({ displayName }),
+      2_500,
+    );
+    const request = new Request("https://cloud.test/n", {
+      headers: { Cookie: cookie },
+    });
+
+    const session = await readCloudAppSession(
+      { NOTEBOOK_CLOUD_APP_SESSION_SECRET: SESSION_SECRET },
+      request,
+      2_600,
+    );
+
+    assert.equal(
+      session?.displayName,
+      displayName.slice(0, NOTEBOOK_CLOUD_APP_SESSION_DISPLAY_NAME_MAX_LENGTH),
+    );
+    assert.notEqual(session?.displayName, displayName);
+    assert.equal(session?.displayName.length, NOTEBOOK_CLOUD_APP_SESSION_DISPLAY_NAME_MAX_LENGTH);
   });
 
   it("rejects expired and tampered sessions", async () => {
@@ -107,7 +133,7 @@ describe("cloud app session cookies", () => {
   });
 });
 
-function oidcIdentity(): AuthenticatedConnection {
+function oidcIdentity(overrides: { displayName?: string } = {}): AuthenticatedConnection {
   return {
     principal: "user:anaconda:subject-a",
     operator: "browser:tab",
@@ -117,7 +143,7 @@ function oidcIdentity(): AuthenticatedConnection {
       provider: "oidc",
       transport: "oidc-bearer",
       principalNamespace: "user:anaconda",
-      displayName: "OIDC User",
+      displayName: overrides.displayName ?? "OIDC User",
       email: "user@example.test",
       emailVerified: true,
     },


### PR DESCRIPTION
## Summary

- cap the OIDC display name signed into the notebook-cloud app-session cookie at 128 characters
- keep the signed payload bounded without adding raw identity claims or changing cookie auth semantics
- cover oversized names in the app-session cookie tests

## Validation

- `pnpm --dir apps/notebook-cloud exec node --import tsx --test test/app-session.test.ts test/worker-routes.test.ts`
- `pnpm --dir apps/notebook-cloud typecheck`
- `cargo xtask lint --fix`
- `pnpm --dir apps/notebook-cloud exec node --import tsx --test test/app-session.test.ts`
