### PR TITLE
feat(notebook): share runtime command projection

### DIFF
--- a/apps/notebook-cloud/package.json
+++ b/apps/notebook-cloud/package.json
@@ -37,6 +37,7 @@
     "lucide-react": "^0.513.0",
     "react": "^19.1.0",
     "react-dom": "^19.1.0",
+    "rxjs": "^7.8.2",
     "runtimed": "workspace:*"
   },
   "devDependencies": {

--- a/apps/notebook-cloud/test/serialized-cell-changes.test.ts
+++ b/apps/notebook-cloud/test/serialized-cell-changes.test.ts
@@ -1,0 +1,111 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+import { Subject } from "rxjs";
+import { subscribeSerializedCloudCellChanges } from "../viewer/serialized-cell-changes";
+
+function deferred<T = void>() {
+  let resolve!: (value: T | PromiseLike<T>) => void;
+  let reject!: (reason?: unknown) => void;
+  const promise = new Promise<T>((promiseResolve, promiseReject) => {
+    resolve = promiseResolve;
+    reject = promiseReject;
+  });
+  return { promise, reject, resolve };
+}
+
+async function flushMicrotasks(times = 4): Promise<void> {
+  for (let index = 0; index < times; index += 1) {
+    await Promise.resolve();
+  }
+}
+
+test("serialized cloud cell changes wait for prior materialization to finish", async () => {
+  const cellChanges$ = new Subject<string>();
+  const first = deferred();
+  const second = deferred();
+  const started: string[] = [];
+  const completed: string[] = [];
+
+  const subscription = subscribeSerializedCloudCellChanges({
+    cellChanges$,
+    materializeChangeset: async (changeset) => {
+      started.push(changeset);
+      await (changeset === "first" ? first.promise : second.promise);
+      completed.push(changeset);
+    },
+  });
+
+  cellChanges$.next("first");
+  cellChanges$.next("second");
+  await flushMicrotasks();
+
+  assert.deepEqual(started, ["first"]);
+  assert.deepEqual(completed, []);
+
+  first.resolve();
+  await flushMicrotasks();
+
+  assert.deepEqual(started, ["first", "second"]);
+  assert.deepEqual(completed, ["first"]);
+
+  second.resolve();
+  await flushMicrotasks();
+
+  assert.deepEqual(completed, ["first", "second"]);
+
+  subscription.unsubscribe();
+});
+
+test("serialized cloud cell changes keep processing after materialization errors", async () => {
+  const cellChanges$ = new Subject<string>();
+  const started: string[] = [];
+  const errors: unknown[] = [];
+
+  const subscription = subscribeSerializedCloudCellChanges({
+    cellChanges$,
+    materializeChangeset: async (changeset) => {
+      started.push(changeset);
+      if (changeset === "bad") {
+        throw new Error("bad changeset");
+      }
+    },
+    onMaterializationError: (error) => {
+      errors.push(error);
+    },
+  });
+
+  cellChanges$.next("bad");
+  cellChanges$.next("next");
+  await flushMicrotasks();
+
+  assert.deepEqual(started, ["bad", "next"]);
+  assert.equal(errors.length, 1);
+  assert.match(errors[0] instanceof Error ? errors[0].message : String(errors[0]), /bad changeset/);
+
+  subscription.unsubscribe();
+});
+
+test("serialized cloud cell changes suppress in-flight errors after unsubscribe", async () => {
+  const cellChanges$ = new Subject<string>();
+  const inFlight = deferred();
+  const errors: unknown[] = [];
+
+  const subscription = subscribeSerializedCloudCellChanges({
+    cellChanges$,
+    materializeChangeset: async () => {
+      await inFlight.promise;
+    },
+    onMaterializationError: (error) => {
+      errors.push(error);
+    },
+  });
+
+  cellChanges$.next("slow");
+  await flushMicrotasks();
+  subscription.unsubscribe();
+
+  inFlight.reject(new Error("after unsubscribe"));
+  await flushMicrotasks();
+
+  assert.deepEqual(errors, []);
+});

--- a/apps/notebook-cloud/test/viewer-notices.test.ts
+++ b/apps/notebook-cloud/test/viewer-notices.test.ts
@@ -42,6 +42,32 @@ test("cloud notebook notices render nothing for ready anonymous viewers", () => 
   assert.equal(html, "");
 });
 
+test("cloud notebook notices suppress stale empty status when cells are readable", () => {
+  assert.equal(
+    cloudNotebookHasNotices({
+      authState: authState("anonymous"),
+      authRenewal: { kind: "idle", message: null },
+      connectionError: null,
+      hasReadableSnapshot: true,
+      status: { kind: "empty", message: "This notebook room has no cells yet." },
+    }),
+    false,
+  );
+
+  const html = renderToStaticMarkup(
+    React.createElement(CloudNotebookNotices, {
+      authState: authState("anonymous"),
+      authRenewal: { kind: "idle", message: null },
+      connectionError: null,
+      hasReadableSnapshot: true,
+      status: { kind: "empty", message: "This notebook room has no cells yet." },
+      onResetAuth: () => {},
+    }),
+  );
+
+  assert.equal(html, "");
+});
+
 test("cloud notebook notices render auth and connection policy through the shared stack", () => {
   const html = renderToStaticMarkup(
     React.createElement(CloudNotebookNotices, {

--- a/apps/notebook-cloud/test/viewer-shared-cell-surface.test.ts
+++ b/apps/notebook-cloud/test/viewer-shared-cell-surface.test.ts
@@ -269,6 +269,9 @@ test("cloud edit mode chrome renders through the shared shell component", () => 
   );
   assert.match(sourceText, /reserveCommandToolbar=\{editAccessPending\}/);
   assert.match(sourceText, /addCellControlsDisabled: editAccessPending/);
+  assert.match(sourceText, /runtimeStatus: cloudRuntimeStatus/);
+  assert.match(sourceText, /onInterruptRuntime: handleCloudInterruptRuntime/);
+  assert.match(sourceText, /onRunAllCells: handleCloudRunAllCells/);
   assert.doesNotMatch(sourceText, /CloudNotebookEditModePlaceholder/);
   assert.doesNotMatch(sourceText, /CloudNotebookCommandToolbarPlaceholder/);
   assert.doesNotMatch(cssText, /cloud-edit-mode-placeholder/);

--- a/apps/notebook-cloud/test/viewer-shared-cell-surface.test.ts
+++ b/apps/notebook-cloud/test/viewer-shared-cell-surface.test.ts
@@ -56,18 +56,20 @@ test("cloud projects live cells into the NotebookView stores", () => {
 
   assert.match(
     sessionSourceText,
-    /useLayoutEffect\(\(\) => \{[\s\S]*cellsRef\.current = cells;[\s\S]*projectCloudCellsIntoNotebookViewStores\(cells\);/,
+    /useLayoutEffect\(\(\) => \{[\s\S]*projectCloudCellsIntoNotebookViewStores\(cells\);/,
   );
   assert.match(sourceText, /<CrdtBridgeProvider[\s\S]*getHandle=\{getLiveNotebookHandle\}/);
   assert.match(sourceText, /<CrdtBridgeProvider[\s\S]*canWriteSource=\{canWriteCellSource\}/);
   assert.match(sourceText, /<CrdtBridgeProvider[\s\S]*onSyncNeeded=\{handleSourceSyncNeeded\}/);
-  assert.match(sourceText, /cell\.cellType === "markdown"/);
+  assert.match(sourceText, /const cell = getCellById\(cellId\);/);
+  assert.match(sourceText, /cell\.cell_type === "markdown"/);
   assert.match(sourceText, /return shellCapabilities\.canEditMarkdown/);
   assert.match(sourceText, /return shellCapabilities\.canEditCells/);
   assert.match(
     sourceText,
     /if \(!shellCapabilities\.canEditCells && !shellCapabilities\.canEditMarkdown\) return;/,
   );
+  assert.doesNotMatch(sourceText, /cellsByIdRef/);
   assert.doesNotMatch(sourceText, /handleMarkdownSyncNeeded/);
   assert.doesNotMatch(sourceText, /onSourceChanged=/);
 });
@@ -382,7 +384,25 @@ test("cloud live materialization skips empty room handles before resolving outpu
   assert.match(sessionSourceText, /const rawCellCount = liveRuntime\.handle\.cell_count\(\);/);
   assert.match(
     sessionSourceText,
-    /if \(rawCellCount === 0 && \(!snapshotResolvedRef\.current \|\| cellsRef\.current\.length > 0\)\) \{\s+return;\s+\}\s+const materialized = await materializeCloudNotebookView/,
+    /if \(rawCellCount === 0 && \(!snapshotResolvedRef\.current \|\| materializedCellCount\(\) > 0\)\) \{\s+return;\s+\}\s+const materialized = await materializeCloudNotebookView/,
+  );
+});
+
+test("cloud live cell changes use serialized incremental materialization", () => {
+  const sessionSourcePath = new URL("../viewer/cloud-viewer-session.ts", import.meta.url);
+  const sessionSourceText = readFileSync(sessionSourcePath, "utf8");
+
+  assert.match(
+    sessionSourceText,
+    /import \{ subscribeSerializedCloudCellChanges \} from "\.\/serialized-cell-changes";/,
+  );
+  assert.match(sessionSourceText, /subscribeSerializedCloudCellChanges\(\{/);
+  assert.match(sessionSourceText, /cellChanges\$: liveRuntime\.engine\.cellChanges\$/);
+  assert.match(sessionSourceText, /materializeChangeset\(changeset, \{/);
+  assert.match(sessionSourceText, /blobResolver,/);
+  assert.doesNotMatch(
+    sessionSourceText,
+    /cellChanges\$\s*\.subscribe\(\(\) => materializeLiveCellsSafely/,
   );
 });
 

--- a/apps/notebook-cloud/test/viewer-shared-cell-surface.test.ts
+++ b/apps/notebook-cloud/test/viewer-shared-cell-surface.test.ts
@@ -54,7 +54,7 @@ test("cloud projects live cells into the NotebookView stores", () => {
   const sessionSourcePath = new URL("../viewer/cloud-viewer-session.ts", import.meta.url);
   const sessionSourceText = readFileSync(sessionSourcePath, "utf8");
 
-  assert.match(
+  assert.doesNotMatch(
     sessionSourceText,
     /useLayoutEffect\(\(\) => \{[\s\S]*projectCloudCellsIntoNotebookViewStores\(cells\);/,
   );

--- a/apps/notebook-cloud/test/viewer-shared-cell-surface.test.ts
+++ b/apps/notebook-cloud/test/viewer-shared-cell-surface.test.ts
@@ -58,6 +58,13 @@ test("cloud projects live cells into the NotebookView stores", () => {
     sessionSourceText,
     /useLayoutEffect\(\(\) => \{[\s\S]*projectCloudCellsIntoNotebookViewStores\(cells\);/,
   );
+  assert.match(
+    sessionSourceText,
+    /const applyResolvedCells = useCallback\(\(resolvedCells: ResolvedCell\[\]\) => \{[\s\S]*projectCloudCellsIntoNotebookViewStores\(resolvedCells\);[\s\S]*setCells\(resolvedCells\);/,
+  );
+  assert.match(sessionSourceText, /applyResolvedCells\(syncCells\);/);
+  assert.match(sessionSourceText, /applyResolvedCells\(progressiveCells\);/);
+  assert.match(sessionSourceText, /applyResolvedCells\(resolvedCells\);/);
   assert.match(sourceText, /<CrdtBridgeProvider[\s\S]*getHandle=\{getLiveNotebookHandle\}/);
   assert.match(sourceText, /<CrdtBridgeProvider[\s\S]*canWriteSource=\{canWriteCellSource\}/);
   assert.match(sourceText, /<CrdtBridgeProvider[\s\S]*onSyncNeeded=\{handleSourceSyncNeeded\}/);

--- a/apps/notebook-cloud/test/viewer-shared-cell-surface.test.ts
+++ b/apps/notebook-cloud/test/viewer-shared-cell-surface.test.ts
@@ -81,6 +81,20 @@ test("cloud projects live cells into the NotebookView stores", () => {
   assert.doesNotMatch(sourceText, /onSourceChanged=/);
 });
 
+test("cloud live changesets gate stale post-await status writes", () => {
+  const sessionSourcePath = new URL("../viewer/cloud-viewer-session.ts", import.meta.url);
+  const sessionSourceText = readFileSync(sessionSourcePath, "utf8");
+
+  assert.match(
+    sessionSourceText,
+    /const materializeLiveCells = async[\s\S]*\+\+materializeSequence/,
+  );
+  assert.match(
+    sessionSourceText,
+    /const materializeLiveChangeset = async[\s\S]*const sequence = materializeSequence;[\s\S]*await materializeChangeset[\s\S]*if \(disposed \|\| sequence !== materializeSequence\) return;[\s\S]*applyExecutionViewChangeset/,
+  );
+});
+
 test("cloud notebook mutations route through the shared notebook controller", () => {
   const sourcePath = new URL("../viewer/index.tsx", import.meta.url);
   const sourceText = readFileSync(sourcePath, "utf8");

--- a/apps/notebook-cloud/viewer/cloud-viewer-session.ts
+++ b/apps/notebook-cloud/viewer/cloud-viewer-session.ts
@@ -149,6 +149,11 @@ export function useCloudViewerSession({
     projectCloudCellsIntoNotebookViewStores(cells);
   }, [cells]);
 
+  const applyResolvedCells = useCallback((resolvedCells: ResolvedCell[]) => {
+    projectCloudCellsIntoNotebookViewStores(resolvedCells);
+    setCells(resolvedCells);
+  }, []);
+
   useEffect(() => resetCloudViewStoreProjection, []);
 
   useEffect(() => {
@@ -276,7 +281,7 @@ export function useCloudViewerSession({
               if (syncCells.length === 0) return;
               markCloudViewerLoadMilestone("snapshot-initial-cells");
               preloadSiftWasm(syncCells);
-              setCells(syncCells);
+              applyResolvedCells(syncCells);
               setStatus({
                 kind: "loading",
                 message: `Rendering ${syncCells.length} cells while resolving output payloads...`,
@@ -285,7 +290,7 @@ export function useCloudViewerSession({
             onCellResolved(resolvedCell, _index, progressiveCells) {
               if (progressiveCells.length === 0) return;
               preloadSiftWasm([resolvedCell]);
-              setCells(progressiveCells);
+              applyResolvedCells(progressiveCells);
             },
           },
         });
@@ -306,7 +311,7 @@ export function useCloudViewerSession({
         if (cancelled || liveMaterializedRef.current) return;
         const resolvedCells = materialized.cells;
         preloadSiftWasm(resolvedCells);
-        setCells(resolvedCells);
+        applyResolvedCells(resolvedCells);
         if (resolvedCells.length === 0) {
           setStatus({ kind: "empty", message: "This published notebook has no cells." });
           return;
@@ -407,7 +412,7 @@ export function useCloudViewerSession({
             liveMaterializedRef.current = true;
             markCloudViewerLoadMilestone("live-initial-cells");
             preloadSiftWasm(syncCells);
-            setCells(syncCells);
+            applyResolvedCells(syncCells);
             setStatus({
               kind: "loading",
               message: `Rendering ${syncCells.length} live cells while resolving output payloads...`,
@@ -417,7 +422,7 @@ export function useCloudViewerSession({
             if (progressiveCells.length === 0) return;
             liveMaterializedRef.current = true;
             preloadSiftWasm([resolvedCell]);
-            setCells(progressiveCells);
+            applyResolvedCells(progressiveCells);
           },
         },
       });
@@ -444,7 +449,7 @@ export function useCloudViewerSession({
       liveMaterializedRef.current = true;
       const resolvedCells = materialized.cells;
       preloadSiftWasm(resolvedCells);
-      setCells(resolvedCells);
+      applyResolvedCells(resolvedCells);
       setStatus(
         resolvedCells.length === 0
           ? { kind: "empty", message: "This notebook room has no cells yet." }
@@ -631,6 +636,7 @@ export function useCloudViewerSession({
     connectAttempt,
     loadingPolicy.shouldConnectLiveRoom,
     presenceStore,
+    applyResolvedCells,
     preloadSiftWasm,
     widgetStore,
   ]);

--- a/apps/notebook-cloud/viewer/cloud-viewer-session.ts
+++ b/apps/notebook-cloud/viewer/cloud-viewer-session.ts
@@ -17,12 +17,16 @@ import {
   applyOutputChangeset,
   emitBroadcast,
   emitPresence,
+  getCellIdsSnapshot,
+  materializeChangeset,
   resetPoolState,
   resetRuntimeState,
   resetRuntimeStoresProjection,
   startCursorDispatch,
   setPoolState,
   setRuntimeState,
+  type CellChangeset,
+  type JupyterOutput as NotebookStoreJupyterOutput,
 } from "../../notebook/src/notebook-surface";
 import {
   cloudSyncAuthFromPrototypeAuthState,
@@ -41,6 +45,7 @@ import {
 import { CloudViewerPresenceStore } from "./presence";
 import { createOutputResolutionCache, type ResolvedCell } from "./render-resolution";
 import { loadSnapshotPairHandle } from "./runtimed-wasm-client";
+import { subscribeSerializedCloudCellChanges } from "./serialized-cell-changes";
 import { projectCloudWidgetComms } from "./widget-comm-projection";
 import type { CloudAuthRenewalState, ViewerStatus } from "./notice-types";
 
@@ -66,7 +71,6 @@ export interface CloudViewerConfig {
 }
 
 export interface CloudViewerSession {
-  cellsByIdRef: MutableRefObject<Map<string, ResolvedCell>>;
   connectionActorLabel: string | null;
   connectionError: string | null;
   connectionPeerId: string | null;
@@ -121,8 +125,6 @@ export function useCloudViewerSession({
   const [notebookMetadata, setNotebookMetadata] = useState<unknown>(null);
   const [workstationAttachment, setWorkstationAttachment] =
     useState<WorkstationAttachmentState | null>(null);
-  const cellsRef = useRef<ResolvedCell[]>([]);
-  const cellsByIdRef = useRef(new Map<string, ResolvedCell>());
   const notebookLanguageRef = useRef("python");
   const workstationAttachmentKeyRef = useRef(notebookShellWorkstationAttachmentCacheKey(null));
   const liveRuntimeRef = useRef<CloudSyncRuntime | null>(null);
@@ -131,6 +133,7 @@ export function useCloudViewerSession({
   const snapshotResolvedRef = useRef(false);
   const projectedWidgetCommIdsRef = useRef(new Set<string>());
   const outputResolutionCacheRef = useRef(createOutputResolutionCache());
+  const incrementalOutputCacheRef = useRef(new Map<string, NotebookStoreJupyterOutput>());
   const presenceStoreRef = useRef<CloudViewerPresenceStore | null>(null);
   if (presenceStoreRef.current === null) {
     presenceStoreRef.current = new CloudViewerPresenceStore();
@@ -143,8 +146,6 @@ export function useCloudViewerSession({
   const [connectAttempt, setConnectAttempt] = useState(0);
 
   useLayoutEffect(() => {
-    cellsRef.current = cells;
-    cellsByIdRef.current = new Map(cells.map((cell) => [cell.id, cell]));
     projectCloudCellsIntoNotebookViewStores(cells);
   }, [cells]);
 
@@ -385,12 +386,14 @@ export function useCloudViewerSession({
       }, 1_000);
     };
 
+    const materializedCellCount = () => getCellIdsSnapshot().length;
+
     const materializeLiveCells = async (liveRuntime: CloudSyncRuntime) => {
       const sequence = ++materializeSequence;
       const previousNotebookLanguage = notebookLanguageRef.current;
       const outputResolutionCache = outputResolutionCacheRef.current;
       const rawCellCount = liveRuntime.handle.cell_count();
-      if (rawCellCount === 0 && (!snapshotResolvedRef.current || cellsRef.current.length > 0)) {
+      if (rawCellCount === 0 && (!snapshotResolvedRef.current || materializedCellCount() > 0)) {
         return;
       }
       const materialized = await materializeCloudNotebookView(liveRuntime.handle, {
@@ -419,7 +422,7 @@ export function useCloudViewerSession({
         },
       });
       if (materialized.rawCellCount === 0) {
-        if (!snapshotResolvedRef.current || cellsRef.current.length > 0) {
+        if (!snapshotResolvedRef.current || materializedCellCount() > 0) {
           return;
         }
       }
@@ -453,6 +456,35 @@ export function useCloudViewerSession({
       if (resolvedCells.length > 0) {
         markCloudViewerLoadMilestone("live-ready");
       }
+    };
+
+    const materializeLiveChangeset = async (
+      changeset: CellChangeset | null,
+      liveRuntime: CloudSyncRuntime,
+    ) => {
+      await materializeChangeset(changeset, {
+        getHandle: () => liveRuntime.handle,
+        materializeCells: async () => materializeLiveCells(liveRuntime),
+        outputCache: incrementalOutputCacheRef.current,
+        blobResolver,
+      });
+      if (disposed) return;
+
+      applyExecutionViewChangeset(liveRuntime.handle.project_execution_view_changeset?.());
+
+      const currentCellCount = materializedCellCount();
+      if (currentCellCount === 0) {
+        if (snapshotResolvedRef.current) {
+          setStatus({ kind: "empty", message: "This notebook room has no cells yet." });
+        }
+        return;
+      }
+
+      liveMaterializedRef.current = true;
+      setStatus({
+        kind: "ready",
+        message: `Rendering ${currentCellCount} cells from the live notebook room.`,
+      });
     };
 
     const materializeLiveCellsSafely = (liveRuntime: CloudSyncRuntime) => {
@@ -515,8 +547,12 @@ export function useCloudViewerSession({
             emitPresence(payload);
             livePresenceStore?.handlePresence(payload);
           }),
-          liveRuntime.engine.cellChanges$.subscribe(() => {
-            materializeLiveCellsSafely(liveRuntime);
+          subscribeSerializedCloudCellChanges({
+            cellChanges$: liveRuntime.engine.cellChanges$,
+            materializeChangeset: (changeset) => materializeLiveChangeset(changeset, liveRuntime),
+            onMaterializationError: (error) => {
+              console.warn("[notebook-cloud] live changeset materialization failed", error);
+            },
           }),
           liveRuntime.engine.runtimeState$.subscribe((state) => {
             setRuntimeState(state);
@@ -546,7 +582,7 @@ export function useCloudViewerSession({
       })
       .catch((error: unknown) => {
         if (disposed) return;
-        if (cellsRef.current.length === 0) {
+        if (materializedCellCount() === 0) {
           setStatus({
             kind: "error",
             message: `Unable to load live notebook room: ${
@@ -608,7 +644,6 @@ export function useCloudViewerSession({
   }, []);
 
   return {
-    cellsByIdRef,
     connectionActorLabel,
     connectionError,
     connectionPeerId,

--- a/apps/notebook-cloud/viewer/cloud-viewer-session.ts
+++ b/apps/notebook-cloud/viewer/cloud-viewer-session.ts
@@ -1,11 +1,4 @@
-import {
-  useCallback,
-  useEffect,
-  useLayoutEffect,
-  useRef,
-  useState,
-  type MutableRefObject,
-} from "react";
+import { useCallback, useEffect, useRef, useState, type MutableRefObject } from "react";
 import {
   notebookShellWorkstationAttachmentCacheKey,
   type BlobResolver,
@@ -121,7 +114,7 @@ export function useCloudViewerSession({
     kind: "loading",
     message: loadingPolicy.initialStatusMessage,
   });
-  const [cells, setCells] = useState<ResolvedCell[]>([]);
+  const [, setCells] = useState<ResolvedCell[]>([]);
   const [notebookMetadata, setNotebookMetadata] = useState<unknown>(null);
   const [workstationAttachment, setWorkstationAttachment] =
     useState<WorkstationAttachmentState | null>(null);
@@ -144,10 +137,6 @@ export function useCloudViewerSession({
   const [connectionActorLabel, setConnectionActorLabel] = useState<string | null>(null);
   const [connectionError, setConnectionError] = useState<string | null>(null);
   const [connectAttempt, setConnectAttempt] = useState(0);
-
-  useLayoutEffect(() => {
-    projectCloudCellsIntoNotebookViewStores(cells);
-  }, [cells]);
 
   const applyResolvedCells = useCallback((resolvedCells: ResolvedCell[]) => {
     projectCloudCellsIntoNotebookViewStores(resolvedCells);

--- a/apps/notebook-cloud/viewer/cloud-viewer-session.ts
+++ b/apps/notebook-cloud/viewer/cloud-viewer-session.ts
@@ -456,13 +456,14 @@ export function useCloudViewerSession({
       changeset: CellChangeset | null,
       liveRuntime: CloudSyncRuntime,
     ) => {
+      const sequence = materializeSequence;
       await materializeChangeset(changeset, {
         getHandle: () => liveRuntime.handle,
         materializeCells: async () => materializeLiveCells(liveRuntime),
         outputCache: incrementalOutputCacheRef.current,
         blobResolver,
       });
-      if (disposed) return;
+      if (disposed || sequence !== materializeSequence) return;
 
       applyExecutionViewChangeset(liveRuntime.handle.project_execution_view_changeset?.());
 

--- a/apps/notebook-cloud/viewer/index.tsx
+++ b/apps/notebook-cloud/viewer/index.tsx
@@ -86,6 +86,7 @@ import {
   createNotebookController,
   NotebookView,
   PresenceValueProvider,
+  getCellById,
   setLoggerHost,
   setOpenUrlHost,
   useRuntimeState,
@@ -1561,7 +1562,6 @@ function NotebookViewer({
     [config.blobBasePath, config.rendererAssetsBasePath],
   );
   const {
-    cellsByIdRef,
     connectionActorLabel,
     connectionError,
     connectionPeerId,
@@ -1744,11 +1744,11 @@ function NotebookViewer({
   }, [canAcceptCellMutations, connectionPeerId, connectionScope, requestedEditAccess]);
   const canWriteCellSource = useCallback(
     (cellId: string) => {
-      const cell = cellsByIdRef.current.get(cellId);
+      const cell = getCellById(cellId);
       if (!cell) {
         return false;
       }
-      if (cell.cellType === "markdown") {
+      if (cell.cell_type === "markdown") {
         return shellCapabilities.canEditMarkdown;
       }
       return shellCapabilities.canEditCells;

--- a/apps/notebook-cloud/viewer/index.tsx
+++ b/apps/notebook-cloud/viewer/index.tsx
@@ -42,7 +42,9 @@ import {
   NotebookDocumentShell,
   NotebookPackageSummaryPanel,
   NotebookWorkstationsPanel,
+  projectNotebookCommandRuntimeStatusFromRuntimeState,
   shouldShowNotebookDocumentCommandToolbar,
+  type NotebookCommandToolbarStatus,
   type NotebookEnvironmentManager,
   type NotebookInteractionMode,
   type NotebookInteractionModeProjection,
@@ -86,6 +88,7 @@ import {
   PresenceValueProvider,
   setLoggerHost,
   setOpenUrlHost,
+  useRuntimeState,
   type PresenceContextValue,
 } from "../../notebook/src/notebook-surface";
 import {
@@ -1587,6 +1590,7 @@ function NotebookViewer({
     presenceStore.getSnapshot,
     presenceStore.getSnapshot,
   );
+  const runtimeState = useRuntimeState();
   const runtimePeerCount = cloudPresenceRuntimePeerCount(presenceSnapshot);
   const runtimePeerAvailable = cloudPresenceHasRuntimePeer(presenceSnapshot);
   const outputHostContext = useMemo<NteractEmbedHostContextPatch>(
@@ -1708,6 +1712,16 @@ function NotebookViewer({
       workstationAttachment,
     ],
   );
+  const cloudRuntimeStatus = useMemo<NotebookCommandToolbarStatus | null>(() => {
+    if (!shellCapabilities.runtime.connected && !shellCapabilities.runtime.executionAvailable) {
+      return null;
+    }
+    return projectNotebookCommandRuntimeStatusFromRuntimeState(runtimeState);
+  }, [
+    runtimeState,
+    shellCapabilities.runtime.connected,
+    shellCapabilities.runtime.executionAvailable,
+  ]);
   useEffect(() => {
     if (!requestedEditAccess) {
       appliedGrantedEditScopeRef.current = null;
@@ -1805,30 +1819,67 @@ function NotebookViewer({
     },
     [cloudNotebookController],
   );
-  const handleCloudExecuteCell = useCallback((cellId: string) => {
-    const liveRuntime = liveRuntimeRef.current;
-    if (!liveRuntime) {
-      console.warn("[notebook-cloud] cannot execute cell without a live room connection");
-      return;
-    }
+  const createCloudNotebookClient = useCallback(
+    (action: string) => {
+      const liveRuntime = liveRuntimeRef.current;
+      if (!liveRuntime) {
+        console.warn(`[notebook-cloud] cannot ${action} without a live room connection`);
+        return null;
+      }
+      return {
+        liveRuntime,
+        client: new NotebookClient({
+          transport: liveRuntime.transport,
+          logger: console,
+          getRequiredHeads: () => liveRuntime.handle.get_heads_hex(),
+        }),
+      };
+    },
+    [liveRuntimeRef],
+  );
+  const handleCloudExecuteCell = useCallback(
+    (cellId: string) => {
+      const runtimeClient = createCloudNotebookClient("execute cell");
+      if (!runtimeClient) return;
+
+      void (async () => {
+        const delivered = await runtimeClient.liveRuntime.engine.flushAndWait();
+        if (!delivered) {
+          console.warn("[notebook-cloud] execute cell request skipped; notebook sync failed");
+          return;
+        }
+
+        await runtimeClient.client.executeCell(cellId);
+      })().catch((error: unknown) => {
+        console.warn("[notebook-cloud] execute cell request failed", error);
+      });
+    },
+    [createCloudNotebookClient],
+  );
+  const handleCloudRunAllCells = useCallback(() => {
+    const runtimeClient = createCloudNotebookClient("run all cells");
+    if (!runtimeClient) return;
 
     void (async () => {
-      const delivered = await liveRuntime.engine.flushAndWait();
+      const delivered = await runtimeClient.liveRuntime.engine.flushAndWait();
       if (!delivered) {
-        console.warn("[notebook-cloud] execute cell request skipped; notebook sync failed");
+        console.warn("[notebook-cloud] run all cells request skipped; notebook sync failed");
         return;
       }
 
-      const client = new NotebookClient({
-        transport: liveRuntime.transport,
-        logger: console,
-        getRequiredHeads: () => liveRuntime.handle.get_heads_hex(),
-      });
-      await client.executeCell(cellId);
+      await runtimeClient.client.runAllCells();
     })().catch((error: unknown) => {
-      console.warn("[notebook-cloud] execute cell request failed", error);
+      console.warn("[notebook-cloud] run all cells request failed", error);
     });
-  }, []);
+  }, [createCloudNotebookClient]);
+  const handleCloudInterruptRuntime = useCallback(() => {
+    const runtimeClient = createCloudNotebookClient("interrupt kernel");
+    if (!runtimeClient) return;
+
+    void runtimeClient.client.interruptKernel().catch((error: unknown) => {
+      console.warn("[notebook-cloud] interrupt kernel request failed", error);
+    });
+  }, [createCloudNotebookClient]);
   const handleCloudSetCellSourceHidden = useCallback(
     (cellId: string, hidden: boolean) => {
       cloudNotebookController.setCellSourceHidden(cellId, hidden);
@@ -2090,9 +2141,12 @@ function NotebookViewer({
         runtime: toolbarRuntime,
         environmentManager: toolbarEnvironmentManager,
         environmentPanelOpen: activeRailPanel === "packages" && !railCollapsed,
+        runtimeStatus: cloudRuntimeStatus,
         addCellControlsDisabled: editAccessPending,
         addAfterCellId: toolbarAddAfterCellId,
         onAddCell: handleCloudAddCell,
+        onInterruptRuntime: handleCloudInterruptRuntime,
+        onRunAllCells: handleCloudRunAllCells,
         onTogglePackages: handleTogglePackagesRail,
       }}
     />

--- a/apps/notebook-cloud/viewer/notices.tsx
+++ b/apps/notebook-cloud/viewer/notices.tsx
@@ -30,7 +30,9 @@ export function cloudNotebookHasNotices({
     ? cloudConnectionNoticeDisplay(connectionError, hasReadableSnapshot)
     : null;
   const shouldShowStatusNotice =
-    status.kind !== "ready" && !isStatusDerivedFromConnectionError(status, connectionError);
+    status.kind !== "ready" &&
+    !(status.kind === "empty" && hasReadableSnapshot) &&
+    !isStatusDerivedFromConnectionError(status, connectionError);
 
   return (
     authState.mode === "invalid" ||
@@ -68,7 +70,9 @@ export function CloudNotebookNotices({
     ? cloudConnectionNoticeDisplay(connectionError, hasReadableSnapshot)
     : null;
   const shouldShowStatusNotice =
-    status.kind !== "ready" && !isStatusDerivedFromConnectionError(status, connectionError);
+    status.kind !== "ready" &&
+    !(status.kind === "empty" && hasReadableSnapshot) &&
+    !isStatusDerivedFromConnectionError(status, connectionError);
 
   return (
     <NotebookNoticeStack>

--- a/apps/notebook-cloud/viewer/serialized-cell-changes.ts
+++ b/apps/notebook-cloud/viewer/serialized-cell-changes.ts
@@ -1,0 +1,26 @@
+import { EMPTY, catchError, concatMap, defer, type Observable, type Subscription } from "rxjs";
+
+interface SerializedCloudCellChangesOptions<TChangeset> {
+  cellChanges$: Observable<TChangeset>;
+  materializeChangeset: (changeset: TChangeset) => Promise<void>;
+  onMaterializationError?: (error: unknown) => void;
+}
+
+export function subscribeSerializedCloudCellChanges<TChangeset>({
+  cellChanges$,
+  materializeChangeset,
+  onMaterializationError,
+}: SerializedCloudCellChangesOptions<TChangeset>): Subscription {
+  return cellChanges$
+    .pipe(
+      concatMap((changeset) =>
+        defer(() => materializeChangeset(changeset)).pipe(
+          catchError((error: unknown) => {
+            onMaterializationError?.(error);
+            return EMPTY;
+          }),
+        ),
+      ),
+    )
+    .subscribe();
+}

--- a/apps/notebook/src/components/NotebookToolbar.tsx
+++ b/apps/notebook/src/components/NotebookToolbar.tsx
@@ -6,7 +6,7 @@ import {
   NotebookNotice,
   NotebookNoticeAction,
   NotebookToolbarFrame,
-  type NotebookCommandRuntimeState,
+  projectNotebookCommandRuntimeStatus,
   type NotebookEnvironmentManager,
   type NotebookShellCapabilities,
 } from "@/components/notebook";
@@ -129,6 +129,11 @@ export function NotebookToolbar({
   // has been smoothed over sub-60ms blips; every other sub-state (launching,
   // resolving, …) passes through untouched with its richer label.
   const kernelStatusText = getStatusKeyLabel(statusKey, errorReason);
+  const commandRuntimeStatus = projectNotebookCommandRuntimeStatus({
+    statusKey,
+    errorReason,
+    forceError: Boolean(envProgress?.error),
+  });
   const hasToolbarHandledIpykernelError =
     errorReason === KERNEL_ERROR_REASON.MISSING_IPYKERNEL ||
     errorReason === KERNEL_ERROR_REASON.DEPENDENCY_CACHE_MISSING_IPYKERNEL ||
@@ -179,7 +184,6 @@ export function NotebookToolbar({
             : "uv"
         : (envTypeHint ?? null)
       : null;
-  const runtimeStatusState = notebookCommandRuntimeState(kernelStatus, Boolean(envErrorMessage));
   const runtimeStatusError = envErrorMessage ? (
     <HoverCard openDelay={150} closeDelay={100}>
       <HoverCardTrigger asChild>
@@ -250,7 +254,7 @@ export function NotebookToolbar({
         environmentPanelOpen={isDepsOpen}
         environmentOutOfSync={depsOutOfSync}
         runtimeStatus={{
-          state: runtimeStatusState,
+          state: commandRuntimeStatus.state,
           label: envProgress?.isActive ? (
             envStatusText
           ) : (
@@ -290,31 +294,6 @@ export function NotebookToolbar({
       />
     </NotebookToolbarFrame>
   );
-}
-
-function notebookCommandRuntimeState(
-  kernelStatus: KernelStatus,
-  hasEnvironmentError: boolean,
-): NotebookCommandRuntimeState {
-  if (hasEnvironmentError) {
-    return "error";
-  }
-  switch (kernelStatus) {
-    case KERNEL_STATUS.NOT_STARTED:
-    case KERNEL_STATUS.AWAITING_TRUST:
-    case KERNEL_STATUS.AWAITING_ENV_BUILD:
-      return "not_started";
-    case KERNEL_STATUS.STARTING:
-      return "starting";
-    case KERNEL_STATUS.IDLE:
-      return "idle";
-    case KERNEL_STATUS.BUSY:
-      return "busy";
-    case KERNEL_STATUS.ERROR:
-      return "error";
-    case KERNEL_STATUS.SHUTDOWN:
-      return "shutdown";
-  }
 }
 
 /** Remediation copy for `KernelErrorReason::MissingIpykernel`, branched by

--- a/apps/notebook/src/lib/frame-pipeline.ts
+++ b/apps/notebook/src/lib/frame-pipeline.ts
@@ -10,7 +10,11 @@ import {
   needsPlugin,
   preWarmForMimes,
 } from "@/components/isolated/iframe-libraries";
-import { isDisplayCapableJupyterOutputType, planCellChangesetProjection } from "runtimed";
+import {
+  isDisplayCapableJupyterOutputType,
+  planCellChangesetProjection,
+  type BlobResolver,
+} from "runtimed";
 import type { JupyterOutput } from "../types";
 import type { NotebookHandle } from "../wasm/runtimed-wasm/runtimed_wasm.js";
 import { getBlobResolver } from "./blob-port";
@@ -46,6 +50,9 @@ export interface MaterializeDeps {
 
   /** Shared output manifest cache (mutated in place). */
   outputCache: Map<string, JupyterOutput>;
+
+  /** Host-provided blob resolver. Defaults to the desktop daemon resolver. */
+  blobResolver?: BlobResolver | null;
 }
 
 // ── Plugin pre-warm helper ──────────────────────────────────────────
@@ -119,7 +126,7 @@ export async function materializeChangeset(
   // ── Per-cell incremental materialization ───────────────────────────
 
   const cache = deps.outputCache;
-  const blobResolver = getBlobResolver();
+  const blobResolver = "blobResolver" in deps ? (deps.blobResolver ?? null) : getBlobResolver();
   let cellStoreTouched = 0;
   let outputOnlySkipped = 0;
 

--- a/apps/notebook/src/lib/kernel-status.ts
+++ b/apps/notebook/src/lib/kernel-status.ts
@@ -5,9 +5,12 @@
  */
 
 export {
+  getLifecycleLabel,
+  getStatusKeyLabel,
   isKernelStatus,
   KERNEL_STATUS,
   RUNTIME_STATUS,
+  RUNTIME_STATUS_LABELS,
   runtimeStatusKey,
   statusKeyToLegacyStatus,
   type KernelActivity,
@@ -17,78 +20,11 @@ export {
 } from "runtimed";
 
 import {
-  KERNEL_ERROR_REASON,
   KERNEL_STATUS,
   RUNTIME_STATUS,
-  runtimeStatusKey,
   type KernelStatus,
-  type RuntimeLifecycle,
   type RuntimeStatusKey,
 } from "runtimed";
-
-const ERROR_REASON_LABELS: Record<string, string> = {
-  [KERNEL_ERROR_REASON.ENVIRONMENT_PREPARE_FAILED]: "environment setup failed",
-  [KERNEL_ERROR_REASON.MISSING_IPYKERNEL]: "ipykernel missing",
-  [KERNEL_ERROR_REASON.DEPENDENCY_CACHE_MISSING_IPYKERNEL]: "ipykernel missing",
-  [KERNEL_ERROR_REASON.IPYKERNEL_SITE_PACKAGES_MISMATCH]: "Python environment mismatch",
-  [KERNEL_ERROR_REASON.CONDA_ENV_YML_MISSING]: "Conda environment missing",
-};
-
-/**
- * User-facing label for each expanded [`RuntimeStatusKey`].
- *
- * Keyed by the flat runtime vocabulary so every lifecycle variant
- * (including each starting sub-phase and all three `Running(_)` cases)
- * gets a dedicated label. Exhaustive `Record` — adding a variant to
- * `RuntimeLifecycle` will fail to typecheck here until a label is added.
- */
-export const RUNTIME_STATUS_LABELS: Record<RuntimeStatusKey, string> = {
-  [RUNTIME_STATUS.NOT_STARTED]: "initializing",
-  [RUNTIME_STATUS.AWAITING_TRUST]: "awaiting approval",
-  [RUNTIME_STATUS.AWAITING_ENV_BUILD]: "awaiting environment build",
-  [RUNTIME_STATUS.RESOLVING]: "resolving environment",
-  [RUNTIME_STATUS.PREPARING_ENV]: "preparing environment",
-  [RUNTIME_STATUS.LAUNCHING]: "launching kernel",
-  [RUNTIME_STATUS.CONNECTING]: "connecting to kernel",
-  [RUNTIME_STATUS.RUNNING_IDLE]: "idle",
-  [RUNTIME_STATUS.RUNNING_BUSY]: "busy",
-  [RUNTIME_STATUS.RUNNING_UNKNOWN]: "running",
-  [RUNTIME_STATUS.ERROR]: "error",
-  [RUNTIME_STATUS.SHUTDOWN]: "shutdown",
-};
-
-/**
- * Render a user-facing label for a [`RuntimeStatusKey`].
- *
- * Uses the expanded vocabulary — each starting sub-phase and each
- * `Running(_)` activity get their own label. The `Error` case appends
- * the typed reason when one is present; other states ignore `errorReason`.
- *
- * Prefer this form when the caller already has a (possibly throttled)
- * status key. Call sites that still hold the raw lifecycle can use
- * [`getLifecycleLabel`] which projects first.
- */
-export function getStatusKeyLabel(key: RuntimeStatusKey, errorReason: string | null): string {
-  if (key === RUNTIME_STATUS.ERROR && errorReason && errorReason.length > 0) {
-    return `error: ${ERROR_REASON_LABELS[errorReason] ?? "kernel failed"}`;
-  }
-  return RUNTIME_STATUS_LABELS[key];
-}
-
-/**
- * Render a user-facing label for the typed runtime lifecycle.
- *
- * Thin wrapper around [`getStatusKeyLabel`] that projects the lifecycle
- * to a [`RuntimeStatusKey`] first. Use the key form directly when you
- * have already throttled the `Running(Idle)` / `Running(Busy)` flicker
- * upstream.
- */
-export function getLifecycleLabel(
-  lifecycle: RuntimeLifecycle,
-  errorReason: string | null,
-): string {
-  return getStatusKeyLabel(runtimeStatusKey(lifecycle), errorReason);
-}
 
 export function getTrustApprovalHandoffDisplayStatus({
   pending,

--- a/apps/notebook/src/notebook-surface.ts
+++ b/apps/notebook/src/notebook-surface.ts
@@ -10,6 +10,18 @@ export {
   applyOutputChangeset,
   resetRuntimeStoresProjection,
 } from "./lib/project-runtime-stores";
+export {
+  materializeChangeset,
+  type CellChangeset,
+  type MaterializeDeps,
+} from "./lib/frame-pipeline";
+export {
+  getCellById,
+  getCellIdsSnapshot,
+  getNotebookCellsSnapshot,
+  type NotebookCell,
+} from "./lib/notebook-cells";
+export type { JupyterOutput } from "./types";
 export { resetPoolState, setPoolState } from "./lib/pool-state";
 export {
   resetRuntimeState,

--- a/apps/notebook/src/notebook-surface.ts
+++ b/apps/notebook/src/notebook-surface.ts
@@ -11,7 +11,12 @@ export {
   resetRuntimeStoresProjection,
 } from "./lib/project-runtime-stores";
 export { resetPoolState, setPoolState } from "./lib/pool-state";
-export { resetRuntimeState, setRuntimeState } from "./lib/runtime-state";
+export {
+  resetRuntimeState,
+  setRuntimeState,
+  useRuntimeState,
+  useRuntimeStateLoaded,
+} from "./lib/runtime-state";
 export { startCursorDispatch } from "./lib/cursor-registry";
 export { setLoggerHost } from "./lib/logger";
 export { setOpenUrlHost } from "./lib/open-url";

--- a/packages/runtimed/src/index.ts
+++ b/packages/runtimed/src/index.ts
@@ -313,6 +313,20 @@ export {
   statusKeyToLegacyStatus,
 } from "./derived-state";
 
+// Notebook command runtime projection
+export {
+  clearNotebookCommandRuntimeStatusCacheForTests,
+  getLifecycleLabel,
+  getStatusKeyLabel,
+  notebookCommandRuntimeStateForStatusKey,
+  projectNotebookCommandRuntimeStatus,
+  projectNotebookCommandRuntimeStatusFromRuntimeState,
+  RUNTIME_STATUS_LABELS,
+  type NotebookCommandRuntimeState,
+  type NotebookCommandRuntimeStatusProjection,
+  type ProjectNotebookCommandRuntimeStatusOptions,
+} from "./notebook-command-runtime";
+
 // Notebook client
 export {
   NotebookClient,

--- a/packages/runtimed/src/notebook-command-runtime.ts
+++ b/packages/runtimed/src/notebook-command-runtime.ts
@@ -1,0 +1,144 @@
+import { KERNEL_ERROR_REASON, type RuntimeLifecycle, type RuntimeState } from "./runtime-state";
+import {
+  KERNEL_STATUS,
+  RUNTIME_STATUS,
+  runtimeStatusKey,
+  statusKeyToLegacyStatus,
+  type RuntimeStatusKey,
+} from "./derived-state";
+import { getBoundedCacheValue, setBoundedCacheValue, stableCacheKey } from "./projection-cache";
+
+export type NotebookCommandRuntimeState =
+  | "not_started"
+  | "starting"
+  | "idle"
+  | "busy"
+  | "error"
+  | "shutdown"
+  | "unknown";
+
+export interface NotebookCommandRuntimeStatusProjection {
+  ariaLabel: string;
+  label: string;
+  state: NotebookCommandRuntimeState;
+  statusKey: RuntimeStatusKey;
+  title: string;
+}
+
+export interface ProjectNotebookCommandRuntimeStatusOptions {
+  statusKey: RuntimeStatusKey;
+  errorReason?: string | null;
+  forceError?: boolean;
+}
+
+const COMMAND_RUNTIME_STATUS_CACHE = new Map<string, NotebookCommandRuntimeStatusProjection>();
+const COMMAND_RUNTIME_STATUS_CACHE_LIMIT = 128;
+
+const ERROR_REASON_LABELS: Record<string, string> = {
+  [KERNEL_ERROR_REASON.ENVIRONMENT_PREPARE_FAILED]: "environment setup failed",
+  [KERNEL_ERROR_REASON.MISSING_IPYKERNEL]: "ipykernel missing",
+  [KERNEL_ERROR_REASON.DEPENDENCY_CACHE_MISSING_IPYKERNEL]: "ipykernel missing",
+  [KERNEL_ERROR_REASON.IPYKERNEL_SITE_PACKAGES_MISMATCH]: "Python environment mismatch",
+  [KERNEL_ERROR_REASON.CONDA_ENV_YML_MISSING]: "Conda environment missing",
+  [KERNEL_ERROR_REASON.CONDA_ENV_BUILD_FAILED]: "Conda environment build failed",
+};
+
+/**
+ * User-facing label for each expanded [`RuntimeStatusKey`].
+ *
+ * Keyed by the flat runtime vocabulary so every lifecycle variant
+ * (including each starting sub-phase and all three `Running(_)` cases)
+ * gets a dedicated label. Exhaustive `Record` — adding a variant to
+ * `RuntimeLifecycle` fails typecheck here until a label is added.
+ */
+export const RUNTIME_STATUS_LABELS: Record<RuntimeStatusKey, string> = {
+  [RUNTIME_STATUS.NOT_STARTED]: "initializing",
+  [RUNTIME_STATUS.AWAITING_TRUST]: "awaiting approval",
+  [RUNTIME_STATUS.AWAITING_ENV_BUILD]: "awaiting environment build",
+  [RUNTIME_STATUS.RESOLVING]: "resolving environment",
+  [RUNTIME_STATUS.PREPARING_ENV]: "preparing environment",
+  [RUNTIME_STATUS.LAUNCHING]: "launching kernel",
+  [RUNTIME_STATUS.CONNECTING]: "connecting to kernel",
+  [RUNTIME_STATUS.RUNNING_IDLE]: "idle",
+  [RUNTIME_STATUS.RUNNING_BUSY]: "busy",
+  [RUNTIME_STATUS.RUNNING_UNKNOWN]: "running",
+  [RUNTIME_STATUS.ERROR]: "error",
+  [RUNTIME_STATUS.SHUTDOWN]: "shutdown",
+};
+
+export function getStatusKeyLabel(key: RuntimeStatusKey, errorReason: string | null): string {
+  if (key === RUNTIME_STATUS.ERROR && errorReason && errorReason.length > 0) {
+    return `error: ${ERROR_REASON_LABELS[errorReason] ?? "kernel failed"}`;
+  }
+  return RUNTIME_STATUS_LABELS[key];
+}
+
+export function getLifecycleLabel(lifecycle: RuntimeLifecycle, errorReason: string | null): string {
+  return getStatusKeyLabel(runtimeStatusKey(lifecycle), errorReason);
+}
+
+export function notebookCommandRuntimeStateForStatusKey(
+  statusKey: RuntimeStatusKey,
+  forceError = false,
+): NotebookCommandRuntimeState {
+  if (forceError) {
+    return "error";
+  }
+
+  switch (statusKeyToLegacyStatus(statusKey)) {
+    case KERNEL_STATUS.NOT_STARTED:
+    case KERNEL_STATUS.AWAITING_TRUST:
+    case KERNEL_STATUS.AWAITING_ENV_BUILD:
+      return "not_started";
+    case KERNEL_STATUS.STARTING:
+      return "starting";
+    case KERNEL_STATUS.IDLE:
+      return "idle";
+    case KERNEL_STATUS.BUSY:
+      return "busy";
+    case KERNEL_STATUS.ERROR:
+      return "error";
+    case KERNEL_STATUS.SHUTDOWN:
+      return "shutdown";
+  }
+}
+
+export function projectNotebookCommandRuntimeStatus({
+  statusKey,
+  errorReason = null,
+  forceError = false,
+}: ProjectNotebookCommandRuntimeStatusOptions): NotebookCommandRuntimeStatusProjection {
+  const normalizedErrorReason = errorReason && errorReason.length > 0 ? errorReason : null;
+  const cacheKey = stableCacheKey([statusKey, normalizedErrorReason, forceError]);
+  const cached = getBoundedCacheValue(COMMAND_RUNTIME_STATUS_CACHE, cacheKey);
+  if (cached) return cached;
+
+  const label = getStatusKeyLabel(statusKey, normalizedErrorReason);
+  const projection = Object.freeze({
+    ariaLabel: `Kernel: ${label}`,
+    label,
+    state: notebookCommandRuntimeStateForStatusKey(statusKey, forceError),
+    statusKey,
+    title: label,
+  });
+  setBoundedCacheValue(
+    COMMAND_RUNTIME_STATUS_CACHE,
+    cacheKey,
+    projection,
+    COMMAND_RUNTIME_STATUS_CACHE_LIMIT,
+  );
+  return projection;
+}
+
+export function projectNotebookCommandRuntimeStatusFromRuntimeState(
+  runtimeState: RuntimeState,
+): NotebookCommandRuntimeStatusProjection {
+  return projectNotebookCommandRuntimeStatus({
+    statusKey: runtimeStatusKey(runtimeState.kernel.lifecycle),
+    errorReason: runtimeState.kernel.error_reason,
+  });
+}
+
+export function clearNotebookCommandRuntimeStatusCacheForTests(): void {
+  COMMAND_RUNTIME_STATUS_CACHE.clear();
+}

--- a/packages/runtimed/tests/notebook-command-runtime.test.ts
+++ b/packages/runtimed/tests/notebook-command-runtime.test.ts
@@ -1,0 +1,104 @@
+import { beforeEach, describe, expect, it } from "vite-plus/test";
+import {
+  clearNotebookCommandRuntimeStatusCacheForTests,
+  getLifecycleLabel,
+  getStatusKeyLabel,
+  KERNEL_ERROR_REASON,
+  notebookCommandRuntimeStateForStatusKey,
+  projectNotebookCommandRuntimeStatus,
+  projectNotebookCommandRuntimeStatusFromRuntimeState,
+  RUNTIME_STATUS,
+  RUNTIME_STATUS_LABELS,
+  type RuntimeState,
+  type RuntimeStatusKey,
+} from "../src";
+
+beforeEach(() => {
+  clearNotebookCommandRuntimeStatusCacheForTests();
+});
+
+describe("notebook command runtime projection", () => {
+  it("labels every expanded runtime status key", () => {
+    const keys = Object.values(RUNTIME_STATUS) as RuntimeStatusKey[];
+    for (const key of keys) {
+      expect(getStatusKeyLabel(key, null)).toBe(RUNTIME_STATUS_LABELS[key]);
+    }
+  });
+
+  it("renders typed error reasons only for error states", () => {
+    expect(getStatusKeyLabel(RUNTIME_STATUS.ERROR, KERNEL_ERROR_REASON.MISSING_IPYKERNEL)).toBe(
+      "error: ipykernel missing",
+    );
+    expect(
+      getStatusKeyLabel(RUNTIME_STATUS.ERROR, KERNEL_ERROR_REASON.IPYKERNEL_SITE_PACKAGES_MISMATCH),
+    ).toBe("error: Python environment mismatch");
+    expect(getStatusKeyLabel(RUNTIME_STATUS.RUNNING_IDLE, "missing_ipykernel")).toBe("idle");
+  });
+
+  it("projects lifecycle labels through the same status-key table", () => {
+    expect(getLifecycleLabel({ lifecycle: "Launching" }, null)).toBe("launching kernel");
+    expect(getLifecycleLabel({ lifecycle: "Running", activity: "Unknown" }, null)).toBe("running");
+  });
+
+  it("maps expanded status keys to toolbar states", () => {
+    expect(notebookCommandRuntimeStateForStatusKey(RUNTIME_STATUS.NOT_STARTED)).toBe("not_started");
+    expect(notebookCommandRuntimeStateForStatusKey(RUNTIME_STATUS.AWAITING_TRUST)).toBe(
+      "not_started",
+    );
+    expect(notebookCommandRuntimeStateForStatusKey(RUNTIME_STATUS.LAUNCHING)).toBe("starting");
+    expect(notebookCommandRuntimeStateForStatusKey(RUNTIME_STATUS.RUNNING_IDLE)).toBe("idle");
+    expect(notebookCommandRuntimeStateForStatusKey(RUNTIME_STATUS.RUNNING_UNKNOWN)).toBe("idle");
+    expect(notebookCommandRuntimeStateForStatusKey(RUNTIME_STATUS.RUNNING_BUSY)).toBe("busy");
+    expect(notebookCommandRuntimeStateForStatusKey(RUNTIME_STATUS.ERROR)).toBe("error");
+    expect(notebookCommandRuntimeStateForStatusKey(RUNTIME_STATUS.SHUTDOWN)).toBe("shutdown");
+  });
+
+  it("returns frozen stable projections for equivalent status inputs", () => {
+    const first = projectNotebookCommandRuntimeStatus({
+      statusKey: RUNTIME_STATUS.RUNNING_IDLE,
+      errorReason: null,
+    });
+    const second = projectNotebookCommandRuntimeStatus({
+      statusKey: RUNTIME_STATUS.RUNNING_IDLE,
+      errorReason: "",
+    });
+
+    expect(first).toBe(second);
+    expect(Object.isFrozen(first)).toBe(true);
+    expect(first).toEqual({
+      ariaLabel: "Kernel: idle",
+      label: "idle",
+      state: "idle",
+      statusKey: RUNTIME_STATUS.RUNNING_IDLE,
+      title: "idle",
+    });
+  });
+
+  it("can force error tone for host-side environment failures", () => {
+    const projection = projectNotebookCommandRuntimeStatus({
+      statusKey: RUNTIME_STATUS.RUNNING_IDLE,
+      errorReason: null,
+      forceError: true,
+    });
+
+    expect(projection).toMatchObject({
+      label: "idle",
+      state: "error",
+    });
+  });
+
+  it("projects directly from RuntimeStateDoc snapshots", () => {
+    const projection = projectNotebookCommandRuntimeStatusFromRuntimeState({
+      kernel: {
+        lifecycle: { lifecycle: "Running", activity: "Busy" },
+        error_reason: null,
+      },
+    } as RuntimeState);
+
+    expect(projection).toMatchObject({
+      label: "busy",
+      state: "busy",
+      statusKey: RUNTIME_STATUS.RUNNING_BUSY,
+    });
+  });
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -589,6 +589,9 @@ importers:
       runtimed:
         specifier: workspace:*
         version: link:../../packages/runtimed
+      rxjs:
+        specifier: ^7.8.2
+        version: 7.8.2
     devDependencies:
       '@playwright/test':
         specifier: ^1.59.1

--- a/src/components/notebook/NotebookCommandToolbar.tsx
+++ b/src/components/notebook/NotebookCommandToolbar.tsx
@@ -10,16 +10,9 @@ import {
 import type { ReactNode } from "react";
 import { CondaIcon, DenoIcon, PixiIcon, PythonIcon, UvIcon } from "@/components/environment";
 import { cn } from "@/lib/utils";
-import type { NotebookShellCapabilities } from "./capabilities";
+import type { NotebookCommandRuntimeState, NotebookShellCapabilities } from "./capabilities";
 
-export type NotebookCommandRuntimeState =
-  | "not_started"
-  | "starting"
-  | "idle"
-  | "busy"
-  | "error"
-  | "shutdown"
-  | "unknown";
+export type { NotebookCommandRuntimeState } from "./capabilities";
 
 export type NotebookEnvironmentManager = "uv" | "conda" | "pixi";
 
@@ -112,12 +105,13 @@ export function NotebookCommandToolbar({
   const showAddCellControls = Boolean(onAddCell) && (canEditStructure || addCellControlsDisabled);
   const showRuntimeStart =
     hasRuntimeStatus && canExecute && !isRuntimeRunning && Boolean(onStartRuntime);
-  const showRuntimeActions =
-    hasRuntimeStatus &&
-    canExecute &&
-    Boolean(onRunAllCells && onRestartRuntime && onRestartAndRunAll);
+  const showRunAll = hasRuntimeStatus && canExecute && Boolean(onRunAllCells);
+  const showRestart = hasRuntimeStatus && canExecute && Boolean(onRestartRuntime);
+  const showRestartAndRunAll = hasRuntimeStatus && canExecute && Boolean(onRestartAndRunAll);
   const showInterrupt =
     hasRuntimeStatus && canExecute && isRuntimeRunning && Boolean(onInterruptRuntime);
+  const showAnyRuntimeAction =
+    showRuntimeStart || showRunAll || showRestart || showRestartAndRunAll || showInterrupt;
   const showPackageToggle = Boolean(runtime && canViewPackages && onTogglePackages);
   const showAuthControls =
     Boolean(authControls) &&
@@ -160,9 +154,7 @@ export function NotebookCommandToolbar({
         </>
       ) : null}
 
-      {showAddCellControls && (showRuntimeStart || showRuntimeActions || showInterrupt) ? (
-        <div className="h-4 w-px bg-border" />
-      ) : null}
+      {showAddCellControls && showAnyRuntimeAction ? <div className="h-4 w-px bg-border" /> : null}
 
       {showRuntimeStart ? (
         <button
@@ -179,50 +171,54 @@ export function NotebookCommandToolbar({
         </button>
       ) : null}
 
-      {showRuntimeActions ? (
-        <>
-          <button
-            type="button"
-            onClick={onRunAllCells}
-            className="flex items-center gap-1 whitespace-nowrap rounded px-2 py-1 text-xs text-foreground transition-colors hover:bg-muted"
-            title="Run all cells"
-            aria-label="Run all cells"
-            data-testid="run-all-button"
-          >
-            <ChevronsRight className="h-3.5 w-3.5" />
-            <span className="hidden @[40rem]:inline">Run all</span>
-          </button>
-          <button
-            type="button"
-            onClick={onRestartRuntime}
-            className="flex items-center gap-1 whitespace-nowrap rounded px-2 py-1 text-xs text-foreground transition-colors hover:bg-muted"
-            title="Restart kernel"
-            aria-label="Restart kernel"
-            data-testid="restart-kernel-button"
-          >
-            <RotateCcw className="h-3 w-3" />
-            <span className="hidden @[40rem]:inline">Restart</span>
-          </button>
-          <button
-            type="button"
-            onClick={onRestartAndRunAll}
-            className={cn(
-              "flex items-center gap-1 rounded px-2 py-1 text-xs transition-colors",
-              environmentOutOfSync
-                ? "bg-amber-500/10 text-amber-700 ring-1 ring-amber-500/30 hover:bg-amber-500/20 dark:text-amber-400"
-                : "text-foreground hover:bg-muted",
-            )}
-            title={
-              environmentOutOfSync
-                ? "Dependencies changed - restart kernel and run all cells"
-                : "Restart kernel and run all cells"
-            }
-            data-testid="restart-run-all-button"
-          >
-            <RotateCcw className="h-3 w-3" />
-            <ChevronsRight className="h-3 w-3 -ml-1" />
-          </button>
-        </>
+      {showRunAll ? (
+        <button
+          type="button"
+          onClick={onRunAllCells}
+          className="flex items-center gap-1 whitespace-nowrap rounded px-2 py-1 text-xs text-foreground transition-colors hover:bg-muted"
+          title="Run all cells"
+          aria-label="Run all cells"
+          data-testid="run-all-button"
+        >
+          <ChevronsRight className="h-3.5 w-3.5" />
+          <span className="hidden @[40rem]:inline">Run all</span>
+        </button>
+      ) : null}
+
+      {showRestart ? (
+        <button
+          type="button"
+          onClick={onRestartRuntime}
+          className="flex items-center gap-1 whitespace-nowrap rounded px-2 py-1 text-xs text-foreground transition-colors hover:bg-muted"
+          title="Restart kernel"
+          aria-label="Restart kernel"
+          data-testid="restart-kernel-button"
+        >
+          <RotateCcw className="h-3 w-3" />
+          <span className="hidden @[40rem]:inline">Restart</span>
+        </button>
+      ) : null}
+
+      {showRestartAndRunAll ? (
+        <button
+          type="button"
+          onClick={onRestartAndRunAll}
+          className={cn(
+            "flex items-center gap-1 rounded px-2 py-1 text-xs transition-colors",
+            environmentOutOfSync
+              ? "bg-amber-500/10 text-amber-700 ring-1 ring-amber-500/30 hover:bg-amber-500/20 dark:text-amber-400"
+              : "text-foreground hover:bg-muted",
+          )}
+          title={
+            environmentOutOfSync
+              ? "Dependencies changed - restart kernel and run all cells"
+              : "Restart kernel and run all cells"
+          }
+          data-testid="restart-run-all-button"
+        >
+          <RotateCcw className="h-3 w-3" />
+          <ChevronsRight className="h-3 w-3 -ml-1" />
+        </button>
       ) : null}
 
       {showInterrupt ? (

--- a/src/components/notebook/__tests__/NotebookCommandToolbar.test.tsx
+++ b/src/components/notebook/__tests__/NotebookCommandToolbar.test.tsx
@@ -53,6 +53,28 @@ describe("NotebookCommandToolbar", () => {
     expect(screen.getByRole("button", { name: "Kyle" })).toBeVisible();
   });
 
+  it("renders run-all without requiring host restart actions", () => {
+    const onRunAllCells = vi.fn();
+    const onInterruptRuntime = vi.fn();
+
+    render(
+      <NotebookCommandToolbar
+        capabilities={editableToolbarCapabilities}
+        runtimeStatus={runtimeStatus}
+        onRunAllCells={onRunAllCells}
+        onInterruptRuntime={onInterruptRuntime}
+      />,
+    );
+
+    fireEvent.click(screen.getByTestId("run-all-button"));
+    fireEvent.click(screen.getByTestId("interrupt-kernel-button"));
+
+    expect(onRunAllCells).toHaveBeenCalledTimes(1);
+    expect(onInterruptRuntime).toHaveBeenCalledTimes(1);
+    expect(screen.queryByTestId("restart-kernel-button")).toBeNull();
+    expect(screen.queryByTestId("restart-run-all-button")).toBeNull();
+  });
+
   it("renders host chrome through named capability-scoped slots", () => {
     render(
       <NotebookCommandToolbar

--- a/src/components/notebook/capabilities.ts
+++ b/src/components/notebook/capabilities.ts
@@ -1,9 +1,13 @@
 export {
   notebookShellRuntimeTargetSummary,
+  projectNotebookCommandRuntimeStatus,
+  projectNotebookCommandRuntimeStatusFromRuntimeState,
   projectNotebookShellCapabilities,
   readOnlyNotebookShellCapabilities,
   resolveNotebookShellRuntimeTarget,
   stabilizeNotebookShellCapabilities,
+  type NotebookCommandRuntimeState,
+  type NotebookCommandRuntimeStatusProjection,
   type NotebookActorIdentity,
   type NotebookActorKind,
   type NotebookActorOperator,
@@ -29,4 +33,5 @@ export {
   type NotebookWorkstationFactProjection,
   type NotebookWorkstationPanelProjection,
   type NotebookWorkstationPanelTone,
+  type ProjectNotebookCommandRuntimeStatusOptions,
 } from "runtimed";

--- a/src/components/notebook/index.ts
+++ b/src/components/notebook/index.ts
@@ -16,10 +16,14 @@ export {
 } from "./actor-projection";
 export {
   notebookShellRuntimeTargetSummary,
+  projectNotebookCommandRuntimeStatus,
+  projectNotebookCommandRuntimeStatusFromRuntimeState,
   projectNotebookShellCapabilities,
   readOnlyNotebookShellCapabilities,
   resolveNotebookShellRuntimeTarget,
   stabilizeNotebookShellCapabilities,
+  type NotebookCommandRuntimeState,
+  type NotebookCommandRuntimeStatusProjection,
   type NotebookActorIdentity,
   type NotebookActorKind,
   type NotebookActorOperator,
@@ -45,6 +49,7 @@ export {
   type NotebookWorkstationFactProjection,
   type NotebookWorkstationPanelProjection,
   type NotebookWorkstationPanelTone,
+  type ProjectNotebookCommandRuntimeStatusOptions,
 } from "./capabilities";
 export { NotebookDocumentShell, type NotebookDocumentShellProps } from "./NotebookDocumentShell";
 export { NotebookDocumentHeader, type NotebookDocumentHeaderProps } from "./NotebookDocumentHeader";
@@ -90,7 +95,6 @@ export type {
 } from "./runtime-surface-types";
 export {
   NotebookCommandToolbar,
-  type NotebookCommandRuntimeState,
   type NotebookCommandToolbarProps,
   type NotebookCommandToolbarStatus,
   type NotebookCommandToolbarUpdateAction,


### PR DESCRIPTION
## Summary
- move runtime command status labels and toolbar state projection into `packages/runtimed`
- let `NotebookCommandToolbar` render supported runtime actions independently instead of requiring the full desktop restart set
- wire cloud notebooks to show RuntimeStateDoc-derived kernel status plus honest run-all and interrupt actions for attached runtime peers
- apply live cloud `cellChanges$` through the shared incremental materializer instead of rematerializing every live cell on each change
- add a small RxJS helper/test boundary so cloud cell materialization is serialized, errors do not terminate the stream, and unsubscribe suppresses in-flight rejection callbacks
- keep live status notices aligned with the shared projected cell store so transient empty-room states do not stick after cells render
- remove the redundant post-commit cloud cell re-projection so daemon-owned execution and queue state remains the final writer after live structural changes
- guard incremental live changeset writes with the same materialization sequence token as full materialization so stale post-await status updates cannot overwrite newer renders

## Validation
- `pnpm test:run packages/runtimed/tests/notebook-command-runtime.test.ts src/components/notebook/__tests__/NotebookCommandToolbar.test.tsx apps/notebook/src/lib/__tests__/kernel-status.test.ts apps/notebook/src/components/__tests__/notebook-toolbar.test.tsx`
- `pnpm --dir apps/notebook-cloud exec node --import tsx --test test/viewer-render-props.test.ts test/viewer-shared-cell-surface.test.ts`
- `pnpm --dir apps/notebook-cloud exec node --import tsx --test test/viewer-notices.test.ts test/viewer-shared-cell-surface.test.ts test/serialized-cell-changes.test.ts test/notebook-view-store-bridge.test.ts`
- `pnpm test:run apps/notebook/src/lib/__tests__/frame-pipeline.test.ts apps/notebook/src/lib/__tests__/notebook-sync-store-bridge.test.ts`
- `pnpm --dir apps/notebook-cloud typecheck`
- `pnpm --dir apps/notebook exec tsc -b`
- `cargo xtask lint --fix`
- `pnpm run deploy` from `apps/notebook-cloud`
- `pnpm run deploy:check` from `apps/notebook-cloud`
- `pnpm --dir apps/notebook-cloud smoke:hosted`
- `pnpm --dir apps/notebook-cloud smoke:hosted:runtime-browser-execute`
- Playwright visible-notebook assertion against `Yet Another Example` and the fresh `Notebook Jun 7, 2026 5:51 PM` room; screenshots saved under `.context/screenshots/workstation-launch-surface/`

## Notes
- Cloud still does not expose start/restart in this PR. Those need the workstation-selection and launch-progress policy to be represented through RuntimeStateDoc rather than a toolbar-only shortcut.
