### PR TITLE
feat(notebook-cloud): register hosted workstations

### DIFF
--- a/.github/actions/install-wasm-pack/action.yml
+++ b/.github/actions/install-wasm-pack/action.yml
@@ -52,12 +52,21 @@ runs:
         tmp="$(mktemp -d)"
         trap 'rm -rf "$tmp"' EXIT
 
-        curl --fail --location --show-error --retry 10 --retry-delay 2 \
+        if curl --fail --location --show-error --retry 10 --retry-delay 2 --retry-all-errors \
           --output "$tmp/$asset" \
-          "$url"
-        tar -xzf "$tmp/$asset" -C "$tmp"
+          "$url"; then
+          tar -xzf "$tmp/$asset" -C "$tmp"
+          bin="$(find "$tmp" -type f \( -name wasm-pack -o -name wasm-pack.exe \) -print -quit)"
+        else
+          echo "::warning::wasm-pack release download failed; falling back to cargo install"
+          cargo_root="$tmp/cargo-install"
+          cargo install wasm-pack --version "$version" --locked --root "$cargo_root"
+          case "$RUNNER_OS" in
+            Windows) bin="$cargo_root/bin/wasm-pack.exe" ;;
+            *) bin="$cargo_root/bin/wasm-pack" ;;
+          esac
+        fi
 
-        bin="$(find "$tmp" -type f \( -name wasm-pack -o -name wasm-pack.exe \) -print -quit)"
         if [ -z "$bin" ]; then
           echo "wasm-pack binary not found in $asset" >&2
           exit 1

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -208,10 +208,29 @@ jobs:
       - name: Lint GitHub Actions workflows
         # Install the binary directly rather than via raven-actions/actionlint@v2,
         # which falls back to `npm install` in the repo root on cache miss and
-        # chokes on the pnpm `catalog:` protocol in package.json.
+        # chokes on the pnpm `catalog:` protocol in package.json. Validate the
+        # downloaded archive before extraction because GitHub release downloads
+        # can transiently return small non-archive error bodies.
         run: |
-          bash <(curl https://raw.githubusercontent.com/rhysd/actionlint/main/scripts/download-actionlint.bash)
-          ./actionlint -color
+          set -euo pipefail
+          version=1.7.12
+          asset="actionlint_${version}_linux_amd64.tar.gz"
+          url="https://github.com/rhysd/actionlint/releases/download/v${version}/${asset}"
+          tmp="$(mktemp -d)"
+          trap 'rm -rf "$tmp"' EXIT
+
+          if curl --fail --location --show-error --retry 10 --retry-delay 2 --retry-all-errors \
+            --output "$tmp/$asset" \
+            "$url" && tar -tzf "$tmp/$asset" >/dev/null 2>&1; then
+            tar -xzf "$tmp/$asset" -C "$tmp" actionlint
+            bin="$tmp/actionlint"
+          else
+            echo "::warning::actionlint release download failed; falling back to go install"
+            go install "github.com/rhysd/actionlint/cmd/actionlint@v${version}"
+            bin="$(go env GOPATH)/bin/actionlint"
+          fi
+
+          "$bin" -color
 
   # Pull requests always run the two branch-protection checks above:
   # Lint & Format and JS Tests & Benchmarks. The jobs below are advisory on PRs:
@@ -326,9 +345,30 @@ jobs:
         run: cargo xtask verify-plugins
 
       - name: Install Deno
-        uses: denoland/setup-deno@v2.0.4
-        with:
-          deno-version: "2.4"
+        run: |
+          set -euo pipefail
+          version=2.4.5
+          asset=deno-x86_64-unknown-linux-gnu.zip
+          url="https://github.com/denoland/deno/releases/download/v${version}/${asset}"
+          tmp="$(mktemp -d)"
+          trap 'rm -rf "$tmp"' EXIT
+
+          if curl --fail --location --show-error --retry 10 --retry-delay 4 --retry-all-errors \
+            --output "$tmp/$asset" \
+            "$url" && unzip -tq "$tmp/$asset" >/dev/null; then
+            unzip -q "$tmp/$asset" -d "$tmp"
+            install_dir="$RUNNER_TEMP/deno/bin"
+            mkdir -p "$install_dir"
+            cp "$tmp/deno" "$install_dir/deno"
+            chmod +x "$install_dir/deno"
+          else
+            echo "::warning::Deno release download failed; falling back to npm deno package"
+            install_dir="$RUNNER_TEMP/deno-npm/bin"
+            npm_config_prefix="$RUNNER_TEMP/deno-npm" npm install -g deno@2.4.4
+          fi
+
+          echo "$install_dir" >> "$GITHUB_PATH"
+          "$install_dir/deno" --version
 
       - name: Run runtimed-wasm Deno tests
         run: deno test --allow-read --allow-env --no-check crates/runtimed-wasm/tests/

--- a/apps/notebook-cloud/README.md
+++ b/apps/notebook-cloud/README.md
@@ -676,15 +676,16 @@ owner room to request attachment.
 Use the combined runtime/browser smoke when you want the full preview remote
 compute path in one command. It creates one API-key room per requested browser
 scope, keeps that room's runtime peer alive, clicks execution through Chromium
-for `owner` and `editor` scope by default, then stops each peer it started:
+for `owner` scope by default, then stops each peer it started:
 
 ```bash
 NTERACT_CLOUD_URL=https://preview.runt.run \
 pnpm --dir apps/notebook-cloud smoke:hosted:runtime-browser-execute
 ```
 
-Set `NOTEBOOK_CLOUD_RUNTIME_BROWSER_EXECUTE_SCOPES=owner` for a single-scope
-run, or set `NOTEBOOK_CLOUD_RUNTIME_BROWSER_EXECUTE_CODE` when you need a fixed
+Set `NOTEBOOK_CLOUD_RUNTIME_BROWSER_EXECUTE_SCOPES=owner,editor` when
+intentionally exercising a deployment with explicit editor execution capability,
+or set `NOTEBOOK_CLOUD_RUNTIME_BROWSER_EXECUTE_CODE` when you need a fixed
 source/output marker for a trace.
 
 To exercise the actual hosted browser execution path against a private room,

--- a/apps/notebook-cloud/README.md
+++ b/apps/notebook-cloud/README.md
@@ -673,6 +673,24 @@ registers, select it as the default workstation in the notebook UI or call
 `PATCH /api/workstations/default`, then use the Workstations rail in a private
 owner room to request attachment.
 
+With the workstation agent already running, use the toolbar smoke to exercise
+the hosted browser path end to end. It verifies the registered workstation is
+online, selects it as the default, creates a private owner notebook, seeds the
+first-party browser OIDC cache, clicks `Attach compute` in the shared toolbar,
+runs the first cell, reloads the page, and runs it again to catch reconnection
+regressions:
+
+```bash
+pnpm --dir apps/notebook-cloud smoke:hosted:workstation-toolbar
+```
+
+The smoke reads the API key from the environment or
+`${PREVIEW_RUNT_ENV:-$HOME/preview.runt.run/.env}` and reads the browser OIDC
+token cache from `${NTERACT_PREVIEW_OIDC_TOKEN_PATH:-$HOME/token.preview.json}`.
+It does not print token material. Set
+`NOTEBOOK_CLOUD_WORKSTATION_TOOLBAR_SMOKE_WORKSTATION_ID` to target a
+workstation other than `lab2`.
+
 Use the combined runtime/browser smoke when you want the full preview remote
 compute path in one command. It creates one API-key room per requested browser
 scope, keeps that room's runtime peer alive, clicks execution through Chromium

--- a/apps/notebook-cloud/README.md
+++ b/apps/notebook-cloud/README.md
@@ -649,6 +649,30 @@ old `--timeout` flag in smoke scripts. Rooms created with the API-key path are
 private; anonymous hosted render smokes may return a catalog 404 unless the
 browser context has a credential for the owning principal.
 
+Hosted workstation agent smoke:
+
+```bash
+cargo build --release -p runtimed
+NTERACT_CLOUD_URL=https://preview.runt.run \
+NOTEBOOK_CLOUD_WORKSTATION_ID=lab2 \
+NOTEBOOK_CLOUD_WORKSTATION_DISPLAY_NAME="lab2 workstation" \
+NOTEBOOK_CLOUD_WORKSTATION_CWD="$PWD" \
+pnpm --dir apps/notebook-cloud smoke:hosted:workstation-agent
+```
+
+The workstation agent reads `NTERACT_API_KEY` from the environment and also
+loads `${PREVIEW_RUNT_ENV:-$HOME/preview.runt.run/.env}` when present. It
+registers and heartbeats the current machine through `POST /api/workstations`,
+polls `GET /api/workstations/:workstationId/attach-jobs`, and spawns
+`runtimed cloud-runtime-agent` for pending attach jobs. The API key is passed to
+the runtime peer through `RUNT_CLOUD_TOKEN`, not through argv; `runtimed`
+removes cloud/API-key environment variables again before launching the Python
+kernel. Run this helper inside tmux for preview/manual testing so the polling
+agent stays alive while the browser attaches workstations. After the agent
+registers, select it as the default workstation in the notebook UI or call
+`PATCH /api/workstations/default`, then use the Workstations rail in a private
+owner room to request attachment.
+
 Use the combined runtime/browser smoke when you want the full preview remote
 compute path in one command. It creates one API-key room per requested browser
 scope, keeps that room's runtime peer alive, clicks execution through Chromium

--- a/apps/notebook-cloud/package.json
+++ b/apps/notebook-cloud/package.json
@@ -24,6 +24,7 @@
     "smoke:hosted:live-rooms": "node scripts/hosted-live-room-matrix-smoke.mjs",
     "smoke:hosted:runtime-peer": "node scripts/hosted-runtime-peer-smoke.mjs",
     "smoke:hosted:workstation-agent": "node scripts/hosted-workstation-agent.mjs",
+    "smoke:hosted:workstation-toolbar": "node scripts/hosted-workstation-toolbar-smoke.mjs",
     "smoke:hosted:browser-execute": "node scripts/hosted-browser-execute-smoke.mjs",
     "smoke:hosted:runtime-browser-execute": "node scripts/hosted-runtime-browser-execute-smoke.mjs",
     "smoke:hosted:collab": "node --import tsx scripts/hosted-collab-smoke.mjs",

--- a/apps/notebook-cloud/package.json
+++ b/apps/notebook-cloud/package.json
@@ -23,6 +23,7 @@
     "smoke:hosted:live-room": "node scripts/hosted-live-room-smoke.mjs",
     "smoke:hosted:live-rooms": "node scripts/hosted-live-room-matrix-smoke.mjs",
     "smoke:hosted:runtime-peer": "node scripts/hosted-runtime-peer-smoke.mjs",
+    "smoke:hosted:workstation-agent": "node scripts/hosted-workstation-agent.mjs",
     "smoke:hosted:browser-execute": "node scripts/hosted-browser-execute-smoke.mjs",
     "smoke:hosted:runtime-browser-execute": "node scripts/hosted-runtime-browser-execute-smoke.mjs",
     "smoke:hosted:collab": "node --import tsx scripts/hosted-collab-smoke.mjs",

--- a/apps/notebook-cloud/scripts/hosted-browser-execute-smoke.mjs
+++ b/apps/notebook-cloud/scripts/hosted-browser-execute-smoke.mjs
@@ -227,7 +227,6 @@ async function main() {
           token: {
             path: tokenPath,
             secondsRemaining: tokenSecondsRemaining,
-            subject: token.claims?.email ?? token.claims?.sub ?? null,
           },
           click: {
             executeButtonIndex,

--- a/apps/notebook-cloud/scripts/hosted-live-room-smoke.mjs
+++ b/apps/notebook-cloud/scripts/hosted-live-room-smoke.mjs
@@ -261,7 +261,6 @@ async function main() {
       token: {
         path: tokenPath,
         secondsRemaining: tokenSecondsRemaining,
-        subject: token.claims?.email ?? token.claims?.sub ?? null,
       },
       checks: {
         requestedScope,

--- a/apps/notebook-cloud/scripts/hosted-runtime-browser-execute-smoke.mjs
+++ b/apps/notebook-cloud/scripts/hosted-runtime-browser-execute-smoke.mjs
@@ -207,12 +207,12 @@ async function processExists(pid) {
 }
 
 export function parseScopes(value) {
-  const raw = value ?? "owner,editor";
+  const raw = value ?? "owner";
   const parsed = raw
     .split(/,|\s+/)
     .map((scope) => scope.trim())
     .filter(Boolean);
-  const scopes = parsed.length > 0 ? parsed : ["owner", "editor"];
+  const scopes = parsed.length > 0 ? parsed : ["owner"];
   for (const scope of scopes) {
     if (!["owner", "editor"].includes(scope)) {
       throw new Error("NOTEBOOK_CLOUD_RUNTIME_BROWSER_EXECUTE_SCOPES must contain owner or editor");

--- a/apps/notebook-cloud/scripts/hosted-workstation-agent-core.mjs
+++ b/apps/notebook-cloud/scripts/hosted-workstation-agent-core.mjs
@@ -1,0 +1,129 @@
+import os from "node:os";
+import path from "node:path";
+
+export function buildWorkstationRegistrationPayload({
+  workstationId,
+  displayName,
+  workingDirectory,
+  pythonPath,
+  cpuCount = os.cpus().length,
+  memoryBytes = os.totalmem(),
+}) {
+  return {
+    workstation_id: workstationId,
+    display_name: displayName,
+    provider: "runtime_peer",
+    default_environment_label: "Current Python",
+    environment_policy: "current_python",
+    working_directory: workingDirectory,
+    cpu_count: cpuCount,
+    memory_bytes: memoryBytes,
+    capabilities: {
+      launch_current_python: true,
+    },
+    runtime: {
+      binary: "runtimed",
+      python_path: pythonPath,
+    },
+  };
+}
+
+export function buildAttachJobSpawnPlan({
+  job,
+  pythonPath,
+  agentRoot,
+  baseUrl,
+  workingDirectory,
+  workstationId,
+  displayName,
+}) {
+  assert(typeof job.job_id === "string" && job.job_id.length > 0, "attach job missing id");
+  assert(
+    typeof job.notebook_id === "string" && job.notebook_id.length > 0,
+    `attach job ${job.job_id} missing notebook_id`,
+  );
+
+  const runRoot = path.join(agentRoot, safePathPart(job.job_id));
+  const blobRoot = path.join(runRoot, "blobs");
+  const logPath = path.join(runRoot, "runtime-peer.log");
+  const launchDirectory = job.working_directory ?? workingDirectory;
+  const args = [
+    "cloud-runtime-agent",
+    "--auth-kind",
+    "anaconda-key",
+    "--cloud-url",
+    baseUrl,
+    "--notebook-id",
+    job.notebook_id,
+    "--scope",
+    "runtime_peer",
+    "--python-path",
+    pythonPath,
+    "--blob-root",
+    blobRoot,
+    "--working-dir",
+    launchDirectory,
+    "--workstation-id",
+    workstationId,
+    "--workstation-display-name",
+    displayName,
+  ];
+
+  if (typeof job.notebook_path === "string" && job.notebook_path.length > 0) {
+    args.push("--notebook-path", job.notebook_path);
+  }
+
+  return {
+    args,
+    blobRoot,
+    cwd: launchDirectory,
+    logPath,
+    runRoot,
+  };
+}
+
+export function buildRuntimeAgentEnv(env, apiKey) {
+  return compactEnv({
+    HOME: env.HOME,
+    PATH: env.PATH,
+    LANG: env.LANG,
+    LC_ALL: env.LC_ALL,
+    SSL_CERT_FILE: env.SSL_CERT_FILE,
+    SSL_CERT_DIR: env.SSL_CERT_DIR,
+    RUST_BACKTRACE: env.RUST_BACKTRACE,
+    RUST_LOG: env.RUST_LOG ?? "info",
+    RUNT_CLOUD_TOKEN: apiKey,
+  });
+}
+
+export function compactEnv(entries) {
+  return Object.fromEntries(
+    Object.entries(entries).filter(([, value]) => typeof value === "string" && value.length > 0),
+  );
+}
+
+export function stableWorkstationId(hostname) {
+  return `ws-${safePathPart(hostname).slice(0, 80) || "local"}`;
+}
+
+export function safePathPart(value) {
+  return String(value)
+    .toLowerCase()
+    .replace(/[^a-z0-9._-]+/g, "-")
+    .replace(/^-+|-+$/g, "");
+}
+
+export function parsePositiveInteger(value, name, fallback) {
+  if (value == null || value === "") return fallback;
+  const parsed = Number(value);
+  if (!Number.isInteger(parsed) || parsed <= 0) {
+    throw new Error(`${name} must be a positive integer`);
+  }
+  return parsed;
+}
+
+function assert(condition, message) {
+  if (!condition) {
+    throw new Error(message);
+  }
+}

--- a/apps/notebook-cloud/scripts/hosted-workstation-agent.mjs
+++ b/apps/notebook-cloud/scripts/hosted-workstation-agent.mjs
@@ -5,6 +5,13 @@ import os from "node:os";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 
+import {
+  buildAttachJobSpawnPlan,
+  buildRuntimeAgentEnv,
+  buildWorkstationRegistrationPayload,
+  parsePositiveInteger,
+  stableWorkstationId,
+} from "./hosted-workstation-agent-core.mjs";
 import { notebookCloudBaseUrl, notebookCloudWorkspaceRoot } from "./local-dev.mjs";
 
 const appDir = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
@@ -88,23 +95,14 @@ async function registerWorkstation(pythonPath) {
       ...apiKeyHeaders(),
       "Content-Type": "application/json",
     },
-    body: JSON.stringify({
-      workstation_id: workstationId,
-      display_name: displayName,
-      provider: "runtime_peer",
-      default_environment_label: "Current Python",
-      environment_policy: "current_python",
-      working_directory: workingDirectory,
-      cpu_count: os.cpus().length,
-      memory_bytes: os.totalmem(),
-      capabilities: {
-        launch_current_python: true,
-      },
-      runtime: {
-        binary: "runtimed",
-        python_path: pythonPath,
-      },
-    }),
+    body: JSON.stringify(
+      buildWorkstationRegistrationPayload({
+        workstationId,
+        displayName,
+        workingDirectory,
+        pythonPath,
+      }),
+    ),
   });
   const body = await responseJson(response);
   assertResponse(response, body, "register workstation", [200, 201]);
@@ -126,48 +124,23 @@ async function pollAttachJobs(pythonPath) {
 }
 
 async function startAttachJob(job, pythonPath) {
-  assert(typeof job.job_id === "string" && job.job_id.length > 0, "attach job missing id");
-  assert(
-    typeof job.notebook_id === "string" && job.notebook_id.length > 0,
-    `attach job ${job.job_id} missing notebook_id`,
-  );
-
-  const runRoot = path.join(agentRoot, safePathPart(job.job_id));
-  const blobRoot = path.join(runRoot, "blobs");
-  const logPath = path.join(runRoot, "runtime-peer.log");
-  await mkdir(blobRoot, { recursive: true });
+  const plan = buildAttachJobSpawnPlan({
+    job,
+    pythonPath,
+    agentRoot,
+    baseUrl,
+    workingDirectory,
+    workstationId,
+    displayName,
+  });
+  await mkdir(plan.blobRoot, { recursive: true });
   await patchAttachJob(job.job_id, {
     status: "accepted",
   });
 
-  const args = [
-    "cloud-runtime-agent",
-    "--auth-kind",
-    "anaconda-key",
-    "--cloud-url",
-    baseUrl,
-    "--notebook-id",
-    job.notebook_id,
-    "--scope",
-    "runtime_peer",
-    "--python-path",
-    pythonPath,
-    "--blob-root",
-    blobRoot,
-    "--working-dir",
-    job.working_directory ?? workingDirectory,
-    "--workstation-id",
-    workstationId,
-    "--workstation-display-name",
-    displayName,
-  ];
-  if (typeof job.notebook_path === "string" && job.notebook_path.length > 0) {
-    args.push("--notebook-path", job.notebook_path);
-  }
-
-  const logFd = openSync(logPath, "a");
-  const child = spawn(runtimedBin, args, {
-    cwd: job.working_directory ?? workingDirectory,
+  const logFd = openSync(plan.logPath, "a");
+  const child = spawn(runtimedBin, plan.args, {
+    cwd: plan.cwd,
     env: runtimeAgentEnv(),
     stdio: ["ignore", logFd, logFd],
   });
@@ -181,7 +154,7 @@ async function startAttachJob(job, pythonPath) {
       jobId: job.job_id,
       notebookId: job.notebook_id,
       pid: child.pid,
-      logPath,
+      logPath: plan.logPath,
     }),
   );
 
@@ -293,23 +266,7 @@ function apiKeyHeaders() {
 }
 
 function runtimeAgentEnv() {
-  return compactEnv({
-    HOME: process.env.HOME,
-    PATH: process.env.PATH,
-    LANG: process.env.LANG,
-    LC_ALL: process.env.LC_ALL,
-    SSL_CERT_FILE: process.env.SSL_CERT_FILE,
-    SSL_CERT_DIR: process.env.SSL_CERT_DIR,
-    RUST_BACKTRACE: process.env.RUST_BACKTRACE,
-    RUST_LOG: process.env.RUST_LOG ?? "info",
-    RUNT_CLOUD_TOKEN: apiKey,
-  });
-}
-
-function compactEnv(entries) {
-  return Object.fromEntries(
-    Object.entries(entries).filter(([, value]) => typeof value === "string" && value.length > 0),
-  );
+  return buildRuntimeAgentEnv(process.env, apiKey);
 }
 
 async function resolvePythonPath() {
@@ -414,36 +371,10 @@ function normalizeJobs(body) {
   return [];
 }
 
-function stableWorkstationId(hostname) {
-  return `ws-${safePathPart(hostname).slice(0, 80) || "local"}`;
-}
-
-function safePathPart(value) {
-  return value
-    .toLowerCase()
-    .replace(/[^a-z0-9._-]+/g, "-")
-    .replace(/^-+|-+$/g, "");
-}
-
-function parsePositiveInteger(value, name, fallback) {
-  if (value == null || value === "") return fallback;
-  const parsed = Number(value);
-  if (!Number.isInteger(parsed) || parsed <= 0) {
-    throw new Error(`${name} must be a positive integer`);
-  }
-  return parsed;
-}
-
 function quoteShell(value) {
   return `'${value.replaceAll("'", "'\\''")}'`;
 }
 
 function sleep(ms) {
   return new Promise((resolve) => setTimeout(resolve, ms));
-}
-
-function assert(condition, message) {
-  if (!condition) {
-    throw new Error(message);
-  }
 }

--- a/apps/notebook-cloud/scripts/hosted-workstation-agent.mjs
+++ b/apps/notebook-cloud/scripts/hosted-workstation-agent.mjs
@@ -1,0 +1,449 @@
+import { spawn } from "node:child_process";
+import { closeSync, openSync } from "node:fs";
+import { access, mkdir, readFile } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+import { notebookCloudBaseUrl, notebookCloudWorkspaceRoot } from "./local-dev.mjs";
+
+const appDir = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
+const workspaceRoot = notebookCloudWorkspaceRoot({ cwd: appDir });
+
+await loadOptionalEnvFile();
+
+const baseUrl = notebookCloudBaseUrl();
+const apiKey = process.env.NTERACT_API_KEY ?? process.env.NOTEBOOK_CLOUD_PUBLISH_BEARER_TOKEN;
+const workstationId =
+  process.env.NOTEBOOK_CLOUD_WORKSTATION_ID ?? stableWorkstationId(os.hostname());
+const displayName =
+  process.env.NOTEBOOK_CLOUD_WORKSTATION_DISPLAY_NAME ?? `${os.hostname()} workstation`;
+const workingDirectory = path.resolve(process.env.NOTEBOOK_CLOUD_WORKSTATION_CWD ?? process.cwd());
+const pollIntervalMs = parsePositiveInteger(
+  process.env.NOTEBOOK_CLOUD_WORKSTATION_POLL_MS,
+  "NOTEBOOK_CLOUD_WORKSTATION_POLL_MS",
+  2_000,
+);
+const heartbeatIntervalMs = parsePositiveInteger(
+  process.env.NOTEBOOK_CLOUD_WORKSTATION_HEARTBEAT_MS,
+  "NOTEBOOK_CLOUD_WORKSTATION_HEARTBEAT_MS",
+  20_000,
+);
+const runtimedBin = path.resolve(
+  workspaceRoot,
+  process.env.NOTEBOOK_CLOUD_RUNTIMED_BIN ?? "target/release/runtimed",
+);
+const agentRoot = path.resolve(
+  workspaceRoot,
+  process.env.NOTEBOOK_CLOUD_WORKSTATION_AGENT_ROOT ??
+    path.join(".context", "smokes", "hosted-workstation-agent"),
+);
+
+const activeJobs = new Map();
+let lastHeartbeatAt = 0;
+
+main().catch((error) => {
+  console.error(error instanceof Error ? error.message : String(error));
+  process.exitCode = 1;
+});
+
+async function main() {
+  requireApiKey();
+  await assertBinaryExists(runtimedBin, "runtimed");
+  const pythonPath = await resolvePythonPath();
+  await mkdir(agentRoot, { recursive: true });
+
+  console.log(
+    JSON.stringify({
+      event: "workstation_agent_starting",
+      baseUrl,
+      workstationId,
+      displayName,
+      workingDirectory,
+      pythonPath,
+      pollIntervalMs,
+    }),
+  );
+
+  while (true) {
+    await heartbeatIfNeeded(pythonPath);
+    await pollAttachJobs(pythonPath);
+    await sleep(pollIntervalMs);
+  }
+}
+
+async function heartbeatIfNeeded(pythonPath) {
+  const now = Date.now();
+  if (now - lastHeartbeatAt < heartbeatIntervalMs) {
+    return;
+  }
+  await registerWorkstation(pythonPath);
+  lastHeartbeatAt = now;
+}
+
+async function registerWorkstation(pythonPath) {
+  const response = await fetch(new URL("/api/workstations", baseUrl), {
+    method: "POST",
+    headers: {
+      ...apiKeyHeaders(),
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify({
+      workstation_id: workstationId,
+      display_name: displayName,
+      provider: "runtime_peer",
+      default_environment_label: "Current Python",
+      environment_policy: "current_python",
+      working_directory: workingDirectory,
+      cpu_count: os.cpus().length,
+      memory_bytes: os.totalmem(),
+      capabilities: {
+        launch_current_python: true,
+      },
+      runtime: {
+        binary: "runtimed",
+        python_path: pythonPath,
+      },
+    }),
+  });
+  const body = await responseJson(response);
+  assertResponse(response, body, "register workstation", [200, 201]);
+}
+
+async function pollAttachJobs(pythonPath) {
+  const response = await fetch(
+    new URL(`/api/workstations/${encodeURIComponent(workstationId)}/attach-jobs`, baseUrl),
+    {
+      headers: apiKeyHeaders(),
+    },
+  );
+  const body = await responseJson(response);
+  assertResponse(response, body, "poll attach jobs", [200]);
+  for (const job of normalizeJobs(body)) {
+    if (activeJobs.has(job.job_id)) continue;
+    await startAttachJob(job, pythonPath);
+  }
+}
+
+async function startAttachJob(job, pythonPath) {
+  assert(typeof job.job_id === "string" && job.job_id.length > 0, "attach job missing id");
+  assert(
+    typeof job.notebook_id === "string" && job.notebook_id.length > 0,
+    `attach job ${job.job_id} missing notebook_id`,
+  );
+
+  const runRoot = path.join(agentRoot, safePathPart(job.job_id));
+  const blobRoot = path.join(runRoot, "blobs");
+  const logPath = path.join(runRoot, "runtime-peer.log");
+  await mkdir(blobRoot, { recursive: true });
+  await patchAttachJob(job.job_id, {
+    status: "accepted",
+  });
+
+  const args = [
+    "cloud-runtime-agent",
+    "--auth-kind",
+    "anaconda-key",
+    "--cloud-url",
+    baseUrl,
+    "--notebook-id",
+    job.notebook_id,
+    "--scope",
+    "runtime_peer",
+    "--python-path",
+    pythonPath,
+    "--blob-root",
+    blobRoot,
+    "--working-dir",
+    job.working_directory ?? workingDirectory,
+    "--workstation-id",
+    workstationId,
+    "--workstation-display-name",
+    displayName,
+  ];
+  if (typeof job.notebook_path === "string" && job.notebook_path.length > 0) {
+    args.push("--notebook-path", job.notebook_path);
+  }
+
+  const logFd = openSync(logPath, "a");
+  const child = spawn(runtimedBin, args, {
+    cwd: job.working_directory ?? workingDirectory,
+    env: runtimeAgentEnv(),
+    stdio: ["ignore", logFd, logFd],
+  });
+  closeSync(logFd);
+
+  const active = { child, logPath, ready: false };
+  activeJobs.set(job.job_id, active);
+  console.log(
+    JSON.stringify({
+      event: "attach_job_spawned",
+      jobId: job.job_id,
+      notebookId: job.notebook_id,
+      pid: child.pid,
+      logPath,
+    }),
+  );
+
+  watchRuntimePeer(job.job_id, active).catch((error) => {
+    console.error(
+      JSON.stringify({
+        event: "attach_job_watch_failed",
+        jobId: job.id,
+        message: error instanceof Error ? error.message : String(error),
+      }),
+    );
+  });
+}
+
+async function watchRuntimePeer(jobId, active) {
+  const readyPoll = setInterval(async () => {
+    if (active.ready) return;
+    const output = await readFile(active.logPath, "utf8").catch(() => "");
+    if (!output.includes("Infrastructure ready, entering main loop")) return;
+    active.ready = true;
+    await patchAttachJob(jobId, {
+      status: "running",
+    });
+  }, 250);
+
+  active.child.on("exit", async (code, signal) => {
+    clearInterval(readyPoll);
+    activeJobs.delete(jobId);
+    await patchAttachJob(jobId, {
+      status: code === 0 ? "completed" : "failed",
+      error_message:
+        code === 0 ? null : `Runtime peer exited with code=${code}, signal=${signal ?? ""}`,
+    }).catch((error) => {
+      console.error(
+        JSON.stringify({
+          event: "attach_job_exit_patch_failed",
+          jobId,
+          message: error instanceof Error ? error.message : String(error),
+        }),
+      );
+    });
+  });
+
+  active.child.on("error", async (error) => {
+    clearInterval(readyPoll);
+    activeJobs.delete(jobId);
+    await patchAttachJob(jobId, {
+      status: "failed",
+      error_message: error.message,
+    });
+  });
+}
+
+async function patchAttachJob(jobId, patch) {
+  const response = await fetch(
+    new URL(
+      `/api/workstations/${encodeURIComponent(workstationId)}/attach-jobs/${encodeURIComponent(jobId)}`,
+      baseUrl,
+    ),
+    {
+      method: "PATCH",
+      headers: {
+        ...apiKeyHeaders(),
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify(patch),
+    },
+  );
+  const body = await responseJson(response);
+  assertResponse(response, body, `patch attach job ${jobId}`, [200, 204]);
+}
+
+async function loadOptionalEnvFile() {
+  const envFile =
+    process.env.PREVIEW_RUNT_ENV ??
+    process.env.NOTEBOOK_CLOUD_ENV_FILE ??
+    path.join(os.homedir(), "preview.runt.run", ".env");
+  try {
+    const raw = await readFile(envFile, "utf8");
+    for (const line of raw.split(/\r?\n/)) {
+      const trimmed = line.trim();
+      if (!trimmed || trimmed.startsWith("#")) continue;
+      const match = trimmed.replace(/^export\s+/, "").match(/^([A-Za-z_][A-Za-z0-9_]*)=(.*)$/);
+      if (!match) continue;
+      const [, key, rawValue] = match;
+      if (process.env[key]) continue;
+      process.env[key] = rawValue.replace(/^["']|["']$/g, "").trim();
+    }
+  } catch (error) {
+    if (error?.code !== "ENOENT") {
+      throw error;
+    }
+  }
+}
+
+function requireApiKey() {
+  if (!apiKey) {
+    throw new Error(
+      "NTERACT_API_KEY or NOTEBOOK_CLOUD_PUBLISH_BEARER_TOKEN is required for hosted workstation agent",
+    );
+  }
+}
+
+function apiKeyHeaders() {
+  return {
+    Authorization: `Bearer ${apiKey}`,
+    "X-Notebook-Cloud-Auth-Provider": "anaconda-api-key",
+  };
+}
+
+function runtimeAgentEnv() {
+  return compactEnv({
+    HOME: process.env.HOME,
+    PATH: process.env.PATH,
+    LANG: process.env.LANG,
+    LC_ALL: process.env.LC_ALL,
+    SSL_CERT_FILE: process.env.SSL_CERT_FILE,
+    SSL_CERT_DIR: process.env.SSL_CERT_DIR,
+    RUST_BACKTRACE: process.env.RUST_BACKTRACE,
+    RUST_LOG: process.env.RUST_LOG ?? "info",
+    RUNT_CLOUD_TOKEN: apiKey,
+  });
+}
+
+function compactEnv(entries) {
+  return Object.fromEntries(
+    Object.entries(entries).filter(([, value]) => typeof value === "string" && value.length > 0),
+  );
+}
+
+async function resolvePythonPath() {
+  const explicit = process.env.NOTEBOOK_CLOUD_RUNTIME_PEER_PYTHON ?? process.env.PYTHON_PATH;
+  if (explicit) {
+    await assertPythonCanLaunchKernel(explicit);
+    return explicit;
+  }
+  const candidates = [
+    path.join(os.homedir(), "k", "bin", "python"),
+    await which("python3"),
+    await which("python"),
+  ].filter(Boolean);
+  for (const candidate of new Set(candidates)) {
+    if (await pythonCanLaunchKernel(candidate)) {
+      return candidate;
+    }
+  }
+  throw new Error(
+    "No Python with ipykernel was found. Set NOTEBOOK_CLOUD_RUNTIME_PEER_PYTHON to a kernel-capable interpreter.",
+  );
+}
+
+async function assertPythonCanLaunchKernel(pythonPath) {
+  if (await pythonCanLaunchKernel(pythonPath)) return;
+  throw new Error(
+    `${pythonPath} cannot import ipykernel. Set NOTEBOOK_CLOUD_RUNTIME_PEER_PYTHON to a kernel-capable interpreter.`,
+  );
+}
+
+async function pythonCanLaunchKernel(pythonPath) {
+  try {
+    await access(pythonPath);
+  } catch {
+    return false;
+  }
+  return new Promise((resolve) => {
+    const child = spawn(
+      pythonPath,
+      [
+        "-c",
+        "import importlib.util; raise SystemExit(0 if importlib.util.find_spec('ipykernel') else 1)",
+      ],
+      { stdio: ["ignore", "ignore", "ignore"] },
+    );
+    const timeout = setTimeout(() => {
+      child.kill("SIGTERM");
+      resolve(false);
+    }, 5_000);
+    child.on("error", () => {
+      clearTimeout(timeout);
+      resolve(false);
+    });
+    child.on("close", (code) => {
+      clearTimeout(timeout);
+      resolve(code === 0);
+    });
+  });
+}
+
+function which(command) {
+  return new Promise((resolve) => {
+    const child = spawn("sh", ["-lc", `command -v ${quoteShell(command)}`], {
+      stdio: ["ignore", "pipe", "ignore"],
+    });
+    let stdout = "";
+    child.stdout.setEncoding("utf8");
+    child.stdout.on("data", (chunk) => {
+      stdout += chunk;
+    });
+    child.on("close", (code) => {
+      resolve(code === 0 ? stdout.trim() : null);
+    });
+    child.on("error", () => resolve(null));
+  });
+}
+
+async function assertBinaryExists(binaryPath, name) {
+  try {
+    await access(binaryPath);
+  } catch {
+    throw new Error(
+      `Missing ${name} binary at ${binaryPath}. Run \`cargo build --release -p runtimed\` first, or set NOTEBOOK_CLOUD_${name.toUpperCase().replaceAll("-", "_")}_BIN.`,
+    );
+  }
+}
+
+async function responseJson(response) {
+  if (response.status === 204) return {};
+  return response.json().catch(async () => ({ error: await response.text() }));
+}
+
+function assertResponse(response, body, label, expectedStatuses) {
+  if (expectedStatuses.includes(response.status)) return;
+  throw new Error(`${label} failed: HTTP ${response.status} ${JSON.stringify(body).slice(0, 500)}`);
+}
+
+function normalizeJobs(body) {
+  if (Array.isArray(body)) return body;
+  if (Array.isArray(body?.jobs)) return body.jobs;
+  if (Array.isArray(body?.attach_jobs)) return body.attach_jobs;
+  return [];
+}
+
+function stableWorkstationId(hostname) {
+  return `ws-${safePathPart(hostname).slice(0, 80) || "local"}`;
+}
+
+function safePathPart(value) {
+  return value
+    .toLowerCase()
+    .replace(/[^a-z0-9._-]+/g, "-")
+    .replace(/^-+|-+$/g, "");
+}
+
+function parsePositiveInteger(value, name, fallback) {
+  if (value == null || value === "") return fallback;
+  const parsed = Number(value);
+  if (!Number.isInteger(parsed) || parsed <= 0) {
+    throw new Error(`${name} must be a positive integer`);
+  }
+  return parsed;
+}
+
+function quoteShell(value) {
+  return `'${value.replaceAll("'", "'\\''")}'`;
+}
+
+function sleep(ms) {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+function assert(condition, message) {
+  if (!condition) {
+    throw new Error(message);
+  }
+}

--- a/apps/notebook-cloud/scripts/hosted-workstation-toolbar-smoke.mjs
+++ b/apps/notebook-cloud/scripts/hosted-workstation-toolbar-smoke.mjs
@@ -215,6 +215,8 @@ async function runBrowserSmoke({
         "cell_output_observed_after_reload_execute",
         "owner_no_workstations_shows_setup_action",
         "owner_offline_default_workstation_shows_review_action",
+        "owner_missing_working_directory_explains_blocked_launch",
+        "owner_missing_environment_explains_blocked_launch",
         "viewer_scope_hides_execution_controls",
         "viewer_scope_hides_workstation_setup_action",
         "editor_scope_can_execute_when_host_capability_exists",
@@ -292,6 +294,7 @@ async function assertOwnerBlockedWorkstationStates({
   const noWorkstations = await assertOwnerToolbarActionWithMockedWorkstations({
     browser,
     expectedLabel: "Set up compute",
+    expectedPanelText: "Register a workstation to make this notebook runnable from your compute.",
     expectedTitleIncludes: ["Open workstations panel"],
     registry: {
       default_workstation_id: null,
@@ -305,6 +308,7 @@ async function assertOwnerBlockedWorkstationStates({
   const offlineDefault = await assertOwnerToolbarActionWithMockedWorkstations({
     browser,
     expectedLabel: "Review compute",
+    expectedPanelText: "No heartbeat from this workstation recently.",
     expectedTitleIncludes: ["Open workstations panel"],
     registry: {
       default_workstation_id: workstationId,
@@ -326,12 +330,59 @@ async function assertOwnerBlockedWorkstationStates({
     tokenStorageJson,
     url,
   });
-  return [noWorkstations, offlineDefault];
+  const missingWorkingDirectory = await assertOwnerToolbarActionWithMockedWorkstations({
+    browser,
+    expectedLabel: "Review compute",
+    expectedPanelText:
+      "This workstation does not have a working directory configured for notebook execution.",
+    expectedTitleIncludes: ["Open workstations panel"],
+    registry: {
+      default_workstation_id: workstationId,
+      workstations: [
+        {
+          workstation_id: workstationId,
+          display_name: "Workstation without cwd",
+          provider: "runtime_peer",
+          status: "online",
+          default_environment_label: "Current Python",
+          environment_policy: "current_python",
+        },
+      ],
+    },
+    scenario: "missing_working_directory",
+    timeoutMs,
+    tokenStorageJson,
+    url,
+  });
+  const missingEnvironment = await assertOwnerToolbarActionWithMockedWorkstations({
+    browser,
+    expectedLabel: "Review compute",
+    expectedPanelText: "This workstation does not have a runnable default environment configured.",
+    expectedTitleIncludes: ["Open workstations panel"],
+    registry: {
+      default_workstation_id: workstationId,
+      workstations: [
+        {
+          workstation_id: workstationId,
+          display_name: "Workstation without environment",
+          provider: "runtime_peer",
+          status: "online",
+          working_directory: "/home/ubuntu/project",
+        },
+      ],
+    },
+    scenario: "missing_environment",
+    timeoutMs,
+    tokenStorageJson,
+    url,
+  });
+  return [noWorkstations, offlineDefault, missingWorkingDirectory, missingEnvironment];
 }
 
 async function assertOwnerToolbarActionWithMockedWorkstations({
   browser,
   expectedLabel,
+  expectedPanelText = null,
   expectedTitleIncludes,
   registry,
   scenario,
@@ -370,6 +421,10 @@ async function assertOwnerToolbarActionWithMockedWorkstations({
       throw new Error(
         `${scenario} expected one workstation setup/review action, saw ${controls.workstationSetupButtonCount}`,
       );
+    }
+    if (expectedPanelText) {
+      await page.getByTestId("workstation-setup-button").click({ timeout: timeoutMs });
+      await waitForText(page, expectedPanelText, timeoutMs);
     }
     assertCleanBrowserDiagnostics(events);
     return {

--- a/apps/notebook-cloud/scripts/hosted-workstation-toolbar-smoke.mjs
+++ b/apps/notebook-cloud/scripts/hosted-workstation-toolbar-smoke.mjs
@@ -180,19 +180,20 @@ async function runBrowserSmoke({
       await ownerContext.close().catch(() => {});
     }
 
-    const scopedControlChecks = [];
-    for (const scope of ["viewer", "editor"]) {
-      scopedControlChecks.push(
-        await assertScopeDoesNotExposeExecutionControls({
-          browser,
-          runMarker,
-          scope,
-          timeoutMs,
-          tokenStorageJson,
-          url,
-        }),
-      );
-    }
+    const viewerControlCheck = await assertViewerDoesNotExposeExecutionControls({
+      browser,
+      runMarker,
+      timeoutMs,
+      tokenStorageJson,
+      url,
+    });
+    const editorRun = await runEditorExecuteSmoke({
+      browser,
+      runMarker,
+      timeoutMs,
+      tokenStorageJson,
+      url,
+    });
 
     return {
       ...ownerRun,
@@ -206,9 +207,10 @@ async function runBrowserSmoke({
         "cell_output_observed_after_reload_execute",
         "viewer_scope_hides_execution_controls",
         "viewer_scope_hides_workstation_setup_action",
-        "editor_scope_hides_execution_controls_until_execute_capability_exists",
+        "editor_scope_can_execute_when_host_capability_exists",
       ],
-      scopedControlChecks,
+      editorRun,
+      scopedControlChecks: [viewerControlCheck],
     };
   } finally {
     await browser.close().catch(() => {});
@@ -270,17 +272,16 @@ async function runOwnerAttachAndExecuteSmoke({
   };
 }
 
-async function assertScopeDoesNotExposeExecutionControls({
+async function assertViewerDoesNotExposeExecutionControls({
   browser,
   runMarker,
-  scope,
   timeoutMs,
   tokenStorageJson,
   url,
 }) {
   const context = await authenticatedContext(browser, {
     origin: url.origin,
-    scope,
+    scope: "viewer",
     tokenStorageJson,
   });
   try {
@@ -291,15 +292,47 @@ async function assertScopeDoesNotExposeExecutionControls({
     await waitForText(page, runMarker, timeoutMs);
     const controls = await visibleControlSummary(page);
     if (controls.executeButtonCount > 0 || controls.runAllButtonCount > 0) {
-      throw new Error(`${scope} scope unexpectedly exposed execution controls`);
+      throw new Error("viewer scope unexpectedly exposed execution controls");
     }
-    if (scope === "viewer" && controls.workstationSetupButtonCount > 0) {
+    if (controls.workstationSetupButtonCount > 0) {
       throw new Error("viewer scope unexpectedly exposed workstation setup controls");
     }
     assertCleanBrowserDiagnostics(events);
     return {
       controls,
-      scope,
+      scope: "viewer",
+    };
+  } finally {
+    await context.close().catch(() => {});
+  }
+}
+
+async function runEditorExecuteSmoke({ browser, runMarker, timeoutMs, tokenStorageJson, url }) {
+  const context = await authenticatedContext(browser, {
+    origin: url.origin,
+    scope: "editor",
+    tokenStorageJson,
+  });
+  const editorMarker = `${runMarker} editor`;
+  try {
+    const page = await context.newPage();
+    const events = collectBrowserDiagnostics(page);
+    await page.goto(url.href, { waitUntil: "domcontentloaded", timeout: timeoutMs });
+    await waitForNotebookSessionReady(page, timeoutMs);
+    await waitForText(page, runMarker, timeoutMs);
+    const cell = page.locator('[data-cell-type="code"]').first();
+    await cell.waitFor({ state: "visible", timeout: timeoutMs });
+    await setCellSource(cell, `print(${JSON.stringify(editorMarker)})`);
+    await executeAndWaitForMarker(page, cell, editorMarker, timeoutMs);
+    const controls = await visibleControlSummary(page);
+    if (controls.executeButtonCount === 0) {
+      throw new Error("editor scope did not expose execution controls despite host capability");
+    }
+    assertCleanBrowserDiagnostics(events);
+    return {
+      controls,
+      marker: editorMarker,
+      scope: "editor",
     };
   } finally {
     await context.close().catch(() => {});

--- a/apps/notebook-cloud/scripts/hosted-workstation-toolbar-smoke.mjs
+++ b/apps/notebook-cloud/scripts/hosted-workstation-toolbar-smoke.mjs
@@ -1,0 +1,477 @@
+import { readFile } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { pathToFileURL } from "node:url";
+
+import { chromium } from "@playwright/test";
+
+import {
+  saveSmokeScreenshot,
+  smokeJsonReportPath,
+  smokeOutputPath,
+  writeSmokeJsonReport,
+} from "./smoke-paths.mjs";
+
+if (isMainModule()) {
+  main().catch((error) => {
+    console.error(error instanceof Error ? error.message : String(error));
+    process.exitCode = 1;
+  });
+}
+
+async function main() {
+  await loadOptionalEnvFile();
+
+  const baseUrl = process.env.NTERACT_CLOUD_URL ?? "https://preview.runt.run";
+  const apiKey = process.env.NTERACT_API_KEY ?? process.env.NOTEBOOK_CLOUD_PUBLISH_BEARER_TOKEN;
+  const workstationId =
+    process.env.NOTEBOOK_CLOUD_WORKSTATION_TOOLBAR_SMOKE_WORKSTATION_ID ??
+    process.env.NOTEBOOK_CLOUD_WORKSTATION_ID ??
+    "lab2";
+  const tokenPath =
+    process.env.NTERACT_PREVIEW_OIDC_TOKEN_PATH ??
+    process.env.NOTEBOOK_CLOUD_OIDC_TOKEN_PATH ??
+    path.join(os.homedir(), "token.preview.json");
+  const timeoutMs = parsePositiveInteger(
+    process.env.NOTEBOOK_CLOUD_WORKSTATION_TOOLBAR_SMOKE_TIMEOUT_MS,
+    "NOTEBOOK_CLOUD_WORKSTATION_TOOLBAR_SMOKE_TIMEOUT_MS",
+    60_000,
+  );
+  const runMarker =
+    process.env.NOTEBOOK_CLOUD_WORKSTATION_TOOLBAR_SMOKE_MARKER ??
+    `toolbar attach smoke ${new Date()
+      .toISOString()
+      .replace(/[-:.TZ]/g, "")
+      .slice(0, 14)}`;
+  const source =
+    process.env.NOTEBOOK_CLOUD_WORKSTATION_TOOLBAR_SMOKE_CODE ??
+    `print(${JSON.stringify(runMarker)})`;
+  const title =
+    process.env.NOTEBOOK_CLOUD_WORKSTATION_TOOLBAR_SMOKE_TITLE ??
+    `Toolbar attach smoke ${new Date().toISOString()}`;
+  const vanityName =
+    process.env.NOTEBOOK_CLOUD_WORKSTATION_TOOLBAR_SMOKE_VANITY ?? "toolbar-attach-smoke";
+  const screenshotPath = smokeOutputPath(
+    process.env.NOTEBOOK_CLOUD_WORKSTATION_TOOLBAR_SMOKE_SCREENSHOT,
+  );
+  const reportPath = smokeJsonReportPath("hosted-workstation-toolbar-smoke");
+
+  if (!apiKey) {
+    throw new Error(
+      "NTERACT_API_KEY or NOTEBOOK_CLOUD_PUBLISH_BEARER_TOKEN is required for hosted workstation toolbar smoke",
+    );
+  }
+
+  const tokenStorageJson = await readOidcTokenStorageJson(tokenPath);
+  const token = JSON.parse(tokenStorageJson);
+  const tokenSecondsRemaining = Number(token.expiresAt) - Math.floor(Date.now() / 1000);
+  if (!Number.isFinite(tokenSecondsRemaining) || tokenSecondsRemaining <= 60) {
+    throw new Error(
+      `${tokenPath} is expired or near expiry; refresh it before running the workstation toolbar smoke`,
+    );
+  }
+
+  const workstationList = await fetchJson({
+    baseUrl,
+    label: "list workstations",
+    pathname: "/api/workstations",
+    token: apiKey,
+  });
+  const workstation = Array.isArray(workstationList.workstations)
+    ? workstationList.workstations.find((item) => item?.workstation_id === workstationId)
+    : null;
+  if (!workstation) {
+    throw new Error(
+      `workstation ${workstationId} is not registered for this user; start the workstation agent first`,
+    );
+  }
+  if (workstation.status !== "online") {
+    throw new Error(`workstation ${workstationId} is not online; status=${workstation.status}`);
+  }
+
+  await fetchJson({
+    baseUrl,
+    body: { workstation_id: workstationId },
+    label: "set default workstation",
+    method: "PATCH",
+    pathname: "/api/workstations/default",
+    token: apiKey,
+  });
+  const created = await fetchJson({
+    baseUrl,
+    body: { title, vanity_name: vanityName },
+    expectedStatuses: [201],
+    label: "create notebook",
+    method: "POST",
+    pathname: "/api/n",
+    token: apiKey,
+  });
+  const viewerUrl = scalarString(created.viewer_url);
+  if (!viewerUrl) {
+    throw new Error("create notebook response did not include viewer_url");
+  }
+
+  const browserResult = await runBrowserSmoke({
+    runMarker,
+    screenshotPath,
+    source,
+    timeoutMs,
+    tokenStorageJson,
+    viewerUrl,
+    workstationId,
+  });
+  const report = {
+    ok: true,
+    baseUrl,
+    notebookId: created.notebook_id,
+    source,
+    title,
+    token: {
+      path: tokenPath,
+      secondsRemaining: tokenSecondsRemaining,
+    },
+    viewerUrl,
+    workstation: {
+      id: workstationId,
+      displayName: scalarString(workstation.display_name),
+      status: scalarString(workstation.status),
+    },
+    checks: [
+      "workstation_registered_online",
+      "default_workstation_selected",
+      "notebook_created",
+      ...browserResult.checks,
+    ],
+    browser: browserResult,
+  };
+  await writeSmokeJsonReport(report, reportPath);
+  console.log(JSON.stringify(report, null, 2));
+}
+
+async function runBrowserSmoke({
+  runMarker,
+  screenshotPath,
+  source,
+  timeoutMs,
+  tokenStorageJson,
+  viewerUrl,
+  workstationId,
+}) {
+  const url = new URL(viewerUrl);
+  const browser = await chromium.launch({ headless: true });
+  try {
+    const context = await browser.newContext({ viewport: { width: 1440, height: 1000 } });
+    await context.addInitScript(
+      ({ origin, tokenJson }) => {
+        try {
+          if (globalThis.location?.origin !== origin) return;
+          globalThis.localStorage?.setItem("nteract:notebook-cloud:oidc-token", tokenJson);
+          globalThis.localStorage?.setItem("nteract:notebook-cloud:scope", "owner");
+        } catch {
+          // Output frames intentionally cannot read first-party localStorage.
+        }
+      },
+      { origin: url.origin, tokenJson: tokenStorageJson },
+    );
+
+    const page = await context.newPage();
+    const events = collectBrowserDiagnostics(page);
+    await openNotebookShell(page, url.href, timeoutMs);
+    const cell = await ensureCodeCell(page, timeoutMs);
+    await setCellSource(cell, source);
+
+    await waitForToolbarAction(page, "Attach compute", timeoutMs);
+    const action = {
+      label: await page.getByTestId("workstation-setup-button").getAttribute("aria-label"),
+      title: await page.getByTestId("workstation-setup-button").getAttribute("title"),
+    };
+    if (!action.title?.includes(workstationId) && !action.title?.includes("workstation")) {
+      throw new Error(`unexpected workstation action title: ${action.title ?? "null"}`);
+    }
+    await page.getByTestId("workstation-setup-button").click({ timeout: timeoutMs });
+
+    await executeAndWaitForMarker(page, cell, runMarker, timeoutMs);
+    const afterFirstRunAria = await cell.getByTestId("execute-button").getAttribute("aria-label");
+
+    await page.reload({ waitUntil: "domcontentloaded", timeout: timeoutMs });
+    await waitForNotebookReady(page, timeoutMs);
+    await waitForText(page, runMarker, timeoutMs);
+    const reloadedCell = page.locator('[data-cell-type="code"]').first();
+    await reloadedCell.waitFor({ state: "visible", timeout: timeoutMs });
+    const beforeReloadRunAria = await reloadedCell
+      .getByTestId("execute-button")
+      .getAttribute("aria-label");
+    await executeAndWaitForMarker(page, reloadedCell, runMarker, timeoutMs);
+    const afterReloadRunAria = await reloadedCell
+      .getByTestId("execute-button")
+      .getAttribute("aria-label");
+
+    if (screenshotPath) {
+      await saveSmokeScreenshot(page, screenshotPath);
+    }
+    assertCleanBrowserDiagnostics(events);
+    return {
+      action,
+      afterFirstRunAria,
+      afterReloadRunAria,
+      beforeReloadRunAria,
+      checks: [
+        "oidc_token_seeded_in_browser_storage",
+        "toolbar_attach_compute_rendered",
+        "toolbar_attach_compute_clicked",
+        "execute_button_rendered_after_attach",
+        "cell_output_observed_after_execute",
+        "page_reload_preserved_output",
+        "cell_output_observed_after_reload_execute",
+      ],
+      events,
+      screenshotPath: screenshotPath ?? null,
+    };
+  } finally {
+    await browser.close().catch(() => {});
+  }
+}
+
+function collectBrowserDiagnostics(page) {
+  const events = {
+    badConsole: [],
+    failedRequests: [],
+    pageErrors: [],
+  };
+  page.on("pageerror", (error) => {
+    const text = String(error.message ?? error);
+    if (!isBenignPageError(text)) {
+      events.pageErrors.push(text);
+    }
+  });
+  page.on("console", (message) => {
+    const text = message.text();
+    if (
+      /OutputResolutionError|Failed to fetch blob|duplicate seq|Unable to load notebook|cloud sync socket is closed|flush_comms_doc_sync|cannot execute|request origin is not allowed/i.test(
+        text,
+      )
+    ) {
+      events.badConsole.push(`${message.type()}: ${text}`);
+    }
+  });
+  page.on("requestfailed", (request) => {
+    const url = request.url();
+    const failure = request.failure()?.errorText ?? null;
+    if (isIgnorableRequestFailure(url, failure)) return;
+    events.failedRequests.push({ failure, url: redactDiagnosticUrl(url) });
+  });
+  return events;
+}
+
+function assertCleanBrowserDiagnostics(events) {
+  if (events.pageErrors.length > 0) {
+    throw new Error(`browser page errors:\n${events.pageErrors.join("\n")}`);
+  }
+  if (events.badConsole.length > 0) {
+    throw new Error(`browser console errors:\n${events.badConsole.join("\n")}`);
+  }
+  if (events.failedRequests.length > 0) {
+    throw new Error(`browser request failures:\n${JSON.stringify(events.failedRequests, null, 2)}`);
+  }
+}
+
+async function openNotebookShell(page, href, timeout) {
+  await page.goto(href, { waitUntil: "domcontentloaded", timeout });
+  await waitForNotebookReady(page, timeout);
+}
+
+async function waitForNotebookReady(page, timeout) {
+  await page.waitForSelector('[data-testid="notebook-toolbar"]', { timeout });
+  await page.waitForFunction(
+    () =>
+      document.querySelector("[data-notebook-synced]")?.getAttribute("data-notebook-synced") ===
+      "true",
+    null,
+    { timeout },
+  );
+  await page.waitForFunction(
+    () =>
+      document.querySelector("[data-session-ready]")?.getAttribute("data-session-ready") === "true",
+    null,
+    { timeout: Math.max(timeout, 120_000) },
+  );
+}
+
+async function ensureCodeCell(page, timeout) {
+  if ((await page.locator('[data-cell-type="code"]').count()) === 0) {
+    await page.getByTestId("add-code-cell-button").click({ timeout });
+  }
+  const cell = page.locator('[data-cell-type="code"]').first();
+  await cell.waitFor({ state: "visible", timeout });
+  return cell;
+}
+
+async function setCellSource(cell, source) {
+  await cell.locator('.cm-content[contenteditable="true"]').evaluate((node, text) => {
+    const editor = node.cmTile?.view;
+    if (!editor) throw new Error("No CodeMirror view found");
+    editor.dispatch({
+      changes: {
+        from: 0,
+        insert: text,
+        to: editor.state.doc.length,
+      },
+      selection: { anchor: text.length },
+    });
+    editor.focus();
+  }, source);
+}
+
+async function waitForToolbarAction(page, label, timeout) {
+  await page.waitForFunction(
+    (expected) =>
+      document
+        .querySelector('[data-testid="workstation-setup-button"]')
+        ?.getAttribute("aria-label") === expected,
+    label,
+    { timeout },
+  );
+}
+
+async function executeAndWaitForMarker(page, cell, marker, timeout) {
+  const executeButton = cell.getByTestId("execute-button");
+  await executeButton.waitFor({ state: "visible", timeout });
+  const beforeAria = await executeButton.getAttribute("aria-label");
+  const beforeOrdinal = executionOrdinal(beforeAria);
+  await executeButton.click({ timeout });
+  await waitForExecutionOrdinalAdvance(page, beforeOrdinal, timeout);
+  await waitForText(page, marker, timeout);
+}
+
+async function waitForText(page, text, timeout) {
+  await page.waitForFunction(
+    (expected) => (document.body.textContent ?? "").includes(expected),
+    text,
+    {
+      timeout,
+    },
+  );
+}
+
+async function waitForExecutionOrdinalAdvance(page, beforeOrdinal, timeout) {
+  await page.waitForFunction(
+    (previous) => {
+      const ordinals = [...document.querySelectorAll('[data-testid="execute-button"]')]
+        .map((button) => {
+          const text = button.getAttribute("aria-label");
+          const match = text?.match(/last execution (\d+)/i);
+          return match ? Number(match[1]) : null;
+        })
+        .filter((value) => Number.isFinite(value));
+      if (ordinals.length === 0) return false;
+      return Math.max(...ordinals) > previous;
+    },
+    beforeOrdinal,
+    { timeout },
+  );
+}
+
+function executionOrdinal(text) {
+  return executionOrdinalFromText(text) ?? 0;
+}
+
+function executionOrdinalFromText(text) {
+  if (!text) return null;
+  const match = text.match(/last execution (\d+)/i);
+  return match ? Number(match[1]) : null;
+}
+
+async function fetchJson({
+  baseUrl,
+  body = null,
+  expectedStatuses = [200],
+  label,
+  method = "GET",
+  pathname,
+  token,
+}) {
+  const requestInit = {
+    headers: {
+      Authorization: `Bearer ${token}`,
+      "Content-Type": "application/json",
+      "X-Notebook-Cloud-Auth-Provider": "anaconda-api-key",
+      "X-Scope": "owner",
+    },
+    method,
+  };
+  if (body) {
+    requestInit.body = JSON.stringify(body);
+  }
+
+  const response = await fetch(new URL(pathname, baseUrl), requestInit);
+  const payload = await response.json().catch(async () => ({ error: await response.text() }));
+  if (!expectedStatuses.includes(response.status)) {
+    throw new Error(`${label} failed: ${response.status} ${JSON.stringify(payload)}`);
+  }
+  return payload;
+}
+
+async function loadOptionalEnvFile() {
+  const envFile =
+    process.env.PREVIEW_RUNT_ENV ??
+    process.env.NOTEBOOK_CLOUD_ENV_FILE ??
+    path.join(os.homedir(), "preview.runt.run", ".env");
+  try {
+    const raw = await readFile(envFile, "utf8");
+    for (const line of raw.split(/\r?\n/)) {
+      const trimmed = line.trim();
+      if (!trimmed || trimmed.startsWith("#")) continue;
+      const match = trimmed.replace(/^export\s+/, "").match(/^([A-Za-z_][A-Za-z0-9_]*)=(.*)$/);
+      if (!match) continue;
+      const [, key, rawValue] = match;
+      if (process.env[key]) continue;
+      process.env[key] = rawValue.replace(/^["']|["']$/g, "").trim();
+    }
+  } catch (error) {
+    if (error?.code !== "ENOENT") {
+      throw error;
+    }
+  }
+}
+
+async function readOidcTokenStorageJson(tokenPath) {
+  const raw = await readFile(tokenPath, "utf8");
+  const token = JSON.parse(raw);
+  if (typeof token.accessToken !== "string" || token.accessToken.length === 0) {
+    throw new Error(`${tokenPath} is missing accessToken`);
+  }
+  if (!token.claims || typeof token.claims.sub !== "string" || token.claims.sub.length === 0) {
+    throw new Error(`${tokenPath} is missing claims.sub`);
+  }
+  return JSON.stringify(token);
+}
+
+function isBenignPageError(text) {
+  return /A listener indicated an asynchronous response by returning true/i.test(text);
+}
+
+export function isIgnorableRequestFailure(url, failure) {
+  if (/cdn-cgi\/rum|favicon/.test(url)) return true;
+  return /preview\.runtusercontent\.com\/frame\//.test(url) && failure === "net::ERR_ABORTED";
+}
+
+export function redactDiagnosticUrl(url) {
+  return url.replace(/([?&](?:token|access_token|authorization)=)[^&]+/gi, "$1[redacted]");
+}
+
+function scalarString(value) {
+  return typeof value === "string" && value.trim() ? value.trim() : null;
+}
+
+function parsePositiveInteger(value, label, fallback) {
+  if (value === undefined || value === null || value === "") return fallback;
+  const parsed = Number(value);
+  if (!Number.isInteger(parsed) || parsed <= 0) {
+    throw new Error(`${label} must be a positive integer`);
+  }
+  return parsed;
+}
+
+function isMainModule() {
+  return process.argv[1] ? import.meta.url === pathToFileURL(process.argv[1]).href : false;
+}

--- a/apps/notebook-cloud/scripts/hosted-workstation-toolbar-smoke.mjs
+++ b/apps/notebook-cloud/scripts/hosted-workstation-toolbar-smoke.mjs
@@ -160,6 +160,14 @@ async function runBrowserSmoke({
   const url = new URL(viewerUrl);
   const browser = await chromium.launch({ headless: true });
   try {
+    const blockedRuns = await assertOwnerBlockedWorkstationStates({
+      browser,
+      timeoutMs,
+      tokenStorageJson,
+      url,
+      workstationId,
+    });
+
     const ownerContext = await authenticatedContext(browser, {
       origin: url.origin,
       scope: "owner",
@@ -205,10 +213,13 @@ async function runBrowserSmoke({
         "cell_output_observed_after_execute",
         "page_reload_preserved_output",
         "cell_output_observed_after_reload_execute",
+        "owner_no_workstations_shows_setup_action",
+        "owner_offline_default_workstation_shows_review_action",
         "viewer_scope_hides_execution_controls",
         "viewer_scope_hides_workstation_setup_action",
         "editor_scope_can_execute_when_host_capability_exists",
       ],
+      blockedRuns,
       editorRun,
       scopedControlChecks: [viewerControlCheck],
     };
@@ -233,13 +244,12 @@ async function runOwnerAttachAndExecuteSmoke({
   await setCellSource(cell, source);
 
   await waitForToolbarAction(page, "Attach compute", timeoutMs);
-  const action = {
-    label: await page.getByTestId("workstation-setup-button").getAttribute("aria-label"),
-    title: await page.getByTestId("workstation-setup-button").getAttribute("title"),
-  };
-  if (!action.title?.includes(workstationId) && !action.title?.includes("workstation")) {
-    throw new Error(`unexpected workstation action title: ${action.title ?? "null"}`);
-  }
+  const action = await readToolbarWorkstationAction(page);
+  assertToolbarWorkstationAction(action, {
+    context: "owner attach",
+    label: "Attach compute",
+    titleIncludes: [workstationId, "workstation"],
+  });
   await page.getByTestId("workstation-setup-button").click({ timeout: timeoutMs });
 
   await executeAndWaitForMarker(page, cell, runMarker, timeoutMs);
@@ -270,6 +280,106 @@ async function runOwnerAttachAndExecuteSmoke({
     events,
     screenshotPath: screenshotPath ?? null,
   };
+}
+
+async function assertOwnerBlockedWorkstationStates({
+  browser,
+  timeoutMs,
+  tokenStorageJson,
+  url,
+  workstationId,
+}) {
+  const noWorkstations = await assertOwnerToolbarActionWithMockedWorkstations({
+    browser,
+    expectedLabel: "Set up compute",
+    expectedTitleIncludes: ["Open workstations panel"],
+    registry: {
+      default_workstation_id: null,
+      workstations: [],
+    },
+    scenario: "no_registered_workstations",
+    timeoutMs,
+    tokenStorageJson,
+    url,
+  });
+  const offlineDefault = await assertOwnerToolbarActionWithMockedWorkstations({
+    browser,
+    expectedLabel: "Review compute",
+    expectedTitleIncludes: ["Open workstations panel"],
+    registry: {
+      default_workstation_id: workstationId,
+      workstations: [
+        {
+          workstation_id: workstationId,
+          display_name: "Offline workstation",
+          provider: "runtime_peer",
+          status: "offline",
+          status_message: "No heartbeat from this workstation recently.",
+          default_environment_label: "Current Python",
+          environment_policy: "current_python",
+          working_directory: "/home/ubuntu/project",
+        },
+      ],
+    },
+    scenario: "offline_default_workstation",
+    timeoutMs,
+    tokenStorageJson,
+    url,
+  });
+  return [noWorkstations, offlineDefault];
+}
+
+async function assertOwnerToolbarActionWithMockedWorkstations({
+  browser,
+  expectedLabel,
+  expectedTitleIncludes,
+  registry,
+  scenario,
+  timeoutMs,
+  tokenStorageJson,
+  url,
+}) {
+  const context = await authenticatedContext(browser, {
+    origin: url.origin,
+    scope: "owner",
+    tokenStorageJson,
+  });
+  await context.route("**/api/workstations", (route) =>
+    route.fulfill({
+      body: JSON.stringify(registry),
+      contentType: "application/json",
+      status: 200,
+    }),
+  );
+  try {
+    const page = await context.newPage();
+    const events = collectBrowserDiagnostics(page);
+    await openNotebookShell(page, url.href, timeoutMs);
+    await waitForToolbarAction(page, expectedLabel, timeoutMs);
+    const action = await readToolbarWorkstationAction(page);
+    assertToolbarWorkstationAction(action, {
+      context: scenario,
+      label: expectedLabel,
+      titleIncludes: expectedTitleIncludes,
+    });
+    const controls = await visibleControlSummary(page);
+    if (controls.executeButtonCount > 0 || controls.runAllButtonCount > 0) {
+      throw new Error(`${scenario} unexpectedly exposed execution controls`);
+    }
+    if (controls.workstationSetupButtonCount !== 1) {
+      throw new Error(
+        `${scenario} expected one workstation setup/review action, saw ${controls.workstationSetupButtonCount}`,
+      );
+    }
+    assertCleanBrowserDiagnostics(events);
+    return {
+      action,
+      controls,
+      scenario,
+    };
+  } finally {
+    await context.close().catch(() => {});
+  }
 }
 
 async function assertViewerDoesNotExposeExecutionControls({
@@ -364,6 +474,38 @@ async function visibleControlSummary(page) {
       '[data-testid="workstation-setup-button"]',
     ).length,
   }));
+}
+
+async function readToolbarWorkstationAction(page) {
+  const button = page.getByTestId("workstation-setup-button");
+  if ((await button.count()) === 0) return null;
+  return {
+    label: await button.getAttribute("aria-label"),
+    title: await button.getAttribute("title"),
+  };
+}
+
+export function assertToolbarWorkstationAction(
+  action,
+  { context = "workstation toolbar", label, titleIncludes = [] },
+) {
+  if (!action) {
+    throw new Error(`${context} expected workstation toolbar action ${label}`);
+  }
+  if (action.label !== label) {
+    throw new Error(
+      `${context} expected workstation toolbar action ${label}, saw ${action.label ?? "null"}`,
+    );
+  }
+  for (const expected of titleIncludes) {
+    if (!action.title?.includes(expected)) {
+      throw new Error(
+        `${context} expected workstation toolbar title to include ${expected}, saw ${
+          action.title ?? "null"
+        }`,
+      );
+    }
+  }
 }
 
 function collectBrowserDiagnostics(page) {
@@ -590,6 +732,7 @@ function isBenignPageError(text) {
 
 export function isIgnorableRequestFailure(url, failure) {
   if (/cdn-cgi\/rum|favicon/.test(url)) return true;
+  if (url.endsWith("/api/workstations") && failure === "net::ERR_ABORTED") return true;
   return /preview\.runtusercontent\.com\/frame\//.test(url) && failure === "net::ERR_ABORTED";
 }
 

--- a/apps/notebook-cloud/scripts/hosted-workstation-toolbar-smoke.mjs
+++ b/apps/notebook-cloud/scripts/hosted-workstation-toolbar-smoke.mjs
@@ -160,61 +160,42 @@ async function runBrowserSmoke({
   const url = new URL(viewerUrl);
   const browser = await chromium.launch({ headless: true });
   try {
-    const context = await browser.newContext({ viewport: { width: 1440, height: 1000 } });
-    await context.addInitScript(
-      ({ origin, tokenJson }) => {
-        try {
-          if (globalThis.location?.origin !== origin) return;
-          globalThis.localStorage?.setItem("nteract:notebook-cloud:oidc-token", tokenJson);
-          globalThis.localStorage?.setItem("nteract:notebook-cloud:scope", "owner");
-        } catch {
-          // Output frames intentionally cannot read first-party localStorage.
-        }
-      },
-      { origin: url.origin, tokenJson: tokenStorageJson },
-    );
-
-    const page = await context.newPage();
-    const events = collectBrowserDiagnostics(page);
-    await openNotebookShell(page, url.href, timeoutMs);
-    const cell = await ensureCodeCell(page, timeoutMs);
-    await setCellSource(cell, source);
-
-    await waitForToolbarAction(page, "Attach compute", timeoutMs);
-    const action = {
-      label: await page.getByTestId("workstation-setup-button").getAttribute("aria-label"),
-      title: await page.getByTestId("workstation-setup-button").getAttribute("title"),
-    };
-    if (!action.title?.includes(workstationId) && !action.title?.includes("workstation")) {
-      throw new Error(`unexpected workstation action title: ${action.title ?? "null"}`);
+    const ownerContext = await authenticatedContext(browser, {
+      origin: url.origin,
+      scope: "owner",
+      tokenStorageJson,
+    });
+    let ownerRun;
+    try {
+      ownerRun = await runOwnerAttachAndExecuteSmoke({
+        context: ownerContext,
+        runMarker,
+        screenshotPath,
+        source,
+        timeoutMs,
+        url,
+        workstationId,
+      });
+    } finally {
+      await ownerContext.close().catch(() => {});
     }
-    await page.getByTestId("workstation-setup-button").click({ timeout: timeoutMs });
 
-    await executeAndWaitForMarker(page, cell, runMarker, timeoutMs);
-    const afterFirstRunAria = await cell.getByTestId("execute-button").getAttribute("aria-label");
-
-    await page.reload({ waitUntil: "domcontentloaded", timeout: timeoutMs });
-    await waitForNotebookReady(page, timeoutMs);
-    await waitForText(page, runMarker, timeoutMs);
-    const reloadedCell = page.locator('[data-cell-type="code"]').first();
-    await reloadedCell.waitFor({ state: "visible", timeout: timeoutMs });
-    const beforeReloadRunAria = await reloadedCell
-      .getByTestId("execute-button")
-      .getAttribute("aria-label");
-    await executeAndWaitForMarker(page, reloadedCell, runMarker, timeoutMs);
-    const afterReloadRunAria = await reloadedCell
-      .getByTestId("execute-button")
-      .getAttribute("aria-label");
-
-    if (screenshotPath) {
-      await saveSmokeScreenshot(page, screenshotPath);
+    const scopedControlChecks = [];
+    for (const scope of ["viewer", "editor"]) {
+      scopedControlChecks.push(
+        await assertScopeDoesNotExposeExecutionControls({
+          browser,
+          runMarker,
+          scope,
+          timeoutMs,
+          tokenStorageJson,
+          url,
+        }),
+      );
     }
-    assertCleanBrowserDiagnostics(events);
+
     return {
-      action,
-      afterFirstRunAria,
-      afterReloadRunAria,
-      beforeReloadRunAria,
+      ...ownerRun,
       checks: [
         "oidc_token_seeded_in_browser_storage",
         "toolbar_attach_compute_rendered",
@@ -223,13 +204,133 @@ async function runBrowserSmoke({
         "cell_output_observed_after_execute",
         "page_reload_preserved_output",
         "cell_output_observed_after_reload_execute",
+        "viewer_scope_hides_execution_controls",
+        "viewer_scope_hides_workstation_setup_action",
+        "editor_scope_hides_execution_controls_until_execute_capability_exists",
       ],
-      events,
-      screenshotPath: screenshotPath ?? null,
+      scopedControlChecks,
     };
   } finally {
     await browser.close().catch(() => {});
   }
+}
+
+async function runOwnerAttachAndExecuteSmoke({
+  context,
+  runMarker,
+  screenshotPath,
+  source,
+  timeoutMs,
+  url,
+  workstationId,
+}) {
+  const page = await context.newPage();
+  const events = collectBrowserDiagnostics(page);
+  await openNotebookShell(page, url.href, timeoutMs);
+  const cell = await ensureCodeCell(page, timeoutMs);
+  await setCellSource(cell, source);
+
+  await waitForToolbarAction(page, "Attach compute", timeoutMs);
+  const action = {
+    label: await page.getByTestId("workstation-setup-button").getAttribute("aria-label"),
+    title: await page.getByTestId("workstation-setup-button").getAttribute("title"),
+  };
+  if (!action.title?.includes(workstationId) && !action.title?.includes("workstation")) {
+    throw new Error(`unexpected workstation action title: ${action.title ?? "null"}`);
+  }
+  await page.getByTestId("workstation-setup-button").click({ timeout: timeoutMs });
+
+  await executeAndWaitForMarker(page, cell, runMarker, timeoutMs);
+  const afterFirstRunAria = await cell.getByTestId("execute-button").getAttribute("aria-label");
+
+  await page.reload({ waitUntil: "domcontentloaded", timeout: timeoutMs });
+  await waitForNotebookReady(page, timeoutMs);
+  await waitForText(page, runMarker, timeoutMs);
+  const reloadedCell = page.locator('[data-cell-type="code"]').first();
+  await reloadedCell.waitFor({ state: "visible", timeout: timeoutMs });
+  const beforeReloadRunAria = await reloadedCell
+    .getByTestId("execute-button")
+    .getAttribute("aria-label");
+  await executeAndWaitForMarker(page, reloadedCell, runMarker, timeoutMs);
+  const afterReloadRunAria = await reloadedCell
+    .getByTestId("execute-button")
+    .getAttribute("aria-label");
+
+  if (screenshotPath) {
+    await saveSmokeScreenshot(page, screenshotPath);
+  }
+  assertCleanBrowserDiagnostics(events);
+  return {
+    action,
+    afterFirstRunAria,
+    afterReloadRunAria,
+    beforeReloadRunAria,
+    events,
+    screenshotPath: screenshotPath ?? null,
+  };
+}
+
+async function assertScopeDoesNotExposeExecutionControls({
+  browser,
+  runMarker,
+  scope,
+  timeoutMs,
+  tokenStorageJson,
+  url,
+}) {
+  const context = await authenticatedContext(browser, {
+    origin: url.origin,
+    scope,
+    tokenStorageJson,
+  });
+  try {
+    const page = await context.newPage();
+    const events = collectBrowserDiagnostics(page);
+    await page.goto(url.href, { waitUntil: "domcontentloaded", timeout: timeoutMs });
+    await waitForNotebookSessionReady(page, timeoutMs);
+    await waitForText(page, runMarker, timeoutMs);
+    const controls = await visibleControlSummary(page);
+    if (controls.executeButtonCount > 0 || controls.runAllButtonCount > 0) {
+      throw new Error(`${scope} scope unexpectedly exposed execution controls`);
+    }
+    if (scope === "viewer" && controls.workstationSetupButtonCount > 0) {
+      throw new Error("viewer scope unexpectedly exposed workstation setup controls");
+    }
+    assertCleanBrowserDiagnostics(events);
+    return {
+      controls,
+      scope,
+    };
+  } finally {
+    await context.close().catch(() => {});
+  }
+}
+
+async function authenticatedContext(browser, { origin, scope, tokenStorageJson }) {
+  const context = await browser.newContext({ viewport: { width: 1440, height: 1000 } });
+  await context.addInitScript(
+    ({ expectedOrigin, requestedScope, tokenJson }) => {
+      try {
+        if (globalThis.location?.origin !== expectedOrigin) return;
+        globalThis.localStorage?.setItem("nteract:notebook-cloud:oidc-token", tokenJson);
+        globalThis.localStorage?.setItem("nteract:notebook-cloud:scope", requestedScope);
+      } catch {
+        // Output frames intentionally cannot read first-party localStorage.
+      }
+    },
+    { expectedOrigin: origin, requestedScope: scope, tokenJson: tokenStorageJson },
+  );
+  return context;
+}
+
+async function visibleControlSummary(page) {
+  return page.evaluate(() => ({
+    executeButtonCount: document.querySelectorAll('[data-testid="execute-button"]').length,
+    runAllButtonCount: document.querySelectorAll('[data-testid="run-all-button"]').length,
+    workstationSetupButtonCount: document.querySelectorAll(
+      '[data-testid="workstation-setup-button"]',
+    ).length,
+  }));
 }
 
 function collectBrowserDiagnostics(page) {
@@ -282,6 +383,10 @@ async function openNotebookShell(page, href, timeout) {
 
 async function waitForNotebookReady(page, timeout) {
   await page.waitForSelector('[data-testid="notebook-toolbar"]', { timeout });
+  await waitForNotebookSessionReady(page, timeout);
+}
+
+async function waitForNotebookSessionReady(page, timeout) {
   await page.waitForFunction(
     () =>
       document.querySelector("[data-notebook-synced]")?.getAttribute("data-notebook-synced") ===

--- a/apps/notebook-cloud/src/index.ts
+++ b/apps/notebook-cloud/src/index.ts
@@ -3245,7 +3245,6 @@ async function viewer(
     workstationAttachEndpoint: `${notebookApiBasePath}/workstation-attachments`,
     hostCapabilities: {
       canManageSharing: true,
-      canSubmitExecutionRequests: true,
     },
     syncEndpoint: `/n/${encodeURIComponent(notebookId)}/sync`,
     blobBasePath: notebookCloudBlobBasePath(notebookId),

--- a/apps/notebook-cloud/src/index.ts
+++ b/apps/notebook-cloud/src/index.ts
@@ -25,23 +25,37 @@ import {
   blobKey,
   commsDocSnapshotKey,
   createNotebookWithOwnerAcl,
+  createWorkstationAttachJob,
   ensureCatalogSchema,
+  getCanonicalPrincipalForTransport,
+  getDefaultWorkstationId,
   getNotebookAclRows,
   getNotebookRow,
   getNotebookCatalog,
   getPublicPublishedNotebookRow,
+  getWorkstationRow,
   grantNotebookAclRow,
+  listPendingWorkstationAttachJobs,
   listNotebooksForPrincipal,
+  listWorkstationsForPrincipal,
   recordBlob,
   recordRevision,
+  registerWorkstation,
   revokeNotebookAclRow,
   runtimeStateSnapshotKey,
   snapshotKey,
+  setDefaultWorkstation,
   updateNotebookTitle,
+  updateWorkstationAttachJobStatus,
   type ListedNotebookRow,
   type NotebookAclRow,
   type NotebookAccessRequestRow,
   type NotebookAccessRequestStatus,
+  type WorkstationAttachJobRow,
+  type WorkstationAttachJobStatus,
+  type WorkstationRegistrationInput,
+  type WorkstationRow,
+  type WorkstationStatus,
 } from "./storage.ts";
 import { materializeSnapshotPairRender } from "./snapshot-render.ts";
 import {
@@ -190,6 +204,32 @@ const NOTEBOOK_CLOUD_ROUTES: readonly WorkerRoute[] = [
     handler: (_match, request, env) => routeListNotebooks(request, env),
   },
   {
+    match: exactPath("/api/workstations"),
+    methods: ["GET", "POST"],
+    handler: (_match, request, env) => routeWorkstations(request, env),
+  },
+  {
+    match: exactPath("/api/workstations/default"),
+    methods: ["PATCH"],
+    handler: (_match, request, env) => routeDefaultWorkstation(request, env),
+  },
+  {
+    match: routePath("/api/workstations/:workstationId/attach-jobs/:jobId", {
+      trailingSlash: "optional",
+    }),
+    methods: ["PATCH"],
+    handler: ({ params }, request, env) =>
+      routeWorkstationAttachJob(request, env, params.workstationId, params.jobId),
+  },
+  {
+    match: routePath("/api/workstations/:workstationId/attach-jobs", {
+      trailingSlash: "optional",
+    }),
+    methods: ["GET"],
+    handler: ({ params }, request, env) =>
+      routeWorkstationAttachJobs(request, env, params.workstationId),
+  },
+  {
     match: routePath("/api/n/:notebookId", { trailingSlash: "optional" }),
     methods: ["GET"],
     handler: ({ params }, request, env) => routeCatalog(request, env, params.notebookId),
@@ -217,6 +257,12 @@ const NOTEBOOK_CLOUD_ROUTES: readonly WorkerRoute[] = [
     match: routePath("/api/n/:notebookId/access-requests", { trailingSlash: "optional" }),
     handler: ({ params }, request, env) =>
       routeNotebookAccessRequests(request, env, params.notebookId),
+  },
+  {
+    match: routePath("/api/n/:notebookId/workstation-attachments", { trailingSlash: "optional" }),
+    methods: ["POST"],
+    handler: ({ params }, request, env) =>
+      routeNotebookWorkstationAttachment(request, env, params.notebookId),
   },
   {
     match: routePath("/api/n/:notebookId/access-requests/:accessRequestId", {
@@ -713,6 +759,326 @@ function parseNotebookListLimit(request: Request): number | Response {
   return Math.min(limit, MAX_NOTEBOOK_LIST_LIMIT);
 }
 
+const WORKSTATION_HEARTBEAT_STALE_MS = 90_000;
+const MAX_WORKSTATION_ATTACH_JOBS_LIMIT = 25;
+
+async function routeWorkstations(request: Request, env: Env): Promise<Response> {
+  if (!env.DB) {
+    return json({ error: "D1 binding DB is not configured" }, 503);
+  }
+
+  if (request.method === "POST") {
+    const originRejection = rejectUntrustedMutationOrigin(request, env);
+    if (originRejection) {
+      return originRejection;
+    }
+  }
+
+  const identity = await authenticateRequestOrResponse(request, env);
+  if (identity instanceof Response) {
+    return identity;
+  }
+  if (isAnonymousViewer(identity)) {
+    return json({ error: "sign in to manage workstations" }, 401);
+  }
+
+  const ownerPrincipal = await canonicalPrincipalForIdentity(env, identity);
+
+  if (request.method === "GET") {
+    const [workstations, defaultWorkstationId] = await Promise.all([
+      listWorkstationsForPrincipal(env, ownerPrincipal),
+      getDefaultWorkstationId(env, ownerPrincipal),
+    ]);
+    return json({
+      ok: true,
+      default_workstation_id: defaultWorkstationId,
+      workstations: workstations.map((workstation) =>
+        workstationResponseRow(workstation, {
+          defaultWorkstationId,
+          now: Date.now(),
+        }),
+      ),
+    });
+  }
+
+  if (request.method !== "POST") {
+    return json({ error: "method not allowed" }, 405);
+  }
+
+  const payload = await readRequiredJsonObject(request, "workstation registration body");
+  if (payload instanceof Response) {
+    return payload;
+  }
+  const registration = parseWorkstationRegistrationPayload(payload);
+  if (registration instanceof Response) {
+    return registration;
+  }
+
+  const workstation = await registerWorkstation(env, ownerPrincipal, registration);
+  if (!workstation) {
+    return json({ error: "workstation was not registered" }, 500);
+  }
+  cloudLog("info", "workstation.registered", {
+    principal: ownerPrincipal,
+    workstation_id: workstation.workstation_id,
+    provider: workstation.provider,
+    counter: "workstation_registrations",
+    counter_delta: 1,
+  });
+  return json(
+    {
+      ok: true,
+      workstation: workstationResponseRow(workstation, {
+        defaultWorkstationId: await getDefaultWorkstationId(env, ownerPrincipal),
+        now: Date.now(),
+      }),
+    },
+    201,
+  );
+}
+
+async function routeDefaultWorkstation(request: Request, env: Env): Promise<Response> {
+  if (!env.DB) {
+    return json({ error: "D1 binding DB is not configured" }, 503);
+  }
+
+  const originRejection = rejectUntrustedMutationOrigin(request, env);
+  if (originRejection) {
+    return originRejection;
+  }
+
+  const identity = await authenticateRequestOrResponse(request, env);
+  if (identity instanceof Response) {
+    return identity;
+  }
+  if (isAnonymousViewer(identity)) {
+    return json({ error: "sign in to select a default workstation" }, 401);
+  }
+
+  const payload = await readRequiredJsonObject(request, "default workstation body");
+  if (payload instanceof Response) {
+    return payload;
+  }
+  const workstationId = boundedStringField(
+    payload.workstation_id ?? payload.workstationId,
+    "workstation_id",
+    128,
+  );
+  if (workstationId instanceof Response) {
+    return workstationId;
+  }
+
+  const ownerPrincipal = await canonicalPrincipalForIdentity(env, identity);
+  const selected = await setDefaultWorkstation(env, ownerPrincipal, workstationId);
+  if (!selected) {
+    return json({ error: "workstation not found" }, 404);
+  }
+
+  return json({
+    ok: true,
+    default_workstation_id: selected,
+  });
+}
+
+async function routeNotebookWorkstationAttachment(
+  request: Request,
+  env: Env,
+  notebookId: string,
+): Promise<Response> {
+  if (!env.DB) {
+    return json({ error: "D1 binding DB is not configured" }, 503);
+  }
+
+  const originRejection = rejectUntrustedMutationOrigin(request, env);
+  if (originRejection) {
+    return originRejection;
+  }
+
+  const identity = await authenticateAndAuthorizeOrResponse(request, env, notebookId, "owner");
+  if (identity instanceof Response) {
+    return identity;
+  }
+
+  const payload = await readOptionalJsonObject(request, "workstation attachment body");
+  if (payload instanceof Response) {
+    return payload;
+  }
+
+  const ownerPrincipal = await canonicalPrincipalForIdentity(env, identity);
+  const explicitWorkstationId = optionalBoundedStringField(
+    payload?.workstation_id ?? payload?.workstationId,
+    "workstation_id",
+    128,
+  );
+  if (explicitWorkstationId instanceof Response) {
+    return explicitWorkstationId;
+  }
+  const workstationId =
+    explicitWorkstationId ?? (await getDefaultWorkstationId(env, ownerPrincipal));
+  if (!workstationId) {
+    return json({ error: "choose a default workstation before attaching compute" }, 409);
+  }
+
+  const workstation = await getWorkstationRow(env, ownerPrincipal, workstationId);
+  if (!workstation) {
+    return json({ error: "workstation not found" }, 404);
+  }
+
+  const projectedStatus = workstationStatusForResponse(workstation, Date.now());
+  if (projectedStatus !== "online") {
+    return json(
+      {
+        error: "workstation is not online",
+        workstation: workstationResponseRow(workstation, {
+          defaultWorkstationId: workstationId,
+          now: Date.now(),
+        }),
+      },
+      409,
+    );
+  }
+
+  await grantNotebookAclRow(env, {
+    notebookId,
+    subjectKind: "principal",
+    subject: ownerPrincipal,
+    scope: "runtime_peer",
+    actorLabel: identity.actorLabel,
+  });
+  const job = await createWorkstationAttachJob(env, {
+    notebookId,
+    ownerPrincipal,
+    workstationId,
+    actorLabel: identity.actorLabel,
+  });
+  if (!job) {
+    return json({ error: "workstation attach job was not created" }, 500);
+  }
+
+  cloudLog("info", "workstation.attach.requested", {
+    notebook_id: notebookId,
+    principal: ownerPrincipal,
+    workstation_id: workstationId,
+    job_id: job.id,
+    counter: "workstation_attach_requests",
+    counter_delta: 1,
+  });
+  return json(
+    {
+      ok: true,
+      job: workstationAttachJobResponseRow(request, job),
+      workstation: workstationResponseRow(workstation, {
+        defaultWorkstationId: workstationId,
+        now: Date.now(),
+      }),
+    },
+    202,
+  );
+}
+
+async function routeWorkstationAttachJobs(
+  request: Request,
+  env: Env,
+  workstationId: string,
+): Promise<Response> {
+  if (!env.DB) {
+    return json({ error: "D1 binding DB is not configured" }, 503);
+  }
+
+  const identity = await authenticateRequestOrResponse(request, env);
+  if (identity instanceof Response) {
+    return identity;
+  }
+  if (isAnonymousViewer(identity)) {
+    return json({ error: "sign in to poll workstation jobs" }, 401);
+  }
+
+  const ownerPrincipal = await canonicalPrincipalForIdentity(env, identity);
+  const workstation = await getWorkstationRow(env, ownerPrincipal, workstationId);
+  if (!workstation) {
+    return json({ error: "workstation not found" }, 404);
+  }
+
+  const limit = parseWorkstationAttachJobsLimit(request);
+  if (limit instanceof Response) {
+    return limit;
+  }
+  const jobs = await listPendingWorkstationAttachJobs(env, ownerPrincipal, workstationId, limit);
+  return json({
+    ok: true,
+    workstation: workstationResponseRow(workstation, {
+      defaultWorkstationId: await getDefaultWorkstationId(env, ownerPrincipal),
+      now: Date.now(),
+    }),
+    jobs: jobs.map((job) => workstationAttachJobResponseRow(request, job)),
+  });
+}
+
+async function routeWorkstationAttachJob(
+  request: Request,
+  env: Env,
+  workstationId: string,
+  jobId: string,
+): Promise<Response> {
+  if (!env.DB) {
+    return json({ error: "D1 binding DB is not configured" }, 503);
+  }
+
+  const originRejection = rejectUntrustedMutationOrigin(request, env);
+  if (originRejection) {
+    return originRejection;
+  }
+
+  const identity = await authenticateRequestOrResponse(request, env);
+  if (identity instanceof Response) {
+    return identity;
+  }
+  if (isAnonymousViewer(identity)) {
+    return json({ error: "sign in to update workstation jobs" }, 401);
+  }
+
+  const payload = await readRequiredJsonObject(request, "workstation attach job body");
+  if (payload instanceof Response) {
+    return payload;
+  }
+  const statusValue = boundedStringField(payload.status, "status", 24);
+  if (statusValue instanceof Response) {
+    return statusValue;
+  }
+  if (!isWorkstationAttachJobStatus(statusValue) || statusValue === "pending") {
+    return json(
+      {
+        error: "status must be accepted, running, failed, completed, or cancelled",
+      },
+      400,
+    );
+  }
+  const errorMessageValue = optionalBoundedStringField(
+    payload.error_message ?? payload.errorMessage,
+    "error_message",
+    512,
+  );
+  if (errorMessageValue instanceof Response) {
+    return errorMessageValue;
+  }
+
+  const ownerPrincipal = await canonicalPrincipalForIdentity(env, identity);
+  const job = await updateWorkstationAttachJobStatus(env, {
+    ownerPrincipal,
+    workstationId,
+    jobId,
+    status: statusValue,
+    errorMessage: errorMessageValue,
+  });
+  if (!job) {
+    return json({ error: "workstation attach job not found" }, 404);
+  }
+  return json({
+    ok: true,
+    job: workstationAttachJobResponseRow(request, job),
+  });
+}
+
 async function readCreateNotebookPayload(
   request: Request,
 ): Promise<CreateNotebookPayload | Response> {
@@ -755,6 +1121,272 @@ function optionalPayloadString(
     return json({ error: `${options.field} is too long` }, 400);
   }
   return value;
+}
+
+async function canonicalPrincipalForIdentity(
+  env: Env,
+  identity: AuthenticatedConnection,
+): Promise<string> {
+  return (await getCanonicalPrincipalForTransport(env, identity.principal)) ?? identity.principal;
+}
+
+async function readRequiredJsonObject(
+  request: Request,
+  bodyName: string,
+): Promise<Record<string, unknown> | Response> {
+  let payload: unknown;
+  try {
+    payload = await request.json();
+  } catch {
+    return json({ error: `${bodyName} must be JSON` }, 400);
+  }
+  if (!isRecord(payload)) {
+    return json({ error: `${bodyName} must be a JSON object` }, 400);
+  }
+  return payload;
+}
+
+async function readOptionalJsonObject(
+  request: Request,
+  bodyName: string,
+): Promise<Record<string, unknown> | null | Response> {
+  const contentType = request.headers.get("content-type")?.toLowerCase() ?? "";
+  if (!contentType.includes("application/json")) {
+    return null;
+  }
+  return readRequiredJsonObject(request, bodyName);
+}
+
+function parseWorkstationRegistrationPayload(
+  payload: Record<string, unknown>,
+): WorkstationRegistrationInput | Response {
+  const workstationId = boundedStringField(
+    payload.workstation_id ?? payload.workstationId,
+    "workstation_id",
+    128,
+  );
+  if (workstationId instanceof Response) {
+    return workstationId;
+  }
+  const displayName =
+    optionalBoundedStringField(payload.display_name ?? payload.displayName, "display_name", 160) ??
+    workstationId;
+  if (displayName instanceof Response) {
+    return displayName;
+  }
+  const provider = optionalBoundedStringField(payload.provider, "provider", 80);
+  if (provider instanceof Response) {
+    return provider;
+  }
+  const providerLabel = optionalBoundedStringField(
+    payload.provider_label ?? payload.providerLabel,
+    "provider_label",
+    120,
+  );
+  if (providerLabel instanceof Response) {
+    return providerLabel;
+  }
+  const statusMessage = optionalBoundedStringField(
+    payload.status_message ?? payload.statusMessage,
+    "status_message",
+    240,
+  );
+  if (statusMessage instanceof Response) {
+    return statusMessage;
+  }
+  const defaultEnvironmentLabel = optionalBoundedStringField(
+    payload.default_environment_label ?? payload.defaultEnvironmentLabel,
+    "default_environment_label",
+    160,
+  );
+  if (defaultEnvironmentLabel instanceof Response) {
+    return defaultEnvironmentLabel;
+  }
+  const environmentPolicy = optionalBoundedStringField(
+    payload.environment_policy ?? payload.environmentPolicy,
+    "environment_policy",
+    80,
+  );
+  if (environmentPolicy instanceof Response) {
+    return environmentPolicy;
+  }
+  const workingDirectory = optionalBoundedStringField(
+    payload.working_directory ?? payload.workingDirectory,
+    "working_directory",
+    512,
+  );
+  if (workingDirectory instanceof Response) {
+    return workingDirectory;
+  }
+  const cpuCount = optionalPositiveIntegerField(payload.cpu_count ?? payload.cpuCount, "cpu_count");
+  if (cpuCount instanceof Response) {
+    return cpuCount;
+  }
+  const memoryBytes = optionalPositiveIntegerField(
+    payload.memory_bytes ?? payload.memoryBytes,
+    "memory_bytes",
+  );
+  if (memoryBytes instanceof Response) {
+    return memoryBytes;
+  }
+  const environmentsJson = normalizeWorkstationEnvironmentsJson(payload.environments);
+  if (environmentsJson instanceof Response) {
+    return environmentsJson;
+  }
+
+  return {
+    workstationId,
+    displayName,
+    provider,
+    providerLabel,
+    statusMessage,
+    defaultEnvironmentLabel,
+    environmentPolicy,
+    workingDirectory,
+    cpuCount,
+    memoryBytes,
+    environmentsJson,
+  };
+}
+
+function normalizeWorkstationEnvironmentsJson(value: unknown): string | null | Response {
+  if (value === undefined || value === null) {
+    return null;
+  }
+  if (!Array.isArray(value)) {
+    return json({ error: "environments must be an array" }, 400);
+  }
+  const normalized: Array<Record<string, unknown>> = [];
+  for (const rawEnvironment of value.slice(0, 16)) {
+    if (!isRecord(rawEnvironment)) {
+      return json({ error: "environments must contain JSON objects" }, 400);
+    }
+    const id = boundedStringField(rawEnvironment.id, "environment.id", 128);
+    if (id instanceof Response) {
+      return id;
+    }
+    const label = boundedStringField(rawEnvironment.label, "environment.label", 160);
+    if (label instanceof Response) {
+      return label;
+    }
+    const detail = optionalBoundedStringField(rawEnvironment.detail, "environment.detail", 240);
+    if (detail instanceof Response) {
+      return detail;
+    }
+    const health = optionalBoundedStringField(rawEnvironment.health, "environment.health", 240);
+    if (health instanceof Response) {
+      return health;
+    }
+    const policy = optionalBoundedStringField(rawEnvironment.policy, "environment.policy", 80);
+    if (policy instanceof Response) {
+      return policy;
+    }
+    normalized.push({
+      id,
+      label,
+      available: rawEnvironment.available === false ? false : true,
+      is_default: rawEnvironment.is_default === true || rawEnvironment.isDefault === true,
+      detail,
+      health,
+      policy,
+    });
+  }
+  return JSON.stringify(normalized);
+}
+
+function workstationResponseRow(
+  workstation: WorkstationRow,
+  options: { defaultWorkstationId: string | null; now: number },
+): Record<string, unknown> {
+  const status = workstationStatusForResponse(workstation, options.now);
+  return {
+    workstation_id: workstation.workstation_id,
+    display_name: workstation.display_name,
+    provider: workstation.provider,
+    provider_label: workstation.provider_label,
+    status,
+    status_message:
+      status === "offline" && workstation.status === "online"
+        ? "No heartbeat from this workstation recently."
+        : workstation.status_message,
+    default_environment_label: workstation.default_environment_label,
+    environment_policy: workstation.environment_policy,
+    working_directory: workstation.working_directory,
+    cpu_count: workstation.cpu_count,
+    memory_bytes: workstation.memory_bytes,
+    environments: parseStoredWorkstationEnvironments(workstation.environments_json),
+    created_at: workstation.created_at,
+    updated_at: workstation.updated_at,
+    last_seen_at: workstation.last_seen_at,
+    is_default: options.defaultWorkstationId === workstation.workstation_id,
+  };
+}
+
+function workstationStatusForResponse(workstation: WorkstationRow, now: number): WorkstationStatus {
+  if (workstation.status === "online" && workstation.last_seen_at) {
+    const lastSeen = Date.parse(workstation.last_seen_at);
+    if (Number.isFinite(lastSeen) && now - lastSeen > WORKSTATION_HEARTBEAT_STALE_MS) {
+      return "offline";
+    }
+  }
+  return workstation.status;
+}
+
+function parseStoredWorkstationEnvironments(value: string | null): unknown[] {
+  if (!value) {
+    return [];
+  }
+  try {
+    const parsed = JSON.parse(value);
+    return Array.isArray(parsed) ? parsed : [];
+  } catch {
+    return [];
+  }
+}
+
+function workstationAttachJobResponseRow(
+  request: Request,
+  job: WorkstationAttachJobRow,
+): Record<string, unknown> {
+  return {
+    job_id: job.id,
+    notebook_id: job.notebook_id,
+    workstation_id: job.workstation_id,
+    status: job.status,
+    requested_at: job.requested_at,
+    updated_at: job.updated_at,
+    accepted_at: job.accepted_at,
+    finished_at: job.finished_at,
+    error_message: job.error_message,
+    runtime_peer: {
+      cloud_url: new URL(request.url).origin,
+      notebook_id: job.notebook_id,
+      scope: "runtime_peer",
+    },
+  };
+}
+
+function parseWorkstationAttachJobsLimit(request: Request): number | Response {
+  const value = new URL(request.url).searchParams.get("limit");
+  if (value === null || value.trim() === "") {
+    return 10;
+  }
+  const limit = Number(value);
+  if (!Number.isInteger(limit) || limit < 1) {
+    return json({ error: "limit must be a positive integer" }, 400);
+  }
+  return Math.min(limit, MAX_WORKSTATION_ATTACH_JOBS_LIMIT);
+}
+
+function isWorkstationAttachJobStatus(value: string): value is WorkstationAttachJobStatus {
+  return (
+    value === "pending" ||
+    value === "accepted" ||
+    value === "running" ||
+    value === "failed" ||
+    value === "completed" ||
+    value === "cancelled"
+  );
 }
 
 async function createUniqueNotebookId(env: Env): Promise<string | null> {
@@ -2285,6 +2917,46 @@ function optionalStringField(value: unknown, fieldName: string): string | null |
   return trimmed ? trimmed : null;
 }
 
+function boundedStringField(
+  value: unknown,
+  fieldName: string,
+  maxLength: number,
+): string | Response {
+  const text = stringField(value, fieldName);
+  if (text instanceof Response) {
+    return text;
+  }
+  if (text.length > maxLength) {
+    return json({ error: `${fieldName} is too long` }, 400);
+  }
+  return text;
+}
+
+function optionalBoundedStringField(
+  value: unknown,
+  fieldName: string,
+  maxLength: number,
+): string | null | Response {
+  const text = optionalStringField(value, fieldName);
+  if (text instanceof Response || text === null) {
+    return text;
+  }
+  if (text.length > maxLength) {
+    return json({ error: `${fieldName} is too long` }, 400);
+  }
+  return text;
+}
+
+function optionalPositiveIntegerField(value: unknown, fieldName: string): number | null | Response {
+  if (value === undefined || value === null) {
+    return null;
+  }
+  if (typeof value !== "number" || !Number.isInteger(value) || value < 0) {
+    return json({ error: `${fieldName} must be a positive integer` }, 400);
+  }
+  return value;
+}
+
 function isOwnerAclInput(row: ParsedNotebookAclInput): boolean {
   return row.subject_kind === "principal" && row.scope === "owner";
 }
@@ -2568,6 +3240,9 @@ async function viewer(
     aclEndpoint: `${notebookApiBasePath}/acl`,
     invitesEndpoint: `${notebookApiBasePath}/invites`,
     accessRequestsEndpoint: `${notebookApiBasePath}/access-requests`,
+    workstationsEndpoint: "/api/workstations",
+    workstationDefaultEndpoint: "/api/workstations/default",
+    workstationAttachEndpoint: `${notebookApiBasePath}/workstation-attachments`,
     hostCapabilities: {
       canManageSharing: true,
     },
@@ -2586,6 +3261,9 @@ interface ViewerShellConfig extends Record<string, unknown> {
   rendererAssetsBasePath?: string;
   runtimedWasmModulePath: string;
   runtimedWasmPath: string;
+  workstationAttachEndpoint?: string;
+  workstationDefaultEndpoint?: string;
+  workstationsEndpoint?: string;
 }
 
 function homeViewer(request: Request, env: Env): Response {

--- a/apps/notebook-cloud/src/index.ts
+++ b/apps/notebook-cloud/src/index.ts
@@ -3245,6 +3245,7 @@ async function viewer(
     workstationAttachEndpoint: `${notebookApiBasePath}/workstation-attachments`,
     hostCapabilities: {
       canManageSharing: true,
+      canSubmitExecutionRequests: true,
     },
     syncEndpoint: `/n/${encodeURIComponent(notebookId)}/sync`,
     blobBasePath: notebookCloudBlobBasePath(notebookId),

--- a/apps/notebook-cloud/src/storage.ts
+++ b/apps/notebook-cloud/src/storage.ts
@@ -904,7 +904,7 @@ export async function createWorkstationAttachJob(
 
   const now = new Date().toISOString();
   const jobId = crypto.randomUUID();
-  await env.DB.prepare(
+  const insert = env.DB.prepare(
     `INSERT INTO workstation_attach_jobs (
        id,
        notebook_id,
@@ -915,17 +915,24 @@ export async function createWorkstationAttachJob(
        requested_at,
        updated_at
      ) VALUES (?, ?, ?, ?, 'pending', ?, ?, ?)`,
-  )
-    .bind(
-      jobId,
-      input.notebookId,
-      input.ownerPrincipal,
-      input.workstationId,
-      input.actorLabel,
-      now,
-      now,
-    )
-    .run();
+  ).bind(
+    jobId,
+    input.notebookId,
+    input.ownerPrincipal,
+    input.workstationId,
+    input.actorLabel,
+    now,
+    now,
+  );
+  try {
+    await insert.run();
+  } catch (error) {
+    const racedExisting = await getActiveWorkstationAttachJob(env, input);
+    if (racedExisting) {
+      return racedExisting;
+    }
+    throw error;
+  }
   return getWorkstationAttachJob(env, input.ownerPrincipal, input.workstationId, jobId);
 }
 

--- a/apps/notebook-cloud/src/storage.ts
+++ b/apps/notebook-cloud/src/storage.ts
@@ -85,6 +85,63 @@ export interface PrincipalAccountLinkRow {
   last_seen_at: string;
 }
 
+export type WorkstationStatus = "online" | "offline" | "connecting" | "attention" | "unknown";
+
+export type WorkstationAttachJobStatus =
+  | "pending"
+  | "accepted"
+  | "running"
+  | "failed"
+  | "completed"
+  | "cancelled";
+
+export interface WorkstationRow {
+  owner_principal: string;
+  workstation_id: string;
+  display_name: string;
+  provider: string;
+  provider_label: string | null;
+  status: WorkstationStatus;
+  status_message: string | null;
+  default_environment_label: string | null;
+  environment_policy: string | null;
+  working_directory: string | null;
+  cpu_count: number | null;
+  memory_bytes: number | null;
+  environments_json: string | null;
+  created_at: string;
+  updated_at: string;
+  last_seen_at: string | null;
+}
+
+export interface WorkstationRegistrationInput {
+  workstationId: string;
+  displayName: string;
+  provider?: string | null;
+  providerLabel?: string | null;
+  statusMessage?: string | null;
+  defaultEnvironmentLabel?: string | null;
+  environmentPolicy?: string | null;
+  workingDirectory?: string | null;
+  cpuCount?: number | null;
+  memoryBytes?: number | null;
+  environmentsJson?: string | null;
+}
+
+export interface WorkstationAttachJobRow {
+  id: string;
+  notebook_id: string;
+  owner_principal: string;
+  workstation_id: string;
+  status: WorkstationAttachJobStatus;
+  requested_by_actor_label: string;
+  requested_at: string;
+  updated_at: string;
+  accepted_at: string | null;
+  finished_at: string | null;
+  error_message: string | null;
+}
+
 const SCHEMA_STATEMENTS = [
   `CREATE TABLE IF NOT EXISTS notebooks (
     id TEXT PRIMARY KEY,
@@ -204,6 +261,51 @@ const SCHEMA_STATEMENTS = [
     ON notebook_access_requests(notebook_id, status, created_at)`,
   `CREATE INDEX IF NOT EXISTS notebook_access_requests_requester_idx
     ON notebook_access_requests(requester_principal, notebook_id, created_at)`,
+  `CREATE TABLE IF NOT EXISTS workstations (
+    owner_principal TEXT NOT NULL,
+    workstation_id TEXT NOT NULL,
+    display_name TEXT NOT NULL,
+    provider TEXT NOT NULL DEFAULT 'runtime_peer',
+    provider_label TEXT,
+    status TEXT NOT NULL CHECK (status IN ('online', 'offline', 'connecting', 'attention', 'unknown')),
+    status_message TEXT,
+    default_environment_label TEXT,
+    environment_policy TEXT,
+    working_directory TEXT,
+    cpu_count INTEGER,
+    memory_bytes INTEGER,
+    environments_json TEXT,
+    created_at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ', 'now')),
+    updated_at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ', 'now')),
+    last_seen_at TEXT,
+    PRIMARY KEY (owner_principal, workstation_id)
+  )`,
+  `CREATE INDEX IF NOT EXISTS workstations_owner_updated_idx
+    ON workstations(owner_principal, updated_at DESC)`,
+  `CREATE TABLE IF NOT EXISTS workstation_defaults (
+    owner_principal TEXT PRIMARY KEY,
+    workstation_id TEXT NOT NULL,
+    updated_at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ', 'now'))
+  )`,
+  `CREATE TABLE IF NOT EXISTS workstation_attach_jobs (
+    id TEXT PRIMARY KEY,
+    notebook_id TEXT NOT NULL,
+    owner_principal TEXT NOT NULL,
+    workstation_id TEXT NOT NULL,
+    status TEXT NOT NULL CHECK (status IN ('pending', 'accepted', 'running', 'failed', 'completed', 'cancelled')),
+    requested_by_actor_label TEXT NOT NULL,
+    requested_at TEXT NOT NULL,
+    updated_at TEXT NOT NULL,
+    accepted_at TEXT,
+    finished_at TEXT,
+    error_message TEXT,
+    FOREIGN KEY (notebook_id) REFERENCES notebooks(id)
+  )`,
+  `CREATE UNIQUE INDEX IF NOT EXISTS workstation_attach_jobs_active_unique_idx
+    ON workstation_attach_jobs(notebook_id, owner_principal, workstation_id)
+    WHERE status IN ('pending', 'accepted', 'running')`,
+  `CREATE INDEX IF NOT EXISTS workstation_attach_jobs_poll_idx
+    ON workstation_attach_jobs(owner_principal, workstation_id, status, requested_at)`,
 ];
 
 const SCHEMA_MIGRATIONS = [
@@ -596,6 +698,382 @@ export async function revokeNotebookAclRow(
     .bind(row.notebookId, row.subjectKind, row.subject, row.scope, row.notebookId, row.subject)
     .run();
   return d1Changes(result) > 0;
+}
+
+export async function registerWorkstation(
+  env: Env,
+  ownerPrincipal: string,
+  input: WorkstationRegistrationInput,
+): Promise<WorkstationRow | null> {
+  if (!env.DB) {
+    return null;
+  }
+
+  await ensureCatalogSchema(env);
+  const now = new Date().toISOString();
+  await env.DB.prepare(
+    `INSERT INTO workstations (
+       owner_principal,
+       workstation_id,
+       display_name,
+       provider,
+       provider_label,
+       status,
+       status_message,
+       default_environment_label,
+       environment_policy,
+       working_directory,
+       cpu_count,
+       memory_bytes,
+       environments_json,
+       created_at,
+       updated_at,
+       last_seen_at
+     ) VALUES (?, ?, ?, ?, ?, 'online', ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+     ON CONFLICT(owner_principal, workstation_id) DO UPDATE SET
+       display_name = excluded.display_name,
+       provider = excluded.provider,
+       provider_label = excluded.provider_label,
+       status = excluded.status,
+       status_message = excluded.status_message,
+       default_environment_label = excluded.default_environment_label,
+       environment_policy = excluded.environment_policy,
+       working_directory = excluded.working_directory,
+       cpu_count = excluded.cpu_count,
+       memory_bytes = excluded.memory_bytes,
+       environments_json = excluded.environments_json,
+       updated_at = excluded.updated_at,
+       last_seen_at = excluded.last_seen_at`,
+  )
+    .bind(
+      ownerPrincipal,
+      input.workstationId,
+      input.displayName,
+      input.provider ?? "runtime_peer",
+      input.providerLabel ?? null,
+      input.statusMessage ?? null,
+      input.defaultEnvironmentLabel ?? null,
+      input.environmentPolicy ?? null,
+      input.workingDirectory ?? null,
+      input.cpuCount ?? null,
+      input.memoryBytes ?? null,
+      input.environmentsJson ?? null,
+      now,
+      now,
+      now,
+    )
+    .run();
+  return getWorkstationRow(env, ownerPrincipal, input.workstationId);
+}
+
+export async function getWorkstationRow(
+  env: Env,
+  ownerPrincipal: string,
+  workstationId: string,
+): Promise<WorkstationRow | null> {
+  if (!env.DB) {
+    return null;
+  }
+
+  await ensureCatalogSchema(env);
+  return env.DB.prepare(
+    `SELECT owner_principal,
+            workstation_id,
+            display_name,
+            provider,
+            provider_label,
+            status,
+            status_message,
+            default_environment_label,
+            environment_policy,
+            working_directory,
+            cpu_count,
+            memory_bytes,
+            environments_json,
+            created_at,
+            updated_at,
+            last_seen_at
+       FROM workstations
+      WHERE owner_principal = ?
+        AND workstation_id = ?`,
+  )
+    .bind(ownerPrincipal, workstationId)
+    .first<WorkstationRow>();
+}
+
+export async function listWorkstationsForPrincipal(
+  env: Env,
+  ownerPrincipal: string,
+): Promise<WorkstationRow[]> {
+  if (!env.DB) {
+    return [];
+  }
+
+  await ensureCatalogSchema(env);
+  const rows = await env.DB.prepare(
+    `SELECT owner_principal,
+            workstation_id,
+            display_name,
+            provider,
+            provider_label,
+            status,
+            status_message,
+            default_environment_label,
+            environment_policy,
+            working_directory,
+            cpu_count,
+            memory_bytes,
+            environments_json,
+            created_at,
+            updated_at,
+            last_seen_at
+       FROM workstations
+      WHERE owner_principal = ?
+      ORDER BY last_seen_at DESC, updated_at DESC, workstation_id`,
+  )
+    .bind(ownerPrincipal)
+    .all<WorkstationRow>();
+  return rows.results ?? [];
+}
+
+export async function getDefaultWorkstationId(
+  env: Env,
+  ownerPrincipal: string,
+): Promise<string | null> {
+  if (!env.DB) {
+    return null;
+  }
+
+  await ensureCatalogSchema(env);
+  const row = await env.DB.prepare(
+    `SELECT workstation_id
+       FROM workstation_defaults
+      WHERE owner_principal = ?`,
+  )
+    .bind(ownerPrincipal)
+    .first<Pick<WorkstationRow, "workstation_id">>();
+  return row?.workstation_id ?? null;
+}
+
+export async function setDefaultWorkstation(
+  env: Env,
+  ownerPrincipal: string,
+  workstationId: string,
+): Promise<string | null> {
+  if (!env.DB) {
+    return null;
+  }
+
+  await ensureCatalogSchema(env);
+  const workstation = await getWorkstationRow(env, ownerPrincipal, workstationId);
+  if (!workstation) {
+    return null;
+  }
+
+  const now = new Date().toISOString();
+  await env.DB.prepare(
+    `INSERT INTO workstation_defaults (owner_principal, workstation_id, updated_at)
+     VALUES (?, ?, ?)
+     ON CONFLICT(owner_principal) DO UPDATE SET
+       workstation_id = excluded.workstation_id,
+       updated_at = excluded.updated_at`,
+  )
+    .bind(ownerPrincipal, workstationId, now)
+    .run();
+  return workstationId;
+}
+
+export async function createWorkstationAttachJob(
+  env: Env,
+  input: {
+    notebookId: string;
+    ownerPrincipal: string;
+    workstationId: string;
+    actorLabel: string;
+  },
+): Promise<WorkstationAttachJobRow | null> {
+  if (!env.DB) {
+    return null;
+  }
+
+  await ensureCatalogSchema(env);
+  const existing = await getActiveWorkstationAttachJob(env, input);
+  if (existing) {
+    return existing;
+  }
+
+  const now = new Date().toISOString();
+  const jobId = crypto.randomUUID();
+  await env.DB.prepare(
+    `INSERT INTO workstation_attach_jobs (
+       id,
+       notebook_id,
+       owner_principal,
+       workstation_id,
+       status,
+       requested_by_actor_label,
+       requested_at,
+       updated_at
+     ) VALUES (?, ?, ?, ?, 'pending', ?, ?, ?)`,
+  )
+    .bind(
+      jobId,
+      input.notebookId,
+      input.ownerPrincipal,
+      input.workstationId,
+      input.actorLabel,
+      now,
+      now,
+    )
+    .run();
+  return getWorkstationAttachJob(env, input.ownerPrincipal, input.workstationId, jobId);
+}
+
+export async function listPendingWorkstationAttachJobs(
+  env: Env,
+  ownerPrincipal: string,
+  workstationId: string,
+  limit = 10,
+): Promise<WorkstationAttachJobRow[]> {
+  if (!env.DB) {
+    return [];
+  }
+
+  await ensureCatalogSchema(env);
+  const rows = await env.DB.prepare(
+    `SELECT id,
+            notebook_id,
+            owner_principal,
+            workstation_id,
+            status,
+            requested_by_actor_label,
+            requested_at,
+            updated_at,
+            accepted_at,
+            finished_at,
+            error_message
+       FROM workstation_attach_jobs
+      WHERE owner_principal = ?
+        AND workstation_id = ?
+        AND status = 'pending'
+      ORDER BY requested_at ASC
+      LIMIT ?`,
+  )
+    .bind(ownerPrincipal, workstationId, limit)
+    .all<WorkstationAttachJobRow>();
+  return rows.results ?? [];
+}
+
+export async function updateWorkstationAttachJobStatus(
+  env: Env,
+  input: {
+    ownerPrincipal: string;
+    workstationId: string;
+    jobId: string;
+    status: WorkstationAttachJobStatus;
+    errorMessage?: string | null;
+  },
+): Promise<WorkstationAttachJobRow | null> {
+  if (!env.DB) {
+    return null;
+  }
+
+  await ensureCatalogSchema(env);
+  const now = new Date().toISOString();
+  await env.DB.prepare(
+    `UPDATE workstation_attach_jobs
+        SET status = ?,
+            updated_at = ?,
+            accepted_at = CASE
+              WHEN ? IN ('accepted', 'running') AND accepted_at IS NULL THEN ?
+              ELSE accepted_at
+            END,
+            finished_at = CASE
+              WHEN ? IN ('failed', 'completed', 'cancelled') THEN ?
+              ELSE finished_at
+            END,
+            error_message = ?
+      WHERE id = ?
+        AND owner_principal = ?
+        AND workstation_id = ?`,
+  )
+    .bind(
+      input.status,
+      now,
+      input.status,
+      now,
+      input.status,
+      now,
+      input.errorMessage ?? null,
+      input.jobId,
+      input.ownerPrincipal,
+      input.workstationId,
+    )
+    .run();
+  return getWorkstationAttachJob(env, input.ownerPrincipal, input.workstationId, input.jobId);
+}
+
+async function getActiveWorkstationAttachJob(
+  env: Env,
+  input: {
+    notebookId: string;
+    ownerPrincipal: string;
+    workstationId: string;
+  },
+): Promise<WorkstationAttachJobRow | null> {
+  const row = await env
+    .DB!.prepare(
+      `SELECT id,
+            notebook_id,
+            owner_principal,
+            workstation_id,
+            status,
+            requested_by_actor_label,
+            requested_at,
+            updated_at,
+            accepted_at,
+            finished_at,
+            error_message
+       FROM workstation_attach_jobs
+      WHERE notebook_id = ?
+        AND owner_principal = ?
+        AND workstation_id = ?
+        AND status IN ('pending', 'accepted', 'running')
+      ORDER BY requested_at DESC
+      LIMIT 1`,
+    )
+    .bind(input.notebookId, input.ownerPrincipal, input.workstationId)
+    .first<WorkstationAttachJobRow>();
+  return row;
+}
+
+async function getWorkstationAttachJob(
+  env: Env,
+  ownerPrincipal: string,
+  workstationId: string,
+  jobId: string,
+): Promise<WorkstationAttachJobRow | null> {
+  const row = await env
+    .DB!.prepare(
+      `SELECT id,
+            notebook_id,
+            owner_principal,
+            workstation_id,
+            status,
+            requested_by_actor_label,
+            requested_at,
+            updated_at,
+            accepted_at,
+            finished_at,
+            error_message
+       FROM workstation_attach_jobs
+      WHERE id = ?
+        AND owner_principal = ?
+        AND workstation_id = ?`,
+    )
+    .bind(jobId, ownerPrincipal, workstationId)
+    .first<WorkstationAttachJobRow>();
+  return row;
 }
 
 export interface CreateNotebookWithOwnerAclResult {

--- a/apps/notebook-cloud/test/hosted-runtime-browser-execute-smoke.test.mjs
+++ b/apps/notebook-cloud/test/hosted-runtime-browser-execute-smoke.test.mjs
@@ -10,7 +10,7 @@ import {
 
 describe("hosted runtime/browser execute smoke helpers", () => {
   it("parses default and explicit browser scopes", () => {
-    assert.deepEqual(parseScopes(undefined), ["owner", "editor"]);
+    assert.deepEqual(parseScopes(undefined), ["owner"]);
     assert.deepEqual(parseScopes("owner,editor"), ["owner", "editor"]);
     assert.deepEqual(parseScopes("owner editor"), ["owner", "editor"]);
     assert.deepEqual(parseScopes(" owner "), ["owner"]);

--- a/apps/notebook-cloud/test/hosted-workstation-agent.test.mjs
+++ b/apps/notebook-cloud/test/hosted-workstation-agent.test.mjs
@@ -1,0 +1,133 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+
+import {
+  buildAttachJobSpawnPlan,
+  buildRuntimeAgentEnv,
+  buildWorkstationRegistrationPayload,
+  parsePositiveInteger,
+  stableWorkstationId,
+} from "../scripts/hosted-workstation-agent-core.mjs";
+
+describe("hosted workstation agent launch contract", () => {
+  it("launches runtime peers from the workstation cwd by default", () => {
+    const plan = buildAttachJobSpawnPlan({
+      job: {
+        job_id: "Job 123",
+        notebook_id: "nb-1",
+      },
+      pythonPath: "/opt/k/bin/python",
+      agentRoot: "/tmp/agent",
+      baseUrl: "https://preview.runt.run",
+      workingDirectory: "/home/ubuntu/project",
+      workstationId: "ws-lab2",
+      displayName: "lab2 workstation",
+    });
+
+    assert.equal(plan.cwd, "/home/ubuntu/project");
+    assert.equal(plan.blobRoot, "/tmp/agent/job-123/blobs");
+    assert.equal(plan.logPath, "/tmp/agent/job-123/runtime-peer.log");
+    assert.deepEqual(plan.args, [
+      "cloud-runtime-agent",
+      "--auth-kind",
+      "anaconda-key",
+      "--cloud-url",
+      "https://preview.runt.run",
+      "--notebook-id",
+      "nb-1",
+      "--scope",
+      "runtime_peer",
+      "--python-path",
+      "/opt/k/bin/python",
+      "--blob-root",
+      "/tmp/agent/job-123/blobs",
+      "--working-dir",
+      "/home/ubuntu/project",
+      "--workstation-id",
+      "ws-lab2",
+      "--workstation-display-name",
+      "lab2 workstation",
+    ]);
+  });
+
+  it("lets an attach job override cwd and notebook path without putting secrets in argv", () => {
+    const plan = buildAttachJobSpawnPlan({
+      job: {
+        job_id: "job-2",
+        notebook_id: "nb-2",
+        working_directory: "/srv/notebook-project",
+        notebook_path: "/srv/notebook-project/report.ipynb",
+      },
+      pythonPath: "/opt/k/bin/python",
+      agentRoot: "/tmp/agent",
+      baseUrl: "https://preview.runt.run",
+      workingDirectory: "/home/ubuntu/project",
+      workstationId: "ws-lab2",
+      displayName: "lab2 workstation",
+    });
+
+    assert.equal(plan.cwd, "/srv/notebook-project");
+    assert.deepEqual(plan.args.slice(-2), [
+      "--notebook-path",
+      "/srv/notebook-project/report.ipynb",
+    ]);
+    assert.equal(plan.args.includes("secret-api-key"), false);
+  });
+
+  it("passes the API key only through the runtime peer environment", () => {
+    const env = buildRuntimeAgentEnv(
+      {
+        HOME: "/home/ubuntu",
+        PATH: "/usr/bin",
+        NTERACT_API_KEY: "caller-secret",
+        NOTEBOOK_CLOUD_PUBLISH_BEARER_TOKEN: "fallback-secret",
+      },
+      "runtime-peer-secret",
+    );
+
+    assert.equal(env.RUNT_CLOUD_TOKEN, "runtime-peer-secret");
+    assert.equal(env.NTERACT_API_KEY, undefined);
+    assert.equal(env.NOTEBOOK_CLOUD_PUBLISH_BEARER_TOKEN, undefined);
+    assert.equal(env.HOME, "/home/ubuntu");
+    assert.equal(env.PATH, "/usr/bin");
+    assert.equal(env.RUST_LOG, "info");
+  });
+
+  it("projects stable registration metadata for the current Python launcher", () => {
+    assert.deepEqual(
+      buildWorkstationRegistrationPayload({
+        workstationId: "ws-lab2",
+        displayName: "lab2 workstation",
+        workingDirectory: "/home/ubuntu/project",
+        pythonPath: "/opt/k/bin/python",
+        cpuCount: 8,
+        memoryBytes: 16_000_000_000,
+      }),
+      {
+        workstation_id: "ws-lab2",
+        display_name: "lab2 workstation",
+        provider: "runtime_peer",
+        default_environment_label: "Current Python",
+        environment_policy: "current_python",
+        working_directory: "/home/ubuntu/project",
+        cpu_count: 8,
+        memory_bytes: 16_000_000_000,
+        capabilities: {
+          launch_current_python: true,
+        },
+        runtime: {
+          binary: "runtimed",
+          python_path: "/opt/k/bin/python",
+        },
+      },
+    );
+  });
+
+  it("keeps generated workstation ids and polling intervals bounded", () => {
+    assert.equal(stableWorkstationId("lab2.example.internal"), "ws-lab2.example.internal");
+    assert.equal(stableWorkstationId("!!!"), "ws-local");
+    assert.equal(parsePositiveInteger(undefined, "TEST_INTERVAL", 2000), 2000);
+    assert.equal(parsePositiveInteger("15", "TEST_INTERVAL", 2000), 15);
+    assert.throws(() => parsePositiveInteger("0", "TEST_INTERVAL", 2000), /positive integer/);
+  });
+});

--- a/apps/notebook-cloud/test/hosted-workstation-toolbar-smoke.test.mjs
+++ b/apps/notebook-cloud/test/hosted-workstation-toolbar-smoke.test.mjs
@@ -1,0 +1,43 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+
+import {
+  isIgnorableRequestFailure,
+  redactDiagnosticUrl,
+} from "../scripts/hosted-workstation-toolbar-smoke.mjs";
+
+describe("hosted workstation toolbar smoke helpers", () => {
+  it("redacts credential-shaped query parameters in diagnostic URLs", () => {
+    assert.equal(
+      redactDiagnosticUrl(
+        "https://preview.runt.run/n/demo?token=secret&next=1&access_token=another",
+      ),
+      "https://preview.runt.run/n/demo?token=[redacted]&next=1&access_token=[redacted]",
+    );
+    assert.equal(
+      redactDiagnosticUrl("https://preview.runt.run/n/demo?authorization=bearer"),
+      "https://preview.runt.run/n/demo?authorization=[redacted]",
+    );
+  });
+
+  it("ignores expected output-frame aborts and browser side requests", () => {
+    assert.equal(
+      isIgnorableRequestFailure(
+        "https://preview.runtusercontent.com/frame/?nteract_theme=light",
+        "net::ERR_ABORTED",
+      ),
+      true,
+    );
+    assert.equal(
+      isIgnorableRequestFailure("https://preview.runt.run/cdn-cgi/rum?", "net::ERR_ABORTED"),
+      true,
+    );
+    assert.equal(
+      isIgnorableRequestFailure(
+        "https://preview.runtusercontent.com/frame/?nteract_theme=light",
+        "net::ERR_FAILED",
+      ),
+      false,
+    );
+  });
+});

--- a/apps/notebook-cloud/test/hosted-workstation-toolbar-smoke.test.mjs
+++ b/apps/notebook-cloud/test/hosted-workstation-toolbar-smoke.test.mjs
@@ -2,6 +2,7 @@ import assert from "node:assert/strict";
 import { describe, it } from "node:test";
 
 import {
+  assertToolbarWorkstationAction,
   isIgnorableRequestFailure,
   redactDiagnosticUrl,
 } from "../scripts/hosted-workstation-toolbar-smoke.mjs";
@@ -33,11 +34,88 @@ describe("hosted workstation toolbar smoke helpers", () => {
       true,
     );
     assert.equal(
+      isIgnorableRequestFailure("https://preview.runt.run/api/workstations", "net::ERR_ABORTED"),
+      true,
+    );
+    assert.equal(
       isIgnorableRequestFailure(
         "https://preview.runtusercontent.com/frame/?nteract_theme=light",
         "net::ERR_FAILED",
       ),
       false,
+    );
+  });
+
+  it("checks blocked and attach workstation toolbar action labels", () => {
+    assert.doesNotThrow(() =>
+      assertToolbarWorkstationAction(
+        {
+          label: "Set up compute",
+          title: "Open workstations panel",
+        },
+        {
+          context: "no registered workstations",
+          label: "Set up compute",
+          titleIncludes: ["Open workstations panel"],
+        },
+      ),
+    );
+    assert.doesNotThrow(() =>
+      assertToolbarWorkstationAction(
+        {
+          label: "Review compute",
+          title: "Open workstations panel",
+        },
+        {
+          context: "offline default workstation",
+          label: "Review compute",
+          titleIncludes: ["Open workstations panel"],
+        },
+      ),
+    );
+    assert.doesNotThrow(() =>
+      assertToolbarWorkstationAction(
+        {
+          label: "Attach compute",
+          title: "Attach lab2 workstation to this notebook",
+        },
+        {
+          context: "online default workstation",
+          label: "Attach compute",
+          titleIncludes: ["lab2", "workstation"],
+        },
+      ),
+    );
+  });
+
+  it("rejects missing or mismatched workstation toolbar actions", () => {
+    assert.throws(
+      () =>
+        assertToolbarWorkstationAction(null, {
+          context: "missing setup",
+          label: "Set up compute",
+        }),
+      /missing setup expected workstation toolbar action Set up compute/,
+    );
+    assert.throws(
+      () =>
+        assertToolbarWorkstationAction(
+          { label: "Run", title: "Open workstations panel" },
+          { context: "wrong label", label: "Review compute" },
+        ),
+      /wrong label expected workstation toolbar action Review compute, saw Run/,
+    );
+    assert.throws(
+      () =>
+        assertToolbarWorkstationAction(
+          { label: "Attach compute", title: "Open workstations panel" },
+          {
+            context: "wrong target",
+            label: "Attach compute",
+            titleIncludes: ["lab2"],
+          },
+        ),
+      /wrong target expected workstation toolbar title to include lab2/,
     );
   });
 });

--- a/apps/notebook-cloud/test/html.test.ts
+++ b/apps/notebook-cloud/test/html.test.ts
@@ -97,7 +97,10 @@ describe("HTML script serialization", () => {
     assert.match(html, /"aclEndpoint":"\/api\/n\/demo\/acl"/);
     assert.match(html, /"invitesEndpoint":"\/api\/n\/demo\/invites"/);
     assert.match(html, /"accessRequestsEndpoint":"\/api\/n\/demo\/access-requests"/);
-    assert.match(html, /"hostCapabilities":\{"canManageSharing":true\}/);
+    assert.match(
+      html,
+      /"hostCapabilities":\{"canManageSharing":true,"canSubmitExecutionRequests":true\}/,
+    );
     assert.match(html, /"blobBasePath":"\/api\/n\/demo\/blobs\/"/);
     assert.match(html, /"rendererAssetsBasePath":"\/renderer-assets\/"/);
     assert.match(html, /"runtimedWasmModulePath":"\/assets\/runtimed_wasm\.js"/);

--- a/apps/notebook-cloud/test/html.test.ts
+++ b/apps/notebook-cloud/test/html.test.ts
@@ -97,10 +97,8 @@ describe("HTML script serialization", () => {
     assert.match(html, /"aclEndpoint":"\/api\/n\/demo\/acl"/);
     assert.match(html, /"invitesEndpoint":"\/api\/n\/demo\/invites"/);
     assert.match(html, /"accessRequestsEndpoint":"\/api\/n\/demo\/access-requests"/);
-    assert.match(
-      html,
-      /"hostCapabilities":\{"canManageSharing":true,"canSubmitExecutionRequests":true\}/,
-    );
+    assert.match(html, /"hostCapabilities":\{"canManageSharing":true\}/);
+    assert.doesNotMatch(html, /"canSubmitExecutionRequests":true/);
     assert.match(html, /"blobBasePath":"\/api\/n\/demo\/blobs\/"/);
     assert.match(html, /"rendererAssetsBasePath":"\/renderer-assets\/"/);
     assert.match(html, /"runtimedWasmModulePath":"\/assets\/runtimed_wasm\.js"/);

--- a/apps/notebook-cloud/test/viewer-shell-capabilities.test.ts
+++ b/apps/notebook-cloud/test/viewer-shell-capabilities.test.ts
@@ -136,8 +136,8 @@ test("cloud shell capabilities surface execution only when a runtime is availabl
   assert.equal(viewerWithRuntime.runtime.target?.runtimePeerCount, 1);
   assert.equal(viewerWithRuntime.canExecute, false);
 
-  // Runtime presence is visible to editors too, and non-viewer room peers may
-  // submit execution-intent request frames while compute is attached.
+  // Runtime presence is visible to editors too, but hosted execution remains
+  // owner-only until the backend exposes an explicit execute capability.
   const editorWithRuntime = cloudNotebookShellCapabilities({
     authState: authState("oidc", "editor"),
     connectionScope: "editor",
@@ -150,7 +150,17 @@ test("cloud shell capabilities surface execution only when a runtime is availabl
   assert.equal(editorWithRuntime.runtime.target?.id, "attached-workstation");
   assert.equal(editorWithRuntime.runtime.target?.label, "Attached workstation");
   assert.equal(editorWithRuntime.runtime.target?.runtimePeerCount, 1);
-  assert.equal(editorWithRuntime.canExecute, true);
+  assert.equal(editorWithRuntime.canExecute, false);
+
+  const editorWithExecuteCapability = cloudNotebookShellCapabilities({
+    authState: authState("oidc", "editor"),
+    connectionScope: "editor",
+    hasCodeCells: true,
+    selectedMode: "edit",
+    runtimeAvailable: true,
+    canSubmitExecutionRequests: true,
+  });
+  assert.equal(editorWithExecuteCapability.canExecute, true);
 });
 
 test("cloud shell capabilities prefer RuntimeStateDoc workstation attachment over presence fallback", () => {

--- a/apps/notebook-cloud/test/viewer-shell-capabilities.test.ts
+++ b/apps/notebook-cloud/test/viewer-shell-capabilities.test.ts
@@ -230,6 +230,36 @@ test("cloud shell capabilities show connecting workstation attachment without en
   assert.equal(capabilities.canExecute, false);
 });
 
+test("cloud shell capabilities do not let presence override a non-executable attachment", () => {
+  const capabilities = cloudNotebookShellCapabilities({
+    authState: authState("oidc", "owner"),
+    connectionScope: "owner",
+    hasCodeCells: true,
+    selectedMode: "edit",
+    runtimeAvailable: true,
+    runtimePeerCount: 1,
+    workstationAttachment: {
+      workstation_id: "ws-lab2",
+      display_name: "Lab 2",
+      provider: "local_daemon",
+      default_environment_label: "Current Python",
+      environment_policy: "current_python",
+      status: "connecting",
+      status_message: "Waiting for runtime peer heartbeat",
+      cpu_count: null,
+      memory_bytes: null,
+      working_directory: null,
+      updated_at: "2026-06-07T21:00:00Z",
+    },
+  });
+
+  assert.equal(capabilities.runtime.connected, true);
+  assert.equal(capabilities.runtime.executionAvailable, false);
+  assert.equal(capabilities.runtime.target?.id, "ws-lab2");
+  assert.equal(capabilities.runtime.target?.status, "connecting");
+  assert.equal(capabilities.canExecute, false);
+});
+
 test("cloud shell capabilities keep user-selected view mode read-only even with editor access", () => {
   const capabilities = cloudNotebookShellCapabilities({
     authState: authState("oidc", "editor"),

--- a/apps/notebook-cloud/test/worker-routes.test.ts
+++ b/apps/notebook-cloud/test/worker-routes.test.ts
@@ -1348,6 +1348,51 @@ describe("Worker artifact routes", () => {
     );
   });
 
+  it("does not create attach jobs or runtime peer grants for offline workstations", async () => {
+    const env = fakeEnv();
+    seedNotebook(env, "attach-demo");
+    seedAcl(env, { notebookId: "attach-demo", subject: "user:dev:alice", scope: "owner" });
+    seedWorkstation(env, {
+      ownerPrincipal: "user:dev:alice",
+      workstationId: "ws-lab2",
+      status: "offline",
+    });
+
+    const attach = await worker.fetch(
+      new Request("http://localhost/api/n/attach-demo/workstation-attachments", {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          "X-Operator": "browser:tab",
+          "X-Scope": "owner",
+          "X-User": "alice",
+        },
+        body: JSON.stringify({ workstation_id: "ws-lab2" }),
+      }),
+      env,
+      fakeContext(),
+    );
+
+    assert.equal(attach.status, 409);
+    const body = (await attach.json()) as {
+      error?: string;
+      workstation?: { workstation_id?: string; status?: string };
+    };
+    assert.equal(body.error, "workstation is not online");
+    assert.equal(body.workstation?.workstation_id, "ws-lab2");
+    assert.equal(body.workstation?.status, "offline");
+    assert.equal(env.DB.workstationAttachJobs.size, 0);
+    assert.equal(
+      env.DB.acl.some(
+        (row) =>
+          row.notebook_id === "attach-demo" &&
+          row.subject === "user:dev:alice" &&
+          row.scope === "runtime_peer",
+      ),
+      false,
+    );
+  });
+
   it("reuses the active workstation attach job for repeated owner requests", async () => {
     const env = fakeEnv();
     seedNotebook(env, "attach-demo");

--- a/apps/notebook-cloud/test/worker-routes.test.ts
+++ b/apps/notebook-cloud/test/worker-routes.test.ts
@@ -1231,6 +1231,30 @@ describe("Worker artifact routes", () => {
     assert.equal(env.DB.workstationDefaults.get("user:dev:alice"), "ws-lab2");
   });
 
+  it("does not let users select another principal's workstation as their default", async () => {
+    const env = fakeEnv();
+    seedWorkstation(env, { ownerPrincipal: "user:dev:bob", workstationId: "ws-lab2" });
+
+    const response = await worker.fetch(
+      new Request("http://localhost/api/workstations/default", {
+        method: "PATCH",
+        headers: {
+          "Content-Type": "application/json",
+          "X-Operator": "browser:tab",
+          "X-Scope": "owner",
+          "X-User": "alice",
+        },
+        body: JSON.stringify({ workstation_id: "ws-lab2" }),
+      }),
+      env,
+      fakeContext(),
+    );
+
+    assert.equal(response.status, 404);
+    assert.deepEqual(await response.json(), { error: "workstation not found" });
+    assert.equal(env.DB.workstationDefaults.get("user:dev:alice"), undefined);
+  });
+
   it("creates workstation attach jobs through notebook owner authority", async () => {
     const env = fakeEnv();
     seedNotebook(env, "attach-demo");
@@ -1289,6 +1313,41 @@ describe("Worker artifact routes", () => {
     );
   });
 
+  it("does not attach another principal's workstation to an owned notebook", async () => {
+    const env = fakeEnv();
+    seedNotebook(env, "attach-demo");
+    seedAcl(env, { notebookId: "attach-demo", subject: "user:dev:alice", scope: "owner" });
+    seedWorkstation(env, { ownerPrincipal: "user:dev:bob", workstationId: "ws-lab2" });
+
+    const attach = await worker.fetch(
+      new Request("http://localhost/api/n/attach-demo/workstation-attachments", {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          "X-Operator": "browser:tab",
+          "X-Scope": "owner",
+          "X-User": "alice",
+        },
+        body: JSON.stringify({ workstation_id: "ws-lab2" }),
+      }),
+      env,
+      fakeContext(),
+    );
+
+    assert.equal(attach.status, 404);
+    assert.deepEqual(await attach.json(), { error: "workstation not found" });
+    assert.equal(env.DB.workstationAttachJobs.size, 0);
+    assert.equal(
+      env.DB.acl.some(
+        (row) =>
+          row.notebook_id === "attach-demo" &&
+          row.subject === "user:dev:alice" &&
+          row.scope === "runtime_peer",
+      ),
+      false,
+    );
+  });
+
   it("reuses the active workstation attach job for repeated owner requests", async () => {
     const env = fakeEnv();
     seedNotebook(env, "attach-demo");
@@ -1321,6 +1380,43 @@ describe("Worker artifact routes", () => {
     const secondBody = (await second.json()) as { job: { job_id: string } };
     assert.equal(secondBody.job.job_id, firstBody.job.job_id);
     assert.equal(env.DB.workstationAttachJobs.size, 1);
+  });
+
+  it("only lists attach jobs for the authenticated workstation owner", async () => {
+    const env = fakeEnv();
+    seedWorkstation(env, { ownerPrincipal: "user:dev:alice", workstationId: "ws-lab2" });
+    seedWorkstation(env, { ownerPrincipal: "user:dev:bob", workstationId: "ws-lab2" });
+    seedWorkstationAttachJob(env, {
+      id: "job-alice",
+      notebookId: "nb-alice",
+      ownerPrincipal: "user:dev:alice",
+      workstationId: "ws-lab2",
+    });
+    seedWorkstationAttachJob(env, {
+      id: "job-bob",
+      notebookId: "nb-bob",
+      ownerPrincipal: "user:dev:bob",
+      workstationId: "ws-lab2",
+    });
+
+    const response = await worker.fetch(
+      new Request("http://localhost/api/workstations/ws-lab2/attach-jobs", {
+        headers: {
+          "X-Operator": "workstation:lab2",
+          "X-Scope": "owner",
+          "X-User": "alice",
+        },
+      }),
+      env,
+      fakeContext(),
+    );
+
+    assert.equal(response.status, 200);
+    const body = (await response.json()) as { jobs: Array<{ job_id: string }> };
+    assert.deepEqual(
+      body.jobs.map((job) => job.job_id),
+      ["job-alice"],
+    );
   });
 
   it("allows workstation owners to update attach job status", async () => {
@@ -1368,6 +1464,37 @@ describe("Worker artifact routes", () => {
     });
     assert.equal(env.DB.workstationAttachJobs.get("job-1")?.status, "running");
     assert.ok(env.DB.workstationAttachJobs.get("job-1")?.accepted_at);
+  });
+
+  it("does not let workstation owners update another principal's attach job", async () => {
+    const env = fakeEnv();
+    seedWorkstation(env, { ownerPrincipal: "user:dev:alice", workstationId: "ws-lab2" });
+    seedWorkstation(env, { ownerPrincipal: "user:dev:bob", workstationId: "ws-lab2" });
+    seedWorkstationAttachJob(env, {
+      id: "job-bob",
+      notebookId: "nb-bob",
+      ownerPrincipal: "user:dev:bob",
+      workstationId: "ws-lab2",
+    });
+
+    const response = await worker.fetch(
+      new Request("http://localhost/api/workstations/ws-lab2/attach-jobs/job-bob", {
+        method: "PATCH",
+        headers: {
+          "Content-Type": "application/json",
+          "X-Operator": "workstation:lab2",
+          "X-Scope": "owner",
+          "X-User": "alice",
+        },
+        body: JSON.stringify({ status: "running" }),
+      }),
+      env,
+      fakeContext(),
+    );
+
+    assert.equal(response.status, 404);
+    assert.deepEqual(await response.json(), { error: "workstation attach job not found" });
+    assert.equal(env.DB.workstationAttachJobs.get("job-bob")?.status, "pending");
   });
 
   it("lists notebooks through canonical Anaconda account ACLs", async (t) => {

--- a/apps/notebook-cloud/test/worker-routes.test.ts
+++ b/apps/notebook-cloud/test/worker-routes.test.ts
@@ -1289,6 +1289,40 @@ describe("Worker artifact routes", () => {
     );
   });
 
+  it("reuses the active workstation attach job for repeated owner requests", async () => {
+    const env = fakeEnv();
+    seedNotebook(env, "attach-demo");
+    seedAcl(env, { notebookId: "attach-demo", subject: "user:dev:alice", scope: "owner" });
+    seedWorkstation(env, { ownerPrincipal: "user:dev:alice", workstationId: "ws-lab2" });
+
+    async function attach() {
+      return worker.fetch(
+        new Request("http://localhost/api/n/attach-demo/workstation-attachments", {
+          method: "POST",
+          headers: {
+            "Content-Type": "application/json",
+            "X-Operator": "browser:tab",
+            "X-Scope": "owner",
+            "X-User": "alice",
+          },
+          body: JSON.stringify({ workstation_id: "ws-lab2" }),
+        }),
+        env,
+        fakeContext(),
+      );
+    }
+
+    const first = await attach();
+    const second = await attach();
+
+    assert.equal(first.status, 202);
+    assert.equal(second.status, 202);
+    const firstBody = (await first.json()) as { job: { job_id: string } };
+    const secondBody = (await second.json()) as { job: { job_id: string } };
+    assert.equal(secondBody.job.job_id, firstBody.job.job_id);
+    assert.equal(env.DB.workstationAttachJobs.size, 1);
+  });
+
   it("allows workstation owners to update attach job status", async () => {
     const env = fakeEnv();
     seedWorkstation(env, { ownerPrincipal: "user:dev:alice", workstationId: "ws-lab2" });

--- a/apps/notebook-cloud/test/worker-routes.test.ts
+++ b/apps/notebook-cloud/test/worker-routes.test.ts
@@ -1138,6 +1138,204 @@ describe("Worker artifact routes", () => {
     assert.deepEqual(await response.json(), { error: "sign in to list notebooks" });
   });
 
+  it("registers and lists user-owned workstations", async () => {
+    const env = fakeEnv();
+
+    const register = await worker.fetch(
+      new Request("http://localhost/api/workstations", {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          "X-Operator": "workstation:lab2",
+          "X-Scope": "owner",
+          "X-User": "alice",
+        },
+        body: JSON.stringify({
+          workstation_id: "ws-lab2",
+          display_name: "Lab2",
+          provider: "runtime_peer",
+          default_environment_label: "Current Python",
+          environment_policy: "current_python",
+          working_directory: "/home/ubuntu/project",
+          cpu_count: 8,
+          memory_bytes: 16_000_000_000,
+          environments: [
+            {
+              id: "current-python",
+              label: "Current Python",
+              policy: "current_python",
+              is_default: true,
+            },
+          ],
+        }),
+      }),
+      env,
+      fakeContext(),
+    );
+
+    assert.equal(register.status, 201);
+    const registered = (await register.json()) as {
+      workstation: Record<string, unknown>;
+    };
+    assert.equal(registered.workstation.workstation_id, "ws-lab2");
+    assert.equal(registered.workstation.status, "online");
+    assert.doesNotMatch(JSON.stringify(registered), /secret|token/i);
+
+    const list = await worker.fetch(
+      new Request("http://localhost/api/workstations", {
+        headers: {
+          "X-Operator": "browser:tab",
+          "X-Scope": "owner",
+          "X-User": "alice",
+        },
+      }),
+      env,
+      fakeContext(),
+    );
+
+    assert.equal(list.status, 200);
+    const body = (await list.json()) as {
+      default_workstation_id: string | null;
+      workstations: Array<Record<string, unknown>>;
+    };
+    assert.equal(body.default_workstation_id, null);
+    assert.equal(body.workstations.length, 1);
+    assert.equal(body.workstations[0]?.display_name, "Lab2");
+    assert.equal(body.workstations[0]?.is_default, false);
+  });
+
+  it("lets users select a default workstation", async () => {
+    const env = fakeEnv();
+    seedWorkstation(env, { ownerPrincipal: "user:dev:alice", workstationId: "ws-lab2" });
+
+    const response = await worker.fetch(
+      new Request("http://localhost/api/workstations/default", {
+        method: "PATCH",
+        headers: {
+          "Content-Type": "application/json",
+          "X-Operator": "browser:tab",
+          "X-Scope": "owner",
+          "X-User": "alice",
+        },
+        body: JSON.stringify({ workstation_id: "ws-lab2" }),
+      }),
+      env,
+      fakeContext(),
+    );
+
+    assert.equal(response.status, 200);
+    assert.deepEqual(await response.json(), {
+      ok: true,
+      default_workstation_id: "ws-lab2",
+    });
+    assert.equal(env.DB.workstationDefaults.get("user:dev:alice"), "ws-lab2");
+  });
+
+  it("creates workstation attach jobs through notebook owner authority", async () => {
+    const env = fakeEnv();
+    seedNotebook(env, "attach-demo");
+    seedAcl(env, { notebookId: "attach-demo", subject: "user:dev:alice", scope: "owner" });
+    seedWorkstation(env, { ownerPrincipal: "user:dev:alice", workstationId: "ws-lab2" });
+    env.DB.workstationDefaults.set("user:dev:alice", "ws-lab2");
+
+    const attach = await worker.fetch(
+      new Request("http://localhost/api/n/attach-demo/workstation-attachments", {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          "X-Operator": "browser:tab",
+          "X-Scope": "owner",
+          "X-User": "alice",
+        },
+        body: JSON.stringify({}),
+      }),
+      env,
+      fakeContext(),
+    );
+
+    assert.equal(attach.status, 202);
+    const body = (await attach.json()) as {
+      job: { job_id: string; notebook_id: string; status: string };
+    };
+    assert.equal(body.job.notebook_id, "attach-demo");
+    assert.equal(body.job.status, "pending");
+    assert.equal(env.DB.workstationAttachJobs.get(body.job.job_id)?.workstation_id, "ws-lab2");
+    assert.equal(
+      env.DB.acl.some(
+        (row) =>
+          row.notebook_id === "attach-demo" &&
+          row.subject === "user:dev:alice" &&
+          row.scope === "runtime_peer",
+      ),
+      true,
+    );
+
+    const poll = await worker.fetch(
+      new Request("http://localhost/api/workstations/ws-lab2/attach-jobs", {
+        headers: {
+          "X-Operator": "workstation:lab2",
+          "X-Scope": "owner",
+          "X-User": "alice",
+        },
+      }),
+      env,
+      fakeContext(),
+    );
+    assert.equal(poll.status, 200);
+    const polled = (await poll.json()) as { jobs: Array<{ job_id: string }> };
+    assert.deepEqual(
+      polled.jobs.map((job) => job.job_id),
+      [body.job.job_id],
+    );
+  });
+
+  it("allows workstation owners to update attach job status", async () => {
+    const env = fakeEnv();
+    seedWorkstation(env, { ownerPrincipal: "user:dev:alice", workstationId: "ws-lab2" });
+    seedWorkstationAttachJob(env, {
+      id: "job-1",
+      notebookId: "nb-1",
+      ownerPrincipal: "user:dev:alice",
+      workstationId: "ws-lab2",
+    });
+
+    const response = await worker.fetch(
+      new Request("http://localhost/api/workstations/ws-lab2/attach-jobs/job-1", {
+        method: "PATCH",
+        headers: {
+          "Content-Type": "application/json",
+          "X-Operator": "workstation:lab2",
+          "X-Scope": "owner",
+          "X-User": "alice",
+        },
+        body: JSON.stringify({ status: "running" }),
+      }),
+      env,
+      fakeContext(),
+    );
+
+    assert.equal(response.status, 200);
+    const body = (await response.json()) as { job: { job_id: string; status: string } };
+    assert.deepEqual(body.job, {
+      job_id: "job-1",
+      notebook_id: "nb-1",
+      workstation_id: "ws-lab2",
+      status: "running",
+      requested_at: "2026-05-22T00:00:00.000Z",
+      updated_at: env.DB.workstationAttachJobs.get("job-1")?.updated_at,
+      accepted_at: env.DB.workstationAttachJobs.get("job-1")?.accepted_at,
+      finished_at: null,
+      error_message: null,
+      runtime_peer: {
+        cloud_url: "http://localhost",
+        notebook_id: "nb-1",
+        scope: "runtime_peer",
+      },
+    });
+    assert.equal(env.DB.workstationAttachJobs.get("job-1")?.status, "running");
+    assert.ok(env.DB.workstationAttachJobs.get("job-1")?.accepted_at);
+  });
+
   it("lists notebooks through canonical Anaconda account ACLs", async (t) => {
     const token = anacondaApiKeyToken({ jti: "list-notebooks-canonical-account" });
     const env = fakeEnv(anacondaApiKeyEnv());
@@ -3429,6 +3627,59 @@ function seedAcl(
   });
 }
 
+function seedWorkstation(
+  env: FakeEnv,
+  input: {
+    ownerPrincipal: string;
+    workstationId: string;
+    status?: WorkstationRow["status"];
+  },
+): void {
+  env.DB.workstations.set(workstationKey(input.ownerPrincipal, input.workstationId), {
+    owner_principal: input.ownerPrincipal,
+    workstation_id: input.workstationId,
+    display_name: "Lab2",
+    provider: "runtime_peer",
+    provider_label: null,
+    status: input.status ?? "online",
+    status_message: null,
+    default_environment_label: "Current Python",
+    environment_policy: "current_python",
+    working_directory: "/home/ubuntu/project",
+    cpu_count: 8,
+    memory_bytes: 16_000_000_000,
+    environments_json: null,
+    created_at: "2026-05-22T00:00:00.000Z",
+    updated_at: "2026-05-22T00:00:00.000Z",
+    last_seen_at: new Date().toISOString(),
+  });
+}
+
+function seedWorkstationAttachJob(
+  env: FakeEnv,
+  input: {
+    id: string;
+    notebookId: string;
+    ownerPrincipal: string;
+    workstationId: string;
+    status?: WorkstationAttachJobRow["status"];
+  },
+): void {
+  env.DB.workstationAttachJobs.set(input.id, {
+    id: input.id,
+    notebook_id: input.notebookId,
+    owner_principal: input.ownerPrincipal,
+    workstation_id: input.workstationId,
+    status: input.status ?? "pending",
+    requested_by_actor_label: "user:dev:alice/browser:tab",
+    requested_at: "2026-05-22T00:00:00.000Z",
+    updated_at: "2026-05-22T00:00:00.000Z",
+    accepted_at: null,
+    finished_at: null,
+    error_message: null,
+  });
+}
+
 function seedPendingInvite(
   env: FakeEnv,
   input: {
@@ -3674,6 +3925,39 @@ interface RevisionRow {
   created_at: string;
 }
 
+interface WorkstationRow {
+  owner_principal: string;
+  workstation_id: string;
+  display_name: string;
+  provider: string;
+  provider_label: string | null;
+  status: "online" | "offline" | "connecting" | "attention" | "unknown";
+  status_message: string | null;
+  default_environment_label: string | null;
+  environment_policy: string | null;
+  working_directory: string | null;
+  cpu_count: number | null;
+  memory_bytes: number | null;
+  environments_json: string | null;
+  created_at: string;
+  updated_at: string;
+  last_seen_at: string | null;
+}
+
+interface WorkstationAttachJobRow {
+  id: string;
+  notebook_id: string;
+  owner_principal: string;
+  workstation_id: string;
+  status: "pending" | "accepted" | "running" | "failed" | "completed" | "cancelled";
+  requested_by_actor_label: string;
+  requested_at: string;
+  updated_at: string;
+  accepted_at: string | null;
+  finished_at: string | null;
+  error_message: string | null;
+}
+
 class FakeD1 implements D1Database {
   readonly notebooks = new Map<string, NotebookRow>();
   readonly revisions: RevisionRow[] = [];
@@ -3683,6 +3967,9 @@ class FakeD1 implements D1Database {
   readonly accountLinks = new Map<string, PrincipalAccountLinkRow>();
   readonly invites = new Map<string, PendingNotebookInviteRow>();
   readonly accessRequests = new Map<string, NotebookAccessRequestRow>();
+  readonly workstations = new Map<string, WorkstationRow>();
+  readonly workstationDefaults = new Map<string, string>();
+  readonly workstationAttachJobs = new Map<string, WorkstationAttachJobRow>();
   readonly batchSizes: number[] = [];
   afterBlockedOwnerDelete?: () => void;
 
@@ -4052,6 +4339,127 @@ class FakeD1Statement implements D1PreparedStatement {
         return okResult(undefined, { changes: 1 });
       }
       return okResult(undefined, { changes: 0 });
+    } else if (this.query.includes("INSERT INTO workstations")) {
+      const [
+        ownerPrincipal,
+        workstationId,
+        displayName,
+        provider,
+        providerLabel,
+        statusMessage,
+        defaultEnvironmentLabel,
+        environmentPolicy,
+        workingDirectory,
+        cpuCount,
+        memoryBytes,
+        environmentsJson,
+        createdAt,
+        updatedAt,
+        lastSeenAt,
+      ] = this.values as [
+        string,
+        string,
+        string,
+        string,
+        string | null,
+        string | null,
+        string | null,
+        string | null,
+        string | null,
+        number | null,
+        number | null,
+        string | null,
+        string,
+        string,
+        string,
+      ];
+      const key = workstationKey(ownerPrincipal, workstationId);
+      const existing = this.db.workstations.get(key);
+      this.db.workstations.set(key, {
+        owner_principal: ownerPrincipal,
+        workstation_id: workstationId,
+        display_name: displayName,
+        provider,
+        provider_label: providerLabel,
+        status: "online",
+        status_message: statusMessage,
+        default_environment_label: defaultEnvironmentLabel,
+        environment_policy: environmentPolicy,
+        working_directory: workingDirectory,
+        cpu_count: cpuCount,
+        memory_bytes: memoryBytes,
+        environments_json: environmentsJson,
+        created_at: existing?.created_at ?? createdAt,
+        updated_at: updatedAt,
+        last_seen_at: lastSeenAt,
+      });
+      return okResult(undefined, { changes: existing ? 0 : 1 });
+    } else if (this.query.includes("INSERT INTO workstation_defaults")) {
+      const [ownerPrincipal, workstationId] = this.values as [string, string, string];
+      this.db.workstationDefaults.set(ownerPrincipal, workstationId);
+      return okResult(undefined, { changes: 1 });
+    } else if (this.query.includes("INSERT INTO workstation_attach_jobs")) {
+      const [id, notebookId, ownerPrincipal, workstationId, actorLabel, requestedAt, updatedAt] =
+        this.values as [string, string, string, string, string, string, string];
+      this.db.workstationAttachJobs.set(id, {
+        id,
+        notebook_id: notebookId,
+        owner_principal: ownerPrincipal,
+        workstation_id: workstationId,
+        status: "pending",
+        requested_by_actor_label: actorLabel,
+        requested_at: requestedAt,
+        updated_at: updatedAt,
+        accepted_at: null,
+        finished_at: null,
+        error_message: null,
+      });
+      return okResult(undefined, { changes: 1 });
+    } else if (this.query.includes("UPDATE workstation_attach_jobs")) {
+      const [
+        status,
+        updatedAt,
+        statusForAcceptedAt,
+        acceptedAt,
+        statusForFinishedAt,
+        finishedAt,
+        errorMessage,
+        jobId,
+        ownerPrincipal,
+        workstationId,
+      ] = this.values as [
+        WorkstationAttachJobRow["status"],
+        string,
+        WorkstationAttachJobRow["status"],
+        string,
+        WorkstationAttachJobRow["status"],
+        string,
+        string | null,
+        string,
+        string,
+        string,
+      ];
+      const job = this.db.workstationAttachJobs.get(jobId);
+      if (job && job.owner_principal === ownerPrincipal && job.workstation_id === workstationId) {
+        job.status = status;
+        job.updated_at = updatedAt;
+        if (
+          (statusForAcceptedAt === "accepted" || statusForAcceptedAt === "running") &&
+          job.accepted_at === null
+        ) {
+          job.accepted_at = acceptedAt;
+        }
+        if (
+          statusForFinishedAt === "failed" ||
+          statusForFinishedAt === "completed" ||
+          statusForFinishedAt === "cancelled"
+        ) {
+          job.finished_at = finishedAt;
+        }
+        job.error_message = errorMessage;
+        return okResult(undefined, { changes: 1 });
+      }
+      return okResult(undefined, { changes: 0 });
     } else if (this.query.includes("INSERT INTO notebooks")) {
       const [id, ownerPrincipal, maybeTitleOrCreatedAt, createdAtOrUpdatedAt, maybeUpdatedAt] = this
         .values as [string, string, string | null, string | undefined, string | undefined];
@@ -4303,6 +4711,42 @@ class FakeD1Statement implements D1PreparedStatement {
       }
       return (this.db.accountLinks.get(this.values[0] as string) as T | undefined) ?? null;
     }
+    if (this.query.includes("FROM workstations")) {
+      const [ownerPrincipal, workstationId] = this.values as [string, string];
+      return (
+        (this.db.workstations.get(workstationKey(ownerPrincipal, workstationId)) as
+          | T
+          | undefined) ?? null
+      );
+    }
+    if (this.query.includes("FROM workstation_defaults")) {
+      const ownerPrincipal = this.values[0] as string;
+      const workstationId = this.db.workstationDefaults.get(ownerPrincipal);
+      return workstationId ? ({ workstation_id: workstationId } as T) : null;
+    }
+    if (this.query.includes("FROM workstation_attach_jobs")) {
+      if (this.query.includes("notebook_id = ?")) {
+        const [notebookId, ownerPrincipal, workstationId] = this.values as [string, string, string];
+        return (
+          ([...this.db.workstationAttachJobs.values()]
+            .filter(
+              (job) =>
+                job.notebook_id === notebookId &&
+                job.owner_principal === ownerPrincipal &&
+                job.workstation_id === workstationId &&
+                (job.status === "pending" || job.status === "accepted" || job.status === "running"),
+            )
+            .sort((left, right) => right.requested_at.localeCompare(left.requested_at))[0] as
+            | T
+            | undefined) ?? null
+        );
+      }
+      const [jobId, ownerPrincipal, workstationId] = this.values as [string, string, string];
+      const job = this.db.workstationAttachJobs.get(jobId);
+      return job?.owner_principal === ownerPrincipal && job.workstation_id === workstationId
+        ? (job as T)
+        : null;
+    }
     if (this.query.includes("FROM notebook_invites")) {
       if (this.query.includes("WHERE notebook_id = ?")) {
         const [notebookId, email, scope, providerHint] = this.values as [
@@ -4396,6 +4840,34 @@ class FakeD1Statement implements D1PreparedStatement {
             (left, right) =>
               right.created_at.localeCompare(left.created_at) || right.id.localeCompare(left.id),
           )
+          .slice(0, limit) as T[],
+      );
+    }
+    if (this.query.includes("FROM workstations")) {
+      const ownerPrincipal = this.values[0] as string;
+      return okResult(
+        [...this.db.workstations.values()]
+          .filter((workstation) => workstation.owner_principal === ownerPrincipal)
+          .sort(
+            (left, right) =>
+              (right.last_seen_at ?? right.updated_at).localeCompare(
+                left.last_seen_at ?? left.updated_at,
+              ) || right.workstation_id.localeCompare(left.workstation_id),
+          ) as T[],
+      );
+    }
+    if (this.query.includes("FROM workstation_attach_jobs")) {
+      const [ownerPrincipal, workstationId, limitValue] = this.values as [string, string, number];
+      const limit = Number.isFinite(limitValue) ? limitValue : Number.POSITIVE_INFINITY;
+      return okResult(
+        [...this.db.workstationAttachJobs.values()]
+          .filter(
+            (job) =>
+              job.owner_principal === ownerPrincipal &&
+              job.workstation_id === workstationId &&
+              job.status === "pending",
+          )
+          .sort((left, right) => left.requested_at.localeCompare(right.requested_at))
           .slice(0, limit) as T[],
       );
     }
@@ -4511,6 +4983,10 @@ function scopeRank(scope: NotebookAclRow["scope"]): number {
     case "viewer":
       return 1;
   }
+}
+
+function workstationKey(ownerPrincipal: string, workstationId: string): string {
+  return `${ownerPrincipal}\0${workstationId}`;
 }
 
 interface BlobRow {

--- a/apps/notebook-cloud/test/workstations-client.test.ts
+++ b/apps/notebook-cloud/test/workstations-client.test.ts
@@ -3,6 +3,9 @@ import { describe, it } from "node:test";
 
 import type { CloudPrototypeAuthState } from "../viewer/collaborator-auth";
 import {
+  CLOUD_WORKSTATIONS_ACTIVE_REFRESH_INTERVAL_MS,
+  CLOUD_WORKSTATIONS_ATTACH_REFRESH_INTERVAL_MS,
+  cloudWorkstationRefreshIntervalMs,
   fetchCloudWorkstations,
   requestCloudWorkstationAttachment,
   setCloudDefaultWorkstation,
@@ -118,6 +121,54 @@ describe("cloud workstations client", () => {
         "ws-lab2",
       ),
       { jobId: "job-1", status: "pending" },
+    );
+  });
+
+  it("keeps registry refresh bounded to owner flows that can change workstation selection", () => {
+    assert.equal(
+      cloudWorkstationRefreshIntervalMs({
+        canChooseHostedWorkstation: false,
+        hasRegisteredWorkstations: false,
+        mutationKind: "idle",
+        panelIsOpen: true,
+      }),
+      null,
+    );
+    assert.equal(
+      cloudWorkstationRefreshIntervalMs({
+        canChooseHostedWorkstation: true,
+        hasRegisteredWorkstations: false,
+        mutationKind: "idle",
+        panelIsOpen: false,
+      }),
+      CLOUD_WORKSTATIONS_ACTIVE_REFRESH_INTERVAL_MS,
+    );
+    assert.equal(
+      cloudWorkstationRefreshIntervalMs({
+        canChooseHostedWorkstation: true,
+        hasRegisteredWorkstations: true,
+        mutationKind: "idle",
+        panelIsOpen: true,
+      }),
+      CLOUD_WORKSTATIONS_ACTIVE_REFRESH_INTERVAL_MS,
+    );
+    assert.equal(
+      cloudWorkstationRefreshIntervalMs({
+        canChooseHostedWorkstation: true,
+        hasRegisteredWorkstations: true,
+        mutationKind: "idle",
+        panelIsOpen: false,
+      }),
+      null,
+    );
+    assert.equal(
+      cloudWorkstationRefreshIntervalMs({
+        canChooseHostedWorkstation: true,
+        hasRegisteredWorkstations: true,
+        mutationKind: "attach",
+        panelIsOpen: false,
+      }),
+      CLOUD_WORKSTATIONS_ATTACH_REFRESH_INTERVAL_MS,
     );
   });
 });

--- a/apps/notebook-cloud/test/workstations-client.test.ts
+++ b/apps/notebook-cloud/test/workstations-client.test.ts
@@ -1,0 +1,130 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+
+import type { CloudPrototypeAuthState } from "../viewer/collaborator-auth";
+import {
+  fetchCloudWorkstations,
+  requestCloudWorkstationAttachment,
+  setCloudDefaultWorkstation,
+} from "../viewer/workstations-client";
+
+const devAuth: CloudPrototypeAuthState = {
+  mode: "dev",
+  token: "dev-secret",
+  user: "alice",
+  oidcClaims: null,
+  requestedScope: "owner",
+  problem: null,
+};
+
+describe("cloud workstations client", () => {
+  it("normalizes registered workstations into shared projection input", async (t) => {
+    t.mock.method(globalThis, "fetch", async (_input: RequestInfo | URL, init?: RequestInit) => {
+      const headers = new Headers(init?.headers);
+      assert.equal(headers.get("x-notebook-cloud-dev-token"), "dev-secret");
+      assert.equal(headers.get("X-User"), "alice");
+      assert.equal(headers.get("X-Scope"), "owner");
+      return jsonResponse({
+        default_workstation_id: "ws-lab2",
+        workstations: [
+          {
+            workstation_id: "ws-lab2",
+            display_name: "Lab2",
+            owner_principal: "user:dev:alice",
+            provider: "runtime_peer",
+            provider_label: "Runtime peer",
+            status: "online",
+            default_environment_label: "Current Python",
+            environment_policy: "current_python",
+            working_directory: "/home/ubuntu/project",
+            cpu_count: 8,
+            memory_bytes: 16000000000,
+            environments: [
+              {
+                id: "current-python",
+                label: "Current Python",
+                policy: "current_python",
+                is_default: true,
+              },
+            ],
+          },
+        ],
+      });
+    });
+
+    const state = await fetchCloudWorkstations("/api/workstations", devAuth);
+
+    assert.equal(state.defaultWorkstationId, "ws-lab2");
+    assert.equal(state.workstations.length, 1);
+    assert.deepEqual(state.workstations[0], {
+      id: "ws-lab2",
+      displayName: "Lab2",
+      provider: "runtime_peer",
+      providerLabel: "Runtime peer",
+      status: "online",
+      statusMessage: null,
+      defaultEnvironmentLabel: "Current Python",
+      environmentPolicy: "current_python",
+      workingDirectory: "/home/ubuntu/project",
+      cpuCount: 8,
+      memoryBytes: 16000000000,
+      updatedAt: null,
+      environments: [
+        {
+          id: "current-python",
+          label: "Current Python",
+          available: true,
+          detail: null,
+          health: null,
+          isDefault: true,
+          policy: "current_python",
+        },
+      ],
+    });
+    assert.equal(Object.hasOwn(state.workstations[0], "owner_principal"), false);
+  });
+
+  it("sends default workstation selection through the configured endpoint", async (t) => {
+    t.mock.method(globalThis, "fetch", async (input: RequestInfo | URL, init?: RequestInit) => {
+      assert.equal(String(input), "/api/workstations/default");
+      assert.equal(init?.method, "PATCH");
+      assert.deepEqual(JSON.parse(String(init?.body)), { workstation_id: "ws-lab2" });
+      return jsonResponse({ default_workstation_id: "ws-lab2" });
+    });
+
+    assert.equal(
+      await setCloudDefaultWorkstation("/api/workstations/default", devAuth, "ws-lab2"),
+      "ws-lab2",
+    );
+  });
+
+  it("requests notebook attachment without optimistic readiness state", async (t) => {
+    t.mock.method(globalThis, "fetch", async (input: RequestInfo | URL, init?: RequestInit) => {
+      assert.equal(String(input), "/api/n/nb-1/workstation-attachments");
+      assert.equal(init?.method, "POST");
+      assert.deepEqual(JSON.parse(String(init?.body)), { workstation_id: "ws-lab2" });
+      return jsonResponse({
+        job: {
+          job_id: "job-1",
+          status: "pending",
+        },
+      });
+    });
+
+    assert.deepEqual(
+      await requestCloudWorkstationAttachment(
+        "/api/n/nb-1/workstation-attachments",
+        devAuth,
+        "ws-lab2",
+      ),
+      { jobId: "job-1", status: "pending" },
+    );
+  });
+});
+
+function jsonResponse(value: unknown, status = 200): Response {
+  return new Response(JSON.stringify(value), {
+    status,
+    headers: { "Content-Type": "application/json" },
+  });
+}

--- a/apps/notebook-cloud/viewer/cloud-viewer-session.ts
+++ b/apps/notebook-cloud/viewer/cloud-viewer-session.ts
@@ -61,6 +61,7 @@ export interface CloudViewerConfig {
   workstationAttachEndpoint?: string;
   hostCapabilities?: {
     canManageSharing?: boolean;
+    canSubmitExecutionRequests?: boolean;
   };
   syncEndpoint: string;
   blobBasePath: string;

--- a/apps/notebook-cloud/viewer/cloud-viewer-session.ts
+++ b/apps/notebook-cloud/viewer/cloud-viewer-session.ts
@@ -56,6 +56,9 @@ export interface CloudViewerConfig {
   aclEndpoint: string;
   invitesEndpoint: string;
   accessRequestsEndpoint: string;
+  workstationsEndpoint?: string;
+  workstationDefaultEndpoint?: string;
+  workstationAttachEndpoint?: string;
   hostCapabilities?: {
     canManageSharing?: boolean;
   };

--- a/apps/notebook-cloud/viewer/index.tsx
+++ b/apps/notebook-cloud/viewer/index.tsx
@@ -106,6 +106,7 @@ import { cloudViewerLoadingPolicy } from "./loading-policy";
 import { markCloudViewerLoadMilestone } from "./load-milestones";
 import { CLOUD_VIEWER_PRIORITY } from "./mime-policy";
 import {
+  cloudWorkstationRefreshIntervalMs,
   fetchCloudWorkstations,
   requestCloudWorkstationAttachment,
   setCloudDefaultWorkstation,
@@ -1761,12 +1762,19 @@ function NotebookViewer({
           workstationId,
         );
         setWorkstationsError(null);
+        await refreshCloudWorkstations();
       } catch (error) {
         setWorkstationsError(error instanceof Error ? error.message : String(error));
         setWorkstationMutation({ kind: "idle", message: null, workstationId: null });
+        await refreshCloudWorkstations();
       }
     },
-    [authState, config.workstationAttachEndpoint, handleOpenWorkstationsRail],
+    [
+      authState,
+      config.workstationAttachEndpoint,
+      handleOpenWorkstationsRail,
+      refreshCloudWorkstations,
+    ],
   );
   const canAcceptCellMutations =
     Boolean(connectionPeerId) &&
@@ -1840,6 +1848,42 @@ function NotebookViewer({
     shellCapabilities.access.source === "cloud" &&
     shellCapabilities.auth.canUseAuthenticatedIdentity &&
     shellCapabilities.access.level === "owner";
+  const workstationRefreshIntervalMs = cloudWorkstationRefreshIntervalMs({
+    canChooseHostedWorkstation,
+    hasRegisteredWorkstations: workstationsState.workstations.length > 0,
+    mutationKind: workstationMutation.kind,
+    panelIsOpen: activeRailPanel === "workstations" && !railCollapsed,
+  });
+  useEffect(() => {
+    if (workstationRefreshIntervalMs === null) {
+      return;
+    }
+    let disposed = false;
+    let timer: number | null = null;
+    let activeController: AbortController | null = null;
+    const scheduleRefresh = () => {
+      timer = window.setTimeout(() => {
+        const controller = new AbortController();
+        activeController = controller;
+        void refreshCloudWorkstations(controller.signal).finally(() => {
+          if (activeController === controller) {
+            activeController = null;
+          }
+          if (!disposed) {
+            scheduleRefresh();
+          }
+        });
+      }, workstationRefreshIntervalMs);
+    };
+    scheduleRefresh();
+    return () => {
+      disposed = true;
+      if (timer !== null) {
+        window.clearTimeout(timer);
+      }
+      activeController?.abort();
+    };
+  }, [refreshCloudWorkstations, workstationRefreshIntervalMs]);
   const workstationSelection = useMemo(
     () =>
       projectNotebookWorkstationSelection({

--- a/apps/notebook-cloud/viewer/index.tsx
+++ b/apps/notebook-cloud/viewer/index.tsx
@@ -272,7 +272,8 @@ function loadConfig(): CloudViewerConfig {
     workstationAttachEndpoint: parsed.workstationAttachEndpoint,
     hostCapabilities: {
       canManageSharing: Boolean(parsed.hostCapabilities?.canManageSharing),
-      canSubmitExecutionRequests: Boolean(parsed.hostCapabilities?.canSubmitExecutionRequests),
+      canSubmitExecutionRequests:
+        parsed.hostCapabilities?.canSubmitExecutionRequests === true ? true : undefined,
     },
     syncEndpoint: parsed.syncEndpoint,
     blobBasePath: parsed.blobBasePath,
@@ -1800,9 +1801,7 @@ function NotebookViewer({
   );
   const requestedEditAccess = roomEditAccess.requestedDocumentEditAccess;
   const editAccessPending = roomEditAccess.editAccessPending;
-  const canSubmitExecutionRequests =
-    connectionScope === "owner" ||
-    (connectionScope === "editor" && Boolean(config.hostCapabilities?.canSubmitExecutionRequests));
+  const canSubmitExecutionRequests = connectionScope === "owner";
   const shellCapabilities = useMemo(
     () =>
       cloudNotebookShellCapabilities({

--- a/apps/notebook-cloud/viewer/index.tsx
+++ b/apps/notebook-cloud/viewer/index.tsx
@@ -1855,15 +1855,18 @@ function NotebookViewer({
     [shellCapabilities, workstationSelection],
   );
   const workstationAction = useMemo(() => {
-    const { primaryAction } = workstationLaunchReadiness;
+    const { primaryAction, workstationId } = workstationLaunchReadiness;
     return primaryAction.kind !== "none" && primaryAction.label && primaryAction.title
       ? {
           label: primaryAction.label,
           title: primaryAction.title,
-          onClick: handleOpenWorkstationsRail,
+          onClick:
+            primaryAction.kind === "attach_workstation" && workstationId
+              ? () => handleAttachWorkstation(workstationId)
+              : handleOpenWorkstationsRail,
         }
       : null;
-  }, [handleOpenWorkstationsRail, workstationLaunchReadiness]);
+  }, [handleAttachWorkstation, handleOpenWorkstationsRail, workstationLaunchReadiness]);
   useEffect(() => {
     if (workstationMutation.kind !== "attach" || !workstationAttachment?.workstation_id) {
       return;

--- a/apps/notebook-cloud/viewer/index.tsx
+++ b/apps/notebook-cloud/viewer/index.tsx
@@ -1917,6 +1917,12 @@ function NotebookViewer({
         }
       : null;
   }, [handleAttachWorkstation, handleOpenWorkstationsRail, workstationLaunchReadiness]);
+  const workstationPanelStatusMessage =
+    workstationMutation.message ??
+    workstationsError ??
+    (workstationLaunchReadiness.state === "workstation_unavailable"
+      ? workstationLaunchReadiness.detail
+      : null);
   useEffect(() => {
     if (workstationMutation.kind !== "attach" || !workstationAttachment?.workstation_id) {
       return;
@@ -2283,7 +2289,7 @@ function NotebookViewer({
         <NotebookWorkstationsPanel
           capabilities={shellCapabilities}
           selection={workstationSelection}
-          statusMessage={workstationMutation.message ?? workstationsError}
+          statusMessage={workstationPanelStatusMessage}
           busyWorkstationId={workstationMutation.workstationId}
           onAttachWorkstation={canChooseHostedWorkstation ? handleAttachWorkstation : undefined}
           onSetDefaultWorkstation={

--- a/apps/notebook-cloud/viewer/index.tsx
+++ b/apps/notebook-cloud/viewer/index.tsx
@@ -106,6 +106,12 @@ import { cloudViewerLoadingPolicy } from "./loading-policy";
 import { markCloudViewerLoadMilestone } from "./load-milestones";
 import { CLOUD_VIEWER_PRIORITY } from "./mime-policy";
 import {
+  fetchCloudWorkstations,
+  requestCloudWorkstationAttachment,
+  setCloudDefaultWorkstation,
+  type CloudWorkstationsState,
+} from "./workstations-client";
+import {
   cloudPresenceHasRuntimePeer,
   cloudPresenceRuntimePeerCount,
   type CloudViewerPresencePeer,
@@ -239,6 +245,9 @@ function loadConfig(): CloudViewerConfig {
     !parsed.aclEndpoint ||
     !parsed.invitesEndpoint ||
     !parsed.accessRequestsEndpoint ||
+    !parsed.workstationsEndpoint ||
+    !parsed.workstationDefaultEndpoint ||
+    !parsed.workstationAttachEndpoint ||
     !parsed.syncEndpoint ||
     !parsed.blobBasePath ||
     !parsed.rendererAssetsBasePath ||
@@ -257,6 +266,9 @@ function loadConfig(): CloudViewerConfig {
     aclEndpoint: parsed.aclEndpoint,
     invitesEndpoint: parsed.invitesEndpoint,
     accessRequestsEndpoint: parsed.accessRequestsEndpoint,
+    workstationsEndpoint: parsed.workstationsEndpoint,
+    workstationDefaultEndpoint: parsed.workstationDefaultEndpoint,
+    workstationAttachEndpoint: parsed.workstationAttachEndpoint,
     hostCapabilities: {
       canManageSharing: Boolean(parsed.hostCapabilities?.canManageSharing),
     },
@@ -1539,6 +1551,16 @@ function NotebookViewer({
     null,
   );
   const [accessRequestError, setAccessRequestError] = useState<string | null>(null);
+  const [workstationsState, setWorkstationsState] = useState<CloudWorkstationsState>({
+    defaultWorkstationId: null,
+    workstations: [],
+  });
+  const [workstationsError, setWorkstationsError] = useState<string | null>(null);
+  const [workstationMutation, setWorkstationMutation] = useState<{
+    kind: "idle" | "default" | "attach";
+    message: string | null;
+    workstationId: string | null;
+  }>({ kind: "idle", message: null, workstationId: null });
   const [selectedInteractionMode, setSelectedInteractionMode] =
     useState<NotebookInteractionMode>("view");
   const [emptyRoomGraceElapsed, setEmptyRoomGraceElapsed] = useState(false);
@@ -1665,6 +1687,86 @@ function NotebookViewer({
     setRailCollapsed(false);
     setActiveRailPanel("workstations");
   }, []);
+  const canLoadCloudWorkstations = authState.mode === "dev" || authState.mode === "oidc";
+  const refreshCloudWorkstations = useCallback(
+    async (signal?: AbortSignal) => {
+      if (!canLoadCloudWorkstations || !config.workstationsEndpoint) {
+        setWorkstationsState({ defaultWorkstationId: null, workstations: [] });
+        setWorkstationsError(null);
+        return;
+      }
+      try {
+        const next = await fetchCloudWorkstations(config.workstationsEndpoint, authState, signal);
+        if (signal?.aborted) return;
+        setWorkstationsState(next);
+        setWorkstationsError(null);
+      } catch (error) {
+        if (signal?.aborted) return;
+        setWorkstationsError(error instanceof Error ? error.message : String(error));
+      }
+    },
+    [authState, canLoadCloudWorkstations, config.workstationsEndpoint],
+  );
+  useEffect(() => {
+    const controller = new AbortController();
+    void refreshCloudWorkstations(controller.signal);
+    return () => controller.abort();
+  }, [refreshCloudWorkstations]);
+  const handleSetDefaultWorkstation = useCallback(
+    async (workstationId: string) => {
+      if (!config.workstationDefaultEndpoint) {
+        return;
+      }
+      setWorkstationMutation({
+        kind: "default",
+        message: null,
+        workstationId,
+      });
+      try {
+        const defaultWorkstationId = await setCloudDefaultWorkstation(
+          config.workstationDefaultEndpoint,
+          authState,
+          workstationId,
+        );
+        setWorkstationsState((previous) => ({
+          ...previous,
+          defaultWorkstationId: defaultWorkstationId ?? workstationId,
+        }));
+        setWorkstationsError(null);
+        await refreshCloudWorkstations();
+      } catch (error) {
+        setWorkstationsError(error instanceof Error ? error.message : String(error));
+      } finally {
+        setWorkstationMutation({ kind: "idle", message: null, workstationId: null });
+      }
+    },
+    [authState, config.workstationDefaultEndpoint, refreshCloudWorkstations],
+  );
+  const handleAttachWorkstation = useCallback(
+    async (workstationId: string) => {
+      if (!config.workstationAttachEndpoint) {
+        return;
+      }
+      setWorkstationMutation({
+        kind: "attach",
+        message: "Attach requested. Waiting for the workstation to join this room.",
+        workstationId,
+      });
+      handleOpenWorkstationsRail();
+      try {
+        await requestCloudWorkstationAttachment(
+          config.workstationAttachEndpoint,
+          authState,
+          workstationId,
+        );
+        setWorkstationsError(null);
+      } catch (error) {
+        setWorkstationsError(error instanceof Error ? error.message : String(error));
+        setWorkstationMutation({ kind: "idle", message: null, workstationId: null });
+      }
+    },
+    [authState, config.workstationAttachEndpoint, handleOpenWorkstationsRail],
+  );
   const canAcceptCellMutations =
     Boolean(connectionPeerId) &&
     !connectionError &&
@@ -1731,7 +1833,7 @@ function NotebookViewer({
   const canChooseHostedWorkstation =
     shellCapabilities.access.source === "cloud" &&
     shellCapabilities.auth.canUseAuthenticatedIdentity &&
-    (shellCapabilities.access.level === "owner" || shellCapabilities.access.level === "editor");
+    shellCapabilities.access.level === "owner";
   const workstationSelection = useMemo(
     () =>
       projectNotebookWorkstationSelection({
@@ -1739,9 +1841,10 @@ function NotebookViewer({
         canRegisterWorkstation: canChooseHostedWorkstation,
         canSelectWorkstation: canChooseHostedWorkstation,
         canSetDefaultWorkstation: canChooseHostedWorkstation,
-        registeredWorkstations: [],
+        defaultWorkstationId: workstationsState.defaultWorkstationId,
+        registeredWorkstations: workstationsState.workstations,
       }),
-    [canChooseHostedWorkstation, workstationAttachment],
+    [canChooseHostedWorkstation, workstationAttachment, workstationsState],
   );
   const workstationLaunchReadiness = useMemo(
     () =>
@@ -1761,6 +1864,17 @@ function NotebookViewer({
         }
       : null;
   }, [handleOpenWorkstationsRail, workstationLaunchReadiness]);
+  useEffect(() => {
+    if (workstationMutation.kind !== "attach" || !workstationAttachment?.workstation_id) {
+      return;
+    }
+    if (
+      !workstationMutation.workstationId ||
+      workstationMutation.workstationId === workstationAttachment.workstation_id
+    ) {
+      setWorkstationMutation({ kind: "idle", message: null, workstationId: null });
+    }
+  }, [workstationAttachment?.workstation_id, workstationMutation]);
   useEffect(() => {
     if (!requestedEditAccess) {
       appliedGrantedEditScopeRef.current = null;
@@ -2116,6 +2230,12 @@ function NotebookViewer({
         <NotebookWorkstationsPanel
           capabilities={shellCapabilities}
           selection={workstationSelection}
+          statusMessage={workstationMutation.message ?? workstationsError}
+          busyWorkstationId={workstationMutation.workstationId}
+          onAttachWorkstation={canChooseHostedWorkstation ? handleAttachWorkstation : undefined}
+          onSetDefaultWorkstation={
+            canChooseHostedWorkstation ? handleSetDefaultWorkstation : undefined
+          }
         />
       }
       packagesPanel={

--- a/apps/notebook-cloud/viewer/index.tsx
+++ b/apps/notebook-cloud/viewer/index.tsx
@@ -271,6 +271,7 @@ function loadConfig(): CloudViewerConfig {
     workstationAttachEndpoint: parsed.workstationAttachEndpoint,
     hostCapabilities: {
       canManageSharing: Boolean(parsed.hostCapabilities?.canManageSharing),
+      canSubmitExecutionRequests: Boolean(parsed.hostCapabilities?.canSubmitExecutionRequests),
     },
     syncEndpoint: parsed.syncEndpoint,
     blobBasePath: parsed.blobBasePath,
@@ -1791,6 +1792,9 @@ function NotebookViewer({
   );
   const requestedEditAccess = roomEditAccess.requestedDocumentEditAccess;
   const editAccessPending = roomEditAccess.editAccessPending;
+  const canSubmitExecutionRequests =
+    connectionScope === "owner" ||
+    (connectionScope === "editor" && Boolean(config.hostCapabilities?.canSubmitExecutionRequests));
   const shellCapabilities = useMemo(
     () =>
       cloudNotebookShellCapabilities({
@@ -1804,6 +1808,7 @@ function NotebookViewer({
         runtimeAvailable: runtimePeerAvailable,
         runtimePeerCount,
         workstationAttachment,
+        canSubmitExecutionRequests,
         hostCapabilities: config.hostCapabilities,
       }),
     [
@@ -1814,6 +1819,7 @@ function NotebookViewer({
       connectionActorLabel,
       connectionScope,
       editAccessRequestPending,
+      canSubmitExecutionRequests,
       runtimePeerCount,
       runtimePeerAvailable,
       selectedInteractionMode,

--- a/apps/notebook-cloud/viewer/shell-capabilities.ts
+++ b/apps/notebook-cloud/viewer/shell-capabilities.ts
@@ -54,8 +54,8 @@ export interface CloudNotebookShellCapabilityInput {
   /**
    * Whether this browser connection may create execution intent in the hosted
    * room. This is a capability, not an interaction mode: owners can submit
-   * execution requests when compute is attached today, while future execute
-   * scope policy can replace this without changing the shared shell projection.
+   * execution requests by default, and hosts may opt editors in when the room
+   * can safely materialize editor-authored execution request frames.
    */
   canSubmitExecutionRequests?: boolean;
   /**
@@ -64,6 +64,7 @@ export interface CloudNotebookShellCapabilityInput {
    */
   hostCapabilities?: {
     canManageSharing?: boolean;
+    canSubmitExecutionRequests?: boolean;
   };
 }
 

--- a/apps/notebook-cloud/viewer/shell-capabilities.ts
+++ b/apps/notebook-cloud/viewer/shell-capabilities.ts
@@ -53,10 +53,9 @@ export interface CloudNotebookShellCapabilityInput {
   workstationAttachment?: WorkstationAttachmentState | null;
   /**
    * Whether this browser connection may create execution intent in the hosted
-   * room. This is a capability, not an interaction mode: owners and editors can
-   * submit execution requests when compute is attached, while future
-   * execute-scope policy can replace this without changing the shared shell
-   * projection.
+   * room. This is a capability, not an interaction mode: owners can submit
+   * execution requests when compute is attached today, while future execute
+   * scope policy can replace this without changing the shared shell projection.
    */
   canSubmitExecutionRequests?: boolean;
   /**
@@ -79,7 +78,7 @@ export function cloudNotebookShellCapabilities({
   runtimeAvailable = false,
   runtimePeerCount = runtimeAvailable ? 1 : 0,
   workstationAttachment = null,
-  canSubmitExecutionRequests = connectionScope === "owner" || connectionScope === "editor",
+  canSubmitExecutionRequests = connectionScope === "owner",
   hostCapabilities,
 }: CloudNotebookShellCapabilityInput): NotebookShellCapabilities {
   const interaction = projectCloudNotebookEditAccess({

--- a/apps/notebook-cloud/viewer/shell-capabilities.ts
+++ b/apps/notebook-cloud/viewer/shell-capabilities.ts
@@ -97,7 +97,11 @@ export function cloudNotebookShellCapabilities({
   const identityImageUrl = cloudIdentityImageUrl(authState);
   const attachmentConnected = workstationAttachmentIsConnected(workstationAttachment);
   const attachmentExecutionAvailable = workstationAttachmentCanExecute(workstationAttachment);
-  const effectiveRuntimeAvailable = runtimeAvailable || attachmentExecutionAvailable;
+  const hasAttachmentSnapshot = workstationAttachment !== null;
+  const effectiveRuntimeConnected = hasAttachmentSnapshot ? attachmentConnected : runtimeAvailable;
+  const effectiveRuntimeAvailable = hasAttachmentSnapshot
+    ? attachmentExecutionAvailable
+    : runtimeAvailable;
   const auth = {
     canSignIn: authState.mode !== "oidc",
     canUseAuthenticatedIdentity: authenticated && !authNeedsAttention,
@@ -112,7 +116,7 @@ export function cloudNotebookShellCapabilities({
   };
   const runtime = {
     canWriteRuntimeState: isRuntimePeer,
-    connected: isRuntimePeer || runtimeAvailable || attachmentConnected,
+    connected: isRuntimePeer || effectiveRuntimeConnected,
     executionAvailable: effectiveRuntimeAvailable,
     source: "cloud" as const,
     actorLabel: isRuntimePeer ? connectionActorLabel : null,

--- a/apps/notebook-cloud/viewer/workstations-client.ts
+++ b/apps/notebook-cloud/viewer/workstations-client.ts
@@ -1,0 +1,183 @@
+import type { NotebookRegisteredWorkstation } from "runtimed";
+
+import { fetchWithCloudPrototypeAuth, type CloudPrototypeAuthState } from "./collaborator-auth";
+
+export interface CloudWorkstationsState {
+  defaultWorkstationId: string | null;
+  workstations: readonly NotebookRegisteredWorkstation[];
+}
+
+interface CloudWorkstationsResponse {
+  default_workstation_id?: unknown;
+  workstations?: unknown;
+}
+
+interface CloudWorkstationAttachmentResponse {
+  job?: {
+    job_id?: unknown;
+    status?: unknown;
+  };
+}
+
+export async function fetchCloudWorkstations(
+  endpoint: string,
+  authState: CloudPrototypeAuthState,
+  signal?: AbortSignal,
+): Promise<CloudWorkstationsState> {
+  const response = await fetchWithCloudPrototypeAuth(
+    endpoint,
+    {
+      headers: { Accept: "application/json" },
+      signal,
+    },
+    authState,
+  );
+  if (!response.ok) {
+    throw new Error(await responseErrorMessage(response, "Unable to load workstations"));
+  }
+  const payload = (await response.json()) as CloudWorkstationsResponse;
+  const workstations = Array.isArray(payload.workstations)
+    ? payload.workstations.map(normalizeCloudWorkstation).filter(isNotebookRegisteredWorkstation)
+    : [];
+  return {
+    defaultWorkstationId: scalarString(payload.default_workstation_id),
+    workstations,
+  };
+}
+
+export async function setCloudDefaultWorkstation(
+  endpoint: string,
+  authState: CloudPrototypeAuthState,
+  workstationId: string,
+): Promise<string | null> {
+  const response = await fetchWithCloudPrototypeAuth(
+    endpoint,
+    {
+      method: "PATCH",
+      headers: {
+        Accept: "application/json",
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({ workstation_id: workstationId }),
+    },
+    authState,
+  );
+  if (!response.ok) {
+    throw new Error(await responseErrorMessage(response, "Unable to set default workstation"));
+  }
+  const payload = (await response.json()) as { default_workstation_id?: unknown };
+  return scalarString(payload.default_workstation_id);
+}
+
+export async function requestCloudWorkstationAttachment(
+  endpoint: string,
+  authState: CloudPrototypeAuthState,
+  workstationId: string,
+): Promise<{ jobId: string | null; status: string | null }> {
+  const response = await fetchWithCloudPrototypeAuth(
+    endpoint,
+    {
+      method: "POST",
+      headers: {
+        Accept: "application/json",
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({ workstation_id: workstationId }),
+    },
+    authState,
+  );
+  if (!response.ok) {
+    throw new Error(await responseErrorMessage(response, "Unable to attach workstation"));
+  }
+  const payload = (await response.json()) as CloudWorkstationAttachmentResponse;
+  return {
+    jobId: scalarString(payload.job?.job_id),
+    status: scalarString(payload.job?.status),
+  };
+}
+
+function normalizeCloudWorkstation(value: unknown): NotebookRegisteredWorkstation | null {
+  if (!value || typeof value !== "object") {
+    return null;
+  }
+  const raw = value as Record<string, unknown>;
+  const id = scalarString(raw.workstation_id);
+  const displayName = scalarString(raw.display_name);
+  if (!id || !displayName) {
+    return null;
+  }
+  return {
+    id,
+    displayName,
+    provider: scalarString(raw.provider),
+    providerLabel: scalarString(raw.provider_label),
+    status: normalizeStatus(raw.status),
+    statusMessage: scalarString(raw.status_message),
+    defaultEnvironmentLabel: scalarString(raw.default_environment_label),
+    environmentPolicy: scalarString(raw.environment_policy),
+    workingDirectory: scalarString(raw.working_directory),
+    cpuCount: scalarNumber(raw.cpu_count),
+    memoryBytes: scalarNumber(raw.memory_bytes),
+    updatedAt: scalarString(raw.updated_at) ?? scalarString(raw.last_seen_at),
+    environments: normalizeCloudEnvironments(raw.environments),
+  };
+}
+
+function normalizeCloudEnvironments(value: unknown): NotebookRegisteredWorkstation["environments"] {
+  if (!Array.isArray(value)) {
+    return [];
+  }
+  return value
+    .map((raw) => {
+      if (!raw || typeof raw !== "object") return null;
+      const item = raw as Record<string, unknown>;
+      const id = scalarString(item.id);
+      const label = scalarString(item.label);
+      if (!id || !label) return null;
+      return {
+        id,
+        label,
+        available: item.available === false ? false : true,
+        detail: scalarString(item.detail),
+        health: scalarString(item.health),
+        isDefault: item.is_default === true || item.isDefault === true,
+        policy: scalarString(item.policy),
+      };
+    })
+    .filter((item): item is NonNullable<typeof item> => Boolean(item));
+}
+
+function isNotebookRegisteredWorkstation(
+  value: NotebookRegisteredWorkstation | null,
+): value is NotebookRegisteredWorkstation {
+  return Boolean(value);
+}
+
+function normalizeStatus(value: unknown): NotebookRegisteredWorkstation["status"] {
+  return value === "online" ||
+    value === "offline" ||
+    value === "connecting" ||
+    value === "attention" ||
+    value === "unknown"
+    ? value
+    : "unknown";
+}
+
+function scalarString(value: unknown): string | null {
+  return typeof value === "string" && value.trim() ? value.trim() : null;
+}
+
+function scalarNumber(value: unknown): number | null {
+  return typeof value === "number" && Number.isFinite(value) ? value : null;
+}
+
+async function responseErrorMessage(response: Response, fallback: string): Promise<string> {
+  const payload = await response.json().catch(() => null);
+  if (payload && typeof payload === "object") {
+    const message = scalarString((payload as Record<string, unknown>).error);
+    if (message) {
+      return message;
+    }
+  }
+  return `${fallback} (${response.status})`;
+}

--- a/apps/notebook-cloud/viewer/workstations-client.ts
+++ b/apps/notebook-cloud/viewer/workstations-client.ts
@@ -7,6 +7,18 @@ export interface CloudWorkstationsState {
   workstations: readonly NotebookRegisteredWorkstation[];
 }
 
+export type CloudWorkstationRegistryMutationKind = "idle" | "default" | "attach";
+
+export interface CloudWorkstationRefreshCadenceOptions {
+  canChooseHostedWorkstation: boolean;
+  hasRegisteredWorkstations: boolean;
+  mutationKind: CloudWorkstationRegistryMutationKind;
+  panelIsOpen: boolean;
+}
+
+export const CLOUD_WORKSTATIONS_ACTIVE_REFRESH_INTERVAL_MS = 10_000;
+export const CLOUD_WORKSTATIONS_ATTACH_REFRESH_INTERVAL_MS = 2_500;
+
 interface CloudWorkstationsResponse {
   default_workstation_id?: unknown;
   workstations?: unknown;
@@ -94,6 +106,24 @@ export async function requestCloudWorkstationAttachment(
     jobId: scalarString(payload.job?.job_id),
     status: scalarString(payload.job?.status),
   };
+}
+
+export function cloudWorkstationRefreshIntervalMs({
+  canChooseHostedWorkstation,
+  hasRegisteredWorkstations,
+  mutationKind,
+  panelIsOpen,
+}: CloudWorkstationRefreshCadenceOptions): number | null {
+  if (!canChooseHostedWorkstation) {
+    return null;
+  }
+  if (mutationKind === "attach") {
+    return CLOUD_WORKSTATIONS_ATTACH_REFRESH_INTERVAL_MS;
+  }
+  if (panelIsOpen || !hasRegisteredWorkstations) {
+    return CLOUD_WORKSTATIONS_ACTIVE_REFRESH_INTERVAL_MS;
+  }
+  return null;
 }
 
 function normalizeCloudWorkstation(value: unknown): NotebookRegisteredWorkstation | null {

--- a/crates/runtimed/src/jupyter_kernel.rs
+++ b/crates/runtimed/src/jupyter_kernel.rs
@@ -49,6 +49,11 @@ use crate::EnvType;
 use notebook_protocol::protocol::{CommRequestMessage, KernelPorts, LaunchedEnvConfig};
 
 const REDACT_ENV_VALUES_IN_OUTPUTS_ENV: &str = "NTERACT_REDACT_ENV_VALUES_IN_OUTPUTS";
+const KERNEL_ENV_SECRET_BLOCKLIST: &[&str] = &[
+    "RUNT_CLOUD_TOKEN",
+    "NTERACT_API_KEY",
+    "NOTEBOOK_CLOUD_PUBLISH_BEARER_TOKEN",
+];
 
 #[cfg(unix)]
 fn ipc_path_prefix(kernel_id: &str) -> PathBuf {
@@ -885,6 +890,7 @@ impl KernelConnection for JupyterKernel {
                 cmd.env(key, value);
             }
         }
+        scrub_secret_kernel_env(&mut cmd);
         cmd.env(
             REDACT_ENV_VALUES_IN_OUTPUTS_ENV,
             if config.redact_env_values_in_outputs {
@@ -3336,6 +3342,12 @@ async fn wait_for_pid_exit(pid: i32, timeout: std::time::Duration) -> bool {
     }
 }
 
+fn scrub_secret_kernel_env(cmd: &mut tokio::process::Command) {
+    for key in KERNEL_ENV_SECRET_BLOCKLIST {
+        cmd.env_remove(key);
+    }
+}
+
 fn prepend_to_path(dir: &std::path::Path) -> String {
     let dir_str = dir.to_string_lossy();
     match std::env::var("PATH") {
@@ -3347,6 +3359,7 @@ fn prepend_to_path(dir: &std::path::Path) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::ffi::OsStr;
 
     fn history_entry(source: &str, line: i32) -> HistoryEntry {
         HistoryEntry {
@@ -3354,6 +3367,30 @@ mod tests {
             line,
             source: source.to_string(),
         }
+    }
+
+    #[test]
+    fn scrub_secret_kernel_env_prevents_cloud_credentials_from_inheriting() {
+        let mut cmd = tokio::process::Command::new("python");
+        cmd.env("RUNT_CLOUD_TOKEN", "cloud-secret");
+        cmd.env("NTERACT_API_KEY", "api-secret");
+        cmd.env("NOTEBOOK_CLOUD_PUBLISH_BEARER_TOKEN", "publish-secret");
+        cmd.env("VISIBLE_KERNEL_ENV", "ok");
+
+        scrub_secret_kernel_env(&mut cmd);
+
+        let envs: Vec<_> = cmd.as_std().get_envs().collect();
+        for key in KERNEL_ENV_SECRET_BLOCKLIST {
+            assert!(
+                envs.iter()
+                    .any(|(name, value)| *name == OsStr::new(key) && value.is_none()),
+                "{key} should be explicitly removed from the kernel environment"
+            );
+        }
+        assert!(envs
+            .iter()
+            .any(|(name, value)| *name == OsStr::new("VISIBLE_KERNEL_ENV")
+                && value == &Some(OsStr::new("ok"))));
     }
 
     #[test]

--- a/crates/runtimed/src/jupyter_kernel.rs
+++ b/crates/runtimed/src/jupyter_kernel.rs
@@ -55,6 +55,19 @@ const KERNEL_ENV_SECRET_BLOCKLIST: &[&str] = &[
     "NOTEBOOK_CLOUD_PUBLISH_BEARER_TOKEN",
 ];
 
+fn is_tolerated_kernel_info_reply_parse_error(error: &jupyter_zmq_client::RuntimeError) -> bool {
+    match error {
+        jupyter_zmq_client::RuntimeError::ParseError { msg_type, source } => {
+            // Deno kernels can report a CodeMirror mode shape that the current
+            // upstream jupyter_protocol enum does not model. `shell.read()` has
+            // already consumed that kernel_info_reply frame before returning the
+            // parse error, so this narrow case is enough to prove liveness.
+            msg_type == "kernel_info_reply" && source.to_string().contains("CodeMirrorMode")
+        }
+        _ => false,
+    }
+}
+
 #[cfg(unix)]
 fn ipc_path_prefix(kernel_id: &str) -> PathBuf {
     crate::ipc_socket_dir().join(format!("kernel-{}-ipc", kernel_id))
@@ -2433,8 +2446,21 @@ impl KernelConnection for JupyterKernel {
         let reply = tokio::select! {
             result = await_result_with_timeout(shell.read(), std::time::Duration::from_secs(30)) => {
                 match result {
-                    TimedResult::Completed(msg) => Ok(msg),
-                    TimedResult::Failed(e) => Err(anyhow::anyhow!("Kernel did not respond: {}", e)),
+                    TimedResult::Completed(msg) => Ok(Some(msg.header.msg_type)),
+                    TimedResult::Failed(e) => {
+                        if is_tolerated_kernel_info_reply_parse_error(&e) {
+                            warn!(
+                                "[jupyter-kernel] Kernel info reply used tolerated parse fallback: kernel_id={} kernel_info_elapsed_ms={} launch_elapsed_ms={} error={}",
+                                kernel_id,
+                                kernel_info_started.elapsed().as_millis(),
+                                launch_started.elapsed().as_millis(),
+                                e
+                            );
+                            Ok(None)
+                        } else {
+                            Err(anyhow::anyhow!("Kernel did not respond: {}", e))
+                        }
+                    },
                     TimedResult::TimedOut => Err(anyhow::anyhow!("Kernel did not respond within 30s")),
                 }
             }
@@ -2445,10 +2471,18 @@ impl KernelConnection for JupyterKernel {
         };
 
         match reply {
-            Ok(msg) => {
+            Ok(Some(msg_type)) => {
                 info!(
                     "[jupyter-kernel] Kernel alive: got {} reply (kernel_id={} kernel_info_elapsed_ms={} launch_elapsed_ms={})",
-                    msg.header.msg_type,
+                    msg_type,
+                    kernel_id,
+                    kernel_info_started.elapsed().as_millis(),
+                    launch_started.elapsed().as_millis()
+                );
+            }
+            Ok(None) => {
+                info!(
+                    "[jupyter-kernel] Kernel alive: accepted kernel_info_reply with tolerated parse fallback (kernel_id={} kernel_info_elapsed_ms={} launch_elapsed_ms={})",
                     kernel_id,
                     kernel_info_started.elapsed().as_millis(),
                     launch_started.elapsed().as_millis()
@@ -3391,6 +3425,49 @@ mod tests {
             .iter()
             .any(|(name, value)| *name == OsStr::new("VISIBLE_KERNEL_ENV")
                 && value == &Some(OsStr::new("ok"))));
+    }
+
+    fn codemirror_mode_parse_error() -> serde_json::Error {
+        serde_json::from_value::<jupyter_protocol::CodeMirrorMode>(serde_json::json!({
+            "name": "typescript",
+            "version": "5.0"
+        }))
+        .expect_err("string version should not match the upstream CodeMirrorMode enum")
+    }
+
+    fn plain_parse_error() -> serde_json::Error {
+        serde_json::from_value::<usize>(serde_json::json!("not-a-number"))
+            .expect_err("string should not parse as usize")
+    }
+
+    #[test]
+    fn tolerates_kernel_info_codemirror_mode_parse_error() {
+        let error = jupyter_zmq_client::RuntimeError::ParseError {
+            msg_type: "kernel_info_reply".to_string(),
+            source: codemirror_mode_parse_error(),
+        };
+
+        assert!(is_tolerated_kernel_info_reply_parse_error(&error));
+    }
+
+    #[test]
+    fn does_not_tolerate_other_kernel_info_parse_errors() {
+        let error = jupyter_zmq_client::RuntimeError::ParseError {
+            msg_type: "kernel_info_reply".to_string(),
+            source: plain_parse_error(),
+        };
+
+        assert!(!is_tolerated_kernel_info_reply_parse_error(&error));
+    }
+
+    #[test]
+    fn does_not_tolerate_codemirror_errors_on_other_messages() {
+        let error = jupyter_zmq_client::RuntimeError::ParseError {
+            msg_type: "execute_reply".to_string(),
+            source: codemirror_mode_parse_error(),
+        };
+
+        assert!(!is_tolerated_kernel_info_reply_parse_error(&error));
     }
 
     #[test]

--- a/crates/runtimed/src/main.rs
+++ b/crates/runtimed/src/main.rs
@@ -178,6 +178,13 @@ enum Commands {
         /// Defaults to the process current directory.
         #[arg(long, alias = "cwd")]
         working_dir: Option<PathBuf>,
+        /// Stable workstation id to present to the hosted room. Non-secret.
+        #[arg(long)]
+        workstation_id: Option<String>,
+        /// Human-readable workstation name to present to the hosted room.
+        /// Non-secret.
+        #[arg(long)]
+        workstation_display_name: Option<String>,
     },
 
     /// Warm a pool environment (internal, spawned by daemon warming loops).
@@ -473,6 +480,8 @@ async fn main() -> anyhow::Result<()> {
             python_path,
             notebook_path,
             working_dir,
+            workstation_id,
+            workstation_display_name,
         }) => {
             let cli_args = runtimed::workstation::CloudAgentArgs {
                 cloud_url,
@@ -480,13 +489,28 @@ async fn main() -> anyhow::Result<()> {
                 scope,
                 auth_kind,
             };
-            let config =
+            let mut config =
                 runtimed::workstation::build_cloud_config(&cli_args, |k| std::env::var(k).ok())
                     .map_err(|e| {
                         eprintln!("[cloud-runtime-agent] Config error: {}", e);
                         e
                     })?;
             let resolved_working_dir = working_dir.or_else(|| std::env::current_dir().ok());
+            if python_path.is_none()
+                && (workstation_id.is_some()
+                    || workstation_display_name.is_some()
+                    || resolved_working_dir.is_some())
+            {
+                config.workstation = Some(notebook_cloud_transport::CloudWorkstationMetadata {
+                    workstation_id: workstation_id.clone(),
+                    display_name: workstation_display_name.clone(),
+                    default_environment_label: None,
+                    environment_policy: None,
+                    working_directory: resolved_working_dir
+                        .as_deref()
+                        .map(|path| path.to_string_lossy().into_owned()),
+                });
+            }
             let result = match python_path {
                 // Launch-on-attach: allocate and *start* a current_python runtime.
                 Some(python_path) => {
@@ -495,16 +519,18 @@ async fn main() -> anyhow::Result<()> {
                             notebook_path.as_deref(),
                             resolved_working_dir.as_deref(),
                         );
+                    let mut workstation_metadata =
+                        runtimed::workstation::current_python_workstation_metadata(
+                            launch_working_dir.as_deref(),
+                        );
+                    workstation_metadata.workstation_id = workstation_id;
+                    workstation_metadata.display_name = workstation_display_name;
                     let target = runtimed::workstation::RoomTarget {
                         cloud_url: config.cloud_url.clone(),
                         notebook_id: config.notebook_id.clone(),
                         scope: config.scope.clone(),
                         operator,
-                        workstation: Some(
-                            runtimed::workstation::current_python_workstation_metadata(
-                                launch_working_dir.as_deref(),
-                            ),
-                        ),
+                        workstation: Some(workstation_metadata),
                     };
                     runtimed::workstation::allocate_current_python_runtime(
                         target,

--- a/crates/runtimed/src/notebook_sync_server/load.rs
+++ b/crates/runtimed/src/notebook_sync_server/load.rs
@@ -660,6 +660,20 @@ where
         path.display(),
         start.elapsed()
     );
+    let loaded_sources: HashMap<String, String> = cells
+        .iter()
+        .map(|cell| (cell.id.clone(), cell.source.clone()))
+        .collect();
+    let should_seed_save_baseline = match room.file_binding.path().await {
+        Some(bound_path) => bound_path == path,
+        None => false,
+    };
+    if should_seed_save_baseline {
+        // The file watcher is live while cells stream to the frontend. Seed the
+        // disk-source baseline before exposing batches so an unchanged initial
+        // watch event cannot roll back immediate live edits.
+        *room.persistence.last_save_sources.write().await = loaded_sources;
+    }
     let notebook_path = room
         .file_binding
         .path()

--- a/crates/runtimed/src/notebook_sync_server/peer_session.rs
+++ b/crates/runtimed/src/notebook_sync_server/peer_session.rs
@@ -247,6 +247,7 @@ where
 
 #[cfg(test)]
 mod tests {
+    use std::collections::HashMap;
     use std::pin::Pin;
     use std::sync::Arc;
     use std::task::{Context, Poll};
@@ -259,6 +260,7 @@ mod tests {
 
     use super::*;
     use crate::blob_store::BlobStore;
+    use crate::notebook_sync_server::apply_ipynb_changes;
 
     #[derive(Default)]
     struct CaptureWriter {
@@ -781,5 +783,82 @@ mod tests {
                 Ok(())
             })
             .unwrap();
+    }
+
+    #[tokio::test]
+    async fn stream_initial_load_seeds_file_watcher_source_baseline() {
+        let tmp = tempfile::tempdir().unwrap();
+        let load_path = tmp.path().join("source.ipynb");
+        write_one_cell_notebook(&load_path).await;
+        let blob_store = Arc::new(BlobStore::new(tmp.path().join("blobs")));
+        let room = Arc::new(NotebookRoom::new_fresh(
+            Uuid::new_v4(),
+            Some(load_path.clone()),
+            tmp.path(),
+            blob_store,
+            false,
+        ));
+        let mut reader = tokio::io::empty();
+        let mut writer = CaptureWriter::default();
+        let mut peer_state = sync::State::new();
+
+        stream_initial_load(
+            &mut reader,
+            &mut writer,
+            &room,
+            Some(&load_path),
+            tmp.path(),
+            &mut peer_state,
+            NotebookDocPhaseWire::Syncing,
+            RuntimeStatePhaseWire::Syncing,
+            InitialLoadPhaseWire::Streaming,
+            4,
+        )
+        .await
+        .expect("valid notebook should stream successfully");
+
+        assert_eq!(
+            room.persistence
+                .last_save_sources
+                .read()
+                .await
+                .get("loaded-cell")
+                .map(String::as_str),
+            Some("x = 1"),
+            "streaming load should seed the file-watcher baseline"
+        );
+
+        {
+            let mut doc = room.doc.write().await;
+            doc.update_source("loaded-cell", "print('edited')")
+                .expect("live edit should update source");
+        }
+
+        let external_cells = vec![notebook_doc::CellSnapshot {
+            id: "loaded-cell".to_string(),
+            cell_type: "code".to_string(),
+            position: "80".to_string(),
+            source: "x = 1".to_string(),
+            execution_count: "7".to_string(),
+            metadata: serde_json::json!({}),
+            resolved_assets: HashMap::new(),
+            attachments: HashMap::new(),
+        }];
+
+        let changed = apply_ipynb_changes(
+            &room,
+            &external_cells,
+            &HashMap::new(),
+            &HashMap::new(),
+            true,
+        )
+        .await;
+        assert!(
+            !changed,
+            "unchanged disk contents should not roll back an immediate live edit"
+        );
+
+        let cells = room.doc.read().await.get_cells();
+        assert_eq!(cells[0].source, "print('edited')");
     }
 }

--- a/crates/runtimed/src/notebook_sync_server/peer_writer.rs
+++ b/crates/runtimed/src/notebook_sync_server/peer_writer.rs
@@ -444,11 +444,46 @@ fn request_allowed_for_scope(
     request: &notebook_protocol::protocol::NotebookRequest,
     connection_scope: ConnectionScope,
 ) -> bool {
-    connection_scope.allows_notebook_write()
-        || matches!(
-            request,
-            notebook_protocol::protocol::NotebookRequest::GetDocBytes {}
-        )
+    matches!(
+        request,
+        notebook_protocol::protocol::NotebookRequest::GetDocBytes {}
+    ) || match request_required_scope(request) {
+        RequestRequiredScope::NotebookWrite => connection_scope.allows_notebook_write(),
+        RequestRequiredScope::Owner => matches!(connection_scope, ConnectionScope::Owner),
+    }
+}
+
+enum RequestRequiredScope {
+    NotebookWrite,
+    Owner,
+}
+
+fn request_required_scope(
+    request: &notebook_protocol::protocol::NotebookRequest,
+) -> RequestRequiredScope {
+    use notebook_protocol::protocol::NotebookRequest;
+
+    match request {
+        NotebookRequest::LaunchKernel { .. }
+        | NotebookRequest::ExecuteCell { .. }
+        | NotebookRequest::ExecuteCellGuarded { .. }
+        | NotebookRequest::GetHistory { .. }
+        | NotebookRequest::Complete { .. }
+        | NotebookRequest::InterruptExecution {}
+        | NotebookRequest::ShutdownKernel {}
+        | NotebookRequest::RunAllCells { .. }
+        | NotebookRequest::RunAllCellsGuarded { .. }
+        | NotebookRequest::SaveNotebook { .. }
+        | NotebookRequest::SyncEnvironment { .. }
+        | NotebookRequest::ApproveTrust { .. }
+        | NotebookRequest::ApproveProjectEnvironment { .. } => RequestRequiredScope::Owner,
+        NotebookRequest::SendComm { .. }
+        | NotebookRequest::CloneAsEphemeral { .. }
+        | NotebookRequest::GetDocBytes {}
+        | NotebookRequest::CreateBlobUpload { .. }
+        | NotebookRequest::CompleteBlobUpload { .. }
+        | NotebookRequest::AbortBlobUpload { .. } => RequestRequiredScope::NotebookWrite,
+    }
 }
 
 pub(super) fn queue_request_error(
@@ -1056,5 +1091,98 @@ mod tests {
             notebook_protocol::protocol::NotebookResponse::Error { ref error }
                 if error.contains("ExecuteCell is not allowed")
         ));
+    }
+
+    #[tokio::test]
+    async fn enqueue_notebook_request_rejects_editor_execution_without_failing_loop() {
+        let (request_tx, mut request_rx) =
+            mpsc::channel::<notebook_protocol::protocol::NotebookRequestEnvelope>(1);
+        let request_worker = PeerRequestWorker {
+            tx: request_tx,
+            handle: tokio::spawn(std::future::pending::<anyhow::Result<()>>()),
+        };
+        let (writer, mut reliable_rx, _ephemeral_rx) = test_peer_writer_with_capacities(1, 1);
+
+        let payload = serde_json::to_vec(&notebook_protocol::protocol::NotebookRequestEnvelope {
+            id: Some("execute".to_string()),
+            required_heads: Vec::new(),
+            request: NotebookRequest::ExecuteCell {
+                cell_id: "cell-1".to_string(),
+                execution_id: None,
+            },
+        })
+        .unwrap();
+        enqueue_notebook_request(
+            &request_worker,
+            &writer,
+            &payload,
+            "notebook",
+            "peer",
+            ConnectionScope::Editor,
+        )
+        .expect("unauthorized requests should be reported without failing the peer loop");
+
+        assert!(
+            request_rx.try_recv().is_err(),
+            "editor execution should not reach the request worker"
+        );
+        let frame = reliable_rx
+            .try_recv()
+            .expect("unauthorized request should enqueue an error response");
+        assert_eq!(frame.frame_type, NotebookFrameType::Response);
+        let reply: notebook_protocol::protocol::NotebookResponseEnvelope =
+            serde_json::from_slice(&frame.payload).unwrap();
+        assert_eq!(reply.id.as_deref(), Some("execute"));
+        assert!(matches!(
+            reply.response,
+            notebook_protocol::protocol::NotebookResponse::Error { ref error }
+                if error.contains("ExecuteCell is not allowed")
+        ));
+    }
+
+    #[tokio::test]
+    async fn enqueue_notebook_request_allows_editor_document_scoped_uploads() {
+        let (request_tx, mut request_rx) =
+            mpsc::channel::<notebook_protocol::protocol::NotebookRequestEnvelope>(1);
+        let request_worker = PeerRequestWorker {
+            tx: request_tx,
+            handle: tokio::spawn(std::future::pending::<anyhow::Result<()>>()),
+        };
+        let (writer, mut reliable_rx, _ephemeral_rx) = test_peer_writer_with_capacities(1, 1);
+
+        let payload = serde_json::to_vec(&notebook_protocol::protocol::NotebookRequestEnvelope {
+            id: Some("upload".to_string()),
+            required_heads: Vec::new(),
+            request: NotebookRequest::CreateBlobUpload {
+                media_type: "image/png".to_string(),
+                size: 42,
+                sha256: None,
+                part_size: None,
+                purpose: Some("cell-attachment".to_string()),
+            },
+        })
+        .unwrap();
+        enqueue_notebook_request(
+            &request_worker,
+            &writer,
+            &payload,
+            "notebook",
+            "peer",
+            ConnectionScope::Editor,
+        )
+        .expect("editor document-scoped request should enqueue");
+
+        let envelope = request_rx
+            .try_recv()
+            .expect("editor document-scoped request should reach the request worker");
+        assert_eq!(envelope.id.as_deref(), Some("upload"));
+        assert!(matches!(
+            envelope.request,
+            NotebookRequest::CreateBlobUpload { .. }
+        ));
+        assert!(
+            reliable_rx.try_recv().is_err(),
+            "allowed request should not enqueue an authorization error"
+        );
     }
 }

--- a/packages/runtimed/src/notebook-workstation-launch.ts
+++ b/packages/runtimed/src/notebook-workstation-launch.ts
@@ -181,6 +181,18 @@ function launchProjectionForCandidate(
   candidate: NotebookRegisteredWorkstationProjection,
 ): NotebookWorkstationLaunchReadinessProjection {
   if (candidate.status === "online") {
+    if (!candidate.workingDirectoryLabel) {
+      return unavailableCandidateProjection(
+        candidate,
+        "This workstation does not have a working directory configured for notebook execution.",
+      );
+    }
+    if (!hasRunnableEnvironment(candidate)) {
+      return unavailableCandidateProjection(
+        candidate,
+        "This workstation does not have a runnable default environment configured.",
+      );
+    }
     return launchProjection({
       canRun: false,
       detail: "This workstation is available but not attached to the notebook yet.",
@@ -206,15 +218,30 @@ function launchProjectionForCandidate(
       workstationId: candidate.id,
     });
   }
+  return unavailableCandidateProjection(
+    candidate,
+    candidate.statusMessage ?? "This workstation is not available to run cells.",
+  );
+}
+
+function unavailableCandidateProjection(
+  candidate: NotebookRegisteredWorkstationProjection,
+  detail: string,
+): NotebookWorkstationLaunchReadinessProjection {
   return launchProjection({
     canRun: false,
-    detail: candidate.statusMessage ?? "This workstation is not available to run cells.",
+    detail,
     primaryAction: launchAction("open_workstations", "Review compute", "Open workstations panel"),
     state: "workstation_unavailable",
     statusLabel: candidate.statusLabel,
     targetLabel: candidate.displayName,
     workstationId: candidate.id,
   });
+}
+
+function hasRunnableEnvironment(candidate: NotebookRegisteredWorkstationProjection): boolean {
+  if (candidate.defaultEnvironmentLabel) return true;
+  return candidate.environments.some((environment) => environment.available);
 }
 
 function launchProjection(

--- a/packages/runtimed/src/notebook-workstation-launch.ts
+++ b/packages/runtimed/src/notebook-workstation-launch.ts
@@ -19,6 +19,7 @@ export type NotebookWorkstationLaunchActionKind =
   | "none"
   | "setup_workstation"
   | "select_workstation"
+  | "attach_workstation"
   | "open_workstations";
 
 export interface NotebookWorkstationLaunchActionProjection {
@@ -183,7 +184,11 @@ function launchProjectionForCandidate(
     return launchProjection({
       canRun: false,
       detail: "This workstation is available but not attached to the notebook yet.",
-      primaryAction: launchAction("open_workstations", "Review compute", "Open workstations panel"),
+      primaryAction: launchAction(
+        "attach_workstation",
+        "Attach compute",
+        `Attach ${candidate.displayName} to this notebook`,
+      ),
       state: "needs_attachment",
       statusLabel: "Attach needed",
       targetLabel: candidate.displayName,

--- a/packages/runtimed/tests/notebook-workstation-launch.test.ts
+++ b/packages/runtimed/tests/notebook-workstation-launch.test.ts
@@ -156,6 +156,96 @@ describe("notebook workstation launch readiness projection", () => {
     });
   });
 
+  it("keeps online workstations without launch context unavailable", () => {
+    const missingWorkingDirectory = projectNotebookWorkstationSelection({
+      canSelectWorkstation: true,
+      defaultWorkstationId: "ws-lab2",
+      registeredWorkstations: [{ ...lab2Workstation, workingDirectory: null }],
+    });
+    const missingWorkingDirectoryProjection = projectNotebookWorkstationLaunchReadiness({
+      capabilities: cloudUnavailableCapabilities,
+      selection: missingWorkingDirectory,
+    });
+
+    expect(missingWorkingDirectoryProjection).toMatchObject({
+      canRun: false,
+      detail:
+        "This workstation does not have a working directory configured for notebook execution.",
+      primaryAction: {
+        kind: "open_workstations",
+        label: "Review compute",
+      },
+      state: "workstation_unavailable",
+      targetLabel: "Lab2 workstation",
+      workstationId: "ws-lab2",
+    });
+
+    const missingEnvironment = projectNotebookWorkstationSelection({
+      canSelectWorkstation: true,
+      defaultWorkstationId: "ws-lab2",
+      registeredWorkstations: [
+        {
+          ...lab2Workstation,
+          defaultEnvironmentLabel: null,
+          environments: [
+            {
+              id: "project-env",
+              label: "Project environment",
+              available: false,
+            },
+          ],
+        },
+      ],
+    });
+    const missingEnvironmentProjection = projectNotebookWorkstationLaunchReadiness({
+      capabilities: cloudUnavailableCapabilities,
+      selection: missingEnvironment,
+    });
+
+    expect(missingEnvironmentProjection).toMatchObject({
+      canRun: false,
+      detail: "This workstation does not have a runnable default environment configured.",
+      primaryAction: {
+        kind: "open_workstations",
+        label: "Review compute",
+      },
+      state: "workstation_unavailable",
+      targetLabel: "Lab2 workstation",
+      workstationId: "ws-lab2",
+    });
+  });
+
+  it("projects an offline default workstation as unavailable with its status message", () => {
+    const selection = projectNotebookWorkstationSelection({
+      canSelectWorkstation: true,
+      defaultWorkstationId: "ws-lab2",
+      registeredWorkstations: [
+        {
+          ...lab2Workstation,
+          status: "offline",
+          statusMessage: "No heartbeat from this workstation recently.",
+        },
+      ],
+    });
+    const projection = projectNotebookWorkstationLaunchReadiness({
+      capabilities: cloudUnavailableCapabilities,
+      selection,
+    });
+
+    expect(projection).toMatchObject({
+      canRun: false,
+      detail: "No heartbeat from this workstation recently.",
+      primaryAction: {
+        kind: "open_workstations",
+        label: "Review compute",
+      },
+      state: "workstation_unavailable",
+      statusLabel: "Offline",
+      targetLabel: "Lab2 workstation",
+      workstationId: "ws-lab2",
+    });
+  });
+
   it("projects registered workstations without a selected/default target as selection needed", () => {
     const selection = projectNotebookWorkstationSelection({
       canSelectWorkstation: true,

--- a/packages/runtimed/tests/notebook-workstation-launch.test.ts
+++ b/packages/runtimed/tests/notebook-workstation-launch.test.ts
@@ -150,7 +150,8 @@ describe("notebook workstation launch readiness projection", () => {
       targetLabel: "Lab2 workstation",
       workstationId: "ws-lab2",
       primaryAction: {
-        kind: "open_workstations",
+        kind: "attach_workstation",
+        label: "Attach compute",
       },
     });
   });

--- a/src/components/notebook/NotebookWorkstationsPanel.tsx
+++ b/src/components/notebook/NotebookWorkstationsPanel.tsx
@@ -8,12 +8,15 @@ import {
   Monitor,
   PlugZap,
   Server,
+  ServerCog,
 } from "lucide-react";
 import type { LucideIcon } from "lucide-react";
+import { Button } from "@/components/ui/button";
 import {
   projectNotebookWorkstationPanel,
   type NotebookShellCapabilities,
   type NotebookShellAccessSource,
+  type NotebookRegisteredWorkstationProjection,
   type NotebookWorkstationFactProjection,
   type NotebookWorkstationPanelTone,
   type NotebookWorkstationSelectionProjection,
@@ -23,17 +26,26 @@ import { cn } from "@/lib/utils";
 export interface NotebookWorkstationsPanelProps {
   capabilities: NotebookShellCapabilities;
   selection?: NotebookWorkstationSelectionProjection | null;
+  busyWorkstationId?: string | null;
   className?: string;
+  onAttachWorkstation?: (workstationId: string) => void;
+  onSetDefaultWorkstation?: (workstationId: string) => void;
+  statusMessage?: string | null;
 }
 
 export function NotebookWorkstationsPanel({
+  busyWorkstationId = null,
   capabilities,
   selection = null,
   className,
+  onAttachWorkstation,
+  onSetDefaultWorkstation,
+  statusMessage = null,
 }: NotebookWorkstationsPanelProps) {
   const projection = projectNotebookWorkstationPanel(capabilities);
   const status = workstationStatusTone(projection.tone);
   const showRegistrationPrompt = selection?.state === "needs_registration";
+  const registeredWorkstations = selection?.registeredWorkstations ?? [];
 
   return (
     <div className={cn("space-y-3 text-sm", className)} data-testid="notebook-workstations-panel">
@@ -82,6 +94,26 @@ export function NotebookWorkstationsPanel({
         ))}
       </section>
 
+      {statusMessage ? (
+        <section className="rounded-md bg-muted/[0.05] px-3 py-2 text-xs text-muted-foreground">
+          {statusMessage}
+        </section>
+      ) : null}
+
+      {registeredWorkstations.length > 0 ? (
+        <section className="space-y-2" aria-label="Registered workstations">
+          {registeredWorkstations.map((workstation) => (
+            <RegisteredWorkstationRow
+              key={workstation.id}
+              busy={busyWorkstationId === workstation.id}
+              workstation={workstation}
+              onAttachWorkstation={onAttachWorkstation}
+              onSetDefaultWorkstation={onSetDefaultWorkstation}
+            />
+          ))}
+        </section>
+      ) : null}
+
       {showRegistrationPrompt ? (
         <section
           className="rounded-md border border-dashed border-border/80 px-3 py-2 text-xs"
@@ -97,6 +129,78 @@ export function NotebookWorkstationsPanel({
           </p>
         </section>
       ) : null}
+    </div>
+  );
+}
+
+function RegisteredWorkstationRow({
+  busy,
+  workstation,
+  onAttachWorkstation,
+  onSetDefaultWorkstation,
+}: {
+  busy: boolean;
+  workstation: NotebookRegisteredWorkstationProjection;
+  onAttachWorkstation?: (workstationId: string) => void;
+  onSetDefaultWorkstation?: (workstationId: string) => void;
+}) {
+  const online = workstation.status === "online";
+  return (
+    <div className="rounded-md bg-muted/[0.04] px-3 py-2" data-testid="registered-workstation">
+      <div className="flex min-w-0 items-start gap-3">
+        <ServerCog className="mt-0.5 size-4 shrink-0 text-muted-foreground" aria-hidden="true" />
+        <div className="min-w-0 flex-1">
+          <div className="mb-0.5 truncate font-mono text-[10.5px] tracking-normal text-muted-foreground">
+            {workstation.id}
+          </div>
+          <div className="flex min-w-0 flex-wrap items-center gap-x-2 gap-y-1">
+            <h4 className="truncate text-sm font-medium">{workstation.displayName}</h4>
+            {workstation.isDefault ? (
+              <span className="text-xs font-medium text-muted-foreground">Default</span>
+            ) : null}
+            <span className="text-xs font-medium text-muted-foreground">
+              {workstation.statusLabel}
+            </span>
+          </div>
+          <div className="mt-1 flex min-w-0 flex-wrap gap-x-2 gap-y-1 text-xs text-muted-foreground">
+            {workstation.defaultEnvironmentLabel ? (
+              <span className="truncate">{workstation.defaultEnvironmentLabel}</span>
+            ) : null}
+            {workstation.workingDirectoryLabel ? (
+              <span className="truncate">{workstation.workingDirectoryLabel}</span>
+            ) : null}
+          </div>
+          {workstation.statusMessage ? (
+            <p className="mt-1 text-xs leading-5 text-muted-foreground">
+              {workstation.statusMessage}
+            </p>
+          ) : null}
+        </div>
+      </div>
+      <div className="mt-2 flex flex-wrap justify-end gap-2">
+        {onSetDefaultWorkstation && !workstation.isDefault ? (
+          <Button
+            type="button"
+            variant="ghost"
+            size="sm"
+            disabled={busy}
+            onClick={() => onSetDefaultWorkstation(workstation.id)}
+          >
+            Set default
+          </Button>
+        ) : null}
+        {onAttachWorkstation ? (
+          <Button
+            type="button"
+            variant={workstation.isAttached ? "secondary" : "outline"}
+            size="sm"
+            disabled={busy || workstation.isAttached || !online}
+            onClick={() => onAttachWorkstation(workstation.id)}
+          >
+            {workstation.isAttached ? "Attached" : busy ? "Attaching" : "Attach"}
+          </Button>
+        ) : null}
+      </div>
     </div>
   );
 }

--- a/src/components/notebook/__tests__/NotebookWorkstationsPanel.test.tsx
+++ b/src/components/notebook/__tests__/NotebookWorkstationsPanel.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen } from "@testing-library/react";
+import { fireEvent, render, screen } from "@testing-library/react";
 import { describe, expect, it } from "vite-plus/test";
 import type { NotebookShellCapabilities } from "../capabilities";
 import {
@@ -197,6 +197,59 @@ describe("NotebookWorkstationsPanel", () => {
     );
 
     expect(screen.queryByTestId("workstation-registration-empty")).not.toBeInTheDocument();
+  });
+
+  it("renders registered workstation targets with default and attach actions", () => {
+    const attached: string[] = [];
+    const defaults: string[] = [];
+    const selection = projectNotebookWorkstationSelection({
+      canRegisterWorkstation: true,
+      canSelectWorkstation: true,
+      canSetDefaultWorkstation: true,
+      defaultWorkstationId: "ws-lab2",
+      registeredWorkstations: [
+        {
+          id: "ws-lab2",
+          displayName: "Lab2",
+          defaultEnvironmentLabel: "Current Python",
+          environmentPolicy: "current_python",
+          provider: "runtime_peer",
+          status: "online",
+          workingDirectory: "/home/ubuntu/project",
+        },
+        {
+          id: "ws-offline",
+          displayName: "Offline workstation",
+          provider: "runtime_peer",
+          status: "offline",
+          statusMessage: "No heartbeat from this workstation recently.",
+        },
+      ],
+    });
+
+    render(
+      <NotebookWorkstationsPanel
+        capabilities={readOnlyNotebookShellCapabilities}
+        selection={selection}
+        onAttachWorkstation={(workstationId) => attached.push(workstationId)}
+        onSetDefaultWorkstation={(workstationId) => defaults.push(workstationId)}
+      />,
+    );
+
+    expect(screen.getByText("ws-lab2")).toBeVisible();
+    expect(screen.getByText("Lab2")).toBeVisible();
+    expect(screen.getByText("Default")).toBeVisible();
+    expect(screen.getByText("/home/ubuntu/project")).toBeVisible();
+    const attachButtons = screen.getAllByRole("button", { name: "Attach" });
+    fireEvent.click(attachButtons[0]!);
+    expect(attached).toEqual(["ws-lab2"]);
+
+    expect(screen.getByText("Offline workstation")).toBeVisible();
+    expect(screen.getByText("No heartbeat from this workstation recently.")).toBeVisible();
+    expect(screen.getByRole("button", { name: "Set default" })).toBeEnabled();
+    fireEvent.click(screen.getByRole("button", { name: "Set default" }));
+    expect(defaults).toEqual(["ws-offline"]);
+    expect(attachButtons[1]).toBeDisabled();
   });
 
   it("keeps legacy resource labels when structured resources are absent", () => {


### PR DESCRIPTION
## Summary
- add D1-backed hosted workstation registration, default selection, and attach-job APIs
- wire cloud viewer workstation listing/default/attach requests into the shared workstation projections and panel
- add a lab2-friendly workstation agent helper that launches `runtimed cloud-runtime-agent` from pending attach jobs
- add a checked-in Playwright toolbar smoke for the hosted attach/run/reload/run path and viewer/editor access-mode checks
- surface the shared `Attach compute` toolbar action when a default workstation is online but not attached
- block incomplete launch targets in the shared projection when an online workstation lacks a working directory or runnable default environment
- make repeated attach requests idempotent while an attach job is active
- keep hosted execution owner-only by default until explicit execute capability exists
- strip cloud/API key environment variables before Python kernel launch
- tolerate Deno-style kernel-info `CodeMirrorMode` metadata during startup without broadening other kernel parse errors
- omit OIDC subject/email from hosted browser smoke reports
- cover cross-principal workstation/default/attach-job isolation in worker route tests
- harden the shared CI `wasm-pack` installer with `--retry-all-errors` plus a `cargo install` fallback after repeated GitHub release 504s

## Validation
- `node --test apps/notebook-cloud/test/hosted-runtime-browser-execute-smoke.test.mjs`
- `node --check apps/notebook-cloud/scripts/hosted-workstation-toolbar-smoke.mjs`
- `node --test apps/notebook-cloud/test/hosted-workstation-toolbar-smoke.test.mjs`
- `node --check apps/notebook-cloud/scripts/hosted-browser-execute-smoke.mjs`
- `node --check apps/notebook-cloud/scripts/hosted-live-room-smoke.mjs`
- `rg -n "claims\\?\\.email|claims\\?\\.sub|subject: token\\.claims" apps/notebook-cloud/scripts apps/notebook-cloud/test` returned no matches
- `pnpm --dir apps/notebook-cloud smoke:hosted:workstation-toolbar`
- `pnpm --dir apps/notebook-cloud exec node --import tsx --test test/worker-routes.test.ts` (92 tests)
- `pnpm test:run packages/runtimed/tests/notebook-workstation-launch.test.ts`
- `pnpm test:run packages/runtimed/tests/notebook-workstation-selection.test.ts packages/runtimed/tests/notebook-workstation-launch.test.ts src/components/notebook/__tests__/NotebookCommandToolbar.test.tsx src/components/notebook/__tests__/NotebookWorkstationsPanel.test.tsx`
- `pnpm --dir apps/notebook-cloud test` (596 tests / 73 suites)
- `pnpm --dir apps/notebook-cloud typecheck`
- `pnpm test:run` (1,969 tests / 193 files passed, 6 skipped)
- `cargo test -p runtimed`
- `cargo test --workspace --exclude runtimed-node --exclude runtimed-py`
- `pnpm --filter notebook-ui test:e2e:browser -- --project=chromium` (28/28 passed)
- `cargo xtask lint --fix`
- `pnpm --dir apps/notebook build`
- `pnpm --dir apps/elements build`
- Python unit job repro:
  - `uv python install 3.12`
  - `cargo build -p runtimed`
  - `uv sync --no-default-groups --package runtimed --package dx --package prewarm --package nteract --package nteract-kernel-launcher --reinstall-package runtimed --group dev`
  - `uv run --no-sync pytest tests/test_session_unit.py tests/test_binary.py tests/test_ipython_bridge.py -v --tb=short` from `python/runtimed`
  - `uv run --no-sync pytest python/dx/tests/ -v --tb=short`
  - `uv run --no-sync pytest python/nteract-kernel-launcher/tests/ -v --tb=short`
  - `uv pip install -e python/prewarm && uv run --no-sync pytest python/prewarm/tests/ -v --tb=short`
  - `uv run --no-sync pytest -v` from `python/nteract`

Local full-suite note:
- `cargo test --workspace` still hits local binding linker failures in `runtimed-node` and `runtimed-py` (`napi_*` / `Py*` symbols); the same workspace passes when those binding crates are excluded.
- The failed `Build shared UI artifacts` and `Python Unit Tests` CI jobs at `e6f4a21c` both failed in the shared `install-wasm-pack` action while GitHub release asset downloads returned repeated 504s, before their build/test commands ran. `41213137` adds the installer fallback.

## Preview Smoke
- deployed preview.runt.run from this branch
- main Worker version: `9e4d5332-8849-4de5-bac5-a06bc7a746b0`
- renderer-assets Worker version: `8693ba25-0605-4ed1-a8c6-d8c9a07d3096`
- registered `lab2` as an online default workstation through `/api/workstations`
- API-triggered attach launched a real `runtime_peer` and current-Python kernel
- owner Playwright smoke clicked Run and observed hosted workstation output with no page errors, bad console diagnostics, failed requests, or websocket errors
- editor-scoped Playwright negative check saw no execute buttons and no Run all button
- UI attach smoke opened the Workstations rail, clicked Attach for `lab2`, reached Attached/Ready, then ran a cell from the browser
- checked-in toolbar smoke ran `pnpm --dir apps/notebook-cloud smoke:hosted:workstation-toolbar`, clicked `Attach compute`, ran the first cell, reloaded, ran again, then reopened the same notebook as requested `viewer` and `editor` scopes and verified no execution controls leaked to either scope

Smoke notebooks:
- https://preview.runt.run/n/01KTJSE6FMJHMXB2P7YDGTVBTT/hosted-workstation-smoke
- https://preview.runt.run/n/01KTJSM2WYRQP7J94HFWWVM1E3/workstation-ui-attach-smoke
- https://preview.runt.run/n/01KTJWRXYDJR2HKMRPVRTBDB2N/toolbar-attach-smoke
- https://preview.runt.run/n/01KTJYS1P7R5ZW0JJH92KHR159/toolbar-attach-smoke (fresh pass after `e6f4a21c`)
