### PR TITLE
chore(notebook-cloud): add preview credential health checks

### DIFF
--- a/apps/notebook-cloud/README.md
+++ b/apps/notebook-cloud/README.md
@@ -172,6 +172,23 @@ uses the transitional OIDC cache to acquire its cookie. The room WebSocket does
 not use that cookie directly; the viewer asks the Worker for a short-lived sync
 ticket derived from the app session.
 
+Before running credentialed preview smokes from lab2, check local credential
+health:
+
+```bash
+pnpm --dir apps/notebook-cloud auth:preview:health
+```
+
+The command checks the `preview-oidc-refresh.timer`/service state, token cache
+freshness, `${PREVIEW_RUNT_ENV:-$HOME/preview.runt.run/.env}`, and a harmless
+API-key request to `/api/n?limit=1`. It writes a non-secret status summary to
+`${NTERACT_PREVIEW_AUTH_HEALTH_PATH:-$HOME/.cache/nteract/preview-auth-health.json}`.
+The summary records only statuses, expiry timing, and response codes/counts; it
+must not include token strings, API keys, emails, or OIDC subject values. Use
+`pnpm --silent --dir apps/notebook-cloud auth:preview:health --json` for
+machine-readable stdout and `--no-network` when only checking the token/timer
+state.
+
 For public/read-only notebooks, run the same live-room smoke without browser
 credentials:
 

--- a/apps/notebook-cloud/package.json
+++ b/apps/notebook-cloud/package.json
@@ -11,6 +11,7 @@
     "deploy:main": "wrangler deploy",
     "deploy:renderer-assets": "wrangler deploy -c wrangler.renderer-assets.toml",
     "deploy:check": "curl -fsS https://preview.runt.run/api/health",
+    "auth:preview:health": "node scripts/preview-auth-health.mjs",
     "pretypecheck": "cargo xtask wasm-ensure-runtime",
     "typecheck": "tsc -p tsconfig.json --noEmit",
     "test": "pnpm run wasm && node --import tsx --test test/*.test.ts test/*.test.mjs",

--- a/apps/notebook-cloud/scripts/preview-auth-health.mjs
+++ b/apps/notebook-cloud/scripts/preview-auth-health.mjs
@@ -460,7 +460,7 @@ export async function readApiKeyHealth({
       reason: "api_key_smoke_error",
       cloud_url: safeCloudUrl(baseUrl),
       endpoint: "/api/n?limit=1",
-      error: safeErrorMessage(error),
+      error: safeErrorMessage(error, [apiKey]),
     };
   }
 }
@@ -535,14 +535,17 @@ function safeCloudUrl(value) {
   }
 }
 
-function safeErrorMessage(error) {
+function safeErrorMessage(error, sensitiveValues = []) {
   const message = error instanceof Error ? error.message : String(error);
-  return message
+  const redactedByShape = message
     .replace(/Bearer\s+[A-Za-z0-9._~+/-]+/g, "Bearer [REDACTED]")
     .replace(
       /(accessToken|refreshToken|idToken|token|Authorization)([^A-Za-z0-9_-]*)([A-Za-z0-9._~+/-]{8,})/gi,
       "$1$2[REDACTED]",
     );
+  return sensitiveValues
+    .filter((value) => typeof value === "string" && value.length >= 8)
+    .reduce((redacted, value) => redacted.split(value).join("[REDACTED]"), redactedByShape);
 }
 
 function isMainModule(metaUrl, argvPath) {

--- a/apps/notebook-cloud/scripts/preview-auth-health.mjs
+++ b/apps/notebook-cloud/scripts/preview-auth-health.mjs
@@ -1,0 +1,550 @@
+#!/usr/bin/env node
+
+import { execFile as execFileCallback } from "node:child_process";
+import { promises as fs } from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { promisify } from "node:util";
+import { pathToFileURL } from "node:url";
+
+const execFile = promisify(execFileCallback);
+
+const DEFAULT_CLOUD_URL = "https://preview.runt.run";
+const DEFAULT_TOKEN_PATH = path.join(os.homedir(), "token.preview.json");
+const DEFAULT_ENV_PATH = path.join(os.homedir(), "preview.runt.run", ".env");
+const DEFAULT_STATUS_PATH = path.join(
+  os.homedir(),
+  ".cache",
+  "nteract",
+  "preview-auth-health.json",
+);
+const DEFAULT_MIN_TOKEN_SECONDS = 15 * 60;
+const DEFAULT_TIMER_UNIT = "preview-oidc-refresh.timer";
+const DEFAULT_SERVICE_UNIT = "preview-oidc-refresh.service";
+
+const STATUS_ORDER = {
+  ok: 0,
+  skipped: 1,
+  unknown: 2,
+  warn: 3,
+  fail: 4,
+};
+
+if (isMainModule(import.meta.url, process.argv[1])) {
+  main().catch((error) => {
+    console.error(
+      `[preview-auth-health] ${error instanceof Error ? error.message : String(error)}`,
+    );
+    process.exitCode = 1;
+  });
+}
+
+async function main() {
+  const options = parseArgs(process.argv.slice(2), process.env);
+  const summary = await collectPreviewAuthHealth({
+    env: process.env,
+    fetchImpl: fetch,
+    now: new Date(),
+    ...options,
+  });
+
+  if (options.writeStatus) {
+    await writeHealthSummary(options.statusPath, summary);
+  }
+
+  if (options.json) {
+    console.log(JSON.stringify(summary, null, 2));
+  } else {
+    console.log(formatHealthSummary(summary, options.writeStatus ? options.statusPath : null));
+  }
+
+  if (summary.status === "fail") {
+    process.exitCode = 1;
+  }
+}
+
+export function parseArgs(args, env = process.env) {
+  const options = {
+    cloudUrl: env.NTERACT_CLOUD_URL || env.NOTEBOOK_CLOUD_URL || DEFAULT_CLOUD_URL,
+    envPath: env.PREVIEW_RUNT_ENV || path.join(os.homedir(), "preview.runt.run", ".env"),
+    json: false,
+    minTokenSeconds: parsePositiveInteger(
+      env.NTERACT_PREVIEW_AUTH_HEALTH_MIN_TOKEN_SECONDS,
+      DEFAULT_MIN_TOKEN_SECONDS,
+    ),
+    network: true,
+    serviceUnit: env.NTERACT_PREVIEW_OIDC_SERVICE_UNIT || DEFAULT_SERVICE_UNIT,
+    statusPath: env.NTERACT_PREVIEW_AUTH_HEALTH_PATH || DEFAULT_STATUS_PATH,
+    systemd: true,
+    timerUnit: env.NTERACT_PREVIEW_OIDC_TIMER_UNIT || DEFAULT_TIMER_UNIT,
+    tokenPath:
+      env.NTERACT_PREVIEW_OIDC_TOKEN_PATH ||
+      env.NOTEBOOK_CLOUD_OIDC_TOKEN_PATH ||
+      DEFAULT_TOKEN_PATH,
+    writeStatus: true,
+  };
+
+  for (let index = 0; index < args.length; index += 1) {
+    const arg = args[index];
+    if (arg === "--json") {
+      options.json = true;
+    } else if (arg === "--no-network") {
+      options.network = false;
+    } else if (arg === "--no-systemd") {
+      options.systemd = false;
+    } else if (arg === "--no-write") {
+      options.writeStatus = false;
+    } else if (arg === "--cloud-url") {
+      options.cloudUrl = requireValue(args, (index += 1), arg);
+    } else if (arg.startsWith("--cloud-url=")) {
+      options.cloudUrl = arg.slice("--cloud-url=".length);
+    } else if (arg === "--env") {
+      options.envPath = requireValue(args, (index += 1), arg);
+    } else if (arg.startsWith("--env=")) {
+      options.envPath = arg.slice("--env=".length);
+    } else if (arg === "--min-token-seconds") {
+      options.minTokenSeconds = parsePositiveInteger(requireValue(args, (index += 1), arg), 0);
+    } else if (arg.startsWith("--min-token-seconds=")) {
+      options.minTokenSeconds = parsePositiveInteger(arg.slice("--min-token-seconds=".length), 0);
+    } else if (arg === "--status-path") {
+      options.statusPath = requireValue(args, (index += 1), arg);
+    } else if (arg.startsWith("--status-path=")) {
+      options.statusPath = arg.slice("--status-path=".length);
+    } else if (arg === "--token") {
+      options.tokenPath = requireValue(args, (index += 1), arg);
+    } else if (arg.startsWith("--token=")) {
+      options.tokenPath = arg.slice("--token=".length);
+    } else {
+      throw new Error(`unknown argument: ${arg}`);
+    }
+  }
+
+  return options;
+}
+
+export async function collectPreviewAuthHealth({
+  cloudUrl = DEFAULT_CLOUD_URL,
+  env = process.env,
+  envPath = DEFAULT_ENV_PATH,
+  execFileImpl = execFile,
+  fetchImpl = fetch,
+  minTokenSeconds = DEFAULT_MIN_TOKEN_SECONDS,
+  network = true,
+  now = new Date(),
+  serviceUnit = DEFAULT_SERVICE_UNIT,
+  systemd = true,
+  timerUnit = DEFAULT_TIMER_UNIT,
+  tokenPath = DEFAULT_TOKEN_PATH,
+} = {}) {
+  const token = await readTokenHealth(tokenPath, { minTokenSeconds, now });
+  const systemdHealth = systemd
+    ? await readSystemdHealth({ execFileImpl, serviceUnit, timerUnit })
+    : skippedCheck("systemd_disabled");
+  const previewEnv = await readPreviewEnvHealth(envPath, env);
+  const apiKey = network
+    ? await readApiKeyHealth({ cloudUrl, env: previewEnv.values, fetchImpl })
+    : skippedCheck("network_disabled");
+
+  const summary = {
+    generated_at: now.toISOString(),
+    ok: false,
+    status: "ok",
+    checks: {
+      token,
+      systemd: systemdHealth,
+      preview_env: withoutValues(previewEnv),
+      api_key: apiKey,
+    },
+  };
+  summary.status = worstStatus([
+    token.status,
+    systemdHealth.status,
+    previewEnv.status,
+    apiKey.status,
+  ]);
+  summary.ok = summary.status === "ok" || summary.status === "skipped";
+  return summary;
+}
+
+export async function readTokenHealth(tokenPath, { minTokenSeconds, now = new Date() } = {}) {
+  try {
+    const stat = await fs.stat(tokenPath);
+    const parsed = JSON.parse(await fs.readFile(tokenPath, "utf8"));
+    return summarizeToken(parsed, {
+      mode: stat.mode & 0o777,
+      mtime: stat.mtime.toISOString(),
+      path: tokenPath,
+      minTokenSeconds,
+      now,
+    });
+  } catch (error) {
+    if (error?.code === "ENOENT") {
+      return {
+        status: "fail",
+        reason: "missing_token_file",
+        path: tokenPath,
+        exists: false,
+      };
+    }
+    return {
+      status: "fail",
+      reason: "invalid_token_file",
+      path: tokenPath,
+      exists: true,
+      error: safeErrorMessage(error),
+    };
+  }
+}
+
+export function summarizeToken(
+  token,
+  {
+    minTokenSeconds = DEFAULT_MIN_TOKEN_SECONDS,
+    mode = null,
+    mtime = null,
+    now = new Date(),
+    path: tokenPath = null,
+  } = {},
+) {
+  const expiresAt = Number(token?.expiresAt);
+  const expiresInSeconds = Number.isFinite(expiresAt)
+    ? Math.round(expiresAt - now.getTime() / 1000)
+    : null;
+  const hasAccessToken = typeof token?.accessToken === "string" && token.accessToken.trim() !== "";
+  const hasRefreshToken =
+    typeof token?.refreshToken === "string" && token.refreshToken.trim() !== "";
+  const hasSubject = typeof token?.claims?.sub === "string" && token.claims.sub.trim() !== "";
+  const hasEmailClaim =
+    typeof token?.claims?.email === "string" && token.claims.email.trim() !== "";
+  const privateMode = typeof mode === "number" ? (mode & 0o077) === 0 : null;
+
+  let status = "ok";
+  let reason = "fresh";
+  if (!hasAccessToken || !hasSubject || !Number.isFinite(expiresAt)) {
+    status = "fail";
+    reason = "missing_required_token_fields";
+  } else if (expiresInSeconds <= 0) {
+    status = "fail";
+    reason = "expired";
+  } else if (expiresInSeconds <= minTokenSeconds) {
+    status = "warn";
+    reason = "refresh_soon";
+  } else if (privateMode === false) {
+    status = "warn";
+    reason = "token_file_permissions_not_private";
+  }
+
+  return {
+    status,
+    reason,
+    path: tokenPath,
+    exists: true,
+    mode: typeof mode === "number" ? mode.toString(8).padStart(3, "0") : null,
+    mtime,
+    expires_at: Number.isFinite(expiresAt) ? new Date(expiresAt * 1000).toISOString() : null,
+    expires_in_seconds: expiresInSeconds,
+    expires_in_minutes: Number.isFinite(expiresInSeconds)
+      ? Math.max(0, Math.round(expiresInSeconds / 60))
+      : null,
+    has_access_token: hasAccessToken,
+    has_refresh_token: hasRefreshToken,
+    has_subject_claim: hasSubject,
+    has_email_claim: hasEmailClaim,
+    private_mode: privateMode,
+  };
+}
+
+export async function readSystemdHealth({
+  execFileImpl = execFile,
+  serviceUnit = DEFAULT_SERVICE_UNIT,
+  timerUnit = DEFAULT_TIMER_UNIT,
+} = {}) {
+  try {
+    const [timer, service] = await Promise.all([
+      readSystemdUnit(execFileImpl, timerUnit, [
+        "ActiveState",
+        "UnitFileState",
+        "NextElapseUSecRealtime",
+        "LastTriggerUSecRealtime",
+      ]),
+      readSystemdUnit(execFileImpl, serviceUnit, [
+        "ActiveState",
+        "Result",
+        "ExecMainStatus",
+        "InactiveExitTimestamp",
+      ]),
+    ]);
+    return summarizeSystemd({ service, serviceUnit, timer, timerUnit });
+  } catch (error) {
+    return {
+      status: "unknown",
+      reason: "systemd_unavailable",
+      error: safeErrorMessage(error),
+      service_unit: serviceUnit,
+      timer_unit: timerUnit,
+    };
+  }
+}
+
+async function readSystemdUnit(execFileImpl, unit, properties) {
+  const { stdout } = await execFileImpl("systemctl", [
+    "--user",
+    "show",
+    unit,
+    "--no-pager",
+    ...properties.map((property) => `--property=${property}`),
+  ]);
+  return parseSystemdProperties(stdout);
+}
+
+export function summarizeSystemd({ service, serviceUnit, timer, timerUnit }) {
+  const timerActive = timer.ActiveState === "active";
+  const timerEnabled = ["enabled", "static", "linked", ""].includes(timer.UnitFileState ?? "");
+  const serviceSucceeded =
+    (service.Result === "success" || service.Result === "") &&
+    (service.ExecMainStatus === "0" || service.ExecMainStatus === "");
+
+  let status = "ok";
+  let reason = "timer_active_last_run_success";
+  if (!timerActive) {
+    status = "fail";
+    reason = "timer_not_active";
+  } else if (!timerEnabled) {
+    status = "warn";
+    reason = "timer_not_enabled";
+  } else if (!serviceSucceeded) {
+    status = "fail";
+    reason = "last_refresh_failed";
+  }
+
+  return {
+    status,
+    reason,
+    timer_unit: timerUnit,
+    timer_active_state: timer.ActiveState ?? null,
+    timer_unit_file_state: timer.UnitFileState ?? null,
+    timer_next_elapsed: timer.NextElapseUSecRealtime || null,
+    timer_last_trigger: timer.LastTriggerUSecRealtime || null,
+    service_unit: serviceUnit,
+    service_active_state: service.ActiveState ?? null,
+    service_result: service.Result ?? null,
+    service_exec_main_status: service.ExecMainStatus ?? null,
+    service_inactive_exit_timestamp: service.InactiveExitTimestamp || null,
+  };
+}
+
+export function parseSystemdProperties(stdout) {
+  const result = {};
+  for (const line of String(stdout).split(/\r?\n/)) {
+    const trimmed = line.trim();
+    const index = trimmed.indexOf("=");
+    if (index <= 0) {
+      continue;
+    }
+    result[trimmed.slice(0, index)] = trimmed.slice(index + 1);
+  }
+  return result;
+}
+
+export async function readPreviewEnvHealth(envPath, processEnv = process.env) {
+  let fileValues = {};
+  let exists = false;
+  try {
+    fileValues = parseEnvFile(await fs.readFile(envPath, "utf8"));
+    exists = true;
+  } catch (error) {
+    if (error?.code !== "ENOENT") {
+      return {
+        status: "fail",
+        reason: "invalid_preview_env",
+        path: envPath,
+        exists: true,
+        values: { ...processEnv },
+        error: safeErrorMessage(error),
+      };
+    }
+  }
+
+  const values = { ...fileValues, ...processEnv };
+  const hasApiKey =
+    typeof values.NTERACT_API_KEY === "string" && values.NTERACT_API_KEY.trim() !== "";
+  const hasCloudUrl =
+    typeof values.NTERACT_CLOUD_URL === "string" && values.NTERACT_CLOUD_URL.trim() !== "";
+  return {
+    status: hasApiKey ? "ok" : "fail",
+    reason: hasApiKey ? "api_key_configured" : "missing_api_key",
+    path: envPath,
+    exists,
+    has_api_key: hasApiKey,
+    has_cloud_url: hasCloudUrl,
+    values,
+  };
+}
+
+export function parseEnvFile(source) {
+  const values = {};
+  for (const line of String(source).split(/\r?\n/)) {
+    const trimmed = line.trim();
+    if (!trimmed || trimmed.startsWith("#")) {
+      continue;
+    }
+    const withoutExport = trimmed.startsWith("export ")
+      ? trimmed.slice("export ".length).trim()
+      : trimmed;
+    const index = withoutExport.indexOf("=");
+    if (index <= 0) {
+      continue;
+    }
+    const key = withoutExport.slice(0, index).trim();
+    if (!/^[A-Za-z_][A-Za-z0-9_]*$/.test(key)) {
+      continue;
+    }
+    values[key] = unquoteEnvValue(withoutExport.slice(index + 1).trim());
+  }
+  return values;
+}
+
+function unquoteEnvValue(value) {
+  if (
+    (value.startsWith('"') && value.endsWith('"')) ||
+    (value.startsWith("'") && value.endsWith("'"))
+  ) {
+    return value.slice(1, -1);
+  }
+  const commentIndex = value.search(/\s#/);
+  return commentIndex >= 0 ? value.slice(0, commentIndex).trimEnd() : value;
+}
+
+export async function readApiKeyHealth({
+  cloudUrl = DEFAULT_CLOUD_URL,
+  env = process.env,
+  fetchImpl = fetch,
+} = {}) {
+  const apiKey = typeof env.NTERACT_API_KEY === "string" ? env.NTERACT_API_KEY.trim() : "";
+  const baseUrl = env.NTERACT_CLOUD_URL || env.NOTEBOOK_CLOUD_URL || cloudUrl || DEFAULT_CLOUD_URL;
+  if (!apiKey) {
+    return {
+      status: "fail",
+      reason: "missing_api_key",
+      cloud_url: safeCloudUrl(baseUrl),
+    };
+  }
+
+  const url = new URL("/api/n?limit=1", baseUrl);
+  try {
+    const response = await fetchImpl(url, {
+      headers: {
+        Accept: "application/json",
+        Authorization: `Bearer ${apiKey}`,
+        "X-Notebook-Cloud-Auth-Provider": "anaconda-api-key",
+      },
+    });
+    const body = await response
+      .clone()
+      .json()
+      .catch(() => null);
+    const notebookCount = Array.isArray(body?.notebooks) ? body.notebooks.length : null;
+    return {
+      status: response.ok ? "ok" : "fail",
+      reason: response.ok ? "api_key_smoke_ok" : "api_key_smoke_failed",
+      cloud_url: safeCloudUrl(baseUrl),
+      endpoint: "/api/n?limit=1",
+      http_status: response.status,
+      response_ok: response.ok,
+      body_ok: body?.ok === true,
+      notebook_count: notebookCount,
+    };
+  } catch (error) {
+    return {
+      status: "fail",
+      reason: "api_key_smoke_error",
+      cloud_url: safeCloudUrl(baseUrl),
+      endpoint: "/api/n?limit=1",
+      error: safeErrorMessage(error),
+    };
+  }
+}
+
+export async function writeHealthSummary(statusPath, summary) {
+  await fs.mkdir(path.dirname(statusPath), { recursive: true, mode: 0o700 });
+  await fs.writeFile(statusPath, `${JSON.stringify(summary, null, 2)}\n`, { mode: 0o600 });
+  await fs.chmod(statusPath, 0o600).catch(() => {});
+}
+
+export function formatHealthSummary(summary, statusPath = null) {
+  const parts = [
+    `[preview-auth-health] overall=${summary.status}`,
+    `token=${checkBrief(summary.checks.token)}`,
+    `oidc_timer=${checkBrief(summary.checks.systemd)}`,
+    `api_key=${checkBrief(summary.checks.api_key)}`,
+  ];
+  if (Number.isFinite(summary.checks.token?.expires_in_minutes)) {
+    parts.splice(2, 0, `token_expires_in=${summary.checks.token.expires_in_minutes}m`);
+  }
+  if (statusPath) {
+    parts.push(`status=${statusPath}`);
+  }
+  return parts.join(" ");
+}
+
+function checkBrief(check) {
+  if (!check) {
+    return "unknown";
+  }
+  return check.reason ? `${check.status}:${check.reason}` : check.status;
+}
+
+function withoutValues(envHealth) {
+  const { values: _values, ...safe } = envHealth;
+  return safe;
+}
+
+function skippedCheck(reason) {
+  return { status: "skipped", reason };
+}
+
+function worstStatus(statuses) {
+  return statuses.reduce((worst, status) => {
+    const current = STATUS_ORDER[status] ?? STATUS_ORDER.unknown;
+    return current > (STATUS_ORDER[worst] ?? STATUS_ORDER.unknown) ? status : worst;
+  }, "ok");
+}
+
+function parsePositiveInteger(value, fallback) {
+  const parsed = Number(value);
+  return Number.isFinite(parsed) && parsed >= 0 ? Math.floor(parsed) : fallback;
+}
+
+function requireValue(args, index, flag) {
+  if (index >= args.length || !args[index]) {
+    throw new Error(`${flag} requires a value`);
+  }
+  return args[index];
+}
+
+function safeCloudUrl(value) {
+  try {
+    const url = new URL(value || DEFAULT_CLOUD_URL);
+    url.username = "";
+    url.password = "";
+    url.search = "";
+    url.hash = "";
+    return url.href.replace(/\/$/, "");
+  } catch {
+    return DEFAULT_CLOUD_URL;
+  }
+}
+
+function safeErrorMessage(error) {
+  const message = error instanceof Error ? error.message : String(error);
+  return message
+    .replace(/Bearer\s+[A-Za-z0-9._~+/-]+/g, "Bearer [REDACTED]")
+    .replace(
+      /(accessToken|refreshToken|idToken|token|Authorization)([^A-Za-z0-9_-]*)([A-Za-z0-9._~+/-]{8,})/gi,
+      "$1$2[REDACTED]",
+    );
+}
+
+function isMainModule(metaUrl, argvPath) {
+  return Boolean(argvPath && metaUrl === pathToFileURL(path.resolve(argvPath)).href);
+}

--- a/apps/notebook-cloud/test/collaborator-auth.test.ts
+++ b/apps/notebook-cloud/test/collaborator-auth.test.ts
@@ -256,7 +256,7 @@ describe("cloud collaborator auth", () => {
     assert.equal(state.user, "Expired User");
     assert.equal(state.requestedScope, NOTEBOOK_CLOUD_DEFAULT_SCOPE);
     assert.equal(state.problem, "Stored OIDC session is expired. Sign in again.");
-    assert.equal(prototypeAuthSummary(state), "Expired User needs sign-in renewal.");
+    assert.equal(prototypeAuthSummary(state), "Your browser sign-in needs renewal.");
     assert.deepEqual(cloudSyncAuthFromPrototypeAuthState(state), {
       headers: {},
       protocols: [],

--- a/apps/notebook-cloud/test/preview-auth-health.test.mjs
+++ b/apps/notebook-cloud/test/preview-auth-health.test.mjs
@@ -148,6 +148,21 @@ describe("preview auth health helpers", () => {
     assert.equal(JSON.stringify(health).includes("secret-api-key"), false);
   });
 
+  it("redacts a bare API key if fetch echoes it in an error message", async () => {
+    const health = await readApiKeyHealth({
+      cloudUrl: "https://preview.runt.run",
+      env: { NTERACT_API_KEY: "secret-api-key" },
+      fetchImpl: async () => {
+        throw new Error("upstream echoed secret-api-key without a key name");
+      },
+    });
+
+    assert.equal(health.status, "fail");
+    assert.equal(health.reason, "api_key_smoke_error");
+    assert.equal(health.error, "upstream echoed [REDACTED] without a key name");
+    assert.equal(JSON.stringify(health).includes("secret-api-key"), false);
+  });
+
   it("collects a non-secret health summary", async () => {
     const health = await collectPreviewAuthHealth({
       env: {},

--- a/apps/notebook-cloud/test/preview-auth-health.test.mjs
+++ b/apps/notebook-cloud/test/preview-auth-health.test.mjs
@@ -1,0 +1,221 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+
+import {
+  collectPreviewAuthHealth,
+  formatHealthSummary,
+  parseArgs,
+  parseEnvFile,
+  parseSystemdProperties,
+  readApiKeyHealth,
+  summarizeSystemd,
+  summarizeToken,
+} from "../scripts/preview-auth-health.mjs";
+
+describe("preview auth health helpers", () => {
+  it("parses preview env files without requiring dotenv", () => {
+    assert.deepEqual(
+      parseEnvFile(`
+        # comment
+        export NTERACT_CLOUD_URL="https://preview.runt.run"
+        NTERACT_API_KEY='secret value'
+        IGNORED LINE
+        NOTEBOOK_CLOUD_LIVE_ROOM_AUTH=anonymous # inline comment
+      `),
+      {
+        NTERACT_CLOUD_URL: "https://preview.runt.run",
+        NTERACT_API_KEY: "secret value",
+        NOTEBOOK_CLOUD_LIVE_ROOM_AUTH: "anonymous",
+      },
+    );
+  });
+
+  it("summarizes token freshness without leaking token or email material", () => {
+    const summary = summarizeToken(
+      {
+        accessToken: "secret-access-token",
+        refreshToken: "secret-refresh-token",
+        expiresAt: 1_000_000,
+        claims: {
+          sub: "subject-123",
+          email: "agent@example.test",
+        },
+      },
+      {
+        mode: 0o600,
+        now: new Date(999_000 * 1000),
+      },
+    );
+
+    assert.equal(summary.status, "ok");
+    assert.equal(summary.expires_in_minutes, 17);
+    assert.equal(summary.has_access_token, true);
+    assert.equal(summary.has_refresh_token, true);
+    assert.equal(summary.has_subject_claim, true);
+    assert.equal(summary.has_email_claim, true);
+
+    const serialized = JSON.stringify(summary);
+    assert.equal(serialized.includes("secret-access-token"), false);
+    assert.equal(serialized.includes("secret-refresh-token"), false);
+    assert.equal(serialized.includes("agent@example.test"), false);
+    assert.equal(serialized.includes("subject-123"), false);
+  });
+
+  it("marks expired or soon-expiring tokens as unhealthy", () => {
+    const freshOptions = { mode: 0o600, now: new Date(1_000 * 1000), minTokenSeconds: 900 };
+    const baseToken = {
+      accessToken: "access",
+      refreshToken: "refresh",
+      claims: { sub: "subject" },
+    };
+
+    assert.deepEqual(
+      summarizeToken({ ...baseToken, expiresAt: 1_100 }, freshOptions).status,
+      "warn",
+    );
+    assert.deepEqual(summarizeToken({ ...baseToken, expiresAt: 999 }, freshOptions).status, "fail");
+  });
+
+  it("parses and summarizes systemd user timer state", () => {
+    const timer = parseSystemdProperties(`
+      ActiveState=active
+      UnitFileState=enabled
+      NextElapseUSecRealtime=Mon 2026-06-08 16:30:58 UTC
+    `);
+    const service = parseSystemdProperties(`
+      ActiveState=inactive
+      Result=success
+      ExecMainStatus=0
+    `);
+
+    assert.deepEqual(
+      summarizeSystemd({
+        service,
+        serviceUnit: "preview-oidc-refresh.service",
+        timer,
+        timerUnit: "preview-oidc-refresh.timer",
+      }),
+      {
+        status: "ok",
+        reason: "timer_active_last_run_success",
+        timer_unit: "preview-oidc-refresh.timer",
+        timer_active_state: "active",
+        timer_unit_file_state: "enabled",
+        timer_next_elapsed: "Mon 2026-06-08 16:30:58 UTC",
+        timer_last_trigger: null,
+        service_unit: "preview-oidc-refresh.service",
+        service_active_state: "inactive",
+        service_result: "success",
+        service_exec_main_status: "0",
+        service_inactive_exit_timestamp: null,
+      },
+    );
+
+    assert.equal(
+      summarizeSystemd({
+        service: { Result: "exit-code", ExecMainStatus: "1" },
+        serviceUnit: "preview-oidc-refresh.service",
+        timer,
+        timerUnit: "preview-oidc-refresh.timer",
+      }).status,
+      "fail",
+    );
+  });
+
+  it("checks the preview API key without leaking credential material", async () => {
+    const health = await readApiKeyHealth({
+      cloudUrl: "https://preview.runt.run",
+      env: { NTERACT_API_KEY: "secret-api-key" },
+      fetchImpl: async (input, init) => {
+        assert.equal(String(input), "https://preview.runt.run/api/n?limit=1");
+        const headers = new Headers(init.headers);
+        assert.equal(headers.get("Authorization"), "Bearer secret-api-key");
+        assert.equal(headers.get("X-Notebook-Cloud-Auth-Provider"), "anaconda-api-key");
+        return Response.json({ ok: true, notebooks: [{ id: "one" }] });
+      },
+    });
+
+    assert.deepEqual(health, {
+      status: "ok",
+      reason: "api_key_smoke_ok",
+      cloud_url: "https://preview.runt.run",
+      endpoint: "/api/n?limit=1",
+      http_status: 200,
+      response_ok: true,
+      body_ok: true,
+      notebook_count: 1,
+    });
+    assert.equal(JSON.stringify(health).includes("secret-api-key"), false);
+  });
+
+  it("collects a non-secret health summary", async () => {
+    const health = await collectPreviewAuthHealth({
+      env: {},
+      envPath: "/missing.env",
+      fetchImpl: async () => Response.json({ ok: true, notebooks: [] }),
+      network: false,
+      now: new Date(999_000 * 1000),
+      systemd: false,
+      tokenPath: "/missing-token.json",
+    });
+
+    assert.equal(health.status, "fail");
+    assert.equal(health.checks.token.reason, "missing_token_file");
+    assert.equal(health.checks.preview_env.has_api_key, false);
+    assert.equal(health.checks.preview_env.values, undefined);
+    assert.equal(health.checks.api_key.status, "skipped");
+  });
+
+  it("formats a compact one-line status", () => {
+    const line = formatHealthSummary(
+      {
+        status: "ok",
+        checks: {
+          token: { status: "ok", reason: "fresh", expires_in_minutes: 42 },
+          systemd: { status: "ok", reason: "timer_active_last_run_success" },
+          api_key: { status: "ok", reason: "api_key_smoke_ok" },
+        },
+      },
+      "/tmp/health.json",
+    );
+
+    assert.equal(
+      line,
+      "[preview-auth-health] overall=ok token=ok:fresh token_expires_in=42m oidc_timer=ok:timer_active_last_run_success api_key=ok:api_key_smoke_ok status=/tmp/health.json",
+    );
+  });
+
+  it("parses CLI options", () => {
+    assert.deepEqual(
+      parseArgs(
+        [
+          "--json",
+          "--no-network",
+          "--no-systemd",
+          "--no-write",
+          "--cloud-url=https://preview.runt.run",
+          "--env",
+          "/tmp/env",
+          "--token=/tmp/token.json",
+          "--status-path",
+          "/tmp/status.json",
+          "--min-token-seconds=120",
+        ],
+        {},
+      ),
+      {
+        cloudUrl: "https://preview.runt.run",
+        envPath: "/tmp/env",
+        json: true,
+        minTokenSeconds: 120,
+        network: false,
+        serviceUnit: "preview-oidc-refresh.service",
+        statusPath: "/tmp/status.json",
+        systemd: false,
+        timerUnit: "preview-oidc-refresh.timer",
+        tokenPath: "/tmp/token.json",
+        writeStatus: false,
+      },
+    );
+  });
+});

--- a/apps/notebook-cloud/test/viewer-notices.test.ts
+++ b/apps/notebook-cloud/test/viewer-notices.test.ts
@@ -80,14 +80,17 @@ test("cloud notebook notices render auth and connection policy through the share
       connectionError: "websocket failed",
       status: { kind: "ready", message: "Ready" },
       onResetAuth: () => {},
+      onSignInAgain: () => {},
     }),
   );
 
   assert.match(html, /data-slot="notebook-notice-stack"/);
   assert.match(html, /Auth needs attention/);
+  assert.match(html, /Your browser sign-in needs renewal/);
   assert.match(html, /Sign-in refresh failed/);
   assert.match(html, /Live room needs attention/);
-  assert.match(html, /Reset to anonymous/);
+  assert.match(html, /Sign in again/);
+  assert.doesNotMatch(html, /Reset to anonymous/);
 });
 
 test("cloud notebook notices distinguish sign-in and access diagnostics from socket failures", () => {
@@ -98,11 +101,14 @@ test("cloud notebook notices distinguish sign-in and access diagnostics from soc
       connectionError: CLOUD_CONNECTION_SIGN_IN_DIAGNOSTIC,
       status: { kind: "ready", message: "Ready" },
       onResetAuth: () => {},
+      onSignInAgain: () => {},
     }),
   );
 
   assert.match(signInHtml, /Sign in required/);
   assert.match(signInHtml, /Sign in again to open the live notebook room/);
+  assert.match(signInHtml, /Sign in again/);
+  assert.doesNotMatch(signInHtml, /Use anonymous/);
   assert.doesNotMatch(signInHtml, /Live room unavailable/);
 
   const noAccessHtml = renderToStaticMarkup(

--- a/apps/notebook-cloud/viewer/collaborator-auth.ts
+++ b/apps/notebook-cloud/viewer/collaborator-auth.ts
@@ -360,7 +360,7 @@ export function prototypeAuthSummary(state: CloudPrototypeAuthState): string {
     }`;
   }
   if (state.mode === "oidc_expired") {
-    return `${state.user ?? "OIDC session"} needs sign-in renewal.`;
+    return "Your browser sign-in needs renewal.";
   }
   if (state.mode === "invalid") {
     return state.problem ?? "Stored collaborator token is invalid.";

--- a/apps/notebook-cloud/viewer/index.tsx
+++ b/apps/notebook-cloud/viewer/index.tsx
@@ -2402,6 +2402,22 @@ function NotebookViewer({
     setSelectedInteractionMode("view");
     refreshAuthState();
   }, [refreshAuthState]);
+  const beginNotebookOidcAuth = useCallback(async () => {
+    if (!authConfig.oidc) {
+      resetPrototypeAuth();
+      return;
+    }
+    try {
+      prepareCloudOidcViewerLogin(window.localStorage);
+      const url = await beginOidcLogin(authConfig.oidc, {
+        currentUrl: window.location.href,
+        storage: window.localStorage,
+      });
+      window.location.assign(url.href);
+    } catch (error) {
+      console.warn("[notebook-cloud] OIDC sign-in start failed", error);
+    }
+  }, [authConfig.oidc, resetPrototypeAuth]);
   const applyLatestAccessRequest = useCallback(
     (request: CloudNotebookAccessRequest | null) => {
       setLatestAccessRequest(request);
@@ -2676,6 +2692,7 @@ function NotebookViewer({
       hasReadableSnapshot={notebookHasReadableSnapshot}
       status={noticeStatus}
       onResetAuth={resetPrototypeAuth}
+      onSignInAgain={authConfig.oidc ? beginNotebookOidcAuth : undefined}
     />
   ) : null;
 

--- a/apps/notebook-cloud/viewer/notices.tsx
+++ b/apps/notebook-cloud/viewer/notices.tsx
@@ -1,5 +1,5 @@
 import type { ReactNode } from "react";
-import { AlertCircle, CloudOff, Loader2, RotateCcw } from "lucide-react";
+import { AlertCircle, CloudOff, Loader2, LogIn, RotateCcw } from "lucide-react";
 import {
   NotebookNotice,
   NotebookNoticeAction,
@@ -22,6 +22,7 @@ export interface CloudNotebookNoticesProps {
   status: ViewerStatus;
   diagnostics?: ReactNode;
   onResetAuth: () => void;
+  onSignInAgain?: () => void | Promise<void>;
 }
 
 export function cloudNotebookHasNotices({
@@ -58,6 +59,7 @@ export function CloudNotebookNotices({
   status,
   diagnostics,
   onResetAuth,
+  onSignInAgain,
 }: CloudNotebookNoticesProps) {
   if (
     !cloudNotebookHasNotices({
@@ -87,7 +89,7 @@ export function CloudNotebookNotices({
           tone="error"
           icon={<AlertCircle className="h-4 w-4" />}
           title="Auth needs attention."
-          actions={<ResetAuthNoticeAction onResetAuth={onResetAuth} />}
+          actions={<AuthNoticeAction onResetAuth={onResetAuth} onSignInAgain={onSignInAgain} />}
         >
           {prototypeAuthSummary(authState)}
         </NotebookNotice>
@@ -106,7 +108,7 @@ export function CloudNotebookNotices({
           title={authRenewal.kind === "failed" ? "Sign-in refresh failed." : "Refreshing sign-in."}
           actions={
             authRenewal.kind === "failed" ? (
-              <ResetAuthNoticeAction onResetAuth={onResetAuth} />
+              <AuthNoticeAction onResetAuth={onResetAuth} onSignInAgain={onSignInAgain} />
             ) : null
           }
         >
@@ -119,7 +121,13 @@ export function CloudNotebookNotices({
           tone={connectionNotice.tone}
           icon={<CloudOff className="h-4 w-4" />}
           title={connectionNotice.title}
-          actions={<ResetAuthNoticeAction label="Use anonymous" onResetAuth={onResetAuth} />}
+          actions={
+            <ConnectionNoticeAction
+              connectionError={connectionError ?? ""}
+              onResetAuth={onResetAuth}
+              onSignInAgain={onSignInAgain}
+            />
+          }
         >
           {connectionNotice.message}
         </NotebookNotice>
@@ -146,16 +154,58 @@ export function CloudNotebookNotices({
   );
 }
 
-function ResetAuthNoticeAction({
-  label = "Reset to anonymous",
+function AuthNoticeAction({
   onResetAuth,
+  onSignInAgain,
 }: {
-  label?: string;
   onResetAuth: () => void;
+  onSignInAgain?: () => void | Promise<void>;
 }) {
+  if (onSignInAgain) {
+    return (
+      <NotebookNoticeAction
+        onClick={() => {
+          void onSignInAgain();
+        }}
+        icon={<LogIn className="h-3 w-3" />}
+      >
+        Sign in again
+      </NotebookNoticeAction>
+    );
+  }
+
   return (
     <NotebookNoticeAction onClick={onResetAuth} icon={<RotateCcw className="h-3 w-3" />}>
-      {label}
+      Clear stale sign-in
+    </NotebookNoticeAction>
+  );
+}
+
+function ConnectionNoticeAction({
+  connectionError,
+  onResetAuth,
+  onSignInAgain,
+}: {
+  connectionError: string;
+  onResetAuth: () => void;
+  onSignInAgain?: () => void | Promise<void>;
+}) {
+  if (connectionError === CLOUD_CONNECTION_SIGN_IN_DIAGNOSTIC && onSignInAgain) {
+    return (
+      <NotebookNoticeAction
+        onClick={() => {
+          void onSignInAgain();
+        }}
+        icon={<LogIn className="h-3 w-3" />}
+      >
+        Sign in again
+      </NotebookNoticeAction>
+    );
+  }
+
+  return (
+    <NotebookNoticeAction onClick={onResetAuth} icon={<RotateCcw className="h-3 w-3" />}>
+      Use anonymous
     </NotebookNoticeAction>
   );
 }


### PR DESCRIPTION
## Summary
- add a local preview auth health command for agents to check OIDC token freshness, the refresh timer/service, preview API-key config, and a harmless `/api/n?limit=1` smoke without exposing secrets
- document the command and persist a non-secret JSON status summary for later diagnostics
- make stale hosted auth notices offer sign-in renewal instead of a misleading anonymous reset CTA

## Validation
- `pnpm --dir apps/notebook-cloud exec node --import tsx --test test/preview-auth-health.test.mjs test/viewer-notices.test.ts test/collaborator-auth.test.ts`
- `pnpm --dir apps/notebook-cloud test`
- `pnpm --dir apps/notebook-cloud run typecheck`
- `cargo xtask lint --fix`
- `pnpm --dir apps/notebook-cloud exec node scripts/preview-auth-health.mjs --json --no-write`
- `pnpm --dir apps/notebook-cloud exec node scripts/preview-auth-health.mjs`
- `NOTEBOOK_CLOUD_LIVE_ROOM_AUTH=anonymous NOTEBOOK_CLOUD_LIVE_ROOM_SCOPE=viewer NOTEBOOK_CLOUD_LIVE_ROOM_MIN_CELLS=20 NOTEBOOK_CLOUD_LIVE_ROOM_REQUIRE_BLOB_FETCH=1 pnpm --dir apps/notebook-cloud run smoke:hosted:live-room -- https://preview.runt.run/n/topic-viz/topic-viz`

## Preview
- Deployed after rebasing onto #3499 / `origin/main`.
- Renderer assets Worker version: `dceae209-2599-46ab-a5db-a0f16ed9c108`.
- Main Worker version: `124affaf-b7d3-4c7f-9175-a35a1ad2575f`.
- Live `/api/health` returned `status: ok`.
- Live preview auth health returned `overall=ok`, including fresh token state, active refresh timer, and API-key smoke `200`.
- Public `topic-viz` browser smoke passed: 23 cells, blob fetches `200`, open room WebSocket, no page errors or bad console.