### PR TITLE
fix(notebook): hide disabled execution history in report mode

### DIFF
--- a/apps/notebook/src/components/CodeCell.tsx
+++ b/apps/notebook/src/components/CodeCell.tsx
@@ -678,6 +678,7 @@ export const CodeCell = memo(function CodeCell({
               submittedByActorLabel={submittedByActorLabel}
               isCellFocused={isFocused}
               canExecute={canExecute}
+              showReadoutWhenDisabled={!readOnly}
               onExecute={handleExecute}
               onInterrupt={onInterrupt}
               className={cn(

--- a/apps/notebook/src/components/__tests__/notebook-view-capabilities-source.test.ts
+++ b/apps/notebook/src/components/__tests__/notebook-view-capabilities-source.test.ts
@@ -89,5 +89,6 @@ describe("NotebookView shell capabilities", () => {
     expect(sourceText).toMatch(/onExecute: canExecute \? handleExecute : undefined/);
     expect(sourceText).toMatch(/onExecuteAndInsert:\s+canExecute && onInsertCellAfter/);
     expect(sourceText).toMatch(/canExecute=\{canExecute\}/);
+    expect(sourceText).toMatch(/showReadoutWhenDisabled=\{!readOnly\}/);
   });
 });

--- a/src/components/cell/CompactExecutionButton.tsx
+++ b/src/components/cell/CompactExecutionButton.tsx
@@ -20,6 +20,8 @@ interface CompactExecutionButtonProps {
   isCellFocused?: boolean;
   /** Whether execution controls are available in this shell */
   canExecute?: boolean;
+  /** Whether disabled historical execution state should still render as status */
+  showReadoutWhenDisabled?: boolean;
   /** Called when user clicks to execute */
   onExecute?: () => void;
   /** Called when user clicks to interrupt */
@@ -51,6 +53,7 @@ export function CompactExecutionButton({
   submittedByActorLabel = null,
   isCellFocused = false,
   canExecute = true,
+  showReadoutWhenDisabled = false,
   onExecute,
   onInterrupt,
   className,
@@ -119,8 +122,9 @@ export function CompactExecutionButton({
     !canExecute && "opacity-65 hover:bg-transparent hover:text-muted-foreground/45",
     className,
   );
+  const disabledHistoricalState = !canExecute && (state === "ran" || state === "error");
   const content =
-    !canExecute && displayCount !== null && (state === "ran" || state === "error") ? (
+    disabledHistoricalState && showReadoutWhenDisabled && displayCount !== null ? (
       <span className="text-[10px] font-medium tabular-nums" aria-hidden="true">
         {displayCount}
       </span>
@@ -136,6 +140,10 @@ export function CompactExecutionButton({
     );
 
   if (!canExecute) {
+    if (disabledHistoricalState && !showReadoutWhenDisabled) {
+      return null;
+    }
+
     return (
       <span
         className={classNameValue}

--- a/src/components/cell/__tests__/CompactExecutionButton.test.tsx
+++ b/src/components/cell/__tests__/CompactExecutionButton.test.tsx
@@ -29,8 +29,17 @@ describe("CompactExecutionButton", () => {
     ).toBeTruthy();
   });
 
-  it("renders non-executable execution history as a status readout instead of a button", () => {
-    render(<CompactExecutionButton count={7} canExecute={false} />);
+  it("renders no control for non-executable execution history by default", () => {
+    const { container } = render(<CompactExecutionButton count={7} canExecute={false} />);
+
+    expect(container.firstChild).toBeNull();
+    expect(screen.queryByRole("button")).toBeNull();
+    expect(screen.queryByRole("status")).toBeNull();
+    expect(screen.queryByTestId("execution-readout")).toBeNull();
+  });
+
+  it("can render disabled execution history as a status readout", () => {
+    render(<CompactExecutionButton count={7} canExecute={false} showReadoutWhenDisabled />);
 
     expect(screen.queryByRole("button")).toBeNull();
     expect(screen.getByRole("status", { name: "Last execution 7" })).toBeTruthy();


### PR DESCRIPTION
## Summary

- Hide disabled historical execution gutter readouts by default so view/report mode does not show run counts as controls
- Let `CodeCell` opt into disabled history readouts only outside read-only mode, preserving the separate edit/no-compute presentation path
- Update focused tests for the compact execution control and view-mode wiring

## Verification

- `pnpm test:run src/components/cell/__tests__/CompactExecutionButton.test.tsx apps/notebook/src/components/__tests__/notebook-view-capabilities-source.test.ts`
- `cargo xtask lint --fix`
