### PR TITLE
fix(runtime): repair stale runtime peer kernel state

### DIFF
--- a/apps/notebook-cloud/src/runtimed-wasm.generated.d.ts
+++ b/apps/notebook-cloud/src/runtimed-wasm.generated.d.ts
@@ -119,6 +119,13 @@ declare module "../../notebook/src/wasm/runtimed-wasm/runtimed_wasm.js" {
     flush_runtime_state_sync(): Uint8Array | undefined;
     generate_comms_doc_sync_reply(): Uint8Array | undefined;
     generate_runtime_state_sync_reply(): Uint8Array | undefined;
+    set_kernel_error(details?: string): void;
+    set_kernel_running(
+      kernelName: string,
+      language: string,
+      envSource: string,
+      runtimeAgentId: string,
+    ): void;
     put_comm_json(
       commId: string,
       targetName: string,

--- a/apps/notebook-cloud/test/room-materializer.test.ts
+++ b/apps/notebook-cloud/test/room-materializer.test.ts
@@ -453,6 +453,113 @@ describe("RoomHostHandle", () => {
     });
   });
 
+  it("lets a runtime peer replace stale published kernel error with live running state", async () => {
+    const seedHost = await createEmptyRoomHost("demo", "system/schema:notebook-cloud-room");
+    const seedRuntime = new RuntimeStatePeerHandle("system/schema:notebook-cloud-room");
+    seedRuntime.set_kernel_error("published runtime state is stale");
+    const host = await loadRoomHostSnapshot(seedHost.save_notebook(), seedRuntime.save());
+
+    const runtimePrincipal = "user:dev:runtime-service";
+    const runtime = new RuntimeStatePeerHandle(`${runtimePrincipal}/agent:runt:test`);
+    syncRuntimeHostWithRuntimePeer(
+      host,
+      "peer-runtime",
+      runtimePrincipal,
+      "runtime_peer",
+      false,
+      runtime,
+    );
+
+    runtime.set_kernel_running("python", "python", "uv:current_python", "runtime-agent-1");
+    const message = runtime.flush_runtime_state_sync();
+    assert.ok(message);
+    const result = host.receive_peer_frame(
+      "peer-runtime",
+      runtimePrincipal,
+      `${runtimePrincipal}/agent:runt:test`,
+      "runtime_peer",
+      false,
+      encodeTypedFrame(FrameType.RUNTIME_STATE_SYNC, message),
+    ) as {
+      changed: boolean;
+      runtime_state_changed: boolean;
+      outbound: Array<{ peer_id: string; frame_type: FrameTypeValue; payload: number[] }>;
+    };
+    assert.equal(result.changed, true);
+    assert.equal(result.runtime_state_changed, true);
+
+    const viewer = NotebookHandle.create_bootstrap("user:dev:carol/desktop:viewer");
+    syncRuntimeHostWithClient(host, "peer-viewer", "user:dev:carol", false, false, viewer);
+    const runtimeState = viewer.get_runtime_state() as {
+      kernel: {
+        lifecycle: { lifecycle: string; activity?: string };
+        name: string;
+        language: string;
+        env_source: string;
+        runtime_agent_id: string;
+      };
+    };
+    assert.deepEqual(runtimeState.kernel.lifecycle, {
+      lifecycle: "Running",
+      activity: "Idle",
+    });
+    assert.equal(runtimeState.kernel.name, "python");
+    assert.equal(runtimeState.kernel.language, "python");
+    assert.equal(runtimeState.kernel.env_source, "uv:current_python");
+    assert.equal(runtimeState.kernel.runtime_agent_id, "runtime-agent-1");
+  });
+
+  it("accepts launch state authored after the runtime peer receives the host snapshot", async () => {
+    const seedHost = await createEmptyRoomHost("demo", "system/schema:notebook-cloud-room");
+    const seedRuntime = new RuntimeStatePeerHandle("system/schema:notebook-cloud-room");
+    seedRuntime.set_kernel_error("published runtime state is stale");
+    const host = await loadRoomHostSnapshot(seedHost.save_notebook(), seedRuntime.save());
+
+    const runtimePrincipal = "user:dev:runtime-service";
+    const runtimeActor = `${runtimePrincipal}/agent:runt:test`;
+    const runtime = new RuntimeStatePeerHandle(runtimeActor);
+    const peerId = "peer-runtime";
+
+    const initial = host.sync_peer(peerId, "runtime_peer") as {
+      outbound: Array<{ peer_id: string; frame_type: FrameTypeValue; payload: number[] }>;
+    };
+    for (const frame of initial.outbound) {
+      if (frame.peer_id !== peerId || frame.frame_type !== FrameType.RUNTIME_STATE_SYNC) {
+        continue;
+      }
+      runtime.receive_frame(encodeTypedFrame(frame.frame_type, new Uint8Array(frame.payload)));
+    }
+
+    runtime.set_kernel_running("python", "python", "uv:current_python", "runtime-agent-1");
+    const reply = runtime.generate_runtime_state_sync_reply();
+    assert.ok(reply);
+
+    const result = host.receive_peer_frame(
+      peerId,
+      runtimePrincipal,
+      runtimeActor,
+      "runtime_peer",
+      false,
+      encodeTypedFrame(FrameType.RUNTIME_STATE_SYNC, reply),
+    ) as {
+      changed: boolean;
+      runtime_state_changed: boolean;
+    };
+    assert.equal(result.changed, true);
+    assert.equal(result.runtime_state_changed, true);
+
+    const viewer = NotebookHandle.create_bootstrap("user:dev:carol/desktop:viewer");
+    syncRuntimeHostWithClient(host, "peer-viewer", "user:dev:carol", false, false, viewer);
+    const runtimeState = viewer.get_runtime_state() as {
+      kernel: { lifecycle: { lifecycle: string; activity?: string }; runtime_agent_id: string };
+    };
+    assert.deepEqual(runtimeState.kernel.lifecycle, {
+      lifecycle: "Running",
+      activity: "Idle",
+    });
+    assert.equal(runtimeState.kernel.runtime_agent_id, "runtime-agent-1");
+  });
+
   it("rejects runtime peer RuntimeStateDoc changes authored by a foreign principal", async () => {
     const host = await createEmptyRoomHost("demo", "system/schema:notebook-cloud-room");
     const forged = new RuntimeStatePeerHandle("user:dev:mallory/runtime:py-3.12");

--- a/crates/runtimed-wasm/src/lib.rs
+++ b/crates/runtimed-wasm/src/lib.rs
@@ -25,7 +25,7 @@ use nteract_identity::{ActorLabel, ConnectionScope, Operator, Principal};
 use runtime_doc::{
     diff_output_ids_in_place, output_ids_for_execution, runtime_state_policy_snapshot,
     validate_runtime_state_sync_scope, CommsDoc, CommsState, ExecutionState,
-    ExecutionViewChangeset, ExecutionViewProjector, RuntimeLifecycle, RuntimeState,
+    ExecutionViewChangeset, ExecutionViewProjector, KernelActivity, RuntimeLifecycle, RuntimeState,
     RuntimeStateDoc, RuntimeStateWriteScope, WorkstationAttachmentState,
 };
 use serde::{Deserialize, Serialize};
@@ -445,6 +445,30 @@ impl RuntimeStatePeerHandle {
 
     pub fn get_runtime_state(&self) -> JsValue {
         serialize_to_js(&self.state_doc.read_state()).unwrap_or(JsValue::UNDEFINED)
+    }
+
+    pub fn set_kernel_running(
+        &mut self,
+        kernel_name: &str,
+        language: &str,
+        env_source: &str,
+        runtime_agent_id: &str,
+    ) -> Result<(), JsError> {
+        self.state_doc
+            .set_lifecycle(&RuntimeLifecycle::Running(KernelActivity::Idle))
+            .map_err(|e| JsError::new(&format!("set kernel lifecycle failed: {e}")))?;
+        self.state_doc
+            .set_kernel_info(kernel_name, language, env_source)
+            .map_err(|e| JsError::new(&format!("set kernel info failed: {e}")))?;
+        self.state_doc
+            .set_runtime_agent_id(runtime_agent_id)
+            .map_err(|e| JsError::new(&format!("set runtime agent id failed: {e}")))
+    }
+
+    pub fn set_kernel_error(&mut self, details: Option<String>) -> Result<(), JsError> {
+        self.state_doc
+            .set_lifecycle_with_error_details(&RuntimeLifecycle::Error, None, details.as_deref())
+            .map_err(|e| JsError::new(&format!("set kernel error failed: {e}")))
     }
 
     pub fn create_execution(&mut self, execution_id: &str) -> Result<(), JsError> {
@@ -1324,6 +1348,9 @@ impl RoomHostHandle {
         attachment: Option<&WorkstationAttachmentState>,
     ) -> Result<RoomHostFrameResult, JsError> {
         let heads_before = self.state_doc.get_heads();
+        if attachment.is_some_and(runtime_peer_attachment_is_ready) {
+            self.clear_stale_runtime_peer_gone_error()?;
+        }
         self.state_doc
             .set_workstation_attachment(attachment)
             .map_err(|e| JsError::new(&format!("set workstation attachment: {e}")))?;
@@ -1338,6 +1365,26 @@ impl RoomHostHandle {
             self.queue_runtime_state_sync_for_other_peers("", &mut result.outbound)?;
         }
         Ok(result)
+    }
+
+    fn clear_stale_runtime_peer_gone_error(&mut self) -> Result<(), JsError> {
+        let state = self.state_doc.read_state();
+        let is_stale_runtime_peer_gone_error =
+            matches!(state.kernel.lifecycle, RuntimeLifecycle::Error)
+                && state
+                    .kernel
+                    .error_details
+                    .as_deref()
+                    .is_some_and(|details| details.starts_with("runtime peer disconnected:"));
+        if !is_stale_runtime_peer_gone_error {
+            return Ok(());
+        }
+        self.state_doc
+            .set_lifecycle_with_error_details(&RuntimeLifecycle::NotStarted, None, None)
+            .map_err(|e| JsError::new(&format!("clear runtime peer gone lifecycle: {e}")))?;
+        self.state_doc
+            .set_runtime_agent_id("")
+            .map_err(|e| JsError::new(&format!("clear runtime peer gone agent id: {e}")))
     }
 }
 
@@ -1361,6 +1408,10 @@ fn runtime_peer_gone_workstation_attachment(
     attachment.status = "error".to_string();
     attachment.status_message = Some(format!("runtime peer disconnected: {reason}"));
     attachment
+}
+
+fn runtime_peer_attachment_is_ready(attachment: &WorkstationAttachmentState) -> bool {
+    attachment.provider == "runtime_peer" && attachment.status == "ready"
 }
 
 /// Whether a kernel lifecycle still reads as "alive" — i.e. a viewer would see
@@ -4014,6 +4065,59 @@ mod tests {
         let state = host.state_doc.read_state();
         assert_eq!(state.kernel.lifecycle, RuntimeLifecycle::Shutdown);
         assert!(state.workstation.is_none());
+    }
+
+    #[test]
+    fn ready_runtime_peer_attachment_clears_stale_peer_gone_kernel_error() {
+        let mut host = RoomHostHandle::create_empty("demo", "system/schema:notebook-cloud-room")
+            .expect("create room host");
+        host.state_doc
+            .set_lifecycle_with_error_details(
+                &RuntimeLifecycle::Error,
+                None,
+                Some("runtime peer disconnected: runtime peer left the room"),
+            )
+            .unwrap();
+        host.state_doc
+            .set_runtime_agent_id("user:dev:alice/agent:runt:old")
+            .unwrap();
+
+        let result = host
+            .set_workstation_attachment_inner(Some(&workstation_attachment_fixture()))
+            .expect("publish ready attachment");
+        assert!(result.changed);
+
+        let state = host.state_doc.read_state();
+        assert_eq!(state.kernel.lifecycle, RuntimeLifecycle::NotStarted);
+        assert_eq!(state.kernel.error_details.as_deref(), Some(""));
+        assert_eq!(state.kernel.runtime_agent_id, "");
+        assert_eq!(
+            state.workstation.as_ref().map(|ws| ws.status.as_str()),
+            Some("ready")
+        );
+    }
+
+    #[test]
+    fn ready_runtime_peer_attachment_preserves_non_watchdog_kernel_error() {
+        let mut host = RoomHostHandle::create_empty("demo", "system/schema:notebook-cloud-room")
+            .expect("create room host");
+        host.state_doc
+            .set_lifecycle_with_error_details(
+                &RuntimeLifecycle::Error,
+                None,
+                Some("kernel launch failed: missing module"),
+            )
+            .unwrap();
+
+        host.set_workstation_attachment_inner(Some(&workstation_attachment_fixture()))
+            .expect("publish ready attachment");
+
+        let state = host.state_doc.read_state();
+        assert_eq!(state.kernel.lifecycle, RuntimeLifecycle::Error);
+        assert_eq!(
+            state.kernel.error_details.as_deref(),
+            Some("kernel launch failed: missing module")
+        );
     }
 
     #[test]

--- a/crates/runtimed/src/runtime_agent.rs
+++ b/crates/runtimed/src/runtime_agent.rs
@@ -97,6 +97,7 @@ struct RuntimeAgentContext {
     broadcast_tx: broadcast::Sender<notebook_protocol::protocol::NotebookBroadcast>,
     presence: Arc<RwLock<PresenceState>>,
     presence_tx: broadcast::Sender<(String, Vec<u8>)>,
+    runtime_agent_id: String,
     kernel_actor_principal: Option<String>,
 }
 
@@ -156,12 +157,12 @@ pub async fn run_runtime_agent(
 ///   hazard the `runt-cloud-peer` spike documented.
 ///
 /// `initial_launch`, when `Some`, is a [`RuntimeAgentRequest::LaunchKernel`] the
-/// agent applies *once* right after bootstrap, so the workstation endpoint can
-/// *start* a runtime in env X without waiting for an inbound `LaunchKernel` RPC
-/// — that inbound channel is req #5, Deferred (decision 38). `None` keeps the
-/// historical attach-only behavior (the agent waits for an RPC that, over the
-/// cloud transport, does not yet arrive). Build it with
-/// [`crate::workstation::build_current_python_launch`].
+/// agent applies *once* after the initial RuntimeStateDoc sync, so the
+/// workstation endpoint can *start* a runtime in env X without waiting for an
+/// inbound `LaunchKernel` RPC. Waiting for the RuntimeStateDoc sync keeps the
+/// launch lifecycle write causally after the room checkpoint instead of racing
+/// stale published lifecycle state. `None` keeps the historical attach-only
+/// behavior. Build it with [`crate::workstation::build_current_python_launch`].
 ///
 /// CODE-ONLY (Phase 3c/3b): this builds and unit-tests the spawn path behind the
 /// transport gate; the live cross-machine re-proof (a preview room + the
@@ -251,6 +252,79 @@ fn direct_python_path_for(
     }
 }
 
+fn record_kernel_launched_state(
+    ctx: &RuntimeAgentContext,
+    kernel_type: &str,
+    env_source: &str,
+) -> Result<(), runtime_doc::RuntimeStateError> {
+    ctx.state.with_doc(|sd| {
+        sd.set_lifecycle(&RuntimeLifecycle::Running(KernelActivity::Idle))?;
+        sd.set_kernel_info(kernel_type, kernel_type, env_source)?;
+        sd.set_runtime_agent_id(&ctx.runtime_agent_id)?;
+        Ok(())
+    })
+}
+
+fn record_kernel_launching_state(
+    ctx: &RuntimeAgentContext,
+    kernel_type: &str,
+    env_source: &str,
+) -> Result<(), runtime_doc::RuntimeStateError> {
+    ctx.state.with_doc(|sd| {
+        sd.set_lifecycle(&RuntimeLifecycle::Launching)?;
+        sd.set_kernel_info(kernel_type, kernel_type, env_source)?;
+        sd.set_runtime_agent_id(&ctx.runtime_agent_id)?;
+        Ok(())
+    })
+}
+
+fn record_kernel_launch_failed_state(
+    ctx: &RuntimeAgentContext,
+    kernel_type: &str,
+    env_source: &str,
+    details: &str,
+) -> Result<(), runtime_doc::RuntimeStateError> {
+    ctx.state.with_doc(|sd| {
+        sd.set_lifecycle_with_error_details(&RuntimeLifecycle::Error, None, Some(details))?;
+        sd.set_kernel_info(kernel_type, kernel_type, env_source)?;
+        sd.set_runtime_agent_id(&ctx.runtime_agent_id)?;
+        Ok(())
+    })
+}
+
+fn is_stale_runtime_peer_disconnect_error(
+    lifecycle: &RuntimeLifecycle,
+    error_details: Option<&str>,
+) -> bool {
+    matches!(lifecycle, RuntimeLifecycle::Error)
+        && error_details.is_some_and(|details| details.starts_with("runtime peer disconnected:"))
+}
+
+fn reassert_live_kernel_projection_if_needed<K: KernelConnection>(
+    ctx: &RuntimeAgentContext,
+    kernel: Option<&K>,
+) -> Result<bool, runtime_doc::RuntimeStateError> {
+    let Some(kernel) = kernel else {
+        return Ok(false);
+    };
+
+    let current = ctx.state.read(|sd| sd.read_state().kernel)?;
+    let should_reassert = matches!(current.lifecycle, RuntimeLifecycle::NotStarted)
+        || is_stale_runtime_peer_disconnect_error(
+            &current.lifecycle,
+            current.error_details.as_deref(),
+        )
+        || (matches!(current.lifecycle, RuntimeLifecycle::Running(_))
+            && current.runtime_agent_id != ctx.runtime_agent_id);
+
+    if !should_reassert {
+        return Ok(false);
+    }
+
+    record_kernel_launched_state(ctx, kernel.kernel_type(), kernel.env_source())?;
+    Ok(true)
+}
+
 /// Run the runtime agent over an arbitrary [`FrameTransport`].
 ///
 /// The desktop/daemon path ([`run_runtime_agent`]) and the cloud path
@@ -337,6 +411,7 @@ where
         broadcast_tx: broadcast_tx.clone(),
         presence,
         presence_tx,
+        runtime_agent_id,
         kernel_actor_principal,
     };
 
@@ -378,43 +453,37 @@ where
     let mut runtime_state_doc_seen = false;
     let mut orphan_comm_candidates: HashSet<String> = HashSet::new();
 
-    // -- 3b. Launch-on-attach (cloud only) ----------------------------------
+    // -- 3b. Launch-on-attach gate (cloud only) -----------------------------
     //
     // The workstation endpoint can hand the agent an initial `LaunchKernel` to
-    // apply right after bootstrap, so it *starts* a runtime in env X without
-    // waiting for an inbound RPC (req #5, Deferred — decision 38). Gated on
-    // `clean_eof_is_recoverable()`, the recoverable/cloud-transport discriminant:
-    // the daemon/UDS path drives launch via its own RPC and must never launch on
-    // attach, so even a (never-passed) `Some` here is ignored on UDS. The launch
-    // runs through the *same* `handle_runtime_agent_request` path an inbound RPC
-    // would, so the kernel drive, queue release, and command-receiver install are
-    // identical — only the trigger differs.
-    if let Some(launch) = initial_launch {
-        if transport.clean_eof_is_recoverable() {
-            info!("[runtime-agent] Applying launch-on-attach LaunchKernel");
-            let (response, new_cmd_rx) = handle_runtime_agent_request(
-                launch,
-                &ctx,
-                &mut kernel,
-                &mut kernel_state,
-                &mut seen_execution_ids,
-            )
-            .await;
-            if let Some(rx) = new_cmd_rx {
-                lifecycle_rx = Some(rx.lifecycle_rx);
-                work_rx = Some(rx.work_rx);
-            }
-            interrupt_handle = kernel.as_ref().and_then(|k| k.interrupt_handle());
-            if let RuntimeAgentResponse::Error { error } = response {
-                warn!("[runtime-agent] Launch-on-attach failed: {}", error);
-            }
-        } else {
+    // apply after the first RuntimeStateDoc sync, so it *starts* a runtime in env
+    // X without waiting for an inbound RPC. The RuntimeStateDoc sync is
+    // load-bearing: the room may bootstrap from a published checkpoint whose
+    // lifecycle still says AwaitingTrust/Error. If the runtime peer writes
+    // Running before receiving that checkpoint, the writes are concurrent and
+    // Automerge can keep projecting the stale checkpoint value even though the
+    // kernel launched. Gated on `clean_eof_is_recoverable()`, the
+    // recoverable/cloud-transport discriminant: the daemon/UDS path drives launch
+    // via its own RPC and must never launch on attach, so even a (never-passed)
+    // `Some` here is ignored on UDS. The launch runs through the *same*
+    // `handle_runtime_agent_request` path an inbound RPC would, so the kernel
+    // drive, queue release, and command-receiver install are identical — only the
+    // trigger differs.
+    let mut pending_initial_launch = match initial_launch {
+        Some(launch) if transport.clean_eof_is_recoverable() => {
+            info!("[runtime-agent] Deferring launch-on-attach until initial RuntimeStateDoc sync");
+            let _ = state_kick_tx.send(());
+            Some(launch)
+        }
+        Some(_) => {
             warn!(
                 "[runtime-agent] Ignoring launch-on-attach on a non-recoverable transport \
                  (daemon-driven launch only)"
             );
+            None
         }
-    }
+        None => None,
+    };
 
     info!("[runtime-agent] Infrastructure ready, entering main loop");
 
@@ -642,6 +711,55 @@ where
                                         Err(e) => {
                                             warn!("[runtime-agent] Closing after RuntimeStateSync failure: {}", e);
                                             break;
+                                        }
+                                    }
+
+                                    if runtime_state_doc_seen {
+                                        if let Some(launch) = pending_initial_launch.take() {
+                                            info!(
+                                                "[runtime-agent] Applying launch-on-attach LaunchKernel after RuntimeStateDoc sync"
+                                            );
+                                            let (response, new_cmd_rx) =
+                                                handle_runtime_agent_request(
+                                                    launch,
+                                                    &ctx,
+                                                    &mut kernel,
+                                                    &mut kernel_state,
+                                                    &mut seen_execution_ids,
+                                                )
+                                                .await;
+                                            if let Some(rx) = new_cmd_rx {
+                                                lifecycle_rx = Some(rx.lifecycle_rx);
+                                                work_rx = Some(rx.work_rx);
+                                            }
+                                            interrupt_handle = kernel
+                                                .as_ref()
+                                                .and_then(|k| k.interrupt_handle());
+                                            if let RuntimeAgentResponse::Error { error } = response
+                                            {
+                                                warn!(
+                                                    "[runtime-agent] Launch-on-attach failed: {}",
+                                                    error
+                                                );
+                                            }
+                                        }
+
+                                        match reassert_live_kernel_projection_if_needed(
+                                            &ctx,
+                                            kernel.as_ref(),
+                                        ) {
+                                            Ok(true) => {
+                                                info!(
+                                                    "[runtime-agent] Reasserted live kernel projection after RuntimeStateDoc sync"
+                                                );
+                                            }
+                                            Ok(false) => {}
+                                            Err(e) => {
+                                                warn!(
+                                                    "[runtime-state] failed to reassert live kernel projection: {}",
+                                                    e
+                                                );
+                                            }
                                         }
                                     }
 
@@ -1433,6 +1551,12 @@ async fn handle_runtime_agent_request(
                 direct_python_path,
             };
 
+            if let Err(e) =
+                record_kernel_launching_state(ctx, &launch_kernel_type, &launch_env_source)
+            {
+                warn!("[runtime-state] {}", e);
+            }
+
             let launch_started = std::time::Instant::now();
             match JupyterKernel::launch(config, shared).await {
                 Ok((k, rx)) => {
@@ -1440,6 +1564,9 @@ async fn handle_runtime_agent_request(
                     *kernel = Some(k);
                     state.reset();
                     state.set_idle();
+                    if let Err(e) = record_kernel_launched_state(ctx, &launch_kernel_type, &es) {
+                        warn!("[runtime-state] {}", e);
+                    }
                     info!(
                         "[runtime-agent] LaunchKernel completed: type={} source={} elapsed_ms={}",
                         launch_kernel_type,
@@ -1467,12 +1594,16 @@ async fn handle_runtime_agent_request(
                         launch_started.elapsed().as_millis(),
                         e
                     );
-                    (
-                        RuntimeAgentResponse::Error {
-                            error: format!("Failed to launch kernel: {}", e),
-                        },
-                        None,
-                    )
+                    let error = format!("Failed to launch kernel: {e}");
+                    if let Err(write_error) = record_kernel_launch_failed_state(
+                        ctx,
+                        &launch_kernel_type,
+                        &launch_env_source,
+                        &error,
+                    ) {
+                        warn!("[runtime-state] {}", write_error);
+                    }
+                    (RuntimeAgentResponse::Error { error }, None)
                 }
             }
         }
@@ -1584,6 +1715,12 @@ async fn handle_runtime_agent_request(
                 warn!("[runtime-state] {}", e);
             }
 
+            if let Err(e) =
+                record_kernel_launching_state(ctx, &launch_kernel_type, &launch_env_source)
+            {
+                warn!("[runtime-state] {}", e);
+            }
+
             let launch_started = std::time::Instant::now();
             match JupyterKernel::launch(config, shared).await {
                 Ok((k, rx)) => {
@@ -1591,6 +1728,9 @@ async fn handle_runtime_agent_request(
                     *kernel = Some(k);
                     state.reset();
                     state.set_idle();
+                    if let Err(e) = record_kernel_launched_state(ctx, &launch_kernel_type, &es) {
+                        warn!("[runtime-state] {}", e);
+                    }
                     info!(
                         "[runtime-agent] RestartKernel completed: type={} source={} elapsed_ms={}",
                         launch_kernel_type,
@@ -1612,12 +1752,16 @@ async fn handle_runtime_agent_request(
                         launch_started.elapsed().as_millis(),
                         e
                     );
-                    (
-                        RuntimeAgentResponse::Error {
-                            error: format!("Failed to restart kernel: {}", e),
-                        },
-                        None,
-                    )
+                    let error = format!("Failed to restart kernel: {e}");
+                    if let Err(write_error) = record_kernel_launch_failed_state(
+                        ctx,
+                        &launch_kernel_type,
+                        &launch_env_source,
+                        &error,
+                    ) {
+                        warn!("[runtime-state] {}", write_error);
+                    }
+                    (RuntimeAgentResponse::Error { error }, None)
                 }
             }
         }
@@ -2804,10 +2948,175 @@ mod tests {
             broadcast_tx: broadcast_tx.clone(),
             presence,
             presence_tx,
+            runtime_agent_id: "test-runtime-agent".to_string(),
             kernel_actor_principal: None,
         };
         let state = KernelState::new(handle.clone());
         (ctx, state, handle)
+    }
+
+    #[test]
+    fn record_kernel_launched_state_publishes_running_kernel_projection() {
+        let (ctx, _state, handle) = test_fixtures();
+
+        record_kernel_launched_state(&ctx, "python", "uv:current_python")
+            .expect("record kernel launch");
+
+        let runtime_state = handle.read(|sd| sd.read_state()).unwrap();
+        assert_eq!(
+            runtime_state.kernel.lifecycle,
+            RuntimeLifecycle::Running(KernelActivity::Idle)
+        );
+        assert_eq!(runtime_state.kernel.name, "python");
+        assert_eq!(runtime_state.kernel.language, "python");
+        assert_eq!(runtime_state.kernel.env_source, "uv:current_python");
+        assert_eq!(runtime_state.kernel.runtime_agent_id, "test-runtime-agent");
+        assert!(runtime_state.env.prewarmed_packages.is_empty());
+    }
+
+    #[test]
+    fn record_kernel_launching_state_publishes_starting_kernel_projection() {
+        let (ctx, _state, handle) = test_fixtures();
+
+        record_kernel_launching_state(&ctx, "python", "uv:current_python")
+            .expect("record kernel launching");
+
+        let runtime_state = handle.read(|sd| sd.read_state()).unwrap();
+        assert_eq!(runtime_state.kernel.lifecycle, RuntimeLifecycle::Launching);
+        assert_eq!(runtime_state.kernel.name, "python");
+        assert_eq!(runtime_state.kernel.language, "python");
+        assert_eq!(runtime_state.kernel.env_source, "uv:current_python");
+        assert_eq!(runtime_state.kernel.runtime_agent_id, "test-runtime-agent");
+    }
+
+    #[test]
+    fn record_kernel_launch_failed_state_terminates_starting_kernel_projection() {
+        let (ctx, _state, handle) = test_fixtures();
+
+        record_kernel_launching_state(&ctx, "python", "uv:current_python")
+            .expect("record kernel launching");
+        record_kernel_launch_failed_state(
+            &ctx,
+            "python",
+            "uv:current_python",
+            "Failed to launch kernel: missing ipykernel",
+        )
+        .expect("record kernel launch failure");
+
+        let runtime_state = handle.read(|sd| sd.read_state()).unwrap();
+        assert_eq!(runtime_state.kernel.lifecycle, RuntimeLifecycle::Error);
+        assert_eq!(
+            runtime_state.kernel.error_details.as_deref(),
+            Some("Failed to launch kernel: missing ipykernel")
+        );
+        assert_eq!(runtime_state.kernel.name, "python");
+        assert_eq!(runtime_state.kernel.env_source, "uv:current_python");
+        assert_eq!(runtime_state.kernel.runtime_agent_id, "test-runtime-agent");
+    }
+
+    #[test]
+    fn live_kernel_reasserts_after_stale_not_started_projection() {
+        let (ctx, _state, handle) = test_fixtures();
+        handle
+            .with_doc(|sd| {
+                sd.set_lifecycle_with_error_details(&RuntimeLifecycle::NotStarted, None, None)?;
+                sd.set_runtime_agent_id("")?;
+                Ok(())
+            })
+            .expect("seed stale not-started state");
+
+        let reasserted = reassert_live_kernel_projection_if_needed(&ctx, Some(&MockKernel))
+            .expect("reassert live kernel");
+
+        assert!(reasserted);
+        let runtime_state = handle.read(|sd| sd.read_state()).unwrap();
+        assert_eq!(
+            runtime_state.kernel.lifecycle,
+            RuntimeLifecycle::Running(KernelActivity::Idle)
+        );
+        assert_eq!(runtime_state.kernel.name, "python");
+        assert_eq!(runtime_state.kernel.env_source, "test");
+        assert_eq!(runtime_state.kernel.runtime_agent_id, "test-runtime-agent");
+    }
+
+    #[test]
+    fn live_kernel_reasserts_after_stale_peer_disconnect_error() {
+        let (ctx, _state, handle) = test_fixtures();
+        handle
+            .with_doc(|sd| {
+                sd.set_lifecycle_with_error_details(
+                    &RuntimeLifecycle::Error,
+                    None,
+                    Some("runtime peer disconnected: websocket closed"),
+                )?;
+                sd.set_runtime_agent_id("old-runtime-agent")?;
+                Ok(())
+            })
+            .expect("seed stale peer-disconnect state");
+
+        let reasserted = reassert_live_kernel_projection_if_needed(&ctx, Some(&MockKernel))
+            .expect("reassert live kernel");
+
+        assert!(reasserted);
+        let runtime_state = handle.read(|sd| sd.read_state()).unwrap();
+        assert_eq!(
+            runtime_state.kernel.lifecycle,
+            RuntimeLifecycle::Running(KernelActivity::Idle)
+        );
+        assert_eq!(runtime_state.kernel.runtime_agent_id, "test-runtime-agent");
+    }
+
+    #[test]
+    fn live_kernel_reasserts_after_stale_running_agent_id() {
+        let (ctx, _state, handle) = test_fixtures();
+        handle
+            .with_doc(|sd| {
+                sd.set_lifecycle(&RuntimeLifecycle::Running(KernelActivity::Idle))?;
+                sd.set_kernel_info("python", "python", "uv:current_python")?;
+                sd.set_runtime_agent_id("old-runtime-agent")?;
+                Ok(())
+            })
+            .expect("seed stale running owner");
+
+        let reasserted = reassert_live_kernel_projection_if_needed(&ctx, Some(&MockKernel))
+            .expect("reassert live kernel owner");
+
+        assert!(reasserted);
+        let runtime_state = handle.read(|sd| sd.read_state()).unwrap();
+        assert_eq!(
+            runtime_state.kernel.lifecycle,
+            RuntimeLifecycle::Running(KernelActivity::Idle)
+        );
+        assert_eq!(runtime_state.kernel.env_source, "test");
+        assert_eq!(runtime_state.kernel.runtime_agent_id, "test-runtime-agent");
+    }
+
+    #[test]
+    fn live_kernel_does_not_overwrite_non_watchdog_error() {
+        let (ctx, _state, handle) = test_fixtures();
+        handle
+            .with_doc(|sd| {
+                sd.set_lifecycle_with_error_details(
+                    &RuntimeLifecycle::Error,
+                    None,
+                    Some("kernel launch failed: missing ipykernel"),
+                )?;
+                sd.set_runtime_agent_id("test-runtime-agent")?;
+                Ok(())
+            })
+            .expect("seed real kernel error");
+
+        let reasserted = reassert_live_kernel_projection_if_needed(&ctx, Some(&MockKernel))
+            .expect("check live kernel repair");
+
+        assert!(!reasserted);
+        let runtime_state = handle.read(|sd| sd.read_state()).unwrap();
+        assert_eq!(runtime_state.kernel.lifecycle, RuntimeLifecycle::Error);
+        assert_eq!(
+            runtime_state.kernel.error_details.as_deref(),
+            Some("kernel launch failed: missing ipykernel")
+        );
+        assert_eq!(runtime_state.kernel.runtime_agent_id, "test-runtime-agent");
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Summary

- wait to apply cloud launch-on-attach until the initial RuntimeStateDoc sync arrives, then publish `Launching` + kernel info before spawning the kernel so users see startup progress after the room checkpoint has landed
- publish `Running(Idle)` + kernel info from the runtime agent after successful launch/restart, and publish `Error` if launch/restart fails
- clear only stale room-host watchdog kernel errors when a ready runtime-peer workstation attachment replaces a disconnected peer
- let a live runtime agent reassert its kernel projection after syncing a stale `NotStarted`, runtime-peer-disconnect `Error`, or stale `Running` state owned by an old runtime-agent id

## Validation

- `cargo test -p runtimed runtime_agent::tests:: -- --nocapture`
- `cargo test -p runtimed-wasm ready_runtime_peer_attachment -- --nocapture`
- `pnpm --dir apps/notebook-cloud exec node --import tsx --test test/room-materializer.test.ts --test-name-pattern "stale published kernel error|launch state authored"`
- `cargo xtask wasm runtimed --skip-renderer-plugins`
- `pnpm --dir apps/notebook-cloud run typecheck`
- `cargo xtask lint --fix`

## Preview

Redeploying after the `Launching` amendment. Previous preview smoke on `topic-viz` verified one runtime peer, workstation `ready`, kernel `Running(Idle)`, matching `runtime_agent_id`, 23 cells loaded, and toolbar run/restart/interrupt controls visible.

## Notes

This does not change the view/edit mode execution-button rules; PR #3498 owns that UI surface.