### PR TITLE
fix(notebook-cloud): gate sharing controls to owners

### DIFF
--- a/apps/notebook-cloud/test/viewer-shell-capabilities.test.ts
+++ b/apps/notebook-cloud/test/viewer-shell-capabilities.test.ts
@@ -362,7 +362,7 @@ test("cloud shell capabilities grant owners full cell, structure, and sharing co
   assert.equal(capabilities.runtime.canWriteRuntimeState, false);
 });
 
-test("cloud shell capabilities surface sharing for authenticated hosted rooms", () => {
+test("cloud shell capabilities surface sharing only for hosted room owners", () => {
   assert.equal(
     cloudNotebookShellCapabilities({
       authState: authState("dev"),
@@ -380,7 +380,7 @@ test("cloud shell capabilities surface sharing for authenticated hosted rooms", 
       hasCodeCells: true,
       hostCapabilities: { canManageSharing: true },
     }).canManageSharing,
-    true,
+    false,
   );
 
   assert.equal(
@@ -429,11 +429,13 @@ test("cloud shell capabilities treat app-session cookies as browser authenticati
     connectionScope: "editor",
     hasAppSession: true,
     hasCodeCells: true,
+    hostCapabilities: { canManageSharing: true },
     runtimeAvailable: true,
   });
 
   assert.equal(editorWithRuntime.auth.canUseAuthenticatedIdentity, true);
   assert.equal(editorWithRuntime.canExecute, false);
+  assert.equal(editorWithRuntime.canManageSharing, false);
 });
 
 test("cloud shell capabilities require the host room to advertise sharing", () => {

--- a/apps/notebook-cloud/viewer/shell-capabilities.ts
+++ b/apps/notebook-cloud/viewer/shell-capabilities.ts
@@ -158,6 +158,7 @@ export function cloudNotebookShellCapabilities({
     sharing: {
       canManage: Boolean(hostCapabilities?.canManageSharing),
       requiresAuthenticatedIdentity: true,
+      requiredAccessLevels: ["owner"],
     },
   });
 }


### PR DESCRIPTION
## Summary
- require owner access before hosted notebooks surface sharing management controls
- keep the existing host capability gate, but align the UI projection with owner-only sharing routes
- add shell-capability coverage for editor/app-session cases that should not manage sharing

## Validation
- `pnpm --dir apps/notebook-cloud exec node --import tsx --test test/viewer-shell-capabilities.test.ts test/viewer-render-props.test.ts`
- `cargo xtask lint --fix`

## Notes
This intentionally avoids changing auth/session behavior. The repeated sign-in churn needs a proven reproduction before modifying the OIDC/app-session handshake.