### PR TITLE
fix(notebook-cloud): use app-session cookies for browser sync

### DIFF
--- a/apps/notebook-cloud/README.md
+++ b/apps/notebook-cloud/README.md
@@ -364,17 +364,18 @@ an anonymous viewer instead, and shows a visible diagnostic with a reset button.
 `preview.runt.run` uses direct OIDC against Anaconda stage only to bootstrap a
 first-party app session. The Worker injects the issuer, client id, and redirect
 URI into the viewer shell, the browser completes an Authorization Code + PKCE
-flow through `/oidc`, and `/api/app-session` exchanges the validated OIDC bearer
+flow through `/oidc`, and `/api/auth/session` exchanges the validated OIDC bearer
 for an HttpOnly, Secure, SameSite=Lax app-session cookie. First-party browser
 HTTP APIs then use that cookie with same-origin credentials.
 
-Live-room WebSockets do not authenticate with the cookie directly and must not
-leak browser credentials into output frames. The viewer asks
-`/api/n/:id/sync-ticket` for a short-lived app-session sync ticket scoped to the
-requested browser operator/scope, then sends that ticket through the sync
-subprotocol. The Worker validates the ticket and forwards a trusted room
-identity to the Durable Object. Runtime peers and automation use API keys
-instead of app-session cookies.
+Live-room WebSockets also use the first-party app-session cookie for browser
+connections. The Worker requires a trusted `Origin` for cookie-backed
+WebSocket upgrades, rejects mixed app-session plus explicit bearer/dev
+credentials, derives the requested live scope from the URL, and forwards only
+trusted identity headers plus the non-sensitive `nteract.v4` application
+subprotocol to the Durable Object. Sandboxed outputs stay on the isolated
+output origin and do not receive app-session cookies or localStorage state.
+Runtime peers and automation use API keys instead of app-session cookies.
 
 The Worker validates OIDC JWT issuer, audience/client id, signature, time
 claims, and principal namespace before minting an app session or consulting the

--- a/apps/notebook-cloud/scripts/hosted-workstation-toolbar-smoke.mjs
+++ b/apps/notebook-cloud/scripts/hosted-workstation-toolbar-smoke.mjs
@@ -188,14 +188,7 @@ async function runBrowserSmoke({
       await ownerContext.close().catch(() => {});
     }
 
-    const viewerControlCheck = await assertViewerDoesNotExposeExecutionControls({
-      browser,
-      runMarker,
-      timeoutMs,
-      tokenStorageJson,
-      url,
-    });
-    const editorRun = await assertEditorDoesNotExposeExecutionControls({
+    const viewModeControlCheck = await assertViewModeDoesNotExposeExecutionControls({
       browser,
       runMarker,
       timeoutMs,
@@ -217,13 +210,11 @@ async function runBrowserSmoke({
         "owner_offline_default_workstation_shows_review_action",
         "owner_missing_working_directory_explains_blocked_launch",
         "owner_missing_environment_explains_blocked_launch",
-        "viewer_scope_hides_execution_controls",
-        "viewer_scope_hides_workstation_setup_action",
-        "editor_scope_hides_execution_controls",
+        "view_mode_hides_execution_controls",
+        "view_mode_hides_workstation_setup_action",
       ],
       blockedRuns,
-      editorRun,
-      scopedControlChecks: [viewerControlCheck],
+      scopedControlChecks: [viewModeControlCheck],
     };
   } finally {
     await browser.close().catch(() => {});
@@ -242,6 +233,7 @@ async function runOwnerAttachAndExecuteSmoke({
   const page = await context.newPage();
   const events = collectBrowserDiagnostics(page);
   await openNotebookShell(page, url.href, timeoutMs);
+  await enterEditMode(page, timeoutMs);
   const cell = await ensureCodeCell(page, timeoutMs);
   await setCellSource(cell, source);
 
@@ -262,15 +254,20 @@ async function runOwnerAttachAndExecuteSmoke({
   await page.reload({ waitUntil: "domcontentloaded", timeout: timeoutMs });
   await waitForNotebookReady(page, timeoutMs);
   await waitForText(page, runMarker, timeoutMs);
+  await enterEditMode(page, timeoutMs);
   const reloadedCell = page.locator('[data-cell-type="code"]').first();
   await reloadedCell.waitFor({ state: "visible", timeout: timeoutMs });
-  const beforeReloadRunAria = await reloadedCell
-    .getByTestId("execute-button")
-    .getAttribute("aria-label");
+  const beforeReloadRunAria = await readExecuteButtonAria(
+    reloadedCell,
+    "read reloaded execute button state",
+    timeoutMs,
+  );
   await executeAndWaitForMarker(page, reloadedCell, runMarker, timeoutMs);
-  const afterReloadRunAria = await reloadedCell
-    .getByTestId("execute-button")
-    .getAttribute("aria-label");
+  const afterReloadRunAria = await readExecuteButtonAria(
+    reloadedCell,
+    "read post-reload execute button state",
+    timeoutMs,
+  );
   const afterReloadKernelStatus = await readKernelStatus(page);
   assertKernelStatusNotInitializing(afterReloadKernelStatus, "after reload execution");
 
@@ -438,6 +435,7 @@ async function assertOwnerToolbarActionWithMockedWorkstations({
     const page = await context.newPage();
     const events = collectBrowserDiagnostics(page);
     await openNotebookShell(page, url.href, timeoutMs);
+    await enterEditMode(page, timeoutMs);
     await waitForToolbarAction(page, expectedLabel, timeoutMs);
     const action = await readToolbarWorkstationAction(page);
     assertToolbarWorkstationAction(action, {
@@ -467,7 +465,7 @@ async function assertOwnerToolbarActionWithMockedWorkstations({
   }
 }
 
-async function assertViewerDoesNotExposeExecutionControls({
+async function assertViewModeDoesNotExposeExecutionControls({
   browser,
   runMarker,
   timeoutMs,
@@ -476,7 +474,7 @@ async function assertViewerDoesNotExposeExecutionControls({
 }) {
   const context = await authenticatedContext(browser, {
     origin: url.origin,
-    scope: "viewer",
+    scope: "owner",
     tokenStorageJson,
   });
   try {
@@ -486,50 +484,14 @@ async function assertViewerDoesNotExposeExecutionControls({
     await waitForNotebookSessionReady(page, timeoutMs);
     await waitForText(page, runMarker, timeoutMs);
     const controls = await visibleControlSummary(page);
-    assertNoExecutionControls(controls, "viewer scope");
+    assertNoExecutionControls(controls, "view mode");
     if (controls.workstationSetupButtonCount > 0) {
-      throw new Error("viewer scope unexpectedly exposed workstation setup controls");
+      throw new Error("view mode unexpectedly exposed workstation setup controls");
     }
     assertCleanBrowserDiagnostics(events);
     return {
       controls,
-      scope: "viewer",
-    };
-  } finally {
-    await context.close().catch(() => {});
-  }
-}
-
-async function assertEditorDoesNotExposeExecutionControls({
-  browser,
-  runMarker,
-  timeoutMs,
-  tokenStorageJson,
-  url,
-}) {
-  const context = await authenticatedContext(browser, {
-    origin: url.origin,
-    scope: "editor",
-    tokenStorageJson,
-  });
-  const editorMarker = `${runMarker} editor`;
-  try {
-    const page = await context.newPage();
-    const events = collectBrowserDiagnostics(page);
-    await page.goto(url.href, { waitUntil: "domcontentloaded", timeout: timeoutMs });
-    await waitForNotebookSessionReady(page, timeoutMs);
-    await waitForText(page, runMarker, timeoutMs);
-    const cell = page.locator('[data-cell-type="code"]').first();
-    await cell.waitFor({ state: "visible", timeout: timeoutMs });
-    await setCellSource(cell, `print(${JSON.stringify(editorMarker)})`);
-    await waitForText(page, editorMarker, timeoutMs);
-    const controls = await visibleControlSummary(page);
-    assertNoExecutionControls(controls, "editor scope");
-    assertCleanBrowserDiagnostics(events);
-    return {
-      controls,
-      marker: editorMarker,
-      scope: "editor",
+      mode: "view",
     };
   } finally {
     await context.close().catch(() => {});
@@ -551,6 +513,41 @@ async function authenticatedContext(browser, { origin, scope, tokenStorageJson }
     { expectedOrigin: origin, requestedScope: scope, tokenJson: tokenStorageJson },
   );
   return context;
+}
+
+async function enterEditMode(page, timeoutMs) {
+  await smokePhase("enter edit mode", async () => {
+    const modeGroup = page.getByRole("group", { name: "Notebook interaction mode" });
+    await modeGroup.waitFor({ state: "visible", timeout: timeoutMs });
+    const editButton = modeGroup.getByRole("button").nth(1);
+    await editButton.click({ timeout: timeoutMs });
+    await page.waitForFunction(
+      () => {
+        const group = document.querySelector('[data-slot="notebook-edit-mode-button"]');
+        const buttons = group?.querySelectorAll("button") ?? [];
+        return buttons[1]?.getAttribute("aria-pressed") === "true";
+      },
+      null,
+      { timeout: timeoutMs },
+    );
+  });
+}
+
+async function smokePhase(label, operation) {
+  try {
+    return await operation();
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    throw new Error(`${label}: ${message}`);
+  }
+}
+
+async function waitForPagePredicate(page, label, predicate, argument, timeout) {
+  await smokePhase(label, async () => await page.waitForFunction(predicate, argument, { timeout }));
+}
+
+function textSample(text) {
+  return text.length > 80 ? `${text.slice(0, 77)}...` : text;
 }
 
 async function visibleControlSummary(page) {
@@ -660,101 +657,133 @@ function assertCleanBrowserDiagnostics(events) {
 }
 
 async function openNotebookShell(page, href, timeout) {
-  await page.goto(href, { waitUntil: "domcontentloaded", timeout });
+  await smokePhase("open notebook shell", async () => {
+    await page.goto(href, { waitUntil: "domcontentloaded", timeout });
+  });
   await waitForNotebookReady(page, timeout);
 }
 
 async function waitForNotebookReady(page, timeout) {
-  await page.waitForSelector('[data-testid="notebook-toolbar"]', { timeout });
+  await smokePhase("wait for notebook toolbar", async () => {
+    await page.waitForSelector('[data-testid="notebook-toolbar"]', { timeout });
+  });
   await waitForNotebookSessionReady(page, timeout);
 }
 
 async function waitForNotebookSessionReady(page, timeout) {
-  await page.waitForFunction(
+  await waitForPagePredicate(
+    page,
+    "wait for notebook document sync",
     () =>
       document.querySelector("[data-notebook-synced]")?.getAttribute("data-notebook-synced") ===
       "true",
     null,
-    { timeout },
+    timeout,
   );
-  await page.waitForFunction(
+  await waitForPagePredicate(
+    page,
+    "wait for live session ready",
     () =>
       document.querySelector("[data-session-ready]")?.getAttribute("data-session-ready") === "true",
     null,
-    { timeout: Math.max(timeout, 120_000) },
+    Math.max(timeout, 120_000),
   );
 }
 
 async function ensureCodeCell(page, timeout) {
-  if ((await page.locator('[data-cell-type="code"]').count()) === 0) {
-    await page.getByTestId("add-code-cell-button").click({ timeout });
-  }
-  const cell = page.locator('[data-cell-type="code"]').first();
-  await cell.waitFor({ state: "visible", timeout });
-  return cell;
+  return smokePhase("ensure code cell", async () => {
+    if ((await page.locator('[data-cell-type="code"]').count()) === 0) {
+      await page.getByTestId("add-code-cell-button").click({ timeout });
+    }
+    const cell = page.locator('[data-cell-type="code"]').first();
+    await cell.waitFor({ state: "visible", timeout });
+    return cell;
+  });
 }
 
 async function setCellSource(cell, source) {
-  await cell.locator('.cm-content[contenteditable="true"]').evaluate((node, text) => {
-    const editor = node.cmTile?.view;
-    if (!editor) throw new Error("No CodeMirror view found");
-    editor.dispatch({
-      changes: {
-        from: 0,
-        insert: text,
-        to: editor.state.doc.length,
-      },
-      selection: { anchor: text.length },
-    });
-    editor.focus();
-  }, source);
+  await smokePhase("set cell source", async () => {
+    await cell.locator('.cm-content[contenteditable="true"]').evaluate((node, text) => {
+      const editor = node.cmTile?.view;
+      if (!editor) throw new Error("No CodeMirror view found");
+      editor.dispatch({
+        changes: {
+          from: 0,
+          insert: text,
+          to: editor.state.doc.length,
+        },
+        selection: { anchor: text.length },
+      });
+      editor.focus();
+    }, source);
+  });
 }
 
 async function waitForToolbarAction(page, label, timeout) {
-  await page.waitForFunction(
+  await waitForPagePredicate(
+    page,
+    `wait for workstation toolbar action ${label}`,
     (expected) =>
       document
         .querySelector('[data-testid="workstation-setup-button"]')
         ?.getAttribute("aria-label") === expected,
     label,
-    { timeout },
+    timeout,
   );
 }
 
 async function executeAndWaitForMarker(page, cell, marker, timeout) {
   await waitForCanExecute(page, timeout);
-  const executeButton = cell.getByTestId("execute-button");
-  await executeButton.waitFor({ state: "visible", timeout });
-  const beforeAria = await executeButton.getAttribute("aria-label");
+  const executeButton = await visibleExecuteButton(cell, timeout);
+  const beforeAria = await readExecuteButtonAria(cell, "read pre-execution button state", timeout);
   const beforeOrdinal = executionOrdinal(beforeAria);
-  await executeButton.click({ timeout });
+  await smokePhase("click cell execute button", async () => {
+    await executeButton.click({ timeout });
+  });
   await waitForExecutionOrdinalAdvance(page, beforeOrdinal, timeout);
   await waitForText(page, marker, timeout);
 }
 
+async function visibleExecuteButton(cell, timeout) {
+  const executeButton = cell.getByTestId("execute-button");
+  await smokePhase("wait for cell execute button", async () => {
+    await executeButton.waitFor({ state: "visible", timeout });
+  });
+  return executeButton;
+}
+
+async function readExecuteButtonAria(cell, label, timeout) {
+  const executeButton = await visibleExecuteButton(cell, timeout);
+  return smokePhase(label, async () => await executeButton.getAttribute("aria-label", { timeout }));
+}
+
 async function waitForCanExecute(page, timeout) {
-  await page.waitForFunction(
+  await waitForPagePredicate(
+    page,
+    "wait for shell can-execute",
     () =>
       document
         .querySelector('[data-slot="notebook-document-shell"]')
         ?.getAttribute("data-can-execute") === "true",
     null,
-    { timeout },
+    timeout,
   );
 }
 
 async function waitForText(page, text, timeout) {
-  await page.waitForFunction(
+  await waitForPagePredicate(
+    page,
+    `wait for text ${JSON.stringify(textSample(text))}`,
     (expected) => (document.body.textContent ?? "").includes(expected),
     text,
-    {
-      timeout,
-    },
+    timeout,
   );
 }
 
 async function waitForExecutionOrdinalAdvance(page, beforeOrdinal, timeout) {
-  await page.waitForFunction(
+  await waitForPagePredicate(
+    page,
+    "wait for execution count advance",
     (previous) => {
       const ordinals = [...document.querySelectorAll('[data-testid="execute-button"]')]
         .map((button) => {
@@ -767,7 +796,7 @@ async function waitForExecutionOrdinalAdvance(page, beforeOrdinal, timeout) {
       return Math.max(...ordinals) > previous;
     },
     beforeOrdinal,
-    { timeout },
+    timeout,
   );
 }
 

--- a/apps/notebook-cloud/src/app-session.ts
+++ b/apps/notebook-cloud/src/app-session.ts
@@ -1,10 +1,4 @@
 import type { AuthenticatedConnection } from "./identity.ts";
-import {
-  APP_SESSION_SYNC_TICKET_PROTOCOL_PREFIX,
-  NOTEBOOK_CLOUD_WEBSOCKET_PROTOCOL,
-  isConnectionScope,
-  type ConnectionScope,
-} from "./auth-shared.ts";
 
 export interface AppSessionEnvironment {
   NOTEBOOK_CLOUD_APP_SESSION_SECRET?: string;
@@ -19,23 +13,6 @@ export interface CloudAppSession {
   provider: "oidc";
 }
 
-export interface CloudSyncTicket {
-  displayName?: string;
-  expiresAt: number;
-  issuedAt: number;
-  notebookId: string;
-  operator: string;
-  principal: string;
-  principalNamespace: string;
-  scope: Exclude<ConnectionScope, "runtime_peer">;
-}
-
-export interface CloudSyncTicketInput {
-  notebookId: string;
-  operator: string;
-  scope: Exclude<ConnectionScope, "runtime_peer">;
-}
-
 interface CloudAppSessionPayload {
   display_name?: string;
   exp: number;
@@ -46,23 +23,10 @@ interface CloudAppSessionPayload {
   v: 1;
 }
 
-interface CloudSyncTicketPayload {
-  display_name?: string;
-  exp: number;
-  iat: number;
-  notebook_id: string;
-  ns: string;
-  operator: string;
-  principal: string;
-  scope: Exclude<ConnectionScope, "runtime_peer">;
-  v: 1;
-}
-
 export const NOTEBOOK_CLOUD_APP_SESSION_COOKIE_NAME = "__Host-nteract_cloud_app_session";
 export const NOTEBOOK_CLOUD_APP_SESSION_DISPLAY_NAME_MAX_LENGTH = 128;
 export const NOTEBOOK_CLOUD_APP_SESSION_MAX_AGE_SECONDS = 6 * 60 * 60;
 export const NOTEBOOK_CLOUD_APP_SESSION_SECRET_MIN_LENGTH = 32;
-export const NOTEBOOK_CLOUD_SYNC_TICKET_MAX_AGE_SECONDS = 90;
 
 const SESSION_SIGNING_ALGORITHM = { name: "HMAC", hash: "SHA-256" };
 
@@ -90,76 +54,6 @@ export async function createCloudAppSessionCookie(
   };
   const value = await signCloudAppSession(env, payload);
   return `${NOTEBOOK_CLOUD_APP_SESSION_COOKIE_NAME}=${value}; Path=/; Max-Age=${NOTEBOOK_CLOUD_APP_SESSION_MAX_AGE_SECONDS}; HttpOnly; Secure; SameSite=Lax`;
-}
-
-export async function createCloudSyncTicket(
-  env: AppSessionEnvironment,
-  session: CloudAppSession,
-  input: CloudSyncTicketInput,
-  nowSeconds = currentEpochSeconds(),
-): Promise<string> {
-  const payload: CloudSyncTicketPayload = {
-    v: 1,
-    principal: session.principal,
-    ns: session.principalNamespace,
-    operator: input.operator,
-    notebook_id: input.notebookId,
-    scope: input.scope,
-    iat: nowSeconds,
-    exp: nowSeconds + NOTEBOOK_CLOUD_SYNC_TICKET_MAX_AGE_SECONDS,
-    ...(session.displayName ? { display_name: session.displayName } : {}),
-  };
-  const encodedPayload = base64UrlEncodeString(JSON.stringify(payload));
-  const signature = await hmacSha256(env, encodedPayload);
-  return `${encodedPayload}.${base64UrlEncodeBytes(signature)}`;
-}
-
-export async function readCloudSyncTicket(
-  env: AppSessionEnvironment,
-  value: string,
-  nowSeconds = currentEpochSeconds(),
-): Promise<CloudSyncTicket | null> {
-  const payload = await verifyCloudSyncTicket(env, value);
-  if (!payload || payload.exp <= nowSeconds || payload.iat > nowSeconds + 60) {
-    return null;
-  }
-
-  return {
-    principal: payload.principal,
-    principalNamespace: payload.ns,
-    operator: payload.operator,
-    notebookId: payload.notebook_id,
-    scope: payload.scope,
-    issuedAt: payload.iat,
-    expiresAt: payload.exp,
-    ...(payload.display_name ? { displayName: payload.display_name } : {}),
-  };
-}
-
-export function cloudSyncTicketFromWebSocketProtocol(
-  value: string | null,
-): { ticket: string; webSocketProtocol?: string } | null {
-  if (!value) return null;
-
-  const webSocketProtocol = value
-    .split(",")
-    .some((protocol) => protocol.trim() === NOTEBOOK_CLOUD_WEBSOCKET_PROTOCOL)
-    ? NOTEBOOK_CLOUD_WEBSOCKET_PROTOCOL
-    : undefined;
-  let credential: { ticket: string; webSocketProtocol?: string } | null = null;
-  for (const protocol of value.split(",")) {
-    const trimmed = protocol.trim();
-    if (!trimmed.startsWith(APP_SESSION_SYNC_TICKET_PROTOCOL_PREFIX)) continue;
-    const ticket = base64UrlDecodeString(
-      trimmed.slice(APP_SESSION_SYNC_TICKET_PROTOCOL_PREFIX.length),
-    );
-    if (!ticket) continue;
-    if (credential) {
-      throw new Error("multiple app-session sync tickets presented");
-    }
-    credential = webSocketProtocol ? { ticket, webSocketProtocol } : { ticket };
-  }
-  return credential;
 }
 
 export function clearCloudAppSessionCookie(): string {
@@ -227,33 +121,6 @@ async function verifyCloudAppSession(
   return parsed;
 }
 
-async function verifyCloudSyncTicket(
-  env: AppSessionEnvironment,
-  value: string,
-): Promise<CloudSyncTicketPayload | null> {
-  const [encodedPayload, encodedSignature, extra] = value.split(".");
-  if (!encodedPayload || !encodedSignature || extra !== undefined) {
-    return null;
-  }
-
-  const expected = await hmacSha256(env, encodedPayload).catch(() => null);
-  const actual = base64UrlDecodeBytes(encodedSignature);
-  if (!expected || !actual || !timingSafeBytesEqual(expected, actual)) {
-    return null;
-  }
-
-  let parsed: unknown;
-  try {
-    parsed = JSON.parse(base64UrlDecodeString(encodedPayload));
-  } catch {
-    return null;
-  }
-  if (!isCloudSyncTicketPayload(parsed)) {
-    return null;
-  }
-  return parsed;
-}
-
 async function hmacSha256(env: AppSessionEnvironment, value: string): Promise<Uint8Array> {
   const secret = appSessionSecret(env);
   if (!secret) {
@@ -309,27 +176,6 @@ function isCloudAppSessionPayload(value: unknown): value is CloudAppSessionPaylo
     payload.provider === "oidc" &&
     typeof payload.principal === "string" &&
     typeof payload.ns === "string" &&
-    Number.isFinite(payload.iat) &&
-    Number.isFinite(payload.exp) &&
-    (payload.display_name === undefined || typeof payload.display_name === "string")
-  );
-}
-
-function isCloudSyncTicketPayload(value: unknown): value is CloudSyncTicketPayload {
-  if (!value || typeof value !== "object") {
-    return false;
-  }
-  const payload = value as Record<string, unknown>;
-  const scope = payload.scope;
-  return (
-    payload.v === 1 &&
-    typeof payload.principal === "string" &&
-    typeof payload.ns === "string" &&
-    typeof payload.operator === "string" &&
-    typeof payload.notebook_id === "string" &&
-    typeof scope === "string" &&
-    isConnectionScope(scope) &&
-    scope !== "runtime_peer" &&
     Number.isFinite(payload.iat) &&
     Number.isFinite(payload.exp) &&
     (payload.display_name === undefined || typeof payload.display_name === "string")

--- a/apps/notebook-cloud/src/auth-shared.ts
+++ b/apps/notebook-cloud/src/auth-shared.ts
@@ -1,6 +1,5 @@
 export type ConnectionScope = "viewer" | "editor" | "runtime_peer" | "owner";
 
-export const APP_SESSION_SYNC_TICKET_PROTOCOL_PREFIX = "nteract-app-session.";
 export const BEARER_AUTH_TOKEN_PROTOCOL_PREFIX = "nteract-bearer.";
 export const DEV_AUTH_TOKEN_HEADER = "x-notebook-cloud-dev-token";
 export const DEV_AUTH_TOKEN_PROTOCOL_PREFIX = "nteract-dev-token.";

--- a/apps/notebook-cloud/src/identity.ts
+++ b/apps/notebook-cloud/src/identity.ts
@@ -8,7 +8,6 @@ import {
 } from "./auth-shared.ts";
 
 export {
-  APP_SESSION_SYNC_TICKET_PROTOCOL_PREFIX,
   BEARER_AUTH_TOKEN_PROTOCOL_PREFIX,
   DEV_AUTH_TOKEN_HEADER,
   DEV_AUTH_TOKEN_PROTOCOL_PREFIX,
@@ -48,7 +47,6 @@ export interface AuthenticatedConnectionMetadata {
   transport:
     | "anonymous"
     | "app-session-cookie"
-    | "app-session-sync-ticket"
     | "loopback-dev"
     | "dev-token-header"
     | "dev-token-subprotocol"
@@ -761,7 +759,6 @@ function isMetadataTransport(value: string): value is AuthenticatedConnectionMet
   return (
     value === "anonymous" ||
     value === "app-session-cookie" ||
-    value === "app-session-sync-ticket" ||
     value === "loopback-dev" ||
     value === "dev-token-header" ||
     value === "dev-token-subprotocol" ||

--- a/apps/notebook-cloud/src/index.ts
+++ b/apps/notebook-cloud/src/index.ts
@@ -3,7 +3,6 @@ import type { BlobRef } from "runtimed";
 import { NotebookRoom } from "./notebook-room.ts";
 import {
   AuthError,
-  APP_SESSION_SYNC_TICKET_PROTOCOL_PREFIX,
   BEARER_AUTH_TOKEN_PROTOCOL_PREFIX,
   allowsBlobUpload,
   allowsPublish,
@@ -11,6 +10,7 @@ import {
   DEV_AUTH_TOKEN_HEADER,
   DEV_AUTH_TOKEN_PROTOCOL_PREFIX,
   isAnonymousViewer,
+  NOTEBOOK_CLOUD_WEBSOCKET_PROTOCOL,
   parseScope,
   stampTrustedIdentity,
   type AuthenticatedConnection,
@@ -108,15 +108,12 @@ import {
   withCors,
 } from "./http-responses.ts";
 import {
+  NOTEBOOK_CLOUD_APP_SESSION_COOKIE_NAME,
   NOTEBOOK_CLOUD_APP_SESSION_MAX_AGE_SECONDS,
-  NOTEBOOK_CLOUD_SYNC_TICKET_MAX_AGE_SECONDS,
   appSessionConfigured,
-  cloudSyncTicketFromWebSocketProtocol,
   clearCloudAppSessionCookie,
   createCloudAppSessionCookie,
-  createCloudSyncTicket,
   readCloudAppSession,
-  readCloudSyncTicket,
   type CloudAppSession,
 } from "./app-session.ts";
 
@@ -264,11 +261,6 @@ const NOTEBOOK_CLOUD_ROUTES: readonly WorkerRoute[] = [
     match: routePath("/api/n/:notebookId/access-requests", { trailingSlash: "optional" }),
     handler: ({ params }, request, env) =>
       routeNotebookAccessRequests(request, env, params.notebookId),
-  },
-  {
-    match: routePath("/api/n/:notebookId/sync-ticket", { trailingSlash: "optional" }),
-    methods: ["POST"],
-    handler: ({ params }, request, env) => routeNotebookSyncTicket(request, env, params.notebookId),
   },
   {
     match: routePath("/api/n/:notebookId/workstation-attachments", { trailingSlash: "optional" }),
@@ -432,8 +424,8 @@ async function routeRoomSync(request: Request, env: Env): Promise<Response> {
   if (!notebookId) {
     return json({ error: "notebook id is required" }, 400);
   }
-  const ticketIdentity = await cloudSyncTicketIdentityFromRequest(request, env, notebookId);
-  const identity = ticketIdentity ?? (await authenticateRequestOrResponse(request, env));
+  const appSessionIdentity = await appSessionIdentityFromWebSocketRequest(request, env);
+  const identity = appSessionIdentity ?? (await authenticateRequestOrResponse(request, env));
   if (identity instanceof Response) {
     return identity;
   }
@@ -456,59 +448,45 @@ async function routeRoomSync(request: Request, env: Env): Promise<Response> {
   return room.fetch(stampTrustedIdentity(request, authorizedIdentity));
 }
 
-async function cloudSyncTicketIdentityFromRequest(
+async function appSessionIdentityFromWebSocketRequest(
   request: Request,
   env: Env,
-  notebookId: string,
 ): Promise<AuthenticatedConnection | Response | null> {
-  let credential: ReturnType<typeof cloudSyncTicketFromWebSocketProtocol>;
+  if (!appSessionConfigured(env)) {
+    return null;
+  }
+  const session = await readCloudAppSession(env, request);
+  if (!session) {
+    return null;
+  }
+  if (hasExplicitIdentityCredential(request)) {
+    return json({ error: "multiple identity credentials presented" }, 400);
+  }
+  const url = new URL(request.url);
+  const requestedScope = parseBrowserAppSessionScope(url.searchParams.get("scope"));
+  if (requestedScope instanceof Response) {
+    return requestedScope;
+  }
+  const operator =
+    optionalBoundedStringField(url.searchParams.get("operator"), "operator", 256) ??
+    `browser:${crypto.randomUUID()}`;
+  if (operator instanceof Response) {
+    return operator;
+  }
   try {
-    credential = cloudSyncTicketFromWebSocketProtocol(
-      request.headers.get("sec-websocket-protocol"),
-    );
+    validateOperator(operator);
   } catch (error) {
     return json({ error: error instanceof Error ? error.message : String(error) }, 400);
   }
-  if (!credential) {
-    return null;
-  }
-  if (hasNonTicketIdentityCredential(request)) {
-    return json({ error: "multiple identity credentials presented" }, 400);
-  }
-  if (!appSessionConfigured(env)) {
-    return json({ error: "app sessions are not configured" }, 503);
-  }
-  const ticket = await readCloudSyncTicket(env, credential.ticket);
-  if (!ticket) {
-    return json({ error: "app-session sync ticket is invalid or expired" }, 401);
-  }
-  if (ticket.notebookId !== notebookId) {
-    return json({ error: "app-session sync ticket does not match this notebook" }, 403);
-  }
 
-  try {
-    validatePrincipal(ticket.principal);
-    validateOperator(ticket.operator);
-  } catch (error) {
-    return json({ error: error instanceof Error ? error.message : String(error) }, 401);
-  }
-
-  return {
-    principal: ticket.principal,
-    operator: ticket.operator,
-    actorLabel: `${ticket.principal}/${ticket.operator}`,
-    scope: ticket.scope,
-    metadata: {
-      provider: "app-session",
-      transport: "app-session-sync-ticket",
-      principalNamespace: ticket.principalNamespace,
-      ...(ticket.displayName ? { displayName: ticket.displayName } : {}),
-    },
-    ...(credential.webSocketProtocol ? { webSocketProtocol: credential.webSocketProtocol } : {}),
-  };
+  const identity = appSessionConnectionIdentity(session, operator, requestedScope);
+  const webSocketProtocol = applicationWebSocketProtocolFromHeader(
+    request.headers.get("Sec-WebSocket-Protocol"),
+  );
+  return webSocketProtocol ? { ...identity, webSocketProtocol } : identity;
 }
 
-function hasNonTicketIdentityCredential(request: Request): boolean {
+function hasExplicitIdentityCredential(request: Request): boolean {
   if (request.headers.has("authorization") || request.headers.has(DEV_AUTH_TOKEN_HEADER)) {
     return true;
   }
@@ -542,7 +520,7 @@ function rejectUntrustedWebSocketOrigin(request: Request, env: Env): Response | 
 }
 
 function requiresWebSocketOrigin(request: Request): boolean {
-  return hasCredentialWebSocketSubprotocol(request);
+  return hasCredentialWebSocketSubprotocol(request) || hasAppSessionCookie(request);
 }
 
 function rejectUntrustedMutationOrigin(request: Request, env: Env): Response | null {
@@ -600,12 +578,26 @@ function hasCredentialWebSocketSubprotocol(request: Request): boolean {
   return protocol
     .split(",")
     .some((part) =>
-      [
-        APP_SESSION_SYNC_TICKET_PROTOCOL_PREFIX,
-        BEARER_AUTH_TOKEN_PROTOCOL_PREFIX,
-        DEV_AUTH_TOKEN_PROTOCOL_PREFIX,
-      ].some((prefix) => part.trim().startsWith(prefix)),
+      [BEARER_AUTH_TOKEN_PROTOCOL_PREFIX, DEV_AUTH_TOKEN_PROTOCOL_PREFIX].some((prefix) =>
+        part.trim().startsWith(prefix),
+      ),
     );
+}
+
+function hasAppSessionCookie(request: Request): boolean {
+  const cookie = request.headers.get("Cookie");
+  if (!cookie) {
+    return false;
+  }
+  return cookie
+    .split(";")
+    .some((part) => part.trim().startsWith(`${NOTEBOOK_CLOUD_APP_SESSION_COOKIE_NAME}=`));
+}
+
+function applicationWebSocketProtocolFromHeader(value: string | null): string | undefined {
+  return value?.split(",").some((protocol) => protocol.trim() === NOTEBOOK_CLOUD_WEBSOCKET_PROTOCOL)
+    ? NOTEBOOK_CLOUD_WEBSOCKET_PROTOCOL
+    : undefined;
 }
 
 function anacondaApiKeyHealth(env: Env): {
@@ -676,75 +668,6 @@ function appSessionResponse(session: CloudAppSession): Record<string, unknown> {
   };
 }
 
-async function routeNotebookSyncTicket(
-  request: Request,
-  env: Env,
-  notebookId: string,
-): Promise<Response> {
-  const originRejection = rejectUntrustedMutationOrigin(request, env);
-  if (originRejection) {
-    return originRejection;
-  }
-  if (!appSessionConfigured(env)) {
-    return json({ error: "app sessions are not configured" }, 503);
-  }
-
-  const session = await readCloudAppSession(env, request);
-  if (!session) {
-    return json({ error: "app session is required" }, 401);
-  }
-
-  const payload = await readOptionalJsonObject(request, "sync ticket request");
-  if (payload instanceof Response) {
-    return payload;
-  }
-  const requestedScope = parseBrowserSyncTicketScope(payload?.scope);
-  if (requestedScope instanceof Response) {
-    return requestedScope;
-  }
-  const operator =
-    optionalBoundedStringField(payload?.operator, "operator", 256) ??
-    `browser:${crypto.randomUUID()}`;
-  if (operator instanceof Response) {
-    return operator;
-  }
-  try {
-    validateOperator(operator);
-  } catch (error) {
-    return json({ error: error instanceof Error ? error.message : String(error) }, 400);
-  }
-
-  const identity = appSessionConnectionIdentity(session, operator, requestedScope);
-  const authorizedIdentity = await authorizeIdentityOrResponse(
-    env,
-    notebookId,
-    identity,
-    requestedScope,
-    {
-      allowViewerDowngrade: true,
-      allowLiveScopeDowngrade: true,
-    },
-  );
-  if (authorizedIdentity instanceof Response) {
-    return authorizedIdentity;
-  }
-  if (authorizedIdentity.scope === "runtime_peer") {
-    return json({ error: "browser app sessions cannot request runtime_peer scope" }, 403);
-  }
-
-  const ticket = await createCloudSyncTicket(env, session, {
-    notebookId,
-    operator,
-    scope: authorizedIdentity.scope,
-  });
-  return json({
-    ok: true,
-    ticket,
-    expires_in: NOTEBOOK_CLOUD_SYNC_TICKET_MAX_AGE_SECONDS,
-    scope: authorizedIdentity.scope,
-  });
-}
-
 function appSessionConnectionIdentity(
   session: CloudAppSession,
   operator: string,
@@ -764,7 +687,7 @@ function appSessionConnectionIdentity(
   };
 }
 
-function parseBrowserSyncTicketScope(
+function parseBrowserAppSessionScope(
   value: unknown,
 ): Exclude<ConnectionScope, "runtime_peer"> | Response {
   if (value === undefined || value === null || value === "") {
@@ -3531,7 +3454,6 @@ async function viewer(
     },
     session: session ? appSessionResponse(session) : null,
     syncEndpoint: `/n/${encodeURIComponent(notebookId)}/sync`,
-    syncTicketEndpoint: `${notebookApiBasePath}/sync-ticket`,
     blobBasePath: notebookCloudBlobBasePath(notebookId),
     rendererAssetsBasePath: rendererAssetsBasePath(env),
     outputDocumentBaseUrl: outputDocumentBaseUrl(env),

--- a/apps/notebook-cloud/test/app-session.test.ts
+++ b/apps/notebook-cloud/test/app-session.test.ts
@@ -4,13 +4,9 @@ import {
   NOTEBOOK_CLOUD_APP_SESSION_COOKIE_NAME,
   NOTEBOOK_CLOUD_APP_SESSION_DISPLAY_NAME_MAX_LENGTH,
   NOTEBOOK_CLOUD_APP_SESSION_MAX_AGE_SECONDS,
-  NOTEBOOK_CLOUD_SYNC_TICKET_MAX_AGE_SECONDS,
-  cloudSyncTicketFromWebSocketProtocol,
   clearCloudAppSessionCookie,
   createCloudAppSessionCookie,
-  createCloudSyncTicket,
   readCloudAppSession,
-  readCloudSyncTicket,
 } from "../src/app-session";
 import type { AuthenticatedConnection } from "../src/identity";
 
@@ -107,61 +103,6 @@ describe("cloud app session cookies", () => {
       headers: { Cookie: tampered },
     });
     assert.equal(await readCloudAppSession(env, tamperedRequest, 3_100), null);
-  });
-
-  it("mints short-lived sync tickets from app sessions", async () => {
-    const env = { NOTEBOOK_CLOUD_APP_SESSION_SECRET: SESSION_SECRET };
-    const cookie = await createCloudAppSessionCookie(env, oidcIdentity(), 4_000);
-    const session = await readCloudAppSession(
-      env,
-      new Request("https://cloud.test/n", {
-        headers: { Cookie: cookie },
-      }),
-      4_010,
-    );
-    assert.ok(session);
-
-    const ticket = await createCloudSyncTicket(
-      env,
-      session,
-      {
-        notebookId: "notebook-a",
-        operator: "browser:tab-a",
-        scope: "editor",
-      },
-      4_020,
-    );
-
-    const parsed = await readCloudSyncTicket(env, ticket, 4_030);
-    assert.deepEqual(parsed, {
-      principal: "user:anaconda:subject-a",
-      principalNamespace: "user:anaconda",
-      operator: "browser:tab-a",
-      notebookId: "notebook-a",
-      scope: "editor",
-      issuedAt: 4_020,
-      expiresAt: 4_020 + NOTEBOOK_CLOUD_SYNC_TICKET_MAX_AGE_SECONDS,
-      displayName: "OIDC User",
-    });
-    assert.equal(
-      await readCloudSyncTicket(
-        env,
-        ticket,
-        4_020 + NOTEBOOK_CLOUD_SYNC_TICKET_MAX_AGE_SECONDS + 1,
-      ),
-      null,
-    );
-  });
-
-  it("extracts app-session sync tickets from WebSocket subprotocols", async () => {
-    const credential = cloudSyncTicketFromWebSocketProtocol(
-      "nteract-app-session.dGlja2V0LXZhbHVl, nteract.v4",
-    );
-
-    assert.deepEqual(credential, {
-      ticket: "ticket-value",
-      webSocketProtocol: "nteract.v4",
-    });
   });
 
   it("requires a configured signing secret and OIDC identity", async () => {

--- a/apps/notebook-cloud/test/collaborator-auth.test.ts
+++ b/apps/notebook-cloud/test/collaborator-auth.test.ts
@@ -10,7 +10,7 @@ import {
   cloudHttpHeadersFromPrototypeAuthState,
   cloudNotebookSignInCopy,
   clearCloudPrototypeDevAuth,
-  cloudSyncAuthFromAppSessionTicket,
+  cloudSyncAuthFromAppSessionCookie,
   cloudSyncAuthFromPrototypeAuthState,
   withCloudPrototypeAuthHeaders,
   isCloudPrototypeAuthStorageKey,
@@ -165,34 +165,18 @@ describe("cloud collaborator auth", () => {
     assert.equal(headers.get("X-Scope"), "editor");
   });
 
-  it("mints WebSocket ticket auth from the app-session endpoint", async () => {
-    const auth = await cloudSyncAuthFromAppSessionTicket({
-      endpoint: "/api/n/notebook-a/sync-ticket",
+  it("uses the app-session cookie directly for browser WebSocket auth", () => {
+    const auth = cloudSyncAuthFromAppSessionCookie({
       requestedScope: "editor",
       sessionId: "session/one",
-      fetchImpl: async (input, init) => {
-        assert.equal(input, "/api/n/notebook-a/sync-ticket");
-        assert.equal(init?.method, "POST");
-        assert.equal(init?.credentials, "same-origin");
-        assert.deepEqual(JSON.parse(String(init?.body)), {
-          operator: "browser:session%2Fone",
-          scope: "editor",
-        });
-        return Response.json({
-          ok: true,
-          ticket: "ticket-value",
-          expires_in: 90,
-          scope: "viewer",
-        });
-      },
     });
 
     assert.deepEqual(auth, {
       headers: {},
-      protocols: ["nteract-app-session.dGlja2V0LXZhbHVl", "nteract.v4"],
+      protocols: ["nteract.v4"],
       user: null,
       operator: "browser:session%2Fone",
-      requestedScope: "viewer",
+      requestedScope: "editor",
     });
   });
 

--- a/apps/notebook-cloud/test/viewer-shared-cell-surface.test.ts
+++ b/apps/notebook-cloud/test/viewer-shared-cell-surface.test.ts
@@ -278,11 +278,13 @@ test("cloud edit mode chrome renders through the shared shell component", () => 
   assert.match(sourceText, /editAccessRequestPending/);
   assert.match(sourceText, /onModeChange=\{setSelectedInteractionMode\}/);
   assert.match(sourceText, /onRequestEditAccess=\{requestCloudEditAccess\}/);
-  assert.match(
-    sourceText,
-    /const requestedEditAccess = roomEditAccess\.requestedDocumentEditAccess/,
-  );
   assert.match(sourceText, /const editAccessPending = roomEditAccess\.editAccessPending/);
+  assert.doesNotMatch(sourceText, /appliedGrantedEditScopeRef/);
+  assert.doesNotMatch(sourceText, /requestedEditAccess/);
+  assert.doesNotMatch(
+    sourceText,
+    /setSelectedInteractionMode\("edit"\);[\s\S]*\[canAcceptCellMutations, connectionPeerId, connectionScope/,
+  );
   assert.match(sourceText, /accessPending=\{editAccessPending\}/);
   assert.match(sourceText, /state=\{accessPending \? "viewing" : interaction\.state\}/);
   assert.match(sourceText, /disabled=\{accessPending\}/);
@@ -479,14 +481,14 @@ test("cloud app-session bridge refreshes cookie-backed state after OIDC exchange
   assert.match(sourceText, /\[authState, bootstrap, hasAppSession, refreshIndex, signedIn\]/);
 });
 
-test("cloud app-session live tickets request owner and let the backend downgrade", () => {
+test("cloud app-session live sync requests owner and lets the backend downgrade", () => {
   const sourcePath = new URL("../viewer/index.tsx", import.meta.url);
   const sourceText = readFileSync(sourcePath, "utf8");
 
-  assert.match(sourceText, /cloudSyncAuthFromAppSessionTicket\(\{[\s\S]*requestedScope: "owner"/);
+  assert.match(sourceText, /cloudSyncAuthFromAppSessionCookie\(\{[\s\S]*requestedScope: "owner"/);
   assert.doesNotMatch(
     sourceText,
-    /cloudSyncAuthFromAppSessionTicket\(\{[\s\S]*requestedScope: authState\.requestedScope/,
+    /cloudSyncAuthFromAppSessionCookie\(\{[\s\S]*requestedScope: authState\.requestedScope/,
   );
 });
 

--- a/apps/notebook-cloud/test/viewer-shell-capabilities.test.ts
+++ b/apps/notebook-cloud/test/viewer-shell-capabilities.test.ts
@@ -278,6 +278,57 @@ test("cloud shell capabilities keep user-selected view mode read-only even with 
   assert.equal(capabilities.runtime.canWriteRuntimeState, false);
 });
 
+test("cloud shell capabilities hide execution in view mode even for owners with compute", () => {
+  const viewMode = cloudNotebookShellCapabilities({
+    authState: authState("oidc", "owner"),
+    connectionScope: "owner",
+    hasCodeCells: true,
+    selectedMode: "view",
+    workstationAttachment: {
+      workstation_id: "ws-lab2",
+      display_name: "Lab 2",
+      provider: "local_daemon",
+      default_environment_label: "Current Python",
+      environment_policy: "current_python",
+      status: "ready",
+      status_message: null,
+      cpu_count: 8,
+      memory_bytes: 32 * 1024 ** 3,
+      working_directory: "/home/ubuntu/notebooks",
+      updated_at: "2026-06-07T21:00:00Z",
+    },
+  });
+  const editMode = cloudNotebookShellCapabilities({
+    authState: authState("oidc", "owner"),
+    connectionScope: "owner",
+    hasCodeCells: true,
+    selectedMode: "edit",
+    workstationAttachment: {
+      workstation_id: "ws-lab2",
+      display_name: "Lab 2",
+      provider: "local_daemon",
+      default_environment_label: "Current Python",
+      environment_policy: "current_python",
+      status: "ready",
+      status_message: null,
+      cpu_count: 8,
+      memory_bytes: 32 * 1024 ** 3,
+      working_directory: "/home/ubuntu/notebooks",
+      updated_at: "2026-06-07T21:00:00Z",
+    },
+  });
+
+  assert.equal(viewMode.access.level, "owner");
+  assert.equal(viewMode.interaction?.activeMode, "view");
+  assert.equal(viewMode.runtime.executionAvailable, true);
+  assert.equal(viewMode.canExecute, false);
+
+  assert.equal(editMode.access.level, "owner");
+  assert.equal(editMode.interaction?.activeMode, "edit");
+  assert.equal(editMode.runtime.executionAvailable, true);
+  assert.equal(editMode.canExecute, true);
+});
+
 test("cloud shell capabilities keep selected mode separate from requested auth scope", () => {
   const viewerMode = cloudNotebookShellCapabilities({
     authState: authState("oidc", "editor"),

--- a/apps/notebook-cloud/test/worker-routes.test.ts
+++ b/apps/notebook-cloud/test/worker-routes.test.ts
@@ -4,7 +4,6 @@ import { readFile } from "node:fs/promises";
 import worker from "../src/index.ts";
 import { NOTEBOOK_CLOUD_APP_SESSION_COOKIE_NAME } from "../src/app-session.ts";
 import {
-  APP_SESSION_SYNC_TICKET_PROTOCOL_PREFIX,
   BEARER_AUTH_TOKEN_PROTOCOL_PREFIX,
   DEV_AUTH_TOKEN_PROTOCOL_PREFIX,
   NOTEBOOK_CLOUD_WEBSOCKET_PROTOCOL,
@@ -546,18 +545,18 @@ describe("Worker artifact routes", () => {
     assert.equal(explicitBadBearer.status, 401);
   });
 
-  it("does not use app session cookies as room WebSocket credentials", async () => {
+  it("uses app-session cookies as same-origin room WebSocket credentials", async () => {
     const { env: oidcEnv, token } = await oidcTokenFixture({ subject: "cookie-ws-user" });
-    let roomFetches = 0;
+    let forwardedRequest: Request | undefined;
     const env = fakeEnv({
       ...oidcEnv,
       NOTEBOOK_CLOUD_APP_SESSION_SECRET: APP_SESSION_SECRET,
       NOTEBOOK_ROOMS: {
         idFromName: (name: string) => ({ toString: () => name }),
         get: () => ({
-          fetch: async () => {
-            roomFetches += 1;
-            return new Response("unexpected room fetch", { status: 500 });
+          fetch: async (request: Request) => {
+            forwardedRequest = request;
+            return new Response("room ok");
           },
         }),
       } satisfies DurableObjectNamespace,
@@ -575,73 +574,7 @@ describe("Worker artifact routes", () => {
         headers: {
           Cookie: cookie,
           Origin: "https://cloud.test",
-          Upgrade: "websocket",
-        },
-      }),
-      env,
-      fakeContext(),
-    );
-
-    assert.equal(response.status, 404);
-    assert.equal(roomFetches, 0);
-  });
-
-  it("mints app-session sync tickets and forwards them as trusted room identity", async () => {
-    const { env: oidcEnv, token } = await oidcTokenFixture({
-      subject: "cookie-ticket-user",
-      name: "Cookie Ticket User",
-    });
-    let forwardedRequest: Request | undefined;
-    const env = fakeEnv({
-      ...oidcEnv,
-      NOTEBOOK_CLOUD_APP_SESSION_SECRET: APP_SESSION_SECRET,
-      NOTEBOOK_ROOMS: {
-        idFromName: (name: string) => ({ toString: () => name }),
-        get: () => ({
-          fetch: async (request: Request) => {
-            forwardedRequest = request;
-            return new Response("room ok");
-          },
-        }),
-      } satisfies DurableObjectNamespace,
-    });
-    seedNotebook(env, "cookie-ticket-private");
-    seedAcl(env, {
-      notebookId: "cookie-ticket-private",
-      subject: "user:anaconda:cookie-ticket-user",
-      scope: "owner",
-    });
-    const cookie = await oidcAppSessionCookie(env, token);
-
-    const mint = await worker.fetch(
-      new Request("https://cloud.test/api/n/cookie-ticket-private/sync-ticket", {
-        method: "POST",
-        headers: {
-          Cookie: cookie,
-          "Content-Type": "application/json",
-          Origin: "https://cloud.test",
-        },
-        body: JSON.stringify({ operator: "browser:tab-cookie", scope: "owner" }),
-      }),
-      env,
-      fakeContext(),
-    );
-    assert.equal(mint.status, 200);
-    const ticketBody = (await mint.json()) as {
-      expires_in: number;
-      scope: string;
-      ticket: string;
-    };
-    assert.equal(ticketBody.scope, "owner");
-    assert.equal(typeof ticketBody.ticket, "string");
-
-    const response = await worker.fetch(
-      new Request("https://cloud.test/n/cookie-ticket-private/sync?scope=owner", {
-        headers: {
-          Origin: "https://cloud.test",
-          "Sec-WebSocket-Protocol": `${APP_SESSION_SYNC_TICKET_PROTOCOL_PREFIX}${base64Url(
-            ticketBody.ticket,
-          )}, ${NOTEBOOK_CLOUD_WEBSOCKET_PROTOCOL}`,
+          "Sec-WebSocket-Protocol": NOTEBOOK_CLOUD_WEBSOCKET_PROTOCOL,
           Upgrade: "websocket",
         },
       }),
@@ -662,7 +595,7 @@ describe("Worker artifact routes", () => {
     assert.equal(forwardedRequest.headers.get(TRUSTED_SCOPE_HEADER), "owner");
   });
 
-  it("rejects app-session sync tickets combined with other credentials", async () => {
+  it("rejects app-session WebSockets combined with explicit bearer credentials", async () => {
     const { env: oidcEnv, token } = await oidcTokenFixture({ subject: "cookie-mixed-user" });
     const env = fakeEnv({
       ...oidcEnv,
@@ -675,29 +608,15 @@ describe("Worker artifact routes", () => {
       scope: "owner",
     });
     const cookie = await oidcAppSessionCookie(env, token);
-    const mint = await worker.fetch(
-      new Request("https://cloud.test/api/n/cookie-mixed-ticket/sync-ticket", {
-        method: "POST",
-        headers: {
-          Cookie: cookie,
-          "Content-Type": "application/json",
-          Origin: "https://cloud.test",
-        },
-        body: JSON.stringify({ operator: "browser:tab-cookie", scope: "owner" }),
-      }),
-      env,
-      fakeContext(),
-    );
-    assert.equal(mint.status, 200);
-    const ticketBody = (await mint.json()) as { ticket: string };
 
     const response = await worker.fetch(
       new Request("https://cloud.test/n/cookie-mixed-ticket/sync?scope=owner", {
         headers: {
+          Cookie: cookie,
           Origin: "https://cloud.test",
-          "Sec-WebSocket-Protocol": `${APP_SESSION_SYNC_TICKET_PROTOCOL_PREFIX}${base64Url(
-            ticketBody.ticket,
-          )}, ${BEARER_AUTH_TOKEN_PROTOCOL_PREFIX}${base64Url(token)}, ${NOTEBOOK_CLOUD_WEBSOCKET_PROTOCOL}`,
+          "Sec-WebSocket-Protocol": `${BEARER_AUTH_TOKEN_PROTOCOL_PREFIX}${base64Url(
+            token,
+          )}, ${NOTEBOOK_CLOUD_WEBSOCKET_PROTOCOL}`,
           Upgrade: "websocket",
         },
       }),
@@ -709,7 +628,7 @@ describe("Worker artifact routes", () => {
     assert.deepEqual(await response.json(), { error: "multiple identity credentials presented" });
   });
 
-  it("rejects app-session sync ticket WebSockets without an origin", async () => {
+  it("rejects app-session cookie WebSockets without an origin", async () => {
     const { env: oidcEnv, token } = await oidcTokenFixture({ subject: "cookie-origin-user" });
     const env = fakeEnv({
       ...oidcEnv,
@@ -722,28 +641,12 @@ describe("Worker artifact routes", () => {
       scope: "owner",
     });
     const cookie = await oidcAppSessionCookie(env, token);
-    const mint = await worker.fetch(
-      new Request("https://cloud.test/api/n/cookie-origin-ticket/sync-ticket", {
-        method: "POST",
-        headers: {
-          Cookie: cookie,
-          "Content-Type": "application/json",
-          Origin: "https://cloud.test",
-        },
-        body: JSON.stringify({ operator: "browser:tab-cookie", scope: "owner" }),
-      }),
-      env,
-      fakeContext(),
-    );
-    assert.equal(mint.status, 200);
-    const ticketBody = (await mint.json()) as { ticket: string };
 
     const response = await worker.fetch(
       new Request("https://cloud.test/n/cookie-origin-ticket/sync?scope=owner", {
         headers: {
-          "Sec-WebSocket-Protocol": `${APP_SESSION_SYNC_TICKET_PROTOCOL_PREFIX}${base64Url(
-            ticketBody.ticket,
-          )}, ${NOTEBOOK_CLOUD_WEBSOCKET_PROTOCOL}`,
+          Cookie: cookie,
+          "Sec-WebSocket-Protocol": NOTEBOOK_CLOUD_WEBSOCKET_PROTOCOL,
           Upgrade: "websocket",
         },
       }),
@@ -755,44 +658,21 @@ describe("Worker artifact routes", () => {
     assert.deepEqual(await response.json(), { error: "websocket origin is required" });
   });
 
-  it("downgrades app-session sync tickets to granted viewer scope", async () => {
-    const { env: oidcEnv, token } = await oidcTokenFixture({ subject: "cookie-viewer-user" });
-    const env = fakeEnv({
-      ...oidcEnv,
-      NOTEBOOK_CLOUD_APP_SESSION_SECRET: APP_SESSION_SECRET,
-    });
-    seedNotebook(env, "cookie-ticket-viewer");
-    seedAcl(env, {
-      notebookId: "cookie-ticket-viewer",
-      subject: "user:anaconda:cookie-viewer-user",
-      scope: "viewer",
-    });
-    const cookie = await oidcAppSessionCookie(env, token);
-
-    const mint = await worker.fetch(
-      new Request("https://cloud.test/api/n/cookie-ticket-viewer/sync-ticket", {
-        method: "POST",
-        headers: {
-          Cookie: cookie,
-          "Content-Type": "application/json",
-          Origin: "https://cloud.test",
-        },
-        body: JSON.stringify({ operator: "browser:tab-cookie", scope: "editor" }),
-      }),
-      env,
-      fakeContext(),
-    );
-
-    assert.equal(mint.status, 200);
-    const ticketBody = (await mint.json()) as { scope: string; ticket: string };
-    assert.equal(ticketBody.scope, "viewer");
-  });
-
-  it("downgrades optimistic owner app-session sync tickets to the best granted live scope", async () => {
+  it("downgrades optimistic owner app-session WebSockets to the best granted live scope", async () => {
     const { env: oidcEnv, token } = await oidcTokenFixture({ subject: "cookie-editor-user" });
+    let forwardedRequest: Request | undefined;
     const env = fakeEnv({
       ...oidcEnv,
       NOTEBOOK_CLOUD_APP_SESSION_SECRET: APP_SESSION_SECRET,
+      NOTEBOOK_ROOMS: {
+        idFromName: (name: string) => ({ toString: () => name }),
+        get: () => ({
+          fetch: async (request: Request) => {
+            forwardedRequest = request;
+            return new Response("room ok");
+          },
+        }),
+      } satisfies DurableObjectNamespace,
     });
     seedNotebook(env, "cookie-ticket-editor");
     seedAcl(env, {
@@ -802,26 +682,25 @@ describe("Worker artifact routes", () => {
     });
     const cookie = await oidcAppSessionCookie(env, token);
 
-    const mint = await worker.fetch(
-      new Request("https://cloud.test/api/n/cookie-ticket-editor/sync-ticket", {
-        method: "POST",
+    const response = await worker.fetch(
+      new Request("https://cloud.test/n/cookie-ticket-editor/sync?scope=owner", {
         headers: {
           Cookie: cookie,
-          "Content-Type": "application/json",
           Origin: "https://cloud.test",
+          "Sec-WebSocket-Protocol": NOTEBOOK_CLOUD_WEBSOCKET_PROTOCOL,
+          Upgrade: "websocket",
         },
-        body: JSON.stringify({ operator: "browser:tab-cookie", scope: "owner" }),
       }),
       env,
       fakeContext(),
     );
 
-    assert.equal(mint.status, 200);
-    const ticketBody = (await mint.json()) as { scope: string; ticket: string };
-    assert.equal(ticketBody.scope, "editor");
+    assert.equal(response.status, 200);
+    assert.ok(forwardedRequest);
+    assert.equal(forwardedRequest.headers.get(TRUSTED_SCOPE_HEADER), "editor");
   });
 
-  it("does not mint runtime_peer tickets for app-session browsers", async () => {
+  it("rejects runtime_peer scope for app-session browser WebSockets", async () => {
     const { env: oidcEnv, token } = await oidcTokenFixture({ subject: "cookie-runtime-user" });
     const env = fakeEnv({
       ...oidcEnv,
@@ -835,22 +714,21 @@ describe("Worker artifact routes", () => {
     });
     const cookie = await oidcAppSessionCookie(env, token);
 
-    const mint = await worker.fetch(
-      new Request("https://cloud.test/api/n/cookie-runtime-ticket/sync-ticket", {
-        method: "POST",
+    const response = await worker.fetch(
+      new Request("https://cloud.test/n/cookie-runtime-ticket/sync?scope=runtime_peer", {
         headers: {
           Cookie: cookie,
-          "Content-Type": "application/json",
           Origin: "https://cloud.test",
+          "Sec-WebSocket-Protocol": NOTEBOOK_CLOUD_WEBSOCKET_PROTOCOL,
+          Upgrade: "websocket",
         },
-        body: JSON.stringify({ operator: "browser:tab-cookie", scope: "runtime_peer" }),
       }),
       env,
       fakeContext(),
     );
 
-    assert.equal(mint.status, 403);
-    assert.deepEqual(await mint.json(), {
+    assert.equal(response.status, 403);
+    assert.deepEqual(await response.json(), {
       error: "browser app sessions cannot request runtime_peer scope",
     });
   });

--- a/apps/notebook-cloud/viewer/cloud-viewer-session.ts
+++ b/apps/notebook-cloud/viewer/cloud-viewer-session.ts
@@ -68,7 +68,6 @@ export interface CloudViewerConfig {
   };
   session?: CloudAppSession | null;
   syncEndpoint: string;
-  syncTicketEndpoint?: string;
   blobBasePath: string;
   rendererAssetsBasePath: string;
   outputDocumentBaseUrl: string | null;

--- a/apps/notebook-cloud/viewer/collaborator-auth.ts
+++ b/apps/notebook-cloud/viewer/collaborator-auth.ts
@@ -1,5 +1,4 @@
 import {
-  APP_SESSION_SYNC_TICKET_PROTOCOL_PREFIX,
   BEARER_AUTH_TOKEN_PROTOCOL_PREFIX,
   DEV_AUTH_TOKEN_HEADER,
   DEV_AUTH_TOKEN_PROTOCOL_PREFIX,
@@ -59,18 +58,9 @@ export interface CloudPrototypeAuthInput {
   scope: ConnectionScope;
 }
 
-export interface CloudSyncTicketAuthOptions {
-  endpoint: string;
+export interface CloudAppSessionCookieAuthOptions {
   requestedScope: ConnectionScope | null;
   sessionId: string;
-  fetchImpl?: typeof fetch;
-}
-
-interface CloudSyncTicketResponse {
-  ok: true;
-  ticket: string;
-  expires_in: number;
-  scope: Exclude<ConnectionScope, "runtime_peer">;
 }
 
 export interface CloudPrototypeConnectionDiagnostics {
@@ -208,41 +198,17 @@ export function cloudSyncAuthFromPrototypeAuthState(state: CloudPrototypeAuthSta
   };
 }
 
-export async function cloudSyncAuthFromAppSessionTicket({
-  endpoint,
+export function cloudSyncAuthFromAppSessionCookie({
   requestedScope,
   sessionId,
-  fetchImpl = fetch,
-}: CloudSyncTicketAuthOptions): Promise<CloudSyncAuth> {
+}: CloudAppSessionCookieAuthOptions): CloudSyncAuth {
   const operator = `browser:${encodeURIComponent(sessionId)}`;
-  const scope = requestedScope ?? NOTEBOOK_CLOUD_DEFAULT_SCOPE;
-  const response = await fetchImpl(endpoint, {
-    method: "POST",
-    credentials: "same-origin",
-    headers: {
-      Accept: "application/json",
-      "Content-Type": "application/json",
-    },
-    body: JSON.stringify({ operator, scope }),
-  });
-  if (!response.ok) {
-    throw new Error(`Unable to mint live room ticket: ${response.status}`);
-  }
-
-  const body = (await response.json()) as unknown;
-  if (!isCloudSyncTicketResponse(body)) {
-    throw new Error("Unable to mint live room ticket: response shape was invalid");
-  }
-
   return {
     headers: {},
-    protocols: [
-      `${APP_SESSION_SYNC_TICKET_PROTOCOL_PREFIX}${base64UrlEncode(body.ticket)}`,
-      NOTEBOOK_CLOUD_WEBSOCKET_PROTOCOL,
-    ],
+    protocols: [NOTEBOOK_CLOUD_WEBSOCKET_PROTOCOL],
     user: null,
     operator,
-    requestedScope: body.scope,
+    requestedScope: requestedScope ?? NOTEBOOK_CLOUD_DEFAULT_SCOPE,
   };
 }
 
@@ -436,7 +402,7 @@ export function prototypeAuthDiagnostics(
       {
         label: "Credential",
         value:
-          "OIDC bearer token cached for sign-in renewal; first-party APIs use an app-session cookie and sync-ticket WebSockets.",
+          "OIDC bearer token cached for sign-in renewal; first-party APIs and live sync use the app-session cookie.",
       },
     );
     if (state.oidcClaims?.sub) {
@@ -576,22 +542,6 @@ function anonymousAuthState(): CloudPrototypeAuthState {
 
 function parseStoredScope(value: string | null): ConnectionScope | null {
   return isConnectionScope(value) ? value : null;
-}
-
-function isCloudSyncTicketResponse(value: unknown): value is CloudSyncTicketResponse {
-  if (!value || typeof value !== "object") {
-    return false;
-  }
-  const candidate = value as Record<string, unknown>;
-  const scope = candidate.scope;
-  return (
-    candidate.ok === true &&
-    typeof candidate.ticket === "string" &&
-    Number.isFinite(candidate.expires_in) &&
-    typeof scope === "string" &&
-    isConnectionScope(scope) &&
-    scope !== "runtime_peer"
-  );
 }
 
 function base64UrlEncode(value: string): string {

--- a/apps/notebook-cloud/viewer/index.tsx
+++ b/apps/notebook-cloud/viewer/index.tsx
@@ -75,7 +75,7 @@ import {
   cloudNotebookSignInCopy,
   cloudPrototypeAuthFromWindow,
   fetchWithCloudPrototypeAuth,
-  cloudSyncAuthFromAppSessionTicket,
+  cloudSyncAuthFromAppSessionCookie,
   cloudSyncAuthFromPrototypeAuthState,
   isCloudPrototypeAuthStorageKey,
   prepareCloudOidcViewerLogin,
@@ -286,7 +286,6 @@ function loadConfig(): CloudViewerConfig {
     },
     session: isCloudAppSession(parsed.session) ? parsed.session : null,
     syncEndpoint: parsed.syncEndpoint,
-    syncTicketEndpoint: parsed.syncTicketEndpoint,
     blobBasePath: parsed.blobBasePath,
     rendererAssetsBasePath: parsed.rendererAssetsBasePath,
     outputDocumentBaseUrl: parsed.outputDocumentBaseUrl ?? null,
@@ -1742,7 +1741,6 @@ function NotebookViewer({
   const [selectedInteractionMode, setSelectedInteractionMode] =
     useState<NotebookInteractionMode>("view");
   const [emptyRoomGraceElapsed, setEmptyRoomGraceElapsed] = useState(false);
-  const appliedGrantedEditScopeRef = useRef<string | null>(null);
   const blobResolver = useMemo(
     () =>
       createNotebookCloudBlobResolver({
@@ -1767,19 +1765,18 @@ function NotebookViewer({
     async (sessionId: string) => {
       const appSession =
         appSessionStatus.session ??
-        (appSessionStatus.status === "loading" && config.syncTicketEndpoint
+        (appSessionStatus.status === "loading"
           ? ((await readCloudAppSessionStatus().catch(() => null))?.session ?? null)
           : null);
-      if (appSession && config.syncTicketEndpoint) {
-        return cloudSyncAuthFromAppSessionTicket({
-          endpoint: config.syncTicketEndpoint,
+      if (appSession) {
+        return cloudSyncAuthFromAppSessionCookie({
           requestedScope: "owner",
           sessionId,
         });
       }
       return cloudSyncAuthFromPrototypeAuthState(authState);
     },
-    [appSessionStatus.session, appSessionStatus.status, authState, config.syncTicketEndpoint],
+    [appSessionStatus.session, appSessionStatus.status, authState],
   );
   const {
     connectionActorLabel,
@@ -2004,7 +2001,6 @@ function NotebookViewer({
       selectedInteractionMode,
     ],
   );
-  const requestedEditAccess = roomEditAccess.requestedDocumentEditAccess;
   const editAccessPending = roomEditAccess.editAccessPending;
   const shellCapabilities = useMemo(
     () =>
@@ -2139,26 +2135,6 @@ function NotebookViewer({
       setWorkstationMutation({ kind: "idle", message: null, workstationId: null });
     }
   }, [workstationAttachment?.workstation_id, workstationMutation]);
-  useEffect(() => {
-    if (!requestedEditAccess) {
-      appliedGrantedEditScopeRef.current = null;
-      return;
-    }
-    if (
-      !canAcceptCellMutations ||
-      (connectionScope !== "editor" && connectionScope !== "owner") ||
-      !connectionPeerId
-    ) {
-      return;
-    }
-
-    const grantKey = `${connectionPeerId}:${connectionScope}`;
-    if (appliedGrantedEditScopeRef.current === grantKey) {
-      return;
-    }
-    appliedGrantedEditScopeRef.current = grantKey;
-    setSelectedInteractionMode("edit");
-  }, [canAcceptCellMutations, connectionPeerId, connectionScope, requestedEditAccess]);
   const canWriteCellSource = useCallback(
     (cellId: string) => {
       const cell = getCellById(cellId);

--- a/apps/notebook-cloud/viewer/shell-capabilities.ts
+++ b/apps/notebook-cloud/viewer/shell-capabilities.ts
@@ -150,6 +150,7 @@ export function cloudNotebookShellCapabilities({
       available: effectiveRuntimeAvailable,
       canSubmit: connectionScope === "owner",
       requiresDocumentEditPermission: true,
+      requiresDocumentMutationSupport: true,
     },
     packages: {
       canView: true,

--- a/docs/adr/hosted-credential-transport.md
+++ b/docs/adr/hosted-credential-transport.md
@@ -70,28 +70,36 @@ The room ACL still derives final connection scope. A provider claim or group may
 cap what the credential can do globally, but it does not grant per-notebook
 editor or owner access by itself.
 
-## Decision 2: Direct OIDC is the hosted browser path for preview
+## Decision 2: Direct OIDC bootstraps hosted app sessions for preview
 
-For the Anaconda-friendly hosted demo, the notebook application owns the OIDC
-browser flow directly:
+For the Anaconda-friendly hosted preview, the notebook application owns the
+OIDC browser flow directly, but OIDC bearer tokens are not the default
+credential for first-party browser app APIs or live-room WebSockets:
 
 1. Browser visits the notebook host.
 2. The viewer/editor shell starts an OIDC Authorization Code + PKCE flow against
    the configured issuer.
 3. The OIDC provider redirects back to the notebook host's `/oidc` callback.
-4. The browser stores the short-lived access token in origin-local storage and
-   refreshes it through the normal OIDC refresh path.
-5. Browser HTTP requests use `Authorization: Bearer <access-token>` when the
-   platform allows headers.
-6. Browser WebSockets use the non-echoed credential subprotocol
-   `nteract-bearer.<base64url-token>` plus the application protocol
-   `nteract.v4`.
-7. Native, CLI, agent, and runtime clients use `Authorization: Bearer
+4. The browser exchanges the validated OIDC bearer at `/api/auth/session` for
+   a first-party, HttpOnly, Secure, SameSite=Lax app-session cookie.
+5. Browser HTTP requests to first-party app APIs use the app-session cookie
+   with same-origin credentials.
+6. Browser live-room WebSockets also use the app-session cookie, but only when
+   the upgrade carries a trusted `Origin`. The Worker rejects missing or
+   untrusted origins for cookie-backed WebSockets, rejects mixed app-session
+   cookies plus explicit bearer/dev credentials, and forwards only trusted
+   identity headers plus the non-sensitive `nteract.v4` application protocol to
+   the room Durable Object.
+7. The browser may keep OIDC token state only for sign-in renewal and for
+   re-establishing the app-session cookie when needed. Sandboxed output frames
+   stay on the isolated output origin and must not receive app-session cookies,
+   OIDC material, or app-origin localStorage.
+8. Native, CLI, agent, and runtime clients use `Authorization: Bearer
    <access-token>` directly on HTTP and WebSocket requests.
-8. The Worker validates the OIDC JWT signature, issuer, audience/client id,
+9. The Worker validates the OIDC JWT signature, issuer, audience/client id,
    expiry, and not-before claims against the provider JWKS before calling the
    room ACL authorization path.
-9. The Durable Object receives only trusted headers stamped by the Worker. It
+10. The Durable Object receives only trusted headers stamped by the Worker. It
    never trusts browser-provided identity headers.
 
 Cloudflare still hosts the Worker, Durable Object, D1, R2, assets, and custom
@@ -130,7 +138,7 @@ principal key. If a later deployment validates another OIDC provider, it must
 use a provider-specific namespace and include an explicit subject mapping or
 ACL-row backfill plan before linking those users to Anaconda subjects.
 
-## Decision 3: Browser WebSocket bearer tokens use subprotocols
+## Decision 3: Browser WebSocket bearer tokens use subprotocols as an explicit fallback
 
 When a browser has a bearer token, prefer a WebSocket subprotocol credential
 over a URL query parameter:
@@ -156,7 +164,9 @@ browser history, referrer paths, or ordinary route metrics. It is still a
 bearer token visible to JavaScript and potentially to infrastructure that logs
 request headers, so it is not proof-of-possession security.
 
-Subprotocol bearer tokens are appropriate for:
+Subprotocol bearer tokens remain useful and supported, but they are no longer
+the default hosted browser path when an app-session cookie is available.
+They are appropriate for:
 
 - browser clients that have obtained an OIDC token through an application login
   flow;
@@ -171,12 +181,20 @@ dev-token smoke tests. A later cleanup may migrate that path behind the generic
 `nteract-bearer.*` prefix once the credential payload carries enough issuer
 metadata to dispatch safely.
 
-## Decision 4: One-time tickets are an optional bridge
+## Decision 4: One-time tickets are a future hardening bridge, not the preview default
 
 One-time tickets are useful when a browser cannot safely or conveniently present
 the real credential during the WebSocket upgrade.
 
-Flow:
+They are not the current preview path. A previous app-session sync-ticket
+prototype added a mint route and another short-lived object to every live-room
+open/reconnect, which made reconnect failures harder to reason about during
+normal notebook navigation. Before reintroducing tickets, the implementation
+needs explicit reconnect diagnostics, browser smoke coverage across reloads and
+flaky sockets, and proof that the extra credential hop improves the security
+posture without degrading demo usability.
+
+Future flow:
 
 1. Browser sends a normal HTTPS request to `/api/session-tickets` with the real
    credential using whichever mechanism the deployment supports.
@@ -204,15 +222,21 @@ short-lived opaque ticket exposure should use bearer-in-subprotocol auth with
 non-echoed credential subprotocols or a cookie/assertion perimeter whose origin
 policy is explicitly owned by the deployment.
 
-Tickets are not the default for the direct-OIDC demo because the browser can
-present the OIDC access token as a non-echoed WebSocket subprotocol. They
-remain the preferred fallback when a deployment would otherwise need to put a
-long-lived bearer token in a WebSocket URL.
+Tickets are not the default for preview because browser app sessions can ride
+same-origin cookie-backed WebSocket upgrades with strict origin checks, and
+explicit bearer clients can use non-echoed WebSocket subprotocols. Tickets
+remain a future option for deployments that cannot accept either of those
+shapes and can meet the verification bar above.
 
 ## Decision 5: Provider cookies are deployment-specific, not generic
 
 Cookies are acceptable only when the deployment owns the CSRF and origin policy
 for the provider.
+
+Notebook-cloud's app-session cookie is one such deployment-owned cookie. It is
+accepted on first-party browser app APIs and same-origin/trusted-origin
+live-room WebSocket upgrades only after the Worker applies its origin policy.
+It is not accepted from renderer asset origins or isolated output origins.
 
 For JupyterHub:
 
@@ -342,10 +366,12 @@ namespace, and optional perimeter configuration.
 
 ## Open Questions
 
-1. **Browser token storage and refresh.** The direct-OIDC viewer can reuse the
-   `runtimed/intheloop` PKCE/localStorage shape initially. Before private
-   notebooks become broad production surface, decide whether tokens should move
-   behind a same-site BFF/session-cookie layer.
+1. **Browser session renewal.** App-session cookies are now the first-party
+   browser credential for app APIs and live room WebSockets. Before private
+   notebooks become broad production surface, prove the refresh behavior across
+   reloads, reconnects, and multiple tabs so stale OIDC refresh state does not
+   show unnecessary "sign in again" prompts while the app session remains
+   usable.
 2. **Additional OIDC providers.** If a public `runtimed.com` viewer validates a
    different OIDC provider, define the principal namespace and future
    subject-linking story up front.

--- a/docs/adr/hosted-room-authorization.md
+++ b/docs/adr/hosted-room-authorization.md
@@ -413,11 +413,12 @@ enforce equivalent access.
    connections while rejecting notebook-level metadata edits from non-owners.
 9. **Runtime peer ingress.** Allow runtime peers to attach and update
    `RuntimeStateDoc` plus blobs without notebook edits.
-10. **Direct OIDC.** Wire real provider validation after ACL lookup is in
-   place. Browser WebSockets follow `hosted-credential-transport.md` for
-   non-echoed bearer subprotocols, one-time tickets, optional perimeter
-   assertions/cookies, and origin checks; native/system clients may use
-   headers.
+10. **Direct OIDC and app sessions.** Wire real provider validation after ACL
+   lookup is in place. Browser app APIs and live-room WebSockets follow
+   `hosted-credential-transport.md`: OIDC bootstraps first-party app-session
+   cookies, cookie-backed WebSockets require trusted origins, explicit bearer
+   subprotocols remain available for compatible browser/native flows, and
+   native/system clients may use headers.
 
 ## Prototype-only behavior to remove
 


### PR DESCRIPTION
## Summary
- remove the browser app-session sync-ticket mint/read path and `/api/n/:id/sync-ticket` route
- authenticate browser live-room WebSockets directly from the HttpOnly app-session cookie with trusted Origin enforcement
- reject mixed cookie + explicit bearer/dev credentials, while keeping explicit bearer/dev WebSocket auth as fallback
- make hosted execution require active edit mode plus owner submit authority so view mode remains read-only even for owners with compute
- update hosted credential ADRs and cloud README to keep sync tickets as future hardening only
- harden the hosted workstation toolbar smoke so reloads explicitly re-enter edit mode and failures identify the exact phase

## Validation
- `pnpm --dir apps/notebook-cloud exec node --import tsx --test test/app-session.test.ts test/collaborator-auth.test.ts test/worker-routes.test.ts test/live-sync.test.ts test/viewer-shared-cell-surface.test.ts test/viewer-shell-capabilities.test.ts` (196 tests)
- `pnpm --dir apps/notebook-cloud exec node --import tsx --test test/viewer-shared-cell-surface.test.ts test/viewer-shell-capabilities.test.ts`
- `pnpm --dir apps/notebook-cloud typecheck`
- `cargo xtask lint --fix`
- `curl -fsS https://preview.runt.run/api/health`
- `pnpm --dir apps/notebook-cloud run auth:preview:health`
- `NOTEBOOK_CLOUD_WORKSTATION_TOOLBAR_SMOKE_SCREENSHOT=.context/smokes/drop-sync-tickets-workstation-toolbar.png NOTEBOOK_CLOUD_WRITE_SMOKE_REPORT=1 pnpm --dir apps/notebook-cloud run smoke:hosted:workstation-toolbar`

## Preview deploy
- renderer assets worker: `3fc20fea-ce9e-469b-9fa4-42f8b04ff5df`
- main preview worker: `0434b40a-1ac1-446d-ba20-ec3f12b91f33`
- smoke notebook: https://preview.runt.run/n/01KTMB72DFGRDH0J3EYW6QK72C/toolbar-attach-smoke
