### PR TITLE
fix(ci): keep generated wire constants LF-normalized

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,5 +1,6 @@
 packages/runtimed/src/request-types.ts text eol=lf
 packages/runtimed/src/protocol-contract.ts text eol=lf
+packages/runtimed/src/wire-constants.ts text eol=lf
 
 # Stable third-party renderer-plugin bundles. LFS-tracked so fresh checkouts
 # don't pay the large vendor rebuild just to boot the daemon. Owned/generated


### PR DESCRIPTION
## Summary
- add the generated wire constants file to .gitattributes with LF line endings
- match the existing generated TypeScript binding files so Windows checkout does not turn this one file into CRLF

## Verification
- git check-attr eol text -- packages/runtimed/src/wire-constants.ts packages/runtimed/src/request-types.ts packages/runtimed/src/protocol-contract.ts
- simulated core.autocrlf=true checkout; all three generated files had 0 CRLF sequences
- cargo test -p notebook-protocol typescript::tests::generated_typescript_bindings_are_current
- cargo xtask lint --fix

Investigated Build run 27159275422: Linux pnpm JSON parse failure appears runner/cache-related; Windows test failure was the repo-actionable missing eol rule for wire-constants.ts.