### PR TITLE
chore(elements): publish catalog worker preview

### DIFF
--- a/apps/elements/next.config.mjs
+++ b/apps/elements/next.config.mjs
@@ -19,6 +19,7 @@ const config = {
   },
   transpilePackages: ["@nteract/sift"],
   turbopack: {
+    root: path.join(dirname, "../.."),
     resolveAlias: {
       "./frame-config": frameConfigAdapterImport,
       [frameConfigSourcePath]: frameConfigAdapterImport,

--- a/apps/elements/package.json
+++ b/apps/elements/package.json
@@ -6,7 +6,9 @@
     "dev": "portless run --name nteract-elements next dev",
     "dev:local": "next dev --port 5176",
     "url": "portless get nteract-elements",
-    "build": "next build"
+    "build": "next build",
+    "deploy:workers": "pnpm run build && wrangler deploy -c wrangler.jsonc",
+    "deploy:workers:dry-run": "pnpm run build && wrangler deploy -c wrangler.jsonc --dry-run"
   },
   "dependencies": {
     "@nteract/sift": "workspace:*",

--- a/apps/elements/wrangler.jsonc
+++ b/apps/elements/wrangler.jsonc
@@ -1,0 +1,11 @@
+{
+  "$schema": "../../node_modules/wrangler/config-schema.json",
+  "name": "nteract-elements-preview",
+  "compatibility_date": "2026-06-08",
+  "workers_dev": true,
+  "assets": {
+    "directory": "./out",
+    "html_handling": "auto-trailing-slash",
+    "not_found_handling": "404-page",
+  },
+}


### PR DESCRIPTION
## Summary
- add an isolated Workers Static Assets config for the Elements catalog
- add Elements deploy and dry-run scripts that build the Next static export first
- pin the Elements Turbopack root to this repo so builds are not affected by lockfiles outside the worktree

Live preview: https://nteract-elements-preview.rgbkrk.workers.dev

This does not add routes or deploy anything under existing runt.run domains.

## Validation
- pnpm --dir apps/elements run deploy:workers:dry-run
- pnpm --dir apps/elements run deploy:workers
- cargo xtask lint --fix
- curl -I https://nteract-elements-preview.rgbkrk.workers.dev/
- curl -I https://nteract-elements-preview.rgbkrk.workers.dev/docs/cloud-dashboard
- curl -I https://nteract-elements-preview.rgbkrk.workers.dev/wasm/sift_wasm_bg.wasm
- Playwright screenshots at 1440x1000 and 390x844 for /docs/cloud-dashboard
