### PR TITLE
fix(notebook-cloud): keep workstation attach watcher alive

### DIFF
--- a/apps/notebook-cloud/scripts/hosted-workstation-agent.mjs
+++ b/apps/notebook-cloud/scripts/hosted-workstation-agent.mjs
@@ -146,7 +146,7 @@ async function startAttachJob(job, pythonPath) {
   });
   closeSync(logFd);
 
-  const active = { child, logPath, ready: false };
+  const active = { child, logPath: plan.logPath, ready: false };
   activeJobs.set(job.job_id, active);
   console.log(
     JSON.stringify({


### PR DESCRIPTION
## Summary
- fix the hosted workstation agent attach watcher to store the spawned runtime peer log path from the spawn plan
- prevents accepted attach jobs from tripping a ReferenceError after the runtime peer process is spawned

## Live verification
- lab2 was offline in `/api/workstations`, then re-registered as online/default
- a runtime peer spawned for notebook `01KTMMHZXYA531NN53PN0DX4ZF` and launched Current Python
- started a patched control-agent transient user service so future attach requests can be accepted without disturbing the active runtime peer

## Validation
- pnpm --dir apps/notebook-cloud exec node --test test/hosted-workstation-agent.test.mjs
- cargo xtask lint --fix
