### PR TITLE
fix(notebook-cloud): renew app-session cookies in active tabs

### DIFF
--- a/apps/notebook-cloud/test/app-session-client.test.ts
+++ b/apps/notebook-cloud/test/app-session-client.test.ts
@@ -3,6 +3,7 @@ import assert from "node:assert/strict";
 import {
   CLOUD_APP_SESSION_ENDPOINT,
   cloudAppSessionIsFresh,
+  cloudAppSessionNeedsRenewal,
   isCloudAppSessionStatus,
   readCloudAppSessionStatus,
 } from "../viewer/app-session.ts";
@@ -39,6 +40,15 @@ describe("cloud app session client", () => {
     assert.equal(cloudAppSessionIsFresh({ provider: "oidc", expires_at: 1_300 }, 1_000), true);
     assert.equal(cloudAppSessionIsFresh({ provider: "oidc", expires_at: 1_060 }, 1_000), false);
     assert.equal(cloudAppSessionIsFresh(null, 1_000), false);
+  });
+
+  it("renews app sessions before the browser cookie expires", () => {
+    assert.equal(
+      cloudAppSessionNeedsRenewal({ provider: "oidc", expires_at: 3_000 }, 1_000),
+      false,
+    );
+    assert.equal(cloudAppSessionNeedsRenewal({ provider: "oidc", expires_at: 2_700 }, 1_000), true);
+    assert.equal(cloudAppSessionNeedsRenewal(null, 1_000), true);
   });
 
   it("rejects identity-bearing status payloads", () => {

--- a/apps/notebook-cloud/test/viewer-notices.test.ts
+++ b/apps/notebook-cloud/test/viewer-notices.test.ts
@@ -93,6 +93,33 @@ test("cloud notebook notices render auth and connection policy through the share
   assert.doesNotMatch(html, /Reset to anonymous/);
 });
 
+test("cloud notebook notices trust a fresh app session over stale localStorage auth", () => {
+  assert.equal(
+    cloudNotebookHasNotices({
+      authState: authState("oidc_expired"),
+      authRenewal: { kind: "failed", message: "refresh failed" },
+      connectionError: null,
+      hasAppSession: true,
+      status: { kind: "ready", message: "Ready" },
+    }),
+    false,
+  );
+
+  const html = renderToStaticMarkup(
+    React.createElement(CloudNotebookNotices, {
+      authState: authState("oidc_expired"),
+      authRenewal: { kind: "failed", message: "refresh failed" },
+      connectionError: null,
+      hasAppSession: true,
+      status: { kind: "ready", message: "Ready" },
+      onResetAuth: () => {},
+      onSignInAgain: () => {},
+    }),
+  );
+
+  assert.equal(html, "");
+});
+
 test("cloud notebook notices distinguish sign-in and access diagnostics from socket failures", () => {
   const signInHtml = renderToStaticMarkup(
     React.createElement(CloudNotebookNotices, {

--- a/apps/notebook-cloud/test/viewer-shared-cell-surface.test.ts
+++ b/apps/notebook-cloud/test/viewer-shared-cell-surface.test.ts
@@ -472,7 +472,7 @@ test("cloud app-session bridge refreshes cookie-backed state after OIDC exchange
 
   assert.match(
     sourceText,
-    /useCloudAppSessionBridge\(authState, appSessionStatus\.refreshAppSessionStatus\)/,
+    /useCloudAppSessionBridge\(\s*authState,\s*appSessionStatus\.session,\s*appSessionStatus\.status === "loading",\s*appSessionStatus\.refreshAppSessionStatus,\s*\)/,
   );
   assert.match(
     sourceText,

--- a/apps/notebook-cloud/viewer/app-session.ts
+++ b/apps/notebook-cloud/viewer/app-session.ts
@@ -14,6 +14,7 @@ export interface CloudAppSessionStatus {
 }
 
 const CLOUD_APP_SESSION_EXPIRY_SKEW_SECONDS = 60;
+const CLOUD_APP_SESSION_RENEWAL_SKEW_SECONDS = 30 * 60;
 
 export async function establishCloudAppSession(authState: CloudPrototypeAuthState): Promise<void> {
   if (authState.mode !== "oidc" || !authState.token) {
@@ -103,6 +104,13 @@ export function cloudAppSessionIsFresh(
   return Boolean(
     session && session.expires_at > nowSeconds + CLOUD_APP_SESSION_EXPIRY_SKEW_SECONDS,
   );
+}
+
+export function cloudAppSessionNeedsRenewal(
+  session: CloudAppSession | null | undefined,
+  nowSeconds = currentEpochSeconds(),
+): boolean {
+  return !session || session.expires_at <= nowSeconds + CLOUD_APP_SESSION_RENEWAL_SKEW_SECONDS;
 }
 
 function currentEpochSeconds(): number {

--- a/apps/notebook-cloud/viewer/index.tsx
+++ b/apps/notebook-cloud/viewer/index.tsx
@@ -151,6 +151,7 @@ import { loadSupplementalViewerCss } from "./supplemental-css";
 import {
   clearCloudAppSession,
   cloudAppSessionIsFresh,
+  cloudAppSessionNeedsRenewal,
   establishCloudAppSession,
   establishCloudAppSessionFromOidcToken,
   isCloudAppSession,
@@ -408,11 +409,6 @@ function useCloudPrototypeAuth(
       if (appSessionExpiresAt && cloudAppSessionIsFresh(appSession)) {
         appSessionRefreshFallbackRef.current = appSessionExpiresAt;
         setAuthRenewal({ kind: "idle", message: null });
-        return;
-      }
-      const fallbackExpiresAt = appSessionRefreshFallbackRef.current;
-      if (fallbackExpiresAt && fallbackExpiresAt > currentEpochSeconds() + 60) {
-        return;
       }
     }
     if (refreshPromiseRef.current) {
@@ -566,27 +562,66 @@ function currentEpochSeconds(): number {
 
 function useCloudAppSessionBridge(
   authState: CloudPrototypeAuthState,
+  appSession: CloudAppSession | null,
+  appSessionLoading: boolean,
   onEstablished?: () => void,
 ): void {
   const establishedTokenRef = useRef<string | null>(null);
-  useEffect(() => {
+  const lastAttemptAtRef = useRef(0);
+  const inFlightRef = useRef<Promise<void> | null>(null);
+  const renewIfNeeded = useCallback(() => {
     if (authState.mode !== "oidc" || !authState.token) {
       establishedTokenRef.current = null;
       return;
     }
-    if (establishedTokenRef.current === authState.token) {
+    if (appSessionLoading && !appSession) {
       return;
     }
-    establishedTokenRef.current = authState.token;
-    void establishCloudAppSession(authState)
+
+    const nowSeconds = currentEpochSeconds();
+    const tokenChanged = establishedTokenRef.current !== authState.token;
+    const sessionNeedsRenewal = cloudAppSessionNeedsRenewal(appSession, nowSeconds);
+    if (!tokenChanged && !sessionNeedsRenewal) {
+      return;
+    }
+    if (inFlightRef.current) {
+      return;
+    }
+    if (!tokenChanged && nowSeconds - lastAttemptAtRef.current < 5 * 60) {
+      return;
+    }
+
+    lastAttemptAtRef.current = nowSeconds;
+    inFlightRef.current = establishCloudAppSession(authState)
       .then(() => {
+        establishedTokenRef.current = authState.token;
         onEstablished?.();
       })
       .catch((error: unknown) => {
-        establishedTokenRef.current = null;
         console.warn("[notebook-cloud] app session exchange failed", error);
+      })
+      .finally(() => {
+        inFlightRef.current = null;
       });
-  }, [authState, onEstablished]);
+  }, [appSession, appSessionLoading, authState, onEstablished]);
+
+  useEffect(() => {
+    renewIfNeeded();
+    const interval = window.setInterval(renewIfNeeded, 60_000);
+    const renewOnFocus = () => renewIfNeeded();
+    const renewOnVisibility = () => {
+      if (document.visibilityState === "visible") {
+        renewIfNeeded();
+      }
+    };
+    window.addEventListener("focus", renewOnFocus);
+    document.addEventListener("visibilitychange", renewOnVisibility);
+    return () => {
+      window.clearInterval(interval);
+      window.removeEventListener("focus", renewOnFocus);
+      document.removeEventListener("visibilitychange", renewOnVisibility);
+    };
+  }, [renewIfNeeded]);
 }
 
 function App() {
@@ -656,7 +691,12 @@ function CloudNotebookListView({ authConfig }: { authConfig: CloudViewerAuthConf
     appSessionLoading: appSessionStatus.status === "loading",
     appSession: appSessionStatus.session,
   });
-  useCloudAppSessionBridge(authState, appSessionStatus.refreshAppSessionStatus);
+  useCloudAppSessionBridge(
+    authState,
+    appSessionStatus.session,
+    appSessionStatus.status === "loading",
+    appSessionStatus.refreshAppSessionStatus,
+  );
   const [listState, setListState] = useState<CloudNotebookListState>(() =>
     initialCloudNotebookListState(authState, bootstrap),
   );
@@ -915,7 +955,7 @@ function CloudNotebookListView({ authConfig }: { authConfig: CloudViewerAuthConf
         </div>
       </header>
 
-      {authRenewal.kind !== "idle" ? (
+      {authRenewal.kind !== "idle" && !hasAppSession ? (
         <div
           className="cloud-notebook-list-banner"
           data-kind={authRenewal.kind === "failed" ? "error" : "info"}
@@ -1444,7 +1484,12 @@ function CloudHomeView({ authConfig }: { authConfig: CloudViewerAuthConfig }) {
     appSessionLoading: appSessionStatus.status === "loading",
     appSession: appSessionStatus.session,
   });
-  useCloudAppSessionBridge(authState, appSessionStatus.refreshAppSessionStatus);
+  useCloudAppSessionBridge(
+    authState,
+    appSessionStatus.session,
+    appSessionStatus.status === "loading",
+    appSessionStatus.refreshAppSessionStatus,
+  );
   const [authAction, setAuthAction] = useState<"idle" | "starting">("idle");
   const [formError, setFormError] = useState<string | null>(null);
   const oidcConfigured = Boolean(authConfig.oidc);
@@ -1525,7 +1570,7 @@ function CloudHomeView({ authConfig }: { authConfig: CloudViewerAuthConfig }) {
               {formError}
             </div>
           ) : null}
-          {authRenewal.kind !== "idle" ? (
+          {authRenewal.kind !== "idle" && !hasAppSession ? (
             <div
               className="cloud-auth-form-error"
               data-kind={authRenewal.kind === "failed" ? "error" : "info"}
@@ -1718,7 +1763,12 @@ function NotebookViewer({
     appSessionLoading: appSessionStatus.status === "loading",
     appSession: appSessionStatus.session,
   });
-  useCloudAppSessionBridge(authState, appSessionStatus.refreshAppSessionStatus);
+  useCloudAppSessionBridge(
+    authState,
+    appSessionStatus.session,
+    appSessionStatus.status === "loading",
+    appSessionStatus.refreshAppSessionStatus,
+  );
   const [focusedCellId, setFocusedCellId] = useState<string | null>(null);
   const [activeRailPanel, setActiveRailPanel] = useState<NotebookRailPanelId>("outline");
   const [railCollapsed, setRailCollapsed] = useState(initialCloudRailCollapsed);
@@ -2656,6 +2706,7 @@ function NotebookViewer({
     authRenewal,
     connectionError,
     diagnostics: accessRequestNotice,
+    hasAppSession: Boolean(appSessionStatus.session),
     hasReadableSnapshot: notebookHasReadableSnapshot,
     status: noticeStatus,
   });
@@ -2665,6 +2716,7 @@ function NotebookViewer({
       authRenewal={authRenewal}
       connectionError={connectionError}
       diagnostics={accessRequestNotice}
+      hasAppSession={Boolean(appSessionStatus.session)}
       hasReadableSnapshot={notebookHasReadableSnapshot}
       status={noticeStatus}
       onResetAuth={resetPrototypeAuth}

--- a/apps/notebook-cloud/viewer/notices.tsx
+++ b/apps/notebook-cloud/viewer/notices.tsx
@@ -18,6 +18,7 @@ export interface CloudNotebookNoticesProps {
   authState: CloudPrototypeAuthState;
   authRenewal: CloudAuthRenewalState;
   connectionError: string | null;
+  hasAppSession?: boolean;
   hasReadableSnapshot?: boolean;
   status: ViewerStatus;
   diagnostics?: ReactNode;
@@ -29,6 +30,7 @@ export function cloudNotebookHasNotices({
   authState,
   authRenewal,
   connectionError,
+  hasAppSession = false,
   hasReadableSnapshot = false,
   status,
   diagnostics,
@@ -41,10 +43,13 @@ export function cloudNotebookHasNotices({
     !(status.kind === "empty" && hasReadableSnapshot) &&
     !isStatusDerivedFromConnectionError(status, connectionError);
 
+  const shouldShowAuthNotice =
+    !hasAppSession && (authState.mode === "invalid" || authState.mode === "oidc_expired");
+  const shouldShowAuthRenewalNotice = !hasAppSession && authRenewal.kind !== "idle";
+
   return (
-    authState.mode === "invalid" ||
-    authState.mode === "oidc_expired" ||
-    authRenewal.kind !== "idle" ||
+    shouldShowAuthNotice ||
+    shouldShowAuthRenewalNotice ||
     Boolean(connectionNotice) ||
     Boolean(diagnostics) ||
     shouldShowStatusNotice
@@ -55,6 +60,7 @@ export function CloudNotebookNotices({
   authState,
   authRenewal,
   connectionError,
+  hasAppSession = false,
   hasReadableSnapshot = false,
   status,
   diagnostics,
@@ -66,6 +72,7 @@ export function CloudNotebookNotices({
       authState,
       authRenewal,
       connectionError,
+      hasAppSession,
       hasReadableSnapshot,
       status,
       diagnostics,
@@ -81,10 +88,13 @@ export function CloudNotebookNotices({
     status.kind !== "ready" &&
     !(status.kind === "empty" && hasReadableSnapshot) &&
     !isStatusDerivedFromConnectionError(status, connectionError);
+  const shouldShowAuthNotice =
+    !hasAppSession && (authState.mode === "invalid" || authState.mode === "oidc_expired");
+  const shouldShowAuthRenewalNotice = !hasAppSession && authRenewal.kind !== "idle";
 
   return (
     <NotebookNoticeStack>
-      {authState.mode === "invalid" || authState.mode === "oidc_expired" ? (
+      {shouldShowAuthNotice ? (
         <NotebookNotice
           tone="error"
           icon={<AlertCircle className="h-4 w-4" />}
@@ -95,7 +105,7 @@ export function CloudNotebookNotices({
         </NotebookNotice>
       ) : null}
 
-      {authRenewal.kind !== "idle" ? (
+      {shouldShowAuthRenewalNotice ? (
         <NotebookNotice
           tone={authRenewal.kind === "failed" ? "error" : "info"}
           icon={


### PR DESCRIPTION
## Summary

- renew first-party notebook-cloud app-session cookies from active tabs before the cookie gets close to expiry
- keep trying OIDC refresh in the background even when a fresh app-session cookie is already present
- trust the fresh app-session cookie for user-facing auth notices so stale localStorage state does not tell users to sign in again mid-session

## Preview

Deployed to preview.runt.run.

- main Worker version: `77bf5d49-c08d-4792-b3d9-12902d2c64c5`
- renderer-assets Worker version: `9776764f-fb5e-47a1-a1b1-d25b3e0a8c1c`

## Validation

- `pnpm --dir apps/notebook-cloud exec node --import tsx --test test/app-session-client.test.ts test/viewer-notices.test.ts test/viewer-shared-cell-surface.test.ts`
- `pnpm --dir apps/notebook-cloud run typecheck`
- `cargo xtask lint --fix`
- `node apps/notebook-cloud/scripts/preview-auth-health.mjs`
- live `/api/auth/session` POST/GET cookie round-trip against preview.runt.run