### PR TITLE
refactor(elements): reshape catalog toward data workspace IA

### DIFF
--- a/apps/elements/app/layout.tsx
+++ b/apps/elements/app/layout.tsx
@@ -8,7 +8,7 @@ export const metadata: Metadata = {
     default: "nteract elements",
     template: "%s | nteract elements",
   },
-  description: "Notebook UI and rendering examples from nteract/nteract.",
+  description: "Notebook workspace surfaces and data workflow components from nteract/nteract.",
 };
 
 export default function RootLayout({ children }: { children: ReactNode }) {

--- a/apps/elements/app/page.tsx
+++ b/apps/elements/app/page.tsx
@@ -37,136 +37,136 @@ interface CatalogGroup {
 
 const catalogGroups = [
   {
-    title: "Shell",
+    title: "Workspace",
     entries: [
       {
-        title: "Notebook shell capabilities",
-        description: "Host capability facts for shared notebook chrome.",
-        href: "/docs/notebook-shell-capabilities",
-        icon: ToggleLeft,
-      },
-      {
-        title: "Cloud notebook shell",
-        description: "Presence, sync, workstations, sharing, mode, and auth.",
-        href: "/docs/cloud-notebook-shell",
-        icon: Cloud,
-      },
-      {
         title: "Cloud dashboard",
-        description: "Notebook home, continuation, workstation context, and sharing previews.",
+        description: "Notebook home, recent work, workstation state, and sharing.",
         href: "/docs/cloud-dashboard",
         icon: LayoutDashboard,
       },
       {
         title: "Compute placement",
-        description: "Rail, environment, and connect-flow options for workstations.",
+        description: "Workstation selection and environment context.",
         href: "/docs/compute-placement",
         icon: Workflow,
       },
       {
+        title: "Identity and environment",
+        description: "User context, access state, and runtime connection.",
+        href: "/docs/identity-environment-surfaces",
+        icon: IdCard,
+      },
+      {
+        title: "Cloud notebook shell",
+        description: "Presence, sync state, collaboration, and sharing controls.",
+        href: "/docs/cloud-notebook-shell",
+        icon: Cloud,
+      },
+    ],
+  },
+  {
+    title: "Notebook",
+    entries: [
+      {
         title: "Notebook toolbar",
-        description: "Runtime and command toolbar state across hosts.",
+        description: "Execution controls, kernel state, and runtime commands.",
         href: "/docs/notebook-toolbar-surfaces",
         icon: PanelTop,
       },
       {
         title: "Notebook outline",
-        description: "Rail-first navigation for long notebooks.",
+        description: "Navigation and document structure for long notebooks.",
         href: "/docs/notebook-outline",
         icon: PanelLeft,
       },
       {
-        title: "Identity and environment",
-        description: "Actors, access state, runtime, and package context.",
-        href: "/docs/identity-environment-surfaces",
-        icon: IdCard,
-      },
-    ],
-  },
-  {
-    title: "Cells",
-    entries: [
-      {
-        title: "Cell anatomy",
-        description: "Inventory map for current nteract cells.",
-        href: "/docs/cell-anatomy",
-        icon: FileCode2,
-      },
-      {
         title: "Cell execution language",
-        description: "Execution language and cell source states.",
+        description: "Execution state, queued runs, and cell status.",
         href: "/docs/cell-execution-language",
         icon: SquareCode,
       },
       {
         title: "Cell insertion affordances",
-        description: "Insertion ribbons and add-cell controls.",
+        description: "Add code, markdown, and data cells.",
         href: "/docs/cell-insertion-affordances",
         icon: ListPlus,
       },
       {
-        title: "Editor surfaces",
-        description: "CodeMirror fixtures for notebook source editing.",
-        href: "/docs/editor-surfaces",
-        icon: TextCursorInput,
-      },
-      {
         title: "Search surfaces",
-        description: "Find and history search over fixture notebook state.",
+        description: "Find in notebook and execution history.",
         href: "/docs/search-surfaces",
         icon: Search,
+      },
+      {
+        title: "Editor surfaces",
+        description: "Code editing with syntax highlighting and completion.",
+        href: "/docs/editor-surfaces",
+        icon: TextCursorInput,
       },
     ],
   },
   {
-    title: "Runtime",
+    title: "Execution & Output",
     entries: [
       {
+        title: "Output renderers",
+        description: "Rich outputs: tables, charts, dataframes, and artifacts.",
+        href: "/docs/output-renderers",
+        icon: Boxes,
+      },
+      {
+        title: "Widget surfaces",
+        description: "Interactive controls and ipywidget components.",
+        href: "/docs/widget-surfaces",
+        icon: SlidersHorizontal,
+      },
+      {
+        title: "Output isolation",
+        description: "Secure rendering and sandboxed output frames.",
+        href: "/docs/isolated-output-surfaces",
+        icon: Frame,
+      },
+      {
         title: "Runtime surfaces",
-        description: "Trust and environment decisions with fixture state.",
+        description: "Environment trust, kernel state, and execution context.",
         href: "/docs/runtime-surfaces",
         icon: ShieldCheck,
       },
       {
         title: "Package managers",
-        description: "Dependency headers and package-state controls.",
+        description: "Dependency management and package installation state.",
         href: "/docs/package-manager-surfaces",
         icon: PackageCheck,
-      },
-      {
-        title: "Read-only notebooks",
-        description: "Hosted notebook cells through shared components.",
-        href: "/docs/read-only-notebook-surfaces",
-        icon: BookOpen,
       },
     ],
   },
   {
-    title: "Rendering",
+    title: "Components",
     entries: [
       {
-        title: "Output renderers",
-        description: "Runtime-free fixtures for output components.",
-        href: "/docs/output-renderers",
-        icon: Boxes,
+        title: "Cell anatomy",
+        description: "Cell structure and component inventory.",
+        href: "/docs/cell-anatomy",
+        icon: FileCode2,
       },
       {
-        title: "Output isolation",
-        description: "Frame policy, host context, and MCP output mapping.",
-        href: "/docs/isolated-output-surfaces",
-        icon: Frame,
-      },
-      {
-        title: "Widget surfaces",
-        description: "Fixture-backed ipywidget controls and adapter notes.",
-        href: "/docs/widget-surfaces",
-        icon: SlidersHorizontal,
+        title: "Read-only notebooks",
+        description: "Published notebook views without execution.",
+        href: "/docs/read-only-notebook-surfaces",
+        icon: BookOpen,
       },
       {
         title: "Theme surfaces",
-        description: "Classic and cream palettes under shared tokens.",
+        description: "Color palettes and visual styling.",
         href: "/docs/theme-surfaces",
         icon: Palette,
+      },
+      {
+        title: "Notebook shell capabilities",
+        description: "Host capabilities and feature detection.",
+        href: "/docs/notebook-shell-capabilities",
+        icon: ToggleLeft,
       },
     ],
   },
@@ -187,8 +187,8 @@ export default function Home() {
               Elements
             </h1>
             <p className="mt-3 max-w-2xl text-sm leading-6 text-fd-muted-foreground">
-              {catalogCount} production-backed notebook surfaces for shell, cells, runtime, and
-              rendering work.
+              {catalogCount} notebook workspace surfaces for workspace, execution, and data
+              workflows.
             </p>
           </div>
           <div className="flex shrink-0 flex-wrap gap-2">
@@ -208,12 +208,12 @@ export default function Home() {
           </div>
         </header>
 
-        <section className="grid gap-x-8 gap-y-7 py-7 lg:grid-cols-2">
+        <section className="grid gap-x-8 gap-y-8 py-8 lg:grid-cols-2">
           {catalogGroups.map((group) => (
             <section key={group.title} aria-labelledby={`${group.title.toLowerCase()}-group`}>
               <h2
                 id={`${group.title.toLowerCase()}-group`}
-                className="text-xs font-semibold uppercase tracking-normal text-fd-muted-foreground"
+                className="border-b border-fd-border pb-2 text-sm font-semibold text-fd-foreground"
               >
                 {group.title}
               </h2>
@@ -235,16 +235,16 @@ function CatalogLink({ entry }: { entry: CatalogEntry }) {
   return (
     <Link
       href={entry.href}
-      className="grid min-w-0 grid-cols-[auto_minmax(0,1fr)_auto] items-center gap-3 rounded-md border border-fd-border bg-fd-background px-3 py-2.5 transition-colors hover:bg-fd-muted/40"
+      className="group grid min-w-0 grid-cols-[auto_minmax(0,1fr)_auto] items-center gap-3 rounded-md border border-fd-border bg-fd-background px-3.5 py-2.5 transition-colors hover:border-fd-foreground/20 hover:bg-fd-muted/30"
     >
-      <Icon className="size-4 text-fd-muted-foreground" aria-hidden="true" />
+      <Icon className="size-4 text-fd-muted-foreground transition-colors group-hover:text-fd-foreground" aria-hidden="true" />
       <span className="min-w-0">
-        <span className="block truncate text-sm font-semibold">{entry.title}</span>
-        <span className="mt-0.5 block truncate text-xs text-fd-muted-foreground">
+        <span className="block truncate text-sm font-medium">{entry.title}</span>
+        <span className="mt-0.5 block truncate text-xs leading-5 text-fd-muted-foreground">
           {entry.description}
         </span>
       </span>
-      <ArrowRight className="size-3.5 text-fd-muted-foreground" aria-hidden="true" />
+      <ArrowRight className="size-3.5 text-fd-muted-foreground opacity-0 transition-opacity group-hover:opacity-100" aria-hidden="true" />
     </Link>
   );
 }

--- a/apps/elements/content/docs/index.mdx
+++ b/apps/elements/content/docs/index.mdx
@@ -1,18 +1,18 @@
 ---
 title: Elements
-description: Notebook UI and rendering examples from nteract/nteract.
+description: Notebook workspace surfaces from nteract/nteract.
 ---
 
-`nteract/nteract` is the canonical home for notebook UI and rendering work.
-This catalog is the in-repo successor direction for examples that used to live
-around `nteract/elements`.
+`nteract/nteract` is the canonical home for notebook UI and data workflow surfaces.
+This catalog documents production-backed notebook workspace components organized by
+user workflow: workspace, notebook, execution, and output.
 
 ## What belongs here
 
-- Runtime-free notebook UI fixtures.
-- Rendering examples for markdown, rich output, and widgets.
-- Component documentation for reusable notebook presentation surfaces.
-- Migration notes for any old `nteract/elements` examples worth recreating.
+- Production notebook workspace surfaces with deterministic fixtures.
+- Execution state, runtime controls, and observability components.
+- Rich output rendering: tables, charts, dataframes, and artifacts.
+- Workspace context: workstations, compute, identity, and collaboration.
 
 ## What stays elsewhere
 
@@ -22,34 +22,40 @@ repo-level `docs/` tree.
 
 ## Current direction
 
-Keep the catalog production-backed. It should render shared shell, rail,
-toolbar, identity, package, cell, output, and widget components from
-deterministic fixtures without importing the desktop runtime, sync engine,
-Cloudflare host, or generated runtimed WASM bindings. Renderer-specific assets
-like Sift WASM should stay explicit, docs-served adapters.
+Keep the catalog production-backed. It should render shared workspace, notebook,
+execution, and output components from deterministic fixtures without importing the
+desktop runtime, sync engine, Cloudflare host, or generated runtimed WASM bindings.
+Renderer-specific assets like Sift WASM should stay explicit, docs-served adapters.
 
-## Production-backed catalog
+## Notebook workspace surfaces
 
-The catalog should make it obvious which surfaces are nteract-owned notebook
-concepts and which boundaries still need a notebook-semantic wrapper.
+The catalog documents surfaces for data notebook workflows, organized by where they
+appear in the user's work:
 
-- [Notebook shell capabilities](/docs/notebook-shell-capabilities)
-- [Cloud notebook shell](/docs/cloud-notebook-shell)
-- [Cloud dashboard](/docs/cloud-dashboard)
-- [Compute placement](/docs/compute-placement)
-- [Identity and environment surfaces](/docs/identity-environment-surfaces)
-- [Notebook toolbar surfaces](/docs/notebook-toolbar-surfaces)
-- [Notebook outline rail](/docs/notebook-outline)
-- [Package manager surfaces](/docs/package-manager-surfaces)
-- [Cell anatomy](/docs/cell-anatomy)
-- [Cell execution language](/docs/cell-execution-language)
-- [Cell insertion affordances](/docs/cell-insertion-affordances)
-- [Editor surfaces](/docs/editor-surfaces)
-- [Runtime surfaces](/docs/runtime-surfaces)
-- [Search surfaces](/docs/search-surfaces)
-- [Markdown typography](/docs/markdown-typography)
-- [Output renderers](/docs/output-renderers)
-- [Output isolation surfaces](/docs/isolated-output-surfaces)
-- [Read-only notebook surfaces](/docs/read-only-notebook-surfaces)
-- [Theme surfaces](/docs/theme-surfaces)
-- [Widget surfaces](/docs/widget-surfaces)
+**Workspace**
+- [Cloud dashboard](/docs/cloud-dashboard) — Notebook home, recent work, workstation state
+- [Compute placement](/docs/compute-placement) — Workstation selection and environment context
+- [Identity and environment](/docs/identity-environment-surfaces) — User context and access state
+- [Cloud notebook shell](/docs/cloud-notebook-shell) — Presence, sync, and collaboration
+
+**Notebook**
+- [Notebook toolbar](/docs/notebook-toolbar-surfaces) — Execution controls and kernel state
+- [Notebook outline](/docs/notebook-outline) — Navigation and document structure
+- [Cell execution language](/docs/cell-execution-language) — Execution state and cell status
+- [Cell insertion](/docs/cell-insertion-affordances) — Add code, markdown, and data cells
+- [Search](/docs/search-surfaces) — Find in notebook and execution history
+- [Editor](/docs/editor-surfaces) — Code editing and syntax highlighting
+
+**Execution & Output**
+- [Output renderers](/docs/output-renderers) — Tables, charts, dataframes, and artifacts
+- [Widget surfaces](/docs/widget-surfaces) — Interactive controls and ipywidgets
+- [Output isolation](/docs/isolated-output-surfaces) — Secure rendering and sandboxing
+- [Runtime surfaces](/docs/runtime-surfaces) — Environment trust and kernel state
+- [Package managers](/docs/package-manager-surfaces) — Dependency management
+
+**Components**
+- [Cell anatomy](/docs/cell-anatomy) — Cell structure and component inventory
+- [Read-only notebooks](/docs/read-only-notebook-surfaces) — Published notebook views
+- [Theme surfaces](/docs/theme-surfaces) — Color palettes and visual styling
+- [Notebook shell capabilities](/docs/notebook-shell-capabilities) — Host capabilities
+- [Markdown typography](/docs/markdown-typography) — Document formatting

--- a/apps/elements/lib/layout.shared.tsx
+++ b/apps/elements/lib/layout.shared.tsx
@@ -8,7 +8,7 @@ export function baseOptions(): BaseLayoutProps {
     },
     links: [
       {
-        text: "Catalog",
+        text: "Surfaces",
         url: "/docs",
         active: "nested-url",
       },


### PR DESCRIPTION
## Summary

Phase 1 redesign pass for the Elements app catalog, moving it away from implementation-oriented component buckets and toward a calmer data-notebook workspace IA.

This is intentionally a focused first pass: it keeps existing deterministic fixtures and production-backed examples intact while making the app shell/catalog read more like a professional notebook/data workflow product surface.

## Design direction

Primary inspiration: Outerbounds-style operational seriousness.
Secondary inspiration: Noteable, Colab, and Hex.

This PR emphasizes:
- workspace / notebook / execution / output workflow grouping
- calmer catalog section hierarchy
- more operational data-product vocabulary
- less component-gallery feel
- no agent-fantasy UI, no toy chrome, no fake warehouse features

## Changes

- Reorganizes the Elements home catalog into workflow groups:
  - Workspace
  - Notebook
  - Execution & Output
  - Components
- Updates catalog labels and descriptions toward execution state, artifacts, workstations, and data workflows.
- Updates Elements metadata/docs index copy to match the new IA.
- Renames the shared nav label from “Catalog” to “Surfaces”.
- Refines catalog card hover treatment and group headers for a calmer product feel.

## Verification

```bash
pnpm --filter nteract-elements build
```

Passed locally:
- Next.js production build completed
- TypeScript completed
- 24 static pages generated

## Notes

This is a deliberately small Phase 1 so Kyle can try it locally and steer the next pass. Follow-up loops can go deeper on individual surfaces, fixture scenarios, execution-state examples, and Outerbounds/Hex-style data workflow details.
