### PR TITLE
fix(notebook-cloud): simplify filters and support oidc agents

### DIFF
--- a/apps/notebook-cloud/README.md
+++ b/apps/notebook-cloud/README.md
@@ -714,14 +714,16 @@ The workstation agent reads `NTERACT_API_KEY` from the environment and also
 loads `${PREVIEW_RUNT_ENV:-$HOME/preview.runt.run/.env}` when present. It
 registers and heartbeats the current machine through `POST /api/workstations`,
 polls `GET /api/workstations/:workstationId/attach-jobs`, and spawns
-`runtimed cloud-runtime-agent` for pending attach jobs. The API key is passed to
-the runtime peer through `RUNT_CLOUD_TOKEN`, not through argv; `runtimed`
-removes cloud/API-key environment variables again before launching the Python
-kernel. Run this helper inside tmux for preview/manual testing so the polling
-agent stays alive while the browser attaches workstations. After the agent
-registers, select it as the default workstation in the notebook UI or call
-`PATCH /api/workstations/default`, then use the Workstations rail in a private
-owner room to request attachment.
+`runtimed cloud-runtime-agent` for pending attach jobs. API-key auth is the
+default (`NOTEBOOK_CLOUD_WORKSTATION_AUTH_KIND=anaconda-key`); set
+`NOTEBOOK_CLOUD_WORKSTATION_AUTH_KIND=oidc` when `NTERACT_API_KEY` carries a
+short-lived OIDC bearer token. The credential is passed to the runtime peer
+through `RUNT_CLOUD_TOKEN`, not through argv; `runtimed` removes cloud
+environment variables again before launching the Python kernel. Run this helper
+inside tmux for preview/manual testing so the polling agent stays alive while
+the browser attaches workstations. After the agent registers, select it as the
+default workstation in the notebook UI or call `PATCH /api/workstations/default`,
+then use the Workstations rail in a private owner room to request attachment.
 
 With the workstation agent already running, use the toolbar smoke to exercise
 the hosted browser path end to end. It verifies the registered workstation is
@@ -737,7 +739,9 @@ pnpm --dir apps/notebook-cloud smoke:hosted:workstation-toolbar
 The smoke reads the API key from the environment or
 `${PREVIEW_RUNT_ENV:-$HOME/preview.runt.run/.env}` and reads the browser OIDC
 token cache from `${NTERACT_PREVIEW_OIDC_TOKEN_PATH:-$HOME/token.preview.json}`.
-It does not print token material. Set
+Set `NOTEBOOK_CLOUD_WORKSTATION_TOOLBAR_SMOKE_AUTH_KIND=oidc` (or the shared
+`NOTEBOOK_CLOUD_WORKSTATION_AUTH_KIND=oidc`) to use that OIDC token for setup
+calls when an API key is not available. It does not print token material. Set
 `NOTEBOOK_CLOUD_WORKSTATION_TOOLBAR_SMOKE_WORKSTATION_ID` to target a
 workstation other than `lab2`.
 

--- a/apps/notebook-cloud/scripts/hosted-workstation-agent-core.mjs
+++ b/apps/notebook-cloud/scripts/hosted-workstation-agent-core.mjs
@@ -1,6 +1,9 @@
 import os from "node:os";
 import path from "node:path";
 
+export const DEFAULT_WORKSTATION_AUTH_KIND = "anaconda-key";
+export const WORKSTATION_AUTH_KINDS = new Set([DEFAULT_WORKSTATION_AUTH_KIND, "oidc"]);
+
 export function buildWorkstationRegistrationPayload({
   workstationId,
   displayName,
@@ -36,6 +39,7 @@ export function buildAttachJobSpawnPlan({
   workingDirectory,
   workstationId,
   displayName,
+  authKind = DEFAULT_WORKSTATION_AUTH_KIND,
 }) {
   assert(typeof job.job_id === "string" && job.job_id.length > 0, "attach job missing id");
   assert(
@@ -47,10 +51,11 @@ export function buildAttachJobSpawnPlan({
   const blobRoot = path.join(runRoot, "blobs");
   const logPath = path.join(runRoot, "runtime-peer.log");
   const launchDirectory = job.working_directory ?? workingDirectory;
+  const normalizedAuthKind = normalizeWorkstationAuthKind(authKind);
   const args = [
     "cloud-runtime-agent",
     "--auth-kind",
-    "anaconda-key",
+    normalizedAuthKind,
     "--cloud-url",
     baseUrl,
     "--notebook-id",
@@ -82,7 +87,7 @@ export function buildAttachJobSpawnPlan({
   };
 }
 
-export function buildRuntimeAgentEnv(env, apiKey) {
+export function buildRuntimeAgentEnv(env, credential) {
   return compactEnv({
     HOME: env.HOME,
     PATH: env.PATH,
@@ -92,8 +97,41 @@ export function buildRuntimeAgentEnv(env, apiKey) {
     SSL_CERT_DIR: env.SSL_CERT_DIR,
     RUST_BACKTRACE: env.RUST_BACKTRACE,
     RUST_LOG: env.RUST_LOG ?? "info",
-    RUNT_CLOUD_TOKEN: apiKey,
+    RUNT_CLOUD_TOKEN: credential,
   });
+}
+
+export function buildWorkstationAuthHeaders(authKind, credential) {
+  const normalizedAuthKind = normalizeWorkstationAuthKind(authKind);
+  const token = credential?.trim();
+  assert(token, "hosted workstation credential is required");
+  const headers = {
+    Authorization: `Bearer ${token}`,
+  };
+  if (normalizedAuthKind === "anaconda-key") {
+    headers["X-Notebook-Cloud-Auth-Provider"] = "anaconda-api-key";
+  }
+  return headers;
+}
+
+export function normalizeWorkstationAuthKind(value) {
+  const normalized = String(value ?? DEFAULT_WORKSTATION_AUTH_KIND)
+    .trim()
+    .toLowerCase();
+  if (normalized === "anaconda-api-key") {
+    return DEFAULT_WORKSTATION_AUTH_KIND;
+  }
+  if (normalized === "oidc-bearer") {
+    return "oidc";
+  }
+  if (WORKSTATION_AUTH_KINDS.has(normalized)) {
+    return normalized;
+  }
+  throw new Error(
+    `NOTEBOOK_CLOUD_WORKSTATION_AUTH_KIND must be ${Array.from(WORKSTATION_AUTH_KINDS).join(
+      " or ",
+    )}`,
+  );
 }
 
 export function compactEnv(entries) {

--- a/apps/notebook-cloud/scripts/hosted-workstation-agent.mjs
+++ b/apps/notebook-cloud/scripts/hosted-workstation-agent.mjs
@@ -8,7 +8,10 @@ import { fileURLToPath } from "node:url";
 import {
   buildAttachJobSpawnPlan,
   buildRuntimeAgentEnv,
+  buildWorkstationAuthHeaders,
   buildWorkstationRegistrationPayload,
+  DEFAULT_WORKSTATION_AUTH_KIND,
+  normalizeWorkstationAuthKind,
   parsePositiveInteger,
   stableWorkstationId,
 } from "./hosted-workstation-agent-core.mjs";
@@ -20,7 +23,13 @@ const workspaceRoot = notebookCloudWorkspaceRoot({ cwd: appDir });
 await loadOptionalEnvFile();
 
 const baseUrl = notebookCloudBaseUrl();
-const apiKey = process.env.NTERACT_API_KEY ?? process.env.NOTEBOOK_CLOUD_PUBLISH_BEARER_TOKEN;
+const cloudCredential =
+  process.env.NTERACT_API_KEY ?? process.env.NOTEBOOK_CLOUD_PUBLISH_BEARER_TOKEN;
+const authKind = normalizeWorkstationAuthKind(
+  process.env.NOTEBOOK_CLOUD_WORKSTATION_AUTH_KIND ??
+    process.env.NTERACT_CLOUD_AUTH_KIND ??
+    DEFAULT_WORKSTATION_AUTH_KIND,
+);
 const workstationId =
   process.env.NOTEBOOK_CLOUD_WORKSTATION_ID ?? stableWorkstationId(os.hostname());
 const displayName =
@@ -55,7 +64,7 @@ main().catch((error) => {
 });
 
 async function main() {
-  requireApiKey();
+  requireCloudCredential();
   await assertBinaryExists(runtimedBin, "runtimed");
   const pythonPath = await resolvePythonPath();
   await mkdir(agentRoot, { recursive: true });
@@ -68,6 +77,7 @@ async function main() {
       displayName,
       workingDirectory,
       pythonPath,
+      authKind,
       pollIntervalMs,
     }),
   );
@@ -92,7 +102,7 @@ async function registerWorkstation(pythonPath) {
   const response = await fetch(new URL("/api/workstations", baseUrl), {
     method: "POST",
     headers: {
-      ...apiKeyHeaders(),
+      ...cloudAuthHeaders(),
       "Content-Type": "application/json",
     },
     body: JSON.stringify(
@@ -112,7 +122,7 @@ async function pollAttachJobs(pythonPath) {
   const response = await fetch(
     new URL(`/api/workstations/${encodeURIComponent(workstationId)}/attach-jobs`, baseUrl),
     {
-      headers: apiKeyHeaders(),
+      headers: cloudAuthHeaders(),
     },
   );
   const body = await responseJson(response);
@@ -132,6 +142,7 @@ async function startAttachJob(job, pythonPath) {
     workingDirectory,
     workstationId,
     displayName,
+    authKind,
   });
   await mkdir(plan.blobRoot, { recursive: true });
   await patchAttachJob(job.job_id, {
@@ -217,7 +228,7 @@ async function patchAttachJob(jobId, patch) {
     {
       method: "PATCH",
       headers: {
-        ...apiKeyHeaders(),
+        ...cloudAuthHeaders(),
         "Content-Type": "application/json",
       },
       body: JSON.stringify(patch),
@@ -250,23 +261,20 @@ async function loadOptionalEnvFile() {
   }
 }
 
-function requireApiKey() {
-  if (!apiKey) {
+function requireCloudCredential() {
+  if (!cloudCredential) {
     throw new Error(
       "NTERACT_API_KEY or NOTEBOOK_CLOUD_PUBLISH_BEARER_TOKEN is required for hosted workstation agent",
     );
   }
 }
 
-function apiKeyHeaders() {
-  return {
-    Authorization: `Bearer ${apiKey}`,
-    "X-Notebook-Cloud-Auth-Provider": "anaconda-api-key",
-  };
+function cloudAuthHeaders() {
+  return buildWorkstationAuthHeaders(authKind, cloudCredential);
 }
 
 function runtimeAgentEnv() {
-  return buildRuntimeAgentEnv(process.env, apiKey);
+  return buildRuntimeAgentEnv(process.env, cloudCredential);
 }
 
 async function resolvePythonPath() {

--- a/apps/notebook-cloud/scripts/hosted-workstation-toolbar-smoke.mjs
+++ b/apps/notebook-cloud/scripts/hosted-workstation-toolbar-smoke.mjs
@@ -6,6 +6,11 @@ import { pathToFileURL } from "node:url";
 import { chromium } from "@playwright/test";
 
 import {
+  buildWorkstationAuthHeaders,
+  DEFAULT_WORKSTATION_AUTH_KIND,
+  normalizeWorkstationAuthKind,
+} from "./hosted-workstation-agent-core.mjs";
+import {
   saveSmokeScreenshot,
   smokeJsonReportPath,
   smokeOutputPath,
@@ -23,7 +28,12 @@ async function main() {
   await loadOptionalEnvFile();
 
   const baseUrl = process.env.NTERACT_CLOUD_URL ?? "https://preview.runt.run";
-  const apiKey = process.env.NTERACT_API_KEY ?? process.env.NOTEBOOK_CLOUD_PUBLISH_BEARER_TOKEN;
+  const authKind = normalizeWorkstationAuthKind(
+    process.env.NOTEBOOK_CLOUD_WORKSTATION_TOOLBAR_SMOKE_AUTH_KIND ??
+      process.env.NOTEBOOK_CLOUD_WORKSTATION_AUTH_KIND ??
+      process.env.NTERACT_CLOUD_AUTH_KIND ??
+      DEFAULT_WORKSTATION_AUTH_KIND,
+  );
   const workstationId =
     process.env.NOTEBOOK_CLOUD_WORKSTATION_TOOLBAR_SMOKE_WORKSTATION_ID ??
     process.env.NOTEBOOK_CLOUD_WORKSTATION_ID ??
@@ -56,14 +66,17 @@ async function main() {
   );
   const reportPath = smokeJsonReportPath("hosted-workstation-toolbar-smoke");
 
-  if (!apiKey) {
+  const tokenStorageJson = await readOidcTokenStorageJson(tokenPath);
+  const token = JSON.parse(tokenStorageJson);
+  const cloudCredential =
+    authKind === "oidc"
+      ? token.accessToken
+      : (process.env.NTERACT_API_KEY ?? process.env.NOTEBOOK_CLOUD_PUBLISH_BEARER_TOKEN);
+  if (!cloudCredential) {
     throw new Error(
       "NTERACT_API_KEY or NOTEBOOK_CLOUD_PUBLISH_BEARER_TOKEN is required for hosted workstation toolbar smoke",
     );
   }
-
-  const tokenStorageJson = await readOidcTokenStorageJson(tokenPath);
-  const token = JSON.parse(tokenStorageJson);
   const tokenSecondsRemaining = Number(token.expiresAt) - Math.floor(Date.now() / 1000);
   if (!Number.isFinite(tokenSecondsRemaining) || tokenSecondsRemaining <= 60) {
     throw new Error(
@@ -75,7 +88,8 @@ async function main() {
     baseUrl,
     label: "list workstations",
     pathname: "/api/workstations",
-    token: apiKey,
+    authKind,
+    credential: cloudCredential,
   });
   const workstation = Array.isArray(workstationList.workstations)
     ? workstationList.workstations.find((item) => item?.workstation_id === workstationId)
@@ -95,7 +109,8 @@ async function main() {
     label: "set default workstation",
     method: "PATCH",
     pathname: "/api/workstations/default",
-    token: apiKey,
+    authKind,
+    credential: cloudCredential,
   });
   const created = await fetchJson({
     baseUrl,
@@ -104,7 +119,8 @@ async function main() {
     label: "create notebook",
     method: "POST",
     pathname: "/api/n",
-    token: apiKey,
+    authKind,
+    credential: cloudCredential,
   });
   const viewerUrl = scalarString(created.viewer_url);
   if (!viewerUrl) {
@@ -123,6 +139,7 @@ async function main() {
   const report = {
     ok: true,
     baseUrl,
+    authKind,
     notebookId: created.notebook_id,
     source,
     title,
@@ -818,13 +835,13 @@ async function fetchJson({
   label,
   method = "GET",
   pathname,
-  token,
+  authKind,
+  credential,
 }) {
   const requestInit = {
     headers: {
-      Authorization: `Bearer ${token}`,
+      ...buildWorkstationAuthHeaders(authKind, credential),
       "Content-Type": "application/json",
-      "X-Notebook-Cloud-Auth-Provider": "anaconda-api-key",
       "X-Scope": "owner",
     },
     method,

--- a/apps/notebook-cloud/test/hosted-workstation-agent.test.mjs
+++ b/apps/notebook-cloud/test/hosted-workstation-agent.test.mjs
@@ -2,9 +2,11 @@ import assert from "node:assert/strict";
 import { describe, it } from "node:test";
 
 import {
+  buildWorkstationAuthHeaders,
   buildAttachJobSpawnPlan,
   buildRuntimeAgentEnv,
   buildWorkstationRegistrationPayload,
+  normalizeWorkstationAuthKind,
   parsePositiveInteger,
   stableWorkstationId,
 } from "../scripts/hosted-workstation-agent-core.mjs";
@@ -50,6 +52,25 @@ describe("hosted workstation agent launch contract", () => {
     ]);
   });
 
+  it("can launch runtime peers with OIDC bearer auth without an API-key provider header", () => {
+    const plan = buildAttachJobSpawnPlan({
+      job: {
+        job_id: "job-oidc",
+        notebook_id: "nb-oidc",
+      },
+      pythonPath: "/opt/k/bin/python",
+      agentRoot: "/tmp/agent",
+      baseUrl: "https://preview.runt.run",
+      workingDirectory: "/home/ubuntu/project",
+      workstationId: "ws-lab2",
+      displayName: "lab2 workstation",
+      authKind: "oidc",
+    });
+
+    assert.deepEqual(plan.args.slice(0, 3), ["cloud-runtime-agent", "--auth-kind", "oidc"]);
+    assert.equal(plan.args.includes("oidc-token"), false);
+  });
+
   it("lets an attach job override cwd and notebook path without putting secrets in argv", () => {
     const plan = buildAttachJobSpawnPlan({
       job: {
@@ -74,7 +95,7 @@ describe("hosted workstation agent launch contract", () => {
     assert.equal(plan.args.includes("secret-api-key"), false);
   });
 
-  it("passes the API key only through the runtime peer environment", () => {
+  it("passes the cloud credential only through the runtime peer environment", () => {
     const env = buildRuntimeAgentEnv(
       {
         HOME: "/home/ubuntu",
@@ -91,6 +112,19 @@ describe("hosted workstation agent launch contract", () => {
     assert.equal(env.HOME, "/home/ubuntu");
     assert.equal(env.PATH, "/usr/bin");
     assert.equal(env.RUST_LOG, "info");
+  });
+
+  it("builds workstation auth headers for API-key and OIDC credentials", () => {
+    assert.deepEqual(buildWorkstationAuthHeaders("anaconda-key", "key-secret"), {
+      Authorization: "Bearer key-secret",
+      "X-Notebook-Cloud-Auth-Provider": "anaconda-api-key",
+    });
+    assert.deepEqual(buildWorkstationAuthHeaders("oidc", "oidc-secret"), {
+      Authorization: "Bearer oidc-secret",
+    });
+    assert.equal(normalizeWorkstationAuthKind("anaconda-api-key"), "anaconda-key");
+    assert.equal(normalizeWorkstationAuthKind("oidc-bearer"), "oidc");
+    assert.throws(() => normalizeWorkstationAuthKind("cookie"), /WORKSTATION_AUTH_KIND/);
   });
 
   it("projects stable registration metadata for the current Python launcher", () => {

--- a/apps/notebook-cloud/viewer/cloud-notebook-dashboard-view.tsx
+++ b/apps/notebook-cloud/viewer/cloud-notebook-dashboard-view.tsx
@@ -109,12 +109,14 @@ export function CloudNotebookDashboard({
                   <button
                     key={filter.id}
                     type="button"
+                    aria-label={`${filter.label}: ${filter.count} notebook${
+                      filter.count === 1 ? "" : "s"
+                    }`}
                     aria-pressed={view.filterId === filter.id}
                     data-active={view.filterId === filter.id ? "true" : undefined}
                     onClick={() => setFilterId(filter.id)}
                   >
                     <span>{filter.label}</span>
-                    <strong>{filter.count}</strong>
                   </button>
                 ))}
               </div>

--- a/apps/notebook-cloud/viewer/index.css
+++ b/apps/notebook-cloud/viewer/index.css
@@ -573,10 +573,8 @@ body {
 }
 
 .cloud-dashboard-filters button {
-  display: inline-grid;
-  grid-template-columns: minmax(0, auto) auto;
+  display: inline-flex;
   align-items: center;
-  gap: 0.5rem;
   min-height: 2rem;
   border: 1px solid transparent;
   border-radius: 6px;
@@ -604,12 +602,6 @@ body {
 
 .cloud-dashboard-filter-group[data-group="cleanup"] button[data-active="true"] {
   color: var(--foreground);
-}
-
-.cloud-dashboard-filters strong {
-  color: color-mix(in srgb, var(--foreground) 54%, transparent);
-  font-size: 0.75rem;
-  font-weight: 700;
 }
 
 .cloud-dashboard-continue {

--- a/packages/runtimed/src/notebook-workstation-panel.ts
+++ b/packages/runtimed/src/notebook-workstation-panel.ts
@@ -173,16 +173,35 @@ function workstationStatus(
     };
   }
 
+  const isPreviousCloudAttachment = previousCloudAttachmentTarget(target);
+  const detail =
+    target.detail ??
+    (capabilities.runtime.source === "local"
+      ? "The local daemon is not exposing an executable runtime."
+      : "No runtime peer is attached to this room.");
+
   return {
-    title: capabilities.runtime.source === "local" ? `${target.label} unavailable` : target.label,
-    detail:
-      target.detail ??
-      (capabilities.runtime.source === "local"
-        ? "The local daemon is not exposing an executable runtime."
-        : "No runtime peer is attached to this room."),
+    title: isPreviousCloudAttachment
+      ? "Previous attachment"
+      : capabilities.runtime.source === "local"
+        ? `${target.label} unavailable`
+        : target.label,
+    detail: isPreviousCloudAttachment ? `${target.label}: ${detail}` : detail,
     statusLabel: target.statusLabel ?? "Offline",
     tone: "offline",
   };
+}
+
+function previousCloudAttachmentTarget(
+  target: ReturnType<typeof resolveNotebookShellRuntimeTarget>,
+): boolean {
+  return (
+    target.kind === "cloud_workstation" &&
+    target.id !== null &&
+    target.id !== undefined &&
+    target.id !== "workstation:none" &&
+    (target.status === "attention" || target.status === "offline")
+  );
 }
 
 function runtimeResourceLabel(

--- a/src/components/notebook/__tests__/NotebookWorkstationsPanel.test.tsx
+++ b/src/components/notebook/__tests__/NotebookWorkstationsPanel.test.tsx
@@ -477,9 +477,10 @@ describe("NotebookWorkstationsPanel", () => {
       />,
     );
 
-    expect(screen.getAllByRole("heading", { name: "Lab2" })).toHaveLength(2);
+    expect(screen.getByRole("heading", { name: "Previous attachment" })).toBeVisible();
+    expect(screen.getAllByRole("heading", { name: "Lab2" })).toHaveLength(1);
     expect(screen.getByText("Needs attention")).toBeVisible();
-    expect(screen.getByText(/runtime peer disconnected/)).toBeVisible();
+    expect(screen.getByText(/Lab2: runtime peer disconnected/)).toBeVisible();
     expect(screen.queryByText("Runtime peer")).not.toBeInTheDocument();
     expect(screen.getAllByText("Current Python")).toHaveLength(1);
     expect(screen.getAllByText("/home/ubuntu/project")).toHaveLength(1);


### PR DESCRIPTION
## Summary

- Removes visible count noise from the `/n` dashboard filter row; sections still carry count context where it helps, and filter buttons keep count-aware accessible labels.
- Lets the hosted workstation agent run with either API-key auth (`anaconda-key`, default) or OIDC bearer auth (`NOTEBOOK_CLOUD_WORKSTATION_AUTH_KIND=oidc`).
- Passes the matching auth kind to `runtimed cloud-runtime-agent` while keeping credentials out of argv and only in request headers / `RUNT_CLOUD_TOKEN`.
- Updates the workstation-agent README and tests so preview/manual sessions can use a refreshed browser OIDC token when a long-lived API key is not available.
- Updates the hosted workstation toolbar smoke to use the same OIDC token for setup calls when `NOTEBOOK_CLOUD_WORKSTATION_TOOLBAR_SMOKE_AUTH_KIND=oidc`, so the full attach/execute smoke works with the credentials available on this box.
- Projects stale cloud workstation attachments as `Previous attachment` in the shared panel projection, with the real workstation name kept in detail and the live registered workstation row left actionable.

## Preview

Deployed to preview.runt.run from this branch after the projection polish.

- Main Worker version: `4f150833-e9fc-4349-b6e4-6e78d6db98fc`
- Renderer assets Worker version: `20a209d4-d3b7-4a83-a031-5c82be809634`

## Validation

- `pnpm --dir apps/notebook-cloud exec node --test test/hosted-workstation-agent.test.mjs`
- `pnpm --dir apps/notebook-cloud exec node --import tsx --test test/notebook-dashboard.test.ts`
- `pnpm test:run src/components/notebook/__tests__/NotebookWorkstationsPanel.test.tsx`
- `node --check apps/notebook-cloud/scripts/hosted-workstation-toolbar-smoke.mjs`
- `pnpm --dir apps/notebook-cloud exec tsc --noEmit --pretty false`
- `cargo xtask lint --fix`
- `pnpm --dir apps/notebook-cloud run deploy`
- `pnpm --dir apps/notebook-cloud run deploy:check`
- `NOTEBOOK_CLOUD_WORKSTATION_TOOLBAR_SMOKE_AUTH_KIND=oidc NOTEBOOK_CLOUD_WORKSTATION_TOOLBAR_SMOKE_TIMEOUT_MS=90000 pnpm --dir apps/notebook-cloud smoke:hosted:workstation-toolbar`
- Preview Playwright smoke on deployed head: `/` routes to `/n`; `/n` desktop/mobile screenshots render loaded notebook sections without email leakage, without `Not published` noise, and with no console/page/request errors.
- Preview Playwright workstation panel smoke on deployed head: desktop/mobile screenshots render `Previous attachment` for the stale active target and the online/default `lab2 workstation` row with no console/page/request errors.
- Live workstation check: `lab2 workstation` is online/default on preview, running through the committed workstation agent with `NOTEBOOK_CLOUD_WORKSTATION_AUTH_KIND=oidc`.

## Notes

This is a small follow-up to #3509 after it merged: it keeps the dashboard quieter, replaces the temporary local OIDC workstation-agent wrapper with explicit supported auth modes, and keeps stale workstation recovery readable without duplicating the same workstation as two headings.
