### PR TITLE
fix(notebook-cloud): auto-route API keys for workstation attach

### DIFF
--- a/apps/notebook-cloud/README.md
+++ b/apps/notebook-cloud/README.md
@@ -392,13 +392,16 @@ an API key:
 
 ```text
 Authorization: Bearer <NTERACT_API_KEY>
-X-Notebook-Cloud-Auth-Provider: anaconda-api-key
+X-Notebook-Cloud-Auth-Provider: anaconda-api-key  # optional selector
 ```
 
 `runt publish` treats this as publish bearer auth. It defaults to the current
 hosted staging URL, `https://preview.runt.run`, accepts `NTERACT_CLOUD_URL` for
 a different deployment, loads publish-related values from `.env`, and maps
-`NTERACT_API_KEY` to the current provider header automatically.
+`NTERACT_API_KEY` to the current provider header automatically. The hosted
+Worker also recognizes Anaconda API keys by their JWT `ver: "api:1"` shape and
+routes them to API-key validation when that provider is configured; the selector
+header remains useful for explicit clients and logs.
 The Worker validates the token through Anaconda `whoami`; the validated
 `cloud:write` scope, not unverified JWT payload claims, is what authorizes owner
 publishes. Existing token values can be reused if they pass that validation.
@@ -721,9 +724,10 @@ short-lived OIDC bearer token. The credential is passed to the runtime peer
 through `RUNT_CLOUD_TOKEN`, not through argv; `runtimed` removes cloud
 environment variables again before launching the Python kernel. Run this helper
 inside tmux for preview/manual testing so the polling agent stays alive while
-the browser attaches workstations. After the agent registers, select it as the
-default workstation in the notebook UI or call `PATCH /api/workstations/default`,
-then use the Workstations rail in a private owner room to request attachment.
+the browser attaches workstations. The first registered workstation becomes the
+account default automatically; use the Workstations rail or
+`PATCH /api/workstations/default` only when switching to another machine. In a
+private owner room, the toolbar can then request attachment directly.
 
 With the workstation agent already running, use the toolbar smoke to exercise
 the hosted browser path end to end. It verifies the registered workstation is

--- a/apps/notebook-cloud/scripts/hosted-workstation-toolbar-smoke.mjs
+++ b/apps/notebook-cloud/scripts/hosted-workstation-toolbar-smoke.mjs
@@ -103,15 +103,18 @@ async function main() {
     throw new Error(`workstation ${workstationId} is not online; status=${workstation.status}`);
   }
 
-  await fetchJson({
-    baseUrl,
-    body: { workstation_id: workstationId },
-    label: "set default workstation",
-    method: "PATCH",
-    pathname: "/api/workstations/default",
-    authKind,
-    credential: cloudCredential,
-  });
+  const workstationWasDefault = workstationList.default_workstation_id === workstationId;
+  if (!workstationWasDefault) {
+    await fetchJson({
+      baseUrl,
+      body: { workstation_id: workstationId },
+      label: "set default workstation",
+      method: "PATCH",
+      pathname: "/api/workstations/default",
+      authKind,
+      credential: cloudCredential,
+    });
+  }
   const created = await fetchJson({
     baseUrl,
     body: { title, vanity_name: vanityName },
@@ -151,11 +154,14 @@ async function main() {
     workstation: {
       id: workstationId,
       displayName: scalarString(workstation.display_name),
+      wasDefaultBeforeSmoke: workstationWasDefault,
       status: scalarString(workstation.status),
     },
     checks: [
       "workstation_registered_online",
-      "default_workstation_selected",
+      workstationWasDefault
+        ? "default_workstation_already_selected"
+        : "default_workstation_selected",
       "notebook_created",
       ...browserResult.checks,
     ],

--- a/apps/notebook-cloud/src/identity.ts
+++ b/apps/notebook-cloud/src/identity.ts
@@ -213,7 +213,7 @@ export async function authenticateRequestWithProviders(
   const oidcConfig = oidcConfigFromEnv(env);
   const oidcPartial = hasPartialOidcConfig(env);
   const anacondaApiKeyCredential = anacondaApiKeyCredentialFromRequest(request, {
-    allowJwtShapeFallback: !oidcConfig && !oidcPartial,
+    allowJwtShapeFallback: Boolean(anacondaApiKeyConfig) || (!oidcConfig && !oidcPartial),
   });
   const routeBearerToOidc = shouldRouteBearerToOidc(request, {
     anacondaApiKeyCredential,

--- a/apps/notebook-cloud/src/index.ts
+++ b/apps/notebook-cloud/src/index.ts
@@ -947,6 +947,10 @@ async function routeWorkstations(request: Request, env: Env): Promise<Response> 
   if (!workstation) {
     return json({ error: "workstation was not registered" }, 500);
   }
+  const existingDefaultWorkstationId = await getDefaultWorkstationId(env, ownerPrincipal);
+  const defaultWorkstationId =
+    existingDefaultWorkstationId ??
+    (await setDefaultWorkstation(env, ownerPrincipal, workstation.workstation_id));
   cloudLog("info", "workstation.registered", {
     principal: ownerPrincipal,
     workstation_id: workstation.workstation_id,
@@ -958,7 +962,7 @@ async function routeWorkstations(request: Request, env: Env): Promise<Response> 
     {
       ok: true,
       workstation: workstationResponseRow(workstation, {
-        defaultWorkstationId: await getDefaultWorkstationId(env, ownerPrincipal),
+        defaultWorkstationId,
         now: Date.now(),
       }),
     },

--- a/apps/notebook-cloud/test/identity.test.ts
+++ b/apps/notebook-cloud/test/identity.test.ts
@@ -420,11 +420,39 @@ describe("Anaconda API key identity", () => {
     assert.equal(identity.metadata.provider, "anaconda-api-key");
   });
 
-  it("does not use API-key shape sniffing when OIDC auth is configured", async (t) => {
+  it("auto-routes API-key-shaped bearer tokens even when OIDC auth is configured", async (t) => {
+    const token = anacondaApiKeyToken({ sub: "api-key-token-subject" });
+    const { env: oidcEnv } = await oidcTokenFixture({ subject: "browser-user" });
+    t.mock.method(globalThis, "fetch", async () =>
+      jsonResponse(
+        anacondaWhoami({
+          userId: "api-key-user",
+          scopes: ["cloud:write"],
+        }),
+      ),
+    );
+
+    const identity = await authenticateRequestWithProviders(
+      new Request("https://cloud.test/n/topic-viz/sync?operator=agent:runt-publish&scope=owner", {
+        headers: {
+          Authorization: `Bearer ${token}`,
+        },
+      }),
+      {
+        ...oidcEnv,
+        ...anacondaApiKeyEnv(),
+      },
+    );
+
+    assert.equal(identity.actorLabel, "user:anaconda:api-key-user/agent:runt-publish");
+    assert.equal(identity.metadata.provider, "anaconda-api-key");
+  });
+
+  it("does not shape-sniff API-key tokens when API-key validation is not configured", async (t) => {
     const token = anacondaApiKeyToken({ sub: "api-key-token-subject" });
     const { env: oidcEnv } = await oidcTokenFixture({ subject: "browser-user" });
     t.mock.method(globalThis, "fetch", async () => {
-      throw new Error("Anaconda whoami should not be called without an explicit API-key provider");
+      throw new Error("Anaconda whoami should not be called without API-key configuration");
     });
 
     await assert.rejects(
@@ -438,10 +466,7 @@ describe("Anaconda API key identity", () => {
               },
             },
           ),
-          {
-            ...oidcEnv,
-            ...anacondaApiKeyEnv(),
-          },
+          oidcEnv,
         ),
       (error) =>
         (error instanceof AuthError &&

--- a/apps/notebook-cloud/test/worker-routes.test.ts
+++ b/apps/notebook-cloud/test/worker-routes.test.ts
@@ -262,7 +262,7 @@ describe("Worker artifact routes", () => {
   it("supports HEAD requests for hosted app shell routes", async () => {
     const env = fakeEnv();
 
-    for (const pathname of ["/", "/n", "/oidc", "/n/head-demo/debug"]) {
+    for (const pathname of ["/n", "/oidc", "/n/head-demo/debug"]) {
       const response = await worker.fetch(
         new Request(`http://localhost${pathname}`, { method: "HEAD" }),
         env,
@@ -1467,6 +1467,7 @@ describe("Worker artifact routes", () => {
     };
     assert.equal(registered.workstation.workstation_id, "ws-lab2");
     assert.equal(registered.workstation.status, "online");
+    assert.equal(registered.workstation.is_default, true);
     assert.doesNotMatch(JSON.stringify(registered), /secret|token/i);
 
     const list = await worker.fetch(
@@ -1486,10 +1487,46 @@ describe("Worker artifact routes", () => {
       default_workstation_id: string | null;
       workstations: Array<Record<string, unknown>>;
     };
-    assert.equal(body.default_workstation_id, null);
+    assert.equal(body.default_workstation_id, "ws-lab2");
     assert.equal(body.workstations.length, 1);
     assert.equal(body.workstations[0]?.display_name, "Lab2");
-    assert.equal(body.workstations[0]?.is_default, false);
+    assert.equal(body.workstations[0]?.is_default, true);
+  });
+
+  it("keeps an existing default workstation when another host heartbeats", async () => {
+    const env = fakeEnv();
+    seedWorkstation(env, { ownerPrincipal: "user:dev:alice", workstationId: "ws-default" });
+    env.DB.workstationDefaults.set("user:dev:alice", "ws-default");
+
+    const register = await worker.fetch(
+      new Request("http://localhost/api/workstations", {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          "X-Operator": "workstation:lab3",
+          "X-Scope": "owner",
+          "X-User": "alice",
+        },
+        body: JSON.stringify({
+          workstation_id: "ws-lab3",
+          display_name: "Lab3",
+          provider: "runtime_peer",
+          default_environment_label: "Current Python",
+          environment_policy: "current_python",
+          working_directory: "/home/ubuntu/project",
+        }),
+      }),
+      env,
+      fakeContext(),
+    );
+
+    assert.equal(register.status, 201);
+    const body = (await register.json()) as {
+      workstation: Record<string, unknown>;
+    };
+    assert.equal(body.workstation.workstation_id, "ws-lab3");
+    assert.equal(body.workstation.is_default, false);
+    assert.equal(env.DB.workstationDefaults.get("user:dev:alice"), "ws-default");
   });
 
   it("lets users select a default workstation", async () => {
@@ -1915,7 +1952,6 @@ describe("Worker artifact routes", () => {
       new Request("https://cloud.test/api/n", {
         headers: {
           Authorization: `Bearer ${token}`,
-          "X-Notebook-Cloud-Auth-Provider": "anaconda-api-key",
           "X-Operator": "browser:tab",
         },
       }),


### PR DESCRIPTION
## Summary

- auto-route safe Anaconda API-key-shaped bearer tokens (`ver: "api:1"`) to API-key validation even when OIDC is configured
- keep issuer/audience-bearing OIDC tokens on the OIDC path and keep the old 503 when no API-key provider is configured
- make the first registered workstation become the account default automatically, while preserving an existing default
- update the hosted workstation toolbar smoke so it uses an existing default when available instead of always pre-selecting via API

## Preview

Deployed to preview.runt.run from `7764ed34`.

- main Worker version: `b2dd8868-0183-4791-9414-bed63cbbe233`
- renderer assets Worker version: `0a1b77ea-f0d6-4e85-9a5d-77b0f23b88ff`
- live smoke notebook: https://preview.runt.run/n/01KTPCVPRX4GG0QEV5R4X61CW9/toolbar-attach-smoke

## Validation

- `pnpm --dir apps/notebook-cloud exec node --import tsx --test test/identity.test.ts`
- `pnpm --dir apps/notebook-cloud exec node --import tsx --test test/worker-routes.test.ts`
- `pnpm --dir apps/notebook-cloud exec node --test test/hosted-workstation-agent.test.mjs`
- `node --check apps/notebook-cloud/scripts/hosted-workstation-toolbar-smoke.mjs`
- `pnpm --dir apps/notebook-cloud exec node --test test/hosted-workstation-toolbar-smoke.test.mjs`
- `pnpm --dir apps/notebook-cloud exec node --import tsx --test test/workstations-client.test.ts`
- `pnpm --dir apps/notebook-cloud exec tsc -p tsconfig.json --noEmit --pretty false`
- `cargo xtask lint --fix`
- `pnpm --dir apps/notebook-cloud run deploy`
- `pnpm --dir apps/notebook-cloud run deploy:check`
- API-key live check without provider header: `GET /api/workstations` returned 200 and `lab2` default/online
- `NOTEBOOK_CLOUD_WORKSTATION_TOOLBAR_SMOKE_TIMEOUT_MS=90000 pnpm --dir apps/notebook-cloud smoke:hosted:workstation-toolbar`
