### PR TITLE
fix(cell): bridge insertion target background

### DIFF
--- a/src/components/cell/CellInsertionRibbon.tsx
+++ b/src/components/cell/CellInsertionRibbon.tsx
@@ -31,20 +31,15 @@ const actionButtonIntentClasses: Record<CellInsertionType, string> = {
     "bg-emerald-500/12 text-emerald-700 ring-emerald-500/20 hover:bg-emerald-500/16 dark:text-emerald-300",
 };
 
-const insertionBridgeIntentClasses: Record<CellInsertionType, string> = {
-  code: "bg-sky-500/8 dark:bg-sky-400/10",
-  markdown: "bg-emerald-500/8 dark:bg-emerald-400/10",
+const insertionBridgeLineClasses: Record<CellInsertionType, string> = {
+  code: "bg-sky-400/50 dark:bg-sky-300/40",
+  markdown: "bg-emerald-400/50 dark:bg-emerald-300/40",
 };
 
 const insertionTrailingRuleIntentClasses: Record<CellInsertionType, string> = {
   code: "bg-gradient-to-r from-sky-400/35 via-border/35 to-transparent dark:from-sky-300/30 dark:via-border/30",
   markdown:
     "bg-gradient-to-r from-emerald-400/35 via-border/35 to-transparent dark:from-emerald-300/30 dark:via-border/30",
-};
-
-const insertionChannelIntentClasses: Record<CellInsertionType, string> = {
-  code: "bg-sky-500/8 dark:bg-sky-400/10",
-  markdown: "bg-emerald-500/8 dark:bg-emerald-400/10",
 };
 
 export function CellInsertionRibbon({
@@ -86,10 +81,8 @@ export function CellInsertionRibbon({
     );
 
   const leadingInsertionRuleClass = cn(
-    "transition-colors duration-150",
-    visualActiveType
-      ? cn("h-full", insertionBridgeIntentClasses[visualActiveType])
-      : "h-px rounded-full bg-border/45",
+    "h-px rounded-full transition-colors duration-150",
+    visualActiveType ? insertionBridgeLineClasses[visualActiveType] : "bg-border/45",
   );
   const trailingInsertionRuleClass = cn(
     "h-px rounded-full transition-colors duration-150",
@@ -158,16 +151,26 @@ export function CellInsertionRibbon({
         onFocus={() => setActiveType("code")}
         onClick={() => onInsert("code")}
         className={cn(
-          "flex h-full w-[var(--cell-content-column-inset,3.25rem)] shrink-0 items-center justify-center rounded-none transition-colors duration-150",
+          "relative flex h-full w-[var(--cell-content-column-inset,3.25rem)] shrink-0 items-center justify-center rounded-none transition-colors duration-150",
           "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/30 focus-visible:ring-inset",
           visualActiveType
-            ? insertionChannelIntentClasses[visualActiveType]
+            ? "text-muted-foreground/0"
             : isOpen
               ? "bg-transparent text-muted-foreground/35 hover:bg-muted/20 hover:text-muted-foreground/65"
               : "text-muted-foreground/0 hover:bg-muted/20",
           terminal && "h-7",
         )}
       >
+        {visualActiveType ? (
+          <span
+            data-slot="cell-adder-primary-bridge"
+            className={cn(
+              "pointer-events-none absolute inset-x-0 top-1/2 h-px -translate-y-1/2 rounded-full",
+              insertionBridgeLineClasses[visualActiveType],
+            )}
+            aria-hidden="true"
+          />
+        ) : null}
         <span className="sr-only">Add code cell here</span>
       </button>
       <div
@@ -190,7 +193,7 @@ export function CellInsertionRibbon({
         />
         <div
           data-slot="cell-adder-action-palette"
-          className="flex h-7 shrink-0 items-center gap-1 py-0 pl-0.5 pr-1 transition-colors duration-150"
+          className="flex h-7 shrink-0 items-center gap-1 py-0 pl-0 pr-1 transition-colors duration-150"
         >
           <button
             type="button"

--- a/src/components/cell/CellInsertionRibbon.tsx
+++ b/src/components/cell/CellInsertionRibbon.tsx
@@ -158,8 +158,9 @@ export function CellInsertionRibbon({
         onFocus={() => setActiveType("code")}
         onClick={() => onInsert("code")}
         className={cn(
-          "flex h-full w-[var(--cell-content-column-inset,3.25rem)] shrink-0 items-center justify-center rounded-none transition-colors duration-150",
+          "flex h-full shrink-0 items-center justify-center overflow-hidden rounded-none transition-[background-color,color,width] duration-150",
           "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/30 focus-visible:ring-inset",
+          isOpen ? "w-0 pointer-events-none" : "w-[var(--cell-content-column-inset,3.25rem)]",
           visualActiveType
             ? insertionChannelIntentClasses[visualActiveType]
             : isOpen
@@ -190,10 +191,7 @@ export function CellInsertionRibbon({
         />
         <div
           data-slot="cell-adder-action-palette"
-          className={cn(
-            "flex h-7 shrink-0 items-center gap-1 py-0 pl-0.5 pr-1 transition-colors duration-150",
-            visualActiveType && insertionBridgeIntentClasses[visualActiveType],
-          )}
+          className="flex h-7 shrink-0 items-center gap-1 py-0 pl-0.5 pr-1 transition-colors duration-150"
         >
           <button
             type="button"

--- a/src/components/cell/CellInsertionRibbon.tsx
+++ b/src/components/cell/CellInsertionRibbon.tsx
@@ -158,9 +158,8 @@ export function CellInsertionRibbon({
         onFocus={() => setActiveType("code")}
         onClick={() => onInsert("code")}
         className={cn(
-          "flex h-full shrink-0 items-center justify-center overflow-hidden rounded-none transition-[background-color,color,width] duration-150",
+          "flex h-full w-[var(--cell-content-column-inset,3.25rem)] shrink-0 items-center justify-center rounded-none transition-colors duration-150",
           "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/30 focus-visible:ring-inset",
-          isOpen ? "w-0 pointer-events-none" : "w-[var(--cell-content-column-inset,3.25rem)]",
           visualActiveType
             ? insertionChannelIntentClasses[visualActiveType]
             : isOpen

--- a/src/components/cell/CellInsertionRibbon.tsx
+++ b/src/components/cell/CellInsertionRibbon.tsx
@@ -42,6 +42,11 @@ const insertionTrailingRuleIntentClasses: Record<CellInsertionType, string> = {
     "bg-gradient-to-r from-emerald-400/35 via-border/35 to-transparent dark:from-emerald-300/30 dark:via-border/30",
 };
 
+const insertionTypeOrder: Record<CellInsertionType, number> = {
+  code: 0,
+  markdown: 1,
+};
+
 export function CellInsertionRibbon({
   terminal = false,
   activeType,
@@ -58,6 +63,7 @@ export function CellInsertionRibbon({
   const visualActiveType = resolvedActiveType ?? null;
   const isOpen = interactionActive || forceActionsVisible;
   const actionTabIndex = isOpen ? 0 : -1;
+  const bridgeActiveType = terminal ? null : visualActiveType;
   const ribbonClass = visualActiveType
     ? terminal
       ? terminalInsertionRibbonClasses[visualActiveType]
@@ -71,19 +77,34 @@ export function CellInsertionRibbon({
     onActiveTypeChange?.(type);
   };
 
-  const actionButtonClass = (type: CellInsertionType) =>
-    cn(
-      "inline-flex h-6 items-center justify-center gap-1 rounded-full px-2.5 text-xs font-medium text-muted-foreground/55 transition-colors ring-1 ring-transparent",
+  const actionButtonClass = (type: CellInsertionType) => {
+    const isActive = visualActiveType === type;
+    const isBridgeLead =
+      bridgeActiveType !== null && insertionTypeOrder[type] < insertionTypeOrder[bridgeActiveType];
+    const isBridged =
+      bridgeActiveType !== null && insertionTypeOrder[type] <= insertionTypeOrder[bridgeActiveType];
+
+    return cn(
+      "inline-flex h-6 items-center justify-center gap-1 px-2.5 text-xs font-medium text-muted-foreground/55 transition-colors ring-1 ring-transparent",
       "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/30",
-      visualActiveType === type
+      isBridged ? "rounded-none" : "rounded-full",
+      bridgeActiveType === type && "rounded-l-none rounded-r-full",
+      bridgeActiveType === "code" && type === "markdown" && "ml-1",
+      isActive
         ? actionButtonIntentClasses[type]
-        : "hover:bg-muted/45 hover:text-foreground",
+        : isBridgeLead && bridgeActiveType
+          ? cn(
+              insertionBridgeSurfaceClasses[bridgeActiveType],
+              "text-muted-foreground/45 hover:text-muted-foreground/65",
+            )
+          : "hover:bg-muted/45 hover:text-foreground",
     );
+  };
 
   const leadingInsertionRuleClass = cn(
     "transition-colors duration-150",
-    visualActiveType
-      ? cn("h-6", insertionBridgeSurfaceClasses[visualActiveType])
+    bridgeActiveType
+      ? cn("h-6", insertionBridgeSurfaceClasses[bridgeActiveType])
       : "h-px rounded-full bg-border/45",
   );
   const trailingInsertionRuleClass = cn(
@@ -163,12 +184,12 @@ export function CellInsertionRibbon({
           terminal && "h-7",
         )}
       >
-        {visualActiveType ? (
+        {bridgeActiveType ? (
           <span
             data-slot="cell-adder-primary-bridge"
             className={cn(
               "pointer-events-none absolute inset-x-0 top-1/2 h-6 -translate-y-1/2 rounded-l-full",
-              insertionBridgeSurfaceClasses[visualActiveType],
+              insertionBridgeSurfaceClasses[bridgeActiveType],
             )}
             aria-hidden="true"
           />
@@ -195,7 +216,10 @@ export function CellInsertionRibbon({
         />
         <div
           data-slot="cell-adder-action-palette"
-          className="flex h-7 shrink-0 items-center gap-1 py-0 pl-0 pr-1 transition-colors duration-150"
+          className={cn(
+            "flex h-7 shrink-0 items-center py-0 pl-0 pr-1 transition-colors duration-150",
+            bridgeActiveType ? "gap-0" : "gap-1",
+          )}
         >
           <button
             type="button"

--- a/src/components/cell/CellInsertionRibbon.tsx
+++ b/src/components/cell/CellInsertionRibbon.tsx
@@ -26,14 +26,19 @@ const terminalInsertionRibbonClasses: Record<CellInsertionType, string> = {
 };
 
 const actionButtonIntentClasses: Record<CellInsertionType, string> = {
-  code: "bg-sky-500/12 text-sky-700 ring-sky-500/20 hover:bg-sky-500/16 dark:text-sky-300",
+  code: "border-sky-500/20 bg-sky-500/12 text-sky-700 hover:bg-sky-500/16 dark:border-sky-300/20 dark:text-sky-300",
   markdown:
-    "bg-emerald-500/12 text-emerald-700 ring-emerald-500/20 hover:bg-emerald-500/16 dark:text-emerald-300",
+    "border-emerald-500/20 bg-emerald-500/12 text-emerald-700 hover:bg-emerald-500/16 dark:border-emerald-300/20 dark:text-emerald-300",
 };
 
 const insertionBridgeSurfaceClasses: Record<CellInsertionType, string> = {
   code: "bg-sky-500/12 dark:bg-sky-400/10",
   markdown: "bg-emerald-500/12 dark:bg-emerald-400/10",
+};
+
+const insertionBridgeBorderClasses: Record<CellInsertionType, string> = {
+  code: "border-sky-500/20 dark:border-sky-300/20",
+  markdown: "border-emerald-500/20 dark:border-emerald-300/20",
 };
 
 const insertionTrailingRuleIntentClasses: Record<CellInsertionType, string> = {
@@ -83,18 +88,25 @@ export function CellInsertionRibbon({
       bridgeActiveType !== null && insertionTypeOrder[type] < insertionTypeOrder[bridgeActiveType];
     const isBridged =
       bridgeActiveType !== null && insertionTypeOrder[type] <= insertionTypeOrder[bridgeActiveType];
+    const bridgeClasses = bridgeActiveType
+      ? cn(
+          insertionBridgeSurfaceClasses[bridgeActiveType],
+          insertionBridgeBorderClasses[bridgeActiveType],
+        )
+      : null;
 
     return cn(
-      "inline-flex h-6 items-center justify-center gap-1 px-2.5 text-xs font-medium text-muted-foreground/55 transition-colors ring-1 ring-transparent",
+      "inline-flex h-6 items-center justify-center gap-1 border border-transparent px-2.5 text-xs font-medium text-muted-foreground/55 transition-colors",
       "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/30",
       isBridged ? "rounded-none" : "rounded-full",
       bridgeActiveType === type && "rounded-l-none rounded-r-full",
       bridgeActiveType === "code" && type === "markdown" && "ml-1",
       isActive
         ? actionButtonIntentClasses[type]
-        : isBridgeLead && bridgeActiveType
+        : isBridgeLead && bridgeClasses
           ? cn(
-              insertionBridgeSurfaceClasses[bridgeActiveType],
+              bridgeClasses,
+              "border-x-0",
               "text-muted-foreground/45 hover:text-muted-foreground/65",
             )
           : "hover:bg-muted/45 hover:text-foreground",
@@ -104,7 +116,11 @@ export function CellInsertionRibbon({
   const leadingInsertionRuleClass = cn(
     "transition-colors duration-150",
     bridgeActiveType
-      ? cn("h-6", insertionBridgeSurfaceClasses[bridgeActiveType])
+      ? cn(
+          "h-6 border-y",
+          insertionBridgeSurfaceClasses[bridgeActiveType],
+          insertionBridgeBorderClasses[bridgeActiveType],
+        )
       : "h-px rounded-full bg-border/45",
   );
   const trailingInsertionRuleClass = cn(
@@ -188,8 +204,9 @@ export function CellInsertionRibbon({
           <span
             data-slot="cell-adder-primary-bridge"
             className={cn(
-              "pointer-events-none absolute inset-x-0 top-1/2 h-6 -translate-y-1/2 rounded-l-full",
+              "pointer-events-none absolute inset-x-0 top-1/2 h-6 -translate-y-1/2 rounded-l-full border-y border-l",
               insertionBridgeSurfaceClasses[bridgeActiveType],
+              insertionBridgeBorderClasses[bridgeActiveType],
             )}
             aria-hidden="true"
           />

--- a/src/components/cell/CellInsertionRibbon.tsx
+++ b/src/components/cell/CellInsertionRibbon.tsx
@@ -1,4 +1,4 @@
-import { Code, LetterText, Plus } from "lucide-react";
+import { Code, LetterText } from "lucide-react";
 import { useState } from "react";
 import { cn } from "@/lib/utils";
 import { notebookCellLayoutVars } from "./cell-layout";
@@ -31,9 +31,9 @@ const actionButtonIntentClasses: Record<CellInsertionType, string> = {
     "bg-emerald-500/12 text-emerald-700 ring-emerald-500/20 hover:bg-emerald-500/16 dark:text-emerald-300",
 };
 
-const insertionRuleIntentClasses: Record<CellInsertionType, string> = {
-  code: "bg-sky-400/50 dark:bg-sky-300/40",
-  markdown: "bg-emerald-400/50 dark:bg-emerald-300/40",
+const insertionBridgeIntentClasses: Record<CellInsertionType, string> = {
+  code: "bg-sky-500/8 dark:bg-sky-400/10",
+  markdown: "bg-emerald-500/8 dark:bg-emerald-400/10",
 };
 
 const insertionTrailingRuleIntentClasses: Record<CellInsertionType, string> = {
@@ -43,8 +43,8 @@ const insertionTrailingRuleIntentClasses: Record<CellInsertionType, string> = {
 };
 
 const insertionChannelIntentClasses: Record<CellInsertionType, string> = {
-  code: "bg-sky-500/6 text-sky-700 dark:text-sky-300",
-  markdown: "bg-emerald-500/6 text-emerald-700 dark:text-emerald-300",
+  code: "bg-sky-500/8 dark:bg-sky-400/10",
+  markdown: "bg-emerald-500/8 dark:bg-emerald-400/10",
 };
 
 export function CellInsertionRibbon({
@@ -86,8 +86,10 @@ export function CellInsertionRibbon({
     );
 
   const leadingInsertionRuleClass = cn(
-    "h-px rounded-full transition-colors duration-150",
-    visualActiveType ? insertionRuleIntentClasses[visualActiveType] : "bg-border/45",
+    "transition-colors duration-150",
+    visualActiveType
+      ? cn("h-full", insertionBridgeIntentClasses[visualActiveType])
+      : "h-px rounded-full bg-border/45",
   );
   const trailingInsertionRuleClass = cn(
     "h-px rounded-full transition-colors duration-150",
@@ -166,14 +168,6 @@ export function CellInsertionRibbon({
           terminal && "h-7",
         )}
       >
-        <Plus
-          data-slot="cell-adder-primary-glyph"
-          className={cn(
-            "size-3 transition-opacity duration-150",
-            visualActiveType ? "opacity-100" : "opacity-0",
-          )}
-          aria-hidden="true"
-        />
         <span className="sr-only">Add code cell here</span>
       </button>
       <div
@@ -196,7 +190,10 @@ export function CellInsertionRibbon({
         />
         <div
           data-slot="cell-adder-action-palette"
-          className="flex h-7 shrink-0 items-center gap-1 py-0 pl-0.5 pr-1"
+          className={cn(
+            "flex h-7 shrink-0 items-center gap-1 py-0 pl-0.5 pr-1 transition-colors duration-150",
+            visualActiveType && insertionBridgeIntentClasses[visualActiveType],
+          )}
         >
           <button
             type="button"
@@ -208,7 +205,6 @@ export function CellInsertionRibbon({
             onClick={() => onInsert("code")}
             className={actionButtonClass("code")}
           >
-            <Plus className="h-2.5 w-2.5" aria-hidden="true" />
             <Code className="h-3 w-3" aria-hidden="true" />
             <span>Code</span>
           </button>
@@ -222,7 +218,6 @@ export function CellInsertionRibbon({
             onClick={() => onInsert("markdown")}
             className={actionButtonClass("markdown")}
           >
-            <Plus className="h-2.5 w-2.5" aria-hidden="true" />
             <LetterText className="h-3 w-3" aria-hidden="true" />
             <span>Markdown</span>
           </button>

--- a/src/components/cell/CellInsertionRibbon.tsx
+++ b/src/components/cell/CellInsertionRibbon.tsx
@@ -31,9 +31,9 @@ const actionButtonIntentClasses: Record<CellInsertionType, string> = {
     "bg-emerald-500/12 text-emerald-700 ring-emerald-500/20 hover:bg-emerald-500/16 dark:text-emerald-300",
 };
 
-const insertionBridgeLineClasses: Record<CellInsertionType, string> = {
-  code: "bg-sky-400/50 dark:bg-sky-300/40",
-  markdown: "bg-emerald-400/50 dark:bg-emerald-300/40",
+const insertionBridgeSurfaceClasses: Record<CellInsertionType, string> = {
+  code: "bg-sky-500/12 dark:bg-sky-400/10",
+  markdown: "bg-emerald-500/12 dark:bg-emerald-400/10",
 };
 
 const insertionTrailingRuleIntentClasses: Record<CellInsertionType, string> = {
@@ -81,8 +81,10 @@ export function CellInsertionRibbon({
     );
 
   const leadingInsertionRuleClass = cn(
-    "h-px rounded-full transition-colors duration-150",
-    visualActiveType ? insertionBridgeLineClasses[visualActiveType] : "bg-border/45",
+    "transition-colors duration-150",
+    visualActiveType
+      ? cn("h-6", insertionBridgeSurfaceClasses[visualActiveType])
+      : "h-px rounded-full bg-border/45",
   );
   const trailingInsertionRuleClass = cn(
     "h-px rounded-full transition-colors duration-150",
@@ -165,8 +167,8 @@ export function CellInsertionRibbon({
           <span
             data-slot="cell-adder-primary-bridge"
             className={cn(
-              "pointer-events-none absolute inset-x-0 top-1/2 h-px -translate-y-1/2 rounded-full",
-              insertionBridgeLineClasses[visualActiveType],
+              "pointer-events-none absolute inset-x-0 top-1/2 h-6 -translate-y-1/2 rounded-l-full",
+              insertionBridgeSurfaceClasses[visualActiveType],
             )}
             aria-hidden="true"
           />

--- a/src/components/cell/__tests__/CellInsertionRibbon.test.tsx
+++ b/src/components/cell/__tests__/CellInsertionRibbon.test.tsx
@@ -34,8 +34,7 @@ describe("CellInsertionRibbon", () => {
     );
     expect(container.querySelector('[data-slot="cell-adder-primary-glyph"]')).toBeNull();
     expect(hitTarget).toHaveClass("bg-sky-500/8");
-    expect(hitTarget).toHaveClass("w-0");
-    expect(hitTarget).toHaveClass("pointer-events-none");
+    expect(hitTarget).toHaveClass("w-[var(--cell-content-column-inset,3.25rem)]");
     expect(container.querySelector('[data-slot="cell-adder-leading-rule"]')).toHaveClass("h-full");
 
     fireEvent.click(hitTarget!);
@@ -102,7 +101,7 @@ describe("CellInsertionRibbon", () => {
     expect(palette).not.toHaveClass("rounded-full");
     expect(palette).not.toHaveClass("shadow-sm");
     expect(hitTarget).toHaveClass("bg-emerald-500/8");
-    expect(hitTarget).toHaveClass("w-0");
+    expect(hitTarget).toHaveClass("w-[var(--cell-content-column-inset,3.25rem)]");
     expect(intent).toHaveClass("bg-emerald-400");
     expect(leadingRule).toHaveClass("w-2");
     expect(leadingRule).toHaveClass("h-full");

--- a/src/components/cell/__tests__/CellInsertionRibbon.test.tsx
+++ b/src/components/cell/__tests__/CellInsertionRibbon.test.tsx
@@ -34,6 +34,8 @@ describe("CellInsertionRibbon", () => {
     );
     expect(container.querySelector('[data-slot="cell-adder-primary-glyph"]')).toBeNull();
     expect(hitTarget).toHaveClass("bg-sky-500/8");
+    expect(hitTarget).toHaveClass("w-0");
+    expect(hitTarget).toHaveClass("pointer-events-none");
     expect(container.querySelector('[data-slot="cell-adder-leading-rule"]')).toHaveClass("h-full");
 
     fireEvent.click(hitTarget!);
@@ -96,10 +98,11 @@ describe("CellInsertionRibbon", () => {
     expect(actions).toHaveClass("flex-1");
     expect(palette).toHaveClass("shrink-0");
     expect(palette).toHaveClass("pl-0.5");
-    expect(palette).toHaveClass("bg-emerald-500/8");
+    expect(palette).not.toHaveClass("bg-emerald-500/8");
     expect(palette).not.toHaveClass("rounded-full");
     expect(palette).not.toHaveClass("shadow-sm");
     expect(hitTarget).toHaveClass("bg-emerald-500/8");
+    expect(hitTarget).toHaveClass("w-0");
     expect(intent).toHaveClass("bg-emerald-400");
     expect(leadingRule).toHaveClass("w-2");
     expect(leadingRule).toHaveClass("h-full");
@@ -108,6 +111,7 @@ describe("CellInsertionRibbon", () => {
     expect(trailingRule).toHaveClass("from-emerald-400/35");
     expect(trailingRule).toHaveClass("flex-1");
     expect(screen.getByTitle("Add markdown cell")).toHaveClass("text-emerald-700");
+    expect(screen.getByTitle("Add code cell")).not.toHaveClass("bg-emerald-500/12");
   });
 
   it("softens the terminal row into a document tail", () => {

--- a/src/components/cell/__tests__/CellInsertionRibbon.test.tsx
+++ b/src/components/cell/__tests__/CellInsertionRibbon.test.tsx
@@ -37,9 +37,9 @@ describe("CellInsertionRibbon", () => {
     );
     expect(container.querySelector('[data-slot="cell-adder-primary-glyph"]')).toBeNull();
     expect(hitTarget).toHaveClass("w-[var(--cell-content-column-inset,3.25rem)]");
-    expect(activePrimaryBridge).toHaveClass("h-px");
-    expect(activePrimaryBridge).toHaveClass("bg-sky-400/50");
-    expect(container.querySelector('[data-slot="cell-adder-leading-rule"]')).toHaveClass("h-px");
+    expect(activePrimaryBridge).toHaveClass("h-6");
+    expect(activePrimaryBridge).toHaveClass("bg-sky-500/12");
+    expect(container.querySelector('[data-slot="cell-adder-leading-rule"]')).toHaveClass("h-6");
 
     fireEvent.click(hitTarget!);
 
@@ -106,12 +106,12 @@ describe("CellInsertionRibbon", () => {
     expect(palette).not.toHaveClass("rounded-full");
     expect(palette).not.toHaveClass("shadow-sm");
     expect(hitTarget).toHaveClass("w-[var(--cell-content-column-inset,3.25rem)]");
-    expect(primaryBridge).toHaveClass("bg-emerald-400/50");
-    expect(primaryBridge).toHaveClass("h-px");
+    expect(primaryBridge).toHaveClass("bg-emerald-500/12");
+    expect(primaryBridge).toHaveClass("h-6");
     expect(intent).toHaveClass("bg-emerald-400");
     expect(leadingRule).toHaveClass("w-2");
-    expect(leadingRule).toHaveClass("h-px");
-    expect(leadingRule).toHaveClass("bg-emerald-400/50");
+    expect(leadingRule).toHaveClass("h-6");
+    expect(leadingRule).toHaveClass("bg-emerald-500/12");
     expect(trailingRule).toHaveClass("bg-gradient-to-r");
     expect(trailingRule).toHaveClass("from-emerald-400/35");
     expect(trailingRule).toHaveClass("flex-1");

--- a/src/components/cell/__tests__/CellInsertionRibbon.test.tsx
+++ b/src/components/cell/__tests__/CellInsertionRibbon.test.tsx
@@ -32,9 +32,9 @@ describe("CellInsertionRibbon", () => {
     expect(container.querySelector('[data-slot="cell-adder-ribbon-intent"]')).toHaveClass(
       "bg-sky-400",
     );
-    expect(container.querySelector('[data-slot="cell-adder-primary-glyph"]')).toHaveClass(
-      "opacity-100",
-    );
+    expect(container.querySelector('[data-slot="cell-adder-primary-glyph"]')).toBeNull();
+    expect(hitTarget).toHaveClass("bg-sky-500/8");
+    expect(container.querySelector('[data-slot="cell-adder-leading-rule"]')).toHaveClass("h-full");
 
     fireEvent.click(hitTarget!);
 
@@ -47,7 +47,6 @@ describe("CellInsertionRibbon", () => {
     const adder = container.querySelector('[data-slot="cell-adder"]');
     const continuation = container.querySelector('[data-slot="cell-adder-ribbon-continuation"]');
     const hitTarget = container.querySelector('[data-slot="cell-adder-primary-hit-target"]');
-    const glyph = container.querySelector('[data-slot="cell-adder-primary-glyph"]');
 
     fireEvent.pointerEnter(adder!);
 
@@ -56,7 +55,7 @@ describe("CellInsertionRibbon", () => {
     expect(container.querySelector('[data-slot="cell-adder-ribbon-intent"]')).toBeNull();
     expect(continuation).toHaveClass("bg-gray-300/70");
     expect(hitTarget).toHaveClass("bg-transparent");
-    expect(glyph).toHaveClass("opacity-0");
+    expect(container.querySelector('[data-slot="cell-adder-primary-glyph"]')).toBeNull();
   });
 
   it("keeps explicit actions out of the tab order until the row is awake", () => {
@@ -97,13 +96,14 @@ describe("CellInsertionRibbon", () => {
     expect(actions).toHaveClass("flex-1");
     expect(palette).toHaveClass("shrink-0");
     expect(palette).toHaveClass("pl-0.5");
+    expect(palette).toHaveClass("bg-emerald-500/8");
     expect(palette).not.toHaveClass("rounded-full");
     expect(palette).not.toHaveClass("shadow-sm");
-    expect(hitTarget).toHaveClass("bg-emerald-500/6");
-    expect(hitTarget).toHaveClass("text-emerald-700");
+    expect(hitTarget).toHaveClass("bg-emerald-500/8");
     expect(intent).toHaveClass("bg-emerald-400");
     expect(leadingRule).toHaveClass("w-2");
-    expect(leadingRule).toHaveClass("bg-emerald-400/50");
+    expect(leadingRule).toHaveClass("h-full");
+    expect(leadingRule).toHaveClass("bg-emerald-500/8");
     expect(trailingRule).toHaveClass("bg-gradient-to-r");
     expect(trailingRule).toHaveClass("from-emerald-400/35");
     expect(trailingRule).toHaveClass("flex-1");

--- a/src/components/cell/__tests__/CellInsertionRibbon.test.tsx
+++ b/src/components/cell/__tests__/CellInsertionRibbon.test.tsx
@@ -24,18 +24,22 @@ describe("CellInsertionRibbon", () => {
     const { container } = render(<CellInsertionRibbon onInsert={onInsert} />);
 
     const hitTarget = container.querySelector('[data-slot="cell-adder-primary-hit-target"]');
+    const primaryBridge = container.querySelector('[data-slot="cell-adder-primary-bridge"]');
     expect(hitTarget).toHaveAttribute("aria-label", "Add code cell here");
     expect(hitTarget).toHaveAttribute("title", "Add code cell here");
     expect(hitTarget).toHaveClass("w-[var(--cell-content-column-inset,3.25rem)]");
+    expect(primaryBridge).toBeNull();
 
     fireEvent.pointerEnter(hitTarget!);
+    const activePrimaryBridge = container.querySelector('[data-slot="cell-adder-primary-bridge"]');
     expect(container.querySelector('[data-slot="cell-adder-ribbon-intent"]')).toHaveClass(
       "bg-sky-400",
     );
     expect(container.querySelector('[data-slot="cell-adder-primary-glyph"]')).toBeNull();
-    expect(hitTarget).toHaveClass("bg-sky-500/8");
     expect(hitTarget).toHaveClass("w-[var(--cell-content-column-inset,3.25rem)]");
-    expect(container.querySelector('[data-slot="cell-adder-leading-rule"]')).toHaveClass("h-full");
+    expect(activePrimaryBridge).toHaveClass("h-px");
+    expect(activePrimaryBridge).toHaveClass("bg-sky-400/50");
+    expect(container.querySelector('[data-slot="cell-adder-leading-rule"]')).toHaveClass("h-px");
 
     fireEvent.click(hitTarget!);
 
@@ -89,6 +93,7 @@ describe("CellInsertionRibbon", () => {
     const actions = container.querySelector('[data-slot="cell-adder-actions"]');
     const palette = container.querySelector('[data-slot="cell-adder-action-palette"]');
     const hitTarget = container.querySelector('[data-slot="cell-adder-primary-hit-target"]');
+    const primaryBridge = container.querySelector('[data-slot="cell-adder-primary-bridge"]');
     const intent = container.querySelector('[data-slot="cell-adder-ribbon-intent"]');
     const leadingRule = container.querySelector('[data-slot="cell-adder-leading-rule"]');
     const trailingRule = container.querySelector('[data-slot="cell-adder-trailing-rule"]');
@@ -96,16 +101,17 @@ describe("CellInsertionRibbon", () => {
     expect(actions).toHaveClass("opacity-100");
     expect(actions).toHaveClass("flex-1");
     expect(palette).toHaveClass("shrink-0");
-    expect(palette).toHaveClass("pl-0.5");
+    expect(palette).toHaveClass("pl-0");
     expect(palette).not.toHaveClass("bg-emerald-500/8");
     expect(palette).not.toHaveClass("rounded-full");
     expect(palette).not.toHaveClass("shadow-sm");
-    expect(hitTarget).toHaveClass("bg-emerald-500/8");
     expect(hitTarget).toHaveClass("w-[var(--cell-content-column-inset,3.25rem)]");
+    expect(primaryBridge).toHaveClass("bg-emerald-400/50");
+    expect(primaryBridge).toHaveClass("h-px");
     expect(intent).toHaveClass("bg-emerald-400");
     expect(leadingRule).toHaveClass("w-2");
-    expect(leadingRule).toHaveClass("h-full");
-    expect(leadingRule).toHaveClass("bg-emerald-500/8");
+    expect(leadingRule).toHaveClass("h-px");
+    expect(leadingRule).toHaveClass("bg-emerald-400/50");
     expect(trailingRule).toHaveClass("bg-gradient-to-r");
     expect(trailingRule).toHaveClass("from-emerald-400/35");
     expect(trailingRule).toHaveClass("flex-1");

--- a/src/components/cell/__tests__/CellInsertionRibbon.test.tsx
+++ b/src/components/cell/__tests__/CellInsertionRibbon.test.tsx
@@ -39,6 +39,7 @@ describe("CellInsertionRibbon", () => {
     expect(hitTarget).toHaveClass("w-[var(--cell-content-column-inset,3.25rem)]");
     expect(activePrimaryBridge).toHaveClass("h-6");
     expect(activePrimaryBridge).toHaveClass("bg-sky-500/12");
+    expect(activePrimaryBridge).toHaveClass("border-sky-500/20");
     expect(container.querySelector('[data-slot="cell-adder-leading-rule"]')).toHaveClass("h-6");
 
     fireEvent.click(hitTarget!);
@@ -109,16 +110,21 @@ describe("CellInsertionRibbon", () => {
     expect(hitTarget).toHaveClass("w-[var(--cell-content-column-inset,3.25rem)]");
     expect(primaryBridge).toHaveClass("bg-emerald-500/12");
     expect(primaryBridge).toHaveClass("h-6");
+    expect(primaryBridge).toHaveClass("border-emerald-500/20");
     expect(intent).toHaveClass("bg-emerald-400");
     expect(leadingRule).toHaveClass("w-2");
     expect(leadingRule).toHaveClass("h-6");
     expect(leadingRule).toHaveClass("bg-emerald-500/12");
+    expect(leadingRule).toHaveClass("border-emerald-500/20");
     expect(trailingRule).toHaveClass("bg-gradient-to-r");
     expect(trailingRule).toHaveClass("from-emerald-400/35");
     expect(trailingRule).toHaveClass("flex-1");
     expect(screen.getByTitle("Add markdown cell")).toHaveClass("text-emerald-700");
     expect(screen.getByTitle("Add markdown cell")).toHaveClass("rounded-l-none");
+    expect(screen.getByTitle("Add markdown cell")).toHaveClass("border-emerald-500/20");
     expect(screen.getByTitle("Add code cell")).toHaveClass("bg-emerald-500/12");
+    expect(screen.getByTitle("Add code cell")).toHaveClass("border-emerald-500/20");
+    expect(screen.getByTitle("Add code cell")).toHaveClass("border-x-0");
     expect(screen.getByTitle("Add code cell")).toHaveClass("text-muted-foreground/45");
     expect(screen.getByTitle("Add code cell")).not.toHaveClass("text-emerald-700");
   });

--- a/src/components/cell/__tests__/CellInsertionRibbon.test.tsx
+++ b/src/components/cell/__tests__/CellInsertionRibbon.test.tsx
@@ -102,6 +102,7 @@ describe("CellInsertionRibbon", () => {
     expect(actions).toHaveClass("flex-1");
     expect(palette).toHaveClass("shrink-0");
     expect(palette).toHaveClass("pl-0");
+    expect(palette).toHaveClass("gap-0");
     expect(palette).not.toHaveClass("bg-emerald-500/8");
     expect(palette).not.toHaveClass("rounded-full");
     expect(palette).not.toHaveClass("shadow-sm");
@@ -116,7 +117,10 @@ describe("CellInsertionRibbon", () => {
     expect(trailingRule).toHaveClass("from-emerald-400/35");
     expect(trailingRule).toHaveClass("flex-1");
     expect(screen.getByTitle("Add markdown cell")).toHaveClass("text-emerald-700");
-    expect(screen.getByTitle("Add code cell")).not.toHaveClass("bg-emerald-500/12");
+    expect(screen.getByTitle("Add markdown cell")).toHaveClass("rounded-l-none");
+    expect(screen.getByTitle("Add code cell")).toHaveClass("bg-emerald-500/12");
+    expect(screen.getByTitle("Add code cell")).toHaveClass("text-muted-foreground/45");
+    expect(screen.getByTitle("Add code cell")).not.toHaveClass("text-emerald-700");
   });
 
   it("softens the terminal row into a document tail", () => {
@@ -140,5 +144,7 @@ describe("CellInsertionRibbon", () => {
     );
     expect(intent).toHaveClass("h-7");
     expect(intent).toHaveClass("bg-gradient-to-b");
+    expect(container.querySelector('[data-slot="cell-adder-primary-bridge"]')).toBeNull();
+    expect(container.querySelector('[data-slot="cell-adder-leading-rule"]')).toHaveClass("h-px");
   });
 });


### PR DESCRIPTION
## Summary

- remove the duplicate plus glyphs from `CellInsertionRibbon` insertion targets
- extend the active insertion background through the primary target, bridge, and action palette
- update the canonical component tests for the new code and markdown target behavior

## Verification

- `pnpm test:run src/components/cell/__tests__/CellInsertionRibbon.test.tsx`
- `pnpm --dir apps/elements build`
- `cargo xtask lint --fix`
- Browser DOM check on `/docs/cell-insertion-affordances`
