### PR TITLE
fix(notebook-cloud): start workstation compute from toolbar

### DIFF
--- a/apps/notebook-cloud/README.md
+++ b/apps/notebook-cloud/README.md
@@ -732,7 +732,7 @@ private owner room, the toolbar can then request attachment directly.
 With the workstation agent already running, use the toolbar smoke to exercise
 the hosted browser path end to end. It verifies the registered workstation is
 online, selects it as the default, creates a private owner notebook, seeds the
-first-party browser OIDC cache, clicks `Attach compute` in the shared toolbar,
+first-party browser OIDC cache, clicks `Start compute` in the shared toolbar,
 runs the first cell, reloads the page, and runs it again to catch reconnection
 regressions:
 

--- a/apps/notebook-cloud/scripts/hosted-workstation-agent.mjs
+++ b/apps/notebook-cloud/scripts/hosted-workstation-agent.mjs
@@ -83,9 +83,23 @@ async function main() {
   );
 
   while (true) {
-    await heartbeatIfNeeded(pythonPath);
-    await pollAttachJobs(pythonPath);
+    await runAgentStep("heartbeat", () => heartbeatIfNeeded(pythonPath));
+    await runAgentStep("poll_attach_jobs", () => pollAttachJobs(pythonPath));
     await sleep(pollIntervalMs);
+  }
+}
+
+async function runAgentStep(step, fn) {
+  try {
+    await fn();
+  } catch (error) {
+    console.error(
+      JSON.stringify({
+        event: "workstation_agent_step_failed",
+        step,
+        message: error instanceof Error ? error.message : String(error),
+      }),
+    );
   }
 }
 
@@ -182,13 +196,23 @@ async function startAttachJob(job, pythonPath) {
 
 async function watchRuntimePeer(jobId, active) {
   const readyPoll = setInterval(async () => {
-    if (active.ready) return;
-    const output = await readFile(active.logPath, "utf8").catch(() => "");
-    if (!output.includes("Infrastructure ready, entering main loop")) return;
-    active.ready = true;
-    await patchAttachJob(jobId, {
-      status: "running",
-    });
+    try {
+      if (active.ready) return;
+      const output = await readFile(active.logPath, "utf8").catch(() => "");
+      if (!output.includes("Infrastructure ready, entering main loop")) return;
+      active.ready = true;
+      await patchAttachJob(jobId, {
+        status: "running",
+      });
+    } catch (error) {
+      console.error(
+        JSON.stringify({
+          event: "attach_job_ready_patch_failed",
+          jobId,
+          message: error instanceof Error ? error.message : String(error),
+        }),
+      );
+    }
   }, 250);
 
   active.child.on("exit", async (code, signal) => {
@@ -215,6 +239,14 @@ async function watchRuntimePeer(jobId, active) {
     await patchAttachJob(jobId, {
       status: "failed",
       error_message: error.message,
+    }).catch((patchError) => {
+      console.error(
+        JSON.stringify({
+          event: "attach_job_error_patch_failed",
+          jobId,
+          message: patchError instanceof Error ? patchError.message : String(patchError),
+        }),
+      );
     });
   });
 }

--- a/apps/notebook-cloud/scripts/hosted-workstation-toolbar-smoke.mjs
+++ b/apps/notebook-cloud/scripts/hosted-workstation-toolbar-smoke.mjs
@@ -223,9 +223,9 @@ async function runBrowserSmoke({
       ...ownerRun,
       checks: [
         "oidc_token_seeded_in_browser_storage",
-        "toolbar_attach_compute_rendered",
-        "toolbar_attach_compute_clicked",
-        "execute_button_rendered_after_attach",
+        "toolbar_start_compute_rendered",
+        "toolbar_start_compute_clicked",
+        "execute_button_rendered_after_compute_start",
         "cell_output_observed_after_execute",
         "page_reload_preserved_output",
         "cell_output_observed_after_reload_execute",

--- a/apps/notebook-cloud/scripts/hosted-workstation-toolbar-smoke.mjs
+++ b/apps/notebook-cloud/scripts/hosted-workstation-toolbar-smoke.mjs
@@ -260,11 +260,11 @@ async function runOwnerAttachAndExecuteSmoke({
   const cell = await ensureCodeCell(page, timeoutMs);
   await setCellSource(cell, source);
 
-  await waitForToolbarAction(page, "Attach compute", timeoutMs);
+  await waitForToolbarAction(page, "Start compute", timeoutMs);
   const action = await readToolbarWorkstationAction(page);
   assertToolbarWorkstationAction(action, {
     context: "owner attach",
-    label: "Attach compute",
+    label: "Start compute",
     titleIncludes: [workstationId, "workstation"],
   });
   await page.getByTestId("workstation-setup-button").click({ timeout: timeoutMs });

--- a/apps/notebook-cloud/src/index.ts
+++ b/apps/notebook-cloud/src/index.ts
@@ -1,5 +1,5 @@
 import type { Env, ExecutionContext, ExportedHandler } from "./cloudflare-types.ts";
-import type { BlobRef } from "runtimed";
+import { projectNotebookWorkstationAttachmentFromClaim, type BlobRef } from "runtimed";
 import { NotebookRoom } from "./notebook-room.ts";
 import {
   AuthError,
@@ -1211,6 +1211,10 @@ async function routeWorkstationAttachJob(
   if (!job) {
     return json({ error: "workstation attach job not found" }, 404);
   }
+  const workstation = await getWorkstationRow(env, ownerPrincipal, workstationId);
+  if (workstation) {
+    await publishWorkstationAttachJobRuntimeState(env, job, workstation);
+  }
   return json({
     ok: true,
     job: workstationAttachJobResponseRow(request, job),
@@ -1502,6 +1506,75 @@ function workstationAttachJobResponseRow(
       scope: "runtime_peer",
     },
   };
+}
+
+async function publishWorkstationAttachJobRuntimeState(
+  env: Env,
+  job: WorkstationAttachJobRow,
+  workstation: WorkstationRow,
+): Promise<void> {
+  const attachment = workstationAttachmentStateForJob(job, workstation);
+  const id = env.NOTEBOOK_ROOMS.idFromName(job.notebook_id);
+  const room = env.NOTEBOOK_ROOMS.get(id);
+  try {
+    const response = await room.fetch(
+      new Request(
+        `https://notebook-room.internal/internal/n/${encodeURIComponent(
+          job.notebook_id,
+        )}/workstation-attachment`,
+        {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ attachment }),
+        },
+      ),
+    );
+    if (response.ok) {
+      return;
+    }
+    cloudLog("warn", "workstation.attach.runtime_state_publish_failed", {
+      notebook_id: job.notebook_id,
+      workstation_id: job.workstation_id,
+      job_id: job.id,
+      status: job.status,
+      response_status: response.status,
+      counter: "workstation_attach_runtime_state_publish_failed",
+      counter_delta: 1,
+    });
+  } catch (error) {
+    cloudLog("warn", "workstation.attach.runtime_state_publish_failed", {
+      notebook_id: job.notebook_id,
+      workstation_id: job.workstation_id,
+      job_id: job.id,
+      status: job.status,
+      error: error instanceof Error ? error.message : String(error),
+      counter: "workstation_attach_runtime_state_publish_failed",
+      counter_delta: 1,
+    });
+  }
+}
+
+function workstationAttachmentStateForJob(
+  job: WorkstationAttachJobRow,
+  workstation: WorkstationRow,
+): ReturnType<typeof projectNotebookWorkstationAttachmentFromClaim> {
+  return projectNotebookWorkstationAttachmentFromClaim({
+    workstation: {
+      workstationId: workstation.workstation_id,
+      displayName: workstation.display_name,
+      provider: workstation.provider,
+      defaultEnvironmentLabel: workstation.default_environment_label,
+      environmentPolicy: workstation.environment_policy,
+      cpuCount: workstation.cpu_count,
+      memoryBytes: workstation.memory_bytes,
+      workingDirectory: workstation.working_directory,
+    },
+    claim: {
+      status: job.status,
+      errorMessage: job.error_message,
+      updatedAt: job.updated_at,
+    },
+  });
 }
 
 function parseWorkstationAttachJobsLimit(request: Request): number | Response {

--- a/apps/notebook-cloud/src/notebook-room.ts
+++ b/apps/notebook-cloud/src/notebook-room.ts
@@ -192,6 +192,9 @@ export class NotebookRoom {
     notebookId: string,
     request: Request,
   ): Promise<Response> {
+    // Worker-internal control path only. External traffic reaches this Durable
+    // Object through the Worker's strict `/n/:notebookId/sync` WebSocket route,
+    // so `/internal/*` is not publicly routable unless that router changes.
     if (request.method !== "POST") {
       return json({ error: "method not allowed" }, 405);
     }

--- a/apps/notebook-cloud/src/notebook-room.ts
+++ b/apps/notebook-cloud/src/notebook-room.ts
@@ -96,6 +96,11 @@ export class NotebookRoom {
 
   async fetch(request: Request): Promise<Response> {
     const url = new URL(request.url);
+    const workstationAttachmentNotebookId = workstationAttachmentControlNotebookId(url.pathname);
+    if (workstationAttachmentNotebookId) {
+      return this.handleWorkstationAttachmentControl(workstationAttachmentNotebookId, request);
+    }
+
     const notebookId = notebookIdFromPath(url.pathname);
 
     if (!notebookId) {
@@ -181,6 +186,54 @@ export class NotebookRoom {
       headers: webSocketUpgradeHeaders(identity),
       webSocket: client,
     } as ResponseInit & { webSocket: CloudflareWebSocket });
+  }
+
+  private async handleWorkstationAttachmentControl(
+    notebookId: string,
+    request: Request,
+  ): Promise<Response> {
+    if (request.method !== "POST") {
+      return json({ error: "method not allowed" }, 405);
+    }
+
+    let payload: unknown;
+    try {
+      payload = await request.json();
+    } catch {
+      return json({ error: "workstation attachment control body must be JSON" }, 400);
+    }
+    if (!isRecord(payload) || !("attachment" in payload)) {
+      return json({ error: "workstation attachment control body requires attachment" }, 400);
+    }
+
+    const attachment = payload.attachment as WorkstationAttachmentState | null;
+    const startedAt = Date.now();
+    try {
+      const materializer = this.materializerFor(notebookId);
+      const result = await materializer.setWorkstationAttachment(attachment);
+      if (result.changed) {
+        this.deliverRoomHostFrames(notebookId, result);
+        await materializer.checkpoint();
+      }
+      cloudLog("debug", "room.workstation_attachment.control_published", {
+        notebook_id: notebookId,
+        changed: result.changed,
+        duration_ms: durationMs(startedAt),
+        outbound_frame_count: result.outbound.length,
+        counter: "workstation_attachment_control_published",
+        counter_delta: result.changed ? 1 : 0,
+      });
+      return json({ ok: true, changed: result.changed }, 200);
+    } catch (error) {
+      cloudLog("warn", "room.workstation_attachment.control_publish_failed", {
+        notebook_id: notebookId,
+        duration_ms: durationMs(startedAt),
+        error: errorMessage(error),
+        counter: "workstation_attachment_control_publish_failed",
+        counter_delta: 1,
+      });
+      return json({ error: "workstation attachment publish failed" }, 500);
+    }
   }
 
   async webSocketMessage(
@@ -1022,6 +1075,18 @@ function notebookIdFromPath(pathname: string): string | undefined {
     return undefined;
   }
   return decodeURIComponent(match[1]);
+}
+
+function workstationAttachmentControlNotebookId(pathname: string): string | undefined {
+  const match = pathname.match(/^\/internal\/n\/([^/]+)\/workstation-attachment\/?$/);
+  if (!match) {
+    return undefined;
+  }
+  return decodeURIComponent(match[1]);
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
 }
 
 function json(value: unknown, status: number): Response {

--- a/apps/notebook-cloud/test/hosted-workstation-toolbar-smoke.test.mjs
+++ b/apps/notebook-cloud/test/hosted-workstation-toolbar-smoke.test.mjs
@@ -76,12 +76,12 @@ describe("hosted workstation toolbar smoke helpers", () => {
     assert.doesNotThrow(() =>
       assertToolbarWorkstationAction(
         {
-          label: "Attach compute",
-          title: "Attach lab2 workstation to this notebook",
+          label: "Start compute",
+          title: "Start compute on lab2 workstation",
         },
         {
           context: "online default workstation",
-          label: "Attach compute",
+          label: "Start compute",
           titleIncludes: ["lab2", "workstation"],
         },
       ),
@@ -108,10 +108,10 @@ describe("hosted workstation toolbar smoke helpers", () => {
     assert.throws(
       () =>
         assertToolbarWorkstationAction(
-          { label: "Attach compute", title: "Open workstations panel" },
+          { label: "Start compute", title: "Open workstations panel" },
           {
             context: "wrong target",
-            label: "Attach compute",
+            label: "Start compute",
             titleIncludes: ["lab2"],
           },
         ),

--- a/apps/notebook-cloud/test/hosted-workstation-toolbar-smoke.test.mjs
+++ b/apps/notebook-cloud/test/hosted-workstation-toolbar-smoke.test.mjs
@@ -46,7 +46,7 @@ describe("hosted workstation toolbar smoke helpers", () => {
     );
   });
 
-  it("checks blocked and attach workstation toolbar action labels", () => {
+  it("checks blocked and start workstation toolbar action labels", () => {
     assert.doesNotThrow(() =>
       assertToolbarWorkstationAction(
         {

--- a/apps/notebook-cloud/test/notebook-room.test.ts
+++ b/apps/notebook-cloud/test/notebook-room.test.ts
@@ -418,6 +418,73 @@ describe("NotebookRoom peer lifecycle", () => {
     assert.deepEqual([...viewerSocket.sent[0]], [FrameType.RUNTIME_STATE_SYNC, 1, 2, 3]);
   });
 
+  it("publishes workstation attachment control updates through the room host", async () => {
+    const state = hibernatedState([]);
+    const room = new NotebookRoom(state.state, {} as Env);
+    const harness = roomHarness(room);
+    const viewerSocket = new FakeSocket();
+    const viewerPeer = {
+      id: "viewer",
+      socket: viewerSocket.asCloudflareWebSocket(),
+      identity: authenticateDevRequest(
+        new Request("https://cloud.test/n/demo/sync?user=viewer&operator=desktop:v&scope=viewer"),
+      ),
+      connectedAt: "2026-06-07T00:00:00.000Z",
+    };
+    harness.peers.set(viewerPeer.id, viewerPeer);
+
+    const attachment = {
+      workstation_id: "ws-lab2",
+      display_name: "Lab2 workstation",
+      provider: "runtime_peer",
+      default_environment_label: "Current Python",
+      environment_policy: "current_python",
+      status: "connecting",
+      status_message: "Lab2 workstation accepted the request and is starting compute.",
+      cpu_count: 8,
+      memory_bytes: 16_000_000_000,
+      working_directory: "/home/ubuntu/project",
+      updated_at: "2026-06-07T00:00:01.000Z",
+    };
+    let checkpointed = 0;
+    let publishedAttachment: unknown;
+    harness.materializers.set("demo", {
+      receiveFrame: async () => noopMaterializedResult(),
+      checkpoint: async () => {
+        checkpointed += 1;
+      },
+      setWorkstationAttachment: async (nextAttachment: unknown) => {
+        publishedAttachment = nextAttachment;
+        return {
+          ...noopMaterializedResult(),
+          changed: true,
+          runtime_state_changed: true,
+          outbound: [
+            {
+              peer_id: viewerPeer.id,
+              frame_type: FrameType.RUNTIME_STATE_SYNC,
+              payload: [4, 5, 6],
+            },
+          ],
+        };
+      },
+    } as never);
+
+    const response = await room.fetch(
+      new Request("https://room.internal/internal/n/demo/workstation-attachment", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ attachment }),
+      }),
+    );
+
+    assert.equal(response.status, 200);
+    assert.deepEqual(await response.json(), { ok: true, changed: true });
+    assert.deepEqual(publishedAttachment, attachment);
+    assert.equal(checkpointed, 1, "changed control updates are checkpointed");
+    assert.deepEqual([...viewerSocket.sent[0]], [FrameType.RUNTIME_STATE_SYNC, 4, 5, 6]);
+  });
+
   it("projects runtime-peer workstation metadata into the attachment", async () => {
     const state = hibernatedState([]);
     const room = new NotebookRoom(state.state, {} as Env);

--- a/apps/notebook-cloud/test/worker-routes.test.ts
+++ b/apps/notebook-cloud/test/worker-routes.test.ts
@@ -1840,7 +1840,21 @@ describe("Worker artifact routes", () => {
   });
 
   it("allows workstation owners to update attach job status", async () => {
-    const env = fakeEnv();
+    let runtimeStateRequest: Request | undefined;
+    const env = fakeEnv({
+      NOTEBOOK_ROOMS: {
+        idFromName: (name: string) => ({ toString: () => name }),
+        get: () => ({
+          fetch: async (request: Request) => {
+            runtimeStateRequest = request;
+            return new Response(JSON.stringify({ ok: true, changed: true }), {
+              status: 200,
+              headers: { "Content-Type": "application/json" },
+            });
+          },
+        }),
+      } satisfies DurableObjectNamespace,
+    });
     seedWorkstation(env, { ownerPrincipal: "user:dev:alice", workstationId: "ws-lab2" });
     seedWorkstationAttachJob(env, {
       id: "job-1",
@@ -1884,6 +1898,77 @@ describe("Worker artifact routes", () => {
     });
     assert.equal(env.DB.workstationAttachJobs.get("job-1")?.status, "running");
     assert.ok(env.DB.workstationAttachJobs.get("job-1")?.accepted_at);
+    assert.ok(runtimeStateRequest);
+    assert.equal(runtimeStateRequest.method, "POST");
+    assert.equal(
+      new URL(runtimeStateRequest.url).pathname,
+      "/internal/n/nb-1/workstation-attachment",
+    );
+    const runtimeStatePayload = (await runtimeStateRequest.json()) as {
+      attachment?: { workstation_id?: string; display_name?: string; status?: string };
+    };
+    assert.deepEqual(runtimeStatePayload.attachment, {
+      workstation_id: "ws-lab2",
+      display_name: "Lab2",
+      provider: "runtime_peer",
+      default_environment_label: "Current Python",
+      environment_policy: "current_python",
+      status: "ready",
+      status_message: null,
+      cpu_count: 8,
+      memory_bytes: 16_000_000_000,
+      working_directory: "/home/ubuntu/project",
+      updated_at: env.DB.workstationAttachJobs.get("job-1")?.updated_at,
+    });
+  });
+
+  it("publishes workstation claim progress into RuntimeStateDoc", async () => {
+    let attachmentStatus: string | undefined;
+    let attachmentMessage: string | undefined | null;
+    const env = fakeEnv({
+      NOTEBOOK_ROOMS: {
+        idFromName: (name: string) => ({ toString: () => name }),
+        get: () => ({
+          fetch: async (request: Request) => {
+            const payload = (await request.json()) as {
+              attachment?: { status?: string; status_message?: string | null };
+            };
+            attachmentStatus = payload.attachment?.status;
+            attachmentMessage = payload.attachment?.status_message;
+            return new Response(JSON.stringify({ ok: true, changed: true }), {
+              status: 200,
+              headers: { "Content-Type": "application/json" },
+            });
+          },
+        }),
+      } satisfies DurableObjectNamespace,
+    });
+    seedWorkstation(env, { ownerPrincipal: "user:dev:alice", workstationId: "ws-lab2" });
+    seedWorkstationAttachJob(env, {
+      id: "job-claim",
+      notebookId: "nb-claim",
+      ownerPrincipal: "user:dev:alice",
+      workstationId: "ws-lab2",
+    });
+
+    const response = await worker.fetch(
+      new Request("http://localhost/api/workstations/ws-lab2/attach-jobs/job-claim", {
+        method: "PATCH",
+        headers: {
+          "Content-Type": "application/json",
+          "X-Operator": "workstation:lab2",
+          "X-Scope": "owner",
+          "X-User": "alice",
+        },
+        body: JSON.stringify({ status: "accepted" }),
+      }),
+      env,
+      fakeContext(),
+    );
+
+    assert.equal(response.status, 200);
+    assert.equal(attachmentStatus, "connecting");
+    assert.equal(attachmentMessage, "Lab2 accepted the request and is starting compute.");
   });
 
   it("does not let workstation owners update another principal's attach job", async () => {

--- a/apps/notebook-cloud/viewer/use-cloud-workstations.ts
+++ b/apps/notebook-cloud/viewer/use-cloud-workstations.ts
@@ -24,6 +24,10 @@ interface CloudWorkstationMutationState {
   workstationId: string | null;
 }
 
+interface AttachWorkstationOptions {
+  revealPanel?: boolean;
+}
+
 interface UseCloudWorkstationManagerInput {
   config: Pick<
     CloudViewerConfig,
@@ -127,16 +131,18 @@ export function useCloudWorkstationManager({
   );
 
   const handleAttachWorkstation = useCallback(
-    async (workstationId: string) => {
+    async (workstationId: string, options: AttachWorkstationOptions = {}) => {
       if (!config.workstationAttachEndpoint) {
         return;
       }
       setWorkstationMutation({
         kind: "attach",
-        message: "Attach requested. Waiting for the workstation to join this room.",
+        message: "Starting compute. Waiting for the workstation to join this notebook.",
         workstationId,
       });
-      onOpenWorkstationsRail();
+      if (options.revealPanel) {
+        onOpenWorkstationsRail();
+      }
       try {
         await requestCloudWorkstationAttachment(
           config.workstationAttachEndpoint,
@@ -216,6 +222,21 @@ export function useCloudWorkstationManager({
 
   const workstationAction = useMemo<NotebookCommandToolbarWorkstationAction | null>(() => {
     const { primaryAction, workstationId } = workstationLaunchReadiness;
+    if (workstationMutation.kind === "attach" && workstationMutation.workstationId) {
+      const pendingTarget =
+        workstationLaunchReadiness.workstationId === workstationMutation.workstationId
+          ? workstationLaunchReadiness.targetLabel
+          : null;
+      return {
+        disabled: true,
+        label: "Starting",
+        pending: true,
+        title: pendingTarget
+          ? `Starting compute on ${pendingTarget}`
+          : "Starting compute on the selected workstation",
+        onClick: () => {},
+      };
+    }
     return primaryAction.kind !== "none" && primaryAction.label && primaryAction.title
       ? {
           label: primaryAction.label,
@@ -226,7 +247,13 @@ export function useCloudWorkstationManager({
               : onOpenWorkstationsRail,
         }
       : null;
-  }, [handleAttachWorkstation, onOpenWorkstationsRail, workstationLaunchReadiness]);
+  }, [
+    handleAttachWorkstation,
+    onOpenWorkstationsRail,
+    workstationLaunchReadiness,
+    workstationMutation.kind,
+    workstationMutation.workstationId,
+  ]);
 
   const workstationPanelStatusMessage =
     workstationMutation.message ??
@@ -253,7 +280,9 @@ export function useCloudWorkstationManager({
   return useMemo(
     () => ({
       busyWorkstationId: workstationMutation.workstationId,
-      onAttachWorkstation: canChooseHostedWorkstation ? handleAttachWorkstation : undefined,
+      onAttachWorkstation: canChooseHostedWorkstation
+        ? (workstationId: string) => handleAttachWorkstation(workstationId, { revealPanel: true })
+        : undefined,
       onSetDefaultWorkstation: canChooseHostedWorkstation ? handleSetDefaultWorkstation : undefined,
       workstationAction,
       workstationPanelStatusMessage,

--- a/packages/runtimed/src/index.ts
+++ b/packages/runtimed/src/index.ts
@@ -257,6 +257,15 @@ export {
   type ProjectNotebookWorkstationSelectionOptions,
 } from "./notebook-workstation-selection";
 
+// Notebook workstation attachment projections
+export {
+  projectNotebookWorkstationAttachmentFromClaim,
+  type NotebookWorkstationAttachmentClaim,
+  type NotebookWorkstationAttachmentClaimStatus,
+  type NotebookWorkstationAttachmentTarget,
+  type ProjectNotebookWorkstationAttachmentFromClaimOptions,
+} from "./notebook-workstation-attachment";
+
 // Notebook workstation launch-readiness projection
 export {
   clearNotebookWorkstationLaunchReadinessProjectionCacheForTests,

--- a/packages/runtimed/src/notebook-workstation-attachment.ts
+++ b/packages/runtimed/src/notebook-workstation-attachment.ts
@@ -1,0 +1,89 @@
+import type { WorkstationAttachmentState } from "./runtime-state";
+
+export type NotebookWorkstationAttachmentClaimStatus =
+  | "pending"
+  | "accepted"
+  | "running"
+  | "failed"
+  | "completed"
+  | "cancelled";
+
+export interface NotebookWorkstationAttachmentClaim {
+  errorMessage?: string | null;
+  status: NotebookWorkstationAttachmentClaimStatus;
+  updatedAt?: string | null;
+}
+
+export interface NotebookWorkstationAttachmentTarget {
+  cpuCount?: number | null;
+  defaultEnvironmentLabel?: string | null;
+  displayName: string;
+  environmentPolicy?: string | null;
+  memoryBytes?: number | null;
+  provider?: string | null;
+  workingDirectory?: string | null;
+  workstationId: string;
+}
+
+export interface ProjectNotebookWorkstationAttachmentFromClaimOptions {
+  claim: NotebookWorkstationAttachmentClaim;
+  workstation: NotebookWorkstationAttachmentTarget;
+}
+
+export function projectNotebookWorkstationAttachmentFromClaim({
+  claim,
+  workstation,
+}: ProjectNotebookWorkstationAttachmentFromClaimOptions): WorkstationAttachmentState {
+  return {
+    workstation_id: workstation.workstationId,
+    display_name: workstation.displayName,
+    provider: workstation.provider || "runtime_peer",
+    default_environment_label: workstation.defaultEnvironmentLabel ?? "Current Python",
+    environment_policy: workstation.environmentPolicy ?? "runtime_peer",
+    status: workstationAttachmentStatusForClaim(claim.status),
+    status_message: workstationAttachmentStatusMessageForClaim(claim, workstation),
+    cpu_count: workstation.cpuCount ?? null,
+    memory_bytes: workstation.memoryBytes ?? null,
+    working_directory: workstation.workingDirectory ?? null,
+    updated_at: claim.updatedAt ?? null,
+  };
+}
+
+function workstationAttachmentStatusForClaim(
+  status: NotebookWorkstationAttachmentClaimStatus,
+): string {
+  switch (status) {
+    case "accepted":
+      return "connecting";
+    case "running":
+      return "ready";
+    case "failed":
+      return "error";
+    case "cancelled":
+    case "completed":
+      return "disconnected";
+    case "pending":
+      return "connecting";
+  }
+}
+
+function workstationAttachmentStatusMessageForClaim(
+  claim: NotebookWorkstationAttachmentClaim,
+  workstation: NotebookWorkstationAttachmentTarget,
+): string | null {
+  const displayName = workstation.displayName || "Selected workstation";
+  switch (claim.status) {
+    case "accepted":
+      return `${displayName} accepted the request and is starting compute.`;
+    case "failed":
+      return claim.errorMessage ?? `${displayName} could not start compute for this notebook.`;
+    case "cancelled":
+      return `${displayName} cancelled the compute request.`;
+    case "completed":
+      return `${displayName} runtime peer disconnected.`;
+    case "pending":
+      return `Waiting for ${displayName} to accept the compute request.`;
+    case "running":
+      return null;
+  }
+}

--- a/packages/runtimed/src/notebook-workstation-launch.ts
+++ b/packages/runtimed/src/notebook-workstation-launch.ts
@@ -195,14 +195,14 @@ function launchProjectionForCandidate(
     }
     return launchProjection({
       canRun: false,
-      detail: "This workstation is available but not attached to the notebook yet.",
+      detail: "This workstation is available and can start compute for this notebook.",
       primaryAction: launchAction(
         "attach_workstation",
-        "Attach compute",
-        `Attach ${candidate.displayName} to this notebook`,
+        "Start compute",
+        `Start compute on ${candidate.displayName}`,
       ),
       state: "needs_attachment",
-      statusLabel: "Attach needed",
+      statusLabel: "Ready to start",
       targetLabel: candidate.displayName,
       workstationId: candidate.id,
     });

--- a/packages/runtimed/tests/notebook-workstation-attachment.test.ts
+++ b/packages/runtimed/tests/notebook-workstation-attachment.test.ts
@@ -1,0 +1,69 @@
+import { describe, expect, it } from "vitest";
+import {
+  projectNotebookWorkstationAttachmentFromClaim,
+  type NotebookWorkstationAttachmentTarget,
+} from "../src/notebook-workstation-attachment";
+
+const lab2Workstation: NotebookWorkstationAttachmentTarget = {
+  workstationId: "lab2",
+  displayName: "lab2 workstation",
+  provider: "runtime_peer",
+  defaultEnvironmentLabel: "Current Python",
+  environmentPolicy: "current_python",
+  cpuCount: 8,
+  memoryBytes: 16_000_000_000,
+  workingDirectory: "/home/ubuntu/project",
+};
+
+describe("projectNotebookWorkstationAttachmentFromClaim", () => {
+  it("projects accepted workstation claims as connecting RuntimeStateDoc attachments", () => {
+    const attachment = projectNotebookWorkstationAttachmentFromClaim({
+      workstation: lab2Workstation,
+      claim: {
+        status: "accepted",
+        updatedAt: "2026-06-09T16:20:00.000Z",
+      },
+    });
+
+    expect(attachment).toEqual({
+      workstation_id: "lab2",
+      display_name: "lab2 workstation",
+      provider: "runtime_peer",
+      default_environment_label: "Current Python",
+      environment_policy: "current_python",
+      status: "connecting",
+      status_message: "lab2 workstation accepted the request and is starting compute.",
+      cpu_count: 8,
+      memory_bytes: 16_000_000_000,
+      working_directory: "/home/ubuntu/project",
+      updated_at: "2026-06-09T16:20:00.000Z",
+    });
+  });
+
+  it("projects running workstation claims as ready RuntimeStateDoc attachments", () => {
+    const attachment = projectNotebookWorkstationAttachmentFromClaim({
+      workstation: lab2Workstation,
+      claim: {
+        status: "running",
+        updatedAt: "2026-06-09T16:21:00.000Z",
+      },
+    });
+
+    expect(attachment.status).toBe("ready");
+    expect(attachment.status_message).toBeNull();
+  });
+
+  it("projects failed workstation claims as attention-worthy attachments", () => {
+    const attachment = projectNotebookWorkstationAttachmentFromClaim({
+      workstation: lab2Workstation,
+      claim: {
+        status: "failed",
+        errorMessage: "python missing ipykernel",
+        updatedAt: "2026-06-09T16:22:00.000Z",
+      },
+    });
+
+    expect(attachment.status).toBe("error");
+    expect(attachment.status_message).toBe("python missing ipykernel");
+  });
+});

--- a/packages/runtimed/tests/notebook-workstation-launch.test.ts
+++ b/packages/runtimed/tests/notebook-workstation-launch.test.ts
@@ -146,12 +146,14 @@ describe("notebook workstation launch readiness projection", () => {
     expect(projection).toMatchObject({
       canRun: false,
       state: "needs_attachment",
-      statusLabel: "Attach needed",
+      detail: "This workstation is available and can start compute for this notebook.",
+      statusLabel: "Ready to start",
       targetLabel: "Lab2 workstation",
       workstationId: "ws-lab2",
       primaryAction: {
         kind: "attach_workstation",
-        label: "Attach compute",
+        label: "Start compute",
+        title: "Start compute on Lab2 workstation",
       },
     });
   });

--- a/src/components/notebook/NotebookCommandToolbar.tsx
+++ b/src/components/notebook/NotebookCommandToolbar.tsx
@@ -3,6 +3,7 @@ import {
   ChevronsRight,
   Code,
   LetterText,
+  Loader2,
   Play,
   RotateCcw,
   ServerCog,
@@ -36,7 +37,9 @@ export interface NotebookCommandToolbarUpdateAction {
 }
 
 export interface NotebookCommandToolbarWorkstationAction {
+  disabled?: boolean;
   label: string;
+  pending?: boolean;
   title: string;
   onClick: () => void;
 }
@@ -259,12 +262,17 @@ export function NotebookCommandToolbar({
         <button
           type="button"
           onClick={workstationAction.onClick}
-          className="flex items-center gap-1 whitespace-nowrap rounded px-2 py-1 text-xs text-muted-foreground transition-colors hover:bg-muted hover:text-foreground"
+          disabled={workstationAction.disabled || workstationAction.pending}
+          className="flex items-center gap-1 whitespace-nowrap rounded px-2 py-1 text-xs text-muted-foreground transition-colors hover:bg-muted hover:text-foreground disabled:cursor-not-allowed disabled:opacity-60 disabled:hover:bg-transparent disabled:hover:text-muted-foreground"
           title={workstationAction.title}
           aria-label={workstationAction.label}
           data-testid="workstation-setup-button"
         >
-          <ServerCog className="h-3 w-3" />
+          {workstationAction.pending ? (
+            <Loader2 className="h-3 w-3 animate-spin" />
+          ) : (
+            <ServerCog className="h-3 w-3" />
+          )}
           <span className="hidden @[40rem]:inline">{workstationAction.label}</span>
         </button>
       ) : null}

--- a/src/components/notebook/NotebookWorkstationsPanel.tsx
+++ b/src/components/notebook/NotebookWorkstationsPanel.tsx
@@ -210,13 +210,9 @@ function RegisteredWorkstationRow({
               {workstation.statusLabel}
             </span>
           </div>
-          <div className="mt-1 flex min-w-0 flex-wrap gap-x-3 gap-y-1 text-xs">
+          <div className="mt-1.5 grid min-w-0 gap-1 text-xs">
             {workstation.facts.map((fact) => (
-              <RegisteredWorkstationFact
-                key={fact.kind}
-                fact={fact}
-                icon={registeredWorkstationFactIcon(fact)}
-              />
+              <RegisteredWorkstationFact key={fact.kind} fact={fact} />
             ))}
           </div>
           {workstation.statusMessage ? (
@@ -282,15 +278,12 @@ function WorkstationFact({
 
 function RegisteredWorkstationFact({
   fact,
-  icon: Icon,
 }: {
   fact: NotebookRegisteredWorkstationFactProjection;
-  icon: LucideIcon;
 }) {
   return (
-    <span className="inline-flex min-w-0 items-center gap-1.5 text-muted-foreground">
-      <Icon className="size-3.5 shrink-0" aria-hidden="true" />
-      <span className="shrink-0">{fact.label}</span>
+    <span className="grid min-w-0 grid-cols-[2.25rem_minmax(0,1fr)] items-baseline gap-1 text-muted-foreground">
+      <span className="text-[11px]">{fact.label}</span>
       <span className="min-w-0 truncate font-medium text-foreground">{fact.value}</span>
     </span>
   );
@@ -407,20 +400,5 @@ function workstationFactIcon(
       return Cloud;
     default:
       return Server;
-  }
-}
-
-function registeredWorkstationFactIcon(
-  fact: NotebookRegisteredWorkstationFactProjection,
-): LucideIcon {
-  switch (fact.kind) {
-    case "cpu":
-      return Gauge;
-    case "memory":
-      return MemoryStick;
-    case "working_directory":
-      return FolderOpen;
-    default:
-      return ServerCog;
   }
 }

--- a/src/components/notebook/__tests__/NotebookCommandToolbar.test.tsx
+++ b/src/components/notebook/__tests__/NotebookCommandToolbar.test.tsx
@@ -202,4 +202,32 @@ describe("NotebookCommandToolbar", () => {
     expect(onWorkstationSetup).toHaveBeenCalledTimes(1);
     expect(screen.queryByTestId("run-all-button")).toBeNull();
   });
+
+  it("shows pending workstation start without dispatching duplicate requests", () => {
+    const onWorkstationSetup = vi.fn();
+
+    render(
+      <NotebookCommandToolbar
+        capabilities={{
+          ...editableToolbarCapabilities,
+          canExecute: false,
+        }}
+        workstationAction={{
+          label: "Starting",
+          pending: true,
+          title: "Starting compute on Lab2 workstation",
+          onClick: onWorkstationSetup,
+        }}
+      />,
+    );
+
+    const setupButton = screen.getByTestId("workstation-setup-button");
+    expect(setupButton).toHaveAccessibleName("Starting");
+    expect(setupButton).toHaveAttribute("title", "Starting compute on Lab2 workstation");
+    expect(setupButton).toBeDisabled();
+
+    fireEvent.click(setupButton);
+
+    expect(onWorkstationSetup).not.toHaveBeenCalled();
+  });
 });


### PR DESCRIPTION
## Summary
- Rename the hosted workstation toolbar action from `Attach compute` to `Start compute` for the selected/default workstation path.
- Let the toolbar request workstation attachment directly without forcing the Workstations rail open.
- Show a disabled pending `Starting` toolbar action while the attachment request waits for RuntimeStateDoc/workstation state to catch up.
- Keep the Workstations rail attach button as the explicit switching/diagnostics path.
- Align workstation smoke diagnostics with the new `Start compute` language.

## Preview rollout
- Deployed preview.runt.run from this branch.
- Main worker version: `91c42734-1c4f-4035-8785-498a6f54ec27`.
- Renderer-assets worker version: `6248f375-4f7e-4a66-ac1e-73a7b71bfad9`.
- Rebuilt `target/release/runtimed` on lab2 and restarted the hosted workstation agent; `lab2` reports online as the default workstation.
- Live smoke notebook: https://preview.runt.run/n/01KTPHRNKYF8YKDDBPWQK8GF3K/toolbar-attach-smoke

## Validation
- `pnpm test:run -- packages/runtimed/tests/notebook-workstation-launch.test.ts src/components/notebook/__tests__/NotebookCommandToolbar.test.tsx` (frontend suite: 194 passed, 1 skipped; 1977 tests passed)
- `pnpm --dir apps/notebook-cloud exec node --import tsx --test test/hosted-workstation-toolbar-smoke.test.mjs test/workstations-client.test.ts`
- `pnpm --dir apps/notebook-cloud exec node --import tsx --test test/hosted-workstation-toolbar-smoke.test.mjs`
- `pnpm --dir apps/notebook-cloud typecheck`
- `cargo xtask lint --fix`
- `pnpm --dir apps/notebook-cloud run deploy:check`
- `pnpm --dir apps/notebook-cloud run auth:preview:health`
- `pnpm --dir apps/notebook-cloud smoke:hosted:workstation-toolbar` against preview: workstation online, `Start compute` toolbar action rendered/clicked, compute attached, first execution output observed, reload preserved output, second execution output observed, blocked workstation scenarios still hide run controls.

## Notes
- Cloud dependency management is intentionally not bolted in here. The follow-up should use shared event -> document state -> projection layers: NotebookDoc metadata for declared deps, RuntimeStateDoc for env/build/trust progress, and existing request transport for launch intent.
