### PR TITLE
refactor(notebook-cloud): own cell focus in the shared store; chart projection convergence

### DIFF
--- a/apps/notebook-cloud/test/viewer-shared-cell-surface.test.ts
+++ b/apps/notebook-cloud/test/viewer-shared-cell-surface.test.ts
@@ -122,16 +122,21 @@ test("cloud command toolbar inserts below the focused cell before falling back t
   );
 });
 
-test("cloud projects host focus through the shared cell UI state bridge", () => {
+test("cloud routes cell focus through the shared store, not a host React shadow", () => {
   const sourceText = viewerCorpus;
 
-  assert.match(sourceText, /useNotebookCellUIStateBridge/);
-  assert.match(
-    sourceText,
-    /const \[focusedCellId, setFocusedCellId\] = useState<string \| null>\(null\)/,
-  );
-  assert.match(sourceText, /useNotebookCellUIStateBridge\(\{ focusedCellId \}\)/);
-  assert.match(sourceText, /onFocusCell=\{setFocusedCellId\}/);
+  // Focus is read from the shared cell-ui-state store and written through the
+  // shared setter with a synchronous flush (the same set+flush pattern
+  // NotebookView uses for interaction focus), so the host holds no React copy.
+  assert.match(sourceText, /const focusedCellId = useFocusedCellId\(\)/);
+  assert.match(sourceText, /const focusCellInStore = useCallback/);
+  assert.match(sourceText, /setFocusedCellId\(id\);\s*flushCellUIState\(\);/);
+  assert.match(sourceText, /onFocusCell=\{focusCellInStore\}/);
+  assert.match(sourceText, /onFocusCell: focusCellInStore/);
+
+  // No host React shadow of focus, and no per-host UI-state bridge double-buffer.
+  assert.doesNotMatch(sourceText, /\[focusedCellId, setFocusedCellId\] = useState/);
+  assert.doesNotMatch(sourceText, /useNotebookCellUIStateBridge/);
   assert.doesNotMatch(
     sourceText,
     /import \{[^}]*setFocusedCellId[^}]*\} from "\.\.\/\.\.\/notebook\/src\/lib\/cell-ui-state"/,

--- a/apps/notebook-cloud/test/viewer-shared-cell-surface.test.ts
+++ b/apps/notebook-cloud/test/viewer-shared-cell-surface.test.ts
@@ -125,14 +125,20 @@ test("cloud command toolbar inserts below the focused cell before falling back t
 test("cloud routes cell focus through the shared store, not a host React shadow", () => {
   const sourceText = viewerCorpus;
 
-  // Focus is read from the shared cell-ui-state store and written through the
-  // shared setter with a synchronous flush (the same set+flush pattern
-  // NotebookView uses for interaction focus), so the host holds no React copy.
+  // Focus is read from the shared cell-ui-state store, and the host holds no
+  // React copy. Programmatic focus the controller drives (focus-after-add) is
+  // written through the shared setter with a synchronous flush.
   assert.match(sourceText, /const focusedCellId = useFocusedCellId\(\)/);
   assert.match(sourceText, /const focusCellInStore = useCallback/);
   assert.match(sourceText, /setFocusedCellId\(id\);\s*flushCellUIState\(\);/);
-  assert.match(sourceText, /onFocusCell=\{focusCellInStore\}/);
   assert.match(sourceText, /onFocusCell: focusCellInStore/);
+
+  // NotebookView owns the interaction-target write for user focus
+  // (publishInteractionTarget carries the real cell/editor/output kind), so the
+  // host passes it a no-op rather than double-writing a transient { kind: "cell" }.
+  assert.match(sourceText, /const handleNotebookViewFocus = useCallback\(\(\) => \{\}, \[\]\)/);
+  assert.match(sourceText, /onFocusCell=\{handleNotebookViewFocus\}/);
+  assert.doesNotMatch(sourceText, /onFocusCell=\{focusCellInStore\}/);
 
   // No host React shadow of focus, and no per-host UI-state bridge double-buffer.
   assert.doesNotMatch(sourceText, /\[focusedCellId, setFocusedCellId\] = useState/);

--- a/apps/notebook-cloud/viewer/notebook-viewer.tsx
+++ b/apps/notebook-cloud/viewer/notebook-viewer.tsx
@@ -124,16 +124,19 @@ export function NotebookViewer({
     appSessionStatus.refreshAppSessionStatus,
   );
   // Cell focus is owned by the shared cell-ui-state store, not host React state.
-  // NotebookView already writes and synchronously flushes focus on user
-  // interaction (publishInteractionTarget). Read focus from the store for host
-  // chrome, and route programmatic focus (e.g. focus-after-add from the
-  // controller) through the same store with a synchronous flush so it propagates
-  // without a per-host bridge re-render.
+  // NotebookView already writes and synchronously flushes the interaction target
+  // on user focus (publishInteractionTarget, which carries the real
+  // cell/editor/output kind), so its onFocusCell is a no-op here. Routing it
+  // through the store would double-write: a transient { kind: "cell" } before the
+  // real { kind: "editor" | "output" }. The host only writes the store for
+  // *programmatic* focus the controller drives (focus-after-add), which has no
+  // publishInteractionTarget of its own; that goes through the set+flush path.
   const focusedCellId = useFocusedCellId();
   const focusCellInStore = useCallback((id: string | null) => {
     setFocusedCellId(id);
     flushCellUIState();
   }, []);
+  const handleNotebookViewFocus = useCallback(() => {}, []);
   const [activeRailPanel, setActiveRailPanel] = useState<NotebookRailPanelId>("outline");
   const [railCollapsed, setRailCollapsed] = useState(initialCloudRailCollapsed);
   const [selectedOutlineItemId, setSelectedOutlineItemId] = useState<string | null>(null);
@@ -926,7 +929,7 @@ export function NotebookViewer({
               canAcceptCellMutations={canAcceptCellMutations}
               runtime={notebookLanguageRef.current === "deno" ? "deno" : "python"}
               sessionRuntimeState={connectionError ? "error" : "ready"}
-              onFocusCell={focusCellInStore}
+              onFocusCell={handleNotebookViewFocus}
               onExecuteCell={handleCloudExecuteCell}
               onInterruptKernel={() => {}}
               onDeleteCell={handleCloudDeleteCell}

--- a/apps/notebook-cloud/viewer/notebook-viewer.tsx
+++ b/apps/notebook-cloud/viewer/notebook-viewer.tsx
@@ -26,7 +26,9 @@ import {
   type NotebookEnvironmentManager,
   type NotebookInteractionMode,
   type NotebookPackageSection,
-  useNotebookCellUIStateBridge,
+  flushCellUIState,
+  setFocusedCellId,
+  useFocusedCellId,
   useNotebookViewModel,
 } from "@/components/notebook";
 import { useWidgetStoreRequired } from "@/components/widgets/widget-store-context";
@@ -121,7 +123,17 @@ export function NotebookViewer({
     appSessionStatus.status === "loading",
     appSessionStatus.refreshAppSessionStatus,
   );
-  const [focusedCellId, setFocusedCellId] = useState<string | null>(null);
+  // Cell focus is owned by the shared cell-ui-state store, not host React state.
+  // NotebookView already writes and synchronously flushes focus on user
+  // interaction (publishInteractionTarget). Read focus from the store for host
+  // chrome, and route programmatic focus (e.g. focus-after-add from the
+  // controller) through the same store with a synchronous flush so it propagates
+  // without a per-host bridge re-render.
+  const focusedCellId = useFocusedCellId();
+  const focusCellInStore = useCallback((id: string | null) => {
+    setFocusedCellId(id);
+    flushCellUIState();
+  }, []);
   const [activeRailPanel, setActiveRailPanel] = useState<NotebookRailPanelId>("outline");
   const [railCollapsed, setRailCollapsed] = useState(initialCloudRailCollapsed);
   const [selectedOutlineItemId, setSelectedOutlineItemId] = useState<string | null>(null);
@@ -231,8 +243,6 @@ export function NotebookViewer({
   useEffect(() => {
     applyDocumentTheme(resolvedTheme);
   }, [resolvedTheme]);
-
-  useNotebookCellUIStateBridge({ focusedCellId });
 
   const notebookViewModel = useNotebookViewModel({
     metadata: notebookMetadata,
@@ -386,10 +396,15 @@ export function NotebookViewer({
             requestCloudMaterialization(liveRuntime);
           }
         },
-        onFocusCell: setFocusedCellId,
+        onFocusCell: focusCellInStore,
         logPrefix: "[notebook-cloud]",
       }),
-    [canWriteCellSource, requestCloudMaterialization, shellCapabilities.canEditStructure],
+    [
+      canWriteCellSource,
+      focusCellInStore,
+      requestCloudMaterialization,
+      shellCapabilities.canEditStructure,
+    ],
   );
   const handleCloudAddCell = useCallback(
     (type: "code" | "markdown", afterCellId?: string | null) => {
@@ -911,7 +926,7 @@ export function NotebookViewer({
               canAcceptCellMutations={canAcceptCellMutations}
               runtime={notebookLanguageRef.current === "deno" ? "deno" : "python"}
               sessionRuntimeState={connectionError ? "error" : "ready"}
-              onFocusCell={setFocusedCellId}
+              onFocusCell={focusCellInStore}
               onExecuteCell={handleCloudExecuteCell}
               onInterruptKernel={() => {}}
               onDeleteCell={handleCloudDeleteCell}

--- a/apps/notebook/src/lib/__tests__/cell-ui-queue-projection.test.tsx
+++ b/apps/notebook/src/lib/__tests__/cell-ui-queue-projection.test.tsx
@@ -19,6 +19,9 @@ describe("cell UI queue projection", () => {
       queued: useIsCellQueued("cell-2"),
       priority: useCellQueuePriority("cell-2"),
       groupRunning: useIsGroupExecuting(["cell-1", "cell-3"]),
+      // A group of only queued cells is not "executing": group chrome tracks the
+      // single running cell from the projection, not queue membership.
+      groupQueuedOnly: useIsGroupExecuting(["cell-2", "cell-3"]),
     }));
 
     expect(result.current).toEqual({
@@ -26,6 +29,7 @@ describe("cell UI queue projection", () => {
       queued: false,
       priority: 0,
       groupRunning: false,
+      groupQueuedOnly: false,
     });
 
     act(() => {
@@ -40,6 +44,7 @@ describe("cell UI queue projection", () => {
       queued: true,
       priority: 1,
       groupRunning: true,
+      groupQueuedOnly: false,
     });
 
     act(() => {
@@ -54,6 +59,7 @@ describe("cell UI queue projection", () => {
       queued: false,
       priority: 0,
       groupRunning: false,
+      groupQueuedOnly: false,
     });
   });
 });

--- a/crates/runtimed-wasm/src/lib.rs
+++ b/crates/runtimed-wasm/src/lib.rs
@@ -1092,8 +1092,10 @@ impl RoomHostHandle {
         let request: serde_json::Value = serde_json::from_slice(payload)
             .map_err(|e| JsError::new(&format!("decode request: {e}")))?;
         match request.get("action").and_then(|v| v.as_str()) {
-            // Guarded and unguarded both create the execution; the observed-heads
-            // causal guard is deferred (see ADR run-cell follow-ups).
+            // Guarded and unguarded execution intent (single-cell and run-all)
+            // both create executions; the observed-heads causal guard is deferred
+            // (see ADR run-cell follow-ups). Until then `_guarded` is accepted for
+            // wire parity but does not validate the requester's NotebookDoc heads.
             Some("execute_cell") | Some("execute_cell_guarded") => {
                 self.handle_execute_cell(&request, peer_id, submitter_actor_label)
             }

--- a/docs/adr/shared-store-projection-convergence.md
+++ b/docs/adr/shared-store-projection-convergence.md
@@ -1,0 +1,97 @@
+# Shared-Store Projection Convergence
+
+**Status:** In progress, 2026-06-09. Follow-up to [notebook-host-shell-convergence](./notebook-host-shell-convergence.md).
+
+## Context
+
+PR #3514 established a pattern: transient cell chrome (queued/running) stopped
+living in per-host React state and moved into a shared, projection-backed store
+(`src/components/notebook/state/execution-store.ts`, the queue projection),
+consumed through `useSyncExternalStore`. Both Desktop (`apps/notebook`) and Cloud
+(`apps/notebook-cloud/viewer`) feed the same `src/components/notebook/state/*`
+stores and render the same shared components, including the same
+`apps/notebook/src/components/NotebookView.tsx` (Cloud imports it). State held
+inside those shared components is therefore effectively cross-host.
+
+The goal of this line of work: stop forcing React to hold notebook state that
+belongs in a shared store, and let Desktop and Cloud share as much as they
+genuinely can. The hosts differ only as *hosts* (transport, runtime, app shell);
+that boundary is real and must not be over-converged.
+
+## Convergence template
+
+A fact belongs in a shared store when more than one host (or a shared component)
+needs it and it is not a host-transport detail. The store owns the value plus a
+`useSyncExternalStore` selector; writers set the value and notify. Cell UI state
+uses a deferred two-phase flush for StrictMode safety (`flushCellUIState()` from
+`useLayoutEffect`), so **event-time and programmatic writes must flush
+synchronously** the way `NotebookView.publishInteractionTarget` does. Skipping
+the flush strands the update (marked dirty, never emitted).
+
+## Done
+
+- **#3514** — cell queued/running chrome reads the shared execution queue
+  projection instead of `setExecutingCellIds`/`setQueuedCellIds` host pushes.
+- **Cloud cell focus** — `notebook-viewer.tsx` no longer holds a `focusedCellId`
+  `useState` shadow. It reads `useFocusedCellId()` and routes programmatic focus
+  through `setFocusedCellId` + `flushCellUIState` (the NotebookView set+flush
+  pattern), dropping the host bridge double-buffer.
+
+## Remaining work (ranked)
+
+Each item removes a second source of truth. None is unit-testable for its
+runtime timing; each needs a hosted/desktop browser smoke (focus, run-all,
+output focus, reconnect) before merge.
+
+1. **NotebookView output-focus → shared store.** `outputFocusedCellId` `useState`
+   + three effects (focus-follows-selection, cell-removal cleanup, Esc) +
+   iframe-blur + click-outside live in the shared `NotebookView`, so this is
+   cross-host today. Highest value (benefits both hosts, ~55 lines collapse).
+   Hazard: the focus-follows-selection effect has a load-bearing deferred-flush
+   race guard (`NotebookView.tsx`, the `focusedCellId !== null` comment) and the
+   Esc/iframe focus paths are not reproducible in unit tests. New
+   `src/components/notebook/state/output-focus-store.ts`.
+
+2. **Cloud `workstationAttachment` → shared runtime-state store.**
+   `cloud-viewer-session.ts` holds a `workstationAttachment` `useState` that is a
+   copy of `useRuntimeState().workstation` (the same subscription pushes the full
+   state via `setRuntimeState`). Hazard: it is deduped by `workstationAttachmentKeyRef`
+   to avoid re-renders on unchanged attachments, and reset in four
+   disconnect/room-change sites. A naive `useRuntimeState().workstation` re-renders
+   on every runtime tick and changes reset timing. Needs an equality-aware
+   selector (e.g. `useRuntimeStateWorkstation()`) on the runtime-state store and
+   careful handling of the reset sites.
+
+3. **Rail/outline chrome (`activeRailPanel`, `railCollapsed`,
+   `selectedOutlineItemId`) → shared `rail-ui-state` store.** Declared identically
+   in `App.tsx` and `notebook-viewer.tsx`. This is a DRY/single-definition win,
+   not a behavioral one: the hosts never share a process, so a module-global store
+   does not enable real cross-host sharing, and it adds more lines than it
+   deletes. Low priority; do it only if it demonstrably simplifies both hosts.
+
+4. **Cloud connection facts (`connectionScope`/`PeerId`/`ActorLabel`/`Error`).**
+   Keep in the session hook. Only promote to a shared store if a *shared* component
+   (not just the cloud-local capabilities deriver) needs to subscribe.
+
+## Keep host-specific (do not converge)
+
+- Daemon lifecycle (`daemonStatus`, reconnect, ready timeouts) — Tauri/daemon
+  bootstrap with no Cloud analog.
+- Environment/pool/trust (`useDependencies`, `usePoolState`, `useTrust`,
+  `runtime-state.ts` Pool/RuntimeStateDoc) — Desktop has direct filesystem and
+  package-manager access; Cloud delegates to remote workstations.
+- OIDC/app-session/room-sync (`collaborator-auth`, `use-cloud-auth`,
+  `cloud-viewer-session` connect/sync) — host transport boundary. Project only
+  their *results* (scope, actor, peer id) into shared stores when a shared
+  consumer needs them.
+- Presence — Cloud room peers/cursors vs Desktop Automerge presence, already
+  bridged through the shared `PresenceContext`. Keep the implementations split.
+- Shell-capabilities *input derivation* — `desktop-shell-capabilities.ts` vs
+  `use-cloud-shell-capabilities.ts`. The shared convergence point is the
+  `NotebookShellCapabilities` type they both produce; the derivation must differ.
+- Cloud synthetic execution IDs (`cloud-execution:<cellId>`) vs Desktop daemon
+  changeset projection — two correct host paths into the same shared stores.
+
+Rejected over-converge: interaction **target** (which cell) and interaction
+**mode** (view vs edit) are different concepts; do not merge Cloud's
+`selectedInteractionMode` into the shared `NotebookInteractionTarget` store.

--- a/docs/adr/shared-store-projection-convergence.md
+++ b/docs/adr/shared-store-projection-convergence.md
@@ -55,12 +55,18 @@ output focus, reconnect) before merge.
 2. **Cloud `workstationAttachment` → shared runtime-state store.**
    `cloud-viewer-session.ts` holds a `workstationAttachment` `useState` that is a
    copy of `useRuntimeState().workstation` (the same subscription pushes the full
-   state via `setRuntimeState`). Hazard: it is deduped by `workstationAttachmentKeyRef`
-   to avoid re-renders on unchanged attachments, and reset in four
-   disconnect/room-change sites. A naive `useRuntimeState().workstation` re-renders
-   on every runtime tick and changes reset timing. Needs an equality-aware
-   selector (e.g. `useRuntimeStateWorkstation()`) on the runtime-state store and
-   careful handling of the reset sites.
+   state via `setRuntimeState`). #3515 strengthens this: the worker now publishes
+   workstation claim progress into RuntimeStateDoc
+   (`publishWorkstationAttachJobRuntimeState` -> room `setWorkstationAttachment`,
+   via the pure `projectNotebookWorkstationAttachmentFromClaim`), so the
+   attachment is a RuntimeStateDoc-owned fact end to end and the session's
+   `useState` is clearly a shadow of the projected runtime state. Hazard: it is
+   deduped by `workstationAttachmentKeyRef` to avoid re-renders on unchanged
+   attachments, and reset in four disconnect/room-change sites. A naive
+   `useRuntimeState().workstation` re-renders on every runtime tick and changes
+   reset timing. Converge by consuming the projected attachment through an
+   equality-aware selector (e.g. `useRuntimeStateWorkstation()`) on the
+   runtime-state store, preserving the reset sites' clear-on-disconnect behavior.
 
 3. **Rail/outline chrome (`activeRailPanel`, `railCollapsed`,
    `selectedOutlineItemId`) → shared `rail-ui-state` store.** Declared identically


### PR DESCRIPTION
Follow-up to #3514, continuing the move of notebook state out of per-host React and onto shared projection-backed stores, with an audit-driven roadmap for the rest.

## Cloud cell focus owns the shared store, not host React state

`NotebookViewer` held `focusedCellId` in a `useState` that shadowed the shared `cell-ui-state` store: it was set only by `onFocusCell`, re-projected into the store through `useNotebookCellUIStateBridge`, and read back once for the toolbar's add-after-cell fallback. But `NotebookView` (rendered by both hosts) already writes and synchronously flushes focus to the shared store on user interaction (`publishInteractionTarget`) and reads it via `useFocusedCellId`. The host copy was a redundant second source of truth.

Now cloud reads `useFocusedCellId()` and routes programmatic focus (the controller's focus-after-add) through `setFocusedCellId` + `flushCellUIState` - the same set+flush pattern `NotebookView` uses - so it propagates without a per-host bridge. The `useState`, the bridge call, and the shadow are gone. The guardrail that pinned the old bridge pattern now asserts the store-routed invariant.

This is small on purpose. The audit (below) found the codebase is already well-converged after #3514: most remaining host state is genuinely host-specific, and the larger convergences carry render/flush-timing risk that wants a browser smoke, not a blind merge.

## #3514 review follow-ups

- `useIsGroupExecuting` now has an assertion that a group of only-queued cells is not "executing" - group chrome tracks the single running cell from the queue projection, not queue membership.
- The `receive_request` match-arm comment is explicit that `run_all_cells_guarded`, like `execute_cell_guarded`, is accepted for wire parity but does not yet validate the requester's NotebookDoc heads.

Note: the hosted run-all validation/rollback error paths return `JsError`, which panics on the native `cargo test` target (wasm-bindgen), so they are not unit-testable there. That is why #3514 covers only the Ok paths; testing the reject paths needs `wasm-bindgen-test` or splitting validation off the wasm boundary.

## Roadmap

`docs/adr/shared-store-projection-convergence.md` records the audit: the convergence template (projection store + `useSyncExternalStore` + the set+flush discipline), what is done, the ranked remaining work with each item's specific runtime hazard, and the host boundaries to keep separate. Highlights of what is left:

- **NotebookView output-focus to a shared store** (highest value, cross-host) - blocked on a load-bearing deferred-flush race guard and Esc/iframe focus paths that are not unit-reproducible.
- **Cloud `workstationAttachment` to the runtime-state store** - blocked on its dedup-by-cache-key and four reset sites; needs an equality-aware selector hook.
- **Rail/outline chrome** - DRY-only (the hosts never share a process), net-adds lines; low priority.

And the explicit do-not-converge list: daemon lifecycle, env/pool/trust, OIDC/room-sync, presence transport, shell-capabilities input derivation, synthetic execution IDs. Plus one rejected over-converge: interaction mode (view/edit) is not the same as interaction target (which cell).

## Verification

- `vp check` (repo-wide): 951 files formatted, 0 lint errors.
- Cloud `tsc --noEmit`: clean. Cloud TS suite: 553 passing.
- `cargo test -p runtimed-wasm hosted_`: 4 passing.
- Desktop frontend queue-projection test: passing.

## Not verified

Cloud focus timing is not browser-verified here. The hosted toolbar smoke (focus + run-all) should exercise it before merge. The roadmap items are deliberately left for browser-verified follow-ups for the same reason.
