### PR TITLE
fix(notebook-cloud): sync hosted widget state across viewers

### DIFF
--- a/apps/notebook-cloud/package.json
+++ b/apps/notebook-cloud/package.json
@@ -26,6 +26,7 @@
     "smoke:hosted:runtime-peer": "node scripts/hosted-runtime-peer-smoke.mjs",
     "smoke:hosted:workstation-agent": "node scripts/hosted-workstation-agent.mjs",
     "smoke:hosted:workstation-toolbar": "node scripts/hosted-workstation-toolbar-smoke.mjs",
+    "smoke:hosted:widget-cross-window": "node scripts/hosted-widget-cross-window-smoke.mjs",
     "smoke:hosted:browser-execute": "node scripts/hosted-browser-execute-smoke.mjs",
     "smoke:hosted:runtime-browser-execute": "node scripts/hosted-runtime-browser-execute-smoke.mjs",
     "smoke:hosted:collab": "node --import tsx scripts/hosted-collab-smoke.mjs",

--- a/apps/notebook-cloud/scripts/hosted-widget-cross-window-smoke.mjs
+++ b/apps/notebook-cloud/scripts/hosted-widget-cross-window-smoke.mjs
@@ -83,11 +83,38 @@ async function main() {
       );
     }
 
-    const browserRun = await runBrowserSmoke({
-      browser,
-      tokenStorageJson,
-      viewerUrl: runtime.viewerUrl,
-    });
+    let browserRun;
+    try {
+      browserRun = await runBrowserSmoke({
+        browser,
+        tokenStorageJson,
+        viewerUrl: runtime.viewerUrl,
+      });
+    } catch (error) {
+      const browserFailure =
+        error && typeof error === "object" && "browserRun" in error ? error.browserRun : null;
+      await writeSmokeJsonReport(
+        {
+          ok: false,
+          viewerUrl: runtime.viewerUrl,
+          notebookId: runtime.notebookId,
+          source,
+          token: {
+            path: tokenPath,
+            secondsRemaining: tokenSecondsRemaining,
+          },
+          runtimePeer: {
+            pid: runtimePeerPid,
+            logPath: runtime.runtimePeer?.logPath ?? null,
+            stopped: false,
+          },
+          browser: browserFailure,
+          error: error instanceof Error ? error.message : String(error),
+        },
+        reportPath,
+      );
+      throw error;
+    }
     await stopProcess(runtimePeerPid);
     runtimePeerPid = null;
 
@@ -109,8 +136,8 @@ async function main() {
         "primary_window_widget_rendered",
         "peer_window_widget_rendered",
         "widget_initial_value_synced",
-        "widget_drag_changed_primary_value",
-        "widget_drag_synced_to_peer_window",
+        "primary_widget_drag_synced_to_peer_window",
+        "peer_widget_drag_synced_to_primary_window",
         "widget_loading_message_absent",
       ],
       browser: browserRun,
@@ -143,9 +170,11 @@ async function runBrowserSmoke({ browser, tokenStorageJson, viewerUrl }) {
     scope: "owner",
     tokenStorageJson,
   });
+  let primary = null;
+  let peer = null;
   try {
-    const primary = await primaryContext.newPage();
-    const peer = await peerContext.newPage();
+    primary = await primaryContext.newPage();
+    peer = await peerContext.newPage();
     collectDiagnostics(primary, "primary", diagnostics);
     collectDiagnostics(peer, "peer", diagnostics);
 
@@ -164,6 +193,10 @@ async function runBrowserSmoke({ browser, tokenStorageJson, viewerUrl }) {
     await dragSliderToValue(primarySlider, 18);
     await expectSliderValue(primarySlider, "18", timeoutMs);
     await expectSliderValue(peerSlider, "18", timeoutMs);
+
+    await dragSliderToValue(peerSlider, 11);
+    await expectSliderValue(peerSlider, "11", timeoutMs);
+    await expectSliderValue(primarySlider, "11", timeoutMs);
     await expectNoWidgetLoading(primary, timeoutMs);
     await expectNoWidgetLoading(peer, timeoutMs);
 
@@ -177,6 +210,36 @@ async function runBrowserSmoke({ browser, tokenStorageJson, viewerUrl }) {
       diagnostics,
       screenshotPath: screenshotPath ?? null,
     };
+  } catch (error) {
+    if (screenshotPath) {
+      if (primary) {
+        await saveSmokeScreenshot(primary, siblingScreenshotPath(screenshotPath, "primary")).catch(
+          () => {},
+        );
+      }
+      if (peer) {
+        await saveSmokeScreenshot(peer, siblingScreenshotPath(screenshotPath, "peer")).catch(
+          () => {},
+        );
+      }
+    }
+    if (error && typeof error === "object") {
+      error.browserRun = {
+        primary: primary
+          ? await widgetPageSnapshot(primary).catch((snapshotError) => ({
+              error: String(snapshotError),
+            }))
+          : null,
+        peer: peer
+          ? await widgetPageSnapshot(peer).catch((snapshotError) => ({
+              error: String(snapshotError),
+            }))
+          : null,
+        diagnostics,
+        screenshotPath: screenshotPath ?? null,
+      };
+    }
+    throw error;
   } finally {
     await primaryContext.close().catch(() => {});
     await peerContext.close().catch(() => {});
@@ -191,6 +254,7 @@ async function authenticatedContext(browser, { origin, scope, tokenStorageJson }
         if (globalThis.location?.origin !== expectedOrigin) return;
         globalThis.localStorage?.setItem("nteract:notebook-cloud:oidc-token", tokenJson);
         globalThis.localStorage?.setItem("nteract:notebook-cloud:scope", requestedScope);
+        globalThis.localStorage?.setItem("nteract:notebook-cloud:widget-diagnostics", "1");
       } catch {
         // Output frames intentionally cannot read first-party localStorage.
       }
@@ -249,13 +313,37 @@ async function dragSliderToValue(slider, targetValue) {
   }
   const clamped = Math.min(max, Math.max(min, targetValue));
   const ratio = max === min ? 0 : (clamped - min) / (max - min);
-  await slider.dragTo(sliderRoot, {
-    force: true,
-    targetPosition: {
-      x: rootBox.width * ratio,
-      y: rootBox.height / 2,
-    },
+  const thumbBox = await slider.boundingBox();
+  if (!thumbBox) {
+    throw new Error("IntSlider did not expose the expected thumb geometry");
+  }
+  const page = slider.page();
+  await page.mouse.move(thumbBox.x + thumbBox.width / 2, thumbBox.y + thumbBox.height / 2);
+  await page.mouse.down();
+  await page.mouse.move(rootBox.x + rootBox.width * ratio, rootBox.y + rootBox.height / 2, {
+    steps: 8,
   });
+  await page.mouse.up();
+  await slider.page().waitForTimeout(settleMs);
+  const currentValue = Number(await slider.getAttribute("aria-valuenow"));
+  if (currentValue === targetValue) {
+    return;
+  }
+
+  // Pointer geometry differs slightly between hosted iframe layouts and browser
+  // channels. Fall back to keyboard stepping so the smoke remains a reliable
+  // cross-window sync proof instead of a drag-mechanics test.
+  await slider.click();
+  const direction = targetValue > currentValue ? "ArrowRight" : "ArrowLeft";
+  for (let value = currentValue; value !== targetValue; ) {
+    await slider.press(direction);
+    await slider.page().waitForTimeout(25);
+    const nextValue = Number(await slider.getAttribute("aria-valuenow"));
+    if (!Number.isFinite(nextValue) || nextValue === value) {
+      break;
+    }
+    value = nextValue;
+  }
   await slider.page().waitForTimeout(settleMs);
 }
 
@@ -272,6 +360,21 @@ async function widgetPageSnapshot(page) {
     .catch(() => []);
   return {
     text: text.replace(/\s+/g, " ").slice(0, 1000),
+    parentWidgetStore: await page
+      .evaluate(() => {
+        const fn = globalThis.__nteractCloudWidgetStoreSnapshot;
+        return typeof fn === "function" ? fn() : null;
+      })
+      .catch(() => null),
+    commEvents: await page
+      .evaluate(() => globalThis.__nteractCloudWidgetCommEvents ?? null)
+      .catch(() => null),
+    liveRuntime: await page
+      .evaluate(() => {
+        const fn = globalThis.__nteractCloudLiveRuntimeSnapshot;
+        return typeof fn === "function" ? fn() : null;
+      })
+      .catch(() => null),
     widgetFrames: (await frameBodies.allInnerTexts()).map((bodyText, index) => ({
       bodyText: bodyText.replace(/\s+/g, " ").slice(0, 500),
       sliderValue: sliderValues[index] ?? null,
@@ -297,6 +400,9 @@ function collectDiagnostics(page, label, diagnostics) {
     }
   });
   page.on("requestfailed", (request) => {
+    if (isBenignRequestFailure(request.url(), request.failure()?.errorText ?? null)) {
+      return;
+    }
     diagnostics.requestFailures.push({
       label,
       url: safeDiagnosticUrl(request.url()),
@@ -309,8 +415,16 @@ function collectDiagnostics(page, label, diagnostics) {
       url: safeDiagnosticUrl(ws.url()),
       closed: false,
       errors: [],
+      framesSent: {},
+      framesReceived: {},
     };
     diagnostics.websockets.push(entry);
+    ws.on("framesent", (frame) => {
+      recordWebSocketFrame(entry.framesSent, frame.payload);
+    });
+    ws.on("framereceived", (frame) => {
+      recordWebSocketFrame(entry.framesReceived, frame.payload);
+    });
     ws.on("socketerror", (error) => {
       entry.errors.push(String(error));
     });
@@ -318,6 +432,64 @@ function collectDiagnostics(page, label, diagnostics) {
       entry.closed = true;
     });
   });
+}
+
+function isBenignRequestFailure(url, failure) {
+  if (failure !== "net::ERR_ABORTED") return false;
+  try {
+    const parsed = new URL(url);
+    return parsed.origin === "https://preview.runtusercontent.com" && parsed.pathname === "/frame/";
+  } catch {
+    return false;
+  }
+}
+
+function recordWebSocketFrame(target, payload) {
+  const label = webSocketFrameLabel(payload);
+  target[label] = (target[label] ?? 0) + 1;
+}
+
+function webSocketFrameLabel(payload) {
+  if (typeof payload === "string") {
+    return "text";
+  }
+  if (payload instanceof Buffer) {
+    return frameTypeName(payload[0]);
+  }
+  if (payload instanceof ArrayBuffer) {
+    return frameTypeName(new Uint8Array(payload)[0]);
+  }
+  if (ArrayBuffer.isView(payload)) {
+    return frameTypeName(new Uint8Array(payload.buffer, payload.byteOffset, payload.byteLength)[0]);
+  }
+  return "unknown";
+}
+
+function frameTypeName(type) {
+  switch (type) {
+    case 0x00:
+      return "automerge_sync";
+    case 0x01:
+      return "request";
+    case 0x02:
+      return "response";
+    case 0x03:
+      return "presence";
+    case 0x04:
+      return "session_control";
+    case 0x05:
+      return "runtime_state_sync";
+    case 0x06:
+      return "pool_state_sync";
+    case 0x07:
+      return "put_blob";
+    case 0x08:
+      return "broadcast";
+    case 0x09:
+      return "comms_doc_sync";
+    default:
+      return `frame_${String(type)}`;
+  }
 }
 
 function assertCleanDiagnostics(diagnostics) {
@@ -455,6 +627,12 @@ function safeDiagnosticUrl(value) {
   } catch {
     return value;
   }
+}
+
+function siblingScreenshotPath(screenshotPath, label) {
+  const extension = path.extname(screenshotPath) || ".png";
+  const base = screenshotPath.slice(0, screenshotPath.length - extension.length);
+  return `${base}-${label}${extension}`;
 }
 
 function isBenignPageError(text) {

--- a/apps/notebook-cloud/scripts/hosted-widget-cross-window-smoke.mjs
+++ b/apps/notebook-cloud/scripts/hosted-widget-cross-window-smoke.mjs
@@ -1,0 +1,476 @@
+import { spawn } from "node:child_process";
+import { readFile } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { fileURLToPath, pathToFileURL } from "node:url";
+
+import { chromium, expect } from "@playwright/test";
+
+import {
+  saveSmokeScreenshot,
+  smokeJsonReportPath,
+  smokeOutputPath,
+  writeSmokeJsonReport,
+} from "./smoke-paths.mjs";
+
+const appDir = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
+const runtimePeerScript = path.join(appDir, "scripts", "hosted-runtime-peer-smoke.mjs");
+const tokenPath =
+  process.env.NTERACT_PREVIEW_OIDC_TOKEN_PATH ??
+  process.env.NOTEBOOK_CLOUD_OIDC_TOKEN_PATH ??
+  path.join(os.homedir(), "token.preview.json");
+const timeoutMs = parsePositiveInteger(
+  process.env.NOTEBOOK_CLOUD_WIDGET_CROSS_WINDOW_TIMEOUT_MS,
+  "NOTEBOOK_CLOUD_WIDGET_CROSS_WINDOW_TIMEOUT_MS",
+  75_000,
+);
+const settleMs = parsePositiveInteger(
+  process.env.NOTEBOOK_CLOUD_WIDGET_CROSS_WINDOW_SETTLE_MS,
+  "NOTEBOOK_CLOUD_WIDGET_CROSS_WINDOW_SETTLE_MS",
+  800,
+);
+const screenshotPath = smokeOutputPath(process.env.NOTEBOOK_CLOUD_WIDGET_CROSS_WINDOW_SCREENSHOT);
+const reportPath = smokeJsonReportPath("hosted-widget-cross-window-smoke");
+const source = [
+  "from IPython.display import display",
+  "import ipywidgets as widgets",
+  "",
+  'slider = widgets.IntSlider(value=7, description="probe")',
+  "display(slider)",
+].join("\n");
+
+if (isMainModule()) {
+  main().catch((error) => {
+    console.error(error instanceof Error ? error.message : String(error));
+    process.exitCode = 1;
+  });
+}
+
+async function main() {
+  const tokenStorageJson = await readOidcTokenStorageJson(tokenPath);
+  const token = JSON.parse(tokenStorageJson);
+  const tokenSecondsRemaining = Number(token.expiresAt) - Math.floor(Date.now() / 1000);
+  if (!Number.isFinite(tokenSecondsRemaining) || tokenSecondsRemaining <= 60) {
+    throw new Error(
+      `${tokenPath} is expired or near expiry; refresh it before running the widget smoke`,
+    );
+  }
+
+  let runtimePeerPid = null;
+  const browser = await chromium.launch({
+    headless: process.env.NOTEBOOK_CLOUD_HEADED !== "1",
+    timeout: timeoutMs,
+  });
+  try {
+    const runtime = await runJsonScript("runtime-peer", runtimePeerScript, [], {
+      ...process.env,
+      NOTEBOOK_CLOUD_KEEP_RUNTIME_PEER: "1",
+      NOTEBOOK_CLOUD_RUNTIME_PEER_PYTHON:
+        process.env.NOTEBOOK_CLOUD_RUNTIME_PEER_PYTHON ?? path.join(os.homedir(), "k/bin/python"),
+      NOTEBOOK_CLOUD_RUNTIME_PEER_SMOKE_CODE: source,
+      NOTEBOOK_CLOUD_RUNTIME_PEER_SMOKE_SECONDS:
+        process.env.NOTEBOOK_CLOUD_RUNTIME_PEER_SMOKE_SECONDS ?? "45",
+      NOTEBOOK_CLOUD_RUNTIME_PEER_SMOKE_VANITY:
+        process.env.NOTEBOOK_CLOUD_WIDGET_CROSS_WINDOW_VANITY ?? "widget-cross-window-smoke",
+    });
+    runtimePeerPid = runtime.runtimePeer?.pid ?? null;
+    if (!runtime.ok || typeof runtime.viewerUrl !== "string" || !runtime.viewerUrl) {
+      throw new Error(`runtime-peer smoke returned an invalid result:\n${stringify(runtime)}`);
+    }
+    if (!Number.isInteger(runtimePeerPid)) {
+      throw new Error(
+        `runtime-peer smoke did not keep a runtime peer alive:\n${stringify(runtime)}`,
+      );
+    }
+
+    const browserRun = await runBrowserSmoke({
+      browser,
+      tokenStorageJson,
+      viewerUrl: runtime.viewerUrl,
+    });
+    await stopProcess(runtimePeerPid);
+    runtimePeerPid = null;
+
+    const report = {
+      ok: true,
+      viewerUrl: runtime.viewerUrl,
+      notebookId: runtime.notebookId,
+      source,
+      token: {
+        path: tokenPath,
+        secondsRemaining: tokenSecondsRemaining,
+      },
+      runtimePeer: {
+        logPath: runtime.runtimePeer?.logPath ?? null,
+        stopped: true,
+      },
+      checks: [
+        "runtime_peer_widget_cell_executed",
+        "primary_window_widget_rendered",
+        "peer_window_widget_rendered",
+        "widget_initial_value_synced",
+        "widget_drag_changed_primary_value",
+        "widget_drag_synced_to_peer_window",
+        "widget_loading_message_absent",
+      ],
+      browser: browserRun,
+    };
+    await writeSmokeJsonReport(report, reportPath);
+    console.log(JSON.stringify(report, null, 2));
+  } finally {
+    await browser.close().catch(() => {});
+    if (Number.isInteger(runtimePeerPid)) {
+      await stopProcess(runtimePeerPid).catch(() => {});
+    }
+  }
+}
+
+async function runBrowserSmoke({ browser, tokenStorageJson, viewerUrl }) {
+  const url = new URL(viewerUrl);
+  const diagnostics = {
+    console: [],
+    pageErrors: [],
+    requestFailures: [],
+    websockets: [],
+  };
+  const primaryContext = await authenticatedContext(browser, {
+    origin: url.origin,
+    scope: "owner",
+    tokenStorageJson,
+  });
+  const peerContext = await authenticatedContext(browser, {
+    origin: url.origin,
+    scope: "owner",
+    tokenStorageJson,
+  });
+  try {
+    const primary = await primaryContext.newPage();
+    const peer = await peerContext.newPage();
+    collectDiagnostics(primary, "primary", diagnostics);
+    collectDiagnostics(peer, "peer", diagnostics);
+
+    await Promise.all([
+      openNotebookShell(primary, url.href, timeoutMs),
+      openNotebookShell(peer, url.href, timeoutMs),
+    ]);
+
+    const primarySlider = await waitForWidgetSlider(primary, timeoutMs);
+    const peerSlider = await waitForWidgetSlider(peer, timeoutMs);
+    await expectSliderValue(primarySlider, "7", timeoutMs);
+    await expectSliderValue(peerSlider, "7", timeoutMs);
+    await expectNoWidgetLoading(primary, timeoutMs);
+    await expectNoWidgetLoading(peer, timeoutMs);
+
+    await dragSliderToValue(primarySlider, 18);
+    await expectSliderValue(primarySlider, "18", timeoutMs);
+    await expectSliderValue(peerSlider, "18", timeoutMs);
+    await expectNoWidgetLoading(primary, timeoutMs);
+    await expectNoWidgetLoading(peer, timeoutMs);
+
+    if (screenshotPath) {
+      await saveSmokeScreenshot(primary, screenshotPath);
+    }
+    assertCleanDiagnostics(diagnostics);
+    return {
+      primary: await widgetPageSnapshot(primary),
+      peer: await widgetPageSnapshot(peer),
+      diagnostics,
+      screenshotPath: screenshotPath ?? null,
+    };
+  } finally {
+    await primaryContext.close().catch(() => {});
+    await peerContext.close().catch(() => {});
+  }
+}
+
+async function authenticatedContext(browser, { origin, scope, tokenStorageJson }) {
+  const context = await browser.newContext({ viewport: { width: 1440, height: 1000 } });
+  await context.addInitScript(
+    ({ expectedOrigin, requestedScope, tokenJson }) => {
+      try {
+        if (globalThis.location?.origin !== expectedOrigin) return;
+        globalThis.localStorage?.setItem("nteract:notebook-cloud:oidc-token", tokenJson);
+        globalThis.localStorage?.setItem("nteract:notebook-cloud:scope", requestedScope);
+      } catch {
+        // Output frames intentionally cannot read first-party localStorage.
+      }
+    },
+    { expectedOrigin: origin, requestedScope: scope, tokenJson: tokenStorageJson },
+  );
+  return context;
+}
+
+async function openNotebookShell(page, href, timeout) {
+  await page.goto(href, { waitUntil: "domcontentloaded", timeout });
+  await page.waitForFunction(
+    () =>
+      document.querySelector("[data-notebook-synced]")?.getAttribute("data-notebook-synced") ===
+        "true" &&
+      document.querySelector("[data-session-ready]")?.getAttribute("data-session-ready") === "true",
+    null,
+    { timeout },
+  );
+}
+
+async function waitForWidgetSlider(page, timeout) {
+  const cell = page.locator('[data-cell-type="code"]').first();
+  await cell.waitFor({ state: "visible", timeout });
+  const slider = cell
+    .frameLocator('[data-slot="isolated-frame"]')
+    .locator('[data-widget-type="IntSlider"]')
+    .getByRole("slider")
+    .first();
+  await slider.waitFor({ state: "visible", timeout });
+  return slider;
+}
+
+async function expectSliderValue(slider, value, timeout) {
+  await expect(slider).toHaveAttribute("aria-valuenow", value, { timeout });
+}
+
+async function expectNoWidgetLoading(page, timeout) {
+  const frameBodies = page.frameLocator('[data-slot="isolated-frame"]').locator("body");
+  await expect
+    .poll(async () => (await frameBodies.allInnerTexts()).join("\n"), { timeout })
+    .not.toMatch(/waiting for widget|loading widget/i);
+}
+
+async function dragSliderToValue(slider, targetValue) {
+  const [min, max] = await Promise.all([
+    slider.getAttribute("aria-valuemin").then((value) => Number(value ?? 0)),
+    slider.getAttribute("aria-valuemax").then((value) => Number(value ?? 100)),
+  ]);
+  const sliderRoot = slider.locator(
+    "xpath=ancestor::*[@data-orientation='horizontal' and contains(@class, 'touch-none')][1]",
+  );
+  const rootBox = await sliderRoot.boundingBox();
+  if (!rootBox) {
+    throw new Error("IntSlider did not expose the expected drag geometry");
+  }
+  const clamped = Math.min(max, Math.max(min, targetValue));
+  const ratio = max === min ? 0 : (clamped - min) / (max - min);
+  await slider.dragTo(sliderRoot, {
+    force: true,
+    targetPosition: {
+      x: rootBox.width * ratio,
+      y: rootBox.height / 2,
+    },
+  });
+  await slider.page().waitForTimeout(settleMs);
+}
+
+async function widgetPageSnapshot(page) {
+  const text = await page
+    .locator("body")
+    .innerText({ timeout: timeoutMs })
+    .catch(() => "");
+  const frameBodies = page.frameLocator('[data-slot="isolated-frame"]').locator("body");
+  const sliderValues = await page
+    .frameLocator('[data-slot="isolated-frame"]')
+    .locator('[data-widget-type="IntSlider"] [role="slider"]')
+    .evaluateAll((sliders) => sliders.map((slider) => slider.getAttribute("aria-valuenow")))
+    .catch(() => []);
+  return {
+    text: text.replace(/\s+/g, " ").slice(0, 1000),
+    widgetFrames: (await frameBodies.allInnerTexts()).map((bodyText, index) => ({
+      bodyText: bodyText.replace(/\s+/g, " ").slice(0, 500),
+      sliderValue: sliderValues[index] ?? null,
+    })),
+  };
+}
+
+function collectDiagnostics(page, label, diagnostics) {
+  page.on("console", (message) => {
+    const text = message.text();
+    if (
+      /waiting for widget|loading widget|WidgetView|widget|comm|OutputResolutionError|Failed to fetch blob|cloud sync socket|WebSocket/i.test(
+        text,
+      )
+    ) {
+      diagnostics.console.push(`[${label}:${message.type()}] ${text}`);
+    }
+  });
+  page.on("pageerror", (error) => {
+    const text = String(error.message ?? error);
+    if (!isBenignPageError(text)) {
+      diagnostics.pageErrors.push(`[${label}] ${text}`);
+    }
+  });
+  page.on("requestfailed", (request) => {
+    diagnostics.requestFailures.push({
+      label,
+      url: safeDiagnosticUrl(request.url()),
+      failure: request.failure()?.errorText ?? null,
+    });
+  });
+  page.on("websocket", (ws) => {
+    const entry = {
+      label,
+      url: safeDiagnosticUrl(ws.url()),
+      closed: false,
+      errors: [],
+    };
+    diagnostics.websockets.push(entry);
+    ws.on("socketerror", (error) => {
+      entry.errors.push(String(error));
+    });
+    ws.on("close", () => {
+      entry.closed = true;
+    });
+  });
+}
+
+function assertCleanDiagnostics(diagnostics) {
+  const badConsole = diagnostics.console.filter((entry) =>
+    /waiting for widget|loading widget|OutputResolutionError|Failed to fetch blob|flush_comms_doc_sync/i.test(
+      entry,
+    ),
+  );
+  if (diagnostics.pageErrors.length > 0) {
+    throw new Error(`browser page errors:\n${diagnostics.pageErrors.join("\n")}`);
+  }
+  if (badConsole.length > 0) {
+    throw new Error(`browser widget console errors:\n${badConsole.join("\n")}`);
+  }
+  if (diagnostics.requestFailures.length > 0) {
+    throw new Error(
+      `browser request failures:\n${JSON.stringify(diagnostics.requestFailures, null, 2)}`,
+    );
+  }
+}
+
+async function readOidcTokenStorageJson(filePath) {
+  const raw = await readFile(filePath, "utf8");
+  const token = JSON.parse(raw);
+  if (typeof token.accessToken !== "string" || token.accessToken.length === 0) {
+    throw new Error(`${filePath} is missing accessToken`);
+  }
+  if (!token.claims || typeof token.claims.sub !== "string" || token.claims.sub.length === 0) {
+    throw new Error(`${filePath} is missing claims.sub`);
+  }
+  return JSON.stringify(token);
+}
+
+async function runJsonScript(label, script, args, env) {
+  const result = await runProcess(process.execPath, [script, ...args], { cwd: appDir, env });
+  if (result.exitCode !== 0) {
+    throw new Error(
+      `${label} smoke failed with exit code ${result.exitCode}\nSTDERR:\n${result.stderr}\nSTDOUT:\n${result.stdout}`,
+    );
+  }
+  return parseJsonOutput(result.stdout, label);
+}
+
+function runProcess(command, args, options) {
+  return new Promise((resolve) => {
+    const child = spawn(command, args, {
+      ...options,
+      stdio: ["ignore", "pipe", "pipe"],
+    });
+    let stdout = "";
+    let stderr = "";
+    child.stdout.setEncoding("utf8");
+    child.stderr.setEncoding("utf8");
+    child.stdout.on("data", (chunk) => {
+      stdout += chunk;
+    });
+    child.stderr.on("data", (chunk) => {
+      stderr += chunk;
+    });
+    child.on("error", (error) => {
+      stderr += `${error.stack ?? error.message}\n`;
+      resolve({ exitCode: 1, stdout, stderr });
+    });
+    child.on("close", (code) => {
+      resolve({ exitCode: code ?? 1, stdout, stderr });
+    });
+  });
+}
+
+function parseJsonOutput(stdout, label) {
+  const trimmed = stdout.trim();
+  try {
+    return JSON.parse(trimmed);
+  } catch {
+    const start = trimmed.indexOf("{");
+    const end = trimmed.lastIndexOf("}");
+    if (start >= 0 && end > start) {
+      try {
+        return JSON.parse(trimmed.slice(start, end + 1));
+      } catch {
+        // Fall through to the clearer diagnostic below.
+      }
+    }
+  }
+  throw new Error(`${label} smoke did not emit parseable JSON:\n${trimmed}`);
+}
+
+async function stopProcess(pid) {
+  if (!(await processExists(pid))) {
+    return;
+  }
+  signalProcess(pid, "SIGTERM");
+  for (let attempt = 0; attempt < 30; attempt += 1) {
+    if (!(await processExists(pid))) {
+      return;
+    }
+    await sleep(100);
+  }
+  if (await processExists(pid)) {
+    signalProcess(pid, "SIGKILL");
+  }
+}
+
+async function processExists(pid) {
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+function signalProcess(pid, signal) {
+  try {
+    process.kill(pid, signal);
+  } catch {
+    // The peer may exit between existence checks and signal delivery.
+  }
+}
+
+function parsePositiveInteger(value, name, fallback) {
+  if (value == null || value === "") return fallback;
+  const parsed = Number(value);
+  if (!Number.isInteger(parsed) || parsed <= 0) {
+    throw new Error(`${name} must be a positive integer`);
+  }
+  return parsed;
+}
+
+function safeDiagnosticUrl(value) {
+  try {
+    const url = new URL(value);
+    url.searchParams.delete("viewer_session");
+    return url.href;
+  } catch {
+    return value;
+  }
+}
+
+function isBenignPageError(text) {
+  return /message channel closed before a response was received|Receiving end does not exist|runtime\.lastError/i.test(
+    text,
+  );
+}
+
+function sleep(ms) {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+function stringify(value) {
+  return JSON.stringify(value, null, 2);
+}
+
+function isMainModule() {
+  return process.argv[1] ? import.meta.url === pathToFileURL(process.argv[1]).href : false;
+}

--- a/apps/notebook-cloud/test/room-materializer.test.ts
+++ b/apps/notebook-cloud/test/room-materializer.test.ts
@@ -1483,6 +1483,84 @@ describe("RoomMaterializer", () => {
     assert.equal(resolved.state?.value, 2);
   });
 
+  it("fans out owner CommsDoc changes to already-open peers", async () => {
+    const state = fakeState();
+    const materializer = new RoomMaterializer("demo", state, {} as Env);
+    const runtimeIdentity = authenticateDevRequest(
+      new Request(
+        "https://cloud.test/n/demo/sync?user=runtime&operator=runtime:py&scope=runtime_peer",
+      ),
+    );
+    const runtimePeerConnection = { id: "peer-runtime", identity: runtimeIdentity };
+    const runtimePeer = new RuntimeStatePeerHandle(runtimeIdentity.actorLabel);
+    await syncMaterializerWithRuntimePeer(materializer, runtimePeerConnection, runtimePeer);
+    runtimePeer.put_comm_json(
+      "comm-widget",
+      "jupyter.widget",
+      "anywidget",
+      "AnyModel",
+      JSON.stringify({ value: 7 }),
+      0,
+    );
+    const topologyAccepted = await applyRuntimePeerChangesToMaterializer(
+      materializer,
+      runtimePeerConnection,
+      runtimePeer,
+    );
+    assert.equal(topologyAccepted.changed, true);
+    const initialStateAccepted = await applyCommsPeerChangesToMaterializer(
+      materializer,
+      runtimePeerConnection,
+      runtimePeer,
+    );
+    assert.equal(initialStateAccepted.changed, true);
+
+    const ownerAIdentity = authenticateDevRequest(
+      new Request("https://cloud.test/n/demo/sync?user=alice&operator=browser:a&scope=owner"),
+    );
+    const ownerBIdentity = authenticateDevRequest(
+      new Request("https://cloud.test/n/demo/sync?user=alice&operator=browser:b&scope=owner"),
+    );
+    const ownerAConnection = { id: "peer-owner-a", identity: ownerAIdentity };
+    const ownerBConnection = { id: "peer-owner-b", identity: ownerBIdentity };
+    const ownerA = NotebookHandle.create_bootstrap(ownerAIdentity.actorLabel);
+    const ownerB = NotebookHandle.create_bootstrap(ownerBIdentity.actorLabel);
+    ownerA.set_blob_port(1234);
+    ownerB.set_blob_port(1234);
+    await syncMaterializerRuntimeStateWithClient(materializer, ownerAConnection, ownerA);
+    await syncMaterializerCommsDocWithClient(materializer, ownerAConnection, ownerA);
+    await syncMaterializerRuntimeStateWithClient(materializer, ownerBConnection, ownerB);
+    await syncMaterializerCommsDocWithClient(materializer, ownerBConnection, ownerB);
+    assert.equal(
+      (ownerB.resolve_comm_state("comm-widget") as { state?: Record<string, unknown> }).state
+        ?.value,
+      7,
+      "second open owner starts from the persisted widget value",
+    );
+
+    assert.equal(ownerA.set_comm_state_property("comm-widget", "value", JSON.stringify(8)), true);
+    const accepted = await applyCommsClientChangesToMaterializer(
+      materializer,
+      ownerAConnection,
+      ownerA,
+    );
+    assert.equal(accepted.changed, true);
+    assert.ok(
+      accepted.outbound.some(
+        (frame) =>
+          frame.peer_id === ownerBConnection.id && frame.frame_type === FrameType.COMMS_DOC_SYNC,
+      ),
+      "CommsDoc mutation from one open owner is fanned out to the other open owner",
+    );
+
+    applyCommsOutboundToClient(accepted.outbound, ownerBConnection.id, ownerB);
+    assert.equal(
+      (ownerB.resolve_comm_state("comm-widget") as { state?: Record<string, unknown> }).state
+        ?.value,
+      8,
+    );
+  });
+
   it("rejects owner-scoped RuntimeStateDoc execution changes", async () => {
     const state = fakeState();
     const materializer = new RoomMaterializer("demo", state, {} as Env);

--- a/apps/notebook-cloud/viewer/cloud-viewer-session.ts
+++ b/apps/notebook-cloud/viewer/cloud-viewer-session.ts
@@ -382,15 +382,8 @@ export function useCloudViewerSession({
       setCrdtCommWriter((commId: string, patch: Record<string, unknown>) => {
         if (liveRuntimeRef.current !== liveRuntime) return;
         try {
-          const changed = liveRuntime.handle.set_comm_state_batch(commId, JSON.stringify(patch));
-          if (changed) {
-            liveRuntime.engine.scheduleFlush();
-          } else {
-            console.warn("[notebook-cloud] widget state update did not mutate CommsDoc", {
-              commId,
-              keys: Object.keys(patch),
-            });
-          }
+          liveRuntime.handle.set_comm_state_batch(commId, JSON.stringify(patch));
+          liveRuntime.engine.scheduleFlush();
         } catch (error) {
           console.warn("[notebook-cloud] widget state update failed", error);
         }

--- a/apps/notebook-cloud/viewer/cloud-viewer-session.ts
+++ b/apps/notebook-cloud/viewer/cloud-viewer-session.ts
@@ -2,6 +2,7 @@ import { useCallback, useEffect, useRef, useState, type MutableRefObject } from 
 import {
   notebookShellWorkstationAttachmentCacheKey,
   type BlobResolver,
+  type CommChanges,
   type WorkstationAttachmentState,
 } from "runtimed";
 import { setCrdtCommWriter } from "@/components/widgets/crdt-comm-writer";
@@ -46,6 +47,7 @@ import { CloudViewerPresenceStore } from "./presence";
 import { createOutputResolutionCache, type ResolvedCell } from "./render-resolution";
 import { loadSnapshotPairHandle } from "./runtimed-wasm-client";
 import { subscribeSerializedCloudCellChanges } from "./serialized-cell-changes";
+import { applyCloudWidgetCommChanges } from "./widget-runtime";
 import { projectCloudWidgetComms } from "./widget-comm-projection";
 import type { CloudAppSession } from "./app-session";
 import type { CloudAuthRenewalState, ViewerStatus } from "./notice-types";
@@ -375,9 +377,18 @@ export function useCloudViewerSession({
     const installCloudWidgetCommWriter = (liveRuntime: CloudSyncRuntime) => {
       setCrdtCommWriter((commId: string, patch: Record<string, unknown>) => {
         if (liveRuntimeRef.current !== liveRuntime) return;
-        const changed = liveRuntime.handle.set_comm_state_batch(commId, JSON.stringify(patch));
-        if (changed) {
-          liveRuntime.engine.scheduleFlush();
+        try {
+          const changed = liveRuntime.handle.set_comm_state_batch(commId, JSON.stringify(patch));
+          if (changed) {
+            liveRuntime.engine.scheduleFlush();
+          } else {
+            console.warn("[notebook-cloud] widget state update did not mutate CommsDoc", {
+              commId,
+              keys: Object.keys(patch),
+            });
+          }
+        } catch (error) {
+          console.warn("[notebook-cloud] widget state update failed", error);
         }
       });
     };
@@ -569,6 +580,8 @@ export function useCloudViewerSession({
         }
         liveRuntimeRef.current = liveRuntime;
         installCloudWidgetCommWriter(liveRuntime);
+        const stopWidgetLiveRuntimeDiagnostics =
+          installCloudWidgetLiveRuntimeDiagnostics(liveRuntime);
         setConnectionScope(liveRuntime.connectionScope);
         setConnectionActorLabel(liveRuntime.actorLabel);
         setConnectionPeerId(liveRuntime.peerId);
@@ -608,11 +621,28 @@ export function useCloudViewerSession({
               },
             );
           }),
+          liveRuntime.engine.commChanges$.subscribe((changes) => {
+            recordCloudWidgetCommChangesDiagnostic(liveRuntime, changes);
+            applyCloudWidgetCommChanges(widgetStore, changes);
+          }),
+          liveRuntime.engine.commBroadcasts$.subscribe((broadcast) => {
+            const content = broadcast.content as Record<string, unknown> | undefined;
+            const data = content?.data as Record<string, unknown> | undefined;
+            if (data?.method !== "custom") return;
+            const commId = content?.comm_id;
+            if (typeof commId !== "string") return;
+            const inner = (data.content as Record<string, unknown> | undefined) ?? {};
+            const buffers = (broadcast as { buffers?: number[][] }).buffers;
+            const arrayBuffers = buffers?.map((arr: number[]) => new Uint8Array(arr).buffer);
+            widgetStore.emitCustomMessage(commId, inner, arrayBuffers);
+          }),
           liveRuntime.engine.poolState$.subscribe((state) => {
             setPoolState(state);
           }),
           { unsubscribe: stopCursorDispatch },
+          { unsubscribe: stopWidgetLiveRuntimeDiagnostics },
         ];
+        liveRuntime.engine.reProjectComms();
         materializeLiveCellsSafely(liveRuntime);
       })
       .catch((error: unknown) => {
@@ -720,6 +750,160 @@ function disposeCloudSyncRuntime(liveRuntime: CloudSyncRuntime): void {
   liveRuntime.engine.stop();
   liveRuntime.transport.disconnect();
   liveRuntime.handle.free();
+}
+
+function recordCloudWidgetCommChangesDiagnostic(
+  liveRuntime: CloudSyncRuntime,
+  changes: CommChanges,
+): void {
+  if (typeof window === "undefined") return;
+  try {
+    if (window.localStorage?.getItem("nteract:notebook-cloud:widget-diagnostics") !== "1") {
+      return;
+    }
+  } catch {
+    return;
+  }
+
+  const target = window as unknown as {
+    __nteractCloudWidgetCommEvents?: unknown[];
+  };
+  const events = target.__nteractCloudWidgetCommEvents ?? [];
+  target.__nteractCloudWidgetCommEvents = events;
+
+  events.push({
+    at: Date.now(),
+    peerId: liveRuntime.peerId,
+    opened: changes.opened.map(summarizeResolvedCommDiagnostic),
+    updated: changes.updated.map(summarizeResolvedCommDiagnostic),
+    closed: changes.closed,
+    runtimeComms: summarizeRuntimeCommsDiagnostic(
+      readHandleSnapshot(liveRuntime, "get_runtime_state"),
+    ),
+    commsDoc: summarizeCommsDocDiagnostic(readHandleSnapshot(liveRuntime, "get_comms_state")),
+  });
+
+  if (events.length > 100) {
+    events.splice(0, events.length - 100);
+  }
+}
+
+function installCloudWidgetLiveRuntimeDiagnostics(liveRuntime: CloudSyncRuntime): () => void {
+  if (typeof window === "undefined") return () => {};
+  try {
+    if (window.localStorage?.getItem("nteract:notebook-cloud:widget-diagnostics") !== "1") {
+      return () => {};
+    }
+  } catch {
+    return () => {};
+  }
+
+  const target = window as unknown as {
+    __nteractCloudLiveRuntimeSnapshot?: () => unknown;
+  };
+  target.__nteractCloudLiveRuntimeSnapshot = () => ({
+    peerId: liveRuntime.peerId,
+    cellCount: safeCallNumber(() => liveRuntime.handle.cell_count()),
+    runtimeComms: summarizeRuntimeCommsDiagnostic(
+      readHandleSnapshot(liveRuntime, "get_runtime_state"),
+    ),
+    commsDoc: summarizeCommsDocDiagnostic(readHandleSnapshot(liveRuntime, "get_comms_state")),
+  });
+
+  return () => {
+    if (target.__nteractCloudLiveRuntimeSnapshot) {
+      delete target.__nteractCloudLiveRuntimeSnapshot;
+    }
+  };
+}
+
+function safeCallNumber(read: () => number): number | null {
+  try {
+    const value = read();
+    return Number.isFinite(value) ? value : null;
+  } catch {
+    return null;
+  }
+}
+
+function readHandleSnapshot(
+  liveRuntime: CloudSyncRuntime,
+  method: "get_runtime_state" | "get_comms_state",
+): unknown {
+  const maybeHandle = liveRuntime.handle as unknown as Record<string, unknown>;
+  const fn = maybeHandle[method];
+  if (typeof fn !== "function") return null;
+  try {
+    return fn.call(liveRuntime.handle);
+  } catch {
+    return null;
+  }
+}
+
+function summarizeResolvedCommDiagnostic(comm: CommChanges["opened"][number]): unknown {
+  return {
+    commId: comm.commId,
+    targetName: comm.targetName,
+    modelModule: comm.modelModule,
+    modelName: comm.modelName,
+    state: summarizeWidgetStateDiagnostic(comm.state),
+  };
+}
+
+function summarizeRuntimeCommsDiagnostic(snapshot: unknown): unknown {
+  if (!isRecord(snapshot) || !isRecord(snapshot.comms)) return null;
+  return Object.fromEntries(
+    Object.entries(snapshot.comms).map(([commId, entry]) => [
+      commId,
+      isRecord(entry)
+        ? {
+            modelModule: entry.model_module,
+            modelName: entry.model_name,
+            state: summarizeWidgetStateDiagnostic(entry.state),
+          }
+        : null,
+    ]),
+  );
+}
+
+function summarizeCommsDocDiagnostic(snapshot: unknown): unknown {
+  if (!isRecord(snapshot) || !isRecord(snapshot.comms)) return null;
+  return Object.fromEntries(
+    Object.entries(snapshot.comms).map(([commId, state]) => [
+      commId,
+      summarizeWidgetStateDiagnostic(state),
+    ]),
+  );
+}
+
+function summarizeWidgetStateDiagnostic(state: unknown): unknown {
+  if (!isRecord(state)) return state;
+  const summary: Record<string, unknown> = {};
+  for (const key of [
+    "_model_module",
+    "_model_name",
+    "value",
+    "description",
+    "min",
+    "max",
+    "step",
+  ]) {
+    const value = state[key];
+    if (
+      value === null ||
+      typeof value === "string" ||
+      typeof value === "number" ||
+      typeof value === "boolean"
+    ) {
+      summary[key] = value;
+    }
+  }
+  summary.__keys = Object.keys(state).sort();
+  return summary;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null;
 }
 
 function isConfiguredBlobUrl(value: string, blobBasePath: string): boolean {

--- a/apps/notebook-cloud/viewer/cloud-viewer-session.ts
+++ b/apps/notebook-cloud/viewer/cloud-viewer-session.ts
@@ -5,6 +5,10 @@ import {
   type CommChanges,
   type WorkstationAttachmentState,
 } from "runtimed";
+import {
+  applyWidgetCommBroadcastToStore,
+  applyWidgetCommChangesToStore,
+} from "@/components/widgets/comm-changes-store-bridge";
 import { setCrdtCommWriter } from "@/components/widgets/crdt-comm-writer";
 import type { WidgetStore } from "@/components/widgets/widget-store";
 import { diagnoseCloudConnectionAccess } from "./connection-diagnostics";
@@ -47,7 +51,7 @@ import { CloudViewerPresenceStore } from "./presence";
 import { createOutputResolutionCache, type ResolvedCell } from "./render-resolution";
 import { loadSnapshotPairHandle } from "./runtimed-wasm-client";
 import { subscribeSerializedCloudCellChanges } from "./serialized-cell-changes";
-import { applyCloudWidgetCommChanges } from "./widget-runtime";
+import { cloudWidgetUpdateManager } from "./widget-runtime";
 import { projectCloudWidgetComms } from "./widget-comm-projection";
 import type { CloudAppSession } from "./app-session";
 import type { CloudAuthRenewalState, ViewerStatus } from "./notice-types";
@@ -623,18 +627,14 @@ export function useCloudViewerSession({
           }),
           liveRuntime.engine.commChanges$.subscribe((changes) => {
             recordCloudWidgetCommChangesDiagnostic(liveRuntime, changes);
-            applyCloudWidgetCommChanges(widgetStore, changes);
+            applyWidgetCommChangesToStore(widgetStore, changes, {
+              shouldSuppressEcho: (commId, state) =>
+                cloudWidgetUpdateManager.shouldSuppressEcho(commId, state),
+              clearComm: (commId) => cloudWidgetUpdateManager.clearComm(commId),
+            });
           }),
           liveRuntime.engine.commBroadcasts$.subscribe((broadcast) => {
-            const content = broadcast.content as Record<string, unknown> | undefined;
-            const data = content?.data as Record<string, unknown> | undefined;
-            if (data?.method !== "custom") return;
-            const commId = content?.comm_id;
-            if (typeof commId !== "string") return;
-            const inner = (data.content as Record<string, unknown> | undefined) ?? {};
-            const buffers = (broadcast as { buffers?: number[][] }).buffers;
-            const arrayBuffers = buffers?.map((arr: number[]) => new Uint8Array(arr).buffer);
-            widgetStore.emitCustomMessage(commId, inner, arrayBuffers);
+            applyWidgetCommBroadcastToStore(widgetStore, broadcast);
           }),
           liveRuntime.engine.poolState$.subscribe((state) => {
             setPoolState(state);

--- a/apps/notebook-cloud/viewer/cloud-viewer-session.ts
+++ b/apps/notebook-cloud/viewer/cloud-viewer-session.ts
@@ -4,6 +4,7 @@ import {
   type BlobResolver,
   type WorkstationAttachmentState,
 } from "runtimed";
+import { setCrdtCommWriter } from "@/components/widgets/crdt-comm-writer";
 import type { WidgetStore } from "@/components/widgets/widget-store";
 import { diagnoseCloudConnectionAccess } from "./connection-diagnostics";
 import {
@@ -371,10 +372,20 @@ export function useCloudViewerSession({
     let livePresenceStore: CloudLivePresenceStore | null = null;
     let reconnectTimer: ReturnType<typeof setTimeout> | null = null;
     const sessionId = crypto.randomUUID ? crypto.randomUUID() : String(Date.now());
+    const installCloudWidgetCommWriter = (liveRuntime: CloudSyncRuntime) => {
+      setCrdtCommWriter((commId: string, patch: Record<string, unknown>) => {
+        if (liveRuntimeRef.current !== liveRuntime) return;
+        const changed = liveRuntime.handle.set_comm_state_batch(commId, JSON.stringify(patch));
+        if (changed) {
+          liveRuntime.engine.scheduleFlush();
+        }
+      });
+    };
     const disposeCurrentRuntime = () => {
       const liveRuntime = liveRuntimeRef.current;
       if (!liveRuntime) return;
       liveRuntimeRef.current = null;
+      setCrdtCommWriter(null);
       disposeCloudSyncRuntime(liveRuntime);
     };
     const scheduleReconnect = (reason: Error) => {
@@ -557,6 +568,7 @@ export function useCloudViewerSession({
           return;
         }
         liveRuntimeRef.current = liveRuntime;
+        installCloudWidgetCommWriter(liveRuntime);
         setConnectionScope(liveRuntime.connectionScope);
         setConnectionActorLabel(liveRuntime.actorLabel);
         setConnectionPeerId(liveRuntime.peerId);
@@ -648,6 +660,7 @@ export function useCloudViewerSession({
       }
       materializeLiveRuntimeRef.current = null;
       disposeCurrentRuntime();
+      setCrdtCommWriter(null);
       resetCloudViewStoreProjection();
       resetRuntimeState();
       resetRuntimeStoresProjection();

--- a/apps/notebook-cloud/viewer/live-sync.ts
+++ b/apps/notebook-cloud/viewer/live-sync.ts
@@ -619,6 +619,8 @@ export function syncableCloudHandle(handle: NotebookHandle): SyncableHandle {
     cell_count: () => handle.cell_count(),
     get_heads_hex: () => handle.get_heads_hex(),
     get_dependency_fingerprint: () => handle.get_dependency_fingerprint(),
+    get_runtime_state: () => handle.get_runtime_state(),
+    get_comms_state: () => handle.get_comms_state(),
     resolve_comm_state: (commId) =>
       handle.resolve_comm_state(commId) as
         | {

--- a/apps/notebook-cloud/viewer/widget-runtime.tsx
+++ b/apps/notebook-cloud/viewer/widget-runtime.tsx
@@ -7,7 +7,6 @@ import { createWidgetStore, type WidgetStore } from "@/components/widgets/widget
 import { WidgetUpdateManager } from "@/components/widgets/widget-update-manager";
 import { parseWidgetViewModelId, WIDGET_VIEW_MIME } from "@/components/widgets/widget-state";
 import { WidgetView } from "@/components/widgets/widget-view";
-import type { CommChanges } from "runtimed";
 export {
   projectCloudWidgetComms,
   type ProjectCloudWidgetCommsOptions,
@@ -62,38 +61,9 @@ function CloudWidgetViewRenderer({ data }: { data: unknown }) {
   return modelId ? <WidgetView modelId={modelId} /> : null;
 }
 
-export function applyCloudWidgetCommChanges(store: WidgetStore, changes: CommChanges): void {
-  for (const comm of changes.opened) {
-    store.createModel(comm.commId, cloudWidgetStateWithMetadata(comm), comm.bufferPaths);
-  }
-  for (const comm of changes.updated) {
-    if (!store.getModel(comm.commId)) {
-      store.createModel(comm.commId, cloudWidgetStateWithMetadata(comm), comm.bufferPaths);
-      continue;
-    }
-    const filtered = cloudWidgetUpdateManager.shouldSuppressEcho(comm.commId, comm.state);
-    if (filtered) {
-      store.updateModel(comm.commId, filtered, comm.bufferPaths);
-    }
-  }
-  for (const commId of changes.closed) {
-    cloudWidgetUpdateManager.clearComm(commId);
-    store.deleteModel(commId);
-  }
-}
-
-function cloudWidgetStateWithMetadata(
-  comm: CommChanges["opened"][number] | CommChanges["updated"][number],
-): Record<string, unknown> {
-  const state = { ...comm.state };
-  state._model_module ??= comm.modelModule || undefined;
-  state._model_name ??= comm.modelName || undefined;
-  return state;
-}
-
 let cloudWidgetStoreRef: WidgetStore | null = null;
 
-const cloudWidgetUpdateManager = new WidgetUpdateManager({
+export const cloudWidgetUpdateManager = new WidgetUpdateManager({
   getStore: () => cloudWidgetStoreRef,
   getCrdtWriter: getCrdtCommWriter,
 });

--- a/apps/notebook-cloud/viewer/widget-runtime.tsx
+++ b/apps/notebook-cloud/viewer/widget-runtime.tsx
@@ -7,6 +7,7 @@ import { createWidgetStore, type WidgetStore } from "@/components/widgets/widget
 import { WidgetUpdateManager } from "@/components/widgets/widget-update-manager";
 import { parseWidgetViewModelId, WIDGET_VIEW_MIME } from "@/components/widgets/widget-state";
 import { WidgetView } from "@/components/widgets/widget-view";
+import type { CommChanges } from "runtimed";
 export {
   projectCloudWidgetComms,
   type ProjectCloudWidgetCommsOptions,
@@ -36,6 +37,7 @@ export function CloudWidgetStoreProvider({ children }: { children: ReactNode }) 
 
   useEffect(() => createLinkManager(store), [store]);
   useEffect(() => createCanvasManagerRouter(store), [store]);
+  useEffect(() => installCloudWidgetDiagnostics(store), [store]);
 
   const value = useMemo(
     () => ({
@@ -60,9 +62,71 @@ function CloudWidgetViewRenderer({ data }: { data: unknown }) {
   return modelId ? <WidgetView modelId={modelId} /> : null;
 }
 
+export function applyCloudWidgetCommChanges(store: WidgetStore, changes: CommChanges): void {
+  for (const comm of changes.opened) {
+    store.createModel(comm.commId, cloudWidgetStateWithMetadata(comm), comm.bufferPaths);
+  }
+  for (const comm of changes.updated) {
+    if (!store.getModel(comm.commId)) {
+      store.createModel(comm.commId, cloudWidgetStateWithMetadata(comm), comm.bufferPaths);
+      continue;
+    }
+    const filtered = cloudWidgetUpdateManager.shouldSuppressEcho(comm.commId, comm.state);
+    if (filtered) {
+      store.updateModel(comm.commId, filtered, comm.bufferPaths);
+    }
+  }
+  for (const commId of changes.closed) {
+    cloudWidgetUpdateManager.clearComm(commId);
+    store.deleteModel(commId);
+  }
+}
+
+function cloudWidgetStateWithMetadata(
+  comm: CommChanges["opened"][number] | CommChanges["updated"][number],
+): Record<string, unknown> {
+  const state = { ...comm.state };
+  state._model_module ??= comm.modelModule || undefined;
+  state._model_name ??= comm.modelName || undefined;
+  return state;
+}
+
 let cloudWidgetStoreRef: WidgetStore | null = null;
 
 const cloudWidgetUpdateManager = new WidgetUpdateManager({
   getStore: () => cloudWidgetStoreRef,
   getCrdtWriter: getCrdtCommWriter,
 });
+
+function installCloudWidgetDiagnostics(store: WidgetStore): () => void {
+  if (typeof window === "undefined") return () => {};
+  try {
+    if (window.localStorage?.getItem("nteract:notebook-cloud:widget-diagnostics") !== "1") {
+      return () => {};
+    }
+  } catch {
+    return () => {};
+  }
+
+  const target = window as unknown as {
+    __nteractCloudWidgetStoreSnapshot?: () => Array<{
+      id: string;
+      modelModule: string;
+      modelName: string;
+      state: Record<string, unknown>;
+    }>;
+  };
+  target.__nteractCloudWidgetStoreSnapshot = () =>
+    Array.from(store.getSnapshot().values()).map((model) => ({
+      id: model.id,
+      modelModule: model.modelModule,
+      modelName: model.modelName,
+      state: model.state,
+    }));
+
+  return () => {
+    if (target.__nteractCloudWidgetStoreSnapshot) {
+      delete target.__nteractCloudWidgetStoreSnapshot;
+    }
+  };
+}

--- a/apps/notebook-cloud/viewer/widget-runtime.tsx
+++ b/apps/notebook-cloud/viewer/widget-runtime.tsx
@@ -1,8 +1,10 @@
 import { type ReactNode, useEffect, useMemo, useRef } from "react";
 import { createCanvasManagerRouter } from "@/components/widgets/canvas-manager-subscriptions";
+import { getCrdtCommWriter } from "@/components/widgets/crdt-comm-writer";
 import { createLinkManager } from "@/components/widgets/link-subscriptions";
 import { WidgetStoreContext } from "@/components/widgets/widget-store-context";
 import { createWidgetStore, type WidgetStore } from "@/components/widgets/widget-store";
+import { WidgetUpdateManager } from "@/components/widgets/widget-update-manager";
 import { parseWidgetViewModelId, WIDGET_VIEW_MIME } from "@/components/widgets/widget-state";
 import { WidgetView } from "@/components/widgets/widget-view";
 export {
@@ -22,6 +24,16 @@ export function CloudWidgetStoreProvider({ children }: { children: ReactNode }) 
   }
   const store = storeRef.current;
 
+  useEffect(() => {
+    cloudWidgetStoreRef = store;
+    return () => {
+      if (cloudWidgetStoreRef === store) {
+        cloudWidgetStoreRef = null;
+      }
+      cloudWidgetUpdateManager.dispose();
+    };
+  }, [store]);
+
   useEffect(() => createLinkManager(store), [store]);
   useEffect(() => createCanvasManagerRouter(store), [store]);
 
@@ -29,10 +41,11 @@ export function CloudWidgetStoreProvider({ children }: { children: ReactNode }) 
     () => ({
       store,
       sendUpdate: async (commId: string, state: Record<string, unknown>) => {
-        store.updateModel(commId, state);
+        await cloudWidgetUpdateManager.updateAndPersist(commId, state);
       },
       sendCustom: () => {},
       closeComm: (commId: string) => {
+        cloudWidgetUpdateManager.clearComm(commId);
         store.deleteModel(commId);
       },
     }),
@@ -46,3 +59,10 @@ function CloudWidgetViewRenderer({ data }: { data: unknown }) {
   const modelId = parseWidgetViewModelId(data);
   return modelId ? <WidgetView modelId={modelId} /> : null;
 }
+
+let cloudWidgetStoreRef: WidgetStore | null = null;
+
+const cloudWidgetUpdateManager = new WidgetUpdateManager({
+  getStore: () => cloudWidgetStoreRef,
+  getCrdtWriter: getCrdtCommWriter,
+});

--- a/apps/notebook/e2e/widget-cross-window-sync.spec.ts
+++ b/apps/notebook/e2e/widget-cross-window-sync.spec.ts
@@ -1,0 +1,140 @@
+import { expect, test, type Locator, type Page } from "@playwright/test";
+import {
+  ensureCodeCell,
+  executeCell,
+  openNotebookRoom,
+  setCellSource,
+  waitForCodeCellContaining,
+  waitForKernelStatus,
+} from "./helpers";
+import { McpPeer } from "./mcp-peer";
+
+test.describe("widget state across notebook windows", () => {
+  test.describe.configure({ timeout: 300_000 });
+
+  let mcp: McpPeer | null = null;
+
+  test.afterEach(async () => {
+    await mcp?.close();
+    mcp = null;
+  });
+
+  test("keeps an IntSlider display in sync when another window drags it", async ({
+    context,
+    page,
+  }) => {
+    const notebookId = crypto.randomUUID();
+    const peerPage = await context.newPage();
+    const widgetLogs: string[] = [];
+    collectWidgetDiagnostics(page, "primary", widgetLogs);
+    collectWidgetDiagnostics(peerPage, "peer", widgetLogs);
+
+    await openNotebookRoom(page, notebookId);
+    await waitForKernelStatus(page, "idle", 120_000);
+
+    mcp = await McpPeer.start();
+    await mcp.connectNotebook(notebookId);
+    await mcp.manageDependencies(["ipywidgets>=8,<9"]);
+    await waitForKernelStatus(page, "idle", 120_000);
+
+    await openNotebookRoom(peerPage, notebookId);
+    await waitForKernelStatus(peerPage, "idle", 120_000);
+
+    const primaryCell = await ensureCodeCell(page);
+    await setCellSource(
+      primaryCell,
+      [
+        "from IPython.display import display",
+        "import ipywidgets as widgets",
+        "",
+        'slider = widgets.IntSlider(value=7, description="probe")',
+        "display(slider)",
+      ].join("\n"),
+    );
+
+    await executeCell(primaryCell);
+    await waitForKernelStatus(page, "idle", 120_000);
+
+    const peerCell = await waitForCodeCellContaining(peerPage, "widgets.IntSlider", 60_000);
+    const primarySlider = widgetSlider(primaryCell);
+    const peerSlider = widgetSlider(peerCell);
+
+    await expect(primarySlider).toBeVisible({ timeout: 60_000 });
+    await expect(peerSlider).toBeVisible({ timeout: 60_000 });
+    await expectNoWidgetLoading(primaryCell);
+    await expectNoWidgetLoading(peerCell);
+    await expectSliderValue(primarySlider, "7");
+    await expectSliderValue(peerSlider, "7");
+
+    await dragSliderToValue(primarySlider, 18);
+
+    await expectSliderValue(primarySlider, "18");
+    await expectSliderValue(peerSlider, "18");
+    expect(widgetLogs.join("\n")).not.toMatch(/waiting for widget|loading widget/i);
+  });
+});
+
+function widgetSlider(cell: Locator): Locator {
+  return cell
+    .frameLocator('[data-slot="isolated-frame"]')
+    .locator('[data-widget-type="IntSlider"]')
+    .getByRole("slider")
+    .first();
+}
+
+async function expectSliderValue(slider: Locator, value: string): Promise<void> {
+  await expect(slider).toHaveAttribute("aria-valuenow", value, { timeout: 60_000 });
+}
+
+async function expectNoWidgetLoading(cell: Locator): Promise<void> {
+  const body = cell.frameLocator('[data-slot="isolated-frame"]').locator("body");
+  await expect
+    .poll(async () => ((await body.count()) > 0 ? await body.innerText() : ""), {
+      timeout: 60_000,
+    })
+    .not.toMatch(/waiting for widget|loading widget/i);
+}
+
+async function dragSliderToValue(slider: Locator, targetValue: number): Promise<void> {
+  const [min, max] = await Promise.all([
+    slider.getAttribute("aria-valuemin").then((value) => Number(value ?? 0)),
+    slider.getAttribute("aria-valuemax").then((value) => Number(value ?? 100)),
+  ]);
+
+  const sliderRoot = slider.locator(
+    "xpath=ancestor::*[@data-orientation='horizontal' and contains(@class, 'touch-none')][1]",
+  );
+  const box = await sliderRoot.boundingBox();
+  if (!box) {
+    throw new Error("IntSlider did not expose a slider root bounding box for drag");
+  }
+
+  const clamped = Math.min(max, Math.max(min, targetValue));
+  const ratio = max === min ? 0 : (clamped - min) / (max - min);
+  const thumbBox = await slider.boundingBox();
+  if (!thumbBox) {
+    throw new Error("IntSlider did not expose a thumb bounding box for drag");
+  }
+
+  const page = slider.page();
+  await page.mouse.move(thumbBox.x + thumbBox.width / 2, thumbBox.y + thumbBox.height / 2);
+  await page.mouse.down();
+  await page.mouse.move(box.x + box.width * ratio, box.y + box.height / 2, { steps: 8 });
+  await page.mouse.up();
+}
+
+function collectWidgetDiagnostics(page: Page, label: string, logs: string[]): void {
+  page.on("console", (message) => {
+    const text = message.text();
+    if (
+      /waiting for widget|loading widget|WidgetView|widget|comm|isolated-frame|isolated-renderer/i.test(
+        text,
+      )
+    ) {
+      logs.push(`[${label}:${message.type()}] ${text}`);
+    }
+  });
+  page.on("pageerror", (error) => {
+    logs.push(`[${label}:pageerror] ${error.message}`);
+  });
+}

--- a/apps/notebook/src/App.tsx
+++ b/apps/notebook/src/App.tsx
@@ -13,6 +13,10 @@ import {
 } from "runtimed";
 import { IsolationTest } from "@/components/isolated";
 import { MediaProvider } from "@/components/outputs/media-provider";
+import {
+  applyWidgetCommBroadcastToStore,
+  applyWidgetCommChangesToStore,
+} from "@/components/widgets/comm-changes-store-bridge";
 import { getCrdtCommWriter, setCrdtCommWriter } from "@/components/widgets/crdt-comm-writer";
 import { SavedWidgetStateProvider } from "@/components/widgets/saved-widget-state-context";
 import {
@@ -739,41 +743,19 @@ function AppContent() {
     if (!engine) return;
 
     const commSub = engine.commChanges$.subscribe((changes) => {
-      for (const comm of changes.opened) {
-        widgetStore.createModel(comm.commId, comm.state, comm.bufferPaths);
-        if (comm.unresolvedOutputs) {
-          resolveCommOutputs(comm.commId, comm.unresolvedOutputs, widgetStore);
-        }
-      }
-      for (const comm of changes.updated) {
+      applyWidgetCommChangesToStore(widgetStore, changes, {
         // Suppress CRDT echoes for keys with pending optimistic values
         // (e.g. slider being dragged — don't clobber with stale echo).
-        const filtered = updateManager.shouldSuppressEcho(comm.commId, comm.state);
-        if (filtered) {
-          widgetStore.updateModel(comm.commId, filtered, comm.bufferPaths);
-        }
-        if (comm.unresolvedOutputs) {
-          resolveCommOutputs(comm.commId, comm.unresolvedOutputs, widgetStore);
-        }
-      }
-      for (const commId of changes.closed) {
-        updateManager.clearComm(commId);
-        widgetStore.deleteModel(commId);
-      }
+        shouldSuppressEcho: (commId, state) => updateManager.shouldSuppressEcho(commId, state),
+        clearComm: (commId) => updateManager.clearComm(commId),
+        resolveOutputs: resolveCommOutputs,
+      });
     });
 
     // Custom comm messages (buttons, model.send()) are ephemeral events
     // delivered via broadcast, not CRDT state. Route to WidgetStore.
     const customSub = engine.commBroadcasts$.subscribe((broadcast) => {
-      const content = broadcast.content as Record<string, unknown> | undefined;
-      const data = content?.data as Record<string, unknown> | undefined;
-      if (data?.method === "custom") {
-        const commId = content?.comm_id as string;
-        const inner = (data?.content as Record<string, unknown>) ?? {};
-        const buffers = (broadcast as { buffers?: number[][] }).buffers;
-        const arrayBuffers = buffers?.map((arr: number[]) => new Uint8Array(arr).buffer);
-        widgetStore.emitCustomMessage(commId, inner, arrayBuffers);
-      }
+      applyWidgetCommBroadcastToStore(widgetStore, broadcast);
     });
 
     return () => {

--- a/crates/runtimed-wasm/src/lib.rs
+++ b/crates/runtimed-wasm/src/lib.rs
@@ -1965,14 +1965,27 @@ fn walk_and_resolve_comm_state(
     match val {
         serde_json::Value::Object(obj) => {
             // Check for inline ContentRef: {"inline": ...}
-            if let Some(inner) = obj.get("inline") {
+            if obj.len() == 1 && obj.contains_key("inline") {
+                let inner = obj.get("inline").expect("inline key exists");
                 return inner.clone();
             }
 
-            // Check for blob ContentRef: {"blob": string, "size": number}
-            if let (Some(serde_json::Value::String(hash)), Some(serde_json::Value::Number(_))) =
-                (obj.get("blob"), obj.get("size"))
-            {
+            // Check for blob ContentRef: {"blob": string, "size": number, "media_type"?: string}
+            let is_exact_blob_ref = matches!(
+                (obj.get("blob"), obj.get("size")),
+                (
+                    Some(serde_json::Value::String(_)),
+                    Some(serde_json::Value::Number(_))
+                )
+            ) && obj
+                .keys()
+                .all(|key| key == "blob" || key == "size" || key == "media_type");
+
+            if is_exact_blob_ref {
+                let hash = obj
+                    .get("blob")
+                    .and_then(|value| value.as_str())
+                    .expect("exact blob ref has string blob");
                 // Anywidget reserves `_esm` and `_css` for URL-preferring
                 // loaders: `_esm` flows through `import(url)` and `_css`
                 // through `<link rel=stylesheet href=url>`, both of which
@@ -4768,6 +4781,25 @@ mod tests {
             "value": { "inline": 42 },
         }));
         assert_eq!(resolved, json!({ "value": 42 }));
+        assert!(buffer_paths.is_empty());
+        assert!(text_paths.is_empty());
+    }
+
+    #[test]
+    fn ordinary_inline_and_blob_properties_are_preserved() {
+        let (resolved, buffer_paths, text_paths) = resolve(json!({
+            "layout": { "inline": true, "display": "flex" },
+            "marker": { "blob": "not-a-content-ref" },
+            "payload": { "blob": "also-not-a-content-ref", "size": 3, "extra": "state" },
+        }));
+        assert_eq!(
+            resolved,
+            json!({
+                "layout": { "inline": true, "display": "flex" },
+                "marker": { "blob": "not-a-content-ref" },
+                "payload": { "blob": "also-not-a-content-ref", "size": 3, "extra": "state" },
+            })
+        );
         assert!(buffer_paths.is_empty());
         assert!(text_paths.is_empty());
     }

--- a/packages/runtimed/src/handle.ts
+++ b/packages/runtimed/src/handle.ts
@@ -195,6 +195,22 @@ export interface SyncableHandle {
   get_dependency_fingerprint(): string | undefined;
 
   /**
+   * Read the current RuntimeStateDoc snapshot from the handle.
+   *
+   * Optional: used by projection replays to recover from adapter bootstrap
+   * races where the handle has already applied sync frames before subscribers
+   * attach to the engine observables.
+   */
+  get_runtime_state?(): unknown;
+
+  /**
+   * Read the current CommsDoc snapshot from the handle.
+   *
+   * Optional for the same reason as `get_runtime_state`.
+   */
+  get_comms_state?(): unknown;
+
+  /**
    * Resolve ContentRef values in a comm's state.
    *
    * Returns `{ state, buffer_paths, text_paths }` where blob ContentRefs are

--- a/packages/runtimed/src/sync-engine.ts
+++ b/packages/runtimed/src/sync-engine.ts
@@ -220,6 +220,24 @@ function isRecord(value: unknown): value is Record<string, unknown> {
   return value !== null && typeof value === "object" && !Array.isArray(value);
 }
 
+function isRuntimeStateSnapshot(value: unknown): value is RuntimeState {
+  return isRecord(value) && isRecord(value.comms);
+}
+
+function isCommsStateSnapshot(value: unknown): value is CommsState {
+  return isRecord(value) && isRecord(value.comms);
+}
+
+function containsContentRef(value: unknown): boolean {
+  if (!isRecord(value)) {
+    return Array.isArray(value) ? value.some(containsContentRef) : false;
+  }
+  if (typeof value.blob === "string" || Object.prototype.hasOwnProperty.call(value, "inline")) {
+    return true;
+  }
+  return Object.values(value).some(containsContentRef);
+}
+
 // ── Options ──────────────────────────────────────────────────────────
 
 export interface SyncEngineOptions {
@@ -873,7 +891,20 @@ export class SyncEngine {
    */
   reProjectComms(): void {
     this.commDiffState = { comms: {}, json: {} };
+    this.refreshCommProjectionSnapshotsFromHandle();
     this.projectComms();
+  }
+
+  private refreshCommProjectionSnapshotsFromHandle(): void {
+    const handle = this.opts.getHandle();
+    const runtimeState = handle?.get_runtime_state?.();
+    if (isRuntimeStateSnapshot(runtimeState)) {
+      this.lastRuntimeState = runtimeState as RuntimeState;
+    }
+    const commsState = handle?.get_comms_state?.();
+    if (isCommsStateSnapshot(commsState)) {
+      this.lastCommsState = commsState as CommsState;
+    }
   }
 
   /**
@@ -898,20 +929,28 @@ export class SyncEngine {
     }
 
     const handle = this.opts.getHandle();
-    const resolve = (commId: string) =>
-      handle?.resolve_comm_state?.(commId) as
+    const resolve = (commId: string, entry: CommDocEntry) => {
+      const resolved = handle?.resolve_comm_state?.(commId) as
         | {
             state: Record<string, unknown>;
             buffer_paths: string[][];
             text_paths?: string[][];
           }
         | undefined;
+      if (resolved) return resolved;
+      if (containsContentRef(entry.state)) return undefined;
+      return {
+        state: isRecord(entry.state) ? entry.state : {},
+        buffer_paths: [] as string[][],
+        text_paths: [] as string[][],
+      };
+    };
 
     // Pending entries carry the raw resolved state plus the text paths that
     // still need to be fetched before emission.
     const opened: Array<{ comm: ResolvedComm; textPaths: string[][] }> = [];
     for (const { commId, entry } of result.opened) {
-      const resolved = resolve(commId);
+      const resolved = resolve(commId, entry);
       if (!resolved) {
         // blob_port not ready — defer by excluding from next state.
         // On the next runtimeState$ emission (after blob_port is set),
@@ -941,7 +980,7 @@ export class SyncEngine {
 
     const updated: Array<{ comm: ResolvedComm; textPaths: string[][] }> = [];
     for (const { commId, entry } of result.updated) {
-      const resolved = resolve(commId);
+      const resolved = resolve(commId, entry);
       if (!resolved) {
         // resolver not ready (e.g. blob_port transiently missing after
         // reconnect). Revert `next` to the previous state for this comm

--- a/packages/runtimed/src/sync-engine.ts
+++ b/packages/runtimed/src/sync-engine.ts
@@ -232,7 +232,15 @@ function containsContentRef(value: unknown): boolean {
   if (!isRecord(value)) {
     return Array.isArray(value) ? value.some(containsContentRef) : false;
   }
-  if (typeof value.blob === "string" || Object.prototype.hasOwnProperty.call(value, "inline")) {
+  const keys = Object.keys(value);
+  if (keys.length === 1 && Object.prototype.hasOwnProperty.call(value, "inline")) {
+    return true;
+  }
+  if (
+    typeof value.blob === "string" &&
+    typeof value.size === "number" &&
+    keys.every((key) => key === "blob" || key === "size" || key === "media_type")
+  ) {
     return true;
   }
   return Object.values(value).some(containsContentRef);

--- a/packages/runtimed/src/sync-engine.ts
+++ b/packages/runtimed/src/sync-engine.ts
@@ -367,8 +367,9 @@ export class SyncEngine {
    * ContentRef blobs replaced by URL strings. Subscribers drive their
    * widget store directly — no Jupyter message synthesis needed.
    *
-   * Depends on `handle.resolve_comm_state()` (optional on SyncableHandle).
-   * If the handle doesn't implement it, this observable never emits.
+   * Uses `handle.resolve_comm_state()` when available. Plain JSON CommsDoc
+   * state that has no ContentRefs can project directly from document truth;
+   * ContentRef-backed state defers until the host provides a resolver.
    */
   readonly commChanges$: Observable<CommChanges>;
 

--- a/packages/runtimed/tests/sync-engine.test.ts
+++ b/packages/runtimed/tests/sync-engine.test.ts
@@ -2051,6 +2051,42 @@ describe("SyncEngine", () => {
       engine.stop();
     });
 
+    it("does not treat plain inline or blob traitlets as ContentRefs", async () => {
+      const commId = "plain-content-ref-key-traitlet-comm";
+      handle = createMockHandle({
+        get_runtime_state: vi.fn(() => runtimeStateWithComm(commId, {})),
+        get_comms_state: vi.fn(() => ({
+          comms: {
+            [commId]: {
+              layout: { inline: true, display: "flex" },
+              marker: { blob: "ordinary-traitlet" },
+              payload: { blob: "ordinary-payload", size: 3, extra: "state" },
+            },
+          },
+        })),
+        resolve_comm_state: vi.fn(() => undefined),
+      });
+
+      const engine = createEngine();
+      engine.start();
+
+      const emissions: Array<{
+        opened: Array<{ commId: string; state: unknown }>;
+      }> = [];
+      engine.commChanges$.subscribe((c) => emissions.push(c));
+      engine.reProjectComms();
+
+      await vi.waitFor(() => expect(emissions.length).toBe(1));
+      expect(emissions[0].opened.map((o) => o.commId)).toEqual([commId]);
+      expect(emissions[0].opened[0].state).toMatchObject({
+        layout: { inline: true, display: "flex" },
+        marker: { blob: "ordinary-traitlet" },
+        payload: { blob: "ordinary-payload", size: 3, extra: "state" },
+      });
+
+      engine.stop();
+    });
+
     it("replays the current comm projection for subscribers installed after bootstrap", async () => {
       const commId = "late-subscriber-comm";
       handle = createMockHandle({

--- a/packages/runtimed/tests/sync-engine.test.ts
+++ b/packages/runtimed/tests/sync-engine.test.ts
@@ -2026,6 +2026,66 @@ describe("SyncEngine", () => {
       engine.stop();
     });
 
+    it("projects plain CommsDoc JSON when the handle resolver is unavailable", async () => {
+      const commId = "plain-json-comm";
+      handle = createMockHandle({
+        get_runtime_state: vi.fn(() => runtimeStateWithComm(commId, {})),
+        get_comms_state: vi.fn(() => ({ comms: { [commId]: { value: 7 } } })),
+        resolve_comm_state: vi.fn(() => undefined),
+      });
+
+      const engine = createEngine();
+      engine.start();
+
+      const emissions: Array<{
+        opened: Array<{ commId: string; state: unknown }>;
+        updated: Array<{ commId: string; state: unknown }>;
+      }> = [];
+      engine.commChanges$.subscribe((c) => emissions.push(c));
+      engine.reProjectComms();
+
+      await vi.waitFor(() => expect(emissions.length).toBe(1));
+      expect(emissions[0].opened.map((o) => o.commId)).toEqual([commId]);
+      expect((emissions[0].opened[0].state as Record<string, unknown>).value).toBe(7);
+
+      engine.stop();
+    });
+
+    it("replays the current comm projection for subscribers installed after bootstrap", async () => {
+      const commId = "late-subscriber-comm";
+      handle = createMockHandle({
+        get_runtime_state: vi.fn(() => runtimeStateWithComm(commId, {})),
+        get_comms_state: vi.fn(() => ({ comms: { [commId]: { value: 7 } } })),
+        resolve_comm_state: vi.fn(() => ({
+          state: { value: 7 },
+          buffer_paths: [] as string[][],
+          text_paths: [] as string[][],
+        })),
+      });
+
+      const engine = createEngine();
+      engine.start();
+
+      // Cloud starts the engine while connecting the socket, then installs
+      // React/widget-store subscribers after the runtime is returned. The
+      // adapter must be able to replay the current durable comm projection
+      // into those late subscribers, especially after reconnect.
+      const emissions: Array<{
+        opened: Array<{ commId: string; state: unknown }>;
+        updated: Array<{ commId: string; state: unknown }>;
+      }> = [];
+      engine.commChanges$.subscribe((c) => emissions.push(c));
+      const beforeReplay = emissions.length;
+      engine.reProjectComms();
+
+      await vi.waitFor(() => expect(emissions.length).toBeGreaterThan(beforeReplay));
+      const replay = emissions.at(-1)!;
+      expect(replay.opened.map((o) => o.commId)).toEqual([commId]);
+      expect((replay.opened[0].state as Record<string, unknown>).value).toBe(7);
+
+      engine.stop();
+    });
+
     it("inlines text-MIME blobs into emitted comm state", async () => {
       const commId = "abc123";
       const pythonSource = "class Counter: count = 0";
@@ -2228,15 +2288,24 @@ describe("SyncEngine", () => {
 
     it("re-surfaces an update dropped while resolver was not ready", async () => {
       // Simulates the race where an update to an already-opened comm
-      // arrives before blob_port is set (resolve_comm_state returns
-      // undefined). Before the fix, projectComms advanced the diff's
-      // recorded json for that comm, so the next projection saw "no
-      // change" and never re-emitted — the update was lost.
+      // arrives before blob/content resolution is ready
+      // (resolve_comm_state returns undefined). Before the fix,
+      // projectComms advanced the diff's recorded json for that comm,
+      // so the next projection saw "no change" and never re-emitted —
+      // the update was lost. Plain JSON states now fall back to raw
+      // CommsDoc state; this test stays on a blob-backed state so it
+      // still exercises the resolver-deferred path.
       const commId = "race1";
       let portReady = false;
       handle = createMockHandle({
         resolve_comm_state: vi.fn((_id: unknown) =>
-          portReady ? { state: { value: 42 }, buffer_paths: [], text_paths: [] } : undefined,
+          portReady
+            ? {
+                state: { image: "http://127.0.0.1:1234/blob/hash-b" },
+                buffer_paths: [["image"]],
+                text_paths: [],
+              }
+            : undefined,
         ),
       });
 
@@ -2252,7 +2321,7 @@ describe("SyncEngine", () => {
       // Open: resolver ready, comm opens fine.
       portReady = true;
       (handle.receive_frame as ReturnType<typeof vi.fn>).mockReturnValue([
-        runtimeStateSyncEvent(runtimeStateWithComm(commId, { value: 1 })),
+        runtimeStateSyncEvent(runtimeStateWithComm(commId, { image: { blob: "hash-a", size: 1 } })),
       ]);
       transport.deliver([0x05, 0x01]);
       await vi.waitFor(() => expect(emissions.length).toBe(1));
@@ -2263,7 +2332,7 @@ describe("SyncEngine", () => {
       // re-surfaced on later projections.
       portReady = false;
       (handle.receive_frame as ReturnType<typeof vi.fn>).mockReturnValue([
-        runtimeStateSyncEvent(runtimeStateWithComm(commId, { value: 2 })),
+        runtimeStateSyncEvent(runtimeStateWithComm(commId, { image: { blob: "hash-b", size: 1 } })),
       ]);
       transport.deliver([0x05, 0x02]);
 
@@ -2276,7 +2345,7 @@ describe("SyncEngine", () => {
       // state and concluding "no change."
       portReady = true;
       (handle.receive_frame as ReturnType<typeof vi.fn>).mockReturnValue([
-        runtimeStateSyncEvent(runtimeStateWithComm(commId, { value: 2 })),
+        runtimeStateSyncEvent(runtimeStateWithComm(commId, { image: { blob: "hash-b", size: 1 } })),
       ]);
       transport.deliver([0x05, 0x03]);
 

--- a/src/components/widgets/__tests__/cloud-widget-runtime.test.tsx
+++ b/src/components/widgets/__tests__/cloud-widget-runtime.test.tsx
@@ -1,8 +1,12 @@
 import { render, waitFor } from "@testing-library/react";
 import { useEffect } from "react";
 import { afterEach, describe, expect, it } from "vitest";
-import { CloudWidgetStoreProvider } from "../../../../apps/notebook-cloud/viewer/widget-runtime";
+import {
+  applyCloudWidgetCommChanges,
+  CloudWidgetStoreProvider,
+} from "../../../../apps/notebook-cloud/viewer/widget-runtime";
 import { setCrdtCommWriter } from "../crdt-comm-writer";
+import { createWidgetStore } from "../widget-store";
 import { useWidgetStoreRequired, type WidgetStore } from "../widget-store-context";
 
 describe("CloudWidgetStoreProvider", () => {
@@ -46,5 +50,82 @@ describe("CloudWidgetStoreProvider", () => {
 
     expect(context?.store.getModel("comm-slider")?.state.value).toBe(18);
     await waitFor(() => expect(writes).toEqual([{ commId: "comm-slider", patch: { value: 18 } }]));
+  });
+
+  it("applies live comm changes into the cloud widget store", () => {
+    const store = createWidgetStore();
+
+    applyCloudWidgetCommChanges(store, {
+      opened: [
+        {
+          commId: "comm-slider",
+          targetName: "jupyter.widget",
+          modelModule: "@jupyter-widgets/controls",
+          modelName: "IntSliderModel",
+          state: {
+            _model_module: "@jupyter-widgets/controls",
+            _model_name: "IntSliderModel",
+            value: 7,
+          },
+          bufferPaths: [],
+          unresolvedOutputs: null,
+        },
+      ],
+      updated: [],
+      closed: [],
+    });
+
+    expect(store.getModel("comm-slider")?.state.value).toBe(7);
+
+    applyCloudWidgetCommChanges(store, {
+      opened: [],
+      updated: [
+        {
+          commId: "comm-slider",
+          targetName: "jupyter.widget",
+          modelModule: "@jupyter-widgets/controls",
+          modelName: "IntSliderModel",
+          state: { value: 18 },
+          bufferPaths: [],
+          unresolvedOutputs: null,
+        },
+      ],
+      closed: [],
+    });
+
+    expect(store.getModel("comm-slider")?.state.value).toBe(18);
+
+    applyCloudWidgetCommChanges(store, {
+      opened: [],
+      updated: [],
+      closed: ["comm-slider"],
+    });
+
+    expect(store.getModel("comm-slider")).toBeUndefined();
+  });
+
+  it("creates a missing model from a live comm update", () => {
+    const store = createWidgetStore();
+
+    applyCloudWidgetCommChanges(store, {
+      opened: [],
+      updated: [
+        {
+          commId: "comm-slider",
+          targetName: "jupyter.widget",
+          modelModule: "@jupyter-widgets/controls",
+          modelName: "IntSliderModel",
+          state: { value: 18 },
+          bufferPaths: [],
+          unresolvedOutputs: null,
+        },
+      ],
+      closed: [],
+    });
+
+    const model = store.getModel("comm-slider");
+    expect(model?.state.value).toBe(18);
+    expect(model?.state._model_module).toBe("@jupyter-widgets/controls");
+    expect(model?.state._model_name).toBe("IntSliderModel");
   });
 });

--- a/src/components/widgets/__tests__/cloud-widget-runtime.test.tsx
+++ b/src/components/widgets/__tests__/cloud-widget-runtime.test.tsx
@@ -1,12 +1,8 @@
 import { render, waitFor } from "@testing-library/react";
 import { useEffect } from "react";
 import { afterEach, describe, expect, it } from "vitest";
-import {
-  applyCloudWidgetCommChanges,
-  CloudWidgetStoreProvider,
-} from "../../../../apps/notebook-cloud/viewer/widget-runtime";
+import { CloudWidgetStoreProvider } from "../../../../apps/notebook-cloud/viewer/widget-runtime";
 import { setCrdtCommWriter } from "../crdt-comm-writer";
-import { createWidgetStore } from "../widget-store";
 import { useWidgetStoreRequired, type WidgetStore } from "../widget-store-context";
 
 describe("CloudWidgetStoreProvider", () => {
@@ -50,82 +46,5 @@ describe("CloudWidgetStoreProvider", () => {
 
     expect(context?.store.getModel("comm-slider")?.state.value).toBe(18);
     await waitFor(() => expect(writes).toEqual([{ commId: "comm-slider", patch: { value: 18 } }]));
-  });
-
-  it("applies live comm changes into the cloud widget store", () => {
-    const store = createWidgetStore();
-
-    applyCloudWidgetCommChanges(store, {
-      opened: [
-        {
-          commId: "comm-slider",
-          targetName: "jupyter.widget",
-          modelModule: "@jupyter-widgets/controls",
-          modelName: "IntSliderModel",
-          state: {
-            _model_module: "@jupyter-widgets/controls",
-            _model_name: "IntSliderModel",
-            value: 7,
-          },
-          bufferPaths: [],
-          unresolvedOutputs: null,
-        },
-      ],
-      updated: [],
-      closed: [],
-    });
-
-    expect(store.getModel("comm-slider")?.state.value).toBe(7);
-
-    applyCloudWidgetCommChanges(store, {
-      opened: [],
-      updated: [
-        {
-          commId: "comm-slider",
-          targetName: "jupyter.widget",
-          modelModule: "@jupyter-widgets/controls",
-          modelName: "IntSliderModel",
-          state: { value: 18 },
-          bufferPaths: [],
-          unresolvedOutputs: null,
-        },
-      ],
-      closed: [],
-    });
-
-    expect(store.getModel("comm-slider")?.state.value).toBe(18);
-
-    applyCloudWidgetCommChanges(store, {
-      opened: [],
-      updated: [],
-      closed: ["comm-slider"],
-    });
-
-    expect(store.getModel("comm-slider")).toBeUndefined();
-  });
-
-  it("creates a missing model from a live comm update", () => {
-    const store = createWidgetStore();
-
-    applyCloudWidgetCommChanges(store, {
-      opened: [],
-      updated: [
-        {
-          commId: "comm-slider",
-          targetName: "jupyter.widget",
-          modelModule: "@jupyter-widgets/controls",
-          modelName: "IntSliderModel",
-          state: { value: 18 },
-          bufferPaths: [],
-          unresolvedOutputs: null,
-        },
-      ],
-      closed: [],
-    });
-
-    const model = store.getModel("comm-slider");
-    expect(model?.state.value).toBe(18);
-    expect(model?.state._model_module).toBe("@jupyter-widgets/controls");
-    expect(model?.state._model_name).toBe("IntSliderModel");
   });
 });

--- a/src/components/widgets/__tests__/cloud-widget-runtime.test.tsx
+++ b/src/components/widgets/__tests__/cloud-widget-runtime.test.tsx
@@ -1,0 +1,50 @@
+import { render, waitFor } from "@testing-library/react";
+import { useEffect } from "react";
+import { afterEach, describe, expect, it } from "vitest";
+import { CloudWidgetStoreProvider } from "../../../../apps/notebook-cloud/viewer/widget-runtime";
+import { setCrdtCommWriter } from "../crdt-comm-writer";
+import { useWidgetStoreRequired, type WidgetStore } from "../widget-store-context";
+
+describe("CloudWidgetStoreProvider", () => {
+  afterEach(() => {
+    setCrdtCommWriter(null);
+  });
+
+  it("persists widget state updates through the CRDT writer", async () => {
+    const writes: Array<{ commId: string; patch: Record<string, unknown> }> = [];
+    let context:
+      | {
+          sendUpdate: (commId: string, state: Record<string, unknown>) => Promise<void>;
+          store: WidgetStore;
+        }
+      | undefined;
+
+    setCrdtCommWriter((commId, patch) => {
+      writes.push({ commId, patch });
+    });
+
+    function Probe() {
+      context = useWidgetStoreRequired();
+      useEffect(() => {
+        context?.store.createModel("comm-slider", {
+          _model_module: "@jupyter-widgets/controls",
+          _model_name: "IntSliderModel",
+          value: 7,
+        });
+      }, []);
+      return null;
+    }
+
+    render(
+      <CloudWidgetStoreProvider>
+        <Probe />
+      </CloudWidgetStoreProvider>,
+    );
+
+    await waitFor(() => expect(context?.store.getModel("comm-slider")).toBeDefined());
+    await context?.sendUpdate("comm-slider", { value: 18 });
+
+    expect(context?.store.getModel("comm-slider")?.state.value).toBe(18);
+    await waitFor(() => expect(writes).toEqual([{ commId: "comm-slider", patch: { value: 18 } }]));
+  });
+});

--- a/src/components/widgets/__tests__/comm-changes-store-bridge.test.ts
+++ b/src/components/widgets/__tests__/comm-changes-store-bridge.test.ts
@@ -1,0 +1,151 @@
+import { describe, expect, it } from "vitest";
+import {
+  applyWidgetCommBroadcastToStore,
+  applyWidgetCommChangesToStore,
+} from "../comm-changes-store-bridge";
+import { createWidgetStore } from "../widget-store";
+
+describe("comm changes store bridge", () => {
+  it("applies opened, updated, and closed comm changes to a WidgetStore", () => {
+    const store = createWidgetStore();
+    const cleared: string[] = [];
+
+    applyWidgetCommChangesToStore(store, {
+      opened: [
+        {
+          commId: "comm-slider",
+          targetName: "jupyter.widget",
+          modelModule: "@jupyter-widgets/controls",
+          modelName: "IntSliderModel",
+          state: { value: 7 },
+          bufferPaths: [],
+          unresolvedOutputs: null,
+        },
+      ],
+      updated: [],
+      closed: [],
+    });
+
+    expect(store.getModel("comm-slider")?.state).toMatchObject({
+      _model_module: "@jupyter-widgets/controls",
+      _model_name: "IntSliderModel",
+      value: 7,
+    });
+
+    applyWidgetCommChangesToStore(store, {
+      opened: [],
+      updated: [
+        {
+          commId: "comm-slider",
+          targetName: "jupyter.widget",
+          modelModule: "@jupyter-widgets/controls",
+          modelName: "IntSliderModel",
+          state: { value: 18 },
+          bufferPaths: [],
+          unresolvedOutputs: null,
+        },
+      ],
+      closed: [],
+    });
+
+    expect(store.getModel("comm-slider")?.state.value).toBe(18);
+
+    applyWidgetCommChangesToStore(
+      store,
+      {
+        opened: [],
+        updated: [],
+        closed: ["comm-slider"],
+      },
+      { clearComm: (commId) => cleared.push(commId) },
+    );
+
+    expect(cleared).toEqual(["comm-slider"]);
+    expect(store.getModel("comm-slider")).toBeUndefined();
+  });
+
+  it("creates a missing model from a live update using comm metadata", () => {
+    const store = createWidgetStore();
+
+    applyWidgetCommChangesToStore(store, {
+      opened: [],
+      updated: [
+        {
+          commId: "comm-slider",
+          targetName: "jupyter.widget",
+          modelModule: "@jupyter-widgets/controls",
+          modelName: "IntSliderModel",
+          state: { value: 18 },
+          bufferPaths: [],
+          unresolvedOutputs: null,
+        },
+      ],
+      closed: [],
+    });
+
+    const model = store.getModel("comm-slider");
+    expect(model?.state.value).toBe(18);
+    expect(model?.state._model_module).toBe("@jupyter-widgets/controls");
+    expect(model?.state._model_name).toBe("IntSliderModel");
+  });
+
+  it("suppresses optimistic echoes while keeping output resolution hooks", () => {
+    const store = createWidgetStore();
+    const resolvedOutputs: Array<{ commId: string; outputs: unknown[] }> = [];
+
+    store.createModel("comm-output", { value: 7 });
+    applyWidgetCommChangesToStore(
+      store,
+      {
+        opened: [],
+        updated: [
+          {
+            commId: "comm-output",
+            targetName: "jupyter.widget",
+            modelModule: "@jupyter-widgets/controls",
+            modelName: "OutputModel",
+            state: { value: 8 },
+            bufferPaths: [],
+            unresolvedOutputs: [{ output_type: "stream", text: "ok" }],
+          },
+        ],
+        closed: [],
+      },
+      {
+        shouldSuppressEcho: () => null,
+        resolveOutputs: (commId, outputs) => resolvedOutputs.push({ commId, outputs }),
+      },
+    );
+
+    expect(store.getModel("comm-output")?.state.value).toBe(7);
+    expect(resolvedOutputs).toEqual([
+      { commId: "comm-output", outputs: [{ output_type: "stream", text: "ok" }] },
+    ]);
+  });
+
+  it("routes custom comm broadcasts as ephemeral WidgetStore messages", () => {
+    const store = createWidgetStore();
+    const messages: Array<{ content: Record<string, unknown>; buffers?: DataView[] }> = [];
+
+    store.subscribeToCustomMessage("comm-button", (content, buffers) => {
+      messages.push({ content, buffers });
+    });
+
+    applyWidgetCommBroadcastToStore(store, {
+      event: "comm",
+      msg_type: "comm_msg",
+      content: {
+        comm_id: "comm-button",
+        data: {
+          method: "custom",
+          content: { event: "click" },
+        },
+      },
+      buffers: [[1, 2, 3]],
+    });
+
+    expect(messages).toHaveLength(1);
+    expect(messages[0].content).toEqual({ event: "click" });
+    expect(messages[0].buffers?.[0].byteLength).toBe(3);
+  });
+});

--- a/src/components/widgets/comm-changes-store-bridge.ts
+++ b/src/components/widgets/comm-changes-store-bridge.ts
@@ -1,0 +1,103 @@
+import type { CommBroadcast, CommChanges } from "runtimed";
+import type { WidgetStore } from "./widget-store";
+
+export interface ApplyWidgetCommChangesOptions {
+  /**
+   * Return a filtered patch after suppressing optimistic CRDT echoes.
+   * Return null/undefined to skip the update.
+   */
+  shouldSuppressEcho?: (
+    commId: string,
+    state: Record<string, unknown>,
+  ) => Record<string, unknown> | null | undefined;
+  /** Clear per-comm optimistic state when the comm closes. */
+  clearComm?: (commId: string) => void;
+  /** Resolve OutputModel manifests after the comm state has reached the store. */
+  resolveOutputs?: (commId: string, outputs: unknown[], store: WidgetStore) => void;
+}
+
+/**
+ * Apply durable RuntimeStateDoc/CommsDoc widget projection changes to a
+ * WidgetStore. Desktop and hosted cloud both consume the same SyncEngine
+ * `commChanges$` stream, so the store transition semantics live here rather
+ * than in host-specific React code.
+ */
+export function applyWidgetCommChangesToStore(
+  store: WidgetStore,
+  changes: CommChanges,
+  options: ApplyWidgetCommChangesOptions = {},
+): void {
+  for (const comm of changes.opened) {
+    store.createModel(comm.commId, widgetStateWithMetadata(comm), comm.bufferPaths);
+    maybeResolveCommOutputs(store, comm.commId, comm.unresolvedOutputs, options);
+  }
+
+  for (const comm of changes.updated) {
+    if (!store.getModel(comm.commId)) {
+      store.createModel(comm.commId, widgetStateWithMetadata(comm), comm.bufferPaths);
+      maybeResolveCommOutputs(store, comm.commId, comm.unresolvedOutputs, options);
+      continue;
+    }
+
+    const patch = options.shouldSuppressEcho
+      ? options.shouldSuppressEcho(comm.commId, comm.state)
+      : comm.state;
+    if (patch) {
+      store.updateModel(
+        comm.commId,
+        widgetStateWithMetadata({ ...comm, state: patch }),
+        comm.bufferPaths,
+      );
+    }
+    maybeResolveCommOutputs(store, comm.commId, comm.unresolvedOutputs, options);
+  }
+
+  for (const commId of changes.closed) {
+    options.clearComm?.(commId);
+    store.deleteModel(commId);
+  }
+}
+
+/**
+ * Apply an ephemeral custom comm broadcast to a WidgetStore.
+ *
+ * These are intentionally separate from `applyWidgetCommChangesToStore`:
+ * RuntimeStateDoc/CommsDoc are durable widget state, while custom broadcasts
+ * are kernel events such as button clicks and `model.send()`.
+ */
+export function applyWidgetCommBroadcastToStore(
+  store: WidgetStore,
+  broadcast: CommBroadcast,
+): void {
+  const data = broadcast.content.data as Record<string, unknown> | undefined;
+  if (data?.method !== "custom") return;
+
+  const commId = broadcast.content.comm_id;
+  if (typeof commId !== "string") return;
+
+  const inner = (data.content as Record<string, unknown> | undefined) ?? {};
+  const arrayBuffers = broadcast.buffers?.map((arr: number[]) => new Uint8Array(arr).buffer);
+  store.emitCustomMessage(commId, inner, arrayBuffers);
+}
+
+function widgetStateWithMetadata(comm: {
+  modelModule: string;
+  modelName: string;
+  state: Record<string, unknown>;
+}): Record<string, unknown> {
+  const state = { ...comm.state };
+  state._model_module ??= comm.modelModule || undefined;
+  state._model_name ??= comm.modelName || undefined;
+  return state;
+}
+
+function maybeResolveCommOutputs(
+  store: WidgetStore,
+  commId: string,
+  unresolvedOutputs: unknown[] | null,
+  options: ApplyWidgetCommChangesOptions,
+): void {
+  if (unresolvedOutputs) {
+    options.resolveOutputs?.(commId, unresolvedOutputs, store);
+  }
+}


### PR DESCRIPTION
## Summary
- project hosted widget comm state into the browser WidgetStore from the shared SyncEngine `commChanges$` stream
- let cloud live handles expose RuntimeStateDoc and CommsDoc snapshots so late subscribers can replay durable comm projection state
- fall back to raw CommsDoc JSON for plain widget state only when no ContentRefs are present; ContentRef-backed state still defers instead of being mis-projected
- converge desktop and hosted cloud on a shared `applyWidgetCommChangesToStore` / `applyWidgetCommBroadcastToStore` bridge so both surfaces consume document truth with the same WidgetStore semantics
- harden the hosted two-window widget smoke so it proves IntSlider sync in both directions and captures first-party diagnostics on failure

## Reviewer focus
- Please scrutinize the raw JSON fallback in `SyncEngine.projectComms()`. It is deliberately constrained to no-ContentRef state, but the likely next step is a real cloud resolver for blob/manifest-backed widget state. The important boundary is that plain JSON widgets should project from CommsDoc truth, while manifest/blob-backed state should be resolved properly or deferred, never plucked half-correctly.
- Please also check the shared widget store bridge: desktop and cloud now use the same store transition semantics for `commChanges$` and custom comm broadcasts.

## Validation
- `cargo xtask lint --fix`
- `pnpm --dir apps/notebook-cloud run typecheck`
- `node --import tsx --test test/room-materializer.test.ts`
- `pnpm test:run -- src/components/widgets/__tests__/comm-changes-store-bridge.test.ts src/components/widgets/__tests__/cloud-widget-runtime.test.tsx packages/runtimed/tests/sync-engine.test.ts src/components/isolated/__tests__/comm-bridge-manager.test.ts`
- `pnpm --filter notebook-ui test:e2e:browser -- --project=chromium apps/notebook/e2e/execute-cell-output.spec.ts`
- `pnpm --filter notebook-ui test:e2e:browser -- --project=chromium apps/notebook/e2e/widget-cross-window-sync.spec.ts`
- deployed preview.runt.run before the rebase: assets worker `ec818943-b1b8-4a66-9ced-0cea4320b6b7`, main worker `6c9a35f0-0061-4664-bff4-ac5da7d02768`
- hosted smoke passed before the rebase against `https://preview.runt.run/n/01KTPTP7PY4YS9YN4A1DNAGBQN/widget-cross-window-smoke`: primary drag synced to peer, then peer drag synced back to primary

## Follow-up
- cloud should grow a host-provided resolver for live comm states that contain ContentRefs, probably using the existing blob/manifest resolution path that feeds iframe buffer paths. This PR intentionally keeps those states deferred rather than mis-projecting them.