### PR TITLE
fix(ci): pin + retry pixi and uv setup in runtimed-py lane

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1176,10 +1176,33 @@ jobs:
       - name: Install uv
         uses: astral-sh/setup-uv@v8.1.0
 
+      # Fetch the exact pixi the daemon targets (PIXI_TARGET_VERSION in
+      # crates/kernel-launch/src/tools.rs) with curl retries. This lane launches
+      # a real kernel in a pixi project (test_pixi_auto_detection), and the
+      # launcher prefers system pixi on PATH, so pinning keeps `pixi info --json`
+      # and `pixi shell-hook --json` output matched to the daemon's tested
+      # version. The retries absorb transient release-CDN failures that an
+      # unguarded download (prefix-dev/setup-pixi has neither pin nor retry here)
+      # turns into a full-lane failure before any test runs.
       - name: Install pixi
-        uses: prefix-dev/setup-pixi@v0.9.5
-        with:
-          run-install: false
+        run: |
+          set -euo pipefail
+          version="$(grep -oP 'PIXI_TARGET_VERSION: &str = "\K[^"]+' crates/kernel-launch/src/tools.rs)"
+          echo "Installing pinned pixi ${version}"
+          asset="pixi-x86_64-unknown-linux-musl.tar.gz"
+          base="https://github.com/prefix-dev/pixi/releases/download/v${version}"
+          tmp="$(mktemp -d)"
+          trap 'rm -rf "$tmp"' EXIT
+          for f in "$asset" "$asset.sha256"; do
+            curl --fail --location --show-error --retry 10 --retry-delay 2 --retry-all-errors \
+              --output "$tmp/$f" "$base/$f"
+          done
+          ( cd "$tmp" && sha256sum --check --status "$asset.sha256" )
+          mkdir -p "$HOME/.pixi/bin"
+          tar -xzf "$tmp/$asset" -C "$HOME/.pixi/bin" pixi
+          chmod +x "$HOME/.pixi/bin/pixi"
+          echo "$HOME/.pixi/bin" >> "$GITHUB_PATH"
+          "$HOME/.pixi/bin/pixi" --version
 
       # Build wasm + renderer plugins (gitignored; runtimed embeds them)
       - uses: ./.github/actions/build-runtime-artifacts
@@ -1194,12 +1217,26 @@ jobs:
         # VIRTUAL_ENV plus `uv run --active` pins maturin to this same .venv
         # so the bindings land where pytest will look.
         run: |
-          uv sync --no-default-groups \
-            --package runtimed \
-            --package dx \
-            --package nteract \
-            --package nteract-kernel-launcher \
-            --group dev
+          set -euo pipefail
+          # uv sync hits the network for the workspace packages; the self-hosted
+          # pool sees intermittent registry/resolver hiccups, so retry transient
+          # failures before failing the lane.
+          for attempt in 1 2 3; do
+            if uv sync --no-default-groups \
+              --package runtimed \
+              --package dx \
+              --package nteract \
+              --package nteract-kernel-launcher \
+              --group dev; then
+              break
+            fi
+            if [ "$attempt" -eq 3 ]; then
+              echo "uv sync failed after ${attempt} attempts" >&2
+              exit 1
+            fi
+            echo "uv sync attempt ${attempt} failed; retrying in $((attempt * 10))s..." >&2
+            sleep "$((attempt * 10))"
+          done
           cd crates/runtimed-py && \
             VIRTUAL_ENV="${GITHUB_WORKSPACE}/.venv" \
             uv run --active --directory ../../python/runtimed maturin develop


### PR DESCRIPTION
The `runtimed-py Integration Tests` lane (Anaconda self-hosted) has been failing on roughly 40% of post-merge main runs, across unrelated commits. The same commit passed once and failed another run, so it is not code-correlated. The failures cluster in environment setup, before any integration test executes.

## Diagnosis

Four recent failed runs, by failing step:

| Failing step | Count | Root cause |
| --- | --- | --- |
| Install pixi | 2 | `prefix-dev/setup-pixi` does an unguarded binary download with no retry; a transient release-CDN hiccup fails the lane in ~30-45s |
| Build runtimed-py (`uv sync`) | 1 | Transient registry/resolver hiccup pulling workspace packages |
| (no recorded step, ~14 min) | 1 | Self-hosted runner infra; not addressed here |

The `long-tail-ci-health-summary` artifact confirmed the pattern: on a bad run both Anaconda self-hosted lanes (`Native E2E` and this one) went red together while every GitHub-hosted lane passed.

## The fix

- **pixi**: replace the `setup-pixi` action with a `curl --retry-all-errors` download of the pixi binary, verified against its published `.sha256`. Pinned to the daemon's `PIXI_TARGET_VERSION` (`crates/kernel-launch/src/tools.rs`) rather than floating on the latest release.
- **uv**: wrap `uv sync` in a bounded 3-attempt retry with backoff.

Both follow the repo's existing `curl --fail --retry 10 --retry-all-errors` download idiom (see the actionlint install in the same workflow).

## Design notes

- **pixi is required, not dead.** `test_pixi_auto_detection` opens a notebook in a `pixi.toml` project and asserts `env_source == "pixi:toml"`; the launcher runs `pixi --version` / `pixi shell-hook --json` and prefers system pixi on PATH. Removing the step would push the fetch into the daemon's own download path inside the 30-minute test window. Keeping a reliable system pixi avoids that.
- **Pinning to `PIXI_TARGET_VERSION`** keeps CI's system pixi matched to the version the daemon's `pixi info --json` / `shell-hook --json` parsing is written against, instead of whatever the action resolves to that day. The version is read from the Rust source at run time so the two cannot drift.
- The ~14-minute no-step failure mode looks like self-hosted runner infra and is out of scope here. If it recurs after this lands, the next step is an automatic single re-run of the failed self-hosted lane.

## Validation

The lane only runs on non-PR events, so it is skipped on this PR. Validated by `workflow_dispatch` on the branch (dispatch satisfies the lane's `github.event_name != 'pull_request'` guard) and by watching the post-merge run on main.
