### PR TITLE
fix(notebook-cloud): trust app sessions over stale oidc state

### DIFF
--- a/apps/notebook-cloud/test/collaborator-auth.test.ts
+++ b/apps/notebook-cloud/test/collaborator-auth.test.ts
@@ -13,6 +13,7 @@ import {
   clearCloudPrototypeDevAuth,
   cloudSyncAuthFromAppSessionCookie,
   cloudSyncAuthFromPrototypeAuthState,
+  shouldShowCloudHeaderSignIn,
   withCloudPrototypeAuthHeaders,
   isCloudPrototypeAuthStorageKey,
   prepareCloudOidcViewerLogin,
@@ -23,6 +24,7 @@ import {
   storeCloudRequestedScope,
   validatePrototypeToken,
   type CloudPrototypeAuthStorage,
+  type CloudPrototypeAuthState,
 } from "../viewer/collaborator-auth.ts";
 
 describe("cloud collaborator auth", () => {
@@ -178,6 +180,21 @@ describe("cloud collaborator auth", () => {
       }),
       false,
     );
+  });
+
+  it("trusts an app-session cookie over stale localStorage renewal state in header chrome", () => {
+    assert.equal(shouldShowCloudHeaderSignIn(authState("oidc_expired")), true);
+    assert.equal(
+      shouldShowCloudHeaderSignIn(authState("oidc_expired"), { hasAppSession: true }),
+      false,
+    );
+    assert.equal(
+      shouldShowCloudHeaderSignIn(authState("oidc_expired"), { appSessionLoading: true }),
+      false,
+    );
+    assert.equal(shouldShowCloudHeaderSignIn(authState("anonymous")), true);
+    assert.equal(shouldShowCloudHeaderSignIn(authState("oidc")), false);
+    assert.equal(shouldShowCloudHeaderSignIn(authState("dev")), false);
   });
 
   it("keeps dev-token headers for prototype browser app APIs", () => {
@@ -534,4 +551,15 @@ function base64UrlJson(value: Record<string, unknown>): string {
 
 function base64Url(value: string): string {
   return Buffer.from(value).toString("base64url");
+}
+
+function authState(mode: CloudPrototypeAuthState["mode"]): CloudPrototypeAuthState {
+  return {
+    mode,
+    token: mode === "dev" || mode === "oidc" ? "token" : null,
+    user: mode === "anonymous" ? null : "User",
+    oidcClaims: null,
+    requestedScope: "owner",
+    problem: mode === "invalid" || mode === "oidc_expired" ? "auth problem" : null,
+  };
 }

--- a/apps/notebook-cloud/test/viewer-render-props.test.ts
+++ b/apps/notebook-cloud/test/viewer-render-props.test.ts
@@ -142,7 +142,10 @@ test("cloud viewer routes notebook header controls through the shared shell chro
     /buildCloudShareAccessRows\(\{ acl, invites, accessRequests \}\)/,
   );
   assert.match(sourceText, /editControls=\{[\s\S]*<CloudNotebookEditModeButton/);
-  assert.match(sourceText, /authControls=\{[\s\S]*shouldShowCloudHeaderSignIn\(authState\) \? \(/);
+  assert.match(
+    sourceText,
+    /authControls=\{[\s\S]*shouldShowCloudHeaderSignIn\(authState, \{[\s\S]*hasAppSession: Boolean\(appSessionStatus\.session\),[\s\S]*\}\) \? \(/,
+  );
   assert.match(sourceText, /authControls=\{[\s\S]*<CloudNotebookSignInButton/);
   assert.match(sourceText, /identityControls=\{null\}/);
   assert.match(sourceText, /useState\(initialCloudRailCollapsed\)/);

--- a/apps/notebook-cloud/viewer/cloud-auth-controls.tsx
+++ b/apps/notebook-cloud/viewer/cloud-auth-controls.tsx
@@ -103,11 +103,3 @@ export function CloudNotebookSignInButton({
     </button>
   );
 }
-
-export function shouldShowCloudHeaderSignIn(authState: CloudPrototypeAuthState): boolean {
-  return (
-    authState.mode === "anonymous" ||
-    authState.mode === "invalid" ||
-    authState.mode === "oidc_expired"
-  );
-}

--- a/apps/notebook-cloud/viewer/collaborator-auth.ts
+++ b/apps/notebook-cloud/viewer/collaborator-auth.ts
@@ -118,6 +118,20 @@ export function cloudBrowserCanUseAuthenticatedApi({
   return authState.mode === "dev" || hasAppSession;
 }
 
+export function shouldShowCloudHeaderSignIn(
+  authState: CloudPrototypeAuthState,
+  options?: { appSessionLoading?: boolean; hasAppSession?: boolean },
+): boolean {
+  if (options?.hasAppSession || options?.appSessionLoading) {
+    return false;
+  }
+  return (
+    authState.mode === "anonymous" ||
+    authState.mode === "invalid" ||
+    authState.mode === "oidc_expired"
+  );
+}
+
 export function readCloudPrototypeAuth(
   storage: Pick<CloudPrototypeAuthStorage, "getItem">,
 ): CloudPrototypeAuthState {

--- a/apps/notebook-cloud/viewer/notebook-list-view.tsx
+++ b/apps/notebook-cloud/viewer/notebook-list-view.tsx
@@ -410,7 +410,7 @@ function cloudNotebookListHeaderDetail(
   authState: CloudPrototypeAuthState,
   hasAppSession: boolean,
 ): string {
-  if (authState.mode === "oidc_expired") {
+  if (authState.mode === "oidc_expired" && !hasAppSession) {
     return "Session expired";
   }
   if (authState.mode === "anonymous" && !hasAppSession) {

--- a/apps/notebook-cloud/viewer/notebook-viewer.tsx
+++ b/apps/notebook-cloud/viewer/notebook-viewer.tsx
@@ -44,6 +44,7 @@ import {
   cloudSyncAuthFromPrototypeAuthState,
   prepareCloudOidcViewerLogin,
   storeCloudRequestedScope,
+  shouldShowCloudHeaderSignIn,
 } from "./collaborator-auth";
 import { createCloudNotebookCellId } from "./cloud-cell-id";
 import { useCloudViewerSession } from "./cloud-viewer-session";
@@ -79,11 +80,7 @@ import {
 } from "./use-cloud-auth";
 import { useCloudShellCapabilities } from "./use-cloud-shell-capabilities";
 import { useCloudWorkstationManager } from "./use-cloud-workstations";
-import {
-  CloudNotebookEditModeButton,
-  CloudNotebookSignInButton,
-  shouldShowCloudHeaderSignIn,
-} from "./cloud-auth-controls";
+import { CloudNotebookEditModeButton, CloudNotebookSignInButton } from "./cloud-auth-controls";
 import { CloudNotebookTitle } from "./cloud-notebook-title";
 import { CloudPresenceStatus } from "./cloud-presence-status";
 
@@ -812,7 +809,10 @@ export function NotebookViewer({
         <CloudPresenceStatus connectionError={connectionError} store={presenceStore} />
       }
       authControls={
-        shouldShowCloudHeaderSignIn(authState) ? (
+        shouldShowCloudHeaderSignIn(authState, {
+          appSessionLoading: appSessionStatus.status === "loading",
+          hasAppSession: Boolean(appSessionStatus.session),
+        }) ? (
           <CloudNotebookSignInButton authConfig={authConfig} authState={authState} />
         ) : null
       }


### PR DESCRIPTION
## Summary
- hide the notebook header sign-in CTA while a first-party app-session cookie is present or still loading
- keep /n from reporting an expired local OIDC renewal token as an expired browser session when the app-session cookie is usable
- move the header sign-in decision into the auth model layer and cover the cookie-over-localStorage behavior

## Why
The live room and first-party APIs use the app-session cookie. A stale localStorage OIDC token is only renewal material at that point, so it should not make the notebook chrome say “Sign in again” while widgets/live sync still work.

## Validation
- pnpm --dir apps/notebook-cloud exec node --import tsx --test test/viewer-render-props.test.ts test/viewer-notices.test.ts test/collaborator-auth.test.ts
- pnpm --dir apps/notebook-cloud run typecheck
- cargo xtask lint --fix
