### PR TITLE
fix(notebook): recover Tauri frame channel after reload

### DIFF
--- a/apps/notebook/e2e/run-browser-e2e.mjs
+++ b/apps/notebook/e2e/run-browser-e2e.mjs
@@ -2,7 +2,6 @@ import crypto from "node:crypto";
 import fs from "node:fs";
 import http from "node:http";
 import https from "node:https";
-import os from "node:os";
 import path from "node:path";
 import { spawn, spawnSync } from "node:child_process";
 import { fileURLToPath } from "node:url";
@@ -23,6 +22,8 @@ const POLL_MS = 250;
 
 const appRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
 const repoRoot = path.resolve(appRoot, "../..");
+const exeSuffix = process.platform === "win32" ? ".exe" : "";
+const runtBinary = path.join(repoRoot, "target", "debug", `runt${exeSuffix}`);
 const port = Number(
   process.env.RUNTIMED_VITE_PORT ?? process.env.CONDUCTOR_PORT ?? vitePort(repoRoot),
 );
@@ -73,15 +74,6 @@ function normalizePortlessUrl(url) {
   return parsed.toString().replace(/\/$/, "");
 }
 
-function cacheDir() {
-  if (process.env.XDG_CACHE_HOME) return process.env.XDG_CACHE_HOME;
-  if (process.platform === "darwin") return path.join(os.homedir(), "Library", "Caches");
-  if (process.platform === "win32") {
-    return process.env.LOCALAPPDATA ?? path.join(os.homedir(), "AppData", "Local");
-  }
-  return path.join(os.homedir(), ".cache");
-}
-
 function worktreeHash(workspace) {
   return crypto.createHash("sha256").update(workspace).digest("hex").slice(0, 12);
 }
@@ -91,42 +83,42 @@ function vitePort(workspace) {
   return 5100 + (Number.parseInt(hash.slice(0, 4), 16) % 4900);
 }
 
-function daemonJsonPath(workspace) {
-  const namespace = process.env.RUNTIMED_CACHE_NAMESPACE ?? "runt-nightly";
-  return path.join(cacheDir(), namespace, "worktrees", worktreeHash(workspace), "daemon.json");
+function managedEnv(extraEnv = {}) {
+  return {
+    ...process.env,
+    ...extraEnv,
+    RUNTIMED_DEV: "1",
+    RUNTIMED_WORKSPACE_PATH: repoRoot,
+    RUNTIMED_VITE_PORT: String(port),
+    NTERACT_BROWSER_E2E_BASE_URL: baseURL,
+    ...(ignoreHTTPSErrors ? { NTERACT_BROWSER_E2E_IGNORE_HTTPS_ERRORS: "1" } : {}),
+    VITE_E2E: "1",
+  };
 }
 
-function processIsRunning(pid) {
+async function ensureRuntBinary() {
+  if (fs.existsSync(runtBinary)) return;
+  const build = spawnManaged("cargo", ["build", "-p", "runt"]);
+  const code = await waitForExit(build);
+  if (code !== 0) throw new Error(`cargo build -p runt failed with exit code ${code}`);
+  if (!fs.existsSync(runtBinary))
+    throw new Error(`cargo build -p runt did not produce ${runtBinary}`);
+}
+
+function daemonRunning() {
+  if (!fs.existsSync(runtBinary)) return false;
+  const result = spawnSync(runtBinary, ["daemon", "status", "--json"], {
+    cwd: repoRoot,
+    encoding: "utf8",
+    env: managedEnv(),
+  });
+  if (result.status !== 0) return false;
   try {
-    process.kill(pid, 0);
-    return true;
+    const status = JSON.parse(result.stdout);
+    return status?.running === true && status?.socket_path !== undefined;
   } catch {
     return false;
   }
-}
-
-function readDaemonState(workspace) {
-  try {
-    return JSON.parse(fs.readFileSync(daemonJsonPath(workspace), "utf8"));
-  } catch {
-    return null;
-  }
-}
-
-function socketExists(state) {
-  const socketPath = state?.socket_path ?? state?.endpoint;
-  if (!socketPath) return false;
-  try {
-    return fs.statSync(socketPath).isSocket();
-  } catch {
-    return false;
-  }
-}
-
-function daemonRunning(workspace) {
-  const state = readDaemonState(workspace);
-  if (!socketExists(state)) return false;
-  return state?.pid === undefined || processIsRunning(state.pid);
 }
 
 function delay(ms) {
@@ -203,16 +195,7 @@ function spawnManaged(command, args, options = {}) {
   return spawn(command, args, {
     cwd: repoRoot,
     stdio: "inherit",
-    env: {
-      ...process.env,
-      ...extraEnv,
-      RUNTIMED_DEV: "1",
-      RUNTIMED_WORKSPACE_PATH: repoRoot,
-      RUNTIMED_VITE_PORT: String(port),
-      NTERACT_BROWSER_E2E_BASE_URL: baseURL,
-      ...(ignoreHTTPSErrors ? { NTERACT_BROWSER_E2E_IGNORE_HTTPS_ERRORS: "1" } : {}),
-      VITE_E2E: "1",
-    },
+    env: managedEnv(extraEnv),
     ...spawnOptions,
   });
 }
@@ -284,9 +267,11 @@ async function main() {
       return;
     }
 
-    if (!daemonRunning(repoRoot)) {
+    await ensureRuntBinary();
+
+    if (!daemonRunning()) {
       daemon = spawnManaged("cargo", ["xtask", "dev-daemon"]);
-      await waitUntil("dev daemon", () => daemonRunning(repoRoot), READY_TIMEOUT_MS, daemon);
+      await waitUntil("dev daemon", daemonRunning, READY_TIMEOUT_MS, daemon);
     }
 
     if (!(await relayHealthy())) {

--- a/apps/notebook/src/hooks/useAutomergeNotebook.ts
+++ b/apps/notebook/src/hooks/useAutomergeNotebook.ts
@@ -345,6 +345,7 @@ export function useNotebook() {
         setLoadError(null);
       },
       bootstrap: (isCancelled) => bootstrap(() => cancelled || isCancelled()),
+      prepareRelay: host.relay.prepareSync,
       notifyRelayReady,
       onMissingGeneration: () => {
         logger.debug(

--- a/crates/notebook/src/lib.rs
+++ b/crates/notebook/src/lib.rs
@@ -832,7 +832,7 @@ async fn setup_sync_receivers(
         // this wait — the mpsc channel is unbounded, so nothing is lost.
         let channel_wait_started = std::time::Instant::now();
         let channel_wait_timeout = std::time::Duration::from_secs(30);
-        let frame_channel = loop {
+        let initial_frame_channel = loop {
             if sync_generation_for_cleanup.load(Ordering::SeqCst) != current_generation {
                 info!(
                     "[notebook-sync] Stale relay for {} (gen {} superseded) before channel registration",
@@ -887,7 +887,7 @@ async fn setup_sync_receivers(
             }
         };
 
-        let Some(frame_channel) = frame_channel else {
+        let Some(_initial_frame_channel) = initial_frame_channel else {
             warn!(
                 "[notebook-sync] Frame relay stopped before frontend channel registration (gen {})",
                 current_generation,
@@ -937,6 +937,19 @@ async fn setup_sync_receivers(
                 );
                 break;
             }
+
+            let Some(frame_channel) = frame_channel_rx
+                .borrow()
+                .as_ref()
+                .filter(|subscription| subscription.generation == current_generation)
+                .cloned()
+            else {
+                warn!(
+                    "[notebook-sync] No frontend frame channel for {} (gen {}) — dropping frame",
+                    notebook_id_for_relay, current_generation,
+                );
+                continue;
+            };
 
             if let Err(e) = frame_channel
                 .channel

--- a/crates/xtask/src/main.rs
+++ b/crates/xtask/src/main.rs
@@ -4,7 +4,7 @@
 use std::collections::{HashSet, VecDeque};
 use std::env;
 use std::fs;
-use std::io::{BufRead, BufReader};
+use std::io::{BufRead, BufReader, Read, Write};
 use std::path::{Path, PathBuf};
 use std::process::{exit, Child, Command, ExitStatus, Stdio};
 use std::thread;
@@ -2882,78 +2882,83 @@ fn dev_daemon_running() -> bool {
         .stderr(Stdio::null());
     apply_worktree_env(&mut command, true);
 
-    let output = command.output();
-
-    let output = match output {
-        Ok(output) if output.status.success() => output,
-        _ => return false,
-    };
-
-    let status_json: serde_json::Value = match serde_json::from_slice(&output.stdout) {
-        Ok(json) => json,
-        Err(_) => return false,
-    };
-
-    status_json
-        .get("running")
-        .and_then(serde_json::Value::as_bool)
-        .unwrap_or(false)
-        || fallback_dev_daemon_running()
-}
-
-fn fallback_dev_daemon_running() -> bool {
-    let Some(workspace) = runt_workspace::get_workspace_path() else {
-        return false;
-    };
-
-    let daemon_json = dirs::cache_dir()
-        .unwrap_or_else(|| std::path::PathBuf::from("/tmp"))
-        .join(runt_workspace::cache_namespace())
-        .join("worktrees")
-        .join(runt_workspace::worktree_hash(&workspace))
-        .join("daemon.json");
-
-    daemon_state_is_running(&daemon_json)
-}
-
-fn daemon_state_is_running(path: &Path) -> bool {
-    let Ok(contents) = fs::read_to_string(path) else {
-        return false;
-    };
-    let Ok(info) = serde_json::from_str::<serde_json::Value>(&contents) else {
-        return false;
-    };
-
-    let pid_running = info
-        .get("pid")
-        .and_then(serde_json::Value::as_u64)
-        .map(process_is_running)
+    let status_reports_running = command
+        .output()
+        .ok()
+        .filter(|output| output.status.success())
+        .and_then(|output| serde_json::from_slice::<serde_json::Value>(&output.stdout).ok())
+        .and_then(|status_json| {
+            status_json
+                .get("running")
+                .and_then(serde_json::Value::as_bool)
+        })
         .unwrap_or(false);
-    if pid_running {
-        return true;
-    }
 
-    info.get("endpoint")
-        .and_then(serde_json::Value::as_str)
-        .map(Path::new)
-        .is_some_and(Path::exists)
+    status_reports_running || dev_daemon_socket_reports_running()
 }
 
-fn process_is_running(pid: u64) -> bool {
-    #[cfg(unix)]
-    {
-        Command::new("kill")
-            .args(["-0", &pid.to_string()])
-            .status()
-            .map(|status| status.success())
-            .unwrap_or(false)
-    }
+#[cfg(unix)]
+fn dev_daemon_socket_reports_running() -> bool {
+    use std::os::unix::net::UnixStream;
 
-    #[cfg(not(unix))]
-    {
-        let _ = pid;
-        false
+    let Ok(mut stream) = UnixStream::connect(dev_socket_path()) else {
+        return false;
+    };
+    let timeout = Some(Duration::from_millis(500));
+    let _ = stream.set_read_timeout(timeout);
+    let _ = stream.set_write_timeout(timeout);
+
+    // Lightweight socket-source-of-truth probe. Keep this local to xtask so
+    // `cargo xtask notebook` can detect an already-running dev daemon before
+    // `target/debug/runt` has been built.
+    if stream.write_all(&[0xC0, 0xDE, 0x01, 0xAC, 4]).is_err() {
+        return false;
     }
+    if send_json_frame_sync(&mut stream, &serde_json::json!({ "channel": "pool" })).is_err() {
+        return false;
+    }
+    if send_json_frame_sync(
+        &mut stream,
+        &serde_json::json!({ "type": "get_daemon_info" }),
+    )
+    .is_err()
+    {
+        return false;
+    }
+    let Ok(response) = recv_json_frame_sync(&mut stream) else {
+        return false;
+    };
+    response
+        .get("type")
+        .and_then(serde_json::Value::as_str)
+        .is_some_and(|kind| kind == "daemon_info")
+}
+
+#[cfg(not(unix))]
+fn dev_daemon_socket_reports_running() -> bool {
+    false
+}
+
+fn send_json_frame_sync(stream: &mut impl Write, value: &serde_json::Value) -> std::io::Result<()> {
+    let payload = serde_json::to_vec(value).map_err(std::io::Error::other)?;
+    stream.write_all(&(payload.len() as u32).to_be_bytes())?;
+    stream.write_all(&payload)?;
+    stream.flush()
+}
+
+fn recv_json_frame_sync(stream: &mut impl Read) -> std::io::Result<serde_json::Value> {
+    let mut len_buf = [0u8; 4];
+    stream.read_exact(&mut len_buf)?;
+    let len = u32::from_be_bytes(len_buf) as usize;
+    if len > 64 * 1024 {
+        return Err(std::io::Error::new(
+            std::io::ErrorKind::InvalidData,
+            format!("daemon info response too large: {len} bytes"),
+        ));
+    }
+    let mut payload = vec![0u8; len];
+    stream.read_exact(&mut payload)?;
+    serde_json::from_slice(&payload).map_err(std::io::Error::other)
 }
 
 fn dev_daemon_binary(release: bool) -> PathBuf {

--- a/crates/xtask/src/main.rs
+++ b/crates/xtask/src/main.rs
@@ -4,7 +4,7 @@
 use std::collections::{HashSet, VecDeque};
 use std::env;
 use std::fs;
-use std::io::{BufRead, BufReader, Read, Write};
+use std::io::{BufRead, BufReader};
 use std::path::{Path, PathBuf};
 use std::process::{exit, Child, Command, ExitStatus, Stdio};
 use std::thread;
@@ -2899,6 +2899,7 @@ fn dev_daemon_running() -> bool {
 
 #[cfg(unix)]
 fn dev_daemon_socket_reports_running() -> bool {
+    use std::io::Write as _;
     use std::os::unix::net::UnixStream;
 
     let Ok(mut stream) = UnixStream::connect(dev_socket_path()) else {
@@ -2939,14 +2940,19 @@ fn dev_daemon_socket_reports_running() -> bool {
     false
 }
 
-fn send_json_frame_sync(stream: &mut impl Write, value: &serde_json::Value) -> std::io::Result<()> {
+#[cfg(unix)]
+fn send_json_frame_sync(
+    stream: &mut impl std::io::Write,
+    value: &serde_json::Value,
+) -> std::io::Result<()> {
     let payload = serde_json::to_vec(value).map_err(std::io::Error::other)?;
     stream.write_all(&(payload.len() as u32).to_be_bytes())?;
     stream.write_all(&payload)?;
     stream.flush()
 }
 
-fn recv_json_frame_sync(stream: &mut impl Read) -> std::io::Result<serde_json::Value> {
+#[cfg(unix)]
+fn recv_json_frame_sync(stream: &mut impl std::io::Read) -> std::io::Result<serde_json::Value> {
     let mut len_buf = [0u8; 4];
     stream.read_exact(&mut len_buf)?;
     let len = u32::from_be_bytes(len_buf) as usize;

--- a/packages/notebook-host/src/relay-bootstrap.ts
+++ b/packages/notebook-host/src/relay-bootstrap.ts
@@ -7,6 +7,7 @@ export interface RelayBootstrapCoordinatorOptions {
   onReady: (cb: (payload: DaemonReadyPayload) => void) => Unlisten;
   requiresReadyGeneration: boolean;
   beforeBootstrap?: (trigger: RelayBootstrapTrigger) => void;
+  prepareRelay?: (generation?: number) => Promise<void>;
   bootstrap: (isCancelled: () => boolean, trigger: RelayBootstrapTrigger) => Promise<boolean>;
   notifyRelayReady: (generation?: number) => Promise<void>;
   onBootstrapError?: (error: unknown, trigger: RelayBootstrapTrigger) => void;
@@ -72,11 +73,17 @@ export function startRelayBootstrapCoordinator(
           return EMPTY;
         }
 
-        return from(options.bootstrap(isCancelled, trigger)).pipe(
+        const generation = trigger.payload.relay_generation;
+        const bootstrap$ = options.prepareRelay
+          ? from(options.prepareRelay(generation)).pipe(
+              switchMap(() => options.bootstrap(isCancelled, trigger)),
+            )
+          : from(options.bootstrap(isCancelled, trigger));
+
+        return bootstrap$.pipe(
           switchMap((bootstrapped) => {
             if (!bootstrapped || isCancelled()) return EMPTY;
 
-            const generation = trigger.payload.relay_generation;
             return from(options.notifyRelayReady(generation)).pipe(
               catchError((error: unknown) => {
                 options.onNotifyError?.(error, generation);

--- a/packages/notebook-host/src/tauri/index.ts
+++ b/packages/notebook-host/src/tauri/index.ts
@@ -214,6 +214,11 @@ export function createTauriHost(opts: CreateTauriHostOptions = {}): NotebookHost
 
   const relay: HostRelay = {
     requiresReadyGeneration: true,
+    async prepareSync(generation?: number) {
+      if (canSubscribeNotebookFrames(transport)) {
+        await transport.subscribeNotebookFrames(generation);
+      }
+    },
     async notifySyncReady(generation?: number) {
       let frameChannelError: unknown;
       if (canSubscribeNotebookFrames(transport)) {

--- a/packages/notebook-host/src/types.ts
+++ b/packages/notebook-host/src/types.ts
@@ -190,6 +190,13 @@ export interface HostRelay {
   readonly requiresReadyGeneration: boolean;
 
   /**
+   * Attach the host frame listener for the current relay generation before
+   * the frontend sends its bootstrap sync frame. Hosts that do not buffer
+   * frames can omit this.
+   */
+  prepareSync?(generation?: number): Promise<void>;
+
+  /**
    * Signal that the JS frame listener is attached and the Tauri-side
    * relay may replay any buffered frames. Matches the existing
    * `notify_sync_ready` Tauri command. No-op in hosts where the main

--- a/packages/notebook-host/tests/relay-bootstrap.test.ts
+++ b/packages/notebook-host/tests/relay-bootstrap.test.ts
@@ -103,6 +103,69 @@ describe("startRelayBootstrapCoordinator", () => {
     coordinator.stop();
   });
 
+  it("prepares the relay channel before bootstrap", async () => {
+    const ready = createReadySource();
+    const order: string[] = [];
+    const prepareRelay = vi.fn(async () => {
+      order.push("prepare");
+    });
+    const bootstrap = vi.fn(async () => {
+      order.push("bootstrap");
+      return true;
+    });
+    const notifyRelayReady = vi.fn(async () => {
+      order.push("notify");
+    });
+
+    const coordinator = startCoordinator({
+      onReady: ready.onReady,
+      prepareRelay,
+      bootstrap,
+      notifyRelayReady,
+    });
+
+    ready.emit({ notebook_id: "nb-1", relay_generation: 7 });
+    await flushMicrotasks();
+
+    expect(prepareRelay).toHaveBeenCalledWith(7);
+    expect(bootstrap).toHaveBeenCalledTimes(1);
+    expect(notifyRelayReady).toHaveBeenCalledWith(7);
+    expect(order).toEqual(["prepare", "bootstrap", "notify"]);
+
+    coordinator.stop();
+  });
+
+  it("does not bootstrap when relay preparation fails", async () => {
+    const ready = createReadySource();
+    const error = new Error("stale frame channel");
+    const prepareRelay = vi.fn(async () => {
+      throw error;
+    });
+    const bootstrap = vi.fn(async () => true);
+    const notifyRelayReady = vi.fn(async () => {});
+    const onBootstrapError = vi.fn();
+
+    const coordinator = startCoordinator({
+      onReady: ready.onReady,
+      prepareRelay,
+      bootstrap,
+      notifyRelayReady,
+      onBootstrapError,
+    });
+
+    ready.emit({ notebook_id: "nb-1", relay_generation: 7 });
+    await flushMicrotasks();
+
+    expect(bootstrap).not.toHaveBeenCalled();
+    expect(notifyRelayReady).not.toHaveBeenCalled();
+    expect(onBootstrapError).toHaveBeenCalledWith(error, {
+      kind: "ready",
+      payload: { notebook_id: "nb-1", relay_generation: 7 },
+    });
+
+    coordinator.stop();
+  });
+
   it("applies the daemon actor label before creating the notebook handle", async () => {
     const ready = createReadySource();
     const authoritativeActor = "local:quill/desktop:daemon";

--- a/packages/notebook-host/tests/tauri-host.test.ts
+++ b/packages/notebook-host/tests/tauri-host.test.ts
@@ -373,6 +373,23 @@ describe("createTauriHost()", () => {
     ).toBeUndefined();
   });
 
+  it("relay.prepareSync registers the frame channel before sync ready", async () => {
+    const subscribeNotebookFrames = vi.fn(async () => {});
+    const host = createTauriHost({
+      transport: {
+        ...stubTransport,
+        subscribeNotebookFrames,
+      } as NotebookTransport & {
+        subscribeNotebookFrames(generation?: number): Promise<void>;
+      },
+    });
+
+    await host.relay.prepareSync?.(7);
+
+    expect(subscribeNotebookFrames).toHaveBeenCalledWith(7);
+    expect(capturedInvokes.at(-1)?.cmd).not.toBe("notify_sync_ready");
+  });
+
   it("relay.notifySyncReady still notifies Rust when frame channel registration fails", async () => {
     const frameChannelError = new Error("stale generation");
     const subscribeNotebookFrames = vi.fn(async () => {


### PR DESCRIPTION
## Summary

- Rebind the Tauri notebook frame channel before each frontend bootstrap so HMR or manual webview reloads can receive daemon frames in the new JS world.
- Make the Rust relay read the current same-generation frame channel for every frame instead of holding the first channel forever.
- Detect an already-running dev daemon by probing the worktree socket instead of relying on `daemon.json`, which is being retired.

## Why

Vite HMR could leave the desktop notebook stuck after reload: the new frontend registered a replacement Tauri channel, but the Rust relay kept sending sync frames to the old channel captured before reload. The new `SyncEngine` could announce readiness, then never receive the session-control frame that makes the notebook interactive.

## Verification

- `cargo xtask lint --fix`
- `pnpm test:run packages/notebook-host/tests/relay-bootstrap.test.ts packages/notebook-host/tests/tauri-host.test.ts`
- `cargo check -p notebook`
- `cargo test -p xtask`
- `cargo test -p notebook sync_ready`
