### PR TITLE
refactor(runtimed): lift runtime-state projections into shared fluent RxJS store

### DIFF
--- a/apps/notebook-cloud/viewer/cloud-viewer-session.ts
+++ b/apps/notebook-cloud/viewer/cloud-viewer-session.ts
@@ -1,10 +1,5 @@
 import { useCallback, useEffect, useRef, useState, type MutableRefObject } from "react";
-import {
-  notebookShellWorkstationAttachmentCacheKey,
-  type BlobResolver,
-  type CommChanges,
-  type WorkstationAttachmentState,
-} from "runtimed";
+import { type BlobResolver, type CommChanges } from "runtimed";
 import {
   applyWidgetCommBroadcastToStore,
   applyWidgetCommChangesToStore,
@@ -96,7 +91,6 @@ export interface CloudViewerSession {
   retryLiveConnection: () => void;
   snapshotResolvedRef: MutableRefObject<boolean>;
   status: ViewerStatus;
-  workstationAttachment: WorkstationAttachmentState | null;
 }
 
 interface UseCloudViewerSessionOptions {
@@ -139,10 +133,7 @@ export function useCloudViewerSession({
   });
   const [, setCells] = useState<ResolvedCell[]>([]);
   const [notebookMetadata, setNotebookMetadata] = useState<unknown>(null);
-  const [workstationAttachment, setWorkstationAttachment] =
-    useState<WorkstationAttachmentState | null>(null);
   const notebookLanguageRef = useRef("python");
-  const workstationAttachmentKeyRef = useRef(notebookShellWorkstationAttachmentCacheKey(null));
   const liveRuntimeRef = useRef<CloudSyncRuntime | null>(null);
   const materializeLiveRuntimeRef = useRef<((runtime: CloudSyncRuntime) => void) | null>(null);
   const liveMaterializedRef = useRef(false);
@@ -403,8 +394,10 @@ export function useCloudViewerSession({
       setConnectionScope(null);
       setConnectionActorLabel(null);
       setConnectionError(reason.message);
-      setWorkstationAttachment(null);
-      workstationAttachmentKeyRef.current = notebookShellWorkstationAttachmentCacheKey(null);
+      // Workstation attachment lives in the shared runtime-state store;
+      // resetRuntimeState() below (via disposeCurrentRuntime/reconnect)
+      // clears it through the workstation$ projection.
+      resetRuntimeState();
       disposeCurrentRuntime();
       if (reconnectTimer) return;
       reconnectTimer = setTimeout(() => {
@@ -526,8 +519,7 @@ export function useCloudViewerSession({
     materializeLiveRuntimeRef.current = materializeLiveCellsSafely;
 
     presenceStore.reset();
-    setWorkstationAttachment(null);
-    workstationAttachmentKeyRef.current = notebookShellWorkstationAttachmentCacheKey(null);
+    resetRuntimeState();
     setConnectionError(null);
     setConnectionActorLabel(null);
     setConnectionPeerId(null);
@@ -599,14 +591,11 @@ export function useCloudViewerSession({
               console.warn("[notebook-cloud] live changeset materialization failed", error);
             },
           }),
+          // Workstation attachment is consumed via the shared store's
+          // deduplicated workstation$ projection (useWorkstationAttachment);
+          // no per-host shadow state.
           liveRuntime.engine.runtimeState$.subscribe((state) => {
             setRuntimeState(state);
-            const nextAttachment = state.workstation ?? null;
-            const nextKey = notebookShellWorkstationAttachmentCacheKey(nextAttachment);
-            if (nextKey !== workstationAttachmentKeyRef.current) {
-              workstationAttachmentKeyRef.current = nextKey;
-              setWorkstationAttachment(nextAttachment);
-            }
           }),
           liveRuntime.engine.executionViewChanges$.subscribe((changeset) => {
             applyExecutionViewChangeset(changeset);
@@ -651,8 +640,7 @@ export function useCloudViewerSession({
         setConnectionScope(null);
         setConnectionActorLabel(null);
         setConnectionPeerId(null);
-        setWorkstationAttachment(null);
-        workstationAttachmentKeyRef.current = notebookShellWorkstationAttachmentCacheKey(null);
+        resetRuntimeState();
         setConnectionError(message);
         void diagnoseCloudConnectionAccess({
           accessRequestsEndpoint: config.accessRequestsEndpoint,
@@ -691,8 +679,6 @@ export function useCloudViewerSession({
       livePresenceStore = null;
       presenceStore.reduceConnection("disconnected");
       setConnectionPeerId(null);
-      setWorkstationAttachment(null);
-      workstationAttachmentKeyRef.current = notebookShellWorkstationAttachmentCacheKey(null);
     };
   }, [
     authRenewalKind,
@@ -735,7 +721,6 @@ export function useCloudViewerSession({
     retryLiveConnection,
     snapshotResolvedRef,
     status,
-    workstationAttachment,
   };
 }
 

--- a/apps/notebook-cloud/viewer/notebook-viewer.tsx
+++ b/apps/notebook-cloud/viewer/notebook-viewer.tsx
@@ -56,6 +56,7 @@ import {
   PresenceValueProvider,
   getCellById,
   useRuntimeState,
+  useWorkstationAttachment,
   type PresenceContextValue,
 } from "../../notebook/src/notebook-surface";
 import { beginOidcLogin } from "./oidc-auth";
@@ -197,7 +198,6 @@ export function NotebookViewer({
     retryLiveConnection,
     snapshotResolvedRef,
     status,
-    workstationAttachment,
   } = useCloudViewerSession({
     authRenewalKind: authRenewal.kind,
     authState,
@@ -223,6 +223,9 @@ export function NotebookViewer({
     presenceStore.getSnapshot,
   );
   const runtimeState = useRuntimeState();
+  // Deduplicated shared projection — re-renders only when attachment facts
+  // change, not on every runtime tick (was per-host shadow state).
+  const workstationAttachment = useWorkstationAttachment();
   const runtimePeerCount = cloudPresenceRuntimePeerCount(presenceSnapshot);
   const runtimePeerAvailable = cloudPresenceHasRuntimePeer(presenceSnapshot);
   const outputHostContext = useMemo<NteractEmbedHostContextPatch>(

--- a/apps/notebook/src/hooks/useDaemonKernel.ts
+++ b/apps/notebook/src/hooks/useDaemonKernel.ts
@@ -7,21 +7,15 @@
  */
 
 import { useNotebookHost } from "@nteract/notebook-host";
-import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { useCallback, useEffect, useRef } from "react";
 import {
   type DaemonQueueState,
   type DependencyGuard,
-  deriveEnvSyncState,
-  deriveKernelInfo,
-  deriveQueueState,
   type ExecuteCellOptions,
   type GuardedNotebookProvenance,
   type KernelStatus,
   type NotebookClient,
   type NotebookResponse,
-  RUNTIME_STATUS,
-  runtimeStatusKey,
-  type RuntimeStatusKey,
   statusKeyToLegacyStatus,
 } from "runtimed";
 import { refreshBlobPort, resetBlobPort } from "../lib/blob-port";
@@ -35,7 +29,10 @@ import {
   diffExecutions,
   type ExecutionState,
   resetRuntimeState,
+  runtimeStateStore,
+  useRuntimeProjection,
   useRuntimeState,
+  useThrottledStatusKey,
 } from "../lib/runtime-state";
 import { markExecutionPerformance } from "../lib/execution-performance";
 
@@ -67,68 +64,18 @@ export function useDaemonKernel({
 }: UseDaemonKernelOptions) {
   const host = useNotebookHost();
   // ── State from RuntimeStateDoc (daemon-authoritative) ─────────────
+  // Each projection is deduplicated in the shared store, so a daemon tick
+  // that doesn't change the slice doesn't re-render this hook's host.
   const runtimeState = useRuntimeState();
+  const kernelInfo = useRuntimeProjection(runtimeStateStore.kernelInfo$);
+  const queueState = useRuntimeProjection(runtimeStateStore.queueState$);
+  const envSyncState = useRuntimeProjection(runtimeStateStore.envSyncState$);
 
-  const kernelInfo = useMemo(() => deriveKernelInfo(runtimeState), [runtimeState]);
-
-  const queueState = useMemo(() => deriveQueueState(runtimeState), [runtimeState]);
-
-  const envSyncState = useMemo(() => deriveEnvSyncState(runtimeState), [runtimeState]);
-
-  // ── Busy throttle ────────────────────────────────────────────────
-  // Project the typed lifecycle into the flat `RuntimeStatusKey`
-  // vocabulary and throttle the `RUNNING_BUSY` ↔ `RUNNING_IDLE`
-  // transition so quick execute/idle cycles don't flash "busy" at the
-  // user. Non-Running keys (starting sub-phases, error, shutdown) pass
-  // through untouched — they carry richer sub-state the toolbar wants
-  // to render verbatim.
-  const rawStatusKey = runtimeStatusKey(runtimeState.kernel.lifecycle);
-  const [throttledStatusKey, setThrottledStatusKey] = useState<RuntimeStatusKey>(rawStatusKey);
-  const busyTimerRef = useRef<number | null>(null);
-  const prevRawStatusKeyRef = useRef(rawStatusKey);
-
-  useEffect(() => {
-    const prev = prevRawStatusKeyRef.current;
-    prevRawStatusKeyRef.current = rawStatusKey;
-    if (rawStatusKey === prev) return;
-
-    if (rawStatusKey === RUNTIME_STATUS.RUNNING_BUSY) {
-      // Delay committing BUSY by 60ms — if IDLE arrives first, the
-      // pending commit is cancelled below and the user never sees a
-      // busy flash.
-      if (busyTimerRef.current === null) {
-        busyTimerRef.current = window.setTimeout(() => {
-          busyTimerRef.current = null;
-          setThrottledStatusKey(RUNTIME_STATUS.RUNNING_BUSY);
-        }, 60);
-      }
-    } else if (
-      rawStatusKey === RUNTIME_STATUS.RUNNING_IDLE ||
-      rawStatusKey === RUNTIME_STATUS.RUNNING_UNKNOWN
-    ) {
-      if (busyTimerRef.current !== null) {
-        clearTimeout(busyTimerRef.current);
-        busyTimerRef.current = null;
-      } else {
-        setThrottledStatusKey(rawStatusKey);
-      }
-    } else {
-      if (busyTimerRef.current !== null) {
-        clearTimeout(busyTimerRef.current);
-        busyTimerRef.current = null;
-      }
-      setThrottledStatusKey(rawStatusKey);
-    }
-
-    return () => {
-      if (busyTimerRef.current !== null) {
-        clearTimeout(busyTimerRef.current);
-        busyTimerRef.current = null;
-      }
-    };
-  }, [rawStatusKey]);
-
-  const statusKey = throttledStatusKey;
+  // Status key with the busy flash suppressed — the shared
+  // `throttleBusyStatus` pipeline holds RUNNING_BUSY back 60ms so quick
+  // execute/idle cycles never flash "busy". Non-Running keys (starting
+  // sub-phases, error, shutdown) pass through untouched.
+  const statusKey = useThrottledStatusKey();
   const kernelStatus: KernelStatus = statusKeyToLegacyStatus(statusKey);
 
   // ── Callbacks in refs (avoid effect re-runs) ──────────────────────
@@ -269,10 +216,6 @@ export function useDaemonKernel({
 
     return () => {
       cancelled = true;
-      if (busyTimerRef.current !== null) {
-        clearTimeout(busyTimerRef.current);
-        busyTimerRef.current = null;
-      }
       unsubscribeBroadcast();
       unlistenDisconnect();
       unlistenReady();

--- a/apps/notebook/src/lib/runtime-state.ts
+++ b/apps/notebook/src/lib/runtime-state.ts
@@ -1,8 +1,10 @@
 /**
  * Runtime state store — reactive state from the daemon's RuntimeStateDoc.
  *
- * Types and diffing logic live in the `runtimed` package (pure, no React).
- * This module adds the React-specific store (useSyncExternalStore) on top.
+ * The reactive store and its projections live in the `runtimed` package
+ * (`RuntimeStateStore`, pure RxJS, no React). This module instantiates the
+ * app-wide store and adds the React bindings (useSyncExternalStore) on top,
+ * so both desktop and cloud consume the same projection pipeline.
  */
 
 import { useSyncExternalStore } from "react";
@@ -18,6 +20,7 @@ export type {
   QueueState,
   RuntimeState,
   TrustState,
+  WorkstationAttachmentState,
 } from "runtimed";
 
 export {
@@ -25,45 +28,37 @@ export {
   diffExecutions,
 } from "runtimed";
 
-import { DEFAULT_RUNTIME_STATE, type RuntimeState } from "runtimed";
+import {
+  RuntimeStateStore,
+  type RuntimeState,
+  type RuntimeStatusKey,
+  type WorkstationAttachmentState,
+} from "runtimed";
+import type { Observable } from "rxjs";
 
 // ── Store ────────────────────────────────────────────────────────────
 
-let currentState: RuntimeState = DEFAULT_RUNTIME_STATE;
-// Tracks whether the daemon has pushed at least one RuntimeStateDoc frame
-// since connect/reset. While false, `currentState` is the static default,
-// and fields like `trust.status` must NOT be used as authoritative signals
-// (the default "no_dependencies" would fail-open a trust gate).
-let loaded = false;
-const subscribers = new Set<() => void>();
-
-function notifySubscribers(): void {
-  for (const cb of subscribers) {
-    try {
-      cb();
-    } catch {
-      // Subscriber errors must not break the dispatch loop
-    }
-  }
-}
+/**
+ * App-wide runtime-state store. Both the desktop sync bridge and the cloud
+ * viewer session push daemon snapshots here; all projections
+ * (kernelInfo$, queueState$, workstation$, throttledStatusKey$, …) hang
+ * off this instance.
+ */
+export const runtimeStateStore = new RuntimeStateStore();
 
 /** Update the runtime state snapshot. Called by the frame pipeline. */
 export function setRuntimeState(state: RuntimeState): void {
-  currentState = state;
-  loaded = true;
-  notifySubscribers();
+  runtimeStateStore.set(state);
 }
 
 /** Reset to default state (e.g., on disconnect). */
 export function resetRuntimeState(): void {
-  currentState = DEFAULT_RUNTIME_STATE;
-  loaded = false;
-  notifySubscribers();
+  runtimeStateStore.reset();
 }
 
 /** Read the current snapshot (non-reactive). */
 export function getRuntimeState(): RuntimeState {
-  return currentState;
+  return runtimeStateStore.snapshot;
 }
 
 /**
@@ -73,20 +68,56 @@ export function getRuntimeState(): RuntimeState {
  * means the current snapshot is `DEFAULT_RUNTIME_STATE`, not a real read.
  */
 export function isRuntimeStateLoaded(): boolean {
-  return loaded;
+  return runtimeStateStore.isLoaded;
 }
 
-// ── React hook ───────────────────────────────────────────────────────
+// ── React bindings ───────────────────────────────────────────────────
 
-function subscribe(cb: () => void): () => void {
-  subscribers.add(cb);
-  return () => {
-    subscribers.delete(cb);
-  };
+/**
+ * Per-observable binding cache so `getSnapshot` returns the same value
+ * between emissions — `useSyncExternalStore` requires snapshot stability
+ * to avoid render loops. Projections derive from a BehaviorSubject, so the
+ * first subscription seeds the cached value synchronously.
+ */
+const projectionCache = new WeakMap<
+  Observable<unknown>,
+  { subscribe: (cb: () => void) => () => void; getSnapshot: () => unknown }
+>();
+
+function bindingFor<T>(observable: Observable<T>): {
+  subscribe: (cb: () => void) => () => void;
+  getSnapshot: () => T;
+} {
+  let binding = projectionCache.get(observable as Observable<unknown>);
+  if (!binding) {
+    let current: unknown;
+    const seed = observable.subscribe((value) => {
+      current = value;
+    });
+    seed.unsubscribe();
+    binding = {
+      subscribe: (cb: () => void) => {
+        const sub = observable.subscribe((value) => {
+          current = value;
+          cb();
+        });
+        return () => sub.unsubscribe();
+      },
+      getSnapshot: () => current,
+    };
+    projectionCache.set(observable as Observable<unknown>, binding);
+  }
+  return binding as { subscribe: (cb: () => void) => () => void; getSnapshot: () => T };
 }
 
-function getSnapshot(): RuntimeState {
-  return currentState;
+/**
+ * Subscribe a React component to a projection observable from the shared
+ * store. The observable must emit synchronously on subscribe (all
+ * `RuntimeStateStore` projections do).
+ */
+export function useRuntimeProjection<T>(observable: Observable<T>): T {
+  const binding = bindingFor(observable);
+  return useSyncExternalStore(binding.subscribe, binding.getSnapshot, binding.getSnapshot);
 }
 
 /**
@@ -96,7 +127,7 @@ function getSnapshot(): RuntimeState {
  * Automerge sync. The frontend never writes to this state.
  */
 export function useRuntimeState(): RuntimeState {
-  return useSyncExternalStore(subscribe, getSnapshot, getSnapshot);
+  return useRuntimeProjection(runtimeStateStore.state$);
 }
 
 /**
@@ -104,5 +135,24 @@ export function useRuntimeState(): RuntimeState {
  * "no snapshot yet" to "first snapshot applied" (and back on reset).
  */
 export function useRuntimeStateLoaded(): boolean {
-  return useSyncExternalStore(subscribe, () => loaded, () => loaded);
+  return useRuntimeProjection(runtimeStateStore.loaded$);
+}
+
+/**
+ * Workstation attachment, deduplicated by the attachment cache key —
+ * re-renders only when attachment facts change, not on every daemon tick.
+ * Shared by desktop and cloud (replaces cloud's shadow state; see
+ * `shared-store-projection-convergence.md` item 2).
+ */
+export function useWorkstationAttachment(): WorkstationAttachmentState | null {
+  return useRuntimeProjection(runtimeStateStore.workstation$);
+}
+
+/**
+ * Lifecycle status key with the busy flash suppressed (the shared
+ * `throttleBusyStatus` pipeline). This is the stream UI status chips
+ * should render.
+ */
+export function useThrottledStatusKey(): RuntimeStatusKey {
+  return useRuntimeProjection(runtimeStateStore.throttledStatusKey$);
 }

--- a/apps/notebook/src/notebook-surface.ts
+++ b/apps/notebook/src/notebook-surface.ts
@@ -26,9 +26,13 @@ export type { JupyterOutput } from "./types";
 export { resetPoolState, setPoolState } from "./lib/pool-state";
 export {
   resetRuntimeState,
+  runtimeStateStore,
   setRuntimeState,
+  useRuntimeProjection,
   useRuntimeState,
   useRuntimeStateLoaded,
+  useThrottledStatusKey,
+  useWorkstationAttachment,
 } from "./lib/runtime-state";
 export { startCursorDispatch } from "./lib/cursor-registry";
 export { setLoggerHost } from "./lib/logger";

--- a/docs/adr/shared-store-projection-convergence.md
+++ b/docs/adr/shared-store-projection-convergence.md
@@ -36,6 +36,16 @@ the flush strands the update (marked dirty, never emitted).
   `useState` shadow. It reads `useFocusedCellId()` and routes programmatic focus
   through `setFocusedCellId` + `flushCellUIState` (the NotebookView set+flush
   pattern), dropping the host bridge double-buffer.
+- **Runtime-state projections → `RuntimeStateStore`** (runtime-state RxJS
+  projection pass). The runtime-state store itself moved out of the desktop app
+  into `packages/runtimed/src/runtime-state-store.ts`: a BehaviorSubject-backed
+  store with fluent `select()` and deduplicated projections (`kernelInfo$`,
+  `queueState$`, `envSyncState$`, `workstation$`, `statusKey$`,
+  `throttledStatusKey$`). The busy-flash throttle that lived as an imperative
+  `setTimeout` effect in `useDaemonKernel` is now the shared, virtual-time-
+  testable `throttleBusyStatus` pipeline. Desktop's
+  `apps/notebook/src/lib/runtime-state.ts` is a thin React adapter
+  (`useRuntimeProjection`) over the package store; item 2 below rode this.
 
 ## Remaining work (ranked)
 
@@ -52,21 +62,16 @@ output focus, reconnect) before merge.
    Esc/iframe focus paths are not reproducible in unit tests. New
    `src/components/notebook/state/output-focus-store.ts`.
 
-2. **Cloud `workstationAttachment` → shared runtime-state store.**
-   `cloud-viewer-session.ts` holds a `workstationAttachment` `useState` that is a
-   copy of `useRuntimeState().workstation` (the same subscription pushes the full
-   state via `setRuntimeState`). #3515 strengthens this: the worker now publishes
-   workstation claim progress into RuntimeStateDoc
-   (`publishWorkstationAttachJobRuntimeState` -> room `setWorkstationAttachment`,
-   via the pure `projectNotebookWorkstationAttachmentFromClaim`), so the
-   attachment is a RuntimeStateDoc-owned fact end to end and the session's
-   `useState` is clearly a shadow of the projected runtime state. Hazard: it is
-   deduped by `workstationAttachmentKeyRef` to avoid re-renders on unchanged
-   attachments, and reset in four disconnect/room-change sites. A naive
-   `useRuntimeState().workstation` re-renders on every runtime tick and changes
-   reset timing. Converge by consuming the projected attachment through an
-   equality-aware selector (e.g. `useRuntimeStateWorkstation()`) on the
-   runtime-state store, preserving the reset sites' clear-on-disconnect behavior.
+2. ~~**Cloud `workstationAttachment` → shared runtime-state store.**~~ **Done**
+   in the runtime-state RxJS projection pass. The shared store is now
+   `RuntimeStateStore` (`packages/runtimed/src/runtime-state-store.ts`), whose
+   `workstation$` projection dedups by
+   `notebookShellWorkstationAttachmentCacheKey` — the same equality the old
+   `workstationAttachmentKeyRef` enforced, but shared by every subscriber.
+   The session's `useState` shadow, its key ref, and all per-site clears are
+   deleted; disconnect/room-change sites call `resetRuntimeState()` and the
+   projection emits null through the same pipeline. Both hosts consume
+   `useWorkstationAttachment()` from the shared runtime-state module.
 
 3. **Rail/outline chrome (`activeRailPanel`, `railCollapsed`,
    `selectedOutlineItemId`) → shared `rail-ui-state` store.** Declared identically

--- a/packages/runtimed/src/index.ts
+++ b/packages/runtimed/src/index.ts
@@ -40,6 +40,9 @@ export {
   type SessionControlMessage,
 } from "./protocol-contract";
 
+// Reactive runtime-state store (framework-agnostic RxJS projections)
+export { BUSY_THROTTLE_MS, RuntimeStateStore, throttleBusyStatus } from "./runtime-state-store";
+
 // Scope capabilities (generated from nteract_identity::ConnectionScope)
 export {
   CONNECTION_SCOPES,

--- a/packages/runtimed/src/runtime-state-store.ts
+++ b/packages/runtimed/src/runtime-state-store.ts
@@ -1,0 +1,226 @@
+/**
+ * Reactive runtime-state store — framework-agnostic projections over the
+ * daemon's RuntimeStateDoc snapshots.
+ *
+ * One BehaviorSubject of `RuntimeState` plus fluent, deduplicated
+ * projections. Hosts (desktop bridge, cloud viewer session) push snapshots
+ * with `set()`; consumers subscribe to a projection observable or read the
+ * synchronous snapshot. React bindings stay in the apps — this module has
+ * no framework dependency, so projections are testable headlessly and any
+ * future host (CLI, MCP surface) consumes the same streams.
+ *
+ * Why projections live here and not in `useMemo` chains: a `useMemo` on the
+ * whole `RuntimeState` recomputes (and re-renders its component) on every
+ * daemon tick, even when the projected slice is unchanged. A
+ * `distinctUntilChanged` projection emits only when its slice actually
+ * changes, and that dedup is shared by every subscriber instead of
+ * re-derived per component instance. See
+ * `docs/adr/shared-store-projection-convergence.md`.
+ */
+
+import {
+  BehaviorSubject,
+  Observable,
+  defer,
+  distinctUntilChanged,
+  map,
+  of,
+  shareReplay,
+  startWith,
+  switchMap,
+  timer,
+} from "rxjs";
+import {
+  deriveEnvSyncState,
+  deriveKernelInfo,
+  deriveQueueState,
+  runtimeStatusKey,
+  RUNTIME_STATUS,
+  type EnvSyncState,
+  type KernelInfo,
+  type DaemonQueueState,
+  type RuntimeStatusKey,
+} from "./derived-state";
+import { notebookShellWorkstationAttachmentCacheKey } from "./notebook-shell-capabilities";
+import {
+  DEFAULT_RUNTIME_STATE,
+  type RuntimeState,
+  type WorkstationAttachmentState,
+} from "./runtime-state";
+
+/**
+ * How long a `RUNNING_BUSY` transition is held back before being shown.
+ * Quick execute→idle cycles complete inside this window, so the user never
+ * sees a "busy" flash for trivial executions.
+ */
+export const BUSY_THROTTLE_MS = 60;
+
+/**
+ * Hold back `RUNNING_BUSY` so quick execute→idle cycles never flash "busy".
+ *
+ * Every non-busy key emits immediately and cancels any pending busy commit
+ * (`switchMap` drops the in-flight timer). Only the busy key waits
+ * [`BUSY_THROTTLE_MS`] before committing. This is the pipeline form of the
+ * imperative `setTimeout` throttle that used to live in
+ * `useDaemonKernel` — same UX, but shared, declarative, and testable with
+ * virtual time.
+ *
+ * `scheduler` is injectable for tests (pass the TestScheduler's scheduler);
+ * production callers omit it.
+ */
+export function throttleBusyStatus(
+  scheduler?: Parameters<typeof timer>[1],
+): (source: Observable<RuntimeStatusKey>) => Observable<RuntimeStatusKey> {
+  return (source) =>
+    source.pipe(
+      switchMap((key) =>
+        key === RUNTIME_STATUS.RUNNING_BUSY
+          ? timer(BUSY_THROTTLE_MS, scheduler).pipe(map(() => key))
+          : of(key),
+      ),
+      distinctUntilChanged(),
+    );
+}
+
+/**
+ * Reactive store over daemon RuntimeStateDoc snapshots.
+ *
+ * The store itself is host-agnostic: desktop's sync bridge and the cloud
+ * viewer session both `set()` snapshots from `SyncEngine.runtimeState$`,
+ * and both apps' React hooks subscribe to the same projections.
+ */
+export class RuntimeStateStore {
+  private readonly _state$ = new BehaviorSubject<RuntimeState>(DEFAULT_RUNTIME_STATE);
+  private readonly _loaded$ = new BehaviorSubject<boolean>(false);
+
+  /** Every snapshot pushed by the host, starting with the default state. */
+  readonly state$: Observable<RuntimeState> = this._state$.asObservable();
+
+  /**
+   * Whether the daemon has pushed at least one snapshot since
+   * connect/reset. While false, the current snapshot is
+   * `DEFAULT_RUNTIME_STATE` and fields like `trust.status` must not be
+   * treated as authoritative (the default would fail-open trust gates).
+   */
+  readonly loaded$: Observable<boolean> = this._loaded$.pipe(distinctUntilChanged());
+
+  /** Kernel type + env source. Emits only when the projection changes. */
+  readonly kernelInfo$: Observable<KernelInfo> = this.select(deriveKernelInfo, kernelInfoEquals);
+
+  /** Executing/queued entries. Emits only when queue membership changes. */
+  readonly queueState$: Observable<DaemonQueueState> = this.select(
+    deriveQueueState,
+    queueStateEquals,
+  );
+
+  /**
+   * Environment sync state (null = unknown: pre-launch, shutdown, error).
+   * Emits only when sync status or the diff changes.
+   */
+  readonly envSyncState$: Observable<EnvSyncState | null> = this.select(
+    deriveEnvSyncState,
+    envSyncStateEquals,
+  );
+
+  /**
+   * Raw lifecycle status key (no busy throttle). For UI status chips,
+   * prefer [`RuntimeStateStore.throttledStatusKey$`].
+   */
+  readonly statusKey$: Observable<RuntimeStatusKey> = this.select((state) =>
+    runtimeStatusKey(state.kernel.lifecycle),
+  );
+
+  /**
+   * Lifecycle status key with the busy flash suppressed
+   * ([`throttleBusyStatus`], window [`BUSY_THROTTLE_MS`]). This is the
+   * stream UI status indicators should render.
+   *
+   * Shared (`shareReplay`) so all subscribers ride one throttle pipeline
+   * and late subscribers get the current value synchronously. Seeded with
+   * the raw key at first subscribe — matching the old hook, a mount during
+   * a busy phase shows busy immediately; only *transitions* into busy are
+   * held back.
+   */
+  readonly throttledStatusKey$: Observable<RuntimeStatusKey> = defer(() =>
+    this.statusKey$.pipe(
+      throttleBusyStatus(),
+      startWith(runtimeStatusKey(this.snapshot.kernel.lifecycle)),
+      distinctUntilChanged(),
+    ),
+  ).pipe(shareReplay({ bufferSize: 1, refCount: false }));
+
+  /**
+   * Workstation attachment, deduplicated by
+   * [`notebookShellWorkstationAttachmentCacheKey`] so consumers re-render
+   * only when attachment facts actually change — not on every daemon tick.
+   * Replaces per-host shadow state (see
+   * `shared-store-projection-convergence.md` item 2).
+   */
+  readonly workstation$: Observable<WorkstationAttachmentState | null> = this.select(
+    (state) => state.workstation ?? null,
+    (a, b) =>
+      notebookShellWorkstationAttachmentCacheKey(a) ===
+      notebookShellWorkstationAttachmentCacheKey(b),
+  );
+
+  /**
+   * Fluent projection builder: derive a slice of `RuntimeState` and emit it
+   * only when it changes. `equals` defaults to `Object.is`; pass a
+   * structural comparator when the projector allocates.
+   */
+  select<T>(
+    project: (state: RuntimeState) => T,
+    equals: (a: T, b: T) => boolean = Object.is,
+  ): Observable<T> {
+    return this._state$.pipe(map(project), distinctUntilChanged(equals));
+  }
+
+  /** Current snapshot (synchronous, non-reactive). */
+  get snapshot(): RuntimeState {
+    return this._state$.getValue();
+  }
+
+  /** Whether a real snapshot has been applied since connect/reset. */
+  get isLoaded(): boolean {
+    return this._loaded$.getValue();
+  }
+
+  /** Push a new daemon snapshot. Host bridges call this. */
+  set(state: RuntimeState): void {
+    this._loaded$.next(true);
+    this._state$.next(state);
+  }
+
+  /** Reset to the default state (disconnect, room change). */
+  reset(): void {
+    this._loaded$.next(false);
+    this._state$.next(DEFAULT_RUNTIME_STATE);
+  }
+}
+
+function kernelInfoEquals(a: KernelInfo, b: KernelInfo): boolean {
+  return a.kernelType === b.kernelType && a.envSource === b.envSource;
+}
+
+function queueStateEquals(a: DaemonQueueState, b: DaemonQueueState): boolean {
+  if (a.executing?.execution_id !== b.executing?.execution_id) return false;
+  if (a.queued.length !== b.queued.length) return false;
+  return a.queued.every((entry, i) => entry.execution_id === b.queued[i]?.execution_id);
+}
+
+function envSyncStateEquals(a: EnvSyncState | null, b: EnvSyncState | null): boolean {
+  if (a === b) return true;
+  if (a === null || b === null) return false;
+  if (a.inSync !== b.inSync) return false;
+  if (a.diff === undefined || b.diff === undefined) return a.diff === b.diff;
+  return (
+    a.diff.channelsChanged === b.diff.channelsChanged &&
+    a.diff.denoChanged === b.diff.denoChanged &&
+    arrayEquals(a.diff.added, b.diff.added) &&
+    arrayEquals(a.diff.removed, b.diff.removed)
+  );
+}
+
+function arrayEquals(a: readonly string[], b: readonly string[]): boolean {
+  return a.length === b.length && a.every((value, i) => value === b[i]);
+}

--- a/packages/runtimed/tests/runtime-state-store.test.ts
+++ b/packages/runtimed/tests/runtime-state-store.test.ts
@@ -1,0 +1,164 @@
+import {
+  BUSY_THROTTLE_MS,
+  DEFAULT_RUNTIME_STATE,
+  RUNTIME_STATUS,
+  RuntimeStateStore,
+  throttleBusyStatus,
+  type RuntimeState,
+  type RuntimeStatusKey,
+} from "runtimed";
+import { Subject } from "rxjs";
+import { TestScheduler } from "rxjs/testing";
+import { describe, expect, it } from "vite-plus/test";
+
+function stateWith(overrides: Partial<RuntimeState>): RuntimeState {
+  return { ...DEFAULT_RUNTIME_STATE, ...overrides };
+}
+
+function runningState(activity: "Idle" | "Busy" | "Unknown"): RuntimeState {
+  return stateWith({
+    kernel: {
+      ...DEFAULT_RUNTIME_STATE.kernel,
+      lifecycle: { lifecycle: "Running", activity },
+    },
+  });
+}
+
+function collect<T>(observable: { subscribe: (next: (value: T) => void) => unknown }): T[] {
+  const values: T[] = [];
+  observable.subscribe((value) => values.push(value));
+  return values;
+}
+
+describe("RuntimeStateStore", () => {
+  it("starts unloaded with the default snapshot", () => {
+    const store = new RuntimeStateStore();
+    expect(store.isLoaded).toBe(false);
+    expect(store.snapshot).toBe(DEFAULT_RUNTIME_STATE);
+  });
+
+  it("set() marks loaded and emits; reset() returns to default", () => {
+    const store = new RuntimeStateStore();
+    const loaded = collect(store.loaded$);
+    store.set(runningState("Idle"));
+    expect(store.isLoaded).toBe(true);
+    store.reset();
+    expect(store.isLoaded).toBe(false);
+    expect(store.snapshot).toBe(DEFAULT_RUNTIME_STATE);
+    expect(loaded).toEqual([false, true, false]);
+  });
+
+  it("select() dedups with the provided equality", () => {
+    const store = new RuntimeStateStore();
+    const seen = collect(store.select((state) => state.kernel.lifecycle.lifecycle));
+    store.set(runningState("Idle"));
+    store.set(runningState("Busy"));
+    expect(seen).toEqual(["NotStarted", "Running"]);
+  });
+
+  it("kernelInfo$ emits only when kernel type or env source changes", () => {
+    const store = new RuntimeStateStore();
+    const seen = collect(store.kernelInfo$);
+    store.set(runningState("Idle"));
+    store.set(runningState("Busy"));
+    store.set(
+      stateWith({
+        kernel: {
+          ...runningState("Busy").kernel,
+          language: "python",
+          env_source: "uv:prewarmed",
+        },
+      }),
+    );
+    expect(seen).toEqual([
+      { kernelType: undefined, envSource: undefined },
+      { kernelType: "python", envSource: "uv:prewarmed" },
+    ]);
+  });
+
+  it("queueState$ dedups on queue membership, not snapshot identity", () => {
+    const store = new RuntimeStateStore();
+    const seen = collect(store.queueState$);
+    const queued = stateWith({
+      queue: { executing: { execution_id: "e1" }, queued: [{ execution_id: "e2" }] },
+    });
+    store.set(queued);
+    // Same queue content, new snapshot object — must not re-emit.
+    store.set(stateWith({ queue: { ...queued.queue } }));
+    store.set(stateWith({ queue: { executing: null, queued: [] } }));
+    expect(seen.map((q) => q.executing?.execution_id ?? null)).toEqual([null, "e1", null]);
+  });
+
+  it("workstation$ dedups by attachment cache key across daemon ticks", () => {
+    const store = new RuntimeStateStore();
+    const attachment = {
+      workstation_id: "w1",
+      display_name: "Lab box",
+      provider: "outerbounds",
+      default_environment_label: "py311",
+      environment_policy: "current_python",
+      status: "connected",
+    };
+    const seen = collect(store.workstation$);
+    store.set(stateWith({ workstation: attachment }));
+    // New object, same facts — a runtime tick that didn't change attachment.
+    store.set(stateWith({ workstation: { ...attachment } }));
+    store.set(stateWith({ workstation: { ...attachment, status: "disconnected" } }));
+    store.set(stateWith({ workstation: undefined }));
+    expect(seen.map((w) => w?.status ?? null)).toEqual([null, "connected", "disconnected", null]);
+  });
+});
+
+describe("throttleBusyStatus", () => {
+  function withScheduler(
+    run: (helpers: {
+      scheduler: TestScheduler;
+      source: Subject<RuntimeStatusKey>;
+      emitted: RuntimeStatusKey[];
+    }) => void,
+  ): void {
+    const scheduler = new TestScheduler((actual, expected) => {
+      expect(actual).toEqual(expected);
+    });
+    scheduler.run(() => {
+      const source = new Subject<RuntimeStatusKey>();
+      const emitted: RuntimeStatusKey[] = [];
+      source.pipe(throttleBusyStatus(scheduler)).subscribe((key) => emitted.push(key));
+      run({ scheduler, source, emitted });
+    });
+  }
+
+  it("suppresses a busy flash shorter than the throttle window", () => {
+    withScheduler(({ scheduler, source, emitted }) => {
+      source.next(RUNTIME_STATUS.RUNNING_IDLE);
+      source.next(RUNTIME_STATUS.RUNNING_BUSY);
+      // Idle arrives before the busy timer fires — busy never shows.
+      scheduler.schedule(() => source.next(RUNTIME_STATUS.RUNNING_IDLE), BUSY_THROTTLE_MS - 1);
+      scheduler.flush();
+      expect(emitted).toEqual([RUNTIME_STATUS.RUNNING_IDLE]);
+    });
+  });
+
+  it("commits busy after the throttle window elapses", () => {
+    withScheduler(({ scheduler, source, emitted }) => {
+      source.next(RUNTIME_STATUS.RUNNING_IDLE);
+      source.next(RUNTIME_STATUS.RUNNING_BUSY);
+      scheduler.schedule(() => source.next(RUNTIME_STATUS.RUNNING_IDLE), BUSY_THROTTLE_MS + 10);
+      scheduler.flush();
+      expect(emitted).toEqual([
+        RUNTIME_STATUS.RUNNING_IDLE,
+        RUNTIME_STATUS.RUNNING_BUSY,
+        RUNTIME_STATUS.RUNNING_IDLE,
+      ]);
+    });
+  });
+
+  it("passes non-running keys through immediately, cancelling pending busy", () => {
+    withScheduler(({ scheduler, source, emitted }) => {
+      source.next(RUNTIME_STATUS.RUNNING_BUSY);
+      source.next(RUNTIME_STATUS.ERROR);
+      scheduler.flush();
+      expect(emitted).toEqual([RUNTIME_STATUS.ERROR]);
+    });
+  });
+});


### PR DESCRIPTION
## Why

Derived notebook/runtime state should live in **shared projections outside React** with fluent RxJS APIs, consumed identically by desktop and cloud — the LNP-1 pattern, generalized. This simplifies the code (less bespoke React plumbing) while keeping UX identical-or-better: projection dedup is shared across subscribers instead of re-derived per component, and timing behavior becomes headlessly testable. Follow-up to #3523.

## What landed

### `RuntimeStateStore` in `packages/runtimed` (new)
BehaviorSubject-backed reactive store over `RuntimeState` with a fluent `select(project, equals?)` API (`distinctUntilChanged` built in) and prebuilt deduplicated projections:

- `kernelInfo$`, `queueState$`, `envSyncState$` — structural equality, so a daemon tick that doesn't change the slice doesn't reach React at all
- `workstation$` — deduped by the existing `notebookShellWorkstationAttachmentCacheKey`
- `statusKey$` / `throttledStatusKey$` — lifecycle status, raw and busy-flash-suppressed
- `state$`, `loaded$`, synchronous `snapshot`/`isLoaded`, `set()`/`reset()` for host bridges

### Busy-flash throttle → shared RxJS pipeline
`useDaemonKernel`'s ~45-line `useEffect`/`useRef`/`setTimeout` debounce (hold `RUNNING_BUSY` 60ms; cancel if idle lands first) is now `throttleBusyStatus` — a `switchMap` + `timer` pipeline with an injectable scheduler, **tested with virtual time** (TestScheduler). Cloud gets the same UX for free via `useThrottledStatusKey()`.

### Cloud `workstationAttachment` shadow state deleted (convergence ADR item 2)
The `useState` + cache-key ref + four per-site clears in `cloud-viewer-session.ts` collapse into the shared `workstation$` projection consumed via `useWorkstationAttachment()`. Reset sites call `resetRuntimeState()`; the equality guard the ref used to enforce now lives once, in the projection.

### Desktop `runtime-state.ts` → thin React adapter
The module now instantiates the app-wide `RuntimeStateStore` and binds projections via a generic `useRuntimeProjection(observable)` (`useSyncExternalStore` with a per-observable snapshot cache). All existing APIs (`useRuntimeState`, `useRuntimeStateLoaded`, `setRuntimeState`, `resetRuntimeState`, `getRuntimeState`, `isRuntimeStateLoaded`) are unchanged for consumers.

### ADR updates
`shared-store-projection-convergence.md`: records the store move + throttle lift under Done, marks item 2 (workstation attachment) done with the mechanism.

## Verification
- New `runtime-state-store.test.ts`: 9 tests — store semantics, projection dedup (incl. queue-membership and attachment-cache-key equality), and virtual-time throttle behavior (flash suppressed below window, committed after, non-running keys cancel pending busy).
- `packages/`: 433 passed. Desktop suite: **620/620**. Cloud Worker: tsc clean, **555/555**. `cargo xtask lint` clean.

## Possible follow-ups (not in this PR)
- Convergence item 1: `outputFocusedCellId` → shared store (needs browser smoke for the deferred-flush race guard).
- A dedicated `executionQueueProjection$` on `SyncEngine` for queue-only consumers.
- FSB-1/FSB-2 (output-changeset error surface; CI guard for stable DOM order).

🤖 Generated with [Claude Code](https://claude.com/claude-code)