### PR TITLE
fix(notebook-cloud): preserve notebook mode in hosted chrome

### DIFF
--- a/apps/notebook-cloud/test/notebook-dashboard.test.ts
+++ b/apps/notebook-cloud/test/notebook-dashboard.test.ts
@@ -1,6 +1,7 @@
 import assert from "node:assert/strict";
 import { describe, it } from "node:test";
 import {
+  cloudNotebookDashboardOpenUrl,
   cloudNotebookDisplayTitle,
   cloudNotebookShortId,
   projectCloudNotebookDashboard,
@@ -119,6 +120,50 @@ describe("cloud notebook dashboard projection", () => {
           notebooks: ["01KTHB58DSJWERSEWHD3EJD74P", "01KSQKEPFJVHV4T4ZDYS9V7T80"],
         },
       ],
+    );
+  });
+
+  it("opens owned notebooks in edit mode while preserving shared notebooks in view mode", () => {
+    const owned = notebook({
+      id: "owned-notebook",
+      title: "Owned notebook",
+      scope: "owner",
+      updatedAt: "2026-06-07T15:00:00.000Z",
+      latestRevisionId: null,
+    });
+    const editor = notebook({
+      id: "editor-notebook",
+      title: "Editor notebook",
+      scope: "editor",
+      updatedAt: "2026-06-07T15:00:00.000Z",
+      latestRevisionId: null,
+    });
+    const viewer = notebook({
+      id: "viewer-notebook",
+      title: "Viewer notebook",
+      scope: "viewer",
+      updatedAt: "2026-06-07T15:00:00.000Z",
+      latestRevisionId: null,
+    });
+
+    assert.equal(cloudNotebookDashboardOpenUrl(owned), "/n/owned-notebook/notebook?mode=edit");
+    assert.equal(cloudNotebookDashboardOpenUrl(editor), "/n/editor-notebook/notebook?mode=view");
+    assert.equal(cloudNotebookDashboardOpenUrl(viewer), "/n/viewer-notebook/notebook?mode=view");
+  });
+
+  it("replaces any stale dashboard mode parameter without losing hash anchors", () => {
+    const owned = notebook({
+      id: "owned-notebook",
+      title: "Owned notebook",
+      scope: "owner",
+      updatedAt: "2026-06-07T15:00:00.000Z",
+      latestRevisionId: null,
+    });
+    owned.viewer_url = "http://localhost/n/owned-notebook/Owned%20notebook?mode=view#section-a";
+
+    assert.equal(
+      cloudNotebookDashboardOpenUrl(owned),
+      "http://localhost/n/owned-notebook/Owned%20notebook?mode=edit#section-a",
     );
   });
 

--- a/apps/notebook-cloud/test/viewer-render-props.test.ts
+++ b/apps/notebook-cloud/test/viewer-render-props.test.ts
@@ -115,6 +115,8 @@ test("cloud viewer routes notebook header controls through the shared shell chro
   const presenceSourceText = readFileSync(presenceSourcePath, "utf8");
   const sharingSourcePath = new URL("../viewer/sharing-controls.tsx", import.meta.url);
   const sharingSourceText = readFileSync(sharingSourcePath, "utf8");
+  const titleSourcePath = new URL("../viewer/cloud-notebook-title.tsx", import.meta.url);
+  const titleSourceText = readFileSync(titleSourcePath, "utf8");
   const cssPath = new URL("../viewer/index.css", import.meta.url);
   const cssText = readFileSync(cssPath, "utf8");
 
@@ -131,6 +133,9 @@ test("cloud viewer routes notebook header controls through the shared shell chro
   assert.match(sourceText, /<NotebookDocumentToolbar[\s\S]*capabilities=\{shellCapabilities\}/);
   assert.match(sourceText, /presence=\{<CloudNotebookTitle \/>/);
   assert.match(sourceText, /import \{ CloudNotebookTitle \} from "\.\/cloud-notebook-title";/);
+  assert.match(titleSourceText, /className="cloud-notebook-home-link"/);
+  assert.match(titleSourceText, /<House aria-hidden="true" \/>/);
+  assert.doesNotMatch(titleSourceText, /cloud-notebook-logo/);
   assert.doesNotMatch(sourceText, /function shouldShowCloudNotebookCommandToolbar/);
   assert.doesNotMatch(sourceText, /toolbarClassName="cloud-report-toolbar"/);
   assert.match(sourceText, /sharingControls=\{[\s\S]*<CloudSharingControls/);
@@ -228,7 +233,7 @@ test("cloud viewer routes notebook header controls through the shared shell chro
   );
   assert.match(
     cssText,
-    /@media \(max-width: 900px\) \{[\s\S]*cloud-room-toolbar[\s\S]*flex-wrap: wrap;[\s\S]*cloud-room-toolbar \[data-slot="notebook-document-header-controls"\] \{[\s\S]*min-width: 0;/,
+    /@media \(max-width: 900px\) \{[\s\S]*cloud-room-toolbar[\s\S]*flex-wrap: nowrap;[\s\S]*cloud-room-toolbar \[data-slot="notebook-document-header-controls"\] \{[\s\S]*min-width: 0;[\s\S]*justify-content: flex-end;/,
   );
   assert.match(
     cssText,

--- a/apps/notebook-cloud/test/viewer-shared-cell-surface.test.ts
+++ b/apps/notebook-cloud/test/viewer-shared-cell-surface.test.ts
@@ -393,7 +393,15 @@ test("cloud host notices sit in the shared shell above the rail and notebook sta
   assert.match(cssText, /\.cloud-notebook-notices \{[\s\S]*top: var\(--cloud-notice-top\);/);
   assert.match(
     cssText,
-    /@media \(max-width: 900px\) \{[\s\S]*\.cloud-notebook-shell \{[\s\S]*--cloud-notice-top: 4\.75rem;[\s\S]*\.cloud-notebook-shell--command-toolbar \{[\s\S]*--cloud-notice-top: calc\(4\.75rem \+ 2\.5rem\);/,
+    /@media \(max-width: 900px\) \{[\s\S]*\.cloud-notebook-shell \{[\s\S]*--cloud-notice-top: 3\.75rem;[\s\S]*\.cloud-notebook-shell--command-toolbar \{[\s\S]*--cloud-notice-top: calc\(3\.75rem \+ 2\.5rem\);/,
+  );
+  assert.match(
+    cssText,
+    /@media \(max-width: 900px\) \{[\s\S]*\.cloud-room-toolbar \{[\s\S]*flex-wrap: nowrap;/,
+  );
+  assert.match(
+    cssText,
+    /@media \(max-width: 900px\) \{[\s\S]*\.cloud-room-toolbar \[data-slot="notebook-document-header-controls"\] \{[\s\S]*justify-content: flex-end;/,
   );
   assert.match(
     shellText,

--- a/apps/notebook-cloud/viewer/cloud-notebook-dashboard-view.tsx
+++ b/apps/notebook-cloud/viewer/cloud-notebook-dashboard-view.tsx
@@ -12,6 +12,7 @@ import {
   X,
 } from "lucide-react";
 import {
+  cloudNotebookDashboardOpenUrl,
   cloudNotebookDisplayTitle,
   cloudNotebookShortId,
   projectCloudNotebookDashboardView,
@@ -72,7 +73,10 @@ export function CloudNotebookDashboard({
               ))}
             </div>
           </div>
-          <a className="cloud-dashboard-primary-link" href={continued.notebook.viewer_url}>
+          <a
+            className="cloud-dashboard-primary-link"
+            href={cloudNotebookDashboardOpenUrl(continued.notebook)}
+          >
             Open notebook
             <ExternalLink aria-hidden="true" />
           </a>
@@ -294,6 +298,7 @@ function CloudNotebookDashboardRow({
   }
 
   const { notebook } = row;
+  const openUrl = cloudNotebookDashboardOpenUrl(notebook);
   const hasTitle = Boolean(notebook.title?.trim());
   const detail = hasTitle
     ? row.contextLabel
@@ -303,7 +308,7 @@ function CloudNotebookDashboardRow({
 
   return (
     <div className="cloud-notebook-list-row">
-      <a className="cloud-notebook-list-main" href={notebook.viewer_url}>
+      <a className="cloud-notebook-list-main" href={openUrl}>
         <span className="cloud-notebook-list-title">{cloudNotebookDisplayTitle(notebook)}</span>
         {detail ? <span className="cloud-notebook-list-detail">{detail}</span> : null}
         {row.facts.length > 0 ? (
@@ -332,7 +337,7 @@ function CloudNotebookDashboardRow({
         ) : null}
         <a
           className="cloud-notebook-list-icon-button"
-          href={notebook.viewer_url}
+          href={openUrl}
           title="Open notebook"
           aria-label={`Open ${cloudNotebookDisplayTitle(notebook)}`}
         >

--- a/apps/notebook-cloud/viewer/cloud-notebook-mode.ts
+++ b/apps/notebook-cloud/viewer/cloud-notebook-mode.ts
@@ -1,0 +1,43 @@
+export type CloudNotebookUrlMode = "edit" | "view";
+
+export function cloudNotebookModeFromSearch(search: string): CloudNotebookUrlMode {
+  const params = new URLSearchParams(search);
+  return normalizeCloudNotebookMode(params.get("mode"));
+}
+
+export function cloudNotebookUrlWithMode(href: string, mode: CloudNotebookUrlMode): string {
+  const trimmed = href.trim();
+  if (!trimmed) {
+    return `?mode=${mode}`;
+  }
+
+  try {
+    const parsed = new URL(trimmed, "https://nteract.invalid");
+    parsed.searchParams.set("mode", mode);
+    if (isAbsoluteUrl(trimmed) || trimmed.startsWith("//")) {
+      return parsed.href;
+    }
+    return `${parsed.pathname}${parsed.search}${parsed.hash}`;
+  } catch {
+    const joiner = trimmed.includes("?") ? "&" : "?";
+    return `${trimmed}${joiner}mode=${encodeURIComponent(mode)}`;
+  }
+}
+
+export function replaceCloudNotebookModeInCurrentUrl(mode: CloudNotebookUrlMode): void {
+  const nextUrl = new URL(window.location.href);
+  nextUrl.searchParams.set("mode", mode);
+  const next = `${nextUrl.pathname}${nextUrl.search}${nextUrl.hash}`;
+  const current = `${window.location.pathname}${window.location.search}${window.location.hash}`;
+  if (next !== current) {
+    window.history.replaceState(window.history.state, "", next);
+  }
+}
+
+function normalizeCloudNotebookMode(value: string | null): CloudNotebookUrlMode {
+  return value === "edit" ? "edit" : "view";
+}
+
+function isAbsoluteUrl(value: string): boolean {
+  return /^[a-z][a-z\d+\-.]*:/i.test(value);
+}

--- a/apps/notebook-cloud/viewer/cloud-notebook-title.tsx
+++ b/apps/notebook-cloud/viewer/cloud-notebook-title.tsx
@@ -1,10 +1,22 @@
+import { House } from "lucide-react";
+
 export function CloudNotebookTitle() {
   const title = cloudNotebookRouteTitle();
 
   return (
-    <div className="cloud-notebook-title" title={title.title}>
-      <span>{title.label}</span>
-      {title.detail ? <small>{title.detail}</small> : null}
+    <div className="cloud-notebook-title-group">
+      <a
+        className="cloud-notebook-home-link"
+        href="/n"
+        aria-label="Open notebooks dashboard"
+        title="Notebooks"
+      >
+        <House aria-hidden="true" />
+      </a>
+      <div className="cloud-notebook-title" title={title.title}>
+        <span>{title.label}</span>
+        {title.detail ? <small>{title.detail}</small> : null}
+      </div>
     </div>
   );
 }

--- a/apps/notebook-cloud/viewer/index.css
+++ b/apps/notebook-cloud/viewer/index.css
@@ -75,7 +75,7 @@ body {
 .cloud-room-toolbar {
   min-height: 3.75rem;
   border-bottom: 1px solid var(--border);
-  padding-inline: clamp(0.75rem, 4vw, 2rem) clamp(0.5rem, 2vw, 1rem);
+  padding-inline: 0.5rem clamp(0.5rem, 2vw, 1rem);
 }
 
 .cloud-room-toolbar [data-slot="notebook-document-header-presence"] {
@@ -97,6 +97,40 @@ body {
   min-width: 0;
   max-width: 100%;
   text-align: left;
+}
+
+.cloud-notebook-title-group {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  min-width: 0;
+  max-width: 100%;
+}
+
+.cloud-notebook-home-link {
+  display: inline-flex;
+  flex: 0 0 auto;
+  align-items: center;
+  justify-content: center;
+  width: 2rem;
+  height: 2rem;
+  border-radius: 6px;
+  color: color-mix(in srgb, var(--foreground) 74%, transparent);
+  text-decoration: none;
+}
+
+.cloud-notebook-home-link:hover {
+  background: color-mix(in srgb, var(--background) 88%, var(--foreground) 8%);
+}
+
+.cloud-notebook-home-link:focus-visible {
+  outline: 2px solid color-mix(in srgb, var(--ring) 70%, transparent);
+  outline-offset: 2px;
+}
+
+.cloud-notebook-home-link svg {
+  width: 1.125rem;
+  height: 1.125rem;
 }
 
 .cloud-notebook-title span,
@@ -214,31 +248,31 @@ body {
 
 @media (max-width: 900px) {
   .cloud-notebook-shell {
-    --cloud-notice-top: 4.75rem;
+    --cloud-notice-top: 3.75rem;
   }
 
   .cloud-notebook-shell--command-toolbar {
-    --cloud-notice-top: calc(4.75rem + 2.5rem);
+    --cloud-notice-top: calc(3.75rem + 2.5rem);
   }
 
   .cloud-room-toolbar {
-    min-height: 4.75rem;
-    flex-wrap: wrap;
+    min-height: 3.75rem;
+    flex-wrap: nowrap;
     align-content: center;
-    justify-content: flex-start;
-    gap: 0.375rem 0.75rem;
-    padding-block: 0.5rem;
+    justify-content: space-between;
+    gap: 0.375rem;
+    padding-block: 0.375rem;
   }
 
   .cloud-room-toolbar [data-slot="notebook-document-header-presence"] {
-    flex: 1 1 100%;
+    flex: 1 1 auto;
     max-width: none;
   }
 
   .cloud-room-toolbar [data-slot="notebook-document-header-controls"] {
-    flex: 1 1 100%;
+    flex: 0 0 auto;
     min-width: 0;
-    justify-content: flex-start;
+    justify-content: flex-end;
     gap: 0.25rem 0.625rem;
   }
 
@@ -253,7 +287,7 @@ body {
   .cloud-share-menu > summary,
   .cloud-auth-menu > summary,
   .cloud-sign-in-button {
-    max-width: min(12rem, 32vw);
+    max-width: min(10rem, 28vw);
     padding-inline: 0.375rem;
   }
 }
@@ -266,7 +300,15 @@ body {
   .cloud-share-menu > summary,
   .cloud-auth-menu > summary,
   .cloud-sign-in-button {
-    max-width: min(9rem, 30vw);
+    width: 2.25rem;
+    max-width: 2.25rem;
+    padding-inline: 0;
+  }
+
+  .cloud-share-menu > summary span,
+  .cloud-auth-menu > summary span,
+  .cloud-sign-in-button span {
+    display: none;
   }
 }
 
@@ -1860,7 +1902,8 @@ main.flex > .cloud-report-toolbar {
 
 @media (max-width: 640px) {
   .cloud-share-panel {
-    left: max(0.75rem, env(safe-area-inset-left));
+    right: max(0.75rem, env(safe-area-inset-right));
+    left: auto;
     width: auto;
   }
 

--- a/apps/notebook-cloud/viewer/notebook-dashboard.ts
+++ b/apps/notebook-cloud/viewer/notebook-dashboard.ts
@@ -1,3 +1,5 @@
+import { cloudNotebookUrlWithMode, type CloudNotebookUrlMode } from "./cloud-notebook-mode";
+
 export interface CloudNotebookListItem {
   notebook_id: string;
   title: string | null;
@@ -163,12 +165,20 @@ export function cloudNotebookDisplayTitle(notebook: CloudNotebookListItem): stri
   return notebook.title?.trim() || "Untitled notebook";
 }
 
+export function cloudNotebookDashboardOpenUrl(notebook: CloudNotebookListItem): string {
+  return cloudNotebookUrlWithMode(notebook.viewer_url, cloudNotebookDefaultOpenMode(notebook));
+}
+
 export function cloudNotebookShortId(notebookId: string): string {
   const trimmed = notebookId.trim();
   if (trimmed.length <= 12) {
     return trimmed;
   }
   return `${trimmed.slice(0, 8)}...${trimmed.slice(-4)}`;
+}
+
+function cloudNotebookDefaultOpenMode(notebook: CloudNotebookListItem): CloudNotebookUrlMode {
+  return notebook.scope === "owner" ? "edit" : "view";
 }
 
 export function isCloudNotebookListItem(value: unknown): value is CloudNotebookListItem {

--- a/apps/notebook-cloud/viewer/notebook-viewer.tsx
+++ b/apps/notebook-cloud/viewer/notebook-viewer.tsx
@@ -73,6 +73,10 @@ import { preloadSiftWasmForCells } from "./sift-preload";
 import { cloudSourceLanguage } from "./source-language";
 import { clearCloudAppSession, readCloudAppSessionStatus } from "./app-session";
 import { applyDocumentTheme, CLOUD_VIEWER_THEME_STORAGE_KEY } from "./theme";
+import {
+  cloudNotebookModeFromSearch,
+  replaceCloudNotebookModeInCurrentUrl,
+} from "./cloud-notebook-mode";
 import type { CloudViewerAuthConfig, ViewerRuntime } from "./cloud-viewer-types";
 import {
   useCloudAppSessionBridge,
@@ -143,8 +147,9 @@ export function NotebookViewer({
     null,
   );
   const [accessRequestError, setAccessRequestError] = useState<string | null>(null);
-  const [selectedInteractionMode, setSelectedInteractionMode] =
-    useState<NotebookInteractionMode>("view");
+  const [selectedInteractionMode, setSelectedInteractionMode] = useState<NotebookInteractionMode>(
+    () => cloudNotebookModeFromSearch(window.location.search),
+  );
   const [emptyRoomGraceElapsed, setEmptyRoomGraceElapsed] = useState(false);
   const blobResolver = useMemo(
     () =>
@@ -244,6 +249,9 @@ export function NotebookViewer({
   useEffect(() => {
     applyDocumentTheme(resolvedTheme);
   }, [resolvedTheme]);
+  useEffect(() => {
+    replaceCloudNotebookModeInCurrentUrl(selectedInteractionMode);
+  }, [selectedInteractionMode]);
 
   const notebookViewModel = useNotebookViewModel({
     metadata: notebookMetadata,


### PR DESCRIPTION
## Summary
- default owned notebooks from `/n` into `?mode=edit` while shared notebooks stay in view mode
- preserve the selected hosted notebook mode in the URL so reloads keep edit/view intent
- add a quiet dashboard/home affordance at the far-left of hosted notebook chrome, centered over the left rail rhythm
- keep share/auth/view controls on the right at constrained widths instead of wrapping them below the title

## Validation
- `node --import tsx --test test/notebook-dashboard.test.ts test/viewer-shared-cell-surface.test.ts test/viewer-shell-capabilities.test.ts test/viewer-render-props.test.ts` from `apps/notebook-cloud`
- `pnpm --dir apps/notebook-cloud typecheck`
- `cargo xtask lint --fix`
- `pnpm --dir apps/notebook-cloud run deploy:check`
- deployed to preview with `pnpm run deploy` from `apps/notebook-cloud`
- browser-checked preview `/n` and a hosted notebook at 1440px, 520px, and 390px: owner links use `mode=edit`, notebook reload keeps `mode=edit`, controls remain on the right, and the dashboard/home affordance links to `/n` centered at x=24px over the left rail column

## Preview
- Main Worker version: `1ff4cf83-98ec-43d4-8634-61673795160c`
- Renderer assets Worker version: `1167ac4e-7a9b-4a72-97c6-b843a644a05d`
