### PR TITLE
fix(runtimed): box kernel dispatch variants

### DIFF
--- a/crates/runtimed/src/kernel_dispatch.rs
+++ b/crates/runtimed/src/kernel_dispatch.rs
@@ -20,8 +20,8 @@ use crate::protocol::{CompletionItem, HistoryEntry};
 use crate::test_kernel::TestKernel;
 
 pub enum Kernel {
-    Jupyter(JupyterKernel),
-    Test(TestKernel),
+    Jupyter(Box<JupyterKernel>),
+    Test(Box<TestKernel>),
 }
 
 impl Kernel {
@@ -45,10 +45,10 @@ impl KernelConnection for Kernel {
     ) -> Result<(Self, QueueCommandReceivers)> {
         if config.kernel_type == "test" {
             let (k, rx) = TestKernel::launch(config, shared).await?;
-            Ok((Kernel::Test(k), rx))
+            Ok((Kernel::Test(Box::new(k)), rx))
         } else {
             let (k, rx) = JupyterKernel::launch(config, shared).await?;
-            Ok((Kernel::Jupyter(k), rx))
+            Ok((Kernel::Jupyter(Box::new(k)), rx))
         }
     }
 


### PR DESCRIPTION
## Summary
- Box both Kernel dispatch enum variants to satisfy clippy::large_enum_variant on main.
- Keeps the enum dispatch API unchanged and only adds indirection at construction.

## Verification
- git lfs pull
- cargo xtask artifacts ensure sift,renderer
- cargo clippy -p runtimed --all-targets -- -D warnings
- cargo xtask lint --fix

Fixes main Build failure in https://github.com/nteract/nteract/actions/runs/27253147213.