### PR TITLE
docs(agents): refresh AGENTS.md files to match current codebase

### DIFF
--- a/apps/notebook-cloud/AGENTS.md
+++ b/apps/notebook-cloud/AGENTS.md
@@ -69,8 +69,22 @@ Use the narrowest relevant command:
 pnpm --dir apps/notebook-cloud typecheck
 pnpm --dir apps/notebook-cloud test
 pnpm --dir apps/notebook-cloud build:viewer
+
+# Core room smoke
 pnpm --dir apps/notebook-cloud smoke:hosted:live-room
+pnpm --dir apps/notebook-cloud smoke:hosted:collab
+
+# Runtime peer / workstation attach
 pnpm --dir apps/notebook-cloud smoke:hosted:runtime-peer
+pnpm --dir apps/notebook-cloud smoke:hosted:workstation-agent
+pnpm --dir apps/notebook-cloud smoke:hosted:workstation-toolbar
+
+# Browser-side execution
+pnpm --dir apps/notebook-cloud smoke:hosted:browser-execute
+pnpm --dir apps/notebook-cloud smoke:hosted:runtime-browser-execute
+
+# Widget cross-window sync
+pnpm --dir apps/notebook-cloud smoke:hosted:widget-cross-window
 ```
 
 Before committing any repo change, still run the root-required formatter/lint:

--- a/crates/kernel-env/AGENTS.md
+++ b/crates/kernel-env/AGENTS.md
@@ -141,17 +141,15 @@ Kernel is dead at this point so rename is safe.
 
 ## Project file discovery
 
-Unified detection in `crates/runtimed/src/project_file.rs`:
+Unified detection in `crates/runtimed/src/`:
 
 | Module | Purpose |
 |--------|---------|
-| `project_file.rs` | `find_nearest_project_file()` — single walk-up, closest wins |
-| `pyproject.rs` | Parsing, Tauri commands, `find_pyproject()` |
-| `pixi.rs` | Parsing, Tauri commands, `find_pixi_toml()` |
-| `environment_yml.rs` | Parsing, Tauri commands, `find_environment_yml()` |
-| `deno_env.rs` | `find_deno_config()` |
+| `project_file.rs` | `find_nearest_project_file()` — single walk-up, closest wins; handles pyproject.toml, pixi.toml, environment.yml |
+| `pixi_project.rs` | Pixi project launch helpers; offline-tolerant `pixi shell-hook` probe with frozen retry |
+| `uv_project.rs` | UV project launch helpers; `uv run` command construction for pyproject-backed kernels |
 
-All walk-up functions stop at `.git` boundaries and user's home directory.
+Walk-up stops at `.git` boundaries and the user's home directory. Tiebreaker order within a directory: pyproject.toml > pixi.toml > environment.yml.
 
 ## Notebook metadata schema
 

--- a/crates/runtimed/AGENTS.md
+++ b/crates/runtimed/AGENTS.md
@@ -1,6 +1,6 @@
 # Runtime daemon (runtimed)
 
-Scope: `crates/runtimed/**`, `crates/runtimed-client/**`, `crates/runtimed-outputs/**`, `crates/runtimed-service/**`, `crates/runtimed-settings-sync/**`, `crates/runtimed-py/**`, `crates/runtime-doc/**`, `crates/notebook-wire/**`, `crates/notebook-doc/**`, `crates/notebook-protocol/**`, `crates/notebook-sync/**`, `packages/runtimed/**`.
+Scope: `crates/runtimed/**`, `crates/runt/**`, `crates/runtimed-client/**`, `crates/runtimed-outputs/**`, `crates/runtimed-service/**`, `crates/runtimed-settings-sync/**`, `crates/runtimed-py/**`, `crates/runtime-doc/**`, `crates/notebook-wire/**`, `crates/notebook-doc/**`, `crates/notebook-protocol/**`, `crates/notebook-sync/**`, `packages/runtimed/**`.
 
 ## Core principles
 
@@ -187,24 +187,46 @@ runt ps                     # List all kernels
 runt notebooks              # List open notebooks
 ```
 
+### Cloud workstation attach
+
+Remote machines offer compute to hosted notebook rooms via `runtimed cloud-runtime-agent`. The agent dials out over WebSocket — no inbound ports required. See `docs/remote-workstation.md` for the operator path and `docs/adr/remote-workstation-doc-agents.md` for design context.
+
+```bash
+RUNT_CLOUD_TOKEN=<token> runtimed cloud-runtime-agent \
+  --cloud-url https://app.runt.run \
+  --notebook-id <id>
+```
+
+The workstation module lives in `crates/runtimed/src/workstation/`. It handles the cloud agent CLI, launch-on-attach, environment allocation, and reconnect logic.
+
 ## Code structure
 
 ```
 crates/runtimed/src/
-├── main.rs                   # CLI entry point
+├── main.rs                   # CLI entry point (runtimed and cloud-runtime-agent subcommands)
 ├── daemon.rs                 # State, pool management, connection routing
 ├── notebook_sync_server/     # Room lifecycle, peer sync, persistence, metadata/trust
 ├── runtime_agent.rs          # Runtime agent subprocess: peer, CRDT queue, kernel ownership
 ├── runtime_agent_handle.rs   # Coordinator-side agent spawn + monitor
 ├── jupyter_kernel.rs         # Process spawn, ZMQ sockets, IOPub routing
 ├── output_prep.rs            # IOPub → nbformat conversion, widget buffers, blob offload
+├── output_committer.rs       # Output commit pipeline with priority path for control signals
+├── output_blob_publisher.rs  # Blob upload coordination for output manifests
+├── stream_committer.rs       # Stream output (stdout/stderr) batched commit path
+├── stream_terminal.rs        # Terminal emulator for carriage-return/ANSI in stream output
 ├── output_store.rs           # Manifest creation, blob inlining threshold
 ├── blob_store.rs             # Content-addressed storage with metadata sidecars
 ├── blob_server.rs            # HTTP read server (hyper 1.x)
 ├── inline_env.rs             # Inline dependency env caching
-├── project_file.rs           # Project file detection
+├── project_file.rs           # Unified project file detection (closest-wins walk-up)
+├── pixi_project.rs           # Pixi project launch helpers (offline-tolerant shell-hook probe)
+├── uv_project.rs             # UV project launch helpers
+├── workstation/              # Cloud workstation: agent CLI, launch-on-attach, env allocation
+├── cloud_peer.rs             # Hosted cloud peer session (outbound WebSocket runtime_peer)
+├── embedded_plugins.rs       # Renderer plugin bytes embedded at build time
 ├── singleton.rs              # Daemon locking/singleton
-└── sync_server.rs            # Settings Automerge sync
+├── sync_server.rs            # Settings Automerge sync
+└── task_supervisor.rs        # Background task supervision
 ```
 
 ## Shipped app behavior


### PR DESCRIPTION
Three AGENTS.md files were drifting from the code they describe. This PR brings them back in sync.

## `crates/runtimed/AGENTS.md`

- Scope line was missing `crates/runt/**` (the user-facing CLI).
- Code structure section was last updated before the stream output pipeline split, workstation module, and several other files landed. Updated to match the actual `src/` layout.
- Added a "Cloud workstation attach" section documenting `runtimed cloud-runtime-agent` and the `workstation/` module, pointing to the operator doc and ADR for detail.

## `apps/notebook-cloud/AGENTS.md`

Verification section listed only two smoke scripts; the current `package.json` has several more. Expanded and grouped by purpose: core room, workstation attach, browser-side execution, widget cross-window sync.

## `crates/kernel-env/AGENTS.md`

The project file discovery table referenced `pyproject.rs`, `pixi.rs`, `environment_yml.rs`, and `deno_env.rs` — none of which exist. Detection is now in `project_file.rs`, `pixi_project.rs`, and `uv_project.rs`. Table updated accordingly.

Does not touch files in PR #3524 (`apps/notebook/src/lib/runtime-state.ts`, `apps/notebook/src/hooks/useDaemonKernel.ts`, `packages/runtimed/src/runtime-state-store.ts`, `docs/adr/shared-store-projection-convergence.md`).
