### PR TITLE
feat(transport): ConnectionStatus observable and notebookDocChanged$ for local-first persistence

### DIFF
--- a/apps/elements/components/fixture-notebook-host.ts
+++ b/apps/elements/components/fixture-notebook-host.ts
@@ -1,3 +1,4 @@
+import { EMPTY } from "rxjs";
 import type { NotebookHost } from "@nteract/notebook-host";
 
 export const noop = () => {};
@@ -27,6 +28,7 @@ export function createFixtureNotebookHost({
     connected: true,
     disconnect: noop,
     ...transportOverrides,
+    connectionStatus$: transportOverrides.connectionStatus$ ?? EMPTY,
   };
 
   return {

--- a/apps/elements/package.json
+++ b/apps/elements/package.json
@@ -40,6 +40,7 @@
     "@nteract/notebook-host": "workspace:*",
     "portless": "^0.13.0",
     "runtimed": "workspace:*",
+    "rxjs": "^7.8.2",
     "tailwindcss": "^4.3.0",
     "typescript": "~5.8.3"
   }

--- a/apps/notebook-cloud/test/cloud-notebook-host.test.ts
+++ b/apps/notebook-cloud/test/cloud-notebook-host.test.ts
@@ -1,5 +1,6 @@
 import { describe, it } from "node:test";
 import assert from "node:assert/strict";
+import { EMPTY } from "rxjs";
 import type { BlobResolver, NotebookTransport } from "runtimed";
 import { createCloudNotebookHost } from "../viewer/cloud-notebook-host.ts";
 import type { CloudSyncRuntime } from "../viewer/live-sync.ts";
@@ -163,6 +164,7 @@ function createRuntime(
       return { result: label };
     },
     sendTypedRequest: async () => ({ result: "ok" }),
+    connectionStatus$: EMPTY,
   };
 
   return {

--- a/apps/notebook-cloud/viewer/cloud-notebook-host.ts
+++ b/apps/notebook-cloud/viewer/cloud-notebook-host.ts
@@ -1,6 +1,8 @@
 import { createCommandRegistry, type NotebookHost, type Unlisten } from "@nteract/notebook-host";
+import { EMPTY, type Observable } from "rxjs";
 import type {
   BlobResolver,
+  ConnectionStatus,
   FrameListener,
   FrameTypeValue,
   HistoryEntry,
@@ -62,6 +64,12 @@ class CloudNotebookHostTransport implements NotebookTransport {
 
   onFrame(callback: FrameListener): Unlisten {
     return this.getRuntime()?.transport.onFrame(callback) ?? unlisten;
+  }
+
+  // Delegates to the underlying transport's observable. EMPTY when no runtime
+  // is active — the facade is a request router, not a lifecycle owner.
+  get connectionStatus$(): Observable<ConnectionStatus> {
+    return this.getRuntime()?.transport.connectionStatus$ ?? EMPTY;
   }
 
   disconnect(): void {

--- a/apps/notebook-cloud/viewer/live-sync.ts
+++ b/apps/notebook-cloud/viewer/live-sync.ts
@@ -1,5 +1,7 @@
+import { BehaviorSubject, type Observable } from "rxjs";
 import {
   SyncEngine,
+  type ConnectionStatus,
   type FrameTypeValue,
   type NotebookRequest,
   type NotebookRequestOptions,
@@ -239,6 +241,8 @@ export class CloudWebSocketTransport implements NotebookTransport {
   ) => void;
   private readyReject!: (error: Error) => void;
   readonly ready: Promise<Extract<SessionControlMessage, { type: "cloud_room_ready" }>>;
+  private readonly _status$ = new BehaviorSubject<ConnectionStatus>("connecting");
+  readonly connectionStatus$: Observable<ConnectionStatus> = this._status$.asObservable();
 
   constructor(
     url: URL,
@@ -250,6 +254,7 @@ export class CloudWebSocketTransport implements NotebookTransport {
       this.readyResolve = (message) => {
         this.readySettled = true;
         this.readyResolved = true;
+        this._status$.next("online");
         resolve(message);
       };
       this.readyReject = (error) => {
@@ -434,6 +439,7 @@ export class CloudWebSocketTransport implements NotebookTransport {
     this.queuedFrames = [];
     this.rejectPendingFrameAcks(reason);
     if (this.readyResolved && !this.manualDisconnect) {
+      this._status$.next("offline");
       this.onDisconnect?.(reason);
     }
   }

--- a/packages/notebook-host/src/browser/index.ts
+++ b/packages/notebook-host/src/browser/index.ts
@@ -6,9 +6,11 @@
  * the Tauri host receives through its frame channel.
  */
 
+import { BehaviorSubject, type Observable } from "rxjs";
 import {
   FrameType,
   createHttpBlobResolver,
+  type ConnectionStatus,
   type FrameListener,
   type FrameTypeValue,
   type NotebookRequest,
@@ -144,6 +146,8 @@ class BrowserDevTransport implements NotebookTransport {
   private queuedFrames: number[][] = [];
   private framesReleased = false;
   private _connected = false;
+  private readonly _status$ = new BehaviorSubject<ConnectionStatus>("connecting");
+  readonly connectionStatus$: Observable<ConnectionStatus> = this._status$.asObservable();
 
   constructor(
     config: BrowserRelayConfig,
@@ -171,6 +175,7 @@ class BrowserDevTransport implements NotebookTransport {
 
     this.framesReleased = false;
     this.queuedFrames = [];
+    this._status$.next("connecting");
     this.connectPromise = new Promise((resolve, reject) => {
       const ws = new this.WebSocketImpl(this.url);
       ws.binaryType = "arraybuffer";
@@ -178,6 +183,7 @@ class BrowserDevTransport implements NotebookTransport {
 
       ws.onopen = () => {
         this._connected = true;
+        this._status$.next("online");
         resolve();
       };
       ws.onerror = () => {
@@ -189,6 +195,7 @@ class BrowserDevTransport implements NotebookTransport {
         const wasConnected = this._connected;
         this._connected = false;
         this.connectPromise = null;
+        this._status$.next("offline");
         this.rejectPending(new Error("browser relay disconnected"));
         if (wasConnected) this.onControl({ type: "disconnected" });
       };
@@ -260,6 +267,7 @@ class BrowserDevTransport implements NotebookTransport {
 
   disconnect(): void {
     this._connected = false;
+    this._status$.next("offline");
     this.ws?.close();
     this.ws = null;
     this.subscribers.clear();

--- a/packages/notebook-host/src/tauri/transport.ts
+++ b/packages/notebook-host/src/tauri/transport.ts
@@ -14,8 +14,10 @@
  */
 
 import { Channel, invoke } from "@tauri-apps/api/core";
+import { BehaviorSubject, type Observable } from "rxjs";
 import {
   FrameType,
+  type ConnectionStatus,
   type FrameTypeValue,
   type FrameListener,
   type NotebookRequest,
@@ -64,6 +66,8 @@ export class TauriTransport implements NotebookTransport {
   private frameChannelSubscription: Promise<void> | null = null;
   /** In-flight requests keyed by correlation id. */
   private pending = new Map<string, PendingEntry>();
+  private readonly _status$ = new BehaviorSubject<ConnectionStatus>("online");
+  readonly connectionStatus$: Observable<ConnectionStatus> = this._status$.asObservable();
 
   get connected(): boolean {
     return this._connected;
@@ -145,6 +149,7 @@ export class TauriTransport implements NotebookTransport {
 
   disconnect(): void {
     this._connected = false;
+    this._status$.next("offline");
     this.subscribers.clear();
     // Reject any still-pending requests so callers don't hang.
     for (const [id, entry] of this.pending) {

--- a/packages/notebook-host/tests/tauri-host.test.ts
+++ b/packages/notebook-host/tests/tauri-host.test.ts
@@ -135,12 +135,14 @@ vi.mock("@tauri-apps/plugin-updater", () => ({
   }),
 }));
 
+import { EMPTY } from "rxjs";
 import type { NotebookTransport } from "runtimed";
 import { createTauriHost } from "../src/tauri";
 
 /** Minimal NotebookTransport double — just enough to satisfy the type. */
 const stubTransport: NotebookTransport = {
   connected: true,
+  connectionStatus$: EMPTY,
   sendFrame: vi.fn(),
   onFrame: vi.fn(() => () => {}),
   sendRequest: vi.fn(),

--- a/packages/runtimed/src/direct-transport.ts
+++ b/packages/runtimed/src/direct-transport.ts
@@ -21,8 +21,11 @@
  * ```
  */
 
+import { BehaviorSubject, type Observable } from "rxjs";
+
 import { FrameType } from "./transport";
 import type {
+  ConnectionStatus,
   FrameListener,
   FrameTypeValue,
   NotebookRequestOptions,
@@ -64,6 +67,8 @@ export class DirectTransport implements NotebookTransport {
   private readonly server: ServerHandle;
   private subscribers = new Set<FrameListener>();
   private _connected = true;
+  private readonly _status$ = new BehaviorSubject<ConnectionStatus>("online");
+  readonly connectionStatus$: Observable<ConnectionStatus> = this._status$.asObservable();
 
   /** Track sent frames for test assertions. */
   readonly sentFrames: Array<{ frameType: number; payload: Uint8Array }> = [];
@@ -182,6 +187,7 @@ export class DirectTransport implements NotebookTransport {
 
   disconnect(): void {
     this._connected = false;
+    this._status$.next("offline");
     this.subscribers.clear();
   }
 
@@ -282,5 +288,6 @@ export class DirectTransport implements NotebookTransport {
   /** Reconnect after a disconnect. */
   reconnect(): void {
     this._connected = true;
+    this._status$.next("online");
   }
 }

--- a/packages/runtimed/src/index.ts
+++ b/packages/runtimed/src/index.ts
@@ -10,7 +10,12 @@ export { SyncEngine } from "./sync-engine";
 export type { PresenceHeartbeatOptions, SyncEngineOptions, SyncEngineLogger } from "./sync-engine";
 
 // Transport
-export type { FrameListener, NotebookRequestOptions, NotebookTransport } from "./transport";
+export type {
+  ConnectionStatus,
+  FrameListener,
+  NotebookRequestOptions,
+  NotebookTransport,
+} from "./transport";
 export {
   FrameType,
   MAX_CONTROL_FRAME_SIZE,

--- a/packages/runtimed/src/sync-engine.ts
+++ b/packages/runtimed/src/sync-engine.ts
@@ -393,6 +393,18 @@ export class SyncEngine {
    */
   readonly initialSyncComplete$: Observable<void>;
 
+  /**
+   * Fires whenever the notebook CRDT document changes due to an incoming sync.
+   *
+   * Each emission corresponds to a `sync_applied` event with `changed=true`.
+   * Persistence consumers should debounce this and call `handle.save()` to
+   * snapshot the `NotebookDoc` bytes for local storage.
+   *
+   * Note: only `NotebookDoc` bytes should be persisted — `RuntimeStateDoc` is
+   * daemon-authoritative and must not be stored locally.
+   */
+  readonly notebookDocChanged$: Observable<void>;
+
   // Backing subjects for public observables
   private readonly _cellChanges$ = new Subject<CellChangeset | null>();
   private readonly _broadcasts$ = new Subject<unknown>();
@@ -408,6 +420,7 @@ export class SyncEngine {
     removed_ids: string[];
   }>();
   private readonly _executionViewChanges$ = new Subject<ExecutionViewChangeset>();
+  private readonly _notebookDocChanged$ = new Subject<void>();
 
   constructor(opts: SyncEngineOptions) {
     this.opts = {
@@ -429,6 +442,7 @@ export class SyncEngine {
     this.commChanges$ = this._commChanges$.asObservable();
     this.outputIdChanges$ = this._outputIdChanges$.asObservable();
     this.executionViewChanges$ = this._executionViewChanges$.asObservable();
+    this.notebookDocChanged$ = this._notebookDocChanged$.asObservable();
 
     // Typed broadcast sub-observables (derived from broadcasts$)
     this.commBroadcasts$ = this.broadcasts$.pipe(filter(isCommBroadcast));
@@ -576,6 +590,7 @@ export class SyncEngine {
                 );
               }
               materialize$.next(cs ?? null);
+              this._notebookDocChanged$.next();
             }
             this.emitExecutionViewChanges(e.execution_view_changeset);
             return EMPTY;

--- a/packages/runtimed/src/transport.ts
+++ b/packages/runtimed/src/transport.ts
@@ -3,10 +3,12 @@
  *
  * The transport is the pluggable boundary between the SyncEngine and the
  * underlying connection to the daemon. Implementations:
- *   - TauriTransport (desktop app, lives in apps/notebook)
+ *   - TauriTransport (desktop app, lives in packages/notebook-host)
+ *   - CloudWebSocketTransport (cloud viewer, lives in apps/notebook-cloud)
  *   - DirectTransport (testing, lives in this package)
- *   - WebSocketTransport (future web app)
  */
+
+import type { Observable } from "rxjs";
 
 import type { NotebookResponse } from "./request-types";
 
@@ -38,6 +40,16 @@ export function sendPresenceFrame(
 
 /** Callback for receiving inbound frames from the daemon. */
 export type FrameListener = (payload: number[]) => void;
+
+/**
+ * Connection lifecycle state emitted by `NotebookTransport.connectionStatus$`.
+ *
+ * - `"connecting"` — initial state before the first successful connection.
+ * - `"online"` — transport is connected and operational.
+ * - `"offline"` — transport has lost its connection (non-manual close).
+ * - `"reconnecting"` — reconnect attempt in progress (reserved for transports with retry logic).
+ */
+export type ConnectionStatus = "connecting" | "online" | "offline" | "reconnecting";
 
 export interface NotebookRequestOptions {
   /** Causal precondition: daemon must have these notebook heads before handling. */
@@ -97,6 +109,14 @@ export interface NotebookTransport {
 
   /** Whether the transport is currently connected. */
   readonly connected: boolean;
+
+  /**
+   * Observable that emits the current connection state whenever it changes.
+   *
+   * Consumers should subscribe to persist `NotebookDoc` bytes on `"online"`
+   * (sync complete) and display UI feedback on `"offline"` or `"reconnecting"`.
+   */
+  readonly connectionStatus$: Observable<ConnectionStatus>;
 
   /** Tear down the transport (unlisten, close connections). */
   disconnect(): void;

--- a/packages/runtimed/src/transport.ts
+++ b/packages/runtimed/src/transport.ts
@@ -113,8 +113,11 @@ export interface NotebookTransport {
   /**
    * Observable that emits the current connection state whenever it changes.
    *
-   * Consumers should subscribe to persist `NotebookDoc` bytes on `"online"`
-   * (sync complete) and display UI feedback on `"offline"` or `"reconnecting"`.
+   * Reflects the physical transport connection: whether the underlying socket
+   * or IPC channel is open. This is not a sync-readiness signal — consumers
+   * that need to know when the notebook doc is ready to read should use
+   * `SyncEngine.initialSyncComplete$`; those that want to persist on each
+   * change should debounce `SyncEngine.notebookDocChanged$`.
    */
   readonly connectionStatus$: Observable<ConnectionStatus>;
 

--- a/packages/runtimed/tests/blob-upload.test.ts
+++ b/packages/runtimed/tests/blob-upload.test.ts
@@ -1,3 +1,4 @@
+import { EMPTY } from "rxjs";
 import { describe, expect, it, vi } from "vite-plus/test";
 
 import {
@@ -33,6 +34,7 @@ function createTransport(
     sendRequest: vi.fn(),
     sendTypedRequest: vi.fn(handler),
     connected: true,
+    connectionStatus$: EMPTY,
     disconnect: vi.fn(),
   };
 }

--- a/packages/runtimed/tests/notebook-client.test.ts
+++ b/packages/runtimed/tests/notebook-client.test.ts
@@ -1,3 +1,4 @@
+import { EMPTY } from "rxjs";
 import { NotebookClient, type NotebookTransport } from "runtimed";
 import { describe, expect, it, vi } from "vite-plus/test";
 
@@ -9,6 +10,7 @@ function stubClient() {
     sendRequest,
     sendTypedRequest: vi.fn(),
     connected: true,
+    connectionStatus$: EMPTY,
     disconnect: () => {},
   } satisfies NotebookTransport;
 
@@ -24,6 +26,7 @@ function stubClientWithHeads(heads: string[]) {
     sendRequest,
     sendTypedRequest: vi.fn(),
     connected: true,
+    connectionStatus$: EMPTY,
     disconnect: () => {},
   } satisfies NotebookTransport;
 

--- a/packages/runtimed/tests/transport.test.ts
+++ b/packages/runtimed/tests/transport.test.ts
@@ -1,3 +1,4 @@
+import { EMPTY } from "rxjs";
 import { describe, expect, it, vi } from "vite-plus/test";
 
 import {
@@ -22,6 +23,7 @@ function createTransportStub(): {
     sendRequest: vi.fn(),
     sendTypedRequest: vi.fn(),
     connected: true,
+    connectionStatus$: EMPTY,
     disconnect: vi.fn(),
   } satisfies NotebookTransport;
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -368,6 +368,9 @@ importers:
       runtimed:
         specifier: workspace:*
         version: link:../../packages/runtimed
+      rxjs:
+        specifier: ^7.8.2
+        version: 7.8.2
       tailwindcss:
         specifier: ^4.3.0
         version: 4.3.0


### PR DESCRIPTION
Precursor work for #3421 (local-first notebook state). Adds the transport-layer primitives that persistence and connection-state UI will build on.

## What's here

**`ConnectionStatus` type + observable on `NotebookTransport`**

```ts
export type ConnectionStatus = "connecting" | "online" | "offline" | "reconnecting";

// Added to NotebookTransport interface:
readonly connectionStatus$: Observable<ConnectionStatus>;
```

Four transport implementations updated:

| Transport | Initial state | Transitions |
|---|---|---|
| `TauriTransport` | `"online"` | `"offline"` on `disconnect()` |
| `BrowserDevTransport` | `"connecting"` | `"online"` on WS open, `"offline"` on close/disconnect, `"connecting"` on reconnect |
| `CloudWebSocketTransport` | `"connecting"` | `"online"` when `cloud_room_ready` handshake completes, `"offline"` on non-manual `markClosed()` |
| `DirectTransport` | `"online"` | `"offline"` on `disconnect()`, `"online"` on `reconnect()` |
| `CloudNotebookHostTransport` | - | Delegates to underlying transport, `EMPTY` when no runtime |

**`notebookDocChanged$` on `SyncEngine`**

```ts
readonly notebookDocChanged$: Observable<void>;
```

Fires on every `sync_applied` event where the notebook CRDT doc changed. Persistence consumers debounce this and call `handle.save()` to snapshot `NotebookDoc` bytes for local storage.

Only `NotebookDoc` bytes should be persisted. `RuntimeStateDoc` is daemon-authoritative and ephemeral - storing it locally would conflict with the daemon-owns-runtime model on reconnect.

## Design decision

`ConnectionStatus` lives on the transport rather than the `SyncEngine` because the transport is the authority on the physical connection. `SyncEngine` surfaces it indirectly (consumers access `engine.opts.transport.connectionStatus$`). Adding a proxy on `SyncEngine` is easy if a future use case wants it.

`"reconnecting"` is reserved for transports with retry logic (none yet). The type is in the union now so downstream UI does not need a breaking change when retry is added to `CloudWebSocketTransport`.

## What's next

With these hooks in place, the follow-on work (#3421) is:
1. IndexedDB persistence layer: debounce `notebookDocChanged$`, call `handle.save()`, write to storage
2. Connection UI slot: subscribe to `connectionStatus$`, render the connecting/online/offline indicator
3. Reconnect loop in `CloudWebSocketTransport`
