### PR TITLE
fix(cloud): stop runtime peer rejection storms

### DIFF
--- a/apps/notebook-cloud/scripts/hosted-workstation-agent-core.mjs
+++ b/apps/notebook-cloud/scripts/hosted-workstation-agent-core.mjs
@@ -2,6 +2,7 @@ import os from "node:os";
 import path from "node:path";
 
 export const DEFAULT_WORKSTATION_AUTH_KIND = "anaconda-key";
+export const DEFAULT_WORKSTATION_RETRY_AFTER_MS = 60_000;
 export const WORKSTATION_AUTH_KINDS = new Set([DEFAULT_WORKSTATION_AUTH_KIND, "oidc"]);
 
 export function buildWorkstationRegistrationPayload({
@@ -158,6 +159,35 @@ export function parsePositiveInteger(value, name, fallback) {
     throw new Error(`${name} must be a positive integer`);
   }
   return parsed;
+}
+
+export async function parseHttpResponseBody(response) {
+  if (response.status === 204) return {};
+  const text = await response.text();
+  if (!text.trim()) return {};
+  try {
+    return JSON.parse(text);
+  } catch {
+    return { error: text.slice(0, 500) };
+  }
+}
+
+export function retryAfterMs(response, fallbackMs = DEFAULT_WORKSTATION_RETRY_AFTER_MS) {
+  if (response.status !== 429 && response.status !== 503) return 0;
+  const header = response.headers?.get?.("Retry-After");
+  if (!header) return fallbackMs;
+
+  const seconds = Number(header);
+  if (Number.isFinite(seconds) && seconds >= 0) {
+    return Math.max(1_000, Math.ceil(seconds * 1_000));
+  }
+
+  const dateMs = Date.parse(header);
+  if (Number.isFinite(dateMs)) {
+    return Math.max(1_000, dateMs - Date.now());
+  }
+
+  return fallbackMs;
 }
 
 function assert(condition, message) {

--- a/apps/notebook-cloud/scripts/hosted-workstation-agent.mjs
+++ b/apps/notebook-cloud/scripts/hosted-workstation-agent.mjs
@@ -12,7 +12,9 @@ import {
   buildWorkstationRegistrationPayload,
   DEFAULT_WORKSTATION_AUTH_KIND,
   normalizeWorkstationAuthKind,
+  parseHttpResponseBody,
   parsePositiveInteger,
+  retryAfterMs,
   stableWorkstationId,
 } from "./hosted-workstation-agent-core.mjs";
 import { notebookCloudBaseUrl, notebookCloudWorkspaceRoot } from "./local-dev.mjs";
@@ -57,6 +59,7 @@ const agentRoot = path.resolve(
 
 const activeJobs = new Map();
 let lastHeartbeatAt = 0;
+let cooldownUntil = 0;
 
 main().catch((error) => {
   console.error(error instanceof Error ? error.message : String(error));
@@ -83,7 +86,15 @@ async function main() {
   );
 
   while (true) {
+    const cooldownRemainingMs = cooldownUntil - Date.now();
+    if (cooldownRemainingMs > 0) {
+      await sleep(Math.min(cooldownRemainingMs, pollIntervalMs));
+      continue;
+    }
     await runAgentStep("heartbeat", () => heartbeatIfNeeded(pythonPath));
+    if (cooldownUntil > Date.now()) {
+      continue;
+    }
     await runAgentStep("poll_attach_jobs", () => pollAttachJobs(pythonPath));
     await sleep(pollIntervalMs);
   }
@@ -93,6 +104,17 @@ async function runAgentStep(step, fn) {
   try {
     await fn();
   } catch (error) {
+    const stepRetryAfterMs = Number(error?.retryAfterMs ?? 0);
+    if (Number.isFinite(stepRetryAfterMs) && stepRetryAfterMs > 0) {
+      cooldownUntil = Math.max(cooldownUntil, Date.now() + stepRetryAfterMs);
+      console.error(
+        JSON.stringify({
+          event: "workstation_agent_cooling_down",
+          step,
+          retryAfterMs: stepRetryAfterMs,
+        }),
+      );
+    }
     console.error(
       JSON.stringify({
         event: "workstation_agent_step_failed",
@@ -128,7 +150,7 @@ async function registerWorkstation(pythonPath) {
       }),
     ),
   });
-  const body = await responseJson(response);
+  const body = await parseHttpResponseBody(response);
   assertResponse(response, body, "register workstation", [200, 201]);
 }
 
@@ -139,7 +161,7 @@ async function pollAttachJobs(pythonPath) {
       headers: cloudAuthHeaders(),
     },
   );
-  const body = await responseJson(response);
+  const body = await parseHttpResponseBody(response);
   assertResponse(response, body, "poll attach jobs", [200]);
   for (const job of normalizeJobs(body)) {
     if (activeJobs.has(job.job_id)) continue;
@@ -266,7 +288,7 @@ async function patchAttachJob(jobId, patch) {
       body: JSON.stringify(patch),
     },
   );
-  const body = await responseJson(response);
+  const body = await parseHttpResponseBody(response);
   assertResponse(response, body, `patch attach job ${jobId}`, [200, 204]);
 }
 
@@ -394,14 +416,13 @@ async function assertBinaryExists(binaryPath, name) {
   }
 }
 
-async function responseJson(response) {
-  if (response.status === 204) return {};
-  return response.json().catch(async () => ({ error: await response.text() }));
-}
-
 function assertResponse(response, body, label, expectedStatuses) {
   if (expectedStatuses.includes(response.status)) return;
-  throw new Error(`${label} failed: HTTP ${response.status} ${JSON.stringify(body).slice(0, 500)}`);
+  const error = new Error(
+    `${label} failed: HTTP ${response.status} ${JSON.stringify(body).slice(0, 500)}`,
+  );
+  error.retryAfterMs = retryAfterMs(response);
+  throw error;
 }
 
 function normalizeJobs(body) {

--- a/apps/notebook-cloud/test/hosted-workstation-agent.test.mjs
+++ b/apps/notebook-cloud/test/hosted-workstation-agent.test.mjs
@@ -194,6 +194,14 @@ describe("hosted workstation agent launch contract", () => {
       retryAfterMs(new Response("slow down", { status: 429, headers: { "Retry-After": "7" } })),
       7_000,
     );
+    const retryDate = new Date(Date.now() + 8_000).toUTCString();
+    const retryDateDelay = retryAfterMs(
+      new Response("slow down", { status: 429, headers: { "Retry-After": retryDate } }),
+    );
+    assert.ok(
+      retryDateDelay >= 1_000 && retryDateDelay <= 8_500,
+      `date retry delay should be bounded, got ${retryDateDelay}`,
+    );
     assert.equal(retryAfterMs(new Response("no hint", { status: 503 }), 12_345), 12_345);
   });
 });

--- a/apps/notebook-cloud/test/hosted-workstation-agent.test.mjs
+++ b/apps/notebook-cloud/test/hosted-workstation-agent.test.mjs
@@ -7,7 +7,9 @@ import {
   buildRuntimeAgentEnv,
   buildWorkstationRegistrationPayload,
   normalizeWorkstationAuthKind,
+  parseHttpResponseBody,
   parsePositiveInteger,
+  retryAfterMs,
   stableWorkstationId,
 } from "../scripts/hosted-workstation-agent-core.mjs";
 
@@ -163,5 +165,35 @@ describe("hosted workstation agent launch contract", () => {
     assert.equal(parsePositiveInteger(undefined, "TEST_INTERVAL", 2000), 2000);
     assert.equal(parsePositiveInteger("15", "TEST_INTERVAL", 2000), 15);
     assert.throws(() => parsePositiveInteger("0", "TEST_INTERVAL", 2000), /positive integer/);
+  });
+
+  it("parses response bodies once and preserves non-json error pages", async () => {
+    assert.deepEqual(await parseHttpResponseBody(new Response(null, { status: 204 })), {});
+    assert.deepEqual(
+      await parseHttpResponseBody(
+        new Response(JSON.stringify({ jobs: [] }), {
+          status: 200,
+          headers: { "Content-Type": "application/json" },
+        }),
+      ),
+      { jobs: [] },
+    );
+
+    const body = await parseHttpResponseBody(
+      new Response("<html><title>Error 1027</title>Please check back later</html>", {
+        status: 429,
+        headers: { "Content-Type": "text/html" },
+      }),
+    );
+    assert.match(body.error, /Error 1027/);
+  });
+
+  it("backs off workstation polling when the cloud asks for retry", () => {
+    assert.equal(retryAfterMs(new Response("ok", { status: 200 })), 0);
+    assert.equal(
+      retryAfterMs(new Response("slow down", { status: 429, headers: { "Retry-After": "7" } })),
+      7_000,
+    );
+    assert.equal(retryAfterMs(new Response("no hint", { status: 503 }), 12_345), 12_345);
   });
 });

--- a/crates/notebook-cloud-transport/src/lib.rs
+++ b/crates/notebook-cloud-transport/src/lib.rs
@@ -276,10 +276,14 @@ fn cloud_frame_rejection_error(payload: &[u8]) -> Option<std::io::Error> {
     if control.get("type").and_then(|t| t.as_str()) != Some("cloud_frame_rejected") {
         return None;
     }
-    let frame_type = control
-        .get("frame_type")
-        .map(|value| value.to_string())
-        .unwrap_or_else(|| "unknown".to_string());
+    let frame_type = match control.get("frame_type") {
+        Some(value) => value
+            .as_u64()
+            .map(|number| number.to_string())
+            .or_else(|| value.as_str().map(str::to_string))
+            .unwrap_or_else(|| value.to_string()),
+        None => "unknown".to_string(),
+    };
     let reason = control
         .get("reason")
         .and_then(|v| v.as_str())
@@ -829,6 +833,20 @@ mod tests {
         }))
         .unwrap();
         assert!(cloud_frame_rejection_error(&accepted).is_none());
+    }
+
+    #[test]
+    fn cloud_frame_rejection_error_formats_string_frame_type_without_json_quotes() {
+        let payload = serde_json::to_vec(&serde_json::json!({
+            "type": "cloud_frame_rejected",
+            "frame_type": "runtime_state_sync",
+            "reason": "rejected",
+        }))
+        .unwrap();
+        let error = cloud_frame_rejection_error(&payload).expect("rejection becomes an error");
+        assert!(error
+            .to_string()
+            .contains("frame_type=runtime_state_sync reason=rejected"));
     }
 
     #[test]

--- a/crates/notebook-cloud-transport/src/lib.rs
+++ b/crates/notebook-cloud-transport/src/lib.rs
@@ -269,6 +269,27 @@ fn classify_ready_control(payload: &[u8]) -> ReadyControl {
     }
 }
 
+fn cloud_frame_rejection_error(payload: &[u8]) -> Option<std::io::Error> {
+    let Ok(control) = serde_json::from_slice::<serde_json::Value>(payload) else {
+        return None;
+    };
+    if control.get("type").and_then(|t| t.as_str()) != Some("cloud_frame_rejected") {
+        return None;
+    }
+    let frame_type = control
+        .get("frame_type")
+        .map(|value| value.to_string())
+        .unwrap_or_else(|| "unknown".to_string());
+    let reason = control
+        .get("reason")
+        .and_then(|v| v.as_str())
+        .unwrap_or("(no reason given)");
+    Some(std::io::Error::new(
+        std::io::ErrorKind::PermissionDenied,
+        format!("cloud room rejected frame: frame_type={frame_type} reason={reason}"),
+    ))
+}
+
 /// Read frames from `source` until the room reaches a terminal ready state,
 /// returning the authenticated principal from `cloud_room_ready`.
 ///
@@ -350,7 +371,14 @@ impl FrameSource for CloudWsSource {
         loop {
             match self.stream.next().await {
                 Some(Ok(msg)) if msg.is_binary() => match decode_frame(&msg.into_data()) {
-                    Some(frame) => return Some(Ok(frame)),
+                    Some(frame) => {
+                        if frame.frame_type == NotebookFrameType::SessionControl {
+                            if let Some(error) = cloud_frame_rejection_error(&frame.payload) {
+                                return Some(Err(error));
+                            }
+                        }
+                        return Some(Ok(frame));
+                    }
                     // Empty / unknown frame: skip, keep reading.
                     None => continue,
                 },
@@ -647,6 +675,10 @@ impl FrameTransport for CloudWsFrameTransport {
         true
     }
 
+    fn stream_error_is_recoverable(&self, error: &std::io::Error) -> bool {
+        error.kind() != std::io::ErrorKind::PermissionDenied
+    }
+
     async fn connect(&self) -> std::io::Result<(Self::Source, Self::Sink)> {
         let (source, sink, principal) = self.connect_cloud().await?;
         // Cache the principal for `Self::principal`. Reconnects to the same room
@@ -779,6 +811,27 @@ mod tests {
     }
 
     #[test]
+    fn cloud_frame_rejection_error_is_non_recoverable_shape() {
+        let payload = serde_json::to_vec(&serde_json::json!({
+            "type": "cloud_frame_rejected",
+            "frame_type": 5,
+            "reason": "actor label must be '<principal>/<operator>'",
+        }))
+        .unwrap();
+        let error = cloud_frame_rejection_error(&payload).expect("rejection becomes an error");
+        assert_eq!(error.kind(), std::io::ErrorKind::PermissionDenied);
+        assert!(error
+            .to_string()
+            .contains("actor label must be '<principal>/<operator>'"));
+
+        let accepted = serde_json::to_vec(&serde_json::json!({
+            "type": "cloud_frame_accepted",
+        }))
+        .unwrap();
+        assert!(cloud_frame_rejection_error(&accepted).is_none());
+    }
+
+    #[test]
     fn classify_treats_accepted_and_garbage_as_other() {
         let accepted = serde_json::to_vec(&serde_json::json!({
             "type": "cloud_frame_accepted",
@@ -847,6 +900,23 @@ mod tests {
             workstation: None,
         });
         assert!(t.clean_eof_is_recoverable());
+    }
+
+    #[test]
+    fn cloud_permission_denied_stream_error_is_terminal() {
+        let t = CloudWsFrameTransport::new(CloudWsConfig {
+            cloud_url: "https://preview.runt.run".into(),
+            notebook_id: "abc".into(),
+            scope: "runtime_peer".into(),
+            auth: CloudAuth::OidcBearer {
+                token: "tok".into(),
+            },
+            workstation: None,
+        });
+        let fatal = std::io::Error::new(std::io::ErrorKind::PermissionDenied, "room rejected");
+        let transient = std::io::Error::new(std::io::ErrorKind::ConnectionReset, "reset");
+        assert!(!t.stream_error_is_recoverable(&fatal));
+        assert!(t.stream_error_is_recoverable(&transient));
     }
 
     // -- token-refresher tests --------------------------------------------

--- a/crates/notebook-protocol/src/connection/transport.rs
+++ b/crates/notebook-protocol/src/connection/transport.rs
@@ -100,6 +100,15 @@ pub trait FrameTransport: Send + Sync {
     fn clean_eof_is_recoverable(&self) -> bool {
         false
     }
+
+    /// Whether a read-side stream error should be handled through the reconnect
+    /// path. Most transport errors are transient wire failures, so the default
+    /// remains recoverable. Cloud transports can mark server-authored protocol
+    /// rejections as terminal: reconnecting with the same local document state
+    /// would just replay the same forbidden frame.
+    fn stream_error_is_recoverable(&self, _error: &std::io::Error) -> bool {
+        true
+    }
 }
 
 // -- UDS implementation -----------------------------------------------------
@@ -291,5 +300,17 @@ mod tests {
             "/tmp/blobs",
         );
         assert!(!transport.clean_eof_is_recoverable());
+    }
+
+    #[test]
+    fn uds_stream_errors_remain_recoverable_by_default() {
+        let transport = UdsFrameTransport::new(
+            "/tmp/does-not-need-to-exist.sock",
+            "nb",
+            "runtime-agent:test",
+            "/tmp/blobs",
+        );
+        let error = std::io::Error::new(std::io::ErrorKind::PermissionDenied, "mock");
+        assert!(transport.stream_error_is_recoverable(&error));
     }
 }

--- a/crates/runtimed/src/runtime_agent.rs
+++ b/crates/runtimed/src/runtime_agent.rs
@@ -431,6 +431,7 @@ where
     let mut last_recoverable_reconnect: Option<tokio::time::Instant> = None;
     let mut lifecycle_rx: Option<mpsc::UnboundedReceiver<LifecycleSignal>> = None;
     let mut work_rx: Option<mpsc::Receiver<WorkCommand>> = None;
+    let mut terminal_error: Option<anyhow::Error> = None;
 
     // Async responses from spawned tasks (currently: SyncEnvironment).
     // Keeping these off the request handler's await frees the main loop to
@@ -996,6 +997,17 @@ where
                         }
                     }
                     Some(Err(e)) => {
+                        if !transport.stream_error_is_recoverable(&e) {
+                            error!(
+                                "[runtime-agent] Non-recoverable sync stream error: {}; \
+                                 shutting down instead of reconnecting",
+                                e
+                            );
+                            terminal_error = Some(anyhow::anyhow!(
+                                "runtime agent sync stream rejected by room: {e}"
+                            ));
+                            break;
+                        }
                         // A framing error here means one of two things:
                         //   - the daemon half-closed the sync stream (clean),
                         //     which we treat as a disconnect,
@@ -1350,7 +1362,10 @@ where
         k.shutdown().await.ok();
     }
 
-    Ok(())
+    match terminal_error {
+        Some(error) => Err(error),
+        None => Ok(()),
+    }
 }
 
 async fn send_runtime_agent_response<S: FrameSink>(


### PR DESCRIPTION
## Summary
- classify steady-state cloud `cloud_frame_rejected` controls as terminal stream errors for cloud runtime peers
- keep ordinary cloud WebSocket closes/resets recoverable, but stop reconnecting when the room rejects our sync frames
- make the hosted workstation agent parse non-JSON 429/1027 responses safely and cool down on 429/503 responses

## Why
Preview hit Cloudflare Error 1027 after the `NotebookRoom` Durable Object consumed roughly 837k hibernation requests. Two old runtime peers for `with anil` and `Renting Cognition` produced most of the traffic after room-host RuntimeStateDoc actor-label rejections, then kept reconnecting/resyncing.

## Validation
- `cargo xtask lint --fix`
- `cargo test -p notebook-protocol connection::transport`
- `cargo test -p notebook-cloud-transport`
- `cargo test -p runtimed reconnect_with_backoff -- --nocapture`
- `pnpm --dir apps/notebook-cloud exec node --test test/hosted-workstation-agent.test.mjs`

## Deployment
Not deployed yet. `preview.runt.run` is currently over the Cloudflare free-plan Durable Object request cap, so live smokes would add noise until the cap resets or the plan is upgraded.