### PR TITLE
refactor(notebook): move outputFocusedCellId into shared store

### DIFF
--- a/apps/notebook/src/components/NotebookView.tsx
+++ b/apps/notebook/src/components/NotebookView.tsx
@@ -37,6 +37,11 @@ import {
   useFocusedCellId,
   useSearchCurrentMatch,
 } from "@/components/notebook/state/cell-ui-state";
+import {
+  clearOutputFocusedCellId,
+  setOutputFocusedCellId,
+  useOutputFocusedCellId,
+} from "@/components/notebook/state/output-focus-store";
 import { logger } from "../lib/logger";
 import { computeCanMutateCells } from "@/components/notebook/mutation-gate";
 import {
@@ -370,33 +375,32 @@ function NotebookViewContent({
   // Read transient UI state from the store instead of props
   const focusedCellId = useFocusedCellId();
   const searchCurrentMatch = useSearchCurrentMatch();
-  const [outputFocusedCellId, setOutputFocusedCellId] = useState<string | null>(null);
+  const outputFocusedCellId = useOutputFocusedCellId();
 
   // Output-focus follows cell selection: when the user moves the caret to a
   // different cell (arrow keys, click, programmatic focus), the previously
   // output-focused cell exits focus. This keeps the "wheel ownership" cell
   // and the "keyboard target" cell aligned without separate handlers.
   //
-  // The `focusedCellId !== null` guard is load-bearing: cell-ui-state uses a
-  // deferred-flush subscriber pattern, so when a click on the focus button
-  // calls onFocusCell + setOutputFocusedCellId in the same tick, the local
-  // useState update lands first and `focusedCellId` is briefly stale (null
-  // or the previous cell) until the cell-ui-state flush propagates. Without
-  // this guard the effect races and clears output focus before it sticks.
-  // Treat null as "no current selection," not "user moved selection away."
+  // The `focusedCellId !== null` guard was needed when outputFocusedCellId
+  // lived in useState (which committed before the deferred cell-ui-state
+  // flush resolved focusedCellId). Both values are now in stores that emit
+  // via React's batching, so the guard is no longer load-bearing — but it
+  // is kept as a safety net: treat null as "no current selection," not
+  // "user moved selection away."
   useEffect(() => {
     if (
       outputFocusedCellId !== null &&
       focusedCellId !== null &&
       focusedCellId !== outputFocusedCellId
     ) {
-      setOutputFocusedCellId(null);
+      clearOutputFocusedCellId();
     }
   }, [focusedCellId, outputFocusedCellId]);
 
   useEffect(() => {
     if (outputFocusedCellId !== null && !cellIds.includes(outputFocusedCellId)) {
-      setOutputFocusedCellId(null);
+      clearOutputFocusedCellId();
     }
   }, [cellIds, outputFocusedCellId]);
 
@@ -425,7 +429,7 @@ function NotebookViewContent({
     if (outputFocusedCellId === null) return;
     const handleKey = (event: KeyboardEvent) => {
       if (event.key === "Escape") {
-        setOutputFocusedCellId(null);
+        clearOutputFocusedCellId();
         publishInteractionTarget({ kind: "cell", cellId: outputFocusedCellId });
       }
     };
@@ -448,7 +452,7 @@ function NotebookViewContent({
         `[data-slot="cell-container"][data-cell-id="${outputFocusedCellId}"]`,
       );
       if (focusedCellEl && !focusedCellEl.contains(target)) {
-        setOutputFocusedCellId(null);
+        clearOutputFocusedCellId();
         publishInteractionTarget({ kind: "cell", cellId: outputFocusedCellId });
       }
     };
@@ -463,7 +467,7 @@ function NotebookViewContent({
         setOutputFocusedCellId(cellId);
         return;
       }
-      setOutputFocusedCellId((current) => (current === cellId ? null : current));
+      clearOutputFocusedCellId(cellId);
       publishInteractionTarget({ kind: "cell", cellId });
     },
     [focusInteractionTarget, publishInteractionTarget],

--- a/src/components/notebook/state/output-focus-store.ts
+++ b/src/components/notebook/state/output-focus-store.ts
@@ -1,0 +1,104 @@
+import { useMemo, useSyncExternalStore } from "react";
+
+// ---------------------------------------------------------------------------
+// Output-focus state store.
+//
+// Tracks which cell currently owns "output focus" — the wheel-scroll owner
+// and iframe focus ring. At most one cell is output-focused at a time.
+//
+// Uses direct emit (not the deferred-flush pattern in cell-ui-state.ts)
+// because writes always originate from event handlers, never from a render
+// pass.
+// ---------------------------------------------------------------------------
+
+let _outputFocusedCellId: string | null = null;
+const _subscribers = new Set<() => void>();
+
+function emit(): void {
+  for (const cb of _subscribers) cb();
+}
+
+// ── Setters ─────────────────────────────────────────────────────────────
+
+/** Set the output-focused cell. No-op when the cell is already focused. */
+export function setOutputFocusedCellId(cellId: string): void {
+  if (_outputFocusedCellId === cellId) return;
+  _outputFocusedCellId = cellId;
+  emit();
+}
+
+/**
+ * Clear output focus.
+ *
+ * When `fromCellId` is provided, only clears if that cell is currently
+ * focused — matching the `setOutputFocusedCellId((current) => current === id
+ * ? null : current)` functional-updater pattern.
+ */
+export function clearOutputFocusedCellId(fromCellId?: string): void {
+  if (fromCellId !== undefined && _outputFocusedCellId !== fromCellId) return;
+  if (_outputFocusedCellId === null) return;
+  _outputFocusedCellId = null;
+  emit();
+}
+
+// ── Snapshot readers (non-reactive) ─────────────────────────────────────
+
+export function getOutputFocusedCellId(): string | null {
+  return _outputFocusedCellId;
+}
+
+// ── Hooks ────────────────────────────────────────────────────────────────
+
+/** Subscribe to the output-focused cell ID. Re-renders on every change. */
+export function useOutputFocusedCellId(): string | null {
+  return useSyncExternalStore(subscribeAll, getOutputFocusedCellId);
+}
+
+/** Returns true only when this specific cell is output-focused. */
+export function useIsCellOutputFocused(cellId: string): boolean {
+  const sub = useMemo(() => subscribeFor(cellId), [cellId]);
+  const snap = useMemo(() => getIsOutputFocusedSnapshot(cellId), [cellId]);
+  return useSyncExternalStore(sub, snap);
+}
+
+/** Returns true when another cell is output-focused (this cell is dimmed). */
+export function useIsCellOutputDimmed(cellId: string): boolean {
+  const sub = useMemo(() => subscribeFor(cellId), [cellId]);
+  const snap = useMemo(() => getIsOutputDimmedSnapshot(cellId), [cellId]);
+  return useSyncExternalStore(sub, snap);
+}
+
+// ── Subscription helpers ─────────────────────────────────────────────────
+
+function subscribeAll(cb: () => void): () => void {
+  _subscribers.add(cb);
+  return () => _subscribers.delete(cb);
+}
+
+// Per-cell subscriptions still listen to the global set — but snapshot
+// returns a boolean so useSyncExternalStore only re-renders when the
+// boolean flips for that specific cell.
+function subscribeFor(_cellId: string): (cb: () => void) => () => void {
+  return (cb: () => void) => {
+    _subscribers.add(cb);
+    return () => _subscribers.delete(cb);
+  };
+}
+
+function getIsOutputFocusedSnapshot(cellId: string): () => boolean {
+  let prev = _outputFocusedCellId === cellId;
+  return () => {
+    const next = _outputFocusedCellId === cellId;
+    if (next !== prev) prev = next;
+    return prev;
+  };
+}
+
+function getIsOutputDimmedSnapshot(cellId: string): () => boolean {
+  let prev = _outputFocusedCellId !== null && _outputFocusedCellId !== cellId;
+  return () => {
+    const next = _outputFocusedCellId !== null && _outputFocusedCellId !== cellId;
+    if (next !== prev) prev = next;
+    return prev;
+  };
+}


### PR DESCRIPTION
`outputFocusedCellId` lived in `useState` inside `NotebookViewContent`. Both Desktop and Cloud import `NotebookView` from the shared component tree, so that state was already effectively cross-host — but opaque to shared store consumers.

New `src/components/notebook/state/output-focus-store.ts` follows the direct-emit pattern from `execution-store.ts`: module-level state, `useSyncExternalStore` hooks, no deferred flush needed because all writes come from event handlers, not render passes.

## What changed

**`output-focus-store.ts`** (new file):
- `setOutputFocusedCellId(cellId)` / `clearOutputFocusedCellId(fromCellId?)` — conditional-clear variant replaces the `setX((current) => current === id ? null : current)` functional-updater pattern
- `useOutputFocusedCellId()` — re-renders on every change (used by `NotebookView`)
- `useIsCellOutputFocused(cellId)` / `useIsCellOutputDimmed(cellId)` — per-cell boolean hooks that only re-render when the boolean flips for that cell

**`NotebookView.tsx`**:
- `useState<string | null>(null)` → `useOutputFocusedCellId()`
- Four `setOutputFocusedCellId(null)` sites → `clearOutputFocusedCellId()`
- `setOutputFocusedCellId((current) => (current === cellId ? null : current))` → `clearOutputFocusedCellId(cellId)`
- `focusedCellId !== null` guard kept as safety net — was load-bearing with the old deferred-flush race; both values now batch together, but the guard is cheap and harmless

## Verification

- `pnpm tsc -p apps/notebook/tsconfig.json --noEmit` — clean
- Full test suite: 2003 tests pass, 0 failures
- Browser smoke: app loads, cells execute, no dimming artifacts at idle

Per [shared-store-projection-convergence ADR](../docs/adr/shared-store-projection-convergence.md) item 1.
