### PR TITLE
fix(notebook-cloud): publish offline cloud transport status

### DIFF
--- a/apps/notebook-cloud/test/live-sync.test.ts
+++ b/apps/notebook-cloud/test/live-sync.test.ts
@@ -259,6 +259,52 @@ describe("cloud live sync", () => {
     }
   });
 
+  it("emits offline when the socket closes before room readiness", async () => {
+    const fake = installFakeWebSocket();
+    const statuses: string[] = [];
+    const disconnects: string[] = [];
+    try {
+      const transport = new CloudWebSocketTransport(
+        new URL("wss://example.test/n/room/sync"),
+        [],
+        undefined,
+        (reason) => disconnects.push(reason.message),
+      );
+      const subscription = transport.connectionStatus$.subscribe((status) => statuses.push(status));
+      const ready = assert.rejects(transport.ready, /cloud sync socket closed before ready/);
+
+      fake.socket.close({ code: 1006 });
+      await ready;
+      subscription.unsubscribe();
+
+      assert.deepEqual(statuses, ["connecting", "offline"]);
+      assert.deepEqual(disconnects, []);
+    } finally {
+      fake.restore();
+    }
+  });
+
+  it("emits offline when manually disconnected after readiness", async () => {
+    const fake = installFakeWebSocket();
+    const statuses: string[] = [];
+    try {
+      const transport = new CloudWebSocketTransport(new URL("wss://example.test/n/room/sync"), []);
+      const subscription = transport.connectionStatus$.subscribe((status) => statuses.push(status));
+      const socket = fake.socket;
+      socket.open();
+      socket.ready("peer-1");
+      await transport.ready;
+
+      transport.disconnect();
+      subscription.unsubscribe();
+
+      assert.equal(transport.connected, false);
+      assert.deepEqual(statuses, ["connecting", "online", "offline"]);
+    } finally {
+      fake.restore();
+    }
+  });
+
   it("sends notebook requests as cloud request frames and resolves on room-host ack", async () => {
     const fake = installFakeWebSocket();
     try {

--- a/apps/notebook-cloud/viewer/live-sync.ts
+++ b/apps/notebook-cloud/viewer/live-sync.ts
@@ -241,6 +241,7 @@ export class CloudWebSocketTransport implements NotebookTransport {
   ) => void;
   private readyReject!: (error: Error) => void;
   readonly ready: Promise<Extract<SessionControlMessage, { type: "cloud_room_ready" }>>;
+  private status: ConnectionStatus = "connecting";
   private readonly _status$ = new BehaviorSubject<ConnectionStatus>("connecting");
   readonly connectionStatus$: Observable<ConnectionStatus> = this._status$.asObservable();
 
@@ -254,7 +255,7 @@ export class CloudWebSocketTransport implements NotebookTransport {
       this.readyResolve = (message) => {
         this.readySettled = true;
         this.readyResolved = true;
-        this._status$.next("online");
+        this.setStatus("online");
         resolve(message);
       };
       this.readyReject = (error) => {
@@ -367,9 +368,7 @@ export class CloudWebSocketTransport implements NotebookTransport {
 
   disconnect(): void {
     this.manualDisconnect = true;
-    this.closed = true;
-    this.listeners.clear();
-    this.queuedFrames = [];
+    this.markClosed(new Error("cloud sync socket disconnected"));
     this.socket.close();
   }
 
@@ -435,13 +434,19 @@ export class CloudWebSocketTransport implements NotebookTransport {
   private markClosed(reason: Error): void {
     if (this.closed) return;
     this.closed = true;
+    this.setStatus("offline");
     this.listeners.clear();
     this.queuedFrames = [];
     this.rejectPendingFrameAcks(reason);
     if (this.readyResolved && !this.manualDisconnect) {
-      this._status$.next("offline");
       this.onDisconnect?.(reason);
     }
+  }
+
+  private setStatus(status: ConnectionStatus): void {
+    if (this.status === status) return;
+    this.status = status;
+    this._status$.next(status);
   }
 
   private registerFrameAck(

--- a/packages/runtimed/src/transport.ts
+++ b/packages/runtimed/src/transport.ts
@@ -46,7 +46,7 @@ export type FrameListener = (payload: number[]) => void;
  *
  * - `"connecting"` — initial state before the first successful connection.
  * - `"online"` — transport is connected and operational.
- * - `"offline"` — transport has lost its connection (non-manual close).
+ * - `"offline"` — transport is closed or otherwise unavailable.
  * - `"reconnecting"` — reconnect attempt in progress (reserved for transports with retry logic).
  */
 export type ConnectionStatus = "connecting" | "online" | "offline" | "reconnecting";


### PR DESCRIPTION
## Summary

- Emit `offline` from `CloudWebSocketTransport.connectionStatus$` for pre-ready socket closures and manual disconnects.
- Keep reconnect scheduling semantics unchanged: `onDisconnect` still fires only after a ready room disconnects unexpectedly.
- Add focused fake-WebSocket tests for the cloud status edge cases.

## Verification

- `pnpm --dir apps/notebook-cloud exec node --import tsx --test test/live-sync.test.ts`
- `pnpm --dir apps/notebook-cloud typecheck`
- `pnpm --dir apps/notebook-cloud test`
- `cargo xtask lint --fix`
