### PR TITLE
fix(cloud): allow configurable runtime agent binary

### DIFF
--- a/apps/notebook-cloud/README.md
+++ b/apps/notebook-cloud/README.md
@@ -681,13 +681,16 @@ pnpm --dir apps/notebook-cloud smoke:hosted:runtime-peer
 The smoke script reads `NTERACT_API_KEY` from the environment. On lab2 it also
 loads `${PREVIEW_RUNT_ENV:-$HOME/preview.runt.run/.env}` when present. It
 creates a private room, grants `runtime_peer` to the owner principal, starts the
-real `runtimed cloud-runtime-agent`, then runs `runtimed cloud-peer` as an owner
-that adds a cell and sends hosted `execute_cell`. The JSON result includes the
+real runtime-agent binary with `cloud-runtime-agent`, then runs the same binary
+family's `cloud-peer` diagnostic command as an owner that adds a cell and sends
+hosted `execute_cell`. Use `NOTEBOOK_CLOUD_RUNTIME_AGENT_BIN` when the installed
+command is `runt`; the older `NOTEBOOK_CLOUD_RUNTIMED_BIN` override still works
+for channels where the command is `runtimed`. The JSON result includes the
 viewer URL, timings, and log paths under `.context/smokes/`. A healthy run
 observes `queued` and `done`, and the runtime log shows a kernel launch plus an
 `execute_request`. The artifact ensure step rebuilds the gitignored sift
-WASM/renderer outputs that `runtimed` embeds and catches unhydrated stable
-renderer LFS bundles before `cargo build` fails. Set
+WASM/renderer outputs that the runtime binary embeds and catches unhydrated
+stable renderer LFS bundles before `cargo build` fails. Set
 `NOTEBOOK_CLOUD_RUNTIME_PEER_PYTHON` when you need a specific interpreter;
 otherwise the script prefers lab2's `~/k/bin/python` before falling back to a
 system Python that can import `ipykernel`.
@@ -696,11 +699,11 @@ Set `NOTEBOOK_CLOUD_KEEP_RUNTIME_PEER=1` to leave the runtime peer alive after
 the smoke for manual browser/OIDC inspection. For truly long-lived manual peers,
 run the command inside tmux; short-lived shells or agent command runners may
 clean up background children after the command exits, which makes later
-execution requests look like room/runtime failures. `runtimed cloud-peer` uses
-`--seconds` to control how long the owner peer remains attached. Do not use the
-old `--timeout` flag in smoke scripts. Rooms created with the API-key path are
-private; anonymous hosted render smokes may return a catalog 404 unless the
-browser context has a credential for the owning principal.
+execution requests look like room/runtime failures. The `cloud-peer` diagnostic
+command uses `--seconds` to control how long the owner peer remains attached. Do
+not use the old `--timeout` flag in smoke scripts. Rooms created with the API-key
+path are private; anonymous hosted render smokes may return a catalog 404 unless
+the browser context has a credential for the owning principal.
 
 Hosted workstation agent smoke:
 
@@ -717,14 +720,17 @@ The workstation agent reads `NTERACT_API_KEY` from the environment and also
 loads `${PREVIEW_RUNT_ENV:-$HOME/preview.runt.run/.env}` when present. It
 registers and heartbeats the current machine through `POST /api/workstations`,
 polls `GET /api/workstations/:workstationId/attach-jobs`, and spawns
-`runtimed cloud-runtime-agent` for pending attach jobs. API-key auth is the
-default (`NOTEBOOK_CLOUD_WORKSTATION_AUTH_KIND=anaconda-key`); set
+the configured runtime-agent binary for pending attach jobs. Set
+`NOTEBOOK_CLOUD_RUNTIME_AGENT_BIN=/path/to/runt` for installs where `runt` is the
+deployed command surface; use `NOTEBOOK_CLOUD_RUNTIMED_BIN` only for legacy
+scripts that still point directly at `runtimed`. API-key auth is the default
+(`NOTEBOOK_CLOUD_WORKSTATION_AUTH_KIND=anaconda-key`); set
 `NOTEBOOK_CLOUD_WORKSTATION_AUTH_KIND=oidc` when `NTERACT_API_KEY` carries a
 short-lived OIDC bearer token. The credential is passed to the runtime peer
-through `RUNT_CLOUD_TOKEN`, not through argv; `runtimed` removes cloud
+through `RUNT_CLOUD_TOKEN`, not through argv; the runtime agent removes cloud
 environment variables again before launching the Python kernel. Run this helper
-inside tmux for preview/manual testing so the polling agent stays alive while
-the browser attaches workstations. The first registered workstation becomes the
+inside tmux for preview/manual testing so the polling agent stays alive while the
+browser attaches workstations. The first registered workstation becomes the
 account default automatically; use the Workstations rail or
 `PATCH /api/workstations/default` only when switching to another machine. In a
 private owner room, the toolbar can then request attachment directly.

--- a/apps/notebook-cloud/scripts/hosted-runtime-peer-smoke.mjs
+++ b/apps/notebook-cloud/scripts/hosted-runtime-peer-smoke.mjs
@@ -5,6 +5,10 @@ import os from "node:os";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 
+import {
+  runtimeAgentBinaryFromEnv,
+  runtimeAgentBinaryLabel,
+} from "./hosted-workstation-agent-core.mjs";
 import { notebookCloudBaseUrl, notebookCloudWorkspaceRoot } from "./local-dev.mjs";
 
 const appDir = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
@@ -39,15 +43,18 @@ const smokeRoot = path.resolve(
 const blobRoot = path.join(smokeRoot, "blobs");
 const computeLogPath = path.join(smokeRoot, "runtime-peer.log");
 const ownerLogPath = path.join(smokeRoot, "owner-peer.log");
-const runtimedBin = path.resolve(
+const runtimeAgentBin = runtimeAgentBinaryFromEnv(process.env, workspaceRoot);
+// The diagnostic cloud peer is a hidden subcommand on the same runtime-agent
+// binary family (the standalone runt-cloud-peer binary was absorbed).
+const cloudPeerBin = runtimeAgentBinaryFromEnv(
+  {
+    ...process.env,
+    NOTEBOOK_CLOUD_RUNTIME_AGENT_BIN:
+      process.env.NOTEBOOK_CLOUD_CLOUD_PEER_BIN ??
+      process.env.NOTEBOOK_CLOUD_RUNT_CLOUD_PEER_BIN ??
+      process.env.NOTEBOOK_CLOUD_RUNTIME_AGENT_BIN,
+  },
   workspaceRoot,
-  process.env.NOTEBOOK_CLOUD_RUNTIMED_BIN ?? "target/release/runtimed",
-);
-// The diagnostic cloud peer is the hidden `runtimed cloud-peer` subcommand
-// (the standalone runt-cloud-peer binary was absorbed into runtimed).
-const cloudPeerBin = path.resolve(
-  workspaceRoot,
-  process.env.NOTEBOOK_CLOUD_RUNT_CLOUD_PEER_BIN ?? "target/release/runtimed",
 );
 
 const timingsMs = {};
@@ -64,8 +71,11 @@ main().catch((error) => {
 async function main() {
   try {
     requireApiKey();
-    await assertBinaryExists(runtimedBin, "runtimed");
-    await assertBinaryExists(cloudPeerBin, "runtimed cloud-peer");
+    await assertBinaryExists(
+      runtimeAgentBin,
+      `${runtimeAgentBinaryLabel(runtimeAgentBin)} cloud-runtime-agent`,
+    );
+    await assertBinaryExists(cloudPeerBin, `${runtimeAgentBinaryLabel(cloudPeerBin)} cloud-peer`);
     const pythonPath = await resolvePythonPath();
     await mkdir(blobRoot, { recursive: true });
     tempDir = await mkdtemp(path.join(os.tmpdir(), "nteract-runtime-peer-smoke-"));
@@ -179,13 +189,21 @@ function requireApiKey() {
 }
 
 async function assertBinaryExists(binaryPath, name) {
+  if (!isPathLike(binaryPath)) {
+    if (await which(binaryPath)) return;
+    throw new Error(`Missing ${name} command ${binaryPath} on PATH.`);
+  }
   try {
     await access(binaryPath);
   } catch {
     throw new Error(
-      `Missing ${name} binary at ${binaryPath}. Run \`cargo xtask artifacts ensure sift,renderer && cargo build --release -p runtimed\` first, or set NOTEBOOK_CLOUD_${name.toUpperCase().replaceAll("-", "_")}_BIN.`,
+      `Missing ${name} at ${binaryPath}. Run \`cargo xtask artifacts ensure sift,renderer && cargo build --release -p runtimed\` first, or set NOTEBOOK_CLOUD_RUNTIME_AGENT_BIN.`,
     );
   }
+}
+
+function isPathLike(value) {
+  return path.isAbsolute(value) || value.includes("/") || value.includes("\\");
 }
 
 async function resolvePythonPath() {
@@ -341,7 +359,7 @@ function startRuntimePeer({ notebookId, pythonPath }) {
     let child;
     try {
       child = spawn(
-        runtimedBin,
+        runtimeAgentBin,
         [
           "cloud-runtime-agent",
           "--auth-kind",
@@ -484,8 +502,8 @@ async function runOwnerPeer({ notebookId }) {
       timeoutMs: seconds * 1000 + 20_000,
       env: {
         ...process.env,
-        // `runtimed cloud-peer` reads the credential from the environment,
-        // never argv, so it cannot leak into the process command line.
+        // `cloud-peer` reads the credential from the environment, never argv,
+        // so it cannot leak into the process command line.
         RUNT_CLOUD_TOKEN: apiKey,
         RUST_LOG: process.env.RUST_LOG ?? "info",
       },

--- a/apps/notebook-cloud/scripts/hosted-workstation-agent-core.mjs
+++ b/apps/notebook-cloud/scripts/hosted-workstation-agent-core.mjs
@@ -3,6 +3,7 @@ import path from "node:path";
 
 export const DEFAULT_WORKSTATION_AUTH_KIND = "anaconda-key";
 export const DEFAULT_WORKSTATION_RETRY_AFTER_MS = 60_000;
+export const DEFAULT_RUNTIME_AGENT_BINARY = "target/release/runtimed";
 export const WORKSTATION_AUTH_KINDS = new Set([DEFAULT_WORKSTATION_AUTH_KIND, "oidc"]);
 
 export function buildWorkstationRegistrationPayload({
@@ -10,6 +11,7 @@ export function buildWorkstationRegistrationPayload({
   displayName,
   workingDirectory,
   pythonPath,
+  runtimeBinary = "runtimed",
   cpuCount = os.cpus().length,
   memoryBytes = os.totalmem(),
 }) {
@@ -26,7 +28,7 @@ export function buildWorkstationRegistrationPayload({
       launch_current_python: true,
     },
     runtime: {
-      binary: "runtimed",
+      binary: runtimeBinary,
       python_path: pythonPath,
     },
   };
@@ -40,6 +42,7 @@ export function buildAttachJobSpawnPlan({
   workingDirectory,
   workstationId,
   displayName,
+  runtimeAgentBin = "runtimed",
   authKind = DEFAULT_WORKSTATION_AUTH_KIND,
 }) {
   assert(typeof job.job_id === "string" && job.job_id.length > 0, "attach job missing id");
@@ -83,6 +86,7 @@ export function buildAttachJobSpawnPlan({
     args,
     blobRoot,
     cwd: launchDirectory,
+    executable: runtimeAgentBin,
     logPath,
     runRoot,
   };
@@ -139,6 +143,22 @@ export function compactEnv(entries) {
   return Object.fromEntries(
     Object.entries(entries).filter(([, value]) => typeof value === "string" && value.length > 0),
   );
+}
+
+export function runtimeAgentBinaryFromEnv(env, workspaceRoot) {
+  const configured =
+    env.NOTEBOOK_CLOUD_RUNTIME_AGENT_BIN ??
+    env.NOTEBOOK_CLOUD_RUNT_BIN ??
+    env.NOTEBOOK_CLOUD_RUNTIMED_BIN;
+  const value = configured?.trim() || DEFAULT_RUNTIME_AGENT_BINARY;
+  if (path.isAbsolute(value) || value.includes("/") || value.includes("\\")) {
+    return path.resolve(workspaceRoot, value);
+  }
+  return value;
+}
+
+export function runtimeAgentBinaryLabel(binaryPath) {
+  return path.basename(binaryPath) || binaryPath;
 }
 
 export function stableWorkstationId(hostname) {

--- a/apps/notebook-cloud/scripts/hosted-workstation-agent.mjs
+++ b/apps/notebook-cloud/scripts/hosted-workstation-agent.mjs
@@ -15,6 +15,8 @@ import {
   parseHttpResponseBody,
   parsePositiveInteger,
   retryAfterMs,
+  runtimeAgentBinaryFromEnv,
+  runtimeAgentBinaryLabel,
   stableWorkstationId,
 } from "./hosted-workstation-agent-core.mjs";
 import { notebookCloudBaseUrl, notebookCloudWorkspaceRoot } from "./local-dev.mjs";
@@ -47,10 +49,7 @@ const heartbeatIntervalMs = parsePositiveInteger(
   "NOTEBOOK_CLOUD_WORKSTATION_HEARTBEAT_MS",
   20_000,
 );
-const runtimedBin = path.resolve(
-  workspaceRoot,
-  process.env.NOTEBOOK_CLOUD_RUNTIMED_BIN ?? "target/release/runtimed",
-);
+const runtimeAgentBin = runtimeAgentBinaryFromEnv(process.env, workspaceRoot);
 const agentRoot = path.resolve(
   workspaceRoot,
   process.env.NOTEBOOK_CLOUD_WORKSTATION_AGENT_ROOT ??
@@ -68,7 +67,7 @@ main().catch((error) => {
 
 async function main() {
   requireCloudCredential();
-  await assertBinaryExists(runtimedBin, "runtimed");
+  await assertBinaryExists(runtimeAgentBin, "runtime agent binary");
   const pythonPath = await resolvePythonPath();
   await mkdir(agentRoot, { recursive: true });
 
@@ -81,6 +80,7 @@ async function main() {
       workingDirectory,
       pythonPath,
       authKind,
+      runtimeAgentBin: runtimeAgentBinaryLabel(runtimeAgentBin),
       pollIntervalMs,
     }),
   );
@@ -147,6 +147,7 @@ async function registerWorkstation(pythonPath) {
         displayName,
         workingDirectory,
         pythonPath,
+        runtimeBinary: runtimeAgentBinaryLabel(runtimeAgentBin),
       }),
     ),
   });
@@ -179,6 +180,7 @@ async function startAttachJob(job, pythonPath) {
     workstationId,
     displayName,
     authKind,
+    runtimeAgentBin,
   });
   await mkdir(plan.blobRoot, { recursive: true });
   await patchAttachJob(job.job_id, {
@@ -186,7 +188,7 @@ async function startAttachJob(job, pythonPath) {
   });
 
   const logFd = openSync(plan.logPath, "a");
-  const child = spawn(runtimedBin, plan.args, {
+  const child = spawn(plan.executable, plan.args, {
     cwd: plan.cwd,
     env: runtimeAgentEnv(),
     stdio: ["ignore", logFd, logFd],
@@ -407,13 +409,21 @@ function which(command) {
 }
 
 async function assertBinaryExists(binaryPath, name) {
+  if (!isPathLike(binaryPath)) {
+    if (await which(binaryPath)) return;
+    throw new Error(`Missing ${name} command ${binaryPath} on PATH.`);
+  }
   try {
     await access(binaryPath);
   } catch {
     throw new Error(
-      `Missing ${name} binary at ${binaryPath}. Run \`cargo build --release -p runtimed\` first, or set NOTEBOOK_CLOUD_${name.toUpperCase().replaceAll("-", "_")}_BIN.`,
+      `Missing ${name} at ${binaryPath}. Run \`cargo build --release -p runtimed\` first, or set NOTEBOOK_CLOUD_RUNTIME_AGENT_BIN.`,
     );
   }
+}
+
+function isPathLike(value) {
+  return path.isAbsolute(value) || value.includes("/") || value.includes("\\");
 }
 
 function assertResponse(response, body, label, expectedStatuses) {

--- a/apps/notebook-cloud/test/hosted-workstation-agent.test.mjs
+++ b/apps/notebook-cloud/test/hosted-workstation-agent.test.mjs
@@ -10,6 +10,8 @@ import {
   parseHttpResponseBody,
   parsePositiveInteger,
   retryAfterMs,
+  runtimeAgentBinaryFromEnv,
+  runtimeAgentBinaryLabel,
   stableWorkstationId,
 } from "../scripts/hosted-workstation-agent-core.mjs";
 
@@ -29,6 +31,7 @@ describe("hosted workstation agent launch contract", () => {
     });
 
     assert.equal(plan.cwd, "/home/ubuntu/project");
+    assert.equal(plan.executable, "runtimed");
     assert.equal(plan.blobRoot, "/tmp/agent/job-123/blobs");
     assert.equal(plan.logPath, "/tmp/agent/job-123/runtime-peer.log");
     assert.deepEqual(plan.args, [
@@ -66,9 +69,11 @@ describe("hosted workstation agent launch contract", () => {
       workingDirectory: "/home/ubuntu/project",
       workstationId: "ws-lab2",
       displayName: "lab2 workstation",
+      runtimeAgentBin: "/home/ubuntu/.local/bin/runt",
       authKind: "oidc",
     });
 
+    assert.equal(plan.executable, "/home/ubuntu/.local/bin/runt");
     assert.deepEqual(plan.args.slice(0, 3), ["cloud-runtime-agent", "--auth-kind", "oidc"]);
     assert.equal(plan.args.includes("oidc-token"), false);
   });
@@ -136,6 +141,7 @@ describe("hosted workstation agent launch contract", () => {
         displayName: "lab2 workstation",
         workingDirectory: "/home/ubuntu/project",
         pythonPath: "/opt/k/bin/python",
+        runtimeBinary: "runt",
         cpuCount: 8,
         memoryBytes: 16_000_000_000,
       }),
@@ -152,11 +158,30 @@ describe("hosted workstation agent launch contract", () => {
           launch_current_python: true,
         },
         runtime: {
-          binary: "runtimed",
+          binary: "runt",
           python_path: "/opt/k/bin/python",
         },
       },
     );
+  });
+
+  it("resolves runtime agent binaries from neutral and compatibility env vars", () => {
+    assert.equal(
+      runtimeAgentBinaryFromEnv(
+        {
+          NOTEBOOK_CLOUD_RUNTIME_AGENT_BIN: "/opt/nteract/bin/runt",
+          NOTEBOOK_CLOUD_RUNTIMED_BIN: "/opt/nteract/bin/runtimed",
+        },
+        "/repo",
+      ),
+      "/opt/nteract/bin/runt",
+    );
+    assert.equal(runtimeAgentBinaryFromEnv({ NOTEBOOK_CLOUD_RUNT_BIN: "runt" }, "/repo"), "runt");
+    assert.equal(
+      runtimeAgentBinaryFromEnv({ NOTEBOOK_CLOUD_RUNTIMED_BIN: "target/debug/runtimed" }, "/repo"),
+      "/repo/target/debug/runtimed",
+    );
+    assert.equal(runtimeAgentBinaryLabel("/opt/nteract/bin/runt"), "runt");
   });
 
   it("keeps generated workstation ids and polling intervals bounded", () => {

--- a/docs/remote-workstation.md
+++ b/docs/remote-workstation.md
@@ -39,15 +39,19 @@ For air-gapped installs, download the release assets yourself and use
 2. On the workstation:
 
 ```bash
-RUNT_CLOUD_TOKEN=<token> runtimed cloud-runtime-agent \
+RUNTIME_AGENT_BIN=${RUNTIME_AGENT_BIN:-runtimed}
+RUNT_CLOUD_TOKEN=<token> "$RUNTIME_AGENT_BIN" cloud-runtime-agent \
   --cloud-url https://app.runt.run \
   --notebook-id <id> \
   --python-path "$(command -v python3)"
 ```
 
-The credential always rides the environment, never argv. Defaults: scope
-`runtime_peer`, auth kind `oidc` (use `--auth-kind anaconda-key` for Anaconda
-API keys), blob root under the daemon's standard cache. `--python-path`
+Use the installed binary that exposes `cloud-runtime-agent`; current channels
+may package that as `runtimed`, while workstation deployments can point
+`RUNTIME_AGENT_BIN` at `runt` when that is the installed command surface. The
+credential always rides the environment, never argv. Defaults: scope
+`runtime_peer`, auth kind `oidc` (use `--auth-kind anaconda-key` for Anaconda API
+keys), blob root under the daemon's standard cache. `--python-path`
 launches a kernel in that interpreter immediately on attach
 (launch-on-attach); omit it to attach idle and wait for the room to dispatch
 work. `--workstation-id` / `--workstation-display-name` set the non-secret


### PR DESCRIPTION
## Summary
- add a neutral runtime-agent binary resolver for hosted workstation automation
- keep `NOTEBOOK_CLOUD_RUNTIMED_BIN` compatibility while preferring `NOTEBOOK_CLOUD_RUNTIME_AGENT_BIN` / `NOTEBOOK_CLOUD_RUNT_BIN`
- pass the resolved executable through attach-job spawn plans and register the displayed binary name in workstation metadata
- update hosted runtime-peer/workstation smoke docs away from hardcoding `runtimed` everywhere

## Notes
This does not move the hidden `cloud-runtime-agent` command into `runt`; current source still exposes it from `runtimed`. It makes the cloud helper/smokes work with whichever installed binary actually exposes the subcommand in a given channel.

## Validation
- `cargo xtask lint --fix`
- `pnpm --dir apps/notebook-cloud exec node --test test/hosted-workstation-agent.test.mjs`
- `node --check apps/notebook-cloud/scripts/hosted-workstation-agent.mjs`
- `node --check apps/notebook-cloud/scripts/hosted-runtime-peer-smoke.mjs`