### PR TITLE
fix(cloud): back off workstation runner on rate limits

### DIFF
--- a/apps/notebook-cloud/README.md
+++ b/apps/notebook-cloud/README.md
@@ -720,12 +720,17 @@ polls `GET /api/workstations/:workstationId/attach-jobs`, and spawns
 `runtimed cloud-runtime-agent` for pending attach jobs. API-key auth is the
 default (`NOTEBOOK_CLOUD_WORKSTATION_AUTH_KIND=anaconda-key`); set
 `NOTEBOOK_CLOUD_WORKSTATION_AUTH_KIND=oidc` when `NTERACT_API_KEY` carries a
-short-lived OIDC bearer token. The credential is passed to the runtime peer
-through `RUNT_CLOUD_TOKEN`, not through argv; `runtimed` removes cloud
-environment variables again before launching the Python kernel. Run this helper
-inside tmux for preview/manual testing so the polling agent stays alive while
-the browser attaches workstations. The first registered workstation becomes the
-account default automatically; use the Workstations rail or
+short-lived OIDC bearer token. Prefer API-key auth for long-lived tmux/systemd
+workstations; browser OIDC token refresh depends on an active browser session.
+The credential is passed to the runtime peer through `RUNT_CLOUD_TOKEN`, not
+through argv; `runtimed` removes cloud environment variables again before
+launching the Python kernel. When the hosted service returns a rate-limit or
+maintenance response (`429`/`503`), the runner honors `Retry-After` when
+present and otherwise backs off with a capped exponential cooldown before
+heartbeating or polling again. Run this helper inside tmux for preview/manual
+testing so the polling agent stays alive while the browser attaches
+workstations. The first registered workstation becomes the account default
+automatically; use the Workstations rail or
 `PATCH /api/workstations/default` only when switching to another machine. In a
 private owner room, the toolbar can then request attachment directly.
 

--- a/apps/notebook-cloud/scripts/hosted-runtime-peer-smoke.mjs
+++ b/apps/notebook-cloud/scripts/hosted-runtime-peer-smoke.mjs
@@ -5,6 +5,7 @@ import os from "node:os";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 
+import { parseHttpResponseBody } from "./hosted-workstation-agent-core.mjs";
 import { notebookCloudBaseUrl, notebookCloudWorkspaceRoot } from "./local-dev.mjs";
 
 const appDir = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
@@ -274,7 +275,7 @@ async function createNotebookRoom() {
     },
     body: JSON.stringify({ vanity_name: vanityName }),
   });
-  const body = await response.json().catch(async () => ({ error: await response.text() }));
+  const body = await parseHttpResponseBody(response);
   assertResponse(response, body, "create notebook room", 201);
   const notebookId = body.notebook_id;
   assert(
@@ -303,7 +304,7 @@ async function grantRuntimePeer(notebookId) {
       scope: "runtime_peer",
     }),
   });
-  const body = await response.json().catch(async () => ({ error: await response.text() }));
+  const body = await parseHttpResponseBody(response);
   assertResponse(response, body, "grant runtime_peer", 201);
 }
 
@@ -311,7 +312,7 @@ async function fetchJson(pathname) {
   const response = await fetch(new URL(pathname, baseUrl), {
     headers: apiKeyHeaders("owner"),
   });
-  const body = await response.json().catch(async () => ({ error: await response.text() }));
+  const body = await parseHttpResponseBody(response);
   assertResponse(response, body, `GET ${pathname}`, 200);
   return body;
 }

--- a/apps/notebook-cloud/scripts/hosted-workstation-agent-core.mjs
+++ b/apps/notebook-cloud/scripts/hosted-workstation-agent-core.mjs
@@ -3,6 +3,7 @@ import path from "node:path";
 
 export const DEFAULT_WORKSTATION_AUTH_KIND = "anaconda-key";
 export const DEFAULT_WORKSTATION_RETRY_AFTER_MS = 60_000;
+export const MAX_WORKSTATION_RETRY_AFTER_MS = 15 * 60_000;
 export const WORKSTATION_AUTH_KINDS = new Set([DEFAULT_WORKSTATION_AUTH_KIND, "oidc"]);
 
 export function buildWorkstationRegistrationPayload({
@@ -188,6 +189,22 @@ export function retryAfterMs(response, fallbackMs = DEFAULT_WORKSTATION_RETRY_AF
   }
 
   return fallbackMs;
+}
+
+export function retryCooldownMs({
+  retryAfterMs,
+  failureCount,
+  maxMs = MAX_WORKSTATION_RETRY_AFTER_MS,
+  jitterRatio = 0.2,
+  random = Math.random,
+}) {
+  const retryAfter = Math.max(1_000, Number(retryAfterMs) || DEFAULT_WORKSTATION_RETRY_AFTER_MS);
+  const failures = Math.max(1, Number(failureCount) || 1);
+  const maxDelay = Math.max(retryAfter, Number(maxMs) || MAX_WORKSTATION_RETRY_AFTER_MS);
+  const exponent = Math.min(failures - 1, 6);
+  const baseDelay = Math.min(maxDelay, retryAfter * 2 ** exponent);
+  const jitter = Math.max(0, baseDelay * jitterRatio * random());
+  return Math.min(maxDelay, Math.ceil(baseDelay + jitter));
 }
 
 function assert(condition, message) {

--- a/apps/notebook-cloud/scripts/hosted-workstation-agent.mjs
+++ b/apps/notebook-cloud/scripts/hosted-workstation-agent.mjs
@@ -14,6 +14,7 @@ import {
   normalizeWorkstationAuthKind,
   parseHttpResponseBody,
   parsePositiveInteger,
+  retryCooldownMs,
   retryAfterMs,
   stableWorkstationId,
 } from "./hosted-workstation-agent-core.mjs";
@@ -60,6 +61,7 @@ const agentRoot = path.resolve(
 const activeJobs = new Map();
 let lastHeartbeatAt = 0;
 let cooldownUntil = 0;
+const retryableFailureCounts = new Map();
 
 main().catch((error) => {
   console.error(error instanceof Error ? error.message : String(error));
@@ -102,16 +104,27 @@ async function main() {
 
 async function runAgentStep(step, fn) {
   try {
-    await fn();
+    const madeCloudRequest = await fn();
+    if (madeCloudRequest) {
+      retryableFailureCounts.delete(step);
+    }
   } catch (error) {
-    const stepRetryAfterMs = Number(error?.retryAfterMs ?? 0);
-    if (Number.isFinite(stepRetryAfterMs) && stepRetryAfterMs > 0) {
-      cooldownUntil = Math.max(cooldownUntil, Date.now() + stepRetryAfterMs);
+    const retryAfterMs = Number(error?.retryAfterMs ?? 0);
+    if (Number.isFinite(retryAfterMs) && retryAfterMs > 0) {
+      const retryableFailureCount = (retryableFailureCounts.get(step) ?? 0) + 1;
+      retryableFailureCounts.set(step, retryableFailureCount);
+      const cooldownMs = retryCooldownMs({
+        retryAfterMs,
+        failureCount: retryableFailureCount,
+      });
+      cooldownUntil = Math.max(cooldownUntil, Date.now() + cooldownMs);
       console.error(
         JSON.stringify({
           event: "workstation_agent_cooling_down",
           step,
-          retryAfterMs: stepRetryAfterMs,
+          retryAfterMs,
+          cooldownMs,
+          retryableFailureCount,
         }),
       );
     }
@@ -128,10 +141,11 @@ async function runAgentStep(step, fn) {
 async function heartbeatIfNeeded(pythonPath) {
   const now = Date.now();
   if (now - lastHeartbeatAt < heartbeatIntervalMs) {
-    return;
+    return false;
   }
   await registerWorkstation(pythonPath);
   lastHeartbeatAt = now;
+  return true;
 }
 
 async function registerWorkstation(pythonPath) {
@@ -167,6 +181,7 @@ async function pollAttachJobs(pythonPath) {
     if (activeJobs.has(job.job_id)) continue;
     await startAttachJob(job, pythonPath);
   }
+  return true;
 }
 
 async function startAttachJob(job, pythonPath) {

--- a/apps/notebook-cloud/scripts/hosted-workstation-toolbar-smoke.mjs
+++ b/apps/notebook-cloud/scripts/hosted-workstation-toolbar-smoke.mjs
@@ -9,6 +9,7 @@ import {
   buildWorkstationAuthHeaders,
   DEFAULT_WORKSTATION_AUTH_KIND,
   normalizeWorkstationAuthKind,
+  parseHttpResponseBody,
 } from "./hosted-workstation-agent-core.mjs";
 import {
   saveSmokeScreenshot,
@@ -857,7 +858,7 @@ async function fetchJson({
   }
 
   const response = await fetch(new URL(pathname, baseUrl), requestInit);
-  const payload = await response.json().catch(async () => ({ error: await response.text() }));
+  const payload = await parseHttpResponseBody(response);
   if (!expectedStatuses.includes(response.status)) {
     throw new Error(`${label} failed: ${response.status} ${JSON.stringify(payload)}`);
   }

--- a/apps/notebook-cloud/test/hosted-workstation-agent.test.mjs
+++ b/apps/notebook-cloud/test/hosted-workstation-agent.test.mjs
@@ -10,6 +10,7 @@ import {
   parseHttpResponseBody,
   parsePositiveInteger,
   retryAfterMs,
+  retryCooldownMs,
   stableWorkstationId,
 } from "../scripts/hosted-workstation-agent-core.mjs";
 
@@ -203,5 +204,41 @@ describe("hosted workstation agent launch contract", () => {
       `date retry delay should be bounded, got ${retryDateDelay}`,
     );
     assert.equal(retryAfterMs(new Response("no hint", { status: 503 }), 12_345), 12_345);
+  });
+
+  it("expands retry cooldowns for repeated rate-limit responses", () => {
+    assert.equal(
+      retryCooldownMs({
+        retryAfterMs: 60_000,
+        failureCount: 1,
+        random: () => 0,
+      }),
+      60_000,
+    );
+    assert.equal(
+      retryCooldownMs({
+        retryAfterMs: 60_000,
+        failureCount: 2,
+        random: () => 0,
+      }),
+      120_000,
+    );
+    assert.equal(
+      retryCooldownMs({
+        retryAfterMs: 60_000,
+        failureCount: 8,
+        random: () => 0,
+      }),
+      900_000,
+    );
+    assert.equal(
+      retryCooldownMs({
+        retryAfterMs: 10_000,
+        failureCount: 1,
+        jitterRatio: 0.2,
+        random: () => 0.5,
+      }),
+      11_000,
+    );
   });
 });

--- a/docs/remote-workstation.md
+++ b/docs/remote-workstation.md
@@ -47,7 +47,9 @@ RUNT_CLOUD_TOKEN=<token> runtimed cloud-runtime-agent \
 
 The credential always rides the environment, never argv. Defaults: scope
 `runtime_peer`, auth kind `oidc` (use `--auth-kind anaconda-key` for Anaconda
-API keys), blob root under the daemon's standard cache. `--python-path`
+API keys). Prefer API-key auth for long-lived headless workstations; OIDC
+bearers are best for browser-coupled sessions where refresh is active. Blob
+root defaults under the daemon's standard cache. `--python-path`
 launches a kernel in that interpreter immediately on attach
 (launch-on-attach); omit it to attach idle and wait for the room to dispatch
 work. `--workstation-id` / `--workstation-display-name` set the non-secret
@@ -69,10 +71,10 @@ Description=nteract workstation agent for notebook %i
 After=network-online.target
 
 [Service]
-Environment=RUNT_CLOUD_AUTH_KIND=oidc
+Environment=RUNT_CLOUD_AUTH_KIND=anaconda-key
 EnvironmentFile=%h/.config/nteract/workstation.env
 ExecStart=%h/.local/bin/runtimed cloud-runtime-agent \
-  --cloud-url https://app.runt.run --notebook-id %i \
+  --auth-kind anaconda-key --cloud-url https://app.runt.run --notebook-id %i \
   --workstation-id %H
 Restart=on-failure
 RestartSec=5
@@ -88,7 +90,7 @@ then:
 systemctl --user enable --now nteract-workstation@<notebook-id>
 ```
 
-For long-lived peers whose OIDC token expires, mint fresh tokens via a
+For browser-coupled OIDC peers whose token expires, mint fresh tokens via a
 refresher (the transport supports per-connect refresh; see
 `notebook-cloud-transport`'s `TokenRefresher`).
 


### PR DESCRIPTION
## Summary

- add capped exponential cooldown with jitter for hosted workstation runner 429/503 responses
- keep backoff state tied to actual cloud request success so skipped heartbeat ticks do not hide repeated failures
- track retry escalation per runner step so a successful heartbeat does not reset attach-job polling backoff
- preserve non-JSON hosted smoke response bodies, including Cloudflare 1027 HTML pages, instead of losing them after failed `response.json()` parsing
- document API-key auth as the preferred long-lived workstation path and describe rate-limit/maintenance backoff behavior

## Validation

- `pnpm --dir apps/notebook-cloud exec node --test test/hosted-workstation-agent.test.mjs test/hosted-workstation-toolbar-smoke.test.mjs test/hosted-runtime-browser-execute-smoke.test.mjs`
- `node --check apps/notebook-cloud/scripts/hosted-workstation-agent.mjs`
- `node --check apps/notebook-cloud/scripts/hosted-workstation-agent-core.mjs`
- `node --check apps/notebook-cloud/scripts/hosted-runtime-peer-smoke.mjs`
- `node --check apps/notebook-cloud/scripts/hosted-workstation-toolbar-smoke.mjs`
- `cargo xtask lint --fix`

Live preview smoke intentionally skipped: `preview.runt.run` is currently Cloudflare 1027 / rate-limit blocked.
