### PR TITLE
docs(cloud): add EC2 fallback runbook

### DIFF
--- a/apps/notebook-cloud/README.md
+++ b/apps/notebook-cloud/README.md
@@ -591,6 +591,12 @@ pnpm --workspace-root exec wrangler tail nteract-notebook-cloud \
   --format pretty
 ```
 
+If `preview.runt.run` is unavailable or rate-limited, use
+[`docs/notebook-cloud-ec2-fallback.md`](../../docs/notebook-cloud-ec2-fallback.md)
+to run this same Worker bundle on one EC2 instance through
+`wrangler dev --local --persist-to`. That fallback is intended for demos and
+recovery drills, not as a production replacement for the hosted topology.
+
 Useful events while debugging collaboration:
 
 - `room.connection.accepted` / `room.connection.closed` - peer lifecycle and

--- a/apps/notebook-cloud/package.json
+++ b/apps/notebook-cloud/package.json
@@ -18,6 +18,7 @@
     "test:renderer-parity": "playwright test -c playwright.render-parity.config.ts",
     "test:renderer-parity:update": "playwright test -c playwright.render-parity.config.ts --update-snapshots",
     "dev": "node scripts/dev.mjs",
+    "dev:ec2": "node scripts/ec2-local-worker.mjs",
     "smoke": "node --import tsx scripts/smoke.mjs",
     "smoke:hosted": "node scripts/hosted-render-smoke.mjs",
     "smoke:hosted:live": "node scripts/hosted-live-smoke.mjs",

--- a/apps/notebook-cloud/scripts/ec2-local-worker.mjs
+++ b/apps/notebook-cloud/scripts/ec2-local-worker.mjs
@@ -1,0 +1,170 @@
+import { spawn } from "node:child_process";
+import { randomBytes } from "node:crypto";
+import path from "node:path";
+
+import { notebookCloudAppDir, notebookCloudWorkspaceRoot } from "./local-dev.mjs";
+
+const DEFAULT_EC2_PORT = 8787;
+const DEFAULT_EC2_HOST = "0.0.0.0";
+
+if (isMainModule()) {
+  main().catch((error) => {
+    console.error(error instanceof Error ? error.message : String(error));
+    process.exitCode = 1;
+  });
+}
+
+async function main() {
+  const workspaceRoot = notebookCloudWorkspaceRoot();
+  const appDir = notebookCloudAppDir();
+  const plan = ec2LocalWorkerPlan({
+    appDir,
+    env: process.env,
+    workspaceRoot,
+  });
+
+  printPlan(plan);
+
+  const child = spawn("pnpm", plan.args, {
+    cwd: workspaceRoot,
+    env: process.env,
+    stdio: "inherit",
+  });
+
+  child.on("error", (error) => {
+    console.error(`Failed to start EC2 notebook-cloud Worker: ${error.message}`);
+    process.exitCode = 1;
+  });
+  child.on("close", (code, signal) => {
+    if (signal) {
+      process.kill(process.pid, signal);
+      return;
+    }
+    process.exitCode = code ?? 1;
+  });
+}
+
+export function ec2LocalWorkerPlan({ appDir, env, workspaceRoot }) {
+  const port = positiveInteger(env.NOTEBOOK_CLOUD_EC2_PORT, DEFAULT_EC2_PORT);
+  const host = env.NOTEBOOK_CLOUD_EC2_HOST?.trim() || DEFAULT_EC2_HOST;
+  const publicOrigin =
+    normalizedOrigin(
+      env.NOTEBOOK_CLOUD_EC2_PUBLIC_ORIGIN || env.NTERACT_CLOUD_URL || env.NOTEBOOK_CLOUD_URL,
+    ) ?? `http://localhost:${port}`;
+  const persistTo = path.resolve(
+    workspaceRoot,
+    env.NOTEBOOK_CLOUD_EC2_PERSIST_TO || path.join(".context", "ec2", "notebook-cloud-state"),
+  );
+  const configPath = path.relative(workspaceRoot, path.join(appDir, "wrangler.toml"));
+  const devToken = env.NOTEBOOK_CLOUD_DEV_TOKEN?.trim() || randomDevToken();
+  const generatedDevToken = !env.NOTEBOOK_CLOUD_DEV_TOKEN?.trim();
+  const oidcEnabled = env.NOTEBOOK_CLOUD_EC2_ENABLE_OIDC === "1";
+
+  const vars = {
+    DEPLOYMENT_ENV: "ec2",
+    NOTEBOOK_CLOUD_ALLOWED_ORIGINS: publicOrigin,
+    NOTEBOOK_CLOUD_DEV_TOKEN: devToken,
+    // EC2 fallback defaults to same-origin assets and srcdoc output frames.
+    RENDERER_ASSETS_BASE_URL: "",
+    RUNTIMED_WASM_BASE_URL: "",
+    OUTPUT_DOCUMENT_BASE_URL: "",
+    ...(oidcEnabled
+      ? {
+          NOTEBOOK_CLOUD_OIDC_REDIRECT_URI:
+            env.NOTEBOOK_CLOUD_OIDC_REDIRECT_URI || `${publicOrigin}/oidc`,
+        }
+      : disabledOidcVars()),
+  };
+
+  const args = [
+    "--workspace-root",
+    "exec",
+    "wrangler",
+    "dev",
+    "--config",
+    configPath,
+    "--local",
+    "--ip",
+    host,
+    "--port",
+    String(port),
+    "--persist-to",
+    persistTo,
+    "--live-reload=false",
+    "--show-interactive-dev-session=false",
+  ];
+  for (const [name, value] of Object.entries(vars)) {
+    args.push("--var", `${name}:${value}`);
+  }
+  args.push(...extraWranglerArgs(env));
+
+  return {
+    args,
+    devToken,
+    generatedDevToken,
+    host,
+    oidcEnabled,
+    persistTo,
+    port,
+    publicOrigin,
+  };
+}
+
+function disabledOidcVars() {
+  return {
+    NOTEBOOK_CLOUD_APP_SESSION_SECRET: "",
+    NOTEBOOK_CLOUD_OIDC_AUDIENCE: "",
+    NOTEBOOK_CLOUD_OIDC_CLIENT_ID: "",
+    NOTEBOOK_CLOUD_OIDC_ISSUER: "",
+    NOTEBOOK_CLOUD_OIDC_JWKS_JSON: "",
+    NOTEBOOK_CLOUD_OIDC_PRINCIPAL_NAMESPACE: "",
+    NOTEBOOK_CLOUD_OIDC_REDIRECT_URI: "",
+  };
+}
+
+function printPlan(plan) {
+  console.error(`Starting notebook-cloud EC2 fallback on ${plan.host}:${plan.port}`);
+  console.error(`Public origin: ${plan.publicOrigin}`);
+  console.error(`Persisted Miniflare state: ${plan.persistTo}`);
+  console.error(
+    plan.oidcEnabled
+      ? "OIDC override enabled; make sure the redirect URI is registered."
+      : "OIDC disabled; use prototype dev-token auth for browser access.",
+  );
+  if (plan.generatedDevToken) {
+    console.error(`Generated ephemeral NOTEBOOK_CLOUD_DEV_TOKEN: ${plan.devToken}`);
+  }
+  console.error(`Open ${plan.publicOrigin}/?dev_auth=1 to enter the dev token.`);
+}
+
+function positiveInteger(value, fallback) {
+  if (value == null || value === "") return fallback;
+  const parsed = Number(value);
+  if (!Number.isInteger(parsed) || parsed <= 0 || parsed > 65_535) {
+    throw new Error("NOTEBOOK_CLOUD_EC2_PORT must be an integer TCP port between 1 and 65535");
+  }
+  return parsed;
+}
+
+function normalizedOrigin(value) {
+  const trimmed = value?.trim();
+  if (!trimmed) return null;
+  try {
+    return new URL(trimmed).origin;
+  } catch {
+    throw new Error(`NOTEBOOK_CLOUD_EC2_PUBLIC_ORIGIN must be an absolute URL, got ${trimmed}`);
+  }
+}
+
+function randomDevToken() {
+  return `ec2-${randomBytes(24).toString("base64url")}`;
+}
+
+function extraWranglerArgs(env) {
+  const raw = env.NOTEBOOK_CLOUD_EC2_WRANGLER_ARGS?.trim();
+  return raw ? raw.split(/\s+/).filter(Boolean) : [];
+}
+
+function isMainModule() {
+  return import.meta.url === new URL(process.argv[1], "file:").href;
+}

--- a/apps/notebook-cloud/test/ec2-local-worker.test.mjs
+++ b/apps/notebook-cloud/test/ec2-local-worker.test.mjs
@@ -1,0 +1,96 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+
+import { ec2LocalWorkerPlan } from "../scripts/ec2-local-worker.mjs";
+
+describe("EC2 local Worker wrapper", () => {
+  it("runs Wrangler local dev with persisted state and same-origin assets by default", () => {
+    const plan = ec2LocalWorkerPlan({
+      appDir: "/repo/apps/notebook-cloud",
+      workspaceRoot: "/repo",
+      env: {
+        NOTEBOOK_CLOUD_DEV_TOKEN: "dev-secret",
+        NOTEBOOK_CLOUD_EC2_PUBLIC_ORIGIN: "https://notebooks.example.test/app",
+      },
+    });
+
+    assert.equal(plan.publicOrigin, "https://notebooks.example.test");
+    assert.equal(plan.generatedDevToken, false);
+    assert.deepEqual(plan.args.slice(0, 12), [
+      "--workspace-root",
+      "exec",
+      "wrangler",
+      "dev",
+      "--config",
+      "apps/notebook-cloud/wrangler.toml",
+      "--local",
+      "--ip",
+      "0.0.0.0",
+      "--port",
+      "8787",
+      "--persist-to",
+    ]);
+    assert.equal(plan.args.includes("/repo/.context/ec2/notebook-cloud-state"), true);
+    assert.equal(varValue(plan.args, "DEPLOYMENT_ENV"), "ec2");
+    assert.equal(
+      varValue(plan.args, "NOTEBOOK_CLOUD_ALLOWED_ORIGINS"),
+      "https://notebooks.example.test",
+    );
+    assert.equal(varValue(plan.args, "NOTEBOOK_CLOUD_DEV_TOKEN"), "dev-secret");
+    assert.equal(varValue(plan.args, "RENDERER_ASSETS_BASE_URL"), "");
+    assert.equal(varValue(plan.args, "RUNTIMED_WASM_BASE_URL"), "");
+    assert.equal(varValue(plan.args, "OUTPUT_DOCUMENT_BASE_URL"), "");
+    assert.equal(varValue(plan.args, "NOTEBOOK_CLOUD_OIDC_ISSUER"), "");
+    assert.equal(varValue(plan.args, "NOTEBOOK_CLOUD_OIDC_REDIRECT_URI"), "");
+  });
+
+  it("can enable OIDC when the deployment has a registered redirect URI", () => {
+    const plan = ec2LocalWorkerPlan({
+      appDir: "/repo/apps/notebook-cloud",
+      workspaceRoot: "/repo",
+      env: {
+        NOTEBOOK_CLOUD_DEV_TOKEN: "dev-secret",
+        NOTEBOOK_CLOUD_EC2_ENABLE_OIDC: "1",
+        NOTEBOOK_CLOUD_EC2_PUBLIC_ORIGIN: "https://notebooks.example.test",
+      },
+    });
+
+    assert.equal(plan.oidcEnabled, true);
+    assert.equal(
+      varValue(plan.args, "NOTEBOOK_CLOUD_OIDC_REDIRECT_URI"),
+      "https://notebooks.example.test/oidc",
+    );
+    assert.equal(varValue(plan.args, "NOTEBOOK_CLOUD_OIDC_ISSUER"), null);
+  });
+
+  it("accepts explicit port, host, persistence path, and extra Wrangler args", () => {
+    const plan = ec2LocalWorkerPlan({
+      appDir: "/repo/apps/notebook-cloud",
+      workspaceRoot: "/repo",
+      env: {
+        NOTEBOOK_CLOUD_DEV_TOKEN: "dev-secret",
+        NOTEBOOK_CLOUD_EC2_HOST: "127.0.0.1",
+        NOTEBOOK_CLOUD_EC2_PORT: "9876",
+        NOTEBOOK_CLOUD_EC2_PERSIST_TO: "/var/lib/nteract-cloud",
+        NOTEBOOK_CLOUD_EC2_WRANGLER_ARGS: "--log-level debug",
+      },
+    });
+
+    assert.equal(plan.host, "127.0.0.1");
+    assert.equal(plan.port, 9876);
+    assert.equal(plan.publicOrigin, "http://localhost:9876");
+    assert.equal(plan.persistTo, "/var/lib/nteract-cloud");
+    assert.deepEqual(plan.args.slice(-2), ["--log-level", "debug"]);
+  });
+});
+
+function varValue(args, name) {
+  for (let index = 0; index < args.length - 1; index += 1) {
+    if (args[index] !== "--var") continue;
+    const value = args[index + 1];
+    if (value.startsWith(`${name}:`)) {
+      return value.slice(name.length + 1);
+    }
+  }
+  return null;
+}

--- a/docs/notebook-cloud-ec2-fallback.md
+++ b/docs/notebook-cloud-ec2-fallback.md
@@ -1,0 +1,208 @@
+# Notebook Cloud EC2 fallback
+
+This is the lowest-churn way to run the hosted notebook prototype when
+`preview.runt.run` is unavailable or rate-limited. It does **not** introduce a
+second room-host implementation. It runs the existing Cloudflare Worker bundle
+locally through Wrangler/Miniflare on one EC2 instance, with persisted local
+Durable Object, D1, and R2-compatible state.
+
+Use this for demos and recovery drills. It is not the long-term production
+topology.
+
+## Shape
+
+```text
+browser
+  |
+  | HTTPS / WebSocket
+  v
+EC2 reverse proxy
+  |
+  | http://127.0.0.1:8787
+  v
+wrangler dev --local --persist-to /var/lib/nteract/notebook-cloud
+  |
+  +- NotebookRoom Durable Objects in local Miniflare state
+  +- D1 catalog/sharing/workstation tables in local Miniflare state
+  +- R2-like snapshot/blob objects in local Miniflare state
+  +- built viewer/runtime/renderer assets from apps/notebook-cloud/dist
+```
+
+The EC2 wrapper deliberately overrides preview-specific asset URLs so the
+viewer uses same-origin `/assets/` and `/renderer-assets/` paths. The isolated
+output document origin falls back to the browser `srcdoc` path unless you run a
+separate output-origin service.
+
+## Build
+
+From the repository checkout on EC2:
+
+```bash
+pnpm install
+pnpm --dir apps/notebook-cloud run build
+```
+
+Build first. The EC2 wrapper starts the Worker runtime; it does not rebuild
+viewer/WASM assets on every process start.
+
+## Browser auth for fallback demos
+
+OIDC login requires a redirect URI registered for the public EC2 origin. Until
+that exists, use the existing prototype dev-token flow for human browser access.
+The token is sent in first-party headers/WebSocket subprotocols, not in URLs.
+
+Generate a token and keep it out of git:
+
+```bash
+install -d -m 700 ~/.config/nteract
+printf "NOTEBOOK_CLOUD_DEV_TOKEN=%s\n" "$(openssl rand -base64 32)" \
+  > ~/.config/nteract/notebook-cloud-ec2.env
+chmod 600 ~/.config/nteract/notebook-cloud-ec2.env
+```
+
+Open `https://<host>/?dev_auth=1`, enter the token, choose the user/scope for
+the demo, then open `/n`.
+
+API-key auth still works for workstation runners and scripts. Put the existing
+Anaconda API key in the environment used by those processes; do not place it in
+the browser.
+
+## Start manually
+
+```bash
+set -a
+. ~/.config/nteract/notebook-cloud-ec2.env
+set +a
+
+NOTEBOOK_CLOUD_EC2_PUBLIC_ORIGIN=https://notebooks.example.com \
+NOTEBOOK_CLOUD_EC2_HOST=127.0.0.1 \
+NOTEBOOK_CLOUD_EC2_PORT=8787 \
+NOTEBOOK_CLOUD_EC2_PERSIST_TO=/var/lib/nteract/notebook-cloud \
+pnpm --dir apps/notebook-cloud run dev:ec2
+```
+
+The wrapper runs:
+
+- `wrangler dev --local`
+- `--persist-to` so rooms/catalog/blob state survives restarts
+- `DEPLOYMENT_ENV=ec2`
+- `NOTEBOOK_CLOUD_ALLOWED_ORIGINS=<public origin>`
+- same-origin renderer/runtime asset URLs
+- OIDC disabled by default, so the prototype dev-token UI is visible
+
+Set `NOTEBOOK_CLOUD_EC2_ENABLE_OIDC=1` only after the public origin's
+`/oidc` redirect URI is registered with the identity provider. In that mode the
+wrapper keeps the normal OIDC config and overrides only
+`NOTEBOOK_CLOUD_OIDC_REDIRECT_URI` to `<public origin>/oidc` unless you set it
+explicitly.
+
+## Reverse proxy
+
+Any proxy must support WebSocket upgrades. A minimal Caddy shape:
+
+```caddyfile
+notebooks.example.com {
+  reverse_proxy 127.0.0.1:8787
+}
+```
+
+For nginx:
+
+```nginx
+server {
+  listen 443 ssl;
+  server_name notebooks.example.com;
+
+  location / {
+    proxy_pass http://127.0.0.1:8787;
+    proxy_http_version 1.1;
+    proxy_set_header Host $host;
+    proxy_set_header X-Forwarded-Proto https;
+    proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+    proxy_set_header Upgrade $http_upgrade;
+    proxy_set_header Connection "upgrade";
+  }
+}
+```
+
+## systemd unit
+
+```ini
+# ~/.config/systemd/user/nteract-notebook-cloud-ec2.service
+[Unit]
+Description=nteract notebook-cloud EC2 fallback
+After=network-online.target
+
+[Service]
+WorkingDirectory=%h/codex/nteract
+EnvironmentFile=%h/.config/nteract/notebook-cloud-ec2.env
+Environment=NOTEBOOK_CLOUD_EC2_PUBLIC_ORIGIN=https://notebooks.example.com
+Environment=NOTEBOOK_CLOUD_EC2_HOST=127.0.0.1
+Environment=NOTEBOOK_CLOUD_EC2_PORT=8787
+Environment=NOTEBOOK_CLOUD_EC2_PERSIST_TO=/var/lib/nteract/notebook-cloud
+ExecStart=%h/.local/share/pnpm/pnpm --dir apps/notebook-cloud run dev:ec2
+Restart=on-failure
+RestartSec=5
+
+[Install]
+WantedBy=default.target
+```
+
+If `/var/lib/nteract/notebook-cloud` is owned by root, create it once and give
+the EC2 user write access:
+
+```bash
+sudo install -d -o "$USER" -g "$USER" -m 700 /var/lib/nteract/notebook-cloud
+```
+
+## Workstation runner
+
+Point the workstation runner at the EC2 origin:
+
+```bash
+set -a
+. ~/preview.runt.run/.env   # provides NTERACT_API_KEY, if that is where it lives
+set +a
+
+NTERACT_CLOUD_URL=https://notebooks.example.com \
+NOTEBOOK_CLOUD_WORKSTATION_ID=lab2 \
+NOTEBOOK_CLOUD_WORKSTATION_DISPLAY_NAME="lab2 workstation" \
+NOTEBOOK_CLOUD_WORKSTATION_CWD="$PWD" \
+pnpm --dir apps/notebook-cloud smoke:hosted:workstation-agent
+```
+
+For manual demos, keep the workstation runner in tmux/systemd. Use API-key auth
+for long-lived headless workstations.
+
+## Smoke checks
+
+Against the EC2 origin:
+
+```bash
+NTERACT_CLOUD_URL=https://notebooks.example.com \
+NOTEBOOK_CLOUD_DEV_TOKEN=<token> \
+pnpm --dir apps/notebook-cloud smoke
+
+NTERACT_CLOUD_URL=https://notebooks.example.com \
+NOTEBOOK_CLOUD_DEV_TOKEN=<token> \
+pnpm --dir apps/notebook-cloud smoke:hosted:collab
+```
+
+Workstation/browser smokes can run after the workstation runner is online, but
+they still need either a browser OIDC token cache or explicit dev-token setup
+depending on the smoke.
+
+## Limitations
+
+- Single EC2 instance only. Local Durable Object state is not shared across
+  machines, so do not run multiple active instances behind one load balancer.
+- Local Miniflare persistence is a fallback store, not managed D1/R2. Back up
+  the persist directory if the demo state matters.
+- OIDC login needs a registered redirect URI for the EC2 origin. Without that,
+  use prototype dev-token browser auth.
+- The default EC2 wrapper uses same-origin renderer assets and `srcdoc` output
+  frames. That is acceptable for a fallback demo, but it is not the same output
+  origin isolation posture as `preview.runt.run` plus `preview.runtusercontent.com`.
+- `wrangler dev` is a development runtime. This buys us independence from the
+  Cloudflare daily Durable Object quota; it is not a substitute for the future
+  Rust/Postgres room-host service.


### PR DESCRIPTION
## Summary

- add `pnpm --dir apps/notebook-cloud run dev:ec2`, a wrapper for running the existing notebook-cloud Worker locally on one EC2 instance with persisted Miniflare state
- default the EC2 fallback to same-origin renderer/runtime assets, `srcdoc` output frames, and prototype dev-token browser auth so it does not depend on preview-specific domains or OIDC redirect registration
- document the EC2 fallback runbook, reverse proxy shape, systemd unit, workstation runner setup, smoke checks, and limitations

## Why

`preview.runt.run` can be blocked by Cloudflare plan limits even when we still need a hosted notebook room for demos. This keeps the fallback path on the existing Worker/Durable Object/D1/R2-compatible model instead of inventing a second room host.

## Validation

- `pnpm --dir apps/notebook-cloud exec node --test test/ec2-local-worker.test.mjs`
- `node --check apps/notebook-cloud/scripts/ec2-local-worker.mjs`
- `pnpm --dir apps/notebook-cloud typecheck`
- `pnpm --dir apps/notebook-cloud test`
- `cargo xtask lint --fix`

## Not yet done

I have not brought up a public EC2 hostname with nginx/Caddy and a running workstation against it in this PR. The wrapper/runbook are the first mergeable slice.
