### PR TITLE
chore: bump automerge pin to rebased patch branch on upstream 0.10.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -602,8 +602,8 @@ checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
 name = "automerge"
-version = "0.9.0"
-source = "git+https://github.com/nteract/automerge?rev=f22752bd5bf7b7df0a0ad30b4618049644249237#f22752bd5bf7b7df0a0ad30b4618049644249237"
+version = "0.10.0"
+source = "git+https://github.com/nteract/automerge?rev=992effbf859fdd5d180bb3cef4312fd41d5a43e0#992effbf859fdd5d180bb3cef4312fd41d5a43e0"
 dependencies = [
  "cfg-if",
  "flate2",
@@ -3240,7 +3240,7 @@ dependencies = [
 [[package]]
 name = "hexane"
 version = "0.2.1"
-source = "git+https://github.com/nteract/automerge?rev=f22752bd5bf7b7df0a0ad30b4618049644249237#f22752bd5bf7b7df0a0ad30b4618049644249237"
+source = "git+https://github.com/nteract/automerge?rev=992effbf859fdd5d180bb3cef4312fd41d5a43e0#992effbf859fdd5d180bb3cef4312fd41d5a43e0"
 dependencies = [
  "leb128",
  "thiserror 2.0.18",
@@ -5132,7 +5132,7 @@ version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "680998035259dcfcafe653688bf2aa6d3e2dc05e98be6ab46afb089dc84f1df8"
 dependencies = [
- "proc-macro-crate 3.5.0",
+ "proc-macro-crate 1.3.1",
  "proc-macro2",
  "quote",
  "syn 2.0.117",
@@ -5712,7 +5712,7 @@ checksum = "9cd31dcfdbbd7431a807ef4df6edd6473228e94d5c805e8cf671227a21bad068"
 dependencies = [
  "anyhow",
  "clap",
- "itertools 0.14.0",
+ "itertools 0.12.1",
  "proc-macro2",
  "quote",
  "rand 0.8.6",
@@ -9576,7 +9576,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
 dependencies = [
  "fastrand",
- "getrandom 0.4.2",
+ "getrandom 0.3.4",
  "once_cell",
  "rustix 1.1.4",
  "windows-sys 0.61.2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -60,7 +60,7 @@ tokio = { version = "1.36.0", features = ["full"] }
 jupyter-zmq-client = { version = "1.0.0", default-features = false }
 jupyter-protocol = "2.0.1"
 nbformat = "3.0.0"
-automerge = { git = "https://github.com/nteract/automerge", rev = "f22752bd5bf7b7df0a0ad30b4618049644249237" }
+automerge = { git = "https://github.com/nteract/automerge", rev = "992effbf859fdd5d180bb3cef4312fd41d5a43e0" }
 thiserror = "2"
 schemars = "1"
 notify = "8"


### PR DESCRIPTION
## Summary

Updates the `nteract/automerge` pin from `f22752bd5` to `992effbf8` — the same 21 carried patches from nteract/automerge#5, rebased onto current upstream `main` (`rust/automerge@0.10.0`, `a4f584c86`).

## What this picks up from upstream

- **`6caefdfef` — fix for automerge/automerge#1390**: upstream's root-cause fix for no-op transactions leaving a stale actor in the patch log, which previously surfaced as `PatchLogMismatch` on merge. This is the bug the old `desktop-patches` patch-log workarounds were papering over from the outside; those stay retired.
- `automerge` 0.9.0 → 0.10.0 release.
- wasm-bindgen 0.2.121 bump.

No nteract source changes were needed — the `PatchLogMismatch(_)` handling added for automerge/automerge#1388 already covers the new code paths.

## Carried-patch status (why we still need the fork)

Upstream automerge/automerge#1366 (fork_at dep dedupe), #1360 (error propagation), and #1367 (fork actor invariant) remain open with no review activity, and the batch-apply/storage hardening has no upstream counterpart, so every patch on the fork branch is still necessary. Details in nteract/automerge#5.

## Verification

Against the new pin, locally on 2026-06-10:

```text
cargo test -p automerge-recovery   # 15 passed
cargo test -p runtime-doc          # 224 passed
cargo test -p runtimed-client      # 122 passed
cargo test -p notebook-doc         # 329 + 6 + 5 passed
cargo test -p runtimed sync        # 358 + 9 passed (incl. sync_server PatchLogMismatch recovery)
```

Automerge-side verification on the rebased branch itself (lib/integration tests, clippy) is documented in nteract/automerge#5.