### PR TITLE
fix(runtimed): refuse stale autosaves and write .ipynb atomically

### DIFF
--- a/crates/runtimed/src/notebook_sync_server/load.rs
+++ b/crates/runtimed/src/notebook_sync_server/load.rs
@@ -673,6 +673,10 @@ where
         // disk-source baseline before exposing batches so an unchanged initial
         // watch event cannot roll back immediate live edits.
         *room.persistence.last_save_sources.write().await = loaded_sources;
+        // Also seed the disk-hash staleness baseline: these bytes are what this
+        // daemon read; autosave refuses to overwrite anything else until the
+        // watcher reconciles it.
+        room.persistence.note_disk_content(&bytes);
     }
     let notebook_path = room
         .file_binding

--- a/crates/runtimed/src/notebook_sync_server/persist.rs
+++ b/crates/runtimed/src/notebook_sync_server/persist.rs
@@ -69,9 +69,19 @@ pub(crate) async fn save_notebook_to_disk(
         },
     };
 
-    // Read existing .ipynb as raw bytes. Used for two things: the
-    // content-hash guard further down (skip no-op writes), and the
-    // `nbformat_minor` floor (not carried in the doc today).
+    // Whether this save targets the room's bound path. Baseline bookkeeping
+    // (last_save_sources, the disk-hash staleness guard) applies only to the
+    // primary path — saving to an alternate path (Save As) must not corrupt
+    // the baselines for the file watcher.
+    let is_primary_path = target_path.is_none()
+        || room
+            .file_binding
+            .path_matches(notebook_path.as_path())
+            .await;
+
+    // Read existing .ipynb as raw bytes. Used for three things: the staleness
+    // guard below, the content-hash guard further down (skip no-op writes),
+    // and the `nbformat_minor` floor (not carried in the doc today).
     // We no longer read metadata from disk — the doc carries unknown
     // top-level keys as extras, so everything round-trips through
     // the snapshot.
@@ -87,6 +97,34 @@ pub(crate) async fn save_notebook_to_disk(
             None
         }
     };
+
+    // Staleness guard: refuse to overwrite a file that changed since this
+    // daemon last read or wrote it. Another writer (a second daemon on the
+    // same path, `git pull`, an external editor) owns the bytes on disk and
+    // the file watcher has not reconciled them into the doc yet — writing now
+    // would silently discard that writer's content (#2285). `Retryable` keeps
+    // the autosave debouncer armed: the watcher merges the external content
+    // and refreshes the baseline, and the next tick saves the merged state.
+    // A missing file with a recorded baseline falls through and is recreated
+    // (deletion is not a merge conflict). The read above and the write below
+    // are not atomic, so a writer landing inside this call can still race us;
+    // this guard shrinks the window from "since our last save" to one call.
+    if is_primary_path {
+        if let Some(ref raw) = existing_raw {
+            if room.persistence.disk_content_diverged(raw) {
+                warn!(
+                    "[notebook-sync] Refusing to save {:?}: on-disk content changed \
+                     since this daemon last read it (external writer?). Will retry \
+                     after the file watcher reconciles.",
+                    notebook_path
+                );
+                return Err(SaveError::Retryable(format!(
+                    "on-disk content of '{}' changed externally; deferring save",
+                    notebook_path.display()
+                )));
+            }
+        }
+    }
 
     // Read cells, metadata, and per-cell execution_ids from the doc.
     let (cells, metadata_snapshot, cell_execution_ids) = {
@@ -347,17 +385,13 @@ pub(crate) async fn save_notebook_to_disk(
                 notebook_path
             );
             // Still update save baselines so the file watcher stays consistent.
-            let is_primary_path = target_path.is_none()
-                || room
-                    .file_binding
-                    .path_matches(notebook_path.as_path())
-                    .await;
             if is_primary_path {
                 let mut saved = HashMap::with_capacity(cells.len());
                 for cell in &cells {
                     saved.insert(cell.id.clone(), cell.source.clone());
                 }
                 *room.persistence.last_save_sources.write().await = saved;
+                room.persistence.note_disk_content(raw);
             }
             // Disk already matches the room, so any failed-load hazard is
             // resolved — clear the flag so a later legitimate empty save writes.
@@ -376,8 +410,9 @@ pub(crate) async fn save_notebook_to_disk(
         })?;
     }
 
-    // Write to disk (async to avoid blocking the runtime)
-    tokio::fs::write(&notebook_path, &content_with_newline)
+    // Write to disk via tempfile + atomic rename so concurrent readers (other
+    // daemons, editors, git) never observe a torn .ipynb.
+    write_file_atomic(&notebook_path, content_with_newline.as_bytes())
         .await
         .map_err(|e| {
             let msg = format!("Failed to write notebook: {e}");
@@ -412,17 +447,14 @@ pub(crate) async fn save_notebook_to_disk(
     // our own writes from genuine external changes. Only update when saving
     // to the primary path - saving to an alternate path (Save As) must not
     // corrupt the baseline for the file watcher.
-    let is_primary_path = target_path.is_none()
-        || room
-            .file_binding
-            .path_matches(notebook_path.as_path())
-            .await;
     if is_primary_path {
         let mut saved = HashMap::with_capacity(cells.len());
         for cell in &cells {
             saved.insert(cell.id.clone(), cell.source.clone());
         }
         *room.persistence.last_save_sources.write().await = saved;
+        room.persistence
+            .note_disk_content(content_with_newline.as_bytes());
     }
 
     info!(
@@ -1290,11 +1322,51 @@ pub(crate) fn persist_notebook_bytes(data: &[u8], path: &Path) -> bool {
             return false;
         }
     }
-    if let Err(e) = std::fs::write(path, data) {
+    let tmp = sibling_temp_path(path);
+    if let Err(e) = std::fs::write(&tmp, data) {
         warn!("[notebook-sync] Failed to save notebook doc: {}", e);
+        let _ = std::fs::remove_file(&tmp);
+        return false;
+    }
+    if let Err(e) = std::fs::rename(&tmp, path) {
+        warn!("[notebook-sync] Failed to save notebook doc: {}", e);
+        let _ = std::fs::remove_file(&tmp);
         return false;
     }
     true
+}
+
+/// A unique same-directory temp path for atomically replacing `path`.
+/// Same-directory keeps the final `rename` on one filesystem (cross-device
+/// renames fail), and the pid + counter make concurrent saves from this
+/// process collision-free.
+fn sibling_temp_path(path: &Path) -> PathBuf {
+    static TEMP_COUNTER: std::sync::atomic::AtomicU64 = std::sync::atomic::AtomicU64::new(0);
+    let n = TEMP_COUNTER.fetch_add(1, Ordering::Relaxed);
+    let file_name = path
+        .file_name()
+        .map(|s| s.to_string_lossy().into_owned())
+        .unwrap_or_else(|| "notebook".to_string());
+    path.with_file_name(format!(".{file_name}.{}-{n}.tmp", std::process::id()))
+}
+
+/// Write `bytes` to `path` through a same-directory temp file + rename so a
+/// reader never observes a torn/partial file: the path always holds either
+/// the previous complete content or the new complete content. Preserves the
+/// destination's permissions when it already exists.
+async fn write_file_atomic(path: &Path, bytes: &[u8]) -> std::io::Result<()> {
+    let tmp = sibling_temp_path(path);
+    tokio::fs::write(&tmp, bytes).await?;
+    if let Ok(meta) = tokio::fs::metadata(path).await {
+        let _ = tokio::fs::set_permissions(&tmp, meta.permissions()).await;
+    }
+    match tokio::fs::rename(&tmp, path).await {
+        Ok(()) => Ok(()),
+        Err(e) => {
+            let _ = tokio::fs::remove_file(&tmp).await;
+            Err(e)
+        }
+    }
 }
 
 // =============================================================================
@@ -1314,25 +1386,20 @@ pub(crate) fn spawn_notebook_file_watcher(
     let (shutdown_tx, mut shutdown_rx) = oneshot::channel();
 
     spawn_best_effort("notebook-file-watcher", async move {
-        // Determine what path to watch
-        let watch_path = if notebook_path.exists() {
-            notebook_path.clone()
-        } else if let Some(parent) = notebook_path.parent() {
-            // Watch parent directory if file doesn't exist yet
-            if !parent.exists() {
+        // Watch the parent directory, not the file itself. Saves replace the
+        // file via tempfile + rename (ours and most editors'), and an inotify
+        // watch on the file follows the old inode — it goes silent after the
+        // first rename-over. A directory watch survives replacement; the
+        // event loop below filters to `notebook_path`.
+        let watch_path = match notebook_path.parent() {
+            Some(parent) if parent.exists() => parent.to_path_buf(),
+            _ => {
                 warn!(
                     "[notebook-watch] Parent dir doesn't exist for {:?}",
                     notebook_path
                 );
                 return;
             }
-            parent.to_path_buf()
-        } else {
-            warn!(
-                "[notebook-watch] Cannot determine watch path for {:?}",
-                notebook_path
-            );
-            return;
         };
 
         // Create tokio mpsc channel to bridge from notify callback thread
@@ -1437,6 +1504,13 @@ pub(crate) fn spawn_notebook_file_watcher(
                                 }
                             };
                             let external_metadata = parse_metadata_from_ipynb(&json);
+
+                            // The watcher has now observed this disk content and
+                            // is about to reconcile it into the doc. Refresh the
+                            // staleness baseline so autosave (which refuses to
+                            // overwrite unobserved external content) can write
+                            // the merged state on its next tick.
+                            room.persistence.note_disk_content(contents.as_bytes());
 
                             // Check if kernel is running (to preserve outputs)
                             let has_kernel = room.has_kernel().await;

--- a/crates/runtimed/src/notebook_sync_server/room.rs
+++ b/crates/runtimed/src/notebook_sync_server/room.rs
@@ -1,5 +1,6 @@
 use super::*;
 use crate::async_outcome::{recv_oneshot_with_timeout, TimedOneShot};
+use sha2::Digest as _;
 
 /// Per-room identity.
 ///
@@ -362,6 +363,17 @@ pub struct RoomPersistence {
     /// Timestamp (ms since epoch) of last self-write to the .ipynb file.
     /// Used to skip file watcher events triggered by our own saves.
     pub last_self_write: AtomicU64,
+    /// SHA-256 of the `.ipynb` bytes as this daemon last saw them on disk:
+    /// seeded at load, refreshed after every self-write and every file-watcher
+    /// read. `save_notebook_to_disk` refuses a primary-path save when the
+    /// on-disk bytes no longer match this baseline — another writer (a second
+    /// daemon, `git pull`) changed the file and the watcher has not reconciled
+    /// it into the doc yet. The refusal is `Retryable`: the watcher merges the
+    /// external content and refreshes this baseline, and the autosave
+    /// debouncer's next tick writes the merged state. `None` means "no disk
+    /// content observed yet" (untitled rooms, Save As targets) and disables
+    /// the check.
+    last_known_disk_hash: std::sync::Mutex<Option<[u8; 32]>>,
     /// Whether a streaming load is in progress for this room.
     /// Prevents two connections from both attempting to load from disk.
     is_loading: AtomicBool,
@@ -398,6 +410,7 @@ impl RoomPersistence {
             last_save_sources: RwLock::new(HashMap::new()),
             previous_visible_executions: std::sync::Mutex::new(HashMap::new()),
             last_self_write: AtomicU64::new(0),
+            last_known_disk_hash: std::sync::Mutex::new(None),
             is_loading: AtomicBool::new(false),
             load_failed: AtomicBool::new(false),
         }
@@ -416,8 +429,36 @@ impl RoomPersistence {
             last_save_sources: RwLock::new(HashMap::new()),
             previous_visible_executions: std::sync::Mutex::new(HashMap::new()),
             last_self_write: AtomicU64::new(0),
+            last_known_disk_hash: std::sync::Mutex::new(None),
             is_loading: AtomicBool::new(false),
             load_failed: AtomicBool::new(false),
+        }
+    }
+
+    /// Record the `.ipynb` bytes this daemon just observed on disk (loaded,
+    /// wrote, or ingested via the file watcher). Future primary-path saves
+    /// compare the on-disk file against this baseline.
+    pub fn note_disk_content(&self, bytes: &[u8]) {
+        let digest: [u8; 32] = sha2::Sha256::digest(bytes).into();
+        if let Ok(mut hash) = self.last_known_disk_hash.lock() {
+            *hash = Some(digest);
+        }
+    }
+
+    /// The baseline recorded by [`Self::note_disk_content`], if any.
+    pub fn known_disk_hash(&self) -> Option<[u8; 32]> {
+        self.last_known_disk_hash.lock().ok().and_then(|h| *h)
+    }
+
+    /// True when `bytes` differ from the recorded disk baseline. `false` when
+    /// no baseline exists (nothing observed yet — the check is disabled).
+    pub fn disk_content_diverged(&self, bytes: &[u8]) -> bool {
+        match self.known_disk_hash() {
+            Some(baseline) => {
+                let digest: [u8; 32] = sha2::Sha256::digest(bytes).into();
+                digest != baseline
+            }
+            None => false,
         }
     }
 

--- a/crates/runtimed/src/notebook_sync_server/tests.rs
+++ b/crates/runtimed/src/notebook_sync_server/tests.rs
@@ -4428,6 +4428,129 @@ async fn path_collision_does_not_overwrite_existing_file() {
     );
 }
 
+/// Staleness guard (#2285 stopgap): a primary-path save refuses to overwrite
+/// a file that changed on disk since this daemon last read or wrote it (a
+/// second daemon, `git pull`, an external editor). The refusal is retryable;
+/// once the file watcher observes the external bytes (`note_disk_content` is
+/// exactly what the watcher calls after reading the file), the next save
+/// writes the room's state.
+#[tokio::test]
+async fn autosave_refuses_to_overwrite_externally_changed_file() {
+    let tmp = tempfile::TempDir::new().unwrap();
+    let (room, notebook_path) = test_room_with_path(&tmp, "stale.ipynb");
+
+    {
+        let mut doc = room.doc.write().await;
+        doc.add_cell(0, "cell1", "code").unwrap();
+        doc.update_source("cell1", "x = 1").unwrap();
+    }
+
+    // First save establishes the disk baseline.
+    save_notebook_to_disk(&room, None).await.unwrap();
+
+    // Another writer replaces the file behind our back.
+    let external_content = r#"{"cells":[{"cell_type":"code","id":"other","source":"y = 2","metadata":{},"outputs":[],"execution_count":null}],"metadata":{},"nbformat":4,"nbformat_minor":5}"#;
+    tokio::fs::write(&notebook_path, external_content)
+        .await
+        .unwrap();
+
+    // Local edit so the no-op content-hash guard doesn't short-circuit.
+    {
+        let mut doc = room.doc.write().await;
+        doc.update_source("cell1", "x = 3").unwrap();
+    }
+
+    let err = save_notebook_to_disk(&room, None).await.unwrap_err();
+    assert!(
+        matches!(err, SaveError::Retryable(_)),
+        "staleness refusal must be retryable, got {err:?}"
+    );
+
+    // The external writer's bytes are untouched.
+    let on_disk = tokio::fs::read_to_string(&notebook_path).await.unwrap();
+    assert_eq!(
+        on_disk, external_content,
+        "refused save must not touch the file"
+    );
+
+    // Watcher reconciliation refreshes the baseline; the retry writes.
+    room.persistence
+        .note_disk_content(external_content.as_bytes());
+    save_notebook_to_disk(&room, None).await.unwrap();
+    let merged = tokio::fs::read_to_string(&notebook_path).await.unwrap();
+    assert!(
+        merged.contains("x = 3"),
+        "post-reconcile save must write the room's state"
+    );
+}
+
+/// Saves to a non-primary path (Save As) are not staleness-guarded:
+/// overwriting the chosen target is the user's intent, and the room's disk
+/// baseline belongs to its bound path.
+#[tokio::test]
+async fn save_as_to_foreign_path_is_not_staleness_guarded() {
+    let tmp = tempfile::TempDir::new().unwrap();
+    let (room, _primary_path) = test_room_with_path(&tmp, "primary.ipynb");
+
+    {
+        let mut doc = room.doc.write().await;
+        doc.add_cell(0, "cell1", "code").unwrap();
+        doc.update_source("cell1", "z = 9").unwrap();
+    }
+    // Establish the primary baseline.
+    save_notebook_to_disk(&room, None).await.unwrap();
+
+    // Save As onto an existing file with foreign content must overwrite.
+    let other_path = tmp.path().join("other.ipynb");
+    tokio::fs::write(
+        &other_path,
+        r#"{"cells":[],"metadata":{},"nbformat":4,"nbformat_minor":5}"#,
+    )
+    .await
+    .unwrap();
+    save_notebook_to_disk(&room, Some(other_path.to_str().unwrap()))
+        .await
+        .unwrap();
+    let written = tokio::fs::read_to_string(&other_path).await.unwrap();
+    assert!(
+        written.contains("z = 9"),
+        "Save As must overwrite the target"
+    );
+}
+
+/// `.ipynb` and `.automerge` writes go through tempfile + rename: the final
+/// content lands and no temp siblings survive.
+#[tokio::test]
+async fn atomic_writes_leave_no_temp_files() {
+    let tmp = tempfile::TempDir::new().unwrap();
+    let (room, notebook_path) = test_room_with_path(&tmp, "atomic.ipynb");
+
+    {
+        let mut doc = room.doc.write().await;
+        doc.add_cell(0, "cell1", "code").unwrap();
+        doc.update_source("cell1", "a = 1").unwrap();
+    }
+    save_notebook_to_disk(&room, None).await.unwrap();
+    assert!(notebook_path.exists());
+
+    let automerge_path = tmp.path().join("docs").join("atomic.automerge");
+    assert!(persist_notebook_bytes(b"snapshot-bytes", &automerge_path));
+    assert_eq!(
+        std::fs::read(&automerge_path).unwrap(),
+        b"snapshot-bytes".to_vec()
+    );
+
+    for dir in [tmp.path().to_path_buf(), tmp.path().join("docs")] {
+        for entry in std::fs::read_dir(&dir).unwrap() {
+            let name = entry.unwrap().file_name().to_string_lossy().into_owned();
+            assert!(
+                !name.ends_with(".tmp"),
+                "temp file left behind in {dir:?}: {name}"
+            );
+        }
+    }
+}
+
 /// Verify the full lifecycle: create untitled room → save to disk →
 /// promote via `promote_untitled_to_file_backed` → edit → autosave flushes
 /// the edit to the .ipynb file.
@@ -9630,9 +9753,19 @@ async fn save_based_recovery_clears_failed_flag() {
         "a successful write clears the failed-load flag"
     );
 
-    // Put content on disk and autosave the still-empty (but recovered) room: it
-    // must write through, proving the flag was cleared by the save.
+    // Put content on disk and autosave the still-empty (but recovered) room.
+    // The external write trips the staleness guard first (the disk no longer
+    // matches the save-time baseline), so the autosave defers; once the file
+    // watcher observes the new bytes (note_disk_content is what the watcher
+    // calls), the autosave writes through — proving the load-failed flag was
+    // cleared by the save, which is this test's subject.
     write_two_cell_notebook(&notebook_path).await;
+    let err = save_notebook_to_disk(&room, None)
+        .await
+        .expect_err("externally changed file defers the autosave");
+    assert!(matches!(err, SaveError::Retryable(_)));
+    room.persistence
+        .note_disk_content(&tokio::fs::read(&notebook_path).await.unwrap());
     save_notebook_to_disk(&room, None)
         .await
         .expect("recovered room must autosave through");


### PR DESCRIPTION
Stopgap for #2285: two daemons (or a daemon plus `git pull` / an external editor) autosaving the same `.ipynb` was last-writer-wins. Each daemon serialized its room state over the file with no awareness of the other; whatever was only in the losing daemon's room vanished on the next open. This PR converts that silent loss into a deferred, logged retry, and makes every notebook write atomic.

## Staleness guard

`RoomPersistence` gains a SHA-256 baseline of the `.ipynb` bytes as this daemon last saw them on disk:

- seeded when the streaming load reads the file,
- refreshed after every self-write (including the no-op skip branch), and
- refreshed when the file watcher reads external content before reconciling it into the doc.

`save_notebook_to_disk` now refuses a primary-path save when the on-disk bytes diverge from that baseline: another writer owns the file and the watcher hasn't merged it yet. The refusal is `SaveError::Retryable`, which the autosave debouncer already handles by keeping the change armed - the watcher's three-way merge (against `last_save_sources`) lands within its 500ms debounce, refreshes the baseline, and the next autosave tick writes the merged state. Save As to a non-primary path is exempt: overwriting the chosen target is the user's intent, and the room's baseline belongs to its bound path.

The pre-write read and the write are still not one atomic step, so a writer landing inside a single save call can race us - the guard shrinks the window from "since our last save" to one call. The principled fix remains the daemons-as-peers primitive (#2284); this buys correctness for the common collision until then.

## Atomic writes

`.ipynb` saves and `.automerge` snapshot persists now go through a same-directory tempfile + rename (same filesystem, so rename is atomic), preserving the destination's permissions. Readers never observe a torn file.

## Watch the parent directory, not the file

Rename-over leaves an inotify file watch following the old (deleted) inode - it goes silent after the first replacement. That was already latent for external editors that save via rename; it becomes load-bearing now that our own saves rename too. The watcher now always watches the notebook's parent directory (the event loop already filtered by path), which survives replacement on every platform.

## Behavioral coverage

| Scenario | Before | After |
|---|---|---|
| File changed externally, autosave fires | overwrites, external content lost | refuses (Retryable), watcher merges, next tick saves merged state |
| File changed externally, explicit save to primary path | overwrites | same deferral as autosave |
| Save As onto an existing foreign file | overwrites | overwrites (user intent, exempt from guard) |
| File deleted externally | recreated | recreated (deletion is not a merge conflict) |
| Crash mid-write | possible torn `.ipynb` | old or new content, never torn |

Tests: staleness refusal preserves the external bytes and succeeds after watcher reconciliation; Save As bypasses the guard; atomic writes leave no temp siblings. `save_based_recovery_clears_failed_flag` updated for the new invariant (its external rewrite now defers the autosave by design). Full `cargo test -p runtimed` green.
