### PR TITLE
fix(notebook-cloud): make blob metadata first-writer-wins on duplicate put

### DIFF
--- a/apps/notebook-cloud/src/index.ts
+++ b/apps/notebook-cloud/src/index.ts
@@ -3027,6 +3027,31 @@ async function routeBlob(
   }
 
   const contentType = request.headers.get("content-type");
+  // Content-addressed first-writer-wins: an existing object already holds
+  // these exact bytes (the hash was verified above), and its stored metadata
+  // (Content-Type) must not be rewritable by later writers. Skip the R2 write;
+  // recordBlob is idempotent and heals a missing catalog row.
+  const existing = await env.NOTEBOOK_SNAPSHOTS.head(key);
+  if (existing) {
+    await recordBlob(env, {
+      notebookId,
+      hash,
+      size: body.byteLength,
+      contentType,
+      r2Key: key,
+    });
+    cloudLog("info", "blob.upload.deduplicated", {
+      notebook_id: notebookId,
+      hash,
+      byte_length: body.byteLength,
+      principal: authorizedIdentity.principal,
+      scope: authorizedIdentity.scope,
+      counter: "blob_upload_dedups",
+      counter_delta: 1,
+    });
+    return json({ ok: true, key, size: body.byteLength, deduplicated: true }, 200);
+  }
+
   await env.NOTEBOOK_SNAPSHOTS.put(key, body, {
     httpMetadata: {
       contentType: contentType ?? "application/octet-stream",

--- a/apps/notebook-cloud/src/storage.ts
+++ b/apps/notebook-cloud/src/storage.ts
@@ -1419,6 +1419,8 @@ export async function recordBlob(
   }
 
   await ensureCatalogSchema(env);
+  // First-writer-wins: blobs are content-addressed, so a duplicate put carries
+  // identical bytes and must not rewrite the recorded content_type.
   await env.DB.prepare(
     `INSERT INTO notebook_blobs (
        notebook_id,
@@ -1427,11 +1429,7 @@ export async function recordBlob(
        content_type,
        r2_key
      ) VALUES (?, ?, ?, ?, ?)
-     ON CONFLICT(notebook_id, hash) DO UPDATE SET
-       size = excluded.size,
-       content_type = excluded.content_type,
-       r2_key = excluded.r2_key,
-       uploaded_at = strftime('%Y-%m-%dT%H:%M:%fZ', 'now')`,
+     ON CONFLICT(notebook_id, hash) DO NOTHING`,
   )
     .bind(blob.notebookId, blob.hash, blob.size, blob.contentType, blob.r2Key)
     .run();

--- a/apps/notebook-cloud/test/worker-routes.test.ts
+++ b/apps/notebook-cloud/test/worker-routes.test.ts
@@ -2371,6 +2371,76 @@ describe("Worker artifact routes", () => {
     });
   });
 
+  it("keeps blob metadata first-writer-wins on duplicate put", async () => {
+    const env = fakeEnv();
+    seedNotebook(env, "runtime-demo");
+    seedAcl(env, {
+      notebookId: "runtime-demo",
+      subject: "user:dev:runtime-service",
+      scope: "runtime_peer",
+    });
+    const body = new Uint8Array([1, 2, 3, 4]);
+    const hash = await sha256Hex(body);
+    const key = blobKey("runtime-demo", hash);
+    const headers = {
+      "X-Scope": "runtime_peer",
+      "X-User": "runtime-service",
+      "X-Operator": "runtime:py-3.12",
+    };
+
+    const first = await scopedPut(env, `/api/n/runtime-demo/blobs/${hash}`, body, {
+      ...headers,
+      "Content-Type": "application/vnd.apache.arrow.stream",
+    });
+    assert.equal(first.status, 201);
+
+    const second = await scopedPut(env, `/api/n/runtime-demo/blobs/${hash}`, body, {
+      ...headers,
+      "Content-Type": "text/plain",
+    });
+    assert.equal(second.status, 200);
+    assert.deepEqual(await second.json(), {
+      ok: true,
+      key,
+      size: body.byteLength,
+      deduplicated: true,
+    });
+    assert.equal(
+      env.NOTEBOOK_SNAPSHOTS.objects.get(key)?.httpMetadata?.contentType,
+      "application/vnd.apache.arrow.stream",
+    );
+    assert.equal(
+      env.DB.blobs.get(`runtime-demo:${hash}`)?.content_type,
+      "application/vnd.apache.arrow.stream",
+    );
+  });
+
+  it("heals a missing catalog row on duplicate blob put", async () => {
+    const env = fakeEnv();
+    seedNotebook(env, "runtime-demo");
+    seedAcl(env, {
+      notebookId: "runtime-demo",
+      subject: "user:dev:runtime-service",
+      scope: "runtime_peer",
+    });
+    const body = new Uint8Array([5, 6, 7, 8]);
+    const hash = await sha256Hex(body);
+    const key = blobKey("runtime-demo", hash);
+    await env.NOTEBOOK_SNAPSHOTS.put(key, body, {
+      httpMetadata: { contentType: "image/png" },
+    });
+    assert.equal(env.DB.blobs.has(`runtime-demo:${hash}`), false);
+
+    const response = await scopedPut(env, `/api/n/runtime-demo/blobs/${hash}`, body, {
+      "Content-Type": "image/png",
+      "X-Scope": "runtime_peer",
+      "X-User": "runtime-service",
+      "X-Operator": "runtime:py-3.12",
+    });
+    assert.equal(response.status, 200);
+    assert.equal(env.DB.blobs.get(`runtime-demo:${hash}`)?.content_type, "image/png");
+  });
+
   it("caches authorized immutable blob reads at the Worker edge", async () => {
     const env = fakeEnv();
     seedNotebook(env, "blob-cache-demo");
@@ -5307,14 +5377,17 @@ class FakeD1Statement implements D1PreparedStatement {
         string | null,
         string,
       ];
-      this.db.blobs.set(`${notebookId}:${hash}`, {
-        notebook_id: notebookId,
-        hash,
-        size,
-        content_type: contentType,
-        r2_key: r2Key,
-        uploaded_at: new Date().toISOString(),
-      });
+      // Mirrors the real ON CONFLICT DO NOTHING: first writer wins.
+      if (!this.db.blobs.has(`${notebookId}:${hash}`)) {
+        this.db.blobs.set(`${notebookId}:${hash}`, {
+          notebook_id: notebookId,
+          hash,
+          size,
+          content_type: contentType,
+          r2_key: r2Key,
+          uploaded_at: new Date().toISOString(),
+        });
+      }
     } else if (this.query.includes("INSERT INTO principal_profiles")) {
       const [
         principal,

--- a/docs/adr/blob-storage-and-content-addressing.md
+++ b/docs/adr/blob-storage-and-content-addressing.md
@@ -515,10 +515,13 @@ elsewhere, some are surfaced here for the first time.
    case but means any peer with write access can rewrite the served
    `Content-Type` of an existing blob. Decision: the desktop sidecar rewrite
    stays a single-user convenience; hosted and any remote-peer backend must
-   be first-writer-wins for blob metadata, preferring to serve media type
-   from the reference layer's `media_type`. The hosted blob PUT currently
-   rewrites R2 `httpMetadata.contentType` on every put; punchlist BS-13
-   tracks the first-writer-wins change.
+   be first-writer-wins for blob metadata. **Hosted is first-writer-wins**
+   (BS-13): the blob PUT short-circuits when the R2 object already exists,
+   so neither `httpMetadata.contentType` nor the D1 catalog `content_type`
+   (`ON CONFLICT DO NOTHING`) is rewritable after the first write. Serving
+   `Content-Type` from the reference layer's `media_type` instead of object
+   metadata remains the preference if reads move off the Worker route
+   (signed-URL direction, hosted-output-origin-isolation HCA-6).
 8. ~~**No `Content-Length`-bounded streaming on the read path.**~~ **Resolved**
    by punchlist BS-1. `BlobStore::open_reader` returns either an in-memory
    `Bytes` (memory-layer hit) or an open `tokio::fs::File` (disk-only).
@@ -577,5 +580,4 @@ to implement; **Design** = needs a decision in this ADR before code moves.
 - **BS-7** (Targeted PR; GC instrumentation): GC mark walks rooms and persisted docs producing one combined hash set with no per-ref provenance. Any mark-miss is a silent data-loss bug at sweep time, with no debug surface to audit.
 - **BS-9** (Design; `crates/runtimed/src/blob_upload.rs` finalize path): `MAX_BLOB_SIZE = 100 MiB` only gates the in-process `BlobStore::put()` API. The multipart finalize path validates against the caller's `expected_size` and the per-peer 256 MiB staging budget but does not enforce a 100 MiB ceiling on the completed blob. A peer can multipart-upload a 200 MiB blob today.
 - **BS-10** (Design; `output_store.rs:62-89`): Save-to-`.ipynb` externalizes Arrow IPC and Parquet only via `BLOB_REF_MIME`; every other binary MIME is base64-inlined in the saved file. A user opening the saved `.ipynb` outside nteract gets self-contained binary for non-Arrow/Parquet but broken refs for the rest unless they keep the colocated blob store.
-- **BS-13** (Targeted PR; `apps/notebook-cloud/src/index.ts`, `docs/adr/blob-storage-and-content-addressing.md`): **Reframed, Design → Targeted PR; absorbs BS-2.** Blob media type is mutable on duplicate put on both hosts: desktop `put_disk` rewrites the sidecar (intentional, documented exception for anywidget `_esm`), and the cloud blob PUT rewrites R2 `httpMetadata.contentType` on every put (`apps/notebook-cloud/src/index.ts:3029-3032`), mitigated only by the owner/runtime_peer upload gate. Make hosted metadata first-writer-wins (short-circuit the put when the object already exists) and prefer serving `Content-Type` from the reference layer's `media_type`.
 - **BS-14** (Targeted PR; `apps/notebook-cloud/src/index.ts`, `crates/runtimed/src/daemon.rs`, `crates/runtimed-wasm/`): The hosted publish validator (TS, walks the materialized render projection via `collectSnapshotBlobRefs`) and the daemon GC mark (Rust, `collect_blob_refs_for_gc`) are two independent blob-ref inventories. A ref shape added to one and not the other is either a broken publish or a silent GC data-loss bug. Converge on one ref-walk exported from `runtimed-wasm`, or pin both walks against shared fixtures covering every ref shape (outputs, comms, attachments, resolved_assets, Arrow manifest children).


### PR DESCRIPTION
Resolves BS-13 from `docs/adr/blob-storage-and-content-addressing.md`.

A duplicate blob PUT rewrote R2 `httpMetadata.contentType` and the D1 catalog `content_type` on every put, so any peer with upload access could rewrite the served `Content-Type` of an existing blob. Blobs are content-addressed: the route's hash check guarantees a duplicate put carries identical bytes, so neither the object nor its metadata needs a second write.

## What changed

- The blob PUT route short-circuits when the R2 object already exists: no R2 write, response is `200` with `{ ok: true, key, size, deduplicated: true }`. Fresh puts still return `201`. Existing clients (`publish-fixture.mjs`, `publish-live.mjs`, `smoke.mjs`) parse the JSON body and check `ok`, so the status split is safe.
- `recordBlob` switches from upsert to `ON CONFLICT(notebook_id, hash) DO NOTHING`, making the catalog row first-writer-wins too. The dedup path still calls it, so a catalog row that went missing (D1 unavailable during the original put) heals on the next put of the same hash.
- The fake D1 in `worker-routes.test.ts` mirrors the DO NOTHING semantics.
- ADR open question 7 records the decision; the BS-13 row is removed from the tracked follow-ups.

Side benefit: a runtime peer re-pushing an existing blob skips the R2 write entirely, which is content-addressed dedup on the upload path.

## Scope notes

- Desktop `put_disk` sidecar rewrite is untouched: the ADR documents it as an intentional single-user convenience (anywidget `_esm` retype).
- The snapshot PUT routes (notebook/runtime/comms) are heads-hash keyed and already do ownership `head()` checks; they're outside BS-13.
- Serving `Content-Type` from the reference layer's `media_type` instead of object metadata stays a preference tied to the signed-URL direction (HCA-6, #3538). With metadata now immutable after first write, the rewrite threat is closed either way.

## Behavioral coverage

| Scenario | Before | After |
|---|---|---|
| Fresh put | 201, object + catalog row written | 201, unchanged |
| Duplicate put, different `Content-Type` | 201, R2 + D1 metadata rewritten | 200 `deduplicated: true`, metadata untouched |
| Duplicate put, R2 object exists but catalog row missing | 201, full rewrite | 200, catalog row inserted |
| Hash mismatch | 400 | 400, unchanged (check runs before the head) |
