### PR TITLE
fix(ci): keep generated scope bindings LF-normalized

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,6 +1,7 @@
 packages/runtimed/src/request-types.ts text eol=lf
 packages/runtimed/src/protocol-contract.ts text eol=lf
 packages/runtimed/src/wire-constants.ts text eol=lf
+packages/runtimed/src/scope-capabilities.ts text eol=lf
 
 # Stable third-party renderer-plugin bundles. LFS-tracked so fresh checkouts
 # don't pay the large vendor rebuild just to boot the daemon. Owned/generated


### PR DESCRIPTION
## Summary
- force LF checkout for generated scope-capabilities TypeScript bindings
- match existing .gitattributes entries for other generated runtimed TypeScript files

## Verification
- cargo xtask help
- git check-attr text eol -- packages/runtimed/src/scope-capabilities.ts
- git ls-files --eol -- packages/runtimed/src/scope-capabilities.ts packages/runtimed/src/request-types.ts packages/runtimed/src/protocol-contract.ts packages/runtimed/src/wire-constants.ts
- cargo test -p notebook-protocol typescript::tests::generated_typescript_bindings_are_current
- cargo test -p notebook-protocol
- pnpm install --frozen-lockfile
- cargo xtask lint --fix

## Notes
Investigated Build run 27284618418. The Windows failure was a CRLF-only mismatch for packages/runtimed/src/scope-capabilities.ts; this file was missing from the LF-normalized generated bindings list in .gitattributes. The separate runtimed-py integration failure was a kernel-launch timeout and is not addressed here.