### PR TITLE
docs(adr): propose AWS rust room host

### DIFF
--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -97,6 +97,7 @@ These entries define the center of gravity for the system:
 | Entry | Status | Notes |
 |-------|--------|-------|
 | [Deployment Topology](deployment-topology.md) | Draft | Hosted room topology, compute attachment, and durable state split. |
+| [AWS Rust Room Host](aws-rust-room-host.md) | Draft | Proposed native Rust room host on AWS with Postgres/RDS and S3. |
 | [Hosted Room Authorization and Cloud Room Host](hosted-room-authorization.md) | Draft | D1 ACLs, scope derivation, and DO room host. |
 | [Runtime Principal Promotion](runtime-principal-promotion.md) | Draft | Local runtime principals, hosted promotion, and execution authority split. |
 | [Remote Workstation Doc Agents](remote-workstation-doc-agents.md) | Draft | Provider-neutral workstation/doc-agent registration and runtime-peer attachment model. |

--- a/docs/adr/aws-rust-room-host.md
+++ b/docs/adr/aws-rust-room-host.md
@@ -339,7 +339,68 @@ The stable split:
 - revision/checkpoint metadata in Postgres;
 - room coordination in the Rust room actor, not S3.
 
-## Decision 7: One Big Room Host First, Leases Later
+## Decision 7: Cloud Notebooks Use Native Document Set Identity
+
+Hosted notebooks are not persisted as `.ipynb` files with a cloud sync wrapper.
+The cloud-native source of truth is a durable document set:
+
+- `NotebookDoc` for cells, metadata, order, and notebook-level authoring state;
+- `RuntimeStateDoc` for execution records, queue state, kernel/session facts,
+  output manifests, workstation attachment state, and other runtime-visible
+  notebook state;
+- `CommsDoc` for widget/comm state needed to render interactive outputs;
+- content-addressed blobs for output bytes and renderer assets referenced by
+  those documents.
+
+`.ipynb`, HTML, and other file formats are import/export projections from that
+document set. They are not the hosted persistence boundary.
+
+Keep identifiers boring and single-purpose:
+
+- `notebook_id` is the stable opaque room/catalog id. It drives routes, ACLs,
+  room placement, leases, workstations, and live sync.
+- document ids identify the individual Automerge documents whose immutable
+  published snapshots live under `docs/{docId}`.
+- `revision_id` identifies an immutable published snapshot bundle for one
+  notebook, including the exact `NotebookDoc`, `RuntimeStateDoc`, `CommsDoc`,
+  and blob references needed to render it.
+- `checkpoint_id` identifies an operational recovery point for a live room.
+  Checkpoints may include runtime state, but they are not the default public
+  sharing surface.
+- titles and slugs are mutable display/navigation metadata. They are never
+  authorization, placement, publication, or checkpoint authority.
+
+The canonical hosted routes should be identity-first with optional decorative
+slugs:
+
+```text
+/n/:notebook_id/:slug?                 live room
+/n/:notebook_id/r/:revision_id/:slug?  immutable published revision
+```
+
+The router trusts only `notebook_id`, the reserved control segment `r`, and
+`revision_id`. The slug exists so copied links remain recognizable to humans;
+it may be stale, missing, or regenerated after a title change. By default,
+shareable links include the slug. If title sensitivity becomes a product
+requirement, add an explicit "copy link without title" affordance later rather
+than making all links opaque now.
+
+Reserve control segments after `notebook_id` for route modes. At minimum, `r`
+is reserved for revisions. If checkpoint links become a user-facing or admin
+feature, use another reserved control segment rather than overloading vanity
+slug parsing. Vanity slugs should be single path segments and generated to
+avoid reserved control words.
+
+Persist `RuntimeStateDoc` and `CommsDoc` in both live checkpoints and published
+revisions so outputs, execution history, widgets, and workstation attachment
+context do not disappear when a room reloads or when a notebook is viewed
+without an active runtime peer. Persistence should compact these documents
+before storage: keep durable execution/output/widget facts, but reconcile
+process-local claims such as "kernel is running on host X" when the room loads.
+If the runtime peer does not reconnect and reclaim ownership, mark process
+state stale while preserving the user-visible execution and output history.
+
+## Decision 8: One Big Room Host First, Leases Later
 
 The first AWS service should be one vertically scaled room-host process behind
 an ALB. One active process owns all live room actors.
@@ -406,7 +467,7 @@ architectural requirements for the native service. A long-running room host can
 keep active rooms in memory and should rely on document sync plus checkpoints
 for recovery rather than porting hibernation behavior mechanically.
 
-## Decision 8: Room Checkpointing Is Debounced But Durable
+## Decision 9: Room Checkpointing Is Debounced But Durable
 
 On room load, port the current Cloudflare materializer's checkpoint precedence
 logic rather than replacing it with a simpler "checkpoint else snapshot" rule:
@@ -463,7 +524,7 @@ becomes an in-process Tokio timer in the single-host service. Because that timer
 dies with the process, room load must also reconcile stale runtime-peer state so
 phantom running executions and kernels do not survive a host crash.
 
-## Decision 9: Authority Boundaries Stay The Same
+## Decision 10: Authority Boundaries Stay The Same
 
 Moving from Durable Objects to Rust/AWS must not weaken hosted authorization:
 
@@ -493,7 +554,7 @@ transport. `KernelIdle`, `ExecutionDone`, `CellError`, and `KernelDied` cannot
 be backpressured by stdout floods, display churn, manifest commits, or blob
 writes.
 
-## Decision 10: Hosted Origins Stay Split
+## Decision 11: Hosted Origins Stay Split
 
 The AWS deployment keeps the three-origin security model from
 `hosted-output-origin-isolation.md`:
@@ -599,11 +660,12 @@ without AWS.
 6. Implement `HostedObjectStore` and `HostedCheckpointStore`; port checkpoint
    precedence logic with shared test vectors for deterministic actor label,
    starter cell id, and keep/discard decisions. Include holder/generation
-   fields in checkpoint pointer metadata from the start.
+   fields in checkpoint pointer metadata from the start. Persist compacted
+   `RuntimeStateDoc` and `CommsDoc` with checkpoints.
 7. Implement Postgres migrations and a `sqlx` `HostedCatalogStore` /
    `HostedAuthz` for catalog, ACL, sharing, workstations, and attach jobs.
    Preserve never-zero-owner ACL protection, partial unique active attach jobs,
-   and transactional revision publication.
+   document-set ids, and transactional revision publication.
 8. Implement the app-session/OIDC credential layer and key-management contract
    needed by the Rust service.
 9. Add integration tests covering:

--- a/docs/adr/aws-rust-room-host.md
+++ b/docs/adr/aws-rust-room-host.md
@@ -63,13 +63,18 @@ The shared protocol surface already exists:
   `/n/:id/sync`, so the browser does not require Durable Object semantics.
 
 The native daemon already has pieces the hosted service should reuse or
-extract:
+extract, but the native `NotebookRoom` itself is not the hosted-room shape. It
+also owns local file bindings, file watchers, autosave, trust state, local
+runtime-agent handles, and destructive kernel teardown. Those are daemon/local
+concerns, not hosted-room concerns.
 
 - `crates/runtimed/src/notebook_sync_server/peer_loop.rs` has the biased
-  frame/readiness/runtime/presence loop.
+  frame/readiness/runtime/presence loop. It is generic over `AsyncRead` and
+  `AsyncWrite`; the remaining daemon couplings should be carved out as
+  explicit parameters or hosted adapters.
 - `peer_writer.rs` classifies reliable frame lanes and gates request authority.
-- The native room model owns `NotebookDoc`, `RuntimeStateDoc`, `CommsDoc`,
-  presence, request workers, blob upload workers, and runtime lifecycle.
+- The shared document and wire crates (`notebook-doc`, `runtime-doc`,
+  `notebook-wire`, `notebook-protocol`) are daemon-free.
 
 The cloud Worker has hosted product pieces that should be ported through proper
 interfaces:
@@ -81,6 +86,13 @@ interfaces:
 - `apps/notebook-cloud/src/room-materializer.ts` has the checkpoint and
   published-snapshot recovery policy, currently backed by Durable Object
   storage, D1, R2, and `runtimed-wasm`.
+
+`crates/runtimed-wasm/src/lib.rs` `RoomHostHandle` is the closest reference
+design for the hosted room's shape: per-peer Automerge sync states, scope
+validation, execution-queue handling, workstation attachment publication, and
+`reconcile_runtime_peer_gone`. The native hosted room should mirror that
+structure in Rust; it should not treat the WASM boundary as the implementation
+to embed or mechanically extract.
 
 ## Decision 1: The Hosted Room Host Is Native Rust
 
@@ -121,10 +133,16 @@ Outputs:
 - catalog/revision writes to Postgres;
 - metrics/logs.
 
+One Tokio task owns the three room documents and all per-peer sync state for a
+given notebook. Peer tasks communicate with that owner through channels. Do not
+share `NotebookDoc`, `RuntimeStateDoc`, `CommsDoc`, or per-peer
+`automerge::sync::State` through `Arc<RwLock<_>>` across peer tasks; that erodes
+the single-writer guarantee that Durable Objects previously gave implicitly.
+
 The service should reuse native `runtimed` room-loop mechanics where possible.
-It should not embed `runtimed-wasm` as its core room engine. WASM remains a
-browser/client boundary and a compatibility/testing asset; the server is native
-Rust.
+It should model the hosted document owner after `RoomHostHandle`, but should
+not embed `runtimed-wasm` as its core room engine. WASM remains a browser/client
+boundary and a compatibility/testing asset; the server is native Rust.
 
 ## Decision 2: The WebSocket Protocol Stays Stable
 
@@ -147,7 +165,46 @@ with current clients, including a `cloud_room_ready`-equivalent announcement
 for hosted runtime/workstation peers that need the authenticated principal for
 actor labeling.
 
-## Decision 3: Postgres Is The Catalog And Authorization Store
+The WebSocket implementation must configure its server-side frame/message caps
+from `notebook-wire`'s frame-size limits instead of using Axum/Tungstenite
+defaults or re-declared constants. `AutomergeSync`, `RuntimeStateSync`, and
+`CommsDocSync` can be large; mismatched server caps will look like sync
+corruption to clients.
+
+The ALB/WebSocket deployment must either raise the ALB idle timeout above the
+default or use a protocol-level keepalive. Quiet viewer-only rooms should not be
+disconnected merely because no notebook edits or presence heartbeats happened
+within the default load-balancer window.
+
+## Decision 3: Authentication Happens Before Room Actor Admission
+
+The Rust service authenticates HTTP and WebSocket requests before they enter a
+room actor. The Worker-to-Durable-Object trusted-header pattern does not carry
+over as an internal security boundary in a single binary.
+
+The service still inherits the credential transport model from
+`hosted-credential-transport.md`:
+
+- browser OIDC callback creates an app-session cookie;
+- browser WebSockets authenticate with the app session and retain the
+  same-origin `Origin` gate;
+- browser bearer/subprotocol fallback remains available only where explicitly
+  allowed by the credential transport ADR;
+- native clients and runtime/workstation peers authenticate with bearer tokens
+  or API keys through the hosted WebSocket upgrade path.
+
+The Rust service owns its own app-session signing/encryption keys. Terraform
+must provision that key material through Secrets Manager or an equivalent secret
+store before the app/auth routes are considered deployable. This is a
+pre-Terraform design input, not a post-deployment cleanup item.
+
+After authentication, authorization loads room ACL state from Postgres and
+derives the requested connection scope before the room actor sees the peer. The
+room actor receives a validated principal, operator/actor label, requested
+scope, and capability bounds. It does not trust client-supplied actor labels or
+scope claims.
+
+## Decision 4: Postgres Is The Catalog And Authorization Store
 
 Postgres is the application database for hosted notebooks. RDS PostgreSQL is
 the preferred AWS deployment form.
@@ -184,6 +241,18 @@ prototype tables while improving the database primitives:
 - explicit transactions around ACL mutation, invite acceptance, attach-job
   transitions, and revision publication.
 
+The hosted ACL invariants from `hosted-room-authorization.md` remain portable
+to Postgres:
+
+- public access is an explicit `public`/`anonymous` viewer row, not inferred
+  from an artifact key;
+- owner rows are protected so ACL mutation cannot orphan a room with no owner;
+- ACL writes update `updated_at` through a migration-owned trigger or storage
+  helper;
+- transactional revision publication updates revision rows and
+  `notebooks.latest_revision_id` together;
+- active workstation attach jobs stay protected by a partial unique index.
+
 Use `sqlx` as the default Rust database client:
 
 - it fits an Axum/Tokio service;
@@ -194,7 +263,7 @@ Use `sqlx` as the default Rust database client:
 `tokio-postgres` remains an acceptable fallback if a concrete dynamic-query
 need makes `sqlx` awkward, but it should not be the default.
 
-## Decision 4: RDS Is The Default Managed Postgres Deployment
+## Decision 5: RDS Is The Default Managed Postgres Deployment
 
 For repeated demos or persistent hosted environments, use RDS PostgreSQL rather
 than self-managed Postgres on the application instance.
@@ -227,7 +296,7 @@ Self-managed Postgres remains acceptable for:
 The application code must not care which Postgres deployment form is used.
 `DATABASE_URL` and migrations should be the boundary.
 
-## Decision 5: S3 Stores Snapshots And Blobs
+## Decision 6: S3 Stores Snapshots And Blobs
 
 S3 stores Automerge document bytes, runtime/comms snapshots, output blobs, and
 rendered/generated artifacts. Postgres stores metadata and authorization
@@ -241,22 +310,36 @@ notebooks/{notebook_id}/checkpoints/{checkpoint_id}/notebook.am
 notebooks/{notebook_id}/checkpoints/{checkpoint_id}/runtime-state.am
 notebooks/{notebook_id}/checkpoints/{checkpoint_id}/comms.am
 
-notebooks/{notebook_id}/snapshots/{notebook_heads_hash}.am
+docs/{notebook_doc_id}/snapshots/{notebook_heads_hash}.am
 docs/{runtime_state_doc_id}/snapshots/{runtime_heads_hash}.am
 docs/{comms_doc_id}/snapshots/{comms_heads_hash}.am
 
 blobs/{sha256}
 ```
 
-This aligns with `hosted-notebook-artifacts.md`: published revisions are
-snapshot bundles, and blob references are content-addressed. The exact key
-prefixes may change during implementation, but the split is stable:
+This lands the long-term namespace from `hosted-notebook-artifacts.md` for new
+AWS buckets: published document snapshots use `docs/{docId}` for all document
+types, including `NotebookDoc`. The `notebooks/{id}/checkpoints/` prefix is
+reserved for operational room-host checkpoints, not published revision
+artifacts.
+
+Revision rows record exact snapshot keys, so mixed-layout reads remain
+possible. Existing Cloudflare/R2 layouts such as `n/{id}/snapshots/...` and
+legacy nested runtime snapshot keys should stay readable during migration.
+
+Global `blobs/{sha256}` objects make S3 the content-addressed byte pool.
+Authorization and lifetime flow through the Postgres `notebook_blobs` reference
+table. The first implementation can choose "no blob GC yet"; if it does, that
+must be explicit. Prefix deletion by notebook id is no longer sufficient once
+the byte pool is shared.
+
+The stable split:
 
 - content-addressed bytes in S3;
 - revision/checkpoint metadata in Postgres;
 - room coordination in the Rust room actor, not S3.
 
-## Decision 6: One Big Room Host First, Leases Later
+## Decision 7: One Big Room Host First, Leases Later
 
 The first AWS service should be one vertically scaled room-host process behind
 an ALB. One active process owns all live room actors.
@@ -287,15 +370,25 @@ A host may own a live room only while it holds the lease. Room movement resets
 per-peer `automerge::sync::State`; document truth comes from the latest
 checkpoint/snapshot.
 
-## Decision 7: Room Checkpointing Is Debounced But Durable
+Durable Object hibernation and the current frame replay buffer are not
+architectural requirements for the native service. A long-running room host can
+keep active rooms in memory and should rely on document sync plus checkpoints
+for recovery rather than porting hibernation behavior mechanically.
 
-On room load:
+## Decision 8: Room Checkpointing Is Debounced But Durable
+
+On room load, port the current Cloudflare materializer's checkpoint precedence
+logic rather than replacing it with a simpler "checkpoint else snapshot" rule:
 
 1. Check the latest checkpoint metadata.
-2. If the checkpoint is compatible with the latest published revision baseline,
+2. If the checkpoint's recorded published revision differs from the latest
+   published revision, keep it only when its recorded heads prove unpublished
+   room changes, with the same legacy-version timestamp fallback used by the
+   prototype.
+3. If the checkpoint is compatible with the latest published revision baseline,
    load checkpointed `NotebookDoc`, `RuntimeStateDoc`, and `CommsDoc` bytes.
-3. Otherwise load the latest published snapshot bundle.
-4. If neither exists, create an empty hosted room using deterministic room-owned
+4. Otherwise load the latest published snapshot bundle.
+5. If neither exists, create an empty hosted room using deterministic room-owned
    actor labels and deterministic hosted starter-cell IDs.
 
 On room mutation:
@@ -306,6 +399,12 @@ On room mutation:
 4. Record checkpoint metadata when useful for recovery/debugging.
 5. Flush checkpoints on graceful shutdown and room eviction.
 
+S3 checkpoint commits should be pointer-swapped, not four independent "latest"
+writes. Write immutable `{checkpoint_id}/*.am` objects first, then write
+`checkpoints/latest.json` last as the single commit point. A crash before the
+pointer update leaves the previous checkpoint active; a crash after the pointer
+update points at a complete immutable object set.
+
 Room-owned bootstrap actors are load-bearing. Use deterministic labels derived
 from notebook id, following the current Cloudflare room-host pattern:
 
@@ -313,11 +412,21 @@ from notebook id, following the current Cloudflare room-host pattern:
 system:notebook-cloud-room/room:{stable_room_key(notebook_id)}
 ```
 
+The hosted starter-cell id is also deterministic:
+`cell-room-{stable_room_key(notebook_id)}`. Port both identities with shared
+test vectors so restart/bootstrap behavior cannot reintroduce duplicate
+Automerge sequence errors.
+
 Concurrent users, agents, and runtime peers must author with unique actor
 labels under their authenticated principal/operator. On reconnect, reset
 per-peer sync state and preserve document truth.
 
-## Decision 8: Authority Boundaries Stay The Same
+The runtime-peer grace timer currently implemented with Durable Object alarms
+becomes an in-process Tokio timer in the single-host service. Because that timer
+dies with the process, room load must also reconcile stale runtime-peer state so
+phantom running executions and kernels do not survive a host crash.
+
+## Decision 9: Authority Boundaries Stay The Same
 
 Moving from Durable Objects to Rust/AWS must not weaken hosted authorization:
 
@@ -335,10 +444,32 @@ owner-only for execution requests until an explicit execute capability exists.
 UI gating is not enough; the room host must reject unauthorized `REQUEST`
 frames.
 
+The hosted request dispatcher must also explicitly reject request types that are
+local-daemon concerns, such as local kernel launch/interrupt/shutdown and
+`.ipynb` save requests, unless a hosted controller intentionally implements
+them. Hosted-safe request types include execution intent for an already attached
+runtime peer, run-all intent, and widget comm messages. Unsupported request
+types return structured error responses; they are not silently dropped.
+
 Runtime control-plane signals must remain independent from output/blob
 transport. `KernelIdle`, `ExecutionDone`, `CellError`, and `KernelDied` cannot
 be backpressured by stdout floods, display churn, manifest commits, or blob
 writes.
+
+## Decision 10: Hosted Origins Stay Split
+
+The AWS deployment keeps the three-origin security model from
+`hosted-output-origin-isolation.md`:
+
+- authenticated app/API/WebSocket origin;
+- renderer asset origin;
+- sandboxed output-document/usercontent origin.
+
+The first Terraform plan therefore needs more than one origin, not merely one
+ALB route. It may serve the authenticated app/API/WebSocket origin from the Rust
+service and serve renderer/output assets through S3 + CloudFront, or another
+equivalent split. The important invariant is that sandboxed output frames cannot
+receive app cookies, tokens, or localStorage.
 
 ## Consequences
 
@@ -361,8 +492,8 @@ Negative:
 - The first single-host deployment is a single point of failure until lease
   based sharding/HA exists.
 - Auth/session code currently written for Workers must be ported or extracted.
-- The room-host core must be extracted from the WASM boundary carefully to avoid
-  reintroducing projection drift.
+- The room-host core must be implemented natively while staying behaviorally
+  aligned with the current `RoomHostHandle` reference design.
 
 Neutral:
 
@@ -400,39 +531,63 @@ correct.
 
 ## Implementation Plan
 
-1. Define native hosted room traits:
+No Terraform should land until the native hosted room passes local integration
+tests against Postgres and an S3-compatible object store such as MinIO. The
+first carve-outs should be verifiable with `cargo test` and local services,
+without AWS.
+
+1. Build an Axum/Tokio WebSocket adapter that implements `FrameSource` and
+   `FrameSink` over one-message-per-frame hosted WebSockets, with frame-size
+   caps sourced from `notebook-wire`. Test it against `CloudWsFrameTransport`
+   as the client.
+2. Decouple the reusable parts of `peer_loop` / `peer_writer` from `Daemon`.
+   Pass idle timeout and pool-doc behavior as explicit parameters or hosted
+   adapters.
+3. Define hosted request policy and dispatch traits. Hosted dispatch should
+   accept only hosted-safe request types and return structured errors for
+   local-daemon request types.
+4. Build `HostedRoom` / `RoomActor` after `RoomHostHandle`'s structure, reusing
+   shared document crates and peer-loop mechanics. The actor owns documents and
+   per-peer sync states in one task; it does not include file binding, local
+   trust state, local kernel handles, or local autosave.
+5. Define fresh native hosted room traits:
    - `HostedCatalogStore`;
    - `HostedObjectStore`;
    - `HostedCheckpointStore`;
    - `HostedAuthz`;
    - `HostedRoom`.
-2. Extract the room-host document logic out of `runtimed-wasm` into native Rust
-   where needed.
-3. Build an Axum/Tokio WebSocket adapter that speaks hosted typed-frame v4
-   messages.
-4. Implement Postgres migrations and a `sqlx` store for catalog, ACL, sharing,
-   workstations, and attach jobs.
-5. Implement S3 object storage for snapshots and blobs, with a filesystem/minio
-   test adapter.
-6. Add integration tests covering:
+   These are new service abstractions, not an existing `runtimed` persistence
+   layer. Provide filesystem/MinIO and dockerized-Postgres test adapters.
+6. Implement `HostedObjectStore` and `HostedCheckpointStore`; port checkpoint
+   precedence logic with shared test vectors for deterministic actor label,
+   starter cell id, and keep/discard decisions.
+7. Implement Postgres migrations and a `sqlx` `HostedCatalogStore` /
+   `HostedAuthz` for catalog, ACL, sharing, workstations, and attach jobs.
+   Preserve never-zero-owner ACL protection, partial unique active attach jobs,
+   and transactional revision publication.
+8. Implement the app-session/OIDC credential layer and key-management contract
+   needed by the Rust service.
+9. Add integration tests covering:
    - initial sync;
    - editor notebook writes;
    - owner execution request acceptance;
    - editor execution request rejection;
+   - explicit rejection for local-daemon-only request types;
    - runtime peer RuntimeStateDoc/CommsDoc sync;
    - `PutBlob`;
    - widget state convergence across two browser clients;
    - checkpoint save/load after process restart.
-7. Add Terraform for one staged AWS deployment:
+10. Add Terraform for one staged AWS deployment:
    - VPC/subnets or use existing VPC input;
    - ALB and target group;
    - EC2/ECS room-host service;
    - RDS PostgreSQL;
    - S3 bucket;
    - Secrets Manager/SSM;
+   - app, renderer-asset, and output-document origins;
    - IAM role/policies;
    - CloudWatch logs/metrics.
-8. Run the existing hosted Playwright/smoke flows against the AWS origin.
+11. Run the existing hosted Playwright/smoke flows against the AWS origin.
 
 ## Tracked Follow-Ups
 
@@ -440,8 +595,6 @@ correct.
   `runt cloud serve`, or a separate temporary binary.
 - Decide whether HTTP app/API routes and WebSocket rooms live in one binary or
   split after the first deployment.
-- Design production session-cookie refresh and OIDC callback handling outside
-  Workers.
 - Define a public/private output blob access policy for S3-backed blobs and the
   separate output origin.
 - Add the future execute capability/scope before granting non-owner execution.
@@ -461,3 +614,9 @@ correct.
   `https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/Concepts.MultiAZ.html`
 - Terraform `aws_db_instance`:
   `https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/db_instance`
+- Hosted credential transport:
+  `hosted-credential-transport.md`
+- Hosted output origin isolation:
+  `hosted-output-origin-isolation.md`
+- Hosted notebook artifacts:
+  `hosted-notebook-artifacts.md`

--- a/docs/adr/aws-rust-room-host.md
+++ b/docs/adr/aws-rust-room-host.md
@@ -358,7 +358,11 @@ document set. They are not the hosted persistence boundary.
 Keep identifiers boring and single-purpose:
 
 - `notebook_id` is the stable opaque room/catalog id. It drives routes, ACLs,
-  room placement, leases, workstations, and live sync.
+  room placement, leases, workstations, and live sync. New hosted notebook ids
+  are uniformly random 26-character Crockford base32 strings, giving 130 bits
+  of randomness while preserving the current URL-safe shape. Nothing may infer
+  time, order, tenancy, or placement from id structure; creation time lives in
+  `created_at`, and placement comes from hashing the full id.
 - document ids identify the individual Automerge documents whose immutable
   published snapshots live under `docs/{docId}`.
 - `revision_id` identifies an immutable published snapshot bundle for one
@@ -369,6 +373,10 @@ Keep identifiers boring and single-purpose:
   sharing surface.
 - titles and slugs are mutable display/navigation metadata. They are never
   authorization, placement, publication, or checkpoint authority.
+
+Existing prototype ULID-shaped notebook ids remain valid as opaque strings.
+They do not require migration and should not receive special routing or
+ordering behavior.
 
 The canonical hosted routes should be identity-first with optional decorative
 slugs:
@@ -444,8 +452,8 @@ seams without adding multi-host machinery yet:
   `RuntimeStateDoc`, and `CommsDoc` co-locate under that notebook id and are
   never placed independently, even though published snapshots use per-document
   `docs/{docId}` namespaces. Vanity names, document ids, and revision ids do
-  not route rooms. Notebook ids are ULID-like and time-prefixed, so any future
-  placement must hash; it must not range-partition by id.
+  not route rooms. Future placement still hashes the full id; it must not
+  range-partition, sort, or otherwise infer meaning from the id.
 - `RoomRegistry` resolution is the single admission gate after authentication
   and authorization. The v1 implementation can always return local ownership,
   but the shape should allow `resolve(notebook_id) -> Owned(handle) |
@@ -665,7 +673,8 @@ without AWS.
 7. Implement Postgres migrations and a `sqlx` `HostedCatalogStore` /
    `HostedAuthz` for catalog, ACL, sharing, workstations, and attach jobs.
    Preserve never-zero-owner ACL protection, partial unique active attach jobs,
-   document-set ids, and transactional revision publication.
+   document-set ids, a uniformly random hosted notebook id generator, and
+   transactional revision publication.
 8. Implement the app-session/OIDC credential layer and key-management contract
    needed by the Rust service.
 9. Add integration tests covering:

--- a/docs/adr/aws-rust-room-host.md
+++ b/docs/adr/aws-rust-room-host.md
@@ -1,0 +1,463 @@
+# AWS Rust Room Host
+
+**Status:** Draft, 2026-06-10.
+
+**Supersedes in part:** `deployment-topology.md` Decision 1 for the next
+hosted deployment target. The Cloudflare Worker/Durable Object stack remains
+the current prototype and evidence source, but the proposed production-oriented
+path is a native Rust room host on AWS.
+
+## Context
+
+The hosted prototype on `preview.runt.run` proved the core product loop:
+
+- browsers, agents, and runtime/workstation peers can connect to a hosted
+  notebook room over typed-frame v4 WebSockets;
+- the room host can own `NotebookDoc`, `RuntimeStateDoc`, and `CommsDoc`;
+- runtime peers can attach from a workstation and publish execution/output
+  state back into the room;
+- the dashboard, sharing, public snapshots, widgets, and workstation attach
+  flows can all be productized around the same document model.
+
+The Cloudflare implementation also exposed a deployment pressure point. Durable
+Objects are convenient for one-object-per-room coordination, but the hosted
+service is now hitting plan limits and is becoming harder to reason about as a
+long-running collaborative runtime surface. The next architecture should keep
+the protocol and local-first document model, but move room authority into a
+native service we can scale, instrument, and operate directly.
+
+The desired shift:
+
+```text
+browser / desktop / agent / workstation runtime peer
+        |
+        | wss://host/n/:notebook_id/sync
+        | one WS binary message = [NotebookFrameType byte][payload]
+        v
+Rust hosted room service
+        |
+        | active room actor owns NotebookDoc + RuntimeStateDoc + CommsDoc
+        v
+Postgres catalog/ACL/workstations + S3 snapshots/blobs
+```
+
+This should be a `runtimed`-adjacent hosted service, not a line-by-line port of
+the TypeScript Worker. The existing Cloudflare code is useful because it
+clarifies product semantics, route contracts, ACL behavior, workstation attach
+jobs, snapshot validation, and output isolation. The native daemon code is
+useful because it already has the Rust room loop, request authority, peer writer
+lanes, and runtime-state handling we want in the hosted service.
+
+## Existing Seams
+
+The shared protocol surface already exists:
+
+- `crates/notebook-wire/src/lib.rs` defines `NotebookFrameType`, frame values,
+  and frame-size limits.
+- `crates/notebook-protocol/src/connection/transport.rs` defines
+  `FrameSource` / `FrameSink` abstractions.
+- `crates/notebook-cloud-transport/src/lib.rs` implements the hosted WebSocket
+  transport for runtime/workstation peers: each WebSocket binary message is one
+  typed frame with no local UDS length preamble.
+- `apps/notebook-cloud/viewer/live-sync.ts` uses browser WebSockets against
+  `/n/:id/sync`, so the browser does not require Durable Object semantics.
+
+The native daemon already has pieces the hosted service should reuse or
+extract:
+
+- `crates/runtimed/src/notebook_sync_server/peer_loop.rs` has the biased
+  frame/readiness/runtime/presence loop.
+- `peer_writer.rs` classifies reliable frame lanes and gates request authority.
+- The native room model owns `NotebookDoc`, `RuntimeStateDoc`, `CommsDoc`,
+  presence, request workers, blob upload workers, and runtime lifecycle.
+
+The cloud Worker has hosted product pieces that should be ported through proper
+interfaces:
+
+- `apps/notebook-cloud/src/index.ts` has route shape, auth/session endpoints,
+  notebook APIs, sharing APIs, and workstation APIs.
+- `apps/notebook-cloud/src/storage.ts` defines the current catalog, ACL,
+  sharing, workstation, default-workstation, and attach-job data model.
+- `apps/notebook-cloud/src/room-materializer.ts` has the checkpoint and
+  published-snapshot recovery policy, currently backed by Durable Object
+  storage, D1, R2, and `runtimed-wasm`.
+
+## Decision 1: The Hosted Room Host Is Native Rust
+
+The next hosted room engine should be a native Rust service. It accepts the same
+typed-frame v4 WebSocket protocol as the Cloudflare room, but owns room state in
+native Rust rather than through `runtimed-wasm` inside a Worker.
+
+The service hosts one active actor per live notebook room:
+
+```text
+RoomRegistry
+  notebook_id -> RoomActorHandle
+
+RoomActor
+  NotebookDoc
+  RuntimeStateDoc
+  CommsDoc
+  per-peer Automerge sync states
+  presence map
+  runtime_peer tracking/grace timer
+  checkpoint debounce
+  peer broadcast channels
+```
+
+Inputs:
+
+- peer joined;
+- typed frame from peer;
+- peer left;
+- workstation attach-job status;
+- checkpoint timer;
+- graceful shutdown.
+
+Outputs:
+
+- typed frames to connected peers;
+- checkpoint writes to S3;
+- catalog/revision writes to Postgres;
+- metrics/logs.
+
+The service should reuse native `runtimed` room-loop mechanics where possible.
+It should not embed `runtimed-wasm` as its core room engine. WASM remains a
+browser/client boundary and a compatibility/testing asset; the server is native
+Rust.
+
+## Decision 2: The WebSocket Protocol Stays Stable
+
+The externally visible room wire protocol does not change:
+
+- Upgrade route: `/n/:notebook_id/sync`.
+- WebSocket binary body: `[NotebookFrameType as u8][payload]`.
+- Notebook document sync: `NotebookFrameType::AutomergeSync`.
+- Runtime state sync: `NotebookFrameType::RuntimeStateSync`.
+- Widget comm state sync: `NotebookFrameType::CommsDocSync`.
+- Requests/responses, presence, session-control, broadcasts, and `PutBlob`
+  remain their existing typed-frame channels.
+
+Do not switch hosted browser/runtime peers to the local UDS length-preamble
+framing. The preamble is for local daemon streams; hosted WebSockets already
+have one-message-per-frame semantics.
+
+The server should continue to send session-control readiness frames compatible
+with current clients, including a `cloud_room_ready`-equivalent announcement
+for hosted runtime/workstation peers that need the authenticated principal for
+actor labeling.
+
+## Decision 3: Postgres Is The Catalog And Authorization Store
+
+Postgres is the application database for hosted notebooks. RDS PostgreSQL is
+the preferred AWS deployment form.
+
+Postgres owns:
+
+- notebook catalog rows;
+- revision metadata;
+- blob indexes;
+- ACL rows;
+- principal profiles and account links;
+- invites and access requests;
+- workstations;
+- default workstation choices;
+- workstation attach jobs;
+- future room leases;
+- optional checkpoint metadata indexes.
+
+S3 owns large bytes. Do not put full Automerge saves or output blobs in
+Postgres rows.
+
+The current D1 schema in `apps/notebook-cloud/src/storage.ts` is a useful
+starting contract, but the Postgres schema should be real migrations rather
+than request-time `ensureCatalogSchema` helpers. The first schema can mirror the
+prototype tables while improving the database primitives:
+
+- `timestamptz` instead of ISO timestamp strings;
+- enum types or checked text domains for scopes and statuses;
+- `jsonb` for bounded workstation environment facts;
+- `updated_at` triggers instead of repeated manual timestamp writes;
+- intentional `ON DELETE` behavior for notebook-owned rows;
+- partial unique indexes for pending invites/access requests and active
+  workstation attach jobs;
+- explicit transactions around ACL mutation, invite acceptance, attach-job
+  transitions, and revision publication.
+
+Use `sqlx` as the default Rust database client:
+
+- it fits an Axum/Tokio service;
+- it has an async pool and transaction API;
+- it gives us checked queries and migrations as the schema grows;
+- it makes it harder to quietly drift between application types and SQL rows.
+
+`tokio-postgres` remains an acceptable fallback if a concrete dynamic-query
+need makes `sqlx` awkward, but it should not be the default.
+
+## Decision 4: RDS Is The Default Managed Postgres Deployment
+
+For repeated demos or persistent hosted environments, use RDS PostgreSQL rather
+than self-managed Postgres on the application instance.
+
+RDS keeps database durability and operations separate from room-host CPU/RAM
+scaling. It also gives us managed backups, snapshots, VPC deployment, SSL,
+read-replica options, and Multi-AZ options when needed.
+
+Terraform should own the initial AWS database shape:
+
+```text
+aws_db_subnet_group
+aws_security_group       # app -> db only
+aws_db_instance          # engine = postgres, private subnets
+aws_secretsmanager_*     # or RDS-managed master password
+aws_iam_role/policy      # app role can read db secret and access S3
+```
+
+Start with a single RDS PostgreSQL instance with backups enabled. Enable
+Multi-AZ when the deployment moves beyond demo/staging reliability needs. Avoid
+Aurora until there is evidence that the room host needs Aurora-specific scaling,
+latency, or availability behavior.
+
+Self-managed Postgres remains acceptable for:
+
+- local integration tests;
+- disposable EC2 experiments;
+- emergency bring-up when RDS/IAM/Terraform setup would block learning.
+
+The application code must not care which Postgres deployment form is used.
+`DATABASE_URL` and migrations should be the boundary.
+
+## Decision 5: S3 Stores Snapshots And Blobs
+
+S3 stores Automerge document bytes, runtime/comms snapshots, output blobs, and
+rendered/generated artifacts. Postgres stores metadata and authorization
+decisions.
+
+Initial object layout:
+
+```text
+notebooks/{notebook_id}/checkpoints/latest.json
+notebooks/{notebook_id}/checkpoints/{checkpoint_id}/notebook.am
+notebooks/{notebook_id}/checkpoints/{checkpoint_id}/runtime-state.am
+notebooks/{notebook_id}/checkpoints/{checkpoint_id}/comms.am
+
+notebooks/{notebook_id}/snapshots/{notebook_heads_hash}.am
+docs/{runtime_state_doc_id}/snapshots/{runtime_heads_hash}.am
+docs/{comms_doc_id}/snapshots/{comms_heads_hash}.am
+
+blobs/{sha256}
+```
+
+This aligns with `hosted-notebook-artifacts.md`: published revisions are
+snapshot bundles, and blob references are content-addressed. The exact key
+prefixes may change during implementation, but the split is stable:
+
+- content-addressed bytes in S3;
+- revision/checkpoint metadata in Postgres;
+- room coordination in the Rust room actor, not S3.
+
+## Decision 6: One Big Room Host First, Leases Later
+
+The first AWS service should be one vertically scaled room-host process behind
+an ALB. One active process owns all live room actors.
+
+This is intentionally not horizontally distributed at first. It avoids a class
+of subtle bugs:
+
+- two active hosts mutating the same room;
+- sticky-session assumptions replacing explicit document authority;
+- concurrent room-owned bootstrap actors producing duplicate Automerge seq
+  errors;
+- per-peer sync state accidentally surviving room movement.
+
+Scale-out should be explicit and later. When more than one room-host process is
+needed, add a Postgres-backed `room_leases` table:
+
+```sql
+CREATE TABLE room_leases (
+  notebook_id text PRIMARY KEY REFERENCES notebooks(id) ON DELETE CASCADE,
+  holder_id text NOT NULL,
+  generation bigint NOT NULL,
+  expires_at timestamptz NOT NULL,
+  updated_at timestamptz NOT NULL DEFAULT now()
+);
+```
+
+A host may own a live room only while it holds the lease. Room movement resets
+per-peer `automerge::sync::State`; document truth comes from the latest
+checkpoint/snapshot.
+
+## Decision 7: Room Checkpointing Is Debounced But Durable
+
+On room load:
+
+1. Check the latest checkpoint metadata.
+2. If the checkpoint is compatible with the latest published revision baseline,
+   load checkpointed `NotebookDoc`, `RuntimeStateDoc`, and `CommsDoc` bytes.
+3. Otherwise load the latest published snapshot bundle.
+4. If neither exists, create an empty hosted room using deterministic room-owned
+   actor labels and deterministic hosted starter-cell IDs.
+
+On room mutation:
+
+1. Apply the mutation to in-memory document truth.
+2. Broadcast sync replies/updates to connected peers.
+3. Debounce checkpoint writes to S3.
+4. Record checkpoint metadata when useful for recovery/debugging.
+5. Flush checkpoints on graceful shutdown and room eviction.
+
+Room-owned bootstrap actors are load-bearing. Use deterministic labels derived
+from notebook id, following the current Cloudflare room-host pattern:
+
+```text
+system:notebook-cloud-room/room:{stable_room_key(notebook_id)}
+```
+
+Concurrent users, agents, and runtime peers must author with unique actor
+labels under their authenticated principal/operator. On reconnect, reset
+per-peer sync state and preserve document truth.
+
+## Decision 8: Authority Boundaries Stay The Same
+
+Moving from Durable Objects to Rust/AWS must not weaken hosted authorization:
+
+- The room URL identifies a room; it does not grant access.
+- Credentials authenticate principals.
+- Postgres ACL rows authorize room scope.
+- The room actor is document authority.
+- Runtime peers are compute/output authority for accepted work, not notebook
+  editors and not execution-intent creators.
+- Sandboxed output frames remain on a separate origin and must not receive app
+  credentials.
+
+Execution authority stays separate from edit authority. The current policy is
+owner-only for execution requests until an explicit execute capability exists.
+UI gating is not enough; the room host must reject unauthorized `REQUEST`
+frames.
+
+Runtime control-plane signals must remain independent from output/blob
+transport. `KernelIdle`, `ExecutionDone`, `CellError`, and `KernelDied` cannot
+be backpressured by stdout floods, display churn, manifest commits, or blob
+writes.
+
+## Consequences
+
+Positive:
+
+- The hosted room engine becomes testable with ordinary Rust integration tests.
+- We can use shared `runtimed` room-loop logic instead of maintaining a
+  TypeScript/WASM room-host fork.
+- Postgres gives real transactions, indexes, row-level locking, and a path to
+  room leases.
+- S3 gives a durable byte store for snapshots/blobs without relational row-size
+  pressure.
+- AWS deployment avoids Cloudflare Durable Object request limits for live demo
+  traffic.
+
+Negative:
+
+- We take on more infrastructure surface: ALB, EC2/ECS, RDS, S3, IAM, secrets,
+  and observability.
+- The first single-host deployment is a single point of failure until lease
+  based sharding/HA exists.
+- Auth/session code currently written for Workers must be ported or extracted.
+- The room-host core must be extracted from the WASM boundary carefully to avoid
+  reintroducing projection drift.
+
+Neutral:
+
+- The browser/client protocol should remain compatible.
+- Runtime/workstation peers should keep using `notebook-cloud-transport`.
+- Cloudflare can still serve static/edge pieces later if useful, but it is not
+  the room authority in this ADR.
+
+## Rejected Alternatives
+
+### Run Wrangler/Miniflare On EC2
+
+This can be useful as a temporary debugging bridge, but it keeps the Worker,
+Durable Object, D1, and R2 mental model while removing the managed platform
+that made that model worthwhile. It also does not move us toward native Rust
+room-host tests or Postgres/S3 durability.
+
+### Self-Managed Postgres On The Room Host
+
+This is fine for disposable spikes but not the default. It couples application
+instance replacement to database durability and makes backups, upgrades,
+restore testing, disk alarms, and credential rotation our immediate problem.
+
+### Store Automerge Bytes In Postgres
+
+Postgres should store metadata and decisions. S3 should store large immutable
+or checkpointed bytes. Keeping Automerge saves and blobs out of relational rows
+avoids row bloat and makes content-addressed blob behavior straightforward.
+
+### Horizontal Multi-Host First
+
+The protocol and product are not ready for implicit multi-host room authority.
+Start with one live host and add explicit leases once the native room host is
+correct.
+
+## Implementation Plan
+
+1. Define native hosted room traits:
+   - `HostedCatalogStore`;
+   - `HostedObjectStore`;
+   - `HostedCheckpointStore`;
+   - `HostedAuthz`;
+   - `HostedRoom`.
+2. Extract the room-host document logic out of `runtimed-wasm` into native Rust
+   where needed.
+3. Build an Axum/Tokio WebSocket adapter that speaks hosted typed-frame v4
+   messages.
+4. Implement Postgres migrations and a `sqlx` store for catalog, ACL, sharing,
+   workstations, and attach jobs.
+5. Implement S3 object storage for snapshots and blobs, with a filesystem/minio
+   test adapter.
+6. Add integration tests covering:
+   - initial sync;
+   - editor notebook writes;
+   - owner execution request acceptance;
+   - editor execution request rejection;
+   - runtime peer RuntimeStateDoc/CommsDoc sync;
+   - `PutBlob`;
+   - widget state convergence across two browser clients;
+   - checkpoint save/load after process restart.
+7. Add Terraform for one staged AWS deployment:
+   - VPC/subnets or use existing VPC input;
+   - ALB and target group;
+   - EC2/ECS room-host service;
+   - RDS PostgreSQL;
+   - S3 bucket;
+   - Secrets Manager/SSM;
+   - IAM role/policies;
+   - CloudWatch logs/metrics.
+8. Run the existing hosted Playwright/smoke flows against the AWS origin.
+
+## Tracked Follow-Ups
+
+- Decide whether the Rust service binary is `runtimed cloud-room-host`,
+  `runt cloud serve`, or a separate temporary binary.
+- Decide whether HTTP app/API routes and WebSocket rooms live in one binary or
+  split after the first deployment.
+- Design production session-cookie refresh and OIDC callback handling outside
+  Workers.
+- Define a public/private output blob access policy for S3-backed blobs and the
+  separate output origin.
+- Add the future execute capability/scope before granting non-owner execution.
+- Add `room_leases` only when multiple room-host processes are introduced.
+
+## References
+
+- AWS ALB WebSocket support:
+  `https://docs.aws.amazon.com/elasticloadbalancing/latest/application/load-balancer-listeners.html`
+- AWS ALB idle timeout attribute:
+  `https://docs.aws.amazon.com/elasticloadbalancing/latest/application/edit-load-balancer-attributes.html`
+- Amazon S3 consistency:
+  `https://docs.aws.amazon.com/AmazonS3/latest/userguide/Welcome.html`
+- Amazon RDS for PostgreSQL:
+  `https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/CHAP_PostgreSQL.html`
+- RDS Multi-AZ deployments:
+  `https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/Concepts.MultiAZ.html`
+- Terraform `aws_db_instance`:
+  `https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/db_instance`

--- a/docs/adr/aws-rust-room-host.md
+++ b/docs/adr/aws-rust-room-host.md
@@ -370,6 +370,37 @@ A host may own a live room only while it holds the lease. Room movement resets
 per-peer `automerge::sync::State`; document truth comes from the latest
 checkpoint/snapshot.
 
+Consistent hashing is a future placement optimization, not a correctness
+mechanism. Leases are authority; hashing only answers which host should first
+try to acquire a lease. If different hosts have different ring views, the lease
+still decides who owns the room. Treating the hash as authority would recreate
+sticky-session split brain.
+
+Keep the single-host implementation ready for that future by preserving these
+seams without adding multi-host machinery yet:
+
+- The placement unit is `notebook_id`. The room's `NotebookDoc`,
+  `RuntimeStateDoc`, and `CommsDoc` co-locate under that notebook id and are
+  never placed independently, even though published snapshots use per-document
+  `docs/{docId}` namespaces. Vanity names, document ids, and revision ids do
+  not route rooms. Notebook ids are ULID-like and time-prefixed, so any future
+  placement must hash; it must not range-partition by id.
+- `RoomRegistry` resolution is the single admission gate after authentication
+  and authorization. The v1 implementation can always return local ownership,
+  but the shape should allow `resolve(notebook_id) -> Owned(handle) |
+  OwnedElsewhere(holder)`. The WebSocket upgrade path is authn, authz,
+  resolve, attach.
+- Room eviction exists on day one. Eviction flushes a checkpoint, drops
+  per-peer sync state, and closes peers. This is needed for idle-memory
+  management in the single-host service and becomes the handoff primitive for
+  later room movement.
+- Clients treat WebSocket close as "reconnect and re-resolve" with backoff.
+  Do not add redirect frames, handoff frames, or cross-host forwarding in v1.
+
+Do not add ring membership, virtual-node configuration, hash-algorithm
+selection, cross-host forwarding, a routing tier, or the `room_leases` table in
+the first single-host implementation.
+
 Durable Object hibernation and the current frame replay buffer are not
 architectural requirements for the native service. A long-running room host can
 keep active rooms in memory and should rely on document sync plus checkpoints
@@ -404,6 +435,12 @@ writes. Write immutable `{checkpoint_id}/*.am` objects first, then write
 `checkpoints/latest.json` last as the single commit point. A crash before the
 pointer update leaves the previous checkpoint active; a crash after the pointer
 update points at a complete immutable object set.
+
+`latest.json` should record the checkpoint id, room-holder identity, and lease
+generation, with holder/generation nullable or sentinel-valued in the v1
+single-host service. Later leased writers can combine S3 conditional writes on
+the pointer object with the recorded generation to fence a stale host from
+clobbering the latest checkpoint after losing ownership.
 
 Room-owned bootstrap actors are load-bearing. Use deterministic labels derived
 from notebook id, following the current Cloudflare room-host pattern:
@@ -549,7 +586,8 @@ without AWS.
 4. Build `HostedRoom` / `RoomActor` after `RoomHostHandle`'s structure, reusing
    shared document crates and peer-loop mechanics. The actor owns documents and
    per-peer sync states in one task; it does not include file binding, local
-   trust state, local kernel handles, or local autosave.
+   trust state, local kernel handles, or local autosave. Add `RoomRegistry`
+   resolution and room eviction as single-host seams, not multi-host behavior.
 5. Define fresh native hosted room traits:
    - `HostedCatalogStore`;
    - `HostedObjectStore`;
@@ -560,7 +598,8 @@ without AWS.
    layer. Provide filesystem/MinIO and dockerized-Postgres test adapters.
 6. Implement `HostedObjectStore` and `HostedCheckpointStore`; port checkpoint
    precedence logic with shared test vectors for deterministic actor label,
-   starter cell id, and keep/discard decisions.
+   starter cell id, and keep/discard decisions. Include holder/generation
+   fields in checkpoint pointer metadata from the start.
 7. Implement Postgres migrations and a `sqlx` `HostedCatalogStore` /
    `HostedAuthz` for catalog, ACL, sharing, workstations, and attach jobs.
    Preserve never-zero-owner ACL protection, partial unique active attach jobs,

--- a/docs/adr/deployment-topology.md
+++ b/docs/adr/deployment-topology.md
@@ -134,6 +134,12 @@ References:
 
 ## Decision 1: Cloudflare is the hosted document engine
 
+This decision records the current Cloudflare prototype and remains useful for
+understanding the shipped `preview.runt.run` path. For the next
+production-oriented hosted target, it is partially superseded by
+`aws-rust-room-host.md`, which moves live room authority to a native Rust room
+host on AWS while preserving the typed-frame protocol and document model.
+
 The primary hosted topology is a Cloudflare Worker routing room requests to one
 Durable Object per notebook room. The Durable Object is the live room host:
 


### PR DESCRIPTION
## Summary
- add a draft ADR for a native Rust hosted room service on AWS
- define Postgres/RDS as the catalog and authorization store, with sqlx as the default Rust client
- define S3 as the durable snapshot/blob byte store while keeping the typed-frame WebSocket protocol stable
- register the ADR in the architecture index

## Validation
- cargo xtask lint --fix