### PR TITLE
perf(outputs): coalesce concurrent text-blob fetches in resolveContentRef

### DIFF
--- a/src/components/isolated/__tests__/output-manifest.test.ts
+++ b/src/components/isolated/__tests__/output-manifest.test.ts
@@ -1,0 +1,154 @@
+import { describe, expect, it, vi } from "vite-plus/test";
+import { type OutputBlobResolver, resolveContentRef, resolveManifest } from "../output-manifest";
+
+function fakeBlobResolver(blobs: Record<string, string>): OutputBlobResolver {
+  return {
+    url(ref: { blob: string }) {
+      return `https://outputs.example.test/blob/${ref.blob}`;
+    },
+    fetch: vi.fn(async (ref) => {
+      const body = blobs[ref.blob];
+      return new Response(body ?? "", {
+        status: body == null ? 404 : 200,
+      });
+    }),
+  };
+}
+
+describe("resolveContentRef blob fetch coalescing", () => {
+  it("shares one fetch across concurrent resolutions of the same ref", async () => {
+    const resolver = fakeBlobResolver({ abc123: "shared text" });
+
+    const [first, second, third] = await Promise.all([
+      resolveContentRef({ blob: "abc123" }, resolver),
+      resolveContentRef({ blob: "abc123" }, resolver),
+      resolveContentRef({ blob: "abc123" }, resolver),
+    ]);
+
+    expect(first).toBe("shared text");
+    expect(second).toBe("shared text");
+    expect(third).toBe("shared text");
+    expect(resolver.fetch).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not coalesce distinct blob hashes", async () => {
+    const resolver = fakeBlobResolver({ aaa: "one", bbb: "two" });
+
+    const [a, b] = await Promise.all([
+      resolveContentRef({ blob: "aaa" }, resolver),
+      resolveContentRef({ blob: "bbb" }, resolver),
+    ]);
+
+    expect(a).toBe("one");
+    expect(b).toBe("two");
+    expect(resolver.fetch).toHaveBeenCalledTimes(2);
+  });
+
+  it("fetches again after the in-flight request settles", async () => {
+    const resolver = fakeBlobResolver({ abc123: "text" });
+
+    await resolveContentRef({ blob: "abc123" }, resolver);
+    await resolveContentRef({ blob: "abc123" }, resolver);
+
+    expect(resolver.fetch).toHaveBeenCalledTimes(2);
+  });
+
+  it("rejects all coalesced callers and retries fresh after a failure", async () => {
+    const resolver = fakeBlobResolver({});
+
+    const results = await Promise.allSettled([
+      resolveContentRef({ blob: "missing" }, resolver),
+      resolveContentRef({ blob: "missing" }, resolver),
+    ]);
+
+    expect(results[0].status).toBe("rejected");
+    expect(results[1].status).toBe("rejected");
+    expect(resolver.fetch).toHaveBeenCalledTimes(1);
+
+    await expect(resolveContentRef({ blob: "missing" }, resolver)).rejects.toThrow(
+      "Failed to fetch blob missing: 404",
+    );
+    expect(resolver.fetch).toHaveBeenCalledTimes(2);
+  });
+
+  it("does not coalesce across distinct resolver instances", async () => {
+    const first = fakeBlobResolver({ abc123: "from first" });
+    const second = fakeBlobResolver({ abc123: "from second" });
+
+    const [a, b] = await Promise.all([
+      resolveContentRef({ blob: "abc123" }, first),
+      resolveContentRef({ blob: "abc123" }, second),
+    ]);
+
+    expect(a).toBe("from first");
+    expect(b).toBe("from second");
+    expect(first.fetch).toHaveBeenCalledTimes(1);
+    expect(second.fetch).toHaveBeenCalledTimes(1);
+  });
+
+  it("coalesces port-number inputs across normalize calls", async () => {
+    const fetchMock = vi.fn(async () => new Response("port text", { status: 200 }));
+    vi.stubGlobal("fetch", fetchMock);
+    try {
+      const [a, b] = await Promise.all([
+        resolveContentRef({ blob: "abc123" }, 9123),
+        resolveContentRef({ blob: "abc123" }, 9123),
+      ]);
+
+      expect(a).toBe("port text");
+      expect(b).toBe("port text");
+      expect(fetchMock).toHaveBeenCalledTimes(1);
+      expect(fetchMock).toHaveBeenCalledWith("http://127.0.0.1:9123/blob/abc123");
+    } finally {
+      vi.unstubAllGlobals();
+    }
+  });
+
+  it("does not coalesce the same hash across different ports", async () => {
+    const fetchMock = vi.fn(
+      async (url: string) => new Response(`from ${new URL(url).port}`, { status: 200 }),
+    );
+    vi.stubGlobal("fetch", fetchMock);
+    try {
+      const [a, b] = await Promise.all([
+        resolveContentRef({ blob: "abc123" }, 9123),
+        resolveContentRef({ blob: "abc123" }, 9124),
+      ]);
+
+      expect(a).toBe("from 9123");
+      expect(b).toBe("from 9124");
+      expect(fetchMock).toHaveBeenCalledTimes(2);
+    } finally {
+      vi.unstubAllGlobals();
+    }
+  });
+
+  it("coalesces text blob fetches reached through resolveManifest", async () => {
+    const resolver = fakeBlobResolver({ shared: "blob body" });
+
+    const manifests = await Promise.all([
+      resolveManifest(
+        {
+          output_id: "out-1",
+          output_type: "stream",
+          name: "stdout",
+          text: { blob: "shared" },
+        },
+        resolver,
+      ),
+      resolveManifest(
+        {
+          output_id: "out-2",
+          output_type: "stream",
+          name: "stdout",
+          text: { blob: "shared" },
+        },
+        resolver,
+      ),
+    ]);
+
+    expect(manifests[0]).toMatchObject({ output_id: "out-1", text: "blob body" });
+    expect(manifests[1]).toMatchObject({ output_id: "out-2", text: "blob body" });
+    expect(resolver.fetch).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/components/isolated/output-manifest.ts
+++ b/src/components/isolated/output-manifest.ts
@@ -122,6 +122,51 @@ export function isOutputManifest(value: unknown): value is OutputManifest {
   }
 }
 
+// In-flight text-blob fetches, coalesced so concurrent resolutions of the same
+// content-addressed ref share one request. The browser HTTP cache (blob routes
+// send immutable cache headers) covers repeat fetches over time but does not
+// coalesce concurrent requests to the same URL. Entries are removed on settle:
+// successes belong to the HTTP cache, and failures must retry fresh because
+// callers (e.g. applyOutputChangeset) run their own retry loops.
+//
+// Object resolvers key a WeakMap by identity, since two resolver instances may
+// carry different fetch policy (auth headers) for the same URL. Port-number
+// inputs produce a fresh resolver per normalizeBlobResolver call, so they
+// coalesce through a shared map keyed by port - the localhost URL for a given
+// (port, hash) is deterministic and unauthenticated.
+const inflightByResolver = new WeakMap<OutputBlobResolver, Map<string, Promise<string>>>();
+const inflightByPort = new Map<string, Promise<string>>();
+
+function inflightBlobText(blobResolver: OutputBlobResolver, ref: OutputBlobRef): Promise<string> {
+  let map: Map<string, Promise<string>>;
+  let key: string;
+  if (blobResolver.port != null) {
+    map = inflightByPort;
+    key = `${blobResolver.port}:${ref.blob}`;
+  } else {
+    const existing = inflightByResolver.get(blobResolver);
+    map = existing ?? new Map();
+    if (!existing) inflightByResolver.set(blobResolver, map);
+    key = ref.blob;
+  }
+
+  const inflight = map.get(key);
+  if (inflight) return inflight;
+
+  const fetched = (async () => {
+    const response = await blobResolver.fetch(ref);
+    if (!response.ok) {
+      throw new Error(`Failed to fetch blob ${ref.blob}: ${response.status}`);
+    }
+    return response.text();
+  })();
+  const tracked = fetched.finally(() => {
+    if (map.get(key) === tracked) map.delete(key);
+  });
+  map.set(key, tracked);
+  return tracked;
+}
+
 export async function resolveContentRef(
   ref: ContentRef,
   blobResolverInput: BlobResolverInput,
@@ -136,11 +181,7 @@ export async function resolveContentRef(
       : blobResolver.url(ref);
   }
 
-  const response = await blobResolver.fetch(ref);
-  if (!response.ok) {
-    throw new Error(`Failed to fetch blob ${ref.blob}: ${response.status}`);
-  }
-  return response.text();
+  return inflightBlobText(blobResolver, ref);
 }
 
 function resolveContentRefSync(


### PR DESCRIPTION
Two manifests referencing the same blob hash each fetched it. The existing caches all sit at the manifest level: `materialize-cells` dedupes by `JSON.stringify(manifest)`, the output store by `output_id`, the cloud render cache by output cache key - none of them dedupe at the blob level, and the widget (`resolveCommOutputs`) and embeddable paths have no cache at all. The browser HTTP cache covers repeat fetches over time (blob routes send `Cache-Control: immutable`) but does not coalesce *concurrent* requests to the same URL, so a burst of resolutions at initial materialization fetched the same blob once per referencing output.

## What changed

`resolveContentRef`'s text path now shares one in-flight `Promise<string>` per (resolver, hash). Every resolution path funnels through this function for text blob refs - output store projection, cell materialization, widget comm outputs, embeddable outputs, cloud snapshot render - so the coalescing covers all of them.

Design choices:

- **In-flight only, no result cache.** Entries drop on settle. Successes belong to the browser HTTP cache, which already handles the time-separated case via the immutable headers; a second result cache would duplicate it and add unbounded memory. Failures must drop so callers' retry loops (`applyOutputChangeset`'s backoff) get a fresh fetch.
- **The shared value is the text promise, not the `Response`.** A `Response` body is single-consumption; sharing it across awaiters would break every caller after the first.
- **Keying.** Object resolvers key a WeakMap by identity - two resolver instances may carry different fetch policy (auth headers) for the same URL, so they must not cross-coalesce. Port-number inputs can't use the WeakMap because `normalizeBlobResolver(port)` creates a fresh resolver per call; they coalesce through a shared map keyed by `port:hash`, which is safe because the localhost URL for a (port, hash) is deterministic and unauthenticated.

## Behavioral coverage

| Scenario | Before | After |
|---|---|---|
| N concurrent resolutions, same ref, same resolver | N fetches | 1 fetch |
| Sequential resolutions (after settle) | N fetches | N fetches (HTTP cache's job) |
| Concurrent failure | N fetches, N rejections | 1 fetch, N rejections, next attempt refetches |
| Same hash, different resolver instances | N fetches | N fetches (auth policy may differ) |
| Same hash, same port number passed twice | 2 fetches | 1 fetch |

Tests cover each row plus the `resolveManifest` end-to-end path (two stream outputs sharing a blob resolve with one fetch).
