### PR TITLE
fix(mcp): make proxy recovery messages install-aware (MSL-3)

### DIFF
--- a/crates/mcp-supervisor/src/main.rs
+++ b/crates/mcp-supervisor/src/main.rs
@@ -3155,6 +3155,10 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
                 server_name: "nteract-dev".to_string(),
                 cache_dir: Some(project_root.join(".context")),
                 monitor_poll_interval_ms: 500,
+                recovery_hint: "Relaunch the worktree dev daemon with the nteract-dev \
+                                `up` tool (rebuild=true if the binary is stale) or \
+                                `cargo xtask dev-daemon`."
+                    .to_string(),
             },
             tool_list_changed_tx,
         );

--- a/crates/nteract-mcp/src/main.rs
+++ b/crates/nteract-mcp/src/main.rs
@@ -202,6 +202,9 @@ fn proxy_config_for_channel(channel: String) -> ProxyConfig {
         server_name: runt_workspace::desktop_product_name().to_string(),
         cache_dir: proxy_cache_dir(),
         monitor_poll_interval_ms: 500,
+        recovery_hint: "Try restarting the nteract app; if that does not recover, \
+                        reinstall the nteract extension."
+            .to_string(),
     }
 }
 

--- a/crates/runt-mcp-proxy/src/proxy.rs
+++ b/crates/runt-mcp-proxy/src/proxy.rs
@@ -68,6 +68,12 @@ pub struct ProxyConfig {
     /// Child monitor polling interval in milliseconds (default: 500ms).
     /// Lower values detect child exit faster but use more CPU.
     pub monitor_poll_interval_ms: u64,
+    /// Recovery action appended to terminal failure messages (circuit-breaker
+    /// trip, incompatible tool-list divergence). The launcher knows how its
+    /// child is installed and what restores it; the proxy does not. The MCPB
+    /// bundle points at reinstalling the extension, the dev supervisor at
+    /// relaunching the worktree daemon.
+    pub recovery_hint: String,
 }
 
 /// Shared mutable state for the proxy.
@@ -254,14 +260,16 @@ impl McpProxy {
 
             // Skip circuit breaker if child exited on its own (daemon upgrade)
             if !was_dead && !state.circuit_breaker.record_crash() {
-                let msg = "The nteract MCP server failed after repeated restarts. \
-                           Try restarting the nteract app, or restart your Claude session \
-                           so a fresh MCP connection is established. You may also need to \
-                           reinstall the nteract extension.";
-                state.reconnection_message = Some(msg.to_string());
+                let msg = format!(
+                    "The nteract MCP server failed after repeated restarts. \
+                     Restart your Claude session so a fresh MCP connection \
+                     is established. {}",
+                    self.config.recovery_hint
+                );
+                state.reconnection_message = Some(msg.clone());
                 drop(state);
                 self.clear_restart_in_progress().await;
-                return Err(msg.to_string());
+                return Err(msg);
             }
 
             (was_dead, old_child)
@@ -542,9 +550,12 @@ impl McpProxy {
             let state = self.state.read().await;
             if state.should_exit {
                 return Err(McpError::internal_error(
-                    "Tool list changed incompatibly after daemon upgrade. \
-                     The MCP server will exit so your client can reconnect with the updated tools. \
-                     You may need to reinstall the nteract extension.",
+                    format!(
+                        "Tool list changed incompatibly after daemon upgrade. \
+                         The MCP server will exit so your client can reconnect \
+                         with the updated tools. {}",
+                        self.config.recovery_hint
+                    ),
                     None,
                 ));
             }
@@ -1118,6 +1129,7 @@ mod tests {
             server_name: "test-proxy".to_string(),
             cache_dir: None,
             monitor_poll_interval_ms: 500,
+            recovery_hint: "Test recovery hint.".to_string(),
         }
     }
 
@@ -1129,6 +1141,7 @@ mod tests {
             server_name: "test-proxy".to_string(),
             cache_dir: Some(dir.to_path_buf()),
             monitor_poll_interval_ms: 500,
+            recovery_hint: "Test recovery hint.".to_string(),
         }
     }
 
@@ -1566,6 +1579,7 @@ mod tests {
             server_name: "nteract".to_string(),
             cache_dir: None,
             monitor_poll_interval_ms: 500,
+            recovery_hint: "Test recovery hint.".to_string(),
         };
 
         assert_eq!(config.child_env.len(), 2);

--- a/docs/adr/mcp-session-lifecycle.md
+++ b/docs/adr/mcp-session-lifecycle.md
@@ -311,5 +311,4 @@ These items were migrated from `docs/adr/cleanup-punchlist.md` when it was
 retired (2026-06-10). Severity: **Targeted PR** = one-or-two-file fix ready
 to implement; **Design** = needs a decision in this ADR before code moves.
 
-- **MSL-3** (Targeted PR; `crates/runt-mcp-proxy/src/proxy.rs` `should_exit` text): `tool_list_changed` divergence reports `Incompatible` with a single "reinstall the nteract extension" error string, hard-coded for the MCPB bundle install path. The `nteract-dev` supervisor-managed path gets the same message even though the recovery action is different (relaunch the dev daemon, not reinstall an extension).
 - **MSL-4** (Design; `crates/runt-mcp-proxy/src/proxy.rs`): When a dev worktree daemon's socket path changes (worktree switch in isolated mode, manual relocation), `mcp-supervisor` compares daemon versions across child restart but not socket paths. The `McpProxy.last_notebook_id` from the old daemon is meaningless in the new daemon's room space; rejoin fails with `SessionDropReason::Evicted` and the agent sees a confusing trail.


### PR DESCRIPTION
Resolves MSL-3 from `docs/adr/mcp-session-lifecycle.md`.

The circuit-breaker and tool-list-divergence error strings hard-coded "reinstall the nteract extension", which is the recovery action for the MCPB bundle install path only. The `nteract-dev` supervisor-managed path got the same advice even though its recovery is relaunching the worktree daemon.

## What changed

`ProxyConfig` grows a `recovery_hint` field the launcher sets. The proxy can't know how its child is installed, but the launcher does:

- `nteract-mcp` (MCPB bundle): "Try restarting the nteract app; if that does not recover, reinstall the nteract extension."
- `mcp-supervisor` (`nteract-dev`): "Relaunch the worktree dev daemon with the nteract-dev `up` tool (rebuild=true if the binary is stale) or `cargo xtask dev-daemon`."

Both terminal failure messages append the hint: the circuit-breaker trip in `restart_child` and the `should_exit` divergence error in the tool-call forward path. The generic "restart your Claude session" advice stays in the shared circuit-breaker text since it applies to both installs; the install-specific tail moved into the hints.

The MSL-3 row is removed from the ADR's tracked follow-ups.
