### PR TITLE
test(runtimed): pin durable change order in flush_then_signal test (EP-1)

### DIFF
--- a/crates/runtimed/src/stream_committer.rs
+++ b/crates/runtimed/src/stream_committer.rs
@@ -345,6 +345,10 @@ mod tests {
         let state = runtime_state();
         create_execution(&state);
 
+        // Subscribe after the setup write so the only expected change
+        // notification is the committer's stream upsert transaction.
+        let mut state_changes = state.subscribe();
+
         let terminals = Arc::new(Mutex::new(StreamTerminals::new()));
         {
             let mut terminals = terminals.lock().await;
@@ -372,6 +376,19 @@ mod tests {
             .expect("signal timeout")
             .expect("signal");
         assert!(matches!(received, LifecycleSignal::ExecutionDone { .. }));
+
+        // Durable change order, not just signal arrival order (EP-1). The
+        // handle broadcasts a change notification synchronously inside the
+        // upsert transaction, and the committer sends the lifecycle signal
+        // afterward from the same task, so a correct implementation
+        // guarantees the notification is observable wherever the signal is.
+        // A refactor that routes ExecutionDone past the priority commit path
+        // delivers the signal with no preceding document change and fails
+        // here.
+        assert!(
+            state_changes.try_recv().is_ok(),
+            "stream upsert must be durable in RuntimeStateDoc before ExecutionDone is signaled"
+        );
 
         let outputs = state
             .read(|sd| sd.get_outputs("exec-1"))

--- a/docs/adr/execution-pipeline.md
+++ b/docs/adr/execution-pipeline.md
@@ -331,7 +331,6 @@ These items were migrated from `docs/adr/cleanup-punchlist.md` when it was
 retired (2026-06-10). Severity: **Targeted PR** = one-or-two-file fix ready
 to implement; **Design** = needs a decision in this ADR before code moves.
 
-- **EP-1** (Targeted PR; `crates/runtimed/src/stream_committer.rs` test): `flush_then_signal_commits_stream_before_lifecycle_signal` test verifies signal arrival order, not durable Automerge change order. A refactor that re-routes `ExecutionDone` past the priority path would still pass.
 - **EP-3** (Design; memo `docs/adr/execution-liveness.md`): **Reframed.** Daemon view of execution state can diverge from kernel reality. A wall-clock watchdog is the wrong fix - multi-hour training jobs are legitimate Jupyter usage and nteract's resume-by-reconnect is a feature. The real signal is divergence between `RuntimeStateDoc.status` and live IOPub / heartbeat / committer state. See design memo `docs/adr/execution-liveness.md`. Code is a follow-up after the memo is reviewed.
 - **EP-5** (Design; telemetry + tuning pass): Capacity constants (`STREAM_COMMITTER_QUEUE_CAPACITY = 32`, `MAX_PENDING_DISPLAY_IDS = 128`, `DEFAULT_OUTPUT_SYNC_GRACE = 500ms`) picked by judgment. No benchmark, no drop-rate metric, no measured upper bound under load.
 - **EP-6** (Design; request handling): `required_heads` is `NotebookDoc`-only. No causal gate exists for requests that depend on recent `RuntimeStateDoc` writes.


### PR DESCRIPTION
Resolves EP-1 from `docs/adr/execution-pipeline.md`.

`flush_then_signal_commits_stream_before_lifecycle_signal` verified signal arrival order and then read outputs. A refactor that routes `ExecutionDone` past the priority commit path could still pass on scheduling luck: the signal arrives, the commit races in behind it, and the output read sees the committed state.

## What changed

The test now subscribes to the `RuntimeStateHandle` change broadcast (the test helper already created the channel and discarded the receiver) and asserts, at the moment the lifecycle signal is received, that the upsert's change notification was already sent.

Why this is durable-order evidence and not another timing check: `with_doc` broadcasts the change notification synchronously inside the mutex section when heads change, before the transaction returns, and the committer sends the lifecycle signal afterward from the same task. In a correct implementation, the notification is therefore observable wherever the signal is - no interleaving can break it. A bypassing implementation delivers the signal with no preceding document change and fails the assertion.

The subscription is created after the setup write (`create_execution`), so the only expected change event is the committer's stream upsert.

## Verification

Mutation-tested: temporarily changing `flush_then_signal` to send the signal directly on `lifecycle_tx` (the pre-EP-11 bypass shape) fails the new assertion deterministically:

```
stream upsert must be durable in RuntimeStateDoc before ExecutionDone is signaled
```

All 5 stream_committer tests pass against the real implementation.

The EP-1 row is removed from the ADR's tracked follow-ups.
