### PR TITLE
fix(runtimed-py): extend tokio mutex lint to runtimed-py and fix violations (TMD-2)

### DIFF
--- a/crates/runtimed-py/src/async_session.rs
+++ b/crates/runtimed-py/src/async_session.rs
@@ -323,10 +323,7 @@ impl AsyncSession {
         future_into_py(py, async move {
             session_core::connect(&state, &effective_id).await?;
             // Announce presence so the daemon registers this peer immediately
-            {
-                let st = state.lock().await;
-                session_core::announce_presence(&st).await;
-            }
+            session_core::announce_presence_shared(&state).await;
             Ok(())
         })
     }

--- a/crates/runtimed-py/src/session_core.rs
+++ b/crates/runtimed-py/src/session_core.rs
@@ -216,15 +216,18 @@ pub(crate) async fn connect_with_socket(
     notebook_id: &str,
     socket_path: PathBuf,
 ) -> PyResult<()> {
-    let mut st = state.lock().await;
-    if st.handle.is_some() {
-        return Ok(());
-    }
-
-    let actor_label = st
-        .actor_label
-        .clone()
-        .unwrap_or_else(|| make_actor_label(DEFAULT_ACTOR_LABEL));
+    // Prepare without the lock held across the connection awaits. Two
+    // concurrent connects may both pass this check and both dial; the
+    // apply block below resolves the race by keeping the first handle.
+    let actor_label = {
+        let st = state.lock().await;
+        if st.handle.is_some() {
+            return Ok(());
+        }
+        st.actor_label
+            .clone()
+            .unwrap_or_else(|| make_actor_label(DEFAULT_ACTOR_LABEL))
+    };
 
     let result =
         notebook_sync::connect::connect(socket_path.clone(), notebook_id.to_string(), &actor_label)
@@ -238,6 +241,13 @@ pub(crate) async fn connect_with_socket(
 
     // Resolve blob paths from daemon info
     let (blob_base_url, blob_store_path) = resolve_blob_paths(&socket_path).await;
+
+    // Apply synchronously. If another connect won the race while we were
+    // dialing, keep its session and drop ours on scope exit.
+    let mut st = state.lock().await;
+    if st.handle.is_some() {
+        return Ok(());
+    }
 
     st.handle = Some(result.handle);
     st.broadcast_rx = Some(result.broadcast_rx);
@@ -268,6 +278,19 @@ pub(crate) async fn announce_presence(state: &SessionState) {
         None => return,
     };
     notebook_sync::presence::announce(handle, state.peer_label.as_deref()).await;
+}
+
+/// Announce presence through shared state. Locks only to clone the handle
+/// and label so no guard is held across the network await.
+pub(crate) async fn announce_presence_shared(state: &Arc<Mutex<SessionState>>) {
+    let (handle, peer_label) = {
+        let st = state.lock().await;
+        let Some(handle) = st.handle.clone() else {
+            return;
+        };
+        (handle, st.peer_label.clone())
+    };
+    notebook_sync::presence::announce(&handle, peer_label.as_deref()).await;
 }
 
 /// Populate `kernel_started`, `kernel_type`, and `env_source` from the
@@ -608,12 +631,12 @@ pub(crate) async fn start_kernel(
 
 /// Shutdown the kernel.
 pub(crate) async fn shutdown_kernel(state: &Arc<Mutex<SessionState>>) -> PyResult<()> {
-    let mut st = state.lock().await;
-
-    let handle = st
-        .handle
-        .as_ref()
-        .ok_or_else(|| to_py_err("Not connected"))?;
+    let handle = {
+        let st = state.lock().await;
+        st.handle
+            .clone()
+            .ok_or_else(|| to_py_err("Not connected"))?
+    };
 
     let response = handle
         .send_request(NotebookRequest::ShutdownKernel {})
@@ -622,6 +645,7 @@ pub(crate) async fn shutdown_kernel(state: &Arc<Mutex<SessionState>>) -> PyResul
 
     match response {
         NotebookResponse::KernelShuttingDown {} | NotebookResponse::NoKernel {} => {
+            let mut st = state.lock().await;
             st.kernel_started = false;
             st.kernel_type = None;
             st.env_source = None;
@@ -649,11 +673,12 @@ pub(crate) async fn restart_kernel(
 
     // Shutdown
     {
-        let mut st = state.lock().await;
-        let handle = st
-            .handle
-            .as_ref()
-            .ok_or_else(|| to_py_err("Not connected"))?;
+        let handle = {
+            let st = state.lock().await;
+            st.handle
+                .clone()
+                .ok_or_else(|| to_py_err("Not connected"))?
+        };
 
         let response = handle
             .send_request(NotebookRequest::ShutdownKernel {})
@@ -662,6 +687,7 @@ pub(crate) async fn restart_kernel(
 
         match response {
             NotebookResponse::KernelShuttingDown {} | NotebookResponse::NoKernel {} => {
+                let mut st = state.lock().await;
                 st.kernel_started = false;
                 st.kernel_type = None;
                 st.env_source = None;
@@ -817,12 +843,12 @@ pub(crate) async fn restart_kernel(
 
 /// Interrupt the currently executing cell.
 pub(crate) async fn interrupt(state: &Arc<Mutex<SessionState>>) -> PyResult<()> {
-    let st = state.lock().await;
-
-    let handle = st
-        .handle
-        .as_ref()
-        .ok_or_else(|| to_py_err("Not connected"))?;
+    let handle = {
+        let st = state.lock().await;
+        st.handle
+            .clone()
+            .ok_or_else(|| to_py_err("Not connected"))?
+    };
 
     let response = handle
         .send_request(NotebookRequest::InterruptExecution {})
@@ -2097,11 +2123,12 @@ pub(crate) async fn complete(
     code: &str,
     cursor_pos: usize,
 ) -> PyResult<CompletionResult> {
-    let st = state.lock().await;
-    let handle = st
-        .handle
-        .as_ref()
-        .ok_or_else(|| to_py_err("Not connected"))?;
+    let handle = {
+        let st = state.lock().await;
+        st.handle
+            .clone()
+            .ok_or_else(|| to_py_err("Not connected"))?
+    };
 
     let response = handle
         .send_request(NotebookRequest::Complete {
@@ -2137,11 +2164,12 @@ pub(crate) async fn get_history(
     n: i32,
     unique: bool,
 ) -> PyResult<Vec<HistoryEntry>> {
-    let st = state.lock().await;
-    let handle = st
-        .handle
-        .as_ref()
-        .ok_or_else(|| to_py_err("Not connected"))?;
+    let handle = {
+        let st = state.lock().await;
+        st.handle
+            .clone()
+            .ok_or_else(|| to_py_err("Not connected"))?
+    };
 
     let response = handle
         .send_request(NotebookRequest::GetHistory {

--- a/crates/runtimed/tests/tokio_mutex_lint.rs
+++ b/crates/runtimed/tests/tokio_mutex_lint.rs
@@ -28,12 +28,9 @@ fn collect_rs_files(dir: &std::path::Path, out: &mut Vec<std::path::PathBuf>) {
     }
 }
 
-#[test]
-fn runtimed_has_no_tokio_mutex_across_await() {
-    let src_dir = std::path::PathBuf::from(concat!(env!("CARGO_MANIFEST_DIR"), "/src"));
-
+fn scan_crate_src(src_dir: &std::path::Path, crate_label: &str) {
     let mut rs_files: Vec<std::path::PathBuf> = Vec::new();
-    collect_rs_files(&src_dir, &mut rs_files);
+    collect_rs_files(src_dir, &mut rs_files);
 
     assert!(
         !rs_files.is_empty(),
@@ -50,7 +47,7 @@ fn runtimed_has_no_tokio_mutex_across_await() {
         let diagnostics =
             async_rust_lsp::rules::mutex_across_await::check_mutex_across_await(&source);
 
-        let display_path = path.strip_prefix(&src_dir).unwrap_or(path).display();
+        let display_path = path.strip_prefix(src_dir).unwrap_or(path).display();
 
         for d in diagnostics {
             violations.push(format!(
@@ -64,7 +61,7 @@ fn runtimed_has_no_tokio_mutex_across_await() {
 
     if !violations.is_empty() {
         let mut msg = format!(
-            "Found {} tokio Mutex guard(s) held across .await in runtimed sources:\n\n",
+            "Found {} tokio Mutex guard(s) held across .await in {crate_label} sources:\n\n",
             violations.len()
         );
         for v in &violations {
@@ -77,4 +74,21 @@ fn runtimed_has_no_tokio_mutex_across_await() {
         );
         panic!("{msg}");
     }
+}
+
+#[test]
+fn runtimed_has_no_tokio_mutex_across_await() {
+    let src_dir = std::path::PathBuf::from(concat!(env!("CARGO_MANIFEST_DIR"), "/src"));
+    scan_crate_src(&src_dir, "runtimed");
+}
+
+/// runtimed-py builds on the post-merge-only Anaconda lane, so its own cargo
+/// tests do not gate PRs. Scanning its sources from here keeps the mutex
+/// discipline on the pre-merge lane (TMD-2). Source-level scan only — no
+/// compilation of runtimed-py is involved.
+#[test]
+fn runtimed_py_has_no_tokio_mutex_across_await() {
+    let src_dir =
+        std::path::PathBuf::from(concat!(env!("CARGO_MANIFEST_DIR"), "/../runtimed-py/src"));
+    scan_crate_src(&src_dir, "runtimed-py");
 }

--- a/docs/adr/tokio-mutex-discipline.md
+++ b/docs/adr/tokio-mutex-discipline.md
@@ -154,9 +154,7 @@ What it does **not** check:
 
 The lint reached zero violations on 2026-04-08 (`runtimed/tests/tokio_mutex_lint.rs:8-12`) and CI keeps it there. New violations fail the test.
 
-**Scope caveat: the lint does not recurse into subdirectories.** It uses `std::fs::read_dir(&src_dir)` with no recursion, where `src_dir = concat!(env!("CARGO_MANIFEST_DIR"), "/src")`. So only top-level files in `crates/runtimed/src/*.rs` are scanned. Subdirectory files including the entire `notebook_sync_server/` tree (`peer_loop.rs`, `peer_runtime_agent.rs`, `metadata.rs`, `room.rs`, `registry.rs`, `peer_writer.rs`, ~24 files), `runtime_agent/echo_suppression.rs`, and `requests/*.rs` are silently invisible to the lint. The "zero violations" claim is scoped to top-level files only. Several files cited elsewhere in this ADR — `room.rs`, `metadata.rs`, `registry.rs`, `peer_loop.rs`, `peer_runtime_agent.rs` — sit in subdirectories the lint never visits.
-
-Fixing the scope is a one-line `walkdir` change to `tokio_mutex_lint.rs`. It is on the cleanup punchlist as a Targeted PR.
+**Scope.** The lint recurses through all of `crates/runtimed/src/` (TMD-1), so the `notebook_sync_server/` tree, `runtime_agent/`, and `requests/` are covered. It also scans `crates/runtimed-py/src/` as a sibling source root (TMD-2): `runtimed-py` builds on a post-merge-only CI lane, so hosting that scan in runtimed's test target is what keeps the discipline on the pre-merge lane. The scan is source-level only; no compilation of `runtimed-py` is involved.
 
 Alternatives we considered:
 
@@ -184,15 +182,14 @@ The runtime agent's loop is the model. Local state, channel-published deltas, ca
 
 ## Limitations
 
-The tokio mutex lint scans only the top-level files of `crates/runtimed/src/`. It does not scan:
+The tokio mutex lint scans `crates/runtimed/src/` and `crates/runtimed-py/src/` recursively. It does not scan:
 
-- Subdirectories of `crates/runtimed/src/` (see the scope caveat in Decision 5). This is the most consequential gap because much of the daemon's async-lock surface lives there.
-- `crates/runtimed-client/`, `crates/runtimed-service/`, `crates/runtimed-py/`. **`runtimed-py`'s `session_core.rs` does hold `tokio::sync::Mutex<SessionState>` across awaited connection calls** outside the pyo3 wrapper (`crates/runtimed-py/src/session_core.rs:59-63, :214-240`); the lint does not see it.
+- `crates/runtimed-client/`, `crates/runtimed-service/`. No known violations, but the discipline there is held by review, not by the lint.
 - `crates/notebook-sync/`. `DocHandle` uses `std::sync::Mutex` so the lint has no work to do there, but a future `tokio::sync::Mutex` in `sync_task.rs` would not be checked.
 - `crates/notebook-protocol/`, `crates/notebook-wire/`, `crates/notebook-doc/`. No async-lock usage today; nothing to scan.
 - The runtime agent uses `Arc<RwLock<PresenceState>>` (`runtime_agent.rs:110`). This is the one async RwLock in the agent's main file. The lint covers it.
 
-Extending the lint to subdirectories (`walkdir` instead of `read_dir`) and to additional crates (multiple source roots) is mechanical. It has not been done because the discipline has held under review; the lint-scope gap was surfaced while writing this ADR.
+Adding further crates is a one-line `scan_crate_src` call per source root in `tokio_mutex_lint.rs`.
 
 Open gaps:
 
@@ -236,11 +233,3 @@ These follow-ups are tracked but not decided here:
 - `crates/notebook-protocol/src/connection/framing.rs:245-297` - `FramedReader`, the cancel-safe read primitive.
 - `crates/runtimed/src/notebook_sync_server/metadata.rs:2249-2267` - a use-site comment documenting mixed-lock ordering.
 - `docs/adr/execution-pipeline.md` Decision 2 - the sibling rule for control-plane signal priority at the IOPub boundary.
-
-## Tracked follow-ups (from the retired cleanup punchlist)
-
-These items were migrated from `docs/adr/cleanup-punchlist.md` when it was
-retired (2026-06-10). Severity: **Targeted PR** = one-or-two-file fix ready
-to implement; **Design** = needs a decision in this ADR before code moves.
-
-- **TMD-2** (Targeted PR; `crates/runtimed-py/src/session_core.rs`): `crates/runtimed-py/src/session_core.rs:59-63, :214-240` holds `Arc<tokio::sync::Mutex<SessionState>>` live across `connect_with_socket` awaits. The lint does not scan `runtimed-py`. Discipline violation, but the cure (restructure or extend lint) is non-trivial.


### PR DESCRIPTION
Resolves TMD-2 from `docs/adr/tokio-mutex-discipline.md`.

The mutex lint scanned only `crates/runtimed/src`, so `runtimed-py`'s session layer held tokio Mutex guards across awaits unchecked. The ADR row cited `connect_with_socket`; pointing the lint at the crate found **nine** sites:

- `connect_with_socket` - one guard across the dial, `await_session_ready`, and blob-path resolution
- `shutdown_kernel`, `restart_kernel`'s shutdown block - guard across `send_request`
- `interrupt`, `complete`, `get_history` - guard across `send_request`
- `AsyncSession::connect` - guard across `announce_presence`'s network await

## Lint placement

The scan lives in runtimed's test target (`tokio_mutex_lint.rs`) as a second source root rather than as a test in `runtimed-py` itself: runtimed-py builds on the post-merge-only Anaconda lane, so a test there wouldn't gate PRs. Hosting it in runtimed keeps the discipline pre-merge. It's a source-level scan - no compilation of runtimed-py involved.

## Fixes

All follow the idiom already in this file (`restart_kernel`'s launch block): clone the `DocHandle` out of a scoped lock, await without the guard, re-lock to apply state writes.

One real semantic to call out: `connect_with_socket` previously serialized concurrent connects by holding the lock for the whole dial. The prepare/apply split admits a race where two connects both dial; the apply block double-checks and the loser's connection drops on scope exit, keeping the first session. `announce_presence` gains a shared-state variant that locks only to clone the handle and label.

Also updates the stale lint-scope text in the ADR (it still described the pre-TMD-1 non-recursive scan) and removes the TMD-2 row.

## Verification

- `cargo test -p runtimed --test tokio_mutex_lint` - both crates at zero violations (the lint found the nine sites before the fixes, which is its own mutation test)
- `cargo check -p runtimed-py` clean (plain `cargo build` fails at link for pyo3 reasons unrelated to this change)
- Anaconda lane triggered manually on this branch since it skips PRs
