### PR TITLE
fix(notebook): simplify rail and outline chrome

### DIFF
--- a/apps/elements/components/cloud-notebook-shell-example.tsx
+++ b/apps/elements/components/cloud-notebook-shell-example.tsx
@@ -332,7 +332,6 @@ function CloudNotebookShellExampleContent() {
       viewModel={scenario.viewModel}
       activePanelId={railState.activePanelId}
       collapsed={railState.collapsed}
-      workstationsSummary={null}
       workstationsPanel={
         <NotebookWorkstationsPanel
           capabilities={shellCapabilities}

--- a/apps/elements/components/rail-outline-example.tsx
+++ b/apps/elements/components/rail-outline-example.tsx
@@ -168,7 +168,6 @@ export function RailOutlineExample() {
             activeOutlineItemId={activeOutlineItemId}
             selectedOutlineItemId={selectedOutlineItemId}
             selectedOutlineCellId={focusedCellId}
-            packagesSummary={null}
             packagesPanel={
               <NotebookPackageSummaryPanel
                 packages={viewModel.packages}

--- a/apps/notebook-cloud/test/viewer-render-props.test.ts
+++ b/apps/notebook-cloud/test/viewer-render-props.test.ts
@@ -156,11 +156,9 @@ test("cloud viewer routes notebook header controls through the shared shell chro
   assert.match(sourceText, /useState\(initialCloudRailCollapsed\)/);
   assert.match(sourceText, /function initialCloudRailCollapsed/);
   assert.match(sourceText, /function initialCloudRailCollapsed\(\): boolean \{[\s\S]*return true;/);
-  assert.match(sourceText, /packagesSummary=\{null\}/);
-  assert.match(
-    sourceText,
-    /workstationsSummary=\{notebookWorkstationsSummary\(shellCapabilities\)\}/,
-  );
+  assert.doesNotMatch(sourceText, /packagesSummary=/);
+  assert.doesNotMatch(sourceText, /workstationsSummary=/);
+  assert.match(sourceText, /workstationsPanel=\{[\s\S]*<NotebookWorkstationsPanel/);
   assert.match(
     sourceText,
     /const shouldShowPackageEnvironmentSummary =[\s\S]*shellCapabilities\.canExecute \|\| shellCapabilities\.canManagePackages/,

--- a/apps/notebook-cloud/viewer/notebook-viewer.tsx
+++ b/apps/notebook-cloud/viewer/notebook-viewer.tsx
@@ -15,7 +15,6 @@ import type { NotebookRailPanelId } from "@/components/notebook-rail";
 import {
   NotebookDocumentToolbar,
   navigateNotebookOutlineItem,
-  notebookWorkstationsSummary,
   NotebookDocumentRail,
   NotebookDocumentShell,
   NotebookPackageSummaryPanel,
@@ -771,8 +770,6 @@ export function NotebookViewer({
       activePanelId={activeRailPanel}
       collapsed={railCollapsed}
       selectedOutlineItemId={selectedOutlineItemId}
-      packagesSummary={null}
-      workstationsSummary={notebookWorkstationsSummary(shellCapabilities)}
       workstationsPanel={
         <NotebookWorkstationsPanel
           capabilities={shellCapabilities}

--- a/apps/notebook/src/App.tsx
+++ b/apps/notebook/src/App.tsx
@@ -44,8 +44,6 @@ import {
   KernelLaunchErrorBanner,
   NotebookDocumentRail,
   NotebookDocumentShell,
-  NotebookWorkstationsPanel,
-  notebookWorkstationsSummary,
   PoolErrorBanner,
   shouldShowKernelLaunchErrorBanner,
   TrustDialog,
@@ -94,7 +92,7 @@ import {
 import { getNotebookCellsSnapshot } from "@/components/notebook/state/cell-store";
 import { useNotebookQueueProjection } from "@/components/notebook/state/execution-store";
 import { useNotebookViewModel } from "@/components/notebook/state/view-model-store";
-import { useDetectRuntime, useNotebookMetadata, usePixiDeps } from "./lib/notebook-metadata";
+import { useDetectRuntime, useNotebookMetadata } from "./lib/notebook-metadata";
 import { useNotebookHost } from "@nteract/notebook-host";
 import { startWindowFocusHandler } from "./lib/window-focus";
 import type { JupyterOutput } from "./types";
@@ -108,7 +106,7 @@ export type MimeBundle = Record<string, unknown>;
  */
 let daemonCommSender: ((message: unknown) => Promise<void>) | null = null;
 
-function focusRailCollapseButtonWhenStageIsHidden(
+function focusActiveRailButtonWhenStageIsHidden(
   railCollapsed: boolean,
   stageHadFocusBeforeTakeover: boolean,
 ): void {
@@ -126,10 +124,10 @@ function focusRailCollapseButtonWhenStageIsHidden(
     stageHadFocusBeforeTakeover && activeElement === document.body;
   if (!focusWasInStage && !focusWasClearedFromHiddenStage) return;
 
-  const collapseButton = document.querySelector<HTMLButtonElement>(
-    '[data-slot="notebook-rail-collapse-button"]',
+  const activeRailButton = document.querySelector<HTMLButtonElement>(
+    '[data-testid="notebook-rail"] button[aria-pressed="true"]',
   );
-  requestAnimationFrame(() => collapseButton?.focus());
+  requestAnimationFrame(() => activeRailButton?.focus());
 }
 
 /**
@@ -459,7 +457,7 @@ function AppContent() {
     if (!takeoverQuery) return;
 
     const handleTakeoverChange = () => {
-      focusRailCollapseButtonWhenStageIsHidden(
+      focusActiveRailButtonWhenStageIsHidden(
         railCollapsed,
         stageHadFocusBeforeRailTakeoverRef.current,
       );
@@ -548,7 +546,6 @@ function AppContent() {
 
   // Pixi project detection
   const { pixiInfo } = usePixiDetection();
-  const pixiDeps = usePixiDeps();
 
   // Deno config detection and settings
   const { denoConfigInfo, flexibleNpmImports, setFlexibleNpmImports } = useDenoConfig();
@@ -919,46 +916,6 @@ function AppContent() {
   }, [envSource, envSyncState]);
 
   const packagesRailOpen = !railCollapsed && activeRailPanel === "packages";
-  const railPackageSummary = useMemo(() => {
-    if (runtime === "deno") {
-      return denoConfigInfo ? "Deno config" : "Deno imports";
-    }
-    if (runtime !== "python") return null;
-    if (envType === "conda") {
-      if (environmentYmlInfo) {
-        const count = environmentYmlPackageCount(environmentYmlDeps, environmentYmlInfo);
-        return packageCountLabel(count);
-      }
-      return `conda · ${packageCountLabel(condaDependencies?.dependencies.length ?? 0)}`;
-    }
-    if (envType === "pixi") {
-      if (pixiInfo) {
-        const pixiCount = pixiPackageCount(pixiInfo);
-        return packageCountLabel(pixiCount);
-      }
-      const pixiCount = pixiInlinePackageCount(pixiDeps);
-      return `pixi · ${packageCountLabel(pixiCount)}`;
-    }
-    if (envSource === "uv:pyproject" || pyprojectInfo?.has_dependencies) {
-      const count = pyprojectPackageCount(pyprojectDeps, pyprojectInfo?.dependency_count);
-      return count === null ? "Project env" : packageCountLabel(count);
-    }
-    return `uv · ${packageCountLabel(dependencies?.dependencies.length ?? 0)}`;
-  }, [
-    condaDependencies?.dependencies.length,
-    denoConfigInfo,
-    dependencies?.dependencies.length,
-    envType,
-    envSource,
-    environmentYmlDeps,
-    environmentYmlInfo,
-    pyprojectDeps,
-    pyprojectInfo?.dependency_count,
-    pyprojectInfo?.has_dependencies,
-    pixiDeps,
-    pixiInfo,
-    runtime,
-  ]);
 
   useEffect(() => {
     if (!selectedOutlineItemId) return;
@@ -1608,13 +1565,10 @@ function AppContent() {
               activeOutlineItemId={activeOutlineItemId}
               selectedOutlineItemId={selectedOutlineItemId}
               selectedOutlineCellId={focusedCellId}
-              packagesSummary={railPackageSummary}
-              workstationsSummary={notebookWorkstationsSummary(shellCapabilities)}
               onActivePanelChange={handleRailPanelChange}
               onCollapsedChange={setRailCollapsed}
               onSelectOutlineItem={handleSelectOutlineItem}
               onNavigateOutlineItem={handleNavigateOutlineItem}
-              workstationsPanel={<NotebookWorkstationsPanel capabilities={shellCapabilities} />}
               packagesPanel={
                 <NotebookPackagesPanel readOnly={!shellCapabilities.canManagePackages}>
                   {runtime === "python" && hasUvDependencies && hasCondaDependencies && (
@@ -1775,72 +1729,6 @@ function AppContent() {
       </div>
     </PresenceProvider>
   );
-}
-
-function packageCountLabel(count: number): string {
-  return count === 1 ? "1 package" : `${count} packages`;
-}
-
-function pyprojectPackageCount(
-  pyprojectDeps:
-    | {
-        dependencies: readonly string[];
-        dev_dependencies: readonly string[];
-      }
-    | null
-    | undefined,
-  fallbackCount: number | null | undefined,
-): number | null {
-  if (pyprojectDeps) {
-    return pyprojectDeps.dependencies.length + pyprojectDeps.dev_dependencies.length;
-  }
-  return typeof fallbackCount === "number" ? fallbackCount : null;
-}
-
-function environmentYmlPackageCount(
-  environmentYmlDeps:
-    | {
-        dependencies: readonly string[];
-        pip_dependencies: readonly string[];
-      }
-    | null
-    | undefined,
-  environmentYmlInfo:
-    | {
-        dependency_count: number;
-        pip_dependency_count: number;
-      }
-    | null
-    | undefined,
-): number {
-  if (environmentYmlDeps) {
-    return environmentYmlDeps.dependencies.length + environmentYmlDeps.pip_dependencies.length;
-  }
-  return (
-    (environmentYmlInfo?.dependency_count ?? 0) + (environmentYmlInfo?.pip_dependency_count ?? 0)
-  );
-}
-
-function pixiPackageCount(pixiInfo: {
-  dependencies: readonly string[];
-  pypi_dependencies: readonly string[];
-  dependency_count: number;
-  pypi_dependency_count: number;
-}): number {
-  const listedCount = pixiInfo.dependencies.length + pixiInfo.pypi_dependencies.length;
-  return listedCount || pixiInfo.dependency_count + pixiInfo.pypi_dependency_count;
-}
-
-function pixiInlinePackageCount(
-  pixiDeps:
-    | {
-        dependencies: readonly string[];
-        pypiDependencies: readonly string[];
-      }
-    | null
-    | undefined,
-): number {
-  return (pixiDeps?.dependencies.length ?? 0) + (pixiDeps?.pypiDependencies.length ?? 0);
 }
 
 function AppErrorFallback(_error: Error, resetErrorBoundary: () => void) {

--- a/apps/notebook/src/components/__tests__/PackageSpecList.test.tsx
+++ b/apps/notebook/src/components/__tests__/PackageSpecList.test.tsx
@@ -253,6 +253,46 @@ describe("DependencyHeader rail package copy", () => {
     expect(screen.getByText("Using")).toBeVisible();
     expect(screen.getAllByText("pyproject.toml").length).toBeGreaterThan(0);
     expect(screen.getByText("Re-initialize after dependency changes.")).toBeVisible();
+    expect(screen.queryByText("Project env")).not.toBeInTheDocument();
+  });
+
+  it("shows pyproject dependencies while using the project environment", () => {
+    render(
+      <DependencyHeader
+        variant="rail"
+        dependencies={[]}
+        requiresPython={null}
+        loading={false}
+        onAdd={async () => undefined}
+        onRemove={async () => undefined}
+        onSetRequiresPython={async () => undefined}
+        pyprojectInfo={{
+          path: "/work/pyproject.toml",
+          relative_path: "pyproject.toml",
+          has_dependencies: true,
+          has_dev_dependencies: true,
+          dependency_count: 2,
+          project_name: "analysis",
+          requires_python: ">=3.12",
+          has_venv: false,
+        }}
+        pyprojectDeps={{
+          path: "/work/pyproject.toml",
+          relative_path: "pyproject.toml",
+          dependencies: ["pandas>=2", "polars"],
+          dev_dependencies: ["pytest"],
+          project_name: "analysis",
+          requires_python: ">=3.12",
+          index_url: null,
+        }}
+        isUsingProjectEnv
+      />,
+    );
+
+    expect(screen.getByText("pandas")).toBeVisible();
+    expect(screen.getByText(">=2")).toBeVisible();
+    expect(screen.getByText("polars")).toBeVisible();
+    expect(screen.getByText("pytest")).toBeVisible();
   });
 
   it("keeps uv package details visible while read-only", () => {

--- a/crates/runtimed/src/notebook_sync_server/metadata.rs
+++ b/crates/runtimed/src/notebook_sync_server/metadata.rs
@@ -2781,7 +2781,7 @@ pub(crate) async fn try_conda_pool_for_inline_deps(
 /// Resolves the metadata snapshot from the Automerge doc (if the first client has
 /// already synced) or falls back to reading the .ipynb from disk.
 pub(crate) async fn auto_launch_kernel(
-    room: &NotebookRoom,
+    room: &std::sync::Arc<NotebookRoom>,
     notebook_id: &str,
     default_runtime: crate::runtime::Runtime,
     default_python_env: crate::settings_doc::PythonEnvType,
@@ -2988,6 +2988,13 @@ pub(crate) async fn auto_launch_kernel(
             detected.path,
             detected.to_env_source().as_str()
         );
+    }
+    if bound_path.is_none() && is_untitled_notebook(notebook_id) && detected_project_file.is_some()
+    {
+        if let Some(anchor) = detection_path {
+            super::project_context::refresh_project_context_async(room, Some(anchor.as_path()))
+                .await;
+        }
     }
     let project_source: Option<notebook_protocol::connection::EnvSource> =
         detected_project_file.as_ref().map(|d| d.to_env_source());

--- a/crates/runtimed/src/notebook_sync_server/project_context.rs
+++ b/crates/runtimed/src/notebook_sync_server/project_context.rs
@@ -45,8 +45,11 @@ use crate::task_supervisor::spawn_best_effort;
 /// filesystem watcher on the detected project file. External edits to
 /// that file will re-enter this routine via the watcher.
 ///
-/// Untitled notebooks (no path) leave the field at `Pending`; a sentinel
-/// write would be misleading because there's nothing to refresh against.
+/// Untitled notebooks with no filesystem anchor leave the field at
+/// `Pending`; a sentinel write would be misleading because there's
+/// nothing to refresh against. Auto-launch may still call this with the
+/// room working directory as an anchor, so project-backed untitled
+/// notebooks can expose parsed package details to clients.
 ///
 /// Re-runnable: the caller may invoke this whenever the room's on-disk
 /// path changes (untitled promotion, save-as rename). The setter clears
@@ -205,8 +208,12 @@ fn spawn_project_file_watcher(
                             // path: the notebook may have been moved such
                             // that a closer project file now wins, or the
                             // detected file may have been deleted.
-                            let notebook_path = room.file_binding.path().await;
-                            refresh_project_context_async(&room, notebook_path.as_deref()).await;
+                            let refresh_anchor = room
+                                .file_binding
+                                .path()
+                                .await
+                                .or_else(|| project_file_path.parent().map(Path::to_path_buf));
+                            refresh_project_context_async(&room, refresh_anchor.as_deref()).await;
                         }
                         Err(e) => {
                             warn!(
@@ -291,7 +298,11 @@ fn translate_kind(kind: &daemon_project_file::ProjectFileKind) -> ProjectFileKin
 /// be cheaply derived. Purely display-oriented; consumers compare by
 /// kind and absolute_path, not by this.
 fn relative_to_notebook(notebook_path: &Path, project_file: &Path) -> String {
-    let notebook_dir = notebook_path.parent().unwrap_or(notebook_path);
+    let notebook_dir = if notebook_path.is_dir() {
+        notebook_path
+    } else {
+        notebook_path.parent().unwrap_or(notebook_path)
+    };
     // For the common case (notebook's directory contains or is the
     // ancestor of the project file), strip_prefix is all we need.
     if let Ok(rel) = project_file.strip_prefix(notebook_dir) {
@@ -705,6 +716,29 @@ mod tests {
     }
 
     #[test]
+    fn build_context_pyproject_from_directory_anchor() {
+        let temp = TempDir::new().unwrap();
+        write(
+            temp.path(),
+            "pyproject.toml",
+            "[project]\nname = \"demo\"\ndependencies = [\"pandas\"]\n",
+        );
+
+        let (ctx, _) = build_context(temp.path());
+        let ProjectContext::Detected {
+            project_file,
+            parsed,
+            ..
+        } = ctx
+        else {
+            panic!("expected Detected");
+        };
+        assert_eq!(project_file.kind, ProjectFileKind::PyprojectToml);
+        assert_eq!(project_file.relative_to_notebook, "pyproject.toml");
+        assert_eq!(parsed.dependencies, vec!["pandas"]);
+    }
+
+    #[test]
     fn build_context_pyproject_captures_tool_uv_dev_dependencies() {
         let temp = TempDir::new().unwrap();
         write(
@@ -915,6 +949,11 @@ mod tests {
                 Path::new("/foo/pyproject.toml"),
             ),
             "../pyproject.toml"
+        );
+        let temp = TempDir::new().unwrap();
+        assert_eq!(
+            relative_to_notebook(temp.path(), &temp.path().join("pyproject.toml")),
+            "pyproject.toml"
         );
     }
 

--- a/packages/runtimed/src/notebook-outline.ts
+++ b/packages/runtimed/src/notebook-outline.ts
@@ -36,6 +36,7 @@ export interface NotebookOutlineMarkdownAnchor {
 export interface NotebookOutlineItem {
   id: string;
   cellId: string;
+  cellType?: string | null;
   title: string;
   level: number;
   kind: NotebookOutlineItemKind;
@@ -81,6 +82,7 @@ export function projectNotebookOutline<TCell extends NotebookOutlineSourceCell>(
   const headings: NotebookOutlineItem[] = [];
 
   for (const cell of cells) {
+    if (isSourceHiddenForOutline(cell)) continue;
     if (cellKind(cell) !== "markdown") continue;
     const parsed = markdownHeadingAnchorsForOutline(cell, options);
     parsed.forEach((heading, index) => {
@@ -110,25 +112,33 @@ export function projectNotebookOutline<TCell extends NotebookOutlineSourceCell>(
     return { items: [], source: "empty" };
   }
 
-  return {
-    source: cells.length > 0 ? "cells" : "empty",
-    items: cells.map((cell, index) => {
-      const kind = cellKind(cell);
-      const cellAnchorId = notebookCellAnchorId(cell.id);
-      return {
+  const fallbackItems = cells.flatMap((cell, index) => {
+    const kind = cellKind(cell);
+    if (!shouldIncludeFallbackCell(cell, kind)) return [];
+
+    const cellAnchorId = notebookCellAnchorId(cell.id);
+    const detail = fallbackDetailLabel(kind);
+    return [
+      {
         id: `${cell.id}:cell`,
         cellId: cell.id,
+        cellType: kind,
         title: summarizeCell(cell, index),
         level: 1,
-        kind: "cell",
+        kind: "cell" as const,
         cellAnchorId,
         headingAnchorId: null,
         href: notebookCellAnchorHref(cell.id),
         anchor: null,
-        detail: detailLabel(kind),
+        ...(detail ? { detail } : {}),
         statusLabel: options.getStatusLabel?.(cell) ?? null,
-      };
-    }),
+      },
+    ];
+  });
+
+  return {
+    source: fallbackItems.length > 0 ? "cells" : "empty",
+    items: fallbackItems,
   };
 }
 
@@ -320,6 +330,23 @@ function summarizeCell(cell: NotebookOutlineSourceCell, index: number): string {
   return summarizeMarkdownProseLine(firstLine);
 }
 
+function shouldIncludeFallbackCell(cell: NotebookOutlineSourceCell, kind: string): boolean {
+  if (isSourceHiddenForOutline(cell)) return false;
+  if (kind !== "code") return true;
+  if (metadataOutlineTitle(cell.metadata)) return true;
+  return (cell.source ?? "").trim().length > 0;
+}
+
+function isSourceHiddenForOutline(cell: NotebookOutlineSourceCell): boolean {
+  const jupyter = cell.metadata?.jupyter;
+  if (!isRecord(jupyter)) return false;
+  return jupyter.source_hidden === true;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null;
+}
+
 function metadataOutlineTitle(
   metadata: NotebookOutlineSourceMetadata | null | undefined,
 ): string | null {
@@ -394,4 +421,9 @@ function detailLabel(kind: string): string {
   if (kind === "markdown") return "Markdown";
   if (kind === "raw") return "Raw";
   return "Cell";
+}
+
+function fallbackDetailLabel(kind: string): string | null {
+  if (kind === "code") return null;
+  return detailLabel(kind);
 }

--- a/packages/runtimed/tests/notebook-outline.test.ts
+++ b/packages/runtimed/tests/notebook-outline.test.ts
@@ -59,6 +59,22 @@ describe("projectNotebookOutline", () => {
     ]);
   });
 
+  it("omits source-hidden markdown headings from the outline", () => {
+    const projection = projectNotebookOutline([
+      {
+        ...markdownCell("hidden", "# Hidden setup", [
+          { title: "Hidden setup", level: 1, slug: "hidden-setup" },
+        ]),
+        metadata: { jupyter: { source_hidden: true } },
+      },
+      markdownCell("visible", "# Visible notes", [
+        { title: "Visible notes", level: 1, slug: "visible-notes" },
+      ]),
+    ]);
+
+    expect(projection.items.map((item) => item.id)).toEqual(["visible:heading:0"]);
+  });
+
   it("does not parse markdown source when no projection anchors are available", () => {
     const projection = projectNotebookOutline([
       { id: "a", cell_type: "markdown", source: "# Intro" },
@@ -90,6 +106,7 @@ describe("projectNotebookOutline", () => {
         {
           id: "a:cell",
           cellId: "a",
+          cellType: "markdown",
           title: "Notebook intro",
           level: 1,
           kind: "cell",
@@ -103,6 +120,7 @@ describe("projectNotebookOutline", () => {
         {
           id: "b:cell",
           cellId: "b",
+          cellType: "code",
           title: "df = pandas.read_csv(path)",
           level: 1,
           kind: "cell",
@@ -110,12 +128,12 @@ describe("projectNotebookOutline", () => {
           headingAnchorId: null,
           href: "#notebook-cell-b",
           anchor: null,
-          detail: "Code",
           statusLabel: "Running",
         },
         {
           id: "c:cell",
           cellId: "c",
+          cellType: "raw",
           title: "Raw 3",
           level: 1,
           kind: "cell",
@@ -128,6 +146,60 @@ describe("projectNotebookOutline", () => {
         },
       ],
     });
+  });
+
+  it("omits empty code cells from fallback summaries", () => {
+    const projection = projectNotebookOutline([
+      { id: "empty", cell_type: "code", source: " \n\t" },
+      {
+        id: "hidden-input",
+        cell_type: "code",
+        source: "secret = 1",
+        metadata: { jupyter: { source_hidden: true } },
+      },
+      { id: "titled", cell_type: "code", source: "", metadata: { title: "Manual setup" } },
+      { id: "non-empty", cell_type: "code", source: "print('ok')" },
+      {
+        id: "hidden-output",
+        cell_type: "code",
+        source: "print('visible input')",
+        metadata: { jupyter: { outputs_hidden: true } },
+      },
+    ]);
+
+    expect(projection.source).toBe("cells");
+    expect(projection.items.map((item) => item.id)).toEqual([
+      "titled:cell",
+      "non-empty:cell",
+      "hidden-output:cell",
+    ]);
+    expect(projection.items).toMatchObject([
+      {
+        cellId: "titled",
+        cellType: "code",
+        title: "Manual setup",
+        kind: "cell",
+      },
+      {
+        cellId: "non-empty",
+        cellType: "code",
+        title: "print('ok')",
+        kind: "cell",
+      },
+      {
+        cellId: "hidden-output",
+        cellType: "code",
+        title: "print('visible input')",
+        kind: "cell",
+      },
+    ]);
+    expect(projection.items.map((item) => item.detail)).toEqual([undefined, undefined, undefined]);
+  });
+
+  it("treats notebooks with only empty code cells as outline-empty", () => {
+    const projection = projectNotebookOutline([{ id: "empty", cell_type: "code", source: "" }]);
+
+    expect(projection).toEqual({ source: "empty", items: [] });
   });
 
   it("prefers explicit metadata and leading section comments for code fallback titles", () => {

--- a/src/components/cell/CellInsertionRibbon.tsx
+++ b/src/components/cell/CellInsertionRibbon.tsx
@@ -217,13 +217,13 @@ export function CellInsertionRibbon({
         data-slot="cell-adder-actions"
         aria-hidden={isOpen ? undefined : true}
         className={cn(
-          "flex min-w-0 flex-1 items-center transition-opacity duration-150",
+          "flex min-w-0 flex-1 items-center transition-[opacity,transform] duration-150 ease-out",
           terminal && "pt-0.5",
           forceActionsVisible
-            ? "opacity-100"
+            ? "translate-x-0 opacity-100"
             : isOpen
-              ? "pointer-events-auto opacity-100 delay-75"
-              : "pointer-events-none opacity-0 transition-none",
+              ? "pointer-events-auto translate-x-0 opacity-100"
+              : "pointer-events-none -translate-x-1 opacity-0 transition-none",
         )}
       >
         <span

--- a/src/components/cell/__tests__/CellInsertionRibbon.test.tsx
+++ b/src/components/cell/__tests__/CellInsertionRibbon.test.tsx
@@ -82,8 +82,30 @@ describe("CellInsertionRibbon", () => {
 
     expect(actions).not.toHaveAttribute("aria-hidden");
     expect(actions).toHaveClass("pointer-events-auto");
+    expect(actions).toHaveClass("translate-x-0");
+    expect(actions).not.toHaveClass("delay-75");
     expect(addCodeButton).toHaveAttribute("tabindex", "0");
     expect(addMarkdownButton).toHaveAttribute("tabindex", "0");
+  });
+
+  it("reveals the insertion rule and action buttons on the same timeline", () => {
+    const { container } = render(<CellInsertionRibbon onInsert={() => undefined} />);
+
+    const hitTarget = container.querySelector('[data-slot="cell-adder-primary-hit-target"]');
+    const actions = container.querySelector('[data-slot="cell-adder-actions"]');
+
+    expect(actions).toHaveClass("-translate-x-1");
+
+    fireEvent.pointerEnter(hitTarget!);
+
+    expect(container.querySelector('[data-slot="cell-adder-primary-bridge"]')).toBeInTheDocument();
+    expect(actions).toHaveClass("transition-[opacity,transform]");
+    expect(actions).toHaveClass("pointer-events-auto");
+    expect(actions).toHaveClass("translate-x-0");
+    expect(actions).toHaveClass("opacity-100");
+    expect(actions).not.toHaveClass("delay-75");
+    expect(screen.getByTitle("Add code cell")).toHaveAttribute("tabindex", "0");
+    expect(screen.getByTitle("Add markdown cell")).toHaveAttribute("tabindex", "0");
   });
 
   it("uses the controlled active type for catalog fixtures", () => {

--- a/src/components/environment/UvDependencyPanel.tsx
+++ b/src/components/environment/UvDependencyPanel.tsx
@@ -120,11 +120,6 @@ export function UvDependencyPanel({
               <span className="whitespace-nowrap text-xs text-muted-foreground">Python</span>
             )}
           </div>
-          {isRail && isUsingProjectEnv && (
-            <span className="shrink-0 rounded-full bg-muted px-2 py-0.5 text-[11px] text-muted-foreground">
-              Project env
-            </span>
-          )}
         </div>
 
         {/* Success feedback after sync completed */}

--- a/src/components/notebook-rail/NotebookRail.tsx
+++ b/src/components/notebook-rail/NotebookRail.tsx
@@ -30,9 +30,7 @@ export interface NotebookRailProps {
   activeOutlineItemId?: string | null;
   selectedOutlineItemId?: string | null;
   selectedOutlineCellId?: string | null;
-  packagesSummary?: string | null;
   packagesPanel: ReactNode;
-  workstationsSummary?: string | null;
   workstationsPanel?: ReactNode;
   onActivePanelChange: (panelId: NotebookRailPanelId) => void;
   onCollapsedChange: (collapsed: boolean) => void;
@@ -55,9 +53,7 @@ export function NotebookRail({
   activeOutlineItemId = null,
   selectedOutlineItemId = null,
   selectedOutlineCellId = null,
-  packagesSummary = null,
   packagesPanel,
-  workstationsSummary = null,
   workstationsPanel,
   onActivePanelChange,
   onCollapsedChange,
@@ -75,12 +71,6 @@ export function NotebookRail({
       : activePanelId === "workstations"
         ? "Workstations"
         : "Outline";
-  const summary =
-    activePanelId === "packages"
-      ? packagesSummary
-      : activePanelId === "workstations"
-        ? workstationsSummary
-        : null;
   return (
     <Rail
       activePanelId={activePanelId}
@@ -88,11 +78,9 @@ export function NotebookRail({
       items={railButtons}
       panelEyebrow="Notebook"
       panelTitle={title}
-      panelSummary={summary}
       panelClassName={NOTEBOOK_RAIL_PANEL_CLASS_NAME}
       className={className}
       dataTestId="notebook-rail"
-      collapseButtonSlot="notebook-rail-collapse-button"
       panelSlot="notebook-rail-panel"
       panelTitleRowSlot="notebook-rail-panel-title-row"
       onActivePanelChange={onActivePanelChange}
@@ -205,6 +193,8 @@ function NotebookOutlineNode({
   const item = node.item;
   const selected = selectedItemId === item.id;
   const itemHref = getItemHref?.(item) ?? item.href ?? null;
+  const isCodeCellOutlineItem = item.kind === "cell" && item.cellType === "code";
+  const metaLabel = isCodeCellOutlineItem ? null : (item.statusLabel ?? item.detail ?? null);
   const className = cn(
     "relative flex min-h-8 w-full items-start gap-2 rounded-md py-1.5 pl-3 pr-2 text-left text-sm transition-colors",
     "cursor-pointer select-none touch-manipulation [-webkit-user-drag:none] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/30",
@@ -217,11 +207,16 @@ function NotebookOutlineNode({
     <>
       <span
         data-slot="notebook-outline-item-title"
-        className="line-clamp-2 min-w-0 flex-1 break-words leading-snug [overflow-wrap:anywhere]"
+        className={cn(
+          "min-w-0 flex-1 leading-snug",
+          isCodeCellOutlineItem
+            ? "truncate font-mono text-[13px] tracking-normal"
+            : "line-clamp-2 break-words [overflow-wrap:anywhere]",
+        )}
       >
         {item.title}
       </span>
-      {item.statusLabel ? (
+      {metaLabel ? (
         <span
           data-slot="notebook-outline-item-meta"
           className={cn(
@@ -229,17 +224,7 @@ function NotebookOutlineNode({
             selected ? "bg-muted text-foreground/70" : "bg-muted text-muted-foreground",
           )}
         >
-          {item.statusLabel}
-        </span>
-      ) : item.detail ? (
-        <span
-          data-slot="notebook-outline-item-meta"
-          className={cn(
-            "mt-0.5 shrink-0 rounded px-1.5 py-0.5 text-[10px] transition-colors",
-            selected ? "bg-muted text-foreground/70" : "bg-muted text-muted-foreground",
-          )}
-        >
-          {item.detail}
+          {metaLabel}
         </span>
       ) : null}
     </>

--- a/src/components/notebook-rail/NotebookRail.tsx
+++ b/src/components/notebook-rail/NotebookRail.tsx
@@ -137,7 +137,7 @@ export function NotebookOutlinePanel({
   if (items.length === 0) {
     return (
       <div className="rounded-md border border-dashed px-3 py-4 text-sm text-muted-foreground">
-        No headings yet.
+        Add Markdown headings to structure your notebook. They will appear here.
       </div>
     );
   }

--- a/src/components/notebook-rail/NotebookRail.tsx
+++ b/src/components/notebook-rail/NotebookRail.tsx
@@ -194,7 +194,11 @@ function NotebookOutlineNode({
   const selected = selectedItemId === item.id;
   const itemHref = getItemHref?.(item) ?? item.href ?? null;
   const isCodeCellOutlineItem = item.kind === "cell" && item.cellType === "code";
-  const metaLabel = isCodeCellOutlineItem ? null : (item.statusLabel ?? item.detail ?? null);
+  const isMarkdownCellOutlineItem = item.kind === "cell" && item.cellType === "markdown";
+  const metaLabel =
+    isCodeCellOutlineItem || isMarkdownCellOutlineItem
+      ? null
+      : (item.statusLabel ?? item.detail ?? null);
   const className = cn(
     "relative flex min-h-8 w-full items-start gap-2 rounded-md py-1.5 pl-3 pr-2 text-left text-sm transition-colors",
     "cursor-pointer select-none touch-manipulation [-webkit-user-drag:none] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/30",

--- a/src/components/notebook-rail/__tests__/NotebookRail.test.tsx
+++ b/src/components/notebook-rail/__tests__/NotebookRail.test.tsx
@@ -78,7 +78,6 @@ describe("NotebookRail", () => {
         activePanelId="outline"
         collapsed={false}
         outlineItems={outlineItems}
-        packagesSummary="uv · 2 packages"
         packagesPanel={
           <NotebookPackagesPanel>
             <div data-testid="host-package-content">real deps panel</div>
@@ -119,7 +118,6 @@ describe("NotebookRail", () => {
         collapsed={false}
         outlineItems={outlineItems}
         packagesPanel={<NotebookPackagesPanel>Packages</NotebookPackagesPanel>}
-        workstationsSummary="Ready"
         workstationsPanel={<div data-testid="host-workstations-content">runtime target</div>}
         onActivePanelChange={onActivePanelChange}
         onCollapsedChange={onCollapsedChange}
@@ -131,14 +129,13 @@ describe("NotebookRail", () => {
     expect(onCollapsedChange).toHaveBeenCalledWith(false);
   });
 
-  it("renders the active workstations panel summary and host content", () => {
+  it("renders the active workstations panel title and host content", () => {
     const { container } = render(
       <NotebookRail
         activePanelId="workstations"
         collapsed={false}
         outlineItems={outlineItems}
         packagesPanel={<NotebookPackagesPanel>Packages</NotebookPackagesPanel>}
-        workstationsSummary="Attached"
         workstationsPanel={<div data-testid="host-workstations-content">runtime target</div>}
         onActivePanelChange={vi.fn()}
         onCollapsedChange={vi.fn()}
@@ -146,7 +143,7 @@ describe("NotebookRail", () => {
     );
 
     expect(screen.getByRole("heading", { name: "Workstations" })).toBeVisible();
-    expect(screen.getByText("Attached")).toBeVisible();
+    expect(screen.queryByText("Attached")).not.toBeInTheDocument();
     expect(screen.getByTestId("host-workstations-content")).toHaveTextContent("runtime target");
     expect(container.querySelector('[data-slot="notebook-rail-panel"]')).toHaveClass(
       "w-[clamp(16rem,20vw,18rem)]",
@@ -154,13 +151,12 @@ describe("NotebookRail", () => {
     );
   });
 
-  it("keeps the active panel title primary when package metadata is present", () => {
+  it("keeps package metadata out of the title row", () => {
     render(
       <NotebookRail
         activePanelId="packages"
         collapsed={false}
         outlineItems={outlineItems}
-        packagesSummary="../pyproject.toml · 25 packages"
         packagesPanel={<NotebookPackagesPanel>Packages</NotebookPackagesPanel>}
         onActivePanelChange={vi.fn()}
         onCollapsedChange={vi.fn()}
@@ -168,12 +164,7 @@ describe("NotebookRail", () => {
     );
 
     expect(screen.getByRole("heading", { name: "Packages" })).toHaveClass("text-sm");
-    expect(
-      screen
-        .getByText("../pyproject.toml · 25 packages")
-        .closest('[data-slot="notebook-rail-panel-title-row"]'),
-    ).toHaveClass("flex-wrap", "justify-between");
-    expect(screen.getByText("../pyproject.toml · 25 packages")).toHaveClass("w-fit", "max-w-full");
+    expect(screen.queryByText("../pyproject.toml · 25 packages")).not.toBeInTheDocument();
   });
 
   it("collapses the rail when clicking the active expanded panel button", () => {
@@ -196,7 +187,7 @@ describe("NotebookRail", () => {
     expect(onActivePanelChange).not.toHaveBeenCalled();
   });
 
-  it("exposes the collapse control for narrow takeover focus recovery", () => {
+  it("does not render a standalone collapse control", () => {
     const { container } = render(
       <NotebookRail
         activePanelId="outline"
@@ -210,7 +201,8 @@ describe("NotebookRail", () => {
 
     expect(
       container.querySelector('[data-slot="notebook-rail-collapse-button"]'),
-    ).toHaveAccessibleName("Collapse rail");
+    ).not.toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: "Collapse rail" })).not.toBeInTheDocument();
   });
 
   it("collapses the expanded packages panel from its rail button", () => {
@@ -396,6 +388,44 @@ describe("NotebookRail", () => {
     expect(outlineTitle).not.toHaveClass("truncate");
   });
 
+  it("renders code cell fallback outline items as single-line code without status badges", () => {
+    const { container } = render(
+      <NotebookRail
+        activePanelId="outline"
+        collapsed={false}
+        outlineItems={[
+          {
+            id: "code-1:cell",
+            cellId: "code-1",
+            cellType: "code",
+            title: "print('ok')",
+            level: 1,
+            kind: "cell" as const,
+            cellAnchorId: "notebook-cell-code-1",
+            headingAnchorId: null,
+            href: "#notebook-cell-code-1",
+            anchor: null,
+            statusLabel: "run 1",
+          },
+        ]}
+        packagesPanel={<NotebookPackagesPanel>Packages</NotebookPackagesPanel>}
+        onActivePanelChange={vi.fn()}
+        onCollapsedChange={vi.fn()}
+      />,
+    );
+
+    expect(screen.getByRole("link", { name: "print('ok')" })).toBeInTheDocument();
+    expect(screen.queryByText("run 1")).not.toBeInTheDocument();
+    expect(container.querySelector('[data-slot="notebook-outline-item-title"]')).toHaveClass(
+      "font-mono",
+      "truncate",
+      "tracking-normal",
+    );
+    expect(container.querySelector('[data-slot="notebook-outline-item-title"]')).not.toHaveClass(
+      "line-clamp-2",
+    );
+  });
+
   it("marks only the first outline item for a focused cell when no item is pinned", () => {
     render(
       <NotebookRail
@@ -552,7 +582,6 @@ describe("NotebookRail", () => {
         activePanelId="packages"
         collapsed={false}
         outlineItems={outlineItems}
-        packagesSummary="uv · 2 packages"
         packagesPanel={
           <NotebookPackagesPanel>
             <div data-testid="host-package-content">real deps panel</div>

--- a/src/components/notebook-rail/__tests__/NotebookRail.test.tsx
+++ b/src/components/notebook-rail/__tests__/NotebookRail.test.tsx
@@ -34,6 +34,24 @@ const outlineItems = [
 ];
 
 describe("NotebookRail", () => {
+  it("explains how to populate an empty outline", () => {
+    render(
+      <NotebookRail
+        activePanelId="outline"
+        collapsed={false}
+        outlineItems={[]}
+        packagesPanel={<NotebookPackagesPanel>Packages</NotebookPackagesPanel>}
+        onActivePanelChange={vi.fn()}
+        onCollapsedChange={vi.fn()}
+      />,
+    );
+
+    expect(
+      screen.getByText("Add Markdown headings to structure your notebook. They will appear here."),
+    ).toBeVisible();
+    expect(screen.queryByText("No headings yet.")).not.toBeInTheDocument();
+  });
+
   it("renders outline items and reports selection through the adapter callback", () => {
     const onSelectOutlineItem = vi.fn();
 

--- a/src/components/notebook-rail/__tests__/NotebookRail.test.tsx
+++ b/src/components/notebook-rail/__tests__/NotebookRail.test.tsx
@@ -444,6 +444,36 @@ describe("NotebookRail", () => {
     );
   });
 
+  it("renders markdown fallback outline items without redundant type badges", () => {
+    const { container } = render(
+      <NotebookRail
+        activePanelId="outline"
+        collapsed={false}
+        outlineItems={[
+          {
+            id: "markdown-1:cell",
+            cellId: "markdown-1",
+            cellType: "markdown",
+            title: "Body row",
+            level: 1,
+            kind: "cell" as const,
+            cellAnchorId: "notebook-cell-markdown-1",
+            headingAnchorId: null,
+            href: "#notebook-cell-markdown-1",
+            anchor: null,
+            detail: "Markdown",
+          },
+        ]}
+        packagesPanel={<NotebookPackagesPanel>Packages</NotebookPackagesPanel>}
+        onActivePanelChange={vi.fn()}
+        onCollapsedChange={vi.fn()}
+      />,
+    );
+
+    expect(screen.getByRole("link", { name: "Body row" })).toBeInTheDocument();
+    expect(container.querySelector('[data-slot="notebook-outline-item-meta"]')).toBeNull();
+  });
+
   it("marks only the first outline item for a focused cell when no item is pinned", () => {
     render(
       <NotebookRail

--- a/src/components/notebook/NotebookDocumentRail.tsx
+++ b/src/components/notebook/NotebookDocumentRail.tsx
@@ -11,9 +11,7 @@ export interface NotebookDocumentRailProps {
   activeOutlineItemId?: string | null;
   selectedOutlineItemId?: string | null;
   selectedOutlineCellId?: string | null;
-  packagesSummary?: string | null;
   packagesPanel: ReactNode;
-  workstationsSummary?: string | null;
   workstationsPanel?: ReactNode;
   onActivePanelChange: (panelId: NotebookRailPanelId) => void;
   onCollapsedChange: (collapsed: boolean) => void;
@@ -30,9 +28,7 @@ export function NotebookDocumentRail({
   activeOutlineItemId = null,
   selectedOutlineItemId = null,
   selectedOutlineCellId = null,
-  packagesSummary,
   packagesPanel,
-  workstationsSummary,
   workstationsPanel,
   onActivePanelChange,
   onCollapsedChange,
@@ -49,9 +45,7 @@ export function NotebookDocumentRail({
       activeOutlineItemId={activeOutlineItemId}
       selectedOutlineItemId={selectedOutlineItemId}
       selectedOutlineCellId={selectedOutlineCellId}
-      packagesSummary={packagesSummary === undefined ? viewModel.packages.summary : packagesSummary}
       packagesPanel={packagesPanel}
-      workstationsSummary={workstationsSummary}
       workstationsPanel={workstationsPanel}
       onActivePanelChange={onActivePanelChange}
       onCollapsedChange={onCollapsedChange}

--- a/src/components/notebook/NotebookWorkstationsPanel.tsx
+++ b/src/components/notebook/NotebookWorkstationsPanel.tsx
@@ -253,10 +253,6 @@ function RegisteredWorkstationRow({
   );
 }
 
-export function notebookWorkstationsSummary(capabilities: NotebookShellCapabilities): string {
-  return projectNotebookWorkstationPanel(capabilities).summary;
-}
-
 function WorkstationFact({
   fact,
   icon: Icon,

--- a/src/components/notebook/__tests__/NotebookDocumentRail.test.tsx
+++ b/src/components/notebook/__tests__/NotebookDocumentRail.test.tsx
@@ -31,7 +31,6 @@ describe("NotebookDocumentRail", () => {
         viewModel={viewModel}
         activePanelId="packages"
         collapsed={false}
-        packagesSummary="Runtime packages"
         packagesPanel={<p>Package details</p>}
         onActivePanelChange={() => {}}
         onCollapsedChange={() => {}}
@@ -39,17 +38,16 @@ describe("NotebookDocumentRail", () => {
     );
 
     expect(screen.getByTestId("notebook-rail")).toHaveAttribute("data-collapsed", "false");
-    expect(screen.getByText("Runtime packages")).toBeVisible();
+    expect(screen.queryByText("Runtime packages")).not.toBeInTheDocument();
     expect(screen.getByText("Package details")).toBeVisible();
   });
 
-  it("can suppress the package title summary when the host renders it in the panel", () => {
+  it("keeps the package title row free of view-model summaries", () => {
     render(
       <NotebookDocumentRail
         viewModel={viewModel}
         activePanelId="packages"
         collapsed={false}
-        packagesSummary={null}
         packagesPanel={<p>Package details</p>}
         onActivePanelChange={() => {}}
         onCollapsedChange={() => {}}
@@ -85,7 +83,6 @@ describe("NotebookDocumentRail", () => {
         activePanelId="workstations"
         collapsed={false}
         packagesPanel={<p>Package details</p>}
-        workstationsSummary="Ready"
         workstationsPanel={<p>Runtime target</p>}
         onActivePanelChange={() => {}}
         onCollapsedChange={() => {}}
@@ -93,7 +90,7 @@ describe("NotebookDocumentRail", () => {
     );
 
     expect(screen.getByRole("heading", { name: "Workstations" })).toBeVisible();
-    expect(screen.getByText("Ready")).toBeVisible();
+    expect(screen.queryByText("Ready")).not.toBeInTheDocument();
     expect(screen.getByText("Runtime target")).toBeVisible();
   });
 });

--- a/src/components/notebook/__tests__/NotebookWorkstationsPanel.test.tsx
+++ b/src/components/notebook/__tests__/NotebookWorkstationsPanel.test.tsx
@@ -5,10 +5,7 @@ import {
   projectNotebookWorkstationSelection,
   readOnlyNotebookShellCapabilities,
 } from "../capabilities";
-import {
-  notebookWorkstationsSummary,
-  NotebookWorkstationsPanel,
-} from "../NotebookWorkstationsPanel";
+import { NotebookWorkstationsPanel } from "../NotebookWorkstationsPanel";
 
 const localReadyCapabilities: NotebookShellCapabilities = {
   ...readOnlyNotebookShellCapabilities,
@@ -527,39 +524,5 @@ describe("NotebookWorkstationsPanel", () => {
     expect(screen.getByText("1")).toBeVisible();
     expect(screen.queryByText("CPUs")).not.toBeInTheDocument();
     expect(screen.queryByText("RAM")).not.toBeInTheDocument();
-  });
-
-  it("summarizes the active workstation by display name for the rail title row", () => {
-    expect(notebookWorkstationsSummary(localReadyCapabilities)).toBe("This machine");
-
-    const cloudOffline: NotebookShellCapabilities = {
-      ...readOnlyNotebookShellCapabilities,
-      runtime: {
-        ...readOnlyNotebookShellCapabilities.runtime,
-        source: "cloud",
-        target: {
-          id: "workstation:none",
-          kind: "cloud_workstation",
-          status: "offline",
-          label: "No workstation attached",
-          statusLabel: "Offline",
-        },
-      },
-    };
-    expect(notebookWorkstationsSummary(cloudOffline)).toBe("No workstation attached");
-
-    const remoteReady: NotebookShellCapabilities = {
-      ...localReadyCapabilities,
-      runtime: {
-        ...localReadyCapabilities.runtime,
-        target: {
-          id: "outerbounds-forecast-gpu",
-          kind: "cloud_workstation",
-          status: "ready",
-          label: "Forecast GPU",
-        },
-      },
-    };
-    expect(notebookWorkstationsSummary(remoteReady)).toBe("Forecast GPU");
   });
 });

--- a/src/components/notebook/__tests__/view-model.test.ts
+++ b/src/components/notebook/__tests__/view-model.test.ts
@@ -210,6 +210,30 @@ describe("notebook shell view model", () => {
     });
   });
 
+  it("omits empty code cells from outline fallbacks without code badges", () => {
+    const outline = notebookViewCellsToOutlineItems([
+      codeViewCell("empty-code", " \n\t"),
+      codeViewCell("hidden-input", "secret = 1", { jupyter: { source_hidden: true } }),
+      codeViewCell("code-1", "print('ok')"),
+      codeViewCell("hidden-output", "print('visible input')", {
+        jupyter: { outputs_hidden: true },
+      }),
+    ]);
+
+    expect(outline.map((item) => item.cellId)).toEqual(["code-1", "hidden-output"]);
+    expect(outline[0]).toMatchObject({
+      cellType: "code",
+      title: "print('ok')",
+      kind: "cell",
+    });
+    expect("detail" in outline[0]).toBe(false);
+    expect(outline[1]).toMatchObject({
+      cellType: "code",
+      title: "print('visible input')",
+      kind: "cell",
+    });
+  });
+
   it("builds a normalized view model for host adapters", () => {
     const cells: NotebookViewCell[] = [
       {
@@ -387,6 +411,23 @@ function markdownViewCell(
     outputs: [],
     metadata: {},
     markdownProjection: testMarkdownProjection(source, anchors),
+  };
+}
+
+function codeViewCell(
+  id: string,
+  source: string,
+  metadata: Record<string, unknown> = {},
+): NotebookViewCell {
+  return {
+    id,
+    cellType: "code",
+    source,
+    language: "python",
+    executionId: null,
+    executionCount: null,
+    outputs: [],
+    metadata,
   };
 }
 

--- a/src/components/notebook/__tests__/view-model.test.ts
+++ b/src/components/notebook/__tests__/view-model.test.ts
@@ -137,6 +137,33 @@ describe("notebook shell view model", () => {
     }
   });
 
+  it("reprojects stale attached markdownProjection anchors from current source", () => {
+    let calls = 0;
+    const restore = setMarkdownProjectionProjector((source) => {
+      calls += 1;
+      return JSON.stringify(
+        testMarkdownProjection(source, [{ title: "More fun", level: 1, slug: "more-fun" }]),
+      );
+    });
+
+    try {
+      const staleCell = markdownViewCell("intro", "Markdown body row", []);
+      const outline = notebookViewCellsToOutlineItems([
+        {
+          ...staleCell,
+          source: "# More fun\n\nMarkdown body row",
+        },
+      ]);
+
+      expect(calls).toBe(1);
+      expect(outline.map((item) => [item.id, item.title, item.anchor])).toEqual([
+        ["intro:heading:0", "More fun", "more-fun"],
+      ]);
+    } finally {
+      restore();
+    }
+  });
+
   it("projects Jupyter hidden metadata into read-only render cells", () => {
     const cells: NotebookViewCell[] = [
       {

--- a/src/components/notebook/index.ts
+++ b/src/components/notebook/index.ts
@@ -182,7 +182,6 @@ export {
   type NotebookPackageSummaryPanelProps,
 } from "./NotebookPackageSummaryPanel";
 export {
-  notebookWorkstationsSummary,
   NotebookWorkstationsPanel,
   type NotebookWorkstationsPanelProps,
 } from "./NotebookWorkstationsPanel";

--- a/src/components/notebook/view-model.ts
+++ b/src/components/notebook/view-model.ts
@@ -141,14 +141,29 @@ export function notebookViewCellsToOutlineItems(
 
 function notebookViewCellMarkdownAnchors(cell: NotebookViewCell) {
   // Live adapters attach markdownProjection during materialization/source edits.
-  // Treat an attached projection as authoritative, including an empty anchor
-  // list for headingless markdown, so outline projection stays O(cells) and
-  // does not reparse markdown in the common path.
-  if (cell.markdownProjection) return cell.markdownProjection.anchors;
+  // Treat a fresh attached projection as authoritative, including an empty
+  // anchor list for headingless markdown, so outline projection stays O(cells)
+  // in the common path. If the source has moved ahead of the projection, fall
+  // back to the source-keyed projector so outline headings update before a full
+  // rematerialization/reload.
+  if (
+    cell.markdownProjection &&
+    markdownProjectionMatchesSource(cell.markdownProjection, cell.source)
+  ) {
+    return cell.markdownProjection.anchors;
+  }
 
   // This Rust/WASM fallback keeps older host adapters correct without reviving
   // a second heading parser; projectMarkdownPlan is source-key cached.
   return projectMarkdownPlan(cell.source)?.anchors ?? null;
+}
+
+function markdownProjectionMatchesSource(plan: MarkdownProjectionPlan, source: string): boolean {
+  return plan.utf16Length === source.length && plan.byteLength === markdownSourceByteLength(source);
+}
+
+function markdownSourceByteLength(source: string): number {
+  return new TextEncoder().encode(source).byteLength;
 }
 
 export function notebookViewCellsToTracebackTargets(

--- a/src/components/rail/Rail.tsx
+++ b/src/components/rail/Rail.tsx
@@ -1,4 +1,4 @@
-import { ChevronLeft, ChevronRight, type LucideIcon } from "lucide-react";
+import type { LucideIcon } from "lucide-react";
 import type { ReactNode } from "react";
 import { cn } from "@/lib/utils";
 
@@ -23,11 +23,9 @@ export interface RailProps<PanelId extends string = string> {
   onActivePanelChange: (panelId: PanelId) => void;
   onCollapsedChange: (collapsed: boolean) => void;
   panelEyebrow?: string;
-  panelSummary?: string | null;
   panelClassName?: string;
   className?: string;
   dataTestId?: string;
-  collapseButtonSlot?: string;
   panelSlot?: string;
   panelTitleRowSlot?: string;
 }
@@ -38,14 +36,12 @@ export function Rail<PanelId extends string = string>({
   items,
   panelTitle,
   panelEyebrow,
-  panelSummary = null,
   panelClassName,
   children,
   onActivePanelChange,
   onCollapsedChange,
   className,
   dataTestId = "rail",
-  collapseButtonSlot = "rail-collapse-button",
   panelSlot = "rail-panel",
   panelTitleRowSlot = "rail-panel-title-row",
 }: RailProps<PanelId>) {
@@ -56,13 +52,6 @@ export function Rail<PanelId extends string = string>({
       data-collapsed={collapsed ? "true" : "false"}
     >
       <div className="flex w-12 shrink-0 flex-col items-center gap-2 border-r bg-muted/40 px-2 py-3">
-        <RailButton
-          label={collapsed ? "Expand rail" : "Collapse rail"}
-          icon={collapsed ? ChevronRight : ChevronLeft}
-          active={false}
-          dataSlot={collapseButtonSlot}
-          onClick={() => onCollapsedChange(!collapsed)}
-        />
         {items.map((item) => (
           <RailButton
             key={item.id}
@@ -106,11 +95,6 @@ export function Rail<PanelId extends string = string>({
                 data-slot={panelTitleRowSlot}
               >
                 <h2 className="text-sm font-semibold text-foreground">{panelTitle}</h2>
-                {panelSummary && (
-                  <span className="w-fit max-w-full truncate rounded-full border bg-muted px-2 py-1 text-[11px] text-muted-foreground">
-                    {panelSummary}
-                  </span>
-                )}
               </div>
             </div>
           </div>

--- a/src/components/rail/__tests__/Rail.test.tsx
+++ b/src/components/rail/__tests__/Rail.test.tsx
@@ -24,7 +24,6 @@ describe("Rail", () => {
         items={items}
         panelEyebrow="Notebook"
         panelTitle="Packages"
-        panelSummary="uv · 2 packages"
         panelClassName="w-64"
         dataTestId="example-rail"
         panelSlot="example-rail-panel"
@@ -39,7 +38,7 @@ describe("Rail", () => {
     expect(screen.getByTestId("example-rail")).toHaveAttribute("data-collapsed", "false");
     expect(screen.getByText("Notebook")).toBeInTheDocument();
     expect(screen.getByRole("heading", { name: "Packages" })).toHaveClass("text-sm");
-    expect(screen.getByText("uv · 2 packages")).toHaveClass("w-fit", "max-w-full");
+    expect(screen.queryByText("uv · 2 packages")).not.toBeInTheDocument();
     expect(screen.getByTestId("panel-content")).toHaveTextContent("Dependencies");
     expect(container.querySelector('[data-slot="example-rail-panel"]')).toHaveClass(
       "w-64",
@@ -70,6 +69,23 @@ describe("Rail", () => {
     fireEvent.click(screen.getByRole("button", { name: "Outline" }));
     expect(onCollapsedChange).toHaveBeenCalledWith(true);
     expect(onActivePanelChange).not.toHaveBeenCalled();
+  });
+
+  it("does not render a separate collapse control", () => {
+    render(
+      <Rail
+        activePanelId="outline"
+        collapsed={false}
+        items={items}
+        panelTitle="Outline"
+        onActivePanelChange={vi.fn()}
+        onCollapsedChange={vi.fn()}
+      >
+        Outline
+      </Rail>,
+    );
+
+    expect(screen.queryByRole("button", { name: "Collapse rail" })).not.toBeInTheDocument();
   });
 
   it("expands and selects a panel while collapsed", () => {


### PR DESCRIPTION
## Summary

- remove notebook rail title-row summary pills and the standalone collapse button
- hide the Desktop workstations rail slot until runtime targets are ready to expose there again
- tighten outline fallback behavior for code cells, hidden inputs, and long code summaries
- keep project-env package details visible in the rail and refresh project context for project-backed untitled notebooks

## Verification

- `pnpm test:run packages/runtimed/tests/notebook-outline.test.ts src/components/notebook/__tests__/view-model.test.ts src/components/notebook-rail/__tests__/NotebookRail.test.tsx apps/notebook/src/lib/__tests__/notebook-view-model.test.ts`
- `pnpm test:run src/components/cell/__tests__/CellInsertionRibbon.test.tsx`
- `pnpm --dir apps/notebook exec tsc -b`
- `cargo test -p runtimed notebook_sync_server::project_context`
- `pnpm test:run apps/notebook/src/components/__tests__/PackageSpecList.test.tsx`
- `cargo xtask lint --fix`
- Browser smoke on `.context/rail-ui-fixture.ipynb`

## Notes

Draft while UI annotation continues.
