### PR TITLE
refactor(runtimed): make IOPub bounded-send discipline structural (EP-8)

### DIFF
--- a/crates/runtimed/src/jupyter_kernel.rs
+++ b/crates/runtimed/src/jupyter_kernel.rs
@@ -213,7 +213,7 @@ enum IoPubStateUpdate {
 }
 
 fn try_send_comm_update(
-    work_tx: &mpsc::Sender<WorkCommand>,
+    work_tx: &crate::output_prep::NonBlockingSender<WorkCommand>,
     comm_id: String,
     state: serde_json::Value,
 ) {
@@ -371,7 +371,7 @@ pub struct JupyterKernel {
     /// With msg_id = execution_id, parent_header.msg_id IS the execution_id.
     registered_execution_ids: Arc<StdMutex<HashSet<String>>>,
     /// Work command sender for iopub/shell tasks.
-    work_cmd_tx: Option<mpsc::Sender<WorkCommand>>,
+    work_cmd_tx: Option<crate::output_prep::NonBlockingSender<WorkCommand>>,
     /// Lifecycle command sender for iopub/shell tasks.
     lifecycle_cmd_tx: Option<mpsc::UnboundedSender<LifecycleSignal>>,
     /// Monotonic counter for comm insertion order (written to RuntimeStateDoc).
@@ -3476,7 +3476,7 @@ mod tests {
 
     #[test]
     fn comm_update_replay_is_best_effort_when_work_queue_is_full() {
-        let (tx, mut rx) = mpsc::channel(1);
+        let (_lifecycle_tx, tx, mut receivers) = crate::output_prep::queue_command_channels(1);
 
         try_send_comm_update(
             &tx,
@@ -3489,13 +3489,16 @@ mod tests {
             serde_json::json!({ "outputs": ["dropped"] }),
         );
 
-        let queued = rx.try_recv().expect("first comm update should be queued");
+        let queued = receivers
+            .work_rx
+            .try_recv()
+            .expect("first comm update should be queued");
         assert!(matches!(
             queued,
             WorkCommand::SendCommUpdate { comm_id, .. } if comm_id == "comm-a"
         ));
         assert!(
-            rx.try_recv().is_err(),
+            receivers.work_rx.try_recv().is_err(),
             "full work queue should drop comm output replay"
         );
     }

--- a/crates/runtimed/src/output_prep.rs
+++ b/crates/runtimed/src/output_prep.rs
@@ -508,18 +508,44 @@ pub struct QueueCommandReceivers {
     pub work_rx: mpsc::Receiver<WorkCommand>,
 }
 
+/// Bounded sender that cannot block: only `try_send` is exposed.
+///
+/// The IOPub reader routes work onto the bounded work queue but must never
+/// await queue capacity — a full work queue backpressuring the reader would
+/// delay later lifecycle status such as `idle` after an interrupt (EP-8,
+/// execution-pipeline.md Decision 2). Wrapping the sender makes that
+/// discipline structural: a blocking `.send().await` on the work channel
+/// does not compile. If a sender outside the IOPub hot path ever needs a
+/// blocking send, add it as a separately named method so the IOPub usage
+/// stays auditable.
+pub struct NonBlockingSender<T>(mpsc::Sender<T>);
+
+// Manual impl: `mpsc::Sender<T>` is Clone for any T, and a derive would
+// needlessly require `T: Clone`.
+impl<T> Clone for NonBlockingSender<T> {
+    fn clone(&self) -> Self {
+        Self(self.0.clone())
+    }
+}
+
+impl<T> NonBlockingSender<T> {
+    pub fn try_send(&self, value: T) -> Result<(), mpsc::error::TrySendError<T>> {
+        self.0.try_send(value)
+    }
+}
+
 pub fn queue_command_channels(
     work_capacity: usize,
 ) -> (
     mpsc::UnboundedSender<LifecycleSignal>,
-    mpsc::Sender<WorkCommand>,
+    NonBlockingSender<WorkCommand>,
     QueueCommandReceivers,
 ) {
     let (lifecycle_tx, lifecycle_rx) = mpsc::unbounded_channel();
     let (work_tx, work_rx) = mpsc::channel(work_capacity);
     (
         lifecycle_tx,
-        work_tx,
+        NonBlockingSender(work_tx),
         QueueCommandReceivers {
             lifecycle_rx,
             work_rx,

--- a/docs/adr/execution-pipeline.md
+++ b/docs/adr/execution-pipeline.md
@@ -75,8 +75,12 @@ pub fn queue_command_channels(work_capacity: usize) -> (
 
 The old `QueueCommand::is_lifecycle()` runtime discipline was replaced by this
 type split, so non-lifecycle work cannot compile on the lifecycle channel. The
-remaining ordering questions are about when lifecycle signals are drained, not
-about accidentally routing widget replay work onto the lifecycle path.
+work sender side is structural too (EP-8): `queue_command_channels` returns a
+`NonBlockingSender<WorkCommand>` that exposes only `try_send`, so an IOPub
+handler arm cannot await queue capacity on the bounded work channel — a
+blocking `.send().await` does not compile. The remaining ordering questions
+are about when lifecycle signals are drained, not about accidentally routing
+widget replay work onto the lifecycle path or blocking the reader on it.
 
 The runtime agent's `select!` loop has two arms for these channels (`crates/runtimed/src/runtime_agent.rs:592-639`):
 
@@ -334,5 +338,4 @@ to implement; **Design** = needs a decision in this ADR before code moves.
 - **EP-3** (Design; memo `docs/adr/execution-liveness.md`): **Reframed.** Daemon view of execution state can diverge from kernel reality. A wall-clock watchdog is the wrong fix - multi-hour training jobs are legitimate Jupyter usage and nteract's resume-by-reconnect is a feature. The real signal is divergence between `RuntimeStateDoc.status` and live IOPub / heartbeat / committer state. See design memo `docs/adr/execution-liveness.md`. Code is a follow-up after the memo is reviewed.
 - **EP-5** (Design; telemetry + tuning pass): Capacity constants (`STREAM_COMMITTER_QUEUE_CAPACITY = 32`, `MAX_PENDING_DISPLAY_IDS = 128`, `DEFAULT_OUTPUT_SYNC_GRACE = 500ms`) picked by judgment. No benchmark, no drop-rate metric, no measured upper bound under load.
 - **EP-6** (Design; request handling): `required_heads` is `NotebookDoc`-only. No causal gate exists for requests that depend on recent `RuntimeStateDoc` writes.
-- **EP-8** (Targeted PR; IOPub handlers, lint or type-level enforcement): "IOPub reader cannot block on bounded queues" is discipline, not a check. Adding `.await` on a bounded send in any IOPub handler arm would silently reintroduce the backpressure failure.
 - **EP-9** (Design; run-all path): Run-all timeouts are shared across the batch; a long first cell starves the budget for later cells. No fairness mechanism.


### PR DESCRIPTION
Resolves EP-8 from `docs/adr/execution-pipeline.md`.

"IOPub reader cannot block on bounded queues" was discipline, not a check. A `.await` on a bounded send in any IOPub handler arm would silently reintroduce the backpressure failure where a full work queue delays later lifecycle status (`idle` after an interrupt, `ExecutionDone`).

## What changed

The ADR row offered "lint or type-level enforcement"; this takes the type-level route, which is stronger and has no false positives. `queue_command_channels` now returns `NonBlockingSender<WorkCommand>` - a wrapper exposing only `try_send`. The only production send path (`try_send_comm_update`) and the kernel's stored sender take the wrapper, so a blocking send on the work channel does not compile from the IOPub path.

Survey of the other channels the IOPub task touches, for completeness:

- the lifecycle channel is unbounded; its `send` is synchronous, nothing to block on
- the comm-coalesce channel is unbounded
- the stream committer's bounded periodic channel already exposes only try-send semantics through `request_flush`

So the work channel was the one bounded queue reachable with a blocking send, and it's now closed off.

## Verification

- Mutation-tested: a `.send().await` on the wrapper fails to compile with E0599 (`no method named 'send' found for struct 'NonBlockingSender<T>'`), and the inner sender is private outside `output_prep`.
- All 951 runtimed lib tests pass. The one test that built a raw channel to exercise `try_send_comm_update` now goes through `queue_command_channels`.

Updates Decision 2 in the ADR to record the structural enforcement (it already documented the `LifecycleSignal`/`WorkCommand` type split this completes) and removes the EP-8 row.
