### PR TITLE
feat(runtimed): per-ref provenance for blob GC mark walk (BS-7)

### DIFF
--- a/crates/runtimed/src/daemon.rs
+++ b/crates/runtimed/src/daemon.rs
@@ -4094,15 +4094,19 @@ impl Daemon {
                         "[runtimed] GC: 0 active rooms and no room has loaded since startup; skipping blob sweep this cycle"
                     );
                 } else {
-                    let mut referenced_hashes = Self::collect_blob_refs_for_gc(
+                    let mut mark = Self::collect_blob_refs_for_gc(
                         &room_arcs,
                         &self.config.notebook_docs_dir,
                         &self.blob_store,
                     )
                     .await;
-                    referenced_hashes.extend(execution_store_refs);
-                    Self::sweep_orphaned_blobs(&self.blob_store, &referenced_hashes, blob_max_age)
-                        .await;
+                    mark.extend_with_source(
+                        "execution-store",
+                        "execution-store",
+                        execution_store_refs,
+                    );
+                    debug!("[runtimed] GC: mark sources: {}", mark.summary());
+                    Self::sweep_orphaned_blobs(&self.blob_store, mark.hashes(), blob_max_age).await;
                 }
             }
 
@@ -4522,6 +4526,71 @@ fn collect_blob_hashes_recursive(
     }
 }
 
+/// Mark set for blob GC with per-ref provenance (BS-7).
+///
+/// The sweep deletes every blob the mark phase did not reach, so a mark-miss
+/// is silent data loss with nothing to audit after the fact. This set records
+/// which source category contributed each hash and how many unique hashes
+/// each category marked. The GC loop logs the per-category counts after every
+/// mark walk — a category that should have refs reporting zero is the
+/// inventory bug made visible — and `first_marker` answers "what protected
+/// this hash" for a specific blob.
+///
+/// Counts are of first marks: a hash reachable from two sources is attributed
+/// to whichever marked it first, so later categories report only their unique
+/// contributions.
+#[derive(Default)]
+pub(crate) struct GcMarkSet {
+    hashes: std::collections::HashSet<String>,
+    first_marker: std::collections::HashMap<String, String>,
+    marks_by_category: std::collections::BTreeMap<&'static str, usize>,
+}
+
+impl GcMarkSet {
+    /// Fold `hashes` into the set. `category` is a stable label for counting
+    /// ("execution-outputs", "persisted-doc", ...); `detail` identifies the
+    /// concrete container for per-hash provenance ("room:abc", a file name).
+    pub(crate) fn extend_with_source(
+        &mut self,
+        category: &'static str,
+        detail: &str,
+        hashes: impl IntoIterator<Item = String>,
+    ) {
+        for hash in hashes {
+            if self.hashes.insert(hash.clone()) {
+                *self.marks_by_category.entry(category).or_default() += 1;
+                self.first_marker
+                    .insert(hash, format!("{category} {detail}"));
+            }
+        }
+    }
+
+    pub(crate) fn hashes(&self) -> &std::collections::HashSet<String> {
+        &self.hashes
+    }
+
+    /// Per-hash audit accessor. No production caller yet: the GC loop logs
+    /// the category summary, and a swept blob is by definition unmarked. This
+    /// exists for tests and for a future diagnostics surface that wants to
+    /// answer "what protected this hash" for a live blob.
+    #[cfg_attr(not(test), expect(dead_code))]
+    pub(crate) fn first_marker(&self, hash: &str) -> Option<&str> {
+        self.first_marker.get(hash).map(String::as_str)
+    }
+
+    /// One-line per-category mark counts for the GC debug log.
+    pub(crate) fn summary(&self) -> String {
+        if self.marks_by_category.is_empty() {
+            return "no refs marked".to_string();
+        }
+        self.marks_by_category
+            .iter()
+            .map(|(category, count)| format!("{category}={count}"))
+            .collect::<Vec<_>>()
+            .join(" ")
+    }
+}
+
 /// Default grace period before an unreferenced blob is swept (30 days).
 ///
 /// Rationale: after `.ipynb` save switches to external blob refs, a
@@ -4642,24 +4711,30 @@ impl Daemon {
         rooms: &[(String, Arc<crate::notebook_sync_server::NotebookRoom>)],
         notebook_docs_dir: &Path,
         blob_store: &BlobStore,
-    ) -> std::collections::HashSet<String> {
+    ) -> GcMarkSet {
         /// Rooms are scanned in batches so the sweep yields back to other
         /// daemon tasks; keeping the constant local keeps it near the loop.
         const ROOM_BATCH_SIZE: usize = 10;
         /// Reading `.automerge` files is I/O-bound; yield between batches.
         const DOC_BATCH_SIZE: usize = 10;
 
-        let mut referenced_hashes = std::collections::HashSet::new();
+        let mut mark = GcMarkSet::default();
 
         // 1. In-memory: active rooms (RuntimeStateDoc + notebook doc).
+        // Each ref shape lands in the mark set under its own category so the
+        // GC log shows which walks contributed (BS-7).
         for batch in rooms.chunks(ROOM_BATCH_SIZE) {
-            for (_id, room) in batch {
+            for (id, room) in batch {
+                let detail = format!("room:{id}");
+                let mut execution_output_hashes = std::collections::HashSet::new();
+                let mut comm_output_hashes = std::collections::HashSet::new();
+                let mut comm_state_hashes = std::collections::HashSet::new();
                 let mut arrow_manifest_blob_hashes = Vec::new();
                 let _ = room.state.read(|sd| {
                     let state = sd.read_state();
                     for exec in state.executions.values() {
                         for output in &exec.outputs {
-                            collect_blob_hashes(output, &mut referenced_hashes);
+                            collect_blob_hashes(output, &mut execution_output_hashes);
                             if let Some(hash) = arrow_manifest_blob_hash(output) {
                                 arrow_manifest_blob_hashes.push(hash);
                             }
@@ -4667,30 +4742,41 @@ impl Daemon {
                     }
                     for comm in state.comms.values() {
                         for output in &comm.outputs {
-                            collect_blob_hashes(output, &mut referenced_hashes);
+                            collect_blob_hashes(output, &mut comm_output_hashes);
                             if let Some(hash) = arrow_manifest_blob_hash(output) {
                                 arrow_manifest_blob_hashes.push(hash);
                             }
                         }
-                        collect_blob_hashes_recursive(&comm.state, &mut referenced_hashes);
+                        collect_blob_hashes_recursive(&comm.state, &mut comm_state_hashes);
                     }
                 });
+                mark.extend_with_source("execution-outputs", &detail, execution_output_hashes);
+                mark.extend_with_source("comm-outputs", &detail, comm_output_hashes);
+                mark.extend_with_source("comm-state", &detail, comm_state_hashes);
+
+                let mut arrow_child_hashes = std::collections::HashSet::new();
                 for hash in arrow_manifest_blob_hashes {
-                    collect_arrow_manifest_blob_hashes(&hash, &mut referenced_hashes, blob_store)
+                    collect_arrow_manifest_blob_hashes(&hash, &mut arrow_child_hashes, blob_store)
                         .await;
                 }
+                mark.extend_with_source("arrow-manifest-children", &detail, arrow_child_hashes);
+
                 {
+                    let mut resolved_asset_hashes = std::collections::HashSet::new();
+                    let mut attachment_hashes = std::collections::HashSet::new();
                     let doc = room.doc.read().await;
                     for cell in doc.get_cells() {
                         for hash in cell.resolved_assets.values() {
-                            referenced_hashes.insert(hash.clone());
+                            resolved_asset_hashes.insert(hash.clone());
                         }
                         for bundle in cell.attachments.values() {
                             for attachment_ref in bundle.values() {
-                                referenced_hashes.insert(attachment_ref.blob_hash.clone());
+                                attachment_hashes.insert(attachment_ref.blob_hash.clone());
                             }
                         }
                     }
+                    mark.extend_with_source("resolved-assets", &detail, resolved_asset_hashes);
+                    mark.extend_with_source("attachments", &detail, attachment_hashes);
                 }
             }
             tokio::task::yield_now().await;
@@ -4734,14 +4820,21 @@ impl Daemon {
                 );
                 for batch in persisted_paths.chunks(DOC_BATCH_SIZE) {
                     for path in batch {
-                        collect_hashes_from_persisted_doc(path, &mut referenced_hashes).await;
+                        let mut doc_hashes = std::collections::HashSet::new();
+                        if collect_hashes_from_persisted_doc(path, &mut doc_hashes).await {
+                            let detail = path
+                                .file_name()
+                                .map(|n| n.to_string_lossy().to_string())
+                                .unwrap_or_else(|| path.display().to_string());
+                            mark.extend_with_source("persisted-doc", &detail, doc_hashes);
+                        }
                     }
                     tokio::task::yield_now().await;
                 }
             }
         }
 
-        referenced_hashes
+        mark
     }
 
     /// Prune expired durable execution records, then return blob hashes
@@ -4795,6 +4888,11 @@ impl Daemon {
                                     age_secs > 0 && age_secs as u64 > blob_max_age.as_secs()
                                 });
                         if is_stale && blob_store.delete(hash).await.unwrap_or(false) {
+                            // Per-deletion audit line: when a sweep turns out
+                            // to have eaten a live blob, this is the record of
+                            // what was deleted and that no mark source
+                            // protected it.
+                            debug!("[runtimed] GC: swept unreferenced blob {hash}");
                             blobs_deleted += 1;
                         }
                     }
@@ -7905,17 +8003,54 @@ mod tests {
 
         let rooms: Vec<(String, Arc<crate::notebook_sync_server::NotebookRoom>)> = vec![];
         let blob_store = BlobStore::new(tmp.path().join("blobs"));
-        let refs = Daemon::collect_blob_refs_for_gc(&rooms, &docs_dir, &blob_store).await;
+        let mark = Daemon::collect_blob_refs_for_gc(&rooms, &docs_dir, &blob_store).await;
         assert!(
-            refs.contains("cafebabe"),
+            mark.hashes().contains("cafebabe"),
             "persisted-doc blob ref should be collected, got {:?}",
-            refs
+            mark.hashes()
         );
         assert!(
-            refs.contains("facefeed"),
+            mark.hashes().contains("facefeed"),
             "persisted-doc attachment ref should be collected, got {:?}",
-            refs
+            mark.hashes()
         );
+        let marker = mark
+            .first_marker("cafebabe")
+            .expect("marked hash should carry provenance");
+        assert!(
+            marker.starts_with("persisted-doc "),
+            "provenance should attribute the persisted-doc walk, got {marker:?}"
+        );
+        assert_eq!(mark.summary(), "persisted-doc=2");
+    }
+
+    #[test]
+    fn gc_mark_set_attributes_first_marker_and_counts_unique_contributions() {
+        let mut mark = GcMarkSet::default();
+        mark.extend_with_source(
+            "execution-outputs",
+            "room:a",
+            ["blob-1".to_string(), "blob-2".to_string()],
+        );
+        // blob-2 is also reachable from a persisted doc; the first marker
+        // wins and the second source counts only its unique contribution.
+        mark.extend_with_source(
+            "persisted-doc",
+            "untitled.automerge",
+            ["blob-2".to_string(), "blob-3".to_string()],
+        );
+
+        assert_eq!(mark.hashes().len(), 3);
+        assert_eq!(
+            mark.first_marker("blob-2"),
+            Some("execution-outputs room:a")
+        );
+        assert_eq!(
+            mark.first_marker("blob-3"),
+            Some("persisted-doc untitled.automerge")
+        );
+        assert_eq!(mark.summary(), "execution-outputs=2 persisted-doc=1");
+        assert_eq!(mark.first_marker("blob-unmarked"), None);
     }
 
     #[tokio::test]

--- a/docs/adr/blob-storage-and-content-addressing.md
+++ b/docs/adr/blob-storage-and-content-addressing.md
@@ -319,8 +319,13 @@ Garbage collection is a daemon-level mark-and-sweep that runs every 30 minutes
    retention window via `collect_execution_store_refs_for_gc`
    (`crates/runtimed/src/daemon.rs:3935-3939`). Arrow stream manifests get a
    second-pass walk that pulls referenced data blobs out of the manifest body
-   (`daemon.rs:4227, 4531-4532`). The mark produces one combined hash set
-   with no per-ref provenance; the punchlist tracks this opacity (BS-7).
+   (`daemon.rs:4227, 4531-4532`). The mark produces a `GcMarkSet` with
+   per-ref provenance (BS-7): each ref shape lands under its own category
+   (execution-outputs, comm-outputs, comm-state, arrow-manifest-children,
+   resolved-assets, attachments, persisted-doc, execution-store), the GC
+   loop logs per-category counts after every walk — a category that should
+   have refs reporting zero is the inventory bug made visible — and each
+   sweep deletion is logged at debug with its hash.
 2. **Skip guard.** If there are zero rooms loaded **and** no room has ever
    been loaded since daemon start, the sweep skips. That guard exists because
    "zero refs" is ambiguous in the post-restart window (we genuinely don't
@@ -577,7 +582,6 @@ These items were migrated from `docs/adr/cleanup-punchlist.md` when it was
 retired (2026-06-10). Severity: **Targeted PR** = one-or-two-file fix ready
 to implement; **Design** = needs a decision in this ADR before code moves.
 
-- **BS-7** (Targeted PR; GC instrumentation): GC mark walks rooms and persisted docs producing one combined hash set with no per-ref provenance. Any mark-miss is a silent data-loss bug at sweep time, with no debug surface to audit.
 - **BS-9** (Design; `crates/runtimed/src/blob_upload.rs` finalize path): `MAX_BLOB_SIZE = 100 MiB` only gates the in-process `BlobStore::put()` API. The multipart finalize path validates against the caller's `expected_size` and the per-peer 256 MiB staging budget but does not enforce a 100 MiB ceiling on the completed blob. A peer can multipart-upload a 200 MiB blob today.
 - **BS-10** (Design; `output_store.rs:62-89`): Save-to-`.ipynb` externalizes Arrow IPC and Parquet only via `BLOB_REF_MIME`; every other binary MIME is base64-inlined in the saved file. A user opening the saved `.ipynb` outside nteract gets self-contained binary for non-Arrow/Parquet but broken refs for the rest unless they keep the colocated blob store.
 - **BS-14** (Targeted PR; `apps/notebook-cloud/src/index.ts`, `crates/runtimed/src/daemon.rs`, `crates/runtimed-wasm/`): The hosted publish validator (TS, walks the materialized render projection via `collectSnapshotBlobRefs`) and the daemon GC mark (Rust, `collect_blob_refs_for_gc`) are two independent blob-ref inventories. A ref shape added to one and not the other is either a broken publish or a silent GC data-loss bug. Converge on one ref-walk exported from `runtimed-wasm`, or pin both walks against shared fixtures covering every ref shape (outputs, comms, attachments, resolved_assets, Arrow manifest children).


### PR DESCRIPTION
Resolves BS-7 from `docs/adr/blob-storage-and-content-addressing.md`.

The GC mark walked rooms and persisted docs into one combined hash set. The sweep deletes anything the mark did not reach, so a mark-miss was silent data loss with no surface to audit which walk should have protected the blob.

## What changed

`collect_blob_refs_for_gc` returns a `GcMarkSet` instead of a bare `HashSet`. Every ref shape lands under its own category:

| Category | Source |
|---|---|
| `execution-outputs` | RuntimeStateDoc execution outputs (per room) |
| `comm-outputs` | RuntimeStateDoc comm outputs (per room) |
| `comm-state` | recursive comm-state blob refs (per room) |
| `arrow-manifest-children` | second-pass arrow manifest data blobs |
| `resolved-assets` | NotebookDoc markdown image refs |
| `attachments` | NotebookDoc nbformat attachments |
| `persisted-doc` | on-disk `.automerge` walk (per file) |
| `execution-store` | durable execution records within retention |

Each marked hash also records a first-marker detail string (`execution-outputs room:abc`, `persisted-doc untitled-xyz.automerge`) answering "what protected this blob" for a specific hash.

The audit surface this buys:

- After every mark walk, the GC loop logs per-category counts at debug (`mark sources: execution-outputs=12 persisted-doc=40 ...`). A category that should have refs reporting zero is the inventory bug made visible - this is exactly the failure mode BS-14 worries about (a ref shape added to the publisher but not the GC walk).
- Every sweep deletion logs its hash at debug, so a sweep that ate a live blob leaves a record of what was deleted and that no source marked it.

Counts are of first marks: a hash reachable from two sources is attributed to whichever marked it first, so later categories report only their unique contributions (documented on the type). The helpers (`collect_blob_hashes` etc.) keep their `HashSet` signatures; call sites fold local sets in with a source label. `sweep_orphaned_blobs` keeps its signature and takes `mark.hashes()`.

## Verification

All 952 runtimed lib tests pass. The persisted-doc GC test now also asserts provenance attribution and the summary line; a new unit test pins first-marker-wins dedup semantics.
