### PR TITLE
fix(notebook): key markdown projection freshness on exact source

### DIFF
--- a/apps/notebook/src/components/MarkdownCell.tsx
+++ b/apps/notebook/src/components/MarkdownCell.tsx
@@ -28,6 +28,7 @@ import {
   type MarkdownProjectionRun,
   projectedMarkdownPreviewHeight,
   projectMarkdownPlan,
+  resolveMarkdownProjection,
 } from "../lib/markdown-projection";
 import { cn } from "@/lib/utils";
 import { usePresenceContext } from "../contexts/PresenceContext";
@@ -239,11 +240,15 @@ export const MarkdownCell = memo(function MarkdownCell({
     }
   }, [cell.source, draftPreviewSource]);
 
+  // Same resolution rule as the outline rail: a source-matching attached plan
+  // wins, an edited source reprojects, never render a plan for source the
+  // cell no longer holds. Keeps the preview and the rail on the same frozen
+  // plan object for a given source.
   const markdownProjection = useMemo(
     () =>
       draftPreviewSource !== null
         ? projectMarkdownPlan(draftPreviewSource)
-        : (cell.markdownProjection ?? projectMarkdownPlan(cell.source)),
+        : resolveMarkdownProjection(cell.markdownProjection, cell.source),
     [cell.markdownProjection, cell.source, draftPreviewSource],
   );
   const canRenderProjectionInHost = canRenderMarkdownProjectionInHost(markdownProjection);

--- a/src/components/notebook/__tests__/view-model.test.ts
+++ b/src/components/notebook/__tests__/view-model.test.ts
@@ -113,7 +113,7 @@ describe("notebook shell view model", () => {
     }
   });
 
-  it("treats attached empty markdownProjection anchors as authoritative", () => {
+  it("prefers current source projection over attached empty markdownProjection anchors", () => {
     let calls = 0;
     const restore = setMarkdownProjectionProjector((source) => {
       calls += 1;
@@ -125,39 +125,59 @@ describe("notebook shell view model", () => {
     try {
       const outline = notebookViewCellsToOutlineItems([markdownViewCell("intro", "# Intro", [])]);
 
-      expect(calls).toBe(0);
-      expect(outline).toHaveLength(1);
-      expect(outline[0]).toMatchObject({
-        id: "intro:cell",
-        kind: "cell",
-        headingAnchorId: null,
-      });
+      expect(calls).toBe(1);
+      expect(outline.map((item) => [item.id, item.title, item.anchor])).toEqual([
+        ["intro:heading:0", "Intro", "intro"],
+      ]);
     } finally {
       restore();
     }
   });
 
-  it("reprojects stale attached markdownProjection anchors from current source", () => {
+  it("reprojects same-length stale markdownProjection anchors from current source", () => {
     let calls = 0;
     const restore = setMarkdownProjectionProjector((source) => {
       calls += 1;
       return JSON.stringify(
-        testMarkdownProjection(source, [{ title: "More fun", level: 1, slug: "more-fun" }]),
+        testMarkdownProjection(
+          source,
+          source.includes("Deep in the emoji train")
+            ? [
+                { title: "Later section", level: 2, slug: "later-section" },
+                { title: "Deep in the emoji train", level: 3, slug: "deep-in-the-emoji-train" },
+                { title: "Deeper note", level: 3, slug: "deeper-note" },
+              ]
+            : [
+                { title: "Later section", level: 2, slug: "later-section" },
+                { title: "Deeper note", level: 3, slug: "deeper-note" },
+              ],
+        ),
       );
     });
 
     try {
-      const staleCell = markdownViewCell("intro", "Markdown body row", []);
+      const currentSource = "## Later section\n\n### Deep in the emoji train\n\n### Deeper note";
+      const staleSource = "## Later section\n\n### Deeper note\n\n".padEnd(
+        currentSource.length,
+        "X",
+      );
+      expect(currentSource.length).toBe(staleSource.length);
+      const staleCell = markdownViewCell("later", staleSource, [
+        { title: "Later section", level: 2, slug: "later-section" },
+        { title: "Deeper note", level: 3, slug: "deeper-note" },
+      ]);
       const outline = notebookViewCellsToOutlineItems([
         {
           ...staleCell,
-          source: "# More fun\n\nMarkdown body row",
+          source: currentSource,
         },
       ]);
 
       expect(calls).toBe(1);
       expect(outline.map((item) => [item.id, item.title, item.anchor])).toEqual([
-        ["intro:heading:0", "More fun", "more-fun"],
+        ["later:heading:0", "Later section", "later-section"],
+        ["later:heading:1", "Deep in the emoji train", "deep-in-the-emoji-train"],
+        ["later:heading:2", "Deeper note", "deeper-note"],
       ]);
     } finally {
       restore();

--- a/src/components/notebook/__tests__/view-model.test.ts
+++ b/src/components/notebook/__tests__/view-model.test.ts
@@ -113,7 +113,7 @@ describe("notebook shell view model", () => {
     }
   });
 
-  it("prefers current source projection over attached empty markdownProjection anchors", () => {
+  it("uses a source-matching attached projection without reprojecting", () => {
     let calls = 0;
     const restore = setMarkdownProjectionProjector((source) => {
       calls += 1;
@@ -123,15 +123,78 @@ describe("notebook shell view model", () => {
     });
 
     try {
-      const outline = notebookViewCellsToOutlineItems([markdownViewCell("intro", "# Intro", [])]);
+      const outline = notebookViewCellsToOutlineItems([
+        markdownViewCell("intro", "# Intro", [{ title: "Intro", level: 1, slug: "intro" }]),
+      ]);
 
-      expect(calls).toBe(1);
+      expect(calls).toBe(0);
       expect(outline.map((item) => [item.id, item.title, item.anchor])).toEqual([
         ["intro:heading:0", "Intro", "intro"],
       ]);
     } finally {
       restore();
     }
+  });
+
+  it("treats a source-matching attached empty projection as authoritative", () => {
+    let calls = 0;
+    const restore = setMarkdownProjectionProjector((source) => {
+      calls += 1;
+      return JSON.stringify(
+        testMarkdownProjection(source, [{ title: "Intro", level: 1, slug: "intro" }]),
+      );
+    });
+
+    try {
+      // The attached plan is keyed to this exact source, so it is the
+      // projector's own (headingless) answer — trusted without a reproject.
+      const outline = notebookViewCellsToOutlineItems([markdownViewCell("intro", "# Intro", [])]);
+
+      expect(calls).toBe(0);
+      expect(outline).toHaveLength(1);
+      expect(outline[0]).toMatchObject({
+        id: "intro:cell",
+        kind: "cell",
+        headingAnchorId: null,
+      });
+    } finally {
+      restore();
+    }
+  });
+
+  it("drops headings when markdown source is emptied past a stale projection", () => {
+    let calls = 0;
+    const restore = setMarkdownProjectionProjector((source) => {
+      calls += 1;
+      return JSON.stringify(
+        testMarkdownProjection(source, [{ title: "Ghost", level: 1, slug: "ghost" }]),
+      );
+    });
+
+    try {
+      const staleCell = markdownViewCell("ghost", "# Ghost", [
+        { title: "Ghost", level: 1, slug: "ghost" },
+      ]);
+      const outline = notebookViewCellsToOutlineItems([{ ...staleCell, source: "  \n" }]);
+
+      expect(calls).toBe(0);
+      expect(outline.filter((item) => item.kind === "heading")).toHaveLength(0);
+    } finally {
+      restore();
+    }
+  });
+
+  it("falls back to a stale attached projection when no projector is registered", () => {
+    // No setMarkdownProjectionProjector override: the module-level projector
+    // is unset in this suite, modeling a host without WASM markdown.
+    const staleCell = markdownViewCell("legacy", "# Old title", [
+      { title: "Old title", level: 1, slug: "old-title" },
+    ]);
+    const outline = notebookViewCellsToOutlineItems([{ ...staleCell, source: "# Renamed title" }]);
+
+    expect(outline.map((item) => [item.id, item.title, item.anchor])).toEqual([
+      ["legacy:heading:0", "Old title", "old-title"],
+    ]);
   });
 
   it("reprojects same-length stale markdownProjection anchors from current source", () => {
@@ -485,6 +548,7 @@ function testMarkdownProjection(
   return {
     version: 1 as const,
     engine: "test",
+    source,
     byteLength: source.length,
     utf16Length: source.length,
     measurement: {

--- a/src/components/notebook/view-model.ts
+++ b/src/components/notebook/view-model.ts
@@ -140,30 +140,13 @@ export function notebookViewCellsToOutlineItems(
 }
 
 function notebookViewCellMarkdownAnchors(cell: NotebookViewCell) {
-  // Live adapters attach markdownProjection during materialization/source edits.
-  // Treat a fresh attached projection as authoritative, including an empty
-  // anchor list for headingless markdown, so outline projection stays O(cells)
-  // in the common path. If the source has moved ahead of the projection, fall
-  // back to the source-keyed projector so outline headings update before a full
-  // rematerialization/reload.
-  if (
-    cell.markdownProjection &&
-    markdownProjectionMatchesSource(cell.markdownProjection, cell.source)
-  ) {
-    return cell.markdownProjection.anchors;
-  }
+  if (!cell.source.trim()) return [];
 
-  // This Rust/WASM fallback keeps older host adapters correct without reviving
-  // a second heading parser; projectMarkdownPlan is source-key cached.
-  return projectMarkdownPlan(cell.source)?.anchors ?? null;
-}
-
-function markdownProjectionMatchesSource(plan: MarkdownProjectionPlan, source: string): boolean {
-  return plan.utf16Length === source.length && plan.byteLength === markdownSourceByteLength(source);
-}
-
-function markdownSourceByteLength(source: string): number {
-  return new TextEncoder().encode(source).byteLength;
+  // Outline should track the current source, not merely an attached projection
+  // snapshot. The projector is source-key cached, so materialized cells reuse
+  // the existing plan while edited cells get a fresh heading list before a full
+  // rematerialization/reload catches up.
+  return projectMarkdownPlan(cell.source)?.anchors ?? cell.markdownProjection?.anchors ?? null;
 }
 
 export function notebookViewCellsToTracebackTargets(

--- a/src/components/notebook/view-model.ts
+++ b/src/components/notebook/view-model.ts
@@ -1,7 +1,10 @@
 import type { JupyterOutput } from "@/components/cell/jupyter-output";
 import type { ReadOnlyNotebookCellData } from "@/components/cell/ReadOnlyNotebook";
 import type { SupportedLanguage } from "@/components/editor/languages";
-import { projectMarkdownPlan, type MarkdownProjectionPlan } from "../../lib/markdown-projection";
+import {
+  resolveMarkdownProjection,
+  type MarkdownProjectionPlan,
+} from "../../lib/markdown-projection";
 import {
   notebookMetadataToPackageViewModel as projectNotebookPackageViewModel,
   type NotebookPackageViewModel,
@@ -140,13 +143,16 @@ export function notebookViewCellsToOutlineItems(
 }
 
 function notebookViewCellMarkdownAnchors(cell: NotebookViewCell) {
+  // Blank markdown has authoritatively no headings — `[]`, not `null`, so the
+  // outline does not treat the cell as "projection unavailable".
   if (!cell.source.trim()) return [];
 
-  // Outline should track the current source, not merely an attached projection
-  // snapshot. The projector is source-key cached, so materialized cells reuse
-  // the existing plan while edited cells get a fresh heading list before a full
-  // rematerialization/reload catches up.
-  return projectMarkdownPlan(cell.source)?.anchors ?? cell.markdownProjection?.anchors ?? null;
+  // resolveMarkdownProjection keys freshness on the plan's exact source: a
+  // matching attached plan keeps outline projection O(cells) without cache
+  // pressure, an edited cell reprojects from current source before
+  // rematerialization catches up, and a stale plan survives only in hosts
+  // with no registered projector.
+  return resolveMarkdownProjection(cell.markdownProjection, cell.source)?.anchors ?? null;
 }
 
 export function notebookViewCellsToTracebackTargets(

--- a/src/lib/__tests__/markdown-projection.test.ts
+++ b/src/lib/__tests__/markdown-projection.test.ts
@@ -7,7 +7,9 @@ import { beforeAll, describe, expect, it } from "vite-plus/test";
 import {
   canRenderMarkdownProjectionInHost,
   findMarkdownProjectionAtSourcePosition,
+  markdownProjectionMatchesSource,
   projectMarkdownPlan,
+  resolveMarkdownProjection,
   setMarkdownProjectionProjector,
 } from "../markdown-projection";
 
@@ -118,6 +120,56 @@ describe("markdown projection", () => {
       expect(Object.isFrozen(first?.runs)).toBe(true);
       expect(Object.isFrozen(first?.measurement)).toBe(true);
       expect(Object.isFrozen(first?.anchors[0])).toBe(true);
+    } finally {
+      restore();
+    }
+  });
+
+  it("stamps plans with their exact source for freshness checks", () => {
+    const source = "# Stamped";
+    const plan = projectMarkdownPlan(source);
+
+    expect(plan?.source).toBe(source);
+    expect(plan && markdownProjectionMatchesSource(plan, source)).toBe(true);
+    // Length-equal but different content must not match — this is the
+    // distinction the retired utf16/byte-length heuristic could not make.
+    expect("# Stamped".length).toBe("# Stampsd".length);
+    expect(plan && markdownProjectionMatchesSource(plan, "# Stampsd")).toBe(false);
+  });
+
+  it("resolves a source-matching attached plan by identity", () => {
+    const attached = projectMarkdownPlan("# Attached heading");
+
+    expect(attached).not.toBeNull();
+    expect(resolveMarkdownProjection(attached, "# Attached heading")).toBe(attached);
+  });
+
+  it("reprojects when the attached plan is stale, including same-length edits", () => {
+    const stale = projectMarkdownPlan("# Alpha title");
+    expect("# Alpha title".length).toBe("# Alpha titlE".length);
+
+    const resolved = resolveMarkdownProjection(stale, "# Alpha titlE");
+
+    expect(resolved).not.toBe(stale);
+    expect(resolved?.source).toBe("# Alpha titlE");
+    expect(resolved?.anchors.map((anchor) => anchor.title)).toEqual(["Alpha titlE"]);
+  });
+
+  it("resolves blank source to null rather than a stale attached plan", () => {
+    const stale = projectMarkdownPlan("# Ghost");
+
+    expect(stale).not.toBeNull();
+    expect(resolveMarkdownProjection(stale, "   \n")).toBeNull();
+  });
+
+  it("falls back to the stale attached plan when projection is unavailable", () => {
+    const stale = projectMarkdownPlan("# Keep me");
+    const restore = setMarkdownProjectionProjector(() => {
+      throw new Error("projector offline");
+    });
+
+    try {
+      expect(resolveMarkdownProjection(stale, "# Newer content")).toBe(stale);
     } finally {
       restore();
     }

--- a/src/lib/markdown-projection.ts
+++ b/src/lib/markdown-projection.ts
@@ -72,6 +72,15 @@ export interface MarkdownProjectionPlan {
   readonly byteLength: number;
   readonly utf16Length: number;
   readonly error?: string;
+  /**
+   * Exact source this plan was projected from. Stamped by
+   * `projectMarkdownPlan`; absent on plans that arrive as MIME payloads
+   * (`markdownProjectionPlanFromMimeData`), which are output data and never
+   * validated against a cell source. This is the freshness key: consumers
+   * holding an attached plan check `source` identity instead of inferring
+   * freshness from lengths, which falsely matches same-length edits.
+   */
+  readonly source?: string;
   readonly measurement: MarkdownProjectionMeasurement;
   readonly anchors: readonly MarkdownProjectionAnchor[];
   readonly blocks: readonly MarkdownProjectionBlock[];
@@ -122,6 +131,42 @@ export function projectMarkdownPlan(source: string): MarkdownProjectionPlan | nu
   }
 }
 
+/** Exact freshness check: the plan was projected from precisely this source. */
+export function markdownProjectionMatchesSource(
+  plan: MarkdownProjectionPlan,
+  source: string,
+): boolean {
+  return plan.source === source;
+}
+
+/**
+ * Resolve the projection for a cell's current source. The single resolution
+ * rule every React surface (outline rail, markdown preview) shares, so they
+ * all consume the same frozen plan object for a given source:
+ *
+ * 1. An attached plan whose `source` matches exactly wins. Attach sites
+ *    produce plans through `projectMarkdownPlan`, so a matching record IS the
+ *    projector's output for this source — same object the cache would return,
+ *    without cache pressure when a notebook outgrows the LRU limit.
+ * 2. Otherwise project from the current source (source-key cached), so
+ *    surfaces update while typing, before rematerialization re-attaches.
+ * 3. A stale attached plan is returned only when no projector is registered
+ *    in this host — stale headings beat dropping the projection entirely.
+ *
+ * Blank source resolves to null: the projector has nothing to parse, and
+ * falling back to a stale plan would resurrect content the user deleted.
+ */
+export function resolveMarkdownProjection(
+  attached: MarkdownProjectionPlan | null | undefined,
+  source: string,
+): MarkdownProjectionPlan | null {
+  if (!source.trim()) return null;
+  if (attached && markdownProjectionMatchesSource(attached, source)) {
+    return attached;
+  }
+  return projectMarkdownPlan(source) ?? attached ?? null;
+}
+
 function warnMissingMarkdownProjectionProjector(): void {
   if (warnedMissingMarkdownProjectionProjector) return;
   warnedMissingMarkdownProjectionProjector = true;
@@ -138,7 +183,7 @@ function cacheMarkdownProjectionPlan(
   source: string,
   plan: MarkdownProjectionPlan,
 ): MarkdownProjectionPlan {
-  const cachedPlan = freezeMarkdownProjectionPlan(plan);
+  const cachedPlan = freezeMarkdownProjectionPlan({ ...plan, source });
   markdownProjectionCache.set(source, cachedPlan);
   if (markdownProjectionCache.size <= MARKDOWN_PROJECTION_CACHE_LIMIT) return cachedPlan;
 


### PR DESCRIPTION
The outline rail could show stale headings because the attached `markdownProjection`'s freshness check compared utf16/byte lengths, which falsely matches same-length edits. And the staleness class was wider than the rail: the markdown preview (`MarkdownCell`) trusted the attached snapshot with **no** freshness check at all, so the rail and the rendered cell could disagree about the same source.

## Design

The projection plan now carries the exact source it was projected from, stamped in `projectMarkdownPlan`. The plan already carried `utf16Length`/`byteLength` as a proxy for the source key; this replaces the proxy with the actual key. One shared resolver, `resolveMarkdownProjection(attached, source)`, encodes the rule for every React surface:

1. **An attached plan whose `source` matches exactly wins.** Attach sites (`materialize-cells`, `cell-store`) produce plans through the same projector, so a matching record is the projector's own cached output for that source. This keeps outline projection O(cells) with no LRU pressure - a notebook with more markdown cells than the 128-entry projection cache would otherwise re-run the WASM parser for every cell on every keystroke. The string compare is usually reference equality, since the source strings flow from one store.
2. **Otherwise reproject from current source** (source-key cached), so surfaces update while typing, before rematerialization re-attaches.
3. **A stale plan survives only when no projector is registered** in the host - stale headings beat dropping the projection entirely.

Blank source resolves to `null`, and the outline maps it to an authoritative empty anchor list - emptying a cell cannot resurrect deleted headings through the stale fallback.

Both consumers - the outline anchor path (`view-model.ts`) and the markdown preview (`MarkdownCell.tsx`) - go through the resolver, so they render from the same frozen plan object for a given source. That is the "thread a deterministic projection record keyed to source content" follow-up this PR's first cut deferred; the source-key cache plus the stamp is that record, with object identity guaranteed by the cache's frozen plans.

Plans arriving as MIME payloads (`markdownProjectionPlanFromMimeData`) carry no source stamp and are never source-validated - they are output data, not cell projections.

## Behavioral coverage

| Scenario | Before (length heuristic) | First cut (always reproject) | Now (exact key) |
|---|---|---|---|
| Attached plan, source unchanged | trusted | reprojected (cache hit) | trusted, zero projector calls |
| Same-length edit | **stale headings** | fresh | fresh |
| Different-length edit | fresh | fresh | fresh |
| Cell emptied, stale plan attached | stale via fallback | `[]` via blank guard | `null`/`[]`, stale never consulted |
| Host without projector | stale fallback | stale fallback | stale fallback |
| Preview (`MarkdownCell`) | attached trusted unconditionally | attached trusted unconditionally | same resolver as the rail |

Heading IDs changing across edits is expected - headings are user content, and cell-ID anchors remain the stable navigation fallback.

## Validation

- `pnpm test:run src/components/notebook src/components/markdown src/lib apps/notebook/src` - 885 tests green, including new resolver tests against the real WASM projector (exact-match identity, same-length reprojection, blank-source null, projector-offline fallback) and view-model tests pinning zero projector calls on the matched path
- `pnpm --dir apps/notebook exec tsc -b`
- `cargo xtask lint --fix`
