### PR TITLE
docs: nono-prototype review and fresh-branch implementation plan

### DIFF
--- a/docs/handoffs/2026-06-10-nono-fresh-branch-plan.md
+++ b/docs/handoffs/2026-06-10-nono-fresh-branch-plan.md
@@ -1,0 +1,143 @@
+# Plan: feature-flagged nono credential injection, fresh from main
+
+Implementation plan for re-doing the `nono-prototype` spike as a clean,
+feature-flagged feature starting from `origin/main`. Companion to
+`2026-06-10-nono-prototype-review.md` (keep/redo map). The prototype branch
+stays unmerged; agents implementing this should read its `docs/sandbox/`
+decisions and empirical docs as reference, not cherry-pick its code.
+
+## Flag architecture: one source of truth
+
+Principle: the daemon computes a single **effective sandbox capability** and
+advertises it. Frontend and MCP read the advertisement; nothing else makes an
+independent platform/availability decision.
+
+### 1. Daemon master switch
+
+- Add `sandbox_nono: bool` (default `false`) to `SyncedSettings`
+  (`crates/runtimed-client/src/settings_doc.rs:232`) and to `FeatureFlags`
+  (`crates/notebook-protocol/src/protocol.rs:27`), wired through
+  `SyncedSettings::feature_flags()` (`settings_doc.rs:352`). This is the
+  repo's documented flag recipe — one field per layer, no schema migration —
+  and it rides the existing settings sync and `LaunchedEnvConfig` snapshot
+  for free. Optional `RUNTIMED_SANDBOX=1` env override OR'd in for dev,
+  mirroring `RUNTIMED_DEV` style.
+- Effective capability, computed in one place (a `Daemon::sandbox_capability()`
+  next to `Daemon::feature_flags()`, `crates/runtimed/src/daemon.rs:1265`):
+
+  ```
+  flag_enabled
+    && cfg!(any(target_os = "macos", target_os = "linux"))
+    && nono binary resolvable (env override → sibling of runtimed → PATH)
+  ```
+
+- Daemon behaviors gated on it:
+  - Never seed `metadata.runt.sandbox` into new notebooks (restores D-3
+    opt-in regardless of flag).
+  - `requests/launch_kernel.rs` / auto-launch in
+    `notebook_sync_server/metadata.rs`: when capability is off, ignore any
+    profile in metadata (log it) and launch direct — a shared sandbox
+    notebook degrades gracefully on a non-flagged machine instead of
+    refusing to launch.
+  - Spawn nono `startup_check()` only when the flag is on.
+
+### 2. Capability advertisement to clients
+
+- Add `sandbox: Option<SandboxCapability>` to `ProtocolCapabilities`
+  (`crates/notebook-protocol/src/connection/handshake.rs:137`), following the
+  existing `put_blob: Option<PutBlobCapability>` pattern. `None` = unsupported;
+  old clients ignore the key, old daemons omit it.
+
+  ```rust
+  struct SandboxCapability {
+      version: u32,
+      nono_version: Option<String>,
+      credential_store: bool, // macOS yes; Linux sandbox-yes/keychain-no
+  }
+  ```
+
+- Plumb via the existing path: `NotebookConnectionInfo.capabilities` →
+  Tauri `DaemonReadyPayload` (`crates/notebook/src/lib.rs:407`; see how
+  `actor_label`/`connection_scope` flow at lines 608/688/760) →
+  `packages/notebook-host/src/types.ts`.
+
+### 3. Frontend gate
+
+- One `useSandboxFeatureEnabled()` hook reading the daemon-ready payload.
+  Gate the toolbar badge+sheet block, degraded banner, restart-needed logic,
+  and the CodeCell annotation lookup (~4 one-line conditionals; all read
+  sites are new).
+- Gate the credential manager surface on `credential_store` within the
+  capability (hides it on Linux/browser hosts).
+- Settings toggle: one entry in `FEATURE_FLAG_METADATA`
+  (`src/hooks/useSyncedSettings.ts:123`) — settings UI auto-renders it.
+
+### 4. MCP gate
+
+- Follow the `no_show` precedent (`crates/runt-mcp/src/lib.rs:60`): capture
+  the capability at startup where `daemon_version` is captured (`lib.rs:103`),
+  filter sandbox tools out of `list_tools` when off, and have `dispatch`
+  return "sandbox feature is disabled on this daemon" (not "unknown tool")
+  for nicer agent errors. Skip `sandbox_event` injection in execution results
+  when off.
+
+### 5. Build/CI gate (independent of runtime flag)
+
+- xtask `ensure_nono_binary`: warn-and-skip by default;
+  `NTERACT_REQUIRE_NONO=1` makes it fatal (set in release jobs once
+  distribution is wired). Runtime capability (binary absent → off) keeps
+  behavior coherent either way.
+- Release bundling — `binaries/nono-{triple}` in `tauri.conf.json`
+  `externalBin`, download/verify steps in `release-common.yml`, macOS
+  codesign/notarize of the third-party binary — lands as its own later PR
+  without changing any runtime gate.
+
+Net new flag surface: one `SyncedSettings` boolean + one optional
+`ProtocolCapabilities` field. Everything else derives from those two.
+
+## PR staging
+
+Each PR compiles, passes `cargo xtask lint --fix` + tests, and is inert
+without the flag.
+
+1. **`feat(runtimed): nono supervisor, profile translator, event parsing`**
+   — `crates/runtimed/src/nono/` (supervisor, profile, events, enrichment)
+   + `notebook-doc` sandbox profile types, ts-rs derives, unit tests, ported
+   `docs/sandbox/` decisions + empirical docs. No call sites; dead code
+   allowed behind `#[allow]` or wired only from tests. Re-derive the
+   supervisor from the prototype's empirical docs against the **open
+   questions** in the review doc (dual-PID kill ordering on all exit paths;
+   enrichment off the bounded output transport; annotation GC/persistence).
+2. **`feat(runtimed): sandbox flag, capability, and launch integration`**
+   — `SyncedSettings`/`FeatureFlags` field, `Daemon::sandbox_capability()`,
+   `ProtocolCapabilities.sandbox`, launch-chain integration on the `Kernel`
+   dispatch enum (sandbox accessors delegating to `Jupyter`,
+   `Disabled`/`None` for `Test`), `cell_annotations` in RuntimeStateDoc,
+   `GetSandboxState` request. Must update
+   `notebook-protocol/src/typescript.rs` discriminant lists and regenerate
+   TS bindings (`cargo run -p notebook-protocol --bin
+   generate-runtimed-types`) — main's exhaustiveness tests fail otherwise.
+   Add the new request to the `NotebookWrite` scope arm in `peer_writer.rs`
+   (main split scopes since the fork).
+3. **`feat(notebook): credential store + sandbox UI behind the flag`**
+   — keyring-backed credential commands, `HostCredentials`, SandboxPanel /
+   CredentialManager / badge / annotation overlay, all behind
+   `useSandboxFeatureEnabled()`. Fix the prototype's known UI defects: one
+   validator (ts-rs or shared fixtures), dirty-flag before auto-save,
+   fine-grained `useCellAnnotation` projection, surfaced keychain errors.
+4. **`feat(runt-mcp): sandbox tools behind capability`** — the four tools
+   with the `no_show`-style filter; MCP reads the same credential index as
+   the UI (no `security dump-keychain`, never `-g`); explicit-`null`
+   semantics for profile removal; honest tool schemas.
+5. **`build: bundle nono in release artifacts`** — externalBin, release-job
+   download/verify, codesigning. Last, independently revertable.
+
+xtask vendoring (warn-and-skip version) can ride PR 1 or 2 — whichever first
+needs the binary for an integration test.
+
+## Suggested first step
+
+Port `docs/sandbox/decisions.md` from the prototype into the fresh branch
+(amending D-3's implementation note and recording the flag architecture above
+as new decisions), so agents implementing PRs 1–5 have the authoritative
+context in-tree.

--- a/docs/handoffs/2026-06-10-nono-prototype-review.md
+++ b/docs/handoffs/2026-06-10-nono-prototype-review.md
@@ -1,0 +1,168 @@
+# Review: nono-prototype branch (keep / redo map)
+
+Anil's `nono-prototype` branch (tip `7cadac08`, 24 commits, forked from main at
+`b3b10f59`) spikes [nono.sh](https://nono.sh) as a credential-injecting network
+proxy wrapped around Python kernel launch. Per Anil, the branch stays unmerged
+as **reference material**; the real implementation starts fresh from `main`
+(see `2026-06-10-nono-fresh-branch-plan.md`). This doc maps what the prototype
+got right (reuse the design) versus what was prototype-grade (redo).
+
+Review coverage: frontend + MCP surface (complete), rebase/merge risk vs main
+(complete), feature-flag and packaging strategy (complete). Daemon supervisor
+internals and CRDT-layer reviews were cut short; partial findings are flagged
+below.
+
+## Keep: designs validated by review
+
+**The locked decisions doc.** `docs/sandbox/decisions.md` on the branch
+(D-1..D-11) is solid and should be ported nearly verbatim: vendored pinned
+nono binary, opt-in profile at `metadata.runt.sandbox`, `--env-credential`
+(not `--credential`, which only supports a fixed service list), dual-PID
+tracking (empirical: SIGKILL on nono does NOT propagate to the kernel
+grandchild), annotations in `RuntimeStateDoc.cell_annotations` following the
+`workstation` lazily-written-post-genesis precedent, names-only MCP listing
+with no `create_credential` tool.
+
+**The secret-value path.** Verified clean end to end: dialog state →
+`host.credentials.add/updateValue` → Tauri invoke → `keyring::Entry::set_password`
+→ Keychain. The index file (`~/.config/nteract/credentials.json`) holds only
+name→description. Nothing writes secret values to the Automerge doc, no value
+logging, list/update never echo values, the browser host throws on mutation,
+and `list_credentials` has a unit test asserting no `value` field.
+
+**The host abstraction.** `HostCredentials` in
+`packages/notebook-host/src/types.ts` follows the NotebookHost pattern
+correctly (tauri impl real, browser impl stubbed).
+
+**Cell annotation overlay placement.** Renders inside `outputContent` above
+`OutputArea` within the same cell; `NotebookView` ordering untouched, so the
+stable-DOM-order invariant holds — annotations appear/disappear without
+reloading output iframes.
+
+**Vendoring mechanics (shape, not failure mode).** `ensure_nono_binary` in
+xtask pins `0.62.0`, verifies hardcoded SHA-256 per target triple
+(macOS/Linux, both arches), caches under `target/nono-cache/`, and copies next
+to `runtimed`. Runtime discovery is `NONO_BIN` env → sibling of the runtimed
+executable → PATH, with a non-fatal daemon `startup_check()`. Keep the shape;
+fix the panic-on-network-failure (below).
+
+**Reference docs.** `docs/sandbox/` on the branch contains ~4k lines of
+empirical findings (nono process-tree behavior, error-signal formats, network
+architecture) and 12 staged task docs. The empirical docs are the most
+valuable artifact of the spike — port them.
+
+## Redo: prototype-grade problems
+
+### Blockers (would have stopped a merge)
+
+1. **D-3 violated — sandbox seeded `enabled: true` on every new notebook.**
+   `notebook_sync_server/load.rs` (two sites) contradicts the branch's own
+   opt-in decision. On any machine without nono, every new notebook fails
+   kernel launch (the launch path refuses rather than silently falling back).
+   This is the single most important thing the fresh branch must not repeat.
+
+2. **Tests fail on the branch as-is.** 6 frontend test failures (sandbox-panel
+   tests click a "Save profile" button that no longer exists after a move to
+   auto-save; status-badge tests assert stale rendering/labels) and 1 Rust
+   failure (`credentials.rs` validator allows hyphens while its own test
+   expects `my-token` rejected). The daemon-review agent also found at least
+   one branch test that does not compile (review cut short before details).
+
+3. **Four credential-name validators disagree.** UI regexes accept hyphens;
+   `src/sandbox/types.ts` and `notebook-doc/src/sandbox.rs` reject them. A
+   user can create keychain credential `my-key`, reference it, and the profile
+   validator silently never saves (auto-save returns early). The "must stay in
+   sync with the Rust validator" comment is false. Fresh branch: one validator
+   in Rust, ts-rs-exported or shared-fixture-tested.
+
+4. **Incompatible with main's kernel dispatch.** Main introduced the `Kernel`
+   enum (`kernel_dispatch.rs`) + `TestKernel`; the prototype hangs
+   `sandbox_state` / `sandbox_event_stream` off `JupyterKernel` and reads them
+   in `runtime_agent.rs`. Neither side's hunk compiles in a merge. Fresh
+   branch: sandbox accessors live on the `Kernel` enum from day one
+   (`Disabled`/`None` for `Test`).
+
+### Should-fix (carry the lessons forward)
+
+5. **MCP keychain probe leaks the secret into the MCP process.**
+   `runt-mcp/tools/sandbox.rs` shells `security find-generic-password ... -g`;
+   `-g` prints the password to stderr, captured by `.output()`. Existence
+   checks don't need `-g`, and it risks keychain prompts hanging the tool.
+
+6. **MCP/UI list inconsistency + parser bug.** MCP enumerates via
+   `security dump-keychain` filtered with `svce.starts_with("nono")` (matches
+   unrelated services); the UI reads `credentials.json`. They can disagree.
+   The dump parser also mis-attributes accounts when `svce` precedes `acct`
+   in a block. Fresh branch: MCP reads the same index the UI uses.
+
+7. **`set_notebook_sandbox_profile` with `{}` silently wipes the profile** —
+   missing key treated as explicit `null`. Tool schemas also advertise
+   `notebook_id`/`runtime_id` params the handlers ignore.
+
+8. **Hand-written TS mirrors instead of ts-rs, drift already present.**
+   `SandboxStateInfo` in `packages/runtimed/src/runtime-state.ts` is missing
+   `session_id` (Active) and `stderr_tail` (StartupFailed) vs the Rust type.
+   Repo convention is ts-rs generation; use it.
+
+9. **CodeCell subscribes to the whole runtime state** via `useRuntimeState()`
+   to read one annotation — every cell re-renders on every RuntimeStateDoc
+   sync. Use a fine-grained projection (`useCellAnnotation(executionId)`).
+
+10. **SandboxPanel auto-saves on mount and echoes peer writes** — opening the
+    panel stamps `metadata.runt.sandbox` into notebooks that never had it and
+    re-writes the metadata snapshot on every inbound peer change. Needs a
+    user-actually-edited dirty flag.
+
+11. **xtask vendoring panics on network failure / unsupported triple** —
+    breaks network-restricted CI and dev machines. Make it warn-and-skip by
+    default, hard-require only in release jobs (`NTERACT_REQUIRE_NONO=1`).
+
+12. **Silent keychain-list failures** render every credential as "missing on
+    this machine" and invite the user to re-enter secrets. Surface the error.
+
+13. **No feature gating anywhere.** Badge/panel/banner unconditional in
+    `App.tsx`, four MCP tools unconditionally registered, Tauri credential
+    commands always live, daemon seeds profiles. The fresh plan gates all of
+    it from one daemon-computed capability.
+
+14. **Protocol doc/wire mismatch** — `protocol.rs` comment documents
+    `{ "type": ... }` but the serde tag is `state`.
+
+### Main has moved (46 commits since the fork)
+
+Beyond the `Kernel` enum: main added protocol exhaustiveness tests
+(`notebook-protocol/src/typescript.rs` hard-codes discriminant lists +
+generated-bindings-current check), so any new request/response variant must
+update the generator lists and regenerate TS bindings or CI fails. Main also
+split `peer_writer.rs` scopes (`NotebookWrite` + `BlobUpload`), reworked the
+runtime_agent main loop (deferred launch-on-attach), consolidated runtime
+binaries/install flow, and refactored frontend focus state into the shared
+store. One prototype commit (`4f410012`) is a byte-identical cherry-pick of
+main's #3546 — already landed.
+
+### Platform reality (as written)
+
+Effectively macOS-only end to end. Linux: nono supports Landlock and the
+supervisor has `/proc`-based child discovery, but `keyring` is built with only
+`apple-native`, so there is no working credential store and MCP silently
+reports `keychain_present: false`. Windows: vendoring is a no-op stub, child
+discovery returns empty, signals are `#[cfg(unix)]`. Error copy hardcodes
+"macOS denied access to the keychain". The fresh branch should advertise a
+per-platform capability rather than rendering a uniform UI everywhere.
+
+### Open questions (reviews cut short)
+
+The daemon-internals review (supervisor kill ordering vs D-4, control-plane
+vs output-transport invariant for enrichment, events.rs parsing brittleness)
+and the CRDT review (concurrent profile-edit convergence, annotation GC,
+`rebuild_from_save` carrying `cell_annotations` through doc trims) were
+stopped early. The fresh implementation should treat these as design review
+items, not assume the prototype's answers are validated:
+
+- Does the dual-PID shutdown order (kernel first, then nono) hold on every
+  exit path, including unexpected nono death?
+- Does sandbox event enrichment stay off the bounded output transport so it
+  can never backpressure `KernelIdle`/`ExecutionDone`?
+- Are `cell_annotations` bounded (cleared on restart? GC'd with executions?)
+  and preserved across document save/load and trim?
+- Do concurrent `metadata.runt.sandbox` edits converge to a valid profile?


### PR DESCRIPTION
## Summary

Review of Anil's spike on the `nono-prototype` branch — [nono.sh](https://nono.sh) credential injection for Python kernels — plus a staged implementation plan for redoing it cleanly from `main` behind a feature flag.

Per the Slack discussion, the prototype branch stays unmerged as **reference material**; this PR adds two handoff docs so agents (and humans) implementing the real feature have the context in-tree:

- **`docs/handoffs/2026-06-10-nono-prototype-review.md`** — keep/redo map of the prototype. Keep: the locked decisions (D-1..D-11), the verified-clean secret-value path (keychain only, names-only everywhere else), the HostCredentials abstraction, the annotation overlay placement (stable-DOM-order safe), and ~4k lines of empirical nono findings. Redo: `sandbox.enabled: true` seeded into every new notebook (violates the prototype's own opt-in decision D-3), 7 failing tests, four disagreeing credential-name validators, incompatibility with main's new `Kernel` dispatch enum, a `security find-generic-password -g` call that leaks secret values into the MCP process, and hand-written TS mirrors with drift already present.
- **`docs/handoffs/2026-06-10-nono-fresh-branch-plan.md`** — flag architecture and PR staging. One `sandbox_nono` boolean in `SyncedSettings`, the daemon computes effective capability (flag && platform && nono binary present) and advertises it via `ProtocolCapabilities` (the `put_blob` pattern), frontend and MCP derive from that single advertisement. Five staged PRs, each inert without the flag: supervisor crates → flag + launch integration → UI → MCP tools → release bundling.

Caveat noted in the review doc: the daemon-internals and CRDT-layer reviews were cut short, so dual-PID kill ordering, enrichment vs the bounded-transport invariant, `cell_annotations` GC, and concurrent profile-edit convergence are listed as open design-review items for the implementation, not validated findings.

## Test plan

- [x] `cargo xtask lint --fix` passes (docs-only change)