### PR TITLE
fix(notebook): polish rail ui interactions

### DIFF
--- a/apps/notebook/src/components/NotebookView.tsx
+++ b/apps/notebook/src/components/NotebookView.tsx
@@ -16,7 +16,7 @@ import {
   verticalListSortingStrategy,
 } from "@dnd-kit/sortable";
 import { CSS as DndCSS } from "@dnd-kit/utilities";
-import { Code2, Plus, RotateCcw, Trash2, X } from "lucide-react";
+import { Eye, EyeOff, Plus, RotateCcw, Trash2, X } from "lucide-react";
 import { memo, useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { notebookCellAnchorId, type NotebookInteractionTarget } from "runtimed";
 import { CellInsertionRibbon, type CellInsertionType } from "@/components/cell/CellInsertionRibbon";
@@ -841,7 +841,11 @@ function NotebookViewContent({
               )}
               title={isSourceHidden ? "Show input" : "Hide input"}
             >
-              <Code2 className="h-3.5 w-3.5" />
+              {isSourceHidden ? (
+                <Eye className="h-3.5 w-3.5" />
+              ) : (
+                <EyeOff className="h-3.5 w-3.5" />
+              )}
             </button>
           ) : null;
         const visibleDeleteButton = !isSourceHidden ? deleteButton : null;

--- a/apps/notebook/src/components/__tests__/PackageSpecList.test.tsx
+++ b/apps/notebook/src/components/__tests__/PackageSpecList.test.tsx
@@ -226,7 +226,7 @@ describe("DependencyHeader rail package copy", () => {
     expect(actions).toHaveTextContent("Copy to notebook");
   });
 
-  it("splits project environment copy into fact and action lines", () => {
+  it("shows the project file without redundant status copy", () => {
     render(
       <DependencyHeader
         variant="rail"
@@ -252,7 +252,8 @@ describe("DependencyHeader rail package copy", () => {
 
     expect(screen.getByText("Using")).toBeVisible();
     expect(screen.getAllByText("pyproject.toml").length).toBeGreaterThan(0);
-    expect(screen.getByText("Re-initialize after dependency changes.")).toBeVisible();
+    expect(screen.queryByText("Kernel uses this file.")).not.toBeInTheDocument();
+    expect(screen.queryByText("Re-initialize after dependency changes.")).not.toBeInTheDocument();
     expect(screen.queryByText("Project env")).not.toBeInTheDocument();
   });
 

--- a/src/components/cell/CellInsertionRibbon.tsx
+++ b/src/components/cell/CellInsertionRibbon.tsx
@@ -96,11 +96,11 @@ export function CellInsertionRibbon({
       : null;
 
     return cn(
-      "inline-flex h-6 items-center justify-center gap-1 border border-transparent px-2.5 text-xs font-medium text-muted-foreground/55 transition-colors",
+      "relative inline-flex h-6 items-center justify-center gap-1 border border-transparent px-2.5 text-xs font-medium text-muted-foreground/55 transition-colors",
       "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/30",
       isBridged ? "rounded-none" : "rounded-full",
       bridgeActiveType === type && "rounded-l-none rounded-r-full",
-      bridgeActiveType === "code" && type === "markdown" && "ml-1",
+      bridgeActiveType && type === "markdown" && "ml-1",
       isActive
         ? actionButtonIntentClasses[type]
         : isBridgeLead && bridgeClasses
@@ -217,13 +217,13 @@ export function CellInsertionRibbon({
         data-slot="cell-adder-actions"
         aria-hidden={isOpen ? undefined : true}
         className={cn(
-          "flex min-w-0 flex-1 items-center transition-[opacity,transform] duration-150 ease-out",
+          "flex min-w-0 flex-1 items-center transition-opacity duration-150 ease-out",
           terminal && "pt-0.5",
           forceActionsVisible
-            ? "translate-x-0 opacity-100"
+            ? "opacity-100"
             : isOpen
-              ? "pointer-events-auto translate-x-0 opacity-100"
-              : "pointer-events-none -translate-x-1 opacity-0 transition-none",
+              ? "pointer-events-auto opacity-100"
+              : "pointer-events-none opacity-0 transition-none",
         )}
       >
         <span
@@ -248,6 +248,17 @@ export function CellInsertionRibbon({
             onClick={() => onInsert("code")}
             className={actionButtonClass("code")}
           >
+            {bridgeActiveType === "markdown" ? (
+              <span
+                data-slot="cell-adder-action-bridge-gap"
+                className={cn(
+                  "pointer-events-none absolute left-full top-1/2 h-6 w-1 -translate-y-1/2 border-y",
+                  insertionBridgeSurfaceClasses.markdown,
+                  insertionBridgeBorderClasses.markdown,
+                )}
+                aria-hidden="true"
+              />
+            ) : null}
             <Code className="h-3 w-3" aria-hidden="true" />
             <span>Code</span>
           </button>

--- a/src/components/cell/__tests__/CellInsertionRibbon.test.tsx
+++ b/src/components/cell/__tests__/CellInsertionRibbon.test.tsx
@@ -82,30 +82,33 @@ describe("CellInsertionRibbon", () => {
 
     expect(actions).not.toHaveAttribute("aria-hidden");
     expect(actions).toHaveClass("pointer-events-auto");
-    expect(actions).toHaveClass("translate-x-0");
+    expect(actions).not.toHaveClass("-translate-x-1");
+    expect(actions).not.toHaveClass("translate-x-0");
     expect(actions).not.toHaveClass("delay-75");
     expect(addCodeButton).toHaveAttribute("tabindex", "0");
     expect(addMarkdownButton).toHaveAttribute("tabindex", "0");
   });
 
-  it("reveals the insertion rule and action buttons on the same timeline", () => {
+  it("reveals the insertion rule and action buttons without translating the row", () => {
     const { container } = render(<CellInsertionRibbon onInsert={() => undefined} />);
 
     const hitTarget = container.querySelector('[data-slot="cell-adder-primary-hit-target"]');
     const actions = container.querySelector('[data-slot="cell-adder-actions"]');
 
-    expect(actions).toHaveClass("-translate-x-1");
+    expect(actions).not.toHaveClass("-translate-x-1");
 
     fireEvent.pointerEnter(hitTarget!);
 
     expect(container.querySelector('[data-slot="cell-adder-primary-bridge"]')).toBeInTheDocument();
-    expect(actions).toHaveClass("transition-[opacity,transform]");
+    expect(actions).toHaveClass("transition-opacity");
     expect(actions).toHaveClass("pointer-events-auto");
-    expect(actions).toHaveClass("translate-x-0");
+    expect(actions).not.toHaveClass("translate-x-0");
     expect(actions).toHaveClass("opacity-100");
     expect(actions).not.toHaveClass("delay-75");
     expect(screen.getByTitle("Add code cell")).toHaveAttribute("tabindex", "0");
     expect(screen.getByTitle("Add markdown cell")).toHaveAttribute("tabindex", "0");
+    expect(screen.getByTitle("Add markdown cell")).toHaveClass("ml-1");
+    expect(container.querySelector('[data-slot="cell-adder-action-bridge-gap"]')).toBeNull();
   });
 
   it("uses the controlled active type for catalog fixtures", () => {
@@ -117,6 +120,7 @@ describe("CellInsertionRibbon", () => {
     const palette = container.querySelector('[data-slot="cell-adder-action-palette"]');
     const hitTarget = container.querySelector('[data-slot="cell-adder-primary-hit-target"]');
     const primaryBridge = container.querySelector('[data-slot="cell-adder-primary-bridge"]');
+    const actionBridgeGap = container.querySelector('[data-slot="cell-adder-action-bridge-gap"]');
     const intent = container.querySelector('[data-slot="cell-adder-ribbon-intent"]');
     const leadingRule = container.querySelector('[data-slot="cell-adder-leading-rule"]');
     const trailingRule = container.querySelector('[data-slot="cell-adder-trailing-rule"]');
@@ -144,11 +148,17 @@ describe("CellInsertionRibbon", () => {
     expect(screen.getByTitle("Add markdown cell")).toHaveClass("text-emerald-700");
     expect(screen.getByTitle("Add markdown cell")).toHaveClass("rounded-l-none");
     expect(screen.getByTitle("Add markdown cell")).toHaveClass("border-emerald-500/20");
+    expect(screen.getByTitle("Add markdown cell")).toHaveClass("ml-1");
     expect(screen.getByTitle("Add code cell")).toHaveClass("bg-emerald-500/12");
     expect(screen.getByTitle("Add code cell")).toHaveClass("border-emerald-500/20");
     expect(screen.getByTitle("Add code cell")).toHaveClass("border-x-0");
     expect(screen.getByTitle("Add code cell")).toHaveClass("text-muted-foreground/45");
     expect(screen.getByTitle("Add code cell")).not.toHaveClass("text-emerald-700");
+    expect(actionBridgeGap).toHaveClass("absolute");
+    expect(actionBridgeGap).toHaveClass("left-full");
+    expect(actionBridgeGap).toHaveClass("w-1");
+    expect(actionBridgeGap).toHaveClass("bg-emerald-500/12");
+    expect(actionBridgeGap).toHaveClass("border-emerald-500/20");
   });
 
   it("softens the terminal row into a document tail", () => {

--- a/src/components/environment/UvDependencyPanel.tsx
+++ b/src/components/environment/UvDependencyPanel.tsx
@@ -260,7 +260,6 @@ export function UvDependencyPanel({
               <div>
                 Using <code className="rounded bg-muted px-1">{pyprojectPath}</code>
               </div>
-              <div>Re-initialize after dependency changes.</div>
               {isRail && pyprojectDependencyValues.length > 0 && (
                 <PackageSpecList
                   values={pyprojectDependencyValues}


### PR DESCRIPTION
## Summary

- remove the redundant project-environment helper copy from the Packages rail
- use visibility icons for the floating code input toggle while keeping the inline hidden-input row code-focused
- stabilize the cell-adder hover geometry so the controls fade in place and the markdown bridge stays visually connected

## Verification

- `pnpm test:run apps/notebook/src/components/__tests__/PackageSpecList.test.tsx`
- `pnpm test:run apps/notebook/src/components/__tests__/code-cell-output-focus.test.tsx`
- `pnpm test:run src/components/cell/__tests__/CellInsertionRibbon.test.tsx`
- `cargo xtask lint --fix`

## Notes

- The markdown adder hover still has a tiny residual shift, but this keeps the current interaction direction without over-polishing the control in this pass.
