### PR TITLE
feat(execution): first-class cancelled status for never-ran queue entries

### DIFF
--- a/apps/notebook/src/components/CodeCell.tsx
+++ b/apps/notebook/src/components/CodeCell.tsx
@@ -371,6 +371,10 @@ export const CodeCell = memo(function CodeCell({
   const executionCount = execution?.execution_count ?? null;
   const submittedByActorLabel = execution?.submitted_by_actor_label ?? null;
   const isExecutionErrored = execution?.success === false || execution?.status === "error";
+  // Cancelled executions never ran (queue dropped behind an earlier error,
+  // interrupt, or kernel death); success stays null on them, so the errored
+  // check above cannot match.
+  const isExecutionCancelled = execution?.status === "cancelled";
   const languageLabel =
     language === "ipython" ? "Python" : (languageDisplayNames[language] ?? "Code");
   // Check cell metadata for visibility (JupyterLab convention)
@@ -647,6 +651,7 @@ export const CodeCell = memo(function CodeCell({
       isQueued={isQueued}
       queuePriority={queuePriority}
       isErrored={isExecutionErrored}
+      isCancelled={isExecutionCancelled}
       isFocused={isFocused}
       compactIdle={isSourceEmpty}
       activityContent={<CellPresenceIndicators cellId={cell.id} variant="inline" prefixSeparator />}
@@ -675,6 +680,7 @@ export const CodeCell = memo(function CodeCell({
               isExecuting={isExecuting || isGroupExecuting}
               isQueued={isQueued}
               isErrored={isExecutionErrored}
+              isCancelled={isExecutionCancelled}
               submittedByActorLabel={submittedByActorLabel}
               isCellFocused={isFocused}
               canExecute={canExecute}

--- a/crates/notebook-sync/src/execution_wait.rs
+++ b/crates/notebook-sync/src/execution_wait.rs
@@ -18,8 +18,8 @@
 //!
 //! ## Two phases
 //!
-//! 1. **Terminal wait.** Poll until `executions[eid].status` is `"done"` or
-//!    `"error"`.
+//! 1. **Terminal wait.** Poll until `executions[eid].status` is `"done"`,
+//!    `"error"`, or `"cancelled"`.
 //! 2. **Output-sync grace.** If the terminal status is reached but the
 //!    output list is still empty, or the terminal output includes a stream
 //!    manifest that may still be updating in place, poll briefly (capped at
@@ -34,9 +34,14 @@ use crate::handle::DocHandle;
 /// Outcome of awaiting a single execution.
 #[derive(Debug, Clone)]
 pub struct ExecutionTerminalState {
-    /// `"done"` | `"error"` | `"timed_out"`.
+    /// `"done"` | `"error"` | `"cancelled"` | `"timed_out"`.
+    ///
+    /// `"cancelled"` means the execution was dropped from the queue without
+    /// running (an earlier cell errored, an interrupt, or kernel
+    /// death/restart).
     pub status: String,
-    /// `true` when the kernel reported success. `false` on error or timeout.
+    /// `true` when the kernel reported success. `false` on error, cancel, or
+    /// timeout.
     pub success: bool,
     /// Raw output manifest values from `RuntimeStateDoc::executions[eid].outputs`.
     /// Empty when the execution produced no outputs or timed out before
@@ -111,7 +116,7 @@ pub async fn await_execution_terminal(
             // execution's real status/outputs rather than being handed a
             // generic `KernelFailed`.
             if let Some(exec) = state.executions.get(execution_id) {
-                if exec.status == "done" || exec.status == "error" {
+                if exec.status == "done" || exec.status == "error" || exec.status == "cancelled" {
                     break ExecutionTerminalState {
                         status: exec.status.clone(),
                         success: exec.success.unwrap_or(false),

--- a/crates/notebook-sync/src/execution_watch.rs
+++ b/crates/notebook-sync/src/execution_watch.rs
@@ -18,6 +18,9 @@ const TERMINAL_BLOB_STREAM_OUTPUT_MAX_GRACE: Duration = Duration::from_secs(3);
 pub enum ExecutionTerminalReason {
     Done,
     Error,
+    /// Dropped from the queue without running (an earlier cell errored, an
+    /// interrupt, or kernel death/restart).
+    Cancelled,
     KernelFailed,
     Interrupted,
     Timeout,
@@ -29,6 +32,7 @@ impl ExecutionTerminalReason {
         match self {
             Self::Done => "done",
             Self::Error => "error",
+            Self::Cancelled => "cancelled",
             Self::KernelFailed => "kernel_failed",
             Self::Interrupted => "interrupted",
             Self::Timeout => "timeout",
@@ -227,6 +231,10 @@ impl ExecutionWatcher {
 fn terminal_reason_for(entry: &ExecutionState) -> Option<ExecutionTerminalReason> {
     match entry.status.as_str() {
         "done" => Some(ExecutionTerminalReason::Done),
+        "cancelled" => Some(ExecutionTerminalReason::Cancelled),
+        // The error-without-outputs arm predates the first-class "cancelled"
+        // status; it still covers a force-failed interrupted execution and
+        // older daemons that marked never-ran queue entries "error".
         "error" if entry.outputs.is_empty() => Some(ExecutionTerminalReason::Interrupted),
         "error" => Some(ExecutionTerminalReason::Error),
         _ => None,

--- a/crates/notebook-sync/src/execution_watch.rs
+++ b/crates/notebook-sync/src/execution_watch.rs
@@ -232,9 +232,9 @@ fn terminal_reason_for(entry: &ExecutionState) -> Option<ExecutionTerminalReason
     match entry.status.as_str() {
         "done" => Some(ExecutionTerminalReason::Done),
         "cancelled" => Some(ExecutionTerminalReason::Cancelled),
-        // The error-without-outputs arm predates the first-class "cancelled"
-        // status; it still covers a force-failed interrupted execution and
-        // older daemons that marked never-ran queue entries "error".
+        // An interrupted running execution is force-failed by the daemon
+        // before the kernel's KeyboardInterrupt output can land, so
+        // error-without-outputs reads as interrupted rather than errored.
         "error" if entry.outputs.is_empty() => Some(ExecutionTerminalReason::Interrupted),
         "error" => Some(ExecutionTerminalReason::Error),
         _ => None,

--- a/crates/runt-mcp/src/execution.rs
+++ b/crates/runt-mcp/src/execution.rs
@@ -292,10 +292,9 @@ pub async fn run_all_and_wait(handle: &DocHandle, timeout: Duration) -> RunAllRe
 
         if let Ok(state) = handle.get_runtime_state() {
             all_terminal = execution_ids.iter().all(|eid| {
-                state
-                    .executions
-                    .get(*eid)
-                    .is_some_and(|exec| exec.status == "done" || exec.status == "error")
+                state.executions.get(*eid).is_some_and(|exec| {
+                    exec.status == "done" || exec.status == "error" || exec.status == "cancelled"
+                })
             });
             if all_terminal {
                 break;

--- a/crates/runt-mcp/src/tools/cell_read.rs
+++ b/crates/runt-mcp/src/tools/cell_read.rs
@@ -499,7 +499,7 @@ fn get_cell_status(handle: &notebook_sync::handle::DocHandle, cell_id: &str) -> 
             return Some("queued".to_string());
         }
         if let Some(exec) = state.executions.get(&execution_id) {
-            if exec.status == "done" || exec.status == "error" {
+            if exec.status == "done" || exec.status == "error" || exec.status == "cancelled" {
                 return Some(exec.status.clone());
             }
         }
@@ -573,7 +573,7 @@ pub fn build_cell_status_map(
                 continue;
             }
             if let Some(exec) = state.executions.get(&execution_id) {
-                if exec.status == "done" || exec.status == "error" {
+                if exec.status == "done" || exec.status == "error" || exec.status == "cancelled" {
                     map.entry(cell.id).or_insert_with(|| exec.status.clone());
                 }
             }

--- a/crates/runt-mcp/src/tools/execution.rs
+++ b/crates/runt-mcp/src/tools/execution.rs
@@ -168,7 +168,10 @@ pub async fn run_all_cells(
         if let Some(exec) = run_exec(&cell.id) {
             match exec.status.as_str() {
                 "done" => succeeded += 1,
+                "cancelled" => cancelled += 1,
                 "error" => {
+                    // Error-without-count means cancelled on older daemons
+                    // that predate the first-class status.
                     if exec.execution_count.is_none() {
                         cancelled += 1;
                     } else {
@@ -234,6 +237,9 @@ pub async fn run_all_cells(
             None => continue,
         };
 
+        // "cancelled" is first-class in RuntimeStateDoc and passes through.
+        // The error-without-count arm is a fallback for older daemons that
+        // marked never-ran queue entries "error".
         let display_status = match exec.status.as_str() {
             "error" if exec.execution_count.is_none() => "cancelled",
             other => other,
@@ -427,9 +433,13 @@ async fn render_execution_result(
     execution_cell_map: Option<std::collections::HashMap<String, String>>,
     full_output: bool,
 ) -> Result<CallToolResult, McpError> {
-    // Determine display status with clear indication of completeness
+    // Determine display status with clear indication of completeness.
+    // "cancelled" is first-class in RuntimeStateDoc; the error-without-count
+    // arm is a fallback for older daemons that marked never-ran queue
+    // entries "error".
     let (display_status, is_terminal) = match exec.status.as_str() {
         "done" => ("done", true),
+        "cancelled" => ("cancelled", true),
         "error" if exec.execution_count.is_none() => ("cancelled", true),
         "error" => ("error", true),
         "running" => ("running (partial — outputs may be incomplete)", false),

--- a/crates/runt-mcp/src/tools/execution.rs
+++ b/crates/runt-mcp/src/tools/execution.rs
@@ -169,15 +169,7 @@ pub async fn run_all_cells(
             match exec.status.as_str() {
                 "done" => succeeded += 1,
                 "cancelled" => cancelled += 1,
-                "error" => {
-                    // Error-without-count means cancelled on older daemons
-                    // that predate the first-class status.
-                    if exec.execution_count.is_none() {
-                        cancelled += 1;
-                    } else {
-                        errored += 1;
-                    }
-                }
+                "error" => errored += 1,
                 "running" => running += 1,
                 "queued" => queued += 1,
                 _ => {}
@@ -237,13 +229,7 @@ pub async fn run_all_cells(
             None => continue,
         };
 
-        // "cancelled" is first-class in RuntimeStateDoc and passes through.
-        // The error-without-count arm is a fallback for older daemons that
-        // marked never-ran queue entries "error".
-        let display_status = match exec.status.as_str() {
-            "error" if exec.execution_count.is_none() => "cancelled",
-            other => other,
-        };
+        let display_status = exec.status.as_str();
         let ec_str = exec.execution_count.map(|c| c.to_string());
 
         // Resolve outputs from the execution's output manifests.
@@ -433,14 +419,10 @@ async fn render_execution_result(
     execution_cell_map: Option<std::collections::HashMap<String, String>>,
     full_output: bool,
 ) -> Result<CallToolResult, McpError> {
-    // Determine display status with clear indication of completeness.
-    // "cancelled" is first-class in RuntimeStateDoc; the error-without-count
-    // arm is a fallback for older daemons that marked never-ran queue
-    // entries "error".
+    // Determine display status with clear indication of completeness
     let (display_status, is_terminal) = match exec.status.as_str() {
         "done" => ("done", true),
         "cancelled" => ("cancelled", true),
-        "error" if exec.execution_count.is_none() => ("cancelled", true),
         "error" => ("error", true),
         "running" => ("running (partial — outputs may be incomplete)", false),
         "queued" => ("queued (no outputs yet)", false),

--- a/crates/runtime-doc/src/doc.rs
+++ b/crates/runtime-doc/src/doc.rs
@@ -20,7 +20,7 @@
 //!     queued_execution_ids: List[Str]  (execution_ids waiting)
 //!   executions/             Map (keyed by execution_id)
 //!     {execution_id}/       Map
-//!       status: Str         ("queued" | "running" | "done" | "error")
+//!       status: Str         ("queued" | "running" | "done" | "error" | "cancelled")
 //!       execution_count: Int|null
 //!       success: Bool|null
 //!       outputs: Map  (keyed by output_id)
@@ -208,12 +208,18 @@ pub struct QueueState {
 /// Stored in `executions/{execution_id}/` in the RuntimeStateDoc.
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct ExecutionState {
-    /// Current status: "queued", "running", "done", "error".
+    /// Current status: "queued", "running", "done", "error", "cancelled".
+    ///
+    /// "cancelled" is terminal and means the execution never ran: it was
+    /// dropped from the queue because an earlier cell errored, the user
+    /// interrupted, or the kernel died/restarted before it started.
     pub status: String,
     /// Kernel execution count (set when execution starts).
     #[serde(default)]
     pub execution_count: Option<i64>,
-    /// Whether the execution succeeded (set on completion).
+    /// Whether the execution succeeded (set on completion). Absent on
+    /// "cancelled" executions: they neither succeeded nor failed, so
+    /// `success == Some(false)` always means "ran and errored".
     #[serde(default)]
     pub success: Option<bool>,
     /// Output manifests for this execution (inline Automerge Maps with blob refs).
@@ -1445,17 +1451,35 @@ impl RuntimeStateDoc {
         Ok(())
     }
 
-    /// Mark all in-flight executions (status "running" or "queued") as failed.
-    /// Returns the number of executions marked. Used during kernel restart or
-    /// interrupt to catch any entries that the local KernelState doesn't know
-    /// about (e.g., entries created by CRDT sync that haven't been processed
-    /// locally yet).
-    pub fn mark_inflight_executions_failed(&mut self) -> Result<usize, RuntimeStateError> {
+    /// Mark an execution as cancelled: it was dropped from the queue without
+    /// ever running (earlier cell errored, interrupt, kernel death/restart).
+    ///
+    /// Terminal like "done"/"error", but `success` stays absent — the
+    /// execution neither succeeded nor failed, and consumers rely on
+    /// `success == false` meaning "ran and errored".
+    pub fn set_execution_cancelled(&mut self, execution_id: &str) -> Result<(), RuntimeStateError> {
+        let executions = self.scaffold_map("executions")?;
+
+        let Some((_, entry)) = self.doc.get(&executions, execution_id).ok().flatten() else {
+            return Ok(());
+        };
+
+        self.doc.put(&entry, "status", "cancelled")?;
+        Ok(())
+    }
+
+    /// Resolve all in-flight executions to a terminal status: "running"
+    /// entries become "error" (the kernel went away mid-run), "queued"
+    /// entries become "cancelled" (they never started). Returns the number of
+    /// executions resolved. Used during kernel restart or interrupt to catch
+    /// any entries that the local KernelState doesn't know about (e.g.,
+    /// entries created by CRDT sync that haven't been processed locally yet).
+    pub fn abort_inflight_executions(&mut self) -> Result<usize, RuntimeStateError> {
         let Some(executions) = self.get_map("executions") else {
             return Ok(0);
         };
 
-        let inflight: Vec<automerge::ObjId> =
+        let inflight: Vec<(automerge::ObjId, bool)> =
             self.doc
                 .map_range(&executions, ..)
                 .filter_map(|item| {
@@ -1469,16 +1493,21 @@ impl RuntimeStateDoc {
                         },
                     );
                     match status.as_deref() {
-                        Some("running") | Some("queued") => Some(item.id()),
+                        Some("running") => Some((item.id(), true)),
+                        Some("queued") => Some((item.id(), false)),
                         _ => None,
                     }
                 })
                 .collect();
 
         let count = inflight.len();
-        for entry_id in inflight {
-            self.doc.put(&entry_id, "status", "error")?;
-            self.doc.put(&entry_id, "success", false)?;
+        for (entry_id, was_running) in inflight {
+            if was_running {
+                self.doc.put(&entry_id, "status", "error")?;
+                self.doc.put(&entry_id, "success", false)?;
+            } else {
+                self.doc.put(&entry_id, "status", "cancelled")?;
+            }
         }
         Ok(count)
     }
@@ -4812,7 +4841,7 @@ mod tests {
     }
 
     #[test]
-    fn test_mark_inflight_executions_failed() {
+    fn test_abort_inflight_executions() {
         let mut doc = RuntimeStateDoc::new();
         // One running, one queued, one already done
         doc.create_execution("exec-running").unwrap();
@@ -4828,32 +4857,49 @@ mod tests {
         assert_eq!(doc.get_execution("exec-queued").unwrap().status, "queued");
         assert_eq!(doc.get_execution("exec-done").unwrap().status, "done");
 
-        let marked = doc.mark_inflight_executions_failed().unwrap();
-        assert_eq!(marked, 2);
+        let resolved = doc.abort_inflight_executions().unwrap();
+        assert_eq!(resolved, 2);
 
+        // Running entry was killed mid-run: error with explicit failure.
         assert_eq!(doc.get_execution("exec-running").unwrap().status, "error");
         assert_eq!(
             doc.get_execution("exec-running").unwrap().success,
             Some(false)
         );
-        assert_eq!(doc.get_execution("exec-queued").unwrap().status, "error");
+        // Queued entry never ran: cancelled, success absent.
         assert_eq!(
-            doc.get_execution("exec-queued").unwrap().success,
-            Some(false)
+            doc.get_execution("exec-queued").unwrap().status,
+            "cancelled"
         );
+        assert_eq!(doc.get_execution("exec-queued").unwrap().success, None);
         // Done execution should be untouched
         assert_eq!(doc.get_execution("exec-done").unwrap().status, "done");
         assert_eq!(doc.get_execution("exec-done").unwrap().success, Some(true));
     }
 
     #[test]
-    fn test_mark_inflight_noop_when_all_done() {
+    fn test_abort_inflight_noop_when_all_done() {
         let mut doc = RuntimeStateDoc::new();
         doc.create_execution("exec-1").unwrap();
         doc.set_execution_running("exec-1").unwrap();
         doc.set_execution_done("exec-1", true).unwrap();
 
-        assert_eq!(doc.mark_inflight_executions_failed().unwrap(), 0);
+        assert_eq!(doc.abort_inflight_executions().unwrap(), 0);
+    }
+
+    #[test]
+    fn test_set_execution_cancelled() {
+        let mut doc = RuntimeStateDoc::new();
+        doc.create_execution("exec-1").unwrap();
+
+        doc.set_execution_cancelled("exec-1").unwrap();
+
+        let exec = doc.get_execution("exec-1").unwrap();
+        assert_eq!(exec.status, "cancelled");
+        assert_eq!(exec.success, None);
+
+        // Unknown execution id is a no-op, matching set_execution_done.
+        doc.set_execution_cancelled("nope").unwrap();
     }
 
     #[test]

--- a/crates/runtimed-py/src/output.rs
+++ b/crates/runtimed-py/src/output.rs
@@ -853,7 +853,8 @@ pub struct ExecutionProgress {
     pub cell_id: String,
     /// Execution ID for this run.
     pub execution_id: String,
-    /// Current status: "queued", "running", "done", "error", or synthetic terminal status.
+    /// Current status: "queued", "running", "done", "error", "cancelled", or
+    /// synthetic terminal status.
     pub status: String,
     /// Whether execution succeeded, once known.
     pub success: Option<bool>,
@@ -863,7 +864,8 @@ pub struct ExecutionProgress {
     pub outputs: Vec<Output>,
     /// Whether this snapshot ends the stream.
     pub terminal: bool,
-    /// Terminal reason: "done", "error", "kernel_failed", "interrupted", "timeout", or "closed".
+    /// Terminal reason: "done", "error", "cancelled", "kernel_failed",
+    /// "interrupted", "timeout", or "closed".
     pub terminal_reason: Option<String>,
 }
 
@@ -1046,11 +1048,12 @@ impl PyEnvState {
 #[pyclass(name = "ExecutionState", get_all, skip_from_py_object)]
 #[derive(Clone, Debug)]
 pub struct PyExecutionState {
-    /// Current status: "queued", "running", "done", "error".
+    /// Current status: "queued", "running", "done", "error", "cancelled".
     pub status: String,
     /// Kernel execution count (set when execution starts).
     pub execution_count: Option<i64>,
-    /// Whether the execution succeeded (set on completion).
+    /// Whether the execution succeeded (set on completion). Absent on
+    /// "cancelled" executions, which never ran.
     pub success: Option<bool>,
     /// Authenticated actor label for the client that submitted this execution.
     pub submitted_by_actor_label: Option<String>,

--- a/crates/runtimed-wasm/src/lib.rs
+++ b/crates/runtimed-wasm/src/lib.rs
@@ -1509,12 +1509,13 @@ impl RoomHostHandle {
     ) -> Result<RoomHostFrameResult, JsError> {
         let heads_before = self.state_doc.get_heads();
 
-        // 1. Terminalize in-flight executions (running + queued) and clear the
-        //    queue, so viewers stop seeing perpetually-spinning cells and the
-        //    idempotency guard in handle_execute_cell no longer suppresses
-        //    re-runs of the orphaned work.
+        // 1. Resolve in-flight executions (running → error, queued →
+        //    cancelled) and clear the queue, so viewers stop seeing
+        //    perpetually-spinning cells and the idempotency guard in
+        //    handle_execute_cell no longer suppresses re-runs of the
+        //    orphaned work.
         self.state_doc
-            .mark_inflight_executions_failed()
+            .abort_inflight_executions()
             .map_err(|e| JsError::new(&format!("reconcile executions: {e}")))?;
         self.state_doc
             .set_queue(None, &[])
@@ -4201,9 +4202,10 @@ mod tests {
         assert!(result.runtime_state_changed);
 
         let state = host.state_doc.read_state();
-        // Both in-flight executions are now terminal (error), not spinning.
+        // Both in-flight executions are now terminal, not spinning: the
+        // running one errored mid-run, the queued one never ran.
         assert_eq!(state.executions["exec-running"].status, "error");
-        assert_eq!(state.executions["exec-queued"].status, "error");
+        assert_eq!(state.executions["exec-queued"].status, "cancelled");
         // Queue drained so the idempotency guard can't suppress re-runs.
         assert!(state.queue.executing.is_none());
         assert!(state.queue.queued.is_empty());

--- a/crates/runtimed/src/requests/interrupt_execution.rs
+++ b/crates/runtimed/src/requests/interrupt_execution.rs
@@ -10,7 +10,7 @@ pub(crate) async fn handle(room: &NotebookRoom) -> NotebookResponse {
         // The coordinator's CRDT copy may contain entries from a concurrent
         // ExecuteCell whose final state should be determined by the runtime
         // agent, not pre-empted by a blanket sweep.  The runtime agent's
-        // interrupt handler calls mark_inflight_executions_failed() on its
+        // interrupt handler calls abort_inflight_executions() on its
         // own CRDT copy - only entries that have actually synced to the
         // agent are affected, so final state is correct regardless of
         // timing between ExecuteCell and InterruptExecution.

--- a/crates/runtimed/src/runtime_agent.rs
+++ b/crates/runtimed/src/runtime_agent.rs
@@ -1694,23 +1694,25 @@ async fn handle_runtime_agent_request(
                 direct_python_path,
             };
 
-            // Mark stale executions as failed in RuntimeStateDoc.
-            // The old kernel is gone after shutdown, so these executions
-            // can never complete — do this before launching the new kernel.
+            // Resolve stale executions in RuntimeStateDoc: the interrupted
+            // one was running when the old kernel went away (error), queued
+            // ones never ran (cancelled). The old kernel is gone after
+            // shutdown, so these executions can never complete — do this
+            // before launching the new kernel.
             if let Err(e) = ctx.state.with_doc(|sd| {
                 if let Some(ref eid) = interrupted_eid {
                     sd.set_execution_done(eid, false)?;
                 }
                 for eid in &stale_queue {
-                    sd.set_execution_done(eid, false)?;
+                    sd.set_execution_cancelled(eid)?;
                 }
-                // Defensive sweep: mark any execution entries stuck in
+                // Defensive sweep: resolve any execution entries stuck in
                 // "running" or "queued" that the local KernelState missed
                 // (e.g., entries from CRDT sync not yet processed locally).
-                match sd.mark_inflight_executions_failed() {
+                match sd.abort_inflight_executions() {
                     Ok(orphans) if orphans > 0 => {
                         info!(
-                            "[runtime-agent] Marked {orphans} orphaned execution(s) as failed on restart"
+                            "[runtime-agent] Resolved {orphans} orphaned execution(s) on restart"
                         );
                     }
                     Err(e) => {
@@ -1782,11 +1784,7 @@ async fn handle_runtime_agent_request(
                         let (interrupted, cleared) = state.interrupt();
                         // Write cleared entries AND sweep CRDT-synced executions
                         // that haven't reached the local queue yet.
-                        mark_interrupted_executions_failed(
-                            &ctx.state,
-                            interrupted.as_ref(),
-                            &cleared,
-                        );
+                        resolve_interrupted_executions(&ctx.state, interrupted.as_ref(), &cleared);
                         (
                             RuntimeAgentResponse::InterruptAcknowledged { cleared },
                             None,
@@ -2097,10 +2095,13 @@ async fn handle_lifecycle_signal(
         LifecycleSignal::CellError { execution_id } => {
             debug!("[runtime-agent] CellError: execution={}", execution_id);
             if state.mark_execution_error(&execution_id) {
+                // The erroring cell itself reports "error" via execution_done;
+                // queued cells behind it never ran, so they are cancelled, not
+                // failed.
                 let cleared = state.clear_queue();
                 if let Err(e) = ctx.state.with_doc(|sd| {
                     for entry in &cleared {
-                        sd.set_execution_done(&entry.execution_id, false)?;
+                        sd.set_execution_cancelled(&entry.execution_id)?;
                     }
                     sd.set_queue(None, &[])?;
                     Ok(())
@@ -2118,11 +2119,13 @@ async fn handle_lifecycle_signal(
             *kernel = None;
             let (interrupted, cleared) = state.kernel_died();
             if let Err(e) = ctx.state.with_doc(|sd| {
+                // The executing cell died mid-run: error. Queued cells never
+                // ran: cancelled.
                 if let Some(ref eid) = interrupted {
                     sd.set_execution_done(eid, false)?;
                 }
                 for entry in &cleared {
-                    sd.set_execution_done(&entry.execution_id, false)?;
+                    sd.set_execution_cancelled(&entry.execution_id)?;
                 }
                 // Generic kernel-died path — no specific typed reason. Clear
                 // any stale error_reason from a prior failure so the frontend
@@ -2185,19 +2188,23 @@ async fn drain_lifecycle_commands(
     Ok(drained)
 }
 
-fn mark_interrupted_executions_failed(
+fn resolve_interrupted_executions(
     state: &RuntimeStateHandle,
     interrupted: Option<&QueueEntry>,
     cleared: &[QueueEntry],
 ) {
     if let Err(e) = state.with_doc(|sd| {
+        // The interrupted cell was running and gets the kernel's
+        // KeyboardInterrupt error output: "error". Queued cells behind it
+        // never ran: "cancelled". The sweep applies the same split to any
+        // entries the local KernelState missed.
         if let Some(entry) = interrupted {
             sd.set_execution_done(&entry.execution_id, false)?;
         }
         for entry in cleared {
-            sd.set_execution_done(&entry.execution_id, false)?;
+            sd.set_execution_cancelled(&entry.execution_id)?;
         }
-        sd.mark_inflight_executions_failed()?;
+        sd.abort_inflight_executions()?;
         sd.set_queue(None, &[])?;
         sd.set_lifecycle(&RuntimeLifecycle::Running(KernelActivity::Idle))?;
         Ok(())
@@ -2334,7 +2341,7 @@ fn interrupt_via_handle_if_available(
     // reached the local queue yet. Only the agent does this sweep - the
     // coordinator intentionally does NOT, so final state is determined by the
     // agent regardless of timing.
-    mark_interrupted_executions_failed(state, interrupted.as_ref(), &cleared);
+    resolve_interrupted_executions(state, interrupted.as_ref(), &cleared);
 
     // Interrupt kernel in background — don't block the loop.
     tokio::spawn(async move {
@@ -3281,7 +3288,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn kernel_died_marks_inflight_executions_as_failed_in_state_doc() {
+    async fn kernel_died_resolves_inflight_executions_in_state_doc() {
         let (ctx, mut state, handle) = test_fixtures();
         let mut mock = MockKernel;
         state.set_idle();
@@ -3314,14 +3321,15 @@ mod tests {
         .await
         .unwrap();
 
-        // Both executions should now be marked as error in RuntimeStateDoc
+        // The executing cell died mid-run: error. The queued cell never ran:
+        // cancelled, with success absent.
         let e1 = handle.read(|sd| sd.get_execution("e1").unwrap()).unwrap();
         assert_eq!(e1.status, "error");
         assert_eq!(e1.success, Some(false));
 
         let e2 = handle.read(|sd| sd.get_execution("e2").unwrap()).unwrap();
-        assert_eq!(e2.status, "error");
-        assert_eq!(e2.success, Some(false));
+        assert_eq!(e2.status, "cancelled");
+        assert_eq!(e2.success, None);
 
         // Queue should be cleared
         let queue = handle.read(|sd| sd.read_state()).unwrap();
@@ -3388,8 +3396,9 @@ mod tests {
 
     /// Simulate the interrupt+execute race: a concurrent execute_cell creates
     /// an execution entry in RuntimeStateDoc that the runtime agent's local
-    /// queue doesn't know about yet. The interrupt handler must mark ALL
-    /// in-flight entries as failed, not just the ones in the local queue.
+    /// queue doesn't know about yet. The interrupt handler must resolve ALL
+    /// in-flight entries (running → error, queued → cancelled), not just the
+    /// ones in the local queue.
     #[tokio::test]
     async fn interrupt_marks_crdt_synced_executions_not_in_local_queue() {
         let (_ctx, mut state, handle) = test_fixtures();
@@ -3423,17 +3432,17 @@ mod tests {
             Some("eA")
         );
         assert!(cleared.is_empty());
-        mark_interrupted_executions_failed(&handle, interrupted.as_ref(), &cleared);
+        resolve_interrupted_executions(&handle, interrupted.as_ref(), &cleared);
 
-        // eA (executing) should be marked failed by mark_inflight
+        // eA (executing) should be marked failed by the inflight sweep
         let ea = handle.read(|sd| sd.get_execution("eA").unwrap()).unwrap();
         assert_eq!(ea.status, "error");
         assert_eq!(ea.success, Some(false));
 
-        // eB (CRDT-only, not in local queue) should ALSO be marked failed
+        // eB (CRDT-only, queued, not in local queue) never ran: cancelled
         let eb = handle.read(|sd| sd.get_execution("eB").unwrap()).unwrap();
-        assert_eq!(eb.status, "error");
-        assert_eq!(eb.success, Some(false));
+        assert_eq!(eb.status, "cancelled");
+        assert_eq!(eb.success, None);
 
         let rs = handle.read(|sd| sd.read_state()).unwrap();
         assert!(rs.queue.executing.is_none());
@@ -3442,6 +3451,65 @@ mod tests {
             rs.kernel.lifecycle,
             RuntimeLifecycle::Running(KernelActivity::Idle)
         );
+    }
+
+    /// Run-all where a middle cell errors: the erroring cell reports
+    /// "error", and the queued cells behind it report "cancelled" — they
+    /// never ran, so showing them as failed misattributes the error.
+    #[tokio::test]
+    async fn cell_error_cancels_queued_cells_behind_it() {
+        let (ctx, mut state, handle) = test_fixtures();
+        let mut mock = MockKernel;
+        state.set_idle();
+
+        // eA executes; eB and eC wait in the queue behind it.
+        state
+            .queue_cell("eA".into(), None, "raise Exception".into(), &mut mock)
+            .await
+            .unwrap();
+        state
+            .queue_cell("eB".into(), None, "print('unreached')".into(), &mut mock)
+            .await
+            .unwrap();
+        state
+            .queue_cell(
+                "eC".into(),
+                None,
+                "print('also unreached')".into(),
+                &mut mock,
+            )
+            .await
+            .unwrap();
+
+        // The kernel reports the error, then terminal status, mirroring the
+        // IOPub order: CellError clears the queue, ExecutionDone closes eA.
+        handle_lifecycle_signal(
+            LifecycleSignal::CellError {
+                execution_id: "eA".to_string(),
+            },
+            &ctx,
+            &mut None::<Kernel>,
+            &mut state,
+        )
+        .await
+        .unwrap();
+        // ExecutionDone closes eA through the same path the lifecycle arm
+        // takes (the arm needs a live kernel handle; tests use MockKernel).
+        state.execution_done("eA", &mut mock).await.unwrap();
+
+        let ea = handle.read(|sd| sd.get_execution("eA").unwrap()).unwrap();
+        assert_eq!(ea.status, "error");
+        assert_eq!(ea.success, Some(false));
+
+        for eid in ["eB", "eC"] {
+            let exec = handle.read(|sd| sd.get_execution(eid).unwrap()).unwrap();
+            assert_eq!(exec.status, "cancelled", "{eid} never ran");
+            assert_eq!(exec.success, None, "{eid} neither succeeded nor failed");
+        }
+
+        let rs = handle.read(|sd| sd.read_state()).unwrap();
+        assert!(rs.queue.executing.is_none());
+        assert!(rs.queue.queued.is_empty());
     }
 
     /// After interrupt, CellError from the interrupted cell should be a
@@ -3470,7 +3538,7 @@ mod tests {
         );
         assert_eq!(cleared.len(), 1); // cB
         assert_eq!(cleared[0].execution_id, "eB");
-        mark_interrupted_executions_failed(&handle, interrupted.as_ref(), &cleared);
+        resolve_interrupted_executions(&handle, interrupted.as_ref(), &cleared);
 
         // Now simulate CellError from the interrupted cell A
         handle_lifecycle_signal(
@@ -3484,11 +3552,11 @@ mod tests {
         .await
         .unwrap();
 
-        // Both should be error
+        // The interrupted cell errored; the queued cell behind it cancelled.
         let ea = handle.read(|sd| sd.get_execution("eA").unwrap()).unwrap();
         assert_eq!(ea.status, "error");
         let eb = handle.read(|sd| sd.get_execution("eB").unwrap()).unwrap();
-        assert_eq!(eb.status, "error");
+        assert_eq!(eb.status, "cancelled");
 
         // A stale CellError from eA must not poison the next execution.
         let mut mock = MockKernel;

--- a/packages/runtimed/src/handle.ts
+++ b/packages/runtimed/src/handle.ts
@@ -43,7 +43,7 @@ export interface TextAttribution {
 
 export interface ExecutionViewSnapshot {
   execution_count: number | null;
-  status: "queued" | "running" | "done" | "error" | (string & {});
+  status: "queued" | "running" | "done" | "error" | "cancelled" | (string & {});
   success: boolean | null;
   output_ids: string[];
   submitted_by_actor_label?: string | null;

--- a/packages/runtimed/src/runtime-state.ts
+++ b/packages/runtimed/src/runtime-state.ts
@@ -177,7 +177,13 @@ export interface TrustState {
 }
 
 export interface ExecutionState {
-  status: "queued" | "running" | "done" | "error";
+  /**
+   * "cancelled" is terminal and means the execution never ran: dropped from
+   * the queue because an earlier cell errored, an interrupt, or kernel
+   * death/restart. `success` stays null on cancelled executions, so
+   * `success === false` always means "ran and errored".
+   */
+  status: "queued" | "running" | "done" | "error" | "cancelled";
   execution_count: number | null;
   success: boolean | null;
   /** Notebook cell that submitted this execution, when available. */
@@ -209,7 +215,7 @@ export interface CommDocEntry {
 /** A detected status transition for a single execution. */
 export interface ExecutionTransition {
   execution_id: string;
-  kind: "started" | "done" | "error";
+  kind: "started" | "done" | "error" | "cancelled";
   execution_count: number | null;
 }
 
@@ -405,7 +411,7 @@ export function diffExecutions(
       continue;
     }
 
-    // Terminal states: done or error
+    // Terminal states: done, error, or cancelled
     if (currStatus === "done") {
       transitions.push({
         execution_id: eid,
@@ -416,6 +422,12 @@ export function diffExecutions(
       transitions.push({
         execution_id: eid,
         kind: "error",
+        execution_count: entry.execution_count,
+      });
+    } else if (currStatus === "cancelled") {
+      transitions.push({
+        execution_id: eid,
+        kind: "cancelled",
         execution_count: entry.execution_count,
       });
     } else if (currStatus === "running" && prevStatus !== "done" && prevStatus !== "error") {

--- a/packages/runtimed/tests/sync-engine.test.ts
+++ b/packages/runtimed/tests/sync-engine.test.ts
@@ -2673,6 +2673,18 @@ describe("diffExecutions", () => {
     expect(transitions[0].kind).toBe("error");
   });
 
+  it("detects cancelled transition for queued cells dropped behind an error", () => {
+    const prev = {
+      e1: { status: "queued" as const, execution_count: null, success: null },
+    };
+    const curr = {
+      e1: { status: "cancelled" as const, execution_count: null, success: null },
+    };
+    const transitions = diffExecutions(prev, curr);
+    expect(transitions).toHaveLength(1);
+    expect(transitions[0].kind).toBe("cancelled");
+  });
+
   it("returns empty for no change", () => {
     const state = {
       e1: { status: "running" as const, execution_count: 1, success: null },

--- a/src/components/cell/CodeCellCurrentLine.tsx
+++ b/src/components/cell/CodeCellCurrentLine.tsx
@@ -17,13 +17,15 @@ export interface CodeCellCurrentLineProps {
   isQueued?: boolean;
   queuePriority?: number;
   isErrored?: boolean;
+  /** The execution was dropped from the queue without running. */
+  isCancelled?: boolean;
   isFocused?: boolean;
   compactIdle?: boolean;
   activityContent?: ReactNode;
   className?: string;
 }
 
-type ExecutionBoundaryState = "idle" | "ran" | "queued" | "running" | "error";
+type ExecutionBoundaryState = "idle" | "ran" | "queued" | "running" | "error" | "cancelled";
 type RunningSignalPhase = "resting" | "building" | "active" | "settling";
 
 const RUNNING_SIGNAL_DELAY_MS = 120;
@@ -112,16 +114,19 @@ function visualExecutionDetail({
   isExecuting,
   isQueued,
   isErrored,
+  isCancelled,
 }: {
   count: number | null;
   elapsedMs: number | null;
   isExecuting: boolean;
   isQueued: boolean;
   isErrored: boolean;
+  isCancelled: boolean;
 }): string {
   if (isExecuting) return "running";
   if (isQueued) return "queued";
   if (isErrored) return "failed";
+  if (isCancelled) return "cancelled";
   if (count !== null) {
     const runPrefix = `run ${formatExecutionCount(count)}`;
     return elapsedMs === null ? runPrefix : `${runPrefix} · ${formatElapsedMs(elapsedMs)}`;
@@ -136,18 +141,21 @@ function accessibleExecutionDetail({
   isExecuting,
   isQueued,
   isErrored,
+  isCancelled,
 }: {
   count: number | null;
   elapsedMs: number | null;
   isExecuting: boolean;
   isQueued: boolean;
   isErrored: boolean;
+  isCancelled: boolean;
 }): string {
   const runPrefix = count === null ? null : `Run ${formatExecutionCount(count)}`;
 
   if (isExecuting) return "Running";
   if (isQueued) return "Queued";
   if (isErrored) return runPrefix === null ? "Execution failed" : `${runPrefix} failed`;
+  if (isCancelled) return "Execution cancelled";
   if (count !== null) {
     return elapsedMs === null
       ? `${runPrefix} completed`
@@ -351,6 +359,22 @@ function ExecutionBoundaryRule({
     );
   }
 
+  if (state === "cancelled") {
+    // Same dashed boundary shape as error, but muted and without the origin
+    // dot: this cell never ran, it is not where the failure happened.
+    return (
+      <div
+        data-slot="code-cell-current-line-rule"
+        className="relative h-3 min-w-12 flex-1 overflow-hidden text-muted-foreground/45"
+      >
+        <span
+          className="absolute left-0 top-1/2 h-px w-full -translate-y-1/2 bg-[repeating-linear-gradient(to_right,currentColor_0_0.375rem,transparent_0.375rem_0.625rem)]"
+          aria-hidden="true"
+        />
+      </div>
+    );
+  }
+
   return (
     <div
       data-slot="code-cell-current-line-rule"
@@ -370,6 +394,7 @@ export function CodeCellCurrentLine({
   isQueued = false,
   queuePriority = 0,
   isErrored = false,
+  isCancelled = false,
   isFocused = false,
   compactIdle = false,
   activityContent,
@@ -382,11 +407,14 @@ export function CodeCellCurrentLine({
       ? "queued"
       : isErrored
         ? "error"
-        : count !== null
-          ? "ran"
-          : "idle";
+        : isCancelled
+          ? "cancelled"
+          : count !== null
+            ? "ran"
+            : "idle";
   const hasRunningSignal =
     !isErrored &&
+    !isCancelled &&
     !isQueued &&
     ((state === "running" && runningSignalPhase === "active") || runningSignalPhase === "settling");
   const boundaryState =
@@ -404,6 +432,7 @@ export function CodeCellCurrentLine({
     isExecuting: visualIsExecuting,
     isQueued,
     isErrored,
+    isCancelled,
   });
   const isIdleReadyDetail = boundaryState === "idle" && detailLabel === "ready";
   const isCompletedRunDetail = boundaryState === "ran" && count !== null;
@@ -414,6 +443,7 @@ export function CodeCellCurrentLine({
     isExecuting,
     isQueued,
     isErrored,
+    isCancelled,
   });
   const countLabel = executionCountLabel(count);
   return (
@@ -440,7 +470,7 @@ export function CodeCellCurrentLine({
       <span
         data-slot="code-cell-current-line-status"
         aria-label={`${languageLabel}: ${accessibleDetailLabel}`}
-        aria-live={isExecuting || isQueued || isErrored ? "polite" : undefined}
+        aria-live={isExecuting || isQueued || isErrored || isCancelled ? "polite" : undefined}
         className={cn(
           "flex min-w-0 shrink-0 items-center whitespace-nowrap font-medium transition-[color,opacity,max-width,gap] duration-150",
           isCompactIdle ? "max-w-0 overflow-hidden opacity-0" : "max-w-64 opacity-100",

--- a/src/components/cell/CompactExecutionButton.tsx
+++ b/src/components/cell/CompactExecutionButton.tsx
@@ -14,6 +14,8 @@ interface CompactExecutionButtonProps {
   isQueued?: boolean;
   /** Whether the latest execution finished with an error */
   isErrored?: boolean;
+  /** Whether the latest execution was cancelled without running */
+  isCancelled?: boolean;
   /** Authenticated actor label for the client that submitted the active execution */
   submittedByActorLabel?: string | null;
   /** Whether the owning cell currently has notebook focus */
@@ -50,6 +52,7 @@ export function CompactExecutionButton({
   isExecuting = false,
   isQueued = false,
   isErrored = false,
+  isCancelled = false,
   submittedByActorLabel = null,
   isCellFocused = false,
   canExecute = true,
@@ -64,9 +67,11 @@ export function CompactExecutionButton({
       ? "queued"
       : isErrored
         ? "error"
-        : count !== null
-          ? "ran"
-          : "idle";
+        : isCancelled
+          ? "cancelled"
+          : count !== null
+            ? "ran"
+            : "idle";
   const displayCount = count === null ? null : formatExecutionCount(count);
   const submittedByLabel = submittedByDisplayLabel(submittedByActorLabel);
   const handleClick = () => {
@@ -87,11 +92,13 @@ export function CompactExecutionButton({
       ? submittedByLabel
         ? `Queued for execution by ${submittedByLabel}`
         : "Queued for execution"
-      : count !== null
-        ? isErrored
-          ? `Last execution ${count} failed`
-          : `Last execution ${count}`
-        : "Execution unavailable";
+      : state === "cancelled"
+        ? "Last execution was cancelled before it ran"
+        : count !== null
+          ? isErrored
+            ? `Last execution ${count} failed`
+            : `Last execution ${count}`
+          : "Execution unavailable";
   const title = canExecute
     ? isExecuting
       ? submittedByLabel
@@ -101,11 +108,13 @@ export function CompactExecutionButton({
         ? submittedByLabel
           ? `Queued for execution by ${submittedByLabel}`
           : "Queued for execution"
-        : count !== null
-          ? isErrored
-            ? `Run cell again; last execution ${count} failed`
-            : `Run cell again; last execution ${count}`
-          : "Run cell"
+        : state === "cancelled"
+          ? "Run cell; last execution was cancelled before it ran"
+          : count !== null
+            ? isErrored
+              ? `Run cell again; last execution ${count} failed`
+              : `Run cell again; last execution ${count}`
+            : "Run cell"
     : readoutTitle;
   const classNameValue = cn(
     "group/exec inline-flex size-5 items-center justify-center rounded-full",
@@ -118,11 +127,13 @@ export function CompactExecutionButton({
     state === "queued" && "text-sky-600 dark:text-sky-400",
     state === "running" && "text-destructive hover:bg-destructive/10",
     state === "error" && "text-destructive/70 hover:bg-destructive/10 hover:text-destructive",
+    state === "cancelled" && "text-muted-foreground/45 hover:bg-muted hover:text-foreground",
     isQueued || !canExecute ? "cursor-default" : "cursor-pointer",
     !canExecute && "opacity-65 hover:bg-transparent hover:text-muted-foreground/45",
     className,
   );
-  const disabledHistoricalState = !canExecute && (state === "ran" || state === "error");
+  const disabledHistoricalState =
+    !canExecute && (state === "ran" || state === "error" || state === "cancelled");
   const content =
     disabledHistoricalState && showReadoutWhenDisabled && displayCount !== null ? (
       <span className="text-[10px] font-medium tabular-nums" aria-hidden="true">

--- a/src/components/cell/__tests__/CompactExecutionButton.test.tsx
+++ b/src/components/cell/__tests__/CompactExecutionButton.test.tsx
@@ -45,4 +45,23 @@ describe("CompactExecutionButton", () => {
     expect(screen.getByRole("status", { name: "Last execution 7" })).toBeTruthy();
     expect(screen.getByTestId("execution-readout")).toHaveAttribute("data-execution-state", "ran");
   });
+
+  it("renders cancelled executions as neutral, not failed", () => {
+    render(<CompactExecutionButton count={null} isCancelled />);
+
+    const button = screen.getByRole("button", {
+      name: "Run cell; last execution was cancelled before it ran",
+    });
+    expect(button).toHaveAttribute("data-execution-state", "cancelled");
+    expect(button.className).not.toContain("text-destructive");
+  });
+
+  it("keeps errored executions distinct from cancelled ones", () => {
+    render(<CompactExecutionButton count={3} isErrored />);
+
+    const button = screen.getByRole("button", {
+      name: "Run cell again; last execution 3 failed",
+    });
+    expect(button).toHaveAttribute("data-execution-state", "error");
+  });
 });


### PR DESCRIPTION
When a run-all queue aborted because a cell errored, the daemon marked every queued entry `status=error` / `success=false`, so the rail showed red "failed" on cells that never ran. Downstream layers were already working around the missing concept: runt-mcp inferred "cancelled" from error-without-execution-count, the execution watcher inferred "interrupted" from error-without-outputs, and the MCP App renderer had a `⊘ cancelled` state with no producer. This makes the status first-class at the source and deletes the guesswork.

## Document schema

`RuntimeStateDoc` executions gain `"cancelled"` as a terminal status: dropped from the queue without running (an earlier cell errored, an interrupt, or kernel death/restart). Cancelled entries carry **no** `success` field - they neither succeeded nor failed - so `success == false` keeps meaning "ran and errored", which is exactly what the frontend's errored check (`success === false || status === "error"`) keys on.

## Writers (daemon + WASM)

Every abort site now splits running from queued:

| Site | Running entry | Queued entries |
|---|---|---|
| `CellError` queue-clear (the screenshot bug) | error via its own `execution_done` | **cancelled** |
| Interrupt (`resolve_interrupted_executions`, renamed) | error (gets the KeyboardInterrupt traceback) | **cancelled** |
| Kernel death | error | **cancelled** |
| Restart stale-queue | error | **cancelled** |
| Defensive sweep (`abort_inflight_executions`, renamed from `mark_inflight_executions_failed`) | error | **cancelled** |
| WASM runtime-peer-gone reconciliation | error | **cancelled** (inherits the sweep) |

## Readers

Cancelled is terminal everywhere a poller checks `done|error` - this is the part that would otherwise hang run-all clients until timeout: `await_execution_terminal`, the MCP run-all poll, `cell_read` status maps, the execution watcher (first-class `Cancelled` terminal reason), and `diffExecutions` (new transition kind). The old runt-mcp inference heuristics are deleted rather than kept as fallbacks - the desktop app ships daemon and MCP server together and cloud is early alpha, so there's no version-skew population to infer for. The watcher's error-without-outputs → interrupted arm stays because it encodes live behavior (the daemon force-fails an interrupted running execution before the KeyboardInterrupt output lands), not version compat. Python's `into_result` already derives success from `status == "done"`, so cancelled flows through as non-success without special-casing.

## UI

Cancelled cells render a muted dashed boundary **without** the origin dot (this cell is not where the failure happened - the dot stays exclusive to the erroring cell), the detail label reads "cancelled" in neutral gray instead of red "failed", and the gutter button gets a neutral cancelled state with explanatory titles ("Run cell; last execution was cancelled before it ran"). An old frontend bundle running against the new daemon shows cancelled cells as quiet "ready" (no count, no error flag) rather than the previous wrong red "failed" - a graceful intermediate state during dev, moot once frontend and daemon ship together.

## Verification

- Live end-to-end against the rebuilt dev daemon: run-all over `[ok, raise, print, print]` yields `done / error / cancelled / cancelled` in the document, `⊘ cancelled` in the MCP cell list, and run-all returns without hanging on the cancelled entries.
- New daemon test pins the exact scenario (`cell_error_cancels_queued_cells_behind_it`); existing kernel-death/interrupt/sweep tests updated to assert the split; `runtime-doc` tests pin cancelled semantics (`success` stays absent).
- Full suites green: 954 runtimed, 225 runtime-doc, 34 runtimed-wasm, 78 notebook-sync, 158 runt-mcp, 1912 frontend; `tsc -b`, clippy, `cargo xtask lint` clean.

Pre-existing behavior left alone, noted for the record: run-all `structuredContent` only includes output-bearing cells, so cancelled cells appear in the text content and cell-list resource but not the structured cells array - same as before, when they were error-without-outputs.
