### PR TITLE
fix(notebook): keep markdown outline live after edits

### DIFF
--- a/apps/notebook/src/components/MarkdownCell.tsx
+++ b/apps/notebook/src/components/MarkdownCell.tsx
@@ -681,6 +681,10 @@ export const MarkdownCell = memo(function MarkdownCell({
     ],
     [searchQuery, remoteCursorsExt, textAttributionExt, presenceSenderExt],
   );
+  const editorExtensions = useMemo(
+    () => [crdtBridgeExt, ...searchExtensions],
+    [crdtBridgeExt, searchExtensions],
+  );
 
   // Get keyboard navigation bindings
   const navigationKeyMap = useCellKeyboardNavigation({
@@ -830,7 +834,7 @@ export const MarkdownCell = memo(function MarkdownCell({
                 onBlur={handleBlur}
                 onSelectionChange={noteEditorSourcePosition}
                 keyMap={keyMap}
-                extensions={[crdtBridgeExt, ...searchExtensions]}
+                extensions={editorExtensions}
                 placeholder="Enter markdown..."
                 className="min-h-[2rem]"
                 autoFocus={editing}

--- a/apps/notebook/src/lib/__tests__/crdt-editor-bridge.test.ts
+++ b/apps/notebook/src/lib/__tests__/crdt-editor-bridge.test.ts
@@ -1,5 +1,5 @@
 // @vitest-environment jsdom
-import { EditorState } from "@codemirror/state";
+import { Compartment, EditorState } from "@codemirror/state";
 import { EditorView } from "@codemirror/view";
 import { afterEach, describe, expect, it } from "vite-plus/test";
 import { createCrdtBridge, remoteChangesFromTextAttributions } from "../crdt-editor-bridge";
@@ -122,6 +122,46 @@ describe("createCrdtBridge capability gating", () => {
     await Promise.resolve();
 
     expect(calls).toEqual(["sync", "sync", "store:hello!?"]);
+  });
+
+  it("keeps notifying source changes after the bridge plugin is recreated", async () => {
+    let source = "hello";
+    const calls: string[] = [];
+    const bridge = createCrdtBridge({
+      getHandle: () =>
+        ({
+          splice_source: (
+            _cellId: string,
+            index: number,
+            deleteCount: number,
+            text: string,
+          ) => {
+            source = `${source.slice(0, index)}${text}${source.slice(index + deleteCount)}`;
+            return true;
+          },
+          get_cell_source: () => source,
+        }) as never,
+      cellId: "cell-a",
+      onSourceChanged: (nextSource) => calls.push(`store:${nextSource}`),
+      onSyncNeeded: () => calls.push("sync"),
+    });
+    const bridgeCompartment = new Compartment();
+    const view = new EditorView({
+      state: EditorState.create({
+        doc: "hello",
+        extensions: [bridgeCompartment.of(bridge.extension)],
+      }),
+    });
+    views.push(view);
+
+    view.dispatch({ effects: bridgeCompartment.reconfigure([]) });
+    view.dispatch({ effects: bridgeCompartment.reconfigure(bridge.extension) });
+    view.dispatch({ changes: { from: 5, insert: "!" } });
+
+    await Promise.resolve();
+
+    expect(view.state.doc.toString()).toBe("hello!");
+    expect(calls).toEqual(["sync", "store:hello!"]);
   });
 
   it("drops pending coalesced store updates after imperative source replacement", async () => {

--- a/apps/notebook/src/lib/__tests__/notebook-cells.test.ts
+++ b/apps/notebook/src/lib/__tests__/notebook-cells.test.ts
@@ -29,6 +29,31 @@ const markdownCell = (id: string, source = ""): NotebookCell => ({
   metadata: {},
 });
 
+function markdownProjection(
+  source: string,
+  anchors: readonly { title: string; level: number; slug: string }[],
+): NonNullable<Extract<NotebookCell, { cell_type: "markdown" }>["markdownProjection"]> {
+  return {
+    version: 1,
+    engine: "test",
+    source,
+    byteLength: source.length,
+    utf16Length: source.length,
+    measurement: { estimatedHeight: 24, confidence: "high", width: 720 },
+    anchors: anchors.map((anchor, index) => ({
+      anchorId: `anchor:${anchor.slug}`,
+      blockId: `block:${index}`,
+      level: anchor.level,
+      slug: anchor.slug,
+      sourceSpanByte: [0, source.length],
+      sourceSpanUtf16: [0, source.length],
+      title: anchor.title,
+    })),
+    blocks: [],
+    runs: [],
+  };
+}
+
 let restoreMarkdownProjectionProjector: (() => void) | undefined;
 
 afterEach(() => {
@@ -461,6 +486,43 @@ describe("cell diffing in replaceNotebookCells", () => {
     const ref2 = getCellById("m1");
 
     expect(ref2).toBe(ref1);
+  });
+
+  it("replaces same-source markdown cells when the projection refreshes", () => {
+    const source = "# ANother one\n\n# LMAO this is fine";
+    const staleCell: NotebookCell = {
+      ...markdownCell("m1", source),
+      markdownProjection: markdownProjection(source, [
+        { title: "LMAO", level: 1, slug: "lmao" },
+        { title: "Deeper note", level: 3, slug: "deeper-note" },
+      ]),
+    };
+    const refreshedCell: NotebookCell = {
+      ...markdownCell("m1", source),
+      markdownProjection: markdownProjection(source, [
+        { title: "ANother one", level: 1, slug: "another-one" },
+        { title: "LMAO this is fine", level: 1, slug: "lmao-this-is-fine" },
+        { title: "Deeper note", level: 3, slug: "deeper-note" },
+      ]),
+    };
+
+    replaceNotebookCells([staleCell]);
+    const ref1 = getCellById("m1");
+    const { result } = renderHook(() => useMaterializeVersion());
+    const initialVersion = result.current;
+
+    act(() => {
+      replaceNotebookCells([refreshedCell]);
+    });
+
+    const ref2 = getCellById("m1");
+    expect(ref2).not.toBe(ref1);
+    expect(result.current).toBe(initialVersion + 1);
+    expect(
+      ref2?.cell_type === "markdown"
+        ? ref2.markdownProjection?.anchors.map((anchor) => anchor.title)
+        : [],
+    ).toEqual(["ANother one", "LMAO this is fine", "Deeper note"]);
   });
 
   it("only changes reference for the cell that changed", () => {

--- a/apps/notebook/src/lib/__tests__/notebook-view-model.test.ts
+++ b/apps/notebook/src/lib/__tests__/notebook-view-model.test.ts
@@ -46,6 +46,32 @@ describe("createNotebookViewModelFromNotebookCells", () => {
     expect(outlineTitles()).toEqual(["Updated title"]);
   });
 
+  it("updates outline headings after direct markdown source edits", () => {
+    restoreMarkdownProjectionProjector = setMarkdownProjectionProjector(testMarkdownProjector);
+    replaceNotebookCells([
+      {
+        ...markdownCell("later", "## Later section\n\n# LMAO\n\n### Deeper note"),
+        markdownProjection: testMarkdownProjection(
+          "## Later section\n\n# LMAO\n\n### Deeper note",
+        ),
+      },
+    ]);
+
+    expect(outlineTitles()).toEqual(["Later section", "LMAO", "Deeper note"]);
+
+    updateCellSourceById(
+      "later",
+      "## Later section\n\n# ANother one\n\n# LMAO this is fine\n\n### Deeper note",
+    );
+
+    expect(outlineTitles()).toEqual([
+      "Later section",
+      "ANother one",
+      "LMAO this is fine",
+      "Deeper note",
+    ]);
+  });
+
   it("projects outline status labels from shared cell chrome", () => {
     replaceNotebookCells([codeCell("code-1", "print('hi')")]);
 
@@ -68,8 +94,28 @@ function testMarkdownProjection(source: string): NonNullable<Extract<NotebookCel
 }
 
 function testMarkdownProjector(source: string): string {
-  const title = source.replace(/^#+\s*/, "").split(/\r?\n/, 1)[0]?.trim() || "Untitled";
-  const slug = title.toLowerCase().replace(/[^a-z0-9]+/g, "-").replace(/^-+|-+$/g, "");
+  const anchors = source
+    .split(/\r?\n/)
+    .flatMap((line, index) => {
+      const match = /^(#{1,6})\s+(.+?)\s*$/.exec(line);
+      if (!match) return [];
+      const title = match[2].trim();
+      const slug = title
+        .toLowerCase()
+        .replace(/[^a-z0-9]+/g, "-")
+        .replace(/^-+|-+$/g, "");
+      return [
+        {
+          anchorId: `anchor:${slug}`,
+          blockId: `block:${index}`,
+          level: match[1].length,
+          slug,
+          sourceSpanByte: [0, source.length],
+          sourceSpanUtf16: [0, source.length],
+          title,
+        },
+      ];
+    });
   return JSON.stringify({
     version: 1,
     engine: "test",
@@ -80,17 +126,7 @@ function testMarkdownProjector(source: string): string {
       confidence: "high",
       width: 720,
     },
-    anchors: [
-      {
-        anchorId: `anchor:${slug}`,
-        blockId: "block:0",
-        level: 1,
-        slug,
-        sourceSpanByte: [0, source.length],
-        sourceSpanUtf16: [0, source.length],
-        title,
-      },
-    ],
+    anchors,
     blocks: [],
     runs: [],
   });

--- a/apps/notebook/src/lib/crdt-editor-bridge.ts
+++ b/apps/notebook/src/lib/crdt-editor-bridge.ts
@@ -174,6 +174,7 @@ export function createCrdtBridge(config: CrdtBridgeConfig): CrdtBridge {
 
   class CrdtBridgePlugin implements PluginValue {
     constructor(view: EditorView) {
+      destroyed = false;
       currentView = view;
     }
 

--- a/src/components/notebook/state/cell-store.ts
+++ b/src/components/notebook/state/cell-store.ts
@@ -241,6 +241,7 @@ function cellsEqual(a: NotebookStoreCell, b: NotebookStoreCell): boolean {
     }
   } else if (a.cell_type === "markdown") {
     const bm = b as typeof a;
+    if (a.markdownProjection !== bm.markdownProjection) return false;
     if (
       !shallowRecordEqual(
         a.resolvedAssets as Record<string, unknown> | undefined,
@@ -266,6 +267,7 @@ function cellChromeEqual(a: NotebookStoreCell, b: NotebookStoreCell): boolean {
 
   if (a.cell_type === "markdown") {
     const bm = b as typeof a;
+    if (a.markdownProjection !== bm.markdownProjection) return false;
     return shallowRecordEqual(
       a.resolvedAssets as Record<string, unknown> | undefined,
       bm.resolvedAssets as Record<string, unknown> | undefined,


### PR DESCRIPTION
## Summary

- keep markdown outline projections live after markdown editor extension reconfiguration
- include refreshed markdown projection objects in cell-store equality so stale headings are replaced
- add regression coverage for bridge plugin recreation, direct markdown source edits, and same-source projection refreshes

## Verification

- `pnpm test:run apps/notebook/src/lib/__tests__/crdt-editor-bridge.test.ts apps/notebook/src/lib/__tests__/notebook-view-model.test.ts apps/notebook/src/lib/__tests__/notebook-cells.test.ts src/components/notebook/__tests__/view-model.test.ts`
- `cargo xtask lint --fix`
- Direct Playwright probe against `localhost:9475` using a temp notebook copy: edit a markdown heading and verify the rail outline replaces the old heading with the new one

## Notes

- Rebases cleanly onto current `origin/main`.
