### PR TITLE
test(notebook): cover outline headings with fixture

### DIFF
--- a/apps/notebook/e2e/fixtures/outline-headings.ipynb
+++ b/apps/notebook/e2e/fixtures/outline-headings.ipynb
@@ -1,0 +1,59 @@
+{
+  "cells": [
+    {
+      "cell_type": "markdown",
+      "id": "outline-overview",
+      "metadata": {},
+      "source": [
+        "# Notebook rail fixture\n",
+        "\n",
+        "This fixture keeps outline assertions tied to real rendered markdown content.\n",
+        "\n",
+        "## Data preparation\n",
+        "\n",
+        "Load source records before analysis.\n",
+        "\n",
+        "### Normalize records\n",
+        "\n",
+        "Check schema changes and empty values.\n",
+        "\n",
+        "## Review outputs\n",
+        "\n",
+        "Confirm the report sections are easy to navigate.\n",
+        "\n",
+        "### Visual checks\n",
+        "\n",
+        "Keep nested headings visible in the notebook rail."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "id": "outline-code",
+      "metadata": {},
+      "outputs": [],
+      "source": ["print(\"outline fixture\")"]
+    },
+    {
+      "cell_type": "markdown",
+      "id": "outline-summary",
+      "metadata": {},
+      "source": [
+        "A trailing markdown cell without a heading should not hide any earlier outline entries."
+      ]
+    }
+  ],
+  "metadata": {
+    "kernelspec": {
+      "display_name": "Python 3",
+      "language": "python",
+      "name": "python3"
+    },
+    "language_info": {
+      "name": "python",
+      "pygments_lexer": "ipython3"
+    }
+  },
+  "nbformat": 4,
+  "nbformat_minor": 5
+}

--- a/apps/notebook/e2e/notebook-rail-outline.spec.ts
+++ b/apps/notebook/e2e/notebook-rail-outline.spec.ts
@@ -1,11 +1,32 @@
 import { expect, test } from "@playwright/test";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
 import {
   openNotebookRoom,
+  openNotebookPath,
   waitForCellCount,
   waitForCodeCellContaining,
   waitForKernelStatus,
 } from "./helpers";
 import { McpPeer } from "./mcp-peer";
+
+const outlineFixturePath = path.resolve(
+  path.dirname(fileURLToPath(import.meta.url)),
+  "fixtures/outline-headings.ipynb",
+);
+
+function copyOutlineFixture() {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "nteract-outline-fixture-"));
+  const notebookPath = path.join(dir, "outline-headings.ipynb");
+  fs.copyFileSync(outlineFixturePath, notebookPath);
+  return { dir, notebookPath };
+}
+
+function cleanupOutlineFixture(dir: string) {
+  fs.rmSync(dir, { recursive: true, force: true });
+}
 
 test.describe("notebook rail outline", () => {
   let mcp: McpPeer | null = null;
@@ -13,6 +34,32 @@ test.describe("notebook rail outline", () => {
   test.afterEach(async () => {
     await mcp?.close();
     mcp = null;
+  });
+
+  test("renders every heading from the outline fixture", async ({ page }) => {
+    const { dir, notebookPath } = copyOutlineFixture();
+    try {
+      await openNotebookPath(page, notebookPath, { environmentMode: "notebook" });
+      await waitForCellCount(page, 3);
+
+      await page.getByLabel("Outline").click();
+      const outlinePanel = page.getByTestId("notebook-outline-panel");
+      for (const heading of [
+        "Notebook rail fixture",
+        "Data preparation",
+        "Normalize records",
+        "Review outputs",
+        "Visual checks",
+      ]) {
+        await expect(outlinePanel.getByRole("link", { name: heading, exact: true })).toBeVisible();
+      }
+
+      await expect(
+        outlinePanel.locator('li[data-outline-level="2"] li[data-outline-level="3"]'),
+      ).toHaveCount(2);
+    } finally {
+      cleanupOutlineFixture(dir);
+    }
   });
 
   test("renders nested headings and keeps code cells in their markdown section", async ({

--- a/apps/notebook/src/lib/__tests__/notebook-view-model.test.ts
+++ b/apps/notebook/src/lib/__tests__/notebook-view-model.test.ts
@@ -50,25 +50,25 @@ describe("createNotebookViewModelFromNotebookCells", () => {
     restoreMarkdownProjectionProjector = setMarkdownProjectionProjector(testMarkdownProjector);
     replaceNotebookCells([
       {
-        ...markdownCell("later", "## Later section\n\n# LMAO\n\n### Deeper note"),
+        ...markdownCell("later", "## Analysis\n\n# Draft checkpoint\n\n### Supporting detail"),
         markdownProjection: testMarkdownProjection(
-          "## Later section\n\n# LMAO\n\n### Deeper note",
+          "## Analysis\n\n# Draft checkpoint\n\n### Supporting detail",
         ),
       },
     ]);
 
-    expect(outlineTitles()).toEqual(["Later section", "LMAO", "Deeper note"]);
+    expect(outlineTitles()).toEqual(["Analysis", "Draft checkpoint", "Supporting detail"]);
 
     updateCellSourceById(
       "later",
-      "## Later section\n\n# ANother one\n\n# LMAO this is fine\n\n### Deeper note",
+      "## Analysis\n\n# Updated checkpoint\n\n# Final review\n\n### Supporting detail",
     );
 
     expect(outlineTitles()).toEqual([
-      "Later section",
-      "ANother one",
-      "LMAO this is fine",
-      "Deeper note",
+      "Analysis",
+      "Updated checkpoint",
+      "Final review",
+      "Supporting detail",
     ]);
   });
 

--- a/src/components/notebook/__tests__/view-model.test.ts
+++ b/src/components/notebook/__tests__/view-model.test.ts
@@ -204,30 +204,27 @@ describe("notebook shell view model", () => {
       return JSON.stringify(
         testMarkdownProjection(
           source,
-          source.includes("Deep in the emoji train")
+          source.includes("Model diagnostics")
             ? [
-                { title: "Later section", level: 2, slug: "later-section" },
-                { title: "Deep in the emoji train", level: 3, slug: "deep-in-the-emoji-train" },
-                { title: "Deeper note", level: 3, slug: "deeper-note" },
+                { title: "Results", level: 2, slug: "results" },
+                { title: "Model diagnostics", level: 3, slug: "model-diagnostics" },
+                { title: "Review outputs", level: 3, slug: "review-outputs" },
               ]
             : [
-                { title: "Later section", level: 2, slug: "later-section" },
-                { title: "Deeper note", level: 3, slug: "deeper-note" },
+                { title: "Results", level: 2, slug: "results" },
+                { title: "Review outputs", level: 3, slug: "review-outputs" },
               ],
         ),
       );
     });
 
     try {
-      const currentSource = "## Later section\n\n### Deep in the emoji train\n\n### Deeper note";
-      const staleSource = "## Later section\n\n### Deeper note\n\n".padEnd(
-        currentSource.length,
-        "X",
-      );
+      const currentSource = "## Results\n\n### Model diagnostics\n\n### Review outputs";
+      const staleSource = "## Results\n\n### Review outputs\n\n".padEnd(currentSource.length, "X");
       expect(currentSource.length).toBe(staleSource.length);
       const staleCell = markdownViewCell("later", staleSource, [
-        { title: "Later section", level: 2, slug: "later-section" },
-        { title: "Deeper note", level: 3, slug: "deeper-note" },
+        { title: "Results", level: 2, slug: "results" },
+        { title: "Review outputs", level: 3, slug: "review-outputs" },
       ]);
       const outline = notebookViewCellsToOutlineItems([
         {
@@ -238,9 +235,9 @@ describe("notebook shell view model", () => {
 
       expect(calls).toBe(1);
       expect(outline.map((item) => [item.id, item.title, item.anchor])).toEqual([
-        ["later:heading:0", "Later section", "later-section"],
-        ["later:heading:1", "Deep in the emoji train", "deep-in-the-emoji-train"],
-        ["later:heading:2", "Deeper note", "deeper-note"],
+        ["later:heading:0", "Results", "results"],
+        ["later:heading:1", "Model diagnostics", "model-diagnostics"],
+        ["later:heading:2", "Review outputs", "review-outputs"],
       ]);
     } finally {
       restore();


### PR DESCRIPTION
## Summary

- add a committed browser E2E notebook fixture that exercises multiple markdown headings in the rail outline
- verify the outline renders every heading from that fixture, including nested headings in the same markdown cell
- replace joke-specific regression names with neutral notebook headings in the unit tests

## Verification

- `pnpm test:run apps/notebook/src/lib/__tests__/notebook-view-model.test.ts src/components/notebook/__tests__/view-model.test.ts`
- `pnpm --filter notebook-ui test:e2e:browser -- --project=chromium apps/notebook/e2e/notebook-rail-outline.spec.ts`
- `cargo xtask lint --fix`

## Notes

- The local dev daemon was restarted and is running for this worktree in development mode.
