### PR TITLE
feat(notebook-cloud): instrument sync frame budgets

### DIFF
--- a/apps/notebook-cloud/src/notebook-room.ts
+++ b/apps/notebook-cloud/src/notebook-room.ts
@@ -27,6 +27,12 @@ import {
   typedFrameFromRoomHostOutbound,
   type RoomHostFrameResult,
 } from "./room-materializer.ts";
+import {
+  syncFrameBudgetLogFields,
+  SyncFrameBudgetTracker,
+  type SyncFrameBudgetDirection,
+  type SyncFrameBudgetSummary,
+} from "./sync-frame-budget.ts";
 
 interface Peer {
   id: string;
@@ -85,6 +91,7 @@ export class NotebookRoom {
   private broadcastDepth = 0;
   private readonly materializers = new Map<string, RoomMaterializer>();
   private readonly restoredPeersReady: Promise<void>;
+  private readonly frameBudget = new SyncFrameBudgetTracker();
 
   constructor(
     private readonly state: DurableObjectState,
@@ -353,7 +360,9 @@ export class NotebookRoom {
     peer: Peer,
     message: string | ArrayBuffer | ArrayBufferView,
   ): Promise<void> {
+    const incomingByteLength = webSocketMessageByteLength(message);
     if (typeof message === "string") {
+      this.recordFrameBudget(notebookId, peer, "incoming", "text", incomingByteLength);
       this.rejectFrame(
         notebookId,
         peer,
@@ -367,9 +376,17 @@ export class NotebookRoom {
     try {
       frame = splitTypedFrame(message);
     } catch (error) {
+      this.recordFrameBudget(notebookId, peer, "incoming", "malformed", incomingByteLength);
       this.rejectFrame(notebookId, peer, undefined, String(error));
       return;
     }
+    this.recordFrameBudget(
+      notebookId,
+      peer,
+      "incoming",
+      frameTypeName(frame.type),
+      incomingByteLength,
+    );
 
     const sizeLimits = frameSizeLimits(frame.type);
     if (frame.payload.byteLength > sizeLimits.cap) {
@@ -721,7 +738,7 @@ export class NotebookRoom {
     this.broadcastDepth += 1;
     try {
       for (const peer of peers) {
-        if (!this.trySendFrame(peer, frame)) {
+        if (!this.trySendFrame(notebookId, peer, frame)) {
           this.queuePeerRemoval(notebookId, peer);
         }
       }
@@ -734,7 +751,7 @@ export class NotebookRoom {
   }
 
   private sendFrameToPeer(notebookId: string, peer: Peer, frame: Uint8Array): void {
-    if (!this.trySendFrame(peer, frame)) {
+    if (!this.trySendFrame(notebookId, peer, frame)) {
       cloudLog("warn", "room.peer_send.failed", {
         notebook_id: notebookId,
         peer_id: peer.id,
@@ -748,7 +765,14 @@ export class NotebookRoom {
     }
   }
 
-  private trySendFrame(peer: Peer, frame: Uint8Array): boolean {
+  private trySendFrame(notebookId: string, peer: Peer, frame: Uint8Array): boolean {
+    this.recordFrameBudget(
+      notebookId,
+      peer,
+      "outgoing",
+      frameTypeName(frame[0] ?? -1),
+      frame.byteLength,
+    );
     try {
       peer.socket.send(frame.buffer.slice(frame.byteOffset, frame.byteOffset + frame.byteLength));
       return true;
@@ -805,6 +829,7 @@ export class NotebookRoom {
       counter: "connections_closed",
       counter_delta: 1,
     });
+    this.logPeerFrameBudget(notebookId, peer);
 
     this.broadcastControl(notebookId, {
       type: "cloud_peer_left",
@@ -823,6 +848,54 @@ export class NotebookRoom {
     if (peer.identity.scope === "runtime_peer") {
       this.refreshRuntimePeerWatch(notebookId);
     }
+  }
+
+  private recordFrameBudget(
+    notebookId: string,
+    peer: Peer,
+    direction: SyncFrameBudgetDirection,
+    frameType: string,
+    byteLength: number,
+  ): void {
+    const nowMs = Date.now();
+    this.frameBudget.record({
+      peerId: peer.id,
+      scope: peer.identity.scope,
+      direction,
+      frameType,
+      byteLength,
+      nowMs,
+    });
+    const summary = this.frameBudget.summarizeWindowIfNeeded(nowMs);
+    if (summary) {
+      this.logFrameBudgetSummary(notebookId, "periodic", summary);
+    }
+  }
+
+  private logFrameBudgetSummary(
+    notebookId: string,
+    reason: "periodic" | "peer_closed",
+    summary: SyncFrameBudgetSummary,
+    peer?: Peer,
+  ): void {
+    cloudLog("info", "room.sync_frame_budget.summary", {
+      notebook_id: notebookId,
+      reason,
+      peer_id: peer?.id,
+      scope: peer?.identity.scope,
+      ...syncFrameBudgetLogFields(summary),
+      counter:
+        reason === "peer_closed" ? "sync_frame_budget_peer_summaries" : "sync_frame_budget_windows",
+      counter_delta: 1,
+    });
+  }
+
+  private logPeerFrameBudget(notebookId: string, peer: Peer): void {
+    const summary = this.frameBudget.consumePeer(peer.id);
+    if (!summary) {
+      return;
+    }
+    this.logFrameBudgetSummary(notebookId, "peer_closed", summary, peer);
   }
 
   /// Whether any currently-attached peer is a `runtime_peer`.
@@ -1090,6 +1163,16 @@ function workstationAttachmentControlNotebookId(pathname: string): string | unde
 
 function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function webSocketMessageByteLength(message: string | ArrayBuffer | ArrayBufferView): number {
+  if (typeof message === "string") {
+    return new TextEncoder().encode(message).byteLength;
+  }
+  if (message instanceof ArrayBuffer) {
+    return message.byteLength;
+  }
+  return message.byteLength;
 }
 
 function json(value: unknown, status: number): Response {

--- a/apps/notebook-cloud/src/notebook-room.ts
+++ b/apps/notebook-cloud/src/notebook-room.ts
@@ -69,6 +69,15 @@ interface RuntimePeerWorkstationMetadata {
   workingDirectory?: string;
 }
 
+interface RejectFrameOptions {
+  countsTowardStreak?: boolean;
+}
+
+interface PeerCloseOptions {
+  code?: number;
+  reason?: string;
+}
+
 const MAX_STORED_FRAMES = 500;
 
 /// Grace window after the last `runtime_peer` leaves before the room reconciles
@@ -78,6 +87,8 @@ const MAX_STORED_FRAMES = 500;
 /// window the alarm is disarmed.
 const RUNTIME_PEER_GONE_GRACE_MS = 30_000;
 const MAX_CONSECUTIVE_REJECTED_FRAMES = 8;
+const REJECTED_FRAME_POLICY_CLOSE_CODE = 1008;
+const REJECTED_FRAME_POLICY_CLOSE_REASON = "too many rejected frames";
 
 /// Storage key holding the notebook id whose `runtime_peer` departure armed the
 /// reconciliation alarm. Persisted so a DO that hibernates between the alarm
@@ -86,7 +97,10 @@ const RUNTIME_PEER_WATCH_KEY = "runtime_peer_gone_watch";
 
 export class NotebookRoom {
   private readonly peers = new Map<string, Peer>();
-  private readonly pendingRemovals = new Map<string, { notebookId: string; peer: Peer }>();
+  private readonly pendingRemovals = new Map<
+    string,
+    { notebookId: string; peer: Peer; closeOptions: PeerCloseOptions }
+  >();
   private nextFrameSequence = 0;
   private frameSequenceReady: Promise<void> | undefined;
   private framePersistQueue: Promise<void> = Promise.resolve();
@@ -480,6 +494,7 @@ export class NotebookRoom {
           peer,
           normalizedFrame.type,
           `room host rejected ${frameTypeName(normalizedFrame.type)} frame: ${String(error)}`,
+          { countsTowardStreak: false },
         );
         return;
       }
@@ -530,6 +545,7 @@ export class NotebookRoom {
         peer,
         normalizedFrame.type,
         `failed to persist ${frameTypeName(normalizedFrame.type)} frame: ${String(error)}`,
+        { countsTowardStreak: false },
       );
       return;
     }
@@ -709,9 +725,19 @@ export class NotebookRoom {
     peer: Peer,
     frameType: number | undefined,
     reason: string,
+    options: RejectFrameOptions = {},
   ): void {
-    const policy = rejectedFramePolicy(peer.consecutiveRejectedFrames);
-    peer.consecutiveRejectedFrames = policy.consecutiveRejectedFrames;
+    const countsTowardStreak = options.countsTowardStreak ?? true;
+    const policy = countsTowardStreak
+      ? rejectedFramePolicy(peer.consecutiveRejectedFrames)
+      : {
+          consecutiveRejectedFrames: peer.consecutiveRejectedFrames,
+          limit: MAX_CONSECUTIVE_REJECTED_FRAMES,
+          shouldClose: false,
+        };
+    if (countsTowardStreak) {
+      peer.consecutiveRejectedFrames = policy.consecutiveRejectedFrames;
+    }
 
     if (policy.shouldClose) {
       cloudLog("warn", "room.peer.closed_for_rejected_frames", {
@@ -727,7 +753,10 @@ export class NotebookRoom {
         counter: "peers_closed_for_rejected_frames",
         counter_delta: 1,
       });
-      this.removePeer(notebookId, peer);
+      this.removePeer(notebookId, peer, {
+        code: REJECTED_FRAME_POLICY_CLOSE_CODE,
+        reason: REJECTED_FRAME_POLICY_CLOSE_REASON,
+      });
       return;
     }
 
@@ -738,6 +767,7 @@ export class NotebookRoom {
       scope: peer.identity.scope,
       frame_type: frameType === undefined ? "unknown" : frameTypeName(frameType),
       reason,
+      counts_toward_rejected_frame_streak: countsTowardStreak,
       consecutive_rejected_frame_count: policy.consecutiveRejectedFrames,
       consecutive_rejected_frame_limit: policy.limit,
       room_peer_count: this.peers.size,
@@ -819,27 +849,31 @@ export class NotebookRoom {
     }
   }
 
-  private queuePeerRemoval(notebookId: string, peer: Peer): void {
+  private queuePeerRemoval(
+    notebookId: string,
+    peer: Peer,
+    closeOptions: PeerCloseOptions = {},
+  ): void {
     if (!this.peers.has(peer.id)) {
       return;
     }
 
-    this.pendingRemovals.set(peer.id, { notebookId, peer });
+    this.pendingRemovals.set(peer.id, { notebookId, peer, closeOptions });
   }
 
   private flushPendingRemovals(): void {
     while (this.pendingRemovals.size > 0) {
       const removals = Array.from(this.pendingRemovals.values());
       this.pendingRemovals.clear();
-      for (const { notebookId, peer } of removals) {
-        this.removePeer(notebookId, peer);
+      for (const { notebookId, peer, closeOptions } of removals) {
+        this.removePeer(notebookId, peer, closeOptions);
       }
     }
   }
 
-  private removePeer(notebookId: string, peer: Peer): void {
+  private removePeer(notebookId: string, peer: Peer, closeOptions: PeerCloseOptions = {}): void {
     if (this.broadcastDepth > 0) {
-      this.queuePeerRemoval(notebookId, peer);
+      this.queuePeerRemoval(notebookId, peer, closeOptions);
       return;
     }
 
@@ -853,7 +887,7 @@ export class NotebookRoom {
     );
 
     try {
-      peer.socket.close();
+      peer.socket.close(closeOptions.code, closeOptions.reason);
     } catch {
       // Socket is already gone; the peer has still been removed from room state.
     }

--- a/apps/notebook-cloud/src/notebook-room.ts
+++ b/apps/notebook-cloud/src/notebook-room.ts
@@ -40,6 +40,7 @@ interface Peer {
   identity: AuthenticatedConnection;
   connectedAt: string;
   workstation: RuntimePeerWorkstationMetadata | null;
+  consecutiveRejectedFrames: number;
 }
 
 interface StoredRoomFrame {
@@ -76,6 +77,7 @@ const MAX_STORED_FRAMES = 500;
 /// kernel that is about to come back: if a `runtime_peer` rejoins inside the
 /// window the alarm is disarmed.
 const RUNTIME_PEER_GONE_GRACE_MS = 30_000;
+const MAX_CONSECUTIVE_REJECTED_FRAMES = 8;
 
 /// Storage key holding the notebook id whose `runtime_peer` departure armed the
 /// reconciliation alarm. Persisted so a DO that hibernates between the alarm
@@ -140,6 +142,7 @@ export class NotebookRoom {
       identity,
       connectedAt: new Date().toISOString(),
       workstation: runtimePeerWorkstationMetadataFromRequest(request, identity),
+      consecutiveRejectedFrames: 0,
     };
 
     this.acceptPeerSocket(notebookId, peer);
@@ -291,6 +294,7 @@ export class NotebookRoom {
         identity: attachment.identity,
         connectedAt: attachment.connectedAt,
         workstation: normalizeRuntimePeerWorkstationMetadata(attachment.workstation),
+        consecutiveRejectedFrames: 0,
       };
       this.peers.set(attachment.peerId, peer);
       restored.push({ notebookId: attachment.notebookId, peer });
@@ -460,6 +464,7 @@ export class NotebookRoom {
         byte_length: normalizedFrame.payload.byteLength,
         timestamp: receivedAt,
       });
+      this.resetRejectedFrameStreak(peer);
       return;
     }
 
@@ -513,6 +518,7 @@ export class NotebookRoom {
         byte_length: normalizedFrame.payload.byteLength,
         timestamp: receivedAt,
       });
+      this.resetRejectedFrameStreak(peer);
       return;
     }
 
@@ -541,6 +547,7 @@ export class NotebookRoom {
       byte_length: normalizedFrame.payload.byteLength,
       timestamp: receivedAt,
     });
+    this.resetRejectedFrameStreak(peer);
   }
 
   private scopeAllowsFrame(identity: AuthenticatedConnection, frame: TypedFrame): boolean {
@@ -703,6 +710,27 @@ export class NotebookRoom {
     frameType: number | undefined,
     reason: string,
   ): void {
+    const policy = rejectedFramePolicy(peer.consecutiveRejectedFrames);
+    peer.consecutiveRejectedFrames = policy.consecutiveRejectedFrames;
+
+    if (policy.shouldClose) {
+      cloudLog("warn", "room.peer.closed_for_rejected_frames", {
+        notebook_id: notebookId,
+        peer_id: peer.id,
+        principal: peer.identity.principal,
+        scope: peer.identity.scope,
+        frame_type: frameType === undefined ? "unknown" : frameTypeName(frameType),
+        reason,
+        consecutive_rejected_frame_count: policy.consecutiveRejectedFrames,
+        consecutive_rejected_frame_limit: policy.limit,
+        room_peer_count: this.peers.size,
+        counter: "peers_closed_for_rejected_frames",
+        counter_delta: 1,
+      });
+      this.removePeer(notebookId, peer);
+      return;
+    }
+
     cloudLog("warn", "room.frame.rejected", {
       notebook_id: notebookId,
       peer_id: peer.id,
@@ -710,6 +738,8 @@ export class NotebookRoom {
       scope: peer.identity.scope,
       frame_type: frameType === undefined ? "unknown" : frameTypeName(frameType),
       reason,
+      consecutive_rejected_frame_count: policy.consecutiveRejectedFrames,
+      consecutive_rejected_frame_limit: policy.limit,
       room_peer_count: this.peers.size,
       counter: "rejected_frames",
       counter_delta: 1,
@@ -722,6 +752,10 @@ export class NotebookRoom {
       reason,
       timestamp: new Date().toISOString(),
     });
+  }
+
+  private resetRejectedFrameStreak(peer: Peer): void {
+    peer.consecutiveRejectedFrames = 0;
   }
 
   private sendControl(notebookId: string, peer: Peer, message: SessionControlMessage): void {
@@ -1011,6 +1045,26 @@ export function shouldPersistMaterializedSyncFrame(
   result: Pick<RoomHostFrameResult, "notebook_changed" | "runtime_state_changed">,
 ): boolean {
   return result.notebook_changed || result.runtime_state_changed;
+}
+
+export function rejectedFramePolicy(
+  consecutiveRejectedFrames: number,
+  limit = MAX_CONSECUTIVE_REJECTED_FRAMES,
+): { consecutiveRejectedFrames: number; limit: number; shouldClose: boolean } {
+  const normalizedLimit = Math.max(1, normalizeNonNegativeInteger(limit, 1));
+  const nextCount = normalizeNonNegativeInteger(consecutiveRejectedFrames, 0) + 1;
+  return {
+    consecutiveRejectedFrames: nextCount,
+    limit: normalizedLimit,
+    shouldClose: nextCount >= normalizedLimit,
+  };
+}
+
+function normalizeNonNegativeInteger(value: number, fallback: number): number {
+  if (!Number.isFinite(value)) {
+    return fallback;
+  }
+  return Math.max(0, Math.trunc(value));
 }
 
 export function webSocketUpgradeHeaders(identity: AuthenticatedConnection): Headers {

--- a/apps/notebook-cloud/src/notebook-room.ts
+++ b/apps/notebook-cloud/src/notebook-room.ts
@@ -91,6 +91,10 @@ export class NotebookRoom {
   private broadcastDepth = 0;
   private readonly materializers = new Map<string, RoomMaterializer>();
   private readonly restoredPeersReady: Promise<void>;
+  // In-memory only by design: persisting on the frame hot path would cost more
+  // than the data is worth. Hibernation resets it, so peer_closed summaries
+  // under-count peers whose connection outlives the DO instance — treat the
+  // numbers as trend data, not billing-exact totals.
   private readonly frameBudget = new SyncFrameBudgetTracker();
 
   constructor(
@@ -1167,7 +1171,10 @@ function isRecord(value: unknown): value is Record<string, unknown> {
 
 function webSocketMessageByteLength(message: string | ArrayBuffer | ArrayBufferView): number {
   if (typeof message === "string") {
-    return new TextEncoder().encode(message).byteLength;
+    // Text frames are rejected unconditionally, so an exact UTF-8 byte count
+    // is not worth an encoder allocation + full copy on a path a misbehaving
+    // client can hammer. UTF-16 code-unit length is close enough for budgets.
+    return message.length;
   }
   if (message instanceof ArrayBuffer) {
     return message.byteLength;

--- a/apps/notebook-cloud/src/sync-frame-budget.ts
+++ b/apps/notebook-cloud/src/sync-frame-budget.ts
@@ -1,0 +1,244 @@
+import type { CloudLogFields } from "./observability.ts";
+
+export type SyncFrameBudgetDirection = "incoming" | "outgoing";
+
+export interface SyncFrameBudgetSample {
+  peerId: string;
+  scope: string;
+  direction: SyncFrameBudgetDirection;
+  frameType: string;
+  byteLength: number;
+  nowMs?: number;
+}
+
+export interface SyncFrameBudgetBucket {
+  key: string;
+  direction: SyncFrameBudgetDirection;
+  scope: string;
+  frameType: string;
+  frameCount: number;
+  byteCount: number;
+  maxFrameBytes: number;
+}
+
+export interface SyncFrameBudgetSummary {
+  windowMs: number;
+  frameCount: number;
+  byteCount: number;
+  incomingFrameCount: number;
+  incomingByteCount: number;
+  outgoingFrameCount: number;
+  outgoingByteCount: number;
+  maxFrameBytes: number;
+  buckets: SyncFrameBudgetBucket[];
+}
+
+export const DEFAULT_SYNC_FRAME_BUDGET_SUMMARY_INTERVAL_MS = 30_000;
+export const DEFAULT_SYNC_FRAME_BUDGET_SUMMARY_FRAME_THRESHOLD = 250;
+
+interface SyncFrameBudgetTrackerOptions {
+  startedAtMs?: number;
+  summaryIntervalMs?: number;
+  frameThreshold?: number;
+}
+
+interface MutableBucket {
+  direction: SyncFrameBudgetDirection;
+  scope: string;
+  frameType: string;
+  frameCount: number;
+  byteCount: number;
+  maxFrameBytes: number;
+}
+
+interface MutableTotals {
+  startedAtMs: number;
+  frameCount: number;
+  byteCount: number;
+  incomingFrameCount: number;
+  incomingByteCount: number;
+  outgoingFrameCount: number;
+  outgoingByteCount: number;
+  maxFrameBytes: number;
+}
+
+export class SyncFrameBudgetTracker {
+  private readonly summaryIntervalMs: number;
+  private readonly frameThreshold: number;
+  private windowTotals: MutableTotals;
+  private readonly windowBuckets = new Map<string, MutableBucket>();
+  private readonly peerTotals = new Map<string, MutableTotals>();
+  private readonly peerBuckets = new Map<string, Map<string, MutableBucket>>();
+
+  constructor(options: SyncFrameBudgetTrackerOptions = {}) {
+    const startedAtMs = options.startedAtMs ?? Date.now();
+    this.summaryIntervalMs =
+      options.summaryIntervalMs ?? DEFAULT_SYNC_FRAME_BUDGET_SUMMARY_INTERVAL_MS;
+    this.frameThreshold =
+      options.frameThreshold ?? DEFAULT_SYNC_FRAME_BUDGET_SUMMARY_FRAME_THRESHOLD;
+    this.windowTotals = emptyTotals(startedAtMs);
+  }
+
+  record(sample: SyncFrameBudgetSample): void {
+    const nowMs = sample.nowMs ?? Date.now();
+    const byteLength = Math.max(0, Math.trunc(sample.byteLength));
+    recordTotals(this.windowTotals, sample.direction, byteLength);
+    recordBucket(this.windowBuckets, sample, byteLength);
+
+    const peerTotals = this.peerTotals.get(sample.peerId) ?? emptyTotals(nowMs);
+    this.peerTotals.set(sample.peerId, peerTotals);
+    recordTotals(peerTotals, sample.direction, byteLength);
+
+    const peerBuckets = this.peerBuckets.get(sample.peerId) ?? new Map<string, MutableBucket>();
+    this.peerBuckets.set(sample.peerId, peerBuckets);
+    recordBucket(peerBuckets, sample, byteLength);
+  }
+
+  shouldSummarizeWindow(nowMs = Date.now()): boolean {
+    if (this.windowTotals.frameCount === 0) return false;
+    return (
+      nowMs - this.windowTotals.startedAtMs >= this.summaryIntervalMs ||
+      this.windowTotals.frameCount >= this.frameThreshold
+    );
+  }
+
+  summarizeWindow(nowMs = Date.now()): SyncFrameBudgetSummary | null {
+    if (this.windowTotals.frameCount === 0) return null;
+    const summary = buildSummary(this.windowTotals, this.windowBuckets, nowMs);
+    this.windowTotals = emptyTotals(nowMs);
+    this.windowBuckets.clear();
+    return summary;
+  }
+
+  summarizeWindowIfNeeded(nowMs = Date.now()): SyncFrameBudgetSummary | null {
+    return this.shouldSummarizeWindow(nowMs) ? this.summarizeWindow(nowMs) : null;
+  }
+
+  consumePeer(peerId: string, nowMs = Date.now()): SyncFrameBudgetSummary | null {
+    const totals = this.peerTotals.get(peerId);
+    const buckets = this.peerBuckets.get(peerId);
+    if (!totals || totals.frameCount === 0 || !buckets) return null;
+    const summary = buildSummary(totals, buckets, nowMs);
+    this.peerTotals.delete(peerId);
+    this.peerBuckets.delete(peerId);
+    return summary;
+  }
+}
+
+export function syncFrameBudgetLogFields(summary: SyncFrameBudgetSummary): CloudLogFields {
+  return {
+    window_ms: summary.windowMs,
+    frame_count: summary.frameCount,
+    byte_count: summary.byteCount,
+    incoming_frame_count: summary.incomingFrameCount,
+    incoming_byte_count: summary.incomingByteCount,
+    outgoing_frame_count: summary.outgoingFrameCount,
+    outgoing_byte_count: summary.outgoingByteCount,
+    max_frame_bytes: summary.maxFrameBytes,
+    top_frame_buckets: formatTopFrameBuckets(summary.buckets),
+  };
+}
+
+export function formatTopFrameBuckets(
+  buckets: readonly SyncFrameBudgetBucket[],
+  limit = 12,
+): string[] {
+  return buckets
+    .slice(0, limit)
+    .map((bucket) =>
+      [
+        bucket.direction,
+        bucket.scope,
+        bucket.frameType,
+        `frames=${bucket.frameCount}`,
+        `bytes=${bucket.byteCount}`,
+        `max=${bucket.maxFrameBytes}`,
+      ].join("|"),
+    );
+}
+
+function recordTotals(
+  totals: MutableTotals,
+  direction: SyncFrameBudgetDirection,
+  byteLength: number,
+): void {
+  totals.frameCount += 1;
+  totals.byteCount += byteLength;
+  totals.maxFrameBytes = Math.max(totals.maxFrameBytes, byteLength);
+  if (direction === "incoming") {
+    totals.incomingFrameCount += 1;
+    totals.incomingByteCount += byteLength;
+  } else {
+    totals.outgoingFrameCount += 1;
+    totals.outgoingByteCount += byteLength;
+  }
+}
+
+function recordBucket(
+  buckets: Map<string, MutableBucket>,
+  sample: SyncFrameBudgetSample,
+  byteLength: number,
+): void {
+  const key = bucketKey(sample);
+  const bucket =
+    buckets.get(key) ??
+    ({
+      direction: sample.direction,
+      scope: sample.scope,
+      frameType: sample.frameType,
+      frameCount: 0,
+      byteCount: 0,
+      maxFrameBytes: 0,
+    } satisfies MutableBucket);
+  buckets.set(key, bucket);
+  bucket.frameCount += 1;
+  bucket.byteCount += byteLength;
+  bucket.maxFrameBytes = Math.max(bucket.maxFrameBytes, byteLength);
+}
+
+function buildSummary(
+  totals: MutableTotals,
+  buckets: Map<string, MutableBucket>,
+  nowMs: number,
+): SyncFrameBudgetSummary {
+  return {
+    windowMs: Math.max(0, Math.round(nowMs - totals.startedAtMs)),
+    frameCount: totals.frameCount,
+    byteCount: totals.byteCount,
+    incomingFrameCount: totals.incomingFrameCount,
+    incomingByteCount: totals.incomingByteCount,
+    outgoingFrameCount: totals.outgoingFrameCount,
+    outgoingByteCount: totals.outgoingByteCount,
+    maxFrameBytes: totals.maxFrameBytes,
+    buckets: Array.from(buckets.entries())
+      .map(([key, bucket]) => ({ key, ...bucket }))
+      .sort(compareBuckets),
+  };
+}
+
+function compareBuckets(a: SyncFrameBudgetBucket, b: SyncFrameBudgetBucket): number {
+  return (
+    b.byteCount - a.byteCount ||
+    b.frameCount - a.frameCount ||
+    a.direction.localeCompare(b.direction) ||
+    a.scope.localeCompare(b.scope) ||
+    a.frameType.localeCompare(b.frameType)
+  );
+}
+
+function bucketKey(sample: SyncFrameBudgetSample): string {
+  return `${sample.direction}:${sample.scope}:${sample.frameType}`;
+}
+
+function emptyTotals(startedAtMs: number): MutableTotals {
+  return {
+    startedAtMs,
+    frameCount: 0,
+    byteCount: 0,
+    incomingFrameCount: 0,
+    incomingByteCount: 0,
+    outgoingFrameCount: 0,
+    outgoingByteCount: 0,
+    maxFrameBytes: 0,
+  };
+}

--- a/apps/notebook-cloud/test/notebook-room.test.ts
+++ b/apps/notebook-cloud/test/notebook-room.test.ts
@@ -282,6 +282,7 @@ describe("NotebookRoom peer lifecycle", () => {
       socket: socket.asCloudflareWebSocket(),
       identity,
       connectedAt: "2026-05-22T00:00:00.000Z",
+      consecutiveRejectedFrames: 0,
     };
     const harness = roomHarness(room);
     harness.peers.set(peer.id, peer);
@@ -305,11 +306,99 @@ describe("NotebookRoom peer lifecycle", () => {
     await harness.handleMessage("demo", peer, "not-a-binary-frame");
 
     assert.equal(socket.closed, true);
+    assert.equal(socket.closeCode, 1008);
+    assert.equal(socket.closeReason, "too many rejected frames");
     assert.equal(harness.peers.has(peer.id), false);
     assert.equal(
       socket.sent.length,
       7,
       "the close-triggering rejection should not echo another control frame",
+    );
+  });
+
+  it("does not count server-side room host failures toward peer close", async () => {
+    const room = new NotebookRoom(fakeState(), {} as Env);
+    const identity = authenticateDevRequest(
+      new Request("https://cloud.test/n/demo/sync?user=alice&operator=desktop:a&scope=editor"),
+    );
+    const socket = new FakeSocket();
+    const peer = {
+      id: "peer-a",
+      socket: socket.asCloudflareWebSocket(),
+      identity,
+      connectedAt: "2026-05-22T00:00:00.000Z",
+      consecutiveRejectedFrames: 0,
+    };
+    const harness = roomHarness(room);
+    harness.peers.set(peer.id, peer);
+    harness.materializers.set("demo", {
+      receiveFrame: async () => {
+        throw new Error("room host storage temporarily unavailable");
+      },
+      checkpoint: async () => undefined,
+      removePeer: async () => undefined,
+    });
+
+    for (let i = 0; i < 10; i += 1) {
+      await harness.handleMessage(
+        "demo",
+        peer,
+        encodeTypedFrame(FrameType.AUTOMERGE_SYNC, new Uint8Array([1])),
+      );
+    }
+
+    assert.equal(socket.closed, false);
+    assert.equal(peer.consecutiveRejectedFrames, 0);
+    assert.equal(socket.sent.length, 10);
+    assert(
+      socket.sent.every(
+        (frame) =>
+          frame[0] === FrameType.SESSION_CONTROL &&
+          decodeJsonPayload<Record<string, unknown>>(frame.slice(1)).type ===
+            "cloud_frame_rejected",
+      ),
+    );
+  });
+
+  it("does not count server-side frame persistence failures toward peer close", async () => {
+    const room = new NotebookRoom(fakeState(), {} as Env);
+    const identity = authenticateDevRequest(
+      new Request(
+        "https://cloud.test/n/demo/sync?user=runtime&operator=runtime:a&scope=runtime_peer",
+      ),
+    );
+    const socket = new FakeSocket();
+    const peer = {
+      id: "runtime-peer",
+      socket: socket.asCloudflareWebSocket(),
+      identity,
+      connectedAt: "2026-05-22T00:00:00.000Z",
+      consecutiveRejectedFrames: 0,
+    };
+    const harness = roomHarness(room);
+    harness.peers.set(peer.id, peer);
+    harness.persistFrame = async () => {
+      throw new Error("storage temporarily unavailable");
+    };
+
+    for (let i = 0; i < 10; i += 1) {
+      await harness.handleMessage(
+        "demo",
+        peer,
+        encodeTypedFrame(FrameType.PUT_BLOB, new Uint8Array([1])),
+      );
+    }
+
+    assert.equal(socket.closed, false);
+    assert.equal(peer.consecutiveRejectedFrames, 0);
+    assert.equal(socket.sent.length, 10);
+    assert(
+      socket.sent.every(
+        (frame) =>
+          frame[0] === FrameType.SESSION_CONTROL &&
+          decodeJsonPayload<Record<string, unknown>>(frame.slice(1)).type ===
+            "cloud_frame_rejected",
+      ),
     );
   });
 
@@ -1201,6 +1290,8 @@ function fakeMaterializer(result: RoomHostFrameResult): {
 class FakeSocket {
   readonly sent: Uint8Array[] = [];
   closed = false;
+  closeCode: number | undefined;
+  closeReason: string | undefined;
   private attachment: unknown;
 
   constructor(private readonly options: { throwOnSend?: boolean } = {}) {}
@@ -1223,8 +1314,10 @@ class FakeSocket {
     }
   }
 
-  close(): void {
+  close(code?: number, reason?: string): void {
     this.closed = true;
+    this.closeCode = code;
+    this.closeReason = reason;
   }
 
   serializeAttachment(value: unknown): void {

--- a/apps/notebook-cloud/test/notebook-room.test.ts
+++ b/apps/notebook-cloud/test/notebook-room.test.ts
@@ -12,6 +12,7 @@ import {
 import {
   NotebookRoom,
   presencePeerLabel,
+  rejectedFramePolicy,
   runtimePeerWorkstationMetadataFromRequest,
   rewritePresenceFrame,
   shouldBroadcastFrame,
@@ -191,6 +192,30 @@ describe("NotebookRoom presence rewrite", () => {
   });
 });
 
+describe("NotebookRoom rejected frame policy", () => {
+  it("allows a bounded streak of rejected frames before closing the peer", () => {
+    let consecutiveRejectedFrames = 0;
+    for (let i = 1; i < 8; i += 1) {
+      const policy = rejectedFramePolicy(consecutiveRejectedFrames, 8);
+      consecutiveRejectedFrames = policy.consecutiveRejectedFrames;
+      assert.equal(policy.shouldClose, false);
+      assert.equal(policy.consecutiveRejectedFrames, i);
+    }
+
+    const policy = rejectedFramePolicy(consecutiveRejectedFrames, 8);
+    assert.equal(policy.consecutiveRejectedFrames, 8);
+    assert.equal(policy.shouldClose, true);
+  });
+
+  it("normalizes invalid limits to one rejected frame", () => {
+    assert.deepEqual(rejectedFramePolicy(0, 0), {
+      consecutiveRejectedFrames: 1,
+      limit: 1,
+      shouldClose: true,
+    });
+  });
+});
+
 describe("NotebookRoom peer lifecycle", () => {
   it("echoes only the trusted non-sensitive WebSocket subprotocol in upgrade headers", () => {
     const identity = {
@@ -244,6 +269,48 @@ describe("NotebookRoom peer lifecycle", () => {
     assert.equal(metadata?.environmentPolicy, "current_python");
     assert.equal(metadata?.workingDirectory?.length, 512);
     assert.equal(runtimePeerWorkstationMetadataFromRequest(request, viewerIdentity), null);
+  });
+
+  it("closes peers after repeated rejected frames without echoing the threshold rejection", async () => {
+    const room = new NotebookRoom(fakeState(), {} as Env);
+    const identity = authenticateDevRequest(
+      new Request("https://cloud.test/n/demo/sync?user=alice&operator=desktop:a&scope=editor"),
+    );
+    const socket = new FakeSocket();
+    const peer = {
+      id: "peer-a",
+      socket: socket.asCloudflareWebSocket(),
+      identity,
+      connectedAt: "2026-05-22T00:00:00.000Z",
+    };
+    const harness = roomHarness(room);
+    harness.peers.set(peer.id, peer);
+    harness.materializers.set("demo", fakeMaterializer(noopMaterializedResult()));
+
+    for (let i = 0; i < 7; i += 1) {
+      await harness.handleMessage("demo", peer, "not-a-binary-frame");
+    }
+
+    assert.equal(socket.closed, false);
+    assert.equal(socket.sent.length, 7);
+    assert(
+      socket.sent.every(
+        (frame) =>
+          frame[0] === FrameType.SESSION_CONTROL &&
+          decodeJsonPayload<Record<string, unknown>>(frame.slice(1)).type ===
+            "cloud_frame_rejected",
+      ),
+    );
+
+    await harness.handleMessage("demo", peer, "not-a-binary-frame");
+
+    assert.equal(socket.closed, true);
+    assert.equal(harness.peers.has(peer.id), false);
+    assert.equal(
+      socket.sent.length,
+      7,
+      "the close-triggering rejection should not echo another control frame",
+    );
   });
 
   it("does not silently resurrect a removed hibernated peer", () => {
@@ -986,6 +1053,7 @@ interface RoomHarness {
     {
       receiveFrame(): Promise<RoomHostFrameResult>;
       checkpoint(): Promise<void>;
+      removePeer?(peerId: string): Promise<void>;
       reconcileRuntimePeerGone?(reason: string): Promise<RoomHostFrameResult>;
       setWorkstationAttachment?(attachment: unknown): Promise<RoomHostFrameResult>;
     }
@@ -1121,10 +1189,12 @@ function noopMaterializedResult(): RoomHostFrameResult {
 function fakeMaterializer(result: RoomHostFrameResult): {
   receiveFrame(): Promise<RoomHostFrameResult>;
   checkpoint(): Promise<void>;
+  removePeer(): Promise<void>;
 } {
   return {
     receiveFrame: async () => result,
     checkpoint: async () => undefined,
+    removePeer: async () => undefined,
   };
 }
 

--- a/apps/notebook-cloud/test/sync-frame-budget.test.ts
+++ b/apps/notebook-cloud/test/sync-frame-budget.test.ts
@@ -1,0 +1,152 @@
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import {
+  formatTopFrameBuckets,
+  SyncFrameBudgetTracker,
+  syncFrameBudgetLogFields,
+} from "../src/sync-frame-budget.ts";
+
+describe("sync frame budget tracking", () => {
+  it("aggregates frame counts and bytes by direction, scope, and frame type", () => {
+    const tracker = new SyncFrameBudgetTracker({
+      startedAtMs: 1_000,
+      summaryIntervalMs: 10_000,
+      frameThreshold: 100,
+    });
+
+    tracker.record({
+      peerId: "peer-a",
+      scope: "owner",
+      direction: "incoming",
+      frameType: "automerge_sync",
+      byteLength: 120,
+      nowMs: 1_010,
+    });
+    tracker.record({
+      peerId: "peer-a",
+      scope: "owner",
+      direction: "incoming",
+      frameType: "automerge_sync",
+      byteLength: 80,
+      nowMs: 1_020,
+    });
+    tracker.record({
+      peerId: "peer-a",
+      scope: "owner",
+      direction: "outgoing",
+      frameType: "runtime_state_sync",
+      byteLength: 75,
+      nowMs: 1_030,
+    });
+
+    const summary = tracker.summarizeWindow(1_100);
+    assert(summary);
+    assert.equal(summary.windowMs, 100);
+    assert.equal(summary.frameCount, 3);
+    assert.equal(summary.byteCount, 275);
+    assert.equal(summary.incomingFrameCount, 2);
+    assert.equal(summary.incomingByteCount, 200);
+    assert.equal(summary.outgoingFrameCount, 1);
+    assert.equal(summary.outgoingByteCount, 75);
+    assert.equal(summary.maxFrameBytes, 120);
+    assert.deepEqual(
+      summary.buckets.map((bucket) => [
+        bucket.direction,
+        bucket.scope,
+        bucket.frameType,
+        bucket.frameCount,
+        bucket.byteCount,
+        bucket.maxFrameBytes,
+      ]),
+      [
+        ["incoming", "owner", "automerge_sync", 2, 200, 120],
+        ["outgoing", "owner", "runtime_state_sync", 1, 75, 75],
+      ],
+    );
+  });
+
+  it("emits a window summary after the configured frame threshold", () => {
+    const tracker = new SyncFrameBudgetTracker({
+      startedAtMs: 2_000,
+      summaryIntervalMs: 60_000,
+      frameThreshold: 2,
+    });
+
+    tracker.record({
+      peerId: "peer-a",
+      scope: "viewer",
+      direction: "incoming",
+      frameType: "presence",
+      byteLength: 10,
+      nowMs: 2_001,
+    });
+    assert.equal(tracker.summarizeWindowIfNeeded(2_002), null);
+
+    tracker.record({
+      peerId: "peer-a",
+      scope: "viewer",
+      direction: "incoming",
+      frameType: "presence",
+      byteLength: 12,
+      nowMs: 2_003,
+    });
+    const summary = tracker.summarizeWindowIfNeeded(2_004);
+    assert(summary);
+    assert.equal(summary.frameCount, 2);
+    assert.equal(tracker.summarizeWindow(2_005), null);
+  });
+
+  it("keeps per-peer lifetime summaries independent of periodic windows", () => {
+    const tracker = new SyncFrameBudgetTracker({
+      startedAtMs: 3_000,
+      summaryIntervalMs: 10,
+      frameThreshold: 100,
+    });
+
+    tracker.record({
+      peerId: "peer-a",
+      scope: "runtime_peer",
+      direction: "incoming",
+      frameType: "runtime_state_sync",
+      byteLength: 100,
+      nowMs: 3_001,
+    });
+    assert(tracker.summarizeWindowIfNeeded(3_100));
+
+    tracker.record({
+      peerId: "peer-a",
+      scope: "runtime_peer",
+      direction: "outgoing",
+      frameType: "comms_doc_sync",
+      byteLength: 50,
+      nowMs: 3_101,
+    });
+
+    const peerSummary = tracker.consumePeer("peer-a", 3_200);
+    assert(peerSummary);
+    assert.equal(peerSummary.frameCount, 2);
+    assert.equal(peerSummary.byteCount, 150);
+    assert.equal(tracker.consumePeer("peer-a", 3_201), null);
+  });
+
+  it("formats log fields as sparse primitive values", () => {
+    const tracker = new SyncFrameBudgetTracker({ startedAtMs: 4_000 });
+    tracker.record({
+      peerId: "peer-a",
+      scope: "owner",
+      direction: "incoming",
+      frameType: "automerge_sync",
+      byteLength: 10,
+      nowMs: 4_001,
+    });
+    const summary = tracker.summarizeWindow(4_010);
+    assert(summary);
+
+    const fields = syncFrameBudgetLogFields(summary);
+    assert.equal(fields.frame_count, 1);
+    assert.deepEqual(fields.top_frame_buckets, [
+      "incoming|owner|automerge_sync|frames=1|bytes=10|max=10",
+    ]);
+    assert.deepEqual(formatTopFrameBuckets(summary.buckets, 0), []);
+  });
+});


### PR DESCRIPTION
## Summary

Adds low-cardinality WebSocket sync frame instrumentation at the hosted room boundary so we can reason about Cloudflare Worker/Durable Object usage from protocol behavior.

- tracks incoming and outgoing frame counts/bytes by direction, connection scope, and frame type
- emits periodic room-level summaries after 30s or 250 frames, whichever comes first
- emits per-peer lifetime summaries when a peer disconnects
- avoids logging payloads, principals, emails, or tokens in the new budget records
- closes a peer after 8 consecutive client-fault rejected frames so rejection logging/control replies cannot amplify a bad client indefinitely
- leaves server-side room host/materializer/persist failures visible as rejected frames without counting them toward the disconnect streak
- uses WebSocket close code 1008 with a short policy reason when the reject-streak close fires
- covers the pure tracker, reject-streak behavior, policy close, and server-fault non-punitive paths with focused node tests

## Why

Durable Object WebSocket messages are now a product cost surface for preview.runt.run. We need concrete data for normal notebook loads, runtime peers, widgets, reconnects, and output-heavy sessions before deciding where to coalesce, throttle, or change Automerge sync behavior.

The reject-streak close is intentionally small defense-in-depth: it lets a normal client recover from occasional protocol mistakes but stops repeated invalid frames from generating unbounded warn logs and `cloud_frame_rejected` control frames.

## Validation

- `pnpm --dir apps/notebook-cloud exec node --import tsx --test test/sync-frame-budget.test.ts`
- `pnpm --dir apps/notebook-cloud exec node --import tsx --test test/notebook-room.test.ts test/sync-frame-budget.test.ts`
- `pnpm --dir apps/notebook-cloud typecheck`
- `pnpm --dir apps/notebook-cloud test` (696 tests)
- `cargo xtask lint --fix`

## Notes

Not deployed yet. Once deployed, useful logs are `room.sync_frame_budget.summary` with `reason=periodic` or `reason=peer_closed`. Repeated invalid clients should now also produce `room.peer.closed_for_rejected_frames` and then disconnect.