### PR TITLE
fix(sift): keep overlay menus opaque without theme panel

### DIFF
--- a/packages/sift/e2e/popover-surface.spec.ts
+++ b/packages/sift/e2e/popover-surface.spec.ts
@@ -1,0 +1,50 @@
+import { expect, test } from "@playwright/test";
+
+test.describe("Sift overlay surfaces", () => {
+  test("category popover remains opaque when theme panel variables are missing", async ({
+    page,
+  }) => {
+    await page.goto("/?dataset=polars-utf8view");
+    await page.waitForSelector(".sift-table-container");
+    await page.waitForSelector(".sift-row");
+
+    await page.locator('.sift-toggle-btn[data-mode="dark"]').click();
+
+    await page.addStyleTag({
+      content: `
+        :root,
+        :root[data-theme="dark"],
+        :root.dark {
+          --sift-panel: initial !important;
+          --sift-rule: initial !important;
+          --sift-ink: initial !important;
+        }
+      `,
+    });
+
+    await page
+      .locator(".sift-th", { hasText: "NAME" })
+      .locator(".sift-cat-row", {
+        hasText: "others",
+      })
+      .click();
+
+    const popoverContent = page
+      .locator("[data-radix-popper-content-wrapper] > .sift-overlay-surface")
+      .first();
+    await expect(popoverContent).toBeVisible();
+
+    const styles = await popoverContent.evaluate((el) => {
+      const style = getComputedStyle(el);
+      return {
+        backgroundColor: style.backgroundColor,
+        borderColor: style.borderColor,
+        color: style.color,
+      };
+    });
+
+    expect(styles.backgroundColor).toBe("rgb(23, 23, 23)");
+    expect(styles.borderColor).toBe("rgb(42, 42, 42)");
+    expect(styles.color).toBe("rgb(229, 229, 229)");
+  });
+});

--- a/packages/sift/src/components/column-context-menu.tsx
+++ b/packages/sift/src/components/column-context-menu.tsx
@@ -66,7 +66,7 @@ export function ColumnContextMenu({ state, onAction, onClose }: Props) {
   return (
     <div
       ref={menuRef}
-      className="fixed z-50 min-w-[12rem] overflow-hidden rounded-lg border border-[var(--sift-rule)] bg-[var(--sift-panel)] p-1 shadow-lg"
+      className="sift-overlay-surface fixed z-50 min-w-[12rem] overflow-hidden rounded-lg border p-1 shadow-lg"
       style={{ left: x, top: y }}
     >
       <div className="px-2 py-1.5 text-xs font-semibold text-[var(--sift-muted)] uppercase tracking-wider">

--- a/packages/sift/src/components/ui/context-menu.tsx
+++ b/packages/sift/src/components/ui/context-menu.tsx
@@ -38,7 +38,7 @@ const ContextMenuSubContent = React.forwardRef<
   <ContextMenuPrimitive.SubContent
     ref={ref}
     className={cn(
-      "z-50 min-w-[128px] overflow-hidden rounded-lg border border-[var(--sift-rule)] bg-[var(--sift-panel)] p-1 shadow-lg",
+      "sift-overlay-surface z-50 min-w-[128px] overflow-hidden rounded-lg border p-1 shadow-lg",
       "data-[state=open]:animate-in data-[state=closed]:animate-out",
       className,
     )}
@@ -55,8 +55,8 @@ const ContextMenuContent = React.forwardRef<
     <ContextMenuPrimitive.Content
       ref={ref}
       className={cn(
-        "z-50 min-w-[160px] overflow-hidden rounded-lg border border-[var(--sift-rule)] bg-[var(--sift-panel)] p-1 shadow-lg",
-        "text-[13px] leading-[1.3] text-[var(--sift-ink)] font-[var(--sift-font)]",
+        "sift-overlay-surface z-50 min-w-[160px] overflow-hidden rounded-lg border p-1 shadow-lg",
+        "text-[13px] leading-[1.3] font-[var(--sift-font)]",
         className,
       )}
       {...props}

--- a/packages/sift/src/components/ui/popover.tsx
+++ b/packages/sift/src/components/ui/popover.tsx
@@ -16,7 +16,7 @@ const PopoverContent = React.forwardRef<
       align={align}
       sideOffset={sideOffset}
       className={cn(
-        "z-50 min-w-[224px] overflow-hidden rounded-lg border border-[var(--sift-rule)] bg-[var(--sift-panel)] p-0 text-[13px] leading-[1.3] shadow-lg",
+        "sift-overlay-surface z-50 min-w-[224px] overflow-hidden rounded-lg border p-0 text-[13px] leading-[1.3] shadow-lg",
         "data-[state=open]:animate-in data-[state=closed]:animate-out",
         "data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0",
         "data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95",

--- a/packages/sift/src/library.css
+++ b/packages/sift/src/library.css
@@ -5,6 +5,27 @@
   box-sizing: border-box;
 }
 
+/* --- Shared overlay fallback surface --- */
+
+:root {
+  --sift-overlay-panel-fallback: #ffffff;
+  --sift-overlay-ink-fallback: #1a1a1a;
+  --sift-overlay-rule-fallback: #e5e7eb;
+}
+
+:root[data-theme="dark"],
+:root.dark {
+  --sift-overlay-panel-fallback: #171717;
+  --sift-overlay-ink-fallback: #e5e5e5;
+  --sift-overlay-rule-fallback: #2a2a2a;
+}
+
+.sift-overlay-surface {
+  background-color: var(--sift-panel, var(--sift-overlay-panel-fallback));
+  border-color: var(--sift-rule, var(--sift-overlay-rule-fallback));
+  color: var(--sift-ink, var(--sift-overlay-ink-fallback));
+}
+
 /* --- Demo page shell --- */
 
 .sift-page {


### PR DESCRIPTION
## Summary

- Add a shared `sift-overlay-surface` class with light/dark fallback colors for panel, border, and text when Sift theme variables are missing
- Use that surface for Sift popovers and context menus instead of relying directly on `--sift-panel`
- Add a Playwright regression that blanks the theme panel variables and verifies the categorical popover stays opaque

## Notes

This is the narrow first fix from the Sift+nteract bug report. It only hardens overlay opacity when theme variables are missing or not propagated correctly. The category filter interaction concerns and notebook-host outside-click dismissal should be handled in follow-up PRs unless we decide to group them.

## Verification

- `npm run test:e2e -- e2e/popover-surface.spec.ts --project=chromium` from `packages/sift`
- `npm run build` from `packages/sift`
- `cargo xtask lint --fix`
