### PR TITLE
fix(sift): dismiss overlays on notebook host clicks

### DIFF
--- a/packages/sift/e2e/host-dismiss.spec.ts
+++ b/packages/sift/e2e/host-dismiss.spec.ts
@@ -1,0 +1,38 @@
+import { expect, test } from "@playwright/test";
+
+test.describe("host outside interaction dismissal", () => {
+  test("closes the category filter popover when the notebook host releases interaction", async ({
+    page,
+  }) => {
+    await page.goto("/?dataset=polars-utf8view");
+    await page.waitForSelector(".sift-table-container", { timeout: 90_000 });
+
+    await page
+      .locator(".sift-cat-row", { hasText: /others/i })
+      .first()
+      .click();
+    await expect(page.locator(".sift-cat-popover-search")).toBeVisible();
+
+    await page.evaluate(() => {
+      window.dispatchEvent(new Event("nteract:host-outside-interaction"));
+    });
+
+    await expect(page.locator(".sift-cat-popover-search")).toBeHidden();
+  });
+
+  test("closes the column context menu when the notebook host releases interaction", async ({
+    page,
+  }) => {
+    await page.goto("/?dataset=polars-utf8view");
+    await page.waitForSelector(".sift-table-container", { timeout: 90_000 });
+
+    await page.locator(".sift-th").first().click({ button: "right" });
+    await expect(page.getByText("Sort ascending")).toBeVisible();
+
+    await page.evaluate(() => {
+      window.dispatchEvent(new Event("nteract:host-outside-interaction"));
+    });
+
+    await expect(page.getByText("Sort ascending")).toBeHidden();
+  });
+});

--- a/packages/sift/src/components/column-context-menu.tsx
+++ b/packages/sift/src/components/column-context-menu.tsx
@@ -3,6 +3,7 @@
  * Positioned manually at click coordinates, rendered as a portal.
  */
 import { useEffect, useRef } from "react";
+import { NTERACT_HOST_OUTSIDE_INTERACTION_EVENT } from "../events";
 import type { ColumnType } from "../table";
 
 export type ColumnAction =
@@ -43,6 +44,7 @@ export function ColumnContextMenu({ state, onAction, onClose }: Props) {
     function onKey(e: KeyboardEvent) {
       if (e.key === "Escape") onClose();
     }
+    window.addEventListener(NTERACT_HOST_OUTSIDE_INTERACTION_EVENT, onClose);
     const timer = setTimeout(() => {
       document.addEventListener("mousedown", onClick, true);
       document.addEventListener("keydown", onKey, true);
@@ -51,6 +53,7 @@ export function ColumnContextMenu({ state, onAction, onClose }: Props) {
       clearTimeout(timer);
       document.removeEventListener("mousedown", onClick, true);
       document.removeEventListener("keydown", onKey, true);
+      window.removeEventListener(NTERACT_HOST_OUTSIDE_INTERACTION_EVENT, onClose);
     };
   }, [state, onClose]);
 

--- a/packages/sift/src/events.ts
+++ b/packages/sift/src/events.ts
@@ -1,0 +1,1 @@
+export const NTERACT_HOST_OUTSIDE_INTERACTION_EVENT = "nteract:host-outside-interaction";

--- a/packages/sift/src/sparkline.tsx
+++ b/packages/sift/src/sparkline.tsx
@@ -1,6 +1,7 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { createRoot, type Root } from "react-dom/client";
 import { Popover, PopoverContent, PopoverTrigger } from "./components/ui/popover";
+import { NTERACT_HOST_OUTSIDE_INTERACTION_EVENT } from "./events";
 import type {
   BooleanColumnSummary,
   CategoricalColumnSummary,
@@ -920,6 +921,22 @@ function CategoricalBars({
   onFilter: FilterCallback;
 }) {
   const [popoverOpen, setPopoverOpen] = useState(false);
+
+  useEffect(() => {
+    if (!popoverOpen) return;
+
+    function handleHostOutsideInteraction() {
+      setPopoverOpen(false);
+    }
+
+    window.addEventListener(NTERACT_HOST_OUTSIDE_INTERACTION_EVENT, handleHostOutsideInteraction);
+    return () => {
+      window.removeEventListener(
+        NTERACT_HOST_OUTSIDE_INTERACTION_EVENT,
+        handleHostOutsideInteraction,
+      );
+    };
+  }, [popoverOpen]);
 
   const items = summary.topCategories.map((c) => ({
     label: c.label,

--- a/src/components/cell/__tests__/OutputArea.test.tsx
+++ b/src/components/cell/__tests__/OutputArea.test.tsx
@@ -699,15 +699,30 @@ describe("OutputArea iframe theme sync", () => {
     expect(screen.queryByRole("button", { name: "Click inside the table to scroll" })).toBeNull();
   });
 
-  it("releases sift iframe scrolling on outside pointer down", () => {
+  it("releases sift iframe scrolling on outside pointer down", async () => {
     const { getByTestId } = render(<OutputArea outputs={makeParquetOutput()} isolated />);
     const frame = getByTestId("isolated-frame");
     const activationWell = frame.parentElement as HTMLElement;
+
+    await waitFor(() => {
+      expect(mockFrameHandle.send).toHaveBeenCalledWith({
+        type: "interaction_state",
+        payload: { active: false },
+      });
+    });
+    mockFrameHandle.send.mockClear();
 
     fireEvent.pointerDown(activationWell);
 
     expect(activationWell.getAttribute("data-frame-interaction-active")).toBe("true");
     expect(frame.getAttribute("data-scroll-passthrough")).toBe("false");
+    await waitFor(() => {
+      expect(mockFrameHandle.send).toHaveBeenCalledWith({
+        type: "interaction_state",
+        payload: { active: true },
+      });
+    });
+    mockFrameHandle.send.mockClear();
 
     fireEvent.pointerDown(document.body);
 
@@ -718,6 +733,12 @@ describe("OutputArea iframe theme sync", () => {
     expect(
       screen.getByRole("button", { name: "Click inside the table to scroll" }),
     ).toBeInTheDocument();
+    await waitFor(() => {
+      expect(mockFrameHandle.send).toHaveBeenCalledWith({
+        type: "interaction_state",
+        payload: { active: false },
+      });
+    });
   });
 
   it("forces focused iframe outputs off scroll passthrough and wheel-boundary forwarding", () => {

--- a/src/isolated-renderer/__tests__/host-interaction.test.ts
+++ b/src/isolated-renderer/__tests__/host-interaction.test.ts
@@ -1,0 +1,23 @@
+import { describe, expect, it, vi } from "vite-plus/test";
+import {
+  dispatchHostOutsideInteractionOnRelease,
+  NTERACT_HOST_OUTSIDE_INTERACTION_EVENT,
+} from "../host-interaction";
+
+describe("isolated renderer host interaction bridge", () => {
+  it("dispatches the outside-interaction event only when active interaction is released", () => {
+    const dispatchEvent = vi.fn();
+    const target = { dispatchEvent } as unknown as Window;
+
+    dispatchHostOutsideInteractionOnRelease(false, false, target);
+    dispatchHostOutsideInteractionOnRelease(false, true, target);
+
+    expect(dispatchEvent).not.toHaveBeenCalled();
+
+    dispatchHostOutsideInteractionOnRelease(true, false, target);
+
+    expect(dispatchEvent).toHaveBeenCalledTimes(1);
+    const event = dispatchEvent.mock.calls[0][0] as Event;
+    expect(event.type).toBe(NTERACT_HOST_OUTSIDE_INTERACTION_EVENT);
+  });
+});

--- a/src/isolated-renderer/host-interaction.ts
+++ b/src/isolated-renderer/host-interaction.ts
@@ -1,0 +1,11 @@
+export const NTERACT_HOST_OUTSIDE_INTERACTION_EVENT = "nteract:host-outside-interaction";
+
+export function dispatchHostOutsideInteractionOnRelease(
+  previousActive: boolean,
+  nextActive: boolean,
+  target: Window = window,
+) {
+  if (previousActive && !nextActive) {
+    target.dispatchEvent(new Event(NTERACT_HOST_OUTSIDE_INTERACTION_EVENT));
+  }
+}

--- a/src/isolated-renderer/index.tsx
+++ b/src/isolated-renderer/index.tsx
@@ -10,7 +10,7 @@
  */
 
 import * as React from "react";
-import { StrictMode, useCallback, useEffect, useState } from "react";
+import { StrictMode, useCallback, useEffect, useRef, useState } from "react";
 import { createRoot, type Root } from "react-dom/client";
 import * as jsxRuntime from "react/jsx-runtime";
 
@@ -60,6 +60,7 @@ import { VideoOutput } from "@/components/outputs/video-output";
 import { SvgOutput } from "@/components/outputs/svg-output";
 import { WidgetView } from "@/components/widgets/widget-view";
 import { parseWidgetViewModelId, WIDGET_VIEW_MIME } from "@/components/widgets/widget-state";
+import { dispatchHostOutsideInteractionOnRelease } from "./host-interaction";
 import { measureDocumentHeight } from "./layout-measure";
 import { outputEntryIdForPayload } from "./output-identity";
 // Import widget support
@@ -531,6 +532,7 @@ function IsolatedRendererApp() {
     isDark: document.documentElement.classList.contains("dark"),
     interactionActive: false,
   });
+  const interactionActiveRef = useRef(false);
 
   // Handle messages from parent
   const handleMessage = useCallback((type: string, payload: unknown) => {
@@ -625,9 +627,12 @@ function IsolatedRendererApp() {
       }
       case "interaction_state": {
         const interactionPayload = payload as { active?: boolean };
+        const active = interactionPayload.active ?? false;
+        dispatchHostOutsideInteractionOnRelease(interactionActiveRef.current, active);
+        interactionActiveRef.current = active;
         setState((prev) => ({
           ...prev,
-          interactionActive: interactionPayload.active ?? false,
+          interactionActive: active,
         }));
         break;
       }


### PR DESCRIPTION
## Summary

- Dispatch a renderer-local host outside-interaction event when the notebook releases an engaged isolated Sift output.
- Close Sift category popovers and column context menus when that event arrives inside the iframe.
- Add focused coverage for the Sift overlay response, the OutputArea parent release signal, and the renderer bridge transition.

## Verification

- `npm run test:e2e -- e2e/host-dismiss.spec.ts --project=chromium`
- `pnpm test:run src/isolated-renderer/__tests__/host-interaction.test.ts src/components/cell/__tests__/OutputArea.test.tsx`
- `npm run build` in `packages/sift`
- `cargo xtask lint --fix`

## Notes

- Rebases on top of `origin/main` after PRs #3566 and #3567.
- This targets the remaining bug-report item where clicks in the notebook host document cannot naturally bubble into the isolated Sift iframe.
