### PR TITLE
feat(notebook): quiet connection/identity slot for cloud and desktop

### DIFF
--- a/apps/notebook-cloud/test/live-sync.test.ts
+++ b/apps/notebook-cloud/test/live-sync.test.ts
@@ -1874,6 +1874,46 @@ describe("cloud connection status bridge", () => {
     assert.deepEqual(statuses, ["connecting", "online", "reconnecting"]);
   });
 
+  it("detach severs silently: no late emissions, no spurious status", () => {
+    const bridge = new CloudConnectionStatusBridge();
+    const statuses: string[] = [];
+    bridge.status$.subscribe((status) => statuses.push(status));
+
+    const transport = new BehaviorSubject<"connecting" | "online" | "offline" | "reconnecting">(
+      "online",
+    );
+    bridge.attach({ connectionStatus$: transport.asObservable() });
+
+    // Plain detach (effect cleanup without a retry in flight): the dead
+    // transport's later emissions must not surface, and detach itself must
+    // not emit anything.
+    bridge.detach();
+    transport.next("offline");
+
+    assert.deepEqual(statuses, ["connecting", "online"]);
+    assert.equal(bridge.current, "online");
+  });
+
+  it("implements the slot source contract: subscribe replay + getCurrent snapshot", () => {
+    const bridge = new CloudConnectionStatusBridge();
+    const transport = new BehaviorSubject<"connecting" | "online" | "offline" | "reconnecting">(
+      "online",
+    );
+    bridge.attach({ connectionStatus$: transport.asObservable() });
+
+    assert.equal(bridge.getCurrent(), "online");
+    const statuses: string[] = [];
+    const subscription = bridge.subscribe((status) => statuses.push(status));
+    assert.deepEqual(statuses, ["online"]); // replayed for late subscribers
+
+    transport.next("reconnecting");
+    assert.deepEqual(statuses, ["online", "reconnecting"]);
+
+    subscription.unsubscribe();
+    transport.next("online");
+    assert.deepEqual(statuses, ["online", "reconnecting"]); // severed
+  });
+
   it("reflects the transport's own reconnect loop without a switch", async () => {
     const fake = installFakeWebSocket();
     try {

--- a/apps/notebook-cloud/test/live-sync.test.ts
+++ b/apps/notebook-cloud/test/live-sync.test.ts
@@ -1,7 +1,9 @@
 import { describe, it } from "node:test";
 import assert from "node:assert/strict";
+import { BehaviorSubject } from "rxjs";
 import { SyncEngine, type PersistedNotebookDoc, type SyncableHandle } from "runtimed";
 import {
+  CloudConnectionStatusBridge,
   CloudRecoverableRejectionTracker,
   CloudWebSocketTransport,
   applyCloudRoomReady,
@@ -1821,6 +1823,83 @@ describe("cloud transport reconnect loop", () => {
       await drainMicrotasks();
       await transport.sendFrame(FrameType.PRESENCE, new Uint8Array([4]));
       assert.equal(second.sent.length, 1);
+      transport.disconnect();
+    } finally {
+      fake.restore();
+    }
+  });
+});
+
+describe("cloud connection status bridge", () => {
+  it("switches to the replacement transport and dedups across the switch", () => {
+    const bridge = new CloudConnectionStatusBridge();
+    const statuses: string[] = [];
+    bridge.status$.subscribe((status) => statuses.push(status));
+
+    // Initial-connect attempt: transport A.
+    const a = new BehaviorSubject<"connecting" | "online" | "offline" | "reconnecting">(
+      "connecting",
+    );
+    bridge.attach({ connectionStatus$: a.asObservable() });
+    a.next("online");
+
+    // The effect re-runs (manual retry / escalation): transport B replaces
+    // A. The single stable subscription must follow B and ignore A.
+    const b = new BehaviorSubject<"connecting" | "online" | "offline" | "reconnecting">("online");
+    bridge.attach({ connectionStatus$: b.asObservable() });
+    a.next("offline"); // dead transport — must not surface
+    b.next("reconnecting");
+    b.next("online");
+
+    assert.deepEqual(statuses, ["connecting", "online", "reconnecting", "online"]);
+    assert.equal(bridge.current, "online");
+  });
+
+  it("reports the retry loop on teardown instead of the disposed transport's offline", () => {
+    const bridge = new CloudConnectionStatusBridge();
+    const statuses: string[] = [];
+    bridge.status$.subscribe((status) => statuses.push(status));
+
+    const transport = new BehaviorSubject<"connecting" | "online" | "offline" | "reconnecting">(
+      "online",
+    );
+    bridge.attach({ connectionStatus$: transport.asObservable() });
+
+    // Escalation teardown: detach first, then the manual disconnect emits
+    // a terminal "offline" that must never surface — the session is
+    // retrying, not going offline.
+    bridge.noteTeardownRetry();
+    transport.next("offline");
+
+    assert.deepEqual(statuses, ["connecting", "online", "reconnecting"]);
+  });
+
+  it("reflects the transport's own reconnect loop without a switch", async () => {
+    const fake = installFakeWebSocket();
+    try {
+      const bridge = new CloudConnectionStatusBridge();
+      const statuses: string[] = [];
+      bridge.status$.subscribe((status) => statuses.push(status));
+
+      const transport = createTransport({ reconnectBaseDelayMs: 1, random: () => 0.5 });
+      bridge.attach(transport);
+
+      const first = await waitForSocket(0);
+      first.open();
+      first.ready("peer-1");
+      await transport.ready;
+
+      // PR-2's transport-level loop: same transport object, status walks
+      // online -> reconnecting -> online through the stable bridge.
+      first.close({ code: 1006 });
+      await delayMs(10);
+      const second = await waitForSocket(1);
+      second.open();
+      second.ready("peer-2");
+      await drainMicrotasks();
+
+      assert.deepEqual(statuses, ["connecting", "online", "reconnecting", "online"]);
+      bridge.detach();
       transport.disconnect();
     } finally {
       fake.restore();

--- a/apps/notebook-cloud/test/sustained-reconnecting.test.ts
+++ b/apps/notebook-cloud/test/sustained-reconnecting.test.ts
@@ -145,10 +145,23 @@ describe("sustained reconnecting notice", () => {
     );
   }
 
-  it("classifies transport-loss reasons, not diagnostics", () => {
+  it("classifies exactly the transport's own link-loss shapes", () => {
+    // The calm-reconnect funnel: link-level losses the retry loop owns.
     assert.equal(isTransportReconnectError("browser reported offline"), true);
     assert.equal(isTransportReconnectError("cloud sync socket closed (1006)"), true);
+    assert.equal(
+      isTransportReconnectError("cloud sync socket closed (1008): too many rejected frames"),
+      true,
+    );
     assert.equal(isTransportReconnectError("cloud sync socket failed"), true);
+    assert.equal(
+      isTransportReconnectError("cloud sync socket send failed: socket is closing"),
+      true,
+    );
+    assert.equal(
+      isTransportReconnectError("cloud sync liveness ping failed: synthetic send failure"),
+      true,
+    );
     assert.equal(
       isTransportReconnectError("cloud sync liveness pong missed (no reply within 10000ms)"),
       true,
@@ -157,8 +170,46 @@ describe("sustained reconnecting notice", () => {
       isTransportReconnectError("cloud room handshake did not complete within 30000ms"),
       true,
     );
+  });
+
+  it("keeps terminal-looking failures on the actionable diagnostic route", () => {
+    // The transport wraps NON-link failures in similar prefixes; a broad
+    // prefix match routed mid-session terminal auth/access failures into
+    // the perpetual calm "Reconnecting." line with no CTA. These must keep
+    // the warning notice.
+    assert.equal(
+      isTransportReconnectError("cloud sync connect target failed: Unable to read app session"),
+      false,
+    );
+    assert.equal(
+      isTransportReconnectError("cloud sync socket creation failed: invalid URL"),
+      false,
+    );
+    assert.equal(
+      isTransportReconnectError("cloud sync socket message failed: unexpected token"),
+      false,
+    );
+    assert.equal(
+      isTransportReconnectError("cloud room rejected frame: notebook sync rejected"),
+      false,
+    );
     assert.equal(isTransportReconnectError(CLOUD_CONNECTION_NO_ACCESS_DIAGNOSTIC), false);
     assert.equal(isTransportReconnectError("websocket failed"), false);
+  });
+
+  it("renders the actionable warning for non-link transport failures", () => {
+    const html = renderNotices({
+      connectionError: "cloud sync connect target failed: Unable to read app session",
+    });
+    assert.match(html, /Live room needs attention/);
+    assert.match(html, /cloud sync connect target failed/);
+    assert.match(html, /Use anonymous/, "the warning keeps its action");
+    assert.doesNotMatch(html, /Your edits are kept locally/);
+
+    const rejectionHtml = renderNotices({
+      connectionError: "cloud room rejected frame: notebook sync rejected",
+    });
+    assert.match(rejectionHtml, /Live room needs attention/);
   });
 
   it("shows the single quiet line while reconnecting is sustained", () => {

--- a/apps/notebook-cloud/test/sustained-reconnecting.test.ts
+++ b/apps/notebook-cloud/test/sustained-reconnecting.test.ts
@@ -1,0 +1,233 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { describe, it, test } from "node:test";
+import * as React from "react";
+import { renderToStaticMarkup } from "react-dom/server";
+import type { CloudPrototypeAuthState } from "../viewer/collaborator-auth";
+import { CLOUD_CONNECTION_NO_ACCESS_DIAGNOSTIC } from "../viewer/connection-diagnostics";
+import {
+  CloudNotebookNotices,
+  cloudNotebookHasNotices,
+  isTransportReconnectError,
+} from "../viewer/notices";
+import { SustainedReconnectingTracker } from "../viewer/use-sustained-reconnecting";
+
+globalThis.React = React;
+
+// Field report: a moderate offline window produced zero UI change. The slot
+// dot is 8px by design, so legibility comes from ONE debounced notices-stack
+// line — present only while "reconnecting" outlives the debounce, cleared the
+// moment the room is back, and silent across sub-debounce flaps.
+describe("sustained reconnecting tracker", () => {
+  function tracked() {
+    const changes: boolean[] = [];
+    const tracker = new SustainedReconnectingTracker({
+      debounceMs: 3_000,
+      onChange: (sustained) => changes.push(sustained),
+    });
+    return { changes, tracker };
+  }
+
+  it("flips true only after reconnecting persists past the debounce", (t) => {
+    t.mock.timers.enable({ apis: ["setTimeout"] });
+    const { changes, tracker } = tracked();
+
+    tracker.next("reconnecting");
+    t.mock.timers.tick(2_999);
+    assert.deepEqual(changes, [] as boolean[], "no line inside the debounce window");
+    t.mock.timers.tick(1);
+    assert.deepEqual(changes, [true]);
+    tracker.dispose();
+  });
+
+  it("clears on online", (t) => {
+    t.mock.timers.enable({ apis: ["setTimeout"] });
+    const { changes, tracker } = tracked();
+
+    tracker.next("reconnecting");
+    t.mock.timers.tick(3_000);
+    tracker.next("online");
+    assert.deepEqual(changes, [true, false]);
+    tracker.dispose();
+  });
+
+  it("stays silent across sub-debounce flaps", (t) => {
+    t.mock.timers.enable({ apis: ["setTimeout"] });
+    const { changes, tracker } = tracked();
+
+    for (let i = 0; i < 5; i += 1) {
+      tracker.next("reconnecting");
+      t.mock.timers.tick(1_000);
+      tracker.next("online");
+      t.mock.timers.tick(1_000);
+    }
+    // The recovered windows must not accumulate into a phantom line.
+    t.mock.timers.tick(60_000);
+    assert.deepEqual(changes, [] as boolean[]);
+    tracker.dispose();
+  });
+
+  it("fires once per outage no matter how many reconnecting deliveries arrive", (t) => {
+    t.mock.timers.enable({ apis: ["setTimeout"] });
+    const { changes, tracker } = tracked();
+
+    tracker.next("reconnecting");
+    t.mock.timers.tick(1_000);
+    tracker.next("reconnecting"); // re-delivery while armed: no re-arm
+    t.mock.timers.tick(2_000);
+    assert.deepEqual(changes, [true], "the ORIGINAL deadline holds");
+    tracker.next("reconnecting"); // while sustained: no-op
+    t.mock.timers.tick(10_000);
+    assert.deepEqual(changes, [true]);
+    tracker.dispose();
+  });
+
+  it("treats a replacement transport's connecting as neutral", (t) => {
+    t.mock.timers.enable({ apis: ["setTimeout"] });
+    const { changes, tracker } = tracked();
+
+    // connecting never arms: initial connect is not an outage.
+    tracker.next("connecting");
+    t.mock.timers.tick(60_000);
+    assert.deepEqual(changes, [] as boolean[]);
+
+    // And it never clears: a session-level retry creates a fresh transport
+    // that reports "connecting" before its first handshake — the room is
+    // still down, so the line stays until online.
+    tracker.next("reconnecting");
+    t.mock.timers.tick(3_000);
+    tracker.next("connecting");
+    assert.deepEqual(changes, [true]);
+    tracker.next("online");
+    assert.deepEqual(changes, [true, false]);
+    tracker.dispose();
+  });
+
+  it("clears on terminal offline and cancels on dispose", (t) => {
+    t.mock.timers.enable({ apis: ["setTimeout"] });
+    const { changes, tracker } = tracked();
+
+    tracker.next("reconnecting");
+    t.mock.timers.tick(3_000);
+    tracker.next("offline"); // manual disconnect: 'Reconnecting' would lie
+    assert.deepEqual(changes, [true, false]);
+
+    tracker.next("reconnecting");
+    tracker.dispose(); // unmount mid-debounce
+    t.mock.timers.tick(60_000);
+    assert.deepEqual(changes, [true, false]);
+  });
+});
+
+describe("sustained reconnecting notice", () => {
+  const anonymousAuth: CloudPrototypeAuthState = {
+    mode: "anonymous",
+    token: null,
+    user: null,
+    oidcClaims: null,
+    requestedScope: "viewer",
+    problem: null,
+  };
+
+  function renderNotices(
+    overrides: Partial<React.ComponentProps<typeof CloudNotebookNotices>>,
+  ): string {
+    return renderToStaticMarkup(
+      React.createElement(CloudNotebookNotices, {
+        authState: anonymousAuth,
+        authRenewal: { kind: "idle", message: null },
+        connectionError: null,
+        hasReadableSnapshot: true,
+        status: { kind: "ready", message: "Ready" },
+        onResetAuth: () => {},
+        ...overrides,
+      }),
+    );
+  }
+
+  it("classifies transport-loss reasons, not diagnostics", () => {
+    assert.equal(isTransportReconnectError("browser reported offline"), true);
+    assert.equal(isTransportReconnectError("cloud sync socket closed (1006)"), true);
+    assert.equal(isTransportReconnectError("cloud sync socket failed"), true);
+    assert.equal(
+      isTransportReconnectError("cloud sync liveness pong missed (no reply within 10000ms)"),
+      true,
+    );
+    assert.equal(
+      isTransportReconnectError("cloud room handshake did not complete within 30000ms"),
+      true,
+    );
+    assert.equal(isTransportReconnectError(CLOUD_CONNECTION_NO_ACCESS_DIAGNOSTIC), false);
+    assert.equal(isTransportReconnectError("websocket failed"), false);
+  });
+
+  it("shows the single quiet line while reconnecting is sustained", () => {
+    const html = renderNotices({
+      sustainedReconnecting: true,
+      connectionError: "cloud sync socket closed (1006)",
+    });
+    assert.match(html, /Reconnecting\./);
+    assert.match(html, /Your edits are kept locally and will sync when the connection returns\./);
+    assert.doesNotMatch(html, /Live room needs attention/);
+    assert.doesNotMatch(html, /cloud sync socket closed/);
+    assert.equal(
+      (html.match(/data-slot="notebook-notice"/g) ?? []).length,
+      1,
+      "one line, not a reconnect line plus a per-drop warning",
+    );
+  });
+
+  it("surfaces nothing for a transport drop inside the debounce window", () => {
+    for (const error of [
+      "cloud sync socket closed (1006)",
+      "browser reported offline",
+      "cloud room handshake did not complete within 30000ms",
+    ]) {
+      assert.equal(
+        cloudNotebookHasNotices({
+          authState: anonymousAuth,
+          authRenewal: { kind: "idle", message: null },
+          connectionError: error,
+          hasReadableSnapshot: true,
+          status: { kind: "ready", message: "Ready" },
+        }),
+        false,
+        `${error} must wait for the sustained flag`,
+      );
+      assert.equal(renderNotices({ connectionError: error }), "");
+    }
+  });
+
+  it("clears the line when sustained reconnecting ends", () => {
+    assert.equal(renderNotices({ sustainedReconnecting: false }), "");
+    assert.equal(
+      cloudNotebookHasNotices({
+        authState: anonymousAuth,
+        authRenewal: { kind: "idle", message: null },
+        connectionError: null,
+        hasReadableSnapshot: true,
+        status: { kind: "ready", message: "Ready" },
+        sustainedReconnecting: false,
+      }),
+      false,
+    );
+  });
+
+  it("keeps access diagnostics as their own immediate notice", () => {
+    const html = renderNotices({ connectionError: CLOUD_CONNECTION_NO_ACCESS_DIAGNOSTIC });
+    assert.match(html, /Notebook access needed/);
+  });
+});
+
+test("notebook viewer wires the debounced status line into the notices stack", () => {
+  const viewerSource = readFileSync(
+    new URL("../viewer/notebook-viewer.tsx", import.meta.url),
+    "utf8",
+  );
+  assert.match(
+    viewerSource,
+    /const sustainedReconnecting = useSustainedReconnecting\(connectionStatus\$\);/,
+  );
+  assert.match(viewerSource, /sustainedReconnecting=\{sustainedReconnecting\}/);
+  assert.match(viewerSource, /sustainedReconnecting,\n/);
+});

--- a/apps/notebook-cloud/test/viewer-render-props.test.ts
+++ b/apps/notebook-cloud/test/viewer-render-props.test.ts
@@ -2,7 +2,12 @@ import assert from "node:assert/strict";
 import { readFileSync } from "node:fs";
 import { test } from "node:test";
 import * as ts from "typescript";
-import { viewerCorpus, viewerFunctionSource, viewerModuleTexts } from "./viewer-source-corpus";
+import {
+  viewerCorpus,
+  viewerFileContaining,
+  viewerFunctionSource,
+  viewerModuleTexts,
+} from "./viewer-source-corpus";
 
 test("cloud notebook rendering uses shared cell chrome instead of report-mode cells", () => {
   const offenders: string[] = [];
@@ -154,12 +159,37 @@ test("cloud viewer routes notebook header controls through the shared shell chro
   assert.match(sourceText, /authControls=\{[\s\S]*<CloudNotebookSignInButton/);
   // The connection/identity slot is filled by the shared quiet component:
   // avatar + connectivity dot, driven by the stable status bridge. It must
-  // never regress into a text pill or a second status label surface.
+  // never regress into a text pill or a second status label surface. The
+  // match is scoped to the module that owns the slot (not the whole
+  // corpus) so an identityControls regression cannot false-pass against a
+  // mount elsewhere.
+  const slotOwnerSource = viewerFileContaining("identityControls=");
   assert.match(
-    sourceText,
-    /identityControls=\{[\s\S]*?<NotebookConnectionIdentity[\s\S]*?connectionStatus\$=\{connectionStatus\$\}/,
+    slotOwnerSource,
+    /identityControls=\{[\s\S]{0,400}?<NotebookConnectionIdentity[\s\S]{0,200}?capabilities=\{shellCapabilities\}[\s\S]{0,200}?connectionStatus\$=\{connectionStatus\$\}/,
   );
   assert.doesNotMatch(sourceText, /identityControls=\{null\}/);
+  // Session-side bridge wiring order (comment-enforced invariants, pinned):
+  // attach follows each replacement transport; teardown paths report the
+  // retry BEFORE the dispose emits its terminal "offline"; the effect
+  // cleanup does the same so the auth-refresh re-run gap reads as a
+  // transition, not stale "online".
+  assert.match(
+    sessionSourceText,
+    /onTransportCreated: \(transport\) => \{[\s\S]{0,400}?connectionStatusBridge\.attach\(transport\);/,
+  );
+  assert.match(
+    sessionSourceText,
+    /const scheduleReconnect = \(reason: Error\) => \{[\s\S]{0,600}?connectionStatusBridge\.noteTeardownRetry\(\);[\s\S]{0,800}?disposeCurrentRuntime\(\);/,
+  );
+  assert.match(
+    sessionSourceText,
+    /connectionStatusBridge\.noteTeardownRetry\(\);[\s\S]{0,400}?pendingSeedDiscardRef\.current = discardPersistedSeedAfterTeardown\(/,
+  );
+  assert.match(
+    sessionSourceText,
+    /connectionStatusBridge\.noteTeardownRetry\(\);[\s\S]{0,600}?const teardownFlush = disposeCurrentRuntime\(\);/,
+  );
   assert.match(sourceText, /useState\(initialCloudRailCollapsed\)/);
   assert.match(sourceText, /function initialCloudRailCollapsed/);
   assert.match(sourceText, /function initialCloudRailCollapsed\(\): boolean \{[\s\S]*return true;/);

--- a/apps/notebook-cloud/test/viewer-render-props.test.ts
+++ b/apps/notebook-cloud/test/viewer-render-props.test.ts
@@ -152,7 +152,14 @@ test("cloud viewer routes notebook header controls through the shared shell chro
     /authControls=\{[\s\S]*shouldShowCloudHeaderSignIn\(authState, \{[\s\S]*hasAppSession: Boolean\(appSessionStatus\.session\),[\s\S]*\}\) \? \(/,
   );
   assert.match(sourceText, /authControls=\{[\s\S]*<CloudNotebookSignInButton/);
-  assert.match(sourceText, /identityControls=\{null\}/);
+  // The connection/identity slot is filled by the shared quiet component:
+  // avatar + connectivity dot, driven by the stable status bridge. It must
+  // never regress into a text pill or a second status label surface.
+  assert.match(
+    sourceText,
+    /identityControls=\{[\s\S]*?<NotebookConnectionIdentity[\s\S]*?connectionStatus\$=\{connectionStatus\$\}/,
+  );
+  assert.doesNotMatch(sourceText, /identityControls=\{null\}/);
   assert.match(sourceText, /useState\(initialCloudRailCollapsed\)/);
   assert.match(sourceText, /function initialCloudRailCollapsed/);
   assert.match(sourceText, /function initialCloudRailCollapsed\(\): boolean \{[\s\S]*return true;/);

--- a/apps/notebook-cloud/viewer/__tests__/use-sustained-reconnecting.test.tsx
+++ b/apps/notebook-cloud/viewer/__tests__/use-sustained-reconnecting.test.tsx
@@ -1,0 +1,132 @@
+import { act, renderHook } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vite-plus/test";
+import type { ConnectionStatus } from "runtimed";
+import {
+  useSustainedReconnecting,
+  type ReconnectingStatusSource,
+} from "../use-sustained-reconnecting";
+
+// The tracker has thorough unit coverage; these tests render the REAL hook
+// so the React wiring is pinned too: subscription on mount, debounce timers
+// driving state, unsubscribe + timer disposal on unmount, and the intended
+// behavior when the source object identity changes mid-outage.
+
+class FakeStatusSource implements ReconnectingStatusSource {
+  listeners = new Set<(status: ConnectionStatus) => void>();
+  current: ConnectionStatus = "connecting";
+
+  subscribe(next: (status: ConnectionStatus) => void): { unsubscribe(): void } {
+    this.listeners.add(next);
+    // BehaviorSubject contract (CloudConnectionStatusBridge): replay the
+    // current status to new subscribers.
+    next(this.current);
+    return { unsubscribe: () => this.listeners.delete(next) };
+  }
+
+  emit(status: ConnectionStatus): void {
+    this.current = status;
+    for (const listener of this.listeners) {
+      listener(status);
+    }
+  }
+}
+
+describe("useSustainedReconnecting", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("flips true only after reconnecting outlives the debounce, and clears on online", () => {
+    const source = new FakeStatusSource();
+    const { result } = renderHook(() => useSustainedReconnecting(source, 3_000));
+    expect(result.current).toBe(false);
+
+    act(() => {
+      source.emit("reconnecting");
+      vi.advanceTimersByTime(2_999);
+    });
+    expect(result.current).toBe(false);
+
+    act(() => {
+      vi.advanceTimersByTime(1);
+    });
+    expect(result.current).toBe(true);
+
+    act(() => {
+      source.emit("online");
+    });
+    expect(result.current).toBe(false);
+  });
+
+  it("stays silent across sub-debounce flaps", () => {
+    const source = new FakeStatusSource();
+    const { result } = renderHook(() => useSustainedReconnecting(source, 3_000));
+
+    act(() => {
+      for (let i = 0; i < 5; i += 1) {
+        source.emit("reconnecting");
+        vi.advanceTimersByTime(1_000);
+        source.emit("online");
+        vi.advanceTimersByTime(1_000);
+      }
+      vi.advanceTimersByTime(60_000);
+    });
+    expect(result.current).toBe(false);
+  });
+
+  it("unsubscribes and disposes the pending timer on unmount", () => {
+    const source = new FakeStatusSource();
+    const { unmount } = renderHook(() => useSustainedReconnecting(source, 3_000));
+    expect(source.listeners.size).toBe(1);
+
+    act(() => {
+      source.emit("reconnecting");
+    });
+    unmount();
+    expect(source.listeners.size).toBe(0);
+
+    // The armed debounce timer must be gone: advancing past it neither
+    // throws nor updates state on an unmounted component.
+    act(() => {
+      vi.advanceTimersByTime(60_000);
+    });
+    expect(vi.getTimerCount()).toBe(0);
+  });
+
+  it("clears then re-arms via replay when the source object changes mid-outage", () => {
+    const first = new FakeStatusSource();
+    first.current = "reconnecting";
+    const { result, rerender } = renderHook(
+      ({ source }: { source: ReconnectingStatusSource }) => useSustainedReconnecting(source, 3_000),
+      { initialProps: { source: first as ReconnectingStatusSource } },
+    );
+
+    act(() => {
+      vi.advanceTimersByTime(3_000);
+    });
+    expect(result.current).toBe(true);
+
+    // A new source identity remounts the subscription: the flag clears
+    // (the old tracker is disposed), and the replacement source's replayed
+    // "reconnecting" re-arms a FRESH debounce window.
+    const second = new FakeStatusSource();
+    second.current = "reconnecting";
+    rerender({ source: second });
+    expect(result.current).toBe(false);
+    expect(first.listeners.size).toBe(0);
+    expect(second.listeners.size).toBe(1);
+
+    act(() => {
+      vi.advanceTimersByTime(2_999);
+    });
+    expect(result.current).toBe(false);
+    act(() => {
+      vi.advanceTimersByTime(1);
+    });
+    expect(result.current).toBe(true);
+  });
+});

--- a/apps/notebook-cloud/viewer/cloud-viewer-session.ts
+++ b/apps/notebook-cloud/viewer/cloud-viewer-session.ts
@@ -1,5 +1,4 @@
 import { useCallback, useEffect, useRef, useState, type MutableRefObject } from "react";
-import type { Observable } from "rxjs";
 import {
   IndexedDbStorageAdapter,
   NotebookDocPersistence,
@@ -7,7 +6,6 @@ import {
   loadPersistedNotebookDoc,
   type BlobResolver,
   type CommChanges,
-  type ConnectionStatus,
 } from "runtimed";
 import {
   applyWidgetCommBroadcastToStore,
@@ -102,10 +100,11 @@ export interface CloudViewerSession {
   connectionScope: string | null;
   /**
    * Stable connection lifecycle across transport replacements (initial
-   * connect attempts and escalation teardowns) — fed by the session's
-   * CloudConnectionStatusBridge, the slot's connectivity-dot source.
+   * connect attempts and escalation teardowns) — the session's
+   * CloudConnectionStatusBridge, the slot's connectivity-dot source
+   * (subscribe + getCurrent for first paint).
    */
-  connectionStatus$: Observable<ConnectionStatus>;
+  connectionStatus$: CloudConnectionStatusBridge;
   liveMaterializedRef: MutableRefObject<boolean>;
   liveRuntimeRef: MutableRefObject<CloudSyncRuntime | null>;
   notebookLanguageRef: MutableRefObject<string>;
@@ -943,9 +942,13 @@ export function useCloudViewerSession({
       window.removeEventListener("pagehide", flushPersistence);
       document.removeEventListener("visibilitychange", flushPersistenceWhenHidden);
       materializeLiveRuntimeRef.current = null;
-      // Stop following before the teardown disconnects emit "offline"; a
-      // re-running effect re-attaches its replacement transport.
-      connectionStatusBridge.detach();
+      // Detach BEFORE the teardown disconnects emit their terminal
+      // "offline", and report "reconnecting": a re-running effect usually
+      // re-attaches a replacement transport, but the auth-refresh re-run
+      // early-returns without attaching — the bridge must read as a
+      // transition, not as stale "online", for that window. Harmless at
+      // real unmount (no subscribers remain).
+      connectionStatusBridge.noteTeardownRetry();
       const teardownFlush = disposeCurrentRuntime();
       // An in-flight connect (runtime not yet resolved) owns a transport
       // whose retry loop would otherwise run forever after unmount.
@@ -1010,7 +1013,7 @@ export function useCloudViewerSession({
   return {
     connectionActorLabel,
     connectionError,
-    connectionStatus$: connectionStatusBridge.status$,
+    connectionStatus$: connectionStatusBridge,
     connectionPeerId,
     connectionScope,
     liveMaterializedRef,

--- a/apps/notebook-cloud/viewer/cloud-viewer-session.ts
+++ b/apps/notebook-cloud/viewer/cloud-viewer-session.ts
@@ -1,4 +1,5 @@
 import { useCallback, useEffect, useRef, useState, type MutableRefObject } from "react";
+import type { Observable } from "rxjs";
 import {
   IndexedDbStorageAdapter,
   NotebookDocPersistence,
@@ -6,6 +7,7 @@ import {
   loadPersistedNotebookDoc,
   type BlobResolver,
   type CommChanges,
+  type ConnectionStatus,
 } from "runtimed";
 import {
   applyWidgetCommBroadcastToStore,
@@ -39,6 +41,7 @@ import {
 import { materializeCloudNotebookView } from "./cloud-view-model";
 import { CloudLivePresenceStore } from "./live-presence";
 import {
+  CloudConnectionStatusBridge,
   CloudRecoverableRejectionTracker,
   cloudPrincipalFromActorLabel,
   connectCloudSyncRuntime,
@@ -97,6 +100,12 @@ export interface CloudViewerSession {
   connectionError: string | null;
   connectionPeerId: string | null;
   connectionScope: string | null;
+  /**
+   * Stable connection lifecycle across transport replacements (initial
+   * connect attempts and escalation teardowns) — fed by the session's
+   * CloudConnectionStatusBridge, the slot's connectivity-dot source.
+   */
+  connectionStatus$: Observable<ConnectionStatus>;
   liveMaterializedRef: MutableRefObject<boolean>;
   liveRuntimeRef: MutableRefObject<CloudSyncRuntime | null>;
   notebookLanguageRef: MutableRefObject<string>;
@@ -168,6 +177,13 @@ export function useCloudViewerSession({
     presenceStoreRef.current = new CloudViewerPresenceStore();
   }
   const presenceStore = presenceStoreRef.current;
+  // Stable across effect re-runs: UI subscribers must not re-subscribe when
+  // a connect attempt or escalation teardown replaces the transport.
+  const connectionStatusBridgeRef = useRef<CloudConnectionStatusBridge | null>(null);
+  if (connectionStatusBridgeRef.current === null) {
+    connectionStatusBridgeRef.current = new CloudConnectionStatusBridge();
+  }
+  const connectionStatusBridge = connectionStatusBridgeRef.current;
   const [connectionScope, setConnectionScope] = useState<string | null>(null);
   const [connectionPeerId, setConnectionPeerId] = useState<string | null>(null);
   const [connectionActorLabel, setConnectionActorLabel] = useState<string | null>(null);
@@ -546,6 +562,9 @@ export function useCloudViewerSession({
     const scheduleReconnect = (reason: Error) => {
       if (disposed) return;
       console.warn("[notebook-cloud] live room session teardown; reconnecting", reason);
+      // Detach BEFORE disposing: the manual disconnect's terminal "offline"
+      // must not surface — the session is retrying, not going offline.
+      connectionStatusBridge.noteTeardownRetry();
       presenceStore.reduceConnection("disconnected");
       setConnectionScope(null);
       setConnectionActorLabel(null);
@@ -713,6 +732,9 @@ export function useCloudViewerSession({
       onConnectionLost: handleConnectionLost,
       onTransportCreated: (transport) => {
         pendingTransport = transport;
+        // Follow the replacement transport so the stable status source
+        // reflects this attempt (and PR-2's reconnect loop within it).
+        connectionStatusBridge.attach(transport);
       },
       onControl: (message) => {
         if (disposed) return;
@@ -768,6 +790,7 @@ export function useCloudViewerSession({
               // unauthorized; losing them is the intended outcome. The chain
               // is stashed so the next attempt arms strictly clear-then-arm.
               skipSeedOnceRef.current = true;
+              connectionStatusBridge.noteTeardownRetry();
               pendingSeedDiscardRef.current = discardPersistedSeedAfterTeardown(
                 disposeCurrentRuntime,
                 persistenceSeed.clear,
@@ -920,6 +943,9 @@ export function useCloudViewerSession({
       window.removeEventListener("pagehide", flushPersistence);
       document.removeEventListener("visibilitychange", flushPersistenceWhenHidden);
       materializeLiveRuntimeRef.current = null;
+      // Stop following before the teardown disconnects emit "offline"; a
+      // re-running effect re-attaches its replacement transport.
+      connectionStatusBridge.detach();
       const teardownFlush = disposeCurrentRuntime();
       // An in-flight connect (runtime not yet resolved) owns a transport
       // whose retry loop would otherwise run forever after unmount.
@@ -984,6 +1010,7 @@ export function useCloudViewerSession({
   return {
     connectionActorLabel,
     connectionError,
+    connectionStatus$: connectionStatusBridge.status$,
     connectionPeerId,
     connectionScope,
     liveMaterializedRef,

--- a/apps/notebook-cloud/viewer/live-sync.ts
+++ b/apps/notebook-cloud/viewer/live-sync.ts
@@ -573,6 +573,54 @@ export function shouldDiscardPersistedSeedOnRejection(
   return seededFromPersistence && isRecoverableCloudFrameRejection(message);
 }
 
+/**
+ * Stable, switching connection-status source for UI consumers.
+ *
+ * The transport object survives transport-level reconnects, but
+ * initial-connect attempts and escalation teardowns still REPLACE it — a
+ * subscriber holding one transport's `connectionStatus$` would watch a
+ * dead object forever (the host facade has exactly that flaw). The bridge
+ * follows whichever transport is current and exposes one
+ * BehaviorSubject-backed observable that stays stable for the session's
+ * lifetime, deduplicating repeated values across switches.
+ */
+export class CloudConnectionStatusBridge {
+  private readonly _status$ = new BehaviorSubject<ConnectionStatus>("connecting");
+  private subscription: { unsubscribe(): void } | null = null;
+  readonly status$: Observable<ConnectionStatus> = this._status$.asObservable();
+
+  get current(): ConnectionStatus {
+    return this._status$.getValue();
+  }
+
+  /** Follow a (replacement) transport's connection status. */
+  attach(transport: Pick<CloudWebSocketTransport, "connectionStatus$">): void {
+    this.subscription?.unsubscribe();
+    this.subscription = transport.connectionStatus$.subscribe((status) => this.next(status));
+  }
+
+  /**
+   * A session-level teardown is about to dispose the current transport and
+   * retry: stop following it (so the manual disconnect's terminal
+   * "offline" never surfaces) and report the retry loop instead.
+   */
+  noteTeardownRetry(): void {
+    this.detach();
+    this.next("reconnecting");
+  }
+
+  /** Stop following the current transport (effect cleanup). */
+  detach(): void {
+    this.subscription?.unsubscribe();
+    this.subscription = null;
+  }
+
+  private next(status: ConnectionStatus): void {
+    if (status === this._status$.getValue()) return;
+    this._status$.next(status);
+  }
+}
+
 export type CloudRejectionDisposition = "absorb" | "resync_in_place" | "escalate";
 
 /**

--- a/apps/notebook-cloud/viewer/live-sync.ts
+++ b/apps/notebook-cloud/viewer/live-sync.ts
@@ -593,6 +593,22 @@ export class CloudConnectionStatusBridge {
     return this._status$.getValue();
   }
 
+  /** Synchronous snapshot (NotebookConnectionStatusSource contract). */
+  getCurrent(): ConnectionStatus {
+    return this._status$.getValue();
+  }
+
+  /**
+   * Subscribe with a plain callback (NotebookConnectionStatusSource
+   * contract) — the bridge is handed to the connection/identity slot
+   * directly, so first paint can read getCurrent() instead of flashing
+   * "connecting".
+   */
+  subscribe(next: (status: ConnectionStatus) => void): { unsubscribe(): void } {
+    const subscription = this._status$.subscribe(next);
+    return { unsubscribe: () => subscription.unsubscribe() };
+  }
+
   /** Follow a (replacement) transport's connection status. */
   attach(transport: Pick<CloudWebSocketTransport, "connectionStatus$">): void {
     this.subscription?.unsubscribe();

--- a/apps/notebook-cloud/viewer/notebook-viewer.tsx
+++ b/apps/notebook-cloud/viewer/notebook-viewer.tsx
@@ -13,6 +13,7 @@ import type { NteractEmbedHostContextPatch } from "@/components/isolated/host-co
 import { NotebookNotice } from "@/components/notebook/NotebookNotice";
 import type { NotebookRailPanelId } from "@/components/notebook-rail";
 import {
+  NotebookConnectionIdentity,
   NotebookDocumentToolbar,
   navigateNotebookOutlineItem,
   NotebookDocumentRail,
@@ -193,6 +194,7 @@ export function NotebookViewer({
     connectionError,
     connectionPeerId,
     connectionScope,
+    connectionStatus$,
     liveMaterializedRef,
     liveRuntimeRef,
     notebookLanguageRef,
@@ -845,7 +847,15 @@ export function NotebookViewer({
           onRequestEditAccess={requestCloudEditAccess}
         />
       }
-      identityControls={null}
+      identityControls={
+        // Connection/identity slot: self-identity avatar + connectivity dot
+        // (the stable bridge survives transport replacement; the dot keeps
+        // frozen runtime chrome interpretable while reconnecting).
+        <NotebookConnectionIdentity
+          capabilities={shellCapabilities}
+          connectionStatus$={connectionStatus$}
+        />
+      }
       reserveCommandToolbar={editAccessPending}
       commandToolbar={{
         runtime: toolbarRuntime,

--- a/apps/notebook-cloud/viewer/notebook-viewer.tsx
+++ b/apps/notebook-cloud/viewer/notebook-viewer.tsx
@@ -65,6 +65,7 @@ import { markCloudViewerLoadMilestone } from "./load-milestones";
 import { cloudPresenceHasRuntimePeer, cloudPresenceRuntimePeerCount } from "./presence";
 import type { ResolvedCell } from "./render-resolution";
 import { CloudNotebookNotices, cloudNotebookHasNotices } from "./notices";
+import { useSustainedReconnecting } from "./use-sustained-reconnecting";
 import type { ViewerStatus } from "./notice-types";
 import type { CloudNotebookAccessRequest } from "./sharing-client";
 import { CloudSharingControls } from "./sharing-controls";
@@ -223,6 +224,10 @@ export function NotebookViewer({
       }),
     [blobResolver, liveRuntimeRef],
   );
+  // Sustained-outage legibility: the connection/identity slot stays an 8px
+  // dot by design, so once "reconnecting" outlives the debounce the notices
+  // stack carries the one calm line (and clears it when the room is back).
+  const sustainedReconnecting = useSustainedReconnecting(connectionStatus$);
   const presenceSnapshot = useSyncExternalStore(
     presenceStore.subscribe,
     presenceStore.getSnapshot,
@@ -898,6 +903,7 @@ export function NotebookViewer({
     diagnostics: accessRequestNotice,
     hasAppSession: Boolean(appSessionStatus.session),
     hasReadableSnapshot: notebookHasReadableSnapshot,
+    sustainedReconnecting,
     status: noticeStatus,
   });
   const notices = hasNotices ? (
@@ -908,6 +914,7 @@ export function NotebookViewer({
       diagnostics={accessRequestNotice}
       hasAppSession={Boolean(appSessionStatus.session)}
       hasReadableSnapshot={notebookHasReadableSnapshot}
+      sustainedReconnecting={sustainedReconnecting}
       status={noticeStatus}
       onResetAuth={resetPrototypeAuth}
       onSignInAgain={authConfig.oidc ? beginNotebookOidcAuth : undefined}

--- a/apps/notebook-cloud/viewer/notices.tsx
+++ b/apps/notebook-cloud/viewer/notices.tsx
@@ -35,14 +35,33 @@ export interface CloudNotebookNoticesProps {
 }
 
 /**
- * Transport-level connection-loss reasons (socket drops, handshake
- * timeouts, missed liveness pongs, the browser offline event). The retry
- * loop owns recovery, so these surface through the debounced sustained-
- * reconnecting line rather than an immediate per-drop warning. Access and
- * sign-in diagnostics keep their dedicated notices.
+ * EXACT connection-loss shapes minted by CloudWebSocketTransport when the
+ * LINK itself drops (socket close/failure, browser offline, liveness
+ * probe misses, handshake that never completed). The retry loop owns
+ * recovery for these, so they surface through the debounced sustained-
+ * reconnecting line rather than an immediate per-drop warning.
+ *
+ * Anchored shape-by-shape on purpose: the transport wraps OTHER failures
+ * in similar prefixes — connect-target resolution ("cloud sync connect
+ * target failed: ..."), socket creation, protocol decode, and the session
+ * escalation's "cloud room rejected frame: ..." — and those carry
+ * actionable detail that must keep the warning notice and its action.
+ * A terminal auth/access failure routed into the perpetual calm
+ * "Reconnecting." line would loop forever with no CTA. Keep this list in
+ * lockstep with the connectionLost reasons in live-sync.ts.
  */
+const TRANSPORT_RECONNECT_ERROR_SHAPES: readonly RegExp[] = [
+  /^browser reported offline$/,
+  /^cloud sync socket failed$/,
+  /^cloud sync socket closed \(\d+\)/,
+  /^cloud sync socket send failed: /,
+  /^cloud room handshake did not complete within \d+ms$/,
+  /^cloud sync liveness ping failed: /,
+  /^cloud sync liveness pong missed \(no reply within \d+ms\)$/,
+];
+
 export function isTransportReconnectError(error: string): boolean {
-  return error === "browser reported offline" || /^cloud (sync|room) /.test(error);
+  return TRANSPORT_RECONNECT_ERROR_SHAPES.some((shape) => shape.test(error));
 }
 
 export function cloudNotebookHasNotices({

--- a/apps/notebook-cloud/viewer/notices.tsx
+++ b/apps/notebook-cloud/viewer/notices.tsx
@@ -20,10 +20,29 @@ export interface CloudNotebookNoticesProps {
   connectionError: string | null;
   hasAppSession?: boolean;
   hasReadableSnapshot?: boolean;
+  /**
+   * The live-room status has been "reconnecting" past the debounce window
+   * (`useSustainedReconnecting`). Renders the single quiet reconnect line;
+   * transport-loss `connectionError` strings are routed here instead of
+   * the per-drop connection notice, so brief blips surface nothing and a
+   * real outage surfaces one calm sentence.
+   */
+  sustainedReconnecting?: boolean;
   status: ViewerStatus;
   diagnostics?: ReactNode;
   onResetAuth: () => void;
   onSignInAgain?: () => void | Promise<void>;
+}
+
+/**
+ * Transport-level connection-loss reasons (socket drops, handshake
+ * timeouts, missed liveness pongs, the browser offline event). The retry
+ * loop owns recovery, so these surface through the debounced sustained-
+ * reconnecting line rather than an immediate per-drop warning. Access and
+ * sign-in diagnostics keep their dedicated notices.
+ */
+export function isTransportReconnectError(error: string): boolean {
+  return error === "browser reported offline" || /^cloud (sync|room) /.test(error);
 }
 
 export function cloudNotebookHasNotices({
@@ -32,6 +51,7 @@ export function cloudNotebookHasNotices({
   connectionError,
   hasAppSession = false,
   hasReadableSnapshot = false,
+  sustainedReconnecting = false,
   status,
   diagnostics,
 }: Omit<CloudNotebookNoticesProps, "onResetAuth">): boolean {
@@ -50,6 +70,7 @@ export function cloudNotebookHasNotices({
   return (
     shouldShowAuthNotice ||
     shouldShowAuthRenewalNotice ||
+    sustainedReconnecting ||
     Boolean(connectionNotice) ||
     Boolean(diagnostics) ||
     shouldShowStatusNotice
@@ -62,6 +83,7 @@ export function CloudNotebookNotices({
   connectionError,
   hasAppSession = false,
   hasReadableSnapshot = false,
+  sustainedReconnecting = false,
   status,
   diagnostics,
   onResetAuth,
@@ -74,6 +96,7 @@ export function CloudNotebookNotices({
       connectionError,
       hasAppSession,
       hasReadableSnapshot,
+      sustainedReconnecting,
       status,
       diagnostics,
     })
@@ -123,6 +146,12 @@ export function CloudNotebookNotices({
           }
         >
           {authRenewal.message}
+        </NotebookNotice>
+      ) : null}
+
+      {sustainedReconnecting ? (
+        <NotebookNotice tone="info" icon={<CloudOff className="h-4 w-4" />} title="Reconnecting.">
+          Your edits are kept locally and will sync when the connection returns.
         </NotebookNotice>
       ) : null}
 
@@ -238,7 +267,14 @@ function cloudConnectionNoticeDisplay(
   title: string;
   message: string;
   tone: "warning";
-} {
+} | null {
+  if (isTransportReconnectError(error)) {
+    // The transport retries forever on its own; the debounced sustained-
+    // reconnecting line is the user-facing surface for these. Rendering a
+    // warning per drop turned every sub-second blip into notice flap.
+    return null;
+  }
+
   if (error === CLOUD_CONNECTION_SIGN_IN_DIAGNOSTIC) {
     return {
       title: "Sign in required.",

--- a/apps/notebook-cloud/viewer/use-sustained-reconnecting.ts
+++ b/apps/notebook-cloud/viewer/use-sustained-reconnecting.ts
@@ -1,0 +1,95 @@
+import { useEffect, useState } from "react";
+import type { ConnectionStatus } from "runtimed";
+
+/**
+ * How long the live room must stay in "reconnecting" before the notices
+ * stack says so. Transient blips (a dropped socket that recovers on the
+ * first retry) resolve well inside this window and surface nothing.
+ */
+export const SUSTAINED_RECONNECTING_DEBOUNCE_MS = 3_000;
+
+/** Structural slice of `CloudConnectionStatusBridge` the hook consumes. */
+export interface ReconnectingStatusSource {
+  subscribe(next: (status: ConnectionStatus) => void): { unsubscribe(): void };
+}
+
+/**
+ * Debounce "reconnecting" into a single sustained flag:
+ *
+ * - `reconnecting` arms one timer; the flag flips true only if the status
+ *   is STILL reconnecting when the debounce elapses. Repeated reconnecting
+ *   deliveries while armed (or already sustained) are no-ops, so flapping
+ *   connections cannot spam the notices stack.
+ * - `online` (and the terminal manual-disconnect `offline`) cancels the
+ *   pending timer and clears the flag.
+ * - `connecting` is neutral: a replacement transport reports "connecting"
+ *   before its first handshake, and that is neither recovery (the line
+ *   must not clear before the room is back) nor a fresh loss.
+ */
+export class SustainedReconnectingTracker {
+  private timer: ReturnType<typeof setTimeout> | null = null;
+  private sustained = false;
+
+  constructor(
+    private readonly options: {
+      debounceMs: number;
+      onChange: (sustained: boolean) => void;
+    },
+  ) {}
+
+  next(status: ConnectionStatus): void {
+    if (status === "reconnecting") {
+      if (this.sustained || this.timer !== null) return;
+      this.timer = setTimeout(() => {
+        this.timer = null;
+        this.sustained = true;
+        this.options.onChange(true);
+      }, this.options.debounceMs);
+      return;
+    }
+    if (status === "online" || status === "offline") {
+      this.clearTimer();
+      if (this.sustained) {
+        this.sustained = false;
+        this.options.onChange(false);
+      }
+    }
+    // "connecting" falls through: neither arms nor clears.
+  }
+
+  dispose(): void {
+    this.clearTimer();
+  }
+
+  private clearTimer(): void {
+    if (this.timer !== null) {
+      clearTimeout(this.timer);
+      this.timer = null;
+    }
+  }
+}
+
+/**
+ * True while the live-room connection has been "reconnecting" for at
+ * least `debounceMs`. Drives the quiet notices-stack line — the
+ * connection/identity slot stays an 8px dot by design, so a sustained
+ * outage needs one legible sentence somewhere calm.
+ */
+export function useSustainedReconnecting(
+  source: ReconnectingStatusSource,
+  debounceMs: number = SUSTAINED_RECONNECTING_DEBOUNCE_MS,
+): boolean {
+  const [sustained, setSustained] = useState(false);
+
+  useEffect(() => {
+    const tracker = new SustainedReconnectingTracker({ debounceMs, onChange: setSustained });
+    const subscription = source.subscribe((status) => tracker.next(status));
+    return () => {
+      subscription.unsubscribe();
+      tracker.dispose();
+      setSustained(false);
+    };
+  }, [source, debounceMs]);
+
+  return sustained;
+}

--- a/apps/notebook/src/App.tsx
+++ b/apps/notebook/src/App.tsx
@@ -51,6 +51,7 @@ import {
   UntrustedBanner,
 } from "@/components/notebook";
 import { GlobalFindBar } from "@/components/search";
+import { createDesktopConnectionStatusSource } from "./lib/desktop-connection-status";
 import {
   CondaDependencyPanel as CondaDependencyHeader,
   DenoDependencyPanel as DenoDependencyHeader,
@@ -639,6 +640,14 @@ function AppContent() {
       statusKey,
     ],
   );
+
+  // Connection/identity slot source: daemon lifecycle, stable for the
+  // app's lifetime (the dot must transition on daemon restarts).
+  const desktopConnectionStatus = useMemo(
+    () => createDesktopConnectionStatusSource(host.daemonEvents),
+    [host],
+  );
+  useEffect(() => () => desktopConnectionStatus.dispose(), [desktopConnectionStatus]);
 
   useEffect(() => {
     installExecutionPerformanceApi();
@@ -1518,10 +1527,13 @@ function AppContent() {
           trailingControls={
             // Connection/identity slot: renders nothing for a purely local
             // session (isRemoteNotebookContext) — conditionality is the
-            // point. The host transport is stable for the app's lifetime.
+            // point. The source derives from daemon lifecycle events (the
+            // IPC transport's status is constant in practice), and the
+            // copy is scoped to the link it measures.
             <NotebookConnectionIdentity
               capabilities={shellCapabilities}
-              connectionStatus$={host.transport.connectionStatus$}
+              connectionStatus$={desktopConnectionStatus}
+              connectionLabel="Daemon connection"
             />
           }
         />

--- a/apps/notebook/src/App.tsx
+++ b/apps/notebook/src/App.tsx
@@ -42,6 +42,7 @@ import {
   DebugBanner,
   EnvBuildDecisionDialog,
   KernelLaunchErrorBanner,
+  NotebookConnectionIdentity,
   NotebookDocumentRail,
   NotebookDocumentShell,
   PoolErrorBanner,
@@ -1514,6 +1515,15 @@ function AppContent() {
           updateStatus={updateStatus}
           updateVersion={updateVersion}
           onRestartToUpdate={restartToUpdate}
+          trailingControls={
+            // Connection/identity slot: renders nothing for a purely local
+            // session (isRemoteNotebookContext) — conditionality is the
+            // point. The host transport is stable for the app's lifetime.
+            <NotebookConnectionIdentity
+              capabilities={shellCapabilities}
+              connectionStatus$={host.transport.connectionStatus$}
+            />
+          }
         />
         {globalFind.isOpen && (
           <GlobalFindBar

--- a/apps/notebook/src/components/__tests__/notebook-toolbar.test.tsx
+++ b/apps/notebook/src/components/__tests__/notebook-toolbar.test.tsx
@@ -19,6 +19,10 @@ import {
   type RuntimeLifecycle,
   type RuntimeStatusKey,
 } from "../../lib/kernel-status";
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { NotebookConnectionIdentity } from "@/components/notebook";
+import { desktopNotebookShellCapabilities } from "../../lib/desktop-shell-capabilities";
 import { NotebookToolbar } from "../NotebookToolbar";
 
 function makeEnvProgress(overrides: Partial<EnvProgressState>): EnvProgressState {
@@ -622,5 +626,77 @@ describe("NotebookToolbar", () => {
       );
       expect(screen.queryByTestId("conda-env-yml-missing-banner")).not.toBeInTheDocument();
     });
+  });
+});
+
+describe("connection/identity slot wiring", () => {
+  const statusSource = {
+    getCurrent: () => "online" as const,
+    subscribe: () => ({ unsubscribe: () => {} }),
+  };
+
+  it("flows trailingControls into the toolbar identity slot for remote sessions", () => {
+    // Real projection output, not hand-rolled capability literals: the
+    // runtime_peer scope is what makes the slot render on desktop.
+    const capabilities = desktopNotebookShellCapabilities({
+      canAcceptCellMutations: true,
+      sessionReady: true,
+      localActor: "user:anaconda:kyle/desktop:window",
+      connectionScope: "runtime_peer",
+    });
+    const { container } = render(
+      <NotebookToolbar
+        {...baseProps}
+        capabilities={capabilities}
+        trailingControls={
+          <NotebookConnectionIdentity
+            capabilities={capabilities}
+            connectionStatus$={statusSource}
+            connectionLabel="Daemon connection"
+          />
+        }
+      />,
+    );
+
+    const slot = container.querySelector('[data-slot="notebook-connection-identity"]');
+    expect(slot).not.toBeNull();
+    expect(slot?.getAttribute("title")).toContain("Daemon connection: Connected");
+  });
+
+  it("renders no identity chrome for a purely local session", () => {
+    const capabilities = desktopNotebookShellCapabilities({
+      canAcceptCellMutations: true,
+      sessionReady: true,
+      localActor: "local:kyle/desktop:window",
+      connectionScope: null,
+    });
+    const { container } = render(
+      <NotebookToolbar
+        {...baseProps}
+        capabilities={capabilities}
+        trailingControls={
+          <NotebookConnectionIdentity
+            capabilities={capabilities}
+            connectionStatus$={statusSource}
+            connectionLabel="Daemon connection"
+          />
+        }
+      />,
+    );
+
+    expect(container.querySelector('[data-slot="notebook-connection-identity"]')).toBeNull();
+  });
+
+  it("App.tsx mounts the slot on the daemon-lifecycle source with scoped copy", () => {
+    // Source-text pin mirroring the cloud guardrail: deleting the desktop
+    // mount, feeding it the IPC transport again, or dropping the scoped
+    // connection label must fail here.
+    // vp test runs from the repo root.
+    const appSource = readFileSync(resolve(process.cwd(), "apps/notebook/src/App.tsx"), "utf8");
+    expect(appSource).toMatch(
+      /trailingControls=\{[\s\S]{0,600}?<NotebookConnectionIdentity[\s\S]{0,200}?capabilities=\{shellCapabilities\}[\s\S]{0,200}?connectionStatus\$=\{desktopConnectionStatus\}[\s\S]{0,200}?connectionLabel="Daemon connection"/,
+    );
+    expect(appSource).toMatch(/createDesktopConnectionStatusSource\(host\.daemonEvents\)/);
+    expect(appSource).not.toMatch(/connectionStatus\$=\{host\.transport\.connectionStatus\$\}/);
   });
 });

--- a/apps/notebook/src/lib/__tests__/desktop-connection-status.test.ts
+++ b/apps/notebook/src/lib/__tests__/desktop-connection-status.test.ts
@@ -1,0 +1,93 @@
+import { describe, expect, it } from "vite-plus/test";
+import type { ConnectionStatus } from "runtimed";
+import { createDesktopConnectionStatusSource } from "../desktop-connection-status";
+
+function createFakeDaemonEvents() {
+  const handlers = {
+    ready: new Set<() => void>(),
+    disconnected: new Set<() => void>(),
+    unavailable: new Set<() => void>(),
+  };
+  return {
+    handlers,
+    fire(kind: keyof typeof handlers): void {
+      for (const handler of [...handlers[kind]]) {
+        handler();
+      }
+    },
+    daemonEvents: {
+      onReady: (cb: () => void) => {
+        handlers.ready.add(cb);
+        return () => handlers.ready.delete(cb);
+      },
+      onDisconnected: (cb: () => void) => {
+        handlers.disconnected.add(cb);
+        return () => handlers.disconnected.delete(cb);
+      },
+      onUnavailable: (cb: () => void) => {
+        handlers.unavailable.add(cb);
+        return () => handlers.unavailable.delete(cb);
+      },
+    },
+  };
+}
+
+describe("createDesktopConnectionStatusSource", () => {
+  it("walks the daemon lifecycle: connecting, online, reconnecting, online, offline", () => {
+    const fake = createFakeDaemonEvents();
+    const source = createDesktopConnectionStatusSource(fake.daemonEvents);
+    const statuses: ConnectionStatus[] = [];
+    source.subscribe((status) => statuses.push(status));
+
+    // daemon:ready (incl. the host facade's cache backfill for late mounts).
+    fake.fire("ready");
+    // daemon:disconnected — the host auto-reconnects, so this is a
+    // transition, not an outage verdict.
+    fake.fire("disconnected");
+    // daemon restart completes.
+    fake.fire("ready");
+    // daemon:unavailable is the terminal state.
+    fake.fire("unavailable");
+
+    expect(statuses).toEqual(["connecting", "online", "reconnecting", "online", "offline"]);
+    expect(source.getCurrent()).toBe("offline");
+  });
+
+  it("dedups repeated lifecycle events", () => {
+    const fake = createFakeDaemonEvents();
+    const source = createDesktopConnectionStatusSource(fake.daemonEvents);
+    const statuses: ConnectionStatus[] = [];
+    source.subscribe((status) => statuses.push(status));
+
+    fake.fire("ready");
+    fake.fire("ready"); // path changes re-emit daemon:ready
+    expect(statuses).toEqual(["connecting", "online"]);
+  });
+
+  it("replays the current value to subscribers and supports getCurrent", () => {
+    const fake = createFakeDaemonEvents();
+    const source = createDesktopConnectionStatusSource(fake.daemonEvents);
+    fake.fire("ready");
+
+    expect(source.getCurrent()).toBe("online");
+    const statuses: ConnectionStatus[] = [];
+    source.subscribe((status) => statuses.push(status));
+    expect(statuses).toEqual(["online"]);
+  });
+
+  it("unsubscribe and dispose detach cleanly", () => {
+    const fake = createFakeDaemonEvents();
+    const source = createDesktopConnectionStatusSource(fake.daemonEvents);
+    const statuses: ConnectionStatus[] = [];
+    const subscription = source.subscribe((status) => statuses.push(status));
+
+    subscription.unsubscribe();
+    fake.fire("ready");
+    expect(statuses).toEqual(["connecting"]); // late events are inert
+
+    source.dispose();
+    expect(fake.handlers.ready.size).toBe(0);
+    expect(fake.handlers.disconnected.size).toBe(0);
+    expect(fake.handlers.unavailable.size).toBe(0);
+  });
+});

--- a/apps/notebook/src/lib/__tests__/desktop-shell-capabilities.test.ts
+++ b/apps/notebook/src/lib/__tests__/desktop-shell-capabilities.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it } from "vite-plus/test";
+import { isRemoteNotebookContext } from "@/components/notebook";
 import { desktopNotebookShellCapabilities } from "../desktop-shell-capabilities";
 import { RUNTIME_STATUS } from "../kernel-status";
 
@@ -374,5 +375,35 @@ describe("desktopNotebookShellCapabilities", () => {
       operator: { kind: "agent", label: "Codex" },
       scope: "editor",
     });
+  });
+
+  it("composes with the connection/identity slot gate on REAL projection output", () => {
+    // Drift guard: the slot's isRemoteNotebookContext must keep agreeing
+    // with what desktopNotebookShellCapabilities actually emits — a purely
+    // local session renders no identity chrome (#3290), a server-assigned
+    // scope does.
+    const local = desktopNotebookShellCapabilities({
+      canAcceptCellMutations: true,
+      sessionReady: true,
+      localActor: "local:kyle/desktop:window",
+      connectionScope: null,
+    });
+    expect(isRemoteNotebookContext(local)).toBe(false);
+
+    const runtimePeer = desktopNotebookShellCapabilities({
+      canAcceptCellMutations: true,
+      sessionReady: true,
+      localActor: "user:anaconda:kyle/desktop:window",
+      connectionScope: "runtime_peer",
+    });
+    expect(isRemoteNotebookContext(runtimePeer)).toBe(true);
+
+    const cloudScoped = desktopNotebookShellCapabilities({
+      canAcceptCellMutations: true,
+      sessionReady: true,
+      localActor: "user:anaconda:kyle/desktop:window",
+      connectionScope: "editor",
+    });
+    expect(isRemoteNotebookContext(cloudScoped)).toBe(true);
   });
 });

--- a/apps/notebook/src/lib/desktop-connection-status.ts
+++ b/apps/notebook/src/lib/desktop-connection-status.ts
@@ -1,0 +1,64 @@
+import type { HostDaemonEvents } from "@nteract/notebook-host";
+import type { ConnectionStatus } from "runtimed";
+import type { NotebookConnectionStatusSource } from "@/components/notebook";
+
+export interface DesktopConnectionStatusSource extends NotebookConnectionStatusSource {
+  getCurrent(): ConnectionStatus;
+  /** Detach from the daemon events (app teardown). */
+  dispose(): void;
+}
+
+/**
+ * Desktop connection-status source for the connection/identity slot,
+ * derived from daemon lifecycle events.
+ *
+ * The Tauri IPC transport's own `connectionStatus$` is honest about IPC
+ * but constant in practice — the app never disconnects it, so a dot fed
+ * from it could never transition (it would sit emerald through a daemon
+ * restart, exactly the window where kernel/execution chrome freezes). The
+ * daemon link is the first hop of any remote context the slot renders
+ * for, and `daemon:ready` / `daemon:disconnected` / `daemon:unavailable`
+ * are the real lifecycle the desktop can report today. Daemon↔room link
+ * health is future work; the slot's copy is scoped to the daemon link via
+ * its `connectionLabel`.
+ *
+ * - `onReady` → "online" (the host facade backfills from its cache, so a
+ *   source created after the daemon is already up still reaches "online")
+ * - `onDisconnected` → "reconnecting" (the host immediately starts its own
+ *   reconnect — "reconnecting" is the truthful state, not "offline")
+ * - `onUnavailable` → "offline"
+ */
+export function createDesktopConnectionStatusSource(
+  daemonEvents: Pick<HostDaemonEvents, "onReady" | "onDisconnected" | "onUnavailable">,
+): DesktopConnectionStatusSource {
+  let current: ConnectionStatus = "connecting";
+  const listeners = new Set<(status: ConnectionStatus) => void>();
+  const next = (status: ConnectionStatus) => {
+    if (status === current) return;
+    current = status;
+    for (const listener of listeners) {
+      listener(status);
+    }
+  };
+
+  const unlisteners = [
+    daemonEvents.onReady(() => next("online")),
+    daemonEvents.onDisconnected(() => next("reconnecting")),
+    daemonEvents.onUnavailable(() => next("offline")),
+  ];
+
+  return {
+    getCurrent: () => current,
+    subscribe(listener) {
+      listener(current);
+      listeners.add(listener);
+      return { unsubscribe: () => listeners.delete(listener) };
+    },
+    dispose() {
+      for (const unlisten of unlisteners) {
+        unlisten();
+      }
+      listeners.clear();
+    },
+  };
+}

--- a/docs/adr/local-first-notebook-state.md
+++ b/docs/adr/local-first-notebook-state.md
@@ -386,23 +386,34 @@ real `createCloudConnectTarget`.
 
 ## PR 3 — Connection/identity slot
 
-One shared component, mounted in slots that already exist and are empty:
+One shared component — `NotebookConnectionIdentity`
+(`src/components/notebook/`) — mounted in slots that already existed and
+were empty:
 
-- **Cloud:** `identityControls={null}` in `notebook-viewer.tsx` (right-most
-  header slot).
-- **Desktop:** `trailingControls` → `identityControls` at the right end of the
-  command toolbar.
+- **Cloud:** the `identityControls={null}` slot in `notebook-viewer.tsx`
+  (right-most header slot), now filled.
+- **Desktop:** `trailingControls` on `<NotebookToolbar>` in `App.tsx` →
+  `identityControls` at the right end of the command toolbar, fed by the
+  host transport's `connectionStatus$` (stable for the app's lifetime;
+  TauriTransport reports online/offline today, which is honest).
 
 **Conditionality** (the reason #3290 pulled the previous attempt): the slot
-renders **nothing** for a purely local desktop session. The predicate already
-exists in `NotebookShellCapabilities`: `access.source !== "local"` or
-`runtime.target.kind === "runtime_peer"`. Cloud is always remote.
+renders **nothing** for a purely local desktop session. The predicate is
+centralized in the component (`isRemoteNotebookContext`):
+`access.source !== "local"` or `runtime.target.kind === "runtime_peer"`.
+Cloud is always remote, so hosts mount unconditionally.
 
-**Content:** self-identity (the flattened `NotebookIdentityBadge` treatment —
-actor initials/avatar) paired with a connectivity dot driven by
-`connectionStatus$` — its first UI consumer. Status vocabulary follows the
-existing tones: emerald `online`, amber pulse `reconnecting`/`connecting`,
-muted `offline`.
+**Content:** self-identity (the flattened avatar treatment via the shared
+actor projection — initials/avatar only, no visible label) paired with a
+connectivity dot driven by `connectionStatus$` — its first UI consumer. The
+component accepts a structural `NotebookConnectionStatusSource` (an
+rxjs-free `Observable` subset) so shared `src/` takes no new dependency.
+Status vocabulary follows the existing tones: emerald `online`, amber pulse
+`reconnecting`/`connecting`, muted `offline`; non-online states also dim
+the wrapper (opacity, not copy). This is the surface that makes the PR-2
+limitation interpretable: runtime-state stores are not blanked during the
+offline window, and the pulsing dot stays live through `reconnecting` so
+frozen kernel/execution chrome reads as "reconnecting", not as truth.
 
 **Aesthetic rules distilled from the three pulled designs** (#3273, #3290,
 #3337, #3349 — recorded so we do not relitigate them):
@@ -421,13 +432,23 @@ muted `offline`.
 Plumbing fix included: the host facade's `connectionStatus$` delegation
 captures whichever transport exists at subscribe time and never switches — a
 subscriber can watch a dead transport forever. With PR 2 the transport object
-survives reconnects, but initial-connect attempts may still replace it; the
-session exposes a stable, switching connection-status source (small
-BehaviorSubject bridge fed by the current transport) for the UI.
+survives reconnects, but initial-connect attempts and escalation teardowns
+still replace it; the session exposes `CloudConnectionStatusBridge`
+(`live-sync.ts`) — a stable BehaviorSubject-backed source attached to each
+replacement transport via `onTransportCreated`, deduplicating across
+switches. On escalation teardown the bridge detaches BEFORE the dispose and
+reports `"reconnecting"`, so the disposed transport's terminal `"offline"`
+(manual-disconnect vocabulary) never surfaces while the session is retrying.
 
-Tests: component tests for each status × identity combination and the
-local-session-renders-nothing gate; keep #3337's quiet-chrome regressions
-green.
+Tests: component tests for every status × identity combination
+(data-state + dot tone + opacity), the local-session-renders-nothing gate,
+the runtime-peer remote case, the live-dot-through-reconnecting regression,
+the flat-never-raised treatment, and icon-only-at-every-width (no visible
+text outside the avatar — collapse-proof by construction); bridge tests for
+transport replacement, teardown-retry masking of the disposed transport's
+offline, and the PR-2 loop reflected without a switch; #3337's quiet-chrome
+regressions stay green (the `identityControls={null}` pin became a pin on
+the new mount).
 
 ---
 

--- a/docs/adr/local-first-notebook-state.md
+++ b/docs/adr/local-first-notebook-state.md
@@ -393,9 +393,17 @@ were empty:
 - **Cloud:** the `identityControls={null}` slot in `notebook-viewer.tsx`
   (right-most header slot), now filled.
 - **Desktop:** `trailingControls` on `<NotebookToolbar>` in `App.tsx` →
-  `identityControls` at the right end of the command toolbar, fed by the
-  host transport's `connectionStatus$` (stable for the app's lifetime;
-  TauriTransport reports online/offline today, which is honest).
+  `identityControls` at the right end of the command toolbar, fed by a
+  daemon-lifecycle source (`createDesktopConnectionStatusSource`:
+  `daemon:ready` → online, `daemon:disconnected` → reconnecting — the host
+  auto-reconnects — `daemon:unavailable` → offline; the host facade's
+  ready-cache backfill covers late mounts). The Tauri IPC transport's own
+  `connectionStatus$` is deliberately NOT used: it is honest about IPC but
+  constant in practice (the app never disconnects it), so a dot fed from
+  it could never transition through a daemon restart. The desktop copy is
+  scoped to the measured link via `connectionLabel="Daemon connection"` —
+  daemon↔room link health for runtime-peer contexts is **future work**;
+  until it exists the dot must say which hop it reports.
 
 **Conditionality** (the reason #3290 pulled the previous attempt): the slot
 renders **nothing** for a purely local desktop session. The predicate is
@@ -404,16 +412,22 @@ centralized in the component (`isRemoteNotebookContext`):
 Cloud is always remote, so hosts mount unconditionally.
 
 **Content:** self-identity (the flattened avatar treatment via the shared
-actor projection — initials/avatar only, no visible label) paired with a
+actor projection — initials/avatar only, no visible label, hidden from the
+a11y tree so the sr-only copy is the single accessible text) paired with a
 connectivity dot driven by `connectionStatus$` — its first UI consumer. The
 component accepts a structural `NotebookConnectionStatusSource` (an
-rxjs-free `Observable` subset) so shared `src/` takes no new dependency.
-Status vocabulary follows the existing tones: emerald `online`, amber pulse
-`reconnecting`/`connecting`, muted `offline`; non-online states also dim
-the wrapper (opacity, not copy). This is the surface that makes the PR-2
+rxjs-free `Observable` subset with an optional `getCurrent()` snapshot so
+first paint shows the real status, no one-frame "connecting" flash) so
+shared `src/` takes no new dependency. Status vocabulary follows the
+existing tones: emerald `online`, amber pulse `reconnecting`/`connecting`,
+muted `offline`; non-online states also dim the wrapper (opacity, not
+copy). Status CHANGES (never the initial value) are announced through a
+polite sr-only live region using the scoped link copy — quiet for the eyes
+is not silence for screen readers. This is the surface that makes the PR-2
 limitation interpretable: runtime-state stores are not blanked during the
 offline window, and the pulsing dot stays live through `reconnecting` so
-frozen kernel/execution chrome reads as "reconnecting", not as truth.
+frozen kernel/execution chrome reads as "reconnecting", not as truth — for
+the link each host actually measures.
 
 **Aesthetic rules distilled from the three pulled designs** (#3273, #3290,
 #3337, #3349 — recorded so we do not relitigate them):
@@ -436,19 +450,33 @@ survives reconnects, but initial-connect attempts and escalation teardowns
 still replace it; the session exposes `CloudConnectionStatusBridge`
 (`live-sync.ts`) — a stable BehaviorSubject-backed source attached to each
 replacement transport via `onTransportCreated`, deduplicating across
-switches. On escalation teardown the bridge detaches BEFORE the dispose and
-reports `"reconnecting"`, so the disposed transport's terminal `"offline"`
-(manual-disconnect vocabulary) never surfaces while the session is retrying.
+switches. On escalation teardown — and in the effect cleanup, where the
+auth-refresh re-run early-returns without attaching a replacement — the
+bridge detaches BEFORE the dispose and reports `"reconnecting"`, so the
+disposed transport's terminal `"offline"` (manual-disconnect vocabulary)
+never surfaces and the gap reads as a transition, never as stale
+`"online"`. The bridge implements the slot's source contract directly
+(`subscribe` + `getCurrent`).
 
 Tests: component tests for every status × identity combination
 (data-state + dot tone + opacity), the local-session-renders-nothing gate,
 the runtime-peer remote case, the live-dot-through-reconnecting regression,
-the flat-never-raised treatment, and icon-only-at-every-width (no visible
-text outside the avatar — collapse-proof by construction); bridge tests for
-transport replacement, teardown-retry masking of the disposed transport's
-offline, and the PR-2 loop reflected without a switch; #3337's quiet-chrome
-regressions stay green (the `identityControls={null}` pin became a pin on
-the new mount).
+scoped-link copy, `getCurrent` first paint, live-region announcements
+(changes only, never the mount), aria-hidden avatar, unmount-unsubscribe,
+the flat-never-raised treatment across the whole subtree, and
+icon-only-at-every-width via clone-and-strip (wrapper text nodes included);
+desktop tests for the daemon-lifecycle source (lifecycle walk, dedup,
+replay/getCurrent, dispose), the real-projection composition with
+`isRemoteNotebookContext`, the toolbar trailingControls flow with real
+`desktopNotebookShellCapabilities` output, and a source-text pin on the
+App.tsx mount (daemon source + scoped label, not the IPC transport); bridge
+tests for transport replacement, plain-detach silence, the slot source
+contract, teardown-retry masking of the disposed transport's offline, and
+the PR-2 loop reflected without a switch; session wiring order
+(attach-on-transport-created, retry-before-dispose in all three teardown
+paths) pinned by source guardrails; #3337's quiet-chrome regressions stay
+green (the `identityControls={null}` pin became a module-scoped pin on the
+new mount).
 
 ---
 

--- a/src/components/notebook/NotebookConnectionIdentity.tsx
+++ b/src/components/notebook/NotebookConnectionIdentity.tsx
@@ -1,0 +1,133 @@
+import { useEffect, useState } from "react";
+import type { ConnectionStatus } from "runtimed";
+import { cn } from "@/lib/utils";
+import { NotebookActorAvatar } from "./NotebookIdentity";
+import { notebookToolbarActors } from "./NotebookToolbarIdentity";
+import type { NotebookShellCapabilities } from "./capabilities";
+
+/**
+ * Structural subset of an RxJS `Observable<ConnectionStatus>` — keeps the
+ * shared component free of a direct rxjs dependency while accepting the
+ * transports' `connectionStatus$` and the cloud session's bridge directly.
+ */
+export interface NotebookConnectionStatusSource {
+  subscribe(next: (status: ConnectionStatus) => void): { unsubscribe(): void };
+}
+
+/**
+ * NotebookConnectionIdentity — the connection/identity slot.
+ *
+ * Self-identity (the flattened avatar treatment) paired with a
+ * connectivity dot driven by the transport's `connectionStatus$` — its
+ * first UI consumer. Runtime-state stores are deliberately not blanked
+ * while a transport reconnects, so this dot is what makes frozen
+ * kernel/execution chrome interpretable during the offline window.
+ *
+ * Quiet-chrome rules (distilled from the pulled #3273/#3290/#3337/#3349
+ * designs — hard constraints, not preferences):
+ * - renders NOTHING for a purely local desktop session
+ *   (`isRemoteNotebookContext`); local identity is noise, not chrome;
+ * - flat `rounded-md border-border/70 bg-muted/35`, never
+ *   rounded-full + shadow;
+ * - icon/avatar-first and icon-only at every width: no visible text pill —
+ *   the label and status live in `sr-only` copy and the title tooltip;
+ * - state expresses as dot color / opacity, never copy;
+ * - errors and reconnect prompts belong to the notices stack, never here;
+ * - connection state never masquerades as kernel/runtime status.
+ */
+export interface NotebookConnectionIdentityProps {
+  capabilities: NotebookShellCapabilities;
+  /**
+   * Connection lifecycle from the live transport. Hosts must hand a source
+   * that survives transport replacement (cloud: the session's
+   * `CloudConnectionStatusBridge`; desktop: the host transport, which is
+   * stable for the app's lifetime).
+   */
+  connectionStatus$: NotebookConnectionStatusSource;
+  className?: string;
+}
+
+export function NotebookConnectionIdentity({
+  capabilities,
+  connectionStatus$,
+  className,
+}: NotebookConnectionIdentityProps) {
+  const status = useConnectionStatus(connectionStatus$);
+
+  // Conditionality is the point (#3290): a purely local desktop session
+  // gets no identity chrome at all.
+  if (!isRemoteNotebookContext(capabilities)) {
+    return null;
+  }
+
+  const actor = notebookToolbarActors(capabilities)[0];
+  if (!actor) {
+    return null;
+  }
+
+  const statusLabel = connectionStatusLabel(status);
+  const detail = `${actor.label} — ${statusLabel}`;
+
+  return (
+    <div
+      className={cn(
+        "inline-flex shrink-0 items-center rounded-md border border-border/70 bg-muted/35 px-1.5 py-0.5",
+        status !== "online" && "opacity-60",
+        className,
+      )}
+      data-slot="notebook-connection-identity"
+      data-state={status}
+      data-actor-kind={actor.kind}
+      title={detail}
+    >
+      <NotebookActorAvatar actor={actor} size="sm" statusClassName={connectionDotTone(status)} />
+      <span className="sr-only">{detail}</span>
+    </div>
+  );
+}
+
+/**
+ * Remote-context predicate: cloud is always remote; a desktop session is
+ * remote only when its access is server-assigned or a runtime peer is the
+ * compute target.
+ */
+export function isRemoteNotebookContext(capabilities: NotebookShellCapabilities): boolean {
+  return (
+    capabilities.access.source !== "local" || capabilities.runtime.target?.kind === "runtime_peer"
+  );
+}
+
+function useConnectionStatus(status$: NotebookConnectionStatusSource): ConnectionStatus {
+  const [status, setStatus] = useState<ConnectionStatus>("connecting");
+  useEffect(() => {
+    const subscription = status$.subscribe((next) => setStatus(next));
+    return () => subscription.unsubscribe();
+  }, [status$]);
+  return status;
+}
+
+/** Existing statusTone vocabulary: emerald active, amber attention, muted offline. */
+function connectionDotTone(status: ConnectionStatus): string {
+  switch (status) {
+    case "online":
+      return "bg-emerald-500";
+    case "connecting":
+    case "reconnecting":
+      return "animate-pulse bg-amber-500";
+    case "offline":
+      return "bg-muted";
+  }
+}
+
+function connectionStatusLabel(status: ConnectionStatus): string {
+  switch (status) {
+    case "online":
+      return "Connected";
+    case "connecting":
+      return "Connecting";
+    case "reconnecting":
+      return "Reconnecting";
+    case "offline":
+      return "Offline";
+  }
+}

--- a/src/components/notebook/NotebookConnectionIdentity.tsx
+++ b/src/components/notebook/NotebookConnectionIdentity.tsx
@@ -12,16 +12,26 @@ import type { NotebookShellCapabilities } from "./capabilities";
  */
 export interface NotebookConnectionStatusSource {
   subscribe(next: (status: ConnectionStatus) => void): { unsubscribe(): void };
+  /**
+   * Optional synchronous snapshot for first paint. BehaviorSubject-backed
+   * sources (the cloud bridge, the desktop daemon source) implement it so
+   * the first committed frame shows the real status instead of a one-frame
+   * "connecting" flash.
+   */
+  getCurrent?(): ConnectionStatus;
 }
 
 /**
  * NotebookConnectionIdentity — the connection/identity slot.
  *
  * Self-identity (the flattened avatar treatment) paired with a
- * connectivity dot driven by the transport's `connectionStatus$` — its
- * first UI consumer. Runtime-state stores are deliberately not blanked
- * while a transport reconnects, so this dot is what makes frozen
- * kernel/execution chrome interpretable during the offline window.
+ * connectivity dot driven by a connection-status source — its first UI
+ * consumer. Runtime-state stores are deliberately not blanked while a
+ * transport reconnects, so this dot is what makes frozen kernel/execution
+ * chrome interpretable during the offline window — for the link the host
+ * actually measures: the cloud room transport on cloud, the daemon link on
+ * desktop (daemon↔room health is future work; `connectionLabel` scopes the
+ * copy to the measured link so the dot never overclaims).
  *
  * Quiet-chrome rules (distilled from the pulled #3273/#3290/#3337/#3349
  * designs — hard constraints, not preferences):
@@ -31,28 +41,39 @@ export interface NotebookConnectionStatusSource {
  *   rounded-full + shadow;
  * - icon/avatar-first and icon-only at every width: no visible text pill —
  *   the label and status live in `sr-only` copy and the title tooltip;
- * - state expresses as dot color / opacity, never copy;
+ * - state expresses as dot color / opacity, never copy; status CHANGES are
+ *   announced through a polite sr-only live region (quiet for the eyes is
+ *   not silence for screen readers);
  * - errors and reconnect prompts belong to the notices stack, never here;
  * - connection state never masquerades as kernel/runtime status.
  */
 export interface NotebookConnectionIdentityProps {
   capabilities: NotebookShellCapabilities;
   /**
-   * Connection lifecycle from the live transport. Hosts must hand a source
-   * that survives transport replacement (cloud: the session's
-   * `CloudConnectionStatusBridge`; desktop: the host transport, which is
+   * Connection lifecycle source. Hosts must hand a source that survives
+   * transport replacement (cloud: the session's
+   * `CloudConnectionStatusBridge`; desktop: the daemon-lifecycle source,
    * stable for the app's lifetime).
    */
   connectionStatus$: NotebookConnectionStatusSource;
+  /**
+   * Names the link the source measures, e.g. "Daemon connection" on
+   * desktop. Scopes the title/sr-only copy and the live-region
+   * announcements so the dot never asserts health it does not observe.
+   */
+  connectionLabel?: string;
   className?: string;
 }
 
 export function NotebookConnectionIdentity({
   capabilities,
   connectionStatus$,
+  connectionLabel,
   className,
 }: NotebookConnectionIdentityProps) {
-  const status = useConnectionStatus(connectionStatus$);
+  const { status, announcedStatus } = useConnectionStatus(connectionStatus$);
+  const statusText = formatStatusText(status, connectionLabel);
+  const announcement = announcedStatus ? formatStatusText(announcedStatus, connectionLabel) : "";
 
   // Conditionality is the point (#3290): a purely local desktop session
   // gets no identity chrome at all.
@@ -65,8 +86,7 @@ export function NotebookConnectionIdentity({
     return null;
   }
 
-  const statusLabel = connectionStatusLabel(status);
-  const detail = `${actor.label} — ${statusLabel}`;
+  const detail = `${actor.label} — ${statusText}`;
 
   return (
     <div
@@ -80,8 +100,18 @@ export function NotebookConnectionIdentity({
       data-actor-kind={actor.kind}
       title={detail}
     >
-      <NotebookActorAvatar actor={actor} size="sm" statusClassName={connectionDotTone(status)} />
+      {/* The visual layer is hidden from the a11y tree (avatar initials
+          would otherwise leak ahead of the sr-only copy). */}
+      <span aria-hidden="true">
+        <NotebookActorAvatar actor={actor} size="sm" statusClassName={connectionDotTone(status)} />
+      </span>
       <span className="sr-only">{detail}</span>
+      {/* Announces status CHANGES only — empty on initial render so a mount
+          never speaks, and sources dedup repeated values so flaps don't
+          spam. */}
+      <span className="sr-only" aria-live="polite">
+        {announcement}
+      </span>
     </div>
   );
 }
@@ -97,13 +127,40 @@ export function isRemoteNotebookContext(capabilities: NotebookShellCapabilities)
   );
 }
 
-function useConnectionStatus(status$: NotebookConnectionStatusSource): ConnectionStatus {
-  const [status, setStatus] = useState<ConnectionStatus>("connecting");
+function useConnectionStatus(status$: NotebookConnectionStatusSource): {
+  status: ConnectionStatus;
+  /** Set only on a CHANGE the source delivered after its initial value. */
+  announcedStatus: ConnectionStatus | null;
+} {
+  const [status, setStatus] = useState<ConnectionStatus>(
+    () => status$.getCurrent?.() ?? "connecting",
+  );
+  const [announcedStatus, setAnnouncedStatus] = useState<ConnectionStatus | null>(null);
   useEffect(() => {
-    const subscription = status$.subscribe((next) => setStatus(next));
+    // The first delivery (BehaviorSubject replay) is the baseline, never an
+    // announcement — only subsequent transitions speak.
+    let baseline: ConnectionStatus | null = null;
+    let delivered = false;
+    const subscription = status$.subscribe((next) => {
+      setStatus(next);
+      if (!delivered) {
+        delivered = true;
+        baseline = next;
+        return;
+      }
+      if (next !== baseline) {
+        baseline = next;
+        setAnnouncedStatus(next);
+      }
+    });
     return () => subscription.unsubscribe();
   }, [status$]);
-  return status;
+  return { status, announcedStatus };
+}
+
+function formatStatusText(status: ConnectionStatus, connectionLabel?: string): string {
+  const label = connectionStatusLabel(status);
+  return connectionLabel ? `${connectionLabel}: ${label}` : label;
 }
 
 /** Existing statusTone vocabulary: emerald active, amber attention, muted offline. */

--- a/src/components/notebook/NotebookIdentity.tsx
+++ b/src/components/notebook/NotebookIdentity.tsx
@@ -141,17 +141,21 @@ export function NotebookIdentityGroup({
   );
 }
 
-function NotebookActorAvatar({
+export function NotebookActorAvatar({
   actor,
-  icon: Icon,
+  icon,
   size = "default",
   showStatus = true,
+  statusClassName,
 }: {
   actor: NotebookActorIdentity;
-  icon: LucideIcon;
+  icon?: LucideIcon;
   size?: "sm" | "default";
   showStatus?: boolean;
+  /** Override the status dot tone (e.g. connection state instead of actor status). */
+  statusClassName?: string;
 }) {
+  const Icon = icon ?? actorIcon(actor.kind);
   return (
     <Avatar
       size={size}
@@ -167,7 +171,9 @@ function NotebookActorAvatar({
           <Icon className="size-3.5" aria-hidden="true" />
         )}
       </AvatarFallback>
-      {showStatus ? <AvatarBadge className={statusTone(actor.status ?? "active")} /> : null}
+      {showStatus ? (
+        <AvatarBadge className={statusClassName ?? statusTone(actor.status ?? "active")} />
+      ) : null}
     </Avatar>
   );
 }

--- a/src/components/notebook/__tests__/NotebookConnectionIdentity.test.tsx
+++ b/src/components/notebook/__tests__/NotebookConnectionIdentity.test.tsx
@@ -27,6 +27,23 @@ class FakeStatusSource implements NotebookConnectionStatusSource {
       listener(status);
     }
   }
+
+  get listenerCount(): number {
+    return this.listeners.size;
+  }
+}
+
+/** Source with a snapshot but NO replay on subscribe — isolates getCurrent. */
+class SnapshotOnlyStatusSource implements NotebookConnectionStatusSource {
+  constructor(private readonly value: ConnectionStatus) {}
+
+  getCurrent(): ConnectionStatus {
+    return this.value;
+  }
+
+  subscribe(): { unsubscribe(): void } {
+    return { unsubscribe: () => {} };
+  }
 }
 
 function capabilities(
@@ -77,7 +94,20 @@ function localCapabilities(): NotebookShellCapabilities {
       source: "local",
       actorLabel: "local:kyle/desktop:abc",
       identityLabel: "Kyle",
-      target: { kind: "local_daemon", status: "connected" },
+      target: { kind: "local_daemon", status: "ready", label: "Local daemon" },
+    },
+  });
+}
+
+function runtimePeerCapabilities(): NotebookShellCapabilities {
+  const caps = localCapabilities();
+  return capabilities({
+    ...caps,
+    access: caps.access,
+    runtime: {
+      ...caps.runtime,
+      source: "cloud",
+      target: { kind: "runtime_peer", status: "attached", label: "Cloud room" },
     },
   });
 }
@@ -85,12 +115,13 @@ function localCapabilities(): NotebookShellCapabilities {
 function renderSlot(
   caps: NotebookShellCapabilities,
   status: ConnectionStatus = "online",
-): { container: HTMLElement; source: FakeStatusSource } {
+  props: { connectionLabel?: string } = {},
+): { container: HTMLElement; source: FakeStatusSource; unmount: () => void } {
   const source = new FakeStatusSource(status);
-  const { container } = render(
-    <NotebookConnectionIdentity capabilities={caps} connectionStatus$={source} />,
+  const { container, unmount } = render(
+    <NotebookConnectionIdentity capabilities={caps} connectionStatus$={source} {...props} />,
   );
-  return { container, source };
+  return { container, source, unmount };
 }
 
 function slotElement(container: HTMLElement): HTMLElement {
@@ -105,6 +136,12 @@ function dotElement(container: HTMLElement): HTMLElement {
   return dot!;
 }
 
+function liveRegion(container: HTMLElement): HTMLElement {
+  const region = container.querySelector<HTMLElement>('[aria-live="polite"]');
+  expect(region).not.toBeNull();
+  return region!;
+}
+
 describe("NotebookConnectionIdentity", () => {
   it("renders nothing for a purely local desktop session", () => {
     // Conditionality is the point (#3290): local identity is noise, not chrome.
@@ -113,18 +150,7 @@ describe("NotebookConnectionIdentity", () => {
   });
 
   it("renders for a local session attached to a runtime peer", () => {
-    const caps = localCapabilities();
-    const { container } = renderSlot(
-      capabilities({
-        ...caps,
-        access: caps.access,
-        runtime: {
-          ...caps.runtime,
-          source: "cloud",
-          target: { kind: "runtime_peer", status: "connected" },
-        },
-      }),
-    );
+    const { container } = renderSlot(runtimePeerCapabilities());
     expect(slotElement(container)).toBeTruthy();
   });
 
@@ -141,10 +167,10 @@ describe("NotebookConnectionIdentity", () => {
       const dot = dotElement(container);
 
       expect(slot.dataset.state).toBe(status);
-      expect(dot.className).toContain(tone);
-      expect(dot.className.includes("animate-pulse")).toBe(pulses);
+      expect(dot.classList.contains(tone)).toBe(true);
+      expect(dot.classList.contains("animate-pulse")).toBe(pulses);
       // State expresses as opacity/dot color, never copy: non-online dims.
-      expect(slot.className.includes("opacity-60")).toBe(status !== "online");
+      expect(slot.classList.contains("opacity-60")).toBe(status !== "online");
       // Detail lives in sr-only copy and the title tooltip only.
       expect(slot.title).toContain(label);
       const srOnly = slot.querySelector(".sr-only");
@@ -152,6 +178,18 @@ describe("NotebookConnectionIdentity", () => {
       expect(srOnly?.textContent).toContain("Alice");
     },
   );
+
+  it("scopes the copy to the measured link via connectionLabel", () => {
+    // Desktop measures the daemon link, not daemon<->room health — the
+    // copy must say which link it reports so the dot never overclaims.
+    const { container } = renderSlot(runtimePeerCapabilities(), "online", {
+      connectionLabel: "Daemon connection",
+    });
+    const slot = slotElement(container);
+
+    expect(slot.title).toContain("Daemon connection: Connected");
+    expect(slot.querySelector(".sr-only")?.textContent).toContain("Daemon connection: Connected");
+  });
 
   it("keeps the dot live through a reconnect loop (stale-chrome motivation)", () => {
     // Runtime-state stores are not blanked while the transport reconnects;
@@ -162,43 +200,91 @@ describe("NotebookConnectionIdentity", () => {
 
     act(() => source.next("reconnecting"));
     expect(slotElement(container).dataset.state).toBe("reconnecting");
-    expect(dotElement(container).className).toContain("animate-pulse");
+    expect(dotElement(container).classList.contains("animate-pulse")).toBe(true);
 
     act(() => source.next("online"));
     expect(slotElement(container).dataset.state).toBe("online");
-    expect(dotElement(container).className).toContain("bg-emerald-500");
+    expect(dotElement(container).classList.contains("bg-emerald-500")).toBe(true);
   });
 
-  it("uses the flat quiet treatment, never a raised bubble", () => {
+  it("seeds first paint from getCurrent without waiting for a subscription replay", () => {
+    // SnapshotOnlyStatusSource never replays on subscribe — the rendered
+    // state can only come from the synchronous getCurrent snapshot.
+    const source = new SnapshotOnlyStatusSource("online");
+    const { container } = render(
+      <NotebookConnectionIdentity capabilities={cloudCapabilities()} connectionStatus$={source} />,
+    );
+    expect(slotElement(container).dataset.state).toBe("online");
+  });
+
+  it("announces status CHANGES politely, never the initial state", () => {
+    const { container, source } = renderSlot(cloudCapabilities(), "online", {
+      connectionLabel: "Live room",
+    });
+    // Mounting must not speak.
+    expect(liveRegion(container).textContent).toBe("");
+
+    act(() => source.next("reconnecting"));
+    expect(liveRegion(container).textContent).toBe("Live room: Reconnecting");
+
+    act(() => source.next("online"));
+    expect(liveRegion(container).textContent).toBe("Live room: Connected");
+  });
+
+  it("hides the avatar from the a11y tree so sr-only copy is the accessible text", () => {
+    // Without aria-hidden, SR users would hear "AL Alice — Connected".
+    const { container } = renderSlot(cloudCapabilities());
+    const avatar = container.querySelector('[data-slot="notebook-actor-avatar"]');
+    expect(avatar).not.toBeNull();
+    expect(avatar?.closest('[aria-hidden="true"]')).not.toBeNull();
+
+    const srOnly = slotElement(container).querySelector(".sr-only");
+    expect(srOnly?.closest('[aria-hidden="true"]')).toBeNull();
+  });
+
+  it("unsubscribes from the source on unmount", () => {
+    const { source, unmount } = renderSlot(cloudCapabilities(), "online");
+    expect(source.listenerCount).toBe(1);
+
+    unmount();
+    expect(source.listenerCount).toBe(0);
+    // Late emissions are inert (no listener left to call).
+    source.next("offline");
+  });
+
+  it("uses the flat quiet treatment, never a raised bubble — across the whole subtree", () => {
     const { container } = renderSlot(cloudCapabilities());
     const slot = slotElement(container);
 
-    expect(slot.className).toContain("rounded-md");
-    expect(slot.className).toContain("border-border/70");
-    expect(slot.className).toContain("bg-muted/35");
-    // The pulled designs' raised-bubble look must never come back.
-    expect(slot.className).not.toContain("rounded-full");
-    expect(slot.className).not.toContain("shadow");
+    expect(slot.classList.contains("rounded-md")).toBe(true);
+    expect(slot.classList.contains("border-border/70")).toBe(true);
+    expect(slot.classList.contains("bg-muted/35")).toBe(true);
+    // The pulled designs' raised-bubble look must never come back. The
+    // wrapper must not be a pill (Avatar internals are legitimately
+    // rounded-full), and NOTHING in the subtree may carry a shadow.
+    expect(slot.classList.contains("rounded-full")).toBe(false);
+    for (const element of [slot, ...Array.from(slot.querySelectorAll("*"))]) {
+      for (const token of Array.from(element.classList)) {
+        expect(token.startsWith("shadow")).toBe(false);
+      }
+    }
   });
 
   it("is icon-only at every width: no visible text pill", () => {
     // Collapse-proof by construction — there is no label to truncate.
+    // Clone-and-strip covers the wrapper's own text nodes and every
+    // nesting depth: remove sr-only copy and the avatar initials, then
+    // nothing visible may remain.
     const { container } = renderSlot(cloudCapabilities());
     const slot = slotElement(container);
 
-    const visibleText = Array.from(slot.querySelectorAll("*"))
-      .filter(
-        (element) =>
-          !element.classList.contains("sr-only") &&
-          !element.closest('[data-slot="avatar-fallback"]'),
-      )
-      .flatMap((element) =>
-        Array.from(element.childNodes)
-          .filter((node) => node.nodeType === Node.TEXT_NODE)
-          .map((node) => node.textContent?.trim() ?? ""),
-      )
-      .filter((text) => text.length > 0);
-    expect(visibleText).toEqual([]);
+    const clone = slot.cloneNode(true) as HTMLElement;
+    for (const hidden of Array.from(
+      clone.querySelectorAll('.sr-only, [data-slot="avatar-fallback"]'),
+    )) {
+      hidden.remove();
+    }
+    expect(clone.textContent?.trim()).toBe("");
 
     // The avatar fallback (initials) is the only visible glyph.
     const fallback = slot.querySelector('[data-slot="avatar-fallback"]');
@@ -220,15 +306,6 @@ describe("isRemoteNotebookContext", () => {
   });
 
   it("treats a runtime-peer compute target as remote even with local access", () => {
-    const caps = localCapabilities();
-    expect(
-      isRemoteNotebookContext(
-        capabilities({
-          ...caps,
-          access: caps.access,
-          runtime: { ...caps.runtime, target: { kind: "runtime_peer", status: "connected" } },
-        }),
-      ),
-    ).toBe(true);
+    expect(isRemoteNotebookContext(runtimePeerCapabilities())).toBe(true);
   });
 });

--- a/src/components/notebook/__tests__/NotebookConnectionIdentity.test.tsx
+++ b/src/components/notebook/__tests__/NotebookConnectionIdentity.test.tsx
@@ -1,0 +1,234 @@
+import { act, render } from "@testing-library/react";
+import { describe, expect, it } from "vite-plus/test";
+import type { ConnectionStatus } from "runtimed";
+import { readOnlyNotebookShellCapabilities } from "../capabilities";
+import {
+  NotebookConnectionIdentity,
+  isRemoteNotebookContext,
+  type NotebookConnectionStatusSource,
+} from "../NotebookConnectionIdentity";
+import type { NotebookShellCapabilities } from "../capabilities";
+
+/** Minimal BehaviorSubject-shaped source (rxjs-free, like the component). */
+class FakeStatusSource implements NotebookConnectionStatusSource {
+  private readonly listeners = new Set<(status: ConnectionStatus) => void>();
+
+  constructor(private value: ConnectionStatus) {}
+
+  subscribe(next: (status: ConnectionStatus) => void): { unsubscribe(): void } {
+    next(this.value);
+    this.listeners.add(next);
+    return { unsubscribe: () => this.listeners.delete(next) };
+  }
+
+  next(status: ConnectionStatus): void {
+    this.value = status;
+    for (const listener of this.listeners) {
+      listener(status);
+    }
+  }
+}
+
+function capabilities(
+  overrides: Partial<NotebookShellCapabilities> = {},
+): NotebookShellCapabilities {
+  return {
+    ...readOnlyNotebookShellCapabilities,
+    ...overrides,
+    access: {
+      ...readOnlyNotebookShellCapabilities.access,
+      ...overrides.access,
+    },
+    auth: {
+      ...readOnlyNotebookShellCapabilities.auth,
+      ...overrides.auth,
+    },
+    runtime: {
+      ...readOnlyNotebookShellCapabilities.runtime,
+      ...overrides.runtime,
+    },
+  };
+}
+
+function cloudCapabilities(): NotebookShellCapabilities {
+  return capabilities({
+    access: {
+      level: "editor",
+      source: "cloud",
+      isPublic: false,
+      actorLabel: "user:anaconda:alice/browser:session-1",
+      identityLabel: "Alice",
+    },
+  });
+}
+
+function localCapabilities(): NotebookShellCapabilities {
+  return capabilities({
+    access: {
+      level: "owner",
+      source: "local",
+      isPublic: false,
+      actorLabel: "local:kyle/desktop:abc",
+      identityLabel: "Kyle",
+    },
+    runtime: {
+      connected: true,
+      canWriteRuntimeState: true,
+      source: "local",
+      actorLabel: "local:kyle/desktop:abc",
+      identityLabel: "Kyle",
+      target: { kind: "local_daemon", status: "connected" },
+    },
+  });
+}
+
+function renderSlot(
+  caps: NotebookShellCapabilities,
+  status: ConnectionStatus = "online",
+): { container: HTMLElement; source: FakeStatusSource } {
+  const source = new FakeStatusSource(status);
+  const { container } = render(
+    <NotebookConnectionIdentity capabilities={caps} connectionStatus$={source} />,
+  );
+  return { container, source };
+}
+
+function slotElement(container: HTMLElement): HTMLElement {
+  const slot = container.querySelector<HTMLElement>('[data-slot="notebook-connection-identity"]');
+  expect(slot).not.toBeNull();
+  return slot!;
+}
+
+function dotElement(container: HTMLElement): HTMLElement {
+  const dot = container.querySelector<HTMLElement>('[data-slot="avatar-badge"]');
+  expect(dot).not.toBeNull();
+  return dot!;
+}
+
+describe("NotebookConnectionIdentity", () => {
+  it("renders nothing for a purely local desktop session", () => {
+    // Conditionality is the point (#3290): local identity is noise, not chrome.
+    const { container } = renderSlot(localCapabilities());
+    expect(container.innerHTML).toBe("");
+  });
+
+  it("renders for a local session attached to a runtime peer", () => {
+    const caps = localCapabilities();
+    const { container } = renderSlot(
+      capabilities({
+        ...caps,
+        access: caps.access,
+        runtime: {
+          ...caps.runtime,
+          source: "cloud",
+          target: { kind: "runtime_peer", status: "connected" },
+        },
+      }),
+    );
+    expect(slotElement(container)).toBeTruthy();
+  });
+
+  it.each([
+    ["online", "bg-emerald-500", false, "Connected"],
+    ["connecting", "bg-amber-500", true, "Connecting"],
+    ["reconnecting", "bg-amber-500", true, "Reconnecting"],
+    ["offline", "bg-muted", false, "Offline"],
+  ] as Array<[ConnectionStatus, string, boolean, string]>)(
+    "renders the %s state with the statusTone dot",
+    (status, tone, pulses, label) => {
+      const { container } = renderSlot(cloudCapabilities(), status);
+      const slot = slotElement(container);
+      const dot = dotElement(container);
+
+      expect(slot.dataset.state).toBe(status);
+      expect(dot.className).toContain(tone);
+      expect(dot.className.includes("animate-pulse")).toBe(pulses);
+      // State expresses as opacity/dot color, never copy: non-online dims.
+      expect(slot.className.includes("opacity-60")).toBe(status !== "online");
+      // Detail lives in sr-only copy and the title tooltip only.
+      expect(slot.title).toContain(label);
+      const srOnly = slot.querySelector(".sr-only");
+      expect(srOnly?.textContent).toContain(label);
+      expect(srOnly?.textContent).toContain("Alice");
+    },
+  );
+
+  it("keeps the dot live through a reconnect loop (stale-chrome motivation)", () => {
+    // Runtime-state stores are not blanked while the transport reconnects;
+    // the dot is what makes the frozen chrome interpretable, so it must
+    // track the loop rather than only steady states.
+    const { container, source } = renderSlot(cloudCapabilities(), "online");
+    expect(slotElement(container).dataset.state).toBe("online");
+
+    act(() => source.next("reconnecting"));
+    expect(slotElement(container).dataset.state).toBe("reconnecting");
+    expect(dotElement(container).className).toContain("animate-pulse");
+
+    act(() => source.next("online"));
+    expect(slotElement(container).dataset.state).toBe("online");
+    expect(dotElement(container).className).toContain("bg-emerald-500");
+  });
+
+  it("uses the flat quiet treatment, never a raised bubble", () => {
+    const { container } = renderSlot(cloudCapabilities());
+    const slot = slotElement(container);
+
+    expect(slot.className).toContain("rounded-md");
+    expect(slot.className).toContain("border-border/70");
+    expect(slot.className).toContain("bg-muted/35");
+    // The pulled designs' raised-bubble look must never come back.
+    expect(slot.className).not.toContain("rounded-full");
+    expect(slot.className).not.toContain("shadow");
+  });
+
+  it("is icon-only at every width: no visible text pill", () => {
+    // Collapse-proof by construction — there is no label to truncate.
+    const { container } = renderSlot(cloudCapabilities());
+    const slot = slotElement(container);
+
+    const visibleText = Array.from(slot.querySelectorAll("*"))
+      .filter(
+        (element) =>
+          !element.classList.contains("sr-only") &&
+          !element.closest('[data-slot="avatar-fallback"]'),
+      )
+      .flatMap((element) =>
+        Array.from(element.childNodes)
+          .filter((node) => node.nodeType === Node.TEXT_NODE)
+          .map((node) => node.textContent?.trim() ?? ""),
+      )
+      .filter((text) => text.length > 0);
+    expect(visibleText).toEqual([]);
+
+    // The avatar fallback (initials) is the only visible glyph.
+    const fallback = slot.querySelector('[data-slot="avatar-fallback"]');
+    expect(fallback?.textContent).toBe("AL");
+  });
+
+  it("renders the actor avatar from the shared identity projection", () => {
+    const { container } = renderSlot(cloudCapabilities());
+    const slot = slotElement(container);
+    expect(slot.dataset.actorKind).toBe("human");
+    expect(slot.querySelector('[data-slot="notebook-actor-avatar"]')).not.toBeNull();
+  });
+});
+
+describe("isRemoteNotebookContext", () => {
+  it("treats cloud access as remote and local-only sessions as local", () => {
+    expect(isRemoteNotebookContext(cloudCapabilities())).toBe(true);
+    expect(isRemoteNotebookContext(localCapabilities())).toBe(false);
+  });
+
+  it("treats a runtime-peer compute target as remote even with local access", () => {
+    const caps = localCapabilities();
+    expect(
+      isRemoteNotebookContext(
+        capabilities({
+          ...caps,
+          access: caps.access,
+          runtime: { ...caps.runtime, target: { kind: "runtime_peer", status: "connected" } },
+        }),
+      ),
+    ).toBe(true);
+  });
+});

--- a/src/components/notebook/index.ts
+++ b/src/components/notebook/index.ts
@@ -142,6 +142,12 @@ export {
 } from "./NotebookIdentity";
 export { NotebookPresenceStatus, type NotebookPresenceStatusProps } from "./NotebookPresenceStatus";
 export {
+  NotebookConnectionIdentity,
+  isRemoteNotebookContext,
+  type NotebookConnectionIdentityProps,
+  type NotebookConnectionStatusSource,
+} from "./NotebookConnectionIdentity";
+export {
   NotebookToolbarIdentity,
   notebookToolbarActors,
   type NotebookToolbarIdentityProps,


### PR DESCRIPTION
PR 3 of the #3421 stack (follows #3565/#3573/#3577, all merged; rebased onto main incl. #3579/#3580). This PR began life as the integration-preview draft deployed to preview.runt.run — now rebased so its diff is exactly the slot work, and promoted to a real PR. Previously reviewed intra-fork as quillaid/nteract#4.

## What this does

The first UI consumer of `connectionStatus$` (#3530): a quiet self-identity + connectivity slot in the upper-right, designed against the distilled rules from the three previously-pulled designs (#3273/#3290/#3337/#3349) — flat, icon-only, sr-only labels, state via dot tone/opacity, errors in the notices stack, and **nothing renders for a purely local desktop session** (the #3290 lesson, centralized as `isRemoteNotebookContext`).

- **Cloud**: fills the empty `identityControls` slot, fed by a session-stable switching bridge (`CloudConnectionStatusBridge`) that follows replacement transports across initial-connect retries and escalation teardowns, masking a disposed transport's terminal `offline` as `reconnecting` while the session retries.
- **Desktop**: mounts in `trailingControls`, driven by real daemon lifecycle events (`ready`→online, `disconnected`→reconnecting, `unavailable`→offline) with copy scoped to the measured link ("Daemon connection: …") — review caught that the transport's own status was a constant that could never transition. daemon↔room link health for runtime-peer contexts is ADR-recorded future work.
- **Sustained-reconnecting notice**: after 3s of `reconnecting`, one calm line — "Reconnecting. Your edits are kept locally and will sync when the connection returns." — replacing the per-drop "Live room needs attention." for exact transport-minted link-loss shapes only (terminal auth/access failures keep the actionable diagnostic route). Flap-silent, single-fire, clears on recovery. Closes the UX gap noted at #3577: main currently reconnects quietly but *notices loudly*.
- **A11y**: polite live-region announces status *changes* (mounts silent); avatar initials aria-hidden so the scoped copy is the accessible name.

## Review

4-lens adversarial review (aesthetic conformance vs the pulled-design rules / bridge lifecycle / a11y+API / test rigor) + per-finding verification: 13 confirmed findings fixed; 12 refuted (notably: surface-split, kernel-dot adjacency, and double-avatar concerns all verified consistent with the design authorities). Field-tested on preview.runt.run from this very PR.

## Verification

Full vp suite 2133 passed / notebook-cloud 786 passed at the reviewed tip; spot-verified post-rebase (199 cloud targeted + 493 component tests), CI confirms the rest. `tsc` (both apps + root) and `cargo xtask lint` clean. Known residual (tracked): access revocation manifesting purely as WS upgrade rejections rides the calm line — fast-follow is re-running access diagnostics after sustained failures.

Stack: PR 4 (asset resilience) follows as a quillaid intra-fork PR based on this branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)