### PR TITLE
fix(notebook-cloud): expire stale workstation attach jobs

### DIFF
--- a/apps/notebook-cloud/scripts/hosted-workstation-agent.mjs
+++ b/apps/notebook-cloud/scripts/hosted-workstation-agent.mjs
@@ -98,6 +98,7 @@ async function main() {
       continue;
     }
     await runAgentStep("poll_attach_jobs", () => pollAttachJobs(pythonPath));
+    await runAgentStep("heartbeat_active_jobs", () => heartbeatActiveJobs());
     await sleep(pollIntervalMs);
   }
 }
@@ -208,7 +209,7 @@ async function startAttachJob(job, pythonPath) {
   });
   closeSync(logFd);
 
-  const active = { child, logPath: plan.logPath, ready: false };
+  const active = { child, logPath: plan.logPath, lastRunningPatchAt: 0, ready: false };
   activeJobs.set(job.job_id, active);
   console.log(
     JSON.stringify({
@@ -238,6 +239,7 @@ async function watchRuntimePeer(jobId, active) {
       const output = await readFile(active.logPath, "utf8").catch(() => "");
       if (!output.includes("Infrastructure ready, entering main loop")) return;
       active.ready = true;
+      active.lastRunningPatchAt = Date.now();
       await patchAttachJob(jobId, {
         status: "running",
       });
@@ -286,6 +288,20 @@ async function watchRuntimePeer(jobId, active) {
       );
     });
   });
+}
+
+async function heartbeatActiveJobs() {
+  const now = Date.now();
+  const runningJobs = [...activeJobs.entries()].filter(
+    ([, active]) => active.ready && now - active.lastRunningPatchAt >= heartbeatIntervalMs,
+  );
+  for (const [jobId, active] of runningJobs) {
+    await patchAttachJob(jobId, {
+      status: "running",
+    });
+    active.lastRunningPatchAt = now;
+  }
+  return runningJobs.length > 0;
 }
 
 async function patchAttachJob(jobId, patch) {

--- a/apps/notebook-cloud/scripts/hosted-workstation-agent.mjs
+++ b/apps/notebook-cloud/scripts/hosted-workstation-agent.mjs
@@ -1,6 +1,6 @@
 import { spawn } from "node:child_process";
 import { closeSync, openSync } from "node:fs";
-import { access, mkdir, readFile } from "node:fs/promises";
+import { access, mkdir, readFile, writeFile } from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
@@ -180,7 +180,11 @@ async function pollAttachJobs(pythonPath) {
   assertResponse(response, body, "poll attach jobs", [200]);
   for (const job of normalizeJobs(body)) {
     if (activeJobs.has(job.job_id)) continue;
-    await startAttachJob(job, pythonPath);
+    if (job.status === "pending") {
+      await startAttachJob(job, pythonPath);
+      continue;
+    }
+    await reconcileActiveAttachJob(job, pythonPath);
   }
   return true;
 }
@@ -200,6 +204,7 @@ async function startAttachJob(job, pythonPath) {
   await patchAttachJob(job.job_id, {
     status: "accepted",
   });
+  const acceptedAt = Date.now();
 
   const logFd = openSync(plan.logPath, "a");
   const child = spawn(runtimedBin, plan.args, {
@@ -209,7 +214,28 @@ async function startAttachJob(job, pythonPath) {
   });
   closeSync(logFd);
 
-  const active = { child, logPath: plan.logPath, lastRunningPatchAt: 0, ready: false };
+  const pidPath = attachJobPidPath(plan);
+  if (Number.isInteger(child.pid)) {
+    await writeFile(pidPath, `${child.pid}\n`, { mode: 0o600 }).catch((error) => {
+      console.error(
+        JSON.stringify({
+          event: "attach_job_pid_write_failed",
+          jobId: job.job_id,
+          message: error instanceof Error ? error.message : String(error),
+          pidPath,
+        }),
+      );
+    });
+  }
+
+  const active = {
+    child,
+    lastStatusPatchAt: acceptedAt,
+    logPath: plan.logPath,
+    pid: Number.isInteger(child.pid) ? child.pid : null,
+    ready: false,
+    status: "accepted",
+  };
   activeJobs.set(job.job_id, active);
   console.log(
     JSON.stringify({
@@ -225,11 +251,72 @@ async function startAttachJob(job, pythonPath) {
     console.error(
       JSON.stringify({
         event: "attach_job_watch_failed",
-        jobId: job.id,
+        jobId: job.job_id,
         message: error instanceof Error ? error.message : String(error),
       }),
     );
   });
+}
+
+async function reconcileActiveAttachJob(job, pythonPath) {
+  const plan = buildAttachJobSpawnPlan({
+    job,
+    pythonPath,
+    agentRoot,
+    baseUrl,
+    workingDirectory,
+    workstationId,
+    displayName,
+    authKind,
+  });
+  const pidPath = attachJobPidPath(plan);
+  const pid = await readRuntimePeerPid(pidPath);
+  if (pid && processExists(pid)) {
+    const active = {
+      child: null,
+      lastStatusPatchAt: 0,
+      logPath: plan.logPath,
+      pid,
+      ready: job.status === "running",
+      status: job.status === "running" ? "running" : "accepted",
+    };
+    activeJobs.set(job.job_id, active);
+    if (!active.ready) {
+      watchAdoptedRuntimePeer(job.job_id, active).catch((error) => {
+        console.error(
+          JSON.stringify({
+            event: "attach_job_adopted_watch_failed",
+            jobId: job.job_id,
+            message: error instanceof Error ? error.message : String(error),
+          }),
+        );
+      });
+    }
+    console.log(
+      JSON.stringify({
+        event: "attach_job_adopted",
+        jobId: job.job_id,
+        notebookId: job.notebook_id,
+        pid,
+        status: active.status,
+      }),
+    );
+    return;
+  }
+
+  await patchAttachJob(job.job_id, {
+    status: "failed",
+    error_message: `Runtime peer for ${job.status} attach job was not running after workstation agent restart`,
+  });
+  console.warn(
+    JSON.stringify({
+      event: "attach_job_recovery_failed",
+      jobId: job.job_id,
+      notebookId: job.notebook_id,
+      status: job.status,
+      pidPath,
+    }),
+  );
 }
 
 async function watchRuntimePeer(jobId, active) {
@@ -239,10 +326,11 @@ async function watchRuntimePeer(jobId, active) {
       const output = await readFile(active.logPath, "utf8").catch(() => "");
       if (!output.includes("Infrastructure ready, entering main loop")) return;
       active.ready = true;
-      active.lastRunningPatchAt = Date.now();
+      active.status = "running";
       await patchAttachJob(jobId, {
         status: "running",
       });
+      active.lastStatusPatchAt = Date.now();
     } catch (error) {
       console.error(
         JSON.stringify({
@@ -290,18 +378,63 @@ async function watchRuntimePeer(jobId, active) {
   });
 }
 
+async function watchAdoptedRuntimePeer(jobId, active) {
+  const readyPoll = setInterval(async () => {
+    try {
+      if (active.ready) {
+        clearInterval(readyPoll);
+        return;
+      }
+      if (active.pid && !processExists(active.pid)) {
+        clearInterval(readyPoll);
+        activeJobs.delete(jobId);
+        await patchAttachJob(jobId, {
+          status: "failed",
+          error_message: "Runtime peer exited before completing workstation agent recovery",
+        });
+        return;
+      }
+      const output = await readFile(active.logPath, "utf8").catch(() => "");
+      if (!output.includes("Infrastructure ready, entering main loop")) return;
+      active.ready = true;
+      active.status = "running";
+      await patchAttachJob(jobId, {
+        status: "running",
+      });
+      active.lastStatusPatchAt = Date.now();
+      clearInterval(readyPoll);
+    } catch (error) {
+      console.error(
+        JSON.stringify({
+          event: "attach_job_adopted_ready_patch_failed",
+          jobId,
+          message: error instanceof Error ? error.message : String(error),
+        }),
+      );
+    }
+  }, 250);
+}
+
 async function heartbeatActiveJobs() {
   const now = Date.now();
-  const runningJobs = [...activeJobs.entries()].filter(
-    ([, active]) => active.ready && now - active.lastRunningPatchAt >= heartbeatIntervalMs,
+  const jobs = [...activeJobs.entries()].filter(
+    ([, active]) => now - active.lastStatusPatchAt >= heartbeatIntervalMs,
   );
-  for (const [jobId, active] of runningJobs) {
+  for (const [jobId, active] of jobs) {
+    if (active.child === null && active.pid && !processExists(active.pid)) {
+      activeJobs.delete(jobId);
+      await patchAttachJob(jobId, {
+        status: "failed",
+        error_message: "Runtime peer exited before the workstation agent could observe it",
+      });
+      continue;
+    }
     await patchAttachJob(jobId, {
-      status: "running",
+      status: active.status,
     });
-    active.lastRunningPatchAt = now;
+    active.lastStatusPatchAt = now;
   }
-  return runningJobs.length > 0;
+  return jobs.length > 0;
 }
 
 async function patchAttachJob(jobId, patch) {
@@ -461,6 +594,25 @@ function normalizeJobs(body) {
   if (Array.isArray(body?.jobs)) return body.jobs;
   if (Array.isArray(body?.attach_jobs)) return body.attach_jobs;
   return [];
+}
+
+function attachJobPidPath(plan) {
+  return path.join(plan.runRoot, "runtime-peer.pid");
+}
+
+async function readRuntimePeerPid(pidPath) {
+  const raw = await readFile(pidPath, "utf8").catch(() => "");
+  const pid = Number(raw.trim());
+  return Number.isInteger(pid) && pid > 0 ? pid : null;
+}
+
+function processExists(pid) {
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch {
+    return false;
+  }
 }
 
 function quoteShell(value) {

--- a/apps/notebook-cloud/src/index.ts
+++ b/apps/notebook-cloud/src/index.ts
@@ -37,7 +37,7 @@ import {
   getPublicPublishedNotebookRow,
   getWorkstationRow,
   grantNotebookAclRow,
-  listPendingWorkstationAttachJobs,
+  listActiveWorkstationAttachJobs,
   listNotebooksForPrincipal,
   listWorkstationsForPrincipal,
   recordBlob,
@@ -1141,7 +1141,7 @@ async function routeWorkstationAttachJobs(
   if (limit instanceof Response) {
     return limit;
   }
-  const jobs = await listPendingWorkstationAttachJobs(env, ownerPrincipal, workstationId, limit);
+  const jobs = await listActiveWorkstationAttachJobs(env, ownerPrincipal, workstationId, limit);
   return json({
     ok: true,
     workstation: workstationResponseRow(workstation, {

--- a/apps/notebook-cloud/src/storage.ts
+++ b/apps/notebook-cloud/src/storage.ts
@@ -95,6 +95,8 @@ export type WorkstationAttachJobStatus =
   | "completed"
   | "cancelled";
 
+export const WORKSTATION_ATTACH_JOB_STALE_MS = 2 * 60_000;
+
 export interface WorkstationRow {
   owner_principal: string;
   workstation_id: string;
@@ -897,12 +899,15 @@ export async function createWorkstationAttachJob(
   }
 
   await ensureCatalogSchema(env);
-  const existing = await getActiveWorkstationAttachJob(env, input);
+  const now = new Date();
+  const nowIso = now.toISOString();
+  const staleBefore = new Date(now.getTime() - WORKSTATION_ATTACH_JOB_STALE_MS).toISOString();
+  await expireStaleWorkstationAttachJobs(env, input, { now: nowIso, staleBefore });
+  const existing = await getActiveWorkstationAttachJob(env, input, staleBefore);
   if (existing) {
     return existing;
   }
 
-  const now = new Date().toISOString();
   const jobId = crypto.randomUUID();
   const insert = env.DB.prepare(
     `INSERT INTO workstation_attach_jobs (
@@ -921,13 +926,13 @@ export async function createWorkstationAttachJob(
     input.ownerPrincipal,
     input.workstationId,
     input.actorLabel,
-    now,
-    now,
+    nowIso,
+    nowIso,
   );
   try {
     await insert.run();
   } catch (error) {
-    const racedExisting = await getActiveWorkstationAttachJob(env, input);
+    const racedExisting = await getActiveWorkstationAttachJob(env, input, staleBefore);
     if (racedExisting) {
       return racedExisting;
     }
@@ -936,7 +941,7 @@ export async function createWorkstationAttachJob(
   return getWorkstationAttachJob(env, input.ownerPrincipal, input.workstationId, jobId);
 }
 
-export async function listPendingWorkstationAttachJobs(
+export async function listActiveWorkstationAttachJobs(
   env: Env,
   ownerPrincipal: string,
   workstationId: string,
@@ -947,6 +952,7 @@ export async function listPendingWorkstationAttachJobs(
   }
 
   await ensureCatalogSchema(env);
+  const staleBefore = new Date(Date.now() - WORKSTATION_ATTACH_JOB_STALE_MS).toISOString();
   const rows = await env.DB.prepare(
     `SELECT id,
             notebook_id,
@@ -962,11 +968,14 @@ export async function listPendingWorkstationAttachJobs(
        FROM workstation_attach_jobs
       WHERE owner_principal = ?
         AND workstation_id = ?
-        AND status = 'pending'
+        AND (
+          status = 'pending'
+          OR (status IN ('accepted', 'running') AND updated_at >= ?)
+        )
       ORDER BY requested_at ASC
       LIMIT ?`,
   )
-    .bind(ownerPrincipal, workstationId, limit)
+    .bind(ownerPrincipal, workstationId, staleBefore, limit)
     .all<WorkstationAttachJobRow>();
   return rows.results ?? [];
 }
@@ -1027,6 +1036,7 @@ async function getActiveWorkstationAttachJob(
     ownerPrincipal: string;
     workstationId: string;
   },
+  staleBefore: string,
 ): Promise<WorkstationAttachJobRow | null> {
   const row = await env
     .DB!.prepare(
@@ -1045,13 +1055,48 @@ async function getActiveWorkstationAttachJob(
       WHERE notebook_id = ?
         AND owner_principal = ?
         AND workstation_id = ?
-        AND status IN ('pending', 'accepted', 'running')
+        AND (
+          status = 'pending'
+          OR (status IN ('accepted', 'running') AND updated_at >= ?)
+        )
       ORDER BY requested_at DESC
       LIMIT 1`,
     )
-    .bind(input.notebookId, input.ownerPrincipal, input.workstationId)
+    .bind(input.notebookId, input.ownerPrincipal, input.workstationId, staleBefore)
     .first<WorkstationAttachJobRow>();
   return row;
+}
+
+async function expireStaleWorkstationAttachJobs(
+  env: Env,
+  input: {
+    notebookId: string;
+    ownerPrincipal: string;
+    workstationId: string;
+  },
+  {
+    now,
+    staleBefore,
+  }: {
+    now: string;
+    staleBefore: string;
+  },
+): Promise<void> {
+  await env
+    .DB!.prepare(
+      `UPDATE workstation_attach_jobs
+          SET status = 'failed',
+              updated_at = ?,
+              finished_at = ?,
+              error_message = 'stale workstation attach job expired after heartbeat timeout'
+        WHERE notebook_id = ?
+          AND owner_principal = ?
+          AND workstation_id = ?
+          AND status IN ('accepted', 'running')
+          AND updated_at < ?`,
+    )
+    .bind(now, now, input.notebookId, input.ownerPrincipal, input.workstationId, staleBefore)
+    .run();
 }
 
 async function getWorkstationAttachJob(

--- a/apps/notebook-cloud/test/worker-routes.test.ts
+++ b/apps/notebook-cloud/test/worker-routes.test.ts
@@ -26,6 +26,7 @@ import type {
 } from "../src/cloudflare-types.ts";
 import { initializeRuntimedWasm, RuntimeStatePeerHandle } from "../src/runtimed-wasm.ts";
 import {
+  WORKSTATION_ATTACH_JOB_STALE_MS,
   blobKey,
   commsDocSnapshotKey,
   createNotebookWithOwnerAcl,
@@ -1800,6 +1801,86 @@ describe("Worker artifact routes", () => {
     const secondBody = (await second.json()) as { job: { job_id: string } };
     assert.equal(secondBody.job.job_id, firstBody.job.job_id);
     assert.equal(env.DB.workstationAttachJobs.size, 1);
+  });
+
+  it("expires stale running attach jobs before creating a replacement", async () => {
+    const env = fakeEnv();
+    seedNotebook(env, "attach-demo");
+    seedAcl(env, { notebookId: "attach-demo", subject: "user:dev:alice", scope: "owner" });
+    seedWorkstation(env, { ownerPrincipal: "user:dev:alice", workstationId: "ws-lab2" });
+    seedWorkstationAttachJob(env, {
+      id: "stale-running",
+      notebookId: "attach-demo",
+      ownerPrincipal: "user:dev:alice",
+      workstationId: "ws-lab2",
+      status: "running",
+      updatedAt: new Date(Date.now() - WORKSTATION_ATTACH_JOB_STALE_MS - 5_000).toISOString(),
+    });
+
+    const attach = await worker.fetch(
+      new Request("http://localhost/api/n/attach-demo/workstation-attachments", {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          "X-Operator": "browser:tab",
+          "X-Scope": "owner",
+          "X-User": "alice",
+        },
+        body: JSON.stringify({ workstation_id: "ws-lab2" }),
+      }),
+      env,
+      fakeContext(),
+    );
+
+    assert.equal(attach.status, 202);
+    const body = (await attach.json()) as { job: { job_id: string; status: string } };
+    assert.notEqual(body.job.job_id, "stale-running");
+    assert.equal(body.job.status, "pending");
+    assert.equal(env.DB.workstationAttachJobs.get("stale-running")?.status, "failed");
+    assert.match(
+      env.DB.workstationAttachJobs.get("stale-running")?.error_message ?? "",
+      /stale workstation attach job expired/,
+    );
+  });
+
+  it("lists fresh running attach jobs so workstation agents can recover after restart", async () => {
+    const env = fakeEnv();
+    seedWorkstation(env, { ownerPrincipal: "user:dev:alice", workstationId: "ws-lab2" });
+    seedWorkstationAttachJob(env, {
+      id: "running-job",
+      notebookId: "nb-running",
+      ownerPrincipal: "user:dev:alice",
+      workstationId: "ws-lab2",
+      status: "running",
+      updatedAt: new Date().toISOString(),
+    });
+    seedWorkstationAttachJob(env, {
+      id: "stale-running-job",
+      notebookId: "nb-stale",
+      ownerPrincipal: "user:dev:alice",
+      workstationId: "ws-lab2",
+      status: "running",
+      updatedAt: new Date(Date.now() - WORKSTATION_ATTACH_JOB_STALE_MS - 5_000).toISOString(),
+    });
+
+    const response = await worker.fetch(
+      new Request("http://localhost/api/workstations/ws-lab2/attach-jobs", {
+        headers: {
+          "X-Operator": "workstation:lab2",
+          "X-Scope": "owner",
+          "X-User": "alice",
+        },
+      }),
+      env,
+      fakeContext(),
+    );
+
+    assert.equal(response.status, 200);
+    const body = (await response.json()) as { jobs: Array<{ job_id: string; status: string }> };
+    assert.deepEqual(
+      body.jobs.map((job) => [job.job_id, job.status]),
+      [["running-job", "running"]],
+    );
   });
 
   it("only lists attach jobs for the authenticated workstation owner", async () => {
@@ -4448,6 +4529,7 @@ function seedWorkstationAttachJob(
     ownerPrincipal: string;
     workstationId: string;
     status?: WorkstationAttachJobRow["status"];
+    updatedAt?: string;
   },
 ): void {
   env.DB.workstationAttachJobs.set(input.id, {
@@ -4458,11 +4540,18 @@ function seedWorkstationAttachJob(
     status: input.status ?? "pending",
     requested_by_actor_label: "user:dev:alice/browser:tab",
     requested_at: "2026-05-22T00:00:00.000Z",
-    updated_at: "2026-05-22T00:00:00.000Z",
+    updated_at: input.updatedAt ?? "2026-05-22T00:00:00.000Z",
     accepted_at: null,
     finished_at: null,
     error_message: null,
   });
+}
+
+function isActiveWorkstationAttachJob(job: WorkstationAttachJobRow, staleBefore: string): boolean {
+  return (
+    job.status === "pending" ||
+    ((job.status === "accepted" || job.status === "running") && job.updated_at >= staleBefore)
+  );
 }
 
 function seedPendingInvite(
@@ -5226,6 +5315,29 @@ class FakeD1Statement implements D1PreparedStatement {
         error_message: null,
       });
       return okResult(undefined, { changes: 1 });
+    } else if (
+      this.query.includes("UPDATE workstation_attach_jobs") &&
+      this.query.includes("stale workstation attach job expired")
+    ) {
+      const [updatedAt, finishedAt, notebookId, ownerPrincipal, workstationId, staleBefore] = this
+        .values as [string, string, string, string, string, string];
+      let changes = 0;
+      for (const job of this.db.workstationAttachJobs.values()) {
+        if (
+          job.notebook_id === notebookId &&
+          job.owner_principal === ownerPrincipal &&
+          job.workstation_id === workstationId &&
+          (job.status === "accepted" || job.status === "running") &&
+          job.updated_at < staleBefore
+        ) {
+          job.status = "failed";
+          job.updated_at = updatedAt;
+          job.finished_at = finishedAt;
+          job.error_message = "stale workstation attach job expired after heartbeat timeout";
+          changes += 1;
+        }
+      }
+      return okResult(undefined, { changes });
     } else if (this.query.includes("UPDATE workstation_attach_jobs")) {
       const [
         status,
@@ -5540,7 +5652,12 @@ class FakeD1Statement implements D1PreparedStatement {
     }
     if (this.query.includes("FROM workstation_attach_jobs")) {
       if (this.query.includes("notebook_id = ?")) {
-        const [notebookId, ownerPrincipal, workstationId] = this.values as [string, string, string];
+        const [notebookId, ownerPrincipal, workstationId, staleBefore] = this.values as [
+          string,
+          string,
+          string,
+          string,
+        ];
         return (
           ([...this.db.workstationAttachJobs.values()]
             .filter(
@@ -5548,7 +5665,7 @@ class FakeD1Statement implements D1PreparedStatement {
                 job.notebook_id === notebookId &&
                 job.owner_principal === ownerPrincipal &&
                 job.workstation_id === workstationId &&
-                (job.status === "pending" || job.status === "accepted" || job.status === "running"),
+                isActiveWorkstationAttachJob(job, staleBefore),
             )
             .sort((left, right) => right.requested_at.localeCompare(left.requested_at))[0] as
             | T
@@ -5671,7 +5788,12 @@ class FakeD1Statement implements D1PreparedStatement {
       );
     }
     if (this.query.includes("FROM workstation_attach_jobs")) {
-      const [ownerPrincipal, workstationId, limitValue] = this.values as [string, string, number];
+      const [ownerPrincipal, workstationId, staleBefore, limitValue] = this.values as [
+        string,
+        string,
+        string,
+        number,
+      ];
       const limit = Number.isFinite(limitValue) ? limitValue : Number.POSITIVE_INFINITY;
       return okResult(
         [...this.db.workstationAttachJobs.values()]
@@ -5679,7 +5801,7 @@ class FakeD1Statement implements D1PreparedStatement {
             (job) =>
               job.owner_principal === ownerPrincipal &&
               job.workstation_id === workstationId &&
-              job.status === "pending",
+              isActiveWorkstationAttachJob(job, staleBefore),
           )
           .sort((left, right) => left.requested_at.localeCompare(right.requested_at))
           .slice(0, limit) as T[],

--- a/packages/runtimed/src/notebook-workstation-selection.ts
+++ b/packages/runtimed/src/notebook-workstation-selection.ts
@@ -139,12 +139,16 @@ export function projectNotebookWorkstationSelection({
 }: ProjectNotebookWorkstationSelectionOptions): NotebookWorkstationSelectionProjection {
   const selectedId = trimToNull(selectedWorkstationId);
   const defaultId = trimToNull(defaultWorkstationId);
-  const activeTarget = projectNotebookRuntimeTargetFromWorkstationAttachment(activeAttachment);
   const activeWorkstationId = trimToNull(activeAttachment?.workstation_id);
+  const normalizedEntries = normalizeRegisteredWorkstations(registeredWorkstations);
+  const activeTarget = projectAttachmentTargetWithRegisteredWorkstationStatus({
+    activeAttachment,
+    activeWorkstationId,
+    registeredWorkstations: normalizedEntries,
+  });
   const attachedWorkstationId = activeTargetCountsAsAttached(activeTarget)
     ? activeWorkstationId
     : null;
-  const normalizedEntries = normalizeRegisteredWorkstations(registeredWorkstations);
   const cacheKey = stableCacheKey([
     activeWorkstationId,
     activeTargetCacheKey(activeTarget),
@@ -168,7 +172,7 @@ export function projectNotebookWorkstationSelection({
   const selectedWorkstation = entries.find((entry) => entry.id === selectedId) ?? null;
   const defaultWorkstation = entries.find((entry) => entry.id === defaultId) ?? null;
   const launchCandidate = selectedWorkstation ?? defaultWorkstation;
-  const state: NotebookWorkstationSelectionState = activeTarget
+  const state: NotebookWorkstationSelectionState = attachedWorkstationId
     ? "attached"
     : selectedWorkstation
       ? "selected"
@@ -214,6 +218,34 @@ function activeTargetCountsAsAttached(
   return (
     target.status === "ready" || target.status === "attached" || target.status === "connecting"
   );
+}
+
+function projectAttachmentTargetWithRegisteredWorkstationStatus({
+  activeAttachment,
+  activeWorkstationId,
+  registeredWorkstations,
+}: {
+  activeAttachment: WorkstationAttachmentState | null;
+  activeWorkstationId: string | null;
+  registeredWorkstations: readonly NotebookRegisteredWorkstation[];
+}): NotebookShellRuntimeTargetProjection | null {
+  const target = projectNotebookRuntimeTargetFromWorkstationAttachment(activeAttachment);
+  if (!target || !activeWorkstationId) return target;
+  const registeredWorkstation =
+    registeredWorkstations.find((workstation) => workstation.id === activeWorkstationId) ?? null;
+  const registeredStatus = normalizeWorkstationStatus(registeredWorkstation?.status);
+  if (registeredStatus !== "offline" && registeredStatus !== "attention") {
+    return target;
+  }
+
+  return Object.freeze({
+    ...target,
+    status: registeredStatus,
+    statusLabel: workstationStatusLabel(registeredStatus),
+    detail:
+      trimToNull(registeredWorkstation?.statusMessage) ??
+      `The ${target.label} attachment is stale because the workstation is ${registeredStatus}.`,
+  });
 }
 
 function projectRegisteredWorkstation(

--- a/packages/runtimed/tests/notebook-workstation-launch.test.ts
+++ b/packages/runtimed/tests/notebook-workstation-launch.test.ts
@@ -248,6 +248,45 @@ describe("notebook workstation launch readiness projection", () => {
     });
   });
 
+  it("keeps stale ready attachments unavailable when the registered workstation is offline", () => {
+    const selection = projectNotebookWorkstationSelection({
+      activeAttachment: {
+        workstation_id: "ws-lab2",
+        display_name: "Lab2 workstation",
+        provider: "runtime_peer",
+        default_environment_label: "Current Python",
+        environment_policy: "current_python",
+        status: "ready",
+      },
+      canSelectWorkstation: true,
+      defaultWorkstationId: "ws-lab2",
+      registeredWorkstations: [
+        {
+          ...lab2Workstation,
+          status: "offline",
+          statusMessage: "No heartbeat from this workstation recently.",
+        },
+      ],
+    });
+    const projection = projectNotebookWorkstationLaunchReadiness({
+      capabilities: cloudUnavailableCapabilities,
+      selection,
+    });
+
+    expect(projection).toMatchObject({
+      canRun: false,
+      detail: "No heartbeat from this workstation recently.",
+      primaryAction: {
+        kind: "open_workstations",
+        label: "Review compute",
+      },
+      state: "workstation_unavailable",
+      statusLabel: "Offline",
+      targetLabel: "Lab2 workstation",
+      workstationId: "ws-lab2",
+    });
+  });
+
   it("projects registered workstations without a selected/default target as selection needed", () => {
     const selection = projectNotebookWorkstationSelection({
       canSelectWorkstation: true,

--- a/packages/runtimed/tests/notebook-workstation-selection.test.ts
+++ b/packages/runtimed/tests/notebook-workstation-selection.test.ts
@@ -102,6 +102,39 @@ describe("notebook workstation selection projection", () => {
     expect(attached.selectedWorkstation?.id).toBe("ws-lab2");
   });
 
+  it("does not let a stale attachment hide an offline registered workstation", () => {
+    const projection = projectNotebookWorkstationSelection({
+      activeAttachment: {
+        workstation_id: "ws-lab2",
+        display_name: "Lab2 workstation",
+        provider: "runtime_peer",
+        default_environment_label: "Current Python",
+        environment_policy: "current_python",
+        status: "ready",
+      },
+      canSelectWorkstation: true,
+      defaultWorkstationId: "ws-lab2",
+      registeredWorkstations: [
+        {
+          ...lab2Workstation,
+          status: "offline",
+          statusMessage: "No heartbeat from this workstation recently.",
+        },
+      ],
+    });
+
+    expect(projection.state).toBe("default");
+    expect(projection.activeWorkstationId).toBe("ws-lab2");
+    expect(projection.activeTarget).toMatchObject({
+      id: "ws-lab2",
+      label: "Lab2 workstation",
+      status: "offline",
+      detail: "No heartbeat from this workstation recently.",
+    });
+    expect(projection.defaultWorkstation?.isAttached).toBe(false);
+    expect(projection.launchCandidate?.id).toBe("ws-lab2");
+  });
+
   it("directs owners with no registered workstations toward workstation setup", () => {
     const projection = projectNotebookWorkstationSelection({
       canRegisterWorkstation: true,


### PR DESCRIPTION
## Summary
- expire stale accepted/running workstation attach jobs before creating a replacement
- let workstation agents poll fresh running jobs so restarts can recover active attachments
- make shared workstation selection projection treat stale ready attachments as offline/attention when the registry says the workstation is unavailable

## Validation
- pnpm exec vp test run packages/runtimed/tests/notebook-workstation-selection.test.ts packages/runtimed/tests/notebook-workstation-launch.test.ts
- pnpm --dir apps/notebook-cloud exec node --import tsx --test test/worker-routes.test.ts
- pnpm --dir apps/notebook-cloud typecheck
- pnpm --dir apps/notebook-cloud exec node --test test/hosted-workstation-agent.test.mjs
- pnpm --dir apps/notebook-cloud exec node --import tsx --test test/workstations-client.test.ts
- cargo xtask lint --fix