### PR TITLE
fix(notebook): avoid scrolling on sift menu clicks

### DIFF
--- a/packages/sift/src/sparkline.test.ts
+++ b/packages/sift/src/sparkline.test.ts
@@ -148,3 +148,52 @@ describe("histogram brushing", () => {
     }
   });
 });
+
+describe("category filter popover", () => {
+  it("focuses the search field without asking the browser to scroll", async () => {
+    const focusSpy = vi.spyOn(HTMLInputElement.prototype, "focus");
+    const container = document.createElement("div");
+    document.body.appendChild(container);
+
+    try {
+      await act(async () => {
+        renderColumnSummary(
+          container,
+          {
+            kind: "categorical",
+            uniqueCount: 3,
+            topCategories: [
+              { label: "core", count: 4, pct: 40 },
+              { label: "sift", count: 3, pct: 30 },
+              { label: "cloud", count: 3, pct: 30 },
+            ],
+            othersCount: 0,
+            othersPct: 0,
+            allCategories: [
+              { label: "core", count: 4, pct: 40 },
+              { label: "sift", count: 3, pct: 30 },
+              { label: "cloud", count: 3, pct: 30 },
+            ],
+            medianTextLength: 5,
+          },
+          180,
+        );
+      });
+
+      const trigger = container.querySelector<HTMLElement>(".sift-cat-summary-trigger");
+      expect(trigger).toBeTruthy();
+
+      await act(async () => {
+        trigger!.click();
+      });
+
+      expect(document.querySelector(".sift-cat-popover-search")).toBeTruthy();
+      expect(focusSpy).toHaveBeenCalledWith({ preventScroll: true });
+    } finally {
+      focusSpy.mockRestore();
+      unmountColumnSummary(container);
+      container.remove();
+      document.querySelector(".sift-cat-popover")?.remove();
+    }
+  });
+});

--- a/packages/sift/src/sparkline.tsx
+++ b/packages/sift/src/sparkline.tsx
@@ -746,7 +746,7 @@ function CategoryPopoverContent({
   }, [searchInput]);
 
   useEffect(() => {
-    inputRef.current?.focus();
+    inputRef.current?.focus({ preventScroll: true });
   }, []);
 
   const filtered = useMemo(() => {
@@ -836,7 +836,7 @@ function CategoryPopoverContent({
     focusSearch();
   }
   function focusSearch() {
-    requestAnimationFrame(() => inputRef.current?.focus());
+    requestAnimationFrame(() => inputRef.current?.focus({ preventScroll: true }));
   }
 
   return (

--- a/src/components/cell/OutputArea.tsx
+++ b/src/components/cell/OutputArea.tsx
@@ -762,23 +762,30 @@ function OutputAreaSingle({
     return () => document.removeEventListener("pointerdown", handlePointerDown, true);
   }, [releaseStaticFrameInteraction, staticFrameInteractionActive]);
 
-  const activateStaticFrameInteraction = useCallback(() => {
-    if (shouldUseScrollPassthroughFrame) {
-      if (!staticFrameInteractionActive && hasSiftOutputs) {
-        scrollElementIntoComfortableView(staticFrameInteractionRef.current);
+  const activateStaticFrameInteraction = useCallback(
+    ({ alignIntoView = false }: { alignIntoView?: boolean } = {}) => {
+      if (shouldUseScrollPassthroughFrame) {
+        if (alignIntoView && !staticFrameInteractionActive && hasSiftOutputs) {
+          scrollElementIntoComfortableView(staticFrameInteractionRef.current);
+        }
+        setStaticFrameInteractionActive(true);
+        // Move DOM focus off CodeMirror without scrolling; this wrapper owns
+        // focus until iframe pointer interaction is active.
+        staticFrameInteractionRef.current?.focus({ preventScroll: true });
       }
-      setStaticFrameInteractionActive(true);
-      // Move DOM focus off CodeMirror without scrolling; this wrapper owns
-      // focus until iframe pointer interaction is active.
-      staticFrameInteractionRef.current?.focus({ preventScroll: true });
-    }
-    onIframeMouseDown?.();
-  }, [
-    hasSiftOutputs,
-    shouldUseScrollPassthroughFrame,
-    staticFrameInteractionActive,
-    onIframeMouseDown,
-  ]);
+      onIframeMouseDown?.();
+    },
+    [
+      hasSiftOutputs,
+      shouldUseScrollPassthroughFrame,
+      staticFrameInteractionActive,
+      onIframeMouseDown,
+    ],
+  );
+
+  const activateStaticFrameInteractionWithAlignment = useCallback(() => {
+    activateStaticFrameInteraction({ alignIntoView: true });
+  }, [activateStaticFrameInteraction]);
 
   const activateStaticFrameInteractionTemporarily = useCallback(() => {
     activateStaticFrameInteraction();
@@ -1112,11 +1119,11 @@ function OutputAreaSingle({
                   className="pointer-events-auto"
                   onPointerDown={(event) => {
                     event.stopPropagation();
-                    activateStaticFrameInteraction();
+                    activateStaticFrameInteractionWithAlignment();
                   }}
                   onClick={(event) => {
                     event.stopPropagation();
-                    activateStaticFrameInteraction();
+                    activateStaticFrameInteractionWithAlignment();
                   }}
                 />
               </div>

--- a/src/components/cell/__tests__/OutputArea.test.tsx
+++ b/src/components/cell/__tests__/OutputArea.test.tsx
@@ -7,6 +7,7 @@ import { OutputArea, type JupyterOutput } from "../OutputArea";
 let mockDarkMode = false;
 let mockColorTheme: string | undefined;
 let lastFrameMessageHandler: ((message: unknown) => void) | undefined;
+let lastFrameMouseDown: (() => void) | undefined;
 let lastFrameMouseUp: ((params: { hasSelection?: boolean }) => void) | undefined;
 let isolatedFrameMountCount = 0;
 let restoreMarkdownProjector: (() => void) | undefined;
@@ -49,6 +50,7 @@ vi.mock("@/components/isolated", async (importOriginal) => {
       forwardWheelBoundaryScroll?: boolean;
       hostContext?: unknown;
       onMessage?: (message: unknown) => void;
+      onMouseDown?: () => void;
       onMouseUp?: (params: { hasSelection?: boolean }) => void;
       scrollPassthrough?: boolean;
       onReady?: () => void;
@@ -60,6 +62,7 @@ vi.mock("@/components/isolated", async (importOriginal) => {
       forwardWheelBoundaryScroll,
       hostContext,
       onMessage,
+      onMouseDown,
       onMouseUp,
       scrollPassthrough,
       onReady,
@@ -84,6 +87,15 @@ vi.mock("@/components/isolated", async (importOriginal) => {
         }
       };
     }, [onMessage]);
+
+    React.useEffect(() => {
+      lastFrameMouseDown = onMouseDown;
+      return () => {
+        if (lastFrameMouseDown === onMouseDown) {
+          lastFrameMouseDown = undefined;
+        }
+      };
+    }, [onMouseDown]);
 
     React.useEffect(() => {
       lastFrameMouseUp = onMouseUp;
@@ -292,6 +304,7 @@ describe("OutputArea iframe theme sync", () => {
     mockFrameHandle.searchNavigate.mockClear();
     mockFrameHandle.measureElement.mockClear();
     lastFrameMessageHandler = undefined;
+    lastFrameMouseDown = undefined;
     lastFrameMouseUp = undefined;
     isolatedFrameMountCount = 0;
     vi.mocked(injectPluginsForMimes).mockResolvedValue(undefined);
@@ -641,7 +654,7 @@ describe("OutputArea iframe theme sync", () => {
     expect(frame.getAttribute("data-forward-wheel-boundary-scroll")).toBe("false");
   });
 
-  it("aligns sift before engaging iframe scrolling and releases on Escape", () => {
+  it("engages sift iframe clicks without scrolling the notebook", () => {
     const scrollBy = vi.fn();
     Object.defineProperty(window, "scrollBy", {
       configurable: true,
@@ -669,7 +682,7 @@ describe("OutputArea iframe theme sync", () => {
 
     fireEvent.pointerDown(activationWell);
 
-    expect(scrollBy).toHaveBeenCalledWith({ top: 604, behavior: "auto" });
+    expect(scrollBy).not.toHaveBeenCalled();
     expect(activationWell.getAttribute("data-frame-interaction-active")).toBe("true");
     expect(frame.getAttribute("data-scroll-passthrough")).toBe("false");
     expect(frame.getAttribute("data-allow-wheel-boundary-scroll")).toBe("false");
@@ -685,13 +698,73 @@ describe("OutputArea iframe theme sync", () => {
     ).toBeInTheDocument();
   });
 
-  it("activates sift iframe scrolling from the magnetize cue", () => {
+  it("engages sift iframe mouse down without scrolling the notebook", () => {
+    const scrollBy = vi.fn();
+    Object.defineProperty(window, "scrollBy", {
+      configurable: true,
+      value: scrollBy,
+    });
+    Object.defineProperty(window, "innerHeight", {
+      configurable: true,
+      value: 800,
+    });
+
     const { getByTestId } = render(<OutputArea outputs={makeParquetOutput()} isolated />);
     const frame = getByTestId("isolated-frame");
     const activationWell = frame.parentElement as HTMLElement;
+    vi.spyOn(activationWell, "getBoundingClientRect").mockReturnValue({
+      top: 700,
+      bottom: 1420,
+      left: 0,
+      right: 1200,
+      width: 1200,
+      height: 720,
+      x: 0,
+      y: 700,
+      toJSON: () => ({}),
+    } as DOMRect);
+
+    act(() => {
+      lastFrameMouseDown?.();
+    });
+
+    expect(scrollBy).not.toHaveBeenCalled();
+    expect(activationWell.getAttribute("data-frame-interaction-active")).toBe("true");
+    expect(frame.getAttribute("data-scroll-passthrough")).toBe("false");
+    expect(frame.getAttribute("data-allow-wheel-boundary-scroll")).toBe("false");
+    expect(frame.getAttribute("data-forward-wheel-boundary-scroll")).toBe("false");
+    expect(screen.queryByRole("button", { name: "Click inside the table to scroll" })).toBeNull();
+  });
+
+  it("aligns sift iframe scrolling from the magnetize cue", () => {
+    const scrollBy = vi.fn();
+    Object.defineProperty(window, "scrollBy", {
+      configurable: true,
+      value: scrollBy,
+    });
+    Object.defineProperty(window, "innerHeight", {
+      configurable: true,
+      value: 800,
+    });
+
+    const { getByTestId } = render(<OutputArea outputs={makeParquetOutput()} isolated />);
+    const frame = getByTestId("isolated-frame");
+    const activationWell = frame.parentElement as HTMLElement;
+    vi.spyOn(activationWell, "getBoundingClientRect").mockReturnValue({
+      top: 700,
+      bottom: 1420,
+      left: 0,
+      right: 1200,
+      width: 1200,
+      height: 720,
+      x: 0,
+      y: 700,
+      toJSON: () => ({}),
+    } as DOMRect);
 
     fireEvent.pointerDown(screen.getByRole("button", { name: "Click inside the table to scroll" }));
 
+    expect(scrollBy).toHaveBeenCalledWith({ top: 604, behavior: "auto" });
     expect(activationWell.getAttribute("data-frame-interaction-active")).toBe("true");
     expect(frame.getAttribute("data-scroll-passthrough")).toBe("false");
     expect(frame.getAttribute("data-allow-wheel-boundary-scroll")).toBe("false");


### PR DESCRIPTION
## Summary

- Stop direct Sift iframe engagement from scroll-aligning the notebook viewport.
- Keep comfortable scroll alignment only for the explicit handoff cue.
- Focus the Sift category popover search field with `preventScroll` so opening a categorical menu does not pull the notebook viewport upward.
- Cover direct wrapper clicks, iframe-originated mouse-downs, and cue-based alignment in `OutputArea` tests.
- Add a Sift regression test for category popover focus options.

## Bug

Opening a Sift categorical menu from an output could move the notebook upward first. There were two contributing paths:

- The first inactive-frame click was routed through the same activation path used by the "Click inside the table to scroll" handoff cue, so ordinary Sift interactions requested `scrollElementIntoComfortableView`.
- Once the popover opened, Sift focused the popover search input with plain `focus()`. Browsers may scroll parent pages to reveal focused inputs inside iframes, so the notebook could jump upward while opening the menu.

## Verification

- `pnpm test:run src/components/cell/__tests__/OutputArea.test.tsx`
- `pnpm --filter @nteract/sift test -- src/sparkline.test.ts`
- `cargo xtask lint --fix`

Note: `cargo xtask lint --fix` completed successfully and reported an unrelated existing warning in `packages/runtimed/tests/notebook-doc-persistence.test.ts` about an unnecessary spread before iteration.
