### PR TITLE
feat(notebook-cloud): transport-owned reconnect loop with session continuity

### DIFF
--- a/apps/notebook-cloud/test/live-sync.test.ts
+++ b/apps/notebook-cloud/test/live-sync.test.ts
@@ -1,19 +1,24 @@
 import { describe, it } from "node:test";
 import assert from "node:assert/strict";
-import type { PersistedNotebookDoc } from "runtimed";
+import { SyncEngine, type PersistedNotebookDoc, type SyncableHandle } from "runtimed";
 import {
   CloudWebSocketTransport,
+  classifyRecoverableRejection,
   cloudPrincipalFromActorLabel,
   cloudRoomReadyPeerLabel,
+  createCloudConnectTarget,
   isAnonymousCloudPrincipal,
   isRecoverableCloudFrameRejection,
+  mintCloudSessionId,
   normalizeConnectionScope,
+  reestablishCloudConnection,
   resolveCloudNotebookHandle,
   shouldDiscardPersistedSeedOnRejection,
   startCloudBootstrapSync,
   syncUrl,
   syncableCloudHandle,
   withReadyTimeout,
+  type CloudWebSocketTransportOptions,
 } from "../viewer/live-sync.ts";
 import { FrameType } from "../src/protocol.ts";
 
@@ -252,54 +257,61 @@ describe("cloud live sync", () => {
     assert.equal(isAnonymousCloudPrincipal("user:anaconda:uuid-123"), false);
   });
 
-  it("notifies disconnect when a send sees a closing socket before the close event", async () => {
+  it("rejects sends while the socket is not open without tearing the connection down", async () => {
     const fake = installFakeWebSocket();
-    const disconnects: string[] = [];
+    const lost: string[] = [];
     try {
-      const transport = new CloudWebSocketTransport(
-        new URL("wss://example.test/n/room/sync"),
-        [],
-        undefined,
-        (reason) => disconnects.push(reason.message),
-      );
-      const socket = fake.socket;
+      const transport = createTransport({
+        onConnectionLost: (reason) => lost.push(reason.message),
+      });
+      const socket = await waitForSocket(0);
       socket.open();
       socket.ready("peer-1");
       await transport.ready;
 
       socket.readyState = FakeWebSocket.CLOSING;
+      // Drop, don't buffer: the sync layer rolls back and regenerates after
+      // the next handshake.
       await assert.rejects(
         transport.sendFrame(FrameType.PRESENCE, new Uint8Array([1, 2, 3])),
-        /cloud sync socket is closed/,
+        /cloud sync socket is not open/,
       );
-      socket.close({ code: 1006 });
+      assert.deepEqual(lost, []);
 
-      assert.deepEqual(disconnects, ["cloud sync socket is closed"]);
+      socket.close({ code: 1006 });
+      assert.equal(lost.length, 1);
+      assert.match(lost[0], /cloud sync socket closed \(1006\)/);
+      transport.disconnect();
     } finally {
       fake.restore();
     }
   });
 
-  it("emits offline when the socket closes before room readiness", async () => {
+  it("keeps connecting and retries when the socket closes before room readiness", async () => {
     const fake = installFakeWebSocket();
     const statuses: string[] = [];
-    const disconnects: string[] = [];
+    const lost: string[] = [];
     try {
-      const transport = new CloudWebSocketTransport(
-        new URL("wss://example.test/n/room/sync"),
-        [],
-        undefined,
-        (reason) => disconnects.push(reason.message),
-      );
+      const transport = createTransport({
+        onConnectionLost: (reason) => lost.push(reason.message),
+        reconnectBaseDelayMs: 1,
+        random: () => 0.5,
+      });
       const subscription = transport.connectionStatus$.subscribe((status) => statuses.push(status));
-      const ready = assert.rejects(transport.ready, /cloud sync socket closed before ready/);
 
-      fake.socket.close({ code: 1006 });
-      await ready;
+      const first = await waitForSocket(0);
+      first.close({ code: 1006 });
+      await delayMs(10); // let the (tiny) retry delay elapse
+
+      // Initial-connect failure rides the retry loop: status stays
+      // "connecting" (never been online) and a fresh socket appears.
+      const second = await waitForSocket(1);
+      assert.notEqual(second, first);
+      assert.equal(lost.length, 1);
+      assert.deepEqual(statuses, ["connecting"]);
+
       subscription.unsubscribe();
-
-      assert.deepEqual(statuses, ["connecting", "offline"]);
-      assert.deepEqual(disconnects, []);
+      transport.disconnect();
     } finally {
       fake.restore();
     }
@@ -309,9 +321,9 @@ describe("cloud live sync", () => {
     const fake = installFakeWebSocket();
     const statuses: string[] = [];
     try {
-      const transport = new CloudWebSocketTransport(new URL("wss://example.test/n/room/sync"), []);
+      const transport = createTransport();
       const subscription = transport.connectionStatus$.subscribe((status) => statuses.push(status));
-      const socket = fake.socket;
+      const socket = await waitForSocket(0);
       socket.open();
       socket.ready("peer-1");
       await transport.ready;
@@ -329,8 +341,8 @@ describe("cloud live sync", () => {
   it("sends notebook requests as cloud request frames and resolves on room-host ack", async () => {
     const fake = installFakeWebSocket();
     try {
-      const transport = new CloudWebSocketTransport(new URL("wss://example.test/n/room/sync"), []);
-      const socket = fake.socket;
+      const transport = createTransport();
+      const socket = await waitForSocket(0);
       socket.open();
       socket.ready("peer-1");
       await transport.ready;
@@ -374,8 +386,8 @@ describe("cloud live sync", () => {
   it("rejects notebook requests when the cloud room rejects the request frame", async () => {
     const fake = installFakeWebSocket();
     try {
-      const transport = new CloudWebSocketTransport(new URL("wss://example.test/n/room/sync"), []);
-      const socket = fake.socket;
+      const transport = createTransport();
+      const socket = await waitForSocket(0);
       socket.open();
       socket.ready("peer-1");
       await transport.ready;
@@ -400,8 +412,8 @@ describe("cloud live sync", () => {
   it("resolves accepted notebook requests without waiting for a response frame", async () => {
     const fake = installFakeWebSocket();
     try {
-      const transport = new CloudWebSocketTransport(new URL("wss://example.test/n/room/sync"), []);
-      const socket = fake.socket;
+      const transport = createTransport();
+      const socket = await waitForSocket(0);
       socket.open();
       socket.ready("peer-1");
       await transport.ready;
@@ -429,17 +441,16 @@ describe("cloud live sync", () => {
     }
   });
 
-  it("notifies disconnect when WebSocket.send throws", async () => {
+  it("recycles the connection when WebSocket.send throws", async () => {
     const fake = installFakeWebSocket();
-    const disconnects: string[] = [];
+    const lost: string[] = [];
     try {
-      const transport = new CloudWebSocketTransport(
-        new URL("wss://example.test/n/room/sync"),
-        [],
-        undefined,
-        (reason) => disconnects.push(reason.message),
-      );
-      const socket = fake.socket;
+      const transport = createTransport({
+        onConnectionLost: (reason) => lost.push(reason.message),
+        reconnectBaseDelayMs: 1,
+        random: () => 0.5,
+      });
+      const socket = await waitForSocket(0);
       socket.open();
       socket.ready("peer-1");
       await transport.ready;
@@ -449,41 +460,58 @@ describe("cloud live sync", () => {
         transport.sendFrame(FrameType.PRESENCE, new Uint8Array([1, 2, 3])),
         /cloud sync socket send failed: synthetic send failure/,
       );
-      assert.deepEqual(disconnects, ["cloud sync socket send failed: synthetic send failure"]);
+      assert.deepEqual(lost, ["cloud sync socket send failed: synthetic send failure"]);
+
+      // The retry loop replaces the broken socket.
+      await delayMs(10);
+      await waitForSocket(1);
+      transport.disconnect();
     } finally {
       fake.restore();
     }
   });
 
-  it("rejects ready when the bootstrap message cannot be decoded", async () => {
+  it("recycles the connection when the bootstrap message cannot be decoded", async () => {
     const fake = installFakeWebSocket();
+    const lost: string[] = [];
     try {
-      const transport = new CloudWebSocketTransport(new URL("wss://example.test/n/room/sync"), []);
-      const socket = fake.socket;
+      const transport = createTransport({
+        onConnectionLost: (reason) => lost.push(reason.message),
+        reconnectBaseDelayMs: 1,
+        random: () => 0.5,
+      });
+      const socket = await waitForSocket(0);
       socket.open();
       socket.message("not binary");
+      await nextMicrotask();
 
-      await assert.rejects(
-        transport.ready,
-        /cloud sync socket message failed: unsupported WebSocket message/,
-      );
+      assert.equal(lost.length, 1);
+      assert.match(lost[0], /cloud sync socket message failed: unsupported WebSocket message/);
       assert.equal(socket.readyState, FakeWebSocket.CLOSED);
+
+      // ready is not rejected — the loop keeps trying until disconnect().
+      await delayMs(10);
+      const second = await waitForSocket(1);
+      second.open();
+      second.ready("peer-1");
+      const ready = await transport.ready;
+      assert.equal(ready.peer_id, "peer-1");
+      transport.disconnect();
     } finally {
       fake.restore();
     }
   });
 
-  it("notifies disconnect when a post-ready message cannot be decoded", async () => {
+  it("recycles the connection when a post-ready message cannot be decoded", async () => {
     const fake = installFakeWebSocket();
-    const disconnects: string[] = [];
+    const lost: string[] = [];
     try {
-      const transport = new CloudWebSocketTransport(
-        new URL("wss://example.test/n/room/sync"),
-        [],
-        undefined,
-        (reason) => disconnects.push(reason.message),
-      );
-      const socket = fake.socket;
+      const transport = createTransport({
+        onConnectionLost: (reason) => lost.push(reason.message),
+        reconnectBaseDelayMs: 1,
+        random: () => 0.5,
+      });
+      const socket = await waitForSocket(0);
       socket.open();
       socket.ready("peer-1");
       await transport.ready;
@@ -491,14 +519,15 @@ describe("cloud live sync", () => {
       socket.message("not binary");
       await nextMicrotask();
 
-      assert.deepEqual(disconnects, [
+      assert.deepEqual(lost, [
         "cloud sync socket message failed: unsupported WebSocket message [object String]",
       ]);
       assert.equal(socket.readyState, FakeWebSocket.CLOSED);
       await assert.rejects(
         transport.sendFrame(FrameType.PRESENCE, new Uint8Array([1, 2, 3])),
-        /cloud sync socket is closed/,
+        /cloud sync socket is not open/,
       );
+      transport.disconnect();
     } finally {
       fake.restore();
     }
@@ -704,6 +733,485 @@ describe("cloud persisted-seed handle resolution", () => {
     );
   });
 });
+
+describe("cloud transport reconnect loop", () => {
+  it("resolves the connect target per attempt (fresh auth + operator nonce)", async () => {
+    const fake = installFakeWebSocket();
+    const targets: string[] = [];
+    try {
+      const transport = createTransport({
+        connectTarget: async () => {
+          const nonce = mintCloudSessionId();
+          targets.push(nonce);
+          return {
+            url: new URL(`wss://example.test/n/room/sync?operator=browser%3A${nonce}`),
+            protocols: [],
+          };
+        },
+        reconnectBaseDelayMs: 1,
+        random: () => 0.5,
+      });
+
+      const first = await waitForSocket(0);
+      first.close({ code: 1006 });
+      await delayMs(10);
+      await waitForSocket(1);
+
+      assert.equal(targets.length, 2);
+      assert.notEqual(targets[0], targets[1]);
+      transport.disconnect();
+    } finally {
+      fake.restore();
+    }
+  });
+
+  it("emits roomReady$ per handshake with the fresh connection identity", async () => {
+    const fake = installFakeWebSocket();
+    const readyPeers: string[] = [];
+    try {
+      const transport = createTransport({ reconnectBaseDelayMs: 1, random: () => 0.5 });
+      transport.roomReady$.subscribe((ready) => readyPeers.push(ready.peer_id));
+
+      const first = await waitForSocket(0);
+      first.open();
+      first.ready("peer-1");
+      const ready = await transport.ready;
+      assert.equal(ready.peer_id, "peer-1");
+
+      first.close({ code: 1006 });
+      await delayMs(10);
+      const second = await waitForSocket(1);
+      second.open();
+      second.ready("peer-2");
+      await drainMicrotasks();
+
+      assert.deepEqual(readyPeers, ["peer-1", "peer-2"]);
+      transport.disconnect();
+    } finally {
+      fake.restore();
+    }
+  });
+
+  it("replays the latest handshake to late roomReady$ subscribers", async () => {
+    const fake = installFakeWebSocket();
+    try {
+      const transport = createTransport();
+      const socket = await waitForSocket(0);
+      socket.open();
+      socket.ready("peer-1");
+      await transport.ready;
+
+      // A subscriber attaching after the handshake (the session wires up
+      // once the runtime resolves) still observes the connection it must
+      // adopt — closes the missed-reconnect-during-setup gap.
+      const replayed: string[] = [];
+      transport.roomReady$.subscribe((ready) => replayed.push(ready.peer_id));
+      assert.deepEqual(replayed, ["peer-1"]);
+      transport.disconnect();
+    } finally {
+      fake.restore();
+    }
+  });
+
+  it("walks the status machine: connecting, online, reconnecting, online, offline", async () => {
+    const fake = installFakeWebSocket();
+    const statuses: string[] = [];
+    try {
+      const transport = createTransport({ reconnectBaseDelayMs: 1, random: () => 0.5 });
+      const subscription = transport.connectionStatus$.subscribe((status) => statuses.push(status));
+
+      const first = await waitForSocket(0);
+      first.open();
+      first.ready("peer-1");
+      await transport.ready;
+
+      first.close({ code: 1006 });
+      await delayMs(10);
+      const second = await waitForSocket(1);
+      second.open();
+      second.ready("peer-2");
+      await drainMicrotasks();
+
+      transport.disconnect();
+      subscription.unsubscribe();
+
+      assert.deepEqual(statuses, ["connecting", "online", "reconnecting", "online", "offline"]);
+    } finally {
+      fake.restore();
+    }
+  });
+
+  it("rejects pending frame ACKs when the connection is lost", async () => {
+    const fake = installFakeWebSocket();
+    try {
+      const transport = createTransport({ reconnectBaseDelayMs: 1, random: () => 0.5 });
+      const socket = await waitForSocket(0);
+      socket.open();
+      socket.ready("peer-1");
+      await transport.ready;
+
+      const response = transport.sendRequest({ type: "execute_cell", cell_id: "cell-1" });
+      await nextMicrotask();
+      assert.equal(socket.sent.length, 1);
+
+      // FIFO frame-type ACK matching cannot span sockets.
+      socket.close({ code: 1006 });
+      await assert.rejects(response, /cloud sync socket closed \(1006\)/);
+      transport.disconnect();
+    } finally {
+      fake.restore();
+    }
+  });
+
+  it("backs off exponentially, caps the delay, and resets on cloud_room_ready", async (t) => {
+    t.mock.timers.enable({ apis: ["setTimeout"] });
+    const fake = installFakeWebSocket();
+    try {
+      // random() = 0.5 makes the jitter factor exactly 1.0.
+      const transport = createTransport({ random: () => 0.5 });
+
+      // Attempt 0 connects immediately.
+      const failAttempt = async (index: number) => {
+        const socket = await waitForSocket(index);
+        socket.close({ code: 1006 });
+      };
+
+      // Failed attempts schedule retries at 1s, 2s, 4s ... capped at 30s.
+      const expectedDelays = [1_000, 2_000, 4_000, 8_000, 16_000, 30_000, 30_000];
+      await failAttempt(0);
+      for (const [index, delay] of expectedDelays.entries()) {
+        t.mock.timers.tick(delay - 1);
+        await drainMicrotasks();
+        assert.equal(
+          FakeWebSocket.instances.length,
+          index + 1,
+          `no early retry before ${delay}ms (attempt ${index + 1})`,
+        );
+        t.mock.timers.tick(1);
+        await failAttempt(index + 1);
+      }
+
+      // A successful handshake resets the backoff to the base delay.
+      t.mock.timers.tick(30_000);
+      const recovered = await waitForSocket(expectedDelays.length + 1);
+      recovered.open();
+      recovered.ready("peer-1");
+      await transport.ready;
+      recovered.close({ code: 1006 });
+
+      t.mock.timers.tick(999);
+      await drainMicrotasks();
+      assert.equal(FakeWebSocket.instances.length, expectedDelays.length + 2);
+      t.mock.timers.tick(1);
+      await waitForSocket(expectedDelays.length + 2);
+
+      transport.disconnect();
+    } finally {
+      fake.restore();
+    }
+  });
+
+  it("keeps retry delays within the ±50% jitter bounds", async (t) => {
+    t.mock.timers.enable({ apis: ["setTimeout"] });
+    const fake = installFakeWebSocket();
+    try {
+      // random() = 0 → 0.5× base; random() = 1 → 1.5× base.
+      const low = createTransport({ random: () => 0 });
+      (await waitForSocket(0)).close({ code: 1006 });
+      t.mock.timers.tick(499);
+      await drainMicrotasks();
+      assert.equal(FakeWebSocket.instances.length, 1, "0.5×base lower bound holds");
+      t.mock.timers.tick(1);
+      await waitForSocket(1);
+      low.disconnect();
+
+      const high = createTransport({ random: () => 1 });
+      (await waitForSocket(2)).close({ code: 1006 });
+      t.mock.timers.tick(1_499);
+      await drainMicrotasks();
+      assert.equal(FakeWebSocket.instances.length, 3, "1.5×base upper bound holds");
+      t.mock.timers.tick(1);
+      await waitForSocket(3);
+      high.disconnect();
+    } finally {
+      fake.restore();
+    }
+  });
+
+  it("short-circuits the backoff wait on the browser online event", async (t) => {
+    t.mock.timers.enable({ apis: ["setTimeout"] });
+    const fake = installFakeWebSocket();
+    const fakeWindow = installFakeWindow();
+    try {
+      const transport = createTransport({ random: () => 0.5 });
+      (await waitForSocket(0)).close({ code: 1006 });
+      // Burn a couple of attempts so the pending delay is long.
+      t.mock.timers.tick(1_000);
+      (await waitForSocket(1)).close({ code: 1006 });
+      t.mock.timers.tick(2_000);
+      (await waitForSocket(2)).close({ code: 1006 });
+
+      // 4s wait pending; connectivity returns — reconnect immediately.
+      fakeWindow.dispatchEvent(new Event("online"));
+      await waitForSocket(3);
+
+      transport.disconnect();
+    } finally {
+      fakeWindow.restore();
+      fake.restore();
+    }
+  });
+
+  it("processes a sync frame arriving immediately after a reconnect ready AFTER the re-establish", async () => {
+    const fake = installFakeWebSocket();
+    const order: string[] = [];
+    try {
+      const transport = createTransport({ reconnectBaseDelayMs: 1, random: () => 0.5 });
+      const first = await waitForSocket(0);
+      first.open();
+      first.ready("peer-1");
+      await transport.ready;
+
+      transport.onFrame((frame) => order.push(`frame:${frame[0]}`));
+      transport.roomReady$.subscribe((ready) => order.push(`ready:${ready.peer_id}`));
+      assert.deepEqual(order, ["ready:peer-1"]); // replayed handshake
+
+      first.close({ code: 1006 });
+      await delayMs(10);
+      const second = await waitForSocket(1);
+      second.open();
+      // The room host kicks sync immediately after ready: the sync frame
+      // lands right behind the handshake. Subscribers (the session's
+      // synchronous re-establish) must run before the frame is dispatched.
+      second.ready("peer-2");
+      second.message(new Uint8Array([FrameType.AUTOMERGE_SYNC, 9]).buffer);
+      await drainMicrotasks();
+
+      assert.deepEqual(order, ["ready:peer-1", "ready:peer-2", "frame:0"]);
+      transport.disconnect();
+    } finally {
+      fake.restore();
+    }
+  });
+
+  it("delivers an edit made while disconnected after the reconnect resync, with continuity", async () => {
+    const fake = installFakeWebSocket();
+    try {
+      const transport = createTransport({ reconnectBaseDelayMs: 1, random: () => 0.5 });
+      const first = await waitForSocket(0);
+      first.open();
+      first.ready("peer-1");
+      const ready = await transport.ready;
+
+      // Mock SyncableHandle with claim/rollback semantics for local edits.
+      const handleCalls: string[] = [];
+      let pendingEdit: Uint8Array | null = null;
+      let claimedEdit: Uint8Array | null = null;
+      const handle: SyncableHandle = {
+        receive_frame: (bytes) =>
+          bytes[0] === FrameType.AUTOMERGE_SYNC
+            ? [
+                {
+                  type: "sync_applied",
+                  changed: true,
+                  changeset: {
+                    changed: [{ cell_id: "c1", fields: { source: true } }],
+                    added: [],
+                    removed: [],
+                    order_changed: false,
+                  },
+                },
+              ]
+            : [],
+        flush_local_changes: () => {
+          const edit = pendingEdit;
+          if (edit) {
+            claimedEdit = edit;
+            pendingEdit = null;
+          }
+          return edit;
+        },
+        cancel_last_flush: () => {
+          handleCalls.push("cancel_last_flush");
+          pendingEdit = claimedEdit;
+          claimedEdit = null;
+        },
+        flush_runtime_state_sync: () => null,
+        cancel_last_runtime_state_flush: () => undefined,
+        generate_runtime_state_sync_reply: () => null,
+        flush_comms_doc_sync: () => null,
+        cancel_last_comms_doc_flush: () => undefined,
+        generate_comms_doc_sync_reply: () => null,
+        flush_pool_state_sync: () => null,
+        cancel_last_pool_state_flush: () => undefined,
+        generate_pool_state_sync_reply: () => null,
+        reset_sync_state: () => {
+          handleCalls.push("reset_sync_state");
+        },
+        cell_count: () => 1,
+        get_heads_hex: () => ["aa"],
+        get_dependency_fingerprint: () => undefined,
+      };
+      const setActorCalls: string[] = [];
+      const engine = new SyncEngine({
+        getHandle: () => handle,
+        transport,
+        presenceHeartbeat: { intervalMs: 60_000, encode: () => new Uint8Array([0]) },
+        flushDeliveryTimeoutMs: 50,
+      });
+      startCloudBootstrapSync(engine);
+
+      // The session-shaped roomReady$ wiring: synchronous re-establish on
+      // every handshake after the one already adopted.
+      let adoptedPeer = ready.peer_id;
+      transport.roomReady$.subscribe((next) => {
+        if (next.peer_id === adoptedPeer) return;
+        adoptedPeer = next.peer_id;
+        reestablishCloudConnection(
+          { set_actor: (label: string) => setActorCalls.push(label) },
+          engine,
+          next.actor_label,
+        );
+      });
+
+      // Continuity seam: the cellChanges$ subscription must survive the
+      // reconnect (no engine restart, no projection blanking).
+      const changesets: unknown[] = [];
+      engine.cellChanges$.subscribe((changeset) => changesets.push(changeset));
+
+      // Connection drops; an edit lands while offline.
+      first.close({ code: 1006 });
+      pendingEdit = new Uint8Array([42]);
+      engine.flush();
+      await delayMs(10);
+      // The send was dropped (not buffered) and rolled back into the handle.
+      assert.deepEqual(handleCalls, ["cancel_last_flush"]);
+      assert.deepEqual(pendingEdit, new Uint8Array([42]));
+
+      // Reconnect: handshake replay triggers the synchronous re-establish,
+      // and the resync flush delivers the preserved edit.
+      const second = await waitForSocket(1);
+      second.open();
+      second.ready("peer-2");
+      await delayMs(10);
+      assert.deepEqual(setActorCalls, ["user:dev:alice/desktop:peer-2"]);
+      assert.ok(handleCalls.includes("reset_sync_state"));
+      const syncFrames = second.sent.filter((frame) => frame[0] === FrameType.AUTOMERGE_SYNC);
+      assert.equal(syncFrames.length, 1);
+      assert.deepEqual(Array.from(syncFrames[0].slice(1)), [42]);
+
+      // Inbound sync after the reconnect still reaches the ORIGINAL
+      // subscription — engine and consumers were preserved throughout.
+      second.message(new Uint8Array([FrameType.AUTOMERGE_SYNC, 7]).buffer);
+      await delayMs(60); // cellChanges$ coalesces on a 32ms buffer
+      assert.equal(changesets.length, 1);
+
+      engine.stop();
+      transport.disconnect();
+    } finally {
+      fake.restore();
+    }
+  });
+});
+
+describe("cloud reconnect session policies", () => {
+  it("re-establishes in the safe order: set_actor, resetForBootstrap, resetAndResync", () => {
+    const calls: string[] = [];
+    reestablishCloudConnection(
+      { set_actor: () => calls.push("set_actor") },
+      {
+        resetForBootstrap: () => calls.push("resetForBootstrap"),
+        resetAndResync: () => calls.push("resetAndResync"),
+      },
+      "user:dev:alice/browser:fresh",
+    );
+    assert.deepEqual(calls, ["set_actor", "resetForBootstrap", "resetAndResync"]);
+  });
+
+  it("classifies the first recoverable rejection as in-place resync, repeats escalate", () => {
+    assert.equal(classifyRecoverableRejection(1, true), "resync_in_place");
+    assert.equal(classifyRecoverableRejection(2, true), "escalate");
+    assert.equal(classifyRecoverableRejection(3, true), "escalate");
+    // No runtime yet (rejection during connect): nothing to resync in place.
+    assert.equal(classifyRecoverableRejection(1, false), "escalate");
+  });
+
+  it("mints a fresh operator nonce and re-resolves auth per connect target call", async () => {
+    const resolvedFor: string[] = [];
+    const connectTarget = createCloudConnectTarget({
+      syncEndpoint: "https://cloud.test/n/demo/sync",
+      resolveAuth: (sessionId) => {
+        resolvedFor.push(sessionId);
+        return {
+          headers: { Authorization: "Bearer token" },
+          protocols: ["nteract-bearer.dG9rZW4", "nteract.v4"],
+          user: null,
+          operator: null,
+          requestedScope: null,
+        };
+      },
+    });
+
+    const first = await connectTarget();
+    const second = await connectTarget();
+
+    assert.equal(resolvedFor.length, 2);
+    assert.notEqual(resolvedFor[0], resolvedFor[1]);
+    assert.equal(
+      first.url.searchParams.get("operator"),
+      `browser:${encodeURIComponent(resolvedFor[0])}`,
+    );
+    assert.equal(
+      second.url.searchParams.get("operator"),
+      `browser:${encodeURIComponent(resolvedFor[1])}`,
+    );
+    assert.deepEqual(first.protocols, ["nteract-bearer.dG9rZW4", "nteract.v4"]);
+  });
+});
+
+function createTransport(
+  overrides: Partial<CloudWebSocketTransportOptions> = {},
+): CloudWebSocketTransport {
+  return new CloudWebSocketTransport({
+    connectTarget: async () => ({
+      url: new URL("wss://example.test/n/room/sync"),
+      protocols: [],
+    }),
+    ...overrides,
+  });
+}
+
+/** Connect attempts resolve their target asynchronously; wait for socket N. */
+async function waitForSocket(index: number): Promise<FakeWebSocket> {
+  for (let i = 0; i < 50 && FakeWebSocket.instances.length <= index; i++) {
+    await nextMicrotask();
+  }
+  const socket = FakeWebSocket.instances[index];
+  assert.ok(socket, `expected WebSocket instance ${index}`);
+  return socket;
+}
+
+async function drainMicrotasks(): Promise<void> {
+  for (let i = 0; i < 10; i++) {
+    await nextMicrotask();
+  }
+}
+
+function delayMs(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+function installFakeWindow(): { dispatchEvent: (event: Event) => void; restore: () => void } {
+  const target = new EventTarget();
+  const original = (globalThis as { window?: unknown }).window;
+  (globalThis as { window?: unknown }).window = target;
+  return {
+    dispatchEvent: (event) => target.dispatchEvent(event),
+    restore: () => {
+      (globalThis as { window?: unknown }).window = original;
+    },
+  };
+}
 
 function installFakeWebSocket(): {
   restore: () => void;

--- a/apps/notebook-cloud/test/live-sync.test.ts
+++ b/apps/notebook-cloud/test/live-sync.test.ts
@@ -2,11 +2,14 @@ import { describe, it } from "node:test";
 import assert from "node:assert/strict";
 import { SyncEngine, type PersistedNotebookDoc, type SyncableHandle } from "runtimed";
 import {
+  CloudRecoverableRejectionTracker,
   CloudWebSocketTransport,
-  classifyRecoverableRejection,
+  applyCloudRoomReady,
+  cloudConnectionIdentityFromReady,
   cloudPrincipalFromActorLabel,
   cloudRoomReadyPeerLabel,
   createCloudConnectTarget,
+  discardPersistedSeedAfterTeardown,
   isAnonymousCloudPrincipal,
   isRecoverableCloudFrameRejection,
   mintCloudSessionId,
@@ -737,17 +740,30 @@ describe("cloud persisted-seed handle resolution", () => {
 describe("cloud transport reconnect loop", () => {
   it("resolves the connect target per attempt (fresh auth + operator nonce)", async () => {
     const fake = installFakeWebSocket();
-    const targets: string[] = [];
+    const minted: string[] = [];
+    const authResolutions: string[] = [];
     try {
+      // The REAL production factory: every transport attempt must re-resolve
+      // auth and carry a freshly-minted operator nonce in the socket URL.
       const transport = createTransport({
-        connectTarget: async () => {
-          const nonce = mintCloudSessionId();
-          targets.push(nonce);
-          return {
-            url: new URL(`wss://example.test/n/room/sync?operator=browser%3A${nonce}`),
-            protocols: [],
-          };
-        },
+        connectTarget: createCloudConnectTarget({
+          syncEndpoint: "https://example.test/n/room/sync",
+          resolveAuth: (sessionId) => {
+            authResolutions.push(sessionId);
+            return {
+              headers: { Authorization: "Bearer token" },
+              protocols: ["nteract-bearer.dG9rZW4", "nteract.v4"],
+              user: null,
+              operator: null,
+              requestedScope: null,
+            };
+          },
+          mintSessionId: () => {
+            const id = mintCloudSessionId();
+            minted.push(id);
+            return id;
+          },
+        }),
         reconnectBaseDelayMs: 1,
         random: () => 0.5,
       });
@@ -755,10 +771,13 @@ describe("cloud transport reconnect loop", () => {
       const first = await waitForSocket(0);
       first.close({ code: 1006 });
       await delayMs(10);
-      await waitForSocket(1);
+      const second = await waitForSocket(1);
 
-      assert.equal(targets.length, 2);
-      assert.notEqual(targets[0], targets[1]);
+      assert.equal(minted.length, 2);
+      assert.notEqual(minted[0], minted[1]);
+      assert.deepEqual(authResolutions, minted); // auth re-resolved per attempt
+      assert.ok(first.url.includes(`operator=browser%3A${minted[0]}`));
+      assert.ok(second.url.includes(`operator=browser%3A${minted[1]}`));
       transport.disconnect();
     } finally {
       fake.restore();
@@ -1061,16 +1080,17 @@ describe("cloud transport reconnect loop", () => {
       });
       startCloudBootstrapSync(engine);
 
-      // The session-shaped roomReady$ wiring: synchronous re-establish on
-      // every handshake after the one already adopted.
-      let adoptedPeer = ready.peer_id;
+      // The session-shaped roomReady$ wiring, through the PRODUCTION
+      // adoption seam: identity dedup + synchronous re-establish on every
+      // handshake after the one already adopted.
+      const identity = cloudConnectionIdentityFromReady(ready);
       transport.roomReady$.subscribe((next) => {
-        if (next.peer_id === adoptedPeer) return;
-        adoptedPeer = next.peer_id;
-        reestablishCloudConnection(
-          { set_actor: (label: string) => setActorCalls.push(label) },
-          engine,
-          next.actor_label,
+        applyCloudRoomReady(identity, next, () =>
+          reestablishCloudConnection(
+            { set_actor: (label: string) => setActorCalls.push(label) },
+            engine,
+            next.actor_label,
+          ),
         );
       });
 
@@ -1095,6 +1115,7 @@ describe("cloud transport reconnect loop", () => {
       second.ready("peer-2");
       await delayMs(10);
       assert.deepEqual(setActorCalls, ["user:dev:alice/desktop:peer-2"]);
+      assert.equal(identity.peerId, "peer-2"); // presence identity adopted
       assert.ok(handleCalls.includes("reset_sync_state"));
       const syncFrames = second.sent.filter((frame) => frame[0] === FrameType.AUTOMERGE_SYNC);
       assert.equal(syncFrames.length, 1);
@@ -1107,6 +1128,259 @@ describe("cloud transport reconnect loop", () => {
       assert.equal(changesets.length, 1);
 
       engine.stop();
+      transport.disconnect();
+    } finally {
+      fake.restore();
+    }
+  });
+
+  it("discards frames queued from a dead connection instead of replaying them", async () => {
+    const fake = installFakeWebSocket();
+    try {
+      const transport = createTransport({ reconnectBaseDelayMs: 1, random: () => 0.5 });
+      const first = await waitForSocket(0);
+      first.open();
+      first.ready("peer-1");
+      await transport.ready;
+
+      // A frame arrives before any onFrame listener exists (the engine
+      // attaches after ready) and the connection then dies: the frame is
+      // bound to connection 1's sync state and must never replay into
+      // connection 2's.
+      first.message(new Uint8Array([FrameType.AUTOMERGE_SYNC, 11]).buffer);
+      await drainMicrotasks();
+      first.close({ code: 1006 });
+
+      await delayMs(10);
+      const second = await waitForSocket(1);
+      second.open();
+      second.ready("peer-2");
+      await drainMicrotasks();
+
+      const frames: number[][] = [];
+      transport.onFrame((frame) => frames.push(frame));
+      assert.deepEqual(frames, []); // stale frame discarded, not replayed
+
+      second.message(new Uint8Array([FrameType.AUTOMERGE_SYNC, 22]).buffer);
+      await drainMicrotasks();
+      assert.deepEqual(frames, [[FrameType.AUTOMERGE_SYNC, 22]]);
+      transport.disconnect();
+    } finally {
+      fake.restore();
+    }
+  });
+
+  it("does not reset the backoff on WS open without cloud_room_ready", async (t) => {
+    t.mock.timers.enable({ apis: ["setTimeout"] });
+    const fake = installFakeWebSocket();
+    try {
+      const transport = createTransport({ random: () => 0.5, handshakeTimeoutMs: 100 });
+
+      // Two failed attempts: delays 1000, 2000.
+      (await waitForSocket(0)).close({ code: 1006 });
+      t.mock.timers.tick(1_000);
+      (await waitForSocket(1)).close({ code: 1006 });
+      t.mock.timers.tick(2_000);
+
+      // Attempt 2 OPENS but never readies (LB accepts the socket while the
+      // room is unreachable). WS open alone must not reset the counter.
+      const opened = await waitForSocket(2);
+      opened.open();
+      opened.close({ code: 1006 });
+
+      // The next delay must continue escalating (4000), not reset to base.
+      t.mock.timers.tick(3_999);
+      await drainMicrotasks();
+      assert.equal(FakeWebSocket.instances.length, 3, "no retry before the escalated delay");
+      t.mock.timers.tick(1);
+      await waitForSocket(3);
+
+      transport.disconnect();
+    } finally {
+      fake.restore();
+    }
+  });
+
+  it("recycles an attempt whose handshake never completes", async (t) => {
+    t.mock.timers.enable({ apis: ["setTimeout"] });
+    const fake = installFakeWebSocket();
+    const lost: string[] = [];
+    try {
+      const transport = createTransport({
+        onConnectionLost: (reason) => lost.push(reason.message),
+        random: () => 0.5,
+        handshakeTimeoutMs: 100,
+      });
+
+      // The socket opens but the room never sends cloud_room_ready.
+      const hung = await waitForSocket(0);
+      hung.open();
+      t.mock.timers.tick(100);
+      await drainMicrotasks();
+
+      assert.equal(lost.length, 1);
+      assert.match(lost[0], /handshake did not complete within 100ms/);
+      assert.equal(hung.readyState, FakeWebSocket.CLOSED);
+
+      // The attempt rides the normal backoff instead of dead-ending.
+      t.mock.timers.tick(1_000);
+      const retry = await waitForSocket(1);
+      retry.open();
+      retry.ready("peer-1");
+      const ready = await transport.ready;
+      assert.equal(ready.peer_id, "peer-1");
+      transport.disconnect();
+    } finally {
+      fake.restore();
+    }
+  });
+
+  it("rides the retry loop when connectTarget rejects (auth re-resolution failure)", async () => {
+    const fake = installFakeWebSocket();
+    const lost: string[] = [];
+    let attempts = 0;
+    try {
+      const transport = createTransport({
+        connectTarget: async () => {
+          attempts += 1;
+          if (attempts === 1) {
+            throw new Error("token refresh 401");
+          }
+          return { url: new URL("wss://example.test/n/room/sync"), protocols: [] };
+        },
+        onConnectionLost: (reason) => lost.push(reason.message),
+        reconnectBaseDelayMs: 1,
+        random: () => 0.5,
+      });
+
+      await delayMs(10);
+      const socket = await waitForSocket(0); // attempt 2's socket
+      socket.open();
+      socket.ready("peer-1");
+      const ready = await transport.ready;
+
+      assert.equal(attempts, 2);
+      assert.equal(lost.length, 1);
+      assert.match(lost[0], /connect target failed: token refresh 401/);
+      assert.equal(ready.peer_id, "peer-1");
+      transport.disconnect();
+    } finally {
+      fake.restore();
+    }
+  });
+
+  it("recycles a hung connectTarget through the per-attempt budget", async (t) => {
+    t.mock.timers.enable({ apis: ["setTimeout"] });
+    const fake = installFakeWebSocket();
+    const lost: string[] = [];
+    let attempts = 0;
+    try {
+      const transport = createTransport({
+        connectTarget: () => {
+          attempts += 1;
+          if (attempts === 1) {
+            return new Promise(() => undefined); // hung auth fetch
+          }
+          return Promise.resolve({
+            url: new URL("wss://example.test/n/room/sync"),
+            protocols: [],
+          });
+        },
+        onConnectionLost: (reason) => lost.push(reason.message),
+        random: () => 0.5,
+        handshakeTimeoutMs: 100,
+      });
+
+      // No socket, no handshake timer, no retry timer — the per-attempt
+      // budget must still recycle the attempt.
+      t.mock.timers.tick(100);
+      await drainMicrotasks();
+      assert.equal(lost.length, 1);
+      assert.match(lost[0], /connect target did not settle within 100ms/);
+
+      t.mock.timers.tick(1_000); // backoff after the failed attempt
+      const socket = await waitForSocket(0);
+      socket.open();
+      socket.ready("peer-1");
+      const ready = await transport.ready;
+      assert.equal(ready.peer_id, "peer-1");
+      assert.equal(attempts, 2);
+      transport.disconnect();
+    } finally {
+      fake.restore();
+    }
+  });
+
+  it("lets the browser online event supersede a parked connectTarget await", async () => {
+    const fake = installFakeWebSocket();
+    const fakeWindow = installFakeWindow();
+    let attempts = 0;
+    try {
+      const transport = createTransport({
+        connectTarget: () => {
+          attempts += 1;
+          if (attempts === 1) {
+            return new Promise(() => undefined); // hung auth fetch
+          }
+          return Promise.resolve({
+            url: new URL("wss://example.test/n/room/sync"),
+            protocols: [],
+          });
+        },
+        // Keeps the superseded attempt's per-attempt budget timer short so
+        // the test process is not held open by a 30s real timer.
+        handshakeTimeoutMs: 50,
+      });
+      await drainMicrotasks();
+      assert.equal(FakeWebSocket.instances.length, 0); // parked in attempt 1
+
+      // Connectivity returns while attempt 1 is parked awaiting auth: the
+      // online event supersedes it (epoch bump discards the late target).
+      fakeWindow.dispatchEvent(new Event("online"));
+      const socket = await waitForSocket(0);
+      socket.open();
+      socket.ready("peer-1");
+      const ready = await transport.ready;
+      assert.equal(ready.peer_id, "peer-1");
+      assert.equal(attempts, 2);
+      transport.disconnect();
+    } finally {
+      fakeWindow.restore();
+      fake.restore();
+    }
+  });
+
+  it("rejects sends in the open-to-ready handshake window", async () => {
+    const fake = installFakeWebSocket();
+    try {
+      const transport = createTransport({ reconnectBaseDelayMs: 1, random: () => 0.5 });
+      const first = await waitForSocket(0);
+      first.open();
+      // Socket OPEN but cloud_room_ready not yet handled: frames would go
+      // out under the previous connection's sync state and actor.
+      await assert.rejects(
+        transport.sendFrame(FrameType.PRESENCE, new Uint8Array([1])),
+        /cloud sync connection is not ready/,
+      );
+
+      first.ready("peer-1");
+      await transport.ready;
+      await transport.sendFrame(FrameType.PRESENCE, new Uint8Array([2]));
+      assert.equal(first.sent.length, 1);
+
+      // The same gate applies per reconnect attempt.
+      first.close({ code: 1006 });
+      await delayMs(10);
+      const second = await waitForSocket(1);
+      second.open();
+      await assert.rejects(
+        transport.sendFrame(FrameType.PRESENCE, new Uint8Array([3])),
+        /cloud sync connection is not ready/,
+      );
+      second.ready("peer-2");
+      await drainMicrotasks();
+      await transport.sendFrame(FrameType.PRESENCE, new Uint8Array([4]));
+      assert.equal(second.sent.length, 1);
       transport.disconnect();
     } finally {
       fake.restore();
@@ -1128,12 +1402,135 @@ describe("cloud reconnect session policies", () => {
     assert.deepEqual(calls, ["set_actor", "resetForBootstrap", "resetAndResync"]);
   });
 
-  it("classifies the first recoverable rejection as in-place resync, repeats escalate", () => {
-    assert.equal(classifyRecoverableRejection(1, true), "resync_in_place");
-    assert.equal(classifyRecoverableRejection(2, true), "escalate");
-    assert.equal(classifyRecoverableRejection(3, true), "escalate");
+  it("tracks rejection strikes: first resyncs in place, post-delivery repeats escalate", () => {
+    const tracker = new CloudRecoverableRejectionTracker();
+    assert.equal(tracker.record(true), "resync_in_place");
+    tracker.resyncSettled();
+    assert.equal(tracker.record(true), "escalate");
+    assert.equal(tracker.record(true), "escalate");
+  });
+
+  it("absorbs pipelined rejections that cannot have observed the in-flight resync", () => {
+    // Several AUTOMERGE_SYNC frames are routinely outstanding and acks
+    // carry no id: rejections arriving before the strike-1 resync's flush
+    // was delivered are the same divergence event, never escalation
+    // evidence — the poison-pill discard must not fire from them.
+    const tracker = new CloudRecoverableRejectionTracker();
+    assert.equal(tracker.record(true), "resync_in_place");
+    assert.equal(tracker.record(true), "absorb");
+    assert.equal(tracker.record(true), "absorb");
+    tracker.resyncSettled();
+    assert.equal(tracker.record(true), "escalate");
+  });
+
+  it("escalates immediately when no runtime exists and resets per connection", () => {
+    const tracker = new CloudRecoverableRejectionTracker();
     // No runtime yet (rejection during connect): nothing to resync in place.
-    assert.equal(classifyRecoverableRejection(1, false), "escalate");
+    assert.equal(tracker.record(false), "escalate");
+
+    // A fresh cloud_room_ready resets the strike count AND any pending
+    // resync gate from the previous connection.
+    tracker.reset();
+    assert.equal(tracker.record(true), "resync_in_place");
+    tracker.reset();
+    assert.equal(tracker.record(true), "resync_in_place");
+  });
+
+  it("adopts a handshake once: dedup, identity update, then re-establish", () => {
+    const identity = cloudConnectionIdentityFromReady({
+      type: "cloud_room_ready",
+      protocol: "v4",
+      notebook_id: "room",
+      peer_id: "peer-1",
+      actor_label: "user:dev:alice/browser:one",
+      connection_scope: "editor",
+      room_peer_count: 1,
+      timestamp: "2026-06-11T00:00:00.000Z",
+    });
+    const reestablishes: string[] = [];
+
+    // Replayed handshake for the connection already adopted: no-op.
+    assert.equal(
+      applyCloudRoomReady(
+        identity,
+        {
+          type: "cloud_room_ready",
+          protocol: "v4",
+          notebook_id: "room",
+          peer_id: "peer-1",
+          actor_label: "user:dev:alice/browser:one",
+          connection_scope: "editor",
+          room_peer_count: 1,
+          timestamp: "2026-06-11T00:00:00.000Z",
+        },
+        () => reestablishes.push(identity.peerId),
+      ),
+      false,
+    );
+    assert.deepEqual(reestablishes, [] as string[]);
+
+    // Fresh connection: identity updated BEFORE the re-establish runs, so
+    // presence encoders already stamp the new peer id during the resync.
+    assert.equal(
+      applyCloudRoomReady(
+        identity,
+        {
+          type: "cloud_room_ready",
+          protocol: "v4",
+          notebook_id: "room",
+          peer_id: "peer-2",
+          actor_label: "user:dev:alice/browser:two",
+          connection_scope: "viewer",
+          room_peer_count: 2,
+          timestamp: "2026-06-11T00:00:01.000Z",
+        },
+        () => reestablishes.push(identity.peerId),
+      ),
+      true,
+    );
+    assert.deepEqual(reestablishes, ["peer-2"]);
+    assert.equal(identity.actorLabel, "user:dev:alice/browser:two");
+    assert.equal(identity.connectionScope, "viewer");
+    assert.equal(
+      identity.peerLabel,
+      cloudRoomReadyPeerLabel({ actor_label: "user:dev:alice/browser:two" }),
+    );
+  });
+
+  it("clears the seed only after the teardown flush settles, and never rejects", async () => {
+    const order: string[] = [];
+    let releaseDispose!: () => void;
+    const disposeRuntime = () =>
+      new Promise<void>((resolve) => {
+        releaseDispose = () => {
+          order.push("dispose_settled");
+          resolve();
+        };
+      });
+
+    const chain = discardPersistedSeedAfterTeardown(disposeRuntime, async () => {
+      order.push("clear");
+    });
+    await delayMs(5);
+    // The teardown flushNow re-writes the record with the rejected changes;
+    // clearing before it settles would leave the poison record behind.
+    assert.deepEqual(order, []);
+    releaseDispose();
+    await chain;
+    assert.deepEqual(order, ["dispose_settled", "clear"]);
+
+    // Clear failures are swallowed (the chain gates the next attempt's
+    // persistence arming, so it must never reject).
+    const originalWarn = console.warn;
+    console.warn = () => {};
+    try {
+      await discardPersistedSeedAfterTeardown(
+        () => Promise.reject(new Error("dispose failed")),
+        () => Promise.reject(new Error("clear failed")),
+      );
+    } finally {
+      console.warn = originalWarn;
+    }
   });
 
   it("mints a fresh operator nonce and re-resolves auth per connect target call", async () => {
@@ -1243,9 +1640,11 @@ class FakeWebSocket extends EventTarget {
   readyState = FakeWebSocket.CONNECTING;
   throwOnSend = false;
   sent: Uint8Array[] = [];
+  readonly url: string;
 
-  constructor() {
+  constructor(url?: unknown) {
     super();
+    this.url = String(url ?? "");
     FakeWebSocket.instances.push(this);
   }
 

--- a/apps/notebook-cloud/viewer/cloud-viewer-session.ts
+++ b/apps/notebook-cloud/viewer/cloud-viewer-session.ts
@@ -39,12 +39,15 @@ import {
 import { materializeCloudNotebookView } from "./cloud-view-model";
 import { CloudLivePresenceStore } from "./live-presence";
 import {
+  classifyRecoverableRejection,
   cloudPrincipalFromActorLabel,
   connectCloudSyncRuntime,
+  createCloudConnectTarget,
   isAnonymousCloudPrincipal,
   isRecoverableCloudFrameRejection,
   shouldDiscardPersistedSeedOnRejection,
   type CloudSyncRuntime,
+  type CloudWebSocketTransport,
 } from "./live-sync";
 import type { CloudViewerLoadingPolicy } from "./loading-policy";
 import { markCloudViewerLoadMilestone } from "./load-milestones";
@@ -381,11 +384,16 @@ export function useCloudViewerSession({
     let materializeSequence = 0;
     let livePresenceStore: CloudLivePresenceStore | null = null;
     let reconnectTimer: ReturnType<typeof setTimeout> | null = null;
-    const sessionId = mintSessionId();
+    let pendingTransport: CloudWebSocketTransport | null = null;
+    // Recoverable sync rejections on the CURRENT connection (reset on each
+    // cloud_room_ready): the first recovers in place, a repeat escalates.
+    let recoverableRejections = 0;
+    let ranConnectionDiagnostics = false;
     // Local-first persistence is fail-open: no IndexedDB (private mode,
     // SSR) means no adapter and the session runs exactly as before.
     const persistenceAdapter = IndexedDbStorageAdapter.create();
     let notebookPersistence: NotebookDocPersistence | null = null;
+    let notebookPersistencePrincipal: string | null = null;
     const persistenceSeed = persistenceAdapter
       ? {
           loadPersisted: () => loadPersistedNotebookDoc(persistenceAdapter, config.notebookId),
@@ -432,12 +440,73 @@ export function useCloudViewerSession({
       const teardownFlush = notebookPersistence?.flushNow() ?? Promise.resolve();
       notebookPersistence?.dispose();
       notebookPersistence = null;
+      notebookPersistencePrincipal = null;
       disposeCloudSyncRuntime(liveRuntime);
       return teardownFlush;
     };
+    // Arm (or re-arm) the persistence save loop for the runtime's CURRENT
+    // principal. Same-principal reconnects keep the controller; a principal
+    // change (auth re-resolution yielded a different account) recreates it
+    // so the envelope is never stamped with the wrong principal.
+    const armPersistence = (liveRuntime: CloudSyncRuntime) => {
+      if (!persistenceAdapter) return;
+      // A failed seed read leaves an unread record (possibly the only copy
+      // of offline edits) in place — never arm the save loop that would
+      // overwrite it, for the whole life of this runtime.
+      if (liveRuntime.persistenceSeedOutcome === "read_failed") return;
+      const principal = cloudPrincipalFromActorLabel(liveRuntime.actorLabel);
+      if (notebookPersistence && notebookPersistencePrincipal === principal) return;
+      notebookPersistence?.dispose();
+      notebookPersistence = null;
+      notebookPersistencePrincipal = null;
+      // Anonymous principals are per-connection: their records can never
+      // seed and would only churn storage.
+      if (isAnonymousCloudPrincipal(principal)) return;
+      // Snapshot the raw NotebookHandle (full NotebookDoc bytes) on every
+      // doc change; the controller throttles, self-disables after repeated
+      // failures, and never throws into the session.
+      notebookPersistence = new NotebookDocPersistence({
+        adapter: persistenceAdapter,
+        notebookId: config.notebookId,
+        principal,
+        changes$: liveRuntime.engine.notebookDocChanged$,
+        getSaveBytes: () => liveRuntime.handle.save(),
+        getHeadsHex: () => liveRuntime.handle.get_heads_hex(),
+        onError: (error) => console.warn("[notebook-cloud] notebook persistence error", error),
+      });
+      notebookPersistencePrincipal = principal;
+    };
+    // Transport-level connection losses are informational: the transport
+    // owns the retry loop, the preserved handle keeps unflushed local
+    // edits, and the rendered projections stay in place until the room
+    // re-syncs. No teardown here.
+    const handleConnectionLost = (reason: Error) => {
+      if (disposed) return;
+      console.warn("[notebook-cloud] live room connection lost; transport is reconnecting", reason);
+      presenceStore.reduceConnection("disconnected");
+      setConnectionError(reason.message);
+      if (!liveRuntimeRef.current && !ranConnectionDiagnostics) {
+        // First pre-ready failure: surface an actionable access diagnosis
+        // while the retry loop keeps running in the background.
+        ranConnectionDiagnostics = true;
+        void diagnoseCloudConnectionAccess({
+          accessRequestsEndpoint: config.accessRequestsEndpoint,
+          authState,
+          hasAppSession,
+        })
+          .then((diagnostic) => {
+            if (disposed || !diagnostic) return;
+            setConnectionError(diagnostic);
+          })
+          .catch(() => undefined);
+      }
+    };
+    // Escalation-only teardown (repeated sync rejections): dispose the
+    // runtime and re-run the effect with a fresh handle. Transport-level
+    // drops never come through here anymore.
     const scheduleReconnect = (reason: Error) => {
       if (disposed) return;
-      console.warn("[notebook-cloud] live room connection closed", reason);
+      console.warn("[notebook-cloud] live room session teardown; reconnecting", reason);
       presenceStore.reduceConnection("disconnected");
       setConnectionScope(null);
       setConnectionActorLabel(null);
@@ -447,6 +516,9 @@ export function useCloudViewerSession({
       // clears it through the workstation$ projection.
       resetRuntimeState();
       disposeCurrentRuntime();
+      // An in-flight connect (no runtime yet) owns a live transport too.
+      pendingTransport?.disconnect();
+      pendingTransport = null;
       if (reconnectTimer) return;
       reconnectTimer = setTimeout(() => {
         reconnectTimer = null;
@@ -571,68 +643,90 @@ export function useCloudViewerSession({
     setConnectionError(null);
     setConnectionActorLabel(null);
     setConnectionPeerId(null);
-    void (async () =>
-      connectCloudSyncRuntime({
+    connectCloudSyncRuntime({
+      // Per-attempt target: re-resolves auth and mints a fresh operator
+      // nonce on every retry (see createCloudConnectTarget).
+      connectTarget: createCloudConnectTarget({
         syncEndpoint: config.syncEndpoint,
-        runtimedWasmModulePath: config.runtimedWasmModulePath,
-        runtimedWasmPath: config.runtimedWasmPath,
-        sessionId,
-        auth: resolveSyncAuth
-          ? await resolveSyncAuth(sessionId)
-          : cloudSyncAuthFromPrototypeAuthState(authState),
-        persistence: skipSeedOnThisAttempt ? undefined : persistenceSeed,
-        onDisconnect: scheduleReconnect,
-        onControl: (message) => {
-          if (disposed) return;
-          if (
-            message.type === "cloud_room_ready" ||
-            message.type === "cloud_peer_joined" ||
-            message.type === "cloud_peer_left"
-          ) {
-            presenceStore.reduceMessage(message);
-          }
-          if (message.type === "cloud_room_ready") {
-            markCloudViewerLoadMilestone("live-room-ready");
-            setConnectionError(null);
-            setConnectionScope(message.connection_scope);
-            setConnectionActorLabel(message.actor_label);
-          }
-          if (message.type === "cloud_frame_rejected") {
-            if (isRecoverableCloudFrameRejection(message)) {
-              const reason = new Error(`Room rejected sync frame: ${message.reason}`);
-              setStatus({
-                kind: "loading",
-                message: "Resynchronizing live notebook room after a rejected sync frame...",
-              });
-              const seededRuntime = liveRuntimeRef.current?.seededFromPersistence === true;
-              if (
-                persistenceSeed &&
-                shouldDiscardPersistedSeedOnRejection(message, seededRuntime)
-              ) {
-                // Poison pill: the record replays changes the room will not
-                // accept; reseeding it would loop forever. Dispose FIRST —
-                // teardown's flushNow re-writes the record with the rejected
-                // changes — then clear once that write has settled, and
-                // bootstrap the next attempt. The rejected changes are
-                // unauthorized; losing them is the intended outcome.
-                skipSeedOnceRef.current = true;
-                disposeCurrentRuntime()
-                  .catch(() => undefined)
-                  .then(() => persistenceSeed.clear())
-                  .catch((error: unknown) =>
-                    console.warn(
-                      "[notebook-cloud] failed to clear rejected persisted NotebookDoc record",
-                      error,
-                    ),
-                  );
-              }
-              scheduleReconnect(reason);
+        resolveAuth: (attemptSessionId) =>
+          resolveSyncAuth
+            ? resolveSyncAuth(attemptSessionId)
+            : cloudSyncAuthFromPrototypeAuthState(authState),
+      }),
+      runtimedWasmModulePath: config.runtimedWasmModulePath,
+      runtimedWasmPath: config.runtimedWasmPath,
+      persistence: skipSeedOnThisAttempt ? undefined : persistenceSeed,
+      onConnectionLost: handleConnectionLost,
+      onTransportCreated: (transport) => {
+        pendingTransport = transport;
+      },
+      onControl: (message) => {
+        if (disposed) return;
+        if (
+          message.type === "cloud_room_ready" ||
+          message.type === "cloud_peer_joined" ||
+          message.type === "cloud_peer_left"
+        ) {
+          presenceStore.reduceMessage(message);
+        }
+        if (message.type === "cloud_room_ready") {
+          markCloudViewerLoadMilestone("live-room-ready");
+          recoverableRejections = 0; // fresh connection, fresh strike count
+          setConnectionError(null);
+          setConnectionScope(message.connection_scope);
+          setConnectionActorLabel(message.actor_label);
+        }
+        if (message.type === "cloud_frame_rejected") {
+          if (isRecoverableCloudFrameRejection(message)) {
+            recoverableRejections += 1;
+            const liveRuntime = liveRuntimeRef.current;
+            setStatus({
+              kind: "loading",
+              message: "Resynchronizing live notebook room after a rejected sync frame...",
+            });
+            if (
+              classifyRecoverableRejection(recoverableRejections, liveRuntime !== null) ===
+              "resync_in_place"
+            ) {
+              // First strike: sync state diverged from the room — reset and
+              // resync on the live connection, no teardown.
+              liveRuntime?.engine.resetAndResync();
               return;
             }
-            setStatus({ kind: "error", message: `Room rejected a frame: ${message.reason}` });
+            const reason = new Error(`Room rejected sync frame: ${message.reason}`);
+            const seededRuntime = liveRuntime?.seededFromPersistence === true;
+            if (persistenceSeed && shouldDiscardPersistedSeedOnRejection(message, seededRuntime)) {
+              // Poison pill: the record replays changes the room will not
+              // accept; reseeding it would loop forever. Dispose FIRST —
+              // teardown's flushNow re-writes the record with the rejected
+              // changes — then clear once that write has settled, and
+              // bootstrap the next attempt. The rejected changes are
+              // unauthorized; losing them is the intended outcome.
+              skipSeedOnceRef.current = true;
+              disposeCurrentRuntime()
+                .catch(() => undefined)
+                .then(() => persistenceSeed.clear())
+                .catch((error: unknown) =>
+                  console.warn(
+                    "[notebook-cloud] failed to clear rejected persisted NotebookDoc record",
+                    error,
+                  ),
+                );
+            } else if (!liveRuntime) {
+              // A rejection before the runtime resolved means the in-flight
+              // bootstrap flush was refused. We cannot tell from here
+              // whether that attempt was seeded, so bootstrap the next one
+              // either way — a non-seeded attempt bootstraps identically,
+              // and a healthy record is re-persisted after convergence.
+              skipSeedOnceRef.current = true;
+            }
+            scheduleReconnect(reason);
+            return;
           }
-        },
-      }))()
+          setStatus({ kind: "error", message: `Room rejected a frame: ${message.reason}` });
+        }
+      },
+    })
       .then((liveRuntime) => {
         if (disposed) {
           disposeCloudSyncRuntime(liveRuntime);
@@ -640,38 +734,37 @@ export function useCloudViewerSession({
         }
         liveRuntimeRef.current = liveRuntime;
         installCloudWidgetCommWriter(liveRuntime);
-        const persistencePrincipal = cloudPrincipalFromActorLabel(liveRuntime.actorLabel);
-        if (
-          persistenceAdapter &&
-          // A failed seed read leaves an unread record (possibly the only
-          // copy of offline edits) in place — never arm the save loop that
-          // would overwrite it.
-          liveRuntime.persistenceSeedOutcome !== "read_failed" &&
-          // Anonymous principals are per-connection: their records can
-          // never seed and would only churn storage.
-          !isAnonymousCloudPrincipal(persistencePrincipal)
-        ) {
-          // Snapshot the raw NotebookHandle (full NotebookDoc bytes) on
-          // every doc change; the controller throttles, self-disables after
-          // repeated failures, and never throws into the session.
-          notebookPersistence = new NotebookDocPersistence({
-            adapter: persistenceAdapter,
-            notebookId: config.notebookId,
-            principal: persistencePrincipal,
-            changes$: liveRuntime.engine.notebookDocChanged$,
-            getSaveBytes: () => liveRuntime.handle.save(),
-            getHeadsHex: () => liveRuntime.handle.get_heads_hex(),
-            onError: (error) => console.warn("[notebook-cloud] notebook persistence error", error),
-          });
-        }
+        armPersistence(liveRuntime);
         const stopWidgetLiveRuntimeDiagnostics =
           installCloudWidgetLiveRuntimeDiagnostics(liveRuntime);
         setConnectionScope(liveRuntime.connectionScope);
         setConnectionActorLabel(liveRuntime.actorLabel);
         setConnectionPeerId(liveRuntime.peerId);
         livePresenceStore = new CloudLivePresenceStore(liveRuntime.peerId);
-        const stopCursorDispatch = startCursorDispatch(liveRuntime.peerId);
+        let stopCursorDispatch = startCursorDispatch(liveRuntime.peerId);
         subscriptions = [
+          // Transport-level reconnects preserve the handle, engine,
+          // subscriptions, and store projections; only per-connection state
+          // is re-established here.
+          liveRuntime.transport.roomReady$.subscribe((ready) => {
+            if (disposed || liveRuntimeRef.current !== liveRuntime) return;
+            // applyRoomReady runs the synchronous re-establish (set_actor +
+            // resetForBootstrap + resetAndResync) — it must complete before
+            // this tick yields, ahead of the new connection's first sync
+            // frame. Everything after it is async-safe.
+            if (!liveRuntime.applyRoomReady(ready)) return;
+            setConnectionError(null);
+            setConnectionScope(liveRuntime.connectionScope);
+            setConnectionActorLabel(liveRuntime.actorLabel);
+            setConnectionPeerId(liveRuntime.peerId);
+            // Presence identity is per-connection (server-assigned peer id).
+            livePresenceStore = new CloudLivePresenceStore(liveRuntime.peerId);
+            stopCursorDispatch();
+            stopCursorDispatch = startCursorDispatch(liveRuntime.peerId);
+            // The persistence principal follows the latest identity;
+            // same-principal reconnects keep the controller.
+            armPersistence(liveRuntime);
+          }),
           liveRuntime.engine.broadcasts$.subscribe((payload) => {
             emitBroadcast(payload);
           }),
@@ -716,7 +809,7 @@ export function useCloudViewerSession({
           liveRuntime.engine.poolState$.subscribe((state) => {
             setPoolState(state);
           }),
-          { unsubscribe: stopCursorDispatch },
+          { unsubscribe: () => stopCursorDispatch() },
           { unsubscribe: stopWidgetLiveRuntimeDiagnostics },
         ];
         liveRuntime.engine.reProjectComms();
@@ -768,6 +861,10 @@ export function useCloudViewerSession({
       document.removeEventListener("visibilitychange", flushPersistenceWhenHidden);
       materializeLiveRuntimeRef.current = null;
       const teardownFlush = disposeCurrentRuntime();
+      // An in-flight connect (runtime not yet resolved) owns a transport
+      // whose retry loop would otherwise run forever after unmount.
+      pendingTransport?.disconnect();
+      pendingTransport = null;
       if (persistenceAdapter) {
         // Connection hygiene across reconnect cycles: close the cached IDB
         // connection once the teardown write has committed. Adapter ops
@@ -831,27 +928,6 @@ function disposeCloudSyncRuntime(liveRuntime: CloudSyncRuntime): void {
   liveRuntime.engine.stop();
   liveRuntime.transport.disconnect();
   liveRuntime.handle.free();
-}
-
-/**
- * Mint the per-connect-attempt session id.
- *
- * Load-bearing for actor uniqueness: the worker derives the anonymous
- * principal and the `browser:<sessionId>` operator nonce from this value
- * and only rewrites the principal segment, so a collision would reuse an
- * actor label across doc instances (DuplicateSeqNumber). The fallbacks
- * for environments without crypto.randomUUID must stay collision-resistant
- * — never a bare timestamp.
- */
-function mintSessionId(): string {
-  if (typeof crypto !== "undefined" && crypto.randomUUID) {
-    return crypto.randomUUID();
-  }
-  if (typeof crypto !== "undefined" && crypto.getRandomValues) {
-    const bytes = crypto.getRandomValues(new Uint8Array(16));
-    return Array.from(bytes, (byte) => byte.toString(16).padStart(2, "0")).join("");
-  }
-  return `${Date.now().toString(36)}-${Math.random().toString(36).slice(2)}`;
 }
 
 function recordCloudWidgetCommChangesDiagnostic(

--- a/apps/notebook-cloud/viewer/cloud-viewer-session.ts
+++ b/apps/notebook-cloud/viewer/cloud-viewer-session.ts
@@ -39,10 +39,11 @@ import {
 import { materializeCloudNotebookView } from "./cloud-view-model";
 import { CloudLivePresenceStore } from "./live-presence";
 import {
-  classifyRecoverableRejection,
+  CloudRecoverableRejectionTracker,
   cloudPrincipalFromActorLabel,
   connectCloudSyncRuntime,
   createCloudConnectTarget,
+  discardPersistedSeedAfterTeardown,
   isAnonymousCloudPrincipal,
   isRecoverableCloudFrameRejection,
   shouldDiscardPersistedSeedOnRejection,
@@ -154,6 +155,10 @@ export function useCloudViewerSession({
   // Set when a seeded session's replayed changes were rejected by the room:
   // the next connect attempt must bootstrap (survives the effect re-run).
   const skipSeedOnceRef = useRef(false);
+  // The escalation's dispose-flush → clear chain (never rejects). The next
+  // attempt's persistence arming awaits it (clear-then-arm), so a
+  // straggling clear can never delete a fresh attempt's first record.
+  const pendingSeedDiscardRef = useRef<Promise<void>>(Promise.resolve());
   const projectedWidgetCommIdsRef = useRef(new Set<string>());
   const outputResolutionCacheRef = useRef(createOutputResolutionCache());
   const incrementalOutputCacheRef = useRef(new Map<string, NotebookStoreJupyterOutput>());
@@ -386,8 +391,10 @@ export function useCloudViewerSession({
     let reconnectTimer: ReturnType<typeof setTimeout> | null = null;
     let pendingTransport: CloudWebSocketTransport | null = null;
     // Recoverable sync rejections on the CURRENT connection (reset on each
-    // cloud_room_ready): the first recovers in place, a repeat escalates.
-    let recoverableRejections = 0;
+    // cloud_room_ready): the first recovers in place, pipelined rejections
+    // that cannot have observed the resync absorb, a post-resync repeat
+    // escalates.
+    const rejectionTracker = new CloudRecoverableRejectionTracker();
     let ranConnectionDiagnostics = false;
     // Local-first persistence is fail-open: no IndexedDB (private mode,
     // SSR) means no adapter and the session runs exactly as before.
@@ -433,6 +440,11 @@ export function useCloudViewerSession({
       if (!liveRuntime) return Promise.resolve();
       liveRuntimeRef.current = null;
       setCrdtCommWriter(null);
+      // Invalidate in-flight materializations before the handle is freed —
+      // their shouldContinue/sequence guards trip instead of touching a
+      // freed handle (the unmount path gets this from the disposed flag;
+      // mid-effect escalation teardowns need it here).
+      materializeSequence += 1;
       // Capture unsaved persistence state before the handle is freed —
       // flushNow reads the snapshot bytes synchronously, and dispose()
       // guarantees no later capture touches the freed handle. The returned
@@ -462,19 +474,26 @@ export function useCloudViewerSession({
       // Anonymous principals are per-connection: their records can never
       // seed and would only churn storage.
       if (isAnonymousCloudPrincipal(principal)) return;
-      // Snapshot the raw NotebookHandle (full NotebookDoc bytes) on every
-      // doc change; the controller throttles, self-disables after repeated
-      // failures, and never throws into the session.
-      notebookPersistence = new NotebookDocPersistence({
-        adapter: persistenceAdapter,
-        notebookId: config.notebookId,
-        principal,
-        changes$: liveRuntime.engine.notebookDocChanged$,
-        getSaveBytes: () => liveRuntime.handle.save(),
-        getHeadsHex: () => liveRuntime.handle.get_heads_hex(),
-        onError: (error) => console.warn("[notebook-cloud] notebook persistence error", error),
+      // Strict clear-then-arm: a previous escalation's dispose-flush → clear
+      // chain (never rejects) must settle before this attempt writes its
+      // first record, or the straggling clear could delete it.
+      void pendingSeedDiscardRef.current.then(() => {
+        if (disposed || liveRuntimeRef.current !== liveRuntime) return;
+        if (notebookPersistence && notebookPersistencePrincipal === principal) return;
+        // Snapshot the raw NotebookHandle (full NotebookDoc bytes) on every
+        // doc change; the controller throttles, self-disables after repeated
+        // failures, and never throws into the session.
+        notebookPersistence = new NotebookDocPersistence({
+          adapter: persistenceAdapter,
+          notebookId: config.notebookId,
+          principal,
+          changes$: liveRuntime.engine.notebookDocChanged$,
+          getSaveBytes: () => liveRuntime.handle.save(),
+          getHeadsHex: () => liveRuntime.handle.get_heads_hex(),
+          onError: (error) => console.warn("[notebook-cloud] notebook persistence error", error),
+        });
+        notebookPersistencePrincipal = principal;
       });
-      notebookPersistencePrincipal = principal;
     };
     // Transport-level connection losses are informational: the transport
     // owns the retry loop, the preserved handle keeps unflushed local
@@ -671,26 +690,36 @@ export function useCloudViewerSession({
         }
         if (message.type === "cloud_room_ready") {
           markCloudViewerLoadMilestone("live-room-ready");
-          recoverableRejections = 0; // fresh connection, fresh strike count
+          rejectionTracker.reset(); // fresh connection, fresh strike count
           setConnectionError(null);
           setConnectionScope(message.connection_scope);
           setConnectionActorLabel(message.actor_label);
         }
         if (message.type === "cloud_frame_rejected") {
           if (isRecoverableCloudFrameRejection(message)) {
-            recoverableRejections += 1;
             const liveRuntime = liveRuntimeRef.current;
+            const disposition = rejectionTracker.record(liveRuntime !== null);
+            if (disposition === "absorb") {
+              // Pipelined rejection: it cannot have observed the in-flight
+              // strike-1 resync (several AUTOMERGE_SYNC frames are routinely
+              // outstanding and acks carry no id) — same divergence event.
+              return;
+            }
             setStatus({
               kind: "loading",
               message: "Resynchronizing live notebook room after a rejected sync frame...",
             });
-            if (
-              classifyRecoverableRejection(recoverableRejections, liveRuntime !== null) ===
-              "resync_in_place"
-            ) {
+            if (disposition === "resync_in_place" && liveRuntime) {
               // First strike: sync state diverged from the room — reset and
-              // resync on the live connection, no teardown.
-              liveRuntime?.engine.resetAndResync();
+              // resync on the live connection, no teardown. The strike only
+              // clears once the resync's outbound flush has actually been
+              // delivered, so only rejections that could have observed it
+              // count toward escalation.
+              liveRuntime.engine.resetAndResync();
+              void liveRuntime.engine
+                .flushAndWait()
+                .catch(() => undefined)
+                .then(() => rejectionTracker.resyncSettled());
               return;
             }
             const reason = new Error(`Room rejected sync frame: ${message.reason}`);
@@ -701,17 +730,13 @@ export function useCloudViewerSession({
               // teardown's flushNow re-writes the record with the rejected
               // changes — then clear once that write has settled, and
               // bootstrap the next attempt. The rejected changes are
-              // unauthorized; losing them is the intended outcome.
+              // unauthorized; losing them is the intended outcome. The chain
+              // is stashed so the next attempt arms strictly clear-then-arm.
               skipSeedOnceRef.current = true;
-              disposeCurrentRuntime()
-                .catch(() => undefined)
-                .then(() => persistenceSeed.clear())
-                .catch((error: unknown) =>
-                  console.warn(
-                    "[notebook-cloud] failed to clear rejected persisted NotebookDoc record",
-                    error,
-                  ),
-                );
+              pendingSeedDiscardRef.current = discardPersistedSeedAfterTeardown(
+                disposeCurrentRuntime,
+                persistenceSeed.clear,
+              );
             } else if (!liveRuntime) {
               // A rejection before the runtime resolved means the in-flight
               // bootstrap flush was refused. We cannot tell from here

--- a/apps/notebook-cloud/viewer/live-sync.ts
+++ b/apps/notebook-cloud/viewer/live-sync.ts
@@ -190,12 +190,7 @@ export async function connectCloudSyncRuntime({
     // Mutable connection identity: presence encoders and the runtime's
     // identity getters always read the LATEST handshake's values, so a
     // reconnect never sends presence under a dead peer id.
-    const identity = {
-      actorLabel: ready.actor_label,
-      peerId: ready.peer_id,
-      peerLabel: cloudRoomReadyPeerLabel(ready),
-      connectionScope: normalizeConnectionScope(ready.connection_scope),
-    };
+    const identity = cloudConnectionIdentityFromReady(ready);
     const engine = new SyncEngine({
       getHandle: () => syncHandle,
       transport,
@@ -234,19 +229,10 @@ export async function connectCloudSyncRuntime({
       transport,
       seededFromPersistence: persistenceSeedOutcome === "seeded",
       persistenceSeedOutcome,
-      applyRoomReady: (nextReady) => {
-        if (nextReady.peer_id === identity.peerId) {
-          // The connection already adopted (roomReady$ replays the latest
-          // handshake to new subscribers).
-          return false;
-        }
-        identity.actorLabel = nextReady.actor_label;
-        identity.peerId = nextReady.peer_id;
-        identity.peerLabel = cloudRoomReadyPeerLabel(nextReady);
-        identity.connectionScope = normalizeConnectionScope(nextReady.connection_scope);
-        reestablishCloudConnection(handle, engine, nextReady.actor_label);
-        return true;
-      },
+      applyRoomReady: (nextReady) =>
+        applyCloudRoomReady(identity, nextReady, () =>
+          reestablishCloudConnection(handle, engine, nextReady.actor_label),
+        ),
       sendCursorPresence: (cellId, line, column) => {
         sendPresence(
           encodeCursorPresenceAfterInit(
@@ -319,6 +305,45 @@ export function reestablishCloudConnection(
   handle.set_actor(actorLabel);
   engine.resetForBootstrap();
   engine.resetAndResync();
+}
+
+/** Mutable per-runtime connection identity (latest handshake's values). */
+export interface CloudConnectionIdentity {
+  actorLabel: string;
+  peerId: string;
+  peerLabel: string;
+  connectionScope: ConnectionScope;
+}
+
+export function cloudConnectionIdentityFromReady(ready: CloudRoomReady): CloudConnectionIdentity {
+  return {
+    actorLabel: ready.actor_label,
+    peerId: ready.peer_id,
+    peerLabel: cloudRoomReadyPeerLabel(ready),
+    connectionScope: normalizeConnectionScope(ready.connection_scope),
+  };
+}
+
+/**
+ * Adopt a handshake on a preserved runtime's identity: dedup against the
+ * connection already adopted (`roomReady$` replays the latest handshake to
+ * new subscribers), update the mutable identity so presence encoders stamp
+ * the fresh peer id, then run the synchronous re-establish.
+ */
+export function applyCloudRoomReady(
+  identity: CloudConnectionIdentity,
+  ready: CloudRoomReady,
+  reestablish: () => void,
+): boolean {
+  if (ready.peer_id === identity.peerId) {
+    return false;
+  }
+  identity.actorLabel = ready.actor_label;
+  identity.peerId = ready.peer_id;
+  identity.peerLabel = cloudRoomReadyPeerLabel(ready);
+  identity.connectionScope = normalizeConnectionScope(ready.connection_scope);
+  reestablish();
+  return true;
 }
 
 /**
@@ -521,21 +546,79 @@ export function shouldDiscardPersistedSeedOnRejection(
   return seededFromPersistence && isRecoverableCloudFrameRejection(message);
 }
 
-export type CloudRejectionDisposition = "resync_in_place" | "escalate";
+export type CloudRejectionDisposition = "absorb" | "resync_in_place" | "escalate";
 
 /**
+ * Per-connection strike tracker for recoverable sync rejections.
+ *
  * First recoverable sync rejection on a connection: recover in place —
  * `resetAndResync()` on the live connection, no teardown. A repeat within
  * the same connection means in-place recovery cannot converge (the resync
  * regenerated the same refused content), so escalate to the full teardown
  * path, where the poison-pill seed discard applies. A rejection before the
  * runtime exists escalates directly — there is nothing to resync in place.
+ *
+ * Pipelining guard: the hosted-room ack protocol carries only frame_type
+ * (no id), and the engine routinely has several AUTOMERGE_SYNC frames in
+ * flight (debounced flushes, inline replies). A rejection that arrives
+ * before the strike-1 resync's outbound flush has been DELIVERED cannot
+ * have observed the resync — it is the same divergence event, not evidence
+ * that recovery failed. Such rejections `"absorb"` into strike 1; callers
+ * mark delivery via `resyncSettled()` (e.g. after `engine.flushAndWait()`),
+ * and only post-delivery rejections escalate. The poison-pill seed discard
+ * therefore never fires from a pipelined rejection.
  */
-export function classifyRecoverableRejection(
-  rejectionsThisConnection: number,
-  hasLiveRuntime: boolean,
-): CloudRejectionDisposition {
-  return rejectionsThisConnection <= 1 && hasLiveRuntime ? "resync_in_place" : "escalate";
+export class CloudRecoverableRejectionTracker {
+  private strikes = 0;
+  private resyncPending = false;
+
+  /** Reset on each cloud_room_ready (fresh connection, fresh strike count). */
+  reset(): void {
+    this.strikes = 0;
+    this.resyncPending = false;
+  }
+
+  /**
+   * Record a recoverable rejection and return its disposition. For
+   * `"resync_in_place"` the caller must run the resync and call
+   * `resyncSettled()` once its outbound flush has been delivered.
+   */
+  record(hasLiveRuntime: boolean): CloudRejectionDisposition {
+    if (this.resyncPending) {
+      return "absorb";
+    }
+    this.strikes += 1;
+    if (this.strikes <= 1 && hasLiveRuntime) {
+      this.resyncPending = true;
+      return "resync_in_place";
+    }
+    return "escalate";
+  }
+
+  /** The strike-1 resync's outbound flush was delivered (or failed terminally). */
+  resyncSettled(): void {
+    this.resyncPending = false;
+  }
+}
+
+/**
+ * Poison-pill discard chain for an escalated rejection on a seeded session:
+ * dispose FIRST — the teardown's `flushNow` re-writes the record with the
+ * rejected changes — then clear once that write has settled. The returned
+ * promise never rejects; callers must gate the next attempt's persistence
+ * arming on it (clear-then-arm), or a straggling clear could delete the
+ * next attempt's first persisted record.
+ */
+export function discardPersistedSeedAfterTeardown(
+  disposeRuntime: () => Promise<void>,
+  clearSeed: () => Promise<void>,
+): Promise<void> {
+  return disposeRuntime()
+    .catch(() => undefined)
+    .then(() => clearSeed())
+    .catch((error: unknown) => {
+      console.warn("[notebook-cloud] failed to clear rejected persisted NotebookDoc record", error);
+    });
 }
 
 export async function withReadyTimeout<T>(
@@ -599,6 +682,8 @@ export class CloudWebSocketTransport implements NotebookTransport {
 
   private socket: WebSocket | null = null;
   private detachSocket: (() => void) | null = null;
+  /** True once the CURRENT connection's cloud_room_ready was handled. */
+  private connectionReady = false;
   /** Bumped per connect attempt and on disconnect to invalidate stale async work. */
   private connectEpoch = 0;
   /** Consecutive attempts without a cloud_room_ready ack (backoff input). */
@@ -638,9 +723,19 @@ export class CloudWebSocketTransport implements NotebookTransport {
   readonly connectionStatus$: Observable<ConnectionStatus> = this._status$.asObservable();
   /** navigator 'online': skip the rest of the current backoff wait. */
   private readonly handleBrowserOnline = () => {
-    if (this.manualDisconnect || this.retryTimer === null) return;
-    this.clearRetryTimer();
-    void this.connect();
+    if (this.manualDisconnect) return;
+    if (this.retryTimer !== null) {
+      this.clearRetryTimer();
+      void this.connect();
+      return;
+    }
+    // No retry timer and no socket means an attempt is parked awaiting
+    // connectTarget() (auth resolution can outlive the outage that caused
+    // the reconnect). Connectivity returning supersedes it: connect() bumps
+    // the epoch, so the late-settling target is discarded harmlessly.
+    if (this.socket === null) {
+      void this.connect();
+    }
   };
 
   constructor(options: CloudWebSocketTransportOptions) {
@@ -673,7 +768,14 @@ export class CloudWebSocketTransport implements NotebookTransport {
 
     let target: CloudConnectTarget;
     try {
-      target = await this.options.connectTarget();
+      // Bounded by the per-attempt budget: a hung auth fetch must become a
+      // normal failed attempt riding connectionLost → backoff, not a wedge
+      // with no socket, no handshake timer, and no retry timer.
+      target = await withReadyTimeout(
+        this.options.connectTarget(),
+        this.handshakeTimeoutMs,
+        `cloud sync connect target did not settle within ${this.handshakeTimeoutMs}ms`,
+      );
     } catch (error) {
       if (epoch !== this.connectEpoch || this.manualDisconnect) return;
       this.connectionLost(
@@ -704,6 +806,7 @@ export class CloudWebSocketTransport implements NotebookTransport {
     }
     socket.binaryType = "arraybuffer";
     this.socket = socket;
+    this.connectionReady = false;
     const onMessage = (event: MessageEvent) => {
       if (socket !== this.socket) return; // superseded connection
       void this.handleMessage(event.data, socket).catch((error: unknown) => {
@@ -736,6 +839,7 @@ export class CloudWebSocketTransport implements NotebookTransport {
   private connectionLost(reason: Error, socket: WebSocket | null): void {
     if (socket !== null && socket !== this.socket) return; // superseded connection
     this.teardownSocket();
+    this.connectionReady = false;
     this.clearHandshakeTimer();
     // Pending FIFO frame ACKs cannot span sockets.
     this.rejectPendingFrameAcks(reason);
@@ -824,6 +928,13 @@ export class CloudWebSocketTransport implements NotebookTransport {
       // Drop, don't buffer: the engine rolls back via cancel_last_flush and
       // regenerates from sync state after the next handshake.
       throw new Error("cloud sync socket is not open");
+    }
+    if (!this.connectionReady) {
+      // The open→ready handshake window: frames sent now would go out under
+      // the PREVIOUS connection's sync state and actor (re-establish runs on
+      // cloud_room_ready). Drop-don't-buffer governs here too — the engine
+      // rolls back and the post-ready resync regenerates everything.
+      throw new Error("cloud sync connection is not ready");
     }
     const frame = new Uint8Array(payload.byteLength + 1);
     frame[0] = frameType;
@@ -936,6 +1047,9 @@ export class CloudWebSocketTransport implements NotebookTransport {
   private handleRoomReady(control: CloudRoomReady): void {
     this.failedAttempts = 0; // backoff resets on the app-level ack
     this.everReady = true;
+    // Before the roomReady$ emission: subscribers' resync flush sends on
+    // this connection within the same tick.
+    this.connectionReady = true;
     this.clearHandshakeTimer();
     this.setStatus("online");
     if (!this.readySettled) {

--- a/apps/notebook-cloud/viewer/live-sync.ts
+++ b/apps/notebook-cloud/viewer/live-sync.ts
@@ -1,4 +1,4 @@
-import { BehaviorSubject, type Observable } from "rxjs";
+import { BehaviorSubject, ReplaySubject, type Observable } from "rxjs";
 import {
   SyncEngine,
   splitNotebookActorPrincipalOperator,
@@ -30,11 +30,19 @@ import {
   type NotebookHandle,
 } from "./runtimed-wasm-client";
 
+export type CloudRoomReady = Extract<SessionControlMessage, { type: "cloud_room_ready" }>;
+
+export interface CloudConnectTarget {
+  url: URL;
+  protocols: string[];
+}
+
 export interface CloudSyncRuntime {
-  actorLabel: string;
-  connectionScope: ConnectionScope;
-  peerId: string;
-  peerLabel: string;
+  /** Latest connection identity — updated on every cloud_room_ready. */
+  readonly actorLabel: string;
+  readonly connectionScope: ConnectionScope;
+  readonly peerId: string;
+  readonly peerLabel: string;
   handle: NotebookHandle;
   engine: SyncEngine;
   transport: CloudWebSocketTransport;
@@ -42,6 +50,16 @@ export interface CloudSyncRuntime {
   seededFromPersistence: boolean;
   /** How the persisted-seed attempt resolved; "read_failed" must not arm saves. */
   persistenceSeedOutcome: CloudPersistenceSeedOutcome;
+  /**
+   * Adopt a reconnect handshake on the PRESERVED runtime: update identity,
+   * `set_actor` with the fresh label, reset engine caches and sync state.
+   * Returns false when the ready belongs to the connection already adopted
+   * (`roomReady$` replays the latest handshake to new subscribers).
+   *
+   * Must be invoked synchronously from the `roomReady$` subscription — see
+   * `reestablishCloudConnection` for the ordering constraint.
+   */
+  applyRoomReady: (ready: CloudRoomReady) => boolean;
   sendCursorPresence: (cellId: string, line: number, column: number) => void;
   sendSelectionPresence: (
     cellId: string,
@@ -54,15 +72,28 @@ export interface CloudSyncRuntime {
 }
 
 export interface CloudSyncConnectOptions {
-  syncEndpoint: string;
+  /**
+   * Per-attempt connection target (see `createCloudConnectTarget`). The
+   * transport re-invokes it on every retry so auth material is re-resolved
+   * and the operator nonce is re-minted.
+   */
+  connectTarget: () => Promise<CloudConnectTarget>;
   runtimedWasmModulePath: string;
   runtimedWasmPath: string;
-  sessionId: string;
-  auth: CloudSyncAuth;
   /** Locally persisted NotebookDoc seed; omitted when storage is unavailable. */
   persistence?: CloudSyncPersistenceSeed;
   onControl?: (message: SessionControlMessage) => void;
-  onDisconnect?: (reason: Error) => void;
+  /**
+   * Informational: a connection dropped or an attempt failed. The transport
+   * keeps retrying — this is a notice surface, not a teardown signal.
+   */
+  onConnectionLost?: (reason: Error) => void;
+  /**
+   * Receives the transport as soon as it exists, so callers can disconnect
+   * an in-flight connect on unmount — `ready` may stay pending for as long
+   * as the retry loop runs.
+   */
+  onTransportCreated?: (transport: CloudWebSocketTransport) => void;
 }
 
 export interface CloudSyncPersistenceSeed {
@@ -90,8 +121,14 @@ export interface ResolvedCloudNotebookHandle<Handle> {
 
 type FrameListener = Parameters<NotebookTransport["onFrame"]>[0];
 
-const LIVE_SYNC_READY_TIMEOUT_MS = 30_000;
+/** Per-attempt bound on cloud_room_ready after the socket is created. */
+const HANDSHAKE_TIMEOUT_MS = 30_000;
 const CLOUD_REQUEST_TIMEOUT_MS = 30_000;
+
+const RECONNECT_BASE_DELAY_MS = 1_000;
+const RECONNECT_MAX_DELAY_MS = 30_000;
+/** ±50% full jitter on every retry delay. */
+const RECONNECT_JITTER_RATIO = 0.5;
 
 /**
  * Bound on the persisted-seed IndexedDB read at connect time. A hung IDB
@@ -123,23 +160,22 @@ export function cloudSyncAuthFromLocalStorage(): CloudSyncAuth {
 }
 
 export async function connectCloudSyncRuntime({
-  syncEndpoint,
+  connectTarget,
   runtimedWasmModulePath,
   runtimedWasmPath,
-  sessionId,
-  auth,
   persistence,
   onControl,
-  onDisconnect,
+  onConnectionLost,
+  onTransportCreated,
 }: CloudSyncConnectOptions): Promise<CloudSyncRuntime> {
-  const url = syncUrl(syncEndpoint, sessionId, auth);
-  const transport = new CloudWebSocketTransport(url, auth.protocols, onControl, onDisconnect);
+  const transport = new CloudWebSocketTransport({ connectTarget, onControl, onConnectionLost });
+  onTransportCreated?.(transport);
   try {
-    const ready = await withReadyTimeout(
-      transport.ready,
-      LIVE_SYNC_READY_TIMEOUT_MS,
-      `notebook cloud WebSocket did not become ready within ${LIVE_SYNC_READY_TIMEOUT_MS}ms`,
-    );
+    // No timeout: the transport retries with backoff until manual
+    // disconnect, so initial-connect failures ride the same loop instead
+    // of dead-ending the session. `ready` resolves on the first successful
+    // handshake, whenever that happens.
+    const ready = await transport.ready;
     const wasmModuleUrl = new URL(runtimedWasmModulePath, location.href);
     const wasmUrl = new URL(runtimedWasmPath, location.href);
     const { handle, outcome: persistenceSeedOutcome } = await resolveCloudNotebookHandle({
@@ -151,81 +187,187 @@ export async function connectCloudSyncRuntime({
         loadNotebookHandleFromBytes(bytes, ready.actor_label, wasmModuleUrl, wasmUrl),
     });
     const syncHandle = syncableCloudHandle(handle);
-    const peerLabel = cloudRoomReadyPeerLabel(ready);
-    const heartbeatPeerId = ready.peer_id;
-    const connectionScope = normalizeConnectionScope(ready.connection_scope);
+    // Mutable connection identity: presence encoders and the runtime's
+    // identity getters always read the LATEST handshake's values, so a
+    // reconnect never sends presence under a dead peer id.
+    const identity = {
+      actorLabel: ready.actor_label,
+      peerId: ready.peer_id,
+      peerLabel: cloudRoomReadyPeerLabel(ready),
+      connectionScope: normalizeConnectionScope(ready.connection_scope),
+    };
     const engine = new SyncEngine({
       getHandle: () => syncHandle,
       transport,
       presenceHeartbeat: {
         intervalMs: 15_000,
-        encode: () => encodeHeartbeatPresenceAfterInit(heartbeatPeerId),
+        encode: () => encodeHeartbeatPresenceAfterInit(identity.peerId),
       },
       logger: consoleSyncLogger,
     });
 
     startCloudBootstrapSync(engine);
 
+    const sendPresence = (payload: Uint8Array, label: string) => {
+      void transport
+        .sendFrame(FrameType.PRESENCE, payload)
+        .catch((error: unknown) =>
+          console.warn(`[notebook-cloud] ${label} presence failed`, error),
+        );
+    };
+
     return {
-      actorLabel: ready.actor_label,
-      connectionScope,
-      peerId: ready.peer_id,
-      peerLabel,
+      get actorLabel() {
+        return identity.actorLabel;
+      },
+      get connectionScope() {
+        return identity.connectionScope;
+      },
+      get peerId() {
+        return identity.peerId;
+      },
+      get peerLabel() {
+        return identity.peerLabel;
+      },
       handle,
       engine,
       transport,
       seededFromPersistence: persistenceSeedOutcome === "seeded",
       persistenceSeedOutcome,
+      applyRoomReady: (nextReady) => {
+        if (nextReady.peer_id === identity.peerId) {
+          // The connection already adopted (roomReady$ replays the latest
+          // handshake to new subscribers).
+          return false;
+        }
+        identity.actorLabel = nextReady.actor_label;
+        identity.peerId = nextReady.peer_id;
+        identity.peerLabel = cloudRoomReadyPeerLabel(nextReady);
+        identity.connectionScope = normalizeConnectionScope(nextReady.connection_scope);
+        reestablishCloudConnection(handle, engine, nextReady.actor_label);
+        return true;
+      },
       sendCursorPresence: (cellId, line, column) => {
-        const payload = encodeCursorPresenceAfterInit(
-          heartbeatPeerId,
-          peerLabel,
-          ready.actor_label,
-          cellId,
-          line,
-          column,
+        sendPresence(
+          encodeCursorPresenceAfterInit(
+            identity.peerId,
+            identity.peerLabel,
+            identity.actorLabel,
+            cellId,
+            line,
+            column,
+          ),
+          "cursor",
         );
-        void transport
-          .sendFrame(FrameType.PRESENCE, payload)
-          .catch((error: unknown) =>
-            console.warn("[notebook-cloud] cursor presence failed", error),
-          );
       },
       sendSelectionPresence: (cellId, anchorLine, anchorCol, headLine, headCol) => {
-        const payload = encodeSelectionPresenceAfterInit(
-          heartbeatPeerId,
-          peerLabel,
-          ready.actor_label,
-          cellId,
-          anchorLine,
-          anchorCol,
-          headLine,
-          headCol,
+        sendPresence(
+          encodeSelectionPresenceAfterInit(
+            identity.peerId,
+            identity.peerLabel,
+            identity.actorLabel,
+            cellId,
+            anchorLine,
+            anchorCol,
+            headLine,
+            headCol,
+          ),
+          "selection",
         );
-        void transport
-          .sendFrame(FrameType.PRESENCE, payload)
-          .catch((error: unknown) =>
-            console.warn("[notebook-cloud] selection presence failed", error),
-          );
       },
       sendInteractionPresence: (target) => {
-        const payload = encodeInteractionPresenceAfterInit(
-          heartbeatPeerId,
-          peerLabel,
-          ready.actor_label,
-          target,
+        sendPresence(
+          encodeInteractionPresenceAfterInit(
+            identity.peerId,
+            identity.peerLabel,
+            identity.actorLabel,
+            target,
+          ),
+          "interaction",
         );
-        void transport
-          .sendFrame(FrameType.PRESENCE, payload)
-          .catch((error: unknown) =>
-            console.warn("[notebook-cloud] interaction presence failed", error),
-          );
       },
     };
   } catch (error) {
     transport.disconnect();
     throw error;
   }
+}
+
+/**
+ * Re-establish per-connection sync state on a PRESERVED runtime after a
+ * reconnect handshake — mirrors the daemon cloud agent's reconnect
+ * (runtime_agent.rs keeps the kernel, queue, and docs; only sync states
+ * are recreated).
+ *
+ * Ordering constraint: this must run synchronously inside the roomReady$
+ * emission. The room host kicks host-initiated sync immediately after
+ * cloud_room_ready, and an inbound sync frame applied against the previous
+ * connection's sync state is garbage. The transport emits roomReady$
+ * before dispatching any frame from the new connection, and every call in
+ * here is synchronous WASM — no awaits allowed before these calls.
+ *
+ * Actor safety: preserve the handle XOR reuse the actor label. The handle
+ * is preserved (unflushed local edits live in it), so it MUST adopt the
+ * new connection's fresh label — set_actor starts a fresh (actor, seq)
+ * chain, avoiding DuplicateSeqNumber.
+ */
+export function reestablishCloudConnection(
+  handle: Pick<NotebookHandle, "set_actor">,
+  engine: Pick<SyncEngine, "resetForBootstrap" | "resetAndResync">,
+  actorLabel: string,
+): void {
+  handle.set_actor(actorLabel);
+  engine.resetForBootstrap();
+  engine.resetAndResync();
+}
+
+/**
+ * Mint the per-connection-attempt session id.
+ *
+ * Load-bearing for actor uniqueness: the worker derives the anonymous
+ * principal and the `browser:<sessionId>` operator nonce from this value
+ * and only rewrites the principal segment, so a collision would reuse an
+ * actor label across doc instances (DuplicateSeqNumber). The fallbacks for
+ * environments without crypto.randomUUID must stay collision-resistant —
+ * never a bare timestamp.
+ */
+export function mintCloudSessionId(): string {
+  if (typeof crypto !== "undefined" && crypto.randomUUID) {
+    return crypto.randomUUID();
+  }
+  if (typeof crypto !== "undefined" && crypto.getRandomValues) {
+    const bytes = crypto.getRandomValues(new Uint8Array(16));
+    return Array.from(bytes, (byte) => byte.toString(16).padStart(2, "0")).join("");
+  }
+  return `${Date.now().toString(36)}-${Math.random().toString(36).slice(2)}`;
+}
+
+/**
+ * Build the per-attempt connect target factory for the transport's retry
+ * loop. Each invocation re-resolves auth (tokens expire mid-session) and
+ * mints a FRESH operator nonce.
+ *
+ * Fresh-per-attempt nonce rationale: the actor-safety rule is "preserve
+ * the handle XOR reuse the actor label". A preserved handle with a NEW
+ * label is safe (set_actor starts a fresh seq chain); a fresh handle with
+ * a REUSED label collides (DuplicateSeqNumber). Fresh-per-attempt is the
+ * universally safe choice for both shapes and matches the previous
+ * per-effect-run behavior.
+ */
+export function createCloudConnectTarget({
+  syncEndpoint,
+  resolveAuth,
+  mintSessionId = mintCloudSessionId,
+}: {
+  syncEndpoint: string;
+  resolveAuth: (sessionId: string) => Promise<CloudSyncAuth> | CloudSyncAuth;
+  mintSessionId?: () => string;
+}): () => Promise<CloudConnectTarget> {
+  return async () => {
+    const sessionId = mintSessionId();
+    const auth = await resolveAuth(sessionId);
+    return { url: syncUrl(syncEndpoint, sessionId, auth), protocols: auth.protocols };
+  };
 }
 
 export function normalizeConnectionScope(value: string): ConnectionScope {
@@ -379,6 +521,23 @@ export function shouldDiscardPersistedSeedOnRejection(
   return seededFromPersistence && isRecoverableCloudFrameRejection(message);
 }
 
+export type CloudRejectionDisposition = "resync_in_place" | "escalate";
+
+/**
+ * First recoverable sync rejection on a connection: recover in place —
+ * `resetAndResync()` on the live connection, no teardown. A repeat within
+ * the same connection means in-place recovery cannot converge (the resync
+ * regenerated the same refused content), so escalate to the full teardown
+ * path, where the poison-pill seed discard applies. A rejection before the
+ * runtime exists escalates directly — there is nothing to resync in place.
+ */
+export function classifyRecoverableRejection(
+  rejectionsThisConnection: number,
+  hasLiveRuntime: boolean,
+): CloudRejectionDisposition {
+  return rejectionsThisConnection <= 1 && hasLiveRuntime ? "resync_in_place" : "escalate";
+}
+
 export async function withReadyTimeout<T>(
   ready: Promise<T>,
   timeoutMs: number,
@@ -397,96 +556,286 @@ export async function withReadyTimeout<T>(
   }
 }
 
+export interface CloudWebSocketTransportOptions {
+  /**
+   * Resolve the connection target for one attempt. Re-invoked on every
+   * retry so auth material is re-resolved (tokens expire mid-session) and
+   * the operator nonce is re-minted (`createCloudConnectTarget`).
+   */
+  connectTarget: () => Promise<CloudConnectTarget>;
+  onControl?: (message: SessionControlMessage) => void;
+  /**
+   * Informational: an established or in-progress connection was lost. The
+   * retry loop keeps running — this is a notice surface, not a teardown
+   * signal. Never fires for manual `disconnect()`.
+   */
+  onConnectionLost?: (reason: Error) => void;
+  /** Backoff/handshake tuning for tests. */
+  reconnectBaseDelayMs?: number;
+  reconnectMaxDelayMs?: number;
+  handshakeTimeoutMs?: number;
+  /** Jitter source (default Math.random); injectable for deterministic tests. */
+  random?: () => number;
+}
+
+/**
+ * Multi-connection cloud transport: one re-entrant connect loop serves the
+ * initial connect and every retry (exponential backoff + full jitter,
+ * reset on the cloud_room_ready app-level ack, short-circuit on the
+ * browser `online` event, retry forever until manual `disconnect()`).
+ *
+ * Drop, don't buffer: sends while the current socket is not OPEN reject,
+ * and pending FIFO frame ACKs are rejected per connection loss — they
+ * cannot span sockets. Sync correctness lives in the protocol: the engine
+ * rolls back via `cancel_last_flush` and regenerates from sync state after
+ * the next handshake.
+ */
 export class CloudWebSocketTransport implements NotebookTransport {
-  private socket: WebSocket;
+  private readonly options: CloudWebSocketTransportOptions;
+  private readonly reconnectBaseDelayMs: number;
+  private readonly reconnectMaxDelayMs: number;
+  private readonly handshakeTimeoutMs: number;
+  private readonly random: () => number;
+
+  private socket: WebSocket | null = null;
+  private detachSocket: (() => void) | null = null;
+  /** Bumped per connect attempt and on disconnect to invalidate stale async work. */
+  private connectEpoch = 0;
+  /** Consecutive attempts without a cloud_room_ready ack (backoff input). */
+  private failedAttempts = 0;
+  private retryTimer: ReturnType<typeof setTimeout> | null = null;
+  private handshakeTimer: ReturnType<typeof setTimeout> | null = null;
+  private manualDisconnect = false;
+  private everReady = false;
+  private readySettled = false;
   private listeners = new Set<FrameListener>();
   private queuedFrames: number[][] = [];
   // Hosted room accept/reject controls currently carry only the frame type, not
   // a request id, so pending acknowledgements are matched FIFO per frame type.
   private pendingFrameAcks = new Map<number, PendingFrameAck[]>();
-  private readySettled = false;
-  private readyResolved = false;
-  private closed = false;
-  private manualDisconnect = false;
-  private readyResolve!: (
-    message: Extract<SessionControlMessage, { type: "cloud_room_ready" }>,
-  ) => void;
+  private readyResolve!: (message: CloudRoomReady) => void;
   private readyReject!: (error: Error) => void;
-  readonly ready: Promise<Extract<SessionControlMessage, { type: "cloud_room_ready" }>>;
+  /**
+   * Resolves on the FIRST successful handshake; rejects only on manual
+   * disconnect. Later handshakes emit on `roomReady$`.
+   */
+  readonly ready: Promise<CloudRoomReady>;
+  private readonly _roomReady$ = new ReplaySubject<CloudRoomReady>(1);
+  /**
+   * Emits per successful cloud_room_ready handshake (initial and every
+   * reconnect) with the new peer_id / actor_label / connection_scope.
+   *
+   * Emission is synchronous within the ready message's handling, BEFORE
+   * any subsequent frame from that connection is dispatched — subscribers
+   * reset per-connection sync state in the same tick so host-initiated
+   * sync never lands on stale state. Replays the latest handshake to new
+   * subscribers (a reconnect during session setup is adopted on
+   * subscribe).
+   */
+  readonly roomReady$: Observable<CloudRoomReady> = this._roomReady$.asObservable();
   private status: ConnectionStatus = "connecting";
   private readonly _status$ = new BehaviorSubject<ConnectionStatus>("connecting");
   readonly connectionStatus$: Observable<ConnectionStatus> = this._status$.asObservable();
+  /** navigator 'online': skip the rest of the current backoff wait. */
+  private readonly handleBrowserOnline = () => {
+    if (this.manualDisconnect || this.retryTimer === null) return;
+    this.clearRetryTimer();
+    void this.connect();
+  };
 
-  constructor(
-    url: URL,
-    protocols: string[],
-    private readonly onControl?: (message: SessionControlMessage) => void,
-    private readonly onDisconnect?: (reason: Error) => void,
-  ) {
+  constructor(options: CloudWebSocketTransportOptions) {
+    this.options = options;
+    this.reconnectBaseDelayMs = options.reconnectBaseDelayMs ?? RECONNECT_BASE_DELAY_MS;
+    this.reconnectMaxDelayMs = options.reconnectMaxDelayMs ?? RECONNECT_MAX_DELAY_MS;
+    this.handshakeTimeoutMs = options.handshakeTimeoutMs ?? HANDSHAKE_TIMEOUT_MS;
+    this.random = options.random ?? Math.random;
     this.ready = new Promise((resolve, reject) => {
-      this.readyResolve = (message) => {
-        this.readySettled = true;
-        this.readyResolved = true;
-        this.setStatus("online");
-        resolve(message);
-      };
-      this.readyReject = (error) => {
-        this.readySettled = true;
-        reject(error);
-      };
+      this.readyResolve = resolve;
+      this.readyReject = reject;
     });
-    this.socket = protocols.length > 0 ? new WebSocket(url, protocols) : new WebSocket(url);
-    this.socket.binaryType = "arraybuffer";
-    this.socket.addEventListener("message", (event) => {
-      void this.handleMessage(event.data).catch((error: unknown) => {
+    // Callers that never await `ready` (tests, fire-and-forget teardown)
+    // must not produce an unhandled rejection on manual disconnect.
+    this.ready.catch(() => undefined);
+    if (typeof window !== "undefined") {
+      window.addEventListener("online", this.handleBrowserOnline);
+    }
+    void this.connect();
+  }
+
+  get connected(): boolean {
+    return !this.manualDisconnect && this.socket?.readyState === WebSocket.OPEN;
+  }
+
+  private async connect(): Promise<void> {
+    if (this.manualDisconnect) return;
+    const epoch = ++this.connectEpoch;
+    this.clearRetryTimer();
+
+    let target: CloudConnectTarget;
+    try {
+      target = await this.options.connectTarget();
+    } catch (error) {
+      if (epoch !== this.connectEpoch || this.manualDisconnect) return;
+      this.connectionLost(
+        error instanceof Error
+          ? new Error(`cloud sync connect target failed: ${error.message}`)
+          : new Error(`cloud sync connect target failed: ${String(error)}`),
+        null,
+      );
+      return;
+    }
+    if (epoch !== this.connectEpoch || this.manualDisconnect) return;
+
+    this.teardownSocket();
+    let socket: WebSocket;
+    try {
+      socket =
+        target.protocols.length > 0
+          ? new WebSocket(target.url, target.protocols)
+          : new WebSocket(target.url);
+    } catch (error) {
+      this.connectionLost(
+        error instanceof Error
+          ? new Error(`cloud sync socket creation failed: ${error.message}`)
+          : new Error(`cloud sync socket creation failed: ${String(error)}`),
+        null,
+      );
+      return;
+    }
+    socket.binaryType = "arraybuffer";
+    this.socket = socket;
+    const onMessage = (event: MessageEvent) => {
+      if (socket !== this.socket) return; // superseded connection
+      void this.handleMessage(event.data, socket).catch((error: unknown) => {
         const reason =
           error instanceof Error
             ? new Error(`cloud sync socket message failed: ${error.message}`)
             : new Error(`cloud sync socket message failed: ${String(error)}`);
-        if (!this.readySettled) {
-          this.readyReject(reason);
-        }
-        this.markClosed(reason);
-        this.socket.close();
+        this.connectionLost(reason, socket);
+        socket.close();
       });
-    });
-    this.socket.addEventListener("error", () => {
-      const reason = new Error(`cloud sync socket failed`);
-      if (!this.readySettled) {
-        this.readyReject(new Error(`failed to connect ${url.href}`));
-      }
-      this.markClosed(reason);
-    });
-    this.socket.addEventListener("close", (event) => {
+    };
+    const onError = () => {
+      this.connectionLost(new Error("cloud sync socket failed"), socket);
+    };
+    const onClose = (event: CloseEvent) => {
       const detail = event.reason ? `: ${event.reason}` : "";
-      const reason = new Error(`cloud sync socket closed (${event.code})${detail}`);
-      if (!this.readySettled) {
-        this.readyReject(new Error(`cloud sync socket closed before ready`));
-      }
-      this.markClosed(reason);
-    });
+      this.connectionLost(new Error(`cloud sync socket closed (${event.code})${detail}`), socket);
+    };
+    socket.addEventListener("message", onMessage as EventListener);
+    socket.addEventListener("error", onError);
+    socket.addEventListener("close", onClose as EventListener);
+    this.detachSocket = () => {
+      socket.removeEventListener("message", onMessage as EventListener);
+      socket.removeEventListener("error", onError);
+      socket.removeEventListener("close", onClose as EventListener);
+    };
+    this.armHandshakeTimer(socket);
   }
 
-  get connected(): boolean {
-    return !this.closed && this.socket.readyState === WebSocket.OPEN;
+  private connectionLost(reason: Error, socket: WebSocket | null): void {
+    if (socket !== null && socket !== this.socket) return; // superseded connection
+    this.teardownSocket();
+    this.clearHandshakeTimer();
+    // Pending FIFO frame ACKs cannot span sockets.
+    this.rejectPendingFrameAcks(reason);
+    // Frames queued from a dead connection are bound to that connection's
+    // sync state; never replay them into the next one.
+    this.queuedFrames = [];
+    if (this.manualDisconnect) return;
+    this.setStatus(this.everReady ? "reconnecting" : "connecting");
+    this.options.onConnectionLost?.(reason);
+    this.scheduleRetry();
+  }
+
+  private scheduleRetry(): void {
+    if (this.manualDisconnect || this.retryTimer !== null) return;
+    this.retryTimer = setTimeout(() => {
+      this.retryTimer = null;
+      void this.connect();
+    }, this.nextRetryDelay());
+  }
+
+  private nextRetryDelay(): number {
+    // Exponential backoff with full ±50% jitter so a fleet of dropped
+    // clients does not reconnect in lockstep. The attempt counter resets on
+    // cloud_room_ready (the app-level ack), NOT on WS open — a load
+    // balancer can accept sockets while the room is unreachable.
+    const exponent = Math.min(this.failedAttempts, 16);
+    this.failedAttempts += 1;
+    const base = Math.min(this.reconnectBaseDelayMs * 2 ** exponent, this.reconnectMaxDelayMs);
+    const jitter = 1 + RECONNECT_JITTER_RATIO * (2 * this.random() - 1);
+    return Math.round(base * jitter);
+  }
+
+  private armHandshakeTimer(socket: WebSocket): void {
+    this.clearHandshakeTimer();
+    this.handshakeTimer = setTimeout(() => {
+      this.handshakeTimer = null;
+      if (socket !== this.socket) return;
+      // The socket opened (or is still connecting) but the room never sent
+      // cloud_room_ready — recycle the attempt.
+      this.connectionLost(
+        new Error(`cloud room handshake did not complete within ${this.handshakeTimeoutMs}ms`),
+        socket,
+      );
+      socket.close();
+    }, this.handshakeTimeoutMs);
+  }
+
+  private teardownSocket(): void {
+    this.detachSocket?.();
+    this.detachSocket = null;
+    const socket = this.socket;
+    this.socket = null;
+    if (
+      socket &&
+      socket.readyState !== WebSocket.CLOSED &&
+      socket.readyState !== WebSocket.CLOSING
+    ) {
+      try {
+        socket.close();
+      } catch {
+        // already closing
+      }
+    }
+  }
+
+  private clearRetryTimer(): void {
+    if (this.retryTimer !== null) {
+      clearTimeout(this.retryTimer);
+      this.retryTimer = null;
+    }
+  }
+
+  private clearHandshakeTimer(): void {
+    if (this.handshakeTimer !== null) {
+      clearTimeout(this.handshakeTimer);
+      this.handshakeTimer = null;
+    }
   }
 
   async sendFrame(frameType: number, payload: Uint8Array): Promise<void> {
-    if (this.closed) {
-      return Promise.reject(new Error("cloud sync socket is closed"));
+    if (this.manualDisconnect) {
+      throw new Error("cloud sync socket is closed");
     }
-    await this.waitUntilOpen();
+    const socket = this.socket;
+    if (!socket || socket.readyState !== WebSocket.OPEN) {
+      // Drop, don't buffer: the engine rolls back via cancel_last_flush and
+      // regenerates from sync state after the next handshake.
+      throw new Error("cloud sync socket is not open");
+    }
     const frame = new Uint8Array(payload.byteLength + 1);
     frame[0] = frameType;
     frame.set(payload, 1);
     try {
-      this.socket.send(frame);
+      socket.send(frame);
     } catch (error) {
       const reason =
         error instanceof Error
           ? new Error(`cloud sync socket send failed: ${error.message}`)
           : new Error(`cloud sync socket send failed: ${String(error)}`);
-      this.markClosed(reason);
+      this.connectionLost(reason, socket);
       throw reason;
     }
   }
@@ -539,20 +888,36 @@ export class CloudWebSocketTransport implements NotebookTransport {
   }
 
   disconnect(): void {
+    if (this.manualDisconnect) return;
     this.manualDisconnect = true;
-    this.markClosed(new Error("cloud sync socket disconnected"));
-    this.socket.close();
+    this.connectEpoch += 1; // invalidate any in-flight connect attempt
+    this.clearRetryTimer();
+    this.clearHandshakeTimer();
+    if (typeof window !== "undefined") {
+      window.removeEventListener("online", this.handleBrowserOnline);
+    }
+    this.teardownSocket();
+    this.rejectPendingFrameAcks(new Error("cloud sync socket disconnected"));
+    this.listeners.clear();
+    this.queuedFrames = [];
+    if (!this.readySettled) {
+      this.readySettled = true;
+      this.readyReject(new Error("cloud sync transport disconnected before ready"));
+    }
+    this.setStatus("offline");
+    this._roomReady$.complete();
   }
 
-  private async handleMessage(data: unknown): Promise<void> {
+  private async handleMessage(data: unknown, socket: WebSocket): Promise<void> {
     const bytes = await bytesFromWebSocketMessage(data);
+    if (socket !== this.socket) return; // superseded while decoding
     if (bytes.byteLength === 0) return;
 
     if (bytes[0] === FrameType.SESSION_CONTROL) {
       const control = JSON.parse(new TextDecoder().decode(bytes.slice(1))) as SessionControlMessage;
-      this.onControl?.(control);
+      this.options.onControl?.(control);
       if (control.type === "cloud_room_ready") {
-        this.readyResolve(control);
+        this.handleRoomReady(control);
       } else if (control.type === "cloud_frame_accepted") {
         this.resolveFrameAck(control.frame_type);
       } else if (control.type === "cloud_frame_rejected") {
@@ -568,6 +933,23 @@ export class CloudWebSocketTransport implements NotebookTransport {
     this.emitFrame(frame);
   }
 
+  private handleRoomReady(control: CloudRoomReady): void {
+    this.failedAttempts = 0; // backoff resets on the app-level ack
+    this.everReady = true;
+    this.clearHandshakeTimer();
+    this.setStatus("online");
+    if (!this.readySettled) {
+      this.readySettled = true;
+      this.readyResolve(control);
+    }
+    // Synchronous emission BEFORE any subsequent frame is dispatched: the
+    // room host kicks host-initiated sync immediately after ready, and
+    // subscribers must reset per-connection sync state before the first
+    // frame of the new connection is applied. WS messages are delivered in
+    // order, so emitting inside the ready message's handling precedes them.
+    this._roomReady$.next(control);
+  }
+
   private emitFrame(frame: number[]): void {
     if (this.listeners.size === 0) {
       this.queuedFrames.push(frame);
@@ -576,42 +958,6 @@ export class CloudWebSocketTransport implements NotebookTransport {
 
     for (const listener of this.listeners) {
       listener(frame);
-    }
-  }
-
-  private waitUntilOpen(): Promise<void> {
-    if (this.socket.readyState === WebSocket.OPEN) {
-      return Promise.resolve();
-    }
-    if (
-      this.socket.readyState === WebSocket.CLOSED ||
-      this.socket.readyState === WebSocket.CLOSING
-    ) {
-      const reason = new Error("cloud sync socket is closed");
-      this.markClosed(reason);
-      return Promise.reject(reason);
-    }
-
-    return new Promise((resolve, reject) => {
-      this.socket.addEventListener("open", () => resolve(), { once: true });
-      this.socket.addEventListener("error", () => reject(new Error("cloud sync socket failed")), {
-        once: true,
-      });
-      this.socket.addEventListener("close", () => reject(new Error("cloud sync socket closed")), {
-        once: true,
-      });
-    });
-  }
-
-  private markClosed(reason: Error): void {
-    if (this.closed) return;
-    this.closed = true;
-    this.setStatus("offline");
-    this.listeners.clear();
-    this.queuedFrames = [];
-    this.rejectPendingFrameAcks(reason);
-    if (this.readyResolved && !this.manualDisconnect) {
-      this.onDisconnect?.(reason);
     }
   }
 

--- a/docs/adr/local-first-notebook-state.md
+++ b/docs/adr/local-first-notebook-state.md
@@ -536,10 +536,51 @@ actor**. The pinned-snapshot path already proves bytes → throwaway handle →
   handle and never flushed. The authority invariant forbids restoring
   runtime state into the sync path, not caching pixels; the syncing handle
   still bootstraps RuntimeStateDoc empty and the room remains the only
-  writer. Blob-backed outputs still need their blob fetches; everything
-  inline paints instantly.
+  writer. Blob-backed output *bytes* are already solved: blob refs are
+  content-addressed and immutable, and the cloud blob endpoints serve
+  `Cache-Control: immutable`, so the browser HTTP cache makes
+  `<img src="blobURL">` instant on revisit with no IndexedDB involvement.
+  The gap is **addressing**, not bytes: which execution is current per cell
+  and which manifest/blob refs to resolve all live in RuntimeStateDoc — the
+  render cache is what preserves the execution-id → output → manifest →
+  blob-ref chain, and the real work is running the output-resolution path
+  (manifest decode, execution-id tracking — see
+  [blob-ref-and-chunk-manifest-protocol](./blob-ref-and-chunk-manifest-protocol.md),
+  [arrow-manifest-durable-storage-design](./arrow-manifest-durable-storage-design.md))
+  against cached bytes with no live room. Cloud-only; desktop has the local
+  daemon.
 - Offline *editing* before the first-ever handshake stays out of scope
   (below) — this PR is about read latency, not offline authoring.
+
+## Prior-art trajectory: subduction / sedimentree
+
+The automerge ecosystem's successor sync line (Ink & Switch
+[subduction](https://github.com/inkandswitch/subduction), the Beelay
+successor; integrated on automerge-repo's `subductionjs` branch, with the
+fragments API on automerge core's `next` tag as `3.3.0-fragments.1`)
+replaces per-peer bloom-filter `sync::State` with content-addressed
+**sedimentree** sync: commit hashes deterministically partition history into
+fragments, batch sync is a 1.5-RT fingerprint diff, and **no durable
+per-peer sync state exists** — reconnect is a re-handshake plus one summary
+exchange. Explicitly experimental upstream ("DO NOT use for production");
+not adoptable now. What this ADR already gets right relative to it: the
+`StorageAdapter` interface here is the same interface subduction's storage
+bridge wraps upstream, and subduction writes under its own
+`["subduction", ...]` key prefix — coexistence requires zero migration, and
+our snapshot envelope degrades into a bootstrap cache. Cheap alignment
+moves when the time comes:
+
+1. Optional `saveBatch(entries)` on `StorageAdapter` (upstream's exact
+   extension; sequential-save fallback) with crash-ordered writes
+   (blobs → metadata → id-marker: a crash leaves invisible orphans, never a
+   visible-but-incomplete record).
+2. Fill the reserved "incremental chunks later" slot against the automerge
+   3.3 fragments API (`getFragmentMetadata`/`bundleFragmentMetadata` via new
+   `NotebookHandle` WASM exports) instead of inventing a chunk format —
+   core-driven, deterministic compaction for free.
+3. Operational patterns worth stealing regardless: per-doc heal-retry with
+   an exhaustion signal, and "confirmation is just another sync"
+   idempotence.
 
 ## Out of scope (recorded, no PR planned)
 

--- a/docs/adr/local-first-notebook-state.md
+++ b/docs/adr/local-first-notebook-state.md
@@ -254,8 +254,13 @@ automerge-repo websocket adapter's good parts and fixing its known flaws:
   the handle XOR reuse the actor label" — a preserved handle with a new
   label is safe (`set_actor` starts a fresh seq chain), a fresh handle with
   a reused label collides (DuplicateSeqNumber); fresh-per-attempt is the
-  universally safe choice. Each attempt is also bounded by a 30 s handshake
-  timer (open ≠ ready) that recycles the attempt instead of dead-ending.
+  universally safe choice. Each attempt is bounded end to end by a 30 s
+  per-attempt budget: the `connectTarget()` resolution itself is timed out
+  (a hung auth fetch becomes a normal failed attempt, never a wedge with no
+  socket and no timers) and the same budget arms a handshake timer (open ≠
+  ready) that recycles the attempt instead of dead-ending. The `online`
+  event also supersedes an attempt parked in `connectTarget()` — the epoch
+  guard discards the late-settling target.
 - **Exponential backoff with jitter** (automerge-repo uses a fixed 5 s
   interval — explicitly noted as a flaw): base 1 s, ×2, cap 30 s, ±50 %
   full jitter. Reset on `cloud_room_ready` (the application-level ack),
@@ -266,10 +271,13 @@ automerge-repo websocket adapter's good parts and fixing its known flaws:
   retries) → `online` (each ready) → `reconnecting` (a previously-online
   connection lost, loop active) → `offline` (manual disconnect only). This
   is the first user of the reserved `"reconnecting"` status.
-- **Drop, don't buffer.** Sends while not-OPEN reject; pending FIFO frame
-  ACKs are rejected per connection loss (they cannot span sockets). Frames
-  queued from a dead connection are likewise discarded — they are bound to
-  that connection's sync state. The sync layer already rolls back via
+- **Drop, don't buffer.** Sends while not-OPEN reject, and so do sends in
+  the open→ready handshake window — frames sent there would go out under
+  the PREVIOUS connection's sync state and actor (the outbound mirror of
+  the inbound roomReady$ ordering guarantee). Pending FIFO frame ACKs are
+  rejected per connection loss (they cannot span sockets). Frames queued
+  from a dead connection are likewise discarded — they are bound to that
+  connection's sync state. The sync layer already rolls back via
   `cancel_last_flush` and regenerates from sync state after the handshake —
   correctness lives in the protocol, not in an outbound queue.
 - **`roomReady$: Observable<CloudRoomReady>`** emits per successful handshake
@@ -312,39 +320,67 @@ change recreates it, and a `read_failed` seed outcome keeps saves disarmed
 for the runtime's whole life).
 
 RuntimeStateDoc/CommsDoc re-sync from the room (authoritative) into the
-preserved stores; `resetForBootstrap`'s pending `SessionStatus` keeps the
-fail-open window closed. The initial-connect failure path (previously a
-terminal error after a 30 s ready timeout) now rides the same loop — the
-transport keeps trying, the session stays in `connecting`/`reconnecting`
-(`onConnectionLost` is informational: presence marked disconnected,
-`connectionError` surfaced, access diagnostics run once), and the existing
-notices surface a quiet reconnecting state instead of the dead-end "Live
-room needs attention."
+preserved stores. The offline fail-open window on cloud is closed by
+`connectionError` → shell-capability / `sessionRuntimeState` gating
+(`canAcceptCellMutations` requires no connection error; cleared on the
+next `cloud_room_ready`) — NOT by `resetForBootstrap`'s pending
+`SessionStatus`, which is inert on this surface: the cloud transport
+consumes every SESSION_CONTROL frame itself, so `sessionStatus$` never
+fires on cloud (it is the engine-level guard for sessionStatus$-consuming
+surfaces, i.e. desktop). `resetForBootstrap` remains load-bearing on cloud
+for its diff-cache clearing. Known limitation until PR 3 surfaces
+connection state: the runtime-state store is deliberately not blanked on
+transport-level reconnects, so stale kernel/execution chrome can stay
+visible during the offline window. The initial-connect failure path
+(previously a terminal error after a 30 s ready timeout) now rides the
+same loop — the transport keeps trying, the session stays in
+`connecting`/`reconnecting` (`onConnectionLost` is informational: presence
+marked disconnected, `connectionError` surfaced, access diagnostics run
+once), and the existing notices surface a quiet reconnecting state instead
+of the dead-end "Live room needs attention."
 
-Escalation (`classifyRecoverableRejection`): the first recoverable
+Escalation (`CloudRecoverableRejectionTracker`): the first recoverable
 `cloud_frame_rejected(AUTOMERGE_SYNC)` on a connection is handled in place —
-`resetAndResync()` on the live connection, no teardown. A repeat within the
-same connection (the strike count resets per `cloud_room_ready`) escalates
-to the full teardown path, as does a rejection that arrives before the
-runtime exists (which also marks the next attempt bootstrap-only — closing
-the former poison-pill blind spot). For transport-level divergence the
-persisted snapshot reseeds the fresh handle loss-lessly; for content-caused
-rejections on a seeded session the reseed would be the poison, so PR 1's
-escalation (clear the record after the teardown flush settles, bootstrap the
-next attempt) takes over and the retry converges from a fresh bootstrap.
+`resetAndResync()` on the live connection, no teardown. The strike only
+clears once the resync's outbound flush has actually been delivered
+(`engine.flushAndWait()`): the ack protocol carries no frame id and several
+AUTOMERGE_SYNC frames are routinely in flight, so rejections that arrive
+before delivery cannot have observed the resync — they **absorb** into
+strike 1 (the same divergence event) instead of escalating. Only a
+post-delivery repeat within the same connection (the tracker resets per
+`cloud_room_ready`) escalates to the full teardown path, as does a
+rejection that arrives before the runtime exists (which also marks the
+next attempt bootstrap-only — closing the former poison-pill blind spot).
+For transport-level divergence the persisted snapshot reseeds the fresh
+handle loss-lessly; for content-caused rejections on a seeded session the
+reseed would be the poison, so PR 1's escalation takes over: dispose, clear
+the record after the teardown flush settles
+(`discardPersistedSeedAfterTeardown`), and bootstrap the next attempt. The
+discard chain is stashed in a ref the next attempt's persistence arming
+awaits (strict clear-then-arm), so a straggling clear can never delete the
+fresh attempt's first record. Escalation teardowns also bump the
+materialization generation before freeing the handle, so in-flight
+materializations bail instead of touching a freed handle.
 
 ### Tests
 
 Mock WS server harness (extended `live-sync.test.ts`): backoff schedule
-under mock timers (growth, cap, jitter bounds, reset-on-ready, online-event
-short-circuit); status transitions incl. `reconnecting`; handshake replay
-emitting `roomReady$` with fresh identity (plus late-subscriber replay);
-pending-ACK rejection and queued-frame discard at socket loss; the
-ready→immediate-sync-frame ordering regression; an engine-level continuity
-test proving an edit made while disconnected is rolled back, preserved, and
-delivered by the reconnect resync while the original `cellChanges$`
-subscription keeps receiving (no engine restart, no projection blanking);
-rejection-escalation classification; fresh-operator-nonce-per-attempt.
+under mock timers (growth, cap, jitter bounds, reset-on-ready, NO reset on
+WS open without ready, online-event short-circuit and supersession of a
+parked `connectTarget()` await); per-attempt budget recycling for both a
+handshake that never completes and a hung or rejecting `connectTarget()`;
+status transitions incl. `reconnecting`; handshake replay emitting
+`roomReady$` with fresh identity (plus late-subscriber replay) and the
+adoption seam (`applyCloudRoomReady` dedup/identity ordering); pending-ACK
+rejection and queued-frame discard at socket loss; pre-ready send
+rejection; the ready→immediate-sync-frame ordering regression; an
+engine-level continuity test proving an edit made while disconnected is
+rolled back, preserved, and delivered by the reconnect resync while the
+original `cellChanges$` subscription keeps receiving (no engine restart,
+no projection blanking); rejection-tracker lifecycle (strike, absorb,
+post-delivery escalation, per-connection reset); the dispose-flush→clear
+ordering of the seed discard; fresh-operator-nonce-per-attempt through the
+real `createCloudConnectTarget`.
 
 ---
 

--- a/docs/adr/local-first-notebook-state.md
+++ b/docs/adr/local-first-notebook-state.md
@@ -249,25 +249,39 @@ automerge-repo websocket adapter's good parts and fixing its known flaws:
   detach the old socket's listeners, open a fresh socket from a
   `connectTarget: () => Promise<{url, protocols}>` factory (re-resolves auth
   per attempt — tokens expire mid-session), replay the `cloud_room_ready`
-  handshake in full.
+  handshake in full. The factory also mints a **fresh operator nonce per
+  attempt** (`createCloudConnectTarget`): the actor-safety rule is "preserve
+  the handle XOR reuse the actor label" — a preserved handle with a new
+  label is safe (`set_actor` starts a fresh seq chain), a fresh handle with
+  a reused label collides (DuplicateSeqNumber); fresh-per-attempt is the
+  universally safe choice. Each attempt is also bounded by a 30 s handshake
+  timer (open ≠ ready) that recycles the attempt instead of dead-ending.
 - **Exponential backoff with jitter** (automerge-repo uses a fixed 5 s
   interval — explicitly noted as a flaw): base 1 s, ×2, cap 30 s, ±50 %
-  jitter. Reset on `cloud_room_ready` (the application-level ack), *not* on
-  WS `open` — an LB can accept sockets while the room is unreachable. A
-  `navigator` `online` event short-circuits the current wait. Retries
-  continue until manual `disconnect()`.
-- **Status transitions:** `connecting` (first attempt) → `online` (each
-  ready) → `reconnecting` (connection lost, loop active) → `offline` (manual
-  disconnect only). This is the first user of the reserved `"reconnecting"`
-  status.
+  full jitter. Reset on `cloud_room_ready` (the application-level ack),
+  *not* on WS `open` — an LB can accept sockets while the room is
+  unreachable. A `navigator` `online` event short-circuits the current
+  wait. Retries continue until manual `disconnect()`.
+- **Status transitions:** `connecting` (first attempt *and* pre-first-ready
+  retries) → `online` (each ready) → `reconnecting` (a previously-online
+  connection lost, loop active) → `offline` (manual disconnect only). This
+  is the first user of the reserved `"reconnecting"` status.
 - **Drop, don't buffer.** Sends while not-OPEN reject; pending FIFO frame
-  ACKs are rejected per connection loss (they cannot span sockets). The sync
-  layer already rolls back via `cancel_last_flush` and regenerates from sync
-  state after the handshake — correctness lives in the protocol, not in an
-  outbound queue.
+  ACKs are rejected per connection loss (they cannot span sockets). Frames
+  queued from a dead connection are likewise discarded — they are bound to
+  that connection's sync state. The sync layer already rolls back via
+  `cancel_last_flush` and regenerates from sync state after the handshake —
+  correctness lives in the protocol, not in an outbound queue.
 - **`roomReady$: Observable<CloudRoomReady>`** emits per successful handshake
   (initial and every reconnect) carrying the new `peer_id`, `actor_label`,
-  `connection_scope` — the session's signal to re-establish identity.
+  `connection_scope` — the session's signal to re-establish identity. Two
+  load-bearing delivery properties: the emission is **synchronous within
+  the ready message's handling**, before any subsequent frame of that
+  connection is dispatched (the room host kicks host-initiated sync
+  immediately after ready, and a sync frame applied against the previous
+  connection's sync state is garbage); and the subject **replays the
+  latest handshake** to late subscribers, so a reconnect that lands while
+  the session is still creating the handle is adopted on subscribe.
 
 ### Session (`cloud-viewer-session.ts`)
 
@@ -277,39 +291,60 @@ live there), the `SyncEngine` and its subscriptions, and the store projections
 (no `resetCloudViewStoreProjection()` / `replaceNotebookCells([])` blanking —
 the desktop bootstrap-preservation pattern, applied to cloud). On each
 `roomReady$` after the first it **recreates** only the per-connection state,
-mirroring the daemon agent (`runtime_agent.rs:1046-1052`):
+mirroring the daemon agent (`runtime_agent.rs:1046-1052`) via
+`CloudSyncRuntime.applyRoomReady` → `reestablishCloudConnection`:
 
 ```
-handle.set_actor(ready.actor_label)   // fresh server-assigned actor, new seq chain
+handle.set_actor(ready.actor_label)   // fresh actor (client-minted nonce,
+                                      // principal rewritten by the worker)
 engine.resetForBootstrap()            // pending session status, cleared diff caches
 engine.resetAndResync()               // reset_sync_state() + flush() — full resync kick
-presence/identity state ← ready       // peer_id, scope, actor label
+presence/identity state ← ready       // peer_id, scope, actor label, peer label
 ```
+
+The first three steps run **synchronously inside the roomReady$ emission**
+(no awaits before them): the room kicks sync immediately after ready, so the
+re-establish must complete before the new connection's first frame is
+applied. Identity is mutable on the runtime (getters), so presence encoders
+always stamp the latest peer id; the persistence principal follows the
+latest identity (same-principal reconnects keep the controller, a principal
+change recreates it, and a `read_failed` seed outcome keeps saves disarmed
+for the runtime's whole life).
 
 RuntimeStateDoc/CommsDoc re-sync from the room (authoritative) into the
 preserved stores; `resetForBootstrap`'s pending `SessionStatus` keeps the
-fail-open window closed. The initial-connect failure path (today: terminal
-error, no retry) now rides the same loop — the transport keeps trying, the
-session stays in `connecting`/`reconnecting`, and the existing notices surface
-a quiet reconnecting state instead of the dead-end "Live room needs
-attention."
+fail-open window closed. The initial-connect failure path (previously a
+terminal error after a 30 s ready timeout) now rides the same loop — the
+transport keeps trying, the session stays in `connecting`/`reconnecting`
+(`onConnectionLost` is informational: presence marked disconnected,
+`connectionError` surfaced, access diagnostics run once), and the existing
+notices surface a quiet reconnecting state instead of the dead-end "Live
+room needs attention."
 
-Escalation: a recoverable `cloud_frame_rejected(AUTOMERGE_SYNC)` (sync state
-diverged from the room) is first handled in place — `resetAndResync()` on the
-live connection; if it recurs immediately, fall back to the full teardown
-path. For transport-level divergence the persisted snapshot reseeds the
-fresh handle loss-lessly; for content-caused rejections on a seeded session
-the reseed would be the poison, so PR 1's escalation (clear the record after
-the teardown flush settles, bootstrap the next attempt) takes over and the
-retry converges from a fresh bootstrap.
+Escalation (`classifyRecoverableRejection`): the first recoverable
+`cloud_frame_rejected(AUTOMERGE_SYNC)` on a connection is handled in place —
+`resetAndResync()` on the live connection, no teardown. A repeat within the
+same connection (the strike count resets per `cloud_room_ready`) escalates
+to the full teardown path, as does a rejection that arrives before the
+runtime exists (which also marks the next attempt bootstrap-only — closing
+the former poison-pill blind spot). For transport-level divergence the
+persisted snapshot reseeds the fresh handle loss-lessly; for content-caused
+rejections on a seeded session the reseed would be the poison, so PR 1's
+escalation (clear the record after the teardown flush settles, bootstrap the
+next attempt) takes over and the retry converges from a fresh bootstrap.
 
 ### Tests
 
-Mock WS server harness (extend `live-sync.test.ts`): backoff schedule under
-fake timers (growth, cap, jitter bounds, reset-on-ready); status transitions
-incl. `reconnecting`; handshake replay; pending-ACK rejection at socket loss;
-session test proving an edit made while disconnected syncs after reconnect
-with no projection blanking; frame-rejection escalation.
+Mock WS server harness (extended `live-sync.test.ts`): backoff schedule
+under mock timers (growth, cap, jitter bounds, reset-on-ready, online-event
+short-circuit); status transitions incl. `reconnecting`; handshake replay
+emitting `roomReady$` with fresh identity (plus late-subscriber replay);
+pending-ACK rejection and queued-frame discard at socket loss; the
+ready→immediate-sync-frame ordering regression; an engine-level continuity
+test proving an edit made while disconnected is rolled back, preserved, and
+delivered by the reconnect resync while the original `cellChanges$`
+subscription keeps receiving (no engine restart, no projection blanking);
+rejection-escalation classification; fresh-operator-nonce-per-attempt.
 
 ---
 


### PR DESCRIPTION
Part 2 of the #3421 stack (follows #3565, now merged; rebased onto main). Previously reviewed as intra-fork quillaid/nteract#3 — closing that in favor of this.

## What this does

**`CloudWebSocketTransport` becomes multi-connection.** One re-entrant connect serves the initial attempt and every retry: detach old listeners → fresh socket from an async `connectTarget` factory (fresh auth + fresh client-minted operator nonce per attempt) → full `cloud_room_ready` handshake replay. Exponential backoff 1s ×2 → 30s cap, ±50% jitter, **reset on the app-level ack, not WS open**; `navigator` online short-circuits the wait, including superseding a parked `connectTarget` await; a per-attempt budget bounds both the auth-resolution phase and the open→ready handshake; retry forever until manual `disconnect()`. First user of the reserved `"reconnecting"` ConnectionStatus. `roomReady$` emits synchronously before any subsequent frame of its connection is dispatched.

**The session preserves continuity instead of tearing the world down.** Across a transport reconnect, the WASM handle (unflushed local edits), the SyncEngine + subscriptions, and the store projections all survive; per `roomReady$` the session synchronously runs `set_actor(fresh label)` → `resetForBootstrap()` → `resetAndResync()` — the daemon runtime agent's shape, applied to the browser. The terminal 30s "Live room needs attention." on initial connect is gone: unreachable rooms retry quietly forever, each attempt individually bounded.

**Rejection escalation is delivery-gated.** A recoverable `AUTOMERGE_SYNC` rejection triggers in-place resync; pipelined rejections from frames already in flight are absorbed (hosted-room ACKs carry no frame id) — only a rejection that can have observed the resync escalates to teardown + the #3565 poison-pill seed discard, with strict teardown-flush → seed-clear → arming order.

## Safety properties (test-backed)

- **Offline edits survive:** edit while disconnected → send dropped → `cancel_last_flush` rollback → reconnect → byte-exact redelivery on the new socket, original `cellChanges$` subscription intact (no projection blanking).
- **Actor safety:** fresh operator nonce per attempt; preserved handle + new label = fresh seq chain (the `DuplicateSeqNumber` guard), asserted through the real `createCloudConnectTarget`.
- **Ready→frame ordering:** regression test delivers a sync frame in the same turn as `cloud_room_ready`; pre-ready sends reject so nothing rides the previous connection's sync state.
- Backoff schedule/cap/jitter bounds pinned under mock timers, including *not* resetting on open-without-ready and recycling hung handshakes.

## Review

4-lens adversarial review (races / invariants / test-quality / chaos), 31 agents: 16 confirmed findings fixed (notably an unbounded `connectTarget` await that could wedge the loop, and pipelined rejections escalating before in-place recovery could be observed), 11 claims refuted under verification.

## Verification (re-run post-rebase)

- notebook-cloud suite: 727 passed, 0 failed (live-sync.test.ts: 59 tests at this PR's tip)
- Full vp suite: 2087 passed, 6 skipped, 0 failed
- `tsc --noEmit` clean; `cargo xtask lint` clean; `BrowserDevTransport`/`TauriTransport`/`DirectTransport` untouched

Also carries the ADR updates (PR-2 design-as-landed, subduction prior-art trajectory, PR 6 output-addressing note). Stack continues: PR 3 (connection/identity slot) is implemented and under review on `local-first/03-slot`; integration preview of 2+3 is deployable from draft #3570.

🤖 Generated with [Claude Code](https://claude.com/claude-code)