### PR TITLE
fix(sift): polish table focus and summaries

### DIFF
--- a/packages/sift/src/auto-width.test.ts
+++ b/packages/sift/src/auto-width.test.ts
@@ -5,7 +5,7 @@ describe("autoWidth", () => {
   it("returns minimum width for short column names", () => {
     expect(autoWidth("x", "numeric")).toBeGreaterThanOrEqual(100);
     expect(autoWidth("y", "boolean")).toBeGreaterThanOrEqual(90);
-    expect(autoWidth("z", "timestamp")).toBeGreaterThanOrEqual(130);
+    expect(autoWidth("z", "timestamp")).toBeGreaterThanOrEqual(170);
     expect(autoWidth("a", "categorical")).toBeGreaterThanOrEqual(120);
   });
 
@@ -35,7 +35,7 @@ describe("autoWidth", () => {
 
   it("timestamp columns have highest minimum", () => {
     const tsW = autoWidth("x", "timestamp");
-    expect(tsW).toBeGreaterThanOrEqual(130);
+    expect(tsW).toBeGreaterThanOrEqual(170);
   });
 
   it("handles empty string column name", () => {
@@ -45,6 +45,6 @@ describe("autoWidth", () => {
 
   it("handles unicode column names", () => {
     const width = autoWidth("日付", "timestamp");
-    expect(width).toBeGreaterThanOrEqual(130);
+    expect(width).toBeGreaterThanOrEqual(170);
   });
 });

--- a/packages/sift/src/auto-width.ts
+++ b/packages/sift/src/auto-width.ts
@@ -25,7 +25,7 @@ export function autoWidth(name: string, colType: ColumnType): number {
     case "boolean":
       return Math.max(90, Math.ceil(labelW));
     case "timestamp":
-      return Math.max(130, Math.ceil(labelW));
+      return Math.max(170, Math.ceil(labelW));
     case "numeric":
       return Math.max(100, Math.ceil(labelW));
     case "categorical":

--- a/packages/sift/src/library.css
+++ b/packages/sift/src/library.css
@@ -432,6 +432,9 @@
   color: var(--sift-muted);
   text-transform: none;
   letter-spacing: normal;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
 }
 
 .sift-tz-default {
@@ -1113,12 +1116,16 @@
   align-items: center;
   gap: 6px;
   margin-left: 12px;
+  min-width: 0;
+  overflow: hidden;
 }
 
 .sift-filter-pill {
   display: inline-flex;
   align-items: center;
   gap: 4px;
+  flex: 0 1 auto;
+  min-width: 0;
   padding: 2px 6px 2px 8px;
   background: color-mix(in srgb, var(--sift-accent) 10%, transparent);
   border: 1px solid color-mix(in srgb, var(--sift-accent) 20%, transparent);
@@ -1130,13 +1137,25 @@
   overflow: hidden;
 }
 
+.sift-filter-pill-label {
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
 .sift-filter-pill-x {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  flex: 0 0 14px;
+  width: 14px;
+  height: 14px;
   background: none;
   border: none;
   color: var(--sift-accent);
   font: 14px/1 var(--sift-font);
   cursor: pointer;
-  padding: 0 2px;
+  padding: 0;
   opacity: 0.6;
   transition: opacity 100ms ease;
 }

--- a/packages/sift/src/table.test.ts
+++ b/packages/sift/src/table.test.ts
@@ -474,6 +474,8 @@ describe("createTable", () => {
       const pills = container.querySelectorAll(".sift-filter-pill");
       expect(pills.length).toBe(1);
       expect(pills[0].textContent).toContain("Score");
+      expect(pills[0].querySelector(".sift-filter-pill-label")?.textContent).toContain("Score");
+      expect(pills[0].querySelector(".sift-filter-pill-x")).not.toBeNull();
     });
 
     it("clearFilter removes the pill", async () => {

--- a/packages/sift/src/table.ts
+++ b/packages/sift/src/table.ts
@@ -1262,6 +1262,7 @@ export function createTable(
       }
 
       const label = document.createElement("span");
+      label.className = "sift-filter-pill-label";
       label.textContent = text;
 
       const closeBtn = document.createElement("button");

--- a/src/components/cell/OutputArea.tsx
+++ b/src/components/cell/OutputArea.tsx
@@ -710,9 +710,9 @@ function OutputAreaSingle({
   const interactionFrameStyle = hasWheelOwningOutputs
     ? ({
         "--notebook-sift-focus": frameFocusAccent,
-        "--notebook-sift-focus-hover": `${frameFocusAccent}66`,
+        "--notebook-sift-focus-hover": `${frameFocusAccent}38`,
         boxShadow: staticFrameInteractionActive
-          ? `0 0 0 2px ${frameFocusAccent}cc, 0 12px 30px ${frameFocusAccent}24`
+          ? `0 0 0 1.5px ${frameFocusAccent}cc, 0 0 0 3px ${frameFocusAccent}14`
           : undefined,
       } as React.CSSProperties)
     : undefined;


### PR DESCRIPTION
## Summary

- Keep Sift filter pill close controls inside the chip by truncating the label independently.
- Give timestamp columns a wider default and keep header range summaries on one line.
- Make the activated Sift output frame read as focused with a clear border instead of the heavier glow.

## Verification

- `pnpm --filter @nteract/sift test -- src/auto-width.test.ts src/table.test.ts`
- `pnpm test:run src/components/cell/__tests__/OutputArea.test.tsx`
- `cargo xtask lint --fix`

Note: lint still reports the pre-existing unrelated `no-useless-spread` warning in `packages/runtimed/tests/notebook-doc-persistence.test.ts:42`.
