### PR TITLE
fix(notebook-cloud): cap snapshot blob-ref validation fan-out

### DIFF
--- a/apps/notebook-cloud/src/index.ts
+++ b/apps/notebook-cloud/src/index.ts
@@ -128,6 +128,11 @@ const VIEWER_RUNTIME_WASM_ASSET_MANIFEST_PATH = "/assets/runtime-wasm-assets.jso
 const VIEWER_RUNTIMED_WASM_MODULE_NAME = "runtimed_wasm.js";
 const VIEWER_RUNTIMED_WASM_NAME = "runtimed_wasm_bg.wasm";
 const SNAPSHOT_BLOB_HEAD_CONCURRENCY = 16;
+// One R2 HEAD is issued per referenced blob during snapshot-pair validation.
+// Cap the total so a single publish cannot fan out unbounded billable R2
+// operations. Sized ~10x the largest blob_ref_count observed in
+// snapshot_pair.validation.completed logs; raise it if legitimate notebooks hit it.
+const MAX_SNAPSHOT_BLOB_REFS = 2000;
 const ULID_ALPHABET = "0123456789ABCDEFGHJKMNPQRSTVWXYZ";
 const CREATE_NOTEBOOK_ID_ATTEMPTS = 8;
 
@@ -2807,6 +2812,29 @@ async function validateSnapshotPair(options: {
     };
   }
 
+  const blobRefs = snapshotBlobRefsOverCap(render);
+  if (blobRefs.over) {
+    cloudLog("warn", "snapshot_pair.validation.blob_refs_over_cap", {
+      notebook_id: options.notebookId,
+      notebook_heads_hash: options.notebookHeadsHash,
+      runtime_heads_hash: options.runtimeHeadsHash,
+      duration_ms: durationMs(startedAt),
+      blob_ref_count: blobRefs.count,
+      blob_ref_cap: blobRefs.cap,
+      counter: "snapshot_pair_validation_blob_ref_cap_rejections",
+      counter_delta: 1,
+    });
+    return {
+      ok: false,
+      status: 422,
+      body: {
+        error: "snapshot references too many blobs",
+        blob_ref_count: blobRefs.count,
+        blob_ref_cap: blobRefs.cap,
+      },
+    };
+  }
+
   const missingBlobs = await findMissingSnapshotBlobs(bucket, options.notebookId, render);
   if (missingBlobs.length > 0) {
     cloudLog("warn", "snapshot_pair.validation.missing_blobs", {
@@ -2848,6 +2876,9 @@ async function findMissingSnapshotBlobs(
   render: unknown,
 ): Promise<MissingSnapshotBlob[]> {
   const refs = collectSnapshotBlobRefs(render);
+  if (refs.length > MAX_SNAPSHOT_BLOB_REFS) {
+    throw new Error(`snapshot blob ref count ${refs.length} exceeds cap ${MAX_SNAPSHOT_BLOB_REFS}`);
+  }
   const missing: Array<MissingSnapshotBlob | null> = [];
 
   for (let index = 0; index < refs.length; index += SNAPSHOT_BLOB_HEAD_CONCURRENCY) {
@@ -2882,6 +2913,14 @@ function collectSnapshotBlobRefs(render: unknown): BlobRef[] {
     }
   }
   return Object.values(refs);
+}
+
+export function snapshotBlobRefsOverCap(
+  render: unknown,
+  cap = MAX_SNAPSHOT_BLOB_REFS,
+): { count: number; cap: number; over: boolean } {
+  const count = collectSnapshotBlobRefs(render).length;
+  return { count, cap, over: count > cap };
 }
 
 function isRecord(value: unknown): value is Record<string, unknown> {

--- a/apps/notebook-cloud/test/worker-routes.test.ts
+++ b/apps/notebook-cloud/test/worker-routes.test.ts
@@ -1,7 +1,7 @@
 import { before, describe, it } from "node:test";
 import assert from "node:assert/strict";
 import { readFile } from "node:fs/promises";
-import worker from "../src/index.ts";
+import worker, { snapshotBlobRefsOverCap } from "../src/index.ts";
 import { NOTEBOOK_CLOUD_APP_SESSION_COOKIE_NAME } from "../src/app-session.ts";
 import {
   BEARER_AUTH_TOKEN_PROTOCOL_PREFIX,
@@ -4275,6 +4275,16 @@ describe("Worker artifact routes", () => {
       (warnings[0][1] as { event: string }).event,
       "snapshot_pair.validation.missing_blobs",
     );
+  });
+
+  it("rejects snapshot renders that reference more blobs than the cap", () => {
+    const over = {
+      blob_urls: Object.fromEntries(
+        Array.from({ length: 5 }, (_, i) => [`sha256:${i}`, `https://x/${i}`]),
+      ),
+    };
+    assert.deepEqual(snapshotBlobRefsOverCap(over, 4), { count: 5, cap: 4, over: true });
+    assert.deepEqual(snapshotBlobRefsOverCap(over, 5), { count: 5, cap: 5, over: false });
   });
 });
 


### PR DESCRIPTION
## Summary

Snapshot-pair validation issues one R2 HEAD per blob referenced by the materialized render, batched 16 at a time, with no upper bound on the total. A single output-heavy or adversarially crafted publish could fan out thousands of billable R2 operations — the same cost class as the runaway-runtime-agent incident that exhausted our Cloudflare free-tier request limits earlier this month.

- adds `MAX_SNAPSHOT_BLOB_REFS = 2000`; `validateSnapshotPair` rejects over-cap snapshots with a 422 (`blob_ref_count` / `blob_ref_cap` in the body) **before any R2 HEAD is issued**
- logs the rejection as `snapshot_pair.validation.blob_refs_over_cap` with a `counter` field, matching the existing validation log shape
- adds a defensive throw inside `findMissingSnapshotBlobs` so a future caller can't bypass the pre-check
- exports a pure `snapshotBlobRefsOverCap` helper (following the existing `escapeHtml` test-export pattern) with a unit test covering the over-cap and at-cap boundary

The cap is sized ~10x plausible legitimate notebooks, not measured. The existing `snapshot_pair.validation.completed` log already records `blob_ref_count` per successful publish — after deploy, check its p99 and calibrate. If sift/Arrow workloads legitimately exceed it, raise the cap rather than removing the check.

## Validation

- `pnpm --dir apps/notebook-cloud typecheck`
- `pnpm --dir apps/notebook-cloud exec node --import tsx --test test/worker-routes.test.ts` — 110/110 including the new cap test
- `pnpm --dir apps/notebook-cloud test` — one pre-existing failure in `renderer-artifacts.test.ts` from a missing generated build artifact in fresh checkouts; unrelated to this change
- `cargo xtask lint --fix` — clean, no resulting diff