### PR TITLE
fix(cloud): apply connection actor to comms doc writes

### DIFF
--- a/apps/notebook-cloud/scripts/hosted-widget-cross-window-smoke.mjs
+++ b/apps/notebook-cloud/scripts/hosted-widget-cross-window-smoke.mjs
@@ -277,9 +277,8 @@ async function openNotebookShell(page, href, timeout) {
 }
 
 async function waitForWidgetSlider(page, timeout) {
-  const cell = page.locator('[data-cell-type="code"]').first();
-  await cell.waitFor({ state: "visible", timeout });
-  const slider = cell
+  await page.locator('[data-cell-type="code"]').first().waitFor({ state: "visible", timeout });
+  const slider = page
     .frameLocator('[data-slot="isolated-frame"]')
     .locator('[data-widget-type="IntSlider"]')
     .getByRole("slider")

--- a/apps/notebook-cloud/test/room-materializer.test.ts
+++ b/apps/notebook-cloud/test/room-materializer.test.ts
@@ -1483,6 +1483,68 @@ describe("RoomMaterializer", () => {
     assert.equal(resolved.state?.value, 2);
   });
 
+  it("allows loaded owner handles to author CommsDoc changes with the connection actor", async () => {
+    const state = fakeState();
+    const materializer = new RoomMaterializer("demo", state, {} as Env);
+    const runtimeIdentity = authenticateDevRequest(
+      new Request(
+        "https://cloud.test/n/demo/sync?user=runtime&operator=runtime:py&scope=runtime_peer",
+      ),
+    );
+    const runtimePeerConnection = { id: "peer-runtime", identity: runtimeIdentity };
+    const runtimePeer = new RuntimeStatePeerHandle(runtimeIdentity.actorLabel);
+    await syncMaterializerWithRuntimePeer(materializer, runtimePeerConnection, runtimePeer);
+    runtimePeer.put_comm_json(
+      "comm-widget",
+      "jupyter.widget",
+      "@jupyter-widgets/controls",
+      "IntSliderModel",
+      JSON.stringify({ value: 7, description: "probe" }),
+      0,
+    );
+    assert.equal(
+      (
+        await applyRuntimePeerChangesToMaterializer(
+          materializer,
+          runtimePeerConnection,
+          runtimePeer,
+        )
+      ).changed,
+      true,
+    );
+    assert.equal(
+      (await applyCommsPeerChangesToMaterializer(materializer, runtimePeerConnection, runtimePeer))
+        .changed,
+      true,
+    );
+
+    const ownerIdentity = authenticateDevRequest(
+      new Request("https://cloud.test/n/demo/sync?user=alice&operator=browser:a&scope=owner"),
+    );
+    const ownerPeerConnection = { id: "peer-owner", identity: ownerIdentity };
+    const loadedOwner = NotebookHandle.load(
+      NotebookHandle.create_bootstrap("user:dev:seed/browser:seed").save(),
+    );
+    loadedOwner.set_actor(ownerIdentity.actorLabel);
+    await syncMaterializerRuntimeStateWithClient(materializer, ownerPeerConnection, loadedOwner);
+    await syncMaterializerCommsDocWithClient(materializer, ownerPeerConnection, loadedOwner);
+
+    assert.equal(
+      loadedOwner.set_comm_state_property("comm-widget", "value", JSON.stringify(11)),
+      true,
+    );
+    const accepted = await applyCommsClientChangesToMaterializer(
+      materializer,
+      ownerPeerConnection,
+      loadedOwner,
+    );
+    assert.equal(
+      accepted.changed,
+      true,
+      "loaded browser handles must not author CommsDoc changes with a raw random actor id",
+    );
+  });
+
   it("fans out owner CommsDoc changes to already-open peers", async () => {
     const state = fakeState();
     const materializer = new RoomMaterializer("demo", state, {} as Env);

--- a/crates/runtimed-wasm/src/lib.rs
+++ b/crates/runtimed-wasm/src/lib.rs
@@ -2256,6 +2256,9 @@ impl NotebookHandle {
     pub fn set_actor(&mut self, actor_label: &str) {
         self.doc.set_actor(actor_label);
         self.state_doc.set_actor(actor_label);
+        self.comms_doc
+            .doc_mut()
+            .set_actor(automerge::ActorId::from(actor_label.as_bytes()));
     }
 
     /// Return the deduplicated, sorted list of actor labels that have


### PR DESCRIPTION
## Summary
- apply `NotebookHandle.set_actor()` to the paired CommsDoc as well as NotebookDoc and RuntimeStateDoc
- add a room materializer regression for a loaded owner handle mutating widget state after syncing runtime comm topology
- make the hosted widget cross-window smoke find sliders in any output frame, not just the first code cell

## Why
Cloud widget edits can be authored by loaded/reconnected browser handles. Before this change, CommsDoc kept its random loaded Automerge actor while NotebookDoc and RuntimeStateDoc adopted the authenticated connection actor. The room host correctly rejected those widget updates with `actor label must be <principal>/<operator>`.

## Deployed
Preview has been deployed from hotfix commit `2d08158b`. The second commit only updates the smoke helper.

## Verification
- `cargo xtask wasm runtimed --skip-renderer-plugins`
- `pnpm --dir apps/notebook-cloud exec tsx --test test/room-materializer.test.ts`
- `cargo test -p runtimed-wasm`
- `cargo xtask lint --fix`
- `pnpm --dir apps/notebook-cloud run deploy:check`
- `pnpm --dir apps/notebook-cloud run smoke:hosted:widget-cross-window`
