### PR TITLE
refactor(notebook): share outline interaction layer between desktop and cloud

### DIFF
--- a/apps/notebook-cloud/test/viewer-render-props.test.ts
+++ b/apps/notebook-cloud/test/viewer-render-props.test.ts
@@ -349,3 +349,23 @@ test("cloud rail takes over constrained widths instead of pushing the stage offs
     /\.cloud-notebook-rail\[data-collapsed="false"\] \+ \[data-slot="notebook-document-stage"\]\s*\{/,
   );
 });
+
+test("cloud viewer uses shared outline interaction hooks", () => {
+  const sourceText = viewerCorpus;
+
+  assert.match(sourceText, /useActiveOutlineItemId,/);
+  assert.match(sourceText, /useOutlineSelection,/);
+  assert.match(sourceText, /useOutlineStatusLabel,/);
+  assert.match(sourceText, /useActiveOutlineItemId\(/);
+  assert.match(sourceText, /useOutlineSelection\(/);
+  assert.match(sourceText, /const getOutlineStatusLabel = useOutlineStatusLabel\(\);/);
+  assert.match(sourceText, /outlineCellIds=\{notebookCellIds\}/);
+  assert.doesNotMatch(
+    sourceText,
+    /const \[selectedOutlineItemId, setSelectedOutlineItemId\] = useState/,
+  );
+  assert.doesNotMatch(
+    sourceText,
+    /const handleSelectOutlineItem = useCallback\(\(item[\s\S]*setSelectedOutlineItemId\(item\.id\)/,
+  );
+});

--- a/apps/notebook-cloud/viewer/notebook-viewer.tsx
+++ b/apps/notebook-cloud/viewer/notebook-viewer.tsx
@@ -21,6 +21,9 @@ import {
   NotebookWorkstationsPanel,
   projectNotebookCommandRuntimeStatusFromRuntimeState,
   shouldShowNotebookDocumentCommandToolbar,
+  useActiveOutlineItemId,
+  useOutlineSelection,
+  useOutlineStatusLabel,
   type NotebookCommandToolbarStatus,
   type NotebookEnvironmentManager,
   type NotebookInteractionMode,
@@ -141,7 +144,6 @@ export function NotebookViewer({
   const handleNotebookViewFocus = useCallback(() => {}, []);
   const [activeRailPanel, setActiveRailPanel] = useState<NotebookRailPanelId>("outline");
   const [railCollapsed, setRailCollapsed] = useState(initialCloudRailCollapsed);
-  const [selectedOutlineItemId, setSelectedOutlineItemId] = useState<string | null>(null);
   const handledHeadingHashRef = useRef<string | null>(null);
   const [latestAccessRequest, setLatestAccessRequest] = useState<CloudNotebookAccessRequest | null>(
     null,
@@ -255,17 +257,24 @@ export function NotebookViewer({
     replaceCloudNotebookModeInCurrentUrl(selectedInteractionMode);
   }, [selectedInteractionMode]);
 
+  const getOutlineStatusLabel = useOutlineStatusLabel();
   const notebookViewModel = useNotebookViewModel({
     metadata: notebookMetadata,
     resolveLanguage: cloudSourceLanguage,
+    getOutlineStatusLabel,
   });
   const { codeCellCount, outlineItems } = notebookViewModel;
-  useEffect(() => {
-    if (!selectedOutlineItemId) return;
-    if (!outlineItems.some((item) => item.id === selectedOutlineItemId)) {
-      setSelectedOutlineItemId(null);
-    }
-  }, [outlineItems, selectedOutlineItemId]);
+  const notebookCellIds = notebookViewModel.cellIds;
+  const activeOutlineItemId = useActiveOutlineItemId(
+    outlineItems,
+    notebookCellIds,
+    !railCollapsed && activeRailPanel === "outline",
+  );
+  const { selectedOutlineItemId, handleSelectOutlineItem } = useOutlineSelection({
+    outlineItems,
+    focusedCellId,
+    setFocusedCellId,
+  });
   useEffect(() => {
     const hash = window.location.hash;
     if (!hash || handledHeadingHashRef.current === hash) return;
@@ -278,19 +287,19 @@ export function NotebookViewer({
     if (!item) return;
 
     handledHeadingHashRef.current = hash;
-    setSelectedOutlineItemId(item.id);
+    handleSelectOutlineItem(item);
     navigateNotebookOutlineItem(item, hash, {
       behavior: "auto",
       headingHashTarget: "cell",
     });
-  }, [outlineItems]);
-  const handleSelectOutlineItem = useCallback((item: NotebookOutlineItem) => {
-    setSelectedOutlineItemId(item.id);
-  }, []);
-  const handleNavigateOutlineItem = useCallback((item: NotebookOutlineItem, href: string) => {
-    setSelectedOutlineItemId(item.id);
-    return navigateNotebookOutlineItem(item, href, { headingHashTarget: "cell" });
-  }, []);
+  }, [handleSelectOutlineItem, outlineItems]);
+  const handleNavigateOutlineItem = useCallback(
+    (item: NotebookOutlineItem, href: string) => {
+      handleSelectOutlineItem(item);
+      return navigateNotebookOutlineItem(item, href, { headingHashTarget: "cell" });
+    },
+    [handleSelectOutlineItem],
+  );
   const handleTogglePackagesRail = useCallback(() => {
     if (activeRailPanel === "packages" && !railCollapsed) {
       setActiveRailPanel("outline");
@@ -366,7 +375,6 @@ export function NotebookViewer({
     },
     [shellCapabilities],
   );
-  const notebookCellIds = notebookViewModel.cellIds;
   const packageEnvironmentManager = cloudNotebookEnvironmentManager(
     notebookViewModel.packages.sections,
   );
@@ -769,7 +777,10 @@ export function NotebookViewer({
       viewModel={notebookViewModel}
       activePanelId={activeRailPanel}
       collapsed={railCollapsed}
+      outlineCellIds={notebookCellIds}
+      activeOutlineItemId={activeOutlineItemId}
       selectedOutlineItemId={selectedOutlineItemId}
+      selectedOutlineCellId={focusedCellId}
       workstationsPanel={
         <NotebookWorkstationsPanel
           capabilities={shellCapabilities}

--- a/apps/notebook/src/App.tsx
+++ b/apps/notebook/src/App.tsx
@@ -2,8 +2,6 @@ import { type ReactNode, useCallback, useEffect, useMemo, useRef, useState } fro
 import {
   deriveEnvManager,
   deriveRuntimeKind,
-  notebookCellAnchorId,
-  resolveNotebookOutlineSelection,
   NotebookClient,
   type ExecuteCellOptions,
   type NotebookResponse,
@@ -37,6 +35,9 @@ import {
 } from "@/components/notebook-rail";
 import {
   navigateNotebookOutlineItem,
+  useActiveOutlineItemId,
+  useOutlineSelection,
+  useOutlineStatusLabel,
   type DaemonStatus,
   DaemonStatusBanner,
   DebugBanner,
@@ -90,7 +91,6 @@ import {
   startExecutionPerformanceTrace,
 } from "./lib/execution-performance";
 import { getNotebookCellsSnapshot } from "@/components/notebook/state/cell-store";
-import { useNotebookQueueProjection } from "@/components/notebook/state/execution-store";
 import { useNotebookViewModel } from "@/components/notebook/state/view-model-store";
 import { useDetectRuntime, useNotebookMetadata } from "./lib/notebook-metadata";
 import { useNotebookHost } from "@nteract/notebook-host";
@@ -223,122 +223,6 @@ function resolveCommOutputs(
   })();
 }
 
-function useActiveOutlineItemId(
-  items: readonly NotebookOutlineItem[],
-  cellIds: readonly string[],
-  enabled: boolean,
-): string | null {
-  const [activeItemId, setActiveItemId] = useState<string | null>(null);
-  const itemsRef = useRef(items);
-  const cellIdsRef = useRef(cellIds);
-  const itemIdsKey = useMemo(() => items.map((item) => item.id).join("\n"), [items]);
-  const cellIdsKey = useMemo(() => cellIds.join("\n"), [cellIds]);
-
-  useEffect(() => {
-    itemsRef.current = items;
-  }, [items]);
-
-  useEffect(() => {
-    cellIdsRef.current = cellIds;
-  }, [cellIds]);
-
-  useEffect(() => {
-    if (!enabled || itemIdsKey.length === 0 || cellIdsKey.length === 0) {
-      setActiveItemId(null);
-      return;
-    }
-
-    let frame: number | null = null;
-    const visibleCellIds = new Set<string>();
-    const observedCellIds = new Map<Element, string>();
-    const anchorTop = 96;
-
-    const measure = () => {
-      frame = null;
-      let currentCellId: string | null = null;
-      let firstUpcomingCellId: string | null = null;
-      let firstUpcomingTop = Number.POSITIVE_INFINITY;
-      const currentCellIds = cellIdsRef.current;
-      const candidateCellIds =
-        visibleCellIds.size > 0
-          ? currentCellIds.filter((cellId) => visibleCellIds.has(cellId))
-          : currentCellIds;
-
-      for (const cellId of candidateCellIds) {
-        const target = document.getElementById(notebookCellAnchorId(cellId));
-        if (!target) continue;
-
-        const rect = target.getBoundingClientRect();
-        if (rect.bottom < anchorTop) continue;
-
-        if (rect.top <= anchorTop) {
-          currentCellId = cellId;
-        } else if (rect.top < firstUpcomingTop) {
-          firstUpcomingTop = rect.top;
-          firstUpcomingCellId = cellId;
-        }
-      }
-
-      const nextCellId = currentCellId ?? firstUpcomingCellId;
-      const nextItemId = nextCellId
-        ? resolveNotebookOutlineSelection(itemsRef.current, {
-            selectedCellId: nextCellId,
-            cellIds: currentCellIds,
-          })
-        : null;
-      setActiveItemId((current) => (current === nextItemId ? current : nextItemId));
-    };
-
-    const scheduleMeasure = () => {
-      if (frame !== null) return;
-      frame = window.requestAnimationFrame(measure);
-    };
-
-    scheduleMeasure();
-    const observer =
-      "IntersectionObserver" in window
-        ? new IntersectionObserver(
-            (entries) => {
-              for (const entry of entries) {
-                const cellId = observedCellIds.get(entry.target);
-                if (!cellId) continue;
-                if (entry.isIntersecting) {
-                  visibleCellIds.add(cellId);
-                } else {
-                  visibleCellIds.delete(cellId);
-                }
-              }
-              scheduleMeasure();
-            },
-            { rootMargin: `-${anchorTop}px 0px 0px 0px`, threshold: [0, 0.01] },
-          )
-        : null;
-
-    if (observer) {
-      for (const cellId of cellIdsRef.current) {
-        const target = document.getElementById(notebookCellAnchorId(cellId));
-        if (!target) continue;
-        observedCellIds.set(target, cellId);
-        observer.observe(target);
-      }
-    }
-
-    document.addEventListener("scroll", scheduleMeasure, true);
-    window.addEventListener("resize", scheduleMeasure);
-
-    return () => {
-      observer?.disconnect();
-      if (frame !== null) {
-        window.cancelAnimationFrame(frame);
-      }
-      document.removeEventListener("scroll", scheduleMeasure, true);
-      window.removeEventListener("resize", scheduleMeasure);
-    };
-  }, [cellIdsKey, enabled, itemIdsKey]);
-
-  return activeItemId;
-}
-
 function AppContent() {
   const host = useNotebookHost();
   const blobUploader = useMemo<BlobUploader>(
@@ -423,7 +307,6 @@ function AppContent() {
   const [activeRailPanel, setActiveRailPanel] = useState<NotebookRailPanelId>("outline");
   const [railCollapsed, setRailCollapsed] = useState(true);
   const stageHadFocusBeforeRailTakeoverRef = useRef(false);
-  const [selectedOutlineItemId, setSelectedOutlineItemId] = useState<string | null>(null);
   const [showIsolationTest, setShowIsolationTest] = useState(false);
   const [envBuildDialogOpen, setEnvBuildDialogOpen] = useState(false);
   const [dismissedEnvBuildDetails, setDismissedEnvBuildDetails] = useState<string | null>(null);
@@ -781,18 +664,7 @@ function AppContent() {
     }
   }, [blobPort, getEngine]);
 
-  const notebookQueueProjection = useNotebookQueueProjection();
-  const getOutlineStatusLabel = useCallback(
-    (cell: { id: string; cellType: string; executionCount: number | null }) => {
-      if (cell.id === notebookQueueProjection.executing_cell_id) return "running";
-      if (notebookQueueProjection.queued_cell_ids.includes(cell.id)) return "queued";
-      if (cell.cellType === "code" && cell.executionCount !== null) {
-        return `run ${cell.executionCount}`;
-      }
-      return null;
-    },
-    [notebookQueueProjection.executing_cell_id, notebookQueueProjection.queued_cell_ids],
-  );
+  const getOutlineStatusLabel = useOutlineStatusLabel();
   const notebookViewModel = useNotebookViewModel({ getOutlineStatusLabel });
   const outlineItems = notebookViewModel.outlineItems;
   const markdownHeadingAnchorsByCellId = notebookViewModel.markdownHeadingAnchorsByCellId;
@@ -801,6 +673,11 @@ function AppContent() {
     cellIds,
     !railCollapsed && activeRailPanel === "outline",
   );
+  const { selectedOutlineItemId, handleSelectOutlineItem } = useOutlineSelection({
+    outlineItems,
+    focusedCellId,
+    setFocusedCellId,
+  });
 
   // ── Sync host-owned transient UI state into shared cell UI store ─────
   useNotebookCellUIStateBridge({
@@ -917,17 +794,6 @@ function AppContent() {
 
   const packagesRailOpen = !railCollapsed && activeRailPanel === "packages";
 
-  useEffect(() => {
-    if (!selectedOutlineItemId) return;
-    const selectedOutlineItem = outlineItems.find((item) => item.id === selectedOutlineItemId);
-    if (
-      !selectedOutlineItem ||
-      (focusedCellId !== null && focusedCellId !== selectedOutlineItem.cellId)
-    ) {
-      setSelectedOutlineItemId(null);
-    }
-  }, [focusedCellId, outlineItems, selectedOutlineItemId]);
-
   const handleRailPanelChange = useCallback((panelId: NotebookRailPanelId) => {
     setActiveRailPanel(panelId);
     setRailCollapsed(false);
@@ -945,14 +811,6 @@ function AppContent() {
     setActiveRailPanel("packages");
     setRailCollapsed(false);
   }, [activeRailPanel, railCollapsed, shellCapabilities.canViewPackages]);
-
-  const handleSelectOutlineItem = useCallback(
-    (item: NotebookOutlineItem) => {
-      setSelectedOutlineItemId(item.id);
-      setFocusedCellId(item.cellId);
-    },
-    [setFocusedCellId],
-  );
 
   const handleNavigateOutlineItem = useCallback((item: NotebookOutlineItem, href: string) => {
     return navigateNotebookOutlineItem(item, href, { headingHashTarget: "cell" });

--- a/src/components/notebook/__tests__/outline-interaction.test.ts
+++ b/src/components/notebook/__tests__/outline-interaction.test.ts
@@ -1,0 +1,171 @@
+import { describe, it, expect, vi } from "vitest";
+import { act, renderHook } from "@testing-library/react";
+import { useActiveOutlineItemId, useOutlineSelection } from "../outline-interaction";
+import type { NotebookOutlineItem } from "runtimed";
+
+describe("useActiveOutlineItemId", () => {
+  it("returns null when disabled", () => {
+    const items: NotebookOutlineItem[] = [];
+    const cellIds: string[] = [];
+    const { result } = renderHook(() => useActiveOutlineItemId(items, cellIds, false));
+    expect(result.current).toBe(null);
+  });
+
+  it("returns null when enabled with empty inputs", () => {
+    const items: NotebookOutlineItem[] = [];
+    const cellIds: string[] = [];
+    const { result } = renderHook(() => useActiveOutlineItemId(items, cellIds, true));
+    expect(result.current).toBe(null);
+  });
+
+  it("does not throw when enabled", () => {
+    const items: NotebookOutlineItem[] = [
+      {
+        id: "outline-1",
+        cellId: "cell-1",
+        level: 1,
+        content: "Heading 1",
+        statusLabel: null,
+        headingAnchorId: null,
+      },
+    ];
+    const cellIds = ["cell-1"];
+    expect(() => {
+      renderHook(() => useActiveOutlineItemId(items, cellIds, true));
+    }).not.toThrow();
+  });
+});
+
+describe("useOutlineSelection", () => {
+  it("clears selection when focus moves to a different cell", () => {
+    const items: NotebookOutlineItem[] = [
+      {
+        id: "outline-1",
+        cellId: "cell-1",
+        level: 1,
+        content: "Heading 1",
+        statusLabel: null,
+        headingAnchorId: null,
+      },
+      {
+        id: "outline-2",
+        cellId: "cell-2",
+        level: 1,
+        content: "Heading 2",
+        statusLabel: null,
+        headingAnchorId: null,
+      },
+    ];
+
+    const { result, rerender } = renderHook(
+      (props: { focusedCellId: string | null }) =>
+        useOutlineSelection({
+          outlineItems: items,
+          focusedCellId: props.focusedCellId,
+          setFocusedCellId: vi.fn(),
+        }),
+      { initialProps: { focusedCellId: null } },
+    );
+
+    // Select outline-1
+    act(() => {
+      result.current.handleSelectOutlineItem(items[0]);
+    });
+    expect(result.current.selectedOutlineItemId).toBe("outline-1");
+
+    // Move focus to cell-2 (different from selected outline-1's cell-1)
+    rerender({ focusedCellId: "cell-2" });
+    expect(result.current.selectedOutlineItemId).toBe(null);
+  });
+
+  it("preserves selection when focus stays on the same cell", () => {
+    const items: NotebookOutlineItem[] = [
+      {
+        id: "outline-1",
+        cellId: "cell-1",
+        level: 1,
+        content: "Heading 1",
+        statusLabel: null,
+        headingAnchorId: null,
+      },
+    ];
+
+    // Start with focus already on cell-1
+    const { result } = renderHook(() =>
+      useOutlineSelection({
+        outlineItems: items,
+        focusedCellId: "cell-1",
+        setFocusedCellId: vi.fn(),
+      }),
+    );
+
+    act(() => {
+      result.current.handleSelectOutlineItem(items[0]);
+    });
+    expect(result.current.selectedOutlineItemId).toBe("outline-1");
+  });
+
+  it("works without setFocusedCellId", () => {
+    const items: NotebookOutlineItem[] = [
+      {
+        id: "outline-1",
+        cellId: "cell-1",
+        level: 1,
+        content: "Heading 1",
+        statusLabel: null,
+        headingAnchorId: null,
+      },
+    ];
+
+    // When setFocusedCellId is undefined, focus stays null, so the effect will clear selection
+    // unless focusedCellId matches the item's cellId
+    const { result } = renderHook(() =>
+      useOutlineSelection({
+        outlineItems: items,
+        focusedCellId: "cell-1",
+        setFocusedCellId: undefined,
+      }),
+    );
+
+    expect(() => {
+      act(() => {
+        result.current.handleSelectOutlineItem(items[0]);
+      });
+    }).not.toThrow();
+    expect(result.current.selectedOutlineItemId).toBe("outline-1");
+  });
+
+  it("calls setFocusedCellId when provided", () => {
+    const items: NotebookOutlineItem[] = [
+      {
+        id: "outline-1",
+        cellId: "cell-1",
+        level: 1,
+        content: "Heading 1",
+        statusLabel: null,
+        headingAnchorId: null,
+      },
+    ];
+    const setFocusedCellId = vi.fn();
+
+    // Simulate the real flow: focusedCellId matches after selection
+    const { result, rerender } = renderHook(
+      (props: { focusedCellId: string | null }) =>
+        useOutlineSelection({
+          outlineItems: items,
+          focusedCellId: props.focusedCellId,
+          setFocusedCellId,
+        }),
+      { initialProps: { focusedCellId: null } },
+    );
+
+    act(() => {
+      result.current.handleSelectOutlineItem(items[0]);
+    });
+    expect(setFocusedCellId).toHaveBeenCalledWith("cell-1");
+
+    // Simulate store update causing rerender with new focusedCellId
+    rerender({ focusedCellId: "cell-1" });
+    expect(result.current.selectedOutlineItemId).toBe("outline-1");
+  });
+});

--- a/src/components/notebook/index.ts
+++ b/src/components/notebook/index.ts
@@ -191,6 +191,8 @@ export {
   navigateNotebookOutlineItem,
   type NavigateNotebookOutlineItemOptions,
 } from "./outline-navigation";
+export { useActiveOutlineItemId, useOutlineSelection } from "./outline-interaction";
+export { useOutlineStatusLabel } from "./outline-status-label";
 export {
   getCellById,
   getCellIdsSnapshot,

--- a/src/components/notebook/outline-interaction.ts
+++ b/src/components/notebook/outline-interaction.ts
@@ -1,0 +1,175 @@
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import {
+  notebookCellAnchorId,
+  resolveNotebookOutlineSelection,
+  type NotebookOutlineItem,
+} from "runtimed";
+
+/**
+ * Tracks the active outline item based on scroll position and visibility.
+ * Uses IntersectionObserver + scroll/resize listeners over cell anchors.
+ *
+ * @param items - Outline items from the notebook view model
+ * @param cellIds - Ordered cell IDs from the notebook
+ * @param enabled - Whether the outline is visible (disables tracking when false)
+ * @returns The ID of the currently active outline item, or null
+ */
+export function useActiveOutlineItemId(
+  items: readonly NotebookOutlineItem[],
+  cellIds: readonly string[],
+  enabled: boolean,
+): string | null {
+  const [activeItemId, setActiveItemId] = useState<string | null>(null);
+  const itemsRef = useRef(items);
+  const cellIdsRef = useRef(cellIds);
+  const itemIdsKey = useMemo(() => items.map((item) => item.id).join("\n"), [items]);
+  const cellIdsKey = useMemo(() => cellIds.join("\n"), [cellIds]);
+
+  useEffect(() => {
+    itemsRef.current = items;
+  }, [items]);
+
+  useEffect(() => {
+    cellIdsRef.current = cellIds;
+  }, [cellIds]);
+
+  useEffect(() => {
+    if (!enabled || itemIdsKey.length === 0 || cellIdsKey.length === 0) {
+      setActiveItemId(null);
+      return;
+    }
+
+    let frame: number | null = null;
+    const visibleCellIds = new Set<string>();
+    const observedCellIds = new Map<Element, string>();
+    const anchorTop = 96;
+
+    const measure = () => {
+      frame = null;
+      let currentCellId: string | null = null;
+      let firstUpcomingCellId: string | null = null;
+      let firstUpcomingTop = Number.POSITIVE_INFINITY;
+      const currentCellIds = cellIdsRef.current;
+      const candidateCellIds =
+        visibleCellIds.size > 0
+          ? currentCellIds.filter((cellId) => visibleCellIds.has(cellId))
+          : currentCellIds;
+
+      for (const cellId of candidateCellIds) {
+        const target = document.getElementById(notebookCellAnchorId(cellId));
+        if (!target) continue;
+
+        const rect = target.getBoundingClientRect();
+        if (rect.bottom < anchorTop) continue;
+
+        if (rect.top <= anchorTop) {
+          currentCellId = cellId;
+        } else if (rect.top < firstUpcomingTop) {
+          firstUpcomingTop = rect.top;
+          firstUpcomingCellId = cellId;
+        }
+      }
+
+      const nextCellId = currentCellId ?? firstUpcomingCellId;
+      const nextItemId = nextCellId
+        ? resolveNotebookOutlineSelection(itemsRef.current, {
+            selectedCellId: nextCellId,
+            cellIds: currentCellIds,
+          })
+        : null;
+      setActiveItemId((current) => (current === nextItemId ? current : nextItemId));
+    };
+
+    const scheduleMeasure = () => {
+      if (frame !== null) return;
+      frame = window.requestAnimationFrame(measure);
+    };
+
+    scheduleMeasure();
+    const observer =
+      "IntersectionObserver" in window
+        ? new IntersectionObserver(
+            (entries) => {
+              for (const entry of entries) {
+                const cellId = observedCellIds.get(entry.target);
+                if (!cellId) continue;
+                if (entry.isIntersecting) {
+                  visibleCellIds.add(cellId);
+                } else {
+                  visibleCellIds.delete(cellId);
+                }
+              }
+              scheduleMeasure();
+            },
+            { rootMargin: `-${anchorTop}px 0px 0px 0px`, threshold: [0, 0.01] },
+          )
+        : null;
+
+    if (observer) {
+      for (const cellId of cellIdsRef.current) {
+        const target = document.getElementById(notebookCellAnchorId(cellId));
+        if (!target) continue;
+        observedCellIds.set(target, cellId);
+        observer.observe(target);
+      }
+    }
+
+    document.addEventListener("scroll", scheduleMeasure, true);
+    window.addEventListener("resize", scheduleMeasure);
+
+    return () => {
+      observer?.disconnect();
+      if (frame !== null) {
+        window.cancelAnimationFrame(frame);
+      }
+      document.removeEventListener("scroll", scheduleMeasure, true);
+      window.removeEventListener("resize", scheduleMeasure);
+    };
+  }, [cellIdsKey, enabled, itemIdsKey]);
+
+  return activeItemId;
+}
+
+/**
+ * Manages outline selection state and focus coupling.
+ * Clears selection when focus moves to a cell not matching the selected outline item.
+ * Optionally couples outline selection to focused cell ID (when setFocusedCellId is provided).
+ *
+ * @param options.outlineItems - Outline items from the notebook view model
+ * @param options.focusedCellId - Currently focused cell ID (or null)
+ * @param options.setFocusedCellId - Optional callback to set focused cell (enables focus coupling)
+ * @returns Selection state and handler
+ */
+export function useOutlineSelection(options: {
+  outlineItems: readonly NotebookOutlineItem[];
+  focusedCellId: string | null;
+  setFocusedCellId?: (cellId: string) => void;
+}): {
+  selectedOutlineItemId: string | null;
+  handleSelectOutlineItem: (item: NotebookOutlineItem) => void;
+} {
+  const { outlineItems, focusedCellId, setFocusedCellId } = options;
+  const [selectedOutlineItemId, setSelectedOutlineItemId] = useState<string | null>(null);
+
+  // Clear selection when focus moves to a different cell
+  useEffect(() => {
+    if (!selectedOutlineItemId) return;
+    const selectedOutlineItem = outlineItems.find((item) => item.id === selectedOutlineItemId);
+    if (
+      !selectedOutlineItem ||
+      (focusedCellId !== null && focusedCellId !== selectedOutlineItem.cellId)
+    ) {
+      setSelectedOutlineItemId(null);
+    }
+  }, [focusedCellId, outlineItems, selectedOutlineItemId]);
+
+  const handleSelectOutlineItem = useCallback(
+    (item: NotebookOutlineItem) => {
+      setSelectedOutlineItemId(item.id);
+      setFocusedCellId?.(item.cellId);
+    },
+    [setFocusedCellId],
+  );
+
+  return { selectedOutlineItemId, handleSelectOutlineItem };
+}

--- a/src/components/notebook/outline-status-label.ts
+++ b/src/components/notebook/outline-status-label.ts
@@ -1,0 +1,28 @@
+import { useCallback } from "react";
+import { useNotebookQueueProjection } from "./state/execution-store";
+
+/**
+ * Returns a function that derives outline status labels from execution state.
+ * Used by useNotebookViewModel to annotate outline items with run status.
+ *
+ * @returns Status label function for outline items
+ */
+export function useOutlineStatusLabel(): (cell: {
+  id: string;
+  cellType: string;
+  executionCount: number | null;
+}) => string | null {
+  const notebookQueueProjection = useNotebookQueueProjection();
+
+  return useCallback(
+    (cell: { id: string; cellType: string; executionCount: number | null }) => {
+      if (cell.id === notebookQueueProjection.executing_cell_id) return "running";
+      if (notebookQueueProjection.queued_cell_ids.includes(cell.id)) return "queued";
+      if (cell.cellType === "code" && cell.executionCount !== null) {
+        return `run ${cell.executionCount}`;
+      }
+      return null;
+    },
+    [notebookQueueProjection.executing_cell_id, notebookQueueProjection.queued_cell_ids],
+  );
+}


### PR DESCRIPTION
## Summary

The 2026-06 outline iteration (#3553–#3564) shipped shared rendering to both hosts, but the *interaction* layer — scroll-synced active item, outline↔focused-cell selection coupling, execution status labels — lived as ~150 lines of hooks inside desktop's `App.tsx`. The cloud viewer rendered the same `NotebookDocumentRail` with a thinner prop set, so hosted users saw "the old outline" even though the current deploy contained all the new shared code.

Two commits:

1. **`refactor(notebook): lift outline interaction into shared hooks`** — moves `useActiveOutlineItemId` (IntersectionObserver scroll tracking), `useOutlineSelection` (selection state + focus coupling, with `setFocusedCellId` optional so hosts without a focus store degrade gracefully), and `useOutlineStatusLabel` (running/queued/run-N labels from the shared queue projection) into `src/components/notebook/`. Desktop's `App.tsx` goes from local implementations to imports: −151/+9 lines, behavior-preserving.
2. **`feat(notebook-cloud): wire shared outline interaction in the viewer`** — the viewer consumes all three hooks and passes the previously-missing rail props (`outlineCellIds`, `activeOutlineItemId`, `selectedOutlineCellId`). The viewer already had `focusedCellId`/`setFocusedCellId` from the shared cell-ui-state store, so full focus coupling works with no extra plumbing. Hosted now gets scroll-synced highlighting, selection coupling, and execution status labels — same implementation as desktop, not a mirror.

The philosophy (per the new case study in `docs/adr/notebook-host-shell-convergence.md`, landed separately): optional interaction props on shared components are a divergence smell; the durable fix is single-implementation sharing, not parity checklists. The `viewer-render-props.test.ts` additions are deliberately thin — they only guard against re-forking, they are not the parity mechanism.

Intentional asymmetry preserved: desktop continues to omit the workstations panel while remote compute matures on hosted.

## Not in this PR

- Cloud markdown-outline liveness: #3560's fix landed half in desktop-only `crdt-editor-bridge.ts`/`MarkdownCell.tsx`; whether cloud still has the stale-outline-while-editing bug needs a live two-window repro on preview before deciding if the shared cell-store half already covers it.
- `/api/health` build SHA (would make "is the deploy stale?" answerable in one curl).

## Validation

- `pnpm test:run` — 2111 passed (incl. 7 new outline-interaction tests)
- `pnpm --dir apps/notebook-cloud test` — 769 pass; 1 pre-existing failure (`renderer-artifacts.test.ts` requires a generated build artifact absent in fresh checkouts; unrelated, same failure documented on #3575)
- `pnpm --dir apps/notebook-cloud typecheck` — exit 0
- `cargo xtask lint --fix` — clean