### PR TITLE
docs: record outline wiring-parity lesson in convergence ADR and agent guides

### DIFF
--- a/apps/notebook-cloud/AGENTS.md
+++ b/apps/notebook-cloud/AGENTS.md
@@ -54,6 +54,15 @@ stores, not from using document boundaries as a rerender workaround.
 - Keep notebook UI behavior in shared notebook surfaces where possible. Cloud
   code should adapt host capabilities and routes, not fork cell/output/runtime
   UI semantics.
+- **Wiring parity, not just component parity.** When desktop iterates on a
+  shared surface (rail, outline, toolbar, cells), check that the viewer passes
+  the same interaction props and hooks — a shared component rendered with a
+  thinner prop set silently lacks the new behavior even though the shared code
+  ships in the bundle. Optional interaction props on shared components are the
+  smell; prefer shared hooks colocated with the component (see the outline
+  case study in `docs/adr/notebook-host-shell-convergence.md`). Known
+  intentional asymmetry: desktop does not render the workstations panel while
+  remote compute matures on hosted first.
 - Public viewer state must be explicit: unauthenticated users only become
   anonymous viewers when the D1 ACL has a public `viewer` row. Anonymous
   presence is local-only unless product policy changes.

--- a/apps/notebook/src/AGENTS.md
+++ b/apps/notebook/src/AGENTS.md
@@ -47,6 +47,8 @@ Put host, transport, sync, and lifecycle mechanisms in packages such as `@nterac
 
 Put code in `apps/notebook/src/` when it owns notebook app policy: stores, routes, layout, UI state, materialization choices, and closures that connect package mechanisms to app-specific state.
 
+When iterating on a shared surface (rail, outline, toolbar, cells), keep the *interaction* layer shared too: scroll observers, selection coupling, and status projections belong as hooks colocated with the shared component, not as hooks inside `App.tsx`. Interaction logic written here reaches only desktop — the cloud viewer renders the same component with whatever props it knows about and silently lacks the new behavior. If you add an optional interaction prop to a shared component, also wire it in `apps/notebook-cloud/viewer/` or record why not (see the outline case study in `docs/adr/notebook-host-shell-convergence.md`). Known intentional asymmetry: desktop omits the workstations panel while remote compute matures on hosted.
+
 ## NotebookHost — platform abstraction
 
 Host-platform side effects (Tauri IPC, plugin calls, window chrome) flow through `@nteract/notebook-host`. React code uses `const host = useNotebookHost()`. Import `@tauri-apps/*` only inside the Tauri host implementation and narrow relay glue — the notebook frontend stays host-agnostic.

--- a/docs/adr/notebook-host-shell-convergence.md
+++ b/docs/adr/notebook-host-shell-convergence.md
@@ -161,6 +161,33 @@ whether cloud should receive the same typed projection and provide different
 callbacks. Divergence is justified for authority and side effects, not for
 duplicating notebook chrome.
 
+### Case study: outline interaction wiring (2026-06)
+
+The 2026-06 outline iteration (#3553–#3564) showed a subtler divergence mode
+than duplicated components: **shared components, unshared wiring.** The outline
+data model, rail panel, and rail wrapper were all shared and both hosts shipped
+the new rendering — but the *interaction* layer (scroll-synced active item,
+outline↔focused-cell selection coupling, execution status labels via
+`getOutlineStatusLabel`) lived as ~150 lines of hooks and callbacks inside
+`apps/notebook/src/App.tsx`. Cloud rendered the same rail with a thinner prop
+set and read as "the old outline," even though its deployed bundle contained
+all the new shared code.
+
+The lesson extends the decision above: a shared component whose behavior
+depends on host-side hooks is only half-shared. When iterating on a shared
+surface, interaction state machines (scroll observers, selection coupling,
+status projection) belong next to the component — as shared hooks with
+host-neutral inputs — not in a host shell. Optional props on a shared
+component (`activeOutlineItemId?`, `outlineCellIds?`) are a divergence smell:
+each optional interaction prop is a behavior one host will silently lack.
+
+Intentional asymmetries still exist and should be recorded rather than
+"fixed": e.g. desktop currently does not render the workstations rail panel
+while remote-compute UX evolves on hosted first (`workstationsPanel` stays an
+optional slot by design). The test for "is this divergence intentional?" is
+whether someone can point to a product reason, not whether the code happens
+to compile on both hosts.
+
 ## Anchor And Navigation Contract
 
 Every rendered notebook cell surface that participates in outline or traceback


### PR DESCRIPTION
## Summary

Docs companion to #3581 (which is now merged). The 2026-06 outline iteration shipped shared components to both hosts but left the interaction layer in desktop's `App.tsx`, so hosted users saw the old outline despite a current deploy.

- Adds a case study to `docs/adr/notebook-host-shell-convergence.md` naming the failure mode the ADR didn't yet cover: **shared components, unshared wiring** — optional interaction props on shared components are a divergence smell.
- Adds reciprocal reminders to `apps/notebook/src/AGENTS.md` (interaction hooks written in App.tsx reach only desktop; colocate them with the shared component) and `apps/notebook-cloud/AGENTS.md` (wiring parity, not just component parity), both pointing at the ADR case study.
- Records the intentional asymmetry: desktop omits the workstations panel while remote compute matures on hosted — divergence is fine when someone can point to the product reason.

Docs only; no code changes.