### PR TITLE
feat(notebook-cloud): asset fetch resilience and degraded output states

### DIFF
--- a/apps/elements/components/isolated/index.tsx
+++ b/apps/elements/components/isolated/index.tsx
@@ -66,6 +66,13 @@ export type {
   OutputSegmentationOptions,
   RenderPayload,
 };
+// Renderer-bundle hooks are SSR-safe (provider-absent fallback, effect-scoped
+// listeners), so the docs build re-exports the real implementations.
+export {
+  useHasIsolatedOutputs,
+  useIsolatedRenderer,
+  useRegisterIsolatedOutput,
+} from "../../../../src/components/isolated/isolated-renderer-context";
 
 export interface IsolatedFrameProps {
   id?: string;

--- a/apps/notebook-cloud/scripts/copy-viewer-assets.mjs
+++ b/apps/notebook-cloud/scripts/copy-viewer-assets.mjs
@@ -1,11 +1,11 @@
 import { copyFile, mkdir } from "node:fs/promises";
 import { access } from "node:fs/promises";
 import { fileURLToPath } from "node:url";
+import { copyRendererSidecarAssets } from "./renderer-sidecar-assets.mjs";
 import { copyRuntimeWasmAssets } from "./runtime-wasm-assets.mjs";
 import { writeViewerCssManifest } from "./viewer-css-assets.mjs";
 
 const siftWasmUrl = new URL("../../../crates/sift-wasm/pkg/sift_wasm_bg.wasm", import.meta.url);
-const outputUrl = new URL("../dist/plugins/sift_wasm.wasm", import.meta.url);
 const runtimedWasmModuleUrl = new URL(
   "../../notebook/src/wasm/runtimed-wasm/runtimed_wasm.js",
   import.meta.url,
@@ -20,14 +20,6 @@ const isolatedRendererModuleUrl = new URL(
 );
 const isolatedRendererCssUrl = new URL(
   "../../notebook/src/renderer-plugins/isolated-renderer.css",
-  import.meta.url,
-);
-const isolatedRendererModuleOutputUrl = new URL(
-  "../dist/plugins/isolated-renderer.js",
-  import.meta.url,
-);
-const isolatedRendererCssOutputUrl = new URL(
-  "../dist/plugins/isolated-renderer.css",
   import.meta.url,
 );
 const outputDocumentFrameUrl = new URL(
@@ -45,33 +37,35 @@ await assertExists(outputDocumentFrameUrl);
 await mkdir(new URL("../dist/plugins/", import.meta.url), { recursive: true });
 await mkdir(new URL("../dist/assets/", import.meta.url), { recursive: true });
 await mkdir(new URL("../dist-output-document/", import.meta.url), { recursive: true });
-await copyFile(siftWasmUrl, outputUrl);
+const rendererSidecarAssets = await copyRendererSidecarAssets({
+  rendererJsUrl: isolatedRendererModuleUrl,
+  rendererCssUrl: isolatedRendererCssUrl,
+  siftWasmUrl,
+  assetsDirUrl: new URL("../dist/assets/", import.meta.url),
+  pluginsDirUrl: new URL("../dist/plugins/", import.meta.url),
+});
 const runtimeWasmAssets = await copyRuntimeWasmAssets({
   moduleUrl: runtimedWasmModuleUrl,
   wasmUrl: runtimedWasmUrl,
   assetsDirUrl: new URL("../dist/assets/", import.meta.url),
   pluginsDirUrl: new URL("../dist/plugins/", import.meta.url),
 });
-await copyFile(isolatedRendererModuleUrl, isolatedRendererModuleOutputUrl);
-await copyFile(isolatedRendererCssUrl, isolatedRendererCssOutputUrl);
 await copyFile(outputDocumentFrameUrl, outputDocumentOutputUrl);
 const { manifest, manifestUrl } = await writeViewerCssManifest(
   new URL("../dist/assets/", import.meta.url),
 );
 
-console.log(`copied ${fileURLToPath(siftWasmUrl)} -> ${fileURLToPath(outputUrl)}`);
+for (const copy of rendererSidecarAssets.copies) {
+  console.log(`copied ${fileURLToPath(copy.sourceUrl)} -> ${fileURLToPath(copy.outputUrl)}`);
+}
 for (const copy of runtimeWasmAssets.copies) {
   console.log(`copied ${fileURLToPath(copy.sourceUrl)} -> ${fileURLToPath(copy.outputUrl)}`);
 }
 console.log(
-  `copied ${fileURLToPath(isolatedRendererModuleUrl)} -> ${fileURLToPath(isolatedRendererModuleOutputUrl)}`,
-);
-console.log(
-  `copied ${fileURLToPath(isolatedRendererCssUrl)} -> ${fileURLToPath(isolatedRendererCssOutputUrl)}`,
-);
-console.log(
   `copied ${fileURLToPath(outputDocumentFrameUrl)} -> ${fileURLToPath(outputDocumentOutputUrl)}`,
 );
+console.log(`wrote renderer sidecar manifest ${fileURLToPath(rendererSidecarAssets.manifestUrl)}`);
+console.log(`renderer sidecar assets: ${JSON.stringify(rendererSidecarAssets.manifest)}`);
 console.log(`wrote runtime WASM manifest ${fileURLToPath(runtimeWasmAssets.manifestUrl)}`);
 console.log(`runtime WASM assets: ${JSON.stringify(runtimeWasmAssets.manifest)}`);
 console.log(`wrote viewer CSS manifest ${fileURLToPath(manifestUrl)}`);

--- a/apps/notebook-cloud/scripts/renderer-sidecar-assets.mjs
+++ b/apps/notebook-cloud/scripts/renderer-sidecar-assets.mjs
@@ -1,0 +1,68 @@
+import { createHash } from "node:crypto";
+import { mkdir, readFile, writeFile } from "node:fs/promises";
+
+/**
+ * Content-hashed renderer sidecar assets (PR #3449's runtime-wasm pattern
+ * applied to the remaining un-hashed sidecars): the isolated renderer
+ * bundle and Sift's WASM binary are written under BOTH their stable names
+ * (documented fallback for shells without manifest names) and
+ * content-hashed names. Hashed pathnames let the renderer-assets worker's
+ * isContentHashedAssetPathname serve them with year-long immutable
+ * caching; the sift_wasm `?v=` query is retired on the cloud path.
+ */
+
+export const RENDERER_SIDECAR_ASSET_MANIFEST = "renderer-sidecar-assets.json";
+export const ISOLATED_RENDERER_JS_STABLE_NAME = "isolated-renderer.js";
+export const ISOLATED_RENDERER_CSS_STABLE_NAME = "isolated-renderer.css";
+export const SIFT_WASM_STABLE_NAME = "sift_wasm.wasm";
+
+export async function copyRendererSidecarAssets({
+  rendererJsUrl,
+  rendererCssUrl,
+  siftWasmUrl,
+  assetsDirUrl,
+  pluginsDirUrl,
+  hashLength = 16,
+}) {
+  const [jsBytes, cssBytes, siftWasmBytes] = await Promise.all([
+    readFile(rendererJsUrl),
+    readFile(rendererCssUrl),
+    readFile(siftWasmUrl),
+  ]);
+  const manifest = {
+    js: `isolated-renderer.${sha256Hex(jsBytes).slice(0, hashLength)}.js`,
+    css: `isolated-renderer.${sha256Hex(cssBytes).slice(0, hashLength)}.css`,
+    siftWasm: `sift_wasm.${sha256Hex(siftWasmBytes).slice(0, hashLength)}.wasm`,
+  };
+
+  await mkdir(pluginsDirUrl, { recursive: true });
+  await mkdir(assetsDirUrl, { recursive: true });
+
+  const copies = [];
+  const assets = [
+    [rendererJsUrl, jsBytes, ISOLATED_RENDERER_JS_STABLE_NAME, manifest.js],
+    [rendererCssUrl, cssBytes, ISOLATED_RENDERER_CSS_STABLE_NAME, manifest.css],
+    [siftWasmUrl, siftWasmBytes, SIFT_WASM_STABLE_NAME, manifest.siftWasm],
+  ];
+  for (const [sourceUrl, bytes, stableName, hashedName] of assets) {
+    copies.push(
+      await writeSidecarAsset(sourceUrl, bytes, pluginsDirUrl, stableName),
+      await writeSidecarAsset(sourceUrl, bytes, pluginsDirUrl, hashedName),
+    );
+  }
+
+  const manifestUrl = new URL(RENDERER_SIDECAR_ASSET_MANIFEST, assetsDirUrl);
+  await writeFile(manifestUrl, `${JSON.stringify(manifest, null, 2)}\n`);
+
+  return { copies, manifest, manifestUrl };
+}
+
+async function writeSidecarAsset(sourceUrl, bytes, outputDirUrl, outputName) {
+  const outputUrl = new URL(outputName, outputDirUrl);
+  await writeFile(outputUrl, bytes);
+  return { sourceUrl, outputUrl };
+}
+
+function sha256Hex(bytes) {
+  return createHash("sha256").update(bytes).digest("hex");
+}

--- a/apps/notebook-cloud/src/index.ts
+++ b/apps/notebook-cloud/src/index.ts
@@ -127,6 +127,10 @@ const DEFAULT_RUNTIMED_WASM_BASE_PATH = "/assets/";
 const VIEWER_RUNTIME_WASM_ASSET_MANIFEST_PATH = "/assets/runtime-wasm-assets.json";
 const VIEWER_RUNTIMED_WASM_MODULE_NAME = "runtimed_wasm.js";
 const VIEWER_RUNTIMED_WASM_NAME = "runtimed_wasm_bg.wasm";
+const VIEWER_RENDERER_SIDECAR_MANIFEST_PATH = "/assets/renderer-sidecar-assets.json";
+const VIEWER_ISOLATED_RENDERER_JS_NAME = "isolated-renderer.js";
+const VIEWER_ISOLATED_RENDERER_CSS_NAME = "isolated-renderer.css";
+const VIEWER_SIFT_WASM_NAME = "sift_wasm.wasm";
 const SNAPSHOT_BLOB_HEAD_CONCURRENCY = 16;
 // One R2 HEAD is issued per referenced blob during snapshot-pair validation.
 // Cap the total so a single publish cannot fan out unbounded billable R2
@@ -145,6 +149,12 @@ interface MissingSnapshotBlob {
 interface RuntimeWasmAssetNames {
   module: string;
   wasm: string;
+}
+
+interface RendererSidecarAssetNames {
+  js: string;
+  css: string;
+  siftWasm: string;
 }
 
 type SnapshotPairValidationResult =
@@ -3576,6 +3586,7 @@ async function viewer(
   const shellMetadata = await publicViewerShellMetadata(env, notebookId, headsHash);
   const notebookApiBasePath = `/api/n/${encodeURIComponent(notebookId)}`;
   const runtimeWasmAssets = await runtimeWasmAssetNames(env);
+  const rendererSidecarAssets = await rendererSidecarAssetNames(env);
   const session = await readCloudAppSession(env, request).catch(() => null);
   const config = {
     notebookId,
@@ -3597,6 +3608,7 @@ async function viewer(
     syncEndpoint: `/n/${encodeURIComponent(notebookId)}/sync`,
     blobBasePath: notebookCloudBlobBasePath(notebookId),
     rendererAssetsBasePath: rendererAssetsBasePath(env),
+    rendererAssets: rendererSidecarAssets,
     outputDocumentBaseUrl: outputDocumentBaseUrl(env),
     runtimedWasmModulePath: runtimedWasmAssetPath(env, runtimeWasmAssets.module),
     runtimedWasmPath: runtimedWasmAssetPath(env, runtimeWasmAssets.wasm),
@@ -3610,6 +3622,7 @@ async function viewer(
 interface ViewerShellConfig extends Record<string, unknown> {
   outputDocumentBaseUrl?: string | null;
   rendererAssetsBasePath?: string;
+  rendererAssets?: RendererSidecarAssetNames;
   runtimedWasmModulePath: string;
   runtimedWasmPath: string;
   workstationAttachEndpoint?: string;
@@ -3917,6 +3930,69 @@ function isRuntimeWasmModuleName(value: unknown): value is string {
 
 function isRuntimeWasmBinaryName(value: unknown): value is string {
   return typeof value === "string" && /^runtimed_wasm_bg(?:\.[a-f0-9]{12,64})?\.wasm$/.test(value);
+}
+
+/**
+ * Content-hashed renderer sidecar names from the deploy manifest. The
+ * hashed pathnames ride the renderer-assets worker's immutable caching;
+ * a missing/invalid manifest falls back to the stable names, which stay
+ * deployed alongside the hashed copies.
+ */
+async function rendererSidecarAssetNames(env: Env): Promise<RendererSidecarAssetNames> {
+  if (!env.ASSETS) {
+    return defaultRendererSidecarAssetNames();
+  }
+
+  try {
+    const manifestRequest = new Request(
+      `https://notebook-cloud.local${VIEWER_RENDERER_SIDECAR_MANIFEST_PATH}`,
+    );
+    const response = await env.ASSETS.fetch(manifestRequest);
+    if (!response.ok) {
+      return defaultRendererSidecarAssetNames();
+    }
+    const manifest = await response.json();
+    if (isRendererSidecarAssetManifest(manifest)) {
+      return manifest;
+    }
+    cloudLog("warn", "viewer.renderer_sidecar_manifest.invalid", {
+      manifest_path: VIEWER_RENDERER_SIDECAR_MANIFEST_PATH,
+    });
+  } catch (error) {
+    cloudLog("warn", "viewer.renderer_sidecar_manifest.failed", {
+      manifest_path: VIEWER_RENDERER_SIDECAR_MANIFEST_PATH,
+      error: errorMessage(error),
+    });
+  }
+
+  return defaultRendererSidecarAssetNames();
+}
+
+function defaultRendererSidecarAssetNames(): RendererSidecarAssetNames {
+  return {
+    js: VIEWER_ISOLATED_RENDERER_JS_NAME,
+    css: VIEWER_ISOLATED_RENDERER_CSS_NAME,
+    siftWasm: VIEWER_SIFT_WASM_NAME,
+  };
+}
+
+function isRendererSidecarAssetManifest(value: unknown): value is RendererSidecarAssetNames {
+  if (!value || typeof value !== "object") {
+    return false;
+  }
+  const manifest = value as Record<string, unknown>;
+  return (
+    isSidecarAssetName(manifest.js, "isolated-renderer", "js") &&
+    isSidecarAssetName(manifest.css, "isolated-renderer", "css") &&
+    isSidecarAssetName(manifest.siftWasm, "sift_wasm", "wasm")
+  );
+}
+
+function isSidecarAssetName(value: unknown, stem: string, extension: string): value is string {
+  return (
+    typeof value === "string" &&
+    new RegExp(`^${stem}(?:\\.[a-f0-9]{12,64})?\\.${extension}$`).test(value)
+  );
 }
 
 function debugViewer(notebookId: string, request: Request): Response {

--- a/apps/notebook-cloud/test/html.test.ts
+++ b/apps/notebook-cloud/test/html.test.ts
@@ -101,6 +101,10 @@ describe("HTML script serialization", () => {
     assert.doesNotMatch(html, /"canSubmitExecutionRequests":true/);
     assert.match(html, /"blobBasePath":"\/api\/n\/demo\/blobs\/"/);
     assert.match(html, /"rendererAssetsBasePath":"\/renderer-assets\/"/);
+    assert.match(
+      html,
+      /"rendererAssets":\{"js":"isolated-renderer\.js","css":"isolated-renderer\.css","siftWasm":"sift_wasm\.wasm"\}/,
+    );
     assert.match(html, /"runtimedWasmModulePath":"\/assets\/runtimed_wasm\.js"/);
     assert.match(html, /"runtimedWasmPath":"\/assets\/runtimed_wasm_bg\.wasm"/);
     assert.doesNotMatch(html, /function renderNotebook/);
@@ -112,10 +116,12 @@ describe("HTML script serialization", () => {
     const response = await worker.fetch(
       new Request("https://cloud.test/n/demo/r/heads-123"),
       fakeEnv({
-        ASSETS: fakeRuntimeWasmManifestAssets(
+        ASSETS: fakeViewerAssetManifests(
           {
-            module: "runtimed_wasm.0123456789abcdef.js",
-            wasm: "runtimed_wasm_bg.fedcba9876543210.wasm",
+            runtimeWasm: {
+              module: "runtimed_wasm.0123456789abcdef.js",
+              wasm: "runtimed_wasm_bg.fedcba9876543210.wasm",
+            },
           },
           seenPaths,
         ),
@@ -125,7 +131,10 @@ describe("HTML script serialization", () => {
     const html = await response.text();
 
     assert.equal(response.status, 200);
-    assert.deepEqual(seenPaths, ["/assets/runtime-wasm-assets.json"]);
+    assert.deepEqual(seenPaths, [
+      "/assets/runtime-wasm-assets.json",
+      "/assets/renderer-sidecar-assets.json",
+    ]);
     assert.match(
       html,
       /rel="modulepreload" href="\/assets\/runtimed_wasm\.0123456789abcdef\.js" crossorigin/,
@@ -136,6 +145,62 @@ describe("HTML script serialization", () => {
     );
     assert.match(html, /"runtimedWasmModulePath":"\/assets\/runtimed_wasm\.0123456789abcdef\.js"/);
     assert.match(html, /"runtimedWasmPath":"\/assets\/runtimed_wasm_bg\.fedcba9876543210\.wasm"/);
+    // No sidecar manifest deployed: stable renderer asset names remain.
+    assert.match(
+      html,
+      /"rendererAssets":\{"js":"isolated-renderer\.js","css":"isolated-renderer\.css","siftWasm":"sift_wasm\.wasm"\}/,
+    );
+  });
+
+  it("uses content-hashed renderer sidecar assets from the deploy manifest", async () => {
+    const seenPaths: string[] = [];
+    const response = await worker.fetch(
+      new Request("https://cloud.test/n/demo/r/heads-123"),
+      fakeEnv({
+        ASSETS: fakeViewerAssetManifests(
+          {
+            rendererSidecar: {
+              js: "isolated-renderer.0123456789abcdef.js",
+              css: "isolated-renderer.fedcba9876543210.css",
+              siftWasm: "sift_wasm.a1b2c3d4e5f60718.wasm",
+            },
+          },
+          seenPaths,
+        ),
+      }),
+      fakeContext(),
+    );
+    const html = await response.text();
+
+    assert.equal(response.status, 200);
+    assert.ok(seenPaths.includes("/assets/renderer-sidecar-assets.json"));
+    assert.match(
+      html,
+      /"rendererAssets":\{"js":"isolated-renderer\.0123456789abcdef\.js","css":"isolated-renderer\.fedcba9876543210\.css","siftWasm":"sift_wasm\.a1b2c3d4e5f60718\.wasm"\}/,
+    );
+  });
+
+  it("falls back to stable renderer sidecar names when the manifest is invalid", async () => {
+    const response = await worker.fetch(
+      new Request("https://cloud.test/n/demo/r/heads-123"),
+      fakeEnv({
+        ASSETS: fakeViewerAssetManifests({
+          rendererSidecar: {
+            js: "../assets/notebook-cloud-viewer.js",
+            css: "isolated-renderer.css",
+            siftWasm: "sift_wasm.wasm",
+          },
+        }),
+      }),
+      fakeContext(),
+    );
+    const html = await response.text();
+
+    assert.equal(response.status, 200);
+    assert.match(
+      html,
+      /"rendererAssets":\{"js":"isolated-renderer\.js","css":"isolated-renderer\.css","siftWasm":"sift_wasm\.wasm"\}/,
+    );
   });
 
   it("does not serve legacy one-segment notebook viewer URLs", async () => {
@@ -363,16 +428,24 @@ function fakeEnv(overrides: Partial<Env> = {}): Env {
   };
 }
 
-function fakeRuntimeWasmManifestAssets(
-  manifest: { module: string; wasm: string },
+function fakeViewerAssetManifests(
+  manifests: {
+    runtimeWasm?: { module: string; wasm: string };
+    rendererSidecar?: { js: string; css: string; siftWasm: string } | Record<string, unknown>;
+  },
   seenPaths: string[] = [],
 ): Env["ASSETS"] {
   return {
     fetch: async (request: Request) => {
       const pathname = new URL(request.url).pathname;
       seenPaths.push(pathname);
-      if (pathname === "/assets/runtime-wasm-assets.json") {
-        return new Response(JSON.stringify(manifest), {
+      if (manifests.runtimeWasm && pathname === "/assets/runtime-wasm-assets.json") {
+        return new Response(JSON.stringify(manifests.runtimeWasm), {
+          headers: { "Content-Type": "application/json" },
+        });
+      }
+      if (manifests.rendererSidecar && pathname === "/assets/renderer-sidecar-assets.json") {
+        return new Response(JSON.stringify(manifests.rendererSidecar), {
           headers: { "Content-Type": "application/json" },
         });
       }

--- a/apps/notebook-cloud/test/html.test.ts
+++ b/apps/notebook-cloud/test/html.test.ts
@@ -185,12 +185,43 @@ describe("HTML script serialization", () => {
       new Request("https://cloud.test/n/demo/r/heads-123"),
       fakeEnv({
         ASSETS: fakeViewerAssetManifests({
+          // js is invalid while css is a VALID hashed name: the whole
+          // manifest must be rejected (never a per-field mix of a stable
+          // js with a hashed css from another deploy).
           rendererSidecar: {
             js: "../assets/notebook-cloud-viewer.js",
-            css: "isolated-renderer.css",
+            css: "isolated-renderer.fedcba9876543210.css",
             siftWasm: "sift_wasm.wasm",
           },
         }),
+      }),
+      fakeContext(),
+    );
+    const html = await response.text();
+
+    assert.equal(response.status, 200);
+    assert.match(
+      html,
+      /"rendererAssets":\{"js":"isolated-renderer\.js","css":"isolated-renderer\.css","siftWasm":"sift_wasm\.wasm"\}/,
+    );
+    assert.doesNotMatch(html, /fedcba9876543210/);
+  });
+
+  it("falls back to stable renderer sidecar names when the manifest body is not JSON", async () => {
+    const response = await worker.fetch(
+      new Request("https://cloud.test/n/demo/r/heads-123"),
+      fakeEnv({
+        ASSETS: {
+          fetch: async (request: Request) => {
+            const pathname = new URL(request.url).pathname;
+            if (pathname === "/assets/renderer-sidecar-assets.json") {
+              return new Response("not json", {
+                headers: { "Content-Type": "application/json" },
+              });
+            }
+            return new Response("not found", { status: 404 });
+          },
+        },
       }),
       fakeContext(),
     );

--- a/apps/notebook-cloud/test/renderer-assets-worker.test.ts
+++ b/apps/notebook-cloud/test/renderer-assets-worker.test.ts
@@ -79,6 +79,46 @@ describe("renderer assets Worker", () => {
     assert.equal(response.headers.get("Cache-Control"), "public, max-age=31536000, immutable");
   });
 
+  it("serves content-hashed renderer sidecars with immutable caching", async () => {
+    const cases = [
+      "https://assets.test/renderer-assets/isolated-renderer.0123456789abcdef.js",
+      "https://assets.test/renderer-assets/isolated-renderer.fedcba9876543210.css",
+      "https://assets.test/renderer-assets/sift_wasm.a1b2c3d4e5f60718.wasm",
+    ];
+
+    for (const url of cases) {
+      const response = await rendererAssetsWorker.fetch(
+        new Request(url),
+        fakeEnv({
+          ASSETS: {
+            fetch: async () => new Response("sidecar"),
+          },
+        }),
+        fakeContext(),
+      );
+
+      assert.equal(response.status, 200);
+      assert.equal(response.headers.get("Cache-Control"), "public, max-age=31536000, immutable");
+    }
+  });
+
+  it("keeps stable-name renderer sidecars on must-revalidate", async () => {
+    for (const name of ["isolated-renderer.js", "isolated-renderer.css"]) {
+      const response = await rendererAssetsWorker.fetch(
+        new Request(`https://assets.test/renderer-assets/${name}`),
+        fakeEnv({
+          ASSETS: {
+            fetch: async () => new Response("sidecar"),
+          },
+        }),
+        fakeContext(),
+      );
+
+      assert.equal(response.status, 200);
+      assert.equal(response.headers.get("Cache-Control"), "public, max-age=0, must-revalidate");
+    }
+  });
+
   it("does not expose the notebook app bundle from the renderer asset origin", async () => {
     const response = await rendererAssetsWorker.fetch(
       new Request("https://assets.test/assets/notebook-cloud-viewer.js"),

--- a/apps/notebook-cloud/test/renderer-sidecar-assets.test.mjs
+++ b/apps/notebook-cloud/test/renderer-sidecar-assets.test.mjs
@@ -1,0 +1,99 @@
+import assert from "node:assert/strict";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { describe, it } from "node:test";
+import { mkdtemp, mkdir, readFile, stat, writeFile } from "node:fs/promises";
+import { pathToFileURL } from "node:url";
+
+import {
+  ISOLATED_RENDERER_CSS_STABLE_NAME,
+  ISOLATED_RENDERER_JS_STABLE_NAME,
+  RENDERER_SIDECAR_ASSET_MANIFEST,
+  SIFT_WASM_STABLE_NAME,
+  copyRendererSidecarAssets,
+} from "../scripts/renderer-sidecar-assets.mjs";
+
+describe("renderer sidecar asset copying", () => {
+  it("emits stable compatibility files plus content-hashed sidecar assets", async () => {
+    const tempDir = await mkdtemp(join(tmpdir(), "renderer-sidecar-assets-"));
+    const tempUrl = pathToFileURL(`${tempDir}/`);
+    const sourceDirUrl = new URL("source/", tempUrl);
+    const assetsDirUrl = new URL("dist/assets/", tempUrl);
+    const pluginsDirUrl = new URL("dist/plugins/", tempUrl);
+    const rendererJsUrl = new URL(ISOLATED_RENDERER_JS_STABLE_NAME, sourceDirUrl);
+    const rendererCssUrl = new URL(ISOLATED_RENDERER_CSS_STABLE_NAME, sourceDirUrl);
+    const siftWasmUrl = new URL(SIFT_WASM_STABLE_NAME, sourceDirUrl);
+    const jsSource = "(() => { /* isolated renderer */ })();\n";
+    const cssSource = ".isolated-renderer { color: inherit; }\n";
+    const wasmBytes = "sift wasm bytes";
+
+    await mkdir(sourceDirUrl, { recursive: true });
+    await writeFile(rendererJsUrl, jsSource);
+    await writeFile(rendererCssUrl, cssSource);
+    await writeFile(siftWasmUrl, wasmBytes);
+
+    const result = await copyRendererSidecarAssets({
+      rendererJsUrl,
+      rendererCssUrl,
+      siftWasmUrl,
+      assetsDirUrl,
+      pluginsDirUrl,
+    });
+
+    assert.match(result.manifest.js, /^isolated-renderer\.[a-f0-9]{16}\.js$/);
+    assert.match(result.manifest.css, /^isolated-renderer\.[a-f0-9]{16}\.css$/);
+    assert.match(result.manifest.siftWasm, /^sift_wasm\.[a-f0-9]{16}\.wasm$/);
+
+    // Stable names AND hashed names in the plugins dir (the renderer-assets
+    // worker's asset root; the main origin serves the same dir via
+    // /plugins/ and /renderer-assets/).
+    assert.equal(
+      await readFile(new URL(ISOLATED_RENDERER_JS_STABLE_NAME, pluginsDirUrl), "utf8"),
+      jsSource,
+    );
+    assert.equal(
+      await readFile(new URL(ISOLATED_RENDERER_CSS_STABLE_NAME, pluginsDirUrl), "utf8"),
+      cssSource,
+    );
+    assert.equal(await readFile(new URL(SIFT_WASM_STABLE_NAME, pluginsDirUrl), "utf8"), wasmBytes);
+    assert.equal(await readFile(new URL(result.manifest.js, pluginsDirUrl), "utf8"), jsSource);
+    assert.equal(await readFile(new URL(result.manifest.css, pluginsDirUrl), "utf8"), cssSource);
+    assert.equal(
+      await readFile(new URL(result.manifest.siftWasm, pluginsDirUrl), "utf8"),
+      wasmBytes,
+    );
+
+    const manifest = JSON.parse(
+      await readFile(new URL(RENDERER_SIDECAR_ASSET_MANIFEST, assetsDirUrl), "utf8"),
+    );
+    assert.deepEqual(manifest, result.manifest);
+    await stat(result.manifestUrl);
+  });
+
+  it("derives distinct hashes per asset content", async () => {
+    const tempDir = await mkdtemp(join(tmpdir(), "renderer-sidecar-assets-"));
+    const tempUrl = pathToFileURL(`${tempDir}/`);
+    const sourceDirUrl = new URL("source/", tempUrl);
+    const rendererJsUrl = new URL("a.js", sourceDirUrl);
+    const rendererCssUrl = new URL("a.css", sourceDirUrl);
+    const siftWasmUrl = new URL("a.wasm", sourceDirUrl);
+
+    await mkdir(sourceDirUrl, { recursive: true });
+    await writeFile(rendererJsUrl, "same-bytes");
+    await writeFile(rendererCssUrl, "same-bytes");
+    await writeFile(siftWasmUrl, "other-bytes");
+
+    const result = await copyRendererSidecarAssets({
+      rendererJsUrl,
+      rendererCssUrl,
+      siftWasmUrl,
+      assetsDirUrl: new URL("dist/assets/", tempUrl),
+      pluginsDirUrl: new URL("dist/plugins/", tempUrl),
+    });
+
+    const hashOf = (name) => name.split(".")[1];
+    // Same content -> same hash segment; different content -> different.
+    assert.equal(hashOf(result.manifest.js), hashOf(result.manifest.css));
+    assert.notEqual(hashOf(result.manifest.js), hashOf(result.manifest.siftWasm));
+  });
+});

--- a/apps/notebook-cloud/test/runtimed-wasm-client-retry.test.ts
+++ b/apps/notebook-cloud/test/runtimed-wasm-client-retry.test.ts
@@ -1,0 +1,107 @@
+/**
+ * Retry/caching behavior of the runtimed WASM client.
+ *
+ * The load path caches the dynamic `import()` promise for the life of the
+ * page. Before the cached-rejection fix, a single transient import failure
+ * pinned the rejected promise forever: every later attempt — including
+ * retryLiveConnection reconnects — re-awaited the same rejection. These
+ * tests inject a controllable importer to prove a failed attempt clears
+ * the cache so the next attempt really re-imports.
+ *
+ * Runs in its own file: the runtimed-wasm-client module caches the loaded
+ * module singleton per process, so these tests must not share a process
+ * with anything that initializes the real WASM module.
+ */
+
+import { afterEach, beforeEach, describe, it } from "node:test";
+import assert from "node:assert/strict";
+import {
+  _resetRuntimedWasmClientForTests,
+  _setRuntimedWasmModuleImporterForTests,
+  initializeRuntimedWasmClient,
+} from "../viewer/runtimed-wasm-client.ts";
+
+function stubModule(initCalls: unknown[] = []) {
+  return {
+    default: async (options: { module_or_path: unknown }) => {
+      initCalls.push(options.module_or_path);
+    },
+    project_markdown_json: () => null,
+  };
+}
+
+describe("runtimed WASM client cached-rejection recovery", () => {
+  beforeEach(() => {
+    _resetRuntimedWasmClientForTests();
+  });
+
+  afterEach(() => {
+    _setRuntimedWasmModuleImporterForTests(null);
+    _resetRuntimedWasmClientForTests();
+  });
+
+  it("clears the cached import on rejection so a retry can succeed", async () => {
+    const importedHrefs: string[] = [];
+    let failuresRemaining = 1;
+    _setRuntimedWasmModuleImporterForTests(async (href) => {
+      importedHrefs.push(href);
+      if (failuresRemaining > 0) {
+        failuresRemaining -= 1;
+        throw new TypeError("Failed to fetch dynamically imported module");
+      }
+      return stubModule();
+    });
+
+    await assert.rejects(
+      initializeRuntimedWasmClient("/assets/runtimed_wasm.js", "/assets/runtimed_wasm_bg.wasm"),
+      /Failed to fetch dynamically imported module/,
+    );
+
+    // The retry path (retryLiveConnection / a fresh connect attempt) calls
+    // initialize again. Before the fix this re-awaited the pinned rejected
+    // import; with it, a fresh import() is issued and succeeds.
+    const module = await initializeRuntimedWasmClient(
+      "/assets/runtimed_wasm.js",
+      "/assets/runtimed_wasm_bg.wasm",
+    );
+
+    assert.equal(typeof module.project_markdown_json, "function");
+    assert.equal(importedHrefs.length, 2);
+    assert.deepEqual(importedHrefs, ["/assets/runtimed_wasm.js", "/assets/runtimed_wasm.js"]);
+  });
+
+  it("clears the init cache when wasm-bindgen init rejects, then recovers", async () => {
+    const initCalls: unknown[] = [];
+    let initFailures = 1;
+    _setRuntimedWasmModuleImporterForTests(async () => ({
+      default: async (options: { module_or_path: unknown }) => {
+        if (initFailures > 0) {
+          initFailures -= 1;
+          throw new Error("synthetic wasm init failure");
+        }
+        initCalls.push(options.module_or_path);
+      },
+      project_markdown_json: () => null,
+    }));
+
+    await assert.rejects(
+      initializeRuntimedWasmClient("/assets/runtimed_wasm.js", "/assets/runtimed_wasm_bg.wasm"),
+      /synthetic wasm init failure/,
+    );
+
+    await initializeRuntimedWasmClient("/assets/runtimed_wasm.js", "/assets/runtimed_wasm_bg.wasm");
+
+    assert.equal(initCalls.length, 1);
+  });
+
+  it("still refuses a second initialization from a different source", async () => {
+    _setRuntimedWasmModuleImporterForTests(async () => stubModule());
+
+    await initializeRuntimedWasmClient("/assets/runtimed_wasm.js", "/assets/runtimed_wasm_bg.wasm");
+
+    await assert.rejects(
+      initializeRuntimedWasmClient("/assets/runtimed_wasm.js", "/assets/other_bg.wasm"),
+      /already initialized from/,
+    );
+  });
+});

--- a/apps/notebook-cloud/test/runtimed-wasm-client-retry.test.ts
+++ b/apps/notebook-cloud/test/runtimed-wasm-client-retry.test.ts
@@ -1,18 +1,21 @@
 /**
  * Retry/caching behavior of the runtimed WASM client.
  *
- * Three layers under test:
- *  1. Cached-rejection recovery — the dynamic import() promise is cached
- *     for the life of the page; a failed connect attempt must clear it so
- *     the next attempt (retryLiveConnection) really re-imports instead of
- *     re-awaiting a pinned rejection.
+ * Layers under test:
+ *  1. Cached-rejection recovery — a failed connect attempt clears the
+ *     cached import so retryLiveConnection really re-imports.
  *  2. The retry ladder ([150, 500, 1500] ms) for both the module import
  *     and the .wasm binary fetch — thrown fetch errors and 404/409/425/
  *     429/5xx statuses retry (404 deliberately, for deploy propagation);
- *     other statuses bail immediately.
- *  3. The hashed→stable filename fallback — runtimed_wasm.<hash>.js /
- *     runtimed_wasm_bg.<hash>.wasm fall back to their stable-name copies
- *     after the ladder exhausts, absorbing deploy-window skew.
+ *     other statuses bail. Delays are boundary-pinned per ladder.
+ *  3. Module-map busting — import() retry rungs carry a unique ?retry=
+ *     query because the browser module map pins failed fetches per
+ *     specifier for the life of the page.
+ *  4. The hashed→stable filename fallback, COUPLED pairwise: if either
+ *     half falls back to stable, the other follows (never hashed glue
+ *     against a stable binary or vice versa — the #3416 skew class).
+ *  5. Per-rung timeouts — a hung attempt becomes a failed rung instead of
+ *     wedging the shared init singleton forever.
  *
  * Runs in its own file: the runtimed-wasm-client module caches the loaded
  * module singleton per process, so these tests must not share a process
@@ -53,6 +56,11 @@ function okFetch(): { calls: string[]; fetch: typeof fetch } {
   };
 }
 
+/** Strip the module-map cache buster for name-based assertions. */
+function unbusted(href: string): string {
+  return href.replace(/[?&]retry=\d+$/, "");
+}
+
 /** Settle the promise chains between mocked-timer ticks. */
 async function drain(): Promise<void> {
   for (let i = 0; i < 25; i += 1) {
@@ -80,7 +88,7 @@ describe("runtimed WASM client retry ladder", () => {
     _resetRuntimedWasmClientForTests();
   });
 
-  it("retries the module import on the exact ladder delays", async (t: TestContext) => {
+  it("retries the module import on the exact ladder delays with module-map busting", async (t: TestContext) => {
     t.mock.timers.enable({ apis: ["setTimeout"] });
     const importedHrefs: string[] = [];
     let failuresRemaining = 2;
@@ -117,7 +125,13 @@ describe("runtimed WASM client retry ladder", () => {
 
     const module = await pending;
     assert.equal(typeof module.project_markdown_json, "function");
-    assert.deepEqual(importedHrefs, [STABLE_MODULE, STABLE_MODULE, STABLE_MODULE]);
+    // Retry rungs bust the browser module map (failed module fetches are
+    // pinned per specifier); rung 0 uses the bare name.
+    assert.deepEqual(importedHrefs, [
+      STABLE_MODULE,
+      `${STABLE_MODULE}?retry=1`,
+      `${STABLE_MODULE}?retry=2`,
+    ]);
     assert.deepEqual(wasmFetch.calls, [STABLE_WASM]);
   });
 
@@ -126,7 +140,7 @@ describe("runtimed WASM client retry ladder", () => {
     const importedHrefs: string[] = [];
     _setRuntimedWasmModuleImporterForTests(async (href) => {
       importedHrefs.push(href);
-      if (href === HASHED_MODULE) {
+      if (unbusted(href) === HASHED_MODULE) {
         throw new TypeError("Failed to fetch dynamically imported module");
       }
       return stubModule();
@@ -143,14 +157,15 @@ describe("runtimed WASM client retry ladder", () => {
 
     assert.deepEqual(importedHrefs, [
       HASHED_MODULE,
-      HASHED_MODULE,
-      HASHED_MODULE,
-      HASHED_MODULE,
+      `${HASHED_MODULE}?retry=1`,
+      `${HASHED_MODULE}?retry=2`,
+      `${HASHED_MODULE}?retry=3`,
       STABLE_MODULE,
     ]);
+    assert.deepEqual(wasmFetch.calls, [STABLE_WASM]);
   });
 
-  it("has no fallback for stable module names: the failure is terminal", async (t: TestContext) => {
+  it("has no fallback for stable module names: the failure is terminal after a boundary-exact final rung", async (t: TestContext) => {
     t.mock.timers.enable({ apis: ["setTimeout"] });
     const importedHrefs: string[] = [];
     _setRuntimedWasmModuleImporterForTests(async (href) => {
@@ -162,23 +177,31 @@ describe("runtimed WASM client retry ladder", () => {
     const { promise, settled } = trackSettled(
       initializeRuntimedWasmClient(STABLE_MODULE, STABLE_WASM),
     );
-    for (const delay of [150, 500, 1500]) {
-      await drain();
-      t.mock.timers.tick(delay);
-    }
     await drain();
+    t.mock.timers.tick(150);
+    await drain();
+    t.mock.timers.tick(500);
+    await drain();
+    assert.equal(importedHrefs.length, 3);
+    // Final rung is exactly 1500ms.
+    t.mock.timers.tick(1499);
+    await drain();
+    assert.equal(importedHrefs.length, 3);
+    assert.equal(settled(), false);
+    t.mock.timers.tick(1);
+    await drain();
+    assert.equal(importedHrefs.length, 4);
     // Exactly one ladder; no further timers pending, the rejection is final.
     assert.equal(settled(), true);
     await assert.rejects(promise, /Failed to fetch dynamically imported module/);
-    assert.equal(importedHrefs.length, 4);
-    assert.ok(importedHrefs.every((href) => href === STABLE_MODULE));
+    assert.ok(importedHrefs.every((href) => unbusted(href) === STABLE_MODULE));
   });
 
-  it("retries the wasm binary on retryable statuses and resolves with the good response", async (t: TestContext) => {
+  it("boundary-pins the binary ladder and retries 404/409/425/429 before the stable fallback", async (t: TestContext) => {
     t.mock.timers.enable({ apis: ["setTimeout"] });
     const initCalls: unknown[] = [];
     _setRuntimedWasmModuleImporterForTests(async () => stubModule(initCalls));
-    const statuses = [404, 503, 429];
+    const statuses = [404, 409, 425, 429];
     const fetchedHrefs: string[] = [];
     _setRuntimedWasmFetchForTests((async (input: RequestInfo | URL) => {
       fetchedHrefs.push(String(input));
@@ -186,16 +209,42 @@ describe("runtimed WASM client retry ladder", () => {
       return status === undefined ? new Response("wasm-bytes") : new Response("nope", { status });
     }) as typeof fetch);
 
-    const pending = initializeRuntimedWasmClient(STABLE_MODULE, STABLE_WASM);
-    for (const delay of [150, 500, 1500]) {
-      await drain();
-      t.mock.timers.tick(delay);
-    }
-    await pending;
+    const pending = initializeRuntimedWasmClient(STABLE_MODULE, HASHED_WASM);
+    await drain();
+    assert.equal(fetchedHrefs.length, 1);
 
-    assert.equal(fetchedHrefs.length, 4);
-    assert.ok(fetchedHrefs.every((href) => href === STABLE_WASM));
-    assert.equal(initCalls.length, 1);
+    // Binary rungs pinned independently of the module ladder.
+    t.mock.timers.tick(149);
+    await drain();
+    assert.equal(fetchedHrefs.length, 1);
+    t.mock.timers.tick(1);
+    await drain();
+    assert.equal(fetchedHrefs.length, 2);
+
+    t.mock.timers.tick(499);
+    await drain();
+    assert.equal(fetchedHrefs.length, 2);
+    t.mock.timers.tick(1);
+    await drain();
+    assert.equal(fetchedHrefs.length, 3);
+
+    t.mock.timers.tick(1499);
+    await drain();
+    assert.equal(fetchedHrefs.length, 3);
+    t.mock.timers.tick(1);
+    await drain();
+    // Final hashed attempt (429) exhausts the ladder; the stable fallback
+    // fires immediately with no further sleep.
+    assert.equal(fetchedHrefs.length, 5);
+
+    await pending;
+    assert.deepEqual(fetchedHrefs, [
+      HASHED_WASM,
+      HASHED_WASM,
+      HASHED_WASM,
+      HASHED_WASM,
+      STABLE_WASM,
+    ]);
     assert.ok(initCalls[0] instanceof Response);
     assert.equal(await (initCalls[0] as Response).text(), "wasm-bytes");
   });
@@ -219,10 +268,14 @@ describe("runtimed WASM client retry ladder", () => {
     assert.deepEqual(fetchedHrefs, [HASHED_WASM, STABLE_WASM]);
   });
 
-  it("falls back from the hashed wasm name to the stable copy after the ladder exhausts", async (t: TestContext) => {
+  it("couples the pair: a binary stable-fallback forces the hashed module onto its stable copy", async (t: TestContext) => {
     t.mock.timers.enable({ apis: ["setTimeout"] });
     const initCalls: unknown[] = [];
-    _setRuntimedWasmModuleImporterForTests(async () => stubModule(initCalls));
+    const importedHrefs: string[] = [];
+    _setRuntimedWasmModuleImporterForTests(async (href) => {
+      importedHrefs.push(href);
+      return stubModule(initCalls);
+    });
     const fetchedHrefs: string[] = [];
     _setRuntimedWasmFetchForTests((async (input: RequestInfo | URL) => {
       const href = String(input);
@@ -232,13 +285,16 @@ describe("runtimed WASM client retry ladder", () => {
         : new Response("wasm-bytes");
     }) as typeof fetch);
 
-    const pending = initializeRuntimedWasmClient(STABLE_MODULE, HASHED_WASM);
+    const pending = initializeRuntimedWasmClient(HASHED_MODULE, HASHED_WASM);
     for (const delay of [150, 500, 1500]) {
       await drain();
       t.mock.timers.tick(delay);
     }
     await pending;
 
+    // Hashed module succeeded, but the binary fell back to stable — the
+    // glue must follow (never hashed glue against a stable binary, #3416).
+    assert.deepEqual(importedHrefs, [HASHED_MODULE, STABLE_MODULE]);
     assert.deepEqual(fetchedHrefs, [
       HASHED_WASM,
       HASHED_WASM,
@@ -246,6 +302,93 @@ describe("runtimed WASM client retry ladder", () => {
       HASHED_WASM,
       STABLE_WASM,
     ]);
+    assert.ok(initCalls[0] instanceof Response);
+  });
+
+  it("couples the pair: a module stable-fallback skips the hashed binary name outright", async (t: TestContext) => {
+    t.mock.timers.enable({ apis: ["setTimeout"] });
+    const importedHrefs: string[] = [];
+    _setRuntimedWasmModuleImporterForTests(async (href) => {
+      importedHrefs.push(href);
+      if (unbusted(href) === HASHED_MODULE) {
+        throw new TypeError("Failed to fetch dynamically imported module");
+      }
+      return stubModule();
+    });
+    const fetchedHrefs: string[] = [];
+    _setRuntimedWasmFetchForTests((async (input: RequestInfo | URL) => {
+      fetchedHrefs.push(String(input));
+      return new Response("wasm-bytes");
+    }) as typeof fetch);
+
+    const pending = initializeRuntimedWasmClient(HASHED_MODULE, HASHED_WASM);
+    for (const delay of [150, 500, 1500]) {
+      await drain();
+      t.mock.timers.tick(delay);
+    }
+    await pending;
+
+    assert.equal(unbusted(importedHrefs[importedHrefs.length - 1] ?? ""), STABLE_MODULE);
+    // The hashed binary name is never attempted once the module pair
+    // already fell back to stable.
+    assert.deepEqual(fetchedHrefs, [STABLE_WASM]);
+  });
+
+  it("turns a hung module import rung into a failed rung instead of wedging the singleton", async (t: TestContext) => {
+    t.mock.timers.enable({ apis: ["setTimeout"] });
+    const importedHrefs: string[] = [];
+    _setRuntimedWasmModuleImporterForTests((href) => {
+      importedHrefs.push(href);
+      if (importedHrefs.length === 1) {
+        return new Promise(() => {}); // black-holed: never settles
+      }
+      return Promise.resolve(stubModule());
+    });
+    _setRuntimedWasmFetchForTests(okFetch().fetch);
+
+    const pending = initializeRuntimedWasmClient(STABLE_MODULE, STABLE_WASM);
+    await drain();
+    assert.equal(importedHrefs.length, 1);
+
+    // The rung timeout (20s) abandons the hung attempt...
+    t.mock.timers.tick(20_000);
+    await drain();
+    assert.equal(importedHrefs.length, 1);
+    // ...and the ladder advances on its normal first rung.
+    t.mock.timers.tick(150);
+    await drain();
+    assert.equal(importedHrefs.length, 2);
+
+    const module = await pending;
+    assert.equal(typeof module.project_markdown_json, "function");
+  });
+
+  it("turns a hung binary fetch rung into a failed rung instead of wedging the connect", async (t: TestContext) => {
+    t.mock.timers.enable({ apis: ["setTimeout"] });
+    const initCalls: unknown[] = [];
+    _setRuntimedWasmModuleImporterForTests(async () => stubModule(initCalls));
+    let fetchCalls = 0;
+    _setRuntimedWasmFetchForTests(((input: RequestInfo | URL) => {
+      void input;
+      fetchCalls += 1;
+      if (fetchCalls === 1) {
+        return new Promise(() => {}); // black-holed: never settles
+      }
+      return Promise.resolve(new Response("wasm-bytes"));
+    }) as typeof fetch);
+
+    const pending = initializeRuntimedWasmClient(STABLE_MODULE, STABLE_WASM);
+    await drain();
+    assert.equal(fetchCalls, 1);
+
+    t.mock.timers.tick(20_000);
+    await drain();
+    assert.equal(fetchCalls, 1);
+    t.mock.timers.tick(150);
+    await drain();
+    assert.equal(fetchCalls, 2);
+
+    await pending;
     assert.ok(initCalls[0] instanceof Response);
   });
 
@@ -291,6 +434,27 @@ describe("runtimed WASM client retry ladder", () => {
 
     assert.equal(typeof module.project_markdown_json, "function");
     assert.equal(importedHrefs.length, 5);
+    assert.equal(importedHrefs[4], STABLE_MODULE);
+  });
+
+  it("prefixes terminal failures for notice classification", async (t: TestContext) => {
+    t.mock.timers.enable({ apis: ["setTimeout"] });
+    _setRuntimedWasmModuleImporterForTests(async () => {
+      throw new TypeError("Failed to fetch dynamically imported module");
+    });
+    _setRuntimedWasmFetchForTests(okFetch().fetch);
+
+    const { promise } = trackSettled(initializeRuntimedWasmClient(STABLE_MODULE, STABLE_WASM));
+    for (const delay of [150, 500, 1500]) {
+      await drain();
+      t.mock.timers.tick(delay);
+    }
+    await drain();
+    await assert.rejects(promise, (error: unknown) => {
+      assert.ok(error instanceof Error);
+      assert.match(error.message, /^runtimed WASM asset failed: /);
+      return true;
+    });
   });
 
   it("clears the init cache when wasm-bindgen init rejects, then recovers", async () => {

--- a/apps/notebook-cloud/test/runtimed-wasm-client-retry.test.ts
+++ b/apps/notebook-cloud/test/runtimed-wasm-client-retry.test.ts
@@ -1,25 +1,37 @@
 /**
  * Retry/caching behavior of the runtimed WASM client.
  *
- * The load path caches the dynamic `import()` promise for the life of the
- * page. Before the cached-rejection fix, a single transient import failure
- * pinned the rejected promise forever: every later attempt — including
- * retryLiveConnection reconnects — re-awaited the same rejection. These
- * tests inject a controllable importer to prove a failed attempt clears
- * the cache so the next attempt really re-imports.
+ * Three layers under test:
+ *  1. Cached-rejection recovery — the dynamic import() promise is cached
+ *     for the life of the page; a failed connect attempt must clear it so
+ *     the next attempt (retryLiveConnection) really re-imports instead of
+ *     re-awaiting a pinned rejection.
+ *  2. The retry ladder ([150, 500, 1500] ms) for both the module import
+ *     and the .wasm binary fetch — thrown fetch errors and 404/409/425/
+ *     429/5xx statuses retry (404 deliberately, for deploy propagation);
+ *     other statuses bail immediately.
+ *  3. The hashed→stable filename fallback — runtimed_wasm.<hash>.js /
+ *     runtimed_wasm_bg.<hash>.wasm fall back to their stable-name copies
+ *     after the ladder exhausts, absorbing deploy-window skew.
  *
  * Runs in its own file: the runtimed-wasm-client module caches the loaded
  * module singleton per process, so these tests must not share a process
  * with anything that initializes the real WASM module.
  */
 
-import { afterEach, beforeEach, describe, it } from "node:test";
+import { afterEach, beforeEach, describe, it, type TestContext } from "node:test";
 import assert from "node:assert/strict";
 import {
   _resetRuntimedWasmClientForTests,
+  _setRuntimedWasmFetchForTests,
   _setRuntimedWasmModuleImporterForTests,
   initializeRuntimedWasmClient,
 } from "../viewer/runtimed-wasm-client.ts";
+
+const HASHED_MODULE = "/assets/runtimed_wasm.0123456789abcdef.js";
+const STABLE_MODULE = "/assets/runtimed_wasm.js";
+const HASHED_WASM = "/assets/runtimed_wasm_bg.fedcba9876543210.wasm";
+const STABLE_WASM = "/assets/runtimed_wasm_bg.wasm";
 
 function stubModule(initCalls: unknown[] = []) {
   return {
@@ -30,19 +42,48 @@ function stubModule(initCalls: unknown[] = []) {
   };
 }
 
-describe("runtimed WASM client cached-rejection recovery", () => {
+function okFetch(): { calls: string[]; fetch: typeof fetch } {
+  const calls: string[] = [];
+  return {
+    calls,
+    fetch: (async (input: RequestInfo | URL) => {
+      calls.push(String(input));
+      return new Response("wasm-bytes");
+    }) as typeof fetch,
+  };
+}
+
+/** Settle the promise chains between mocked-timer ticks. */
+async function drain(): Promise<void> {
+  for (let i = 0; i < 25; i += 1) {
+    await Promise.resolve();
+  }
+}
+
+function trackSettled<T>(promise: Promise<T>): { promise: Promise<T>; settled: () => boolean } {
+  let isSettled = false;
+  const tracked = promise.finally(() => {
+    isSettled = true;
+  });
+  // The caller asserts/awaits `tracked`; rejections are observed there.
+  return { promise: tracked, settled: () => isSettled };
+}
+
+describe("runtimed WASM client retry ladder", () => {
   beforeEach(() => {
     _resetRuntimedWasmClientForTests();
   });
 
   afterEach(() => {
     _setRuntimedWasmModuleImporterForTests(null);
+    _setRuntimedWasmFetchForTests(null);
     _resetRuntimedWasmClientForTests();
   });
 
-  it("clears the cached import on rejection so a retry can succeed", async () => {
+  it("retries the module import on the exact ladder delays", async (t: TestContext) => {
+    t.mock.timers.enable({ apis: ["setTimeout"] });
     const importedHrefs: string[] = [];
-    let failuresRemaining = 1;
+    let failuresRemaining = 2;
     _setRuntimedWasmModuleImporterForTests(async (href) => {
       importedHrefs.push(href);
       if (failuresRemaining > 0) {
@@ -51,23 +92,205 @@ describe("runtimed WASM client cached-rejection recovery", () => {
       }
       return stubModule();
     });
+    const wasmFetch = okFetch();
+    _setRuntimedWasmFetchForTests(wasmFetch.fetch);
 
-    await assert.rejects(
-      initializeRuntimedWasmClient("/assets/runtimed_wasm.js", "/assets/runtimed_wasm_bg.wasm"),
-      /Failed to fetch dynamically imported module/,
+    const pending = initializeRuntimedWasmClient(STABLE_MODULE, STABLE_WASM);
+    await drain();
+    assert.equal(importedHrefs.length, 1);
+
+    // First rung is exactly 150ms.
+    t.mock.timers.tick(149);
+    await drain();
+    assert.equal(importedHrefs.length, 1);
+    t.mock.timers.tick(1);
+    await drain();
+    assert.equal(importedHrefs.length, 2);
+
+    // Second rung is exactly 500ms.
+    t.mock.timers.tick(499);
+    await drain();
+    assert.equal(importedHrefs.length, 2);
+    t.mock.timers.tick(1);
+    await drain();
+    assert.equal(importedHrefs.length, 3);
+
+    const module = await pending;
+    assert.equal(typeof module.project_markdown_json, "function");
+    assert.deepEqual(importedHrefs, [STABLE_MODULE, STABLE_MODULE, STABLE_MODULE]);
+    assert.deepEqual(wasmFetch.calls, [STABLE_WASM]);
+  });
+
+  it("falls back from the hashed module name to the stable copy after the ladder exhausts", async (t: TestContext) => {
+    t.mock.timers.enable({ apis: ["setTimeout"] });
+    const importedHrefs: string[] = [];
+    _setRuntimedWasmModuleImporterForTests(async (href) => {
+      importedHrefs.push(href);
+      if (href === HASHED_MODULE) {
+        throw new TypeError("Failed to fetch dynamically imported module");
+      }
+      return stubModule();
+    });
+    const wasmFetch = okFetch();
+    _setRuntimedWasmFetchForTests(wasmFetch.fetch);
+
+    const pending = initializeRuntimedWasmClient(HASHED_MODULE, STABLE_WASM);
+    for (const delay of [150, 500, 1500]) {
+      await drain();
+      t.mock.timers.tick(delay);
+    }
+    await pending;
+
+    assert.deepEqual(importedHrefs, [
+      HASHED_MODULE,
+      HASHED_MODULE,
+      HASHED_MODULE,
+      HASHED_MODULE,
+      STABLE_MODULE,
+    ]);
+  });
+
+  it("has no fallback for stable module names: the failure is terminal", async (t: TestContext) => {
+    t.mock.timers.enable({ apis: ["setTimeout"] });
+    const importedHrefs: string[] = [];
+    _setRuntimedWasmModuleImporterForTests(async (href) => {
+      importedHrefs.push(href);
+      throw new TypeError("Failed to fetch dynamically imported module");
+    });
+    _setRuntimedWasmFetchForTests(okFetch().fetch);
+
+    const { promise, settled } = trackSettled(
+      initializeRuntimedWasmClient(STABLE_MODULE, STABLE_WASM),
     );
+    for (const delay of [150, 500, 1500]) {
+      await drain();
+      t.mock.timers.tick(delay);
+    }
+    await drain();
+    // Exactly one ladder; no further timers pending, the rejection is final.
+    assert.equal(settled(), true);
+    await assert.rejects(promise, /Failed to fetch dynamically imported module/);
+    assert.equal(importedHrefs.length, 4);
+    assert.ok(importedHrefs.every((href) => href === STABLE_MODULE));
+  });
+
+  it("retries the wasm binary on retryable statuses and resolves with the good response", async (t: TestContext) => {
+    t.mock.timers.enable({ apis: ["setTimeout"] });
+    const initCalls: unknown[] = [];
+    _setRuntimedWasmModuleImporterForTests(async () => stubModule(initCalls));
+    const statuses = [404, 503, 429];
+    const fetchedHrefs: string[] = [];
+    _setRuntimedWasmFetchForTests((async (input: RequestInfo | URL) => {
+      fetchedHrefs.push(String(input));
+      const status = statuses.shift();
+      return status === undefined ? new Response("wasm-bytes") : new Response("nope", { status });
+    }) as typeof fetch);
+
+    const pending = initializeRuntimedWasmClient(STABLE_MODULE, STABLE_WASM);
+    for (const delay of [150, 500, 1500]) {
+      await drain();
+      t.mock.timers.tick(delay);
+    }
+    await pending;
+
+    assert.equal(fetchedHrefs.length, 4);
+    assert.ok(fetchedHrefs.every((href) => href === STABLE_WASM));
+    assert.equal(initCalls.length, 1);
+    assert.ok(initCalls[0] instanceof Response);
+    assert.equal(await (initCalls[0] as Response).text(), "wasm-bytes");
+  });
+
+  it("bails immediately on non-retryable wasm statuses (still trying the stable copy once)", async (t: TestContext) => {
+    t.mock.timers.enable({ apis: ["setTimeout"] });
+    _setRuntimedWasmModuleImporterForTests(async () => stubModule());
+    const fetchedHrefs: string[] = [];
+    _setRuntimedWasmFetchForTests((async (input: RequestInfo | URL) => {
+      fetchedHrefs.push(String(input));
+      return new Response("forbidden", { status: 403 });
+    }) as typeof fetch);
+
+    const { promise, settled } = trackSettled(
+      initializeRuntimedWasmClient(STABLE_MODULE, HASHED_WASM),
+    );
+    await drain();
+    // 403 is not in the retryable set: no ladder sleeps for either name.
+    assert.equal(settled(), true);
+    await assert.rejects(promise, /Failed to fetch runtimed WASM \(403\)/);
+    assert.deepEqual(fetchedHrefs, [HASHED_WASM, STABLE_WASM]);
+  });
+
+  it("falls back from the hashed wasm name to the stable copy after the ladder exhausts", async (t: TestContext) => {
+    t.mock.timers.enable({ apis: ["setTimeout"] });
+    const initCalls: unknown[] = [];
+    _setRuntimedWasmModuleImporterForTests(async () => stubModule(initCalls));
+    const fetchedHrefs: string[] = [];
+    _setRuntimedWasmFetchForTests((async (input: RequestInfo | URL) => {
+      const href = String(input);
+      fetchedHrefs.push(href);
+      return href === HASHED_WASM
+        ? new Response("gone", { status: 404 })
+        : new Response("wasm-bytes");
+    }) as typeof fetch);
+
+    const pending = initializeRuntimedWasmClient(STABLE_MODULE, HASHED_WASM);
+    for (const delay of [150, 500, 1500]) {
+      await drain();
+      t.mock.timers.tick(delay);
+    }
+    await pending;
+
+    assert.deepEqual(fetchedHrefs, [
+      HASHED_WASM,
+      HASHED_WASM,
+      HASHED_WASM,
+      HASHED_WASM,
+      STABLE_WASM,
+    ]);
+    assert.ok(initCalls[0] instanceof Response);
+  });
+
+  it("passes non-URL wasm inputs through to wasm-bindgen untouched", async () => {
+    const initCalls: unknown[] = [];
+    _setRuntimedWasmModuleImporterForTests(async () => stubModule(initCalls));
+    const wasmFetch = okFetch();
+    _setRuntimedWasmFetchForTests(wasmFetch.fetch);
+
+    const bytes = new ArrayBuffer(8);
+    await initializeRuntimedWasmClient(STABLE_MODULE, bytes);
+
+    assert.deepEqual(wasmFetch.calls, []);
+    assert.equal(initCalls[0], bytes);
+  });
+
+  it("clears the cached import after a fully failed attempt so a retry can succeed", async (t: TestContext) => {
+    t.mock.timers.enable({ apis: ["setTimeout"] });
+    const importedHrefs: string[] = [];
+    let healed = false;
+    _setRuntimedWasmModuleImporterForTests(async (href) => {
+      importedHrefs.push(href);
+      if (!healed) {
+        throw new TypeError("Failed to fetch dynamically imported module");
+      }
+      return stubModule();
+    });
+    _setRuntimedWasmFetchForTests(okFetch().fetch);
+
+    const firstAttempt = initializeRuntimedWasmClient(STABLE_MODULE, STABLE_WASM);
+    for (const delay of [150, 500, 1500]) {
+      await drain();
+      t.mock.timers.tick(delay);
+    }
+    await assert.rejects(firstAttempt, /Failed to fetch dynamically imported module/);
+    assert.equal(importedHrefs.length, 4);
 
     // The retry path (retryLiveConnection / a fresh connect attempt) calls
-    // initialize again. Before the fix this re-awaited the pinned rejected
-    // import; with it, a fresh import() is issued and succeeds.
-    const module = await initializeRuntimedWasmClient(
-      "/assets/runtimed_wasm.js",
-      "/assets/runtimed_wasm_bg.wasm",
-    );
+    // initialize again. Before the cached-rejection fix this re-awaited the
+    // pinned rejected import; with it, a fresh import() is issued.
+    healed = true;
+    const module = await initializeRuntimedWasmClient(STABLE_MODULE, STABLE_WASM);
 
     assert.equal(typeof module.project_markdown_json, "function");
-    assert.equal(importedHrefs.length, 2);
-    assert.deepEqual(importedHrefs, ["/assets/runtimed_wasm.js", "/assets/runtimed_wasm.js"]);
+    assert.equal(importedHrefs.length, 5);
   });
 
   it("clears the init cache when wasm-bindgen init rejects, then recovers", async () => {
@@ -83,24 +306,26 @@ describe("runtimed WASM client cached-rejection recovery", () => {
       },
       project_markdown_json: () => null,
     }));
+    _setRuntimedWasmFetchForTests(okFetch().fetch);
 
     await assert.rejects(
-      initializeRuntimedWasmClient("/assets/runtimed_wasm.js", "/assets/runtimed_wasm_bg.wasm"),
+      initializeRuntimedWasmClient(STABLE_MODULE, STABLE_WASM),
       /synthetic wasm init failure/,
     );
 
-    await initializeRuntimedWasmClient("/assets/runtimed_wasm.js", "/assets/runtimed_wasm_bg.wasm");
+    await initializeRuntimedWasmClient(STABLE_MODULE, STABLE_WASM);
 
     assert.equal(initCalls.length, 1);
   });
 
   it("still refuses a second initialization from a different source", async () => {
     _setRuntimedWasmModuleImporterForTests(async () => stubModule());
+    _setRuntimedWasmFetchForTests(okFetch().fetch);
 
-    await initializeRuntimedWasmClient("/assets/runtimed_wasm.js", "/assets/runtimed_wasm_bg.wasm");
+    await initializeRuntimedWasmClient(STABLE_MODULE, STABLE_WASM);
 
     await assert.rejects(
-      initializeRuntimedWasmClient("/assets/runtimed_wasm.js", "/assets/other_bg.wasm"),
+      initializeRuntimedWasmClient(STABLE_MODULE, "/assets/other_bg.wasm"),
       /already initialized from/,
     );
   });

--- a/apps/notebook-cloud/test/viewer-config.test.ts
+++ b/apps/notebook-cloud/test/viewer-config.test.ts
@@ -1,0 +1,40 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+import { normalizeRendererAssetNames } from "../viewer/cloud-viewer-config.ts";
+
+/**
+ * The client half of the manifest-missing contract: the viewer bundle
+ * ships under a stable name, so NEW viewer JS routinely executes against
+ * OLD shell config (gradual worker deploys). A config without the
+ * rendererAssets key — or with partial keys — must resolve to the stable
+ * names, never throw.
+ */
+describe("cloud viewer renderer asset name normalization", () => {
+  it("falls back to the stable names when the shell config predates rendererAssets", () => {
+    assert.deepEqual(normalizeRendererAssetNames(undefined), {
+      js: "isolated-renderer.js",
+      css: "isolated-renderer.css",
+      siftWasm: "sift_wasm.wasm",
+    });
+  });
+
+  it("fills missing or empty keys per-field while keeping provided names", () => {
+    assert.deepEqual(
+      normalizeRendererAssetNames({ js: "isolated-renderer.0123456789abcdef.js", css: "" }),
+      {
+        js: "isolated-renderer.0123456789abcdef.js",
+        css: "isolated-renderer.css",
+        siftWasm: "sift_wasm.wasm",
+      },
+    );
+  });
+
+  it("passes a complete manifest through untouched", () => {
+    const names = {
+      js: "isolated-renderer.0123456789abcdef.js",
+      css: "isolated-renderer.fedcba9876543210.css",
+      siftWasm: "sift_wasm.a1b2c3d4e5f60718.wasm",
+    };
+    assert.deepEqual(normalizeRendererAssetNames(names), names);
+  });
+});

--- a/apps/notebook-cloud/test/viewer-notices.test.ts
+++ b/apps/notebook-cloud/test/viewer-notices.test.ts
@@ -201,6 +201,62 @@ test("cloud notebook notices render nothing extra when renderer assets are healt
   );
 });
 
+test("terminal wasm-asset failures get a dedicated notice with a non-destructive Retry", () => {
+  const html = renderToStaticMarkup(
+    React.createElement(CloudNotebookNotices, {
+      authState: authState("anonymous"),
+      authRenewal: { kind: "idle", message: null },
+      connectionError:
+        "runtimed WASM asset failed: Failed to fetch runtimed WASM (404): https://wasm.example/assets/runtimed_wasm_bg.0123456789abcdef.wasm",
+      status: { kind: "ready", message: "Ready" },
+      onResetAuth: () => {},
+      onRetryConnection: () => {},
+      onSignInAgain: () => {},
+    }),
+  );
+
+  assert.match(html, /Notebook engine failed to load/);
+  assert.match(html, /Retry/);
+  // Auth actions cannot remedy an asset 404 — and "Use anonymous" would
+  // destroy a signed-in session.
+  assert.doesNotMatch(html, /Use anonymous/);
+  assert.doesNotMatch(html, /Sign in again/);
+  assert.doesNotMatch(html, /Live room needs attention/);
+});
+
+test("wasm-asset failures keep the legacy action when no retry callback is wired", () => {
+  const html = renderToStaticMarkup(
+    React.createElement(CloudNotebookNotices, {
+      authState: authState("anonymous"),
+      authRenewal: { kind: "idle", message: null },
+      connectionError: "runtimed WASM asset failed: Failed to fetch dynamically imported module",
+      status: { kind: "ready", message: "Ready" },
+      onResetAuth: () => {},
+    }),
+  );
+
+  assert.match(html, /Notebook engine failed to load/);
+  assert.match(html, /Use anonymous/);
+});
+
+test("connection notice sanitizer redacts http(s) URLs down to host and path", () => {
+  const html = renderToStaticMarkup(
+    React.createElement(CloudNotebookNotices, {
+      authState: authState("anonymous"),
+      authRenewal: { kind: "idle", message: null },
+      connectionError:
+        "runtimed WASM asset failed: Failed to fetch runtimed WASM (403): https://cdn.example/assets/runtimed_wasm_bg.wasm?token=SECRET#frag",
+      status: { kind: "ready", message: "Ready" },
+      onResetAuth: () => {},
+      onRetryConnection: () => {},
+    }),
+  );
+
+  assert.match(html, /https:\/\/cdn\.example\/assets\/runtimed_wasm_bg\.wasm/);
+  assert.doesNotMatch(html, /SECRET/);
+  assert.doesNotMatch(html, /token=/);
+});
+
 test("cloud notebook notices keep dev diagnostics inside the shared stack", () => {
   const html = renderToStaticMarkup(
     React.createElement(CloudNotebookNotices, {

--- a/apps/notebook-cloud/test/viewer-notices.test.ts
+++ b/apps/notebook-cloud/test/viewer-notices.test.ts
@@ -153,6 +153,54 @@ test("cloud notebook notices distinguish sign-in and access diagnostics from soc
   assert.doesNotMatch(noAccessHtml, /Live room unavailable/);
 });
 
+test("cloud notebook notices aggregate renderer-asset failures into one quiet line with retry", () => {
+  assert.equal(
+    cloudNotebookHasNotices({
+      authState: authState("anonymous"),
+      authRenewal: { kind: "idle", message: null },
+      connectionError: null,
+      rendererAssetError: new Error("Failed to fetch renderer JS: 404"),
+      status: { kind: "ready", message: "Ready" },
+    }),
+    true,
+  );
+
+  const html = renderToStaticMarkup(
+    React.createElement(CloudNotebookNotices, {
+      authState: authState("anonymous"),
+      authRenewal: { kind: "idle", message: null },
+      connectionError: null,
+      rendererAssetError: new Error("Failed to fetch renderer JS: 404"),
+      status: { kind: "ready", message: "Ready" },
+      onResetAuth: () => {},
+      onRetryRendererAssets: () => {},
+    }),
+  );
+
+  // Exactly ONE notice for the whole page — N failing output wells never
+  // produce per-output notice spam (the provider state is module-level).
+  assert.equal(html.match(/Output renderer unavailable/g)?.length, 1);
+  assert.match(html, /Rich outputs are paused/);
+  assert.match(html, /Retry/);
+  // Asset health stays out of connection vocabulary: no connection notice,
+  // no reconnecting line.
+  assert.doesNotMatch(html, /Live room/);
+  assert.doesNotMatch(html, /Reconnecting/);
+});
+
+test("cloud notebook notices render nothing extra when renderer assets are healthy", () => {
+  assert.equal(
+    cloudNotebookHasNotices({
+      authState: authState("anonymous"),
+      authRenewal: { kind: "idle", message: null },
+      connectionError: null,
+      rendererAssetError: null,
+      status: { kind: "ready", message: "Ready" },
+    }),
+    false,
+  );
+});
+
 test("cloud notebook notices keep dev diagnostics inside the shared stack", () => {
   const html = renderToStaticMarkup(
     React.createElement(CloudNotebookNotices, {

--- a/apps/notebook-cloud/test/viewer-sift-preload.test.ts
+++ b/apps/notebook-cloud/test/viewer-sift-preload.test.ts
@@ -69,6 +69,32 @@ describe("cloud viewer Sift WASM preload", () => {
     );
   });
 
+  it("prefetches the content-hashed manifest name without the ?v= query", () => {
+    const cells = [
+      cell([
+        {
+          output_type: "execute_result",
+          execution_count: 1,
+          data: {
+            "application/vnd.apache.arrow.stream": "https://cloud.test/api/n/demo/blobs/sha256",
+          },
+          metadata: {},
+        },
+      ]),
+    ];
+
+    assert.equal(
+      siftWasmPreloadUrlForCells(
+        cells,
+        preloadOptions({
+          rendererAssetsBasePath: "https://outputs.example/renderer-assets/",
+          siftWasmAssetName: "sift_wasm.0123456789abcdef.wasm",
+        }),
+      ),
+      "https://outputs.example/renderer-assets/sift_wasm.0123456789abcdef.wasm",
+    );
+  });
+
   it("uses prefetch so sandboxed output frames do not trigger unused-preload warnings", () => {
     const targetDocument = fakeDocument();
     const cells = [

--- a/apps/notebook-cloud/viewer/cloud-viewer-config.ts
+++ b/apps/notebook-cloud/viewer/cloud-viewer-config.ts
@@ -1,5 +1,5 @@
 import { isCloudAppSession } from "./app-session";
-import type { CloudViewerConfig } from "./cloud-viewer-session";
+import type { CloudRendererAssetNames, CloudViewerConfig } from "./cloud-viewer-session";
 import { isCloudNotebookListItem } from "./notebook-dashboard";
 import { normalizeOidcAuthConfig, type CloudOidcAuthConfig } from "./oidc-auth";
 import type {
@@ -60,9 +60,30 @@ function loadConfig(): CloudViewerConfig {
     syncEndpoint: parsed.syncEndpoint,
     blobBasePath: parsed.blobBasePath,
     rendererAssetsBasePath: parsed.rendererAssetsBasePath,
+    rendererAssets: normalizeRendererAssetNames(parsed.rendererAssets),
     outputDocumentBaseUrl: parsed.outputDocumentBaseUrl ?? null,
     runtimedWasmModulePath: parsed.runtimedWasmModulePath,
     runtimedWasmPath: parsed.runtimedWasmPath,
+  };
+}
+
+const STABLE_RENDERER_ASSET_NAMES: CloudRendererAssetNames = {
+  js: "isolated-renderer.js",
+  css: "isolated-renderer.css",
+  siftWasm: "sift_wasm.wasm",
+};
+
+/**
+ * Shells without manifest names (older workers, missing manifest) keep
+ * loading the stable-name copies — the documented fallback.
+ */
+function normalizeRendererAssetNames(
+  value: Partial<CloudRendererAssetNames> | undefined,
+): CloudRendererAssetNames {
+  return {
+    js: value?.js || STABLE_RENDERER_ASSET_NAMES.js,
+    css: value?.css || STABLE_RENDERER_ASSET_NAMES.css,
+    siftWasm: value?.siftWasm || STABLE_RENDERER_ASSET_NAMES.siftWasm,
   };
 }
 

--- a/apps/notebook-cloud/viewer/cloud-viewer-config.ts
+++ b/apps/notebook-cloud/viewer/cloud-viewer-config.ts
@@ -75,9 +75,12 @@ const STABLE_RENDERER_ASSET_NAMES: CloudRendererAssetNames = {
 
 /**
  * Shells without manifest names (older workers, missing manifest) keep
- * loading the stable-name copies — the documented fallback.
+ * loading the stable-name copies — the documented fallback. The viewer
+ * bundle ships under a stable name, so NEW viewer JS routinely executes
+ * against OLD shell config during gradual worker deploys; this guard is
+ * that skew's client half and must stay tolerant of an absent key.
  */
-function normalizeRendererAssetNames(
+export function normalizeRendererAssetNames(
   value: Partial<CloudRendererAssetNames> | undefined,
 ): CloudRendererAssetNames {
   return {

--- a/apps/notebook-cloud/viewer/cloud-viewer-session.ts
+++ b/apps/notebook-cloud/viewer/cloud-viewer-session.ts
@@ -67,6 +67,17 @@ import { projectCloudWidgetComms } from "./widget-comm-projection";
 import type { CloudAppSession } from "./app-session";
 import type { CloudAuthRenewalState, ViewerStatus } from "./notice-types";
 
+/**
+ * Renderer sidecar filenames from the deploy manifest. Content-hashed
+ * names ride immutable caching on the renderer-assets origin; the stable
+ * names are the documented fallback when no manifest was deployed.
+ */
+export interface CloudRendererAssetNames {
+  js: string;
+  css: string;
+  siftWasm: string;
+}
+
 export interface CloudViewerConfig {
   notebookId: string;
   headsHash: string | null;
@@ -88,6 +99,7 @@ export interface CloudViewerConfig {
   syncEndpoint: string;
   blobBasePath: string;
   rendererAssetsBasePath: string;
+  rendererAssets: CloudRendererAssetNames;
   outputDocumentBaseUrl: string | null;
   runtimedWasmModulePath: string;
   runtimedWasmPath: string;

--- a/apps/notebook-cloud/viewer/index.tsx
+++ b/apps/notebook-cloud/viewer/index.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState, type ReactNode } from "react";
+import { useEffect, useMemo, useState, type ReactNode } from "react";
 import { createRoot } from "react-dom/client";
 import { IsolatedRendererProvider } from "@/components/isolated/isolated-renderer-context";
 import { MediaProvider } from "@/components/outputs/media-provider";
@@ -88,9 +88,18 @@ function CloudNotebookProviders({
     loadSupplementalViewerCss();
   }, []);
 
+  // Manifest filenames (content-hashed when deployed) keep the renderer
+  // bundle on the asset origin's immutable cache path; the stable names
+  // remain the fallback for shells without manifest names.
+  const rendererAssetNames = useMemo(
+    () => ({ js: config.rendererAssets.js, css: config.rendererAssets.css }),
+    [config.rendererAssets.css, config.rendererAssets.js],
+  );
+
   return (
     <IsolatedRendererProvider
       basePath={rendererAssetBasePathForProvider(config.rendererAssetsBasePath)}
+      assetNames={rendererAssetNames}
     >
       <CloudWidgetStoreProvider>
         <MediaProvider priority={CLOUD_VIEWER_PRIORITY} renderers={CLOUD_WIDGET_RENDERERS}>

--- a/apps/notebook-cloud/viewer/notebook-viewer.tsx
+++ b/apps/notebook-cloud/viewer/notebook-viewer.tsx
@@ -10,6 +10,7 @@ import {
 import { NotebookHostProvider } from "@nteract/notebook-host";
 import { AlertCircle, Check, Loader2, X } from "lucide-react";
 import type { NteractEmbedHostContextPatch } from "@/components/isolated/host-context";
+import { useIsolatedRenderer } from "@/components/isolated/isolated-renderer-context";
 import { NotebookNotice } from "@/components/notebook/NotebookNotice";
 import type { NotebookRailPanelId } from "@/components/notebook-rail";
 import {
@@ -230,6 +231,9 @@ export function NotebookViewer({
   // dot by design, so once "reconnecting" outlives the debounce the notices
   // stack carries the one calm line (and clears it when the room is back).
   const sustainedReconnecting = useSustainedReconnecting(connectionStatus$);
+  // Shared renderer-bundle state from the root IsolatedRendererProvider
+  // (CloudNotebookProviders): drives the single asset-health notice below.
+  const isolatedRenderer = useIsolatedRenderer();
   const presenceSnapshot = useSyncExternalStore(
     presenceStore.subscribe,
     presenceStore.getSnapshot,
@@ -907,6 +911,11 @@ export function NotebookViewer({
       ? { kind: "loading", message: "Preparing notebook view..." }
       : status;
   const accessRequestNotice = cloudAccessRequestNotice(latestAccessRequest, accessRequestError);
+  // Asset health is its own quiet surface: N identical renderer failures
+  // collapse into ONE notice (the provider state is module-level shared)
+  // plus per-output fallbacks. It never feeds the connection dot or
+  // CloudConnectionStatusBridge — that bridge models room transport health.
+  const rendererAssetError = isolatedRenderer.isLoading ? null : isolatedRenderer.error;
   const hasNotices = cloudNotebookHasNotices({
     authState,
     authRenewal,
@@ -914,6 +923,7 @@ export function NotebookViewer({
     diagnostics: accessRequestNotice,
     hasAppSession: Boolean(appSessionStatus.session),
     hasReadableSnapshot: notebookHasReadableSnapshot,
+    rendererAssetError,
     sustainedReconnecting,
     status: noticeStatus,
   });
@@ -925,9 +935,11 @@ export function NotebookViewer({
       diagnostics={accessRequestNotice}
       hasAppSession={Boolean(appSessionStatus.session)}
       hasReadableSnapshot={notebookHasReadableSnapshot}
+      rendererAssetError={rendererAssetError}
       sustainedReconnecting={sustainedReconnecting}
       status={noticeStatus}
       onResetAuth={resetPrototypeAuth}
+      onRetryRendererAssets={isolatedRenderer.retry}
       onSignInAgain={authConfig.oidc ? beginNotebookOidcAuth : undefined}
     />
   ) : null;

--- a/apps/notebook-cloud/viewer/notebook-viewer.tsx
+++ b/apps/notebook-cloud/viewer/notebook-viewer.tsx
@@ -171,10 +171,11 @@ export function NotebookViewer({
       preloadSiftWasmForCells(nextCells, {
         blobBasePath: config.blobBasePath,
         rendererAssetsBasePath: config.rendererAssetsBasePath,
+        siftWasmAssetName: config.rendererAssets.siftWasm,
         pageUrl: location.href,
       });
     },
-    [config.blobBasePath, config.rendererAssetsBasePath],
+    [config.blobBasePath, config.rendererAssetsBasePath, config.rendererAssets.siftWasm],
   );
   const resolveSyncAuth = useCallback(
     async (sessionId: string) => {
@@ -249,12 +250,13 @@ export function NotebookViewer({
     () => ({
       nteract: {
         rendererAssetsBaseUrl: new URL(config.rendererAssetsBasePath, location.href).href,
+        siftWasmAssetName: config.rendererAssets.siftWasm,
         outputDocumentUrl: config.outputDocumentBaseUrl
           ? new URL(config.outputDocumentBaseUrl, location.href).href
           : undefined,
       },
     }),
-    [config.outputDocumentBaseUrl, config.rendererAssetsBasePath],
+    [config.outputDocumentBaseUrl, config.rendererAssetsBasePath, config.rendererAssets.siftWasm],
   );
 
   useEffect(() => {

--- a/apps/notebook-cloud/viewer/notebook-viewer.tsx
+++ b/apps/notebook-cloud/viewer/notebook-viewer.tsx
@@ -10,7 +10,10 @@ import {
 import { NotebookHostProvider } from "@nteract/notebook-host";
 import { AlertCircle, Check, Loader2, X } from "lucide-react";
 import type { NteractEmbedHostContextPatch } from "@/components/isolated/host-context";
-import { useIsolatedRenderer } from "@/components/isolated/isolated-renderer-context";
+import {
+  useHasIsolatedOutputs,
+  useIsolatedRenderer,
+} from "@/components/isolated/isolated-renderer-context";
 import { NotebookNotice } from "@/components/notebook/NotebookNotice";
 import type { NotebookRailPanelId } from "@/components/notebook-rail";
 import {
@@ -235,6 +238,9 @@ export function NotebookViewer({
   // Shared renderer-bundle state from the root IsolatedRendererProvider
   // (CloudNotebookProviders): drives the single asset-health notice below.
   const isolatedRenderer = useIsolatedRenderer();
+  // The provider preloads the bundle for every notebook; only surface its
+  // failure when something on screen actually renders isolated outputs.
+  const hasIsolatedOutputs = useHasIsolatedOutputs();
   const presenceSnapshot = useSyncExternalStore(
     presenceStore.subscribe,
     presenceStore.getSnapshot,
@@ -917,7 +923,12 @@ export function NotebookViewer({
   // collapse into ONE notice (the provider state is module-level shared)
   // plus per-output fallbacks. It never feeds the connection dot or
   // CloudConnectionStatusBridge — that bridge models room transport health.
-  const rendererAssetError = isolatedRenderer.isLoading ? null : isolatedRenderer.error;
+  // `lastError` keeps the notice steady through an in-flight retry (no
+  // per-click flap); the presence gate keeps pure-markdown/text notebooks
+  // free of a warning about outputs they do not have.
+  const rendererAssetError = hasIsolatedOutputs
+    ? (isolatedRenderer.error ?? isolatedRenderer.lastError)
+    : null;
   const hasNotices = cloudNotebookHasNotices({
     authState,
     authRenewal,
@@ -941,6 +952,7 @@ export function NotebookViewer({
       sustainedReconnecting={sustainedReconnecting}
       status={noticeStatus}
       onResetAuth={resetPrototypeAuth}
+      onRetryConnection={retryLiveConnection}
       onRetryRendererAssets={isolatedRenderer.retry}
       onSignInAgain={authConfig.oidc ? beginNotebookOidcAuth : undefined}
     />

--- a/apps/notebook-cloud/viewer/notices.tsx
+++ b/apps/notebook-cloud/viewer/notices.tsx
@@ -12,6 +12,7 @@ import {
   CLOUD_CONNECTION_NO_ACCESS_DIAGNOSTIC,
   CLOUD_CONNECTION_SIGN_IN_DIAGNOSTIC,
 } from "./connection-diagnostics";
+import { isRuntimedWasmAssetFailure } from "./runtimed-wasm-failure";
 import type { CloudAuthRenewalState, ViewerStatus } from "./notice-types";
 
 export interface CloudNotebookNoticesProps {
@@ -41,6 +42,13 @@ export interface CloudNotebookNoticesProps {
   rendererAssetError?: Error | null;
   /** Restarts the renderer bundle load ladder; recovery un-blanks every output at once. */
   onRetryRendererAssets?: () => void;
+  /**
+   * Re-enters the live connection (retryLiveConnection — a connectAttempt
+   * bump; the wasm client's caches clear on rejection so the retry
+   * genuinely re-imports). Rendered as the action for terminal notebook-
+   * engine asset failures, which auth actions cannot remedy.
+   */
+  onRetryConnection?: () => void;
   onResetAuth: () => void;
   onSignInAgain?: () => void | Promise<void>;
 }
@@ -120,6 +128,7 @@ export function CloudNotebookNotices({
   status,
   diagnostics,
   onResetAuth,
+  onRetryConnection,
   onRetryRendererAssets,
   onSignInAgain,
 }: CloudNotebookNoticesProps) {
@@ -199,6 +208,7 @@ export function CloudNotebookNotices({
             <ConnectionNoticeAction
               connectionError={connectionError ?? ""}
               onResetAuth={onResetAuth}
+              onRetryConnection={onRetryConnection}
               onSignInAgain={onSignInAgain}
             />
           }
@@ -279,12 +289,25 @@ function AuthNoticeAction({
 function ConnectionNoticeAction({
   connectionError,
   onResetAuth,
+  onRetryConnection,
   onSignInAgain,
 }: {
   connectionError: string;
   onResetAuth: () => void;
+  onRetryConnection?: () => void;
   onSignInAgain?: () => void | Promise<void>;
 }) {
+  if (isRuntimedWasmAssetFailure(connectionError) && onRetryConnection) {
+    // Asset failures are not auth problems: "Use anonymous" would destroy
+    // a signed-in session without fixing anything. retryLiveConnection is
+    // the documented re-entry and genuinely re-imports.
+    return (
+      <NotebookNoticeAction onClick={onRetryConnection} icon={<RotateCcw className="h-3 w-3" />}>
+        Retry
+      </NotebookNoticeAction>
+    );
+  }
+
   if (connectionError === CLOUD_CONNECTION_SIGN_IN_DIAGNOSTIC && onSignInAgain) {
     return (
       <NotebookNoticeAction
@@ -364,6 +387,14 @@ function cloudConnectionNoticeDisplay(
     };
   }
 
+  if (isRuntimedWasmAssetFailure(error)) {
+    return {
+      title: "Notebook engine failed to load.",
+      message: sanitizeCloudConnectionError(error),
+      tone: "warning",
+    };
+  }
+
   if (/\bfailed to connect\s+wss?:\/\//i.test(error)) {
     if (!hasReadableSnapshot) {
       return {
@@ -387,7 +418,10 @@ function cloudConnectionNoticeDisplay(
 }
 
 function sanitizeCloudConnectionError(error: string): string {
-  return error.replace(/\bwss?:\/\/[^\s]+/gi, (rawUrl) => {
+  // http(s) joined the redaction set when runtimed WASM asset hrefs began
+  // flowing into this surface; query/fragment (where signed-CDN tokens
+  // would live) are stripped, protocol//host/pathname stay legible.
+  return error.replace(/\b(?:wss?|https?):\/\/[^\s]+/gi, (rawUrl) => {
     try {
       const url = new URL(rawUrl);
       return `${url.protocol}//${url.host}${url.pathname}`;

--- a/apps/notebook-cloud/viewer/notices.tsx
+++ b/apps/notebook-cloud/viewer/notices.tsx
@@ -1,5 +1,5 @@
 import type { ReactNode } from "react";
-import { AlertCircle, CloudOff, Loader2, LogIn, RotateCcw } from "lucide-react";
+import { AlertCircle, CloudOff, ImageOff, Loader2, LogIn, RotateCcw } from "lucide-react";
 import {
   NotebookNotice,
   NotebookNoticeAction,
@@ -30,6 +30,17 @@ export interface CloudNotebookNoticesProps {
   sustainedReconnecting?: boolean;
   status: ViewerStatus;
   diagnostics?: ReactNode;
+  /**
+   * Terminal renderer-asset failure from the shared IsolatedRendererProvider
+   * (bounded retries already exhausted). The provider state is module-level,
+   * so N blank output wells collapse into this ONE quiet line — never
+   * per-output spam. Asset health is notices + output fallbacks only; it
+   * must never feed the connection dot or CloudConnectionStatusBridge
+   * (that bridge models room transport health exclusively).
+   */
+  rendererAssetError?: Error | null;
+  /** Restarts the renderer bundle load ladder; recovery un-blanks every output at once. */
+  onRetryRendererAssets?: () => void;
   onResetAuth: () => void;
   onSignInAgain?: () => void | Promise<void>;
 }
@@ -70,6 +81,7 @@ export function cloudNotebookHasNotices({
   connectionError,
   hasAppSession = false,
   hasReadableSnapshot = false,
+  rendererAssetError = null,
   sustainedReconnecting = false,
   status,
   diagnostics,
@@ -91,6 +103,7 @@ export function cloudNotebookHasNotices({
     shouldShowAuthRenewalNotice ||
     sustainedReconnecting ||
     Boolean(connectionNotice) ||
+    Boolean(rendererAssetError) ||
     Boolean(diagnostics) ||
     shouldShowStatusNotice
   );
@@ -102,10 +115,12 @@ export function CloudNotebookNotices({
   connectionError,
   hasAppSession = false,
   hasReadableSnapshot = false,
+  rendererAssetError = null,
   sustainedReconnecting = false,
   status,
   diagnostics,
   onResetAuth,
+  onRetryRendererAssets,
   onSignInAgain,
 }: CloudNotebookNoticesProps) {
   if (
@@ -115,6 +130,7 @@ export function CloudNotebookNotices({
       connectionError,
       hasAppSession,
       hasReadableSnapshot,
+      rendererAssetError,
       sustainedReconnecting,
       status,
       diagnostics,
@@ -188,6 +204,27 @@ export function CloudNotebookNotices({
           }
         >
           {connectionNotice.message}
+        </NotebookNotice>
+      ) : null}
+
+      {rendererAssetError ? (
+        <NotebookNotice
+          tone="warning"
+          icon={<ImageOff className="h-4 w-4" />}
+          title="Output renderer unavailable."
+          actions={
+            onRetryRendererAssets ? (
+              <NotebookNoticeAction
+                onClick={onRetryRendererAssets}
+                icon={<RotateCcw className="h-3 w-3" />}
+              >
+                Retry
+              </NotebookNoticeAction>
+            ) : null
+          }
+        >
+          Rich outputs are paused because their renderer assets failed to load. Code and text stay
+          readable; retry to restore outputs.
         </NotebookNotice>
       ) : null}
 

--- a/apps/notebook-cloud/viewer/runtimed-wasm-client.ts
+++ b/apps/notebook-cloud/viewer/runtimed-wasm-client.ts
@@ -20,6 +20,22 @@ const defaultModuleImporter: RuntimedWasmModuleImporter = (href) =>
   import(/* @vite-ignore */ href) as Promise<RuntimedWasmModule>;
 
 let importModule: RuntimedWasmModuleImporter = defaultModuleImporter;
+let fetchImpl: typeof fetch = (input, init) => fetch(input, init);
+
+/**
+ * Retry ladder shared by the module import and the .wasm binary fetch —
+ * the blob-resolver shape with one extra rung for the heavier asset.
+ * 404 is deliberately retryable: freshly deployed hashed assets propagate
+ * eventually, exactly like fresh blobs.
+ */
+const RUNTIMED_WASM_RETRY_DELAYS_MS = [150, 500, 1500];
+
+/**
+ * Hashed deploys keep stable-name copies (`runtimed_wasm.js` /
+ * `runtimed_wasm_bg.wasm`) alongside the content-hashed files precisely so
+ * a viewer holding a stale hashed URL across a deploy window can fall back.
+ */
+const CONTENT_HASHED_RUNTIMED_ASSET_RE = /^(.+)\.[a-f0-9]{12,64}(\.(?:js|wasm))$/;
 
 export async function initializeRuntimedWasmClient(
   modulePath: string | URL,
@@ -37,7 +53,7 @@ export async function initializeRuntimedWasmClient(
   initializedSource = source;
   initialized ??= loadRuntimedWasmModule(modulePath)
     .then(async (module) => {
-      await module.default({ module_or_path: moduleOrPath });
+      await module.default({ module_or_path: await resolveRuntimedWasmBinary(moduleOrPath) });
       setMarkdownProjectionProjector(module.project_markdown_json);
       resolvedModule = module;
       return module;
@@ -175,7 +191,7 @@ function loadRuntimedWasmModule(modulePath: string | URL): Promise<RuntimedWasmM
     // a pinned rejected promise would turn one transient failure into a
     // permanent one — every later attempt (manual retry, reconnect) would
     // re-await the same rejection for the life of the page.
-    const pending = importModule(href).catch((error: unknown) => {
+    const pending = importRuntimedWasmModuleWithRecovery(href).catch((error: unknown) => {
       if (loadedModule === pending) {
         loadedModule = undefined;
         loadedModuleSource = undefined;
@@ -185,6 +201,136 @@ function loadRuntimedWasmModule(modulePath: string | URL): Promise<RuntimedWasmM
     loadedModule = pending;
   }
   return loadedModule;
+}
+
+async function importRuntimedWasmModuleWithRecovery(href: string): Promise<RuntimedWasmModule> {
+  try {
+    return await importRuntimedWasmModuleWithRetries(href);
+  } catch (error) {
+    const stableHref = stableRuntimedAssetHref(href);
+    if (!stableHref) throw error;
+    console.warn(
+      `[notebook-cloud] runtimed WASM module failed from ${href}; falling back to ${stableHref}`,
+      error,
+    );
+    return importRuntimedWasmModuleWithRetries(stableHref);
+  }
+}
+
+async function importRuntimedWasmModuleWithRetries(href: string): Promise<RuntimedWasmModule> {
+  let lastFailure: unknown = null;
+  // import() exposes no response status — every failure shape (network
+  // error, 404 mid-deploy, MIME rejection) surfaces as a rejection, so the
+  // whole ladder applies.
+  for (let attempt = 0; attempt <= RUNTIMED_WASM_RETRY_DELAYS_MS.length; attempt += 1) {
+    try {
+      return await importModule(href);
+    } catch (error) {
+      lastFailure = error;
+    }
+    const delay = RUNTIMED_WASM_RETRY_DELAYS_MS[attempt];
+    if (delay === undefined) break;
+    await sleep(delay);
+  }
+  throw lastFailure instanceof Error ? lastFailure : new Error(String(lastFailure));
+}
+
+/**
+ * Resolve the wasm-bindgen `module_or_path` input. URL-shaped inputs are
+ * fetched here (instead of inside wasm-bindgen's init) so the ladder and
+ * the hashed→stable fallback cover the binary exactly like the module;
+ * everything else (Response, ArrayBuffer, compiled module) passes through.
+ */
+async function resolveRuntimedWasmBinary(
+  moduleOrPath: WasmModuleOrPath,
+): Promise<WasmModuleOrPath> {
+  if (typeof moduleOrPath !== "string" && !(moduleOrPath instanceof URL)) {
+    return moduleOrPath;
+  }
+  const href = typeof moduleOrPath === "string" ? moduleOrPath : moduleOrPath.href;
+  if (!isLadderFetchableHref(href)) {
+    // Non-network schemes (file:, data:, blob: in tests/embeddings) go
+    // straight to wasm-bindgen; the ladder exists for HTTP asset origins.
+    return moduleOrPath;
+  }
+  try {
+    return await fetchRuntimedWasmBinaryWithRetries(href);
+  } catch (error) {
+    const stableHref = stableRuntimedAssetHref(href);
+    if (!stableHref) throw error;
+    console.warn(
+      `[notebook-cloud] runtimed WASM binary failed from ${href}; falling back to ${stableHref}`,
+      error,
+    );
+    return fetchRuntimedWasmBinaryWithRetries(stableHref);
+  }
+}
+
+async function fetchRuntimedWasmBinaryWithRetries(href: string): Promise<Response> {
+  let lastFailure: unknown = null;
+  for (let attempt = 0; attempt <= RUNTIMED_WASM_RETRY_DELAYS_MS.length; attempt += 1) {
+    let response: Response | null = null;
+    try {
+      response = await fetchImpl(href);
+    } catch (error) {
+      // Thrown fetch errors (network drop, DNS, CORS) are always retryable.
+      lastFailure = error;
+    }
+    if (response) {
+      if (response.ok) return response;
+      const failure = new Error(`Failed to fetch runtimed WASM (${response.status}): ${href}`);
+      if (!shouldRetryRuntimedWasmResponse(response)) throw failure;
+      lastFailure = failure;
+      await cancelResponseBody(response);
+    }
+    const delay = RUNTIMED_WASM_RETRY_DELAYS_MS[attempt];
+    if (delay === undefined) break;
+    await sleep(delay);
+  }
+  throw lastFailure instanceof Error ? lastFailure : new Error(String(lastFailure));
+}
+
+function shouldRetryRuntimedWasmResponse(response: Response): boolean {
+  return (
+    response.status === 404 ||
+    response.status === 409 ||
+    response.status === 425 ||
+    response.status === 429 ||
+    response.status >= 500
+  );
+}
+
+async function cancelResponseBody(response: Response): Promise<void> {
+  try {
+    await response.body?.cancel();
+  } catch {
+    // Best effort; a failed cancel should not mask the retryable response.
+  }
+}
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+function isLadderFetchableHref(href: string): boolean {
+  // Bare and root-relative paths resolve against the page origin (http/s).
+  const hasScheme = /^[a-zA-Z][a-zA-Z0-9+.-]*:/.test(href);
+  return !hasScheme || href.startsWith("http:") || href.startsWith("https:");
+}
+
+/**
+ * `runtimed_wasm.<sha16>.js` → `runtimed_wasm.js` (same directory, query
+ * preserved). Returns null when the name carries no content hash — stable
+ * names have nowhere further to fall.
+ */
+function stableRuntimedAssetHref(href: string): string | null {
+  const suffixIndex = href.search(/[?#]/);
+  const path = suffixIndex === -1 ? href : href.slice(0, suffixIndex);
+  const suffix = suffixIndex === -1 ? "" : href.slice(suffixIndex);
+  const nameIndex = path.lastIndexOf("/") + 1;
+  const match = CONTENT_HASHED_RUNTIMED_ASSET_RE.exec(path.slice(nameIndex));
+  if (!match) return null;
+  return `${path.slice(0, nameIndex)}${match[1]}${match[2]}${suffix}`;
 }
 
 /**
@@ -197,6 +343,15 @@ export function _setRuntimedWasmModuleImporterForTests(
   importer: ((href: string) => Promise<unknown>) | null,
 ): void {
   importModule = (importer as RuntimedWasmModuleImporter | null) ?? defaultModuleImporter;
+}
+
+/**
+ * Swap the fetch used for the .wasm binary ladder. Pass `null` to restore
+ * the global fetch.
+ * @internal
+ */
+export function _setRuntimedWasmFetchForTests(impl: typeof fetch | null): void {
+  fetchImpl = impl ?? ((input, init) => fetch(input, init));
 }
 
 /**

--- a/apps/notebook-cloud/viewer/runtimed-wasm-client.ts
+++ b/apps/notebook-cloud/viewer/runtimed-wasm-client.ts
@@ -14,6 +14,13 @@ let initialized: Promise<RuntimedWasmModule> | undefined;
 let initializedSource: string | undefined;
 let resolvedModule: RuntimedWasmModule | undefined;
 
+type RuntimedWasmModuleImporter = (href: string) => Promise<RuntimedWasmModule>;
+
+const defaultModuleImporter: RuntimedWasmModuleImporter = (href) =>
+  import(/* @vite-ignore */ href) as Promise<RuntimedWasmModule>;
+
+let importModule: RuntimedWasmModuleImporter = defaultModuleImporter;
+
 export async function initializeRuntimedWasmClient(
   modulePath: string | URL,
   moduleOrPath: WasmModuleOrPath,
@@ -163,8 +170,45 @@ function loadRuntimedWasmModule(modulePath: string | URL): Promise<RuntimedWasmM
   }
 
   loadedModuleSource = href;
-  loadedModule ??= import(/* @vite-ignore */ href) as Promise<RuntimedWasmModule>;
+  if (!loadedModule) {
+    // Cache by REQUESTED href, and clear the cache when the import rejects:
+    // a pinned rejected promise would turn one transient failure into a
+    // permanent one — every later attempt (manual retry, reconnect) would
+    // re-await the same rejection for the life of the page.
+    const pending = importModule(href).catch((error: unknown) => {
+      if (loadedModule === pending) {
+        loadedModule = undefined;
+        loadedModuleSource = undefined;
+      }
+      throw error;
+    });
+    loadedModule = pending;
+  }
   return loadedModule;
+}
+
+/**
+ * Swap the dynamic `import()` used for the runtimed WASM module. Node test
+ * runners cannot intercept real dynamic imports, so retry/caching tests
+ * inject failures here. Pass `null` to restore the real importer.
+ * @internal
+ */
+export function _setRuntimedWasmModuleImporterForTests(
+  importer: ((href: string) => Promise<unknown>) | null,
+): void {
+  importModule = (importer as RuntimedWasmModuleImporter | null) ?? defaultModuleImporter;
+}
+
+/**
+ * Reset the module-level load/init caches between tests.
+ * @internal
+ */
+export function _resetRuntimedWasmClientForTests(): void {
+  loadedModule = undefined;
+  loadedModuleSource = undefined;
+  initialized = undefined;
+  initializedSource = undefined;
+  resolvedModule = undefined;
 }
 
 function runtimedWasmModuleAfterInit(): RuntimedWasmModule {

--- a/apps/notebook-cloud/viewer/runtimed-wasm-client.ts
+++ b/apps/notebook-cloud/viewer/runtimed-wasm-client.ts
@@ -4,6 +4,7 @@ import {
 } from "runtimed";
 import { setMarkdownProjectionProjector } from "../../../src/lib/markdown-projection";
 import type { NotebookHandle } from "../../notebook/src/wasm/runtimed-wasm/runtimed_wasm.js";
+import { asRuntimedWasmAssetFailure } from "./runtimed-wasm-failure";
 
 type RuntimedWasmModule = typeof import("../../notebook/src/wasm/runtimed-wasm/runtimed_wasm.js");
 type WasmModuleOrPath = string | URL | Request | Response | ArrayBuffer | WebAssembly.Module;
@@ -27,8 +28,26 @@ let fetchImpl: typeof fetch = (input, init) => fetch(input, init);
  * the blob-resolver shape with one extra rung for the heavier asset.
  * 404 is deliberately retryable: freshly deployed hashed assets propagate
  * eventually, exactly like fresh blobs.
+ *
+ * Bounds (accepted): the ladders are sequential (module, then binary) and
+ * each name tier runs its own ladder, so a fully-skewed page (hashed module
+ * AND hashed binary both falling back to stable) pays ~4.3s of sleeps plus
+ * up to ~10 round trips before a NotebookHandle exists. The healthy path
+ * pays zero sleeps. Each rung is also time-bounded (see
+ * RUNTIMED_WASM_RUNG_TIMEOUT_MS) so a black-holed request becomes a failed
+ * rung instead of wedging the shared init promise forever.
  */
 const RUNTIMED_WASM_RETRY_DELAYS_MS = [150, 500, 1500];
+
+/**
+ * Per-rung time bound. A stalled (slow-loris) attempt that never settles
+ * would otherwise park every caller — including retryLiveConnection, which
+ * awaits the same cached singleton promise — in a permanent loading state.
+ * fetch rungs also get an AbortSignal so the network request is actually
+ * cancelled; import() cannot be aborted, so its rung is abandoned via the
+ * same race and left to the module map.
+ */
+const RUNTIMED_WASM_RUNG_TIMEOUT_MS = 20_000;
 
 /**
  * Hashed deploys keep stable-name copies (`runtimed_wasm.js` /
@@ -36,6 +55,26 @@ const RUNTIMED_WASM_RETRY_DELAYS_MS = [150, 500, 1500];
  * a viewer holding a stale hashed URL across a deploy window can fall back.
  */
 const CONTENT_HASHED_RUNTIMED_ASSET_RE = /^(.+)\.[a-f0-9]{12,64}(\.(?:js|wasm))$/;
+
+/**
+ * True when the currently cached module was imported from the STABLE name
+ * after its hashed name failed. The module and binary must fall back as a
+ * PAIR: hashed wasm-bindgen glue against a stable binary (or vice versa)
+ * is exactly the silent missing-export skew class from PR #3416.
+ */
+let moduleLoadedFromStableFallback = false;
+
+/**
+ * Monotonic cache-buster for module import retries. Same-specifier
+ * import() retries are served from the browser module map — the HTML spec
+ * caches FAILED module fetches for the life of the page (whatwg/html#6768)
+ * and Chromium/WebKit conform — so rungs >= 1 would replay the pinned
+ * rejection without touching the network. A unique query per retry rung
+ * forces a fresh fetch; the module is side-effect-light glue, so a second
+ * evaluation under a different specifier is benign, and
+ * stableRuntimedAssetHref preserves queries on fallback.
+ */
+let moduleImportBusterSequence = 0;
 
 export async function initializeRuntimedWasmClient(
   modulePath: string | URL,
@@ -53,7 +92,14 @@ export async function initializeRuntimedWasmClient(
   initializedSource = source;
   initialized ??= loadRuntimedWasmModule(modulePath)
     .then(async (module) => {
-      await module.default({ module_or_path: await resolveRuntimedWasmBinary(moduleOrPath) });
+      const binary = await resolveRuntimedWasmBinary(moduleOrPath);
+      if (binary.usedStableFallback && !moduleLoadedFromStableFallback) {
+        // Couple the fallback decision: the binary fell back to its stable
+        // copy, so the (hashed) glue must follow or the pair can silently
+        // mix deploys (#3416's missing-export class).
+        module = await reloadModuleFromStablePair(module);
+      }
+      await module.default({ module_or_path: binary.value });
       setMarkdownProjectionProjector(module.project_markdown_json);
       resolvedModule = module;
       return module;
@@ -62,7 +108,7 @@ export async function initializeRuntimedWasmClient(
       initialized = undefined;
       initializedSource = undefined;
       resolvedModule = undefined;
-      throw error;
+      throw asRuntimedWasmAssetFailure(error);
     });
   return initialized;
 }
@@ -195,6 +241,7 @@ function loadRuntimedWasmModule(modulePath: string | URL): Promise<RuntimedWasmM
       if (loadedModule === pending) {
         loadedModule = undefined;
         loadedModuleSource = undefined;
+        moduleLoadedFromStableFallback = false;
       }
       throw error;
     });
@@ -205,7 +252,9 @@ function loadRuntimedWasmModule(modulePath: string | URL): Promise<RuntimedWasmM
 
 async function importRuntimedWasmModuleWithRecovery(href: string): Promise<RuntimedWasmModule> {
   try {
-    return await importRuntimedWasmModuleWithRetries(href);
+    const module = await importRuntimedWasmModuleWithRetries(href);
+    moduleLoadedFromStableFallback = false;
+    return module;
   } catch (error) {
     const stableHref = stableRuntimedAssetHref(href);
     if (!stableHref) throw error;
@@ -213,8 +262,41 @@ async function importRuntimedWasmModuleWithRecovery(href: string): Promise<Runti
       `[notebook-cloud] runtimed WASM module failed from ${href}; falling back to ${stableHref}`,
       error,
     );
-    return importRuntimedWasmModuleWithRetries(stableHref);
+    const module = await importRuntimedWasmModuleWithRetries(stableHref);
+    moduleLoadedFromStableFallback = true;
+    return module;
   }
+}
+
+/**
+ * The binary fell back to its stable copy while the cached module came
+ * from a hashed name: re-import the module from ITS stable name so the
+ * glue/binary pair stays deploy-consistent. No-op when the module name
+ * carries no hash (already stable — the pair is consistent).
+ */
+async function reloadModuleFromStablePair(module: RuntimedWasmModule): Promise<RuntimedWasmModule> {
+  const requestedHref = loadedModuleSource;
+  const stableHref = requestedHref ? stableRuntimedAssetHref(requestedHref) : null;
+  if (!stableHref) return module;
+  console.warn(
+    `[notebook-cloud] runtimed WASM binary fell back to stable; reloading module from ${stableHref} to keep the pair consistent`,
+  );
+  const pending = importRuntimedWasmModuleWithRetries(stableHref)
+    .then((stableModule) => {
+      moduleLoadedFromStableFallback = true;
+      return stableModule;
+    })
+    .catch((error: unknown) => {
+      if (loadedModule === pending) {
+        loadedModule = undefined;
+        loadedModuleSource = undefined;
+        moduleLoadedFromStableFallback = false;
+      }
+      throw error;
+    });
+  // Cache stays keyed on the REQUESTED href; only the resolution swaps.
+  loadedModule = pending;
+  return pending;
 }
 
 async function importRuntimedWasmModuleWithRetries(href: string): Promise<RuntimedWasmModule> {
@@ -224,9 +306,103 @@ async function importRuntimedWasmModuleWithRetries(href: string): Promise<Runtim
   // whole ladder applies.
   for (let attempt = 0; attempt <= RUNTIMED_WASM_RETRY_DELAYS_MS.length; attempt += 1) {
     try {
-      return await importModule(href);
+      // Rungs >= 1 carry a unique ?retry= query: the module map pins failed
+      // fetches per specifier (see moduleImportBusterSequence), so a bare
+      // same-href retry would replay the cached rejection network-free.
+      return await withRungTimeout(
+        importModule(bustedModuleHref(href, attempt)),
+        `runtimed WASM module import (${href})`,
+      );
     } catch (error) {
       lastFailure = error;
+    }
+    const delay = RUNTIMED_WASM_RETRY_DELAYS_MS[attempt];
+    if (delay === undefined) break;
+    await sleep(delay);
+  }
+  throw lastFailure instanceof Error ? lastFailure : new Error(String(lastFailure));
+}
+
+function bustedModuleHref(href: string, attempt: number): string {
+  if (attempt === 0) return href;
+  const separator = href.includes("?") ? "&" : "?";
+  moduleImportBusterSequence += 1;
+  return `${href}${separator}retry=${moduleImportBusterSequence}`;
+}
+
+interface ResolvedRuntimedWasmBinary {
+  value: WasmModuleOrPath;
+  usedStableFallback: boolean;
+}
+
+/**
+ * Resolve the wasm-bindgen `module_or_path` input. URL-shaped inputs are
+ * fetched here (instead of inside wasm-bindgen's init) so the ladder and
+ * the hashed→stable fallback cover the binary exactly like the module;
+ * everything else (Response, ArrayBuffer, compiled module) passes through.
+ * When the module already fell back to its stable name, the hashed binary
+ * name is skipped outright — fallback decisions are coupled pairwise.
+ */
+async function resolveRuntimedWasmBinary(
+  moduleOrPath: WasmModuleOrPath,
+): Promise<ResolvedRuntimedWasmBinary> {
+  if (typeof moduleOrPath !== "string" && !(moduleOrPath instanceof URL)) {
+    return { value: moduleOrPath, usedStableFallback: false };
+  }
+  const href = typeof moduleOrPath === "string" ? moduleOrPath : moduleOrPath.href;
+  if (!isLadderFetchableHref(href)) {
+    // Non-network schemes (file:, data:, blob: in tests/embeddings) go
+    // straight to wasm-bindgen; the ladder exists for HTTP asset origins.
+    return { value: moduleOrPath, usedStableFallback: false };
+  }
+  const stableHref = stableRuntimedAssetHref(href);
+  if (stableHref && moduleLoadedFromStableFallback) {
+    console.warn(
+      `[notebook-cloud] runtimed WASM module fell back to stable; fetching binary from ${stableHref} to keep the pair consistent`,
+    );
+    return {
+      value: await fetchRuntimedWasmBinaryWithRetries(stableHref),
+      usedStableFallback: true,
+    };
+  }
+  try {
+    return { value: await fetchRuntimedWasmBinaryWithRetries(href), usedStableFallback: false };
+  } catch (error) {
+    if (!stableHref) throw error;
+    console.warn(
+      `[notebook-cloud] runtimed WASM binary failed from ${href}; falling back to ${stableHref}`,
+      error,
+    );
+    return {
+      value: await fetchRuntimedWasmBinaryWithRetries(stableHref),
+      usedStableFallback: true,
+    };
+  }
+}
+
+async function fetchRuntimedWasmBinaryWithRetries(href: string): Promise<Response> {
+  let lastFailure: unknown = null;
+  for (let attempt = 0; attempt <= RUNTIMED_WASM_RETRY_DELAYS_MS.length; attempt += 1) {
+    let response: Response | null = null;
+    try {
+      response = await withRungTimeout(
+        fetchImpl(href, rungAbortInit()),
+        `runtimed WASM fetch (${href})`,
+      );
+    } catch (error) {
+      // Thrown fetch errors (network drop, DNS, CORS, rung timeout) are
+      // always retryable.
+      lastFailure = error;
+    }
+    if (response) {
+      if (response.ok) return response;
+      const failure = new Error(`Failed to fetch runtimed WASM (${response.status}): ${href}`);
+      if (!shouldRetryRuntimedWasmResponse(response)) {
+        await cancelResponseBody(response);
+        throw failure;
+      }
+      lastFailure = failure;
+      await cancelResponseBody(response);
     }
     const delay = RUNTIMED_WASM_RETRY_DELAYS_MS[attempt];
     if (delay === undefined) break;
@@ -236,58 +412,37 @@ async function importRuntimedWasmModuleWithRetries(href: string): Promise<Runtim
 }
 
 /**
- * Resolve the wasm-bindgen `module_or_path` input. URL-shaped inputs are
- * fetched here (instead of inside wasm-bindgen's init) so the ladder and
- * the hashed→stable fallback cover the binary exactly like the module;
- * everything else (Response, ArrayBuffer, compiled module) passes through.
+ * Bound a rung with a settle deadline. The race (not just AbortSignal)
+ * carries the bound so a hung attempt advances the ladder even where
+ * abort is unsupported (dynamic import) — the loser is abandoned.
  */
-async function resolveRuntimedWasmBinary(
-  moduleOrPath: WasmModuleOrPath,
-): Promise<WasmModuleOrPath> {
-  if (typeof moduleOrPath !== "string" && !(moduleOrPath instanceof URL)) {
-    return moduleOrPath;
-  }
-  const href = typeof moduleOrPath === "string" ? moduleOrPath : moduleOrPath.href;
-  if (!isLadderFetchableHref(href)) {
-    // Non-network schemes (file:, data:, blob: in tests/embeddings) go
-    // straight to wasm-bindgen; the ladder exists for HTTP asset origins.
-    return moduleOrPath;
-  }
+async function withRungTimeout<T>(work: Promise<T>, label: string): Promise<T> {
+  let timer: ReturnType<typeof setTimeout> | undefined;
   try {
-    return await fetchRuntimedWasmBinaryWithRetries(href);
-  } catch (error) {
-    const stableHref = stableRuntimedAssetHref(href);
-    if (!stableHref) throw error;
-    console.warn(
-      `[notebook-cloud] runtimed WASM binary failed from ${href}; falling back to ${stableHref}`,
-      error,
-    );
-    return fetchRuntimedWasmBinaryWithRetries(stableHref);
+    return await Promise.race([
+      work,
+      new Promise<never>((_, reject) => {
+        timer = setTimeout(() => {
+          // The abandoned loser may still settle later; observe its
+          // rejection so it never surfaces as unhandled.
+          void Promise.resolve(work).catch(() => undefined);
+          reject(new Error(`${label} timed out after ${RUNTIMED_WASM_RUNG_TIMEOUT_MS}ms`));
+        }, RUNTIMED_WASM_RUNG_TIMEOUT_MS);
+      }),
+    ]);
+  } finally {
+    clearTimeout(timer);
   }
 }
 
-async function fetchRuntimedWasmBinaryWithRetries(href: string): Promise<Response> {
-  let lastFailure: unknown = null;
-  for (let attempt = 0; attempt <= RUNTIMED_WASM_RETRY_DELAYS_MS.length; attempt += 1) {
-    let response: Response | null = null;
-    try {
-      response = await fetchImpl(href);
-    } catch (error) {
-      // Thrown fetch errors (network drop, DNS, CORS) are always retryable.
-      lastFailure = error;
-    }
-    if (response) {
-      if (response.ok) return response;
-      const failure = new Error(`Failed to fetch runtimed WASM (${response.status}): ${href}`);
-      if (!shouldRetryRuntimedWasmResponse(response)) throw failure;
-      lastFailure = failure;
-      await cancelResponseBody(response);
-    }
-    const delay = RUNTIMED_WASM_RETRY_DELAYS_MS[attempt];
-    if (delay === undefined) break;
-    await sleep(delay);
+function rungAbortInit(): RequestInit | undefined {
+  // Best-effort network cancellation alongside the race; the race is the
+  // load-bearing bound (AbortSignal.timeout is not mockable in tests and
+  // unsupported in some embedders).
+  if (typeof AbortSignal === "undefined" || typeof AbortSignal.timeout !== "function") {
+    return undefined;
   }
-  throw lastFailure instanceof Error ? lastFailure : new Error(String(lastFailure));
+  return { signal: AbortSignal.timeout(RUNTIMED_WASM_RUNG_TIMEOUT_MS) };
 }
 
 function shouldRetryRuntimedWasmResponse(response: Response): boolean {
@@ -364,6 +519,8 @@ export function _resetRuntimedWasmClientForTests(): void {
   initialized = undefined;
   initializedSource = undefined;
   resolvedModule = undefined;
+  moduleLoadedFromStableFallback = false;
+  moduleImportBusterSequence = 0;
 }
 
 function runtimedWasmModuleAfterInit(): RuntimedWasmModule {

--- a/apps/notebook-cloud/viewer/runtimed-wasm-failure.ts
+++ b/apps/notebook-cloud/viewer/runtimed-wasm-failure.ts
@@ -1,0 +1,25 @@
+/**
+ * Classification for terminal runtimed WASM asset failures.
+ *
+ * The wasm client prefixes every terminal load/init failure so the notices
+ * layer can distinguish "the notebook engine's assets failed to load" from
+ * auth/access/transport failures — the former gets a Retry action wired to
+ * retryLiveConnection (the documented re-entry; the caches clear on
+ * rejection so the retry genuinely re-imports), never the auth-flavored
+ * actions. Kept dependency-free so notices.tsx can import the predicate
+ * without pulling the WASM client module graph into its tests.
+ */
+
+export const RUNTIMED_WASM_ASSET_FAILURE_PREFIX = "runtimed WASM asset failed: ";
+
+export function isRuntimedWasmAssetFailure(message: string): boolean {
+  return message.includes(RUNTIMED_WASM_ASSET_FAILURE_PREFIX);
+}
+
+export function asRuntimedWasmAssetFailure(error: unknown): Error {
+  const message = error instanceof Error ? error.message : String(error);
+  if (isRuntimedWasmAssetFailure(message)) {
+    return error instanceof Error ? error : new Error(message);
+  }
+  return new Error(`${RUNTIMED_WASM_ASSET_FAILURE_PREFIX}${message}`, { cause: error });
+}

--- a/apps/notebook-cloud/viewer/sift-preload.ts
+++ b/apps/notebook-cloud/viewer/sift-preload.ts
@@ -8,6 +8,8 @@ import type { ResolvedCell } from "./render-resolution";
 interface SiftWasmPreloadOptions {
   blobBasePath: string;
   rendererAssetsBasePath: string;
+  /** Manifest filename (content-hashed when deployed); stable name fallback. */
+  siftWasmAssetName?: string;
   pageUrl: string;
 }
 
@@ -17,13 +19,14 @@ export function cellsUseSift(cells: readonly ResolvedCell[]): boolean {
 
 export function siftWasmPreloadUrlForCells(
   cells: readonly ResolvedCell[],
-  { blobBasePath, rendererAssetsBasePath, pageUrl }: SiftWasmPreloadOptions,
+  { blobBasePath, rendererAssetsBasePath, siftWasmAssetName, pageUrl }: SiftWasmPreloadOptions,
 ): string | null {
   if (!cellsUseSift(cells)) return null;
 
   return resolveSiftWasmUrl({
     tableUrl: new URL(blobBasePath, pageUrl).href,
     rendererAssetsBaseUrl: new URL(rendererAssetsBasePath, pageUrl).href,
+    siftWasmAssetName,
   });
 }
 

--- a/packages/sift/src/predicate.test.ts
+++ b/packages/sift/src/predicate.test.ts
@@ -1,0 +1,74 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  _resetPredicateModuleForTests,
+  _setWasmModuleLoaderForTests,
+  ensureModule,
+  setWasmUrl,
+} from "./predicate";
+
+function stubWasmModule(initUrls: (string | undefined)[], failFor: Set<string | undefined>) {
+  return {
+    default: async (options: { module_or_path?: string }) => {
+      initUrls.push(options.module_or_path);
+      if (failFor.has(options.module_or_path)) {
+        throw new Error(`synthetic wasm load failure: ${options.module_or_path}`);
+      }
+    },
+  };
+}
+
+describe("predicate wasm loading fallback", () => {
+  beforeEach(() => {
+    _resetPredicateModuleForTests();
+    vi.spyOn(console, "warn").mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    _setWasmModuleLoaderForTests(null);
+    _resetPredicateModuleForTests();
+    vi.restoreAllMocks();
+  });
+
+  it("retries the stable fallback URL once when the primary hashed URL fails", async () => {
+    const initUrls: (string | undefined)[] = [];
+    const hashed = "https://assets.test/renderer-assets/sift_wasm.0123456789abcdef.wasm";
+    const stable = "https://assets.test/renderer-assets/sift_wasm.wasm?v=dev";
+    _setWasmModuleLoaderForTests(async () => stubWasmModule(initUrls, new Set([hashed])));
+
+    setWasmUrl(hashed, stable);
+    await ensureModule();
+
+    expect(initUrls).toEqual([hashed, stable]);
+  });
+
+  it("stays terminal when no fallback is configured", async () => {
+    const initUrls: (string | undefined)[] = [];
+    const url = "https://assets.test/renderer-assets/sift_wasm.wasm?v=dev";
+    _setWasmModuleLoaderForTests(async () => stubWasmModule(initUrls, new Set([url])));
+
+    setWasmUrl(url);
+    await expect(ensureModule()).rejects.toThrow(/synthetic wasm load failure/);
+    expect(initUrls).toEqual([url]);
+  });
+
+  it("does not double-load when primary and fallback are identical", async () => {
+    const initUrls: (string | undefined)[] = [];
+    const url = "https://assets.test/renderer-assets/sift_wasm.wasm?v=dev";
+    _setWasmModuleLoaderForTests(async () => stubWasmModule(initUrls, new Set([url])));
+
+    setWasmUrl(url, url);
+    await expect(ensureModule()).rejects.toThrow(/synthetic wasm load failure/);
+    expect(initUrls).toEqual([url]);
+  });
+
+  it("loads the primary URL without touching the fallback on success", async () => {
+    const initUrls: (string | undefined)[] = [];
+    const hashed = "https://assets.test/renderer-assets/sift_wasm.0123456789abcdef.wasm";
+    _setWasmModuleLoaderForTests(async () => stubWasmModule(initUrls, new Set()));
+
+    setWasmUrl(hashed, "https://assets.test/renderer-assets/sift_wasm.wasm?v=dev");
+    await ensureModule();
+
+    expect(initUrls).toEqual([hashed]);
+  });
+});

--- a/packages/sift/src/predicate.ts
+++ b/packages/sift/src/predicate.ts
@@ -106,22 +106,69 @@ type PredicateModule = {
 
 let mod: PredicateModule | null = null;
 let configuredWasmUrl: string | undefined;
+let configuredWasmFallbackUrl: string | undefined;
+
+type SiftWasmModuleLoader = () => Promise<{
+  default: (options: { module_or_path?: string }) => Promise<unknown>;
+}>;
+
+const defaultWasmModuleLoader: SiftWasmModuleLoader = () =>
+  import("sift-wasm/sift_wasm.js") as ReturnType<SiftWasmModuleLoader>;
+
+let wasmModuleLoader: SiftWasmModuleLoader = defaultWasmModuleLoader;
 
 /**
  * Configure an explicit URL for the WASM binary.
  * Must be called before the first WASM operation.
  * Used in iframe contexts where import.meta.url doesn't resolve.
+ *
+ * `fallbackUrl` (optional) is retried once when loading `url` fails —
+ * hosts pass the stable-name copy here so a content-hashed URL that
+ * vanished across a deploy window degrades to the stable asset instead
+ * of failing terminally. An ABI mismatch on the fallback still fails
+ * loudly at instantiation, which is no worse than no fallback.
  */
-export function setWasmUrl(url: string): void {
+export function setWasmUrl(url: string, fallbackUrl?: string): void {
   configuredWasmUrl = url;
+  configuredWasmFallbackUrl = fallbackUrl;
 }
 
 export async function ensureModule(): Promise<PredicateModule> {
   if (mod) return mod;
-  const wasm = await import("sift-wasm/sift_wasm.js");
-  await wasm.default({ module_or_path: configuredWasmUrl });
+  const wasm = await wasmModuleLoader();
+  try {
+    await wasm.default({ module_or_path: configuredWasmUrl });
+  } catch (error) {
+    if (!configuredWasmFallbackUrl || configuredWasmFallbackUrl === configuredWasmUrl) {
+      throw error;
+    }
+    console.warn(
+      `[sift] wasm load failed from ${configuredWasmUrl}; falling back to ${configuredWasmFallbackUrl}`,
+      error,
+    );
+    await wasm.default({ module_or_path: configuredWasmFallbackUrl });
+  }
   mod = wasm as unknown as PredicateModule;
   return mod;
+}
+
+/**
+ * Swap the wasm module loader (the dynamic import is not interceptable in
+ * unit tests). Pass `null` to restore the real loader.
+ * @internal
+ */
+export function _setWasmModuleLoaderForTests(loader: SiftWasmModuleLoader | null): void {
+  wasmModuleLoader = loader ?? defaultWasmModuleLoader;
+}
+
+/**
+ * Reset the module/url singletons between tests.
+ * @internal
+ */
+export function _resetPredicateModuleForTests(): void {
+  mod = null;
+  configuredWasmUrl = undefined;
+  configuredWasmFallbackUrl = undefined;
 }
 
 /**

--- a/src/components/cell/OutputArea.tsx
+++ b/src/components/cell/OutputArea.tsx
@@ -26,6 +26,7 @@ import {
   type RenderPayload,
   segmentedOutputLanes,
   useIsolatedRenderer,
+  useRegisterIsolatedOutput,
 } from "@/components/isolated";
 import type { NteractEmbedHostContextPatch } from "@/components/isolated/host-context";
 import { injectPluginsForMimes, needsPlugin } from "@/components/isolated/iframe-libraries";
@@ -645,12 +646,19 @@ function OutputAreaSingle({
   const shouldIsolate =
     outputs.length > 0 &&
     (isolated === true || (isolated === "auto" && anyOutputNeedsIsolation(outputs, priority)));
-  // Terminal renderer-bundle failure (the provider's bounded retries are
-  // exhausted): the frame could only render a silent blank well, so show
-  // the same degraded fallback the in-DOM branch gets. retry() recovery is
-  // shared module-level state — one click un-blanks every output at once.
-  const rendererBundleError =
-    shouldIsolate && !rendererBundle.isLoading ? rendererBundle.error : null;
+  // Page-level surfaces (the cloud's aggregated asset notice) gate on
+  // whether anything on screen actually renders isolated outputs.
+  useRegisterIsolatedOutput(shouldIsolate);
+  // Renderer-bundle failure (the provider's bounded retries exhausted):
+  // the frame could only render a silent blank well, so show the same
+  // degraded fallback the in-DOM branch gets. `lastError` keeps the
+  // fallback mounted through an in-flight retry ladder — frames remount
+  // only once the bundle actually loads, so a hopeless Retry click never
+  // churns N blank iframes. retry() recovery is shared module-level
+  // state — one click un-blanks every output at once.
+  const rendererBundleError = shouldIsolate
+    ? (rendererBundle.error ?? rendererBundle.lastError)
+    : null;
   const shouldConstrainIsolatedOutput = shouldIsolate && (focused || maxHeight != null);
   const isolatedOutputWellMaxHeight = focused
     ? focusedOutputWellMaxHeight

--- a/src/components/cell/OutputArea.tsx
+++ b/src/components/cell/OutputArea.tsx
@@ -25,6 +25,7 @@ import {
   outputUsesWheelOwningFrame,
   type RenderPayload,
   segmentedOutputLanes,
+  useIsolatedRenderer,
 } from "@/components/isolated";
 import type { NteractEmbedHostContextPatch } from "@/components/isolated/host-context";
 import { injectPluginsForMimes, needsPlugin } from "@/components/isolated/iframe-libraries";
@@ -638,11 +639,18 @@ function OutputAreaSingle({
   // Get widget store context (may be null if not in provider)
   const widgetContext = useWidgetStore();
   const savedWidgetModels = useSavedWidgetModels();
+  const rendererBundle = useIsolatedRenderer();
 
   // Determine if we should use isolation (when we have outputs)
   const shouldIsolate =
     outputs.length > 0 &&
     (isolated === true || (isolated === "auto" && anyOutputNeedsIsolation(outputs, priority)));
+  // Terminal renderer-bundle failure (the provider's bounded retries are
+  // exhausted): the frame could only render a silent blank well, so show
+  // the same degraded fallback the in-DOM branch gets. retry() recovery is
+  // shared module-level state — one click un-blanks every output at once.
+  const rendererBundleError =
+    shouldIsolate && !rendererBundle.isLoading ? rendererBundle.error : null;
   const shouldConstrainIsolatedOutput = shouldIsolate && (focused || maxHeight != null);
   const isolatedOutputWellMaxHeight = focused
     ? focusedOutputWellMaxHeight
@@ -1083,28 +1091,44 @@ function OutputAreaSingle({
             onKeyDown={shouldUseScrollPassthroughFrame ? handleStaticFrameKeyDown : undefined}
           >
             {shouldMountIsolatedFrame ? (
-              <IsolatedFrame
-                ref={setIsolatedFrameHandle}
-                name={frameName}
-                darkMode={darkMode}
-                colorTheme={colorTheme}
-                minHeight={24}
-                maxHeight={isolatedOutputWellMaxHeight}
-                autoHeight={shouldIsolate && !focused}
-                allowWheelBoundaryScroll={allowWheelBoundaryScroll}
-                forwardWheelBoundaryScroll={shouldForwardWheelBoundaryScroll}
-                scrollPassthrough={shouldScrollPassthroughFrame}
-                onReady={handleIsolatedFrameReady}
-                onLinkClick={onLinkClick}
-                onMouseDown={activateStaticFrameInteraction}
-                onMouseUp={handleStaticFrameMouseUp}
-                onWidgetUpdate={onWidgetUpdate}
-                onMessage={handleIframeMessage}
-                onError={handleIframeError}
-                onDiagnostic={onDiagnostic}
-                hostContext={hostContext}
-                outputDocumentUrl={hostContext?.nteract?.outputDocumentUrl}
-              />
+              rendererBundleError ? (
+                <OutputErrorFallback error={rendererBundleError} onRetry={rendererBundle.retry} />
+              ) : (
+                <ErrorBoundary
+                  resetKeys={[outputs]}
+                  fallback={(error, reset) => <OutputErrorFallback error={error} onRetry={reset} />}
+                  onError={(error, errorInfo) => {
+                    console.error(
+                      "[OutputArea] Error rendering isolated output:",
+                      error,
+                      errorInfo.componentStack,
+                    );
+                  }}
+                >
+                  <IsolatedFrame
+                    ref={setIsolatedFrameHandle}
+                    name={frameName}
+                    darkMode={darkMode}
+                    colorTheme={colorTheme}
+                    minHeight={24}
+                    maxHeight={isolatedOutputWellMaxHeight}
+                    autoHeight={shouldIsolate && !focused}
+                    allowWheelBoundaryScroll={allowWheelBoundaryScroll}
+                    forwardWheelBoundaryScroll={shouldForwardWheelBoundaryScroll}
+                    scrollPassthrough={shouldScrollPassthroughFrame}
+                    onReady={handleIsolatedFrameReady}
+                    onLinkClick={onLinkClick}
+                    onMouseDown={activateStaticFrameInteraction}
+                    onMouseUp={handleStaticFrameMouseUp}
+                    onWidgetUpdate={onWidgetUpdate}
+                    onMessage={handleIframeMessage}
+                    onError={handleIframeError}
+                    onDiagnostic={onDiagnostic}
+                    hostContext={hostContext}
+                    outputDocumentUrl={hostContext?.nteract?.outputDocumentUrl}
+                  />
+                </ErrorBoundary>
+              )
             ) : (
               <div
                 aria-hidden="true"

--- a/src/components/cell/__tests__/OutputAreaIsolatedFallback.test.tsx
+++ b/src/components/cell/__tests__/OutputAreaIsolatedFallback.test.tsx
@@ -1,0 +1,190 @@
+/**
+ * Degraded states for the isolated-output branch of OutputArea.
+ *
+ * A terminal renderer-bundle failure used to render as a silent blank
+ * 24px well per output (plus a console error per frame). The isolated
+ * branch now gets the same ErrorBoundary + OutputErrorFallback-with-retry
+ * treatment the in-DOM branch has: a visible fallback whose Retry calls
+ * the shared provider retry() (module-level state — one recovery
+ * un-blanks every output at once).
+ */
+
+import { fireEvent, render, screen } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vite-plus/test";
+import { OutputArea, type JupyterOutput } from "../OutputArea";
+
+let isolatedFrameMountCount = 0;
+let frameShouldThrow = false;
+
+interface MockRendererBundleState {
+  rendererCode: string | undefined;
+  rendererCss: string | undefined;
+  isLoading: boolean;
+  error: Error | null;
+  retry: () => void;
+}
+
+let mockRendererBundle: MockRendererBundleState;
+
+vi.mock("@/lib/dark-mode", () => ({
+  useDarkMode: () => false,
+  useColorTheme: () => undefined,
+}));
+
+vi.mock("@/components/isolated/iframe-libraries", () => ({
+  injectPluginsForMimes: vi.fn(async () => {}),
+  needsPlugin: vi.fn(() => false),
+}));
+
+vi.mock("@/components/isolated", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@/components/isolated")>();
+  const React = await import("react");
+
+  function MockIsolatedFrame() {
+    React.useEffect(() => {
+      isolatedFrameMountCount += 1;
+    }, []);
+    if (frameShouldThrow) {
+      throw new Error("synthetic isolated frame render failure");
+    }
+    return <div data-testid="isolated-frame" />;
+  }
+
+  return {
+    ...actual,
+    IsolatedFrame: MockIsolatedFrame,
+    useIsolatedRenderer: () => mockRendererBundle,
+  };
+});
+
+function htmlOutput(outputId: string): JupyterOutput {
+  return {
+    output_type: "display_data",
+    output_id: outputId,
+    data: { "text/html": "<b>needs isolation</b>" },
+    metadata: {},
+  } as JupyterOutput;
+}
+
+function streamOutput(outputId: string): JupyterOutput {
+  return {
+    output_type: "stream",
+    output_id: outputId,
+    name: "stdout",
+    text: "plain stream text",
+  } as JupyterOutput;
+}
+
+describe("OutputArea isolated degraded states", () => {
+  beforeEach(() => {
+    isolatedFrameMountCount = 0;
+    frameShouldThrow = false;
+    mockRendererBundle = {
+      rendererCode: undefined,
+      rendererCss: undefined,
+      isLoading: true,
+      error: null,
+      retry: vi.fn(),
+    };
+    vi.spyOn(console, "error").mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("mounts the frame normally while the bundle is still loading", () => {
+    render(<OutputArea cellId="cell-1" outputs={[htmlOutput("o1")]} isolated />);
+
+    expect(screen.getByTestId("isolated-frame")).toBeTruthy();
+    expect(screen.queryByText("Output rendering failed")).toBeNull();
+  });
+
+  it("replaces the blank frame with a visible fallback on terminal bundle failure", () => {
+    mockRendererBundle.isLoading = false;
+    mockRendererBundle.error = new Error("Failed to fetch renderer JS: 404");
+
+    render(<OutputArea cellId="cell-1" outputs={[htmlOutput("o1")]} isolated />);
+
+    expect(screen.queryByTestId("isolated-frame")).toBeNull();
+    expect(isolatedFrameMountCount).toBe(0);
+    expect(screen.getByText("Output rendering failed")).toBeTruthy();
+    expect(screen.getByText("Failed to fetch renderer JS: 404")).toBeTruthy();
+  });
+
+  it("wires the fallback Retry to the shared provider retry()", () => {
+    mockRendererBundle.isLoading = false;
+    mockRendererBundle.error = new Error("Failed to fetch renderer JS: 404");
+
+    render(<OutputArea cellId="cell-1" outputs={[htmlOutput("o1")]} isolated />);
+
+    fireEvent.click(screen.getByRole("button", { name: "Retry" }));
+    expect(mockRendererBundle.retry).toHaveBeenCalledTimes(1);
+  });
+
+  it("renders one quiet fallback per output well and emits no per-frame error cascade", () => {
+    mockRendererBundle.isLoading = false;
+    mockRendererBundle.error = new Error("Failed to fetch renderer JS: 404");
+
+    render(
+      <>
+        <OutputArea cellId="cell-1" outputs={[htmlOutput("o1")]} isolated />
+        <OutputArea cellId="cell-2" outputs={[htmlOutput("o2")]} isolated />
+        <OutputArea cellId="cell-3" outputs={[htmlOutput("o3")]} isolated />
+      </>,
+    );
+
+    // Visible degraded wells instead of N silent blanks...
+    expect(screen.getAllByText("Output rendering failed")).toHaveLength(3);
+    // ...and no frames mounted, so no renderer-bundle-provider-error
+    // cascade per iframe (the page-level notice aggregation lives in
+    // CloudNotebookNotices, fed by the single shared provider state).
+    expect(isolatedFrameMountCount).toBe(0);
+    expect(console.error).not.toHaveBeenCalled();
+  });
+
+  it("recovers in place once the shared bundle state clears", () => {
+    mockRendererBundle.isLoading = false;
+    mockRendererBundle.error = new Error("Failed to fetch renderer JS: 404");
+
+    const outputs = [htmlOutput("o1")];
+    const { rerender } = render(<OutputArea cellId="cell-1" outputs={outputs} isolated />);
+    expect(screen.queryByTestId("isolated-frame")).toBeNull();
+
+    mockRendererBundle = {
+      rendererCode: "code",
+      rendererCss: "css",
+      isLoading: false,
+      error: null,
+      retry: vi.fn(),
+    };
+    rerender(<OutputArea cellId="cell-1" outputs={outputs} isolated />);
+
+    expect(screen.queryByText("Output rendering failed")).toBeNull();
+    expect(screen.getByTestId("isolated-frame")).toBeTruthy();
+  });
+
+  it("leaves in-DOM outputs untouched by a renderer bundle failure", () => {
+    mockRendererBundle.isLoading = false;
+    mockRendererBundle.error = new Error("Failed to fetch renderer JS: 404");
+
+    render(<OutputArea cellId="cell-1" outputs={[streamOutput("s1")]} isolated={false} />);
+
+    expect(screen.getByText("plain stream text")).toBeTruthy();
+    expect(screen.queryByText("Output rendering failed")).toBeNull();
+  });
+
+  it("catches isolated-branch render errors in the new boundary with a retry affordance", () => {
+    frameShouldThrow = true;
+
+    render(<OutputArea cellId="cell-1" outputs={[htmlOutput("o1")]} isolated />);
+
+    expect(screen.getByText("Output rendering failed")).toBeTruthy();
+    expect(screen.getByText("synthetic isolated frame render failure")).toBeTruthy();
+
+    // Boundary reset: healed frame re-renders cleanly after Retry.
+    frameShouldThrow = false;
+    fireEvent.click(screen.getByRole("button", { name: "Retry" }));
+    expect(screen.getByTestId("isolated-frame")).toBeTruthy();
+  });
+});

--- a/src/components/cell/__tests__/OutputAreaIsolatedFallback.test.tsx
+++ b/src/components/cell/__tests__/OutputAreaIsolatedFallback.test.tsx
@@ -21,6 +21,7 @@ interface MockRendererBundleState {
   rendererCss: string | undefined;
   isLoading: boolean;
   error: Error | null;
+  lastError: Error | null;
   retry: () => void;
 }
 
@@ -84,6 +85,7 @@ describe("OutputArea isolated degraded states", () => {
       rendererCss: undefined,
       isLoading: true,
       error: null,
+      lastError: null,
       retry: vi.fn(),
     };
     vi.spyOn(console, "error").mockImplementation(() => {});
@@ -103,6 +105,7 @@ describe("OutputArea isolated degraded states", () => {
   it("replaces the blank frame with a visible fallback on terminal bundle failure", () => {
     mockRendererBundle.isLoading = false;
     mockRendererBundle.error = new Error("Failed to fetch renderer JS: 404");
+    mockRendererBundle.lastError = mockRendererBundle.error;
 
     render(<OutputArea cellId="cell-1" outputs={[htmlOutput("o1")]} isolated />);
 
@@ -115,6 +118,7 @@ describe("OutputArea isolated degraded states", () => {
   it("wires the fallback Retry to the shared provider retry()", () => {
     mockRendererBundle.isLoading = false;
     mockRendererBundle.error = new Error("Failed to fetch renderer JS: 404");
+    mockRendererBundle.lastError = mockRendererBundle.error;
 
     render(<OutputArea cellId="cell-1" outputs={[htmlOutput("o1")]} isolated />);
 
@@ -125,6 +129,7 @@ describe("OutputArea isolated degraded states", () => {
   it("renders one quiet fallback per output well and emits no per-frame error cascade", () => {
     mockRendererBundle.isLoading = false;
     mockRendererBundle.error = new Error("Failed to fetch renderer JS: 404");
+    mockRendererBundle.lastError = mockRendererBundle.error;
 
     render(
       <>
@@ -141,11 +146,29 @@ describe("OutputArea isolated degraded states", () => {
     // CloudNotebookNotices, fed by the single shared provider state).
     expect(isolatedFrameMountCount).toBe(0);
     expect(console.error).not.toHaveBeenCalled();
+    // OutputArea must NEVER render the page-level notice itself — N
+    // failing wells aggregate into ONE notice in the cloud notices stack.
+    expect(screen.queryByText("Output renderer unavailable.")).toBeNull();
+  });
+
+  it("keeps the fallback mounted through an in-flight retry instead of churning blank frames", () => {
+    // The provider reports a retry kicked from a terminal error as
+    // isLoading with lastError sticky.
+    mockRendererBundle.isLoading = true;
+    mockRendererBundle.error = null;
+    mockRendererBundle.lastError = new Error("Failed to fetch renderer JS: 404");
+
+    render(<OutputArea cellId="cell-1" outputs={[htmlOutput("o1")]} isolated />);
+
+    expect(screen.queryByTestId("isolated-frame")).toBeNull();
+    expect(isolatedFrameMountCount).toBe(0);
+    expect(screen.getByText("Output rendering failed")).toBeTruthy();
   });
 
   it("recovers in place once the shared bundle state clears", () => {
     mockRendererBundle.isLoading = false;
     mockRendererBundle.error = new Error("Failed to fetch renderer JS: 404");
+    mockRendererBundle.lastError = mockRendererBundle.error;
 
     const outputs = [htmlOutput("o1")];
     const { rerender } = render(<OutputArea cellId="cell-1" outputs={outputs} isolated />);
@@ -156,6 +179,7 @@ describe("OutputArea isolated degraded states", () => {
       rendererCss: "css",
       isLoading: false,
       error: null,
+      lastError: null,
       retry: vi.fn(),
     };
     rerender(<OutputArea cellId="cell-1" outputs={outputs} isolated />);
@@ -167,6 +191,7 @@ describe("OutputArea isolated degraded states", () => {
   it("leaves in-DOM outputs untouched by a renderer bundle failure", () => {
     mockRendererBundle.isLoading = false;
     mockRendererBundle.error = new Error("Failed to fetch renderer JS: 404");
+    mockRendererBundle.lastError = mockRendererBundle.error;
 
     render(<OutputArea cellId="cell-1" outputs={[streamOutput("s1")]} isolated={false} />);
 
@@ -185,6 +210,23 @@ describe("OutputArea isolated degraded states", () => {
     // Boundary reset: healed frame re-renders cleanly after Retry.
     frameShouldThrow = false;
     fireEvent.click(screen.getByRole("button", { name: "Retry" }));
+    expect(screen.getByTestId("isolated-frame")).toBeTruthy();
+  });
+
+  it("auto-resets the boundary when a NEW outputs array arrives (resetKeys), no Retry click", () => {
+    frameShouldThrow = true;
+
+    const { rerender } = render(
+      <OutputArea cellId="cell-1" outputs={[htmlOutput("o1")]} isolated />,
+    );
+    expect(screen.getByText("Output rendering failed")).toBeTruthy();
+
+    // Re-execution delivers a fresh outputs array: resetKeys=[outputs]
+    // must clear the boundary without any user interaction.
+    frameShouldThrow = false;
+    rerender(<OutputArea cellId="cell-1" outputs={[htmlOutput("o2")]} isolated />);
+
+    expect(screen.queryByText("Output rendering failed")).toBeNull();
     expect(screen.getByTestId("isolated-frame")).toBeTruthy();
   });
 });

--- a/src/components/isolated/__tests__/isolated-renderer-context.test.tsx
+++ b/src/components/isolated/__tests__/isolated-renderer-context.test.tsx
@@ -3,16 +3,19 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vite-plus/test"
 import {
   _resetBundleCache,
   IsolatedRendererProvider,
+  useHasIsolatedOutputs,
   useIsolatedRenderer,
+  useRegisterIsolatedOutput,
 } from "../isolated-renderer-context";
 
 function Probe({ id }: { id: string }) {
-  const { rendererCode, rendererCss, isLoading, error, retry } = useIsolatedRenderer();
+  const { rendererCode, rendererCss, isLoading, error, lastError, retry } = useIsolatedRenderer();
   return (
     <div
       data-testid={id}
       data-loading={isLoading ? "true" : "false"}
       data-error={error?.message ?? ""}
+      data-last-error={lastError?.message ?? ""}
       data-code={rendererCode ?? ""}
       data-css={rendererCss ?? ""}
     >
@@ -28,6 +31,7 @@ function probeState(id: string) {
   return {
     loading: node.getAttribute("data-loading"),
     error: node.getAttribute("data-error"),
+    lastError: node.getAttribute("data-last-error"),
     code: node.getAttribute("data-code"),
     css: node.getAttribute("data-css"),
   };
@@ -287,6 +291,154 @@ describe("IsolatedRendererProvider retry behavior", () => {
       "/renderer-assets/isolated-renderer.css",
     ]);
     vi.unstubAllGlobals();
+  });
+
+  it("keeps lastError sticky through an in-flight retry so degraded UI does not flap", async () => {
+    const loader = vi.fn(async () => {
+      throw new Error("Failed to fetch renderer JS: 503");
+    });
+
+    render(
+      <IsolatedRendererProvider loader={loader}>
+        <Probe id="a" />
+      </IsolatedRendererProvider>,
+    );
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(150 + 500 + 1500);
+    });
+    expect(probeState("a")).toMatchObject({
+      loading: "false",
+      error: "Failed to fetch renderer JS: 503",
+      lastError: "Failed to fetch renderer JS: 503",
+    });
+
+    // Mid-retry: terminal `error` clears (the ladder is running) but
+    // `lastError` keeps the failure visible — consumers keep their
+    // fallback instead of remounting blank frames.
+    await act(async () => {
+      screen.getByTestId("a-retry").click();
+      await vi.advanceTimersByTimeAsync(0);
+    });
+    expect(probeState("a")).toMatchObject({
+      loading: "true",
+      error: "",
+      lastError: "Failed to fetch renderer JS: 503",
+    });
+
+    // Exhausting again restores the terminal error.
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(150 + 500 + 1500);
+    });
+    expect(probeState("a")).toMatchObject({
+      loading: "false",
+      error: "Failed to fetch renderer JS: 503",
+    });
+  });
+
+  it("falls back to the stable bundle names once after a hashed-name ladder exhausts", async () => {
+    const fetched: string[] = [];
+    const fetchMock = vi.fn(async (input: RequestInfo | URL) => {
+      const url = String(input);
+      fetched.push(url);
+      if (/\.[a-f0-9]{12,64}\.(?:js|css)$/.test(url)) {
+        return new Response("gone", { status: 404 });
+      }
+      return new Response(url.endsWith(".css") ? "stable-css" : "stable-js");
+    });
+    vi.stubGlobal("fetch", fetchMock);
+    vi.spyOn(console, "warn").mockImplementation(() => {});
+
+    render(
+      <IsolatedRendererProvider
+        basePath="/renderer-assets"
+        assetNames={{
+          js: "isolated-renderer.0123456789abcdef.js",
+          css: "isolated-renderer.fedcba9876543210.css",
+        }}
+      >
+        <Probe id="a" />
+      </IsolatedRendererProvider>,
+    );
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(150 + 500 + 1500);
+    });
+
+    // Four hashed-pair attempts, then ONE stable-pair attempt (js and css
+    // fall back together so the pair stays deploy-consistent).
+    expect(fetched.slice(-2)).toEqual([
+      "/renderer-assets/isolated-renderer.js",
+      "/renderer-assets/isolated-renderer.css",
+    ]);
+    expect(fetched.filter((url) => url.includes("0123456789abcdef"))).toHaveLength(4);
+    expect(probeState("a")).toMatchObject({
+      loading: "false",
+      error: "",
+      lastError: "",
+      code: "stable-js",
+      css: "stable-css",
+    });
+    vi.unstubAllGlobals();
+  });
+
+  it("re-kicks a terminally failed load when the browser comes back online", async () => {
+    let healed = false;
+    const loader = vi.fn(async () => {
+      if (!healed) throw new Error("Failed to fetch renderer JS: 503");
+      return { rendererCode: "code-v4", rendererCss: "css-v4" };
+    });
+
+    render(
+      <IsolatedRendererProvider loader={loader}>
+        <Probe id="a" />
+      </IsolatedRendererProvider>,
+    );
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(150 + 500 + 1500);
+    });
+    expect(probeState("a").error).toBe("Failed to fetch renderer JS: 503");
+
+    healed = true;
+    await act(async () => {
+      window.dispatchEvent(new Event("online"));
+      await vi.advanceTimersByTimeAsync(0);
+    });
+
+    expect(probeState("a")).toMatchObject({ loading: "false", error: "", code: "code-v4" });
+    expect(loader).toHaveBeenCalledTimes(5);
+  });
+
+  it("tracks isolated-output presence across mounts", async () => {
+    function Watcher() {
+      const present = useHasIsolatedOutputs();
+      return <div data-testid="watcher" data-present={present ? "true" : "false"} />;
+    }
+    function IsolatedWell() {
+      useRegisterIsolatedOutput(true);
+      return null;
+    }
+
+    const { rerender } = render(
+      <>
+        <Watcher />
+      </>,
+    );
+    expect(screen.getByTestId("watcher").getAttribute("data-present")).toBe("false");
+
+    rerender(
+      <>
+        <Watcher />
+        <IsolatedWell />
+      </>,
+    );
+    expect(screen.getByTestId("watcher").getAttribute("data-present")).toBe("true");
+
+    rerender(
+      <>
+        <Watcher />
+      </>,
+    );
+    expect(screen.getByTestId("watcher").getAttribute("data-present")).toBe("false");
   });
 
   it("reports a configuration error when neither basePath nor loader is provided", async () => {

--- a/src/components/isolated/__tests__/isolated-renderer-context.test.tsx
+++ b/src/components/isolated/__tests__/isolated-renderer-context.test.tsx
@@ -1,0 +1,245 @@
+import { act, render, screen } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vite-plus/test";
+import {
+  _resetBundleCache,
+  IsolatedRendererProvider,
+  useIsolatedRenderer,
+} from "../isolated-renderer-context";
+
+function Probe({ id }: { id: string }) {
+  const { rendererCode, rendererCss, isLoading, error, retry } = useIsolatedRenderer();
+  return (
+    <div
+      data-testid={id}
+      data-loading={isLoading ? "true" : "false"}
+      data-error={error?.message ?? ""}
+      data-code={rendererCode ?? ""}
+      data-css={rendererCss ?? ""}
+    >
+      <button type="button" data-testid={`${id}-retry`} onClick={retry}>
+        retry
+      </button>
+    </div>
+  );
+}
+
+function probeState(id: string) {
+  const node = screen.getByTestId(id);
+  return {
+    loading: node.getAttribute("data-loading"),
+    error: node.getAttribute("data-error"),
+    code: node.getAttribute("data-code"),
+    css: node.getAttribute("data-css"),
+  };
+}
+
+describe("IsolatedRendererProvider retry behavior", () => {
+  beforeEach(() => {
+    _resetBundleCache();
+    vi.useFakeTimers();
+    vi.spyOn(console, "error").mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.restoreAllMocks();
+    _resetBundleCache();
+  });
+
+  it("serves the bundle to consumers when the loader succeeds", async () => {
+    const loader = vi.fn(async () => ({ rendererCode: "code-v1", rendererCss: "css-v1" }));
+
+    render(
+      <IsolatedRendererProvider loader={loader}>
+        <Probe id="a" />
+      </IsolatedRendererProvider>,
+    );
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(0);
+    });
+
+    expect(probeState("a")).toMatchObject({ loading: "false", error: "", code: "code-v1" });
+    expect(loader).toHaveBeenCalledTimes(1);
+  });
+
+  it("retries on the backoff ladder before surfacing anything to consumers", async () => {
+    let failuresRemaining = 2;
+    const loader = vi.fn(async () => {
+      if (failuresRemaining > 0) {
+        failuresRemaining -= 1;
+        throw new Error("Failed to fetch renderer JS: 404");
+      }
+      return { rendererCode: "code-v1", rendererCss: "css-v1" };
+    });
+
+    render(
+      <IsolatedRendererProvider loader={loader}>
+        <Probe id="a" />
+      </IsolatedRendererProvider>,
+    );
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(0);
+    });
+    expect(loader).toHaveBeenCalledTimes(1);
+    // Mid-ladder: still quietly loading, no error surfaced.
+    expect(probeState("a")).toMatchObject({ loading: "true", error: "" });
+
+    // First rung is exactly 150ms.
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(149);
+    });
+    expect(loader).toHaveBeenCalledTimes(1);
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(1);
+    });
+    expect(loader).toHaveBeenCalledTimes(2);
+    expect(probeState("a")).toMatchObject({ loading: "true", error: "" });
+
+    // Second rung (500ms) recovers.
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(500);
+    });
+    expect(loader).toHaveBeenCalledTimes(3);
+    expect(probeState("a")).toMatchObject({ loading: "false", error: "", code: "code-v1" });
+  });
+
+  it("surfaces a terminal error after the ladder exhausts and recovers via retry()", async () => {
+    let healed = false;
+    const loader = vi.fn(async () => {
+      if (!healed) throw new Error("Failed to fetch renderer JS: 503");
+      return { rendererCode: "code-v2", rendererCss: "css-v2" };
+    });
+
+    render(
+      <IsolatedRendererProvider loader={loader}>
+        <Probe id="a" />
+        <Probe id="b" />
+      </IsolatedRendererProvider>,
+    );
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(150 + 500 + 1500);
+    });
+
+    // 4 attempts (1 + 3 retries), then the error reaches every consumer.
+    expect(loader).toHaveBeenCalledTimes(4);
+    expect(probeState("a")).toMatchObject({
+      loading: "false",
+      error: "Failed to fetch renderer JS: 503",
+    });
+    expect(probeState("b")).toMatchObject({
+      loading: "false",
+      error: "Failed to fetch renderer JS: 503",
+    });
+
+    // One consumer's retry un-blanks every mounted consumer at once.
+    healed = true;
+    await act(async () => {
+      screen.getByTestId("a-retry").click();
+      await vi.advanceTimersByTimeAsync(0);
+    });
+
+    expect(loader).toHaveBeenCalledTimes(5);
+    expect(probeState("a")).toMatchObject({ loading: "false", error: "", code: "code-v2" });
+    expect(probeState("b")).toMatchObject({ loading: "false", error: "", code: "code-v2" });
+  });
+
+  it("propagates recovery across separate provider instances via the shared cache", async () => {
+    let healed = false;
+    const loader = vi.fn(async () => {
+      if (!healed) throw new Error("Failed to fetch renderer CSS: 404");
+      return { rendererCode: "code-v3", rendererCss: "css-v3" };
+    });
+
+    render(
+      <>
+        <IsolatedRendererProvider loader={loader}>
+          <Probe id="a" />
+        </IsolatedRendererProvider>
+        <IsolatedRendererProvider loader={loader}>
+          <Probe id="b" />
+        </IsolatedRendererProvider>
+      </>,
+    );
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(150 + 500 + 1500);
+    });
+    expect(probeState("a").error).toBe("Failed to fetch renderer CSS: 404");
+    expect(probeState("b").error).toBe("Failed to fetch renderer CSS: 404");
+
+    healed = true;
+    await act(async () => {
+      screen.getByTestId("b-retry").click();
+      await vi.advanceTimersByTimeAsync(0);
+    });
+
+    expect(probeState("a")).toMatchObject({ loading: "false", error: "", code: "code-v3" });
+    expect(probeState("b")).toMatchObject({ loading: "false", error: "", code: "code-v3" });
+  });
+
+  it("retry() is a no-op while loading or after success", async () => {
+    const loader = vi.fn(async () => ({ rendererCode: "code", rendererCss: "css" }));
+
+    render(
+      <IsolatedRendererProvider loader={loader}>
+        <Probe id="a" />
+      </IsolatedRendererProvider>,
+    );
+
+    await act(async () => {
+      // Click while the initial load is still in flight.
+      screen.getByTestId("a-retry").click();
+      await vi.advanceTimersByTimeAsync(0);
+    });
+    await act(async () => {
+      // Click again after success.
+      screen.getByTestId("a-retry").click();
+      await vi.advanceTimersByTimeAsync(0);
+    });
+
+    expect(loader).toHaveBeenCalledTimes(1);
+    expect(probeState("a")).toMatchObject({ loading: "false", error: "", code: "code" });
+  });
+
+  it("fetches js and css from basePath and reports HTTP failures", async () => {
+    const fetchMock = vi.fn(async (input: RequestInfo | URL) => {
+      const url = String(input);
+      if (url.endsWith("isolated-renderer.js")) {
+        return new Response("js-code");
+      }
+      return new Response("missing", { status: 404 });
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    render(
+      <IsolatedRendererProvider basePath="/renderer-assets">
+        <Probe id="a" />
+      </IsolatedRendererProvider>,
+    );
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(150 + 500 + 1500);
+    });
+
+    expect(probeState("a").error).toBe("Failed to fetch renderer CSS: 404");
+    expect(
+      fetchMock.mock.calls.map((call) => String(call[0])).filter((url) => url.endsWith(".css"))
+        .length,
+    ).toBe(4);
+    vi.unstubAllGlobals();
+  });
+
+  it("reports a configuration error when neither basePath nor loader is provided", async () => {
+    render(
+      <IsolatedRendererProvider>
+        <Probe id="a" />
+      </IsolatedRendererProvider>,
+    );
+
+    expect(probeState("a").loading).toBe("false");
+    expect(probeState("a").error).toContain("requires either 'basePath' or 'loader'");
+  });
+});

--- a/src/components/isolated/__tests__/isolated-renderer-context.test.tsx
+++ b/src/components/isolated/__tests__/isolated-renderer-context.test.tsx
@@ -232,6 +232,63 @@ describe("IsolatedRendererProvider retry behavior", () => {
     vi.unstubAllGlobals();
   });
 
+  it("fetches manifest-named (content-hashed) bundle files when assetNames are provided", async () => {
+    const fetched: string[] = [];
+    const fetchMock = vi.fn(async (input: RequestInfo | URL) => {
+      fetched.push(String(input));
+      return new Response(String(input).endsWith(".css") ? "css-code" : "js-code");
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    render(
+      <IsolatedRendererProvider
+        basePath="/renderer-assets"
+        assetNames={{
+          js: "isolated-renderer.0123456789abcdef.js",
+          css: "isolated-renderer.fedcba9876543210.css",
+        }}
+      >
+        <Probe id="a" />
+      </IsolatedRendererProvider>,
+    );
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(0);
+    });
+
+    expect(fetched).toEqual([
+      "/renderer-assets/isolated-renderer.0123456789abcdef.js",
+      "/renderer-assets/isolated-renderer.fedcba9876543210.css",
+    ]);
+    expect(probeState("a")).toMatchObject({ loading: "false", error: "", code: "js-code" });
+    vi.unstubAllGlobals();
+  });
+
+  it("defaults to the stable bundle filenames without assetNames", async () => {
+    const fetched: string[] = [];
+    const fetchMock = vi.fn(async (input: RequestInfo | URL) => {
+      fetched.push(String(input));
+      return new Response("ok");
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    render(
+      <IsolatedRendererProvider basePath="/renderer-assets">
+        <Probe id="a" />
+      </IsolatedRendererProvider>,
+    );
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(0);
+    });
+
+    expect(fetched).toEqual([
+      "/renderer-assets/isolated-renderer.js",
+      "/renderer-assets/isolated-renderer.css",
+    ]);
+    vi.unstubAllGlobals();
+  });
+
   it("reports a configuration error when neither basePath nor loader is provided", async () => {
     render(
       <IsolatedRendererProvider>

--- a/src/components/isolated/__tests__/isolated-renderer-context.test.tsx
+++ b/src/components/isolated/__tests__/isolated-renderer-context.test.tsx
@@ -123,10 +123,35 @@ describe("IsolatedRendererProvider retry behavior", () => {
       </IsolatedRendererProvider>,
     );
 
+    // Boundary-pin every rung of THIS ladder (it has its own constant,
+    // separate from the wasm client's): 150 / 500 / 1500 exactly.
     await act(async () => {
-      await vi.advanceTimersByTimeAsync(150 + 500 + 1500);
+      await vi.advanceTimersByTimeAsync(0);
     });
-
+    expect(loader).toHaveBeenCalledTimes(1);
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(149);
+    });
+    expect(loader).toHaveBeenCalledTimes(1);
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(1);
+    });
+    expect(loader).toHaveBeenCalledTimes(2);
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(499);
+    });
+    expect(loader).toHaveBeenCalledTimes(2);
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(1);
+    });
+    expect(loader).toHaveBeenCalledTimes(3);
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(1499);
+    });
+    expect(loader).toHaveBeenCalledTimes(3);
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(1);
+    });
     // 4 attempts (1 + 3 retries), then the error reaches every consumer.
     expect(loader).toHaveBeenCalledTimes(4);
     expect(probeState("a")).toMatchObject({

--- a/src/components/isolated/host-context.ts
+++ b/src/components/isolated/host-context.ts
@@ -46,6 +46,13 @@ export interface NteractEmbedHostContext {
      */
     rendererAssetsBaseUrl?: string;
     /**
+     * Sift WASM filename under the renderer asset base, from the host's
+     * deploy manifest. Content-hashed names (`sift_wasm.<sha16>.wasm`)
+     * ride immutable caching and drop the `?v=` query; the stable
+     * `sift_wasm.wasm` + `?v=` remains the fallback.
+     */
+    siftWasmAssetName?: string;
+    /**
      * Absolute or host-relative URL for the isolated output document shell.
      * Hosted deployments can use this to load the sandboxed frame from a
      * separate output-document origin instead of browser `srcDoc`.

--- a/src/components/isolated/index.ts
+++ b/src/components/isolated/index.ts
@@ -159,4 +159,9 @@ export {
 export type { RendererPluginInfo, RendererPluginName } from "./renderer-plugin-info";
 export type { IdentifiedJupyterOutput } from "./output-payloads";
 // Provider and hook for renderer bundle
-export { IsolatedRendererProvider, useIsolatedRenderer } from "./isolated-renderer-context";
+export {
+  IsolatedRendererProvider,
+  useHasIsolatedOutputs,
+  useIsolatedRenderer,
+  useRegisterIsolatedOutput,
+} from "./isolated-renderer-context";

--- a/src/components/isolated/isolated-renderer-context.tsx
+++ b/src/components/isolated/isolated-renderer-context.tsx
@@ -1,4 +1,12 @@
-import { createContext, type ReactNode, useContext, useEffect, useState } from "react";
+import {
+  createContext,
+  type ReactNode,
+  useCallback,
+  useContext,
+  useEffect,
+  useMemo,
+  useSyncExternalStore,
+} from "react";
 
 interface IsolatedRendererBundle {
   rendererCode: string;
@@ -10,6 +18,12 @@ interface IsolatedRendererContextValue {
   rendererCss: string | undefined;
   isLoading: boolean;
   error: Error | null;
+  /**
+   * Re-attempt a failed bundle load. The bundle state is module-level, so
+   * one successful retry un-blanks every mounted consumer at once. No-op
+   * while a load is in flight or once the bundle has loaded.
+   */
+  retry: () => void;
 }
 
 const IsolatedRendererContext = createContext<IsolatedRendererContextValue | null>(null);
@@ -22,14 +36,118 @@ interface IsolatedRendererProviderProps {
   loader?: () => Promise<IsolatedRendererBundle>;
 }
 
-// Module-level cache (shared across all provider instances)
-let bundleCache: IsolatedRendererBundle | null = null;
-let loadingPromise: Promise<IsolatedRendererBundle> | null = null;
+/**
+ * Bounded in-load backoff before a failure is surfaced at all. A transient
+ * asset-origin blip or deploy-window 404 recovers invisibly; only a
+ * persistent failure reaches consumers (who then hold `retry()`).
+ */
+const RENDERER_BUNDLE_RETRY_DELAYS_MS = [150, 500, 1500];
+
+interface RendererBundleLoadState {
+  bundle: IsolatedRendererBundle | null;
+  isLoading: boolean;
+  error: Error | null;
+}
+
+// Module-level load state (shared across all provider instances): a single
+// recovery propagates to every mounted consumer because they all subscribe
+// to this store.
+let loadState: RendererBundleLoadState = { bundle: null, isLoading: false, error: null };
+const loadListeners = new Set<() => void>();
+let loadGeneration = 0;
+let retryTimer: ReturnType<typeof setTimeout> | null = null;
+
+function getLoadState(): RendererBundleLoadState {
+  return loadState;
+}
+
+function subscribeLoadState(listener: () => void): () => void {
+  loadListeners.add(listener);
+  return () => {
+    loadListeners.delete(listener);
+  };
+}
+
+function setLoadState(next: RendererBundleLoadState): void {
+  loadState = next;
+  for (const listener of [...loadListeners]) {
+    listener();
+  }
+}
+
+/**
+ * Idempotent load kick: no-ops while a load is in flight or after success,
+ * starts a fresh attempt (with the backoff ladder) otherwise — including
+ * after a terminal failure, which is what makes `retry()` and the
+ * historical retry-on-next-mount behavior work.
+ */
+function startRendererBundleLoad(load: () => Promise<IsolatedRendererBundle>): void {
+  if (loadState.bundle || loadState.isLoading) return;
+  const generation = ++loadGeneration;
+  setLoadState({ bundle: null, isLoading: true, error: null });
+  void runRendererBundleLoad(load, generation);
+}
+
+async function runRendererBundleLoad(
+  load: () => Promise<IsolatedRendererBundle>,
+  generation: number,
+): Promise<void> {
+  for (let attempt = 0; ; attempt += 1) {
+    try {
+      const bundle = await load();
+      if (generation !== loadGeneration) return;
+      setLoadState({ bundle, isLoading: false, error: null });
+      return;
+    } catch (error) {
+      if (generation !== loadGeneration) return;
+      const delay = RENDERER_BUNDLE_RETRY_DELAYS_MS[attempt];
+      if (delay === undefined) {
+        console.error("[IsolatedRendererProvider] Bundle load failed:", error);
+        setLoadState({
+          bundle: null,
+          isLoading: false,
+          error: error instanceof Error ? error : new Error(String(error)),
+        });
+        return;
+      }
+      await new Promise<void>((resolve) => {
+        retryTimer = setTimeout(() => {
+          retryTimer = null;
+          resolve();
+        }, delay);
+      });
+      if (generation !== loadGeneration) return;
+    }
+  }
+}
+
+async function fetchRendererBundle(basePath: string): Promise<IsolatedRendererBundle> {
+  const [rendererCode, rendererCss] = await Promise.all([
+    fetch(`${basePath}/isolated-renderer.js`).then((r) => {
+      if (!r.ok) throw new Error(`Failed to fetch renderer JS: ${r.status}`);
+      return r.text();
+    }),
+    fetch(`${basePath}/isolated-renderer.css`).then((r) => {
+      if (!r.ok) throw new Error(`Failed to fetch renderer CSS: ${r.status}`);
+      return r.text();
+    }),
+  ]);
+  return { rendererCode, rendererCss };
+}
+
+const MISSING_CONFIG_ERROR_MESSAGE =
+  "IsolatedRendererProvider requires either 'basePath' or 'loader' prop. " +
+  "See: https://elements.nteract.io/docs/outputs/isolated-frame#setup";
+
+const noopRetry = () => {};
 
 /**
  * Provider for the isolated renderer bundle.
  *
  * Wrap your app (or the part that uses IsolatedFrame) with this provider.
+ * Fetch failures retry on a bounded backoff ladder before surfacing an
+ * error; consumers can call `retry()` from the context value to start a
+ * fresh ladder after a terminal failure.
  *
  * @example
  * // Option A: Fetch from a URL path
@@ -48,82 +166,48 @@ export function IsolatedRendererProvider({
   basePath,
   loader,
 }: IsolatedRendererProviderProps) {
-  const [state, setState] = useState<IsolatedRendererContextValue>(() => ({
-    rendererCode: bundleCache?.rendererCode,
-    rendererCss: bundleCache?.rendererCss,
-    isLoading: !bundleCache,
-    error: null,
-  }));
+  const loadBundle = useMemo(() => {
+    if (loader) return loader;
+    if (basePath) return () => fetchRendererBundle(basePath);
+    return null;
+  }, [basePath, loader]);
+
+  const snapshot = useSyncExternalStore(subscribeLoadState, getLoadState, getLoadState);
 
   useEffect(() => {
-    if (bundleCache) {
-      // Already loaded, update state if needed
-      if (state.isLoading) {
-        setState({
-          rendererCode: bundleCache.rendererCode,
-          rendererCss: bundleCache.rendererCss,
-          isLoading: false,
-          error: null,
-        });
-      }
-      return;
+    if (!loadBundle) return;
+    startRendererBundleLoad(loadBundle);
+  }, [loadBundle]);
+
+  const retry = useCallback(() => {
+    if (!loadBundle) return;
+    startRendererBundleLoad(loadBundle);
+  }, [loadBundle]);
+
+  const value = useMemo<IsolatedRendererContextValue>(() => {
+    if (!loadBundle) {
+      return {
+        rendererCode: undefined,
+        rendererCss: undefined,
+        isLoading: false,
+        error: new Error(MISSING_CONFIG_ERROR_MESSAGE),
+        retry: noopRetry,
+      };
     }
-
-    let cancelled = false;
-
-    if (!loadingPromise) {
-      if (loader) {
-        // Use custom loader (Vite plugin, etc.)
-        loadingPromise = loader();
-      } else if (basePath) {
-        // Fetch from URL
-        loadingPromise = Promise.all([
-          fetch(`${basePath}/isolated-renderer.js`).then((r) => {
-            if (!r.ok) throw new Error(`Failed to fetch renderer JS: ${r.status}`);
-            return r.text();
-          }),
-          fetch(`${basePath}/isolated-renderer.css`).then((r) => {
-            if (!r.ok) throw new Error(`Failed to fetch renderer CSS: ${r.status}`);
-            return r.text();
-          }),
-        ]).then(([js, css]) => ({ rendererCode: js, rendererCss: css }));
-      } else {
-        const error = new Error(
-          "IsolatedRendererProvider requires either 'basePath' or 'loader' prop. " +
-            "See: https://elements.nteract.io/docs/outputs/isolated-frame#setup",
-        );
-        setState((s) => ({ ...s, isLoading: false, error }));
-        return;
-      }
-    }
-
-    loadingPromise
-      .then((bundle) => {
-        bundleCache = bundle;
-        if (!cancelled) {
-          setState({
-            rendererCode: bundle.rendererCode,
-            rendererCss: bundle.rendererCss,
-            isLoading: false,
-            error: null,
-          });
-        }
-      })
-      .catch((error) => {
-        console.error("[IsolatedRendererProvider] Bundle load failed:", error);
-        loadingPromise = null; // Allow retry on next mount
-        if (!cancelled) {
-          setState((s) => ({ ...s, isLoading: false, error }));
-        }
-      });
-
-    return () => {
-      cancelled = true;
+    return {
+      rendererCode: snapshot.bundle?.rendererCode,
+      rendererCss: snapshot.bundle?.rendererCss,
+      // Before the mount effect kicks the first load the store is idle;
+      // report that window as loading so consumers never see a false
+      // "no bundle, no error, not loading" state.
+      isLoading: snapshot.isLoading || (!snapshot.bundle && !snapshot.error),
+      error: snapshot.error,
+      retry,
     };
-  }, [basePath, loader, state.isLoading]);
+  }, [loadBundle, retry, snapshot]);
 
   return (
-    <IsolatedRendererContext.Provider value={state}>{children}</IsolatedRendererContext.Provider>
+    <IsolatedRendererContext.Provider value={value}>{children}</IsolatedRendererContext.Provider>
   );
 }
 
@@ -133,6 +217,7 @@ const NO_PROVIDER_STATE: IsolatedRendererContextValue = {
   rendererCss: undefined,
   isLoading: true,
   error: null,
+  retry: noopRetry,
 };
 
 /**
@@ -164,6 +249,10 @@ export function useIsolatedRenderer(): IsolatedRendererContextValue {
  * @internal
  */
 export function _resetBundleCache() {
-  bundleCache = null;
-  loadingPromise = null;
+  loadGeneration += 1;
+  if (retryTimer !== null) {
+    clearTimeout(retryTimer);
+    retryTimer = null;
+  }
+  setLoadState({ bundle: null, isLoading: false, error: null });
 }

--- a/src/components/isolated/isolated-renderer-context.tsx
+++ b/src/components/isolated/isolated-renderer-context.tsx
@@ -19,6 +19,13 @@ interface IsolatedRendererContextValue {
   isLoading: boolean;
   error: Error | null;
   /**
+   * Sticky failure: stays populated while a retry ladder kicked from a
+   * terminal error is in flight, so degraded UI (fallback wells, the
+   * aggregated notice) does not flap back to blank frames until the
+   * bundle actually loads. Cleared on success.
+   */
+  lastError: Error | null;
+  /**
    * Re-attempt a failed bundle load. The bundle state is module-level, so
    * one successful retry un-blanks every mounted consumer at once. No-op
    * while a load is in flight or once the bundle has loaded.
@@ -35,7 +42,11 @@ interface IsolatedRendererProviderProps {
   /**
    * Bundle filenames under `basePath` — content-hashed names from a deploy
    * manifest (e.g. `isolated-renderer.<sha16>.js`) get immutable caching on
-   * the renderer-assets origin. Defaults to the stable names.
+   * the renderer-assets origin. Defaults to the stable names. When hashed
+   * names exhaust the retry ladder (deploy-window skew: the page predates a
+   * deploy that replaced the hashed copies), the stable names are tried
+   * once before the failure goes terminal — they are deployed alongside
+   * the hashed copies for exactly this.
    */
   assetNames?: { js?: string; css?: string };
   /** Custom loader function (e.g., for Vite virtual modules) */
@@ -44,21 +55,36 @@ interface IsolatedRendererProviderProps {
 
 /**
  * Bounded in-load backoff before a failure is surfaced at all. A transient
- * asset-origin blip or deploy-window 404 recovers invisibly; only a
- * persistent failure reaches consumers (who then hold `retry()`).
+ * asset-origin blip recovers invisibly; only a persistent failure reaches
+ * consumers (who then hold `retry()`, and a window `online` event re-kicks
+ * the load automatically).
  */
 const RENDERER_BUNDLE_RETRY_DELAYS_MS = [150, 500, 1500];
+
+/**
+ * Per-rung settle deadline so a black-holed fetch becomes a failed rung
+ * (and eventually a visible, retryable error) instead of pinning the
+ * provider in a permanent isLoading state where neither the fallback
+ * wells nor the notice can surface.
+ */
+const RENDERER_BUNDLE_RUNG_TIMEOUT_MS = 20_000;
 
 interface RendererBundleLoadState {
   bundle: IsolatedRendererBundle | null;
   isLoading: boolean;
   error: Error | null;
+  lastError: Error | null;
 }
 
 // Module-level load state (shared across all provider instances): a single
 // recovery propagates to every mounted consumer because they all subscribe
 // to this store.
-let loadState: RendererBundleLoadState = { bundle: null, isLoading: false, error: null };
+let loadState: RendererBundleLoadState = {
+  bundle: null,
+  isLoading: false,
+  error: null,
+  lastError: null,
+};
 const loadListeners = new Set<() => void>();
 let loadGeneration = 0;
 let retryTimer: ReturnType<typeof setTimeout> | null = null;
@@ -81,39 +107,50 @@ function setLoadState(next: RendererBundleLoadState): void {
   }
 }
 
+interface RendererBundleLoader {
+  load: () => Promise<IsolatedRendererBundle>;
+  /**
+   * Stable-name retry used once after the primary ladder exhausts — only
+   * set when the primary names are content-hashed (hashed→stable skew
+   * absorption, mirroring the runtimed WASM client).
+   */
+  stableFallback: (() => Promise<IsolatedRendererBundle>) | null;
+}
+
 /**
  * Idempotent load kick: no-ops while a load is in flight or after success,
  * starts a fresh attempt (with the backoff ladder) otherwise — including
  * after a terminal failure, which is what makes `retry()` and the
- * historical retry-on-next-mount behavior work.
+ * historical retry-on-next-mount behavior work. A kick from a terminal
+ * error keeps that error visible via `lastError` until the load succeeds.
  */
-function startRendererBundleLoad(load: () => Promise<IsolatedRendererBundle>): void {
+function startRendererBundleLoad(loader: RendererBundleLoader): void {
   if (loadState.bundle || loadState.isLoading) return;
   const generation = ++loadGeneration;
-  setLoadState({ bundle: null, isLoading: true, error: null });
-  void runRendererBundleLoad(load, generation);
+  setLoadState({
+    bundle: null,
+    isLoading: true,
+    error: null,
+    lastError: loadState.error ?? loadState.lastError,
+  });
+  void runRendererBundleLoad(loader, generation);
 }
 
 async function runRendererBundleLoad(
-  load: () => Promise<IsolatedRendererBundle>,
+  loader: RendererBundleLoader,
   generation: number,
 ): Promise<void> {
   for (let attempt = 0; ; attempt += 1) {
     try {
-      const bundle = await load();
+      const bundle = await loader.load();
       if (generation !== loadGeneration) return;
-      setLoadState({ bundle, isLoading: false, error: null });
+      setLoadState({ bundle, isLoading: false, error: null, lastError: null });
       return;
     } catch (error) {
       if (generation !== loadGeneration) return;
       const delay = RENDERER_BUNDLE_RETRY_DELAYS_MS[attempt];
       if (delay === undefined) {
-        console.error("[IsolatedRendererProvider] Bundle load failed:", error);
-        setLoadState({
-          bundle: null,
-          isLoading: false,
-          error: error instanceof Error ? error : new Error(String(error)),
-        });
+        await finishWithStableFallbackOrError(loader, generation, error);
         return;
       }
       await new Promise<void>((resolve) => {
@@ -127,8 +164,34 @@ async function runRendererBundleLoad(
   }
 }
 
+async function finishWithStableFallbackOrError(
+  loader: RendererBundleLoader,
+  generation: number,
+  ladderError: unknown,
+): Promise<void> {
+  if (loader.stableFallback) {
+    console.warn(
+      "[IsolatedRendererProvider] Hashed bundle names exhausted the ladder; trying stable names:",
+      ladderError,
+    );
+    try {
+      const bundle = await loader.stableFallback();
+      if (generation !== loadGeneration) return;
+      setLoadState({ bundle, isLoading: false, error: null, lastError: null });
+      return;
+    } catch (fallbackError) {
+      if (generation !== loadGeneration) return;
+      ladderError = fallbackError;
+    }
+  }
+  console.error("[IsolatedRendererProvider] Bundle load failed:", ladderError);
+  const error = ladderError instanceof Error ? ladderError : new Error(String(ladderError));
+  setLoadState({ bundle: null, isLoading: false, error, lastError: error });
+}
+
 const ISOLATED_RENDERER_JS_STABLE_NAME = "isolated-renderer.js";
 const ISOLATED_RENDERER_CSS_STABLE_NAME = "isolated-renderer.css";
+const CONTENT_HASHED_RENDERER_ASSET_RE = /^isolated-renderer\.[a-f0-9]{12,64}\.(?:js|css)$/;
 
 async function fetchRendererBundle(
   basePath: string,
@@ -136,16 +199,44 @@ async function fetchRendererBundle(
   cssName: string,
 ): Promise<IsolatedRendererBundle> {
   const [rendererCode, rendererCss] = await Promise.all([
-    fetch(`${basePath}/${jsName}`).then((r) => {
-      if (!r.ok) throw new Error(`Failed to fetch renderer JS: ${r.status}`);
-      return r.text();
-    }),
-    fetch(`${basePath}/${cssName}`).then((r) => {
-      if (!r.ok) throw new Error(`Failed to fetch renderer CSS: ${r.status}`);
-      return r.text();
-    }),
+    fetchBundleAsset(`${basePath}/${jsName}`, "JS"),
+    fetchBundleAsset(`${basePath}/${cssName}`, "CSS"),
   ]);
   return { rendererCode, rendererCss };
+}
+
+async function fetchBundleAsset(url: string, label: string): Promise<string> {
+  // The race is the load-bearing settle bound (works under fake timers and
+  // embedders without AbortSignal.timeout); the signal additionally
+  // cancels the network request where supported.
+  let timer: ReturnType<typeof setTimeout> | undefined;
+  try {
+    const response = await Promise.race([
+      fetch(url, bundleAssetAbortInit()),
+      new Promise<never>((_, reject) => {
+        timer = setTimeout(
+          () =>
+            reject(
+              new Error(
+                `Renderer ${label} fetch timed out after ${RENDERER_BUNDLE_RUNG_TIMEOUT_MS}ms`,
+              ),
+            ),
+          RENDERER_BUNDLE_RUNG_TIMEOUT_MS,
+        );
+      }),
+    ]);
+    if (!response.ok) throw new Error(`Failed to fetch renderer ${label}: ${response.status}`);
+    return await response.text();
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
+function bundleAssetAbortInit(): RequestInit | undefined {
+  if (typeof AbortSignal === "undefined" || typeof AbortSignal.timeout !== "function") {
+    return undefined;
+  }
+  return { signal: AbortSignal.timeout(RENDERER_BUNDLE_RUNG_TIMEOUT_MS) };
 }
 
 const MISSING_CONFIG_ERROR_MESSAGE =
@@ -158,9 +249,11 @@ const noopRetry = () => {};
  * Provider for the isolated renderer bundle.
  *
  * Wrap your app (or the part that uses IsolatedFrame) with this provider.
- * Fetch failures retry on a bounded backoff ladder before surfacing an
+ * Fetch failures retry on a bounded backoff ladder (content-hashed names
+ * additionally fall back to the stable copies once) before surfacing an
  * error; consumers can call `retry()` from the context value to start a
- * fresh ladder after a terminal failure.
+ * fresh ladder after a terminal failure, and a browser `online` event
+ * re-kicks a terminally failed load automatically.
  *
  * @example
  * // Option A: Fetch from a URL path
@@ -182,31 +275,65 @@ export function IsolatedRendererProvider({
 }: IsolatedRendererProviderProps) {
   const jsName = assetNames?.js || ISOLATED_RENDERER_JS_STABLE_NAME;
   const cssName = assetNames?.css || ISOLATED_RENDERER_CSS_STABLE_NAME;
-  const loadBundle = useMemo(() => {
-    if (loader) return loader;
-    if (basePath) return () => fetchRendererBundle(basePath, jsName, cssName);
+  const bundleLoader = useMemo<RendererBundleLoader | null>(() => {
+    if (loader) return { load: loader, stableFallback: null };
+    if (basePath) {
+      const hasHashedName =
+        CONTENT_HASHED_RENDERER_ASSET_RE.test(jsName) ||
+        CONTENT_HASHED_RENDERER_ASSET_RE.test(cssName);
+      return {
+        load: () => fetchRendererBundle(basePath, jsName, cssName),
+        // Fall back as a PAIR so js and css always come from the same
+        // deploy tier (mirrors the wasm client's coupled fallback).
+        stableFallback: hasHashedName
+          ? () =>
+              fetchRendererBundle(
+                basePath,
+                ISOLATED_RENDERER_JS_STABLE_NAME,
+                ISOLATED_RENDERER_CSS_STABLE_NAME,
+              )
+          : null,
+      };
+    }
     return null;
   }, [basePath, cssName, jsName, loader]);
 
   const snapshot = useSyncExternalStore(subscribeLoadState, getLoadState, getLoadState);
 
   useEffect(() => {
-    if (!loadBundle) return;
-    startRendererBundleLoad(loadBundle);
-  }, [loadBundle]);
+    if (!bundleLoader) return;
+    startRendererBundleLoad(bundleLoader);
+  }, [bundleLoader]);
+
+  // Auto-recovery nudge: a terminal failure during an outage stays pinned
+  // after the network returns (the transport reconnects itself, the bundle
+  // did not). One principled listener — no polling; startRendererBundleLoad
+  // is idempotent and generation-guarded.
+  useEffect(() => {
+    if (!bundleLoader || typeof window === "undefined") return;
+    const handleOnline = () => {
+      if (getLoadState().error) {
+        startRendererBundleLoad(bundleLoader);
+      }
+    };
+    window.addEventListener("online", handleOnline);
+    return () => window.removeEventListener("online", handleOnline);
+  }, [bundleLoader]);
 
   const retry = useCallback(() => {
-    if (!loadBundle) return;
-    startRendererBundleLoad(loadBundle);
-  }, [loadBundle]);
+    if (!bundleLoader) return;
+    startRendererBundleLoad(bundleLoader);
+  }, [bundleLoader]);
 
   const value = useMemo<IsolatedRendererContextValue>(() => {
-    if (!loadBundle) {
+    if (!bundleLoader) {
+      const error = new Error(MISSING_CONFIG_ERROR_MESSAGE);
       return {
         rendererCode: undefined,
         rendererCss: undefined,
         isLoading: false,
-        error: new Error(MISSING_CONFIG_ERROR_MESSAGE),
+        error,
+        lastError: error,
         retry: noopRetry,
       };
     }
@@ -218,9 +345,10 @@ export function IsolatedRendererProvider({
       // "no bundle, no error, not loading" state.
       isLoading: snapshot.isLoading || (!snapshot.bundle && !snapshot.error),
       error: snapshot.error,
+      lastError: snapshot.lastError,
       retry,
     };
-  }, [loadBundle, retry, snapshot]);
+  }, [bundleLoader, retry, snapshot]);
 
   return (
     <IsolatedRendererContext.Provider value={value}>{children}</IsolatedRendererContext.Provider>
@@ -233,6 +361,7 @@ const NO_PROVIDER_STATE: IsolatedRendererContextValue = {
   rendererCss: undefined,
   isLoading: true,
   error: null,
+  lastError: null,
   retry: noopRetry,
 };
 
@@ -260,6 +389,55 @@ export function useIsolatedRenderer(): IsolatedRendererContextValue {
   return context;
 }
 
+// Presence of isolation-needing outputs (module-level, mirrors the bundle
+// store): lets page-level surfaces (the cloud's aggregated asset notice)
+// stay silent on notebooks where nothing on screen is actually degraded.
+let isolatedOutputConsumers = 0;
+const presenceListeners = new Set<() => void>();
+
+function notifyIsolatedOutputPresence(): void {
+  for (const listener of presenceListeners) {
+    listener();
+  }
+}
+
+function subscribeIsolatedOutputPresence(listener: () => void): () => void {
+  presenceListeners.add(listener);
+  return () => {
+    presenceListeners.delete(listener);
+  };
+}
+
+function hasIsolatedOutputConsumers(): boolean {
+  return isolatedOutputConsumers > 0;
+}
+
+/**
+ * Report that this component currently renders isolation-needing outputs.
+ * OutputArea calls this with its `shouldIsolate` so `useHasIsolatedOutputs`
+ * reflects what is actually on screen.
+ */
+export function useRegisterIsolatedOutput(active: boolean): void {
+  useEffect(() => {
+    if (!active) return;
+    isolatedOutputConsumers += 1;
+    notifyIsolatedOutputPresence();
+    return () => {
+      isolatedOutputConsumers -= 1;
+      notifyIsolatedOutputPresence();
+    };
+  }, [active]);
+}
+
+/** True while at least one mounted consumer renders isolated outputs. */
+export function useHasIsolatedOutputs(): boolean {
+  return useSyncExternalStore(
+    subscribeIsolatedOutputPresence,
+    hasIsolatedOutputConsumers,
+    () => false,
+  );
+}
+
 /**
  * Reset the bundle cache (useful for testing).
  * @internal
@@ -270,5 +448,5 @@ export function _resetBundleCache() {
     clearTimeout(retryTimer);
     retryTimer = null;
   }
-  setLoadState({ bundle: null, isLoading: false, error: null });
+  setLoadState({ bundle: null, isLoading: false, error: null, lastError: null });
 }

--- a/src/components/isolated/isolated-renderer-context.tsx
+++ b/src/components/isolated/isolated-renderer-context.tsx
@@ -32,6 +32,12 @@ interface IsolatedRendererProviderProps {
   children: ReactNode;
   /** Base path to fetch isolated-renderer.js and isolated-renderer.css from */
   basePath?: string;
+  /**
+   * Bundle filenames under `basePath` — content-hashed names from a deploy
+   * manifest (e.g. `isolated-renderer.<sha16>.js`) get immutable caching on
+   * the renderer-assets origin. Defaults to the stable names.
+   */
+  assetNames?: { js?: string; css?: string };
   /** Custom loader function (e.g., for Vite virtual modules) */
   loader?: () => Promise<IsolatedRendererBundle>;
 }
@@ -70,7 +76,7 @@ function subscribeLoadState(listener: () => void): () => void {
 
 function setLoadState(next: RendererBundleLoadState): void {
   loadState = next;
-  for (const listener of [...loadListeners]) {
+  for (const listener of loadListeners) {
     listener();
   }
 }
@@ -121,13 +127,20 @@ async function runRendererBundleLoad(
   }
 }
 
-async function fetchRendererBundle(basePath: string): Promise<IsolatedRendererBundle> {
+const ISOLATED_RENDERER_JS_STABLE_NAME = "isolated-renderer.js";
+const ISOLATED_RENDERER_CSS_STABLE_NAME = "isolated-renderer.css";
+
+async function fetchRendererBundle(
+  basePath: string,
+  jsName: string,
+  cssName: string,
+): Promise<IsolatedRendererBundle> {
   const [rendererCode, rendererCss] = await Promise.all([
-    fetch(`${basePath}/isolated-renderer.js`).then((r) => {
+    fetch(`${basePath}/${jsName}`).then((r) => {
       if (!r.ok) throw new Error(`Failed to fetch renderer JS: ${r.status}`);
       return r.text();
     }),
-    fetch(`${basePath}/isolated-renderer.css`).then((r) => {
+    fetch(`${basePath}/${cssName}`).then((r) => {
       if (!r.ok) throw new Error(`Failed to fetch renderer CSS: ${r.status}`);
       return r.text();
     }),
@@ -164,13 +177,16 @@ const noopRetry = () => {};
 export function IsolatedRendererProvider({
   children,
   basePath,
+  assetNames,
   loader,
 }: IsolatedRendererProviderProps) {
+  const jsName = assetNames?.js || ISOLATED_RENDERER_JS_STABLE_NAME;
+  const cssName = assetNames?.css || ISOLATED_RENDERER_CSS_STABLE_NAME;
   const loadBundle = useMemo(() => {
     if (loader) return loader;
-    if (basePath) return () => fetchRendererBundle(basePath);
+    if (basePath) return () => fetchRendererBundle(basePath, jsName, cssName);
     return null;
-  }, [basePath, loader]);
+  }, [basePath, cssName, jsName, loader]);
 
   const snapshot = useSyncExternalStore(subscribeLoadState, getLoadState, getLoadState);
 

--- a/src/isolated-renderer/__tests__/sift-assets.test.ts
+++ b/src/isolated-renderer/__tests__/sift-assets.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vite-plus/test";
-import { resolveSiftWasmUrl } from "../sift-assets";
+import { resolveSiftWasmUrl, resolveSiftWasmUrls } from "../sift-assets";
 
 describe("Sift renderer assets", () => {
   it("uses an explicit renderer asset base when the host provides one", () => {
@@ -56,5 +56,52 @@ describe("Sift renderer assets", () => {
         siftWasmAssetName: "../secrets.wasm",
       }),
     ).toBe("https://outputs.example/renderer-assets/sift_wasm.wasm?v=dev");
+  });
+
+  it("pins the validation regex boundaries: short hash, uppercase hex, wrong stem all fall back", () => {
+    // Mirrors the worker's isContentHashedAssetPathname predicate (12-64
+    // lowercase hex) so immutable caching and the ?v= buster never diverge.
+    for (const rejected of [
+      "sift_wasm.abc123.wasm", // 6-char hash: too short
+      "sift_wasm.0123456789ABCDEF.wasm", // uppercase hex
+      "sift_wasm2.0123456789abcdef.wasm", // wrong stem
+      "sift_wasm.0123456789abcdef.wasm.js", // wrong extension tail
+    ]) {
+      expect(
+        resolveSiftWasmUrl({
+          tableUrl: "https://notebooks.example/api/n/demo/blobs/sha256-abc",
+          rendererAssetsBaseUrl: "https://outputs.example/renderer-assets/",
+          siftWasmAssetName: rejected,
+        }),
+      ).toBe("https://outputs.example/renderer-assets/sift_wasm.wasm?v=dev");
+    }
+  });
+
+  it("pairs a hashed primary URL with the stable + ?v= fallback for deploy-window skew", () => {
+    expect(
+      resolveSiftWasmUrls({
+        tableUrl: "https://notebooks.example/api/n/demo/blobs/sha256-abc",
+        rendererAssetsBaseUrl: "https://outputs.example/renderer-assets/",
+        siftWasmAssetName: "sift_wasm.0123456789abcdef.wasm",
+      }),
+    ).toEqual({
+      url: "https://outputs.example/renderer-assets/sift_wasm.0123456789abcdef.wasm",
+      fallbackUrl: "https://outputs.example/renderer-assets/sift_wasm.wasm?v=dev",
+    });
+  });
+
+  it("emits no fallback when the primary name is already stable", () => {
+    expect(
+      resolveSiftWasmUrls({
+        tableUrl: "https://notebooks.example/api/n/demo/blobs/sha256-abc",
+        rendererAssetsBaseUrl: "https://outputs.example/renderer-assets/",
+        siftWasmAssetName: "sift_wasm.wasm",
+      }).fallbackUrl,
+    ).toBeNull();
+    expect(
+      resolveSiftWasmUrls({
+        tableUrl: "https://notebooks.example/api/n/demo/blobs/sha256-abc",
+      }).fallbackUrl,
+    ).toBeNull();
   });
 });

--- a/src/isolated-renderer/__tests__/sift-assets.test.ts
+++ b/src/isolated-renderer/__tests__/sift-assets.test.ts
@@ -27,4 +27,34 @@ describe("Sift renderer assets", () => {
       }),
     ).toBe("http://127.0.0.1:49152/plugins/sift_wasm.wasm?v=dev");
   });
+
+  it("uses a content-hashed manifest name without the ?v= query", () => {
+    expect(
+      resolveSiftWasmUrl({
+        tableUrl: "https://notebooks.example/api/n/demo/blobs/sha256-abc",
+        rendererAssetsBaseUrl: "https://outputs.example/renderer-assets/",
+        siftWasmAssetName: "sift_wasm.0123456789abcdef.wasm",
+      }),
+    ).toBe("https://outputs.example/renderer-assets/sift_wasm.0123456789abcdef.wasm");
+  });
+
+  it("keeps the ?v= cache buster when the manifest hands back the stable name", () => {
+    expect(
+      resolveSiftWasmUrl({
+        tableUrl: "https://notebooks.example/api/n/demo/blobs/sha256-abc",
+        rendererAssetsBaseUrl: "https://outputs.example/renderer-assets/",
+        siftWasmAssetName: "sift_wasm.wasm",
+      }),
+    ).toBe("https://outputs.example/renderer-assets/sift_wasm.wasm?v=dev");
+  });
+
+  it("rejects asset names that are not sift_wasm variants (host context is sandbox input)", () => {
+    expect(
+      resolveSiftWasmUrl({
+        tableUrl: "https://notebooks.example/api/n/demo/blobs/sha256-abc",
+        rendererAssetsBaseUrl: "https://outputs.example/renderer-assets/",
+        siftWasmAssetName: "../secrets.wasm",
+      }),
+    ).toBe("https://outputs.example/renderer-assets/sift_wasm.wasm?v=dev");
+  });
 });

--- a/src/isolated-renderer/__tests__/sift-renderer.test.tsx
+++ b/src/isolated-renderer/__tests__/sift-renderer.test.tsx
@@ -46,8 +46,10 @@ describe("Sift renderer plugin", () => {
       />,
     );
 
+    // Stable names carry no hashed fallback URL.
     expect(siftMocks.setWasmUrl).toHaveBeenLastCalledWith(
       "https://notebooks.example/plugins/sift_wasm.wasm?v=dev",
+      undefined,
     );
 
     hostContext = {
@@ -60,6 +62,38 @@ describe("Sift renderer plugin", () => {
     }
 
     expect(siftMocks.setWasmUrl).toHaveBeenLastCalledWith(
+      "https://outputs.example/renderer-assets/sift_wasm.wasm?v=dev",
+      undefined,
+    );
+  });
+
+  it("threads the stable fallback URL alongside a hashed manifest name", () => {
+    let Renderer: ComponentType<RendererProps> | undefined;
+
+    install({
+      register: (_mimeTypes, component) => {
+        Renderer = component;
+      },
+      registerPattern: vi.fn(),
+      getHostContext: () => ({
+        nteract: {
+          rendererAssetsBaseUrl: "https://outputs.example/renderer-assets/",
+          siftWasmAssetName: "sift_wasm.0123456789abcdef.wasm",
+        },
+      }),
+      subscribeHostContext: () => () => {},
+    });
+
+    expect(Renderer).toBeDefined();
+    render(
+      <Renderer
+        data="https://notebooks.example/api/n/demo/blobs/sha256-abc"
+        mimeType="application/vnd.apache.parquet"
+      />,
+    );
+
+    expect(siftMocks.setWasmUrl).toHaveBeenLastCalledWith(
+      "https://outputs.example/renderer-assets/sift_wasm.0123456789abcdef.wasm",
       "https://outputs.example/renderer-assets/sift_wasm.wasm?v=dev",
     );
   });

--- a/src/isolated-renderer/sift-assets.ts
+++ b/src/isolated-renderer/sift-assets.ts
@@ -47,3 +47,27 @@ export function resolveSiftWasmUrl({
   }
   return wasmUrl.toString();
 }
+
+export interface ResolvedSiftWasmUrls {
+  url: string;
+  /**
+   * Stable-name copy (`sift_wasm.wasm?v=...`) to retry once when the
+   * primary URL fails to load. Only set when the primary name is
+   * content-hashed: the stable copies are deployed alongside the hashed
+   * ones precisely so a stale tab whose hashed name vanished across a
+   * deploy window can still render its first sift output.
+   */
+  fallbackUrl: string | null;
+}
+
+export function resolveSiftWasmUrls(options: ResolveSiftWasmUrlOptions): ResolvedSiftWasmUrls {
+  const url = resolveSiftWasmUrl(options);
+  const requestedName = options.siftWasmAssetName?.trim();
+  const usesHashedName = Boolean(requestedName && CONTENT_HASHED_SIFT_WASM_RE.test(requestedName));
+  return {
+    url,
+    fallbackUrl: usesHashedName
+      ? resolveSiftWasmUrl({ ...options, siftWasmAssetName: undefined })
+      : null,
+  };
+}

--- a/src/isolated-renderer/sift-assets.ts
+++ b/src/isolated-renderer/sift-assets.ts
@@ -3,9 +3,23 @@ declare const __SIFT_WASM_CACHE_KEY__: string | undefined;
 const SIFT_WASM_CACHE_KEY =
   typeof __SIFT_WASM_CACHE_KEY__ === "string" ? __SIFT_WASM_CACHE_KEY__ : "dev";
 
+const SIFT_WASM_STABLE_NAME = "sift_wasm.wasm";
+
+// The asset name arrives via host context, which crosses the sandbox
+// boundary — only accept the stable name or a content-hashed variant of it.
+const SIFT_WASM_ASSET_NAME_RE = /^sift_wasm(?:\.[a-f0-9]{12,64})?\.wasm$/;
+const CONTENT_HASHED_SIFT_WASM_RE = /^sift_wasm\.[a-f0-9]{12,64}\.wasm$/;
+
 export interface ResolveSiftWasmUrlOptions {
   tableUrl: string;
   rendererAssetsBaseUrl?: string;
+  /**
+   * Sift WASM filename from the host's deploy manifest. A content-hashed
+   * name (`sift_wasm.<sha16>.wasm`) rides immutable caching and drops the
+   * `?v=` query; the stable name (default) keeps the build-keyed query as
+   * its cache buster.
+   */
+  siftWasmAssetName?: string;
 }
 
 function withTrailingSlash(value: string): string {
@@ -15,13 +29,21 @@ function withTrailingSlash(value: string): string {
 export function resolveSiftWasmUrl({
   tableUrl,
   rendererAssetsBaseUrl,
+  siftWasmAssetName,
 }: ResolveSiftWasmUrlOptions): string {
   const parsedTableUrl = new URL(tableUrl);
   const assetsBase = rendererAssetsBaseUrl?.trim();
+  const requestedName = siftWasmAssetName?.trim();
+  const assetName =
+    requestedName && SIFT_WASM_ASSET_NAME_RE.test(requestedName)
+      ? requestedName
+      : SIFT_WASM_STABLE_NAME;
   const wasmUrl = assetsBase
-    ? new URL("sift_wasm.wasm", withTrailingSlash(new URL(assetsBase, parsedTableUrl.origin).href))
-    : new URL("/plugins/sift_wasm.wasm", parsedTableUrl.origin);
+    ? new URL(assetName, withTrailingSlash(new URL(assetsBase, parsedTableUrl.origin).href))
+    : new URL(`/plugins/${assetName}`, parsedTableUrl.origin);
 
-  wasmUrl.searchParams.set("v", SIFT_WASM_CACHE_KEY);
+  if (!CONTENT_HASHED_SIFT_WASM_RE.test(assetName)) {
+    wasmUrl.searchParams.set("v", SIFT_WASM_CACHE_KEY);
+  }
   return wasmUrl.toString();
 }

--- a/src/isolated-renderer/sift-renderer.tsx
+++ b/src/isolated-renderer/sift-renderer.tsx
@@ -64,9 +64,11 @@ let unsubscribeHostContext: (() => void) | undefined;
 function configureWasm(blobUrl: string): void {
   lastTableUrl = blobUrl;
   try {
+    const hostNteract = getHostContext?.()?.nteract;
     const nextUrl = resolveSiftWasmUrl({
       tableUrl: blobUrl,
-      rendererAssetsBaseUrl: getHostContext?.()?.nteract?.rendererAssetsBaseUrl,
+      rendererAssetsBaseUrl: hostNteract?.rendererAssetsBaseUrl,
+      siftWasmAssetName: hostNteract?.siftWasmAssetName,
     });
     if (wasmConfigured && configuredWasmUrl === nextUrl) return;
     setWasmUrl(nextUrl);

--- a/src/isolated-renderer/sift-renderer.tsx
+++ b/src/isolated-renderer/sift-renderer.tsx
@@ -33,7 +33,7 @@ import type {
   RendererInstallContext,
   RendererProps,
 } from "@/lib/renderer-registry";
-import { resolveSiftWasmUrl } from "./sift-assets";
+import { resolveSiftWasmUrls } from "./sift-assets";
 
 const ARROW_STREAM_MANIFEST_MIME = "application/vnd.nteract.arrow-stream-manifest+json";
 
@@ -65,14 +65,16 @@ function configureWasm(blobUrl: string): void {
   lastTableUrl = blobUrl;
   try {
     const hostNteract = getHostContext?.()?.nteract;
-    const nextUrl = resolveSiftWasmUrl({
+    const next = resolveSiftWasmUrls({
       tableUrl: blobUrl,
       rendererAssetsBaseUrl: hostNteract?.rendererAssetsBaseUrl,
       siftWasmAssetName: hostNteract?.siftWasmAssetName,
     });
-    if (wasmConfigured && configuredWasmUrl === nextUrl) return;
-    setWasmUrl(nextUrl);
-    configuredWasmUrl = nextUrl;
+    if (wasmConfigured && configuredWasmUrl === next.url) return;
+    // The stable-name fallback rides into the sandboxed loader — sift's
+    // lazy wasm fetch is the seam that actually sees a hashed-name 404.
+    setWasmUrl(next.url, next.fallbackUrl ?? undefined);
+    configuredWasmUrl = next.url;
     wasmConfigured = true;
   } catch (err) {
     console.warn("[sift-renderer] configureWasm failed, using defaults:", err);

--- a/src/lib/renderer-registry.ts
+++ b/src/lib/renderer-registry.ts
@@ -27,6 +27,7 @@ export interface RendererHostContext {
   };
   nteract?: {
     rendererAssetsBaseUrl?: string;
+    siftWasmAssetName?: string;
   };
 }
 


### PR DESCRIPTION
Final PR of the #3421 stack (follows #3565/#3573/#3577/#3570, all merged; rebased onto main). Previously reviewed intra-fork as quillaid/nteract#5 — closing that in favor of this.

## What this does

Asset failures stop producing blank viewers and silent iframe cascades:

1. **Cached-rejection bug fixed**: a failed dynamic `import()` of the runtimed WASM module was pinned for the life of the page — every retry re-awaited the same dead promise. This silently defeated `retryLiveConnection` since the day it shipped.
2. **Runtimed WASM retry ladder** ([150/500/1500]ms, blob-resolver status semantics, 404 retryable for deploy propagation) with **hashed→stable filename fallback**, module-map cache-busting on retry rungs (the HTML spec mandates caching failed module fetches — same-specifier retries don't refetch), **coupled pairing** (never hashed glue with a stable binary or vice versa — the #3416 skew class), per-rung 20s deadlines so a black-holed fetch can't wedge the shared init singleton, and a **Retry affordance** on the terminal "Notebook engine failed to load." notice wired to `retryLiveConnection`.
3. **Renderer bundle + sift WASM** get the same treatment: bounded ladder, hashed→stable pair fallback, exposed `retry()`, `online`-event re-kick, sticky fallback wells (no iframe churn during in-flight retries).
4. **Visible degraded outputs**: the isolated branch gets the `ErrorBoundary` + `OutputErrorFallback`-with-retry treatment the in-DOM branch already had; N identical failures aggregate into ONE quiet notice (gated on isolated outputs actually existing). Asset health has zero coupling to the connection dot/bridge — by contract; reviewers can check the rule by absence.
5. **Content-hash completion**: `isolated-renderer.js/.css` + `sift_wasm.wasm` get hashed filenames + a manifest (the runtime-wasm-assets pattern), returning the renderer-assets origin to fully `immutable` caching (#3416 → #3449 arc complete). Manifest missing/invalid → stable names; no deploy-ordering hazard — the first deploy after this PR simply starts emitting the manifest.

## Review

4-lens adversarial review + per-finding verification: 25 confirmed findings fixed in one consolidated round, 5 refuted. Accepted-as-documented: worst-case ~4.3s sequential skew ladders (commented at the ladder).

## Verification

vp 2162 passed / notebook-cloud 816 passed / sift package 177 passed at the reviewed tip; `tsc` + `cargo xtask lint` clean; targeted post-rebase runs green, CI confirms.

This completes the #3421 stack. Remaining tracked follow-ups: access-revocation diagnostics (fast-follow), PR 5 (offline-merge surfacing), PR 6 (instant first paint), and the #3580 persistence-side actor-rejection hardening (Bedrock workstream, coordination note on #3580).

🤖 Generated with [Claude Code](https://claude.com/claude-code)