### PR TITLE
feat(notebook-cloud): instant first paint from the persisted snapshot

### DIFF
--- a/apps/notebook-cloud/test/cloud-projection-flicker.test.ts
+++ b/apps/notebook-cloud/test/cloud-projection-flicker.test.ts
@@ -89,6 +89,42 @@ describe("cloud projection flicker gate", () => {
     assertPainted();
   });
 
+  it("hands an instant paint to the live effect: survives the gate, replaced in place", () => {
+    // Instant first paint lands before the live effect settles; the gate
+    // must keep it (no full→empty→full flash), and the live
+    // materialization then replaces the painted cells wholesale — through
+    // the same projection, never via a clearing reset.
+    paintNotebook();
+    const preserved = resetCloudProjectionUnlessPreserved({
+      paintedNotebookIdentity: PAINTED,
+      nextNotebookIdentity: PAINTED,
+    });
+    assert.equal(preserved, true);
+    assertPainted();
+
+    projectCloudCellsIntoNotebookViewStores([
+      {
+        id: "cell-code",
+        cellType: "code",
+        source: "print('live')",
+        language: "python",
+        executionId: "exec-2",
+        executionCount: 4,
+        outputs: [
+          { output_type: "stream", name: "stdout", text: "live output\n", output_id: "out-2" },
+        ],
+        metadata: {},
+      },
+    ] satisfies ResolvedCell[]);
+
+    assert.deepEqual(getCellIdsSnapshot(), ["cell-code"]);
+    assert.equal(getCellExecutionId("cell-code"), "exec-2");
+    assert.equal(getOutputById("out-2")?.output_type, "stream");
+    // The painted snapshot's stale cloud-owned ids were swept by the
+    // replacement, not by a blanking reset.
+    assert.equal(getOutputById("out-1"), undefined);
+  });
+
   it("clears every projected store on a real notebook switch", () => {
     paintNotebook();
 

--- a/apps/notebook-cloud/test/fixtures/stub-runtimed-wasm-module.mts
+++ b/apps/notebook-cloud/test/fixtures/stub-runtimed-wasm-module.mts
@@ -16,12 +16,22 @@ export function project_markdown_json(): null {
 
 export class StubNotebookHandle {
   loadedBytes: Uint8Array = new Uint8Array(0);
+  loadedRuntimeStateBytes: Uint8Array | null = null;
   actors: string[] = [];
   freed = 0;
 
   static load(bytes: Uint8Array): StubNotebookHandle {
     const handle = new StubNotebookHandle();
     handle.loadedBytes = bytes;
+    return handle;
+  }
+
+  static load_snapshot(
+    notebookBytes: Uint8Array,
+    runtimeStateBytes: Uint8Array,
+  ): StubNotebookHandle {
+    const handle = StubNotebookHandle.load(notebookBytes);
+    handle.loadedRuntimeStateBytes = runtimeStateBytes;
     return handle;
   }
 

--- a/apps/notebook-cloud/test/instant-paint.test.ts
+++ b/apps/notebook-cloud/test/instant-paint.test.ts
@@ -1,0 +1,310 @@
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import type { PersistedNotebookDoc } from "runtimed";
+import type { CloudPrototypeAuthState } from "../viewer/collaborator-auth.ts";
+import {
+  cloudInstantPaintPrincipalMatcher,
+  resolveCloudInstantPaintHandle,
+  type CloudInstantPaintOptions,
+} from "../viewer/instant-paint.ts";
+import { cloudViewerLoadingPolicy } from "../viewer/loading-policy.ts";
+
+function authState(overrides: Partial<CloudPrototypeAuthState>): CloudPrototypeAuthState {
+  return {
+    mode: "anonymous",
+    token: null,
+    user: null,
+    oidcClaims: null,
+    requestedScope: null,
+    problem: null,
+    ...overrides,
+  };
+}
+
+async function withSilencedWarnings<T>(run: () => Promise<T>): Promise<T> {
+  const originalWarn = console.warn;
+  console.warn = () => {};
+  try {
+    return await run();
+  } finally {
+    console.warn = originalWarn;
+  }
+}
+
+describe("cloudInstantPaintPrincipalMatcher", () => {
+  it("matches the exact dev principal derived from the stored user", () => {
+    const matcher = cloudInstantPaintPrincipalMatcher(
+      authState({ mode: "dev", token: "token", user: "alice smith" }),
+    );
+
+    assert.ok(matcher);
+    assert.equal(matcher("user:dev:alice%20smith"), true);
+    assert.equal(matcher("user:dev:mallory"), false);
+  });
+
+  it("matches OIDC principals by encoded subject id segment, namespace-agnostic", () => {
+    const matcher = cloudInstantPaintPrincipalMatcher(
+      authState({
+        mode: "oidc",
+        token: "token",
+        oidcClaims: { sub: "auth0|abc 123" },
+      }),
+    );
+
+    assert.ok(matcher);
+    // The worker's namespace prefix is server-configured; only the encoded
+    // subject id segment is client-derivable.
+    assert.equal(matcher("user:oidc:auth0%7Cabc%20123"), true);
+    assert.equal(matcher("user:anaconda:auth0%7Cabc%20123"), true);
+    assert.equal(matcher("user:oidc:someone-else"), false);
+    // A dev principal can never satisfy an OIDC-derived matcher.
+    assert.equal(matcher("user:dev:auth0%7Cabc%20123"), false);
+  });
+
+  it("never matches anonymous principals", () => {
+    const matcher = cloudInstantPaintPrincipalMatcher(
+      authState({ mode: "oidc", token: "token", oidcClaims: { sub: "abc" } }),
+    );
+
+    assert.ok(matcher);
+    assert.equal(matcher("anonymous:abc"), false);
+  });
+
+  it("accepts expired OIDC claims only when an app-session cookie backs them", () => {
+    const expired = authState({ mode: "oidc_expired", oidcClaims: { sub: "abc" } });
+
+    assert.equal(cloudInstantPaintPrincipalMatcher(expired), null);
+    const matcher = cloudInstantPaintPrincipalMatcher(expired, { hasAppSession: true });
+    assert.ok(matcher);
+    assert.equal(matcher("user:oidc:abc"), true);
+  });
+
+  it("derives no principal for anonymous and invalid auth states", () => {
+    assert.equal(cloudInstantPaintPrincipalMatcher(authState({ mode: "anonymous" })), null);
+    assert.equal(
+      cloudInstantPaintPrincipalMatcher(authState({ mode: "invalid", token: "x", user: "u" })),
+      null,
+    );
+  });
+});
+
+describe("resolveCloudInstantPaintHandle", () => {
+  const PRINCIPAL = "user:dev:alice";
+
+  function record(
+    principal: string,
+    bytes: Uint8Array = new Uint8Array([1, 2]),
+  ): PersistedNotebookDoc {
+    return { bytes, meta: { headsHex: ["aa"], savedAt: 1, principal, schemaVersion: 1 } };
+  }
+
+  function createHarness(input: { notebook?: PersistedNotebookDoc; cache?: PersistedNotebookDoc }) {
+    const calls: string[] = [];
+    const options: CloudInstantPaintOptions<string> = {
+      matchesPrincipal: (principal) => principal === PRINCIPAL,
+      loadNotebookRecord: async () => {
+        calls.push("loadNotebook");
+        return input.notebook;
+      },
+      loadRuntimeStateCacheRecord: async () => {
+        calls.push("loadCache");
+        return input.cache;
+      },
+      clearRuntimeStateCacheRecord: async () => {
+        calls.push("clearCache");
+      },
+      loadRenderHandle: async (_notebookBytes, runtimeStateBytes) => {
+        calls.push(runtimeStateBytes ? "load(pair)" : "load(cells-only)");
+        return runtimeStateBytes ? "paired-handle" : "cells-only-handle";
+      },
+    };
+    return { calls, options };
+  }
+
+  it("paints cells AND outputs when both records pass the principal gate", async () => {
+    const harness = createHarness({ notebook: record(PRINCIPAL), cache: record(PRINCIPAL) });
+    const resolved = await resolveCloudInstantPaintHandle(harness.options);
+
+    assert.deepEqual(resolved, { handle: "paired-handle", outcome: "painted" });
+    assert.deepEqual(harness.calls, ["loadNotebook", "loadCache", "load(pair)"]);
+  });
+
+  it("degrades to cells-only when no runtime cache record exists", async () => {
+    const harness = createHarness({ notebook: record(PRINCIPAL) });
+    const resolved = await resolveCloudInstantPaintHandle(harness.options);
+
+    assert.deepEqual(resolved, { handle: "cells-only-handle", outcome: "painted_cells_only" });
+  });
+
+  it("skips the paint without reading storage when no principal is derivable", async () => {
+    const harness = createHarness({ notebook: record(PRINCIPAL) });
+    const resolved = await resolveCloudInstantPaintHandle({
+      ...harness.options,
+      matchesPrincipal: null,
+    });
+
+    assert.deepEqual(resolved, { handle: null, outcome: "skipped_no_principal" });
+    assert.deepEqual(harness.calls, []);
+  });
+
+  it("skips on notebook principal mismatch and clears nothing", async () => {
+    const harness = createHarness({ notebook: record("user:dev:mallory") });
+    const resolved = await resolveCloudInstantPaintHandle(harness.options);
+
+    assert.deepEqual(resolved, { handle: null, outcome: "skipped_principal_mismatch" });
+    assert.deepEqual(harness.calls, ["loadNotebook", "loadCache"]);
+  });
+
+  it("skips on cache principal mismatch and clears nothing", async () => {
+    const harness = createHarness({
+      notebook: record(PRINCIPAL),
+      cache: record("user:dev:mallory"),
+    });
+    const resolved = await resolveCloudInstantPaintHandle(harness.options);
+
+    assert.deepEqual(resolved, { handle: null, outcome: "skipped_principal_mismatch" });
+    assert.equal(harness.calls.includes("clearCache"), false);
+  });
+
+  it("clears only the cache record for a torn cache envelope and paints cells-only", async () => {
+    const harness = createHarness({ notebook: record(PRINCIPAL), cache: { meta: null } });
+    const resolved = await resolveCloudInstantPaintHandle(harness.options);
+
+    assert.deepEqual(resolved, { handle: "cells-only-handle", outcome: "painted_cells_only" });
+    assert.deepEqual(harness.calls, [
+      "loadNotebook",
+      "loadCache",
+      "clearCache",
+      "load(cells-only)",
+    ]);
+  });
+
+  it("clears the cache record when load_snapshot rejects, then paints cells-only", async () => {
+    const harness = createHarness({ notebook: record(PRINCIPAL), cache: record(PRINCIPAL) });
+    const loadRenderHandle = harness.options.loadRenderHandle;
+    harness.options.loadRenderHandle = async (notebookBytes, runtimeStateBytes) => {
+      if (runtimeStateBytes) {
+        harness.calls.push("load(pair)");
+        throw new Error("corrupt runtime-state bytes");
+      }
+      return loadRenderHandle(notebookBytes, runtimeStateBytes);
+    };
+
+    const resolved = await withSilencedWarnings(() =>
+      resolveCloudInstantPaintHandle(harness.options),
+    );
+
+    assert.deepEqual(resolved, { handle: "cells-only-handle", outcome: "painted_cells_only" });
+    assert.deepEqual(harness.calls, [
+      "loadNotebook",
+      "loadCache",
+      "load(pair)",
+      "clearCache",
+      "load(cells-only)",
+    ]);
+  });
+
+  it("never clears the cache for transient WASM asset failures", async () => {
+    const harness = createHarness({ notebook: record(PRINCIPAL), cache: record(PRINCIPAL) });
+    harness.options.loadRenderHandle = async () => {
+      harness.calls.push("load(pair)");
+      throw new Error("runtimed WASM asset failed: import timed out");
+    };
+    harness.options.isTransientLoadFailure = (error) =>
+      error instanceof Error && error.message.startsWith("runtimed WASM asset failed");
+
+    const resolved = await withSilencedWarnings(() =>
+      resolveCloudInstantPaintHandle(harness.options),
+    );
+
+    assert.deepEqual(resolved, { handle: null, outcome: "skipped_unloadable" });
+    assert.equal(harness.calls.includes("clearCache"), false);
+  });
+
+  it("skips without clearing when the notebook bytes themselves fail to load", async () => {
+    const harness = createHarness({ notebook: record(PRINCIPAL) });
+    harness.options.loadRenderHandle = async () => {
+      throw new Error("automerge load failed");
+    };
+
+    const resolved = await withSilencedWarnings(() =>
+      resolveCloudInstantPaintHandle(harness.options),
+    );
+
+    assert.deepEqual(resolved, { handle: null, outcome: "skipped_unloadable" });
+    assert.equal(harness.calls.includes("clearCache"), false);
+  });
+
+  it("fails open as skipped_read_failed without clearing when the read hangs", async () => {
+    const harness = createHarness({});
+    harness.options.loadNotebookRecord = () => new Promise(() => undefined);
+    harness.options.readTimeoutMs = 5;
+
+    const resolved = await withSilencedWarnings(() =>
+      resolveCloudInstantPaintHandle(harness.options),
+    );
+
+    assert.deepEqual(resolved, { handle: null, outcome: "skipped_read_failed" });
+    assert.equal(harness.calls.includes("clearCache"), false);
+  });
+
+  it("race guard: a live materialization landing during the read skips the paint", async () => {
+    // The fast-network race: the cache read settles AFTER the live room
+    // already materialized. No handle is created — stale cache must never
+    // overwrite live pixels.
+    let liveMaterialized = false;
+    const harness = createHarness({ notebook: record(PRINCIPAL), cache: record(PRINCIPAL) });
+    harness.options.shouldContinue = () => !liveMaterialized;
+    harness.options.loadNotebookRecord = async () => {
+      liveMaterialized = true; // live connect wins while IDB reads
+      return record(PRINCIPAL);
+    };
+
+    const resolved = await resolveCloudInstantPaintHandle(harness.options);
+
+    assert.deepEqual(resolved, { handle: null, outcome: "skipped_superseded" });
+    assert.equal(
+      harness.calls.some((call) => call.startsWith("load(")),
+      false,
+    );
+  });
+});
+
+describe("instant paint mutual exclusion and session wiring", () => {
+  it("the loading policy never enables the live-room and pinned-snapshot paints together", () => {
+    const pinned = cloudViewerLoadingPolicy({ headsHash: "abc" });
+    const live = cloudViewerLoadingPolicy({ headsHash: null });
+
+    assert.deepEqual(
+      [pinned.shouldConnectLiveRoom, pinned.shouldFetchSnapshotRender],
+      [false, true],
+    );
+    assert.deepEqual([live.shouldConnectLiveRoom, live.shouldFetchSnapshotRender], [true, false]);
+  });
+
+  // Source pins for wiring that cannot run under node (the session hook
+  // imports the component-bearing notebook surface).
+  const sessionSource = readFileSync(
+    new URL("../viewer/cloud-viewer-session.ts", import.meta.url),
+    "utf8",
+  );
+
+  it("kicks the instant paint only with a healthy adapter and no poison-pill skip", () => {
+    assert.match(
+      sessionSource,
+      /if \(persistenceAdapter && !skipSeedOnThisAttempt\) \{\s*void paintFromPersistedSnapshot\(\)/,
+    );
+  });
+
+  it("guards every instant-paint apply on the live-materialization race flag", () => {
+    assert.match(
+      sessionSource,
+      /const instantPaintFresh = \(\) => !disposed && !liveMaterializedRef\.current;/,
+    );
+  });
+
+  it("frees the throwaway render handle after materialization", () => {
+    assert.match(sessionSource, /\} finally \{\s*renderHandle\.free\(\);\s*\}/);
+  });
+});

--- a/apps/notebook-cloud/test/notebook-persistence.test.ts
+++ b/apps/notebook-cloud/test/notebook-persistence.test.ts
@@ -1,0 +1,138 @@
+/**
+ * createCloudNotebookPersistence — the per-runtime controller pair: the
+ * NotebookDoc seed record plus the render-only RuntimeStateDoc paint
+ * cache. The cache is written from `save_state_doc()` under its own key
+ * and never touches the seed record's key (a paint source, not a seed).
+ */
+
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import { Subject } from "rxjs";
+import {
+  RUNTIME_STATE_CACHE_KEY_SEGMENT,
+  decodePersistedNotebookDoc,
+  type StorageAdapter,
+  type StorageKey,
+} from "runtimed";
+import { createCloudNotebookPersistence } from "../viewer/notebook-persistence.ts";
+
+function createRecordingAdapter(): StorageAdapter & { records: Map<string, Uint8Array> } {
+  const records = new Map<string, Uint8Array>();
+  return {
+    records,
+    load: async (key: StorageKey) => records.get(key.join("/")),
+    save: async (key: StorageKey, data: Uint8Array) => {
+      records.set(key.join("/"), data);
+    },
+    remove: async (key: StorageKey) => {
+      records.delete(key.join("/"));
+    },
+    loadRange: async () => [],
+    removeRange: async () => {
+      records.clear();
+    },
+  };
+}
+
+function createHarness() {
+  const adapter = createRecordingAdapter();
+  const notebookDocChanged$ = new Subject<void>();
+  const runtimeState$ = new Subject<unknown>();
+  let stateBytes = new Uint8Array([1]);
+  const handle = {
+    save: () => new Uint8Array([100]),
+    get_heads_hex: () => ["doc-head"],
+    save_state_doc: () => stateBytes,
+    get_runtime_state_heads_hex: () => ["state-head"],
+  };
+  return {
+    adapter,
+    notebookDocChanged$,
+    runtimeState$,
+    handle,
+    setStateBytes: (bytes: Uint8Array) => {
+      stateBytes = bytes;
+    },
+    arm: (principal = "user:dev:alice") =>
+      createCloudNotebookPersistence({
+        adapter,
+        notebookId: "nb-1",
+        principal,
+        engine: { notebookDocChanged$, runtimeState$ },
+        handle,
+        throttleMs: 5,
+      }),
+  };
+}
+
+const sleep = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms));
+
+describe("createCloudNotebookPersistence", () => {
+  it("throttles runtime-state emissions into one cache record from save_state_doc", async () => {
+    const harness = createHarness();
+    const controller = harness.arm();
+    assert.ok(controller);
+
+    harness.runtimeState$.next({});
+    harness.runtimeState$.next({});
+    harness.setStateBytes(new Uint8Array([7, 7]));
+    harness.runtimeState$.next({});
+    await sleep(30);
+
+    // Exactly one throttled write, capturing the LATEST state bytes, under
+    // the cache key — and nothing under the NotebookDoc seed key (the
+    // runtime-state stream must never cross-wire into the seed record).
+    assert.deepEqual([...harness.adapter.records.keys()], ["nb-1/runtime-state-cache"]);
+    const record = decodePersistedNotebookDoc(
+      harness.adapter.records.get(`nb-1/${RUNTIME_STATE_CACHE_KEY_SEGMENT}`)!,
+    );
+    assert.deepEqual(record.bytes, new Uint8Array([7, 7]));
+    assert.deepEqual(record.meta?.headsHex, ["state-head"]);
+    assert.equal(record.meta?.principal, "user:dev:alice");
+    controller.dispose();
+  });
+
+  it("writes the seed record from notebookDocChanged$ without touching the cache", async () => {
+    const harness = createHarness();
+    const controller = harness.arm();
+    assert.ok(controller);
+
+    harness.notebookDocChanged$.next();
+    await sleep(30);
+
+    assert.deepEqual([...harness.adapter.records.keys()], ["nb-1/snapshot"]);
+    controller.dispose();
+  });
+
+  it("arms nothing for anonymous principals", () => {
+    const harness = createHarness();
+    const controller = harness.arm("anonymous:viewer-session-1");
+
+    assert.equal(controller, null);
+    assert.equal(harness.notebookDocChanged$.observed, false);
+    assert.equal(harness.runtimeState$.observed, false);
+  });
+
+  it("flushNow captures both records synchronously, before the handle is freed", async () => {
+    const harness = createHarness();
+    const controller = harness.arm();
+    assert.ok(controller);
+
+    const flush = controller.flushNow();
+    // Simulate the session freeing the WASM handle right after flushNow
+    // returns: any later capture would throw.
+    harness.handle.save = () => {
+      throw new Error("handle freed");
+    };
+    harness.handle.save_state_doc = () => {
+      throw new Error("handle freed");
+    };
+    await flush;
+
+    assert.deepEqual([...harness.adapter.records.keys()].sort(), [
+      "nb-1/runtime-state-cache",
+      "nb-1/snapshot",
+    ]);
+    controller.dispose();
+  });
+});

--- a/apps/notebook-cloud/test/runtimed-wasm-client-seed.test.ts
+++ b/apps/notebook-cloud/test/runtimed-wasm-client-seed.test.ts
@@ -13,7 +13,10 @@
 
 import { describe, it } from "node:test";
 import assert from "node:assert/strict";
-import { loadNotebookHandleFromBytes } from "../viewer/runtimed-wasm-client.ts";
+import {
+  loadNotebookHandleFromBytes,
+  loadRenderSnapshotHandle,
+} from "../viewer/runtimed-wasm-client.ts";
 import { stubCalls, type StubNotebookHandle } from "./fixtures/stub-runtimed-wasm-module.mts";
 
 const STUB_MODULE_URL = new URL("./fixtures/stub-runtimed-wasm-module.mts", import.meta.url);
@@ -47,5 +50,35 @@ describe("loadNotebookHandleFromBytes", () => {
 
     assert.equal(stubCalls.freedHandles.length, 1);
     assert.equal(stubCalls.freedHandles[0].freed, 1);
+  });
+});
+
+describe("loadRenderSnapshotHandle", () => {
+  it("loads the notebook/runtime-state pair without ever setting an actor", async () => {
+    const handle = (await loadRenderSnapshotHandle(
+      new Uint8Array([1, 2]),
+      new Uint8Array([3, 4]),
+      STUB_MODULE_URL,
+      STUB_MODULE_URL,
+    )) as unknown as StubNotebookHandle;
+
+    assert.deepEqual(handle.loadedBytes, new Uint8Array([1, 2]));
+    assert.deepEqual(handle.loadedRuntimeStateBytes, new Uint8Array([3, 4]));
+    // Render-only: painting needs no actor, and the handle must never
+    // author or sync.
+    assert.deepEqual(handle.actors, []);
+  });
+
+  it("degrades to a cells-only load when no runtime-state cache bytes exist", async () => {
+    const handle = (await loadRenderSnapshotHandle(
+      new Uint8Array([5]),
+      undefined,
+      STUB_MODULE_URL,
+      STUB_MODULE_URL,
+    )) as unknown as StubNotebookHandle;
+
+    assert.deepEqual(handle.loadedBytes, new Uint8Array([5]));
+    assert.equal(handle.loadedRuntimeStateBytes, null);
+    assert.deepEqual(handle.actors, []);
   });
 });

--- a/apps/notebook-cloud/test/viewer-notices.test.ts
+++ b/apps/notebook-cloud/test/viewer-notices.test.ts
@@ -4,8 +4,10 @@ import * as React from "react";
 import { renderToStaticMarkup } from "react-dom/server";
 import type { CloudPrototypeAuthState } from "../viewer/collaborator-auth";
 import {
+  CLOUD_CONNECTION_EDIT_ACCESS_PENDING_DIAGNOSTIC,
   CLOUD_CONNECTION_NO_ACCESS_DIAGNOSTIC,
   CLOUD_CONNECTION_SIGN_IN_DIAGNOSTIC,
+  cloudConnectionErrorAcceptsAccessDiagnostic,
 } from "../viewer/connection-diagnostics";
 import { CloudNotebookNotices, cloudNotebookHasNotices } from "../viewer/notices";
 
@@ -222,6 +224,33 @@ test("terminal wasm-asset failures get a dedicated notice with a non-destructive
   assert.doesNotMatch(html, /Use anonymous/);
   assert.doesNotMatch(html, /Sign in again/);
   assert.doesNotMatch(html, /Live room needs attention/);
+});
+
+test("a resolved access diagnostic never overwrites the wasm-failure Retry notice", () => {
+  // The session applies an access diagnostic only when the guard allows it;
+  // a terminal asset failure refuses, so the connection error — and the
+  // notice rendered from it — keeps the WASM-failure Retry shape.
+  const assetFailure =
+    "runtimed WASM asset failed: Failed to fetch runtimed WASM (404): https://wasm.example/assets/runtimed_wasm_bg.wasm";
+  const connectionError = cloudConnectionErrorAcceptsAccessDiagnostic(assetFailure)
+    ? CLOUD_CONNECTION_EDIT_ACCESS_PENDING_DIAGNOSTIC
+    : assetFailure;
+
+  const html = renderToStaticMarkup(
+    React.createElement(CloudNotebookNotices, {
+      authState: authState("oidc"),
+      authRenewal: { kind: "idle", message: null },
+      connectionError,
+      status: { kind: "ready", message: "Ready" },
+      onResetAuth: () => {},
+      onRetryConnection: () => {},
+      onSignInAgain: () => {},
+    }),
+  );
+
+  assert.match(html, /Notebook engine failed to load/);
+  assert.match(html, /Retry/);
+  assert.doesNotMatch(html, /Edit access pending/);
 });
 
 test("wasm-asset failures keep the legacy action when no retry callback is wired", () => {

--- a/apps/notebook-cloud/viewer/cloud-viewer-session.ts
+++ b/apps/notebook-cloud/viewer/cloud-viewer-session.ts
@@ -13,7 +13,10 @@ import {
 } from "@/components/widgets/comm-changes-store-bridge";
 import { setCrdtCommWriter } from "@/components/widgets/crdt-comm-writer";
 import type { WidgetStore } from "@/components/widgets/widget-store";
-import { diagnoseCloudConnectionAccess } from "./connection-diagnostics";
+import {
+  cloudConnectionErrorAcceptsAccessDiagnostic,
+  diagnoseCloudConnectionAccess,
+} from "./connection-diagnostics";
 import {
   applyExecutionViewChangeset,
   applyOutputChangeset,
@@ -924,22 +927,26 @@ export function useCloudViewerSession({
         setConnectionPeerId(null);
         resetRuntimeState();
         setConnectionError(message);
-        void diagnoseCloudConnectionAccess({
-          accessRequestsEndpoint: config.accessRequestsEndpoint,
-          authState,
-          hasAppSession,
-        })
-          .then((diagnostic) => {
-            if (disposed || !diagnostic) return;
-            if (materializedCellCount() === 0) {
-              setStatus({
-                kind: "error",
-                message: `Unable to load live notebook room: ${diagnostic}`,
-              });
-            }
-            setConnectionError(diagnostic);
+        // Terminal WASM asset failures own the notice (Retry affordance):
+        // a coinciding access diagnostic must not overwrite them.
+        if (cloudConnectionErrorAcceptsAccessDiagnostic(message)) {
+          void diagnoseCloudConnectionAccess({
+            accessRequestsEndpoint: config.accessRequestsEndpoint,
+            authState,
+            hasAppSession,
           })
-          .catch(() => undefined);
+            .then((diagnostic) => {
+              if (disposed || !diagnostic) return;
+              if (materializedCellCount() === 0) {
+                setStatus({
+                  kind: "error",
+                  message: `Unable to load live notebook room: ${diagnostic}`,
+                });
+              }
+              setConnectionError(diagnostic);
+            })
+            .catch(() => undefined);
+        }
         console.warn("[notebook-cloud] live room connection failed", error);
       });
 

--- a/apps/notebook-cloud/viewer/cloud-viewer-session.ts
+++ b/apps/notebook-cloud/viewer/cloud-viewer-session.ts
@@ -1,8 +1,11 @@
 import { useCallback, useEffect, useRef, useState, type MutableRefObject } from "react";
 import {
   IndexedDbStorageAdapter,
+  RUNTIME_STATE_CACHE_KEY_SEGMENT,
   clearPersistedNotebookDoc,
+  clearPersistedNotebookRecord,
   loadPersistedNotebookDoc,
+  loadPersistedNotebookRecord,
   type BlobResolver,
   type CommChanges,
 } from "runtimed";
@@ -53,6 +56,7 @@ import {
   type CloudSyncRuntime,
   type CloudWebSocketTransport,
 } from "./live-sync";
+import { cloudInstantPaintPrincipalMatcher, resolveCloudInstantPaintHandle } from "./instant-paint";
 import type { CloudViewerLoadingPolicy } from "./loading-policy";
 import { markCloudViewerLoadMilestone } from "./load-milestones";
 import {
@@ -66,7 +70,8 @@ import {
 } from "./notebook-view-store-bridge";
 import { CloudViewerPresenceStore } from "./presence";
 import { createOutputResolutionCache, type ResolvedCell } from "./render-resolution";
-import { loadSnapshotPairHandle } from "./runtimed-wasm-client";
+import { loadRenderSnapshotHandle, loadSnapshotPairHandle } from "./runtimed-wasm-client";
+import { isRuntimedWasmAssetFailure } from "./runtimed-wasm-failure";
 import { subscribeSerializedCloudCellChanges } from "./serialized-cell-changes";
 import { cloudWidgetUpdateManager } from "./widget-runtime";
 import { projectCloudWidgetComms } from "./widget-comm-projection";
@@ -714,6 +719,102 @@ export function useCloudViewerSession({
     };
     materializeLiveRuntimeRef.current = materializeLiveCellsSafely;
 
+    // Instant first paint from the persisted snapshot: runs in parallel
+    // with the WS dial (never delaying it) and paints cells AND outputs
+    // from the local envelope records through a THROWAWAY render handle —
+    // the pinned-snapshot path's exact shape, freed after materialization.
+    // The race guard (`liveMaterializedRef`) ensures a fast live connect
+    // wins: stale cache never overwrites a live materialization, and the
+    // live materialization replaces the paint wholesale when sync lands
+    // (the preservation gate keeps the paint until then, no blanking).
+    const instantPaintFresh = () => !disposed && !liveMaterializedRef.current;
+    const paintFromPersistedSnapshot = async () => {
+      if (!persistenceAdapter) return;
+      const resolved = await resolveCloudInstantPaintHandle({
+        // Pre-handshake principal gate from locally stored auth material;
+        // null (no derivable principal) skips the paint entirely.
+        matchesPrincipal: cloudInstantPaintPrincipalMatcher(authState, { hasAppSession }),
+        loadNotebookRecord: () => loadPersistedNotebookDoc(persistenceAdapter, config.notebookId),
+        loadRuntimeStateCacheRecord: () =>
+          loadPersistedNotebookRecord(
+            persistenceAdapter,
+            config.notebookId,
+            RUNTIME_STATE_CACHE_KEY_SEGMENT,
+          ),
+        clearRuntimeStateCacheRecord: () =>
+          clearPersistedNotebookRecord(
+            persistenceAdapter,
+            config.notebookId,
+            RUNTIME_STATE_CACHE_KEY_SEGMENT,
+          ),
+        loadRenderHandle: (notebookBytes, runtimeStateBytes) =>
+          loadRenderSnapshotHandle(
+            notebookBytes,
+            runtimeStateBytes,
+            config.runtimedWasmModulePath,
+            config.runtimedWasmPath,
+          ),
+        shouldContinue: instantPaintFresh,
+        // Asset-load failures do not incriminate the cached bytes: never
+        // clear the cache record for them.
+        isTransientLoadFailure: (error) =>
+          isRuntimedWasmAssetFailure(error instanceof Error ? error.message : String(error)),
+      });
+      const renderHandle = resolved.handle;
+      if (!renderHandle) return;
+      try {
+        if (!instantPaintFresh()) return;
+        const materialized = await materializeCloudNotebookView(renderHandle, {
+          blobResolver,
+          defaultNotebookLanguage: notebookLanguageRef.current ?? "python",
+          outputResolutionCache: outputResolutionCacheRef.current,
+          callbacks: {
+            shouldContinue: instantPaintFresh,
+            onInitialCells(syncCells) {
+              if (syncCells.length === 0) return;
+              markCloudViewerLoadMilestone("instant-paint-initial-cells");
+              preloadSiftWasm(syncCells);
+              applyResolvedCells(syncCells);
+              setStatus({
+                kind: "loading",
+                message: `Rendering ${syncCells.length} cells from the local snapshot while connecting...`,
+              });
+            },
+            onCellResolved(resolvedCell, _index, progressiveCells) {
+              if (progressiveCells.length === 0) return;
+              preloadSiftWasm([resolvedCell]);
+              applyResolvedCells(progressiveCells);
+            },
+          },
+        });
+        if (!instantPaintFresh()) return;
+        // An empty persisted snapshot paints nothing: the room decides
+        // what an empty notebook means.
+        if (materialized.cells.length === 0) return;
+        notebookLanguageRef.current = materialized.notebookLanguage;
+        setNotebookMetadata(materialized.metadata);
+        await projectCloudWidgetComms(
+          widgetStore,
+          materialized.widgetComms,
+          projectedWidgetCommIdsRef,
+          {
+            isAllowedBlobUrl: (url) => isConfiguredBlobUrl(url, config.blobBasePath),
+            shouldContinue: instantPaintFresh,
+          },
+        );
+        if (!instantPaintFresh()) return;
+        preloadSiftWasm(materialized.cells);
+        applyResolvedCells(materialized.cells);
+        setStatus({
+          kind: "ready",
+          message: `Rendering ${materialized.cells.length} cells from the locally persisted snapshot while the live room connects.`,
+        });
+        markCloudViewerLoadMilestone("instant-paint-ready");
+      } finally {
+        renderHandle.free();
+      }
+    };
+
     // Notebook-switch gate (desktop beforeBootstrap placement): the effect
     // CLEANUP closes over its own run's config, so it can only ever compare
     // the painted identity against itself — a real switch is visible only
@@ -953,6 +1054,18 @@ export function useCloudViewerSession({
         }
         console.warn("[notebook-cloud] live room connection failed", error);
       });
+
+    // Kicked AFTER the connect call so the WS dial is never delayed, and
+    // only on the live-room path (the pinned-revision URL path keeps its
+    // snapshot fetch; the two paints are mutually exclusive by policy).
+    // A poison-pill attempt (its record discard is in flight) skips the
+    // paint along with the seed.
+    if (persistenceAdapter && !skipSeedOnThisAttempt) {
+      void paintFromPersistedSnapshot().catch((error: unknown) => {
+        if (disposed) return;
+        console.warn("[notebook-cloud] instant paint from persisted snapshot failed", error);
+      });
+    }
 
     return () => {
       disposed = true;

--- a/apps/notebook-cloud/viewer/cloud-viewer-session.ts
+++ b/apps/notebook-cloud/viewer/cloud-viewer-session.ts
@@ -1,7 +1,6 @@
 import { useCallback, useEffect, useRef, useState, type MutableRefObject } from "react";
 import {
   IndexedDbStorageAdapter,
-  NotebookDocPersistence,
   clearPersistedNotebookDoc,
   loadPersistedNotebookDoc,
   type BlobResolver,
@@ -56,6 +55,10 @@ import {
 } from "./live-sync";
 import type { CloudViewerLoadingPolicy } from "./loading-policy";
 import { markCloudViewerLoadMilestone } from "./load-milestones";
+import {
+  createCloudNotebookPersistence,
+  type CloudNotebookPersistenceController,
+} from "./notebook-persistence";
 import {
   projectCloudCellsIntoNotebookViewStores,
   resetCloudProjectionUnlessPreserved,
@@ -449,7 +452,7 @@ export function useCloudViewerSession({
     // Local-first persistence is fail-open: no IndexedDB (private mode,
     // SSR) means no adapter and the session runs exactly as before.
     const persistenceAdapter = IndexedDbStorageAdapter.create();
-    let notebookPersistence: NotebookDocPersistence | null = null;
+    let notebookPersistence: CloudNotebookPersistenceController | null = null;
     let notebookPersistencePrincipal: string | null = null;
     const persistenceSeed = persistenceAdapter
       ? {
@@ -530,19 +533,20 @@ export function useCloudViewerSession({
       void pendingSeedDiscardRef.current.then(() => {
         if (disposed || liveRuntimeRef.current !== liveRuntime) return;
         if (notebookPersistence && notebookPersistencePrincipal === principal) return;
-        // Snapshot the raw NotebookHandle (full NotebookDoc bytes) on every
-        // doc change; the controller throttles, self-disables after repeated
-        // failures, and never throws into the session.
-        notebookPersistence = new NotebookDocPersistence({
+        // Snapshot the raw NotebookHandle on every doc change: the
+        // NotebookDoc seed record plus the render-only RuntimeStateDoc
+        // paint cache (instant first paint's outputs). The controllers
+        // throttle, self-disable after repeated failures, and never throw
+        // into the session.
+        notebookPersistence = createCloudNotebookPersistence({
           adapter: persistenceAdapter,
           notebookId: config.notebookId,
           principal,
-          changes$: liveRuntime.engine.notebookDocChanged$,
-          getSaveBytes: () => liveRuntime.handle.save(),
-          getHeadsHex: () => liveRuntime.handle.get_heads_hex(),
+          engine: liveRuntime.engine,
+          handle: liveRuntime.handle,
           onError: (error) => console.warn("[notebook-cloud] notebook persistence error", error),
         });
-        notebookPersistencePrincipal = principal;
+        notebookPersistencePrincipal = notebookPersistence ? principal : null;
       });
     };
     // Transport-level connection losses are informational: the transport

--- a/apps/notebook-cloud/viewer/connection-diagnostics.ts
+++ b/apps/notebook-cloud/viewer/connection-diagnostics.ts
@@ -1,4 +1,5 @@
 import { withCloudPrototypeAuthHeaders, type CloudPrototypeAuthState } from "./collaborator-auth";
+import { isRuntimedWasmAssetFailure } from "./runtimed-wasm-failure";
 import type { CloudNotebookAccessRequest } from "./sharing-client";
 
 export const CLOUD_CONNECTION_SIGN_IN_DIAGNOSTIC = "Sign in again to open this notebook.";
@@ -8,6 +9,20 @@ export const CLOUD_CONNECTION_EDIT_ACCESS_PENDING_DIAGNOSTIC =
   "Edit access is waiting for owner approval.";
 export const CLOUD_CONNECTION_EDIT_ACCESS_APPROVED_DIAGNOSTIC =
   "Edit access was approved. Reconnect to open the live notebook room with editor access.";
+
+/**
+ * Whether an access diagnostic may replace the current connection error.
+ *
+ * Terminal runtimed-WASM asset failures own the connection notice: their
+ * Retry affordance is the documented re-entry (the wasm client clears its
+ * caches on rejection, so the retry genuinely re-imports), and an access
+ * diagnostic resolving around the same time (sign-in, pending edit access)
+ * must not overwrite it — auth-flavored copy and actions cannot fix a
+ * failed WASM load.
+ */
+export function cloudConnectionErrorAcceptsAccessDiagnostic(message: string): boolean {
+  return !isRuntimedWasmAssetFailure(message);
+}
 
 export interface DiagnoseCloudConnectionAccessOptions {
   accessRequestsEndpoint: string;

--- a/apps/notebook-cloud/viewer/instant-paint.ts
+++ b/apps/notebook-cloud/viewer/instant-paint.ts
@@ -1,0 +1,235 @@
+/**
+ * Instant first paint from the persisted snapshot (cloud, live-room path).
+ *
+ * Page load paints the notebook immediately from the local envelope
+ * records instead of waiting for the WS dial + cloud_room_ready + full
+ * bootstrap sync: NotebookDoc bytes plus the render-only RuntimeStateDoc
+ * cache decode into a THROWAWAY render handle (the pinned-snapshot path's
+ * exact shape) that is materialized once and freed. Painting needs no
+ * actor and no connection; the syncing handle is still seeded separately,
+ * after the handshake, by `resolveCloudNotebookHandle`.
+ *
+ * Pre-handshake principal gate: before cloud_room_ready we do not know
+ * the connection's principal, and IndexedDB may hold another user's
+ * notebook on a shared machine. The paint is gated on a principal
+ * MATCHER derived from locally stored auth material — the dev-token user
+ * (exact principal, mirroring `principalForDevUser`) or the stored OIDC
+ * subject claim (the principal's id segment; the namespace prefix is
+ * server-configured and not client-derivable). No derivable principal ⇒
+ * no paint — wait for the room.
+ *
+ * Clearing discipline: a mismatched principal on either record skips the
+ * paint WITHOUT clearing — post-handshake seeding owns that decision. The
+ * only clears here target the render-only cache record, and only when the
+ * cache itself is unusable (torn envelope, `load_snapshot` rejecting its
+ * bytes) — never on transient WASM asset failures, and never the
+ * NotebookDoc seed record (which may hold offline edits).
+ */
+
+import type { PersistedNotebookDoc } from "runtimed";
+import type { CloudPrototypeAuthState } from "./collaborator-auth";
+import { isAnonymousCloudPrincipal, withReadyTimeout } from "./live-sync";
+
+/**
+ * Bound on the instant-paint IndexedDB reads. A hung IDB open must
+ * degrade to no-paint; the live room is dialing in parallel regardless.
+ */
+const INSTANT_PAINT_READ_TIMEOUT_MS = 2_000;
+
+const DEV_PRINCIPAL_PREFIX = "user:dev:";
+
+/**
+ * Mirrors the worker's `principalForDevUser` (src/identity.ts):
+ * `user:dev:<encodePrincipalComponent(user)>`, where the encoder is
+ * `encodeURIComponent`.
+ */
+function devPrincipalForUser(user: string): string {
+  return `${DEV_PRINCIPAL_PREFIX}${encodeURIComponent(user.trim() || "browser-editor")}`;
+}
+
+/**
+ * Derive a principal matcher from locally stored auth material, WITHOUT
+ * the room handshake. Returns null when no principal is derivable — the
+ * caller must then skip the paint entirely.
+ *
+ * - Dev token: the worker derives the principal deterministically from
+ *   the presented user, so an exact match is available.
+ * - OIDC (valid stored token, or expired claims backed by a live
+ *   app-session cookie — the cookie was minted from that subject's
+ *   token): the worker's principal is `<namespace>:<encoded sub>` with a
+ *   server-configured namespace, so the matcher pins the encoded subject
+ *   as the principal's id segment and rejects the namespaces it cannot
+ *   belong to (anonymous, dev).
+ *
+ * Anonymous principals never match any matcher: they are per-connection
+ * nonces and persisted records are never written for them anyway.
+ */
+export function cloudInstantPaintPrincipalMatcher(
+  authState: CloudPrototypeAuthState,
+  options: { hasAppSession?: boolean } = {},
+): ((principal: string) => boolean) | null {
+  if (authState.mode === "dev" && authState.token) {
+    const expected = devPrincipalForUser(authState.user ?? "browser-editor");
+    return (principal) => !isAnonymousCloudPrincipal(principal) && principal === expected;
+  }
+
+  const sub = authState.oidcClaims?.sub?.trim();
+  const oidcUsable =
+    authState.mode === "oidc" ||
+    (authState.mode === "oidc_expired" && options.hasAppSession === true);
+  if (oidcUsable && sub) {
+    const encodedSub = encodeURIComponent(sub);
+    return (principal) =>
+      !isAnonymousCloudPrincipal(principal) &&
+      !principal.startsWith(DEV_PRINCIPAL_PREFIX) &&
+      principal.endsWith(`:${encodedSub}`);
+  }
+
+  return null;
+}
+
+export type CloudInstantPaintOutcome =
+  | "painted"
+  | "painted_cells_only"
+  | "skipped_no_principal"
+  | "skipped_no_record"
+  | "skipped_principal_mismatch"
+  | "skipped_read_failed"
+  | "skipped_superseded"
+  | "skipped_unloadable";
+
+export interface ResolvedCloudInstantPaint<Handle> {
+  /** Throwaway render handle; the caller must free it after materialization. */
+  handle: Handle | null;
+  outcome: CloudInstantPaintOutcome;
+}
+
+export interface CloudInstantPaintOptions<Handle> {
+  /** From `cloudInstantPaintPrincipalMatcher`; null skips the paint. */
+  matchesPrincipal: ((principal: string) => boolean) | null;
+  loadNotebookRecord: () => Promise<PersistedNotebookDoc | undefined>;
+  loadRuntimeStateCacheRecord: () => Promise<PersistedNotebookDoc | undefined>;
+  /** Discards ONLY the render cache record; the seed record never clears here. */
+  clearRuntimeStateCacheRecord: () => Promise<void>;
+  loadRenderHandle: (
+    notebookBytes: Uint8Array,
+    runtimeStateBytes: Uint8Array | undefined,
+  ) => Promise<Handle>;
+  /**
+   * Race guard: re-checked after every await. A live materialization that
+   * wins the race against the cache read flips this to false and the
+   * paint is skipped — stale cache must never overwrite live pixels.
+   */
+  shouldContinue?: () => boolean;
+  /**
+   * True for failures that do NOT incriminate the cached bytes (WASM
+   * asset load failures). Those skip the cells-only retry and never clear
+   * the cache record.
+   */
+  isTransientLoadFailure?: (error: unknown) => boolean;
+  readTimeoutMs?: number;
+}
+
+/**
+ * Resolve the throwaway render handle for an instant first paint, or the
+ * reason there is nothing to paint. Mirrors `resolveCloudNotebookHandle`'s
+ * dependency-injected shape so every branch is testable without WASM.
+ */
+export async function resolveCloudInstantPaintHandle<Handle>({
+  matchesPrincipal,
+  loadNotebookRecord,
+  loadRuntimeStateCacheRecord,
+  clearRuntimeStateCacheRecord,
+  loadRenderHandle,
+  shouldContinue = () => true,
+  isTransientLoadFailure = () => false,
+  readTimeoutMs = INSTANT_PAINT_READ_TIMEOUT_MS,
+}: CloudInstantPaintOptions<Handle>): Promise<ResolvedCloudInstantPaint<Handle>> {
+  if (!matchesPrincipal) {
+    return { handle: null, outcome: "skipped_no_principal" };
+  }
+
+  let notebookRecord: PersistedNotebookDoc | undefined;
+  let cacheRecord: PersistedNotebookDoc | undefined;
+  try {
+    [notebookRecord, cacheRecord] = await withReadyTimeout(
+      Promise.all([loadNotebookRecord(), loadRuntimeStateCacheRecord()]),
+      readTimeoutMs,
+      `instant-paint record read did not settle within ${readTimeoutMs}ms`,
+    );
+  } catch (error) {
+    // Fail-open reads stay fail-closed for clears: leave both records be.
+    console.warn("[notebook-cloud] instant-paint record read failed; skipping paint", error);
+    return { handle: null, outcome: "skipped_read_failed" };
+  }
+  if (!shouldContinue()) {
+    return { handle: null, outcome: "skipped_superseded" };
+  }
+
+  if (!notebookRecord?.meta || !notebookRecord.bytes) {
+    // Absent or unverifiable seed record: nothing paintable. Seeding's
+    // post-handshake logic owns whether an unverifiable record clears.
+    return { handle: null, outcome: "skipped_no_record" };
+  }
+  if (!matchesPrincipal(notebookRecord.meta.principal)) {
+    return { handle: null, outcome: "skipped_principal_mismatch" };
+  }
+
+  let runtimeStateBytes: Uint8Array | undefined;
+  if (cacheRecord) {
+    if (cacheRecord.meta && cacheRecord.bytes) {
+      if (!matchesPrincipal(cacheRecord.meta.principal)) {
+        // Verifiably someone else's pixels: skip the whole paint. No
+        // clear — seeding's principal logic owns the discard decision.
+        return { handle: null, outcome: "skipped_principal_mismatch" };
+      }
+      runtimeStateBytes = cacheRecord.bytes;
+    } else {
+      // Torn/unverifiable cache record: render-only garbage. Discard it
+      // (the seed record is untouched) and degrade to cells-only.
+      await clearCacheRecord(clearRuntimeStateCacheRecord);
+    }
+  }
+
+  try {
+    const handle = await loadRenderHandle(notebookRecord.bytes, runtimeStateBytes);
+    return { handle, outcome: runtimeStateBytes ? "painted" : "painted_cells_only" };
+  } catch (error) {
+    if (runtimeStateBytes && !isTransientLoadFailure(error)) {
+      // load_snapshot rejected with cache bytes in play: treat the cache
+      // as corrupt, clear ONLY that record, and retry cells-only — the
+      // notebook envelope may be fine.
+      console.warn(
+        "[notebook-cloud] instant-paint snapshot load failed; clearing runtime-state cache and retrying cells-only",
+        error,
+      );
+      await clearCacheRecord(clearRuntimeStateCacheRecord);
+      if (!shouldContinue()) {
+        return { handle: null, outcome: "skipped_superseded" };
+      }
+      try {
+        const handle = await loadRenderHandle(notebookRecord.bytes, undefined);
+        return { handle, outcome: "painted_cells_only" };
+      } catch (cellsOnlyError) {
+        console.warn(
+          "[notebook-cloud] instant-paint cells-only load failed; skipping paint",
+          cellsOnlyError,
+        );
+        return { handle: null, outcome: "skipped_unloadable" };
+      }
+    }
+    // Corrupt notebook bytes degrade to no-paint without clearing: the
+    // seed record may hold offline edits and post-handshake seeding owns
+    // its corruption handling. Transient asset failures clear nothing.
+    console.warn("[notebook-cloud] instant-paint load failed; skipping paint", error);
+    return { handle: null, outcome: "skipped_unloadable" };
+  }
+}
+
+async function clearCacheRecord(clear: () => Promise<void>): Promise<void> {
+  try {
+    await clear();
+  } catch (error) {
+    console.warn("[notebook-cloud] failed to clear runtime-state cache record", error);
+  }
+}

--- a/apps/notebook-cloud/viewer/load-milestones.ts
+++ b/apps/notebook-cloud/viewer/load-milestones.ts
@@ -4,6 +4,8 @@ export type CloudViewerLoadMilestone =
   | "viewer-start"
   | "snapshot-initial-cells"
   | "snapshot-ready"
+  | "instant-paint-initial-cells"
+  | "instant-paint-ready"
   | "live-room-ready"
   | "live-initial-cells"
   | "live-ready";

--- a/apps/notebook-cloud/viewer/notebook-persistence.ts
+++ b/apps/notebook-cloud/viewer/notebook-persistence.ts
@@ -1,0 +1,110 @@
+/**
+ * Per-runtime local-first persistence controllers for the cloud session.
+ *
+ * Two throttled envelope records per notebook, one principal:
+ *
+ * - `[notebookId, "snapshot"]` — NotebookDoc bytes from `handle.save()`,
+ *   driven by `notebookDocChanged$`. The seed record: the only one ever
+ *   loaded back into a SYNCING handle (see resolveCloudNotebookHandle).
+ * - `[notebookId, "runtime-state-cache"]` — RuntimeStateDoc bytes from
+ *   `handle.save_state_doc()`, driven by the engine's runtime-state
+ *   stream. A PAINT SOURCE ONLY for the next page load's instant first
+ *   paint: never loaded into the syncing handle, never flushed, never
+ *   synced. The syncing handle still bootstraps RuntimeStateDoc empty and
+ *   the room remains the only writer — the authority invariant forbids
+ *   restoring runtime state into the sync path, not caching pixels.
+ *
+ * Anonymous principals skip persistence entirely (their records could
+ * never match the next session, and an anonymous session must never clear
+ * a signed-in user's records), so the factory returns null for them.
+ */
+
+import { map, type Observable } from "rxjs";
+import {
+  NotebookDocPersistence,
+  RUNTIME_STATE_CACHE_KEY_SEGMENT,
+  type StorageAdapter,
+} from "runtimed";
+import { isAnonymousCloudPrincipal } from "./live-sync";
+
+export interface CloudPersistenceChangeSignals {
+  /** `SyncEngine.notebookDocChanged$` — the NotebookDoc save hint. */
+  notebookDocChanged$: Observable<void>;
+  /** `SyncEngine.runtimeState$` — fires per applied RuntimeStateDoc change. */
+  runtimeState$: Observable<unknown>;
+}
+
+export interface CloudPersistenceHandleSurface {
+  save(): Uint8Array;
+  get_heads_hex(): string[];
+  save_state_doc(): Uint8Array;
+  get_runtime_state_heads_hex(): string[];
+}
+
+export interface CloudNotebookPersistenceController {
+  readonly principal: string;
+  /** Commit both records immediately (pagehide, teardown); never rejects late captures. */
+  flushNow(): Promise<void>;
+  dispose(): void;
+}
+
+export interface CreateCloudNotebookPersistenceOptions {
+  adapter: StorageAdapter;
+  notebookId: string;
+  principal: string;
+  engine: CloudPersistenceChangeSignals;
+  handle: CloudPersistenceHandleSurface;
+  onError?: (error: unknown) => void;
+  /** Test hook: trailing-edge throttle for both controllers. */
+  throttleMs?: number;
+}
+
+export function createCloudNotebookPersistence({
+  adapter,
+  notebookId,
+  principal,
+  engine,
+  handle,
+  onError,
+  throttleMs,
+}: CreateCloudNotebookPersistenceOptions): CloudNotebookPersistenceController | null {
+  if (isAnonymousCloudPrincipal(principal)) {
+    return null;
+  }
+
+  const notebookDoc = new NotebookDocPersistence({
+    adapter,
+    notebookId,
+    principal,
+    changes$: engine.notebookDocChanged$,
+    getSaveBytes: () => handle.save(),
+    getHeadsHex: () => handle.get_heads_hex(),
+    onError,
+    ...(throttleMs !== undefined ? { throttleMs } : {}),
+  });
+  const runtimeStateCache = new NotebookDocPersistence({
+    adapter,
+    notebookId,
+    principal,
+    keySegment: RUNTIME_STATE_CACHE_KEY_SEGMENT,
+    changes$: engine.runtimeState$.pipe(map(() => undefined)),
+    getSaveBytes: () => handle.save_state_doc(),
+    getHeadsHex: () => handle.get_runtime_state_heads_hex(),
+    onError,
+    ...(throttleMs !== undefined ? { throttleMs } : {}),
+  });
+
+  return {
+    principal,
+    flushNow: async () => {
+      // Both captures run synchronously inside flushNow before the first
+      // await, so the caller may free the WASM handle as soon as this call
+      // returns; the promise settles once both write chains commit.
+      await Promise.all([notebookDoc.flushNow(), runtimeStateCache.flushNow()]);
+    },
+    dispose: () => {
+      notebookDoc.dispose();
+      runtimeStateCache.dispose();
+    },
+  };
+}

--- a/apps/notebook-cloud/viewer/runtimed-wasm-client.ts
+++ b/apps/notebook-cloud/viewer/runtimed-wasm-client.ts
@@ -146,6 +146,26 @@ export async function loadNotebookHandleFromBytes(
   return handle;
 }
 
+/**
+ * Render-only handle for instant first paint from locally persisted
+ * envelopes: NotebookDoc bytes plus, when the render cache is present,
+ * RuntimeStateDoc bytes (so outputs paint too). Deliberately no
+ * `set_actor` — painting needs no actor. The handle exists to materialize
+ * pixels and is freed right after; it must never author or sync, and the
+ * runtime-state cache bytes are a paint source, never a sync seed.
+ */
+export async function loadRenderSnapshotHandle(
+  notebookBytes: Uint8Array,
+  runtimeStateBytes: Uint8Array | undefined,
+  modulePath: string | URL,
+  moduleOrPath: WasmModuleOrPath,
+): Promise<NotebookHandle> {
+  const module = await initializeRuntimedWasmClient(modulePath, moduleOrPath);
+  return runtimeStateBytes
+    ? module.NotebookHandle.load_snapshot(notebookBytes, runtimeStateBytes)
+    : module.NotebookHandle.load(notebookBytes);
+}
+
 export async function loadSnapshotPairHandle(
   notebookBytes: Uint8Array,
   runtimeStateBytes: Uint8Array,

--- a/docs/adr/local-first-notebook-state.md
+++ b/docs/adr/local-first-notebook-state.md
@@ -113,6 +113,7 @@ Key layout (room for incremental chunks later, without migration):
 | Key | Value |
 |---|---|
 | `[notebookId, "snapshot"]` | one **envelope record**: 4-byte little-endian meta-JSON length, meta JSON utf8 (`{ headsHex, savedAt, principal, schemaVersion: 1 }`), then full `handle.save()` NotebookDoc bytes |
+| `[notebookId, "runtime-state-cache"]` | same envelope shape over `save_state_doc()` RuntimeStateDoc bytes (meta heads = runtime heads) — PR 6's render-only paint cache, never a sync seed |
 
 The envelope is deliberate: a single record means a single IDB transaction,
 so the meta (which carries the principal guard) can never tear apart from
@@ -517,8 +518,13 @@ connection resilience lives.
 
 ## Invariants (load-bearing, checked in review)
 
-- Persist **NotebookDoc bytes only**. RuntimeStateDoc/CommsDoc/sync states are
-  never written to storage.
+- Only **NotebookDoc bytes** may seed a syncing handle. CommsDoc and
+  Automerge sync states are never written to storage. RuntimeStateDoc bytes
+  are stored solely as the render-only `runtime-state-cache` record (PR 6)
+  — a paint source decoded into a throwaway handle, never loaded into the
+  syncing handle, never flushed, never synced; the syncing handle always
+  bootstraps RuntimeStateDoc empty and the daemon/room remains the only
+  writer.
 - After `NotebookHandle.load()`, `set_actor()` with a **fresh per-connection
   label** before any authoring (operator nonce client-minted per connect
   attempt; principal rewritten by the worker). Never reuse an actor label
@@ -557,47 +563,73 @@ point ("merged N offline changes" affordance, never a modal). We will
 inevitably hit this as collaborative offline use grows; scoped follow-up
 once the stack lands.
 
-### PR 6 — Instant first paint from the persisted snapshot
+### PR 6 — Instant first paint from the persisted snapshot (landed)
 
 The persistence layer's second purpose (and a primary motivation for using
-IndexedDB at all): page load should paint the notebook *immediately* from
-the local envelope instead of waiting for the WS dial + `cloud_room_ready` +
-full bootstrap sync. PR 1 deliberately seeds *after* the handshake because
-authoring needs the server-assigned actor label — but **painting needs no
-actor**. The pinned-snapshot path already proves bytes → throwaway handle →
-`materializeCloudNotebookView` works without a live connection. Sketch:
+IndexedDB at all): page load paints the notebook *immediately* from the
+local envelope records instead of waiting for the WS dial +
+`cloud_room_ready` + full bootstrap sync. PR 1 deliberately seeds *after*
+the handshake because authoring needs the server-assigned actor label — but
+**painting needs no actor**. The pinned-snapshot path already proved
+bytes → throwaway handle → `materializeCloudNotebookView` works without a
+live connection. As landed:
 
-- Read the envelope in parallel with the WS dial; if present, materialize a
-  render-only view at once (ms, zero network), letting the live engine's
-  first materialization take over when ready (respecting the no-blanking
-  rules).
-- **Pre-handshake principal gate:** before `cloud_room_ready` we don't know
-  the connection's principal, and IDB may hold another user's notebook on a
-  shared machine. Gate the paint on the principal derivable from the locally
-  stored auth material (collaborator-auth token) matching the envelope meta;
-  no match → skip paint, wait for the room.
-- **Outputs paint too — via a render-only RuntimeStateDoc cache (base
-  case).** Outputs are most of what a notebook visually *is*, so first paint
-  must include them: alongside the NotebookDoc envelope, cache the last
-  received RuntimeStateDoc bytes (`save_state_doc()`) under a sibling key,
-  strictly as a paint source — decoded into a throwaway render handle (the
-  pinned-snapshot path's exact shape), **never** loaded into the syncing
-  handle and never flushed. The authority invariant forbids restoring
-  runtime state into the sync path, not caching pixels; the syncing handle
-  still bootstraps RuntimeStateDoc empty and the room remains the only
-  writer. Blob-backed output *bytes* are already solved: blob refs are
-  content-addressed and immutable, and the cloud blob endpoints serve
-  `Cache-Control: immutable`, so the browser HTTP cache makes
-  `<img src="blobURL">` instant on revisit with no IndexedDB involvement.
-  The gap is **addressing**, not bytes: which execution is current per cell
-  and which manifest/blob refs to resolve all live in RuntimeStateDoc — the
-  render cache is what preserves the execution-id → output → manifest →
-  blob-ref chain, and the real work is running the output-resolution path
-  (manifest decode, execution-id tracking — see
-  [blob-ref-and-chunk-manifest-protocol](./blob-ref-and-chunk-manifest-protocol.md),
-  [arrow-manifest-durable-storage-design](./arrow-manifest-durable-storage-design.md))
-  against cached bytes with no live room. Cloud-only; desktop has the local
-  daemon.
+- **Outputs paint too — via a render-only RuntimeStateDoc cache (the base
+  case).** Outputs are most of what a notebook visually *is*. The session
+  arms a second throttled persistence controller alongside the NotebookDoc
+  seed (`createCloudNotebookPersistence`,
+  `apps/notebook-cloud/viewer/notebook-persistence.ts`): RuntimeStateDoc
+  bytes from `save_state_doc()` under the sibling key
+  `[notebookId, "runtime-state-cache"]`, same envelope codec, own meta
+  (runtime heads via `get_runtime_state_heads_hex()`, savedAt, principal,
+  schemaVersion 1), driven by the engine's `runtimeState$` stream. The
+  record is **strictly a paint source** — decoded into a throwaway render
+  handle, never loaded into the syncing handle, never flushed, never
+  synced. The authority invariant forbids restoring runtime state into the
+  sync path, not caching pixels; the syncing handle still bootstraps
+  RuntimeStateDoc empty and the room remains the only writer. Anonymous
+  sessions and `read_failed` seed outcomes keep the whole save loop
+  disarmed; teardown/pagehide flushes commit both records before the handle
+  frees, and seed-level clears (`removeRange`) discard the cache with the
+  seed. Blob-backed output *bytes* were already solved (content-addressed
+  refs + `Cache-Control: immutable`); the cache preserves the
+  **addressing** — the execution-id → output → manifest → blob-ref chain —
+  so the normal output-resolution path runs against cached bytes with no
+  live room. Cloud-only; desktop has the local daemon.
+- **Paint-before-handshake:** the live-room effect kicks
+  `resolveCloudInstantPaintHandle` (`viewer/instant-paint.ts`) in parallel
+  with the WS dial (after the connect call, so the dial is never delayed).
+  Both envelopes are read (bounded by a 2 s timeout; a failed read skips
+  the paint and clears nothing), decoded via
+  `loadRenderSnapshotHandle` — `load_snapshot(notebook, runtimeState)`
+  with the cache, plain `load(notebook)` without it, **no `set_actor`** —
+  then materialized through `materializeCloudNotebookView` and freed.
+- **Pre-handshake principal gate:** before `cloud_room_ready` the
+  connection's principal is unknown, and IDB may hold another user's
+  notebook on a shared machine. `cloudInstantPaintPrincipalMatcher`
+  derives a matcher from locally stored auth material: the dev-token user
+  maps to the exact `user:dev:<encoded user>` principal (the worker's
+  derivation is deterministic); OIDC matches the stored subject claim as
+  the principal's encoded id segment (the namespace prefix is
+  server-configured and not client-derivable), with expired claims
+  accepted only when the app-session cookie backs them. No derivable
+  principal, or a mismatch on **either** envelope, skips the paint without
+  clearing — post-handshake seeding owns clear decisions. Anonymous
+  principals never match.
+- **Degradations:** notebook envelope without a cache record paints
+  cells-only. A torn cache envelope, or `load_snapshot` rejecting with
+  cache bytes in play, clears **only** the `runtime-state-cache` record
+  and retries cells-only; corrupt notebook bytes skip the paint without
+  clearing; transient WASM asset failures clear nothing.
+- **Race + handoff:** if the live connect wins the race against the cache
+  read, the paint is skipped (`liveMaterializedRef` guards every apply) —
+  stale cache never overwrites a live materialization. When the paint
+  wins, it lands through the same `applyResolvedCells` path, so the #3577
+  preservation gate keeps it across effect re-runs and the live
+  materialization replaces it wholesale in place (no blanking). The paint
+  runs only on the live-room path; the pinned-revision URL keeps its
+  snapshot fetch (mutually exclusive by loading policy). Poison-pill
+  attempts (seed discard in flight) skip the paint along with the seed.
 - Offline *editing* before the first-ever handshake stays out of scope
   (below) — this PR is about read latency, not offline authoring.
 

--- a/packages/runtimed/src/index.ts
+++ b/packages/runtimed/src/index.ts
@@ -48,17 +48,23 @@ export {
 // Reactive runtime-state store (framework-agnostic RxJS projections)
 export { BUSY_THROTTLE_MS, RuntimeStateStore, throttleBusyStatus } from "./runtime-state-store";
 
-// Local-first persistence (NotebookDoc bytes only; see notebookDocChanged$)
+// Local-first persistence: the NotebookDoc seed record plus the render-only
+// RuntimeStateDoc paint cache (see notebookDocChanged$ and the key-segment
+// docs in notebook-doc-persistence.ts)
 export {
   IndexedDbStorageAdapter,
   type IndexedDbStorageAdapterOptions,
 } from "./persistence/indexeddb-storage-adapter";
 export {
+  NOTEBOOK_DOC_SNAPSHOT_KEY_SEGMENT,
   NotebookDocPersistence,
+  RUNTIME_STATE_CACHE_KEY_SEGMENT,
   clearPersistedNotebookDoc,
+  clearPersistedNotebookRecord,
   decodePersistedNotebookDoc,
   encodePersistedNotebookDoc,
   loadPersistedNotebookDoc,
+  loadPersistedNotebookRecord,
   type NotebookDocPersistenceLogger,
   type NotebookDocPersistenceMeta,
   type NotebookDocPersistenceOptions,

--- a/packages/runtimed/src/persistence/notebook-doc-persistence.ts
+++ b/packages/runtimed/src/persistence/notebook-doc-persistence.ts
@@ -1,13 +1,13 @@
 /**
- * NotebookDocPersistence — trailing-edge throttled NotebookDoc snapshots.
+ * NotebookDocPersistence — trailing-edge throttled document snapshots.
  *
  * Subscribes a narrow change signal (`SyncEngine.notebookDocChanged$`) and
  * persists one self-contained envelope record under
- * `[notebookId, "snapshot"]`: a 4-byte little-endian meta-JSON length, the
- * meta JSON (utf8), then the full `handle.save()` NotebookDoc bytes. A
- * single record means a single IDB transaction — meta and bytes can never
- * tear apart, so the principal guard always describes the bytes it sits
- * next to.
+ * `[notebookId, keySegment]`: a 4-byte little-endian meta-JSON length, the
+ * meta JSON (utf8), then the full `handle.save()` doc bytes. A single
+ * record means a single IDB transaction — meta and bytes can never tear
+ * apart, so the principal guard always describes the bytes it sits next
+ * to.
  *
  * Save semantics mirror automerge-repo's `asyncThrottle`: trailing edge,
  * never two concurrent writes, latest state wins. `flushNow()` (pagehide,
@@ -15,9 +15,16 @@
  * flush debounce have not emitted yet, but `handle.save()` already sees
  * them, and saves are idempotent.
  *
- * Persists NotebookDoc bytes only — RuntimeStateDoc/CommsDoc are
- * daemon/room-authoritative and must never be written to storage, and
- * Automerge sync states are per-connection and not persisted either.
+ * Two records exist per notebook:
+ * - `[notebookId, "snapshot"]` — NotebookDoc bytes, the seed record. The
+ *   only record ever loaded back into a SYNCING handle.
+ * - `[notebookId, "runtime-state-cache"]` — RuntimeStateDoc bytes as a
+ *   render-only paint source for instant first paint. NEVER loaded into
+ *   the syncing handle, never flushed, never synced: the syncing handle
+ *   still bootstraps RuntimeStateDoc empty and the daemon/room remains the
+ *   only writer. The authority invariant forbids restoring runtime state
+ *   into the sync path, not caching pixels. CommsDoc and Automerge sync
+ *   states are never written to storage.
  *
  * Failures never propagate into the live session: every error routes to
  * the `onError` callback and the logger, and after
@@ -30,7 +37,15 @@ import type { Observable, Subscription } from "rxjs";
 import type { StorageAdapter } from "./storage-adapter";
 
 const DEFAULT_SAVE_THROTTLE_MS = 1_000;
-const SNAPSHOT_KEY_SEGMENT = "snapshot";
+
+/** Key segment of the NotebookDoc snapshot record (the seed record). */
+export const NOTEBOOK_DOC_SNAPSHOT_KEY_SEGMENT = "snapshot";
+
+/**
+ * Key segment of the render-only RuntimeStateDoc cache record — a paint
+ * source for instant first paint, never a sync seed.
+ */
+export const RUNTIME_STATE_CACHE_KEY_SEGMENT = "runtime-state-cache";
 
 /** Consecutive save failures tolerated before persistence self-disables. */
 const MAX_CONSECUTIVE_SAVE_FAILURES = 3;
@@ -69,11 +84,17 @@ export interface NotebookDocPersistenceOptions {
   /** Change signal, typically `SyncEngine.notebookDocChanged$`. */
   changes$: Observable<void>;
 
-  /** Full NotebookDoc snapshot bytes (raw `NotebookHandle.save()`). */
+  /** Full doc snapshot bytes (raw `NotebookHandle.save()` or `save_state_doc()`). */
   getSaveBytes: () => Uint8Array;
 
-  /** Current notebook heads (`NotebookHandle.get_heads_hex()`). */
+  /** Current doc heads (`get_heads_hex()` / `get_runtime_state_heads_hex()`). */
   getHeadsHex: () => string[];
+
+  /**
+   * Record key segment under the notebook id; defaults to the NotebookDoc
+   * snapshot record (`"snapshot"`).
+   */
+  keySegment?: string;
 
   /** Trailing-edge save throttle in milliseconds (default 1000). */
   throttleMs?: number;
@@ -86,6 +107,7 @@ export interface NotebookDocPersistenceOptions {
 
 export class NotebookDocPersistence {
   private readonly opts: NotebookDocPersistenceOptions;
+  private readonly keySegment: string;
   private readonly throttleMs: number;
   private readonly logger: NotebookDocPersistenceLogger;
   private readonly subscription: Subscription;
@@ -98,6 +120,7 @@ export class NotebookDocPersistence {
 
   constructor(opts: NotebookDocPersistenceOptions) {
     this.opts = opts;
+    this.keySegment = opts.keySegment ?? NOTEBOOK_DOC_SNAPSHOT_KEY_SEGMENT;
     this.throttleMs = opts.throttleMs ?? DEFAULT_SAVE_THROTTLE_MS;
     this.logger = opts.logger ?? console;
     this.subscription = opts.changes$.subscribe(() => this.onChanged());
@@ -174,9 +197,10 @@ export class NotebookDocPersistence {
     }
 
     const { adapter, notebookId } = this.opts;
+    const key = [notebookId, this.keySegment];
     const write = this.writeChain.then(async () => {
       try {
-        await adapter.save([notebookId, SNAPSHOT_KEY_SEGMENT], envelope);
+        await adapter.save(key, envelope);
         this.consecutiveSaveFailures = 0;
       } catch (error) {
         this.reportSaveFailure("save failed", error);
@@ -212,21 +236,50 @@ export class NotebookDocPersistence {
  * bytes) — callers must treat that as unverifiable provenance
  * (clear + bootstrap), never as a match.
  */
-export async function loadPersistedNotebookDoc(
+export function loadPersistedNotebookDoc(
   adapter: StorageAdapter,
   notebookId: string,
 ): Promise<PersistedNotebookDoc | undefined> {
-  const envelope = await adapter.load([notebookId, SNAPSHOT_KEY_SEGMENT]);
+  return loadPersistedNotebookRecord(adapter, notebookId, NOTEBOOK_DOC_SNAPSHOT_KEY_SEGMENT);
+}
+
+/**
+ * Load one persisted envelope record (`[notebookId, keySegment]`); same
+ * decode degradation rules as `loadPersistedNotebookDoc`.
+ */
+export async function loadPersistedNotebookRecord(
+  adapter: StorageAdapter,
+  notebookId: string,
+  keySegment: string,
+): Promise<PersistedNotebookDoc | undefined> {
+  const envelope = await adapter.load([notebookId, keySegment]);
   if (!envelope) return undefined;
   return decodePersistedNotebookDoc(envelope);
 }
 
-/** Remove every persisted record for a notebook. */
+/**
+ * Remove every persisted record for a notebook (snapshot AND the
+ * runtime-state render cache — a discard of one user's seed must not
+ * leave their cached pixels behind).
+ */
 export function clearPersistedNotebookDoc(
   adapter: StorageAdapter,
   notebookId: string,
 ): Promise<void> {
   return adapter.removeRange([notebookId]);
+}
+
+/**
+ * Remove exactly one persisted record. Used when only the render-only
+ * runtime-state cache is corrupt — the NotebookDoc snapshot record (which
+ * may hold offline edits) must survive.
+ */
+export function clearPersistedNotebookRecord(
+  adapter: StorageAdapter,
+  notebookId: string,
+  keySegment: string,
+): Promise<void> {
+  return adapter.remove([notebookId, keySegment]);
 }
 
 /** Encode meta + doc bytes into one atomic envelope record. */

--- a/packages/runtimed/src/sync-engine.ts
+++ b/packages/runtimed/src/sync-engine.ts
@@ -427,8 +427,10 @@ export class SyncEngine {
    * throttle this signal and call `handle.save()` to snapshot the
    * `NotebookDoc` bytes for local storage.
    *
-   * Note: only `NotebookDoc` bytes should be persisted — `RuntimeStateDoc` is
-   * daemon-authoritative and must not be stored locally.
+   * Note: only `NotebookDoc` bytes may seed a syncing handle —
+   * `RuntimeStateDoc` is daemon-authoritative and must never be restored
+   * into the sync path. (A render-only RuntimeStateDoc paint cache is the
+   * one storage exception; see `RUNTIME_STATE_CACHE_KEY_SEGMENT`.)
    */
   readonly notebookDocChanged$: Observable<void>;
 

--- a/packages/runtimed/tests/notebook-doc-persistence.test.ts
+++ b/packages/runtimed/tests/notebook-doc-persistence.test.ts
@@ -9,10 +9,13 @@ import { Subject } from "rxjs";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vite-plus/test";
 import {
   NotebookDocPersistence,
+  RUNTIME_STATE_CACHE_KEY_SEGMENT,
   clearPersistedNotebookDoc,
+  clearPersistedNotebookRecord,
   decodePersistedNotebookDoc,
   encodePersistedNotebookDoc,
   loadPersistedNotebookDoc,
+  loadPersistedNotebookRecord,
   type NotebookDocPersistenceMeta,
 } from "../src/persistence/notebook-doc-persistence";
 import type { StorageAdapter, StorageKey } from "../src/persistence/storage-adapter";
@@ -253,6 +256,30 @@ describe("NotebookDocPersistence", () => {
     controller.dispose();
   });
 
+  it("writes the runtime-state render cache under its own record key", async () => {
+    // The cache record shares the envelope codec end to end: a throttled
+    // save under [id, "runtime-state-cache"] round-trips through the
+    // segment-aware loader with meta intact and the snapshot key untouched.
+    saveBytes = new Uint8Array([42, 43]);
+    headsHex = ["state-head"];
+    const controller = createController({ keySegment: RUNTIME_STATE_CACHE_KEY_SEGMENT });
+
+    changes$.next();
+    await vi.advanceTimersByTimeAsync(1_000);
+
+    expect(adapter.saves.map((s) => s.key)).toEqual([["nb-1", "runtime-state-cache"]]);
+    const record = await loadPersistedNotebookRecord(
+      adapter,
+      "nb-1",
+      RUNTIME_STATE_CACHE_KEY_SEGMENT,
+    );
+    expect(record?.bytes).toEqual(new Uint8Array([42, 43]));
+    expect(record?.meta?.headsHex).toEqual(["state-head"]);
+    expect(record?.meta?.principal).toBe("user:test:alice");
+    expect(await loadPersistedNotebookDoc(adapter, "nb-1")).toBeUndefined();
+    controller.dispose();
+  });
+
   it("routes adapter save failures to onError without throwing", async () => {
     const onError = vi.fn();
     const failure = new Error("quota exceeded");
@@ -446,5 +473,26 @@ describe("clearPersistedNotebookDoc", () => {
 
     expect(adapter.removeRange).toHaveBeenCalledWith(["nb-1"]);
     expect(await loadPersistedNotebookDoc(adapter, "nb-1")).toBeUndefined();
+  });
+});
+
+describe("clearPersistedNotebookRecord", () => {
+  it("removes only the targeted record — the snapshot seed survives", async () => {
+    const adapter = createRecordingAdapter();
+    await adapter.save(
+      ["nb-1", "snapshot"],
+      encodePersistedNotebookDoc(testMeta(), new Uint8Array([9])),
+    );
+    await adapter.save(
+      ["nb-1", RUNTIME_STATE_CACHE_KEY_SEGMENT],
+      encodePersistedNotebookDoc(testMeta(), new Uint8Array([10])),
+    );
+
+    await clearPersistedNotebookRecord(adapter, "nb-1", RUNTIME_STATE_CACHE_KEY_SEGMENT);
+
+    expect(
+      await loadPersistedNotebookRecord(adapter, "nb-1", RUNTIME_STATE_CACHE_KEY_SEGMENT),
+    ).toBeUndefined();
+    expect((await loadPersistedNotebookDoc(adapter, "nb-1"))?.bytes).toEqual(new Uint8Array([9]));
   });
 });


### PR DESCRIPTION
The ADR's "PR 6" — the second purpose of the #3421 persistence layer, and the primary motivation for IndexedDB: page load paints the notebook in milliseconds from the local envelope instead of waiting for the WS dial + handshake + bootstrap sync.

## What this does

- **Paint before the handshake.** In parallel with the WS dial (never delaying it), read the persisted NotebookDoc envelope + a new **render-only RuntimeStateDoc cache**, load them into a throwaway render handle (`load_snapshot`, deliberately no `set_actor` — it authors nothing and is freed after materialization), and materialize through the same machinery the pinned-revision path uses. **Outputs paint too** — the cache preserves the execution-id → output → manifest → blob-ref chain, and blob bytes are already `immutable`-cached by the browser.
- **The cache is a paint source only.** Never loaded into the syncing handle, never flushed, never synced; the syncing handle still bootstraps RuntimeStateDoc empty and the room remains the only writer (the authority invariant forbids restoring runtime state into the sync path, not caching pixels). Saved alongside the snapshot by a second throttled controller (`save_state_doc()`), anonymous sessions skip it, and a corrupt cache clears only itself (cells-only paint; the seed record is never collateral).
- **Pre-handshake principal gate**: the expected principal is derived from locally stored auth material (dev tokens exact; OIDC by encoded-`sub` id segment — the namespace is server-configured and not client-derivable, recorded in the ADR); mismatch or nothing derivable → no paint, wait for the room. A shared machine never flashes another user's notebook.
- **Race + lifecycle guards**: live materialization winning the race skips the paint (never overwrite live with stale cache); poison-pill attempts skip it (rejected content is not repainted mid-discard); transient WASM asset failures never incriminate the cached bytes (only genuine `load_snapshot` byte rejections clear). The handoff rides the merged #3577 preservation gate — the paint survives the live effect start and is replaced wholesale by the first live materialization.
- Also carries the LOW finding from the external #3584 audit as its own commit: access diagnostics no longer overwrite the "Notebook engine failed to load." Retry notice in the double-failure case.

## Verification

- vp suite: **2171 passed, 0 failed** · notebook-cloud: **852/853** — the single failure is a stale gitignored local WASM artifact predating #3580's actor fix (passes 39/39 after `cargo xtask wasm runtimed`); no Rust changes in this branch
- `pnpm elements:build` verified (no shim-relevant exports added) · `tsc` + `cargo xtask lint` clean
- ADR PR 6 section updated to design-as-landed

Field-QA suggestion on preview: reload a previously-visited notebook → cells *and* outputs should appear near-instantly with a "rendering from local snapshot while connecting" status line, then hand off invisibly when the room syncs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)