### PR TITLE
fix(notebook-cloud): treat same-resource WASM sources as identical; drop the Use-anonymous fallback

### DIFF
--- a/apps/notebook-cloud/test/runtimed-wasm-client-retry.test.ts
+++ b/apps/notebook-cloud/test/runtimed-wasm-client-retry.test.ts
@@ -494,3 +494,57 @@ describe("runtimed WASM client retry ladder", () => {
     );
   });
 });
+
+describe("runtimed WASM source normalization", () => {
+  beforeEach(() => {
+    _resetRuntimedWasmClientForTests();
+  });
+  afterEach(() => {
+    _setRuntimedWasmModuleImporterForTests(null);
+    _setRuntimedWasmFetchForTests(null);
+    _resetRuntimedWasmClientForTests();
+    delete (globalThis as { location?: unknown }).location;
+  });
+
+  it("accepts the same wasm spelled relative then absolute (preview field failure)", async () => {
+    (globalThis as { location?: unknown }).location = {
+      href: "https://preview.runt.run/n/topic-viz/Topic%20Visualization",
+    };
+    _setRuntimedWasmModuleImporterForTests(async () => stubModule());
+    const { fetch } = okFetch();
+    _setRuntimedWasmFetchForTests(fetch);
+
+    const first = await initializeRuntimedWasmClient(
+      "/assets/runtimed_wasm.716993c935bb1411.js",
+      "/assets/runtimed_wasm_bg.716993c935bb1411.wasm",
+    );
+    // The live path resolves the identical assets to absolute URLs; the
+    // single-init guard must treat them as the same resource, not refuse.
+    const second = await initializeRuntimedWasmClient(
+      new URL("/assets/runtimed_wasm.716993c935bb1411.js", "https://preview.runt.run/"),
+      new URL("/assets/runtimed_wasm_bg.716993c935bb1411.wasm", "https://preview.runt.run/"),
+    );
+    assert.equal(first, second);
+  });
+
+  it("still refuses a genuinely different wasm source", async () => {
+    (globalThis as { location?: unknown }).location = {
+      href: "https://preview.runt.run/n/x",
+    };
+    _setRuntimedWasmModuleImporterForTests(async () => stubModule());
+    const { fetch } = okFetch();
+    _setRuntimedWasmFetchForTests(fetch);
+
+    await initializeRuntimedWasmClient(
+      "/assets/runtimed_wasm.aaaa.js",
+      "/assets/runtimed_wasm_bg.aaaa.wasm",
+    );
+    await assert.rejects(
+      initializeRuntimedWasmClient(
+        "/assets/runtimed_wasm.aaaa.js",
+        "/assets/runtimed_wasm_bg.bbbb.wasm",
+      ),
+      /already initialized from .*; refusing/,
+    );
+  });
+});

--- a/apps/notebook-cloud/test/viewer-notices.test.ts
+++ b/apps/notebook-cloud/test/viewer-notices.test.ts
@@ -253,7 +253,7 @@ test("a resolved access diagnostic never overwrites the wasm-failure Retry notic
   assert.doesNotMatch(html, /Edit access pending/);
 });
 
-test("wasm-asset failures keep the legacy action when no retry callback is wired", () => {
+test("wasm-asset failures show no action when no retry callback is wired", () => {
   const html = renderToStaticMarkup(
     React.createElement(CloudNotebookNotices, {
       authState: authState("anonymous"),
@@ -265,7 +265,8 @@ test("wasm-asset failures keep the legacy action when no retry callback is wired
   );
 
   assert.match(html, /Notebook engine failed to load/);
-  assert.match(html, /Use anonymous/);
+  // The prototype-era "Use anonymous" fallback is gone: no destructive CTA.
+  assert.doesNotMatch(html, /Use anonymous/);
 });
 
 test("connection notice sanitizer redacts http(s) URLs down to host and path", () => {

--- a/apps/notebook-cloud/viewer/live-sync.ts
+++ b/apps/notebook-cloud/viewer/live-sync.ts
@@ -1,3 +1,4 @@
+import { isRuntimedWasmAssetFailure } from "./runtimed-wasm-failure";
 import { BehaviorSubject, ReplaySubject, type Observable } from "rxjs";
 import {
   SyncEngine,
@@ -537,6 +538,18 @@ export async function resolveCloudNotebookHandle<Handle>({
   try {
     return { handle: await loadFromBytes(persisted.bytes), outcome: "seeded" };
   } catch (error) {
+    // A WASM client/asset failure does not incriminate the persisted bytes:
+    // clearing here destroyed a healthy record in the field when an
+    // init-source refusal cascaded out of loadFromBytes. Fail open and let
+    // the next attempt retry the seed.
+    const message = error instanceof Error ? error.message : String(error);
+    if (isRuntimedWasmAssetFailure(message)) {
+      console.warn(
+        "[notebook-cloud] runtimed WASM failed while seeding; bootstrapping without clearing",
+        error,
+      );
+      return { handle: await createBootstrap(), outcome: "read_failed" };
+    }
     console.warn(
       "[notebook-cloud] persisted NotebookDoc bytes failed to load; clearing and bootstrapping",
       error,

--- a/apps/notebook-cloud/viewer/notices.tsx
+++ b/apps/notebook-cloud/viewer/notices.tsx
@@ -207,7 +207,6 @@ export function CloudNotebookNotices({
           actions={
             <ConnectionNoticeAction
               connectionError={connectionError ?? ""}
-              onResetAuth={onResetAuth}
               onRetryConnection={onRetryConnection}
               onSignInAgain={onSignInAgain}
             />
@@ -288,12 +287,10 @@ function AuthNoticeAction({
 
 function ConnectionNoticeAction({
   connectionError,
-  onResetAuth,
   onRetryConnection,
   onSignInAgain,
 }: {
   connectionError: string;
-  onResetAuth: () => void;
   onRetryConnection?: () => void;
   onSignInAgain?: () => void | Promise<void>;
 }) {
@@ -321,11 +318,18 @@ function ConnectionNoticeAction({
     );
   }
 
-  return (
-    <NotebookNoticeAction onClick={onResetAuth} icon={<RotateCcw className="h-3 w-3" />}>
-      Use anonymous
-    </NotebookNoticeAction>
-  );
+  if (onRetryConnection) {
+    return (
+      <NotebookNoticeAction onClick={onRetryConnection} icon={<RotateCcw className="h-3 w-3" />}>
+        Retry
+      </NotebookNoticeAction>
+    );
+  }
+
+  // No destructive fallback: "Use anonymous" (a prototype-era relic) reset a
+  // signed-in session for errors auth could never fix. With no retry wired,
+  // the notice text stands on its own.
+  return null;
 }
 
 function isStatusDerivedFromConnectionError(

--- a/apps/notebook-cloud/viewer/runtimed-wasm-client.ts
+++ b/apps/notebook-cloud/viewer/runtimed-wasm-client.ts
@@ -4,7 +4,10 @@ import {
 } from "runtimed";
 import { setMarkdownProjectionProjector } from "../../../src/lib/markdown-projection";
 import type { NotebookHandle } from "../../notebook/src/wasm/runtimed-wasm/runtimed_wasm.js";
-import { asRuntimedWasmAssetFailure } from "./runtimed-wasm-failure";
+import {
+  asRuntimedWasmAssetFailure,
+  RUNTIMED_WASM_ASSET_FAILURE_PREFIX,
+} from "./runtimed-wasm-failure";
 
 type RuntimedWasmModule = typeof import("../../notebook/src/wasm/runtimed-wasm/runtimed_wasm.js");
 type WasmModuleOrPath = string | URL | Request | Response | ArrayBuffer | WebAssembly.Module;
@@ -80,11 +83,11 @@ export async function initializeRuntimedWasmClient(
   modulePath: string | URL,
   moduleOrPath: WasmModuleOrPath,
 ): Promise<RuntimedWasmModule> {
-  const source = wasmSourceLabel(moduleOrPath);
+  const source = normalizedWasmSource(wasmSourceLabel(moduleOrPath));
   if (initialized && initializedSource !== source) {
     return Promise.reject(
       new Error(
-        `runtimed WASM is already initialized from ${initializedSource}; refusing ${source}`,
+        `${RUNTIMED_WASM_ASSET_FAILURE_PREFIX}already initialized from ${initializedSource}; refusing ${source}`,
       ),
     );
   }
@@ -242,11 +245,11 @@ export function encodeInteractionPresenceAfterInit(
 export type { NotebookHandle };
 
 function loadRuntimedWasmModule(modulePath: string | URL): Promise<RuntimedWasmModule> {
-  const href = typeof modulePath === "string" ? modulePath : modulePath.href;
+  const href = normalizedWasmSource(typeof modulePath === "string" ? modulePath : modulePath.href);
   if (loadedModule && loadedModuleSource !== href) {
     return Promise.reject(
       new Error(
-        `runtimed WASM module is already loaded from ${loadedModuleSource}; refusing ${href}`,
+        `${RUNTIMED_WASM_ASSET_FAILURE_PREFIX}module already loaded from ${loadedModuleSource}; refusing ${href}`,
       ),
     );
   }
@@ -548,6 +551,26 @@ function runtimedWasmModuleAfterInit(): RuntimedWasmModule {
     throw new Error("runtimed WASM is not initialized");
   }
   return resolvedModule;
+}
+
+/**
+ * Normalize a source label to an absolute href so the single-init guards
+ * compare resources, not string forms. The instant-paint path passes the
+ * shell config's relative "/assets/..." while the live path passes a
+ * resolved absolute URL — the same wasm in two spellings must never be
+ * "refused" as a different source (observed on preview: slow connections
+ * let the paint initialize first, then the live connect was refused over
+ * the relative-vs-absolute spelling of the identical hashed binary).
+ * Bracketed sentinel labels ("[wasm-bytes]" etc.) pass through untouched.
+ */
+function normalizedWasmSource(label: string): string {
+  if (label.startsWith("[")) return label;
+  if (typeof location === "undefined") return label;
+  try {
+    return new URL(label, location.href).href;
+  } catch {
+    return label;
+  }
 }
 
 function wasmSourceLabel(moduleOrPath: WasmModuleOrPath): string {


### PR DESCRIPTION
Fixes the field failure Kyle hit on preview.runt.run (slow connection, `?mode=edit`):

> `runtimed WASM is already initialized from /assets/runtimed_wasm_bg.716993c935bb1411.wasm; refusing https://preview.runt.run/assets/runtimed_wasm_bg.716993c935bb1411.wasm`

It *is* literally the same wasm. The instant paint (#3586) initializes the client with the shell config's **relative** `/assets/...` path; the live connect passes a **resolved absolute URL**. The single-init guards compared raw strings, so whichever path lost the race got refused over a spelling difference. Slow connections make the paint win (fast local IDB vs slow WS), so the **live room failed exactly when instant paint worked best**. Console logs showed the worse second-order effect: the seed path read the refusal as corrupt bytes and **cleared the user's persisted record** — a plumbing error destroying durable data.

Three changes:

1. **Normalize sources to absolute hrefs** before both single-init guard comparisons (`new URL(label, location.href).href`; bracketed sentinels and no-`location` environments pass through). Same resource in two spellings → same source. Genuinely different sources still refuse.
2. **Init refusals are non-incriminating**: they now carry the wasm-failure prefix, and the seed path classifies them like other WASM client failures — bootstrap **without clearing** the persisted record (`read_failed` outcome, so the save loop stays disarmed too).
3. **The prototype-era "Use anonymous" fallback CTA is gone** (requested): it reset a signed-in session for connection errors auth could never fix. The notice fallback is now Retry when a retry callback is wired, otherwise the text stands alone. The auth-specific notices keep their "Sign in again" / "Clear stale sign-in" actions.

Field note from the same session: the connection dot correctly showed offline on the flaky link — the #3421 machinery working as designed around this bug.

## Verification
- New regression: same wasm spelled relative-then-absolute accepted (the exact preview failure, URL-for-URL); different binary still refused.
- `tsc --noEmit` clean; targeted suites (wasm-client retry, live-sync, viewer-notices incl. updated CTA expectations): **103 pass, 0 fail**; `cargo xtask lint` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)