### PR TITLE
feat(notebook-cloud): surface offline merges; authoritative empty room displaces the instant paint

### DIFF
--- a/apps/notebook-cloud/test/cloud-projection-flicker.test.ts
+++ b/apps/notebook-cloud/test/cloud-projection-flicker.test.ts
@@ -175,10 +175,16 @@ describe("cloud projection flicker gate", () => {
     it("clears real notebook switches in the next run's body, before connecting", () => {
       // The cleanup closes over its own run's config, so switch-clearing
       // can only happen here — and a cleared switch also drops the painted
-      // identity so later gates fail closed.
+      // identity AND the live/paint-origin race flags (a cleared stage has
+      // no pixels for either flag to describe), so the next notebook's
+      // instant paint is not gated on the previous notebook's history.
       assert.match(
         sessionSource,
-        /const preservedAcrossRuns = resetCloudProjectionUnlessPreserved\(\{\s*paintedNotebookIdentity: paintedNotebookIdentityRef\.current,\s*nextNotebookIdentity: `id:\$\{config\.notebookId\}`,\s*\}\);\s*if \(!preservedAcrossRuns\) \{\s*paintedNotebookIdentityRef\.current = null;\s*\}/,
+        /const preservedAcrossRuns = resetCloudProjectionUnlessPreserved\(\{\s*paintedNotebookIdentity: paintedNotebookIdentityRef\.current,\s*nextNotebookIdentity: `id:\$\{config\.notebookId\}`,\s*\}\);\s*if \(!preservedAcrossRuns\) \{\s*paintedNotebookIdentityRef\.current = null;/,
+      );
+      assert.match(
+        sessionSource,
+        /if \(!preservedAcrossRuns\) \{[\s\S]*?liveMaterializedRef\.current = false;\s*paintOriginRef\.current = false;\s*\}/,
       );
     });
 

--- a/apps/notebook-cloud/test/connection-diagnostics.test.ts
+++ b/apps/notebook-cloud/test/connection-diagnostics.test.ts
@@ -1,8 +1,11 @@
 import { describe, it } from "node:test";
 import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
 import {
   CLOUD_CONNECTION_EDIT_ACCESS_APPROVED_DIAGNOSTIC,
   CLOUD_CONNECTION_EDIT_ACCESS_PENDING_DIAGNOSTIC,
+  CLOUD_CONNECTION_SIGN_IN_DIAGNOSTIC,
+  cloudConnectionErrorWithAccessDiagnostic,
   diagnoseCloudConnectionAccess,
 } from "../viewer/connection-diagnostics.ts";
 import type { CloudPrototypeAuthState } from "../viewer/collaborator-auth.ts";
@@ -122,6 +125,52 @@ describe("cloud connection diagnostics", () => {
     });
 
     assert.equal(diagnostic, null);
+  });
+});
+
+describe("late access diagnostics never displace a terminal WASM-failure notice", () => {
+  const ASSET_FAILURE =
+    "runtimed WASM asset failed: Failed to fetch runtimed WASM (404): https://wasm.example/runtimed_wasm_bg.wasm";
+
+  it("keeps the WASM failure when the diagnostic resolves after it surfaced", () => {
+    assert.equal(
+      cloudConnectionErrorWithAccessDiagnostic(ASSET_FAILURE, CLOUD_CONNECTION_SIGN_IN_DIAGNOSTIC),
+      ASSET_FAILURE,
+    );
+  });
+
+  it("applies the diagnostic over ordinary or absent connection errors", () => {
+    assert.equal(
+      cloudConnectionErrorWithAccessDiagnostic(null, CLOUD_CONNECTION_SIGN_IN_DIAGNOSTIC),
+      CLOUD_CONNECTION_SIGN_IN_DIAGNOSTIC,
+    );
+    assert.equal(
+      cloudConnectionErrorWithAccessDiagnostic(
+        "cloud sync socket closed (1006)",
+        CLOUD_CONNECTION_SIGN_IN_DIAGNOSTIC,
+      ),
+      CLOUD_CONNECTION_SIGN_IN_DIAGNOSTIC,
+    );
+  });
+
+  // Session wiring pins (the hook cannot run under node): the kick-time
+  // guard on the connect-failure path, and BOTH late-resolution sites
+  // merging through the resolution-time guard.
+  it("the session guards at kick time and at every resolution site", () => {
+    const sessionSource = readFileSync(
+      new URL("../viewer/cloud-viewer-session.ts", import.meta.url),
+      "utf8",
+    );
+    assert.match(sessionSource, /if \(cloudConnectionErrorAcceptsAccessDiagnostic\(message\)\) \{/);
+    assert.equal(
+      (
+        sessionSource.match(
+          /setConnectionError\(\(current\) =>\s*cloudConnectionErrorWithAccessDiagnostic\(current, diagnostic\),\s*\)/g,
+        ) ?? []
+      ).length,
+      2,
+      "both diagnostic resolution sites must merge through the resolution-time guard",
+    );
   });
 });
 

--- a/apps/notebook-cloud/test/instant-paint.test.ts
+++ b/apps/notebook-cloud/test/instant-paint.test.ts
@@ -5,7 +5,9 @@ import type { PersistedNotebookDoc } from "runtimed";
 import type { CloudPrototypeAuthState } from "../viewer/collaborator-auth.ts";
 import {
   cloudInstantPaintPrincipalMatcher,
+  cloudNotebookHandleCaughtUp,
   resolveCloudInstantPaintHandle,
+  shouldDisplayEmptyLiveNotebook,
   type CloudInstantPaintOptions,
 } from "../viewer/instant-paint.ts";
 import { cloudViewerLoadingPolicy } from "../viewer/loading-policy.ts";
@@ -267,6 +269,81 @@ describe("resolveCloudInstantPaintHandle", () => {
     assert.equal(
       harness.calls.some((call) => call.startsWith("load(")),
       false,
+    );
+  });
+});
+
+describe("empty live room displacement", () => {
+  it("displaces painted cells only once the handle has caught up to the room", () => {
+    // The matcher heuristic's backstop: a (possibly false-positive) paint
+    // may block a zero-cell apply only while the bootstrap exchange could
+    // still deliver content. Once the room's advertised heads are all
+    // applied, zero cells IS the room's truth.
+    const painted = { snapshotResolved: true, paintedCellCount: 3 };
+
+    assert.equal(shouldDisplayEmptyLiveNotebook({ ...painted, handleCaughtUp: false }), false);
+    assert.equal(shouldDisplayEmptyLiveNotebook({ ...painted, handleCaughtUp: true }), true);
+    // Nothing painted: the empty state may always show once resolved.
+    assert.equal(
+      shouldDisplayEmptyLiveNotebook({
+        snapshotResolved: true,
+        paintedCellCount: 0,
+        handleCaughtUp: false,
+      }),
+      true,
+    );
+    // Pinned-snapshot path still resolving: never blank under it.
+    assert.equal(
+      shouldDisplayEmptyLiveNotebook({
+        snapshotResolved: false,
+        paintedCellCount: 0,
+        handleCaughtUp: true,
+      }),
+      false,
+    );
+  });
+
+  it("treats handles without the caught-up export (or a throwing one) as not caught up", () => {
+    assert.equal(cloudNotebookHandleCaughtUp({}), false);
+    assert.equal(
+      cloudNotebookHandleCaughtUp({
+        notebook_doc_caught_up: () => {
+          throw new Error("freed handle");
+        },
+      }),
+      false,
+    );
+    assert.equal(cloudNotebookHandleCaughtUp({ notebook_doc_caught_up: () => true }), true);
+  });
+
+  // Session wiring pins (the hook cannot run under node). Count-based:
+  // BOTH zero-cell checkpoints must route through the displacement policy,
+  // the caught-up kick must exist, and the changeset tail must never
+  // relabel paint-origin content as live.
+  const sessionSource = readFileSync(
+    new URL("../viewer/cloud-viewer-session.ts", import.meta.url),
+    "utf8",
+  );
+
+  it("routes both zero-cell checkpoints through the displacement policy", () => {
+    assert.ok(
+      (sessionSource.match(/mayShowEmptyLiveNotebook\(liveRuntime\)/g) ?? []).length >= 2,
+      "both rawCellCount === 0 checkpoints must consult mayShowEmptyLiveNotebook",
+    );
+    assert.match(sessionSource, /shouldDisplayEmptyLiveNotebook\(\{/);
+  });
+
+  it("kicks one full materialization when the doc first catches up to the room", () => {
+    assert.match(
+      sessionSource,
+      /notebookSyncApplied\$\.subscribe\(\(\) => \{\s*if \(caughtUpMaterializeKicked\) return;\s*if \(!cloudNotebookHandleCaughtUp\(liveRuntime\.handle\)\) return;\s*caughtUpMaterializeKicked = true;\s*materializeLiveCellsSafely\(liveRuntime\);/,
+    );
+  });
+
+  it("never relabels paint-origin content as live in the changeset tail", () => {
+    assert.match(
+      sessionSource,
+      /if \(paintOriginRef\.current\) \{[\s\S]*?return;\s*\}\s*liveMaterializedRef\.current = true;\s*setStatus\(\{\s*kind: "ready",\s*message: `Rendering \$\{currentCellCount\} cells from the live notebook room\.`/,
     );
   });
 });

--- a/apps/notebook-cloud/test/instant-paint.test.ts
+++ b/apps/notebook-cloud/test/instant-paint.test.ts
@@ -453,10 +453,11 @@ describe("cloudInstantPaintStorageOptions (session storage boundary)", () => {
       loadRange: async () => [],
       removeRange: async (prefix) => {
         const rangePrefix = `${keyOf(prefix)}/`;
-        for (const key of [...records.keys()]) {
-          if (key === keyOf(prefix) || key.startsWith(rangePrefix)) {
-            records.delete(key);
-          }
+        const doomed = Array.from(records.keys()).filter(
+          (key) => key === keyOf(prefix) || key.startsWith(rangePrefix),
+        );
+        for (const key of doomed) {
+          records.delete(key);
         }
       },
     };

--- a/apps/notebook-cloud/test/instant-paint.test.ts
+++ b/apps/notebook-cloud/test/instant-paint.test.ts
@@ -1,16 +1,37 @@
 import { describe, it } from "node:test";
 import assert from "node:assert/strict";
 import { readFileSync } from "node:fs";
-import type { PersistedNotebookDoc } from "runtimed";
+import {
+  RUNTIME_STATE_CACHE_KEY_SEGMENT,
+  encodePersistedNotebookDoc,
+  type PersistedNotebookDoc,
+  type StorageAdapter,
+  type StorageKey,
+} from "runtimed";
 import type { CloudPrototypeAuthState } from "../viewer/collaborator-auth.ts";
 import {
   cloudInstantPaintPrincipalMatcher,
+  cloudInstantPaintStorageOptions,
   cloudNotebookHandleCaughtUp,
   resolveCloudInstantPaintHandle,
+  runCloudInstantPaint,
   shouldDisplayEmptyLiveNotebook,
   type CloudInstantPaintOptions,
+  type CloudInstantPaintRunOptions,
 } from "../viewer/instant-paint.ts";
 import { cloudViewerLoadingPolicy } from "../viewer/loading-policy.ts";
+import {
+  asRuntimedWasmAssetFailure,
+  isRuntimedWasmAssetFailure,
+} from "../viewer/runtimed-wasm-failure.ts";
+
+/**
+ * The session's exact transient-failure classifier (cloud-viewer-session
+ * wires this expression verbatim) — drift between the test's predicate and
+ * the shipped one must show up here.
+ */
+const sessionIsTransientLoadFailure = (error: unknown) =>
+  isRuntimedWasmAssetFailure(error instanceof Error ? error.message : String(error));
 
 function authState(overrides: Partial<CloudPrototypeAuthState>): CloudPrototypeAuthState {
   return {
@@ -188,10 +209,13 @@ describe("resolveCloudInstantPaintHandle", () => {
     harness.options.loadRenderHandle = async (notebookBytes, runtimeStateBytes) => {
       if (runtimeStateBytes) {
         harness.calls.push("load(pair)");
+        // A bare load_snapshot rejection carries no asset-failure prefix:
+        // through the REAL classifier it must read as corrupt cache.
         throw new Error("corrupt runtime-state bytes");
       }
       return loadRenderHandle(notebookBytes, runtimeStateBytes);
     };
+    harness.options.isTransientLoadFailure = sessionIsTransientLoadFailure;
 
     const resolved = await withSilencedWarnings(() =>
       resolveCloudInstantPaintHandle(harness.options),
@@ -211,16 +235,47 @@ describe("resolveCloudInstantPaintHandle", () => {
     const harness = createHarness({ notebook: record(PRINCIPAL), cache: record(PRINCIPAL) });
     harness.options.loadRenderHandle = async () => {
       harness.calls.push("load(pair)");
-      throw new Error("runtimed WASM asset failed: import timed out");
+      // The terminal init-failure shape the wasm client actually throws.
+      throw asRuntimedWasmAssetFailure(new Error("import timed out"));
     };
-    harness.options.isTransientLoadFailure = (error) =>
-      error instanceof Error && error.message.startsWith("runtimed WASM asset failed");
+    harness.options.isTransientLoadFailure = sessionIsTransientLoadFailure;
 
     const resolved = await withSilencedWarnings(() =>
       resolveCloudInstantPaintHandle(harness.options),
     );
 
     assert.deepEqual(resolved, { handle: null, outcome: "skipped_unloadable" });
+    assert.equal(harness.calls.includes("clearCache"), false);
+  });
+
+  it("treats an absent or torn seed record as nothing to paint, clearing nothing", async () => {
+    for (const notebook of [undefined, { meta: null } as PersistedNotebookDoc]) {
+      const harness = createHarness({ notebook, cache: record(PRINCIPAL) });
+      const resolved = await resolveCloudInstantPaintHandle(harness.options);
+
+      assert.deepEqual(resolved, { handle: null, outcome: "skipped_no_record" });
+      // Seeding's post-handshake logic owns whether an unverifiable seed
+      // record clears — the paint path must touch neither record.
+      assert.equal(harness.calls.includes("clearCache"), false);
+    }
+  });
+
+  it("a stale attempt never clears the cache after losing the race inside the load", async () => {
+    // Seconds can pass inside loadRenderHandle (WASM init ladder); a live
+    // session arming persistence meanwhile may have REWRITTEN the cache
+    // record. The corrupt-cache clear decision was made against the OLD
+    // bytes, so a superseded attempt must skip the delete.
+    let liveMaterialized = false;
+    const harness = createHarness({ notebook: record(PRINCIPAL), cache: record(PRINCIPAL) });
+    harness.options.shouldContinue = () => !liveMaterialized;
+    harness.options.loadRenderHandle = async () => {
+      liveMaterialized = true; // live connect wins during the WASM load
+      throw new Error("corrupt runtime-state bytes");
+    };
+
+    const resolved = await resolveCloudInstantPaintHandle(harness.options);
+
+    assert.deepEqual(resolved, { handle: null, outcome: "skipped_superseded" });
     assert.equal(harness.calls.includes("clearCache"), false);
   });
 
@@ -270,6 +325,177 @@ describe("resolveCloudInstantPaintHandle", () => {
       harness.calls.some((call) => call.startsWith("load(")),
       false,
     );
+  });
+});
+
+describe("runCloudInstantPaint", () => {
+  interface RunHarness {
+    calls: string[];
+    liveMaterialized: { current: boolean };
+    options: CloudInstantPaintRunOptions<string, { cells: string[] }>;
+  }
+
+  function createRunHarness(cells: string[] = ["cell-1"]): RunHarness {
+    const calls: string[] = [];
+    const liveMaterialized = { current: false };
+    return {
+      calls,
+      liveMaterialized,
+      options: {
+        resolveHandle: async () => {
+          calls.push("resolve");
+          return { handle: "render-handle", outcome: "painted" as const };
+        },
+        // The session's freshness flag shape: live materialization flips it.
+        isFresh: () => !liveMaterialized.current,
+        materialize: async (handle, _shouldContinue) => {
+          calls.push(`materialize(${handle})`);
+          return { cells };
+        },
+        acceptMetadata: () => {
+          calls.push("acceptMetadata");
+        },
+        projectWidgets: async () => {
+          calls.push("projectWidgets");
+        },
+        applyPaint: () => {
+          calls.push("applyPaint");
+        },
+        freeHandle: (handle) => {
+          calls.push(`free(${handle})`);
+        },
+      },
+    };
+  }
+
+  it("runs resolve, materialize, metadata, widgets, apply in order and frees the handle", async () => {
+    const harness = createRunHarness();
+    const outcome = await runCloudInstantPaint(harness.options);
+
+    assert.equal(outcome, "painted");
+    assert.deepEqual(harness.calls, [
+      "resolve",
+      "materialize(render-handle)",
+      "acceptMetadata",
+      "projectWidgets",
+      "applyPaint",
+      "free(render-handle)",
+    ]);
+  });
+
+  it("a live materialization landing while the handle resolves skips every later step", async () => {
+    const harness = createRunHarness();
+    harness.options.resolveHandle = async () => {
+      harness.calls.push("resolve");
+      harness.liveMaterialized.current = true; // live wins during IDB/WASM work
+      return { handle: "render-handle", outcome: "painted" as const };
+    };
+
+    const outcome = await runCloudInstantPaint(harness.options);
+
+    assert.equal(outcome, "skipped_superseded");
+    assert.deepEqual(harness.calls, ["resolve", "free(render-handle)"]);
+  });
+
+  it("a live materialization landing mid-materialize means no apply lands", async () => {
+    const harness = createRunHarness();
+    harness.options.materialize = async () => {
+      harness.calls.push("materialize");
+      harness.liveMaterialized.current = true; // live wins mid-flight
+      return { cells: ["stale-cell"] };
+    };
+
+    const outcome = await runCloudInstantPaint(harness.options);
+
+    assert.equal(outcome, "skipped_superseded");
+    assert.equal(harness.calls.includes("applyPaint"), false);
+    assert.equal(harness.calls.includes("acceptMetadata"), false);
+    assert.equal(harness.calls.at(-1), "free(render-handle)");
+  });
+
+  it("a live materialization landing during widget projection means no final apply", async () => {
+    const harness = createRunHarness();
+    harness.options.projectWidgets = async () => {
+      harness.calls.push("projectWidgets");
+      harness.liveMaterialized.current = true;
+    };
+
+    const outcome = await runCloudInstantPaint(harness.options);
+
+    assert.equal(outcome, "skipped_superseded");
+    assert.equal(harness.calls.includes("applyPaint"), false);
+    assert.equal(harness.calls.at(-1), "free(render-handle)");
+  });
+
+  it("an empty persisted snapshot paints nothing and still frees the handle", async () => {
+    const harness = createRunHarness([]);
+    const outcome = await runCloudInstantPaint(harness.options);
+
+    assert.equal(outcome, "skipped_empty_snapshot");
+    assert.equal(harness.calls.includes("applyPaint"), false);
+    assert.equal(harness.calls.at(-1), "free(render-handle)");
+  });
+});
+
+describe("cloudInstantPaintStorageOptions (session storage boundary)", () => {
+  function createRecordingAdapter(): StorageAdapter & { records: Map<string, Uint8Array> } {
+    const records = new Map<string, Uint8Array>();
+    const keyOf = (key: StorageKey) => key.join("/");
+    return {
+      records,
+      load: async (key) => records.get(keyOf(key)),
+      save: async (key, data) => {
+        records.set(keyOf(key), data);
+      },
+      remove: async (key) => {
+        records.delete(keyOf(key));
+      },
+      loadRange: async () => [],
+      removeRange: async (prefix) => {
+        const rangePrefix = `${keyOf(prefix)}/`;
+        for (const key of [...records.keys()]) {
+          if (key === keyOf(prefix) || key.startsWith(rangePrefix)) {
+            records.delete(key);
+          }
+        }
+      },
+    };
+  }
+
+  it("a corrupt runtime cache clears ONLY the cache record — the seed record survives", async () => {
+    // Review C[2]: the unit harness cannot observe a seed clear by
+    // construction, so this drives the REAL storage bindings the session
+    // spreads (load + clear against real envelope records) and asserts the
+    // boundary: load_snapshot rejecting the cache bytes deletes
+    // [id, "runtime-state-cache"] and nothing else.
+    const adapter = createRecordingAdapter();
+    const meta = {
+      headsHex: ["aa"],
+      savedAt: 1,
+      principal: "user:dev:alice",
+      schemaVersion: 1 as const,
+    };
+    await adapter.save(["nb-1", "snapshot"], encodePersistedNotebookDoc(meta, new Uint8Array([1])));
+    await adapter.save(
+      ["nb-1", RUNTIME_STATE_CACHE_KEY_SEGMENT],
+      encodePersistedNotebookDoc(meta, new Uint8Array([2])),
+    );
+
+    const resolved = await withSilencedWarnings(() =>
+      resolveCloudInstantPaintHandle<string>({
+        matchesPrincipal: (principal) => principal === "user:dev:alice",
+        ...cloudInstantPaintStorageOptions(adapter, "nb-1"),
+        loadRenderHandle: async (_notebookBytes, runtimeStateBytes) => {
+          if (runtimeStateBytes) {
+            throw new Error("corrupt runtime-state bytes");
+          }
+          return "cells-only-handle";
+        },
+      }),
+    );
+
+    assert.deepEqual(resolved, { handle: "cells-only-handle", outcome: "painted_cells_only" });
+    assert.deepEqual([...adapter.records.keys()], ["nb-1/snapshot"]);
   });
 });
 
@@ -374,14 +600,21 @@ describe("instant paint mutual exclusion and session wiring", () => {
     );
   });
 
-  it("guards every instant-paint apply on the live-materialization race flag", () => {
+  it("drives the paint through the tested runner with the real freshness flag", () => {
+    // The race-guard SEQUENCING is tested for real in the runCloudInstantPaint
+    // suite above; these pin the session's thin wiring into it — the flag
+    // definition, both injection points, and the storage-option factory
+    // whose clear targets only the cache record.
     assert.match(
       sessionSource,
       /const instantPaintFresh = \(\) => !disposed && !liveMaterializedRef\.current;/,
     );
-  });
-
-  it("frees the throwaway render handle after materialization", () => {
-    assert.match(sessionSource, /\} finally \{\s*renderHandle\.free\(\);\s*\}/);
+    assert.match(sessionSource, /isFresh: instantPaintFresh,/);
+    assert.match(sessionSource, /shouldContinue: instantPaintFresh,/);
+    assert.match(
+      sessionSource,
+      /\.\.\.cloudInstantPaintStorageOptions\(persistenceAdapter, config\.notebookId\),/,
+    );
+    assert.match(sessionSource, /freeHandle: \(renderHandle\) => renderHandle\.free\(\),/);
   });
 });

--- a/apps/notebook-cloud/test/notebook-persistence.test.ts
+++ b/apps/notebook-cloud/test/notebook-persistence.test.ts
@@ -28,8 +28,18 @@ function createRecordingAdapter(): StorageAdapter & { records: Map<string, Uint8
       records.delete(key.join("/"));
     },
     loadRange: async () => [],
-    removeRange: async () => {
-      records.clear();
+    // Prefix-faithful (mirrors the runtimed test adapter): a future
+    // range-clear assertion in this file must never pass vacuously
+    // against a clear-everything stub.
+    removeRange: async (prefix: StorageKey) => {
+      const exact = prefix.join("/");
+      const rangePrefix = `${exact}/`;
+      const doomed = Array.from(records.keys()).filter(
+        (key) => key === exact || key.startsWith(rangePrefix),
+      );
+      for (const key of doomed) {
+        records.delete(key);
+      }
     },
   };
 }

--- a/apps/notebook-cloud/test/offline-merge-tracker.test.ts
+++ b/apps/notebook-cloud/test/offline-merge-tracker.test.ts
@@ -1,0 +1,288 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+import { OfflineMergeTracker, type OfflineMergeNoticeData } from "../viewer/offline-merge-tracker";
+
+const SETTLE_MS = 1_500;
+
+// Offline edits merge silently today: no signal that local edits
+// interleaved with remote ones, and a cell edited offline that was deleted
+// remotely vanishes wordlessly. The tracker derives ONE quiet notice per
+// outage from existing signals only — and a reconnect with nothing pending
+// must surface nothing at all.
+describe("offline merge tracker", () => {
+  function tracked(projectedCellIds: () => readonly string[] = () => ["cell-a"]) {
+    const notices: OfflineMergeNoticeData[] = [];
+    const tracker = new OfflineMergeTracker({
+      settleMs: SETTLE_MS,
+      getProjectedCellIds: projectedCellIds,
+      onNotice: (notice) => notices.push(notice),
+    });
+    return { notices, tracker };
+  }
+
+  it("fires once after offline edits, recovery, and the settle window", (t) => {
+    t.mock.timers.enable({ apis: ["setTimeout"] });
+    const { notices, tracker } = tracked();
+
+    tracker.noteConnectionStatus("reconnecting");
+    tracker.noteLocalDocActivity();
+    tracker.noteConnectionStatus("online");
+    assert.deepEqual(notices, [], "no notice before the settle window elapses");
+
+    t.mock.timers.tick(SETTLE_MS - 1);
+    assert.deepEqual(notices, []);
+    t.mock.timers.tick(1);
+    assert.equal(notices.length, 1);
+    assert.deepEqual(notices[0], { mergedRemoteCellCount: 0, removedEditedCellCount: 0 });
+    tracker.dispose();
+  });
+
+  it("stays silent on a clean reconnect with nothing pending", (t) => {
+    t.mock.timers.enable({ apis: ["setTimeout"] });
+    const { notices, tracker } = tracked();
+
+    tracker.noteConnectionStatus("reconnecting");
+    tracker.noteConnectionStatus("online");
+    t.mock.timers.tick(60_000);
+    assert.deepEqual(notices, []);
+    tracker.dispose();
+  });
+
+  it("stays silent across pending-free flaps", (t) => {
+    t.mock.timers.enable({ apis: ["setTimeout"] });
+    const { notices, tracker } = tracked();
+
+    for (let i = 0; i < 5; i += 1) {
+      tracker.noteConnectionStatus("reconnecting");
+      tracker.noteConnectionStatus("connecting");
+      tracker.noteConnectionStatus("online");
+    }
+    t.mock.timers.tick(60_000);
+    assert.deepEqual(notices, []);
+    tracker.dispose();
+  });
+
+  it("ignores local doc activity and edits outside the offline window", (t) => {
+    t.mock.timers.enable({ apis: ["setTimeout"] });
+    const { notices, tracker } = tracked();
+
+    // Online edits are ordinary sync, not offline work.
+    tracker.noteLocalDocActivity();
+    tracker.noteLocalCellEdit("cell-a");
+    tracker.noteConnectionStatus("reconnecting");
+    tracker.noteConnectionStatus("online");
+    t.mock.timers.tick(60_000);
+    assert.deepEqual(notices, []);
+    tracker.dispose();
+  });
+
+  it("counts distinct remote-touched cells during the settle window", (t) => {
+    t.mock.timers.enable({ apis: ["setTimeout"] });
+    const { notices, tracker } = tracked();
+
+    tracker.noteConnectionStatus("reconnecting");
+    tracker.noteLocalDocActivity();
+    tracker.noteConnectionStatus("online");
+    tracker.noteRemoteCellChanges({
+      changed: [{ cell_id: "cell-b" }, { cell_id: "cell-c" }],
+      added: ["cell-d"],
+      removed: [],
+    });
+    tracker.noteRemoteCellChanges({
+      changed: [{ cell_id: "cell-b" }], // repeat — deduplicated
+      added: [],
+      removed: ["cell-e"],
+    });
+    t.mock.timers.tick(SETTLE_MS);
+    assert.equal(notices.length, 1);
+    assert.equal(notices[0].mergedRemoteCellCount, 4);
+    tracker.dispose();
+  });
+
+  it("drops the count (null) when a full-materialization changeset is seen", (t) => {
+    t.mock.timers.enable({ apis: ["setTimeout"] });
+    const { notices, tracker } = tracked();
+
+    tracker.noteConnectionStatus("reconnecting");
+    tracker.noteLocalDocActivity();
+    tracker.noteConnectionStatus("online");
+    tracker.noteRemoteCellChanges({ changed: [{ cell_id: "cell-b" }], added: [], removed: [] });
+    tracker.noteRemoteCellChanges(null);
+    tracker.noteRemoteCellChanges({ changed: [{ cell_id: "cell-c" }], added: [], removed: [] });
+    t.mock.timers.tick(SETTLE_MS);
+    assert.equal(notices.length, 1);
+    assert.equal(notices[0].mergedRemoteCellCount, null, "unknowable, never guessed");
+    tracker.dispose();
+  });
+
+  it("ignores remote changesets outside the settle window", (t) => {
+    t.mock.timers.enable({ apis: ["setTimeout"] });
+    const { notices, tracker } = tracked();
+
+    tracker.noteRemoteCellChanges({ changed: [{ cell_id: "cell-x" }], added: [], removed: [] });
+    tracker.noteConnectionStatus("reconnecting");
+    tracker.noteLocalDocActivity();
+    tracker.noteConnectionStatus("online");
+    t.mock.timers.tick(SETTLE_MS);
+    assert.equal(notices.length, 1);
+    assert.equal(notices[0].mergedRemoteCellCount, 0);
+    tracker.dispose();
+  });
+
+  it("reports a cell edited offline that is absent post-resync", (t) => {
+    t.mock.timers.enable({ apis: ["setTimeout"] });
+    const { notices, tracker } = tracked(() => ["cell-a", "cell-b"]);
+
+    tracker.noteConnectionStatus("reconnecting");
+    tracker.noteLocalCellEdit("cell-gone");
+    tracker.noteLocalCellEdit("cell-a"); // still present — not counted
+    tracker.noteConnectionStatus("online");
+    t.mock.timers.tick(SETTLE_MS);
+    assert.equal(notices.length, 1);
+    assert.equal(notices[0].removedEditedCellCount, 1);
+    tracker.dispose();
+  });
+
+  it("an edit alone marks local work pending (flush may land post-resync)", (t) => {
+    t.mock.timers.enable({ apis: ["setTimeout"] });
+    const { notices, tracker } = tracked();
+
+    tracker.noteConnectionStatus("reconnecting");
+    tracker.noteLocalCellEdit("cell-a"); // no noteLocalDocActivity — debounce had not fired
+    tracker.noteConnectionStatus("online");
+    t.mock.timers.tick(SETTLE_MS);
+    assert.equal(notices.length, 1);
+    tracker.dispose();
+  });
+
+  it("does not blame collaborators for the user's own delete", (t) => {
+    t.mock.timers.enable({ apis: ["setTimeout"] });
+    const { notices, tracker } = tracked(() => ["cell-a"]);
+
+    tracker.noteConnectionStatus("reconnecting");
+    tracker.noteLocalCellEdit("cell-gone");
+    tracker.noteLocalCellDelete("cell-gone");
+    tracker.noteLocalDocActivity();
+    tracker.noteConnectionStatus("online");
+    t.mock.timers.tick(SETTLE_MS);
+    assert.equal(notices.length, 1);
+    assert.equal(notices[0].removedEditedCellCount, 0);
+    tracker.dispose();
+  });
+
+  it("distrusts an empty projection instead of reporting mass deletion", (t) => {
+    t.mock.timers.enable({ apis: ["setTimeout"] });
+    const { notices, tracker } = tracked(() => []);
+
+    tracker.noteConnectionStatus("reconnecting");
+    tracker.noteLocalCellEdit("cell-a");
+    tracker.noteConnectionStatus("online");
+    t.mock.timers.tick(SETTLE_MS);
+    assert.equal(notices.length, 1);
+    assert.equal(notices[0].removedEditedCellCount, 0);
+    tracker.dispose();
+  });
+
+  it("a drop during settling resumes the SAME outage and still fires once", (t) => {
+    t.mock.timers.enable({ apis: ["setTimeout"] });
+    const { notices, tracker } = tracked();
+
+    tracker.noteConnectionStatus("reconnecting");
+    tracker.noteLocalCellEdit("cell-gone");
+    tracker.noteConnectionStatus("online");
+    t.mock.timers.tick(SETTLE_MS - 100);
+    tracker.noteConnectionStatus("reconnecting"); // outage resumes pre-settle
+    t.mock.timers.tick(60_000);
+    assert.deepEqual(notices, [], "cancelled settle never fires");
+
+    tracker.noteConnectionStatus("online");
+    t.mock.timers.tick(SETTLE_MS);
+    assert.equal(notices.length, 1, "single notice for the whole outage");
+    tracker.dispose();
+  });
+
+  it("repeated reconnecting deliveries are no-ops within one outage", (t) => {
+    t.mock.timers.enable({ apis: ["setTimeout"] });
+    const { notices, tracker } = tracked();
+
+    tracker.noteConnectionStatus("reconnecting");
+    tracker.noteLocalDocActivity();
+    tracker.noteConnectionStatus("reconnecting");
+    tracker.noteConnectionStatus("connecting");
+    tracker.noteConnectionStatus("reconnecting");
+    tracker.noteConnectionStatus("online");
+    t.mock.timers.tick(SETTLE_MS);
+    assert.equal(notices.length, 1);
+    tracker.dispose();
+  });
+
+  it("firing resets state — the next flap needs fresh pending work", (t) => {
+    t.mock.timers.enable({ apis: ["setTimeout"] });
+    const { notices, tracker } = tracked();
+
+    tracker.noteConnectionStatus("reconnecting");
+    tracker.noteLocalDocActivity();
+    tracker.noteConnectionStatus("online");
+    t.mock.timers.tick(SETTLE_MS);
+    assert.equal(notices.length, 1);
+
+    tracker.noteConnectionStatus("reconnecting");
+    tracker.noteConnectionStatus("online");
+    t.mock.timers.tick(60_000);
+    assert.equal(notices.length, 1, "clean follow-up reconnect stays silent");
+    tracker.dispose();
+  });
+
+  it("terminal manual disconnect clears the window without firing", (t) => {
+    t.mock.timers.enable({ apis: ["setTimeout"] });
+    const { notices, tracker } = tracked();
+
+    tracker.noteConnectionStatus("reconnecting");
+    tracker.noteLocalCellEdit("cell-a");
+    tracker.noteConnectionStatus("offline");
+    tracker.noteConnectionStatus("online");
+    t.mock.timers.tick(60_000);
+    assert.deepEqual(notices, []);
+    tracker.dispose();
+  });
+
+  it("ineligible (anonymous) sessions are inert", (t) => {
+    t.mock.timers.enable({ apis: ["setTimeout"] });
+    const { notices, tracker } = tracked();
+
+    tracker.noteSessionEligibility(false);
+    tracker.noteConnectionStatus("reconnecting");
+    tracker.noteLocalDocActivity();
+    tracker.noteLocalCellEdit("cell-a");
+    tracker.noteConnectionStatus("online");
+    t.mock.timers.tick(60_000);
+    assert.deepEqual(notices, []);
+    tracker.dispose();
+  });
+
+  it("going ineligible mid-window drops tracked state", (t) => {
+    t.mock.timers.enable({ apis: ["setTimeout"] });
+    const { notices, tracker } = tracked();
+
+    tracker.noteConnectionStatus("reconnecting");
+    tracker.noteLocalDocActivity();
+    tracker.noteSessionEligibility(false);
+    tracker.noteSessionEligibility(true);
+    tracker.noteConnectionStatus("online");
+    t.mock.timers.tick(60_000);
+    assert.deepEqual(notices, []);
+    tracker.dispose();
+  });
+
+  it("dispose cancels an armed settle timer", (t) => {
+    t.mock.timers.enable({ apis: ["setTimeout"] });
+    const { notices, tracker } = tracked();
+
+    tracker.noteConnectionStatus("reconnecting");
+    tracker.noteLocalDocActivity();
+    tracker.noteConnectionStatus("online");
+    tracker.dispose();
+    t.mock.timers.tick(60_000);
+    assert.deepEqual(notices, []);
+  });
+});

--- a/apps/notebook-cloud/test/viewer-notices.test.ts
+++ b/apps/notebook-cloud/test/viewer-notices.test.ts
@@ -302,3 +302,130 @@ test("cloud notebook notices keep dev diagnostics inside the shared stack", () =
   assert.match(html, /data-slot="notebook-notice-stack"/);
   assert.match(html, /data-kind="diagnostics"/);
 });
+
+// ── Offline-merge surfacing (local-first ADR, PR 5) ────────────────────
+
+import { offlineMergeNoticeTitle, offlineMergeRemovedCellsLine } from "../viewer/notices";
+
+test("offline merge notice copy drops the suffix when the count is unknown or zero", () => {
+  assert.equal(
+    offlineMergeNoticeTitle({ mergedRemoteCellCount: null, removedEditedCellCount: 0 }),
+    "Synced your offline edits.",
+  );
+  assert.equal(
+    offlineMergeNoticeTitle({ mergedRemoteCellCount: 0, removedEditedCellCount: 0 }),
+    "Synced your offline edits.",
+  );
+  assert.equal(
+    offlineMergeNoticeTitle({ mergedRemoteCellCount: 1, removedEditedCellCount: 0 }),
+    "Synced your offline edits — 1 update from collaborators merged.",
+  );
+  assert.equal(
+    offlineMergeNoticeTitle({ mergedRemoteCellCount: 3, removedEditedCellCount: 0 }),
+    "Synced your offline edits — 3 updates from collaborators merged.",
+  );
+});
+
+test("offline merge removed-cells line appears only for a real removal", () => {
+  assert.equal(offlineMergeRemovedCellsLine(0), null);
+  assert.equal(
+    offlineMergeRemovedCellsLine(1),
+    "A cell you edited offline was removed by a collaborator.",
+  );
+  assert.equal(
+    offlineMergeRemovedCellsLine(2),
+    "2 cells you edited offline were removed by a collaborator.",
+  );
+});
+
+test("cloud notebook notices render the offline merge line as one quiet info notice", () => {
+  assert.equal(
+    cloudNotebookHasNotices({
+      authState: authState("oidc"),
+      authRenewal: { kind: "idle", message: null },
+      connectionError: null,
+      hasAppSession: true,
+      offlineMergeNotice: { mergedRemoteCellCount: 2, removedEditedCellCount: 1 },
+      status: { kind: "ready", message: "Ready" },
+    }),
+    true,
+  );
+
+  const html = renderToStaticMarkup(
+    React.createElement(CloudNotebookNotices, {
+      authState: authState("oidc"),
+      authRenewal: { kind: "idle", message: null },
+      connectionError: null,
+      hasAppSession: true,
+      offlineMergeNotice: { mergedRemoteCellCount: 2, removedEditedCellCount: 1 },
+      status: { kind: "ready", message: "Ready" },
+      onResetAuth: () => {},
+    }),
+  );
+
+  assert.match(html, /data-slot="notebook-notice-stack"/);
+  assert.match(html, /data-tone="info"/);
+  assert.match(html, /Synced your offline edits — 2 updates from collaborators merged\./);
+  assert.match(html, /A cell you edited offline was removed by a collaborator\./);
+  // One quiet notice, no modal-ish chrome: no actions and no error tone.
+  assert.doesNotMatch(html, /data-tone="error"/);
+  assert.doesNotMatch(html, /data-tone="warning"/);
+});
+
+test("offline merge notice omits the removed-cells line when nothing vanished", () => {
+  const html = renderToStaticMarkup(
+    React.createElement(CloudNotebookNotices, {
+      authState: authState("oidc"),
+      authRenewal: { kind: "idle", message: null },
+      connectionError: null,
+      hasAppSession: true,
+      offlineMergeNotice: { mergedRemoteCellCount: null, removedEditedCellCount: 0 },
+      status: { kind: "ready", message: "Ready" },
+      onResetAuth: () => {},
+    }),
+  );
+
+  assert.match(html, /Synced your offline edits\./);
+  assert.doesNotMatch(html, /from collaborators merged/);
+  assert.doesNotMatch(html, /removed by a collaborator/);
+});
+
+test("offline merge notice stacks with (and does not disturb) the reconnect line", () => {
+  // In practice they are sequential — the sustained line clears the moment
+  // the room is back, exactly when the merge notice can first appear — but
+  // the stack must keep both legible if state ever overlaps mid-render.
+  const html = renderToStaticMarkup(
+    React.createElement(CloudNotebookNotices, {
+      authState: authState("oidc"),
+      authRenewal: { kind: "idle", message: null },
+      connectionError: null,
+      hasAppSession: true,
+      offlineMergeNotice: { mergedRemoteCellCount: 0, removedEditedCellCount: 0 },
+      sustainedReconnecting: true,
+      status: { kind: "ready", message: "Ready" },
+      onResetAuth: () => {},
+    }),
+  );
+
+  assert.match(html, /Reconnecting\./);
+  assert.match(html, /Your edits are kept locally/);
+  assert.match(html, /Synced your offline edits\./);
+});
+
+test("no offline merge notice means no offline merge markup", () => {
+  const html = renderToStaticMarkup(
+    React.createElement(CloudNotebookNotices, {
+      authState: authState("oidc"),
+      authRenewal: { kind: "idle", message: null },
+      connectionError: null,
+      hasAppSession: true,
+      offlineMergeNotice: null,
+      sustainedReconnecting: true,
+      status: { kind: "ready", message: "Ready" },
+      onResetAuth: () => {},
+    }),
+  );
+
+  assert.match(html, /Reconnecting\./);
+  assert.doesNotMatch(html, /Synced your offline edits/);
+});

--- a/apps/notebook-cloud/test/viewer-shared-cell-surface.test.ts
+++ b/apps/notebook-cloud/test/viewer-shared-cell-surface.test.ts
@@ -458,9 +458,12 @@ test("cloud live materialization skips empty room handles before resolving outpu
     /status\.kind === "empty" && notebookCellIds\.length === 0 && !emptyRoomGraceElapsed/,
   );
   assert.match(sessionSourceText, /const rawCellCount = liveRuntime\.handle\.cell_count\(\);/);
+  // The zero-cell guard routes through the displacement policy: a painted
+  // notebook blocks the empty apply only until the handle has caught up to
+  // the room (see instant-paint.test.ts for the policy matrix).
   assert.match(
     sessionSourceText,
-    /if \(rawCellCount === 0 && \(!snapshotResolvedRef\.current \|\| materializedCellCount\(\) > 0\)\) \{\s+return;\s+\}\s+const materialized = await materializeCloudNotebookView/,
+    /if \(rawCellCount === 0 && !mayShowEmptyLiveNotebook\(liveRuntime\)\) \{\s+return;\s+\}/,
   );
 });
 

--- a/apps/notebook-cloud/viewer/__tests__/use-offline-merge-notice.test.tsx
+++ b/apps/notebook-cloud/viewer/__tests__/use-offline-merge-notice.test.tsx
@@ -1,0 +1,103 @@
+import { renderHook } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vite-plus/test";
+import type { OfflineMergeNoticeData } from "../offline-merge-tracker";
+import {
+  OFFLINE_MERGE_NOTICE_TIMEOUT_MS,
+  useOfflineMergeNoticeAutoClear,
+} from "../use-offline-merge-notice";
+
+// The tracker fires the notice; this hook owns its retirement. A merge
+// confirmation must clear itself — on the next user action (the user has
+// moved on) or a short timeout — and never demand a dismissal.
+
+const NOTICE: OfflineMergeNoticeData = { mergedRemoteCellCount: 1, removedEditedCellCount: 0 };
+
+describe("useOfflineMergeNoticeAutoClear", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("clears after the timeout", () => {
+    const clear = vi.fn();
+    renderHook(() => useOfflineMergeNoticeAutoClear(NOTICE, clear));
+
+    vi.advanceTimersByTime(OFFLINE_MERGE_NOTICE_TIMEOUT_MS - 1);
+    expect(clear).not.toHaveBeenCalled();
+    vi.advanceTimersByTime(1);
+    expect(clear).toHaveBeenCalledTimes(1);
+  });
+
+  it("clears on the next pointer interaction", () => {
+    const clear = vi.fn();
+    renderHook(() => useOfflineMergeNoticeAutoClear(NOTICE, clear));
+
+    window.dispatchEvent(new Event("pointerdown"));
+    expect(clear).toHaveBeenCalledTimes(1);
+  });
+
+  it("clears on the next key press", () => {
+    const clear = vi.fn();
+    renderHook(() => useOfflineMergeNoticeAutoClear(NOTICE, clear));
+
+    window.dispatchEvent(new KeyboardEvent("keydown", { key: "a" }));
+    expect(clear).toHaveBeenCalledTimes(1);
+  });
+
+  it("does nothing while no notice is shown", () => {
+    const clear = vi.fn();
+    renderHook(() => useOfflineMergeNoticeAutoClear(null, clear));
+
+    window.dispatchEvent(new Event("pointerdown"));
+    window.dispatchEvent(new KeyboardEvent("keydown", { key: "a" }));
+    vi.advanceTimersByTime(OFFLINE_MERGE_NOTICE_TIMEOUT_MS * 2);
+    expect(clear).not.toHaveBeenCalled();
+  });
+
+  it("tears listeners and the timer down once the notice clears", () => {
+    const clear = vi.fn();
+    const { rerender } = renderHook(
+      ({ notice }: { notice: OfflineMergeNoticeData | null }) =>
+        useOfflineMergeNoticeAutoClear(notice, clear),
+      { initialProps: { notice: NOTICE as OfflineMergeNoticeData | null } },
+    );
+
+    rerender({ notice: null });
+    window.dispatchEvent(new Event("pointerdown"));
+    vi.advanceTimersByTime(OFFLINE_MERGE_NOTICE_TIMEOUT_MS * 2);
+    expect(clear).not.toHaveBeenCalled();
+    expect(vi.getTimerCount()).toBe(0);
+  });
+
+  it("tears everything down on unmount", () => {
+    const clear = vi.fn();
+    const { unmount } = renderHook(() => useOfflineMergeNoticeAutoClear(NOTICE, clear));
+
+    unmount();
+    window.dispatchEvent(new Event("pointerdown"));
+    vi.advanceTimersByTime(OFFLINE_MERGE_NOTICE_TIMEOUT_MS * 2);
+    expect(clear).not.toHaveBeenCalled();
+    expect(vi.getTimerCount()).toBe(0);
+  });
+
+  it("a fresh notice restarts the timeout window", () => {
+    const clear = vi.fn();
+    const { rerender } = renderHook(
+      ({ notice }: { notice: OfflineMergeNoticeData | null }) =>
+        useOfflineMergeNoticeAutoClear(notice, clear),
+      { initialProps: { notice: NOTICE as OfflineMergeNoticeData | null } },
+    );
+
+    vi.advanceTimersByTime(OFFLINE_MERGE_NOTICE_TIMEOUT_MS - 1);
+    // A new outage produced a new notice object just before the old timer
+    // would have fired.
+    rerender({ notice: { mergedRemoteCellCount: null, removedEditedCellCount: 1 } });
+    vi.advanceTimersByTime(OFFLINE_MERGE_NOTICE_TIMEOUT_MS - 1);
+    expect(clear).not.toHaveBeenCalled();
+    vi.advanceTimersByTime(1);
+    expect(clear).toHaveBeenCalledTimes(1);
+  });
+});

--- a/apps/notebook-cloud/viewer/cloud-viewer-session.ts
+++ b/apps/notebook-cloud/viewer/cloud-viewer-session.ts
@@ -14,6 +14,7 @@ import { setCrdtCommWriter } from "@/components/widgets/crdt-comm-writer";
 import type { WidgetStore } from "@/components/widgets/widget-store";
 import {
   cloudConnectionErrorAcceptsAccessDiagnostic,
+  cloudConnectionErrorWithAccessDiagnostic,
   diagnoseCloudConnectionAccess,
 } from "./connection-diagnostics";
 import {
@@ -646,7 +647,12 @@ export function useCloudViewerSession({
         })
           .then((diagnostic) => {
             if (disposed || !diagnostic) return;
-            setConnectionError(diagnostic);
+            // Resolution-time guard: this fetch has no deadline, and a
+            // terminal WASM asset failure may own the notice by now — its
+            // Retry affordance must survive the late diagnostic.
+            setConnectionError((current) =>
+              cloudConnectionErrorWithAccessDiagnostic(current, diagnostic),
+            );
           })
           .catch(() => undefined);
       }
@@ -1184,7 +1190,11 @@ export function useCloudViewerSession({
                   message: `Unable to load live notebook room: ${diagnostic}`,
                 });
               }
-              setConnectionError(diagnostic);
+              // Resolution-time sibling of the kick-time guard above: a
+              // WASM failure surfaced meanwhile keeps the notice.
+              setConnectionError((current) =>
+                cloudConnectionErrorWithAccessDiagnostic(current, diagnostic),
+              );
             })
             .catch(() => undefined);
         }

--- a/apps/notebook-cloud/viewer/cloud-viewer-session.ts
+++ b/apps/notebook-cloud/viewer/cloud-viewer-session.ts
@@ -64,6 +64,11 @@ import {
   type CloudNotebookPersistenceController,
 } from "./notebook-persistence";
 import {
+  OFFLINE_MERGE_RESYNC_SETTLE_MS,
+  OfflineMergeTracker,
+  type OfflineMergeNoticeData,
+} from "./offline-merge-tracker";
+import {
   projectCloudCellsIntoNotebookViewStores,
   resetCloudProjectionUnlessPreserved,
   resetCloudViewStoreProjection,
@@ -132,6 +137,17 @@ export interface CloudViewerSession {
   liveRuntimeRef: MutableRefObject<CloudSyncRuntime | null>;
   notebookLanguageRef: MutableRefObject<string>;
   notebookMetadata: unknown;
+  /**
+   * Quiet offline-merge surfacing (notices stack only): set once per outage
+   * after a reconnect completes with locally-authored work pending across
+   * the gap. The viewer clears it on user action or a short timeout.
+   */
+  offlineMergeNotice: OfflineMergeNoticeData | null;
+  clearOfflineMergeNotice: () => void;
+  /** A local source edit reached the handle for this cell (CRDT bridge). */
+  noteLocalCellEdit: (cellId: string) => void;
+  /** The user deleted this cell locally — never a collaborator removal. */
+  noteLocalCellDelete: (cellId: string) => void;
   presenceStore: CloudViewerPresenceStore;
   requestCloudMaterialization: (liveRuntime: CloudSyncRuntime) => void;
   retryLiveConnection: () => void;
@@ -206,6 +222,47 @@ export function useCloudViewerSession({
     connectionStatusBridgeRef.current = new CloudConnectionStatusBridge();
   }
   const connectionStatusBridge = connectionStatusBridgeRef.current;
+  // Offline-merge surfacing: one tracker per session (stable across effect
+  // re-runs and escalation teardowns, like the bridge — an outage that
+  // spans a transport replacement is still ONE outage). It derives
+  // everything from signals that already exist; see offline-merge-tracker.
+  const [offlineMergeNotice, setOfflineMergeNotice] = useState<OfflineMergeNoticeData | null>(null);
+  const offlineMergeTrackerRef = useRef<OfflineMergeTracker | null>(null);
+  if (offlineMergeTrackerRef.current === null) {
+    offlineMergeTrackerRef.current = new OfflineMergeTracker({
+      settleMs: OFFLINE_MERGE_RESYNC_SETTLE_MS,
+      getProjectedCellIds: () => getCellIdsSnapshot(),
+      onNotice: (notice) => setOfflineMergeNotice(notice),
+    });
+  }
+  const offlineMergeTracker = offlineMergeTrackerRef.current;
+  // The bridge replays the current status on subscribe and survives
+  // transport replacement, so one mount-scoped subscription covers every
+  // connect attempt and teardown-retry transition.
+  useEffect(() => {
+    const subscription = connectionStatusBridge.subscribe((connectionStatus) => {
+      offlineMergeTracker.noteConnectionStatus(connectionStatus);
+    });
+    return () => {
+      subscription.unsubscribe();
+      offlineMergeTracker.dispose();
+    };
+  }, [connectionStatusBridge, offlineMergeTracker]);
+  const clearOfflineMergeNotice = useCallback(() => {
+    setOfflineMergeNotice(null);
+  }, []);
+  const noteLocalCellEdit = useCallback(
+    (cellId: string) => {
+      offlineMergeTracker.noteLocalCellEdit(cellId);
+    },
+    [offlineMergeTracker],
+  );
+  const noteLocalCellDelete = useCallback(
+    (cellId: string) => {
+      offlineMergeTracker.noteLocalCellDelete(cellId);
+    },
+    [offlineMergeTracker],
+  );
   const [connectionScope, setConnectionScope] = useState<string | null>(null);
   const [connectionPeerId, setConnectionPeerId] = useState<string | null>(null);
   const [connectionActorLabel, setConnectionActorLabel] = useState<string | null>(null);
@@ -937,6 +994,11 @@ export function useCloudViewerSession({
         liveRuntimeRef.current = liveRuntime;
         installCloudWidgetCommWriter(liveRuntime);
         armPersistence(liveRuntime);
+        // Anonymous sessions are out of scope for offline-merge surfacing
+        // (per-connection principals; persistence never arms for them).
+        offlineMergeTracker.noteSessionEligibility(
+          !isAnonymousCloudPrincipal(cloudPrincipalFromActorLabel(liveRuntime.actorLabel)),
+        );
         const stopWidgetLiveRuntimeDiagnostics =
           installCloudWidgetLiveRuntimeDiagnostics(liveRuntime);
         setConnectionScope(liveRuntime.connectionScope);
@@ -966,6 +1028,11 @@ export function useCloudViewerSession({
             // The persistence principal follows the latest identity;
             // same-principal reconnects keep the controller.
             armPersistence(liveRuntime);
+            // Re-resolution can change the principal mid-session; the
+            // offline-merge eligibility follows the latest identity too.
+            offlineMergeTracker.noteSessionEligibility(
+              !isAnonymousCloudPrincipal(cloudPrincipalFromActorLabel(liveRuntime.actorLabel)),
+            );
           }),
           liveRuntime.engine.broadcasts$.subscribe((payload) => {
             emitBroadcast(payload);
@@ -1010,6 +1077,18 @@ export function useCloudViewerSession({
           }),
           liveRuntime.engine.poolState$.subscribe((state) => {
             setPoolState(state);
+          }),
+          // Offline-merge derivation taps (no new engine observables):
+          // notebookDocChanged$ emissions are local flush attempts while
+          // the offline window is open (no inbound frames offline), and
+          // cellChanges$ is remote-authored by construction (sync_applied
+          // pipeline) — during the settle window it is the collaborator
+          // backlog that interleaved with the user's offline edits.
+          liveRuntime.engine.notebookDocChanged$.subscribe(() => {
+            offlineMergeTracker.noteLocalDocActivity();
+          }),
+          liveRuntime.engine.cellChanges$.subscribe((changeset) => {
+            offlineMergeTracker.noteRemoteCellChanges(changeset);
           }),
           { unsubscribe: () => stopCursorDispatch() },
           { unsubscribe: stopWidgetLiveRuntimeDiagnostics },
@@ -1156,6 +1235,10 @@ export function useCloudViewerSession({
     liveRuntimeRef,
     notebookLanguageRef,
     notebookMetadata,
+    offlineMergeNotice,
+    clearOfflineMergeNotice,
+    noteLocalCellEdit,
+    noteLocalCellDelete,
     presenceStore,
     requestCloudMaterialization,
     retryLiveConnection,

--- a/apps/notebook-cloud/viewer/cloud-viewer-session.ts
+++ b/apps/notebook-cloud/viewer/cloud-viewer-session.ts
@@ -56,7 +56,12 @@ import {
   type CloudSyncRuntime,
   type CloudWebSocketTransport,
 } from "./live-sync";
-import { cloudInstantPaintPrincipalMatcher, resolveCloudInstantPaintHandle } from "./instant-paint";
+import {
+  cloudInstantPaintPrincipalMatcher,
+  cloudNotebookHandleCaughtUp,
+  resolveCloudInstantPaintHandle,
+  shouldDisplayEmptyLiveNotebook,
+} from "./instant-paint";
 import type { CloudViewerLoadingPolicy } from "./loading-policy";
 import { markCloudViewerLoadMilestone } from "./load-milestones";
 import {
@@ -199,6 +204,12 @@ export function useCloudViewerSession({
   const liveRuntimeRef = useRef<CloudSyncRuntime | null>(null);
   const materializeLiveRuntimeRef = useRef<((runtime: CloudSyncRuntime) => void) | null>(null);
   const liveMaterializedRef = useRef(false);
+  // True while the cells in the view stores were last applied by the
+  // instant paint (paint-origin pixels); any live apply clears it. Gates
+  // the live-changeset tail's status labeling and the empty-room
+  // displacement: paint-origin content is never RELABELED as live — it is
+  // replaced (or displaced by authoritative emptiness) wholesale.
+  const paintOriginRef = useRef(false);
   const snapshotResolvedRef = useRef(false);
   // Set when a seeded session's replayed changes were rejected by the room:
   // the next connect attempt must bootstrap (survives the effect re-run).
@@ -511,6 +522,11 @@ export function useCloudViewerSession({
     // escalates.
     const rejectionTracker = new CloudRecoverableRejectionTracker();
     let ranConnectionDiagnostics = false;
+    // One full-materialization kick per runtime when the syncing doc first
+    // catches up to the room's advertised heads (see the notebookSyncApplied$
+    // subscription) — the only path that displaces painted cells when the
+    // room converges with zero cell changes.
+    let caughtUpMaterializeKicked = false;
     // Local-first persistence is fail-open: no IndexedDB (private mode,
     // SSR) means no adapter and the session runs exactly as before.
     const persistenceAdapter = IndexedDbStorageAdapter.create();
@@ -668,14 +684,29 @@ export function useCloudViewerSession({
 
     const materializedCellCount = () => getCellIdsSnapshot().length;
 
+    // Zero-cell guard for both checkpoints below: blocks an empty handle
+    // from blanking painted/preserved cells until the handle has provably
+    // caught up to the room's advertised heads — after which live
+    // emptiness DISPLACES whatever is showing (instant paint included).
+    const mayShowEmptyLiveNotebook = (liveRuntime: CloudSyncRuntime) =>
+      shouldDisplayEmptyLiveNotebook({
+        snapshotResolved: snapshotResolvedRef.current,
+        paintedCellCount: materializedCellCount(),
+        handleCaughtUp: cloudNotebookHandleCaughtUp(liveRuntime.handle),
+      });
+
     const materializeLiveCells = async (liveRuntime: CloudSyncRuntime) => {
       const sequence = ++materializeSequence;
       const previousNotebookLanguage = notebookLanguageRef.current;
       const outputResolutionCache = outputResolutionCacheRef.current;
       const rawCellCount = liveRuntime.handle.cell_count();
-      if (rawCellCount === 0 && (!snapshotResolvedRef.current || materializedCellCount() > 0)) {
+      if (rawCellCount === 0 && !mayShowEmptyLiveNotebook(liveRuntime)) {
         return;
       }
+      // Warm loads: a painted notebook is already on screen as 'ready';
+      // the live pass replaces it in place, so don't demote the status to
+      // a 'loading' notice over fully visible content.
+      const paintedContentShowing = paintOriginRef.current && materializedCellCount() > 0;
       const materialized = await materializeCloudNotebookView(liveRuntime.handle, {
         blobResolver,
         defaultNotebookLanguage: previousNotebookLanguage ?? "python",
@@ -685,24 +716,28 @@ export function useCloudViewerSession({
           onInitialCells(syncCells) {
             if (syncCells.length === 0) return;
             liveMaterializedRef.current = true;
+            paintOriginRef.current = false;
             markCloudViewerLoadMilestone("live-initial-cells");
             preloadSiftWasm(syncCells);
             applyResolvedCells(syncCells);
-            setStatus({
-              kind: "loading",
-              message: `Rendering ${syncCells.length} live cells while resolving output payloads...`,
-            });
+            if (!paintedContentShowing) {
+              setStatus({
+                kind: "loading",
+                message: `Rendering ${syncCells.length} live cells while resolving output payloads...`,
+              });
+            }
           },
           onCellResolved(resolvedCell, _index, progressiveCells) {
             if (progressiveCells.length === 0) return;
             liveMaterializedRef.current = true;
+            paintOriginRef.current = false;
             preloadSiftWasm([resolvedCell]);
             applyResolvedCells(progressiveCells);
           },
         },
       });
       if (materialized.rawCellCount === 0) {
-        if (!snapshotResolvedRef.current || materializedCellCount() > 0) {
+        if (!mayShowEmptyLiveNotebook(liveRuntime)) {
           return;
         }
       }
@@ -722,6 +757,7 @@ export function useCloudViewerSession({
       );
       if (disposed || sequence !== materializeSequence) return;
       liveMaterializedRef.current = true;
+      paintOriginRef.current = false;
       const resolvedCells = materialized.cells;
       preloadSiftWasm(resolvedCells);
       applyResolvedCells(resolvedCells);
@@ -758,6 +794,15 @@ export function useCloudViewerSession({
         if (snapshotResolvedRef.current) {
           setStatus({ kind: "empty", message: "This notebook room has no cells yet." });
         }
+        return;
+      }
+
+      if (paintOriginRef.current) {
+        // Paint-origin cells are still on screen: the full-materialization
+        // fallback above was skipped by the zero-cell guard or has not
+        // applied yet. Never RELABEL the instant paint as live content —
+        // the live status (and the race flag) belong to the apply that
+        // actually replaces or displaces it.
         return;
       }
 
@@ -832,6 +877,7 @@ export function useCloudViewerSession({
               markCloudViewerLoadMilestone("instant-paint-initial-cells");
               preloadSiftWasm(syncCells);
               applyResolvedCells(syncCells);
+              paintOriginRef.current = true;
               setStatus({
                 kind: "loading",
                 message: `Rendering ${syncCells.length} cells from the local snapshot while connecting...`,
@@ -841,6 +887,7 @@ export function useCloudViewerSession({
               if (progressiveCells.length === 0) return;
               preloadSiftWasm([resolvedCell]);
               applyResolvedCells(progressiveCells);
+              paintOriginRef.current = true;
             },
           },
         });
@@ -862,6 +909,7 @@ export function useCloudViewerSession({
         if (!instantPaintFresh()) return;
         preloadSiftWasm(materialized.cells);
         applyResolvedCells(materialized.cells);
+        paintOriginRef.current = true;
         setStatus({
           kind: "ready",
           message: `Rendering ${materialized.cells.length} cells from the locally persisted snapshot while the live room connects.`,
@@ -885,6 +933,12 @@ export function useCloudViewerSession({
     });
     if (!preservedAcrossRuns) {
       paintedNotebookIdentityRef.current = null;
+      // A cleared projection means no live pixels are on screen: the race
+      // flag must not gate the NEXT notebook's instant paint (or its
+      // zero-cell handling) on the previous notebook's materialization,
+      // and nothing paint-origin is showing either.
+      liveMaterializedRef.current = false;
+      paintOriginRef.current = false;
     }
 
     presenceStore.reset();
@@ -1077,6 +1131,19 @@ export function useCloudViewerSession({
           }),
           liveRuntime.engine.poolState$.subscribe((state) => {
             setPoolState(state);
+          }),
+          // The bootstrap exchange can settle with ZERO cellChanges$
+          // emissions — a room at genesis answers the handshake heads-only
+          // — and the changeset stream is the only other trigger for a
+          // full materialization. Once the syncing doc first catches up to
+          // the room's advertised heads, run one full materialization so
+          // live truth INCLUDING EMPTINESS displaces painted or preserved
+          // cells (see the zero-cell guard above).
+          liveRuntime.engine.notebookSyncApplied$.subscribe(() => {
+            if (caughtUpMaterializeKicked) return;
+            if (!cloudNotebookHandleCaughtUp(liveRuntime.handle)) return;
+            caughtUpMaterializeKicked = true;
+            materializeLiveCellsSafely(liveRuntime);
           }),
           // Offline-merge derivation taps (no new engine observables):
           // notebookDocChanged$ emissions are local flush attempts while

--- a/apps/notebook-cloud/viewer/cloud-viewer-session.ts
+++ b/apps/notebook-cloud/viewer/cloud-viewer-session.ts
@@ -1,11 +1,8 @@
 import { useCallback, useEffect, useRef, useState, type MutableRefObject } from "react";
 import {
   IndexedDbStorageAdapter,
-  RUNTIME_STATE_CACHE_KEY_SEGMENT,
   clearPersistedNotebookDoc,
-  clearPersistedNotebookRecord,
   loadPersistedNotebookDoc,
-  loadPersistedNotebookRecord,
   type BlobResolver,
   type CommChanges,
 } from "runtimed";
@@ -58,8 +55,10 @@ import {
 } from "./live-sync";
 import {
   cloudInstantPaintPrincipalMatcher,
+  cloudInstantPaintStorageOptions,
   cloudNotebookHandleCaughtUp,
   resolveCloudInstantPaintHandle,
+  runCloudInstantPaint,
   shouldDisplayEmptyLiveNotebook,
 } from "./instant-paint";
 import type { CloudViewerLoadingPolicy } from "./loading-policy";
@@ -829,95 +828,86 @@ export function useCloudViewerSession({
     // wins: stale cache never overwrites a live materialization, and the
     // live materialization replaces the paint wholesale when sync lands
     // (the preservation gate keeps the paint until then, no blanking).
+    // Sequencing, freshness re-checks, and handle freeing live in
+    // runCloudInstantPaint (under test); this wires the session effects.
     const instantPaintFresh = () => !disposed && !liveMaterializedRef.current;
     const paintFromPersistedSnapshot = async () => {
       if (!persistenceAdapter) return;
-      const resolved = await resolveCloudInstantPaintHandle({
-        // Pre-handshake principal gate from locally stored auth material;
-        // null (no derivable principal) skips the paint entirely.
-        matchesPrincipal: cloudInstantPaintPrincipalMatcher(authState, { hasAppSession }),
-        loadNotebookRecord: () => loadPersistedNotebookDoc(persistenceAdapter, config.notebookId),
-        loadRuntimeStateCacheRecord: () =>
-          loadPersistedNotebookRecord(
-            persistenceAdapter,
-            config.notebookId,
-            RUNTIME_STATE_CACHE_KEY_SEGMENT,
+      await runCloudInstantPaint({
+        resolveHandle: () =>
+          resolveCloudInstantPaintHandle({
+            // Pre-handshake principal gate from locally stored auth
+            // material; null (no derivable principal) skips the paint.
+            matchesPrincipal: cloudInstantPaintPrincipalMatcher(authState, { hasAppSession }),
+            // Record bindings — including that the corrupt-cache clear
+            // targets ONLY the runtime-state-cache record, never the seed.
+            ...cloudInstantPaintStorageOptions(persistenceAdapter, config.notebookId),
+            loadRenderHandle: (notebookBytes, runtimeStateBytes) =>
+              loadRenderSnapshotHandle(
+                notebookBytes,
+                runtimeStateBytes,
+                config.runtimedWasmModulePath,
+                config.runtimedWasmPath,
+              ),
+            shouldContinue: instantPaintFresh,
+            // Asset-load failures do not incriminate the cached bytes:
+            // never clear the cache record for them.
+            isTransientLoadFailure: (error) =>
+              isRuntimedWasmAssetFailure(error instanceof Error ? error.message : String(error)),
+          }),
+        isFresh: instantPaintFresh,
+        materialize: (renderHandle, shouldContinue) =>
+          materializeCloudNotebookView(renderHandle, {
+            blobResolver,
+            defaultNotebookLanguage: notebookLanguageRef.current ?? "python",
+            outputResolutionCache: outputResolutionCacheRef.current,
+            callbacks: {
+              shouldContinue,
+              onInitialCells(syncCells) {
+                if (syncCells.length === 0) return;
+                markCloudViewerLoadMilestone("instant-paint-initial-cells");
+                preloadSiftWasm(syncCells);
+                applyResolvedCells(syncCells);
+                paintOriginRef.current = true;
+                setStatus({
+                  kind: "loading",
+                  message: `Rendering ${syncCells.length} cells from the local snapshot while connecting...`,
+                });
+              },
+              onCellResolved(resolvedCell, _index, progressiveCells) {
+                if (progressiveCells.length === 0) return;
+                preloadSiftWasm([resolvedCell]);
+                applyResolvedCells(progressiveCells);
+                paintOriginRef.current = true;
+              },
+            },
+          }),
+        acceptMetadata: (materialized) => {
+          notebookLanguageRef.current = materialized.notebookLanguage;
+          setNotebookMetadata(materialized.metadata);
+        },
+        projectWidgets: (materialized, shouldContinue) =>
+          projectCloudWidgetComms(
+            widgetStore,
+            materialized.widgetComms,
+            projectedWidgetCommIdsRef,
+            {
+              isAllowedBlobUrl: (url) => isConfiguredBlobUrl(url, config.blobBasePath),
+              shouldContinue,
+            },
           ),
-        clearRuntimeStateCacheRecord: () =>
-          clearPersistedNotebookRecord(
-            persistenceAdapter,
-            config.notebookId,
-            RUNTIME_STATE_CACHE_KEY_SEGMENT,
-          ),
-        loadRenderHandle: (notebookBytes, runtimeStateBytes) =>
-          loadRenderSnapshotHandle(
-            notebookBytes,
-            runtimeStateBytes,
-            config.runtimedWasmModulePath,
-            config.runtimedWasmPath,
-          ),
-        shouldContinue: instantPaintFresh,
-        // Asset-load failures do not incriminate the cached bytes: never
-        // clear the cache record for them.
-        isTransientLoadFailure: (error) =>
-          isRuntimedWasmAssetFailure(error instanceof Error ? error.message : String(error)),
+        applyPaint: (materialized) => {
+          preloadSiftWasm(materialized.cells);
+          applyResolvedCells(materialized.cells);
+          paintOriginRef.current = true;
+          setStatus({
+            kind: "ready",
+            message: `Rendering ${materialized.cells.length} cells from the locally persisted snapshot while the live room connects.`,
+          });
+          markCloudViewerLoadMilestone("instant-paint-ready");
+        },
+        freeHandle: (renderHandle) => renderHandle.free(),
       });
-      const renderHandle = resolved.handle;
-      if (!renderHandle) return;
-      try {
-        if (!instantPaintFresh()) return;
-        const materialized = await materializeCloudNotebookView(renderHandle, {
-          blobResolver,
-          defaultNotebookLanguage: notebookLanguageRef.current ?? "python",
-          outputResolutionCache: outputResolutionCacheRef.current,
-          callbacks: {
-            shouldContinue: instantPaintFresh,
-            onInitialCells(syncCells) {
-              if (syncCells.length === 0) return;
-              markCloudViewerLoadMilestone("instant-paint-initial-cells");
-              preloadSiftWasm(syncCells);
-              applyResolvedCells(syncCells);
-              paintOriginRef.current = true;
-              setStatus({
-                kind: "loading",
-                message: `Rendering ${syncCells.length} cells from the local snapshot while connecting...`,
-              });
-            },
-            onCellResolved(resolvedCell, _index, progressiveCells) {
-              if (progressiveCells.length === 0) return;
-              preloadSiftWasm([resolvedCell]);
-              applyResolvedCells(progressiveCells);
-              paintOriginRef.current = true;
-            },
-          },
-        });
-        if (!instantPaintFresh()) return;
-        // An empty persisted snapshot paints nothing: the room decides
-        // what an empty notebook means.
-        if (materialized.cells.length === 0) return;
-        notebookLanguageRef.current = materialized.notebookLanguage;
-        setNotebookMetadata(materialized.metadata);
-        await projectCloudWidgetComms(
-          widgetStore,
-          materialized.widgetComms,
-          projectedWidgetCommIdsRef,
-          {
-            isAllowedBlobUrl: (url) => isConfiguredBlobUrl(url, config.blobBasePath),
-            shouldContinue: instantPaintFresh,
-          },
-        );
-        if (!instantPaintFresh()) return;
-        preloadSiftWasm(materialized.cells);
-        applyResolvedCells(materialized.cells);
-        paintOriginRef.current = true;
-        setStatus({
-          kind: "ready",
-          message: `Rendering ${materialized.cells.length} cells from the locally persisted snapshot while the live room connects.`,
-        });
-        markCloudViewerLoadMilestone("instant-paint-ready");
-      } finally {
-        renderHandle.free();
-      }
     };
 
     // Notebook-switch gate (desktop beforeBootstrap placement): the effect

--- a/apps/notebook-cloud/viewer/collaborator-auth.ts
+++ b/apps/notebook-cloud/viewer/collaborator-auth.ts
@@ -579,6 +579,13 @@ function base64UrlEncode(value: string): string {
   return btoa(binary).replaceAll("+", "-").replaceAll("/", "_").replaceAll("=", "");
 }
 
-function devPrincipalLabel(user: string): string {
+/**
+ * Client-side mirror of the worker's `principalForDevUser`
+ * (src/identity.ts): `user:dev:<encodePrincipalComponent(user)>` where the
+ * encoder is `encodeURIComponent`. The single client-side definition —
+ * auth diagnostics and the instant-paint principal matcher both derive
+ * the dev principal from here so the two cannot drift apart.
+ */
+export function devPrincipalLabel(user: string): string {
   return `user:dev:${encodeURIComponent(user.trim() || "browser-editor")}`;
 }

--- a/apps/notebook-cloud/viewer/connection-diagnostics.ts
+++ b/apps/notebook-cloud/viewer/connection-diagnostics.ts
@@ -24,6 +24,25 @@ export function cloudConnectionErrorAcceptsAccessDiagnostic(message: string): bo
   return !isRuntimedWasmAssetFailure(message);
 }
 
+/**
+ * Merge a LATE-resolving access diagnostic into the connection error that
+ * is current at resolution time. Guarding only at kick time is not
+ * enough: `diagnoseCloudConnectionAccess` has no deadline, and by the
+ * time it resolves a terminal WASM asset failure may own the notice — its
+ * Retry affordance must not be replaced with auth-flavored copy whose
+ * "Use anonymous" action can destroy a signed-in session without fixing
+ * the asset load.
+ */
+export function cloudConnectionErrorWithAccessDiagnostic(
+  current: string | null,
+  diagnostic: string,
+): string {
+  if (current !== null && !cloudConnectionErrorAcceptsAccessDiagnostic(current)) {
+    return current;
+  }
+  return diagnostic;
+}
+
 export interface DiagnoseCloudConnectionAccessOptions {
   accessRequestsEndpoint: string;
   authState: CloudPrototypeAuthState;

--- a/apps/notebook-cloud/viewer/instant-paint.ts
+++ b/apps/notebook-cloud/viewer/instant-paint.ts
@@ -59,6 +59,21 @@ const DEV_PRINCIPAL_PREFIX = "user:dev:";
  *   as the principal's id segment and rejects the namespaces it cannot
  *   belong to (anonymous, dev).
  *
+ * HEURISTIC, deliberately weaker than the post-handshake guard. The
+ * full-principal equality check in `resolveCloudNotebookHandle` compares
+ * against the handshake's actual principal; this matcher cannot, because
+ * the OIDC namespace is server configuration that is not client-derivable
+ * before the first handshake. Its namespace-agnostic id-segment match is
+ * sound today only because browser-written records carry exactly one of:
+ * `user:dev:*` (rejected here unless dev-derived), the deployment's
+ * single OIDC/API-key namespace, or anonymous (never persisted at all).
+ * Adding a browser-reachable auth provider whose subject space overlaps
+ * the OIDC sub space widens this match — revisit then. The backstops if
+ * it ever false-positives: the post-handshake guard clears the mismatched
+ * seed, the live materialization replaces the paint wholesale, and an
+ * authoritative EMPTY room displaces it too (the zero-cell guard's
+ * caught-up displacement) — a foreign paint cannot outlive the handshake.
+ *
  * Anonymous principals never match any matcher: they are per-connection
  * nonces and persisted records are never written for them anyway.
  */

--- a/apps/notebook-cloud/viewer/instant-paint.ts
+++ b/apps/notebook-cloud/viewer/instant-paint.ts
@@ -88,6 +88,48 @@ export function cloudInstantPaintPrincipalMatcher(
   return null;
 }
 
+/**
+ * Zero-cell displacement policy for the live materialization path.
+ *
+ * An empty SYNCING handle usually means the bootstrap exchange has not
+ * delivered the room's content yet, and applying it would blank a painted
+ * (instant paint) or preserved notebook — so a zero-cell materialization
+ * is skipped while cells are showing. But once the handle has provably
+ * caught up to the room's advertised heads, zero cells IS the room's
+ * truth: live emptiness must displace whatever is showing. This is the
+ * principal-matcher heuristic's backstop — a false-positive paint must
+ * not outlive the handshake, even over a room with nothing to send. With
+ * nothing painted, the empty state may always show once the pinned
+ * snapshot path has resolved.
+ */
+export function shouldDisplayEmptyLiveNotebook({
+  snapshotResolved,
+  paintedCellCount,
+  handleCaughtUp,
+}: {
+  snapshotResolved: boolean;
+  paintedCellCount: number;
+  handleCaughtUp: boolean;
+}): boolean {
+  if (!snapshotResolved) return false;
+  return paintedCellCount === 0 || handleCaughtUp;
+}
+
+/**
+ * `notebook_doc_caught_up()` with deployed-handle tolerance: an older WASM
+ * bundle without the export reports not-caught-up, degrading to the
+ * previous behavior (painted cells are never displaced by emptiness).
+ */
+export function cloudNotebookHandleCaughtUp(handle: {
+  notebook_doc_caught_up?: () => boolean;
+}): boolean {
+  try {
+    return handle.notebook_doc_caught_up?.() ?? false;
+  } catch {
+    return false;
+  }
+}
+
 export type CloudInstantPaintOutcome =
   | "painted"
   | "painted_cells_only"

--- a/apps/notebook-cloud/viewer/instant-paint.ts
+++ b/apps/notebook-cloud/viewer/instant-paint.ts
@@ -26,8 +26,15 @@
  * NotebookDoc seed record (which may hold offline edits).
  */
 
-import type { PersistedNotebookDoc } from "runtimed";
-import type { CloudPrototypeAuthState } from "./collaborator-auth";
+import {
+  RUNTIME_STATE_CACHE_KEY_SEGMENT,
+  clearPersistedNotebookRecord,
+  loadPersistedNotebookDoc,
+  loadPersistedNotebookRecord,
+  type PersistedNotebookDoc,
+  type StorageAdapter,
+} from "runtimed";
+import { devPrincipalLabel, type CloudPrototypeAuthState } from "./collaborator-auth";
 import { isAnonymousCloudPrincipal, withReadyTimeout } from "./live-sync";
 
 /**
@@ -37,15 +44,6 @@ import { isAnonymousCloudPrincipal, withReadyTimeout } from "./live-sync";
 const INSTANT_PAINT_READ_TIMEOUT_MS = 2_000;
 
 const DEV_PRINCIPAL_PREFIX = "user:dev:";
-
-/**
- * Mirrors the worker's `principalForDevUser` (src/identity.ts):
- * `user:dev:<encodePrincipalComponent(user)>`, where the encoder is
- * `encodeURIComponent`.
- */
-function devPrincipalForUser(user: string): string {
-  return `${DEV_PRINCIPAL_PREFIX}${encodeURIComponent(user.trim() || "browser-editor")}`;
-}
 
 /**
  * Derive a principal matcher from locally stored auth material, WITHOUT
@@ -69,7 +67,7 @@ export function cloudInstantPaintPrincipalMatcher(
   options: { hasAppSession?: boolean } = {},
 ): ((principal: string) => boolean) | null {
   if (authState.mode === "dev" && authState.token) {
-    const expected = devPrincipalForUser(authState.user ?? "browser-editor");
+    const expected = devPrincipalLabel(authState.user ?? "browser-editor");
     return (principal) => !isAnonymousCloudPrincipal(principal) && principal === expected;
   }
 
@@ -158,9 +156,13 @@ export interface CloudInstantPaintOptions<Handle> {
     runtimeStateBytes: Uint8Array | undefined,
   ) => Promise<Handle>;
   /**
-   * Race guard: re-checked after every await. A live materialization that
-   * wins the race against the cache read flips this to false and the
-   * paint is skipped — stale cache must never overwrite live pixels.
+   * Race guard: re-checked after every await that precedes a paintable
+   * decision or a destructive step (the cache-record clear). A handle may
+   * still be returned after a late flip — callers must re-check before
+   * materializing and must always free the handle. A live materialization
+   * that wins the race flips this to false and the paint is skipped —
+   * stale cache must never overwrite live pixels, and a stale ATTEMPT
+   * must never clear a record the live session may have just rewritten.
    */
   shouldContinue?: () => boolean;
   /**
@@ -238,6 +240,13 @@ export async function resolveCloudInstantPaintHandle<Handle>({
     return { handle, outcome: runtimeStateBytes ? "painted" : "painted_cells_only" };
   } catch (error) {
     if (runtimeStateBytes && !isTransientLoadFailure(error)) {
+      // Seconds can elapse inside loadRenderHandle (the WASM init ladder),
+      // and the clear decision was made against the OLD bytes: a stale
+      // attempt must not delete a fresh record the live session's save
+      // loop may have just written under the same key.
+      if (!shouldContinue()) {
+        return { handle: null, outcome: "skipped_superseded" };
+      }
       // load_snapshot rejected with cache bytes in play: treat the cache
       // as corrupt, clear ONLY that record, and retry cells-only — the
       // notebook envelope may be fine.
@@ -273,5 +282,102 @@ async function clearCacheRecord(clear: () => Promise<void>): Promise<void> {
     await clear();
   } catch (error) {
     console.warn("[notebook-cloud] failed to clear runtime-state cache record", error);
+  }
+}
+
+/**
+ * The instant paint's storage bindings: which record each resolver
+ * dependency reads, and — load-bearing — that the corrupt-cache clear
+ * targets ONLY `[notebookId, "runtime-state-cache"]`. The NotebookDoc
+ * seed record may hold the only copy of offline edits; a paint-side
+ * clear must never be able to touch it. Built here (not inline in the
+ * session) so the binding is testable against a real adapter.
+ */
+export function cloudInstantPaintStorageOptions(
+  adapter: StorageAdapter,
+  notebookId: string,
+): Pick<
+  CloudInstantPaintOptions<never>,
+  "loadNotebookRecord" | "loadRuntimeStateCacheRecord" | "clearRuntimeStateCacheRecord"
+> {
+  return {
+    loadNotebookRecord: () => loadPersistedNotebookDoc(adapter, notebookId),
+    loadRuntimeStateCacheRecord: () =>
+      loadPersistedNotebookRecord(adapter, notebookId, RUNTIME_STATE_CACHE_KEY_SEGMENT),
+    clearRuntimeStateCacheRecord: () =>
+      clearPersistedNotebookRecord(adapter, notebookId, RUNTIME_STATE_CACHE_KEY_SEGMENT),
+  };
+}
+
+export type CloudInstantPaintRunOutcome = CloudInstantPaintOutcome | "skipped_empty_snapshot";
+
+export interface CloudInstantPaintRunOptions<Handle, Materialized extends { cells: unknown[] }> {
+  /** Typically `resolveCloudInstantPaintHandle` — yields the throwaway handle. */
+  resolveHandle: () => Promise<ResolvedCloudInstantPaint<Handle>>;
+  /**
+   * The freshness flag (`!disposed && !liveMaterialized`). Re-checked here
+   * after EVERY await: a live materialization that lands first — or while
+   * the cache decodes, materializes, or projects widgets — wins, and no
+   * later step applies stale cache over it.
+   */
+  isFresh: () => boolean;
+  /**
+   * Progressive materialization of the render handle. Receives the
+   * freshness flag for its progressive-apply callbacks (`shouldContinue`).
+   */
+  materialize: (handle: Handle, shouldContinue: () => boolean) => Promise<Materialized>;
+  /** Synchronous adoption of notebook language + metadata. */
+  acceptMetadata: (materialized: Materialized) => void;
+  /** Async widget-comm projection; receives the freshness flag. */
+  projectWidgets: (materialized: Materialized, shouldContinue: () => boolean) => Promise<void>;
+  /** Final wholesale apply + status + milestone. Only invoked while fresh. */
+  applyPaint: (materialized: Materialized) => void;
+  /** Free the throwaway handle; runs whenever a handle was resolved. */
+  freeHandle: (handle: Handle) => void;
+}
+
+/**
+ * Drive one instant-paint attempt end to end: resolve the throwaway
+ * handle, materialize it, project widget comms, apply the final cells —
+ * with the freshness re-check between every step and the handle freed on
+ * every exit path. The session injects its store/status effects; the
+ * sequencing and the race guard live here, under test.
+ */
+export async function runCloudInstantPaint<Handle, Materialized extends { cells: unknown[] }>({
+  resolveHandle,
+  isFresh,
+  materialize,
+  acceptMetadata,
+  projectWidgets,
+  applyPaint,
+  freeHandle,
+}: CloudInstantPaintRunOptions<Handle, Materialized>): Promise<CloudInstantPaintRunOutcome> {
+  const resolved = await resolveHandle();
+  const handle = resolved.handle;
+  if (handle === null) {
+    return resolved.outcome;
+  }
+  try {
+    if (!isFresh()) {
+      return "skipped_superseded";
+    }
+    const materialized = await materialize(handle, isFresh);
+    if (!isFresh()) {
+      return "skipped_superseded";
+    }
+    if (materialized.cells.length === 0) {
+      // An empty persisted snapshot paints nothing: the room decides what
+      // an empty notebook means.
+      return "skipped_empty_snapshot";
+    }
+    acceptMetadata(materialized);
+    await projectWidgets(materialized, isFresh);
+    if (!isFresh()) {
+      return "skipped_superseded";
+    }
+    applyPaint(materialized);
+    return resolved.outcome;
+  } finally {
+    freeHandle(handle);
   }
 }

--- a/apps/notebook-cloud/viewer/notebook-viewer.tsx
+++ b/apps/notebook-cloud/viewer/notebook-viewer.tsx
@@ -72,6 +72,7 @@ import { markCloudViewerLoadMilestone } from "./load-milestones";
 import { cloudPresenceHasRuntimePeer, cloudPresenceRuntimePeerCount } from "./presence";
 import type { ResolvedCell } from "./render-resolution";
 import { CloudNotebookNotices, cloudNotebookHasNotices } from "./notices";
+import { useOfflineMergeNoticeAutoClear } from "./use-offline-merge-notice";
 import { useSustainedReconnecting } from "./use-sustained-reconnecting";
 import type { ViewerStatus } from "./notice-types";
 import type { CloudNotebookAccessRequest } from "./sharing-client";
@@ -207,6 +208,10 @@ export function NotebookViewer({
     liveRuntimeRef,
     notebookLanguageRef,
     notebookMetadata,
+    offlineMergeNotice,
+    clearOfflineMergeNotice,
+    noteLocalCellEdit,
+    noteLocalCellDelete,
     presenceStore,
     requestCloudMaterialization,
     retryLiveConnection,
@@ -235,6 +240,9 @@ export function NotebookViewer({
   // dot by design, so once "reconnecting" outlives the debounce the notices
   // stack carries the one calm line (and clears it when the room is back).
   const sustainedReconnecting = useSustainedReconnecting(connectionStatus$);
+  // The offline-merge notice is a confirmation, not a warning: it clears on
+  // the next user action or a short timeout, never demanding a dismissal.
+  useOfflineMergeNoticeAutoClear(offlineMergeNotice, clearOfflineMergeNotice);
   // Shared renderer-bundle state from the root IsolatedRendererProvider
   // (CloudNotebookProviders): drives the single asset-health notice below.
   const isolatedRenderer = useIsolatedRenderer();
@@ -452,9 +460,12 @@ export function NotebookViewer({
   );
   const handleCloudDeleteCell = useCallback(
     (cellId: string) => {
+      // The user's own delete must never read as a collaborator removal in
+      // the offline-merge notice.
+      noteLocalCellDelete(cellId);
       cloudNotebookController.deleteCell(cellId);
     },
-    [cloudNotebookController],
+    [cloudNotebookController, noteLocalCellDelete],
   );
   const handleCloudMoveCell = useCallback(
     (cellId: string, afterCellId?: string | null) => {
@@ -614,10 +625,19 @@ export function NotebookViewer({
         : null,
     [connectionPeerId],
   );
-  const handleSourceSyncNeeded = useCallback(() => {
-    if (!shellCapabilities.canEditCells && !shellCapabilities.canEditMarkdown) return;
-    liveRuntimeRef.current?.engine.scheduleFlush();
-  }, [shellCapabilities.canEditCells, shellCapabilities.canEditMarkdown]);
+  const handleSourceSyncNeeded = useCallback(
+    (cellId?: string) => {
+      if (!shellCapabilities.canEditCells && !shellCapabilities.canEditMarkdown) return;
+      if (cellId) {
+        // Offline-merge tracking: the bridge only signals after a real
+        // handle mutation, so this is an honest "this cell carried a local
+        // edit" fact (counted only while the offline window is open).
+        noteLocalCellEdit(cellId);
+      }
+      liveRuntimeRef.current?.engine.scheduleFlush();
+    },
+    [shellCapabilities.canEditCells, shellCapabilities.canEditMarkdown, noteLocalCellEdit],
+  );
   const resetPrototypeAuth = useCallback(() => {
     void clearCloudAppSession().catch((error: unknown) => {
       console.warn("[notebook-cloud] app session clear failed", error);
@@ -936,6 +956,7 @@ export function NotebookViewer({
     diagnostics: accessRequestNotice,
     hasAppSession: Boolean(appSessionStatus.session),
     hasReadableSnapshot: notebookHasReadableSnapshot,
+    offlineMergeNotice,
     rendererAssetError,
     sustainedReconnecting,
     status: noticeStatus,
@@ -948,6 +969,7 @@ export function NotebookViewer({
       diagnostics={accessRequestNotice}
       hasAppSession={Boolean(appSessionStatus.session)}
       hasReadableSnapshot={notebookHasReadableSnapshot}
+      offlineMergeNotice={offlineMergeNotice}
       rendererAssetError={rendererAssetError}
       sustainedReconnecting={sustainedReconnecting}
       status={noticeStatus}

--- a/apps/notebook-cloud/viewer/notices.tsx
+++ b/apps/notebook-cloud/viewer/notices.tsx
@@ -1,5 +1,5 @@
 import type { ReactNode } from "react";
-import { AlertCircle, CloudOff, ImageOff, Loader2, LogIn, RotateCcw } from "lucide-react";
+import { AlertCircle, Cloud, CloudOff, ImageOff, Loader2, LogIn, RotateCcw } from "lucide-react";
 import {
   NotebookNotice,
   NotebookNoticeAction,
@@ -14,6 +14,7 @@ import {
 } from "./connection-diagnostics";
 import { isRuntimedWasmAssetFailure } from "./runtimed-wasm-failure";
 import type { CloudAuthRenewalState, ViewerStatus } from "./notice-types";
+import type { OfflineMergeNoticeData } from "./offline-merge-tracker";
 
 export interface CloudNotebookNoticesProps {
   authState: CloudPrototypeAuthState;
@@ -29,6 +30,15 @@ export interface CloudNotebookNoticesProps {
    * real outage surfaces one calm sentence.
    */
   sustainedReconnecting?: boolean;
+  /**
+   * One quiet line per outage after a reconnect completed with
+   * locally-authored work pending across the gap (offline-merge tracker).
+   * Cleared by the next user action or a short timeout; a reconnect with
+   * nothing pending never sets it. Coexists with the sustained-reconnecting
+   * line naturally: that one clears the moment the room is back, exactly
+   * when this one can first appear.
+   */
+  offlineMergeNotice?: OfflineMergeNoticeData | null;
   status: ViewerStatus;
   diagnostics?: ReactNode;
   /**
@@ -89,6 +99,7 @@ export function cloudNotebookHasNotices({
   connectionError,
   hasAppSession = false,
   hasReadableSnapshot = false,
+  offlineMergeNotice = null,
   rendererAssetError = null,
   sustainedReconnecting = false,
   status,
@@ -110,6 +121,7 @@ export function cloudNotebookHasNotices({
     shouldShowAuthNotice ||
     shouldShowAuthRenewalNotice ||
     sustainedReconnecting ||
+    Boolean(offlineMergeNotice) ||
     Boolean(connectionNotice) ||
     Boolean(rendererAssetError) ||
     Boolean(diagnostics) ||
@@ -123,6 +135,7 @@ export function CloudNotebookNotices({
   connectionError,
   hasAppSession = false,
   hasReadableSnapshot = false,
+  offlineMergeNotice = null,
   rendererAssetError = null,
   sustainedReconnecting = false,
   status,
@@ -139,6 +152,7 @@ export function CloudNotebookNotices({
       connectionError,
       hasAppSession,
       hasReadableSnapshot,
+      offlineMergeNotice,
       rendererAssetError,
       sustainedReconnecting,
       status,
@@ -196,6 +210,16 @@ export function CloudNotebookNotices({
       {sustainedReconnecting ? (
         <NotebookNotice tone="info" icon={<CloudOff className="h-4 w-4" />} title="Reconnecting.">
           Your edits are kept locally and will sync when the connection returns.
+        </NotebookNotice>
+      ) : null}
+
+      {offlineMergeNotice ? (
+        <NotebookNotice
+          tone="info"
+          icon={<Cloud className="h-4 w-4" />}
+          title={offlineMergeNoticeTitle(offlineMergeNotice)}
+        >
+          {offlineMergeRemovedCellsLine(offlineMergeNotice.removedEditedCellCount)}
         </NotebookNotice>
       ) : null}
 
@@ -330,6 +354,36 @@ function ConnectionNoticeAction({
   // signed-in session for errors auth could never fix. With no retry wired,
   // the notice text stands on its own.
   return null;
+}
+
+/**
+ * Calm one-liner for the offline-merge notice. The collaborator suffix
+ * appears only when the count is known AND non-zero — a null count means a
+ * full-materialization changeset made it unknowable, and the quiet rules
+ * say drop the suffix rather than guess.
+ */
+export function offlineMergeNoticeTitle(notice: OfflineMergeNoticeData): string {
+  const count = notice.mergedRemoteCellCount;
+  if (count === null || count === 0) {
+    return "Synced your offline edits.";
+  }
+  const noun = count === 1 ? "update" : "updates";
+  return `Synced your offline edits — ${count} ${noun} from collaborators merged.`;
+}
+
+/**
+ * The sharp edge, stated once and plainly: a cell that carried offline
+ * edits is gone from the post-resync notebook. Automerge does not
+ * resurrect it, so the user deserves one line saying where the work went.
+ */
+export function offlineMergeRemovedCellsLine(removedEditedCellCount: number): string | null {
+  if (removedEditedCellCount <= 0) {
+    return null;
+  }
+  if (removedEditedCellCount === 1) {
+    return "A cell you edited offline was removed by a collaborator.";
+  }
+  return `${removedEditedCellCount} cells you edited offline were removed by a collaborator.`;
 }
 
 function isStatusDerivedFromConnectionError(

--- a/apps/notebook-cloud/viewer/offline-merge-tracker.ts
+++ b/apps/notebook-cloud/viewer/offline-merge-tracker.ts
@@ -1,0 +1,240 @@
+import type { ConnectionStatus } from "runtimed";
+
+/**
+ * How long after a reconnect completes ("online") the tracker waits before
+ * evaluating the merge outcome. The post-reconnect re-establish
+ * (`resetAndResync`) pulls the away-window backlog through `sync_applied`
+ * and the projection re-materializes shortly after; evaluating immediately
+ * would read a pre-merge cell set and miss the remote backlog entirely.
+ */
+export const OFFLINE_MERGE_RESYNC_SETTLE_MS = 1_500;
+
+/**
+ * Structural slice of the engine's `CellChangeset` the tracker consumes
+ * (`SyncEngine.cellChanges$`). `null` mirrors the engine contract: a full
+ * materialization is needed and per-cell attribution is unknowable.
+ */
+export interface OfflineMergeCellChangeset {
+  changed: ReadonlyArray<{ cell_id: string }>;
+  added: readonly string[];
+  removed: readonly string[];
+}
+
+export interface OfflineMergeNoticeData {
+  /**
+   * Distinct cells touched by remote changes applied during the resync
+   * window. `null` means unknowable (a full-materialization changeset was
+   * seen) — render no count rather than guess.
+   */
+  mergedRemoteCellCount: number | null;
+  /**
+   * Cells that carried local edits during the offline window but are
+   * absent from the post-resync projection — edited offline, removed by a
+   * collaborator (Automerge does not resurrect them).
+   */
+  removedEditedCellCount: number;
+}
+
+export interface OfflineMergeTrackerOptions {
+  /** Post-recovery settle window before the notice fires. */
+  settleMs: number;
+  /** Current projected cell ids (the store the user actually sees). */
+  getProjectedCellIds: () => readonly string[];
+  /** Fires AT MOST once per outage, only when local work was pending. */
+  onNotice: (notice: OfflineMergeNoticeData) => void;
+}
+
+/**
+ * Derive "your offline edits just merged" from signals that already exist —
+ * no new engine observables, no second diff:
+ *
+ * - `connectionStatus$` (via the session's stable bridge) bounds the
+ *   offline window: it opens on "reconnecting" and closes on "online".
+ *   "connecting" is neutral, mirroring `SustainedReconnectingTracker` — a
+ *   replacement transport reports it before its first handshake.
+ * - Local authorship during the window comes from two unambiguous sources:
+ *   `notebookDocChanged$` emissions (while offline no inbound frame can
+ *   fire the `sync_applied` source, so every emission is a local flush
+ *   attempt — and offline flush attempts are exactly the pending edits) and
+ *   the CRDT bridge's per-cell sync callbacks (which also supply the cell
+ *   ids the deleted-while-edited check needs).
+ * - Remote authorship after recovery comes from `cellChanges$`, which is
+ *   fed exclusively by the `sync_applied` pipeline: during the settle
+ *   window its changesets are the collaborator backlog that interleaved
+ *   with the user's offline edits.
+ *
+ * Single-fire discipline (the sustained-reconnecting debounce pattern,
+ * extended): repeated "reconnecting" deliveries are no-ops; a drop during
+ * the settle window cancels the pending evaluation and resumes the SAME
+ * outage (accumulated state intact); only a recovery whose settle window
+ * elapses fires, once, and firing resets everything. A reconnect with
+ * nothing pending resets silently — flaps surface nothing.
+ *
+ * Out of scope here (recorded in the local-first ADR): cross-reload seeded
+ * offline edits (every signed-in reload seeds from the persisted record, so
+ * "seeded" alone cannot distinguish offline work from a routine reload
+ * without room heads in the handshake) and edits made in the zombie-socket
+ * seconds before the transport notices a drop.
+ */
+export class OfflineMergeTracker {
+  private phase: "idle" | "offline" | "settling" = "idle";
+  private eligible = true;
+  private pendingLocalFlush = false;
+  private readonly offlineEditedCellIds = new Set<string>();
+  /** null = a full-materialization changeset made the count unknowable. */
+  private remoteChangedCellIds: Set<string> | null = new Set();
+  private settleTimer: ReturnType<typeof setTimeout> | null = null;
+
+  constructor(private readonly options: OfflineMergeTrackerOptions) {}
+
+  /**
+   * Anonymous sessions are out of scope (their principals are
+   * per-connection and persistence never arms for them); the session
+   * reports eligibility whenever the connection identity (re)resolves.
+   * Going ineligible drops all tracked state.
+   */
+  noteSessionEligibility(eligible: boolean): void {
+    if (this.eligible === eligible) return;
+    this.eligible = eligible;
+    if (!eligible) {
+      this.reset();
+    }
+  }
+
+  noteConnectionStatus(status: ConnectionStatus): void {
+    if (!this.eligible) return;
+    if (status === "reconnecting") {
+      if (this.phase === "settling") {
+        // The outage resumed before the settle window elapsed: same
+        // outage, same accumulated state, no notice yet.
+        this.clearSettleTimer();
+        this.phase = "offline";
+        return;
+      }
+      if (this.phase === "idle") {
+        this.phase = "offline";
+      }
+      return;
+    }
+    if (status === "online") {
+      if (this.phase !== "offline") return;
+      if (!this.hasPendingLocalWork()) {
+        // Flap-safe: a reconnect with nothing pending surfaces nothing.
+        this.reset();
+        return;
+      }
+      this.phase = "settling";
+      this.settleTimer = setTimeout(() => {
+        this.settleTimer = null;
+        this.fireNotice();
+      }, this.options.settleMs);
+      return;
+    }
+    if (status === "offline") {
+      // Terminal manual disconnect: nothing will resync, drop the window.
+      this.reset();
+    }
+    // "connecting" falls through: neither opens nor closes the window.
+  }
+
+  /**
+   * `notebookDocChanged$` emission. Only counted while the offline window
+   * is open: with no inbound frames the `sync_applied` source cannot fire,
+   * so an offline emission is a local flush attempt by construction. Once
+   * online again the signal is mixed-authorship and ignored.
+   */
+  noteLocalDocActivity(): void {
+    if (!this.eligible) return;
+    if (this.phase === "offline") {
+      this.pendingLocalFlush = true;
+    }
+  }
+
+  /**
+   * A local source edit reached the handle for `cellId` (CRDT bridge sync
+   * callback). Tracked only during the offline window. Also marks local
+   * work pending directly: an edit landed just before recovery sits inside
+   * the engine's flush debounce and only flushes post-resync — exactly the
+   * "unflushed handle changes delivered post-resync" shape.
+   */
+  noteLocalCellEdit(cellId: string): void {
+    if (!this.eligible) return;
+    if (this.phase !== "offline") return;
+    this.pendingLocalFlush = true;
+    this.offlineEditedCellIds.add(cellId);
+  }
+
+  /**
+   * The user deleted `cellId` themselves; its absence after resync is not
+   * a collaborator removal.
+   */
+  noteLocalCellDelete(cellId: string): void {
+    this.offlineEditedCellIds.delete(cellId);
+  }
+
+  /**
+   * `cellChanges$` emission (remote-authored by construction — the engine
+   * feeds it from `sync_applied` only). Counted during the settle window;
+   * a `null` changeset means full materialization and makes the
+   * collaborator count unknowable for this outage.
+   */
+  noteRemoteCellChanges(changeset: OfflineMergeCellChangeset | null): void {
+    if (this.phase !== "settling") return;
+    if (changeset === null) {
+      this.remoteChangedCellIds = null;
+      return;
+    }
+    if (this.remoteChangedCellIds === null) return;
+    for (const { cell_id } of changeset.changed) {
+      this.remoteChangedCellIds.add(cell_id);
+    }
+    for (const id of changeset.added) {
+      this.remoteChangedCellIds.add(id);
+    }
+    for (const id of changeset.removed) {
+      this.remoteChangedCellIds.add(id);
+    }
+  }
+
+  dispose(): void {
+    this.clearSettleTimer();
+  }
+
+  private fireNotice(): void {
+    let removedEditedCellCount = 0;
+    const projected = this.options.getProjectedCellIds();
+    // An empty projection mid-rematerialization is not evidence of
+    // deletion; distrust it rather than claim every edited cell vanished.
+    if (projected.length > 0) {
+      const present = new Set(projected);
+      for (const cellId of this.offlineEditedCellIds) {
+        if (!present.has(cellId)) {
+          removedEditedCellCount += 1;
+        }
+      }
+    }
+    const mergedRemoteCellCount =
+      this.remoteChangedCellIds === null ? null : this.remoteChangedCellIds.size;
+    this.reset();
+    this.options.onNotice({ mergedRemoteCellCount, removedEditedCellCount });
+  }
+
+  private hasPendingLocalWork(): boolean {
+    return this.pendingLocalFlush || this.offlineEditedCellIds.size > 0;
+  }
+
+  private reset(): void {
+    this.clearSettleTimer();
+    this.phase = "idle";
+    this.pendingLocalFlush = false;
+    this.offlineEditedCellIds.clear();
+    this.remoteChangedCellIds = new Set();
+  }
+
+  private clearSettleTimer(): void {
+    if (this.settleTimer !== null) {
+      clearTimeout(this.settleTimer);
+      this.settleTimer = null;
+    }
+  }
+}

--- a/apps/notebook-cloud/viewer/use-offline-merge-notice.ts
+++ b/apps/notebook-cloud/viewer/use-offline-merge-notice.ts
@@ -1,0 +1,33 @@
+import { useEffect } from "react";
+import type { OfflineMergeNoticeData } from "./offline-merge-tracker";
+
+/**
+ * How long the offline-merge notice stays up with no user action. It is a
+ * confirmation, not a warning — it must never demand a dismissal.
+ */
+export const OFFLINE_MERGE_NOTICE_TIMEOUT_MS = 10_000;
+
+/**
+ * Clear the offline-merge notice on the next user action (any pointer or
+ * key input — the user has moved on) or after a short timeout. Listeners
+ * are capture-phase so a click consumed by an editor still clears it, and
+ * everything is torn down when the notice clears or the host unmounts.
+ */
+export function useOfflineMergeNoticeAutoClear(
+  notice: OfflineMergeNoticeData | null,
+  clear: () => void,
+  timeoutMs: number = OFFLINE_MERGE_NOTICE_TIMEOUT_MS,
+): void {
+  useEffect(() => {
+    if (!notice) return;
+    const timer = setTimeout(clear, timeoutMs);
+    const onUserAction = () => clear();
+    window.addEventListener("pointerdown", onUserAction, { capture: true });
+    window.addEventListener("keydown", onUserAction, { capture: true });
+    return () => {
+      clearTimeout(timer);
+      window.removeEventListener("pointerdown", onUserAction, { capture: true });
+      window.removeEventListener("keydown", onUserAction, { capture: true });
+    };
+  }, [notice, clear, timeoutMs]);
+}

--- a/apps/notebook/src/hooks/useCrdtBridge.tsx
+++ b/apps/notebook/src/hooks/useCrdtBridge.tsx
@@ -35,8 +35,12 @@ interface CrdtBridgeContextValue {
   getHandle: () => NotebookHandle | null;
   /** Host capability gate for outbound source mutations for a specific cell. */
   canWriteSource?: (cellId: string) => boolean;
-  /** Signal that the CRDT was mutated and needs syncing to daemon. */
-  onSyncNeeded: () => void;
+  /**
+   * Signal that the CRDT was mutated and needs syncing to daemon. The hook
+   * supplies the mutated cell's id; hosts that only trigger sync may ignore
+   * it (the cloud viewer's offline-merge tracking consumes it).
+   */
+  onSyncNeeded: (cellId?: string) => void;
   /** Local actor label (e.g. "local:kyle/desktop:abcd1234") for filtering self-echo attributions. */
   localActor: string;
 }
@@ -48,7 +52,7 @@ const CrdtBridgeContext = createContext<CrdtBridgeContextValue | null>(null);
 interface CrdtBridgeProviderProps {
   getHandle: () => NotebookHandle | null;
   canWriteSource?: (cellId: string) => boolean;
-  onSyncNeeded: () => void;
+  onSyncNeeded: (cellId?: string) => void;
   localActor: string;
   children: ReactNode;
 }
@@ -112,7 +116,7 @@ export function useCrdtBridge(cellId: string): {
         updateCellSourceById(cellId, source);
       },
       onSyncNeeded: () => {
-        ctxRef.current.onSyncNeeded();
+        ctxRef.current.onSyncNeeded(cellId);
       },
     });
   }, [cellId]);

--- a/crates/runtimed-wasm/src/lib.rs
+++ b/crates/runtimed-wasm/src/lib.rs
@@ -2783,6 +2783,30 @@ impl NotebookHandle {
         self.doc.get_heads_hex()
     }
 
+    /// True when the local NotebookDoc contains every head the connected
+    /// peer last advertised on this connection's sync state — the doc has
+    /// provably caught up to everything the peer said it has.
+    ///
+    /// `their_heads` is `None` until the first inbound sync message is
+    /// applied, so this reports `false` before any exchange: an empty
+    /// bootstrap doc is never "caught up" merely because nothing has
+    /// arrived. Local-only changes keep this `true` — only the peer's
+    /// advertised heads must be present locally. `reset_sync_state()`
+    /// (reconnect) returns this to `false` until the new connection's
+    /// first inbound message applies.
+    ///
+    /// Hosted viewers use this to decide when an empty synced doc is the
+    /// room's truth (safe to displace locally painted content) rather
+    /// than a handshake that has not delivered content yet.
+    pub fn notebook_doc_caught_up(&mut self) -> bool {
+        let Some(their_heads) = self.sync_state.their_heads.clone() else {
+            return false;
+        };
+        their_heads
+            .iter()
+            .all(|hash| self.doc.doc_mut().get_change_by_hash(hash).is_some())
+    }
+
     /// Return the current RuntimeStateDoc heads as hex strings.
     pub fn get_runtime_state_heads_hex(&mut self) -> Vec<String> {
         self.state_doc

--- a/docs/adr/local-first-notebook-state.md
+++ b/docs/adr/local-first-notebook-state.md
@@ -48,6 +48,7 @@ main
      └─ PR 2  local-first/02-reconnect    transport reconnect loop, session preservation
          └─ PR 3  local-first/03-slot     connection/identity slot (cloud + desktop)
              └─ PR 4  local-first/04-assets  asset retry + degraded states
+                 └─ PR 5  local-first/05-merge-surfacing  quiet offline-merge notice
 ```
 
 ---
@@ -516,6 +517,106 @@ connection resilience lives.
 
 ---
 
+## PR 5 — Surface offline merges
+
+Offline edits merged silently before this PR: the returning user got no
+signal that their changes interleaved with remote ones, and — the sharp
+edge — a cell they edited offline that was deleted remotely stays deleted
+(Automerge does not resurrect; the work vanished wordlessly). PR 5 surfaces
+both, cloud viewer only, as ONE quiet info notice in the PR 3 notices stack:
+
+> **Synced your offline edits.** — extended to "Synced your offline edits —
+> N updates from collaborators merged." when remote changes also applied
+> during the resync window, plus one body line, "A cell you edited offline
+> was removed by a collaborator.", when a locally-edited-offline cell is
+> absent from the post-resync projection.
+
+Never a modal, never header chrome; the notice clears on the next user
+action or a short timeout (`useOfflineMergeNoticeAutoClear`, 10 s); a
+reconnect with nothing pending shows nothing; the suffix is dropped — never
+guessed — when the count is unknowable.
+
+### Derivation (existing signals only, no new engine observables)
+
+`OfflineMergeTracker` (`apps/notebook-cloud/viewer/offline-merge-tracker.ts`)
+is one per session, stable across effect re-runs and escalation teardowns
+like `CloudConnectionStatusBridge` — an outage spanning a transport
+replacement is still one outage. It extends the sustained-reconnecting
+tracker's debounce discipline with a post-recovery settle window:
+
+- **Offline window** — bounded by the bridge's `connectionStatus$`:
+  "reconnecting" opens it, "online" closes it, "connecting" is neutral
+  (replacement transports report it pre-handshake), terminal "offline"
+  drops it. Repeated "reconnecting" deliveries are no-ops.
+- **Local authorship** — two unambiguous sources. `notebookDocChanged$`
+  emissions *inside the window* are local flush attempts by construction:
+  no inbound frame can fire the `sync_applied` source while offline, and
+  the protocol-only emitters (bootstrap flush, post-ready `resetAndResync`)
+  all run after status flips "online". The CRDT bridge's per-cell sync
+  callback (now carrying the mutated `cellId`) supplies the edited-cell ids
+  AND marks work pending directly — an edit landed just before recovery
+  sits inside the engine's 20 ms flush debounce and only flushes
+  post-resync, the exact "unflushed handle changes delivered post-resync"
+  shape.
+- **Remote authorship** — `cellChanges$` is fed exclusively by the
+  `sync_applied` pipeline, so during the settle window
+  (`OFFLINE_MERGE_RESYNC_SETTLE_MS`, 1.5 s after recovery) its changesets
+  are the collaborator backlog. The count is distinct touched cell ids
+  (changed + added + removed); a `null` changeset (full materialization)
+  makes it unknowable → `null` → suffix dropped.
+- **Deleted-while-edited** — pure TS-side set-tracking, no new WASM exports
+  and no second diff: edited-offline cell ids minus the post-resync
+  projection (`getCellIdsSnapshot()`). The user's own deletes are exempted
+  (the viewer's delete handler removes the id), and an empty projection is
+  distrusted rather than read as mass deletion.
+- **Single-fire per outage** — a drop during the settle window cancels the
+  pending evaluation and resumes the SAME outage with accumulated state;
+  only a recovery whose settle window elapses fires, once, and firing
+  resets everything.
+- **Scope gate** — anonymous sessions are out (per-connection principals,
+  persistence never arms); eligibility follows the latest
+  `cloud_room_ready` principal. Desktop is out of scope entirely (the
+  tracker mounts only in `useCloudViewerSession`).
+
+The escalation-teardown path needs no special casing: a mid-outage teardown
+re-seeds the next attempt from the persisted record, the tracker's window
+stays open across the transport replacement, and the eventual recovery
+fires the same single notice.
+
+### Scoped out (recorded, not built)
+
+- **Cross-reload seeded offline edits.** `seededFromPersistence` cannot
+  distinguish "seed carries offline work" from a routine reload — every
+  signed-in reload seeds from the persisted record, and firing on every
+  reload would violate the quiet rules outright. Distinguishing requires
+  the room's heads in the `cloud_room_ready` handshake (compare against
+  the envelope's `headsHex`) or a durable pending-edits marker with
+  multi-tab reconciliation; both are protocol/storage additions beyond
+  TS-side set-tracking. Follow-up if cross-reload offline authoring grows.
+- **Zombie-socket pre-detection edits.** Edits made in the seconds before
+  the transport notices a drop (liveness probe window) are counted only
+  from the moment status leaves "online". They still sync correctly; they
+  just may not trigger the notice. Quiet bias: prefer a false negative.
+- **Same-key deterministic-loss attribution** ("your metadata write lost to
+  a concurrent one"). Needs per-op attribution diffing the changeset stream
+  does not carry; the text-attribution broadcast covers live typing, not an
+  offline merge audit. Out of scope until a real field report demands it.
+
+Tests: tracker derivation units (offline edits + reconnect → one notice
+after settle; clean reconnect/flaps → nothing; distinct-count + null
+unknowability; deleted-while-edited including own-delete exemption and
+empty-projection distrust; settle-interrupted outage continuity;
+eligibility; terminal disconnect; dispose), notice rendering (copy
+exactness, suffix presence/absence, removal line, info tone, stacking
+beside — not disturbing — the sustained-reconnecting line), and auto-clear
+lifecycle (timeout, pointer/key clear, teardown on clear and unmount,
+fresh-notice window restart). The sustained-reconnecting suite is
+untouched: reconnecting still shows its line, and recovery-with-pending
+replaces it naturally because the sustained flag clears at "online", which
+is exactly when the merge notice can first appear.
+
+---
+
 ## Invariants (load-bearing, checked in review)
 
 - Only **NotebookDoc bytes** may seed a syncing handle. CommsDoc and
@@ -550,18 +651,6 @@ connection resilience lives.
   DOM order while projections update in place.
 
 ## Planned follow-ups (beyond the stack)
-
-### PR 5 — Surface offline merges (conflicts are silent today)
-
-Offline edits merge silently on reconnect: the returning user gets no signal
-that their changes interleaved with remote ones, that a same-key write lost
-deterministically, or — the sharp edge — that a cell they edited offline was
-deleted remotely and stays deleted (Automerge does not resurrect). The
-ingredients to surface this already exist: heads before/after resync, the
-text-attribution stream, and the PR 3 slot/notices stack as the quiet mount
-point ("merged N offline changes" affordance, never a modal). We will
-inevitably hit this as collaborative offline use grows; scoped follow-up
-once the stack lands.
 
 ### PR 6 — Instant first paint from the persisted snapshot (landed)
 

--- a/docs/adr/local-first-notebook-state.md
+++ b/docs/adr/local-first-notebook-state.md
@@ -693,32 +693,59 @@ live connection. As landed:
   `loadRenderSnapshotHandle` — `load_snapshot(notebook, runtimeState)`
   with the cache, plain `load(notebook)` without it, **no `set_actor`** —
   then materialized through `materializeCloudNotebookView` and freed.
-- **Pre-handshake principal gate:** before `cloud_room_ready` the
-  connection's principal is unknown, and IDB may hold another user's
-  notebook on a shared machine. `cloudInstantPaintPrincipalMatcher`
-  derives a matcher from locally stored auth material: the dev-token user
-  maps to the exact `user:dev:<encoded user>` principal (the worker's
-  derivation is deterministic); OIDC matches the stored subject claim as
-  the principal's encoded id segment (the namespace prefix is
-  server-configured and not client-derivable), with expired claims
-  accepted only when the app-session cookie backs them. No derivable
-  principal, or a mismatch on **either** envelope, skips the paint without
-  clearing — post-handshake seeding owns clear decisions. Anonymous
-  principals never match.
+- **Pre-handshake principal gate (a documented heuristic):** before
+  `cloud_room_ready` the connection's principal is unknown, and IDB may
+  hold another user's notebook on a shared machine.
+  `cloudInstantPaintPrincipalMatcher` derives a matcher from locally
+  stored auth material: the dev-token user maps to the exact
+  `user:dev:<encoded user>` principal (the worker's derivation is
+  deterministic); OIDC matches the stored subject claim as the
+  principal's encoded id segment — the namespace prefix is
+  server-configured and **not client-derivable before the first
+  handshake**, so this is deliberately weaker than the post-handshake
+  full-principal guard. The namespace-agnostic match is sound while
+  browser-written records carry only `user:dev:*`, the deployment's
+  single OIDC/API-key namespace, or anonymous (never persisted); adding a
+  browser-reachable provider with an overlapping subject space widens it
+  (the invariant is asserted at the matcher and must be revisited then).
+  Expired claims are accepted only when the app-session cookie backs
+  them. No derivable principal, or a mismatch on **either** envelope,
+  skips the paint without clearing — post-handshake seeding owns clear
+  decisions. Anonymous principals never match.
 - **Degradations:** notebook envelope without a cache record paints
   cells-only. A torn cache envelope, or `load_snapshot` rejecting with
   cache bytes in play, clears **only** the `runtime-state-cache` record
   and retries cells-only; corrupt notebook bytes skip the paint without
-  clearing; transient WASM asset failures clear nothing.
+  clearing; transient WASM asset failures clear nothing; an attempt that
+  lost the freshness race never clears (the live session's save loop may
+  have just rewritten the record).
 - **Race + handoff:** if the live connect wins the race against the cache
-  read, the paint is skipped (`liveMaterializedRef` guards every apply) —
-  stale cache never overwrites a live materialization. When the paint
-  wins, it lands through the same `applyResolvedCells` path, so the #3577
-  preservation gate keeps it across effect re-runs and the live
-  materialization replaces it wholesale in place (no blanking). The paint
-  runs only on the live-room path; the pinned-revision URL keeps its
-  snapshot fetch (mutually exclusive by loading policy). Poison-pill
-  attempts (seed discard in flight) skip the paint along with the seed.
+  read, the paint is skipped — stale cache never overwrites a live
+  materialization. The sequencing (resolve → materialize → widget
+  projection → final apply, with the freshness flag re-checked between
+  every step and the throwaway handle freed on every exit path) lives in
+  `runCloudInstantPaint`; the session injects its store/status effects.
+  When the paint wins, it lands through the same `applyResolvedCells`
+  path, so the #3577 preservation gate keeps it across effect re-runs and
+  the live materialization replaces it wholesale in place (no blanking).
+  The paint runs only on the live-room path; the pinned-revision URL
+  keeps its snapshot fetch (mutually exclusive by loading policy).
+  Poison-pill attempts (seed discard in flight) skip the paint along with
+  the seed.
+- **Empty-room displacement (the heuristic's backstop):** painted cells
+  block a zero-cell live apply only until the syncing handle has provably
+  caught up to the room's advertised heads
+  (`NotebookHandle.notebook_doc_caught_up()`, polled on the engine's
+  `notebookSyncApplied$` — a room at genesis converges with zero
+  `cellChanges$` emissions, so a dedicated kick runs one full
+  materialization on first catch-up). After that, zero cells IS the
+  room's truth: the stage clears to status `empty`, displacing the paint
+  (including a matcher false-positive) and fixing the pre-existing
+  seeded-session shape where a room emptied to zero could never blank the
+  stale projection. `paintOriginRef` tracks paint-origin pixels so the
+  live-changeset tail never relabels them as live content, and the live
+  pass keeps a painted `ready` status instead of flapping back to a
+  loading notice over visible cells.
 - Offline *editing* before the first-ever handshake stays out of scope
   (below) — this PR is about read latency, not offline authoring.
 

--- a/packages/runtimed/src/sync-engine.ts
+++ b/packages/runtimed/src/sync-engine.ts
@@ -434,6 +434,21 @@ export class SyncEngine {
    */
   readonly notebookDocChanged$: Observable<void>;
 
+  /**
+   * Fires once per APPLIED inbound NotebookDoc sync frame, whether or not
+   * the document changed.
+   *
+   * `cellChanges$` and `notebookDocChanged$` are silent for no-op
+   * exchanges, but converging with a peer whose doc already matches ours
+   * is exactly such an exchange — e.g. a hosted room at genesis answers
+   * the bootstrap handshake with heads only and no changes. Hosts that
+   * must act once the exchange settles (the cloud viewer polls
+   * `notebook_doc_caught_up()` on each emission to let an authoritative
+   * empty room displace painted content) listen here. Derived 1:1 from
+   * the existing WASM `sync_applied` event — no second diff, no payload.
+   */
+  readonly notebookSyncApplied$: Observable<void>;
+
   // Backing subjects for public observables
   private readonly _cellChanges$ = new Subject<CellChangeset | null>();
   private readonly _broadcasts$ = new Subject<unknown>();
@@ -450,6 +465,7 @@ export class SyncEngine {
   }>();
   private readonly _executionViewChanges$ = new Subject<ExecutionViewChangeset>();
   private readonly _notebookDocChanged$ = new Subject<void>();
+  private readonly _notebookSyncApplied$ = new Subject<void>();
 
   constructor(opts: SyncEngineOptions) {
     this.opts = {
@@ -472,6 +488,7 @@ export class SyncEngine {
     this.outputIdChanges$ = this._outputIdChanges$.asObservable();
     this.executionViewChanges$ = this._executionViewChanges$.asObservable();
     this.notebookDocChanged$ = this._notebookDocChanged$.asObservable();
+    this.notebookSyncApplied$ = this._notebookSyncApplied$.asObservable();
 
     // Typed broadcast sub-observables (derived from broadcasts$)
     this.commBroadcasts$ = this.broadcasts$.pipe(filter(isCommBroadcast));
@@ -629,6 +646,10 @@ export class SyncEngine {
               this._notebookDocChanged$.next();
             }
             this.emitExecutionViewChanges(e.execution_view_changeset);
+            // After the changed/reply handling: the handle has already
+            // applied the frame (receive_frame is synchronous), so
+            // subscribers polling handle facts see post-apply state.
+            this._notebookSyncApplied$.next();
             return EMPTY;
           }),
         )

--- a/packages/runtimed/tests/notebook-doc-persistence.test.ts
+++ b/packages/runtimed/tests/notebook-doc-persistence.test.ts
@@ -462,17 +462,32 @@ describe("loadPersistedNotebookDoc", () => {
 });
 
 describe("clearPersistedNotebookDoc", () => {
-  it("removes the whole notebook prefix", async () => {
+  it("removes the whole notebook prefix — seed AND render cache, neighbors untouched", async () => {
+    // The poison-pill discard rides this: a discarded seed must not leave
+    // its cached pixels behind to repaint rejected content on the next
+    // load, and another notebook's records must survive.
     const adapter = createRecordingAdapter();
     await adapter.save(
       ["nb-1", "snapshot"],
       encodePersistedNotebookDoc(testMeta(), new Uint8Array([9])),
+    );
+    await adapter.save(
+      ["nb-1", RUNTIME_STATE_CACHE_KEY_SEGMENT],
+      encodePersistedNotebookDoc(testMeta(), new Uint8Array([10])),
+    );
+    await adapter.save(
+      ["nb-2", "snapshot"],
+      encodePersistedNotebookDoc(testMeta(), new Uint8Array([11])),
     );
 
     await clearPersistedNotebookDoc(adapter, "nb-1");
 
     expect(adapter.removeRange).toHaveBeenCalledWith(["nb-1"]);
     expect(await loadPersistedNotebookDoc(adapter, "nb-1")).toBeUndefined();
+    expect(
+      await loadPersistedNotebookRecord(adapter, "nb-1", RUNTIME_STATE_CACHE_KEY_SEGMENT),
+    ).toBeUndefined();
+    expect((await loadPersistedNotebookDoc(adapter, "nb-2"))?.bytes).toEqual(new Uint8Array([11]));
   });
 });
 

--- a/packages/runtimed/tests/sync-engine.test.ts
+++ b/packages/runtimed/tests/sync-engine.test.ts
@@ -464,6 +464,49 @@ describe("SyncEngine", () => {
     });
   });
 
+  // ── Notebook sync applied (per inbound exchange) ──────────────
+
+  describe("notebookSyncApplied$", () => {
+    it("fires per applied inbound notebook sync frame, even when nothing changed", () => {
+      // The no-op exchange is the load-bearing case: converging with a
+      // peer at identical heads emits no cellChanges$/notebookDocChanged$,
+      // yet hosts must learn the exchange settled.
+      (handle.receive_frame as ReturnType<typeof vi.fn>).mockReturnValue([
+        syncAppliedEvent({ changed: false }),
+      ]);
+
+      const engine = createEngine();
+      engine.start();
+
+      let emissions = 0;
+      engine.notebookSyncApplied$.subscribe(() => {
+        emissions += 1;
+      });
+
+      transport.deliver(Array.from([0x00, 1]));
+      expect(emissions).toBe(1);
+      engine.stop();
+    });
+
+    it("stays silent for runtime-state sync frames", () => {
+      (handle.receive_frame as ReturnType<typeof vi.fn>).mockReturnValue([
+        runtimeStateSyncEvent(makeRuntimeState({})),
+      ]);
+
+      const engine = createEngine();
+      engine.start();
+
+      let emissions = 0;
+      engine.notebookSyncApplied$.subscribe(() => {
+        emissions += 1;
+      });
+
+      transport.deliver(Array.from([0x05, 1]));
+      expect(emissions).toBe(0);
+      engine.stop();
+    });
+  });
+
   // ── Cell changes (coalescing) ─────────────────────────────────
 
   describe("cellChanges$", () => {

--- a/packages/runtimed/tests/wasm-integration.test.ts
+++ b/packages/runtimed/tests/wasm-integration.test.ts
@@ -682,4 +682,32 @@ describe("WASM integration: real frames through SyncEngine", { retry: 3 }, () =>
       loaded.free();
     });
   });
+
+  // ── notebook_doc_caught_up (sync authority fact) ─────────────────
+
+  describe("notebook_doc_caught_up", () => {
+    it("is false before any exchange and true after a zero-change handshake settles", async () => {
+      // The no-change convergence is the load-bearing case: an empty room
+      // answers the bootstrap handshake heads-only, with no cellChanges$
+      // ever firing — caught-up is the only proof its emptiness is truth.
+      expect(h.client.notebook_doc_caught_up()).toBe(false);
+
+      await h.startAndCompleteSync();
+
+      expect(h.client.notebook_doc_caught_up()).toBe(true);
+    });
+
+    it("stays false while the peer has advertised heads whose changes have not arrived", async () => {
+      // Drive the protocol by hand: the first sync message carries heads
+      // and bloom only — the client learns what the server HAS before it
+      // has it, and must not report caught-up on that knowledge alone.
+      h.serverAddCell("cell-1", "code");
+      const firstMessage = h.server.flush_local_changes();
+      expect(firstMessage).toBeTruthy();
+
+      h.client.receive_sync_message(firstMessage!);
+
+      expect(h.client.notebook_doc_caught_up()).toBe(false);
+    });
+  });
 });


### PR DESCRIPTION
Two related pieces on one train (separable commits): the ADR's PR 5, plus the confirmed findings from #3586's post-merge adversarial review.

## Offline-merge surfacing (PR 5 of the #3421 line)

Offline edits merge silently today. Now, when a reconnect completes with locally-authored work pending across the gap, one quiet notice: **"Synced your offline edits."** — extended with "— N update(s) from collaborators merged." when remote changes applied during the resync settle window (count dropped when unknowable, never guessed). And the sharp edge: **"A cell you edited offline was removed by a collaborator."** — Automerge doesn't resurrect, so this is the one merge outcome that silently destroys work; it turned out cheaply derivable with TS-side set-tracking only (locally-edited ids during the offline window vs the post-resync cell set; own deletes exempted).

Derivation discipline: everything from existing signals (`connectionStatus$` bounds the window via the status bridge; `notebookDocChanged$` + the CRDT bridge's per-cell callback prove local authorship — including edits stuck in the 20ms flush debounce; `cellChanges$` during settle counts remote). One tracker per session, stable across transport replacements and escalation teardowns. Flap-silent, single-fire per outage, clears on user action or 10s. Scoped out (ADR-recorded): the seeded-from-persistence trigger — every signed-in reload seeds, so it can't distinguish offline work from a routine reload without a durable pending marker.

## Empty-room displacement (the #3586 review's confirmed major)

An authoritative empty live room could never displace the instant paint: the zero-cell guard blocked the wholesale replace forever, so painted cells persisted as "ready" all session — including the cross-principal false-positive case the paint's heuristic matcher explicitly relies on live replacement to correct. "Settled empty" is observable only via the peer's advertised heads (a genesis room answers heads-only, then silence — no engine event distinguishes it from changes-in-flight), so the fix is a small WASM fact — `NotebookHandle.notebook_doc_caught_up()` — plus one narrow observable (`notebookSyncApplied$`, fires per applied inbound frame, changed or not). Painted cells now block the empty apply only until caught-up; then live emptiness clears the stage. This also fixed the pre-existing seeded-session delete-to-zero hole on main, which fell out naturally. A `paintOriginRef` stops the null-changeset tail relabeling paint as live and stops warm-load status flapping.

Also from the review: real wiring tests replace the source-pin "tests" the review caught (mid-flight race, corrupt-cache-clears-only-itself across the session boundary — the previously-green mutants now fail); freshness re-check before the corrupt-cache clear; late access diagnostics merge instead of displacing the WASM-failure Retry notice at both resolution sites; the principal-matcher heuristic + its restored empty-room backstop documented and asserted (namespace genuinely isn't client-derivable pre-handshake — the verifier-endorsed fallback).

## Verification

vp suite: **2182 passed, 0 failed** · notebook-cloud: **892/892** · post-rebase (over #3587) targeted suites: 143 pass · `tsc --noEmit` + `cargo xtask lint` clean · WASM rebuilt for the new export, real-WASM tests cover the caught-up transitions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)