### PR TITLE
feat(persistence): saveBatch adapter extension and heads-dedupe on save

### DIFF
--- a/apps/notebook-cloud/test/live-sync.test.ts
+++ b/apps/notebook-cloud/test/live-sync.test.ts
@@ -627,7 +627,18 @@ describe("cloud persisted-seed handle resolution", () => {
     const harness = createHarness(persistedRecord("user:dev:alice"));
     const resolved = await resolveCloudNotebookHandle(harness.options);
 
-    assert.deepEqual(resolved, { handle: "seeded-handle", outcome: "seeded" });
+    assert.deepEqual(resolved, {
+      handle: "seeded-handle",
+      outcome: "seeded",
+      // The seeded record's meta rides along so the save loop can dedupe
+      // its first save against the record it loaded from.
+      seedMeta: {
+        headsHex: ["aa"],
+        savedAt: 123,
+        principal: "user:dev:alice",
+        schemaVersion: 1,
+      },
+    });
     assert.deepEqual(harness.calls, ["loadPersisted", "loadFromBytes"]);
     assert.deepEqual(harness.loadedBytes, [new Uint8Array([7, 8, 9])]);
   });

--- a/apps/notebook-cloud/test/notebook-persistence.test.ts
+++ b/apps/notebook-cloud/test/notebook-persistence.test.ts
@@ -63,13 +63,14 @@ function createHarness() {
     setStateBytes: (bytes: Uint8Array) => {
       stateBytes = bytes;
     },
-    arm: (principal = "user:dev:alice") =>
+    arm: (principal = "user:dev:alice", seedSavedHeadsHex?: string[]) =>
       createCloudNotebookPersistence({
         adapter,
         notebookId: "nb-1",
         principal,
         engine: { notebookDocChanged$, runtimeState$ },
         handle,
+        seedSavedHeadsHex,
         throttleMs: 5,
       }),
   };
@@ -111,6 +112,24 @@ describe("createCloudNotebookPersistence", () => {
     await sleep(30);
 
     assert.deepEqual([...harness.adapter.records.keys()], ["nb-1/snapshot"]);
+    controller.dispose();
+  });
+
+  it("seedSavedHeadsHex dedupes only the seed record, never the cache", async () => {
+    const harness = createHarness();
+    // The runtime seeded from a record at the handle's current doc heads.
+    const controller = harness.arm("user:dev:alice", ["doc-head"]);
+    assert.ok(controller);
+
+    // The handshake's protocol-only change signal: unchanged doc heads must
+    // not re-write the seed record the session just loaded.
+    harness.notebookDocChanged$.next();
+    // The cache controller's heads space is the RuntimeStateDoc's — the
+    // seed's NotebookDoc heads must not suppress its first write.
+    harness.runtimeState$.next({});
+    await sleep(30);
+
+    assert.deepEqual([...harness.adapter.records.keys()], ["nb-1/runtime-state-cache"]);
     controller.dispose();
   });
 

--- a/apps/notebook-cloud/viewer/cloud-viewer-session.ts
+++ b/apps/notebook-cloud/viewer/cloud-viewer-session.ts
@@ -532,6 +532,10 @@ export function useCloudViewerSession({
     const persistenceAdapter = IndexedDbStorageAdapter.create();
     let notebookPersistence: CloudNotebookPersistenceController | null = null;
     let notebookPersistencePrincipal: string | null = null;
+    // True once any controller has been armed this session: a previous
+    // controller may have overwritten the seeded record, so only the very
+    // first arm may trust the seed's heads to describe what is in storage.
+    let notebookPersistenceEverArmed = false;
     const persistenceSeed = persistenceAdapter
       ? {
           loadPersisted: () => loadPersistedNotebookDoc(persistenceAdapter, config.notebookId),
@@ -616,14 +620,29 @@ export function useCloudViewerSession({
         // paint cache (instant first paint's outputs). The controllers
         // throttle, self-disable after repeated failures, and never throw
         // into the session.
+        // Seed-initialized heads-dedupe: when this runtime loaded from the
+        // record still sitting in storage (and no earlier controller has
+        // overwritten it), the first protocol-only change signal must not
+        // re-write the identical envelope. Gated on the seeded principal
+        // matching the armed one — a mismatched record would be re-stamped,
+        // which dedupe must not suppress.
+        const seedMeta = liveRuntime.persistenceSeedMeta;
+        const seedSavedHeadsHex =
+          !notebookPersistenceEverArmed && seedMeta?.principal === principal
+            ? seedMeta.headsHex
+            : undefined;
         notebookPersistence = createCloudNotebookPersistence({
           adapter: persistenceAdapter,
           notebookId: config.notebookId,
           principal,
           engine: liveRuntime.engine,
           handle: liveRuntime.handle,
+          seedSavedHeadsHex,
           onError: (error) => console.warn("[notebook-cloud] notebook persistence error", error),
         });
+        if (notebookPersistence !== null) {
+          notebookPersistenceEverArmed = true;
+        }
         notebookPersistencePrincipal = notebookPersistence ? principal : null;
       });
     };

--- a/apps/notebook-cloud/viewer/live-sync.ts
+++ b/apps/notebook-cloud/viewer/live-sync.ts
@@ -9,6 +9,7 @@ import {
   type NotebookRequestOptions,
   type NotebookResponse,
   type NotebookTransport,
+  type NotebookDocPersistenceMeta,
   type PersistedNotebookDoc,
   type SyncableHandle,
   type NotebookInteractionTarget,
@@ -56,6 +57,12 @@ export interface CloudSyncRuntime {
   seededFromPersistence: boolean;
   /** How the persisted-seed attempt resolved; "read_failed" must not arm saves. */
   persistenceSeedOutcome: CloudPersistenceSeedOutcome;
+  /**
+   * Meta of the seeded record (outcome `"seeded"` only) — its `headsHex`
+   * initializes the save loop's heads-dedupe against the record already in
+   * storage, gated on its `principal` still matching the armed principal.
+   */
+  persistenceSeedMeta?: NotebookDocPersistenceMeta;
   /**
    * Adopt a reconnect handshake on the PRESERVED runtime: update identity,
    * `set_actor` with the fresh label, reset engine caches and sync state.
@@ -123,6 +130,12 @@ export type CloudPersistenceSeedOutcome = "seeded" | "bootstrap" | "cleared" | "
 export interface ResolvedCloudNotebookHandle<Handle> {
   handle: Handle;
   outcome: CloudPersistenceSeedOutcome;
+  /**
+   * Meta of the record the handle was seeded from (outcome `"seeded"`
+   * only). Its `headsHex` initializes the save loop's heads-dedupe so an
+   * unchanged notebook never re-writes the identical envelope it loaded.
+   */
+  seedMeta?: NotebookDocPersistenceMeta;
 }
 
 type FrameListener = Parameters<NotebookTransport["onFrame"]>[0];
@@ -206,7 +219,11 @@ export async function connectCloudSyncRuntime({
     const ready = await transport.ready;
     const wasmModuleUrl = new URL(runtimedWasmModulePath, location.href);
     const wasmUrl = new URL(runtimedWasmPath, location.href);
-    const { handle, outcome: persistenceSeedOutcome } = await resolveCloudNotebookHandle({
+    const {
+      handle,
+      outcome: persistenceSeedOutcome,
+      seedMeta,
+    } = await resolveCloudNotebookHandle({
       actorLabel: ready.actor_label,
       persistence,
       createBootstrap: () =>
@@ -257,6 +274,7 @@ export async function connectCloudSyncRuntime({
       transport,
       seededFromPersistence: persistenceSeedOutcome === "seeded",
       persistenceSeedOutcome,
+      persistenceSeedMeta: seedMeta,
       applyRoomReady: (nextReady) =>
         applyCloudRoomReady(identity, nextReady, () =>
           reestablishCloudConnection(handle, engine, nextReady.actor_label),
@@ -536,7 +554,11 @@ export async function resolveCloudNotebookHandle<Handle>({
   }
 
   try {
-    return { handle: await loadFromBytes(persisted.bytes), outcome: "seeded" };
+    return {
+      handle: await loadFromBytes(persisted.bytes),
+      outcome: "seeded",
+      seedMeta: persisted.meta,
+    };
   } catch (error) {
     // A WASM client/asset failure does not incriminate the persisted bytes:
     // clearing here destroyed a healthy record in the field when an

--- a/apps/notebook-cloud/viewer/notebook-persistence.ts
+++ b/apps/notebook-cloud/viewer/notebook-persistence.ts
@@ -54,6 +54,15 @@ export interface CreateCloudNotebookPersistenceOptions {
   principal: string;
   engine: CloudPersistenceChangeSignals;
   handle: CloudPersistenceHandleSurface;
+  /**
+   * `meta.headsHex` of the snapshot record this runtime seeded from, when
+   * that record is still the one in storage. Initializes the NotebookDoc
+   * controller's heads-dedupe so the handshake's protocol-only change
+   * signal does not re-write the identical envelope it just loaded. Never
+   * applies to the runtime-state cache (the seed meta describes the
+   * snapshot record only).
+   */
+  seedSavedHeadsHex?: string[];
   onError?: (error: unknown) => void;
   /** Test hook: trailing-edge throttle for both controllers. */
   throttleMs?: number;
@@ -65,6 +74,7 @@ export function createCloudNotebookPersistence({
   principal,
   engine,
   handle,
+  seedSavedHeadsHex,
   onError,
   throttleMs,
 }: CreateCloudNotebookPersistenceOptions): CloudNotebookPersistenceController | null {
@@ -79,6 +89,7 @@ export function createCloudNotebookPersistence({
     changes$: engine.notebookDocChanged$,
     getSaveBytes: () => handle.save(),
     getHeadsHex: () => handle.get_heads_hex(),
+    initialSavedHeadsHex: seedSavedHeadsHex,
     onError,
     ...(throttleMs !== undefined ? { throttleMs } : {}),
   });

--- a/docs/adr/local-first-notebook-state.md
+++ b/docs/adr/local-first-notebook-state.md
@@ -74,14 +74,22 @@ protocol-only messages (the initial handshake on a fresh `sync::State`,
 resync negotiation). It never under-fires for committed local changes.
 Consumers must treat saves as idempotent; the persistence throttle makes the
 occasional no-op snapshot cheap, and the controller's heads-dedupe
-(automerge-repo's `#shouldSave` shape, #3585 slice 2) removes it entirely:
-each capture compares `get_heads_hex()` against the heads of the newest
-capture handed to the write chain and skips both the full-doc serialization
-and the write when they match. A failed write forgets its recorded heads
-(unless a newer capture superseded them) so the next signal retries; a
-seeded session initializes the dedupe from the loaded record's
-`meta.headsHex` (first arm only, principal-gated) so the handshake's
-protocol-only signal does not re-write the envelope it just loaded.
+(automerge-repo's `#shouldSave` shape, #3585 slice 2) removes it entirely.
+Two keys with different trust levels: change-signal captures dedupe against
+the heads of the newest capture handed to the write chain (optimistic —
+prevents queueing duplicates behind an identical in-flight write; a late
+failure self-heals through the next signal), while `flushNow` dedupes only
+against the newest **committed** write — an in-flight write is not proof of
+durability, and a teardown flush gets no next signal, so skipping on its
+behalf could lose the only copy of offline edits if it then failed. A
+failed write forgets its recorded heads (unless a newer capture superseded
+them) so the next signal retries. A seeded session initializes both keys
+from the loaded record's `meta.headsHex` (first arm only, principal-gated,
+and only when the heads are non-empty — an empty heads array also describes
+a freshly-bootstrapped doc and must read as unknown, not as a match) so the
+handshake's protocol-only signal does not re-write the envelope it just
+loaded; the runtime-state cache controller never inherits these heads (its
+heads space is the RuntimeStateDoc's).
 
 This stays consistent with the projection-convergence ADR: a narrow,
 cross-host observable derived from already-computed WASM facts (the heads

--- a/docs/adr/local-first-notebook-state.md
+++ b/docs/adr/local-first-notebook-state.md
@@ -73,7 +73,15 @@ over-fire, because `generate_sync_message` also yields bytes for
 protocol-only messages (the initial handshake on a fresh `sync::State`,
 resync negotiation). It never under-fires for committed local changes.
 Consumers must treat saves as idempotent; the persistence throttle makes the
-occasional no-op snapshot cheap.
+occasional no-op snapshot cheap, and the controller's heads-dedupe
+(automerge-repo's `#shouldSave` shape, #3585 slice 2) removes it entirely:
+each capture compares `get_heads_hex()` against the heads of the newest
+capture handed to the write chain and skips both the full-doc serialization
+and the write when they match. A failed write forgets its recorded heads
+(unless a newer capture superseded them) so the next signal retries; a
+seeded session initializes the dedupe from the loaded record's
+`meta.headsHex` (first arm only, principal-gated) so the handshake's
+protocol-only signal does not re-write the envelope it just loaded.
 
 This stays consistent with the projection-convergence ADR: a narrow,
 cross-host observable derived from already-computed WASM facts (the heads
@@ -94,8 +102,21 @@ export interface StorageAdapter {
   remove(key: StorageKey): Promise<void>;
   loadRange(prefix: StorageKey): Promise<StorageChunk[]>;
   removeRange(prefix: StorageKey): Promise<void>;
+  saveBatch?(entries: Array<[StorageKey, Uint8Array]>): Promise<void>;
 }
 ```
+
+`saveBatch` is upstream's exact `StorageAdapterInterface` extension (#3585
+slice 1), optional here with a sequential-`save` fallback via the
+`saveBatch(adapter, entries)` helper. The contract is per-batch atomicity at
+minimum (staged two-phase where the backend allows; the IndexedDB
+implementation gets all-or-nothing from a single transaction); cross-batch
+crash-ordering stays the caller's job — payload chunks first, metadata
+second, the visibility marker last, so a crash leaves invisible orphans
+rather than a visible-but-incomplete record. The envelope write goes through
+the helper; today's single-record envelope is a one-entry batch, and the
+incremental-chunk future gets multi-entry writes without an interface
+change.
 
 `IndexedDbStorageAdapter`: database `"nteract-local-first"`, object store
 `"notebook-docs"`, out-of-line `string[]` keys (IDB array-key ordering gives
@@ -767,10 +788,11 @@ bridge wraps upstream, and subduction writes under its own
 our snapshot envelope degrades into a bootstrap cache. Cheap alignment
 moves when the time comes:
 
-1. Optional `saveBatch(entries)` on `StorageAdapter` (upstream's exact
+1. ~~Optional `saveBatch(entries)` on `StorageAdapter` (upstream's exact
    extension; sequential-save fallback) with crash-ordered writes
    (blobs → metadata → id-marker: a crash leaves invisible orphans, never a
-   visible-but-incomplete record).
+   visible-but-incomplete record).~~ **Adopted** (#3585 slice 1) — see the
+   storage-layer section above.
 2. Fill the reserved "incremental chunks later" slot against the automerge
    3.3 fragments API (`getFragmentMetadata`/`bundleFragmentMetadata` via new
    `NotebookHandle` WASM exports) instead of inventing a chunk format —

--- a/packages/runtimed/src/index.ts
+++ b/packages/runtimed/src/index.ts
@@ -70,7 +70,12 @@ export {
   type NotebookDocPersistenceOptions,
   type PersistedNotebookDoc,
 } from "./persistence/notebook-doc-persistence";
-export type { StorageAdapter, StorageChunk, StorageKey } from "./persistence/storage-adapter";
+export {
+  saveBatch,
+  type StorageAdapter,
+  type StorageChunk,
+  type StorageKey,
+} from "./persistence/storage-adapter";
 
 // Scope capabilities (generated from nteract_identity::ConnectionScope)
 export {

--- a/packages/runtimed/src/index.ts
+++ b/packages/runtimed/src/index.ts
@@ -71,6 +71,7 @@ export {
   type PersistedNotebookDoc,
 } from "./persistence/notebook-doc-persistence";
 export {
+  SaveBatchEntryError,
   saveBatch,
   type StorageAdapter,
   type StorageChunk,

--- a/packages/runtimed/src/persistence/indexeddb-storage-adapter.ts
+++ b/packages/runtimed/src/persistence/indexeddb-storage-adapter.ts
@@ -115,6 +115,40 @@ export class IndexedDbStorageAdapter implements StorageAdapter {
     );
   }
 
+  /**
+   * All entries commit in one readwrite transaction — IDB transactions
+   * are atomic, so this is all-or-nothing (strictly stronger than the
+   * staged two-phase minimum the interface asks for).
+   */
+  saveBatch(entries: Array<[StorageKey, Uint8Array]>): Promise<void> {
+    if (entries.length === 0) return Promise.resolve();
+    return this.withStore(
+      "readwrite",
+      (store, transaction) =>
+        new Promise<void>((resolve, reject) => {
+          transaction.oncomplete = () => resolve();
+          transaction.onabort = () =>
+            reject(transaction.error ?? new Error("indexedDB saveBatch aborted"));
+          transaction.onerror = () =>
+            reject(transaction.error ?? new Error("indexedDB saveBatch failed"));
+          try {
+            for (const [key, data] of entries) {
+              store.put(data, key);
+            }
+          } catch (error) {
+            // A synchronous put failure (DataError, quota in some engines)
+            // must not let already-issued puts auto-commit a partial batch.
+            reject(error);
+            try {
+              transaction.abort();
+            } catch {
+              // already aborted/finished — the rejection above stands
+            }
+          }
+        }),
+    );
+  }
+
   remove(key: StorageKey): Promise<void> {
     return this.withStore(
       "readwrite",

--- a/packages/runtimed/src/persistence/indexeddb-storage-adapter.ts
+++ b/packages/runtimed/src/persistence/indexeddb-storage-adapter.ts
@@ -126,14 +126,21 @@ export class IndexedDbStorageAdapter implements StorageAdapter {
       "readwrite",
       (store, transaction) =>
         new Promise<void>((resolve, reject) => {
+          // `transaction.error` can be null when an async put fails (seen
+          // with quota aborts); remember the failing request's error so the
+          // rejection names the real cause.
+          let requestError: unknown = null;
           transaction.oncomplete = () => resolve();
           transaction.onabort = () =>
-            reject(transaction.error ?? new Error("indexedDB saveBatch aborted"));
+            reject(transaction.error ?? requestError ?? new Error("indexedDB saveBatch aborted"));
           transaction.onerror = () =>
-            reject(transaction.error ?? new Error("indexedDB saveBatch failed"));
+            reject(transaction.error ?? requestError ?? new Error("indexedDB saveBatch failed"));
           try {
             for (const [key, data] of entries) {
-              store.put(data, key);
+              const request = store.put(data, key);
+              request.onerror = () => {
+                requestError ??= request.error;
+              };
             }
           } catch (error) {
             // A synchronous put failure (DataError, quota in some engines)

--- a/packages/runtimed/src/persistence/notebook-doc-persistence.ts
+++ b/packages/runtimed/src/persistence/notebook-doc-persistence.ts
@@ -143,15 +143,30 @@ export class NotebookDocPersistence {
    * signal retries.
    */
   private lastSavedHeadsKey: string | null = null;
+  /**
+   * Heads of the newest write that COMMITTED (or of the seeded record, which
+   * is committed by definition). `flushNow` dedupes against this key, never
+   * the optimistic one: a teardown flush that skipped because an in-flight
+   * write "covered" its state would lose that state forever if the write
+   * then failed — errors are swallowed and the handle is freed right after.
+   */
+  private lastCommittedHeadsKey: string | null = null;
 
   constructor(opts: NotebookDocPersistenceOptions) {
     this.opts = opts;
     this.keySegment = opts.keySegment ?? NOTEBOOK_DOC_SNAPSHOT_KEY_SEGMENT;
     this.throttleMs = opts.throttleMs ?? DEFAULT_SAVE_THROTTLE_MS;
     this.logger = opts.logger ?? console;
-    this.lastSavedHeadsKey = opts.initialSavedHeadsHex
-      ? headsCacheKey(opts.initialSavedHeadsHex)
-      : null;
+    // An empty heads array is treated as unknown, not as an identity: a
+    // freshly-bootstrapped doc (RuntimeStateDoc starts empty by design)
+    // would otherwise match a stale prior-session record's empty heads and
+    // skip its first save.
+    const initialHeads = opts.initialSavedHeadsHex;
+    if (initialHeads && initialHeads.length > 0) {
+      const initialKey = headsCacheKey(initialHeads);
+      this.lastSavedHeadsKey = initialKey;
+      this.lastCommittedHeadsKey = initialKey;
+    }
     this.subscription = opts.changes$.subscribe(() => this.onChanged());
   }
 
@@ -177,12 +192,14 @@ export class NotebookDocPersistence {
    *
    * Captures ignoring the change-signal dirty flag: local edits inside
    * the engine's flush debounce have not emitted yet, but `getSaveBytes()`
-   * already sees them. The heads-dedupe still applies — committed edits
-   * always move the heads, so the only skipped flushes are ones whose
-   * exact state the write chain has already accepted. Bytes are captured
-   * synchronously, so a handle freed right after this call returns is
-   * never touched by the queued write; the returned promise resolves once
-   * the write chain has committed.
+   * already sees them. The heads-dedupe applies only against COMMITTED
+   * writes — an in-flight write may still fail after this call returns
+   * (errors are swallowed, the handle freed), so "covered by a pending
+   * write" must not skip the teardown's last chance to persist. A flush
+   * racing an identical in-flight write costs one redundant idempotent
+   * write. Bytes are captured synchronously, so a handle freed right after
+   * this call returns is never touched by the queued write; the returned
+   * promise resolves once the write chain has committed.
    */
   async flushNow(): Promise<void> {
     if (this.disposed) return;
@@ -190,7 +207,7 @@ export class NotebookDocPersistence {
       clearTimeout(this.saveTimer);
       this.saveTimer = null;
     }
-    await this.captureAndEnqueue();
+    await this.captureAndEnqueue("committed");
   }
 
   private onChanged(): void {
@@ -208,7 +225,15 @@ export class NotebookDocPersistence {
     return this.captureAndEnqueue();
   }
 
-  private captureAndEnqueue(): Promise<void> {
+  /**
+   * `dedupeAgainst` selects which heads key may skip the capture:
+   * change-signal saves use `"newest"` (the optimistic key — prevents
+   * queueing duplicates behind an identical in-flight write, and a late
+   * failure self-heals through the next signal), while `flushNow` uses
+   * `"committed"` (an in-flight write is not proof of durability, and a
+   * teardown flush gets no next signal).
+   */
+  private captureAndEnqueue(dedupeAgainst: "newest" | "committed" = "newest"): Promise<void> {
     this.dirty = false;
 
     // Capture synchronously: getSaveBytes touches the WASM handle, which a
@@ -218,11 +243,14 @@ export class NotebookDocPersistence {
     try {
       const headsHex = this.opts.getHeadsHex();
       headsKey = headsCacheKey(headsHex);
-      if (headsKey === this.lastSavedHeadsKey) {
-        // Heads unchanged since the newest capture: the change signal
-        // over-fired (protocol-only flush) — skip the no-op snapshot.
-        // Edits inside the engine's flush debounce are already committed
-        // to the doc, so they move the heads and never land here.
+      const skipKey =
+        dedupeAgainst === "newest" ? this.lastSavedHeadsKey : this.lastCommittedHeadsKey;
+      if (headsKey === skipKey) {
+        // Heads unchanged since the newest capture (or, for flushes, the
+        // newest COMMITTED write): the signal over-fired (protocol-only
+        // flush) — skip the no-op snapshot. Edits inside the engine's
+        // flush debounce are already committed to the doc, so they move
+        // the heads and never land here.
         return this.writeChain;
       }
       const meta: NotebookDocPersistenceMeta = {
@@ -247,6 +275,7 @@ export class NotebookDocPersistence {
       try {
         await saveBatch(adapter, [[key, envelope]]);
         this.consecutiveSaveFailures = 0;
+        this.lastCommittedHeadsKey = headsKey;
       } catch (error) {
         // Forget this capture's heads so the next signal retries — unless
         // a newer capture already superseded them.

--- a/packages/runtimed/src/persistence/notebook-doc-persistence.ts
+++ b/packages/runtimed/src/persistence/notebook-doc-persistence.ts
@@ -15,6 +15,13 @@
  * flush debounce have not emitted yet, but `handle.save()` already sees
  * them, and saves are idempotent.
  *
+ * Change signals over-fire by design (`notebookDocChanged$` also emits for
+ * protocol-only flushes), so every capture first compares the doc heads
+ * against the last heads handed to the adapter — automerge-repo's
+ * `#shouldSave` shape. Unchanged heads skip both the full-doc serialization
+ * and the write; a failed write forgets its recorded heads so the next
+ * signal retries instead of deduping against a record that never landed.
+ *
  * Two records exist per notebook:
  * - `[notebookId, "snapshot"]` — NotebookDoc bytes, the seed record. The
  *   only record ever loaded back into a SYNCING handle.
@@ -34,7 +41,7 @@
 
 import type { Observable, Subscription } from "rxjs";
 
-import type { StorageAdapter } from "./storage-adapter";
+import { saveBatch, type StorageAdapter } from "./storage-adapter";
 
 const DEFAULT_SAVE_THROTTLE_MS = 1_000;
 
@@ -99,6 +106,17 @@ export interface NotebookDocPersistenceOptions {
   /** Trailing-edge save throttle in milliseconds (default 1000). */
   throttleMs?: number;
 
+  /**
+   * Heads of the record already sitting in storage, when the session
+   * seeded from it (`meta.headsHex`). Lets the first capture dedupe
+   * against the existing record instead of unconditionally re-writing
+   * identical bytes on the handshake's protocol-only change signal —
+   * automerge-repo records loaded heads the same way (`loadDoc` updates
+   * its stored-heads handle). Only pass heads that describe the record
+   * currently in storage.
+   */
+  initialSavedHeadsHex?: string[];
+
   /** Persistence failures route here; they never throw into the session. */
   onError?: (error: unknown) => void;
 
@@ -117,12 +135,23 @@ export class NotebookDocPersistence {
   private consecutiveSaveFailures = 0;
   /** Serializes adapter writes so two saves never interleave (latest wins). */
   private writeChain: Promise<void> = Promise.resolve();
+  /**
+   * Heads of the newest capture handed to the write chain (null = none).
+   * Recorded optimistically at capture so a protocol-only signal during an
+   * in-flight write cannot queue a duplicate; a failed write forgets its
+   * own heads (only if no newer capture has superseded them) so the next
+   * signal retries.
+   */
+  private lastSavedHeadsKey: string | null = null;
 
   constructor(opts: NotebookDocPersistenceOptions) {
     this.opts = opts;
     this.keySegment = opts.keySegment ?? NOTEBOOK_DOC_SNAPSHOT_KEY_SEGMENT;
     this.throttleMs = opts.throttleMs ?? DEFAULT_SAVE_THROTTLE_MS;
     this.logger = opts.logger ?? console;
+    this.lastSavedHeadsKey = opts.initialSavedHeadsHex
+      ? headsCacheKey(opts.initialSavedHeadsHex)
+      : null;
     this.subscription = opts.changes$.subscribe(() => this.onChanged());
   }
 
@@ -146,12 +175,14 @@ export class NotebookDocPersistence {
   /**
    * Commit the current document state immediately (pagehide, teardown).
    *
-   * Captures unconditionally, ignoring the change-signal dirty flag: local
-   * edits inside the engine's flush debounce have not emitted yet, but
-   * `getSaveBytes()` already sees them. Bytes are captured synchronously,
-   * so a handle freed right after this call returns is never touched by
-   * the queued write; the returned promise resolves once the write chain
-   * has committed.
+   * Captures ignoring the change-signal dirty flag: local edits inside
+   * the engine's flush debounce have not emitted yet, but `getSaveBytes()`
+   * already sees them. The heads-dedupe still applies — committed edits
+   * always move the heads, so the only skipped flushes are ones whose
+   * exact state the write chain has already accepted. Bytes are captured
+   * synchronously, so a handle freed right after this call returns is
+   * never touched by the queued write; the returned promise resolves once
+   * the write chain has committed.
    */
   async flushNow(): Promise<void> {
     if (this.disposed) return;
@@ -183,9 +214,19 @@ export class NotebookDocPersistence {
     // Capture synchronously: getSaveBytes touches the WASM handle, which a
     // disposing session may free as soon as this call returns.
     let envelope: Uint8Array;
+    let headsKey: string;
     try {
+      const headsHex = this.opts.getHeadsHex();
+      headsKey = headsCacheKey(headsHex);
+      if (headsKey === this.lastSavedHeadsKey) {
+        // Heads unchanged since the newest capture: the change signal
+        // over-fired (protocol-only flush) — skip the no-op snapshot.
+        // Edits inside the engine's flush debounce are already committed
+        // to the doc, so they move the heads and never land here.
+        return this.writeChain;
+      }
       const meta: NotebookDocPersistenceMeta = {
-        headsHex: this.opts.getHeadsHex(),
+        headsHex,
         savedAt: Date.now(),
         principal: this.opts.principal,
         schemaVersion: 1,
@@ -196,13 +237,22 @@ export class NotebookDocPersistence {
       return this.writeChain;
     }
 
+    // Record optimistically so signals during the in-flight write dedupe
+    // against this capture rather than queueing an identical envelope.
+    this.lastSavedHeadsKey = headsKey;
+
     const { adapter, notebookId } = this.opts;
     const key = [notebookId, this.keySegment];
     const write = this.writeChain.then(async () => {
       try {
-        await adapter.save(key, envelope);
+        await saveBatch(adapter, [[key, envelope]]);
         this.consecutiveSaveFailures = 0;
       } catch (error) {
+        // Forget this capture's heads so the next signal retries — unless
+        // a newer capture already superseded them.
+        if (this.lastSavedHeadsKey === headsKey) {
+          this.lastSavedHeadsKey = null;
+        }
         this.reportSaveFailure("save failed", error);
       }
     });
@@ -226,6 +276,15 @@ export class NotebookDocPersistence {
       this.dispose();
     }
   }
+}
+
+/**
+ * Comparison key for a heads array. Heads from `get_heads_hex()` are
+ * already canonically sorted (automerge sorts `get_heads()`), so plain
+ * joining matches automerge-repo's exact-array `headsAreSame`.
+ */
+function headsCacheKey(headsHex: string[]): string {
+  return headsHex.join(" ");
 }
 
 /**

--- a/packages/runtimed/src/persistence/storage-adapter.ts
+++ b/packages/runtimed/src/persistence/storage-adapter.ts
@@ -75,11 +75,16 @@ export async function saveBatch(
 export class SaveBatchEntryError extends Error {
   readonly key: StorageKey;
   readonly index: number;
+  // Declared and assigned directly rather than via the ES2022 ErrorOptions
+  // constructor argument — apps/notebook compiles this package under
+  // lib: ES2020, where Error has no `cause` member.
+  readonly cause: unknown;
 
   constructor(key: StorageKey, index: number, cause: unknown) {
-    super(`saveBatch fallback failed at entry ${index} (${key.join("/")})`, { cause });
+    super(`saveBatch fallback failed at entry ${index} (${key.join("/")})`);
     this.name = "SaveBatchEntryError";
     this.key = key;
     this.index = index;
+    this.cause = cause;
   }
 }

--- a/packages/runtimed/src/persistence/storage-adapter.ts
+++ b/packages/runtimed/src/persistence/storage-adapter.ts
@@ -20,4 +20,43 @@ export interface StorageAdapter {
   remove(key: StorageKey): Promise<void>;
   loadRange(prefix: StorageKey): Promise<StorageChunk[]>;
   removeRange(prefix: StorageKey): Promise<void>;
+
+  /**
+   * Save multiple key-value pairs as a staged batch (upstream
+   * automerge-repo's `StorageAdapterInterface.saveBatch` extension, kept
+   * optional here so plain adapters keep working via {@link saveBatch}'s
+   * sequential fallback).
+   *
+   * Implementations SHOULD apply the batch in two phases — stage every
+   * entry durably, then commit — so a failure before commit leaves no
+   * entry observable. At minimum each entry must be atomic on its own.
+   *
+   * The contract is per-batch, not cross-batch: callers that need
+   * crash-ordering across record kinds must issue separate sequential
+   * `saveBatch` calls in dependency order (payload chunks first, metadata
+   * second, the visibility marker last), so a crash between batches
+   * leaves invisible orphans rather than a visible-but-incomplete record.
+   */
+  saveBatch?(entries: Array<[StorageKey, Uint8Array]>): Promise<void>;
+}
+
+/**
+ * Save a batch through the adapter's `saveBatch` when it has one,
+ * falling back to sequential `save` calls (upstream's default-impl
+ * shape). The fallback is per-entry-atomic only — callers that need the
+ * stronger staged semantics get them exactly when the adapter provides
+ * them.
+ */
+export async function saveBatch(
+  adapter: StorageAdapter,
+  entries: Array<[StorageKey, Uint8Array]>,
+): Promise<void> {
+  if (entries.length === 0) return;
+  if (adapter.saveBatch) {
+    await adapter.saveBatch(entries);
+    return;
+  }
+  for (const [key, data] of entries) {
+    await adapter.save(key, data);
+  }
 }

--- a/packages/runtimed/src/persistence/storage-adapter.ts
+++ b/packages/runtimed/src/persistence/storage-adapter.ts
@@ -43,9 +43,12 @@ export interface StorageAdapter {
 /**
  * Save a batch through the adapter's `saveBatch` when it has one,
  * falling back to sequential `save` calls (upstream's default-impl
- * shape). The fallback is per-entry-atomic only — callers that need the
- * stronger staged semantics get them exactly when the adapter provides
- * them.
+ * shape). The fallback is per-entry-atomic only: when entry N fails,
+ * entries 0..N-1 are already durable and N.. were never attempted — the
+ * thrown `SaveBatchEntryError` carries the failed key and index so
+ * callers can tell a clean prefix from an unknown state. Callers that
+ * need the stronger staged semantics get them exactly when the adapter
+ * provides them.
  */
 export async function saveBatch(
   adapter: StorageAdapter,
@@ -56,7 +59,27 @@ export async function saveBatch(
     await adapter.saveBatch(entries);
     return;
   }
-  for (const [key, data] of entries) {
-    await adapter.save(key, data);
+  for (const [index, [key, data]] of entries.entries()) {
+    try {
+      await adapter.save(key, data);
+    } catch (cause) {
+      throw new SaveBatchEntryError(key, index, cause);
+    }
+  }
+}
+
+/**
+ * Sequential-fallback failure: entries before `index` are durable,
+ * `index` and after are not written.
+ */
+export class SaveBatchEntryError extends Error {
+  readonly key: StorageKey;
+  readonly index: number;
+
+  constructor(key: StorageKey, index: number, cause: unknown) {
+    super(`saveBatch fallback failed at entry ${index} (${key.join("/")})`, { cause });
+    this.name = "SaveBatchEntryError";
+    this.key = key;
+    this.index = index;
   }
 }

--- a/packages/runtimed/tests/indexeddb-storage-adapter.test.ts
+++ b/packages/runtimed/tests/indexeddb-storage-adapter.test.ts
@@ -109,6 +109,59 @@ describe("IndexedDbStorageAdapter", () => {
     expect(await adapter.load(["nb-2", "snapshot"])).toEqual(new Uint8Array([3]));
   });
 
+  it("saveBatch commits all entries in one transaction", async () => {
+    const adapter = createAdapter();
+
+    await adapter.saveBatch([
+      [["nb-1", "snapshot"], new Uint8Array([1])],
+      [["nb-1", "meta"], new Uint8Array([2])],
+    ]);
+
+    expect(await adapter.load(["nb-1", "snapshot"])).toEqual(new Uint8Array([1]));
+    expect(await adapter.load(["nb-1", "meta"])).toEqual(new Uint8Array([2]));
+  });
+
+  it("saveBatch of no entries resolves without opening a transaction", async () => {
+    const factory = new IDBFactory();
+    const opens = vi.spyOn(factory, "open");
+    const adapter = IndexedDbStorageAdapter.create({ indexedDB: factory });
+    if (!adapter) throw new Error("expected adapter for injected factory");
+
+    await adapter.saveBatch([]);
+
+    expect(opens).not.toHaveBeenCalled();
+  });
+
+  it("saveBatch is all-or-nothing when a put fails mid-batch", async () => {
+    const onError = vi.fn();
+    const adapter = createAdapter({ onError });
+    const quotaError = new DOMException("quota exceeded", "QuotaExceededError");
+    const realPut = IDBObjectStore.prototype.put;
+    let puts = 0;
+    vi.spyOn(IDBObjectStore.prototype, "put").mockImplementation(function (
+      this: IDBObjectStore,
+      ...args: Parameters<typeof realPut>
+    ) {
+      puts += 1;
+      if (puts === 2) throw quotaError;
+      return realPut.apply(this, args);
+    });
+
+    await expect(
+      adapter.saveBatch([
+        [["nb-1", "snapshot"], new Uint8Array([1])],
+        [["nb-1", "meta"], new Uint8Array([2])],
+      ]),
+    ).rejects.toBe(quotaError);
+    expect(onError).toHaveBeenCalledWith(quotaError);
+
+    // The first entry's put was issued on the same aborted transaction, so
+    // nothing from the batch is observable.
+    vi.restoreAllMocks();
+    expect(await adapter.load(["nb-1", "snapshot"])).toBeUndefined();
+    expect(await adapter.load(["nb-1", "meta"])).toBeUndefined();
+  });
+
   it("create returns null when indexedDB is unavailable", () => {
     vi.stubGlobal("indexedDB", undefined);
     expect(IndexedDbStorageAdapter.create()).toBeNull();

--- a/packages/runtimed/tests/indexeddb-storage-adapter.test.ts
+++ b/packages/runtimed/tests/indexeddb-storage-adapter.test.ts
@@ -132,6 +132,55 @@ describe("IndexedDbStorageAdapter", () => {
     expect(opens).not.toHaveBeenCalled();
   });
 
+  it("saveBatch surfaces the failing request's error when the transaction aborts with error: null", async () => {
+    // Async per-request failures (quota aborts) can leave transaction.error
+    // null; the rejection must still name the real cause from the request.
+    const adapter = createAdapter();
+    const quotaError = new DOMException("quota exceeded", "QuotaExceededError");
+    type PutRequest = { error: DOMException | null; onerror: (() => void) | null };
+    type FakeTransaction = {
+      error: DOMException | null;
+      oncomplete: (() => void) | null;
+      onabort: (() => void) | null;
+      onerror: (() => void) | null;
+      objectStore: () => { put: () => PutRequest };
+    };
+    // Warm the connection first: a prototype-level transaction mock would
+    // otherwise break fake-indexeddb's internal versionchange transaction
+    // during open.
+    await adapter.save(["warm"], new Uint8Array([0]));
+
+    let fake: FakeTransaction | null = null;
+    const requests: PutRequest[] = [];
+    vi.spyOn(IDBDatabase.prototype, "transaction").mockImplementationOnce(function () {
+      fake = {
+        error: null,
+        oncomplete: null,
+        onabort: null,
+        onerror: null,
+        objectStore: () => ({
+          put: () => {
+            const request: PutRequest = { error: null, onerror: null };
+            requests.push(request);
+            return request;
+          },
+        }),
+      };
+      return fake as unknown as IDBTransaction;
+    });
+
+    const attempt = adapter.saveBatch([
+      [["nb-1", "a"], new Uint8Array([1])],
+      [["nb-1", "b"], new Uint8Array([2])],
+    ]);
+    await vi.waitFor(() => expect(requests).toHaveLength(2));
+    requests[1]!.error = quotaError;
+    requests[1]!.onerror?.();
+    fake!.onabort?.(); // transaction.error stays null
+
+    await expect(attempt).rejects.toBe(quotaError);
+  });
+
   it("saveBatch is all-or-nothing when a put fails mid-batch", async () => {
     const onError = vi.fn();
     const adapter = createAdapter({ onError });

--- a/packages/runtimed/tests/notebook-doc-persistence.test.ts
+++ b/packages/runtimed/tests/notebook-doc-persistence.test.ts
@@ -298,8 +298,12 @@ describe("NotebookDocPersistence", () => {
     changes$.next();
     await controller.flushNow();
 
-    expect(onError).toHaveBeenCalledWith(failure);
-    expect(warn).toHaveBeenCalledWith(expect.stringContaining("[notebook-persistence]"), failure);
+    // The sequential fallback wraps the failure with the entry's key and
+    // index; the original error rides along as `cause`.
+    expect(onError).toHaveBeenCalledTimes(1);
+    const reported = onError.mock.calls[0]![0] as Error;
+    expect(reported.cause).toBe(failure);
+    expect(warn).toHaveBeenCalledWith(expect.stringContaining("[notebook-persistence]"), reported);
     controller.dispose();
   });
 
@@ -482,6 +486,53 @@ describe("NotebookDocPersistence", () => {
     controller.dispose();
   });
 
+  it("flushNow does not trust an in-flight write that then fails", async () => {
+    // Teardown sequence: capture H1, write W1 in flight, flushNow() at H1.
+    // If the flush deduped against the OPTIMISTIC key it would skip — and
+    // when W1 then fails (errors are swallowed, handle freed) the H1 state,
+    // possibly the only copy of offline edits, would never be persisted.
+    // The flush must dedupe only against COMMITTED writes.
+    const outcomes: Array<{ resolve: () => void; reject: (e: Error) => void }> = [];
+    adapter.save = vi.fn((key: StorageKey, data: Uint8Array) => {
+      return new Promise<void>((resolve, reject) => {
+        outcomes.push({
+          resolve: () => {
+            adapter.saves.push({ key, data });
+            resolve();
+          },
+          reject,
+        });
+      });
+    });
+    const controller = createController();
+
+    changes$.next();
+    await vi.advanceTimersByTimeAsync(1_000); // capture H1, W1 in flight
+
+    const flushed = controller.flushNow(); // H1 again — must NOT skip
+    controller.dispose();
+
+    outcomes.shift()?.reject(new Error("quota exceeded")); // W1 fails late
+    await vi.advanceTimersByTimeAsync(0);
+    outcomes.shift()?.resolve(); // the flush's write commits
+    await flushed;
+
+    expect(adapter.saves).toHaveLength(1);
+    expect(decodePersistedNotebookDoc(adapter.saves[0]!.data).meta?.headsHex).toEqual(["aa"]);
+  });
+
+  it("flushNow dedupes against a write that has committed", async () => {
+    const controller = createController();
+
+    changes$.next();
+    await vi.advanceTimersByTimeAsync(1_000); // W1 committed
+    expect(adapter.saves).toHaveLength(1);
+
+    await controller.flushNow(); // same heads, durably saved — skip
+    expect(adapter.saves).toHaveLength(1);
+    controller.dispose();
+  });
+
   it("initialSavedHeadsHex dedupes the first save against the seeded record", async () => {
     const getSaveBytes = vi.fn(() => saveBytes);
     const controller = createController({
@@ -502,12 +553,63 @@ describe("NotebookDocPersistence", () => {
     controller.dispose();
   });
 
+  it("treats empty initialSavedHeadsHex as unknown, never an identity", async () => {
+    // decodeMeta accepts headsHex: [] and a freshly-bootstrapped doc
+    // (RuntimeStateDoc starts empty by design) also reports empty heads —
+    // matching the two would skip the first save over a stale record.
+    headsHex = [];
+    const controller = createController({ initialSavedHeadsHex: [] });
+
+    changes$.next();
+    await vi.advanceTimersByTimeAsync(1_000);
+
+    expect(adapter.saves).toHaveLength(1);
+    controller.dispose();
+  });
+
+  it("a deduped skip neither increments nor resets the failure counter", async () => {
+    // Three consecutive failures self-dispose; a skip is not a save and
+    // must count for nothing. Observed through the threshold: with the
+    // counter at 2, a skip must not dispose (no increment) and the NEXT
+    // failure must (no reset).
+    const disposedMsg = "[notebook-persistence] disabled after repeated save failures";
+    adapter.save = vi.fn(async () => {
+      throw new Error("quota exceeded");
+    });
+    const warn = vi.fn();
+    const controller = createController({
+      logger: { warn },
+      initialSavedHeadsHex: ["aa"], // committed key for the flush skip below
+    });
+
+    // Two failures bring the counter to 2.
+    for (const head of ["h1", "h2"]) {
+      headsHex = [head];
+      changes$.next();
+      await vi.advanceTimersByTimeAsync(1_000);
+    }
+    expect(warn).not.toHaveBeenCalledWith(disposedMsg);
+
+    // A flush at the seeded (committed) heads skips. An incrementing skip
+    // would hit 3 and dispose here.
+    headsHex = ["aa"];
+    await controller.flushNow();
+    expect(warn).not.toHaveBeenCalledWith(disposedMsg);
+
+    // The next failure must be the third — a resetting skip would leave
+    // the counter at 1 and keep the controller alive.
+    headsHex = ["h3"];
+    changes$.next();
+    await vi.advanceTimersByTimeAsync(1_000);
+    expect(warn).toHaveBeenCalledWith(disposedMsg);
+  });
+
   it("prefers the adapter's saveBatch over plain save when available", async () => {
     const batches: Array<Array<[StorageKey, Uint8Array]>> = [];
     adapter.saveBatch = vi.fn(async (entries: Array<[StorageKey, Uint8Array]>) => {
       batches.push(entries);
       for (const [key, data] of entries) {
-        adapter.records.set(key.join(" "), data);
+        adapter.records.set(key.join("\u0000"), data);
       }
     });
     const controller = createController();
@@ -565,9 +667,13 @@ describe("saveBatch helper", () => {
     ]);
   });
 
-  it("preserves entry order in the sequential fallback (crash-ordering)", async () => {
-    // Callers express crash-ordering by entry order within (and across)
-    // batches; the fallback must not reorder or parallelize.
+  it("preserves entry order in the sequential fallback", async () => {
+    // Crash-ordering proper lives ACROSS batches (callers sequence
+    // dependent record kinds as separate saveBatch calls; a native batch
+    // is atomic, so within-batch order is moot there). The fallback is
+    // per-entry, where order is the only structure left: keeping it means
+    // a crash mid-fallback leaves a clean prefix, never an arbitrary
+    // subset.
     const adapter = createRecordingAdapter();
     const order: string[] = [];
     let release: (() => void) | null = null;
@@ -600,6 +706,33 @@ describe("saveBatch helper", () => {
 
     expect(adapter.saveBatch).toHaveBeenCalledWith(entries);
     expect(adapter.save).not.toHaveBeenCalled();
+  });
+
+  it("fallback failure names the failed entry and leaves a clean prefix", async () => {
+    const adapter = createRecordingAdapter();
+    const failure = new Error("disk full");
+    let saves = 0;
+    adapter.save = vi.fn(async (key: StorageKey, data: Uint8Array) => {
+      if (++saves === 2) throw failure;
+      adapter.records.set(key.join("/"), data);
+    });
+
+    const attempt = saveBatch(adapter, [
+      [["nb-1", "a"], new Uint8Array([1])],
+      [["nb-1", "b"], new Uint8Array([2])],
+      [["nb-1", "c"], new Uint8Array([3])],
+    ]);
+
+    await expect(attempt).rejects.toMatchObject({
+      name: "SaveBatchEntryError",
+      key: ["nb-1", "b"],
+      index: 1,
+      cause: failure,
+    });
+    // Entries before the failure are durable; the failed entry and
+    // everything after were never written.
+    expect([...adapter.records.keys()]).toEqual(["nb-1/a"]);
+    expect(adapter.save).toHaveBeenCalledTimes(2);
   });
 
   it("is a no-op for an empty batch", async () => {

--- a/packages/runtimed/tests/notebook-doc-persistence.test.ts
+++ b/packages/runtimed/tests/notebook-doc-persistence.test.ts
@@ -18,7 +18,11 @@ import {
   loadPersistedNotebookRecord,
   type NotebookDocPersistenceMeta,
 } from "../src/persistence/notebook-doc-persistence";
-import type { StorageAdapter, StorageKey } from "../src/persistence/storage-adapter";
+import {
+  saveBatch,
+  type StorageAdapter,
+  type StorageKey,
+} from "../src/persistence/storage-adapter";
 
 interface RecordingAdapter extends StorageAdapter {
   saves: Array<{ key: StorageKey; data: Uint8Array }>;
@@ -146,7 +150,9 @@ describe("NotebookDocPersistence", () => {
     await vi.advanceTimersByTimeAsync(1_000);
     expect(adapter.saves).toHaveLength(1); // first envelope write in flight
 
-    // A second change while the first write is stuck queues a second save.
+    // A second change (heads moved) while the first write is stuck queues
+    // a second save.
+    headsHex = ["bb"];
     changes$.next();
     await vi.advanceTimersByTimeAsync(1_000);
     expect(adapter.saves).toHaveLength(1); // still queued behind write one
@@ -339,6 +345,182 @@ describe("NotebookDocPersistence", () => {
     expect(getSaveBytes).toHaveBeenCalledTimes(3);
   });
 
+  it("skips the save when heads are unchanged since the last save", async () => {
+    // notebookDocChanged$ over-fires for protocol-only flushes; identical
+    // heads mean identical doc state, so the snapshot would be a no-op.
+    const getSaveBytes = vi.fn(() => saveBytes);
+    const controller = createController({ getSaveBytes });
+
+    changes$.next();
+    await vi.advanceTimersByTimeAsync(1_000);
+    expect(adapter.saves).toHaveLength(1);
+
+    // Same heads: the signal was protocol-only churn.
+    changes$.next();
+    await vi.advanceTimersByTimeAsync(1_000);
+    expect(adapter.saves).toHaveLength(1);
+    expect(getSaveBytes).toHaveBeenCalledTimes(1); // no doomed serialization either
+
+    // Heads moved: a real doc change saves again.
+    headsHex = ["bb"];
+    changes$.next();
+    await vi.advanceTimersByTimeAsync(1_000);
+    expect(adapter.saves).toHaveLength(2);
+    controller.dispose();
+  });
+
+  it("dedupes against in-flight writes, not just committed ones", async () => {
+    const resolvers: Array<() => void> = [];
+    adapter.save = vi.fn((key: StorageKey, data: Uint8Array) => {
+      adapter.saves.push({ key, data });
+      return new Promise<void>((resolve) => {
+        resolvers.push(resolve);
+      });
+    });
+    const controller = createController();
+
+    changes$.next();
+    await vi.advanceTimersByTimeAsync(1_000);
+    expect(adapter.saves).toHaveLength(1); // write one stuck in flight
+
+    // A protocol-only signal while write one is still pending must not
+    // queue an identical envelope behind it.
+    changes$.next();
+    await vi.advanceTimersByTimeAsync(1_000);
+
+    while (resolvers.length > 0) {
+      resolvers.shift()?.();
+      await vi.advanceTimersByTimeAsync(0);
+    }
+    expect(adapter.saves).toHaveLength(1);
+    controller.dispose();
+  });
+
+  it("distinguishes heads sets, not just lengths or prefixes", async () => {
+    const controller = createController();
+
+    headsHex = ["aa", "bb"];
+    changes$.next();
+    await vi.advanceTimersByTimeAsync(1_000);
+
+    headsHex = ["aa"];
+    changes$.next();
+    await vi.advanceTimersByTimeAsync(1_000);
+
+    expect(adapter.saves).toHaveLength(2);
+    controller.dispose();
+  });
+
+  it("a failed save forgets its heads so the next signal retries", async () => {
+    let failNext = true;
+    adapter.save = vi.fn(async (key: StorageKey, data: Uint8Array) => {
+      if (failNext) throw new Error("quota exceeded");
+      adapter.saves.push({ key, data });
+    });
+    const controller = createController();
+
+    changes$.next();
+    await vi.advanceTimersByTimeAsync(1_000);
+    expect(adapter.saves).toHaveLength(0); // write failed
+
+    // Same heads, but the failed write must not count as saved.
+    failNext = false;
+    changes$.next();
+    await vi.advanceTimersByTimeAsync(1_000);
+    expect(adapter.saves).toHaveLength(1);
+    controller.dispose();
+  });
+
+  it("a failed write does not clobber a newer capture's recorded heads", async () => {
+    // Write one (heads aa) fails AFTER write two (heads bb) was captured:
+    // the failure must not reset the dedupe to null and reopen writes for
+    // heads bb state that write two already covers.
+    const outcomes: Array<{ resolve: () => void; reject: (e: Error) => void }> = [];
+    adapter.save = vi.fn((key: StorageKey, data: Uint8Array) => {
+      adapter.saves.push({ key, data });
+      return new Promise<void>((resolve, reject) => {
+        outcomes.push({ resolve, reject: (e) => reject(e) });
+      });
+    });
+    const controller = createController();
+
+    changes$.next();
+    await vi.advanceTimersByTimeAsync(1_000); // capture aa, write one in flight
+
+    headsHex = ["bb"];
+    changes$.next();
+    await vi.advanceTimersByTimeAsync(1_000); // capture bb, queued behind one
+
+    outcomes.shift()?.reject(new Error("disk full")); // write one fails late
+    await vi.advanceTimersByTimeAsync(0);
+    outcomes.shift()?.resolve(); // write two commits
+    await vi.advanceTimersByTimeAsync(0);
+    expect(adapter.saves).toHaveLength(2);
+
+    // Protocol-only signal at heads bb: still deduped.
+    changes$.next();
+    await vi.advanceTimersByTimeAsync(1_000);
+    expect(adapter.saves).toHaveLength(2);
+    controller.dispose();
+  });
+
+  it("flushNow skips the write when heads are unchanged", async () => {
+    const getSaveBytes = vi.fn(() => saveBytes);
+    const controller = createController({ getSaveBytes });
+
+    changes$.next();
+    await vi.advanceTimersByTimeAsync(1_000);
+    expect(adapter.saves).toHaveLength(1);
+
+    await controller.flushNow(); // pagehide with nothing new
+    expect(adapter.saves).toHaveLength(1);
+    expect(getSaveBytes).toHaveBeenCalledTimes(1);
+
+    headsHex = ["bb"]; // committed edit inside the engine's flush debounce
+    await controller.flushNow();
+    expect(adapter.saves).toHaveLength(2);
+    controller.dispose();
+  });
+
+  it("initialSavedHeadsHex dedupes the first save against the seeded record", async () => {
+    const getSaveBytes = vi.fn(() => saveBytes);
+    const controller = createController({
+      getSaveBytes,
+      initialSavedHeadsHex: ["aa"],
+    });
+
+    // The handshake's protocol-only change signal at the seeded heads.
+    changes$.next();
+    await vi.advanceTimersByTimeAsync(1_000);
+    expect(adapter.saves).toHaveLength(0);
+    expect(getSaveBytes).not.toHaveBeenCalled();
+
+    headsHex = ["bb"];
+    changes$.next();
+    await vi.advanceTimersByTimeAsync(1_000);
+    expect(adapter.saves).toHaveLength(1);
+    controller.dispose();
+  });
+
+  it("prefers the adapter's saveBatch over plain save when available", async () => {
+    const batches: Array<Array<[StorageKey, Uint8Array]>> = [];
+    adapter.saveBatch = vi.fn(async (entries: Array<[StorageKey, Uint8Array]>) => {
+      batches.push(entries);
+      for (const [key, data] of entries) {
+        adapter.records.set(key.join(" "), data);
+      }
+    });
+    const controller = createController();
+
+    changes$.next();
+    await vi.advanceTimersByTimeAsync(1_000);
+
+    expect(adapter.save).not.toHaveBeenCalled();
+    expect(batches).toHaveLength(1);
+    expect(batches[0]!.map(([key]) => key)).toEqual([["nb-1", "snapshot"]]);
+    controller.dispose();
+  });
+
   it("a successful save resets the consecutive-failure count", async () => {
     const getSaveBytes = vi.fn(() => saveBytes);
     let failNext = true;
@@ -349,18 +531,85 @@ describe("NotebookDocPersistence", () => {
     const controller = createController({ getSaveBytes });
 
     // Two failures, then a success, then two more failures: never three
-    // consecutive, so persistence stays alive.
+    // consecutive, so persistence stays alive. Heads move on every change
+    // so the dedupe never absorbs a capture.
+    let head = 0;
     for (const fail of [true, true, false, true, true]) {
       failNext = fail;
+      headsHex = [`head-${head++}`];
       changes$.next();
       await vi.advanceTimersByTimeAsync(1_000);
     }
 
     failNext = false;
+    headsHex = [`head-${head++}`];
     changes$.next();
     await vi.advanceTimersByTimeAsync(1_000);
     expect(getSaveBytes).toHaveBeenCalledTimes(6);
     controller.dispose();
+  });
+});
+
+describe("saveBatch helper", () => {
+  it("falls back to sequential saves when the adapter lacks saveBatch", async () => {
+    const adapter = createRecordingAdapter();
+
+    await saveBatch(adapter, [
+      [["nb-1", "a"], new Uint8Array([1])],
+      [["nb-1", "b"], new Uint8Array([2])],
+    ]);
+
+    expect(adapter.saves.map((s) => s.key)).toEqual([
+      ["nb-1", "a"],
+      ["nb-1", "b"],
+    ]);
+  });
+
+  it("preserves entry order in the sequential fallback (crash-ordering)", async () => {
+    // Callers express crash-ordering by entry order within (and across)
+    // batches; the fallback must not reorder or parallelize.
+    const adapter = createRecordingAdapter();
+    const order: string[] = [];
+    let release: (() => void) | null = null;
+    adapter.save = vi.fn(async (key: StorageKey) => {
+      order.push(key.join("/"));
+      if (!release) {
+        await new Promise<void>((resolve) => {
+          release = resolve;
+        });
+      }
+    });
+
+    const done = saveBatch(adapter, [
+      [["nb-1", "blob"], new Uint8Array([1])],
+      [["nb-1", "marker"], new Uint8Array([2])],
+    ]);
+    await Promise.resolve();
+    expect(order).toEqual(["nb-1/blob"]); // marker not started while blob pends
+    release!();
+    await done;
+    expect(order).toEqual(["nb-1/blob", "nb-1/marker"]);
+  });
+
+  it("uses the adapter's saveBatch when present", async () => {
+    const adapter = createRecordingAdapter();
+    const entries: Array<[StorageKey, Uint8Array]> = [[["nb-1", "a"], new Uint8Array([1])]];
+    adapter.saveBatch = vi.fn(async () => {});
+
+    await saveBatch(adapter, entries);
+
+    expect(adapter.saveBatch).toHaveBeenCalledWith(entries);
+    expect(adapter.save).not.toHaveBeenCalled();
+  });
+
+  it("is a no-op for an empty batch", async () => {
+    const adapter = createRecordingAdapter();
+    adapter.saveBatch = vi.fn(async () => {});
+
+    await saveBatch(adapter, []);
+
+    expect(adapter.saveBatch).not.toHaveBeenCalled();
+    expect(adapter.save).not.toHaveBeenCalled();
   });
 });
 


### PR DESCRIPTION
Adopts slices 1 and 2 of #3585 — the two "small, ready now" shapes from automerge-repo's storage subsystem.

## Slice 1 — `saveBatch(entries)` adapter extension

- `StorageAdapter` gains an **optional** `saveBatch(entries: Array<[StorageKey, Uint8Array]>)` — upstream's exact `StorageAdapterInterface` extension (subductionjs branch), kept optional so plain adapters keep working.
- A `saveBatch(adapter, entries)` helper provides the sequential-`save` fallback (upstream's deprecated-base-class default impl shape), preserving entry order so callers can express crash-ordering.
- `IndexedDbStorageAdapter.saveBatch` commits all entries in **one readwrite transaction** — all-or-nothing, strictly stronger than the staged two-phase minimum the interface asks for. A synchronous `put` throw aborts the transaction so already-issued puts can't auto-commit a partial batch.
- The interface doc records the cross-batch crash-ordering discipline from upstream's `saveBatchAll` (payload chunks → metadata → visibility marker: a crash leaves invisible orphans, never a visible-but-incomplete record) for when incremental chunks arrive (#3585 slice 4).
- The envelope write is the first user: today's single-record envelope is a one-entry batch through the helper.

## Slice 2 — heads-dedupe on save

automerge-repo's `#shouldSave` shape. `notebookDocChanged$` is documented as an over-firing save hint (protocol-only flushes — handshake, resync negotiation — also emit). Previously every emission triggered a full-doc serialization + IDB write; now:

- Each capture compares `get_heads_hex()` (canonically sorted by automerge core) against the heads of the **newest capture handed to the write chain**, and skips both the serialization and the write on a match. Recording optimistically at capture time means a protocol-only signal during an in-flight write can't queue an identical envelope behind it.
- A **failed** write forgets its recorded heads so the next signal retries — unless a newer capture already superseded them (a late failure must not reopen writes for state a queued newer write covers).
- `flushNow()` keeps its capture-unconditionally semantics but now dedupes too: committed edits always move the heads, so the only skipped flushes are ones whose exact state the write chain already accepted.
- Seeded sessions initialize the dedupe from the loaded record's `meta.headsHex` (threaded through `resolveCloudNotebookHandle` → `CloudSyncRuntime.persistenceSeedMeta`), so the handshake's protocol-only signal doesn't re-write the identical envelope it just loaded. Gated on **first arm only** (a later controller may follow an overwrite of the seeded record) and on the seeded principal matching the armed principal (a mismatched record would need re-stamping, which dedupe must not suppress).

## Testing

- `packages/runtimed` tests: 53 pass in the two persistence files (15 new: dedupe skip/retry/in-flight/heads-set-vs-prefix/seed-init, saveBatch helper fallback + ordering, IDB one-transaction + abort-on-partial).
- `apps/notebook-cloud` node suite: 692 pass (one existing deep-equal updated for the new `seedMeta` field).
- `tsc -p apps/notebook-cloud` clean, `cargo xtask lint --fix` clean.

ADR (`docs/adr/local-first-notebook-state.md`) updated: storage-layer interface, save-hint section, and prior-art alignment item 1 marked adopted.

Closes the "Slices 1+2 are a natural single PR" line of #3585; slice 3 (BroadcastChannel multi-tab) and slice 4 (fragments API) remain.

🤖 Generated with [Claude Code](https://claude.com/claude-code)