### PR TITLE
fix(notebook-cloud): repair stale room runtime state

### DIFF
--- a/apps/notebook-cloud/src/index.ts
+++ b/apps/notebook-cloud/src/index.ts
@@ -284,6 +284,12 @@ const NOTEBOOK_CLOUD_ROUTES: readonly WorkerRoute[] = [
       routeNotebookWorkstationAttachment(request, env, params.notebookId),
   },
   {
+    match: routePath("/api/n/:notebookId/runtime-state-repair", { trailingSlash: "optional" }),
+    methods: ["POST"],
+    handler: ({ params }, request, env) =>
+      routeNotebookRuntimeStateRepair(request, env, params.notebookId),
+  },
+  {
     match: routePath("/api/n/:notebookId/access-requests/:accessRequestId", {
       trailingSlash: "optional",
     }),
@@ -1138,6 +1144,66 @@ async function routeNotebookWorkstationAttachment(
     },
     202,
   );
+}
+
+async function routeNotebookRuntimeStateRepair(
+  request: Request,
+  env: Env,
+  notebookId: string,
+): Promise<Response> {
+  if (!env.DB) {
+    return json({ error: "D1 binding DB is not configured" }, 503);
+  }
+
+  const originRejection = rejectUntrustedMutationOrigin(request, env);
+  if (originRejection) {
+    return originRejection;
+  }
+
+  const identity = await authenticateAndAuthorizeOrAppSessionOrResponse(
+    request,
+    env,
+    notebookId,
+    "owner",
+  );
+  if (identity instanceof Response) {
+    return identity;
+  }
+
+  const payload = await readOptionalJsonObject(request, "runtime state repair body");
+  if (payload instanceof Response) {
+    return payload;
+  }
+  const reason = optionalBoundedStringField(payload?.reason, "reason", 240);
+  if (reason instanceof Response) {
+    return reason;
+  }
+  const force = payload?.force === true;
+
+  const id = env.NOTEBOOK_ROOMS.idFromName(notebookId);
+  const room = env.NOTEBOOK_ROOMS.get(id);
+  const response = await room.fetch(
+    new Request(
+      `https://notebook-room.internal/internal/n/${encodeURIComponent(
+        notebookId,
+      )}/runtime-state-repair`,
+      {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          force,
+          reason: reason ?? "manual runtime state repair",
+        }),
+      },
+    ),
+  );
+  let body: unknown;
+  try {
+    body = await response.json();
+  } catch {
+    body = { error: "runtime state repair returned a non-JSON response" };
+  }
+  return json(body, response.status);
 }
 
 async function routeWorkstationAttachJobs(

--- a/apps/notebook-cloud/src/notebook-room.ts
+++ b/apps/notebook-cloud/src/notebook-room.ts
@@ -151,6 +151,10 @@ export class NotebookRoom {
     if (workstationAttachmentNotebookId) {
       return this.handleWorkstationAttachmentControl(workstationAttachmentNotebookId, request);
     }
+    const runtimeStateRepairNotebookId = runtimeStateRepairControlNotebookId(url.pathname);
+    if (runtimeStateRepairNotebookId) {
+      return this.handleRuntimeStateRepairControl(runtimeStateRepairNotebookId, request);
+    }
 
     const notebookId = notebookIdFromPath(url.pathname);
 
@@ -171,6 +175,14 @@ export class NotebookRoom {
 
     await this.restoredPeersReady;
 
+    const workstation = runtimePeerWorkstationMetadataFromRequest(request, identity);
+    if (identity.scope === "runtime_peer") {
+      const authorityError = await this.runtimePeerAuthorityError(notebookId, workstation);
+      if (authorityError) {
+        return json({ error: authorityError }, 409);
+      }
+    }
+
     const pair = new WebSocketPair();
     const client = pair[0];
     const server = pair[1];
@@ -179,7 +191,7 @@ export class NotebookRoom {
       socket: server,
       identity,
       connectedAt: new Date().toISOString(),
-      workstation: runtimePeerWorkstationMetadataFromRequest(request, identity),
+      workstation,
       consecutiveRejectedFrames: 0,
     };
 
@@ -291,6 +303,85 @@ export class NotebookRoom {
     }
   }
 
+  private async handleRuntimeStateRepairControl(
+    notebookId: string,
+    request: Request,
+  ): Promise<Response> {
+    // Worker-internal/admin control path only. External traffic reaches this
+    // Durable Object through the Worker's strict `/n/:notebookId/sync`
+    // WebSocket route; the public alpha admin API calls this path from the
+    // Worker after owner authorization.
+    if (request.method !== "POST") {
+      return json({ error: "method not allowed" }, 405);
+    }
+
+    const payload = await readOptionalJsonObject(request, "runtime state repair body");
+    if (payload instanceof Response) {
+      return payload;
+    }
+    const force = payload?.force === true;
+    const reason =
+      optionalBoundedStringField(payload?.reason, "reason", 240) ?? "manual runtime state repair";
+    if (reason instanceof Response) {
+      return reason;
+    }
+
+    if (this.hasRuntimePeer()) {
+      if (!force) {
+        return json(
+          {
+            error: "runtime peer is connected; reconnecting compute should reconcile live state",
+            runtime_peer_count: this.runtimePeerCount(),
+          },
+          409,
+        );
+      }
+      this.removeRuntimePeers(notebookId, {
+        code: 1008,
+        reason: "runtime state repair",
+      });
+    }
+
+    const startedAt = Date.now();
+    try {
+      const materializer = this.materializerFor(notebookId);
+      const result = await materializer.reconcileRuntimePeerGone(reason);
+      if (result.changed) {
+        this.deliverRoomHostFrames(notebookId, result);
+        await materializer.checkpoint();
+      }
+      cloudLog("info", "room.runtime_state_repair.completed", {
+        notebook_id: notebookId,
+        changed: result.changed,
+        forced: force,
+        runtime_peer_count: this.runtimePeerCount(),
+        duration_ms: durationMs(startedAt),
+        outbound_frame_count: result.outbound.length,
+        counter: "runtime_state_repairs_completed",
+        counter_delta: 1,
+      });
+      return json(
+        {
+          ok: true,
+          changed: result.changed,
+          forced: force,
+          runtime_peer_count: this.runtimePeerCount(),
+        },
+        200,
+      );
+    } catch (error) {
+      cloudLog("warn", "room.runtime_state_repair.failed", {
+        notebook_id: notebookId,
+        forced: force,
+        duration_ms: durationMs(startedAt),
+        error: errorMessage(error),
+        counter: "runtime_state_repairs_failed",
+        counter_delta: 1,
+      });
+      return json({ error: "runtime state repair failed" }, 500);
+    }
+  }
+
   async webSocketMessage(
     socket: CloudflareWebSocket,
     message: string | ArrayBuffer | ArrayBufferView,
@@ -344,9 +435,29 @@ export class NotebookRoom {
     }
     await Promise.all(
       restored.map(async ({ notebookId, peer }) => {
+        if (peer.identity.scope === "runtime_peer") {
+          const authorityError = await this.runtimePeerAuthorityError(notebookId, peer.workstation);
+          if (authorityError) {
+            cloudLog("warn", "room.runtime_peer.rejected_on_restore", {
+              notebook_id: notebookId,
+              peer_id: peer.id,
+              principal: peer.identity.principal,
+              reason: authorityError,
+              workstation_id: runtimePeerWorkstationId(peer.workstation),
+              counter: "runtime_peers_rejected_on_restore",
+              counter_delta: 1,
+            });
+            this.removePeer(notebookId, peer, {
+              code: 1008,
+              reason: "workstation mismatch",
+            });
+            return;
+          }
+        }
         await this.syncPeerFromRoomHost(notebookId, peer);
         if (peer.identity.scope === "runtime_peer") {
           this.refreshRuntimePeerWatch(notebookId);
+          await this.publishRuntimePeerAttachment(notebookId, peer);
         }
       }),
     );
@@ -684,6 +795,36 @@ export class NotebookRoom {
         counter: "workstation_attachment_publish_failed",
         counter_delta: 1,
       });
+    }
+  }
+
+  private async runtimePeerAuthorityError(
+    notebookId: string,
+    workstation: RuntimePeerWorkstationMetadata | null,
+  ): Promise<string | null> {
+    const attachment = await this.materializerFor(notebookId).getWorkstationAttachment();
+    if (!attachment) {
+      return null;
+    }
+
+    const selectedWorkstationId = attachment.workstation_id.trim();
+    if (!selectedWorkstationId || selectedWorkstationId === "runtime-peer") {
+      return null;
+    }
+
+    const presentedWorkstationId = runtimePeerWorkstationId(workstation);
+    if (presentedWorkstationId === selectedWorkstationId) {
+      return null;
+    }
+
+    return `runtime peer workstation ${presentedWorkstationId} does not match selected workstation ${selectedWorkstationId}`;
+  }
+
+  private removeRuntimePeers(notebookId: string, closeOptions: PeerCloseOptions): void {
+    for (const peer of Array.from(this.peers.values())) {
+      if (peer.identity.scope === "runtime_peer") {
+        this.removePeer(notebookId, peer, closeOptions);
+      }
     }
   }
 
@@ -1185,6 +1326,11 @@ function runtimePeerWorkstationAttachment(peer: Peer): WorkstationAttachmentStat
   };
 }
 
+function runtimePeerWorkstationId(workstation: RuntimePeerWorkstationMetadata | null): string {
+  const workstationId = workstation?.workstationId?.trim();
+  return workstationId && workstationId.length > 0 ? workstationId : "runtime-peer";
+}
+
 export function runtimePeerWorkstationMetadataFromRequest(
   request: Request,
   identity: AuthenticatedConnection,
@@ -1288,8 +1434,54 @@ function workstationAttachmentControlNotebookId(pathname: string): string | unde
   return decodeURIComponent(match[1]);
 }
 
+function runtimeStateRepairControlNotebookId(pathname: string): string | undefined {
+  const match = pathname.match(/^\/internal\/n\/([^/]+)\/runtime-state-repair\/?$/);
+  if (!match) {
+    return undefined;
+  }
+  return decodeURIComponent(match[1]);
+}
+
 function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+async function readOptionalJsonObject(
+  request: Request,
+  label: string,
+): Promise<Record<string, unknown> | null | Response> {
+  const text = await request.text();
+  if (!text.trim()) {
+    return null;
+  }
+  let payload: unknown;
+  try {
+    payload = JSON.parse(text);
+  } catch {
+    return json({ error: `${label} must be JSON` }, 400);
+  }
+  if (!isRecord(payload)) {
+    return json({ error: `${label} must be a JSON object` }, 400);
+  }
+  return payload;
+}
+
+function optionalBoundedStringField(
+  value: unknown,
+  fieldName: string,
+  maxLength: number,
+): string | null | Response {
+  if (value === undefined || value === null) {
+    return null;
+  }
+  if (typeof value !== "string") {
+    return json({ error: `${fieldName} must be a string` }, 400);
+  }
+  const trimmed = value.trim();
+  if (!trimmed) {
+    return null;
+  }
+  return trimmed.slice(0, maxLength);
 }
 
 function webSocketMessageByteLength(message: string | ArrayBuffer | ArrayBufferView): number {

--- a/apps/notebook-cloud/src/room-materializer.ts
+++ b/apps/notebook-cloud/src/room-materializer.ts
@@ -83,6 +83,12 @@ export class RoomMaterializer {
     return this.withHost((host) => normalizeResult(host.reconcile_runtime_peer_gone(reason)));
   }
 
+  async getWorkstationAttachment(): Promise<WorkstationAttachmentState | null> {
+    return this.withHost((host) =>
+      normalizeWorkstationAttachmentJson(host.get_workstation_attachment_json()),
+    );
+  }
+
   /// Publish the room-host-owned active workstation attachment into the
   /// RuntimeStateDoc. Runtime peers do not mutate this map directly; the room
   /// host owns the notebook-visible selected-compute projection.
@@ -551,6 +557,29 @@ function normalizeResult(value: unknown): RoomHostFrameResult {
     runtime_state_changed: result?.runtime_state_changed ?? false,
     outbound: result?.outbound ?? [],
   };
+}
+
+function normalizeWorkstationAttachmentJson(value: string): WorkstationAttachmentState | null {
+  const parsed = JSON.parse(value) as unknown;
+  if (parsed === null || isWorkstationAttachmentState(parsed)) {
+    return parsed;
+  }
+  throw new Error("RoomHostHandle returned an invalid workstation attachment");
+}
+
+function isWorkstationAttachmentState(value: unknown): value is WorkstationAttachmentState {
+  if (!value || typeof value !== "object") {
+    return false;
+  }
+  const record = value as Record<string, unknown>;
+  return (
+    typeof record.workstation_id === "string" &&
+    typeof record.display_name === "string" &&
+    typeof record.provider === "string" &&
+    typeof record.default_environment_label === "string" &&
+    typeof record.environment_policy === "string" &&
+    typeof record.status === "string"
+  );
 }
 
 function checkpointKeepReasonForRevisionMismatch(

--- a/apps/notebook-cloud/test/notebook-room.test.ts
+++ b/apps/notebook-cloud/test/notebook-room.test.ts
@@ -793,6 +793,42 @@ describe("NotebookRoom peer lifecycle", () => {
       updated_at: runtimePeer.connectedAt,
     });
   });
+
+  it("allows only the selected workstation to refresh runtime-peer attachment state", async () => {
+    const state = hibernatedState([]);
+    const room = new NotebookRoom(state.state, {} as Env);
+    const harness = roomHarness(room);
+    harness.materializers.set("demo", {
+      receiveFrame: async () => noopMaterializedResult(),
+      checkpoint: async () => undefined,
+      getWorkstationAttachment: async () => ({
+        workstation_id: "lab2",
+        display_name: "lab2 workstation",
+        provider: "runtime_peer",
+        default_environment_label: "Current Python",
+        environment_policy: "current_python",
+        status: "connecting",
+        status_message: "lab2 accepted the request",
+        cpu_count: null,
+        memory_bytes: null,
+        working_directory: "/home/ubuntu/codex/nteract",
+        updated_at: "2026-06-07T00:00:00.000Z",
+      }),
+      setWorkstationAttachment: async () => noopMaterializedResult(),
+    } as never);
+
+    const matching = await harness.runtimePeerAuthorityError?.("demo", {
+      workstationId: "lab2",
+    });
+    const mismatched = await harness.runtimePeerAuthorityError?.("demo", {
+      workstationId: "other-box",
+    });
+    const missing = await harness.runtimePeerAuthorityError?.("demo", null);
+
+    assert.equal(matching, null);
+    assert.match(String(mismatched), /does not match selected workstation lab2/);
+    assert.match(String(missing), /runtime-peer does not match selected workstation lab2/);
+  });
 });
 
 describe("NotebookRoom materialized sync persistence", () => {
@@ -1223,6 +1259,140 @@ describe("NotebookRoom runtime_peer-gone watchdog", () => {
     await state.drain();
     assert.equal(reconcileCalls, 0, "present runtime_peer suppresses reconcile");
   });
+
+  it("runs manual runtime-state repair through the internal room-host control path", async () => {
+    const state = hibernatedState([]);
+    const room = new NotebookRoom(state.state, {} as Env);
+    const harness = roomHarness(room);
+    const viewerSocket = new FakeSocket();
+    const viewerPeer = peerWithScope("viewer", "viewer");
+    viewerPeer.socket = viewerSocket.asCloudflareWebSocket();
+    harness.peers.set(viewerPeer.id, viewerPeer);
+
+    let checkpointed = 0;
+    let repairReason: string | undefined;
+    harness.materializers.set("demo", {
+      receiveFrame: async () => noopMaterializedResult(),
+      checkpoint: async () => {
+        checkpointed += 1;
+      },
+      reconcileRuntimePeerGone: async (reason: string) => {
+        repairReason = reason;
+        return {
+          ...noopMaterializedResult(),
+          changed: true,
+          runtime_state_changed: true,
+          outbound: [
+            {
+              peer_id: viewerPeer.id,
+              frame_type: FrameType.RUNTIME_STATE_SYNC,
+              payload: [9, 8, 7],
+            },
+          ],
+        };
+      },
+    } as never);
+
+    const response = await room.fetch(
+      new Request("https://room.internal/internal/n/demo/runtime-state-repair", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ reason: "manual repair: stale topic-viz runtime" }),
+      }),
+    );
+
+    assert.equal(response.status, 200);
+    assert.deepEqual(await response.json(), {
+      ok: true,
+      changed: true,
+      forced: false,
+      runtime_peer_count: 0,
+    });
+    assert.equal(repairReason, "manual repair: stale topic-viz runtime");
+    assert.equal(checkpointed, 1);
+    assert.deepEqual([...viewerSocket.sent[0]], [FrameType.RUNTIME_STATE_SYNC, 9, 8, 7]);
+  });
+
+  it("refuses manual runtime-state repair while a runtime_peer is connected", async () => {
+    const state = hibernatedState([]);
+    const room = new NotebookRoom(state.state, {} as Env);
+    const harness = roomHarness(room);
+    let reconcileCalls = 0;
+    harness.materializers.set("demo", {
+      receiveFrame: async () => noopMaterializedResult(),
+      checkpoint: async () => undefined,
+      reconcileRuntimePeerGone: async () => {
+        reconcileCalls += 1;
+        return noopMaterializedResult();
+      },
+    } as never);
+    harness.peers.set("rt", peerWithScope("rt", "runtime_peer"));
+
+    const response = await room.fetch(
+      new Request("https://room.internal/internal/n/demo/runtime-state-repair", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: "{}",
+      }),
+    );
+
+    assert.equal(response.status, 409);
+    assert.equal(reconcileCalls, 0);
+    assert.deepEqual(await response.json(), {
+      error: "runtime peer is connected; reconnecting compute should reconcile live state",
+      runtime_peer_count: 1,
+    });
+  });
+
+  it("force-repairs by disconnecting runtime peers before reconciliation", async () => {
+    const state = hibernatedState([]);
+    const room = new NotebookRoom(state.state, {} as Env);
+    const harness = roomHarness(room);
+    let checkpointed = 0;
+    let reconcileCalls = 0;
+    harness.materializers.set("demo", {
+      receiveFrame: async () => noopMaterializedResult(),
+      checkpoint: async () => {
+        checkpointed += 1;
+      },
+      removePeer: async () => undefined,
+      reconcileRuntimePeerGone: async () => {
+        reconcileCalls += 1;
+        return {
+          ...noopMaterializedResult(),
+          changed: true,
+          runtime_state_changed: true,
+        };
+      },
+    } as never);
+    const runtimeSocket = new FakeSocket();
+    const runtimePeer = {
+      ...peerWithScope("rt", "runtime_peer"),
+      socket: runtimeSocket.asCloudflareWebSocket(),
+    };
+    harness.peers.set(runtimePeer.id, runtimePeer);
+
+    const response = await room.fetch(
+      new Request("https://room.internal/internal/n/demo/runtime-state-repair", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ force: true }),
+      }),
+    );
+
+    assert.equal(response.status, 200);
+    assert.deepEqual(await response.json(), {
+      ok: true,
+      changed: true,
+      forced: true,
+      runtime_peer_count: 0,
+    });
+    assert.equal(reconcileCalls, 1);
+    assert.equal(checkpointed, 1);
+    assert.equal(runtimeSocket.closed, true);
+    assert.equal(runtimeSocket.closeCode, 1008);
+    assert.equal(runtimeSocket.closeReason, "runtime state repair");
+  });
 });
 
 type PeerForTest = {
@@ -1246,12 +1416,17 @@ interface RoomHarness {
     {
       receiveFrame(): Promise<RoomHostFrameResult>;
       checkpoint(): Promise<void>;
+      getWorkstationAttachment?(): Promise<unknown>;
       removePeer?(peerId: string): Promise<void>;
       reconcileRuntimePeerGone?(reason: string): Promise<RoomHostFrameResult>;
       setWorkstationAttachment?(attachment: unknown): Promise<RoomHostFrameResult>;
     }
   >;
   refreshRuntimePeerWatch?(notebookId: string): void;
+  runtimePeerAuthorityError?(
+    notebookId: string,
+    workstation: PeerForTest["workstation"],
+  ): Promise<string | null>;
   publishRuntimePeerAttachment(notebookId: string, peer: PeerForTest): Promise<void>;
   handleMessage(
     notebookId: string,

--- a/apps/notebook-cloud/test/worker-routes.test.ts
+++ b/apps/notebook-cloud/test/worker-routes.test.ts
@@ -2071,6 +2071,67 @@ describe("Worker artifact routes", () => {
     assert.equal(attachmentMessage, "Lab2 accepted the request and is starting compute.");
   });
 
+  it("lets notebook owners request a room-host runtime-state repair", async () => {
+    let repairRequest: Request | undefined;
+    const env = fakeEnv({
+      NOTEBOOK_ROOMS: {
+        idFromName: (name: string) => ({ toString: () => name }),
+        get: () => ({
+          fetch: async (request: Request) => {
+            repairRequest = request;
+            return new Response(
+              JSON.stringify({
+                ok: true,
+                changed: true,
+                forced: false,
+                runtime_peer_count: 0,
+              }),
+              {
+                status: 200,
+                headers: { "Content-Type": "application/json" },
+              },
+            );
+          },
+        }),
+      } satisfies DurableObjectNamespace,
+    });
+    seedNotebook(env, "repair-demo");
+    seedAcl(env, { notebookId: "repair-demo", subject: "user:dev:alice", scope: "owner" });
+
+    const response = await worker.fetch(
+      new Request("http://localhost/api/n/repair-demo/runtime-state-repair", {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          "X-Operator": "desktop:a",
+          "X-Scope": "owner",
+          "X-User": "alice",
+        },
+        body: JSON.stringify({ reason: "manual repair: stale runtime", force: false }),
+      }),
+      env,
+      fakeContext(),
+    );
+
+    assert.equal(response.status, 200);
+    assert.deepEqual(await response.json(), {
+      ok: true,
+      changed: true,
+      forced: false,
+      runtime_peer_count: 0,
+    });
+    assert.ok(repairRequest);
+    assert.equal(repairRequest.method, "POST");
+    assert.equal(
+      new URL(repairRequest.url).pathname,
+      "/internal/n/repair-demo/runtime-state-repair",
+    );
+    assert.deepEqual(await repairRequest.json(), {
+      force: false,
+      reason: "manual repair: stale runtime",
+    });
+  });
+
   it("does not let workstation owners update another principal's attach job", async () => {
     const env = fakeEnv();
     seedWorkstation(env, { ownerPrincipal: "user:dev:alice", workstationId: "ws-lab2" });

--- a/crates/runtimed-wasm/src/lib.rs
+++ b/crates/runtimed-wasm/src/lib.rs
@@ -748,6 +748,17 @@ impl RoomHostHandle {
         })
     }
 
+    /// Return the current room-host-owned workstation attachment snapshot.
+    ///
+    /// The Worker uses this before accepting a runtime peer so only the
+    /// workstation selected for the notebook can refresh the live attachment
+    /// projection. This is read-only; mutations still go through
+    /// `set_workstation_attachment_json` or runtime-peer-gone reconciliation.
+    pub fn get_workstation_attachment_json(&self) -> Result<String, JsError> {
+        serde_json::to_string(&self.state_doc.workstation_attachment())
+            .map_err(|e| JsError::new(&format!("serialize workstation attachment: {e}")))
+    }
+
     /// Generate current sync frames for a peer.
     ///
     /// The Worker calls this immediately after accepting a socket and after the
@@ -4432,6 +4443,34 @@ mod tests {
         assert_eq!(
             state.workstation.as_ref().map(|ws| ws.provider.as_str()),
             Some("runtime_peer")
+        );
+    }
+
+    #[test]
+    fn get_workstation_attachment_json_reads_current_attachment() {
+        let mut host = RoomHostHandle::create_empty("demo", "system/schema:notebook-cloud-room")
+            .expect("create room host");
+        assert_eq!(
+            host.get_workstation_attachment_json()
+                .expect("read empty attachment"),
+            "null"
+        );
+
+        host.set_workstation_attachment_inner(Some(&workstation_attachment_fixture()))
+            .expect("set attachment");
+        let attachment = serde_json::from_str::<Option<WorkstationAttachmentState>>(
+            &host
+                .get_workstation_attachment_json()
+                .expect("read attachment"),
+        )
+        .expect("attachment json");
+        assert_eq!(
+            attachment.map(|ws| (ws.workstation_id, ws.provider, ws.status)),
+            Some((
+                "runtime-peer".to_string(),
+                "runtime_peer".to_string(),
+                "ready".to_string(),
+            ))
         );
     }
 


### PR DESCRIPTION
## Summary
- add an owner-only alpha API to ask the room host to repair stale RuntimeStateDoc state
- let the Durable Object reconcile stale runtime state when no runtime peer is connected, with an explicit force path that disconnects runtime peers first
- reject runtime_peer reconnects/restores when their workstation id no longer matches the notebook-selected workstation
- expose the current room-host workstation attachment from runtimed-wasm so the Worker can make that authority decision from document truth
- update the stale reconnect notice test to match the current Retry action path

## Validation
- pnpm --dir apps/notebook-cloud typecheck
- pnpm --dir apps/notebook-cloud exec node --import tsx --test test/notebook-room.test.ts
- pnpm --dir apps/notebook-cloud exec node --import tsx --test test/worker-routes.test.ts
- pnpm --dir apps/notebook-cloud exec node --import tsx --test test/sustained-reconnecting.test.ts
- pnpm --dir apps/notebook-cloud test
- cargo test -p runtimed-wasm
- cargo xtask lint --fix

Note: lint still reports an unrelated existing no-useless-spread warning in packages/runtimed/tests/notebook-doc-persistence.test.ts, but exits successfully.