### PR TITLE
test(notebook-cloud): align the warning-action pin with the post-#3587 Retry fallback

### DIFF
--- a/apps/notebook-cloud/test/sustained-reconnecting.test.ts
+++ b/apps/notebook-cloud/test/sustained-reconnecting.test.ts
@@ -198,12 +198,17 @@ describe("sustained reconnecting notice", () => {
   });
 
   it("renders the actionable warning for non-link transport failures", () => {
+    // The production viewer wires onRetryConnection (retryLiveConnection);
+    // since #3587 retired the destructive "Use anonymous" fallback, Retry is
+    // the action that keeps non-link failures actionable.
     const html = renderNotices({
       connectionError: "cloud sync connect target failed: Unable to read app session",
+      onRetryConnection: () => {},
     });
     assert.match(html, /Live room needs attention/);
     assert.match(html, /cloud sync connect target failed/);
-    assert.match(html, /Use anonymous/, "the warning keeps its action");
+    assert.match(html, /Retry/, "the warning keeps its action");
+    assert.doesNotMatch(html, /Use anonymous/);
     assert.doesNotMatch(html, /Your edits are kept locally/);
 
     const rejectionHtml = renderNotices({


### PR DESCRIPTION
Fixes the one failing test on clean main (caught by the #3589 agent's post-rebase verification — thanks): #3588's 'actionable warning' pin asserted the 'Use anonymous' fallback that #3587 retired, and the two PRs' targeted post-rebase runs each missed the other's test file. The test now wires onRetryConnection as the production viewer does and asserts the Retry action, plus pins the absence of the retired CTA.

Full notebook-cloud suite on this branch: all pass (the prior 761/762 → green).

Process note recorded on our side: stacked PRs touching shared notice/session surfaces get full-suite post-rebase verification, not targeted runs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)