### PR TITLE
test(runtimed-py): wait for created cells before listing

### DIFF
--- a/python/runtimed/tests/test_daemon_integration.py
+++ b/python/runtimed/tests/test_daemon_integration.py
@@ -1924,6 +1924,12 @@ class TestDocumentFirstExecution:
             await session.create_cell("c = 3"),
         ]
 
+        async def cells_are_visible():
+            cells = await session.get_cells()
+            found_ids = {c.id for c in cells}
+            return all(cid in found_ids for cid in cell_ids)
+
+        await async_wait_for_sync(cells_are_visible, description="created cells visible")
         cells = await session.get_cells()
         assert len(cells) >= 3
 


### PR DESCRIPTION
## Summary
- fix the failing `runtimed-py Integration Tests` main CI job by waiting for newly created cells to appear in `get_cells()` before asserting membership
- keeps the test aligned with nearby sync-sensitive integration tests instead of assuming immediate snapshot projection after `create_cell()`

## CI failure addressed
`TestDocumentFirstExecution.test_async_get_cells` failed on main after #3590 with one created cell missing from the immediate `get_cells()` snapshot.

## Validation
- `RUNTIMED_INTEGRATION_TEST=1 RUNTIMED_BINARY=/home/ubuntu/codex/nteract/target/release/runtimed RUNTIMED_LOG_LEVEL=debug RUNTIMED_WORKSPACE_PATH=/home/ubuntu/codex/nteract RUNTIMED_TEST_UV_POOL_SIZE=1 RUNTIMED_TEST_CONDA_POOL_SIZE=0 VIRTUAL_ENV=/home/ubuntu/codex/nteract/.venv uv run --directory python/runtimed pytest tests/test_daemon_integration.py::TestDocumentFirstExecution::test_async_get_cells -v --tb=short`
- `RUNTIMED_INTEGRATION_TEST=1 RUNTIMED_BINARY=/home/ubuntu/codex/nteract/target/release/runtimed RUNTIMED_LOG_LEVEL=debug RUNTIMED_WORKSPACE_PATH=/home/ubuntu/codex/nteract RUNTIMED_TEST_UV_POOL_SIZE=1 RUNTIMED_TEST_CONDA_POOL_SIZE=0 VIRTUAL_ENV=/home/ubuntu/codex/nteract/.venv uv run --directory python/runtimed pytest tests/test_daemon_integration.py::TestDocumentFirstExecution -v --tb=short`
- `cargo xtask lint --fix`