### PR TITLE
fix(notebook-cloud): preserve output refs across cell adds

### DIFF
--- a/apps/notebook-cloud/test/notebook-view-store-bridge.test.ts
+++ b/apps/notebook-cloud/test/notebook-view-store-bridge.test.ts
@@ -1,12 +1,13 @@
 import assert from "node:assert/strict";
 import { afterEach, describe, it } from "node:test";
-import { updateCellSourceById } from "@/components/notebook/state/cell-store";
+import { getCellById, updateCellSourceById } from "@/components/notebook/state/cell-store";
 import {
   getExecutionById,
   getNotebookQueueProjection,
   setExecution,
   setNotebookQueueProjection,
 } from "@/components/notebook/state/execution-store";
+import { getOutputById } from "@/components/notebook/state/output-store";
 import { createNotebookViewModelFromNotebookCells } from "@/components/notebook/state/view-model-store";
 import { setMarkdownProjectionProjector } from "@/lib/markdown-projection";
 import {
@@ -134,7 +135,72 @@ describe("cloud NotebookView store bridge", () => {
       output_ids: ["out-runtime"],
     });
   });
+
+  it("keeps existing output references stable when structural cloud projection adds a cell", () => {
+    projectCloudCellsIntoNotebookViewStores([
+      codeCellWithWidgetOutput("widget-cell", "slider-model", 7),
+    ]);
+
+    const firstCell = getCellById("widget-cell");
+    const firstOutput = getOutputById("widget-output");
+
+    projectCloudCellsIntoNotebookViewStores([
+      codeCellWithWidgetOutput("widget-cell", "slider-model", 7),
+      {
+        id: "new-cell",
+        cellType: "code",
+        source: "",
+        language: "python",
+        executionId: null,
+        executionCount: null,
+        outputs: [],
+        metadata: {},
+      },
+    ]);
+
+    assert.equal(getCellById("widget-cell"), firstCell);
+    assert.equal(getOutputById("widget-output"), firstOutput);
+  });
+
+  it("updates an existing output reference when the cloud output payload changes", () => {
+    projectCloudCellsIntoNotebookViewStores([
+      codeCellWithWidgetOutput("widget-cell", "slider-model", 7),
+    ]);
+
+    const firstOutput = getOutputById("widget-output");
+
+    projectCloudCellsIntoNotebookViewStores([
+      codeCellWithWidgetOutput("widget-cell", "slider-model", 8),
+    ]);
+
+    assert.notEqual(getOutputById("widget-output"), firstOutput);
+  });
 });
+
+function codeCellWithWidgetOutput(cellId: string, modelId: string, value: number) {
+  return {
+    id: cellId,
+    cellType: "code" as const,
+    source: "display(slider)",
+    language: "python",
+    executionId: "exec-widget",
+    executionCount: 1,
+    outputs: [
+      {
+        output_id: "widget-output",
+        output_type: "display_data" as const,
+        data: {
+          "application/vnd.jupyter.widget-view+json": {
+            model_id: modelId,
+          },
+          "text/plain": `IntSlider(value=${value})`,
+        },
+        metadata: {},
+      },
+    ],
+    metadata: {},
+  };
+}
 
 function outlineTitlesFromStore(): string[] {
   return createNotebookViewModelFromNotebookCells().outlineItems.map((item) => item.title);

--- a/apps/notebook-cloud/viewer/notebook-view-store-bridge.ts
+++ b/apps/notebook-cloud/viewer/notebook-view-store-bridge.ts
@@ -12,7 +12,7 @@ import {
   setExecution,
   setNotebookQueueProjection,
 } from "@/components/notebook/state/execution-store";
-import { deleteOutputs, setOutput } from "@/components/notebook/state/output-store";
+import { deleteOutputs, getOutputById, setOutput } from "@/components/notebook/state/output-store";
 import {
   getCellIdsSnapshot,
   resetRuntimeState,
@@ -167,17 +167,49 @@ function normalizeOutputForNotebookView(
   index: number,
 ): NotebookStoreOutput {
   const output_id = output.output_id ?? `cloud-output:${cellId}:${index}`;
+  const previous = getOutputById(output_id);
+  let normalized: NotebookStoreOutput;
+
   if (output.output_type === "stream") {
-    return {
-      ...output,
-      output_id,
-      text: Array.isArray(output.text) ? output.text.join("") : output.text,
-    };
+    const text = Array.isArray(output.text) ? output.text.join("") : output.text;
+    normalized =
+      output.output_id === output_id && output.text === text
+        ? (output as NotebookStoreOutput)
+        : {
+            ...output,
+            output_id,
+            text,
+          };
+    return reusePreviousOutputIfEqual(previous, normalized);
   }
-  return {
-    ...output,
-    output_id,
-  } as NotebookStoreOutput;
+
+  normalized =
+    output.output_id === output_id
+      ? (output as NotebookStoreOutput)
+      : ({
+          ...output,
+          output_id,
+        } as NotebookStoreOutput);
+  return reusePreviousOutputIfEqual(previous, normalized);
+}
+
+function reusePreviousOutputIfEqual(
+  previous: NotebookStoreOutput | undefined,
+  next: NotebookStoreOutput,
+): NotebookStoreOutput {
+  if (!previous || previous === next) return next;
+  const previousSerialized = serializedOutput(previous);
+  return previousSerialized !== null && previousSerialized === serializedOutput(next)
+    ? previous
+    : next;
+}
+
+function serializedOutput(output: NotebookStoreOutput): string | null {
+  try {
+    return JSON.stringify(output);
+  } catch {
+    return null;
+  }
 }
 
 function difference(previous: ReadonlySet<string>, next: ReadonlySet<string>): string[] {


### PR DESCRIPTION
## Summary
- keep cloud output objects reference-stable when full structural projection reprocesses unchanged outputs
- reuse the previous output-store entry when normalization allocates but the payload is unchanged
- add regression coverage that adding a cell does not change an existing widget output/cell reference while real output payload changes still update

## Validation
- `pnpm --dir apps/notebook-cloud exec node --import tsx --test test/notebook-view-store-bridge.test.ts`
- `pnpm --dir apps/notebook-cloud typecheck`
- `pnpm --dir apps/notebook-cloud test`
- `cargo xtask lint --fix`
- deployed preview and verified with Playwright on `/n/01KTPGC0HG9QMMJY52THQGZKD1/widgets?mode=edit`: adding a cell keeps the animated HTML widget child connected after the fix; before the fix the same check detached the child and restarted the flash animation

## Notes
- `cargo xtask lint --fix` still reports the existing `no-useless-spread` warning in `packages/runtimed/tests/notebook-doc-persistence.test.ts`.
- The preview health SHA reports the base commit because the deployed fix was built before this commit was created; the uploaded viewer asset includes this branch change.