### PR TITLE
fix(notebook-cloud): simplify anonymous auth notices

### DIFF
--- a/apps/notebook-cloud/test/viewer-notices.test.ts
+++ b/apps/notebook-cloud/test/viewer-notices.test.ts
@@ -89,10 +89,45 @@ test("cloud notebook notices render auth and connection policy through the share
   assert.match(html, /data-slot="notebook-notice-stack"/);
   assert.match(html, /Auth needs attention/);
   assert.match(html, /Your browser sign-in needs renewal/);
-  assert.match(html, /Sign-in refresh failed/);
+  assert.doesNotMatch(html, /Sign-in refresh failed/);
   assert.match(html, /Live room needs attention/);
   assert.match(html, /Sign in again/);
+  assert.equal(html.match(/Sign in again/g)?.length, 1);
   assert.doesNotMatch(html, /Reset to anonymous/);
+});
+
+test("cloud notebook notices collapse stale auth into one public-viewer banner", () => {
+  assert.equal(
+    cloudNotebookHasNotices({
+      authState: authState("oidc_expired"),
+      authRenewal: { kind: "failed", message: "refresh failed" },
+      connectionError: null,
+      isPublicViewer: true,
+      status: { kind: "ready", message: "Ready" },
+    }),
+    true,
+  );
+
+  const html = renderToStaticMarkup(
+    React.createElement(CloudNotebookNotices, {
+      authState: authState("oidc_expired"),
+      authRenewal: { kind: "failed", message: "refresh failed" },
+      connectionError: null,
+      isPublicViewer: true,
+      status: { kind: "ready", message: "Ready" },
+      onResetAuth: () => {},
+      onSignInAgain: () => {},
+    }),
+  );
+
+  assert.match(html, /Viewing anonymously/);
+  assert.match(html, /This public notebook is open read-only/);
+  assert.match(html, /Use your account to edit/);
+  assert.match(html, /Sign in/);
+  assert.doesNotMatch(html, /Auth needs attention/);
+  assert.doesNotMatch(html, /Sign-in refresh failed/);
+  assert.doesNotMatch(html, /Your browser sign-in needs renewal/);
+  assert.equal(html.match(/Sign in/g)?.length, 1);
 });
 
 test("cloud notebook notices trust a fresh app session over stale localStorage auth", () => {

--- a/apps/notebook-cloud/viewer/notebook-viewer.tsx
+++ b/apps/notebook-cloud/viewer/notebook-viewer.tsx
@@ -71,7 +71,11 @@ import { cloudViewerLoadingPolicy } from "./loading-policy";
 import { markCloudViewerLoadMilestone } from "./load-milestones";
 import { cloudPresenceHasRuntimePeer, cloudPresenceRuntimePeerCount } from "./presence";
 import type { ResolvedCell } from "./render-resolution";
-import { CloudNotebookNotices, cloudNotebookHasNotices } from "./notices";
+import {
+  CloudNotebookNotices,
+  cloudNotebookHasNotices,
+  shouldShowCloudAnonymousViewerAuthNotice,
+} from "./notices";
 import { useOfflineMergeNoticeAutoClear } from "./use-offline-merge-notice";
 import { useSustainedReconnecting } from "./use-sustained-reconnecting";
 import type { ViewerStatus } from "./notice-types";
@@ -363,6 +367,16 @@ export function NotebookViewer({
       status,
       workstationAttachment,
     });
+  const isPublicViewer =
+    shellCapabilities.access.isPublic &&
+    shellCapabilities.access.level === "viewer" &&
+    connectionScope === "viewer" &&
+    Boolean(connectionPeerId);
+  const showAnonymousViewerAuthNotice = shouldShowCloudAnonymousViewerAuthNotice({
+    authState,
+    hasAppSession: Boolean(appSessionStatus.session),
+    isPublicViewer,
+  });
   const cloudRuntimeStatus = useMemo<NotebookCommandToolbarStatus | null>(() => {
     if (!shellCapabilities.runtime.connected && !shellCapabilities.runtime.executionAvailable) {
       return null;
@@ -870,6 +884,7 @@ export function NotebookViewer({
         <CloudPresenceStatus connectionError={connectionError} store={presenceStore} />
       }
       authControls={
+        !showAnonymousViewerAuthNotice &&
         shouldShowCloudHeaderSignIn(authState, {
           appSessionLoading: appSessionStatus.status === "loading",
           hasAppSession: Boolean(appSessionStatus.session),
@@ -957,6 +972,7 @@ export function NotebookViewer({
     connectionError,
     diagnostics: accessRequestNotice,
     hasAppSession: Boolean(appSessionStatus.session),
+    isPublicViewer,
     hasReadableSnapshot: notebookHasReadableSnapshot,
     offlineMergeNotice,
     rendererAssetError,
@@ -970,6 +986,7 @@ export function NotebookViewer({
       connectionError={connectionError}
       diagnostics={accessRequestNotice}
       hasAppSession={Boolean(appSessionStatus.session)}
+      isPublicViewer={isPublicViewer}
       hasReadableSnapshot={notebookHasReadableSnapshot}
       offlineMergeNotice={offlineMergeNotice}
       rendererAssetError={rendererAssetError}

--- a/apps/notebook-cloud/viewer/notices.tsx
+++ b/apps/notebook-cloud/viewer/notices.tsx
@@ -21,6 +21,12 @@ export interface CloudNotebookNoticesProps {
   authRenewal: CloudAuthRenewalState;
   connectionError: string | null;
   hasAppSession?: boolean;
+  /**
+   * The room accepted this browser as an anonymous public viewer. In this
+   * state stale browser auth is not blocking notebook readability, so auth
+   * renewal internals collapse into one calm sign-in invitation.
+   */
+  isPublicViewer?: boolean;
   hasReadableSnapshot?: boolean;
   /**
    * The live-room status has been "reconnecting" past the debounce window
@@ -98,6 +104,7 @@ export function cloudNotebookHasNotices({
   authRenewal,
   connectionError,
   hasAppSession = false,
+  isPublicViewer = false,
   hasReadableSnapshot = false,
   offlineMergeNotice = null,
   rendererAssetError = null,
@@ -113,11 +120,23 @@ export function cloudNotebookHasNotices({
     !(status.kind === "empty" && hasReadableSnapshot) &&
     !isStatusDerivedFromConnectionError(status, connectionError);
 
+  const shouldShowAnonymousViewerAuthNotice = shouldShowCloudAnonymousViewerAuthNotice({
+    authState,
+    hasAppSession,
+    isPublicViewer,
+  });
   const shouldShowAuthNotice =
-    !hasAppSession && (authState.mode === "invalid" || authState.mode === "oidc_expired");
-  const shouldShowAuthRenewalNotice = !hasAppSession && authRenewal.kind !== "idle";
+    !shouldShowAnonymousViewerAuthNotice &&
+    !hasAppSession &&
+    (authState.mode === "invalid" || authState.mode === "oidc_expired");
+  const shouldShowAuthRenewalNotice =
+    !shouldShowAnonymousViewerAuthNotice &&
+    !shouldShowAuthNotice &&
+    !hasAppSession &&
+    authRenewal.kind !== "idle";
 
   return (
+    shouldShowAnonymousViewerAuthNotice ||
     shouldShowAuthNotice ||
     shouldShowAuthRenewalNotice ||
     sustainedReconnecting ||
@@ -134,6 +153,7 @@ export function CloudNotebookNotices({
   authRenewal,
   connectionError,
   hasAppSession = false,
+  isPublicViewer = false,
   hasReadableSnapshot = false,
   offlineMergeNotice = null,
   rendererAssetError = null,
@@ -151,6 +171,7 @@ export function CloudNotebookNotices({
       authRenewal,
       connectionError,
       hasAppSession,
+      isPublicViewer,
       hasReadableSnapshot,
       offlineMergeNotice,
       rendererAssetError,
@@ -169,12 +190,39 @@ export function CloudNotebookNotices({
     status.kind !== "ready" &&
     !(status.kind === "empty" && hasReadableSnapshot) &&
     !isStatusDerivedFromConnectionError(status, connectionError);
+  const shouldShowAnonymousViewerAuthNotice = shouldShowCloudAnonymousViewerAuthNotice({
+    authState,
+    hasAppSession,
+    isPublicViewer,
+  });
   const shouldShowAuthNotice =
-    !hasAppSession && (authState.mode === "invalid" || authState.mode === "oidc_expired");
-  const shouldShowAuthRenewalNotice = !hasAppSession && authRenewal.kind !== "idle";
+    !shouldShowAnonymousViewerAuthNotice &&
+    !hasAppSession &&
+    (authState.mode === "invalid" || authState.mode === "oidc_expired");
+  const shouldShowAuthRenewalNotice =
+    !shouldShowAnonymousViewerAuthNotice &&
+    !shouldShowAuthNotice &&
+    !hasAppSession &&
+    authRenewal.kind !== "idle";
 
   return (
     <NotebookNoticeStack>
+      {shouldShowAnonymousViewerAuthNotice ? (
+        <NotebookNotice
+          tone="info"
+          icon={<LogIn className="h-4 w-4" />}
+          title="Viewing anonymously."
+          actions={
+            onSignInAgain ? (
+              <SignInNoticeAction onSignInAgain={onSignInAgain}>Sign in</SignInNoticeAction>
+            ) : null
+          }
+        >
+          This public notebook is open read-only. Use your account to edit or access private
+          features.
+        </NotebookNotice>
+      ) : null}
+
       {shouldShowAuthNotice ? (
         <NotebookNotice
           tone="error"
@@ -282,6 +330,22 @@ export function CloudNotebookNotices({
   );
 }
 
+export function shouldShowCloudAnonymousViewerAuthNotice({
+  authState,
+  hasAppSession = false,
+  isPublicViewer = false,
+}: {
+  authState: CloudPrototypeAuthState;
+  hasAppSession?: boolean;
+  isPublicViewer?: boolean;
+}): boolean {
+  return (
+    isPublicViewer &&
+    !hasAppSession &&
+    (authState.mode === "invalid" || authState.mode === "oidc_expired")
+  );
+}
+
 function AuthNoticeAction({
   onResetAuth,
   onSignInAgain,
@@ -290,21 +354,31 @@ function AuthNoticeAction({
   onSignInAgain?: () => void | Promise<void>;
 }) {
   if (onSignInAgain) {
-    return (
-      <NotebookNoticeAction
-        onClick={() => {
-          void onSignInAgain();
-        }}
-        icon={<LogIn className="h-3 w-3" />}
-      >
-        Sign in again
-      </NotebookNoticeAction>
-    );
+    return <SignInNoticeAction onSignInAgain={onSignInAgain}>Sign in again</SignInNoticeAction>;
   }
 
   return (
     <NotebookNoticeAction onClick={onResetAuth} icon={<RotateCcw className="h-3 w-3" />}>
       Clear stale sign-in
+    </NotebookNoticeAction>
+  );
+}
+
+function SignInNoticeAction({
+  children,
+  onSignInAgain,
+}: {
+  children: ReactNode;
+  onSignInAgain: () => void | Promise<void>;
+}) {
+  return (
+    <NotebookNoticeAction
+      onClick={() => {
+        void onSignInAgain();
+      }}
+      icon={<LogIn className="h-3 w-3" />}
+    >
+      {children}
     </NotebookNoticeAction>
   );
 }
@@ -330,16 +404,7 @@ function ConnectionNoticeAction({
   }
 
   if (connectionError === CLOUD_CONNECTION_SIGN_IN_DIAGNOSTIC && onSignInAgain) {
-    return (
-      <NotebookNoticeAction
-        onClick={() => {
-          void onSignInAgain();
-        }}
-        icon={<LogIn className="h-3 w-3" />}
-      >
-        Sign in again
-      </NotebookNoticeAction>
-    );
+    return <SignInNoticeAction onSignInAgain={onSignInAgain}>Sign in again</SignInNoticeAction>;
   }
 
   if (onRetryConnection) {

--- a/src/components/notebook/NotebookConnectionIdentity.tsx
+++ b/src/components/notebook/NotebookConnectionIdentity.tsx
@@ -81,6 +81,10 @@ export function NotebookConnectionIdentity({
     return null;
   }
 
+  if (isPublicViewerContext(capabilities)) {
+    return null;
+  }
+
   const actor = notebookToolbarActors(capabilities)[0];
   if (!actor) {
     return null;
@@ -124,6 +128,15 @@ export function NotebookConnectionIdentity({
 export function isRemoteNotebookContext(capabilities: NotebookShellCapabilities): boolean {
   return (
     capabilities.access.source !== "local" || capabilities.runtime.target?.kind === "runtime_peer"
+  );
+}
+
+function isPublicViewerContext(capabilities: NotebookShellCapabilities): boolean {
+  return (
+    capabilities.access.source === "cloud" &&
+    capabilities.access.isPublic &&
+    capabilities.access.level === "viewer" &&
+    !capabilities.auth.canUseAuthenticatedIdentity
   );
 }
 

--- a/src/components/notebook/__tests__/NotebookConnectionIdentity.test.tsx
+++ b/src/components/notebook/__tests__/NotebookConnectionIdentity.test.tsx
@@ -79,6 +79,23 @@ function cloudCapabilities(): NotebookShellCapabilities {
   });
 }
 
+function publicViewerCapabilities(): NotebookShellCapabilities {
+  return capabilities({
+    access: {
+      level: "viewer",
+      source: "cloud",
+      isPublic: true,
+      actorLabel: "anonymous:viewer:session-1/browser:tab",
+      identityLabel: null,
+    },
+    auth: {
+      canSignIn: true,
+      canUseAuthenticatedIdentity: false,
+      needsAttention: false,
+    },
+  });
+}
+
 function localCapabilities(): NotebookShellCapabilities {
   return capabilities({
     access: {
@@ -152,6 +169,11 @@ describe("NotebookConnectionIdentity", () => {
   it("renders for a local session attached to a runtime peer", () => {
     const { container } = renderSlot(runtimePeerCapabilities());
     expect(slotElement(container)).toBeTruthy();
+  });
+
+  it("renders nothing for an anonymous public viewer", () => {
+    const { container } = renderSlot(publicViewerCapabilities());
+    expect(container.innerHTML).toBe("");
   });
 
   it.each([


### PR DESCRIPTION
## Summary

- collapse stale browser-auth renewal noise into one public-viewer banner when the room has already accepted the browser anonymously
- suppress the duplicate header sign-in button while that anonymous-viewer banner owns the action
- hide the shared connection identity chip for anonymous public viewers so the toolbar does not show ambiguous "Public viewer" connection chrome

## Verification

- `pnpm --dir apps/notebook-cloud exec node --import tsx --test test/viewer-notices.test.ts test/viewer-render-props.test.ts`
- `pnpm --dir apps/notebook-cloud typecheck`
- `pnpm test:run -- src/components/notebook/__tests__/NotebookConnectionIdentity.test.tsx`
- `cargo xtask lint --fix`
- `git diff --check`

## Notes

- The first `pnpm test:run -- src/components/notebook/__tests__/NotebookConnectionIdentity.test.tsx` run failed in unrelated WASM persistence/tab-bridge tests before `pnpm --dir apps/notebook-cloud typecheck` refreshed the WASM package. The rerun passed the full frontend suite.
- `cargo xtask lint --fix` still reports unrelated warnings in `packages/runtimed/tests/*`, but exits successfully.

## Draft status

Draft while CI and review are pending.
