### PR TITLE
feat(notebook-cloud): resync heal loop with convergence verification and quiet exhaustion

### DIFF
--- a/apps/notebook-cloud/test/instant-paint.test.ts
+++ b/apps/notebook-cloud/test/instant-paint.test.ts
@@ -691,7 +691,7 @@ describe("empty live room displacement", () => {
   it("kicks one full materialization when the doc first catches up to the room", () => {
     assert.match(
       sessionSource,
-      /notebookSyncApplied\$\.subscribe\(\(\) => \{\s*if \(caughtUpMaterializeKicked\) return;\s*if \(!cloudNotebookHandleCaughtUp\(liveRuntime\.handle\)\) return;\s*caughtUpMaterializeKicked = true;\s*materializeLiveCellsSafely\(liveRuntime\);/,
+      /notebookSyncApplied\$\.subscribe\(\(\) => \{\s*const caughtUp = cloudNotebookHandleCaughtUp\(liveRuntime\.handle\);[\s\S]{0,400}?if \(caughtUpMaterializeKicked\) return;\s*if \(!caughtUp\) return;\s*caughtUpMaterializeKicked = true;\s*materializeLiveCellsSafely\(liveRuntime\);/,
     );
   });
 

--- a/apps/notebook-cloud/test/notebook-persistence.test.ts
+++ b/apps/notebook-cloud/test/notebook-persistence.test.ts
@@ -24,6 +24,7 @@ import {
   type StorageKey,
 } from "runtimed";
 import {
+  PersistenceRearmGate,
   createCloudNotebookPersistence,
   loadCloudPersistedNotebookSeed,
 } from "../viewer/notebook-persistence.ts";
@@ -389,5 +390,68 @@ describe("loadCloudPersistedNotebookSeed", () => {
       "fresh snapshot chunk written; envelope left in place for rollback",
     );
     controller.dispose();
+  });
+});
+
+describe("persistence single heal (self-disable -> one re-arm)", () => {
+  it("the controller pair signals self-disable ONCE even when both controllers die", async () => {
+    const harness = createHarness();
+    let heads = 0;
+    harness.handle.get_heads_hex = () => [`h${heads}`];
+    let stateHeads = 0;
+    harness.handle.get_runtime_state_heads_hex = () => [`s${stateHeads}`];
+    harness.adapter.save = async () => {
+      throw new Error("quota exceeded");
+    };
+    const selfDisabled: number[] = [];
+    const controller = createCloudNotebookPersistence({
+      adapter: harness.adapter,
+      notebookId: "nb-1",
+      principal: ALICE,
+      engine: {
+        notebookDocChanged$: harness.notebookDocChanged$,
+        runtimeState$: harness.runtimeState$,
+      },
+      handle: harness.handle,
+      throttleMs: 5,
+      onSelfDisabled: () => selfDisabled.push(1),
+    });
+    assert.ok(controller);
+
+    // Kill the NotebookDoc controller: three failed captures (heads must
+    // move; a failed write forgets its optimistic key, but distinct heads
+    // keep this honest).
+    for (let i = 0; i < 3; i++) {
+      heads += 1;
+      harness.notebookDocChanged$.next();
+      await sleep(20);
+    }
+    assert.equal(selfDisabled.length, 1, "first controller death signals");
+
+    // Kill the runtime-state cache controller too: no second signal —
+    // they share one backend and one heal budget.
+    for (let i = 0; i < 3; i++) {
+      stateHeads += 1;
+      harness.runtimeState$.next({});
+      await sleep(20);
+    }
+    assert.equal(selfDisabled.length, 1, "the pair signals at most once");
+    controller.dispose();
+  });
+
+  it("PersistenceRearmGate: one retry on the next trigger; a second failure stays disabled", () => {
+    const gate = new PersistenceRearmGate();
+
+    // No self-disable yet: online transitions consume nothing.
+    assert.equal(gate.takeRearm(), false);
+
+    // Self-disable, then the next online event -> the single re-arm.
+    gate.noteSelfDisabled();
+    assert.equal(gate.takeRearm(), true, "one retry is owed");
+    assert.equal(gate.takeRearm(), false, "and only one");
+
+    // The re-armed controller fails again: disabled for the session.
+    gate.noteSelfDisabled();
+    assert.equal(gate.takeRearm(), false, "the single heal is spent");
   });
 });

--- a/apps/notebook-cloud/test/sync-heal.test.ts
+++ b/apps/notebook-cloud/test/sync-heal.test.ts
@@ -281,6 +281,18 @@ describe("cloud session sync-heal wiring", () => {
     );
   });
 
+  it("arms verification for the initial bootstrap exchange", () => {
+    // The replayed first handshake trips the applyRoomReady peer-id dedupe,
+    // so the roomReady$ arming never covers the cold load — the connect
+    // resolution block must arm it directly or a first-connection stall
+    // never kicks, never exhausts, and never surfaces.
+    assert.match(
+      sessionSource,
+      /armTabBridge\(liveRuntime\);[\s\S]{0,600}?syncHeal\.noteResyncKicked\(NOTEBOOK_DOC_HEAL_KEY\);/,
+      "the connect resolution block arms initial-exchange verification",
+    );
+  });
+
   it("feeds the caught-up confirmation from notebookSyncApplied$", () => {
     assert.match(
       sessionSource,

--- a/apps/notebook-cloud/test/sync-heal.test.ts
+++ b/apps/notebook-cloud/test/sync-heal.test.ts
@@ -1,0 +1,337 @@
+/**
+ * SyncHealScheduler — the resync heal loop's ladder, confirmation
+ * settling, exhaustion-once discipline, roomReady reset, and the
+ * deliberate non-interference with the rejection tracker. Session wiring
+ * (the hook cannot run under node) is pinned by source guardrails.
+ */
+
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { describe, it } from "node:test";
+import { CloudRecoverableRejectionTracker } from "../viewer/live-sync.ts";
+import { NOTEBOOK_DOC_HEAL_KEY, SyncHealScheduler } from "../viewer/sync-heal.ts";
+
+const DOC = NOTEBOOK_DOC_HEAL_KEY;
+
+const silentLogger = { debug: () => {}, warn: () => {} };
+
+/**
+ * node:test mock timers do NOT fire timers scheduled during a tick, so a
+ * chained deadline ladder must be advanced rung by rung.
+ */
+function tickRungs(t: { mock: { timers: { tick: (ms: number) => void } } }, rungs: number[]): void {
+  for (const rung of rungs) {
+    t.mock.timers.tick(rung);
+  }
+}
+
+function createHarness(
+  overrides: Partial<ConstructorParameters<typeof SyncHealScheduler>[0]> = {},
+) {
+  const kicks: string[] = [];
+  const exhausted: string[] = [];
+  const recovered: string[] = [];
+  let kickAllowed = true;
+  const scheduler = new SyncHealScheduler({
+    kick: (docKey) => kicks.push(docKey),
+    shouldKick: () => kickAllowed,
+    onExhausted: (docKey) => exhausted.push(docKey),
+    onRecovered: (docKey) => recovered.push(docKey),
+    baseDelayMs: 100,
+    maxDelayMs: 800,
+    backoffFactor: 2,
+    maxAttempts: 3,
+    random: () => 0.5, // exact rungs — no jitter
+    logger: silentLogger,
+    ...overrides,
+  });
+  return {
+    scheduler,
+    kicks,
+    exhausted,
+    recovered,
+    setKickAllowed: (allowed: boolean) => {
+      kickAllowed = allowed;
+    },
+  };
+}
+
+describe("SyncHealScheduler", () => {
+  it("re-kicks on the deadline ladder and exhausts ONCE", (t) => {
+    t.mock.timers.enable({ apis: ["setTimeout"] });
+    const h = createHarness();
+
+    h.scheduler.noteResyncKicked(DOC);
+    t.mock.timers.tick(99);
+    assert.deepEqual(h.kicks, [], "no kick before the first deadline");
+    t.mock.timers.tick(1); // 100ms rung
+    assert.deepEqual(h.kicks, [DOC]);
+
+    t.mock.timers.tick(199);
+    assert.equal(h.kicks.length, 1, "second rung is 200ms (factor 2)");
+    t.mock.timers.tick(1);
+    assert.equal(h.kicks.length, 2);
+
+    t.mock.timers.tick(400); // third rung
+    assert.equal(h.kicks.length, 3);
+    assert.deepEqual(h.exhausted, []);
+
+    t.mock.timers.tick(800); // fourth deadline: attempts == max -> terminal
+    assert.deepEqual(h.exhausted, [DOC], "exhaustion fires once");
+    assert.equal(h.kicks.length, 3, "no kick on the exhausting deadline");
+
+    // The ladder is stopped: nothing further fires, ever.
+    t.mock.timers.tick(600_000);
+    assert.equal(h.kicks.length, 3);
+    assert.deepEqual(h.exhausted, [DOC]);
+    h.scheduler.dispose();
+  });
+
+  it("caught_up settles the loop — no spurious re-kicks after convergence", (t) => {
+    t.mock.timers.enable({ apis: ["setTimeout"] });
+    const h = createHarness();
+
+    h.scheduler.noteResyncKicked(DOC);
+    t.mock.timers.tick(100);
+    assert.equal(h.kicks.length, 1);
+
+    // Confirmation is just another sync: the catch-up fact landing true
+    // means the previous exchange landed.
+    h.scheduler.noteVerification(DOC, true);
+    t.mock.timers.tick(600_000);
+    assert.equal(h.kicks.length, 1, "converged: the deadline is cancelled");
+    assert.deepEqual(h.exhausted, []);
+    assert.deepEqual(h.recovered, [], "recovery only fires after an exhaustion");
+
+    // The ladder also reset: a NEW stall starts from the base rung.
+    h.scheduler.noteResyncKicked(DOC);
+    t.mock.timers.tick(100);
+    assert.equal(h.kicks.length, 2, "fresh episode starts at the base deadline");
+    h.scheduler.dispose();
+  });
+
+  it("caught_up === false is not a failure; the deadline stays the judge", (t) => {
+    t.mock.timers.enable({ apis: ["setTimeout"] });
+    const h = createHarness();
+
+    h.scheduler.noteResyncKicked(DOC);
+    h.scheduler.noteVerification(DOC, false);
+    h.scheduler.noteVerification(DOC, false);
+    t.mock.timers.tick(99);
+    assert.deepEqual(h.kicks, []);
+    t.mock.timers.tick(1);
+    assert.deepEqual(h.kicks, [DOC], "deadline unaffected by not-yet polls");
+    h.scheduler.dispose();
+  });
+
+  it("late convergence after exhaustion fires onRecovered once and re-arms future episodes", (t) => {
+    t.mock.timers.enable({ apis: ["setTimeout"] });
+    const h = createHarness();
+
+    h.scheduler.noteResyncKicked(DOC);
+    tickRungs(t, [100, 200, 400, 800]);
+    assert.deepEqual(h.exhausted, [DOC]);
+
+    h.scheduler.noteVerification(DOC, true);
+    assert.deepEqual(h.recovered, [DOC], "late convergence clears the terminal surface");
+    h.scheduler.noteVerification(DOC, true);
+    assert.deepEqual(h.recovered, [DOC], "recovery fires once per episode");
+
+    // A NEW stall after recovery is a new episode: it may exhaust again.
+    h.scheduler.noteResyncKicked(DOC);
+    tickRungs(t, [100, 200, 400, 800]);
+    assert.deepEqual(h.exhausted, [DOC, DOC]);
+    h.scheduler.dispose();
+  });
+
+  it("roomReady reset returns the ladder to the base rung but keeps a standing exhaustion", (t) => {
+    t.mock.timers.enable({ apis: ["setTimeout"] });
+    const h = createHarness();
+
+    h.scheduler.noteResyncKicked(DOC);
+    tickRungs(t, [100, 200]); // two re-kicks in
+    assert.equal(h.kicks.length, 2);
+
+    h.scheduler.reset(DOC); // fresh connection
+    t.mock.timers.tick(600_000);
+    assert.equal(h.kicks.length, 2, "reset cancels the pending deadline");
+
+    h.scheduler.noteResyncKicked(DOC); // the re-establish's resync
+    t.mock.timers.tick(100);
+    assert.equal(h.kicks.length, 3, "ladder restarted at the base rung");
+
+    // Exhaust, reconnect, stall again: the SAME episode stays silent.
+    tickRungs(t, [200, 400, 800]);
+    assert.deepEqual(h.exhausted, [DOC]);
+    h.scheduler.reset(DOC);
+    h.scheduler.noteResyncKicked(DOC);
+    tickRungs(t, [100, 200, 400, 800]);
+    assert.deepEqual(h.exhausted, [DOC], "no second terminal signal without convergence between");
+    h.scheduler.dispose();
+  });
+
+  it("a closed kick gate holds the rung without kicking or consuming attempts", (t) => {
+    t.mock.timers.enable({ apis: ["setTimeout"] });
+    const h = createHarness();
+
+    h.scheduler.noteResyncKicked(DOC);
+    h.setKickAllowed(false); // link down: the reconnect line owns this
+    t.mock.timers.tick(100 * 50);
+    assert.deepEqual(h.kicks, [], "no kicks while the gate is closed");
+    assert.deepEqual(h.exhausted, [], "held deadlines never consume attempts");
+
+    h.setKickAllowed(true);
+    t.mock.timers.tick(100);
+    assert.deepEqual(h.kicks, [DOC], "first open deadline kicks at the held rung");
+    h.scheduler.dispose();
+  });
+
+  it("ignores verification for docs that never armed and is inert after dispose", (t) => {
+    t.mock.timers.enable({ apis: ["setTimeout"] });
+    const h = createHarness();
+
+    h.scheduler.noteVerification("runtime-state-doc", true); // future adopter, not armed
+    assert.deepEqual(h.recovered, []);
+
+    h.scheduler.noteResyncKicked(DOC);
+    h.scheduler.dispose();
+    t.mock.timers.tick(600_000);
+    assert.deepEqual(h.kicks, []);
+    h.scheduler.noteResyncKicked(DOC); // post-dispose no-op
+    t.mock.timers.tick(600_000);
+    assert.deepEqual(h.kicks, []);
+  });
+
+  it("jitter stays inside the configured ratio around each rung", (t) => {
+    t.mock.timers.enable({ apis: ["setTimeout"] });
+    // random() = 1 -> +25%; the first deadline lands at 125ms, not 100.
+    const h = createHarness({ random: () => 1, jitterRatio: 0.25 });
+    h.scheduler.noteResyncKicked(DOC);
+    t.mock.timers.tick(124);
+    assert.deepEqual(h.kicks, []);
+    t.mock.timers.tick(1);
+    assert.deepEqual(h.kicks, [DOC]);
+    h.scheduler.dispose();
+  });
+
+  it("keys docs independently (RuntimeStateDoc/Comms can adopt later)", (t) => {
+    t.mock.timers.enable({ apis: ["setTimeout"] });
+    const h = createHarness();
+
+    h.scheduler.noteResyncKicked(DOC);
+    h.scheduler.noteResyncKicked("runtime-state-doc");
+    t.mock.timers.tick(100);
+    assert.deepEqual(h.kicks.sort(), [DOC, "runtime-state-doc"].sort());
+
+    h.scheduler.noteVerification(DOC, true); // settles one doc only
+    t.mock.timers.tick(200);
+    assert.equal(h.kicks.filter((k) => k === "runtime-state-doc").length, 2);
+    assert.equal(h.kicks.filter((k) => k === DOC).length, 1);
+    h.scheduler.dispose();
+  });
+});
+
+describe("heal loop / rejection tracker non-interference", () => {
+  it("heal re-kicks never count as strikes or disturb the absorb window", (t) => {
+    t.mock.timers.enable({ apis: ["setTimeout"] });
+    const tracker = new CloudRecoverableRejectionTracker();
+    const h = createHarness({
+      // The session's kick seam calls engine.resetAndResync() ONLY — by
+      // construction it cannot touch the tracker. Model that here.
+      kick: () => {},
+    });
+
+    // Strike 1: in-place resync, absorb window open until delivery.
+    assert.equal(tracker.record(true), "resync_in_place");
+
+    // The heal loop re-kicks several times while the window is open.
+    h.scheduler.noteResyncKicked(NOTEBOOK_DOC_HEAL_KEY);
+    t.mock.timers.tick(100 + 200 + 400);
+
+    // A pipelined rejection still absorbs — heal activity added nothing.
+    assert.equal(tracker.record(true), "absorb");
+    assert.equal(tracker.record(true), "absorb");
+
+    // Post-delivery escalation semantics are untouched.
+    tracker.resyncSettled();
+    assert.equal(tracker.record(true), "escalate");
+    h.scheduler.dispose();
+  });
+});
+
+// Session wiring pins (the hook cannot run under node).
+describe("cloud session sync-heal wiring", () => {
+  const sessionSource = readFileSync(
+    new URL("../viewer/cloud-viewer-session.ts", import.meta.url),
+    "utf8",
+  );
+
+  it("verifies both fire-and-forget resync sites", () => {
+    // roomReady adoption: reset the ladder, then verify the re-establish.
+    assert.match(
+      sessionSource,
+      /applyRoomReady\(ready\)\) return;[\s\S]{0,400}?syncHeal\.reset\(NOTEBOOK_DOC_HEAL_KEY\);\s*\n\s*syncHeal\.noteResyncKicked\(NOTEBOOK_DOC_HEAL_KEY\);/,
+      "roomReady resets the ladder then arms verification",
+    );
+    // The rejection tracker's in-place recovery is verified too.
+    assert.match(
+      sessionSource,
+      /resync_in_place[\s\S]{0,700}?resetAndResync\(\);[\s\S]{0,400}?syncHeal\.noteResyncKicked\(NOTEBOOK_DOC_HEAL_KEY\);/,
+      "strike-1 in-place resync arms verification",
+    );
+  });
+
+  it("feeds the caught-up confirmation from notebookSyncApplied$", () => {
+    assert.match(
+      sessionSource,
+      /notebookSyncApplied\$\.subscribe[\s\S]{0,400}?cloudNotebookHandleCaughtUp\(liveRuntime\.handle\);[\s\S]{0,400}?syncHeal\.noteVerification\(NOTEBOOK_DOC_HEAL_KEY, caughtUp\);/,
+    );
+  });
+
+  it("gates re-kicks on the link being online and keeps failure domains separate", () => {
+    const schedulerBlock = sessionSource.slice(
+      sessionSource.indexOf("const syncHeal = new SyncHealScheduler"),
+      sessionSource.indexOf("const persistenceRearmGate"),
+    );
+    assert.match(schedulerBlock, /getCurrent\(\) === "online"/, "shouldKick gates on online");
+    assert.match(schedulerBlock, /resetAndResync\(\)/, "kick is the resync seam");
+    assert.doesNotMatch(
+      schedulerBlock,
+      /rejectionTracker/,
+      "heal kicks never touch the rejection tracker",
+    );
+    assert.doesNotMatch(
+      schedulerBlock,
+      /tabBridgeQuarantinedRef/,
+      "heal exhaustion is not bridge poison",
+    );
+    assert.doesNotMatch(
+      schedulerBlock,
+      /offlineMergeTracker/,
+      "heal kicks never feed the offline-merge tracker directly",
+    );
+  });
+
+  it("disposes the scheduler and clears the stall surface on cleanup", () => {
+    assert.match(sessionSource, /syncHeal\.dispose\(\);/);
+    assert.match(sessionSource, /setSyncHealStalled\(false\);/);
+  });
+
+  it("wires the persistence single heal: self-disable noted, one re-arm on online or recovery", () => {
+    assert.match(
+      sessionSource,
+      /onSelfDisabled: \(\) => persistenceRearmGate\.noteSelfDisabled\(\)/,
+      "controller pair reports self-disable into the gate",
+    );
+    assert.match(
+      sessionSource,
+      /status === "online"[\s\S]{0,80}?attemptPersistenceRearm\(\);/,
+      "online transition attempts the single re-arm",
+    );
+    assert.match(
+      sessionSource,
+      /onRecovered: [\s\S]{0,400}?attemptPersistenceRearm\(\);/,
+      "heal-loop recovery is the successful-resync trigger",
+    );
+  });
+});

--- a/apps/notebook-cloud/test/viewer-notices.test.ts
+++ b/apps/notebook-cloud/test/viewer-notices.test.ts
@@ -429,3 +429,69 @@ test("no offline merge notice means no offline merge markup", () => {
   assert.match(html, /Reconnecting\./);
   assert.doesNotMatch(html, /Synced your offline edits/);
 });
+
+test("sync-heal exhaustion renders ONE calm stalled line and counts as a notice", () => {
+  assert.equal(
+    cloudNotebookHasNotices({
+      authState: authState("oidc"),
+      authRenewal: { kind: "idle", message: null },
+      connectionError: null,
+      hasAppSession: true,
+      syncHealStalled: true,
+      status: { kind: "ready", message: "Ready" },
+    }),
+    true,
+  );
+
+  const html = renderToStaticMarkup(
+    React.createElement(CloudNotebookNotices, {
+      authState: authState("oidc"),
+      authRenewal: { kind: "idle", message: null },
+      connectionError: null,
+      hasAppSession: true,
+      syncHealStalled: true,
+      status: { kind: "ready", message: "Ready" },
+      onResetAuth: () => {},
+    }),
+  );
+
+  assert.match(html, /Sync is stalled\./);
+  assert.match(html, /Your edits are kept locally\./);
+  // Quiet rules: one occurrence, info tone, never a modal or action.
+  assert.equal(html.match(/Sync is stalled\./g)?.length, 1);
+});
+
+test("the sustained-reconnecting line owns the surface while the link is down", () => {
+  // The heal loop does not even re-kick while the transport is
+  // reconnecting, and two "edits are kept locally" lines would be noise:
+  // the stalled line yields to the reconnect line.
+  const html = renderToStaticMarkup(
+    React.createElement(CloudNotebookNotices, {
+      authState: authState("oidc"),
+      authRenewal: { kind: "idle", message: null },
+      connectionError: null,
+      hasAppSession: true,
+      sustainedReconnecting: true,
+      syncHealStalled: true,
+      status: { kind: "ready", message: "Ready" },
+      onResetAuth: () => {},
+    }),
+  );
+
+  assert.match(html, /Reconnecting\./);
+  assert.doesNotMatch(html, /Sync is stalled\./);
+});
+
+test("a cleared stall renders nothing (late convergence clears the line)", () => {
+  assert.equal(
+    cloudNotebookHasNotices({
+      authState: authState("oidc"),
+      authRenewal: { kind: "idle", message: null },
+      connectionError: null,
+      hasAppSession: true,
+      syncHealStalled: false,
+      status: { kind: "ready", message: "Ready" },
+    }),
+    false,
+  );
+});

--- a/apps/notebook-cloud/viewer/cloud-viewer-session.ts
+++ b/apps/notebook-cloud/viewer/cloud-viewer-session.ts
@@ -64,10 +64,12 @@ import {
 import type { CloudViewerLoadingPolicy } from "./loading-policy";
 import { markCloudViewerLoadMilestone } from "./load-milestones";
 import {
+  PersistenceRearmGate,
   createCloudNotebookPersistence,
   loadCloudPersistedNotebookSeed,
   type CloudNotebookPersistenceController,
 } from "./notebook-persistence";
+import { NOTEBOOK_DOC_HEAL_KEY, SyncHealScheduler } from "./sync-heal";
 import { createCloudNotebookTabBridge } from "./tab-bridge";
 import {
   OFFLINE_MERGE_RESYNC_SETTLE_MS,
@@ -160,6 +162,12 @@ export interface CloudViewerSession {
   retryLiveConnection: () => void;
   snapshotResolvedRef: MutableRefObject<boolean>;
   status: ViewerStatus;
+  /**
+   * The resync heal loop exhausted its ladder without the NotebookDoc
+   * catching up to the room (sync-heal.ts). Drives the quiet
+   * "Sync is stalled" notices line; clears the moment convergence lands.
+   */
+  syncHealStalled: boolean;
 }
 
 interface UseCloudViewerSessionOptions {
@@ -283,6 +291,8 @@ export function useCloudViewerSession({
     },
     [offlineMergeTracker],
   );
+  // Terminal heal-exhaustion surface (one quiet line; see sync-heal.ts).
+  const [syncHealStalled, setSyncHealStalled] = useState(false);
   const [connectionScope, setConnectionScope] = useState<string | null>(null);
   const [connectionPeerId, setConnectionPeerId] = useState<string | null>(null);
   const [connectionPeerLabel, setConnectionPeerLabel] = useState<string | null>(null);
@@ -531,6 +541,53 @@ export function useCloudViewerSession({
     // that cannot have observed the resync absorb, a post-resync repeat
     // escalates.
     const rejectionTracker = new CloudRecoverableRejectionTracker();
+    // Resync heal loop (slice 5): verify that resync kicks actually
+    // converge, re-kick on a bounded ladder, surface ONE quiet stall
+    // signal at exhaustion. Deliberately decoupled from the rejection
+    // tracker (kicks are not strikes), the offline-merge tracker (no
+    // kicks while the link is down), and the tab-bridge quarantine
+    // (separate failure domains) — see sync-heal.ts.
+    const syncHeal = new SyncHealScheduler({
+      kick: () => {
+        liveRuntimeRef.current?.engine.resetAndResync();
+      },
+      shouldKick: () =>
+        !disposed &&
+        liveRuntimeRef.current !== null &&
+        connectionStatusBridge.getCurrent() === "online",
+      onExhausted: () => {
+        if (disposed) return;
+        setSyncHealStalled(true);
+      },
+      onRecovered: () => {
+        if (disposed) return;
+        setSyncHealStalled(false);
+        // A converged resync is also the "successful resync" trigger for
+        // the persistence single heal.
+        attemptPersistenceRearm();
+      },
+      logger: console,
+    });
+    // Persistence single heal: one re-arm after a self-disable, consumed
+    // on the next online transition or heal-loop recovery.
+    const persistenceRearmGate = new PersistenceRearmGate();
+    const attemptPersistenceRearm = () => {
+      if (disposed || !persistenceRearmGate.takeRearm()) return;
+      const liveRuntime = liveRuntimeRef.current;
+      if (!liveRuntime) return;
+      console.warn("[notebook-persistence] re-arming once after self-disable");
+      // Force a fresh controller pair: no seed trust (the first save
+      // takes the unconditional snapshot arm — chunk-safe by design).
+      notebookPersistence?.dispose();
+      notebookPersistence = null;
+      notebookPersistencePrincipal = null;
+      armPersistence(liveRuntime);
+    };
+    const persistenceRearmSubscription = connectionStatusBridge.subscribe((status) => {
+      if (status === "online") {
+        attemptPersistenceRearm();
+      }
+    });
     let ranConnectionDiagnostics = false;
     // One full-materialization kick per runtime when the syncing doc first
     // catches up to the room's advertised heads (see the notebookSyncApplied$
@@ -693,6 +750,9 @@ export function useCloudViewerSession({
           seedChunks,
           seedGeneration,
           onError: (error) => console.warn("[notebook-cloud] notebook persistence error", error),
+          // Single heal: the gate notes the self-disable; the next online
+          // transition or heal-loop recovery consumes the one re-arm.
+          onSelfDisabled: () => persistenceRearmGate.noteSelfDisabled(),
         });
         if (notebookPersistence !== null) {
           notebookPersistenceEverArmed = true;
@@ -1081,6 +1141,11 @@ export function useCloudViewerSession({
               // delivered, so only rejections that could have observed it
               // count toward escalation.
               liveRuntime.engine.resetAndResync();
+              // Heal verification for the fire-and-forget kick. The heal
+              // loop never feeds back into the tracker: its re-kicks are
+              // not strikes and cannot disturb the delivery-gated absorb
+              // window above.
+              syncHeal.noteResyncKicked(NOTEBOOK_DOC_HEAL_KEY);
               void liveRuntime.engine
                 .flushAndWait()
                 .catch(() => undefined)
@@ -1157,6 +1222,12 @@ export function useCloudViewerSession({
             // this tick yields, ahead of the new connection's first sync
             // frame. Everything after it is async-safe.
             if (!liveRuntime.applyRoomReady(ready)) return;
+            // Fresh connection: reset the heal ladder (like reconnect
+            // backoff resets on the app-level ack) and verify the
+            // re-establish's resetAndResync that just ran inside
+            // applyRoomReady.
+            syncHeal.reset(NOTEBOOK_DOC_HEAL_KEY);
+            syncHeal.noteResyncKicked(NOTEBOOK_DOC_HEAL_KEY);
             setConnectionError(null);
             setConnectionScope(liveRuntime.connectionScope);
             setConnectionActorLabel(liveRuntime.actorLabel);
@@ -1229,8 +1300,13 @@ export function useCloudViewerSession({
           // live truth INCLUDING EMPTINESS displaces painted or preserved
           // cells (see the zero-cell guard above).
           liveRuntime.engine.notebookSyncApplied$.subscribe(() => {
+            const caughtUp = cloudNotebookHandleCaughtUp(liveRuntime.handle);
+            // Confirmation is just another sync: caught_up === true means
+            // the previous exchange provably landed — it settles the heal
+            // loop (and clears a standing stall notice).
+            syncHeal.noteVerification(NOTEBOOK_DOC_HEAL_KEY, caughtUp);
             if (caughtUpMaterializeKicked) return;
-            if (!cloudNotebookHandleCaughtUp(liveRuntime.handle)) return;
+            if (!caughtUp) return;
             caughtUpMaterializeKicked = true;
             materializeLiveCellsSafely(liveRuntime);
           }),
@@ -1309,6 +1385,9 @@ export function useCloudViewerSession({
 
     return () => {
       disposed = true;
+      syncHeal.dispose();
+      persistenceRearmSubscription.unsubscribe();
+      setSyncHealStalled(false);
       for (const subscription of subscriptions) {
         subscription.unsubscribe();
       }
@@ -1407,6 +1486,7 @@ export function useCloudViewerSession({
     retryLiveConnection,
     snapshotResolvedRef,
     status,
+    syncHealStalled,
   };
 }
 

--- a/apps/notebook-cloud/viewer/cloud-viewer-session.ts
+++ b/apps/notebook-cloud/viewer/cloud-viewer-session.ts
@@ -1198,6 +1198,14 @@ export function useCloudViewerSession({
         installCloudWidgetCommWriter(liveRuntime);
         armPersistence(liveRuntime);
         armTabBridge(liveRuntime);
+        // Arm convergence verification for the INITIAL bootstrap exchange.
+        // The roomReady$ arming never covers it: the replayed first
+        // handshake trips the applyRoomReady peer-id dedupe, so without
+        // this a first-connection stall (wedged room host answering
+        // liveness pings without converging) would never kick, exhaust,
+        // or surface — and the cold load is the most common connection
+        // event.
+        syncHeal.noteResyncKicked(NOTEBOOK_DOC_HEAL_KEY);
         // Anonymous sessions are out of scope for offline-merge surfacing
         // (per-connection principals; persistence never arms for them).
         offlineMergeTracker.noteSessionEligibility(

--- a/apps/notebook-cloud/viewer/notebook-persistence.ts
+++ b/apps/notebook-cloud/viewer/notebook-persistence.ts
@@ -91,6 +91,13 @@ export interface CreateCloudNotebookPersistenceOptions {
    */
   seedGeneration?: number;
   onError?: (error: unknown) => void;
+  /**
+   * Fired AT MOST ONCE per controller pair when either controller
+   * self-disables after repeated save failures (never on manual
+   * dispose). The session consumes it through PersistenceRearmGate's
+   * single-heal discipline.
+   */
+  onSelfDisabled?: () => void;
   /** Test hook: trailing-edge throttle for both controllers. */
   throttleMs?: number;
   /** Test hook: content-hash override for incremental chunk keys. */
@@ -107,12 +114,25 @@ export function createCloudNotebookPersistence({
   seedChunks,
   seedGeneration,
   onError,
+  onSelfDisabled,
   throttleMs,
   chunkDigest,
 }: CreateCloudNotebookPersistenceOptions): CloudNotebookPersistenceController | null {
   if (isAnonymousCloudPrincipal(principal)) {
     return null;
   }
+
+  // Both controllers share one backend; if it is dead enough to disable
+  // one, the other follows within its own failure budget — surface ONE
+  // signal for the pair so the single-heal gate is consumed once.
+  let selfDisabledSignaled = false;
+  const signalSelfDisabledOnce = onSelfDisabled
+    ? () => {
+        if (selfDisabledSignaled) return;
+        selfDisabledSignaled = true;
+        onSelfDisabled();
+      }
+    : undefined;
 
   const notebookDoc = new NotebookDocPersistence({
     adapter,
@@ -129,6 +149,7 @@ export function createCloudNotebookPersistence({
       ...(chunkDigest ? { digest: chunkDigest } : {}),
     },
     onError,
+    onSelfDisabled: signalSelfDisabledOnce,
     ...(throttleMs !== undefined ? { throttleMs } : {}),
   });
   const runtimeStateCache = new NotebookDocPersistence({
@@ -140,6 +161,7 @@ export function createCloudNotebookPersistence({
     getSaveBytes: () => handle.save_state_doc(),
     getHeadsHex: () => handle.get_runtime_state_heads_hex(),
     onError,
+    onSelfDisabled: signalSelfDisabledOnce,
     ...(throttleMs !== undefined ? { throttleMs } : {}),
   });
 
@@ -216,4 +238,32 @@ export async function loadCloudPersistedNotebookSeed(
     return { bytes: chunkSeed.bytes, meta: chunkSeed.meta, chunks: chunkSeed.chunks };
   }
   return envelope;
+}
+
+/**
+ * One-shot heal gate for a self-disabled persistence controller pair.
+ *
+ * The controller's 3-failure self-dispose is usually quota or a dead
+ * backend — but a transient-network IndexedDB hiccup deserves exactly one
+ * second chance. The session notes the self-disable here and consumes the
+ * single re-arm on the next `online` transition or successful resync
+ * (heal-loop recovery); a second self-disable within the same session
+ * stays disabled with the controller's existing one-line warn. Single
+ * heal, not a loop.
+ */
+export class PersistenceRearmGate {
+  private selfDisabled = false;
+  private used = false;
+
+  noteSelfDisabled(): void {
+    this.selfDisabled = true;
+  }
+
+  /** Consume the single re-arm if one is owed (true at most once). */
+  takeRearm(): boolean {
+    if (!this.selfDisabled || this.used) return false;
+    this.used = true;
+    this.selfDisabled = false;
+    return true;
+  }
 }

--- a/apps/notebook-cloud/viewer/notebook-viewer.tsx
+++ b/apps/notebook-cloud/viewer/notebook-viewer.tsx
@@ -218,6 +218,7 @@ export function NotebookViewer({
     retryLiveConnection,
     snapshotResolvedRef,
     status,
+    syncHealStalled,
   } = useCloudViewerSession({
     authRenewalKind: authRenewal.kind,
     authState,
@@ -961,6 +962,7 @@ export function NotebookViewer({
     offlineMergeNotice,
     rendererAssetError,
     sustainedReconnecting,
+    syncHealStalled,
     status: noticeStatus,
   });
   const notices = hasNotices ? (
@@ -974,6 +976,7 @@ export function NotebookViewer({
       offlineMergeNotice={offlineMergeNotice}
       rendererAssetError={rendererAssetError}
       sustainedReconnecting={sustainedReconnecting}
+      syncHealStalled={syncHealStalled}
       status={noticeStatus}
       onResetAuth={resetPrototypeAuth}
       onRetryConnection={retryLiveConnection}

--- a/apps/notebook-cloud/viewer/notices.tsx
+++ b/apps/notebook-cloud/viewer/notices.tsx
@@ -31,6 +31,15 @@ export interface CloudNotebookNoticesProps {
    */
   sustainedReconnecting?: boolean;
   /**
+   * The resync heal loop exhausted its ladder without the doc catching
+   * up to the room (sync-heal.ts). One calm line under the quiet rules —
+   * never a modal — cleared the moment convergence lands. While the
+   * sustained-reconnecting line is up it stays silent: the link-down
+   * line owns that surface, and the heal loop does not even re-kick
+   * while the transport is reconnecting.
+   */
+  syncHealStalled?: boolean;
+  /**
    * One quiet line per outage after a reconnect completed with
    * locally-authored work pending across the gap (offline-merge tracker).
    * Cleared by the next user action or a short timeout; a reconnect with
@@ -102,6 +111,7 @@ export function cloudNotebookHasNotices({
   offlineMergeNotice = null,
   rendererAssetError = null,
   sustainedReconnecting = false,
+  syncHealStalled = false,
   status,
   diagnostics,
 }: Omit<CloudNotebookNoticesProps, "onResetAuth">): boolean {
@@ -121,6 +131,7 @@ export function cloudNotebookHasNotices({
     shouldShowAuthNotice ||
     shouldShowAuthRenewalNotice ||
     sustainedReconnecting ||
+    (syncHealStalled && !sustainedReconnecting) ||
     Boolean(offlineMergeNotice) ||
     Boolean(connectionNotice) ||
     Boolean(rendererAssetError) ||
@@ -138,6 +149,7 @@ export function CloudNotebookNotices({
   offlineMergeNotice = null,
   rendererAssetError = null,
   sustainedReconnecting = false,
+  syncHealStalled = false,
   status,
   diagnostics,
   onResetAuth,
@@ -155,6 +167,7 @@ export function CloudNotebookNotices({
       offlineMergeNotice,
       rendererAssetError,
       sustainedReconnecting,
+      syncHealStalled,
       status,
       diagnostics,
     })
@@ -210,6 +223,16 @@ export function CloudNotebookNotices({
       {sustainedReconnecting ? (
         <NotebookNotice tone="info" icon={<CloudOff className="h-4 w-4" />} title="Reconnecting.">
           Your edits are kept locally and will sync when the connection returns.
+        </NotebookNotice>
+      ) : null}
+
+      {syncHealStalled && !sustainedReconnecting ? (
+        <NotebookNotice
+          tone="info"
+          icon={<CloudOff className="h-4 w-4" />}
+          title="Sync is stalled."
+        >
+          Your edits are kept locally. This clears as soon as the room catches up.
         </NotebookNotice>
       ) : null}
 

--- a/apps/notebook-cloud/viewer/sync-heal.ts
+++ b/apps/notebook-cloud/viewer/sync-heal.ts
@@ -1,0 +1,219 @@
+/**
+ * SyncHealScheduler — per-doc resync heal-retry with an exhaustion signal
+ * (slice 5 of #3585; automerge-repo's SyncScheduler shape: 2s → 60s,
+ * factor 2, jittered, bounded attempts, then ONE terminal heal-exhausted
+ * event).
+ *
+ * Confirmation is just another sync: after a resync kick the session
+ * polls the doc's catch-up fact (`notebook_doc_caught_up()` on each
+ * `notebookSyncApplied$` emission — the #3588 primitives) and feeds it
+ * here. `caught_up === true` IS the confirmation check — a
+ * re-verification that returns true iff the previous exchange landed.
+ * No confirmation inside the deadline → re-kick the resync on the next
+ * ladder rung; ladder exhausted → one terminal signal (the quiet
+ * "Sync is stalled" notice), cleared if convergence later lands.
+ *
+ * Per-doc keyed so RuntimeStateDoc/CommsDoc can adopt the same loop
+ * later; only the NotebookDoc is wired today (`NOTEBOOK_DOC_HEAL_KEY`).
+ *
+ * Interplay (deliberate non-couplings):
+ * - Re-kicks call `resetAndResync()` directly and never touch the
+ *   CloudRecoverableRejectionTracker: strikes count inbound rejections
+ *   only, and the tracker's delivery-gated absorb window
+ *   (`resyncPending`) is set exclusively by its own strike-1 path.
+ * - Re-kicks are gated on the link being up (`shouldKick`): while the
+ *   transport is reconnecting, the deadline neither kicks nor consumes
+ *   an attempt — offline stalls belong to the sustained-reconnecting
+ *   line, and a kick's flush attempt while the offline-merge tracker's
+ *   window is open would be miscounted as local authoring.
+ * - Heal exhaustion is NOT bridge poison: it never touches the tab
+ *   bridge quarantine flag (separate failure domains).
+ * - A `roomReady$` adoption resets the ladder like reconnect backoff
+ *   resets on the app-level ack: fresh connection, fresh verification.
+ */
+
+export const SYNC_HEAL_BASE_DELAY_MS = 2_000;
+export const SYNC_HEAL_MAX_DELAY_MS = 60_000;
+export const SYNC_HEAL_BACKOFF_FACTOR = 2;
+export const SYNC_HEAL_MAX_ATTEMPTS = 10;
+/** ± full jitter ratio on every deadline (random 0.5 = exact rung). */
+export const SYNC_HEAL_JITTER_RATIO = 0.25;
+
+/** The only doc wired today. */
+export const NOTEBOOK_DOC_HEAL_KEY = "notebook-doc";
+
+export interface SyncHealLogger {
+  debug(msg: string, ...args: unknown[]): void;
+  warn(msg: string, ...args: unknown[]): void;
+}
+
+export interface SyncHealSchedulerOptions {
+  /** Re-issue the doc's resync (the session's `resetAndResync()` seam). */
+  kick: (docKey: string) => void;
+
+  /**
+   * Gate consulted at each deadline: false (link down, runtime gone)
+   * re-arms the SAME rung without kicking or consuming an attempt.
+   */
+  shouldKick?: (docKey: string) => boolean;
+
+  /** The ONE terminal signal per stalled episode. */
+  onExhausted: (docKey: string) => void;
+
+  /** Convergence landed after exhaustion — clear the terminal surface. */
+  onRecovered: (docKey: string) => void;
+
+  baseDelayMs?: number;
+  maxDelayMs?: number;
+  backoffFactor?: number;
+  maxAttempts?: number;
+  jitterRatio?: number;
+
+  /** Jitter source override for deterministic tests (0.5 = no jitter). */
+  random?: () => number;
+
+  logger?: SyncHealLogger;
+}
+
+interface DocHealState {
+  /** Re-kicks issued since the ladder last reset. */
+  attempts: number;
+  /** Pending verification deadline (null = not verifying). */
+  timer: ReturnType<typeof setTimeout> | null;
+  /**
+   * The terminal signal fired and convergence has not landed since. The
+   * episode ends only at `caught_up === true` (onRecovered), never at a
+   * ladder reset — a reconnect that still cannot converge must not
+   * re-fire the notice for what is the same stall.
+   */
+  exhausted: boolean;
+}
+
+export class SyncHealScheduler {
+  private readonly opts: SyncHealSchedulerOptions;
+  private readonly docs = new Map<string, DocHealState>();
+  private disposed = false;
+
+  constructor(opts: SyncHealSchedulerOptions) {
+    this.opts = opts;
+  }
+
+  /**
+   * A resync was just issued for this doc (roomReady re-establish, the
+   * rejection tracker's in-place recovery, or this scheduler's own
+   * re-kick): arm the verification deadline at the current ladder rung.
+   */
+  noteResyncKicked(docKey: string): void {
+    if (this.disposed) return;
+    const state = this.docState(docKey);
+    this.clearTimer(state);
+    this.armDeadline(docKey, state);
+  }
+
+  /**
+   * Feed each `notebookSyncApplied$` poll of `notebook_doc_caught_up()`.
+   * `true` settles the loop: the previous exchange provably landed —
+   * cancel the deadline, reset the ladder, and clear a standing
+   * exhaustion. `false` is not a failure (frames are still flowing);
+   * the deadline timer remains the judge.
+   */
+  noteVerification(docKey: string, caughtUp: boolean): void {
+    if (this.disposed || !caughtUp) return;
+    const state = this.docs.get(docKey);
+    if (!state) return;
+    this.clearTimer(state);
+    state.attempts = 0;
+    if (state.exhausted) {
+      state.exhausted = false;
+      this.opts.logger?.debug(`[sync-heal] ${docKey} converged after exhaustion; clearing`);
+      this.opts.onRecovered(docKey);
+    }
+  }
+
+  /**
+   * Fresh connection (roomReady adoption): reset the ladder the way
+   * reconnect backoff resets on the app-level ack. Keeps a standing
+   * exhaustion flag — only real convergence clears the notice.
+   */
+  reset(docKey: string): void {
+    if (this.disposed) return;
+    const state = this.docs.get(docKey);
+    if (!state) return;
+    this.clearTimer(state);
+    state.attempts = 0;
+  }
+
+  dispose(): void {
+    if (this.disposed) return;
+    this.disposed = true;
+    for (const state of this.docs.values()) {
+      this.clearTimer(state);
+    }
+    this.docs.clear();
+  }
+
+  private clearTimer(state: DocHealState): void {
+    if (state.timer !== null) {
+      clearTimeout(state.timer);
+      state.timer = null;
+    }
+  }
+
+  private docState(docKey: string): DocHealState {
+    let state = this.docs.get(docKey);
+    if (!state) {
+      state = { attempts: 0, timer: null, exhausted: false };
+      this.docs.set(docKey, state);
+    }
+    return state;
+  }
+
+  private armDeadline(docKey: string, state: DocHealState): void {
+    state.timer = setTimeout(() => {
+      state.timer = null;
+      this.onDeadline(docKey, state);
+    }, this.deadlineMs(state.attempts));
+  }
+
+  private onDeadline(docKey: string, state: DocHealState): void {
+    if (this.disposed) return;
+    if (!(this.opts.shouldKick?.(docKey) ?? true)) {
+      // Link down or runtime gone: not a sync stall. Hold the rung —
+      // the reconnect machinery owns this state, and roomReady resets
+      // the ladder when the room is back.
+      this.armDeadline(docKey, state);
+      return;
+    }
+    const maxAttempts = this.opts.maxAttempts ?? SYNC_HEAL_MAX_ATTEMPTS;
+    if (state.attempts >= maxAttempts) {
+      // Stop the ladder. One terminal signal per episode; a standing
+      // exhaustion (e.g. after a roomReady reset re-ran the ladder
+      // without converging) stays silent.
+      if (!state.exhausted) {
+        state.exhausted = true;
+        this.opts.logger?.warn(
+          `[sync-heal] ${docKey} resync verification exhausted after ${maxAttempts} attempts; edits stay local until sync recovers`,
+        );
+        this.opts.onExhausted(docKey);
+      }
+      return;
+    }
+    state.attempts += 1;
+    this.opts.logger?.debug(
+      `[sync-heal] ${docKey} not caught up by deadline; re-kicking resync (attempt ${state.attempts})`,
+    );
+    this.opts.kick(docKey);
+    this.armDeadline(docKey, state);
+  }
+
+  private deadlineMs(attempts: number): number {
+    const base = this.opts.baseDelayMs ?? SYNC_HEAL_BASE_DELAY_MS;
+    const max = this.opts.maxDelayMs ?? SYNC_HEAL_MAX_DELAY_MS;
+    const factor = this.opts.backoffFactor ?? SYNC_HEAL_BACKOFF_FACTOR;
+    const ratio = this.opts.jitterRatio ?? SYNC_HEAL_JITTER_RATIO;
+    const rung = Math.min(base * factor ** attempts, max);
+    const random = this.opts.random ?? Math.random;
+    // Full ± jitter: random() of 0.5 lands exactly on the rung.
+    return Math.max(0, Math.round(rung * (1 + (2 * random() - 1) * ratio)));
+  }
+}

--- a/docs/adr/local-first-notebook-state.md
+++ b/docs/adr/local-first-notebook-state.md
@@ -912,6 +912,51 @@ never writes storage), arms only when the deployed WASM bundle ships
 `save_since_heads` (older bundles degrade to single-tab), and its
 channel closes before the WASM handle frees.
 
+### PR 8 — Resync heal loop + persistence single heal (landed)
+
+Slice 5 of #3585 — the two operational prior-art patterns (per-doc
+heal-retry with an exhaustion signal; "confirmation is just another
+sync") applied to our shapeless spot: resync verification.
+
+**Resync heal loop** (`apps/notebook-cloud/viewer/sync-heal.ts`,
+upstream `SyncScheduler` shape). Both fire-and-forget `resetAndResync()`
+sites — the per-roomReady re-establish and the rejection tracker's
+strike-1 in-place recovery — now arm a verification deadline. The
+confirmation primitive is the #3588 pair: `notebook_doc_caught_up()`
+polled on each `notebookSyncApplied$` emission — a re-verification that
+returns true iff the previous exchange landed. Not caught up within the
+deadline → re-kick the resync on a bounded ladder (2 s → 60 s, factor 2,
+± 25 % jitter, 10 attempts) → exhaustion is ONE terminal signal: the
+quiet "Sync is stalled." notices line (info tone, never a modal, yields
+to the sustained-reconnecting line, clears the moment convergence lands)
+plus a `[sync-heal]` warn. The scheduler is per-doc keyed —
+RuntimeStateDoc/CommsDoc adoption is open follow-up; only the
+NotebookDoc is wired.
+
+Deliberate non-couplings, pinned by tests: heal re-kicks never count as
+rejection strikes and cannot disturb the tracker's delivery-gated absorb
+window (strikes count inbound rejections only); re-kicks are gated on
+the link being `online`, so a held deadline neither kicks nor consumes
+attempts while the transport reconnects (offline stalls belong to the
+sustained-reconnecting line, and a kick's flush during the offline-merge
+window would be miscounted as local authoring); heal exhaustion never
+touches the tab-bridge quarantine (separate failure domains); a
+`roomReady$` adoption resets the ladder like reconnect backoff resets on
+the app-level ack — but a standing exhaustion notice clears only on real
+convergence, never on a reset (same stall, one signal).
+
+**Persistence single heal.** The save controller's 3-failure
+self-dispose was terminal-silent; it now emits `onSelfDisabled` (once
+per controller pair — both share one backend), and the session grants
+exactly ONE re-arm, consumed on the next `online` transition or a
+heal-loop recovery (the successful-resync trigger): a fresh controller
+pair with no seed trust, whose first save takes the unconditional
+snapshot arm (chunk-safe by design). A second self-disable in the same
+session stays disabled with the existing one-line warn. Single heal, not
+a loop — storage that failed three times is usually quota or a dead
+backend; the one retry exists for the transient-network IndexedDB
+hiccup.
+
 ## Prior-art trajectory: subduction / sedimentree
 
 The automerge ecosystem's successor sync line (Ink & Switch
@@ -942,9 +987,11 @@ moves when the time comes:
    slot in as new records under the same `[notebookId, "chunks", ...]`
    prefix (unknown sub-keys are already ignored, never deleted, by every
    read path), so the swap needs no migration.
-3. Operational patterns worth stealing regardless: per-doc heal-retry with
-   an exhaustion signal, and "confirmation is just another sync"
-   idempotence.
+3. ~~Operational patterns worth stealing regardless: per-doc heal-retry
+   with an exhaustion signal, and "confirmation is just another sync"
+   idempotence~~ — landed as PR 8's resync heal loop (NotebookDoc only;
+   RuntimeStateDoc/Comms adoption of the per-doc-keyed scheduler is open
+   follow-up).
 
 ## Out of scope (recorded, no PR planned)
 

--- a/docs/adr/local-first-notebook-state.md
+++ b/docs/adr/local-first-notebook-state.md
@@ -919,9 +919,13 @@ heal-retry with an exhaustion signal; "confirmation is just another
 sync") applied to our shapeless spot: resync verification.
 
 **Resync heal loop** (`apps/notebook-cloud/viewer/sync-heal.ts`,
-upstream `SyncScheduler` shape). Both fire-and-forget `resetAndResync()`
-sites — the per-roomReady re-establish and the rejection tracker's
-strike-1 in-place recovery — now arm a verification deadline. The
+upstream `SyncScheduler` shape). All three fire-and-forget sync
+exchanges — the **initial bootstrap** (armed in the connect resolution
+block: the replayed first handshake trips the `applyRoomReady` peer-id
+dedupe, so the roomReady arming never covers the cold load — the
+review's confirmed finding), the per-roomReady re-establish, and the
+rejection tracker's strike-1 in-place recovery — now arm a
+verification deadline. The
 confirmation primitive is the #3588 pair: `notebook_doc_caught_up()`
 polled on each `notebookSyncApplied$` emission — a re-verification that
 returns true iff the previous exchange landed. Not caught up within the

--- a/packages/runtimed/src/persistence/notebook-doc-persistence.ts
+++ b/packages/runtimed/src/persistence/notebook-doc-persistence.ts
@@ -284,6 +284,17 @@ export interface NotebookDocPersistenceOptions {
   /** Persistence failures route here; they never throw into the session. */
   onError?: (error: unknown) => void;
 
+  /**
+   * Fired exactly once when the controller self-disables after
+   * `MAX_CONSECUTIVE_SAVE_FAILURES` (never on a manual `dispose()`).
+   * The session layer uses it for the single heal: ONE re-arm attempt
+   * (a fresh controller) on the next `online` event or successful
+   * resync — storage that failed three times is usually quota or a dead
+   * backend, but a transient-network IndexedDB hiccup deserves one
+   * second chance. Exhaustion of that one attempt stays disabled.
+   */
+  onSelfDisabled?: () => void;
+
   logger?: NotebookDocPersistenceLogger;
 }
 
@@ -740,6 +751,11 @@ export class NotebookDocPersistence {
       // session. A fresh session recreates persistence and retries.
       this.logger.warn("[notebook-persistence] disabled after repeated save failures");
       this.dispose();
+      try {
+        this.opts.onSelfDisabled?.();
+      } catch {
+        // the self-disable signal must never throw back into the pipeline
+      }
     }
   }
 }

--- a/packages/runtimed/tests/chunked-notebook-doc-persistence.test.ts
+++ b/packages/runtimed/tests/chunked-notebook-doc-persistence.test.ts
@@ -71,7 +71,7 @@ function createRecordingAdapter({ withSaveBatch = true } = {}): RecordingAdapter
     removeRange: vi.fn(async (prefix: StorageKey) => {
       const exact = joinKey(prefix);
       const rangePrefix = `${exact}/`;
-      for (const key of [...records.keys()]) {
+      for (const key of Array.from(records.keys())) {
         if (key === exact || key.startsWith(rangePrefix)) {
           records.delete(key);
         }

--- a/packages/runtimed/tests/notebook-doc-persistence.test.ts
+++ b/packages/runtimed/tests/notebook-doc-persistence.test.ts
@@ -349,6 +349,53 @@ describe("NotebookDocPersistence", () => {
     expect(getSaveBytes).toHaveBeenCalledTimes(3);
   });
 
+  it("fires onSelfDisabled exactly once at the self-disable threshold", async () => {
+    adapter.save = vi.fn(async () => {
+      throw new Error("quota exceeded");
+    });
+    const onSelfDisabled = vi.fn();
+    const controller = createController({ logger: silentLogger, onSelfDisabled });
+
+    for (let i = 0; i < 2; i++) {
+      changes$.next();
+      await vi.advanceTimersByTimeAsync(1_000);
+    }
+    expect(onSelfDisabled).not.toHaveBeenCalled();
+
+    changes$.next();
+    await vi.advanceTimersByTimeAsync(1_000);
+    expect(onSelfDisabled).toHaveBeenCalledTimes(1);
+
+    // Already disposed: nothing can re-fire the signal.
+    await controller.flushNow();
+    changes$.next();
+    await vi.advanceTimersByTimeAsync(5_000);
+    expect(onSelfDisabled).toHaveBeenCalledTimes(1);
+  });
+
+  it("never fires onSelfDisabled for a manual dispose or sub-threshold failures", async () => {
+    const onSelfDisabled = vi.fn();
+    let failing = true;
+    adapter.save = vi.fn(async (key: StorageKey, data: Uint8Array) => {
+      if (failing) throw new Error("transient");
+      adapter.saves.push({ key, data });
+    });
+    const controller = createController({ logger: silentLogger, onSelfDisabled });
+
+    // Two failures, then recovery: the count resets, no signal.
+    for (let i = 0; i < 2; i++) {
+      changes$.next();
+      await vi.advanceTimersByTimeAsync(1_000);
+    }
+    failing = false;
+    changes$.next();
+    await vi.advanceTimersByTimeAsync(1_000);
+    expect(adapter.saves).toHaveLength(1);
+
+    controller.dispose();
+    expect(onSelfDisabled).not.toHaveBeenCalled();
+  });
+
   it("skips the save when heads are unchanged since the last save", async () => {
     // notebookDocChanged$ over-fires for protocol-only flushes; identical
     // heads mean identical doc state, so the snapshot would be a no-op.

--- a/packages/runtimed/tests/notebook-doc-persistence.test.ts
+++ b/packages/runtimed/tests/notebook-doc-persistence.test.ts
@@ -46,7 +46,7 @@ function createRecordingAdapter(): RecordingAdapter {
     loadRange: vi.fn(async () => []),
     removeRange: vi.fn(async (prefix: StorageKey) => {
       const rangePrefix = `${prefix.join("\u0000")}\u0000`;
-      for (const key of [...records.keys()]) {
+      for (const key of Array.from(records.keys())) {
         if (key.startsWith(rangePrefix) || key === prefix.join("\u0000")) {
           records.delete(key);
         }

--- a/packages/runtimed/tests/notebook-tab-bridge.test.ts
+++ b/packages/runtimed/tests/notebook-tab-bridge.test.ts
@@ -413,7 +413,7 @@ describe("NotebookTabBridge offline convergence (real WASM)", () => {
       handle.set_actor(`user:test:alice/browser:tab-${suffix}`);
       return createTab(handle, "user:test:alice", bus);
     });
-    const [tabA, tabB, tabC] = tabs as [Tab, Tab, Tab];
+    const [tabA, _tabB, _tabC] = tabs as [Tab, Tab, Tab];
     try {
       tabA.handle.add_cell(0, "cell-a", "code");
       tabA.handle.update_source("cell-a", "from_tab_a = 1");


### PR DESCRIPTION
The final live slice of #3585 — the two operational patterns from the automerge-repo/subduction deep-read, applied to our own shapeless spot: **resync verification**.

## Resync heal loop

`resetAndResync()` was fire-and-forget — nothing verified that a recovery actually converged. Now every fire-and-forget sync exchange arms a per-doc verification deadline in the upstream `SyncScheduler` shape: the **initial bootstrap** (the compact adversarial review's confirmed major: the replayed first handshake trips the `applyRoomReady` peer-id dedupe, so roomReady arming never covers the cold load — the most common connection event was the one left unverified, exactly the scenario where instant paint shows editable content under an honest *online* dot while a wedged room host answers liveness pings without converging), the per-roomReady re-establish, and the rejection tracker's strike-1 in-place recovery.

The confirmation primitive is `notebook_doc_caught_up()` polled on `notebookSyncApplied$` (#3588's pair) — *"confirmation is just another sync"*: a re-verification that returns true iff the previous exchange landed. Not converged by deadline → re-kick on a bounded ladder (2s→60s, ×2, ±25% jitter, 10 attempts) → exhaustion is ONE quiet signal: "Sync is stalled. / Your edits are kept locally." (info tone, yields to the sustained-reconnecting line, clears on late convergence) + a `[sync-heal]` log.

Interplay, all test-pinned: heal kicks never count as rejection-tracker strikes; `shouldKick` gates on the link being online (held deadlines don't consume attempts while reconnecting); roomReady resets the ladder but a standing exhaustion clears only on real convergence (same stall, one signal); exhaustion never touches the tab-bridge quarantine. Per-doc keyed — RuntimeStateDoc/Comms adoption recorded open in the ADR.

## Persistence self-disable: one second chance

The controller's 3-failure self-dispose was terminal-silent. It now signals `onSelfDisabled` once per controller pair, and a `PersistenceRearmGate` grants exactly one re-arm on the next `online` transition or heal recovery — a transient IDB hiccup gets a second chance; a genuinely dead backend stays disabled after one retry.

## Review

Compact adversarial pass (1 finder + verification): 1 confirmed major (the initial-bootstrap arming gap above — fixed with a wiring pin and ADR acknowledgment), 1 refuted (the cross-reset starvation claim — the notice survives ladder resets once fired, and flapping *accelerates* healing). Also clears the four pre-existing lint warnings from #3595's tests.

## Verification

vp suite **2244 passed, 0 failed** · notebook-cloud **946 passed, 0 failed** (sync-heal 16, notices 21) · no Rust changes · `cargo xtask lint` **0 warnings** · ADR updated.

With this, #3585 reduces to its watch-list (fragments successor + subduction protocol items).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
