### PR TITLE
feat(notebook-cloud): workstation pairing codes mint scoped workstation credentials

### DIFF
--- a/.claude/.gitignore
+++ b/.claude/.gitignore
@@ -1,0 +1,1 @@
+worktrees/

--- a/apps/notebook-cloud/src/identity.ts
+++ b/apps/notebook-cloud/src/identity.ts
@@ -43,7 +43,13 @@ export interface IdentityEnvironment {
 }
 
 export interface AuthenticatedConnectionMetadata {
-  provider: "anonymous" | "app-session" | "dev" | "oidc" | "anaconda-api-key";
+  provider:
+    | "anonymous"
+    | "app-session"
+    | "dev"
+    | "oidc"
+    | "anaconda-api-key"
+    | "workstation-credential";
   transport:
     | "anonymous"
     | "app-session-cookie"
@@ -52,11 +58,14 @@ export interface AuthenticatedConnectionMetadata {
     | "dev-token-subprotocol"
     | "api-key-bearer"
     | "oidc-bearer"
-    | "oidc-subprotocol";
+    | "oidc-subprotocol"
+    | "workstation-credential-header";
   principalNamespace: string;
   displayName?: string;
   email?: string;
   emailVerified?: boolean;
+  workstationCredentialId?: string;
+  workstationPairingCodeId?: string;
 }
 
 const ANONYMOUS_PRINCIPAL_PREFIX = "anonymous:";
@@ -746,7 +755,8 @@ function isMetadataProvider(value: string): value is AuthenticatedConnectionMeta
     value === "app-session" ||
     value === "dev" ||
     value === "oidc" ||
-    value === "anaconda-api-key"
+    value === "anaconda-api-key" ||
+    value === "workstation-credential"
   );
 }
 
@@ -759,7 +769,8 @@ function isMetadataTransport(value: string): value is AuthenticatedConnectionMet
     value === "dev-token-subprotocol" ||
     value === "api-key-bearer" ||
     value === "oidc-bearer" ||
-    value === "oidc-subprotocol"
+    value === "oidc-subprotocol" ||
+    value === "workstation-credential-header"
   );
 }
 

--- a/apps/notebook-cloud/src/index.ts
+++ b/apps/notebook-cloud/src/index.ts
@@ -59,6 +59,15 @@ import {
   type WorkstationRow,
   type WorkstationStatus,
 } from "./storage.ts";
+import {
+  authenticateWorkstationCredentialRequest,
+  createWorkstationPairingCode,
+  getWorkstationPairingCodeForOwner,
+  linkWorkstationToPairing,
+  redeemWorkstationPairingCode,
+  workstationCredentialTokenFromRequest,
+  workstationPairingStatus,
+} from "./workstation-credentials.ts";
 import { materializeSnapshotPairRender } from "./snapshot-render.ts";
 import {
   createNotebookCloudBlobResolver,
@@ -231,6 +240,24 @@ const NOTEBOOK_CLOUD_ROUTES: readonly WorkerRoute[] = [
     match: exactPath("/api/workstations/default"),
     methods: ["PATCH"],
     handler: (_match, request, env) => routeDefaultWorkstation(request, env),
+  },
+  {
+    match: exactPath("/api/workstations/pairing-codes"),
+    methods: ["POST"],
+    handler: (_match, request, env) => routeWorkstationPairingCodes(request, env),
+  },
+  {
+    match: exactPath("/api/workstations/pairing-codes/redeem"),
+    methods: ["POST"],
+    handler: (_match, request, env) => routeWorkstationPairingCodeRedeem(request, env),
+  },
+  {
+    match: routePath("/api/workstations/pairing-codes/:pairingId", {
+      trailingSlash: "optional",
+    }),
+    methods: ["GET"],
+    handler: ({ params }, request, env) =>
+      routeWorkstationPairingCode(request, env, params.pairingId),
   },
   {
     match: routePath("/api/workstations/:workstationId/attach-jobs/:jobId", {
@@ -457,7 +484,9 @@ async function routeRoomSync(request: Request, env: Env): Promise<Response> {
     return json({ error: "notebook id is required" }, 400);
   }
   const appSessionIdentity = await appSessionIdentityFromWebSocketRequest(request, env);
-  const identity = appSessionIdentity ?? (await authenticateRequestOrResponse(request, env));
+  const identity =
+    appSessionIdentity ??
+    (await authenticateRequestOrResponse(request, env, { allowWorkstationCredential: true }));
   if (identity instanceof Response) {
     return identity;
   }
@@ -934,8 +963,10 @@ async function routeWorkstations(request: Request, env: Env): Promise<Response> 
 
   const identity =
     request.method === "GET"
-      ? await authenticateRequestOrAppSessionOrResponse(request, env, "owner")
-      : await authenticateRequestOrResponse(request, env);
+      ? await authenticateRequestOrAppSessionOrResponse(request, env, "owner", {
+          allowWorkstationCredential: true,
+        })
+      : await authenticateRequestOrResponse(request, env, { allowWorkstationCredential: true });
   if (identity instanceof Response) {
     return identity;
   }
@@ -978,6 +1009,13 @@ async function routeWorkstations(request: Request, env: Env): Promise<Response> 
   const workstation = await registerWorkstation(env, ownerPrincipal, registration);
   if (!workstation) {
     return json({ error: "workstation was not registered" }, 500);
+  }
+  if (identity.metadata.workstationPairingCodeId) {
+    await linkWorkstationToPairing(
+      env,
+      identity.metadata.workstationPairingCodeId,
+      workstation.workstation_id,
+    );
   }
   const existingDefaultWorkstationId = await getDefaultWorkstationId(env, ownerPrincipal);
   const defaultWorkstationId =
@@ -1043,6 +1081,139 @@ async function routeDefaultWorkstation(request: Request, env: Env): Promise<Resp
     ok: true,
     default_workstation_id: selected,
   });
+}
+
+async function routeWorkstationPairingCodes(request: Request, env: Env): Promise<Response> {
+  if (!env.DB) {
+    return json({ error: "D1 binding DB is not configured" }, 503);
+  }
+
+  const originRejection = rejectUntrustedMutationOrigin(request, env);
+  if (originRejection) {
+    return originRejection;
+  }
+
+  const identity = await authenticateRequestOrAppSessionOrResponse(request, env, "owner");
+  if (identity instanceof Response) {
+    return identity;
+  }
+  if (isAnonymousViewer(identity)) {
+    return json({ error: "sign in to add a workstation" }, 401);
+  }
+
+  const ownerPrincipal = await canonicalPrincipalForIdentity(env, identity);
+  const minted = await createWorkstationPairingCode(env, {
+    ownerPrincipal,
+    principalNamespace: identity.metadata.principalNamespace,
+    actorLabel: identity.actorLabel,
+  });
+  if (!minted) {
+    return json({ error: "pairing code was not created" }, 500);
+  }
+
+  cloudLog("info", "workstation.pairing.minted", {
+    principal: ownerPrincipal,
+    pairing_id: minted.id,
+    counter: "workstation_pairing_codes_minted",
+    counter_delta: 1,
+  });
+  return json(
+    {
+      ok: true,
+      pairing: {
+        id: minted.id,
+        code: minted.code,
+        expires_at: minted.expires_at,
+      },
+    },
+    201,
+  );
+}
+
+async function routeWorkstationPairingCode(
+  request: Request,
+  env: Env,
+  pairingId: string,
+): Promise<Response> {
+  if (!env.DB) {
+    return json({ error: "D1 binding DB is not configured" }, 503);
+  }
+
+  const identity = await authenticateRequestOrAppSessionOrResponse(request, env, "owner");
+  if (identity instanceof Response) {
+    return identity;
+  }
+  if (isAnonymousViewer(identity)) {
+    return json({ error: "sign in to check pairing status" }, 401);
+  }
+
+  const ownerPrincipal = await canonicalPrincipalForIdentity(env, identity);
+  const pairing = await getWorkstationPairingCodeForOwner(env, ownerPrincipal, pairingId);
+  if (!pairing) {
+    return json({ error: "pairing code not found" }, 404);
+  }
+
+  return json({
+    ok: true,
+    pairing: {
+      id: pairing.id,
+      status: workstationPairingStatus(pairing, Date.now()),
+      expires_at: pairing.expires_at,
+      workstation_id: pairing.workstation_id,
+    },
+  });
+}
+
+async function routeWorkstationPairingCodeRedeem(request: Request, env: Env): Promise<Response> {
+  if (!env.DB) {
+    return json({ error: "D1 binding DB is not configured" }, 503);
+  }
+
+  const originRejection = rejectUntrustedMutationOrigin(request, env);
+  if (originRejection) {
+    return originRejection;
+  }
+
+  const payload = await readRequiredJsonObject(request, "pairing redeem body");
+  if (payload instanceof Response) {
+    return payload;
+  }
+  const code = boundedStringField(payload.code, "code", 64);
+  if (code instanceof Response) {
+    return code;
+  }
+
+  const redeemed = await redeemWorkstationPairingCode(env, code);
+  if (!redeemed) {
+    // Unknown, expired, and already-redeemed codes are indistinguishable in
+    // the response so the endpoint does not oracle live codes.
+    cloudLog("info", "workstation.pairing.redeem_rejected", {
+      counter: "workstation_pairing_redeem_rejections",
+      counter_delta: 1,
+    });
+    return json({ error: "pairing code is invalid, expired, or already used" }, 404);
+  }
+
+  cloudLog("info", "workstation.pairing.redeemed", {
+    principal: redeemed.owner_principal,
+    pairing_id: redeemed.pairing_code_id,
+    credential_id: redeemed.credential_id,
+    counter: "workstation_pairing_codes_redeemed",
+    counter_delta: 1,
+  });
+  return json(
+    {
+      ok: true,
+      credential: {
+        token: redeemed.token,
+        credential_id: redeemed.credential_id,
+      },
+      pairing: {
+        id: redeemed.pairing_code_id,
+      },
+    },
+    201,
+  );
 }
 
 async function routeNotebookWorkstationAttachment(
@@ -1215,7 +1386,9 @@ async function routeWorkstationAttachJobs(
     return json({ error: "D1 binding DB is not configured" }, 503);
   }
 
-  const identity = await authenticateRequestOrResponse(request, env);
+  const identity = await authenticateRequestOrResponse(request, env, {
+    allowWorkstationCredential: true,
+  });
   if (identity instanceof Response) {
     return identity;
   }
@@ -1259,7 +1432,9 @@ async function routeWorkstationAttachJob(
     return originRejection;
   }
 
-  const identity = await authenticateRequestOrResponse(request, env);
+  const identity = await authenticateRequestOrResponse(request, env, {
+    allowWorkstationCredential: true,
+  });
   if (identity instanceof Response) {
     return identity;
   }
@@ -3409,8 +3584,20 @@ async function safeEnsureCatalogSchema(env: Env, ctx: ExecutionContext): Promise
 async function authenticateRequestOrResponse(
   request: Request,
   env: Env,
+  options?: { allowWorkstationCredential?: boolean },
 ): Promise<AuthenticatedConnection | Response> {
   try {
+    // Workstation credentials are least-privilege by allowlist: only the
+    // workstation surface and room dials opt in. Every other route rejects
+    // the prefix here, before provider dispatch, so a leaked agent token
+    // cannot act on notebooks, ACLs, or account state.
+    const workstationToken = workstationCredentialTokenFromRequest(request);
+    if (workstationToken) {
+      if (!options?.allowWorkstationCredential) {
+        throw new AuthError("workstation credentials cannot access this resource", 403);
+      }
+      return await authenticateWorkstationCredentialRequest(env, request, workstationToken);
+    }
     const identity = await authenticateRequestWithProviders(request, env);
     await syncAuthenticatedProfile(env, identity);
     return identity;
@@ -3493,8 +3680,9 @@ async function authenticateRequestOrAppSessionOrResponse(
   request: Request,
   env: Env,
   appSessionScope: Exclude<ConnectionScope, "runtime_peer">,
+  options?: { allowWorkstationCredential?: boolean },
 ): Promise<AuthenticatedConnection | Response> {
-  const identity = await authenticateRequestOrResponse(request, env);
+  const identity = await authenticateRequestOrResponse(request, env, options);
   if (identity instanceof Response || !isAnonymousViewer(identity)) {
     return identity;
   }

--- a/apps/notebook-cloud/src/index.ts
+++ b/apps/notebook-cloud/src/index.ts
@@ -64,7 +64,9 @@ import {
   createWorkstationPairingCode,
   getWorkstationPairingCodeForOwner,
   linkWorkstationToPairing,
+  listWorkstationCredentialsForOwner,
   redeemWorkstationPairingCode,
+  revokeWorkstationCredential,
   workstationCredentialTokenFromRequest,
   workstationPairingStatus,
 } from "./workstation-credentials.ts";
@@ -258,6 +260,19 @@ const NOTEBOOK_CLOUD_ROUTES: readonly WorkerRoute[] = [
     methods: ["GET"],
     handler: ({ params }, request, env) =>
       routeWorkstationPairingCode(request, env, params.pairingId),
+  },
+  {
+    match: exactPath("/api/workstations/credentials"),
+    methods: ["GET"],
+    handler: (_match, request, env) => routeWorkstationCredentials(request, env),
+  },
+  {
+    match: routePath("/api/workstations/credentials/:credentialId/revoke", {
+      trailingSlash: "optional",
+    }),
+    methods: ["POST"],
+    handler: ({ params }, request, env) =>
+      routeWorkstationCredentialRevoke(request, env, params.credentialId),
   },
   {
     match: routePath("/api/workstations/:workstationId/attach-jobs/:jobId", {
@@ -1162,6 +1177,72 @@ async function routeWorkstationPairingCode(
       workstation_id: pairing.workstation_id,
     },
   });
+}
+
+async function routeWorkstationCredentials(request: Request, env: Env): Promise<Response> {
+  if (!env.DB) {
+    return json({ error: "D1 binding DB is not configured" }, 503);
+  }
+
+  // Deliberately NOT opened to workstation credentials: a stolen agent
+  // token must not be able to enumerate or revoke its siblings.
+  const identity = await authenticateRequestOrAppSessionOrResponse(request, env, "owner");
+  if (identity instanceof Response) {
+    return identity;
+  }
+  if (isAnonymousViewer(identity)) {
+    return json({ error: "sign in to manage workstation credentials" }, 401);
+  }
+
+  const ownerPrincipal = await canonicalPrincipalForIdentity(env, identity);
+  const credentials = await listWorkstationCredentialsForOwner(env, ownerPrincipal);
+  return json({
+    ok: true,
+    credentials: credentials.map((credential) => ({
+      credential_id: credential.id,
+      pairing_code_id: credential.pairing_code_id,
+      created_at: credential.created_at,
+      last_used_at: credential.last_used_at,
+      revoked_at: credential.revoked_at,
+    })),
+  });
+}
+
+async function routeWorkstationCredentialRevoke(
+  request: Request,
+  env: Env,
+  credentialId: string,
+): Promise<Response> {
+  if (!env.DB) {
+    return json({ error: "D1 binding DB is not configured" }, 503);
+  }
+
+  const originRejection = rejectUntrustedMutationOrigin(request, env);
+  if (originRejection) {
+    return originRejection;
+  }
+
+  const identity = await authenticateRequestOrAppSessionOrResponse(request, env, "owner");
+  if (identity instanceof Response) {
+    return identity;
+  }
+  if (isAnonymousViewer(identity)) {
+    return json({ error: "sign in to manage workstation credentials" }, 401);
+  }
+
+  const ownerPrincipal = await canonicalPrincipalForIdentity(env, identity);
+  const revoked = await revokeWorkstationCredential(env, ownerPrincipal, credentialId);
+  if (!revoked) {
+    return json({ error: "workstation credential not found" }, 404);
+  }
+
+  cloudLog("info", "workstation.credential.revoked", {
+    principal: ownerPrincipal,
+    credential_id: credentialId,
+    counter: "workstation_credentials_revoked",
+    counter_delta: 1,
+  });
+  return json({ ok: true, credential_id: credentialId, revoked: true });
 }
 
 async function routeWorkstationPairingCodeRedeem(request: Request, env: Env): Promise<Response> {

--- a/apps/notebook-cloud/src/storage.ts
+++ b/apps/notebook-cloud/src/storage.ts
@@ -308,6 +308,31 @@ const SCHEMA_STATEMENTS = [
     WHERE status IN ('pending', 'accepted', 'running')`,
   `CREATE INDEX IF NOT EXISTS workstation_attach_jobs_poll_idx
     ON workstation_attach_jobs(owner_principal, workstation_id, status, requested_at)`,
+  `CREATE TABLE IF NOT EXISTS workstation_pairing_codes (
+    id TEXT PRIMARY KEY,
+    code_hash TEXT NOT NULL UNIQUE,
+    owner_principal TEXT NOT NULL,
+    principal_namespace TEXT NOT NULL,
+    created_by_actor_label TEXT NOT NULL,
+    created_at TEXT NOT NULL,
+    expires_at TEXT NOT NULL,
+    redeemed_at TEXT,
+    workstation_id TEXT
+  )`,
+  `CREATE INDEX IF NOT EXISTS workstation_pairing_codes_owner_idx
+    ON workstation_pairing_codes(owner_principal, created_at DESC)`,
+  `CREATE TABLE IF NOT EXISTS workstation_credentials (
+    id TEXT PRIMARY KEY,
+    token_hash TEXT NOT NULL UNIQUE,
+    owner_principal TEXT NOT NULL,
+    principal_namespace TEXT NOT NULL,
+    pairing_code_id TEXT,
+    created_at TEXT NOT NULL,
+    last_used_at TEXT,
+    revoked_at TEXT
+  )`,
+  `CREATE INDEX IF NOT EXISTS workstation_credentials_owner_idx
+    ON workstation_credentials(owner_principal, created_at DESC)`,
 ];
 
 const SCHEMA_MIGRATIONS = [

--- a/apps/notebook-cloud/src/storage.ts
+++ b/apps/notebook-cloud/src/storage.ts
@@ -317,6 +317,7 @@ const SCHEMA_STATEMENTS = [
     created_at TEXT NOT NULL,
     expires_at TEXT NOT NULL,
     redeemed_at TEXT,
+    redeemed_by_credential_id TEXT,
     workstation_id TEXT
   )`,
   `CREATE INDEX IF NOT EXISTS workstation_pairing_codes_owner_idx

--- a/apps/notebook-cloud/src/workstation-credentials.ts
+++ b/apps/notebook-cloud/src/workstation-credentials.ts
@@ -1,0 +1,376 @@
+// Workstation pairing codes and workstation credentials.
+//
+// A signed-in owner mints a short-lived, single-use pairing code from the
+// workstation panel. The remote agent redeems it — the code is the entire
+// credential for the redeem call — and receives a long-lived workstation
+// credential token bound to the owner's canonical principal. The token is the
+// least-privilege bearer for the workstation surface: registration/heartbeat,
+// attach-job polling, and runtime_peer room dials. Both secrets are stored
+// hashed; cleartext exists only in the mint and redeem responses.
+//
+// Contract: docs/adr/hosted-credential-transport.md, Decision 9.
+
+import type { Env } from "./cloudflare-types.ts";
+import { ensureCatalogSchema } from "./storage.ts";
+import {
+  AuthError,
+  parseScope,
+  validateOperator,
+  type AuthenticatedConnection,
+  type ConnectionScope,
+} from "./identity.ts";
+
+export const WORKSTATION_CREDENTIAL_TOKEN_PREFIX = "nwc_";
+export const WORKSTATION_PAIRING_CODE_TTL_MS = 10 * 60_000;
+const WORKSTATION_CREDENTIAL_LAST_USED_REFRESH_MS = 5 * 60_000;
+const DEFAULT_WORKSTATION_OPERATOR = "workstation:agent";
+
+// Crockford-adjacent alphabet: no 0/1/I/L/O/U, so codes survive being read
+// aloud or retyped. 12 characters ≈ 59 bits — enough that a live 10-minute
+// code cannot be guessed, which matters because first registration
+// auto-selects the owner's default workstation target.
+const PAIRING_CODE_ALPHABET = "23456789ABCDEFGHJKMNPQRSTVWXYZ";
+const PAIRING_CODE_LENGTH = 12;
+const PAIRING_CODE_GROUP = 4;
+
+export interface WorkstationPairingCodeRow {
+  id: string;
+  code_hash: string;
+  owner_principal: string;
+  principal_namespace: string;
+  created_by_actor_label: string;
+  created_at: string;
+  expires_at: string;
+  redeemed_at: string | null;
+  workstation_id: string | null;
+}
+
+export interface WorkstationCredentialRow {
+  id: string;
+  token_hash: string;
+  owner_principal: string;
+  principal_namespace: string;
+  pairing_code_id: string | null;
+  created_at: string;
+  last_used_at: string | null;
+  revoked_at: string | null;
+}
+
+export type WorkstationPairingStatus = "pending" | "redeemed" | "registered" | "expired";
+
+export function generatePairingCode(): string {
+  const bytes = new Uint8Array(PAIRING_CODE_LENGTH);
+  crypto.getRandomValues(bytes);
+  let code = "";
+  for (let index = 0; index < PAIRING_CODE_LENGTH; index += 1) {
+    if (index > 0 && index % PAIRING_CODE_GROUP === 0) {
+      code += "-";
+    }
+    // Rejection-free modulo bias is acceptable here: 256 % 30 spreads the
+    // bias across the alphabet at well under one bit of the 59-bit budget.
+    code += PAIRING_CODE_ALPHABET[bytes[index]! % PAIRING_CODE_ALPHABET.length]!;
+  }
+  return code;
+}
+
+export function normalizePairingCode(input: string): string {
+  return input.replace(/[\s-]+/g, "").toUpperCase();
+}
+
+export function generateWorkstationCredentialToken(): string {
+  const bytes = new Uint8Array(32);
+  crypto.getRandomValues(bytes);
+  let binary = "";
+  for (const byte of bytes) {
+    binary += String.fromCharCode(byte);
+  }
+  const base64url = btoa(binary).replace(/\+/g, "-").replace(/\//g, "_").replace(/=+$/g, "");
+  return `${WORKSTATION_CREDENTIAL_TOKEN_PREFIX}${base64url}`;
+}
+
+export async function hashWorkstationSecret(value: string): Promise<string> {
+  const digest = await crypto.subtle.digest("SHA-256", new TextEncoder().encode(value));
+  return [...new Uint8Array(digest)].map((byte) => byte.toString(16).padStart(2, "0")).join("");
+}
+
+export interface MintedWorkstationPairingCode {
+  id: string;
+  code: string;
+  expires_at: string;
+}
+
+export async function createWorkstationPairingCode(
+  env: Env,
+  input: {
+    ownerPrincipal: string;
+    principalNamespace: string;
+    actorLabel: string;
+  },
+): Promise<MintedWorkstationPairingCode | null> {
+  if (!env.DB) {
+    return null;
+  }
+  await ensureCatalogSchema(env);
+
+  const id = crypto.randomUUID();
+  const code = generatePairingCode();
+  const codeHash = await hashWorkstationSecret(normalizePairingCode(code));
+  const now = new Date();
+  const expiresAt = new Date(now.getTime() + WORKSTATION_PAIRING_CODE_TTL_MS).toISOString();
+  await env.DB.prepare(
+    `INSERT INTO workstation_pairing_codes (
+       id,
+       code_hash,
+       owner_principal,
+       principal_namespace,
+       created_by_actor_label,
+       created_at,
+       expires_at
+     ) VALUES (?, ?, ?, ?, ?, ?, ?)`,
+  )
+    .bind(
+      id,
+      codeHash,
+      input.ownerPrincipal,
+      input.principalNamespace,
+      input.actorLabel,
+      now.toISOString(),
+      expiresAt,
+    )
+    .run();
+  return { id, code, expires_at: expiresAt };
+}
+
+export async function getWorkstationPairingCodeForOwner(
+  env: Env,
+  ownerPrincipal: string,
+  pairingId: string,
+): Promise<WorkstationPairingCodeRow | null> {
+  if (!env.DB) {
+    return null;
+  }
+  await ensureCatalogSchema(env);
+  const row = await env.DB.prepare(
+    `SELECT id,
+            code_hash,
+            owner_principal,
+            principal_namespace,
+            created_by_actor_label,
+            created_at,
+            expires_at,
+            redeemed_at,
+            workstation_id
+       FROM workstation_pairing_codes
+      WHERE id = ?
+        AND owner_principal = ?`,
+  )
+    .bind(pairingId, ownerPrincipal)
+    .first<WorkstationPairingCodeRow>();
+  return row ?? null;
+}
+
+export function workstationPairingStatus(
+  row: WorkstationPairingCodeRow,
+  now: number,
+): WorkstationPairingStatus {
+  if (row.workstation_id) {
+    return "registered";
+  }
+  if (row.redeemed_at) {
+    return "redeemed";
+  }
+  if (Date.parse(row.expires_at) <= now) {
+    return "expired";
+  }
+  return "pending";
+}
+
+export interface RedeemedWorkstationCredential {
+  token: string;
+  credential_id: string;
+  pairing_code_id: string;
+  owner_principal: string;
+}
+
+/**
+ * Atomically consume a pairing code and mint the workstation credential.
+ * Returns null when the code is unknown, expired, or already redeemed —
+ * callers must not distinguish those cases in the response.
+ */
+export async function redeemWorkstationPairingCode(
+  env: Env,
+  code: string,
+): Promise<RedeemedWorkstationCredential | null> {
+  if (!env.DB) {
+    return null;
+  }
+  await ensureCatalogSchema(env);
+
+  const codeHash = await hashWorkstationSecret(normalizePairingCode(code));
+  const now = new Date().toISOString();
+  // Single-statement consume: two concurrent redeems cannot both pass the
+  // redeemed_at IS NULL guard.
+  const consumed = await env.DB.prepare(
+    `UPDATE workstation_pairing_codes
+        SET redeemed_at = ?
+      WHERE code_hash = ?
+        AND redeemed_at IS NULL
+        AND expires_at > ?
+      RETURNING id, owner_principal, principal_namespace`,
+  )
+    .bind(now, codeHash, now)
+    .all<Pick<WorkstationPairingCodeRow, "id" | "owner_principal" | "principal_namespace">>();
+  const pairing = consumed.results?.[0];
+  if (!pairing) {
+    return null;
+  }
+
+  const token = generateWorkstationCredentialToken();
+  const credentialId = crypto.randomUUID();
+  await env.DB.prepare(
+    `INSERT INTO workstation_credentials (
+       id,
+       token_hash,
+       owner_principal,
+       principal_namespace,
+       pairing_code_id,
+       created_at
+     ) VALUES (?, ?, ?, ?, ?, ?)`,
+  )
+    .bind(
+      credentialId,
+      await hashWorkstationSecret(token),
+      pairing.owner_principal,
+      pairing.principal_namespace,
+      pairing.id,
+      now,
+    )
+    .run();
+  return {
+    token,
+    credential_id: credentialId,
+    pairing_code_id: pairing.id,
+    owner_principal: pairing.owner_principal,
+  };
+}
+
+export async function resolveWorkstationCredential(
+  env: Env,
+  token: string,
+): Promise<WorkstationCredentialRow | null> {
+  if (!env.DB) {
+    return null;
+  }
+  await ensureCatalogSchema(env);
+  const tokenHash = await hashWorkstationSecret(token);
+  const row = await env.DB.prepare(
+    `SELECT id,
+            token_hash,
+            owner_principal,
+            principal_namespace,
+            pairing_code_id,
+            created_at,
+            last_used_at,
+            revoked_at
+       FROM workstation_credentials
+      WHERE token_hash = ?`,
+  )
+    .bind(tokenHash)
+    .first<WorkstationCredentialRow>();
+  if (!row || row.revoked_at) {
+    return null;
+  }
+
+  const now = Date.now();
+  const lastUsed = row.last_used_at ? Date.parse(row.last_used_at) : 0;
+  // Heartbeats and job polls arrive every few seconds; refreshing
+  // last_used_at on every request would double the surface's write volume
+  // for a column that only needs operator-facing freshness.
+  if (now - lastUsed > WORKSTATION_CREDENTIAL_LAST_USED_REFRESH_MS) {
+    await env.DB.prepare(`UPDATE workstation_credentials SET last_used_at = ? WHERE id = ?`)
+      .bind(new Date(now).toISOString(), row.id)
+      .run();
+  }
+  return row;
+}
+
+/**
+ * Record which workstation a pairing produced, so the panel dialog can move
+ * from "redeemed" to "registered: <name>". First registration wins; later
+ * heartbeats through the same credential are no-ops here.
+ */
+export async function linkWorkstationToPairing(
+  env: Env,
+  pairingCodeId: string,
+  workstationId: string,
+): Promise<void> {
+  if (!env.DB) {
+    return;
+  }
+  await env.DB.prepare(
+    `UPDATE workstation_pairing_codes
+        SET workstation_id = ?
+      WHERE id = ?
+        AND workstation_id IS NULL`,
+  )
+    .bind(workstationId, pairingCodeId)
+    .run();
+}
+
+export function workstationCredentialTokenFromRequest(request: Request): string | null {
+  const header = request.headers.get("authorization");
+  if (!header) {
+    return null;
+  }
+  const match = header.match(/^Bearer\s+(.+)$/i);
+  const token = match?.[1]?.trim();
+  if (!token || !token.startsWith(WORKSTATION_CREDENTIAL_TOKEN_PREFIX)) {
+    return null;
+  }
+  return token;
+}
+
+const WORKSTATION_CREDENTIAL_SCOPES: ReadonlySet<ConnectionScope> = new Set([
+  "viewer",
+  "runtime_peer",
+]);
+
+export async function authenticateWorkstationCredentialRequest(
+  env: Env,
+  request: Request,
+  token: string,
+): Promise<AuthenticatedConnection> {
+  const credential = await resolveWorkstationCredential(env, token);
+  if (!credential) {
+    throw new AuthError("workstation credential is not recognized", 401);
+  }
+
+  const url = new URL(request.url);
+  const scopeValue = request.headers.get("x-scope") ?? url.searchParams.get("scope") ?? "viewer";
+  const scope = parseScope(scopeValue);
+  if (!WORKSTATION_CREDENTIAL_SCOPES.has(scope)) {
+    throw new AuthError(`workstation credentials cannot request ${scope} scope`, 403);
+  }
+
+  const operator =
+    request.headers.get("x-operator") ??
+    url.searchParams.get("operator") ??
+    DEFAULT_WORKSTATION_OPERATOR;
+  validateOperator(operator);
+
+  return {
+    principal: credential.owner_principal,
+    operator,
+    actorLabel: `${credential.owner_principal}/${operator}`,
+    scope,
+    metadata: {
+      provider: "workstation-credential",
+      transport: "workstation-credential-header",
+      principalNamespace: credential.principal_namespace,
+      workstationCredentialId: credential.id,
+      ...(credential.pairing_code_id
+        ? { workstationPairingCodeId: credential.pairing_code_id }
+        : {}),
+    },
+  };
+}

--- a/apps/notebook-cloud/src/workstation-credentials.ts
+++ b/apps/notebook-cloud/src/workstation-credentials.ts
@@ -42,6 +42,7 @@ export interface WorkstationPairingCodeRow {
   created_at: string;
   expires_at: string;
   redeemed_at: string | null;
+  redeemed_by_credential_id: string | null;
   workstation_id: string | null;
 }
 
@@ -207,51 +208,110 @@ export async function redeemWorkstationPairingCode(
   await ensureCatalogSchema(env);
 
   const codeHash = await hashWorkstationSecret(normalizePairingCode(code));
+  const token = generateWorkstationCredentialToken();
+  const credentialId = crypto.randomUUID();
+  const tokenHash = await hashWorkstationSecret(token);
   const now = new Date().toISOString();
-  // Single-statement consume: two concurrent redeems cannot both pass the
-  // redeemed_at IS NULL guard.
-  const consumed = await env.DB.prepare(
-    `UPDATE workstation_pairing_codes
-        SET redeemed_at = ?
-      WHERE code_hash = ?
-        AND redeemed_at IS NULL
-        AND expires_at > ?
-      RETURNING id, owner_principal, principal_namespace`,
-  )
-    .bind(now, codeHash, now)
-    .all<Pick<WorkstationPairingCodeRow, "id" | "owner_principal" | "principal_namespace">>();
-  const pairing = consumed.results?.[0];
+  // One transaction: consume and mint commit together, so a transient
+  // failure can never burn a code without producing its credential. The
+  // INSERT joins on redeemed_by_credential_id — unique per request — rather
+  // than the redeem timestamp, so a concurrent loser (whose UPDATE matched
+  // nothing) cannot mint against the winner's same-millisecond consume.
+  const [consumed] = await env.DB.batch([
+    env.DB.prepare(
+      `UPDATE workstation_pairing_codes
+          SET redeemed_at = ?,
+              redeemed_by_credential_id = ?
+        WHERE code_hash = ?
+          AND redeemed_at IS NULL
+          AND expires_at > ?
+        RETURNING id, owner_principal, principal_namespace`,
+    ).bind(now, credentialId, codeHash, now),
+    env.DB.prepare(
+      `INSERT INTO workstation_credentials (
+         id,
+         token_hash,
+         owner_principal,
+         principal_namespace,
+         pairing_code_id,
+         created_at
+       )
+       SELECT ?, ?, owner_principal, principal_namespace, id, ?
+         FROM workstation_pairing_codes
+        WHERE redeemed_by_credential_id = ?`,
+    ).bind(credentialId, tokenHash, now, credentialId),
+  ]);
+  const pairing = (
+    consumed?.results as
+      | Array<Pick<WorkstationPairingCodeRow, "id" | "owner_principal" | "principal_namespace">>
+      | undefined
+  )?.[0];
   if (!pairing) {
     return null;
   }
-
-  const token = generateWorkstationCredentialToken();
-  const credentialId = crypto.randomUUID();
-  await env.DB.prepare(
-    `INSERT INTO workstation_credentials (
-       id,
-       token_hash,
-       owner_principal,
-       principal_namespace,
-       pairing_code_id,
-       created_at
-     ) VALUES (?, ?, ?, ?, ?, ?)`,
-  )
-    .bind(
-      credentialId,
-      await hashWorkstationSecret(token),
-      pairing.owner_principal,
-      pairing.principal_namespace,
-      pairing.id,
-      now,
-    )
-    .run();
   return {
     token,
     credential_id: credentialId,
     pairing_code_id: pairing.id,
     owner_principal: pairing.owner_principal,
   };
+}
+
+export interface WorkstationCredentialSummary {
+  id: string;
+  pairing_code_id: string | null;
+  created_at: string;
+  last_used_at: string | null;
+  revoked_at: string | null;
+}
+
+export async function listWorkstationCredentialsForOwner(
+  env: Env,
+  ownerPrincipal: string,
+): Promise<WorkstationCredentialSummary[]> {
+  if (!env.DB) {
+    return [];
+  }
+  await ensureCatalogSchema(env);
+  const rows = await env.DB.prepare(
+    `SELECT id,
+            pairing_code_id,
+            created_at,
+            last_used_at,
+            revoked_at
+       FROM workstation_credentials
+      WHERE owner_principal = ?
+      ORDER BY created_at DESC`,
+  )
+    .bind(ownerPrincipal)
+    .all<WorkstationCredentialSummary>();
+  return rows.results ?? [];
+}
+
+export async function revokeWorkstationCredential(
+  env: Env,
+  ownerPrincipal: string,
+  credentialId: string,
+): Promise<boolean> {
+  if (!env.DB) {
+    return false;
+  }
+  await ensureCatalogSchema(env);
+  const result = await env.DB.prepare(
+    `UPDATE workstation_credentials
+        SET revoked_at = ?
+      WHERE id = ?
+        AND owner_principal = ?
+        AND revoked_at IS NULL`,
+  )
+    .bind(new Date().toISOString(), credentialId, ownerPrincipal)
+    .run();
+  return d1Changes(result) > 0;
+}
+
+function d1Changes(result: { meta: Record<string, unknown> }): number {
+  const changes = result.meta?.["changes"];
+  return typeof changes === "number" ? changes : 0;
 }
 
 export async function resolveWorkstationCredential(

--- a/apps/notebook-cloud/test/worker-routes.test.ts
+++ b/apps/notebook-cloud/test/worker-routes.test.ts
@@ -4667,6 +4667,98 @@ describe("Workstation pairing", () => {
       [attachBody.job.job_id],
     );
   });
+
+  it("consumes and mints in one batch so a code cannot burn without a credential", async () => {
+    const env = fakeEnv();
+    const pairing = await mintPairingCode(env);
+
+    await redeemedCredentialToken(env, pairing.code);
+
+    assert.ok(
+      env.DB.batchSizes.includes(2),
+      "redeem must issue the consume UPDATE and credential INSERT as one batch transaction",
+    );
+    const row = env.DB.workstationPairingCodes.get(pairing.id);
+    assert.ok(row?.redeemed_by_credential_id, "consume stamps the per-request credential marker");
+    const credential = [...env.DB.workstationCredentials.values()][0];
+    assert.equal(credential?.id, row?.redeemed_by_credential_id);
+  });
+
+  it("lists and revokes workstation credentials; revoked bearers lose access", async () => {
+    const env = fakeEnv();
+    const pairing = await mintPairingCode(env);
+    const token = await redeemedCredentialToken(env, pairing.code);
+    assert.equal((await registerWorkstationWithToken(env, token, "ws-paired")).status, 201);
+
+    const list = await worker.fetch(
+      new Request("http://localhost/api/workstations/credentials", { headers: OWNER_HEADERS }),
+      env,
+      fakeContext(),
+    );
+    assert.equal(list.status, 200);
+    const listed = (await list.json()) as {
+      credentials: Array<{ credential_id: string; revoked_at: string | null }>;
+    };
+    assert.equal(listed.credentials.length, 1);
+    assert.equal(listed.credentials[0]?.revoked_at, null);
+    const credentialId = listed.credentials[0]!.credential_id;
+
+    const revoke = await worker.fetch(
+      new Request(`http://localhost/api/workstations/credentials/${credentialId}/revoke`, {
+        method: "POST",
+        headers: OWNER_HEADERS,
+      }),
+      env,
+      fakeContext(),
+    );
+    assert.equal(revoke.status, 200);
+    assert.deepEqual(await revoke.json(), {
+      ok: true,
+      credential_id: credentialId,
+      revoked: true,
+    });
+
+    const heartbeat = await registerWorkstationWithToken(env, token, "ws-paired");
+    assert.equal(heartbeat.status, 401);
+    assert.deepEqual(await heartbeat.json(), {
+      error: "workstation credential is not recognized",
+    });
+
+    const replayRevoke = await worker.fetch(
+      new Request(`http://localhost/api/workstations/credentials/${credentialId}/revoke`, {
+        method: "POST",
+        headers: OWNER_HEADERS,
+      }),
+      env,
+      fakeContext(),
+    );
+    assert.equal(replayRevoke.status, 404);
+  });
+
+  it("denies the credential-management surface to workstation credentials", async () => {
+    const env = fakeEnv();
+    const pairing = await mintPairingCode(env);
+    const token = await redeemedCredentialToken(env, pairing.code);
+
+    const list = await worker.fetch(
+      new Request("http://localhost/api/workstations/credentials", {
+        headers: { Authorization: `Bearer ${token}` },
+      }),
+      env,
+      fakeContext(),
+    );
+    assert.equal(list.status, 403);
+
+    const revoke = await worker.fetch(
+      new Request("http://localhost/api/workstations/credentials/any-id/revoke", {
+        method: "POST",
+        headers: { Authorization: `Bearer ${token}` },
+      }),
+      env,
+      fakeContext(),
+    );
+    assert.equal(revoke.status, 403);
+  });
 });
 
 async function ownerPut(
@@ -5788,9 +5880,44 @@ class FakeD1Statement implements D1PreparedStatement {
         created_at: createdAt,
         expires_at: expiresAt,
         redeemed_at: null,
+        redeemed_by_credential_id: null,
         workstation_id: null,
       });
       return okResult(undefined, { changes: 1 });
+    } else if (
+      this.query.includes("UPDATE workstation_pairing_codes") &&
+      this.query.includes("SET redeemed_at")
+    ) {
+      // Batched consume: enforce single-use and expiry exactly like the
+      // RETURNING UPDATE in redeemWorkstationPairingCode, and stamp the
+      // per-request credential marker the companion INSERT...SELECT joins on.
+      const [redeemedAt, credentialMarker, codeHash, now] = this.values as [
+        string,
+        string,
+        string,
+        string,
+      ];
+      for (const pairing of this.db.workstationPairingCodes.values()) {
+        if (
+          pairing.code_hash === codeHash &&
+          pairing.redeemed_at === null &&
+          pairing.expires_at > now
+        ) {
+          pairing.redeemed_at = redeemedAt;
+          pairing.redeemed_by_credential_id = credentialMarker;
+          return okResult(
+            [
+              {
+                id: pairing.id,
+                owner_principal: pairing.owner_principal,
+                principal_namespace: pairing.principal_namespace,
+              },
+            ] as T[],
+            { changes: 1 },
+          );
+        }
+      }
+      return okResult([] as T[], { changes: 0 });
     } else if (
       this.query.includes("UPDATE workstation_pairing_codes") &&
       this.query.includes("SET workstation_id")
@@ -5804,19 +5931,46 @@ class FakeD1Statement implements D1PreparedStatement {
       }
       return okResult(undefined, { changes: 0 });
     } else if (this.query.includes("INSERT INTO workstation_credentials")) {
-      const [id, tokenHash, ownerPrincipal, principalNamespace, pairingCodeId, createdAt] = this
-        .values as [string, string, string, string, string | null, string];
+      // INSERT...SELECT joined on the per-request marker: mints only when
+      // this request's UPDATE consumed the code.
+      const [id, tokenHash, createdAt, credentialMarker] = this.values as [
+        string,
+        string,
+        string,
+        string,
+      ];
+      const pairing = [...this.db.workstationPairingCodes.values()].find(
+        (row) => row.redeemed_by_credential_id === credentialMarker,
+      );
+      if (!pairing) {
+        return okResult(undefined, { changes: 0 });
+      }
       this.db.workstationCredentials.set(id, {
         id,
         token_hash: tokenHash,
-        owner_principal: ownerPrincipal,
-        principal_namespace: principalNamespace,
-        pairing_code_id: pairingCodeId,
+        owner_principal: pairing.owner_principal,
+        principal_namespace: pairing.principal_namespace,
+        pairing_code_id: pairing.id,
         created_at: createdAt,
         last_used_at: null,
         revoked_at: null,
       });
       return okResult(undefined, { changes: 1 });
+    } else if (
+      this.query.includes("UPDATE workstation_credentials") &&
+      this.query.includes("SET revoked_at")
+    ) {
+      const [revokedAt, credentialId, ownerPrincipal] = this.values as [string, string, string];
+      const credential = this.db.workstationCredentials.get(credentialId);
+      if (
+        credential &&
+        credential.owner_principal === ownerPrincipal &&
+        credential.revoked_at === null
+      ) {
+        credential.revoked_at = revokedAt;
+        return okResult(undefined, { changes: 1 });
+      }
+      return okResult(undefined, { changes: 0 });
     } else if (
       this.query.includes("UPDATE workstation_credentials") &&
       this.query.includes("SET last_used_at")
@@ -6185,32 +6339,22 @@ class FakeD1Statement implements D1PreparedStatement {
 
   async all<T = unknown>(): Promise<D1Result<T>> {
     if (
-      this.query.includes("UPDATE workstation_pairing_codes") &&
-      this.query.includes("SET redeemed_at")
+      this.query.includes("FROM workstation_credentials") &&
+      this.query.includes("WHERE owner_principal")
     ) {
-      // Single-statement consume: enforce single-use and expiry exactly like
-      // the RETURNING UPDATE in redeemWorkstationPairingCode.
-      const [redeemedAt, codeHash, now] = this.values as [string, string, string];
-      for (const pairing of this.db.workstationPairingCodes.values()) {
-        if (
-          pairing.code_hash === codeHash &&
-          pairing.redeemed_at === null &&
-          pairing.expires_at > now
-        ) {
-          pairing.redeemed_at = redeemedAt;
-          return okResult(
-            [
-              {
-                id: pairing.id,
-                owner_principal: pairing.owner_principal,
-                principal_namespace: pairing.principal_namespace,
-              },
-            ] as T[],
-            { changes: 1 },
-          );
-        }
-      }
-      return okResult([] as T[], { changes: 0 });
+      const ownerPrincipal = this.values[0] as string;
+      return okResult(
+        [...this.db.workstationCredentials.values()]
+          .filter((credential) => credential.owner_principal === ownerPrincipal)
+          .sort((left, right) => right.created_at.localeCompare(left.created_at))
+          .map((credential) => ({
+            id: credential.id,
+            pairing_code_id: credential.pairing_code_id,
+            created_at: credential.created_at,
+            last_used_at: credential.last_used_at,
+            revoked_at: credential.revoked_at,
+          })) as T[],
+      );
     }
     if (this.query.includes("FROM notebook_access_requests")) {
       const notebookId = this.values[0] as string;

--- a/apps/notebook-cloud/test/worker-routes.test.ts
+++ b/apps/notebook-cloud/test/worker-routes.test.ts
@@ -38,6 +38,10 @@ import {
 import type { PendingNotebookInviteRow, PrincipalProfileRow } from "../src/sharing-storage.ts";
 import { canonicalAccountPrincipalForProfile } from "../src/sharing-storage.ts";
 import type { PrincipalAccountLinkRow } from "../src/storage.ts";
+import type {
+  WorkstationCredentialRow,
+  WorkstationPairingCodeRow,
+} from "../src/workstation-credentials.ts";
 import { oidcTokenFixture } from "./oidc-jwt-fixture.ts";
 
 const wasmBytes = await readFile(
@@ -4368,6 +4372,303 @@ describe("Worker artifact routes", () => {
   });
 });
 
+describe("Workstation pairing", () => {
+  const PAIRING_CODE_PATTERN =
+    /^[2-9A-HJKMNP-TV-Z]{4}-[2-9A-HJKMNP-TV-Z]{4}-[2-9A-HJKMNP-TV-Z]{4}$/;
+  const OWNER_HEADERS = {
+    "X-User": "alice",
+    "X-Operator": "browser:tab",
+    "X-Scope": "owner",
+  };
+
+  async function mintPairingCode(env: FakeEnv): Promise<{
+    id: string;
+    code: string;
+    expires_at: string;
+  }> {
+    const response = await worker.fetch(
+      new Request("http://localhost/api/workstations/pairing-codes", {
+        method: "POST",
+        headers: OWNER_HEADERS,
+      }),
+      env,
+      fakeContext(),
+    );
+    assert.equal(response.status, 201);
+    const body = (await response.json()) as {
+      ok: boolean;
+      pairing: { id: string; code: string; expires_at: string };
+    };
+    assert.equal(body.ok, true);
+    return body.pairing;
+  }
+
+  async function redeemPairingCode(env: FakeEnv, code: string): Promise<Response> {
+    return worker.fetch(
+      new Request("http://localhost/api/workstations/pairing-codes/redeem", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ code }),
+      }),
+      env,
+      fakeContext(),
+    );
+  }
+
+  async function redeemedCredentialToken(env: FakeEnv, code: string): Promise<string> {
+    const redeem = await redeemPairingCode(env, code);
+    assert.equal(redeem.status, 201);
+    const body = (await redeem.json()) as { credential: { token: string } };
+    return body.credential.token;
+  }
+
+  async function pairingStatus(
+    env: FakeEnv,
+    pairingId: string,
+  ): Promise<{ status: string; workstation_id: string | null }> {
+    const response = await worker.fetch(
+      new Request(`http://localhost/api/workstations/pairing-codes/${pairingId}`, {
+        headers: OWNER_HEADERS,
+      }),
+      env,
+      fakeContext(),
+    );
+    assert.equal(response.status, 200);
+    const body = (await response.json()) as {
+      pairing: { status: string; workstation_id: string | null };
+    };
+    return body.pairing;
+  }
+
+  async function registerWorkstationWithToken(
+    env: FakeEnv,
+    token: string,
+    workstationId: string,
+  ): Promise<Response> {
+    return worker.fetch(
+      new Request("http://localhost/api/workstations", {
+        method: "POST",
+        headers: {
+          Authorization: `Bearer ${token}`,
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({
+          workstation_id: workstationId,
+          display_name: "Paired Lab",
+          provider: "runtime_peer",
+        }),
+      }),
+      env,
+      fakeContext(),
+    );
+  }
+
+  it("requires sign-in to mint pairing codes", async () => {
+    const env = fakeEnv();
+
+    const response = await worker.fetch(
+      new Request("http://localhost/api/workstations/pairing-codes", { method: "POST" }),
+      env,
+      fakeContext(),
+    );
+
+    assert.equal(response.status, 401);
+    assert.deepEqual(await response.json(), { error: "sign in to add a workstation" });
+    assert.equal(env.DB.workstationPairingCodes.size, 0);
+  });
+
+  it("mints, redeems, and registers a workstation through a pairing code", async () => {
+    const env = fakeEnv();
+
+    const pairing = await mintPairingCode(env);
+    assert.match(pairing.code, PAIRING_CODE_PATTERN);
+    assert.ok(pairing.id);
+    assert.ok(Date.parse(pairing.expires_at) > Date.now());
+
+    assert.equal((await pairingStatus(env, pairing.id)).status, "pending");
+
+    const redeem = await redeemPairingCode(env, pairing.code);
+    assert.equal(redeem.status, 201);
+    const redeemed = (await redeem.json()) as {
+      ok: boolean;
+      credential: { token: string; credential_id: string };
+      pairing: { id: string };
+    };
+    assert.equal(redeemed.ok, true);
+    assert.ok(redeemed.credential.token.startsWith("nwc_"));
+    assert.ok(redeemed.credential.credential_id);
+    assert.equal(redeemed.pairing.id, pairing.id);
+
+    assert.equal((await pairingStatus(env, pairing.id)).status, "redeemed");
+
+    const register = await registerWorkstationWithToken(
+      env,
+      redeemed.credential.token,
+      "ws-paired",
+    );
+    assert.equal(register.status, 201);
+    const registered = (await register.json()) as { workstation: Record<string, unknown> };
+    assert.equal(registered.workstation.workstation_id, "ws-paired");
+    assert.equal(registered.workstation.is_default, true);
+
+    const status = await pairingStatus(env, pairing.id);
+    assert.equal(status.status, "registered");
+    assert.equal(status.workstation_id, "ws-paired");
+
+    const list = await worker.fetch(
+      new Request("http://localhost/api/workstations", { headers: OWNER_HEADERS }),
+      env,
+      fakeContext(),
+    );
+    assert.equal(list.status, 200);
+    const listBody = (await list.json()) as {
+      default_workstation_id: string | null;
+      workstations: Array<Record<string, unknown>>;
+    };
+    assert.equal(listBody.default_workstation_id, "ws-paired");
+    assert.equal(listBody.workstations.length, 1);
+    assert.equal(listBody.workstations[0]?.workstation_id, "ws-paired");
+    assert.equal(listBody.workstations[0]?.is_default, true);
+  });
+
+  it("rejects pairing code replay after the first redeem", async () => {
+    const env = fakeEnv();
+    const pairing = await mintPairingCode(env);
+
+    assert.equal((await redeemPairingCode(env, pairing.code)).status, 201);
+
+    const replay = await redeemPairingCode(env, pairing.code);
+    assert.equal(replay.status, 404);
+    assert.deepEqual(await replay.json(), {
+      error: "pairing code is invalid, expired, or already used",
+    });
+    assert.equal(env.DB.workstationCredentials.size, 1);
+  });
+
+  it("rejects expired pairing codes and reports expired status", async () => {
+    const env = fakeEnv();
+    const pairing = await mintPairingCode(env);
+
+    const row = env.DB.workstationPairingCodes.get(pairing.id);
+    assert.ok(row);
+    row.expires_at = new Date(Date.now() - 1000).toISOString();
+
+    const redeem = await redeemPairingCode(env, pairing.code);
+    assert.equal(redeem.status, 404);
+    assert.equal(env.DB.workstationCredentials.size, 0);
+
+    assert.equal((await pairingStatus(env, pairing.id)).status, "expired");
+  });
+
+  it("accepts pairing codes lowercased with spaces instead of dashes", async () => {
+    const env = fakeEnv();
+    const pairing = await mintPairingCode(env);
+
+    const sloppy = pairing.code.toLowerCase().replaceAll("-", " ");
+    const redeem = await redeemPairingCode(env, sloppy);
+    assert.equal(redeem.status, 201);
+    const redeemed = (await redeem.json()) as { credential: { token: string } };
+    assert.ok(redeemed.credential.token.startsWith("nwc_"));
+  });
+
+  it("rejects workstation credentials outside the workstation surface", async () => {
+    const env = fakeEnv();
+    const pairing = await mintPairingCode(env);
+    const token = await redeemedCredentialToken(env, pairing.code);
+
+    const createNotebook = await worker.fetch(
+      new Request("http://localhost/api/n", {
+        method: "POST",
+        headers: { Authorization: `Bearer ${token}` },
+      }),
+      env,
+      fakeContext(),
+    );
+    assert.equal(createNotebook.status, 403);
+    const createBody = (await createNotebook.json()) as { error: string };
+    assert.match(createBody.error, /workstation credentials/);
+    assert.equal(env.DB.notebooks.size, 0);
+
+    const selectDefault = await worker.fetch(
+      new Request("http://localhost/api/workstations/default", {
+        method: "PATCH",
+        headers: {
+          Authorization: `Bearer ${token}`,
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({ workstation_id: "ws-any" }),
+      }),
+      env,
+      fakeContext(),
+    );
+    assert.equal(selectDefault.status, 403);
+  });
+
+  it("clamps workstation credential scope requests", async () => {
+    const env = fakeEnv();
+    const pairing = await mintPairingCode(env);
+    const token = await redeemedCredentialToken(env, pairing.code);
+
+    const ownerScope = await worker.fetch(
+      new Request("http://localhost/api/workstations", {
+        headers: { Authorization: `Bearer ${token}`, "X-Scope": "owner" },
+      }),
+      env,
+      fakeContext(),
+    );
+    assert.equal(ownerScope.status, 403);
+    const ownerScopeBody = (await ownerScope.json()) as { error: string };
+    assert.match(ownerScopeBody.error, /workstation credentials cannot request owner scope/);
+
+    const runtimePeerScope = await worker.fetch(
+      new Request("http://localhost/api/workstations", {
+        headers: { Authorization: `Bearer ${token}`, "X-Scope": "runtime_peer" },
+      }),
+      env,
+      fakeContext(),
+    );
+    assert.equal(runtimePeerScope.status, 200);
+  });
+
+  it("lets a paired workstation credential poll attach jobs", async () => {
+    const env = fakeEnv();
+    seedNotebook(env, "pairing-attach-demo");
+    seedAcl(env, { notebookId: "pairing-attach-demo", subject: "user:dev:alice", scope: "owner" });
+
+    const pairing = await mintPairingCode(env);
+    const token = await redeemedCredentialToken(env, pairing.code);
+
+    const register = await registerWorkstationWithToken(env, token, "ws-paired");
+    assert.equal(register.status, 201);
+
+    const attach = await worker.fetch(
+      new Request("http://localhost/api/n/pairing-attach-demo/workstation-attachments", {
+        method: "POST",
+        headers: { "Content-Type": "application/json", ...OWNER_HEADERS },
+        body: JSON.stringify({}),
+      }),
+      env,
+      fakeContext(),
+    );
+    assert.equal(attach.status, 202);
+    const attachBody = (await attach.json()) as { job: { job_id: string } };
+
+    const poll = await worker.fetch(
+      new Request("http://localhost/api/workstations/ws-paired/attach-jobs", {
+        headers: { Authorization: `Bearer ${token}` },
+      }),
+      env,
+      fakeContext(),
+    );
+    assert.equal(poll.status, 200);
+    const polled = (await poll.json()) as { jobs: Array<{ job_id: string }> };
+    assert.deepEqual(
+      polled.jobs.map((job) => job.job_id),
+      [attachBody.job.job_id],
+    );
+  });
+});
+
 async function ownerPut(
   env: FakeEnv,
   pathname: string,
@@ -4960,6 +5261,8 @@ class FakeD1 implements D1Database {
   readonly workstations = new Map<string, WorkstationRow>();
   readonly workstationDefaults = new Map<string, string>();
   readonly workstationAttachJobs = new Map<string, WorkstationAttachJobRow>();
+  readonly workstationPairingCodes = new Map<string, WorkstationPairingCodeRow>();
+  readonly workstationCredentials = new Map<string, WorkstationCredentialRow>();
   readonly batchSizes: number[] = [];
   afterBlockedOwnerDelete?: () => void;
 
@@ -5473,6 +5776,58 @@ class FakeD1Statement implements D1PreparedStatement {
         return okResult(undefined, { changes: 1 });
       }
       return okResult(undefined, { changes: 0 });
+    } else if (this.query.includes("INSERT INTO workstation_pairing_codes")) {
+      const [id, codeHash, ownerPrincipal, principalNamespace, actorLabel, createdAt, expiresAt] =
+        this.values as [string, string, string, string, string, string, string];
+      this.db.workstationPairingCodes.set(id, {
+        id,
+        code_hash: codeHash,
+        owner_principal: ownerPrincipal,
+        principal_namespace: principalNamespace,
+        created_by_actor_label: actorLabel,
+        created_at: createdAt,
+        expires_at: expiresAt,
+        redeemed_at: null,
+        workstation_id: null,
+      });
+      return okResult(undefined, { changes: 1 });
+    } else if (
+      this.query.includes("UPDATE workstation_pairing_codes") &&
+      this.query.includes("SET workstation_id")
+    ) {
+      // linkWorkstationToPairing: first registration wins.
+      const [workstationId, pairingId] = this.values as [string, string];
+      const pairing = this.db.workstationPairingCodes.get(pairingId);
+      if (pairing && pairing.workstation_id === null) {
+        pairing.workstation_id = workstationId;
+        return okResult(undefined, { changes: 1 });
+      }
+      return okResult(undefined, { changes: 0 });
+    } else if (this.query.includes("INSERT INTO workstation_credentials")) {
+      const [id, tokenHash, ownerPrincipal, principalNamespace, pairingCodeId, createdAt] = this
+        .values as [string, string, string, string, string | null, string];
+      this.db.workstationCredentials.set(id, {
+        id,
+        token_hash: tokenHash,
+        owner_principal: ownerPrincipal,
+        principal_namespace: principalNamespace,
+        pairing_code_id: pairingCodeId,
+        created_at: createdAt,
+        last_used_at: null,
+        revoked_at: null,
+      });
+      return okResult(undefined, { changes: 1 });
+    } else if (
+      this.query.includes("UPDATE workstation_credentials") &&
+      this.query.includes("SET last_used_at")
+    ) {
+      const [lastUsedAt, credentialId] = this.values as [string, string];
+      const credential = this.db.workstationCredentials.get(credentialId);
+      if (credential) {
+        credential.last_used_at = lastUsedAt;
+        return okResult(undefined, { changes: 1 });
+      }
+      return okResult(undefined, { changes: 0 });
     } else if (this.query.includes("INSERT INTO notebooks")) {
       const [id, ownerPrincipal, maybeTitleOrCreatedAt, createdAtOrUpdatedAt, maybeUpdatedAt] = this
         .values as [string, string, string | null, string | undefined, string | undefined];
@@ -5727,6 +6082,19 @@ class FakeD1Statement implements D1PreparedStatement {
       }
       return (this.db.accountLinks.get(this.values[0] as string) as T | undefined) ?? null;
     }
+    if (this.query.includes("FROM workstation_pairing_codes")) {
+      const [pairingId, ownerPrincipal] = this.values as [string, string];
+      const pairing = this.db.workstationPairingCodes.get(pairingId);
+      return pairing?.owner_principal === ownerPrincipal ? (pairing as T) : null;
+    }
+    if (this.query.includes("FROM workstation_credentials")) {
+      const [tokenHash] = this.values as [string];
+      return (
+        ([...this.db.workstationCredentials.values()].find(
+          (credential) => credential.token_hash === tokenHash,
+        ) as T | undefined) ?? null
+      );
+    }
     if (this.query.includes("FROM workstations")) {
       const [ownerPrincipal, workstationId] = this.values as [string, string];
       return (
@@ -5816,6 +6184,34 @@ class FakeD1Statement implements D1PreparedStatement {
   }
 
   async all<T = unknown>(): Promise<D1Result<T>> {
+    if (
+      this.query.includes("UPDATE workstation_pairing_codes") &&
+      this.query.includes("SET redeemed_at")
+    ) {
+      // Single-statement consume: enforce single-use and expiry exactly like
+      // the RETURNING UPDATE in redeemWorkstationPairingCode.
+      const [redeemedAt, codeHash, now] = this.values as [string, string, string];
+      for (const pairing of this.db.workstationPairingCodes.values()) {
+        if (
+          pairing.code_hash === codeHash &&
+          pairing.redeemed_at === null &&
+          pairing.expires_at > now
+        ) {
+          pairing.redeemed_at = redeemedAt;
+          return okResult(
+            [
+              {
+                id: pairing.id,
+                owner_principal: pairing.owner_principal,
+                principal_namespace: pairing.principal_namespace,
+              },
+            ] as T[],
+            { changes: 1 },
+          );
+        }
+      }
+      return okResult([] as T[], { changes: 0 });
+    }
     if (this.query.includes("FROM notebook_access_requests")) {
       const notebookId = this.values[0] as string;
       const limit = typeof this.values[1] === "number" ? this.values[1] : Number.POSITIVE_INFINITY;

--- a/docs/adr/hosted-credential-transport.md
+++ b/docs/adr/hosted-credential-transport.md
@@ -364,9 +364,17 @@ Properties:
   guessed code cannot realistically register an attacker workstation —
   important because first registration auto-selects the owner's default
   workstation target.
-- Credentials do not expire in this iteration; they are revocable rows.
-  Short-lived attachment tickets (Decision 4) remain the hardening path for
-  deployments that cannot tolerate long-lived agent credentials.
+- Credentials do not expire in this iteration; they are revocable rows. The
+  owner lists them via `GET /api/workstations/credentials` and kills one via
+  `POST /api/workstations/credentials/:id/revoke` — both owner-auth only, so
+  a stolen agent token cannot enumerate or revoke its siblings. Short-lived
+  attachment tickets (Decision 4) remain the hardening path for deployments
+  that cannot tolerate long-lived agent credentials.
+- Consume and mint commit in one D1 batch transaction, with the credential
+  insert joined on a per-request `redeemed_by_credential_id` marker rather
+  than the redeem timestamp — a transient failure cannot burn a code without
+  minting its credential, and a same-millisecond concurrent redeem cannot
+  mint against the winner's consume.
 - A workstation credential is bound to the owner, not to one workstation id;
   one credential may serve several registrations from the same machine. If
   per-workstation binding becomes necessary (shared multi-user hosts), bind at

--- a/docs/adr/hosted-credential-transport.md
+++ b/docs/adr/hosted-credential-transport.md
@@ -327,6 +327,51 @@ when an allowlist is configured. If any client sends `Origin`, malformed or
 untrusted values are rejected. One-time ticket flows still benefit from origin
 checks, but they do not rely on ambient cookies and therefore reduce CSRF risk.
 
+## Decision 9: Workstation pairing codes mint scoped workstation credentials
+
+Workstation registration previously required an externally issued bearer
+credential (Anaconda API key or OIDC token) or a dev token. That blocks the
+operator path on another provider's key-issuance flow and hands the agent a
+full-user credential when it only needs the workstation surface.
+
+The pairing flow replaces that for provider-neutral registration:
+
+1. A signed-in owner mints a pairing code from the workstation panel
+   (`POST /api/workstations/pairing-codes`). The code is short-lived
+   (10 minutes), single use, and stored hashed. The response is the only time
+   the cleartext code exists server-side.
+2. The operator runs the connect one-liner on the remote machine. The agent
+   redeems the code (`POST /api/workstations/pairing-codes/redeem`, no other
+   auth; the code is the credential) and receives a long-lived workstation
+   credential token (`nwc_` prefix, 256-bit random, stored hashed, revocable
+   via `revoked_at`).
+3. The agent registers and heartbeats with `Authorization: Bearer nwc_...`.
+   The browser dialog polls `GET /api/workstations/pairing-codes/:id` (owner
+   auth) and reports pending → redeemed → registered as the workstation row
+   appears.
+
+Properties:
+
+- The workstation credential maps to the minting owner's canonical principal,
+  so existing room attachment (owner-principal `runtime_peer` ACL row) and the
+  WebSocket dial work unchanged.
+- The credential is least-privilege by allowlist: it authenticates only the
+  workstation surface (registration/heartbeat, attach-job polling and status
+  patches) and room WebSocket dials, and may request only `viewer` or
+  `runtime_peer` connection scope. Every other route rejects it by default —
+  the gate sits in the central request-auth wrapper, not per-route opt-outs.
+- Pairing codes use a 12-character unambiguous alphabet (~59 bits) so a
+  guessed code cannot realistically register an attacker workstation —
+  important because first registration auto-selects the owner's default
+  workstation target.
+- Credentials do not expire in this iteration; they are revocable rows.
+  Short-lived attachment tickets (Decision 4) remain the hardening path for
+  deployments that cannot tolerate long-lived agent credentials.
+- A workstation credential is bound to the owner, not to one workstation id;
+  one credential may serve several registrations from the same machine. If
+  per-workstation binding becomes necessary (shared multi-user hosts), bind at
+  redeem time instead.
+
 ## Operational path for the Anaconda demo
 
 The exact deployment steps, direct OIDC variables, route takeover, and smoke


### PR DESCRIPTION
## Summary

Workstation registration previously required an externally issued bearer (Anaconda API key / OIDC token) or a dev token plus a hand-seeded ACL row. This PR adds the provider-neutral pairing flow from #3381's registration UX track:

1. A signed-in owner mints a **pairing code** — `POST /api/workstations/pairing-codes` — short-lived (10 min), single use, 12 chars from an unambiguous alphabet (~59 bits), stored hashed.
2. The remote agent redeems it — `POST /api/workstations/pairing-codes/redeem` (the code is the entire credential for this call) — and receives a long-lived **workstation credential** (`nwc_` prefix, 256-bit random, stored hashed, revocable via `revoked_at`).
3. The agent registers/heartbeats with `Authorization: Bearer nwc_...`; the browser polls `GET /api/workstations/pairing-codes/:id` and watches `pending → redeemed → registered`.

## Least privilege

The credential authenticates **only the workstation surface**: registration/heartbeat, attach-job polling/patching, and `runtime_peer` room dials. The gate is default-deny in the central request-auth wrapper (`authenticateRequestOrResponse`), so every route that doesn't explicitly opt in rejects the prefix before provider dispatch — a leaked agent token cannot create notebooks, mutate ACLs, or read account state. Scope requests are clamped to `viewer` / `runtime_peer`.

Because the credential maps to the minting owner's canonical principal, the existing attach path (owner-principal `runtime_peer` ACL row) and the Rust cloud transport's `Authorization`-header WS dial work unchanged.

## Contract record

`docs/adr/hosted-credential-transport.md` Decision 9, including why codes are 59-bit (first registration auto-selects the default workstation target — a guessed code must not be able to plant an attacker workstation), why redeem responses don't oracle live codes, and where ticket-based hardening (Decision 4) still applies.

## Tests

8 new route tests in `worker-routes.test.ts` (mint auth, full happy path, replay, expiry, code normalization, least-privilege denials, scope clamp, attach-job polling with the credential) plus FakeD1 emulation for the new statements. 120 pass / 0 fail.

Part of #3381 (step 6 — registration/attachment credentials). UI follow-up (panel pairing card) and `runt workstation` CLI are stacked next.
