### PR TITLE
feat(notebook-cloud): Add-workstation pairing flow in the workstations panel

### DIFF
--- a/apps/notebook-cloud/test/workstations-client.test.ts
+++ b/apps/notebook-cloud/test/workstations-client.test.ts
@@ -5,8 +5,11 @@ import type { CloudPrototypeAuthState } from "../viewer/collaborator-auth";
 import {
   CLOUD_WORKSTATIONS_ACTIVE_REFRESH_INTERVAL_MS,
   CLOUD_WORKSTATIONS_ATTACH_REFRESH_INTERVAL_MS,
+  cloudWorkstationConnectCommand,
   cloudWorkstationRefreshIntervalMs,
+  fetchCloudWorkstationPairingStatus,
   fetchCloudWorkstations,
+  mintCloudWorkstationPairingCode,
   requestCloudWorkstationAttachment,
   setCloudDefaultWorkstation,
 } from "../viewer/workstations-client";
@@ -169,6 +172,71 @@ describe("cloud workstations client", () => {
         panelIsOpen: false,
       }),
       CLOUD_WORKSTATIONS_ATTACH_REFRESH_INTERVAL_MS,
+    );
+  });
+
+  it("mints a pairing code and reads its status", async (t) => {
+    const calls: string[] = [];
+    t.mock.method(globalThis, "fetch", async (input: RequestInfo | URL, init?: RequestInit) => {
+      const url = String(input);
+      calls.push(`${init?.method ?? "GET"} ${url}`);
+      if (url.endsWith("/api/workstations/pairing-codes")) {
+        return jsonResponse(
+          {
+            ok: true,
+            pairing: {
+              id: "pair-1",
+              code: "ABCD-EFGH-JKMN",
+              expires_at: "2026-06-12T12:00:00.000Z",
+            },
+          },
+          201,
+        );
+      }
+      return jsonResponse({
+        ok: true,
+        pairing: {
+          id: "pair-1",
+          status: "registered",
+          expires_at: "2026-06-12T12:00:00.000Z",
+          workstation_id: "ws-hub",
+        },
+      });
+    });
+
+    const minted = await mintCloudWorkstationPairingCode("/api/workstations", devAuth);
+    assert.deepEqual(minted, {
+      id: "pair-1",
+      code: "ABCD-EFGH-JKMN",
+      expiresAt: "2026-06-12T12:00:00.000Z",
+    });
+
+    const status = await fetchCloudWorkstationPairingStatus("/api/workstations", devAuth, "pair-1");
+    assert.deepEqual(status, {
+      status: "registered",
+      expiresAt: "2026-06-12T12:00:00.000Z",
+      workstationId: "ws-hub",
+    });
+    assert.deepEqual(calls, [
+      "POST /api/workstations/pairing-codes",
+      "GET /api/workstations/pairing-codes/pair-1",
+    ]);
+  });
+
+  it("surfaces server errors from pairing mint", async (t) => {
+    t.mock.method(globalThis, "fetch", async () =>
+      jsonResponse({ error: "sign in to add a workstation" }, 401),
+    );
+    await assert.rejects(
+      mintCloudWorkstationPairingCode("/api/workstations", devAuth),
+      /sign in to add a workstation/,
+    );
+  });
+
+  it("builds the connect one-liner from origin and code", () => {
+    assert.equal(
+      cloudWorkstationConnectCommand("https://preview.runt.run", "ABCD-EFGH-JKMN"),
+      "runt workstation connect https://preview.runt.run --code ABCD-EFGH-JKMN && runt workstation run",
     );
   });
 });

--- a/apps/notebook-cloud/viewer/__tests__/use-cloud-workstations.test.tsx
+++ b/apps/notebook-cloud/viewer/__tests__/use-cloud-workstations.test.tsx
@@ -1,0 +1,257 @@
+import { act, renderHook } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vite-plus/test";
+import { readOnlyNotebookShellCapabilities, type NotebookShellCapabilities } from "runtimed";
+
+import type { CloudPrototypeAuthState } from "../collaborator-auth";
+
+// The pairing state machine lives in React wiring — mint, a 2s status poll
+// with abort/dispose interplay, a client-driven expiry flip, and display-name
+// resolution against the registry. These tests render the REAL hook with the
+// workstations client mocked, following use-sustained-reconnecting.test.tsx.
+const clientMocks = vi.hoisted(() => ({
+  fetchCloudWorkstations: vi.fn(),
+  fetchCloudWorkstationPairingStatus: vi.fn(),
+  mintCloudWorkstationPairingCode: vi.fn(),
+  requestCloudWorkstationAttachment: vi.fn(),
+  setCloudDefaultWorkstation: vi.fn(),
+}));
+
+vi.mock("../workstations-client", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../workstations-client")>();
+  return { ...actual, ...clientMocks };
+});
+
+import { useCloudWorkstationManager } from "../use-cloud-workstations";
+
+const ownerCloudCapabilities: NotebookShellCapabilities = {
+  ...readOnlyNotebookShellCapabilities,
+  access: {
+    ...readOnlyNotebookShellCapabilities.access,
+    level: "owner",
+    source: "cloud",
+  },
+  auth: {
+    ...readOnlyNotebookShellCapabilities.auth,
+    canUseAuthenticatedIdentity: true,
+  },
+};
+
+const devAuth: CloudPrototypeAuthState = {
+  mode: "dev",
+  token: "dev-secret",
+  user: "alice",
+  oidcClaims: null,
+  requestedScope: "owner",
+  problem: null,
+};
+
+const config = {
+  workstationsEndpoint: "/api/workstations",
+  workstationDefaultEndpoint: "/api/workstations/default",
+  workstationAttachEndpoint: "/api/n/nb-1/workstation-attachments",
+};
+
+function renderManager() {
+  return renderHook(() =>
+    useCloudWorkstationManager({
+      config,
+      authState: devAuth,
+      capabilities: ownerCloudCapabilities,
+      canLoadCloudWorkstations: true,
+      workstationAttachment: null,
+      panelIsOpen: false,
+      onOpenWorkstationsRail: vi.fn(),
+    }),
+  );
+}
+
+const futureIso = (ms: number) => new Date(Date.now() + ms).toISOString();
+
+describe("useCloudWorkstationManager pairing", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    clientMocks.fetchCloudWorkstations.mockResolvedValue({
+      defaultWorkstationId: null,
+      workstations: [],
+    });
+    clientMocks.fetchCloudWorkstationPairingStatus.mockResolvedValue({
+      status: "pending",
+      expiresAt: null,
+      workstationId: null,
+    });
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.clearAllMocks();
+  });
+
+  it("starts a pending pairing with the connect command built from the origin", async () => {
+    clientMocks.mintCloudWorkstationPairingCode.mockResolvedValue({
+      id: "pair-1",
+      code: "ABCD-EFGH-JKMN",
+      expiresAt: futureIso(10 * 60_000),
+    });
+    const { result } = renderManager();
+
+    await act(async () => {
+      await result.current.onStartPairing?.();
+    });
+
+    const pairing = result.current.workstationPairing;
+    expect(pairing?.status).toBe("pending");
+    expect(pairing?.code).toBe("ABCD-EFGH-JKMN");
+    expect(pairing?.connectCommand).toBe(
+      `runt workstation connect ${window.location.origin} --code ABCD-EFGH-JKMN && runt workstation run`,
+    );
+  });
+
+  it("surfaces mint failure as an expired pairing and never polls", async () => {
+    clientMocks.mintCloudWorkstationPairingCode.mockRejectedValue(
+      new Error("sign in to add a workstation"),
+    );
+    const { result } = renderManager();
+
+    await act(async () => {
+      await result.current.onStartPairing?.();
+    });
+
+    expect(result.current.workstationPairing?.status).toBe("expired");
+    expect(result.current.workstationPairing?.error).toBe("sign in to add a workstation");
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(5_000);
+    });
+    expect(clientMocks.fetchCloudWorkstationPairingStatus).not.toHaveBeenCalled();
+  });
+
+  it("polls through redeemed to registered, refreshes the registry, and stops", async () => {
+    clientMocks.mintCloudWorkstationPairingCode.mockResolvedValue({
+      id: "pair-1",
+      code: "ABCD-EFGH-JKMN",
+      expiresAt: futureIso(10 * 60_000),
+    });
+    clientMocks.fetchCloudWorkstationPairingStatus
+      .mockResolvedValueOnce({ status: "redeemed", expiresAt: null, workstationId: null })
+      .mockResolvedValueOnce({ status: "registered", expiresAt: null, workstationId: "ws-hub" });
+    const { result } = renderManager();
+
+    await act(async () => {
+      await result.current.onStartPairing?.();
+    });
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(2_000);
+    });
+    expect(result.current.workstationPairing?.status).toBe("redeemed");
+
+    const refreshesBeforeRegistered = clientMocks.fetchCloudWorkstations.mock.calls.length;
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(2_000);
+    });
+    expect(result.current.workstationPairing?.status).toBe("registered");
+    expect(result.current.workstationPairing?.workstationId).toBe("ws-hub");
+    expect(clientMocks.fetchCloudWorkstations.mock.calls.length).toBeGreaterThan(
+      refreshesBeforeRegistered,
+    );
+
+    // Terminal status: no further status polls get scheduled (stay under the
+    // 10s registry-refresh interval so it cannot confound the count).
+    const statusCalls = clientMocks.fetchCloudWorkstationPairingStatus.mock.calls.length;
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(6_000);
+    });
+    expect(clientMocks.fetchCloudWorkstationPairingStatus.mock.calls.length).toBe(statusCalls);
+  });
+
+  it("aborts the in-flight status poll on unmount", async () => {
+    clientMocks.mintCloudWorkstationPairingCode.mockResolvedValue({
+      id: "pair-1",
+      code: "ABCD-EFGH-JKMN",
+      expiresAt: futureIso(10 * 60_000),
+    });
+    let capturedSignal: AbortSignal | undefined;
+    clientMocks.fetchCloudWorkstationPairingStatus.mockImplementation(
+      (_endpoint: string, _auth: unknown, _id: string, signal?: AbortSignal) => {
+        capturedSignal = signal;
+        return new Promise(() => {});
+      },
+    );
+    const { result, unmount } = renderManager();
+
+    await act(async () => {
+      await result.current.onStartPairing?.();
+    });
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(2_000);
+    });
+    expect(capturedSignal).toBeDefined();
+    expect(capturedSignal?.aborted).toBe(false);
+
+    unmount();
+    expect(capturedSignal?.aborted).toBe(true);
+  });
+
+  it("flips a pending pairing to expired when the deadline passes without a poll result", async () => {
+    clientMocks.mintCloudWorkstationPairingCode.mockResolvedValue({
+      id: "pair-1",
+      code: "ABCD-EFGH-JKMN",
+      expiresAt: futureIso(5_000),
+    });
+    const { result } = renderManager();
+
+    await act(async () => {
+      await result.current.onStartPairing?.();
+    });
+    expect(result.current.workstationPairing?.status).toBe("pending");
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(5_100);
+    });
+    expect(result.current.workstationPairing?.status).toBe("expired");
+  });
+
+  it("resolves the registered workstation's display name from the registry", async () => {
+    clientMocks.mintCloudWorkstationPairingCode.mockResolvedValue({
+      id: "pair-1",
+      code: "ABCD-EFGH-JKMN",
+      expiresAt: futureIso(10 * 60_000),
+    });
+    clientMocks.fetchCloudWorkstationPairingStatus.mockResolvedValue({
+      status: "registered",
+      expiresAt: null,
+      workstationId: "ws-hub",
+    });
+    clientMocks.fetchCloudWorkstations.mockResolvedValue({
+      defaultWorkstationId: "ws-hub",
+      workstations: [
+        {
+          id: "ws-hub",
+          displayName: "Hub devbox",
+          provider: "runtime_peer",
+          providerLabel: null,
+          status: "online",
+          statusMessage: null,
+          defaultEnvironmentLabel: "Current Python",
+          environmentPolicy: "current_python",
+          workingDirectory: null,
+          cpuCount: null,
+          memoryBytes: null,
+          updatedAt: null,
+          environments: [],
+        },
+      ],
+    });
+    const { result } = renderManager();
+
+    await act(async () => {
+      await result.current.onStartPairing?.();
+    });
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(2_000);
+    });
+
+    expect(result.current.workstationPairing?.status).toBe("registered");
+    expect(result.current.workstationPairing?.workstationName).toBe("Hub devbox");
+  });
+});

--- a/apps/notebook-cloud/viewer/notebook-viewer.tsx
+++ b/apps/notebook-cloud/viewer/notebook-viewer.tsx
@@ -394,7 +394,10 @@ export function NotebookViewer({
     busyWorkstationId,
     onAttachWorkstation,
     onSetDefaultWorkstation,
+    onStartPairing,
+    onCancelPairing,
     workstationAction,
+    workstationPairing,
     workstationPanelStatusMessage,
     workstationSelection,
   } = useCloudWorkstationManager({
@@ -845,6 +848,9 @@ export function NotebookViewer({
           busyWorkstationId={busyWorkstationId}
           onAttachWorkstation={onAttachWorkstation}
           onSetDefaultWorkstation={onSetDefaultWorkstation}
+          pairing={workstationPairing}
+          onStartPairing={onStartPairing}
+          onCancelPairing={onCancelPairing}
         />
       }
       packagesPanel={

--- a/apps/notebook-cloud/viewer/use-cloud-workstations.ts
+++ b/apps/notebook-cloud/viewer/use-cloud-workstations.ts
@@ -11,12 +11,28 @@ import {
 import type { CloudPrototypeAuthState } from "./collaborator-auth";
 import type { CloudViewerConfig } from "./cloud-viewer-session";
 import {
+  CLOUD_WORKSTATION_PAIRING_POLL_INTERVAL_MS,
+  cloudWorkstationConnectCommand,
   cloudWorkstationRefreshIntervalMs,
+  fetchCloudWorkstationPairingStatus,
   fetchCloudWorkstations,
+  mintCloudWorkstationPairingCode,
   requestCloudWorkstationAttachment,
   setCloudDefaultWorkstation,
+  type CloudWorkstationPairingStatus,
   type CloudWorkstationsState,
 } from "./workstations-client";
+
+export interface CloudWorkstationPairing {
+  id: string;
+  code: string;
+  connectCommand: string;
+  expiresAt: string;
+  status: CloudWorkstationPairingStatus;
+  workstationId: string | null;
+  workstationName: string | null;
+  error: string | null;
+}
 
 interface CloudWorkstationMutationState {
   kind: "idle" | "default" | "attach";
@@ -160,6 +176,139 @@ export function useCloudWorkstationManager({
     [authState, config.workstationAttachEndpoint, onOpenWorkstationsRail, refreshCloudWorkstations],
   );
 
+  const [pairing, setPairing] = useState<CloudWorkstationPairing | null>(null);
+
+  const handleStartPairing = useCallback(async () => {
+    if (!config.workstationsEndpoint) {
+      return;
+    }
+    try {
+      const minted = await mintCloudWorkstationPairingCode(config.workstationsEndpoint, authState);
+      setPairing({
+        id: minted.id,
+        code: minted.code,
+        connectCommand: cloudWorkstationConnectCommand(window.location.origin, minted.code),
+        expiresAt: minted.expiresAt,
+        status: "pending",
+        workstationId: null,
+        workstationName: null,
+        error: null,
+      });
+    } catch (error) {
+      setPairing({
+        id: "",
+        code: "",
+        connectCommand: "",
+        expiresAt: new Date(0).toISOString(),
+        status: "expired",
+        workstationId: null,
+        workstationName: null,
+        error: error instanceof Error ? error.message : String(error),
+      });
+    }
+  }, [authState, config.workstationsEndpoint]);
+
+  const handleCancelPairing = useCallback(() => {
+    setPairing(null);
+  }, []);
+
+  const pairingPollActive =
+    pairing !== null &&
+    pairing.id !== "" &&
+    (pairing.status === "pending" || pairing.status === "redeemed");
+
+  useEffect(() => {
+    if (!pairingPollActive || !config.workstationsEndpoint) {
+      return;
+    }
+    const endpoint = config.workstationsEndpoint;
+    let disposed = false;
+    let timer: number | null = null;
+    let activeController: AbortController | null = null;
+    const poll = () => {
+      timer = window.setTimeout(() => {
+        const controller = new AbortController();
+        activeController = controller;
+        const pairingId = pairing.id;
+        void fetchCloudWorkstationPairingStatus(endpoint, authState, pairingId, controller.signal)
+          .then((next) => {
+            if (disposed || controller.signal.aborted) return;
+            setPairing((previous) =>
+              previous && previous.id === pairingId
+                ? {
+                    ...previous,
+                    status: next.status,
+                    workstationId: next.workstationId,
+                    error: null,
+                  }
+                : previous,
+            );
+            if (next.status === "registered") {
+              void refreshCloudWorkstations();
+            }
+          })
+          .catch(() => {
+            // Transient poll failures are invisible; the next tick retries.
+          })
+          .finally(() => {
+            if (activeController === controller) {
+              activeController = null;
+            }
+            if (!disposed) {
+              poll();
+            }
+          });
+      }, CLOUD_WORKSTATION_PAIRING_POLL_INTERVAL_MS);
+    };
+    poll();
+    return () => {
+      disposed = true;
+      if (timer !== null) {
+        window.clearTimeout(timer);
+      }
+      activeController?.abort();
+    };
+  }, [authState, config.workstationsEndpoint, pairing?.id, pairingPollActive]);
+
+  // The expiry transition is client-driven so the card flips to "expired"
+  // even if no poll lands exactly at the boundary.
+  useEffect(() => {
+    if (!pairing || pairing.status !== "pending") {
+      return;
+    }
+    const remaining = Date.parse(pairing.expiresAt) - Date.now();
+    if (!Number.isFinite(remaining)) {
+      return;
+    }
+    if (remaining <= 0) {
+      setPairing((previous) =>
+        previous && previous.id === pairing.id ? { ...previous, status: "expired" } : previous,
+      );
+      return;
+    }
+    const timer = window.setTimeout(() => {
+      setPairing((previous) =>
+        previous && previous.id === pairing.id && previous.status === "pending"
+          ? { ...previous, status: "expired" }
+          : previous,
+      );
+    }, remaining);
+    return () => window.clearTimeout(timer);
+  }, [pairing]);
+
+  const pairingWithName = useMemo<CloudWorkstationPairing | null>(() => {
+    if (!pairing) {
+      return null;
+    }
+    if (!pairing.workstationId) {
+      return pairing;
+    }
+    const registered = workstationsState.workstations.find(
+      (workstation) => workstation.id === pairing.workstationId,
+    );
+    return registered ? { ...pairing, workstationName: registered.displayName } : pairing;
+  }, [pairing, workstationsState.workstations]);
+
   const workstationRefreshIntervalMs = cloudWorkstationRefreshIntervalMs({
     canChooseHostedWorkstation: canChooseHostedWorkstation && canLoadCloudWorkstations,
     hasRegisteredWorkstations: workstationsState.workstations.length > 0,
@@ -284,14 +433,20 @@ export function useCloudWorkstationManager({
         ? (workstationId: string) => handleAttachWorkstation(workstationId, { revealPanel: true })
         : undefined,
       onSetDefaultWorkstation: canChooseHostedWorkstation ? handleSetDefaultWorkstation : undefined,
+      onStartPairing: canChooseHostedWorkstation ? handleStartPairing : undefined,
+      onCancelPairing: canChooseHostedWorkstation ? handleCancelPairing : undefined,
       workstationAction,
+      workstationPairing: canChooseHostedWorkstation ? pairingWithName : null,
       workstationPanelStatusMessage,
       workstationSelection,
     }),
     [
       canChooseHostedWorkstation,
       handleAttachWorkstation,
+      handleCancelPairing,
       handleSetDefaultWorkstation,
+      handleStartPairing,
+      pairingWithName,
       workstationAction,
       workstationMutation.workstationId,
       workstationPanelStatusMessage,

--- a/apps/notebook-cloud/viewer/workstations-client.ts
+++ b/apps/notebook-cloud/viewer/workstations-client.ts
@@ -108,6 +108,78 @@ export async function requestCloudWorkstationAttachment(
   };
 }
 
+export type CloudWorkstationPairingStatus = "pending" | "redeemed" | "registered" | "expired";
+
+export interface MintedCloudWorkstationPairing {
+  id: string;
+  code: string;
+  expiresAt: string;
+}
+
+export interface CloudWorkstationPairingStatusState {
+  status: CloudWorkstationPairingStatus;
+  expiresAt: string | null;
+  workstationId: string | null;
+}
+
+export const CLOUD_WORKSTATION_PAIRING_POLL_INTERVAL_MS = 2_000;
+
+export async function mintCloudWorkstationPairingCode(
+  workstationsEndpoint: string,
+  authState: CloudPrototypeAuthState,
+): Promise<MintedCloudWorkstationPairing> {
+  const response = await fetchWithCloudPrototypeAuth(
+    `${workstationsEndpoint}/pairing-codes`,
+    {
+      method: "POST",
+      headers: { Accept: "application/json" },
+    },
+    authState,
+  );
+  if (!response.ok) {
+    throw new Error(await responseErrorMessage(response, "Unable to create a pairing code"));
+  }
+  const payload = (await response.json()) as { pairing?: Record<string, unknown> };
+  const id = scalarString(payload.pairing?.id);
+  const code = scalarString(payload.pairing?.code);
+  const expiresAt = scalarString(payload.pairing?.expires_at);
+  if (!id || !code || !expiresAt) {
+    throw new Error("Pairing code response was incomplete");
+  }
+  return { id, code, expiresAt };
+}
+
+export async function fetchCloudWorkstationPairingStatus(
+  workstationsEndpoint: string,
+  authState: CloudPrototypeAuthState,
+  pairingId: string,
+  signal?: AbortSignal,
+): Promise<CloudWorkstationPairingStatusState> {
+  const response = await fetchWithCloudPrototypeAuth(
+    `${workstationsEndpoint}/pairing-codes/${encodeURIComponent(pairingId)}`,
+    {
+      headers: { Accept: "application/json" },
+      signal,
+    },
+    authState,
+  );
+  if (!response.ok) {
+    throw new Error(await responseErrorMessage(response, "Unable to check pairing status"));
+  }
+  const payload = (await response.json()) as { pairing?: Record<string, unknown> };
+  const status = payload.pairing?.status;
+  return {
+    status:
+      status === "pending" || status === "redeemed" || status === "registered" ? status : "expired",
+    expiresAt: scalarString(payload.pairing?.expires_at),
+    workstationId: scalarString(payload.pairing?.workstation_id),
+  };
+}
+
+export function cloudWorkstationConnectCommand(origin: string, code: string): string {
+  return `runt workstation connect ${origin} --code ${code} && runt workstation run`;
+}
+
 export function cloudWorkstationRefreshIntervalMs({
   canChooseHostedWorkstation,
   hasRegisteredWorkstations,

--- a/src/components/notebook/NotebookWorkstationsPanel.tsx
+++ b/src/components/notebook/NotebookWorkstationsPanel.tsx
@@ -1,15 +1,20 @@
+import { useEffect, useState } from "react";
 import {
+  Check,
   CircleAlert,
   CircleCheck,
   Cloud,
+  Copy,
   FolderOpen,
   Gauge,
   MemoryStick,
   Monitor,
   PlugZap,
+  Plus,
   Server,
   ServerCog,
   ServerOff,
+  X,
 } from "lucide-react";
 import type { LucideIcon } from "lucide-react";
 import { Button } from "@/components/ui/button";
@@ -25,6 +30,15 @@ import {
 } from "./capabilities";
 import { cn } from "@/lib/utils";
 
+export interface NotebookWorkstationPairingView {
+  code: string;
+  connectCommand: string;
+  expiresAt: string;
+  status: "pending" | "redeemed" | "registered" | "expired";
+  workstationName: string | null;
+  error: string | null;
+}
+
 export interface NotebookWorkstationsPanelProps {
   capabilities: NotebookShellCapabilities;
   selection?: NotebookWorkstationSelectionProjection | null;
@@ -32,6 +46,9 @@ export interface NotebookWorkstationsPanelProps {
   className?: string;
   onAttachWorkstation?: (workstationId: string) => void;
   onSetDefaultWorkstation?: (workstationId: string) => void;
+  pairing?: NotebookWorkstationPairingView | null;
+  onStartPairing?: () => void;
+  onCancelPairing?: () => void;
   statusMessage?: string | null;
 }
 
@@ -42,6 +59,9 @@ export function NotebookWorkstationsPanel({
   className,
   onAttachWorkstation,
   onSetDefaultWorkstation,
+  pairing = null,
+  onStartPairing,
+  onCancelPairing,
   statusMessage = null,
 }: NotebookWorkstationsPanelProps) {
   const projection = projectNotebookWorkstationPanel(capabilities);
@@ -148,7 +168,15 @@ export function NotebookWorkstationsPanel({
         </section>
       ) : null}
 
-      {showRegistrationPrompt ? (
+      {pairing ? (
+        <WorkstationPairingCard
+          pairing={pairing}
+          onCancel={onCancelPairing}
+          onRestart={onStartPairing}
+        />
+      ) : null}
+
+      {showRegistrationPrompt && !pairing ? (
         <section
           className="space-y-1.5 text-xs"
           aria-label="Workstation setup"
@@ -159,11 +187,181 @@ export function NotebookWorkstationsPanel({
             <span>No workstation registered</span>
           </div>
           <p className="leading-5 text-muted-foreground">
-            Run the workstation agent on a machine you own, then attach it here to start compute.
+            Connect a machine you own to run this notebook&rsquo;s compute there.
           </p>
+          {onStartPairing ? (
+            <Button
+              type="button"
+              variant="outline"
+              size="sm"
+              className="mt-1"
+              onClick={onStartPairing}
+              data-testid="workstation-add-button"
+            >
+              <Plus className="size-3.5" aria-hidden="true" />
+              Add workstation
+            </Button>
+          ) : null}
+        </section>
+      ) : null}
+
+      {!showRegistrationPrompt && !pairing && onStartPairing ? (
+        <section aria-label="Workstation setup">
+          <Button
+            type="button"
+            variant="ghost"
+            size="sm"
+            className="text-xs text-muted-foreground"
+            onClick={onStartPairing}
+            data-testid="workstation-add-button"
+          >
+            <Plus className="size-3.5" aria-hidden="true" />
+            Add workstation
+          </Button>
         </section>
       ) : null}
     </div>
+  );
+}
+
+function WorkstationPairingCard({
+  pairing,
+  onCancel,
+  onRestart,
+}: {
+  pairing: NotebookWorkstationPairingView;
+  onCancel?: () => void;
+  onRestart?: () => void;
+}) {
+  return (
+    <section
+      className="space-y-2 rounded-md border border-border/70 px-2.5 py-2"
+      aria-label="Connect a machine"
+      data-testid="workstation-pairing-card"
+    >
+      <div className="flex items-center justify-between gap-2">
+        <h4 className="text-sm font-medium">Connect a machine</h4>
+        {onCancel ? (
+          <Button
+            type="button"
+            variant="ghost"
+            size="icon"
+            className="size-6"
+            aria-label="Dismiss pairing"
+            onClick={onCancel}
+          >
+            <X className="size-3.5" aria-hidden="true" />
+          </Button>
+        ) : null}
+      </div>
+
+      {pairing.status === "registered" ? (
+        <div className="space-y-2 text-xs" aria-live="polite">
+          <div className="flex min-w-0 items-center gap-2 text-foreground">
+            <CircleCheck className="size-4 shrink-0 text-emerald-500" aria-hidden="true" />
+            <span data-testid="workstation-pairing-status">
+              {pairing.workstationName ?? "Workstation"} is connected.
+            </span>
+          </div>
+          {onCancel ? (
+            <Button type="button" variant="secondary" size="sm" onClick={onCancel}>
+              Done
+            </Button>
+          ) : null}
+        </div>
+      ) : pairing.status === "expired" ? (
+        <div className="space-y-2 text-xs" aria-live="polite">
+          <div className="flex min-w-0 items-center gap-2 text-muted-foreground">
+            <CircleAlert className="size-4 shrink-0 text-amber-500" aria-hidden="true" />
+            <span data-testid="workstation-pairing-status">
+              {pairing.error ?? "The pairing code expired before a machine connected."}
+            </span>
+          </div>
+          {onRestart ? (
+            <Button type="button" variant="outline" size="sm" onClick={onRestart}>
+              Generate a new code
+            </Button>
+          ) : null}
+        </div>
+      ) : (
+        <div className="space-y-2 text-xs">
+          <p className="leading-5 text-muted-foreground">
+            Run this on the machine you want to attach:
+          </p>
+          <PairingCommand command={pairing.connectCommand} />
+          <p className="leading-5 text-muted-foreground" aria-live="polite">
+            {pairing.status === "redeemed" ? (
+              <span data-testid="workstation-pairing-status">Machine connected — registering…</span>
+            ) : (
+              <span data-testid="workstation-pairing-status">
+                Waiting for the machine to connect.
+                <PairingCountdown expiresAt={pairing.expiresAt} />
+              </span>
+            )}
+          </p>
+        </div>
+      )}
+    </section>
+  );
+}
+
+function PairingCommand({ command }: { command: string }) {
+  const [copied, setCopied] = useState(false);
+  useEffect(() => {
+    if (!copied) {
+      return;
+    }
+    const timer = window.setTimeout(() => setCopied(false), 2_000);
+    return () => window.clearTimeout(timer);
+  }, [copied]);
+
+  return (
+    <div className="flex items-start gap-1.5">
+      <code
+        className="min-w-0 flex-1 rounded bg-muted/40 px-2 py-1.5 font-mono text-[11px] leading-4 break-all whitespace-pre-wrap"
+        data-testid="workstation-pairing-command"
+      >
+        {command}
+      </code>
+      <Button
+        type="button"
+        variant="ghost"
+        size="icon"
+        className="size-7 shrink-0"
+        aria-label={copied ? "Copied" : "Copy connect command"}
+        onClick={() => {
+          void navigator.clipboard.writeText(command).then(() => setCopied(true));
+        }}
+      >
+        {copied ? (
+          <Check className="size-3.5 text-emerald-500" aria-hidden="true" />
+        ) : (
+          <Copy className="size-3.5" aria-hidden="true" />
+        )}
+      </Button>
+    </div>
+  );
+}
+
+function PairingCountdown({ expiresAt }: { expiresAt: string }) {
+  const [now, setNow] = useState(() => Date.now());
+  useEffect(() => {
+    const timer = window.setInterval(() => setNow(Date.now()), 1_000);
+    return () => window.clearInterval(timer);
+  }, []);
+
+  const remainingMs = Date.parse(expiresAt) - now;
+  if (!Number.isFinite(remainingMs) || remainingMs <= 0) {
+    return null;
+  }
+  const totalSeconds = Math.floor(remainingMs / 1_000);
+  const minutes = Math.floor(totalSeconds / 60);
+  const seconds = totalSeconds % 60;
+  return (
+    <span>
+      {" "}
+      Code expires in {minutes}:{seconds.toString().padStart(2, "0")}.
+    </span>
   );
 }
 

--- a/src/components/notebook/__tests__/NotebookWorkstationsPanel.test.tsx
+++ b/src/components/notebook/__tests__/NotebookWorkstationsPanel.test.tsx
@@ -175,9 +175,7 @@ describe("NotebookWorkstationsPanel", () => {
     expect(screen.getByTestId("workstation-registration-empty")).toBeVisible();
     expect(screen.getByText("No workstation registered")).toBeVisible();
     expect(
-      screen.getByText(
-        "Run the workstation agent on a machine you own, then attach it here to start compute.",
-      ),
+      screen.getByText("Connect a machine you own to run this notebook’s compute there."),
     ).toBeVisible();
   });
 
@@ -524,5 +522,103 @@ describe("NotebookWorkstationsPanel", () => {
     expect(screen.getByText("1")).toBeVisible();
     expect(screen.queryByText("CPUs")).not.toBeInTheDocument();
     expect(screen.queryByText("RAM")).not.toBeInTheDocument();
+  });
+
+  it("offers Add workstation and starts pairing", () => {
+    const started: number[] = [];
+    render(
+      <NotebookWorkstationsPanel
+        capabilities={localReadyCapabilities}
+        onStartPairing={() => started.push(1)}
+      />,
+    );
+
+    const addButton = screen.getByTestId("workstation-add-button");
+    fireEvent.click(addButton);
+    expect(started).toHaveLength(1);
+  });
+
+  it("renders the pending pairing card with the connect command and countdown", () => {
+    render(
+      <NotebookWorkstationsPanel
+        capabilities={localReadyCapabilities}
+        pairing={{
+          code: "ABCD-EFGH-JKMN",
+          connectCommand:
+            "runt workstation connect https://cloud.test --code ABCD-EFGH-JKMN && runt workstation run",
+          expiresAt: new Date(Date.now() + 9 * 60_000).toISOString(),
+          status: "pending",
+          workstationName: null,
+          error: null,
+        }}
+      />,
+    );
+
+    expect(screen.getByTestId("workstation-pairing-command")).toHaveTextContent(
+      "runt workstation connect https://cloud.test --code ABCD-EFGH-JKMN && runt workstation run",
+    );
+    expect(screen.getByTestId("workstation-pairing-status")).toHaveTextContent(
+      /Waiting for the machine to connect/,
+    );
+    expect(screen.getByTestId("workstation-pairing-status")).toHaveTextContent(
+      /Code expires in 8:5\d/,
+    );
+    expect(screen.getByRole("button", { name: "Copy connect command" })).toBeVisible();
+  });
+
+  it("announces redemption and registration, and Done dismisses", () => {
+    const dismissed: number[] = [];
+    const pairingBase = {
+      code: "ABCD-EFGH-JKMN",
+      connectCommand: "runt workstation connect https://cloud.test --code ABCD-EFGH-JKMN",
+      expiresAt: new Date(Date.now() + 60_000).toISOString(),
+      workstationName: null,
+      error: null,
+    };
+    const { rerender } = render(
+      <NotebookWorkstationsPanel
+        capabilities={localReadyCapabilities}
+        pairing={{ ...pairingBase, status: "redeemed" }}
+        onCancelPairing={() => dismissed.push(1)}
+      />,
+    );
+    expect(screen.getByTestId("workstation-pairing-status")).toHaveTextContent(/Machine connected/);
+
+    rerender(
+      <NotebookWorkstationsPanel
+        capabilities={localReadyCapabilities}
+        pairing={{ ...pairingBase, status: "registered", workstationName: "Hub devbox" }}
+        onCancelPairing={() => dismissed.push(1)}
+      />,
+    );
+    expect(screen.getByTestId("workstation-pairing-status")).toHaveTextContent(
+      "Hub devbox is connected.",
+    );
+    fireEvent.click(screen.getByRole("button", { name: "Done" }));
+    expect(dismissed).toHaveLength(1);
+  });
+
+  it("offers a fresh code when the pairing expires", () => {
+    const restarted: number[] = [];
+    render(
+      <NotebookWorkstationsPanel
+        capabilities={localReadyCapabilities}
+        pairing={{
+          code: "ABCD-EFGH-JKMN",
+          connectCommand: "runt workstation connect https://cloud.test --code ABCD-EFGH-JKMN",
+          expiresAt: new Date(Date.now() - 1_000).toISOString(),
+          status: "expired",
+          workstationName: null,
+          error: null,
+        }}
+        onStartPairing={() => restarted.push(1)}
+      />,
+    );
+
+    expect(screen.getByTestId("workstation-pairing-status")).toHaveTextContent(
+      /pairing code expired/i,
+    );
+    fireEvent.click(screen.getByRole("button", { name: "Generate a new code" }));
+    expect(restarted).toHaveLength(1);
   });
 });


### PR DESCRIPTION
## Summary

The product face of the pairing contract in #3609: an **Add workstation** flow in the workstations rail panel.

- "Add workstation" appears in the empty state (replacing the passive "run the agent" copy) and as a quiet entry under the registered list.
- Clicking mints a pairing code and shows the copy-paste one-liner —
  `runt workstation connect https://preview.runt.run --code XXXX-XXXX-XXXX && runt workstation run`
  — with a live `Code expires in m:ss` countdown and a copy button.
- The card follows the pairing live: waiting → "Machine connected — registering…" → "✓ <name> is connected", polling `GET /api/workstations/pairing-codes/:id` every 2s and refreshing the workstation list on registration. Expiry flips client-side (no poll-boundary dependence) and offers "Generate a new code".
- All new panel props are optional, so the elements docs prototype keeps compiling unchanged.

## Stack

Promoted from quillaid#6 after #3609 merged; now based on `main`. The `runt workstation` CLI that the one-liner invokes is #3611. Post-rebase full-suite verification: 2255 JS tests, 961 worker tests, all green. Also includes the review-driven hook state-machine tests (`use-cloud-workstations.test.tsx`).

## Tests

4 new panel tests (entry point, pending card + countdown, redeemed→registered + Done, expiry + regenerate) and 3 new client tests (mint/status round-trip with auth headers, error surfacing, one-liner construction). 13 + 7 green.

