### PR TITLE
feat(workstation): runt workstation connect/run/status and runtimed workstation-agent loop

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7426,6 +7426,7 @@ dependencies = [
  "notify",
  "nteract-telemetry",
  "petname",
+ "reqwest 0.12.28",
  "rmcp",
  "runt-mcp",
  "runt-publish",

--- a/crates/notebook-cloud-transport/src/lib.rs
+++ b/crates/notebook-cloud-transport/src/lib.rs
@@ -82,6 +82,12 @@ pub enum CloudAuth {
     /// treats a bearer as an API key when the provider-selector header is
     /// present; without it the key is parsed as OIDC and rejected.
     AnacondaApiKey { token: String },
+    /// Workstation credential minted by the pairing flow (`nwc_`-prefixed
+    /// token; see `docs/adr/hosted-credential-transport.md` Decision 9). Plain
+    /// `Authorization: Bearer` on the wire — the same shape as
+    /// [`CloudAuth::OidcBearer`], but honestly labeled: the cloud identity
+    /// router recognizes the credential by its token prefix, not a header.
+    WorkstationCredential { token: String },
     /// Dev token (`X-Notebook-Cloud-Dev-Token`) plus a user label.
     Dev { token: String, user: String },
 }
@@ -109,6 +115,7 @@ impl CloudAuth {
         match self {
             CloudAuth::OidcBearer { .. } => CloudAuth::OidcBearer { token },
             CloudAuth::AnacondaApiKey { .. } => CloudAuth::AnacondaApiKey { token },
+            CloudAuth::WorkstationCredential { .. } => CloudAuth::WorkstationCredential { token },
             CloudAuth::Dev { user, .. } => CloudAuth::Dev {
                 token,
                 user: user.clone(),
@@ -543,7 +550,9 @@ impl CloudWsFrameTransport {
                     HeaderValue::from_static("anaconda-api-key"),
                 );
             }
-            CloudAuth::OidcBearer { token } => {
+            // Workstation credentials share OIDC's wire shape (plain bearer);
+            // the cloud side dispatches on the `nwc_` token prefix.
+            CloudAuth::OidcBearer { token } | CloudAuth::WorkstationCredential { token } => {
                 h.insert(
                     HeaderName::from_static("authorization"),
                     HeaderValue::from_str(&format!("Bearer {token}"))?,
@@ -949,6 +958,10 @@ mod tests {
             CloudAuth::AnacondaApiKey { token: "old".into() }.with_token("new".into()),
             CloudAuth::AnacondaApiKey { token } if token == "new"
         ));
+        assert!(matches!(
+            CloudAuth::WorkstationCredential { token: "old".into() }.with_token("new".into()),
+            CloudAuth::WorkstationCredential { token } if token == "new"
+        ));
         // Dev keeps its user label, swaps only the token.
         match (CloudAuth::Dev {
             token: "old".into(),
@@ -1022,6 +1035,40 @@ mod tests {
                 .and_then(|value| value.to_str().ok()),
             Some("current_python")
         );
+    }
+
+    /// The workstation credential rides as a plain bearer — same wire shape as
+    /// OIDC, no provider-selector or dev-token headers.
+    #[test]
+    fn apply_auth_headers_workstation_credential_is_plain_bearer() {
+        let t = CloudWsFrameTransport::new(CloudWsConfig {
+            cloud_url: "https://preview.runt.run".into(),
+            notebook_id: "abc".into(),
+            scope: "runtime_peer".into(),
+            auth: CloudAuth::WorkstationCredential {
+                token: "nwc_secret".into(),
+            },
+            workstation: None,
+        });
+        let mut request = t.ws_url().into_client_request().unwrap();
+
+        t.apply_auth_headers(
+            &mut request,
+            &CloudAuth::WorkstationCredential {
+                token: "nwc_secret".into(),
+            },
+        )
+        .unwrap();
+
+        let headers = request.headers();
+        assert_eq!(
+            headers
+                .get("authorization")
+                .and_then(|value| value.to_str().ok()),
+            Some("Bearer nwc_secret")
+        );
+        assert!(headers.get("x-notebook-cloud-auth-provider").is_none());
+        assert!(headers.get("x-notebook-cloud-dev-token").is_none());
     }
 
     #[tokio::test]

--- a/crates/runt-workspace/src/lib.rs
+++ b/crates/runt-workspace/src/lib.rs
@@ -1215,6 +1215,96 @@ pub fn session_state_path() -> PathBuf {
     }
 }
 
+/// Get the path to the workstation credential file written by
+/// `runt workstation connect` and read by `runt workstation run` / `status`.
+///
+/// In dev mode: stored per-worktree for isolation during development.
+/// In production: stored in config directory alongside settings
+/// (mirrors [`session_state_path`]).
+pub fn workstation_credentials_path() -> PathBuf {
+    if is_dev_mode() {
+        // Per-worktree credential for dev isolation
+        daemon_base_dir().join("workstation.json")
+    } else {
+        // Production: config directory
+        dirs::config_dir()
+            .unwrap_or_else(|| PathBuf::from("."))
+            .join(config_namespace())
+            .join("workstation.json")
+    }
+}
+
+/// Best-effort machine hostname for non-secret workstation identity labels.
+///
+/// Tries the kernel (Linux), well-known environment variables, and the
+/// `hostname` binary before falling back to `"localhost"`. This is only used
+/// to derive human-readable defaults (`--display-name`, `ws-<slug>` ids), so
+/// a fallback is acceptable.
+pub fn machine_hostname() -> String {
+    #[cfg(target_os = "linux")]
+    if let Ok(name) = std::fs::read_to_string("/proc/sys/kernel/hostname") {
+        let name = name.trim();
+        if !name.is_empty() {
+            return name.to_string();
+        }
+    }
+    // HOSTNAME is set by interactive POSIX shells (not services);
+    // COMPUTERNAME is the Windows equivalent.
+    for var in ["HOSTNAME", "COMPUTERNAME"] {
+        if let Ok(name) = std::env::var(var) {
+            let name = name.trim();
+            if !name.is_empty() {
+                return name.to_string();
+            }
+        }
+    }
+    if let Ok(output) = std::process::Command::new("hostname").output() {
+        if output.status.success() {
+            if let Ok(name) = String::from_utf8(output.stdout) {
+                let name = name.trim();
+                if !name.is_empty() {
+                    return name.to_string();
+                }
+            }
+        }
+    }
+    "localhost".to_string()
+}
+
+/// Filesystem- and id-safe slug: lowercase, runs of characters outside
+/// `[a-z0-9._-]` collapse to a single `-`, leading/trailing `-` stripped.
+/// Mirrors `safePathPart` in
+/// `apps/notebook-cloud/scripts/hosted-workstation-agent-core.mjs` so Rust and
+/// Node agents derive identical workstation ids and job directories.
+pub fn safe_path_part(value: &str) -> String {
+    let lower = value.to_lowercase();
+    let mut out = String::with_capacity(lower.len());
+    let mut in_disallowed_run = false;
+    for ch in lower.chars() {
+        if ch.is_ascii_lowercase() || ch.is_ascii_digit() || matches!(ch, '.' | '_' | '-') {
+            out.push(ch);
+            in_disallowed_run = false;
+        } else if !in_disallowed_run {
+            out.push('-');
+            in_disallowed_run = true;
+        }
+    }
+    out.trim_matches('-').to_string()
+}
+
+/// Stable default workstation id derived from the hostname:
+/// `ws-<slug>` (slug capped at 80 chars), or `ws-local` when the hostname
+/// yields an empty slug. Mirrors `stableWorkstationId` in
+/// `hosted-workstation-agent-core.mjs`.
+pub fn stable_workstation_id(hostname: &str) -> String {
+    let slug: String = safe_path_part(hostname).chars().take(80).collect();
+    if slug.is_empty() {
+        "ws-local".to_string()
+    } else {
+        format!("ws-{slug}")
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -1250,6 +1340,41 @@ mod tests {
         assert_eq!(
             build_channel_from_str(Some("something-else")),
             BuildChannel::Nightly
+        );
+    }
+
+    #[test]
+    fn test_safe_path_part_mirrors_node_core() {
+        // Same expectations as hosted-workstation-agent-core.mjs safePathPart.
+        assert_eq!(safe_path_part("Job 123"), "job-123");
+        assert_eq!(
+            safe_path_part("lab2.example.internal"),
+            "lab2.example.internal"
+        );
+        assert_eq!(safe_path_part("!!!"), "");
+        assert_eq!(safe_path_part("a!-b"), "a--b");
+        assert_eq!(safe_path_part("--keep--"), "keep");
+    }
+
+    #[test]
+    fn test_stable_workstation_id_mirrors_node_core() {
+        assert_eq!(
+            stable_workstation_id("lab2.example.internal"),
+            "ws-lab2.example.internal"
+        );
+        assert_eq!(stable_workstation_id("!!!"), "ws-local");
+        let long = "h".repeat(200);
+        let id = stable_workstation_id(&long);
+        assert_eq!(id.len(), "ws-".len() + 80);
+    }
+
+    #[test]
+    fn test_workstation_credentials_path_filename() {
+        assert_eq!(
+            workstation_credentials_path()
+                .file_name()
+                .and_then(|n| n.to_str()),
+            Some("workstation.json")
         );
     }
 

--- a/crates/runt/Cargo.toml
+++ b/crates/runt/Cargo.toml
@@ -26,6 +26,7 @@ kernel-env = { path = "../kernel-env" }
 rmcp = { version = "1.4", features = ["server", "transport-io"] }
 clap = { version = "4.5.1", features = ["derive", "color"] }
 colored = "3"
+reqwest = { version = "0.12", default-features = false, features = ["json", "native-tls"] }
 tokio = { version = "1", features = ["full"] }
 petname = "2"
 dirs = "6"

--- a/crates/runt/src/main.rs
+++ b/crates/runt/src/main.rs
@@ -3,6 +3,7 @@
 
 extern crate runtimed_client as runtimed;
 mod notebook_cli;
+mod workstation_cli;
 
 use anyhow::Result;
 use clap::{Parser, Subcommand};
@@ -177,6 +178,11 @@ enum Commands {
     Nb {
         #[command(subcommand)]
         command: Box<notebook_cli::NotebookCommands>,
+    },
+    /// Offer this machine's compute to hosted notebooks (pair, run, status)
+    Workstation {
+        #[command(subcommand)]
+        command: workstation_cli::WorkstationCommands,
     },
 
     // =========================================================================
@@ -558,6 +564,7 @@ async fn async_main(command: Option<Commands>) -> Result<()> {
         }
         Some(Commands::Diagnostics { output }) => diagnostics_command(output).await?,
         Some(Commands::Nb { command }) => notebook_cli::command(*command).await?,
+        Some(Commands::Workstation { command }) => workstation_cli::command(command).await?,
         Some(Commands::Config { command }) => config_command(command).await?,
         Some(Commands::Mcp { no_show, socket }) => {
             if let Some(socket) = socket {

--- a/crates/runt/src/workstation_cli.rs
+++ b/crates/runt/src/workstation_cli.rs
@@ -1,0 +1,654 @@
+//! `runt workstation` — pair this machine with a hosted nteract cloud and
+//! serve attach requests.
+//!
+//! The operator path (`docs/remote-workstation.md`, ADR
+//! `docs/adr/hosted-credential-transport.md` Decision 9):
+//!
+//! 1. Mint a pairing code in the hosted workstation panel.
+//! 2. `runt workstation connect <url> --code XXXX-XXXX-XXXX` redeems it for a
+//!    long-lived workstation credential (`nwc_` token) and stores it at
+//!    [`runt_workspace::workstation_credentials_path`] (mode 0600).
+//! 3. `runt workstation run` launches the sibling `runtimed workstation-agent`
+//!    service loop with the credential in the environment (never argv).
+//!
+//! `runt workstation status` lists the workstations the credential can see.
+
+use std::io::Write as _;
+use std::path::{Path, PathBuf};
+use std::time::Duration;
+
+use anyhow::{bail, Context, Result};
+use serde::{Deserialize, Serialize};
+
+/// Environment variable carrying the workstation credential. Overrides the
+/// credential file when set; also how `run` hands the token to `runtimed`.
+pub const CLOUD_TOKEN_ENV: &str = "RUNT_CLOUD_TOKEN";
+/// Environment override for the cloud base URL.
+pub const CLOUD_URL_ENV: &str = "RUNT_CLOUD_URL";
+
+#[derive(clap::Subcommand)]
+pub enum WorkstationCommands {
+    /// Pair this machine with a hosted cloud using a pairing code
+    Connect {
+        /// Base URL of the hosted nteract cloud (e.g. https://app.runt.run)
+        url: String,
+        /// Pairing code from the workstation panel (XXXX-XXXX-XXXX);
+        /// prompts on stdin when omitted
+        #[arg(long)]
+        code: Option<String>,
+        /// Stable workstation id (default: ws-<hostname slug>)
+        #[arg(long)]
+        id: Option<String>,
+        /// Display name shown in the workstation panel (default: hostname)
+        #[arg(long)]
+        name: Option<String>,
+    },
+    /// Serve attach requests using the stored workstation credential
+    Run,
+    /// List workstations registered to the stored credential
+    Status {
+        /// Output raw JSON
+        #[arg(long)]
+        json: bool,
+    },
+}
+
+pub async fn command(command: WorkstationCommands) -> Result<()> {
+    match command {
+        WorkstationCommands::Connect {
+            url,
+            code,
+            id,
+            name,
+        } => connect(url, code, id, name).await,
+        WorkstationCommands::Run => run().await,
+        WorkstationCommands::Status { json } => status(json).await,
+    }
+}
+
+/// Stored credential file: `workstation.json` in the config directory
+/// (per-worktree in dev mode). Created with mode 0600 — it holds the bearer.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct WorkstationCredentialFile {
+    pub cloud_url: String,
+    pub token: String,
+    pub credential_id: String,
+    pub workstation_id: String,
+    pub display_name: String,
+    pub connected_at: String,
+}
+
+// ---------------------------------------------------------------------------
+// connect
+// ---------------------------------------------------------------------------
+
+async fn connect(
+    url: String,
+    code: Option<String>,
+    id: Option<String>,
+    name: Option<String>,
+) -> Result<()> {
+    let cloud_url = normalize_cloud_url(&url)?;
+    let code = match code {
+        Some(code) => code,
+        None => prompt_for_pairing_code()?,
+    };
+    let code = code.trim().to_string();
+    if code.is_empty() {
+        bail!("a pairing code is required (mint one from the workstation panel)");
+    }
+
+    let client = http_client()?;
+    let redeem_url = format!("{cloud_url}/api/workstations/pairing-codes/redeem");
+    let response = client
+        .post(&redeem_url)
+        .json(&serde_json::json!({ "code": code }))
+        .send()
+        .await
+        .with_context(|| format!("could not reach {cloud_url}"))?;
+    let status = response.status().as_u16();
+    let body = response.text().await.unwrap_or_default();
+    let credential = match parse_redeem_response(status, &body) {
+        Ok(credential) => credential,
+        Err(RedeemError::Rejected) => {
+            eprintln!(
+                "Pairing code is invalid, expired, or already used — mint a fresh one from the workstation panel."
+            );
+            std::process::exit(1);
+        }
+        Err(RedeemError::Unexpected(message)) => bail!("pairing code redeem failed: {message}"),
+    };
+
+    let hostname = runt_workspace::machine_hostname();
+    let workstation_id = id.unwrap_or_else(|| runt_workspace::stable_workstation_id(&hostname));
+    let display_name = name.unwrap_or(hostname);
+    let credentials = WorkstationCredentialFile {
+        cloud_url: cloud_url.clone(),
+        token: credential.token,
+        credential_id: credential.credential_id,
+        workstation_id: workstation_id.clone(),
+        display_name: display_name.clone(),
+        connected_at: chrono::Utc::now().to_rfc3339(),
+    };
+    let path = runt_workspace::workstation_credentials_path();
+    write_credential_file(&path, &credentials)?;
+    println!("Workstation credential stored at {}", path.display());
+
+    // One registration so the workstation appears in the panel (and the
+    // pairing dialog flips to "registered") without waiting for `run`.
+    let payload = minimal_registration_payload(
+        &workstation_id,
+        &display_name,
+        std::env::current_dir()
+            .ok()
+            .map(|dir| dir.to_string_lossy().into_owned())
+            .as_deref(),
+        cpu_count(),
+    );
+    let registration = client
+        .post(format!("{cloud_url}/api/workstations"))
+        .bearer_auth(&credentials.token)
+        .json(&payload)
+        .send()
+        .await;
+    match registration {
+        Ok(response) if response.status().is_success() => {
+            println!(
+                "Registered workstation \"{display_name}\" ({workstation_id}) with {cloud_url}."
+            );
+        }
+        Ok(response) => {
+            eprintln!(
+                "Warning: registration returned HTTP {}; `runt workstation run` will retry.",
+                response.status()
+            );
+        }
+        Err(error) => {
+            eprintln!("Warning: registration failed ({error}); `runt workstation run` will retry.");
+        }
+    }
+
+    println!("Run `runt workstation run` to serve attach requests.");
+    Ok(())
+}
+
+fn prompt_for_pairing_code() -> Result<String> {
+    eprint!("Enter pairing code (XXXX-XXXX-XXXX): ");
+    std::io::stderr().flush().ok();
+    let mut line = String::new();
+    std::io::stdin()
+        .read_line(&mut line)
+        .context("failed to read pairing code from stdin")?;
+    Ok(line.trim().to_string())
+}
+
+/// Redeem result: the long-lived workstation credential.
+#[derive(Debug, PartialEq, Eq)]
+pub(crate) struct RedeemedCredential {
+    pub token: String,
+    pub credential_id: String,
+}
+
+#[derive(Debug, PartialEq, Eq)]
+pub(crate) enum RedeemError {
+    /// 404: unknown, expired, and already-used codes are indistinguishable
+    /// by design (the endpoint must not oracle live codes).
+    Rejected,
+    Unexpected(String),
+}
+
+/// Parse `POST /api/workstations/pairing-codes/redeem`. Success is
+/// `201 {"ok":true,"credential":{"token":"nwc_...","credential_id":"..."},...}`.
+pub(crate) fn parse_redeem_response(
+    status: u16,
+    body: &str,
+) -> Result<RedeemedCredential, RedeemError> {
+    if status == 404 {
+        return Err(RedeemError::Rejected);
+    }
+    if status != 200 && status != 201 {
+        let snippet: String = body.chars().take(300).collect();
+        return Err(RedeemError::Unexpected(format!("HTTP {status} {snippet}")));
+    }
+    let value: serde_json::Value = serde_json::from_str(body)
+        .map_err(|e| RedeemError::Unexpected(format!("invalid JSON response: {e}")))?;
+    let token = value
+        .pointer("/credential/token")
+        .and_then(|v| v.as_str())
+        .filter(|t| !t.is_empty());
+    let credential_id = value
+        .pointer("/credential/credential_id")
+        .and_then(|v| v.as_str())
+        .filter(|c| !c.is_empty());
+    match (token, credential_id) {
+        (Some(token), Some(credential_id)) => Ok(RedeemedCredential {
+            token: token.to_string(),
+            credential_id: credential_id.to_string(),
+        }),
+        _ => Err(RedeemError::Unexpected(
+            "redeem response is missing credential.token / credential.credential_id".to_string(),
+        )),
+    }
+}
+
+/// Minimal registration payload for the one-shot `connect` registration.
+/// (`runtimed workstation-agent` sends the full payload — python path,
+/// capabilities, memory — on every heartbeat.)
+pub(crate) fn minimal_registration_payload(
+    workstation_id: &str,
+    display_name: &str,
+    working_directory: Option<&str>,
+    cpu_count: Option<u64>,
+) -> serde_json::Value {
+    let mut payload = serde_json::json!({
+        "workstation_id": workstation_id,
+        "display_name": display_name,
+        "provider": "runtime_peer",
+        "environment_policy": "current_python",
+        "default_environment_label": "Current Python",
+    });
+    if let Some(dir) = working_directory {
+        payload["working_directory"] = dir.into();
+    }
+    if let Some(cpu) = cpu_count {
+        payload["cpu_count"] = cpu.into();
+    }
+    payload
+}
+
+// ---------------------------------------------------------------------------
+// run
+// ---------------------------------------------------------------------------
+
+async fn run() -> Result<()> {
+    let resolved = resolve_credentials()?;
+
+    let runtimed_bin = locate_runtimed_binary().ok_or_else(|| {
+        anyhow::anyhow!(
+            "could not find a runtimed binary next to runt or in the installed app; \
+             build one with `cargo build -p runtimed` or reinstall nteract"
+        )
+    })?;
+
+    println!(
+        "Serving attach requests for {} as {} (\"{}\") via {}",
+        resolved.cloud_url,
+        resolved.workstation_id,
+        resolved.display_name,
+        runtimed_bin.display()
+    );
+
+    let status = std::process::Command::new(&runtimed_bin)
+        .arg("workstation-agent")
+        .arg("--cloud-url")
+        .arg(&resolved.cloud_url)
+        .arg("--workstation-id")
+        .arg(&resolved.workstation_id)
+        .arg("--display-name")
+        .arg(&resolved.display_name)
+        // The credential rides the environment, never argv.
+        .env(CLOUD_TOKEN_ENV, &resolved.token)
+        .status()
+        .with_context(|| format!("failed to launch {}", runtimed_bin.display()))?;
+
+    std::process::exit(status.code().unwrap_or(1));
+}
+
+/// Credentials in effect: the stored file, with `RUNT_CLOUD_TOKEN` /
+/// `RUNT_CLOUD_URL` environment overrides winning when set.
+struct ResolvedCredentials {
+    cloud_url: String,
+    token: String,
+    workstation_id: String,
+    display_name: String,
+}
+
+fn resolve_credentials() -> Result<ResolvedCredentials> {
+    let path = runt_workspace::workstation_credentials_path();
+    let stored = read_credential_file(&path)?;
+    let env_token = non_empty_env(CLOUD_TOKEN_ENV);
+    let env_url = non_empty_env(CLOUD_URL_ENV);
+
+    let token = env_token.or_else(|| stored.as_ref().map(|c| c.token.clone()));
+    let cloud_url = env_url.or_else(|| stored.as_ref().map(|c| c.cloud_url.clone()));
+    let (Some(token), Some(cloud_url)) = (token, cloud_url) else {
+        bail!(
+            "no workstation credential found at {} — run `runt workstation connect <url>` first \
+             (or set {CLOUD_TOKEN_ENV} and {CLOUD_URL_ENV})",
+            path.display()
+        );
+    };
+
+    let hostname = runt_workspace::machine_hostname();
+    let workstation_id = stored
+        .as_ref()
+        .map(|c| c.workstation_id.clone())
+        .unwrap_or_else(|| runt_workspace::stable_workstation_id(&hostname));
+    let display_name = stored
+        .as_ref()
+        .map(|c| c.display_name.clone())
+        .unwrap_or(hostname);
+
+    Ok(ResolvedCredentials {
+        cloud_url: normalize_cloud_url(&cloud_url)?,
+        token,
+        workstation_id,
+        display_name,
+    })
+}
+
+/// Find the runtimed binary: the bundled/sibling lookup `runt` already uses
+/// for daemon management, with a dev fallback to the workspace target dir.
+fn locate_runtimed_binary() -> Option<PathBuf> {
+    if let Some(path) = crate::find_bundled_runtimed() {
+        return Some(path);
+    }
+    if crate::is_dev_mode() {
+        let binary_name = if cfg!(windows) {
+            "runtimed.exe"
+        } else {
+            "runtimed"
+        };
+        if let Some(workspace) = runt_workspace::get_workspace_path() {
+            for profile in ["debug", "release"] {
+                let candidate = workspace.join("target").join(profile).join(binary_name);
+                if candidate.exists() {
+                    return Some(candidate);
+                }
+            }
+        }
+    }
+    None
+}
+
+// ---------------------------------------------------------------------------
+// status
+// ---------------------------------------------------------------------------
+
+async fn status(json_output: bool) -> Result<()> {
+    let resolved = resolve_credentials()?;
+    let client = http_client()?;
+    let response = client
+        .get(format!("{}/api/workstations", resolved.cloud_url))
+        .bearer_auth(&resolved.token)
+        .send()
+        .await
+        .with_context(|| format!("could not reach {}", resolved.cloud_url))?;
+    let status = response.status().as_u16();
+    let body = response.text().await.unwrap_or_default();
+    if status == 401 || status == 403 {
+        bail!(
+            "the workstation credential was rejected (HTTP {status}) — it may have been revoked; \
+             run `runt workstation connect {}` with a fresh pairing code",
+            resolved.cloud_url
+        );
+    }
+    if status != 200 {
+        let snippet: String = body.chars().take(300).collect();
+        bail!("listing workstations failed: HTTP {status} {snippet}");
+    }
+    let value: serde_json::Value =
+        serde_json::from_str(&body).context("workstation list was not valid JSON")?;
+
+    if json_output {
+        println!("{}", serde_json::to_string_pretty(&value)?);
+        return Ok(());
+    }
+
+    println!("Cloud: {}", resolved.cloud_url);
+    println!(
+        "This machine: {} (\"{}\")",
+        resolved.workstation_id, resolved.display_name
+    );
+    println!();
+    let workstations = value
+        .get("workstations")
+        .and_then(|v| v.as_array())
+        .cloned()
+        .unwrap_or_default();
+    if workstations.is_empty() {
+        println!("No workstations registered yet. Run `runt workstation run` to register.");
+        return Ok(());
+    }
+    println!(
+        "{:<28} {:<24} {:<9} {:<25} DEFAULT",
+        "WORKSTATION", "NAME", "STATUS", "LAST SEEN"
+    );
+    for workstation in &workstations {
+        let field = |key: &str| {
+            workstation
+                .get(key)
+                .and_then(|v| v.as_str())
+                .unwrap_or("-")
+                .to_string()
+        };
+        let is_default = workstation
+            .get("is_default")
+            .and_then(|v| v.as_bool())
+            .unwrap_or(false);
+        println!(
+            "{:<28} {:<24} {:<9} {:<25} {}",
+            field("workstation_id"),
+            field("display_name"),
+            field("status"),
+            field("last_seen_at"),
+            if is_default { "*" } else { "" }
+        );
+    }
+    Ok(())
+}
+
+// ---------------------------------------------------------------------------
+// shared helpers
+// ---------------------------------------------------------------------------
+
+fn http_client() -> Result<reqwest::Client> {
+    reqwest::Client::builder()
+        .timeout(Duration::from_secs(30))
+        .build()
+        .context("build HTTP client")
+}
+
+fn non_empty_env(key: &str) -> Option<String> {
+    std::env::var(key)
+        .ok()
+        .map(|value| value.trim().to_string())
+        .filter(|value| !value.is_empty())
+}
+
+fn normalize_cloud_url(url: &str) -> Result<String> {
+    let url = url.trim().trim_end_matches('/').to_string();
+    if !url.starts_with("https://") && !url.starts_with("http://") {
+        bail!("cloud URL must start with https:// or http:// (got {url:?})");
+    }
+    Ok(url)
+}
+
+fn cpu_count() -> Option<u64> {
+    std::thread::available_parallelism()
+        .ok()
+        .map(|n| n.get() as u64)
+}
+
+/// Write the credential file with owner-only permissions (0600 on unix).
+pub(crate) fn write_credential_file(
+    path: &Path,
+    credentials: &WorkstationCredentialFile,
+) -> Result<()> {
+    if let Some(parent) = path.parent() {
+        std::fs::create_dir_all(parent)
+            .with_context(|| format!("create config directory {}", parent.display()))?;
+    }
+    let json = serde_json::to_string_pretty(credentials)?;
+    let mut options = std::fs::OpenOptions::new();
+    options.write(true).create(true).truncate(true);
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::OpenOptionsExt;
+        options.mode(0o600);
+    }
+    let mut file = options
+        .open(path)
+        .with_context(|| format!("open credential file {}", path.display()))?;
+    file.write_all(json.as_bytes())?;
+    file.write_all(b"\n")?;
+    // OpenOptions mode only applies on create — tighten a pre-existing file too.
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        std::fs::set_permissions(path, std::fs::Permissions::from_mode(0o600))
+            .with_context(|| format!("set permissions on {}", path.display()))?;
+    }
+    Ok(())
+}
+
+/// Read the credential file; `Ok(None)` when it does not exist.
+pub(crate) fn read_credential_file(path: &Path) -> Result<Option<WorkstationCredentialFile>> {
+    match std::fs::read_to_string(path) {
+        Ok(raw) => Ok(Some(serde_json::from_str(&raw).with_context(|| {
+            format!("credential file {} is not valid JSON", path.display())
+        })?)),
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => Ok(None),
+        Err(error) => {
+            Err(error).with_context(|| format!("read credential file {}", path.display()))
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn sample_credentials() -> WorkstationCredentialFile {
+        WorkstationCredentialFile {
+            cloud_url: "https://preview.runt.run".to_string(),
+            token: "nwc_secret".to_string(),
+            credential_id: "cred-1".to_string(),
+            workstation_id: "ws-lab2".to_string(),
+            display_name: "lab2".to_string(),
+            connected_at: "2026-06-12T00:00:00Z".to_string(),
+        }
+    }
+
+    /// (a) Credential file round-trip, including owner-only permissions.
+    #[test]
+    fn credential_file_round_trip_with_0600_permissions() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("nested").join("workstation.json");
+        let credentials = sample_credentials();
+
+        write_credential_file(&path, &credentials).unwrap();
+        let loaded = read_credential_file(&path).unwrap().unwrap();
+        assert_eq!(loaded, credentials);
+
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            let mode = std::fs::metadata(&path).unwrap().permissions().mode();
+            assert_eq!(mode & 0o777, 0o600, "credential file must be 0600");
+        }
+    }
+
+    #[test]
+    fn credential_file_rewrites_tighten_permissions() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("workstation.json");
+        std::fs::write(&path, "{}").unwrap();
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            std::fs::set_permissions(&path, std::fs::Permissions::from_mode(0o644)).unwrap();
+        }
+
+        write_credential_file(&path, &sample_credentials()).unwrap();
+
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            let mode = std::fs::metadata(&path).unwrap().permissions().mode();
+            assert_eq!(mode & 0o777, 0o600);
+        }
+    }
+
+    #[test]
+    fn missing_credential_file_reads_as_none() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("does-not-exist.json");
+        assert_eq!(read_credential_file(&path).unwrap(), None);
+    }
+
+    /// (b) Redeem response parsing: the 201 success shape from
+    /// `routeWorkstationPairingCodeRedeem`.
+    #[test]
+    fn parse_redeem_success_shape() {
+        let body = r#"{
+            "ok": true,
+            "credential": { "token": "nwc_abc123", "credential_id": "cred-9" },
+            "pairing": { "id": "pairing-1" }
+        }"#;
+        assert_eq!(
+            parse_redeem_response(201, body).unwrap(),
+            RedeemedCredential {
+                token: "nwc_abc123".to_string(),
+                credential_id: "cred-9".to_string(),
+            }
+        );
+    }
+
+    /// (b) 404 means invalid/expired/used — indistinguishable by design.
+    #[test]
+    fn parse_redeem_404_is_rejected() {
+        let body = r#"{"error":"pairing code is invalid, expired, or already used"}"#;
+        assert_eq!(
+            parse_redeem_response(404, body).unwrap_err(),
+            RedeemError::Rejected
+        );
+    }
+
+    #[test]
+    fn parse_redeem_other_failures_are_unexpected() {
+        assert!(matches!(
+            parse_redeem_response(500, "boom"),
+            Err(RedeemError::Unexpected(message)) if message.contains("HTTP 500")
+        ));
+        assert!(matches!(
+            parse_redeem_response(201, "not json"),
+            Err(RedeemError::Unexpected(message)) if message.contains("invalid JSON")
+        ));
+        assert!(matches!(
+            parse_redeem_response(201, r#"{"ok":true}"#),
+            Err(RedeemError::Unexpected(message)) if message.contains("missing credential")
+        ));
+    }
+
+    #[test]
+    fn minimal_registration_payload_field_set() {
+        let payload =
+            minimal_registration_payload("ws-lab2", "lab2", Some("/home/ubuntu/project"), Some(8));
+        assert_eq!(
+            payload,
+            serde_json::json!({
+                "workstation_id": "ws-lab2",
+                "display_name": "lab2",
+                "provider": "runtime_peer",
+                "environment_policy": "current_python",
+                "default_environment_label": "Current Python",
+                "working_directory": "/home/ubuntu/project",
+                "cpu_count": 8,
+            })
+        );
+
+        let sparse = minimal_registration_payload("ws", "ws", None, None);
+        assert!(sparse.get("working_directory").is_none());
+        assert!(sparse.get("cpu_count").is_none());
+    }
+
+    #[test]
+    fn cloud_url_normalization() {
+        assert_eq!(
+            normalize_cloud_url("https://app.runt.run/").unwrap(),
+            "https://app.runt.run"
+        );
+        assert!(normalize_cloud_url("app.runt.run").is_err());
+    }
+}

--- a/crates/runtimed/Cargo.toml
+++ b/crates/runtimed/Cargo.toml
@@ -57,7 +57,7 @@ rattler_conda_types = "0.44"
 rattler_repodata_gateway = { version = "0.27", default-features = false, features = ["gateway", "native-tls"] }
 rattler_solve = { version = "5.0", features = ["resolvo"] }
 rattler_virtual_packages = "2.3"
-reqwest = { version = "0.12", default-features = false, features = ["native-tls"] }
+reqwest = { version = "0.12", default-features = false, features = ["json", "native-tls"] }
 reqwest-middleware = "0.4"
 
 # Content-addressed blob store

--- a/crates/runtimed/src/main.rs
+++ b/crates/runtimed/src/main.rs
@@ -188,6 +188,38 @@ enum Commands {
         workstation_display_name: Option<String>,
     },
 
+    /// Serve this machine as a workstation for a hosted nteract cloud:
+    /// register/heartbeat, poll attach jobs, and spawn one
+    /// `cloud-runtime-agent` runtime peer per job. The workstation credential
+    /// is read from RUNT_CLOUD_TOKEN (never argv); `runt workstation connect`
+    /// stores it and `runt workstation run` launches this subcommand.
+    #[command(name = "workstation-agent")]
+    WorkstationAgent {
+        /// Base URL of the notebook cloud (https/http).
+        #[arg(long)]
+        cloud_url: String,
+        /// Stable workstation id (default: ws-<hostname slug>). Non-secret.
+        #[arg(long)]
+        workstation_id: Option<String>,
+        /// Workstation name shown in the panel (default: hostname).
+        #[arg(long)]
+        display_name: Option<String>,
+        /// Default working directory for runtime peers (default: current
+        /// directory). Attach jobs may override it per job.
+        #[arg(long)]
+        working_dir: Option<PathBuf>,
+        /// Python interpreter for launch-on-attach kernels (default: python3,
+        /// then python, found on PATH).
+        #[arg(long)]
+        python_path: Option<PathBuf>,
+        /// Attach-job poll interval in milliseconds.
+        #[arg(long, default_value_t = runtimed::workstation::DEFAULT_POLL_MS, value_parser = clap::value_parser!(u64).range(1..))]
+        poll_ms: u64,
+        /// Registration heartbeat interval in milliseconds.
+        #[arg(long, default_value_t = runtimed::workstation::DEFAULT_HEARTBEAT_MS, value_parser = clap::value_parser!(u64).range(1..))]
+        heartbeat_ms: u64,
+    },
+
     /// Warm a pool environment (internal, spawned by daemon warming loops).
     /// Reads JSON config from stdin, writes JSON events to stdout.
     #[command(hide = true, name = "warm-env")]
@@ -592,6 +624,64 @@ async fn main() -> anyhow::Result<()> {
                 eprintln!("[cloud-runtime-agent] Fatal: {}", e);
                 e
             })
+        }
+        Some(Commands::WorkstationAgent {
+            cloud_url,
+            workstation_id,
+            display_name,
+            working_dir,
+            python_path,
+            poll_ms,
+            heartbeat_ms,
+        }) => {
+            let token = std::env::var(runtimed::workstation::CLOUD_TOKEN_ENV)
+                .ok()
+                .map(|t| t.trim().to_string())
+                .filter(|t| !t.is_empty())
+                .ok_or_else(|| {
+                    let msg = format!(
+                        "workstation credential not found; set {} (never passed on argv)",
+                        runtimed::workstation::CLOUD_TOKEN_ENV
+                    );
+                    eprintln!("[workstation-agent] {msg}");
+                    anyhow::anyhow!(msg)
+                })?;
+            let hostname = runt_workspace::machine_hostname();
+            let workstation_id =
+                workstation_id.unwrap_or_else(|| runt_workspace::stable_workstation_id(&hostname));
+            let display_name = display_name.unwrap_or(hostname);
+            let working_dir = match working_dir {
+                Some(dir) => dir,
+                None => std::env::current_dir()
+                    .map_err(|e| anyhow::anyhow!("resolve current directory: {e}"))?,
+            };
+            let python_path = match python_path {
+                Some(path) => path,
+                None => runtimed::workstation::resolve_python_on_path(
+                    std::env::var("PATH").ok().as_deref(),
+                )
+                .ok_or_else(|| {
+                    let msg = "no python3 or python found on PATH; pass --python-path";
+                    eprintln!("[workstation-agent] {msg}");
+                    anyhow::anyhow!(msg)
+                })?,
+            };
+            let options = runtimed::workstation::WorkstationAgentOptions {
+                cloud_url,
+                workstation_id,
+                display_name,
+                working_dir,
+                python_path,
+                poll_interval: std::time::Duration::from_millis(poll_ms),
+                heartbeat_interval: std::time::Duration::from_millis(heartbeat_ms),
+                agent_root: runt_workspace::daemon_base_dir().join("workstation-agent"),
+            };
+            runtimed::workstation::run_workstation_agent(options, token)
+                .await
+                .map_err(|e| {
+                    eprintln!("[workstation-agent] Fatal: {}", e);
+                    e
+                })
         }
         Some(Commands::WarmEnv) => {
             runtimed::warm_env::run().await;

--- a/crates/runtimed/src/output_blob_publisher.rs
+++ b/crates/runtimed/src/output_blob_publisher.rs
@@ -230,7 +230,10 @@ fn apply_auth_headers(
     auth: &CloudAuth,
 ) -> reqwest::RequestBuilder {
     match auth {
-        CloudAuth::OidcBearer { token } => request.bearer_auth(token),
+        // Workstation credentials share OIDC's wire shape (plain bearer).
+        CloudAuth::OidcBearer { token } | CloudAuth::WorkstationCredential { token } => {
+            request.bearer_auth(token)
+        }
         CloudAuth::AnacondaApiKey { token } => request
             .bearer_auth(token)
             .header("X-Notebook-Cloud-Auth-Provider", "anaconda-api-key"),

--- a/crates/runtimed/src/workstation/agent_loop.rs
+++ b/crates/runtimed/src/workstation/agent_loop.rs
@@ -1,0 +1,1339 @@
+//! `runtimed workstation-agent` — the long-running workstation service loop.
+//!
+//! Rust port of `apps/notebook-cloud/scripts/hosted-workstation-agent.mjs`:
+//! registers/heartbeats this machine against the hosted workstation surface
+//! (`POST /api/workstations`), polls the attach-job queue
+//! (`GET /api/workstations/{id}/attach-jobs`), and serves each pending job by
+//! spawning a `runtimed cloud-runtime-agent` runtime peer (the agent *is*
+//! `runtimed`, so it spawns `std::env::current_exe()`).
+//!
+//! Lifecycle per job: `pending` → PATCH `accepted` → spawn runtime peer →
+//! PATCH `running` once the peer logs [`READINESS_LINE`] → PATCH
+//! `completed`/`failed` on exit. The peer's stdout/stderr go to a per-job log
+//! file (not a pipe) so an orphaned peer can never block on a dead reader, and
+//! a restarted agent can adopt it: the agent writes a pid file per job and on
+//! restart re-attaches to `accepted`/`running` jobs whose pid is still alive,
+//! failing the ones whose peer is gone (the server's stale-job sweep is the
+//! backstop for anything this misses).
+//!
+//! Security: the workstation credential is read from [`CLOUD_TOKEN_ENV`]
+//! (`RUNT_CLOUD_TOKEN`) and forwarded to runtime peers through the
+//! environment, never argv, so it cannot leak into `ps` output.
+//!
+//! Concurrency: one owned-state loop, mirroring the single-threaded `.mjs`
+//! agent — no shared mutexes, so nothing can hold a lock across an await.
+
+use std::collections::HashMap;
+use std::path::{Path, PathBuf};
+use std::time::{Duration, Instant};
+
+use anyhow::{Context, Result};
+use serde::Deserialize;
+use serde_json::{json, Value};
+use tracing::{error, info, warn};
+
+pub use super::cloud_agent_cli::CLOUD_TOKEN_ENV;
+
+/// Line the runtime peer prints when its kernel-facing infrastructure is up;
+/// the agent promotes the attach job to `running` when this appears in the
+/// peer's log. Must match `run_cloud_runtime_agent`'s startup logging (the
+/// `.mjs` agent keys on the same string).
+pub const READINESS_LINE: &str = "Infrastructure ready, entering main loop";
+
+/// Default attach-job poll interval (mirrors the `.mjs` agent).
+pub const DEFAULT_POLL_MS: u64 = 2_000;
+/// Default registration-heartbeat interval (mirrors the `.mjs` agent).
+pub const DEFAULT_HEARTBEAT_MS: u64 = 20_000;
+
+/// Cooldown applied to 429/503 responses without a usable `Retry-After`.
+const DEFAULT_RETRY_AFTER_MS: u64 = 60_000;
+/// Upper bound for rate-limit cooldowns (15 minutes, like the `.mjs` agent).
+const MAX_RETRY_AFTER_MS: u64 = 15 * 60_000;
+/// How often active children are checked for exit/readiness between polls
+/// (the `.mjs` agent's `readyPoll` interval).
+const CHILD_TICK_MS: u64 = 250;
+
+/// Configuration for [`run_workstation_agent`]. All fields are non-secret;
+/// the credential travels separately.
+#[derive(Debug, Clone)]
+pub struct WorkstationAgentOptions {
+    /// Base URL of the notebook cloud (e.g. `https://app.runt.run`).
+    pub cloud_url: String,
+    /// Stable workstation id presented to the cloud (`ws-<hostname slug>`).
+    pub workstation_id: String,
+    /// Human-readable workstation name for the workstation panel.
+    pub display_name: String,
+    /// Default working directory for runtime peers (jobs may override).
+    pub working_dir: PathBuf,
+    /// Python interpreter used for launch-on-attach kernels.
+    pub python_path: PathBuf,
+    /// How often to poll the attach-job queue.
+    pub poll_interval: Duration,
+    /// How often to re-register (heartbeat) and re-patch active job status.
+    pub heartbeat_interval: Duration,
+    /// Root directory for per-job state (logs, pid files, blob roots).
+    pub agent_root: PathBuf,
+}
+
+/// One attach job from `GET /api/workstations/{id}/attach-jobs`.
+#[derive(Debug, Clone, Deserialize)]
+pub struct AttachJob {
+    pub job_id: String,
+    pub notebook_id: String,
+    #[serde(default)]
+    pub status: String,
+    #[serde(default)]
+    pub working_directory: Option<String>,
+    #[serde(default)]
+    pub notebook_path: Option<String>,
+}
+
+/// Filesystem + argv plan for spawning one runtime peer. Pure data so the
+/// argv/env contract is unit-testable without spawning anything.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct AttachJobSpawnPlan {
+    /// `runtimed` argv (subcommand + flags). Never contains the credential.
+    pub args: Vec<String>,
+    /// Working directory for the peer (job override or the workstation cwd).
+    pub cwd: PathBuf,
+    /// Per-job state directory: `<agent_root>/<safe job id>`.
+    pub run_root: PathBuf,
+    /// Blob store root handed to the peer.
+    pub blob_root: PathBuf,
+    /// Log file receiving the peer's stdout+stderr.
+    pub log_path: PathBuf,
+    /// Pid file enabling adoption after an agent restart.
+    pub pid_path: PathBuf,
+}
+
+/// Build the registration/heartbeat payload for `POST /api/workstations`.
+/// Field set mirrors `buildWorkstationRegistrationPayload` in
+/// `hosted-workstation-agent-core.mjs`; `cpu_count`/`memory_bytes` are
+/// omitted (the route treats them as optional) where the platform cannot
+/// report them.
+pub fn registration_payload(
+    workstation_id: &str,
+    display_name: &str,
+    working_directory: &str,
+    python_path: &str,
+    cpu_count: Option<u64>,
+    memory_bytes: Option<u64>,
+) -> Value {
+    let mut payload = json!({
+        "workstation_id": workstation_id,
+        "display_name": display_name,
+        "provider": "runtime_peer",
+        "default_environment_label": "Current Python",
+        "environment_policy": "current_python",
+        "working_directory": working_directory,
+        "capabilities": {
+            "launch_current_python": true,
+        },
+        "runtime": {
+            "binary": "runtimed",
+            "python_path": python_path,
+        },
+    });
+    if let Some(cpu) = cpu_count {
+        payload["cpu_count"] = cpu.into();
+    }
+    if let Some(mem) = memory_bytes {
+        payload["memory_bytes"] = mem.into();
+    }
+    payload
+}
+
+/// Logical CPU count for the registration payload.
+pub fn cpu_count() -> Option<u64> {
+    std::thread::available_parallelism()
+        .ok()
+        .map(|n| n.get() as u64)
+}
+
+/// Total physical memory, when the platform exposes it cheaply
+/// (Linux `/proc/meminfo`; elsewhere the field is omitted).
+#[cfg(target_os = "linux")]
+pub fn total_memory_bytes() -> Option<u64> {
+    parse_meminfo_total_bytes(&std::fs::read_to_string("/proc/meminfo").ok()?)
+}
+
+/// Total physical memory, when the platform exposes it cheaply
+/// (Linux `/proc/meminfo`; elsewhere the field is omitted).
+#[cfg(not(target_os = "linux"))]
+pub fn total_memory_bytes() -> Option<u64> {
+    None
+}
+
+/// Parse `MemTotal: <n> kB` out of `/proc/meminfo` content.
+// Only the linux total_memory_bytes calls this; left un-cfg'd so the pure
+// parser stays compiled and unit-tested on every host.
+#[cfg_attr(not(target_os = "linux"), allow(dead_code))]
+fn parse_meminfo_total_bytes(meminfo: &str) -> Option<u64> {
+    let line = meminfo.lines().find(|line| line.starts_with("MemTotal:"))?;
+    let kb: u64 = line.split_whitespace().nth(1)?.parse().ok()?;
+    Some(kb * 1024)
+}
+
+/// Resolve the default Python interpreter: first `python3`, then `python`,
+/// searched across `path_var` (the `PATH` environment value).
+pub fn resolve_python_on_path(path_var: Option<&str>) -> Option<PathBuf> {
+    let path_var = path_var?;
+    let names: &[&str] = if cfg!(windows) {
+        &["python3.exe", "python.exe", "python3", "python"]
+    } else {
+        &["python3", "python"]
+    };
+    for name in names {
+        for dir in std::env::split_paths(path_var) {
+            if dir.as_os_str().is_empty() {
+                continue;
+            }
+            let candidate = dir.join(name);
+            if is_executable_file(&candidate) {
+                return Some(candidate);
+            }
+        }
+    }
+    None
+}
+
+#[cfg(unix)]
+fn is_executable_file(path: &Path) -> bool {
+    use std::os::unix::fs::PermissionsExt;
+    match std::fs::metadata(path) {
+        Ok(meta) => meta.is_file() && meta.permissions().mode() & 0o111 != 0,
+        Err(_) => false,
+    }
+}
+
+#[cfg(not(unix))]
+fn is_executable_file(path: &Path) -> bool {
+    path.is_file()
+}
+
+/// Build the spawn plan for one attach job. Mirrors `buildAttachJobSpawnPlan`
+/// in `hosted-workstation-agent-core.mjs`, with `--auth-kind workstation`
+/// because the agent holds a pairing-flow workstation credential.
+pub fn build_attach_job_spawn_plan(
+    job: &AttachJob,
+    opts: &WorkstationAgentOptions,
+) -> Result<AttachJobSpawnPlan> {
+    anyhow::ensure!(!job.job_id.is_empty(), "attach job missing id");
+    anyhow::ensure!(
+        !job.notebook_id.is_empty(),
+        "attach job {} missing notebook_id",
+        job.job_id
+    );
+
+    let run_root = opts
+        .agent_root
+        .join(runt_workspace::safe_path_part(&job.job_id));
+    let blob_root = run_root.join("blobs");
+    let log_path = run_root.join("runtime-peer.log");
+    let pid_path = run_root.join("runtime-peer.pid");
+    let cwd = job
+        .working_directory
+        .as_deref()
+        .map(PathBuf::from)
+        .unwrap_or_else(|| opts.working_dir.clone());
+
+    let mut args = vec![
+        "cloud-runtime-agent".to_string(),
+        "--auth-kind".to_string(),
+        "workstation".to_string(),
+        "--cloud-url".to_string(),
+        opts.cloud_url.clone(),
+        "--notebook-id".to_string(),
+        job.notebook_id.clone(),
+        "--scope".to_string(),
+        "runtime_peer".to_string(),
+        "--python-path".to_string(),
+        opts.python_path.to_string_lossy().into_owned(),
+        "--blob-root".to_string(),
+        blob_root.to_string_lossy().into_owned(),
+        "--working-dir".to_string(),
+        cwd.to_string_lossy().into_owned(),
+        "--workstation-id".to_string(),
+        opts.workstation_id.clone(),
+        "--workstation-display-name".to_string(),
+        opts.display_name.clone(),
+    ];
+    if let Some(notebook_path) = job.notebook_path.as_deref().filter(|path| !path.is_empty()) {
+        args.push("--notebook-path".to_string());
+        args.push(notebook_path.to_string());
+    }
+
+    Ok(AttachJobSpawnPlan {
+        args,
+        cwd,
+        run_root,
+        blob_root,
+        log_path,
+        pid_path,
+    })
+}
+
+/// Environment for the runtime peer: a minimal allowlist from the parent
+/// environment plus the credential under [`CLOUD_TOKEN_ENV`]. Mirrors
+/// `buildRuntimeAgentEnv` in `hosted-workstation-agent-core.mjs` — the
+/// credential never appears in argv, and no other secret-bearing parent
+/// variables leak through.
+pub fn build_runtime_agent_env(
+    parent: impl Fn(&str) -> Option<String>,
+    token: &str,
+) -> Vec<(String, String)> {
+    let mut env = Vec::new();
+    for key in [
+        "HOME",
+        "PATH",
+        "LANG",
+        "LC_ALL",
+        "SSL_CERT_FILE",
+        "SSL_CERT_DIR",
+        "RUST_BACKTRACE",
+    ] {
+        if let Some(value) = parent(key).filter(|value| !value.is_empty()) {
+            env.push((key.to_string(), value));
+        }
+    }
+    let rust_log = parent("RUST_LOG")
+        .filter(|value| !value.is_empty())
+        .unwrap_or_else(|| "info".to_string());
+    env.push(("RUST_LOG".to_string(), rust_log));
+    env.push((CLOUD_TOKEN_ENV.to_string(), token.to_string()));
+    env
+}
+
+/// Does the peer's accumulated log output indicate it reached its main loop?
+pub fn log_indicates_ready(log_content: &str) -> bool {
+    log_content.contains(READINESS_LINE)
+}
+
+/// Extract jobs from the attach-jobs response body: a bare array, `jobs`,
+/// or `attach_jobs` (mirrors `normalizeJobs` in the `.mjs` agent).
+pub fn normalize_jobs(body: &Value) -> Vec<AttachJob> {
+    let list = if body.is_array() {
+        Some(body)
+    } else {
+        body.get("jobs")
+            .filter(|v| v.is_array())
+            .or_else(|| body.get("attach_jobs").filter(|v| v.is_array()))
+    };
+    let Some(Value::Array(items)) = list else {
+        return Vec::new();
+    };
+    items
+        .iter()
+        .filter_map(|item| serde_json::from_value(item.clone()).ok())
+        .collect()
+}
+
+/// Cooldown hint from a response: nonzero only for 429/503. `Retry-After`
+/// may be delta-seconds or an HTTP date; absent/unparseable falls back to
+/// [`DEFAULT_RETRY_AFTER_MS`]. Mirrors `retryAfterMs` in the `.mjs` agent.
+pub fn retry_after_ms(status: u16, retry_after_header: Option<&str>) -> u64 {
+    if status != 429 && status != 503 {
+        return 0;
+    }
+    let Some(header) = retry_after_header.map(str::trim).filter(|h| !h.is_empty()) else {
+        return DEFAULT_RETRY_AFTER_MS;
+    };
+    if let Ok(seconds) = header.parse::<f64>() {
+        if seconds.is_finite() && seconds >= 0.0 {
+            return (((seconds * 1000.0).ceil()) as u64).max(1_000);
+        }
+        return DEFAULT_RETRY_AFTER_MS;
+    }
+    if let Ok(date) = chrono::DateTime::parse_from_rfc2822(header) {
+        let delta = date.timestamp_millis() - chrono::Utc::now().timestamp_millis();
+        return delta.max(1_000) as u64;
+    }
+    DEFAULT_RETRY_AFTER_MS
+}
+
+/// Exponential cooldown for repeated retryable failures, capped at
+/// [`MAX_RETRY_AFTER_MS`] with up to 20% jitter. `jitter_unit` is a value in
+/// `[0, 1)` (injected so tests are deterministic). Mirrors `retryCooldownMs`
+/// in the `.mjs` agent.
+pub fn retry_cooldown_ms(retry_after_ms: u64, failure_count: u32, jitter_unit: f64) -> u64 {
+    let retry_after = retry_after_ms.max(1_000);
+    let failures = failure_count.max(1);
+    let max_delay = retry_after.max(MAX_RETRY_AFTER_MS);
+    let exponent = (failures - 1).min(6);
+    let base_delay = retry_after.saturating_mul(1u64 << exponent).min(max_delay);
+    let jitter = (base_delay as f64 * 0.2 * jitter_unit.clamp(0.0, 1.0)).max(0.0);
+    base_delay
+        .saturating_add(jitter.ceil() as u64)
+        .min(max_delay)
+}
+
+/// Pseudo-random unit value for cooldown jitter. `RandomState` keys are
+/// random per construction; this is jitter, not cryptography.
+fn jitter_unit() -> f64 {
+    use std::collections::hash_map::RandomState;
+    use std::hash::{BuildHasher, Hasher};
+    let hash = RandomState::new().build_hasher().finish();
+    (hash % 1_000_000) as f64 / 1_000_000.0
+}
+
+/// Percent-encode a value for use as one URL path segment
+/// (`encodeURIComponent` for the characters that matter in ids).
+fn encode_path_segment(value: &str) -> String {
+    let mut out = String::with_capacity(value.len());
+    for byte in value.bytes() {
+        match byte {
+            b'A'..=b'Z' | b'a'..=b'z' | b'0'..=b'9' | b'-' | b'_' | b'.' | b'~' => {
+                out.push(byte as char);
+            }
+            _ => {
+                out.push('%');
+                out.push_str(&format!("{byte:02X}"));
+            }
+        }
+    }
+    out
+}
+
+/// Parse an HTTP response body the way the `.mjs` agent does: empty → `{}`,
+/// JSON → the value, anything else → `{"error": <first 500 chars>}` so HTML
+/// error pages stay diagnosable.
+pub fn parse_response_body(text: &str) -> Value {
+    if text.trim().is_empty() {
+        return json!({});
+    }
+    match serde_json::from_str(text) {
+        Ok(value) => value,
+        Err(_) => json!({ "error": text.chars().take(500).collect::<String>() }),
+    }
+}
+
+/// Error from one cloud call, carrying the rate-limit cooldown hint.
+#[derive(Debug)]
+pub struct AgentHttpError {
+    pub message: String,
+    pub retry_after_ms: u64,
+}
+
+impl AgentHttpError {
+    fn local(message: String) -> Self {
+        Self {
+            message,
+            retry_after_ms: 0,
+        }
+    }
+}
+
+impl std::fmt::Display for AgentHttpError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(&self.message)
+    }
+}
+
+impl std::error::Error for AgentHttpError {}
+
+/// Thin client for the three workstation-surface endpoints. All calls carry
+/// `Authorization: Bearer <workstation credential>`.
+struct CloudApi {
+    client: reqwest::Client,
+    base: String,
+    token: String,
+}
+
+impl CloudApi {
+    fn new(cloud_url: &str, token: String) -> Result<Self> {
+        let client = reqwest::Client::builder()
+            .timeout(Duration::from_secs(30))
+            .build()
+            .context("build HTTP client")?;
+        Ok(Self {
+            client,
+            base: cloud_url.trim_end_matches('/').to_string(),
+            token,
+        })
+    }
+
+    async fn register_workstation(&self, payload: &Value) -> Result<(), AgentHttpError> {
+        let url = format!("{}/api/workstations", self.base);
+        self.execute(
+            "register workstation",
+            self.client.post(&url).json(payload),
+            &[200, 201],
+        )
+        .await?;
+        Ok(())
+    }
+
+    async fn poll_attach_jobs(
+        &self,
+        workstation_id: &str,
+    ) -> Result<Vec<AttachJob>, AgentHttpError> {
+        let url = format!(
+            "{}/api/workstations/{}/attach-jobs",
+            self.base,
+            encode_path_segment(workstation_id)
+        );
+        let body = self
+            .execute("poll attach jobs", self.client.get(&url), &[200])
+            .await?;
+        Ok(normalize_jobs(&body))
+    }
+
+    async fn patch_attach_job(
+        &self,
+        workstation_id: &str,
+        job_id: &str,
+        status: &str,
+        error_message: Option<&str>,
+    ) -> Result<(), AgentHttpError> {
+        let url = format!(
+            "{}/api/workstations/{}/attach-jobs/{}",
+            self.base,
+            encode_path_segment(workstation_id),
+            encode_path_segment(job_id)
+        );
+        let mut payload = json!({ "status": status });
+        if let Some(message) = error_message {
+            payload["error_message"] = message.into();
+        }
+        self.execute(
+            &format!("patch attach job {job_id}"),
+            self.client.patch(&url).json(&payload),
+            &[200, 204],
+        )
+        .await?;
+        Ok(())
+    }
+
+    async fn execute(
+        &self,
+        label: &str,
+        request: reqwest::RequestBuilder,
+        expected_statuses: &[u16],
+    ) -> Result<Value, AgentHttpError> {
+        let response = request
+            .bearer_auth(&self.token)
+            .send()
+            .await
+            .map_err(|e| AgentHttpError::local(format!("{label} failed: {e}")))?;
+        let status = response.status().as_u16();
+        let retry_after_header = response
+            .headers()
+            .get("retry-after")
+            .and_then(|value| value.to_str().ok())
+            .map(str::to_string);
+        let text = response.text().await.unwrap_or_default();
+        let body = parse_response_body(&text);
+        if expected_statuses.contains(&status) {
+            return Ok(body);
+        }
+        let snippet: String = serde_json::to_string(&body)
+            .unwrap_or_default()
+            .chars()
+            .take(500)
+            .collect();
+        Err(AgentHttpError {
+            message: format!("{label} failed: HTTP {status} {snippet}"),
+            retry_after_ms: retry_after_ms(status, retry_after_header.as_deref()),
+        })
+    }
+}
+
+/// One job this agent is responsible for. `child` is `Some` for peers this
+/// process spawned and `None` for peers adopted after an agent restart
+/// (tracked by pid + log file instead).
+struct ActiveJob {
+    child: Option<tokio::process::Child>,
+    pid: Option<u32>,
+    log_path: PathBuf,
+    ready: bool,
+    status: &'static str,
+    last_status_patch_at: Instant,
+}
+
+enum JobTick {
+    None,
+    BecameReady,
+    Exited {
+        success: bool,
+        error_message: Option<String>,
+    },
+}
+
+/// Tracks per-step retryable failures and the shared cooldown window
+/// (port of the `.mjs` `runAgentStep` bookkeeping).
+#[derive(Default)]
+struct StepTracker {
+    failure_counts: HashMap<&'static str, u32>,
+    cooldown_until: Option<Instant>,
+}
+
+impl StepTracker {
+    fn cooldown_remaining(&mut self) -> Option<Duration> {
+        let until = self.cooldown_until?;
+        let now = Instant::now();
+        if until <= now {
+            self.cooldown_until = None;
+            return None;
+        }
+        Some(until - now)
+    }
+
+    /// `Ok(true)` means the step completed a cloud round-trip, which resets
+    /// its failure streak. Retryable errors (rate limits) extend the shared
+    /// cooldown with exponential backoff.
+    fn record(&mut self, step: &'static str, result: Result<bool, AgentHttpError>) {
+        match result {
+            Ok(made_cloud_request) => {
+                if made_cloud_request {
+                    self.failure_counts.remove(step);
+                }
+            }
+            Err(err) => {
+                if err.retry_after_ms > 0 {
+                    let count = self.failure_counts.entry(step).or_insert(0);
+                    *count += 1;
+                    let cooldown_ms = retry_cooldown_ms(err.retry_after_ms, *count, jitter_unit());
+                    let until = Instant::now() + Duration::from_millis(cooldown_ms);
+                    self.cooldown_until =
+                        Some(self.cooldown_until.map_or(until, |cur| cur.max(until)));
+                    warn!(
+                        "[workstation-agent] cooling down step={step} retry_after_ms={} cooldown_ms={cooldown_ms} retryable_failures={count}",
+                        err.retry_after_ms
+                    );
+                }
+                error!(
+                    "[workstation-agent] step failed step={step}: {}",
+                    err.message
+                );
+            }
+        }
+    }
+}
+
+/// Run the workstation agent loop until the process is terminated.
+pub async fn run_workstation_agent(opts: WorkstationAgentOptions, token: String) -> Result<()> {
+    let api = CloudApi::new(&opts.cloud_url, token.clone())?;
+    std::fs::create_dir_all(&opts.agent_root).with_context(|| {
+        format!(
+            "create workstation agent root {}",
+            opts.agent_root.display()
+        )
+    })?;
+
+    info!(
+        "[workstation-agent] starting cloud_url={} workstation_id={} display_name={:?} working_dir={} python_path={} poll_ms={} heartbeat_ms={} agent_root={}",
+        opts.cloud_url,
+        opts.workstation_id,
+        opts.display_name,
+        opts.working_dir.display(),
+        opts.python_path.display(),
+        opts.poll_interval.as_millis(),
+        opts.heartbeat_interval.as_millis(),
+        opts.agent_root.display(),
+    );
+
+    let mut active: HashMap<String, ActiveJob> = HashMap::new();
+    let mut last_heartbeat: Option<Instant> = None;
+    let mut tracker = StepTracker::default();
+
+    loop {
+        if let Some(remaining) = tracker.cooldown_remaining() {
+            tokio::time::sleep(remaining.min(opts.poll_interval)).await;
+            continue;
+        }
+
+        // Registration heartbeat.
+        if last_heartbeat.is_none_or(|at| at.elapsed() >= opts.heartbeat_interval) {
+            let result = heartbeat(&api, &opts).await;
+            if result.is_ok() {
+                last_heartbeat = Some(Instant::now());
+            }
+            tracker.record("heartbeat", result.map(|()| true));
+        }
+        if tracker.cooldown_remaining().is_some() {
+            continue;
+        }
+
+        // Accept/adopt attach jobs.
+        let result = poll_attach_jobs(&api, &opts, &token, &mut active).await;
+        tracker.record("poll_attach_jobs", result);
+
+        // Periodic status re-patch so the cloud sees active jobs as live.
+        let result = heartbeat_active_jobs(&api, &opts, &mut active).await;
+        tracker.record("heartbeat_active_jobs", result);
+
+        // Watch children at a finer tick than the poll interval so readiness
+        // and exits land promptly (the `.mjs` agent's 250ms readyPoll).
+        let deadline = Instant::now() + opts.poll_interval;
+        loop {
+            tick_active_jobs(&api, &opts, &mut active).await;
+            let now = Instant::now();
+            if now >= deadline {
+                break;
+            }
+            tokio::time::sleep(Duration::from_millis(CHILD_TICK_MS).min(deadline - now)).await;
+        }
+    }
+}
+
+async fn heartbeat(api: &CloudApi, opts: &WorkstationAgentOptions) -> Result<(), AgentHttpError> {
+    let payload = registration_payload(
+        &opts.workstation_id,
+        &opts.display_name,
+        &opts.working_dir.to_string_lossy(),
+        &opts.python_path.to_string_lossy(),
+        cpu_count(),
+        total_memory_bytes(),
+    );
+    api.register_workstation(&payload).await
+}
+
+async fn poll_attach_jobs(
+    api: &CloudApi,
+    opts: &WorkstationAgentOptions,
+    token: &str,
+    active: &mut HashMap<String, ActiveJob>,
+) -> Result<bool, AgentHttpError> {
+    let jobs = api.poll_attach_jobs(&opts.workstation_id).await?;
+    for job in jobs {
+        if active.contains_key(&job.job_id) {
+            continue;
+        }
+        if job.status == "pending" {
+            start_attach_job(api, opts, token, active, &job).await?;
+        } else {
+            reconcile_active_attach_job(api, opts, active, &job).await?;
+        }
+    }
+    Ok(true)
+}
+
+async fn start_attach_job(
+    api: &CloudApi,
+    opts: &WorkstationAgentOptions,
+    token: &str,
+    active: &mut HashMap<String, ActiveJob>,
+    job: &AttachJob,
+) -> Result<(), AgentHttpError> {
+    let plan = build_attach_job_spawn_plan(job, opts)
+        .map_err(|e| AgentHttpError::local(format!("plan attach job: {e}")))?;
+    std::fs::create_dir_all(&plan.blob_root).map_err(|e| {
+        AgentHttpError::local(format!(
+            "create blob root {}: {e}",
+            plan.blob_root.display()
+        ))
+    })?;
+
+    api.patch_attach_job(&opts.workstation_id, &job.job_id, "accepted", None)
+        .await?;
+
+    match spawn_runtime_peer(&plan, token) {
+        Ok((child, pid)) => {
+            if let Some(pid) = pid {
+                write_pid_file(&plan.pid_path, pid);
+            }
+            info!(
+                "[workstation-agent] attach job spawned job_id={} notebook_id={} pid={:?} log={}",
+                job.job_id,
+                job.notebook_id,
+                pid,
+                plan.log_path.display()
+            );
+            active.insert(
+                job.job_id.clone(),
+                ActiveJob {
+                    child: Some(child),
+                    pid,
+                    log_path: plan.log_path,
+                    ready: false,
+                    status: "accepted",
+                    last_status_patch_at: Instant::now(),
+                },
+            );
+        }
+        Err(e) => {
+            error!(
+                "[workstation-agent] attach job spawn failed job_id={}: {e}",
+                job.job_id
+            );
+            if let Err(patch_err) = api
+                .patch_attach_job(
+                    &opts.workstation_id,
+                    &job.job_id,
+                    "failed",
+                    Some(&format!("Failed to spawn runtime peer: {e}")),
+                )
+                .await
+            {
+                error!(
+                    "[workstation-agent] spawn-failure patch failed job_id={}: {}",
+                    job.job_id, patch_err.message
+                );
+            }
+        }
+    }
+    Ok(())
+}
+
+/// A job the cloud believes is `accepted`/`running` but this agent does not
+/// own — typically after an agent restart. Adopt it when its recorded pid is
+/// still alive; otherwise report the peer gone (the `.mjs` recovery path).
+async fn reconcile_active_attach_job(
+    api: &CloudApi,
+    opts: &WorkstationAgentOptions,
+    active: &mut HashMap<String, ActiveJob>,
+    job: &AttachJob,
+) -> Result<(), AgentHttpError> {
+    let plan = build_attach_job_spawn_plan(job, opts)
+        .map_err(|e| AgentHttpError::local(format!("plan attach job: {e}")))?;
+    let pid = read_pid_file(&plan.pid_path);
+    if let Some(pid) = pid.filter(|&pid| process_exists(pid)) {
+        let ready = job.status == "running";
+        info!(
+            "[workstation-agent] attach job adopted job_id={} notebook_id={} pid={pid} status={}",
+            job.job_id,
+            job.notebook_id,
+            if ready { "running" } else { "accepted" }
+        );
+        // Backdate the patch clock so the next heartbeat re-patches the
+        // status promptly (`lastStatusPatchAt: 0` in the `.mjs` agent).
+        let backdated = Instant::now()
+            .checked_sub(opts.heartbeat_interval)
+            .unwrap_or_else(Instant::now);
+        active.insert(
+            job.job_id.clone(),
+            ActiveJob {
+                child: None,
+                pid: Some(pid),
+                log_path: plan.log_path,
+                ready,
+                status: if ready { "running" } else { "accepted" },
+                last_status_patch_at: backdated,
+            },
+        );
+        return Ok(());
+    }
+
+    warn!(
+        "[workstation-agent] attach job recovery failed job_id={} notebook_id={} status={} pid_path={}",
+        job.job_id,
+        job.notebook_id,
+        job.status,
+        plan.pid_path.display()
+    );
+    api.patch_attach_job(
+        &opts.workstation_id,
+        &job.job_id,
+        "failed",
+        Some(&format!(
+            "Runtime peer for {} attach job was not running after workstation agent restart",
+            job.status
+        )),
+    )
+    .await
+}
+
+async fn heartbeat_active_jobs(
+    api: &CloudApi,
+    opts: &WorkstationAgentOptions,
+    active: &mut HashMap<String, ActiveJob>,
+) -> Result<bool, AgentHttpError> {
+    let due: Vec<String> = active
+        .iter()
+        .filter(|(_, job)| job.last_status_patch_at.elapsed() >= opts.heartbeat_interval)
+        .map(|(job_id, _)| job_id.clone())
+        .collect();
+    for job_id in &due {
+        let status = match active.get(job_id) {
+            Some(job) => job.status,
+            None => continue,
+        };
+        api.patch_attach_job(&opts.workstation_id, job_id, status, None)
+            .await?;
+        if let Some(job) = active.get_mut(job_id) {
+            job.last_status_patch_at = Instant::now();
+        }
+    }
+    Ok(!due.is_empty())
+}
+
+async fn tick_active_jobs(
+    api: &CloudApi,
+    opts: &WorkstationAgentOptions,
+    active: &mut HashMap<String, ActiveJob>,
+) {
+    let job_ids: Vec<String> = active.keys().cloned().collect();
+    for job_id in job_ids {
+        let outcome = match active.get_mut(&job_id) {
+            Some(job) => poll_job_once(&job_id, job),
+            None => continue,
+        };
+        match outcome {
+            JobTick::None => {}
+            JobTick::BecameReady => {
+                // Mark ready before patching: if the patch fails, the periodic
+                // status heartbeat re-sends "running" (same healing path as
+                // the `.mjs` agent).
+                if let Some(job) = active.get_mut(&job_id) {
+                    job.ready = true;
+                    job.status = "running";
+                    job.last_status_patch_at = Instant::now();
+                }
+                info!("[workstation-agent] attach job ready job_id={job_id}");
+                if let Err(e) = api
+                    .patch_attach_job(&opts.workstation_id, &job_id, "running", None)
+                    .await
+                {
+                    error!(
+                        "[workstation-agent] ready patch failed job_id={job_id}: {}",
+                        e.message
+                    );
+                }
+            }
+            JobTick::Exited {
+                success,
+                error_message,
+            } => {
+                active.remove(&job_id);
+                info!(
+                    "[workstation-agent] attach job exited job_id={job_id} success={success} error={:?}",
+                    error_message
+                );
+                let status = if success { "completed" } else { "failed" };
+                if let Err(e) = api
+                    .patch_attach_job(
+                        &opts.workstation_id,
+                        &job_id,
+                        status,
+                        error_message.as_deref(),
+                    )
+                    .await
+                {
+                    // Job already dropped from the active set; the server's
+                    // stale-job sweep finishes it if this patch never lands.
+                    error!(
+                        "[workstation-agent] exit patch failed job_id={job_id}: {}",
+                        e.message
+                    );
+                }
+            }
+        }
+    }
+}
+
+fn poll_job_once(job_id: &str, job: &mut ActiveJob) -> JobTick {
+    if let Some(child) = job.child.as_mut() {
+        match child.try_wait() {
+            Ok(Some(status)) => {
+                return if status.success() {
+                    JobTick::Exited {
+                        success: true,
+                        error_message: None,
+                    }
+                } else {
+                    JobTick::Exited {
+                        success: false,
+                        error_message: Some(exit_status_message(&status)),
+                    }
+                };
+            }
+            Ok(None) => {}
+            Err(e) => {
+                warn!("[workstation-agent] try_wait failed job_id={job_id}: {e}");
+            }
+        }
+    } else if let Some(pid) = job.pid {
+        if !process_exists(pid) {
+            let message = if job.ready {
+                "Runtime peer exited before the workstation agent could observe it"
+            } else {
+                "Runtime peer exited before completing workstation agent recovery"
+            };
+            return JobTick::Exited {
+                success: false,
+                error_message: Some(message.to_string()),
+            };
+        }
+    }
+
+    if !job.ready {
+        let log_content = std::fs::read_to_string(&job.log_path).unwrap_or_default();
+        if log_indicates_ready(&log_content) {
+            return JobTick::BecameReady;
+        }
+    }
+    JobTick::None
+}
+
+/// Port of the `.mjs` exit message:
+/// `Runtime peer exited with code=<code>, signal=<signal>`.
+fn exit_status_message(status: &std::process::ExitStatus) -> String {
+    let code = status
+        .code()
+        .map(|code| code.to_string())
+        .unwrap_or_default();
+    #[cfg(unix)]
+    let signal = {
+        use std::os::unix::process::ExitStatusExt;
+        status
+            .signal()
+            .map(|signal| signal.to_string())
+            .unwrap_or_default()
+    };
+    #[cfg(not(unix))]
+    let signal = String::new();
+    format!("Runtime peer exited with code={code}, signal={signal}")
+}
+
+fn spawn_runtime_peer(
+    plan: &AttachJobSpawnPlan,
+    token: &str,
+) -> Result<(tokio::process::Child, Option<u32>)> {
+    // The workstation agent IS runtimed: spawn our own binary as the peer.
+    let exe = std::env::current_exe().context("resolve current runtimed binary")?;
+    // The peer writes straight to the log file (no pipe): an orphaned peer
+    // can never block on a dead pipe reader, and a restarted agent can read
+    // the same file to adopt the job.
+    let log = std::fs::OpenOptions::new()
+        .create(true)
+        .append(true)
+        .open(&plan.log_path)
+        .with_context(|| format!("open runtime peer log {}", plan.log_path.display()))?;
+    let log_for_stderr = log
+        .try_clone()
+        .context("clone runtime peer log handle for stderr")?;
+
+    let mut command = tokio::process::Command::new(exe);
+    command
+        .args(&plan.args)
+        .current_dir(&plan.cwd)
+        .env_clear()
+        .envs(build_runtime_agent_env(
+            |key| std::env::var(key).ok(),
+            token,
+        ))
+        .stdin(std::process::Stdio::null())
+        .stdout(std::process::Stdio::from(log))
+        .stderr(std::process::Stdio::from(log_for_stderr));
+    // Default kill_on_drop=false: the peer (and its kernel) outlives an agent
+    // crash/restart, which is what makes adoption possible.
+    let child = command
+        .spawn()
+        .with_context(|| format!("spawn runtime peer in {}", plan.cwd.display()))?;
+    let pid = child.id();
+    Ok((child, pid))
+}
+
+fn write_pid_file(path: &Path, pid: u32) {
+    use std::io::Write;
+    let mut options = std::fs::OpenOptions::new();
+    options.write(true).create(true).truncate(true);
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::OpenOptionsExt;
+        options.mode(0o600);
+    }
+    match options.open(path) {
+        Ok(mut file) => {
+            if let Err(e) = writeln!(file, "{pid}") {
+                warn!(
+                    "[workstation-agent] pid file write failed path={}: {e}",
+                    path.display()
+                );
+            }
+        }
+        Err(e) => {
+            warn!(
+                "[workstation-agent] pid file open failed path={}: {e}",
+                path.display()
+            );
+        }
+    }
+}
+
+fn read_pid_file(path: &Path) -> Option<u32> {
+    let raw = std::fs::read_to_string(path).ok()?;
+    let pid: u32 = raw.trim().parse().ok()?;
+    (pid > 0).then_some(pid)
+}
+
+#[cfg(unix)]
+fn process_exists(pid: u32) -> bool {
+    let Ok(pid) = i32::try_from(pid) else {
+        return false;
+    };
+    // Signal 0: existence check without delivering anything.
+    nix::sys::signal::kill(nix::unistd::Pid::from_raw(pid), None).is_ok()
+}
+
+#[cfg(not(unix))]
+fn process_exists(_pid: u32) -> bool {
+    // No cheap existence probe on this platform; adopted jobs are treated as
+    // gone and re-dispatched (the server sweep also covers them).
+    false
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn options() -> WorkstationAgentOptions {
+        WorkstationAgentOptions {
+            cloud_url: "https://preview.runt.run".to_string(),
+            workstation_id: "ws-lab2".to_string(),
+            display_name: "lab2 workstation".to_string(),
+            working_dir: PathBuf::from("/home/ubuntu/project"),
+            python_path: PathBuf::from("/opt/k/bin/python"),
+            poll_interval: Duration::from_millis(DEFAULT_POLL_MS),
+            heartbeat_interval: Duration::from_millis(DEFAULT_HEARTBEAT_MS),
+            agent_root: PathBuf::from("/tmp/agent"),
+        }
+    }
+
+    fn job(job_id: &str, notebook_id: &str) -> AttachJob {
+        AttachJob {
+            job_id: job_id.to_string(),
+            notebook_id: notebook_id.to_string(),
+            status: "pending".to_string(),
+            working_directory: None,
+            notebook_path: None,
+        }
+    }
+
+    /// (c) Heartbeat payload field set matches the `.mjs` agent exactly.
+    #[test]
+    fn registration_payload_matches_mjs_field_set() {
+        let payload = registration_payload(
+            "ws-lab2",
+            "lab2 workstation",
+            "/home/ubuntu/project",
+            "/opt/k/bin/python",
+            Some(8),
+            Some(16_000_000_000),
+        );
+        assert_eq!(
+            payload,
+            serde_json::json!({
+                "workstation_id": "ws-lab2",
+                "display_name": "lab2 workstation",
+                "provider": "runtime_peer",
+                "default_environment_label": "Current Python",
+                "environment_policy": "current_python",
+                "working_directory": "/home/ubuntu/project",
+                "cpu_count": 8,
+                "memory_bytes": 16_000_000_000u64,
+                "capabilities": {
+                    "launch_current_python": true,
+                },
+                "runtime": {
+                    "binary": "runtimed",
+                    "python_path": "/opt/k/bin/python",
+                },
+            })
+        );
+    }
+
+    #[test]
+    fn registration_payload_omits_unknown_hardware_facts() {
+        let payload = registration_payload("ws", "ws", "/w", "/usr/bin/python3", None, None);
+        assert!(payload.get("cpu_count").is_none());
+        assert!(payload.get("memory_bytes").is_none());
+    }
+
+    /// (d) Attach-job → spawn argv mapping mirrors the `.mjs` plan, with the
+    /// workstation auth kind. The credential never appears in argv.
+    #[test]
+    fn spawn_plan_matches_mjs_contract() {
+        let plan = build_attach_job_spawn_plan(&job("Job 123", "nb-1"), &options()).unwrap();
+
+        assert_eq!(plan.cwd, PathBuf::from("/home/ubuntu/project"));
+        assert_eq!(plan.run_root, PathBuf::from("/tmp/agent/job-123"));
+        assert_eq!(plan.blob_root, PathBuf::from("/tmp/agent/job-123/blobs"));
+        assert_eq!(
+            plan.log_path,
+            PathBuf::from("/tmp/agent/job-123/runtime-peer.log")
+        );
+        assert_eq!(
+            plan.pid_path,
+            PathBuf::from("/tmp/agent/job-123/runtime-peer.pid")
+        );
+        assert_eq!(
+            plan.args,
+            vec![
+                "cloud-runtime-agent",
+                "--auth-kind",
+                "workstation",
+                "--cloud-url",
+                "https://preview.runt.run",
+                "--notebook-id",
+                "nb-1",
+                "--scope",
+                "runtime_peer",
+                "--python-path",
+                "/opt/k/bin/python",
+                "--blob-root",
+                "/tmp/agent/job-123/blobs",
+                "--working-dir",
+                "/home/ubuntu/project",
+                "--workstation-id",
+                "ws-lab2",
+                "--workstation-display-name",
+                "lab2 workstation",
+            ]
+        );
+    }
+
+    #[test]
+    fn spawn_plan_honors_job_cwd_and_notebook_path_overrides() {
+        let mut overridden = job("job-2", "nb-2");
+        overridden.working_directory = Some("/srv/notebook-project".to_string());
+        overridden.notebook_path = Some("/srv/notebook-project/report.ipynb".to_string());
+        let plan = build_attach_job_spawn_plan(&overridden, &options()).unwrap();
+
+        assert_eq!(plan.cwd, PathBuf::from("/srv/notebook-project"));
+        assert_eq!(
+            &plan.args[plan.args.len() - 2..],
+            ["--notebook-path", "/srv/notebook-project/report.ipynb"]
+        );
+    }
+
+    #[test]
+    fn spawn_plan_rejects_jobs_missing_ids() {
+        assert!(build_attach_job_spawn_plan(&job("", "nb"), &options()).is_err());
+        assert!(build_attach_job_spawn_plan(&job("job", ""), &options()).is_err());
+    }
+
+    /// (d) The credential rides only the child environment, never argv, and
+    /// secret-bearing parent variables do not leak through.
+    #[test]
+    fn runtime_agent_env_passes_token_only_through_env() {
+        let parent: HashMap<&str, &str> = [
+            ("HOME", "/home/ubuntu"),
+            ("PATH", "/usr/bin"),
+            ("NTERACT_API_KEY", "caller-secret"),
+            ("NOTEBOOK_CLOUD_PUBLISH_BEARER_TOKEN", "fallback-secret"),
+        ]
+        .into_iter()
+        .collect();
+        let env = build_runtime_agent_env(
+            |key| parent.get(key).map(|v| v.to_string()),
+            "runtime-peer-secret",
+        );
+        let env: HashMap<String, String> = env.into_iter().collect();
+
+        assert_eq!(
+            env.get(CLOUD_TOKEN_ENV).map(String::as_str),
+            Some("runtime-peer-secret")
+        );
+        assert!(!env.contains_key("NTERACT_API_KEY"));
+        assert!(!env.contains_key("NOTEBOOK_CLOUD_PUBLISH_BEARER_TOKEN"));
+        assert_eq!(env.get("HOME").map(String::as_str), Some("/home/ubuntu"));
+        assert_eq!(env.get("PATH").map(String::as_str), Some("/usr/bin"));
+        assert_eq!(env.get("RUST_LOG").map(String::as_str), Some("info"));
+
+        // And the argv side of the same contract: no token anywhere.
+        let plan = build_attach_job_spawn_plan(&job("job-x", "nb-x"), &options()).unwrap();
+        assert!(!plan
+            .args
+            .iter()
+            .any(|arg| arg.contains("runtime-peer-secret")));
+    }
+
+    /// (e) Readiness-line detection.
+    #[test]
+    fn readiness_line_detection() {
+        assert!(!log_indicates_ready(""));
+        assert!(!log_indicates_ready("[cloud-runtime-agent] connecting..."));
+        assert!(log_indicates_ready(
+            "2026-06-12 [info] Infrastructure ready, entering main loop\n"
+        ));
+        // Embedded mid-stream still counts (the `.mjs` agent greps the file).
+        assert!(log_indicates_ready(&format!(
+            "noise\n{READINESS_LINE}\nmore noise"
+        )));
+    }
+
+    #[test]
+    fn normalize_jobs_accepts_all_known_shapes() {
+        let raw = serde_json::json!([{ "job_id": "a", "notebook_id": "n" }]);
+        assert_eq!(normalize_jobs(&raw).len(), 1);
+        let wrapped = serde_json::json!({ "jobs": [{ "job_id": "a", "notebook_id": "n" }] });
+        assert_eq!(normalize_jobs(&wrapped).len(), 1);
+        let alt = serde_json::json!({ "attach_jobs": [{ "job_id": "a", "notebook_id": "n" }] });
+        assert_eq!(normalize_jobs(&alt).len(), 1);
+        assert!(normalize_jobs(&serde_json::json!({ "ok": true })).is_empty());
+    }
+
+    #[test]
+    fn parse_response_body_preserves_non_json_error_pages() {
+        assert_eq!(parse_response_body(""), serde_json::json!({}));
+        assert_eq!(
+            parse_response_body("{\"jobs\":[]}"),
+            serde_json::json!({ "jobs": [] })
+        );
+        let body = parse_response_body("<html><title>Error 1027</title>Please check back</html>");
+        assert!(body["error"]
+            .as_str()
+            .is_some_and(|text| text.contains("Error 1027")));
+    }
+
+    #[test]
+    fn retry_after_only_applies_to_rate_limit_statuses() {
+        assert_eq!(retry_after_ms(200, None), 0);
+        assert_eq!(retry_after_ms(429, Some("7")), 7_000);
+        assert_eq!(retry_after_ms(503, None), 60_000);
+        // Sub-second hints are floored to 1s.
+        assert_eq!(retry_after_ms(429, Some("0")), 1_000);
+        // Unparseable headers fall back to the default.
+        assert_eq!(retry_after_ms(429, Some("soon")), 60_000);
+        // An HTTP-date in the past still cools down for at least a second.
+        assert_eq!(
+            retry_after_ms(429, Some("Tue, 15 Nov 1994 08:12:31 GMT")),
+            1_000
+        );
+    }
+
+    #[test]
+    fn retry_cooldown_expands_with_failures_and_caps() {
+        assert_eq!(retry_cooldown_ms(60_000, 1, 0.0), 60_000);
+        assert_eq!(retry_cooldown_ms(60_000, 2, 0.0), 120_000);
+        assert_eq!(retry_cooldown_ms(60_000, 8, 0.0), 900_000);
+        // 20% jitter at jitter_unit=0.5 adds 10% of the base delay.
+        assert_eq!(retry_cooldown_ms(10_000, 1, 0.5), 11_000);
+    }
+
+    #[test]
+    fn meminfo_parsing() {
+        let meminfo = "MemTotal:       16384256 kB\nMemFree:         1234 kB\n";
+        assert_eq!(parse_meminfo_total_bytes(meminfo), Some(16_384_256 * 1024));
+        assert_eq!(parse_meminfo_total_bytes("MemFree: 1 kB"), None);
+    }
+
+    #[test]
+    fn path_segment_encoding() {
+        assert_eq!(encode_path_segment("ws-lab2"), "ws-lab2");
+        assert_eq!(encode_path_segment("a b/c"), "a%20b%2Fc");
+    }
+
+    #[test]
+    fn resolve_python_prefers_python3() {
+        let dir = tempfile::tempdir().unwrap();
+        let bin = dir.path();
+        for name in ["python", "python3"] {
+            let path = bin.join(name);
+            std::fs::write(&path, "#!/bin/sh\n").unwrap();
+            #[cfg(unix)]
+            {
+                use std::os::unix::fs::PermissionsExt;
+                std::fs::set_permissions(&path, std::fs::Permissions::from_mode(0o755)).unwrap();
+            }
+        }
+        let path_var = bin.to_string_lossy().into_owned();
+        let resolved = resolve_python_on_path(Some(&path_var)).unwrap();
+        assert!(resolved
+            .file_name()
+            .and_then(|name| name.to_str())
+            .is_some_and(|name| name.starts_with("python3")));
+        assert!(resolve_python_on_path(None).is_none());
+    }
+}

--- a/crates/runtimed/src/workstation/cloud_agent_cli.rs
+++ b/crates/runtimed/src/workstation/cloud_agent_cli.rs
@@ -33,6 +33,10 @@ pub enum CloudAuthKind {
     /// Anaconda API key (bearer + provider-selector header).
     #[value(name = "anaconda-key")]
     AnacondaKey,
+    /// Workstation credential from the pairing flow (`nwc_` token; plain
+    /// bearer on the wire).
+    #[value(name = "workstation")]
+    Workstation,
     /// Dev token (`X-Notebook-Cloud-Dev-Token`) + user label.
     #[value(name = "dev")]
     Dev,
@@ -73,6 +77,7 @@ pub fn build_cloud_config(
     let auth = match args.auth_kind {
         CloudAuthKind::Oidc => CloudAuth::OidcBearer { token },
         CloudAuthKind::AnacondaKey => CloudAuth::AnacondaApiKey { token },
+        CloudAuthKind::Workstation => CloudAuth::WorkstationCredential { token },
         CloudAuthKind::Dev => {
             let user = env(CLOUD_DEV_USER_ENV)
                 .map(|u| u.trim().to_string())
@@ -140,6 +145,19 @@ mod tests {
         assert!(matches!(
             cfg.auth,
             CloudAuth::AnacondaApiKey { token } if token == "tok-key"
+        ));
+    }
+
+    #[test]
+    fn workstation_kind_builds_workstation_credential_auth() {
+        let cfg = build_cloud_config(
+            &args(CloudAuthKind::Workstation),
+            env_from(&[(CLOUD_TOKEN_ENV, "nwc_tok")]),
+        )
+        .expect("build");
+        assert!(matches!(
+            cfg.auth,
+            CloudAuth::WorkstationCredential { token } if token == "nwc_tok"
         ));
     }
 

--- a/crates/runtimed/src/workstation/mod.rs
+++ b/crates/runtimed/src/workstation/mod.rs
@@ -17,16 +17,21 @@
 //! (workstation registry, attach jobs) lives in `apps/notebook-cloud`; the
 //! operator path is `docs/remote-workstation.md`.
 
+pub mod agent_loop;
 pub mod allocate;
 pub mod cloud_agent_cli;
 pub mod environments;
 pub mod launch_on_attach;
 
+pub use agent_loop::{
+    resolve_python_on_path, run_workstation_agent, WorkstationAgentOptions, DEFAULT_HEARTBEAT_MS,
+    DEFAULT_POLL_MS,
+};
 pub use allocate::{
     allocate_current_python_runtime, current_python_launch_working_dir,
     current_python_workstation_metadata, plan_current_python_allocation, Allocation, RoomTarget,
 };
-pub use cloud_agent_cli::{build_cloud_config, CloudAgentArgs, CloudAuthKind};
+pub use cloud_agent_cli::{build_cloud_config, CloudAgentArgs, CloudAuthKind, CLOUD_TOKEN_ENV};
 pub use environments::{
     environments_from_pool_state, list_environments, EnvKind, EnvironmentPolicy,
     WorkstationEnvironment,

--- a/docs/remote-workstation.md
+++ b/docs/remote-workstation.md
@@ -31,7 +31,84 @@ live.)
 For air-gapped installs, download the release assets yourself and use
 `--from-dir`.
 
-## Attach to a hosted notebook
+## Pair and serve (recommended)
+
+The pairing flow needs no externally issued credential
+(`docs/adr/hosted-credential-transport.md`, Decision 9):
+
+1. In the hosted workstation panel, mint a pairing code. Codes look like
+   `XXXX-XXXX-XXXX`, live 10 minutes, and are single use.
+2. On the workstation:
+
+```bash
+runt workstation connect https://app.runt.run --code XXXX-XXXX-XXXX
+```
+
+   (Omit `--code` to be prompted.) This redeems the code for a long-lived
+   workstation credential scoped to the workstation surface only, stores it
+   at `~/.config/nteract/workstation.json` (mode 0600), and registers the
+   workstation so it appears in the panel immediately. `--id` / `--name`
+   override the default `ws-<hostname>` identity. If the code is rejected,
+   mint a fresh one from the panel — codes expire and cannot be reused.
+
+3. Serve attach requests:
+
+```bash
+runt workstation run
+```
+
+   This launches `runtimed workstation-agent`, which heartbeats the
+   registration, polls for attach jobs, and spawns one
+   `runtimed cloud-runtime-agent` runtime peer per job (pending → accepted →
+   running → completed/failed). The credential rides the environment
+   (`RUNT_CLOUD_TOKEN`), never argv. `RUNT_CLOUD_TOKEN` / `RUNT_CLOUD_URL`
+   environment variables override the stored credential when set.
+
+4. Check what the credential sees:
+
+```bash
+runt workstation status          # workstations, status, last-seen, default
+runt workstation status --json
+```
+
+In the hosted notebook, attaching compute to a workstation dispatches an
+attach job; the agent accepts it and the runtime peer attaches to the room as
+`runtime_peer` over an outbound WebSocket. The peer reconnects with backoff
+across room evictions and network blips and keeps the kernel alive across
+reconnects; a clean room close does not tear the kernel down. If the agent
+restarts, it adopts runtime peers that are still alive (per-job pid + log
+files under the daemon cache) and reports the ones that are gone.
+
+## Run it as a service
+
+The installer's systemd unit runs the *daemon*. To serve attach requests
+permanently, add a user unit for the workstation agent (after a one-time
+`runt workstation connect`):
+
+```ini
+# ~/.config/systemd/user/nteract-workstation.service
+[Unit]
+Description=nteract workstation agent
+After=network-online.target
+
+[Service]
+ExecStart=%h/.local/bin/runt workstation run
+Restart=on-failure
+RestartSec=5
+
+[Install]
+WantedBy=default.target
+```
+
+```bash
+systemctl --user enable --now nteract-workstation
+```
+
+## Attach a single room directly (legacy / dev)
+
+Before the pairing flow, the operator path was a per-notebook agent with an
+externally issued bearer. It still works and remains useful for dev and for
+deployments that issue their own credentials:
 
 1. In the hosted notebook, grant the workstation principal an explicit
    `runtime_peer` ACL row (owner alone is not sufficient — compute access is
@@ -47,48 +124,17 @@ RUNT_CLOUD_TOKEN=<token> runtimed cloud-runtime-agent \
 
 The credential always rides the environment, never argv. Defaults: scope
 `runtime_peer`, auth kind `oidc` (use `--auth-kind anaconda-key` for Anaconda
-API keys). Prefer API-key auth for long-lived headless workstations; OIDC
-bearers are best for browser-coupled sessions where refresh is active. Blob
-root defaults under the daemon's standard cache. `--python-path`
-launches a kernel in that interpreter immediately on attach
-(launch-on-attach); omit it to attach idle and wait for the room to dispatch
-work. `--workstation-id` / `--workstation-display-name` set the non-secret
-identity shown in the notebook's workstation panel.
+API keys, `--auth-kind workstation` for a pairing-flow credential). Blob root
+defaults under the daemon's standard cache. `--python-path` launches a kernel
+in that interpreter immediately on attach (launch-on-attach); omit it to
+attach idle and wait for the room to dispatch work. `--workstation-id` /
+`--workstation-display-name` set the non-secret identity shown in the
+notebook's workstation panel.
 
-The agent reconnects with backoff across room evictions and network blips and
-keeps the kernel alive across reconnects; a clean room close does not tear the
-kernel down.
-
-## Run it as a service
-
-The installer's systemd unit runs the *daemon*. To keep a long-lived agent
-attached to a specific room, add a user unit alongside it:
-
-```ini
-# ~/.config/systemd/user/nteract-workstation@.service
-[Unit]
-Description=nteract workstation agent for notebook %i
-After=network-online.target
-
-[Service]
-Environment=RUNT_CLOUD_AUTH_KIND=anaconda-key
-EnvironmentFile=%h/.config/nteract/workstation.env
-ExecStart=%h/.local/bin/runtimed cloud-runtime-agent \
-  --auth-kind anaconda-key --cloud-url https://app.runt.run --notebook-id %i \
-  --workstation-id %H
-Restart=on-failure
-RestartSec=5
-
-[Install]
-WantedBy=default.target
-```
-
-Put `RUNT_CLOUD_TOKEN=...` in `~/.config/nteract/workstation.env` (mode 0600),
-then:
-
-```bash
-systemctl --user enable --now nteract-workstation@<notebook-id>
-```
+The Node connector (`apps/notebook-cloud/scripts/hosted-workstation-agent.mjs`)
+is the dev-loop equivalent of `runtimed workstation-agent` and keeps working
+against the same attach-job surface with `NTERACT_API_KEY` or
+`NOTEBOOK_CLOUD_PUBLISH_BEARER_TOKEN`.
 
 For browser-coupled OIDC peers whose token expires, mint fresh tokens via a
 refresher (the transport supports per-connect refresh; see
@@ -123,8 +169,12 @@ workstation panel surfaces attachment state. Inbound kernel lifecycle dispatch
 ## Diagnostics
 
 ```bash
+runt workstation status     # workstations the credential can see
 runt daemon status          # daemon state, pool sizes
 runt daemon logs -f         # tail the daemon log
 runt diagnostics            # bundle logs + system info into an archive
-journalctl --user -u 'nteract-workstation@*'   # agent service logs
+journalctl --user -u nteract-workstation      # agent service logs
 ```
+
+Per-job runtime peer logs land under the daemon cache
+(`~/.cache/runt*/workstation-agent/<job>/runtime-peer.log`).


### PR DESCRIPTION
## Summary

The operator side of the pairing contract (#3609): a single static-binary path from pairing code to serving compute, replacing the `.mjs` connector's eight env vars.

```
runt workstation connect https://preview.runt.run --code XXXX-XXXX-XXXX
runt workstation run
```

- **`runt workstation connect`** — prompts for/accepts the code, redeems it, stores the `nwc_` credential at the `session_state_path()`-style location (0600), and does one registration POST so the workstation appears in the panel immediately. A used/expired code gets a clear message and exit 1.
- **`runt workstation run`** — resolves the sibling `runtimed` (bundled lookup + dev `target/` fallback) and launches the agent with the token in env, never argv.
- **`runtimed workstation-agent`** — the long-lived loop, living in `runtimed` to match the `runt`-launches-`runtimed` split: heartbeat registration, attach-job polling, one `cloud-runtime-agent` runtime peer per job (`--auth-kind workstation` → new honestly-labeled `CloudAuth::WorkstationCredential`, plain bearer on the WS dial), readiness-line detection, rate-limit cooldowns with jitter, and full job **adoption across restarts** via per-job log + pid files.
- **`runt workstation status [--json]`** — registered workstations through the stored credential.
- `docs/remote-workstation.md` now leads with mint → connect → run; the env-var/`.mjs` path stays documented as the dev/legacy alternative.

## Verification

`runtimed` lib 969 passed (+ tokio mutex lint), `runt` 18 (8 new), `notebook-cloud-transport` 25 (2 new), `runt-workspace` 26 (3 new). Plus a live smoke against a mock cloud server: bad code → exit 1; good code → 0600 credential + registration; `run` → register → accept job → spawn real `cloud-runtime-agent` → status PATCHes through failed on peer exit.

## Stack

Promoted from quillaid#7 after #3609 merged; now based on `main`. The panel one-liner in #3610 invokes exactly this CLI. Post-rebase verification: full runtimed lib (969) + tokio mutex lint + runt/transport/workspace suites, all green.

