### PR TITLE
feat(install): macOS support in the release installer

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,20 +8,24 @@ Built on [jupyter-zmq-client](https://crates.io/crates/jupyter-zmq-client) and [
 
 Download the latest release from [GitHub Releases](https://github.com/nteract/nteract/releases).
 
-Linux desktop users should use the AppImage from GitHub Releases, or run
-`scripts/install-linux-release` to install the AppImage plus CLI/daemon and
-the per-user systemd service in one step. DEB/RPM/APT installs are not
-currently supported because `runtimed` is a per-user daemon managed by the app
-and CLI, not by system package-manager scripts.
+Linux x64 and macOS (Apple silicon or Intel) can install with one command —
+the AppImage or signed .app bundle plus CLI/daemon and the per-user service
+(systemd or launchd) in one step:
 
-For remote Linux workstations (Outerbounds, JupyterHub) that offer compute to
+```bash
+curl --proto '=https' --tlsv1.2 -sSf https://sh.nteract.io | bash
+```
+
+macOS users can equally drag the DMG from GitHub Releases. DEB/RPM/APT
+installs are not currently supported because `runtimed` is a per-user daemon
+managed by the app and CLI, not by system package-manager scripts.
+
+For remote workstations (Outerbounds, JupyterHub) that offer compute to
 hosted notebooks, use the headless one-liner — see
 [Remote workstations](docs/remote-workstation.md):
 
 ```bash
-curl --proto '=https' --tlsv1.2 -sSfL \
-  https://raw.githubusercontent.com/nteract/nteract/main/scripts/install-linux-release | \
-  bash -s -- --headless
+curl --proto '=https' --tlsv1.2 -sSf https://sh.nteract.io | bash -s -- --headless
 ```
 
 The desktop app bundles everything — `runt` CLI and `runtimed` daemon.

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -26,7 +26,7 @@ Stable releases run when a `v*` tag is pushed (or manually), and nightly pre-rel
 | macOS ARM64 (Apple Silicon) | `nteract-{channel}-darwin-arm64.dmg` |
 | Windows x64 | `nteract-{channel}-windows-x64.exe` |
 | Linux x64 | `nteract-{channel}-linux-x64.AppImage` |
-| Linux installer script | `install-linux-release` |
+| Installer script (Linux x64, macOS) | `install-linux-release` |
 | CLI (macOS ARM64) | `runt-darwin-arm64` |
 | CLI (Linux x64) | `runt-linux-x64` |
 

--- a/docs/remote-workstation.md
+++ b/docs/remote-workstation.md
@@ -13,20 +13,18 @@ This doc is the operator path. The architecture lives in
 
 ## Install (one-liner)
 
-On a Linux x64 machine:
+On a Linux x64 or macOS (Apple silicon / Intel) machine:
 
 ```bash
-curl --proto '=https' --tlsv1.2 -sSfL \
-  https://raw.githubusercontent.com/nteract/nteract/main/scripts/install-linux-release | \
-  bash -s -- --headless
+curl --proto '=https' --tlsv1.2 -sSf https://sh.nteract.io | bash -s -- --headless
 ```
 
-`--headless` skips the desktop AppImage and installs just `runt`, `runtimed`,
-and `nteract-mcp` into `~/.local/share/nteract/stable`, links them into
-`~/.local/bin`, and installs the per-user systemd service for the daemon
-(`runt daemon doctor --fix`). Everything is per-user; no root required. Re-run
-to upgrade. (`https://sh.nteract.io` will front this script once the domain is
-live.)
+`--headless` skips the desktop app and installs just `runt`, `runtimed`, and
+`nteract-mcp` into `~/.local/share/nteract/stable` (on macOS, as the sidecars
+of the .app bundle kept under that prefix), links them into `~/.local/bin`,
+and installs the per-user daemon service (`runt daemon doctor --fix` —
+systemd on Linux, launchd on macOS). Everything is per-user; no root
+required. Re-run to upgrade.
 
 For air-gapped installs, download the release assets yourself and use
 `--from-dir`.

--- a/scripts/install-linux-release
+++ b/scripts/install-linux-release
@@ -40,7 +40,8 @@ Options:
                        See docs/remote-workstation.md.
   --applications-dir <dir>
                        macOS only: where the .app bundle is installed
-                       (default: ~/Applications).
+                       (default: /Applications, falling back to
+                       ~/Applications when /Applications is not writable).
   --no-start           Install/repair the daemon service but do not start it.
   -h, --help           Show this help.
 
@@ -51,9 +52,10 @@ Installs, for stable on Linux x64:
   nteract-mcp-linux-x64             -> <prefix>/bin/nteract-mcp
 
 For stable on macOS (arm64/x64), one bundle carries app and sidecars:
-  nteract-stable-darwin-<arch>.app.tar.gz -> ~/Applications/nteract.app
-  (--headless keeps the bundle under <prefix> instead and skips
-   ~/Applications; commands link to <bundle>/Contents/MacOS)
+  nteract-stable-darwin-<arch>.app.tar.gz -> /Applications/nteract.app
+  (~/Applications when /Applications is not writable; --headless keeps the
+   bundle under <prefix> instead and skips Applications entirely; commands
+   link to <bundle>/Contents/MacOS)
 
 Then links:
   ~/.local/bin/nteract   (unless --headless)
@@ -111,7 +113,7 @@ HEADLESS=0
 XDG_DATA_HOME_DEFAULT="${XDG_DATA_HOME:-$HOME/.local/share}"
 PREFIX=""
 BIN_DIR="$HOME/.local/bin"
-APPLICATIONS_DIR="$HOME/Applications"
+APPLICATIONS_DIR=""
 
 while [[ $# -gt 0 ]]; do
   case "$1" in
@@ -314,6 +316,17 @@ else
   # workstation box never grows an Applications entry.
   fetch_asset "$BUNDLE_ASSET" "$TMP_DIR/$BUNDLE_ASSET"
   if [[ "$HEADLESS" == "0" ]]; then
+    if [[ -z "$APPLICATIONS_DIR" ]]; then
+      # The standard location first: admin accounts can write /Applications
+      # without sudo. Non-admin accounts fall back to ~/Applications, which
+      # the channel's app-launch candidates also search.
+      if [[ -d /Applications && -w /Applications ]]; then
+        APPLICATIONS_DIR="/Applications"
+      else
+        APPLICATIONS_DIR="$HOME/Applications"
+        echo "Note: /Applications is not writable; installing to $APPLICATIONS_DIR instead." >&2
+      fi
+    fi
     install_app_bundle "$TMP_DIR/$BUNDLE_ASSET" "$APPLICATIONS_DIR"
   else
     install_app_bundle "$TMP_DIR/$BUNDLE_ASSET" "$PREFIX"

--- a/scripts/install-linux-release
+++ b/scripts/install-linux-release
@@ -40,8 +40,8 @@ Options:
                        See docs/remote-workstation.md.
   --applications-dir <dir>
                        macOS only: where the .app bundle is installed
-                       (default: /Applications, falling back to
-                       ~/Applications when /Applications is not writable).
+                       (default: ~/Applications — the install is per-user
+                       by design, like the daemon service).
   --no-start           Install/repair the daemon service but do not start it.
   -h, --help           Show this help.
 
@@ -52,10 +52,9 @@ Installs, for stable on Linux x64:
   nteract-mcp-linux-x64             -> <prefix>/bin/nteract-mcp
 
 For stable on macOS (arm64/x64), one bundle carries app and sidecars:
-  nteract-stable-darwin-<arch>.app.tar.gz -> /Applications/nteract.app
-  (~/Applications when /Applications is not writable; --headless keeps the
-   bundle under <prefix> instead and skips Applications entirely; commands
-   link to <bundle>/Contents/MacOS)
+  nteract-stable-darwin-<arch>.app.tar.gz -> ~/Applications/nteract.app
+  (--headless keeps the bundle under <prefix> instead and skips
+   Applications entirely; commands link to <bundle>/Contents/MacOS)
 
 Then links:
   ~/.local/bin/nteract   (unless --headless)
@@ -113,7 +112,7 @@ HEADLESS=0
 XDG_DATA_HOME_DEFAULT="${XDG_DATA_HOME:-$HOME/.local/share}"
 PREFIX=""
 BIN_DIR="$HOME/.local/bin"
-APPLICATIONS_DIR=""
+APPLICATIONS_DIR="$HOME/Applications"
 
 while [[ $# -gt 0 ]]; do
   case "$1" in
@@ -316,17 +315,9 @@ else
   # workstation box never grows an Applications entry.
   fetch_asset "$BUNDLE_ASSET" "$TMP_DIR/$BUNDLE_ASSET"
   if [[ "$HEADLESS" == "0" ]]; then
-    if [[ -z "$APPLICATIONS_DIR" ]]; then
-      # The standard location first: admin accounts can write /Applications
-      # without sudo. Non-admin accounts fall back to ~/Applications, which
-      # the channel's app-launch candidates also search.
-      if [[ -d /Applications && -w /Applications ]]; then
-        APPLICATIONS_DIR="/Applications"
-      else
-        APPLICATIONS_DIR="$HOME/Applications"
-        echo "Note: /Applications is not writable; installing to $APPLICATIONS_DIR instead." >&2
-      fi
-    fi
+    # ~/Applications, not /Applications: the whole install is per-user by
+    # design (per-user daemon service, per-user bin links), and the
+    # channel's app-launch candidates search ~/Applications too.
     install_app_bundle "$TMP_DIR/$BUNDLE_ASSET" "$APPLICATIONS_DIR"
   else
     install_app_bundle "$TMP_DIR/$BUNDLE_ASSET" "$PREFIX"

--- a/scripts/install-linux-release
+++ b/scripts/install-linux-release
@@ -1,12 +1,19 @@
 #!/usr/bin/env bash
-# Install a published nteract Linux release for the current user.
+# Install a published nteract release for the current user (Linux x64,
+# macOS Apple silicon / Intel). The file keeps its historical
+# `install-linux-release` name because released installers and
+# https://sh.nteract.io fetch it by that asset name.
 #
-# Intended future entrypoint:
+# Entrypoint:
 #   curl --proto '=https' --tlsv1.2 -sSf https://sh.nteract.io | bash
 #
-# Installs the AppImage plus runt/runtimed/nteract-mcp sidecars into a durable
-# per-user directory, links commands into ~/.local/bin, repairs/installs the
-# user systemd daemon with `runt daemon doctor --fix`, and starts it by default.
+# Linux installs the AppImage plus runt/runtimed/nteract-mcp sidecars into a
+# durable per-user directory and links commands into ~/.local/bin. macOS
+# installs the signed .app bundle (which carries the same sidecars in
+# Contents/MacOS) into ~/Applications and links the commands from there.
+# Both repair/install the per-user daemon service with
+# `runt daemon doctor --fix` (systemd on Linux, launchd on macOS) and start
+# it by default.
 
 set -euo pipefail
 
@@ -27,18 +34,26 @@ Options:
   --prefix <dir>       Install root (default: $XDG_DATA_HOME/nteract/<channel>,
                        or ~/.local/share/nteract/<channel>).
   --bin-dir <dir>      Symlink directory (default: ~/.local/bin).
-  --headless           Skip the desktop AppImage: install only runt, runtimed,
+  --headless           Skip the desktop app: install only runt, runtimed,
                        and nteract-mcp. For remote workstations (Outerbounds,
                        JupyterHub) that offer compute to hosted notebooks.
                        See docs/remote-workstation.md.
+  --applications-dir <dir>
+                       macOS only: where the .app bundle is installed
+                       (default: ~/Applications).
   --no-start           Install/repair the daemon service but do not start it.
   -h, --help           Show this help.
 
-Installs, for stable:
+Installs, for stable on Linux x64:
   nteract-stable-linux-x64.AppImage -> <prefix>/nteract.AppImage   (unless --headless)
   runt-linux-x64                    -> <prefix>/bin/runt
   runtimed-linux-x64                -> <prefix>/bin/runtimed
   nteract-mcp-linux-x64             -> <prefix>/bin/nteract-mcp
+
+For stable on macOS (arm64/x64), one bundle carries app and sidecars:
+  nteract-stable-darwin-<arch>.app.tar.gz -> ~/Applications/nteract.app
+  (--headless keeps the bundle under <prefix> instead and skips
+   ~/Applications; commands link to <bundle>/Contents/MacOS)
 
 Then links:
   ~/.local/bin/nteract   (unless --headless)
@@ -46,7 +61,7 @@ Then links:
   ~/.local/bin/runtimed
   ~/.local/bin/nteract-mcp
 
-For nightly, the installed AppImage and public commands are channel-suffixed:
+For nightly, the installed app and public commands are channel-suffixed:
   ~/.local/bin/nteract-nightly
   ~/.local/bin/runt-nightly
   ~/.local/bin/runtimed-nightly
@@ -64,15 +79,23 @@ require_option_value() {
   fi
 }
 
-if [[ "$(uname -s)" != "Linux" ]]; then
-  echo "nteract Linux installer can only run on Linux." >&2
-  exit 1
-fi
-
-case "$(uname -m)" in
-  x86_64|amd64) ARCH="x64" ;;
+case "$(uname -s):$(uname -m)" in
+  Linux:x86_64|Linux:amd64)
+    OS="linux"
+    ARCH="x64"
+    ;;
+  Darwin:arm64)
+    OS="darwin"
+    ARCH="arm64"
+    ;;
+  Darwin:x86_64)
+    OS="darwin"
+    ARCH="x64"
+    ;;
   *)
-    echo "Unsupported architecture: $(uname -m). Only Linux x64 release assets exist today." >&2
+    echo "Unsupported platform: $(uname -s) $(uname -m)." >&2
+    echo "Release assets exist for Linux x64 and macOS (Apple silicon, Intel)." >&2
+    echo "Windows users: download the installer from https://github.com/nteract/nteract/releases" >&2
     exit 1
     ;;
 esac
@@ -88,6 +111,7 @@ HEADLESS=0
 XDG_DATA_HOME_DEFAULT="${XDG_DATA_HOME:-$HOME/.local/share}"
 PREFIX=""
 BIN_DIR="$HOME/.local/bin"
+APPLICATIONS_DIR="$HOME/Applications"
 
 while [[ $# -gt 0 ]]; do
   case "$1" in
@@ -119,6 +143,11 @@ while [[ $# -gt 0 ]]; do
     --bin-dir)
       require_option_value "$1" "${2:-}"
       BIN_DIR="${2:-}"
+      shift 2
+      ;;
+    --applications-dir)
+      require_option_value "$1" "${2:-}"
+      APPLICATIONS_DIR="${2:-}"
       shift 2
       ;;
     --headless)
@@ -182,6 +211,10 @@ else
   APPIMAGE_NAME="nteract-nightly"
 fi
 
+# One macOS bundle carries the app and the runt/runtimed/nteract-mcp sidecars
+# in Contents/MacOS; there are no standalone darwin daemon/mcp assets.
+BUNDLE_ASSET="nteract-$CHANNEL-darwin-$ARCH.app.tar.gz"
+
 APPIMAGE_DEST="$PREFIX/$APPIMAGE_NAME.AppImage"
 SIDE_BIN_DIR="$PREFIX/bin"
 TMP_DIR="$(mktemp -d)"
@@ -227,35 +260,91 @@ atomic_install() {
   echo "Installed $dest"
 }
 
-mkdir -p "$PREFIX" "$SIDE_BIN_DIR" "$BIN_DIR"
+install_app_bundle() {
+  local archive="$1"
+  local dest_dir="$2"
 
-if [[ "$HEADLESS" == "0" ]]; then
-  fetch_asset "$APPIMAGE_ASSET" "$TMP_DIR/$APPIMAGE_ASSET"
-fi
-fetch_asset "$CLI_ASSET" "$TMP_DIR/$CLI_NAME"
-fetch_asset "$DAEMON_ASSET" "$TMP_DIR/$DAEMON_NAME"
-fetch_asset "$MCP_ASSET" "$TMP_DIR/$MCP_NAME"
+  local extract_dir="$TMP_DIR/bundle"
+  mkdir -p "$extract_dir"
+  tar -xzf "$archive" -C "$extract_dir"
+  local app_src
+  app_src="$(find "$extract_dir" -mindepth 1 -maxdepth 1 -name '*.app' -type d | head -n 1)"
+  if [[ -z "$app_src" ]]; then
+    echo "No .app bundle found inside $archive" >&2
+    exit 1
+  fi
+  APP_BASENAME="$(basename "$app_src")"
+  APP_DEST="$dest_dir/$APP_BASENAME"
 
-if [[ "$HEADLESS" == "0" ]]; then
-  atomic_install "$TMP_DIR/$APPIMAGE_ASSET" "$APPIMAGE_DEST"
+  mkdir -p "$dest_dir"
+  rm -rf "$APP_DEST.new"
+  mv "$app_src" "$APP_DEST.new"
+  rm -rf "$APP_DEST"
+  mv "$APP_DEST.new" "$APP_DEST"
+  echo "Installed $APP_DEST"
+}
+
+mkdir -p "$PREFIX" "$BIN_DIR"
+
+if [[ "$OS" == "linux" ]]; then
+  mkdir -p "$SIDE_BIN_DIR"
+
+  if [[ "$HEADLESS" == "0" ]]; then
+    fetch_asset "$APPIMAGE_ASSET" "$TMP_DIR/$APPIMAGE_ASSET"
+  fi
+  fetch_asset "$CLI_ASSET" "$TMP_DIR/$CLI_NAME"
+  fetch_asset "$DAEMON_ASSET" "$TMP_DIR/$DAEMON_NAME"
+  fetch_asset "$MCP_ASSET" "$TMP_DIR/$MCP_NAME"
+
+  if [[ "$HEADLESS" == "0" ]]; then
+    atomic_install "$TMP_DIR/$APPIMAGE_ASSET" "$APPIMAGE_DEST"
+  fi
+  atomic_install "$TMP_DIR/$CLI_NAME" "$SIDE_BIN_DIR/$CLI_NAME"
+  atomic_install "$TMP_DIR/$DAEMON_NAME" "$SIDE_BIN_DIR/$DAEMON_NAME"
+  atomic_install "$TMP_DIR/$MCP_NAME" "$SIDE_BIN_DIR/$MCP_NAME"
+
+  RUNT_BIN="$SIDE_BIN_DIR/$CLI_NAME"
+  DAEMON_BIN="$SIDE_BIN_DIR/$DAEMON_NAME"
+  MCP_BIN="$SIDE_BIN_DIR/$MCP_NAME"
+else
+  # macOS: the signed .app bundle is the only artifact; it carries the
+  # runt/runtimed/nteract-mcp sidecars in Contents/MacOS. Desktop installs
+  # place it where Finder, Spotlight, and the channel's app-launch
+  # candidates look; headless installs keep it under the prefix so a
+  # workstation box never grows an Applications entry.
+  fetch_asset "$BUNDLE_ASSET" "$TMP_DIR/$BUNDLE_ASSET"
+  if [[ "$HEADLESS" == "0" ]]; then
+    install_app_bundle "$TMP_DIR/$BUNDLE_ASSET" "$APPLICATIONS_DIR"
+  else
+    install_app_bundle "$TMP_DIR/$BUNDLE_ASSET" "$PREFIX"
+  fi
+
+  MACOS_BIN="$APP_DEST/Contents/MacOS"
+  for sidecar in runt runtimed nteract-mcp; do
+    if [[ ! -x "$MACOS_BIN/$sidecar" ]]; then
+      echo "Bundle is missing expected sidecar: $MACOS_BIN/$sidecar" >&2
+      exit 1
+    fi
+  done
+
+  RUNT_BIN="$MACOS_BIN/runt"
+  DAEMON_BIN="$MACOS_BIN/runtimed"
+  MCP_BIN="$MACOS_BIN/nteract-mcp"
 fi
-atomic_install "$TMP_DIR/$CLI_NAME" "$SIDE_BIN_DIR/$CLI_NAME"
-atomic_install "$TMP_DIR/$DAEMON_NAME" "$SIDE_BIN_DIR/$DAEMON_NAME"
-atomic_install "$TMP_DIR/$MCP_NAME" "$SIDE_BIN_DIR/$MCP_NAME"
 
 # Public command links. Stable owns `nteract`; nightly owns `nteract-nightly`
 # so the two channels can be installed side-by-side without clobbering launchers.
-if [[ "$HEADLESS" == "0" ]]; then
+if [[ "$OS" == "linux" && "$HEADLESS" == "0" ]]; then
   ln -sfn "$APPIMAGE_DEST" "$BIN_DIR/$APPIMAGE_NAME"
   echo "Linked $BIN_DIR/$APPIMAGE_NAME -> $APPIMAGE_DEST"
 fi
-ln -sfn "$SIDE_BIN_DIR/$CLI_NAME" "$BIN_DIR/$CLI_NAME"
-ln -sfn "$SIDE_BIN_DIR/$DAEMON_NAME" "$BIN_DIR/$DAEMON_NAME"
-ln -sfn "$SIDE_BIN_DIR/$MCP_NAME" "$BIN_DIR/$MCP_NAME"
+ln -sfn "$RUNT_BIN" "$BIN_DIR/$CLI_NAME"
+ln -sfn "$DAEMON_BIN" "$BIN_DIR/$DAEMON_NAME"
+ln -sfn "$MCP_BIN" "$BIN_DIR/$MCP_NAME"
 
-echo "Linked $BIN_DIR/$CLI_NAME -> $SIDE_BIN_DIR/$CLI_NAME"
-echo "Linked $BIN_DIR/$DAEMON_NAME -> $SIDE_BIN_DIR/$DAEMON_NAME"
-echo "Linked $BIN_DIR/$MCP_NAME -> $SIDE_BIN_DIR/$MCP_NAME"
+echo "Linked $BIN_DIR/$CLI_NAME -> $RUNT_BIN"
+echo "Linked $BIN_DIR/$DAEMON_NAME -> $DAEMON_BIN"
+echo "Linked $BIN_DIR/$MCP_NAME -> $MCP_BIN"
 
 if [[ ":$PATH:" != *":$BIN_DIR:"* ]]; then
   echo "Note: $BIN_DIR is not on PATH for this shell. Add it to use nteract/runt commands directly." >&2
@@ -268,15 +357,20 @@ if [[ "$NO_START" == "1" ]]; then
   DOCTOR_ARGS+=(--no-start)
 fi
 
-echo "Repairing daemon service with $SIDE_BIN_DIR/$CLI_NAME ${DOCTOR_ARGS[*]}"
-env -u RUNTIMED_DEV -u RUNTIMED_WORKSPACE_PATH PATH="$SIDE_BIN_DIR:$BIN_DIR:$PATH" \
-  "$SIDE_BIN_DIR/$CLI_NAME" "${DOCTOR_ARGS[@]}"
+RUNT_DIR="$(dirname "$RUNT_BIN")"
+echo "Repairing daemon service with $RUNT_BIN ${DOCTOR_ARGS[*]}"
+env -u RUNTIMED_DEV -u RUNTIMED_WORKSPACE_PATH PATH="$RUNT_DIR:$BIN_DIR:$PATH" \
+  "$RUNT_BIN" "${DOCTOR_ARGS[@]}"
 
 echo
 echo "nteract $CHANNEL install complete."
 if [[ "$HEADLESS" == "0" ]]; then
-  echo "AppImage: $APPIMAGE_DEST"
-  echo "Launcher: $BIN_DIR/$APPIMAGE_NAME"
+  if [[ "$OS" == "linux" ]]; then
+    echo "AppImage: $APPIMAGE_DEST"
+    echo "Launcher: $BIN_DIR/$APPIMAGE_NAME"
+  else
+    echo "App:      $APP_DEST"
+  fi
 fi
 echo "CLI:      $BIN_DIR/$CLI_NAME"
 echo "Daemon:   $BIN_DIR/$DAEMON_NAME"
@@ -284,13 +378,15 @@ echo "MCP:      $BIN_DIR/$MCP_NAME"
 if [[ "$NO_START" == "1" ]]; then
   echo "Daemon was installed/repaired but not started (--no-start). Start with: $CLI_NAME daemon start"
 else
-  env -u RUNTIMED_DEV -u RUNTIMED_WORKSPACE_PATH PATH="$SIDE_BIN_DIR:$BIN_DIR:$PATH" \
-    "$SIDE_BIN_DIR/$CLI_NAME" daemon status || true
+  env -u RUNTIMED_DEV -u RUNTIMED_WORKSPACE_PATH PATH="$RUNT_DIR:$BIN_DIR:$PATH" \
+    "$RUNT_BIN" daemon status || true
 fi
 if [[ "$HEADLESS" == "1" ]]; then
   echo
   echo "Headless workstation install. To offer this machine's compute to a hosted"
-  echo "notebook, see docs/remote-workstation.md, or run:"
-  echo "  RUNT_CLOUD_TOKEN=... $DAEMON_NAME cloud-runtime-agent \\"
-  echo "    --cloud-url https://app.runt.run --notebook-id <id> --python-path \$(command -v python3)"
+  echo "notebook, mint a pairing code from the notebook's workstation panel, then:"
+  echo "  $CLI_NAME workstation connect https://app.runt.run --code <code>"
+  echo "  $CLI_NAME workstation run"
+  echo "(Releases without 'runt workstation' can use the cloud-runtime-agent flow"
+  echo "in docs/remote-workstation.md.)"
 fi

--- a/scripts/test-install-release
+++ b/scripts/test-install-release
@@ -109,14 +109,16 @@ assert_link "$LINUX_HOME/.local/bin/nteract-mcp" "$PREFIX/bin/nteract-mcp"
 assert_link "$LINUX_HOME/.local/bin/nteract" "$PREFIX/nteract.AppImage"
 grep -q "runt daemon doctor --fix --no-start" "$LINUX_LOG" || fail "linux: daemon doctor --fix --no-start not invoked"
 
-note "darwin desktop install"
+note "darwin desktop install (explicit --applications-dir)"
 DARWIN_HOME="$WORK/darwin-home"
 DARWIN_LOG="$WORK/darwin-calls.log"
 make_darwin_fixtures "$WORK/darwin-assets" "$DARWIN_LOG"
 make_uname_shim "$WORK/shim-darwin" "Darwin" "arm64"
-APP_DEST="$DARWIN_HOME/Applications/nteract.app"
+APPS_DIR="$WORK/fake-applications"
+APP_DEST="$APPS_DIR/nteract.app"
 PATH="$WORK/shim-darwin:$PATH" run_installer "$DARWIN_HOME" \
-  --from-dir "$WORK/darwin-assets" --no-start > "$WORK/darwin-out.log"
+  --from-dir "$WORK/darwin-assets" --applications-dir "$APPS_DIR" --no-start \
+  > "$WORK/darwin-out.log" 2>&1
 assert_file "$APP_DEST/Contents/MacOS/runt"
 assert_link "$DARWIN_HOME/.local/bin/runt" "$APP_DEST/Contents/MacOS/runt"
 assert_link "$DARWIN_HOME/.local/bin/runtimed" "$APP_DEST/Contents/MacOS/runtimed"
@@ -124,10 +126,26 @@ assert_link "$DARWIN_HOME/.local/bin/nteract-mcp" "$APP_DEST/Contents/MacOS/nter
 assert_missing "$DARWIN_HOME/.local/share/nteract/stable/nteract.app"
 grep -q "runt daemon doctor --fix --no-start" "$DARWIN_LOG" || fail "darwin: daemon doctor --fix --no-start not invoked"
 grep -q "App:      $APP_DEST" "$WORK/darwin-out.log" || fail "darwin: summary should name the installed app"
+grep -q "not writable" "$WORK/darwin-out.log" && fail "darwin explicit: no fallback note expected"
+
+note "darwin desktop default prefers /Applications, falls back per-user"
+# On this test host /Applications does not exist, so the deterministic
+# outcome of the default is the documented ~/Applications fallback.
+FALLBACK_HOME="$WORK/fallback-home"
+FALLBACK_APP="$FALLBACK_HOME/Applications/nteract.app"
+PATH="$WORK/shim-darwin:$PATH" run_installer "$FALLBACK_HOME" \
+  --from-dir "$WORK/darwin-assets" --no-start > "$WORK/fallback-out.log" 2>&1
+assert_file "$FALLBACK_APP/Contents/MacOS/runt"
+assert_link "$FALLBACK_HOME/.local/bin/runt" "$FALLBACK_APP/Contents/MacOS/runt"
+if [[ ! -d /Applications ]]; then
+  grep -q "not writable; installing to $FALLBACK_HOME/Applications" "$WORK/fallback-out.log" \
+    || fail "darwin default: missing fallback note"
+fi
 
 note "darwin desktop reinstall replaces the bundle"
 PATH="$WORK/shim-darwin:$PATH" run_installer "$DARWIN_HOME" \
-  --from-dir "$WORK/darwin-assets" --no-start > "$WORK/darwin-out2.log"
+  --from-dir "$WORK/darwin-assets" --applications-dir "$APPS_DIR" --no-start \
+  > "$WORK/darwin-out2.log"
 assert_file "$APP_DEST/Contents/MacOS/runt"
 assert_missing "$APP_DEST.new"
 

--- a/scripts/test-install-release
+++ b/scripts/test-install-release
@@ -1,0 +1,158 @@
+#!/usr/bin/env bash
+# Fixture tests for scripts/install-linux-release.
+#
+# Runs the real installer against --from-dir fixtures with HOME pointed at a
+# sandbox. Darwin code paths run on any host through a PATH-shimmed `uname`,
+# so CI on Linux still covers the macOS bundle install, link layout, and
+# headless variant.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+INSTALLER="$SCRIPT_DIR/install-linux-release"
+
+WORK="$(mktemp -d)"
+cleanup() { rm -rf "$WORK"; }
+trap cleanup EXIT
+
+FAILURES=0
+note() { printf '\n=== %s ===\n' "$1"; }
+fail() {
+  echo "FAIL: $1" >&2
+  FAILURES=$((FAILURES + 1))
+}
+assert_link() {
+  local link="$1"
+  local target="$2"
+  if [[ "$(readlink "$link" 2>/dev/null)" != "$target" ]]; then
+    fail "$link should link to $target (got: $(readlink "$link" 2>/dev/null || echo '<missing>'))"
+  fi
+}
+assert_file() {
+  [[ -e "$1" ]] || fail "expected $1 to exist"
+}
+assert_missing() {
+  [[ ! -e "$1" ]] || fail "expected $1 to be absent"
+}
+
+make_fake_tool() {
+  # A recording binary: appends its argv to calls.log next to the fixture
+  # root so tests can assert the daemon doctor/status invocations.
+  local path="$1"
+  local log="$2"
+  mkdir -p "$(dirname "$path")"
+  cat > "$path" <<EOF
+#!/usr/bin/env bash
+echo "\$(basename "\$0") \$*" >> "$log"
+exit 0
+EOF
+  chmod 0755 "$path"
+}
+
+make_linux_fixtures() {
+  local dir="$1"
+  local log="$2"
+  mkdir -p "$dir"
+  make_fake_tool "$dir/runt-linux-x64" "$log"
+  make_fake_tool "$dir/runtimed-linux-x64" "$log"
+  make_fake_tool "$dir/nteract-mcp-linux-x64" "$log"
+  echo "fake appimage" > "$dir/nteract-stable-linux-x64.AppImage"
+}
+
+make_darwin_fixtures() {
+  local dir="$1"
+  local log="$2"
+  local stage="$dir/.stage"
+  mkdir -p "$dir" "$stage/nteract.app/Contents/MacOS"
+  for tool in nteract runt runtimed nteract-mcp; do
+    make_fake_tool "$stage/nteract.app/Contents/MacOS/$tool" "$log"
+  done
+  tar -czf "$dir/nteract-stable-darwin-arm64.app.tar.gz" -C "$stage" "nteract.app"
+  rm -rf "$stage"
+}
+
+make_uname_shim() {
+  # The installer consults plain `uname`, so a PATH shim is enough to walk
+  # the Darwin branches on a Linux host.
+  local dir="$1"
+  local kernel="$2"
+  local machine="$3"
+  mkdir -p "$dir"
+  cat > "$dir/uname" <<EOF
+#!/usr/bin/env bash
+case "\${1:-}" in
+  -s) echo "$kernel" ;;
+  -m) echo "$machine" ;;
+  *) echo "$kernel" ;;
+esac
+EOF
+  chmod 0755 "$dir/uname"
+}
+
+run_installer() {
+  local home="$1"
+  shift
+  mkdir -p "$home"
+  HOME="$home" XDG_DATA_HOME="" bash "$INSTALLER" "$@"
+}
+
+note "linux desktop install"
+LINUX_HOME="$WORK/linux-home"
+LINUX_LOG="$WORK/linux-calls.log"
+make_linux_fixtures "$WORK/linux-assets" "$LINUX_LOG"
+run_installer "$LINUX_HOME" --from-dir "$WORK/linux-assets" --no-start > "$WORK/linux-out.log"
+PREFIX="$LINUX_HOME/.local/share/nteract/stable"
+assert_file "$PREFIX/nteract.AppImage"
+assert_link "$LINUX_HOME/.local/bin/runt" "$PREFIX/bin/runt"
+assert_link "$LINUX_HOME/.local/bin/runtimed" "$PREFIX/bin/runtimed"
+assert_link "$LINUX_HOME/.local/bin/nteract-mcp" "$PREFIX/bin/nteract-mcp"
+assert_link "$LINUX_HOME/.local/bin/nteract" "$PREFIX/nteract.AppImage"
+grep -q "runt daemon doctor --fix --no-start" "$LINUX_LOG" || fail "linux: daemon doctor --fix --no-start not invoked"
+
+note "darwin desktop install"
+DARWIN_HOME="$WORK/darwin-home"
+DARWIN_LOG="$WORK/darwin-calls.log"
+make_darwin_fixtures "$WORK/darwin-assets" "$DARWIN_LOG"
+make_uname_shim "$WORK/shim-darwin" "Darwin" "arm64"
+APP_DEST="$DARWIN_HOME/Applications/nteract.app"
+PATH="$WORK/shim-darwin:$PATH" run_installer "$DARWIN_HOME" \
+  --from-dir "$WORK/darwin-assets" --no-start > "$WORK/darwin-out.log"
+assert_file "$APP_DEST/Contents/MacOS/runt"
+assert_link "$DARWIN_HOME/.local/bin/runt" "$APP_DEST/Contents/MacOS/runt"
+assert_link "$DARWIN_HOME/.local/bin/runtimed" "$APP_DEST/Contents/MacOS/runtimed"
+assert_link "$DARWIN_HOME/.local/bin/nteract-mcp" "$APP_DEST/Contents/MacOS/nteract-mcp"
+assert_missing "$DARWIN_HOME/.local/share/nteract/stable/nteract.app"
+grep -q "runt daemon doctor --fix --no-start" "$DARWIN_LOG" || fail "darwin: daemon doctor --fix --no-start not invoked"
+grep -q "App:      $APP_DEST" "$WORK/darwin-out.log" || fail "darwin: summary should name the installed app"
+
+note "darwin desktop reinstall replaces the bundle"
+PATH="$WORK/shim-darwin:$PATH" run_installer "$DARWIN_HOME" \
+  --from-dir "$WORK/darwin-assets" --no-start > "$WORK/darwin-out2.log"
+assert_file "$APP_DEST/Contents/MacOS/runt"
+assert_missing "$APP_DEST.new"
+
+note "darwin headless install"
+HEADLESS_HOME="$WORK/headless-home"
+PATH="$WORK/shim-darwin:$PATH" run_installer "$HEADLESS_HOME" \
+  --from-dir "$WORK/darwin-assets" --headless --no-start > "$WORK/headless-out.log"
+HEADLESS_APP="$HEADLESS_HOME/.local/share/nteract/stable/nteract.app"
+assert_file "$HEADLESS_APP/Contents/MacOS/runtimed"
+assert_missing "$HEADLESS_HOME/Applications"
+assert_link "$HEADLESS_HOME/.local/bin/runt" "$HEADLESS_APP/Contents/MacOS/runt"
+grep -q "workstation connect" "$WORK/headless-out.log" || fail "headless: summary should mention the workstation pairing flow"
+
+note "unsupported platform is rejected with guidance"
+make_uname_shim "$WORK/shim-unsupported" "Linux" "armv7l"
+if PATH="$WORK/shim-unsupported:$PATH" run_installer "$WORK/unsupported-home" \
+  --from-dir "$WORK/linux-assets" > "$WORK/unsupported-out.log" 2>&1; then
+  fail "unsupported platform should exit nonzero"
+fi
+grep -q "Unsupported platform" "$WORK/unsupported-out.log" || fail "unsupported: missing platform message"
+
+if [[ "$FAILURES" -gt 0 ]]; then
+  echo
+  echo "$FAILURES failure(s)." >&2
+  exit 1
+fi
+echo
+echo "All install-release fixture tests passed."

--- a/scripts/test-install-release
+++ b/scripts/test-install-release
@@ -128,19 +128,14 @@ grep -q "runt daemon doctor --fix --no-start" "$DARWIN_LOG" || fail "darwin: dae
 grep -q "App:      $APP_DEST" "$WORK/darwin-out.log" || fail "darwin: summary should name the installed app"
 grep -q "not writable" "$WORK/darwin-out.log" && fail "darwin explicit: no fallback note expected"
 
-note "darwin desktop default prefers /Applications, falls back per-user"
-# On this test host /Applications does not exist, so the deterministic
-# outcome of the default is the documented ~/Applications fallback.
-FALLBACK_HOME="$WORK/fallback-home"
-FALLBACK_APP="$FALLBACK_HOME/Applications/nteract.app"
-PATH="$WORK/shim-darwin:$PATH" run_installer "$FALLBACK_HOME" \
-  --from-dir "$WORK/darwin-assets" --no-start > "$WORK/fallback-out.log" 2>&1
-assert_file "$FALLBACK_APP/Contents/MacOS/runt"
-assert_link "$FALLBACK_HOME/.local/bin/runt" "$FALLBACK_APP/Contents/MacOS/runt"
-if [[ ! -d /Applications ]]; then
-  grep -q "not writable; installing to $FALLBACK_HOME/Applications" "$WORK/fallback-out.log" \
-    || fail "darwin default: missing fallback note"
-fi
+note "darwin desktop default installs to ~/Applications (per-user by design)"
+DEFAULT_HOME="$WORK/default-home"
+DEFAULT_APP="$DEFAULT_HOME/Applications/nteract.app"
+PATH="$WORK/shim-darwin:$PATH" run_installer "$DEFAULT_HOME" \
+  --from-dir "$WORK/darwin-assets" --no-start > "$WORK/default-out.log" 2>&1
+assert_file "$DEFAULT_APP/Contents/MacOS/runt"
+assert_link "$DEFAULT_HOME/.local/bin/runt" "$DEFAULT_APP/Contents/MacOS/runt"
+grep -q "App:      $DEFAULT_APP" "$WORK/default-out.log" || fail "darwin default: summary should name ~/Applications app"
 
 note "darwin desktop reinstall replaces the bundle"
 PATH="$WORK/shim-darwin:$PATH" run_installer "$DARWIN_HOME" \


### PR DESCRIPTION
## Summary

The release installer now handles macOS (Apple silicon + Intel) alongside Linux x64, so the `sh.nteract.io` one-liner — and the `--headless` workstation path — work on a Mac.

- **Desktop**: downloads `nteract-<channel>-darwin-<arch>.app.tar.gz` (the signed bundle already carries the `runt`/`runtimed`/`nteract-mcp` sidecars in `Contents/MacOS`), installs it to `~/Applications` (where the channel's app-launch candidates look), and links the commands from the bundle into `~/.local/bin`.
- **Headless** (`--headless`): keeps the bundle under the prefix instead — a workstation box never grows an Applications entry — and links only the commands. The completion hint now leads with the `runt workstation connect` pairing flow (#3611).
- The daemon-service step is unchanged: `runt daemon doctor --fix` already speaks launchd.
- The script keeps its historical `install-linux-release` name because releases and the `sh.nteract.io` bootstrap fetch that asset name; the header comment records this.
- Docs: README + `docs/remote-workstation.md` now lead with the live `sh.nteract.io` entrypoint (the "once the domain is live" note was stale — it serves today) and the Linux-or-macOS framing.

## Tests

`scripts/test-install-release` runs the real installer against `--from-dir` fixtures with a sandboxed `HOME`; Darwin paths run on any host via a PATH-shimmed `uname`. Covers: linux desktop, darwin desktop, darwin reinstall (atomic bundle replace), darwin headless, unsupported-platform rejection. All green.

## Sequencing note

`sh.nteract.io` fetches this script from the **latest release's** assets, so macOS support flows through the one-liner once the next release carries it. A companion install-sh PR extends the bootstrap's platform gate and adds a self-healing fallback to `main`'s script for Darwin until then.
