### PR TITLE
fix(sift): publish Arrow chunks and logical dataset rows

### DIFF
--- a/crates/runtimed/src/output_blob_publisher.rs
+++ b/crates/runtimed/src/output_blob_publisher.rs
@@ -45,7 +45,12 @@ impl OutputBlobPublisher {
             return Ok(());
         };
 
-        for blob in manifest.blob_refs() {
+        let blobs = manifest.blob_refs(blob_store).await.map_err(|error| {
+            BlobPublishError::InvalidManifest {
+                message: error.to_string(),
+            }
+        })?;
+        for blob in blobs {
             cloud.publish_blob(blob, blob_store).await?;
         }
         Ok(())
@@ -207,6 +212,8 @@ pub(crate) enum BlobPublishError {
         expected: u64,
         actual: u64,
     },
+    #[error("failed to enumerate output manifest blobs: {message}")]
+    InvalidManifest { message: String },
     #[error("failed to upload blob {hash}: {message}")]
     RemoteRequest { hash: String, message: String },
     #[error("blob {hash} upload failed with {status}: {body}")]
@@ -226,9 +233,10 @@ impl BlobPublishError {
                     || *status == StatusCode::TOO_MANY_REQUESTS
                     || status.is_server_error()
             }
-            Self::MissingLocalBlob { .. } | Self::LocalRead { .. } | Self::SizeMismatch { .. } => {
-                false
-            }
+            Self::MissingLocalBlob { .. }
+            | Self::LocalRead { .. }
+            | Self::SizeMismatch { .. }
+            | Self::InvalidManifest { .. } => false,
         }
     }
 }

--- a/crates/runtimed/src/output_store.rs
+++ b/crates/runtimed/src/output_store.rs
@@ -527,13 +527,23 @@ impl OutputManifest {
         }
     }
 
-    pub(crate) fn blob_refs(&self) -> Vec<OutputBlobRef> {
+    pub(crate) async fn blob_refs(&self, blob_store: &BlobStore) -> io::Result<Vec<OutputBlobRef>> {
         let mut refs = Vec::new();
         match self {
             OutputManifest::DisplayData { data, .. }
             | OutputManifest::ExecuteResult { data, .. } => {
                 for (media_type, content_ref) in data {
                     push_blob_ref(&mut refs, content_ref, media_type);
+                }
+                if let Some(arrow_manifest) = data.get(ARROW_STREAM_MANIFEST_MIME) {
+                    let content = arrow_manifest.resolve(blob_store).await?;
+                    let manifest = serde_json::from_str(&content).map_err(|error| {
+                        io::Error::new(
+                            io::ErrorKind::InvalidData,
+                            format!("failed to parse Arrow stream manifest: {error}"),
+                        )
+                    })?;
+                    collect_arrow_manifest_blob_refs(&manifest, blob_store, &mut refs).await?;
                 }
             }
             OutputManifest::Stream { text, .. } => {
@@ -548,7 +558,7 @@ impl OutputManifest {
                 }
             }
         }
-        refs
+        Ok(refs)
     }
 }
 
@@ -560,6 +570,90 @@ fn push_blob_ref(refs: &mut Vec<OutputBlobRef>, content_ref: &ContentRef, media_
             media_type: media_type.to_string(),
         });
     }
+}
+
+async fn collect_arrow_manifest_blob_refs(
+    manifest: &Value,
+    blob_store: &BlobStore,
+    refs: &mut Vec<OutputBlobRef>,
+) -> io::Result<()> {
+    let fallback_media_type = manifest
+        .get("content_type")
+        .and_then(Value::as_str)
+        .unwrap_or(ARROW_STREAM_MIME);
+
+    if let Some(chunks) = manifest.get("chunks").and_then(Value::as_array) {
+        for chunk in chunks {
+            push_arrow_manifest_blob_ref(refs, chunk, fallback_media_type, blob_store).await?;
+        }
+    }
+    if let Some(blobs) = manifest.get("blobs").and_then(Value::as_array) {
+        for blob in blobs {
+            push_arrow_manifest_blob_ref(refs, blob, fallback_media_type, blob_store).await?;
+        }
+    }
+    if let Some(coalesced) = manifest.get("coalesced") {
+        push_arrow_manifest_blob_ref(refs, coalesced, fallback_media_type, blob_store).await?;
+        if let Some(segments) = coalesced.get("segments").and_then(Value::as_array) {
+            for segment in segments {
+                push_arrow_manifest_blob_ref(refs, segment, fallback_media_type, blob_store)
+                    .await?;
+            }
+        }
+    }
+
+    Ok(())
+}
+
+async fn push_arrow_manifest_blob_ref(
+    refs: &mut Vec<OutputBlobRef>,
+    value: &Value,
+    fallback_media_type: &str,
+    blob_store: &BlobStore,
+) -> io::Result<()> {
+    let Some(hash) = value
+        .get("hash")
+        .or_else(|| value.get("blob"))
+        .and_then(Value::as_str)
+    else {
+        return Ok(());
+    };
+
+    let meta = if value.get("size").and_then(Value::as_u64).is_some()
+        && value
+            .get("media_type")
+            .or_else(|| value.get("content_type"))
+            .and_then(Value::as_str)
+            .is_some()
+    {
+        None
+    } else {
+        blob_store.get_meta(hash).await?
+    };
+    let size = value
+        .get("size")
+        .and_then(Value::as_u64)
+        .or_else(|| meta.as_ref().map(|meta| meta.size))
+        .ok_or_else(|| {
+            io::Error::new(
+                io::ErrorKind::NotFound,
+                format!("Arrow stream blob metadata not found: {hash}"),
+            )
+        })?;
+    let media_type = value
+        .get("media_type")
+        .or_else(|| value.get("content_type"))
+        .and_then(Value::as_str)
+        .map(str::to_string)
+        .or_else(|| meta.as_ref().map(|meta| meta.media_type.clone()))
+        .unwrap_or_else(|| fallback_media_type.to_string());
+
+    refs.push(OutputBlobRef {
+        hash: hash.to_string(),
+        size,
+        media_type,
+    });
+    Ok(())
 }
 
 // =============================================================================
@@ -1701,8 +1795,10 @@ mod tests {
         assert_eq!(p.frames, 0);
     }
 
-    #[test]
-    fn output_manifest_blob_refs_collect_direct_content_refs() {
+    #[tokio::test]
+    async fn output_manifest_blob_refs_collect_direct_content_refs() {
+        let dir = tempfile::tempdir().unwrap();
+        let blob_store = test_store(&dir);
         let mut display_data = HashMap::new();
         display_data.insert(
             "image/png".to_string(),
@@ -1750,9 +1846,9 @@ mod tests {
         };
 
         let mut refs = Vec::new();
-        refs.extend(display.blob_refs());
-        refs.extend(stream.blob_refs());
-        refs.extend(error.blob_refs());
+        refs.extend(display.blob_refs(&blob_store).await.unwrap());
+        refs.extend(stream.blob_refs(&blob_store).await.unwrap());
+        refs.extend(error.blob_refs(&blob_store).await.unwrap());
         refs.sort_by(|left, right| left.hash.cmp(&right.hash));
 
         assert_eq!(
@@ -1777,6 +1873,99 @@ mod tests {
                     hash: "traceback-hash".to_string(),
                     size: 789,
                     media_type: "application/json".to_string(),
+                },
+            ]
+        );
+    }
+
+    #[tokio::test]
+    async fn output_manifest_blob_refs_collect_inline_arrow_stream_chunks() {
+        let dir = tempfile::tempdir().unwrap();
+        let blob_store = test_store(&dir);
+        let chunk = b"arrow stream chunk";
+        let chunk_hash = blob_store.put(chunk, ARROW_STREAM_MIME).await.unwrap();
+        let arrow_manifest = json!({
+            "version": 1,
+            "content_type": ARROW_STREAM_MIME,
+            "chunks": [{
+                "hash": chunk_hash,
+                "size": chunk.len(),
+                "row_count": 2
+            }],
+            "complete": true
+        });
+        let manifest = OutputManifest::DisplayData {
+            output_id: "out-arrow".to_string(),
+            data: HashMap::from([(
+                ARROW_STREAM_MANIFEST_MIME.to_string(),
+                ContentRef::Inline {
+                    inline: arrow_manifest.to_string(),
+                },
+            )]),
+            metadata: HashMap::new(),
+            transient: TransientData::default(),
+        };
+
+        assert_eq!(
+            manifest.blob_refs(&blob_store).await.unwrap(),
+            vec![OutputBlobRef {
+                hash: chunk_hash,
+                size: chunk.len() as u64,
+                media_type: ARROW_STREAM_MIME.to_string(),
+            }]
+        );
+    }
+
+    #[tokio::test]
+    async fn output_manifest_blob_refs_collect_chunks_from_blob_backed_arrow_manifest() {
+        let dir = tempfile::tempdir().unwrap();
+        let blob_store = test_store(&dir);
+        let chunk = b"arrow stream chunk";
+        let chunk_hash = blob_store.put(chunk, ARROW_STREAM_MIME).await.unwrap();
+        let arrow_manifest = json!({
+            "version": 1,
+            "content_type": ARROW_STREAM_MIME,
+            "chunks": [{
+                "blob": chunk_hash,
+                "size": chunk.len(),
+                "row_count": 2
+            }],
+            "complete": true
+        })
+        .to_string();
+        let manifest_hash = blob_store
+            .put(arrow_manifest.as_bytes(), ARROW_STREAM_MANIFEST_MIME)
+            .await
+            .unwrap();
+        let manifest = OutputManifest::ExecuteResult {
+            output_id: "out-arrow".to_string(),
+            data: HashMap::from([(
+                ARROW_STREAM_MANIFEST_MIME.to_string(),
+                ContentRef::Blob {
+                    blob: manifest_hash.clone(),
+                    size: arrow_manifest.len() as u64,
+                },
+            )]),
+            metadata: HashMap::new(),
+            execution_count: Some(1),
+            transient: TransientData::default(),
+        };
+
+        let mut refs = manifest.blob_refs(&blob_store).await.unwrap();
+        refs.sort_by(|left, right| left.media_type.cmp(&right.media_type));
+
+        assert_eq!(
+            refs,
+            vec![
+                OutputBlobRef {
+                    hash: chunk_hash,
+                    size: chunk.len() as u64,
+                    media_type: ARROW_STREAM_MIME.to_string(),
+                },
+                OutputBlobRef {
+                    hash: manifest_hash,
+                    size: arrow_manifest.len() as u64,
+                    media_type: ARROW_STREAM_MANIFEST_MIME.to_string(),
                 },
             ]
         );

--- a/python/nteract-kernel-launcher/nteract_kernel_launcher/_bootstrap.py
+++ b/python/nteract-kernel-launcher/nteract_kernel_launcher/_bootstrap.py
@@ -204,21 +204,31 @@ def _arrow_stream_mimebundle(source: Any, include=None, exclude=None) -> dict | 
 def _dataset_mimebundle(ds: Any, include=None, exclude=None) -> dict | None:
     """Emit Arrow IPC bytes + HF features summary for a ``datasets.Dataset``.
 
-    The underlying ``ds.data.table`` carries the ``huggingface`` schema KV
+    The Arrow-formatted logical view preserves the ``huggingface`` schema KV
     metadata that Sift uses to detect rich types (Image, ClassLabel,
-    Translation, …). Going through the arrow table preserves that metadata
-    end-to-end. When no underlying table is available (IterableDataset,
-    streaming, …), fall back to the legacy summary-only bundle so the
-    formatter stays best-effort.
+    Translation, …) while also applying any Dataset indices mapping from
+    ``shuffle`` / ``select``. Reading ``ds.data.table`` directly would expose
+    the physical backing rows instead. When no table-backed logical view is
+    available (IterableDataset, streaming, …), fall back to the legacy
+    summary-only bundle so the formatter stays best-effort.
     """
-    table = getattr(getattr(ds, "data", None), "table", None)
     summary = lambda: summarize_dataset(ds)  # noqa: E731
+    table = getattr(getattr(ds, "data", None), "table", None)
 
     if table is None:
         try:
             return {"text/llm+plain": summary()}
         except Exception as exc:  # noqa: BLE001
             log.debug("dataset mimebundle failed: %s", exc)
+            return None
+
+    try:
+        table = ds.with_format("arrow")[:]
+    except Exception as exc:  # noqa: BLE001
+        log.debug("dataset logical Arrow materialization failed: %s", exc)
+        try:
+            return {"text/llm+plain": summary()}
+        except Exception:  # noqa: BLE001
             return None
 
     total_rows = getattr(ds, "num_rows", table.num_rows)

--- a/python/nteract-kernel-launcher/tests/test_bootstrap.py
+++ b/python/nteract-kernel-launcher/tests/test_bootstrap.py
@@ -856,6 +856,41 @@ def test_dataset_mimebundle_emits_arrow_ipc_with_hf_features():
     assert b'"_type": "Image"' in md[b"huggingface"]
 
 
+def test_dataset_mimebundle_applies_logical_indices_mapping():
+    """Selected/shuffled datasets must render their logical rows, not every
+    row in the physical backing table that ``Dataset.data.table`` exposes."""
+    import io
+
+    pa = pytest.importorskip("pyarrow")
+    pytest.importorskip("datasets")
+    from datasets import Dataset
+    from nteract_kernel_launcher import _bootstrap, _buffer_hook
+    from nteract_kernel_launcher._format import ARROW_STREAM_MANIFEST_MIME
+    from nteract_kernel_launcher._refs import BLOB_REF_MIME
+
+    _buffer_hook.pending_buffers().clear()
+
+    ds = Dataset.from_dict({"id": [0, 1, 2, 3, 4], "value": ["a", "b", "c", "d", "e"]})
+    selected = ds.select([4, 2, 0])
+    assert selected._indices is not None
+    assert selected.data.table.num_rows == 5
+
+    bundle = _bootstrap._dataset_mimebundle(selected)
+
+    assert bundle is not None
+    ref = bundle[BLOB_REF_MIME]
+    data = _buffer_hook.pending_buffers()[ref["hash"]]
+    rendered = pa.ipc.open_stream(io.BytesIO(data)).read_all()
+    assert rendered.column("id").to_pylist() == [4, 2, 0]
+    assert rendered.num_rows == selected.num_rows
+    assert bundle[ARROW_STREAM_MANIFEST_MIME]["summary"] == {
+        "total_rows": 3,
+        "included_rows": 3,
+        "sampled": False,
+        "sample_strategy": "none",
+    }
+
+
 def test_dataset_mimebundle_falls_back_to_summary_when_no_table():
     """Streaming / iterable datasets have no ``.data.table``; the formatter
     must keep the legacy text-only behavior so it stays best-effort."""


### PR DESCRIPTION
## Summary

- publish Arrow stream chunk blobs to the hosted notebook blob API before `RuntimeStateDoc` advertises their hashes
- enumerate nested chunk refs from both inline and blob-backed Arrow manifests
- materialize the logical Arrow view of Hugging Face datasets so shuffle/select indices determine the rows and order Sift receives
- replace the old provisional-footer treatment with fixes at the two producer boundaries that created the mismatched/missing data

## Root cause

There were two independent producer bugs:

1. The cloud output publisher only walked top-level `ContentRef::Blob` values. Arrow stream chunks are nested inside `application/vnd.nteract.arrow-stream-manifest+json`, so the runtime could sync a complete-looking manifest while never uploading the chunk bytes that Sift later requested from `/api/n/:id/blobs/:hash`.
2. The Hugging Face formatter serialized `Dataset.data.table`, which is the physical backing table. A shuffled or selected Dataset can instead own a logical indices mapping, so the emitted bytes could contain different rows (and a different row count) than `Dataset.num_rows` described.

## Verification

- `cargo test -p runtimed` (1089 unit tests passed, 2 ignored; all integration and lint tests passed)
- `uv run pytest python/nteract-kernel-launcher/tests -q` (113 passed)
- `cargo xtask lint --fix`

## Deployment note

Existing outputs whose manifests already reference an absent hosted blob will remain broken. After this ships in the runtime/workstation build, re-executing the cell republishes the chunk bytes before syncing the output manifest.
