### PR TITLE
fix(cloud): allow workstation runtime output uploads

### DIFF
--- a/apps/notebook-cloud/src/index.ts
+++ b/apps/notebook-cloud/src/index.ts
@@ -3368,7 +3368,9 @@ async function routeBlob(
     return originRejection;
   }
 
-  const identity = await authenticateRequestOrResponse(request, env);
+  const identity = await authenticateRequestOrResponse(request, env, {
+    allowWorkstationCredential: true,
+  });
   if (identity instanceof Response) {
     return identity;
   }

--- a/apps/notebook-cloud/test/worker-routes.test.ts
+++ b/apps/notebook-cloud/test/worker-routes.test.ts
@@ -4668,6 +4668,55 @@ describe("Workstation pairing", () => {
     );
   });
 
+  it("lets a paired workstation credential upload runtime output blobs", async () => {
+    const env = fakeEnv();
+    seedNotebook(env, "pairing-blob-demo");
+    seedAcl(env, { notebookId: "pairing-blob-demo", subject: "user:dev:alice", scope: "owner" });
+
+    const pairing = await mintPairingCode(env);
+    const token = await redeemedCredentialToken(env, pairing.code);
+
+    const register = await registerWorkstationWithToken(env, token, "ws-paired");
+    assert.equal(register.status, 201);
+
+    const attach = await worker.fetch(
+      new Request("http://localhost/api/n/pairing-blob-demo/workstation-attachments", {
+        method: "POST",
+        headers: { "Content-Type": "application/json", ...OWNER_HEADERS },
+        body: JSON.stringify({ workstation_id: "ws-paired" }),
+      }),
+      env,
+      fakeContext(),
+    );
+    assert.equal(attach.status, 202);
+
+    const body = new Uint8Array([1, 3, 3, 7]);
+    const hash = await sha256Hex(body);
+
+    const response = await scopedPut(env, `/api/n/pairing-blob-demo/blobs/${hash}`, body, {
+      Authorization: `Bearer ${token}`,
+      "Content-Type": "application/vnd.apache.arrow.stream",
+      "X-Scope": "runtime_peer",
+      "X-Operator": "agent:runt:blob-publisher",
+    });
+
+    assert.equal(response.status, 201);
+    assert.deepEqual(await response.json(), {
+      ok: true,
+      key: blobKey("pairing-blob-demo", hash),
+      size: body.byteLength,
+    });
+    assert.equal(env.NOTEBOOK_SNAPSHOTS.objects.has(blobKey("pairing-blob-demo", hash)), true);
+    assert.deepEqual(env.DB.blobs.get(`pairing-blob-demo:${hash}`), {
+      notebook_id: "pairing-blob-demo",
+      hash,
+      size: body.byteLength,
+      content_type: "application/vnd.apache.arrow.stream",
+      r2_key: blobKey("pairing-blob-demo", hash),
+      uploaded_at: env.DB.blobs.get(`pairing-blob-demo:${hash}`)?.uploaded_at,
+    });
+  });
+
   it("consumes and mints in one batch so a code cannot burn without a credential", async () => {
     const env = fakeEnv();
     const pairing = await mintPairingCode(env);

--- a/crates/runtime-doc/src/policy.rs
+++ b/crates/runtime-doc/src/policy.rs
@@ -336,6 +336,7 @@ fn runtime_peer_status_transition_allowed(before: &str, after: &str) -> bool {
         ("queued", "running")
             | ("queued", "done")
             | ("queued", "error")
+            | ("queued", "cancelled")
             | ("running", "done")
             | ("running", "error")
     )
@@ -383,7 +384,10 @@ fn validate_runtime_peer_queue_delta(
                 "queue entries must reference existing executions",
             ));
         };
-        if matches!(execution_after.status.as_str(), "done" | "error") {
+        if matches!(
+            execution_after.status.as_str(),
+            "done" | "error" | "cancelled"
+        ) {
             return Err(runtime_state_policy_error(
                 scope,
                 "queue",
@@ -833,6 +837,22 @@ mod tests {
             )
             .unwrap();
         after_doc.set_execution_done("exec-accepted", true).unwrap();
+        let after = runtime_state_policy_snapshot(&after_doc);
+
+        validate_runtime_state_sync_scope(&before, &after, RuntimeStateWriteScope::RuntimePeer)
+            .unwrap();
+    }
+
+    #[test]
+    fn runtime_peer_policy_allows_queued_execution_cancellation() {
+        let mut before_doc = RuntimeStateDoc::new();
+        before_doc
+            .create_execution_with_source("exec-accepted", "print('accepted')", 0)
+            .unwrap();
+        let before = runtime_state_policy_snapshot(&before_doc);
+
+        let mut after_doc = RuntimeStateDoc::from_doc(before_doc.doc().clone());
+        after_doc.set_execution_cancelled("exec-accepted").unwrap();
         let after = runtime_state_policy_snapshot(&after_doc);
 
         validate_runtime_state_sync_scope(&before, &after, RuntimeStateWriteScope::RuntimePeer)


### PR DESCRIPTION
## Summary
- allow paired workstation credentials on the runtime blob upload route while preserving the `runtime_peer` scope check
- add a worker-route regression covering pairing -> registration -> attach -> content-addressed blob upload
- allow runtime peers to mark accepted queued executions as `cancelled` during shutdown, and prevent cancelled executions from remaining in queue projections

## Validation
- `node --import tsx --test test/worker-routes.test.ts --test-name-pattern "paired workstation credential upload|paired workstation credential poll|rejects workstation credentials outside"`
- `cargo test -p runtime-doc runtime_peer_policy`
- `pnpm --dir apps/notebook-cloud typecheck`
- `cargo xtask lint --fix`
- deployed preview.runt.run from `5b3456ea5861990af72719fdfb05d827ac1dae87`
- repaired `topic-viz` RuntimeStateDoc and reattached `ws-lab2`; fresh runtime peer launched Python kernel successfully
