### PR TITLE
perf(runtime): batch initial widget comm writes

### DIFF
--- a/crates/automunge/src/lib.rs
+++ b/crates/automunge/src/lib.rs
@@ -8,7 +8,10 @@
 //! can cover the workspace Automerge API we need. Until then, this is the
 //! single source of truth for JSON/Automerge conversion.
 
-use automerge::{transaction::Transactable, AutoCommit, AutomergeError, ObjId, ObjType, ReadDoc};
+use automerge::{
+    hydrate, transaction::Transactable, AutoCommit, AutomergeError, ObjId, ObjType, ReadDoc,
+    ScalarValue,
+};
 
 /// Read a string scalar at `prop`, distinguishing "absent" from "empty".
 ///
@@ -132,6 +135,46 @@ pub fn put_json_at_key(
     Ok(())
 }
 
+/// Write a JSON value at a map key, using Automerge's batched object creation
+/// for fresh object trees.
+///
+/// This is intended for new keys where replacing an existing object would be
+/// correct, such as a fresh widget `comm_id` from `comm_open`. For shared keys
+/// that may already have concurrent object identity, use
+/// [`update_json_at_key`].
+pub fn put_json_at_key_batched(
+    doc: &mut AutoCommit,
+    parent: &ObjId,
+    key: &str,
+    value: &serde_json::Value,
+) -> Result<(), AutomergeError> {
+    match value {
+        serde_json::Value::Null => {
+            doc.put(parent, key, ScalarValue::Null)?;
+        }
+        serde_json::Value::Bool(b) => {
+            doc.put(parent, key, *b)?;
+        }
+        serde_json::Value::Number(n) => {
+            if let Some(i) = n.as_i64() {
+                doc.put(parent, key, i)?;
+            } else if let Some(u) = n.as_u64() {
+                doc.put(parent, key, u)?;
+            } else if let Some(f) = n.as_f64() {
+                doc.put(parent, key, f)?;
+            }
+        }
+        serde_json::Value::String(s) => {
+            doc.put(parent, key, s.as_str())?;
+        }
+        serde_json::Value::Array(_) | serde_json::Value::Object(_) => {
+            let hydrated = json_to_hydrate(value);
+            doc.batch_create_object(parent, key, &hydrated, false)?;
+        }
+    }
+    Ok(())
+}
+
 /// Recursively insert a JSON value into an Automerge List at a given index.
 ///
 /// Safe when the parent list was just created by the caller (no competing
@@ -177,6 +220,38 @@ pub fn insert_json_at_index(
         }
     }
     Ok(())
+}
+
+fn json_to_hydrate(value: &serde_json::Value) -> hydrate::Value {
+    match value {
+        serde_json::Value::Null => hydrate::Value::Scalar(ScalarValue::Null),
+        serde_json::Value::Bool(b) => hydrate::Value::Scalar(ScalarValue::Boolean(*b)),
+        serde_json::Value::Number(n) => {
+            if let Some(i) = n.as_i64() {
+                hydrate::Value::Scalar(ScalarValue::Int(i))
+            } else if let Some(u) = n.as_u64() {
+                hydrate::Value::Scalar(ScalarValue::Uint(u))
+            } else if let Some(f) = n.as_f64() {
+                hydrate::Value::Scalar(ScalarValue::F64(f))
+            } else {
+                hydrate::Value::Scalar(ScalarValue::Null)
+            }
+        }
+        serde_json::Value::String(s) => hydrate::Value::Scalar(ScalarValue::Str(s.into())),
+        serde_json::Value::Array(values) => hydrate::Value::List(
+            values
+                .iter()
+                .map(json_to_hydrate)
+                .collect::<Vec<_>>()
+                .into(),
+        ),
+        serde_json::Value::Object(map) => hydrate::Value::Map(
+            map.iter()
+                .map(|(key, value)| (key.clone(), json_to_hydrate(value)))
+                .collect::<std::collections::HashMap<_, _>>()
+                .into(),
+        ),
+    }
 }
 
 /// Recursively update a JSON value in an Automerge Map, reusing existing objects.
@@ -359,6 +434,23 @@ mod tests {
         let mut doc = AutoCommit::new();
         doc.put(ROOT, "count", 7i64)?;
         assert_eq!(read_str_if_present(&doc, &ROOT, "count"), None);
+        Ok(())
+    }
+
+    #[test]
+    fn put_json_at_key_batched_roundtrips_nested_json() -> Result<(), AutomergeError> {
+        let mut doc = AutoCommit::new();
+        let value = serde_json::json!({
+            "name": "widget",
+            "count": 7,
+            "enabled": true,
+            "tags": ["a", "b"],
+            "nested": { "value": 42 },
+        });
+
+        put_json_at_key_batched(&mut doc, &ROOT, "state", &value)?;
+
+        assert_eq!(read_json_value(&doc, &ROOT, "state"), Some(value));
         Ok(())
     }
 }

--- a/crates/runtime-doc/src/comms.rs
+++ b/crates/runtime-doc/src/comms.rs
@@ -222,7 +222,11 @@ impl CommsDoc {
         state: &serde_json::Value,
     ) -> Result<(), RuntimeStateError> {
         let comms = self.scaffold_map("comms")?;
-        automunge::update_json_at_key(&mut self.doc, &comms, comm_id, state)?;
+        if self.doc.get(&comms, comm_id)?.is_some() {
+            automunge::update_json_at_key(&mut self.doc, &comms, comm_id, state)?;
+        } else {
+            automunge::put_json_at_key_batched(&mut self.doc, &comms, comm_id, state)?;
+        }
         Ok(())
     }
 

--- a/crates/runtime-doc/src/doc.rs
+++ b/crates/runtime-doc/src/doc.rs
@@ -2718,15 +2718,19 @@ impl RuntimeStateDoc {
         seq: u64,
     ) -> Result<(), RuntimeStateError> {
         let comms = self.scaffold_map("comms")?;
-        let entry = self.doc.put_object(&comms, comm_id, ObjType::Map)?;
-        self.doc.put(&entry, "target_name", target_name)?;
-        self.doc.put(&entry, "model_module", model_module)?;
-        self.doc.put(&entry, "model_name", model_name)?;
-        #[allow(deprecated)]
-        automunge::put_json_at_key(&mut self.doc, &entry, "state", state)?;
-        self.doc.put(&entry, "seq", seq as i64)?;
-        self.doc.put_object(&entry, "outputs", ObjType::List)?;
-        self.doc.put(&entry, "capture_msg_id", "")?;
+        // A comm-open owns this topology record as a replaceable snapshot. The
+        // mutable widget values live in CommsDoc, where existing object identity
+        // is preserved on later comm_msg updates.
+        let entry = serde_json::json!({
+            "target_name": target_name,
+            "model_module": model_module,
+            "model_name": model_name,
+            "state": state,
+            "seq": seq as i64,
+            "outputs": [],
+            "capture_msg_id": "",
+        });
+        automunge::put_json_at_key_batched(&mut self.doc, &comms, comm_id, &entry)?;
         Ok(())
     }
 

--- a/crates/runtimed/src/output_commit_measure.rs
+++ b/crates/runtimed/src/output_commit_measure.rs
@@ -10,7 +10,8 @@ use std::collections::VecDeque;
 use std::time::Instant;
 
 use anyhow::{ensure, Context};
-use runtime_doc::{diff_output_ids, diff_output_ids_in_place, RuntimeStateDoc};
+use automerge::ActorId;
+use runtime_doc::{diff_output_ids, diff_output_ids_in_place, CommsDoc, RuntimeStateDoc};
 use serde::Serialize;
 use uuid::Uuid;
 
@@ -19,6 +20,8 @@ use crate::output_redaction::OutputRedactor;
 use crate::output_store::{self, DEFAULT_INLINE_THRESHOLD};
 
 const EXECUTION_ID: &str = "exec-output-commit-measure";
+const COMM_OPEN_RUNTIME_ACTOR: &str = "user:perf/agent:runt:00000000";
+const COMM_OPEN_KERNEL_ACTOR: &str = "user:perf/runtime:kernel:00000000";
 
 #[derive(Debug, Clone, Copy, Serialize)]
 #[serde(rename_all = "snake_case")]
@@ -51,6 +54,21 @@ impl Default for OutputCommitMeasurementConfig {
             output_count: 100,
             payload_bytes: 256,
             kind: OutputCommitKind::DisplayData,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy)]
+pub struct CommOpenMeasurementConfig {
+    pub comm_count: usize,
+    pub state_bytes: usize,
+}
+
+impl Default for CommOpenMeasurementConfig {
+    fn default() -> Self {
+        Self {
+            comm_count: 100,
+            state_bytes: 1024,
         }
     }
 }
@@ -98,6 +116,20 @@ pub struct OutputIdDiffMeasurement {
     pub diff_nanos: u128,
 }
 
+#[derive(Debug, Clone, Serialize)]
+pub struct CommOpenMeasurement {
+    pub strategy: &'static str,
+    pub comm_count: usize,
+    pub state_bytes: usize,
+    pub runtime_doc_writes: usize,
+    pub comms_doc_writes: usize,
+    pub committed_topology: usize,
+    pub committed_comm_states: usize,
+    pub runtime_doc_nanos: u128,
+    pub comms_doc_nanos: u128,
+    pub total_nanos: u128,
+}
+
 impl OutputCommitMeasurement {
     fn new(strategy: &'static str, config: OutputCommitMeasurementConfig) -> Self {
         Self {
@@ -116,6 +148,23 @@ impl OutputCommitMeasurement {
             manifest_nanos: 0,
             append_nanos: 0,
             worker_nanos: 0,
+            total_nanos: 0,
+        }
+    }
+}
+
+impl CommOpenMeasurement {
+    fn new(strategy: &'static str, config: CommOpenMeasurementConfig) -> Self {
+        Self {
+            strategy,
+            comm_count: config.comm_count,
+            state_bytes: config.state_bytes,
+            runtime_doc_writes: 0,
+            comms_doc_writes: 0,
+            committed_topology: 0,
+            committed_comm_states: 0,
+            runtime_doc_nanos: 0,
+            comms_doc_nanos: 0,
             total_nanos: 0,
         }
     }
@@ -419,8 +468,228 @@ pub async fn measure_output_id_diff_paths(
     ])
 }
 
+pub fn measure_current_comm_open_loop(
+    config: CommOpenMeasurementConfig,
+) -> anyhow::Result<CommOpenMeasurement> {
+    let started = Instant::now();
+    let mut metrics = CommOpenMeasurement::new("current_per_comm_transactions", config);
+    let mut runtime_doc = RuntimeStateDoc::try_new_with_actor(COMM_OPEN_RUNTIME_ACTOR)?;
+    let mut comms_doc = CommsDoc::try_new_with_actor(COMM_OPEN_RUNTIME_ACTOR)?;
+
+    for index in 0..config.comm_count {
+        let comm_id = measured_comm_id(index);
+        let state = measured_widget_state(index, config.state_bytes);
+        let model_module = state
+            .get("_model_module")
+            .and_then(|v| v.as_str())
+            .unwrap_or("");
+        let model_name = state
+            .get("_model_name")
+            .and_then(|v| v.as_str())
+            .unwrap_or("");
+
+        let runtime_started = Instant::now();
+        runtime_doc.put_comm(
+            &comm_id,
+            "jupyter.widget",
+            model_module,
+            model_name,
+            &serde_json::json!({}),
+            index as u64,
+        )?;
+        metrics.runtime_doc_nanos += runtime_started.elapsed().as_nanos();
+        metrics.runtime_doc_writes += 1;
+
+        let comms_started = Instant::now();
+        let heads = comms_doc.get_heads();
+        comms_doc.transact_at_heads_recovering(
+            &heads,
+            Some(COMM_OPEN_KERNEL_ACTOR),
+            "measure-current-comm-open",
+            |doc| doc.put_comm_state(&comm_id, &state),
+        )?;
+        metrics.comms_doc_nanos += comms_started.elapsed().as_nanos();
+        metrics.comms_doc_writes += 1;
+    }
+
+    metrics.committed_topology = runtime_doc.get_comms().len();
+    metrics.committed_comm_states = comms_doc.get_comms().len();
+    ensure_comm_open_measurement(&metrics)?;
+    metrics.total_nanos = started.elapsed().as_nanos();
+    Ok(metrics)
+}
+
+pub fn measure_batched_comm_open_loop(
+    config: CommOpenMeasurementConfig,
+) -> anyhow::Result<CommOpenMeasurement> {
+    let started = Instant::now();
+    let mut metrics = CommOpenMeasurement::new("batched_comm_open_transactions", config);
+    let mut runtime_doc = RuntimeStateDoc::try_new_with_actor(COMM_OPEN_RUNTIME_ACTOR)?;
+    let mut comms_doc = CommsDoc::try_new_with_actor(COMM_OPEN_RUNTIME_ACTOR)?;
+    let states = measured_widget_states(config);
+
+    let runtime_started = Instant::now();
+    for (index, (comm_id, state)) in states.iter().enumerate() {
+        let model_module = state
+            .get("_model_module")
+            .and_then(|v| v.as_str())
+            .unwrap_or("");
+        let model_name = state
+            .get("_model_name")
+            .and_then(|v| v.as_str())
+            .unwrap_or("");
+        runtime_doc.put_comm(
+            comm_id,
+            "jupyter.widget",
+            model_module,
+            model_name,
+            &serde_json::json!({}),
+            index as u64,
+        )?;
+        metrics.runtime_doc_writes += 1;
+    }
+    metrics.runtime_doc_nanos = runtime_started.elapsed().as_nanos();
+
+    let comms_started = Instant::now();
+    let heads = comms_doc.get_heads();
+    comms_doc.transact_at_heads_recovering(
+        &heads,
+        Some(COMM_OPEN_KERNEL_ACTOR),
+        "measure-batched-comm-open",
+        |doc| {
+            for (comm_id, state) in &states {
+                doc.put_comm_state(comm_id, state)?;
+                metrics.comms_doc_writes += 1;
+            }
+            Ok(())
+        },
+    )?;
+    metrics.comms_doc_nanos = comms_started.elapsed().as_nanos();
+
+    metrics.committed_topology = runtime_doc.get_comms().len();
+    metrics.committed_comm_states = comms_doc.get_comms().len();
+    ensure_comm_open_measurement(&metrics)?;
+    metrics.total_nanos = started.elapsed().as_nanos();
+    Ok(metrics)
+}
+
+pub fn measure_direct_actor_comm_open_loop(
+    config: CommOpenMeasurementConfig,
+) -> anyhow::Result<CommOpenMeasurement> {
+    let started = Instant::now();
+    let mut metrics = CommOpenMeasurement::new("direct_actor_comm_open_writes", config);
+    let mut runtime_doc = RuntimeStateDoc::try_new_with_actor(COMM_OPEN_RUNTIME_ACTOR)?;
+    let mut comms_doc = CommsDoc::try_new_with_actor(COMM_OPEN_RUNTIME_ACTOR)?;
+    let states = measured_widget_states(config);
+
+    let runtime_started = Instant::now();
+    for (index, (comm_id, state)) in states.iter().enumerate() {
+        let model_module = state
+            .get("_model_module")
+            .and_then(|v| v.as_str())
+            .unwrap_or("");
+        let model_name = state
+            .get("_model_name")
+            .and_then(|v| v.as_str())
+            .unwrap_or("");
+        runtime_doc.put_comm(
+            comm_id,
+            "jupyter.widget",
+            model_module,
+            model_name,
+            &serde_json::json!({}),
+            index as u64,
+        )?;
+        metrics.runtime_doc_writes += 1;
+    }
+    metrics.runtime_doc_nanos = runtime_started.elapsed().as_nanos();
+
+    let comms_started = Instant::now();
+    let original_actor = comms_doc.doc().get_actor().clone();
+    comms_doc
+        .doc_mut()
+        .set_actor(ActorId::from(COMM_OPEN_KERNEL_ACTOR.as_bytes()));
+    for (comm_id, state) in &states {
+        comms_doc.put_comm_state(comm_id, state)?;
+        metrics.comms_doc_writes += 1;
+    }
+    comms_doc.doc_mut().set_actor(original_actor);
+    metrics.comms_doc_nanos = comms_started.elapsed().as_nanos();
+
+    metrics.committed_topology = runtime_doc.get_comms().len();
+    metrics.committed_comm_states = comms_doc.get_comms().len();
+    ensure_comm_open_measurement(&metrics)?;
+    metrics.total_nanos = started.elapsed().as_nanos();
+    Ok(metrics)
+}
+
+pub fn measure_comm_open_paths(
+    config: CommOpenMeasurementConfig,
+) -> anyhow::Result<Vec<CommOpenMeasurement>> {
+    Ok(vec![
+        measure_current_comm_open_loop(config)?,
+        measure_batched_comm_open_loop(config)?,
+        measure_direct_actor_comm_open_loop(config)?,
+    ])
+}
+
+fn ensure_comm_open_measurement(metrics: &CommOpenMeasurement) -> anyhow::Result<()> {
+    ensure!(
+        metrics.committed_topology == metrics.comm_count,
+        "{} committed unexpected topology count",
+        metrics.strategy
+    );
+    ensure!(
+        metrics.committed_comm_states == metrics.comm_count,
+        "{} committed unexpected comm state count",
+        metrics.strategy
+    );
+    Ok(())
+}
+
 fn output_commit_measure_blob_root() -> std::path::PathBuf {
     std::env::temp_dir().join(format!("runtimed-output-commit-measure-{}", Uuid::new_v4()))
+}
+
+fn measured_widget_states(config: CommOpenMeasurementConfig) -> Vec<(String, serde_json::Value)> {
+    (0..config.comm_count)
+        .map(|index| {
+            (
+                measured_comm_id(index),
+                measured_widget_state(index, config.state_bytes),
+            )
+        })
+        .collect()
+}
+
+fn measured_comm_id(index: usize) -> String {
+    format!("comm-output-commit-measure-{index:06}")
+}
+
+fn measured_widget_state(index: usize, state_bytes: usize) -> serde_json::Value {
+    let label = format!("Measured widget {index}");
+    let base = serde_json::json!({
+        "_model_module": "@jupyter-widgets/controls",
+        "_model_module_version": "2.0.0",
+        "_model_name": "IntSliderModel",
+        "_view_module": "@jupyter-widgets/controls",
+        "_view_module_version": "2.0.0",
+        "_view_name": "IntSliderView",
+        "description": label,
+        "min": 0,
+        "max": 100,
+        "step": 1,
+        "value": index as i64,
+    });
+
+    let mut object = base.as_object().cloned().unwrap_or_default();
+    let current_len = serde_json::to_string(&object).map(|s| s.len()).unwrap_or(0);
+    let padding_len = state_bytes.saturating_sub(current_len + "\"padding\":\"\"".len());
+    object.insert(
+        "padding".to_string(),
+        serde_json::Value::String("x".repeat(padding_len)),
+    );
+    serde_json::Value::Object(object)
 }
 
 fn measured_output(
@@ -550,5 +819,44 @@ mod tests {
             assert_eq!(metric.removed_outputs, 0);
             assert_eq!(metric.snapshot_outputs, 5);
         }
+    }
+
+    #[test]
+    fn comm_open_measurement_paths_commit_equivalent_state() {
+        let metrics = measure_comm_open_paths(CommOpenMeasurementConfig {
+            comm_count: 4,
+            state_bytes: 256,
+        })
+        .expect("measurement should run");
+
+        assert_eq!(metrics.len(), 3);
+        for metric in metrics {
+            assert_eq!(metric.runtime_doc_writes, 4);
+            assert_eq!(metric.comms_doc_writes, 4);
+            assert_eq!(metric.committed_topology, 4);
+            assert_eq!(metric.committed_comm_states, 4);
+        }
+    }
+
+    #[test]
+    #[ignore = "prints local timing data for runtime comm-open perf investigations"]
+    fn print_comm_open_measurement_paths() {
+        let mut all_metrics = Vec::new();
+        for config in [
+            CommOpenMeasurementConfig {
+                comm_count: 32,
+                state_bytes: 1024,
+            },
+            CommOpenMeasurementConfig {
+                comm_count: 128,
+                state_bytes: 1024,
+            },
+        ] {
+            all_metrics.extend(measure_comm_open_paths(config).expect("measurement should run"));
+        }
+        eprintln!(
+            "{}",
+            serde_json::to_string_pretty(&all_metrics).expect("serialize measurements")
+        );
     }
 }


### PR DESCRIPTION
## Summary

This makes the shared runtime widget `comm_open` path faster by using Automerge's batched object creation for fresh JSON trees.

- adds `automunge::put_json_at_key_batched` for new/replacement map keys
- uses it for initial RuntimeStateDoc comm topology entries
- uses it for initial CommsDoc comm state, while keeping existing comm updates on `update_json_at_key` so mutable widget object identity is preserved
- adds a reproducible runtimed measurement harness for widget comm-open write paths

## Local measurement

Command:

```bash
cargo test -p runtimed print_comm_open_measurement_paths -- --ignored --nocapture
```

On lab2, the synthetic 128-widget/1KB-state comm-open path improved from the earlier baseline of about `2512ms` total to about `290ms` total after the batched JSON writes.

Current branch timing:

| Count | RuntimeStateDoc | CommsDoc | Total |
|---:|---:|---:|---:|
| 32 | 5.8ms | 16.3ms | 27.6ms |
| 128 | 54.1ms | 215.4ms | 289.6ms |

## Validation

- `cargo test -p automunge put_json_at_key_batched -- --nocapture`
- `cargo test -p runtime-doc comm -- --nocapture`
- `cargo test -p runtimed output_commit_measure -- --nocapture`
- `cargo test -p automunge`
- `cargo test -p runtime-doc`
- `cargo test -p runtimed`
- `cargo xtask lint --fix`
- `cargo build -p runtimed -p runt`

## Notes

The batched helper is deliberately documented as safe only for fresh or replaceable object trees. Shared/mutable existing JSON objects should continue to use `update_json_at_key`.
