### PR TITLE
feat(workstation): allow python path override

### DIFF
--- a/crates/runt/src/workstation_cli.rs
+++ b/crates/runt/src/workstation_cli.rs
@@ -44,7 +44,16 @@ pub enum WorkstationCommands {
         name: Option<String>,
     },
     /// Serve attach requests using the stored workstation credential
-    Run,
+    Run {
+        /// Python interpreter used for launch-on-attach kernels.
+        ///
+        /// This is a pragmatic override until workstation setup grows a
+        /// first-run configuration flow. The value is passed to the sibling
+        /// `runtimed workstation-agent`; credentials still ride only in the
+        /// environment.
+        #[arg(long)]
+        python_path: Option<PathBuf>,
+    },
     /// List workstations registered to the stored credential
     Status {
         /// Output raw JSON
@@ -61,7 +70,7 @@ pub async fn command(command: WorkstationCommands) -> Result<()> {
             id,
             name,
         } => connect(url, code, id, name).await,
-        WorkstationCommands::Run => run().await,
+        WorkstationCommands::Run { python_path } => run(python_path).await,
         WorkstationCommands::Status { json } => status(json).await,
     }
 }
@@ -260,7 +269,7 @@ pub(crate) fn minimal_registration_payload(
 // run
 // ---------------------------------------------------------------------------
 
-async fn run() -> Result<()> {
+async fn run(python_path: Option<PathBuf>) -> Result<()> {
     let resolved = resolve_credentials()?;
 
     let runtimed_bin = locate_runtimed_binary().ok_or_else(|| {
@@ -277,21 +286,41 @@ async fn run() -> Result<()> {
         resolved.display_name,
         runtimed_bin.display()
     );
+    if let Some(path) = &python_path {
+        println!("Python interpreter: {}", path.display());
+    }
 
-    let status = std::process::Command::new(&runtimed_bin)
-        .arg("workstation-agent")
-        .arg("--cloud-url")
-        .arg(&resolved.cloud_url)
-        .arg("--workstation-id")
-        .arg(&resolved.workstation_id)
-        .arg("--display-name")
-        .arg(&resolved.display_name)
+    let mut command = std::process::Command::new(&runtimed_bin);
+    command
+        .args(workstation_agent_args(&resolved, python_path.as_deref()))
         // The credential rides the environment, never argv.
-        .env(CLOUD_TOKEN_ENV, &resolved.token)
+        .env(CLOUD_TOKEN_ENV, &resolved.token);
+
+    let status = command
         .status()
         .with_context(|| format!("failed to launch {}", runtimed_bin.display()))?;
 
     std::process::exit(status.code().unwrap_or(1));
+}
+
+fn workstation_agent_args(
+    resolved: &ResolvedCredentials,
+    python_path: Option<&Path>,
+) -> Vec<std::ffi::OsString> {
+    let mut args = vec![
+        "workstation-agent".into(),
+        "--cloud-url".into(),
+        resolved.cloud_url.as_str().into(),
+        "--workstation-id".into(),
+        resolved.workstation_id.as_str().into(),
+        "--display-name".into(),
+        resolved.display_name.as_str().into(),
+    ];
+    if let Some(path) = python_path {
+        args.push("--python-path".into());
+        args.push(path.as_os_str().into());
+    }
+    args
 }
 
 /// Credentials in effect: the stored file, with `RUNT_CLOUD_TOKEN` /
@@ -641,6 +670,57 @@ mod tests {
         let sparse = minimal_registration_payload("ws", "ws", None, None);
         assert!(sparse.get("working_directory").is_none());
         assert!(sparse.get("cpu_count").is_none());
+    }
+
+    #[test]
+    fn workstation_agent_args_include_python_path_override_without_token() {
+        let resolved = ResolvedCredentials {
+            cloud_url: "https://preview.runt.run".to_string(),
+            token: "nwc_secret".to_string(),
+            workstation_id: "ws-lab2".to_string(),
+            display_name: "lab2".to_string(),
+        };
+
+        let args = workstation_agent_args(&resolved, Some(Path::new("/home/ubuntu/k/bin/python")));
+        let rendered = args
+            .iter()
+            .map(|arg| arg.to_string_lossy().into_owned())
+            .collect::<Vec<_>>();
+
+        assert_eq!(
+            rendered,
+            vec![
+                "workstation-agent",
+                "--cloud-url",
+                "https://preview.runt.run",
+                "--workstation-id",
+                "ws-lab2",
+                "--display-name",
+                "lab2",
+                "--python-path",
+                "/home/ubuntu/k/bin/python",
+            ]
+        );
+        assert!(!rendered.iter().any(|arg| arg.contains("nwc_secret")));
+    }
+
+    #[test]
+    fn workstation_agent_args_omit_python_path_when_not_overridden() {
+        let resolved = ResolvedCredentials {
+            cloud_url: "https://preview.runt.run".to_string(),
+            token: "nwc_secret".to_string(),
+            workstation_id: "ws-lab2".to_string(),
+            display_name: "lab2".to_string(),
+        };
+
+        let args = workstation_agent_args(&resolved, None);
+        let rendered = args
+            .iter()
+            .map(|arg| arg.to_string_lossy().into_owned())
+            .collect::<Vec<_>>();
+
+        assert!(!rendered.iter().any(|arg| arg == "--python-path"));
+        assert!(!rendered.iter().any(|arg| arg.contains("nwc_secret")));
     }
 
     #[test]

--- a/docs/remote-workstation.md
+++ b/docs/remote-workstation.md
@@ -61,6 +61,9 @@ runt workstation run
    running → completed/failed). The credential rides the environment
    (`RUNT_CLOUD_TOKEN`), never argv. `RUNT_CLOUD_TOKEN` / `RUNT_CLOUD_URL`
    environment variables override the stored credential when set.
+   Use `--python-path /path/to/python` when the workstation should launch
+   kernels from a project or virtual environment interpreter instead of the
+   first `python3`/`python` on `PATH`.
 
 4. Check what the credential sees:
 
@@ -90,7 +93,7 @@ Description=nteract workstation agent
 After=network-online.target
 
 [Service]
-ExecStart=%h/.local/bin/runt workstation run
+ExecStart=%h/.local/bin/runt workstation run --python-path %h/project/.venv/bin/python
 Restart=on-failure
 RestartSec=5
 


### PR DESCRIPTION
## Summary

Adds a pragmatic interpreter override for paired workstation agents:

```bash
runt workstation run --python-path /path/to/python
```

The flag is forwarded to the sibling `runtimed workstation-agent` as `--python-path`; the workstation credential still rides only through `RUNT_CLOUD_TOKEN` and is not included in argv.

This is intentionally the small unblocker. A more user-centered first-run setup can later prompt for interpreter/CWD defaults and persist them in workstation config.

## Validation

- `cargo test -p runt workstation_agent_args -- --nocapture`
- `cargo run -p runt -- workstation run --help`
- `cargo test -p runt`
- `cargo xtask lint --fix`
- relaunched lab2 with `target/debug/runt workstation run --python-path /home/ubuntu/k/bin/python`; `runt workstation status --json` reports `ws-lab2` online
