### PR TITLE
feat(workstations): measure and forward runtime peer commands

### DIFF
--- a/apps/notebook-cloud/scripts/hosted-workstation-toolbar-smoke.mjs
+++ b/apps/notebook-cloud/scripts/hosted-workstation-toolbar-smoke.mjs
@@ -232,6 +232,8 @@ async function runBrowserSmoke({
         "cell_output_observed_after_execute",
         "restart_button_clicked",
         "cell_output_observed_after_restart",
+        "restart_run_all_button_clicked",
+        "all_cell_outputs_observed_after_restart_run_all",
         "page_reload_preserved_output",
         "cell_output_observed_after_reload_execute",
         "owner_no_workstations_shows_setup_action",
@@ -288,9 +290,20 @@ async function runOwnerAttachAndExecuteSmoke({
   const afterRestartKernelStatus = await readKernelStatus(page);
   assertKernelStatusNotInitializing(afterRestartKernelStatus, "after restart execution");
 
+  const restartRunAllMarkers = [`${runMarker} restart run all 1`, `${runMarker} restart run all 2`];
+  const secondCell = await ensureCodeCellCount(page, 2, timeoutMs).then((cells) => cells.nth(1));
+  await setCellSource(cell, `print(${JSON.stringify(restartRunAllMarkers[0])})`);
+  await setCellSource(secondCell, `print(${JSON.stringify(restartRunAllMarkers[1])})`);
+  await restartAndRunAllAndWait(page, restartRunAllMarkers, timeoutMs);
+  const afterRestartRunAllKernelStatus = await readKernelStatus(page);
+  assertKernelStatusNotInitializing(
+    afterRestartRunAllKernelStatus,
+    "after restart-and-run-all execution",
+  );
+
   await page.reload({ waitUntil: "domcontentloaded", timeout: timeoutMs });
   await waitForNotebookReady(page, timeoutMs);
-  await waitForText(page, restartMarker, timeoutMs);
+  await waitForText(page, restartRunAllMarkers[1], timeoutMs);
   await enterEditMode(page, timeoutMs);
   const reloadedCell = page.locator('[data-cell-type="code"]').first();
   await reloadedCell.waitFor({ state: "visible", timeout: timeoutMs });
@@ -317,11 +330,13 @@ async function runOwnerAttachAndExecuteSmoke({
     afterFirstRunKernelStatus,
     afterFirstRunAria,
     afterRestartKernelStatus,
+    afterRestartRunAllKernelStatus,
     afterReloadKernelStatus,
     afterReloadRunAria,
     beforeReloadRunAria,
     events,
     restartMarker,
+    restartRunAllMarkers,
     screenshotPath: screenshotPath ?? null,
   };
 }
@@ -740,6 +755,21 @@ async function ensureCodeCell(page, timeout) {
   });
 }
 
+async function ensureCodeCellCount(page, count, timeout) {
+  return smokePhase(`ensure ${count} code cells`, async () => {
+    const cells = page.locator('[data-cell-type="code"]');
+    while ((await cells.count()) < count) {
+      await page.getByTestId("add-code-cell-button").click({ timeout });
+      await page.waitForFunction(
+        (expected) => document.querySelectorAll('[data-cell-type="code"]').length >= expected,
+        count,
+        { timeout },
+      );
+    }
+    return cells;
+  });
+}
+
 async function setCellSource(cell, source) {
   await smokePhase("set cell source", async () => {
     await cell.locator('.cm-content[contenteditable="true"]').evaluate((node, text) => {
@@ -817,6 +847,37 @@ async function restartComputeAndWait(page, timeout) {
     // marker execution below is the durable assertion that the new runtime can
     // accept work.
   });
+  await waitForCanExecute(page, timeout);
+}
+
+async function restartAndRunAllAndWait(page, markers, timeout) {
+  const restartRunAllButton = page.getByTestId("restart-run-all-button");
+  await smokePhase("wait for restart-and-run-all button", async () => {
+    await restartRunAllButton.waitFor({ state: "visible", timeout });
+  });
+  await smokePhase("click restart-and-run-all button", async () => {
+    await restartRunAllButton.click({ timeout });
+  });
+  await waitForPagePredicate(
+    page,
+    "wait for hosted restart-and-run-all to leave ready state",
+    () => {
+      const shell = document.querySelector('[data-slot="notebook-document-shell"]');
+      const kernelStatus = document.querySelector('[data-testid="kernel-status"]');
+      return (
+        shell?.getAttribute("data-can-execute") !== "true" ||
+        kernelStatus?.getAttribute("data-kernel-status") !== "idle"
+      );
+    },
+    null,
+    Math.min(timeout, 10_000),
+  ).catch(() => {
+    // Fast replacements can move from ready to ready between browser polls.
+    // The marker outputs below prove the queued run-all survived the gap.
+  });
+  for (const marker of markers) {
+    await waitForText(page, marker, timeout);
+  }
   await waitForCanExecute(page, timeout);
 }
 

--- a/apps/notebook-cloud/scripts/hosted-workstation-toolbar-smoke.mjs
+++ b/apps/notebook-cloud/scripts/hosted-workstation-toolbar-smoke.mjs
@@ -230,6 +230,8 @@ async function runBrowserSmoke({
         "toolbar_start_compute_clicked",
         "execute_button_rendered_after_compute_start",
         "cell_output_observed_after_execute",
+        "restart_button_clicked",
+        "cell_output_observed_after_restart",
         "page_reload_preserved_output",
         "cell_output_observed_after_reload_execute",
         "owner_no_workstations_shows_setup_action",
@@ -277,9 +279,18 @@ async function runOwnerAttachAndExecuteSmoke({
   assertKernelStatusNotInitializing(afterFirstRunKernelStatus, "after first execution");
   const afterFirstRunAria = await cell.getByTestId("execute-button").getAttribute("aria-label");
 
+  const restartMarker = `${runMarker} after restart`;
+  await restartComputeAndWait(page, timeoutMs);
+  await setCellSource(cell, `print(${JSON.stringify(restartMarker)})`);
+  await executeAndWaitForMarker(page, cell, restartMarker, timeoutMs, {
+    requireOrdinalAdvance: false,
+  });
+  const afterRestartKernelStatus = await readKernelStatus(page);
+  assertKernelStatusNotInitializing(afterRestartKernelStatus, "after restart execution");
+
   await page.reload({ waitUntil: "domcontentloaded", timeout: timeoutMs });
   await waitForNotebookReady(page, timeoutMs);
-  await waitForText(page, runMarker, timeoutMs);
+  await waitForText(page, restartMarker, timeoutMs);
   await enterEditMode(page, timeoutMs);
   const reloadedCell = page.locator('[data-cell-type="code"]').first();
   await reloadedCell.waitFor({ state: "visible", timeout: timeoutMs });
@@ -305,10 +316,12 @@ async function runOwnerAttachAndExecuteSmoke({
     action,
     afterFirstRunKernelStatus,
     afterFirstRunAria,
+    afterRestartKernelStatus,
     afterReloadKernelStatus,
     afterReloadRunAria,
     beforeReloadRunAria,
     events,
+    restartMarker,
     screenshotPath: screenshotPath ?? null,
   };
 }
@@ -758,7 +771,13 @@ async function waitForToolbarAction(page, label, timeout) {
   );
 }
 
-async function executeAndWaitForMarker(page, cell, marker, timeout) {
+async function executeAndWaitForMarker(
+  page,
+  cell,
+  marker,
+  timeout,
+  { requireOrdinalAdvance = true } = {},
+) {
   await waitForCanExecute(page, timeout);
   const executeButton = await visibleExecuteButton(cell, timeout);
   const beforeAria = await readExecuteButtonAria(cell, "read pre-execution button state", timeout);
@@ -766,8 +785,39 @@ async function executeAndWaitForMarker(page, cell, marker, timeout) {
   await smokePhase("click cell execute button", async () => {
     await executeButton.click({ timeout });
   });
-  await waitForExecutionOrdinalAdvance(page, beforeOrdinal, timeout);
+  if (requireOrdinalAdvance) {
+    await waitForExecutionOrdinalAdvance(page, beforeOrdinal, timeout);
+  }
   await waitForText(page, marker, timeout);
+}
+
+async function restartComputeAndWait(page, timeout) {
+  const restartButton = page.getByTestId("restart-kernel-button");
+  await smokePhase("wait for restart button", async () => {
+    await restartButton.waitFor({ state: "visible", timeout });
+  });
+  await smokePhase("click restart button", async () => {
+    await restartButton.click({ timeout });
+  });
+  await waitForPagePredicate(
+    page,
+    "wait for hosted restart to leave ready state",
+    () => {
+      const shell = document.querySelector('[data-slot="notebook-document-shell"]');
+      const kernelStatus = document.querySelector('[data-testid="kernel-status"]');
+      return (
+        shell?.getAttribute("data-can-execute") !== "true" ||
+        kernelStatus?.getAttribute("data-kernel-status") !== "idle"
+      );
+    },
+    null,
+    Math.min(timeout, 10_000),
+  ).catch(() => {
+    // Fast replacements can move from ready to ready between browser polls. The
+    // marker execution below is the durable assertion that the new runtime can
+    // accept work.
+  });
+  await waitForCanExecute(page, timeout);
 }
 
 async function visibleExecuteButton(cell, timeout) {

--- a/apps/notebook-cloud/scripts/hosted-workstation-toolbar-smoke.mjs
+++ b/apps/notebook-cloud/scripts/hosted-workstation-toolbar-smoke.mjs
@@ -138,6 +138,7 @@ async function main() {
     timeoutMs,
     tokenStorageJson,
     viewerUrl,
+    workstationDisplayName: scalarString(workstation.display_name) ?? workstationId,
     workstationId,
   });
   const report = {
@@ -179,6 +180,7 @@ async function runBrowserSmoke({
   timeoutMs,
   tokenStorageJson,
   viewerUrl,
+  workstationDisplayName,
   workstationId,
 }) {
   const url = new URL(viewerUrl);
@@ -206,7 +208,7 @@ async function runBrowserSmoke({
         source,
         timeoutMs,
         url,
-        workstationId,
+        workstationDisplayName,
       });
     } finally {
       await ownerContext.close().catch(() => {});
@@ -252,7 +254,7 @@ async function runOwnerAttachAndExecuteSmoke({
   source,
   timeoutMs,
   url,
-  workstationId,
+  workstationDisplayName,
 }) {
   const page = await context.newPage();
   const events = collectBrowserDiagnostics(page);
@@ -266,7 +268,7 @@ async function runOwnerAttachAndExecuteSmoke({
   assertToolbarWorkstationAction(action, {
     context: "owner attach",
     label: "Start compute",
-    titleIncludes: [workstationId, "workstation"],
+    titleIncludes: [workstationDisplayName],
   });
   await page.getByTestId("workstation-setup-button").click({ timeout: timeoutMs });
 
@@ -347,8 +349,7 @@ async function assertOwnerBlockedWorkstationStates({
   const noWorkstations = await assertOwnerToolbarActionWithMockedWorkstations({
     browser,
     expectedLabel: "Set up compute",
-    expectedPanelText:
-      "Run the workstation agent on a machine you own, then attach it here to start compute.",
+    expectedPanelText: "No workstation registered",
     expectedTitleIncludes: ["Open workstations panel"],
     registry: {
       default_workstation_id: null,

--- a/apps/notebook-cloud/src/index.ts
+++ b/apps/notebook-cloud/src/index.ts
@@ -1340,6 +1340,10 @@ async function routeNotebookWorkstationAttachment(
   if (!workstationId) {
     return json({ error: "choose a default workstation before attaching compute" }, 409);
   }
+  const replaceExisting =
+    payload?.replace_existing === true ||
+    payload?.replaceExisting === true ||
+    payload?.intent === "restart";
 
   const workstation = await getWorkstationRow(env, ownerPrincipal, workstationId);
   if (!workstation) {
@@ -1370,18 +1374,24 @@ async function routeNotebookWorkstationAttachment(
   const job = await createWorkstationAttachJob(env, {
     notebookId,
     ownerPrincipal,
+    replaceActive: replaceExisting,
     workstationId,
     actorLabel: identity.actorLabel,
   });
   if (!job) {
     return json({ error: "workstation attach job was not created" }, 500);
   }
+  await publishWorkstationAttachJobRuntimeState(env, job, workstation, {
+    closeRuntimePeers: replaceExisting,
+    closeReason: replaceExisting ? "workstation restart requested" : undefined,
+  });
 
   cloudLog("info", "workstation.attach.requested", {
     notebook_id: notebookId,
     principal: ownerPrincipal,
     workstation_id: workstationId,
     job_id: job.id,
+    replace_existing: replaceExisting,
     counter: "workstation_attach_requests",
     counter_delta: 1,
   });
@@ -1558,6 +1568,15 @@ async function routeWorkstationAttachJob(
   });
   if (!job) {
     return json({ error: "workstation attach job not found" }, 404);
+  }
+  if (job.status !== statusValue) {
+    return json(
+      {
+        error: "workstation attach job is no longer active",
+        job: workstationAttachJobResponseRow(request, job),
+      },
+      409,
+    );
   }
   const workstation = await getWorkstationRow(env, ownerPrincipal, workstationId);
   if (workstation) {
@@ -1860,6 +1879,10 @@ async function publishWorkstationAttachJobRuntimeState(
   env: Env,
   job: WorkstationAttachJobRow,
   workstation: WorkstationRow,
+  options: {
+    closeReason?: string;
+    closeRuntimePeers?: boolean;
+  } = {},
 ): Promise<void> {
   const attachment = workstationAttachmentStateForJob(job, workstation);
   const id = env.NOTEBOOK_ROOMS.idFromName(job.notebook_id);
@@ -1873,7 +1896,15 @@ async function publishWorkstationAttachJobRuntimeState(
         {
           method: "POST",
           headers: { "Content-Type": "application/json" },
-          body: JSON.stringify({ attachment }),
+          body: JSON.stringify({
+            attachment,
+            ...(options.closeRuntimePeers
+              ? {
+                  close_runtime_peers: true,
+                  close_reason: options.closeReason ?? "workstation attachment replaced",
+                }
+              : {}),
+          }),
         },
       ),
     );

--- a/apps/notebook-cloud/src/notebook-room.ts
+++ b/apps/notebook-cloud/src/notebook-room.ts
@@ -382,6 +382,8 @@ export class NotebookRoom {
         : "workstation attachment replaced";
     const startedAt = Date.now();
     try {
+      const materializer = this.materializerFor(notebookId);
+      const result = await materializer.setWorkstationAttachment(attachment);
       if (closeRuntimePeers) {
         this.removeRuntimePeers(notebookId, {
           code: 1012,
@@ -389,8 +391,6 @@ export class NotebookRoom {
           suppressRuntimePeerWatch: true,
         });
       }
-      const materializer = this.materializerFor(notebookId);
-      const result = await materializer.setWorkstationAttachment(attachment);
       if (result.changed) {
         this.deliverRoomHostFrames(notebookId, result);
         await materializer.checkpoint();
@@ -1158,9 +1158,16 @@ export class NotebookRoom {
   }
 
   private activeRuntimePeer(sourcePeerId: string): Peer | undefined {
-    return Array.from(this.peers.values())
-      .filter((peer) => peer.id !== sourcePeerId && peer.identity.scope === "runtime_peer")
-      .sort((a, b) => b.connectedAt.localeCompare(a.connectedAt))[0];
+    let selected: Peer | undefined;
+    for (const peer of this.peers.values()) {
+      if (peer.id === sourcePeerId || peer.identity.scope !== "runtime_peer") {
+        continue;
+      }
+      if (!selected || peer.connectedAt >= selected.connectedAt) {
+        selected = peer;
+      }
+    }
+    return selected;
   }
 
   private forwardFrameToRuntimePeer(

--- a/apps/notebook-cloud/src/notebook-room.ts
+++ b/apps/notebook-cloud/src/notebook-room.ts
@@ -86,6 +86,12 @@ interface PeerCloseOptions {
 }
 
 type RuntimePeerForwardedRequestAction = "interrupt_execution" | "send_comm";
+type UnsupportedHostedRuntimeRequestAction =
+  | "launch_kernel"
+  | "shutdown_kernel"
+  | "sync_environment"
+  | "complete"
+  | "get_history";
 
 const MAX_STORED_FRAMES = 500;
 
@@ -106,6 +112,13 @@ const RUNTIME_PEER_WATCH_KEY = "runtime_peer_gone_watch";
 const runtimePeerForwardedRequestActions = new Set<RuntimePeerForwardedRequestAction>([
   "interrupt_execution",
   "send_comm",
+]);
+const unsupportedHostedRuntimeRequestActions = new Set<UnsupportedHostedRuntimeRequestAction>([
+  "launch_kernel",
+  "shutdown_kernel",
+  "sync_environment",
+  "complete",
+  "get_history",
 ]);
 
 function requestActionFromPayload(payload: Uint8Array): string | null {
@@ -129,6 +142,17 @@ function runtimePeerForwardedRequestAction(
   }
   return runtimePeerForwardedRequestActions.has(action as RuntimePeerForwardedRequestAction)
     ? (action as RuntimePeerForwardedRequestAction)
+    : null;
+}
+
+function unsupportedHostedRuntimeRequestAction(
+  action: string | null,
+): UnsupportedHostedRuntimeRequestAction | null {
+  if (!action) {
+    return null;
+  }
+  return unsupportedHostedRuntimeRequestActions.has(action as UnsupportedHostedRuntimeRequestAction)
+    ? (action as UnsupportedHostedRuntimeRequestAction)
     : null;
 }
 
@@ -701,6 +725,21 @@ export class NotebookRoom {
         timestamp: receivedAt,
       });
       this.resetRejectedFrameStreak(peer);
+      return;
+    }
+
+    const unsupportedRuntimeRequestAction =
+      normalizedFrame.type === FrameType.REQUEST
+        ? unsupportedHostedRuntimeRequestAction(requestActionFromPayload(normalizedFrame.payload))
+        : null;
+    if (unsupportedRuntimeRequestAction) {
+      this.rejectFrame(
+        notebookId,
+        peer,
+        normalizedFrame.type,
+        `hosted cloud rooms do not yet support response-bearing runtime request ${unsupportedRuntimeRequestAction}`,
+        { countsTowardStreak: false },
+      );
       return;
     }
 

--- a/apps/notebook-cloud/src/notebook-room.ts
+++ b/apps/notebook-cloud/src/notebook-room.ts
@@ -1135,9 +1135,14 @@ export class NotebookRoom {
     if (this.pendingRuntimePeerResponses.size >= MAX_PENDING_RUNTIME_PEER_RESPONSES) {
       const oldest = Array.from(this.pendingRuntimePeerResponses.entries()).sort(
         (a, b) => a[1].createdAtMs - b[1].createdAtMs,
-      )[0]?.[0];
+      )[0];
       if (oldest) {
-        this.pendingRuntimePeerResponses.delete(oldest);
+        this.rejectPendingRuntimePeerResponse(
+          oldest[1].notebookId,
+          oldest[0],
+          oldest[1],
+          `runtime peer query ${oldest[1].action} was evicted because too many queries are pending`,
+        );
       }
     }
 
@@ -1239,8 +1244,37 @@ export class NotebookRoom {
   private prunePendingRuntimePeerResponses(nowMs = Date.now()): void {
     for (const [requestId, pending] of this.pendingRuntimePeerResponses) {
       if (nowMs - pending.createdAtMs > PENDING_RUNTIME_PEER_RESPONSE_MAX_AGE_MS) {
-        this.pendingRuntimePeerResponses.delete(requestId);
+        this.rejectPendingRuntimePeerResponse(
+          pending.notebookId,
+          requestId,
+          pending,
+          `runtime peer query ${pending.action} expired before the runtime peer responded`,
+        );
       }
+    }
+  }
+
+  private rejectPendingRuntimePeerResponse(
+    notebookId: string,
+    requestId: string,
+    pending: PendingRuntimePeerResponse,
+    reason: string,
+  ): void {
+    this.pendingRuntimePeerResponses.delete(requestId);
+    const sourcePeer = this.peers.get(pending.sourcePeerId);
+    if (!sourcePeer) {
+      return;
+    }
+
+    const payload = new TextEncoder().encode(
+      JSON.stringify({
+        id: requestId,
+        result: "error",
+        error: reason,
+      }),
+    );
+    if (!this.trySendFrame(notebookId, sourcePeer, encodeTypedFrame(FrameType.RESPONSE, payload))) {
+      this.queuePeerRemoval(notebookId, sourcePeer);
     }
   }
 
@@ -1262,23 +1296,7 @@ export class NotebookRoom {
         continue;
       }
 
-      const sourcePeer = this.peers.get(pending.sourcePeerId);
-      if (!sourcePeer) {
-        continue;
-      }
-
-      const payload = new TextEncoder().encode(
-        JSON.stringify({
-          id: requestId,
-          result: "error",
-          error: reason,
-        }),
-      );
-      if (
-        !this.trySendFrame(notebookId, sourcePeer, encodeTypedFrame(FrameType.RESPONSE, payload))
-      ) {
-        this.queuePeerRemoval(notebookId, sourcePeer);
-      }
+      this.rejectPendingRuntimePeerResponse(notebookId, requestId, pending, reason);
     }
   }
 

--- a/apps/notebook-cloud/src/notebook-room.ts
+++ b/apps/notebook-cloud/src/notebook-room.ts
@@ -83,6 +83,7 @@ interface RejectFrameOptions {
 interface PeerCloseOptions {
   code?: number;
   reason?: string;
+  suppressRuntimePeerWatch?: boolean;
 }
 
 type RuntimePeerForwardedRequestAction = "interrupt_execution" | "send_comm";
@@ -373,8 +374,21 @@ export class NotebookRoom {
     }
 
     const attachment = payload.attachment as WorkstationAttachmentState | null;
+    const closeRuntimePeers =
+      payload.close_runtime_peers === true || payload.closeRuntimePeers === true;
+    const closeReason =
+      typeof payload.close_reason === "string" && payload.close_reason.trim().length > 0
+        ? payload.close_reason.trim().slice(0, 120)
+        : "workstation attachment replaced";
     const startedAt = Date.now();
     try {
+      if (closeRuntimePeers) {
+        this.removeRuntimePeers(notebookId, {
+          code: 1012,
+          reason: closeReason,
+          suppressRuntimePeerWatch: true,
+        });
+      }
       const materializer = this.materializerFor(notebookId);
       const result = await materializer.setWorkstationAttachment(attachment);
       if (result.changed) {
@@ -386,6 +400,7 @@ export class NotebookRoom {
         changed: result.changed,
         duration_ms: durationMs(startedAt),
         outbound_frame_count: result.outbound.length,
+        closed_runtime_peers: closeRuntimePeers,
         counter: "workstation_attachment_control_published",
         counter_delta: result.changed ? 1 : 0,
       });
@@ -1511,7 +1526,7 @@ export class NotebookRoom {
     // A runtime_peer departure is the one failure the daemon can't self-correct
     // (its death IS the trigger). Arm the reconciliation watchdog if it left no
     // runtime_peer behind.
-    if (peer.identity.scope === "runtime_peer") {
+    if (peer.identity.scope === "runtime_peer" && !closeOptions.suppressRuntimePeerWatch) {
       this.refreshRuntimePeerWatch(notebookId);
     }
   }

--- a/apps/notebook-cloud/src/notebook-room.ts
+++ b/apps/notebook-cloud/src/notebook-room.ts
@@ -728,7 +728,6 @@ export class NotebookRoom {
         peer,
         normalizedFrame.type,
         "runtime peer response does not match an in-flight hosted request",
-        { countsTowardStreak: false },
       );
       return;
     }

--- a/apps/notebook-cloud/src/notebook-room.ts
+++ b/apps/notebook-cloud/src/notebook-room.ts
@@ -86,12 +86,25 @@ interface PeerCloseOptions {
 }
 
 type RuntimePeerForwardedRequestAction = "interrupt_execution" | "send_comm";
+type RuntimePeerQueryRequestAction = "complete";
 type UnsupportedHostedRuntimeRequestAction =
   | "launch_kernel"
   | "shutdown_kernel"
   | "sync_environment"
-  | "complete"
   | "get_history";
+
+interface RequestEnvelopeMetadata {
+  id: string | null;
+  action: string | null;
+}
+
+interface PendingRuntimePeerResponse {
+  notebookId: string;
+  sourcePeerId: string;
+  runtimePeerId: string;
+  action: RuntimePeerQueryRequestAction;
+  createdAtMs: number;
+}
 
 const MAX_STORED_FRAMES = 500;
 
@@ -113,22 +126,40 @@ const runtimePeerForwardedRequestActions = new Set<RuntimePeerForwardedRequestAc
   "interrupt_execution",
   "send_comm",
 ]);
+const runtimePeerQueryRequestActions = new Set<RuntimePeerQueryRequestAction>(["complete"]);
 const unsupportedHostedRuntimeRequestActions = new Set<UnsupportedHostedRuntimeRequestAction>([
   "launch_kernel",
   "shutdown_kernel",
   "sync_environment",
-  "complete",
   "get_history",
 ]);
 
-function requestActionFromPayload(payload: Uint8Array): string | null {
+const MAX_PENDING_RUNTIME_PEER_RESPONSES = 128;
+const PENDING_RUNTIME_PEER_RESPONSE_MAX_AGE_MS = 60_000;
+
+function requestEnvelopeMetadataFromPayload(payload: Uint8Array): RequestEnvelopeMetadata {
+  try {
+    const value = JSON.parse(new TextDecoder().decode(payload)) as unknown;
+    if (typeof value !== "object" || value === null) {
+      return { id: null, action: null };
+    }
+    const record = value as Record<string, unknown>;
+    const id = typeof record.id === "string" ? record.id : null;
+    const action = typeof record.action === "string" ? record.action : null;
+    return { id, action };
+  } catch {
+    return { id: null, action: null };
+  }
+}
+
+function runtimeResponseIdFromPayload(payload: Uint8Array): string | null {
   try {
     const value = JSON.parse(new TextDecoder().decode(payload)) as unknown;
     if (typeof value !== "object" || value === null) {
       return null;
     }
-    const action = (value as Record<string, unknown>).action;
-    return typeof action === "string" ? action : null;
+    const id = (value as Record<string, unknown>).id;
+    return typeof id === "string" ? id : null;
   } catch {
     return null;
   }
@@ -142,6 +173,17 @@ function runtimePeerForwardedRequestAction(
   }
   return runtimePeerForwardedRequestActions.has(action as RuntimePeerForwardedRequestAction)
     ? (action as RuntimePeerForwardedRequestAction)
+    : null;
+}
+
+function runtimePeerQueryRequestAction(
+  action: string | null,
+): RuntimePeerQueryRequestAction | null {
+  if (!action) {
+    return null;
+  }
+  return runtimePeerQueryRequestActions.has(action as RuntimePeerQueryRequestAction)
+    ? (action as RuntimePeerQueryRequestAction)
     : null;
 }
 
@@ -168,6 +210,7 @@ export class NotebookRoom {
   private broadcastDepth = 0;
   private readonly materializers = new Map<string, RoomMaterializer>();
   private readonly restoredPeersReady: Promise<void>;
+  private readonly pendingRuntimePeerResponses = new Map<string, PendingRuntimePeerResponse>();
   // In-memory only by design: persisting on the frame hot path would cost more
   // than the data is worth. Hibernation resets it, so peer_closed summaries
   // under-count peers whose connection outlives the DO instance — treat the
@@ -659,6 +702,22 @@ export class NotebookRoom {
     }
 
     const receivedAt = new Date().toISOString();
+    if (normalizedFrame.type === FrameType.RESPONSE) {
+      const routed = this.routeRuntimePeerResponse(notebookId, peer, normalizedFrame);
+      if (routed) {
+        this.resetRejectedFrameStreak(peer);
+        return;
+      }
+      this.rejectFrame(
+        notebookId,
+        peer,
+        normalizedFrame.type,
+        "runtime peer response does not match an in-flight hosted request",
+        { countsTowardStreak: false },
+      );
+      return;
+    }
+
     if (!shouldBroadcastFrame(normalizedFrame, peer.identity)) {
       // Anonymous public viewers are read-only observers. Their presence is
       // acknowledged locally but not broadcast or persisted as room activity.
@@ -684,17 +743,20 @@ export class NotebookRoom {
       return;
     }
 
-    const forwardedRequestAction =
+    const requestMetadata =
       normalizedFrame.type === FrameType.REQUEST
-        ? runtimePeerForwardedRequestAction(requestActionFromPayload(normalizedFrame.payload))
+        ? requestEnvelopeMetadataFromPayload(normalizedFrame.payload)
         : null;
+    const forwardedRequestAction = runtimePeerForwardedRequestAction(
+      requestMetadata?.action ?? null,
+    );
     if (forwardedRequestAction) {
-      const forwardedPeerCount = this.forwardRequestToActiveRuntimePeer(
+      const forwardedRuntimePeerId = this.forwardRequestToActiveRuntimePeer(
         notebookId,
         normalizedFrame,
         peer.id,
       );
-      if (forwardedPeerCount === 0) {
+      if (!forwardedRuntimePeerId) {
         this.rejectFrame(
           notebookId,
           peer,
@@ -711,7 +773,7 @@ export class NotebookRoom {
         principal: peer.identity.principal,
         scope: peer.identity.scope,
         action: forwardedRequestAction,
-        forwarded_peer_count: forwardedPeerCount,
+        forwarded_runtime_peer_id: forwardedRuntimePeerId,
         byte_length: normalizedFrame.payload.byteLength,
         counter: "runtime_peer_requests_forwarded",
         counter_delta: 1,
@@ -728,9 +790,75 @@ export class NotebookRoom {
       return;
     }
 
+    const runtimePeerQueryAction = runtimePeerQueryRequestAction(requestMetadata?.action ?? null);
+    if (runtimePeerQueryAction) {
+      const requestId = requestMetadata?.id;
+      if (!requestId) {
+        this.rejectFrame(
+          notebookId,
+          peer,
+          normalizedFrame.type,
+          `hosted runtime query ${runtimePeerQueryAction} is missing a request id`,
+          { countsTowardStreak: false },
+        );
+        return;
+      }
+      if (this.pendingRuntimePeerResponses.has(requestId)) {
+        this.rejectFrame(
+          notebookId,
+          peer,
+          normalizedFrame.type,
+          `hosted runtime query ${runtimePeerQueryAction} request id is already pending`,
+          { countsTowardStreak: false },
+        );
+        return;
+      }
+
+      const forwardedRuntimePeerId = this.forwardQueryToActiveRuntimePeer(
+        notebookId,
+        normalizedFrame,
+        peer.id,
+        requestId,
+        runtimePeerQueryAction,
+      );
+      if (!forwardedRuntimePeerId) {
+        this.rejectFrame(
+          notebookId,
+          peer,
+          normalizedFrame.type,
+          `no runtime peer is attached for ${runtimePeerQueryAction}`,
+          { countsTowardStreak: false },
+        );
+        return;
+      }
+
+      cloudLog("debug", "room.runtime_peer_query.forwarded", {
+        notebook_id: notebookId,
+        peer_id: peer.id,
+        principal: peer.identity.principal,
+        scope: peer.identity.scope,
+        action: runtimePeerQueryAction,
+        request_id: requestId,
+        forwarded_runtime_peer_id: forwardedRuntimePeerId,
+        byte_length: normalizedFrame.payload.byteLength,
+        counter: "runtime_peer_queries_forwarded",
+        counter_delta: 1,
+      });
+      this.sendControl(notebookId, peer, {
+        type: "cloud_frame_accepted",
+        notebook_id: notebookId,
+        peer_id: peer.id,
+        frame_type: normalizedFrame.type,
+        byte_length: normalizedFrame.payload.byteLength,
+        timestamp: receivedAt,
+      });
+      this.resetRejectedFrameStreak(peer);
+      return;
+    }
+
     const unsupportedRuntimeRequestAction =
       normalizedFrame.type === FrameType.REQUEST
-        ? unsupportedHostedRuntimeRequestAction(requestActionFromPayload(normalizedFrame.payload))
+        ? unsupportedHostedRuntimeRequestAction(requestMetadata?.action ?? null)
         : null;
     if (unsupportedRuntimeRequestAction) {
       this.rejectFrame(
@@ -842,6 +970,8 @@ export class NotebookRoom {
         return identity.scope === "owner";
       case FrameType.REQUEST:
         return allowsExecutionRequestSubmit(identity.scope);
+      case FrameType.RESPONSE:
+        return identity.scope === "runtime_peer";
       case FrameType.PRESENCE:
         return true;
       default:
@@ -966,23 +1096,73 @@ export class NotebookRoom {
     notebookId: string,
     frame: TypedFrame,
     sourcePeerId: string,
-  ): number {
-    const encoded = encodeTypedFrame(frame.type, frame.payload);
-    const runtimePeer = Array.from(this.peers.values())
+  ): string | null {
+    const runtimePeer = this.activeRuntimePeer(sourcePeerId);
+    if (!runtimePeer) {
+      return null;
+    }
+    return this.forwardFrameToRuntimePeer(notebookId, runtimePeer, frame) ? runtimePeer.id : null;
+  }
+
+  private forwardQueryToActiveRuntimePeer(
+    notebookId: string,
+    frame: TypedFrame,
+    sourcePeerId: string,
+    requestId: string,
+    action: RuntimePeerQueryRequestAction,
+  ): string | null {
+    const runtimePeer = this.activeRuntimePeer(sourcePeerId);
+    if (!runtimePeer) {
+      return null;
+    }
+
+    this.prunePendingRuntimePeerResponses();
+    if (this.pendingRuntimePeerResponses.size >= MAX_PENDING_RUNTIME_PEER_RESPONSES) {
+      const oldest = Array.from(this.pendingRuntimePeerResponses.entries()).sort(
+        (a, b) => a[1].createdAtMs - b[1].createdAtMs,
+      )[0]?.[0];
+      if (oldest) {
+        this.pendingRuntimePeerResponses.delete(oldest);
+      }
+    }
+
+    this.pendingRuntimePeerResponses.set(requestId, {
+      notebookId,
+      sourcePeerId,
+      runtimePeerId: runtimePeer.id,
+      action,
+      createdAtMs: Date.now(),
+    });
+
+    if (!this.forwardFrameToRuntimePeer(notebookId, runtimePeer, frame)) {
+      this.pendingRuntimePeerResponses.delete(requestId);
+      return null;
+    }
+
+    return runtimePeer.id;
+  }
+
+  private activeRuntimePeer(sourcePeerId: string): Peer | undefined {
+    return Array.from(this.peers.values())
       .filter((peer) => peer.id !== sourcePeerId && peer.identity.scope === "runtime_peer")
       .sort((a, b) => b.connectedAt.localeCompare(a.connectedAt))[0];
-    if (!runtimePeer) {
-      return 0;
-    }
+  }
+
+  private forwardFrameToRuntimePeer(
+    notebookId: string,
+    runtimePeer: Peer,
+    frame: TypedFrame,
+  ): boolean {
+    const encoded = encodeTypedFrame(frame.type, frame.payload);
 
     // Overlapping runtime peers can happen during reconnect races. Command
     // requests target the latest peer, matching the workstation attachment's
     // `updated_at` projection until runtime generations become explicit.
     this.broadcastDepth += 1;
-    let delivered = 0;
+    let delivered = false;
     try {
       if (this.trySendFrame(notebookId, runtimePeer, encoded)) {
-        delivered = 1;
+        delivered = true;
       } else {
         this.queuePeerRemoval(notebookId, runtimePeer);
       }
@@ -994,6 +1174,90 @@ export class NotebookRoom {
     }
 
     return delivered;
+  }
+
+  private routeRuntimePeerResponse(notebookId: string, peer: Peer, frame: TypedFrame): boolean {
+    if (peer.identity.scope !== "runtime_peer") {
+      return false;
+    }
+
+    const requestId = runtimeResponseIdFromPayload(frame.payload);
+    if (!requestId) {
+      return false;
+    }
+
+    const pending = this.pendingRuntimePeerResponses.get(requestId);
+    if (!pending || pending.runtimePeerId !== peer.id || pending.notebookId !== notebookId) {
+      return false;
+    }
+
+    this.pendingRuntimePeerResponses.delete(requestId);
+    const sourcePeer = this.peers.get(pending.sourcePeerId);
+    if (!sourcePeer) {
+      return true;
+    }
+
+    const encoded = encodeTypedFrame(frame.type, frame.payload);
+    if (!this.trySendFrame(notebookId, sourcePeer, encoded)) {
+      this.queuePeerRemoval(notebookId, sourcePeer);
+    }
+    cloudLog("debug", "room.runtime_peer_query.response_forwarded", {
+      notebook_id: notebookId,
+      peer_id: sourcePeer.id,
+      runtime_peer_id: peer.id,
+      request_id: requestId,
+      action: pending.action,
+      byte_length: frame.payload.byteLength,
+      counter: "runtime_peer_query_responses_forwarded",
+      counter_delta: 1,
+    });
+    return true;
+  }
+
+  private prunePendingRuntimePeerResponses(nowMs = Date.now()): void {
+    for (const [requestId, pending] of this.pendingRuntimePeerResponses) {
+      if (nowMs - pending.createdAtMs > PENDING_RUNTIME_PEER_RESPONSE_MAX_AGE_MS) {
+        this.pendingRuntimePeerResponses.delete(requestId);
+      }
+    }
+  }
+
+  private rejectPendingRuntimePeerResponsesForPeer(
+    notebookId: string,
+    peerId: string,
+    reason: string,
+  ): void {
+    for (const [requestId, pending] of Array.from(this.pendingRuntimePeerResponses)) {
+      if (
+        pending.notebookId !== notebookId ||
+        (pending.sourcePeerId !== peerId && pending.runtimePeerId !== peerId)
+      ) {
+        continue;
+      }
+
+      this.pendingRuntimePeerResponses.delete(requestId);
+      if (pending.sourcePeerId === peerId) {
+        continue;
+      }
+
+      const sourcePeer = this.peers.get(pending.sourcePeerId);
+      if (!sourcePeer) {
+        continue;
+      }
+
+      const payload = new TextEncoder().encode(
+        JSON.stringify({
+          id: requestId,
+          result: "error",
+          error: reason,
+        }),
+      );
+      if (
+        !this.trySendFrame(notebookId, sourcePeer, encodeTypedFrame(FrameType.RESPONSE, payload))
+      ) {
+        this.queuePeerRemoval(notebookId, sourcePeer);
+      }
+    }
   }
 
   private async persistFrame(peer: Peer, frame: TypedFrame, receivedAt: string): Promise<void> {
@@ -1205,6 +1469,11 @@ export class NotebookRoom {
     if (!this.peers.delete(peer.id)) {
       return;
     }
+    this.rejectPendingRuntimePeerResponsesForPeer(
+      notebookId,
+      peer.id,
+      `${peer.identity.scope} disconnected before runtime query completed`,
+    );
     this.state.waitUntil(
       this.materializerFor(notebookId)
         .removePeer(peer.id)

--- a/apps/notebook-cloud/src/notebook-room.ts
+++ b/apps/notebook-cloud/src/notebook-room.ts
@@ -85,6 +85,8 @@ interface PeerCloseOptions {
   reason?: string;
 }
 
+type RuntimePeerForwardedRequestAction = "interrupt_execution" | "send_comm";
+
 const MAX_STORED_FRAMES = 500;
 
 /// Grace window after the last `runtime_peer` leaves before the room reconciles
@@ -101,6 +103,34 @@ const REJECTED_FRAME_POLICY_CLOSE_REASON = "too many rejected frames";
 /// reconciliation alarm. Persisted so a DO that hibernates between the alarm
 /// being set and firing still knows which room to reconcile.
 const RUNTIME_PEER_WATCH_KEY = "runtime_peer_gone_watch";
+const runtimePeerForwardedRequestActions = new Set<RuntimePeerForwardedRequestAction>([
+  "interrupt_execution",
+  "send_comm",
+]);
+
+function requestActionFromPayload(payload: Uint8Array): string | null {
+  try {
+    const value = JSON.parse(new TextDecoder().decode(payload)) as unknown;
+    if (typeof value !== "object" || value === null) {
+      return null;
+    }
+    const action = (value as Record<string, unknown>).action;
+    return typeof action === "string" ? action : null;
+  } catch {
+    return null;
+  }
+}
+
+function runtimePeerForwardedRequestAction(
+  action: string | null,
+): RuntimePeerForwardedRequestAction | null {
+  if (!action) {
+    return null;
+  }
+  return runtimePeerForwardedRequestActions.has(action as RuntimePeerForwardedRequestAction)
+    ? (action as RuntimePeerForwardedRequestAction)
+    : null;
+}
 
 export class NotebookRoom {
   private readonly peers = new Map<string, Peer>();
@@ -630,6 +660,50 @@ export class NotebookRoom {
       return;
     }
 
+    const forwardedRequestAction =
+      normalizedFrame.type === FrameType.REQUEST
+        ? runtimePeerForwardedRequestAction(requestActionFromPayload(normalizedFrame.payload))
+        : null;
+    if (forwardedRequestAction) {
+      const forwardedPeerCount = this.forwardRequestToActiveRuntimePeer(
+        notebookId,
+        normalizedFrame,
+        peer.id,
+      );
+      if (forwardedPeerCount === 0) {
+        this.rejectFrame(
+          notebookId,
+          peer,
+          normalizedFrame.type,
+          `no runtime peer is attached for ${forwardedRequestAction}`,
+          { countsTowardStreak: false },
+        );
+        return;
+      }
+
+      cloudLog("debug", "room.runtime_peer_request.forwarded", {
+        notebook_id: notebookId,
+        peer_id: peer.id,
+        principal: peer.identity.principal,
+        scope: peer.identity.scope,
+        action: forwardedRequestAction,
+        forwarded_peer_count: forwardedPeerCount,
+        byte_length: normalizedFrame.payload.byteLength,
+        counter: "runtime_peer_requests_forwarded",
+        counter_delta: 1,
+      });
+      this.sendControl(notebookId, peer, {
+        type: "cloud_frame_accepted",
+        notebook_id: notebookId,
+        peer_id: peer.id,
+        frame_type: normalizedFrame.type,
+        byte_length: normalizedFrame.payload.byteLength,
+        timestamp: receivedAt,
+      });
+      this.resetRejectedFrameStreak(peer);
+      return;
+    }
+
     if (isMaterializedSyncFrame(normalizedFrame.type)) {
       let result: RoomHostFrameResult;
       const materializer = this.materializerFor(notebookId);
@@ -847,6 +921,40 @@ export class NotebookRoom {
       }
       this.sendFrameToPeer(notebookId, target, typedFrameFromRoomHostOutbound(outbound));
     }
+  }
+
+  private forwardRequestToActiveRuntimePeer(
+    notebookId: string,
+    frame: TypedFrame,
+    sourcePeerId: string,
+  ): number {
+    const encoded = encodeTypedFrame(frame.type, frame.payload);
+    const runtimePeer = Array.from(this.peers.values())
+      .filter((peer) => peer.id !== sourcePeerId && peer.identity.scope === "runtime_peer")
+      .sort((a, b) => b.connectedAt.localeCompare(a.connectedAt))[0];
+    if (!runtimePeer) {
+      return 0;
+    }
+
+    // Overlapping runtime peers can happen during reconnect races. Command
+    // requests target the latest peer, matching the workstation attachment's
+    // `updated_at` projection until runtime generations become explicit.
+    this.broadcastDepth += 1;
+    let delivered = 0;
+    try {
+      if (this.trySendFrame(notebookId, runtimePeer, encoded)) {
+        delivered = 1;
+      } else {
+        this.queuePeerRemoval(notebookId, runtimePeer);
+      }
+    } finally {
+      this.broadcastDepth -= 1;
+      if (this.broadcastDepth === 0) {
+        this.flushPendingRemovals();
+      }
+    }
+
+    return delivered;
   }
 
   private async persistFrame(peer: Peer, frame: TypedFrame, receivedAt: string): Promise<void> {

--- a/apps/notebook-cloud/src/protocol.ts
+++ b/apps/notebook-cloud/src/protocol.ts
@@ -139,6 +139,7 @@ export function isClientWritableFrame(type: FrameTypeValue): boolean {
   return (
     type === FrameType.AUTOMERGE_SYNC ||
     type === FrameType.REQUEST ||
+    type === FrameType.RESPONSE ||
     type === FrameType.PRESENCE ||
     type === FrameType.RUNTIME_STATE_SYNC ||
     type === FrameType.COMMS_DOC_SYNC ||

--- a/apps/notebook-cloud/src/storage.ts
+++ b/apps/notebook-cloud/src/storage.ts
@@ -916,6 +916,7 @@ export async function createWorkstationAttachJob(
   input: {
     notebookId: string;
     ownerPrincipal: string;
+    replaceActive?: boolean;
     workstationId: string;
     actorLabel: string;
   },
@@ -929,6 +930,12 @@ export async function createWorkstationAttachJob(
   const nowIso = now.toISOString();
   const staleBefore = new Date(now.getTime() - WORKSTATION_ATTACH_JOB_STALE_MS).toISOString();
   await expireStaleWorkstationAttachJobs(env, input, { now: nowIso, staleBefore });
+  if (input.replaceActive === true) {
+    await cancelActiveWorkstationAttachJobs(env, input, {
+      now: nowIso,
+      errorMessage: "replaced by a newer workstation attach request",
+    });
+  }
   const existing = await getActiveWorkstationAttachJob(env, input, staleBefore);
   if (existing) {
     return existing;
@@ -1037,7 +1044,8 @@ export async function updateWorkstationAttachJobStatus(
             error_message = ?
       WHERE id = ?
         AND owner_principal = ?
-        AND workstation_id = ?`,
+        AND workstation_id = ?
+        AND status IN ('pending', 'accepted', 'running')`,
   )
     .bind(
       input.status,
@@ -1122,6 +1130,37 @@ async function expireStaleWorkstationAttachJobs(
           AND updated_at < ?`,
     )
     .bind(now, now, input.notebookId, input.ownerPrincipal, input.workstationId, staleBefore)
+    .run();
+}
+
+async function cancelActiveWorkstationAttachJobs(
+  env: Env,
+  input: {
+    notebookId: string;
+    ownerPrincipal: string;
+    workstationId: string;
+  },
+  {
+    now,
+    errorMessage,
+  }: {
+    now: string;
+    errorMessage: string;
+  },
+): Promise<void> {
+  await env
+    .DB!.prepare(
+      `UPDATE workstation_attach_jobs
+          SET status = 'cancelled',
+              updated_at = ?,
+              finished_at = ?,
+              error_message = ?
+        WHERE notebook_id = ?
+          AND owner_principal = ?
+          AND workstation_id = ?
+          AND status IN ('pending', 'accepted', 'running')`,
+    )
+    .bind(now, now, errorMessage, input.notebookId, input.ownerPrincipal, input.workstationId)
     .run();
 }
 

--- a/apps/notebook-cloud/test/cloud-notebook-host.test.ts
+++ b/apps/notebook-cloud/test/cloud-notebook-host.test.ts
@@ -43,6 +43,7 @@ describe("cloud notebook host", () => {
     const host = createCloudNotebookHost({
       blobResolver: fixtureBlobResolver,
       getRuntime: () => createRuntime("cloud", calls),
+      hasRuntimePeer: () => true,
     });
 
     assert.deepEqual(
@@ -50,6 +51,26 @@ describe("cloud notebook host", () => {
       { result: "cloud" },
     );
     assert.deepEqual(calls, ["cloud:sendRequest:complete"]);
+  });
+
+  it("returns empty hosted completions when the live room has no runtime peer", async () => {
+    const calls: string[] = [];
+    const host = createCloudNotebookHost({
+      blobResolver: fixtureBlobResolver,
+      getRuntime: () => createRuntime("cloud", calls),
+      hasRuntimePeer: () => false,
+    });
+
+    assert.deepEqual(
+      await host.transport.sendRequest({ type: "complete", code: "pri", cursor_pos: 3 }),
+      {
+        result: "completion_result",
+        items: [],
+        cursor_start: 3,
+        cursor_end: 3,
+      },
+    );
+    assert.deepEqual(calls, []);
   });
 
   it("returns empty hosted completions even before the live room is connected", async () => {

--- a/apps/notebook-cloud/test/cloud-notebook-host.test.ts
+++ b/apps/notebook-cloud/test/cloud-notebook-host.test.ts
@@ -38,7 +38,7 @@ describe("cloud notebook host", () => {
     assert.deepEqual(calls, ["b:sendRequest:save_notebook", "b:sendFrame:1"]);
   });
 
-  it("returns an immediate empty completion result without touching the room transport", async () => {
+  it("delegates hosted completions to the live runtime transport when connected", async () => {
     const calls: string[] = [];
     const host = createCloudNotebookHost({
       blobResolver: fixtureBlobResolver,
@@ -47,14 +47,9 @@ describe("cloud notebook host", () => {
 
     assert.deepEqual(
       await host.transport.sendRequest({ type: "complete", code: "pri", cursor_pos: 3 }),
-      {
-        result: "completion_result",
-        items: [],
-        cursor_start: 3,
-        cursor_end: 3,
-      },
+      { result: "cloud" },
     );
-    assert.deepEqual(calls, []);
+    assert.deepEqual(calls, ["cloud:sendRequest:complete"]);
   });
 
   it("returns empty hosted completions even before the live room is connected", async () => {

--- a/apps/notebook-cloud/test/live-sync.test.ts
+++ b/apps/notebook-cloud/test/live-sync.test.ts
@@ -472,10 +472,10 @@ describe("cloud live sync", () => {
 
       const response = transport.sendTypedRequest(
         FrameType.REQUEST,
-        new TextEncoder().encode(JSON.stringify({ id: "req-1", action: "complete" })),
+        new TextEncoder().encode(JSON.stringify({ id: "req-1", action: "execute_cell" })),
         "req-1",
         20,
-        "complete",
+        "execute_cell",
       );
       await nextMicrotask();
       socket.control({
@@ -488,6 +488,68 @@ describe("cloud live sync", () => {
       });
 
       assert.deepEqual(await response, { result: "ok" });
+    } finally {
+      fake.restore();
+    }
+  });
+
+  it("waits for a runtime peer response for hosted completion requests", async () => {
+    const fake = installFakeWebSocket();
+    try {
+      const transport = createTransport();
+      const socket = await waitForSocket(0);
+      socket.open();
+      socket.ready("peer-1");
+      await transport.ready;
+
+      let settled = false;
+      const response = transport
+        .sendRequest({ type: "complete", code: "pri", cursor_pos: 3 })
+        .then((value) => {
+          settled = true;
+          return value;
+        });
+      await nextMicrotask();
+
+      assert.equal(socket.sent.length, 1);
+      const requestFrame = socket.sent[0];
+      const requestEnvelope = JSON.parse(new TextDecoder().decode(requestFrame.slice(1))) as {
+        id: string;
+        action: string;
+      };
+      assert.equal(requestEnvelope.action, "complete");
+
+      socket.control({
+        type: "cloud_frame_accepted",
+        notebook_id: "room",
+        peer_id: "peer-1",
+        frame_type: FrameType.REQUEST,
+        byte_length: requestFrame.byteLength - 1,
+        timestamp: "2026-06-06T00:00:00.000Z",
+      });
+      await nextMicrotask();
+      assert.equal(settled, false);
+
+      const responsePayload = new TextEncoder().encode(
+        JSON.stringify({
+          id: requestEnvelope.id,
+          result: "completion_result",
+          items: [{ label: "print", kind: "function" }],
+          cursor_start: 0,
+          cursor_end: 3,
+        }),
+      );
+      const responseFrame = new Uint8Array(responsePayload.byteLength + 1);
+      responseFrame[0] = FrameType.RESPONSE;
+      responseFrame.set(responsePayload, 1);
+      socket.message(responseFrame.buffer);
+
+      assert.deepEqual(await response, {
+        result: "completion_result",
+        items: [{ label: "print", kind: "function" }],
+        cursor_start: 0,
+        cursor_end: 3,
+      });
     } finally {
       fake.restore();
     }

--- a/apps/notebook-cloud/test/notebook-room.test.ts
+++ b/apps/notebook-cloud/test/notebook-room.test.ts
@@ -745,6 +745,66 @@ describe("NotebookRoom peer lifecycle", () => {
     assert.deepEqual([...viewerSocket.sent[0]], [FrameType.RUNTIME_STATE_SYNC, 4, 5, 6]);
   });
 
+  it("disconnects runtime peers when replacement workstation attachment control is published", async () => {
+    const state = alarmCapableState();
+    const room = new NotebookRoom(state.state, {} as Env);
+    const harness = roomHarness(room);
+    const runtimeSocket = new FakeSocket();
+    const runtimePeer = {
+      id: "runtime",
+      socket: runtimeSocket.asCloudflareWebSocket(),
+      identity: authenticateDevRequest(
+        new Request(
+          "https://cloud.test/n/demo/sync?user=runtime&operator=runtime:py&scope=runtime_peer",
+        ),
+      ),
+      connectedAt: "2026-06-07T00:00:00.000Z",
+    };
+    harness.peers.set(runtimePeer.id, runtimePeer);
+    harness.materializers.set("demo", {
+      receiveFrame: async () => noopMaterializedResult(),
+      checkpoint: async () => undefined,
+      removePeer: async () => undefined,
+      setWorkstationAttachment: async () => ({
+        ...noopMaterializedResult(),
+        changed: true,
+        runtime_state_changed: true,
+      }),
+    } as never);
+
+    const response = await room.fetch(
+      new Request("https://room.internal/internal/n/demo/workstation-attachment", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          close_runtime_peers: true,
+          close_reason: "workstation restart requested",
+          attachment: {
+            workstation_id: "ws-lab2",
+            display_name: "Lab2 workstation",
+            provider: "runtime_peer",
+            default_environment_label: "Current Python",
+            environment_policy: "current_python",
+            status: "connecting",
+            status_message: "Waiting for Lab2 to accept the compute request.",
+            cpu_count: 8,
+            memory_bytes: 16_000_000_000,
+            working_directory: "/home/ubuntu/project",
+            updated_at: "2026-06-07T00:00:01.000Z",
+          },
+        }),
+      }),
+    );
+
+    await state.drain();
+    assert.equal(response.status, 200);
+    assert.equal(harness.hasRuntimePeer(), false);
+    assert.equal(runtimeSocket.closed, true);
+    assert.equal(runtimeSocket.closeCode, 1012);
+    assert.equal(runtimeSocket.closeReason, "workstation restart requested");
+    assert.equal(await state.getAlarm(), null, "intentional replacement does not arm stale repair");
+  });
+
   it("projects runtime-peer workstation metadata into the attachment", async () => {
     const state = hibernatedState([]);
     const room = new NotebookRoom(state.state, {} as Env);

--- a/apps/notebook-cloud/test/notebook-room.test.ts
+++ b/apps/notebook-cloud/test/notebook-room.test.ts
@@ -1123,9 +1123,7 @@ describe("NotebookRoom materialized sync persistence", () => {
               },
             }
           : { id: `request-${action}`, action };
-      const requestPayload = new TextEncoder().encode(
-        JSON.stringify(envelope),
-      );
+      const requestPayload = new TextEncoder().encode(JSON.stringify(envelope));
 
       await harness.handleMessage(
         "demo",

--- a/apps/notebook-cloud/test/notebook-room.test.ts
+++ b/apps/notebook-cloud/test/notebook-room.test.ts
@@ -1476,6 +1476,119 @@ describe("NotebookRoom materialized sync persistence", () => {
     assert.equal(persisted, 0);
   });
 
+  it("settles the oldest hosted completion when the pending query cap evicts it", async () => {
+    const room = new NotebookRoom(fakeState(), {} as Env);
+    const ownerIdentity = authenticateDevRequest(
+      new Request("https://cloud.test/n/demo/sync?user=alice&operator=browser:a&scope=owner"),
+    );
+    const runtimeIdentity = authenticateDevRequest(
+      new Request(
+        "https://cloud.test/n/demo/sync?user=runtime&operator=runtime:new&scope=runtime_peer",
+      ),
+    );
+    const ownerSocket = new FakeSocket();
+    const runtimeSocket = new FakeSocket();
+    const ownerPeer = {
+      id: "owner",
+      socket: ownerSocket.asCloudflareWebSocket(),
+      identity: ownerIdentity,
+      connectedAt: "2026-05-22T00:00:00.000Z",
+      workstation: null,
+      consecutiveRejectedFrames: 0,
+    };
+    const runtimePeer = {
+      id: "runtime",
+      socket: runtimeSocket.asCloudflareWebSocket(),
+      identity: runtimeIdentity,
+      connectedAt: "2026-05-22T00:00:01.000Z",
+      workstation: null,
+      consecutiveRejectedFrames: 0,
+    };
+    const harness = roomHarness(room);
+    harness.peers.set(ownerPeer.id, ownerPeer);
+    harness.peers.set(runtimePeer.id, runtimePeer);
+    harness.materializers.set("demo", fakeMaterializer(noopMaterializedResult()));
+
+    for (let index = 0; index < 129; index += 1) {
+      await harness.handleMessage(
+        "demo",
+        ownerPeer,
+        encodeTypedFrame(
+          FrameType.REQUEST,
+          new TextEncoder().encode(
+            JSON.stringify({
+              id: `request-${index}`,
+              action: "complete",
+              code: "pri",
+              cursor_pos: 3,
+            }),
+          ),
+        ),
+      );
+    }
+
+    const responseFrames = ownerSocket.sent.filter((frame) => frame[0] === FrameType.RESPONSE);
+    assert.equal(responseFrames.length, 1);
+    const evicted = decodeJsonPayload<Record<string, unknown>>(responseFrames[0].slice(1));
+    assert.equal(evicted.id, "request-0");
+    assert.equal(evicted.result, "error");
+    assert.match(String(evicted.error), /too many queries are pending/);
+    assert.equal(runtimeSocket.sent.length, 129);
+  });
+
+  it("settles expired hosted completions when pending queries are pruned", async () => {
+    const room = new NotebookRoom(fakeState(), {} as Env);
+    const ownerIdentity = authenticateDevRequest(
+      new Request("https://cloud.test/n/demo/sync?user=alice&operator=browser:a&scope=owner"),
+    );
+    const runtimeIdentity = authenticateDevRequest(
+      new Request(
+        "https://cloud.test/n/demo/sync?user=runtime&operator=runtime:new&scope=runtime_peer",
+      ),
+    );
+    const ownerSocket = new FakeSocket();
+    const runtimeSocket = new FakeSocket();
+    const ownerPeer = {
+      id: "owner",
+      socket: ownerSocket.asCloudflareWebSocket(),
+      identity: ownerIdentity,
+      connectedAt: "2026-05-22T00:00:00.000Z",
+      workstation: null,
+      consecutiveRejectedFrames: 0,
+    };
+    const runtimePeer = {
+      id: "runtime",
+      socket: runtimeSocket.asCloudflareWebSocket(),
+      identity: runtimeIdentity,
+      connectedAt: "2026-05-22T00:00:01.000Z",
+      workstation: null,
+      consecutiveRejectedFrames: 0,
+    };
+    const harness = roomHarness(room);
+    harness.peers.set(ownerPeer.id, ownerPeer);
+    harness.peers.set(runtimePeer.id, runtimePeer);
+    harness.materializers.set("demo", fakeMaterializer(noopMaterializedResult()));
+    await harness.handleMessage(
+      "demo",
+      ownerPeer,
+      encodeTypedFrame(
+        FrameType.REQUEST,
+        new TextEncoder().encode(
+          JSON.stringify({ id: "request-1", action: "complete", code: "pri", cursor_pos: 3 }),
+        ),
+      ),
+    );
+
+    harness.prunePendingRuntimePeerResponses(Date.now() + 61_000);
+
+    const responseFrames = ownerSocket.sent.filter((frame) => frame[0] === FrameType.RESPONSE);
+    assert.equal(responseFrames.length, 1);
+    const expired = decodeJsonPayload<Record<string, unknown>>(responseFrames[0].slice(1));
+    assert.equal(expired.id, "request-1");
+    assert.equal(expired.result, "error");
+    assert.match(String(expired.error), /expired before the runtime peer responded/);
+  });
+
   it("rejects forwarded runtime-agent command REQUEST frames when no runtime peer is attached", async () => {
     const room = new NotebookRoom(fakeState(), {} as Env);
     const identity = authenticateDevRequest(
@@ -1946,6 +2059,7 @@ interface RoomHarness {
   peerForSocket(socket: CloudflareWebSocket): PeerForTest | undefined;
   broadcastFrame(notebookId: string, frame: Uint8Array, excludePeerId?: string): void;
   hasRuntimePeer(): boolean;
+  prunePendingRuntimePeerResponses(nowMs?: number): void;
 }
 
 function roomHarness(room: NotebookRoom): RoomHarness {

--- a/apps/notebook-cloud/test/notebook-room.test.ts
+++ b/apps/notebook-cloud/test/notebook-room.test.ts
@@ -1065,6 +1065,200 @@ describe("NotebookRoom materialized sync persistence", () => {
     assert.equal(accepted.type, "cloud_frame_accepted");
   });
 
+  it("forwards owner runtime-agent command REQUEST frames to attached runtime peers", async () => {
+    const room = new NotebookRoom(fakeState(), {} as Env);
+    const ownerIdentity = authenticateDevRequest(
+      new Request("https://cloud.test/n/demo/sync?user=alice&operator=browser:a&scope=owner"),
+    );
+    const runtimeIdentity = authenticateDevRequest(
+      new Request(
+        "https://cloud.test/n/demo/sync?user=runtime&operator=runtime:py&scope=runtime_peer",
+      ),
+    );
+    const ownerSocket = new FakeSocket();
+    const runtimeSocket = new FakeSocket();
+    const ownerPeer = {
+      id: "owner",
+      socket: ownerSocket.asCloudflareWebSocket(),
+      identity: ownerIdentity,
+      connectedAt: "2026-05-22T00:00:00.000Z",
+      consecutiveRejectedFrames: 0,
+    };
+    const runtimePeer = {
+      id: "runtime",
+      socket: runtimeSocket.asCloudflareWebSocket(),
+      identity: runtimeIdentity,
+      connectedAt: "2026-05-22T00:00:00.000Z",
+      consecutiveRejectedFrames: 0,
+    };
+    const harness = roomHarness(room);
+    let persisted = 0;
+    let materialized = 0;
+    harness.peers.set(ownerPeer.id, ownerPeer);
+    harness.peers.set(runtimePeer.id, runtimePeer);
+    harness.materializers.set("demo", {
+      receiveFrame: async () => {
+        materialized += 1;
+        return noopMaterializedResult();
+      },
+      checkpoint: async () => undefined,
+      removePeer: async () => undefined,
+    });
+    harness.persistFrame = async () => {
+      persisted += 1;
+    };
+    const actions = ["interrupt_execution", "send_comm"] as const;
+    for (const action of actions) {
+      const envelope =
+        action === "send_comm"
+          ? {
+              id: `request-${action}`,
+              action,
+              message: {
+                header: { msg_type: "comm_msg" },
+                metadata: {},
+                content: {},
+                buffers: [],
+                channel: "shell",
+              },
+            }
+          : { id: `request-${action}`, action };
+      const requestPayload = new TextEncoder().encode(
+        JSON.stringify(envelope),
+      );
+
+      await harness.handleMessage(
+        "demo",
+        ownerPeer,
+        encodeTypedFrame(FrameType.REQUEST, requestPayload),
+      );
+
+      assert.equal(runtimeSocket.sent.length, actions.indexOf(action) + 1);
+      assert.deepEqual(
+        [...runtimeSocket.sent.at(-1)!],
+        [FrameType.REQUEST, ...Array.from(requestPayload)],
+      );
+      assert.equal(ownerSocket.sent.length, actions.indexOf(action) + 1);
+      const accepted = decodeJsonPayload<Record<string, unknown>>(
+        ownerSocket.sent.at(-1)!.slice(1),
+      );
+      assert.equal(accepted.type, "cloud_frame_accepted");
+    }
+
+    assert.equal(materialized, 0);
+    assert.equal(persisted, 0);
+  });
+
+  it("forwards runtime-agent command REQUEST frames only to the newest runtime peer", async () => {
+    const room = new NotebookRoom(fakeState(), {} as Env);
+    const ownerIdentity = authenticateDevRequest(
+      new Request("https://cloud.test/n/demo/sync?user=alice&operator=browser:a&scope=owner"),
+    );
+    const oldRuntimeIdentity = authenticateDevRequest(
+      new Request(
+        "https://cloud.test/n/demo/sync?user=runtime&operator=runtime:old&scope=runtime_peer",
+      ),
+    );
+    const newRuntimeIdentity = authenticateDevRequest(
+      new Request(
+        "https://cloud.test/n/demo/sync?user=runtime&operator=runtime:new&scope=runtime_peer",
+      ),
+    );
+    const ownerSocket = new FakeSocket();
+    const oldRuntimeSocket = new FakeSocket();
+    const newRuntimeSocket = new FakeSocket();
+    const ownerPeer = {
+      id: "owner",
+      socket: ownerSocket.asCloudflareWebSocket(),
+      identity: ownerIdentity,
+      connectedAt: "2026-05-22T00:00:00.000Z",
+      consecutiveRejectedFrames: 0,
+    };
+    const oldRuntimePeer = {
+      id: "runtime-old",
+      socket: oldRuntimeSocket.asCloudflareWebSocket(),
+      identity: oldRuntimeIdentity,
+      connectedAt: "2026-05-22T00:00:00.000Z",
+      consecutiveRejectedFrames: 0,
+    };
+    const newRuntimePeer = {
+      id: "runtime-new",
+      socket: newRuntimeSocket.asCloudflareWebSocket(),
+      identity: newRuntimeIdentity,
+      connectedAt: "2026-05-22T00:00:01.000Z",
+      consecutiveRejectedFrames: 0,
+    };
+    const harness = roomHarness(room);
+    harness.peers.set(ownerPeer.id, ownerPeer);
+    harness.peers.set(oldRuntimePeer.id, oldRuntimePeer);
+    harness.peers.set(newRuntimePeer.id, newRuntimePeer);
+    harness.materializers.set("demo", fakeMaterializer(noopMaterializedResult()));
+    const requestPayload = new TextEncoder().encode(
+      JSON.stringify({ id: "request-1", action: "interrupt_execution" }),
+    );
+
+    await harness.handleMessage(
+      "demo",
+      ownerPeer,
+      encodeTypedFrame(FrameType.REQUEST, requestPayload),
+    );
+
+    assert.equal(oldRuntimeSocket.sent.length, 0);
+    assert.equal(newRuntimeSocket.sent.length, 1);
+    assert.deepEqual(
+      [...newRuntimeSocket.sent[0]],
+      [FrameType.REQUEST, ...Array.from(requestPayload)],
+    );
+  });
+
+  it("rejects forwarded runtime-agent command REQUEST frames when no runtime peer is attached", async () => {
+    const room = new NotebookRoom(fakeState(), {} as Env);
+    const identity = authenticateDevRequest(
+      new Request("https://cloud.test/n/demo/sync?user=alice&operator=browser:a&scope=owner"),
+    );
+    const socket = new FakeSocket();
+    const peer = {
+      id: "owner",
+      socket: socket.asCloudflareWebSocket(),
+      identity,
+      connectedAt: "2026-05-22T00:00:00.000Z",
+      consecutiveRejectedFrames: 0,
+    };
+    const harness = roomHarness(room);
+    let persisted = 0;
+    let materialized = 0;
+    harness.materializers.set("demo", {
+      receiveFrame: async () => {
+        materialized += 1;
+        return noopMaterializedResult();
+      },
+      checkpoint: async () => undefined,
+      removePeer: async () => undefined,
+    });
+    harness.persistFrame = async () => {
+      persisted += 1;
+    };
+
+    await harness.handleMessage(
+      "demo",
+      peer,
+      encodeTypedFrame(
+        FrameType.REQUEST,
+        new TextEncoder().encode(
+          JSON.stringify({ id: "request-1", action: "interrupt_execution" }),
+        ),
+      ),
+    );
+
+    assert.equal(materialized, 0);
+    assert.equal(persisted, 0);
+    assert.equal(peer.consecutiveRejectedFrames, 0);
+    assert.equal(socket.sent.length, 1);
+    const rejected = decodeJsonPayload<Record<string, unknown>>(socket.sent[0].slice(1));
+    assert.equal(rejected.type, "cloud_frame_rejected");
+    assert.equal(rejected.reason, "no runtime peer is attached for interrupt_execution");
+  });
+
   it("rejects non-owner REQUEST frames on the WebSocket path", async () => {
     for (const scope of ["editor", "viewer", "runtime_peer"] as const) {
       const room = new NotebookRoom(fakeState(), {} as Env);

--- a/apps/notebook-cloud/test/notebook-room.test.ts
+++ b/apps/notebook-cloud/test/notebook-room.test.ts
@@ -1257,6 +1257,55 @@ describe("NotebookRoom materialized sync persistence", () => {
     assert.equal(rejected.reason, "no runtime peer is attached for interrupt_execution");
   });
 
+  it("rejects response-bearing runtime REQUEST frames instead of acknowledging no-ops", async () => {
+    const room = new NotebookRoom(fakeState(), {} as Env);
+    const identity = authenticateDevRequest(
+      new Request("https://cloud.test/n/demo/sync?user=alice&operator=browser:a&scope=owner"),
+    );
+    const socket = new FakeSocket();
+    const peer = {
+      id: "owner",
+      socket: socket.asCloudflareWebSocket(),
+      identity,
+      connectedAt: "2026-05-22T00:00:00.000Z",
+      consecutiveRejectedFrames: 0,
+    };
+    const harness = roomHarness(room);
+    let persisted = 0;
+    let materialized = 0;
+    harness.materializers.set("demo", {
+      receiveFrame: async () => {
+        materialized += 1;
+        return noopMaterializedResult();
+      },
+      checkpoint: async () => undefined,
+      removePeer: async () => undefined,
+    });
+    harness.persistFrame = async () => {
+      persisted += 1;
+    };
+
+    await harness.handleMessage(
+      "demo",
+      peer,
+      encodeTypedFrame(
+        FrameType.REQUEST,
+        new TextEncoder().encode(JSON.stringify({ id: "request-1", action: "shutdown_kernel" })),
+      ),
+    );
+
+    assert.equal(materialized, 0);
+    assert.equal(persisted, 0);
+    assert.equal(peer.consecutiveRejectedFrames, 0);
+    assert.equal(socket.sent.length, 1);
+    const rejected = decodeJsonPayload<Record<string, unknown>>(socket.sent[0].slice(1));
+    assert.equal(rejected.type, "cloud_frame_rejected");
+    assert.equal(
+      rejected.reason,
+      "hosted cloud rooms do not yet support response-bearing runtime request shutdown_kernel",
+    );
+  });
+
   it("rejects non-owner REQUEST frames on the WebSocket path", async () => {
     for (const scope of ["editor", "viewer", "runtime_peer"] as const) {
       const room = new NotebookRoom(fakeState(), {} as Env);

--- a/apps/notebook-cloud/test/notebook-room.test.ts
+++ b/apps/notebook-cloud/test/notebook-room.test.ts
@@ -1209,6 +1209,95 @@ describe("NotebookRoom materialized sync persistence", () => {
     );
   });
 
+  it("routes hosted completion REQUEST frames through the active runtime peer response", async () => {
+    const room = new NotebookRoom(fakeState(), {} as Env);
+    const ownerIdentity = authenticateDevRequest(
+      new Request("https://cloud.test/n/demo/sync?user=alice&operator=browser:a&scope=owner"),
+    );
+    const runtimeIdentity = authenticateDevRequest(
+      new Request(
+        "https://cloud.test/n/demo/sync?user=runtime&operator=runtime:new&scope=runtime_peer",
+      ),
+    );
+    const ownerSocket = new FakeSocket();
+    const runtimeSocket = new FakeSocket();
+    const ownerPeer = {
+      id: "owner",
+      socket: ownerSocket.asCloudflareWebSocket(),
+      identity: ownerIdentity,
+      connectedAt: "2026-05-22T00:00:00.000Z",
+      workstation: null,
+      consecutiveRejectedFrames: 0,
+    };
+    const runtimePeer = {
+      id: "runtime",
+      socket: runtimeSocket.asCloudflareWebSocket(),
+      identity: runtimeIdentity,
+      connectedAt: "2026-05-22T00:00:01.000Z",
+      workstation: null,
+      consecutiveRejectedFrames: 0,
+    };
+    const harness = roomHarness(room);
+    let persisted = 0;
+    let materialized = 0;
+    harness.peers.set(ownerPeer.id, ownerPeer);
+    harness.peers.set(runtimePeer.id, runtimePeer);
+    harness.materializers.set("demo", {
+      receiveFrame: async () => {
+        materialized += 1;
+        return noopMaterializedResult();
+      },
+      checkpoint: async () => undefined,
+      removePeer: async () => undefined,
+    });
+    harness.persistFrame = async () => {
+      persisted += 1;
+    };
+    const requestPayload = new TextEncoder().encode(
+      JSON.stringify({ id: "request-1", action: "complete", code: "pri", cursor_pos: 3 }),
+    );
+
+    await harness.handleMessage(
+      "demo",
+      ownerPeer,
+      encodeTypedFrame(FrameType.REQUEST, requestPayload),
+    );
+
+    assert.equal(runtimeSocket.sent.length, 1);
+    assert.deepEqual(
+      [...runtimeSocket.sent[0]],
+      [FrameType.REQUEST, ...Array.from(requestPayload)],
+    );
+    assert.equal(ownerSocket.sent.length, 1);
+    assert.equal(
+      decodeJsonPayload<Record<string, unknown>>(ownerSocket.sent[0].slice(1)).type,
+      "cloud_frame_accepted",
+    );
+
+    const responsePayload = new TextEncoder().encode(
+      JSON.stringify({
+        id: "request-1",
+        result: "completion_result",
+        items: [{ label: "print", kind: "function" }],
+        cursor_start: 0,
+        cursor_end: 3,
+      }),
+    );
+    await harness.handleMessage(
+      "demo",
+      runtimePeer,
+      encodeTypedFrame(FrameType.RESPONSE, responsePayload),
+    );
+
+    assert.equal(ownerSocket.sent.length, 2);
+    assert.deepEqual(
+      [...ownerSocket.sent[1]],
+      [FrameType.RESPONSE, ...Array.from(responsePayload)],
+    );
+    assert.equal(materialized, 0);
+    assert.equal(persisted, 0);
+  });
+
   it("rejects forwarded runtime-agent command REQUEST frames when no runtime peer is attached", async () => {
     const room = new NotebookRoom(fakeState(), {} as Env);
     const identity = authenticateDevRequest(

--- a/apps/notebook-cloud/test/notebook-room.test.ts
+++ b/apps/notebook-cloud/test/notebook-room.test.ts
@@ -805,6 +805,61 @@ describe("NotebookRoom peer lifecycle", () => {
     assert.equal(await state.getAlarm(), null, "intentional replacement does not arm stale repair");
   });
 
+  it("keeps runtime peers when replacement workstation attachment publish fails", async () => {
+    const state = alarmCapableState();
+    const room = new NotebookRoom(state.state, {} as Env);
+    const harness = roomHarness(room);
+    const runtimeSocket = new FakeSocket();
+    const runtimePeer = {
+      id: "runtime",
+      socket: runtimeSocket.asCloudflareWebSocket(),
+      identity: authenticateDevRequest(
+        new Request(
+          "https://cloud.test/n/demo/sync?user=runtime&operator=runtime:py&scope=runtime_peer",
+        ),
+      ),
+      connectedAt: "2026-06-07T00:00:00.000Z",
+    };
+    harness.peers.set(runtimePeer.id, runtimePeer);
+    harness.materializers.set("demo", {
+      receiveFrame: async () => noopMaterializedResult(),
+      checkpoint: async () => undefined,
+      removePeer: async () => undefined,
+      setWorkstationAttachment: async () => {
+        throw new Error("publish failed");
+      },
+    } as never);
+
+    const response = await room.fetch(
+      new Request("https://room.internal/internal/n/demo/workstation-attachment", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          close_runtime_peers: true,
+          attachment: {
+            workstation_id: "ws-lab2",
+            display_name: "Lab2 workstation",
+            provider: "runtime_peer",
+            default_environment_label: "Current Python",
+            environment_policy: "current_python",
+            status: "connecting",
+            status_message: "Waiting for Lab2 to accept the compute request.",
+            cpu_count: 8,
+            memory_bytes: 16_000_000_000,
+            working_directory: "/home/ubuntu/project",
+            updated_at: "2026-06-07T00:00:01.000Z",
+          },
+        }),
+      }),
+    );
+
+    await state.drain();
+    assert.equal(response.status, 500);
+    assert.equal(harness.hasRuntimePeer(), true);
+    assert.equal(runtimeSocket.closed, false);
+    assert.equal(await state.getAlarm(), null);
+  });
+
   it("projects runtime-peer workstation metadata into the attachment", async () => {
     const state = hibernatedState([]);
     const room = new NotebookRoom(state.state, {} as Env);
@@ -1244,6 +1299,69 @@ describe("NotebookRoom materialized sync persistence", () => {
       socket: newRuntimeSocket.asCloudflareWebSocket(),
       identity: newRuntimeIdentity,
       connectedAt: "2026-05-22T00:00:01.000Z",
+      consecutiveRejectedFrames: 0,
+    };
+    const harness = roomHarness(room);
+    harness.peers.set(ownerPeer.id, ownerPeer);
+    harness.peers.set(oldRuntimePeer.id, oldRuntimePeer);
+    harness.peers.set(newRuntimePeer.id, newRuntimePeer);
+    harness.materializers.set("demo", fakeMaterializer(noopMaterializedResult()));
+    const requestPayload = new TextEncoder().encode(
+      JSON.stringify({ id: "request-1", action: "interrupt_execution" }),
+    );
+
+    await harness.handleMessage(
+      "demo",
+      ownerPeer,
+      encodeTypedFrame(FrameType.REQUEST, requestPayload),
+    );
+
+    assert.equal(oldRuntimeSocket.sent.length, 0);
+    assert.equal(newRuntimeSocket.sent.length, 1);
+    assert.deepEqual(
+      [...newRuntimeSocket.sent[0]],
+      [FrameType.REQUEST, ...Array.from(requestPayload)],
+    );
+  });
+
+  it("breaks equal runtime-peer timestamps in favor of the later connection", async () => {
+    const room = new NotebookRoom(fakeState(), {} as Env);
+    const ownerIdentity = authenticateDevRequest(
+      new Request("https://cloud.test/n/demo/sync?user=alice&operator=browser:a&scope=owner"),
+    );
+    const oldRuntimeIdentity = authenticateDevRequest(
+      new Request(
+        "https://cloud.test/n/demo/sync?user=runtime&operator=runtime:old&scope=runtime_peer",
+      ),
+    );
+    const newRuntimeIdentity = authenticateDevRequest(
+      new Request(
+        "https://cloud.test/n/demo/sync?user=runtime&operator=runtime:new&scope=runtime_peer",
+      ),
+    );
+    const ownerSocket = new FakeSocket();
+    const oldRuntimeSocket = new FakeSocket();
+    const newRuntimeSocket = new FakeSocket();
+    const connectedAt = "2026-05-22T00:00:00.000Z";
+    const ownerPeer = {
+      id: "owner",
+      socket: ownerSocket.asCloudflareWebSocket(),
+      identity: ownerIdentity,
+      connectedAt,
+      consecutiveRejectedFrames: 0,
+    };
+    const oldRuntimePeer = {
+      id: "runtime-old",
+      socket: oldRuntimeSocket.asCloudflareWebSocket(),
+      identity: oldRuntimeIdentity,
+      connectedAt,
+      consecutiveRejectedFrames: 0,
+    };
+    const newRuntimePeer = {
+      id: "runtime-new",
+      socket: newRuntimeSocket.asCloudflareWebSocket(),
+      identity: newRuntimeIdentity,
+      connectedAt,
       consecutiveRejectedFrames: 0,
     };
     const harness = roomHarness(room);

--- a/apps/notebook-cloud/test/notebook-room.test.ts
+++ b/apps/notebook-cloud/test/notebook-room.test.ts
@@ -1589,6 +1589,46 @@ describe("NotebookRoom materialized sync persistence", () => {
     assert.match(String(expired.error), /expired before the runtime peer responded/);
   });
 
+  it("counts unmatched runtime-peer RESPONSE frames toward rejected-frame close", async () => {
+    const room = new NotebookRoom(fakeState(), {} as Env);
+    const runtimeIdentity = authenticateDevRequest(
+      new Request(
+        "https://cloud.test/n/demo/sync?user=runtime&operator=runtime:new&scope=runtime_peer",
+      ),
+    );
+    const runtimeSocket = new FakeSocket();
+    const runtimePeer = {
+      id: "runtime",
+      socket: runtimeSocket.asCloudflareWebSocket(),
+      identity: runtimeIdentity,
+      connectedAt: "2026-05-22T00:00:01.000Z",
+      workstation: null,
+      consecutiveRejectedFrames: 0,
+    };
+    const harness = roomHarness(room);
+    harness.peers.set(runtimePeer.id, runtimePeer);
+    harness.materializers.set("demo", fakeMaterializer(noopMaterializedResult()));
+    const responsePayload = new TextEncoder().encode(
+      JSON.stringify({ id: "missing-request", result: "completion_result", items: [] }),
+    );
+
+    await harness.handleMessage(
+      "demo",
+      runtimePeer,
+      encodeTypedFrame(FrameType.RESPONSE, responsePayload),
+    );
+
+    assert.equal(runtimePeer.consecutiveRejectedFrames, 1);
+    assert.equal(runtimeSocket.closed, false);
+    assert.equal(runtimeSocket.sent.length, 1);
+    const rejected = decodeJsonPayload<Record<string, unknown>>(runtimeSocket.sent[0].slice(1));
+    assert.equal(rejected.type, "cloud_frame_rejected");
+    assert.equal(
+      rejected.reason,
+      "runtime peer response does not match an in-flight hosted request",
+    );
+  });
+
   it("rejects forwarded runtime-agent command REQUEST frames when no runtime peer is attached", async () => {
     const room = new NotebookRoom(fakeState(), {} as Env);
     const identity = authenticateDevRequest(

--- a/apps/notebook-cloud/test/worker-routes.test.ts
+++ b/apps/notebook-cloud/test/worker-routes.test.ts
@@ -1866,6 +1866,81 @@ describe("Worker artifact routes", () => {
     );
   });
 
+  it("replaces active workstation attach jobs when restarting hosted compute", async () => {
+    let runtimeStateRequest: Request | undefined;
+    const env = fakeEnv({
+      NOTEBOOK_ROOMS: {
+        idFromName: (name: string) => ({ toString: () => name }),
+        get: () => ({
+          fetch: async (request: Request) => {
+            runtimeStateRequest = request;
+            return new Response(JSON.stringify({ ok: true, changed: true }), {
+              status: 200,
+              headers: { "Content-Type": "application/json" },
+            });
+          },
+        }),
+      } satisfies DurableObjectNamespace,
+    });
+    seedNotebook(env, "attach-demo");
+    seedAcl(env, { notebookId: "attach-demo", subject: "user:dev:alice", scope: "owner" });
+    seedWorkstation(env, { ownerPrincipal: "user:dev:alice", workstationId: "ws-lab2" });
+    seedWorkstationAttachJob(env, {
+      id: "running-job",
+      notebookId: "attach-demo",
+      ownerPrincipal: "user:dev:alice",
+      workstationId: "ws-lab2",
+      status: "running",
+      updatedAt: new Date().toISOString(),
+    });
+
+    const attach = await worker.fetch(
+      new Request("http://localhost/api/n/attach-demo/workstation-attachments", {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          "X-Operator": "browser:tab",
+          "X-Scope": "owner",
+          "X-User": "alice",
+        },
+        body: JSON.stringify({ workstation_id: "ws-lab2", replace_existing: true }),
+      }),
+      env,
+      fakeContext(),
+    );
+
+    assert.equal(attach.status, 202);
+    const body = (await attach.json()) as { job: { job_id: string; status: string } };
+    assert.notEqual(body.job.job_id, "running-job");
+    assert.equal(body.job.status, "pending");
+    assert.equal(env.DB.workstationAttachJobs.get("running-job")?.status, "cancelled");
+    assert.match(
+      env.DB.workstationAttachJobs.get("running-job")?.error_message ?? "",
+      /replaced by a newer workstation attach request/,
+    );
+    assert.ok(runtimeStateRequest);
+    const payload = (await runtimeStateRequest.json()) as {
+      attachment?: { status?: string; status_message?: string | null; workstation_id?: string };
+      close_runtime_peers?: boolean;
+      close_reason?: string;
+    };
+    assert.equal(payload.close_runtime_peers, true);
+    assert.equal(payload.close_reason, "workstation restart requested");
+    assert.deepEqual(payload.attachment, {
+      workstation_id: "ws-lab2",
+      display_name: "Lab2",
+      provider: "runtime_peer",
+      default_environment_label: "Current Python",
+      environment_policy: "current_python",
+      status: "connecting",
+      status_message: "Waiting for Lab2 to accept the compute request.",
+      cpu_count: 8,
+      memory_bytes: 16_000_000_000,
+      working_directory: "/home/ubuntu/project",
+      updated_at: env.DB.workstationAttachJobs.get(body.job.job_id)?.updated_at,
+    });
+  });
+
   it("lists fresh running attach jobs so workstation agents can recover after restart", async () => {
     const env = fakeEnv();
     seedWorkstation(env, { ownerPrincipal: "user:dev:alice", workstationId: "ws-lab2" });
@@ -2073,6 +2148,72 @@ describe("Worker artifact routes", () => {
     assert.equal(response.status, 200);
     assert.equal(attachmentStatus, "connecting");
     assert.equal(attachmentMessage, "Lab2 accepted the request and is starting compute.");
+  });
+
+  it("rejects late workstation status patches after a replacement cancelled the job", async () => {
+    let publishCount = 0;
+    const env = fakeEnv({
+      NOTEBOOK_ROOMS: {
+        idFromName: (name: string) => ({ toString: () => name }),
+        get: () => ({
+          fetch: async () => {
+            publishCount += 1;
+            return new Response(JSON.stringify({ ok: true, changed: true }), {
+              status: 200,
+              headers: { "Content-Type": "application/json" },
+            });
+          },
+        }),
+      } satisfies DurableObjectNamespace,
+    });
+    seedWorkstation(env, { ownerPrincipal: "user:dev:alice", workstationId: "ws-lab2" });
+    seedWorkstationAttachJob(env, {
+      id: "job-old",
+      notebookId: "nb-old",
+      ownerPrincipal: "user:dev:alice",
+      workstationId: "ws-lab2",
+      status: "cancelled",
+      errorMessage: "replaced by a newer workstation attach request",
+      finishedAt: "2026-05-22T00:00:01.000Z",
+    });
+
+    const response = await worker.fetch(
+      new Request("http://localhost/api/workstations/ws-lab2/attach-jobs/job-old", {
+        method: "PATCH",
+        headers: {
+          "Content-Type": "application/json",
+          "X-Operator": "workstation:lab2",
+          "X-Scope": "owner",
+          "X-User": "alice",
+        },
+        body: JSON.stringify({ status: "completed" }),
+      }),
+      env,
+      fakeContext(),
+    );
+
+    assert.equal(response.status, 409);
+    assert.equal(publishCount, 0);
+    assert.equal(env.DB.workstationAttachJobs.get("job-old")?.status, "cancelled");
+    assert.deepEqual(await response.json(), {
+      error: "workstation attach job is no longer active",
+      job: {
+        job_id: "job-old",
+        notebook_id: "nb-old",
+        workstation_id: "ws-lab2",
+        status: "cancelled",
+        requested_at: "2026-05-22T00:00:00.000Z",
+        updated_at: "2026-05-22T00:00:00.000Z",
+        accepted_at: null,
+        finished_at: "2026-05-22T00:00:01.000Z",
+        error_message: "replaced by a newer workstation attach request",
+        runtime_peer: {
+          cloud_url: "http://localhost",
+          notebook_id: "nb-old",
+          scope: "runtime_peer",
+        },
+      },
+    });
   });
 
   it("lets notebook owners request a room-host runtime-state repair", async () => {
@@ -5060,6 +5201,8 @@ function seedWorkstationAttachJob(
     notebookId: string;
     ownerPrincipal: string;
     workstationId: string;
+    errorMessage?: string | null;
+    finishedAt?: string | null;
     status?: WorkstationAttachJobRow["status"];
     updatedAt?: string;
   },
@@ -5074,8 +5217,8 @@ function seedWorkstationAttachJob(
     requested_at: "2026-05-22T00:00:00.000Z",
     updated_at: input.updatedAt ?? "2026-05-22T00:00:00.000Z",
     accepted_at: null,
-    finished_at: null,
-    error_message: null,
+    finished_at: input.finishedAt ?? null,
+    error_message: input.errorMessage ?? null,
   });
 }
 
@@ -5872,6 +6015,28 @@ class FakeD1Statement implements D1PreparedStatement {
         }
       }
       return okResult(undefined, { changes });
+    } else if (
+      this.query.includes("UPDATE workstation_attach_jobs") &&
+      this.query.includes("SET status = 'cancelled'")
+    ) {
+      const [updatedAt, finishedAt, errorMessage, notebookId, ownerPrincipal, workstationId] = this
+        .values as [string, string, string, string, string, string];
+      let changes = 0;
+      for (const job of this.db.workstationAttachJobs.values()) {
+        if (
+          job.notebook_id === notebookId &&
+          job.owner_principal === ownerPrincipal &&
+          job.workstation_id === workstationId &&
+          (job.status === "pending" || job.status === "accepted" || job.status === "running")
+        ) {
+          job.status = "cancelled";
+          job.updated_at = updatedAt;
+          job.finished_at = finishedAt;
+          job.error_message = errorMessage;
+          changes += 1;
+        }
+      }
+      return okResult(undefined, { changes });
     } else if (this.query.includes("UPDATE workstation_attach_jobs")) {
       const [
         status,
@@ -5898,6 +6063,14 @@ class FakeD1Statement implements D1PreparedStatement {
       ];
       const job = this.db.workstationAttachJobs.get(jobId);
       if (job && job.owner_principal === ownerPrincipal && job.workstation_id === workstationId) {
+        if (
+          this.query.includes("status IN ('pending', 'accepted', 'running')") &&
+          job.status !== "pending" &&
+          job.status !== "accepted" &&
+          job.status !== "running"
+        ) {
+          return okResult(undefined, { changes: 0 });
+        }
         job.status = status;
         job.updated_at = updatedAt;
         if (

--- a/apps/notebook-cloud/test/workstations-client.test.ts
+++ b/apps/notebook-cloud/test/workstations-client.test.ts
@@ -127,6 +127,34 @@ describe("cloud workstations client", () => {
     );
   });
 
+  it("requests replacement notebook attachment for hosted restarts", async (t) => {
+    t.mock.method(globalThis, "fetch", async (input: RequestInfo | URL, init?: RequestInit) => {
+      assert.equal(String(input), "/api/n/nb-1/workstation-attachments");
+      assert.equal(init?.method, "POST");
+      assert.deepEqual(JSON.parse(String(init?.body)), {
+        workstation_id: "ws-lab2",
+        replace_existing: true,
+        intent: "restart",
+      });
+      return jsonResponse({
+        job: {
+          job_id: "job-restart",
+          status: "pending",
+        },
+      });
+    });
+
+    assert.deepEqual(
+      await requestCloudWorkstationAttachment(
+        "/api/n/nb-1/workstation-attachments",
+        devAuth,
+        "ws-lab2",
+        { replaceExisting: true },
+      ),
+      { jobId: "job-restart", status: "pending" },
+    );
+  });
+
   it("keeps registry refresh bounded to owner flows that can change workstation selection", () => {
     assert.equal(
       cloudWorkstationRefreshIntervalMs({

--- a/apps/notebook-cloud/viewer/__tests__/use-cloud-workstations.test.tsx
+++ b/apps/notebook-cloud/viewer/__tests__/use-cloud-workstations.test.tsx
@@ -65,6 +65,22 @@ function renderManager() {
   );
 }
 
+const lab2Workstation = {
+  id: "ws-lab2",
+  displayName: "Lab2",
+  provider: "runtime_peer",
+  providerLabel: null,
+  status: "online" as const,
+  statusMessage: null,
+  defaultEnvironmentLabel: "Current Python",
+  environmentPolicy: "current_python",
+  workingDirectory: "/home/ubuntu/project",
+  cpuCount: 8,
+  memoryBytes: 16_000_000_000,
+  updatedAt: null,
+  environments: [],
+};
+
 const futureIso = (ms: number) => new Date(Date.now() + ms).toISOString();
 
 describe("useCloudWorkstationManager pairing", () => {
@@ -253,5 +269,57 @@ describe("useCloudWorkstationManager pairing", () => {
 
     expect(result.current.workstationPairing?.status).toBe("registered");
     expect(result.current.workstationPairing?.workstationName).toBe("Hub devbox");
+  });
+
+  it("starts the launch candidate from toolbar wiring", async () => {
+    clientMocks.fetchCloudWorkstations.mockResolvedValue({
+      defaultWorkstationId: "ws-lab2",
+      workstations: [lab2Workstation],
+    });
+    clientMocks.requestCloudWorkstationAttachment.mockResolvedValue({
+      jobId: "job-1",
+      status: "pending",
+    });
+    const { result } = renderManager();
+
+    await act(async () => {
+      await Promise.resolve();
+    });
+    await act(async () => {
+      await result.current.onStartSelectedWorkstation?.();
+    });
+
+    expect(clientMocks.requestCloudWorkstationAttachment).toHaveBeenCalledWith(
+      "/api/n/nb-1/workstation-attachments",
+      devAuth,
+      "ws-lab2",
+      { replaceExisting: false },
+    );
+  });
+
+  it("requests a replacement attach job for toolbar restart", async () => {
+    clientMocks.fetchCloudWorkstations.mockResolvedValue({
+      defaultWorkstationId: "ws-lab2",
+      workstations: [lab2Workstation],
+    });
+    clientMocks.requestCloudWorkstationAttachment.mockResolvedValue({
+      jobId: "job-restart",
+      status: "pending",
+    });
+    const { result } = renderManager();
+
+    await act(async () => {
+      await Promise.resolve();
+    });
+    await act(async () => {
+      await result.current.onStartSelectedWorkstation?.({ replaceExisting: true });
+    });
+
+    expect(clientMocks.requestCloudWorkstationAttachment).toHaveBeenCalledWith(
+      "/api/n/nb-1/workstation-attachments",
+      devAuth,
+      "ws-lab2",
+      { replaceExisting: true },
+    );
   });
 });

--- a/apps/notebook-cloud/viewer/cloud-notebook-host.ts
+++ b/apps/notebook-cloud/viewer/cloud-notebook-host.ts
@@ -20,11 +20,15 @@ const unlisten: Unlisten = () => {};
 export interface CreateCloudNotebookHostOptions {
   blobResolver: BlobResolver;
   getRuntime: () => CloudSyncRuntime | null;
+  hasRuntimePeer?: () => boolean;
   openExternalUrl?: (url: string) => void | Promise<void>;
 }
 
 class CloudNotebookHostTransport implements NotebookTransport {
-  constructor(private readonly getRuntime: () => CloudSyncRuntime | null) {}
+  constructor(
+    private readonly getRuntime: () => CloudSyncRuntime | null,
+    private readonly hasRuntimePeer: () => boolean,
+  ) {}
 
   get connected(): boolean {
     return this.getRuntime()?.transport.connected ?? false;
@@ -56,7 +60,7 @@ class CloudNotebookHostTransport implements NotebookTransport {
       if (request.type === "get_history") {
         return historyResultFromLiveNotebook(this.getRuntime(), request);
       }
-      if (request.type === "complete" && !runtime) {
+      if (request.type === "complete" && (!runtime || !this.hasRuntimePeer())) {
         return emptyCompletionResult(request);
       }
     }
@@ -144,9 +148,10 @@ function emptyCompletionResult(
 export function createCloudNotebookHost({
   blobResolver,
   getRuntime,
+  hasRuntimePeer = () => Boolean(getRuntime()),
   openExternalUrl,
 }: CreateCloudNotebookHostOptions): NotebookHost {
-  const transport = new CloudNotebookHostTransport(getRuntime);
+  const transport = new CloudNotebookHostTransport(getRuntime, hasRuntimePeer);
   const openUrl =
     openExternalUrl ??
     ((url: string) => {

--- a/apps/notebook-cloud/viewer/cloud-notebook-host.ts
+++ b/apps/notebook-cloud/viewer/cloud-notebook-host.ts
@@ -52,10 +52,11 @@ class CloudNotebookHostTransport implements NotebookTransport {
 
   async sendRequest(request: unknown, options?: NotebookRequestOptions): Promise<unknown> {
     if (isNotebookRequest(request)) {
+      const runtime = this.getRuntime();
       if (request.type === "get_history") {
         return historyResultFromLiveNotebook(this.getRuntime(), request);
       }
-      if (request.type === "complete") {
+      if (request.type === "complete" && !runtime) {
         return emptyCompletionResult(request);
       }
     }

--- a/apps/notebook-cloud/viewer/live-sync.ts
+++ b/apps/notebook-cloud/viewer/live-sync.ts
@@ -203,6 +203,12 @@ interface PendingFrameAck {
   timeoutId: ReturnType<typeof setTimeout>;
 }
 
+interface PendingRequestResponse {
+  reject: (error: Error) => void;
+  resolve: (response: NotebookResponse) => void;
+  timeoutId: ReturnType<typeof setTimeout>;
+}
+
 /**
  * Browser timers are numbers; Node timers are objects whose `unref()`
  * releases the event loop. The liveness probe's periodic timers must never
@@ -224,6 +230,10 @@ function requestTimeoutMs(request: NotebookRequest): number {
     default:
       return CLOUD_REQUEST_TIMEOUT_MS;
   }
+}
+
+function awaitsRuntimePeerResponse(request: NotebookRequest): boolean {
+  return request.type === "complete";
 }
 
 export function cloudSyncAuthFromLocalStorage(): CloudSyncAuth {
@@ -867,6 +877,7 @@ export class CloudWebSocketTransport implements NotebookTransport {
   // Hosted room accept/reject controls currently carry only the frame type, not
   // a request id, so pending acknowledgements are matched FIFO per frame type.
   private pendingFrameAcks = new Map<number, PendingFrameAck[]>();
+  private pendingRequestResponses = new Map<string, PendingRequestResponse>();
   private readyResolve!: (message: CloudRoomReady) => void;
   private readyReject!: (error: Error) => void;
   /**
@@ -1031,6 +1042,7 @@ export class CloudWebSocketTransport implements NotebookTransport {
     this.stopLivenessProbe();
     // Pending FIFO frame ACKs cannot span sockets.
     this.rejectPendingFrameAcks(reason);
+    this.rejectPendingRequestResponses(reason);
     // Frames queued from a dead connection are bound to that connection's
     // sync state; never replay them into the next one.
     this.queuedFrames = [];
@@ -1242,10 +1254,45 @@ export class CloudWebSocketTransport implements NotebookTransport {
     }
   }
 
+  private async sendRuntimePeerQuery(
+    frameType: FrameTypeValue,
+    payload: Uint8Array,
+    id: string,
+    timeoutMs: number,
+    timeoutLabel = "cloud runtime query",
+  ): Promise<NotebookResponse> {
+    if (frameType !== FrameType.REQUEST) {
+      throw new Error(
+        `cloud viewer transport does not support runtime query frame 0x${frameType.toString(16)}`,
+      );
+    }
+
+    const pendingAck = this.registerFrameAck(frameType, timeoutMs, timeoutLabel);
+    const pendingResponse = this.registerRequestResponse(id, timeoutMs, timeoutLabel);
+    try {
+      await this.sendFrame(frameType, payload);
+      await pendingAck.promise;
+      return await pendingResponse.promise;
+    } catch (error) {
+      pendingAck.cancel();
+      pendingResponse.cancel();
+      throw error;
+    }
+  }
+
   async sendRequest(request: unknown, options?: NotebookRequestOptions): Promise<unknown> {
     const req = request as NotebookRequest;
     const envelope = notebookRequestEnvelope(req, options);
     const payload = new TextEncoder().encode(JSON.stringify(envelope));
+    if (awaitsRuntimePeerResponse(req)) {
+      return this.sendRuntimePeerQuery(
+        FrameType.REQUEST,
+        payload,
+        envelope.id,
+        requestTimeoutMs(req),
+        envelope.action,
+      );
+    }
     return this.sendTypedRequest(
       FrameType.REQUEST,
       payload,
@@ -1278,6 +1325,7 @@ export class CloudWebSocketTransport implements NotebookTransport {
     }
     this.teardownSocket();
     this.rejectPendingFrameAcks(new Error("cloud sync socket disconnected"));
+    this.rejectPendingRequestResponses(new Error("cloud sync socket disconnected"));
     this.listeners.clear();
     this.queuedFrames = [];
     if (!this.readySettled) {
@@ -1321,6 +1369,10 @@ export class CloudWebSocketTransport implements NotebookTransport {
           new Error(`cloud room rejected frame: ${control.reason}`),
         );
       }
+      return;
+    }
+
+    if (bytes[0] === FrameType.RESPONSE && this.resolveRequestResponse(bytes.slice(1))) {
       return;
     }
 
@@ -1439,6 +1491,56 @@ export class CloudWebSocketTransport implements NotebookTransport {
     }
     this.pendingFrameAcks.clear();
   }
+
+  private registerRequestResponse(
+    id: string,
+    timeoutMs: number,
+    timeoutLabel: string,
+  ): { cancel: () => void; promise: Promise<NotebookResponse> } {
+    let pending!: PendingRequestResponse;
+    const promise = new Promise<NotebookResponse>((resolve, reject) => {
+      const timeoutId = setTimeout(() => {
+        this.pendingRequestResponses.delete(id);
+        reject(new Error(`${timeoutLabel} timed out waiting for runtime peer response`));
+      }, timeoutMs);
+      pending = { reject, resolve, timeoutId };
+      this.pendingRequestResponses.set(id, pending);
+    });
+    promise.catch(() => undefined);
+
+    return {
+      cancel: () => {
+        const current = this.pendingRequestResponses.get(id);
+        if (current !== pending) return;
+        clearTimeout(pending.timeoutId);
+        this.pendingRequestResponses.delete(id);
+      },
+      promise,
+    };
+  }
+
+  private resolveRequestResponse(payload: Uint8Array): boolean {
+    const envelope = notebookResponseEnvelopeFromPayload(payload);
+    if (!envelope) {
+      return false;
+    }
+    const pending = this.pendingRequestResponses.get(envelope.id);
+    if (!pending) {
+      return false;
+    }
+    clearTimeout(pending.timeoutId);
+    this.pendingRequestResponses.delete(envelope.id);
+    pending.resolve(envelope.response);
+    return true;
+  }
+
+  private rejectPendingRequestResponses(error: Error): void {
+    for (const pending of this.pendingRequestResponses.values()) {
+      clearTimeout(pending.timeoutId);
+      pending.reject(error);
+    }
+    this.pendingRequestResponses.clear();
+  }
 }
 
 function notebookRequestEnvelope(
@@ -1457,6 +1559,21 @@ function notebookRequestEnvelope(
     ...(requiredHeads?.length ? { required_heads: requiredHeads } : {}),
     ...rest,
   };
+}
+
+function notebookResponseEnvelopeFromPayload(
+  payload: Uint8Array,
+): { id: string; response: NotebookResponse } | null {
+  try {
+    const value = JSON.parse(new TextDecoder().decode(payload)) as unknown;
+    if (!isRecord(value) || typeof value.id !== "string" || typeof value.result !== "string") {
+      return null;
+    }
+    const { id, ...response } = value;
+    return { id, response: response as NotebookResponse };
+  } catch {
+    return null;
+  }
 }
 
 function isRecord(value: unknown): value is Record<string, unknown> {

--- a/apps/notebook-cloud/viewer/notebook-viewer.tsx
+++ b/apps/notebook-cloud/viewer/notebook-viewer.tsx
@@ -239,8 +239,9 @@ export function NotebookViewer({
       createCloudNotebookHost({
         blobResolver,
         getRuntime: () => liveRuntimeRef.current,
+        hasRuntimePeer: () => cloudPresenceHasRuntimePeer(presenceStore.getSnapshot()),
       }),
-    [blobResolver, liveRuntimeRef],
+    [blobResolver, liveRuntimeRef, presenceStore],
   );
   // Sustained-outage legibility: the connection/identity slot stays an 8px
   // dot by design, so once "reconnecting" outlives the debounce the notices

--- a/apps/notebook-cloud/viewer/notebook-viewer.tsx
+++ b/apps/notebook-cloud/viewer/notebook-viewer.tsx
@@ -394,6 +394,7 @@ export function NotebookViewer({
     busyWorkstationId,
     onAttachWorkstation,
     onSetDefaultWorkstation,
+    onStartSelectedWorkstation,
     onStartPairing,
     onCancelPairing,
     workstationAction,
@@ -571,21 +572,10 @@ export function NotebookViewer({
     });
   }, [createCloudNotebookClient]);
   const handleCloudStartRuntime = useCallback(() => {
-    const runtimeClient = createCloudNotebookClient("start kernel");
-    if (!runtimeClient) return;
-
-    void (async () => {
-      const delivered = await runtimeClient.liveRuntime.engine.flushAndWait();
-      if (!delivered) {
-        console.warn("[notebook-cloud] start kernel request skipped; notebook sync failed");
-        return;
-      }
-
-      await runtimeClient.client.launchKernel("auto", "auto");
-    })().catch((error: unknown) => {
+    void onStartSelectedWorkstation?.().catch((error: unknown) => {
       console.warn("[notebook-cloud] start kernel request failed", error);
     });
-  }, [createCloudNotebookClient]);
+  }, [onStartSelectedWorkstation]);
   const handleCloudInterruptRuntime = useCallback(() => {
     const runtimeClient = createCloudNotebookClient("interrupt kernel");
     if (!runtimeClient) return;
@@ -595,22 +585,13 @@ export function NotebookViewer({
     });
   }, [createCloudNotebookClient]);
   const handleCloudRestartRuntime = useCallback(() => {
-    const runtimeClient = createCloudNotebookClient("restart kernel");
-    if (!runtimeClient) return;
-
-    void (async () => {
-      const delivered = await runtimeClient.liveRuntime.engine.flushAndWait();
-      if (!delivered) {
-        console.warn("[notebook-cloud] restart kernel request skipped; notebook sync failed");
-        return;
-      }
-
-      await runtimeClient.client.shutdownKernel();
-      await runtimeClient.client.launchKernel("auto", "auto");
-    })().catch((error: unknown) => {
+    void onStartSelectedWorkstation?.({
+      message: "Restarting compute. Waiting for the workstation to replace the runtime peer.",
+      replaceExisting: true,
+    }).catch((error: unknown) => {
       console.warn("[notebook-cloud] restart kernel request failed", error);
     });
-  }, [createCloudNotebookClient]);
+  }, [onStartSelectedWorkstation]);
   const handleCloudRestartAndRunAll = useCallback(() => {
     const runtimeClient = createCloudNotebookClient("restart kernel and run all cells");
     if (!runtimeClient) return;
@@ -624,13 +605,15 @@ export function NotebookViewer({
         return;
       }
 
-      await runtimeClient.client.shutdownKernel();
-      await runtimeClient.client.launchKernel("auto", "auto");
+      await onStartSelectedWorkstation?.({
+        message: "Restarting compute. Run all is queued for the replacement runtime.",
+        replaceExisting: true,
+      });
       await runtimeClient.client.runAllCells();
     })().catch((error: unknown) => {
       console.warn("[notebook-cloud] restart kernel and run all cells request failed", error);
     });
-  }, [createCloudNotebookClient]);
+  }, [createCloudNotebookClient, onStartSelectedWorkstation]);
   const handleCloudSetCellSourceHidden = useCallback(
     (cellId: string, hidden: boolean) => {
       cloudNotebookController.setCellSourceHidden(cellId, hidden);

--- a/apps/notebook-cloud/viewer/use-cloud-workstations.ts
+++ b/apps/notebook-cloud/viewer/use-cloud-workstations.ts
@@ -41,6 +41,8 @@ interface CloudWorkstationMutationState {
 }
 
 interface AttachWorkstationOptions {
+  message?: string;
+  replaceExisting?: boolean;
   revealPanel?: boolean;
 }
 
@@ -153,7 +155,8 @@ export function useCloudWorkstationManager({
       }
       setWorkstationMutation({
         kind: "attach",
-        message: "Starting compute. Waiting for the workstation to join this notebook.",
+        message:
+          options.message ?? "Starting compute. Waiting for the workstation to join this notebook.",
         workstationId,
       });
       if (options.revealPanel) {
@@ -164,6 +167,7 @@ export function useCloudWorkstationManager({
           config.workstationAttachEndpoint,
           authState,
           workstationId,
+          { replaceExisting: options.replaceExisting === true },
         );
         setWorkstationsError(null);
         await refreshCloudWorkstations();
@@ -426,9 +430,22 @@ export function useCloudWorkstationManager({
     }
   }, [workstationAttachment?.workstation_id, workstationMutation]);
 
+  const startSelectedWorkstation = useCallback(
+    async (options: Omit<AttachWorkstationOptions, "revealPanel"> = {}) => {
+      const workstationId = workstationLaunchReadiness.workstationId;
+      if (!workstationId) {
+        onOpenWorkstationsRail();
+        return;
+      }
+      await handleAttachWorkstation(workstationId, options);
+    },
+    [handleAttachWorkstation, onOpenWorkstationsRail, workstationLaunchReadiness.workstationId],
+  );
+
   return useMemo(
     () => ({
       busyWorkstationId: workstationMutation.workstationId,
+      onStartSelectedWorkstation: canChooseHostedWorkstation ? startSelectedWorkstation : undefined,
       onAttachWorkstation: canChooseHostedWorkstation
         ? (workstationId: string) => handleAttachWorkstation(workstationId, { revealPanel: true })
         : undefined,
@@ -446,6 +463,7 @@ export function useCloudWorkstationManager({
       handleCancelPairing,
       handleSetDefaultWorkstation,
       handleStartPairing,
+      startSelectedWorkstation,
       pairingWithName,
       workstationAction,
       workstationMutation.workstationId,

--- a/apps/notebook-cloud/viewer/workstations-client.ts
+++ b/apps/notebook-cloud/viewer/workstations-client.ts
@@ -31,6 +31,10 @@ interface CloudWorkstationAttachmentResponse {
   };
 }
 
+export interface RequestCloudWorkstationAttachmentOptions {
+  replaceExisting?: boolean;
+}
+
 export async function fetchCloudWorkstations(
   endpoint: string,
   authState: CloudPrototypeAuthState,
@@ -85,6 +89,7 @@ export async function requestCloudWorkstationAttachment(
   endpoint: string,
   authState: CloudPrototypeAuthState,
   workstationId: string,
+  options: RequestCloudWorkstationAttachmentOptions = {},
 ): Promise<{ jobId: string | null; status: string | null }> {
   const response = await fetchWithCloudPrototypeAuth(
     endpoint,
@@ -94,7 +99,10 @@ export async function requestCloudWorkstationAttachment(
         Accept: "application/json",
         "Content-Type": "application/json",
       },
-      body: JSON.stringify({ workstation_id: workstationId }),
+      body: JSON.stringify({
+        workstation_id: workstationId,
+        ...(options.replaceExisting ? { replace_existing: true, intent: "restart" } : {}),
+      }),
     },
     authState,
   );

--- a/crates/runtimed/src/display_update_committer.rs
+++ b/crates/runtimed/src/display_update_committer.rs
@@ -10,7 +10,7 @@ use std::collections::HashMap;
 use std::sync::{Arc, Mutex as StdMutex};
 
 use tokio::sync::{mpsc, oneshot, Notify};
-use tracing::{debug, error, warn};
+use tracing::{debug, error, info, warn};
 
 use crate::output_commit_context::OutputCommitContext;
 use crate::output_prep::LifecycleSignal;
@@ -26,6 +26,7 @@ struct PendingDisplayUpdate {
     data: serde_json::Value,
     metadata: serde_json::Map<String, serde_json::Value>,
     buffers: Vec<Vec<u8>>,
+    requested_at: std::time::Instant,
 }
 
 struct SharedPending {
@@ -81,6 +82,7 @@ impl DisplayUpdateCommitterHandle {
                 data,
                 metadata,
                 buffers,
+                requested_at: std::time::Instant::now(),
             },
         );
         drop(updates);
@@ -117,6 +119,16 @@ fn take_pending(pending: &SharedPending) -> HashMap<String, PendingDisplayUpdate
 
 async fn commit_pending_updates(pending: &SharedPending, context: &OutputCommitContext) {
     let updates = take_pending(pending);
+    if updates.is_empty() {
+        return;
+    }
+    let commit_started = std::time::Instant::now();
+    let count = updates.len();
+    let max_request_age_ms = updates
+        .values()
+        .map(|update| update.requested_at.elapsed().as_millis())
+        .max()
+        .unwrap_or(0);
     for (display_id, update) in updates {
         let preflight_wrapper = serde_json::json!({ "data": update.data });
         crate::output_store::preflight_ref_buffers(
@@ -181,6 +193,12 @@ async fn commit_pending_updates(pending: &SharedPending, context: &OutputCommitC
             }
         }
     }
+    info!(
+        "[display-update-committer-timing] display updates committed count={} max_request_age_ms={} elapsed_ms={}",
+        count,
+        max_request_age_ms,
+        commit_started.elapsed().as_millis()
+    );
 }
 
 async fn run_display_update_committer(

--- a/crates/runtimed/src/kernel_state.rs
+++ b/crates/runtimed/src/kernel_state.rs
@@ -168,13 +168,22 @@ impl KernelState {
             // Write to state doc
             {
                 let doc_queued = to_doc_entries(&self.queued_entries());
+                let mut output_count = 0usize;
                 if let Err(e) = self.state.with_doc(|sd| {
+                    output_count = sd.get_outputs(execution_id).len();
                     sd.set_execution_done(execution_id, success)?;
                     sd.set_queue(None, &doc_queued)?;
                     Ok(())
                 }) {
                     warn!("[runtime-state] {}", e);
                 }
+                info!(
+                    "[kernel-state-timing] Execution terminalized: execution_id={} success={} output_count={} remaining_queue={}",
+                    execution_id,
+                    success,
+                    output_count,
+                    doc_queued.len()
+                );
             }
 
             // Process next

--- a/crates/runtimed/src/kernel_state.rs
+++ b/crates/runtimed/src/kernel_state.rs
@@ -126,6 +126,7 @@ impl KernelState {
             execution_id: execution_id.clone(),
             cell_id,
             code: source,
+            queued_at: std::time::Instant::now(),
         });
 
         // Write to state doc
@@ -320,6 +321,8 @@ impl KernelState {
         let Some(cell) = self.queue.pop_front() else {
             return Ok(());
         };
+        let queue_wait_ms = cell.queued_at.elapsed().as_millis();
+        let remaining_queue = self.queue.len();
 
         self.executing = Some(cell.execution_id.clone());
         self.status = KernelStatus::Busy;
@@ -342,8 +345,8 @@ impl KernelState {
             .await?;
 
         info!(
-            "[kernel-state] Sent execute_request: execution_id={}",
-            cell.execution_id
+            "[kernel-state] Sent execute_request: execution_id={} queue_wait_ms={} remaining_queue={}",
+            cell.execution_id, queue_wait_ms, remaining_queue
         );
 
         Ok(())

--- a/crates/runtimed/src/output_committer.rs
+++ b/crates/runtimed/src/output_committer.rs
@@ -7,7 +7,7 @@
 //! are durable in RuntimeStateDoc.
 
 use tokio::sync::{mpsc, oneshot};
-use tracing::{debug, warn};
+use tracing::{debug, info, warn};
 
 use crate::output_blob_publisher::publish_or_warn;
 use crate::output_commit_context::OutputCommitContext;
@@ -53,15 +53,21 @@ pub(crate) struct OrdinaryOutputCommit {
 }
 
 #[derive(Debug)]
+struct TimedOrdinaryOutputCommit {
+    output: OrdinaryOutputCommit,
+    enqueued_at: std::time::Instant,
+}
+
+#[derive(Debug)]
 struct PriorityOutputRequest {
-    output: Option<OrdinaryOutputCommit>,
+    output: Option<TimedOrdinaryOutputCommit>,
     signal: Option<LifecycleSignal>,
     ack: Option<oneshot::Sender<()>>,
 }
 
 #[derive(Clone)]
 pub(crate) struct OutputCommitterHandle {
-    output_tx: mpsc::Sender<OrdinaryOutputCommit>,
+    output_tx: mpsc::Sender<TimedOrdinaryOutputCommit>,
     priority_tx: mpsc::UnboundedSender<PriorityOutputRequest>,
     lifecycle_tx: mpsc::UnboundedSender<LifecycleSignal>,
 }
@@ -75,11 +81,15 @@ impl OutputCommitterHandle {
     /// output ordering without allowing unbounded queue growth or forcing the
     /// IOPub reader to synchronously drain all pending output work mid-burst.
     pub(crate) async fn enqueue_output(&self, output: OrdinaryOutputCommit) {
-        match self.output_tx.try_send(output) {
+        let timed = TimedOrdinaryOutputCommit {
+            output,
+            enqueued_at: std::time::Instant::now(),
+        };
+        match self.output_tx.try_send(timed) {
             Ok(()) => {}
-            Err(mpsc::error::TrySendError::Full(output)) => {
+            Err(mpsc::error::TrySendError::Full(timed)) => {
                 debug!("[output-committer] Queue full; waiting for output queue capacity");
-                if self.output_tx.send(output).await.is_err() {
+                if self.output_tx.send(timed).await.is_err() {
                     warn!("[output-committer] Dropping output: committer closed");
                 }
             }
@@ -124,7 +134,7 @@ impl OutputCommitterHandle {
 
 async fn commit_priority_request(
     request: PriorityOutputRequest,
-    output_rx: &mut mpsc::Receiver<OrdinaryOutputCommit>,
+    output_rx: &mut mpsc::Receiver<TimedOrdinaryOutputCommit>,
     context: &OutputCommitContext,
 ) {
     drain_queued_outputs(output_rx, context).await;
@@ -140,7 +150,7 @@ async fn commit_priority_request(
 }
 
 async fn drain_queued_outputs(
-    output_rx: &mut mpsc::Receiver<OrdinaryOutputCommit>,
+    output_rx: &mut mpsc::Receiver<TimedOrdinaryOutputCommit>,
     context: &OutputCommitContext,
 ) {
     loop {
@@ -159,7 +169,7 @@ async fn drain_queued_outputs(
 }
 
 async fn run_output_committer(
-    mut output_rx: mpsc::Receiver<OrdinaryOutputCommit>,
+    mut output_rx: mpsc::Receiver<TimedOrdinaryOutputCommit>,
     mut priority_rx: mpsc::UnboundedReceiver<PriorityOutputRequest>,
     context: OutputCommitContext,
 ) {
@@ -222,14 +232,34 @@ fn start_output_committer_with_capacity(
     }
 }
 
-async fn commit_output_batch(outputs: Vec<OrdinaryOutputCommit>, context: &OutputCommitContext) {
+async fn commit_output_batch(
+    outputs: Vec<TimedOrdinaryOutputCommit>,
+    context: &OutputCommitContext,
+) {
     if outputs.is_empty() {
         return;
     }
 
+    let commit_started = std::time::Instant::now();
+    let max_queue_age_ms = outputs
+        .iter()
+        .map(|output| output.enqueued_at.elapsed().as_millis())
+        .max()
+        .unwrap_or(0);
+    let mut display_data_count = 0usize;
+    let mut execute_result_count = 0usize;
+    let mut error_count = 0usize;
+    for output in &outputs {
+        match output.output.kind {
+            OrdinaryOutputKind::DisplayData => display_data_count += 1,
+            OrdinaryOutputKind::ExecuteResult => execute_result_count += 1,
+            OrdinaryOutputKind::Error => error_count += 1,
+        }
+    }
+
     let mut manifests = Vec::with_capacity(outputs.len());
     for output in &outputs {
-        manifests.push(create_manifest_json(output, context).await);
+        manifests.push(create_manifest_json(&output.output, context).await);
     }
 
     if let Err(e) = context.state.transact_at_current_heads(
@@ -238,9 +268,9 @@ async fn commit_output_batch(outputs: Vec<OrdinaryOutputCommit>, context: &Outpu
         |sd| {
             let mut index = 0;
             while index < outputs.len() {
-                let execution_id = outputs[index].execution_id.as_str();
+                let execution_id = outputs[index].output.execution_id.as_str();
                 let start = index;
-                while index < outputs.len() && outputs[index].execution_id == execution_id {
+                while index < outputs.len() && outputs[index].output.execution_id == execution_id {
                     index += 1;
                 }
                 if let Err(e) = sd.append_outputs(execution_id, &manifests[start..index]) {
@@ -252,6 +282,15 @@ async fn commit_output_batch(outputs: Vec<OrdinaryOutputCommit>, context: &Outpu
     ) {
         warn!("[runtime-state] {}", e);
     }
+    info!(
+        "[output-committer-timing] ordinary output batch committed count={} display_data_count={} execute_result_count={} error_count={} max_queue_age_ms={} elapsed_ms={}",
+        outputs.len(),
+        display_data_count,
+        execute_result_count,
+        error_count,
+        max_queue_age_ms,
+        commit_started.elapsed().as_millis()
+    );
 }
 
 async fn create_manifest_json(

--- a/crates/runtimed/src/output_prep.rs
+++ b/crates/runtimed/src/output_prep.rs
@@ -419,6 +419,7 @@ pub struct QueuedCell {
     pub execution_id: String,
     pub cell_id: Option<String>,
     pub code: String,
+    pub queued_at: std::time::Instant,
 }
 
 /// Kernel status.

--- a/crates/runtimed/src/runtime_agent.rs
+++ b/crates/runtimed/src/runtime_agent.rs
@@ -356,10 +356,16 @@ where
 {
     // -- 1. Connect ---------------------------------------------------------
 
+    let agent_started = std::time::Instant::now();
+    let connect_started = std::time::Instant::now();
     // `connect` owns the transport-specific dial + handshake/auth.
     let (mut frame_source, mut frame_sink) = transport.connect().await?;
 
-    info!("[runtime-agent] Connected, handshake sent");
+    info!(
+        "[runtime-agent] Connected, handshake sent connect_elapsed_ms={} startup_elapsed_ms={}",
+        connect_started.elapsed().as_millis(),
+        agent_started.elapsed().as_millis()
+    );
 
     // The transport hands back a cancel-safe `FrameSource` (backed by a
     // dedicated `FramedReader` actor) so the busy `select!` below stays
@@ -452,6 +458,7 @@ where
     let sync_generation = std::sync::Arc::new(std::sync::atomic::AtomicU64::new(0));
     let mut inflight_sync: Option<tokio::task::JoinHandle<()>> = None;
     let mut runtime_state_doc_seen = false;
+    let mut runtime_state_doc_seen_at: Option<std::time::Instant> = None;
     let mut orphan_comm_candidates: HashSet<String> = HashSet::new();
 
     // -- 3b. Launch-on-attach gate (cloud only) -----------------------------
@@ -667,6 +674,9 @@ where
 
                             // RuntimeStateSync -- apply coordinator's changes and check for new queue entries.
                             NotebookFrameType::RuntimeStateSync => {
+                                let sync_started = std::time::Instant::now();
+                                let mut inbound_queued_count = 0usize;
+                                let mut accepted_queued_count = 0usize;
                                 if let Ok(msg) = automerge::sync::Message::decode(&typed_frame.payload) {
                                     let sync_result = ctx.state.with_doc(|sd| {
                                         match sd.receive_sync_message_with_changes_recovering(
@@ -692,7 +702,8 @@ where
                                     match sync_result {
                                         Ok(Some(queued)) => {
                                             runtime_state_doc_seen = true;
-                                            queue_synced_executions(
+                                            inbound_queued_count = queued.len();
+                                            accepted_queued_count = queue_synced_executions(
                                                 queued,
                                                 &mut seen_execution_ids,
                                                 &mut kernel_state,
@@ -710,10 +721,28 @@ where
                                     }
 
                                     if runtime_state_doc_seen {
+                                        if runtime_state_doc_seen_at.is_none() {
+                                            runtime_state_doc_seen_at = Some(std::time::Instant::now());
+                                            info!(
+                                                "[runtime-agent-timing] initial RuntimeStateDoc sync applied startup_elapsed_ms={} sync_elapsed_ms={} inbound_queued_count={}",
+                                                agent_started.elapsed().as_millis(),
+                                                sync_started.elapsed().as_millis(),
+                                                inbound_queued_count
+                                            );
+                                        } else if accepted_queued_count > 0 {
+                                            info!(
+                                                "[runtime-agent-timing] RuntimeStateDoc queued executions observed inbound_count={} accepted_count={} sync_elapsed_ms={}",
+                                                inbound_queued_count,
+                                                accepted_queued_count,
+                                                sync_started.elapsed().as_millis()
+                                            );
+                                        }
                                         if let Some(launch) = pending_initial_launch.take() {
                                             info!(
-                                                "[runtime-agent] Applying launch-on-attach LaunchKernel after RuntimeStateDoc sync"
+                                                "[runtime-agent] Applying launch-on-attach LaunchKernel after RuntimeStateDoc sync startup_elapsed_ms={}",
+                                                agent_started.elapsed().as_millis()
                                             );
+                                            let launch_apply_started = std::time::Instant::now();
                                             let (response, new_cmd_rx) =
                                                 handle_runtime_agent_request(
                                                     launch,
@@ -735,6 +764,12 @@ where
                                                 warn!(
                                                     "[runtime-agent] Launch-on-attach failed: {}",
                                                     error
+                                                );
+                                            } else {
+                                                info!(
+                                                    "[runtime-agent-timing] launch-on-attach completed elapsed_ms={} startup_elapsed_ms={}",
+                                                    launch_apply_started.elapsed().as_millis(),
+                                                    agent_started.elapsed().as_millis()
                                                 );
                                             }
                                         }

--- a/crates/runtimed/src/stream_committer.rs
+++ b/crates/runtimed/src/stream_committer.rs
@@ -11,7 +11,7 @@
 use std::sync::Arc;
 
 use tokio::sync::{mpsc, oneshot, Mutex};
-use tracing::{debug, warn};
+use tracing::{debug, info, warn};
 
 use crate::output_blob_publisher::publish_or_warn;
 use crate::output_commit_context::OutputCommitContext;
@@ -25,9 +25,15 @@ const STREAM_COMMITTER_QUEUE_CAPACITY: usize = 32;
 
 #[derive(Debug)]
 struct PriorityStreamCommit {
-    flushes: Vec<PendingStreamFlush>,
+    flushes: Vec<TimedPendingStreamFlush>,
     signal: Option<LifecycleSignal>,
     ack: Option<oneshot::Sender<()>>,
+}
+
+#[derive(Debug)]
+struct TimedPendingStreamFlush {
+    flush: PendingStreamFlush,
+    requested_at: std::time::Instant,
 }
 
 struct StreamCommitterContext {
@@ -37,7 +43,7 @@ struct StreamCommitterContext {
 
 #[derive(Clone)]
 pub(crate) struct StreamCommitterHandle {
-    periodic_tx: mpsc::Sender<PendingStreamFlush>,
+    periodic_tx: mpsc::Sender<TimedPendingStreamFlush>,
     priority_tx: mpsc::UnboundedSender<PriorityStreamCommit>,
     lifecycle_tx: mpsc::UnboundedSender<LifecycleSignal>,
 }
@@ -50,7 +56,11 @@ impl StreamCommitterHandle {
     /// and a later flush (especially the final execution flush) will publish
     /// the newest content.
     pub(crate) fn request_flush(&self, flush: PendingStreamFlush) {
-        match self.periodic_tx.try_send(flush) {
+        let timed = TimedPendingStreamFlush {
+            flush,
+            requested_at: std::time::Instant::now(),
+        };
+        match self.periodic_tx.try_send(timed) {
             Ok(()) => {}
             Err(mpsc::error::TrySendError::Full(_)) => {
                 debug!("[stream-committer] Dropping periodic stream flush: queue full");
@@ -76,7 +86,7 @@ impl StreamCommitterHandle {
 
         let (ack_tx, ack_rx) = oneshot::channel();
         let request = PriorityStreamCommit {
-            flushes,
+            flushes: timed_stream_flushes(flushes),
             signal: None,
             ack: Some(ack_tx),
         };
@@ -110,7 +120,7 @@ impl StreamCommitterHandle {
         // commit_priority_streams costs nothing.
 
         let request = PriorityStreamCommit {
-            flushes,
+            flushes: timed_stream_flushes(flushes),
             signal: Some(signal),
             ack: None,
         };
@@ -122,24 +132,82 @@ impl StreamCommitterHandle {
     }
 }
 
+fn timed_stream_flushes(flushes: Vec<PendingStreamFlush>) -> Vec<TimedPendingStreamFlush> {
+    let now = std::time::Instant::now();
+    flushes
+        .into_iter()
+        .map(|flush| TimedPendingStreamFlush {
+            flush,
+            requested_at: now,
+        })
+        .collect()
+}
+
+fn lifecycle_signal_label(signal: &LifecycleSignal) -> &'static str {
+    match signal {
+        LifecycleSignal::ExecutionDone { .. } => "execution_done",
+        LifecycleSignal::KernelIdle { .. } => "kernel_idle",
+        LifecycleSignal::CellError { .. } => "cell_error",
+        LifecycleSignal::KernelDied => "kernel_died",
+    }
+}
+
 async fn commit_priority_streams(request: PriorityStreamCommit, context: &StreamCommitterContext) {
+    let commit_started = std::time::Instant::now();
+    let flush_count = request.flushes.len();
+    let max_request_age_ms = request
+        .flushes
+        .iter()
+        .map(|flush| flush.requested_at.elapsed().as_millis())
+        .max()
+        .unwrap_or(0);
+    let signal_label = request
+        .signal
+        .as_ref()
+        .map(lifecycle_signal_label)
+        .unwrap_or("none");
     for flush in request.flushes {
-        commit_stream_flush(&context.output, &context.stream_terminals, flush).await;
+        commit_stream_flush(&context.output, &context.stream_terminals, flush.flush).await;
     }
     if let Some(signal) = request.signal {
         let _ = context.output.lifecycle_tx.send(signal);
+    }
+    if flush_count > 0 || signal_label != "none" {
+        info!(
+            "[stream-committer-timing] priority stream flush committed flush_count={} max_request_age_ms={} elapsed_ms={} signal={}",
+            flush_count,
+            max_request_age_ms,
+            commit_started.elapsed().as_millis(),
+            signal_label
+        );
     }
     if let Some(ack) = request.ack {
         let _ = ack.send(());
     }
 }
 
-async fn commit_periodic_stream(flush: PendingStreamFlush, context: &StreamCommitterContext) {
-    commit_stream_flush(&context.output, &context.stream_terminals, flush).await;
+async fn commit_periodic_stream(flush: TimedPendingStreamFlush, context: &StreamCommitterContext) {
+    let commit_started = std::time::Instant::now();
+    let request_age_ms = flush.requested_at.elapsed().as_millis();
+    commit_stream_flush(&context.output, &context.stream_terminals, flush.flush).await;
+    let elapsed_ms = commit_started.elapsed().as_millis();
+    if request_age_ms >= 100 || elapsed_ms >= 100 {
+        info!(
+            "[stream-committer-timing] periodic stream flush committed request_age_ms={} elapsed_ms={}",
+            request_age_ms,
+            elapsed_ms
+        );
+    } else {
+        debug!(
+            "[stream-committer-timing] periodic stream flush committed request_age_ms={} elapsed_ms={}",
+            request_age_ms,
+            elapsed_ms
+        );
+    }
 }
 
 async fn run_stream_committer(
-    mut periodic_rx: mpsc::Receiver<PendingStreamFlush>,
+    mut periodic_rx: mpsc::Receiver<TimedPendingStreamFlush>,
     mut priority_rx: mpsc::UnboundedReceiver<PriorityStreamCommit>,
     context: StreamCommitterContext,
 ) {
@@ -512,8 +580,8 @@ mod tests {
         });
 
         let received = periodic_rx.try_recv().expect("first flush stays queued");
-        assert_eq!(received.execution_id, "exec-1");
-        assert_eq!(received.stream_name, "stdout");
+        assert_eq!(received.flush.execution_id, "exec-1");
+        assert_eq!(received.flush.stream_name, "stdout");
         assert!(
             periodic_rx.try_recv().is_err(),
             "second flush should be dropped"

--- a/crates/runtimed/src/workstation/agent_loop.rs
+++ b/crates/runtimed/src/workstation/agent_loop.rs
@@ -697,10 +697,14 @@ async fn poll_attach_jobs(
 ) -> Result<bool, AgentHttpError> {
     let poll_started = Instant::now();
     let jobs = api.poll_attach_jobs(&opts.workstation_id).await?;
-    if !jobs.is_empty() {
+    let actionable_job_count = jobs
+        .iter()
+        .filter(|job| !active.contains_key(&job.job_id))
+        .count();
+    if actionable_job_count > 0 {
         info!(
             "[workstation-agent] attach jobs polled count={} elapsed_ms={}",
-            jobs.len(),
+            actionable_job_count,
             poll_started.elapsed().as_millis()
         );
     }

--- a/crates/runtimed/src/workstation/agent_loop.rs
+++ b/crates/runtimed/src/workstation/agent_loop.rs
@@ -547,6 +547,7 @@ struct ActiveJob {
     log_path: PathBuf,
     ready: bool,
     status: &'static str,
+    started_at: Instant,
     last_status_patch_at: Instant,
 }
 
@@ -694,7 +695,15 @@ async fn poll_attach_jobs(
     token: &str,
     active: &mut HashMap<String, ActiveJob>,
 ) -> Result<bool, AgentHttpError> {
+    let poll_started = Instant::now();
     let jobs = api.poll_attach_jobs(&opts.workstation_id).await?;
+    if !jobs.is_empty() {
+        info!(
+            "[workstation-agent] attach jobs polled count={} elapsed_ms={}",
+            jobs.len(),
+            poll_started.elapsed().as_millis()
+        );
+    }
     for job in jobs {
         if active.contains_key(&job.job_id) {
             continue;
@@ -715,6 +724,7 @@ async fn start_attach_job(
     active: &mut HashMap<String, ActiveJob>,
     job: &AttachJob,
 ) -> Result<(), AgentHttpError> {
+    let attach_started = Instant::now();
     let plan = build_attach_job_spawn_plan(job, opts)
         .map_err(|e| AgentHttpError::local(format!("plan attach job: {e}")))?;
     std::fs::create_dir_all(&plan.blob_root).map_err(|e| {
@@ -724,21 +734,33 @@ async fn start_attach_job(
         ))
     })?;
 
+    let accept_started = Instant::now();
     api.patch_attach_job(&opts.workstation_id, &job.job_id, "accepted", None)
         .await?;
+    info!(
+        "[workstation-agent] attach job accepted job_id={} notebook_id={} accept_elapsed_ms={} elapsed_ms={}",
+        job.job_id,
+        job.notebook_id,
+        accept_started.elapsed().as_millis(),
+        attach_started.elapsed().as_millis()
+    );
 
+    let spawn_started = Instant::now();
     match spawn_runtime_peer(&plan, token) {
         Ok((child, pid)) => {
             if let Some(pid) = pid {
                 write_pid_file(&plan.pid_path, pid);
             }
             info!(
-                "[workstation-agent] attach job spawned job_id={} notebook_id={} pid={:?} log={}",
+                "[workstation-agent] attach job spawned job_id={} notebook_id={} pid={:?} spawn_elapsed_ms={} elapsed_ms={} log={}",
                 job.job_id,
                 job.notebook_id,
                 pid,
+                spawn_started.elapsed().as_millis(),
+                attach_started.elapsed().as_millis(),
                 plan.log_path.display()
             );
+            let now = Instant::now();
             active.insert(
                 job.job_id.clone(),
                 ActiveJob {
@@ -747,7 +769,8 @@ async fn start_attach_job(
                     log_path: plan.log_path,
                     ready: false,
                     status: "accepted",
-                    last_status_patch_at: Instant::now(),
+                    started_at: now,
+                    last_status_patch_at: now,
                 },
             );
         }
@@ -808,6 +831,7 @@ async fn reconcile_active_attach_job(
                 log_path: plan.log_path,
                 ready,
                 status: if ready { "running" } else { "accepted" },
+                started_at: backdated,
                 last_status_patch_at: backdated,
             },
         );
@@ -871,6 +895,10 @@ async fn tick_active_jobs(
         match outcome {
             JobTick::None => {}
             JobTick::BecameReady => {
+                let ready_elapsed_ms = active
+                    .get(&job_id)
+                    .map(|job| job.started_at.elapsed().as_millis())
+                    .unwrap_or_default();
                 // Mark ready before patching: if the patch fails, the periodic
                 // status heartbeat re-sends "running" (same healing path as
                 // the `.mjs` agent).
@@ -879,7 +907,9 @@ async fn tick_active_jobs(
                     job.status = "running";
                     job.last_status_patch_at = Instant::now();
                 }
-                info!("[workstation-agent] attach job ready job_id={job_id}");
+                info!(
+                    "[workstation-agent] attach job ready job_id={job_id} elapsed_ms={ready_elapsed_ms}"
+                );
                 if let Err(e) = api
                     .patch_attach_job(&opts.workstation_id, &job_id, "running", None)
                     .await

--- a/docs/adr/remote-workstation-doc-agents.md
+++ b/docs/adr/remote-workstation-doc-agents.md
@@ -723,6 +723,12 @@ sequence:
   forwarded the comm message to the selected runtime peer. The widget-visible
   result is still the later CommsDoc/RuntimeStateDoc change; cloud must not
   invent a response envelope or treat the ack as a completed widget round trip.
+- **Unsupported response-bearing runtime requests fail honestly.** Hosted cloud
+  rooms reject direct `launch_kernel`, `shutdown_kernel`, `sync_environment`,
+  `complete`, and `get_history` request frames instead of acknowledging them as
+  empty room-host no-ops. The cloud viewer still handles current hosted history
+  and empty completions in `CloudNotebookHostTransport`; a real kernel-backed
+  implementation needs a response path rather than a socket delivery ack.
 
 Operator instructions: `docs/remote-workstation.md`.
 

--- a/docs/adr/remote-workstation-doc-agents.md
+++ b/docs/adr/remote-workstation-doc-agents.md
@@ -705,20 +705,32 @@ sequence:
   (`use-cloud-workstations.ts`) drives `/api/n/:id/workstation-attachments`;
   attach jobs command the connector, which attaches as `runtime_peer` over
   `CloudWsFrameTransport`.
-- **Execution (steps 10–11).** The room host queues executions from editor
+- **Execution (steps 10–11).** The room host queues executions from owner
   REQUESTs (#3399); viewer requests resolve via `cloud_frame_accepted` /
   `cloud_frame_rejected` acks. Launch-on-attach starts a `current_python`
   kernel through the daemon's launcher (`crates/runtimed/src/workstation/`).
   Verified live: browser submits, workstation executes, output lands in the
   viewer.
+- **Runtime-agent commands.** Cloud now forwards owner-authorized
+  fire-and-forget runtime-agent command REQUESTs (`interrupt_execution` and
+  `send_comm`) directly to attached `runtime_peer` sockets. These requests do
+  not persist as room history and do not produce `RESPONSE` envelopes; visible
+  results must arrive through RuntimeStateDoc/CommsDoc convergence, matching the
+  local runtime-agent command model. During reconnect overlap, command routing
+  targets the newest connected runtime peer, matching the attachment
+  `updated_at` projection until runtime generations become explicit.
 
 Operator instructions: `docs/remote-workstation.md`.
 
-Still open: inbound kernel lifecycle over cloud (interrupt/restart/shutdown —
-the "req 5" channel; launch-on-attach covers only the first launch), the
-attachment-ticket contract (step 6; dev path today is API key / dev token plus
-an explicit `runtime_peer` ACL row), catalog projection (step 5), and the
-provider-specific Outerbounds/JupyterHub smokes (step 12). Tracked in
+Still open: response-bearing kernel lifecycle over cloud
+(`launch_kernel`/`shutdown_kernel`/restart, plus `sync_environment` and kernel
+queries such as completion/history), the attachment-ticket contract (step 6;
+dev path today is API key / dev token plus an explicit `runtime_peer` ACL row),
+catalog projection (step 5), and the provider-specific Outerbounds/JupyterHub
+smokes (step 12). Restart also needs a bounded stale-runtime policy: if the
+selected runtime does not confirm restart in time, the room should assume that
+runtime generation is gone, start a new attachment, and ignore late frames from
+the old runtime. Tracked in
 [#3381](https://github.com/nteract/nteract/issues/3381).
 
 ## Open questions

--- a/docs/adr/remote-workstation-doc-agents.md
+++ b/docs/adr/remote-workstation-doc-agents.md
@@ -234,10 +234,22 @@ remains for workstations is target selection: how the active runtime peer is
 chosen for accepted executions, and how readiness/disconnect gates the
 dispatch (punchlist 3D-7).
 
-Kernel lifecycle requests should follow the same split. The room host accepts
-`LaunchKernel`, `RestartKernel`, `InterruptExecution`, and `ShutdownKernel`
-requests from allowed user roles, then dispatches the corresponding runtime work
-to the active workstation runtime peer.
+Kernel lifecycle and widget requests should follow the same split, but they do
+not all have the same reply contract. `InterruptExecution` and `SendComm` are
+command-only today: the hosted room can authorize the user request and forward
+the typed frame to the newest active `runtime_peer`. The browser ack for those
+frames means "accepted and delivered to a runtime peer", not "the kernel handled
+it" and not "widget state converged". Widget-visible results must still arrive
+through the normal runtime documents (`CommsDoc` / `RuntimeStateDoc`) and shared
+projections.
+
+Response-bearing runtime requests need a stronger contract. `LaunchKernel`,
+`RestartKernel`, `ShutdownKernel`, `SyncEnvironment`, `Complete`, and
+`GetHistory` require either a room-owned state transition or a correlated
+response path back from the runtime peer. Hosted rooms should reject direct
+runtime request frames for these actions until that response path exists rather
+than acknowledging a no-op delivery. This keeps toolbar/history/completion UI
+from mistaking WebSocket delivery for kernel success.
 
 ## Decision 5: Current Python is a first-class environment policy
 

--- a/docs/adr/remote-workstation-doc-agents.md
+++ b/docs/adr/remote-workstation-doc-agents.md
@@ -243,13 +243,17 @@ it" and not "widget state converged". Widget-visible results must still arrive
 through the normal runtime documents (`CommsDoc` / `RuntimeStateDoc`) and shared
 projections.
 
-Response-bearing runtime requests need a stronger contract. `LaunchKernel`,
-`RestartKernel`, `ShutdownKernel`, `SyncEnvironment`, `Complete`, and
-`GetHistory` require either a room-owned state transition or a correlated
+Response-bearing runtime requests need a stronger contract. `Complete` can use
+a narrow correlated response bridge because the browser's `NotebookResponse`
+envelope and the runtime peer's `RuntimeAgentResponse` envelope have compatible
+result shapes for that query RPC. `GetHistory` remains hosted-local for now
+because it is a broader notebook feature in Cloud rather than only a kernel
+history query. `LaunchKernel`, `RestartKernel`, `ShutdownKernel`, and
+`SyncEnvironment` require either a room-owned state transition or a mapped
 response path back from the runtime peer. Hosted rooms should reject direct
-runtime request frames for these actions until that response path exists rather
-than acknowledging a no-op delivery. This keeps toolbar/history/completion UI
-from mistaking WebSocket delivery for kernel success.
+runtime request frames for unsupported actions until that orchestration exists
+rather than acknowledging a no-op delivery. This keeps toolbar and environment
+UI from mistaking WebSocket delivery for kernel success.
 
 ## Decision 5: Current Python is a first-class environment policy
 
@@ -735,19 +739,46 @@ sequence:
   forwarded the comm message to the selected runtime peer. The widget-visible
   result is still the later CommsDoc/RuntimeStateDoc change; cloud must not
   invent a response envelope or treat the ack as a completed widget round trip.
+- **Runtime-agent query bridge.** Cloud supports a narrow correlated response
+  bridge for `complete`. The room stores a bounded in-memory pending map,
+  forwards the request to the newest active runtime peer, and routes the
+  matching runtime-peer `RESPONSE` frame back to the original browser peer.
+  This is intentionally narrower than a generic runtime-agent RPC bridge:
+  `complete` works because the browser request/response envelopes and
+  runtime-agent response shape are compatible. The bridge must remain bounded,
+  disconnect-aware, and non-durable until runtime generations and room-owned
+  lifecycle transitions are explicit.
 - **Unsupported response-bearing runtime requests fail honestly.** Hosted cloud
   rooms reject direct `launch_kernel`, `shutdown_kernel`, `sync_environment`,
-  `complete`, and `get_history` request frames instead of acknowledging them as
-  empty room-host no-ops. The cloud viewer still handles current hosted history
-  and empty completions in `CloudNotebookHostTransport`; a real kernel-backed
-  implementation needs a response path rather than a socket delivery ack.
+  and `get_history` request frames instead of acknowledging them as empty
+  room-host no-ops. The cloud viewer still handles current hosted history in
+  `CloudNotebookHostTransport`; a real kernel-backed history implementation
+  needs a product decision about whether history is notebook-wide, user-wide,
+  or kernel-local before routing it through the runtime peer.
+
+Runtime request subtleties to keep visible:
+
+- A WebSocket delivery ack is not a kernel success signal. For commands such as
+  `interrupt_execution` and `send_comm`, users should only see success through
+  later runtime-document convergence or explicit lifecycle state.
+- `send_comm` is input to kernel/widget machinery, not durable widget state.
+  It should never bypass CommsDoc/RuntimeStateDoc projection or become a
+  room-authored widget update.
+- Response-bearing requests need per-action contracts. A narrow query bridge is
+  acceptable for `complete`; lifecycle requests such as restart need room-owned
+  state transitions, stale-runtime deadlines, and late-response suppression.
+- The newest-runtime-peer rule is a temporary routing policy. Runtime
+  generations should eventually make "which runtime handled this request"
+  explicit enough to ignore late frames from a replaced peer.
+- Unsupported requests should fail loudly and cheaply. Accepting a delivered
+  frame that the room cannot observe or reconcile creates false UI readiness.
 
 Operator instructions: `docs/remote-workstation.md`.
 
 Still open: response-bearing kernel lifecycle over cloud
-(`launch_kernel`/`shutdown_kernel`/restart, plus `sync_environment` and kernel
-queries such as completion/history), the attachment-ticket contract (step 6;
-dev path today is API key / dev token plus an explicit `runtime_peer` ACL row),
+(`launch_kernel`/`shutdown_kernel`/restart, plus `sync_environment` and a
+product-shaped history contract), the attachment-ticket contract (step 6; dev
+path today is API key / dev token plus an explicit `runtime_peer` ACL row),
 catalog projection (step 5), and the provider-specific Outerbounds/JupyterHub
 smokes (step 12). Restart also needs a bounded stale-runtime policy: if the
 selected runtime does not confirm restart in time, the room should assume that

--- a/docs/adr/remote-workstation-doc-agents.md
+++ b/docs/adr/remote-workstation-doc-agents.md
@@ -719,6 +719,10 @@ sequence:
   local runtime-agent command model. During reconnect overlap, command routing
   targets the newest connected runtime peer, matching the attachment
   `updated_at` projection until runtime generations become explicit.
+  `send_comm` is especially easy to misread: the socket ack only means the room
+  forwarded the comm message to the selected runtime peer. The widget-visible
+  result is still the later CommsDoc/RuntimeStateDoc change; cloud must not
+  invent a response envelope or treat the ack as a completed widget round trip.
 
 Operator instructions: `docs/remote-workstation.md`.
 

--- a/docs/remote-workstation.md
+++ b/docs/remote-workstation.md
@@ -163,9 +163,17 @@ flows.
 `runtimed` maintains prewarmed environment pools (uv/conda/pixi) and captured
 per-notebook environments. The workstation endpoint projects these as the
 environments it can offer (`list_environments`), and the hosted room's
-workstation panel surfaces attachment state. Inbound kernel lifecycle dispatch
-(interrupt/restart over the room) is tracked in
-[#3381](https://github.com/nteract/nteract/issues/3381).
+workstation panel surfaces attachment state.
+
+Hosted runtime controls use the workstation contract rather than browser-owned
+kernel launch state. Interrupt requests are forwarded to the active runtime
+peer for the current attachment. Restart requests replace the active
+workstation attachment: the room publishes a fresh pending attachment in the
+RuntimeStateDoc, closes the previous runtime peer, and waits for the selected
+workstation to claim the new job and launch a new runtime peer. Direct
+browser-authored `launch_kernel` / `shutdown_kernel` frames remain unsupported
+for hosted rooms because the workstation owns the Python path, working
+directory, and environment policy.
 
 ## Diagnostics
 


### PR DESCRIPTION
## Summary

- Add timing logs across workstation attach polling, runtime peer startup/sync, launch-on-attach, queued-to-kernel send latency, output commit batches, final stream flushes, display-update commits, and terminal execution output counts.
- Forward owner-authorized runtime-agent command requests (`interrupt_execution`, `send_comm`) from the cloud room to the active runtime peer instead of acknowledging them as no-op hosted room requests.
- Add a narrow hosted completion query bridge: browser `complete` requests wait for room ACK and the matching runtime-peer `RESPONSE` frame when a runtime peer is present.
- Return an empty completion result without a websocket round-trip when the hosted room is connected but no runtime peer is attached.
- Settle evicted or pruned hosted completion queries with an immediate error response instead of leaving the browser waiting on its timeout.
- Count unmatched runtime-peer `RESPONSE` frames toward the rejected-frame close streak, while keeping server-side storage/materializer failures out of that streak.
- Reject direct hosted runtime request frames that still need orchestration (`launch_kernel`, `shutdown_kernel`, `sync_environment`, `get_history`) instead of silently acknowledging unsupported no-ops.
- Support hosted restart by replacing the active workstation attachment: cancel active attach jobs, publish a fresh pending attachment to RuntimeStateDoc, close old runtime peers, and reject late status patches from cancelled jobs.
- Document the command-vs-response split, `send_comm` subtleties, hosted restart semantics, and remaining stale-runtime/runtime-generation policy.
- Keep the hosted workstation toolbar smoke current with start, execute, restart, restart-and-run-all, reload, view-mode gating, and blocked-workstation states.

## Notes

This keeps execution intent (`execute_cell*`, `run_all_cells*`) on the room-host materialization path. Runtime-agent command-shaped requests are forwarded directly, and overlapping runtime peers route to the newest connected peer until we add explicit runtime generations. Same-millisecond runtime-peer reconnects now deterministically prefer the later inserted peer.

`send_comm` is explicitly documented as subtle: the room/socket ack only means the command reached the selected runtime peer. Widget-visible completion still has to arrive by CommsDoc/RuntimeStateDoc convergence.

`complete` is the first response-bearing runtime query wired through a correlated hosted bridge because the browser request/response envelope and runtime-agent response shape are compatible. The bridge is bounded, disconnect-aware, timeout-settling, and memory-only. Lifecycle requests and environment sync still need room-owned state transitions or a mapped response contract before the hosted room should claim success.

Hosted restart intentionally does not synthesize browser-owned `shutdown_kernel` / `launch_kernel` frames. The selected workstation owns Python path, working directory, and environment policy, so restart means “replace this workstation attachment and let the workstation claim a fresh runtime peer.” The room publishes the new attachment before closing the old runtime peer, so a publish failure leaves the prior peer alive rather than stranding the room.

## Preview smoke

Deployed this branch to preview and kept `ws-lab2` running from a freshly built local binary in tmux.

- Latest deployed preview build: `6afc51a6ce0b42bc770f0b04af68cc05333e670f` (`/api/health` reports it at `build.sha`)
- Latest assets worker version: `3116ddc3-335f-4007-96f2-4f8cabd564d7`
- Latest main worker version: `c27748d5-50c3-430c-85af-c91d86e55f92`
- Latest smoke notebook: https://preview.runt.run/n/01KTYY91TAAYEKYPPSKQ7ADSYT/toolbar-restart-run-all-smoke-20260612221207
- Workstation: `ws-lab2` (`lab2`)
- Browser flow: owner opens notebook, clicks Start compute, runtime peer attaches, executes a cell, clicks Restart, replacement runtime attaches, executes again, creates a second code cell, clicks Restart-and-run-all, replacement runtime attaches, both code cells execute, reloads, executes again. View mode hides execution/workstation controls.
- Browser diagnostics: no bad console messages, failed requests, or page errors.
- Kernel status after first execution, restart execution, restart-and-run-all, and reload execution: `idle`.
- Restart smoke marker observed: `toolbar attach smoke 20260612221208 after restart`.
- Restart-and-run-all markers observed: `toolbar attach smoke 20260612221208 restart run all 1`, `toolbar attach smoke 20260612221208 restart run all 2`.

Representative timings from the deployed smoke remain consistent: queue observation and output transport for simple stdout are effectively immediate after kernel launch; the cold path is workstation poll/claim, websocket handshake, and Python kernel launch. Rich output/blob/display-update cases now have log points but still need representative measurements.

## Validation

- `cd apps/notebook-cloud && node --import tsx --test test/cloud-notebook-host.test.ts`
- `cd apps/notebook-cloud && node --import tsx --test test/notebook-room.test.ts`
- `cd apps/notebook-cloud && node --import tsx --test test/worker-routes.test.ts`
- `cd apps/notebook-cloud && node --import tsx --test test/workstations-client.test.ts`
- `pnpm vp test --run apps/notebook-cloud/viewer/__tests__/use-cloud-workstations.test.tsx`
- `pnpm --dir apps/notebook-cloud typecheck`
- `node --check apps/notebook-cloud/scripts/hosted-workstation-toolbar-smoke.mjs`
- `cargo build -p runt -p runtimed`
- `cargo xtask lint --fix`
- `pnpm --dir apps/notebook-cloud run deploy`
- `pnpm --dir apps/notebook-cloud run deploy:check`
- Hosted workstation toolbar smoke with OIDC auth and `ws-lab2`, including restart/replacement execution and restart-and-run-all across replacement

Earlier commits on this PR were also validated with the runtime-agent/output-committer Rust test slices listed in the previous PR body.
