### PR TITLE
docs: update agent documentation taxonomy guidance

### DIFF
--- a/.agents/skills/architecture/SKILL.md
+++ b/.agents/skills/architecture/SKILL.md
@@ -1,0 +1,41 @@
+---
+name: architecture
+description: Architecture and documentation framing for cross-cutting repo decisions, docs taxonomy placement, ADRs, memos, PRDs, implementation plans, audits, measurements, runbooks, and source-grounded proposals. Use when deciding where durable docs belong, drafting or moving architecture/product/design docs, or promoting `.context/` notes into repo docs. Do not use for routine code changes unless they require durable cross-functional documentation.
+---
+
+# Architecture and Documentation
+
+Use this skill when the work is about durable architecture, product, or design
+documentation, or when deciding where a document belongs. Do not load it for
+routine implementation notes, test plans, or ordinary code changes.
+
+## Default Path
+
+- Start working notes in `.context/`.
+- Keep routine implementation notes in the PR body, code comments, or final response.
+- Promote only when the artifact should outlive the immediate change and help
+  product, design, engineering, research, or AI collaborators.
+
+## Placement
+
+- `docs/memos/`: shared thinking, research, options, and RFC-style proposals
+  before there is a decision.
+- `docs/adr/`: durable technical decisions, invariants, compatibility
+  boundaries, and rejected alternatives.
+- `docs/prd/`: user-facing requirements, workflows, roles, and launch criteria.
+- `docs/plans/`: scoped execution plans for already-framed work.
+- `docs/audits/`: source-backed evidence and follow-up lists.
+- `docs/measurements/`: benchmark evidence and performance models.
+- `docs/runbooks/`: operational procedures.
+- `docs/handoffs/`: time-bound transfer notes.
+
+## Workflow
+
+1. Read `docs/README.md` and the relevant directory README before creating or
+   moving durable docs.
+2. When moving docs, update indexes and cross-links; search for old paths with
+   `git grep`.
+3. Prefer the smallest durable artifact. Mark contentious sections as open
+   questions or commentary instead of forcing them into a decision.
+4. Run focused link/path checks for moved docs and `cargo xtask lint --fix`
+   before commit.

--- a/.agents/skills/frontend-dev/SKILL.md
+++ b/.agents/skills/frontend-dev/SKILL.md
@@ -126,8 +126,6 @@ should not fork cell, output, rail, toolbar, or execution UI.
 - When adding new API facts for UI, keep them structured and host-owned. Avoid
   parsing principal strings, display labels, or notebook IDs in React except as
   compatibility fallback.
-- Capture product/architecture decisions in `.context/` during exploration and
-  graduate them to ADRs when they become durable.
 
 ## Hot Reload
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -8,9 +8,27 @@ This is a map. Subsystem details live in nested `AGENTS.md` files next to code, 
 
 nteract is a local-first, agent-ready notebook environment where humans, kernels, and AI agents work against the same live notebook document set. Describe that in concrete system terms: Automerge-backed notebook state, explicit runtime state, daemon-owned kernels, outputs, and execution, and programmatic control through the same runtime model. Avoid broad AI slogans; prefer the mechanics users and developers can verify.
 
+## Documentation taxonomy
+
+Use `docs/README.md` as the front door for repo documentation. Start working
+notes in `.context/` while exploring. Do not create a persistent doc for routine
+implementation notes, test plans, or context that only explains the current
+patch; use the PR description, code comments, or final response instead.
+
+Promote `.context/` notes into `docs/` only when they should persist for product,
+design, engineering, research, or AI collaborators. Use `docs/memos/` for shared
+thinking, research, options, and RFC-style proposals; do not file exploratory
+work as a Draft ADR just because it mentions architecture. Graduate durable
+technical decisions to `docs/adr/`, durable product requirements to `docs/prd/`,
+scoped execution work to `docs/plans/`, evidence and follow-up lists to
+`docs/audits/`, benchmark evidence to `docs/measurements/`, operational
+procedures to `docs/runbooks/`, and time-bound transfer notes to
+`docs/handoffs/`.
+
 ## Skills
 
 Use `.agents/skills/` when the task matches:
+- `architecture` — docs taxonomy, ADR/memo/PRD placement, cross-cutting architecture, and source-grounded proposal work
 - `automerge-sync` — sync protocol internals, document model, reconnection, peer state, in-flight suppression, protocol design patterns, convergence debugging
 - `daemon-dev` — daemon development, Python bindings, build system, kernel debugging, xtask workflows
 - `execution-pipeline` — end-to-end cell execution: required_heads → ExecuteCell → CellQueued → RuntimeStateDoc polling → output-sync grace → output resolution


### PR DESCRIPTION
## Summary

- add the new documentation taxonomy to the root `AGENTS.md` agent map
- update the frontend-dev skill to route exploration through `.context/` and `docs/memos/` before graduating durable decisions/requirements/plans
- confirm no stale moved-doc `docs/adr/...` paths or old "graduate to ADRs" guidance remain in tracked agent/skill/rule docs

## Verification

- focused `git grep` checks for stale guidance and moved-doc paths
- `cargo xtask lint --fix`