### PR TITLE
fix(cloud): show kernel status on workstation target

### DIFF
--- a/apps/notebook-cloud/test/viewer-shell-capabilities.test.ts
+++ b/apps/notebook-cloud/test/viewer-shell-capabilities.test.ts
@@ -199,6 +199,37 @@ test("cloud shell capabilities prefer RuntimeStateDoc workstation attachment ove
   assert.equal(capabilities.canExecute, true);
 });
 
+test("cloud shell capabilities surface RuntimeStateDoc kernel status on workstation targets", () => {
+  const capabilities = cloudNotebookShellCapabilities({
+    authState: authState("oidc", "owner"),
+    connectionScope: "owner",
+    hasCodeCells: true,
+    selectedMode: "edit",
+    runtimePeerCount: 1,
+    kernelStatusLabel: "launching kernel",
+    workstationAttachment: {
+      workstation_id: "ws-lab2",
+      display_name: "Lab 2",
+      provider: "local_daemon",
+      default_environment_label: "Current Python",
+      environment_policy: "current_python",
+      status: "ready",
+      status_message: null,
+      cpu_count: 8,
+      memory_bytes: 32 * 1024 ** 3,
+      working_directory: "/home/ubuntu/notebooks",
+      updated_at: "2026-06-07T21:00:00Z",
+    },
+  });
+
+  assert.equal(capabilities.runtime.connected, true);
+  assert.equal(capabilities.runtime.executionAvailable, true);
+  assert.equal(capabilities.runtime.target?.id, "ws-lab2");
+  assert.equal(capabilities.runtime.target?.status, "ready");
+  assert.equal(capabilities.runtime.target?.kernelStatusLabel, "launching kernel");
+  assert.equal(capabilities.canExecute, true);
+});
+
 test("cloud shell capabilities show connecting workstation attachment without enabling execution", () => {
   const capabilities = cloudNotebookShellCapabilities({
     authState: authState("oidc", "owner"),

--- a/apps/notebook-cloud/viewer/notebook-viewer.tsx
+++ b/apps/notebook-cloud/viewer/notebook-viewer.tsx
@@ -41,7 +41,13 @@ import {
 import { useWidgetStoreRequired } from "@/components/widgets/widget-store-context";
 import { useTheme } from "@/hooks/useTheme";
 import { EnvironmentSummary } from "@/components/environment";
-import { NotebookClient, type CellChangeset, type NotebookOutlineItem } from "runtimed";
+import {
+  NotebookClient,
+  workstationAttachmentCanExecute,
+  workstationAttachmentIsConnected,
+  type CellChangeset,
+  type NotebookOutlineItem,
+} from "runtimed";
 import { createNotebookCloudBlobResolver } from "../src/blob-resolver";
 import {
   clearCloudPrototypeDevAuth,
@@ -352,6 +358,25 @@ export function NotebookViewer({
     authState,
     hasAppSession: Boolean(appSessionStatus.session),
   });
+  const cloudRuntimeConnectedForStatus = workstationAttachment
+    ? workstationAttachmentIsConnected(workstationAttachment)
+    : runtimePeerAvailable;
+  const cloudRuntimeExecutionAvailableForStatus = workstationAttachment
+    ? workstationAttachmentCanExecute(workstationAttachment)
+    : runtimePeerAvailable;
+  const cloudRuntimeStatus = useMemo<NotebookCommandToolbarStatus | null>(() => {
+    if (!cloudRuntimeConnectedForStatus && !cloudRuntimeExecutionAvailableForStatus) {
+      return null;
+    }
+    return projectNotebookCommandRuntimeStatusFromRuntimeState(runtimeState, {
+      executionAvailable: cloudRuntimeExecutionAvailableForStatus,
+    });
+  }, [cloudRuntimeConnectedForStatus, cloudRuntimeExecutionAvailableForStatus, runtimeState]);
+  const cloudKernelStatusLabel = cloudRuntimeExecutionAvailableForStatus
+    ? typeof cloudRuntimeStatus?.label === "string"
+      ? cloudRuntimeStatus.label
+      : null
+    : null;
   const { shellCapabilities, canAcceptCellMutations, editAccessPending } =
     useCloudShellCapabilities({
       authState,
@@ -363,6 +388,7 @@ export function NotebookViewer({
       connectionScope,
       hasAppSession: Boolean(appSessionStatus.session),
       hostCapabilities: config.hostCapabilities,
+      kernelStatusLabel: cloudKernelStatusLabel,
       runtimePeerAvailable,
       runtimePeerCount,
       selectedMode: selectedInteractionMode,
@@ -379,18 +405,6 @@ export function NotebookViewer({
     hasAppSession: Boolean(appSessionStatus.session),
     isPublicViewer,
   });
-  const cloudRuntimeStatus = useMemo<NotebookCommandToolbarStatus | null>(() => {
-    if (!shellCapabilities.runtime.connected && !shellCapabilities.runtime.executionAvailable) {
-      return null;
-    }
-    return projectNotebookCommandRuntimeStatusFromRuntimeState(runtimeState, {
-      executionAvailable: shellCapabilities.runtime.executionAvailable,
-    });
-  }, [
-    runtimeState,
-    shellCapabilities.runtime.connected,
-    shellCapabilities.runtime.executionAvailable,
-  ]);
   const {
     busyWorkstationId,
     onAttachWorkstation,

--- a/apps/notebook-cloud/viewer/shell-capabilities.ts
+++ b/apps/notebook-cloud/viewer/shell-capabilities.ts
@@ -47,6 +47,11 @@ export interface CloudNotebookShellCapabilityInput {
    */
   runtimePeerCount?: number;
   /**
+   * RuntimeStateDoc-derived kernel lifecycle label. This keeps the workstation
+   * target honest during the peer-connected/kernel-launching gap.
+   */
+  kernelStatusLabel?: string | null;
+  /**
    * Room-host-owned RuntimeStateDoc workstation attachment snapshot. When
    * present this is the durable notebook-visible source for the selected
    * compute target; live presence remains the fallback while older rooms have
@@ -74,6 +79,7 @@ export function cloudNotebookShellCapabilities({
   editAccessRequestPending = false,
   runtimeAvailable = false,
   runtimePeerCount = runtimeAvailable ? 1 : 0,
+  kernelStatusLabel = null,
   workstationAttachment = null,
   hostCapabilities,
 }: CloudNotebookShellCapabilityInput): NotebookShellCapabilities {
@@ -122,6 +128,7 @@ export function cloudNotebookShellCapabilities({
       isRuntimePeer,
       runtimeAvailable: effectiveRuntimeAvailable,
       runtimePeerCount,
+      kernelStatusLabel,
       workstationAttachment,
     }),
   };
@@ -170,11 +177,13 @@ function cloudRuntimeTarget({
   isRuntimePeer,
   runtimeAvailable,
   runtimePeerCount,
+  kernelStatusLabel,
   workstationAttachment,
 }: {
   isRuntimePeer: boolean;
   runtimeAvailable: boolean;
   runtimePeerCount: number;
+  kernelStatusLabel: string | null;
   workstationAttachment: WorkstationAttachmentState | null;
 }): NotebookShellRuntimeTargetProjection {
   const visibleRuntimePeerCount = Math.max(0, Math.floor(runtimePeerCount));
@@ -194,7 +203,7 @@ function cloudRuntimeTarget({
   }
   const attachmentTarget = projectNotebookRuntimeTargetFromWorkstationAttachment(
     workstationAttachment,
-    { runtimePeerCount: visibleRuntimePeerCount },
+    { runtimePeerCount: visibleRuntimePeerCount, kernelStatusLabel },
   );
   if (attachmentTarget) {
     return attachmentTarget;
@@ -210,6 +219,7 @@ function cloudRuntimeTarget({
       providerLabel: "Cloud room",
       defaultEnvironmentLabel: "Current Python",
       environmentLabel: "Current Python",
+      kernelStatusLabel,
       runtimePeerCount: visibleRuntimePeerCount || 1,
     };
   }

--- a/apps/notebook-cloud/viewer/use-cloud-shell-capabilities.ts
+++ b/apps/notebook-cloud/viewer/use-cloud-shell-capabilities.ts
@@ -25,6 +25,7 @@ interface UseCloudShellCapabilitiesInput {
   codeCellCount: number;
   runtimePeerAvailable: boolean;
   runtimePeerCount: number;
+  kernelStatusLabel: string | null;
   workstationAttachment: WorkstationAttachmentState | null;
   hostCapabilities: CloudViewerConfig["hostCapabilities"];
 }
@@ -55,6 +56,7 @@ export function useCloudShellCapabilities({
   codeCellCount,
   runtimePeerAvailable,
   runtimePeerCount,
+  kernelStatusLabel,
   workstationAttachment,
   hostCapabilities,
 }: UseCloudShellCapabilitiesInput): CloudShellCapabilities {
@@ -89,6 +91,7 @@ export function useCloudShellCapabilities({
         editAccessRequestPending,
         runtimeAvailable: runtimePeerAvailable,
         runtimePeerCount,
+        kernelStatusLabel,
         workstationAttachment,
         hostCapabilities,
       }),
@@ -102,6 +105,7 @@ export function useCloudShellCapabilities({
       connectionPeerLabel,
       connectionScope,
       editAccessRequestPending,
+      kernelStatusLabel,
       runtimePeerCount,
       runtimePeerAvailable,
       selectedMode,


### PR DESCRIPTION
## Summary

- Feed the RuntimeStateDoc-derived kernel status label into the cloud shell capability projection.
- Pass that label through the existing shared workstation target projection so the workstation surface can show states like `launching kernel` during the peer-connected/kernel-launching gap.
- Keep the derivation above React-local state: cloud still derives toolbar status from RuntimeStateDoc, then passes the label into shared shell/workstation projections.

## Context

Live timing after #3618 showed `ws-lab2` can claim/spawn a runtime peer in under a second, while current-python kernel launch remains about 3 seconds. Before this patch, the workstation target could read as `Ready` as soon as the peer connected, even while the kernel was still launching.

## Preview

Deployed to preview:

- `/api/health` build SHA: `5863a8d1dfc57428aea620e0e829c3b1565b5231`
- Assets worker version: `72e230bb-1e39-4e30-8895-419bd9f63edc`
- Main worker version: `a6933b7f-5984-4211-8404-7df8cfd46722`
- `ws-lab2` remains online after deploy.

## Validation

- `cd apps/notebook-cloud && node --import tsx --test test/viewer-shell-capabilities.test.ts`
- `pnpm --dir apps/notebook-cloud typecheck`
- `cargo xtask lint --fix`
- `pnpm --dir apps/notebook-cloud run deploy`
- `pnpm --dir apps/notebook-cloud run deploy:check`
