### PR TITLE
fix(cloud): stop persisting transient room frames

### DIFF
--- a/apps/notebook-cloud/README.md
+++ b/apps/notebook-cloud/README.md
@@ -500,8 +500,9 @@ Accepted WebSocket frame payload caps mirror `notebook-wire` per-frame limits:
 Automerge sync, runtime-state sync, and response frames may be up to 64 MiB;
 `PUT_BLOB` up to 32 MiB; request and broadcast frames up to 16 MiB; presence
 frames up to 4 KiB; and pool-state/session-control frames up to 1 MiB. The
-Durable Object keeps only the latest 500 `frame:*` metadata entries in object
-storage; D1 is not a frame replay log.
+Durable Object does not persist a frame replay log. Reconnecting peers recover
+from the materialized `NotebookDoc`, `RuntimeStateDoc`, and `CommsDoc`
+checkpoints, with published snapshots as the fallback durable boundary.
 
 Published revision artifacts follow `docs/adr/hosted-notebook-artifacts.md`:
 

--- a/apps/notebook-cloud/src/notebook-room.ts
+++ b/apps/notebook-cloud/src/notebook-room.ts
@@ -378,7 +378,7 @@ export class NotebookRoom {
       }
       if (result.changed) {
         this.deliverRoomHostFrames(notebookId, result);
-        await materializer.checkpoint();
+        await this.checkpointRoomHost(notebookId, materializer, "workstation_attachment_control");
       }
       cloudLog("debug", "room.workstation_attachment.control_published", {
         notebook_id: notebookId,
@@ -447,7 +447,7 @@ export class NotebookRoom {
       const result = await materializer.reconcileRuntimePeerGone(reason);
       if (result.changed) {
         this.deliverRoomHostFrames(notebookId, result);
-        await materializer.checkpoint();
+        await this.checkpointRoomHost(notebookId, materializer, "runtime_state_repair");
       }
       cloudLog("info", "room.runtime_state_repair.completed", {
         notebook_id: notebookId,
@@ -925,7 +925,7 @@ export class NotebookRoom {
 
       this.deliverRoomHostFrames(notebookId, result);
       if (result.changed) {
-        this.state.waitUntil(materializer.checkpoint().catch(() => undefined));
+        this.scheduleRoomHostCheckpoint(notebookId, materializer, "materialized_frame");
       }
       this.sendControl(notebookId, peer, {
         type: "cloud_frame_accepted",
@@ -995,17 +995,50 @@ export class NotebookRoom {
       });
       this.deliverRoomHostFrames(notebookId, result);
     } catch (error) {
+      const reason = errorMessage(error);
       cloudLog("warn", "room.peer_sync.failed", {
         notebook_id: notebookId,
         peer_id: peer.id,
         principal: peer.identity.principal,
         scope: peer.identity.scope,
         duration_ms: durationMs(startedAt),
-        error: errorMessage(error),
+        error: reason,
         counter: "peer_sync_failed",
         counter_delta: 1,
       });
-      this.removePeer(notebookId, peer);
+      this.sendControl(notebookId, peer, {
+        type: "cloud_room_degraded",
+        notebook_id: notebookId,
+        peer_id: peer.id,
+        reason,
+        timestamp: new Date().toISOString(),
+      });
+    }
+  }
+
+  private scheduleRoomHostCheckpoint(
+    notebookId: string,
+    materializer: RoomMaterializer,
+    operation: string,
+  ): void {
+    this.state.waitUntil(this.checkpointRoomHost(notebookId, materializer, operation));
+  }
+
+  private async checkpointRoomHost(
+    notebookId: string,
+    materializer: RoomMaterializer,
+    operation: string,
+  ): Promise<void> {
+    try {
+      await materializer.checkpoint();
+    } catch (error) {
+      cloudLog("warn", "room.materializer.checkpoint_failed", {
+        notebook_id: notebookId,
+        operation,
+        error: errorMessage(error),
+        counter: "materializer_checkpoint_failures",
+        counter_delta: 1,
+      });
     }
   }
 
@@ -1018,7 +1051,7 @@ export class NotebookRoom {
       );
       if (result.changed) {
         this.deliverRoomHostFrames(notebookId, result);
-        await materializer.checkpoint();
+        await this.checkpointRoomHost(notebookId, materializer, "runtime_peer_attachment");
       }
       cloudLog("debug", "room.workstation_attachment.published", {
         notebook_id: notebookId,
@@ -1617,10 +1650,10 @@ export class NotebookRoom {
       );
       if (result.changed) {
         this.deliverRoomHostFrames(notebookId, result);
-        this.state.waitUntil(
-          this.materializerFor(notebookId)
-            .checkpoint()
-            .catch(() => undefined),
+        this.scheduleRoomHostCheckpoint(
+          notebookId,
+          this.materializerFor(notebookId),
+          "runtime_peer_watch_reconcile",
         );
       }
       cloudLog("info", "room.runtime_peer_watch.reconciled", {

--- a/apps/notebook-cloud/src/notebook-room.ts
+++ b/apps/notebook-cloud/src/notebook-room.ts
@@ -50,16 +50,6 @@ interface Peer {
   consecutiveRejectedFrames: number;
 }
 
-interface StoredRoomFrame {
-  sequence: number;
-  peerId: string;
-  actorLabel: string;
-  connectionScope: string;
-  frameType: number;
-  byteLength: number;
-  receivedAt: string;
-}
-
 interface PeerAttachment {
   notebookId: string;
   peerId: string;
@@ -106,8 +96,6 @@ interface PendingRuntimePeerResponse {
   action: RuntimePeerQueryRequestAction;
   createdAtMs: number;
 }
-
-const MAX_STORED_FRAMES = 500;
 
 /// Grace window after the last `runtime_peer` leaves before the room reconciles
 /// its in-flight state (lifecycle-analysis reqs #3/#7). Tolerates a transient
@@ -205,9 +193,6 @@ export class NotebookRoom {
     string,
     { notebookId: string; peer: Peer; closeOptions: PeerCloseOptions }
   >();
-  private nextFrameSequence = 0;
-  private frameSequenceReady: Promise<void> | undefined;
-  private framePersistQueue: Promise<void> = Promise.resolve();
   private broadcastDepth = 0;
   private readonly materializers = new Map<string, RoomMaterializer>();
   private readonly restoredPeersReady: Promise<void>;
@@ -734,7 +719,7 @@ export class NotebookRoom {
 
     if (!shouldBroadcastFrame(normalizedFrame, peer.identity)) {
       // Anonymous public viewers are read-only observers. Their presence is
-      // acknowledged locally but not broadcast or persisted as room activity.
+      // acknowledged locally but not broadcast as room activity.
       cloudLog("debug", "room.presence.local_only", {
         notebook_id: notebookId,
         peer_id: peer.id,
@@ -745,6 +730,27 @@ export class NotebookRoom {
         counter: "local_only_presence_frames",
         counter_delta: 1,
       });
+      this.sendControl(notebookId, peer, {
+        type: "cloud_frame_accepted",
+        notebook_id: notebookId,
+        peer_id: peer.id,
+        frame_type: normalizedFrame.type,
+        byte_length: normalizedFrame.payload.byteLength,
+        timestamp: receivedAt,
+      });
+      this.resetRejectedFrameStreak(peer);
+      return;
+    }
+
+    if (normalizedFrame.type === FrameType.PRESENCE) {
+      // Presence is live-only coordination. Persisting it burns Durable Object
+      // storage writes without improving recovery; reconnecting peers send a
+      // fresh heartbeat/cursor snapshot.
+      this.broadcastFrame(
+        notebookId,
+        encodeTypedFrame(normalizedFrame.type, normalizedFrame.payload),
+        peer.id,
+      );
       this.sendControl(notebookId, peer, {
         type: "cloud_frame_accepted",
         notebook_id: notebookId,
@@ -901,7 +907,6 @@ export class NotebookRoom {
         );
         return;
       }
-      const persistMaterializedFrame = shouldPersistMaterializedSyncFrame(result);
       cloudLog("debug", "room.materialized_frame.applied", {
         notebook_id: notebookId,
         peer_id: peer.id,
@@ -913,17 +918,11 @@ export class NotebookRoom {
         changed: result.changed,
         notebook_changed: result.notebook_changed,
         runtime_state_changed: result.runtime_state_changed,
-        persisted: persistMaterializedFrame,
         outbound_frame_count: result.outbound.length,
         counter: "materialized_frames_applied",
         counter_delta: 1,
       });
 
-      if (persistMaterializedFrame) {
-        this.state.waitUntil(
-          this.persistFrame(peer, normalizedFrame, receivedAt).catch(() => undefined),
-        );
-      }
       this.deliverRoomHostFrames(notebookId, result);
       if (result.changed) {
         this.state.waitUntil(materializer.checkpoint().catch(() => undefined));
@@ -937,19 +936,6 @@ export class NotebookRoom {
         timestamp: receivedAt,
       });
       this.resetRejectedFrameStreak(peer);
-      return;
-    }
-
-    try {
-      await this.persistFrame(peer, normalizedFrame, receivedAt);
-    } catch (error) {
-      this.rejectFrame(
-        notebookId,
-        peer,
-        normalizedFrame.type,
-        `failed to persist ${frameTypeName(normalizedFrame.type)} frame: ${String(error)}`,
-        { countsTowardStreak: false },
-      );
       return;
     }
 
@@ -1297,55 +1283,6 @@ export class NotebookRoom {
 
       this.rejectPendingRuntimePeerResponse(notebookId, requestId, pending, reason);
     }
-  }
-
-  private async persistFrame(peer: Peer, frame: TypedFrame, receivedAt: string): Promise<void> {
-    const operation = this.framePersistQueue
-      .catch(() => undefined)
-      .then(async () => {
-        await this.prepareFrameSequence();
-        const sequence = this.nextFrameSequence + 1;
-        const stored: StoredRoomFrame = {
-          sequence,
-          peerId: peer.id,
-          actorLabel: peer.identity.actorLabel,
-          connectionScope: peer.identity.scope,
-          frameType: frame.type,
-          byteLength: frame.payload.byteLength,
-          receivedAt,
-        };
-
-        await this.state.storage.put(frameStorageKey(sequence), stored);
-        await this.state.storage.put("frame_sequence", sequence);
-        this.nextFrameSequence = sequence;
-        this.state.waitUntil(
-          this.evictStoredFrame(sequence - MAX_STORED_FRAMES).catch(() => undefined),
-        );
-      });
-
-    this.framePersistQueue = operation.then(
-      () => undefined,
-      () => undefined,
-    );
-    await operation;
-  }
-
-  private async prepareFrameSequence(): Promise<void> {
-    this.frameSequenceReady ??= this.state.storage
-      .get<number>("frame_sequence")
-      .then((sequence) => {
-        this.nextFrameSequence = sequence ?? 0;
-      });
-
-    await this.frameSequenceReady;
-  }
-
-  private async evictStoredFrame(sequence: number): Promise<void> {
-    if (sequence < 1) {
-      return;
-    }
-
-    await this.state.storage.delete(frameStorageKey(sequence));
   }
 
   private rejectFrame(
@@ -1708,12 +1645,6 @@ export function shouldBroadcastFrame(
   return !(frame.type === FrameType.PRESENCE && isAnonymousViewer(identity));
 }
 
-export function shouldPersistMaterializedSyncFrame(
-  result: Pick<RoomHostFrameResult, "notebook_changed" | "runtime_state_changed">,
-): boolean {
-  return result.notebook_changed || result.runtime_state_changed;
-}
-
 export function rejectedFramePolicy(
   consecutiveRejectedFrames: number,
   limit = MAX_CONSECUTIVE_REJECTED_FRAMES,
@@ -1959,10 +1890,6 @@ function json(value: unknown, status: number): Response {
     status,
     headers: { "Content-Type": "application/json" },
   });
-}
-
-function frameStorageKey(sequence: number): string {
-  return `frame:${sequence.toString().padStart(12, "0")}`;
 }
 
 function socketAttachment(socket: CloudflareWebSocket): PeerAttachment | undefined {

--- a/apps/notebook-cloud/src/notebook-room.ts
+++ b/apps/notebook-cloud/src/notebook-room.ts
@@ -898,6 +898,10 @@ export class NotebookRoom {
       try {
         result = await materializer.receiveFrame(peer, normalizedFrame);
       } catch (error) {
+        if (isRoomStorageDegradedError(error)) {
+          this.sendRoomDegradedControl(notebookId, peer, errorMessage(error));
+          return;
+        }
         this.rejectFrame(
           notebookId,
           peer,
@@ -1006,14 +1010,18 @@ export class NotebookRoom {
         counter: "peer_sync_failed",
         counter_delta: 1,
       });
-      this.sendControl(notebookId, peer, {
-        type: "cloud_room_degraded",
-        notebook_id: notebookId,
-        peer_id: peer.id,
-        reason,
-        timestamp: new Date().toISOString(),
-      });
+      this.sendRoomDegradedControl(notebookId, peer, reason);
     }
+  }
+
+  private sendRoomDegradedControl(notebookId: string, peer: Peer, reason: string): void {
+    this.sendControl(notebookId, peer, {
+      type: "cloud_room_degraded",
+      notebook_id: notebookId,
+      peer_id: peer.id,
+      reason,
+      timestamp: new Date().toISOString(),
+    });
   }
 
   private scheduleRoomHostCheckpoint(
@@ -1916,6 +1924,15 @@ function webSocketMessageByteLength(message: string | ArrayBuffer | ArrayBufferV
     return message.byteLength;
   }
   return message.byteLength;
+}
+
+function isRoomStorageDegradedError(error: unknown): boolean {
+  const message = errorMessage(error);
+  return (
+    message.includes("Exceeded allowed rows written in Durable Objects free tier") ||
+    message.includes("SQLITE_FULL") ||
+    message.includes("database or disk is full")
+  );
 }
 
 function json(value: unknown, status: number): Response {

--- a/apps/notebook-cloud/src/notebook-room.ts
+++ b/apps/notebook-cloud/src/notebook-room.ts
@@ -378,18 +378,24 @@ export class NotebookRoom {
       }
       if (result.changed) {
         this.deliverRoomHostFrames(notebookId, result);
-        await this.checkpointRoomHost(notebookId, materializer, "workstation_attachment_control");
       }
+      const checkpointPersisted = result.changed
+        ? await this.checkpointRoomHost(notebookId, materializer, "workstation_attachment_control")
+        : true;
       cloudLog("debug", "room.workstation_attachment.control_published", {
         notebook_id: notebookId,
         changed: result.changed,
+        checkpoint_persisted: checkpointPersisted,
         duration_ms: durationMs(startedAt),
         outbound_frame_count: result.outbound.length,
         closed_runtime_peers: closeRuntimePeers,
         counter: "workstation_attachment_control_published",
         counter_delta: result.changed ? 1 : 0,
       });
-      return json({ ok: true, changed: result.changed }, 200);
+      return json(
+        { ok: true, changed: result.changed, checkpoint_persisted: checkpointPersisted },
+        200,
+      );
     } catch (error) {
       cloudLog("warn", "room.workstation_attachment.control_publish_failed", {
         notebook_id: notebookId,
@@ -447,12 +453,15 @@ export class NotebookRoom {
       const result = await materializer.reconcileRuntimePeerGone(reason);
       if (result.changed) {
         this.deliverRoomHostFrames(notebookId, result);
-        await this.checkpointRoomHost(notebookId, materializer, "runtime_state_repair");
       }
+      const checkpointPersisted = result.changed
+        ? await this.checkpointRoomHost(notebookId, materializer, "runtime_state_repair")
+        : true;
       cloudLog("info", "room.runtime_state_repair.completed", {
         notebook_id: notebookId,
         changed: result.changed,
         forced: force,
+        checkpoint_persisted: checkpointPersisted,
         runtime_peer_count: this.runtimePeerCount(),
         duration_ms: durationMs(startedAt),
         outbound_frame_count: result.outbound.length,
@@ -464,6 +473,7 @@ export class NotebookRoom {
           ok: true,
           changed: result.changed,
           forced: force,
+          checkpoint_persisted: checkpointPersisted,
           runtime_peer_count: this.runtimePeerCount(),
         },
         200,
@@ -1010,6 +1020,13 @@ export class NotebookRoom {
         counter: "peer_sync_failed",
         counter_delta: 1,
       });
+      if (!isRoomStorageDegradedError(error)) {
+        this.removePeer(notebookId, peer, {
+          code: 1011,
+          reason: "room sync failed",
+        });
+        return;
+      }
       this.sendRoomDegradedControl(notebookId, peer, reason);
     }
   }
@@ -1036,9 +1053,10 @@ export class NotebookRoom {
     notebookId: string,
     materializer: RoomMaterializer,
     operation: string,
-  ): Promise<void> {
+  ): Promise<boolean> {
     try {
       await materializer.checkpoint();
+      return true;
     } catch (error) {
       cloudLog("warn", "room.materializer.checkpoint_failed", {
         notebook_id: notebookId,
@@ -1047,6 +1065,7 @@ export class NotebookRoom {
         counter: "materializer_checkpoint_failures",
         counter_delta: 1,
       });
+      return false;
     }
   }
 
@@ -1928,6 +1947,9 @@ function webSocketMessageByteLength(message: string | ArrayBuffer | ArrayBufferV
 
 function isRoomStorageDegradedError(error: unknown): boolean {
   const message = errorMessage(error);
+  // Cloudflare Durable Objects and SQLite surface storage quota/full-disk
+  // failures as message text, not typed errors. Keep this classifier narrow so
+  // only storage pressure enters the recoverable degraded-room path.
   return (
     message.includes("Exceeded allowed rows written in Durable Objects free tier") ||
     message.includes("SQLITE_FULL") ||

--- a/apps/notebook-cloud/src/protocol.ts
+++ b/apps/notebook-cloud/src/protocol.ts
@@ -60,6 +60,13 @@ export type SessionControlMessage =
       timestamp: string;
     }
   | {
+      type: "cloud_room_degraded";
+      notebook_id: string;
+      peer_id: string;
+      reason: string;
+      timestamp: string;
+    }
+  | {
       type: "cloud_peer_joined" | "cloud_peer_left";
       notebook_id: string;
       peer_id: string;

--- a/apps/notebook-cloud/src/room-materializer.ts
+++ b/apps/notebook-cloud/src/room-materializer.ts
@@ -181,7 +181,8 @@ export class RoomMaterializer {
   private async loadHostFromStorage(): Promise<RoomHostHandle> {
     const startedAt = Date.now();
     try {
-      const checkpoint = await this.loadCheckpoint();
+      const checkpointResult = await this.loadCheckpointForHydration(startedAt);
+      const checkpoint = checkpointResult.checkpoint;
       if (checkpoint) {
         const latestPublished = await this.loadLatestPublishedSnapshotPairForCheckpoint();
         if (
@@ -275,6 +276,10 @@ export class RoomMaterializer {
         return host;
       }
 
+      if (checkpointResult.error) {
+        throw checkpointResult.error;
+      }
+
       this.loadedPublishedRevisionId = null;
       this.loadedPublishedNotebookHeads = null;
       this.loadedPublishedRuntimeStateHeads = null;
@@ -298,6 +303,29 @@ export class RoomMaterializer {
         counter_delta: 1,
       });
       throw error;
+    }
+  }
+
+  private async loadCheckpointForHydration(startedAt: number): Promise<{
+    checkpoint: {
+      notebookBytes: Uint8Array;
+      runtimeStateBytes: Uint8Array;
+      commsDocBytes?: Uint8Array;
+      metadata: RoomCheckpointMetadata;
+    } | null;
+    error: unknown | null;
+  }> {
+    try {
+      return { checkpoint: await this.loadCheckpoint(), error: null };
+    } catch (error) {
+      cloudLog("warn", "room.materializer.checkpoint_load_failed", {
+        notebook_id: this.notebookId,
+        duration_ms: durationMs(startedAt),
+        error: errorMessage(error),
+        counter: "materializer_checkpoint_load_failures",
+        counter_delta: 1,
+      });
+      return { checkpoint: null, error };
     }
   }
 
@@ -340,7 +368,16 @@ export class RoomMaterializer {
         published.commsDocBytes,
       );
       this.markLoadedPublishedSnapshot(published.revisionId, host);
-      await this.clearCheckpoint();
+      await this.clearCheckpoint().catch((clearError: unknown) => {
+        cloudLog("warn", "room.materializer.checkpoint_clear_failed", {
+          notebook_id: this.notebookId,
+          operation,
+          published_revision_id: published.revisionId,
+          error: errorMessage(clearError),
+          counter: "materializer_checkpoint_clear_failures",
+          counter_delta: 1,
+        });
+      });
       this.hostReady = Promise.resolve(host);
       cloudLog("warn", "room.materializer.recovered_from_published_snapshot", {
         notebook_id: this.notebookId,

--- a/apps/notebook-cloud/test/notebook-room.test.ts
+++ b/apps/notebook-cloud/test/notebook-room.test.ts
@@ -538,6 +538,39 @@ describe("NotebookRoom peer lifecycle", () => {
     assert.match(String(degraded.reason), /Exceeded allowed rows written/);
   });
 
+  it("closes the socket when initial room-host peer sync fails for non-storage errors", async () => {
+    const room = new NotebookRoom(fakeState(), {} as Env);
+    const identity = authenticateDevRequest(
+      new Request("https://cloud.test/n/demo/sync?user=alice&operator=desktop:a&scope=editor"),
+    );
+    const socket = new FakeSocket();
+    const peer = {
+      id: "peer-a",
+      socket: socket.asCloudflareWebSocket(),
+      identity,
+      connectedAt: "2026-05-22T00:00:00.000Z",
+      consecutiveRejectedFrames: 0,
+    };
+    const harness = roomHarness(room);
+    harness.peers.set(peer.id, peer);
+    harness.materializers.set("demo", {
+      syncPeer: async () => {
+        throw new Error("host document could not be materialized");
+      },
+      receiveFrame: async () => noopMaterializedResult(),
+      checkpoint: async () => undefined,
+      removePeer: async () => undefined,
+    });
+
+    await harness.syncPeerFromRoomHost("demo", peer);
+
+    assert.equal(socket.closed, true);
+    assert.equal(socket.closeCode, 1011);
+    assert.equal(socket.closeReason, "room sync failed");
+    assert.equal(harness.peers.has(peer.id), false);
+    assert.equal(socket.sent.length, 0);
+  });
+
   it("reports materialized sync storage degradation without rejecting the frame", async () => {
     const room = new NotebookRoom(fakeState(), {} as Env);
     const identity = authenticateDevRequest(
@@ -811,10 +844,60 @@ describe("NotebookRoom peer lifecycle", () => {
     );
 
     assert.equal(response.status, 200);
-    assert.deepEqual(await response.json(), { ok: true, changed: true });
+    assert.deepEqual(await response.json(), {
+      ok: true,
+      changed: true,
+      checkpoint_persisted: true,
+    });
     assert.deepEqual(publishedAttachment, attachment);
     assert.equal(checkpointed, 1, "changed control updates are checkpointed");
     assert.deepEqual([...viewerSocket.sent[0]], [FrameType.RUNTIME_STATE_SYNC, 4, 5, 6]);
+  });
+
+  it("reports workstation attachment control when checkpoint persistence fails", async () => {
+    const state = hibernatedState([]);
+    const room = new NotebookRoom(state.state, {} as Env);
+    const harness = roomHarness(room);
+    harness.materializers.set("demo", {
+      receiveFrame: async () => noopMaterializedResult(),
+      checkpoint: async () => {
+        throw new Error("Exceeded allowed rows written in Durable Objects free tier.");
+      },
+      setWorkstationAttachment: async () => ({
+        ...noopMaterializedResult(),
+        changed: true,
+        runtime_state_changed: true,
+      }),
+    } as never);
+
+    const response = await room.fetch(
+      new Request("https://room.internal/internal/n/demo/workstation-attachment", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          attachment: {
+            workstation_id: "ws-lab2",
+            display_name: "Lab2 workstation",
+            provider: "runtime_peer",
+            default_environment_label: "Current Python",
+            environment_policy: "current_python",
+            status: "connecting",
+            status_message: "Waiting for Lab2 to accept the compute request.",
+            cpu_count: null,
+            memory_bytes: null,
+            working_directory: null,
+            updated_at: "2026-06-07T00:00:01.000Z",
+          },
+        }),
+      }),
+    );
+
+    assert.equal(response.status, 200);
+    assert.deepEqual(await response.json(), {
+      ok: true,
+      changed: true,
+      checkpoint_persisted: false,
+    });
   });
 
   it("disconnects runtime peers when replacement workstation attachment control is published", async () => {
@@ -1965,6 +2048,7 @@ describe("NotebookRoom runtime_peer-gone watchdog", () => {
       ok: true,
       changed: true,
       forced: false,
+      checkpoint_persisted: true,
       runtime_peer_count: 0,
     });
     assert.equal(repairReason, "manual repair: stale topic-viz runtime");
@@ -2044,6 +2128,7 @@ describe("NotebookRoom runtime_peer-gone watchdog", () => {
       ok: true,
       changed: true,
       forced: true,
+      checkpoint_persisted: true,
       runtime_peer_count: 0,
     });
     assert.equal(reconcileCalls, 1);

--- a/apps/notebook-cloud/test/notebook-room.test.ts
+++ b/apps/notebook-cloud/test/notebook-room.test.ts
@@ -473,6 +473,7 @@ describe("NotebookRoom peer lifecycle", () => {
     const harness = roomHarness(room);
     harness.peers.set(peer.id, peer);
     harness.materializers.set("demo", {
+      syncPeer: async () => noopMaterializedResult(),
       receiveFrame: async () => {
         throw new Error("room host storage temporarily unavailable");
       },
@@ -499,6 +500,42 @@ describe("NotebookRoom peer lifecycle", () => {
             "cloud_frame_rejected",
       ),
     );
+  });
+
+  it("keeps the socket open when initial room-host peer sync is degraded", async () => {
+    const room = new NotebookRoom(fakeState(), {} as Env);
+    const identity = authenticateDevRequest(
+      new Request("https://cloud.test/n/demo/sync?user=alice&operator=desktop:a&scope=editor"),
+    );
+    const socket = new FakeSocket();
+    const peer = {
+      id: "peer-a",
+      socket: socket.asCloudflareWebSocket(),
+      identity,
+      connectedAt: "2026-05-22T00:00:00.000Z",
+      consecutiveRejectedFrames: 0,
+    };
+    const harness = roomHarness(room);
+    harness.peers.set(peer.id, peer);
+    harness.materializers.set("demo", {
+      syncPeer: async () => {
+        throw new Error("Exceeded allowed rows written in Durable Objects free tier.");
+      },
+      receiveFrame: async () => noopMaterializedResult(),
+      checkpoint: async () => undefined,
+      removePeer: async () => undefined,
+    });
+
+    await harness.syncPeerFromRoomHost("demo", peer);
+
+    assert.equal(socket.closed, false);
+    assert.equal(harness.peers.has(peer.id), true);
+    assert.equal(socket.sent.length, 1);
+    assert.equal(socket.sent[0][0], FrameType.SESSION_CONTROL);
+    const degraded = decodeJsonPayload<Record<string, unknown>>(socket.sent[0].slice(1));
+    assert.equal(degraded.type, "cloud_room_degraded");
+    assert.equal(degraded.peer_id, peer.id);
+    assert.match(String(degraded.reason), /Exceeded allowed rows written/);
   });
 
   it("does not silently resurrect a removed hibernated peer", () => {
@@ -1996,6 +2033,7 @@ interface RoomHarness {
   materializers: Map<
     string,
     {
+      syncPeer?(): Promise<RoomHostFrameResult>;
       receiveFrame(): Promise<RoomHostFrameResult>;
       checkpoint(): Promise<void>;
       getWorkstationAttachment?(): Promise<unknown>;
@@ -2010,6 +2048,7 @@ interface RoomHarness {
     workstation: PeerForTest["workstation"],
   ): Promise<string | null>;
   publishRuntimePeerAttachment(notebookId: string, peer: PeerForTest): Promise<void>;
+  syncPeerFromRoomHost(notebookId: string, peer: PeerForTest): Promise<void>;
   handleMessage(
     notebookId: string,
     peer: PeerForTest,

--- a/apps/notebook-cloud/test/notebook-room.test.ts
+++ b/apps/notebook-cloud/test/notebook-room.test.ts
@@ -538,6 +538,46 @@ describe("NotebookRoom peer lifecycle", () => {
     assert.match(String(degraded.reason), /Exceeded allowed rows written/);
   });
 
+  it("reports materialized sync storage degradation without rejecting the frame", async () => {
+    const room = new NotebookRoom(fakeState(), {} as Env);
+    const identity = authenticateDevRequest(
+      new Request("https://cloud.test/n/demo/sync?user=alice&operator=desktop:a&scope=editor"),
+    );
+    const socket = new FakeSocket();
+    const peer = {
+      id: "peer-a",
+      socket: socket.asCloudflareWebSocket(),
+      identity,
+      connectedAt: "2026-05-22T00:00:00.000Z",
+      consecutiveRejectedFrames: 0,
+    };
+    const harness = roomHarness(room);
+    harness.peers.set(peer.id, peer);
+    harness.materializers.set("demo", {
+      syncPeer: async () => noopMaterializedResult(),
+      receiveFrame: async () => {
+        throw new Error("Exceeded allowed rows written in Durable Objects free tier.");
+      },
+      checkpoint: async () => undefined,
+      removePeer: async () => undefined,
+    });
+
+    await harness.handleMessage(
+      "demo",
+      peer,
+      encodeTypedFrame(FrameType.AUTOMERGE_SYNC, new Uint8Array([1])),
+    );
+
+    assert.equal(socket.closed, false);
+    assert.equal(peer.consecutiveRejectedFrames, 0);
+    assert.equal(socket.sent.length, 1);
+    assert.equal(socket.sent[0][0], FrameType.SESSION_CONTROL);
+    const degraded = decodeJsonPayload<Record<string, unknown>>(socket.sent[0].slice(1));
+    assert.equal(degraded.type, "cloud_room_degraded");
+    assert.equal(degraded.peer_id, peer.id);
+    assert.match(String(degraded.reason), /Exceeded allowed rows written/);
+  });
+
   it("does not silently resurrect a removed hibernated peer", () => {
     const room = new NotebookRoom(fakeState(), {} as Env);
     const identity = authenticateDevRequest(

--- a/apps/notebook-cloud/test/notebook-room.test.ts
+++ b/apps/notebook-cloud/test/notebook-room.test.ts
@@ -16,7 +16,6 @@ import {
   runtimePeerWorkstationMetadataFromRequest,
   rewritePresenceFrame,
   shouldBroadcastFrame,
-  shouldPersistMaterializedSyncFrame,
   webSocketUpgradeHeaders,
 } from "../src/notebook-room.ts";
 import {
@@ -191,6 +190,44 @@ describe("NotebookRoom presence rewrite", () => {
 
     assert.equal(shouldBroadcastFrame(frame, anonymous), false);
     assert.equal(shouldBroadcastFrame(frame, editor), true);
+  });
+
+  it("broadcasts authenticated presence without durable room history", async () => {
+    const room = new NotebookRoom(fakeState(), {} as Env);
+    const identity = authenticateDevRequest(
+      new Request("https://cloud.test/n/demo/sync?user=alice&operator=desktop:a&scope=editor"),
+    );
+    const socket = new FakeSocket();
+    const peer = {
+      id: "peer-a",
+      socket: socket.asCloudflareWebSocket(),
+      identity,
+      connectedAt: "2026-05-22T00:00:00.000Z",
+      consecutiveRejectedFrames: 0,
+    };
+    const harness = roomHarness(room);
+    let broadcasted = 0;
+    harness.peers.set(peer.id, peer);
+    harness.broadcastFrame = () => {
+      broadcasted += 1;
+    };
+    const message = encodeTypedFrame(
+      FrameType.PRESENCE,
+      await encodePresenceFrame({
+        type: "heartbeat",
+        peer_id: "client-peer",
+      }),
+    );
+
+    await harness.handleMessage("demo", peer, message);
+
+    assert.equal(broadcasted, 1);
+    assert.equal(socket.sent.length, 1);
+    assert.equal(
+      decodeJsonPayload<Record<string, unknown>>(socket.sent[0].slice(1)).type,
+      "cloud_frame_accepted",
+    );
+    assert.equal(peer.consecutiveRejectedFrames, 0);
   });
 });
 
@@ -448,48 +485,6 @@ describe("NotebookRoom peer lifecycle", () => {
         "demo",
         peer,
         encodeTypedFrame(FrameType.AUTOMERGE_SYNC, new Uint8Array([1])),
-      );
-    }
-
-    assert.equal(socket.closed, false);
-    assert.equal(peer.consecutiveRejectedFrames, 0);
-    assert.equal(socket.sent.length, 10);
-    assert(
-      socket.sent.every(
-        (frame) =>
-          frame[0] === FrameType.SESSION_CONTROL &&
-          decodeJsonPayload<Record<string, unknown>>(frame.slice(1)).type ===
-            "cloud_frame_rejected",
-      ),
-    );
-  });
-
-  it("does not count server-side frame persistence failures toward peer close", async () => {
-    const room = new NotebookRoom(fakeState(), {} as Env);
-    const identity = authenticateDevRequest(
-      new Request(
-        "https://cloud.test/n/demo/sync?user=runtime&operator=runtime:a&scope=runtime_peer",
-      ),
-    );
-    const socket = new FakeSocket();
-    const peer = {
-      id: "runtime-peer",
-      socket: socket.asCloudflareWebSocket(),
-      identity,
-      connectedAt: "2026-05-22T00:00:00.000Z",
-      consecutiveRejectedFrames: 0,
-    };
-    const harness = roomHarness(room);
-    harness.peers.set(peer.id, peer);
-    harness.persistFrame = async () => {
-      throw new Error("storage temporarily unavailable");
-    };
-
-    for (let i = 0; i < 10; i += 1) {
-      await harness.handleMessage(
-        "demo",
-        peer,
-        encodeTypedFrame(FrameType.PUT_BLOB, new Uint8Array([1])),
       );
     }
 
@@ -946,31 +941,7 @@ describe("NotebookRoom peer lifecycle", () => {
   });
 });
 
-describe("NotebookRoom materialized sync persistence", () => {
-  it("persists only sync frames that changed a materialized document", () => {
-    assert.equal(
-      shouldPersistMaterializedSyncFrame({
-        notebook_changed: false,
-        runtime_state_changed: false,
-      }),
-      false,
-    );
-    assert.equal(
-      shouldPersistMaterializedSyncFrame({
-        notebook_changed: true,
-        runtime_state_changed: false,
-      }),
-      true,
-    );
-    assert.equal(
-      shouldPersistMaterializedSyncFrame({
-        notebook_changed: false,
-        runtime_state_changed: true,
-      }),
-      true,
-    );
-  });
-
+describe("NotebookRoom materialized sync routing", () => {
   it("acknowledges no-op sync control frames without persisted room history", async () => {
     const room = new NotebookRoom(fakeState(), {} as Env);
     const identity = authenticateDevRequest(
@@ -984,11 +955,7 @@ describe("NotebookRoom materialized sync persistence", () => {
       connectedAt: "2026-05-22T00:00:00.000Z",
     };
     const harness = roomHarness(room);
-    let persisted = 0;
     harness.materializers.set("demo", fakeMaterializer(noopMaterializedResult()));
-    harness.persistFrame = async () => {
-      persisted += 1;
-    };
 
     await harness.handleMessage(
       "demo",
@@ -996,7 +963,6 @@ describe("NotebookRoom materialized sync persistence", () => {
       encodeTypedFrame(FrameType.AUTOMERGE_SYNC, new Uint8Array()),
     );
 
-    assert.equal(persisted, 0);
     assert.equal(socket.sent.length, 1);
     assert.equal(
       decodeJsonPayload<Record<string, unknown>>(socket.sent[0].slice(1)).type,
@@ -1004,7 +970,7 @@ describe("NotebookRoom materialized sync persistence", () => {
     );
   });
 
-  it("persists materialized sync frames that change document state", async () => {
+  it("acknowledges changed materialized sync frames without persisted room history", async () => {
     const room = new NotebookRoom(fakeState(), {} as Env);
     const identity = authenticateDevRequest(
       new Request("https://cloud.test/n/demo/sync?user=alice&operator=desktop:a&scope=editor"),
@@ -1017,18 +983,18 @@ describe("NotebookRoom materialized sync persistence", () => {
       connectedAt: "2026-05-22T00:00:00.000Z",
     };
     const harness = roomHarness(room);
-    let persisted = 0;
-    harness.materializers.set(
-      "demo",
-      fakeMaterializer({
+    let checkpointed = 0;
+    harness.materializers.set("demo", {
+      receiveFrame: async () => ({
         ...noopMaterializedResult(),
         changed: true,
         notebook_changed: true,
       }),
-    );
-    harness.persistFrame = async () => {
-      persisted += 1;
-    };
+      checkpoint: async () => {
+        checkpointed += 1;
+      },
+      removePeer: async () => undefined,
+    });
 
     await harness.handleMessage(
       "demo",
@@ -1036,7 +1002,7 @@ describe("NotebookRoom materialized sync persistence", () => {
       encodeTypedFrame(FrameType.AUTOMERGE_SYNC, new Uint8Array([1])),
     );
 
-    assert.equal(persisted, 1);
+    assert.equal(checkpointed, 1);
     assert.equal(socket.sent.length, 1);
     assert.equal(
       decodeJsonPayload<Record<string, unknown>>(socket.sent[0].slice(1)).type,
@@ -1067,7 +1033,6 @@ describe("NotebookRoom materialized sync persistence", () => {
       connectedAt: "2026-05-22T00:00:00.000Z",
     };
     const harness = roomHarness(room);
-    let persisted = 0;
     harness.peers.set(editorPeer.id, editorPeer);
     harness.peers.set(viewerPeer.id, viewerPeer);
     harness.materializers.set(
@@ -1085,9 +1050,6 @@ describe("NotebookRoom materialized sync persistence", () => {
         ],
       }),
     );
-    harness.persistFrame = async () => {
-      persisted += 1;
-    };
 
     await harness.handleMessage(
       "demo",
@@ -1095,7 +1057,6 @@ describe("NotebookRoom materialized sync persistence", () => {
       encodeTypedFrame(FrameType.AUTOMERGE_SYNC, new Uint8Array([1])),
     );
 
-    assert.equal(persisted, 1);
     assert.equal(viewerSocket.sent.length, 1);
     assert.deepEqual([...viewerSocket.sent[0]], [FrameType.AUTOMERGE_SYNC, 7, 8, 9]);
     assert.equal(editorSocket.sent.length, 1);
@@ -1118,10 +1079,6 @@ describe("NotebookRoom materialized sync persistence", () => {
       connectedAt: "2026-05-22T00:00:00.000Z",
     };
     const harness = roomHarness(room);
-    let persisted = 0;
-    harness.persistFrame = async () => {
-      persisted += 1;
-    };
 
     await harness.handleMessage(
       "demo",
@@ -1129,7 +1086,6 @@ describe("NotebookRoom materialized sync persistence", () => {
       encodeTypedFrame(FrameType.PUT_BLOB, new Uint8Array([1, 2, 3])),
     );
 
-    assert.equal(persisted, 0);
     assert.equal(socket.sent.length, 1);
     const rejected = decodeJsonPayload<Record<string, unknown>>(socket.sent[0].slice(1));
     assert.equal(rejected.type, "cloud_frame_rejected");
@@ -1149,7 +1105,6 @@ describe("NotebookRoom materialized sync persistence", () => {
       connectedAt: "2026-05-22T00:00:00.000Z",
     };
     const harness = roomHarness(room);
-    let persisted = 0;
     let materialized = 0;
     harness.materializers.set("demo", {
       receiveFrame: async () => {
@@ -1158,9 +1113,6 @@ describe("NotebookRoom materialized sync persistence", () => {
       },
       checkpoint: async () => undefined,
     });
-    harness.persistFrame = async () => {
-      persisted += 1;
-    };
 
     await harness.handleMessage(
       "demo",
@@ -1174,7 +1126,6 @@ describe("NotebookRoom materialized sync persistence", () => {
     );
 
     assert.equal(materialized, 1);
-    assert.equal(persisted, 0);
     assert.equal(socket.sent.length, 1);
     const accepted = decodeJsonPayload<Record<string, unknown>>(socket.sent[0].slice(1));
     assert.equal(accepted.type, "cloud_frame_accepted");
@@ -1207,7 +1158,6 @@ describe("NotebookRoom materialized sync persistence", () => {
       consecutiveRejectedFrames: 0,
     };
     const harness = roomHarness(room);
-    let persisted = 0;
     let materialized = 0;
     harness.peers.set(ownerPeer.id, ownerPeer);
     harness.peers.set(runtimePeer.id, runtimePeer);
@@ -1219,9 +1169,6 @@ describe("NotebookRoom materialized sync persistence", () => {
       checkpoint: async () => undefined,
       removePeer: async () => undefined,
     });
-    harness.persistFrame = async () => {
-      persisted += 1;
-    };
     const actions = ["interrupt_execution", "send_comm"] as const;
     for (const action of actions) {
       const envelope =
@@ -1259,7 +1206,6 @@ describe("NotebookRoom materialized sync persistence", () => {
     }
 
     assert.equal(materialized, 0);
-    assert.equal(persisted, 0);
   });
 
   it("forwards runtime-agent command REQUEST frames only to the newest runtime peer", async () => {
@@ -1416,7 +1362,6 @@ describe("NotebookRoom materialized sync persistence", () => {
       consecutiveRejectedFrames: 0,
     };
     const harness = roomHarness(room);
-    let persisted = 0;
     let materialized = 0;
     harness.peers.set(ownerPeer.id, ownerPeer);
     harness.peers.set(runtimePeer.id, runtimePeer);
@@ -1428,9 +1373,6 @@ describe("NotebookRoom materialized sync persistence", () => {
       checkpoint: async () => undefined,
       removePeer: async () => undefined,
     });
-    harness.persistFrame = async () => {
-      persisted += 1;
-    };
     const requestPayload = new TextEncoder().encode(
       JSON.stringify({ id: "request-1", action: "complete", code: "pri", cursor_pos: 3 }),
     );
@@ -1473,7 +1415,6 @@ describe("NotebookRoom materialized sync persistence", () => {
       [FrameType.RESPONSE, ...Array.from(responsePayload)],
     );
     assert.equal(materialized, 0);
-    assert.equal(persisted, 0);
   });
 
   it("settles the oldest hosted completion when the pending query cap evicts it", async () => {
@@ -1643,7 +1584,6 @@ describe("NotebookRoom materialized sync persistence", () => {
       consecutiveRejectedFrames: 0,
     };
     const harness = roomHarness(room);
-    let persisted = 0;
     let materialized = 0;
     harness.materializers.set("demo", {
       receiveFrame: async () => {
@@ -1653,9 +1593,6 @@ describe("NotebookRoom materialized sync persistence", () => {
       checkpoint: async () => undefined,
       removePeer: async () => undefined,
     });
-    harness.persistFrame = async () => {
-      persisted += 1;
-    };
 
     await harness.handleMessage(
       "demo",
@@ -1669,7 +1606,6 @@ describe("NotebookRoom materialized sync persistence", () => {
     );
 
     assert.equal(materialized, 0);
-    assert.equal(persisted, 0);
     assert.equal(peer.consecutiveRejectedFrames, 0);
     assert.equal(socket.sent.length, 1);
     const rejected = decodeJsonPayload<Record<string, unknown>>(socket.sent[0].slice(1));
@@ -1691,7 +1627,6 @@ describe("NotebookRoom materialized sync persistence", () => {
       consecutiveRejectedFrames: 0,
     };
     const harness = roomHarness(room);
-    let persisted = 0;
     let materialized = 0;
     harness.materializers.set("demo", {
       receiveFrame: async () => {
@@ -1701,9 +1636,6 @@ describe("NotebookRoom materialized sync persistence", () => {
       checkpoint: async () => undefined,
       removePeer: async () => undefined,
     });
-    harness.persistFrame = async () => {
-      persisted += 1;
-    };
 
     await harness.handleMessage(
       "demo",
@@ -1715,7 +1647,6 @@ describe("NotebookRoom materialized sync persistence", () => {
     );
 
     assert.equal(materialized, 0);
-    assert.equal(persisted, 0);
     assert.equal(peer.consecutiveRejectedFrames, 0);
     assert.equal(socket.sent.length, 1);
     const rejected = decodeJsonPayload<Record<string, unknown>>(socket.sent[0].slice(1));
@@ -1742,7 +1673,6 @@ describe("NotebookRoom materialized sync persistence", () => {
         connectedAt: "2026-05-22T00:00:00.000Z",
       };
       const harness = roomHarness(room);
-      let persisted = 0;
       let materialized = 0;
       harness.materializers.set("demo", {
         receiveFrame: async () => {
@@ -1751,9 +1681,6 @@ describe("NotebookRoom materialized sync persistence", () => {
         },
         checkpoint: async () => undefined,
       });
-      harness.persistFrame = async () => {
-        persisted += 1;
-      };
 
       await harness.handleMessage(
         "demo",
@@ -1767,7 +1694,6 @@ describe("NotebookRoom materialized sync persistence", () => {
       );
 
       assert.equal(materialized, 0, `${scope} request reached room host`);
-      assert.equal(persisted, 0, `${scope} request was persisted`);
       assert.equal(socket.sent.length, 1);
       const rejected = decodeJsonPayload<Record<string, unknown>>(socket.sent[0].slice(1));
       assert.equal(rejected.type, "cloud_frame_rejected");
@@ -1790,10 +1716,6 @@ describe("NotebookRoom materialized sync persistence", () => {
       connectedAt: "2026-05-22T00:00:00.000Z",
     };
     const harness = roomHarness(room);
-    let persisted = 0;
-    harness.persistFrame = async () => {
-      persisted += 1;
-    };
 
     await harness.handleMessage(
       "demo",
@@ -1801,7 +1723,6 @@ describe("NotebookRoom materialized sync persistence", () => {
       encodeTypedFrame(FrameType.PUT_BLOB, new Uint8Array([1, 2, 3])),
     );
 
-    assert.equal(persisted, 1);
     assert.equal(socket.sent.length, 1);
     assert.equal(
       decodeJsonPayload<Record<string, unknown>>(socket.sent[0].slice(1)).type,
@@ -2094,7 +2015,6 @@ interface RoomHarness {
     peer: PeerForTest,
     message: string | ArrayBuffer | ArrayBufferView,
   ): Promise<void>;
-  persistFrame(): Promise<void>;
   removePeer(notebookId: string, peer: PeerForTest): void;
   peerForSocket(socket: CloudflareWebSocket): PeerForTest | undefined;
   broadcastFrame(notebookId: string, frame: Uint8Array, excludePeerId?: string): void;

--- a/apps/notebook-cloud/test/room-materializer.test.ts
+++ b/apps/notebook-cloud/test/room-materializer.test.ts
@@ -1345,6 +1345,130 @@ describe("RoomMaterializer", () => {
     assert.deepEqual([...(await state.storage.list({ prefix: "room-host:" })).keys()], []);
   });
 
+  it("recovers from a published snapshot when stale checkpoint cleanup is over quota", async () => {
+    const state = fakeState();
+    const checkpointSnapshot = await createNotebookRoomSnapshot(
+      "demo",
+      "checkpoint-cell",
+      "Unreachable checkpoint edit\n",
+    );
+    const publishedSnapshot = await createNotebookRoomSnapshot(
+      "demo",
+      "published-cell",
+      "Recovered published snapshot without cleanup\n",
+    );
+    await Promise.all([
+      state.storage.put(
+        "room-host:notebook-doc",
+        arrayBufferFromBytes(checkpointSnapshot.notebookBytes),
+      ),
+      state.storage.put(
+        "room-host:runtime-state-doc",
+        arrayBufferFromBytes(checkpointSnapshot.runtimeStateBytes),
+      ),
+      state.storage.put("room-host:checkpoint", {
+        version: 4,
+        notebook_heads: checkpointSnapshot.notebookHeads,
+        runtime_state_heads: checkpointSnapshot.runtimeStateHeads,
+        saved_at: "2026-05-28T00:00:00.000Z",
+        published_revision_id: "revision-current",
+        published_notebook_heads: publishedSnapshot.notebookHeads,
+        published_runtime_state_heads: publishedSnapshot.runtimeStateHeads,
+      }),
+    ]);
+
+    const deleteQuotaError = new Error(
+      "Exceeded allowed rows written in Durable Objects free tier.",
+    );
+    state.storage.delete = async () => {
+      throw deleteQuotaError;
+    };
+
+    const env = fakePublishedSnapshotEnv({
+      notebookId: "demo",
+      revisionId: "revision-current",
+      actorLabel: "user:dev:publisher/agent:runt-publish",
+      notebookBytes: publishedSnapshot.notebookBytes,
+      runtimeStateBytes: publishedSnapshot.runtimeStateBytes,
+    });
+
+    const reloaded = new RoomMaterializer("demo", state, env);
+    const checkpointHost = await (
+      reloaded as unknown as {
+        loadHost(): Promise<{ sync_peer: (peerId: string, connectionScope: string) => unknown }>;
+      }
+    ).loadHost();
+    checkpointHost.sync_peer = () => {
+      throw new Error("recursive use of an object detected which would lead to unsafe aliasing");
+    };
+
+    const viewer = NotebookHandle.create_bootstrap("user:dev:bob/desktop:b");
+    await syncMaterializerWithClient(
+      reloaded,
+      {
+        id: "peer-viewer",
+        identity: authenticateDevRequest(
+          new Request("https://cloud.test/n/demo/sync?user=bob&operator=desktop:b&scope=viewer"),
+        ),
+      },
+      viewer,
+    );
+
+    const cells = JSON.parse(viewer.get_cells_json()) as Array<{ id: string; source: string }>;
+    assert.deepEqual(
+      cells.map((cell) => [cell.id, cell.source]),
+      [["published-cell", "Recovered published snapshot without cleanup\n"]],
+    );
+    assert.deepEqual(
+      [...(await state.storage.list({ prefix: "room-host:" })).keys()].sort(),
+      ["room-host:checkpoint", "room-host:notebook-doc", "room-host:runtime-state-doc"],
+      "stale checkpoint keys can remain until storage writes recover",
+    );
+  });
+
+  it("loads a published snapshot when checkpoint reads are temporarily unavailable", async () => {
+    const state = fakeState();
+    const publishedSnapshot = await createNotebookRoomSnapshot(
+      "demo",
+      "published-cell",
+      "Recovered after checkpoint read failure\n",
+    );
+    const originalGet = state.storage.get.bind(state.storage);
+    state.storage.get = async (key: string) => {
+      if (key.startsWith("room-host:")) {
+        throw new Error("Exceeded allowed rows written in Durable Objects free tier.");
+      }
+      return originalGet(key);
+    };
+
+    const env = fakePublishedSnapshotEnv({
+      notebookId: "demo",
+      revisionId: "revision-current",
+      actorLabel: "user:dev:publisher/agent:runt-publish",
+      notebookBytes: publishedSnapshot.notebookBytes,
+      runtimeStateBytes: publishedSnapshot.runtimeStateBytes,
+    });
+
+    const reloaded = new RoomMaterializer("demo", state, env);
+    const viewer = NotebookHandle.create_bootstrap("user:dev:bob/desktop:b");
+    await syncMaterializerWithClient(
+      reloaded,
+      {
+        id: "peer-viewer",
+        identity: authenticateDevRequest(
+          new Request("https://cloud.test/n/demo/sync?user=bob&operator=desktop:b&scope=viewer"),
+        ),
+      },
+      viewer,
+    );
+
+    const cells = JSON.parse(viewer.get_cells_json()) as Array<{ id: string; source: string }>;
+    assert.deepEqual(
+      cells.map((cell) => [cell.id, cell.source]),
+      [["published-cell", "Recovered after checkpoint read failure\n"]],
+    );
+  });
+
   it("rejects runtime peer execution creation over runtime-state sync", async () => {
     const state = fakeState();
     const materializer = new RoomMaterializer("demo", state, {} as Env);

--- a/apps/notebook-cloud/viewer/cloud-viewer-session.ts
+++ b/apps/notebook-cloud/viewer/cloud-viewer-session.ts
@@ -1125,6 +1125,15 @@ export function useCloudViewerSession({
           setConnectionActorLabel(message.actor_label);
           setConnectionPeerLabel(presenceStore.getSnapshot().ownPeerLabel);
         }
+        if (message.type === "cloud_room_degraded") {
+          const reason = `Cloud room storage is temporarily unavailable: ${message.reason}`;
+          setConnectionError(reason);
+          setStatus({
+            kind: "error",
+            message: reason,
+          });
+          return;
+        }
         if (message.type === "cloud_frame_rejected") {
           if (isRecoverableCloudFrameRejection(message)) {
             const liveRuntime = liveRuntimeRef.current;

--- a/docs/adr/hosted-room-authorization.md
+++ b/docs/adr/hosted-room-authorization.md
@@ -230,11 +230,12 @@ requests, or ACL mutations.
 Public viewer presence is a product policy layered on top of this ACL. The
 minimum hosted-room behavior keeps anonymous public presence connection-local,
 matching the current prototype: the server acknowledges the frame to the sender
-but does not broadcast it to other peers or persist it as room activity.
-Authenticated viewers can use normal broadcast presence. If product later wants
-public viewer presence, that change should be explicit and should define whether
-anonymous users appear as aggregate document presence or full cursor/cell
-presence.
+but does not broadcast it to other peers. Authenticated viewers can use normal
+live broadcast presence. Room frames are not persisted as a separate activity
+log; the materialized `NotebookDoc`/`RuntimeStateDoc`/`CommsDoc` checkpoint path
+is the durable recovery boundary. If product later wants public viewer presence,
+that change should be explicit and should define whether anonymous users appear
+as aggregate document presence or full cursor/cell presence.
 
 ## Decision 5: Room creation is a privileged operation
 


### PR DESCRIPTION
## Summary
- remove Durable Object per-frame history writes from the notebook room hot path
- keep authenticated presence live-only: broadcast + ack, no storage row
- keep materialized document recovery on the RoomMaterializer checkpoint path instead of a separate frame log
- update hosted-room authorization docs to spell out the document checkpoint boundary

## Validation
- pnpm --dir apps/notebook-cloud test test/notebook-room.test.ts (984 tests passed; package script runs the full cloud test suite)
- pnpm --dir apps/notebook-cloud typecheck
- cargo xtask lint --fix

## Notes
This removes the old `frame:<sequence>` / `frame_sequence` metadata writes. Those rows were not read for room replay or recovery; they only amplified Durable Object storage writes for accepted live frames.