### PR TITLE
fix(runtimed): silence non-unix stderr buffer warning

### DIFF
--- a/crates/runtimed/src/jupyter_kernel.rs
+++ b/crates/runtimed/src/jupyter_kernel.rs
@@ -1200,6 +1200,9 @@ impl KernelConnection for JupyterKernel {
             }
         };
 
+        #[cfg(not(unix))]
+        let _ = &stderr_buffer;
+
         #[cfg(unix)]
         let kernel_pid = process.id().map(|pid| pid as i32);
 


### PR DESCRIPTION
## Summary
- mark the launched kernel stderr buffer as intentionally retained on non-Unix targets
- fixes Windows clippy failing on `unused variable: stderr_buffer`

## Verification
- `cargo clippy --target x86_64-pc-windows-gnu --workspace --exclude notebook --exclude runtimed-wasm --exclude sift-wasm --exclude runtimed-py --exclude runtimed-node --all-targets -- -D warnings`
- `cargo xtask lint --fix`

CI context: https://github.com/nteract/nteract/actions/runs/27449082181