### PR TITLE
fix(workstations): stabilize hosted runtime peers

### DIFF
--- a/apps/notebook-cloud/scripts/hosted-workstation-toolbar-smoke.mjs
+++ b/apps/notebook-cloud/scripts/hosted-workstation-toolbar-smoke.mjs
@@ -18,6 +18,8 @@ import {
   writeSmokeJsonReport,
 } from "./smoke-paths.mjs";
 
+const smokePhaseTimings = [];
+
 if (isMainModule()) {
   main().catch((error) => {
     console.error(error instanceof Error ? error.message : String(error));
@@ -57,6 +59,10 @@ async function main() {
   const source =
     process.env.NOTEBOOK_CLOUD_WORKSTATION_TOOLBAR_SMOKE_CODE ??
     `print(${JSON.stringify(runMarker)})`;
+  const runOutputProbes = parseBoolean(
+    process.env.NOTEBOOK_CLOUD_WORKSTATION_TOOLBAR_SMOKE_OUTPUT_PROBES,
+    false,
+  );
   const title =
     process.env.NOTEBOOK_CLOUD_WORKSTATION_TOOLBAR_SMOKE_TITLE ??
     `Toolbar attach smoke ${new Date().toISOString()}`;
@@ -140,6 +146,7 @@ async function main() {
     viewerUrl,
     workstationDisplayName: scalarString(workstation.display_name) ?? workstationId,
     workstationId,
+    runOutputProbes,
   });
   const report = {
     ok: true,
@@ -159,6 +166,7 @@ async function main() {
       wasDefaultBeforeSmoke: workstationWasDefault,
       status: scalarString(workstation.status),
     },
+    phaseTimings: smokePhaseTimings,
     checks: [
       "workstation_registered_online",
       workstationWasDefault
@@ -182,6 +190,7 @@ async function runBrowserSmoke({
   viewerUrl,
   workstationDisplayName,
   workstationId,
+  runOutputProbes,
 }) {
   const url = new URL(viewerUrl);
   const browser = await chromium.launch({ headless: true });
@@ -209,6 +218,7 @@ async function runBrowserSmoke({
         timeoutMs,
         url,
         workstationDisplayName,
+        runOutputProbes,
       });
     } finally {
       await ownerContext.close().catch(() => {});
@@ -230,6 +240,9 @@ async function runBrowserSmoke({
         "toolbar_start_compute_clicked",
         "execute_button_rendered_after_compute_start",
         "cell_output_observed_after_execute",
+        ...(runOutputProbes
+          ? ["error_output_probe_observed", "display_update_output_probe_observed"]
+          : []),
         "restart_button_clicked",
         "cell_output_observed_after_restart",
         "restart_run_all_button_clicked",
@@ -259,6 +272,7 @@ async function runOwnerAttachAndExecuteSmoke({
   timeoutMs,
   url,
   workstationDisplayName,
+  runOutputProbes,
 }) {
   const page = await context.newPage();
   const events = collectBrowserDiagnostics(page);
@@ -320,6 +334,9 @@ async function runOwnerAttachAndExecuteSmoke({
   );
   const afterReloadKernelStatus = await readKernelStatus(page);
   assertKernelStatusNotInitializing(afterReloadKernelStatus, "after reload execution");
+  const outputProbes = runOutputProbes
+    ? await runOutputTimingProbes(page, runMarker, timeoutMs)
+    : null;
 
   if (screenshotPath) {
     await saveSmokeScreenshot(page, screenshotPath);
@@ -335,9 +352,57 @@ async function runOwnerAttachAndExecuteSmoke({
     afterReloadRunAria,
     beforeReloadRunAria,
     events,
+    outputProbes,
     restartMarker,
     restartRunAllMarkers,
     screenshotPath: screenshotPath ?? null,
+  };
+}
+
+async function runOutputTimingProbes(page, runMarker, timeoutMs) {
+  const probeBase = `${runMarker} output probe`;
+  const errorMarker = `${probeBase} error complete`;
+  const displayMarker = `${probeBase} display update complete`;
+  const cells = await ensureCodeCellCount(page, 4, timeoutMs);
+  const errorCell = cells.nth(2);
+  const displayCell = cells.nth(3);
+
+  await setCellSource(
+    errorCell,
+    [
+      "raise RuntimeError(",
+      `  ${JSON.stringify(errorMarker.slice(0, Math.ceil(errorMarker.length / 2)))} +`,
+      `  ${JSON.stringify(errorMarker.slice(Math.ceil(errorMarker.length / 2)))}`,
+      ")",
+    ].join("\n"),
+  );
+  await executeAndWaitForMarker(page, errorCell, errorMarker, timeoutMs);
+  const afterErrorKernelStatus = await readKernelStatus(page);
+  assertKernelStatusNotInitializing(afterErrorKernelStatus, "after error output probe");
+
+  await setCellSource(
+    displayCell,
+    [
+      "from IPython.display import display, update_display",
+      "display('display probe starting', display_id='nteract_latency_probe')",
+      "for index in range(4):",
+      "    update_display(f'display probe update {index}', display_id='nteract_latency_probe')",
+      `update_display(${JSON.stringify(
+        displayMarker.slice(0, Math.ceil(displayMarker.length / 2)),
+      )} + ${JSON.stringify(
+        displayMarker.slice(Math.ceil(displayMarker.length / 2)),
+      )}, display_id='nteract_latency_probe')`,
+    ].join("\n"),
+  );
+  await executeAndWaitForMarkerEverywhere(page, displayCell, displayMarker, timeoutMs);
+  const afterDisplayKernelStatus = await readKernelStatus(page);
+  assertKernelStatusNotInitializing(afterDisplayKernelStatus, "after display-update output probe");
+
+  return {
+    afterDisplayKernelStatus,
+    afterErrorKernelStatus,
+    displayMarker,
+    errorMarker,
   };
 }
 
@@ -554,6 +619,22 @@ async function assertViewModeDoesNotExposeExecutionControls({
 
 async function authenticatedContext(browser, { origin, scope, tokenStorageJson }) {
   const context = await browser.newContext({ viewport: { width: 1440, height: 1000 } });
+  const token = JSON.parse(tokenStorageJson);
+  const accessToken = typeof token.accessToken === "string" ? token.accessToken : null;
+  if (!accessToken) {
+    throw new Error("authenticated browser context requires an OIDC accessToken");
+  }
+  const sessionResponse = await context.request.post(new URL("/api/auth/session", origin).href, {
+    headers: {
+      Accept: "application/json",
+      Authorization: `Bearer ${accessToken}`,
+    },
+  });
+  if (!sessionResponse.ok()) {
+    throw new Error(
+      `establish browser app session failed: ${sessionResponse.status()} ${await sessionResponse.text()}`,
+    );
+  }
   await context.addInitScript(
     ({ expectedOrigin, requestedScope, tokenJson }) => {
       try {
@@ -588,9 +669,21 @@ async function enterEditMode(page, timeoutMs) {
 }
 
 async function smokePhase(label, operation) {
+  const startedAt = Date.now();
   try {
-    return await operation();
+    const result = await operation();
+    smokePhaseTimings.push({
+      elapsed_ms: Date.now() - startedAt,
+      label,
+      ok: true,
+    });
+    return result;
   } catch (error) {
+    smokePhaseTimings.push({
+      elapsed_ms: Date.now() - startedAt,
+      label,
+      ok: false,
+    });
     const message = error instanceof Error ? error.message : String(error);
     throw new Error(`${label}: ${message}`);
   }
@@ -821,6 +914,26 @@ async function executeAndWaitForMarker(
   await waitForText(page, marker, timeout);
 }
 
+async function executeAndWaitForMarkerEverywhere(
+  page,
+  cell,
+  marker,
+  timeout,
+  { requireOrdinalAdvance = true } = {},
+) {
+  await waitForCanExecute(page, timeout);
+  const executeButton = await visibleExecuteButton(cell, timeout);
+  const beforeAria = await readExecuteButtonAria(cell, "read pre-execution button state", timeout);
+  const beforeOrdinal = executionOrdinal(beforeAria);
+  await smokePhase("click cell execute button", async () => {
+    await executeButton.click({ timeout });
+  });
+  if (requireOrdinalAdvance) {
+    await waitForExecutionOrdinalAdvance(page, beforeOrdinal, timeout);
+  }
+  await waitForTextEverywhere(page, marker, timeout);
+}
+
 async function restartComputeAndWait(page, timeout) {
   const restartButton = page.getByTestId("restart-kernel-button");
   await smokePhase("wait for restart button", async () => {
@@ -915,6 +1028,45 @@ async function waitForText(page, text, timeout) {
     text,
     timeout,
   );
+}
+
+async function waitForTextEverywhere(page, text, timeout) {
+  await smokePhase(
+    `wait for text ${JSON.stringify(textSample(text))} in page or frames`,
+    async () => {
+      const deadline = Date.now() + timeout;
+      while (Date.now() < deadline) {
+        if (await pageOrFrameTextIncludes(page, text)) {
+          return;
+        }
+        await page.waitForTimeout(100);
+      }
+      throw new Error(`text was not found in page or frames: ${text}`);
+    },
+  );
+}
+
+async function pageOrFrameTextIncludes(page, text) {
+  const bodyIncludes = await page
+    .evaluate((expected) => (document.body.textContent ?? "").includes(expected), text)
+    .catch(() => false);
+  if (bodyIncludes) {
+    return true;
+  }
+  for (const frame of page.frames()) {
+    if (frame === page.mainFrame()) {
+      continue;
+    }
+    const frameIncludes = await frame
+      .locator("body")
+      .textContent({ timeout: 100 })
+      .then((value) => (value ?? "").includes(text))
+      .catch(() => false);
+    if (frameIncludes) {
+      return true;
+    }
+  }
+  return false;
 }
 
 async function waitForExecutionOrdinalAdvance(page, beforeOrdinal, timeout) {
@@ -1037,6 +1189,11 @@ function parsePositiveInteger(value, label, fallback) {
     throw new Error(`${label} must be a positive integer`);
   }
   return parsed;
+}
+
+function parseBoolean(value, fallback) {
+  if (value === undefined || value === null || value === "") return fallback;
+  return /^(1|true|yes|on)$/i.test(value);
 }
 
 function isMainModule() {

--- a/apps/notebook-cloud/src/notebook-room.ts
+++ b/apps/notebook-cloud/src/notebook-room.ts
@@ -547,27 +547,33 @@ export class NotebookRoom {
         restored_peer_count: this.peers.size,
       });
     }
-    await Promise.all(
-      restored.map(async ({ notebookId, peer }) => {
-        if (peer.identity.scope === "runtime_peer") {
-          const authorityError = await this.runtimePeerAuthorityError(notebookId, peer.workstation);
-          if (authorityError) {
-            cloudLog("warn", "room.runtime_peer.rejected_on_restore", {
-              notebook_id: notebookId,
-              peer_id: peer.id,
-              principal: peer.identity.principal,
-              reason: authorityError,
-              workstation_id: runtimePeerWorkstationId(peer.workstation),
-              counter: "runtime_peers_rejected_on_restore",
-              counter_delta: 1,
-            });
-            this.removePeer(notebookId, peer, {
-              code: 1008,
-              reason: "workstation mismatch",
-            });
-            return;
-          }
+    const authorizedRestored: Array<{ notebookId: string; peer: Peer }> = [];
+    for (const { notebookId, peer } of restored) {
+      if (peer.identity.scope === "runtime_peer") {
+        const authorityError = await this.runtimePeerAuthorityError(notebookId, peer.workstation);
+        if (authorityError) {
+          cloudLog("warn", "room.runtime_peer.rejected_on_restore", {
+            notebook_id: notebookId,
+            peer_id: peer.id,
+            principal: peer.identity.principal,
+            reason: authorityError,
+            workstation_id: runtimePeerWorkstationId(peer.workstation),
+            counter: "runtime_peers_rejected_on_restore",
+            counter_delta: 1,
+          });
+          this.removePeer(notebookId, peer, {
+            code: 1008,
+            reason: "workstation mismatch",
+          });
+          continue;
         }
+      }
+      authorizedRestored.push({ notebookId, peer });
+    }
+
+    const activeRestored = this.removeDuplicateRestoredRuntimePeers(authorizedRestored);
+    await Promise.all(
+      activeRestored.map(async ({ notebookId, peer }) => {
         await this.syncPeerFromRoomHost(notebookId, peer);
         if (peer.identity.scope === "runtime_peer") {
           this.refreshRuntimePeerWatch(notebookId);
@@ -575,6 +581,62 @@ export class NotebookRoom {
         }
       }),
     );
+  }
+
+  private removeDuplicateRestoredRuntimePeers(
+    restored: Array<{ notebookId: string; peer: Peer }>,
+  ): Array<{ notebookId: string; peer: Peer }> {
+    const latestByWorkstation = new Map<string, { notebookId: string; peer: Peer }>();
+    for (const restoredPeer of restored) {
+      const { notebookId, peer } = restoredPeer;
+      if (peer.identity.scope !== "runtime_peer") {
+        continue;
+      }
+      const workstationId = runtimePeerWorkstationId(peer.workstation);
+      if (!workstationId) {
+        continue;
+      }
+      const key = `${notebookId}\0${workstationId}`;
+      const latest = latestByWorkstation.get(key);
+      if (!latest || peer.connectedAt >= latest.peer.connectedAt) {
+        latestByWorkstation.set(key, restoredPeer);
+      }
+    }
+
+    const active: Array<{ notebookId: string; peer: Peer }> = [];
+    for (const restoredPeer of restored) {
+      const { notebookId, peer } = restoredPeer;
+      if (peer.identity.scope !== "runtime_peer") {
+        active.push(restoredPeer);
+        continue;
+      }
+      const workstationId = runtimePeerWorkstationId(peer.workstation);
+      if (!workstationId) {
+        active.push(restoredPeer);
+        continue;
+      }
+      const key = `${notebookId}\0${workstationId}`;
+      const latest = latestByWorkstation.get(key);
+      if (latest?.peer.id === peer.id) {
+        active.push(restoredPeer);
+        continue;
+      }
+      this.removePeer(notebookId, peer, {
+        code: DUPLICATE_RUNTIME_PEER_CLOSE_CODE,
+        reason: DUPLICATE_RUNTIME_PEER_CLOSE_REASON,
+        suppressRuntimePeerWatch: true,
+      });
+      cloudLog("warn", "room.runtime_peer.duplicate_replaced_on_restore", {
+        notebook_id: notebookId,
+        closed_peer_id: peer.id,
+        replacement_peer_id: latest?.peer.id,
+        workstation_id: workstationId,
+        counter: "runtime_peer_restore_duplicates_replaced",
+        counter_delta: 1,
+      });
+    }
+
+    return active;
   }
 
   private acceptPeerSocket(notebookId: string, peer: Peer): void {

--- a/apps/notebook-cloud/src/notebook-room.ts
+++ b/apps/notebook-cloud/src/notebook-room.ts
@@ -106,6 +106,8 @@ const RUNTIME_PEER_GONE_GRACE_MS = 30_000;
 const MAX_CONSECUTIVE_REJECTED_FRAMES = 8;
 const REJECTED_FRAME_POLICY_CLOSE_CODE = 1008;
 const REJECTED_FRAME_POLICY_CLOSE_REASON = "too many rejected frames";
+const DUPLICATE_RUNTIME_PEER_CLOSE_CODE = 1000;
+const DUPLICATE_RUNTIME_PEER_CLOSE_REASON = "replaced by newer runtime peer";
 
 /// Storage key holding the notebook id whose `runtime_peer` departure armed the
 /// reconciliation alarm. Persisted so a DO that hibernates between the alarm
@@ -278,6 +280,9 @@ export class NotebookRoom {
       consecutiveRejectedFrames: 0,
     };
 
+    if (identity.scope === "runtime_peer") {
+      this.removeDuplicateRuntimePeers(notebookId, peer);
+    }
     this.acceptPeerSocket(notebookId, peer);
     this.peers.set(peer.id, peer);
     // A runtime_peer (re)joining cancels any pending reconciliation alarm: the
@@ -1130,6 +1135,37 @@ export class NotebookRoom {
       if (peer.identity.scope === "runtime_peer") {
         this.removePeer(notebookId, peer, closeOptions);
       }
+    }
+  }
+
+  private removeDuplicateRuntimePeers(notebookId: string, incomingPeer: Peer): void {
+    const incomingWorkstationId = runtimePeerWorkstationId(incomingPeer.workstation);
+    let closedCount = 0;
+    for (const peer of Array.from(this.peers.values())) {
+      if (peer.identity.scope !== "runtime_peer") {
+        continue;
+      }
+      if (runtimePeerWorkstationId(peer.workstation) !== incomingWorkstationId) {
+        continue;
+      }
+
+      this.removePeer(notebookId, peer, {
+        code: DUPLICATE_RUNTIME_PEER_CLOSE_CODE,
+        reason: DUPLICATE_RUNTIME_PEER_CLOSE_REASON,
+        suppressRuntimePeerWatch: true,
+      });
+      closedCount += 1;
+    }
+
+    if (closedCount > 0) {
+      cloudLog("warn", "room.runtime_peer.duplicate_replaced", {
+        notebook_id: notebookId,
+        incoming_peer_id: incomingPeer.id,
+        workstation_id: incomingWorkstationId,
+        closed_runtime_peers: closedCount,
+        counter: "runtime_peer_duplicates_replaced",
+        counter_delta: closedCount,
+      });
     }
   }
 

--- a/apps/notebook-cloud/test/notebook-room.test.ts
+++ b/apps/notebook-cloud/test/notebook-room.test.ts
@@ -1430,6 +1430,65 @@ describe("NotebookRoom materialized sync routing", () => {
     );
   });
 
+  it("replaces duplicate runtime peers for the same workstation only", () => {
+    const room = new NotebookRoom(fakeState(), {} as Env);
+    const sameWorkstationIdentity = authenticateDevRequest(
+      new Request(
+        "https://cloud.test/n/demo/sync?user=runtime&operator=runtime:old&scope=runtime_peer",
+      ),
+    );
+    const otherWorkstationIdentity = authenticateDevRequest(
+      new Request(
+        "https://cloud.test/n/demo/sync?user=runtime&operator=runtime:other&scope=runtime_peer",
+      ),
+    );
+    const incomingIdentity = authenticateDevRequest(
+      new Request(
+        "https://cloud.test/n/demo/sync?user=runtime&operator=runtime:new&scope=runtime_peer",
+      ),
+    );
+    const sameWorkstationSocket = new FakeSocket();
+    const otherWorkstationSocket = new FakeSocket();
+    const incomingSocket = new FakeSocket();
+    const sameWorkstationPeer = {
+      id: "runtime-old",
+      socket: sameWorkstationSocket.asCloudflareWebSocket(),
+      identity: sameWorkstationIdentity,
+      connectedAt: "2026-05-22T00:00:00.000Z",
+      workstation: { workstationId: "ws-lab2" },
+      consecutiveRejectedFrames: 0,
+    };
+    const otherWorkstationPeer = {
+      id: "runtime-other",
+      socket: otherWorkstationSocket.asCloudflareWebSocket(),
+      identity: otherWorkstationIdentity,
+      connectedAt: "2026-05-22T00:00:00.000Z",
+      workstation: { workstationId: "ws-other" },
+      consecutiveRejectedFrames: 0,
+    };
+    const incomingPeer = {
+      id: "runtime-new",
+      socket: incomingSocket.asCloudflareWebSocket(),
+      identity: incomingIdentity,
+      connectedAt: "2026-05-22T00:00:01.000Z",
+      workstation: { workstationId: "ws-lab2" },
+      consecutiveRejectedFrames: 0,
+    };
+    const harness = roomHarness(room);
+    harness.peers.set(sameWorkstationPeer.id, sameWorkstationPeer);
+    harness.peers.set(otherWorkstationPeer.id, otherWorkstationPeer);
+    harness.materializers.set("demo", fakeMaterializer(noopMaterializedResult()));
+
+    harness.removeDuplicateRuntimePeers?.("demo", incomingPeer);
+
+    assert.equal(harness.peers.has(sameWorkstationPeer.id), false);
+    assert.equal(sameWorkstationSocket.closed, true);
+    assert.equal(sameWorkstationSocket.closeCode, 1000);
+    assert.equal(sameWorkstationSocket.closeReason, "replaced by newer runtime peer");
+    assert.equal(harness.peers.has(otherWorkstationPeer.id), true);
+    assert.equal(otherWorkstationSocket.closed, false);
+  });
+
   it("breaks equal runtime-peer timestamps in favor of the later connection", async () => {
     const room = new NotebookRoom(fakeState(), {} as Env);
     const ownerIdentity = authenticateDevRequest(
@@ -2172,6 +2231,7 @@ interface RoomHarness {
     notebookId: string,
     workstation: PeerForTest["workstation"],
   ): Promise<string | null>;
+  removeDuplicateRuntimePeers?(notebookId: string, incomingPeer: PeerForTest): void;
   publishRuntimePeerAttachment(notebookId: string, peer: PeerForTest): Promise<void>;
   syncPeerFromRoomHost(notebookId: string, peer: PeerForTest): Promise<void>;
   handleMessage(

--- a/apps/notebook-cloud/test/notebook-room.test.ts
+++ b/apps/notebook-cloud/test/notebook-room.test.ts
@@ -714,6 +714,72 @@ describe("NotebookRoom peer lifecycle", () => {
     );
   });
 
+  it("collapses duplicate hibernated runtime peers for the same workstation", async () => {
+    const oldIdentity = authenticateDevRequest(
+      new Request(
+        "https://cloud.test/n/demo/sync?user=runtime&operator=runtime:old&scope=runtime_peer",
+      ),
+    );
+    const otherIdentity = authenticateDevRequest(
+      new Request(
+        "https://cloud.test/n/demo/sync?user=runtime&operator=runtime:other&scope=runtime_peer",
+      ),
+    );
+    const newIdentity = authenticateDevRequest(
+      new Request(
+        "https://cloud.test/n/demo/sync?user=runtime&operator=runtime:new&scope=runtime_peer",
+      ),
+    );
+    const oldSocket = new FakeSocket();
+    const otherSocket = new FakeSocket();
+    const newSocket = new FakeSocket();
+    oldSocket.serializeAttachment({
+      notebookId: "demo",
+      peerId: "runtime-old",
+      identity: oldIdentity,
+      connectedAt: "2026-06-06T00:00:00.000Z",
+      workstation: { workstationId: "ws-lab2" },
+    });
+    otherSocket.serializeAttachment({
+      notebookId: "demo",
+      peerId: "runtime-other",
+      identity: otherIdentity,
+      connectedAt: "2026-06-06T00:00:00.000Z",
+      workstation: { workstationId: "ws-other" },
+    });
+    newSocket.serializeAttachment({
+      notebookId: "demo",
+      peerId: "runtime-new",
+      identity: newIdentity,
+      connectedAt: "2026-06-06T00:00:01.000Z",
+      workstation: { workstationId: "ws-lab2" },
+    });
+    const state = hibernatedState([
+      oldSocket.asCloudflareWebSocket(),
+      otherSocket.asCloudflareWebSocket(),
+      newSocket.asCloudflareWebSocket(),
+    ]);
+    const room = new NotebookRoom(state.state, {} as Env);
+    const harness = roomHarness(room);
+
+    await state.drain();
+
+    assert.equal(oldSocket.closed, true);
+    assert.equal(oldSocket.closeCode, 1000);
+    assert.equal(oldSocket.closeReason, "replaced by newer runtime peer");
+    assert.equal(harness.peerForSocket(oldSocket.asCloudflareWebSocket()), undefined);
+    assert.equal(
+      harness.peerForSocket(newSocket.asCloudflareWebSocket())?.id,
+      "runtime-new",
+      "newer runtime peer for the same workstation survives restore",
+    );
+    assert.equal(
+      harness.peerForSocket(otherSocket.asCloudflareWebSocket())?.id,
+      "runtime-other",
+      "different workstation runtime peer survives restore",
+    );
+  });
+
   it("publishes a sanitized runtime-peer workstation attachment", async () => {
     const state = hibernatedState([]);
     const room = new NotebookRoom(state.state, {} as Env);

--- a/crates/runtimed/src/runtime_agent.rs
+++ b/crates/runtimed/src/runtime_agent.rs
@@ -88,6 +88,52 @@ fn reconnect_floor_delay(
     }
 }
 
+fn install_runtime_agent_shutdown_signal_handlers(
+    shutdown_tx: mpsc::UnboundedSender<&'static str>,
+) {
+    #[cfg(unix)]
+    {
+        use tokio::signal::unix::{signal, SignalKind};
+
+        match signal(SignalKind::terminate()) {
+            Ok(mut sigterm) => {
+                let tx = shutdown_tx.clone();
+                tokio::spawn(async move {
+                    if sigterm.recv().await.is_some() {
+                        let _ = tx.send("SIGTERM");
+                    }
+                });
+            }
+            Err(error) => {
+                warn!("[runtime-agent] Failed to install SIGTERM handler: {error}");
+            }
+        }
+
+        match signal(SignalKind::interrupt()) {
+            Ok(mut sigint) => {
+                let tx = shutdown_tx;
+                tokio::spawn(async move {
+                    if sigint.recv().await.is_some() {
+                        let _ = tx.send("SIGINT");
+                    }
+                });
+            }
+            Err(error) => {
+                warn!("[runtime-agent] Failed to install SIGINT handler: {error}");
+            }
+        }
+    }
+
+    #[cfg(not(unix))]
+    {
+        tokio::spawn(async move {
+            if tokio::signal::ctrl_c().await.is_ok() {
+                let _ = shutdown_tx.send("ctrl-c");
+            }
+        });
+    }
+}
+
 /// Shared context for the runtime agent (no kernel -- kernel is owned locally).
 struct RuntimeAgentContext {
     state: RuntimeStateHandle,
@@ -460,6 +506,8 @@ where
     let mut runtime_state_doc_seen = false;
     let mut runtime_state_doc_seen_at: Option<std::time::Instant> = None;
     let mut orphan_comm_candidates: HashSet<String> = HashSet::new();
+    let (shutdown_tx, mut shutdown_rx) = mpsc::unbounded_channel::<&'static str>();
+    install_runtime_agent_shutdown_signal_handlers(shutdown_tx);
 
     // -- 3b. Launch-on-attach gate (cloud only) -----------------------------
     //
@@ -1157,6 +1205,14 @@ where
                         }
                     }
                 }
+            }
+
+            // Process-level shutdown from the workstation agent or host. This
+            // must exit through the normal cleanup section below so the kernel
+            // receives a Jupyter shutdown request instead of being orphaned.
+            Some(signal_name) = shutdown_rx.recv() => {
+                info!("[runtime-agent] Received shutdown signal {signal_name}");
+                break;
             }
 
             // Process lifecycle commands from kernel tasks. These are

--- a/crates/runtimed/src/workstation/agent_loop.rs
+++ b/crates/runtimed/src/workstation/agent_loop.rs
@@ -24,6 +24,9 @@
 //! agent — no shared mutexes, so nothing can hold a lock across an await.
 
 use std::collections::HashMap;
+use std::fs::{File, OpenOptions};
+#[cfg(unix)]
+use std::os::fd::AsRawFd;
 use std::path::{Path, PathBuf};
 use std::time::{Duration, Instant};
 
@@ -626,6 +629,7 @@ pub async fn run_workstation_agent(opts: WorkstationAgentOptions, token: String)
             opts.agent_root.display()
         )
     })?;
+    let _agent_lock = WorkstationAgentLock::try_acquire(&opts.agent_root, &opts.workstation_id)?;
 
     info!(
         "[workstation-agent] starting cloud_url={} workstation_id={} display_name={:?} working_dir={} python_path={} poll_ms={} heartbeat_ms={} agent_root={}",
@@ -681,6 +685,103 @@ pub async fn run_workstation_agent(opts: WorkstationAgentOptions, token: String)
             tokio::time::sleep(Duration::from_millis(CHILD_TICK_MS).min(deadline - now)).await;
         }
     }
+}
+
+struct WorkstationAgentLock {
+    _lock_file: File,
+    lock_path: PathBuf,
+}
+
+impl WorkstationAgentLock {
+    fn try_acquire(agent_root: &Path, workstation_id: &str) -> Result<Self> {
+        let lock_dir = workstation_agent_lock_dir(agent_root);
+        std::fs::create_dir_all(lock_dir)
+            .with_context(|| format!("create workstation agent lock dir {}", lock_dir.display()))?;
+        let lock_path = workstation_agent_lock_path(agent_root, workstation_id);
+        let lock_file = OpenOptions::new()
+            .create(true)
+            .read(true)
+            .write(true)
+            .open(&lock_path)
+            .with_context(|| format!("open workstation agent lock {}", lock_path.display()))?;
+
+        #[cfg(unix)]
+        {
+            let result =
+                unsafe { libc::flock(lock_file.as_raw_fd(), libc::LOCK_EX | libc::LOCK_NB) };
+            anyhow::ensure!(
+                result == 0,
+                "another workstation agent is already running for {workstation_id} (lock {})",
+                lock_path.display()
+            );
+        }
+
+        #[cfg(windows)]
+        {
+            use std::os::windows::io::AsRawHandle;
+            use windows_sys::Win32::Foundation::HANDLE;
+            use windows_sys::Win32::Storage::FileSystem::{
+                LockFileEx, LOCKFILE_EXCLUSIVE_LOCK, LOCKFILE_FAIL_IMMEDIATELY,
+            };
+
+            let handle = lock_file.as_raw_handle() as HANDLE;
+            let mut overlapped = unsafe { std::mem::zeroed() };
+            let result = unsafe {
+                LockFileEx(
+                    handle,
+                    LOCKFILE_EXCLUSIVE_LOCK | LOCKFILE_FAIL_IMMEDIATELY,
+                    0,
+                    1,
+                    0,
+                    &mut overlapped,
+                )
+            };
+            anyhow::ensure!(
+                result != 0,
+                "another workstation agent is already running for {workstation_id} (lock {})",
+                lock_path.display()
+            );
+        }
+
+        info!(
+            "[workstation-agent] acquired local singleton lock path={}",
+            lock_path.display()
+        );
+        Ok(Self {
+            _lock_file: lock_file,
+            lock_path,
+        })
+    }
+}
+
+impl Drop for WorkstationAgentLock {
+    fn drop(&mut self) {
+        #[cfg(unix)]
+        unsafe {
+            let _ = libc::flock(self._lock_file.as_raw_fd(), libc::LOCK_UN);
+        }
+        info!(
+            "[workstation-agent] released local singleton lock path={}",
+            self.lock_path.display()
+        );
+    }
+}
+
+fn workstation_agent_lock_path(agent_root: &Path, workstation_id: &str) -> PathBuf {
+    workstation_agent_lock_dir(agent_root).join(format!(
+        "workstation-{}.lock",
+        runt_workspace::safe_path_part(workstation_id)
+    ))
+}
+
+fn workstation_agent_lock_dir(agent_root: &Path) -> &Path {
+    if agent_root
+        .file_name()
+        .is_some_and(|name| name == "workstation-agent")
+    {
+        return agent_root.parent().unwrap_or(agent_root);
+    }
+    agent_root
 }
 
 async fn heartbeat(api: &CloudApi, opts: &WorkstationAgentOptions) -> Result<(), AgentHttpError> {
@@ -1250,6 +1351,35 @@ mod tests {
             started_at: Instant::now(),
             last_status_patch_at: Instant::now(),
         }
+    }
+
+    #[test]
+    fn workstation_agent_lock_prevents_duplicate_runner() -> Result<()> {
+        let tmp = tempfile::TempDir::new()?;
+        let root = tmp.path();
+        let first = WorkstationAgentLock::try_acquire(root, "ws-lab2")?;
+
+        let Err(error) = WorkstationAgentLock::try_acquire(root, "ws-lab2") else {
+            anyhow::bail!("second workstation agent lock should fail while first is held");
+        };
+        assert!(error
+            .to_string()
+            .contains("another workstation agent is already running"));
+
+        drop(first);
+        let _second = WorkstationAgentLock::try_acquire(root, "ws-lab2")?;
+        Ok(())
+    }
+
+    #[test]
+    fn workstation_agent_lock_uses_daemon_base_dir_for_standard_agent_root() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        let agent_root = tmp.path().join("workstation-agent");
+
+        assert_eq!(
+            workstation_agent_lock_path(&agent_root, "ws-lab2"),
+            tmp.path().join("workstation-ws-lab2.lock")
+        );
     }
 
     /// (c) Heartbeat payload field set matches the `.mjs` agent exactly.

--- a/crates/runtimed/src/workstation/agent_loop.rs
+++ b/crates/runtimed/src/workstation/agent_loop.rs
@@ -700,6 +700,7 @@ impl WorkstationAgentLock {
         let lock_path = workstation_agent_lock_path(agent_root, workstation_id);
         let lock_file = OpenOptions::new()
             .create(true)
+            .truncate(false)
             .read(true)
             .write(true)
             .open(&lock_path)
@@ -1117,17 +1118,31 @@ fn attach_job_patch_no_longer_active(error: &AgentHttpError) -> bool {
 
 async fn terminate_active_job(mut job: ActiveJob) {
     if let Some(child) = job.child.as_mut() {
-        if let Err(error) = child.start_kill() {
-            warn!("[workstation-agent] failed to terminate inactive child job: {error}");
-            return;
+        if let Err(error) = request_child_shutdown(child) {
+            warn!("[workstation-agent] failed to request inactive child shutdown: {error}");
         }
-        match tokio::time::timeout(Duration::from_secs(2), child.wait()).await {
+        match tokio::time::timeout(Duration::from_secs(5), child.wait()).await {
             Ok(Ok(_status)) => {}
             Ok(Err(error)) => {
                 warn!("[workstation-agent] failed to reap inactive child job: {error}");
             }
             Err(_) => {
-                warn!("[workstation-agent] timed out reaping inactive child job");
+                warn!("[workstation-agent] timed out waiting for inactive child shutdown; killing");
+                if let Err(error) = child.start_kill() {
+                    warn!("[workstation-agent] failed to kill inactive child job: {error}");
+                    return;
+                }
+                match tokio::time::timeout(Duration::from_secs(2), child.wait()).await {
+                    Ok(Ok(_status)) => {}
+                    Ok(Err(error)) => {
+                        warn!(
+                            "[workstation-agent] failed to reap killed inactive child job: {error}"
+                        );
+                    }
+                    Err(_) => {
+                        warn!("[workstation-agent] timed out reaping killed inactive child job");
+                    }
+                }
             }
         }
         return;
@@ -1135,6 +1150,24 @@ async fn terminate_active_job(mut job: ActiveJob) {
     if let Some(pid) = job.pid {
         terminate_pid(pid);
     }
+}
+
+#[cfg(unix)]
+fn request_child_shutdown(child: &mut tokio::process::Child) -> std::result::Result<(), String> {
+    let Some(pid) = child.id() else {
+        return Ok(());
+    };
+    let pid = i32::try_from(pid).map_err(|error| format!("invalid child pid {pid}: {error}"))?;
+    nix::sys::signal::kill(
+        nix::unistd::Pid::from_raw(pid),
+        Some(nix::sys::signal::Signal::SIGTERM),
+    )
+    .map_err(|error| format!("SIGTERM pid={pid}: {error}"))
+}
+
+#[cfg(not(unix))]
+fn request_child_shutdown(child: &mut tokio::process::Child) -> std::result::Result<(), String> {
+    child.start_kill().map_err(|error| error.to_string())
 }
 
 #[cfg(unix)]
@@ -1461,6 +1494,48 @@ mod tests {
 
         assert!(!drop_terminal_attach_job(&mut active, "job-1", "heartbeat", &error).await);
         assert!(active.contains_key("job-1"));
+    }
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn inactive_child_job_gets_graceful_shutdown_before_kill() -> Result<()> {
+        let tmp = tempfile::TempDir::new()?;
+        let marker_path = tmp.path().join("sigterm-marker");
+        let ready_path = tmp.path().join("ready-marker");
+        let child = tokio::process::Command::new("sh")
+            .env("SIGTERM_MARKER", &marker_path)
+            .env("READY_MARKER", &ready_path)
+            .arg("-c")
+            .arg(
+                "trap 'printf term > \"$SIGTERM_MARKER\"; exit 0' TERM; \
+                 printf ready > \"$READY_MARKER\"; \
+                 while :; do sleep 1; done",
+            )
+            .stdout(std::process::Stdio::null())
+            .stderr(std::process::Stdio::null())
+            .spawn()?;
+
+        let ready_deadline = Instant::now() + Duration::from_secs(2);
+        while !ready_path.exists() {
+            if Instant::now() >= ready_deadline {
+                anyhow::bail!("child did not install SIGTERM trap before test timeout");
+            }
+            tokio::time::sleep(Duration::from_millis(10)).await;
+        }
+
+        terminate_active_job(ActiveJob {
+            child: Some(child),
+            pid: None,
+            log_path: tmp.path().join("runtime-peer.log"),
+            ready: true,
+            status: "running",
+            started_at: Instant::now(),
+            last_status_patch_at: Instant::now(),
+        })
+        .await;
+
+        assert_eq!(std::fs::read_to_string(marker_path)?, "term");
+        Ok(())
     }
 
     /// (d) Attach-job → spawn argv mapping mirrors the `.mjs` plan, with the


### PR DESCRIPTION
## Summary
- add a per-workstation advisory singleton lock for the hosted workstation agent so one local workstation identity cannot be served by multiple runner processes
- replace older runtime peers in a room when a newer peer connects with the same workstation id, including restored hibernated peers, while leaving other workstation ids/kernels alone
- shut down replaced/inactive runtime-peer children gracefully so `cloud-runtime-agent` reaches its normal kernel cleanup path before the workstation agent falls back to a hard kill
- add timing/session-cookie support to the hosted workstation toolbar smoke harness for latency/debug runs

## Validation
- `cargo xtask lint --fix`
- `cargo test -p runtimed workstation::agent_loop::tests --lib`
- `cargo test -p runtimed runtime_agent --lib`
- `pnpm --dir apps/notebook-cloud test -- notebook-room` (992/992 cloud tests passed)
- rebuilt local `runt`/`runtimed`, started one `ws-lab2` workstation runner, and verified a second runner exits with `another workstation agent is already running for ws-lab2`

## Notes
- Pullfrog's hibernation-restore edge is addressed: restored duplicate runtime peers collapse to the newest peer for the same notebook/workstation key before room-host sync/publish.
- Live smoke found that hard-killing inactive `cloud-runtime-agent` jobs could orphan launched kernel children; this branch now sends SIGTERM first and runtime agents exit through their normal `k.shutdown().await` cleanup path.
