### PR TITLE
fix(notebook-cloud): refresh shared invites from home

### DIFF
--- a/apps/notebook-cloud/test/viewer-shared-cell-surface.test.ts
+++ b/apps/notebook-cloud/test/viewer-shared-cell-surface.test.ts
@@ -539,6 +539,18 @@ test("cloud app-session bridge refreshes cookie-backed state after OIDC exchange
   );
 });
 
+test("cloud notebook list refresh re-establishes app sessions before listing notebooks", () => {
+  const routeSourcePath = new URL("../viewer/notebook-list-view.tsx", import.meta.url);
+  const routeSourceText = readFileSync(routeSourcePath, "utf8");
+
+  assert.match(routeSourceText, /import \{ clearCloudAppSession, establishCloudAppSession \}/);
+  assert.match(
+    routeSourceText,
+    /const refreshList = \(\) => \{[\s\S]*authState\.mode === "oidc" && authState\.token[\s\S]*establishCloudAppSession\(authState\)[\s\S]*appSessionStatus\.refreshAppSessionStatus\(\)[\s\S]*setRefreshIndex/,
+    "manual notebook-list refresh should re-run the trusted session exchange so pending invites can resolve",
+  );
+});
+
 test("cloud notebook list waits for app-session cookies before catalog fetches", () => {
   const sourcePath = new URL("../viewer/notebook-list-view.tsx", import.meta.url);
   const sourceText = readFileSync(sourcePath, "utf8");

--- a/apps/notebook-cloud/viewer/notebook-list-view.tsx
+++ b/apps/notebook-cloud/viewer/notebook-list-view.tsx
@@ -16,7 +16,7 @@ import {
   type CloudPrototypeAuthState,
 } from "./collaborator-auth";
 import { cloudResponseError } from "./cloud-response";
-import { clearCloudAppSession } from "./app-session";
+import { clearCloudAppSession, establishCloudAppSession } from "./app-session";
 import { CloudNotebookDashboard } from "./cloud-notebook-dashboard-view";
 import { loadCloudNotebookListBootstrap } from "./cloud-viewer-config";
 import type {
@@ -131,6 +131,17 @@ export function CloudNotebookListView({ authConfig }: { authConfig: CloudViewerA
   }, [authState, bootstrap, canFetchNotebookList, refreshIndex, waitingForAppSession]);
 
   const refreshList = () => {
+    if (authState.mode === "oidc" && authState.token) {
+      void establishCloudAppSession(authState)
+        .catch((error: unknown) => {
+          console.warn("[notebook-cloud] app session refresh before notebook list failed", error);
+        })
+        .finally(() => {
+          appSessionStatus.refreshAppSessionStatus();
+          setRefreshIndex((value) => value + 1);
+        });
+      return;
+    }
     setRefreshIndex((value) => value + 1);
   };
 

--- a/src/components/notebook/NotebookEditModeButton.tsx
+++ b/src/components/notebook/NotebookEditModeButton.tsx
@@ -31,7 +31,7 @@ export function NotebookEditModeButton({
     ? state === "editing"
       ? "Return to read-only viewing"
       : "Stop requesting edit access"
-    : "Request edit access";
+    : "Switch to edit mode";
 
   if (variant === "segmented") {
     return (
@@ -83,7 +83,7 @@ export function NotebookEditModeButton({
               ? "Editing notebook"
               : requestedEdit
                 ? "Edit access requested"
-                : "Request edit access"
+                : "Switch to edit mode"
           }
           onClick={() => {
             if (mode !== "edit") {

--- a/src/components/notebook/__tests__/NotebookEditModeButton.test.tsx
+++ b/src/components/notebook/__tests__/NotebookEditModeButton.test.tsx
@@ -11,6 +11,7 @@ describe("NotebookEditModeButton", () => {
     const button = screen.getByRole("button", { name: "Edit" });
     expect(button).toHaveAttribute("data-slot", "notebook-edit-mode-button");
     expect(button).toHaveAttribute("data-state", "viewing");
+    expect(button).toHaveAttribute("title", "Switch to edit mode");
 
     fireEvent.click(button);
 
@@ -47,6 +48,10 @@ describe("NotebookEditModeButton", () => {
     expect(group).toHaveAttribute("data-slot", "notebook-edit-mode-button");
     expect(group).toHaveAttribute("data-variant", "segmented");
     expect(screen.getByRole("button", { name: "Viewing" })).toHaveAttribute("aria-pressed", "true");
+    expect(screen.getByRole("button", { name: "Editing" })).toHaveAttribute(
+      "title",
+      "Switch to edit mode",
+    );
 
     fireEvent.click(screen.getByRole("button", { name: "Editing" }));
 


### PR DESCRIPTION
## Summary
- re-run the OIDC app-session exchange when a signed-in user presses Refresh on the notebook home page, so pending shared notebook invites can resolve before the list reloads
- change the view-mode edit affordance title from "Request edit access" to the neutral "Switch to edit mode" for users who may already have editor access
- add focused coverage for the invite refresh path and edit-mode button title

## Field report
- https://github.com/quillaid/nteract-cloud-explorations/tree/main/reports/preview-runt-sharing/2026-06-13

## Tests
- pnpm --dir apps/notebook-cloud exec node --import tsx --test test/viewer-shared-cell-surface.test.ts
- pnpm test:run src/components/notebook/__tests__/NotebookEditModeButton.test.tsx
- pnpm --dir apps/notebook-cloud typecheck
- cargo xtask lint --fix

## Notes
This makes the explicit refresh path recover pending legitimate shares after sign-in. The direct shared-notebook link before invite resolution can still enter the room shell and hit owner-scoped socket/catalog failures; that remains documented in the report and likely needs a dedicated accept/resolve-before-room-load flow.