### PR TITLE
fix(notebook): focus markdown before gutter edit

### DIFF
--- a/apps/notebook/src/components/MarkdownCell.tsx
+++ b/apps/notebook/src/components/MarkdownCell.tsx
@@ -350,7 +350,7 @@ export const MarkdownCell = memo(function MarkdownCell({
     };
   }, [headingAnchors, markdownProjection]);
 
-  const handleDoubleClick = useCallback(() => {
+  const enterEditing = useCallback(() => {
     if (readOnly) return;
     onFocus();
     setPreviewFrameInteractionActive(false);
@@ -626,11 +626,11 @@ export const MarkdownCell = memo(function MarkdownCell({
           return;
         }
         // Enter: enter edit mode
-        setEditing(true);
+        enterEditing();
         e.preventDefault();
       }
     },
-    [onFocusNext, onFocusPrevious, readOnly],
+    [enterEditing, onFocusNext, onFocusPrevious, readOnly],
   );
 
   // Handle focus next, creating a new cell if at the end
@@ -808,7 +808,7 @@ export const MarkdownCell = memo(function MarkdownCell({
             <button
               type="button"
               tabIndex={-1}
-              onClick={() => setEditing(true)}
+              onClick={enterEditing}
               className="flex items-center justify-center rounded p-1 text-muted-foreground/40 transition-colors hover:text-foreground"
               title="Edit"
             >
@@ -852,7 +852,7 @@ export const MarkdownCell = memo(function MarkdownCell({
             tabIndex={0}
             className={cn("py-2 cursor-text outline-none", editing && "hidden")}
             onFocus={activatePreviewFrameInteraction}
-            onDoubleClick={handleDoubleClick}
+            onDoubleClick={enterEditing}
             onPointerDown={handlePreviewWrapperPointerDown}
             onKeyDown={handleViewKeyDown}
           >
@@ -888,7 +888,7 @@ export const MarkdownCell = memo(function MarkdownCell({
                   onLinkClick={handleLinkClick}
                   onMouseDown={activatePreviewFrameInteraction}
                   onMouseUp={handlePreviewFrameMouseUp}
-                  onDoubleClick={handleDoubleClick}
+                  onDoubleClick={enterEditing}
                   onError={handleIframeError}
                   onDiagnostic={logNotebookIsolatedDiagnostic}
                   className="w-full"

--- a/apps/notebook/src/components/__tests__/markdown-cell-theme.test.tsx
+++ b/apps/notebook/src/components/__tests__/markdown-cell-theme.test.tsx
@@ -537,6 +537,32 @@ describe("MarkdownCell theme sync", () => {
     expect(onFocus).toHaveBeenCalled();
   });
 
+  it("focuses the cell before entering edit mode from the gutter action", async () => {
+    mockIsFocused = false;
+
+    let rerenderCell: ReturnType<typeof render>["rerender"] | undefined;
+    const cell = makeTaskCell();
+    const onFocus = vi.fn(() => {
+      mockIsFocused = true;
+      rerenderCell?.(<MarkdownCell cell={cell} onFocus={onFocus} onDelete={() => {}} />);
+    });
+
+    const { getByLabelText, getByTitle, rerender } = render(
+      <MarkdownCell cell={cell} onFocus={onFocus} onDelete={() => {}} />,
+    );
+    rerenderCell = rerender;
+
+    const preview = getByLabelText("Markdown cell content");
+    expect(preview.className).not.toContain("hidden");
+
+    fireEvent.click(getByTitle("Edit"));
+
+    expect(onFocus).toHaveBeenCalled();
+    await waitFor(() => {
+      expect(preview.className).toContain("hidden");
+    });
+  });
+
   it("Ctrl+Enter exits edit mode for markdown cells", async () => {
     const cell = { ...makeCell(), source: "" };
 


### PR DESCRIPTION
## Summary
- route markdown edit-entry actions through a shared focus-aware path before setting local edit mode
- fix the gutter pencil path where an unfocused rendered markdown cell could focus the readonly preview instead of reopening the editor
- add a regression test for clicking the gutter edit action from an unfocused markdown cell

## Field report
- https://github.com/quillaid/nteract-cloud-explorations/tree/main/reports/preview-runt-sharing/2026-06-13

## Tests
- pnpm test:run apps/notebook/src/components/__tests__/markdown-cell-theme.test.tsx
- cargo xtask lint --fix

## Notes
This came from the shared Sup Quill notebook pass. Creating a new markdown cell worked and persisted after reload, but clicking the rendered cell pencil action only focused the readonly markdown preview when the cell was not already focused.