### PR TITLE
fix(notebook-cloud): use resolved scope for viewer links

### DIFF
--- a/apps/notebook-cloud/test/cloud-notebook-mode.test.ts
+++ b/apps/notebook-cloud/test/cloud-notebook-mode.test.ts
@@ -1,0 +1,62 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+import { cloudNotebookInteractionModeForAccess } from "../viewer/cloud-notebook-mode";
+
+test("cloud notebook edit links stay view-only for viewers without an access request", () => {
+  assert.equal(
+    cloudNotebookInteractionModeForAccess({
+      accessRequestStatus: null,
+      connectionScope: "viewer",
+      selectedMode: "edit",
+    }),
+    "view",
+  );
+  assert.equal(
+    cloudNotebookInteractionModeForAccess({
+      accessRequestStatus: "rejected",
+      connectionScope: "viewer",
+      selectedMode: "edit",
+    }),
+    "view",
+  );
+  assert.equal(
+    cloudNotebookInteractionModeForAccess({
+      accessRequestStatus: "pending",
+      connectionScope: "viewer",
+      selectedMode: "edit",
+    }),
+    "edit",
+  );
+  assert.equal(
+    cloudNotebookInteractionModeForAccess({
+      accessRequestStatus: "approved",
+      connectionScope: "viewer",
+      selectedMode: "edit",
+    }),
+    "edit",
+  );
+  assert.equal(
+    cloudNotebookInteractionModeForAccess({
+      accessRequestStatus: null,
+      connectionScope: "editor",
+      selectedMode: "edit",
+    }),
+    "edit",
+  );
+  assert.equal(
+    cloudNotebookInteractionModeForAccess({
+      accessRequestStatus: null,
+      connectionScope: "owner",
+      selectedMode: "edit",
+    }),
+    "edit",
+  );
+  assert.equal(
+    cloudNotebookInteractionModeForAccess({
+      accessRequestStatus: "pending",
+      connectionScope: "viewer",
+      selectedMode: "view",
+    }),
+    "view",
+  );
+});

--- a/apps/notebook-cloud/test/viewer-shared-cell-surface.test.ts
+++ b/apps/notebook-cloud/test/viewer-shared-cell-surface.test.ts
@@ -336,6 +336,12 @@ test("cloud edit mode chrome renders through the shared shell component", () => 
   assert.match(authControlsSourceText, /state=\{accessPending \? "viewing" : interaction\.state\}/);
   assert.match(authControlsSourceText, /disabled=\{accessPending\}/);
   assert.match(
+    authControlsSourceText,
+    /const canSwitchToEdit = accessLevel === "editor" \|\| accessLevel === "owner"/,
+  );
+  assert.match(authControlsSourceText, /editLabel=\{editLabel\}/);
+  assert.match(authControlsSourceText, /editTitle=\{editTitle\}/);
+  assert.match(
     sourceText,
     /const showCloudCommandToolbar = shouldShowNotebookDocumentCommandToolbar\(shellCapabilities, \{[\s\S]*reserve: editAccessPending,[\s\S]*\}\)/,
   );
@@ -351,10 +357,7 @@ test("cloud edit mode chrome renders through the shared shell component", () => 
   assert.doesNotMatch(sourceText, /CloudNotebookCommandToolbarPlaceholder/);
   assert.doesNotMatch(cssText, /cloud-edit-mode-placeholder/);
   assert.doesNotMatch(cssText, /cloud-command-toolbar-placeholder/);
-  assert.match(
-    authControlsSourceText,
-    /if \(mode === "edit" && accessLevel !== "editor" && accessLevel !== "owner"\) \{/,
-  );
+  assert.match(authControlsSourceText, /if \(mode === "edit" && !canSwitchToEdit\) \{/);
   assert.match(sourceText, /storeCloudRequestedScope\(window\.localStorage, "editor"\)/);
   assert.doesNotMatch(sourceText, /mode === "edit" \? "editor" : NOTEBOOK_CLOUD_DEFAULT_SCOPE/);
   assert.doesNotMatch(sourceText, /className="cloud-scope-toggle-button"/);
@@ -570,14 +573,24 @@ test("cloud notebook list waits for app-session cookies before catalog fetches",
   );
 });
 
-test("cloud app-session live sync requests owner and lets the backend downgrade", () => {
+test("cloud app-session live sync requests the resolved notebook-list scope", () => {
   const sourceText = viewerCorpus;
 
-  assert.match(sourceText, /cloudSyncAuthFromAppSessionCookie\(\{[\s\S]*requestedScope: "owner"/);
+  assert.match(sourceText, /async function resolveCloudAppSessionSyncScope/);
+  assert.match(sourceText, /new URL\("api\/n\?limit=100"/);
+  assert.match(sourceText, /isCloudNotebookListItem\(candidate\)/);
+  assert.match(sourceText, /candidate\.notebook_id === notebookId/);
+  assert.match(sourceText, /return notebook\.scope/);
+  assert.match(sourceText, /return selectedMode === "edit" \? "owner" : "viewer"/);
+  assert.match(
+    sourceText,
+    /const requestedScope = await resolveCloudAppSessionSyncScope\([\s\S]*config\.notebookId,[\s\S]*selectedInteractionMode,[\s\S]*\)/,
+  );
   assert.doesNotMatch(
     sourceText,
-    /cloudSyncAuthFromAppSessionCookie\(\{[\s\S]*requestedScope: authState\.requestedScope/,
+    /cloudSyncAuthFromAppSessionCookie\(\{[\s\S]*requestedScope: "owner"/,
   );
+  assert.doesNotMatch(sourceText, /setSelectedInteractionMode\(selectedInteractionModeForAccess\)/);
 });
 
 test("cloud sync keeps routine frame logs out of the browser console", () => {

--- a/apps/notebook-cloud/viewer/cloud-auth-controls.tsx
+++ b/apps/notebook-cloud/viewer/cloud-auth-controls.tsx
@@ -44,15 +44,20 @@ export function CloudNotebookEditModeButton({
   ) {
     return null;
   }
+  const canSwitchToEdit = accessLevel === "editor" || accessLevel === "owner";
+  const editLabel = canSwitchToEdit ? "Editing" : "Request edit";
+  const editTitle = canSwitchToEdit ? "Switch to edit mode" : "Request edit access";
 
   return (
     <NotebookEditModeButton
+      editLabel={editLabel}
+      editTitle={editTitle}
       mode={accessPending ? "view" : interaction.selectedMode}
       state={accessPending ? "viewing" : interaction.state}
       variant="segmented"
       disabled={accessPending}
       onModeChange={(mode) => {
-        if (mode === "edit" && accessLevel !== "editor" && accessLevel !== "owner") {
+        if (mode === "edit" && !canSwitchToEdit) {
           onRequestEditAccess();
           return;
         }

--- a/apps/notebook-cloud/viewer/cloud-notebook-mode.ts
+++ b/apps/notebook-cloud/viewer/cloud-notebook-mode.ts
@@ -1,5 +1,23 @@
 export type CloudNotebookUrlMode = "edit" | "view";
 
+export function cloudNotebookInteractionModeForAccess({
+  accessRequestStatus,
+  connectionScope,
+  selectedMode,
+}: {
+  accessRequestStatus?: string | null;
+  connectionScope: string | null;
+  selectedMode: CloudNotebookUrlMode;
+}): CloudNotebookUrlMode {
+  if (selectedMode !== "edit" || connectionScope !== "viewer") {
+    return selectedMode;
+  }
+  if (accessRequestStatus === "pending" || accessRequestStatus === "approved") {
+    return "edit";
+  }
+  return "view";
+}
+
 export function cloudNotebookModeFromSearch(search: string): CloudNotebookUrlMode {
   const params = new URLSearchParams(search);
   return normalizeCloudNotebookMode(params.get("mode"));

--- a/apps/notebook-cloud/viewer/notebook-viewer.tsx
+++ b/apps/notebook-cloud/viewer/notebook-viewer.tsx
@@ -59,6 +59,7 @@ import {
   storeCloudRequestedScope,
   shouldShowCloudHeaderSignIn,
 } from "./collaborator-auth";
+import type { ConnectionScope } from "../src/auth-shared";
 
 import { useCloudViewerSession } from "./cloud-viewer-session";
 import {
@@ -94,6 +95,7 @@ import { cloudSourceLanguage } from "./source-language";
 import { clearCloudAppSession, readCloudAppSessionStatus } from "./app-session";
 import { applyDocumentTheme, CLOUD_VIEWER_THEME_STORAGE_KEY } from "./theme";
 import {
+  cloudNotebookInteractionModeForAccess,
   cloudNotebookModeFromSearch,
   replaceCloudNotebookModeInCurrentUrl,
 } from "./cloud-notebook-mode";
@@ -108,6 +110,7 @@ import { useCloudWorkstationManager } from "./use-cloud-workstations";
 import { CloudNotebookEditModeButton, CloudNotebookSignInButton } from "./cloud-auth-controls";
 import { CloudNotebookTitle } from "./cloud-notebook-title";
 import { CloudPresenceStatus } from "./cloud-presence-status";
+import { isCloudNotebookListItem } from "./notebook-dashboard";
 
 const CLOUD_VIEWER_OUTPUT_IFRAME_ROOT_MARGIN = "400px 0px";
 const CLOUD_ACCESS_REQUEST_POLL_INTERVAL_MS = 10_000;
@@ -120,6 +123,33 @@ function decodeHashAnchorId(hash: string): string {
   } catch {
     return raw;
   }
+}
+
+async function resolveCloudAppSessionSyncScope(
+  notebookId: string,
+  selectedMode: NotebookInteractionMode,
+): Promise<Exclude<ConnectionScope, "runtime_peer">> {
+  try {
+    const endpoint = new URL("api/n?limit=100", `${window.location.origin}/`);
+    const response = await fetch(endpoint.href, {
+      cache: "no-store",
+      credentials: "same-origin",
+      headers: { Accept: "application/json" },
+    });
+    if (response.ok) {
+      const body = (await response.json()) as { notebooks?: unknown };
+      const notebooks = Array.isArray(body.notebooks) ? body.notebooks : [];
+      const notebook = notebooks.find(
+        (candidate) => isCloudNotebookListItem(candidate) && candidate.notebook_id === notebookId,
+      );
+      if (isCloudNotebookListItem(notebook) && notebook.scope !== "runtime_peer") {
+        return notebook.scope;
+      }
+    }
+  } catch (error) {
+    console.warn("[notebook-cloud] unable to resolve notebook access scope before sync", error);
+  }
+  return selectedMode === "edit" ? "owner" : "viewer";
 }
 
 export function NotebookViewer({
@@ -199,14 +229,24 @@ export function NotebookViewer({
           ? ((await readCloudAppSessionStatus().catch(() => null))?.session ?? null)
           : null);
       if (appSession) {
+        const requestedScope = await resolveCloudAppSessionSyncScope(
+          config.notebookId,
+          selectedInteractionMode,
+        );
         return cloudSyncAuthFromAppSessionCookie({
-          requestedScope: "owner",
+          requestedScope,
           sessionId,
         });
       }
       return cloudSyncAuthFromPrototypeAuthState(authState);
     },
-    [appSessionStatus.session, appSessionStatus.status, authState],
+    [
+      appSessionStatus.session,
+      appSessionStatus.status,
+      authState,
+      config.notebookId,
+      selectedInteractionMode,
+    ],
   );
   const {
     connectionActorLabel,
@@ -377,6 +417,11 @@ export function NotebookViewer({
       ? cloudRuntimeStatus.label
       : null
     : null;
+  const selectedInteractionModeForAccess = cloudNotebookInteractionModeForAccess({
+    accessRequestStatus: latestAccessRequest?.status,
+    connectionScope,
+    selectedMode: selectedInteractionMode,
+  });
   const { shellCapabilities, canAcceptCellMutations, editAccessPending } =
     useCloudShellCapabilities({
       authState,
@@ -391,7 +436,7 @@ export function NotebookViewer({
       kernelStatusLabel: cloudKernelStatusLabel,
       runtimePeerAvailable,
       runtimePeerCount,
-      selectedMode: selectedInteractionMode,
+      selectedMode: selectedInteractionModeForAccess,
       status,
       workstationAttachment,
     });

--- a/src/components/notebook/NotebookEditModeButton.tsx
+++ b/src/components/notebook/NotebookEditModeButton.tsx
@@ -10,6 +10,8 @@ export interface NotebookEditModeButtonProps {
   state: NotebookEditModeState;
   onModeChange: (mode: NotebookEditMode) => void;
   disabled?: boolean;
+  editLabel?: string;
+  editTitle?: string;
   variant?: "button" | "segmented";
   className?: string;
 }
@@ -17,6 +19,8 @@ export interface NotebookEditModeButtonProps {
 export function NotebookEditModeButton({
   className,
   disabled = false,
+  editLabel: editLabelProp,
+  editTitle = "Switch to edit mode",
   mode,
   onModeChange,
   state,
@@ -25,13 +29,14 @@ export function NotebookEditModeButton({
   const requestingEdit = mode === "edit";
   const requestedEdit = requestingEdit && state === "requested";
   const nextMode: NotebookEditMode = requestingEdit ? "view" : "edit";
+  const editLabel = editLabelProp ?? "Editing";
   const label = requestingEdit ? "View" : "Edit";
-  const editSegmentLabel = requestedEdit ? "Request sent" : "Editing";
+  const editSegmentLabel = requestedEdit ? "Request sent" : editLabel;
   const title = requestingEdit
     ? state === "editing"
       ? "Return to read-only viewing"
       : "Stop requesting edit access"
-    : "Switch to edit mode";
+    : editTitle;
 
   if (variant === "segmented") {
     return (
@@ -83,7 +88,7 @@ export function NotebookEditModeButton({
               ? "Editing notebook"
               : requestedEdit
                 ? "Edit access requested"
-                : "Switch to edit mode"
+                : editTitle
           }
           onClick={() => {
             if (mode !== "edit") {

--- a/src/components/notebook/__tests__/NotebookEditModeButton.test.tsx
+++ b/src/components/notebook/__tests__/NotebookEditModeButton.test.tsx
@@ -58,6 +58,30 @@ describe("NotebookEditModeButton", () => {
     expect(onModeChange).toHaveBeenCalledWith("edit");
   });
 
+  it("can render host-specific segmented edit copy", () => {
+    const onModeChange = vi.fn();
+
+    render(
+      <NotebookEditModeButton
+        mode="view"
+        state="viewing"
+        variant="segmented"
+        editLabel="Request edit"
+        editTitle="Request edit access"
+        onModeChange={onModeChange}
+      />,
+    );
+
+    expect(screen.getByRole("button", { name: "Request edit" })).toHaveAttribute(
+      "title",
+      "Request edit access",
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "Request edit" }));
+
+    expect(onModeChange).toHaveBeenCalledWith("edit");
+  });
+
   it("does not reapply the already selected segmented mode", () => {
     const onModeChange = vi.fn();
 


### PR DESCRIPTION
## Summary
- resolve the current notebook scope from `/api/n?limit=100` before opening app-session live-room sockets
- stop hard-coding app-session room sockets to owner, preserving owner/editor/viewer scope from the catalog when available
- label viewer edit affordances as `Request edit` / `Request edit access` while preserving `Editing` / `Switch to edit mode` for editor and owner access

## Field report
- https://github.com/quillaid/nteract-cloud-explorations/tree/main/reports/preview-runt-view-only/2026-06-13

## Tests
- pnpm test:run src/components/notebook/__tests__/NotebookEditModeButton.test.tsx
- pnpm --dir apps/notebook-cloud exec node --import tsx --test test/viewer-shared-cell-surface.test.ts
- pnpm --dir apps/notebook-cloud typecheck
- cargo xtask lint --fix

## Notes
This came from the view-only share pass. The dashboard resolved `view-only-quill` as `viewer` after app-session refresh, but direct view/edit routes still attempted owner-scoped room sockets and the view-mode edit segment said `Switch to edit mode` for a viewer. The socket fix uses the catalog/list scope when present, then falls back to editor for unresolved `?mode=edit` links and viewer for view links.