### PR TITLE
fix(cloud): stabilize workstation and auth reconnects

### DIFF
--- a/apps/notebook-cloud/scripts/hosted-workstation-toolbar-smoke.mjs
+++ b/apps/notebook-cloud/scripts/hosted-workstation-toolbar-smoke.mjs
@@ -851,13 +851,16 @@ async function ensureCodeCell(page, timeout) {
 async function ensureCodeCellCount(page, count, timeout) {
   return smokePhase(`ensure ${count} code cells`, async () => {
     const cells = page.locator('[data-cell-type="code"]');
-    while ((await cells.count()) < count) {
+    let currentCount = await cells.count();
+    while (currentCount < count) {
+      const expectedCount = currentCount + 1;
       await page.getByTestId("add-code-cell-button").click({ timeout });
       await page.waitForFunction(
         (expected) => document.querySelectorAll('[data-cell-type="code"]').length >= expected,
-        count,
+        expectedCount,
         { timeout },
       );
+      currentCount = await cells.count();
     }
     return cells;
   });

--- a/apps/notebook-cloud/scripts/hosted-workstation-toolbar-smoke.mjs
+++ b/apps/notebook-cloud/scripts/hosted-workstation-toolbar-smoke.mjs
@@ -1109,24 +1109,36 @@ async function fetchJson({
   authKind,
   credential,
 }) {
-  const requestInit = {
-    headers: {
-      ...buildWorkstationAuthHeaders(authKind, credential),
-      "Content-Type": "application/json",
-      "X-Scope": "owner",
-    },
-    method,
-  };
-  if (body) {
-    requestInit.body = JSON.stringify(body);
-  }
+  return smokePhase(`api ${label}`, async () => {
+    const controller = new AbortController();
+    const timeout = setTimeout(
+      () => controller.abort(new Error(`${label} timed out after 15000ms`)),
+      15_000,
+    );
+    try {
+      const requestInit = {
+        headers: {
+          ...buildWorkstationAuthHeaders(authKind, credential),
+          "Content-Type": "application/json",
+          "X-Scope": "owner",
+        },
+        method,
+        signal: controller.signal,
+      };
+      if (body) {
+        requestInit.body = JSON.stringify(body);
+      }
 
-  const response = await fetch(new URL(pathname, baseUrl), requestInit);
-  const payload = await parseHttpResponseBody(response);
-  if (!expectedStatuses.includes(response.status)) {
-    throw new Error(`${label} failed: ${response.status} ${JSON.stringify(payload)}`);
-  }
-  return payload;
+      const response = await fetch(new URL(pathname, baseUrl), requestInit);
+      const payload = await parseHttpResponseBody(response);
+      if (!expectedStatuses.includes(response.status)) {
+        throw new Error(`${label} failed: ${response.status} ${JSON.stringify(payload)}`);
+      }
+      return payload;
+    } finally {
+      clearTimeout(timeout);
+    }
+  });
 }
 
 async function loadOptionalEnvFile() {

--- a/apps/notebook-cloud/src/notebook-room.ts
+++ b/apps/notebook-cloud/src/notebook-room.ts
@@ -106,7 +106,7 @@ const RUNTIME_PEER_GONE_GRACE_MS = 30_000;
 const MAX_CONSECUTIVE_REJECTED_FRAMES = 8;
 const REJECTED_FRAME_POLICY_CLOSE_CODE = 1008;
 const REJECTED_FRAME_POLICY_CLOSE_REASON = "too many rejected frames";
-const DUPLICATE_RUNTIME_PEER_CLOSE_CODE = 1000;
+const DUPLICATE_RUNTIME_PEER_CLOSE_CODE = 1008;
 const DUPLICATE_RUNTIME_PEER_CLOSE_REASON = "replaced by newer runtime peer";
 
 /// Storage key holding the notebook id whose `runtime_peer` departure armed the

--- a/apps/notebook-cloud/test/cloud-projection-flicker.test.ts
+++ b/apps/notebook-cloud/test/cloud-projection-flicker.test.ts
@@ -208,5 +208,28 @@ describe("cloud projection flicker gate", () => {
         /useEffect\(\s*\(\) => \(\) => \{\s*resetCloudViewStoreProjection\(\);\s*resetRuntimeState\(\);\s*resetRuntimeStoresProjection\(\);\s*\},\s*\[\],\s*\);/,
       );
     });
+
+    it("keys live-room reconnects by effective auth credentials, not auth object identity", () => {
+      assert.match(
+        sessionSource,
+        /const syncAuthConnectionKey = cloudSyncAuthConnectionKey\(authState, \{ hasAppSession \}\);/,
+      );
+      assert.match(
+        sessionSource,
+        /const authStateRef = useRef\(authState\);\s*authStateRef\.current = authState;[\s\S]*const hasAppSessionRef = useRef\(hasAppSession\);/,
+      );
+      const liveRoomDependencies = sessionSource.match(
+        /\[\s*blobResolver,[\s\S]*?widgetStore,\s*\]\);/,
+      )?.[0];
+      assert.ok(liveRoomDependencies, "live-room dependency list should be identifiable");
+      assert.match(
+        liveRoomDependencies,
+        /connectAttempt,\s*syncAuthConnectionKey,\s*loadingPolicy\.shouldConnectLiveRoom,/,
+      );
+      assert.doesNotMatch(
+        liveRoomDependencies,
+        /\bauthRenewalKind\b|\bauthState\b|\bhasAppSession\b/,
+      );
+    });
   });
 });

--- a/apps/notebook-cloud/test/cloud-session-auth-stability.test.ts
+++ b/apps/notebook-cloud/test/cloud-session-auth-stability.test.ts
@@ -1,0 +1,74 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+import type { CloudPrototypeAuthState } from "../viewer/collaborator-auth";
+import {
+  cloudBlobAuthStateForBrowserFetch,
+  cloudSyncAuthConnectionKey,
+} from "../viewer/session-auth-stability";
+
+function authState(overrides: Partial<CloudPrototypeAuthState> = {}): CloudPrototypeAuthState {
+  return {
+    mode: "oidc",
+    token: "token-a",
+    user: "user@example.test",
+    oidcClaims: null,
+    requestedScope: "owner",
+    problem: null,
+    ...overrides,
+  };
+}
+
+describe("cloud session auth stability", () => {
+  it("keeps cookie-backed blob fetch auth stable across OIDC token churn", () => {
+    const first = cloudBlobAuthStateForBrowserFetch(authState({ token: "token-a" }));
+    const second = cloudBlobAuthStateForBrowserFetch(authState({ token: "token-b" }));
+
+    assert.equal(first, second);
+    assert.deepEqual(first, {
+      mode: "anonymous",
+      token: null,
+      user: null,
+      oidcClaims: null,
+      requestedScope: null,
+      problem: null,
+    });
+  });
+
+  it("keeps dev-token blob fetch auth keyed by the dev headers", () => {
+    const first = cloudBlobAuthStateForBrowserFetch(
+      authState({ mode: "dev", token: "dev-a", requestedScope: "owner" }),
+    );
+    const second = cloudBlobAuthStateForBrowserFetch(
+      authState({ mode: "dev", token: "dev-b", requestedScope: "owner" }),
+    );
+
+    assert.notEqual(first, second);
+    assert.equal(first.mode, "dev");
+    assert.equal(first.token, "dev-a");
+    assert.equal(second.token, "dev-b");
+  });
+
+  it("keeps app-session live room auth keyed to the session transport mode", () => {
+    assert.equal(
+      cloudSyncAuthConnectionKey(authState({ token: "token-a" }), { hasAppSession: true }),
+      "app-session",
+    );
+    assert.equal(
+      cloudSyncAuthConnectionKey(authState({ token: "token-b" }), { hasAppSession: true }),
+      "app-session",
+    );
+  });
+
+  it("keeps token-backed live room auth keyed by effective socket credentials", () => {
+    const first = cloudSyncAuthConnectionKey(authState({ token: "token-a" }), {
+      hasAppSession: false,
+    });
+    const second = cloudSyncAuthConnectionKey(authState({ token: "token-b" }), {
+      hasAppSession: false,
+    });
+
+    assert.notEqual(first, second);
+    assert.equal(first, "oidc:token-a:user@example.test:owner");
+    assert.equal(second, "oidc:token-b:user@example.test:owner");
+  });
+});

--- a/apps/notebook-cloud/test/notebook-room.test.ts
+++ b/apps/notebook-cloud/test/notebook-room.test.ts
@@ -765,7 +765,7 @@ describe("NotebookRoom peer lifecycle", () => {
     await state.drain();
 
     assert.equal(oldSocket.closed, true);
-    assert.equal(oldSocket.closeCode, 1000);
+    assert.equal(oldSocket.closeCode, 1008);
     assert.equal(oldSocket.closeReason, "replaced by newer runtime peer");
     assert.equal(harness.peerForSocket(oldSocket.asCloudflareWebSocket()), undefined);
     assert.equal(
@@ -1549,7 +1549,7 @@ describe("NotebookRoom materialized sync routing", () => {
 
     assert.equal(harness.peers.has(sameWorkstationPeer.id), false);
     assert.equal(sameWorkstationSocket.closed, true);
-    assert.equal(sameWorkstationSocket.closeCode, 1000);
+    assert.equal(sameWorkstationSocket.closeCode, 1008);
     assert.equal(sameWorkstationSocket.closeReason, "replaced by newer runtime peer");
     assert.equal(harness.peers.has(otherWorkstationPeer.id), true);
     assert.equal(otherWorkstationSocket.closed, false);

--- a/apps/notebook-cloud/viewer/cloud-viewer-session.ts
+++ b/apps/notebook-cloud/viewer/cloud-viewer-session.ts
@@ -38,6 +38,7 @@ import {
   type CloudPrototypeAuthState,
   type CloudSyncAuth,
 } from "./collaborator-auth";
+import { cloudSyncAuthConnectionKey } from "./session-auth-stability";
 import { materializeCloudNotebookView } from "./cloud-view-model";
 import { CloudLivePresenceStore } from "./live-presence";
 import {
@@ -301,6 +302,31 @@ export function useCloudViewerSession({
   const [connectionActorLabel, setConnectionActorLabel] = useState<string | null>(null);
   const [connectionError, setConnectionError] = useState<string | null>(null);
   const [connectAttempt, setConnectAttempt] = useState(0);
+  // The live-room effect must not depend on raw auth/session object identity:
+  // browser auth refreshes can rebuild those objects without changing the
+  // effective socket credentials. Key the effect by the transport credential
+  // shape, and read the latest auth through refs at connect/diagnostic time.
+  const authStateRef = useRef(authState);
+  authStateRef.current = authState;
+  const hasAppSessionRef = useRef(hasAppSession);
+  hasAppSessionRef.current = hasAppSession;
+  const authRenewalKindRef = useRef(authRenewalKind);
+  authRenewalKindRef.current = authRenewalKind;
+  const previousAuthRenewalKindRef = useRef(authRenewalKind);
+  const syncAuthConnectionKey = cloudSyncAuthConnectionKey(authState, { hasAppSession });
+
+  useEffect(() => {
+    const previousKind = previousAuthRenewalKindRef.current;
+    previousAuthRenewalKindRef.current = authRenewalKind;
+    if (
+      previousKind === "refreshing" &&
+      authRenewalKind !== "refreshing" &&
+      loadingPolicy.shouldConnectLiveRoom &&
+      liveRuntimeRef.current === null
+    ) {
+      setConnectAttempt((attempt) => attempt + 1);
+    }
+  }, [authRenewalKind, loadingPolicy.shouldConnectLiveRoom]);
 
   // Identity of the notebook whose cells are currently painted into the
   // view stores — the flicker gate's "previous" side (see effect cleanup).
@@ -525,7 +551,7 @@ export function useCloudViewerSession({
   ]);
 
   useEffect(() => {
-    if (authRenewalKind === "refreshing") {
+    if (authRenewalKindRef.current === "refreshing") {
       return;
     }
     if (!loadingPolicy.shouldConnectLiveRoom) {
@@ -777,8 +803,8 @@ export function useCloudViewerSession({
         ranConnectionDiagnostics = true;
         void diagnoseCloudConnectionAccess({
           accessRequestsEndpoint: config.accessRequestsEndpoint,
-          authState,
-          hasAppSession,
+          authState: authStateRef.current,
+          hasAppSession: hasAppSessionRef.current,
         })
           .then((diagnostic) => {
             if (disposed || !diagnostic) return;
@@ -981,7 +1007,9 @@ export function useCloudViewerSession({
       // null (no derivable principal) skips the paint. Shared with the
       // storage bindings, which use it to pick the matching principal's
       // chunk sub-range.
-      const instantPaintMatcher = cloudInstantPaintPrincipalMatcher(authState, { hasAppSession });
+      const instantPaintMatcher = cloudInstantPaintPrincipalMatcher(authStateRef.current, {
+        hasAppSession: hasAppSessionRef.current,
+      });
       await runCloudInstantPaint({
         resolveHandle: () =>
           resolveCloudInstantPaintHandle({
@@ -1096,7 +1124,7 @@ export function useCloudViewerSession({
         resolveAuth: (attemptSessionId) =>
           resolveSyncAuth
             ? resolveSyncAuth(attemptSessionId)
-            : cloudSyncAuthFromPrototypeAuthState(authState),
+            : cloudSyncAuthFromPrototypeAuthState(authStateRef.current),
       }),
       runtimedWasmModulePath: config.runtimedWasmModulePath,
       runtimedWasmPath: config.runtimedWasmPath,
@@ -1371,8 +1399,8 @@ export function useCloudViewerSession({
         if (cloudConnectionErrorAcceptsAccessDiagnostic(message)) {
           void diagnoseCloudConnectionAccess({
             accessRequestsEndpoint: config.accessRequestsEndpoint,
-            authState,
-            hasAppSession,
+            authState: authStateRef.current,
+            hasAppSession: hasAppSessionRef.current,
           })
             .then((diagnostic) => {
               if (disposed || !diagnostic) return;
@@ -1462,8 +1490,6 @@ export function useCloudViewerSession({
       setConnectionPeerLabel(null);
     };
   }, [
-    authRenewalKind,
-    authState,
     blobResolver,
     config.accessRequestsEndpoint,
     config.blobBasePath,
@@ -1471,7 +1497,7 @@ export function useCloudViewerSession({
     config.runtimedWasmPath,
     config.syncEndpoint,
     connectAttempt,
-    hasAppSession,
+    syncAuthConnectionKey,
     loadingPolicy.shouldConnectLiveRoom,
     presenceStore,
     applyResolvedCells,

--- a/apps/notebook-cloud/viewer/notebook-viewer.tsx
+++ b/apps/notebook-cloud/viewer/notebook-viewer.tsx
@@ -63,6 +63,10 @@ import type { ConnectionScope } from "../src/auth-shared";
 
 import { useCloudViewerSession } from "./cloud-viewer-session";
 import {
+  cloudBlobAuthStateForBrowserFetch,
+  cloudSyncAuthConnectionKey,
+} from "./session-auth-stability";
+import {
   CrdtBridgeProvider,
   createNotebookCellId,
   createNotebookController,
@@ -169,6 +173,14 @@ export function NotebookViewer({
     appSessionLoading: appSessionStatus.status === "loading",
     appSession: appSessionStatus.session,
   });
+  const authStateRef = useRef(authState);
+  useEffect(() => {
+    authStateRef.current = authState;
+  }, [authState]);
+  const appSessionStatusRef = useRef(appSessionStatus);
+  useEffect(() => {
+    appSessionStatusRef.current = appSessionStatus;
+  }, [appSessionStatus]);
   useCloudAppSessionBridge(
     authState,
     appSessionStatus.session,
@@ -199,16 +211,30 @@ export function NotebookViewer({
   const [selectedInteractionMode, setSelectedInteractionMode] = useState<NotebookInteractionMode>(
     () => cloudNotebookModeFromSearch(window.location.search),
   );
+  const selectedInteractionModeRef = useRef(selectedInteractionMode);
+  useEffect(() => {
+    selectedInteractionModeRef.current = selectedInteractionMode;
+  }, [selectedInteractionMode]);
   const [emptyRoomGraceElapsed, setEmptyRoomGraceElapsed] = useState(false);
+  const blobAuthState = useMemo(
+    () => cloudBlobAuthStateForBrowserFetch(authState),
+    [
+      authState.mode,
+      authState.mode === "dev" ? authState.token : null,
+      authState.mode === "dev" ? authState.user : null,
+      authState.mode === "dev" ? authState.requestedScope : null,
+      authState.mode === "dev" ? authState.problem : null,
+    ],
+  );
   const blobResolver = useMemo(
     () =>
       createNotebookCloudBlobResolver({
         baseUrl: location.href,
         blobBasePath: config.blobBasePath,
-        fetchImpl: (input, init) => fetchWithCloudPrototypeAuth(input, init, authState),
+        fetchImpl: (input, init) => fetchWithCloudPrototypeAuth(input, init, blobAuthState),
         authenticatedBinaryDisplayUrls: true,
       }),
-    [authState, config.blobBasePath],
+    [blobAuthState, config.blobBasePath],
   );
   const preloadSiftWasm = useCallback(
     (nextCells: readonly ResolvedCell[]) => {
@@ -221,32 +247,30 @@ export function NotebookViewer({
     },
     [config.blobBasePath, config.rendererAssetsBasePath, config.rendererAssets.siftWasm],
   );
+  const syncAuthConnectionKey = cloudSyncAuthConnectionKey(authState, {
+    hasAppSession: Boolean(appSessionStatus.session),
+  });
   const resolveSyncAuth = useCallback(
     async (sessionId: string) => {
+      const currentAppSessionStatus = appSessionStatusRef.current;
       const appSession =
-        appSessionStatus.session ??
-        (appSessionStatus.status === "loading"
+        currentAppSessionStatus.session ??
+        (currentAppSessionStatus.status === "loading"
           ? ((await readCloudAppSessionStatus().catch(() => null))?.session ?? null)
           : null);
       if (appSession) {
         const requestedScope = await resolveCloudAppSessionSyncScope(
           config.notebookId,
-          selectedInteractionMode,
+          selectedInteractionModeRef.current,
         );
         return cloudSyncAuthFromAppSessionCookie({
           requestedScope,
           sessionId,
         });
       }
-      return cloudSyncAuthFromPrototypeAuthState(authState);
+      return cloudSyncAuthFromPrototypeAuthState(authStateRef.current);
     },
-    [
-      appSessionStatus.session,
-      appSessionStatus.status,
-      authState,
-      config.notebookId,
-      selectedInteractionMode,
-    ],
+    [config.notebookId, syncAuthConnectionKey],
   );
   const {
     connectionActorLabel,

--- a/apps/notebook-cloud/viewer/notebook-viewer.tsx
+++ b/apps/notebook-cloud/viewer/notebook-viewer.tsx
@@ -211,6 +211,10 @@ export function NotebookViewer({
   const [selectedInteractionMode, setSelectedInteractionMode] = useState<NotebookInteractionMode>(
     () => cloudNotebookModeFromSearch(window.location.search),
   );
+  // Scope resolution reads the latest selected mode at connect time, but
+  // access-mode correction itself must not rebuild the live-room callback:
+  // viewer-owned `?mode=edit` links are corrected to view mode after access is
+  // known, and making that correction a dependency tears the room down.
   const selectedInteractionModeRef = useRef(selectedInteractionMode);
   useEffect(() => {
     selectedInteractionModeRef.current = selectedInteractionMode;

--- a/apps/notebook-cloud/viewer/session-auth-stability.ts
+++ b/apps/notebook-cloud/viewer/session-auth-stability.ts
@@ -12,6 +12,8 @@ const CLOUD_COOKIE_BLOB_AUTH_STATE: CloudPrototypeAuthState = Object.freeze({
 export function cloudBlobAuthStateForBrowserFetch(
   authState: CloudPrototypeAuthState,
 ): CloudPrototypeAuthState {
+  // Cookie/app-session browser fetches do not add OIDC bearer headers, so they
+  // intentionally share one stable auth object across OIDC token refreshes.
   if (authState.mode !== "dev") {
     return CLOUD_COOKIE_BLOB_AUTH_STATE;
   }
@@ -29,6 +31,9 @@ export function cloudSyncAuthConnectionKey(
   authState: CloudPrototypeAuthState,
   options: { hasAppSession: boolean },
 ): string {
+  // App-session sockets authenticate with HttpOnly cookies plus a per-attempt
+  // operator nonce, not the localStorage OIDC object. Keep the connection key
+  // stable across equivalent session refreshes.
   if (options.hasAppSession) {
     return "app-session";
   }

--- a/apps/notebook-cloud/viewer/session-auth-stability.ts
+++ b/apps/notebook-cloud/viewer/session-auth-stability.ts
@@ -1,0 +1,41 @@
+import type { CloudPrototypeAuthState } from "./collaborator-auth";
+
+const CLOUD_COOKIE_BLOB_AUTH_STATE: CloudPrototypeAuthState = Object.freeze({
+  mode: "anonymous",
+  token: null,
+  user: null,
+  oidcClaims: null,
+  requestedScope: null,
+  problem: null,
+});
+
+export function cloudBlobAuthStateForBrowserFetch(
+  authState: CloudPrototypeAuthState,
+): CloudPrototypeAuthState {
+  if (authState.mode !== "dev") {
+    return CLOUD_COOKIE_BLOB_AUTH_STATE;
+  }
+  return {
+    mode: "dev",
+    token: authState.token,
+    user: authState.user,
+    oidcClaims: null,
+    requestedScope: authState.requestedScope,
+    problem: authState.problem,
+  };
+}
+
+export function cloudSyncAuthConnectionKey(
+  authState: CloudPrototypeAuthState,
+  options: { hasAppSession: boolean },
+): string {
+  if (options.hasAppSession) {
+    return "app-session";
+  }
+  return [
+    authState.mode,
+    authState.token ?? "",
+    authState.user ?? "",
+    authState.requestedScope ?? "",
+  ].join(":");
+}

--- a/crates/notebook-cloud-transport/src/lib.rs
+++ b/crates/notebook-cloud-transport/src/lib.rs
@@ -303,14 +303,15 @@ fn cloud_frame_rejection_error(payload: &[u8]) -> Option<std::io::Error> {
 
 fn terminal_cloud_close_error(code: Option<u16>, reason: &str) -> Option<std::io::Error> {
     let reason = reason.trim();
-    let terminal_by_code = matches!(code, Some(1008));
     let terminal_by_reason = matches!(
         reason,
-        "replaced by newer runtime peer"
+        "too many rejected frames"
+            | "replaced by newer runtime peer"
             | "workstation attachment replaced"
             | "workstation restart requested"
+            | "workstation mismatch"
     );
-    if !terminal_by_code && !terminal_by_reason {
+    if !terminal_by_reason {
         return None;
     }
 
@@ -908,6 +909,8 @@ mod tests {
         let policy = terminal_cloud_close_error(Some(1008), "too many rejected frames")
             .expect("policy close should be terminal");
         assert_eq!(policy.kind(), std::io::ErrorKind::PermissionDenied);
+
+        assert!(terminal_cloud_close_error(Some(1008), "runtime state repair").is_none());
 
         let replacement = terminal_cloud_close_error(Some(1000), "replaced by newer runtime peer")
             .expect("replacement reason should be terminal even on normal close code");

--- a/crates/notebook-cloud-transport/src/lib.rs
+++ b/crates/notebook-cloud-transport/src/lib.rs
@@ -301,6 +301,34 @@ fn cloud_frame_rejection_error(payload: &[u8]) -> Option<std::io::Error> {
     ))
 }
 
+fn terminal_cloud_close_error(code: Option<u16>, reason: &str) -> Option<std::io::Error> {
+    let reason = reason.trim();
+    let terminal_by_code = matches!(code, Some(1008));
+    let terminal_by_reason = matches!(
+        reason,
+        "replaced by newer runtime peer"
+            | "workstation attachment replaced"
+            | "workstation restart requested"
+    );
+    if !terminal_by_code && !terminal_by_reason {
+        return None;
+    }
+
+    Some(std::io::Error::new(
+        std::io::ErrorKind::PermissionDenied,
+        format!(
+            "cloud room closed runtime peer: code={} reason={}",
+            code.map(|value| value.to_string())
+                .unwrap_or_else(|| "none".to_string()),
+            if reason.is_empty() {
+                "(no reason given)"
+            } else {
+                reason
+            }
+        ),
+    ))
+}
+
 /// Read frames from `source` until the room reaches a terminal ready state,
 /// returning the authenticated principal from `cloud_room_ready`.
 ///
@@ -393,8 +421,25 @@ impl FrameSource for CloudWsSource {
                     // Empty / unknown frame: skip, keep reading.
                     None => continue,
                 },
-                Some(Ok(msg)) if msg.is_close() => {
-                    info!("[cloud-transport] room closed the connection");
+                Some(Ok(WsMessage::Close(frame))) => {
+                    let (code, reason) = match frame {
+                        Some(frame) => (Some(u16::from(frame.code)), frame.reason.to_string()),
+                        None => (None, String::new()),
+                    };
+                    if let Some(error) = terminal_cloud_close_error(code, &reason) {
+                        warn!("[cloud-transport] {error}");
+                        return Some(Err(error));
+                    }
+                    info!(
+                        "[cloud-transport] room closed the connection code={} reason={}",
+                        code.map(|value| value.to_string())
+                            .unwrap_or_else(|| "none".to_string()),
+                        if reason.is_empty() {
+                            "(no reason given)"
+                        } else {
+                            reason.as_str()
+                        }
+                    );
                     return None;
                 }
                 // Ping/pong/text/frame: ignore and keep reading.
@@ -856,6 +901,31 @@ mod tests {
         assert!(error
             .to_string()
             .contains("frame_type=runtime_state_sync reason=rejected"));
+    }
+
+    #[test]
+    fn terminal_cloud_close_error_marks_policy_and_replacement_closes_terminal() {
+        let policy = terminal_cloud_close_error(Some(1008), "too many rejected frames")
+            .expect("policy close should be terminal");
+        assert_eq!(policy.kind(), std::io::ErrorKind::PermissionDenied);
+
+        let replacement = terminal_cloud_close_error(Some(1000), "replaced by newer runtime peer")
+            .expect("replacement reason should be terminal even on normal close code");
+        assert_eq!(replacement.kind(), std::io::ErrorKind::PermissionDenied);
+
+        let restart = terminal_cloud_close_error(Some(1012), "workstation restart requested")
+            .expect("workstation restart close should be terminal for the old peer");
+        assert!(restart
+            .to_string()
+            .contains("workstation restart requested"));
+    }
+
+    #[test]
+    fn terminal_cloud_close_error_keeps_ordinary_clean_closes_recoverable() {
+        assert!(terminal_cloud_close_error(Some(1000), "").is_none());
+        assert!(terminal_cloud_close_error(Some(1001), "going away").is_none());
+        assert!(terminal_cloud_close_error(None, "").is_none());
+        assert!(terminal_cloud_close_error(Some(1012), "server restart").is_none());
     }
 
     #[test]

--- a/crates/runtimed/src/workstation/agent_loop.rs
+++ b/crates/runtimed/src/workstation/agent_loop.rs
@@ -554,6 +554,7 @@ struct ActiveJob {
     child: Option<tokio::process::Child>,
     pid: Option<u32>,
     log_path: PathBuf,
+    pid_path: PathBuf,
     ready: bool,
     status: &'static str,
     started_at: Instant,
@@ -879,6 +880,7 @@ async fn start_attach_job(
                     child: Some(child),
                     pid,
                     log_path: plan.log_path,
+                    pid_path: plan.pid_path,
                     ready: false,
                     status: "accepted",
                     started_at: now,
@@ -941,6 +943,7 @@ async fn reconcile_active_attach_job(
                 child: None,
                 pid: Some(pid),
                 log_path: plan.log_path,
+                pid_path: plan.pid_path,
                 ready,
                 status: if ready { "running" } else { "accepted" },
                 started_at: backdated,
@@ -1081,7 +1084,9 @@ async fn tick_active_jobs(
                 success,
                 error_message,
             } => {
-                active.remove(&job_id);
+                if let Some(job) = active.remove(&job_id) {
+                    remove_stale_pid_file(&job.pid_path);
+                }
                 info!(
                     "[workstation-agent] attach job exited job_id={job_id} success={success} error={:?}",
                     error_message
@@ -1125,6 +1130,7 @@ async fn drop_terminal_attach_job(
     }
     let job = active.remove(job_id);
     if let Some(job) = job {
+        remove_stale_pid_file(&job.pid_path);
         terminate_active_job(job).await;
     }
     info!(
@@ -1414,6 +1420,7 @@ mod tests {
             child: None,
             pid: None,
             log_path: PathBuf::from("/tmp/runtime-peer.log"),
+            pid_path: PathBuf::from("/tmp/runtime-peer.pid"),
             ready: true,
             status: "running",
             started_at: Instant::now(),
@@ -1523,6 +1530,24 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn terminal_attach_job_patch_removes_local_pid_file() -> Result<()> {
+        let tmp = tempfile::TempDir::new()?;
+        let pid_path = tmp.path().join("runtime-peer.pid");
+        std::fs::write(&pid_path, "123\n")?;
+        let mut job = active_job();
+        job.pid_path = pid_path.clone();
+        let mut active = HashMap::from([("job-1".to_string(), job)]);
+        let error = http_error(
+            409,
+            json!({ "error": "workstation attach job is no longer active" }),
+        );
+
+        assert!(drop_terminal_attach_job(&mut active, "job-1", "heartbeat", &error).await);
+        assert!(!pid_path.exists());
+        Ok(())
+    }
+
+    #[tokio::test]
     async fn non_terminal_attach_job_patch_keeps_local_active_job() {
         let mut active = HashMap::from([("job-1".to_string(), active_job())]);
         let error = http_error(503, json!({ "error": "temporarily unavailable" }));
@@ -1576,6 +1601,7 @@ mod tests {
             child: Some(child),
             pid: None,
             log_path: tmp.path().join("runtime-peer.log"),
+            pid_path: tmp.path().join("runtime-peer.pid"),
             ready: true,
             status: "running",
             started_at: Instant::now(),

--- a/crates/runtimed/src/workstation/agent_loop.rs
+++ b/crates/runtimed/src/workstation/agent_loop.rs
@@ -957,16 +957,51 @@ async fn reconcile_active_attach_job(
         job.status,
         plan.pid_path.display()
     );
-    api.patch_attach_job(
-        &opts.workstation_id,
-        &job.job_id,
-        "failed",
-        Some(&format!(
-            "Runtime peer for {} attach job was not running after workstation agent restart",
-            job.status
-        )),
-    )
-    .await
+    let failure_message = format!(
+        "Runtime peer for {} attach job was not running after workstation agent restart",
+        job.status
+    );
+    match api
+        .patch_attach_job(
+            &opts.workstation_id,
+            &job.job_id,
+            "failed",
+            Some(&failure_message),
+        )
+        .await
+    {
+        Ok(()) => {
+            remove_stale_pid_file(&plan.pid_path);
+            Ok(())
+        }
+        Err(error) if attach_job_patch_no_longer_active(&error) => {
+            remove_stale_pid_file(&plan.pid_path);
+            info!(
+                "[workstation-agent] recovery patch ignored for inactive job job_id={}",
+                job.job_id
+            );
+            Ok(())
+        }
+        Err(error) => Err(error),
+    }
+}
+
+fn remove_stale_pid_file(path: &Path) {
+    match std::fs::remove_file(path) {
+        Ok(()) => {
+            info!(
+                "[workstation-agent] removed stale runtime peer pid file path={}",
+                path.display()
+            );
+        }
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => {}
+        Err(error) => {
+            warn!(
+                "[workstation-agent] stale pid file cleanup failed path={}: {error}",
+                path.display()
+            );
+        }
+    }
 }
 
 async fn heartbeat_active_jobs(
@@ -1494,6 +1529,20 @@ mod tests {
 
         assert!(!drop_terminal_attach_job(&mut active, "job-1", "heartbeat", &error).await);
         assert!(active.contains_key("job-1"));
+    }
+
+    #[test]
+    fn stale_pid_file_cleanup_removes_existing_file_and_ignores_missing() -> Result<()> {
+        let tmp = tempfile::TempDir::new()?;
+        let pid_path = tmp.path().join("runtime-peer.pid");
+        std::fs::write(&pid_path, "123\n")?;
+
+        remove_stale_pid_file(&pid_path);
+        assert!(!pid_path.exists());
+
+        remove_stale_pid_file(&pid_path);
+        assert!(!pid_path.exists());
+        Ok(())
     }
 
     #[cfg(unix)]


### PR DESCRIPTION
## Summary
- closes replaced runtime peers with policy close semantics and makes the runtime transport treat those closes as terminal, stopping stale workstation peers from reconnecting after replacement/restart
- narrows terminal transport close handling to explicit policy/replacement/restart reasons so recoverable server closes, including runtime-state repair, can still reconnect
- keeps app-session/cookie-backed live room auth dependencies stable across OIDC token/session object churn by keying `useCloudViewerSession` on effective sync credentials instead of raw auth object identity
- adds bounded setup timeouts and a more robust cell-count helper to the hosted workstation toolbar smoke so API/UI hangs fail loudly instead of stalling the run
- cleans up stale workstation attach pid files after restart recovery reports a missing runtime peer, preventing dead local recovery state from recurring across restarts

## Validation
- `pnpm --dir apps/notebook-cloud exec tsc --noEmit`
- `pnpm --dir apps/notebook-cloud exec node --import tsx --test test/cloud-projection-flicker.test.ts test/cloud-session-auth-stability.test.ts`
- `pnpm --dir apps/notebook-cloud exec node --import tsx --test test/cloud-session-auth-stability.test.ts test/cloud-notebook-mode.test.ts test/use-cloud-auth-session-identity.test.ts`
- `pnpm --dir apps/notebook-cloud test` (999 tests)
- `cargo test -p notebook-cloud-transport terminal_cloud_close_error`
- `cargo test -p runtimed --lib workstation::agent_loop`
- `cargo build -p runt -p runtimed`
- `cargo xtask lint --fix`
- deployed preview at `9ed85d426f4d79215ce8d3e0ca4d5dfe92d2fc0a` (`/api/health` reports that SHA)
- restarted `ws-lab2` from the rebuilt local binaries via `setsid`
- live smoke passed: `NOTEBOOK_CLOUD_WORKSTATION_TOOLBAR_SMOKE_AUTH_KIND=oidc NOTEBOOK_CLOUD_WORKSTATION_TOOLBAR_SMOKE_WORKSTATION_ID=ws-lab2 NOTEBOOK_CLOUD_WORKSTATION_TOOLBAR_SMOKE_TIMEOUT_MS=90000 NOTEBOOK_CLOUD_WORKSTATION_TOOLBAR_SMOKE_OUTPUT_PROBES=1 pnpm --dir apps/notebook-cloud run smoke:hosted:workstation-toolbar`

## Review focus
Please review this adversarially for hotfix risk: auth/session state can churn during page load, access downgrades, cookie refresh, and reconnect. Look for any remaining React dependency or resolver identity change that can tear down `useCloudViewerSession` without a real notebook, wasm asset, auth credential, or sync endpoint change.

Also check transport close-code handling: replacement/restart/policy closes should stop stale runtime peer reconnect loops, but recoverable server closes should still reconnect.

For the workstation agent, check restart recovery behavior around stale local pid files and server-side attach jobs that are already inactive.
