### PR TITLE
fix(notebook-cloud): name dashboard search input

### DIFF
--- a/apps/notebook-cloud/test/viewer-shared-cell-surface.test.ts
+++ b/apps/notebook-cloud/test/viewer-shared-cell-surface.test.ts
@@ -20,6 +20,19 @@ test("cloud notebook body renders through the desktop NotebookView surface", () 
   assert.doesNotMatch(sourceText, /<NotebookReadOnlyView/);
 });
 
+test("cloud notebook dashboard search input has stable form metadata", () => {
+  const dashboardSourcePath = new URL(
+    "../viewer/cloud-notebook-dashboard-view.tsx",
+    import.meta.url,
+  );
+  const dashboardSourceText = readFileSync(dashboardSourcePath, "utf8");
+
+  assert.match(dashboardSourceText, /id="cloud-dashboard-search-input"/);
+  assert.match(dashboardSourceText, /name="notebook-search"/);
+  assert.match(dashboardSourceText, /type="search"/);
+  assert.match(dashboardSourceText, /aria-label="Search notebooks"/);
+});
+
 test("cloud viewer imports desktop notebook code only through public surfaces", () => {
   const viewerDir = new URL("../viewer", import.meta.url);
   const offenders: string[] = [];

--- a/apps/notebook-cloud/viewer/cloud-notebook-dashboard-view.tsx
+++ b/apps/notebook-cloud/viewer/cloud-notebook-dashboard-view.tsx
@@ -88,6 +88,8 @@ export function CloudNotebookDashboard({
             <label className="cloud-dashboard-search">
               <Search aria-hidden="true" />
               <input
+                id="cloud-dashboard-search-input"
+                name="notebook-search"
                 type="search"
                 value={query}
                 placeholder="Search notebooks"


### PR DESCRIPTION
## Summary
- add stable `id` and `name` metadata to the cloud dashboard notebook search field
- keep the existing accessible label and add a source guard for the form metadata

## Context
DevTools reported `A form field element should have an id or name attribute` during the authenticated `/n` cloud audit. The affected node was the notebook search input.

## Verification
- `pnpm --dir apps/notebook-cloud exec node --import tsx --test test/viewer-shared-cell-surface.test.ts`
- `pnpm --dir apps/notebook-cloud typecheck`
- `cargo xtask lint --fix`