### PR TITLE
fix(notebook-cloud): polish hosted shell diagnostics

### DIFF
--- a/apps/notebook-cloud/scripts/hosted-render-smoke-runtime-wasm.mjs
+++ b/apps/notebook-cloud/scripts/hosted-render-smoke-runtime-wasm.mjs
@@ -13,9 +13,9 @@ export function checkRuntimeWasmHints(hints, options = {}) {
       relIncludes(hint.rel, "modulepreload") &&
       matchesRuntimeWasmFilename(hint.href, RUNTIMED_WASM_MODULE_FILENAME),
   );
-  const wasmPreload = hints.find(
+  const wasmPrefetch = hints.find(
     (hint) =>
-      relIncludes(hint.rel, "preload") &&
+      relIncludes(hint.rel, "prefetch") &&
       matchesRuntimeWasmFilename(hint.href, RUNTIMED_WASM_BINARY_FILENAME),
   );
 
@@ -25,10 +25,10 @@ export function checkRuntimeWasmHints(hints, options = {}) {
       text: `Missing ${RUNTIMED_WASM_MODULE_NAME} modulepreload hint`,
     });
   }
-  if (requireHints && !wasmPreload) {
+  if (requireHints && !wasmPrefetch) {
     failures.push({
       kind: "runtimed-wasm-hint",
-      text: `Missing ${RUNTIMED_WASM_BINARY_NAME} preload hint`,
+      text: `Missing ${RUNTIMED_WASM_BINARY_NAME} prefetch hint`,
     });
   }
 
@@ -41,32 +41,32 @@ export function checkRuntimeWasmHints(hints, options = {}) {
       `${RUNTIMED_WASM_MODULE_NAME} modulepreload`,
     );
   }
-  if (wasmPreload) {
-    if (wasmPreload.as !== "fetch") {
+  if (wasmPrefetch) {
+    if (wasmPrefetch.as !== "fetch") {
       failures.push({
         kind: "runtimed-wasm-hint",
-        text: `${RUNTIMED_WASM_BINARY_NAME} preload used as=${JSON.stringify(wasmPreload.as)}`,
+        text: `${RUNTIMED_WASM_BINARY_NAME} prefetch used as=${JSON.stringify(wasmPrefetch.as)}`,
       });
     }
-    if (wasmPreload.type !== "application/wasm") {
+    if (wasmPrefetch.type !== "application/wasm") {
       failures.push({
         kind: "runtimed-wasm-hint",
-        text: `${RUNTIMED_WASM_BINARY_NAME} preload used type=${JSON.stringify(wasmPreload.type)}`,
+        text: `${RUNTIMED_WASM_BINARY_NAME} prefetch used type=${JSON.stringify(wasmPrefetch.type)}`,
       });
     }
-    assertCrossOrigin(wasmPreload, failures, `${RUNTIMED_WASM_BINARY_NAME} preload`);
+    assertCrossOrigin(wasmPrefetch, failures, `${RUNTIMED_WASM_BINARY_NAME} prefetch`);
     assertExpectedOrigin(
-      wasmPreload,
+      wasmPrefetch,
       expectedRuntimeWasmOrigin,
       failures,
-      `${RUNTIMED_WASM_BINARY_NAME} preload`,
+      `${RUNTIMED_WASM_BINARY_NAME} prefetch`,
     );
   }
 
   return {
     ok: failures.length === 0,
     modulepreload: modulepreload ?? null,
-    wasmPreload: wasmPreload ?? null,
+    wasmPrefetch: wasmPrefetch ?? null,
     runtimedWasmHints: hints.filter((hint) => isRuntimeWasmAssetHref(hint.href)),
     failures,
   };

--- a/apps/notebook-cloud/src/index.ts
+++ b/apps/notebook-cloud/src/index.ts
@@ -4215,7 +4215,7 @@ function viewerResourceHints(config: ViewerShellConfig | null): string {
     ]),
     viewerEntryHint,
     `<link rel="modulepreload" href="${escapeHtml(config.runtimedWasmModulePath)}" crossorigin />`,
-    `<link rel="preload" href="${escapeHtml(
+    `<link rel="prefetch" href="${escapeHtml(
       config.runtimedWasmPath,
     )}" as="fetch" type="application/wasm" crossorigin />`,
   ].join("\n  ");

--- a/apps/notebook-cloud/src/index.ts
+++ b/apps/notebook-cloud/src/index.ts
@@ -143,6 +143,11 @@ const VIEWER_RENDERER_SIDECAR_MANIFEST_PATH = "/assets/renderer-sidecar-assets.j
 const VIEWER_ISOLATED_RENDERER_JS_NAME = "isolated-renderer.js";
 const VIEWER_ISOLATED_RENDERER_CSS_NAME = "isolated-renderer.css";
 const VIEWER_SIFT_WASM_NAME = "sift_wasm.wasm";
+const NOTEBOOK_CLOUD_FAVICON_SVG = `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <rect width="32" height="32" rx="7" fill="#111827"/>
+  <path d="M9 9.5h14v13H9z" fill="none" stroke="#f9fafb" stroke-width="2"/>
+  <path d="M13 14h6M13 18h4" stroke="#38bdf8" stroke-width="2" stroke-linecap="round"/>
+</svg>`;
 const SNAPSHOT_BLOB_HEAD_CONCURRENCY = 16;
 // One R2 HEAD is issued per referenced blob during snapshot-pair validation.
 // Cap the total so a single publish cannot fan out unbounded billable R2
@@ -184,6 +189,11 @@ const NOTEBOOK_CLOUD_ROUTES: readonly WorkerRoute[] = [
     match: exactPath("/api/health"),
     methods: ["GET"],
     handler: routeHealth,
+  },
+  {
+    match: exactPath("/favicon.ico", "/favicon.svg"),
+    methods: ["GET", "HEAD"],
+    handler: (_match, request) => routeFavicon(request),
   },
   {
     match: exactPath("/api/auth/session"),
@@ -412,6 +422,20 @@ function normalizedBuildSha(value: string | undefined): string | null {
     return null;
   }
   return trimmed.toLowerCase();
+}
+
+function routeFavicon(request: Request): Response {
+  return responseForRequestMethod(
+    request,
+    withCors(
+      new Response(NOTEBOOK_CLOUD_FAVICON_SVG, {
+        headers: {
+          "Cache-Control": "public, max-age=86400",
+          "Content-Type": "image/svg+xml; charset=utf-8",
+        },
+      }),
+    ),
+  );
 }
 
 async function routeAsset(request: Request, env: Env): Promise<Response | null> {
@@ -4138,6 +4162,7 @@ function viewerShell(
   <meta property="og:description" content="${description}" />
   <meta property="og:type" content="article" />
   <meta name="twitter:card" content="summary" />
+  <link rel="icon" href="/favicon.svg" type="image/svg+xml" />
   <style id="nteract-cloud-viewer-theme-surface">${viewerThemeFirstPaintStyle()}</style>
   <script>${viewerThemeBootstrapScript()}</script>
   ${viewerResourceHints(config)}

--- a/apps/notebook-cloud/src/index.ts
+++ b/apps/notebook-cloud/src/index.ts
@@ -221,7 +221,8 @@ const NOTEBOOK_CLOUD_ROUTES: readonly WorkerRoute[] = [
   {
     match: routePath("/n/:notebookId/:vanityName", { trailingSlash: "optional" }),
     methods: ["GET", "HEAD"],
-    handler: ({ params }, request, env) => viewer(params.notebookId, request, env),
+    handler: ({ params }, request, env) =>
+      viewer(params.notebookId, request, env, undefined, params.vanityName),
   },
   {
     match: exactPath("/api/n"),
@@ -3961,8 +3962,14 @@ async function viewer(
   request: Request,
   env: Env,
   headsHash?: string,
+  routeTitleSegment?: string,
 ): Promise<Response> {
-  const shellMetadata = await publicViewerShellMetadata(env, notebookId, headsHash);
+  const shellMetadata = await publicViewerShellMetadata(
+    env,
+    notebookId,
+    headsHash,
+    routeTitleSegment,
+  );
   const notebookApiBasePath = `/api/n/${encodeURIComponent(notebookId)}`;
   const runtimeWasmAssets = await runtimeWasmAssetNames(env);
   const rendererSidecarAssets = await rendererSidecarAssetNames(env);
@@ -4063,8 +4070,9 @@ async function publicViewerShellMetadata(
   env: Env,
   notebookId: string,
   headsHash?: string,
+  routeTitleSegment?: string,
 ): Promise<ViewerShellMetadata> {
-  const generic = genericNotebookShellMetadata(notebookId, headsHash);
+  const generic = genericNotebookShellMetadata(notebookId, headsHash, routeTitleSegment);
   if (!env.DB) {
     return generic;
   }
@@ -4084,13 +4092,55 @@ async function publicViewerShellMetadata(
   };
 }
 
-function genericNotebookShellMetadata(notebookId: string, headsHash?: string): ViewerShellMetadata {
+function genericNotebookShellMetadata(
+  notebookId: string,
+  headsHash?: string,
+  routeTitleSegment?: string,
+): ViewerShellMetadata {
+  const routeTitle = notebookRouteSegmentTitle(routeTitleSegment);
+  if (routeTitle) {
+    return {
+      title: `nteract notebook: ${routeTitle}`,
+      description:
+        "A hosted nteract notebook. Private notebook metadata is shown after access is verified.",
+    };
+  }
   const suffix = headsHash ? ` @ ${headsHash}` : "";
   return {
     title: `nteract cloud notebook ${notebookId}${suffix}`,
     description:
       "A hosted nteract notebook. Private notebook metadata is shown after access is verified.",
   };
+}
+
+function notebookRouteSegmentTitle(value: string | null | undefined): string | null {
+  const decoded = safeDecodeRouteSegment(value);
+  if (!decoded) {
+    return null;
+  }
+  return decoded
+    .replace(/[-_]+/g, " ")
+    .replace(/\s+/g, " ")
+    .trim()
+    .split(" ")
+    .map((word) => {
+      if (!word) {
+        return word;
+      }
+      return `${word[0]?.toUpperCase() ?? ""}${word.slice(1).toLowerCase()}`;
+    })
+    .join(" ");
+}
+
+function safeDecodeRouteSegment(value: string | null | undefined): string | null {
+  if (!value) {
+    return null;
+  }
+  try {
+    return decodeURIComponent(value).trim() || null;
+  } catch {
+    return value.trim() || null;
+  }
 }
 
 function shortNotebookId(value: string): string {

--- a/apps/notebook-cloud/src/index.ts
+++ b/apps/notebook-cloud/src/index.ts
@@ -71,6 +71,7 @@ import {
   workstationPairingStatus,
 } from "./workstation-credentials.ts";
 import { materializeSnapshotPairRender } from "./snapshot-render.ts";
+import { notebookRouteSegmentTitle } from "./notebook-route-title.ts";
 import {
   createNotebookCloudBlobResolver,
   notebookCloudBlobBasePath,
@@ -4111,36 +4112,6 @@ function genericNotebookShellMetadata(
     description:
       "A hosted nteract notebook. Private notebook metadata is shown after access is verified.",
   };
-}
-
-function notebookRouteSegmentTitle(value: string | null | undefined): string | null {
-  const decoded = safeDecodeRouteSegment(value);
-  if (!decoded) {
-    return null;
-  }
-  return decoded
-    .replace(/[-_]+/g, " ")
-    .replace(/\s+/g, " ")
-    .trim()
-    .split(" ")
-    .map((word) => {
-      if (!word) {
-        return word;
-      }
-      return `${word[0]?.toUpperCase() ?? ""}${word.slice(1).toLowerCase()}`;
-    })
-    .join(" ");
-}
-
-function safeDecodeRouteSegment(value: string | null | undefined): string | null {
-  if (!value) {
-    return null;
-  }
-  try {
-    return decodeURIComponent(value).trim() || null;
-  } catch {
-    return value.trim() || null;
-  }
 }
 
 function shortNotebookId(value: string): string {

--- a/apps/notebook-cloud/src/notebook-route-title.ts
+++ b/apps/notebook-cloud/src/notebook-route-title.ts
@@ -1,0 +1,36 @@
+export function notebookRouteSegmentTitle(value: string | null | undefined): string | null {
+  const decoded = safeDecodeNotebookRouteSegment(value);
+  if (!decoded) {
+    return null;
+  }
+  return humanizeNotebookRouteTitle(decoded);
+}
+
+export function humanizeNotebookRouteTitle(value: string): string {
+  return value
+    .replace(/[-_]+/g, " ")
+    .replace(/\s+/g, " ")
+    .trim()
+    .split(" ")
+    .map((word) => {
+      if (!word) {
+        return word;
+      }
+      if (/[A-Z]/u.test(word.slice(1))) {
+        return word;
+      }
+      return `${word[0]?.toUpperCase() ?? ""}${word.slice(1).toLowerCase()}`;
+    })
+    .join(" ");
+}
+
+function safeDecodeNotebookRouteSegment(value: string | null | undefined): string | null {
+  if (!value) {
+    return null;
+  }
+  try {
+    return decodeURIComponent(value).trim() || null;
+  } catch {
+    return value.trim() || null;
+  }
+}

--- a/apps/notebook-cloud/test/cloud-access-request-state.test.ts
+++ b/apps/notebook-cloud/test/cloud-access-request-state.test.ts
@@ -2,6 +2,7 @@ import assert from "node:assert/strict";
 import { describe, it } from "node:test";
 import {
   cloudPrototypeAuthCarriesRequestedScope,
+  projectCloudAccessRequestNotice,
   projectCloudAccessRequestTransition,
 } from "../viewer/cloud-access-request-state";
 import type { CloudPrototypeAuthState } from "../viewer/collaborator-auth";
@@ -129,6 +130,54 @@ describe("cloud access-request state projection", () => {
         selectedMode: null,
         refreshPrototypeAuth: false,
         retryLiveConnection: false,
+      },
+    );
+  });
+
+  it("keeps stored edit-request notices passive in explicit view mode", () => {
+    assert.equal(
+      projectCloudAccessRequestNotice({
+        error: null,
+        request: { status: "pending" },
+        selectedMode: "view",
+      }),
+      null,
+    );
+    assert.equal(
+      projectCloudAccessRequestNotice({
+        error: null,
+        request: { status: "denied" },
+        selectedMode: "view",
+      }),
+      null,
+    );
+  });
+
+  it("projects user-facing edit-request notices for explicit edit mode", () => {
+    assert.deepEqual(
+      projectCloudAccessRequestNotice({
+        error: null,
+        request: { status: "pending" },
+        selectedMode: "edit",
+      }),
+      {
+        kind: "pending",
+        tone: "info",
+        title: "Edit access requested.",
+        message: "The owner can review this request from the sharing panel.",
+      },
+    );
+    assert.deepEqual(
+      projectCloudAccessRequestNotice({
+        error: "network failed",
+        request: null,
+        selectedMode: "view",
+      }),
+      {
+        kind: "error",
+        tone: "error",
+        title: "Edit request failed.",
+        message: "network failed",
       },
     );
   });

--- a/apps/notebook-cloud/test/cloud-access-request-state.test.ts
+++ b/apps/notebook-cloud/test/cloud-access-request-state.test.ts
@@ -4,6 +4,7 @@ import {
   cloudPrototypeAuthCarriesRequestedScope,
   projectCloudAccessRequestNotice,
   projectCloudAccessRequestTransition,
+  shouldLoadOwnCloudAccessRequest,
 } from "../viewer/cloud-access-request-state";
 import type { CloudPrototypeAuthState } from "../viewer/collaborator-auth";
 
@@ -179,6 +180,49 @@ describe("cloud access-request state projection", () => {
         title: "Edit request failed.",
         message: "network failed",
       },
+    );
+  });
+
+  it("loads own edit-request state only for explicit editable viewer intent", () => {
+    assert.equal(
+      shouldLoadOwnCloudAccessRequest({
+        canUseAuthenticatedCloudApi: true,
+        catalogGrantsDocumentEdit: false,
+        connectionScope: "viewer",
+        hasBrowserAppIdentity: true,
+        selectedMode: "edit",
+      }),
+      true,
+    );
+    assert.equal(
+      shouldLoadOwnCloudAccessRequest({
+        canUseAuthenticatedCloudApi: true,
+        catalogGrantsDocumentEdit: false,
+        connectionScope: "viewer",
+        hasBrowserAppIdentity: true,
+        selectedMode: "view",
+      }),
+      false,
+    );
+    assert.equal(
+      shouldLoadOwnCloudAccessRequest({
+        canUseAuthenticatedCloudApi: true,
+        catalogGrantsDocumentEdit: true,
+        connectionScope: "viewer",
+        hasBrowserAppIdentity: true,
+        selectedMode: "edit",
+      }),
+      false,
+    );
+    assert.equal(
+      shouldLoadOwnCloudAccessRequest({
+        canUseAuthenticatedCloudApi: true,
+        catalogGrantsDocumentEdit: false,
+        connectionScope: "editor",
+        hasBrowserAppIdentity: true,
+        selectedMode: "edit",
+      }),
+      false,
     );
   });
 });

--- a/apps/notebook-cloud/test/cloud-access-request-state.test.ts
+++ b/apps/notebook-cloud/test/cloud-access-request-state.test.ts
@@ -24,6 +24,7 @@ describe("cloud access-request state projection", () => {
         connectionScope: "viewer",
         hasAppSession: true,
         request: { status: "pending" },
+        selectedMode: "edit",
       }),
       {
         requestedScope: "editor",
@@ -41,6 +42,7 @@ describe("cloud access-request state projection", () => {
         connectionScope: "viewer",
         hasAppSession: false,
         request: { status: "pending" },
+        selectedMode: "edit",
       }),
       {
         requestedScope: "editor",
@@ -58,6 +60,7 @@ describe("cloud access-request state projection", () => {
         connectionScope: "viewer",
         hasAppSession: false,
         request: { status: "approved" },
+        selectedMode: "edit",
       }),
       {
         requestedScope: "editor",
@@ -75,6 +78,7 @@ describe("cloud access-request state projection", () => {
         connectionScope: "viewer",
         hasAppSession: false,
         request: null,
+        selectedMode: "edit",
       }),
       {
         requestedScope: "viewer",
@@ -93,6 +97,7 @@ describe("cloud access-request state projection", () => {
         connectionScope: "viewer",
         hasAppSession: true,
         request: { status: "pending" },
+        selectedMode: "edit",
       }),
       {
         requestedScope: null,
@@ -108,5 +113,23 @@ describe("cloud access-request state projection", () => {
     assert.equal(cloudPrototypeAuthCarriesRequestedScope("oidc", false), true);
     assert.equal(cloudPrototypeAuthCarriesRequestedScope("oidc", true), false);
     assert.equal(cloudPrototypeAuthCarriesRequestedScope("anonymous", true), false);
+  });
+
+  it("does not let a stored edit request override explicit view mode", () => {
+    assert.deepEqual(
+      projectCloudAccessRequestTransition({
+        authState: authState({ mode: "anonymous", requestedScope: null }),
+        connectionScope: "viewer",
+        hasAppSession: true,
+        request: { status: "pending" },
+        selectedMode: "view",
+      }),
+      {
+        requestedScope: null,
+        selectedMode: null,
+        refreshPrototypeAuth: false,
+        retryLiveConnection: false,
+      },
+    );
   });
 });

--- a/apps/notebook-cloud/test/cloud-access-request-state.test.ts
+++ b/apps/notebook-cloud/test/cloud-access-request-state.test.ts
@@ -85,6 +85,24 @@ describe("cloud access-request state projection", () => {
     );
   });
 
+  it("ignores stale request state once the catalog already grants document edit access", () => {
+    assert.deepEqual(
+      projectCloudAccessRequestTransition({
+        accessScope: "owner",
+        authState: authState({ mode: "oidc", requestedScope: "viewer" }),
+        connectionScope: "viewer",
+        hasAppSession: true,
+        request: { status: "pending" },
+      }),
+      {
+        requestedScope: null,
+        selectedMode: null,
+        refreshPrototypeAuth: false,
+        retryLiveConnection: false,
+      },
+    );
+  });
+
   it("treats app-session auth as the access source of truth over local prototype scope", () => {
     assert.equal(cloudPrototypeAuthCarriesRequestedScope("dev", true), true);
     assert.equal(cloudPrototypeAuthCarriesRequestedScope("oidc", false), true);

--- a/apps/notebook-cloud/test/cloud-access-request-state.test.ts
+++ b/apps/notebook-cloud/test/cloud-access-request-state.test.ts
@@ -1,0 +1,94 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+import {
+  cloudPrototypeAuthCarriesRequestedScope,
+  projectCloudAccessRequestTransition,
+} from "../viewer/cloud-access-request-state";
+import type { CloudPrototypeAuthState } from "../viewer/collaborator-auth";
+
+function authState(
+  overrides: Partial<Pick<CloudPrototypeAuthState, "mode" | "requestedScope">> = {},
+): Pick<CloudPrototypeAuthState, "mode" | "requestedScope"> {
+  return {
+    mode: "oidc",
+    requestedScope: "viewer",
+    ...overrides,
+  };
+}
+
+describe("cloud access-request state projection", () => {
+  it("does not refresh prototype auth scope for cookie-backed pending edit requests", () => {
+    assert.deepEqual(
+      projectCloudAccessRequestTransition({
+        authState: authState({ mode: "anonymous", requestedScope: null }),
+        connectionScope: "viewer",
+        hasAppSession: true,
+        request: { status: "pending" },
+      }),
+      {
+        requestedScope: "editor",
+        selectedMode: "edit",
+        refreshPrototypeAuth: false,
+        retryLiveConnection: false,
+      },
+    );
+  });
+
+  it("refreshes token-backed prototype auth when pending edit scope changes", () => {
+    assert.deepEqual(
+      projectCloudAccessRequestTransition({
+        authState: authState({ mode: "oidc", requestedScope: "viewer" }),
+        connectionScope: "viewer",
+        hasAppSession: false,
+        request: { status: "pending" },
+      }),
+      {
+        requestedScope: "editor",
+        selectedMode: "edit",
+        refreshPrototypeAuth: true,
+        retryLiveConnection: false,
+      },
+    );
+  });
+
+  it("retries the live room once edit access is approved", () => {
+    assert.deepEqual(
+      projectCloudAccessRequestTransition({
+        authState: authState({ mode: "dev", requestedScope: "editor" }),
+        connectionScope: "viewer",
+        hasAppSession: false,
+        request: { status: "approved" },
+      }),
+      {
+        requestedScope: "editor",
+        selectedMode: "edit",
+        refreshPrototypeAuth: false,
+        retryLiveConnection: true,
+      },
+    );
+  });
+
+  it("returns token-backed editors to viewer scope when no edit request is active", () => {
+    assert.deepEqual(
+      projectCloudAccessRequestTransition({
+        authState: authState({ mode: "oidc", requestedScope: "editor" }),
+        connectionScope: "viewer",
+        hasAppSession: false,
+        request: null,
+      }),
+      {
+        requestedScope: "viewer",
+        selectedMode: "view",
+        refreshPrototypeAuth: true,
+        retryLiveConnection: false,
+      },
+    );
+  });
+
+  it("treats app-session auth as the access source of truth over local prototype scope", () => {
+    assert.equal(cloudPrototypeAuthCarriesRequestedScope("dev", true), true);
+    assert.equal(cloudPrototypeAuthCarriesRequestedScope("oidc", false), true);
+    assert.equal(cloudPrototypeAuthCarriesRequestedScope("oidc", true), false);
+    assert.equal(cloudPrototypeAuthCarriesRequestedScope("anonymous", true), false);
+  });
+});

--- a/apps/notebook-cloud/test/cloud-document-edit-readiness.test.ts
+++ b/apps/notebook-cloud/test/cloud-document-edit-readiness.test.ts
@@ -1,0 +1,77 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+import { projectCloudNotebookDocumentEditReadiness } from "../viewer/edit-access";
+
+describe("cloud notebook document edit readiness projection", () => {
+  it("waits for the writable live room when catalog says the user owns the notebook", () => {
+    assert.deepEqual(
+      projectCloudNotebookDocumentEditReadiness({
+        accessScope: "owner",
+        connectionError: null,
+        connectionPeerId: null,
+        connectionScope: "viewer",
+        selectedMode: "edit",
+        statusKind: "loading",
+      }),
+      {
+        canAcceptCellMutations: false,
+        selectedEditModeWaitingForRoom: true,
+        editAccessRequestPending: true,
+      },
+    );
+  });
+
+  it("allows document edits only after the live room grants editor or owner scope", () => {
+    assert.deepEqual(
+      projectCloudNotebookDocumentEditReadiness({
+        accessScope: "editor",
+        connectionError: null,
+        connectionPeerId: "peer-1",
+        connectionScope: "editor",
+        selectedMode: "edit",
+        statusKind: "ready",
+      }),
+      {
+        canAcceptCellMutations: true,
+        selectedEditModeWaitingForRoom: false,
+        editAccessRequestPending: false,
+      },
+    );
+  });
+
+  it("does not treat viewer room access as editable even with a connected peer", () => {
+    assert.deepEqual(
+      projectCloudNotebookDocumentEditReadiness({
+        accessScope: "viewer",
+        connectionError: null,
+        connectionPeerId: "peer-1",
+        connectionScope: "viewer",
+        selectedMode: "edit",
+        statusKind: "ready",
+      }),
+      {
+        canAcceptCellMutations: false,
+        selectedEditModeWaitingForRoom: false,
+        editAccessRequestPending: false,
+      },
+    );
+  });
+
+  it("shows connection errors as errors instead of pending edit access", () => {
+    assert.deepEqual(
+      projectCloudNotebookDocumentEditReadiness({
+        accessScope: "owner",
+        connectionError: "socket closed",
+        connectionPeerId: null,
+        connectionScope: null,
+        selectedMode: "edit",
+        statusKind: "loading",
+      }),
+      {
+        canAcceptCellMutations: false,
+        selectedEditModeWaitingForRoom: false,
+        editAccessRequestPending: false,
+      },
+    );
+  });
+});

--- a/apps/notebook-cloud/test/cloud-notebook-catalog-access.test.ts
+++ b/apps/notebook-cloud/test/cloud-notebook-catalog-access.test.ts
@@ -1,0 +1,78 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+import {
+  cloudNotebookAccessScopeForShell,
+  cloudNotebookCatalogScopeFromList,
+  cloudNotebookScopeCanEditDocument,
+} from "../viewer/cloud-notebook-catalog-access";
+import type { CloudNotebookListItem } from "../viewer/notebook-dashboard";
+
+describe("cloud notebook catalog access projection", () => {
+  it("projects the current notebook scope from the authenticated list", () => {
+    assert.equal(
+      cloudNotebookCatalogScopeFromList(
+        [notebook({ id: "other", scope: "viewer" }), notebook({ id: "owned", scope: "owner" })],
+        "owned",
+      ),
+      "owner",
+    );
+  });
+
+  it("ignores runtime-peer catalog rows for browser access chrome", () => {
+    assert.equal(
+      cloudNotebookCatalogScopeFromList([notebook({ id: "room", scope: "runtime_peer" })], "room"),
+      null,
+    );
+  });
+
+  it("uses catalog scope only while the live room scope is not ready", () => {
+    assert.equal(
+      cloudNotebookAccessScopeForShell({
+        catalogScope: "owner",
+        connectionReady: false,
+        connectionScope: "viewer",
+      }),
+      "owner",
+    );
+    assert.equal(
+      cloudNotebookAccessScopeForShell({
+        catalogScope: "owner",
+        connectionReady: true,
+        connectionScope: "viewer",
+      }),
+      "viewer",
+    );
+  });
+
+  it("classifies editor and owner as document-edit scopes", () => {
+    assert.equal(cloudNotebookScopeCanEditDocument("owner"), true);
+    assert.equal(cloudNotebookScopeCanEditDocument("editor"), true);
+    assert.equal(cloudNotebookScopeCanEditDocument("viewer"), false);
+    assert.equal(cloudNotebookScopeCanEditDocument("runtime_peer"), false);
+    assert.equal(cloudNotebookScopeCanEditDocument(null), false);
+  });
+});
+
+function notebook({
+  id,
+  scope,
+}: {
+  id: string;
+  scope: CloudNotebookListItem["scope"];
+}): CloudNotebookListItem {
+  return {
+    notebook_id: id,
+    title: "Notebook",
+    owner_principal: "user:dev:owner",
+    scope,
+    created_at: "2026-06-01T00:00:00.000Z",
+    updated_at: "2026-06-01T00:00:00.000Z",
+    latest_revision_id: null,
+    viewer_url: `/n/${id}/Notebook`,
+    endpoints: {
+      catalog: `/api/n/${id}`,
+      acl: `/api/n/${id}/acl`,
+      access_requests: `/api/n/${id}/access-requests`,
+    },
+  };
+}

--- a/apps/notebook-cloud/test/cloud-notebook-catalog-access.test.ts
+++ b/apps/notebook-cloud/test/cloud-notebook-catalog-access.test.ts
@@ -4,10 +4,12 @@ import {
   cloudNotebookAccessScopeForShell,
   cloudNotebookCatalogAccessFromList,
   cloudNotebookCatalogScopeFromList,
+  cloudNotebookLiveRoomConnectionPolicy,
   cloudNotebookScopeCanEditDocument,
   cloudNotebookSyncScopeForCatalogAccess,
   createCloudNotebookCatalogAccessLoader,
 } from "../viewer/cloud-notebook-catalog-access";
+import { CLOUD_CONNECTION_NO_ACCESS_DIAGNOSTIC } from "../viewer/connection-diagnostics";
 import type { CloudNotebookListItem } from "../viewer/notebook-dashboard";
 
 describe("cloud notebook catalog access projection", () => {
@@ -143,6 +145,70 @@ describe("cloud notebook catalog access projection", () => {
         selectedMode: "edit",
       }),
       "owner",
+    );
+  });
+
+  it("holds live-room connection while authenticated catalog access is still loading", () => {
+    assert.deepEqual(
+      cloudNotebookLiveRoomConnectionPolicy({
+        canUseAuthenticatedCloudApi: true,
+        catalogResolved: false,
+        catalogScope: null,
+      }),
+      {
+        shouldConnectLiveRoom: false,
+        disabledStatus: { kind: "loading", message: "Checking notebook access..." },
+      },
+    );
+  });
+
+  it("blocks live-room connection once authenticated catalog access resolves without the notebook", () => {
+    assert.deepEqual(
+      cloudNotebookLiveRoomConnectionPolicy({
+        canUseAuthenticatedCloudApi: true,
+        catalogResolved: true,
+        catalogScope: null,
+      }),
+      {
+        shouldConnectLiveRoom: false,
+        disabledStatus: { kind: "error", message: CLOUD_CONNECTION_NO_ACCESS_DIAGNOSTIC },
+      },
+    );
+  });
+
+  it("connects the live room when authenticated catalog access grants any browser scope", () => {
+    for (const catalogScope of ["viewer", "editor", "owner"] as const) {
+      assert.deepEqual(
+        cloudNotebookLiveRoomConnectionPolicy({
+          canUseAuthenticatedCloudApi: true,
+          catalogResolved: true,
+          catalogScope,
+        }),
+        { shouldConnectLiveRoom: true, disabledStatus: null },
+      );
+    }
+  });
+
+  it("keeps live-room fallback when authenticated catalog access could not be loaded", () => {
+    assert.deepEqual(
+      cloudNotebookLiveRoomConnectionPolicy({
+        canUseAuthenticatedCloudApi: true,
+        catalogLoadFailed: true,
+        catalogResolved: false,
+        catalogScope: null,
+      }),
+      { shouldConnectLiveRoom: true, disabledStatus: null },
+    );
+  });
+
+  it("does not gate anonymous or prototype live-room access on the authenticated catalog", () => {
+    assert.deepEqual(
+      cloudNotebookLiveRoomConnectionPolicy({
+        canUseAuthenticatedCloudApi: false,
+        catalogResolved: false,
+        catalogScope: null,
+      }),
+      { shouldConnectLiveRoom: true, disabledStatus: null },
     );
   });
 });

--- a/apps/notebook-cloud/test/cloud-notebook-catalog-access.test.ts
+++ b/apps/notebook-cloud/test/cloud-notebook-catalog-access.test.ts
@@ -2,9 +2,11 @@ import assert from "node:assert/strict";
 import { describe, it } from "node:test";
 import {
   cloudNotebookAccessScopeForShell,
+  cloudNotebookCatalogAccessFromList,
   cloudNotebookCatalogScopeFromList,
   cloudNotebookScopeCanEditDocument,
   cloudNotebookSyncScopeForCatalogAccess,
+  createCloudNotebookCatalogAccessLoader,
 } from "../viewer/cloud-notebook-catalog-access";
 import type { CloudNotebookListItem } from "../viewer/notebook-dashboard";
 
@@ -24,6 +26,64 @@ describe("cloud notebook catalog access projection", () => {
       cloudNotebookCatalogScopeFromList([notebook({ id: "room", scope: "runtime_peer" })], "room"),
       null,
     );
+  });
+
+  it("projects resolved catalog access from the authenticated notebook list", () => {
+    assert.deepEqual(
+      cloudNotebookCatalogAccessFromList(
+        [notebook({ id: "room", scope: "editor" }), notebook({ id: "other", scope: "owner" })],
+        "room",
+      ),
+      {
+        catalogResolved: true,
+        catalogScope: "editor",
+      },
+    );
+  });
+
+  it("coalesces concurrent catalog access loads for one notebook open", async () => {
+    let loadCount = 0;
+    let releaseLoad!: () => void;
+    const loadGate = new Promise<void>((resolve) => {
+      releaseLoad = resolve;
+    });
+    const loader = createCloudNotebookCatalogAccessLoader({
+      notebookId: "room",
+      loadNotebooks: async () => {
+        loadCount += 1;
+        await loadGate;
+        return [notebook({ id: "room", scope: "owner" })];
+      },
+    });
+
+    const first = loader.load();
+    const second = loader.load();
+    assert.equal(loadCount, 1);
+    releaseLoad();
+
+    assert.deepEqual(await Promise.all([first, second]), [
+      { catalogResolved: true, catalogScope: "owner" },
+      { catalogResolved: true, catalogScope: "owner" },
+    ]);
+    assert.equal(loadCount, 1);
+  });
+
+  it("retries catalog access loads after a failed request", async () => {
+    let loadCount = 0;
+    const loader = createCloudNotebookCatalogAccessLoader({
+      notebookId: "room",
+      loadNotebooks: async () => {
+        loadCount += 1;
+        if (loadCount === 1) {
+          throw new Error("temporary catalog failure");
+        }
+        return [notebook({ id: "room", scope: "viewer" })];
+      },
+    });
+
+    await assert.rejects(loader.load(), /temporary catalog failure/);
+    assert.deepEqual(await loader.load(), { catalogResolved: true, catalogScope: "viewer" });
+    assert.equal(loadCount, 2);
   });
 
   it("uses catalog scope only while the live room scope is not ready", () => {

--- a/apps/notebook-cloud/test/cloud-notebook-catalog-access.test.ts
+++ b/apps/notebook-cloud/test/cloud-notebook-catalog-access.test.ts
@@ -4,6 +4,7 @@ import {
   cloudNotebookAccessScopeForShell,
   cloudNotebookCatalogScopeFromList,
   cloudNotebookScopeCanEditDocument,
+  cloudNotebookSyncScopeForCatalogAccess,
 } from "../viewer/cloud-notebook-catalog-access";
 import type { CloudNotebookListItem } from "../viewer/notebook-dashboard";
 
@@ -50,6 +51,39 @@ describe("cloud notebook catalog access projection", () => {
     assert.equal(cloudNotebookScopeCanEditDocument("viewer"), false);
     assert.equal(cloudNotebookScopeCanEditDocument("runtime_peer"), false);
     assert.equal(cloudNotebookScopeCanEditDocument(null), false);
+  });
+
+  it("requests the catalog scope for app-session room sync when available", () => {
+    assert.equal(
+      cloudNotebookSyncScopeForCatalogAccess({
+        catalogResolved: true,
+        catalogScope: "editor",
+        selectedMode: "view",
+      }),
+      "editor",
+    );
+  });
+
+  it("does not escalate edit-mode URLs when the authenticated catalog excludes the notebook", () => {
+    assert.equal(
+      cloudNotebookSyncScopeForCatalogAccess({
+        catalogResolved: true,
+        catalogScope: null,
+        selectedMode: "edit",
+      }),
+      "viewer",
+    );
+  });
+
+  it("keeps the existing edit-mode fallback when the catalog could not be resolved", () => {
+    assert.equal(
+      cloudNotebookSyncScopeForCatalogAccess({
+        catalogResolved: false,
+        catalogScope: null,
+        selectedMode: "edit",
+      }),
+      "owner",
+    );
   });
 });
 

--- a/apps/notebook-cloud/test/cloud-notebook-mode.test.ts
+++ b/apps/notebook-cloud/test/cloud-notebook-mode.test.ts
@@ -21,8 +21,36 @@ test("cloud notebook edit links stay view-only for viewers without an access req
   );
   assert.equal(
     cloudNotebookInteractionModeForAccess({
+      accessRequestStatus: "denied",
+      catalogResolved: true,
+      connectionScope: null,
+      selectedMode: "edit",
+    }),
+    "view",
+  );
+  assert.equal(
+    cloudNotebookInteractionModeForAccess({
+      accessRequestStatus: "dismissed",
+      catalogResolved: true,
+      connectionScope: null,
+      selectedMode: "edit",
+    }),
+    "view",
+  );
+  assert.equal(
+    cloudNotebookInteractionModeForAccess({
       accessRequestStatus: "pending",
+      catalogResolved: true,
       connectionScope: "viewer",
+      selectedMode: "edit",
+    }),
+    "edit",
+  );
+  assert.equal(
+    cloudNotebookInteractionModeForAccess({
+      accessRequestStatus: "pending",
+      catalogResolved: true,
+      connectionScope: null,
       selectedMode: "edit",
     }),
     "edit",
@@ -76,5 +104,14 @@ test("cloud notebook edit links stay view-only for viewers without an access req
       selectedMode: "view",
     }),
     "view",
+  );
+  assert.equal(
+    cloudNotebookInteractionModeForAccess({
+      accessRequestStatus: null,
+      catalogResolved: false,
+      connectionScope: null,
+      selectedMode: "edit",
+    }),
+    "edit",
   );
 });

--- a/apps/notebook-cloud/test/cloud-notebook-mode.test.ts
+++ b/apps/notebook-cloud/test/cloud-notebook-mode.test.ts
@@ -13,7 +13,7 @@ test("cloud notebook edit links stay view-only for viewers without an access req
   );
   assert.equal(
     cloudNotebookInteractionModeForAccess({
-      accessRequestStatus: "rejected",
+      accessRequestStatus: "denied",
       connectionScope: "viewer",
       selectedMode: "edit",
     }),

--- a/apps/notebook-cloud/test/cloud-notebook-mode.test.ts
+++ b/apps/notebook-cloud/test/cloud-notebook-mode.test.ts
@@ -38,6 +38,24 @@ test("cloud notebook edit links stay view-only for viewers without an access req
   assert.equal(
     cloudNotebookInteractionModeForAccess({
       accessRequestStatus: null,
+      accessScope: "owner",
+      connectionScope: "viewer",
+      selectedMode: "edit",
+    }),
+    "edit",
+  );
+  assert.equal(
+    cloudNotebookInteractionModeForAccess({
+      accessRequestStatus: "pending",
+      accessScope: "editor",
+      connectionScope: "viewer",
+      selectedMode: "edit",
+    }),
+    "edit",
+  );
+  assert.equal(
+    cloudNotebookInteractionModeForAccess({
+      accessRequestStatus: null,
       connectionScope: "editor",
       selectedMode: "edit",
     }),

--- a/apps/notebook-cloud/test/cloud-session-auth-stability.test.ts
+++ b/apps/notebook-cloud/test/cloud-session-auth-stability.test.ts
@@ -2,6 +2,7 @@ import assert from "node:assert/strict";
 import { describe, it } from "node:test";
 import type { CloudPrototypeAuthState } from "../viewer/collaborator-auth";
 import {
+  cloudBrowserApiAuthStateForFetch,
   cloudBlobAuthStateForBrowserFetch,
   cloudSyncAuthConnectionKey,
 } from "../viewer/session-auth-stability";
@@ -19,6 +20,21 @@ function authState(overrides: Partial<CloudPrototypeAuthState> = {}): CloudProto
 }
 
 describe("cloud session auth stability", () => {
+  it("keeps cookie-backed browser API fetch auth stable across OIDC token churn", () => {
+    const first = cloudBrowserApiAuthStateForFetch(authState({ token: "token-a" }));
+    const second = cloudBrowserApiAuthStateForFetch(authState({ token: "token-b" }));
+
+    assert.equal(first, second);
+    assert.deepEqual(first, {
+      mode: "anonymous",
+      token: null,
+      user: null,
+      oidcClaims: null,
+      requestedScope: null,
+      problem: null,
+    });
+  });
+
   it("keeps cookie-backed blob fetch auth stable across OIDC token churn", () => {
     const first = cloudBlobAuthStateForBrowserFetch(authState({ token: "token-a" }));
     const second = cloudBlobAuthStateForBrowserFetch(authState({ token: "token-b" }));

--- a/apps/notebook-cloud/test/connection-diagnostics.test.ts
+++ b/apps/notebook-cloud/test/connection-diagnostics.test.ts
@@ -195,6 +195,11 @@ describe("late access diagnostics never displace a terminal WASM-failure notice"
       2,
       "both diagnostic resolution sites must stop the pre-ready retry loop",
     );
+    assert.match(
+      sessionSource,
+      /connectionStatusBridge\.noteLiveRoomDisabled\(\);[\s\S]{0,120}?presenceStore\.reduceConnection\("disconnected"\);/,
+      "catalog-resolved no-access routes must render the connection slot as offline, not connecting",
+    );
   });
 });
 

--- a/apps/notebook-cloud/test/connection-diagnostics.test.ts
+++ b/apps/notebook-cloud/test/connection-diagnostics.test.ts
@@ -6,6 +6,7 @@ import {
   CLOUD_CONNECTION_EDIT_ACCESS_PENDING_DIAGNOSTIC,
   CLOUD_CONNECTION_NO_ACCESS_DIAGNOSTIC,
   CLOUD_CONNECTION_SIGN_IN_DIAGNOSTIC,
+  cloudConnectionDiagnosticBlocksNotebookBody,
   cloudConnectionErrorWithAccessDiagnostic,
   diagnoseCloudConnectionAccess,
   isCloudConnectionAccessDiagnostic,
@@ -160,6 +161,27 @@ describe("late access diagnostics never displace a terminal WASM-failure notice"
     assert.equal(isCloudConnectionAccessDiagnostic(CLOUD_CONNECTION_SIGN_IN_DIAGNOSTIC), true);
     assert.equal(isCloudConnectionAccessDiagnostic("cloud sync socket failed"), false);
     assert.equal(isCloudConnectionAccessDiagnostic(null), false);
+  });
+
+  it("identifies diagnostics that should block notebook body rendering", () => {
+    assert.equal(
+      cloudConnectionDiagnosticBlocksNotebookBody(CLOUD_CONNECTION_NO_ACCESS_DIAGNOSTIC),
+      true,
+    );
+    assert.equal(
+      cloudConnectionDiagnosticBlocksNotebookBody(CLOUD_CONNECTION_SIGN_IN_DIAGNOSTIC),
+      true,
+    );
+    assert.equal(
+      cloudConnectionDiagnosticBlocksNotebookBody(CLOUD_CONNECTION_EDIT_ACCESS_PENDING_DIAGNOSTIC),
+      false,
+    );
+    assert.equal(
+      cloudConnectionDiagnosticBlocksNotebookBody(CLOUD_CONNECTION_EDIT_ACCESS_APPROVED_DIAGNOSTIC),
+      false,
+    );
+    assert.equal(cloudConnectionDiagnosticBlocksNotebookBody("cloud sync socket failed"), false);
+    assert.equal(cloudConnectionDiagnosticBlocksNotebookBody(null), false);
   });
 
   // Session wiring pins (the hook cannot run under node): the kick-time

--- a/apps/notebook-cloud/test/connection-diagnostics.test.ts
+++ b/apps/notebook-cloud/test/connection-diagnostics.test.ts
@@ -4,9 +4,11 @@ import { readFileSync } from "node:fs";
 import {
   CLOUD_CONNECTION_EDIT_ACCESS_APPROVED_DIAGNOSTIC,
   CLOUD_CONNECTION_EDIT_ACCESS_PENDING_DIAGNOSTIC,
+  CLOUD_CONNECTION_NO_ACCESS_DIAGNOSTIC,
   CLOUD_CONNECTION_SIGN_IN_DIAGNOSTIC,
   cloudConnectionErrorWithAccessDiagnostic,
   diagnoseCloudConnectionAccess,
+  isCloudConnectionAccessDiagnostic,
 } from "../viewer/connection-diagnostics.ts";
 import type { CloudPrototypeAuthState } from "../viewer/collaborator-auth.ts";
 
@@ -153,6 +155,13 @@ describe("late access diagnostics never displace a terminal WASM-failure notice"
     );
   });
 
+  it("identifies access diagnostics that should survive reconnect noise", () => {
+    assert.equal(isCloudConnectionAccessDiagnostic(CLOUD_CONNECTION_NO_ACCESS_DIAGNOSTIC), true);
+    assert.equal(isCloudConnectionAccessDiagnostic(CLOUD_CONNECTION_SIGN_IN_DIAGNOSTIC), true);
+    assert.equal(isCloudConnectionAccessDiagnostic("cloud sync socket failed"), false);
+    assert.equal(isCloudConnectionAccessDiagnostic(null), false);
+  });
+
   // Session wiring pins (the hook cannot run under node): the kick-time
   // guard on the connect-failure path, and BOTH late-resolution sites
   // merging through the resolution-time guard.
@@ -170,6 +179,21 @@ describe("late access diagnostics never displace a terminal WASM-failure notice"
       ).length,
       2,
       "both diagnostic resolution sites must merge through the resolution-time guard",
+    );
+    assert.match(
+      sessionSource,
+      /isCloudConnectionAccessDiagnostic\(current\) \? current : reason\.message/,
+      "transport retry noise must not overwrite an already-actionable access diagnostic",
+    );
+    assert.match(
+      sessionSource,
+      /const stopPendingTransportForAccessDiagnostic = \(diagnostic: string\) => \{/,
+      "pre-ready access diagnostics must stop the pending transport retry loop",
+    );
+    assert.equal(
+      (sessionSource.match(/stopPendingTransportForAccessDiagnostic\(diagnostic\);/g) ?? []).length,
+      2,
+      "both diagnostic resolution sites must stop the pre-ready retry loop",
     );
   });
 });

--- a/apps/notebook-cloud/test/hosted-smoke-runtime-wasm.test.mjs
+++ b/apps/notebook-cloud/test/hosted-smoke-runtime-wasm.test.mjs
@@ -4,7 +4,7 @@ import { describe, it } from "node:test";
 import { checkRuntimeWasmHints } from "../scripts/hosted-render-smoke-runtime-wasm.mjs";
 
 describe("hosted smoke runtime WASM hints", () => {
-  it("accepts the viewer shell modulepreload and fetch preload pair", () => {
+  it("accepts the viewer shell modulepreload and fetch prefetch pair", () => {
     const check = checkRuntimeWasmHints(
       [
         {
@@ -16,7 +16,7 @@ describe("hosted smoke runtime WASM hints", () => {
           crossOrigin: "",
         },
         {
-          rel: "preload",
+          rel: "prefetch",
           href: "https://preview.runt.run/assets/runtimed_wasm_bg.fedcba9876543210.wasm",
           as: "fetch",
           type: "application/wasm",
@@ -32,14 +32,14 @@ describe("hosted smoke runtime WASM hints", () => {
     assert.equal(check.ok, true);
     assert.deepEqual(check.failures, []);
     assert.match(check.modulepreload.href, /runtimed_wasm\.[a-f0-9]{16}\.js$/);
-    assert.match(check.wasmPreload.href, /runtimed_wasm_bg\.[a-f0-9]{16}\.wasm$/);
+    assert.match(check.wasmPrefetch.href, /runtimed_wasm_bg\.[a-f0-9]{16}\.wasm$/);
   });
 
-  it("reports missing or malformed runtime WASM preload hints", () => {
+  it("reports missing or malformed runtime WASM prefetch hints", () => {
     const check = checkRuntimeWasmHints(
       [
         {
-          rel: "preload",
+          rel: "prefetch",
           href: "https://preview.runt.run/assets/runtimed_wasm_bg.wasm",
           as: "script",
           type: "application/octet-stream",
@@ -60,7 +60,7 @@ describe("hosted smoke runtime WASM hints", () => {
     assert.match(check.failures[3].text, /did not declare crossorigin/);
     assert.match(
       check.failures[4].text,
-      /runtimed_wasm_bg\.wasm preload did not point at https:\/\/nteract-notebook-cloud-assets\.rgbkrk\.workers\.dev/,
+      /runtimed_wasm_bg\.wasm prefetch did not point at https:\/\/nteract-notebook-cloud-assets\.rgbkrk\.workers\.dev/,
     );
   });
 

--- a/apps/notebook-cloud/test/html.test.ts
+++ b/apps/notebook-cloud/test/html.test.ts
@@ -63,7 +63,7 @@ describe("HTML script serialization", () => {
     assert.match(html, /rel="modulepreload" href="\/assets\/runtimed_wasm\.js" crossorigin/);
     assert.match(
       html,
-      /rel="preload" href="\/assets\/runtimed_wasm_bg\.wasm" as="fetch" type="application\/wasm" crossorigin/,
+      /rel="prefetch" href="\/assets\/runtimed_wasm_bg\.wasm" as="fetch" type="application\/wasm" crossorigin/,
     );
     assert.ok(
       html.indexOf(viewerThemeFirstPaintStyle()) < html.indexOf(viewerThemeBootstrapScript()),
@@ -141,7 +141,7 @@ describe("HTML script serialization", () => {
     );
     assert.match(
       html,
-      /rel="preload" href="\/assets\/runtimed_wasm_bg\.fedcba9876543210\.wasm" as="fetch" type="application\/wasm" crossorigin/,
+      /rel="prefetch" href="\/assets\/runtimed_wasm_bg\.fedcba9876543210\.wasm" as="fetch" type="application\/wasm" crossorigin/,
     );
     assert.match(html, /"runtimedWasmModulePath":"\/assets\/runtimed_wasm\.0123456789abcdef\.js"/);
     assert.match(html, /"runtimedWasmPath":"\/assets\/runtimed_wasm_bg\.fedcba9876543210\.wasm"/);
@@ -380,7 +380,7 @@ describe("HTML script serialization", () => {
     );
     assert.match(
       html,
-      /rel="preload" href="https:\/\/wasm\.example\/runtime\/runtimed_wasm_bg\.wasm" as="fetch" type="application\/wasm" crossorigin/,
+      /rel="prefetch" href="https:\/\/wasm\.example\/runtime\/runtimed_wasm_bg\.wasm" as="fetch" type="application\/wasm" crossorigin/,
     );
     assert.match(
       response.headers.get("Content-Security-Policy") ?? "",

--- a/apps/notebook-cloud/test/html.test.ts
+++ b/apps/notebook-cloud/test/html.test.ts
@@ -58,6 +58,7 @@ describe("HTML script serialization", () => {
     assert.match(html, /"oidc":null/);
     assert.match(html, /id="nteract-cloud-viewer-config" type="application\/json"/);
     assert.match(html, /href="\/assets\/notebook-cloud-viewer\.css"/);
+    assert.match(html, /rel="icon" href="\/favicon\.svg" type="image\/svg\+xml"/);
     assert.match(html, /src="\/assets\/notebook-cloud-viewer\.js"/);
     assert.match(html, /rel="modulepreload" href="\/assets\/notebook-cloud-viewer\.js"/);
     assert.match(html, /rel="modulepreload" href="\/assets\/runtimed_wasm\.js" crossorigin/);

--- a/apps/notebook-cloud/test/live-sync.test.ts
+++ b/apps/notebook-cloud/test/live-sync.test.ts
@@ -2030,6 +2030,18 @@ describe("cloud connection status bridge", () => {
     assert.equal(bridge.current, "online");
   });
 
+  it("reports an intentionally disabled live room as offline, not connecting", () => {
+    const bridge = new CloudConnectionStatusBridge();
+    const statuses: string[] = [];
+    bridge.status$.subscribe((status) => statuses.push(status));
+
+    bridge.noteLiveRoomDisabled();
+    bridge.noteLiveRoomDisabled();
+
+    assert.deepEqual(statuses, ["connecting", "offline"]);
+    assert.equal(bridge.current, "offline");
+  });
+
   it("implements the slot source contract: subscribe replay + getCurrent snapshot", () => {
     const bridge = new CloudConnectionStatusBridge();
     const transport = new BehaviorSubject<"connecting" | "online" | "offline" | "reconnecting">(

--- a/apps/notebook-cloud/test/notebook-dashboard.test.ts
+++ b/apps/notebook-cloud/test/notebook-dashboard.test.ts
@@ -299,8 +299,8 @@ describe("cloud notebook dashboard projection", () => {
         ]),
       ),
       [
-        ["renderer-regression", "Shared edit access", [["access", "editor"]], null],
-        ["archive", "Shared view access", [["access", "viewer"]], null],
+        ["renderer-regression", "Shared notebook", [["access", "editor"]], null],
+        ["archive", "Shared notebook", [["access", "viewer"]], null],
       ],
     );
   });

--- a/apps/notebook-cloud/test/notebook-dashboard.test.ts
+++ b/apps/notebook-cloud/test/notebook-dashboard.test.ts
@@ -421,12 +421,18 @@ describe("cloud notebook dashboard projection", () => {
       view.sections.map((section) => [
         section.id,
         section.title,
+        section.detail,
         section.notebooks.map((item) => item.notebook_id),
       ]),
       [
-        ["named", "Recent work", ["workstation-notes"]],
-        ["generated", "Generated runs", ["toolbar-smoke"]],
-        ["untitled", "Needs title", ["untitled-new"]],
+        ["named", "Recent work", "1 more notebook to reopen", ["workstation-notes"]],
+        ["generated", "Generated runs", "1 notebook from smoke and debug work", ["toolbar-smoke"]],
+        [
+          "untitled",
+          "Needs title",
+          "Rename notebooks worth keeping so they stay easy to find.",
+          ["untitled-new"],
+        ],
       ],
     );
     assert.deepEqual(

--- a/apps/notebook-cloud/test/notebook-dashboard.test.ts
+++ b/apps/notebook-cloud/test/notebook-dashboard.test.ts
@@ -123,7 +123,7 @@ describe("cloud notebook dashboard projection", () => {
     );
   });
 
-  it("opens owned notebooks in edit mode while preserving shared notebooks in view mode", () => {
+  it("opens editable notebooks in edit mode while preserving viewer notebooks in view mode", () => {
     const owned = notebook({
       id: "owned-notebook",
       title: "Owned notebook",
@@ -147,7 +147,7 @@ describe("cloud notebook dashboard projection", () => {
     });
 
     assert.equal(cloudNotebookDashboardOpenUrl(owned), "/n/owned-notebook/notebook?mode=edit");
-    assert.equal(cloudNotebookDashboardOpenUrl(editor), "/n/editor-notebook/notebook?mode=view");
+    assert.equal(cloudNotebookDashboardOpenUrl(editor), "/n/editor-notebook/notebook?mode=edit");
     assert.equal(cloudNotebookDashboardOpenUrl(viewer), "/n/viewer-notebook/notebook?mode=view");
   });
 

--- a/apps/notebook-cloud/test/notebook-route-title.test.ts
+++ b/apps/notebook-cloud/test/notebook-route-title.test.ts
@@ -1,0 +1,27 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+import {
+  humanizeNotebookRouteTitle,
+  notebookRouteSegmentTitle,
+} from "../src/notebook-route-title.ts";
+
+describe("notebook route title projection", () => {
+  it("turns slug-like route segments into readable titles", () => {
+    assert.equal(notebookRouteSegmentTitle("topic-viz"), "Topic Viz");
+    assert.equal(notebookRouteSegmentTitle("topic_viz"), "Topic Viz");
+    assert.equal(notebookRouteSegmentTitle("sup%20quill"), "Sup Quill");
+  });
+
+  it("preserves acronym-looking words that are already in the route", () => {
+    assert.equal(
+      notebookRouteSegmentTitle("Quill%20HF%20workstation%20smoke"),
+      "Quill HF Workstation Smoke",
+    );
+    assert.equal(humanizeNotebookRouteTitle("OAuth API Q2 review"), "OAuth API Q2 Review");
+  });
+
+  it("falls back cleanly for empty or malformed route segments", () => {
+    assert.equal(notebookRouteSegmentTitle(""), null);
+    assert.equal(notebookRouteSegmentTitle("%"), "%");
+  });
+});

--- a/apps/notebook-cloud/test/notebook-view-loading.test.ts
+++ b/apps/notebook-cloud/test/notebook-view-loading.test.ts
@@ -1,0 +1,70 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+
+import { CLOUD_CONNECTION_NO_ACCESS_DIAGNOSTIC } from "../viewer/connection-diagnostics.ts";
+import { projectCloudNotebookViewLoading } from "../viewer/notebook-view-loading.ts";
+
+const ready = { kind: "ready" as const, message: "Ready" };
+const loading = { kind: "loading" as const, message: "Connecting to live notebook room..." };
+
+function project(overrides: Partial<Parameters<typeof projectCloudNotebookViewLoading>[0]> = {}) {
+  return projectCloudNotebookViewLoading({
+    cellCount: 0,
+    canEditStructure: false,
+    connectionError: null,
+    editAccessPending: false,
+    emptyRoomGraceElapsed: true,
+    hasAccessDiagnostic: false,
+    hasReadableSnapshot: false,
+    liveMaterialized: false,
+    status: ready,
+    ...overrides,
+  });
+}
+
+describe("cloud notebook body loading projection", () => {
+  it("does not show notebook loading placeholders for resolved no-access pages", () => {
+    assert.equal(
+      project({
+        connectionError: CLOUD_CONNECTION_NO_ACCESS_DIAGNOSTIC,
+        hasAccessDiagnostic: true,
+        status: { kind: "error", message: CLOUD_CONNECTION_NO_ACCESS_DIAGNOSTIC },
+      }),
+      false,
+    );
+  });
+
+  it("keeps loading placeholders for real connection errors without readable content", () => {
+    assert.equal(
+      project({
+        connectionError: "cloud sync socket closed",
+        status: { kind: "error", message: "cloud sync socket closed" },
+      }),
+      true,
+    );
+  });
+
+  it("keeps startup, pending edit, empty-room grace, and editable bootstrap states loading", () => {
+    assert.equal(project({ status: loading }), true);
+    assert.equal(project({ editAccessPending: true }), true);
+    assert.equal(
+      project({
+        emptyRoomGraceElapsed: false,
+        status: { kind: "empty", message: "This notebook room has no cells yet." },
+      }),
+      true,
+    );
+    assert.equal(project({ canEditStructure: true }), true);
+  });
+
+  it("does not show loading placeholders over readable snapshots", () => {
+    assert.equal(
+      project({
+        connectionError: "cloud sync socket closed",
+        hasReadableSnapshot: true,
+        status: { kind: "error", message: "cloud sync socket closed" },
+      }),
+      false,
+    );
+  });
+});

--- a/apps/notebook-cloud/test/notebook-view-loading.test.ts
+++ b/apps/notebook-cloud/test/notebook-view-loading.test.ts
@@ -6,6 +6,7 @@ import {
   CLOUD_CONNECTION_NO_ACCESS_DIAGNOSTIC,
 } from "../viewer/connection-diagnostics.ts";
 import {
+  projectCloudNotebookHeaderChrome,
   projectCloudNotebookViewLoading,
   projectCloudNotebookViewSurface,
 } from "../viewer/notebook-view-loading.ts";
@@ -114,6 +115,32 @@ describe("cloud notebook body loading projection", () => {
       {
         isLoading: false,
         shouldRenderNotebookView: true,
+      },
+    );
+  });
+});
+
+describe("cloud notebook header chrome projection", () => {
+  it("hides live collaboration chrome when the notebook body is access-blocked", () => {
+    assert.deepEqual(
+      projectCloudNotebookHeaderChrome({
+        bodyAccessBlocked: true,
+      }),
+      {
+        showConnectionIdentity: false,
+        showPresenceStatus: false,
+      },
+    );
+  });
+
+  it("keeps live collaboration chrome for readable notebook surfaces", () => {
+    assert.deepEqual(
+      projectCloudNotebookHeaderChrome({
+        bodyAccessBlocked: false,
+      }),
+      {
+        showConnectionIdentity: true,
+        showPresenceStatus: true,
       },
     );
   });

--- a/apps/notebook-cloud/test/notebook-view-loading.test.ts
+++ b/apps/notebook-cloud/test/notebook-view-loading.test.ts
@@ -1,14 +1,21 @@
 import assert from "node:assert/strict";
 import { describe, it } from "node:test";
 
-import { CLOUD_CONNECTION_NO_ACCESS_DIAGNOSTIC } from "../viewer/connection-diagnostics.ts";
-import { projectCloudNotebookViewLoading } from "../viewer/notebook-view-loading.ts";
+import {
+  CLOUD_CONNECTION_EDIT_ACCESS_PENDING_DIAGNOSTIC,
+  CLOUD_CONNECTION_NO_ACCESS_DIAGNOSTIC,
+} from "../viewer/connection-diagnostics.ts";
+import {
+  projectCloudNotebookViewLoading,
+  projectCloudNotebookViewSurface,
+} from "../viewer/notebook-view-loading.ts";
 
 const ready = { kind: "ready" as const, message: "Ready" };
 const loading = { kind: "loading" as const, message: "Connecting to live notebook room..." };
 
 function project(overrides: Partial<Parameters<typeof projectCloudNotebookViewLoading>[0]> = {}) {
   return projectCloudNotebookViewLoading({
+    bodyAccessBlocked: false,
     cellCount: 0,
     canEditStructure: false,
     connectionError: null,
@@ -26,6 +33,7 @@ describe("cloud notebook body loading projection", () => {
   it("does not show notebook loading placeholders for resolved no-access pages", () => {
     assert.equal(
       project({
+        bodyAccessBlocked: true,
         connectionError: CLOUD_CONNECTION_NO_ACCESS_DIAGNOSTIC,
         hasAccessDiagnostic: true,
         status: { kind: "error", message: CLOUD_CONNECTION_NO_ACCESS_DIAGNOSTIC },
@@ -65,6 +73,48 @@ describe("cloud notebook body loading projection", () => {
         status: { kind: "error", message: "cloud sync socket closed" },
       }),
       false,
+    );
+  });
+
+  it("does not render the notebook view when content access is blocked", () => {
+    assert.deepEqual(
+      projectCloudNotebookViewSurface({
+        bodyAccessBlocked: true,
+        cellCount: 0,
+        canEditStructure: false,
+        connectionError: CLOUD_CONNECTION_NO_ACCESS_DIAGNOSTIC,
+        editAccessPending: false,
+        emptyRoomGraceElapsed: true,
+        hasAccessDiagnostic: true,
+        hasReadableSnapshot: false,
+        liveMaterialized: false,
+        status: { kind: "error", message: CLOUD_CONNECTION_NO_ACCESS_DIAGNOSTIC },
+      }),
+      {
+        isLoading: false,
+        shouldRenderNotebookView: false,
+      },
+    );
+  });
+
+  it("keeps non-blocking access diagnostics on the normal notebook surface", () => {
+    assert.deepEqual(
+      projectCloudNotebookViewSurface({
+        bodyAccessBlocked: false,
+        cellCount: 1,
+        canEditStructure: false,
+        connectionError: CLOUD_CONNECTION_EDIT_ACCESS_PENDING_DIAGNOSTIC,
+        editAccessPending: false,
+        emptyRoomGraceElapsed: true,
+        hasAccessDiagnostic: true,
+        hasReadableSnapshot: true,
+        liveMaterialized: true,
+        status: { kind: "error", message: CLOUD_CONNECTION_EDIT_ACCESS_PENDING_DIAGNOSTIC },
+      }),
+      {
+        isLoading: false,
+        shouldRenderNotebookView: true,
+      },
     );
   });
 });

--- a/apps/notebook-cloud/test/sync-heal.test.ts
+++ b/apps/notebook-cloud/test/sync-heal.test.ts
@@ -324,6 +324,24 @@ describe("cloud session sync-heal wiring", () => {
     );
   });
 
+  it("keeps routine heal re-kicks out of the production console", () => {
+    assert.match(
+      sessionSource,
+      /const quietSyncHealLogger = \{[\s\S]{0,120}?debug: \(\) => \{\},[\s\S]{0,160}?warn: \(message: string, \.\.\.args: unknown\[\]\) => console\.warn\(message, \.\.\.args\),[\s\S]{0,80}?\};/,
+      "quiet logger drops routine retry debug lines but preserves terminal warnings",
+    );
+    assert.match(
+      sessionSource,
+      /logger: quietSyncHealLogger/,
+      "the hosted viewer should not wire sync-heal directly to console",
+    );
+    assert.doesNotMatch(
+      sessionSource,
+      /logger: console,\s*\}\);[\s\S]{0,120}?const persistenceRearmGate/,
+      "routine sync-heal retries must not leak to the browser console",
+    );
+  });
+
   it("disposes the scheduler and clears the stall surface on cleanup", () => {
     assert.match(sessionSource, /syncHeal\.dispose\(\);/);
     assert.match(sessionSource, /setSyncHealStalled\(false\);/);

--- a/apps/notebook-cloud/test/viewer-notices.test.ts
+++ b/apps/notebook-cloud/test/viewer-notices.test.ts
@@ -190,6 +190,32 @@ test("cloud notebook notices distinguish sign-in and access diagnostics from soc
   assert.doesNotMatch(noAccessHtml, /Live room unavailable/);
 });
 
+test("cloud notebook notices let access diagnostics own private-route loading", () => {
+  assert.equal(
+    cloudNotebookHasNotices({
+      authState: authState("anonymous"),
+      authRenewal: { kind: "idle", message: null },
+      connectionError: CLOUD_CONNECTION_NO_ACCESS_DIAGNOSTIC,
+      status: { kind: "loading", message: "Connecting to live notebook room..." },
+    }),
+    true,
+  );
+
+  const html = renderToStaticMarkup(
+    React.createElement(CloudNotebookNotices, {
+      authState: authState("anonymous"),
+      authRenewal: { kind: "idle", message: null },
+      connectionError: CLOUD_CONNECTION_NO_ACCESS_DIAGNOSTIC,
+      status: { kind: "loading", message: "Connecting to live notebook room..." },
+      onResetAuth: () => {},
+    }),
+  );
+
+  assert.match(html, /Notebook access needed/);
+  assert.doesNotMatch(html, /Loading notebook/);
+  assert.doesNotMatch(html, /Connecting to live notebook room/);
+});
+
 test("cloud notebook notices aggregate renderer-asset failures into one quiet line with retry", () => {
   assert.equal(
     cloudNotebookHasNotices({

--- a/apps/notebook-cloud/test/viewer-notices.test.ts
+++ b/apps/notebook-cloud/test/viewer-notices.test.ts
@@ -216,6 +216,34 @@ test("cloud notebook notices let access diagnostics own private-route loading", 
   assert.doesNotMatch(html, /Connecting to live notebook room/);
 });
 
+test("cloud notebook notices do not duplicate no-access diagnostics as a generic load error", () => {
+  assert.equal(
+    cloudNotebookHasNotices({
+      authState: authState("oidc"),
+      authRenewal: { kind: "idle", message: null },
+      connectionError: CLOUD_CONNECTION_NO_ACCESS_DIAGNOSTIC,
+      hasAppSession: true,
+      status: { kind: "error", message: CLOUD_CONNECTION_NO_ACCESS_DIAGNOSTIC },
+    }),
+    true,
+  );
+
+  const html = renderToStaticMarkup(
+    React.createElement(CloudNotebookNotices, {
+      authState: authState("oidc"),
+      authRenewal: { kind: "idle", message: null },
+      connectionError: CLOUD_CONNECTION_NO_ACCESS_DIAGNOSTIC,
+      hasAppSession: true,
+      status: { kind: "error", message: CLOUD_CONNECTION_NO_ACCESS_DIAGNOSTIC },
+      onResetAuth: () => {},
+    }),
+  );
+
+  assert.match(html, /Notebook access needed/);
+  assert.equal(html.match(/does not have access to this notebook/g)?.length, 1);
+  assert.doesNotMatch(html, /Unable to load notebook/);
+});
+
 test("cloud notebook notices aggregate renderer-asset failures into one quiet line with retry", () => {
   assert.equal(
     cloudNotebookHasNotices({

--- a/apps/notebook-cloud/test/viewer-presence.test.ts
+++ b/apps/notebook-cloud/test/viewer-presence.test.ts
@@ -300,7 +300,17 @@ describe("cloud viewer presence", () => {
         email: "alice@example.com",
         actorLabel: "user:anaconda:550e8400-e29b-41d4-a716-446655440000/browser:tab",
       }),
-      "alice@example.com",
+      "Anaconda user",
+    );
+    assert.equal(
+      cloudFriendlyPeerLabel({
+        email: "alice@example.com",
+      }),
+      "User",
+    );
+    assert.equal(
+      cloudVisiblePeerLabel("alice@example.com", "user:anaconda:alice/browser:tab"),
+      "Alice",
     );
     assert.equal(
       cloudFriendlyPeerLabel({

--- a/apps/notebook-cloud/test/viewer-render-props.test.ts
+++ b/apps/notebook-cloud/test/viewer-render-props.test.ts
@@ -240,31 +240,30 @@ test("cloud viewer routes notebook header controls through the shared shell chro
   assert.doesNotMatch(sourceText, /setPresence\(/);
   assert.doesNotMatch(sourceText, /label=\{compactCloudPresenceLabel\(presenceDisplay\.label\)\}/);
   assert.match(sharingSourceText, /export function CloudSharingControls/);
+  assert.match(sharingSourceText, /Invite people, review requests, and manage link access\./);
   assert.match(
     sharingSourceText,
-    /Public link, collaborators, pending invites, and edit requests\./,
-  );
-  assert.match(
-    sharingSourceText,
-    /const accessSummary = useMemo\(\(\) => cloudShareAccessSummary\(accessRows\)/,
+    /const accessProjection = useMemo\(\s*\(\) => buildCloudShareAccessProjection\(\{ acl, invites, accessRequests \}\)/,
   );
   assert.match(sharingSourceText, /<div className="cloud-share-current-heading">/);
+  assert.match(sharingSourceText, /aria-label="Compute access"/);
+  assert.match(sharingSourceText, /accessProjection\.runtimeAccessRows\.map/);
   assert.match(sharingSourceText, /<div className="cloud-share-row-actions">/);
   assert.match(
     sharingSourceText,
     /<span className="cloud-share-state" data-tone=\{row\.stateTone \?\? undefined\}>/,
   );
   assert.match(sharingSourceText, /Can view this notebook without signing in/);
-  assert.match(sharingSourceText, /Only invited people can open this notebook/);
+  assert.match(sharingSourceText, /Link access is off\. Only listed people can open this notebook/);
   assert.match(sharingSourceText, /const copyLinkLabel =[\s\S]*"Copy link"/);
   assert.match(sharingSourceText, /const compactCopyLinkLabel =[\s\S]*"Copy"/);
   assert.match(
     sharingSourceText,
-    /buildCloudShareAccessRows\(\{ acl, invites, accessRequests \}\)/,
+    /buildCloudShareAccessProjection\(\{ acl, invites, accessRequests \}\)/,
   );
   assert.match(
     sharingSourceText,
-    /accessRows\.map\(\(row\) =>[\s\S]*<CloudShareRowIcon row=\{row\} \/>[\s\S]*<strong>\{row\.label\}<\/strong>[\s\S]*<span>\{row\.detail\}<\/span>/,
+    /accessProjection\.notebookAccessRows\.map\(\(row\) =>[\s\S]*<CloudShareRowIcon row=\{row\} \/>[\s\S]*<strong>\{row\.label\}<\/strong>[\s\S]*<span>\{row\.detail\}<\/span>/,
   );
   assert.match(sharingSourceText, /aria-label=\{`Remove \$\{row\.label\}`\}/);
   const sharePanelCss = cssText.match(/\.cloud-share-panel \{(?<body>[\s\S]*?)\n\}/)?.groups?.body;

--- a/apps/notebook-cloud/test/viewer-render-props.test.ts
+++ b/apps/notebook-cloud/test/viewer-render-props.test.ts
@@ -112,6 +112,20 @@ test("cloud callback keeps sign-in handoff in the entry surface language", () =>
   assert.doesNotMatch(callbackSource, /className="flex min-h-screen/);
 });
 
+test("cloud viewer keeps pending access-request polling quiet", () => {
+  const sourceText = viewerFileContaining("CLOUD_ACCESS_REQUEST_POLL_INTERVAL_MS");
+
+  assert.match(sourceText, /const CLOUD_ACCESS_REQUEST_POLL_INTERVAL_MS = 30_000;/);
+  assert.match(sourceText, /function shouldPollPendingCloudAccessRequest\(\): boolean/);
+  assert.match(sourceText, /document\.visibilityState !== "hidden"/);
+  assert.match(sourceText, /let pollInFlight = false;/);
+  assert.match(sourceText, /if \(!shouldPollPendingCloudAccessRequest\(\) \|\| pollInFlight\)/);
+  assert.match(
+    sourceText,
+    /document\.addEventListener\("visibilitychange", handleVisibilityChange\)/,
+  );
+});
+
 test("cloud viewer routes notebook header controls through the shared shell chrome", () => {
   const sourceText = viewerCorpus;
   const sessionSourcePath = new URL("../viewer/cloud-viewer-session.ts", import.meta.url);
@@ -137,7 +151,10 @@ test("cloud viewer routes notebook header controls through the shared shell chro
   );
   assert.match(sourceText, /<NotebookDocumentToolbar[\s\S]*capabilities=\{shellCapabilities\}/);
   assert.match(sourceText, /presence=\{<CloudNotebookTitle \/>/);
-  assert.match(sourceText, /import \{ CloudNotebookTitle \} from "\.\/cloud-notebook-title";/);
+  assert.match(
+    sourceText,
+    /import \{ CloudNotebookTitle, cloudNotebookRouteTitle \} from "\.\/cloud-notebook-title";/,
+  );
   assert.match(titleSourceText, /className="cloud-notebook-home-link"/);
   assert.match(titleSourceText, /<House aria-hidden="true" \/>/);
   assert.doesNotMatch(titleSourceText, /cloud-notebook-logo/);
@@ -154,9 +171,11 @@ test("cloud viewer routes notebook header controls through the shared shell chro
   assert.match(sourceText, /editControls=\{[\s\S]*<CloudNotebookEditModeButton/);
   assert.match(
     sourceText,
-    /authControls=\{[\s\S]*shouldShowCloudHeaderSignIn\(authState, \{[\s\S]*hasAppSession: Boolean\(appSessionStatus\.session\),[\s\S]*\}\) \? \(/,
+    /authControls=\{[\s\S]*shouldShowCloudHeaderSignIn\(authState, \{[\s\S]*hasAppSession,[\s\S]*\}\) \? \(/,
   );
   assert.match(sourceText, /authControls=\{[\s\S]*<CloudNotebookSignInButton/);
+  assert.match(sourceText, /const hasAppSession = Boolean\(appSessionStatus\.session\)/);
+  assert.match(sourceText, /projectCloudAccessRequestTransition\(\{/);
   // The connection/identity slot is filled by the shared quiet component:
   // avatar + connectivity dot, driven by the stable status bridge. It must
   // never regress into a text pill or a second status label surface. The

--- a/apps/notebook-cloud/test/viewer-shared-cell-surface.test.ts
+++ b/apps/notebook-cloud/test/viewer-shared-cell-surface.test.ts
@@ -333,12 +333,16 @@ test("cloud edit mode chrome renders through the shared shell component", () => 
   assert.doesNotMatch(sourceText, /projectCloudNotebookEditAccess/);
   assert.doesNotMatch(sourceText, /cloudNotebookShellCapabilities/);
   assert.match(shellHookSourceText, /projectCloudNotebookEditAccess/);
+  assert.match(shellHookSourceText, /projectCloudNotebookDocumentEditReadiness/);
   assert.match(shellHookSourceText, /cloudNotebookShellCapabilities/);
   assert.match(shellHookSourceText, /selectedMode/);
   assert.match(shellHookSourceText, /editAccessRequestPending/);
   assert.match(sourceText, /onModeChange=\{setSelectedInteractionMode\}/);
   assert.match(sourceText, /onRequestEditAccess=\{requestCloudEditAccess\}/);
-  assert.match(shellHookSourceText, /const editAccessPending = roomEditAccess\.editAccessPending/);
+  assert.match(
+    shellHookSourceText,
+    /const editAccessPending =[\s\S]*roomEditAccess\.editAccessPending \|\| editReadiness\.selectedEditModeWaitingForRoom/,
+  );
   assert.doesNotMatch(sourceText, /appliedGrantedEditScopeRef/);
   assert.doesNotMatch(sourceText, /requestedEditAccess/);
   assert.doesNotMatch(
@@ -595,9 +599,8 @@ test("cloud app-session live sync requests the resolved notebook-list scope", ()
 
   assert.match(sourceText, /async function resolveCloudAppSessionSyncScope/);
   assert.match(sourceText, /new URL\("api\/n\?limit=100"/);
-  assert.match(sourceText, /isCloudNotebookListItem\(candidate\)/);
-  assert.match(sourceText, /candidate\.notebook_id === notebookId/);
-  assert.match(sourceText, /return notebook\.scope/);
+  assert.match(sourceText, /cloudNotebookCatalogScopeFromList\(notebooks, notebookId\)/);
+  assert.match(sourceText, /if \(catalogScope\) \{[\s\S]*return catalogScope;/);
   assert.match(sourceText, /return selectedMode === "edit" \? "owner" : "viewer"/);
   assert.match(
     sourceText,

--- a/apps/notebook-cloud/test/viewer-shared-cell-surface.test.ts
+++ b/apps/notebook-cloud/test/viewer-shared-cell-surface.test.ts
@@ -405,10 +405,12 @@ test("cloud host notices sit in the shared shell above the rail and notebook sta
 
   assert.match(sourceText, /const hasNotices =/);
   assert.match(sourceText, /const noticeStatus: ViewerStatus =/);
+  assert.match(sourceText, /projectCloudNotebookViewLoading\(\{/);
   assert.match(
     sourceText,
-    /notebookViewIsLoading && \(status\.kind === "ready" \|\| status\.kind === "empty"\)[\s\S]*Preparing notebook view/,
+    /hasAccessDiagnostic: isCloudConnectionAccessDiagnostic\(connectionError\)/,
   );
+  assert.match(sourceText, /Preparing notebook view/);
   assert.match(sourceText, /const notices = hasNotices \? \(/);
   assert.match(sourceText, /notices=\{notices\}/);
   assert.match(sourceText, /noticesClassName="cloud-notebook-notices"/);
@@ -472,14 +474,19 @@ test("cloud outline keeps iframe heading hashes at parent cell anchors", () => {
 
 test("cloud live materialization skips empty room handles before resolving outputs", () => {
   const sourceText = viewerCorpus;
+  const loadingProjectionSourcePath = new URL(
+    "../viewer/notebook-view-loading.ts",
+    import.meta.url,
+  );
+  const loadingProjectionSourceText = readFileSync(loadingProjectionSourcePath, "utf8");
   const sessionSourcePath = new URL("../viewer/cloud-viewer-session.ts", import.meta.url);
   const sessionSourceText = readFileSync(sessionSourcePath, "utf8");
 
   assert.match(sourceText, /const CLOUD_EMPTY_ROOM_GRACE_MS = 900;/);
   assert.match(sourceText, /const \[emptyRoomGraceElapsed, setEmptyRoomGraceElapsed\]/);
   assert.match(
-    sourceText,
-    /status\.kind === "empty" && notebookCellIds\.length === 0 && !emptyRoomGraceElapsed/,
+    loadingProjectionSourceText,
+    /status\.kind === "empty" && cellCount === 0 && !emptyRoomGraceElapsed/,
   );
   assert.match(sessionSourceText, /const rawCellCount = liveRuntime\.handle\.cell_count\(\);/);
   // The zero-cell guard routes through the displacement policy: a painted

--- a/apps/notebook-cloud/test/viewer-shared-cell-surface.test.ts
+++ b/apps/notebook-cloud/test/viewer-shared-cell-surface.test.ts
@@ -635,6 +635,25 @@ test("cloud sync keeps routine frame logs out of the browser console", () => {
   assert.match(sourceText, /warn: \(message: string, \.\.\.args: unknown\[\]\) => console\.warn/);
 });
 
+test("cloud command client keeps routine command logs out of the browser console", () => {
+  const sourceText = viewerFileContaining("const createCloudNotebookClient = useCallback");
+
+  assert.match(sourceText, /const cloudNotebookClientLogger: SyncEngineLogger = \{/);
+  assert.match(
+    sourceText,
+    /const cloudNotebookClientLogger: SyncEngineLogger = \{[\s\S]*debug: \(\) => \{\}/,
+  );
+  assert.match(
+    sourceText,
+    /const cloudNotebookClientLogger: SyncEngineLogger = \{[\s\S]*info: \(\) => \{\}/,
+  );
+  assert.match(
+    sourceText,
+    /logger: cloudNotebookClientLogger,[\s\S]*getRequiredHeads: \(\) => liveRuntime\.handle\.get_heads_hex\(\)/,
+  );
+  assert.doesNotMatch(sourceText, /logger: console/);
+});
+
 test("cloud installs a host logger sink for shared notebook components", () => {
   const sourceText = viewerCorpus;
 

--- a/apps/notebook-cloud/test/viewer-shared-cell-surface.test.ts
+++ b/apps/notebook-cloud/test/viewer-shared-cell-surface.test.ts
@@ -371,7 +371,11 @@ test("cloud edit mode chrome renders through the shared shell component", () => 
   assert.doesNotMatch(cssText, /cloud-edit-mode-placeholder/);
   assert.doesNotMatch(cssText, /cloud-command-toolbar-placeholder/);
   assert.match(authControlsSourceText, /if \(mode === "edit" && !canSwitchToEdit\) \{/);
-  assert.match(sourceText, /storeCloudRequestedScope\(window\.localStorage, "editor"\)/);
+  assert.match(sourceText, /projectCloudAccessRequestTransition\(\{/);
+  assert.match(
+    sourceText,
+    /if \(transition\.requestedScope\) \{[\s\S]*storeCloudRequestedScope\(window\.localStorage, transition\.requestedScope\);/,
+  );
   assert.doesNotMatch(sourceText, /mode === "edit" \? "editor" : NOTEBOOK_CLOUD_DEFAULT_SCOPE/);
   assert.doesNotMatch(sourceText, /className="cloud-scope-toggle-button"/);
   assert.doesNotMatch(cssText, /cloud-scope-toggle-button/);

--- a/apps/notebook-cloud/test/viewer-shared-cell-surface.test.ts
+++ b/apps/notebook-cloud/test/viewer-shared-cell-surface.test.ts
@@ -599,13 +599,14 @@ test("cloud app-session live sync requests the resolved notebook-list scope", ()
 
   assert.match(sourceText, /async function resolveCloudAppSessionSyncScope/);
   assert.match(sourceText, /new URL\("api\/n\?limit=100"/);
-  assert.match(sourceText, /cloudNotebookCatalogScopeFromList\(notebooks, notebookId\)/);
+  assert.match(sourceText, /createCloudNotebookCatalogAccessLoader\(\{/);
+  assert.match(sourceText, /catalogAccessLoader\.load/);
   assert.match(sourceText, /cloudNotebookSyncScopeForCatalogAccess\(\{/);
-  assert.match(sourceText, /catalogResolved: true/);
   assert.match(sourceText, /catalogResolved: false/);
+  assert.match(sourceText, /\.\.\.\(await loadCatalogAccess\(\)\)/);
   assert.match(
     sourceText,
-    /const requestedScope = await resolveCloudAppSessionSyncScope\([\s\S]*config\.notebookId,[\s\S]*selectedInteractionMode,[\s\S]*\)/,
+    /const requestedScope = await resolveCloudAppSessionSyncScope\([\s\S]*catalogAccessLoader\.load,[\s\S]*selectedInteractionMode,[\s\S]*\)/,
   );
   assert.doesNotMatch(
     sourceText,

--- a/apps/notebook-cloud/test/viewer-shared-cell-surface.test.ts
+++ b/apps/notebook-cloud/test/viewer-shared-cell-surface.test.ts
@@ -405,11 +405,13 @@ test("cloud host notices sit in the shared shell above the rail and notebook sta
 
   assert.match(sourceText, /const hasNotices =/);
   assert.match(sourceText, /const noticeStatus: ViewerStatus =/);
-  assert.match(sourceText, /projectCloudNotebookViewSurface\(\{/);
   assert.match(
     sourceText,
-    /bodyAccessBlocked: cloudConnectionDiagnosticBlocksNotebookBody\(connectionError\)/,
+    /const notebookBodyAccessBlocked = cloudConnectionDiagnosticBlocksNotebookBody\(connectionError\)/,
   );
+  assert.match(sourceText, /const notebookHeaderChrome = projectCloudNotebookHeaderChrome\(\{/);
+  assert.match(sourceText, /projectCloudNotebookViewSurface\(\{/);
+  assert.match(sourceText, /bodyAccessBlocked: notebookBodyAccessBlocked/);
   assert.match(
     sourceText,
     /hasAccessDiagnostic: isCloudConnectionAccessDiagnostic\(connectionError\)/,

--- a/apps/notebook-cloud/test/viewer-shared-cell-surface.test.ts
+++ b/apps/notebook-cloud/test/viewer-shared-cell-surface.test.ts
@@ -600,8 +600,9 @@ test("cloud app-session live sync requests the resolved notebook-list scope", ()
   assert.match(sourceText, /async function resolveCloudAppSessionSyncScope/);
   assert.match(sourceText, /new URL\("api\/n\?limit=100"/);
   assert.match(sourceText, /cloudNotebookCatalogScopeFromList\(notebooks, notebookId\)/);
-  assert.match(sourceText, /if \(catalogScope\) \{[\s\S]*return catalogScope;/);
-  assert.match(sourceText, /return selectedMode === "edit" \? "owner" : "viewer"/);
+  assert.match(sourceText, /cloudNotebookSyncScopeForCatalogAccess\(\{/);
+  assert.match(sourceText, /catalogResolved: true/);
+  assert.match(sourceText, /catalogResolved: false/);
   assert.match(
     sourceText,
     /const requestedScope = await resolveCloudAppSessionSyncScope\([\s\S]*config\.notebookId,[\s\S]*selectedInteractionMode,[\s\S]*\)/,

--- a/apps/notebook-cloud/test/viewer-shared-cell-surface.test.ts
+++ b/apps/notebook-cloud/test/viewer-shared-cell-surface.test.ts
@@ -405,7 +405,11 @@ test("cloud host notices sit in the shared shell above the rail and notebook sta
 
   assert.match(sourceText, /const hasNotices =/);
   assert.match(sourceText, /const noticeStatus: ViewerStatus =/);
-  assert.match(sourceText, /projectCloudNotebookViewLoading\(\{/);
+  assert.match(sourceText, /projectCloudNotebookViewSurface\(\{/);
+  assert.match(
+    sourceText,
+    /bodyAccessBlocked: cloudConnectionDiagnosticBlocksNotebookBody\(connectionError\)/,
+  );
   assert.match(
     sourceText,
     /hasAccessDiagnostic: isCloudConnectionAccessDiagnostic\(connectionError\)/,

--- a/apps/notebook-cloud/test/viewer-sharing.test.ts
+++ b/apps/notebook-cloud/test/viewer-sharing.test.ts
@@ -1,6 +1,7 @@
 import assert from "node:assert/strict";
 import { describe, it } from "node:test";
 import {
+  buildCloudShareAccessProjection,
   buildCloudShareAccessRows,
   clearCloudShareAccessRowsCachesForTests,
   cloudShareAccessSummary,
@@ -83,6 +84,50 @@ describe("cloud viewer sharing client", () => {
       ],
     );
     assert.equal(cloudShareAccessSummary(rows), "2 people, public link, 1 invite, 1 request");
+  });
+
+  it("projects runtime peer access separately from notebook collaborators", () => {
+    const acl: CloudNotebookAclRow[] = [
+      aclRow({
+        subject: "user:anaconda:owner",
+        scope: "owner",
+        display: {
+          kind: "principal",
+          label: "Owner User",
+          principal: "user:anaconda:owner",
+          email: "owner@example.com",
+        },
+      }),
+      aclRow({
+        subject: "user:anaconda:runtime",
+        scope: "runtime_peer",
+        display: {
+          kind: "principal",
+          label: "Lab Runtime",
+          principal: "user:anaconda:runtime",
+          email: "runtime@example.com",
+        },
+      }),
+    ];
+    const invites = [inviteRow({ id: "invite-runtime-split", email: "bob@example.com" })];
+    const projection = buildCloudShareAccessProjection({ acl, invites });
+
+    assert.deepEqual(
+      projection.notebookAccessRows.map((row) => [row.label, row.badge, row.removable]),
+      [
+        ["Owner User", "Owner", false],
+        ["b...b@example.com", "Can edit", true],
+      ],
+    );
+    assert.deepEqual(
+      projection.runtimeAccessRows.map((row) => [row.label, row.detail, row.badge, row.removable]),
+      [["Lab Runtime", "Compute access for runtime peers", "Runtime", false]],
+    );
+    assert.equal(projection.notebookAccessSummary, "1 person, 1 invite");
+    assert.equal(projection.runtimeAccessSummary, "1 runtime peer");
+    assert.equal(Object.isFrozen(projection), true);
+    assert.equal(Object.isFrozen(projection.notebookAccessRows), true);
+    assert.equal(Object.isFrozen(projection.runtimeAccessRows), true);
   });
 
   it("detects public viewer access from explicit public ACL rows", () => {

--- a/apps/notebook-cloud/test/viewer-shell-capabilities.test.ts
+++ b/apps/notebook-cloud/test/viewer-shell-capabilities.test.ts
@@ -403,6 +403,30 @@ test("cloud shell capabilities keep requested edit pending until the room grants
   assert.equal(capabilities.access.level, "viewer");
 });
 
+test("cloud shell capabilities can show catalog owner access without granting live execution", () => {
+  const capabilities = cloudNotebookShellCapabilities({
+    accessConnectionScope: "owner",
+    authState: authState("anonymous"),
+    connectionScope: null,
+    hasAppSession: true,
+    hasCodeCells: true,
+    selectedMode: "edit",
+    canAcceptCellMutations: false,
+    runtimeAvailable: true,
+    hostCapabilities: { canManageSharing: true },
+  });
+
+  assert.equal(capabilities.access.level, "owner");
+  assert.equal(capabilities.canManageSharing, true);
+  assert.equal(capabilities.canEditMarkdown, false);
+  assert.equal(capabilities.canEditCells, false);
+  assert.equal(capabilities.canEditStructure, false);
+  assert.equal(capabilities.interaction?.selectedMode, "edit");
+  assert.equal(capabilities.interaction?.activeMode, "view");
+  assert.equal(capabilities.runtime.executionAvailable, true);
+  assert.equal(capabilities.canExecute, false);
+});
+
 test("cloud shell capabilities suppress editor mode while a requested edit reconnect is pending", () => {
   const capabilities = cloudNotebookShellCapabilities({
     authState: authState("oidc", "editor"),

--- a/apps/notebook-cloud/test/viewer-shell-capabilities.test.ts
+++ b/apps/notebook-cloud/test/viewer-shell-capabilities.test.ts
@@ -64,8 +64,8 @@ test("cloud shell capabilities grant editors full cell and structure editing wit
   assert.equal(capabilities.interaction?.activeMode, "edit");
   assert.equal(capabilities.interaction?.state, "editing");
   assert.equal(capabilities.access.level, "editor");
-  assert.equal(capabilities.access.identityLabel, "user@example.test");
-  assert.equal(capabilities.access.actor?.principal.label, "user@example.test");
+  assert.equal(capabilities.access.identityLabel, "User");
+  assert.equal(capabilities.access.actor?.principal.label, "User");
   assert.equal(capabilities.access.actor?.principal.source?.provider, "oidc");
   assert.equal(capabilities.access.actor?.operator.kind, "browser");
   assert.equal(capabilities.auth.canUseAuthenticatedIdentity, true);
@@ -606,9 +606,9 @@ test("cloud shell capabilities preserve room actor labels for shared access UI",
 
   assert.equal(capabilities.access.level, "owner");
   assert.equal(capabilities.access.actorLabel, "user:anaconda:alice/browser:tab");
-  assert.equal(capabilities.access.identityLabel, "user@example.test");
+  assert.equal(capabilities.access.identityLabel, "Alice");
   assert.equal(capabilities.access.actor?.actorLabel, "user:anaconda:alice/browser:tab");
-  assert.equal(capabilities.access.actor?.principal.label, "user@example.test");
+  assert.equal(capabilities.access.actor?.principal.label, "Alice");
 });
 
 test("cloud shell capabilities prefer the room-ready peer label over local auth fallbacks", () => {
@@ -708,13 +708,13 @@ test("cloud shell capabilities keep runtime peer authority separate from documen
   assert.equal(capabilities.runtime.connected, true);
   assert.equal(capabilities.runtime.source, "cloud");
   assert.equal(capabilities.runtime.actorLabel, "user:anaconda:alice/runtime:jupyterhub");
-  assert.equal(capabilities.runtime.identityLabel, "user@example.test");
+  assert.equal(capabilities.runtime.identityLabel, "JupyterHub for Alice");
   assert.equal(capabilities.runtime.actor?.scope, "runtime_peer");
   assert.equal(capabilities.runtime.target?.id, "runtime-peer");
   assert.equal(capabilities.runtime.target?.kind, "runtime_peer");
   assert.equal(capabilities.runtime.target?.status, "attached");
   assert.equal(capabilities.runtime.target?.label, "Runtime peer");
-  assert.equal(capabilities.runtime.actor?.principal.label, "user@example.test");
+  assert.equal(capabilities.runtime.actor?.principal.label, "JupyterHub for Alice");
   assert.equal(capabilities.runtime.actor?.operator.kind, "runtime");
   assert.equal(capabilities.runtime.actor?.operator.label, "JupyterHub");
 });

--- a/apps/notebook-cloud/test/worker-routes.test.ts
+++ b/apps/notebook-cloud/test/worker-routes.test.ts
@@ -880,6 +880,31 @@ describe("Worker artifact routes", () => {
     assert.equal(response.headers.get("Content-Type"), "application/javascript");
   });
 
+  it("serves favicon requests without falling through to the JSON 404", async () => {
+    const env = fakeEnv();
+
+    const response = await worker.fetch(
+      new Request("http://localhost/favicon.ico"),
+      env,
+      fakeContext(),
+    );
+    const body = await response.text();
+
+    assert.equal(response.status, 200);
+    assert.equal(response.headers.get("Content-Type"), "image/svg+xml; charset=utf-8");
+    assert.equal(response.headers.get("Cache-Control"), "public, max-age=86400");
+    assert.match(body, /<svg xmlns="http:\/\/www\.w3\.org\/2000\/svg"/);
+
+    const headResponse = await worker.fetch(
+      new Request("http://localhost/favicon.svg", { method: "HEAD" }),
+      env,
+      fakeContext(),
+    );
+    assert.equal(headResponse.status, 200);
+    assert.equal(headResponse.headers.get("Content-Type"), "image/svg+xml; charset=utf-8");
+    assert.equal(await headResponse.text(), "");
+  });
+
   it("adds CORS when plugin assets are routed through the Worker", async () => {
     const seenPaths: string[] = [];
     const env = fakeEnv({

--- a/apps/notebook-cloud/test/worker-routes.test.ts
+++ b/apps/notebook-cloud/test/worker-routes.test.ts
@@ -219,6 +219,20 @@ describe("Worker artifact routes", () => {
     assert.doesNotMatch(html, /topic-viz.*render/);
   });
 
+  it("preserves acronym-looking words in route-derived viewer titles", async () => {
+    const env = fakeEnv();
+
+    const response = await worker.fetch(
+      new Request("http://localhost/n/notebook-123/Quill%20HF%20workstation%20smoke"),
+      env,
+      fakeContext(),
+    );
+
+    assert.equal(response.status, 200);
+    const html = await response.text();
+    assert.match(html, /<title>nteract notebook: Quill HF Workstation Smoke<\/title>/);
+  });
+
   it("uses catalog-safe metadata for public published notebook viewers", async () => {
     const env = fakeEnv();
     seedNotebook(env, "public-meta-demo");

--- a/apps/notebook-cloud/test/worker-routes.test.ts
+++ b/apps/notebook-cloud/test/worker-routes.test.ts
@@ -214,7 +214,7 @@ describe("Worker artifact routes", () => {
 
     assert.equal(response.status, 200);
     const html = await response.text();
-    assert.match(html, /nteract cloud notebook notebook-123/);
+    assert.match(html, /<title>nteract notebook: Topic Viz<\/title>/);
     assert.match(html, /"notebookId":"notebook-123"/);
     assert.doesNotMatch(html, /topic-viz.*render/);
   });
@@ -265,7 +265,7 @@ describe("Worker artifact routes", () => {
 
     assert.equal(response.status, 200);
     const html = await response.text();
-    assert.match(html, /<title>nteract cloud notebook private-meta-demo<\/title>/);
+    assert.match(html, /<title>nteract notebook: Secret Plan<\/title>/);
     assert.match(html, /Private notebook metadata is shown after access is verified\./);
     assert.doesNotMatch(html, /Secret Research Plan|revision-private-metadata/);
   });

--- a/apps/notebook-cloud/viewer/__tests__/use-cloud-workstations.test.tsx
+++ b/apps/notebook-cloud/viewer/__tests__/use-cloud-workstations.test.tsx
@@ -36,6 +36,19 @@ const ownerCloudCapabilities: NotebookShellCapabilities = {
   },
 };
 
+const viewerCloudCapabilities: NotebookShellCapabilities = {
+  ...readOnlyNotebookShellCapabilities,
+  access: {
+    ...readOnlyNotebookShellCapabilities.access,
+    level: "viewer",
+    source: "cloud",
+  },
+  auth: {
+    ...readOnlyNotebookShellCapabilities.auth,
+    canUseAuthenticatedIdentity: true,
+  },
+};
+
 const devAuth: CloudPrototypeAuthState = {
   mode: "dev",
   token: "dev-secret",
@@ -51,15 +64,21 @@ const config = {
   workstationAttachEndpoint: "/api/n/nb-1/workstation-attachments",
 };
 
-function renderManager() {
+function renderManager(
+  options: {
+    canLoadCloudWorkstations?: boolean;
+    capabilities?: NotebookShellCapabilities;
+    panelIsOpen?: boolean;
+  } = {},
+) {
   return renderHook(() =>
     useCloudWorkstationManager({
       config,
       authState: devAuth,
-      capabilities: ownerCloudCapabilities,
-      canLoadCloudWorkstations: true,
+      capabilities: options.capabilities ?? ownerCloudCapabilities,
+      canLoadCloudWorkstations: options.canLoadCloudWorkstations ?? true,
       workstationAttachment: null,
-      panelIsOpen: false,
+      panelIsOpen: options.panelIsOpen ?? false,
       onOpenWorkstationsRail: vi.fn(),
     }),
   );
@@ -100,6 +119,16 @@ describe("useCloudWorkstationManager pairing", () => {
   afterEach(() => {
     vi.useRealTimers();
     vi.clearAllMocks();
+  });
+
+  it("does not load the workstation registry for authenticated viewers", async () => {
+    renderManager({ capabilities: viewerCloudCapabilities });
+
+    await act(async () => {
+      await Promise.resolve();
+    });
+
+    expect(clientMocks.fetchCloudWorkstations).not.toHaveBeenCalled();
   });
 
   it("starts a pending pairing with the connect command built from the origin", async () => {

--- a/apps/notebook-cloud/viewer/cloud-access-request-state.ts
+++ b/apps/notebook-cloud/viewer/cloud-access-request-state.ts
@@ -16,6 +16,7 @@ export interface ProjectCloudAccessRequestTransitionOptions {
   connectionScope: string | null;
   hasAppSession: boolean;
   request: Pick<CloudNotebookAccessRequest, "status"> | null;
+  selectedMode: CloudNotebookUrlMode;
 }
 
 const NO_CLOUD_ACCESS_REQUEST_TRANSITION: CloudAccessRequestTransition = Object.freeze({
@@ -31,12 +32,16 @@ export function projectCloudAccessRequestTransition({
   connectionScope,
   hasAppSession,
   request,
+  selectedMode,
 }: ProjectCloudAccessRequestTransitionOptions): CloudAccessRequestTransition {
   if (accessScope === "editor" || accessScope === "owner") {
     return NO_CLOUD_ACCESS_REQUEST_TRANSITION;
   }
 
   if (request?.status === "pending" || request?.status === "approved") {
+    if (selectedMode !== "edit") {
+      return NO_CLOUD_ACCESS_REQUEST_TRANSITION;
+    }
     return {
       requestedScope: "editor",
       selectedMode: "edit",

--- a/apps/notebook-cloud/viewer/cloud-access-request-state.ts
+++ b/apps/notebook-cloud/viewer/cloud-access-request-state.ts
@@ -11,6 +11,7 @@ export interface CloudAccessRequestTransition {
 }
 
 export interface ProjectCloudAccessRequestTransitionOptions {
+  accessScope?: string | null;
   authState: Pick<CloudPrototypeAuthState, "mode" | "requestedScope">;
   connectionScope: string | null;
   hasAppSession: boolean;
@@ -25,11 +26,16 @@ const NO_CLOUD_ACCESS_REQUEST_TRANSITION: CloudAccessRequestTransition = Object.
 });
 
 export function projectCloudAccessRequestTransition({
+  accessScope = null,
   authState,
   connectionScope,
   hasAppSession,
   request,
 }: ProjectCloudAccessRequestTransitionOptions): CloudAccessRequestTransition {
+  if (accessScope === "editor" || accessScope === "owner") {
+    return NO_CLOUD_ACCESS_REQUEST_TRANSITION;
+  }
+
   if (request?.status === "pending" || request?.status === "approved") {
     return {
       requestedScope: "editor",

--- a/apps/notebook-cloud/viewer/cloud-access-request-state.ts
+++ b/apps/notebook-cloud/viewer/cloud-access-request-state.ts
@@ -1,0 +1,71 @@
+import type { ConnectionScope } from "../src/auth-shared";
+import type { CloudPrototypeAuthState } from "./collaborator-auth";
+import type { CloudNotebookUrlMode } from "./cloud-notebook-mode";
+import type { CloudNotebookAccessRequest } from "./sharing-client";
+
+export interface CloudAccessRequestTransition {
+  requestedScope: ConnectionScope | null;
+  selectedMode: CloudNotebookUrlMode | null;
+  refreshPrototypeAuth: boolean;
+  retryLiveConnection: boolean;
+}
+
+export interface ProjectCloudAccessRequestTransitionOptions {
+  authState: Pick<CloudPrototypeAuthState, "mode" | "requestedScope">;
+  connectionScope: string | null;
+  hasAppSession: boolean;
+  request: Pick<CloudNotebookAccessRequest, "status"> | null;
+}
+
+const NO_CLOUD_ACCESS_REQUEST_TRANSITION: CloudAccessRequestTransition = Object.freeze({
+  requestedScope: null,
+  selectedMode: null,
+  refreshPrototypeAuth: false,
+  retryLiveConnection: false,
+});
+
+export function projectCloudAccessRequestTransition({
+  authState,
+  connectionScope,
+  hasAppSession,
+  request,
+}: ProjectCloudAccessRequestTransitionOptions): CloudAccessRequestTransition {
+  if (request?.status === "pending" || request?.status === "approved") {
+    return {
+      requestedScope: "editor",
+      selectedMode: "edit",
+      refreshPrototypeAuth:
+        cloudPrototypeAuthCarriesRequestedScope(authState.mode, hasAppSession) &&
+        authState.requestedScope !== "editor",
+      retryLiveConnection: request.status === "approved",
+    };
+  }
+
+  if (
+    authState.requestedScope === "editor" &&
+    connectionScope === "viewer" &&
+    cloudPrototypeAuthCarriesRequestedScope(authState.mode, hasAppSession)
+  ) {
+    return {
+      requestedScope: "viewer",
+      selectedMode: "view",
+      refreshPrototypeAuth: true,
+      retryLiveConnection: false,
+    };
+  }
+
+  return NO_CLOUD_ACCESS_REQUEST_TRANSITION;
+}
+
+export function cloudPrototypeAuthCarriesRequestedScope(
+  mode: CloudPrototypeAuthState["mode"],
+  hasAppSession: boolean,
+): boolean {
+  if (mode === "dev") {
+    return true;
+  }
+  if (hasAppSession) {
+    return false;
+  }
+  return mode === "oidc" || mode === "invalid";
+}

--- a/apps/notebook-cloud/viewer/cloud-access-request-state.ts
+++ b/apps/notebook-cloud/viewer/cloud-access-request-state.ts
@@ -3,6 +3,13 @@ import type { CloudPrototypeAuthState } from "./collaborator-auth";
 import type { CloudNotebookUrlMode } from "./cloud-notebook-mode";
 import type { CloudNotebookAccessRequest } from "./sharing-client";
 
+export interface CloudAccessRequestNoticeProjection {
+  kind: "error" | "pending" | "approved" | "denied" | "dismissed";
+  tone: "info" | "warning" | "error" | "success";
+  title: string;
+  message: string;
+}
+
 export interface CloudAccessRequestTransition {
   requestedScope: ConnectionScope | null;
   selectedMode: CloudNotebookUrlMode | null;
@@ -79,4 +86,61 @@ export function cloudPrototypeAuthCarriesRequestedScope(
     return false;
   }
   return mode === "oidc" || mode === "invalid";
+}
+
+export function projectCloudAccessRequestNotice({
+  error,
+  request,
+  selectedMode,
+}: {
+  error: string | null;
+  request: Pick<CloudNotebookAccessRequest, "status"> | null;
+  selectedMode: CloudNotebookUrlMode;
+}): CloudAccessRequestNoticeProjection | null {
+  if (error) {
+    return {
+      kind: "error",
+      tone: "error",
+      title: "Edit request failed.",
+      message: error,
+    };
+  }
+
+  if (!request || selectedMode !== "edit") {
+    return null;
+  }
+
+  if (request.status === "pending") {
+    return {
+      kind: "pending",
+      tone: "info",
+      title: "Edit access requested.",
+      message: "The owner can review this request from the sharing panel.",
+    };
+  }
+
+  if (request.status === "approved") {
+    return {
+      kind: "approved",
+      tone: "success",
+      title: "Edit access approved.",
+      message: "Reconnecting with editor access.",
+    };
+  }
+
+  if (request.status === "denied") {
+    return {
+      kind: "denied",
+      tone: "warning",
+      title: "Edit request denied.",
+      message: "The notebook stays in view mode.",
+    };
+  }
+
+  return {
+    kind: "dismissed",
+    tone: "info",
+    title: "Edit request dismissed.",
+    message: "The owner dismissed the request.",
+  };
 }

--- a/apps/notebook-cloud/viewer/cloud-access-request-state.ts
+++ b/apps/notebook-cloud/viewer/cloud-access-request-state.ts
@@ -26,6 +26,14 @@ export interface ProjectCloudAccessRequestTransitionOptions {
   selectedMode: CloudNotebookUrlMode;
 }
 
+export interface CloudAccessRequestLoadProjectionInput {
+  canUseAuthenticatedCloudApi: boolean;
+  catalogGrantsDocumentEdit: boolean;
+  connectionScope: string | null;
+  hasBrowserAppIdentity: boolean;
+  selectedMode: CloudNotebookUrlMode;
+}
+
 const NO_CLOUD_ACCESS_REQUEST_TRANSITION: CloudAccessRequestTransition = Object.freeze({
   requestedScope: null,
   selectedMode: null,
@@ -86,6 +94,22 @@ export function cloudPrototypeAuthCarriesRequestedScope(
     return false;
   }
   return mode === "oidc" || mode === "invalid";
+}
+
+export function shouldLoadOwnCloudAccessRequest({
+  canUseAuthenticatedCloudApi,
+  catalogGrantsDocumentEdit,
+  connectionScope,
+  hasBrowserAppIdentity,
+  selectedMode,
+}: CloudAccessRequestLoadProjectionInput): boolean {
+  return (
+    selectedMode === "edit" &&
+    connectionScope === "viewer" &&
+    hasBrowserAppIdentity &&
+    canUseAuthenticatedCloudApi &&
+    !catalogGrantsDocumentEdit
+  );
 }
 
 export function projectCloudAccessRequestNotice({

--- a/apps/notebook-cloud/viewer/cloud-notebook-catalog-access.ts
+++ b/apps/notebook-cloud/viewer/cloud-notebook-catalog-access.ts
@@ -1,4 +1,5 @@
 import type { ConnectionScope } from "../src/auth-shared";
+import type { NotebookInteractionMode } from "@/components/notebook";
 import { isCloudNotebookListItem, type CloudNotebookListItem } from "./notebook-dashboard";
 
 export type CloudNotebookCatalogAccessScope = Exclude<
@@ -10,6 +11,12 @@ export interface CloudNotebookAccessScopeProjectionInput {
   catalogScope?: CloudNotebookCatalogAccessScope | null;
   connectionReady: boolean;
   connectionScope: string | null;
+}
+
+export interface CloudNotebookSyncScopeProjectionInput {
+  catalogResolved: boolean;
+  catalogScope?: CloudNotebookCatalogAccessScope | null;
+  selectedMode: NotebookInteractionMode;
 }
 
 export function cloudNotebookCatalogScopeFromList(
@@ -34,6 +41,20 @@ export function cloudNotebookAccessScopeForShell({
     return connectionScope;
   }
   return catalogScope ?? connectionScope;
+}
+
+export function cloudNotebookSyncScopeForCatalogAccess({
+  catalogResolved,
+  catalogScope = null,
+  selectedMode,
+}: CloudNotebookSyncScopeProjectionInput): Exclude<ConnectionScope, "runtime_peer"> {
+  if (catalogScope) {
+    return catalogScope;
+  }
+  if (catalogResolved) {
+    return "viewer";
+  }
+  return selectedMode === "edit" ? "owner" : "viewer";
 }
 
 export function cloudNotebookScopeCanEditDocument(

--- a/apps/notebook-cloud/viewer/cloud-notebook-catalog-access.ts
+++ b/apps/notebook-cloud/viewer/cloud-notebook-catalog-access.ts
@@ -13,6 +13,16 @@ export interface CloudNotebookAccessScopeProjectionInput {
   connectionScope: string | null;
 }
 
+export interface CloudNotebookCatalogAccessLoadResult {
+  catalogResolved: boolean;
+  catalogScope: CloudNotebookCatalogAccessScope | null;
+}
+
+export interface CloudNotebookCatalogAccessLoaderOptions {
+  loadNotebooks: () => Promise<readonly unknown[]>;
+  notebookId: string;
+}
+
 export interface CloudNotebookSyncScopeProjectionInput {
   catalogResolved: boolean;
   catalogScope?: CloudNotebookCatalogAccessScope | null;
@@ -30,6 +40,35 @@ export function cloudNotebookCatalogScopeFromList(
     return null;
   }
   return notebook.scope;
+}
+
+export function cloudNotebookCatalogAccessFromList(
+  notebooks: readonly unknown[],
+  notebookId: string,
+): CloudNotebookCatalogAccessLoadResult {
+  return {
+    catalogResolved: true,
+    catalogScope: cloudNotebookCatalogScopeFromList(notebooks, notebookId),
+  };
+}
+
+export function createCloudNotebookCatalogAccessLoader({
+  loadNotebooks,
+  notebookId,
+}: CloudNotebookCatalogAccessLoaderOptions): {
+  load: () => Promise<CloudNotebookCatalogAccessLoadResult>;
+} {
+  let inFlight: Promise<CloudNotebookCatalogAccessLoadResult> | null = null;
+  const load = () => {
+    inFlight ??= loadNotebooks()
+      .then((notebooks) => cloudNotebookCatalogAccessFromList(notebooks, notebookId))
+      .catch((error: unknown) => {
+        inFlight = null;
+        throw error;
+      });
+    return inFlight;
+  };
+  return { load };
 }
 
 export function cloudNotebookAccessScopeForShell({

--- a/apps/notebook-cloud/viewer/cloud-notebook-catalog-access.ts
+++ b/apps/notebook-cloud/viewer/cloud-notebook-catalog-access.ts
@@ -1,0 +1,43 @@
+import type { ConnectionScope } from "../src/auth-shared";
+import { isCloudNotebookListItem, type CloudNotebookListItem } from "./notebook-dashboard";
+
+export type CloudNotebookCatalogAccessScope = Exclude<
+  CloudNotebookListItem["scope"],
+  "runtime_peer"
+>;
+
+export interface CloudNotebookAccessScopeProjectionInput {
+  catalogScope?: CloudNotebookCatalogAccessScope | null;
+  connectionReady: boolean;
+  connectionScope: string | null;
+}
+
+export function cloudNotebookCatalogScopeFromList(
+  notebooks: readonly unknown[],
+  notebookId: string,
+): CloudNotebookCatalogAccessScope | null {
+  const notebook = notebooks.find(
+    (candidate) => isCloudNotebookListItem(candidate) && candidate.notebook_id === notebookId,
+  );
+  if (!isCloudNotebookListItem(notebook) || notebook.scope === "runtime_peer") {
+    return null;
+  }
+  return notebook.scope;
+}
+
+export function cloudNotebookAccessScopeForShell({
+  catalogScope = null,
+  connectionReady,
+  connectionScope,
+}: CloudNotebookAccessScopeProjectionInput): string | null {
+  if (connectionReady && connectionScope) {
+    return connectionScope;
+  }
+  return catalogScope ?? connectionScope;
+}
+
+export function cloudNotebookScopeCanEditDocument(
+  scope: string | null | undefined,
+): scope is Extract<ConnectionScope, "editor" | "owner"> {
+  return scope === "editor" || scope === "owner";
+}

--- a/apps/notebook-cloud/viewer/cloud-notebook-catalog-access.ts
+++ b/apps/notebook-cloud/viewer/cloud-notebook-catalog-access.ts
@@ -1,5 +1,6 @@
 import type { ConnectionScope } from "../src/auth-shared";
 import type { NotebookInteractionMode } from "@/components/notebook";
+import { CLOUD_CONNECTION_NO_ACCESS_DIAGNOSTIC } from "./connection-diagnostics";
 import { isCloudNotebookListItem, type CloudNotebookListItem } from "./notebook-dashboard";
 
 export type CloudNotebookCatalogAccessScope = Exclude<
@@ -27,6 +28,18 @@ export interface CloudNotebookSyncScopeProjectionInput {
   catalogResolved: boolean;
   catalogScope?: CloudNotebookCatalogAccessScope | null;
   selectedMode: NotebookInteractionMode;
+}
+
+export interface CloudNotebookLiveRoomConnectionProjectionInput {
+  canUseAuthenticatedCloudApi: boolean;
+  catalogLoadFailed?: boolean;
+  catalogResolved: boolean;
+  catalogScope?: CloudNotebookCatalogAccessScope | null;
+}
+
+export interface CloudNotebookLiveRoomConnectionPolicy {
+  shouldConnectLiveRoom: boolean;
+  disabledStatus: { kind: "error" | "loading"; message: string } | null;
 }
 
 export function cloudNotebookCatalogScopeFromList(
@@ -94,6 +107,27 @@ export function cloudNotebookSyncScopeForCatalogAccess({
     return "viewer";
   }
   return selectedMode === "edit" ? "owner" : "viewer";
+}
+
+export function cloudNotebookLiveRoomConnectionPolicy({
+  canUseAuthenticatedCloudApi,
+  catalogLoadFailed = false,
+  catalogResolved,
+  catalogScope = null,
+}: CloudNotebookLiveRoomConnectionProjectionInput): CloudNotebookLiveRoomConnectionPolicy {
+  if (!canUseAuthenticatedCloudApi || catalogLoadFailed || catalogScope) {
+    return { shouldConnectLiveRoom: true, disabledStatus: null };
+  }
+  if (!catalogResolved) {
+    return {
+      shouldConnectLiveRoom: false,
+      disabledStatus: { kind: "loading", message: "Checking notebook access..." },
+    };
+  }
+  return {
+    shouldConnectLiveRoom: false,
+    disabledStatus: { kind: "error", message: CLOUD_CONNECTION_NO_ACCESS_DIAGNOSTIC },
+  };
 }
 
 export function cloudNotebookScopeCanEditDocument(

--- a/apps/notebook-cloud/viewer/cloud-notebook-mode.ts
+++ b/apps/notebook-cloud/viewer/cloud-notebook-mode.ts
@@ -2,11 +2,13 @@ export type CloudNotebookUrlMode = "edit" | "view";
 
 export function cloudNotebookInteractionModeForAccess({
   accessRequestStatus,
+  catalogResolved = false,
   accessScope,
   connectionScope,
   selectedMode,
 }: {
   accessRequestStatus?: string | null;
+  catalogResolved?: boolean;
   accessScope?: string | null;
   connectionScope: string | null;
   selectedMode: CloudNotebookUrlMode;
@@ -17,11 +19,14 @@ export function cloudNotebookInteractionModeForAccess({
   if (accessScope === "editor" || accessScope === "owner") {
     return "edit";
   }
-  if (connectionScope !== "viewer") {
-    return selectedMode;
-  }
   if (accessRequestStatus === "pending" || accessRequestStatus === "approved") {
     return "edit";
+  }
+  if (catalogResolved && !accessScope) {
+    return "view";
+  }
+  if (connectionScope !== "viewer") {
+    return selectedMode;
   }
   return "view";
 }

--- a/apps/notebook-cloud/viewer/cloud-notebook-mode.ts
+++ b/apps/notebook-cloud/viewer/cloud-notebook-mode.ts
@@ -2,14 +2,22 @@ export type CloudNotebookUrlMode = "edit" | "view";
 
 export function cloudNotebookInteractionModeForAccess({
   accessRequestStatus,
+  accessScope,
   connectionScope,
   selectedMode,
 }: {
   accessRequestStatus?: string | null;
+  accessScope?: string | null;
   connectionScope: string | null;
   selectedMode: CloudNotebookUrlMode;
 }): CloudNotebookUrlMode {
-  if (selectedMode !== "edit" || connectionScope !== "viewer") {
+  if (selectedMode !== "edit") {
+    return selectedMode;
+  }
+  if (accessScope === "editor" || accessScope === "owner") {
+    return "edit";
+  }
+  if (connectionScope !== "viewer") {
     return selectedMode;
   }
   if (accessRequestStatus === "pending" || accessRequestStatus === "approved") {

--- a/apps/notebook-cloud/viewer/cloud-notebook-title.tsx
+++ b/apps/notebook-cloud/viewer/cloud-notebook-title.tsx
@@ -21,7 +21,7 @@ export function CloudNotebookTitle() {
   );
 }
 
-function cloudNotebookRouteTitle(): {
+export function cloudNotebookRouteTitle(): {
   label: string;
   detail: string | null;
   title: string;

--- a/apps/notebook-cloud/viewer/cloud-notebook-title.tsx
+++ b/apps/notebook-cloud/viewer/cloud-notebook-title.tsx
@@ -1,4 +1,5 @@
 import { House } from "lucide-react";
+import { notebookRouteSegmentTitle } from "../src/notebook-route-title";
 
 export function CloudNotebookTitle() {
   const title = cloudNotebookRouteTitle();
@@ -28,14 +29,13 @@ export function cloudNotebookRouteTitle(): {
 } {
   const pathParts = window.location.pathname.split("/").filter(Boolean);
   const routeSlug = pathParts[0] === "n" ? pathParts[2] : null;
-  const decodedSlug = safeDecodeRouteSegment(routeSlug);
+  const routeTitle = notebookRouteSegmentTitle(routeSlug);
 
-  if (decodedSlug) {
-    const label = humanizeCloudRouteTitle(decodedSlug);
+  if (routeTitle) {
     return {
-      label,
+      label: routeTitle,
       detail: null,
-      title: label,
+      title: routeTitle,
     };
   }
 
@@ -44,26 +44,4 @@ export function cloudNotebookRouteTitle(): {
     detail: null,
     title: "Cloud Notebook",
   };
-}
-
-function humanizeCloudRouteTitle(value: string): string {
-  return value
-    .replace(/[-_]+/g, " ")
-    .replace(/\s+/g, " ")
-    .trim()
-    .split(" ")
-    .map((word) => {
-      if (!word) return word;
-      return `${word[0]?.toUpperCase() ?? ""}${word.slice(1).toLowerCase()}`;
-    })
-    .join(" ");
-}
-
-function safeDecodeRouteSegment(value: string | null | undefined): string | null {
-  if (!value) return null;
-  try {
-    return decodeURIComponent(value).trim() || null;
-  } catch {
-    return value.trim() || null;
-  }
 }

--- a/apps/notebook-cloud/viewer/cloud-viewer-session.ts
+++ b/apps/notebook-cloud/viewer/cloud-viewer-session.ts
@@ -181,6 +181,7 @@ interface UseCloudViewerSessionOptions {
   config: CloudViewerConfig;
   hasAppSession?: boolean;
   loadingPolicy: CloudViewerLoadingPolicy;
+  liveRoomDisabledStatus?: Extract<ViewerStatus, { kind: "error" | "loading" }> | null;
   preloadSiftWasm: (cells: readonly ResolvedCell[]) => void;
   resolveSyncAuth?: (sessionId: string) => Promise<CloudSyncAuth>;
   widgetStore: WidgetStore;
@@ -204,6 +205,7 @@ export function useCloudViewerSession({
   config,
   hasAppSession = false,
   loadingPolicy,
+  liveRoomDisabledStatus = null,
   preloadSiftWasm,
   resolveSyncAuth,
   widgetStore,
@@ -328,6 +330,21 @@ export function useCloudViewerSession({
       setConnectAttempt((attempt) => attempt + 1);
     }
   }, [authRenewalKind, loadingPolicy.shouldConnectLiveRoom]);
+
+  useEffect(() => {
+    if (
+      authRenewalKind === "refreshing" ||
+      loadingPolicy.shouldConnectLiveRoom ||
+      liveRoomDisabledStatus === null
+    ) {
+      return;
+    }
+    presenceStore.reduceConnection("disconnected");
+    setConnectionError(
+      liveRoomDisabledStatus.kind === "error" ? liveRoomDisabledStatus.message : null,
+    );
+    setStatus(liveRoomDisabledStatus);
+  }, [authRenewalKind, liveRoomDisabledStatus, loadingPolicy.shouldConnectLiveRoom, presenceStore]);
 
   // Identity of the notebook whose cells are currently painted into the
   // view stores — the flicker gate's "previous" side (see effect cleanup).

--- a/apps/notebook-cloud/viewer/cloud-viewer-session.ts
+++ b/apps/notebook-cloud/viewer/cloud-viewer-session.ts
@@ -339,12 +339,19 @@ export function useCloudViewerSession({
     ) {
       return;
     }
+    connectionStatusBridge.noteLiveRoomDisabled();
     presenceStore.reduceConnection("disconnected");
     setConnectionError(
       liveRoomDisabledStatus.kind === "error" ? liveRoomDisabledStatus.message : null,
     );
     setStatus(liveRoomDisabledStatus);
-  }, [authRenewalKind, liveRoomDisabledStatus, loadingPolicy.shouldConnectLiveRoom, presenceStore]);
+  }, [
+    authRenewalKind,
+    connectionStatusBridge,
+    liveRoomDisabledStatus,
+    loadingPolicy.shouldConnectLiveRoom,
+    presenceStore,
+  ]);
 
   // Identity of the notebook whose cells are currently painted into the
   // view stores — the flicker gate's "previous" side (see effect cleanup).

--- a/apps/notebook-cloud/viewer/cloud-viewer-session.ts
+++ b/apps/notebook-cloud/viewer/cloud-viewer-session.ts
@@ -95,6 +95,11 @@ import { projectCloudWidgetComms } from "./widget-comm-projection";
 import type { CloudAppSession } from "./app-session";
 import type { CloudAuthRenewalState, ViewerStatus } from "./notice-types";
 
+const quietSyncHealLogger = {
+  debug: () => {},
+  warn: (message: string, ...args: unknown[]) => console.warn(message, ...args),
+};
+
 /**
  * Renderer sidecar filenames from the deploy manifest. Content-hashed
  * names ride immutable caching on the renderer-assets origin; the stable
@@ -619,7 +624,7 @@ export function useCloudViewerSession({
         // the persistence single heal.
         attemptPersistenceRearm();
       },
-      logger: console,
+      logger: quietSyncHealLogger,
     });
     // Persistence single heal: one re-arm after a self-disable, consumed
     // on the next online transition or heal-loop recovery.

--- a/apps/notebook-cloud/viewer/cloud-viewer-session.ts
+++ b/apps/notebook-cloud/viewer/cloud-viewer-session.ts
@@ -15,6 +15,7 @@ import {
   cloudConnectionErrorAcceptsAccessDiagnostic,
   cloudConnectionErrorWithAccessDiagnostic,
   diagnoseCloudConnectionAccess,
+  isCloudConnectionAccessDiagnostic,
 } from "./connection-diagnostics";
 import {
   applyExecutionViewChangeset,
@@ -617,6 +618,11 @@ export function useCloudViewerSession({
       }
     });
     let ranConnectionDiagnostics = false;
+    const stopPendingTransportForAccessDiagnostic = (diagnostic: string) => {
+      if (!isCloudConnectionAccessDiagnostic(diagnostic) || liveRuntimeRef.current) return;
+      pendingTransport?.disconnect();
+      pendingTransport = null;
+    };
     // One full-materialization kick per runtime when the syncing doc first
     // catches up to the room's advertised heads (see the notebookSyncApplied$
     // subscription) — the only path that displaces painted cells when the
@@ -796,7 +802,9 @@ export function useCloudViewerSession({
       if (disposed) return;
       console.warn("[notebook-cloud] live room connection lost; transport is reconnecting", reason);
       presenceStore.reduceConnection("disconnected");
-      setConnectionError(reason.message);
+      setConnectionError((current) =>
+        isCloudConnectionAccessDiagnostic(current) ? current : reason.message,
+      );
       if (!liveRuntimeRef.current && !ranConnectionDiagnostics) {
         // First pre-ready failure: surface an actionable access diagnosis
         // while the retry loop keeps running in the background.
@@ -814,6 +822,7 @@ export function useCloudViewerSession({
             setConnectionError((current) =>
               cloudConnectionErrorWithAccessDiagnostic(current, diagnostic),
             );
+            stopPendingTransportForAccessDiagnostic(diagnostic);
           })
           .catch(() => undefined);
       }
@@ -1415,6 +1424,7 @@ export function useCloudViewerSession({
               setConnectionError((current) =>
                 cloudConnectionErrorWithAccessDiagnostic(current, diagnostic),
               );
+              stopPendingTransportForAccessDiagnostic(diagnostic);
             })
             .catch(() => undefined);
         }

--- a/apps/notebook-cloud/viewer/connection-diagnostics.ts
+++ b/apps/notebook-cloud/viewer/connection-diagnostics.ts
@@ -21,6 +21,13 @@ export function isCloudConnectionAccessDiagnostic(message: string | null): boole
   return Boolean(message && ACCESS_DIAGNOSTICS.has(message));
 }
 
+export function cloudConnectionDiagnosticBlocksNotebookBody(message: string | null): boolean {
+  return (
+    message === CLOUD_CONNECTION_SIGN_IN_DIAGNOSTIC ||
+    message === CLOUD_CONNECTION_NO_ACCESS_DIAGNOSTIC
+  );
+}
+
 /**
  * Whether an access diagnostic may replace the current connection error.
  *

--- a/apps/notebook-cloud/viewer/connection-diagnostics.ts
+++ b/apps/notebook-cloud/viewer/connection-diagnostics.ts
@@ -10,6 +10,17 @@ export const CLOUD_CONNECTION_EDIT_ACCESS_PENDING_DIAGNOSTIC =
 export const CLOUD_CONNECTION_EDIT_ACCESS_APPROVED_DIAGNOSTIC =
   "Edit access was approved. Reconnect to open the live notebook room with editor access.";
 
+const ACCESS_DIAGNOSTICS = new Set<string>([
+  CLOUD_CONNECTION_SIGN_IN_DIAGNOSTIC,
+  CLOUD_CONNECTION_NO_ACCESS_DIAGNOSTIC,
+  CLOUD_CONNECTION_EDIT_ACCESS_PENDING_DIAGNOSTIC,
+  CLOUD_CONNECTION_EDIT_ACCESS_APPROVED_DIAGNOSTIC,
+]);
+
+export function isCloudConnectionAccessDiagnostic(message: string | null): boolean {
+  return Boolean(message && ACCESS_DIAGNOSTICS.has(message));
+}
+
 /**
  * Whether an access diagnostic may replace the current connection error.
  *

--- a/apps/notebook-cloud/viewer/edit-access.ts
+++ b/apps/notebook-cloud/viewer/edit-access.ts
@@ -8,6 +8,8 @@ import {
   type NotebookRoomRequestedScope,
 } from "runtimed";
 import type { CloudPrototypeAuthState } from "./collaborator-auth";
+import { cloudNotebookScopeCanEditDocument } from "./cloud-notebook-catalog-access";
+import type { ViewerStatus } from "./notice-types";
 
 export interface CloudNotebookEditAccessInput {
   authState: CloudPrototypeAuthState;
@@ -16,6 +18,33 @@ export interface CloudNotebookEditAccessInput {
   selectedMode?: NotebookEditMode;
   canAcceptCellMutations?: boolean;
   editAccessRequestPending?: boolean;
+}
+
+export interface CloudNotebookDocumentEditReadinessInput {
+  accessScope: string | null;
+  connectionError: string | null;
+  connectionPeerId: string | null;
+  connectionScope: string | null;
+  selectedMode?: NotebookEditMode;
+  statusKind: ViewerStatus["kind"];
+}
+
+export interface CloudNotebookDocumentEditReadinessProjection {
+  /**
+   * The live room is connected with write authority and can safely accept local
+   * NotebookDoc mutations. Catalog access alone is not enough here.
+   */
+  canAcceptCellMutations: boolean;
+  /**
+   * The user selected edit mode and their account has edit access, but the
+   * writable live room has not arrived yet.
+   */
+  selectedEditModeWaitingForRoom: boolean;
+  /**
+   * The shared shell should keep edit controls in a pending/viewing state while
+   * the hosted room is reconnecting or still waiting for writable authority.
+   */
+  editAccessRequestPending: boolean;
 }
 
 export function projectCloudNotebookEditAccess({
@@ -34,6 +63,33 @@ export function projectCloudNotebookEditAccess({
     canRequestEdit: cloudAuthCanRequestEdit(authState, hasAppSession),
     editAccessRequestPending,
   });
+}
+
+export function projectCloudNotebookDocumentEditReadiness({
+  accessScope,
+  connectionError,
+  connectionPeerId,
+  connectionScope,
+  selectedMode = "view",
+  statusKind,
+}: CloudNotebookDocumentEditReadinessInput): CloudNotebookDocumentEditReadinessProjection {
+  const canAcceptCellMutations =
+    Boolean(connectionPeerId) &&
+    !connectionError &&
+    (statusKind === "ready" || statusKind === "empty") &&
+    cloudNotebookScopeCanEditDocument(connectionScope);
+  const selectedEditModeWaitingForRoom =
+    selectedMode === "edit" &&
+    cloudNotebookScopeCanEditDocument(accessScope) &&
+    !canAcceptCellMutations &&
+    !connectionError &&
+    statusKind === "loading";
+  return {
+    canAcceptCellMutations,
+    selectedEditModeWaitingForRoom,
+    editAccessRequestPending:
+      (!connectionError && statusKind === "loading") || selectedEditModeWaitingForRoom,
+  };
 }
 
 export function cloudConnectionAccessLevel(

--- a/apps/notebook-cloud/viewer/live-sync.ts
+++ b/apps/notebook-cloud/viewer/live-sync.ts
@@ -700,6 +700,17 @@ export class CloudConnectionStatusBridge {
     this.next("reconnecting");
   }
 
+  /**
+   * The host has decided not to open a live-room transport for this route.
+   * This is not a reconnect loop: no socket exists, and the user-facing
+   * connection chrome should read as offline instead of the default
+   * first-paint "connecting" state.
+   */
+  noteLiveRoomDisabled(): void {
+    this.detach();
+    this.next("offline");
+  }
+
   /** Stop following the current transport (effect cleanup). */
   detach(): void {
     this.subscription?.unsubscribe();

--- a/apps/notebook-cloud/viewer/notebook-dashboard.ts
+++ b/apps/notebook-cloud/viewer/notebook-dashboard.ts
@@ -178,7 +178,7 @@ export function cloudNotebookShortId(notebookId: string): string {
 }
 
 function cloudNotebookDefaultOpenMode(notebook: CloudNotebookListItem): CloudNotebookUrlMode {
-  return notebook.scope === "owner" ? "edit" : "view";
+  return notebook.scope === "owner" || notebook.scope === "editor" ? "edit" : "view";
 }
 
 export function isCloudNotebookListItem(value: unknown): value is CloudNotebookListItem {

--- a/apps/notebook-cloud/viewer/notebook-dashboard.ts
+++ b/apps/notebook-cloud/viewer/notebook-dashboard.ts
@@ -375,7 +375,7 @@ function cloudNotebookWorkSections(
   if (namedWork.length > 0) {
     sections.push({
       action: null,
-      detail: bucketDetail(namedWork.length, "ready to reopen"),
+      detail: remainingNotebookDetail(namedWork.length),
       id: "named",
       notebooks: namedWork,
       overflowAction: null,
@@ -697,6 +697,10 @@ function activityBuckets(notebooks: readonly CloudNotebookListItem[]): {
 
 function bucketDetail(count: number, label: string): string {
   return `${count} notebook${count === 1 ? "" : "s"} ${label}`;
+}
+
+function remainingNotebookDetail(count: number): string {
+  return `${count} more notebook${count === 1 ? "" : "s"} to reopen`;
 }
 
 function startOfUtcDay(time: number): number {

--- a/apps/notebook-cloud/viewer/notebook-dashboard.ts
+++ b/apps/notebook-cloud/viewer/notebook-dashboard.ts
@@ -521,9 +521,9 @@ function cloudNotebookDashboardRowContextLabel(notebook: CloudNotebookListItem):
   }
   switch (notebook.scope) {
     case "editor":
-      return "Shared edit access";
+      return "Shared notebook";
     case "viewer":
-      return "Shared view access";
+      return "Shared notebook";
     case "runtime_peer":
       return "Runtime peer access";
     case "owner":

--- a/apps/notebook-cloud/viewer/notebook-view-loading.ts
+++ b/apps/notebook-cloud/viewer/notebook-view-loading.ts
@@ -1,6 +1,7 @@
 import type { ViewerStatus } from "./notice-types";
 
 export interface CloudNotebookViewLoadingProjectionInput {
+  bodyAccessBlocked: boolean;
   cellCount: number;
   canEditStructure: boolean;
   connectionError: string | null;
@@ -12,7 +13,13 @@ export interface CloudNotebookViewLoadingProjectionInput {
   status: ViewerStatus;
 }
 
+export interface CloudNotebookViewSurfaceProjection {
+  isLoading: boolean;
+  shouldRenderNotebookView: boolean;
+}
+
 export function projectCloudNotebookViewLoading({
+  bodyAccessBlocked,
   cellCount,
   canEditStructure,
   connectionError,
@@ -23,9 +30,19 @@ export function projectCloudNotebookViewLoading({
   liveMaterialized,
   status,
 }: CloudNotebookViewLoadingProjectionInput): boolean {
+  if (bodyAccessBlocked) return false;
   if (status.kind === "loading") return true;
   if (editAccessPending) return true;
   if (status.kind === "empty" && cellCount === 0 && !emptyRoomGraceElapsed) return true;
   if (connectionError && !hasReadableSnapshot && !hasAccessDiagnostic) return true;
   return canEditStructure && cellCount === 0 && !liveMaterialized;
+}
+
+export function projectCloudNotebookViewSurface(
+  input: CloudNotebookViewLoadingProjectionInput,
+): CloudNotebookViewSurfaceProjection {
+  return {
+    isLoading: projectCloudNotebookViewLoading(input),
+    shouldRenderNotebookView: !input.bodyAccessBlocked,
+  };
 }

--- a/apps/notebook-cloud/viewer/notebook-view-loading.ts
+++ b/apps/notebook-cloud/viewer/notebook-view-loading.ts
@@ -1,0 +1,31 @@
+import type { ViewerStatus } from "./notice-types";
+
+export interface CloudNotebookViewLoadingProjectionInput {
+  cellCount: number;
+  canEditStructure: boolean;
+  connectionError: string | null;
+  editAccessPending: boolean;
+  emptyRoomGraceElapsed: boolean;
+  hasAccessDiagnostic: boolean;
+  hasReadableSnapshot: boolean;
+  liveMaterialized: boolean;
+  status: ViewerStatus;
+}
+
+export function projectCloudNotebookViewLoading({
+  cellCount,
+  canEditStructure,
+  connectionError,
+  editAccessPending,
+  emptyRoomGraceElapsed,
+  hasAccessDiagnostic,
+  hasReadableSnapshot,
+  liveMaterialized,
+  status,
+}: CloudNotebookViewLoadingProjectionInput): boolean {
+  if (status.kind === "loading") return true;
+  if (editAccessPending) return true;
+  if (status.kind === "empty" && cellCount === 0 && !emptyRoomGraceElapsed) return true;
+  if (connectionError && !hasReadableSnapshot && !hasAccessDiagnostic) return true;
+  return canEditStructure && cellCount === 0 && !liveMaterialized;
+}

--- a/apps/notebook-cloud/viewer/notebook-view-loading.ts
+++ b/apps/notebook-cloud/viewer/notebook-view-loading.ts
@@ -18,6 +18,15 @@ export interface CloudNotebookViewSurfaceProjection {
   shouldRenderNotebookView: boolean;
 }
 
+export interface CloudNotebookHeaderChromeProjectionInput {
+  bodyAccessBlocked: boolean;
+}
+
+export interface CloudNotebookHeaderChromeProjection {
+  showConnectionIdentity: boolean;
+  showPresenceStatus: boolean;
+}
+
 export function projectCloudNotebookViewLoading({
   bodyAccessBlocked,
   cellCount,
@@ -44,5 +53,15 @@ export function projectCloudNotebookViewSurface(
   return {
     isLoading: projectCloudNotebookViewLoading(input),
     shouldRenderNotebookView: !input.bodyAccessBlocked,
+  };
+}
+
+export function projectCloudNotebookHeaderChrome({
+  bodyAccessBlocked,
+}: CloudNotebookHeaderChromeProjectionInput): CloudNotebookHeaderChromeProjection {
+  const showCollaborationChrome = !bodyAccessBlocked;
+  return {
+    showConnectionIdentity: showCollaborationChrome,
+    showPresenceStatus: showCollaborationChrome,
   };
 }

--- a/apps/notebook-cloud/viewer/notebook-viewer.tsx
+++ b/apps/notebook-cloud/viewer/notebook-viewer.tsx
@@ -87,6 +87,8 @@ import {
   cloudNotebookHasNotices,
   shouldShowCloudAnonymousViewerAuthNotice,
 } from "./notices";
+import { isCloudConnectionAccessDiagnostic } from "./connection-diagnostics";
+import { projectCloudNotebookViewLoading } from "./notebook-view-loading";
 import { useOfflineMergeNoticeAutoClear } from "./use-offline-merge-notice";
 import { useSustainedReconnecting } from "./use-sustained-reconnecting";
 import type { ViewerStatus } from "./notice-types";
@@ -1201,14 +1203,17 @@ export function NotebookViewer({
   const notebookHasReadableSnapshot =
     notebookCellIds.length > 0 ||
     (!connectionError && snapshotResolvedRef.current && status.kind === "ready");
-  const notebookViewIsLoading =
-    status.kind === "loading" ||
-    editAccessPending ||
-    (status.kind === "empty" && notebookCellIds.length === 0 && !emptyRoomGraceElapsed) ||
-    (Boolean(connectionError) && !notebookHasReadableSnapshot) ||
-    (shellCapabilities.canEditStructure &&
-      notebookCellIds.length === 0 &&
-      !liveMaterializedRef.current);
+  const notebookViewIsLoading = projectCloudNotebookViewLoading({
+    cellCount: notebookCellIds.length,
+    canEditStructure: shellCapabilities.canEditStructure,
+    connectionError,
+    editAccessPending,
+    emptyRoomGraceElapsed,
+    hasAccessDiagnostic: isCloudConnectionAccessDiagnostic(connectionError),
+    hasReadableSnapshot: notebookHasReadableSnapshot,
+    liveMaterialized: liveMaterializedRef.current,
+    status,
+  });
   const noticeStatus: ViewerStatus =
     notebookViewIsLoading && (status.kind === "ready" || status.kind === "empty")
       ? { kind: "loading", message: "Preparing notebook view..." }

--- a/apps/notebook-cloud/viewer/notebook-viewer.tsx
+++ b/apps/notebook-cloud/viewer/notebook-viewer.tsx
@@ -63,7 +63,7 @@ import type { ConnectionScope } from "../src/auth-shared";
 
 import { useCloudViewerSession } from "./cloud-viewer-session";
 import {
-  cloudBlobAuthStateForBrowserFetch,
+  cloudBrowserApiAuthStateForFetch,
   cloudSyncAuthConnectionKey,
 } from "./session-auth-stability";
 import {
@@ -97,6 +97,7 @@ import { cloudResponseError } from "./cloud-response";
 import { preloadSiftWasmForCells } from "./sift-preload";
 import { cloudSourceLanguage } from "./source-language";
 import { clearCloudAppSession, readCloudAppSessionStatus } from "./app-session";
+import { projectCloudAccessRequestTransition } from "./cloud-access-request-state";
 import { applyDocumentTheme, CLOUD_VIEWER_THEME_STORAGE_KEY } from "./theme";
 import {
   cloudNotebookInteractionModeForAccess,
@@ -112,12 +113,12 @@ import {
 import { useCloudShellCapabilities } from "./use-cloud-shell-capabilities";
 import { useCloudWorkstationManager } from "./use-cloud-workstations";
 import { CloudNotebookEditModeButton, CloudNotebookSignInButton } from "./cloud-auth-controls";
-import { CloudNotebookTitle } from "./cloud-notebook-title";
+import { CloudNotebookTitle, cloudNotebookRouteTitle } from "./cloud-notebook-title";
 import { CloudPresenceStatus } from "./cloud-presence-status";
 import { isCloudNotebookListItem } from "./notebook-dashboard";
 
 const CLOUD_VIEWER_OUTPUT_IFRAME_ROOT_MARGIN = "400px 0px";
-const CLOUD_ACCESS_REQUEST_POLL_INTERVAL_MS = 10_000;
+const CLOUD_ACCESS_REQUEST_POLL_INTERVAL_MS = 30_000;
 const CLOUD_EMPTY_ROOM_GRACE_MS = 900;
 
 function decodeHashAnchorId(hash: string): string {
@@ -127,6 +128,10 @@ function decodeHashAnchorId(hash: string): string {
   } catch {
     return raw;
   }
+}
+
+function shouldPollPendingCloudAccessRequest(): boolean {
+  return typeof document === "undefined" || document.visibilityState !== "hidden";
 }
 
 async function resolveCloudAppSessionSyncScope(
@@ -164,10 +169,12 @@ export function NotebookViewer({
   authConfig: CloudViewerAuthConfig;
 }) {
   const { config } = runtime;
+  const routeTitle = useMemo(() => cloudNotebookRouteTitle(), []);
   const loadingPolicy = cloudViewerLoadingPolicy(config);
   const { resolvedTheme } = useTheme(CLOUD_VIEWER_THEME_STORAGE_KEY);
   const { store: widgetStore } = useWidgetStoreRequired();
   const appSessionStatus = useCloudAppSessionStatus(config.session ?? null);
+  const hasAppSession = Boolean(appSessionStatus.session);
   const { authState, authRenewal, refreshAuthState } = useCloudPrototypeAuth(authConfig, {
     appSessionRefreshFallback: true,
     appSessionLoading: appSessionStatus.status === "loading",
@@ -220,8 +227,8 @@ export function NotebookViewer({
     selectedInteractionModeRef.current = selectedInteractionMode;
   }, [selectedInteractionMode]);
   const [emptyRoomGraceElapsed, setEmptyRoomGraceElapsed] = useState(false);
-  const blobAuthState = useMemo(
-    () => cloudBlobAuthStateForBrowserFetch(authState),
+  const browserApiAuthState = useMemo(
+    () => cloudBrowserApiAuthStateForFetch(authState),
     [
       authState.mode,
       authState.mode === "dev" ? authState.token : null,
@@ -235,10 +242,10 @@ export function NotebookViewer({
       createNotebookCloudBlobResolver({
         baseUrl: location.href,
         blobBasePath: config.blobBasePath,
-        fetchImpl: (input, init) => fetchWithCloudPrototypeAuth(input, init, blobAuthState),
+        fetchImpl: (input, init) => fetchWithCloudPrototypeAuth(input, init, browserApiAuthState),
         authenticatedBinaryDisplayUrls: true,
       }),
-    [blobAuthState, config.blobBasePath],
+    [browserApiAuthState, config.blobBasePath],
   );
   const preloadSiftWasm = useCallback(
     (nextCells: readonly ResolvedCell[]) => {
@@ -252,7 +259,7 @@ export function NotebookViewer({
     [config.blobBasePath, config.rendererAssetsBasePath, config.rendererAssets.siftWasm],
   );
   const syncAuthConnectionKey = cloudSyncAuthConnectionKey(authState, {
-    hasAppSession: Boolean(appSessionStatus.session),
+    hasAppSession,
   });
   const resolveSyncAuth = useCallback(
     async (sessionId: string) => {
@@ -302,7 +309,7 @@ export function NotebookViewer({
     authState,
     blobResolver,
     config,
-    hasAppSession: Boolean(appSessionStatus.session),
+    hasAppSession,
     loadingPolicy,
     preloadSiftWasm,
     resolveSyncAuth,
@@ -421,10 +428,10 @@ export function NotebookViewer({
     setActiveRailPanel("workstations");
   }, []);
   const hasBrowserAppIdentity =
-    Boolean(appSessionStatus.session) || authState.mode === "dev" || authState.mode === "oidc";
+    hasAppSession || authState.mode === "dev" || authState.mode === "oidc";
   const canUseAuthenticatedCloudApi = cloudBrowserCanUseAuthenticatedApi({
     authState,
-    hasAppSession: Boolean(appSessionStatus.session),
+    hasAppSession,
   });
   const cloudRuntimeConnectedForStatus = workstationAttachment
     ? workstationAttachmentIsConnected(workstationAttachment)
@@ -459,7 +466,7 @@ export function NotebookViewer({
       connectionPeerId,
       connectionPeerLabel,
       connectionScope,
-      hasAppSession: Boolean(appSessionStatus.session),
+      hasAppSession,
       hostCapabilities: config.hostCapabilities,
       kernelStatusLabel: cloudKernelStatusLabel,
       runtimePeerAvailable,
@@ -475,7 +482,7 @@ export function NotebookViewer({
     Boolean(connectionPeerId);
   const showAnonymousViewerAuthNotice = shouldShowCloudAnonymousViewerAuthNotice({
     authState,
-    hasAppSession: Boolean(appSessionStatus.session),
+    hasAppSession,
     isPublicViewer,
   });
   const {
@@ -782,25 +789,36 @@ export function NotebookViewer({
   const applyLatestAccessRequest = useCallback(
     (request: CloudNotebookAccessRequest | null) => {
       setLatestAccessRequest(request);
-      if (request?.status === "pending" || request?.status === "approved") {
-        storeCloudRequestedScope(window.localStorage, "editor");
-        setSelectedInteractionMode("edit");
-        if (request.status === "approved") {
-          retryLiveConnection();
-        }
-        if (authState.requestedScope !== "editor") {
-          refreshAuthState();
-        }
-        return;
+      const transition = projectCloudAccessRequestTransition({
+        authState: {
+          mode: authState.mode,
+          requestedScope: authState.requestedScope,
+        },
+        connectionScope,
+        hasAppSession,
+        request,
+      });
+      if (transition.requestedScope) {
+        storeCloudRequestedScope(window.localStorage, transition.requestedScope);
       }
-
-      if (authState.requestedScope === "editor" && connectionScope === "viewer") {
-        storeCloudRequestedScope(window.localStorage, "viewer");
-        setSelectedInteractionMode("view");
+      if (transition.selectedMode) {
+        setSelectedInteractionMode(transition.selectedMode);
+      }
+      if (transition.retryLiveConnection) {
+        retryLiveConnection();
+      }
+      if (transition.refreshPrototypeAuth) {
         refreshAuthState();
       }
     },
-    [authState.requestedScope, connectionScope, refreshAuthState, retryLiveConnection],
+    [
+      authState.mode,
+      authState.requestedScope,
+      connectionScope,
+      hasAppSession,
+      refreshAuthState,
+      retryLiveConnection,
+    ],
   );
   const loadOwnAccessRequest = useCallback(
     async (options?: { signal?: AbortSignal }) => {
@@ -812,7 +830,7 @@ export function NotebookViewer({
         const response = await fetchWithCloudPrototypeAuth(
           config.accessRequestsEndpoint,
           { headers: { Accept: "application/json" }, signal: options?.signal },
-          authState,
+          browserApiAuthState,
         );
         if (options?.signal?.aborted) {
           return;
@@ -833,7 +851,7 @@ export function NotebookViewer({
     },
     [
       applyLatestAccessRequest,
-      authState,
+      browserApiAuthState,
       canUseAuthenticatedCloudApi,
       config.accessRequestsEndpoint,
       connectionScope,
@@ -861,12 +879,27 @@ export function NotebookViewer({
     }
 
     const controller = new AbortController();
+    let pollInFlight = false;
+    const poll = () => {
+      if (!shouldPollPendingCloudAccessRequest() || pollInFlight) {
+        return;
+      }
+      pollInFlight = true;
+      void loadOwnAccessRequest({ signal: controller.signal }).finally(() => {
+        pollInFlight = false;
+      });
+    };
     const intervalId = window.setInterval(() => {
-      void loadOwnAccessRequest({ signal: controller.signal });
+      poll();
     }, CLOUD_ACCESS_REQUEST_POLL_INTERVAL_MS);
+    const handleVisibilityChange = () => {
+      poll();
+    };
+    document.addEventListener("visibilitychange", handleVisibilityChange);
     return () => {
       controller.abort();
       window.clearInterval(intervalId);
+      document.removeEventListener("visibilitychange", handleVisibilityChange);
     };
   }, [
     canUseAuthenticatedCloudApi,
@@ -888,7 +921,7 @@ export function NotebookViewer({
             },
             body: JSON.stringify({ scope: "editor" }),
           },
-          authState,
+          browserApiAuthState,
         );
         if (!response.ok) {
           throw await cloudResponseError(response, "Unable to request edit access");
@@ -917,7 +950,12 @@ export function NotebookViewer({
         setAccessRequestError(error instanceof Error ? error.message : String(error));
       }
     })();
-  }, [applyLatestAccessRequest, authState, config.accessRequestsEndpoint, config.notebookId]);
+  }, [
+    applyLatestAccessRequest,
+    browserApiAuthState,
+    config.accessRequestsEndpoint,
+    config.notebookId,
+  ]);
   const shouldShowPackageEnvironmentSummary =
     shellCapabilities.canExecute || shellCapabilities.canManagePackages;
   const toolbarAddAfterCellId =
@@ -989,7 +1027,7 @@ export function NotebookViewer({
         !showAnonymousViewerAuthNotice &&
         shouldShowCloudHeaderSignIn(authState, {
           appSessionLoading: appSessionStatus.status === "loading",
-          hasAppSession: Boolean(appSessionStatus.session),
+          hasAppSession,
         }) ? (
           <CloudNotebookSignInButton authConfig={authConfig} authState={authState} />
         ) : null
@@ -1006,7 +1044,7 @@ export function NotebookViewer({
       editControls={
         <CloudNotebookEditModeButton
           authState={authState}
-          hasAppSession={Boolean(appSessionStatus.session)}
+          hasAppSession={hasAppSession}
           interaction={shellCapabilities.interaction ?? null}
           accessLevel={shellCapabilities.access.level}
           accessPending={editAccessPending}
@@ -1073,7 +1111,7 @@ export function NotebookViewer({
     authRenewal,
     connectionError,
     diagnostics: accessRequestNotice,
-    hasAppSession: Boolean(appSessionStatus.session),
+    hasAppSession,
     isPublicViewer,
     hasReadableSnapshot: notebookHasReadableSnapshot,
     offlineMergeNotice,
@@ -1088,7 +1126,7 @@ export function NotebookViewer({
       authRenewal={authRenewal}
       connectionError={connectionError}
       diagnostics={accessRequestNotice}
-      hasAppSession={Boolean(appSessionStatus.session)}
+      hasAppSession={hasAppSession}
       isPublicViewer={isPublicViewer}
       hasReadableSnapshot={notebookHasReadableSnapshot}
       offlineMergeNotice={offlineMergeNotice}
@@ -1121,7 +1159,7 @@ export function NotebookViewer({
         rail={rail}
         stageLabel="Hosted notebook"
       >
-        <h1 className="sr-only">nteract cloud notebook {config.notebookId}</h1>
+        <h1 className="sr-only">{routeTitle.title}</h1>
 
         <PresenceValueProvider value={cloudPresenceContext}>
           <CrdtBridgeProvider

--- a/apps/notebook-cloud/viewer/notebook-viewer.tsx
+++ b/apps/notebook-cloud/viewer/notebook-viewer.tsx
@@ -47,6 +47,7 @@ import {
   workstationAttachmentIsConnected,
   type CellChangeset,
   type NotebookOutlineItem,
+  type SyncEngineLogger,
 } from "runtimed";
 import { createNotebookCloudBlobResolver } from "../src/blob-resolver";
 import {
@@ -129,6 +130,13 @@ import { useCloudWorkstationManager } from "./use-cloud-workstations";
 import { CloudNotebookEditModeButton, CloudNotebookSignInButton } from "./cloud-auth-controls";
 import { CloudNotebookTitle, cloudNotebookRouteTitle } from "./cloud-notebook-title";
 import { CloudPresenceStatus } from "./cloud-presence-status";
+
+const cloudNotebookClientLogger: SyncEngineLogger = {
+  debug: () => {},
+  info: () => {},
+  warn: (message: string, ...args: unknown[]) => console.warn(message, ...args),
+  error: (message: string, ...args: unknown[]) => console.error(message, ...args),
+};
 
 const CLOUD_VIEWER_OUTPUT_IFRAME_ROOT_MARGIN = "400px 0px";
 const CLOUD_ACCESS_REQUEST_POLL_INTERVAL_MS = 30_000;
@@ -731,7 +739,7 @@ export function NotebookViewer({
         liveRuntime,
         client: new NotebookClient({
           transport: liveRuntime.transport,
-          logger: console,
+          logger: cloudNotebookClientLogger,
           getRequiredHeads: () => liveRuntime.handle.get_heads_hex(),
         }),
       };

--- a/apps/notebook-cloud/viewer/notebook-viewer.tsx
+++ b/apps/notebook-cloud/viewer/notebook-viewer.tsx
@@ -92,7 +92,10 @@ import {
   cloudConnectionDiagnosticBlocksNotebookBody,
   isCloudConnectionAccessDiagnostic,
 } from "./connection-diagnostics";
-import { projectCloudNotebookViewSurface } from "./notebook-view-loading";
+import {
+  projectCloudNotebookHeaderChrome,
+  projectCloudNotebookViewSurface,
+} from "./notebook-view-loading";
 import { useOfflineMergeNoticeAutoClear } from "./use-offline-merge-notice";
 import { useSustainedReconnecting } from "./use-sustained-reconnecting";
 import type { ViewerStatus } from "./notice-types";
@@ -1138,6 +1141,10 @@ export function NotebookViewer({
   const showCloudCommandToolbar = shouldShowNotebookDocumentCommandToolbar(shellCapabilities, {
     reserve: editAccessPending,
   });
+  const notebookBodyAccessBlocked = cloudConnectionDiagnosticBlocksNotebookBody(connectionError);
+  const notebookHeaderChrome = projectCloudNotebookHeaderChrome({
+    bodyAccessBlocked: notebookBodyAccessBlocked,
+  });
 
   const toolbar = (
     <NotebookDocumentToolbar
@@ -1146,7 +1153,9 @@ export function NotebookViewer({
       headerClassName="cloud-room-toolbar"
       presence={<CloudNotebookTitle />}
       utilityControls={
-        <CloudPresenceStatus connectionError={connectionError} store={presenceStore} />
+        notebookHeaderChrome.showPresenceStatus ? (
+          <CloudPresenceStatus connectionError={connectionError} store={presenceStore} />
+        ) : null
       }
       authControls={
         !showAnonymousViewerAuthNotice &&
@@ -1181,10 +1190,12 @@ export function NotebookViewer({
         // Connection/identity slot: self-identity avatar + connectivity dot
         // (the stable bridge survives transport replacement; the dot keeps
         // frozen runtime chrome interpretable while reconnecting).
-        <NotebookConnectionIdentity
-          capabilities={shellCapabilities}
-          connectionStatus$={connectionStatus$}
-        />
+        notebookHeaderChrome.showConnectionIdentity ? (
+          <NotebookConnectionIdentity
+            capabilities={shellCapabilities}
+            connectionStatus$={connectionStatus$}
+          />
+        ) : null
       }
       reserveCommandToolbar={editAccessPending}
       commandToolbar={{
@@ -1209,7 +1220,7 @@ export function NotebookViewer({
     notebookCellIds.length > 0 ||
     (!connectionError && snapshotResolvedRef.current && status.kind === "ready");
   const notebookViewSurface = projectCloudNotebookViewSurface({
-    bodyAccessBlocked: cloudConnectionDiagnosticBlocksNotebookBody(connectionError),
+    bodyAccessBlocked: notebookBodyAccessBlocked,
     cellCount: notebookCellIds.length,
     canEditStructure: shellCapabilities.canEditStructure,
     connectionError,

--- a/apps/notebook-cloud/viewer/notebook-viewer.tsx
+++ b/apps/notebook-cloud/viewer/notebook-viewer.tsx
@@ -103,7 +103,11 @@ import { cloudResponseError } from "./cloud-response";
 import { preloadSiftWasmForCells } from "./sift-preload";
 import { cloudSourceLanguage } from "./source-language";
 import { clearCloudAppSession, readCloudAppSessionStatus } from "./app-session";
-import { projectCloudAccessRequestTransition } from "./cloud-access-request-state";
+import {
+  projectCloudAccessRequestNotice,
+  projectCloudAccessRequestTransition,
+  type CloudAccessRequestNoticeProjection,
+} from "./cloud-access-request-state";
 import {
   cloudNotebookAccessScopeForShell,
   cloudNotebookLiveRoomConnectionPolicy,
@@ -1239,7 +1243,13 @@ export function NotebookViewer({
     notebookViewIsLoading && (status.kind === "ready" || status.kind === "empty")
       ? { kind: "loading", message: "Preparing notebook view..." }
       : status;
-  const accessRequestNotice = cloudAccessRequestNotice(effectiveAccessRequest, accessRequestError);
+  const accessRequestNotice = cloudAccessRequestNotice(
+    projectCloudAccessRequestNotice({
+      error: accessRequestError,
+      request: effectiveAccessRequest,
+      selectedMode: selectedInteractionMode,
+    }),
+  );
   // Asset health is its own quiet surface: N identical renderer failures
   // collapse into ONE notice (the provider state is module-level shared)
   // plus per-output fallbacks. It never feeds the connection dot or
@@ -1354,64 +1364,67 @@ function cloudNotebookEnvironmentManager(
 }
 
 function cloudAccessRequestNotice(
-  request: CloudNotebookAccessRequest | null,
-  error: string | null,
+  projection: CloudAccessRequestNoticeProjection | null,
 ): ReactNode {
-  if (error) {
-    return (
-      <NotebookNotice
-        tone="error"
-        icon={<AlertCircle className="h-4 w-4" />}
-        title="Edit request failed."
-      >
-        {error}
-      </NotebookNotice>
-    );
-  }
-
-  if (!request) {
+  if (!projection) {
     return null;
   }
 
-  if (request.status === "pending") {
+  if (projection.kind === "error") {
     return (
       <NotebookNotice
-        tone="info"
+        tone={projection.tone}
+        icon={<AlertCircle className="h-4 w-4" />}
+        title={projection.title}
+      >
+        {projection.message}
+      </NotebookNotice>
+    );
+  }
+
+  if (projection.kind === "pending") {
+    return (
+      <NotebookNotice
+        tone={projection.tone}
         icon={<Loader2 className="h-4 w-4 animate-spin" />}
-        title="Edit access requested."
+        title={projection.title}
       >
-        The owner can review this request from the sharing panel.
+        {projection.message}
       </NotebookNotice>
     );
   }
 
-  if (request.status === "approved") {
+  if (projection.kind === "approved") {
     return (
       <NotebookNotice
-        tone="success"
+        tone={projection.tone}
         icon={<Check className="h-4 w-4" />}
-        title="Edit access approved."
+        title={projection.title}
       >
-        Reconnecting with editor access.
+        {projection.message}
       </NotebookNotice>
     );
   }
 
-  if (request.status === "denied") {
+  if (projection.kind === "denied") {
     return (
-      <NotebookNotice tone="warning" icon={<X className="h-4 w-4" />} title="Edit request denied.">
-        The notebook stays in view mode.
+      <NotebookNotice
+        tone={projection.tone}
+        icon={<X className="h-4 w-4" />}
+        title={projection.title}
+      >
+        {projection.message}
       </NotebookNotice>
     );
   }
 
   return (
     <NotebookNotice
-      tone="info"
+      tone={projection.tone}
       icon={<AlertCircle className="h-4 w-4" />}
-      title="Edit request dismissed."
+      title={projection.title}
     >
-      The owner dismissed the request.
+      {projection.message}
     </NotebookNotice>
   );
 }

--- a/apps/notebook-cloud/viewer/notebook-viewer.tsx
+++ b/apps/notebook-cloud/viewer/notebook-viewer.tsx
@@ -102,6 +102,7 @@ import {
   cloudNotebookAccessScopeForShell,
   cloudNotebookCatalogScopeFromList,
   cloudNotebookScopeCanEditDocument,
+  cloudNotebookSyncScopeForCatalogAccess,
   type CloudNotebookCatalogAccessScope,
 } from "./cloud-notebook-catalog-access";
 import { applyDocumentTheme, CLOUD_VIEWER_THEME_STORAGE_KEY } from "./theme";
@@ -153,15 +154,19 @@ async function resolveCloudAppSessionSyncScope(
     if (response.ok) {
       const body = (await response.json()) as { notebooks?: unknown };
       const notebooks = Array.isArray(body.notebooks) ? body.notebooks : [];
-      const catalogScope = cloudNotebookCatalogScopeFromList(notebooks, notebookId);
-      if (catalogScope) {
-        return catalogScope;
-      }
+      return cloudNotebookSyncScopeForCatalogAccess({
+        catalogResolved: true,
+        catalogScope: cloudNotebookCatalogScopeFromList(notebooks, notebookId),
+        selectedMode,
+      });
     }
   } catch (error) {
     console.warn("[notebook-cloud] unable to resolve notebook access scope before sync", error);
   }
-  return selectedMode === "edit" ? "owner" : "viewer";
+  return cloudNotebookSyncScopeForCatalogAccess({
+    catalogResolved: false,
+    selectedMode,
+  });
 }
 
 export function NotebookViewer({

--- a/apps/notebook-cloud/viewer/notebook-viewer.tsx
+++ b/apps/notebook-cloud/viewer/notebook-viewer.tsx
@@ -98,6 +98,12 @@ import { preloadSiftWasmForCells } from "./sift-preload";
 import { cloudSourceLanguage } from "./source-language";
 import { clearCloudAppSession, readCloudAppSessionStatus } from "./app-session";
 import { projectCloudAccessRequestTransition } from "./cloud-access-request-state";
+import {
+  cloudNotebookAccessScopeForShell,
+  cloudNotebookCatalogScopeFromList,
+  cloudNotebookScopeCanEditDocument,
+  type CloudNotebookCatalogAccessScope,
+} from "./cloud-notebook-catalog-access";
 import { applyDocumentTheme, CLOUD_VIEWER_THEME_STORAGE_KEY } from "./theme";
 import {
   cloudNotebookInteractionModeForAccess,
@@ -115,7 +121,6 @@ import { useCloudWorkstationManager } from "./use-cloud-workstations";
 import { CloudNotebookEditModeButton, CloudNotebookSignInButton } from "./cloud-auth-controls";
 import { CloudNotebookTitle, cloudNotebookRouteTitle } from "./cloud-notebook-title";
 import { CloudPresenceStatus } from "./cloud-presence-status";
-import { isCloudNotebookListItem } from "./notebook-dashboard";
 
 const CLOUD_VIEWER_OUTPUT_IFRAME_ROOT_MARGIN = "400px 0px";
 const CLOUD_ACCESS_REQUEST_POLL_INTERVAL_MS = 30_000;
@@ -148,11 +153,9 @@ async function resolveCloudAppSessionSyncScope(
     if (response.ok) {
       const body = (await response.json()) as { notebooks?: unknown };
       const notebooks = Array.isArray(body.notebooks) ? body.notebooks : [];
-      const notebook = notebooks.find(
-        (candidate) => isCloudNotebookListItem(candidate) && candidate.notebook_id === notebookId,
-      );
-      if (isCloudNotebookListItem(notebook) && notebook.scope !== "runtime_peer") {
-        return notebook.scope;
+      const catalogScope = cloudNotebookCatalogScopeFromList(notebooks, notebookId);
+      if (catalogScope) {
+        return catalogScope;
       }
     }
   } catch (error) {
@@ -214,6 +217,8 @@ export function NotebookViewer({
   const [latestAccessRequest, setLatestAccessRequest] = useState<CloudNotebookAccessRequest | null>(
     null,
   );
+  const [catalogAccessScope, setCatalogAccessScope] =
+    useState<CloudNotebookCatalogAccessScope | null>(null);
   const [accessRequestError, setAccessRequestError] = useState<string | null>(null);
   const [selectedInteractionMode, setSelectedInteractionMode] = useState<NotebookInteractionMode>(
     () => cloudNotebookModeFromSearch(window.location.search),
@@ -433,6 +438,42 @@ export function NotebookViewer({
     authState,
     hasAppSession,
   });
+  useEffect(() => {
+    if (!canUseAuthenticatedCloudApi) {
+      setCatalogAccessScope(null);
+      return;
+    }
+
+    const controller = new AbortController();
+    void (async () => {
+      try {
+        const endpoint = new URL("api/n?limit=100", `${window.location.origin}/`);
+        const response = await fetchWithCloudPrototypeAuth(
+          endpoint.href,
+          {
+            cache: "no-store",
+            headers: { Accept: "application/json" },
+            signal: controller.signal,
+          },
+          browserApiAuthState,
+        );
+        if (controller.signal.aborted || !response.ok) {
+          return;
+        }
+        const body = (await response.json()) as { notebooks?: unknown };
+        if (controller.signal.aborted) {
+          return;
+        }
+        const notebooks = Array.isArray(body.notebooks) ? body.notebooks : [];
+        setCatalogAccessScope(cloudNotebookCatalogScopeFromList(notebooks, config.notebookId));
+      } catch {
+        return;
+      }
+    })();
+
+    return () => controller.abort();
+  }, [browserApiAuthState, canUseAuthenticatedCloudApi, config.notebookId]);
+  const catalogGrantsDocumentEdit = cloudNotebookScopeCanEditDocument(catalogAccessScope);
   const cloudRuntimeConnectedForStatus = workstationAttachment
     ? workstationAttachmentIsConnected(workstationAttachment)
     : runtimePeerAvailable;
@@ -452,13 +493,25 @@ export function NotebookViewer({
       ? cloudRuntimeStatus.label
       : null
     : null;
+  const connectionReadyForAccessScope =
+    !connectionError &&
+    Boolean(connectionPeerId) &&
+    (status.kind === "ready" || status.kind === "empty");
+  const accessConnectionScope = cloudNotebookAccessScopeForShell({
+    catalogScope: catalogAccessScope,
+    connectionReady: connectionReadyForAccessScope,
+    connectionScope,
+  });
+  const effectiveAccessRequest = catalogGrantsDocumentEdit ? null : latestAccessRequest;
   const selectedInteractionModeForAccess = cloudNotebookInteractionModeForAccess({
-    accessRequestStatus: latestAccessRequest?.status,
+    accessRequestStatus: effectiveAccessRequest?.status,
+    accessScope: accessConnectionScope,
     connectionScope,
     selectedMode: selectedInteractionMode,
   });
   const { shellCapabilities, canAcceptCellMutations, editAccessPending } =
     useCloudShellCapabilities({
+      accessConnectionScope,
       authState,
       codeCellCount,
       connectionActorLabel,
@@ -790,13 +843,14 @@ export function NotebookViewer({
     (request: CloudNotebookAccessRequest | null) => {
       setLatestAccessRequest(request);
       const transition = projectCloudAccessRequestTransition({
+        accessScope: catalogAccessScope,
         authState: {
           mode: authState.mode,
           requestedScope: authState.requestedScope,
         },
         connectionScope,
         hasAppSession,
-        request,
+        request: catalogGrantsDocumentEdit ? null : request,
       });
       if (transition.requestedScope) {
         storeCloudRequestedScope(window.localStorage, transition.requestedScope);
@@ -814,6 +868,8 @@ export function NotebookViewer({
     [
       authState.mode,
       authState.requestedScope,
+      catalogAccessScope,
+      catalogGrantsDocumentEdit,
       connectionScope,
       hasAppSession,
       refreshAuthState,
@@ -822,7 +878,11 @@ export function NotebookViewer({
   );
   const loadOwnAccessRequest = useCallback(
     async (options?: { signal?: AbortSignal }) => {
-      if (connectionScope !== "viewer" || !canUseAuthenticatedCloudApi) {
+      if (
+        connectionScope !== "viewer" ||
+        !canUseAuthenticatedCloudApi ||
+        catalogGrantsDocumentEdit
+      ) {
         return;
       }
 
@@ -853,12 +913,13 @@ export function NotebookViewer({
       applyLatestAccessRequest,
       browserApiAuthState,
       canUseAuthenticatedCloudApi,
+      catalogGrantsDocumentEdit,
       config.accessRequestsEndpoint,
       connectionScope,
     ],
   );
   useEffect(() => {
-    if (connectionScope !== "viewer" || !hasBrowserAppIdentity) {
+    if (connectionScope !== "viewer" || !hasBrowserAppIdentity || catalogGrantsDocumentEdit) {
       setLatestAccessRequest(null);
       return;
     }
@@ -868,12 +929,19 @@ export function NotebookViewer({
     const controller = new AbortController();
     void loadOwnAccessRequest({ signal: controller.signal });
     return () => controller.abort();
-  }, [canUseAuthenticatedCloudApi, connectionScope, hasBrowserAppIdentity, loadOwnAccessRequest]);
+  }, [
+    canUseAuthenticatedCloudApi,
+    catalogGrantsDocumentEdit,
+    connectionScope,
+    hasBrowserAppIdentity,
+    loadOwnAccessRequest,
+  ]);
   useEffect(() => {
     if (
-      latestAccessRequest?.status !== "pending" ||
+      effectiveAccessRequest?.status !== "pending" ||
       connectionScope !== "viewer" ||
-      !canUseAuthenticatedCloudApi
+      !canUseAuthenticatedCloudApi ||
+      catalogGrantsDocumentEdit
     ) {
       return;
     }
@@ -903,8 +971,9 @@ export function NotebookViewer({
     };
   }, [
     canUseAuthenticatedCloudApi,
+    catalogGrantsDocumentEdit,
     connectionScope,
-    latestAccessRequest?.status,
+    effectiveAccessRequest?.status,
     loadOwnAccessRequest,
   ]);
   const requestCloudEditAccess = useCallback(() => {
@@ -1095,7 +1164,7 @@ export function NotebookViewer({
     notebookViewIsLoading && (status.kind === "ready" || status.kind === "empty")
       ? { kind: "loading", message: "Preparing notebook view..." }
       : status;
-  const accessRequestNotice = cloudAccessRequestNotice(latestAccessRequest, accessRequestError);
+  const accessRequestNotice = cloudAccessRequestNotice(effectiveAccessRequest, accessRequestError);
   // Asset health is its own quiet surface: N identical renderer failures
   // collapse into ONE notice (the provider state is module-level shared)
   // plus per-output fallbacks. It never feeds the connection dot or

--- a/apps/notebook-cloud/viewer/notebook-viewer.tsx
+++ b/apps/notebook-cloud/viewer/notebook-viewer.tsx
@@ -100,9 +100,10 @@ import { clearCloudAppSession, readCloudAppSessionStatus } from "./app-session";
 import { projectCloudAccessRequestTransition } from "./cloud-access-request-state";
 import {
   cloudNotebookAccessScopeForShell,
-  cloudNotebookCatalogScopeFromList,
   cloudNotebookScopeCanEditDocument,
   cloudNotebookSyncScopeForCatalogAccess,
+  createCloudNotebookCatalogAccessLoader,
+  type CloudNotebookCatalogAccessLoadResult,
   type CloudNotebookCatalogAccessScope,
 } from "./cloud-notebook-catalog-access";
 import { applyDocumentTheme, CLOUD_VIEWER_THEME_STORAGE_KEY } from "./theme";
@@ -141,25 +142,14 @@ function shouldPollPendingCloudAccessRequest(): boolean {
 }
 
 async function resolveCloudAppSessionSyncScope(
-  notebookId: string,
+  loadCatalogAccess: () => Promise<CloudNotebookCatalogAccessLoadResult>,
   selectedMode: NotebookInteractionMode,
 ): Promise<Exclude<ConnectionScope, "runtime_peer">> {
   try {
-    const endpoint = new URL("api/n?limit=100", `${window.location.origin}/`);
-    const response = await fetch(endpoint.href, {
-      cache: "no-store",
-      credentials: "same-origin",
-      headers: { Accept: "application/json" },
+    return cloudNotebookSyncScopeForCatalogAccess({
+      ...(await loadCatalogAccess()),
+      selectedMode,
     });
-    if (response.ok) {
-      const body = (await response.json()) as { notebooks?: unknown };
-      const notebooks = Array.isArray(body.notebooks) ? body.notebooks : [];
-      return cloudNotebookSyncScopeForCatalogAccess({
-        catalogResolved: true,
-        catalogScope: cloudNotebookCatalogScopeFromList(notebooks, notebookId),
-        selectedMode,
-      });
-    }
   } catch (error) {
     console.warn("[notebook-cloud] unable to resolve notebook access scope before sync", error);
   }
@@ -247,6 +237,29 @@ export function NotebookViewer({
       authState.mode === "dev" ? authState.problem : null,
     ],
   );
+  const catalogAccessLoader = useMemo(
+    () =>
+      createCloudNotebookCatalogAccessLoader({
+        notebookId: config.notebookId,
+        loadNotebooks: async () => {
+          const endpoint = new URL("api/n?limit=100", `${window.location.origin}/`);
+          const response = await fetchWithCloudPrototypeAuth(
+            endpoint.href,
+            {
+              cache: "no-store",
+              headers: { Accept: "application/json" },
+            },
+            browserApiAuthState,
+          );
+          if (!response.ok) {
+            throw new Error(`Unable to load notebook catalog: ${response.status}`);
+          }
+          const body = (await response.json()) as { notebooks?: unknown };
+          return Array.isArray(body.notebooks) ? body.notebooks : [];
+        },
+      }),
+    [browserApiAuthState, config.notebookId],
+  );
   const blobResolver = useMemo(
     () =>
       createNotebookCloudBlobResolver({
@@ -281,7 +294,7 @@ export function NotebookViewer({
           : null);
       if (appSession) {
         const requestedScope = await resolveCloudAppSessionSyncScope(
-          config.notebookId,
+          catalogAccessLoader.load,
           selectedInteractionModeRef.current,
         );
         return cloudSyncAuthFromAppSessionCookie({
@@ -291,7 +304,7 @@ export function NotebookViewer({
       }
       return cloudSyncAuthFromPrototypeAuthState(authStateRef.current);
     },
-    [config.notebookId, syncAuthConnectionKey],
+    [catalogAccessLoader, config.notebookId, syncAuthConnectionKey],
   );
   const {
     connectionActorLabel,
@@ -449,35 +462,22 @@ export function NotebookViewer({
       return;
     }
 
-    const controller = new AbortController();
+    let cancelled = false;
     void (async () => {
       try {
-        const endpoint = new URL("api/n?limit=100", `${window.location.origin}/`);
-        const response = await fetchWithCloudPrototypeAuth(
-          endpoint.href,
-          {
-            cache: "no-store",
-            headers: { Accept: "application/json" },
-            signal: controller.signal,
-          },
-          browserApiAuthState,
-        );
-        if (controller.signal.aborted || !response.ok) {
-          return;
+        const access = await catalogAccessLoader.load();
+        if (!cancelled) {
+          setCatalogAccessScope(access.catalogScope);
         }
-        const body = (await response.json()) as { notebooks?: unknown };
-        if (controller.signal.aborted) {
-          return;
-        }
-        const notebooks = Array.isArray(body.notebooks) ? body.notebooks : [];
-        setCatalogAccessScope(cloudNotebookCatalogScopeFromList(notebooks, config.notebookId));
       } catch {
         return;
       }
     })();
 
-    return () => controller.abort();
-  }, [browserApiAuthState, canUseAuthenticatedCloudApi, config.notebookId]);
+    return () => {
+      cancelled = true;
+    };
+  }, [canUseAuthenticatedCloudApi, catalogAccessLoader]);
   const catalogGrantsDocumentEdit = cloudNotebookScopeCanEditDocument(catalogAccessScope);
   const cloudRuntimeConnectedForStatus = workstationAttachment
     ? workstationAttachmentIsConnected(workstationAttachment)

--- a/apps/notebook-cloud/viewer/notebook-viewer.tsx
+++ b/apps/notebook-cloud/viewer/notebook-viewer.tsx
@@ -87,8 +87,11 @@ import {
   cloudNotebookHasNotices,
   shouldShowCloudAnonymousViewerAuthNotice,
 } from "./notices";
-import { isCloudConnectionAccessDiagnostic } from "./connection-diagnostics";
-import { projectCloudNotebookViewLoading } from "./notebook-view-loading";
+import {
+  cloudConnectionDiagnosticBlocksNotebookBody,
+  isCloudConnectionAccessDiagnostic,
+} from "./connection-diagnostics";
+import { projectCloudNotebookViewSurface } from "./notebook-view-loading";
 import { useOfflineMergeNoticeAutoClear } from "./use-offline-merge-notice";
 import { useSustainedReconnecting } from "./use-sustained-reconnecting";
 import type { ViewerStatus } from "./notice-types";
@@ -1203,7 +1206,8 @@ export function NotebookViewer({
   const notebookHasReadableSnapshot =
     notebookCellIds.length > 0 ||
     (!connectionError && snapshotResolvedRef.current && status.kind === "ready");
-  const notebookViewIsLoading = projectCloudNotebookViewLoading({
+  const notebookViewSurface = projectCloudNotebookViewSurface({
+    bodyAccessBlocked: cloudConnectionDiagnosticBlocksNotebookBody(connectionError),
     cellCount: notebookCellIds.length,
     canEditStructure: shellCapabilities.canEditStructure,
     connectionError,
@@ -1214,6 +1218,7 @@ export function NotebookViewer({
     liveMaterialized: liveMaterializedRef.current,
     status,
   });
+  const notebookViewIsLoading = notebookViewSurface.isLoading;
   const noticeStatus: ViewerStatus =
     notebookViewIsLoading && (status.kind === "ready" || status.kind === "empty")
       ? { kind: "loading", message: "Preparing notebook view..." }
@@ -1291,27 +1296,29 @@ export function NotebookViewer({
             onSyncNeeded={handleSourceSyncNeeded}
             localActor={connectionActorLabel ?? ""}
           >
-            <NotebookView
-              cellIds={notebookCellIds}
-              isLoading={notebookViewIsLoading}
-              capabilities={shellCapabilities}
-              canAcceptCellMutations={canAcceptCellMutations}
-              runtime={notebookLanguageRef.current === "deno" ? "deno" : "python"}
-              sessionRuntimeState={connectionError ? "error" : "ready"}
-              onFocusCell={handleNotebookViewFocus}
-              onExecuteCell={handleCloudExecuteCell}
-              onInterruptKernel={() => {}}
-              onDeleteCell={handleCloudDeleteCell}
-              onAddCell={handleCloudAddCell}
-              onMoveCell={handleCloudMoveCell}
-              onSetCellSourceHidden={handleCloudSetCellSourceHidden}
-              onSetCellOutputsHidden={handleCloudSetCellOutputsHidden}
-              markdownHeadingAnchorsByCellId={notebookViewModel.markdownHeadingAnchorsByCellId}
-              outputHostContext={outputHostContext}
-              deferOutputIsolatedFramesUntilVisible={!shellCapabilities.canEditCells}
-              deferredOutputIsolatedFrameRootMargin={CLOUD_VIEWER_OUTPUT_IFRAME_ROOT_MARGIN}
-              autoFocusFirstCell={false}
-            />
+            {notebookViewSurface.shouldRenderNotebookView ? (
+              <NotebookView
+                cellIds={notebookCellIds}
+                isLoading={notebookViewIsLoading}
+                capabilities={shellCapabilities}
+                canAcceptCellMutations={canAcceptCellMutations}
+                runtime={notebookLanguageRef.current === "deno" ? "deno" : "python"}
+                sessionRuntimeState={connectionError ? "error" : "ready"}
+                onFocusCell={handleNotebookViewFocus}
+                onExecuteCell={handleCloudExecuteCell}
+                onInterruptKernel={() => {}}
+                onDeleteCell={handleCloudDeleteCell}
+                onAddCell={handleCloudAddCell}
+                onMoveCell={handleCloudMoveCell}
+                onSetCellSourceHidden={handleCloudSetCellSourceHidden}
+                onSetCellOutputsHidden={handleCloudSetCellOutputsHidden}
+                markdownHeadingAnchorsByCellId={notebookViewModel.markdownHeadingAnchorsByCellId}
+                outputHostContext={outputHostContext}
+                deferOutputIsolatedFramesUntilVisible={!shellCapabilities.canEditCells}
+                deferredOutputIsolatedFrameRootMargin={CLOUD_VIEWER_OUTPUT_IFRAME_ROOT_MARGIN}
+                autoFocusFirstCell={false}
+              />
+            ) : null}
           </CrdtBridgeProvider>
         </PresenceValueProvider>
       </NotebookDocumentShell>

--- a/apps/notebook-cloud/viewer/notebook-viewer.tsx
+++ b/apps/notebook-cloud/viewer/notebook-viewer.tsx
@@ -554,6 +554,7 @@ export function NotebookViewer({
   const selectedInteractionModeForAccess = cloudNotebookInteractionModeForAccess({
     accessRequestStatus: effectiveAccessRequest?.status,
     accessScope: accessConnectionScope,
+    catalogResolved: catalogAccessResolved,
     connectionScope,
     selectedMode: selectedInteractionMode,
   });

--- a/apps/notebook-cloud/viewer/notebook-viewer.tsx
+++ b/apps/notebook-cloud/viewer/notebook-viewer.tsx
@@ -106,6 +106,7 @@ import { clearCloudAppSession, readCloudAppSessionStatus } from "./app-session";
 import {
   projectCloudAccessRequestNotice,
   projectCloudAccessRequestTransition,
+  shouldLoadOwnCloudAccessRequest,
   type CloudAccessRequestNoticeProjection,
 } from "./cloud-access-request-state";
 import {
@@ -568,6 +569,13 @@ export function NotebookViewer({
     connectionScope,
   });
   const effectiveAccessRequest = catalogGrantsDocumentEdit ? null : latestAccessRequest;
+  const shouldLoadOwnEditAccessRequest = shouldLoadOwnCloudAccessRequest({
+    canUseAuthenticatedCloudApi,
+    catalogGrantsDocumentEdit,
+    connectionScope,
+    hasBrowserAppIdentity,
+    selectedMode: selectedInteractionMode,
+  });
   const selectedInteractionModeForAccess = cloudNotebookInteractionModeForAccess({
     accessRequestStatus: effectiveAccessRequest?.status,
     accessScope: accessConnectionScope,
@@ -949,11 +957,7 @@ export function NotebookViewer({
   );
   const loadOwnAccessRequest = useCallback(
     async (options?: { signal?: AbortSignal }) => {
-      if (
-        connectionScope !== "viewer" ||
-        !canUseAuthenticatedCloudApi ||
-        catalogGrantsDocumentEdit
-      ) {
+      if (!shouldLoadOwnEditAccessRequest) {
         return;
       }
 
@@ -983,37 +987,21 @@ export function NotebookViewer({
     [
       applyLatestAccessRequest,
       browserApiAuthState,
-      canUseAuthenticatedCloudApi,
-      catalogGrantsDocumentEdit,
       config.accessRequestsEndpoint,
-      connectionScope,
+      shouldLoadOwnEditAccessRequest,
     ],
   );
   useEffect(() => {
-    if (connectionScope !== "viewer" || !hasBrowserAppIdentity || catalogGrantsDocumentEdit) {
+    if (!shouldLoadOwnEditAccessRequest) {
       setLatestAccessRequest(null);
-      return;
-    }
-    if (!canUseAuthenticatedCloudApi) {
       return;
     }
     const controller = new AbortController();
     void loadOwnAccessRequest({ signal: controller.signal });
     return () => controller.abort();
-  }, [
-    canUseAuthenticatedCloudApi,
-    catalogGrantsDocumentEdit,
-    connectionScope,
-    hasBrowserAppIdentity,
-    loadOwnAccessRequest,
-  ]);
+  }, [loadOwnAccessRequest, shouldLoadOwnEditAccessRequest]);
   useEffect(() => {
-    if (
-      effectiveAccessRequest?.status !== "pending" ||
-      connectionScope !== "viewer" ||
-      !canUseAuthenticatedCloudApi ||
-      catalogGrantsDocumentEdit
-    ) {
+    if (effectiveAccessRequest?.status !== "pending" || !shouldLoadOwnEditAccessRequest) {
       return;
     }
 
@@ -1040,13 +1028,7 @@ export function NotebookViewer({
       window.clearInterval(intervalId);
       document.removeEventListener("visibilitychange", handleVisibilityChange);
     };
-  }, [
-    canUseAuthenticatedCloudApi,
-    catalogGrantsDocumentEdit,
-    connectionScope,
-    effectiveAccessRequest?.status,
-    loadOwnAccessRequest,
-  ]);
+  }, [effectiveAccessRequest?.status, loadOwnAccessRequest, shouldLoadOwnEditAccessRequest]);
   const requestCloudEditAccess = useCallback(() => {
     void (async () => {
       setAccessRequestError(null);

--- a/apps/notebook-cloud/viewer/notebook-viewer.tsx
+++ b/apps/notebook-cloud/viewer/notebook-viewer.tsx
@@ -100,6 +100,7 @@ import { clearCloudAppSession, readCloudAppSessionStatus } from "./app-session";
 import { projectCloudAccessRequestTransition } from "./cloud-access-request-state";
 import {
   cloudNotebookAccessScopeForShell,
+  cloudNotebookLiveRoomConnectionPolicy,
   cloudNotebookScopeCanEditDocument,
   cloudNotebookSyncScopeForCatalogAccess,
   createCloudNotebookCatalogAccessLoader,
@@ -168,7 +169,7 @@ export function NotebookViewer({
 }) {
   const { config } = runtime;
   const routeTitle = useMemo(() => cloudNotebookRouteTitle(), []);
-  const loadingPolicy = cloudViewerLoadingPolicy(config);
+  const loadingPolicy = useMemo(() => cloudViewerLoadingPolicy(config), [config.headsHash]);
   const { resolvedTheme } = useTheme(CLOUD_VIEWER_THEME_STORAGE_KEY);
   const { store: widgetStore } = useWidgetStoreRequired();
   const appSessionStatus = useCloudAppSessionStatus(config.session ?? null);
@@ -214,6 +215,8 @@ export function NotebookViewer({
   );
   const [catalogAccessScope, setCatalogAccessScope] =
     useState<CloudNotebookCatalogAccessScope | null>(null);
+  const [catalogAccessResolved, setCatalogAccessResolved] = useState(false);
+  const [catalogAccessLoadFailed, setCatalogAccessLoadFailed] = useState(false);
   const [accessRequestError, setAccessRequestError] = useState<string | null>(null);
   const [selectedInteractionMode, setSelectedInteractionMode] = useState<NotebookInteractionMode>(
     () => cloudNotebookModeFromSearch(window.location.search),
@@ -237,6 +240,10 @@ export function NotebookViewer({
       authState.mode === "dev" ? authState.problem : null,
     ],
   );
+  const canUseAuthenticatedCloudApi = cloudBrowserCanUseAuthenticatedApi({
+    authState,
+    hasAppSession,
+  });
   const catalogAccessLoader = useMemo(
     () =>
       createCloudNotebookCatalogAccessLoader({
@@ -259,6 +266,31 @@ export function NotebookViewer({
         },
       }),
     [browserApiAuthState, config.notebookId],
+  );
+  const catalogLiveRoomPolicy = useMemo(
+    () =>
+      cloudNotebookLiveRoomConnectionPolicy({
+        canUseAuthenticatedCloudApi,
+        catalogLoadFailed: catalogAccessLoadFailed,
+        catalogResolved: catalogAccessResolved,
+        catalogScope: catalogAccessScope,
+      }),
+    [
+      canUseAuthenticatedCloudApi,
+      catalogAccessLoadFailed,
+      catalogAccessResolved,
+      catalogAccessScope,
+    ],
+  );
+  const effectiveLoadingPolicy = useMemo(
+    () => ({
+      ...loadingPolicy,
+      shouldConnectLiveRoom:
+        loadingPolicy.shouldConnectLiveRoom && catalogLiveRoomPolicy.shouldConnectLiveRoom,
+      initialStatusMessage:
+        catalogLiveRoomPolicy.disabledStatus?.message ?? loadingPolicy.initialStatusMessage,
+    }),
+    [catalogLiveRoomPolicy, loadingPolicy],
   );
   const blobResolver = useMemo(
     () =>
@@ -333,7 +365,10 @@ export function NotebookViewer({
     blobResolver,
     config,
     hasAppSession,
-    loadingPolicy,
+    loadingPolicy: effectiveLoadingPolicy,
+    liveRoomDisabledStatus: loadingPolicy.shouldConnectLiveRoom
+      ? catalogLiveRoomPolicy.disabledStatus
+      : null,
     preloadSiftWasm,
     resolveSyncAuth,
     widgetStore,
@@ -452,24 +487,32 @@ export function NotebookViewer({
   }, []);
   const hasBrowserAppIdentity =
     hasAppSession || authState.mode === "dev" || authState.mode === "oidc";
-  const canUseAuthenticatedCloudApi = cloudBrowserCanUseAuthenticatedApi({
-    authState,
-    hasAppSession,
-  });
   useEffect(() => {
     if (!canUseAuthenticatedCloudApi) {
       setCatalogAccessScope(null);
+      setCatalogAccessResolved(false);
+      setCatalogAccessLoadFailed(false);
       return;
     }
 
     let cancelled = false;
+    setCatalogAccessScope(null);
+    setCatalogAccessResolved(false);
+    setCatalogAccessLoadFailed(false);
     void (async () => {
       try {
         const access = await catalogAccessLoader.load();
         if (!cancelled) {
           setCatalogAccessScope(access.catalogScope);
+          setCatalogAccessResolved(access.catalogResolved);
+          setCatalogAccessLoadFailed(false);
         }
       } catch {
+        if (!cancelled) {
+          setCatalogAccessScope(null);
+          setCatalogAccessResolved(false);
+          setCatalogAccessLoadFailed(true);
+        }
         return;
       }
     })();

--- a/apps/notebook-cloud/viewer/notebook-viewer.tsx
+++ b/apps/notebook-cloud/viewer/notebook-viewer.tsx
@@ -902,7 +902,10 @@ export function NotebookViewer({
     }
   }, [authConfig.oidc, resetPrototypeAuth]);
   const applyLatestAccessRequest = useCallback(
-    (request: CloudNotebookAccessRequest | null) => {
+    (
+      request: CloudNotebookAccessRequest | null,
+      options?: { selectedMode?: NotebookInteractionMode },
+    ) => {
       setLatestAccessRequest(request);
       const transition = projectCloudAccessRequestTransition({
         accessScope: catalogAccessScope,
@@ -913,6 +916,7 @@ export function NotebookViewer({
         connectionScope,
         hasAppSession,
         request: catalogGrantsDocumentEdit ? null : request,
+        selectedMode: options?.selectedMode ?? selectedInteractionMode,
       });
       if (transition.requestedScope) {
         storeCloudRequestedScope(window.localStorage, transition.requestedScope);
@@ -936,6 +940,7 @@ export function NotebookViewer({
       hasAppSession,
       refreshAuthState,
       retryLiveConnection,
+      selectedInteractionMode,
     ],
   );
   const loadOwnAccessRequest = useCallback(
@@ -1062,21 +1067,24 @@ export function NotebookViewer({
           access_status?: string;
         };
         if (body.access_status === "granted") {
-          applyLatestAccessRequest({
-            id: "already-granted",
-            notebook_id: config.notebookId,
-            requester_principal: "",
-            scope: "editor",
-            status: "approved",
-            requested_by_actor_label: "",
-            resolved_by_actor_label: null,
-            created_at: new Date().toISOString(),
-            updated_at: new Date().toISOString(),
-            resolved_at: new Date().toISOString(),
-          });
+          applyLatestAccessRequest(
+            {
+              id: "already-granted",
+              notebook_id: config.notebookId,
+              requester_principal: "",
+              scope: "editor",
+              status: "approved",
+              requested_by_actor_label: "",
+              resolved_by_actor_label: null,
+              created_at: new Date().toISOString(),
+              updated_at: new Date().toISOString(),
+              resolved_at: new Date().toISOString(),
+            },
+            { selectedMode: "edit" },
+          );
           return;
         }
-        applyLatestAccessRequest(body.access_request ?? null);
+        applyLatestAccessRequest(body.access_request ?? null, { selectedMode: "edit" });
       } catch (error) {
         setAccessRequestError(error instanceof Error ? error.message : String(error));
       }

--- a/apps/notebook-cloud/viewer/notices.tsx
+++ b/apps/notebook-cloud/viewer/notices.tsx
@@ -128,6 +128,7 @@ export function cloudNotebookHasNotices({
   const shouldShowStatusNotice =
     status.kind !== "ready" &&
     !(status.kind === "empty" && hasReadableSnapshot) &&
+    !(connectionNotice && status.kind === "loading") &&
     !isStatusDerivedFromConnectionError(status, connectionError);
 
   const shouldShowAnonymousViewerAuthNotice = shouldShowCloudAnonymousViewerAuthNotice({
@@ -202,6 +203,7 @@ export function CloudNotebookNotices({
   const shouldShowStatusNotice =
     status.kind !== "ready" &&
     !(status.kind === "empty" && hasReadableSnapshot) &&
+    !(connectionNotice && status.kind === "loading") &&
     !isStatusDerivedFromConnectionError(status, connectionError);
   const shouldShowAnonymousViewerAuthNotice = shouldShowCloudAnonymousViewerAuthNotice({
     authState,

--- a/apps/notebook-cloud/viewer/notices.tsx
+++ b/apps/notebook-cloud/viewer/notices.tsx
@@ -11,6 +11,7 @@ import {
   CLOUD_CONNECTION_EDIT_ACCESS_PENDING_DIAGNOSTIC,
   CLOUD_CONNECTION_NO_ACCESS_DIAGNOSTIC,
   CLOUD_CONNECTION_SIGN_IN_DIAGNOSTIC,
+  isCloudConnectionAccessDiagnostic,
 } from "./connection-diagnostics";
 import { isRuntimedWasmAssetFailure } from "./runtimed-wasm-failure";
 import type { CloudAuthRenewalState, ViewerStatus } from "./notice-types";
@@ -480,10 +481,12 @@ function isStatusDerivedFromConnectionError(
   status: ViewerStatus,
   connectionError: string | null,
 ): boolean {
+  if (status.kind !== "error" || !connectionError) {
+    return false;
+  }
   return (
-    status.kind === "error" &&
-    Boolean(connectionError) &&
-    status.message.startsWith("Unable to load live notebook room:")
+    status.message.startsWith("Unable to load live notebook room:") ||
+    (status.message === connectionError && isCloudConnectionAccessDiagnostic(connectionError))
   );
 }
 

--- a/apps/notebook-cloud/viewer/presence.ts
+++ b/apps/notebook-cloud/viewer/presence.ts
@@ -336,11 +336,18 @@ export function cloudVisiblePeerLabel(
   actorLabel?: string | null,
 ): string {
   const trimmedPeerLabel = peerLabel?.trim();
-  if (trimmedPeerLabel && !looksLikeRawIdentityLabel(trimmedPeerLabel)) {
+  if (
+    trimmedPeerLabel &&
+    !looksLikeRawIdentityLabel(trimmedPeerLabel) &&
+    !looksLikeEmailAddress(trimmedPeerLabel)
+  ) {
     return trimmedPeerLabel;
   }
 
-  return cloudFriendlyPeerLabel({ actorLabel: actorLabel ?? trimmedPeerLabel });
+  return cloudFriendlyPeerLabel({
+    actorLabel: actorLabel ?? trimmedPeerLabel,
+    email: looksLikeEmailAddress(trimmedPeerLabel ?? "") ? trimmedPeerLabel : null,
+  });
 }
 
 export function cloudFriendlyPeerLabel({
@@ -353,17 +360,14 @@ export function cloudFriendlyPeerLabel({
     return trimmedDisplayName;
   }
 
-  const trimmedEmail = email?.trim();
-  if (trimmedEmail) {
-    return trimmedEmail;
+  const trimmedActorLabel = actorLabel?.trim();
+  if (trimmedActorLabel) {
+    return notebookActorIdentityFromProjection(
+      notebookActorProjectionFromLabel(trimmedActorLabel, { source: "cloud", isPublic: false }),
+    ).label;
   }
 
-  const trimmedActorLabel = actorLabel?.trim();
-  if (!trimmedActorLabel) return "Peer";
-
-  return notebookActorIdentityFromProjection(
-    notebookActorProjectionFromLabel(trimmedActorLabel, { source: "cloud", isPublic: false }),
-  ).label;
+  return email?.trim() ? "User" : "Peer";
 }
 
 function safeRoomPeerCount(value: number): number {

--- a/apps/notebook-cloud/viewer/session-auth-stability.ts
+++ b/apps/notebook-cloud/viewer/session-auth-stability.ts
@@ -9,11 +9,12 @@ const CLOUD_COOKIE_BLOB_AUTH_STATE: CloudPrototypeAuthState = Object.freeze({
   problem: null,
 });
 
-export function cloudBlobAuthStateForBrowserFetch(
+export function cloudBrowserApiAuthStateForFetch(
   authState: CloudPrototypeAuthState,
 ): CloudPrototypeAuthState {
-  // Cookie/app-session browser fetches do not add OIDC bearer headers, so they
-  // intentionally share one stable auth object across OIDC token refreshes.
+  // Cookie/app-session browser fetches do not add OIDC bearer headers, so
+  // host-owned APIs and blob fetches intentionally share one stable auth
+  // object across OIDC token refreshes.
   if (authState.mode !== "dev") {
     return CLOUD_COOKIE_BLOB_AUTH_STATE;
   }
@@ -25,6 +26,12 @@ export function cloudBlobAuthStateForBrowserFetch(
     requestedScope: authState.requestedScope,
     problem: authState.problem,
   };
+}
+
+export function cloudBlobAuthStateForBrowserFetch(
+  authState: CloudPrototypeAuthState,
+): CloudPrototypeAuthState {
+  return cloudBrowserApiAuthStateForFetch(authState);
 }
 
 export function cloudSyncAuthConnectionKey(

--- a/apps/notebook-cloud/viewer/sharing-client.ts
+++ b/apps/notebook-cloud/viewer/sharing-client.ts
@@ -106,10 +106,20 @@ export type CloudShareAccessRow =
       removable: boolean;
     };
 
+export interface CloudShareAccessProjection {
+  allRows: CloudShareAccessRow[];
+  notebookAccessRows: CloudShareAccessRow[];
+  runtimeAccessRows: CloudShareAccessRow[];
+  notebookAccessSummary: string | null;
+  runtimeAccessSummary: string | null;
+}
+
 const SHARE_ACCESS_ROW_CACHE = new Map<string, CloudShareAccessRow>();
 const SHARE_ACCESS_ROWS_CACHE = new Map<string, CloudShareAccessRow[]>();
+const SHARE_ACCESS_PROJECTION_CACHE = new Map<string, CloudShareAccessProjection>();
 const SHARE_ACCESS_ROW_CACHE_LIMIT = 512;
 const SHARE_ACCESS_ROWS_CACHE_LIMIT = 128;
+const SHARE_ACCESS_PROJECTION_CACHE_LIMIT = 128;
 const CLOUD_NOTEBOOK_ACL_ROW_FIELDS = {
   notebook_id: true,
   subject_kind: true,
@@ -153,6 +163,39 @@ const CLOUD_NOTEBOOK_ACCESS_REQUEST_FIELDS = {
 export function clearCloudShareAccessRowsCachesForTests(): void {
   SHARE_ACCESS_ROW_CACHE.clear();
   SHARE_ACCESS_ROWS_CACHE.clear();
+  SHARE_ACCESS_PROJECTION_CACHE.clear();
+}
+
+export function buildCloudShareAccessProjection(input: {
+  acl: CloudNotebookAclRow[];
+  invites: CloudNotebookInvite[];
+  accessRequests?: CloudNotebookAccessRequest[];
+}): CloudShareAccessProjection {
+  const allRows = buildCloudShareAccessRows(input);
+  const projectionKey = stableCacheKey(allRows.map(cloudShareAccessRowProjectionKey));
+  const cached = getBoundedCacheValue(SHARE_ACCESS_PROJECTION_CACHE, projectionKey);
+  if (cached) return cached;
+
+  const notebookAccessRows = Object.freeze(
+    allRows.filter((row) => !isCloudShareRuntimeAccessRow(row)),
+  ) as CloudShareAccessRow[];
+  const runtimeAccessRows = Object.freeze(
+    allRows.filter(isCloudShareRuntimeAccessRow),
+  ) as CloudShareAccessRow[];
+  const projection = Object.freeze({
+    allRows,
+    notebookAccessRows,
+    runtimeAccessRows,
+    notebookAccessSummary: cloudShareAccessSummary(notebookAccessRows),
+    runtimeAccessSummary: cloudShareRuntimeAccessSummary(runtimeAccessRows),
+  });
+  setBoundedCacheValue(
+    SHARE_ACCESS_PROJECTION_CACHE,
+    projectionKey,
+    projection,
+    SHARE_ACCESS_PROJECTION_CACHE_LIMIT,
+  );
+  return projection;
 }
 
 export function buildCloudShareAccessRows(input: {
@@ -171,7 +214,8 @@ export function buildCloudShareAccessRows(input: {
     const badge = scopeLabel(acl.scope);
     const stateLabel = acl.subject_kind === "public" ? "Enabled" : null;
     const stateTone = acl.subject_kind === "public" ? "success" : null;
-    const removable = acl.subject_kind === "public" || acl.scope !== "owner";
+    const removable =
+      acl.subject_kind === "public" || (acl.scope !== "owner" && acl.scope !== "runtime_peer");
     const rowKey = stableCacheKey([
       "acl",
       cloudNotebookAclRowCacheKey(acl),
@@ -305,6 +349,17 @@ export function cloudShareAccessSummary(rows: CloudShareAccessRow[]): string | n
   return parts.join(", ") || null;
 }
 
+export function cloudShareRuntimeAccessSummary(rows: CloudShareAccessRow[]): string | null {
+  const runtimePeers = rows.filter(isCloudShareRuntimeAccessRow).length;
+  return runtimePeers > 0 ? pluralize(runtimePeers, "runtime peer", "runtime peers") : null;
+}
+
+export function isCloudShareRuntimeAccessRow(
+  row: CloudShareAccessRow,
+): row is Extract<CloudShareAccessRow, { kind: "acl" }> {
+  return row.kind === "acl" && row.acl.subject_kind === "principal" && row.scope === "runtime_peer";
+}
+
 export function hasPublicViewerAccess(acl: CloudNotebookAclRow[]): boolean {
   return acl.some(
     (row) => row.subject_kind === "public" && row.subject === "anonymous" && row.scope === "viewer",
@@ -355,6 +410,9 @@ function labelForAcl(row: CloudNotebookAclRow): string {
 function detailForAcl(row: CloudNotebookAclRow): string {
   if (row.subject_kind === "public") {
     return row.display?.label || "Anyone with the link";
+  }
+  if (row.scope === "runtime_peer") {
+    return "Compute access for runtime peers";
   }
   const display = row.display;
   if (display?.kind === "principal") {
@@ -451,6 +509,21 @@ function compareAclRows(a: CloudNotebookAclRow, b: CloudNotebookAclRow): number 
   const rankDelta = rank(a) - rank(b);
   if (rankDelta !== 0) return rankDelta;
   return `${labelForAcl(a)}:${a.scope}`.localeCompare(`${labelForAcl(b)}:${b.scope}`);
+}
+
+function cloudShareAccessRowProjectionKey(row: CloudShareAccessRow): string {
+  return stableCacheKey([
+    row.kind,
+    row.id,
+    row.label,
+    row.detail,
+    row.title,
+    row.scope,
+    row.badge,
+    row.stateLabel,
+    row.stateTone,
+    row.removable,
+  ]);
 }
 
 function cachedCloudShareAccessRow<Row extends CloudShareAccessRow>(

--- a/apps/notebook-cloud/viewer/sharing-controls.tsx
+++ b/apps/notebook-cloud/viewer/sharing-controls.tsx
@@ -361,9 +361,11 @@ export function CloudSharingControls({
         </section>
 
         <form className="cloud-share-invite" onSubmit={submitInvite}>
-          <label>
+          <label htmlFor="cloud-share-invite-email">
             <span>Invite by email</span>
             <input
+              id="cloud-share-invite-email"
+              name="invite-email"
               type="email"
               value={inviteEmail}
               placeholder="name@example.com"
@@ -374,9 +376,11 @@ export function CloudSharingControls({
               }}
             />
           </label>
-          <label>
+          <label htmlFor="cloud-share-invite-scope">
             <span>Access</span>
             <select
+              id="cloud-share-invite-scope"
+              name="invite-scope"
               value={inviteScope}
               onChange={(event) => setInviteScope(event.target.value as CloudShareInviteScope)}
             >

--- a/apps/notebook-cloud/viewer/sharing-controls.tsx
+++ b/apps/notebook-cloud/viewer/sharing-controls.tsx
@@ -1,10 +1,9 @@
 import { useCallback, useEffect, useMemo, useRef, useState, type FormEvent } from "react";
-import { Check, Globe2, Link2, Mail, Share2, Trash2, UserRound, X } from "lucide-react";
+import { Check, Globe2, Link2, Mail, ServerCog, Share2, Trash2, UserRound, X } from "lucide-react";
 import { fetchWithCloudPrototypeAuth, type CloudPrototypeAuthState } from "./collaborator-auth";
 import { appendEndpointPathSegment, cloudResponseError } from "./cloud-response";
 import {
-  buildCloudShareAccessRows,
-  cloudShareAccessSummary,
+  buildCloudShareAccessProjection,
   hasPublicViewerAccess,
   normalizeShareInviteEmail,
   type CloudNotebookAccessRequest,
@@ -47,11 +46,10 @@ export function CloudSharingControls({
   const [busyAction, setBusyAction] = useState<string | null>(null);
   const [copyState, setCopyState] = useState<CloudSharingCopyState>("idle");
   const inviteSubmitLockRef = useRef(false);
-  const accessRows = useMemo(
-    () => buildCloudShareAccessRows({ acl, invites, accessRequests }),
+  const accessProjection = useMemo(
+    () => buildCloudShareAccessProjection({ acl, invites, accessRequests }),
     [accessRequests, acl, invites],
   );
-  const accessSummary = useMemo(() => cloudShareAccessSummary(accessRows), [accessRows]);
   const publicEnabled = useMemo(() => hasPublicViewerAccess(acl), [acl]);
   const inviteReady = normalizeShareInviteEmail(inviteEmail) !== null;
 
@@ -330,7 +328,7 @@ export function CloudSharingControls({
         <header>
           <div>
             <h2>Share notebook</h2>
-            <p>Public link, collaborators, pending invites, and edit requests.</p>
+            <p>Invite people, review requests, and manage link access.</p>
           </div>
           <button type="button" aria-label={copyLinkLabel} onClick={() => void copyPublicLink()}>
             <Link2 aria-hidden="true" />
@@ -347,7 +345,7 @@ export function CloudSharingControls({
               <span>
                 {publicEnabled
                   ? "Can view this notebook without signing in"
-                  : "Only invited people can open this notebook"}
+                  : "Link access is off. Only listed people can open this notebook"}
               </span>
             </div>
           </div>
@@ -402,15 +400,17 @@ export function CloudSharingControls({
         <section className="cloud-share-current" aria-label="Current notebook access">
           <div className="cloud-share-current-heading">
             <h3>Current access</h3>
-            {accessSummary ? <span>{accessSummary}</span> : null}
+            {accessProjection.notebookAccessSummary ? (
+              <span>{accessProjection.notebookAccessSummary}</span>
+            ) : null}
           </div>
-          {loadState === "loading" && accessRows.length === 0 ? (
+          {loadState === "loading" && accessProjection.allRows.length === 0 ? (
             <div className="cloud-share-empty">Loading access...</div>
-          ) : accessRows.length === 0 ? (
+          ) : accessProjection.notebookAccessRows.length === 0 ? (
             <div className="cloud-share-empty">Only the owner can access this notebook.</div>
           ) : (
             <ul>
-              {accessRows.map((row) => (
+              {accessProjection.notebookAccessRows.map((row) => (
                 <li key={row.id} title={row.title}>
                   <CloudShareRowIcon row={row} />
                   <div>
@@ -473,6 +473,31 @@ export function CloudSharingControls({
           )}
         </section>
 
+        {accessProjection.runtimeAccessRows.length > 0 ? (
+          <section className="cloud-share-current cloud-share-runtime" aria-label="Compute access">
+            <div className="cloud-share-current-heading">
+              <h3>Compute access</h3>
+              {accessProjection.runtimeAccessSummary ? (
+                <span>{accessProjection.runtimeAccessSummary}</span>
+              ) : null}
+            </div>
+            <ul>
+              {accessProjection.runtimeAccessRows.map((row) => (
+                <li key={row.id} title={row.title}>
+                  <CloudShareRowIcon row={row} />
+                  <div>
+                    <strong>{row.label}</strong>
+                    <span>{row.detail}</span>
+                  </div>
+                  <div className="cloud-share-row-actions">
+                    <span className="cloud-share-badge">{row.badge}</span>
+                  </div>
+                </li>
+              ))}
+            </ul>
+          </section>
+        ) : null}
+
         {message ? (
           <div className="cloud-share-message" data-kind={messageKind}>
             {message}
@@ -489,6 +514,9 @@ function CloudShareRowIcon({ row }: { row: CloudShareAccessRow }) {
   }
   if (row.kind === "access_request") {
     return <UserRound aria-hidden="true" />;
+  }
+  if (row.kind === "acl" && row.scope === "runtime_peer") {
+    return <ServerCog aria-hidden="true" />;
   }
   if (row.acl.subject_kind === "public") {
     return <Globe2 aria-hidden="true" />;

--- a/apps/notebook-cloud/viewer/shell-capabilities.ts
+++ b/apps/notebook-cloud/viewer/shell-capabilities.ts
@@ -16,6 +16,13 @@ import { projectCloudNotebookEditAccess } from "./edit-access";
 
 export interface CloudNotebookShellCapabilityInput {
   authState: CloudPrototypeAuthState;
+  /**
+   * Document access used for UI projection. During reconnect this can come
+   * from the authenticated notebook catalog so owners do not see stale
+   * request-access chrome. Actual mutation and execution authority still comes
+   * from the live room `connectionScope` below.
+   */
+  accessConnectionScope?: string | null;
   connectionScope: string | null;
   connectionActorLabel?: string | null;
   connectionPeerLabel?: string | null;
@@ -68,6 +75,7 @@ export interface CloudNotebookShellCapabilityInput {
 }
 
 export function cloudNotebookShellCapabilities({
+  accessConnectionScope,
   authState,
   connectionScope,
   connectionActorLabel = null,
@@ -83,9 +91,10 @@ export function cloudNotebookShellCapabilities({
   workstationAttachment = null,
   hostCapabilities,
 }: CloudNotebookShellCapabilityInput): NotebookShellCapabilities {
+  const documentAccessScope = accessConnectionScope ?? connectionScope;
   const interaction = projectCloudNotebookEditAccess({
     authState,
-    connectionScope,
+    connectionScope: documentAccessScope,
     hasAppSession,
     selectedMode,
     canAcceptCellMutations,

--- a/apps/notebook-cloud/viewer/shell-capabilities.ts
+++ b/apps/notebook-cloud/viewer/shell-capabilities.ts
@@ -13,6 +13,7 @@ import {
 } from "runtimed";
 import type { CloudPrototypeAuthState } from "./collaborator-auth";
 import { projectCloudNotebookEditAccess } from "./edit-access";
+import { cloudFriendlyPeerLabel, cloudVisiblePeerLabel } from "./presence";
 
 export interface CloudNotebookShellCapabilityInput {
   authState: CloudPrototypeAuthState;
@@ -105,7 +106,9 @@ export function cloudNotebookShellCapabilities({
   const authenticated = hasAppSession || authState.mode === "dev" || authState.mode === "oidc";
   const authNeedsAttention =
     !hasAppSession && (authState.mode === "invalid" || authState.mode === "oidc_expired");
-  const identityLabel = connectionPeerLabel?.trim() || cloudIdentityDisplayLabel(authState);
+  const identityLabel = connectionPeerLabel?.trim()
+    ? cloudVisiblePeerLabel(connectionPeerLabel, connectionActorLabel)
+    : cloudIdentityDisplayLabel(authState, connectionActorLabel);
   const identityImageUrl = cloudIdentityImageUrl(authState);
   const attachmentConnected = workstationAttachmentIsConnected(workstationAttachment);
   const attachmentExecutionAvailable = workstationAttachmentCanExecute(workstationAttachment);
@@ -245,27 +248,29 @@ function cloudRuntimeTarget({
   };
 }
 
-function cloudIdentityDisplayLabel(authState: CloudPrototypeAuthState): string | null {
+function cloudIdentityDisplayLabel(
+  authState: CloudPrototypeAuthState,
+  actorLabel?: string | null,
+): string | null {
   const claimName = authState.oidcClaims?.name?.trim();
   if (claimName) {
     return claimName;
   }
-  const claimEmail = identityEmailLabel(authState.oidcClaims?.email);
+  const claimEmail = authState.oidcClaims?.email?.trim();
   if (claimEmail) {
-    return claimEmail;
+    return cloudFriendlyPeerLabel({ actorLabel, email: claimEmail });
   }
   const user = authState.user?.trim();
-  return identityEmailLabel(user) ?? user ?? null;
+  if (!user) {
+    return null;
+  }
+  return looksLikeEmailAddress(user) ? cloudFriendlyPeerLabel({ actorLabel, email: user }) : user;
 }
 
 function cloudIdentityImageUrl(authState: CloudPrototypeAuthState): string | null {
   return authState.oidcClaims?.picture?.trim() || null;
 }
 
-function identityEmailLabel(value: string | null | undefined): string | null {
-  const trimmed = value?.trim();
-  if (!trimmed) {
-    return null;
-  }
-  return /^[^@\s]+@[^@\s]+\.[^@\s]+$/.test(trimmed) ? trimmed : null;
+function looksLikeEmailAddress(value: string): boolean {
+  return /^[^@\s]+@[^@\s]+\.[^@\s]+$/.test(value);
 }

--- a/apps/notebook-cloud/viewer/use-cloud-shell-capabilities.ts
+++ b/apps/notebook-cloud/viewer/use-cloud-shell-capabilities.ts
@@ -8,11 +8,15 @@ import {
 
 import type { CloudPrototypeAuthState } from "./collaborator-auth";
 import type { CloudViewerConfig } from "./cloud-viewer-session";
-import { projectCloudNotebookEditAccess } from "./edit-access";
+import {
+  projectCloudNotebookDocumentEditReadiness,
+  projectCloudNotebookEditAccess,
+} from "./edit-access";
 import type { ViewerStatus } from "./notice-types";
 import { cloudNotebookShellCapabilities } from "./shell-capabilities";
 
 interface UseCloudShellCapabilitiesInput {
+  accessConnectionScope?: string | null;
   authState: CloudPrototypeAuthState;
   connectionScope: string | null;
   connectionActorLabel: string | null;
@@ -44,6 +48,7 @@ export interface CloudShellCapabilities {
  * derives stable UI capabilities for the shared shell, toolbar, and rail.
  */
 export function useCloudShellCapabilities({
+  accessConnectionScope = null,
   authState,
   connectionScope,
   connectionActorLabel,
@@ -60,26 +65,49 @@ export function useCloudShellCapabilities({
   workstationAttachment,
   hostCapabilities,
 }: UseCloudShellCapabilitiesInput): CloudShellCapabilities {
-  const canAcceptCellMutations =
-    Boolean(connectionPeerId) &&
-    !connectionError &&
-    (status.kind === "ready" || status.kind === "empty");
-  const editAccessRequestPending = !connectionError && status.kind === "loading";
+  const documentAccessScope = accessConnectionScope ?? connectionScope;
+  const editReadiness = useMemo(
+    () =>
+      projectCloudNotebookDocumentEditReadiness({
+        accessScope: documentAccessScope,
+        connectionError,
+        connectionPeerId,
+        connectionScope,
+        selectedMode,
+        statusKind: status.kind,
+      }),
+    [
+      connectionError,
+      connectionPeerId,
+      connectionScope,
+      documentAccessScope,
+      selectedMode,
+      status.kind,
+    ],
+  );
   const roomEditAccess = useMemo(
     () =>
       projectCloudNotebookEditAccess({
         authState,
-        connectionScope,
+        connectionScope: documentAccessScope,
         selectedMode,
-        canAcceptCellMutations,
-        editAccessRequestPending,
+        canAcceptCellMutations: editReadiness.canAcceptCellMutations,
+        editAccessRequestPending: editReadiness.editAccessRequestPending,
       }),
-    [authState, canAcceptCellMutations, connectionScope, editAccessRequestPending, selectedMode],
+    [
+      authState,
+      documentAccessScope,
+      editReadiness.canAcceptCellMutations,
+      editReadiness.editAccessRequestPending,
+      selectedMode,
+    ],
   );
-  const editAccessPending = roomEditAccess.editAccessPending;
+  const editAccessPending =
+    roomEditAccess.editAccessPending || editReadiness.selectedEditModeWaitingForRoom;
   const shellCapabilities = useMemo(
     () =>
       cloudNotebookShellCapabilities({
+        accessConnectionScope: documentAccessScope,
         authState,
         connectionScope,
         connectionActorLabel,
@@ -87,8 +115,8 @@ export function useCloudShellCapabilities({
         hasAppSession,
         hasCodeCells: codeCellCount > 0,
         selectedMode,
-        canAcceptCellMutations,
-        editAccessRequestPending,
+        canAcceptCellMutations: editReadiness.canAcceptCellMutations,
+        editAccessRequestPending: editReadiness.editAccessRequestPending,
         runtimeAvailable: runtimePeerAvailable,
         runtimePeerCount,
         kernelStatusLabel,
@@ -98,13 +126,14 @@ export function useCloudShellCapabilities({
     [
       authState,
       hasAppSession,
-      canAcceptCellMutations,
+      documentAccessScope,
       codeCellCount,
       hostCapabilities,
       connectionActorLabel,
       connectionPeerLabel,
       connectionScope,
-      editAccessRequestPending,
+      editReadiness.canAcceptCellMutations,
+      editReadiness.editAccessRequestPending,
       kernelStatusLabel,
       runtimePeerCount,
       runtimePeerAvailable,
@@ -114,7 +143,11 @@ export function useCloudShellCapabilities({
   );
 
   return useMemo(
-    () => ({ shellCapabilities, canAcceptCellMutations, editAccessPending }),
-    [canAcceptCellMutations, editAccessPending, shellCapabilities],
+    () => ({
+      shellCapabilities,
+      canAcceptCellMutations: editReadiness.canAcceptCellMutations,
+      editAccessPending,
+    }),
+    [editAccessPending, editReadiness.canAcceptCellMutations, shellCapabilities],
   );
 }

--- a/apps/notebook-cloud/viewer/use-cloud-workstations.ts
+++ b/apps/notebook-cloud/viewer/use-cloud-workstations.ts
@@ -83,10 +83,11 @@ export function useCloudWorkstationManager({
     capabilities.access.source === "cloud" &&
     capabilities.auth.canUseAuthenticatedIdentity &&
     capabilities.access.level === "owner";
+  const canLoadHostedWorkstations = canLoadCloudWorkstations && canChooseHostedWorkstation;
 
   const refreshCloudWorkstations = useCallback(
     async (signal?: AbortSignal) => {
-      if (!canLoadCloudWorkstations || !config.workstationsEndpoint) {
+      if (!canLoadHostedWorkstations || !config.workstationsEndpoint) {
         if (!capabilities.auth.canUseAuthenticatedIdentity) {
           setWorkstationsState({ defaultWorkstationId: null, workstations: [] });
         }
@@ -105,7 +106,7 @@ export function useCloudWorkstationManager({
     },
     [
       authState,
-      canLoadCloudWorkstations,
+      canLoadHostedWorkstations,
       capabilities.auth.canUseAuthenticatedIdentity,
       config.workstationsEndpoint,
     ],
@@ -314,7 +315,7 @@ export function useCloudWorkstationManager({
   }, [pairing, workstationsState.workstations]);
 
   const workstationRefreshIntervalMs = cloudWorkstationRefreshIntervalMs({
-    canChooseHostedWorkstation: canChooseHostedWorkstation && canLoadCloudWorkstations,
+    canChooseHostedWorkstation: canLoadHostedWorkstations,
     hasRegisteredWorkstations: workstationsState.workstations.length > 0,
     mutationKind: workstationMutation.kind,
     panelIsOpen,

--- a/packages/runtimed/src/notebook-shell-capabilities.ts
+++ b/packages/runtimed/src/notebook-shell-capabilities.ts
@@ -875,7 +875,7 @@ function workstationAttachmentProviderLabel(provider: string): string {
     case "local_daemon":
       return "Local daemon";
     case "runtime_peer":
-      return "Runtime peer";
+      return "Workstation";
     case "cloud_room":
       return "Cloud room";
     case "cloud_workstation":

--- a/packages/runtimed/src/notebook-workstation-panel.ts
+++ b/packages/runtimed/src/notebook-workstation-panel.ts
@@ -52,6 +52,9 @@ export function projectNotebookWorkstationPanel(
 ): NotebookWorkstationPanelProjection {
   const target = resolveNotebookShellRuntimeTarget(capabilities.runtime);
   const cacheKey = stableCacheKey([
+    capabilities.access.level,
+    capabilities.access.source,
+    capabilities.auth.canUseAuthenticatedIdentity,
     capabilities.canExecute,
     capabilities.runtime.canWriteRuntimeState,
     capabilities.runtime.connected,
@@ -179,6 +182,16 @@ function workstationStatus(
     (capabilities.runtime.source === "local"
       ? "The local daemon is not exposing an executable runtime."
       : "No runtime peer is attached to this room.");
+  const previousAttachmentDetail = isPreviousCloudAttachment
+    ? previousCloudAttachmentDetail({
+        canManageCompute:
+          capabilities.access.source === "cloud" &&
+          capabilities.access.level === "owner" &&
+          capabilities.auth.canUseAuthenticatedIdentity,
+        detail,
+        targetLabel: target.label,
+      })
+    : detail;
 
   return {
     title: isPreviousCloudAttachment
@@ -186,7 +199,7 @@ function workstationStatus(
       : capabilities.runtime.source === "local"
         ? `${target.label} unavailable`
         : target.label,
-    detail: isPreviousCloudAttachment ? `${target.label}: ${detail}` : detail,
+    detail: previousAttachmentDetail,
     statusLabel: target.statusLabel ?? "Offline",
     tone: "offline",
   };
@@ -201,6 +214,33 @@ function previousCloudAttachmentTarget(
     target.id !== undefined &&
     target.id !== "workstation:none" &&
     (target.status === "attention" || target.status === "offline")
+  );
+}
+
+function previousCloudAttachmentDetail({
+  canManageCompute,
+  detail,
+  targetLabel,
+}: {
+  canManageCompute: boolean;
+  detail: string;
+  targetLabel: string;
+}): string {
+  if (!isRuntimePeerDisconnectDetail(detail)) {
+    return `${targetLabel}: ${detail}`;
+  }
+
+  const action = canManageCompute
+    ? "Start compute again from an available workstation."
+    : "The owner can start compute again from an available workstation.";
+  return `Compute from ${targetLabel} is no longer connected to this notebook. ${action}`;
+}
+
+function isRuntimePeerDisconnectDetail(detail: string): boolean {
+  const normalized = detail.trim().toLowerCase();
+  return (
+    normalized.startsWith("runtime peer disconnected") ||
+    normalized.includes("runtime peer left the room")
   );
 }
 

--- a/packages/runtimed/src/notebook-workstation-panel.ts
+++ b/packages/runtimed/src/notebook-workstation-panel.ts
@@ -106,7 +106,7 @@ export function projectNotebookWorkstationPanel(
     facts.push(workstationFact("resource", "Resources", target.resourceLabel));
   }
   if (typeof target.runtimePeerCount === "number" && target.runtimePeerCount > 0) {
-    facts.push(workstationFact("runtime_peers", "Runtime peers", `${target.runtimePeerCount}`));
+    facts.push(workstationFact("runtime_peers", "Compute sessions", `${target.runtimePeerCount}`));
   }
   if (target.workingDirectoryLabel) {
     facts.push(workstationFact("working_directory", "Working dir", target.workingDirectoryLabel));

--- a/packages/runtimed/src/notebook-workstation-selection.ts
+++ b/packages/runtimed/src/notebook-workstation-selection.ts
@@ -507,7 +507,7 @@ function providerLabel(provider: string | null | undefined): string | null {
   const normalized = trimToNull(provider);
   if (!normalized) return null;
   if (normalized === "local_daemon") return "Local daemon";
-  if (normalized === "runtime_peer") return "Runtime peer";
+  if (normalized === "runtime_peer") return "Workstation";
   return normalized
     .split(/[-_\s]+/g)
     .filter(Boolean)

--- a/packages/runtimed/tests/notebook-workstation-panel.test.ts
+++ b/packages/runtimed/tests/notebook-workstation-panel.test.ts
@@ -220,7 +220,7 @@ describe("projectNotebookWorkstationPanel", () => {
       statusLabel: "Needs attention",
       detail:
         "runtime peer disconnected: runtime peer left the room and did not return within the grace window",
-      providerLabel: "Runtime peer",
+      providerLabel: "Workstation",
       defaultEnvironmentLabel: "Current Python",
     };
     const ownerProjection = projectNotebookWorkstationPanel(

--- a/packages/runtimed/tests/notebook-workstation-panel.test.ts
+++ b/packages/runtimed/tests/notebook-workstation-panel.test.ts
@@ -206,7 +206,7 @@ describe("projectNotebookWorkstationPanel", () => {
     expect(projection.facts.map((fact) => [fact.kind, fact.label, fact.value])).toEqual([
       ["provider", "Provider", "Cloud room"],
       ["default_environment", "Default env", "Current Python"],
-      ["runtime_peers", "Runtime peers", "2"],
+      ["runtime_peers", "Compute sessions", "2"],
       ["execution_state", "State", "Can run"],
     ]);
   });

--- a/packages/runtimed/tests/notebook-workstation-panel.test.ts
+++ b/packages/runtimed/tests/notebook-workstation-panel.test.ts
@@ -5,6 +5,7 @@ import {
   projectNotebookShellCapabilities,
   projectNotebookWorkstationPanel,
   type NotebookShellAccessCapabilities,
+  type NotebookShellAuthCapabilities,
   type NotebookShellRuntimeCapabilities,
 } from "../src";
 import { clearNotebookShellCapabilitiesCachesForTests } from "../src/notebook-shell-capabilities";
@@ -54,11 +55,24 @@ function runtime(
   };
 }
 
+function auth(
+  overrides: Partial<NotebookShellAuthCapabilities> = {},
+): NotebookShellAuthCapabilities {
+  return {
+    canSignIn: false,
+    canUseAuthenticatedIdentity: false,
+    needsAttention: false,
+    ...overrides,
+  };
+}
+
 function capabilities({
   accessOverrides,
+  authOverrides,
   runtimeOverrides,
 }: {
   accessOverrides?: Partial<NotebookShellAccessCapabilities>;
+  authOverrides?: Partial<NotebookShellAuthCapabilities>;
   runtimeOverrides?: Partial<NotebookShellRuntimeCapabilities>;
 } = {}) {
   return projectNotebookShellCapabilities({
@@ -70,6 +84,7 @@ function capabilities({
       canRequestEdit: false,
     }),
     access: access(accessOverrides),
+    auth: auth(authOverrides),
     runtime: runtime(runtimeOverrides),
     execution: {
       available: runtimeOverrides?.executionAvailable ?? true,
@@ -194,5 +209,54 @@ describe("projectNotebookWorkstationPanel", () => {
       ["runtime_peers", "Runtime peers", "2"],
       ["execution_state", "State", "Can run"],
     ]);
+  });
+
+  it("projects stale cloud attachments with access-sensitive user copy", () => {
+    const target = {
+      id: "ws-lab2",
+      kind: "cloud_workstation" as const,
+      status: "attention" as const,
+      label: "Lab2",
+      statusLabel: "Needs attention",
+      detail:
+        "runtime peer disconnected: runtime peer left the room and did not return within the grace window",
+      providerLabel: "Runtime peer",
+      defaultEnvironmentLabel: "Current Python",
+    };
+    const ownerProjection = projectNotebookWorkstationPanel(
+      capabilities({
+        accessOverrides: { level: "owner", source: "cloud" },
+        authOverrides: { canUseAuthenticatedIdentity: true },
+        runtimeOverrides: {
+          canWriteRuntimeState: false,
+          connected: false,
+          executionAvailable: false,
+          source: "cloud",
+          target,
+        },
+      }),
+    );
+    const viewerProjection = projectNotebookWorkstationPanel(
+      capabilities({
+        accessOverrides: { level: "viewer", source: "cloud" },
+        runtimeOverrides: {
+          canWriteRuntimeState: false,
+          connected: false,
+          executionAvailable: false,
+          source: "cloud",
+          target,
+        },
+      }),
+    );
+
+    expect(ownerProjection.detail).toBe(
+      "Compute from Lab2 is no longer connected to this notebook. Start compute again from an available workstation.",
+    );
+    expect(viewerProjection.detail).toBe(
+      "Compute from Lab2 is no longer connected to this notebook. The owner can start compute again from an available workstation.",
+    );
+    expect(ownerProjection.detail).not.toContain("runtime peer");
+    expect(viewerProjection.detail).not.toContain("grace window");
+    expect(ownerProjection).not.toBe(viewerProjection);
   });
 });

--- a/packages/runtimed/tests/notebook-workstation-selection.test.ts
+++ b/packages/runtimed/tests/notebook-workstation-selection.test.ts
@@ -57,7 +57,7 @@ describe("notebook workstation selection projection", () => {
     expect(first.defaultWorkstation).toMatchObject({
       id: "ws-lab2",
       displayName: "Lab2 workstation",
-      providerLabel: "Runtime peer",
+      providerLabel: "Workstation",
       isDefault: true,
       cpuCount: 8,
       memoryBytes: 32 * 1024 ** 3,

--- a/src/components/notebook/__tests__/NotebookWorkstationsPanel.test.tsx
+++ b/src/components/notebook/__tests__/NotebookWorkstationsPanel.test.tsx
@@ -566,7 +566,8 @@ describe("NotebookWorkstationsPanel", () => {
     expect(screen.getByText("Current Python")).toBeVisible();
     expect(screen.getByText("Resources")).toBeVisible();
     expect(screen.getByText("4 CPU / 16 GB RAM")).toBeVisible();
-    expect(screen.getByText("Runtime peers")).toBeVisible();
+    expect(screen.getByText("Compute sessions")).toBeVisible();
+    expect(screen.queryByText("Runtime peers")).not.toBeInTheDocument();
     expect(screen.getByText("1")).toBeVisible();
     expect(screen.queryByText("CPUs")).not.toBeInTheDocument();
     expect(screen.queryByText("RAM")).not.toBeInTheDocument();

--- a/src/components/notebook/__tests__/NotebookWorkstationsPanel.test.tsx
+++ b/src/components/notebook/__tests__/NotebookWorkstationsPanel.test.tsx
@@ -341,7 +341,7 @@ describe("NotebookWorkstationsPanel", () => {
           status: "ready",
           label: "Lab2",
           statusLabel: "Ready",
-          providerLabel: "Runtime peer",
+          providerLabel: "Workstation",
           defaultEnvironmentLabel: "Current Python",
           environmentLabel: "Current Python",
           cpuCount: 8,
@@ -398,7 +398,7 @@ describe("NotebookWorkstationsPanel", () => {
     );
 
     expect(screen.getByRole("heading", { name: "Lab2" })).toBeVisible();
-    expect(screen.getAllByText("Runtime peer")).toHaveLength(1);
+    expect(screen.getAllByText("Workstation")).toHaveLength(1);
     expect(screen.getAllByText("Current Python")).toHaveLength(1);
     expect(screen.getByText("id ws-lab2")).toBeVisible();
     expect(screen.getAllByTestId("registered-workstation")).toHaveLength(1);
@@ -431,7 +431,7 @@ describe("NotebookWorkstationsPanel", () => {
           statusLabel: "Needs attention",
           detail:
             "runtime peer disconnected: runtime peer left the room and did not return within the grace window",
-          providerLabel: "Runtime peer",
+          providerLabel: "Workstation",
           defaultEnvironmentLabel: "Current Python",
           environmentLabel: "Current Python",
           workingDirectoryLabel: "/home/ubuntu/project",
@@ -518,7 +518,7 @@ describe("NotebookWorkstationsPanel", () => {
           statusLabel: "Needs attention",
           detail:
             "runtime peer disconnected: runtime peer left the room and did not return within the grace window",
-          providerLabel: "Runtime peer",
+          providerLabel: "Workstation",
           defaultEnvironmentLabel: "Current Python",
           environmentLabel: "Current Python",
           workingDirectoryLabel: "/home/ubuntu/project",

--- a/src/components/notebook/__tests__/NotebookWorkstationsPanel.test.tsx
+++ b/src/components/notebook/__tests__/NotebookWorkstationsPanel.test.tsx
@@ -416,6 +416,10 @@ describe("NotebookWorkstationsPanel", () => {
         level: "owner",
         source: "cloud",
       },
+      auth: {
+        ...readOnlyNotebookShellCapabilities.auth,
+        canUseAuthenticatedIdentity: true,
+      },
       runtime: {
         ...readOnlyNotebookShellCapabilities.runtime,
         source: "cloud",
@@ -475,7 +479,12 @@ describe("NotebookWorkstationsPanel", () => {
     expect(screen.getByRole("heading", { name: "Previous attachment" })).toBeVisible();
     expect(screen.getAllByRole("heading", { name: "Lab2" })).toHaveLength(1);
     expect(screen.getByText("Needs attention")).toBeVisible();
-    expect(screen.getByText(/Lab2: runtime peer disconnected/)).toBeVisible();
+    expect(
+      screen.getByText(
+        "Compute from Lab2 is no longer connected to this notebook. Start compute again from an available workstation.",
+      ),
+    ).toBeVisible();
+    expect(screen.queryByText(/runtime peer disconnected/i)).not.toBeInTheDocument();
     expect(screen.queryByText("Runtime peer")).not.toBeInTheDocument();
     expect(screen.getAllByText("Current Python")).toHaveLength(1);
     expect(screen.getAllByText("/home/ubuntu/project")).toHaveLength(1);
@@ -488,6 +497,45 @@ describe("NotebookWorkstationsPanel", () => {
     expect(attachButton).toBeEnabled();
     fireEvent.click(attachButton);
     expect(attached).toEqual(["ws-lab2"]);
+  });
+
+  it("explains stale cloud attachments to viewers without implementation terms", () => {
+    const capabilities: NotebookShellCapabilities = {
+      ...readOnlyNotebookShellCapabilities,
+      access: {
+        ...readOnlyNotebookShellCapabilities.access,
+        level: "viewer",
+        source: "cloud",
+      },
+      runtime: {
+        ...readOnlyNotebookShellCapabilities.runtime,
+        source: "cloud",
+        target: {
+          id: "ws-lab2",
+          kind: "cloud_workstation",
+          status: "attention",
+          label: "Lab2",
+          statusLabel: "Needs attention",
+          detail:
+            "runtime peer disconnected: runtime peer left the room and did not return within the grace window",
+          providerLabel: "Runtime peer",
+          defaultEnvironmentLabel: "Current Python",
+          environmentLabel: "Current Python",
+          workingDirectoryLabel: "/home/ubuntu/project",
+        },
+      },
+    };
+
+    render(<NotebookWorkstationsPanel capabilities={capabilities} />);
+
+    expect(screen.getByRole("heading", { name: "Previous attachment" })).toBeVisible();
+    expect(
+      screen.getByText(
+        "Compute from Lab2 is no longer connected to this notebook. The owner can start compute again from an available workstation.",
+      ),
+    ).toBeVisible();
+    expect(screen.queryByText(/runtime peer disconnected/i)).not.toBeInTheDocument();
+    expect(screen.queryByText(/grace window/i)).not.toBeInTheDocument();
   });
 
   it("keeps legacy resource labels when structured resources are absent", () => {


### PR DESCRIPTION
## Summary
- keep private/shared access diagnostics visible instead of letting reconnect noise overwrite them
- stop pre-ready live-room websocket retries once an access diagnostic confirms the account cannot currently open the room
- model access-request UI transitions as pure projections so cookie-backed sessions do not churn prototype auth scope
- reconcile authenticated catalog scope into hosted shell access chrome during reconnect so owners/editors do not see stale “Request sent” state
- keep live room scope as the write/execute authority: catalog access can show owner/editor chrome, but cannot enable cell mutations or execution without a live owner/editor room connection
- extract document-edit readiness into a pure projection so reconnect/loading/editor states are directly testable outside React
- request the least-privileged viewer sync scope when the authenticated catalog was resolved and does not include the notebook, avoiding owner escalation from `?mode=edit` URLs
- coalesce the notebook viewer’s catalog access load so shell access and app-session sync scope share one `/api/n?limit=100` request
- gate live-room startup on the resolved authenticated catalog: known no-access notebooks now render access-needed UI without opening a doomed `/sync` WebSocket
- avoid duplicating access diagnostics as generic “Unable to load notebook” banners
- keep runtime WASM resource hints testable and user-oriented: the JS glue remains `modulepreload`, while the binary sidecar is `prefetch` so access-blocked pages do not warn about an unused high-priority preload
- open editor-access dashboard notebooks in edit mode by default while preserving viewer-access notebooks in view mode
- keep cloud identity chrome on friendly projection labels instead of raw account emails, while preserving explicit sharing/invite data paths
- return denied/dismissed edit requests to normal view mode so known no-access pages can offer `Request edit` again instead of a stale `Request sent` state
- mark catalog-disabled live rooms as offline in the stable connection-status bridge so no-access pages do not show stale `Connecting` chrome
- separate runtime-peer grants from notebook collaborator rows in the sharing projection, so compute access is shown distinctly and is not removable from the sharing dialog
- serve a hosted favicon route and explicit shell icon link so browser defaults no longer create a missing `/favicon.ico` request
- keep routine sync-heal retry attempts out of the production browser console while preserving the terminal stalled-sync warning path
- keep routine notebook command-client debug logs out of the production browser console while preserving warnings and errors
- quiet dashboard/share form diagnostics and reduce duplicated shared-notebook wording
- use the notebook route title for hosted page headings and browser titles instead of raw room ids when the route already carries a safe title, preserving acronym casing
- clarify the dashboard continuation count as a projection fact: the promoted Continue card is separate from the remaining list, so the section says “more notebooks to reopen”
- keep stored edit-request state passive in explicit view mode, so shared viewer links stay view-only unless the user asks to edit
- project access-request notices outside React so old request state stays quiet while reading and only explicit edit intent owns the request banner
- load and poll viewer edit-request state only for explicit edit intent, keeping read-only shared pages operationally quiet
- hide live collaboration chrome on access-blocked pages so access-denied routes read as access states, not transport outages

## Deploy
- Deployed to preview.runt.run from `b33ef707a1f2357f7de1352e9ed9de61b2675f8e`
- Main Worker version: `c523b43e-da74-4553-979d-cb4dcf1adfaf`
- Renderer assets Worker version: `c38fc992-2ff9-465f-8685-2edca5cf3751`
- `/api/health` reports build SHA `b33ef707a1f2357f7de1352e9ed9de61b2675f8e`

## Validation
- `pnpm --dir apps/notebook-cloud exec node --import tsx --test test/cloud-notebook-catalog-access.test.ts test/cloud-projection-flicker.test.ts test/viewer-loading-policy.test.ts`
- `pnpm --dir apps/notebook-cloud exec node --import tsx --test test/viewer-notices.test.ts test/viewer-render-props.test.ts`
- `pnpm --dir apps/notebook-cloud exec node --import tsx --test test/html.test.ts test/hosted-smoke-runtime-wasm.test.mjs`
- `pnpm --dir apps/notebook-cloud exec node --import tsx --test test/notebook-dashboard.test.ts test/cloud-notebook-mode.test.ts`
- `pnpm --dir apps/notebook-cloud exec node --import tsx --test test/viewer-presence.test.ts test/viewer-shell-capabilities.test.ts`
- `pnpm --dir apps/notebook-cloud exec node --import tsx --test test/cloud-notebook-mode.test.ts test/cloud-notebook-catalog-access.test.ts test/viewer-shell-capabilities.test.ts`
- `pnpm --dir apps/notebook-cloud exec node --import tsx --test test/live-sync.test.ts test/connection-diagnostics.test.ts`
- `pnpm --dir apps/notebook-cloud exec node --import tsx --test test/viewer-shell-capabilities.test.ts test/cloud-notebook-catalog-access.test.ts test/cloud-notebook-mode.test.ts test/viewer-notices.test.ts`
- `pnpm --dir apps/notebook-cloud exec node --import tsx --test test/viewer-sharing.test.ts test/viewer-render-props.test.ts`
- `pnpm --dir apps/notebook-cloud exec node --import tsx --test test/html.test.ts test/worker-routes.test.ts`
- `pnpm --dir apps/notebook-cloud exec node --import tsx --test test/sync-heal.test.ts`
- `pnpm --dir apps/notebook-cloud exec node --import tsx --test test/notebook-view-loading.test.ts test/viewer-shared-cell-surface.test.ts test/connection-diagnostics.test.ts`
- `pnpm --dir apps/notebook-cloud exec node --import tsx --test test/cloud-access-request-state.test.ts test/cloud-notebook-mode.test.ts test/viewer-shared-cell-surface.test.ts`
- `pnpm --dir apps/notebook-cloud exec node --import tsx --test test/cloud-access-request-state.test.ts test/viewer-shared-cell-surface.test.ts`
- `pnpm --dir apps/notebook-cloud typecheck`
- `pnpm --dir apps/notebook-cloud test` (1036 tests)
- `cargo xtask lint --fix`
- `git diff --check`
- `curl -fsS https://preview.runt.run/api/health`
- `curl -fsSI https://preview.runt.run/favicon.svg`
- `curl -fsSI https://preview.runt.run/favicon.ico`
- Browser smoke on deployed preview: `/n` dashboard at wide/tablet/mobile/narrow mobile widths; owned notebook edit/share shell; shared editor; shared viewer forced through `?mode=edit`; private/no-access notebook forced through `?mode=edit`.
- Latest deployed owned-notebook smoke confirms edit/runtime controls still appear, the notebook connects normally, display outputs render, `/favicon.svg` avoids the old missing favicon request, and routine sync-heal retry attempts no longer emit browser console messages after the retry window.
- Latest deployed dashboard smoke confirms owned and editor-access notebook links use `mode=edit`, viewer-access notebook links use `mode=view`, `/favicon.svg` returns 200, and `/n` emits no browser console messages with only expected session/catalog requests after static assets.
- Latest post-`#3636` authenticated dashboard audit confirms shared-with-me rows remain visible on this branch at wide, narrow, and mobile widths without raw account text, and a clean reload emits no browser console messages.
- Latest deployed sharing smoke confirms the share panel copy loads from the new viewer bundle, notebook access lists people only, compute access renders as its own section, runtime-peer access is not removable from the sharing dialog, and share API calls return 200.
- Latest deployed private/no-access smoke confirms the page calls session/catalog APIs, does not open a live-room `/sync` WebSocket, shows one access-needed notice without the duplicate generic load-error banner, hides the notebook body instead of rendering skeletons or an “Empty notebook” state, does not expose raw account email, and emits no browser console messages.
- Latest deployed private/no-access smoke confirms access-blocked routes now omit live presence and connection identity chrome entirely while keeping the title, `Viewing`, `Request edit`, the access-needed notice, no `/sync`, and no console messages.
- Latest deployed resource-hint smoke confirms the shell declares `runtimed_wasm.js` as `modulepreload` and `runtimed_wasm_bg.wasm` as `prefetch` with `as=fetch`, `type=application/wasm`, and `crossorigin`.
- Earlier deployed owned-notebook load smoke confirms one `/api/n?limit=100` request, edit/runtime controls still appear, and the notebook connects normally.
- Latest deployed shared-viewer `?mode=view` smoke confirms the URL stays in view mode, the read-only notebook body remains visible, old pending edit-request state stays quiet, no dormant access-request endpoint calls are made, and no console messages emit.
- Latest deployed shared-viewer `?mode=edit` smoke confirms explicit edit intent shows request-sent copy, keeps the notebook read-only, and emits no console messages.
- Latest deployed execution smoke reran a small owned-notebook code cell against an attached kernel, advanced it to the next run count, produced the expected output, and left no browser console errors/warnings.
- Earlier browser smokes on this branch: owned-notebook compute attach and scratch cell execution; access-request smoke reduced `/access-requests` polling from 82 calls over ~40s to initial read plus normal 30s poll.

## Follow-ups recorded locally
- If a notebook reaches sync-heal exhaustion, the quiet stalled-sync notice should remain the user-facing path; routine retry attempts are intentionally not logged in production.
- Dashboard top actions read a bit prominent versus sparse notebook lists on wide screens; worth a later visual pass with more real notebook cards/previews.
- Runtime peers still appear in the room presence surface; a later pass should decide whether compute actors move entirely to RuntimeStateDoc-derived compute chrome or use a dedicated compute avatar treatment.








