### PR TITLE
fix(notebook-cloud): surface shared notebooks on dashboard

### DIFF
--- a/apps/notebook-cloud/test/notebook-dashboard.test.ts
+++ b/apps/notebook-cloud/test/notebook-dashboard.test.ts
@@ -51,7 +51,7 @@ describe("cloud notebook dashboard projection", () => {
       [
         ["all", "Recent", 3, "work"],
         ["owned", "Owned", 1, "work"],
-        ["shared", "Shared", 2, "work"],
+        ["shared", "Shared with me", 2, "work"],
         ["published", "Published", 2, "work"],
       ],
     );
@@ -267,6 +267,22 @@ describe("cloud notebook dashboard projection", () => {
       ],
     );
     assert.deepEqual(
+      defaultView.sections.map((section) => [
+        section.id,
+        section.title,
+        section.detail,
+        section.notebooks.map((item) => item.notebook_id),
+      ]),
+      [
+        [
+          "shared",
+          "Shared with me",
+          "2 notebooks shared with this account",
+          ["renderer-regression", "archive"],
+        ],
+      ],
+    );
+    assert.deepEqual(
       sharedView.sections.map((section) => [section.id, section.title, section.notebooks.length]),
       [
         ["latest", "Latest activity", 1],
@@ -324,6 +340,46 @@ describe("cloud notebook dashboard projection", () => {
     assert.deepEqual(
       searchView.sections.flatMap((section) => section.rows.map((row) => row.notebook.notebook_id)),
       ["topic-viz"],
+    );
+  });
+
+  it("surfaces shared notebooks as their own default dashboard section", () => {
+    const owned = notebook({
+      id: "owned-notes",
+      title: "Owned Notes",
+      scope: "owner",
+      updatedAt: "2026-06-06T15:00:00.000Z",
+      latestRevisionId: null,
+    });
+    const sharedEditor = notebook({
+      id: "shared-editor",
+      title: "Shared Editor",
+      scope: "editor",
+      updatedAt: "2026-06-07T15:00:00.000Z",
+      latestRevisionId: null,
+    });
+    const sharedViewer = notebook({
+      id: "shared-viewer",
+      title: "Shared Viewer",
+      scope: "viewer",
+      updatedAt: "2026-06-05T12:00:00.000Z",
+      latestRevisionId: null,
+    });
+
+    const model = projectCloudNotebookDashboard([sharedViewer, owned, sharedEditor]);
+    const view = projectCloudNotebookDashboardView(model);
+
+    assert.equal(model.continueNotebook?.notebook_id, "shared-editor");
+    assert.deepEqual(
+      view.sections.map((section) => [
+        section.id,
+        section.title,
+        section.notebooks.map((item) => item.notebook_id),
+      ]),
+      [
+        ["named", "Recent work", ["owned-notes"]],
+        ["shared", "Shared with me", ["shared-editor", "shared-viewer"]],
+      ],
     );
   });
 

--- a/apps/notebook-cloud/viewer/notebook-dashboard.ts
+++ b/apps/notebook-cloud/viewer/notebook-dashboard.ts
@@ -236,7 +236,7 @@ function cloudNotebookDashboardFilters(
     filters.push({ id: "owned", label: "Owned", count: ownerCount, group: "work" });
   }
   if (sharedCount > 0) {
-    filters.push({ id: "shared", label: "Shared", count: sharedCount, group: "work" });
+    filters.push({ id: "shared", label: "Shared with me", count: sharedCount, group: "work" });
   }
   if (publishedCount > 0) {
     filters.push({ id: "published", label: "Published", count: publishedCount, group: "work" });
@@ -356,8 +356,18 @@ function cloudNotebookWorkSections(
     if (notebook.notebook_id === options.omitNotebookId) {
       return false;
     }
-    return cloudNotebookHasTitle(notebook) && !cloudNotebookIsGeneratedRun(notebook);
+    return (
+      notebook.scope === "owner" &&
+      cloudNotebookHasTitle(notebook) &&
+      !cloudNotebookIsGeneratedRun(notebook)
+    );
   });
+  const sharedWithMe = notebooks.filter(
+    (notebook) =>
+      notebook.scope !== "owner" &&
+      cloudNotebookHasTitle(notebook) &&
+      !cloudNotebookIsGeneratedRun(notebook),
+  );
   const generatedRuns = notebooks.filter(cloudNotebookIsGeneratedRun);
   const untitled = notebooks.filter((notebook) => !cloudNotebookHasTitle(notebook));
 
@@ -374,6 +384,11 @@ function cloudNotebookWorkSections(
       totalCount: namedWork.length,
     });
   }
+  if (sharedWithMe.length > 0) {
+    sections.push(
+      sharedWithMeNotebookSection(sharedWithMe, { limit: SECONDARY_DASHBOARD_SECTION_LIMIT }),
+    );
+  }
   if (generatedRuns.length > 0) {
     sections.push(
       generatedNotebookSection(generatedRuns, { limit: SECONDARY_DASHBOARD_SECTION_LIMIT }),
@@ -383,6 +398,31 @@ function cloudNotebookWorkSections(
     sections.push(untitledNotebookSection(untitled, { limit: SECONDARY_DASHBOARD_SECTION_LIMIT }));
   }
   return sections;
+}
+
+function sharedWithMeNotebookSection(
+  notebooks: readonly CloudNotebookListItem[],
+  options: { limit: number | null },
+): CloudNotebookDashboardSection {
+  const visibleNotebooks = limitNotebooks(notebooks, options.limit);
+  const overflowAction =
+    options.limit && notebooks.length > visibleNotebooks.length
+      ? {
+          filterId: "shared" as const,
+          kind: "filter" as const,
+          label: "View all shared",
+        }
+      : null;
+  return {
+    action: overflowAction,
+    detail: bucketDetail(notebooks.length, "shared with this account"),
+    id: "shared",
+    notebooks: visibleNotebooks,
+    overflowAction,
+    rows: dashboardRows(visibleNotebooks),
+    title: "Shared with me",
+    totalCount: notebooks.length,
+  };
 }
 
 function generatedNotebookSection(


### PR DESCRIPTION
## Summary
- rename the dashboard shared filter to "Shared with me"
- add a dedicated default /n section for shared notebooks so invite recipients can find them without a direct link
- keep owned recent work separate while still preserving search and shared-filter behavior

## Tests
- pnpm --dir apps/notebook-cloud exec node --import tsx --test test/notebook-dashboard.test.ts
- pnpm --dir apps/notebook-cloud typecheck
- cargo xtask lint --fix