### PR TITLE
fix(notebook-cloud): project presence from room roster

### DIFF
--- a/apps/notebook-cloud/src/notebook-room.ts
+++ b/apps/notebook-cloud/src/notebook-room.ts
@@ -24,6 +24,7 @@ import {
   LIVENESS_PONG,
   splitTypedFrame,
   type SessionControlMessage,
+  type CloudRoomPeerRosterEntry,
   type TypedFrame,
 } from "./protocol.ts";
 import { cloudLog, durationMs, errorMessage } from "./observability.ts";
@@ -314,6 +315,7 @@ export class NotebookRoom {
       email: identity.metadata.email,
       room_peer_count: this.peers.size,
       runtime_peer_count: this.runtimePeerCount(),
+      peers: this.roomPeerRoster(),
       timestamp: peer.connectedAt,
     });
 
@@ -325,8 +327,8 @@ export class NotebookRoom {
         peer_id: peer.id,
         actor_label: identity.actorLabel,
         connection_scope: identity.scope,
+        participant_key: roomPeerParticipantKey(peer),
         display_name: identity.metadata.displayName,
-        email: identity.metadata.email,
         room_peer_count: this.peers.size,
         runtime_peer_count: this.runtimePeerCount(),
         timestamp: peer.connectedAt,
@@ -1515,6 +1517,23 @@ export class NotebookRoom {
     this.sendFrameToPeer(notebookId, peer, encodeJsonFrame(FrameType.SESSION_CONTROL, message));
   }
 
+  private roomPeerRoster(): CloudRoomPeerRosterEntry[] {
+    return Array.from(this.peers.values(), (peer) => this.roomPeerRosterEntry(peer));
+  }
+
+  private roomPeerRosterEntry(peer: Peer): CloudRoomPeerRosterEntry {
+    return {
+      peer_id: peer.id,
+      actor_label: peer.identity.actorLabel,
+      connection_scope: peer.identity.scope,
+      participant_key: roomPeerParticipantKey(peer),
+      identity_provider: peer.identity.metadata.provider,
+      principal_namespace: peer.identity.metadata.principalNamespace,
+      display_name: peer.identity.metadata.displayName,
+      connected_at: peer.connectedAt,
+    };
+  }
+
   private broadcastControl(
     notebookId: string,
     message: SessionControlMessage,
@@ -1637,6 +1656,7 @@ export class NotebookRoom {
       peer_id: peer.id,
       actor_label: peer.identity.actorLabel,
       connection_scope: peer.identity.scope,
+      participant_key: roomPeerParticipantKey(peer),
       room_peer_count: this.peers.size,
       runtime_peer_count: this.runtimePeerCount(),
       timestamp: new Date().toISOString(),
@@ -1875,6 +1895,13 @@ function runtimePeerWorkstationAttachment(peer: Peer): WorkstationAttachmentStat
 function runtimePeerWorkstationId(workstation: RuntimePeerWorkstationMetadata | null): string {
   const workstationId = workstation?.workstationId?.trim();
   return workstationId && workstationId.length > 0 ? workstationId : "runtime-peer";
+}
+
+function roomPeerParticipantKey(peer: Peer): string {
+  if (isAnonymousViewer(peer.identity)) {
+    return `anonymous:${peer.id}`;
+  }
+  return peer.identity.principal;
 }
 
 export function runtimePeerWorkstationMetadataFromRequest(

--- a/apps/notebook-cloud/src/protocol.ts
+++ b/apps/notebook-cloud/src/protocol.ts
@@ -22,6 +22,17 @@ export const NOTEBOOK_PROTOCOL = "v4";
 export const LIVENESS_PING = "nteract-liveness-ping";
 export const LIVENESS_PONG = "nteract-liveness-pong";
 
+export interface CloudRoomPeerRosterEntry {
+  peer_id: string;
+  actor_label: string;
+  connection_scope: string;
+  participant_key: string;
+  identity_provider?: string;
+  principal_namespace?: string;
+  display_name?: string;
+  connected_at: string;
+}
+
 export interface TypedFrame {
   type: FrameTypeValue;
   payload: Uint8Array;
@@ -41,6 +52,7 @@ export type SessionControlMessage =
       email?: string;
       room_peer_count: number;
       runtime_peer_count?: number;
+      peers?: CloudRoomPeerRosterEntry[];
       timestamp: string;
     }
   | {
@@ -72,8 +84,8 @@ export type SessionControlMessage =
       peer_id: string;
       actor_label: string;
       connection_scope?: string;
+      participant_key?: string;
       display_name?: string;
-      email?: string;
       room_peer_count: number;
       runtime_peer_count?: number;
       timestamp: string;

--- a/apps/notebook-cloud/test/notebook-room.test.ts
+++ b/apps/notebook-cloud/test/notebook-room.test.ts
@@ -42,6 +42,67 @@ before(async () => {
 });
 
 describe("NotebookRoom presence rewrite", () => {
+  it("builds room-ready rosters from current peers", () => {
+    const room = new NotebookRoom(fakeState(), {} as Env);
+    const harness = roomHarness(room);
+    const ownerIdentity = authenticateDevRequest(
+      new Request("https://cloud.test/n/demo/sync?user=alice&operator=browser:a&scope=owner"),
+    );
+    const runtimeIdentity = authenticateDevRequest(
+      new Request(
+        "https://cloud.test/n/demo/sync?user=alice&operator=runtime:py&scope=runtime_peer",
+      ),
+    );
+    harness.peers.set("owner", {
+      id: "owner",
+      socket: new FakeSocket().asCloudflareWebSocket(),
+      identity: {
+        ...ownerIdentity,
+        metadata: {
+          ...ownerIdentity.metadata,
+          displayName: "Alice Demo",
+        },
+      },
+      connectedAt: "2026-06-13T00:00:00.000Z",
+      consecutiveRejectedFrames: 0,
+    });
+    harness.peers.set("runtime", {
+      id: "runtime",
+      socket: new FakeSocket().asCloudflareWebSocket(),
+      identity: runtimeIdentity,
+      connectedAt: "2026-06-13T00:00:01.000Z",
+      consecutiveRejectedFrames: 0,
+    });
+
+    const roster = harness.roomPeerRoster();
+
+    assert.deepEqual(
+      roster.map((peer) => ({
+        peer_id: peer.peer_id,
+        actor_label: peer.actor_label,
+        connection_scope: peer.connection_scope,
+        participant_key: peer.participant_key,
+        display_name: peer.display_name,
+      })),
+      [
+        {
+          peer_id: "owner",
+          actor_label: "user:dev:alice/browser:a",
+          connection_scope: "owner",
+          participant_key: "user:dev:alice",
+          display_name: "Alice Demo",
+        },
+        {
+          peer_id: "runtime",
+          actor_label: "user:dev:alice/runtime:py",
+          connection_scope: "runtime_peer",
+          participant_key: "user:dev:alice",
+          display_name: "alice",
+        },
+      ],
+    );
+  });
+
   it("rewrites canonical CBOR presence to the server peer and friendly display label", async () => {
     const identity = authenticateDevRequest(
       new Request("https://cloud.test/n/demo/sync?user=alice&operator=desktop:a&scope=editor"),
@@ -2269,6 +2330,7 @@ type PeerForTest = {
   socket: CloudflareWebSocket;
   identity: ReturnType<typeof authenticateDevRequest>;
   connectedAt: string;
+  consecutiveRejectedFrames?: number;
   workstation?: {
     workstationId?: string;
     displayName?: string;
@@ -2307,6 +2369,13 @@ interface RoomHarness {
   ): Promise<void>;
   removePeer(notebookId: string, peer: PeerForTest): void;
   peerForSocket(socket: CloudflareWebSocket): PeerForTest | undefined;
+  roomPeerRoster(): Array<{
+    peer_id: string;
+    actor_label: string;
+    connection_scope: string;
+    participant_key: string;
+    display_name?: string;
+  }>;
   broadcastFrame(notebookId: string, frame: Uint8Array, excludePeerId?: string): void;
   hasRuntimePeer(): boolean;
   prunePendingRuntimePeerResponses(nowMs?: number): void;

--- a/apps/notebook-cloud/test/viewer-presence.test.ts
+++ b/apps/notebook-cloud/test/viewer-presence.test.ts
@@ -45,7 +45,7 @@ describe("cloud viewer presence", () => {
         runtimePeerCount: 0,
       },
     );
-    assert.equal(cloudViewerPresenceDisplay(state).label, "1 here now");
+    assert.equal(cloudViewerPresenceDisplay(state).label, "No one else here");
 
     state = reduceCloudViewerPresenceMessage(state, {
       type: "cloud_peer_joined",
@@ -57,17 +57,14 @@ describe("cloud viewer presence", () => {
       timestamp: "2026-05-23T00:00:01.000Z",
     });
     assert.equal(state.roomPeerCount, 2);
-    assert.equal(cloudViewerPresenceDisplay(state).label, "2 here now");
+    assert.equal(cloudViewerPresenceDisplay(state).label, "1 other here");
     assert.deepEqual(
       cloudViewerPresenceDisplay(state).peers.map((peer) => ({
         kind: peer.kind,
         label: peer.label,
         count: peer.count,
       })),
-      [
-        { kind: "self", label: "Alice Demo", count: undefined },
-        { kind: "anonymous", label: "Anonymous viewer", count: 1 },
-      ],
+      [{ kind: "anonymous", label: "Anonymous viewer", count: 1 }],
     );
 
     state = reduceCloudViewerPresenceMessage(state, {
@@ -80,7 +77,7 @@ describe("cloud viewer presence", () => {
       timestamp: "2026-05-23T00:00:02.000Z",
     });
     assert.equal(state.roomPeerCount, 1);
-    assert.equal(cloudViewerPresenceDisplay(state).label, "1 here now");
+    assert.equal(cloudViewerPresenceDisplay(state).label, "No one else here");
   });
 
   it("surfaces disconnected state without losing the last room count", () => {
@@ -102,7 +99,7 @@ describe("cloud viewer presence", () => {
     assert.equal(display.label, "Offline");
     assert.equal(display.title, "Room unavailable");
     assert.equal(display.connected, false);
-    assert.equal(display.peers.length, 1);
+    assert.equal(display.peers.length, 0);
     assert.equal(
       display.peers.every((peer) => peer.status === "offline"),
       true,
@@ -125,8 +122,8 @@ describe("cloud viewer presence", () => {
 
     assert.equal(state.ownPeerLabel, "Alice Demo");
     const display = cloudViewerPresenceDisplay(state);
-    assert.equal(display.label, "1 here now");
-    assert.equal(display.title, "1 participant");
+    assert.equal(display.label, "No one else here");
+    assert.equal(display.title, "No one else here");
     assert.equal(display.connected, true);
     assert.deepEqual(
       display.peers.map((peer) => ({
@@ -134,7 +131,7 @@ describe("cloud viewer presence", () => {
         label: peer.label,
         count: peer.count,
       })),
-      [{ kind: "self", label: "Alice Demo", count: undefined }],
+      [],
     );
   });
 
@@ -180,23 +177,20 @@ describe("cloud viewer presence", () => {
 
     const display = cloudViewerPresenceDisplay(state);
 
-    assert.equal(display.label, "2 here now");
+    assert.equal(display.label, "1 other here");
     assert.deepEqual(
       display.peers.map((peer) => ({
         kind: peer.kind,
         label: peer.label,
         count: peer.count,
       })),
-      [
-        { kind: "self", label: "Alice Demo", count: undefined },
-        { kind: "peer", label: "Bob Demo", count: undefined },
-      ],
+      [{ kind: "peer", label: "Bob Demo", count: undefined }],
     );
     assert.equal(cloudPresenceHasRuntimePeer(state), true);
     assert.equal(cloudPresenceRuntimePeerCount(state), 1);
   });
 
-  it("collapses multiple same-account browser peers to one human avatar", () => {
+  it("excludes same-account browser peers from the avatar stack", () => {
     const state = reduceCloudViewerPresenceMessage(initialCloudViewerPresence(), {
       type: "cloud_room_ready",
       protocol: "v4",
@@ -229,14 +223,14 @@ describe("cloud viewer presence", () => {
 
     const display = cloudViewerPresenceDisplay(state);
 
-    assert.equal(display.label, "1 here now");
+    assert.equal(display.label, "No one else here");
     assert.deepEqual(
       display.peers.map((peer) => ({
         kind: peer.kind,
         label: peer.label,
         count: peer.count,
       })),
-      [{ kind: "self", label: "Alice Demo", count: undefined }],
+      [],
     );
   });
 
@@ -279,17 +273,14 @@ describe("cloud viewer presence", () => {
 
     const display = cloudViewerPresenceDisplay(state);
 
-    assert.equal(display.label, "3 here now");
+    assert.equal(display.label, "2 others here");
     assert.deepEqual(
       display.peers.map((peer) => ({
         kind: peer.kind,
         label: peer.label,
         count: peer.count,
       })),
-      [
-        { kind: "self", label: "Alice Demo", count: undefined },
-        { kind: "anonymous", label: "2 anonymous viewers", count: 2 },
-      ],
+      [{ kind: "anonymous", label: "2 anonymous viewers", count: 2 }],
     );
   });
 
@@ -335,7 +326,6 @@ describe("cloud viewer presence", () => {
         count: peer.count,
       })),
       [
-        { kind: "self", label: "Alice Demo", count: undefined },
         { kind: "peer", label: "Bob Demo", count: undefined },
         { kind: "anonymous", label: "Anonymous viewer", count: 1 },
       ],
@@ -381,7 +371,7 @@ describe("cloud viewer presence", () => {
         kind: peer.kind,
         label: peer.label,
       })),
-      [{ kind: "self", label: "Alice Demo" }],
+      [],
     );
 
     state = reduceCloudViewerPresenceMessage(state, {

--- a/apps/notebook-cloud/test/viewer-presence.test.ts
+++ b/apps/notebook-cloud/test/viewer-presence.test.ts
@@ -13,16 +13,17 @@ import {
 } from "../viewer/presence.ts";
 
 describe("cloud viewer presence", () => {
-  it("tracks the authoritative room count from session-control messages", () => {
+  it("tracks actual anonymous viewers from session-control messages", () => {
     let state = initialCloudViewerPresence();
 
     state = reduceCloudViewerPresenceMessage(state, {
       type: "cloud_room_ready",
       protocol: "v4",
       notebook_id: "demo",
-      peer_id: "peer-a",
-      actor_label: "anonymous:viewer:session-a/desktop:browser",
-      connection_scope: "viewer",
+      peer_id: "peer-owner",
+      actor_label: "user:anaconda:alice/browser:tab",
+      connection_scope: "owner",
+      display_name: "Alice Demo",
       room_peer_count: 1,
       timestamp: "2026-05-23T00:00:00.000Z",
     });
@@ -37,9 +38,9 @@ describe("cloud viewer presence", () => {
       },
       {
         connection: "connected",
-        ownPeerId: "peer-a",
-        actorLabel: "anonymous:viewer:session-a/desktop:browser",
-        ownPeerLabel: "Anonymous",
+        ownPeerId: "peer-owner",
+        actorLabel: "user:anaconda:alice/browser:tab",
+        ownPeerLabel: "Alice Demo",
         roomPeerCount: 1,
         runtimePeerCount: 0,
       },
@@ -49,8 +50,8 @@ describe("cloud viewer presence", () => {
     state = reduceCloudViewerPresenceMessage(state, {
       type: "cloud_peer_joined",
       notebook_id: "demo",
-      peer_id: "peer-b",
-      actor_label: "anonymous:viewer:session-b/desktop:browser",
+      peer_id: "peer-anon",
+      actor_label: "anonymous:viewer:session-a/desktop:browser",
       connection_scope: "viewer",
       room_peer_count: 2,
       timestamp: "2026-05-23T00:00:01.000Z",
@@ -63,14 +64,17 @@ describe("cloud viewer presence", () => {
         label: peer.label,
         count: peer.count,
       })),
-      [{ kind: "anonymous", label: "2 anonymous viewers", count: 2 }],
+      [
+        { kind: "self", label: "Alice Demo", count: undefined },
+        { kind: "anonymous", label: "Anonymous viewer", count: 1 },
+      ],
     );
 
     state = reduceCloudViewerPresenceMessage(state, {
       type: "cloud_peer_left",
       notebook_id: "demo",
-      peer_id: "peer-b",
-      actor_label: "anonymous:viewer:session-b/desktop:browser",
+      peer_id: "peer-anon",
+      actor_label: "anonymous:viewer:session-a/desktop:browser",
       connection_scope: "viewer",
       room_peer_count: 1,
       timestamp: "2026-05-23T00:00:02.000Z",
@@ -98,14 +102,14 @@ describe("cloud viewer presence", () => {
     assert.equal(display.label, "Offline");
     assert.equal(display.title, "Room unavailable");
     assert.equal(display.connected, false);
-    assert.equal(display.peers.length, 3);
+    assert.equal(display.peers.length, 1);
     assert.equal(
       display.peers.every((peer) => peer.status === "offline"),
       true,
     );
   });
 
-  it("uses friendly display metadata in the connected status title", () => {
+  it("does not turn count-only private peers into anonymous viewers", () => {
     const state = reduceCloudViewerPresenceMessage(initialCloudViewerPresence(), {
       type: "cloud_room_ready",
       protocol: "v4",
@@ -121,9 +125,62 @@ describe("cloud viewer presence", () => {
 
     assert.equal(state.ownPeerLabel, "Alice Demo");
     const display = cloudViewerPresenceDisplay(state);
-    assert.equal(display.label, "2 here now");
-    assert.equal(display.title, "2 participants");
+    assert.equal(display.label, "1 here now");
+    assert.equal(display.title, "1 participant");
     assert.equal(display.connected, true);
+    assert.deepEqual(
+      display.peers.map((peer) => ({
+        kind: peer.kind,
+        label: peer.label,
+        count: peer.count,
+      })),
+      [{ kind: "self", label: "Alice Demo", count: undefined }],
+    );
+  });
+
+  it("uses the room-ready roster for existing peers", () => {
+    const state = reduceCloudViewerPresenceMessage(initialCloudViewerPresence(), {
+      type: "cloud_room_ready",
+      protocol: "v4",
+      notebook_id: "demo",
+      peer_id: "peer-owner",
+      actor_label: "user:anaconda:alice/browser:tab",
+      connection_scope: "owner",
+      display_name: "Alice Demo",
+      room_peer_count: 3,
+      runtime_peer_count: 1,
+      peers: [
+        {
+          peer_id: "peer-owner",
+          actor_label: "user:anaconda:alice/browser:tab",
+          connection_scope: "owner",
+          participant_key: "user:anaconda:alice",
+          display_name: "Alice Demo",
+          connected_at: "2026-05-23T00:00:00.000Z",
+        },
+        {
+          peer_id: "peer-bob",
+          actor_label: "user:anaconda:bob/browser:tab",
+          connection_scope: "editor",
+          participant_key: "user:anaconda:bob",
+          display_name: "Bob Demo",
+          connected_at: "2026-05-23T00:00:01.000Z",
+        },
+        {
+          peer_id: "peer-runtime",
+          actor_label: "user:anaconda:alice/agent:runt-cloud-peer",
+          connection_scope: "runtime_peer",
+          participant_key: "user:anaconda:alice",
+          display_name: "Alice Workstation",
+          connected_at: "2026-05-23T00:00:02.000Z",
+        },
+      ],
+      timestamp: "2026-05-23T00:00:03.000Z",
+    });
+
+    const display = cloudViewerPresenceDisplay(state);
+
+    assert.equal(display.label, "2 here now");
     assert.deepEqual(
       display.peers.map((peer) => ({
         kind: peer.kind,
@@ -132,7 +189,106 @@ describe("cloud viewer presence", () => {
       })),
       [
         { kind: "self", label: "Alice Demo", count: undefined },
-        { kind: "anonymous", label: "Anonymous viewer", count: 1 },
+        { kind: "peer", label: "Bob Demo", count: undefined },
+      ],
+    );
+    assert.equal(cloudPresenceHasRuntimePeer(state), true);
+    assert.equal(cloudPresenceRuntimePeerCount(state), 1);
+  });
+
+  it("collapses multiple same-account browser peers to one human avatar", () => {
+    const state = reduceCloudViewerPresenceMessage(initialCloudViewerPresence(), {
+      type: "cloud_room_ready",
+      protocol: "v4",
+      notebook_id: "demo",
+      peer_id: "peer-owner-a",
+      actor_label: "user:anaconda:alice/browser:tab-a",
+      connection_scope: "owner",
+      display_name: "Alice Demo",
+      room_peer_count: 2,
+      peers: [
+        {
+          peer_id: "peer-owner-a",
+          actor_label: "user:anaconda:alice/browser:tab-a",
+          connection_scope: "owner",
+          participant_key: "user:anaconda:alice",
+          display_name: "Alice Demo",
+          connected_at: "2026-05-23T00:00:00.000Z",
+        },
+        {
+          peer_id: "peer-owner-b",
+          actor_label: "user:anaconda:alice/browser:tab-b",
+          connection_scope: "owner",
+          participant_key: "user:anaconda:alice",
+          display_name: "Alice Demo",
+          connected_at: "2026-05-23T00:00:01.000Z",
+        },
+      ],
+      timestamp: "2026-05-23T00:00:02.000Z",
+    });
+
+    const display = cloudViewerPresenceDisplay(state);
+
+    assert.equal(display.label, "1 here now");
+    assert.deepEqual(
+      display.peers.map((peer) => ({
+        kind: peer.kind,
+        label: peer.label,
+        count: peer.count,
+      })),
+      [{ kind: "self", label: "Alice Demo", count: undefined }],
+    );
+  });
+
+  it("groups true anonymous public viewers from the room roster", () => {
+    const state = reduceCloudViewerPresenceMessage(initialCloudViewerPresence(), {
+      type: "cloud_room_ready",
+      protocol: "v4",
+      notebook_id: "demo",
+      peer_id: "peer-owner",
+      actor_label: "user:anaconda:alice/browser:tab",
+      connection_scope: "owner",
+      display_name: "Alice Demo",
+      room_peer_count: 3,
+      peers: [
+        {
+          peer_id: "peer-owner",
+          actor_label: "user:anaconda:alice/browser:tab",
+          connection_scope: "owner",
+          participant_key: "user:anaconda:alice",
+          display_name: "Alice Demo",
+          connected_at: "2026-05-23T00:00:00.000Z",
+        },
+        {
+          peer_id: "peer-anon-a",
+          actor_label: "anonymous:viewer:session-a/browser",
+          connection_scope: "viewer",
+          participant_key: "anonymous:peer-anon-a",
+          connected_at: "2026-05-23T00:00:01.000Z",
+        },
+        {
+          peer_id: "peer-anon-b",
+          actor_label: "anonymous:viewer:session-b/browser",
+          connection_scope: "viewer",
+          participant_key: "anonymous:peer-anon-b",
+          connected_at: "2026-05-23T00:00:02.000Z",
+        },
+      ],
+      timestamp: "2026-05-23T00:00:03.000Z",
+    });
+
+    const display = cloudViewerPresenceDisplay(state);
+
+    assert.equal(display.label, "3 here now");
+    assert.deepEqual(
+      display.peers.map((peer) => ({
+        kind: peer.kind,
+        label: peer.label,
+        count: peer.count,
+      })),
+      [
+        { kind: "self", label: "Alice Demo", count: undefined },
+        { kind: "anonymous", label: "2 anonymous viewers", count: 2 },
       ],
     );
   });
@@ -157,7 +313,6 @@ describe("cloud viewer presence", () => {
       actor_label: "user:anaconda:bob/browser:tab",
       connection_scope: "editor",
       display_name: "Bob Demo",
-      email: "bob@example.com",
       room_peer_count: 2,
       timestamp: "2026-05-23T00:00:01.000Z",
     });
@@ -201,6 +356,7 @@ describe("cloud viewer presence", () => {
       peer_id: "peer-owner",
       actor_label: "user:anaconda:alice/browser:tab",
       connection_scope: "owner",
+      display_name: "Alice Demo",
       room_peer_count: 1,
       runtime_peer_count: 0,
       timestamp: "2026-05-23T00:00:00.000Z",
@@ -220,6 +376,13 @@ describe("cloud viewer presence", () => {
     });
     assert.equal(cloudPresenceHasRuntimePeer(state), true);
     assert.equal(cloudPresenceRuntimePeerCount(state), 1);
+    assert.deepEqual(
+      cloudViewerPresenceDisplay(state).peers.map((peer) => ({
+        kind: peer.kind,
+        label: peer.label,
+      })),
+      [{ kind: "self", label: "Alice Demo" }],
+    );
 
     state = reduceCloudViewerPresenceMessage(state, {
       type: "cloud_peer_left",

--- a/apps/notebook-cloud/viewer/cloud-presence-status.tsx
+++ b/apps/notebook-cloud/viewer/cloud-presence-status.tsx
@@ -28,6 +28,9 @@ export function CloudPresenceStatus({
     ? `Room unavailable: ${cloudConnectionStatusErrorTitle(connectionError)}`
     : presenceDisplay.title;
   const state = connected ? "live" : presence.connection === "connecting" ? "joining" : "waiting";
+  if (connected && presenceDisplay.peers.length === 0 && presenceDisplay.hiddenCount === 0) {
+    return null;
+  }
 
   return (
     <span

--- a/apps/notebook-cloud/viewer/notebook-viewer.tsx
+++ b/apps/notebook-cloud/viewer/notebook-viewer.tsx
@@ -1200,6 +1200,7 @@ export function NotebookViewer({
       reserveCommandToolbar={editAccessPending}
       commandToolbar={{
         runtime: toolbarRuntime,
+        runtimeTarget: shellCapabilities.runtime.target ?? null,
         environmentManager: toolbarEnvironmentManager,
         environmentPanelOpen: activeRailPanel === "packages" && !railCollapsed,
         runtimeStatus: cloudRuntimeStatus,

--- a/apps/notebook-cloud/viewer/presence.ts
+++ b/apps/notebook-cloud/viewer/presence.ts
@@ -1,4 +1,4 @@
-import type { SessionControlMessage } from "../src/protocol";
+import type { CloudRoomPeerRosterEntry, SessionControlMessage } from "../src/protocol";
 import type { ConnectionScope } from "../src/auth-shared";
 import { notebookActorIdentityFromProjection, notebookActorProjectionFromLabel } from "runtimed";
 
@@ -24,9 +24,10 @@ export interface CloudViewerPresenceDisplay {
 
 export interface CloudViewerPresencePeer {
   id: string;
+  participantKey: string;
   label: string;
   connectionScope: ConnectionScope | null;
-  kind: "self" | "peer" | "anonymous" | "unknown";
+  kind: "self" | "peer" | "anonymous" | "runtime" | "unknown";
   status: "active" | "idle" | "offline";
   count?: number;
 }
@@ -100,72 +101,66 @@ export function reduceCloudViewerPresenceMessage(
 ): CloudViewerPresenceState {
   switch (message.type) {
     case "cloud_room_ready":
-      return withRoomPeerCount(
-        {
-          connection: "connected",
-          ownPeerId: message.peer_id,
+      return {
+        connection: "connected",
+        ownPeerId: message.peer_id,
+        actorLabel: message.actor_label,
+        ownPeerLabel: cloudFriendlyPeerLabel({
+          displayName: message.display_name,
+          email: message.email,
           actorLabel: message.actor_label,
-          ownPeerLabel: cloudFriendlyPeerLabel({
-            displayName: message.display_name,
-            email: message.email,
-            actorLabel: message.actor_label,
-          }),
-          peers: [
-            cloudPresencePeerFromMessage({
-              peerId: message.peer_id,
-              displayName: message.display_name,
-              email: message.email,
-              actorLabel: message.actor_label,
-              connectionScope: message.connection_scope,
-              kind: "self",
-            }),
-          ],
-          roomPeerCount: safeRoomPeerCount(message.room_peer_count),
-          runtimePeerCount: safeRuntimePeerCount(
-            message.runtime_peer_count,
-            message.connection_scope === "runtime_peer" ? 1 : 0,
-          ),
-        },
-        message.room_peer_count,
-      );
+        }),
+        peers:
+          message.peers && message.peers.length > 0
+            ? cloudPresencePeersFromRoster(message.peers, message.peer_id)
+            : [
+                cloudPresencePeerFromMessage({
+                  peerId: message.peer_id,
+                  displayName: message.display_name,
+                  email: message.email,
+                  actorLabel: message.actor_label,
+                  connectionScope: message.connection_scope,
+                  kind: "self",
+                }),
+              ],
+        roomPeerCount: safeRoomPeerCount(message.room_peer_count),
+        runtimePeerCount: safeRuntimePeerCount(
+          message.runtime_peer_count,
+          message.connection_scope === "runtime_peer" ? 1 : 0,
+        ),
+      };
     case "cloud_peer_joined":
-      return withRoomPeerCount(
-        {
-          ...state,
-          connection: "connected",
-          peers: upsertCloudPresencePeer(
-            state.peers,
-            cloudPresencePeerFromMessage({
-              peerId: message.peer_id,
-              displayName: message.display_name,
-              email: message.email,
-              actorLabel: message.actor_label,
-              connectionScope: message.connection_scope ?? null,
-              kind: "peer",
-            }),
-          ),
-          roomPeerCount: safeRoomPeerCount(message.room_peer_count),
-          runtimePeerCount: safeRuntimePeerCount(
-            message.runtime_peer_count,
-            state.runtimePeerCount + (message.connection_scope === "runtime_peer" ? 1 : 0),
-          ),
-        },
-        message.room_peer_count,
-      );
+      return {
+        ...state,
+        connection: "connected",
+        peers: upsertCloudPresencePeer(
+          state.peers,
+          cloudPresencePeerFromMessage({
+            peerId: message.peer_id,
+            displayName: message.display_name,
+            actorLabel: message.actor_label,
+            connectionScope: message.connection_scope ?? null,
+            participantKey: message.participant_key,
+            kind: "peer",
+          }),
+        ),
+        roomPeerCount: safeRoomPeerCount(message.room_peer_count),
+        runtimePeerCount: safeRuntimePeerCount(
+          message.runtime_peer_count,
+          state.runtimePeerCount + (message.connection_scope === "runtime_peer" ? 1 : 0),
+        ),
+      };
     case "cloud_peer_left":
-      return withRoomPeerCount(
-        {
-          ...state,
-          connection: "connected",
-          peers: state.peers.filter((peer) => peer.id !== message.peer_id),
-          roomPeerCount: safeRoomPeerCount(message.room_peer_count),
-          runtimePeerCount: safeRuntimePeerCount(
-            message.runtime_peer_count,
-            state.runtimePeerCount - (message.connection_scope === "runtime_peer" ? 1 : 0),
-          ),
-        },
-        message.room_peer_count,
-      );
+      return {
+        ...state,
+        connection: "connected",
+        peers: state.peers.filter((peer) => peer.id !== message.peer_id),
+        roomPeerCount: safeRoomPeerCount(message.room_peer_count),
+        runtimePeerCount: safeRuntimePeerCount(
+          message.runtime_peer_count,
+          state.runtimePeerCount - (message.connection_scope === "runtime_peer" ? 1 : 0),
+        ),
+      };
     default:
       return state;
   }
@@ -177,6 +172,7 @@ function cloudPresencePeerFromMessage({
   email,
   actorLabel,
   connectionScope,
+  participantKey,
   kind,
 }: {
   peerId: string;
@@ -184,16 +180,37 @@ function cloudPresencePeerFromMessage({
   email?: string | null;
   actorLabel?: string | null;
   connectionScope?: string | null;
+  participantKey?: string | null;
   kind: "self" | "peer";
 }): CloudViewerPresencePeer {
   const label = cloudFriendlyPeerLabel({ displayName, email, actorLabel });
+  const normalizedConnectionScope = normalizePresenceConnectionScope(connectionScope);
+  const isRuntimePeer = normalizedConnectionScope === "runtime_peer";
+  const isAnonymous = !isRuntimePeer && label === "Anonymous";
   return {
     id: peerId,
+    participantKey: cloudPresenceParticipantKey({ participantKey, actorLabel, peerId }),
     label,
-    connectionScope: normalizePresenceConnectionScope(connectionScope),
-    kind: label === "Anonymous" ? "anonymous" : kind === "self" ? "self" : "peer",
+    connectionScope: normalizedConnectionScope,
+    kind: isRuntimePeer ? "runtime" : isAnonymous ? "anonymous" : kind === "self" ? "self" : "peer",
     status: "active",
   };
+}
+
+function cloudPresencePeersFromRoster(
+  roster: readonly CloudRoomPeerRosterEntry[],
+  ownPeerId: string,
+): CloudViewerPresencePeer[] {
+  return roster.map((entry) =>
+    cloudPresencePeerFromMessage({
+      peerId: entry.peer_id,
+      displayName: entry.display_name,
+      actorLabel: entry.actor_label,
+      connectionScope: entry.connection_scope,
+      participantKey: entry.participant_key,
+      kind: entry.peer_id === ownPeerId ? "self" : "peer",
+    }),
+  );
 }
 
 function upsertCloudPresencePeer(
@@ -202,47 +219,23 @@ function upsertCloudPresencePeer(
 ): CloudViewerPresencePeer[] {
   const existingIndex = peers.findIndex((peer) => peer.id === nextPeer.id);
   if (existingIndex === -1) {
-    return [...peers.filter((peer) => peer.kind !== "unknown"), nextPeer];
+    return [...peers, nextPeer];
   }
 
   return peers.map((peer, index) => (index === existingIndex ? nextPeer : peer));
-}
-
-function withRoomPeerCount(
-  state: CloudViewerPresenceState,
-  roomPeerCount: number,
-): CloudViewerPresenceState {
-  const count = safeRoomPeerCount(roomPeerCount);
-  const knownPeers = state.peers.filter((peer) => peer.kind !== "unknown").slice(0, count);
-  const missingCount = Math.max(0, count - knownPeers.length);
-  const placeholders = Array.from({ length: missingCount }, (_, index): CloudViewerPresencePeer => {
-    const ordinal = knownPeers.length + index + 1;
-    return {
-      id: `unknown-${ordinal}`,
-      label: "Anonymous",
-      connectionScope: null,
-      kind: "unknown",
-      status: state.connection === "connected" ? "active" : "idle",
-    };
-  });
-
-  return {
-    ...state,
-    roomPeerCount: count,
-    peers: [...knownPeers, ...placeholders],
-  };
 }
 
 export function cloudViewerPresenceDisplay(
   state: CloudViewerPresenceState,
 ): CloudViewerPresenceDisplay {
   if (state.connection === "disconnected") {
+    const displayPeers = cloudHumanPresenceDisplayPeers(state.peers);
     return {
       label: "Offline",
       title: "Room unavailable",
       connected: false,
-      peers: state.peers.map((peer) => ({ ...peer, status: "offline" })),
-      hiddenCount: 0,
+      peers: displayPeers.peers.map((peer) => ({ ...peer, status: "offline" })),
+      hiddenCount: displayPeers.hiddenCount,
     };
   }
 
@@ -254,6 +247,7 @@ export function cloudViewerPresenceDisplay(
       peers: [
         {
           id: "joining",
+          participantKey: "joining",
           label: "Joining room",
           connectionScope: null,
           kind: "unknown",
@@ -264,12 +258,26 @@ export function cloudViewerPresenceDisplay(
     };
   }
 
-  const count = Math.max(1, state.roomPeerCount);
-  const knownPeers = state.peers.filter((peer) => peer.kind !== "unknown");
-  const anonymousCount = state.peers.filter(
-    (peer) => peer.kind === "anonymous" || peer.kind === "unknown",
-  ).length;
-  const namedPeers = knownPeers.filter((peer) => peer.kind !== "anonymous");
+  const displayPeers = cloudHumanPresenceDisplayPeers(state.peers);
+  const count = displayPeers.count;
+  const title = count === 1 ? "1 participant" : `${count} participants`;
+  return {
+    label: count === 1 ? "1 here now" : `${count} here now`,
+    title,
+    connected: true,
+    peers: displayPeers.peers,
+    hiddenCount: displayPeers.hiddenCount,
+  };
+}
+
+function cloudHumanPresenceDisplayPeers(peers: readonly CloudViewerPresencePeer[]): {
+  count: number;
+  peers: CloudViewerPresencePeer[];
+  hiddenCount: number;
+} {
+  const humanPeerGroups = cloudHumanPresenceGroups(peers);
+  const anonymousCount = peers.filter((peer) => peer.kind === "anonymous").length;
+  const namedPeers = humanPeerGroups.filter((peer) => peer.kind !== "anonymous");
   const visibleNamedPeerLimit = anonymousCount > 0 ? 2 : 3;
   const visibleNamedPeers = namedPeers.slice(0, visibleNamedPeerLimit);
   const visiblePeers =
@@ -278,6 +286,7 @@ export function cloudViewerPresenceDisplay(
           ...visibleNamedPeers,
           {
             id: "anonymous-group",
+            participantKey: "anonymous",
             label:
               anonymousCount === 1 ? "Anonymous viewer" : `${anonymousCount} anonymous viewers`,
             connectionScope: null,
@@ -288,14 +297,31 @@ export function cloudViewerPresenceDisplay(
         ]
       : visibleNamedPeers;
   const hiddenCount = Math.max(0, namedPeers.length - visibleNamedPeers.length);
-  const title = count === 1 ? "1 participant" : `${count} participants`;
+  const count = namedPeers.length + anonymousCount;
   return {
-    label: count === 1 ? "1 here now" : `${count} here now`,
-    title,
-    connected: true,
+    count,
     peers: visiblePeers,
     hiddenCount,
   };
+}
+
+function cloudHumanPresenceGroups(
+  peers: readonly CloudViewerPresencePeer[],
+): CloudViewerPresencePeer[] {
+  const groups = new Map<string, CloudViewerPresencePeer>();
+  for (const peer of peers) {
+    if (peer.kind === "runtime" || peer.kind === "unknown") {
+      continue;
+    }
+    if (peer.kind === "anonymous") {
+      continue;
+    }
+    const existing = groups.get(peer.participantKey);
+    if (!existing || (peer.kind === "self" && existing.kind !== "self")) {
+      groups.set(peer.participantKey, peer);
+    }
+  }
+  return Array.from(groups.values());
 }
 
 export function cloudPresenceHasRuntimePeer(state: CloudViewerPresenceState): boolean {
@@ -377,6 +403,29 @@ function safeRoomPeerCount(value: number): number {
 function safeRuntimePeerCount(value: number | undefined, fallback: number): number {
   const count = value ?? fallback;
   return Number.isFinite(count) && count > 0 ? Math.floor(count) : 0;
+}
+
+function cloudPresenceParticipantKey({
+  participantKey,
+  actorLabel,
+  peerId,
+}: {
+  participantKey?: string | null;
+  actorLabel?: string | null;
+  peerId: string;
+}): string {
+  const trimmedParticipantKey = participantKey?.trim();
+  if (trimmedParticipantKey) return trimmedParticipantKey;
+
+  const trimmedActorLabel = actorLabel?.trim();
+  if (trimmedActorLabel) {
+    return notebookActorProjectionFromLabel(trimmedActorLabel, {
+      source: "cloud",
+      isPublic: trimmedActorLabel.startsWith("anonymous:"),
+    }).principal.id;
+  }
+
+  return `peer:${peerId}`;
 }
 
 function looksLikeRawIdentityLabel(value: string): boolean {

--- a/apps/notebook-cloud/viewer/presence.ts
+++ b/apps/notebook-cloud/viewer/presence.ts
@@ -229,7 +229,7 @@ export function cloudViewerPresenceDisplay(
   state: CloudViewerPresenceState,
 ): CloudViewerPresenceDisplay {
   if (state.connection === "disconnected") {
-    const displayPeers = cloudHumanPresenceDisplayPeers(state.peers);
+    const displayPeers = cloudHumanPresenceDisplayPeers(state.peers, state.ownPeerId);
     return {
       label: "Offline",
       title: "Room unavailable",
@@ -258,11 +258,16 @@ export function cloudViewerPresenceDisplay(
     };
   }
 
-  const displayPeers = cloudHumanPresenceDisplayPeers(state.peers);
+  const displayPeers = cloudHumanPresenceDisplayPeers(state.peers, state.ownPeerId);
   const count = displayPeers.count;
-  const title = count === 1 ? "1 participant" : `${count} participants`;
+  const title =
+    count === 0
+      ? "No one else here"
+      : count === 1
+        ? "1 other participant"
+        : `${count} other participants`;
   return {
-    label: count === 1 ? "1 here now" : `${count} here now`,
+    label: count === 0 ? "No one else here" : count === 1 ? "1 other here" : `${count} others here`,
     title,
     connected: true,
     peers: displayPeers.peers,
@@ -270,13 +275,17 @@ export function cloudViewerPresenceDisplay(
   };
 }
 
-function cloudHumanPresenceDisplayPeers(peers: readonly CloudViewerPresencePeer[]): {
+function cloudHumanPresenceDisplayPeers(
+  peers: readonly CloudViewerPresencePeer[],
+  ownPeerId: string | null,
+): {
   count: number;
   peers: CloudViewerPresencePeer[];
   hiddenCount: number;
 } {
-  const humanPeerGroups = cloudHumanPresenceGroups(peers);
-  const anonymousCount = peers.filter((peer) => peer.kind === "anonymous").length;
+  const otherPeers = cloudOtherPresencePeers(peers, ownPeerId);
+  const humanPeerGroups = cloudHumanPresenceGroups(otherPeers);
+  const anonymousCount = otherPeers.filter((peer) => peer.kind === "anonymous").length;
   const namedPeers = humanPeerGroups.filter((peer) => peer.kind !== "anonymous");
   const visibleNamedPeerLimit = anonymousCount > 0 ? 2 : 3;
   const visibleNamedPeers = namedPeers.slice(0, visibleNamedPeerLimit);
@@ -303,6 +312,19 @@ function cloudHumanPresenceDisplayPeers(peers: readonly CloudViewerPresencePeer[
     peers: visiblePeers,
     hiddenCount,
   };
+}
+
+function cloudOtherPresencePeers(
+  peers: readonly CloudViewerPresencePeer[],
+  ownPeerId: string | null,
+): CloudViewerPresencePeer[] {
+  const ownPeer = ownPeerId ? peers.find((peer) => peer.id === ownPeerId) : null;
+  const ownParticipantKey = ownPeer?.participantKey ?? null;
+  return peers.filter((peer) => {
+    if (ownPeerId && peer.id === ownPeerId) return false;
+    if (ownParticipantKey && peer.participantKey === ownParticipantKey) return false;
+    return true;
+  });
 }
 
 function cloudHumanPresenceGroups(

--- a/src/components/notebook/NotebookCommandToolbar.tsx
+++ b/src/components/notebook/NotebookCommandToolbar.tsx
@@ -16,6 +16,7 @@ import {
   projectNotebookCommandRuntimeActions,
   type NotebookCommandRuntimeState,
   type NotebookShellCapabilities,
+  type NotebookShellRuntimeTargetProjection,
 } from "./capabilities";
 
 export type { NotebookCommandRuntimeState } from "./capabilities";
@@ -55,6 +56,7 @@ export interface NotebookCommandToolbarProps {
     | "auth"
   >;
   runtime?: string | null;
+  runtimeTarget?: NotebookShellRuntimeTargetProjection | null;
   environmentManager?: NotebookEnvironmentManager | null;
   environmentPanelOpen?: boolean;
   environmentOutOfSync?: boolean;
@@ -85,6 +87,7 @@ export interface NotebookCommandToolbarProps {
 export function NotebookCommandToolbar({
   capabilities,
   runtime = null,
+  runtimeTarget = null,
   environmentManager = null,
   environmentPanelOpen = false,
   environmentOutOfSync = false,
@@ -126,6 +129,8 @@ export function NotebookCommandToolbar({
     },
   });
   const showPackageToggle = Boolean(runtime && canViewPackages && onTogglePackages);
+  const runtimePeerCount = runtimeTarget?.runtimePeerCount ?? 0;
+  const showRuntimePeerIndicator = runtimePeerCount > 0;
   const showAuthControls =
     Boolean(authControls) &&
     (auth.canSignIn || auth.canUseAuthenticatedIdentity || auth.needsAttention);
@@ -301,6 +306,8 @@ export function NotebookCommandToolbar({
           data-testid="deps-toggle"
           data-runtime={runtime ?? undefined}
           data-env-manager={environmentManager || undefined}
+          data-runtime-target={runtimeTarget?.kind}
+          data-runtime-peer-count={showRuntimePeerIndicator ? runtimePeerCount : undefined}
           className={cn(
             "flex items-center gap-1 rounded px-1.5 py-0.5 text-[10px] font-medium transition-colors",
             runtime === "deno"
@@ -308,14 +315,12 @@ export function NotebookCommandToolbar({
               : "bg-blue-500/10 text-blue-600 hover:bg-blue-500/20 dark:text-blue-400",
             environmentPanelOpen && "ring-1 ring-current/25",
           )}
-          title={(() => {
-            const lang = runtime === "deno" ? "Deno/TypeScript" : "Python";
-            const manager = environmentManager ? ` / ${environmentManager}` : "";
-            const action = environmentPanelOpen
-              ? "close environment panel"
-              : "open environment panel";
-            return `${lang}${manager} - ${action}`;
-          })()}
+          title={runtimeChipTitle({
+            environmentManager,
+            environmentPanelOpen,
+            runtime,
+            runtimeTarget,
+          })}
         >
           {runtime === "deno" ? (
             <>
@@ -340,6 +345,12 @@ export function NotebookCommandToolbar({
               {environmentManager === "pixi" ? (
                 <PixiIcon className="h-2.5 w-2.5 text-amber-600 dark:text-amber-400" />
               ) : null}
+            </>
+          ) : null}
+          {showRuntimePeerIndicator ? (
+            <>
+              <span className="opacity-40">/</span>
+              <ServerCog className="h-2.5 w-2.5" aria-hidden="true" />
             </>
           ) : null}
         </button>
@@ -379,4 +390,49 @@ export function NotebookCommandToolbar({
       {trailingControls}
     </div>
   );
+}
+
+function runtimeChipTitle({
+  environmentManager,
+  environmentPanelOpen,
+  runtime,
+  runtimeTarget,
+}: {
+  environmentManager: NotebookEnvironmentManager | null;
+  environmentPanelOpen: boolean;
+  runtime: string | null;
+  runtimeTarget: NotebookShellRuntimeTargetProjection | null;
+}): string {
+  const lang = runtime === "deno" ? "Deno/TypeScript" : "Python";
+  const manager = environmentManager ? ` / ${environmentManager}` : "";
+  const action = environmentPanelOpen ? "close environment panel" : "open environment panel";
+  const targetParts = runtimeTargetTitleParts(runtimeTarget);
+  return targetParts.length > 0
+    ? `${lang}${manager} - ${targetParts.join(" · ")} - ${action}`
+    : `${lang}${manager} - ${action}`;
+}
+
+function runtimeTargetTitleParts(
+  runtimeTarget: NotebookShellRuntimeTargetProjection | null,
+): string[] {
+  if (!runtimeTarget) return [];
+
+  const parts: string[] = [];
+  if (runtimeTarget.label) {
+    parts.push(runtimeTarget.label);
+  }
+  if (runtimeTarget.statusLabel) {
+    parts.push(runtimeTarget.statusLabel);
+  }
+  if (runtimeTarget.kernelStatusLabel) {
+    parts.push(`Kernel ${runtimeTarget.kernelStatusLabel}`);
+  }
+  if (typeof runtimeTarget.runtimePeerCount === "number" && runtimeTarget.runtimePeerCount > 0) {
+    parts.push(
+      runtimeTarget.runtimePeerCount === 1
+        ? "1 compute session"
+        : `${runtimeTarget.runtimePeerCount} compute sessions`,
+    );
+  }
+  return parts;
 }

--- a/src/components/notebook/__tests__/NotebookCommandToolbar.test.tsx
+++ b/src/components/notebook/__tests__/NotebookCommandToolbar.test.tsx
@@ -176,6 +176,37 @@ describe("NotebookCommandToolbar", () => {
     expect(screen.queryByTestId("run-all-button")).toBeNull();
   });
 
+  it("surfaces attached compute metadata on the runtime chip", () => {
+    render(
+      <NotebookCommandToolbar
+        capabilities={editableToolbarCapabilities}
+        runtime="python"
+        runtimeTarget={{
+          id: "ws-lab2",
+          kind: "cloud_workstation",
+          status: "ready",
+          label: "Lab2 workstation",
+          statusLabel: "Ready",
+          detail: "Runtime peer attached",
+          providerLabel: "Cloud room",
+          defaultEnvironmentLabel: "Current Python",
+          environmentLabel: "Current Python",
+          kernelStatusLabel: "idle",
+          runtimePeerCount: 1,
+        }}
+        onTogglePackages={() => {}}
+      />,
+    );
+
+    const chip = screen.getByTestId("deps-toggle");
+    expect(chip).toHaveAttribute("data-runtime-target", "cloud_workstation");
+    expect(chip).toHaveAttribute("data-runtime-peer-count", "1");
+    expect(chip).toHaveAttribute(
+      "title",
+      "Python - Lab2 workstation · Ready · Kernel idle · 1 compute session - open environment panel",
+    );
+  });
+
   it("can direct eligible users toward workstation setup without a runtime status", () => {
     const onWorkstationSetup = vi.fn();
 


### PR DESCRIPTION
## Summary
- send an explicit room peer roster with cloud_room_ready so new viewers know who is actually present
- project human presence by participant/account, with true anonymous viewers only from anonymous peer records
- hide the current signed-in user from the top avatar stack; that stack now represents other people in the room
- keep runtime peers out of the human avatar stack and surface attached compute on the runtime chip

## Validation
- pnpm --dir apps/notebook-cloud exec tsc --noEmit
- pnpm --dir apps/notebook-cloud exec tsx --test test/viewer-presence.test.ts
- pnpm --dir apps/notebook-cloud exec tsx --test test/notebook-room.test.ts
- pnpm test:run src/components/notebook/__tests__/NotebookCommandToolbar.test.tsx
- pnpm --dir apps/notebook-cloud exec tsx --test test/viewer-render-props.test.ts test/viewer-shared-cell-surface.test.ts
- cargo xtask lint --fix
- deployed preview.runt.run at 1b569a760cc6701da3d43b46a78c07a553bdf372
- Chrome verified: self-only shared notebook renders no presence stack; attached-workstation notebook shows only a distinct other participant when present, with runtime state remaining on the Python chip