### PR TITLE
fix(notebook-cloud): polish reconnecting toolbar chrome

### DIFF
--- a/apps/notebook-cloud/src/index.ts
+++ b/apps/notebook-cloud/src/index.ts
@@ -4452,14 +4452,22 @@ function preconnectResourceHints(urls: Array<string | null | undefined>): string
   return hints;
 }
 
-function authConfigForRequest(request: Request, env: Env): { oidc: Record<string, string> | null } {
+function authConfigForRequest(
+  request: Request,
+  env: Env,
+): { oidc: Record<string, string> | null; localDev: Record<string, string> | null } {
+  const localDev = localDevAuthConfigForRequest(request, env);
+  if (localDev) {
+    return { oidc: null, localDev };
+  }
   const issuer = env.NOTEBOOK_CLOUD_OIDC_ISSUER?.trim();
   const clientId = env.NOTEBOOK_CLOUD_OIDC_CLIENT_ID?.trim();
   const providerLabel = env.NOTEBOOK_CLOUD_OIDC_PROVIDER_LABEL?.trim();
   if (!issuer || !clientId) {
-    return { oidc: null };
+    return { oidc: null, localDev: null };
   }
   return {
+    localDev: null,
     oidc: {
       issuer,
       clientId,
@@ -4467,6 +4475,19 @@ function authConfigForRequest(request: Request, env: Env): { oidc: Record<string
         env.NOTEBOOK_CLOUD_OIDC_REDIRECT_URI?.trim() || new URL("/oidc", request.url).href,
       ...(providerLabel ? { providerLabel } : {}),
     },
+  };
+}
+
+function localDevAuthConfigForRequest(request: Request, env: Env): Record<string, string> | null {
+  const url = new URL(request.url);
+  if (!isLoopbackWorkerRequest(request, url, loopbackRequestOptions(env))) {
+    return null;
+  }
+  const authUrl = new URL("/local-auth", url.origin);
+  authUrl.searchParams.set("next", `${url.pathname}${url.search}${url.hash}`);
+  return {
+    authUrl: `${authUrl.pathname}${authUrl.search}`,
+    label: "Use local auth",
   };
 }
 

--- a/apps/notebook-cloud/test/html.test.ts
+++ b/apps/notebook-cloud/test/html.test.ts
@@ -317,6 +317,30 @@ describe("HTML script serialization", () => {
     );
   });
 
+  it("injects local auth config instead of OIDC provider chrome on loopback", async () => {
+    const response = await worker.fetch(
+      new Request("http://localhost:45316/n/demo/example?mode=view"),
+      fakeEnv({
+        NOTEBOOK_CLOUD_OIDC_CLIENT_ID: "client-id",
+        NOTEBOOK_CLOUD_OIDC_ISSUER: "https://auth.stage.anaconda.com/api/auth",
+        NOTEBOOK_CLOUD_OIDC_PROVIDER_LABEL: "Anaconda",
+        NOTEBOOK_CLOUD_OIDC_REDIRECT_URI: "https://preview.runt.run/oidc",
+      }),
+      fakeContext(),
+    );
+    const html = await response.text();
+
+    assert.equal(response.status, 200);
+    assert.match(html, /"oidc":null/);
+    assert.match(
+      html,
+      /"localDev":\{"authUrl":"\/local-auth\?next=%2Fn%2Fdemo%2Fexample%3Fmode%3Dview"/,
+    );
+    assert.match(html, /"label":"Use local auth"/);
+    assert.doesNotMatch(html, /"providerLabel":"Anaconda"/);
+    assert.doesNotMatch(html, /"issuer":"https:\/\/auth\.stage\.anaconda\.com\/api\/auth"/);
+  });
+
   it("serves the OIDC callback shell without a notebook runtime config", async () => {
     const response = await worker.fetch(
       new Request("https://preview.runt.run/oidc?code=abc&state=def"),

--- a/apps/notebook-cloud/test/viewer-render-props.test.ts
+++ b/apps/notebook-cloud/test/viewer-render-props.test.ts
@@ -84,6 +84,13 @@ test("cloud home keeps prototype controls out of the primary auth surface", () =
   assert.match(homeSource, /realtime notebooks/);
   assert.match(homeSource, /View notebooks/);
   assert.match(homeSource, /href="\/n"/);
+  assert.match(homeSource, /const localDevAuth = authConfig\.localDev/);
+  assert.match(
+    homeSource,
+    /const signInConfigured = Boolean\(localDevAuth \|\| authConfig\.oidc\)/,
+  );
+  assert.match(homeSource, /window\.location\.assign\(localDevAuth\.authUrl\)/);
+  assert.match(homeSource, /const hasLocalDevAuth = authState\.mode === "dev"/);
   assert.doesNotMatch(homeSource, /showPrototypeDevControls/);
   assert.doesNotMatch(homeSource, /className="cloud-home-scope"/);
   assert.doesNotMatch(homeSource, /<select/);
@@ -174,6 +181,12 @@ test("cloud viewer routes notebook header controls through the shared shell chro
     /authControls=\{[\s\S]*shouldShowCloudHeaderSignIn\(authState, \{[\s\S]*hasAppSession,[\s\S]*\}\) \? \(/,
   );
   assert.match(sourceText, /authControls=\{[\s\S]*<CloudNotebookSignInButton/);
+  assert.match(sourceText, /const beginNotebookAuth = useCallback/);
+  assert.match(sourceText, /window\.location\.assign\(localDevAuth\.authUrl\)/);
+  assert.match(
+    sourceText,
+    /onSignInAgain=\{authConfig\.localDev \|\| authConfig\.oidc \? beginNotebookAuth : undefined\}/,
+  );
   assert.match(sourceText, /const hasAppSession = Boolean\(appSessionStatus\.session\)/);
   assert.match(sourceText, /projectCloudAccessRequestTransition\(\{/);
   // The connection/identity slot is filled by the shared quiet component:

--- a/apps/notebook-cloud/test/viewer-shared-cell-surface.test.ts
+++ b/apps/notebook-cloud/test/viewer-shared-cell-surface.test.ts
@@ -328,6 +328,21 @@ test("cloud edit mode chrome renders through the shared shell component", () => 
     /<NotebookEditModeButton[\s\S]*state=\{accessPending \? "viewing" : interaction\.state\}/,
   );
   assert.match(authControlsSourceText, /<NotebookEditModeButton[\s\S]*variant="segmented"/);
+  assert.match(authControlsSourceText, /authConfig\.localDev\?\.label\?\.trim\(\)/);
+  assert.match(authControlsSourceText, /return "Use local auth"/);
+  assert.match(authControlsSourceText, /window\.location\.assign\(localDevAuth\.authUrl\)/);
+  assert.match(
+    authControlsSourceText,
+    /const providerLabel = authConfig\.oidc\?\.providerLabel\?\.trim\(\)/,
+  );
+  assert.match(
+    authControlsSourceText,
+    /<NotebookEditModeButton[\s\S]*requestedEditLabel=\{reconnecting \? "Offline" : "Request sent"\}/,
+  );
+  assert.match(
+    authControlsSourceText,
+    /<NotebookEditModeButton[\s\S]*requestedEditTitle=\{[\s\S]*reconnecting \? "Offline while the room reconnects" : "Edit access requested"/,
+  );
   assert.match(authControlsSourceText, /onModeChange=\{\(mode\) => \{/);
   assert.match(sourceText, /accessLevel=\{shellCapabilities\.access\.level\}/);
   assert.doesNotMatch(sourceText, /projectCloudNotebookEditAccess/);
@@ -339,6 +354,7 @@ test("cloud edit mode chrome renders through the shared shell component", () => 
   assert.match(shellHookSourceText, /editAccessRequestPending/);
   assert.match(sourceText, /onModeChange=\{setSelectedInteractionMode\}/);
   assert.match(sourceText, /onRequestEditAccess=\{requestCloudEditAccess\}/);
+  assert.match(sourceText, /reconnecting=\{sustainedReconnecting\}/);
   assert.match(
     shellHookSourceText,
     /const editAccessPending =[\s\S]*roomEditAccess\.editAccessPending \|\| editReadiness\.selectedEditModeWaitingForRoom/,
@@ -422,16 +438,26 @@ test("cloud host notices sit in the shared shell above the rail and notebook sta
   assert.match(sourceText, /noticesClassName="cloud-notebook-notices"/);
   assert.match(sourceText, /cloud-notebook-shell--command-toolbar/);
   assert.match(cssText, /\.cloud-notebook-shell \{[\s\S]*position: relative;/);
-  assert.match(cssText, /\.cloud-notebook-shell \{[\s\S]*--cloud-notice-top: 3\.75rem;/);
+  assert.match(cssText, /\.cloud-notebook-shell \{[\s\S]*--cloud-notice-height: 3rem;/);
   assert.match(
     cssText,
-    /\.cloud-notebook-shell--command-toolbar \{[\s\S]*--cloud-notice-top: calc\(3\.75rem \+ 2\.5rem\);/,
+    /\.cloud-notebook-shell--command-toolbar \{[\s\S]*--cloud-notice-height: 3rem;/,
   );
-  assert.match(cssText, /\.cloud-notebook-notices \{[\s\S]*position: absolute;/);
-  assert.match(cssText, /\.cloud-notebook-notices \{[\s\S]*top: var\(--cloud-notice-top\);/);
+  const noticesCss = cssText.match(/\.cloud-notebook-notices \{(?<body>[\s\S]*?)\n\}/)?.groups
+    ?.body;
+  assert.ok(noticesCss);
+  assert.match(noticesCss, /flex: 0 0 var\(--cloud-notice-height\);/);
+  assert.match(noticesCss, /height: var\(--cloud-notice-height\);/);
+  assert.match(noticesCss, /overflow-y: auto;/);
+  assert.match(noticesCss, /animation: cloud-notice-enter/);
+  assert.doesNotMatch(noticesCss, /position: absolute;/);
   assert.match(
     cssText,
-    /@media \(max-width: 900px\) \{[\s\S]*\.cloud-notebook-shell \{[\s\S]*--cloud-notice-top: 3\.75rem;[\s\S]*\.cloud-notebook-shell--command-toolbar \{[\s\S]*--cloud-notice-top: calc\(3\.75rem \+ 2\.5rem\);/,
+    /\.cloud-notebook-notices \[data-slot="notebook-notice"\] \{[\s\S]*min-height: var\(--cloud-notice-height\);/,
+  );
+  assert.match(
+    cssText,
+    /@media \(max-width: 900px\) \{[\s\S]*\.cloud-notebook-shell \{[\s\S]*--cloud-notice-height: 3rem;[\s\S]*\.cloud-notebook-shell--command-toolbar \{[\s\S]*--cloud-notice-height: 3rem;/,
   );
   assert.match(
     cssText,

--- a/apps/notebook-cloud/viewer/cloud-auth-controls.tsx
+++ b/apps/notebook-cloud/viewer/cloud-auth-controls.tsx
@@ -15,6 +15,13 @@ import { beginOidcLogin } from "./oidc-auth";
 import type { CloudViewerAuthConfig } from "./cloud-viewer-types";
 
 export function cloudNotebookSignInLabel(authConfig: CloudViewerAuthConfig): string {
+  const localDevLabel = authConfig.localDev?.label?.trim();
+  if (localDevLabel) {
+    return localDevLabel;
+  }
+  if (authConfig.localDev) {
+    return "Use local auth";
+  }
   const providerLabel = authConfig.oidc?.providerLabel?.trim();
   return providerLabel ? `Sign in with ${providerLabel}` : "Sign in";
 }
@@ -25,6 +32,7 @@ export function CloudNotebookEditModeButton({
   accessLevel,
   accessPending,
   interaction,
+  reconnecting = false,
   onModeChange,
   onRequestEditAccess,
 }: {
@@ -33,6 +41,7 @@ export function CloudNotebookEditModeButton({
   accessLevel: NotebookShellCapabilities["access"]["level"];
   accessPending: boolean;
   interaction: NotebookInteractionModeProjection | null;
+  reconnecting?: boolean;
   onModeChange: (mode: NotebookInteractionMode) => void;
   onRequestEditAccess: () => void;
 }) {
@@ -52,6 +61,10 @@ export function CloudNotebookEditModeButton({
     <NotebookEditModeButton
       editLabel={editLabel}
       editTitle={editTitle}
+      requestedEditLabel={reconnecting ? "Offline" : "Request sent"}
+      requestedEditTitle={
+        reconnecting ? "Offline while the room reconnects" : "Edit access requested"
+      }
       mode={accessPending ? "view" : interaction.selectedMode}
       state={accessPending ? "viewing" : interaction.state}
       variant="segmented"
@@ -79,7 +92,13 @@ export function CloudNotebookSignInButton({
   const [authAction, setAuthAction] = useState<"idle" | "starting">("idle");
   const [error, setError] = useState<string | null>(null);
 
-  if (!authConfig.oidc || authState.mode === "oidc") {
+  if (authState.mode === "dev") {
+    return null;
+  }
+  const localDevAuth = authConfig.localDev;
+  const useLocalDevAuth = Boolean(localDevAuth);
+  const useOidcAuth = !useLocalDevAuth && Boolean(authConfig.oidc) && authState.mode !== "oidc";
+  if (!useLocalDevAuth && !useOidcAuth) {
     return null;
   }
   const copy = cloudNotebookSignInCopy(authState, authAction, error);
@@ -88,7 +107,18 @@ export function CloudNotebookSignInButton({
       ? (idleLabel ?? cloudNotebookSignInLabel(authConfig))
       : copy.label;
 
-  const beginOidcAuth = async () => {
+  const beginAuth = async () => {
+    if (localDevAuth) {
+      try {
+        setAuthAction("starting");
+        setError(null);
+        window.location.assign(localDevAuth.authUrl);
+      } catch (caught) {
+        setAuthAction("idle");
+        setError(caught instanceof Error ? caught.message : String(caught));
+      }
+      return;
+    }
     if (!authConfig.oidc) return;
     try {
       setAuthAction("starting");
@@ -112,7 +142,7 @@ export function CloudNotebookSignInButton({
       data-state={error ? "error" : authAction}
       disabled={authAction === "starting"}
       title={copy.title}
-      onClick={beginOidcAuth}
+      onClick={beginAuth}
     >
       <LogIn aria-hidden="true" />
       <span>{label}</span>

--- a/apps/notebook-cloud/viewer/cloud-viewer-config.ts
+++ b/apps/notebook-cloud/viewer/cloud-viewer-config.ts
@@ -5,6 +5,7 @@ import { normalizeOidcAuthConfig, type CloudOidcAuthConfig } from "./oidc-auth";
 import type {
   CloudNotebookListBootstrap,
   CloudViewerAuthConfig,
+  CloudViewerLocalDevAuthConfig,
   ViewerRuntimeState,
 } from "./cloud-viewer-types";
 
@@ -108,15 +109,41 @@ export function loadViewerRuntime(): ViewerRuntimeState {
 export function loadAuthConfig(): CloudViewerAuthConfig {
   const element = document.querySelector<HTMLScriptElement>("#nteract-cloud-auth-config");
   if (!element) {
-    return { oidc: null };
+    return { oidc: null, localDev: null };
   }
   try {
     const parsed = JSON.parse(element.textContent ?? "{}") as {
+      localDev?: Partial<CloudViewerLocalDevAuthConfig> | null;
       oidc?: Partial<CloudOidcAuthConfig> | null;
     };
-    return { oidc: normalizeOidcAuthConfig(parsed.oidc) };
+    return {
+      oidc: normalizeOidcAuthConfig(parsed.oidc),
+      localDev: normalizeLocalDevAuthConfig(parsed.localDev),
+    };
   } catch {
-    return { oidc: null };
+    return { oidc: null, localDev: null };
+  }
+}
+
+function normalizeLocalDevAuthConfig(
+  input: Partial<CloudViewerLocalDevAuthConfig> | null | undefined,
+): CloudViewerLocalDevAuthConfig | null {
+  const rawAuthUrl = input?.authUrl?.trim();
+  if (!rawAuthUrl) {
+    return null;
+  }
+  try {
+    const authUrl = new URL(rawAuthUrl, window.location.origin);
+    if (authUrl.origin !== window.location.origin) {
+      return null;
+    }
+    const label = input?.label?.trim();
+    return {
+      authUrl: `${authUrl.pathname}${authUrl.search}${authUrl.hash}`,
+      ...(label ? { label } : {}),
+    };
+  } catch {
+    return null;
   }
 }
 

--- a/apps/notebook-cloud/viewer/cloud-viewer-types.ts
+++ b/apps/notebook-cloud/viewer/cloud-viewer-types.ts
@@ -5,6 +5,12 @@ import type { CloudOidcAuthConfig } from "./oidc-auth";
 
 export interface CloudViewerAuthConfig {
   oidc: CloudOidcAuthConfig | null;
+  localDev: CloudViewerLocalDevAuthConfig | null;
+}
+
+export interface CloudViewerLocalDevAuthConfig {
+  authUrl: string;
+  label?: string;
 }
 
 export interface ViewerRuntime {

--- a/apps/notebook-cloud/viewer/home-view.tsx
+++ b/apps/notebook-cloud/viewer/home-view.tsx
@@ -29,19 +29,32 @@ export function CloudHomeView({ authConfig }: { authConfig: CloudViewerAuthConfi
   );
   const [authAction, setAuthAction] = useState<"idle" | "starting">("idle");
   const [formError, setFormError] = useState<string | null>(null);
-  const oidcConfigured = Boolean(authConfig.oidc);
+  const localDevAuth = authConfig.localDev;
+  const signInConfigured = Boolean(localDevAuth || authConfig.oidc);
 
   useEffect(() => {
     applyDocumentTheme(resolvedTheme);
   }, [resolvedTheme]);
 
-  const beginOidcAuth = async () => {
+  const beginAuth = async () => {
+    if (localDevAuth) {
+      try {
+        setAuthAction("starting");
+        setFormError(null);
+        window.location.assign(localDevAuth.authUrl);
+      } catch (error) {
+        setAuthAction("idle");
+        setFormError(error instanceof Error ? error.message : String(error));
+      }
+      return;
+    }
     if (!authConfig.oidc) {
-      setFormError("OIDC sign-in is not configured for this host.");
+      setFormError("Sign-in is not configured for this host.");
       return;
     }
     try {
       setAuthAction("starting");
+      setFormError(null);
       prepareCloudOidcViewerLogin(window.localStorage);
       const url = await beginOidcLogin(authConfig.oidc, {
         currentUrl: window.location.href,
@@ -67,18 +80,23 @@ export function CloudHomeView({ authConfig }: { authConfig: CloudViewerAuthConfi
   };
 
   const hasExplicitAuth = authState.mode === "oidc";
+  const hasLocalDevAuth = authState.mode === "dev";
   const hasAppSession = Boolean(appSessionStatus.session);
-  const signedIn = hasExplicitAuth || hasAppSession;
-  const homeStatusMode = signedIn ? "oidc" : authState.mode;
+  const signedIn = hasExplicitAuth || hasLocalDevAuth || hasAppSession;
+  const homeStatusMode = signedIn ? (hasLocalDevAuth ? "dev" : "oidc") : authState.mode;
   const homeStatusTitle = hasExplicitAuth
     ? (authState.user ?? "Signed in")
-    : hasAppSession
-      ? "Signed in"
-      : "Open a notebook";
+    : hasLocalDevAuth
+      ? (authState.user ?? "Local auth")
+      : hasAppSession
+        ? "Signed in"
+        : "Open a notebook";
   const homeStatusDescription = signedIn
     ? hasExplicitAuth
       ? "Open a notebook or sign out of this browser session."
-      : "Open and manage notebooks with this browser session."
+      : hasLocalDevAuth
+        ? "Open and manage notebooks with local auth."
+        : "Open and manage notebooks with this browser session."
     : "Sign in to open private notebooks or request edit access.";
 
   return (
@@ -137,16 +155,16 @@ export function CloudHomeView({ authConfig }: { authConfig: CloudViewerAuthConfi
                 Sign out
               </button>
             ) : null}
-            {hasExplicitAuth ? null : (
+            {hasExplicitAuth || hasLocalDevAuth ? null : (
               <button
                 type="button"
-                disabled={authAction === "starting" || !oidcConfigured}
-                onClick={beginOidcAuth}
+                disabled={authAction === "starting" || !signInConfigured}
+                onClick={beginAuth}
               >
                 <LogIn aria-hidden="true" />
                 {authAction === "starting"
                   ? "Starting sign-in"
-                  : !oidcConfigured
+                  : !signInConfigured
                     ? "Sign-in unavailable"
                     : hasAppSession
                       ? "Renew sign-in"
@@ -161,7 +179,7 @@ export function CloudHomeView({ authConfig }: { authConfig: CloudViewerAuthConfi
             ) : null}
           </div>
 
-          {oidcConfigured ? null : (
+          {signInConfigured ? null : (
             <p className="cloud-home-note">
               This host has no sign-in provider configured. Public notebooks can still be read.
             </p>

--- a/apps/notebook-cloud/viewer/index.css
+++ b/apps/notebook-cloud/viewer/index.css
@@ -16,7 +16,7 @@ body {
 }
 
 .cloud-notebook-shell {
-  --cloud-notice-top: 3.75rem;
+  --cloud-notice-height: 3rem;
 
   display: flex;
   position: relative;
@@ -28,7 +28,7 @@ body {
 }
 
 .cloud-notebook-shell--command-toolbar {
-  --cloud-notice-top: calc(3.75rem + 2.5rem);
+  --cloud-notice-height: 3rem;
 }
 
 .cloud-notebook-rail {
@@ -47,29 +47,49 @@ body {
 
 .cloud-notebook-notices {
   display: grid;
-  position: absolute;
-  top: var(--cloud-notice-top);
-  right: 0;
-  left: 0;
+  flex: 0 0 var(--cloud-notice-height);
+  height: var(--cloud-notice-height);
+  min-height: var(--cloud-notice-height);
   z-index: 18;
   gap: 0;
   border-bottom: 1px solid var(--border);
   background: var(--background);
   padding: 0;
-  box-shadow: 0 6px 14px color-mix(in srgb, #000 4%, transparent);
+  overflow-y: auto;
+  overscroll-behavior: contain;
+  box-shadow: 0 4px 10px color-mix(in srgb, #000 4%, transparent);
+  animation: cloud-notice-enter 180ms cubic-bezier(0.2, 0.8, 0.2, 1);
+}
+
+.cloud-notebook-notices [data-slot="notebook-notice-stack"] {
+  min-height: 100%;
+  gap: 0;
 }
 
 .cloud-notebook-notices [data-slot="notebook-notice"] {
+  min-height: var(--cloud-notice-height);
+  align-items: center;
   border: 0;
-  border-top: 2px solid currentColor;
   border-radius: 0;
-  padding: 0.625rem clamp(0.5rem, 2vw, 1rem) 0.625rem clamp(0.75rem, 4vw, 2rem);
+  padding: 0.5rem clamp(0.5rem, 2vw, 1rem) 0.5rem clamp(0.75rem, 4vw, 2rem);
   background: linear-gradient(
     180deg,
     color-mix(in srgb, currentColor 9%, var(--background)) 0%,
     color-mix(in srgb, currentColor 4%, var(--background)) 42%,
     var(--background) 100%
   );
+}
+
+@keyframes cloud-notice-enter {
+  from {
+    clip-path: inset(0 0 100% 0);
+    opacity: 0;
+  }
+
+  to {
+    clip-path: inset(0 0 0 0);
+    opacity: 1;
+  }
 }
 
 .cloud-room-toolbar {
@@ -248,11 +268,11 @@ body {
 
 @media (max-width: 900px) {
   .cloud-notebook-shell {
-    --cloud-notice-top: 3.75rem;
+    --cloud-notice-height: 3rem;
   }
 
   .cloud-notebook-shell--command-toolbar {
-    --cloud-notice-top: calc(3.75rem + 2.5rem);
+    --cloud-notice-height: 3rem;
   }
 
   .cloud-room-toolbar {

--- a/apps/notebook-cloud/viewer/notebook-viewer.tsx
+++ b/apps/notebook-cloud/viewer/notebook-viewer.tsx
@@ -900,7 +900,12 @@ export function NotebookViewer({
     setSelectedInteractionMode("view");
     refreshAuthState();
   }, [refreshAuthState]);
-  const beginNotebookOidcAuth = useCallback(async () => {
+  const beginNotebookAuth = useCallback(async () => {
+    const localDevAuth = authConfig.localDev;
+    if (localDevAuth) {
+      window.location.assign(localDevAuth.authUrl);
+      return;
+    }
     if (!authConfig.oidc) {
       resetPrototypeAuth();
       return;
@@ -913,9 +918,9 @@ export function NotebookViewer({
       });
       window.location.assign(url.href);
     } catch (error) {
-      console.warn("[notebook-cloud] OIDC sign-in start failed", error);
+      console.warn("[notebook-cloud] sign-in start failed", error);
     }
-  }, [authConfig.oidc, resetPrototypeAuth]);
+  }, [authConfig.localDev, authConfig.oidc, resetPrototypeAuth]);
   const applyLatestAccessRequest = useCallback(
     (
       request: CloudNotebookAccessRequest | null,
@@ -1182,6 +1187,7 @@ export function NotebookViewer({
           interaction={shellCapabilities.interaction ?? null}
           accessLevel={shellCapabilities.access.level}
           accessPending={editAccessPending}
+          reconnecting={sustainedReconnecting}
           onModeChange={setSelectedInteractionMode}
           onRequestEditAccess={requestCloudEditAccess}
         />
@@ -1285,7 +1291,7 @@ export function NotebookViewer({
       onResetAuth={resetPrototypeAuth}
       onRetryConnection={retryLiveConnection}
       onRetryRendererAssets={isolatedRenderer.retry}
-      onSignInAgain={authConfig.oidc ? beginNotebookOidcAuth : undefined}
+      onSignInAgain={authConfig.localDev || authConfig.oidc ? beginNotebookAuth : undefined}
     />
   ) : null;
 

--- a/src/components/notebook/NotebookConnectionIdentity.tsx
+++ b/src/components/notebook/NotebookConnectionIdentity.tsx
@@ -37,8 +37,8 @@ export interface NotebookConnectionStatusSource {
  * designs — hard constraints, not preferences):
  * - renders NOTHING for a purely local desktop session
  *   (`isRemoteNotebookContext`); local identity is noise, not chrome;
- * - flat `rounded-md border-border/70 bg-muted/35`, never
- *   rounded-full + shadow;
+ * - borderless wrapper: the avatar and connectivity dot carry the signal,
+ *   never a bordered status bubble or shadow;
  * - icon/avatar-first and icon-only at every width: no visible text pill —
  *   the label and status live in `sr-only` copy and the title tooltip;
  * - state expresses as dot color / opacity, never copy; status CHANGES are
@@ -95,8 +95,8 @@ export function NotebookConnectionIdentity({
   return (
     <div
       className={cn(
-        "inline-flex shrink-0 items-center rounded-md border border-border/70 bg-muted/35 px-1.5 py-0.5",
-        status !== "online" && "opacity-60",
+        "inline-flex h-8 shrink-0 items-center justify-center rounded-md px-0.5 text-foreground transition-colors hover:bg-muted/60",
+        status !== "online" && "opacity-70",
         className,
       )}
       data-slot="notebook-connection-identity"
@@ -107,7 +107,12 @@ export function NotebookConnectionIdentity({
       {/* The visual layer is hidden from the a11y tree (avatar initials
           would otherwise leak ahead of the sr-only copy). */}
       <span aria-hidden="true">
-        <NotebookActorAvatar actor={actor} size="sm" statusClassName={connectionDotTone(status)} />
+        <NotebookActorAvatar
+          actor={actor}
+          className="border-0"
+          size="sm"
+          statusClassName={connectionDotTone(status)}
+        />
       </span>
       <span className="sr-only">{detail}</span>
       {/* Announces status CHANGES only — empty on initial render so a mount

--- a/src/components/notebook/NotebookEditModeButton.tsx
+++ b/src/components/notebook/NotebookEditModeButton.tsx
@@ -12,6 +12,8 @@ export interface NotebookEditModeButtonProps {
   disabled?: boolean;
   editLabel?: string;
   editTitle?: string;
+  requestedEditLabel?: string;
+  requestedEditTitle?: string;
   variant?: "button" | "segmented";
   className?: string;
 }
@@ -23,6 +25,8 @@ export function NotebookEditModeButton({
   editTitle = "Switch to edit mode",
   mode,
   onModeChange,
+  requestedEditLabel = "Request sent",
+  requestedEditTitle = "Edit access requested",
   state,
   variant = "button",
 }: NotebookEditModeButtonProps) {
@@ -31,7 +35,7 @@ export function NotebookEditModeButton({
   const nextMode: NotebookEditMode = requestingEdit ? "view" : "edit";
   const editLabel = editLabelProp ?? "Editing";
   const label = requestingEdit ? "View" : "Edit";
-  const editSegmentLabel = requestedEdit ? "Request sent" : editLabel;
+  const editSegmentLabel = requestedEdit ? requestedEditLabel : editLabel;
   const title = requestingEdit
     ? state === "editing"
       ? "Return to read-only viewing"
@@ -87,7 +91,7 @@ export function NotebookEditModeButton({
             state === "editing"
               ? "Editing notebook"
               : requestedEdit
-                ? "Edit access requested"
+                ? requestedEditTitle
                 : editTitle
           }
           onClick={() => {

--- a/src/components/notebook/NotebookIdentity.tsx
+++ b/src/components/notebook/NotebookIdentity.tsx
@@ -142,12 +142,14 @@ export function NotebookIdentityGroup({
 
 export function NotebookActorAvatar({
   actor,
+  className,
   icon,
   size = "default",
   showStatus = true,
   statusClassName,
 }: {
   actor: NotebookActorIdentity;
+  className?: string;
   icon?: LucideIcon;
   size?: "sm" | "default";
   showStatus?: boolean;
@@ -158,7 +160,11 @@ export function NotebookActorAvatar({
   return (
     <Avatar
       size={size}
-      className={cn("border border-border bg-muted text-muted-foreground", actorTone(actor.kind))}
+      className={cn(
+        "border border-border bg-muted text-muted-foreground",
+        actorTone(actor.kind),
+        className,
+      )}
       data-slot="notebook-actor-avatar"
       data-actor-kind={actor.kind}
     >

--- a/src/components/notebook/__tests__/NotebookConnectionIdentity.test.tsx
+++ b/src/components/notebook/__tests__/NotebookConnectionIdentity.test.tsx
@@ -192,7 +192,7 @@ describe("NotebookConnectionIdentity", () => {
       expect(dot.classList.contains(tone)).toBe(true);
       expect(dot.classList.contains("animate-pulse")).toBe(pulses);
       // State expresses as opacity/dot color, never copy: non-online dims.
-      expect(slot.classList.contains("opacity-60")).toBe(status !== "online");
+      expect(slot.classList.contains("opacity-70")).toBe(status !== "online");
       // Detail lives in sr-only copy and the title tooltip only.
       expect(slot.title).toContain(label);
       const srOnly = slot.querySelector(".sr-only");
@@ -274,13 +274,17 @@ describe("NotebookConnectionIdentity", () => {
     source.next("offline");
   });
 
-  it("uses the flat quiet treatment, never a raised bubble — across the whole subtree", () => {
+  it("uses a borderless quiet treatment, never a raised bubble — across the whole subtree", () => {
     const { container } = renderSlot(cloudCapabilities());
     const slot = slotElement(container);
+    const avatar = container.querySelector<HTMLElement>('[data-slot="notebook-actor-avatar"]');
 
     expect(slot.classList.contains("rounded-md")).toBe(true);
-    expect(slot.classList.contains("border-border/70")).toBe(true);
-    expect(slot.classList.contains("bg-muted/35")).toBe(true);
+    expect(slot.classList.contains("border")).toBe(false);
+    expect(slot.classList.contains("border-border/70")).toBe(false);
+    expect(slot.classList.contains("bg-muted/35")).toBe(false);
+    expect(slot.classList.contains("hover:bg-muted/60")).toBe(true);
+    expect(avatar?.classList.contains("border-0")).toBe(true);
     // The pulled designs' raised-bubble look must never come back. The
     // wrapper must not be a pill (Avatar internals are legitimately
     // rounded-full), and NOTHING in the subtree may carry a shadow.

--- a/src/components/notebook/__tests__/NotebookEditModeButton.test.tsx
+++ b/src/components/notebook/__tests__/NotebookEditModeButton.test.tsx
@@ -126,4 +126,24 @@ describe("NotebookEditModeButton", () => {
 
     expect(onModeChange).toHaveBeenCalledWith("view");
   });
+
+  it("accepts host-specific pending edit copy", () => {
+    const onModeChange = vi.fn();
+
+    render(
+      <NotebookEditModeButton
+        mode="edit"
+        state="requested"
+        variant="segmented"
+        requestedEditLabel="Offline"
+        requestedEditTitle="Offline while the room reconnects"
+        onModeChange={onModeChange}
+      />,
+    );
+
+    expect(screen.getByRole("button", { name: "Offline" })).toHaveAttribute(
+      "title",
+      "Offline while the room reconnects",
+    );
+  });
 });


### PR DESCRIPTION
## Summary

- Move cloud notebook notices into a fixed-height row in the shared shell flow so reconnecting/auth banners push the notebook body instead of overlaying toolbar controls.
- Keep the icon + explanatory notice treatment, but reveal the row with a clipped fade-in inside the reserved height.
- Make the pending edit segment say `Offline` while sustained reconnecting is visible, and remove the bordered wrapper from the connection identity avatar/dot.
- In loopback local mode, inject a local auth target instead of OIDC provider chrome so the toolbar says `Use local auth` rather than `Sign in with Anaconda`.
- Teach the `/n` dashboard and notebook notice sign-in action to use the same local auth target, so local mode does not fall back to disabled OIDC-only copy.

## Verification

- `pnpm --dir apps/notebook-cloud exec node --import tsx --test test/html.test.ts test/viewer-shared-cell-surface.test.ts test/viewer-render-props.test.ts test/viewer-notices.test.ts test/sustained-reconnecting.test.ts`
- `pnpm test:run src/components/notebook/__tests__/NotebookEditModeButton.test.tsx src/components/notebook/__tests__/NotebookConnectionIdentity.test.tsx`
- `pnpm --dir apps/notebook-cloud typecheck`
- `pnpm --dir apps/notebook-cloud build`
- `cargo xtask lint --fix`
- Browser check on `http://localhost:45316/n/01KV0WMBEH64P5SW16AQ3V1ZA8/Browser%20local%20auth%20smoke%203?mode=edit`: measured toolbar, notice, and body as adjacent flow boxes; identity wrapper/avatar borders measured at `0px`.
- Browser check on local view mode: before local auth, sync was denied as anonymous and the page stayed on the loading notice; after clicking `Use local auth`, the room accepted `user:dev:browser-editor`, peer sync completed, and the loading notice disappeared.
- Browser check on `/n`: signed-out local mode shows one enabled `Use local auth` button; after clicking it, the dashboard returns to signed-in state with `Sign out`.
