### PR TITLE
fix(notebook-cloud): clarify local auth dashboard copy

### DIFF
--- a/apps/notebook-cloud/test/viewer-shared-cell-surface.test.ts
+++ b/apps/notebook-cloud/test/viewer-shared-cell-surface.test.ts
@@ -33,6 +33,27 @@ test("cloud notebook dashboard search input has stable form metadata", () => {
   assert.match(dashboardSourceText, /aria-label="Search notebooks"/);
 });
 
+test("cloud notebook list uses local auth copy in local mode", () => {
+  const listSourcePath = new URL("../viewer/notebook-list-view.tsx", import.meta.url);
+  const listSourceText = readFileSync(listSourcePath, "utf8");
+
+  assert.match(listSourceText, /const localMode = Boolean\(authConfig\.localDev\)/);
+  assert.match(listSourceText, /localMode \? "LOCAL MODE" : "NTERACT"/);
+  assert.match(
+    listSourceText,
+    /localMode \? "Open local notebooks\." : "Bring computation to life\."/,
+  );
+  assert.match(
+    listSourceText,
+    /Use local auth to create notebooks and test the live room on this machine\./,
+  );
+  assert.match(listSourceText, /return authConfig\.localDev \? "Local auth" : "Cloud preview"/);
+  assert.match(
+    listSourceText,
+    /return authState\.user \? `Local: \$\{authState\.user\}` : "Local auth"/,
+  );
+});
+
 test("cloud viewer imports desktop notebook code only through public surfaces", () => {
   const viewerDir = new URL("../viewer", import.meta.url);
   const offenders: string[] = [];

--- a/apps/notebook-cloud/viewer/notebook-list-view.tsx
+++ b/apps/notebook-cloud/viewer/notebook-list-view.tsx
@@ -290,7 +290,7 @@ export function CloudNotebookListView({ authConfig }: { authConfig: CloudViewerA
     refreshAuthState();
   };
 
-  const headerDetail = cloudNotebookListHeaderDetail(authState, hasAppSession);
+  const headerDetail = cloudNotebookListHeaderDetail(authState, hasAppSession, authConfig);
 
   return (
     <main className="cloud-notebook-list-page">
@@ -419,15 +419,22 @@ function CloudNotebookSignedOutPanel({
   authConfig: CloudViewerAuthConfig;
   authState: CloudPrototypeAuthState;
 }) {
+  const localMode = Boolean(authConfig.localDev);
   return (
     <div className="cloud-notebook-signed-out" aria-labelledby="cloud-notebook-signed-out-title">
       <div className="cloud-notebook-signed-out-copy">
         <div className="cloud-notebook-signed-out-kicker">
           <Sparkles aria-hidden="true" />
-          NTERACT
+          {localMode ? "LOCAL MODE" : "NTERACT"}
         </div>
-        <h2 id="cloud-notebook-signed-out-title">Bring computation to life.</h2>
-        <p>Sign in to create live notebooks, share work with colleagues, and attach compute.</p>
+        <h2 id="cloud-notebook-signed-out-title">
+          {localMode ? "Open local notebooks." : "Bring computation to life."}
+        </h2>
+        <p>
+          {localMode
+            ? "Use local auth to create notebooks and test the live room on this machine."
+            : "Sign in to create live notebooks, share work with colleagues, and attach compute."}
+        </p>
       </div>
       <div className="cloud-notebook-signed-out-actions">
         <CloudNotebookSignInButton authConfig={authConfig} authState={authState} />
@@ -443,12 +450,16 @@ function CloudNotebookSignedOutPanel({
 function cloudNotebookListHeaderDetail(
   authState: CloudPrototypeAuthState,
   hasAppSession: boolean,
+  authConfig: CloudViewerAuthConfig,
 ): string {
   if (authState.mode === "oidc_expired" && !hasAppSession) {
     return "Session expired";
   }
   if (authState.mode === "anonymous" && !hasAppSession) {
-    return "Cloud preview";
+    return authConfig.localDev ? "Local auth" : "Cloud preview";
+  }
+  if (authState.mode === "dev") {
+    return authState.user ? `Local: ${authState.user}` : "Local auth";
   }
   const firstName = cloudNotebookListFirstName(authState);
   return firstName ? `by ${firstName}` : "Signed in";


### PR DESCRIPTION
## Summary

- Make the `/n` signed-out dashboard use local-mode copy when a loopback local auth target is present.
- Show `Local: <user>` in the signed-in dashboard header for dev/local auth instead of the generic `Signed in`.
- Preserve hosted/OIDC dashboard copy when local auth is absent.

## Verification

- `pnpm --dir apps/notebook-cloud exec node --import tsx --test test/viewer-shared-cell-surface.test.ts test/viewer-render-props.test.ts test/html.test.ts`
- `pnpm --dir apps/notebook-cloud typecheck`
- `pnpm --dir apps/notebook-cloud build`
- `cargo xtask lint --fix`
- Browser check on `http://localhost:45316/n`: signed-in local auth shows `Local: browser-editor`; signed-out local auth shows `LOCAL MODE`, `Open local notebooks.`, and an enabled `Use local auth` button; local auth was restored after the check.
