### PR TITLE
feat(notebook-cloud): edit notebook titles from viewer

### DIFF
--- a/apps/notebook-cloud/test/cloud-notebook-title-state.test.ts
+++ b/apps/notebook-cloud/test/cloud-notebook-title-state.test.ts
@@ -1,0 +1,85 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+import {
+  cloudNotebookCatalogResponseTitle,
+  cloudNotebookDocumentTitle,
+  cloudNotebookTitleDisplay,
+  cloudNotebookUrlAfterRename,
+  type CloudNotebookRouteTitle,
+} from "../viewer/cloud-notebook-title-state";
+
+const fallbackTitle: CloudNotebookRouteTitle = {
+  label: "Route Fallback",
+  detail: null,
+  title: "Route Fallback",
+};
+
+describe("cloud notebook title state", () => {
+  it("uses the route fallback until authenticated catalog title data is loaded", () => {
+    assert.deepEqual(cloudNotebookTitleDisplay(undefined, fallbackTitle), fallbackTitle);
+  });
+
+  it("projects loaded catalog titles and untitled notebooks for viewer chrome", () => {
+    assert.deepEqual(cloudNotebookTitleDisplay("  Research Notes  ", fallbackTitle), {
+      label: "Research Notes",
+      detail: null,
+      title: "Research Notes",
+    });
+    assert.equal(cloudNotebookTitleDisplay(null, fallbackTitle).label, "Untitled notebook");
+    assert.equal(cloudNotebookTitleDisplay("   ", fallbackTitle).title, "Untitled notebook");
+  });
+
+  it("keeps the browser document title in the notebook title namespace", () => {
+    assert.equal(cloudNotebookDocumentTitle("Research Notes"), "nteract notebook: Research Notes");
+    assert.equal(cloudNotebookDocumentTitle("   "), "nteract notebook: Untitled notebook");
+  });
+
+  it("reads the catalog title only from the requested notebook row", () => {
+    assert.equal(
+      cloudNotebookCatalogResponseTitle(
+        {
+          notebook: {
+            id: "demo",
+            title: "Demo",
+          },
+        },
+        "demo",
+      ),
+      "Demo",
+    );
+
+    assert.throws(
+      () =>
+        cloudNotebookCatalogResponseTitle(
+          {
+            notebook: {
+              id: "other",
+              title: "Wrong row",
+            },
+          },
+          "demo",
+        ),
+      /response shape was invalid/,
+    );
+  });
+
+  it("updates the vanity path after rename while preserving mode and hash", () => {
+    assert.equal(
+      cloudNotebookUrlAfterRename(
+        "https://preview.runt.run/n/abc/old-title?mode=edit#intro",
+        "https://worker.example/n/abc/New%20Title",
+      ),
+      "https://preview.runt.run/n/abc/New%20Title?mode=edit#intro",
+    );
+  });
+
+  it("ignores non-notebook rename URLs", () => {
+    assert.equal(
+      cloudNotebookUrlAfterRename(
+        "https://preview.runt.run/n/abc/old-title?mode=view",
+        "https://worker.example/dashboard",
+      ),
+      "https://preview.runt.run/n/abc/old-title?mode=view",
+    );
+  });
+});

--- a/apps/notebook-cloud/test/viewer-render-props.test.ts
+++ b/apps/notebook-cloud/test/viewer-render-props.test.ts
@@ -157,13 +157,19 @@ test("cloud viewer routes notebook header controls through the shared shell chro
     /<NotebookDocumentToolbar[\s\S]*frameClassName="z-20"[\s\S]*headerClassName="cloud-room-toolbar"[\s\S]*commandToolbar=\{\{[\s\S]*addAfterCellId: toolbarAddAfterCellId/,
   );
   assert.match(sourceText, /<NotebookDocumentToolbar[\s\S]*capabilities=\{shellCapabilities\}/);
-  assert.match(sourceText, /presence=\{<CloudNotebookTitle \/>/);
+  assert.match(
+    sourceText,
+    /presence=\{[\s\S]*<CloudNotebookTitle[\s\S]*title=\{notebookTitle\}[\s\S]*canRename=\{catalogAccessResolved && catalogGrantsDocumentEdit\}[\s\S]*onRename=\{saveCloudNotebookTitle\}/,
+  );
   assert.match(
     sourceText,
     /import \{ CloudNotebookTitle, cloudNotebookRouteTitle \} from "\.\/cloud-notebook-title";/,
   );
+  assert.match(sourceText, /cloudNotebookTitleDisplay,/);
+  assert.match(sourceText, /cloudNotebookUrlAfterRename,/);
   assert.match(titleSourceText, /className="cloud-notebook-home-link"/);
   assert.match(titleSourceText, /<House aria-hidden="true" \/>/);
+  assert.match(titleSourceText, /<PencilLine aria-hidden="true" \/>/);
   assert.doesNotMatch(titleSourceText, /cloud-notebook-logo/);
   assert.doesNotMatch(sourceText, /function shouldShowCloudNotebookCommandToolbar/);
   assert.doesNotMatch(sourceText, /toolbarClassName="cloud-report-toolbar"/);

--- a/apps/notebook-cloud/viewer/cloud-notebook-title-state.ts
+++ b/apps/notebook-cloud/viewer/cloud-notebook-title-state.ts
@@ -1,0 +1,68 @@
+export interface CloudNotebookRouteTitle {
+  label: string;
+  detail: string | null;
+  title: string;
+}
+
+export interface CloudNotebookTitleDisplay {
+  label: string;
+  detail: string | null;
+  title: string;
+}
+
+export interface CloudNotebookCatalogResponse {
+  notebook?: {
+    id?: unknown;
+    title?: unknown;
+  };
+}
+
+const UNTITLED_NOTEBOOK_LABEL = "Untitled notebook";
+
+export function cloudNotebookTitleDisplay(
+  catalogTitle: string | null | undefined,
+  fallback: CloudNotebookRouteTitle,
+): CloudNotebookTitleDisplay {
+  if (catalogTitle === undefined) {
+    return fallback;
+  }
+
+  const label = catalogTitle?.trim() || UNTITLED_NOTEBOOK_LABEL;
+  return {
+    label,
+    detail: null,
+    title: label,
+  };
+}
+
+export function cloudNotebookDocumentTitle(displayTitle: string): string {
+  return `nteract notebook: ${displayTitle.trim() || UNTITLED_NOTEBOOK_LABEL}`;
+}
+
+export function cloudNotebookCatalogResponseTitle(
+  body: CloudNotebookCatalogResponse,
+  notebookId: string,
+): string | null {
+  const notebook = body.notebook;
+  if (!notebook || notebook.id !== notebookId) {
+    throw new Error("Unable to load notebook title: response shape was invalid");
+  }
+  if (notebook.title === null || typeof notebook.title === "string") {
+    return notebook.title;
+  }
+  throw new Error("Unable to load notebook title: response shape was invalid");
+}
+
+export function cloudNotebookUrlAfterRename(currentHref: string, viewerUrl: string): string {
+  try {
+    const currentUrl = new URL(currentHref);
+    const renamedUrl = new URL(viewerUrl, currentUrl.origin);
+    if (!renamedUrl.pathname.startsWith("/n/")) {
+      return currentHref;
+    }
+    currentUrl.pathname = renamedUrl.pathname;
+    return currentUrl.href;
+  } catch {
+    return currentHref;
+  }
+}

--- a/apps/notebook-cloud/viewer/cloud-notebook-title.tsx
+++ b/apps/notebook-cloud/viewer/cloud-notebook-title.tsx
@@ -1,8 +1,53 @@
-import { House } from "lucide-react";
+import { useEffect, useState, type FormEvent } from "react";
+import { Check, House, Loader2, PencilLine, X } from "lucide-react";
 import { notebookRouteSegmentTitle } from "../src/notebook-route-title";
+import type { CloudNotebookTitleDisplay } from "./cloud-notebook-title-state";
 
-export function CloudNotebookTitle() {
-  const title = cloudNotebookRouteTitle();
+export function CloudNotebookTitle({
+  canRename = false,
+  renameError = null,
+  renameSaving = false,
+  renameTitle,
+  title,
+  onRename,
+}: {
+  canRename?: boolean;
+  renameError?: string | null;
+  renameSaving?: boolean;
+  renameTitle: string;
+  title: CloudNotebookTitleDisplay;
+  onRename?: (title: string) => boolean | Promise<boolean>;
+}) {
+  const [editing, setEditing] = useState(false);
+  const [draftTitle, setDraftTitle] = useState(renameTitle);
+
+  useEffect(() => {
+    if (!editing) {
+      setDraftTitle(renameTitle);
+    }
+  }, [editing, renameTitle]);
+
+  const saveRename = (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    if (!onRename || renameSaving) {
+      return;
+    }
+    void Promise.resolve(onRename(draftTitle))
+      .then((saved) => {
+        if (saved) {
+          setEditing(false);
+        }
+      })
+      .catch(() => {});
+  };
+
+  const cancelRename = () => {
+    if (renameSaving) {
+      return;
+    }
+    setDraftTitle(renameTitle);
+    setEditing(false);
+  };
 
   return (
     <div className="cloud-notebook-title-group">
@@ -14,19 +59,72 @@ export function CloudNotebookTitle() {
       >
         <House aria-hidden="true" />
       </a>
-      <div className="cloud-notebook-title" title={title.title}>
-        <span>{title.label}</span>
-        {title.detail ? <small>{title.detail}</small> : null}
+      <div className="cloud-notebook-title" title={renameError ?? title.title}>
+        {editing ? (
+          <form className="cloud-notebook-title-form" onSubmit={saveRename}>
+            <input
+              aria-label="Notebook title"
+              autoFocus
+              disabled={renameSaving}
+              maxLength={160}
+              name="notebook-title"
+              placeholder="Untitled notebook"
+              type="text"
+              value={draftTitle}
+              onChange={(event) => setDraftTitle(event.currentTarget.value)}
+            />
+            <button
+              type="submit"
+              disabled={renameSaving}
+              title="Save title"
+              aria-label="Save title"
+            >
+              {renameSaving ? (
+                <Loader2 className="cloud-notebook-title-spinner" aria-hidden="true" />
+              ) : (
+                <Check aria-hidden="true" />
+              )}
+            </button>
+            <button
+              type="button"
+              disabled={renameSaving}
+              title="Cancel rename"
+              aria-label="Cancel rename"
+              onClick={cancelRename}
+            >
+              <X aria-hidden="true" />
+            </button>
+          </form>
+        ) : (
+          <div className="cloud-notebook-title-static">
+            <span>{title.label}</span>
+            {canRename && onRename ? (
+              <button
+                type="button"
+                className="cloud-notebook-title-edit-button"
+                disabled={renameSaving}
+                title="Rename notebook"
+                aria-label={`Rename ${title.label}`}
+                onClick={() => setEditing(true)}
+              >
+                <PencilLine aria-hidden="true" />
+              </button>
+            ) : null}
+          </div>
+        )}
+        {renameError ? (
+          <small className="cloud-notebook-title-status" role="status">
+            {renameError}
+          </small>
+        ) : title.detail ? (
+          <small>{title.detail}</small>
+        ) : null}
       </div>
     </div>
   );
 }
 
-export function cloudNotebookRouteTitle(): {
-  label: string;
-  detail: string | null;
-  title: string;
-} {
+export function cloudNotebookRouteTitle(): CloudNotebookTitleDisplay {
   const pathParts = window.location.pathname.split("/").filter(Boolean);
   const routeSlug = pathParts[0] === "n" ? pathParts[2] : null;
   const routeTitle = notebookRouteSegmentTitle(routeSlug);

--- a/apps/notebook-cloud/viewer/index.css
+++ b/apps/notebook-cloud/viewer/index.css
@@ -153,6 +153,15 @@ body {
   height: 1.125rem;
 }
 
+.cloud-notebook-title-static,
+.cloud-notebook-title-form {
+  display: flex;
+  min-width: 0;
+  max-width: 100%;
+  align-items: center;
+  gap: 0.375rem;
+}
+
 .cloud-notebook-title span,
 .cloud-notebook-title small {
   min-width: 0;
@@ -174,6 +183,67 @@ body {
   font-size: 0.6875rem;
   font-weight: 500;
   line-height: 1.2;
+}
+
+.cloud-notebook-title-status {
+  color: color-mix(in srgb, var(--destructive) 72%, var(--foreground) 28%);
+}
+
+.cloud-notebook-title-edit-button,
+.cloud-notebook-title-form button {
+  display: inline-flex;
+  flex: 0 0 auto;
+  align-items: center;
+  justify-content: center;
+  width: 1.625rem;
+  height: 1.625rem;
+  border: 0;
+  border-radius: 6px;
+  color: color-mix(in srgb, var(--foreground) 64%, transparent);
+  background: transparent;
+}
+
+.cloud-notebook-title-edit-button:hover,
+.cloud-notebook-title-form button:hover {
+  color: var(--foreground);
+  background: color-mix(in srgb, var(--background) 86%, var(--foreground) 10%);
+}
+
+.cloud-notebook-title-edit-button:focus-visible,
+.cloud-notebook-title-form button:focus-visible,
+.cloud-notebook-title-form input:focus-visible {
+  outline: 2px solid color-mix(in srgb, var(--ring) 70%, transparent);
+  outline-offset: 2px;
+}
+
+.cloud-notebook-title-edit-button:disabled,
+.cloud-notebook-title-form button:disabled {
+  cursor: default;
+  opacity: 0.55;
+}
+
+.cloud-notebook-title-edit-button svg,
+.cloud-notebook-title-form button svg {
+  width: 0.9375rem;
+  height: 0.9375rem;
+}
+
+.cloud-notebook-title-form input {
+  min-width: 7rem;
+  width: min(18rem, 32vw);
+  max-width: 100%;
+  height: 1.875rem;
+  border: 1px solid color-mix(in srgb, var(--foreground) 18%, transparent);
+  border-radius: 6px;
+  padding: 0 0.5rem;
+  color: var(--foreground);
+  background: color-mix(in srgb, var(--background) 94%, var(--foreground) 6%);
+  font-size: 0.875rem;
+  font-weight: 600;
+}
+
+.cloud-notebook-title-spinner {
+  animation: cloud-status-spin 1s linear infinite;
 }
 
 .cloud-presence-stack {
@@ -300,6 +370,15 @@ body {
     max-width: 100%;
   }
 
+  .cloud-notebook-title-group {
+    gap: 0.5rem;
+  }
+
+  .cloud-notebook-title-form input {
+    min-width: 6rem;
+    width: min(12rem, 28vw);
+  }
+
   .cloud-notebook-title small {
     display: none;
   }
@@ -313,6 +392,25 @@ body {
 }
 
 @media (max-width: 520px) {
+  .cloud-notebook-title-group {
+    gap: 0.375rem;
+  }
+
+  .cloud-notebook-title-form {
+    gap: 0.25rem;
+  }
+
+  .cloud-notebook-title-form input {
+    min-width: 5.5rem;
+    width: min(9rem, 34vw);
+  }
+
+  .cloud-notebook-title-edit-button,
+  .cloud-notebook-title-form button {
+    width: 1.5rem;
+    height: 1.5rem;
+  }
+
   .cloud-room-toolbar [data-slot="notebook-document-header-controls"] {
     gap: 0.125rem 0.375rem;
   }

--- a/apps/notebook-cloud/viewer/notebook-viewer.tsx
+++ b/apps/notebook-cloud/viewer/notebook-viewer.tsx
@@ -127,7 +127,11 @@ import {
   cloudNotebookModeFromSearch,
   replaceCloudNotebookModeInCurrentUrl,
 } from "./cloud-notebook-mode";
-import type { CloudViewerAuthConfig, ViewerRuntime } from "./cloud-viewer-types";
+import type {
+  CloudNotebookUpdateResponse,
+  CloudViewerAuthConfig,
+  ViewerRuntime,
+} from "./cloud-viewer-types";
 import {
   useCloudAppSessionBridge,
   useCloudAppSessionStatus,
@@ -137,6 +141,13 @@ import { useCloudShellCapabilities } from "./use-cloud-shell-capabilities";
 import { useCloudWorkstationManager } from "./use-cloud-workstations";
 import { CloudNotebookEditModeButton, CloudNotebookSignInButton } from "./cloud-auth-controls";
 import { CloudNotebookTitle, cloudNotebookRouteTitle } from "./cloud-notebook-title";
+import {
+  cloudNotebookCatalogResponseTitle,
+  cloudNotebookDocumentTitle,
+  cloudNotebookTitleDisplay,
+  cloudNotebookUrlAfterRename,
+  type CloudNotebookCatalogResponse,
+} from "./cloud-notebook-title-state";
 import { CloudPresenceStatus } from "./cloud-presence-status";
 
 const cloudNotebookClientLogger: SyncEngineLogger = {
@@ -190,6 +201,15 @@ export function NotebookViewer({
 }) {
   const { config } = runtime;
   const routeTitle = useMemo(() => cloudNotebookRouteTitle(), []);
+  const [catalogNotebookTitle, setCatalogNotebookTitle] = useState<string | null | undefined>(
+    undefined,
+  );
+  const [notebookTitleSaving, setNotebookTitleSaving] = useState(false);
+  const [notebookTitleError, setNotebookTitleError] = useState<string | null>(null);
+  const notebookTitle = useMemo(
+    () => cloudNotebookTitleDisplay(catalogNotebookTitle, routeTitle),
+    [catalogNotebookTitle, routeTitle],
+  );
   const loadingPolicy = useMemo(() => cloudViewerLoadingPolicy(config), [config.headsHash]);
   const { resolvedTheme } = useTheme(CLOUD_VIEWER_THEME_STORAGE_KEY);
   const { store: widgetStore } = useWidgetStoreRequired();
@@ -288,6 +308,56 @@ export function NotebookViewer({
       }),
     [browserApiAuthState, config.notebookId],
   );
+  useEffect(() => {
+    if (!canUseAuthenticatedCloudApi) {
+      setCatalogNotebookTitle(undefined);
+      setNotebookTitleError(null);
+      return;
+    }
+
+    const controller = new AbortController();
+    let cancelled = false;
+    void (async () => {
+      try {
+        const response = await fetchWithCloudPrototypeAuth(
+          config.catalogEndpoint,
+          {
+            cache: "no-store",
+            headers: { Accept: "application/json" },
+            signal: controller.signal,
+          },
+          browserApiAuthState,
+        );
+        if (!response.ok) {
+          throw await cloudResponseError(response, "Unable to load notebook title");
+        }
+        const body = (await response.json()) as CloudNotebookCatalogResponse;
+        const title = cloudNotebookCatalogResponseTitle(body, config.notebookId);
+        if (!cancelled) {
+          setCatalogNotebookTitle(title);
+          setNotebookTitleError(null);
+        }
+      } catch (error) {
+        if (
+          cancelled ||
+          (typeof DOMException !== "undefined" &&
+            error instanceof DOMException &&
+            error.name === "AbortError")
+        ) {
+          return;
+        }
+        console.warn("[notebook-cloud] unable to load notebook title", error);
+        if (!cancelled) {
+          setCatalogNotebookTitle(undefined);
+        }
+      }
+    })();
+
+    return () => {
+      cancelled = true;
+      controller.abort();
+    };
+  }, [browserApiAuthState, canUseAuthenticatedCloudApi, config.catalogEndpoint, config.notebookId]);
   const catalogLiveRoomPolicy = useMemo(
     () =>
       cloudNotebookLiveRoomConnectionPolicy({
@@ -448,6 +518,9 @@ export function NotebookViewer({
     applyDocumentTheme(resolvedTheme);
   }, [resolvedTheme]);
   useEffect(() => {
+    document.title = cloudNotebookDocumentTitle(notebookTitle.title);
+  }, [notebookTitle.title]);
+  useEffect(() => {
     replaceCloudNotebookModeInCurrentUrl(selectedInteractionMode);
   }, [selectedInteractionMode]);
 
@@ -543,6 +616,61 @@ export function NotebookViewer({
     };
   }, [canUseAuthenticatedCloudApi, catalogAccessLoader]);
   const catalogGrantsDocumentEdit = cloudNotebookScopeCanEditDocument(catalogAccessScope);
+  const saveCloudNotebookTitle = useCallback(
+    async (nextTitle: string): Promise<boolean> => {
+      if (!canUseAuthenticatedCloudApi || !catalogGrantsDocumentEdit || notebookTitleSaving) {
+        return false;
+      }
+
+      try {
+        setNotebookTitleSaving(true);
+        setNotebookTitleError(null);
+        const response = await fetchWithCloudPrototypeAuth(
+          config.catalogEndpoint,
+          {
+            method: "PATCH",
+            headers: {
+              Accept: "application/json",
+              "Content-Type": "application/json",
+            },
+            body: JSON.stringify({ title: nextTitle.trim() || null }),
+          },
+          {
+            ...browserApiAuthState,
+            requestedScope: "editor",
+          },
+        );
+        if (!response.ok) {
+          throw await cloudResponseError(response, "Unable to rename notebook");
+        }
+        const body = (await response.json()) as CloudNotebookUpdateResponse;
+        if (body.ok !== true || body.notebook_id !== config.notebookId) {
+          throw new Error("Unable to rename notebook: response shape was invalid");
+        }
+        setCatalogNotebookTitle(body.title ?? null);
+        if (body.viewer_url) {
+          const nextHref = cloudNotebookUrlAfterRename(window.location.href, body.viewer_url);
+          if (nextHref !== window.location.href) {
+            window.history.replaceState(window.history.state, "", nextHref);
+          }
+        }
+        return true;
+      } catch (error) {
+        setNotebookTitleError(error instanceof Error ? error.message : String(error));
+        return false;
+      } finally {
+        setNotebookTitleSaving(false);
+      }
+    },
+    [
+      browserApiAuthState,
+      canUseAuthenticatedCloudApi,
+      catalogGrantsDocumentEdit,
+      config.catalogEndpoint,
+      config.notebookId,
+      notebookTitleSaving,
+    ],
+  );
   const cloudRuntimeConnectedForStatus = workstationAttachment
     ? workstationAttachmentIsConnected(workstationAttachment)
     : runtimePeerAvailable;
@@ -1156,7 +1284,16 @@ export function NotebookViewer({
       capabilities={shellCapabilities}
       frameClassName="z-20"
       headerClassName="cloud-room-toolbar"
-      presence={<CloudNotebookTitle />}
+      presence={
+        <CloudNotebookTitle
+          title={notebookTitle}
+          renameTitle={catalogNotebookTitle?.trim() ?? ""}
+          canRename={catalogAccessResolved && catalogGrantsDocumentEdit}
+          renameSaving={notebookTitleSaving}
+          renameError={notebookTitleError}
+          onRename={saveCloudNotebookTitle}
+        />
+      }
       utilityControls={
         notebookHeaderChrome.showPresenceStatus ? (
           <CloudPresenceStatus connectionError={connectionError} store={presenceStore} />
@@ -1313,7 +1450,7 @@ export function NotebookViewer({
         rail={rail}
         stageLabel="Hosted notebook"
       >
-        <h1 className="sr-only">{routeTitle.title}</h1>
+        <h1 className="sr-only">{notebookTitle.title}</h1>
 
         <PresenceValueProvider value={cloudPresenceContext}>
           <CrdtBridgeProvider


### PR DESCRIPTION
## Summary

- load the authenticated catalog title on notebook viewer pages without exposing private titles in server-rendered shell metadata
- add an inline title rename control for users with edit-capable catalog access
- PATCH the existing notebook metadata endpoint, update the browser document title, and preserve query/hash while replacing the vanity route after rename
- cover title projection, catalog response validation, and rename URL behavior with focused tests

## Verification

- `pnpm --dir apps/notebook-cloud exec node --import tsx --test test/cloud-notebook-title-state.test.ts test/viewer-render-props.test.ts`
- `pnpm --dir apps/notebook-cloud exec tsc -p tsconfig.json --noEmit`
- `cargo xtask lint --fix`
- `pnpm --dir apps/notebook-cloud run build:viewer`
- local Wrangler visual pass via `pnpm --dir apps/notebook-cloud dev:browser --skip-build --next /n --scope owner --user quill`
  - created a local notebook, opened the viewer, renamed from the toolbar, and confirmed document title + vanity URL updated while preserving mode
  - checked desktop and 390px mobile toolbar screenshots for overlap
  - reloaded rebuilt assets and confirmed the title input no longer emits Chrome's missing `id`/`name` form-field issue

## Notes

Current local console still reports renderer sidecar 404 fallback noise in this loopback setup; the notebook viewer itself loads and the title control works.
