### PR TITLE
fix(notebook-cloud): show local sign-in required notice

### DIFF
--- a/apps/notebook-cloud/test/viewer-notices.test.ts
+++ b/apps/notebook-cloud/test/viewer-notices.test.ts
@@ -190,6 +190,38 @@ test("cloud notebook notices distinguish sign-in and access diagnostics from soc
   assert.doesNotMatch(noAccessHtml, /Live room unavailable/);
 });
 
+test("cloud notebook notices replace signed-out local room retries with sign-in required", () => {
+  assert.equal(
+    cloudNotebookHasNotices({
+      authState: authState("anonymous"),
+      authRenewal: { kind: "idle", message: null },
+      connectionError: "cloud sync socket failed",
+      signInRequired: true,
+      status: { kind: "loading", message: "Connecting to live notebook room..." },
+    }),
+    true,
+  );
+
+  const html = renderToStaticMarkup(
+    React.createElement(CloudNotebookNotices, {
+      authState: authState("anonymous"),
+      authRenewal: { kind: "idle", message: null },
+      connectionError: "cloud sync socket failed",
+      signInRequired: true,
+      status: { kind: "loading", message: "Connecting to live notebook room..." },
+      onResetAuth: () => {},
+      onSignInAgain: () => {},
+    }),
+  );
+
+  assert.match(html, /Sign in required/);
+  assert.match(html, /Sign in again to open the live notebook room/);
+  assert.match(html, /Sign in again/);
+  assert.doesNotMatch(html, /Loading notebook/);
+  assert.doesNotMatch(html, /Connecting to live notebook room/);
+  assert.doesNotMatch(html, /cloud sync socket failed/);
+});
+
 test("cloud notebook notices let access diagnostics own private-route loading", () => {
   assert.equal(
     cloudNotebookHasNotices({

--- a/apps/notebook-cloud/test/viewer-render-props.test.ts
+++ b/apps/notebook-cloud/test/viewer-render-props.test.ts
@@ -333,9 +333,17 @@ test("cloud viewer presents live-room failures as one host notice", () => {
     sourceText,
     /notebookCellIds\.length > 0 \|\|[\s\S]*!\s*connectionError && snapshotResolvedRef\.current && status\.kind === "ready"/,
   );
+  assert.match(sourceText, /const signedOutNotebookSignInRequired =/);
+  assert.match(
+    sourceText,
+    /Boolean\(authConfig\.localDev \|\| authConfig\.oidc\)[\s\S]*authState\.mode === "anonymous"[\s\S]*!isPublicViewer[\s\S]*!notebookHasReadableSnapshot[\s\S]*isTransportReconnectError\(connectionError\)/,
+  );
+  assert.match(sourceText, /signInRequired: signedOutNotebookSignInRequired/);
+  assert.match(sourceText, /signInRequired=\{signedOutNotebookSignInRequired\}/);
   assert.match(noticesText, /const connectionNotice = connectionError/);
   assert.match(noticesText, /cloudConnectionNoticeDisplay\(connectionError, hasReadableSnapshot\)/);
   assert.match(noticesText, /const shouldShowStatusNotice =/);
+  assert.match(noticesText, /!signInRequired &&/);
   assert.match(noticesText, /isStatusDerivedFromConnectionError\(status, connectionError\)/);
   assert.match(noticesText, /function isStatusDerivedFromConnectionError/);
   assert.match(noticesText, /function cloudConnectionNoticeDisplay/);

--- a/apps/notebook-cloud/viewer/notebook-viewer.tsx
+++ b/apps/notebook-cloud/viewer/notebook-viewer.tsx
@@ -86,6 +86,7 @@ import type { ResolvedCell } from "./render-resolution";
 import {
   CloudNotebookNotices,
   cloudNotebookHasNotices,
+  isTransportReconnectError,
   shouldShowCloudAnonymousViewerAuthNotice,
 } from "./notices";
 import {
@@ -1226,6 +1227,15 @@ export function NotebookViewer({
   const notebookHasReadableSnapshot =
     notebookCellIds.length > 0 ||
     (!connectionError && snapshotResolvedRef.current && status.kind === "ready");
+  const signedOutNotebookSignInRequired =
+    Boolean(authConfig.localDev || authConfig.oidc) &&
+    appSessionStatus.status !== "loading" &&
+    !hasAppSession &&
+    authState.mode === "anonymous" &&
+    !isPublicViewer &&
+    !notebookHasReadableSnapshot &&
+    status.kind === "loading" &&
+    Boolean(connectionError && isTransportReconnectError(connectionError));
   const notebookViewSurface = projectCloudNotebookViewSurface({
     bodyAccessBlocked: notebookBodyAccessBlocked,
     cellCount: notebookCellIds.length,
@@ -1268,6 +1278,7 @@ export function NotebookViewer({
     hasAppSession,
     isPublicViewer,
     hasReadableSnapshot: notebookHasReadableSnapshot,
+    signInRequired: signedOutNotebookSignInRequired,
     offlineMergeNotice,
     rendererAssetError,
     sustainedReconnecting,
@@ -1283,6 +1294,7 @@ export function NotebookViewer({
       hasAppSession={hasAppSession}
       isPublicViewer={isPublicViewer}
       hasReadableSnapshot={notebookHasReadableSnapshot}
+      signInRequired={signedOutNotebookSignInRequired}
       offlineMergeNotice={offlineMergeNotice}
       rendererAssetError={rendererAssetError}
       sustainedReconnecting={sustainedReconnecting}

--- a/apps/notebook-cloud/viewer/notices.tsx
+++ b/apps/notebook-cloud/viewer/notices.tsx
@@ -30,6 +30,13 @@ export interface CloudNotebookNoticesProps {
   isPublicViewer?: boolean;
   hasReadableSnapshot?: boolean;
   /**
+   * The route has no authenticated browser identity and the live-room join is
+   * retrying without a readable public snapshot. This is different from stale
+   * or expired auth: the browser needs to start a sign-in flow before the room
+   * can become readable.
+   */
+  signInRequired?: boolean;
+  /**
    * The live-room status has been "reconnecting" past the debounce window
    * (`useSustainedReconnecting`). Renders the single quiet reconnect line;
    * transport-loss `connectionError` strings are routed here instead of
@@ -116,6 +123,7 @@ export function cloudNotebookHasNotices({
   hasAppSession = false,
   isPublicViewer = false,
   hasReadableSnapshot = false,
+  signInRequired = false,
   offlineMergeNotice = null,
   rendererAssetError = null,
   sustainedReconnecting = false,
@@ -130,6 +138,7 @@ export function cloudNotebookHasNotices({
     status.kind !== "ready" &&
     !(status.kind === "empty" && hasReadableSnapshot) &&
     !(connectionNotice && status.kind === "loading") &&
+    !signInRequired &&
     !isStatusDerivedFromConnectionError(status, connectionError);
 
   const shouldShowAnonymousViewerAuthNotice = shouldShowCloudAnonymousViewerAuthNotice({
@@ -137,18 +146,23 @@ export function cloudNotebookHasNotices({
     hasAppSession,
     isPublicViewer,
   });
+  const shouldShowSignInRequiredNotice =
+    signInRequired && !shouldShowAnonymousViewerAuthNotice && !hasAppSession;
   const shouldShowAuthNotice =
     !shouldShowAnonymousViewerAuthNotice &&
+    !shouldShowSignInRequiredNotice &&
     !hasAppSession &&
     (authState.mode === "invalid" || authState.mode === "oidc_expired");
   const shouldShowAuthRenewalNotice =
     !shouldShowAnonymousViewerAuthNotice &&
+    !shouldShowSignInRequiredNotice &&
     !shouldShowAuthNotice &&
     !hasAppSession &&
     authRenewal.kind !== "idle";
 
   return (
     shouldShowAnonymousViewerAuthNotice ||
+    shouldShowSignInRequiredNotice ||
     shouldShowAuthNotice ||
     shouldShowAuthRenewalNotice ||
     sustainedReconnecting ||
@@ -168,6 +182,7 @@ export function CloudNotebookNotices({
   hasAppSession = false,
   isPublicViewer = false,
   hasReadableSnapshot = false,
+  signInRequired = false,
   offlineMergeNotice = null,
   rendererAssetError = null,
   sustainedReconnecting = false,
@@ -187,6 +202,7 @@ export function CloudNotebookNotices({
       hasAppSession,
       isPublicViewer,
       hasReadableSnapshot,
+      signInRequired,
       offlineMergeNotice,
       rendererAssetError,
       sustainedReconnecting,
@@ -205,18 +221,23 @@ export function CloudNotebookNotices({
     status.kind !== "ready" &&
     !(status.kind === "empty" && hasReadableSnapshot) &&
     !(connectionNotice && status.kind === "loading") &&
+    !signInRequired &&
     !isStatusDerivedFromConnectionError(status, connectionError);
   const shouldShowAnonymousViewerAuthNotice = shouldShowCloudAnonymousViewerAuthNotice({
     authState,
     hasAppSession,
     isPublicViewer,
   });
+  const shouldShowSignInRequiredNotice =
+    signInRequired && !shouldShowAnonymousViewerAuthNotice && !hasAppSession;
   const shouldShowAuthNotice =
     !shouldShowAnonymousViewerAuthNotice &&
+    !shouldShowSignInRequiredNotice &&
     !hasAppSession &&
     (authState.mode === "invalid" || authState.mode === "oidc_expired");
   const shouldShowAuthRenewalNotice =
     !shouldShowAnonymousViewerAuthNotice &&
+    !shouldShowSignInRequiredNotice &&
     !shouldShowAuthNotice &&
     !hasAppSession &&
     authRenewal.kind !== "idle";
@@ -236,6 +257,21 @@ export function CloudNotebookNotices({
         >
           This public notebook is open read-only. Use your account to edit or access private
           features.
+        </NotebookNotice>
+      ) : null}
+
+      {shouldShowSignInRequiredNotice ? (
+        <NotebookNotice
+          tone="warning"
+          icon={<LogIn className="h-4 w-4" />}
+          title="Sign in required."
+          actions={
+            onSignInAgain ? (
+              <SignInNoticeAction onSignInAgain={onSignInAgain}>Sign in again</SignInNoticeAction>
+            ) : null
+          }
+        >
+          Sign in again to open the live notebook room.
         </NotebookNotice>
       ) : null}
 


### PR DESCRIPTION
## Summary

- Show a `Sign in required` notice when a signed-out local/OIDC notebook route is stuck retrying the live room without a readable snapshot.
- Keep public anonymous viewers and stale/expired auth notices on their existing paths.
- Suppress the generic `Loading notebook` notice for this auth-required state so local mode does not look like a missing service.

## Verification

- `pnpm --dir apps/notebook-cloud exec node --import tsx --test test/viewer-notices.test.ts test/viewer-render-props.test.ts test/viewer-shared-cell-surface.test.ts test/html.test.ts`
- `pnpm --dir apps/notebook-cloud typecheck`
- `pnpm --dir apps/notebook-cloud build`
- `cargo xtask lint --fix`
- Browser check on `http://localhost:45316/n/01KV0WMBEH64P5SW16AQ3V1ZA8/Browser%20local%20auth%20smoke%203?mode=view`: signed out now shows `Sign in required` and toolbar `Use local auth`, with no `Anaconda` and no lingering `Loading notebook`; local auth was restored afterward.
