### PR TITLE
perf(notebook-cloud): coalesce protected blob display fetches

### DIFF
--- a/apps/notebook-cloud/src/blob-resolver.ts
+++ b/apps/notebook-cloud/src/blob-resolver.ts
@@ -17,6 +17,7 @@ export function createNotebookCloudBlobResolver(input: {
   const blobBaseUrl = new URL(withTrailingSlash(input.blobBasePath), input.baseUrl);
   const fetchImpl = input.fetchImpl ?? fetch;
   const displayUrls = new Map<string, string>();
+  const displayUrlRequests = new Map<string, Promise<string>>();
   const url = (ref: BlobRef) => new URL(encodeURIComponent(ref.blob), blobBaseUrl).href;
   const fetchWithBlobRetries: typeof fetch = (request, init) =>
     fetchBlobWithRetries(fetchImpl, request, init);
@@ -32,30 +33,59 @@ export function createNotebookCloudBlobResolver(input: {
             const cacheKey = displayUrlCacheKey(ref, mediaType);
             const cached = displayUrls.get(cacheKey);
             if (cached) return cached;
+            const inFlight = displayUrlRequests.get(cacheKey);
+            if (inFlight) return inFlight;
 
-            const response = await fetchBlobWithRetries(fetchImpl, url(ref), { cache: "no-store" });
-            if (!response.ok) {
-              throw new Error(`Failed to fetch blob ${ref.blob}: ${response.status}`);
-            }
-            const responseBlob = await response.blob();
-            const resolvedMediaType = mediaType ?? ref.media_type ?? responseBlob.type;
-            const typedBlob =
-              responseBlob.type || !resolvedMediaType
-                ? responseBlob
-                : new Blob([responseBlob], { type: resolvedMediaType });
-            const displayUrl =
-              typeof FileReader === "function"
-                ? await blobToDataUrl(typedBlob)
-                : typeof URL.createObjectURL === "function"
-                  ? URL.createObjectURL(typedBlob)
-                  : url(ref);
-            displayUrls.set(cacheKey, displayUrl);
-            return displayUrl;
+            const request = resolveAuthenticatedDisplayUrl({
+              fetchImpl,
+              mediaType,
+              ref,
+              url: url(ref),
+            })
+              .then((displayUrl) => {
+                displayUrls.set(cacheKey, displayUrl);
+                return displayUrl;
+              })
+              .finally(() => {
+                if (displayUrlRequests.get(cacheKey) === request) {
+                  displayUrlRequests.delete(cacheKey);
+                }
+              });
+            displayUrlRequests.set(cacheKey, request);
+            return request;
           },
           resolvesBinaryUrlsSynchronously: false,
         }
       : {}),
   });
+}
+
+async function resolveAuthenticatedDisplayUrl({
+  fetchImpl,
+  mediaType,
+  ref,
+  url,
+}: {
+  fetchImpl: typeof fetch;
+  mediaType?: string;
+  ref: BlobRef;
+  url: string;
+}): Promise<string> {
+  const response = await fetchBlobWithRetries(fetchImpl, url, { cache: "no-store" });
+  if (!response.ok) {
+    throw new Error(`Failed to fetch blob ${ref.blob}: ${response.status}`);
+  }
+  const responseBlob = await response.blob();
+  const resolvedMediaType = mediaType ?? ref.media_type ?? responseBlob.type;
+  const typedBlob =
+    responseBlob.type || !resolvedMediaType
+      ? responseBlob
+      : new Blob([responseBlob], { type: resolvedMediaType });
+  return typeof FileReader === "function"
+    ? await blobToDataUrl(typedBlob)
+    : typeof URL.createObjectURL === "function"
+      ? URL.createObjectURL(typedBlob)
+      : url;
 }
 
 export function withTrailingSlash(value: string): string {

--- a/apps/notebook-cloud/test/blob-resolver.test.ts
+++ b/apps/notebook-cloud/test/blob-resolver.test.ts
@@ -128,4 +128,80 @@ describe("notebook cloud blob resolver", () => {
       },
     ]);
   });
+
+  it("coalesces concurrent protected binary display URL requests", async () => {
+    const originalFileReader = globalThis.FileReader;
+    class TestFileReader {
+      result: string | ArrayBuffer | null = null;
+      error: Error | null = null;
+      onload: (() => void) | null = null;
+      onerror: (() => void) | null = null;
+
+      readAsDataURL(blob: Blob) {
+        blob
+          .arrayBuffer()
+          .then((buffer) => {
+            this.result = `data:${blob.type};base64,${Buffer.from(buffer).toString("base64")}`;
+            this.onload?.();
+          })
+          .catch((error) => {
+            this.error = error instanceof Error ? error : new Error(String(error));
+            this.onerror?.();
+          });
+      }
+    }
+    globalThis.FileReader = TestFileReader as typeof FileReader;
+    let resolveFetch!: (response: Response) => void;
+    const fetchCalls: Array<{ input: RequestInfo | URL; init?: RequestInit }> = [];
+    const resolver = createNotebookCloudBlobResolver({
+      baseUrl: "https://viewer.example.test/n/notebook-1",
+      blobBasePath: "/api/n/notebook-1/blobs/",
+      authenticatedBinaryDisplayUrls: true,
+      fetchImpl: async (input, init) => {
+        fetchCalls.push({ input, init });
+        return new Promise<Response>((resolve) => {
+          resolveFetch = resolve;
+        });
+      },
+    });
+
+    try {
+      const first = resolver.displayUrl?.({
+        blob: "sha256:image",
+        media_type: "image/png",
+        size: 4,
+      });
+      const second = resolver.displayUrl?.({
+        blob: "sha256:image",
+        media_type: "image/png",
+        size: 4,
+      });
+
+      assert.equal(fetchCalls.length, 1);
+      resolveFetch(
+        new Response(new Blob([new Uint8Array([137, 80, 78, 71])], { type: "image/png" })),
+      );
+      assert.deepEqual(await Promise.all([first, second]), [
+        "data:image/png;base64,iVBORw==",
+        "data:image/png;base64,iVBORw==",
+      ]);
+      assert.equal(
+        await resolver.displayUrl?.({
+          blob: "sha256:image",
+          media_type: "image/png",
+          size: 4,
+        }),
+        "data:image/png;base64,iVBORw==",
+      );
+    } finally {
+      globalThis.FileReader = originalFileReader;
+    }
+
+    assert.deepEqual(fetchCalls, [
+      {
+        input: "https://viewer.example.test/api/n/notebook-1/blobs/sha256%3Aimage",
+        init: { cache: "no-store" },
+      },
+    ]);
+  });
 });


### PR DESCRIPTION
## Summary

- coalesce concurrent authenticated binary `displayUrl` resolutions for the same hosted blob
- keep the existing resolved display URL cache for completed requests
- clear in-flight entries on settle so failed blob fetches still retry fresh later

## Why

While auditing a live `preview.runt.run` notebook with rich outputs, DevTools showed the same `/api/n/:id/blobs/:hash` URLs fetched multiple times during one page load. Text blob resolution already coalesces concurrent reads through the shared manifest resolver, but authenticated binary display URLs only cached after the first request completed. Parallel output renders could therefore duplicate protected blob fetches.

## Verification

- `pnpm --dir apps/notebook-cloud exec node --import tsx --test test/blob-resolver.test.ts`
- `pnpm --dir apps/notebook-cloud exec tsc -p tsconfig.json --noEmit`
- `cargo xtask lint --fix`

## Live audit notes

- Verified current `preview.runt.run/n` dashboard has the Shared with me filter/section on mobile.
- Verified the owned notebook Workstations rail and pairing card render on mobile.
