### PR TITLE
fix(notebook-cloud): improve dashboard status contrast

### DIFF
--- a/apps/notebook-cloud/test/notebook-dashboard.test.ts
+++ b/apps/notebook-cloud/test/notebook-dashboard.test.ts
@@ -359,6 +359,28 @@ describe("cloud notebook dashboard projection", () => {
     );
   });
 
+  it("distinguishes a continue-only dashboard from a truly empty notebook list", () => {
+    const continued = notebook({
+      id: "solo-notebook",
+      title: "Solo Notebook",
+      scope: "owner",
+      updatedAt: "2026-06-07T15:00:00.000Z",
+      latestRevisionId: null,
+    });
+
+    const soloModel = projectCloudNotebookDashboard([continued]);
+    const soloView = projectCloudNotebookDashboardView(soloModel);
+    const emptyModel = projectCloudNotebookDashboard([]);
+    const emptyView = projectCloudNotebookDashboardView(emptyModel);
+
+    assert.equal(soloModel.continueNotebook?.notebook_id, "solo-notebook");
+    assert.equal(soloView.resultCount, 1);
+    assert.deepEqual(soloView.sections, []);
+    assert.equal(soloView.emptyMessage, "No other notebooks yet.");
+    assert.equal(emptyView.resultCount, 0);
+    assert.equal(emptyView.emptyMessage, "No notebooks yet.");
+  });
+
   it("surfaces shared notebooks as their own default dashboard section", () => {
     const owned = notebook({
       id: "owned-notes",

--- a/apps/notebook-cloud/viewer/index.css
+++ b/apps/notebook-cloud/viewer/index.css
@@ -714,7 +714,7 @@ body {
 }
 
 .cloud-dashboard-result-count {
-  color: color-mix(in srgb, var(--foreground) 56%, transparent);
+  color: color-mix(in srgb, var(--foreground) 64%, transparent);
   font-size: 0.8125rem;
   white-space: nowrap;
 }
@@ -759,7 +759,7 @@ body {
 }
 
 .cloud-dashboard-filter-group[data-group="cleanup"] button {
-  color: color-mix(in srgb, var(--foreground) 56%, transparent);
+  color: color-mix(in srgb, var(--foreground) 64%, transparent);
   font-size: 0.75rem;
   min-height: 1.75rem;
   padding-inline: 0.5rem;
@@ -791,7 +791,7 @@ body {
 }
 
 .cloud-dashboard-continue-main p {
-  color: color-mix(in srgb, var(--foreground) 54%, transparent);
+  color: color-mix(in srgb, var(--foreground) 64%, transparent);
   font-size: 0.6875rem;
   font-weight: 700;
   letter-spacing: 0;
@@ -813,7 +813,7 @@ body {
   display: flex;
   flex-wrap: wrap;
   gap: 0.375rem 0.875rem;
-  color: color-mix(in srgb, var(--foreground) 58%, transparent);
+  color: color-mix(in srgb, var(--foreground) 64%, transparent);
   font-size: 0.75rem;
 }
 
@@ -899,7 +899,7 @@ body {
 }
 
 .cloud-dashboard-section-heading p {
-  color: color-mix(in srgb, var(--foreground) 48%, transparent);
+  color: color-mix(in srgb, var(--foreground) 64%, transparent);
   font-size: 0.75rem;
   line-height: 1.25;
 }
@@ -947,7 +947,7 @@ body {
   margin: 0;
   border-bottom: 1px solid var(--border);
   padding-block: 0.75rem;
-  color: color-mix(in srgb, var(--foreground) 52%, transparent);
+  color: color-mix(in srgb, var(--foreground) 64%, transparent);
   font-size: 0.75rem;
   line-height: 1.3;
 }
@@ -1010,7 +1010,7 @@ body {
 }
 
 .cloud-notebook-list-detail {
-  color: color-mix(in srgb, var(--foreground) 54%, transparent);
+  color: color-mix(in srgb, var(--foreground) 64%, transparent);
   font-size: 0.75rem;
   line-height: 1.2;
 }
@@ -1024,7 +1024,7 @@ body {
   align-items: center;
   justify-content: flex-end;
   gap: 0.375rem;
-  color: color-mix(in srgb, var(--foreground) 58%, transparent);
+  color: color-mix(in srgb, var(--foreground) 64%, transparent);
   font-size: 0.8125rem;
   white-space: nowrap;
 }

--- a/apps/notebook-cloud/viewer/notebook-dashboard.ts
+++ b/apps/notebook-cloud/viewer/notebook-dashboard.ts
@@ -143,7 +143,7 @@ export function projectCloudNotebookDashboardView(
   const filtered = searched.filter((notebook) => cloudNotebookMatchesFilter(notebook, filterId));
 
   return {
-    emptyMessage: cloudNotebookDashboardEmptyMessage(filterId, query),
+    emptyMessage: cloudNotebookDashboardEmptyMessage(filterId, query, filtered.length),
     filterId,
     filterGroups: cloudNotebookDashboardFilterGroups(filters),
     filters,
@@ -633,13 +633,14 @@ function cloudNotebookMatchesSearch(notebook: CloudNotebookListItem, query: stri
 function cloudNotebookDashboardEmptyMessage(
   filterId: CloudNotebookDashboardFilterId,
   query: string,
+  resultCount: number,
 ): string {
   if (query) {
     return "No notebooks match that search.";
   }
   switch (filterId) {
     case "all":
-      return "No notebooks yet.";
+      return resultCount > 0 ? "No other notebooks yet." : "No notebooks yet.";
     case "owned":
       return "No owned notebooks yet.";
     case "shared":


### PR DESCRIPTION
## Summary

- darken small muted dashboard/list text on the hosted notebook home so it clears contrast checks
- change the default dashboard empty copy to "No other notebooks yet." when the only notebook is already represented by the Continue card
- add projection coverage for the continue-only dashboard state

## Audit notes

Live `https://preview.runt.run/n` Lighthouse snapshot before this patch scored Accessibility 95 with one failed audit: `color-contrast`. The failing nodes were the Continue kicker, section detail text, and shared notebook detail labels on the dashboard.

While reproducing locally with one notebook, the accessibility tree also exposed a copy/state bug: the page showed a Continue card for the only notebook, then announced `No notebooks yet.` below it. The projection now distinguishes that from a truly empty catalog.

## Verification

- `pnpm --dir apps/notebook-cloud exec node --import tsx --test test/notebook-dashboard.test.ts`
- `pnpm --dir apps/notebook-cloud exec tsc -p tsconfig.json --noEmit`
- `pnpm --dir apps/notebook-cloud build:viewer`
- local Chrome DevTools Lighthouse snapshot on `http://127.0.0.1:45320/n`: Accessibility 100, Best Practices 100, SEO 100, Agentic Browsing 100, failed audits 0
- `cargo xtask lint --fix`
