### PR TITLE
perf(notebook-cloud): lazy load notebook route

### DIFF
--- a/apps/notebook-cloud/scripts/copy-viewer-assets.mjs
+++ b/apps/notebook-cloud/scripts/copy-viewer-assets.mjs
@@ -3,6 +3,7 @@ import { access } from "node:fs/promises";
 import { fileURLToPath } from "node:url";
 import { copyRendererSidecarAssets } from "./renderer-sidecar-assets.mjs";
 import { copyRuntimeWasmAssets } from "./runtime-wasm-assets.mjs";
+import { writeNotebookRouteAssetsManifest } from "./notebook-route-assets.mjs";
 import { writeViewerCssManifest } from "./viewer-css-assets.mjs";
 
 const siftWasmUrl = new URL("../../../crates/sift-wasm/pkg/sift_wasm_bg.wasm", import.meta.url);
@@ -54,6 +55,8 @@ await copyFile(outputDocumentFrameUrl, outputDocumentOutputUrl);
 const { manifest, manifestUrl } = await writeViewerCssManifest(
   new URL("../dist/assets/", import.meta.url),
 );
+const { manifest: notebookRouteManifest, manifestUrl: notebookRouteManifestUrl } =
+  await writeNotebookRouteAssetsManifest(new URL("../dist/assets/", import.meta.url));
 
 for (const copy of rendererSidecarAssets.copies) {
   console.log(`copied ${fileURLToPath(copy.sourceUrl)} -> ${fileURLToPath(copy.outputUrl)}`);
@@ -70,6 +73,8 @@ console.log(`wrote runtime WASM manifest ${fileURLToPath(runtimeWasmAssets.manif
 console.log(`runtime WASM assets: ${JSON.stringify(runtimeWasmAssets.manifest)}`);
 console.log(`wrote viewer CSS manifest ${fileURLToPath(manifestUrl)}`);
 console.log(`viewer CSS assets: ${JSON.stringify(manifest)}`);
+console.log(`wrote notebook route asset manifest ${fileURLToPath(notebookRouteManifestUrl)}`);
+console.log(`notebook route assets: ${JSON.stringify(notebookRouteManifest)}`);
 
 async function assertExists(url) {
   try {

--- a/apps/notebook-cloud/scripts/notebook-route-assets.mjs
+++ b/apps/notebook-cloud/scripts/notebook-route-assets.mjs
@@ -1,0 +1,44 @@
+import { readdir, writeFile } from "node:fs/promises";
+
+export const NOTEBOOK_ROUTE_ASSETS_MANIFEST = "notebook-route-assets.json";
+
+const MODULE_PRELOAD_STEMS = [
+  "notebook-route",
+  "MarkdownText",
+  "markdown",
+  "markdown-output",
+  "katex.min",
+  "utils",
+];
+const STYLE_PRELOAD_STEMS = ["notebook-route", "katex"];
+
+export async function collectNotebookRouteAssets(
+  assetsDirUrl,
+  { modulePreloadStems = MODULE_PRELOAD_STEMS, stylePreloadStems = STYLE_PRELOAD_STEMS } = {},
+) {
+  const entries = await readdir(assetsDirUrl);
+  return {
+    modulepreload: collectAssetNames(entries, modulePreloadStems, ".js"),
+    stylepreload: collectAssetNames(entries, stylePreloadStems, ".css"),
+  };
+}
+
+export async function writeNotebookRouteAssetsManifest(assetsDirUrl) {
+  const manifest = await collectNotebookRouteAssets(assetsDirUrl);
+  const manifestUrl = new URL(NOTEBOOK_ROUTE_ASSETS_MANIFEST, assetsDirUrl);
+  await writeFile(manifestUrl, `${JSON.stringify(manifest, null, 2)}\n`);
+  return { manifest, manifestUrl };
+}
+
+function collectAssetNames(entries, stems, extension) {
+  const names = new Set();
+  for (const stem of stems) {
+    for (const entry of entries
+      .filter((entry) => entry.endsWith(extension))
+      .filter((entry) => entry === `${stem}${extension}` || entry.startsWith(`${stem}-`))
+      .sort()) {
+      names.add(entry);
+    }
+  }
+  return Array.from(names);
+}

--- a/apps/notebook-cloud/scripts/notebook-route-assets.mjs
+++ b/apps/notebook-cloud/scripts/notebook-route-assets.mjs
@@ -11,6 +11,8 @@ const MODULE_PRELOAD_STEMS = [
   "utils",
 ];
 const STYLE_PRELOAD_STEMS = ["notebook-route", "katex"];
+const REQUIRED_MODULE_PRELOAD_STEMS = ["notebook-route", "katex.min"];
+const REQUIRED_STYLE_PRELOAD_STEMS = ["notebook-route", "katex"];
 
 export async function collectNotebookRouteAssets(
   assetsDirUrl,
@@ -25,6 +27,7 @@ export async function collectNotebookRouteAssets(
 
 export async function writeNotebookRouteAssetsManifest(assetsDirUrl) {
   const manifest = await collectNotebookRouteAssets(assetsDirUrl);
+  assertRequiredRouteAssets(manifest);
   const manifestUrl = new URL(NOTEBOOK_ROUTE_ASSETS_MANIFEST, assetsDirUrl);
   await writeFile(manifestUrl, `${JSON.stringify(manifest, null, 2)}\n`);
   return { manifest, manifestUrl };
@@ -35,10 +38,40 @@ function collectAssetNames(entries, stems, extension) {
   for (const stem of stems) {
     for (const entry of entries
       .filter((entry) => entry.endsWith(extension))
-      .filter((entry) => entry === `${stem}${extension}` || entry.startsWith(`${stem}-`))
+      .filter((entry) => assetNameMatchesStem(entry, stem, extension))
       .sort()) {
       names.add(entry);
     }
   }
   return Array.from(names);
+}
+
+function assertRequiredRouteAssets(
+  manifest,
+  {
+    modulePreloadStems = REQUIRED_MODULE_PRELOAD_STEMS,
+    stylePreloadStems = REQUIRED_STYLE_PRELOAD_STEMS,
+  } = {},
+) {
+  const missingModuleStems = missingAssetStems(manifest.modulepreload, modulePreloadStems, ".js");
+  const missingStyleStems = missingAssetStems(manifest.stylepreload, stylePreloadStems, ".css");
+  if (missingModuleStems.length === 0 && missingStyleStems.length === 0) {
+    return;
+  }
+
+  const missing = [
+    ...missingModuleStems.map((stem) => `${stem}.js`),
+    ...missingStyleStems.map((stem) => `${stem}.css`),
+  ];
+  throw new Error(
+    `Unable to write ${NOTEBOOK_ROUTE_ASSETS_MANIFEST}: missing required route preload assets: ${missing.join(", ")}`,
+  );
+}
+
+function missingAssetStems(names, stems, extension) {
+  return stems.filter((stem) => !names.some((name) => assetNameMatchesStem(name, stem, extension)));
+}
+
+function assetNameMatchesStem(name, stem, extension) {
+  return name === `${stem}${extension}` || name.startsWith(`${stem}-`);
 }

--- a/apps/notebook-cloud/src/auth-shared.ts
+++ b/apps/notebook-cloud/src/auth-shared.ts
@@ -1,8 +1,22 @@
-// The scope union and its guard come from the generated capability lattice
+// The scope union comes from the generated capability lattice
 // (`packages/runtimed/src/scope-capabilities.ts`, generated from
 // `nteract_identity::ConnectionScope`) so the Worker cannot drift from the
-// daemon's Rust enforcement.
-export { isConnectionScope, type ConnectionScope } from "runtimed";
+// daemon's Rust enforcement. Keep the runtime guard local so dashboard/auth
+// code does not eagerly pull the notebook sync runtime into the app shell.
+import type { ConnectionScope } from "runtimed";
+
+export type { ConnectionScope };
+
+const CONNECTION_SCOPES = [
+  "viewer",
+  "editor",
+  "runtime_peer",
+  "owner",
+] as const satisfies readonly ConnectionScope[];
+
+export function isConnectionScope(value: string | null | undefined): value is ConnectionScope {
+  return typeof value === "string" && CONNECTION_SCOPES.includes(value as ConnectionScope);
+}
 
 export const BEARER_AUTH_TOKEN_PROTOCOL_PREFIX = "nteract-bearer.";
 export const DEV_AUTH_TOKEN_HEADER = "x-notebook-cloud-dev-token";

--- a/apps/notebook-cloud/src/auth-shared.ts
+++ b/apps/notebook-cloud/src/auth-shared.ts
@@ -13,6 +13,9 @@ const CONNECTION_SCOPES = [
   "runtime_peer",
   "owner",
 ] as const satisfies readonly ConnectionScope[];
+type MissingConnectionScope = Exclude<ConnectionScope, (typeof CONNECTION_SCOPES)[number]>;
+const CONNECTION_SCOPES_EXHAUSTIVE: MissingConnectionScope extends never ? true : never = true;
+void CONNECTION_SCOPES_EXHAUSTIVE;
 
 export function isConnectionScope(value: string | null | undefined): value is ConnectionScope {
   return typeof value === "string" && CONNECTION_SCOPES.includes(value as ConnectionScope);

--- a/apps/notebook-cloud/src/index.ts
+++ b/apps/notebook-cloud/src/index.ts
@@ -147,6 +147,7 @@ export { NotebookRoom };
 const DEFAULT_RENDERER_ASSETS_BASE_PATH = "/renderer-assets/";
 const DEFAULT_RUNTIMED_WASM_BASE_PATH = "/assets/";
 const VIEWER_RUNTIME_WASM_ASSET_MANIFEST_PATH = "/assets/runtime-wasm-assets.json";
+const VIEWER_NOTEBOOK_ROUTE_ASSET_MANIFEST_PATH = "/assets/notebook-route-assets.json";
 const VIEWER_RUNTIMED_WASM_MODULE_NAME = "runtimed_wasm.js";
 const VIEWER_RUNTIMED_WASM_NAME = "runtimed_wasm_bg.wasm";
 const VIEWER_RENDERER_SIDECAR_MANIFEST_PATH = "/assets/renderer-sidecar-assets.json";
@@ -176,6 +177,11 @@ interface MissingSnapshotBlob {
 interface RuntimeWasmAssetNames {
   module: string;
   wasm: string;
+}
+
+interface ViewerNotebookRouteAssets {
+  modulepreload: string[];
+  stylepreload: string[];
 }
 
 interface RendererSidecarAssetNames {
@@ -4182,6 +4188,7 @@ async function viewer(
   const notebookApiBasePath = `/api/n/${encodeURIComponent(notebookId)}`;
   const runtimeWasmAssets = await runtimeWasmAssetNames(env);
   const rendererSidecarAssets = await rendererSidecarAssetNames(env);
+  const notebookRouteAssets = await notebookRouteAssetNames(env);
   const session = await readCloudAppSession(env, request).catch(() => null);
   const config = {
     notebookId,
@@ -4204,6 +4211,7 @@ async function viewer(
     blobBasePath: notebookCloudBlobBasePath(notebookId),
     rendererAssetsBasePath: rendererAssetsBasePath(env),
     rendererAssets: rendererSidecarAssets,
+    notebookRouteAssets,
     outputDocumentBaseUrl: outputDocumentBaseUrl(env),
     runtimedWasmModulePath: runtimedWasmAssetPath(env, runtimeWasmAssets.module),
     runtimedWasmPath: runtimedWasmAssetPath(env, runtimeWasmAssets.wasm),
@@ -4215,6 +4223,7 @@ async function viewer(
 }
 
 interface ViewerShellConfig extends Record<string, unknown> {
+  notebookRouteAssets?: ViewerNotebookRouteAssets;
   outputDocumentBaseUrl?: string | null;
   rendererAssetsBasePath?: string;
   rendererAssets?: RendererSidecarAssetNames;
@@ -4423,11 +4432,26 @@ function viewerResourceHints(config: ViewerShellConfig | null): string {
       config.runtimedWasmModulePath,
     ]),
     viewerEntryHint,
+    ...notebookRouteResourceHints(config.notebookRouteAssets),
     `<link rel="modulepreload" href="${escapeHtml(config.runtimedWasmModulePath)}" crossorigin />`,
     `<link rel="prefetch" href="${escapeHtml(
       config.runtimedWasmPath,
     )}" as="fetch" type="application/wasm" crossorigin />`,
   ].join("\n  ");
+}
+
+function notebookRouteResourceHints(assets: ViewerNotebookRouteAssets | undefined): string[] {
+  if (!assets) {
+    return [];
+  }
+  return [
+    ...assets.modulepreload.map(
+      (name) => `<link rel="modulepreload" href="/assets/${escapeHtml(name)}" />`,
+    ),
+    ...assets.stylepreload.map(
+      (name) => `<link rel="preload" href="/assets/${escapeHtml(name)}" as="style" />`,
+    ),
+  ];
 }
 
 function preconnectResourceHints(urls: Array<string | null | undefined>): string[] {
@@ -4509,6 +4533,57 @@ function outputDocumentBaseUrl(env: Env): string | null {
 
 function runtimedWasmAssetPath(env: Env, name: string): string {
   return `${runtimedWasmBasePath(env)}${name}`;
+}
+
+async function notebookRouteAssetNames(env: Env): Promise<ViewerNotebookRouteAssets> {
+  if (!env.ASSETS) {
+    return defaultNotebookRouteAssetNames();
+  }
+
+  try {
+    const manifestRequest = new Request(
+      `https://notebook-cloud.local${VIEWER_NOTEBOOK_ROUTE_ASSET_MANIFEST_PATH}`,
+    );
+    const response = await env.ASSETS.fetch(manifestRequest);
+    if (!response.ok) {
+      return defaultNotebookRouteAssetNames();
+    }
+    const manifest = await response.json();
+    if (isNotebookRouteAssetManifest(manifest)) {
+      return manifest;
+    }
+    cloudLog("warn", "viewer.notebook_route_manifest.invalid", {
+      manifest_path: VIEWER_NOTEBOOK_ROUTE_ASSET_MANIFEST_PATH,
+    });
+  } catch (error) {
+    cloudLog("warn", "viewer.notebook_route_manifest.failed", {
+      manifest_path: VIEWER_NOTEBOOK_ROUTE_ASSET_MANIFEST_PATH,
+      error: errorMessage(error),
+    });
+  }
+
+  return defaultNotebookRouteAssetNames();
+}
+
+function defaultNotebookRouteAssetNames(): ViewerNotebookRouteAssets {
+  return { modulepreload: [], stylepreload: [] };
+}
+
+function isNotebookRouteAssetManifest(value: unknown): value is ViewerNotebookRouteAssets {
+  if (!value || typeof value !== "object") {
+    return false;
+  }
+  const manifest = value as Record<string, unknown>;
+  return (
+    Array.isArray(manifest.modulepreload) &&
+    Array.isArray(manifest.stylepreload) &&
+    manifest.modulepreload.every((entry) => isViewerAssetName(entry, "js")) &&
+    manifest.stylepreload.every((entry) => isViewerAssetName(entry, "css"))
+  );
+}
+
+function isViewerAssetName(value: unknown, extension: "css" | "js"): value is string {
+  return typeof value === "string" && new RegExp(`^[A-Za-z0-9_.-]+\\.${extension}$`).test(value);
 }
 
 async function runtimeWasmAssetNames(env: Env): Promise<RuntimeWasmAssetNames> {

--- a/apps/notebook-cloud/test/html.test.ts
+++ b/apps/notebook-cloud/test/html.test.ts
@@ -112,6 +112,77 @@ describe("HTML script serialization", () => {
     assert.doesNotMatch(html, /id="notebook"/);
   });
 
+  it("preloads the lazy notebook route assets for direct notebook pages", async () => {
+    const seenPaths: string[] = [];
+    const response = await worker.fetch(
+      new Request("https://cloud.test/n/demo/example"),
+      fakeEnv({
+        ASSETS: fakeViewerAssetManifests(
+          {
+            notebookRoute: {
+              modulepreload: [
+                "notebook-route.0123456789abcdef.js",
+                "MarkdownText.0123456789abcdef.js",
+                "markdown.0123456789abcdef.js",
+                "katex.min.0123456789abcdef.js",
+              ],
+              stylepreload: ["notebook-route.0123456789abcdef.css", "katex.0123456789abcdef.css"],
+            },
+          },
+          seenPaths,
+        ),
+      }),
+      fakeContext(),
+    );
+    const html = await response.text();
+
+    assert.equal(response.status, 200);
+    assert.deepEqual(seenPaths, [
+      "/assets/runtime-wasm-assets.json",
+      "/assets/renderer-sidecar-assets.json",
+      "/assets/notebook-route-assets.json",
+    ]);
+    assert.match(html, /rel="modulepreload" href="\/assets\/notebook-route\.0123456789abcdef\.js"/);
+    assert.match(html, /rel="modulepreload" href="\/assets\/MarkdownText\.0123456789abcdef\.js"/);
+    assert.match(html, /rel="modulepreload" href="\/assets\/markdown\.0123456789abcdef\.js"/);
+    assert.match(html, /rel="modulepreload" href="\/assets\/katex\.min\.0123456789abcdef\.js"/);
+    assert.match(
+      html,
+      /rel="preload" href="\/assets\/notebook-route\.0123456789abcdef\.css" as="style"/,
+    );
+    assert.match(html, /rel="preload" href="\/assets\/katex\.0123456789abcdef\.css" as="style"/);
+    assert.ok(
+      html.indexOf('rel="modulepreload" href="/assets/notebook-cloud-viewer.js"') <
+        html.indexOf('rel="modulepreload" href="/assets/notebook-route.0123456789abcdef.js"'),
+      "viewer entry should stay ahead of lazy notebook-route hints",
+    );
+  });
+
+  it("keeps notebook route asset hints out of the dashboard shell", async () => {
+    const seenPaths: string[] = [];
+    const response = await worker.fetch(
+      new Request("https://cloud.test/n"),
+      fakeEnv({
+        ASSETS: fakeViewerAssetManifests(
+          {
+            notebookRoute: {
+              modulepreload: ["notebook-route.0123456789abcdef.js"],
+              stylepreload: ["notebook-route.0123456789abcdef.css"],
+            },
+          },
+          seenPaths,
+        ),
+      }),
+      fakeContext(),
+    );
+    const html = await response.text();
+
+    assert.equal(response.status, 200);
+    assert.deepEqual(seenPaths, []);
+    assert.match(html, /rel="modulepreload" href="\/assets\/notebook-cloud-viewer\.js"/);
+    assert.doesNotMatch(html, /notebook-route\.0123456789abcdef/);
+  });
+
   it("uses content-hashed runtime WASM assets from the viewer asset manifest", async () => {
     const seenPaths: string[] = [];
     const response = await worker.fetch(
@@ -135,6 +206,7 @@ describe("HTML script serialization", () => {
     assert.deepEqual(seenPaths, [
       "/assets/runtime-wasm-assets.json",
       "/assets/renderer-sidecar-assets.json",
+      "/assets/notebook-route-assets.json",
     ]);
     assert.match(
       html,
@@ -489,6 +561,7 @@ function fakeEnv(overrides: Partial<Env> = {}): Env {
 
 function fakeViewerAssetManifests(
   manifests: {
+    notebookRoute?: { modulepreload: string[]; stylepreload: string[] } | Record<string, unknown>;
     runtimeWasm?: { module: string; wasm: string };
     rendererSidecar?: { js: string; css: string; siftWasm: string } | Record<string, unknown>;
   },
@@ -505,6 +578,11 @@ function fakeViewerAssetManifests(
       }
       if (manifests.rendererSidecar && pathname === "/assets/renderer-sidecar-assets.json") {
         return new Response(JSON.stringify(manifests.rendererSidecar), {
+          headers: { "Content-Type": "application/json" },
+        });
+      }
+      if (manifests.notebookRoute && pathname === "/assets/notebook-route-assets.json") {
+        return new Response(JSON.stringify(manifests.notebookRoute), {
           headers: { "Content-Type": "application/json" },
         });
       }

--- a/apps/notebook-cloud/test/notebook-route-assets.test.mjs
+++ b/apps/notebook-cloud/test/notebook-route-assets.test.mjs
@@ -40,14 +40,29 @@ describe("notebook route asset manifest", () => {
 
     await writeFile(new URL("notebook-route-abc123.js", assetsUrl), "");
     await writeFile(new URL("notebook-route-abc123.css", assetsUrl), "");
+    await writeFile(new URL("katex.min-jkl012.js", assetsUrl), "");
+    await writeFile(new URL("katex-mno345.css", assetsUrl), "");
 
     const { manifest, manifestUrl } = await writeNotebookRouteAssetsManifest(assetsUrl);
     const written = JSON.parse(await readFile(manifestUrl, "utf8"));
 
     assert.deepEqual(written, manifest);
     assert.deepEqual(written, {
-      modulepreload: ["notebook-route-abc123.js"],
-      stylepreload: ["notebook-route-abc123.css"],
+      modulepreload: ["notebook-route-abc123.js", "katex.min-jkl012.js"],
+      stylepreload: ["notebook-route-abc123.css", "katex-mno345.css"],
     });
+  });
+
+  it("fails loudly when required route preload chunks are missing", async () => {
+    const dir = await mkdtemp(path.join(tmpdir(), "notebook-cloud-route-manifest-missing-"));
+    const assetsUrl = pathToFileURL(`${dir}/`);
+
+    await writeFile(new URL("MarkdownText-def456.js", assetsUrl), "");
+    await writeFile(new URL("markdown-ghi789.js", assetsUrl), "");
+
+    await assert.rejects(
+      writeNotebookRouteAssetsManifest(assetsUrl),
+      /missing required route preload assets: notebook-route\.js, katex\.min\.js, notebook-route\.css, katex\.css/,
+    );
   });
 });

--- a/apps/notebook-cloud/test/notebook-route-assets.test.mjs
+++ b/apps/notebook-cloud/test/notebook-route-assets.test.mjs
@@ -1,0 +1,53 @@
+import { mkdtemp, readFile, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { pathToFileURL } from "node:url";
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import {
+  collectNotebookRouteAssets,
+  writeNotebookRouteAssetsManifest,
+} from "../scripts/notebook-route-assets.mjs";
+
+describe("notebook route asset manifest", () => {
+  it("collects route-load chunks without pulling lazy output renderers", async () => {
+    const dir = await mkdtemp(path.join(tmpdir(), "notebook-cloud-route-assets-"));
+    const assetsUrl = pathToFileURL(`${dir}/`);
+
+    await writeFile(new URL("notebook-route-abc123.js", assetsUrl), "");
+    await writeFile(new URL("notebook-route-abc123.css", assetsUrl), "");
+    await writeFile(new URL("MarkdownText-def456.js", assetsUrl), "");
+    await writeFile(new URL("markdown-ghi789.js", assetsUrl), "");
+    await writeFile(new URL("katex.min-jkl012.js", assetsUrl), "");
+    await writeFile(new URL("katex-mno345.css", assetsUrl), "");
+    await writeFile(new URL("plotly-pqr678.js", assetsUrl), "");
+    await writeFile(new URL("notebook-cloud-viewer.js", assetsUrl), "");
+
+    assert.deepEqual(await collectNotebookRouteAssets(assetsUrl), {
+      modulepreload: [
+        "notebook-route-abc123.js",
+        "MarkdownText-def456.js",
+        "markdown-ghi789.js",
+        "katex.min-jkl012.js",
+      ],
+      stylepreload: ["notebook-route-abc123.css", "katex-mno345.css"],
+    });
+  });
+
+  it("writes a generated manifest beside the built viewer assets", async () => {
+    const dir = await mkdtemp(path.join(tmpdir(), "notebook-cloud-route-manifest-"));
+    const assetsUrl = pathToFileURL(`${dir}/`);
+
+    await writeFile(new URL("notebook-route-abc123.js", assetsUrl), "");
+    await writeFile(new URL("notebook-route-abc123.css", assetsUrl), "");
+
+    const { manifest, manifestUrl } = await writeNotebookRouteAssetsManifest(assetsUrl);
+    const written = JSON.parse(await readFile(manifestUrl, "utf8"));
+
+    assert.deepEqual(written, manifest);
+    assert.deepEqual(written, {
+      modulepreload: ["notebook-route-abc123.js"],
+      stylepreload: ["notebook-route-abc123.css"],
+    });
+  });
+});

--- a/apps/notebook-cloud/viewer/cloud-auth-controls.tsx
+++ b/apps/notebook-cloud/viewer/cloud-auth-controls.tsx
@@ -1,12 +1,6 @@
 import { useState } from "react";
 import { LogIn } from "lucide-react";
 import {
-  NotebookEditModeButton,
-  type NotebookInteractionMode,
-  type NotebookInteractionModeProjection,
-  type NotebookShellCapabilities,
-} from "@/components/notebook";
-import {
   cloudNotebookSignInCopy,
   prepareCloudOidcViewerLogin,
   type CloudPrototypeAuthState,
@@ -24,60 +18,6 @@ export function cloudNotebookSignInLabel(authConfig: CloudViewerAuthConfig): str
   }
   const providerLabel = authConfig.oidc?.providerLabel?.trim();
   return providerLabel ? `Sign in with ${providerLabel}` : "Sign in";
-}
-
-export function CloudNotebookEditModeButton({
-  authState,
-  hasAppSession,
-  accessLevel,
-  accessPending,
-  interaction,
-  reconnecting = false,
-  onModeChange,
-  onRequestEditAccess,
-}: {
-  authState: CloudPrototypeAuthState;
-  hasAppSession: boolean;
-  accessLevel: NotebookShellCapabilities["access"]["level"];
-  accessPending: boolean;
-  interaction: NotebookInteractionModeProjection | null;
-  reconnecting?: boolean;
-  onModeChange: (mode: NotebookInteractionMode) => void;
-  onRequestEditAccess: () => void;
-}) {
-  const canUseEditModeControl =
-    hasAppSession || authState.mode === "dev" || authState.mode === "oidc";
-  if (
-    !canUseEditModeControl ||
-    (!interaction?.canRequestEdit && interaction?.activeMode !== "edit")
-  ) {
-    return null;
-  }
-  const canSwitchToEdit = accessLevel === "editor" || accessLevel === "owner";
-  const editLabel = canSwitchToEdit ? "Editing" : "Request edit";
-  const editTitle = canSwitchToEdit ? "Switch to edit mode" : "Request edit access";
-
-  return (
-    <NotebookEditModeButton
-      editLabel={editLabel}
-      editTitle={editTitle}
-      requestedEditLabel={reconnecting ? "Offline" : "Request sent"}
-      requestedEditTitle={
-        reconnecting ? "Offline while the room reconnects" : "Edit access requested"
-      }
-      mode={accessPending ? "view" : interaction.selectedMode}
-      state={accessPending ? "viewing" : interaction.state}
-      variant="segmented"
-      disabled={accessPending}
-      onModeChange={(mode) => {
-        if (mode === "edit" && !canSwitchToEdit) {
-          onRequestEditAccess();
-          return;
-        }
-        onModeChange(mode);
-      }}
-    />
-  );
 }
 
 export function CloudNotebookSignInButton({

--- a/apps/notebook-cloud/viewer/cloud-edit-mode-button.tsx
+++ b/apps/notebook-cloud/viewer/cloud-edit-mode-button.tsx
@@ -1,0 +1,61 @@
+import {
+  NotebookEditModeButton,
+  type NotebookInteractionMode,
+  type NotebookInteractionModeProjection,
+  type NotebookShellCapabilities,
+} from "@/components/notebook";
+import type { CloudPrototypeAuthState } from "./collaborator-auth";
+
+export function CloudNotebookEditModeButton({
+  authState,
+  hasAppSession,
+  accessLevel,
+  accessPending,
+  interaction,
+  reconnecting = false,
+  onModeChange,
+  onRequestEditAccess,
+}: {
+  authState: CloudPrototypeAuthState;
+  hasAppSession: boolean;
+  accessLevel: NotebookShellCapabilities["access"]["level"];
+  accessPending: boolean;
+  interaction: NotebookInteractionModeProjection | null;
+  reconnecting?: boolean;
+  onModeChange: (mode: NotebookInteractionMode) => void;
+  onRequestEditAccess: () => void;
+}) {
+  const canUseEditModeControl =
+    hasAppSession || authState.mode === "dev" || authState.mode === "oidc";
+  if (
+    !canUseEditModeControl ||
+    (!interaction?.canRequestEdit && interaction?.activeMode !== "edit")
+  ) {
+    return null;
+  }
+  const canSwitchToEdit = accessLevel === "editor" || accessLevel === "owner";
+  const editLabel = canSwitchToEdit ? "Editing" : "Request edit";
+  const editTitle = canSwitchToEdit ? "Switch to edit mode" : "Request edit access";
+
+  return (
+    <NotebookEditModeButton
+      editLabel={editLabel}
+      editTitle={editTitle}
+      requestedEditLabel={reconnecting ? "Offline" : "Request sent"}
+      requestedEditTitle={
+        reconnecting ? "Offline while the room reconnects" : "Edit access requested"
+      }
+      mode={accessPending ? "view" : interaction.selectedMode}
+      state={accessPending ? "viewing" : interaction.state}
+      variant="segmented"
+      disabled={accessPending}
+      onModeChange={(mode) => {
+        if (mode === "edit" && !canSwitchToEdit) {
+          onRequestEditAccess();
+          return;
+        }
+        onModeChange(mode);
+      }}
+    />
+  );
+}

--- a/apps/notebook-cloud/viewer/cloud-notebook-dashboard-view.tsx
+++ b/apps/notebook-cloud/viewer/cloud-notebook-dashboard-view.tsx
@@ -34,6 +34,7 @@ export function CloudNotebookDashboard({
   canRename,
   renameState,
   renameSavingId,
+  onOpenNotebookIntent,
   onOpenRename,
   onCancelRename,
   onRenameTitleChange,
@@ -43,6 +44,7 @@ export function CloudNotebookDashboard({
   canRename: boolean;
   renameState: CloudNotebookDashboardRenameState | null;
   renameSavingId: string | null;
+  onOpenNotebookIntent?: () => void;
   onOpenRename: (notebook: CloudNotebookListItem) => void;
   onCancelRename: () => void;
   onRenameTitleChange: (title: string) => void;
@@ -76,6 +78,8 @@ export function CloudNotebookDashboard({
           <a
             className="cloud-dashboard-primary-link"
             href={cloudNotebookDashboardOpenUrl(continued.notebook)}
+            onFocus={onOpenNotebookIntent}
+            onPointerEnter={onOpenNotebookIntent}
           >
             Open notebook
             <ExternalLink aria-hidden="true" />
@@ -137,6 +141,7 @@ export function CloudNotebookDashboard({
                   canRename={canRename}
                   renameState={renameState}
                   renameSavingId={renameSavingId}
+                  onOpenNotebookIntent={onOpenNotebookIntent}
                   onOpenRename={onOpenRename}
                   onCancelRename={onCancelRename}
                   onSelectFilter={setFilterId}
@@ -162,6 +167,7 @@ function CloudNotebookDashboardSectionView({
   canRename,
   renameState,
   renameSavingId,
+  onOpenNotebookIntent,
   onOpenRename,
   onCancelRename,
   onSelectFilter,
@@ -172,6 +178,7 @@ function CloudNotebookDashboardSectionView({
   canRename: boolean;
   renameState: CloudNotebookDashboardRenameState | null;
   renameSavingId: string | null;
+  onOpenNotebookIntent?: () => void;
   onOpenRename: (notebook: CloudNotebookListItem) => void;
   onCancelRename: () => void;
   onSelectFilter: (filterId: CloudNotebookDashboardFilterId) => void;
@@ -220,6 +227,7 @@ function CloudNotebookDashboardSectionView({
                 renameState?.notebookId === row.notebook.notebook_id ? renameState.title : null
               }
               renameSaving={renameSavingId === row.notebook.notebook_id}
+              onOpenNotebookIntent={onOpenNotebookIntent}
               onOpenRename={onOpenRename}
               onCancelRename={onCancelRename}
               onRenameTitleChange={onRenameTitleChange}
@@ -252,6 +260,7 @@ function CloudNotebookDashboardRow({
   canRename,
   renameTitle,
   renameSaving,
+  onOpenNotebookIntent,
   onOpenRename,
   onCancelRename,
   onRenameTitleChange,
@@ -261,6 +270,7 @@ function CloudNotebookDashboardRow({
   canRename: boolean;
   renameTitle: string | null;
   renameSaving: boolean;
+  onOpenNotebookIntent?: () => void;
   onOpenRename: (notebook: CloudNotebookListItem) => void;
   onCancelRename: () => void;
   onRenameTitleChange: (title: string) => void;
@@ -310,7 +320,12 @@ function CloudNotebookDashboardRow({
 
   return (
     <div className="cloud-notebook-list-row">
-      <a className="cloud-notebook-list-main" href={openUrl}>
+      <a
+        className="cloud-notebook-list-main"
+        href={openUrl}
+        onFocus={onOpenNotebookIntent}
+        onPointerEnter={onOpenNotebookIntent}
+      >
         <span className="cloud-notebook-list-title">{cloudNotebookDisplayTitle(notebook)}</span>
         {detail ? <span className="cloud-notebook-list-detail">{detail}</span> : null}
         {row.facts.length > 0 ? (
@@ -342,6 +357,8 @@ function CloudNotebookDashboardRow({
           href={openUrl}
           title="Open notebook"
           aria-label={`Open ${cloudNotebookDisplayTitle(notebook)}`}
+          onFocus={onOpenNotebookIntent}
+          onPointerEnter={onOpenNotebookIntent}
         >
           <ExternalLink aria-hidden="true" />
         </a>

--- a/apps/notebook-cloud/viewer/index.tsx
+++ b/apps/notebook-cloud/viewer/index.tsx
@@ -1,14 +1,9 @@
-import { useEffect, useMemo, useState, type ReactNode } from "react";
+import { lazy, Suspense, useState } from "react";
 import { createRoot } from "react-dom/client";
-import { IsolatedRendererProvider } from "@/components/isolated/isolated-renderer-context";
-import { MediaProvider } from "@/components/outputs/media-provider";
 import { ErrorBoundary } from "@/lib/error-boundary";
-import { setLoggerHost, setOpenUrlHost } from "../../notebook/src/notebook-surface";
-import { rendererAssetBasePathForProvider } from "./renderer-assets";
-import { loadSupplementalViewerCss } from "./supplemental-css";
+import { setLoggerHost } from "../../notebook/src/lib/logger";
+import { setOpenUrlHost } from "../../notebook/src/lib/open-url";
 import { installDocumentThemeSync } from "./theme";
-import { CLOUD_WIDGET_RENDERERS, CloudWidgetStoreProvider } from "./widget-runtime";
-import { CLOUD_VIEWER_PRIORITY } from "./mime-policy";
 import {
   isHomePath,
   isNotebookListPath,
@@ -17,13 +12,16 @@ import {
   loadViewerRuntime,
   requireElement,
 } from "./cloud-viewer-config";
-import type { CloudViewerConfig } from "./cloud-viewer-session";
 import type { CloudViewerAuthConfig, ViewerRuntimeState } from "./cloud-viewer-types";
 import { CloudHomeView } from "./home-view";
 import { CloudNotebookListView } from "./notebook-list-view";
+import { loadNotebookRouteModule } from "./notebook-route-preload";
 import { OidcCallbackView } from "./oidc-callback-view";
-import { NotebookViewer } from "./notebook-viewer";
 import "./index.css";
+
+const NotebookRoute = lazy(() =>
+  loadNotebookRouteModule().then((module) => ({ default: module.NotebookRoute })),
+);
 
 setLoggerHost({
   debug: () => {},
@@ -71,42 +69,9 @@ function App() {
   }
 
   return (
-    <CloudNotebookProviders config={runtimeState.runtime.config}>
-      <NotebookViewer runtime={runtimeState.runtime} authConfig={authConfig} />
-    </CloudNotebookProviders>
-  );
-}
-
-function CloudNotebookProviders({
-  children,
-  config,
-}: {
-  children: ReactNode;
-  config: CloudViewerConfig;
-}) {
-  useEffect(() => {
-    loadSupplementalViewerCss();
-  }, []);
-
-  // Manifest filenames (content-hashed when deployed) keep the renderer
-  // bundle on the asset origin's immutable cache path; the stable names
-  // remain the fallback for shells without manifest names.
-  const rendererAssetNames = useMemo(
-    () => ({ js: config.rendererAssets.js, css: config.rendererAssets.css }),
-    [config.rendererAssets.css, config.rendererAssets.js],
-  );
-
-  return (
-    <IsolatedRendererProvider
-      basePath={rendererAssetBasePathForProvider(config.rendererAssetsBasePath)}
-      assetNames={rendererAssetNames}
-    >
-      <CloudWidgetStoreProvider>
-        <MediaProvider priority={CLOUD_VIEWER_PRIORITY} renderers={CLOUD_WIDGET_RENDERERS}>
-          {children}
-        </MediaProvider>
-      </CloudWidgetStoreProvider>
-    </IsolatedRendererProvider>
+    <Suspense fallback={<ViewerStartupLoading />}>
+      <NotebookRoute runtime={runtimeState.runtime} authConfig={authConfig} />
+    </Suspense>
   );
 }
 
@@ -118,6 +83,19 @@ function ViewerStartupError({ message }: { message: string }) {
       </header>
       <div className="cloud-state" data-kind="error">
         {message}
+      </div>
+    </main>
+  );
+}
+
+function ViewerStartupLoading() {
+  return (
+    <main className="flex min-h-screen w-full flex-col px-8 py-4 pr-4">
+      <header className="mb-4">
+        <h1 className="text-2xl font-semibold tracking-normal">nteract cloud notebook</h1>
+      </header>
+      <div className="cloud-state" role="status">
+        Loading notebook.
       </div>
     </main>
   );

--- a/apps/notebook-cloud/viewer/notebook-list-view.tsx
+++ b/apps/notebook-cloud/viewer/notebook-list-view.tsx
@@ -45,6 +45,7 @@ import {
   useCloudPrototypeAuth,
 } from "./use-cloud-auth";
 import { CloudNotebookSignInButton } from "./cloud-auth-controls";
+import { preloadNotebookRoute, scheduleNotebookRoutePreload } from "./notebook-route-preload";
 
 export function CloudNotebookListView({ authConfig }: { authConfig: CloudViewerAuthConfig }) {
   const { resolvedTheme } = useTheme(CLOUD_VIEWER_THEME_STORAGE_KEY);
@@ -87,6 +88,12 @@ export function CloudNotebookListView({ authConfig }: { authConfig: CloudViewerA
   useEffect(() => {
     applyDocumentTheme(resolvedTheme);
   }, [resolvedTheme]);
+
+  useEffect(() => {
+    if (listState.kind === "ready" && listState.notebooks.length > 0) {
+      scheduleNotebookRoutePreload();
+    }
+  }, [listState]);
 
   useEffect(() => {
     const cachedNotebooks =
@@ -394,6 +401,7 @@ export function CloudNotebookListView({ authConfig }: { authConfig: CloudViewerA
             canRename={signedIn}
             renameState={renameState}
             renameSavingId={renameSavingId}
+            onOpenNotebookIntent={preloadNotebookRoute}
             onOpenRename={openRenameForm}
             onCancelRename={closeRenameForm}
             onRenameTitleChange={(title) =>

--- a/apps/notebook-cloud/viewer/notebook-route-preload.ts
+++ b/apps/notebook-cloud/viewer/notebook-route-preload.ts
@@ -1,0 +1,36 @@
+let notebookRouteModulePromise: Promise<typeof import("./notebook-route")> | null = null;
+let scheduledNotebookRoutePreload = false;
+
+export function loadNotebookRouteModule(): Promise<typeof import("./notebook-route")> {
+  if (!notebookRouteModulePromise) {
+    notebookRouteModulePromise = import("./notebook-route").catch((error: unknown) => {
+      notebookRouteModulePromise = null;
+      throw error;
+    });
+  }
+  return notebookRouteModulePromise;
+}
+
+export function preloadNotebookRoute(): void {
+  void loadNotebookRouteModule().catch((error: unknown) => {
+    console.warn("[notebook-cloud] notebook route preload failed", error);
+  });
+}
+
+export function scheduleNotebookRoutePreload(): void {
+  if (scheduledNotebookRoutePreload || notebookRouteModulePromise) {
+    return;
+  }
+  if (typeof window === "undefined") {
+    return;
+  }
+  scheduledNotebookRoutePreload = true;
+
+  const load = () => preloadNotebookRoute();
+  if ("requestIdleCallback" in window) {
+    window.requestIdleCallback(load, { timeout: 1500 });
+    return;
+  }
+
+  setTimeout(load, 750);
+}

--- a/apps/notebook-cloud/viewer/notebook-route.tsx
+++ b/apps/notebook-cloud/viewer/notebook-route.tsx
@@ -1,0 +1,57 @@
+import { useEffect, useMemo, type ReactNode } from "react";
+import { IsolatedRendererProvider } from "@/components/isolated/isolated-renderer-context";
+import { MediaProvider } from "@/components/outputs/media-provider";
+import type { CloudViewerConfig } from "./cloud-viewer-session";
+import type { CloudViewerAuthConfig, ViewerRuntime } from "./cloud-viewer-types";
+import { CLOUD_VIEWER_PRIORITY } from "./mime-policy";
+import { NotebookViewer } from "./notebook-viewer";
+import { rendererAssetBasePathForProvider } from "./renderer-assets";
+import { loadSupplementalViewerCss } from "./supplemental-css";
+import { CLOUD_WIDGET_RENDERERS, CloudWidgetStoreProvider } from "./widget-runtime";
+
+export function NotebookRoute({
+  authConfig,
+  runtime,
+}: {
+  authConfig: CloudViewerAuthConfig;
+  runtime: ViewerRuntime;
+}) {
+  return (
+    <CloudNotebookProviders config={runtime.config}>
+      <NotebookViewer runtime={runtime} authConfig={authConfig} />
+    </CloudNotebookProviders>
+  );
+}
+
+function CloudNotebookProviders({
+  children,
+  config,
+}: {
+  children: ReactNode;
+  config: CloudViewerConfig;
+}) {
+  useEffect(() => {
+    loadSupplementalViewerCss();
+  }, []);
+
+  // Manifest filenames (content-hashed when deployed) keep the renderer
+  // bundle on the asset origin's immutable cache path; the stable names
+  // remain the fallback for shells without manifest names.
+  const rendererAssetNames = useMemo(
+    () => ({ js: config.rendererAssets.js, css: config.rendererAssets.css }),
+    [config.rendererAssets.css, config.rendererAssets.js],
+  );
+
+  return (
+    <IsolatedRendererProvider
+      basePath={rendererAssetBasePathForProvider(config.rendererAssetsBasePath)}
+      assetNames={rendererAssetNames}
+    >
+      <CloudWidgetStoreProvider>
+        <MediaProvider priority={CLOUD_VIEWER_PRIORITY} renderers={CLOUD_WIDGET_RENDERERS}>
+          {children}
+        </MediaProvider>
+      </CloudWidgetStoreProvider>
+    </IsolatedRendererProvider>
+  );
+}

--- a/apps/notebook-cloud/viewer/notebook-viewer.tsx
+++ b/apps/notebook-cloud/viewer/notebook-viewer.tsx
@@ -140,7 +140,8 @@ import {
 } from "./use-cloud-auth";
 import { useCloudShellCapabilities } from "./use-cloud-shell-capabilities";
 import { useCloudWorkstationManager } from "./use-cloud-workstations";
-import { CloudNotebookEditModeButton, CloudNotebookSignInButton } from "./cloud-auth-controls";
+import { CloudNotebookSignInButton } from "./cloud-auth-controls";
+import { CloudNotebookEditModeButton } from "./cloud-edit-mode-button";
 import { CloudNotebookTitle, cloudNotebookRouteTitle } from "./cloud-notebook-title";
 import {
   cloudNotebookCatalogResponseTitle,


### PR DESCRIPTION
## Summary

- lazy-load the hosted notebook route instead of importing the full notebook viewer from the cloud entrypoint
- move notebook-only renderer/media/widget providers into the lazy route module
- keep dashboard auth/scope parsing out of the `runtimed` runtime graph so `/n` does not eagerly pull notebook sync/RxJS code
- warm the notebook route after the dashboard has a ready notebook list, and immediately on notebook-link hover/focus, so the first notebook open can reuse cached route/Markdown/KaTeX chunks
- generate a notebook-route asset manifest during `build:viewer` and emit direct-notebook HTML hints for the route chunk plus Markdown/KaTeX route-load assets, while keeping those hints out of the `/n` dashboard shell

## Audit notes

Live `https://preview.runt.run/n` currently loads notebook/markdown chunks on the dashboard route even though no notebook body is shown. The observed dashboard requests included:

- `/assets/notebook-cloud-viewer.js`
- `/assets/MarkdownText-*.js`
- `/assets/katex.min-*.js`
- `/assets/utils-*.js`

After this split, the initial dashboard shell stays on dashboard/auth dependencies plus the session/list APIs. Once a notebook list is ready, the browser idles into a route preload for `notebook-route-*.js`; Vite also warms dependent Markdown/KaTeX chunks. Opening a notebook then reuses those cached chunks instead of discovering the route bundle at click time.

Direct notebook pages also receive static HTML hints from `/assets/notebook-route-assets.json`, so the browser can start fetching the lazy route chunk, MarkdownText, markdown, KaTeX, utils, and route/Katex CSS before the entry module discovers the lazy route. The `/n` dashboard shell still emits only the entry modulepreload.

Build output moved the heavy notebook surface out of the entry bundle:

- before: `notebook-cloud-viewer.js` was about 1.42 MB uncompressed in the prior build
- after: `notebook-cloud-viewer.js` is about 283.6 KB uncompressed; the live notebook surface is in `notebook-route-*.js`
- after removing the eager runtime scope guard from dashboard auth, `cloud-response-*.js` is about 39.9 KB uncompressed instead of about 196 KB

## Verification

- `pnpm --dir apps/notebook-cloud exec tsc -p tsconfig.json --noEmit`
- `pnpm --dir apps/notebook-cloud exec node --import tsx --test test/collaborator-auth.test.ts test/notebook-dashboard.test.ts`
- `pnpm --dir apps/notebook-cloud exec node --import tsx --test test/notebook-route-assets.test.mjs test/html.test.ts test/viewer-css-assets.test.mjs`
- `pnpm --dir apps/notebook-cloud build:viewer`
- `cargo xtask lint --fix`
- local Wrangler `/n` browser check: dashboard rendered, first wave loaded dashboard/auth/session/list assets, then idle preload fetched `notebook-route-*.js` plus dependent Markdown/KaTeX chunks
- local notebook browser check: opening the preloaded notebook route rendered the hosted notebook shell/edit controls; warmed JS chunks were served from cache/revalidation
- local Wrangler HTML check: `/n/demo/example` emitted modulepreload/preload hints for `notebook-route-*`, `MarkdownText-*`, `markdown-*`, `markdown-output-*`, `katex.min-*`, `utils-*`, `notebook-route-*.css`, and `katex-*.css`; `/n` emitted only `/assets/notebook-cloud-viewer.js`
