### PR TITLE
fix(notebook-cloud): keep view-only edit links passive

### DIFF
--- a/apps/notebook-cloud/test/cloud-access-request-state.test.ts
+++ b/apps/notebook-cloud/test/cloud-access-request-state.test.ts
@@ -4,6 +4,7 @@ import {
   cloudPrototypeAuthCarriesRequestedScope,
   projectCloudAccessRequestNotice,
   projectCloudAccessRequestTransition,
+  shouldFallbackCloudEditUrlToView,
   shouldLoadOwnCloudAccessRequest,
 } from "../viewer/cloud-access-request-state";
 import type { CloudPrototypeAuthState } from "../viewer/collaborator-auth";
@@ -189,6 +190,7 @@ describe("cloud access-request state projection", () => {
         canUseAuthenticatedCloudApi: true,
         catalogGrantsDocumentEdit: false,
         connectionScope: "viewer",
+        editAccessRequested: true,
         hasBrowserAppIdentity: true,
         selectedMode: "edit",
       }),
@@ -199,6 +201,18 @@ describe("cloud access-request state projection", () => {
         canUseAuthenticatedCloudApi: true,
         catalogGrantsDocumentEdit: false,
         connectionScope: "viewer",
+        editAccessRequested: false,
+        hasBrowserAppIdentity: true,
+        selectedMode: "edit",
+      }),
+      false,
+    );
+    assert.equal(
+      shouldLoadOwnCloudAccessRequest({
+        canUseAuthenticatedCloudApi: true,
+        catalogGrantsDocumentEdit: false,
+        connectionScope: "viewer",
+        editAccessRequested: true,
         hasBrowserAppIdentity: true,
         selectedMode: "view",
       }),
@@ -209,6 +223,7 @@ describe("cloud access-request state projection", () => {
         canUseAuthenticatedCloudApi: true,
         catalogGrantsDocumentEdit: true,
         connectionScope: "viewer",
+        editAccessRequested: true,
         hasBrowserAppIdentity: true,
         selectedMode: "edit",
       }),
@@ -219,8 +234,57 @@ describe("cloud access-request state projection", () => {
         canUseAuthenticatedCloudApi: true,
         catalogGrantsDocumentEdit: false,
         connectionScope: "editor",
+        editAccessRequested: true,
         hasBrowserAppIdentity: true,
         selectedMode: "edit",
+      }),
+      false,
+    );
+  });
+
+  it("falls owner-style edit URLs back to view mode for view-only access", () => {
+    assert.equal(
+      shouldFallbackCloudEditUrlToView({
+        catalogGrantsDocumentEdit: false,
+        catalogResolved: true,
+        editAccessRequested: false,
+        selectedMode: "edit",
+      }),
+      true,
+    );
+    assert.equal(
+      shouldFallbackCloudEditUrlToView({
+        catalogGrantsDocumentEdit: false,
+        catalogResolved: true,
+        editAccessRequested: true,
+        selectedMode: "edit",
+      }),
+      false,
+    );
+    assert.equal(
+      shouldFallbackCloudEditUrlToView({
+        catalogGrantsDocumentEdit: true,
+        catalogResolved: true,
+        editAccessRequested: false,
+        selectedMode: "edit",
+      }),
+      false,
+    );
+    assert.equal(
+      shouldFallbackCloudEditUrlToView({
+        catalogGrantsDocumentEdit: false,
+        catalogResolved: false,
+        editAccessRequested: false,
+        selectedMode: "edit",
+      }),
+      false,
+    );
+    assert.equal(
+      shouldFallbackCloudEditUrlToView({
+        catalogGrantsDocumentEdit: false,
+        catalogResolved: true,
+        editAccessRequested: false,
+        selectedMode: "view",
       }),
       false,
     );

--- a/apps/notebook-cloud/viewer/cloud-access-request-state.ts
+++ b/apps/notebook-cloud/viewer/cloud-access-request-state.ts
@@ -30,7 +30,15 @@ export interface CloudAccessRequestLoadProjectionInput {
   canUseAuthenticatedCloudApi: boolean;
   catalogGrantsDocumentEdit: boolean;
   connectionScope: string | null;
+  editAccessRequested: boolean;
   hasBrowserAppIdentity: boolean;
+  selectedMode: CloudNotebookUrlMode;
+}
+
+export interface CloudEditModeFallbackProjectionInput {
+  catalogGrantsDocumentEdit: boolean;
+  catalogResolved: boolean;
+  editAccessRequested: boolean;
   selectedMode: CloudNotebookUrlMode;
 }
 
@@ -100,15 +108,28 @@ export function shouldLoadOwnCloudAccessRequest({
   canUseAuthenticatedCloudApi,
   catalogGrantsDocumentEdit,
   connectionScope,
+  editAccessRequested,
   hasBrowserAppIdentity,
   selectedMode,
 }: CloudAccessRequestLoadProjectionInput): boolean {
   return (
     selectedMode === "edit" &&
+    editAccessRequested &&
     connectionScope === "viewer" &&
     hasBrowserAppIdentity &&
     canUseAuthenticatedCloudApi &&
     !catalogGrantsDocumentEdit
+  );
+}
+
+export function shouldFallbackCloudEditUrlToView({
+  catalogGrantsDocumentEdit,
+  catalogResolved,
+  editAccessRequested,
+  selectedMode,
+}: CloudEditModeFallbackProjectionInput): boolean {
+  return (
+    selectedMode === "edit" && catalogResolved && !catalogGrantsDocumentEdit && !editAccessRequested
   );
 }
 

--- a/apps/notebook-cloud/viewer/notebook-viewer.tsx
+++ b/apps/notebook-cloud/viewer/notebook-viewer.tsx
@@ -110,6 +110,7 @@ import { clearCloudAppSession, readCloudAppSessionStatus } from "./app-session";
 import {
   projectCloudAccessRequestNotice,
   projectCloudAccessRequestTransition,
+  shouldFallbackCloudEditUrlToView,
   shouldLoadOwnCloudAccessRequest,
   type CloudAccessRequestNoticeProjection,
 } from "./cloud-access-request-state";
@@ -263,6 +264,7 @@ export function NotebookViewer({
   const [selectedInteractionMode, setSelectedInteractionMode] = useState<NotebookInteractionMode>(
     () => cloudNotebookModeFromSearch(window.location.search),
   );
+  const [editAccessRequestedByUser, setEditAccessRequestedByUser] = useState(false);
   // Scope resolution reads the latest selected mode at connect time, but
   // access-mode correction itself must not rebuild the live-room callback:
   // viewer-owned `?mode=edit` links are corrected to view mode after access is
@@ -524,6 +526,11 @@ export function NotebookViewer({
   useEffect(() => {
     replaceCloudNotebookModeInCurrentUrl(selectedInteractionMode);
   }, [selectedInteractionMode]);
+  useEffect(() => {
+    if (selectedInteractionMode !== "edit") {
+      setEditAccessRequestedByUser(false);
+    }
+  }, [selectedInteractionMode]);
 
   const getOutlineStatusLabel = useOutlineStatusLabel();
   const notebookViewModel = useNotebookViewModel({
@@ -617,6 +624,23 @@ export function NotebookViewer({
     };
   }, [canUseAuthenticatedCloudApi, catalogAccessLoader]);
   const catalogGrantsDocumentEdit = cloudNotebookScopeCanEditDocument(catalogAccessScope);
+  useEffect(() => {
+    if (
+      shouldFallbackCloudEditUrlToView({
+        catalogGrantsDocumentEdit,
+        catalogResolved: catalogAccessResolved,
+        editAccessRequested: editAccessRequestedByUser,
+        selectedMode: selectedInteractionMode,
+      })
+    ) {
+      setSelectedInteractionMode("view");
+    }
+  }, [
+    catalogAccessResolved,
+    catalogGrantsDocumentEdit,
+    editAccessRequestedByUser,
+    selectedInteractionMode,
+  ]);
   const saveCloudNotebookTitle = useCallback(
     async (nextTitle: string): Promise<boolean> => {
       if (!canUseAuthenticatedCloudApi || !catalogGrantsDocumentEdit || notebookTitleSaving) {
@@ -705,6 +729,7 @@ export function NotebookViewer({
     canUseAuthenticatedCloudApi,
     catalogGrantsDocumentEdit,
     connectionScope,
+    editAccessRequested: editAccessRequestedByUser,
     hasBrowserAppIdentity,
     selectedMode: selectedInteractionMode,
   });
@@ -1168,6 +1193,7 @@ export function NotebookViewer({
   }, [effectiveAccessRequest?.status, loadOwnAccessRequest, shouldLoadOwnEditAccessRequest]);
   const requestCloudEditAccess = useCallback(() => {
     void (async () => {
+      setEditAccessRequestedByUser(true);
       setAccessRequestError(null);
       try {
         const response = await fetchWithCloudPrototypeAuth(


### PR DESCRIPTION
## Summary

- Keep owner-style `?mode=edit` notebook links passive for signed-in users who only have view access.
- Fall those links back to view mode after catalog access resolves, instead of showing pending edit-request state.
- Load a viewer's own edit-request state only after they explicitly click `Request edit`.
- Add projection coverage for passive edit-link fallback and explicit request gating.

## Verification

- `pnpm --dir apps/notebook-cloud exec tsc -p tsconfig.json --noEmit`
- `pnpm --dir apps/notebook-cloud exec node --import tsx --test test/cloud-access-request-state.test.ts test/viewer-render-props.test.ts test/viewer-shared-cell-surface.test.ts test/cloud-notebook-catalog-access.test.ts`
- `pnpm --dir apps/notebook-cloud build:viewer`
- `cargo xtask lint --fix`
- Local OIDC-backed Wrangler browser smoke:
  - health showed OIDC and app sessions configured
  - created a local notebook and granted the OIDC app-session principal `viewer`
  - opened `/n/<id>/<title>?mode=edit`
  - verified the URL rewrote to `mode=view`
  - verified the toolbar showed `Viewing` and `Request edit`
  - verified no `/access-requests` calls occurred during load
