### PR TITLE
fix(notebook-cloud): hide offline chrome while access loads

### DIFF
--- a/apps/notebook-cloud/test/notebook-view-loading.test.ts
+++ b/apps/notebook-cloud/test/notebook-view-loading.test.ts
@@ -125,6 +125,20 @@ describe("cloud notebook header chrome projection", () => {
     assert.deepEqual(
       projectCloudNotebookHeaderChrome({
         bodyAccessBlocked: true,
+        liveRoomAccessPending: false,
+      }),
+      {
+        showConnectionIdentity: false,
+        showPresenceStatus: false,
+      },
+    );
+  });
+
+  it("hides live collaboration chrome while catalog access is still pending", () => {
+    assert.deepEqual(
+      projectCloudNotebookHeaderChrome({
+        bodyAccessBlocked: false,
+        liveRoomAccessPending: true,
       }),
       {
         showConnectionIdentity: false,
@@ -137,6 +151,7 @@ describe("cloud notebook header chrome projection", () => {
     assert.deepEqual(
       projectCloudNotebookHeaderChrome({
         bodyAccessBlocked: false,
+        liveRoomAccessPending: false,
       }),
       {
         showConnectionIdentity: true,

--- a/apps/notebook-cloud/viewer/notebook-view-loading.ts
+++ b/apps/notebook-cloud/viewer/notebook-view-loading.ts
@@ -20,6 +20,7 @@ export interface CloudNotebookViewSurfaceProjection {
 
 export interface CloudNotebookHeaderChromeProjectionInput {
   bodyAccessBlocked: boolean;
+  liveRoomAccessPending: boolean;
 }
 
 export interface CloudNotebookHeaderChromeProjection {
@@ -58,8 +59,9 @@ export function projectCloudNotebookViewSurface(
 
 export function projectCloudNotebookHeaderChrome({
   bodyAccessBlocked,
+  liveRoomAccessPending,
 }: CloudNotebookHeaderChromeProjectionInput): CloudNotebookHeaderChromeProjection {
-  const showCollaborationChrome = !bodyAccessBlocked;
+  const showCollaborationChrome = !bodyAccessBlocked && !liveRoomAccessPending;
   return {
     showConnectionIdentity: showCollaborationChrome,
     showPresenceStatus: showCollaborationChrome,

--- a/apps/notebook-cloud/viewer/notebook-viewer.tsx
+++ b/apps/notebook-cloud/viewer/notebook-viewer.tsx
@@ -408,6 +408,9 @@ export function NotebookViewer({
   const syncAuthConnectionKey = cloudSyncAuthConnectionKey(authState, {
     hasAppSession,
   });
+  const liveRoomDisabledStatus = loadingPolicy.shouldConnectLiveRoom
+    ? catalogLiveRoomPolicy.disabledStatus
+    : null;
   const resolveSyncAuth = useCallback(
     async (sessionId: string) => {
       const currentAppSessionStatus = appSessionStatusRef.current;
@@ -458,9 +461,7 @@ export function NotebookViewer({
     config,
     hasAppSession,
     loadingPolicy: effectiveLoadingPolicy,
-    liveRoomDisabledStatus: loadingPolicy.shouldConnectLiveRoom
-      ? catalogLiveRoomPolicy.disabledStatus
-      : null,
+    liveRoomDisabledStatus,
     preloadSiftWasm,
     resolveSyncAuth,
     widgetStore,
@@ -1278,6 +1279,7 @@ export function NotebookViewer({
   const notebookBodyAccessBlocked = cloudConnectionDiagnosticBlocksNotebookBody(connectionError);
   const notebookHeaderChrome = projectCloudNotebookHeaderChrome({
     bodyAccessBlocked: notebookBodyAccessBlocked,
+    liveRoomAccessPending: liveRoomDisabledStatus?.kind === "loading",
   });
 
   const toolbar = (


### PR DESCRIPTION
## Summary
- hide the cloud connection identity and presence slots while catalog access is still loading
- keep the existing hidden behavior for access-blocked pages and visible behavior for normal readable notebook pages
- reuse the computed live-room disabled status for both the session hook and header projection

## Verification
- pnpm --dir apps/notebook-cloud exec node --import tsx --test test/notebook-view-loading.test.ts test/cloud-notebook-catalog-access.test.ts
- pnpm --dir apps/notebook-cloud exec tsc -p tsconfig.json --noEmit
- pnpm --dir apps/notebook-cloud build:viewer
- local Wrangler app-session smoke with delayed /api/n?limit=100 catalog response: pending state showed no visible Offline text
- cargo xtask lint --fix