### PR TITLE
fix(notebook-cloud): clarify shared workstation empty state

### DIFF
--- a/apps/notebook-cloud/test/viewer-shell-capabilities.test.ts
+++ b/apps/notebook-cloud/test/viewer-shell-capabilities.test.ts
@@ -70,6 +70,10 @@ test("cloud shell capabilities grant editors full cell and structure editing wit
   assert.equal(capabilities.access.actor?.operator.kind, "browser");
   assert.equal(capabilities.auth.canUseAuthenticatedIdentity, true);
   assert.equal(capabilities.runtime.canWriteRuntimeState, false);
+  assert.equal(
+    capabilities.runtime.target?.detail,
+    "Only the notebook owner can attach compute to run cells in this notebook.",
+  );
 });
 
 test("cloud shell capabilities wait for host mutation support before activating editor mode", () => {
@@ -102,6 +106,10 @@ test("cloud shell capabilities surface execution only when a runtime is availabl
   assert.equal(withoutRuntime.runtime.target?.id, "workstation:none");
   assert.equal(withoutRuntime.runtime.target?.label, "No compute session");
   assert.equal(withoutRuntime.runtime.target?.status, "offline");
+  assert.equal(
+    withoutRuntime.runtime.target?.detail,
+    "Start compute from a user-owned workstation to run cells in this notebook.",
+  );
   assert.equal(withoutRuntime.runtime.target?.defaultEnvironmentLabel, "Not running");
   assert.equal(withoutRuntime.canExecute, false);
 
@@ -151,6 +159,19 @@ test("cloud shell capabilities surface execution only when a runtime is availabl
   assert.equal(editorWithRuntime.runtime.target?.label, "Connected workstation");
   assert.equal(editorWithRuntime.runtime.target?.runtimePeerCount, 1);
   assert.equal(editorWithRuntime.canExecute, false);
+
+  const viewerWithoutRuntime = cloudNotebookShellCapabilities({
+    authState: authState("oidc", "viewer"),
+    connectionScope: "viewer",
+    hasCodeCells: true,
+  });
+  assert.equal(viewerWithoutRuntime.runtime.executionAvailable, false);
+  assert.equal(viewerWithoutRuntime.runtime.target?.id, "workstation:none");
+  assert.equal(
+    viewerWithoutRuntime.runtime.target?.detail,
+    "Only the notebook owner can attach compute to run cells in this notebook.",
+  );
+  assert.equal(viewerWithoutRuntime.canExecute, false);
 
   const ownerWithRuntime = cloudNotebookShellCapabilities({
     authState: authState("oidc", "owner"),

--- a/apps/notebook-cloud/viewer/shell-capabilities.ts
+++ b/apps/notebook-cloud/viewer/shell-capabilities.ts
@@ -122,6 +122,7 @@ export function cloudNotebookShellCapabilities({
     canUseAuthenticatedIdentity: authenticated && !authNeedsAttention,
     needsAttention: authNeedsAttention,
   };
+  const canChooseHostedWorkstation = accessLevel === "owner" && auth.canUseAuthenticatedIdentity;
   const access = {
     level: accessLevel,
     source: "cloud" as const,
@@ -142,6 +143,7 @@ export function cloudNotebookShellCapabilities({
       runtimePeerCount,
       kernelStatusLabel,
       workstationAttachment,
+      canChooseHostedWorkstation,
     }),
   };
   const accessActor = notebookActorProjectionWithPrincipalImage(
@@ -191,12 +193,14 @@ function cloudRuntimeTarget({
   runtimePeerCount,
   kernelStatusLabel,
   workstationAttachment,
+  canChooseHostedWorkstation,
 }: {
   isRuntimePeer: boolean;
   runtimeAvailable: boolean;
   runtimePeerCount: number;
   kernelStatusLabel: string | null;
   workstationAttachment: WorkstationAttachmentState | null;
+  canChooseHostedWorkstation: boolean;
 }): NotebookShellRuntimeTargetProjection {
   const visibleRuntimePeerCount = Math.max(0, Math.floor(runtimePeerCount));
   if (isRuntimePeer) {
@@ -241,7 +245,9 @@ function cloudRuntimeTarget({
     status: "offline",
     label: "No compute session",
     statusLabel: "Offline",
-    detail: "Start compute from a user-owned workstation to run cells in this notebook.",
+    detail: canChooseHostedWorkstation
+      ? "Start compute from a user-owned workstation to run cells in this notebook."
+      : "Only the notebook owner can attach compute to run cells in this notebook.",
     providerLabel: "Cloud room",
     defaultEnvironmentLabel: "Not running",
     environmentLabel: "Not running",


### PR DESCRIPTION
## Summary
- Make the hosted no-compute workstation target use owner-only wording for shared viewer/editor access.
- Preserve the existing owner setup prompt and add projection assertions for owner, editor, and viewer cases.

## Verification
- pnpm --dir apps/notebook-cloud exec node --import tsx --test test/viewer-shell-capabilities.test.ts
- pnpm --dir apps/notebook-cloud exec tsc -p tsconfig.json --noEmit
- cargo xtask lint --fix