### PR TITLE
fix(notebook-cloud): open new notebooks in edit mode

### DIFF
--- a/apps/notebook-cloud/test/notebook-dashboard.test.ts
+++ b/apps/notebook-cloud/test/notebook-dashboard.test.ts
@@ -3,6 +3,7 @@ import { describe, it } from "node:test";
 import {
   cloudNotebookDashboardOpenUrl,
   cloudNotebookDisplayTitle,
+  cloudNotebookOpenUrlWithMode,
   cloudNotebookShortId,
   projectCloudNotebookDashboard,
   projectCloudNotebookDashboardView,
@@ -164,6 +165,17 @@ describe("cloud notebook dashboard projection", () => {
     assert.equal(
       cloudNotebookDashboardOpenUrl(owned),
       "http://localhost/n/owned-notebook/Owned%20notebook?mode=edit#section-a",
+    );
+  });
+
+  it("opens newly created notebooks in edit mode on the current browser origin", () => {
+    assert.equal(
+      cloudNotebookOpenUrlWithMode(
+        "https://preview.runt.run/n/new-notebook/Exploration%20Notes",
+        "edit",
+        { browserOrigin: "http://localhost:45320" },
+      ),
+      "http://localhost:45320/n/new-notebook/Exploration%20Notes?mode=edit",
     );
   });
 

--- a/apps/notebook-cloud/viewer/notebook-dashboard.ts
+++ b/apps/notebook-cloud/viewer/notebook-dashboard.ts
@@ -169,8 +169,18 @@ export function cloudNotebookDashboardOpenUrl(
   notebook: CloudNotebookListItem,
   options: { browserOrigin?: string | null } = {},
 ): string {
+  return cloudNotebookOpenUrlWithMode(notebook.viewer_url, cloudNotebookDefaultOpenMode(notebook), {
+    browserOrigin: options.browserOrigin,
+  });
+}
+
+export function cloudNotebookOpenUrlWithMode(
+  viewerUrl: string,
+  mode: CloudNotebookUrlMode,
+  options: { browserOrigin?: string | null } = {},
+): string {
   return cloudNotebookViewerUrlOnBrowserOrigin(
-    cloudNotebookUrlWithMode(notebook.viewer_url, cloudNotebookDefaultOpenMode(notebook)),
+    cloudNotebookUrlWithMode(viewerUrl, mode),
     options.browserOrigin ?? currentBrowserOrigin(),
   );
 }

--- a/apps/notebook-cloud/viewer/notebook-list-view.tsx
+++ b/apps/notebook-cloud/viewer/notebook-list-view.tsx
@@ -29,7 +29,7 @@ import type {
   CloudViewerAuthConfig,
 } from "./cloud-viewer-types";
 import {
-  cloudNotebookViewerUrlOnBrowserOrigin,
+  cloudNotebookOpenUrlWithMode,
   projectCloudNotebookDashboard,
   type CloudNotebookListItem,
 } from "./notebook-dashboard";
@@ -202,7 +202,9 @@ export function CloudNotebookListView({ authConfig }: { authConfig: CloudViewerA
         throw new Error("Unable to create notebook: response shape was invalid");
       }
       window.location.assign(
-        cloudNotebookViewerUrlOnBrowserOrigin(body.viewer_url, window.location.origin),
+        cloudNotebookOpenUrlWithMode(body.viewer_url, "edit", {
+          browserOrigin: window.location.origin,
+        }),
       );
     } catch (error) {
       setCreateState("idle");


### PR DESCRIPTION
## Summary
- Route newly created notebooks through the same mode-aware URL helper used by dashboard links.
- Force post-create navigation to mode=edit so owners land with edit controls visible.
- Add a regression test for create-style URLs projected onto the current browser origin.

## Verification
- pnpm --dir apps/notebook-cloud exec node --import tsx --test test/notebook-dashboard.test.ts
- pnpm --dir apps/notebook-cloud exec tsc -p tsconfig.json --noEmit
- pnpm --dir apps/notebook-cloud build:viewer
- Browser local Wrangler smoke: created Quill local edit landing; landed at /n/.../Quill%20local%20edit%20landing?mode=edit with Editing, Add code cell, and Add markdown cell visible.
- Preview deploy smoke: shared editor workstation rail shows owner-only compute copy; view-only ?mode=edit link rewrites to ?mode=view without passive /access-requests calls.
- cargo xtask lint --fix