### PR TITLE
fix(notebook): harden browser e2e output waiters

### DIFF
--- a/apps/notebook/e2e/helpers.ts
+++ b/apps/notebook/e2e/helpers.ts
@@ -211,7 +211,7 @@ export async function getExecutionPerformanceSnapshot(
 }
 
 export async function waitForOutputContaining(cell: Locator, text: string, timeout = 60_000) {
-  const output = cell.locator('[data-slot="ansi-stream-output"]');
+  const output = cell.locator('[data-slot="ansi-stream-output"]').filter({ hasText: text }).first();
   await expect(output).toContainText(text, { timeout });
   return output;
 }
@@ -219,9 +219,12 @@ export async function waitForOutputContaining(cell: Locator, text: string, timeo
 export async function waitForOutputMatching(cell: Locator, matcher: RegExp, timeout = 60_000) {
   const output = cell.locator('[data-slot="ansi-stream-output"]');
   await expect
-    .poll(async () => ((await output.count()) > 0 ? output.innerText() : ""), {
-      timeout,
-    })
+    .poll(
+      async () => ((await output.count()) > 0 ? (await output.allInnerTexts()).join("\n") : ""),
+      {
+        timeout,
+      },
+    )
     .toMatch(matcher);
   return output;
 }


### PR DESCRIPTION
## Summary
- make `waitForOutputContaining` target the stream output node that contains the expected text
- make `waitForOutputMatching` aggregate stream output text before matching

## Why
The current main Browser E2E lane fails in `noisy-output-interrupt.spec.ts` after a cell emits multiple stream output nodes. Playwright strict mode rejects `toContainText` on the unfiltered multi-node locator.

## Validation
- `pnpm --filter notebook-ui test:e2e:browser -- --project=chromium --workers=1 apps/notebook/e2e/noisy-output-interrupt.spec.ts apps/notebook/e2e/execution-performance.spec.ts`
- `RUNTIMED_INTEGRATION_TEST=1 RUNTIMED_BINARY=/home/ubuntu/codex/nteract/target/release/runtimed RUNTIMED_LOG_LEVEL=debug RUNTIMED_WORKSPACE_PATH=/home/ubuntu/codex/nteract RUNTIMED_TEST_UV_POOL_SIZE=1 RUNTIMED_TEST_CONDA_POOL_SIZE=0 RUNTIMED_INTEGRATION_LOG_DIR=/tmp/nteract-local-deno-integration-logs UV_PROJECT_ENVIRONMENT=/home/ubuntu/codex/nteract/.venv /home/ubuntu/codex/nteract/.venv/bin/python -m pytest tests/test_daemon_integration.py::TestDenoKernel -vv --tb=short`
- `cargo xtask lint --fix`