### PR TITLE
fix(notebook): consume disabled run shortcuts

### DIFF
--- a/apps/notebook/src/components/CodeCell.tsx
+++ b/apps/notebook/src/components/CodeCell.tsx
@@ -536,6 +536,7 @@ export const CodeCell = memo(function CodeCell({
             onInsertCellAfter();
           }
         : undefined,
+    consumeExecutionShortcuts: !readOnly || canExecute,
     onDelete,
     cellId: cell.id,
   });

--- a/apps/notebook/src/components/__tests__/notebook-view-capabilities-source.test.ts
+++ b/apps/notebook/src/components/__tests__/notebook-view-capabilities-source.test.ts
@@ -79,7 +79,7 @@ describe("NotebookView shell capabilities", () => {
     expect(sourceText).toMatch(/data-notebook-synced=\{!isLoading && !loadError\}/);
   });
 
-  it("does not install code execution keybindings when execution is unavailable", () => {
+  it("consumes code execution keybindings when execution is unavailable", () => {
     const sourceText = readFileSync(
       join(process.cwd(), "apps/notebook/src/components/CodeCell.tsx"),
       "utf8",
@@ -87,7 +87,9 @@ describe("NotebookView shell capabilities", () => {
 
     expect(sourceText).toMatch(/canExecute\?: boolean;/);
     expect(sourceText).toMatch(/onExecute: canExecute \? handleExecute : undefined/);
+    expect(sourceText).toMatch(/onExecuteInPlace: canExecute \? handleExecuteInPlace : undefined/);
     expect(sourceText).toMatch(/onExecuteAndInsert:\s+canExecute && onInsertCellAfter/);
+    expect(sourceText).toMatch(/consumeExecutionShortcuts: !readOnly \|\| canExecute/);
     expect(sourceText).toMatch(/canExecute=\{canExecute\}/);
     expect(sourceText).toMatch(/showReadoutWhenDisabled=\{!readOnly\}/);
   });

--- a/apps/notebook/src/hooks/__tests__/useCellKeyboardNavigation.test.ts
+++ b/apps/notebook/src/hooks/__tests__/useCellKeyboardNavigation.test.ts
@@ -67,4 +67,23 @@ describe("useCellKeyboardNavigation", () => {
 
     expect(onExecute).toHaveBeenCalledTimes(2);
   });
+
+  it("consumes execution shortcuts without executing or moving focus when requested", () => {
+    const onFocusNext = vi.fn();
+
+    const { result } = renderHook(() =>
+      useCellKeyboardNavigation({
+        onFocusPrevious: vi.fn(),
+        onFocusNext,
+        consumeExecutionShortcuts: true,
+      }),
+    );
+
+    expect(bindingFor(result.current, "Shift-Enter").run({} as EditorView)).toBe(true);
+    expect(bindingFor(result.current, "Ctrl-Enter").run({} as EditorView)).toBe(true);
+    expect(bindingFor(result.current, "Mod-Enter").run({} as EditorView)).toBe(true);
+    expect(bindingFor(result.current, "Alt-Enter").run({} as EditorView)).toBe(true);
+
+    expect(onFocusNext).not.toHaveBeenCalled();
+  });
 });

--- a/apps/notebook/src/hooks/useCellKeyboardNavigation.ts
+++ b/apps/notebook/src/hooks/useCellKeyboardNavigation.ts
@@ -8,6 +8,7 @@ interface UseCellKeyboardNavigationOptions {
   onExecute?: () => void;
   onExecuteInPlace?: () => void;
   onExecuteAndInsert?: () => void;
+  consumeExecutionShortcuts?: boolean;
   onDelete?: () => void;
   /** Cell ID for debug logging */
   cellId?: string;
@@ -27,6 +28,7 @@ export function useCellKeyboardNavigation({
   onExecute,
   onExecuteInPlace,
   onExecuteAndInsert,
+  consumeExecutionShortcuts = false,
   onDelete,
   cellId,
 }: UseCellKeyboardNavigationOptions): KeyBinding[] {
@@ -98,13 +100,15 @@ export function useCellKeyboardNavigation({
             },
           ]
         : []),
-      ...(onExecute
+      ...(onExecute || consumeExecutionShortcuts
         ? [
             {
               key: "Shift-Enter",
               run: () => {
-                onExecuteRef.current?.();
-                onFocusNextRef.current("start");
+                if (onExecuteRef.current) {
+                  onExecuteRef.current();
+                  onFocusNextRef.current("start");
+                }
                 return true;
               },
             },
@@ -124,7 +128,7 @@ export function useCellKeyboardNavigation({
             },
           ]
         : []),
-      ...(onExecuteAndInsert
+      ...(onExecuteAndInsert || consumeExecutionShortcuts
         ? [
             {
               key: "Alt-Enter",
@@ -137,6 +141,6 @@ export function useCellKeyboardNavigation({
         : []),
     ],
     // Only recreate if the presence of optional callbacks changes
-    [!!onExecute, !!onExecuteInPlace, !!onExecuteAndInsert, !!onDelete],
+    [!!onExecute, !!onExecuteInPlace, !!onExecuteAndInsert, consumeExecutionShortcuts, !!onDelete],
   );
 }


### PR DESCRIPTION
Summary
- Keep code-cell run keybindings installed for editable cells even when execution is unavailable.
- Consume Shift/Ctrl/Mod/Alt Enter as no-ops when execution is disabled, so CodeMirror does not insert newlines or move focus.
- Preserve cloud owner-only execution because disabled shortcuts still receive no execution callback.

Verification
- pnpm test:run apps/notebook/src/hooks/__tests__/useCellKeyboardNavigation.test.ts apps/notebook/src/components/__tests__/notebook-view-capabilities-source.test.ts
- pnpm --dir apps/notebook-cloud typecheck
- pnpm --filter notebook-ui exec tsc -p tsconfig.json --noEmit
- cargo xtask lint --fix
- Local Wrangler browser smoke: non-owner editor ACL on a hosted notebook, source set to print('editor cannot run'), Shift/Ctrl/Alt/Meta Enter left source unchanged, kept focus in the editor, and did not produce the new output.