### PR TITLE
perf(notebook-cloud): preload notebook route from dashboard

### DIFF
--- a/apps/notebook-cloud/src/index.ts
+++ b/apps/notebook-cloud/src/index.ts
@@ -4234,6 +4234,14 @@ interface ViewerShellConfig extends Record<string, unknown> {
   workstationsEndpoint?: string;
 }
 
+interface ViewerShellResourceHints {
+  notebookRouteAssets?: ViewerNotebookRouteAssets;
+  outputDocumentBaseUrl?: string | null;
+  rendererAssetsBasePath?: string;
+  runtimedWasmModulePath?: string | null;
+  runtimedWasmPath?: string | null;
+}
+
 function rootNotebookListRedirect(request: Request): Response {
   const url = new URL(request.url);
   url.pathname = "/n";
@@ -4242,6 +4250,9 @@ function rootNotebookListRedirect(request: Request): Response {
 
 async function notebookListViewer(request: Request, env: Env): Promise<Response> {
   const bootstrap = await notebookListBootstrap(request, env);
+  const resourceHints = notebookListBootstrapHasNotebooks(bootstrap)
+    ? { notebookRouteAssets: await notebookRouteAssetNames(env) }
+    : null;
   return responseForRequestMethod(
     request,
     viewerShell(
@@ -4253,6 +4264,7 @@ async function notebookListViewer(request: Request, env: Env): Promise<Response>
       authConfigForRequest(request, env),
       null,
       bootstrap,
+      resourceHints,
     ),
   );
 }
@@ -4341,6 +4353,7 @@ function viewerShell(
   authConfig: unknown,
   config: ViewerShellConfig | null,
   bootstrap: unknown | null = null,
+  resourceHints: ViewerShellResourceHints | null = config,
 ): Response {
   const title = escapeHtml(metadata.title);
   const description = escapeHtml(metadata.description);
@@ -4358,7 +4371,7 @@ function viewerShell(
   <link rel="icon" href="/favicon.svg" type="image/svg+xml" />
   <style id="nteract-cloud-viewer-theme-surface">${viewerThemeFirstPaintStyle()}</style>
   <script>${viewerThemeBootstrapScript()}</script>
-  ${viewerResourceHints(config)}
+  ${viewerResourceHints(resourceHints)}
   <link rel="stylesheet" href="/assets/notebook-cloud-viewer.css" />
 </head>
 <body>
@@ -4419,13 +4432,18 @@ async function notebookListBootstrap(
   };
 }
 
-function viewerResourceHints(config: ViewerShellConfig | null): string {
+function notebookListBootstrapHasNotebooks(bootstrap: Record<string, unknown> | null): boolean {
+  const notebooks = bootstrap?.notebooks;
+  return Array.isArray(notebooks) && notebooks.length > 0;
+}
+
+function viewerResourceHints(config: ViewerShellResourceHints | null): string {
   const viewerEntryHint = `<link rel="modulepreload" href="/assets/notebook-cloud-viewer.js" />`;
   if (!config) {
     return viewerEntryHint;
   }
 
-  return [
+  const hints = [
     ...preconnectResourceHints([
       config.rendererAssetsBasePath,
       config.outputDocumentBaseUrl,
@@ -4433,11 +4451,20 @@ function viewerResourceHints(config: ViewerShellConfig | null): string {
     ]),
     viewerEntryHint,
     ...notebookRouteResourceHints(config.notebookRouteAssets),
-    `<link rel="modulepreload" href="${escapeHtml(config.runtimedWasmModulePath)}" crossorigin />`,
-    `<link rel="prefetch" href="${escapeHtml(
-      config.runtimedWasmPath,
-    )}" as="fetch" type="application/wasm" crossorigin />`,
-  ].join("\n  ");
+  ];
+  if (config.runtimedWasmModulePath) {
+    hints.push(
+      `<link rel="modulepreload" href="${escapeHtml(config.runtimedWasmModulePath)}" crossorigin />`,
+    );
+  }
+  if (config.runtimedWasmPath) {
+    hints.push(
+      `<link rel="prefetch" href="${escapeHtml(
+        config.runtimedWasmPath,
+      )}" as="fetch" type="application/wasm" crossorigin />`,
+    );
+  }
+  return hints.join("\n  ");
 }
 
 function notebookRouteResourceHints(assets: ViewerNotebookRouteAssets | undefined): string[] {

--- a/apps/notebook-cloud/test/worker-routes.test.ts
+++ b/apps/notebook-cloud/test/worker-routes.test.ts
@@ -570,6 +570,50 @@ describe("Worker artifact routes", () => {
     assert.doesNotMatch(html, /bootstrap@example\.test|bootstrap-user|Bootstrap User/);
   });
 
+  it("preloads notebook route assets when the bootstrapped notebook home has rows", async () => {
+    const { env: oidcEnv, token } = await oidcTokenFixture({
+      subject: "home-preload-user",
+      email: "home-preload@example.test",
+      extraPayload: { email_verified: true },
+      name: "Home Preload User",
+    });
+    const seenAssetPaths: string[] = [];
+    const env = fakeEnv({
+      ...oidcEnv,
+      ASSETS: fakeNotebookRouteAssets(seenAssetPaths),
+      NOTEBOOK_CLOUD_APP_SESSION_SECRET: APP_SESSION_SECRET,
+    });
+    seedNotebook(env, "home-preload-visible");
+    seedAcl(env, {
+      notebookId: "home-preload-visible",
+      subject: "user:anaconda:home-preload-user",
+      scope: "owner",
+    });
+    const cookie = await oidcAppSessionCookie(env, token);
+
+    const response = await worker.fetch(
+      new Request("https://cloud.test/n", {
+        headers: { Cookie: cookie },
+      }),
+      env,
+      fakeContext(),
+    );
+
+    assert.equal(response.status, 200);
+    const html = await response.text();
+    assert.deepEqual(seenAssetPaths, ["/assets/notebook-route-assets.json"]);
+    assert.match(html, /rel="modulepreload" href="\/assets\/notebook-route\.0123456789abcdef\.js"/);
+    assert.match(html, /rel="modulepreload" href="\/assets\/MarkdownText\.0123456789abcdef\.js"/);
+    assert.match(html, /rel="modulepreload" href="\/assets\/markdown\.0123456789abcdef\.js"/);
+    assert.match(
+      html,
+      /rel="preload" href="\/assets\/notebook-route\.0123456789abcdef\.css" as="style"/,
+    );
+    assert.match(html, /rel="preload" href="\/assets\/katex\.0123456789abcdef\.css" as="style"/);
+    assert.doesNotMatch(html, /id="nteract-cloud-viewer-config"/);
+    assert.doesNotMatch(html, /runtimed_wasm\.0123456789abcdef/);
+  });
+
   it("bootstraps notebook viewers with safe app session status", async () => {
     const { env: oidcEnv, token } = await oidcTokenFixture({
       subject: "viewer-bootstrap-user",
@@ -2131,6 +2175,7 @@ describe("Worker artifact routes", () => {
       provider: "runtime_peer",
       default_environment_label: "Current Python",
       environment_policy: "current_python",
+      runtime_session_id: body.job.job_id,
       status: "connecting",
       status_message: "Waiting for Lab2 to accept the compute request.",
       cpu_count: 8,
@@ -2291,6 +2336,7 @@ describe("Worker artifact routes", () => {
       provider: "runtime_peer",
       default_environment_label: "Current Python",
       environment_policy: "current_python",
+      runtime_session_id: "job-1",
       status: "ready",
       status_message: null,
       cpu_count: 8,
@@ -5583,6 +5629,27 @@ function jsonResponse(value: unknown): Response {
       "Content-Type": "application/json",
     },
   });
+}
+
+function fakeNotebookRouteAssets(seenPaths: string[] = []): Env["ASSETS"] {
+  return {
+    fetch: async (request: Request) => {
+      const pathname = new URL(request.url).pathname;
+      seenPaths.push(pathname);
+      if (pathname === "/assets/notebook-route-assets.json") {
+        return jsonResponse({
+          modulepreload: [
+            "notebook-route.0123456789abcdef.js",
+            "MarkdownText.0123456789abcdef.js",
+            "markdown.0123456789abcdef.js",
+            "katex.min.0123456789abcdef.js",
+          ],
+          stylepreload: ["notebook-route.0123456789abcdef.css", "katex.0123456789abcdef.css"],
+        });
+      }
+      return new Response("not found", { status: 404 });
+    },
+  };
 }
 
 async function oidcAppSessionCookie(env: Env, token: string): Promise<string> {


### PR DESCRIPTION
## Summary
- Preload the notebook route asset manifest from `/n` when the Worker already bootstraps a signed-in notebook list with rows.
- Keep signed-out and empty dashboard shells light, and keep dashboard HTML free of notebook runtime config.
- Update workstation attachment route expectations for the existing `runtime_session_id` field so the worker route suite is green.

## Verification
- `node --import tsx --test test/html.test.ts test/worker-routes.test.ts`
- `pnpm --dir apps/notebook-cloud typecheck`
- `cargo xtask lint --fix`