### PR TITLE
perf(notebook-cloud): allow cached blob fetches

### DIFF
--- a/apps/notebook-cloud/src/blob-resolver.ts
+++ b/apps/notebook-cloud/src/blob-resolver.ts
@@ -28,7 +28,6 @@ export function createNotebookCloudBlobResolver(input: {
     url,
     ...(authenticatedBinaryDisplayUrls
       ? {
-          requestInit: { cache: "no-store" },
           async displayUrl(ref: BlobRef, mediaType?: string) {
             const cacheKey = displayUrlCacheKey(ref, mediaType);
             const cached = displayUrls.get(cacheKey);

--- a/apps/notebook-cloud/test/blob-resolver.test.ts
+++ b/apps/notebook-cloud/test/blob-resolver.test.ts
@@ -129,6 +129,32 @@ describe("notebook cloud blob resolver", () => {
     ]);
   });
 
+  it("lets ordinary authenticated blob fetches use the browser cache", async () => {
+    const fetchCalls: Array<{ input: RequestInfo | URL; init?: RequestInit }> = [];
+    const resolver = createNotebookCloudBlobResolver({
+      baseUrl: "https://viewer.example.test/n/notebook-1",
+      blobBasePath: "/api/n/notebook-1/blobs/",
+      authenticatedBinaryDisplayUrls: true,
+      fetchImpl: async (input, init) => {
+        fetchCalls.push({ input, init });
+        return new Response("<table></table>", {
+          headers: { "Content-Type": "text/html" },
+        });
+      },
+    });
+
+    const response = await resolver.fetch({ blob: "sha256:html", media_type: "text/html" });
+
+    assert.equal(response.status, 200);
+    assert.equal(await response.text(), "<table></table>");
+    assert.deepEqual(fetchCalls, [
+      {
+        input: "https://viewer.example.test/api/n/notebook-1/blobs/sha256%3Ahtml",
+        init: undefined,
+      },
+    ]);
+  });
+
   it("coalesces concurrent protected binary display URL requests", async () => {
     const originalFileReader = globalThis.FileReader;
     class TestFileReader {


### PR DESCRIPTION
## Summary
- Stop applying `cache: "no-store"` to ordinary cloud `blobResolver.fetch` calls when authenticated binary display URLs are enabled.
- Keep protected binary display URL fetches on their explicit no-store path.
- Add coverage that text/html blob resolution can use the browser HTTP cache while binary display fetches remain protected.

## Live preview evidence
On deployed preview build `38c4dd5e`, opening the workstation smoke notebook showed repeated parent-side HTML blob requests with `cache-control: no-cache` for the same immutable blob hashes. Those responses were Cloudflare cache hits, but the browser still had to make network requests because the resolver forced no-store for all blob fetches.

## Verification
- `node --import tsx --test test/cloud-session-auth-stability.test.ts test/blob-resolver.test.ts`
- `pnpm --dir apps/notebook-cloud typecheck`
- `cargo xtask lint --fix`