### PR TITLE
fix(notebook-cloud): start compute from run shortcuts

### DIFF
--- a/apps/notebook-cloud/test/viewer-shared-cell-surface.test.ts
+++ b/apps/notebook-cloud/test/viewer-shared-cell-surface.test.ts
@@ -11,6 +11,14 @@ test("cloud notebook body renders through the desktop NotebookView surface", () 
   assert.match(sourceText, /<NotebookView[\s\S]*cellIds=\{notebookCellIds\}/);
   assert.match(sourceText, /<NotebookView[\s\S]*capabilities=\{shellCapabilities\}/);
   assert.match(sourceText, /<NotebookView[\s\S]*canAcceptCellMutations=\{canAcceptCellMutations\}/);
+  assert.match(
+    sourceText,
+    /<NotebookView[\s\S]*onRequestExecuteCell=\{[\s\S]*canRequestCloudCellExecution \? handleCloudRequestExecuteCell : undefined[\s\S]*\}/,
+  );
+  assert.match(
+    sourceText,
+    /const canRequestCloudCellExecution =[\s\S]*canStartSelectedWorkstation && shellCapabilities\.canEditCells && canAcceptCellMutations/,
+  );
   assert.doesNotMatch(sourceText, /\.\.\/\.\.\/notebook\/src\/components\/NotebookView/);
   assert.doesNotMatch(sourceText, /canAcceptCellMutations=\{false\}/);
   assert.doesNotMatch(sourceText, /readOnly=\{!canEditMarkdown\}/);
@@ -70,6 +78,10 @@ test("cloud viewer imports desktop notebook code only through public surfaces", 
       const importPath = match[1] ?? "";
       if (
         importPath.includes("/wasm/") ||
+        // Entry-only host shims install cloud-safe logger and external-link
+        // behavior for shared notebook components.
+        (fileName === "index.tsx" &&
+          (importPath.endsWith("/lib/logger") || importPath.endsWith("/lib/open-url"))) ||
         importPath.endsWith("/notebook-surface") ||
         // Headless store surface: same public symbols, no component/CSS
         // imports, so node-run tests can exercise the bridge directly.
@@ -212,7 +224,7 @@ test("cloud passes shared NotebookView source and output visibility handlers", (
 });
 
 test("cloud wires shared presence and cleans projected store entries", () => {
-  const sourceText = viewerCorpus;
+  const sourceText = viewerFileContaining("export function NotebookViewer");
   const sessionSourcePath = new URL("../viewer/cloud-viewer-session.ts", import.meta.url);
   const sessionSourceText = readFileSync(sessionSourcePath, "utf8");
   const bridgeSourcePath = new URL("../viewer/notebook-view-store-bridge.ts", import.meta.url);
@@ -277,6 +289,7 @@ test("cloud workstation registry state lives in the workstation manager hook", (
   );
   assert.match(sourceText, /selection=\{workstationSelection\}/);
   assert.match(sourceText, /busyWorkstationId=\{busyWorkstationId\}/);
+  assert.match(sourceText, /canStartSelectedWorkstation/);
   assert.match(sourceText, /onAttachWorkstation=\{onAttachWorkstation\}/);
   assert.match(sourceText, /onSetDefaultWorkstation=\{onSetDefaultWorkstation\}/);
   assert.doesNotMatch(sourceText, /fetchCloudWorkstations/);
@@ -331,6 +344,8 @@ test("cloud presence chrome renders as an isolated host avatar stack", () => {
 
 test("cloud edit mode chrome renders through the shared shell component", () => {
   const sourceText = viewerFileContaining("export function NotebookViewer");
+  const editModeButtonSourcePath = new URL("../viewer/cloud-edit-mode-button.tsx", import.meta.url);
+  const editModeButtonSourceText = readFileSync(editModeButtonSourcePath, "utf8");
   const authControlsSourcePath = new URL("../viewer/cloud-auth-controls.tsx", import.meta.url);
   const authControlsSourceText = readFileSync(authControlsSourcePath, "utf8");
   const shellHookSourcePath = new URL("../viewer/use-cloud-shell-capabilities.ts", import.meta.url);
@@ -339,16 +354,16 @@ test("cloud edit mode chrome renders through the shared shell component", () => 
   const cssText = readFileSync(cssPath, "utf8");
 
   assert.match(sourceText, /useCloudShellCapabilities/);
-  assert.match(authControlsSourceText, /NotebookEditModeButton/);
+  assert.match(editModeButtonSourceText, /NotebookEditModeButton/);
   assert.match(
-    authControlsSourceText,
+    editModeButtonSourceText,
     /<NotebookEditModeButton[\s\S]*mode=\{accessPending \? "view" : interaction\.selectedMode\}/,
   );
   assert.match(
-    authControlsSourceText,
+    editModeButtonSourceText,
     /<NotebookEditModeButton[\s\S]*state=\{accessPending \? "viewing" : interaction\.state\}/,
   );
-  assert.match(authControlsSourceText, /<NotebookEditModeButton[\s\S]*variant="segmented"/);
+  assert.match(editModeButtonSourceText, /<NotebookEditModeButton[\s\S]*variant="segmented"/);
   assert.match(authControlsSourceText, /authConfig\.localDev\?\.label\?\.trim\(\)/);
   assert.match(authControlsSourceText, /return "Use local auth"/);
   assert.match(authControlsSourceText, /window\.location\.assign\(localDevAuth\.authUrl\)/);
@@ -357,14 +372,14 @@ test("cloud edit mode chrome renders through the shared shell component", () => 
     /const providerLabel = authConfig\.oidc\?\.providerLabel\?\.trim\(\)/,
   );
   assert.match(
-    authControlsSourceText,
+    editModeButtonSourceText,
     /<NotebookEditModeButton[\s\S]*requestedEditLabel=\{reconnecting \? "Offline" : "Request sent"\}/,
   );
   assert.match(
-    authControlsSourceText,
+    editModeButtonSourceText,
     /<NotebookEditModeButton[\s\S]*requestedEditTitle=\{[\s\S]*reconnecting \? "Offline while the room reconnects" : "Edit access requested"/,
   );
-  assert.match(authControlsSourceText, /onModeChange=\{\(mode\) => \{/);
+  assert.match(editModeButtonSourceText, /onModeChange=\{\(mode\) => \{/);
   assert.match(sourceText, /accessLevel=\{shellCapabilities\.access\.level\}/);
   assert.doesNotMatch(sourceText, /projectCloudNotebookEditAccess/);
   assert.doesNotMatch(sourceText, /cloudNotebookShellCapabilities/);
@@ -387,14 +402,17 @@ test("cloud edit mode chrome renders through the shared shell component", () => 
     /setSelectedInteractionMode\("edit"\);[\s\S]*\[canAcceptCellMutations, connectionPeerId, connectionScope/,
   );
   assert.match(sourceText, /accessPending=\{editAccessPending\}/);
-  assert.match(authControlsSourceText, /state=\{accessPending \? "viewing" : interaction\.state\}/);
-  assert.match(authControlsSourceText, /disabled=\{accessPending\}/);
   assert.match(
-    authControlsSourceText,
+    editModeButtonSourceText,
+    /state=\{accessPending \? "viewing" : interaction\.state\}/,
+  );
+  assert.match(editModeButtonSourceText, /disabled=\{accessPending\}/);
+  assert.match(
+    editModeButtonSourceText,
     /const canSwitchToEdit = accessLevel === "editor" \|\| accessLevel === "owner"/,
   );
-  assert.match(authControlsSourceText, /editLabel=\{editLabel\}/);
-  assert.match(authControlsSourceText, /editTitle=\{editTitle\}/);
+  assert.match(editModeButtonSourceText, /editLabel=\{editLabel\}/);
+  assert.match(editModeButtonSourceText, /editTitle=\{editTitle\}/);
   assert.match(
     sourceText,
     /const showCloudCommandToolbar = shouldShowNotebookDocumentCommandToolbar\(shellCapabilities, \{[\s\S]*reserve: editAccessPending,[\s\S]*\}\)/,
@@ -411,7 +429,7 @@ test("cloud edit mode chrome renders through the shared shell component", () => 
   assert.doesNotMatch(sourceText, /CloudNotebookCommandToolbarPlaceholder/);
   assert.doesNotMatch(cssText, /cloud-edit-mode-placeholder/);
   assert.doesNotMatch(cssText, /cloud-command-toolbar-placeholder/);
-  assert.match(authControlsSourceText, /if \(mode === "edit" && !canSwitchToEdit\) \{/);
+  assert.match(editModeButtonSourceText, /if \(mode === "edit" && !canSwitchToEdit\) \{/);
   assert.match(sourceText, /projectCloudAccessRequestTransition\(\{/);
   assert.match(
     sourceText,

--- a/apps/notebook-cloud/test/viewer-source-corpus.ts
+++ b/apps/notebook-cloud/test/viewer-source-corpus.ts
@@ -17,6 +17,7 @@ import { readFileSync } from "node:fs";
 
 const VIEWER_MODULE_FILES = [
   "index.tsx",
+  "notebook-route.tsx",
   "notebook-viewer.tsx",
   "home-view.tsx",
   "notebook-list-view.tsx",

--- a/apps/notebook-cloud/test/worker-routes.test.ts
+++ b/apps/notebook-cloud/test/worker-routes.test.ts
@@ -2119,7 +2119,12 @@ describe("Worker artifact routes", () => {
     );
     assert.ok(runtimeStateRequest);
     const payload = (await runtimeStateRequest.json()) as {
-      attachment?: { status?: string; status_message?: string | null; workstation_id?: string };
+      attachment?: {
+        status?: string;
+        status_message?: string | null;
+        workstation_id?: string;
+        runtime_session_id?: string | null;
+      };
       close_runtime_peers?: boolean;
       close_reason?: string;
     };
@@ -2133,6 +2138,7 @@ describe("Worker artifact routes", () => {
       environment_policy: "current_python",
       status: "connecting",
       status_message: "Waiting for Lab2 to accept the compute request.",
+      runtime_session_id: body.job.job_id,
       cpu_count: 8,
       memory_bytes: 16_000_000_000,
       working_directory: "/home/ubuntu/project",
@@ -2283,7 +2289,12 @@ describe("Worker artifact routes", () => {
       "/internal/n/nb-1/workstation-attachment",
     );
     const runtimeStatePayload = (await runtimeStateRequest.json()) as {
-      attachment?: { workstation_id?: string; display_name?: string; status?: string };
+      attachment?: {
+        workstation_id?: string;
+        display_name?: string;
+        status?: string;
+        runtime_session_id?: string | null;
+      };
     };
     assert.deepEqual(runtimeStatePayload.attachment, {
       workstation_id: "ws-lab2",
@@ -2293,6 +2304,7 @@ describe("Worker artifact routes", () => {
       environment_policy: "current_python",
       status: "ready",
       status_message: null,
+      runtime_session_id: "job-1",
       cpu_count: 8,
       memory_bytes: 16_000_000_000,
       working_directory: "/home/ubuntu/project",

--- a/apps/notebook-cloud/viewer/__tests__/use-cloud-workstations.test.tsx
+++ b/apps/notebook-cloud/viewer/__tests__/use-cloud-workstations.test.tsx
@@ -314,8 +314,10 @@ describe("useCloudWorkstationManager pairing", () => {
     await act(async () => {
       await Promise.resolve();
     });
+    expect(result.current.canStartSelectedWorkstation).toBe(true);
     await act(async () => {
-      await result.current.onStartSelectedWorkstation?.();
+      const started = await result.current.onStartSelectedWorkstation?.();
+      expect(started).toBe(true);
     });
 
     expect(clientMocks.requestCloudWorkstationAttachment).toHaveBeenCalledWith(
@@ -350,5 +352,24 @@ describe("useCloudWorkstationManager pairing", () => {
       "ws-lab2",
       { replaceExisting: true },
     );
+  });
+
+  it("does not report a startable workstation without a launch candidate", async () => {
+    clientMocks.fetchCloudWorkstations.mockResolvedValue({
+      defaultWorkstationId: null,
+      workstations: [],
+    });
+    const { result } = renderManager();
+
+    await act(async () => {
+      await Promise.resolve();
+    });
+
+    expect(result.current.canStartSelectedWorkstation).toBe(false);
+    await act(async () => {
+      const started = await result.current.onStartSelectedWorkstation?.();
+      expect(started).toBe(false);
+    });
+    expect(clientMocks.requestCloudWorkstationAttachment).not.toHaveBeenCalled();
   });
 });

--- a/apps/notebook-cloud/viewer/notebook-viewer.tsx
+++ b/apps/notebook-cloud/viewer/notebook-viewer.tsx
@@ -469,6 +469,7 @@ export function NotebookViewer({
     resolveSyncAuth,
     widgetStore,
   });
+  const cloudExecutionStartPromiseRef = useRef<Promise<boolean> | null>(null);
   const cloudNotebookHost = useMemo(
     () =>
       createCloudNotebookHost({
@@ -773,6 +774,7 @@ export function NotebookViewer({
   });
   const {
     busyWorkstationId,
+    canStartSelectedWorkstation,
     onAttachWorkstation,
     onSetDefaultWorkstation,
     onStartSelectedWorkstation,
@@ -935,6 +937,55 @@ export function NotebookViewer({
       });
     },
     [createCloudNotebookClient],
+  );
+  const canRequestCloudCellExecution =
+    canStartSelectedWorkstation && shellCapabilities.canEditCells && canAcceptCellMutations;
+  const startCloudExecutionWorkstation = useCallback(async () => {
+    if (!onStartSelectedWorkstation) {
+      return false;
+    }
+    if (!cloudExecutionStartPromiseRef.current) {
+      cloudExecutionStartPromiseRef.current = onStartSelectedWorkstation({
+        message: "Starting compute. Run is queued for the selected workstation.",
+      }).finally(() => {
+        cloudExecutionStartPromiseRef.current = null;
+      });
+    }
+    return cloudExecutionStartPromiseRef.current;
+  }, [onStartSelectedWorkstation]);
+  const handleCloudRequestExecuteCell = useCallback(
+    (cellId: string) => {
+      if (!canRequestCloudCellExecution || !onStartSelectedWorkstation) {
+        return;
+      }
+      const runtimeClient = createCloudNotebookClient("start compute and execute cell");
+      if (!runtimeClient) return;
+
+      void (async () => {
+        const delivered = await runtimeClient.liveRuntime.engine.flushAndWait();
+        if (!delivered) {
+          console.warn(
+            "[notebook-cloud] start compute and execute request skipped; notebook sync failed",
+          );
+          return;
+        }
+
+        const started = await startCloudExecutionWorkstation();
+        if (!started) {
+          return;
+        }
+
+        await runtimeClient.client.executeCell(cellId);
+      })().catch((error: unknown) => {
+        console.warn("[notebook-cloud] start compute and execute request failed", error);
+      });
+    },
+    [
+      canRequestCloudCellExecution,
+      createCloudNotebookClient,
+      onStartSelectedWorkstation,
+      startCloudExecutionWorkstation,
+    ],
   );
   const handleCloudRunAllCells = useCallback(() => {
     const runtimeClient = createCloudNotebookClient("run all cells");
@@ -1510,6 +1561,9 @@ export function NotebookViewer({
                 sessionRuntimeState={connectionError ? "error" : "ready"}
                 onFocusCell={handleNotebookViewFocus}
                 onExecuteCell={handleCloudExecuteCell}
+                onRequestExecuteCell={
+                  canRequestCloudCellExecution ? handleCloudRequestExecuteCell : undefined
+                }
                 onInterruptKernel={() => {}}
                 onDeleteCell={handleCloudDeleteCell}
                 onAddCell={handleCloudAddCell}

--- a/apps/notebook-cloud/viewer/use-cloud-workstations.ts
+++ b/apps/notebook-cloud/viewer/use-cloud-workstations.ts
@@ -152,7 +152,7 @@ export function useCloudWorkstationManager({
   const handleAttachWorkstation = useCallback(
     async (workstationId: string, options: AttachWorkstationOptions = {}) => {
       if (!config.workstationAttachEndpoint) {
-        return;
+        return false;
       }
       setWorkstationMutation({
         kind: "attach",
@@ -172,10 +172,12 @@ export function useCloudWorkstationManager({
         );
         setWorkstationsError(null);
         await refreshCloudWorkstations();
+        return true;
       } catch (error) {
         setWorkstationsError(error instanceof Error ? error.message : String(error));
         setWorkstationMutation({ kind: "idle", message: null, workstationId: null });
         await refreshCloudWorkstations();
+        return false;
       }
     },
     [authState, config.workstationAttachEndpoint, onOpenWorkstationsRail, refreshCloudWorkstations],
@@ -436,16 +438,21 @@ export function useCloudWorkstationManager({
       const workstationId = workstationLaunchReadiness.workstationId;
       if (!workstationId) {
         onOpenWorkstationsRail();
-        return;
+        return false;
       }
-      await handleAttachWorkstation(workstationId, options);
+      return handleAttachWorkstation(workstationId, options);
     },
     [handleAttachWorkstation, onOpenWorkstationsRail, workstationLaunchReadiness.workstationId],
   );
+  const canStartSelectedWorkstation =
+    canChooseHostedWorkstation &&
+    workstationMutation.kind !== "attach" &&
+    Boolean(workstationLaunchReadiness.workstationId);
 
   return useMemo(
     () => ({
       busyWorkstationId: workstationMutation.workstationId,
+      canStartSelectedWorkstation,
       onStartSelectedWorkstation: canChooseHostedWorkstation ? startSelectedWorkstation : undefined,
       onAttachWorkstation: canChooseHostedWorkstation
         ? (workstationId: string) => handleAttachWorkstation(workstationId, { revealPanel: true })
@@ -459,6 +466,7 @@ export function useCloudWorkstationManager({
       workstationSelection,
     }),
     [
+      canStartSelectedWorkstation,
       canChooseHostedWorkstation,
       handleAttachWorkstation,
       handleCancelPairing,

--- a/apps/notebook/src/components/CodeCell.tsx
+++ b/apps/notebook/src/components/CodeCell.tsx
@@ -76,6 +76,10 @@ interface CodeCellProps {
   onToggleOutputsHidden?: (hidden: boolean) => void;
   /** Executes without moving focus to another cell or following the notebook tail. */
   onExecuteInPlace?: () => void;
+  /** Requests execution when execution controls are not active yet, e.g. by starting compute. */
+  onRequestExecute?: () => void;
+  /** Requests in-place execution when execution controls are not active yet. */
+  onRequestExecuteInPlace?: () => void;
   /** Number of consecutive fully-hidden cells in this group (including this one) */
   hiddenGroupCount?: number;
   /** Callback to expand all cells in a hidden group */
@@ -332,6 +336,8 @@ export const CodeCell = memo(function CodeCell({
   onToggleSourceHidden,
   onToggleOutputsHidden,
   onExecuteInPlace,
+  onRequestExecute,
+  onRequestExecuteInPlace,
   hiddenGroupCount,
   onExpandHiddenGroup,
   hiddenGroupCellIds,
@@ -488,18 +494,20 @@ export const CodeCell = memo(function CodeCell({
   );
 
   const handleExecute = useCallback(() => {
-    if (!canExecute) {
-      return;
+    if (canExecute) {
+      onExecute();
+    } else {
+      onRequestExecute?.();
     }
-    onExecute();
-  }, [canExecute, onExecute]);
+  }, [canExecute, onExecute, onRequestExecute]);
 
   const handleExecuteInPlace = useCallback(() => {
-    if (!canExecute) {
-      return;
+    if (canExecute) {
+      (onExecuteInPlace ?? onExecute)();
+    } else {
+      (onRequestExecuteInPlace ?? onRequestExecute)?.();
     }
-    (onExecuteInPlace ?? onExecute)();
-  }, [canExecute, onExecute, onExecuteInPlace]);
+  }, [canExecute, onExecute, onExecuteInPlace, onRequestExecute, onRequestExecuteInPlace]);
 
   const handleHiddenDisclosureKeyDown = useCallback(
     (event: React.KeyboardEvent) => {
@@ -524,19 +532,21 @@ export const CodeCell = memo(function CodeCell({
   );
 
   // Get keyboard navigation bindings
+  const canRequestExecute = !readOnly && Boolean(onRequestExecute);
+  const canRunExecutionShortcut = canExecute || canRequestExecute;
   const navigationKeyMap = useCellKeyboardNavigation({
     onFocusPrevious: onFocusPrevious ?? (() => {}),
     onFocusNext: handleFocusNextOrCreate,
-    onExecute: canExecute ? handleExecute : undefined,
-    onExecuteInPlace: canExecute ? handleExecuteInPlace : undefined,
+    onExecute: canRunExecutionShortcut ? handleExecute : undefined,
+    onExecuteInPlace: canRunExecutionShortcut ? handleExecuteInPlace : undefined,
     onExecuteAndInsert:
-      canExecute && onInsertCellAfter
+      canRunExecutionShortcut && onInsertCellAfter
         ? () => {
             handleExecute();
             onInsertCellAfter();
           }
         : undefined,
-    consumeExecutionShortcuts: !readOnly || canExecute,
+    consumeExecutionShortcuts: !readOnly || canExecute || canRequestExecute,
     onDelete,
     cellId: cell.id,
   });

--- a/apps/notebook/src/components/NotebookView.tsx
+++ b/apps/notebook/src/components/NotebookView.tsx
@@ -75,6 +75,7 @@ export interface NotebookViewProps {
   sessionRuntimeState?: string | null;
   onFocusCell: (cellId: string) => void;
   onExecuteCell: (cellId: string) => void;
+  onRequestExecuteCell?: (cellId: string) => void;
   onInterruptKernel: () => void;
   onDeleteCell: (cellId: string) => void;
   onUpdateCellSource?: (cellId: string, source: string) => void;
@@ -350,6 +351,7 @@ function NotebookViewContent({
   sessionRuntimeState = null,
   onFocusCell,
   onExecuteCell,
+  onRequestExecuteCell,
   onInterruptKernel,
   onDeleteCell,
   onUpdateCellSource,
@@ -877,10 +879,28 @@ function NotebookViewContent({
             onExecuteCell(cell.id);
           }
         };
+        const requestExecuteCellOrHiddenGroup = onRequestExecuteCell
+          ? () => {
+              const latestHiddenGroup = hiddenGroupsRef.current.get(cell.id);
+              if (latestHiddenGroup && latestHiddenGroup.count > 1) {
+                for (const hiddenCellId of latestHiddenGroup.groupCellIds) {
+                  onRequestExecuteCell(hiddenCellId);
+                }
+              } else {
+                onRequestExecuteCell(cell.id);
+              }
+            }
+          : undefined;
         const executeCellInPlaceOrHiddenGroup = () => {
           suppressTailFollowForInPlaceExecution();
           executeCellOrHiddenGroup();
         };
+        const requestExecuteCellInPlaceOrHiddenGroup = requestExecuteCellOrHiddenGroup
+          ? () => {
+              suppressTailFollowForInPlaceExecution();
+              requestExecuteCellOrHiddenGroup();
+            }
+          : undefined;
 
         return (
           <CodeCell
@@ -900,6 +920,8 @@ function NotebookViewContent({
             onOutputFocusChange={(focused) => handleOutputFocusChange(cell.id, focused)}
             onExecute={executeCellOrHiddenGroup}
             onExecuteInPlace={executeCellInPlaceOrHiddenGroup}
+            onRequestExecute={requestExecuteCellOrHiddenGroup}
+            onRequestExecuteInPlace={requestExecuteCellInPlaceOrHiddenGroup}
             onInterrupt={onInterruptKernel}
             onDelete={canMutateCells ? () => onDeleteCell(cell.id) : undefined}
             onFocusPrevious={onFocusPrevious}

--- a/apps/notebook/src/components/__tests__/notebook-view-capabilities-source.test.ts
+++ b/apps/notebook/src/components/__tests__/notebook-view-capabilities-source.test.ts
@@ -21,6 +21,8 @@ describe("NotebookView shell capabilities", () => {
     );
     expect(sourceText).toMatch(/capabilities\?\.canExecute \?\? !readOnly/);
     expect(sourceText).toMatch(/<CodeCell[\s\S]*canExecute=\{canExecuteCells\}/);
+    expect(sourceText).toMatch(/onRequestExecuteCell\?: \(cellId: string\) => void;/);
+    expect(sourceText).toMatch(/onRequestExecute=\{requestExecuteCellOrHiddenGroup\}/);
     expect(sourceText).toMatch(/<MarkdownCell[\s\S]*readOnly=\{!canEditMarkdownSources\}/);
     expect(sourceText).toMatch(
       /onDelete=\{canMutateCells \? \(\) => onDeleteCell\(cell\.id\) : undefined\}/,
@@ -86,10 +88,21 @@ describe("NotebookView shell capabilities", () => {
     );
 
     expect(sourceText).toMatch(/canExecute\?: boolean;/);
-    expect(sourceText).toMatch(/onExecute: canExecute \? handleExecute : undefined/);
-    expect(sourceText).toMatch(/onExecuteInPlace: canExecute \? handleExecuteInPlace : undefined/);
-    expect(sourceText).toMatch(/onExecuteAndInsert:\s+canExecute && onInsertCellAfter/);
-    expect(sourceText).toMatch(/consumeExecutionShortcuts: !readOnly \|\| canExecute/);
+    expect(sourceText).toMatch(/onRequestExecute\?: \(\) => void;/);
+    expect(sourceText).toMatch(
+      /const canRequestExecute = !readOnly && Boolean\(onRequestExecute\)/,
+    );
+    expect(sourceText).toMatch(/const canRunExecutionShortcut = canExecute \|\| canRequestExecute/);
+    expect(sourceText).toMatch(/onExecute: canRunExecutionShortcut \? handleExecute : undefined/);
+    expect(sourceText).toMatch(
+      /onExecuteInPlace: canRunExecutionShortcut \? handleExecuteInPlace : undefined/,
+    );
+    expect(sourceText).toMatch(
+      /onExecuteAndInsert:\s+canRunExecutionShortcut && onInsertCellAfter/,
+    );
+    expect(sourceText).toMatch(
+      /consumeExecutionShortcuts: !readOnly \|\| canExecute \|\| canRequestExecute/,
+    );
     expect(sourceText).toMatch(/canExecute=\{canExecute\}/);
     expect(sourceText).toMatch(/showReadoutWhenDisabled=\{!readOnly\}/);
   });


### PR DESCRIPTION
## Summary
- add a deferred execution request path for code-cell run shortcuts when hosted compute is not attached yet
- gate deferred execution to owner/edit-mode writable cloud rooms with a selected startable workstation
- return start success from workstation attachment wiring and keep execution requests from creating duplicate start requests
- refresh cloud source guardrails for the split notebook route and workstation runtime_session_id payloads

## Verification
- pnpm test:run apps/notebook-cloud/viewer/__tests__/use-cloud-workstations.test.tsx apps/notebook/src/components/__tests__/notebook-view-capabilities-source.test.ts apps/notebook/src/hooks/__tests__/useCellKeyboardNavigation.test.ts
- pnpm --dir apps/notebook-cloud exec node --import tsx --test test/viewer-shared-cell-surface.test.ts test/viewer-render-props.test.ts test/worker-routes.test.ts
- pnpm --dir apps/notebook-cloud typecheck
- pnpm --dir apps/notebook-cloud test
- cargo xtask lint --fix