### PR TITLE
test(runtimed-py): wait for auto-launched shared kernel

### DIFF
--- a/python/runtimed/tests/test_daemon_integration.py
+++ b/python/runtimed/tests/test_daemon_integration.py
@@ -206,6 +206,28 @@ async def async_start_kernel_with_retry(session, *, retries=15, delay=1.0, **kwa
     raise last_err
 
 
+def runtime_kernel_is_running(session):
+    """Return whether RuntimeStateDoc says the kernel is ready to execute."""
+    state = session.get_runtime_state_sync()
+    lifecycle = state.kernel.lifecycle
+    activity = state.kernel.activity
+    return lifecycle == "Running" and activity in {"Idle", "Busy", "Unknown", ""}
+
+
+async def async_wait_for_runtime_kernel(session, *, timeout=15.0, description="kernel running"):
+    """Wait for RuntimeStateDoc to report a usable kernel.
+
+    This observes the live runtime projection instead of the session's cached
+    `kernel_started()` flag. That avoids racing create-notebook auto-launch with
+    an unnecessary manual LaunchKernel request.
+    """
+
+    async def _check():
+        return runtime_kernel_is_running(session)
+
+    await async_wait_for_sync(_check, timeout=timeout, interval=0.25, description=description)
+
+
 async def async_wait_for_conda_env_yml_missing(
     session,
     expected_env_name,
@@ -408,10 +430,9 @@ async def daemon_health_check(daemon_process):
         # create_notebook() auto-launches a prewarmed kernel. Prefer waiting for
         # that path instead of racing it with a manual LaunchKernel request.
         try:
-            await async_wait_for_sync(
-                session.kernel_started,
+            await async_wait_for_runtime_kernel(
+                session,
                 timeout=15.0,
-                interval=0.25,
                 description="health-check auto-launched kernel",
             )
         except AssertionError:
@@ -2065,8 +2086,12 @@ class TestMultiClientSync:
 
         s1, s2 = two_sessions
 
-        await async_start_kernel_with_retry(s1)
-        await async_start_kernel_with_retry(s2)  # No-op in daemon
+        await async_wait_for_runtime_kernel(
+            s1, description="auto-launched shared kernel visible to session 1"
+        )
+        await async_wait_for_runtime_kernel(
+            s2, description="auto-launched shared kernel visible to session 2"
+        )
 
         cell1 = await async_create_cell_and_wait_for_sync(s1, "async_shared = 'from async s1'")
         r1 = await s1.execute_cell(cell1)


### PR DESCRIPTION
## Summary
- add a RuntimeStateDoc-backed readiness helper for integration tests
- use it in the daemon health check instead of polling the cached `kernel_started()` flag
- stop the multi-client shared-kernel test from issuing two manual `LaunchKernel` requests against an already auto-launched runtime

## Why
The latest main Build failure showed `TestMultiClientSync::test_async_shared_kernel_execution` repeatedly sending `LaunchKernel` while the notebook runtime was already being auto-launched/restarted. The test comment said the second start was a no-op, but the daemon currently treats `LaunchKernel` against a connected runtime agent as a restart path. This keeps the test aligned with the intended assertion: both sessions share the same already-launched kernel.

## Validation
- `python/runtimed` `TestMultiClientSync` integration class: passed
- `python/runtimed` `TestMultiClientSync::test_async_shared_kernel_execution`: passed
- `python/runtimed` `TestDenoKernel::test_create_deno_notebook_launches_kernel`: passed
- `cargo xtask lint --fix`: passed