### PR TITLE
fix(notebook-cloud): clean up workstation exit messages

### DIFF
--- a/apps/notebook-cloud/scripts/hosted-workstation-agent-core.mjs
+++ b/apps/notebook-cloud/scripts/hosted-workstation-agent-core.mjs
@@ -209,6 +209,22 @@ export function retryCooldownMs({
   return Math.min(maxDelay, Math.ceil(baseDelay + jitter));
 }
 
+export function runtimePeerExitMessage(code, signal) {
+  const exitCode = Number.isInteger(code) ? code : null;
+  const exitSignal = typeof signal === "string" && signal.length > 0 ? signal : null;
+
+  if (exitCode != null && exitSignal != null) {
+    return `Runtime peer exited with code=${exitCode}, signal=${exitSignal}`;
+  }
+  if (exitCode != null) {
+    return `Runtime peer exited with code=${exitCode}`;
+  }
+  if (exitSignal != null) {
+    return `Runtime peer exited with signal=${exitSignal}`;
+  }
+  return "Runtime peer exited";
+}
+
 function assert(condition, message) {
   if (!condition) {
     throw new Error(message);

--- a/apps/notebook-cloud/scripts/hosted-workstation-agent.mjs
+++ b/apps/notebook-cloud/scripts/hosted-workstation-agent.mjs
@@ -16,6 +16,7 @@ import {
   parsePositiveInteger,
   retryCooldownMs,
   retryAfterMs,
+  runtimePeerExitMessage,
   stableWorkstationId,
 } from "./hosted-workstation-agent-core.mjs";
 import { notebookCloudBaseUrl, notebookCloudWorkspaceRoot } from "./local-dev.mjs";
@@ -347,8 +348,7 @@ async function watchRuntimePeer(jobId, active) {
     activeJobs.delete(jobId);
     await patchAttachJob(jobId, {
       status: code === 0 ? "completed" : "failed",
-      error_message:
-        code === 0 ? null : `Runtime peer exited with code=${code}, signal=${signal ?? ""}`,
+      error_message: code === 0 ? null : runtimePeerExitMessage(code, signal),
     }).catch((error) => {
       console.error(
         JSON.stringify({

--- a/apps/notebook-cloud/test/hosted-workstation-agent.test.mjs
+++ b/apps/notebook-cloud/test/hosted-workstation-agent.test.mjs
@@ -11,6 +11,7 @@ import {
   parsePositiveInteger,
   retryAfterMs,
   retryCooldownMs,
+  runtimePeerExitMessage,
   stableWorkstationId,
 } from "../scripts/hosted-workstation-agent-core.mjs";
 
@@ -242,5 +243,18 @@ describe("hosted workstation agent launch contract", () => {
       }),
       11_000,
     );
+  });
+
+  it("formats runtime peer exit messages without empty signal details", () => {
+    assert.equal(runtimePeerExitMessage(1, null), "Runtime peer exited with code=1");
+    assert.equal(
+      runtimePeerExitMessage(null, "SIGTERM"),
+      "Runtime peer exited with signal=SIGTERM",
+    );
+    assert.equal(
+      runtimePeerExitMessage(1, "SIGTERM"),
+      "Runtime peer exited with code=1, signal=SIGTERM",
+    );
+    assert.equal(runtimePeerExitMessage(null, null), "Runtime peer exited");
   });
 });

--- a/crates/runtimed/src/workstation/agent_loop.rs
+++ b/crates/runtimed/src/workstation/agent_loop.rs
@@ -1273,24 +1273,26 @@ fn poll_job_once(job_id: &str, job: &mut ActiveJob) -> JobTick {
     JobTick::None
 }
 
-/// Port of the `.mjs` exit message:
-/// `Runtime peer exited with code=<code>, signal=<signal>`.
 fn exit_status_message(status: &std::process::ExitStatus) -> String {
-    let code = status
-        .code()
-        .map(|code| code.to_string())
-        .unwrap_or_default();
     #[cfg(unix)]
     let signal = {
         use std::os::unix::process::ExitStatusExt;
-        status
-            .signal()
-            .map(|signal| signal.to_string())
-            .unwrap_or_default()
+        status.signal()
     };
     #[cfg(not(unix))]
-    let signal = String::new();
-    format!("Runtime peer exited with code={code}, signal={signal}")
+    let signal = None;
+    format_runtime_peer_exit_message(status.code(), signal)
+}
+
+fn format_runtime_peer_exit_message(code: Option<i32>, signal: Option<i32>) -> String {
+    match (code, signal) {
+        (Some(code), Some(signal)) => {
+            format!("Runtime peer exited with code={code}, signal={signal}")
+        }
+        (Some(code), None) => format!("Runtime peer exited with code={code}"),
+        (None, Some(signal)) => format!("Runtime peer exited with signal={signal}"),
+        (None, None) => "Runtime peer exited".to_string(),
+    }
 }
 
 fn spawn_runtime_peer(
@@ -1456,6 +1458,26 @@ mod tests {
         assert_eq!(
             workstation_agent_lock_path(&agent_root, "ws-lab2"),
             tmp.path().join("workstation-ws-lab2.lock")
+        );
+    }
+
+    #[test]
+    fn runtime_peer_exit_messages_omit_empty_details() {
+        assert_eq!(
+            format_runtime_peer_exit_message(Some(1), None),
+            "Runtime peer exited with code=1"
+        );
+        assert_eq!(
+            format_runtime_peer_exit_message(None, Some(15)),
+            "Runtime peer exited with signal=15"
+        );
+        assert_eq!(
+            format_runtime_peer_exit_message(Some(1), Some(15)),
+            "Runtime peer exited with code=1, signal=15"
+        );
+        assert_eq!(
+            format_runtime_peer_exit_message(None, None),
+            "Runtime peer exited"
         );
     }
 


### PR DESCRIPTION
## Summary
- format workstation runtime-peer exit messages without empty `signal=` details in both workstation-agent implementations
- use the formatter when attach jobs fail after the spawned peer exits
- add regression coverage for code-only, signal-only, combined, and unknown exits

## Context
Live preview showed a failed workstation start as `Runtime peer exited with code=1, signal=`. The running preview agent is the Rust `runtimed workstation-agent`, which had the same empty-field formatter as the older JS hosted agent. This keeps the same status flow but avoids surfacing blank signal metadata in the notebook Workstations panel.

The runtime-peer log for that failed attach showed `runtime peer session unknown does not match selected runtime session ...`; that was from a stale local workstation-agent process whose executable had already been replaced. After restarting this machine's workstation agent on the current binary, the same owner notebook attached successfully, launched the current-Python kernel, and ran `2 + 2` to `4`.

## Verification
- `cargo test -p runtimed runtime_peer_exit_messages_omit_empty_details`
- `cargo test -p runtimed workstation::agent_loop::tests`
- `pnpm --dir apps/notebook-cloud exec node --import tsx --test test/hosted-workstation-agent.test.mjs`
- `pnpm --dir apps/notebook-cloud typecheck`
- `cargo xtask lint --fix`
- Live preview: restarted the local `runtimed workstation-agent`, attached `ws-lab1-quill` to notebook `01KV1BKBQ83XVZ13DZ0T28EWXH`, and executed `2 + 2` via `Control+Enter` with output `4`.