### PR TITLE
perf(notebook-cloud): prefetch dashboard route styles

### DIFF
--- a/apps/notebook-cloud/src/index.ts
+++ b/apps/notebook-cloud/src/index.ts
@@ -4236,6 +4236,7 @@ interface ViewerShellConfig extends Record<string, unknown> {
 
 interface ViewerShellResourceHints {
   notebookRouteAssets?: ViewerNotebookRouteAssets;
+  notebookRouteStyleHint?: "preload" | "prefetch";
   outputDocumentBaseUrl?: string | null;
   rendererAssetsBasePath?: string;
   runtimedWasmModulePath?: string | null;
@@ -4251,7 +4252,10 @@ function rootNotebookListRedirect(request: Request): Response {
 async function notebookListViewer(request: Request, env: Env): Promise<Response> {
   const bootstrap = await notebookListBootstrap(request, env);
   const resourceHints = notebookListBootstrapHasNotebooks(bootstrap)
-    ? { notebookRouteAssets: await notebookRouteAssetNames(env) }
+    ? {
+        notebookRouteAssets: await notebookRouteAssetNames(env),
+        notebookRouteStyleHint: "prefetch" as const,
+      }
     : null;
   return responseForRequestMethod(
     request,
@@ -4450,7 +4454,10 @@ function viewerResourceHints(config: ViewerShellResourceHints | null): string {
       config.runtimedWasmModulePath,
     ]),
     viewerEntryHint,
-    ...notebookRouteResourceHints(config.notebookRouteAssets),
+    ...notebookRouteResourceHints(
+      config.notebookRouteAssets,
+      config.notebookRouteStyleHint ?? "preload",
+    ),
   ];
   if (config.runtimedWasmModulePath) {
     hints.push(
@@ -4467,17 +4474,22 @@ function viewerResourceHints(config: ViewerShellResourceHints | null): string {
   return hints.join("\n  ");
 }
 
-function notebookRouteResourceHints(assets: ViewerNotebookRouteAssets | undefined): string[] {
+function notebookRouteResourceHints(
+  assets: ViewerNotebookRouteAssets | undefined,
+  styleHint: "preload" | "prefetch",
+): string[] {
   if (!assets) {
     return [];
   }
+  const styleRel =
+    styleHint === "prefetch"
+      ? (name: string) => `<link rel="prefetch" href="/assets/${escapeHtml(name)}" as="style" />`
+      : (name: string) => `<link rel="preload" href="/assets/${escapeHtml(name)}" as="style" />`;
   return [
     ...assets.modulepreload.map(
       (name) => `<link rel="modulepreload" href="/assets/${escapeHtml(name)}" />`,
     ),
-    ...assets.stylepreload.map(
-      (name) => `<link rel="preload" href="/assets/${escapeHtml(name)}" as="style" />`,
-    ),
+    ...assets.stylepreload.map(styleRel),
   ];
 }
 

--- a/apps/notebook-cloud/test/worker-routes.test.ts
+++ b/apps/notebook-cloud/test/worker-routes.test.ts
@@ -570,7 +570,7 @@ describe("Worker artifact routes", () => {
     assert.doesNotMatch(html, /bootstrap@example\.test|bootstrap-user|Bootstrap User/);
   });
 
-  it("preloads notebook route assets when the bootstrapped notebook home has rows", async () => {
+  it("warms notebook route assets when the bootstrapped notebook home has rows", async () => {
     const { env: oidcEnv, token } = await oidcTokenFixture({
       subject: "home-preload-user",
       email: "home-preload@example.test",
@@ -607,9 +607,13 @@ describe("Worker artifact routes", () => {
     assert.match(html, /rel="modulepreload" href="\/assets\/markdown\.0123456789abcdef\.js"/);
     assert.match(
       html,
+      /rel="prefetch" href="\/assets\/notebook-route\.0123456789abcdef\.css" as="style"/,
+    );
+    assert.match(html, /rel="prefetch" href="\/assets\/katex\.0123456789abcdef\.css" as="style"/);
+    assert.doesNotMatch(
+      html,
       /rel="preload" href="\/assets\/notebook-route\.0123456789abcdef\.css" as="style"/,
     );
-    assert.match(html, /rel="preload" href="\/assets\/katex\.0123456789abcdef\.css" as="style"/);
     assert.doesNotMatch(html, /id="nteract-cloud-viewer-config"/);
     assert.doesNotMatch(html, /runtimed_wasm\.0123456789abcdef/);
   });


### PR DESCRIPTION
## Summary
- keep notebook-route JavaScript modulepreload hints for warm dashboard-to-notebook navigation
- switch dashboard-only notebook-route CSS hints from `preload` to `prefetch` to avoid Chrome unused-preload warnings on `/n`
- preserve direct notebook page CSS `preload`, where the route consumes those styles immediately

## Verification
- Live preview audit reproduced Chrome warnings on `/n` for `notebook-route-*.css` and `katex-*.css` being preloaded but unused shortly after load
- `pnpm --dir apps/notebook-cloud exec node --import tsx --test test/worker-routes.test.ts --test-name-pattern "warms notebook route assets|preloads the lazy notebook route assets"`
- `pnpm --dir apps/notebook-cloud exec node --import tsx --test test/html.test.ts --test-name-pattern "preloads the lazy notebook route assets|keeps notebook route asset hints out"`
- `pnpm --dir apps/notebook-cloud typecheck`
- `cargo xtask lint --fix`