### PR TITLE
test(runtimed-py): retry transient Deno notebook creation

### DIFF
--- a/python/runtimed/tests/test_daemon_integration.py
+++ b/python/runtimed/tests/test_daemon_integration.py
@@ -206,6 +206,32 @@ async def async_start_kernel_with_retry(session, *, retries=15, delay=1.0, **kwa
     raise last_err
 
 
+async def async_create_notebook_with_retry(
+    client,
+    *,
+    runtime="python",
+    retries=5,
+    delay=1.0,
+    **kwargs,
+):
+    """Async retry wrapper for create_notebook.
+
+    Deno notebook creation waits for the auto-launched kernel before returning.
+    CI can occasionally lose that first runtime-agent connection while the Deno
+    kernel is bootstrapping, so retry the whole fresh-room creation path rather
+    than failing the fixture setup on one transient connection reset.
+    """
+    last_err: Exception = Exception("max retries exceeded")
+    for attempt in range(retries):
+        try:
+            return await client.create_notebook(runtime=runtime, **kwargs)
+        except runtimed.RuntimedError as e:
+            last_err = e
+            if attempt < retries - 1:
+                await asyncio.sleep(delay)
+    raise last_err
+
+
 def runtime_kernel_is_running(session):
     """Return whether RuntimeStateDoc says the kernel is ready to execute."""
     state = session.get_runtime_state_sync()
@@ -1553,7 +1579,7 @@ class TestDenoKernel:
     @pytest.fixture
     async def deno_session(self, client):
         """Create a Deno notebook — auto-launches with a Deno kernel."""
-        sess = await client.create_notebook(runtime="deno")
+        sess = await async_create_notebook_with_retry(client, runtime="deno")
         yield sess
         try:
             if await sess.kernel_started():


### PR DESCRIPTION
## Summary
- add a small create_notebook retry helper for integration tests
- use it for the Deno notebook fixture, whose create path waits for auto-launch readiness
- keeps persistent Deno launch failures visible after retries while absorbing transient runtime-agent connection resets seen in main CI

## Evidence
Main CI failure on run 27479607701 / job 81224964867:
- TestDenoKernel.test_create_deno_notebook_launches_kernel setup errored
- TestDenoKernel.test_deno_kernelspec_via_typed_api setup errored
- both failed at client.create_notebook(runtime="deno") with connection reset by peer during kernel auto-launch

## Validation
- cd python/runtimed && RUNTIMED_INTEGRATION_TEST=1 RUNTIMED_BINARY=/home/ubuntu/codex/nteract/target/release/runtimed RUNTIMED_LOG_LEVEL=debug RUNTIMED_WORKSPACE_PATH=/home/ubuntu/codex/nteract RUNTIMED_TEST_UV_POOL_SIZE=1 RUNTIMED_TEST_CONDA_POOL_SIZE=0 RUNTIMED_INTEGRATION_LOG_DIR=/tmp/nteract-deno-retry-logs UV_PROJECT_ENVIRONMENT=/home/ubuntu/codex/nteract/.venv /home/ubuntu/codex/nteract/.venv/bin/python -m pytest tests/test_daemon_integration.py::TestDenoKernel -vv --tb=short
- cd python/runtimed && RUNTIMED_INTEGRATION_TEST=1 RUNTIMED_BINARY=/home/ubuntu/codex/nteract/target/release/runtimed RUNTIMED_LOG_LEVEL=debug RUNTIMED_WORKSPACE_PATH=/home/ubuntu/codex/nteract RUNTIMED_TEST_UV_POOL_SIZE=1 RUNTIMED_TEST_CONDA_POOL_SIZE=0 RUNTIMED_INTEGRATION_LOG_DIR=/tmp/nteract-runtimed-py-full-retry-logs VIRTUAL_ENV=/home/ubuntu/codex/nteract/.venv uv run --no-sync pytest tests/test_daemon_integration.py tests/test_dx_integration.py -n 1 --dist loadscope --durations=25 -v --tb=short
- cargo xtask lint --fix
