### PR TITLE
fix(notebook-cloud): close public viewers on revoke

### DIFF
--- a/apps/notebook-cloud/src/index.ts
+++ b/apps/notebook-cloud/src/index.ts
@@ -3209,6 +3209,9 @@ async function routeNotebookAcl(request: Request, env: Env, notebookId: string):
       counter: "acl_revocations",
       counter_delta: 1,
     });
+    if (revoked && isPublicViewerAclInput(aclInput)) {
+      await closeRevokedPublicViewers(env, notebookId);
+    }
     return json({
       ok: true,
       notebook_id: notebookId,
@@ -3241,6 +3244,44 @@ async function routeNotebookAcl(request: Request, env: Env, notebookId: string):
     },
     201,
   );
+}
+
+async function closeRevokedPublicViewers(env: Env, notebookId: string): Promise<void> {
+  const id = env.NOTEBOOK_ROOMS.idFromName(notebookId);
+  const room = env.NOTEBOOK_ROOMS.get(id);
+  try {
+    const response = await room.fetch(
+      new Request(
+        `https://notebook-room.internal/internal/n/${encodeURIComponent(
+          notebookId,
+        )}/access-revocation`,
+        {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({
+            close_anonymous_viewers: true,
+            close_reason: "public link access revoked",
+          }),
+        },
+      ),
+    );
+    if (response.ok) {
+      return;
+    }
+    cloudLog("warn", "acl.revoke.close_public_viewers_failed", {
+      notebook_id: notebookId,
+      response_status: response.status,
+      counter: "acl_revoke_close_public_viewers_failures",
+      counter_delta: 1,
+    });
+  } catch (error) {
+    cloudLog("warn", "acl.revoke.close_public_viewers_failed", {
+      notebook_id: notebookId,
+      error: errorMessage(error),
+      counter: "acl_revoke_close_public_viewers_failures",
+      counter_delta: 1,
+    });
+  }
 }
 
 async function routeCatalog(request: Request, env: Env, notebookId: string): Promise<Response> {
@@ -3881,6 +3922,10 @@ function optionalPositiveIntegerField(value: unknown, fieldName: string): number
 
 function isOwnerAclInput(row: ParsedNotebookAclInput): boolean {
   return row.subject_kind === "principal" && row.scope === "owner";
+}
+
+function isPublicViewerAclInput(row: ParsedNotebookAclInput): boolean {
+  return row.subject_kind === "public" && row.subject === "anonymous" && row.scope === "viewer";
 }
 
 function aclContainsInput(rows: NotebookAclRow[], row: ParsedNotebookAclInput): boolean {

--- a/apps/notebook-cloud/src/notebook-room.ts
+++ b/apps/notebook-cloud/src/notebook-room.ts
@@ -251,6 +251,10 @@ export class NotebookRoom {
     if (runtimeStateRepairNotebookId) {
       return this.handleRuntimeStateRepairControl(runtimeStateRepairNotebookId, request);
     }
+    const accessControlNotebookId = accessRevocationControlNotebookId(url.pathname);
+    if (accessControlNotebookId) {
+      return this.handleAccessRevocationControl(accessControlNotebookId, request);
+    }
 
     const notebookId = notebookIdFromPath(url.pathname);
 
@@ -508,6 +512,49 @@ export class NotebookRoom {
       });
       return json({ error: "runtime state repair failed" }, 500);
     }
+  }
+
+  private async handleAccessRevocationControl(
+    notebookId: string,
+    request: Request,
+  ): Promise<Response> {
+    // Worker-internal control path only. External traffic reaches this Durable
+    // Object through the Worker's strict `/n/:notebookId/sync` WebSocket route,
+    // so `/internal/*` is not publicly routable unless that router changes.
+    if (request.method !== "POST") {
+      return json({ error: "method not allowed" }, 405);
+    }
+
+    let payload: unknown;
+    try {
+      payload = await request.json();
+    } catch {
+      return json({ error: "access revocation control body must be JSON" }, 400);
+    }
+    if (!isRecord(payload)) {
+      return json({ error: "access revocation control body must be an object" }, 400);
+    }
+
+    const closeAnonymousViewers =
+      payload.close_anonymous_viewers === true || payload.closeAnonymousViewers === true;
+    const closeReason =
+      typeof payload.close_reason === "string" && payload.close_reason.trim().length > 0
+        ? payload.close_reason.trim().slice(0, 120)
+        : "public link access revoked";
+    const closedAnonymousViewers = closeAnonymousViewers
+      ? this.removeAnonymousViewerPeers(notebookId, {
+          code: 1008,
+          reason: closeReason,
+        })
+      : 0;
+
+    cloudLog("info", "room.access_revocation.control_completed", {
+      notebook_id: notebookId,
+      closed_anonymous_viewers: closedAnonymousViewers,
+      counter: "access_revocation_controls_completed",
+      counter_delta: 1,
+    });
+    return json({ ok: true, closed_anonymous_viewers: closedAnonymousViewers }, 200);
   }
 
   async webSocketMessage(
@@ -1238,6 +1285,18 @@ export class NotebookRoom {
         this.removePeer(notebookId, peer, closeOptions);
       }
     }
+  }
+
+  private removeAnonymousViewerPeers(notebookId: string, closeOptions: PeerCloseOptions): number {
+    let closedCount = 0;
+    for (const peer of Array.from(this.peers.values())) {
+      if (!isAnonymousViewerPeer(peer)) {
+        continue;
+      }
+      this.removePeer(notebookId, peer, closeOptions);
+      closedCount += 1;
+    }
+    return closedCount;
   }
 
   private removeDuplicateRuntimePeers(notebookId: string, incomingPeer: Peer): void {
@@ -2134,6 +2193,22 @@ function runtimeStateRepairControlNotebookId(pathname: string): string | undefin
     return undefined;
   }
   return decodeURIComponent(match[1]);
+}
+
+function accessRevocationControlNotebookId(pathname: string): string | undefined {
+  const match = pathname.match(/^\/internal\/n\/([^/]+)\/access-revocation\/?$/);
+  if (!match) {
+    return undefined;
+  }
+  return decodeURIComponent(match[1]);
+}
+
+function isAnonymousViewerPeer(peer: Peer): boolean {
+  return (
+    peer.identity.scope === "viewer" &&
+    peer.identity.metadata.provider === "anonymous" &&
+    peer.identity.metadata.principalNamespace === "anonymous"
+  );
 }
 
 function isRecord(value: unknown): value is Record<string, unknown> {

--- a/apps/notebook-cloud/test/notebook-room.test.ts
+++ b/apps/notebook-cloud/test/notebook-room.test.ts
@@ -1090,6 +1090,67 @@ describe("NotebookRoom peer lifecycle", () => {
     assert.equal(await state.getAlarm(), null, "intentional replacement does not arm stale repair");
   });
 
+  it("disconnects anonymous viewers when public link access is revoked", async () => {
+    const room = new NotebookRoom(fakeState(), {} as Env);
+    const harness = roomHarness(room);
+    const anonymousSocket = new FakeSocket();
+    const signedInViewerSocket = new FakeSocket();
+    const ownerSocket = new FakeSocket();
+    const anonymousPeer = {
+      id: "anonymous-viewer",
+      socket: anonymousSocket.asCloudflareWebSocket(),
+      identity: authenticateAnonymousViewer(
+        new Request("https://cloud.test/n/demo/sync?viewer_session=anon-a"),
+      ),
+      connectedAt: "2026-06-07T00:00:00.000Z",
+    };
+    const signedInViewerPeer = {
+      id: "signed-in-viewer",
+      socket: signedInViewerSocket.asCloudflareWebSocket(),
+      identity: authenticateDevRequest(
+        new Request("https://cloud.test/n/demo/sync?user=bob&operator=browser:b&scope=viewer"),
+      ),
+      connectedAt: "2026-06-07T00:00:01.000Z",
+    };
+    const ownerPeer = {
+      id: "owner",
+      socket: ownerSocket.asCloudflareWebSocket(),
+      identity: authenticateDevRequest(
+        new Request("https://cloud.test/n/demo/sync?user=alice&operator=browser:a&scope=owner"),
+      ),
+      connectedAt: "2026-06-07T00:00:02.000Z",
+    };
+    harness.peers.set(anonymousPeer.id, anonymousPeer);
+    harness.peers.set(signedInViewerPeer.id, signedInViewerPeer);
+    harness.peers.set(ownerPeer.id, ownerPeer);
+    harness.materializers.set("demo", fakeMaterializer(noopMaterializedResult()));
+
+    const response = await room.fetch(
+      new Request("https://room.internal/internal/n/demo/access-revocation", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          close_anonymous_viewers: true,
+          close_reason: "public link access revoked",
+        }),
+      }),
+    );
+
+    assert.equal(response.status, 200);
+    assert.deepEqual(await response.json(), {
+      ok: true,
+      closed_anonymous_viewers: 1,
+    });
+    assert.equal(anonymousSocket.closed, true);
+    assert.equal(anonymousSocket.closeCode, 1008);
+    assert.equal(anonymousSocket.closeReason, "public link access revoked");
+    assert.equal(signedInViewerSocket.closed, false);
+    assert.equal(ownerSocket.closed, false);
+    assert.equal(harness.peers.has(anonymousPeer.id), false);
+    assert.equal(harness.peers.has(signedInViewerPeer.id), true);
+    assert.equal(harness.peers.has(ownerPeer.id), true);
+  });
+
   it("keeps runtime peers when replacement workstation attachment publish fails", async () => {
     const state = alarmCapableState();
     const room = new NotebookRoom(state.state, {} as Env);

--- a/apps/notebook-cloud/test/worker-routes.test.ts
+++ b/apps/notebook-cloud/test/worker-routes.test.ts
@@ -3407,6 +3407,57 @@ describe("Worker artifact routes", () => {
     );
   });
 
+  it("closes anonymous live viewers when public link access is revoked", async () => {
+    const roomRequests: Request[] = [];
+    const env = fakeEnv({
+      NOTEBOOK_ROOMS: {
+        idFromName: (name: string) => ({ toString: () => name }),
+        get: () => ({
+          fetch: async (request: Request) => {
+            roomRequests.push(request.clone());
+            return Response.json({ ok: true, closed_anonymous_viewers: 1 });
+          },
+        }),
+      } satisfies DurableObjectNamespace,
+    });
+    seedNotebook(env, "public-revoke-demo");
+    seedAcl(env, {
+      notebookId: "public-revoke-demo",
+      subject: "user:dev:alice",
+      scope: "owner",
+    });
+    seedAcl(env, {
+      notebookId: "public-revoke-demo",
+      subjectKind: "public",
+      subject: "anonymous",
+      scope: "viewer",
+    });
+
+    const response = await aclRequest(
+      env,
+      "DELETE",
+      {
+        subject_kind: "public",
+        subject: "anonymous",
+        scope: "viewer",
+      },
+      "public-revoke-demo",
+    );
+
+    assert.equal(response.status, 200);
+    assert.equal(roomRequests.length, 1);
+    const roomRequest = roomRequests[0];
+    assert.ok(roomRequest);
+    assert.equal(
+      new URL(roomRequest.url).pathname,
+      "/internal/n/public-revoke-demo/access-revocation",
+    );
+    assert.deepEqual(await roomRequest.json(), {
+      close_anonymous_viewers: true,
+      close_reason: "public link access revoked",
+    });
+  });
+
   it("keeps ACL management owner-only and public grants viewer-only", async () => {
     const env = fakeEnv();
     seedNotebook(env, "acl-private-demo");


### PR DESCRIPTION
## Summary
- close existing anonymous live-room viewers when an owner removes the public-link ACL row
- add an internal room control path for access revocation that only disconnects anonymous viewer peers
- keep signed-in viewers, owners, editors, and runtime peers connected when public-link access changes

## Live finding
While auditing preview, I enabled public link access on a disposable owned notebook, opened it in a signed-out browser context, then disabled public link access again. The owner page still showed the anonymous tab as present, which means existing anonymous WebSocket sessions can outlive public-link revocation until they disconnect or reload.

## Verification
- `pnpm --dir apps/notebook-cloud exec node --import tsx --test test/notebook-room.test.ts --test-name-pattern "disconnects anonymous viewers"`
- `pnpm --dir apps/notebook-cloud exec node --import tsx --test test/worker-routes.test.ts --test-name-pattern "closes anonymous live viewers"`
- `pnpm --dir apps/notebook-cloud typecheck`
- `cargo xtask lint --fix`