### PR TITLE
fix(notebook-cloud): normalize view-only edit links

### DIFF
--- a/apps/notebook-cloud/test/cloud-notebook-mode.test.ts
+++ b/apps/notebook-cloud/test/cloud-notebook-mode.test.ts
@@ -1,6 +1,9 @@
 import assert from "node:assert/strict";
 import { test } from "node:test";
-import { cloudNotebookInteractionModeForAccess } from "../viewer/cloud-notebook-mode";
+import {
+  cloudNotebookInteractionModeForAccess,
+  cloudNotebookSelectedModeCorrectionForAccess,
+} from "../viewer/cloud-notebook-mode";
 
 test("cloud notebook edit links stay view-only for viewers without an access request", () => {
   assert.equal(
@@ -113,5 +116,29 @@ test("cloud notebook edit links stay view-only for viewers without an access req
       selectedMode: "edit",
     }),
     "edit",
+  );
+});
+
+test("cloud notebook mode correction normalizes owner edit links for view-only access", () => {
+  assert.equal(
+    cloudNotebookSelectedModeCorrectionForAccess({
+      accessMode: "view",
+      selectedMode: "edit",
+    }),
+    "view",
+  );
+  assert.equal(
+    cloudNotebookSelectedModeCorrectionForAccess({
+      accessMode: "edit",
+      selectedMode: "edit",
+    }),
+    null,
+  );
+  assert.equal(
+    cloudNotebookSelectedModeCorrectionForAccess({
+      accessMode: "view",
+      selectedMode: "view",
+    }),
+    null,
   );
 });

--- a/apps/notebook-cloud/viewer/cloud-notebook-mode.ts
+++ b/apps/notebook-cloud/viewer/cloud-notebook-mode.ts
@@ -31,6 +31,19 @@ export function cloudNotebookInteractionModeForAccess({
   return "view";
 }
 
+export function cloudNotebookSelectedModeCorrectionForAccess({
+  accessMode,
+  selectedMode,
+}: {
+  accessMode: CloudNotebookUrlMode;
+  selectedMode: CloudNotebookUrlMode;
+}): CloudNotebookUrlMode | null {
+  if (selectedMode === "edit" && accessMode === "view") {
+    return "view";
+  }
+  return null;
+}
+
 export function cloudNotebookModeFromSearch(search: string): CloudNotebookUrlMode {
   const params = new URLSearchParams(search);
   return normalizeCloudNotebookMode(params.get("mode"));

--- a/apps/notebook-cloud/viewer/notebook-viewer.tsx
+++ b/apps/notebook-cloud/viewer/notebook-viewer.tsx
@@ -127,6 +127,7 @@ import { applyDocumentTheme, CLOUD_VIEWER_THEME_STORAGE_KEY } from "./theme";
 import {
   cloudNotebookInteractionModeForAccess,
   cloudNotebookModeFromSearch,
+  cloudNotebookSelectedModeCorrectionForAccess,
   replaceCloudNotebookModeInCurrentUrl,
 } from "./cloud-notebook-mode";
 import type {
@@ -743,6 +744,15 @@ export function NotebookViewer({
     connectionScope,
     selectedMode: selectedInteractionMode,
   });
+  useEffect(() => {
+    const correctedMode = cloudNotebookSelectedModeCorrectionForAccess({
+      accessMode: selectedInteractionModeForAccess,
+      selectedMode: selectedInteractionMode,
+    });
+    if (correctedMode) {
+      setSelectedInteractionMode(correctedMode);
+    }
+  }, [selectedInteractionMode, selectedInteractionModeForAccess]);
   const { shellCapabilities, canAcceptCellMutations, editAccessPending } =
     useCloudShellCapabilities({
       accessConnectionScope,


### PR DESCRIPTION
## Summary
- normalize owner-style `?mode=edit` links back to `?mode=view` when access resolution says the current user is view-only
- keep pending/approved edit-access request flows in edit mode
- cover the selected-mode correction with a focused cloud mode unit test

## Verification
- `pnpm --dir apps/notebook-cloud exec node --import tsx --test test/cloud-notebook-mode.test.ts`
- `pnpm --dir apps/notebook-cloud typecheck`
- `cargo xtask lint --fix`