### PR TITLE
fix(notebook-cloud): hide workstation rail for non-owners

### DIFF
--- a/apps/notebook-cloud/test/viewer-render-props.test.ts
+++ b/apps/notebook-cloud/test/viewer-render-props.test.ts
@@ -233,7 +233,18 @@ test("cloud viewer routes notebook header controls through the shared shell chro
   assert.match(sourceText, /function initialCloudRailCollapsed\(\): boolean \{[\s\S]*return true;/);
   assert.doesNotMatch(sourceText, /packagesSummary=/);
   assert.doesNotMatch(sourceText, /workstationsSummary=/);
-  assert.match(sourceText, /workstationsPanel=\{[\s\S]*<NotebookWorkstationsPanel/);
+  assert.match(
+    sourceText,
+    /const shouldShowCloudWorkstationsPanel =[\s\S]*shellCapabilities\.access\.level === "owner"[\s\S]*shellCapabilities\.auth\.canUseAuthenticatedIdentity/,
+  );
+  assert.match(
+    sourceText,
+    /if \(!shouldShowCloudWorkstationsPanel && activeRailPanel === "workstations"\) \{[\s\S]*setActiveRailPanel\("outline"\)/,
+  );
+  assert.match(
+    sourceText,
+    /workstationsPanel=\{[\s\S]*shouldShowCloudWorkstationsPanel \? \([\s\S]*<NotebookWorkstationsPanel/,
+  );
   assert.match(
     sourceText,
     /const shouldShowPackageEnvironmentSummary =[\s\S]*shellCapabilities\.canExecute \|\| shellCapabilities\.canManagePackages/,

--- a/apps/notebook-cloud/viewer/notebook-viewer.tsx
+++ b/apps/notebook-cloud/viewer/notebook-viewer.tsx
@@ -1309,6 +1309,14 @@ export function NotebookViewer({
   ]);
   const shouldShowPackageEnvironmentSummary =
     shellCapabilities.canExecute || shellCapabilities.canManagePackages;
+  const shouldShowCloudWorkstationsPanel =
+    shellCapabilities.access.level === "owner" &&
+    shellCapabilities.auth.canUseAuthenticatedIdentity;
+  useEffect(() => {
+    if (!shouldShowCloudWorkstationsPanel && activeRailPanel === "workstations") {
+      setActiveRailPanel("outline");
+    }
+  }, [activeRailPanel, shouldShowCloudWorkstationsPanel]);
   const toolbarAddAfterCellId =
     focusedCellId ?? notebookCellIds[notebookCellIds.length - 1] ?? null;
   const publicNotebookLink = useMemo(
@@ -1325,17 +1333,19 @@ export function NotebookViewer({
       selectedOutlineItemId={selectedOutlineItemId}
       selectedOutlineCellId={focusedCellId}
       workstationsPanel={
-        <NotebookWorkstationsPanel
-          capabilities={shellCapabilities}
-          selection={workstationSelection}
-          statusMessage={workstationPanelStatusMessage}
-          busyWorkstationId={busyWorkstationId}
-          onAttachWorkstation={onAttachWorkstation}
-          onSetDefaultWorkstation={onSetDefaultWorkstation}
-          pairing={workstationPairing}
-          onStartPairing={onStartPairing}
-          onCancelPairing={onCancelPairing}
-        />
+        shouldShowCloudWorkstationsPanel ? (
+          <NotebookWorkstationsPanel
+            capabilities={shellCapabilities}
+            selection={workstationSelection}
+            statusMessage={workstationPanelStatusMessage}
+            busyWorkstationId={busyWorkstationId}
+            onAttachWorkstation={onAttachWorkstation}
+            onSetDefaultWorkstation={onSetDefaultWorkstation}
+            pairing={workstationPairing}
+            onStartPairing={onStartPairing}
+            onCancelPairing={onCancelPairing}
+          />
+        ) : undefined
       }
       packagesPanel={
         <NotebookPackageSummaryPanel


### PR DESCRIPTION
## Summary
- hide the cloud Workstations rail slot unless the current access level is owner with authenticated identity
- return to the outline panel if access changes while the Workstations rail is active
- update the viewer source guard so non-owner viewers do not receive workstation panel wiring

## Live finding
In preview, a view-only shared notebook exposed the Workstations rail. It did not show start controls, but it did reveal stale owner compute metadata such as workstation id, CPU/RAM, and working directory. Hosted compute is owner-only, so the detailed workstation panel should be owner-only too.

## Verification
- `pnpm --dir apps/notebook-cloud exec node --import tsx --test test/viewer-render-props.test.ts`
- `pnpm --dir apps/notebook-cloud typecheck`
- `cargo xtask lint --fix`