### PR TITLE
refactor(notebook-cloud): reuse anonymous viewer predicate

### DIFF
--- a/apps/notebook-cloud/src/notebook-room.ts
+++ b/apps/notebook-cloud/src/notebook-room.ts
@@ -1290,7 +1290,7 @@ export class NotebookRoom {
   private removeAnonymousViewerPeers(notebookId: string, closeOptions: PeerCloseOptions): number {
     let closedCount = 0;
     for (const peer of Array.from(this.peers.values())) {
-      if (!isAnonymousViewerPeer(peer)) {
+      if (!isAnonymousViewer(peer.identity)) {
         continue;
       }
       this.removePeer(notebookId, peer, closeOptions);
@@ -2201,14 +2201,6 @@ function accessRevocationControlNotebookId(pathname: string): string | undefined
     return undefined;
   }
   return decodeURIComponent(match[1]);
-}
-
-function isAnonymousViewerPeer(peer: Peer): boolean {
-  return (
-    peer.identity.scope === "viewer" &&
-    peer.identity.metadata.provider === "anonymous" &&
-    peer.identity.metadata.principalNamespace === "anonymous"
-  );
 }
 
 function isRecord(value: unknown): value is Record<string, unknown> {


### PR DESCRIPTION
## Summary
- reuse the canonical identity isAnonymousViewer helper when closing anonymous peers after public-link revoke
- remove the duplicate room-local anonymous viewer predicate

## Verification
- pnpm --dir apps/notebook-cloud exec node --import tsx --test test/identity.test.ts
- pnpm --dir apps/notebook-cloud exec node --import tsx --test --test-name-pattern "disconnects anonymous viewers" test/notebook-room.test.ts
- pnpm --dir apps/notebook-cloud typecheck
- cargo xtask lint --fix