### PR TITLE
fix(notebook-cloud): fall back from hidden workstation rail

### DIFF
--- a/apps/notebook-cloud/test/viewer-render-props.test.ts
+++ b/apps/notebook-cloud/test/viewer-render-props.test.ts
@@ -243,6 +243,11 @@ test("cloud viewer routes notebook header controls through the shared shell chro
   );
   assert.match(
     sourceText,
+    /const renderedActiveRailPanel =[\s\S]*!shouldShowCloudWorkstationsPanel && activeRailPanel === "workstations"[\s\S]*\? "outline"[\s\S]*: activeRailPanel/,
+  );
+  assert.match(sourceText, /activePanelId=\{renderedActiveRailPanel\}/);
+  assert.match(
+    sourceText,
     /workstationsPanel=\{[\s\S]*shouldShowCloudWorkstationsPanel \? \([\s\S]*<NotebookWorkstationsPanel/,
   );
   assert.match(

--- a/apps/notebook-cloud/viewer/notebook-viewer.tsx
+++ b/apps/notebook-cloud/viewer/notebook-viewer.tsx
@@ -1323,10 +1323,14 @@ export function NotebookViewer({
     () => new URL(window.location.pathname, window.location.origin).href,
     [],
   );
+  const renderedActiveRailPanel =
+    !shouldShowCloudWorkstationsPanel && activeRailPanel === "workstations"
+      ? "outline"
+      : activeRailPanel;
   const rail = (
     <NotebookDocumentRail
       viewModel={notebookViewModel}
-      activePanelId={activeRailPanel}
+      activePanelId={renderedActiveRailPanel}
       collapsed={railCollapsed}
       outlineCellIds={notebookCellIds}
       activeOutlineItemId={activeOutlineItemId}


### PR DESCRIPTION
## Summary
- derive the rendered active rail panel so Workstations falls back to Outline immediately when it is not available
- keep the existing state cleanup effect so persisted rail state also resets
- pin the behavior in the cloud viewer source guard

## Context
Follow-up to #3667 from the review note about a possible intermediate render where Workstations is active but hidden.

## Verification
- pnpm --dir apps/notebook-cloud exec node --import tsx --test test/viewer-render-props.test.ts
- pnpm --dir apps/notebook-cloud typecheck
- cargo xtask lint --fix