### PR TITLE
fix(notebook-cloud): resolve app-session invites before listing

### DIFF
--- a/apps/notebook-cloud/src/index.ts
+++ b/apps/notebook-cloud/src/index.ts
@@ -81,6 +81,7 @@ import { collectBlobRefs } from "./blob-refs.ts";
 import { cloudLog, durationMs } from "./observability.ts";
 import {
   createPendingNotebookInvite,
+  getPrincipalProfile,
   getPrincipalProfiles,
   listNotebookInvites,
   resolveNotebookInvitesForLogin,
@@ -716,6 +717,7 @@ async function appSessionIdentityFromWebSocketRequest(
     return json({ error: error instanceof Error ? error.message : String(error) }, 400);
   }
 
+  await syncStoredAppSessionProfile(env, session);
   const identity = appSessionConnectionIdentity(session, operator, requestedScope);
   const webSocketProtocol = applicationWebSocketProtocolFromHeader(
     request.headers.get("Sec-WebSocket-Protocol"),
@@ -1116,6 +1118,7 @@ async function routeListNotebooks(request: Request, env: Env): Promise<Response>
   }
 
   let principal: string | null = null;
+  let appSession: CloudAppSession | null = null;
   const identity = await authenticateRequestOrResponse(request, env);
   if (identity instanceof Response) {
     return identity;
@@ -1123,10 +1126,14 @@ async function routeListNotebooks(request: Request, env: Env): Promise<Response>
   if (!isAnonymousViewer(identity)) {
     principal = identity.principal;
   } else {
-    principal = (await readCloudAppSession(env, request))?.principal ?? null;
+    appSession = await readCloudAppSession(env, request);
+    principal = appSession?.principal ?? null;
   }
   if (!principal) {
     return json({ error: "sign in to list notebooks" }, 401);
+  }
+  if (appSession) {
+    await syncStoredAppSessionProfile(env, appSession);
   }
 
   const notebooks = await listNotebooksForPrincipal(env, principal, limit);
@@ -4029,16 +4036,11 @@ async function syncAuthenticatedProfile(
           ? Boolean(identity.metadata.email)
           : identity.metadata.emailVerified === true,
     });
-    if (resolution.acceptedInvites.length === 0 && resolution.aclGrants.length === 0) {
-      return;
-    }
-    cloudLog("info", "invites.resolution.completed", {
+    logInviteResolutionCompleted({
       principal: identity.principal,
       provider: identity.metadata.provider,
-      accepted_invite_count: resolution.acceptedInvites.length,
-      acl_grant_count: resolution.aclGrants.length,
-      counter: "invite_resolutions",
-      counter_delta: resolution.acceptedInvites.length,
+      acceptedInviteCount: resolution.acceptedInvites.length,
+      aclGrantCount: resolution.aclGrants.length,
     });
   } catch (error) {
     cloudLog("warn", "profile.sync.failed", {
@@ -4049,6 +4051,72 @@ async function syncAuthenticatedProfile(
       counter_delta: 1,
     });
   }
+}
+
+async function syncStoredAppSessionProfile(env: Env, session: CloudAppSession): Promise<void> {
+  if (!env.DB) {
+    return;
+  }
+
+  try {
+    const profile = await getPrincipalProfile(env, session.principal);
+    if (
+      !profile ||
+      profile.provider !== session.provider ||
+      profile.email_verified !== 1 ||
+      !profile.email_normalized
+    ) {
+      return;
+    }
+
+    const resolution = await resolveNotebookInvitesForLogin(env, {
+      principal: session.principal,
+      provider: profile.provider,
+      principalNamespace: session.principalNamespace,
+      email: profile.email_normalized,
+      emailVerified: true,
+      displayName: session.displayName ?? profile.display_name,
+    });
+    logInviteResolutionCompleted({
+      principal: session.principal,
+      provider: profile.provider,
+      acceptedInviteCount: resolution.acceptedInvites.length,
+      aclGrantCount: resolution.aclGrants.length,
+    });
+  } catch (error) {
+    cloudLog("warn", "profile.sync.failed", {
+      principal: session.principal,
+      provider: session.provider,
+      reason: error instanceof Error ? error.message : String(error),
+      counter: "profile_sync_failures",
+      counter_delta: 1,
+    });
+  }
+}
+
+function logInviteResolutionCompleted({
+  principal,
+  provider,
+  acceptedInviteCount,
+  aclGrantCount,
+}: {
+  principal: string;
+  provider: string;
+  acceptedInviteCount: number;
+  aclGrantCount: number;
+}): void {
+  if (acceptedInviteCount === 0 && aclGrantCount === 0) {
+    return;
+  }
+
+  cloudLog("info", "invites.resolution.completed", {
+    principal,
+    provider,
+    accepted_invite_count: acceptedInviteCount,
+    acl_grant_count: aclGrantCount,
+    counter: "invite_resolutions",
+    counter_delta: acceptedInviteCount,
+  });
 }
 
 async function authenticateRequestOrAppSessionOrResponse(
@@ -4065,6 +4133,7 @@ async function authenticateRequestOrAppSessionOrResponse(
   if (!session) {
     return identity;
   }
+  await syncStoredAppSessionProfile(env, session);
   return appSessionConnectionIdentity(session, "browser:http", appSessionScope);
 }
 
@@ -4468,6 +4537,7 @@ async function notebookListBootstrap(
   if (!session) {
     return null;
   }
+  await syncStoredAppSessionProfile(env, session);
   const notebooks = await listNotebooksForPrincipal(
     env,
     session.principal,

--- a/apps/notebook-cloud/test/worker-routes.test.ts
+++ b/apps/notebook-cloud/test/worker-routes.test.ts
@@ -752,6 +752,154 @@ describe("Worker artifact routes", () => {
     assert.equal(explicitBadBearer.status, 401);
   });
 
+  it("resolves post-login pending invites for app-session notebook list APIs", async () => {
+    const { env: oidcEnv, token } = await oidcTokenFixture({
+      subject: "cookie-invite-list-user",
+      email: "cookie-invite-list@example.test",
+      extraPayload: { email_verified: true },
+      name: "Cookie Invite List User",
+    });
+    const env = fakeEnv({
+      ...oidcEnv,
+      NOTEBOOK_CLOUD_APP_SESSION_SECRET: APP_SESSION_SECRET,
+    });
+    const cookie = await oidcAppSessionCookie(env, token);
+    seedNotebook(env, "cookie-list-invited");
+    seedPendingInvite(env, {
+      id: "invite-cookie-list",
+      notebookId: "cookie-list-invited",
+      email: "cookie-invite-list@example.test",
+      providerHint: null,
+      scope: "editor",
+    });
+
+    const response = await worker.fetch(
+      new Request("https://cloud.test/api/n", {
+        headers: { Cookie: cookie },
+      }),
+      env,
+      fakeContext(),
+    );
+
+    assert.equal(response.status, 200);
+    const body = (await response.json()) as {
+      notebooks: Array<{ notebook_id: string; scope: NotebookAclRow["scope"] }>;
+    };
+    assert.deepEqual(
+      body.notebooks.map((notebook) => [notebook.notebook_id, notebook.scope]),
+      [["cookie-list-invited", "editor"]],
+    );
+    const accountPrincipal = await canonicalAccountPrincipalForProfile({
+      provider: "oidc",
+      principalNamespace: "user:anaconda",
+      email: "cookie-invite-list@example.test",
+      emailVerified: true,
+    });
+    assert.ok(accountPrincipal);
+    assert.equal(env.DB.invites.get("invite-cookie-list")?.status, "accepted");
+    assert.ok(
+      env.DB.acl.some(
+        (row) =>
+          row.notebook_id === "cookie-list-invited" &&
+          row.subject_kind === "principal" &&
+          row.subject === accountPrincipal &&
+          row.scope === "editor",
+      ),
+    );
+  });
+
+  it("resolves post-login pending invites for app-session notebook home bootstrap", async () => {
+    const { env: oidcEnv, token } = await oidcTokenFixture({
+      subject: "cookie-invite-bootstrap-user",
+      email: "cookie-invite-bootstrap@example.test",
+      extraPayload: { email_verified: true },
+      name: "Cookie Invite Bootstrap User",
+    });
+    const env = fakeEnv({
+      ...oidcEnv,
+      NOTEBOOK_CLOUD_APP_SESSION_SECRET: APP_SESSION_SECRET,
+    });
+    const cookie = await oidcAppSessionCookie(env, token);
+    seedNotebook(env, "cookie-bootstrap-invited");
+    const notebook = env.DB.notebooks.get("cookie-bootstrap-invited");
+    assert.ok(notebook);
+    notebook.title = "Cookie Bootstrap Invited";
+    seedPendingInvite(env, {
+      id: "invite-cookie-bootstrap",
+      notebookId: "cookie-bootstrap-invited",
+      email: "cookie-invite-bootstrap@example.test",
+      providerHint: null,
+      scope: "viewer",
+    });
+
+    const response = await worker.fetch(
+      new Request("https://cloud.test/n", {
+        headers: { Cookie: cookie },
+      }),
+      env,
+      fakeContext(),
+    );
+
+    assert.equal(response.status, 200);
+    const html = await response.text();
+    const bootstrap = notebookHomeBootstrap(html);
+    assert.deepEqual(
+      bootstrap.notebooks.map((notebook) => [notebook.notebook_id, notebook.title]),
+      [["cookie-bootstrap-invited", "Cookie Bootstrap Invited"]],
+    );
+    assert.equal(env.DB.invites.get("invite-cookie-bootstrap")?.status, "accepted");
+  });
+
+  it("resolves post-login pending invites before app-session WebSocket authorization", async () => {
+    const { env: oidcEnv, token } = await oidcTokenFixture({
+      subject: "cookie-invite-ws-user",
+      email: "cookie-invite-ws@example.test",
+      extraPayload: { email_verified: true },
+      name: "Cookie Invite WebSocket User",
+    });
+    let forwardedRequest: Request | undefined;
+    const env = fakeEnv({
+      ...oidcEnv,
+      NOTEBOOK_CLOUD_APP_SESSION_SECRET: APP_SESSION_SECRET,
+      NOTEBOOK_ROOMS: {
+        idFromName: (name: string) => ({ toString: () => name }),
+        get: () => ({
+          fetch: async (request: Request) => {
+            forwardedRequest = request;
+            return new Response("room ok");
+          },
+        }),
+      } satisfies DurableObjectNamespace,
+    });
+    const cookie = await oidcAppSessionCookie(env, token);
+    seedNotebook(env, "cookie-ws-invited");
+    seedPendingInvite(env, {
+      id: "invite-cookie-ws",
+      notebookId: "cookie-ws-invited",
+      email: "cookie-invite-ws@example.test",
+      providerHint: null,
+      scope: "editor",
+    });
+
+    const response = await worker.fetch(
+      new Request("https://cloud.test/n/cookie-ws-invited/sync?scope=editor", {
+        headers: {
+          Cookie: cookie,
+          Origin: "https://cloud.test",
+          "Sec-WebSocket-Protocol": NOTEBOOK_CLOUD_WEBSOCKET_PROTOCOL,
+          Upgrade: "websocket",
+        },
+      }),
+      env,
+      fakeContext(),
+    );
+
+    assert.equal(response.status, 200);
+    assert.ok(forwardedRequest);
+    assert.equal(forwardedRequest.headers.get(TRUSTED_SCOPE_HEADER), "editor");
+    assert.equal(env.DB.invites.get("invite-cookie-ws")?.status, "accepted");
+  });
+
   it("uses app-session cookies as same-origin room WebSocket credentials", async () => {
     const { env: oidcEnv, token } = await oidcTokenFixture({ subject: "cookie-ws-user" });
     let forwardedRequest: Request | undefined;


### PR DESCRIPTION
## Summary
- resolve pending email invites from the stored verified OIDC profile when a browser is authenticated only by the first-party app-session cookie
- run that resolution before `/api/n` list responses, `/n` notebook-list bootstrap, first-party notebook API authorization, and app-session WebSocket authorization
- keep the app-session cookie identity-only; the verified email stays server-side in the existing profile table

## Why
If a user is already signed in and another user shares a notebook with their email later, `/n` can be backed only by the app-session cookie. That cookie intentionally does not contain email, so fresh pending invites were not accepted before listing or opening direct links unless another provider-backed auth request happened first.

## Verification
- `pnpm --dir apps/notebook-cloud exec node --import tsx --test --test-name-pattern "post-login pending invites" test/worker-routes.test.ts`
- `pnpm --dir apps/notebook-cloud exec node --import tsx --test test/app-session.test.ts test/sharing-storage.test.ts`
- `pnpm --dir apps/notebook-cloud exec node --import tsx --test test/worker-routes.test.ts`
- `pnpm --dir apps/notebook-cloud typecheck`
- `cargo xtask lint --fix`
