### PR TITLE
fix(notebook): enable markdown spellcheck

### DIFF
--- a/apps/notebook/src/components/MarkdownCell.tsx
+++ b/apps/notebook/src/components/MarkdownCell.tsx
@@ -59,6 +59,11 @@ import { CellPresenceIndicators } from "./cell/CellPresenceIndicators";
 const handleIframeError = (err: { message: string; stack?: string }) =>
   logger.error("[MarkdownCell] iframe error:", err);
 const EMPTY_HEADING_ANCHORS: readonly MarkdownHeadingAnchor[] = [];
+const MARKDOWN_EDITOR_CONTENT_ATTRIBUTES = {
+  autocapitalize: "sentences",
+  autocorrect: "on",
+  spellcheck: "true",
+} as const;
 const MARKDOWN_PREVIEW_MIN_HEIGHT = 24;
 const MARKDOWN_PREVIEW_MAX_INITIAL_HEIGHT = 720;
 
@@ -835,6 +840,7 @@ export const MarkdownCell = memo(function MarkdownCell({
                 onSelectionChange={noteEditorSourcePosition}
                 keyMap={keyMap}
                 extensions={editorExtensions}
+                contentAttributes={MARKDOWN_EDITOR_CONTENT_ATTRIBUTES}
                 placeholder="Enter markdown..."
                 className="min-h-[2rem]"
                 autoFocus={editing}

--- a/apps/notebook/src/components/__tests__/markdown-cell-theme.test.tsx
+++ b/apps/notebook/src/components/__tests__/markdown-cell-theme.test.tsx
@@ -102,7 +102,11 @@ vi.mock("@/components/cell/CellContainer", () => ({
 
 vi.mock("@/components/editor/codemirror-editor", () => ({
   CodeMirrorEditor: React.forwardRef(function CodeMirrorEditor(
-    props: { initialValue?: string; keyMap?: Array<{ key: string; run: () => boolean }> },
+    props: {
+      contentAttributes?: Readonly<Record<string, string>>;
+      initialValue?: string;
+      keyMap?: Array<{ key: string; run: () => boolean }>;
+    },
     ref,
   ) {
     React.useImperativeHandle(ref, () => ({
@@ -125,6 +129,9 @@ vi.mock("@/components/editor/codemirror-editor", () => ({
     return (
       <div
         data-testid="markdown-editor"
+        data-autocapitalize={props.contentAttributes?.autocapitalize}
+        data-autocorrect={props.contentAttributes?.autocorrect}
+        data-spellcheck={props.contentAttributes?.spellcheck}
         tabIndex={0}
         onKeyDown={(event) => {
           const key = event.ctrlKey && event.key === "Enter" ? "Ctrl-Enter" : event.key;
@@ -561,6 +568,19 @@ describe("MarkdownCell theme sync", () => {
     await waitFor(() => {
       expect(preview.className).toContain("hidden");
     });
+  });
+
+  it("enables browser spellcheck and autocorrect for markdown editing", () => {
+    mockIsFocused = true;
+
+    const { getByTestId } = render(
+      <MarkdownCell cell={makeCell()} onFocus={() => {}} onDelete={() => {}} />,
+    );
+
+    const editor = getByTestId("markdown-editor");
+    expect(editor.getAttribute("data-autocapitalize")).toBe("sentences");
+    expect(editor.getAttribute("data-autocorrect")).toBe("on");
+    expect(editor.getAttribute("data-spellcheck")).toBe("true");
   });
 
   it("Ctrl+Enter exits edit mode for markdown cells", async () => {

--- a/src/components/editor/__tests__/codemirror-editor.test.tsx
+++ b/src/components/editor/__tests__/codemirror-editor.test.tsx
@@ -67,6 +67,30 @@ describe("CodeMirrorEditor", () => {
     expect(editorView?.state.facet(EditorState.readOnly)).toBe(true);
   });
 
+  it("applies custom content attributes to the editable surface", async () => {
+    render(
+      <CodeMirrorEditor
+        initialValue="markdown words"
+        contentAttributes={{
+          autocapitalize: "sentences",
+          autocorrect: "on",
+          spellcheck: "true",
+        }}
+        theme="light"
+      />,
+    );
+
+    const content = await waitFor(() => {
+      const el = document.querySelector(".cm-content");
+      expect(el).not.toBeNull();
+      return el as HTMLElement;
+    });
+
+    expect(content.getAttribute("autocapitalize")).toBe("sentences");
+    expect(content.getAttribute("autocorrect")).toBe("on");
+    expect(content.getAttribute("spellcheck")).toBe("true");
+  });
+
   it("reports primary cursor position changes", async () => {
     const ref = createRef<CodeMirrorEditorRef>();
     const onSelectionChange = vi.fn();

--- a/src/components/editor/codemirror-editor.tsx
+++ b/src/components/editor/codemirror-editor.tsx
@@ -30,6 +30,8 @@ export interface CodeMirrorEditorRef {
   getEditor: () => EditorView | null;
 }
 
+type CodeMirrorContentAttributes = Record<string, string>;
+
 /**
  * Annotation marking a transaction as an external (inbound) change.
  * The editor's updateListener skips the onValueChange callback for these.
@@ -64,6 +66,8 @@ export interface CodeMirrorEditorProps {
   lineWrapping?: boolean;
   /** Additional CodeMirror extensions */
   extensions?: Extension[];
+  /** Additional DOM attributes for CodeMirror's editable content element */
+  contentAttributes?: Readonly<CodeMirrorContentAttributes>;
   /** Replace default extensions entirely */
   baseExtensions?: Extension[];
   /** Read-only mode */
@@ -76,6 +80,12 @@ export interface CodeMirrorEditorProps {
 
 function readOnlyExtensions(readOnly: boolean): Extension[] {
   return readOnly ? [EditorState.readOnly.of(true), EditorView.editable.of(false)] : [];
+}
+
+function contentAttributeExtensions(
+  contentAttributes?: Readonly<CodeMirrorContentAttributes>,
+): Extension[] {
+  return contentAttributes ? [EditorView.contentAttributes.of({ ...contentAttributes })] : [];
 }
 
 /**
@@ -105,6 +115,7 @@ export const CodeMirrorEditor = forwardRef<CodeMirrorEditorRef, CodeMirrorEditor
       maxHeight,
       lineWrapping = false,
       extensions: additionalExtensions,
+      contentAttributes,
       baseExtensions = defaultExtensions,
       readOnly = false,
       theme = "system",
@@ -128,6 +139,7 @@ export const CodeMirrorEditor = forwardRef<CodeMirrorEditorRef, CodeMirrorEditor
     const placeholderCompartment = useRef(new Compartment());
     const lineWrappingCompartment = useRef(new Compartment());
     const readOnlyCompartment = useRef(new Compartment());
+    const contentAttributesCompartment = useRef(new Compartment());
     const additionalCompartment = useRef(new Compartment());
 
     // Track dark mode state for "system" theme
@@ -254,6 +266,7 @@ export const CodeMirrorEditor = forwardRef<CodeMirrorEditorRef, CodeMirrorEditor
           placeholderCompartment.current.of(placeholder ? placeholderExt(placeholder) : []),
           lineWrappingCompartment.current.of(lineWrapping ? EditorView.lineWrapping : []),
           readOnlyCompartment.current.of(readOnlyExtensions(readOnly)),
+          contentAttributesCompartment.current.of(contentAttributeExtensions(contentAttributes)),
           additionalCompartment.current.of(additionalExtensions ?? []),
           ...maxHeightTheme,
           updateListener,
@@ -348,6 +361,14 @@ export const CodeMirrorEditor = forwardRef<CodeMirrorEditorRef, CodeMirrorEditor
         effects: readOnlyCompartment.current.reconfigure(readOnlyExtensions(readOnly)),
       });
     }, [readOnly]);
+
+    useEffect(() => {
+      viewRef.current?.dispatch({
+        effects: contentAttributesCompartment.current.reconfigure(
+          contentAttributeExtensions(contentAttributes),
+        ),
+      });
+    }, [contentAttributes]);
 
     useEffect(() => {
       const view = viewRef.current;


### PR DESCRIPTION
## Summary
- add a `contentAttributes` hook to the shared CodeMirror editor wrapper
- enable spellcheck, autocorrect, and sentence autocapitalization for Markdown cell edit mode
- cover the shared editor behavior and Markdown cell wiring with unit tests

## Verification
- `pnpm test:run src/components/editor/__tests__/codemirror-editor.test.tsx`
- `pnpm test:run apps/notebook/src/components/__tests__/markdown-cell-theme.test.tsx`
- `pnpm --dir apps/notebook build`
- `pnpm --dir apps/notebook-cloud typecheck`
- `pnpm --dir apps/notebook-cloud build:viewer`
- `cargo xtask lint --fix`