### PR TITLE
fix(notebook-cloud): improve mobile rail affordance

### DIFF
--- a/apps/notebook-cloud/test/viewer-render-props.test.ts
+++ b/apps/notebook-cloud/test/viewer-render-props.test.ts
@@ -136,6 +136,10 @@ test("cloud notebook startup loading uses route-shaped shell chrome", () => {
   assert.match(cssText, /\.cloud-startup-shell/);
   assert.match(cssText, /\.cloud-startup-toolbar/);
   assert.match(cssText, /\.cloud-startup-line/);
+  assert.match(
+    cssText,
+    /@media \(max-width: 599\.98px\) \{[\s\S]*\.cloud-startup-rail,[\s\S]*\.cloud-notebook-rail\[data-collapsed="true"\]\s*\{[\s\S]*display: none;/,
+  );
 });
 
 test("cloud viewer keeps pending access-request polling quiet", () => {

--- a/apps/notebook-cloud/test/viewer-shared-cell-surface.test.ts
+++ b/apps/notebook-cloud/test/viewer-shared-cell-surface.test.ts
@@ -448,6 +448,36 @@ test("cloud rail binds through the shared document rail adapter", () => {
   assert.doesNotMatch(sourceText, /<NotebookRail[\s>]/);
 });
 
+test("cloud mobile shell gives the collapsed rail a toolbar entrypoint", () => {
+  const sourceText = viewerFileContaining("export function NotebookViewer");
+  const cssPath = new URL("../viewer/index.css", import.meta.url);
+  const cssText = readFileSync(cssPath, "utf8");
+
+  assert.match(sourceText, /PanelLeftOpen/);
+  assert.match(sourceText, /const handleOpenMobileRail = useCallback\(\(\) => \{/);
+  assert.match(sourceText, /setRailCollapsed\(false\);/);
+  assert.match(
+    sourceText,
+    /leadingControls: \(\s*<button[\s\S]*className="cloud-mobile-rail-toggle hidden h-8 w-8[\s\S]*aria-label="Open notebook panels"[\s\S]*onClick=\{handleOpenMobileRail\}/,
+  );
+  assert.match(
+    cssText,
+    /@media \(max-width: 599\.98px\) \{[\s\S]*\.cloud-mobile-rail-toggle\s*\{[\s\S]*display: inline-flex;/,
+  );
+  assert.match(
+    cssText,
+    /@media \(max-width: 599\.98px\) \{[\s\S]*\.cloud-notebook-rail\[data-collapsed="true"\]\s*\{[\s\S]*display: none;/,
+  );
+  assert.match(
+    cssText,
+    /@media \(max-width: 599\.98px\) \{[\s\S]*\.cloud-notebook-shell \[data-slot="notebook-command-toolbar"\] button\s*\{[\s\S]*min-width: 2rem;[\s\S]*min-height: 2rem;/,
+  );
+  assert.match(
+    cssText,
+    /@media \(max-width: 599\.98px\) \{[\s\S]*\.cloud-notebook-rail\[data-collapsed="false"\]\s*\{[\s\S]*width: 100%;/,
+  );
+});
+
 test("cloud host notices sit in the shared shell above the rail and notebook stage", () => {
   const sourceText = viewerCorpus;
   const cssPath = new URL("../viewer/index.css", import.meta.url);

--- a/apps/notebook-cloud/viewer/index.css
+++ b/apps/notebook-cloud/viewer/index.css
@@ -578,6 +578,49 @@ body {
 }
 
 @media (max-width: 599.98px) {
+  .cloud-mobile-rail-toggle {
+    display: inline-flex;
+  }
+
+  .cloud-startup-rail,
+  .cloud-notebook-rail[data-collapsed="true"] {
+    display: none;
+  }
+
+  .cloud-notebook-title-edit-button,
+  .cloud-notebook-title-form button,
+  .cloud-notebook-shell [data-slot="cell-action-overlay"] button {
+    width: 2rem;
+    height: 2rem;
+  }
+
+  .cloud-notebook-shell [data-slot="notebook-edit-mode-button"] {
+    height: 2.5rem;
+  }
+
+  .cloud-notebook-shell [data-slot="notebook-edit-mode-button"] button {
+    min-width: 2rem;
+    min-height: 2rem;
+  }
+
+  .cloud-notebook-shell [data-slot="notebook-command-toolbar"] {
+    height: 2.75rem;
+  }
+
+  .cloud-notebook-shell [data-slot="notebook-command-toolbar"] button {
+    min-width: 2rem;
+    min-height: 2rem;
+  }
+
+  .cloud-notebook-shell [data-slot="cell-adder-primary-hit-target"] {
+    min-width: 2.75rem;
+    min-height: 2.25rem;
+  }
+
+  .cloud-notebook-shell [data-slot="cell-adder-action-palette"] button {
+    min-height: 2rem;
+  }
+
   .cloud-notebook-rail[data-collapsed="false"] {
     width: 100%;
     max-width: 100%;

--- a/apps/notebook-cloud/viewer/notebook-viewer.tsx
+++ b/apps/notebook-cloud/viewer/notebook-viewer.tsx
@@ -8,7 +8,7 @@ import {
   type ReactNode,
 } from "react";
 import { NotebookHostProvider } from "@nteract/notebook-host";
-import { AlertCircle, Check, Loader2, X } from "lucide-react";
+import { AlertCircle, Check, Loader2, PanelLeftOpen, X } from "lucide-react";
 import type { NteractEmbedHostContextPatch } from "@/components/isolated/host-context";
 import {
   useHasIsolatedOutputs,
@@ -587,6 +587,9 @@ export function NotebookViewer({
     setRailCollapsed(false);
     setActiveRailPanel("packages");
   }, [activeRailPanel, railCollapsed]);
+  const handleOpenMobileRail = useCallback(() => {
+    setRailCollapsed(false);
+  }, []);
   const handleOpenWorkstationsRail = useCallback(() => {
     setRailCollapsed(false);
     setActiveRailPanel("workstations");
@@ -1447,6 +1450,17 @@ export function NotebookViewer({
       }
       reserveCommandToolbar={editAccessPending}
       commandToolbar={{
+        leadingControls: (
+          <button
+            type="button"
+            className="cloud-mobile-rail-toggle hidden h-8 w-8 shrink-0 items-center justify-center rounded-md text-muted-foreground transition-colors hover:bg-muted hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+            aria-label="Open notebook panels"
+            title="Notebook panels"
+            onClick={handleOpenMobileRail}
+          >
+            <PanelLeftOpen className="h-4 w-4" aria-hidden="true" />
+          </button>
+        ),
         runtime: toolbarRuntime,
         runtimeTarget: shellCapabilities.runtime.target ?? null,
         environmentManager: toolbarEnvironmentManager,


### PR DESCRIPTION
## Summary
- add a mobile-only notebook panels button to the cloud command toolbar
- hide the collapsed rail below 600px so the notebook stage can use the full mobile width
- keep the existing full-width rail takeover when a rail panel is open
- increase mobile tap targets for cloud title, edit-mode, command-toolbar, cell action, and cell-adder controls

## Preview check
- On preview.runt.run mobile emulation, injecting the final responsive CSS moved the notebook stage from 341px to 390px wide and widened the rendered markdown heading/content area from 241px to 290px.
- The command toolbar buttons measured at 32x32 or larger after the final rule.

## Verification
- `pnpm --dir apps/notebook-cloud exec node --import tsx --test test/viewer-shared-cell-surface.test.ts`
- `pnpm --dir apps/notebook-cloud typecheck`
- `pnpm --dir apps/notebook-cloud build:viewer` (primary viewer CSS: 247.38 kB)
- `cargo xtask lint --fix`