### PR TITLE
fix(notebook-cloud): trust dashboard bootstrap on first paint

### DIFF
--- a/apps/notebook-cloud/test/viewer-shared-cell-surface.test.ts
+++ b/apps/notebook-cloud/test/viewer-shared-cell-surface.test.ts
@@ -672,6 +672,26 @@ test("cloud notebook list waits for app-session cookies before catalog fetches",
   );
 });
 
+test("cloud notebook list trusts server bootstrap on initial app-session paint", () => {
+  const sourcePath = new URL("../viewer/notebook-list-view.tsx", import.meta.url);
+  const sourceText = readFileSync(sourcePath, "utf8");
+
+  assert.match(
+    sourceText,
+    /const seededNotebooks = cloudNotebookListSeedFromBootstrapOrCache\(authState, bootstrap\);/,
+  );
+  assert.match(
+    sourceText,
+    /if \(refreshIndex === 0 && bootstrap\) \{[\s\S]*writeCachedCloudNotebookListToWindow\(authState, bootstrap\.notebooks\);[\s\S]*setListState\(\{ kind: "ready", notebooks: bootstrap\.notebooks \}\);[\s\S]*return;/,
+    "fresh notebook-home bootstrap should satisfy the initial render without an immediate duplicate /api/n fetch",
+  );
+  assert.match(
+    sourceText,
+    /return bootstrap\?\.notebooks \?\? readCachedCloudNotebookListFromWindow\(authState\);/,
+    "server bootstrap should beat stale sessionStorage cache when both are present",
+  );
+});
+
 test("cloud app-session live sync requests the resolved notebook-list scope", () => {
   const sourceText = viewerCorpus;
 

--- a/apps/notebook-cloud/viewer/notebook-list-view.tsx
+++ b/apps/notebook-cloud/viewer/notebook-list-view.tsx
@@ -96,12 +96,11 @@ export function CloudNotebookListView({ authConfig }: { authConfig: CloudViewerA
   }, [listState]);
 
   useEffect(() => {
-    const cachedNotebooks =
-      readCachedCloudNotebookListFromWindow(authState) ?? bootstrap?.notebooks ?? null;
+    const seededNotebooks = cloudNotebookListSeedFromBootstrapOrCache(authState, bootstrap);
     if (!canFetchNotebookList) {
       if (waitingForAppSession) {
         setListState(
-          cachedNotebooks ? { kind: "ready", notebooks: cachedNotebooks } : { kind: "loading" },
+          seededNotebooks ? { kind: "ready", notebooks: seededNotebooks } : { kind: "loading" },
         );
         return;
       }
@@ -110,9 +109,15 @@ export function CloudNotebookListView({ authConfig }: { authConfig: CloudViewerA
       return;
     }
 
+    if (refreshIndex === 0 && bootstrap) {
+      writeCachedCloudNotebookListToWindow(authState, bootstrap.notebooks);
+      setListState({ kind: "ready", notebooks: bootstrap.notebooks });
+      return;
+    }
+
     const controller = new AbortController();
     setListState(
-      cachedNotebooks ? { kind: "ready", notebooks: cachedNotebooks } : { kind: "loading" },
+      seededNotebooks ? { kind: "ready", notebooks: seededNotebooks } : { kind: "loading" },
     );
     void (async () => {
       try {
@@ -512,8 +517,8 @@ function initialCloudNotebookListState(
   authState: CloudPrototypeAuthState,
   bootstrap: CloudNotebookListBootstrap | null,
 ): CloudNotebookListState {
-  const cachedNotebooks = readCachedCloudNotebookListFromWindow(authState) ?? bootstrap?.notebooks;
-  return cachedNotebooks ? { kind: "ready", notebooks: cachedNotebooks } : { kind: "loading" };
+  const seededNotebooks = cloudNotebookListSeedFromBootstrapOrCache(authState, bootstrap);
+  return seededNotebooks ? { kind: "ready", notebooks: seededNotebooks } : { kind: "loading" };
 }
 
 function fetchCloudNotebookList(
@@ -532,6 +537,13 @@ function fetchCloudNotebookList(
     headers: { Accept: "application/json" },
     signal,
   });
+}
+
+function cloudNotebookListSeedFromBootstrapOrCache(
+  authState: CloudPrototypeAuthState,
+  bootstrap: CloudNotebookListBootstrap | null,
+): CloudNotebookListItem[] | null {
+  return bootstrap?.notebooks ?? readCachedCloudNotebookListFromWindow(authState);
 }
 
 function readCachedCloudNotebookListFromWindow(


### PR DESCRIPTION
## Summary
- prefer the server-rendered notebook-list bootstrap over stale sessionStorage on `/n`
- skip the immediate duplicate `/api/n` fetch on the initial app-session dashboard paint
- keep manual refresh and non-bootstrapped paths fetching normally

## Verification
- `pnpm --dir apps/notebook-cloud exec node --import tsx --test test/viewer-shared-cell-surface.test.ts`
- `pnpm --dir apps/notebook-cloud exec node --import tsx --test test/notebook-dashboard.test.ts`
- `pnpm --dir apps/notebook-cloud typecheck`
- `pnpm --dir apps/notebook-cloud build:viewer`
- `cargo xtask lint --fix`