### PR TITLE
perf(notebook-cloud): cache viewer asset manifests

### DIFF
--- a/apps/notebook-cloud/src/index.ts
+++ b/apps/notebook-cloud/src/index.ts
@@ -1,4 +1,4 @@
-import type { Env, ExecutionContext, ExportedHandler } from "./cloudflare-types.ts";
+import type { Env, ExecutionContext, ExportedHandler, WorkerAssets } from "./cloudflare-types.ts";
 import { projectNotebookWorkstationAttachmentFromClaim, type BlobRef } from "runtimed";
 import { NotebookRoom } from "./notebook-room.ts";
 import {
@@ -189,6 +189,16 @@ interface RendererSidecarAssetNames {
   css: string;
   siftWasm: string;
 }
+
+const notebookRouteAssetNamesCache = new WeakMap<
+  WorkerAssets,
+  Promise<ViewerNotebookRouteAssets>
+>();
+const runtimeWasmAssetNamesCache = new WeakMap<WorkerAssets, Promise<RuntimeWasmAssetNames>>();
+const rendererSidecarAssetNamesCache = new WeakMap<
+  WorkerAssets,
+  Promise<RendererSidecarAssetNames>
+>();
 
 type SnapshotPairValidationResult =
   | {
@@ -4620,15 +4630,27 @@ function runtimedWasmAssetPath(env: Env, name: string): string {
 }
 
 async function notebookRouteAssetNames(env: Env): Promise<ViewerNotebookRouteAssets> {
-  if (!env.ASSETS) {
+  const assets = env.ASSETS;
+  if (!assets) {
     return defaultNotebookRouteAssetNames();
   }
 
+  let cached = notebookRouteAssetNamesCache.get(assets);
+  if (!cached) {
+    cached = readNotebookRouteAssetNames(assets);
+    notebookRouteAssetNamesCache.set(assets, cached);
+  }
+  return cached;
+}
+
+async function readNotebookRouteAssetNames(
+  assets: WorkerAssets,
+): Promise<ViewerNotebookRouteAssets> {
   try {
     const manifestRequest = new Request(
       `https://notebook-cloud.local${VIEWER_NOTEBOOK_ROUTE_ASSET_MANIFEST_PATH}`,
     );
-    const response = await env.ASSETS.fetch(manifestRequest);
+    const response = await assets.fetch(manifestRequest);
     if (!response.ok) {
       return defaultNotebookRouteAssetNames();
     }
@@ -4671,15 +4693,25 @@ function isViewerAssetName(value: unknown, extension: "css" | "js"): value is st
 }
 
 async function runtimeWasmAssetNames(env: Env): Promise<RuntimeWasmAssetNames> {
-  if (!env.ASSETS) {
+  const assets = env.ASSETS;
+  if (!assets) {
     return defaultRuntimeWasmAssetNames();
   }
 
+  let cached = runtimeWasmAssetNamesCache.get(assets);
+  if (!cached) {
+    cached = readRuntimeWasmAssetNames(assets);
+    runtimeWasmAssetNamesCache.set(assets, cached);
+  }
+  return cached;
+}
+
+async function readRuntimeWasmAssetNames(assets: WorkerAssets): Promise<RuntimeWasmAssetNames> {
   try {
     const manifestRequest = new Request(
       `https://notebook-cloud.local${VIEWER_RUNTIME_WASM_ASSET_MANIFEST_PATH}`,
     );
-    const response = await env.ASSETS.fetch(manifestRequest);
+    const response = await assets.fetch(manifestRequest);
     if (!response.ok) {
       return defaultRuntimeWasmAssetNames();
     }
@@ -4730,15 +4762,27 @@ function isRuntimeWasmBinaryName(value: unknown): value is string {
  * deployed alongside the hashed copies.
  */
 async function rendererSidecarAssetNames(env: Env): Promise<RendererSidecarAssetNames> {
-  if (!env.ASSETS) {
+  const assets = env.ASSETS;
+  if (!assets) {
     return defaultRendererSidecarAssetNames();
   }
 
+  let cached = rendererSidecarAssetNamesCache.get(assets);
+  if (!cached) {
+    cached = readRendererSidecarAssetNames(assets);
+    rendererSidecarAssetNamesCache.set(assets, cached);
+  }
+  return cached;
+}
+
+async function readRendererSidecarAssetNames(
+  assets: WorkerAssets,
+): Promise<RendererSidecarAssetNames> {
   try {
     const manifestRequest = new Request(
       `https://notebook-cloud.local${VIEWER_RENDERER_SIDECAR_MANIFEST_PATH}`,
     );
-    const response = await env.ASSETS.fetch(manifestRequest);
+    const response = await assets.fetch(manifestRequest);
     if (!response.ok) {
       return defaultRendererSidecarAssetNames();
     }

--- a/apps/notebook-cloud/test/html.test.ts
+++ b/apps/notebook-cloud/test/html.test.ts
@@ -158,6 +158,59 @@ describe("HTML script serialization", () => {
     );
   });
 
+  it("caches immutable viewer asset manifests across warm shell renders", async () => {
+    const seenPaths: string[] = [];
+    const env = fakeEnv({
+      ASSETS: fakeViewerAssetManifests(
+        {
+          notebookRoute: {
+            modulepreload: ["notebook-route.0123456789abcdef.js"],
+            stylepreload: ["notebook-route.0123456789abcdef.css"],
+          },
+          runtimeWasm: {
+            module: "runtimed_wasm.0123456789abcdef.js",
+            wasm: "runtimed_wasm_bg.fedcba9876543210.wasm",
+          },
+          rendererSidecar: {
+            js: "isolated-renderer.0123456789abcdef.js",
+            css: "isolated-renderer.0123456789abcdef.css",
+            siftWasm: "sift_wasm.0123456789abcdef.wasm",
+          },
+        },
+        seenPaths,
+      ),
+    });
+
+    const firstResponse = await worker.fetch(
+      new Request("https://cloud.test/n/demo/example"),
+      env,
+      fakeContext(),
+    );
+    const secondResponse = await worker.fetch(
+      new Request("https://cloud.test/n/demo/example"),
+      env,
+      fakeContext(),
+    );
+    const secondHtml = await secondResponse.text();
+
+    assert.equal(firstResponse.status, 200);
+    assert.equal(secondResponse.status, 200);
+    assert.deepEqual(seenPaths, [
+      "/assets/runtime-wasm-assets.json",
+      "/assets/renderer-sidecar-assets.json",
+      "/assets/notebook-route-assets.json",
+    ]);
+    assert.match(
+      secondHtml,
+      /rel="modulepreload" href="\/assets\/runtimed_wasm\.0123456789abcdef\.js" crossorigin/,
+    );
+    assert.match(
+      secondHtml,
+      /rel="modulepreload" href="\/assets\/notebook-route\.0123456789abcdef\.js"/,
+    );
+    assert.match(secondHtml, /isolated-renderer\.0123456789abcdef\.js/);
+  });
+
   it("keeps notebook route asset hints out of the dashboard shell", async () => {
     const seenPaths: string[] = [];
     const response = await worker.fetch(


### PR DESCRIPTION
## Summary
- cache notebook-route, runtime WASM, and renderer sidecar asset manifest lookups per Worker assets binding
- keep the same content-hashed resource hints while avoiding repeated ASSETS manifest fetches across warm shell renders
- add HTML shell coverage proving a second render with the same binding reuses cached manifest data

## Verification
- pnpm --dir apps/notebook-cloud exec node --import tsx --test test/html.test.ts
- pnpm --dir apps/notebook-cloud exec node --import tsx --test test/worker-routes.test.ts
- pnpm --dir apps/notebook-cloud typecheck
- cargo xtask lint --fix