### PR TITLE
perf(notebook-cloud): short-circuit app shell head requests

### DIFF
--- a/apps/notebook-cloud/src/index.ts
+++ b/apps/notebook-cloud/src/index.ts
@@ -4224,6 +4224,10 @@ async function viewer(
   headsHash?: string,
   routeTitleSegment?: string,
 ): Promise<Response> {
+  if (request.method === "HEAD") {
+    return viewerShellHead(env);
+  }
+
   const shellMetadata = await publicViewerShellMetadata(
     env,
     notebookId,
@@ -4295,6 +4299,10 @@ function rootNotebookListRedirect(request: Request): Response {
 }
 
 async function notebookListViewer(request: Request, env: Env): Promise<Response> {
+  if (request.method === "HEAD") {
+    return viewerShellHead(env);
+  }
+
   const bootstrap = await notebookListBootstrap(request, env);
   const resourceHints = notebookListBootstrapHasNotebooks(bootstrap)
     ? {
@@ -4319,6 +4327,10 @@ async function notebookListViewer(request: Request, env: Env): Promise<Response>
 }
 
 function oidcCallbackViewer(request: Request, env: Env): Response {
+  if (request.method === "HEAD") {
+    return viewerShellHead(env);
+  }
+
   return responseForRequestMethod(
     request,
     viewerShell(
@@ -4338,6 +4350,20 @@ function responseForRequestMethod(request: Request, response: Response): Respons
     return response;
   }
   return new Response(null, response);
+}
+
+function viewerShellHead(env: Env): Response {
+  return withCors(
+    withBrowserSecurityHeaders(
+      new Response(null, {
+        headers: {
+          "Cache-Control": "no-store",
+          "Content-Type": "text/html; charset=utf-8",
+        },
+      }),
+      viewerContentSecurityPolicy(env),
+    ),
+  );
 }
 
 interface ViewerShellMetadata {

--- a/apps/notebook-cloud/test/worker-routes.test.ts
+++ b/apps/notebook-cloud/test/worker-routes.test.ts
@@ -318,6 +318,20 @@ describe("Worker artifact routes", () => {
     }
   });
 
+  it("short-circuits notebook shell HEAD requests before asset bootstrap", async () => {
+    const seenAssetPaths: string[] = [];
+    const response = await worker.fetch(
+      new Request("http://localhost/n/head-demo/Example", { method: "HEAD" }),
+      fakeEnv({ ASSETS: fakeNotebookRouteAssets(seenAssetPaths) }),
+      fakeContext(),
+    );
+
+    assert.equal(response.status, 200);
+    assert.match(response.headers.get("Content-Type") ?? "", /text\/html/);
+    assert.equal(await response.text(), "");
+    assert.deepEqual(seenAssetPaths, []);
+  });
+
   it("serves loopback local dev auth bootstrap without exposing external credentials", async () => {
     const response = await worker.fetch(
       new Request("http://127.0.0.1/local-auth?user=alice&scope=owner&next=/n"),


### PR DESCRIPTION
## Summary
- return hosted app-shell HEAD responses before building viewer/list/OIDC shell bodies
- avoid asset manifest and bootstrap work for HEAD probes that only need headers
- add Worker route coverage proving notebook HEAD requests do not touch the asset binding

## Verification
- pnpm --dir apps/notebook-cloud exec node --import tsx --test test/worker-routes.test.ts
- pnpm --dir apps/notebook-cloud typecheck
- cargo xtask lint --fix