### PR TITLE
fix(notebook-cloud): align home onboarding copy

### DIFF
--- a/apps/notebook-cloud/test/viewer-render-props.test.ts
+++ b/apps/notebook-cloud/test/viewer-render-props.test.ts
@@ -80,10 +80,17 @@ test("cloud home keeps prototype controls out of the primary auth surface", () =
   assert.match(homeSource, /aria-label="nteract notebook entry"/);
   assert.match(homeSource, /aria-label="Notebook sign-in"/);
   assert.match(homeSource, /className="cloud-home-copy"/);
-  assert.match(homeSource, /<h1>nteract<\/h1>/);
-  assert.match(homeSource, /realtime notebooks/);
+  assert.match(homeSource, /className="cloud-home-kicker"/);
+  assert.match(homeSource, /NTERACT/);
+  assert.match(homeSource, /<h1>Bring computation to life\.<\/h1>/);
+  assert.match(
+    homeSource,
+    /Sign in to create live notebooks, share work with colleagues, and attach compute\./,
+  );
   assert.match(homeSource, /View notebooks/);
   assert.match(homeSource, /href="\/n"/);
+  assert.match(homeSource, /Visit nteract\.io/);
+  assert.match(homeSource, /href="https:\/\/nteract\.io\/"/);
   assert.match(homeSource, /const localDevAuth = authConfig\.localDev/);
   assert.match(
     homeSource,
@@ -97,6 +104,7 @@ test("cloud home keeps prototype controls out of the primary auth surface", () =
   assert.doesNotMatch(homeSource, /cloud-report-toolbar/);
   assert.doesNotMatch(homeSource, /requesting viewer/);
   assert.match(cssText, /\.cloud-home-layout/);
+  assert.match(cssText, /\.cloud-home-kicker/);
   assert.doesNotMatch(cssText, /\.cloud-home-scope/);
   assert.doesNotMatch(homePanelCss, /box-shadow/);
   assert.doesNotMatch(homePanelCss, /border-radius/);

--- a/apps/notebook-cloud/viewer/home-view.tsx
+++ b/apps/notebook-cloud/viewer/home-view.tsx
@@ -1,5 +1,13 @@
 import { useEffect, useState } from "react";
-import { KeyRound, LogIn, LogOut, RotateCcw, UserRound } from "lucide-react";
+import {
+  ArrowUpRight,
+  KeyRound,
+  LogIn,
+  LogOut,
+  RotateCcw,
+  Sparkles,
+  UserRound,
+} from "lucide-react";
 import { useTheme } from "@/hooks/useTheme";
 import { clearCloudAppSession } from "./app-session";
 import { cloudNotebookSignInLabel } from "./cloud-auth-controls";
@@ -103,8 +111,12 @@ export function CloudHomeView({ authConfig }: { authConfig: CloudViewerAuthConfi
     <main className="cloud-home">
       <section className="cloud-home-layout" aria-label="nteract notebook entry">
         <div className="cloud-home-copy">
-          <h1>nteract</h1>
-          <span>realtime notebooks</span>
+          <div className="cloud-home-kicker">
+            <Sparkles aria-hidden="true" />
+            NTERACT
+          </div>
+          <h1>Bring computation to life.</h1>
+          <p>Sign in to create live notebooks, share work with colleagues, and attach compute.</p>
         </div>
 
         <section
@@ -137,6 +149,10 @@ export function CloudHomeView({ authConfig }: { authConfig: CloudViewerAuthConfi
 
           <div className="cloud-home-actions">
             <a href="/n">View notebooks</a>
+            <a href="https://nteract.io/" target="_blank" rel="noreferrer">
+              Visit nteract.io
+              <ArrowUpRight aria-hidden="true" />
+            </a>
             {signedIn ? (
               <button
                 type="button"

--- a/apps/notebook-cloud/viewer/index.css
+++ b/apps/notebook-cloud/viewer/index.css
@@ -1459,26 +1459,44 @@ body {
 .cloud-home-copy {
   display: grid;
   justify-items: center;
-  gap: 0.375rem;
+  gap: 0.75rem;
   text-align: center;
 }
 
 .cloud-home-copy h1,
-.cloud-home-copy span {
+.cloud-home-copy p {
   margin: 0;
 }
 
-.cloud-home-copy h1 {
-  color: var(--foreground);
-  font-size: clamp(3rem, 8vw, 5rem);
+.cloud-home-kicker {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.375rem;
+  color: color-mix(in srgb, #0f766e 72%, var(--foreground) 28%);
+  font-size: 0.8125rem;
   font-weight: 760;
-  letter-spacing: 0;
-  line-height: 0.95;
+  letter-spacing: 0.08em;
+  line-height: 1;
 }
 
-.cloud-home-copy span {
+.cloud-home-kicker svg {
+  width: 1rem;
+  height: 1rem;
+}
+
+.cloud-home-copy h1 {
+  max-width: 11ch;
+  color: var(--foreground);
+  font-size: 4.25rem;
+  font-weight: 760;
+  letter-spacing: 0;
+  line-height: 1;
+}
+
+.cloud-home-copy p {
+  max-width: 31rem;
   color: color-mix(in srgb, var(--foreground) 62%, transparent);
-  font-size: clamp(1rem, 2vw, 1.25rem);
+  font-size: 1.125rem;
   line-height: 1.35;
 }
 
@@ -1622,6 +1640,10 @@ body {
   .cloud-home-layout {
     width: min(100%, calc(100vw - 2rem));
     padding-block: 3rem;
+  }
+
+  .cloud-home-copy h1 {
+    font-size: 3rem;
   }
 }
 


### PR DESCRIPTION
## Summary
- update the cloud home fallback/rollback screen to the NTERACT onboarding copy
- add an explicit nteract.io link alongside the notebook entry action
- keep the home typography on fixed responsive steps instead of viewport-scaled type

## Verification
- pnpm --dir apps/notebook-cloud exec node --import tsx --test test/viewer-render-props.test.ts
- pnpm --dir apps/notebook-cloud typecheck
- pnpm --dir apps/notebook-cloud build:viewer
- cargo xtask lint --fix

## Note
The current Worker redirects `/` and `/index.html` to `/n`; this keeps the retained home route aligned with the signed-out dashboard copy for rollback/future use.