### PR TITLE
fix(notebook-cloud): surface edit requests in sharing

### DIFF
--- a/apps/notebook-cloud/test/viewer-render-props.test.ts
+++ b/apps/notebook-cloud/test/viewer-render-props.test.ts
@@ -312,6 +312,10 @@ test("cloud viewer routes notebook header controls through the shared shell chro
     /const accessProjection = useMemo\(\s*\(\) => buildCloudShareAccessProjection\(\{ acl, invites, accessRequests \}\)/,
   );
   assert.match(sharingSourceText, /<div className="cloud-share-current-heading">/);
+  assert.match(sharingSourceText, /aria-label="Edit access requests"/);
+  assert.match(sharingSourceText, /<h3>Edit requests<\/h3>/);
+  assert.match(sharingSourceText, /accessProjection\.accessRequestRows\.map/);
+  assert.match(sharingSourceText, /accessProjection\.accessRequestSummary/);
   assert.match(sharingSourceText, /aria-label="Compute access"/);
   assert.match(sharingSourceText, /accessProjection\.runtimeAccessRows\.map/);
   assert.match(sharingSourceText, /<div className="cloud-share-row-actions">/);
@@ -330,6 +334,10 @@ test("cloud viewer routes notebook header controls through the shared shell chro
   assert.match(
     sharingSourceText,
     /accessProjection\.notebookAccessRows\.map\(\(row\) =>[\s\S]*<CloudShareRowIcon row=\{row\} \/>[\s\S]*<strong>\{row\.label\}<\/strong>[\s\S]*<span>\{row\.detail\}<\/span>/,
+  );
+  assert.match(
+    sharingSourceText,
+    /accessProjection\.accessRequestRows\.map\(\(row\) =>[\s\S]*aria-label=\{`Approve \$\{row\.label\}`\}/,
   );
   assert.match(sharingSourceText, /aria-label=\{`Remove \$\{row\.label\}`\}/);
   const sharePanelCss = cssText.match(/\.cloud-share-panel \{(?<body>[\s\S]*?)\n\}/)?.groups?.body;

--- a/apps/notebook-cloud/test/viewer-sharing.test.ts
+++ b/apps/notebook-cloud/test/viewer-sharing.test.ts
@@ -125,9 +125,61 @@ describe("cloud viewer sharing client", () => {
     );
     assert.equal(projection.notebookAccessSummary, "1 person, 1 invite");
     assert.equal(projection.runtimeAccessSummary, "1 runtime peer");
+    assert.deepEqual(projection.accessRequestRows, []);
+    assert.equal(projection.accessRequestSummary, null);
     assert.equal(Object.isFrozen(projection), true);
     assert.equal(Object.isFrozen(projection.notebookAccessRows), true);
     assert.equal(Object.isFrozen(projection.runtimeAccessRows), true);
+    assert.equal(Object.isFrozen(projection.accessRequestRows), true);
+  });
+
+  it("projects pending edit requests as their own action queue", () => {
+    const owner = aclRow({
+      subject: "user:anaconda:owner",
+      scope: "owner",
+      display: {
+        kind: "principal",
+        label: "Owner User",
+        principal: "user:anaconda:owner",
+        email: "owner@example.com",
+      },
+    });
+    const pendingRequest = accessRequestRow({
+      id: "request-pending",
+      requester_principal: "user:anaconda:dana",
+      display: {
+        kind: "principal",
+        label: "Dana Requester",
+        principal: "user:anaconda:dana",
+        email: "dana@example.com",
+      },
+    });
+
+    const projection = buildCloudShareAccessProjection({
+      acl: [owner],
+      invites: [],
+      accessRequests: [
+        pendingRequest,
+        accessRequestRow({ id: "request-approved", status: "approved" }),
+      ],
+    });
+
+    assert.deepEqual(
+      projection.notebookAccessRows.map((row) => [row.kind, row.label]),
+      [["acl", "Owner User"]],
+    );
+    assert.deepEqual(
+      projection.accessRequestRows.map((row) => [
+        row.kind,
+        row.label,
+        row.badge,
+        row.stateLabel,
+        row.removable,
+      ]),
+      [["access_request", "Dana Requester", "Can edit", "Requested", false]],
+    );
+    assert.equal(projection.notebookAccessSummary, "1 person");
+    assert.equal(projection.accessRequestSummary, "1 request");
   });
 
   it("detects public viewer access from explicit public ACL rows", () => {

--- a/apps/notebook-cloud/viewer/index.css
+++ b/apps/notebook-cloud/viewer/index.css
@@ -1945,12 +1945,33 @@ body {
   padding: 0.875rem 1rem;
 }
 
+.cloud-share-requests {
+  border-top-color: color-mix(in srgb, #b45309 34%, transparent);
+  background: color-mix(in srgb, #b45309 5%, transparent);
+}
+
 .cloud-share-current-heading {
   display: flex;
   align-items: center;
   justify-content: space-between;
   gap: 0.75rem;
   min-width: 0;
+}
+
+.cloud-share-current-heading > div {
+  min-width: 0;
+}
+
+.cloud-share-current-heading h3,
+.cloud-share-current-heading p {
+  margin: 0;
+}
+
+.cloud-share-current-heading p {
+  margin-top: 0.125rem;
+  color: color-mix(in srgb, var(--foreground) 58%, transparent);
+  font-size: 0.75rem;
+  line-height: 1.3;
 }
 
 .cloud-share-current-heading > span {

--- a/apps/notebook-cloud/viewer/sharing-client.ts
+++ b/apps/notebook-cloud/viewer/sharing-client.ts
@@ -107,6 +107,8 @@ export type CloudShareAccessRow =
     };
 
 export interface CloudShareAccessProjection {
+  accessRequestRows: readonly Extract<CloudShareAccessRow, { kind: "access_request" }>[];
+  accessRequestSummary: string | null;
   allRows: CloudShareAccessRow[];
   notebookAccessRows: CloudShareAccessRow[];
   runtimeAccessRows: CloudShareAccessRow[];
@@ -176,13 +178,21 @@ export function buildCloudShareAccessProjection(input: {
   const cached = getBoundedCacheValue(SHARE_ACCESS_PROJECTION_CACHE, projectionKey);
   if (cached) return cached;
 
+  const accessRequestRows = Object.freeze(allRows.filter(isCloudShareAccessRequestRow)) as Extract<
+    CloudShareAccessRow,
+    { kind: "access_request" }
+  >[];
   const notebookAccessRows = Object.freeze(
-    allRows.filter((row) => !isCloudShareRuntimeAccessRow(row)),
+    allRows.filter(
+      (row) => !isCloudShareRuntimeAccessRow(row) && !isCloudShareAccessRequestRow(row),
+    ),
   ) as CloudShareAccessRow[];
   const runtimeAccessRows = Object.freeze(
     allRows.filter(isCloudShareRuntimeAccessRow),
   ) as CloudShareAccessRow[];
   const projection = Object.freeze({
+    accessRequestRows,
+    accessRequestSummary: cloudShareAccessRequestSummary(accessRequestRows),
     allRows,
     notebookAccessRows,
     runtimeAccessRows,
@@ -354,10 +364,22 @@ export function cloudShareRuntimeAccessSummary(rows: CloudShareAccessRow[]): str
   return runtimePeers > 0 ? pluralize(runtimePeers, "runtime peer", "runtime peers") : null;
 }
 
+export function cloudShareAccessRequestSummary(
+  rows: readonly Extract<CloudShareAccessRow, { kind: "access_request" }>[],
+): string | null {
+  return rows.length > 0 ? pluralize(rows.length, "request", "requests") : null;
+}
+
 export function isCloudShareRuntimeAccessRow(
   row: CloudShareAccessRow,
 ): row is Extract<CloudShareAccessRow, { kind: "acl" }> {
   return row.kind === "acl" && row.acl.subject_kind === "principal" && row.scope === "runtime_peer";
+}
+
+export function isCloudShareAccessRequestRow(
+  row: CloudShareAccessRow,
+): row is Extract<CloudShareAccessRow, { kind: "access_request" }> {
+  return row.kind === "access_request";
 }
 
 export function hasPublicViewerAccess(acl: CloudNotebookAclRow[]): boolean {

--- a/apps/notebook-cloud/viewer/sharing-controls.tsx
+++ b/apps/notebook-cloud/viewer/sharing-controls.tsx
@@ -397,6 +397,67 @@ export function CloudSharingControls({
           ) : null}
         </form>
 
+        {accessProjection.accessRequestRows.length > 0 ? (
+          <section
+            className="cloud-share-current cloud-share-requests"
+            aria-label="Edit access requests"
+          >
+            <div className="cloud-share-current-heading">
+              <div>
+                <h3>Edit requests</h3>
+                <p>Approve collaborators you recognize, or dismiss stale requests.</p>
+              </div>
+              {accessProjection.accessRequestSummary ? (
+                <span>{accessProjection.accessRequestSummary}</span>
+              ) : null}
+            </div>
+            <ul>
+              {accessProjection.accessRequestRows.map((row) => (
+                <li key={row.id} title={row.title}>
+                  <CloudShareRowIcon row={row} />
+                  <div>
+                    <strong>{row.label}</strong>
+                    <span>{row.detail}</span>
+                  </div>
+                  <div className="cloud-share-row-actions">
+                    <span className="cloud-share-badge">{row.badge}</span>
+                    <span className="cloud-share-state" data-tone={row.stateTone ?? undefined}>
+                      {row.stateLabel}
+                    </span>
+                    <button
+                      type="button"
+                      aria-label={`Approve ${row.label}`}
+                      title={`Approve ${row.label}`}
+                      disabled={busyAction === `${row.id}:approve`}
+                      onClick={() => void resolveAccessRequest(row, "approve")}
+                    >
+                      <Check aria-hidden="true" />
+                    </button>
+                    <button
+                      type="button"
+                      aria-label={`Deny ${row.label}`}
+                      title={`Deny ${row.label}`}
+                      disabled={busyAction === `${row.id}:deny`}
+                      onClick={() => void resolveAccessRequest(row, "deny")}
+                    >
+                      <X aria-hidden="true" />
+                    </button>
+                    <button
+                      type="button"
+                      aria-label={`Dismiss ${row.label}`}
+                      title={`Dismiss ${row.label}`}
+                      disabled={busyAction === `${row.id}:dismiss`}
+                      onClick={() => void resolveAccessRequest(row, "dismiss")}
+                    >
+                      <Trash2 aria-hidden="true" />
+                    </button>
+                  </div>
+                </li>
+              ))}
+            </ul>
+          </section>
+        ) : null}
+
         <section className="cloud-share-current" aria-label="Current notebook access">
           <div className="cloud-share-current-heading">
             <h3>Current access</h3>
@@ -423,37 +484,6 @@ export function CloudSharingControls({
                       <span className="cloud-share-state" data-tone={row.stateTone ?? undefined}>
                         {row.stateLabel}
                       </span>
-                    ) : null}
-                    {row.kind === "access_request" ? (
-                      <>
-                        <button
-                          type="button"
-                          aria-label={`Approve ${row.label}`}
-                          title={`Approve ${row.label}`}
-                          disabled={busyAction === `${row.id}:approve`}
-                          onClick={() => void resolveAccessRequest(row, "approve")}
-                        >
-                          <Check aria-hidden="true" />
-                        </button>
-                        <button
-                          type="button"
-                          aria-label={`Deny ${row.label}`}
-                          title={`Deny ${row.label}`}
-                          disabled={busyAction === `${row.id}:deny`}
-                          onClick={() => void resolveAccessRequest(row, "deny")}
-                        >
-                          <X aria-hidden="true" />
-                        </button>
-                        <button
-                          type="button"
-                          aria-label={`Dismiss ${row.label}`}
-                          title={`Dismiss ${row.label}`}
-                          disabled={busyAction === `${row.id}:dismiss`}
-                          onClick={() => void resolveAccessRequest(row, "dismiss")}
-                        >
-                          <Trash2 aria-hidden="true" />
-                        </button>
-                      </>
                     ) : null}
                     {row.removable ? (
                       <button


### PR DESCRIPTION
## Summary
- split pending edit access requests into a dedicated sharing-panel section
- keep current access focused on granted collaborators, public link rows, and pending invites
- add projection/test coverage for the new request queue and source-level render coverage

## Verification
- pnpm --dir apps/notebook-cloud exec node --import tsx --test test/viewer-sharing.test.ts test/viewer-render-props.test.ts
- pnpm --dir apps/notebook-cloud typecheck
- pnpm --dir apps/notebook-cloud build:viewer
- cargo xtask lint --fix