### PR TITLE
refactor(notebook-cloud): centralize access and sharing facts

### DIFF
--- a/apps/notebook-cloud/test/cloud-access-facts.test.ts
+++ b/apps/notebook-cloud/test/cloud-access-facts.test.ts
@@ -168,6 +168,11 @@ describe("cloud access facts projection", () => {
 
   it("deduplicates equivalent realtime source updates through RxJS selectors", () => {
     const store = new CloudAccessFactsStore(sourceFacts());
+    const initialSnapshot = store.snapshot;
+    assert.equal(store.snapshot, initialSnapshot);
+    store.set({ ...sourceFacts(), connection: { ...sourceFacts().connection } });
+    assert.equal(store.snapshot, initialSnapshot);
+
     const projectedModes: string[] = [];
     const fullProjectionKeys: string[] = [];
     const sub = store
@@ -183,7 +188,6 @@ describe("cloud access facts projection", () => {
       );
     });
 
-    store.set({ ...sourceFacts(), connection: { ...sourceFacts().connection } });
     store.update((current) => ({
       ...current,
       request: {

--- a/apps/notebook-cloud/test/cloud-access-facts.test.ts
+++ b/apps/notebook-cloud/test/cloud-access-facts.test.ts
@@ -1,0 +1,252 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+
+import {
+  CloudAccessFactsStore,
+  cloudCatalogAccessFacts,
+  projectCloudAccessFacts,
+  projectCloudAccessLiveRoomPolicy,
+  type CloudAccessSourceFacts,
+} from "../viewer/cloud-access-facts";
+import { CLOUD_CONNECTION_NO_ACCESS_DIAGNOSTIC } from "../viewer/connection-diagnostics";
+import type { CloudNotebookAccessRequest } from "../viewer/sharing-client";
+
+describe("cloud access facts projection", () => {
+  it("models catalog fetch lifecycle as host-owned source facts", () => {
+    assert.deepEqual(
+      cloudCatalogAccessFacts({
+        canUseAuthenticatedCloudApi: false,
+        loadFailed: false,
+        resolved: false,
+        scope: "owner",
+      }),
+      { status: "idle", scope: null },
+    );
+    assert.deepEqual(
+      cloudCatalogAccessFacts({
+        canUseAuthenticatedCloudApi: true,
+        loadFailed: false,
+        resolved: false,
+        scope: null,
+      }),
+      { status: "loading", scope: null },
+    );
+    assert.deepEqual(
+      cloudCatalogAccessFacts({
+        canUseAuthenticatedCloudApi: true,
+        loadFailed: false,
+        resolved: true,
+        scope: "editor",
+      }),
+      { status: "ready", scope: "editor" },
+    );
+    assert.deepEqual(
+      cloudCatalogAccessFacts({
+        canUseAuthenticatedCloudApi: true,
+        loadFailed: true,
+        resolved: true,
+        scope: "owner",
+      }),
+      { status: "error", scope: null },
+    );
+  });
+
+  it("projects live-room connection policy from catalog freshness", () => {
+    assert.deepEqual(
+      projectCloudAccessLiveRoomPolicy({
+        canUseAuthenticatedCloudApi: true,
+        catalog: { status: "loading", scope: null },
+      }),
+      {
+        shouldConnectLiveRoom: false,
+        disabledStatus: { kind: "loading", message: "Checking notebook access..." },
+      },
+    );
+    assert.deepEqual(
+      projectCloudAccessLiveRoomPolicy({
+        canUseAuthenticatedCloudApi: true,
+        catalog: { status: "ready", scope: null },
+      }),
+      {
+        shouldConnectLiveRoom: false,
+        disabledStatus: {
+          kind: "error",
+          message: CLOUD_CONNECTION_NO_ACCESS_DIAGNOSTIC,
+        },
+      },
+    );
+    assert.deepEqual(
+      projectCloudAccessLiveRoomPolicy({
+        canUseAuthenticatedCloudApi: true,
+        catalog: { status: "error", scope: null },
+      }),
+      { shouldConnectLiveRoom: true, disabledStatus: null },
+    );
+  });
+
+  it("centralizes selected mode, request loading, notice, and shell access facts", () => {
+    const projection = projectCloudAccessFacts({
+      ...sourceFacts(),
+      catalog: { status: "ready", scope: null },
+      connection: {
+        error: null,
+        peerId: "peer-viewer",
+        scope: "viewer",
+        statusKind: "ready",
+      },
+      request: {
+        error: null,
+        latest: accessRequest({ status: "pending" }),
+        requestedByUser: true,
+      },
+      selectedMode: "edit",
+    });
+
+    assert.equal(projection.accessConnectionScope, "viewer");
+    assert.equal(projection.catalogGrantsDocumentEdit, false);
+    assert.equal(projection.effectiveAccessRequest?.status, "pending");
+    assert.equal(projection.selectedInteractionModeForAccess, "edit");
+    assert.equal(projection.selectedModeCorrection, null);
+    assert.equal(projection.shouldFallbackEditUrlToView, false);
+    assert.equal(projection.shouldLoadOwnEditAccessRequest, true);
+    assert.deepEqual(projection.accessRequestNotice, {
+      kind: "pending",
+      tone: "info",
+      title: "Edit access requested.",
+      message: "The owner can review this request from the sharing panel.",
+    });
+  });
+
+  it("uses catalog edit grants as facts without making catalog the write authority", () => {
+    const projection = projectCloudAccessFacts({
+      ...sourceFacts(),
+      catalog: { status: "ready", scope: "owner" },
+      connection: {
+        error: null,
+        peerId: null,
+        scope: "viewer",
+        statusKind: "loading",
+      },
+      request: {
+        error: null,
+        latest: accessRequest({ status: "pending" }),
+        requestedByUser: true,
+      },
+      selectedMode: "edit",
+    });
+
+    assert.equal(projection.catalogGrantsDocumentEdit, true);
+    assert.equal(projection.accessConnectionScope, "owner");
+    assert.equal(projection.effectiveAccessRequest, null);
+    assert.equal(projection.shouldLoadOwnEditAccessRequest, false);
+    assert.equal(projection.selectedInteractionModeForAccess, "edit");
+  });
+
+  it("keeps copied edit links view-only when fresh catalog facts deny access", () => {
+    const projection = projectCloudAccessFacts({
+      ...sourceFacts(),
+      catalog: { status: "ready", scope: null },
+      connection: {
+        error: null,
+        peerId: "peer-viewer",
+        scope: "viewer",
+        statusKind: "ready",
+      },
+      request: {
+        error: null,
+        latest: null,
+        requestedByUser: false,
+      },
+      selectedMode: "edit",
+    });
+
+    assert.equal(projection.selectedInteractionModeForAccess, "view");
+    assert.equal(projection.selectedModeCorrection, "view");
+    assert.equal(projection.shouldFallbackEditUrlToView, true);
+    assert.equal(projection.shouldLoadOwnEditAccessRequest, false);
+  });
+
+  it("deduplicates equivalent realtime source updates through RxJS selectors", () => {
+    const store = new CloudAccessFactsStore(sourceFacts());
+    const projectedModes: string[] = [];
+    const fullProjectionKeys: string[] = [];
+    const sub = store
+      .select((projection) => projection.selectedInteractionModeForAccess)
+      .subscribe((mode) => projectedModes.push(mode));
+    const fullSub = store.projection$.subscribe((projection) => {
+      fullProjectionKeys.push(
+        [
+          projection.accessConnectionScope,
+          projection.shouldLoadOwnEditAccessRequest,
+          projection.selectedInteractionModeForAccess,
+        ].join(":"),
+      );
+    });
+
+    store.set({ ...sourceFacts(), connection: { ...sourceFacts().connection } });
+    store.update((current) => ({
+      ...current,
+      request: {
+        ...current.request,
+        latest: accessRequest({ status: "pending", updated_at: "2026-06-14T00:01:00.000Z" }),
+        requestedByUser: true,
+      },
+      selectedMode: "edit",
+    }));
+    store.update((current) => ({
+      ...current,
+      connection: {
+        ...current.connection,
+        scope: "editor",
+      },
+    }));
+
+    sub.unsubscribe();
+    fullSub.unsubscribe();
+
+    assert.deepEqual(projectedModes, ["view", "edit"]);
+    assert.deepEqual(fullProjectionKeys, [
+      "viewer:false:view",
+      "viewer:true:edit",
+      "editor:false:edit",
+    ]);
+  });
+});
+
+function sourceFacts(): CloudAccessSourceFacts {
+  return {
+    canUseAuthenticatedCloudApi: true,
+    catalog: { status: "ready", scope: null },
+    connection: {
+      error: null,
+      peerId: "peer-viewer",
+      scope: "viewer",
+      statusKind: "ready",
+    },
+    hasBrowserAppIdentity: true,
+    request: {
+      error: null,
+      latest: null,
+      requestedByUser: false,
+    },
+    selectedMode: "view",
+  };
+}
+
+function accessRequest(
+  overrides: Partial<CloudNotebookAccessRequest> = {},
+): CloudNotebookAccessRequest {
+  return {
+    id: "request-1",
+    notebook_id: "notebook-1",
+    requester_principal: "user:anaconda:quill",
+    scope: "editor",
+    status: "pending",
+    requested_by_actor_label: "user:anaconda:quill/browser:preview",
+    resolved_by_actor_label: null,
+    created_at: "2026-06-14T00:00:00.000Z",
+    updated_at: "2026-06-14T00:00:00.000Z",
+    resolved_at: null,
+    ...overrides,
+  };
+}

--- a/apps/notebook-cloud/test/cloud-access-facts.test.ts
+++ b/apps/notebook-cloud/test/cloud-access-facts.test.ts
@@ -215,6 +215,36 @@ describe("cloud access facts projection", () => {
       "editor:false:edit",
     ]);
   });
+
+  it("updates snapshots before flushing render-phase subscriber notifications", () => {
+    const store = new CloudAccessFactsStore(sourceFacts());
+    const projectedModes: string[] = [];
+    const sub = store
+      .select((projection) => projection.selectedInteractionModeForAccess)
+      .subscribe((mode) => projectedModes.push(mode));
+
+    store.set(
+      {
+        ...sourceFacts(),
+        request: {
+          error: null,
+          latest: accessRequest({ status: "pending" }),
+          requestedByUser: true,
+        },
+        selectedMode: "edit",
+      },
+      { notify: false },
+    );
+
+    assert.equal(store.snapshot.selectedInteractionModeForAccess, "edit");
+    assert.deepEqual(projectedModes, ["view"]);
+
+    store.flush();
+    store.flush();
+    sub.unsubscribe();
+
+    assert.deepEqual(projectedModes, ["view", "edit"]);
+  });
 });
 
 function sourceFacts(): CloudAccessSourceFacts {

--- a/apps/notebook-cloud/test/cloud-sharing-facts.test.ts
+++ b/apps/notebook-cloud/test/cloud-sharing-facts.test.ts
@@ -1,0 +1,226 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+
+import {
+  CloudSharingFactsStore,
+  projectCloudSharingFacts,
+  type CloudSharingSourceFacts,
+} from "../viewer/cloud-sharing-facts";
+import type {
+  CloudNotebookAccessRequest,
+  CloudNotebookAclRow,
+  CloudNotebookInvite,
+} from "../viewer/sharing-client";
+
+describe("cloud sharing facts projection", () => {
+  it("projects loading, invite, copy, and public-link facts for the share panel", () => {
+    const loading = projectCloudSharingFacts({
+      accessRequests: [],
+      acl: [],
+      copyState: "idle",
+      inviteEmail: "bad input",
+      invites: [],
+      loadState: "loading",
+    });
+
+    assert.equal(loading.showInitialAccessLoading, true);
+    assert.equal(loading.publicEnabled, false);
+    assert.equal(loading.inviteReady, false);
+    assert.equal(loading.copyLinkLabel, "Copy link");
+    assert.equal(loading.compactCopyLinkLabel, "Copy");
+
+    const ready = projectCloudSharingFacts({
+      accessRequests: [],
+      acl: [aclRow({ subject_kind: "public", subject: "anonymous", scope: "viewer" })],
+      copyState: "copied",
+      inviteEmail: "Quill@Example.COM ",
+      invites: [],
+      loadState: "ready",
+    });
+
+    assert.equal(ready.showInitialAccessLoading, false);
+    assert.equal(ready.publicEnabled, true);
+    assert.equal(ready.inviteReady, true);
+    assert.equal(ready.copyLinkLabel, "Copied link");
+    assert.equal(ready.compactCopyLinkLabel, "Copied");
+  });
+
+  it("keeps owner access, invites, runtime peers, and edit requests in one ledger projection", () => {
+    const projection = projectCloudSharingFacts({
+      accessRequests: [accessRequestRow({ id: "request-bob" })],
+      acl: [
+        aclRow({ subject: "user:anaconda:owner", scope: "owner" }),
+        aclRow({ subject: "runtime:agent", scope: "runtime_peer" }),
+      ],
+      copyState: "failed",
+      inviteEmail: "friend@example.com",
+      invites: [inviteRow({ email: "friend@example.com", scope: "editor" })],
+      loadState: "ready",
+    });
+
+    assert.equal(projection.copyLinkLabel, "Copy failed");
+    assert.equal(projection.compactCopyLinkLabel, "Failed");
+    assert.equal(projection.inviteReady, true);
+    assert.deepEqual(
+      projection.access.notebookAccessRows.map((row) => [row.kind, row.label, row.badge]),
+      [
+        ["acl", "owner", "Owner"],
+        ["invite", "f...d@example.com", "Can edit"],
+      ],
+    );
+    assert.deepEqual(
+      projection.access.runtimeAccessRows.map((row) => [row.kind, row.label, row.badge]),
+      [["acl", "agent", "Runtime"]],
+    );
+    assert.deepEqual(
+      projection.access.accessRequestRows.map((row) => [row.kind, row.label, row.badge]),
+      [["access_request", "bob", "Can edit"]],
+    );
+    assert.equal(projection.access.accessRequestSummary, "1 request");
+  });
+
+  it("reuses stable access projections for equivalent source facts", () => {
+    const acl = [aclRow({ subject: "user:anaconda:owner", scope: "owner" })];
+    const invites = [inviteRow({ email: "friend@example.com", scope: "viewer" })];
+    const accessRequests = [accessRequestRow({ id: "request-bob" })];
+
+    const first = projectCloudSharingFacts({
+      accessRequests,
+      acl,
+      copyState: "idle",
+      inviteEmail: "friend@example.com",
+      invites,
+      loadState: "ready",
+    });
+    const second = projectCloudSharingFacts({
+      accessRequests: [{ ...accessRequests[0] }],
+      acl: [{ ...acl[0] }],
+      copyState: "idle",
+      inviteEmail: "friend@example.com",
+      invites: [{ ...invites[0] }],
+      loadState: "ready",
+    });
+    const changed = projectCloudSharingFacts({
+      accessRequests,
+      acl,
+      copyState: "idle",
+      inviteEmail: "friend@example.com",
+      invites,
+      loadState: "ready",
+    });
+
+    assert.equal(first.access, second.access);
+    assert.equal(first.access.notebookAccessRows, second.access.notebookAccessRows);
+    assert.equal(first.access.accessRequestRows, second.access.accessRequestRows);
+    assert.equal(changed.access, first.access);
+    assert.equal(Object.isFrozen(first), true);
+  });
+
+  it("deduplicates equivalent share source updates through RxJS selectors", () => {
+    const store = new CloudSharingFactsStore(sourceFacts());
+    const copyLabels: string[] = [];
+    const projectionKeys: string[] = [];
+    const copySub = store
+      .select((projection) => projection.copyLinkLabel)
+      .subscribe((label) => copyLabels.push(label));
+    const projectionSub = store.projection$.subscribe((projection) => {
+      projectionKeys.push(
+        [
+          projection.copyLinkLabel,
+          projection.publicEnabled ? "public" : "private",
+          projection.inviteReady ? "invite-ready" : "invite-not-ready",
+          projection.access.notebookAccessSummary ?? "",
+          projection.access.accessRequestSummary ?? "",
+        ].join(":"),
+      );
+    });
+
+    store.set({
+      ...sourceFacts(),
+      acl: [aclRow({ subject: "user:anaconda:owner", scope: "owner" })],
+    });
+    store.update((current) => ({
+      ...current,
+      copyState: "copied",
+    }));
+    store.update((current) => ({
+      ...current,
+      accessRequests: [accessRequestRow({ id: "request-bob" })],
+    }));
+    store.update((current) => ({
+      ...current,
+      accessRequests: [{ ...accessRequestRow({ id: "request-bob" }) }],
+    }));
+
+    copySub.unsubscribe();
+    projectionSub.unsubscribe();
+
+    assert.deepEqual(copyLabels, ["Copy link", "Copied link"]);
+    assert.deepEqual(projectionKeys, [
+      "Copy link:private:invite-ready:1 person:",
+      "Copied link:private:invite-ready:1 person:",
+      "Copied link:private:invite-ready:1 person:1 request",
+    ]);
+  });
+});
+
+function sourceFacts(): CloudSharingSourceFacts {
+  return {
+    accessRequests: [],
+    acl: [aclRow({ subject: "user:anaconda:owner", scope: "owner" })],
+    copyState: "idle",
+    inviteEmail: "friend@example.com",
+    invites: [],
+    loadState: "ready",
+  };
+}
+
+function aclRow(overrides: Partial<CloudNotebookAclRow> = {}): CloudNotebookAclRow {
+  return {
+    notebook_id: "notebook-1",
+    subject_kind: "principal",
+    subject: "user:anaconda:alice",
+    scope: "viewer",
+    created_at: "2026-06-14T00:00:00.000Z",
+    updated_at: "2026-06-14T00:00:00.000Z",
+    created_by_actor_label: "user:anaconda:owner/browser:preview",
+    ...overrides,
+  };
+}
+
+function inviteRow(overrides: Partial<CloudNotebookInvite> = {}): CloudNotebookInvite {
+  return {
+    id: "invite-1",
+    notebook_id: "notebook-1",
+    email: "friend@example.com",
+    provider_hint: null,
+    scope: "viewer",
+    status: "pending",
+    invited_by_actor_label: "user:anaconda:owner/browser:preview",
+    accepted_by_principal: null,
+    created_at: "2026-06-14T00:00:00.000Z",
+    expires_at: null,
+    accepted_at: null,
+    revoked_at: null,
+    revoked_by_actor_label: null,
+    ...overrides,
+  };
+}
+
+function accessRequestRow(
+  overrides: Partial<CloudNotebookAccessRequest> = {},
+): CloudNotebookAccessRequest {
+  return {
+    id: "request-1",
+    notebook_id: "notebook-1",
+    requester_principal: "user:anaconda:bob",
+    scope: "editor",
+    status: "pending",
+    requested_by_actor_label: "user:anaconda:bob/browser:preview",
+    resolved_by_actor_label: null,
+    created_at: "2026-06-14T00:00:00.000Z",
+    updated_at: "2026-06-14T00:00:00.000Z",
+    resolved_at: null,
+    ...overrides,
+  };
+}

--- a/apps/notebook-cloud/test/cloud-sharing-facts.test.ts
+++ b/apps/notebook-cloud/test/cloud-sharing-facts.test.ts
@@ -166,6 +166,25 @@ describe("cloud sharing facts projection", () => {
       "Copied link:private:invite-ready:1 person:1 request",
     ]);
   });
+
+  it("updates snapshots before flushing render-phase subscriber notifications", () => {
+    const store = new CloudSharingFactsStore(sourceFacts());
+    const copyLabels: string[] = [];
+    const sub = store
+      .select((projection) => projection.copyLinkLabel)
+      .subscribe((label) => copyLabels.push(label));
+
+    store.set({ ...sourceFacts(), copyState: "copied" }, { notify: false });
+
+    assert.equal(store.snapshot.copyLinkLabel, "Copied link");
+    assert.deepEqual(copyLabels, ["Copy link"]);
+
+    store.flush();
+    store.flush();
+    sub.unsubscribe();
+
+    assert.deepEqual(copyLabels, ["Copy link", "Copied link"]);
+  });
 });
 
 function sourceFacts(): CloudSharingSourceFacts {

--- a/apps/notebook-cloud/test/cloud-sharing-facts.test.ts
+++ b/apps/notebook-cloud/test/cloud-sharing-facts.test.ts
@@ -118,6 +118,14 @@ describe("cloud sharing facts projection", () => {
 
   it("deduplicates equivalent share source updates through RxJS selectors", () => {
     const store = new CloudSharingFactsStore(sourceFacts());
+    const initialSnapshot = store.snapshot;
+    assert.equal(store.snapshot, initialSnapshot);
+    store.set({
+      ...sourceFacts(),
+      acl: [aclRow({ subject: "user:anaconda:owner", scope: "owner" })],
+    });
+    assert.equal(store.snapshot, initialSnapshot);
+
     const copyLabels: string[] = [];
     const projectionKeys: string[] = [];
     const copySub = store
@@ -135,10 +143,6 @@ describe("cloud sharing facts projection", () => {
       );
     });
 
-    store.set({
-      ...sourceFacts(),
-      acl: [aclRow({ subject: "user:anaconda:owner", scope: "owner" })],
-    });
     store.update((current) => ({
       ...current,
       copyState: "copied",

--- a/apps/notebook-cloud/test/viewer-render-props.test.ts
+++ b/apps/notebook-cloud/test/viewer-render-props.test.ts
@@ -333,6 +333,19 @@ test("cloud viewer routes notebook header controls through the shared shell chro
     sharingSourceText,
     /buildCloudShareAccessProjection\(\{ acl, invites, accessRequests \}\)/,
   );
+  const cloudFactsReactSourcePath = new URL("../viewer/cloud-facts-react.ts", import.meta.url);
+  const cloudFactsReactSource = readFileSync(cloudFactsReactSourcePath, "utf8");
+  const silentSetIndex = cloudFactsReactSource.indexOf("store.set(source, { notify: false });");
+  const snapshotSubscribeIndex = cloudFactsReactSource.indexOf(
+    "const projection = useSyncExternalStore",
+  );
+  const flushIndex = cloudFactsReactSource.indexOf("store.flush();");
+  assert.ok(silentSetIndex >= 0);
+  assert.ok(snapshotSubscribeIndex >= 0);
+  assert.ok(flushIndex >= 0);
+  assert.ok(silentSetIndex < snapshotSubscribeIndex);
+  assert.ok(snapshotSubscribeIndex < flushIndex);
+  assert.doesNotMatch(cloudFactsReactSource, /useLayoutEffect\(\(\) => \{\s*store\.set\(source\)/);
   assert.match(sharingSourceText, /<div className="cloud-share-current-heading">/);
   assert.match(sharingSourceText, /aria-label="Edit access requests"/);
   assert.match(sharingSourceText, /<h3>Edit requests<\/h3>/);

--- a/apps/notebook-cloud/test/viewer-render-props.test.ts
+++ b/apps/notebook-cloud/test/viewer-render-props.test.ts
@@ -305,13 +305,30 @@ test("cloud viewer routes notebook header controls through the shared shell chro
   assert.doesNotMatch(sourceText, /useState\(initialCloudViewerPresence\)/);
   assert.doesNotMatch(sourceText, /setPresence\(/);
   assert.doesNotMatch(sourceText, /label=\{compactCloudPresenceLabel\(presenceDisplay\.label\)\}/);
+  assert.match(sourceText, /CloudAccessFactsStore/);
+  assert.match(sourceText, /function useCloudAccessFactsProjection/);
+  assert.match(
+    sourceText,
+    /const cloudAccessSourceFacts = useMemo<CloudAccessSourceFacts>\(\s*\(\) => \(\{[\s\S]*canUseAuthenticatedCloudApi,[\s\S]*catalog: catalogAccessFacts,[\s\S]*connection: \{[\s\S]*statusKind: status\.kind,/,
+  );
+  assert.match(
+    sourceText,
+    /const cloudAccessFacts = useCloudAccessFactsProjection\(cloudAccessSourceFacts\)/,
+  );
+  assert.doesNotMatch(sourceText, /projectCloudAccessFacts\(/);
   assert.match(sharingSourceText, /export function CloudSharingControls/);
   assert.match(sharingSourceText, /Invite people, review requests, and manage link access\./);
+  assert.match(sharingSourceText, /CloudSharingFactsStore/);
   assert.match(
     sharingSourceText,
-    /const sharingFacts = useMemo\(\s*\(\) =>[\s\S]*projectCloudSharingFacts\(\{[\s\S]*accessRequests,[\s\S]*acl,[\s\S]*copyState,[\s\S]*inviteEmail,[\s\S]*invites,[\s\S]*loadState,/,
+    /const sharingSourceFacts = useMemo<CloudSharingSourceFacts>\(\s*\(\) => \(\{[\s\S]*accessRequests,[\s\S]*acl,[\s\S]*copyState,[\s\S]*inviteEmail,[\s\S]*invites,[\s\S]*loadState,/,
+  );
+  assert.match(
+    sharingSourceText,
+    /const sharingFacts = useCloudSharingFactsProjection\(sharingSourceFacts\)/,
   );
   assert.match(sharingSourceText, /const accessProjection = sharingFacts\.access/);
+  assert.doesNotMatch(sharingSourceText, /projectCloudSharingFacts\(/);
   assert.doesNotMatch(
     sharingSourceText,
     /buildCloudShareAccessProjection\(\{ acl, invites, accessRequests \}\)/,

--- a/apps/notebook-cloud/test/viewer-render-props.test.ts
+++ b/apps/notebook-cloud/test/viewer-render-props.test.ts
@@ -309,7 +309,12 @@ test("cloud viewer routes notebook header controls through the shared shell chro
   assert.match(sharingSourceText, /Invite people, review requests, and manage link access\./);
   assert.match(
     sharingSourceText,
-    /const accessProjection = useMemo\(\s*\(\) => buildCloudShareAccessProjection\(\{ acl, invites, accessRequests \}\)/,
+    /const sharingFacts = useMemo\(\s*\(\) =>[\s\S]*projectCloudSharingFacts\(\{[\s\S]*accessRequests,[\s\S]*acl,[\s\S]*copyState,[\s\S]*inviteEmail,[\s\S]*invites,[\s\S]*loadState,/,
+  );
+  assert.match(sharingSourceText, /const accessProjection = sharingFacts\.access/);
+  assert.doesNotMatch(
+    sharingSourceText,
+    /buildCloudShareAccessProjection\(\{ acl, invites, accessRequests \}\)/,
   );
   assert.match(sharingSourceText, /<div className="cloud-share-current-heading">/);
   assert.match(sharingSourceText, /aria-label="Edit access requests"/);
@@ -325,12 +330,8 @@ test("cloud viewer routes notebook header controls through the shared shell chro
   );
   assert.match(sharingSourceText, /Can view this notebook without signing in/);
   assert.match(sharingSourceText, /Link access is off\. Only listed people can open this notebook/);
-  assert.match(sharingSourceText, /const copyLinkLabel =[\s\S]*"Copy link"/);
-  assert.match(sharingSourceText, /const compactCopyLinkLabel =[\s\S]*"Copy"/);
-  assert.match(
-    sharingSourceText,
-    /buildCloudShareAccessProjection\(\{ acl, invites, accessRequests \}\)/,
-  );
+  assert.match(sharingSourceText, /aria-label=\{sharingFacts\.copyLinkLabel\}/);
+  assert.match(sharingSourceText, /sharingFacts\.compactCopyLinkLabel/);
   assert.match(
     sharingSourceText,
     /accessProjection\.notebookAccessRows\.map\(\(row\) =>[\s\S]*<CloudShareRowIcon row=\{row\} \/>[\s\S]*<strong>\{row\.label\}<\/strong>[\s\S]*<span>\{row\.detail\}<\/span>/,

--- a/apps/notebook-cloud/viewer/cloud-access-facts.ts
+++ b/apps/notebook-cloud/viewer/cloud-access-facts.ts
@@ -173,16 +173,17 @@ export function projectCloudAccessFacts(
  * projects stable UI facts from those sources; it is not an ACL authority.
  */
 export class CloudAccessFactsStore {
-  private readonly source$: BehaviorSubject<CloudAccessSourceFacts>;
+  private sourceFacts: CloudAccessSourceFacts;
+  private currentProjection: CloudAccessFactsProjection;
+  private readonly projectionSubject: BehaviorSubject<CloudAccessFactsProjection>;
 
   readonly projection$: Observable<CloudAccessFactsProjection>;
 
   constructor(initial: CloudAccessSourceFacts) {
-    this.source$ = new BehaviorSubject(initial);
-    this.projection$ = this.source$.pipe(
-      map(projectCloudAccessFacts),
-      distinctUntilChanged(cloudAccessFactsProjectionEquals),
-    );
+    this.sourceFacts = initial;
+    this.currentProjection = projectCloudAccessFacts(initial);
+    this.projectionSubject = new BehaviorSubject(this.currentProjection);
+    this.projection$ = this.projectionSubject.asObservable();
   }
 
   select<T>(
@@ -193,15 +194,21 @@ export class CloudAccessFactsStore {
   }
 
   get source(): CloudAccessSourceFacts {
-    return this.source$.getValue();
+    return this.sourceFacts;
   }
 
   get snapshot(): CloudAccessFactsProjection {
-    return projectCloudAccessFacts(this.source);
+    return this.currentProjection;
   }
 
   set(next: CloudAccessSourceFacts): void {
-    this.source$.next(next);
+    this.sourceFacts = next;
+    const nextProjection = projectCloudAccessFacts(next);
+    if (cloudAccessFactsProjectionEquals(this.currentProjection, nextProjection)) {
+      return;
+    }
+    this.currentProjection = nextProjection;
+    this.projectionSubject.next(nextProjection);
   }
 
   update(project: (current: CloudAccessSourceFacts) => CloudAccessSourceFacts): void {

--- a/apps/notebook-cloud/viewer/cloud-access-facts.ts
+++ b/apps/notebook-cloud/viewer/cloud-access-facts.ts
@@ -1,0 +1,252 @@
+import { BehaviorSubject, distinctUntilChanged, map, type Observable } from "rxjs";
+
+import type { ViewerStatus } from "./notice-types";
+import {
+  projectCloudAccessRequestNotice,
+  shouldFallbackCloudEditUrlToView,
+  shouldLoadOwnCloudAccessRequest,
+  type CloudAccessRequestNoticeProjection,
+} from "./cloud-access-request-state";
+import {
+  cloudNotebookAccessScopeForShell,
+  cloudNotebookLiveRoomConnectionPolicy,
+  cloudNotebookScopeCanEditDocument,
+  type CloudNotebookCatalogAccessScope,
+  type CloudNotebookLiveRoomConnectionPolicy,
+} from "./cloud-notebook-catalog-access";
+import {
+  cloudNotebookInteractionModeForAccess,
+  cloudNotebookSelectedModeCorrectionForAccess,
+  type CloudNotebookUrlMode,
+} from "./cloud-notebook-mode";
+import type { CloudNotebookAccessRequest } from "./sharing-client";
+
+export type CloudCatalogAccessFetchStatus = "idle" | "loading" | "ready" | "error";
+
+export interface CloudCatalogAccessFacts {
+  status: CloudCatalogAccessFetchStatus;
+  scope: CloudNotebookCatalogAccessScope | null;
+}
+
+export interface CloudAccessConnectionFacts {
+  error: string | null;
+  peerId: string | null;
+  scope: string | null;
+  statusKind: ViewerStatus["kind"];
+}
+
+export interface CloudAccessRequestFacts {
+  error: string | null;
+  latest: CloudNotebookAccessRequest | null;
+  requestedByUser: boolean;
+}
+
+export interface CloudAccessSourceFacts {
+  canUseAuthenticatedCloudApi: boolean;
+  catalog: CloudCatalogAccessFacts;
+  connection: CloudAccessConnectionFacts;
+  hasBrowserAppIdentity: boolean;
+  request: CloudAccessRequestFacts;
+  selectedMode: CloudNotebookUrlMode;
+}
+
+export interface CloudAccessFactsProjection {
+  accessConnectionScope: string | null;
+  accessRequestNotice: CloudAccessRequestNoticeProjection | null;
+  catalogGrantsDocumentEdit: boolean;
+  connectionReadyForAccessScope: boolean;
+  effectiveAccessRequest: CloudNotebookAccessRequest | null;
+  liveRoomPolicy: CloudNotebookLiveRoomConnectionPolicy;
+  selectedInteractionModeForAccess: CloudNotebookUrlMode;
+  selectedModeCorrection: CloudNotebookUrlMode | null;
+  shouldFallbackEditUrlToView: boolean;
+  shouldLoadOwnEditAccessRequest: boolean;
+}
+
+export function cloudCatalogAccessFacts({
+  canUseAuthenticatedCloudApi,
+  loadFailed,
+  resolved,
+  scope,
+}: {
+  canUseAuthenticatedCloudApi: boolean;
+  loadFailed: boolean;
+  resolved: boolean;
+  scope: CloudNotebookCatalogAccessScope | null;
+}): CloudCatalogAccessFacts {
+  if (!canUseAuthenticatedCloudApi) {
+    return Object.freeze({ status: "idle", scope: null });
+  }
+  if (loadFailed) {
+    return Object.freeze({ status: "error", scope: null });
+  }
+  if (resolved) {
+    return Object.freeze({ status: "ready", scope });
+  }
+  return Object.freeze({ status: "loading", scope: null });
+}
+
+export function projectCloudAccessLiveRoomPolicy({
+  canUseAuthenticatedCloudApi,
+  catalog,
+}: {
+  canUseAuthenticatedCloudApi: boolean;
+  catalog: CloudCatalogAccessFacts;
+}): CloudNotebookLiveRoomConnectionPolicy {
+  return cloudNotebookLiveRoomConnectionPolicy({
+    canUseAuthenticatedCloudApi,
+    catalogLoadFailed: catalog.status === "error",
+    catalogResolved: catalog.status === "ready",
+    catalogScope: catalog.scope,
+  });
+}
+
+export function projectCloudAccessFacts(
+  source: CloudAccessSourceFacts,
+): CloudAccessFactsProjection {
+  const catalogResolved = source.catalog.status === "ready";
+  const catalogGrantsDocumentEdit = cloudNotebookScopeCanEditDocument(source.catalog.scope);
+  const liveRoomPolicy = projectCloudAccessLiveRoomPolicy({
+    canUseAuthenticatedCloudApi: source.canUseAuthenticatedCloudApi,
+    catalog: source.catalog,
+  });
+  const connectionReadyForAccessScope =
+    !source.connection.error &&
+    Boolean(source.connection.peerId) &&
+    (source.connection.statusKind === "ready" || source.connection.statusKind === "empty");
+  const accessConnectionScope = cloudNotebookAccessScopeForShell({
+    catalogScope: source.catalog.scope,
+    connectionReady: connectionReadyForAccessScope,
+    connectionScope: source.connection.scope,
+  });
+  const effectiveAccessRequest = catalogGrantsDocumentEdit ? null : source.request.latest;
+  const shouldLoadOwnEditAccessRequest = shouldLoadOwnCloudAccessRequest({
+    canUseAuthenticatedCloudApi: source.canUseAuthenticatedCloudApi,
+    catalogGrantsDocumentEdit,
+    connectionScope: source.connection.scope,
+    editAccessRequested: source.request.requestedByUser,
+    hasBrowserAppIdentity: source.hasBrowserAppIdentity,
+    selectedMode: source.selectedMode,
+  });
+  const selectedInteractionModeForAccess = cloudNotebookInteractionModeForAccess({
+    accessRequestStatus: effectiveAccessRequest?.status,
+    accessScope: accessConnectionScope,
+    catalogResolved,
+    connectionScope: source.connection.scope,
+    selectedMode: source.selectedMode,
+  });
+  const selectedModeCorrection = cloudNotebookSelectedModeCorrectionForAccess({
+    accessMode: selectedInteractionModeForAccess,
+    selectedMode: source.selectedMode,
+  });
+  const shouldFallbackEditUrlToView = shouldFallbackCloudEditUrlToView({
+    catalogGrantsDocumentEdit,
+    catalogResolved,
+    editAccessRequested: source.request.requestedByUser,
+    selectedMode: source.selectedMode,
+  });
+  const accessRequestNotice = projectCloudAccessRequestNotice({
+    error: source.request.error,
+    request: effectiveAccessRequest,
+    selectedMode: source.selectedMode,
+  });
+
+  return Object.freeze({
+    accessConnectionScope,
+    accessRequestNotice,
+    catalogGrantsDocumentEdit,
+    connectionReadyForAccessScope,
+    effectiveAccessRequest,
+    liveRoomPolicy,
+    selectedInteractionModeForAccess,
+    selectedModeCorrection,
+    shouldFallbackEditUrlToView,
+    shouldLoadOwnEditAccessRequest,
+  });
+}
+
+/**
+ * Per-notebook cloud access facts store.
+ *
+ * Source facts stay host-owned: catalog fetch state, live-room connection
+ * state, URL-selected mode, and edit-request fetch results. The store only
+ * projects stable UI facts from those sources; it is not an ACL authority.
+ */
+export class CloudAccessFactsStore {
+  private readonly source$: BehaviorSubject<CloudAccessSourceFacts>;
+
+  readonly projection$: Observable<CloudAccessFactsProjection>;
+
+  constructor(initial: CloudAccessSourceFacts) {
+    this.source$ = new BehaviorSubject(initial);
+    this.projection$ = this.source$.pipe(
+      map(projectCloudAccessFacts),
+      distinctUntilChanged(cloudAccessFactsProjectionEquals),
+    );
+  }
+
+  select<T>(
+    project: (projection: CloudAccessFactsProjection) => T,
+    equals: (a: T, b: T) => boolean = Object.is,
+  ): Observable<T> {
+    return this.projection$.pipe(map(project), distinctUntilChanged(equals));
+  }
+
+  get source(): CloudAccessSourceFacts {
+    return this.source$.getValue();
+  }
+
+  get snapshot(): CloudAccessFactsProjection {
+    return projectCloudAccessFacts(this.source);
+  }
+
+  set(next: CloudAccessSourceFacts): void {
+    this.source$.next(next);
+  }
+
+  update(project: (current: CloudAccessSourceFacts) => CloudAccessSourceFacts): void {
+    this.set(project(this.source));
+  }
+}
+
+export function cloudAccessFactsProjectionEquals(
+  a: CloudAccessFactsProjection,
+  b: CloudAccessFactsProjection,
+): boolean {
+  return cloudAccessFactsProjectionKey(a) === cloudAccessFactsProjectionKey(b);
+}
+
+function cloudAccessFactsProjectionKey(projection: CloudAccessFactsProjection): string {
+  return [
+    projection.accessConnectionScope ?? "",
+    cloudAccessRequestNoticeKey(projection.accessRequestNotice),
+    projection.catalogGrantsDocumentEdit ? "edit" : "read",
+    projection.connectionReadyForAccessScope ? "ready" : "not-ready",
+    cloudAccessRequestKey(projection.effectiveAccessRequest),
+    projection.liveRoomPolicy.shouldConnectLiveRoom ? "connect" : "hold",
+    projection.liveRoomPolicy.disabledStatus?.kind ?? "",
+    projection.liveRoomPolicy.disabledStatus?.message ?? "",
+    projection.selectedInteractionModeForAccess,
+    projection.selectedModeCorrection ?? "",
+    projection.shouldFallbackEditUrlToView ? "fallback" : "",
+    projection.shouldLoadOwnEditAccessRequest ? "load-request" : "",
+  ].join("\u001f");
+}
+
+function cloudAccessRequestKey(request: CloudNotebookAccessRequest | null): string {
+  if (!request) return "";
+  return [
+    request.id,
+    request.notebook_id,
+    request.requester_principal,
+    request.scope,
+    request.status,
+    request.updated_at,
+    request.resolved_at ?? "",
+  ].join("\u001e");
+}
+
+function cloudAccessRequestNoticeKey(notice: CloudAccessRequestNoticeProjection | null): string {
+  if (!notice) return "";
+  return [notice.kind, notice.tone, notice.title, notice.message].join("\u001e");
+}

--- a/apps/notebook-cloud/viewer/cloud-access-facts.ts
+++ b/apps/notebook-cloud/viewer/cloud-access-facts.ts
@@ -63,6 +63,10 @@ export interface CloudAccessFactsProjection {
   shouldLoadOwnEditAccessRequest: boolean;
 }
 
+interface CloudAccessFactsSetOptions {
+  notify?: boolean;
+}
+
 export function cloudCatalogAccessFacts({
   canUseAuthenticatedCloudApi,
   loadFailed,
@@ -175,6 +179,8 @@ export function projectCloudAccessFacts(
 export class CloudAccessFactsStore {
   private sourceFacts: CloudAccessSourceFacts;
   private currentProjection: CloudAccessFactsProjection;
+  private publishedProjection: CloudAccessFactsProjection;
+  private pendingProjectionNotification = false;
   private readonly projectionSubject: BehaviorSubject<CloudAccessFactsProjection>;
 
   readonly projection$: Observable<CloudAccessFactsProjection>;
@@ -182,6 +188,7 @@ export class CloudAccessFactsStore {
   constructor(initial: CloudAccessSourceFacts) {
     this.sourceFacts = initial;
     this.currentProjection = projectCloudAccessFacts(initial);
+    this.publishedProjection = this.currentProjection;
     this.projectionSubject = new BehaviorSubject(this.currentProjection);
     this.projection$ = this.projectionSubject.asObservable();
   }
@@ -201,18 +208,43 @@ export class CloudAccessFactsStore {
     return this.currentProjection;
   }
 
-  set(next: CloudAccessSourceFacts): void {
+  set(next: CloudAccessSourceFacts, options: CloudAccessFactsSetOptions = {}): void {
     this.sourceFacts = next;
     const nextProjection = projectCloudAccessFacts(next);
     if (cloudAccessFactsProjectionEquals(this.currentProjection, nextProjection)) {
+      if (options.notify !== false) {
+        this.flush();
+      }
       return;
     }
     this.currentProjection = nextProjection;
-    this.projectionSubject.next(nextProjection);
+    this.pendingProjectionNotification = !cloudAccessFactsProjectionEquals(
+      this.publishedProjection,
+      this.currentProjection,
+    );
+    if (options.notify === false) {
+      return;
+    }
+    this.flush();
   }
 
-  update(project: (current: CloudAccessSourceFacts) => CloudAccessSourceFacts): void {
-    this.set(project(this.source));
+  update(
+    project: (current: CloudAccessSourceFacts) => CloudAccessSourceFacts,
+    options?: CloudAccessFactsSetOptions,
+  ): void {
+    this.set(project(this.source), options);
+  }
+
+  flush(): void {
+    if (!this.pendingProjectionNotification) {
+      return;
+    }
+    this.pendingProjectionNotification = false;
+    if (cloudAccessFactsProjectionEquals(this.publishedProjection, this.currentProjection)) {
+      return;
+    }
+    this.publishedProjection = this.currentProjection;
+    this.projectionSubject.next(this.currentProjection);
   }
 }
 

--- a/apps/notebook-cloud/viewer/cloud-facts-react.ts
+++ b/apps/notebook-cloud/viewer/cloud-facts-react.ts
@@ -4,7 +4,8 @@ import type { Observable } from "rxjs";
 export interface CloudFactsProjectionStore<TSource, TProjection> {
   readonly projection$: Observable<TProjection>;
   readonly snapshot: TProjection;
-  set(next: TSource): void;
+  set(next: TSource, options?: { notify?: boolean }): void;
+  flush(): void;
 }
 
 /**
@@ -23,9 +24,7 @@ export function useCloudFactsProjection<TSource, TProjection>(
   }
   const store = storeRef.current;
 
-  useLayoutEffect(() => {
-    store.set(source);
-  }, [store, source]);
+  store.set(source, { notify: false });
 
   const subscribe = useCallback(
     (callback: () => void) => {
@@ -36,5 +35,11 @@ export function useCloudFactsProjection<TSource, TProjection>(
   );
   const getSnapshot = useCallback(() => store.snapshot, [store]);
 
-  return useSyncExternalStore(subscribe, getSnapshot, getSnapshot);
+  const projection = useSyncExternalStore(subscribe, getSnapshot, getSnapshot);
+
+  useLayoutEffect(() => {
+    store.flush();
+  });
+
+  return projection;
 }

--- a/apps/notebook-cloud/viewer/cloud-facts-react.ts
+++ b/apps/notebook-cloud/viewer/cloud-facts-react.ts
@@ -1,0 +1,40 @@
+import { useCallback, useLayoutEffect, useRef, useSyncExternalStore } from "react";
+import type { Observable } from "rxjs";
+
+export interface CloudFactsProjectionStore<TSource, TProjection> {
+  readonly projection$: Observable<TProjection>;
+  readonly snapshot: TProjection;
+  set(next: TSource): void;
+}
+
+/**
+ * React adapter for cloud facts stores.
+ *
+ * Source facts still live in React state and host fetch lifecycles. The store
+ * owns the stable derived projection and selector boundary.
+ */
+export function useCloudFactsProjection<TSource, TProjection>(
+  source: TSource,
+  createStore: (initial: TSource) => CloudFactsProjectionStore<TSource, TProjection>,
+): TProjection {
+  const storeRef = useRef<CloudFactsProjectionStore<TSource, TProjection> | null>(null);
+  if (storeRef.current === null) {
+    storeRef.current = createStore(source);
+  }
+  const store = storeRef.current;
+
+  useLayoutEffect(() => {
+    store.set(source);
+  }, [store, source]);
+
+  const subscribe = useCallback(
+    (callback: () => void) => {
+      const subscription = store.projection$.subscribe(() => callback());
+      return () => subscription.unsubscribe();
+    },
+    [store],
+  );
+  const getSnapshot = useCallback(() => store.snapshot, [store]);
+
+  return useSyncExternalStore(subscribe, getSnapshot, getSnapshot);
+}

--- a/apps/notebook-cloud/viewer/cloud-sharing-facts.ts
+++ b/apps/notebook-cloud/viewer/cloud-sharing-facts.ts
@@ -75,16 +75,17 @@ export function projectCloudSharingFacts({
  * owner-panel affordances from those facts; it is not an ACL authority.
  */
 export class CloudSharingFactsStore {
-  private readonly source$: BehaviorSubject<CloudSharingSourceFacts>;
+  private sourceFacts: CloudSharingSourceFacts;
+  private currentProjection: CloudSharingFactsProjection;
+  private readonly projectionSubject: BehaviorSubject<CloudSharingFactsProjection>;
 
   readonly projection$: Observable<CloudSharingFactsProjection>;
 
   constructor(initial: CloudSharingSourceFacts) {
-    this.source$ = new BehaviorSubject(initial);
-    this.projection$ = this.source$.pipe(
-      map(projectCloudSharingFacts),
-      distinctUntilChanged(cloudSharingFactsProjectionEquals),
-    );
+    this.sourceFacts = initial;
+    this.currentProjection = projectCloudSharingFacts(initial);
+    this.projectionSubject = new BehaviorSubject(this.currentProjection);
+    this.projection$ = this.projectionSubject.asObservable();
   }
 
   select<T>(
@@ -95,15 +96,21 @@ export class CloudSharingFactsStore {
   }
 
   get source(): CloudSharingSourceFacts {
-    return this.source$.getValue();
+    return this.sourceFacts;
   }
 
   get snapshot(): CloudSharingFactsProjection {
-    return projectCloudSharingFacts(this.source);
+    return this.currentProjection;
   }
 
   set(next: CloudSharingSourceFacts): void {
-    this.source$.next(next);
+    this.sourceFacts = next;
+    const nextProjection = projectCloudSharingFacts(next);
+    if (cloudSharingFactsProjectionEquals(this.currentProjection, nextProjection)) {
+      return;
+    }
+    this.currentProjection = nextProjection;
+    this.projectionSubject.next(nextProjection);
   }
 
   update(project: (current: CloudSharingSourceFacts) => CloudSharingSourceFacts): void {

--- a/apps/notebook-cloud/viewer/cloud-sharing-facts.ts
+++ b/apps/notebook-cloud/viewer/cloud-sharing-facts.ts
@@ -1,0 +1,126 @@
+import { BehaviorSubject, distinctUntilChanged, map, type Observable } from "rxjs";
+
+import {
+  buildCloudShareAccessProjection,
+  hasPublicViewerAccess,
+  normalizeShareInviteEmail,
+  type CloudNotebookAccessRequest,
+  type CloudNotebookAclRow,
+  type CloudNotebookInvite,
+  type CloudShareAccessProjection,
+} from "./sharing-client";
+
+export type CloudSharingLoadState = "idle" | "loading" | "ready" | "error";
+export type CloudSharingCopyState = "idle" | "copied" | "failed";
+
+export interface CloudSharingSourceFacts {
+  accessRequests: readonly CloudNotebookAccessRequest[];
+  acl: readonly CloudNotebookAclRow[];
+  copyState: CloudSharingCopyState;
+  inviteEmail: string;
+  invites: readonly CloudNotebookInvite[];
+  loadState: CloudSharingLoadState;
+}
+
+export interface CloudSharingFactsProjection {
+  access: CloudShareAccessProjection;
+  compactCopyLinkLabel: string;
+  copyLinkLabel: string;
+  inviteReady: boolean;
+  publicEnabled: boolean;
+  showInitialAccessLoading: boolean;
+}
+
+/**
+ * Projection for the owner-facing sharing panel.
+ *
+ * D1 ACL rows, invite rows, and access-request rows remain source facts loaded
+ * and mutated by the cloud host APIs. This projection only derives stable panel
+ * affordances from those facts.
+ */
+export function projectCloudSharingFacts({
+  accessRequests,
+  acl,
+  copyState,
+  inviteEmail,
+  invites,
+  loadState,
+}: CloudSharingSourceFacts): CloudSharingFactsProjection {
+  const access = buildCloudShareAccessProjection({
+    acl: [...acl],
+    invites: [...invites],
+    accessRequests: [...accessRequests],
+  });
+  const publicEnabled = hasPublicViewerAccess([...acl]);
+  const copyLinkLabel =
+    copyState === "copied" ? "Copied link" : copyState === "failed" ? "Copy failed" : "Copy link";
+  const compactCopyLinkLabel =
+    copyState === "copied" ? "Copied" : copyState === "failed" ? "Failed" : "Copy";
+
+  return Object.freeze({
+    access,
+    compactCopyLinkLabel,
+    copyLinkLabel,
+    inviteReady: normalizeShareInviteEmail(inviteEmail) !== null,
+    publicEnabled,
+    showInitialAccessLoading: loadState === "loading" && access.allRows.length === 0,
+  });
+}
+
+/**
+ * Per-notebook cloud sharing facts store.
+ *
+ * Source facts stay host-owned: D1 ACL rows, invite rows, edit-request rows,
+ * public-link copy state, and panel fetch state. The store projects stable
+ * owner-panel affordances from those facts; it is not an ACL authority.
+ */
+export class CloudSharingFactsStore {
+  private readonly source$: BehaviorSubject<CloudSharingSourceFacts>;
+
+  readonly projection$: Observable<CloudSharingFactsProjection>;
+
+  constructor(initial: CloudSharingSourceFacts) {
+    this.source$ = new BehaviorSubject(initial);
+    this.projection$ = this.source$.pipe(
+      map(projectCloudSharingFacts),
+      distinctUntilChanged(cloudSharingFactsProjectionEquals),
+    );
+  }
+
+  select<T>(
+    project: (projection: CloudSharingFactsProjection) => T,
+    equals: (a: T, b: T) => boolean = Object.is,
+  ): Observable<T> {
+    return this.projection$.pipe(map(project), distinctUntilChanged(equals));
+  }
+
+  get source(): CloudSharingSourceFacts {
+    return this.source$.getValue();
+  }
+
+  get snapshot(): CloudSharingFactsProjection {
+    return projectCloudSharingFacts(this.source);
+  }
+
+  set(next: CloudSharingSourceFacts): void {
+    this.source$.next(next);
+  }
+
+  update(project: (current: CloudSharingSourceFacts) => CloudSharingSourceFacts): void {
+    this.set(project(this.source));
+  }
+}
+
+export function cloudSharingFactsProjectionEquals(
+  a: CloudSharingFactsProjection,
+  b: CloudSharingFactsProjection,
+): boolean {
+  return (
+    a.access === b.access &&
+    a.compactCopyLinkLabel === b.compactCopyLinkLabel &&
+    a.copyLinkLabel === b.copyLinkLabel &&
+    a.inviteReady === b.inviteReady &&
+    a.publicEnabled === b.publicEnabled &&
+    a.showInitialAccessLoading === b.showInitialAccessLoading
+  );
+}

--- a/apps/notebook-cloud/viewer/cloud-sharing-facts.ts
+++ b/apps/notebook-cloud/viewer/cloud-sharing-facts.ts
@@ -31,6 +31,10 @@ export interface CloudSharingFactsProjection {
   showInitialAccessLoading: boolean;
 }
 
+interface CloudSharingFactsSetOptions {
+  notify?: boolean;
+}
+
 /**
  * Projection for the owner-facing sharing panel.
  *
@@ -77,6 +81,8 @@ export function projectCloudSharingFacts({
 export class CloudSharingFactsStore {
   private sourceFacts: CloudSharingSourceFacts;
   private currentProjection: CloudSharingFactsProjection;
+  private publishedProjection: CloudSharingFactsProjection;
+  private pendingProjectionNotification = false;
   private readonly projectionSubject: BehaviorSubject<CloudSharingFactsProjection>;
 
   readonly projection$: Observable<CloudSharingFactsProjection>;
@@ -84,6 +90,7 @@ export class CloudSharingFactsStore {
   constructor(initial: CloudSharingSourceFacts) {
     this.sourceFacts = initial;
     this.currentProjection = projectCloudSharingFacts(initial);
+    this.publishedProjection = this.currentProjection;
     this.projectionSubject = new BehaviorSubject(this.currentProjection);
     this.projection$ = this.projectionSubject.asObservable();
   }
@@ -103,18 +110,43 @@ export class CloudSharingFactsStore {
     return this.currentProjection;
   }
 
-  set(next: CloudSharingSourceFacts): void {
+  set(next: CloudSharingSourceFacts, options: CloudSharingFactsSetOptions = {}): void {
     this.sourceFacts = next;
     const nextProjection = projectCloudSharingFacts(next);
     if (cloudSharingFactsProjectionEquals(this.currentProjection, nextProjection)) {
+      if (options.notify !== false) {
+        this.flush();
+      }
       return;
     }
     this.currentProjection = nextProjection;
-    this.projectionSubject.next(nextProjection);
+    this.pendingProjectionNotification = !cloudSharingFactsProjectionEquals(
+      this.publishedProjection,
+      this.currentProjection,
+    );
+    if (options.notify === false) {
+      return;
+    }
+    this.flush();
   }
 
-  update(project: (current: CloudSharingSourceFacts) => CloudSharingSourceFacts): void {
-    this.set(project(this.source));
+  update(
+    project: (current: CloudSharingSourceFacts) => CloudSharingSourceFacts,
+    options?: CloudSharingFactsSetOptions,
+  ): void {
+    this.set(project(this.source), options);
+  }
+
+  flush(): void {
+    if (!this.pendingProjectionNotification) {
+      return;
+    }
+    this.pendingProjectionNotification = false;
+    if (cloudSharingFactsProjectionEquals(this.publishedProjection, this.currentProjection)) {
+      return;
+    }
+    this.publishedProjection = this.currentProjection;
+    this.projectionSubject.next(this.currentProjection);
   }
 }
 

--- a/apps/notebook-cloud/viewer/notebook-viewer.tsx
+++ b/apps/notebook-cloud/viewer/notebook-viewer.tsx
@@ -123,10 +123,13 @@ import {
   replaceCloudNotebookModeInCurrentUrl,
 } from "./cloud-notebook-mode";
 import {
+  CloudAccessFactsStore,
   cloudCatalogAccessFacts,
-  projectCloudAccessFacts,
   projectCloudAccessLiveRoomPolicy,
+  type CloudAccessFactsProjection,
+  type CloudAccessSourceFacts,
 } from "./cloud-access-facts";
+import { useCloudFactsProjection } from "./cloud-facts-react";
 import type {
   CloudNotebookUpdateResponse,
   CloudViewerAuthConfig,
@@ -173,6 +176,10 @@ function decodeHashAnchorId(hash: string): string {
 
 function shouldPollPendingCloudAccessRequest(): boolean {
   return typeof document === "undefined" || document.visibilityState !== "hidden";
+}
+
+function useCloudAccessFactsProjection(source: CloudAccessSourceFacts): CloudAccessFactsProjection {
+  return useCloudFactsProjection(source, (initial) => new CloudAccessFactsStore(initial));
 }
 
 async function resolveCloudAppSessionSyncScope(
@@ -635,25 +642,24 @@ export function NotebookViewer({
       cancelled = true;
     };
   }, [canUseAuthenticatedCloudApi, catalogAccessLoader]);
-  const cloudAccessFacts = useMemo(
-    () =>
-      projectCloudAccessFacts({
-        canUseAuthenticatedCloudApi,
-        catalog: catalogAccessFacts,
-        connection: {
-          error: connectionError,
-          peerId: connectionPeerId,
-          scope: connectionScope,
-          statusKind: status.kind,
-        },
-        hasBrowserAppIdentity,
-        request: {
-          error: accessRequestError,
-          latest: latestAccessRequest,
-          requestedByUser: editAccessRequestedByUser,
-        },
-        selectedMode: selectedInteractionMode,
-      }),
+  const cloudAccessSourceFacts = useMemo<CloudAccessSourceFacts>(
+    () => ({
+      canUseAuthenticatedCloudApi,
+      catalog: catalogAccessFacts,
+      connection: {
+        error: connectionError,
+        peerId: connectionPeerId,
+        scope: connectionScope,
+        statusKind: status.kind,
+      },
+      hasBrowserAppIdentity,
+      request: {
+        error: accessRequestError,
+        latest: latestAccessRequest,
+        requestedByUser: editAccessRequestedByUser,
+      },
+      selectedMode: selectedInteractionMode,
+    }),
     [
       accessRequestError,
       canUseAuthenticatedCloudApi,
@@ -668,6 +674,7 @@ export function NotebookViewer({
       status.kind,
     ],
   );
+  const cloudAccessFacts = useCloudAccessFactsProjection(cloudAccessSourceFacts);
   const {
     accessConnectionScope,
     catalogGrantsDocumentEdit,

--- a/apps/notebook-cloud/viewer/notebook-viewer.tsx
+++ b/apps/notebook-cloud/viewer/notebook-viewer.tsx
@@ -108,16 +108,10 @@ import { preloadSiftWasmForCells } from "./sift-preload";
 import { cloudSourceLanguage } from "./source-language";
 import { clearCloudAppSession, readCloudAppSessionStatus } from "./app-session";
 import {
-  projectCloudAccessRequestNotice,
   projectCloudAccessRequestTransition,
-  shouldFallbackCloudEditUrlToView,
-  shouldLoadOwnCloudAccessRequest,
   type CloudAccessRequestNoticeProjection,
 } from "./cloud-access-request-state";
 import {
-  cloudNotebookAccessScopeForShell,
-  cloudNotebookLiveRoomConnectionPolicy,
-  cloudNotebookScopeCanEditDocument,
   cloudNotebookSyncScopeForCatalogAccess,
   createCloudNotebookCatalogAccessLoader,
   type CloudNotebookCatalogAccessLoadResult,
@@ -125,11 +119,14 @@ import {
 } from "./cloud-notebook-catalog-access";
 import { applyDocumentTheme, CLOUD_VIEWER_THEME_STORAGE_KEY } from "./theme";
 import {
-  cloudNotebookInteractionModeForAccess,
   cloudNotebookModeFromSearch,
-  cloudNotebookSelectedModeCorrectionForAccess,
   replaceCloudNotebookModeInCurrentUrl,
 } from "./cloud-notebook-mode";
+import {
+  cloudCatalogAccessFacts,
+  projectCloudAccessFacts,
+  projectCloudAccessLiveRoomPolicy,
+} from "./cloud-access-facts";
 import type {
   CloudNotebookUpdateResponse,
   CloudViewerAuthConfig,
@@ -313,6 +310,21 @@ export function NotebookViewer({
       }),
     [browserApiAuthState, config.notebookId],
   );
+  const catalogAccessFacts = useMemo(
+    () =>
+      cloudCatalogAccessFacts({
+        canUseAuthenticatedCloudApi,
+        loadFailed: catalogAccessLoadFailed,
+        resolved: catalogAccessResolved,
+        scope: catalogAccessScope,
+      }),
+    [
+      canUseAuthenticatedCloudApi,
+      catalogAccessLoadFailed,
+      catalogAccessResolved,
+      catalogAccessScope,
+    ],
+  );
   useEffect(() => {
     if (!canUseAuthenticatedCloudApi) {
       setCatalogNotebookTitle(undefined);
@@ -365,18 +377,11 @@ export function NotebookViewer({
   }, [browserApiAuthState, canUseAuthenticatedCloudApi, config.catalogEndpoint, config.notebookId]);
   const catalogLiveRoomPolicy = useMemo(
     () =>
-      cloudNotebookLiveRoomConnectionPolicy({
+      projectCloudAccessLiveRoomPolicy({
         canUseAuthenticatedCloudApi,
-        catalogLoadFailed: catalogAccessLoadFailed,
-        catalogResolved: catalogAccessResolved,
-        catalogScope: catalogAccessScope,
+        catalog: catalogAccessFacts,
       }),
-    [
-      canUseAuthenticatedCloudApi,
-      catalogAccessLoadFailed,
-      catalogAccessResolved,
-      catalogAccessScope,
-    ],
+    [canUseAuthenticatedCloudApi, catalogAccessFacts],
   );
   const effectiveLoadingPolicy = useMemo(
     () => ({
@@ -630,24 +635,51 @@ export function NotebookViewer({
       cancelled = true;
     };
   }, [canUseAuthenticatedCloudApi, catalogAccessLoader]);
-  const catalogGrantsDocumentEdit = cloudNotebookScopeCanEditDocument(catalogAccessScope);
-  useEffect(() => {
-    if (
-      shouldFallbackCloudEditUrlToView({
-        catalogGrantsDocumentEdit,
-        catalogResolved: catalogAccessResolved,
-        editAccessRequested: editAccessRequestedByUser,
+  const cloudAccessFacts = useMemo(
+    () =>
+      projectCloudAccessFacts({
+        canUseAuthenticatedCloudApi,
+        catalog: catalogAccessFacts,
+        connection: {
+          error: connectionError,
+          peerId: connectionPeerId,
+          scope: connectionScope,
+          statusKind: status.kind,
+        },
+        hasBrowserAppIdentity,
+        request: {
+          error: accessRequestError,
+          latest: latestAccessRequest,
+          requestedByUser: editAccessRequestedByUser,
+        },
         selectedMode: selectedInteractionMode,
-      })
-    ) {
+      }),
+    [
+      accessRequestError,
+      canUseAuthenticatedCloudApi,
+      catalogAccessFacts,
+      connectionError,
+      connectionPeerId,
+      connectionScope,
+      editAccessRequestedByUser,
+      hasBrowserAppIdentity,
+      latestAccessRequest,
+      selectedInteractionMode,
+      status.kind,
+    ],
+  );
+  const {
+    accessConnectionScope,
+    catalogGrantsDocumentEdit,
+    effectiveAccessRequest,
+    selectedInteractionModeForAccess,
+    shouldLoadOwnEditAccessRequest,
+  } = cloudAccessFacts;
+  useEffect(() => {
+    if (cloudAccessFacts.shouldFallbackEditUrlToView) {
       setSelectedInteractionMode("view");
     }
-  }, [
-    catalogAccessResolved,
-    catalogGrantsDocumentEdit,
-    editAccessRequestedByUser,
-    selectedInteractionMode,
-  ]);
+  }, [cloudAccessFacts.shouldFallbackEditUrlToView]);
   const saveCloudNotebookTitle = useCallback(
     async (nextTitle: string): Promise<boolean> => {
       if (!canUseAuthenticatedCloudApi || !catalogGrantsDocumentEdit || notebookTitleSaving) {
@@ -722,40 +754,11 @@ export function NotebookViewer({
       ? cloudRuntimeStatus.label
       : null
     : null;
-  const connectionReadyForAccessScope =
-    !connectionError &&
-    Boolean(connectionPeerId) &&
-    (status.kind === "ready" || status.kind === "empty");
-  const accessConnectionScope = cloudNotebookAccessScopeForShell({
-    catalogScope: catalogAccessScope,
-    connectionReady: connectionReadyForAccessScope,
-    connectionScope,
-  });
-  const effectiveAccessRequest = catalogGrantsDocumentEdit ? null : latestAccessRequest;
-  const shouldLoadOwnEditAccessRequest = shouldLoadOwnCloudAccessRequest({
-    canUseAuthenticatedCloudApi,
-    catalogGrantsDocumentEdit,
-    connectionScope,
-    editAccessRequested: editAccessRequestedByUser,
-    hasBrowserAppIdentity,
-    selectedMode: selectedInteractionMode,
-  });
-  const selectedInteractionModeForAccess = cloudNotebookInteractionModeForAccess({
-    accessRequestStatus: effectiveAccessRequest?.status,
-    accessScope: accessConnectionScope,
-    catalogResolved: catalogAccessResolved,
-    connectionScope,
-    selectedMode: selectedInteractionMode,
-  });
   useEffect(() => {
-    const correctedMode = cloudNotebookSelectedModeCorrectionForAccess({
-      accessMode: selectedInteractionModeForAccess,
-      selectedMode: selectedInteractionMode,
-    });
-    if (correctedMode) {
-      setSelectedInteractionMode(correctedMode);
+    if (cloudAccessFacts.selectedModeCorrection) {
+      setSelectedInteractionMode(cloudAccessFacts.selectedModeCorrection);
     }
-  }, [selectedInteractionMode, selectedInteractionModeForAccess]);
+  }, [cloudAccessFacts.selectedModeCorrection]);
   const { shellCapabilities, canAcceptCellMutations, editAccessPending } =
     useCloudShellCapabilities({
       accessConnectionScope,
@@ -1508,13 +1511,7 @@ export function NotebookViewer({
     notebookViewIsLoading && (status.kind === "ready" || status.kind === "empty")
       ? { kind: "loading", message: "Preparing notebook view..." }
       : status;
-  const accessRequestNotice = cloudAccessRequestNotice(
-    projectCloudAccessRequestNotice({
-      error: accessRequestError,
-      request: effectiveAccessRequest,
-      selectedMode: selectedInteractionMode,
-    }),
-  );
+  const accessRequestNotice = cloudAccessRequestNotice(cloudAccessFacts.accessRequestNotice);
   // Asset health is its own quiet surface: N identical renderer failures
   // collapse into ONE notice (the provider state is module-level shared)
   // plus per-output fallbacks. It never feeds the connection dot or

--- a/apps/notebook-cloud/viewer/sharing-controls.tsx
+++ b/apps/notebook-cloud/viewer/sharing-controls.tsx
@@ -3,8 +3,11 @@ import { Check, Globe2, Link2, Mail, ServerCog, Share2, Trash2, UserRound, X } f
 import { fetchWithCloudPrototypeAuth, type CloudPrototypeAuthState } from "./collaborator-auth";
 import { appendEndpointPathSegment, cloudResponseError } from "./cloud-response";
 import {
-  buildCloudShareAccessProjection,
-  hasPublicViewerAccess,
+  projectCloudSharingFacts,
+  type CloudSharingCopyState,
+  type CloudSharingLoadState,
+} from "./cloud-sharing-facts";
+import {
   normalizeShareInviteEmail,
   type CloudNotebookAccessRequest,
   type CloudNotebookAclRow,
@@ -21,9 +24,7 @@ interface CloudSharingControlsProps {
   publicLink: string;
 }
 
-type CloudSharingLoadState = "idle" | "loading" | "ready" | "error";
 type CloudSharingMessageKind = "info" | "error";
-type CloudSharingCopyState = "idle" | "copied" | "failed";
 type CloudSharingAccessRequestAction = "approve" | "deny" | "dismiss";
 
 export function CloudSharingControls({
@@ -46,12 +47,21 @@ export function CloudSharingControls({
   const [busyAction, setBusyAction] = useState<string | null>(null);
   const [copyState, setCopyState] = useState<CloudSharingCopyState>("idle");
   const inviteSubmitLockRef = useRef(false);
-  const accessProjection = useMemo(
-    () => buildCloudShareAccessProjection({ acl, invites, accessRequests }),
-    [accessRequests, acl, invites],
+  const sharingFacts = useMemo(
+    () =>
+      projectCloudSharingFacts({
+        accessRequests,
+        acl,
+        copyState,
+        inviteEmail,
+        invites,
+        loadState,
+      }),
+    [accessRequests, acl, copyState, inviteEmail, invites, loadState],
   );
-  const publicEnabled = useMemo(() => hasPublicViewerAccess(acl), [acl]);
-  const inviteReady = normalizeShareInviteEmail(inviteEmail) !== null;
+  const accessProjection = sharingFacts.access;
+  const publicEnabled = sharingFacts.publicEnabled;
+  const inviteReady = sharingFacts.inviteReady;
 
   const loadSharingState = useCallback(
     async (options?: { preserveMessage?: boolean; signal?: AbortSignal }) => {
@@ -309,11 +319,6 @@ export function CloudSharingControls({
     }
   };
 
-  const copyLinkLabel =
-    copyState === "copied" ? "Copied link" : copyState === "failed" ? "Copy failed" : "Copy link";
-  const compactCopyLinkLabel =
-    copyState === "copied" ? "Copied" : copyState === "failed" ? "Failed" : "Copy";
-
   return (
     <details
       className="cloud-share-menu"
@@ -330,10 +335,16 @@ export function CloudSharingControls({
             <h2>Share notebook</h2>
             <p>Invite people, review requests, and manage link access.</p>
           </div>
-          <button type="button" aria-label={copyLinkLabel} onClick={() => void copyPublicLink()}>
+          <button
+            type="button"
+            aria-label={sharingFacts.copyLinkLabel}
+            onClick={() => void copyPublicLink()}
+          >
             <Link2 aria-hidden="true" />
-            <span className="cloud-share-copy-label-full">{copyLinkLabel}</span>
-            <span className="cloud-share-copy-label-compact">{compactCopyLinkLabel}</span>
+            <span className="cloud-share-copy-label-full">{sharingFacts.copyLinkLabel}</span>
+            <span className="cloud-share-copy-label-compact">
+              {sharingFacts.compactCopyLinkLabel}
+            </span>
           </button>
         </header>
 
@@ -465,7 +476,7 @@ export function CloudSharingControls({
               <span>{accessProjection.notebookAccessSummary}</span>
             ) : null}
           </div>
-          {loadState === "loading" && accessProjection.allRows.length === 0 ? (
+          {sharingFacts.showInitialAccessLoading ? (
             <div className="cloud-share-empty">Loading access...</div>
           ) : accessProjection.notebookAccessRows.length === 0 ? (
             <div className="cloud-share-empty">Only the owner can access this notebook.</div>

--- a/apps/notebook-cloud/viewer/sharing-controls.tsx
+++ b/apps/notebook-cloud/viewer/sharing-controls.tsx
@@ -3,10 +3,13 @@ import { Check, Globe2, Link2, Mail, ServerCog, Share2, Trash2, UserRound, X } f
 import { fetchWithCloudPrototypeAuth, type CloudPrototypeAuthState } from "./collaborator-auth";
 import { appendEndpointPathSegment, cloudResponseError } from "./cloud-response";
 import {
-  projectCloudSharingFacts,
+  CloudSharingFactsStore,
   type CloudSharingCopyState,
+  type CloudSharingFactsProjection,
   type CloudSharingLoadState,
+  type CloudSharingSourceFacts,
 } from "./cloud-sharing-facts";
+import { useCloudFactsProjection } from "./cloud-facts-react";
 import {
   normalizeShareInviteEmail,
   type CloudNotebookAccessRequest,
@@ -26,6 +29,12 @@ interface CloudSharingControlsProps {
 
 type CloudSharingMessageKind = "info" | "error";
 type CloudSharingAccessRequestAction = "approve" | "deny" | "dismiss";
+
+function useCloudSharingFactsProjection(
+  source: CloudSharingSourceFacts,
+): CloudSharingFactsProjection {
+  return useCloudFactsProjection(source, (initial) => new CloudSharingFactsStore(initial));
+}
 
 export function CloudSharingControls({
   accessRequestsEndpoint,
@@ -47,18 +56,18 @@ export function CloudSharingControls({
   const [busyAction, setBusyAction] = useState<string | null>(null);
   const [copyState, setCopyState] = useState<CloudSharingCopyState>("idle");
   const inviteSubmitLockRef = useRef(false);
-  const sharingFacts = useMemo(
-    () =>
-      projectCloudSharingFacts({
-        accessRequests,
-        acl,
-        copyState,
-        inviteEmail,
-        invites,
-        loadState,
-      }),
+  const sharingSourceFacts = useMemo<CloudSharingSourceFacts>(
+    () => ({
+      accessRequests,
+      acl,
+      copyState,
+      inviteEmail,
+      invites,
+      loadState,
+    }),
     [accessRequests, acl, copyState, inviteEmail, invites, loadState],
   );
+  const sharingFacts = useCloudSharingFactsProjection(sharingSourceFacts);
   const accessProjection = sharingFacts.access;
   const publicEnabled = sharingFacts.publicEnabled;
   const inviteReady = sharingFacts.inviteReady;

--- a/apps/notebook/src/lib/__tests__/desktop-shell-capabilities.test.ts
+++ b/apps/notebook/src/lib/__tests__/desktop-shell-capabilities.test.ts
@@ -220,6 +220,27 @@ describe("desktopNotebookShellCapabilities", () => {
     });
   });
 
+  it("treats local file permissions as desktop access facts", () => {
+    const readWriteFile = desktopNotebookShellCapabilities({
+      canAcceptCellMutations: true,
+      sessionReady: true,
+      localActor: "local:kyle/desktop:window",
+      connectionScope: null,
+    });
+    const readOnlyFile = desktopNotebookShellCapabilities({
+      canAcceptCellMutations: false,
+      sessionReady: true,
+      localActor: "local:kyle/desktop:window",
+      connectionScope: "viewer",
+    });
+
+    expect(readWriteFile.access).toMatchObject({ level: "owner", source: "local" });
+    expect(readWriteFile.canEditStructure).toBe(true);
+    expect(readOnlyFile.access).toMatchObject({ level: "viewer", source: "local" });
+    expect(readOnlyFile.canEditStructure).toBe(false);
+    expect(readOnlyFile.canRequestEdit).toBe(false);
+  });
+
   it("maps unknown non-null connection scopes to no document access", () => {
     const capabilities = desktopNotebookShellCapabilities({
       canAcceptCellMutations: true,

--- a/docs/adr/shared-store-projection-convergence.md
+++ b/docs/adr/shared-store-projection-convergence.md
@@ -46,6 +46,14 @@ the flush strands the update (marked dirty, never emitted).
   testable `throttleBusyStatus` pipeline. Desktop's
   `apps/notebook/src/lib/runtime-state.ts` is a thin React adapter
   (`useRuntimeProjection`) over the package store; item 2 below rode this.
+- **Cloud access facts first pass.** `apps/notebook-cloud/viewer/cloud-access-facts.ts`
+  now names the hosted source facts for catalog access, live-room connection
+  scope, selected mode, and the viewer's own edit request. It projects the
+  effective shell access scope, edit-request notice, request-loading predicate,
+  edit-link fallback, and live-room connect policy through one tested projection
+  and a small RxJS store. `notebook-viewer.tsx` consumes that projection instead
+  of recomputing the same access policy at each call site. The authoritative
+  facts still come from hosted APIs/session state and the room host.
 
 ## Remaining work (ranked)
 
@@ -79,20 +87,16 @@ output focus, reconnect) before merge.
    does not enable real cross-host sharing, and it adds more lines than it
    deletes. Low priority; do it only if it demonstrably simplifies both hosts.
 
-4. **Cloud access/share projections → cloud-local projection store.** The live
-   audits around view-only edit links, edit-request state, public-link revoke,
-   and share panel summaries exposed a cloud-local second-source-of-truth smell:
-   `notebook-viewer.tsx`, `use-cloud-shell-capabilities.ts`,
-   `sharing-controls.tsx`, and diagnostics helpers each reconcile overlapping
-   access facts. The next extraction should centralize derived hosted facts such
-   as catalog access resolution, selected vs effective interaction mode, own
-   edit-request status, public-link status, and share ledger summaries behind a
-   small projection store with React selectors. Keep D1/ACL/OIDC fetching,
-   mutation, and URL normalization in the cloud host; the store owns the
-   projection of those facts, not the authority. Do not move this policy into
-   `runtimed-wasm`: WASM should receive already-negotiated room/document facts,
-   not know what an OIDC invite, public ACL row, or copied `?mode=edit` URL
-   means.
+4. **Finish cloud access/share projection extraction.** The first access facts
+   pass centralizes catalog access, selected vs effective interaction mode,
+   own edit-request status, edit-link fallback, and live-room connect policy.
+   Remaining cloud-local second sources of truth are share/public-link ledger
+   summaries, owner mutation refresh state, diagnostics fetch helpers, and
+   fuller React selector adoption. Keep D1/ACL/OIDC fetching, mutation, and URL
+   normalization in the cloud host; stores own the projection of those facts, not
+   the authority. Do not move this policy into `runtimed-wasm`: WASM should
+   receive already-negotiated room/document facts, not know what an OIDC invite,
+   public ACL row, or copied `?mode=edit` URL means.
 
 5. **Cloud connection facts (`connectionScope`/`PeerId`/`ActorLabel`/`Error`).**
    Keep in the session hook. Only promote to a shared store if a *shared* component

--- a/docs/adr/shared-store-projection-convergence.md
+++ b/docs/adr/shared-store-projection-convergence.md
@@ -55,9 +55,10 @@ the flush strands the update (marked dirty, never emitted).
   `apps/notebook-cloud/viewer/cloud-sharing-facts.ts` likewise projects
   owner-facing share panel facts: access ledgers, public-link state, copy labels,
   invite readiness, and initial loading state, with the same facts-store/select
-  contract for future React adoption. `notebook-viewer.tsx` and
-  `sharing-controls.tsx` consume those projections instead of recomputing the
-  same policy at each render site. The authoritative facts still come from
+  contract. `apps/notebook-cloud/viewer/cloud-facts-react.ts` adapts those
+  stores to `useSyncExternalStore`, and `notebook-viewer.tsx` plus
+  `sharing-controls.tsx` consume the store projections instead of recomputing
+  the same policy at each render site. The authoritative facts still come from
   hosted APIs/session state and the room host.
 
 ## Remaining work (ranked)
@@ -97,10 +98,9 @@ output focus, reconnect) before merge.
    mode, own edit-request status, edit-link fallback, live-room connect policy,
    share ledger rows, public-link state, and panel loading/copy/invite readiness.
    Remaining cloud-local second sources of truth are owner mutation refresh
-   state, diagnostics fetch helpers, and fuller React selector adoption from the
-   access/share stores. Keep D1/ACL/OIDC fetching, mutation, and URL
-   normalization in the cloud host; stores own the projection of those facts, not
-   the authority. Do not move this policy into `runtimed-wasm`: WASM should
+   state and diagnostics fetch helpers. Keep D1/ACL/OIDC fetching, mutation, and
+   URL normalization in the cloud host; stores own the projection of those facts,
+   not the authority. Do not move this policy into `runtimed-wasm`: WASM should
    receive already-negotiated room/document facts, not know what an OIDC invite,
    public ACL row, or copied `?mode=edit` URL means.
 

--- a/docs/adr/shared-store-projection-convergence.md
+++ b/docs/adr/shared-store-projection-convergence.md
@@ -46,14 +46,19 @@ the flush strands the update (marked dirty, never emitted).
   testable `throttleBusyStatus` pipeline. Desktop's
   `apps/notebook/src/lib/runtime-state.ts` is a thin React adapter
   (`useRuntimeProjection`) over the package store; item 2 below rode this.
-- **Cloud access facts first pass.** `apps/notebook-cloud/viewer/cloud-access-facts.ts`
-  now names the hosted source facts for catalog access, live-room connection
-  scope, selected mode, and the viewer's own edit request. It projects the
-  effective shell access scope, edit-request notice, request-loading predicate,
-  edit-link fallback, and live-room connect policy through one tested projection
-  and a small RxJS store. `notebook-viewer.tsx` consumes that projection instead
-  of recomputing the same access policy at each call site. The authoritative
-  facts still come from hosted APIs/session state and the room host.
+- **Cloud access/share facts first pass.**
+  `apps/notebook-cloud/viewer/cloud-access-facts.ts` now names the hosted source
+  facts for catalog access, live-room connection scope, selected mode, and the
+  viewer's own edit request. It projects the effective shell access scope,
+  edit-request notice, request-loading predicate, edit-link fallback, and
+  live-room connect policy through one tested projection and a small RxJS store.
+  `apps/notebook-cloud/viewer/cloud-sharing-facts.ts` likewise projects
+  owner-facing share panel facts: access ledgers, public-link state, copy labels,
+  invite readiness, and initial loading state, with the same facts-store/select
+  contract for future React adoption. `notebook-viewer.tsx` and
+  `sharing-controls.tsx` consume those projections instead of recomputing the
+  same policy at each render site. The authoritative facts still come from
+  hosted APIs/session state and the room host.
 
 ## Remaining work (ranked)
 
@@ -87,12 +92,13 @@ output focus, reconnect) before merge.
    does not enable real cross-host sharing, and it adds more lines than it
    deletes. Low priority; do it only if it demonstrably simplifies both hosts.
 
-4. **Finish cloud access/share projection extraction.** The first access facts
-   pass centralizes catalog access, selected vs effective interaction mode,
-   own edit-request status, edit-link fallback, and live-room connect policy.
-   Remaining cloud-local second sources of truth are share/public-link ledger
-   summaries, owner mutation refresh state, diagnostics fetch helpers, and
-   fuller React selector adoption. Keep D1/ACL/OIDC fetching, mutation, and URL
+4. **Finish cloud access/share projection extraction.** The first access/share
+   facts pass centralizes catalog access, selected vs effective interaction
+   mode, own edit-request status, edit-link fallback, live-room connect policy,
+   share ledger rows, public-link state, and panel loading/copy/invite readiness.
+   Remaining cloud-local second sources of truth are owner mutation refresh
+   state, diagnostics fetch helpers, and fuller React selector adoption from the
+   access/share stores. Keep D1/ACL/OIDC fetching, mutation, and URL
    normalization in the cloud host; stores own the projection of those facts, not
    the authority. Do not move this policy into `runtimed-wasm`: WASM should
    receive already-negotiated room/document facts, not know what an OIDC invite,


### PR DESCRIPTION
## Summary
- add cloud access facts with explicit source facts, derived UI projection, and an RxJS-backed selector store
- route notebook viewer access-mode, edit-request notice, request-load, edit-link fallback, and live-room policy decisions through the access facts store via `useSyncExternalStore`
- add cloud sharing facts for owner-panel ledgers, public-link state, copy labels, invite readiness, and loading state, with the same projection/store/select contract wired into the sharing panel
- document the first cloud access/share facts slice and add desktop boundary coverage for local file permissions as access facts

## Pullfrog follow-up
- Pullfrog found no blocking issues, but noted the facts stores were only test-consumed; this branch now wires `CloudAccessFactsStore` and `CloudSharingFactsStore` into production React via `cloud-facts-react.ts`.
- Follow-up review noted the React adapter snapshot lagged by one render. The stores now support silent render-phase snapshot updates and post-commit `flush()` notifications, with timing tests and a source guard for the hook ordering.

## Verification
- pnpm --dir apps/notebook-cloud exec node --import tsx --test test/cloud-access-facts.test.ts test/cloud-sharing-facts.test.ts test/viewer-render-props.test.ts
- pnpm --dir apps/notebook-cloud exec node --import tsx --test test/cloud-access-facts.test.ts test/cloud-sharing-facts.test.ts test/cloud-access-request-state.test.ts test/cloud-notebook-catalog-access.test.ts test/cloud-notebook-mode.test.ts test/viewer-sharing.test.ts test/viewer-render-props.test.ts
- pnpm test:run apps/notebook/src/lib/__tests__/desktop-shell-capabilities.test.ts
- pnpm --dir apps/notebook-cloud typecheck
- pnpm --dir apps/notebook-cloud build:viewer
- pnpm --dir apps/notebook-cloud test
- cargo xtask lint --fix