### PR TITLE
fix(notebook): hide disabled gutter execution counts

### DIFF
--- a/apps/notebook/src/components/CodeCell.tsx
+++ b/apps/notebook/src/components/CodeCell.tsx
@@ -695,7 +695,6 @@ export const CodeCell = memo(function CodeCell({
               submittedByActorLabel={submittedByActorLabel}
               isCellFocused={isFocused}
               canExecute={canExecute}
-              showReadoutWhenDisabled={!readOnly}
               onExecute={handleExecute}
               onInterrupt={onInterrupt}
               className={cn(

--- a/apps/notebook/src/components/__tests__/notebook-view-capabilities-source.test.ts
+++ b/apps/notebook/src/components/__tests__/notebook-view-capabilities-source.test.ts
@@ -104,6 +104,6 @@ describe("NotebookView shell capabilities", () => {
       /consumeExecutionShortcuts: !readOnly \|\| canExecute \|\| canRequestExecute/,
     );
     expect(sourceText).toMatch(/canExecute=\{canExecute\}/);
-    expect(sourceText).toMatch(/showReadoutWhenDisabled=\{!readOnly\}/);
+    expect(sourceText).not.toContain("showReadoutWhenDisabled");
   });
 });

--- a/src/components/cell/CompactExecutionButton.tsx
+++ b/src/components/cell/CompactExecutionButton.tsx
@@ -22,8 +22,6 @@ interface CompactExecutionButtonProps {
   isCellFocused?: boolean;
   /** Whether execution controls are available in this shell */
   canExecute?: boolean;
-  /** Whether disabled historical execution state should still render as status */
-  showReadoutWhenDisabled?: boolean;
   /** Called when user clicks to execute */
   onExecute?: () => void;
   /** Called when user clicks to interrupt */
@@ -56,7 +54,6 @@ export function CompactExecutionButton({
   submittedByActorLabel = null,
   isCellFocused = false,
   canExecute = true,
-  showReadoutWhenDisabled = false,
   onExecute,
   onInterrupt,
   className,
@@ -135,11 +132,7 @@ export function CompactExecutionButton({
   const disabledHistoricalState =
     !canExecute && (state === "ran" || state === "error" || state === "cancelled");
   const content =
-    disabledHistoricalState && showReadoutWhenDisabled && displayCount !== null ? (
-      <span className="text-[10px] font-medium tabular-nums" aria-hidden="true">
-        {displayCount}
-      </span>
-    ) : state === "running" ? (
+    state === "running" ? (
       <Square className="size-2.5 fill-current animate-exec-squish" aria-hidden="true" />
     ) : state === "queued" ? (
       <span
@@ -151,7 +144,7 @@ export function CompactExecutionButton({
     );
 
   if (!canExecute) {
-    if (disabledHistoricalState && !showReadoutWhenDisabled) {
+    if (disabledHistoricalState) {
       return null;
     }
 

--- a/src/components/cell/__tests__/CompactExecutionButton.test.tsx
+++ b/src/components/cell/__tests__/CompactExecutionButton.test.tsx
@@ -38,12 +38,15 @@ describe("CompactExecutionButton", () => {
     expect(screen.queryByTestId("execution-readout")).toBeNull();
   });
 
-  it("can render disabled execution history as a status readout", () => {
-    render(<CompactExecutionButton count={7} canExecute={false} showReadoutWhenDisabled />);
+  it("still renders unavailable live execution state as a status readout", () => {
+    render(<CompactExecutionButton count={null} canExecute={false} isExecuting />);
 
     expect(screen.queryByRole("button")).toBeNull();
-    expect(screen.getByRole("status", { name: "Last execution 7" })).toBeTruthy();
-    expect(screen.getByTestId("execution-readout")).toHaveAttribute("data-execution-state", "ran");
+    expect(screen.getByRole("status", { name: "Execution running" })).toBeTruthy();
+    expect(screen.getByTestId("execution-readout")).toHaveAttribute(
+      "data-execution-state",
+      "running",
+    );
   });
 
   it("renders cancelled executions as neutral, not failed", () => {


### PR DESCRIPTION
## Summary

- stop rendering disabled historical execution counts in the left cell gutter
- keep live unavailable execution states, such as running or queued, available as status
- preserve the cell status-row execution label, e.g. `Python / run 24`

## Verification

- `pnpm test:run src/components/cell/__tests__/CompactExecutionButton.test.tsx apps/notebook/src/components/__tests__/notebook-view-capabilities-source.test.ts`
- `pnpm -C apps/notebook-cloud run build:viewer`
- `cargo xtask lint --fix`
- Browser reload on local cloud notebook: no `[data-testid="execution-readout"]` nodes remained, while the status row still showed `Python: Run 24 completed`
