### PR TITLE
refactor(notebook): share notebook view projections

### DIFF
--- a/apps/notebook-cloud/test/notebook-view-store-bridge.test.ts
+++ b/apps/notebook-cloud/test/notebook-view-store-bridge.test.ts
@@ -223,27 +223,27 @@ describe("cloud NotebookView store bridge", () => {
     }
   });
 
-  it("cleans cloud-owned execution and output entries for removed cells only", () => {
+  it("cleans projector-owned execution and output entries for removed cells only", () => {
     projectCloudCellsIntoNotebookViewStores([
       codeCellWithSyntheticOutput("removed-cell", "gone"),
       codeCellWithSyntheticOutput("kept-cell", "still here"),
     ]);
 
-    assert.equal(getCellExecutionId("removed-cell"), "cloud-execution:removed-cell");
-    assert.ok(getExecutionById("cloud-execution:removed-cell"));
-    assert.ok(getOutputById("cloud-output:removed-cell:0"));
-    assert.equal(getCellExecutionId("kept-cell"), "cloud-execution:kept-cell");
-    assert.ok(getExecutionById("cloud-execution:kept-cell"));
-    assert.ok(getOutputById("cloud-output:kept-cell:0"));
+    assert.equal(getCellExecutionId("removed-cell"), "notebook-view-execution:removed-cell");
+    assert.ok(getExecutionById("notebook-view-execution:removed-cell"));
+    assert.ok(getOutputById("notebook-view-output:removed-cell:0"));
+    assert.equal(getCellExecutionId("kept-cell"), "notebook-view-execution:kept-cell");
+    assert.ok(getExecutionById("notebook-view-execution:kept-cell"));
+    assert.ok(getOutputById("notebook-view-output:kept-cell:0"));
 
     cleanupCloudProjectionForRemovedCells(["removed-cell"]);
 
     assert.equal(getCellExecutionId("removed-cell"), null);
-    assert.equal(getExecutionById("cloud-execution:removed-cell"), undefined);
-    assert.equal(getOutputById("cloud-output:removed-cell:0"), undefined);
-    assert.equal(getCellExecutionId("kept-cell"), "cloud-execution:kept-cell");
-    assert.ok(getExecutionById("cloud-execution:kept-cell"));
-    assert.ok(getOutputById("cloud-output:kept-cell:0"));
+    assert.equal(getExecutionById("notebook-view-execution:removed-cell"), undefined);
+    assert.equal(getOutputById("notebook-view-output:removed-cell:0"), undefined);
+    assert.equal(getCellExecutionId("kept-cell"), "notebook-view-execution:kept-cell");
+    assert.ok(getExecutionById("notebook-view-execution:kept-cell"));
+    assert.ok(getOutputById("notebook-view-output:kept-cell:0"));
   });
 });
 

--- a/apps/notebook-cloud/test/viewer-render-props.test.ts
+++ b/apps/notebook-cloud/test/viewer-render-props.test.ts
@@ -259,9 +259,13 @@ test("cloud viewer routes notebook header controls through the shared shell chro
     sessionSourceText,
     /connectionStatusBridge\.noteTeardownRetry\(\);[\s\S]{0,600}?const teardownFlush = disposeCurrentRuntime\(\);/,
   );
-  assert.match(sourceText, /useState\(initialCloudRailCollapsed\)/);
-  assert.match(sourceText, /function initialCloudRailCollapsed/);
-  assert.match(sourceText, /function initialCloudRailCollapsed\(\): boolean \{[\s\S]*return true;/);
+  assert.match(sourceText, /useNotebookRailUiState/);
+  assert.match(
+    sourceText,
+    /const \{ activePanelId: activeRailPanel, collapsed: railCollapsed \} = useNotebookRailUiState\(\)/,
+  );
+  assert.doesNotMatch(sourceText, /useState\(initialCloudRailCollapsed\)/);
+  assert.doesNotMatch(sourceText, /function initialCloudRailCollapsed/);
   assert.doesNotMatch(sourceText, /packagesSummary=/);
   assert.doesNotMatch(sourceText, /workstationsSummary=/);
   assert.match(
@@ -270,7 +274,7 @@ test("cloud viewer routes notebook header controls through the shared shell chro
   );
   assert.match(
     sourceText,
-    /if \(!shouldShowCloudWorkstationsPanel && activeRailPanel === "workstations"\) \{[\s\S]*setActiveRailPanel\("outline"\)/,
+    /if \(!shouldShowCloudWorkstationsPanel && activeRailPanel === "workstations"\) \{[\s\S]*setActiveNotebookRailPanel\("outline"\)/,
   );
   assert.match(
     sourceText,

--- a/apps/notebook-cloud/test/viewer-shared-cell-surface.test.ts
+++ b/apps/notebook-cloud/test/viewer-shared-cell-surface.test.ts
@@ -244,14 +244,20 @@ test("cloud wires shared presence and cleans projected store entries", () => {
   );
   assert.match(sourceText, /sendInteractionPresence\(target\)/);
   assert.match(sessionSourceText, /resetCloudViewStoreProjection/);
-  assert.match(bridgeSourceText, /@\/components\/notebook\/state\/cell-store/);
-  assert.match(bridgeSourceText, /@\/components\/notebook\/state\/execution-store/);
-  assert.match(bridgeSourceText, /@\/components\/notebook\/state\/output-store/);
+  assert.match(bridgeSourceText, /@\/components\/notebook\/state\/view-store-projection/);
+  assert.match(bridgeSourceText, /createNotebookViewStoreProjector/);
+  assert.match(
+    bridgeSourceText,
+    /syntheticExecutionId: \(cellId\) => `cloud-execution:\$\{cellId\}`/,
+  );
+  assert.doesNotMatch(bridgeSourceText, /@\/components\/notebook\/state\/cell-store/);
+  assert.doesNotMatch(bridgeSourceText, /@\/components\/notebook\/state\/execution-store/);
+  assert.doesNotMatch(bridgeSourceText, /@\/components\/notebook\/state\/output-store/);
   assert.doesNotMatch(bridgeSourceText, /\.\.\/\.\.\/notebook\/src\/lib\/notebook-cells/);
   assert.doesNotMatch(bridgeSourceText, /\.\.\/\.\.\/notebook\/src\/lib\/notebook-executions/);
   assert.doesNotMatch(bridgeSourceText, /\.\.\/\.\.\/notebook\/src\/lib\/notebook-outputs/);
-  assert.match(bridgeSourceText, /deleteOutputs\(difference\(cloudOwnedOutputIds/);
-  assert.match(bridgeSourceText, /deleteExecutions\(difference\(cloudOwnedExecutionIds/);
+  assert.doesNotMatch(bridgeSourceText, /deleteOutputs\(difference/);
+  assert.doesNotMatch(bridgeSourceText, /deleteExecutions\(difference/);
 });
 
 test("cloud package rail renders package metadata through the shared shell panel", () => {
@@ -455,7 +461,7 @@ test("cloud mobile shell gives the collapsed rail a toolbar entrypoint", () => {
 
   assert.match(sourceText, /PanelLeftOpen/);
   assert.match(sourceText, /const handleOpenMobileRail = useCallback\(\(\) => \{/);
-  assert.match(sourceText, /setRailCollapsed\(false\);/);
+  assert.match(sourceText, /setNotebookRailCollapsed\(false\);/);
   assert.match(
     sourceText,
     /leadingControls: \(\s*<button[\s\S]*className="cloud-mobile-rail-toggle hidden h-8 w-8[\s\S]*aria-label="Open notebook panels"[\s\S]*onClick=\{handleOpenMobileRail\}/,

--- a/apps/notebook-cloud/test/viewer-shared-cell-surface.test.ts
+++ b/apps/notebook-cloud/test/viewer-shared-cell-surface.test.ts
@@ -245,11 +245,9 @@ test("cloud wires shared presence and cleans projected store entries", () => {
   assert.match(sourceText, /sendInteractionPresence\(target\)/);
   assert.match(sessionSourceText, /resetCloudViewStoreProjection/);
   assert.match(bridgeSourceText, /@\/components\/notebook\/state\/view-store-projection/);
-  assert.match(bridgeSourceText, /createNotebookViewStoreProjector/);
-  assert.match(
-    bridgeSourceText,
-    /syntheticExecutionId: \(cellId\) => `cloud-execution:\$\{cellId\}`/,
-  );
+  assert.match(bridgeSourceText, /createNotebookViewStoreProjector\(\)/);
+  assert.doesNotMatch(bridgeSourceText, /syntheticExecutionId/);
+  assert.doesNotMatch(bridgeSourceText, /syntheticOutputId/);
   assert.doesNotMatch(bridgeSourceText, /@\/components\/notebook\/state\/cell-store/);
   assert.doesNotMatch(bridgeSourceText, /@\/components\/notebook\/state\/execution-store/);
   assert.doesNotMatch(bridgeSourceText, /@\/components\/notebook\/state\/output-store/);

--- a/apps/notebook-cloud/viewer/notebook-view-store-bridge.ts
+++ b/apps/notebook-cloud/viewer/notebook-view-store-bridge.ts
@@ -1,19 +1,4 @@
-import type { JupyterOutput as SharedJupyterOutput } from "@/components/cell/jupyter-output";
-import {
-  replaceNotebookCells,
-  type NotebookStoreCell,
-  type NotebookStoreOutput,
-} from "@/components/notebook/state/cell-store";
-import { projectMarkdownPlan } from "@/lib/markdown-projection";
-import {
-  deleteExecutions,
-  getCellExecutionId,
-  getExecutionById,
-  setCellExecutionPointer,
-  setExecution,
-  setNotebookQueueProjection,
-} from "@/components/notebook/state/execution-store";
-import { deleteOutputs, getOutputById, setOutput } from "@/components/notebook/state/output-store";
+import { createNotebookViewStoreProjector } from "@/components/notebook/state/view-store-projection";
 import {
   getCellIdsSnapshot,
   resetRuntimeState,
@@ -22,127 +7,22 @@ import {
 } from "../../notebook/src/notebook-surface-stores";
 import type { ResolvedCell } from "./render-resolution";
 
-let cloudOwnedExecutionIds = new Set<string>();
-let cloudOwnedOutputIds = new Set<string>();
-
-const RUNT_OUTPUT_CACHE_KEY = "_runt_output_cache_key";
-const outputCacheKeys = new WeakMap<NotebookStoreOutput, string>();
+const cloudViewStoreProjector = createNotebookViewStoreProjector({
+  syntheticExecutionId: (cellId) => `cloud-execution:${cellId}`,
+  syntheticOutputId: (cellId, outputIndex) => `cloud-output:${cellId}:${outputIndex}`,
+  syntheticOutputPrefix: (cellId) => `cloud-output:${cellId}:`,
+});
 
 export function projectCloudCellsIntoNotebookViewStores(cells: readonly ResolvedCell[]): void {
-  const projectedCells = cells.map((cell) => {
-    const outputs =
-      cell.cellType === "code"
-        ? cell.outputs.map((output, index) =>
-            normalizeOutputForNotebookView(output, cell.id, index),
-          )
-        : [];
-    return { cell, notebookCell: resolvedCellToNotebookCell(cell, outputs), outputs };
-  });
-
-  replaceNotebookCells(projectedCells.map(({ notebookCell }) => notebookCell));
-
-  const nextCloudOwnedExecutionIds = new Set<string>();
-  const nextCloudOwnedOutputIds = new Set<string>();
-
-  for (const { cell, outputs } of projectedCells) {
-    if (cell.cellType !== "code") {
-      setCellExecutionPointer(cell.id, null);
-      continue;
-    }
-
-    for (const output of outputs) {
-      if (output.output_id) {
-        nextCloudOwnedOutputIds.add(output.output_id);
-        setOutput(output.output_id, output);
-      }
-    }
-
-    const outputIds = outputs
-      .map((output) => output.output_id)
-      .filter((outputId): outputId is string => typeof outputId === "string");
-    const syntheticExecutionId = outputIds.length > 0 ? `cloud-execution:${cell.id}` : null;
-    const executionId = cell.executionId ?? syntheticExecutionId;
-    setCellExecutionPointer(cell.id, executionId);
-    if (executionId && !getExecutionById(executionId)) {
-      if (executionId === syntheticExecutionId) {
-        nextCloudOwnedExecutionIds.add(executionId);
-      }
-      // Snapshot/live cell materialization can seed a display placeholder, but
-      // it must never downgrade a real RuntimeStateDoc execution snapshot.
-      setExecution(executionId, {
-        execution_count: cell.executionCount,
-        status: "done",
-        success: null,
-        output_ids: outputIds,
-      });
-    }
-  }
-
-  deleteOutputs(difference(cloudOwnedOutputIds, nextCloudOwnedOutputIds));
-  deleteExecutions(difference(cloudOwnedExecutionIds, nextCloudOwnedExecutionIds));
-  cloudOwnedOutputIds = nextCloudOwnedOutputIds;
-  cloudOwnedExecutionIds = nextCloudOwnedExecutionIds;
+  cloudViewStoreProjector.projectCells(cells);
 }
 
 export function cleanupCloudProjectionForRemovedCells(removedCellIds: readonly string[]): void {
-  const outputIdsToDelete = new Set<string>();
-  const executionIdsToDelete = new Set<string>();
-
-  for (const cellId of removedCellIds) {
-    const syntheticExecutionId = `cloud-execution:${cellId}`;
-    const executionId =
-      getCellExecutionId(cellId) ??
-      (getExecutionById(syntheticExecutionId) ? syntheticExecutionId : null);
-
-    if (executionId) {
-      const execution = getExecutionById(executionId);
-      if (execution) {
-        for (const outputId of execution.output_ids) {
-          if (cloudOwnedOutputIds.has(outputId)) {
-            outputIdsToDelete.add(outputId);
-          }
-        }
-      }
-      if (cloudOwnedExecutionIds.has(executionId)) {
-        executionIdsToDelete.add(executionId);
-      }
-    }
-
-    const syntheticOutputPrefix = `cloud-output:${cellId}:`;
-    for (const outputId of cloudOwnedOutputIds) {
-      if (outputId.startsWith(syntheticOutputPrefix)) {
-        outputIdsToDelete.add(outputId);
-      }
-    }
-
-    setCellExecutionPointer(cellId, null);
-  }
-
-  if (outputIdsToDelete.size > 0) {
-    deleteOutputs(outputIdsToDelete);
-    for (const outputId of outputIdsToDelete) {
-      cloudOwnedOutputIds.delete(outputId);
-    }
-  }
-
-  if (executionIdsToDelete.size > 0) {
-    deleteExecutions(executionIdsToDelete);
-    for (const executionId of executionIdsToDelete) {
-      cloudOwnedExecutionIds.delete(executionId);
-    }
-  }
+  cloudViewStoreProjector.cleanupRemovedCells(removedCellIds);
 }
 
 export function resetCloudViewStoreProjection(): void {
-  replaceNotebookCells([]);
-  setNotebookQueueProjection({
-    executing_cell_id: null,
-    queued_cell_ids: [],
-  });
-  deleteOutputs([...cloudOwnedOutputIds]);
-  deleteExecutions([...cloudOwnedExecutionIds]);
-  cloudOwnedOutputIds = new Set<string>();
-  cloudOwnedExecutionIds = new Set<string>();
+  cloudViewStoreProjector.reset({ resetQueue: true });
 }
 
 /**
@@ -178,132 +58,4 @@ export function resetCloudProjectionUnlessPreserved(options: {
     resetRuntimeStoresProjection();
   }
   return preserve;
-}
-
-function resolvedCellToNotebookCell(
-  cell: ResolvedCell,
-  outputs: readonly NotebookStoreOutput[],
-): NotebookStoreCell {
-  const metadata = cell.metadata ?? {};
-  if (cell.cellType === "code") {
-    return {
-      cell_type: "code",
-      id: cell.id,
-      source: cell.source,
-      execution_count: cell.executionCount,
-      outputs: [...outputs],
-      metadata,
-    };
-  }
-
-  if (cell.cellType === "markdown") {
-    return {
-      cell_type: "markdown",
-      id: cell.id,
-      source: cell.source,
-      metadata,
-      markdownProjection: projectMarkdownPlan(cell.source) ?? undefined,
-    };
-  }
-
-  return {
-    cell_type: "raw",
-    id: cell.id,
-    source: cell.source,
-    metadata,
-  };
-}
-
-function normalizeOutputForNotebookView(
-  output: SharedJupyterOutput,
-  cellId: string,
-  index: number,
-): NotebookStoreOutput {
-  const output_id = output.output_id ?? `cloud-output:${cellId}:${index}`;
-  const previous = getOutputById(output_id);
-  let normalized: NotebookStoreOutput;
-
-  if (output.output_type === "stream") {
-    const text = Array.isArray(output.text) ? output.text.join("") : output.text;
-    normalized =
-      output.output_id === output_id && output.text === text
-        ? (output as NotebookStoreOutput)
-        : {
-            ...output,
-            output_id,
-            text,
-          };
-    return finalizeOutputForNotebookView(reusePreviousOutputIfEqual(previous, normalized));
-  }
-
-  normalized =
-    output.output_id === output_id
-      ? (output as NotebookStoreOutput)
-      : ({
-          ...output,
-          output_id,
-        } as NotebookStoreOutput);
-  return finalizeOutputForNotebookView(reusePreviousOutputIfEqual(previous, normalized));
-}
-
-function reusePreviousOutputIfEqual(
-  previous: NotebookStoreOutput | undefined,
-  next: NotebookStoreOutput,
-): NotebookStoreOutput {
-  if (!previous || previous === next) return next;
-  const previousCacheKey = outputCacheKeyForEquality(previous);
-  const nextCacheKey = outputCacheKeyForEquality(next);
-  if (previousCacheKey !== null && nextCacheKey !== null) {
-    return previousCacheKey === nextCacheKey ? previous : next;
-  }
-  const previousSerialized = serializedOutput(previous);
-  return previousSerialized !== null && previousSerialized === serializedOutput(next)
-    ? previous
-    : next;
-}
-
-function finalizeOutputForNotebookView(output: NotebookStoreOutput): NotebookStoreOutput {
-  const cacheKey = outputCacheKeyForEquality(output);
-  const stripped = stripOutputCacheKey(output);
-  if (cacheKey !== null) {
-    outputCacheKeys.set(stripped, cacheKey);
-  }
-  return stripped;
-}
-
-function outputCacheKeyForEquality(output: NotebookStoreOutput): string | null {
-  return stampedOutputCacheKey(output) ?? outputCacheKeys.get(output) ?? null;
-}
-
-function stampedOutputCacheKey(output: unknown): string | null {
-  if (typeof output !== "object" || output === null) return null;
-  const key = (output as Record<string, unknown>)[RUNT_OUTPUT_CACHE_KEY];
-  return typeof key === "string" ? key : null;
-}
-
-function stripOutputCacheKey(output: NotebookStoreOutput): NotebookStoreOutput {
-  if (!Object.prototype.hasOwnProperty.call(output, RUNT_OUTPUT_CACHE_KEY)) {
-    return output;
-  }
-  const { [RUNT_OUTPUT_CACHE_KEY]: _cacheKey, ...stripped } = output as NotebookStoreOutput &
-    Record<string, unknown>;
-  return stripped as NotebookStoreOutput;
-}
-
-function serializedOutput(output: NotebookStoreOutput): string | null {
-  try {
-    return JSON.stringify(output);
-  } catch {
-    return null;
-  }
-}
-
-function difference(previous: ReadonlySet<string>, next: ReadonlySet<string>): string[] {
-  const removed: string[] = [];
-  for (const id of previous) {
-    if (!next.has(id)) {
-      removed.push(id);
-    }
-  }
-  return removed;
 }

--- a/apps/notebook-cloud/viewer/notebook-view-store-bridge.ts
+++ b/apps/notebook-cloud/viewer/notebook-view-store-bridge.ts
@@ -7,11 +7,7 @@ import {
 } from "../../notebook/src/notebook-surface-stores";
 import type { ResolvedCell } from "./render-resolution";
 
-const cloudViewStoreProjector = createNotebookViewStoreProjector({
-  syntheticExecutionId: (cellId) => `cloud-execution:${cellId}`,
-  syntheticOutputId: (cellId, outputIndex) => `cloud-output:${cellId}:${outputIndex}`,
-  syntheticOutputPrefix: (cellId) => `cloud-output:${cellId}:`,
-});
+const cloudViewStoreProjector = createNotebookViewStoreProjector();
 
 export function projectCloudCellsIntoNotebookViewStores(cells: readonly ResolvedCell[]): void {
   cloudViewStoreProjector.projectCells(cells);
@@ -36,8 +32,7 @@ export function resetCloudViewStoreProjection(): void {
  *
  * Stale-data safety on preserve: the next materialization replaces cells
  * wholesale and `projectCloudCellsIntoNotebookViewStores` sweeps stale
- * cloud-owned output/execution ids via the `cloudOwned*` difference sets,
- * which this function leaves intact.
+ * projector-owned output/execution ids, which this function leaves intact.
  *
  * Returns true when the painted projection was preserved.
  */

--- a/apps/notebook-cloud/viewer/notebook-viewer.tsx
+++ b/apps/notebook-cloud/viewer/notebook-viewer.tsx
@@ -15,7 +15,6 @@ import {
   useIsolatedRenderer,
 } from "@/components/isolated/isolated-renderer-context";
 import { NotebookNotice } from "@/components/notebook/NotebookNotice";
-import type { NotebookRailPanelId } from "@/components/notebook-rail";
 import {
   NotebookConnectionIdentity,
   NotebookDocumentToolbar,
@@ -38,6 +37,12 @@ import {
   useFocusedCellId,
   useNotebookViewModel,
 } from "@/components/notebook";
+import {
+  openNotebookRailPanel,
+  setActiveNotebookRailPanel,
+  setNotebookRailCollapsed,
+  useNotebookRailUiState,
+} from "@/components/notebook/state/rail-ui-state";
 import { useWidgetStoreRequired } from "@/components/widgets/widget-store-context";
 import { useTheme } from "@/hooks/useTheme";
 import { EnvironmentSummary } from "@/components/environment";
@@ -256,8 +261,7 @@ export function NotebookViewer({
     flushCellUIState();
   }, []);
   const handleNotebookViewFocus = useCallback(() => {}, []);
-  const [activeRailPanel, setActiveRailPanel] = useState<NotebookRailPanelId>("outline");
-  const [railCollapsed, setRailCollapsed] = useState(initialCloudRailCollapsed);
+  const { activePanelId: activeRailPanel, collapsed: railCollapsed } = useNotebookRailUiState();
   const handledHeadingHashRef = useRef<string | null>(null);
   const [latestAccessRequest, setLatestAccessRequest] = useState<CloudNotebookAccessRequest | null>(
     null,
@@ -593,18 +597,16 @@ export function NotebookViewer({
   );
   const handleTogglePackagesRail = useCallback(() => {
     if (activeRailPanel === "packages" && !railCollapsed) {
-      setActiveRailPanel("outline");
+      setActiveNotebookRailPanel("outline");
       return;
     }
-    setRailCollapsed(false);
-    setActiveRailPanel("packages");
+    openNotebookRailPanel("packages");
   }, [activeRailPanel, railCollapsed]);
   const handleOpenMobileRail = useCallback(() => {
-    setRailCollapsed(false);
+    setNotebookRailCollapsed(false);
   }, []);
   const handleOpenWorkstationsRail = useCallback(() => {
-    setRailCollapsed(false);
-    setActiveRailPanel("workstations");
+    openNotebookRailPanel("workstations");
   }, []);
   const hasBrowserAppIdentity =
     hasAppSession || authState.mode === "dev" || authState.mode === "oidc";
@@ -1327,7 +1329,7 @@ export function NotebookViewer({
     shellCapabilities.auth.canUseAuthenticatedIdentity;
   useEffect(() => {
     if (!shouldShowCloudWorkstationsPanel && activeRailPanel === "workstations") {
-      setActiveRailPanel("outline");
+      setActiveNotebookRailPanel("outline");
     }
   }, [activeRailPanel, shouldShowCloudWorkstationsPanel]);
   const toolbarAddAfterCellId =
@@ -1380,8 +1382,8 @@ export function NotebookViewer({
           }
         />
       }
-      onActivePanelChange={setActiveRailPanel}
-      onCollapsedChange={setRailCollapsed}
+      onActivePanelChange={setActiveNotebookRailPanel}
+      onCollapsedChange={setNotebookRailCollapsed}
       onSelectOutlineItem={handleSelectOutlineItem}
       onNavigateOutlineItem={handleNavigateOutlineItem}
       className="cloud-notebook-rail"
@@ -1701,8 +1703,4 @@ function cloudAccessRequestNotice(
       {projection.message}
     </NotebookNotice>
   );
-}
-
-function initialCloudRailCollapsed(): boolean {
-  return true;
 }

--- a/apps/notebook/src/App.tsx
+++ b/apps/notebook/src/App.tsx
@@ -80,6 +80,12 @@ import { startAttributionDispatch } from "./lib/attribution-registry";
 import { getBlobResolver, useBlobPort } from "./lib/blob-port";
 import { useRuntimeState } from "./lib/runtime-state";
 import { useNotebookCellUIStateBridge } from "@/components/notebook/state/cell-ui-state";
+import {
+  openNotebookRailPanel,
+  setNotebookRailCollapsed,
+  toggleNotebookRailPanel,
+  useNotebookRailUiState,
+} from "@/components/notebook/state/rail-ui-state";
 import { startCursorDispatch } from "./lib/cursor-registry";
 import { desktopNotebookShellCapabilities } from "./lib/desktop-shell-capabilities";
 import { getTrustApprovalHandoffDisplayStatus, KERNEL_STATUS } from "./lib/kernel-status";
@@ -306,8 +312,7 @@ function AppContent() {
   // Global find (Cmd+F)
   const globalFind = useGlobalFind(cellIds);
 
-  const [activeRailPanel, setActiveRailPanel] = useState<NotebookRailPanelId>("outline");
-  const [railCollapsed, setRailCollapsed] = useState(true);
+  const { activePanelId: activeRailPanel, collapsed: railCollapsed } = useNotebookRailUiState();
   const stageHadFocusBeforeRailTakeoverRef = useRef(false);
   const [showIsolationTest, setShowIsolationTest] = useState(false);
   const [envBuildDialogOpen, setEnvBuildDialogOpen] = useState(false);
@@ -805,8 +810,7 @@ function AppContent() {
   const packagesRailOpen = !railCollapsed && activeRailPanel === "packages";
 
   const handleRailPanelChange = useCallback((panelId: NotebookRailPanelId) => {
-    setActiveRailPanel(panelId);
-    setRailCollapsed(false);
+    openNotebookRailPanel(panelId);
   }, []);
 
   const handleTogglePackagesRail = useCallback(() => {
@@ -814,13 +818,8 @@ function AppContent() {
       logger.debug("[App] handleTogglePackagesRail: package view capability unavailable, skipping");
       return;
     }
-    if (activeRailPanel === "packages" && !railCollapsed) {
-      setRailCollapsed(true);
-      return;
-    }
-    setActiveRailPanel("packages");
-    setRailCollapsed(false);
-  }, [activeRailPanel, railCollapsed, shellCapabilities.canViewPackages]);
+    toggleNotebookRailPanel("packages");
+  }, [shellCapabilities.canViewPackages]);
 
   const handleNavigateOutlineItem = useCallback((item: NotebookOutlineItem, href: string) => {
     return navigateNotebookOutlineItem(item, href, { headingHashTarget: "cell" });
@@ -1446,7 +1445,7 @@ function AppContent() {
               selectedOutlineItemId={selectedOutlineItemId}
               selectedOutlineCellId={focusedCellId}
               onActivePanelChange={handleRailPanelChange}
-              onCollapsedChange={setRailCollapsed}
+              onCollapsedChange={setNotebookRailCollapsed}
               onSelectOutlineItem={handleSelectOutlineItem}
               onNavigateOutlineItem={handleNavigateOutlineItem}
               packagesPanel={

--- a/apps/notebook/src/components/__tests__/notebook-toolbar.test.tsx
+++ b/apps/notebook/src/components/__tests__/notebook-toolbar.test.tsx
@@ -699,4 +699,17 @@ describe("connection/identity slot wiring", () => {
     expect(appSource).toMatch(/createDesktopConnectionStatusSource\(host\.daemonEvents\)/);
     expect(appSource).not.toMatch(/connectionStatus\$=\{host\.transport\.connectionStatus\$\}/);
   });
+
+  it("App.tsx reads rail chrome from the shared rail UI store", () => {
+    const appSource = readFileSync(resolve(process.cwd(), "apps/notebook/src/App.tsx"), "utf8");
+
+    expect(appSource).toMatch(/useNotebookRailUiState/);
+    expect(appSource).toMatch(
+      /const \{ activePanelId: activeRailPanel, collapsed: railCollapsed \} = useNotebookRailUiState\(\)/,
+    );
+    expect(appSource).toMatch(/openNotebookRailPanel\(panelId\)/);
+    expect(appSource).toMatch(/toggleNotebookRailPanel\("packages"\)/);
+    expect(appSource).not.toMatch(/\[activeRailPanel, setActiveRailPanel\] = useState/);
+    expect(appSource).not.toMatch(/\[railCollapsed, setRailCollapsed\] = useState/);
+  });
 });

--- a/apps/notebook/src/lib/__tests__/project-runtime-stores.test.ts
+++ b/apps/notebook/src/lib/__tests__/project-runtime-stores.test.ts
@@ -3,6 +3,7 @@ import {
   getCellExecutionId,
   getExecutionById,
   getNotebookQueueProjection,
+  isExecutionRuntimeOwned,
   setCellExecutionPointer,
 } from "../notebook-executions";
 import { getOutputById } from "../notebook-outputs";
@@ -41,6 +42,7 @@ describe("applyExecutionViewChangeset", () => {
       success: null,
       output_ids: ["out-1"],
     });
+    expect(isExecutionRuntimeOwned("exec-1")).toBe(true);
   });
 
   it("applies cell execution pointer changes from NotebookDoc", () => {
@@ -77,6 +79,7 @@ describe("applyExecutionViewChangeset", () => {
     });
     expect(getExecutionById("exec-1")).toBeUndefined();
     expect(getCellExecutionId("cell-1")).toBeNull();
+    expect(isExecutionRuntimeOwned("exec-1")).toBe(false);
   });
 
   it("applies notebook queue projection when WASM provides the adapter join", () => {

--- a/apps/notebook/src/lib/notebook-executions.ts
+++ b/apps/notebook/src/lib/notebook-executions.ts
@@ -4,6 +4,8 @@ export {
   getCellIdForExecutionId,
   getExecutionById,
   getNotebookQueueProjection,
+  isExecutionRuntimeOwned,
+  markExecutionsRuntimeOwned,
   resetNotebookExecutions,
   setCellExecutionPointer,
   setExecution,

--- a/apps/notebook/src/lib/project-runtime-stores.ts
+++ b/apps/notebook/src/lib/project-runtime-stores.ts
@@ -28,6 +28,7 @@ import { isOutputManifest } from "./materialize-cells";
 import {
   deleteExecutions,
   getExecutionById,
+  markExecutionsRuntimeOwned,
   resetNotebookExecutions,
   setCellExecutionPointer,
   setExecution,
@@ -161,6 +162,7 @@ export function applyExecutionViewChangeset(
   if (!changeset) return;
 
   for (const [execution_id, snapshot] of changeset.execution_upserts ?? []) {
+    markExecutionsRuntimeOwned([execution_id]);
     setExecution(execution_id, snapshot);
     markExecutionPerformance(`runtime.execution.snapshot.${snapshot.status}`, {
       executionId: execution_id,

--- a/docs/adr/shared-store-projection-convergence.md
+++ b/docs/adr/shared-store-projection-convergence.md
@@ -60,6 +60,23 @@ the flush strands the update (marked dirty, never emitted).
   `sharing-controls.tsx` consume the store projections instead of recomputing
   the same policy at each render site. The authoritative facts still come from
   hosted APIs/session state and the room host.
+- **Materialized NotebookView projection → shared projector.**
+  `src/components/notebook/state/view-store-projection.ts` owns the common
+  mechanics for projecting materialized cells into the shared cell, execution,
+  and output stores: markdown projection attachment, synthetic output IDs,
+  synthetic display executions, output cache-key reuse, and cleanup of
+  projector-owned execution/output entries. Cloud now keeps only a thin
+  `notebook-view-store-bridge.ts` adapter that names hosted synthetic ID
+  prefixes and applies the bootstrap-preservation policy. RuntimeStateDoc-owned
+  queue/execution snapshots still win over snapshot placeholders.
+- **Rail/outline chrome → shared `rail-ui-state` store.**
+  `src/components/notebook/state/rail-ui-state.ts` now owns
+  `activePanelId`, `collapsed`, and `selectedOutlineItemId` through
+  `useSyncExternalStore`. Desktop (`App.tsx`) and Cloud
+  (`notebook-viewer.tsx`) consume the same store while keeping host policy
+  local: desktop still collapses the packages rail on a second toolbar toggle,
+  and cloud still falls back to outline when the owner-only workstations panel
+  is unavailable.
 
 ## Remaining work (ranked)
 
@@ -86,12 +103,11 @@ output focus, reconnect) before merge.
    projection emits null through the same pipeline. Both hosts consume
    `useWorkstationAttachment()` from the shared runtime-state module.
 
-3. **Rail/outline chrome (`activeRailPanel`, `railCollapsed`,
-   `selectedOutlineItemId`) → shared `rail-ui-state` store.** Declared identically
-   in `App.tsx` and `notebook-viewer.tsx`. This is a DRY/single-definition win,
-   not a behavioral one: the hosts never share a process, so a module-global store
-   does not enable real cross-host sharing, and it adds more lines than it
-   deletes. Low priority; do it only if it demonstrably simplifies both hosts.
+3. ~~**Rail/outline chrome (`activeRailPanel`, `railCollapsed`,
+   `selectedOutlineItemId`) → shared `rail-ui-state` store.**~~ **Done** in
+   the rail-ui-state pass. The store removes the duplicated host `useState`
+   declarations and keeps the shared outline selection/focus coupling in
+   `useOutlineSelection`, now backed by the same external store.
 
 4. **Finish cloud access/share projection extraction.** The first access/share
    facts pass centralizes catalog access, selected vs effective interaction

--- a/docs/adr/shared-store-projection-convergence.md
+++ b/docs/adr/shared-store-projection-convergence.md
@@ -66,9 +66,9 @@ the flush strands the update (marked dirty, never emitted).
   and output stores: markdown projection attachment, synthetic output IDs,
   synthetic display executions, output cache-key reuse, and cleanup of
   projector-owned execution/output entries. Cloud now keeps only a thin
-  `notebook-view-store-bridge.ts` adapter that names hosted synthetic ID
-  prefixes and applies the bootstrap-preservation policy. RuntimeStateDoc-owned
-  queue/execution snapshots still win over snapshot placeholders.
+  `notebook-view-store-bridge.ts` adapter that applies the
+  bootstrap-preservation policy. RuntimeStateDoc-owned queue/execution
+  snapshots still win over snapshot placeholders.
 - **Rail/outline chrome → shared `rail-ui-state` store.**
   `src/components/notebook/state/rail-ui-state.ts` now owns
   `activePanelId`, `collapsed`, and `selectedOutlineItemId` through
@@ -142,8 +142,10 @@ output focus, reconnect) before merge.
 - Shell-capabilities *input derivation* — `desktop-shell-capabilities.ts` vs
   `use-cloud-shell-capabilities.ts`. The shared convergence point is the
   `NotebookShellCapabilities` type they both produce; the derivation must differ.
-- Cloud synthetic execution IDs (`cloud-execution:<cellId>`) vs Desktop daemon
-  changeset projection — two correct host paths into the same shared stores.
+- NotebookView display placeholders (`notebook-view-execution:<cellId>`) vs
+  RuntimeStateDoc changeset projection — the placeholder path is shared, but
+  runtime-authored snapshots stay authoritative and release placeholder
+  ownership when they arrive.
 
 Rejected over-converge: interaction **target** (which cell) and interaction
 **mode** (view vs edit) are different concepts; do not merge Cloud's

--- a/src/components/notebook/__tests__/outline-interaction.test.ts
+++ b/src/components/notebook/__tests__/outline-interaction.test.ts
@@ -1,7 +1,12 @@
-import { describe, it, expect, vi } from "vitest";
+import { afterEach, describe, it, expect, vi } from "vitest";
 import { act, renderHook } from "@testing-library/react";
 import { useActiveOutlineItemId, useOutlineSelection } from "../outline-interaction";
+import { resetNotebookRailUiState } from "../state/rail-ui-state";
 import type { NotebookOutlineItem } from "runtimed";
+
+afterEach(() => {
+  resetNotebookRailUiState();
+});
 
 describe("useActiveOutlineItemId", () => {
   it("returns null when disabled", () => {

--- a/src/components/notebook/__tests__/rail-ui-state.test.ts
+++ b/src/components/notebook/__tests__/rail-ui-state.test.ts
@@ -1,0 +1,90 @@
+import { act, renderHook } from "@testing-library/react";
+import { afterEach, describe, expect, it } from "vite-plus/test";
+import {
+  closeNotebookRail,
+  getNotebookRailUiState,
+  openNotebookRailPanel,
+  resetNotebookRailUiState,
+  setActiveNotebookRailPanel,
+  setNotebookRailCollapsed,
+  setSelectedNotebookOutlineItemId,
+  toggleNotebookRailPanel,
+  useNotebookRailUiState,
+} from "@/components/notebook/state/rail-ui-state";
+
+afterEach(() => {
+  resetNotebookRailUiState();
+});
+
+describe("notebook rail UI state", () => {
+  it("opens, closes, and toggles panels through one shared store", () => {
+    expect(getNotebookRailUiState()).toEqual({
+      activePanelId: "outline",
+      collapsed: true,
+      selectedOutlineItemId: null,
+    });
+
+    setSelectedNotebookOutlineItemId("intro:heading:0");
+    expect(getNotebookRailUiState()).toEqual({
+      activePanelId: "outline",
+      collapsed: true,
+      selectedOutlineItemId: "intro:heading:0",
+    });
+
+    openNotebookRailPanel("packages");
+    expect(getNotebookRailUiState()).toEqual({
+      activePanelId: "packages",
+      collapsed: false,
+      selectedOutlineItemId: "intro:heading:0",
+    });
+
+    toggleNotebookRailPanel("packages");
+    expect(getNotebookRailUiState()).toEqual({
+      activePanelId: "packages",
+      collapsed: true,
+      selectedOutlineItemId: "intro:heading:0",
+    });
+
+    toggleNotebookRailPanel("outline");
+    expect(getNotebookRailUiState()).toEqual({
+      activePanelId: "outline",
+      collapsed: false,
+      selectedOutlineItemId: "intro:heading:0",
+    });
+
+    setSelectedNotebookOutlineItemId(null);
+    expect(getNotebookRailUiState().selectedOutlineItemId).toBe(null);
+
+    closeNotebookRail();
+    expect(getNotebookRailUiState()).toEqual({
+      activePanelId: "outline",
+      collapsed: true,
+      selectedOutlineItemId: null,
+    });
+  });
+
+  it("notifies React consumers when host policy updates the rail", () => {
+    const { result } = renderHook(() => useNotebookRailUiState());
+
+    act(() => setActiveNotebookRailPanel("workstations"));
+    expect(result.current).toEqual({
+      activePanelId: "workstations",
+      collapsed: true,
+      selectedOutlineItemId: null,
+    });
+
+    act(() => setNotebookRailCollapsed(false));
+    expect(result.current).toEqual({
+      activePanelId: "workstations",
+      collapsed: false,
+      selectedOutlineItemId: null,
+    });
+
+    act(() => setSelectedNotebookOutlineItemId("outline-1"));
+    expect(result.current).toEqual({
+      activePanelId: "workstations",
+      collapsed: false,
+      selectedOutlineItemId: "outline-1",
+    });
+  });
+});

--- a/src/components/notebook/__tests__/view-store-projection.test.ts
+++ b/src/components/notebook/__tests__/view-store-projection.test.ts
@@ -1,0 +1,307 @@
+import { afterEach, describe, expect, it } from "vite-plus/test";
+import type { JupyterOutput } from "@/components/cell/jupyter-output";
+import {
+  getCellById,
+  getCellIdsSnapshot,
+  resetNotebookCells,
+} from "@/components/notebook/state/cell-store";
+import {
+  getCellExecutionId,
+  getExecutionById,
+  getNotebookQueueProjection,
+  resetNotebookExecutions,
+  setExecution,
+  setNotebookQueueProjection,
+} from "@/components/notebook/state/execution-store";
+import { getOutputById, resetNotebookOutputs } from "@/components/notebook/state/output-store";
+import { createNotebookViewStoreProjector } from "@/components/notebook/state/view-store-projection";
+import { setMarkdownProjectionProjector } from "@/lib/markdown-projection";
+
+let restoreMarkdownProjectionProjector: (() => void) | undefined;
+
+afterEach(() => {
+  restoreMarkdownProjectionProjector?.();
+  restoreMarkdownProjectionProjector = undefined;
+  resetNotebookCells();
+  resetNotebookExecutions();
+  resetNotebookOutputs();
+});
+
+describe("NotebookViewStoreProjector", () => {
+  it("projects materialized cells into the shared cell, execution, and output stores", () => {
+    restoreMarkdownProjectionProjector = setMarkdownProjectionProjector(testMarkdownProjector);
+    const projector = createNotebookViewStoreProjector({
+      syntheticExecutionId: (cellId) => `projection-execution:${cellId}`,
+      syntheticOutputId: (cellId, outputIndex) => `projection-output:${cellId}:${outputIndex}`,
+      syntheticOutputPrefix: (cellId) => `projection-output:${cellId}:`,
+    });
+
+    projector.projectCells([
+      {
+        id: "intro",
+        cellType: "markdown",
+        source: "# Projected title",
+        executionId: null,
+        executionCount: null,
+        outputs: [],
+        metadata: { tags: ["doc"] },
+      },
+      {
+        id: "code",
+        cellType: "code",
+        source: "print('hello')",
+        executionId: null,
+        executionCount: 12,
+        outputs: [
+          {
+            output_type: "stream",
+            name: "stdout",
+            text: ["hello", "\n"],
+          },
+        ],
+        metadata: {},
+      },
+    ]);
+
+    expect(getCellIdsSnapshot()).toEqual(["intro", "code"]);
+    expect(getCellById("intro")).toMatchObject({
+      cell_type: "markdown",
+      source: "# Projected title",
+      metadata: { tags: ["doc"] },
+    });
+    expect(getCellById("intro")).toHaveProperty("markdownProjection");
+    expect(getCellExecutionId("code")).toBe("projection-execution:code");
+    expect(getExecutionById("projection-execution:code")).toEqual({
+      execution_count: 12,
+      status: "done",
+      success: null,
+      output_ids: ["projection-output:code:0"],
+    });
+    expect(getOutputById("projection-output:code:0")).toEqual({
+      output_id: "projection-output:code:0",
+      output_type: "stream",
+      name: "stdout",
+      text: "hello\n",
+    });
+  });
+
+  it("keeps projector-owned execution records across repeated projections", () => {
+    const projector = createNotebookViewStoreProjector({
+      syntheticExecutionId: (cellId) => `projection-execution:${cellId}`,
+      syntheticOutputId: (cellId, outputIndex) => `projection-output:${cellId}:${outputIndex}`,
+      syntheticOutputPrefix: (cellId) => `projection-output:${cellId}:`,
+    });
+    const cells = [codeCellWithSyntheticOutput("code", "hello\n")];
+
+    projector.projectCells(cells);
+    projector.projectCells(cells);
+
+    expect(getCellExecutionId("code")).toBe("projection-execution:code");
+    expect(getExecutionById("projection-execution:code")).toEqual({
+      execution_count: 1,
+      status: "done",
+      success: null,
+      output_ids: ["projection-output:code:0"],
+    });
+    expect(getOutputById("projection-output:code:0")).toBeDefined();
+  });
+
+  it("preserves RuntimeStateDoc-owned queue and execution snapshots", () => {
+    const projector = createNotebookViewStoreProjector({
+      syntheticExecutionId: (cellId) => `projection-execution:${cellId}`,
+    });
+    setNotebookQueueProjection({
+      executing_cell_id: "running-cell",
+      queued_cell_ids: ["queued-cell"],
+    });
+    setExecution("exec-real", {
+      execution_count: 7,
+      status: "running",
+      success: null,
+      output_ids: ["runtime-output"],
+    });
+
+    projector.projectCells([
+      {
+        id: "running-cell",
+        cellType: "code",
+        source: "print('runtime-owned')",
+        executionId: "exec-real",
+        executionCount: 3,
+        outputs: [],
+        metadata: {},
+      },
+    ]);
+
+    expect(getNotebookQueueProjection()).toEqual({
+      executing_cell_id: "running-cell",
+      queued_cell_ids: ["queued-cell"],
+    });
+    expect(getExecutionById("exec-real")).toEqual({
+      execution_count: 7,
+      status: "running",
+      success: null,
+      output_ids: ["runtime-output"],
+    });
+  });
+
+  it("cleans real-id display placeholders created by the projector", () => {
+    const projector = createNotebookViewStoreProjector();
+
+    projector.projectCells([
+      {
+        id: "cell-1",
+        cellType: "code",
+        source: "print('snapshot')",
+        executionId: "exec-from-notebook-doc",
+        executionCount: 3,
+        outputs: [
+          {
+            output_id: "out-from-notebook-doc",
+            output_type: "stream",
+            name: "stdout",
+            text: "snapshot\n",
+          },
+        ],
+        metadata: {},
+      },
+    ]);
+
+    expect(getCellExecutionId("cell-1")).toBe("exec-from-notebook-doc");
+    expect(getExecutionById("exec-from-notebook-doc")).toEqual({
+      execution_count: 3,
+      status: "done",
+      success: null,
+      output_ids: ["out-from-notebook-doc"],
+    });
+
+    projector.reset();
+
+    expect(getCellExecutionId("cell-1")).toBe(null);
+    expect(getExecutionById("exec-from-notebook-doc")).toBeUndefined();
+    expect(getOutputById("out-from-notebook-doc")).toBeUndefined();
+  });
+
+  it("reuses stamped output references without serializing them", () => {
+    const projector = createNotebookViewStoreProjector({
+      syntheticExecutionId: (cellId) => `projection-execution:${cellId}`,
+    });
+
+    projector.projectCells([codeCellWithStampedOutput("widget-cell", "output:widget:1:0", "one")]);
+    const firstOutput = getOutputById("widget-output");
+    expect(firstOutput).toBeDefined();
+    expect(firstOutput).not.toHaveProperty("_runt_output_cache_key");
+
+    projector.projectCells([codeCellWithStampedOutput("widget-cell", "output:widget:1:0", "two")]);
+
+    expect(getOutputById("widget-output")).toBe(firstOutput);
+    const cell = getCellById("widget-cell");
+    expect(cell?.cell_type).toBe("code");
+    if (cell?.cell_type === "code") {
+      expect(cell.outputs[0]).toBe(firstOutput);
+    }
+  });
+
+  it("cleans only projector-owned synthetic executions and outputs for removed cells", () => {
+    const projector = createNotebookViewStoreProjector({
+      syntheticExecutionId: (cellId) => `projection-execution:${cellId}`,
+      syntheticOutputId: (cellId, outputIndex) => `projection-output:${cellId}:${outputIndex}`,
+      syntheticOutputPrefix: (cellId) => `projection-output:${cellId}:`,
+    });
+
+    projector.projectCells([
+      codeCellWithSyntheticOutput("removed-cell", "gone"),
+      codeCellWithSyntheticOutput("kept-cell", "still here"),
+    ]);
+
+    expect(getExecutionById("projection-execution:removed-cell")).toBeDefined();
+    expect(getOutputById("projection-output:removed-cell:0")).toBeDefined();
+
+    projector.cleanupRemovedCells(["removed-cell"]);
+
+    expect(getCellExecutionId("removed-cell")).toBe(null);
+    expect(getExecutionById("projection-execution:removed-cell")).toBeUndefined();
+    expect(getOutputById("projection-output:removed-cell:0")).toBeUndefined();
+    expect(getCellExecutionId("kept-cell")).toBe("projection-execution:kept-cell");
+    expect(getExecutionById("projection-execution:kept-cell")).toBeDefined();
+    expect(getOutputById("projection-output:kept-cell:0")).toBeDefined();
+  });
+});
+
+function codeCellWithStampedOutput(cellId: string, cacheKey: string, text: string) {
+  return {
+    id: cellId,
+    cellType: "code" as const,
+    source: "display(value)",
+    executionId: null,
+    executionCount: 1,
+    outputs: [
+      {
+        output_id: "widget-output",
+        output_type: "display_data",
+        data: { "text/plain": text },
+        metadata: {},
+        _runt_output_cache_key: cacheKey,
+        toJSON() {
+          throw new Error("stamped output should not be stringified");
+        },
+      } as JupyterOutput & Record<string, unknown>,
+    ],
+    metadata: {},
+  };
+}
+
+function codeCellWithSyntheticOutput(cellId: string, text: string) {
+  return {
+    id: cellId,
+    cellType: "code" as const,
+    source: "print(value)",
+    executionId: null,
+    executionCount: 1,
+    outputs: [
+      {
+        output_type: "stream" as const,
+        name: "stdout" as const,
+        text,
+      },
+    ],
+    metadata: {},
+  };
+}
+
+function testMarkdownProjector(source: string): string {
+  const title =
+    source
+      .replace(/^#+\s*/, "")
+      .split(/\r?\n/, 1)[0]
+      ?.trim() || "Untitled";
+  const slug = title
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/^-+|-+$/g, "");
+  return JSON.stringify({
+    version: 1,
+    engine: "test",
+    source,
+    byteLength: source.length,
+    utf16Length: source.length,
+    measurement: {
+      estimatedHeight: 24,
+      confidence: "high",
+      width: 720,
+    },
+    anchors: [
+      {
+        anchorId: `anchor:${slug}`,
+        blockId: "block:0",
+        level: 1,
+        slug,
+        sourceSpanByte: [0, source.length],
+        sourceSpanUtf16: [0, source.length],
+        title,
+      },
+    ],
+    blocks: [],
+    runs: [],
+  });
+}

--- a/src/components/notebook/__tests__/view-store-projection.test.ts
+++ b/src/components/notebook/__tests__/view-store-projection.test.ts
@@ -9,6 +9,7 @@ import {
   getCellExecutionId,
   getExecutionById,
   getNotebookQueueProjection,
+  markExecutionsRuntimeOwned,
   resetNotebookExecutions,
   setExecution,
   setNotebookQueueProjection,
@@ -180,6 +181,66 @@ describe("NotebookViewStoreProjector", () => {
     expect(getCellExecutionId("cell-1")).toBe(null);
     expect(getExecutionById("exec-from-notebook-doc")).toBeUndefined();
     expect(getOutputById("out-from-notebook-doc")).toBeUndefined();
+  });
+
+  it("releases ownership when RuntimeStateDoc authors a seeded execution id", () => {
+    const projector = createNotebookViewStoreProjector();
+
+    projector.projectCells([
+      {
+        id: "cell-1",
+        cellType: "code",
+        source: "print('snapshot')",
+        executionId: "exec-runtime-late",
+        executionCount: 3,
+        outputs: [
+          {
+            output_id: "out-placeholder",
+            output_type: "stream",
+            name: "stdout",
+            text: "snapshot\n",
+          },
+        ],
+        metadata: {},
+      },
+    ]);
+
+    markExecutionsRuntimeOwned(["exec-runtime-late"]);
+    setExecution("exec-runtime-late", {
+      execution_count: 4,
+      status: "running",
+      success: null,
+      output_ids: ["out-runtime"],
+    });
+
+    projector.projectCells([
+      {
+        id: "cell-1",
+        cellType: "code",
+        source: "print('live')",
+        executionId: "exec-runtime-late",
+        executionCount: 4,
+        outputs: [
+          {
+            output_id: "out-runtime",
+            output_type: "stream",
+            name: "stdout",
+            text: "live\n",
+          },
+        ],
+        metadata: {},
+      },
+    ]);
+    projector.cleanupRemovedCells(["cell-1"]);
+
+    expect(getCellExecutionId("cell-1")).toBe(null);
+    expect(getExecutionById("exec-runtime-late")).toEqual({
+      execution_count: 4,
+      status: "running",
+      success: null,
+      output_ids: ["out-runtime"],
+    });
+    expect(getOutputById("out-placeholder")).toBeUndefined();
   });
 
   it("reuses stamped output references without serializing them", () => {

--- a/src/components/notebook/index.ts
+++ b/src/components/notebook/index.ts
@@ -274,10 +274,29 @@ export {
   useOutputsVersion,
 } from "./state/output-store";
 export {
+  closeNotebookRail,
+  getNotebookRailUiState,
+  openNotebookRailPanel,
+  resetNotebookRailUiState,
+  setActiveNotebookRailPanel,
+  setNotebookRailCollapsed,
+  setSelectedNotebookOutlineItemId,
+  toggleNotebookRailPanel,
+  useNotebookRailUiState,
+  type NotebookRailUiState,
+} from "./state/rail-ui-state";
+export {
   createNotebookViewModelFromNotebookCells,
   notebookCellToViewCell,
   useNotebookViewModel,
 } from "./state/view-model-store";
+export {
+  createNotebookViewStoreProjector,
+  NotebookViewStoreProjector,
+  type NotebookViewStoreProjectionCell,
+  type NotebookViewStoreProjectorOptions,
+  type ResetNotebookViewStoreProjectionOptions,
+} from "./state/view-store-projection";
 export {
   createNotebookViewModel,
   notebookViewCellsToOutlineItems,

--- a/src/components/notebook/index.ts
+++ b/src/components/notebook/index.ts
@@ -250,6 +250,8 @@ export {
   getCellIdForExecutionId,
   getExecutionById,
   getNotebookQueueProjection,
+  isExecutionRuntimeOwned,
+  markExecutionsRuntimeOwned,
   resetNotebookExecutions,
   setCellExecutionPointer,
   setExecution,

--- a/src/components/notebook/outline-interaction.ts
+++ b/src/components/notebook/outline-interaction.ts
@@ -4,6 +4,7 @@ import {
   resolveNotebookOutlineSelection,
   type NotebookOutlineItem,
 } from "runtimed";
+import { setSelectedNotebookOutlineItemId, useNotebookRailUiState } from "./state/rail-ui-state";
 
 /**
  * Tracks the active outline item based on scroll position and visibility.
@@ -149,7 +150,7 @@ export function useOutlineSelection(options: {
   handleSelectOutlineItem: (item: NotebookOutlineItem) => void;
 } {
   const { outlineItems, focusedCellId, setFocusedCellId } = options;
-  const [selectedOutlineItemId, setSelectedOutlineItemId] = useState<string | null>(null);
+  const { selectedOutlineItemId } = useNotebookRailUiState();
 
   // Clear selection when focus moves to a different cell
   useEffect(() => {
@@ -159,13 +160,13 @@ export function useOutlineSelection(options: {
       !selectedOutlineItem ||
       (focusedCellId !== null && focusedCellId !== selectedOutlineItem.cellId)
     ) {
-      setSelectedOutlineItemId(null);
+      setSelectedNotebookOutlineItemId(null);
     }
   }, [focusedCellId, outlineItems, selectedOutlineItemId]);
 
   const handleSelectOutlineItem = useCallback(
     (item: NotebookOutlineItem) => {
-      setSelectedOutlineItemId(item.id);
+      setSelectedNotebookOutlineItemId(item.id);
       setFocusedCellId?.(item.cellId);
     },
     [setFocusedCellId],

--- a/src/components/notebook/state/execution-store.ts
+++ b/src/components/notebook/state/execution-store.ts
@@ -31,6 +31,7 @@ export interface NotebookQueueProjectionSnapshot {
 }
 
 const _executionMap: Map<string, ExecutionSnapshot> = new Map();
+const _runtimeOwnedExecutionIds = new Set<string>();
 
 /** Per-cell reverse index: cell_id -> latest execution_id. */
 const _cellToExecution: Map<string, string> = new Map();
@@ -190,6 +191,23 @@ export function setExecution(execution_id: string, snap: ExecutionSnapshot): voi
 }
 
 /**
+ * Mark execution snapshots whose authoritative source is RuntimeStateDoc.
+ *
+ * Projection placeholders can seed the same execution id before runtime sync
+ * catches up. Runtime upserts call this even when the snapshot is unchanged so
+ * projector cleanup can release ownership without deleting the runtime record.
+ */
+export function markExecutionsRuntimeOwned(execution_ids: Iterable<string>): void {
+  for (const execution_id of execution_ids) {
+    _runtimeOwnedExecutionIds.add(execution_id);
+  }
+}
+
+export function isExecutionRuntimeOwned(execution_id: string): boolean {
+  return _runtimeOwnedExecutionIds.has(execution_id);
+}
+
+/**
  * Explicitly set the active execution_id for a cell.
  *
  * Used on execution_started broadcasts and on clearOutputs (pass null).
@@ -233,7 +251,9 @@ export function setNotebookQueueProjection(projection: NotebookQueueProjectionSn
  */
 export function deleteExecutions(execution_ids: Iterable<string>): void {
   for (const eid of execution_ids) {
-    if (!_executionMap.delete(eid)) continue;
+    const existed = _executionMap.delete(eid);
+    _runtimeOwnedExecutionIds.delete(eid);
+    if (!existed) continue;
     emitExecutionChange(eid);
     const cellId = _executionToCell.get(eid);
     _executionToCell.delete(eid);
@@ -264,6 +284,7 @@ export function resetNotebookExecutions(): void {
   const eids = [..._executionMap.keys()];
   const cells = [..._cellToExecution.keys()];
   _executionMap.clear();
+  _runtimeOwnedExecutionIds.clear();
   _cellToExecution.clear();
   _executionToCell.clear();
   _notebookQueueProjection = {

--- a/src/components/notebook/state/rail-ui-state.ts
+++ b/src/components/notebook/state/rail-ui-state.ts
@@ -1,0 +1,96 @@
+import { useSyncExternalStore } from "react";
+import type { NotebookRailPanelId } from "@/components/notebook-rail";
+
+export interface NotebookRailUiState {
+  activePanelId: NotebookRailPanelId;
+  collapsed: boolean;
+  selectedOutlineItemId: string | null;
+}
+
+const DEFAULT_RAIL_UI_STATE: NotebookRailUiState = Object.freeze({
+  activePanelId: "outline",
+  collapsed: true,
+  selectedOutlineItemId: null,
+});
+
+let railUiState: NotebookRailUiState = DEFAULT_RAIL_UI_STATE;
+const subscribers = new Set<() => void>();
+
+export function useNotebookRailUiState(): NotebookRailUiState {
+  return useSyncExternalStore(subscribeNotebookRailUiState, getNotebookRailUiState);
+}
+
+export function getNotebookRailUiState(): NotebookRailUiState {
+  return railUiState;
+}
+
+export function setActiveNotebookRailPanel(panelId: NotebookRailPanelId): void {
+  setNotebookRailUiState({ activePanelId: panelId });
+}
+
+export function setNotebookRailCollapsed(collapsed: boolean): void {
+  setNotebookRailUiState({ collapsed });
+}
+
+export function setSelectedNotebookOutlineItemId(itemId: string | null): void {
+  setNotebookRailUiState({ selectedOutlineItemId: itemId });
+}
+
+export function openNotebookRailPanel(panelId: NotebookRailPanelId): void {
+  setNotebookRailUiState({ activePanelId: panelId, collapsed: false });
+}
+
+export function closeNotebookRail(): void {
+  setNotebookRailUiState({ collapsed: true });
+}
+
+export function toggleNotebookRailPanel(panelId: NotebookRailPanelId): void {
+  const current = getNotebookRailUiState();
+  if (!current.collapsed && current.activePanelId === panelId) {
+    closeNotebookRail();
+    return;
+  }
+  openNotebookRailPanel(panelId);
+}
+
+export function resetNotebookRailUiState(next: Partial<NotebookRailUiState> = {}): void {
+  setNotebookRailUiState({
+    activePanelId: next.activePanelId ?? DEFAULT_RAIL_UI_STATE.activePanelId,
+    collapsed: next.collapsed ?? DEFAULT_RAIL_UI_STATE.collapsed,
+    selectedOutlineItemId: hasPatch(next, "selectedOutlineItemId")
+      ? (next.selectedOutlineItemId ?? null)
+      : DEFAULT_RAIL_UI_STATE.selectedOutlineItemId,
+  });
+}
+
+function subscribeNotebookRailUiState(callback: () => void): () => void {
+  subscribers.add(callback);
+  return () => {
+    subscribers.delete(callback);
+  };
+}
+
+function setNotebookRailUiState(patch: Partial<NotebookRailUiState>): void {
+  const next = {
+    activePanelId: patch.activePanelId ?? railUiState.activePanelId,
+    collapsed: patch.collapsed ?? railUiState.collapsed,
+    selectedOutlineItemId: hasPatch(patch, "selectedOutlineItemId")
+      ? (patch.selectedOutlineItemId ?? null)
+      : railUiState.selectedOutlineItemId,
+  };
+  if (
+    next.activePanelId === railUiState.activePanelId &&
+    next.collapsed === railUiState.collapsed &&
+    next.selectedOutlineItemId === railUiState.selectedOutlineItemId
+  ) {
+    return;
+  }
+  railUiState = Object.freeze(next);
+  for (const callback of subscribers) {
+    callback();
+  }
+}
+
+function hasPatch<T extends object>(patch: T, key: keyof T): boolean {
+  return Object.prototype.hasOwnProperty.call(patch, key);
+}

--- a/src/components/notebook/state/view-store-projection.ts
+++ b/src/components/notebook/state/view-store-projection.ts
@@ -10,6 +10,7 @@ import {
   deleteExecutions,
   getCellExecutionId,
   getExecutionById,
+  isExecutionRuntimeOwned,
   setCellExecutionPointer,
   setExecution,
   setNotebookQueueProjection,
@@ -101,7 +102,9 @@ export class NotebookViewStoreProjector {
       const executionId = cell.executionId ?? syntheticExecutionId;
       const existingExecution = executionId ? getExecutionById(executionId) : undefined;
       const projectorOwnsExecution =
-        executionId !== null && (this.ownedExecutionIds.has(executionId) || !existingExecution);
+        executionId !== null &&
+        !isExecutionRuntimeOwned(executionId) &&
+        (this.ownedExecutionIds.has(executionId) || !existingExecution);
       setCellExecutionPointer(cell.id, executionId);
       if (executionId && projectorOwnsExecution) {
         nextOwnedExecutionIds.add(executionId);
@@ -119,7 +122,7 @@ export class NotebookViewStoreProjector {
     }
 
     deleteOutputs(difference(this.ownedOutputIds, nextOwnedOutputIds));
-    deleteExecutions(difference(this.ownedExecutionIds, nextOwnedExecutionIds));
+    this.deleteProjectorOwnedExecutions(difference(this.ownedExecutionIds, nextOwnedExecutionIds));
     this.ownedOutputIds = nextOwnedOutputIds;
     this.ownedExecutionIds = nextOwnedExecutionIds;
   }
@@ -143,9 +146,10 @@ export class NotebookViewStoreProjector {
             }
           }
         }
-        if (this.ownedExecutionIds.has(executionId)) {
+        if (this.ownedExecutionIds.has(executionId) && !isExecutionRuntimeOwned(executionId)) {
           executionIdsToDelete.add(executionId);
         }
+        this.ownedExecutionIds.delete(executionId);
       }
 
       const syntheticOutputPrefix = this.syntheticOutputPrefix(cellId);
@@ -169,9 +173,6 @@ export class NotebookViewStoreProjector {
 
     if (executionIdsToDelete.size > 0) {
       deleteExecutions(executionIdsToDelete);
-      for (const executionId of executionIdsToDelete) {
-        this.ownedExecutionIds.delete(executionId);
-      }
     }
   }
 
@@ -184,9 +185,21 @@ export class NotebookViewStoreProjector {
       });
     }
     deleteOutputs([...this.ownedOutputIds]);
-    deleteExecutions([...this.ownedExecutionIds]);
+    this.deleteProjectorOwnedExecutions(this.ownedExecutionIds);
     this.ownedOutputIds = new Set<string>();
     this.ownedExecutionIds = new Set<string>();
+  }
+
+  private deleteProjectorOwnedExecutions(executionIds: Iterable<string>): void {
+    const executionIdsToDelete: string[] = [];
+    for (const executionId of executionIds) {
+      if (!isExecutionRuntimeOwned(executionId)) {
+        executionIdsToDelete.push(executionId);
+      }
+    }
+    if (executionIdsToDelete.length > 0) {
+      deleteExecutions(executionIdsToDelete);
+    }
   }
 
   private resolvedCellToNotebookCell(

--- a/src/components/notebook/state/view-store-projection.ts
+++ b/src/components/notebook/state/view-store-projection.ts
@@ -1,0 +1,329 @@
+import type { JupyterOutput } from "../../cell/jupyter-output";
+import { projectMarkdownPlan } from "../../../lib/markdown-projection";
+import {
+  replaceNotebookCells,
+  type NotebookCellMetadata,
+  type NotebookStoreCell,
+  type NotebookStoreOutput,
+} from "./cell-store";
+import {
+  deleteExecutions,
+  getCellExecutionId,
+  getExecutionById,
+  setCellExecutionPointer,
+  setExecution,
+  setNotebookQueueProjection,
+} from "./execution-store";
+import { deleteOutputs, getOutputById, setOutput } from "./output-store";
+
+export interface NotebookViewStoreProjectionCell {
+  id: string;
+  cellType: "code" | "markdown" | "raw";
+  source: string;
+  executionId: string | null;
+  executionCount: number | null;
+  outputs: readonly JupyterOutput[];
+  metadata?: NotebookCellMetadata | null;
+}
+
+export interface NotebookViewStoreProjectorOptions {
+  syntheticExecutionId?: (cellId: string) => string;
+  syntheticOutputId?: (cellId: string, outputIndex: number) => string;
+  syntheticOutputPrefix?: (cellId: string) => string;
+}
+
+export interface ResetNotebookViewStoreProjectionOptions {
+  resetQueue?: boolean;
+}
+
+const RUNT_OUTPUT_CACHE_KEY = "_runt_output_cache_key";
+
+/**
+ * Host-neutral projector from materialized notebook cells into the shared
+ * NotebookView stores.
+ *
+ * Hosts still own transport, authority, and source facts. This class owns the
+ * common projection mechanics: cell-store replacement, per-output/execution
+ * store seeding, synthetic display placeholders, and cleanup of entries this
+ * projector created.
+ */
+export class NotebookViewStoreProjector {
+  private ownedExecutionIds = new Set<string>();
+  private ownedOutputIds = new Set<string>();
+  private readonly outputCacheKeys = new WeakMap<NotebookStoreOutput, string>();
+  private readonly syntheticExecutionId: (cellId: string) => string;
+  private readonly syntheticOutputId: (cellId: string, outputIndex: number) => string;
+  private readonly syntheticOutputPrefix: (cellId: string) => string | null;
+
+  constructor({
+    syntheticExecutionId = (cellId) => `notebook-view-execution:${cellId}`,
+    syntheticOutputId = (cellId, outputIndex) => `notebook-view-output:${cellId}:${outputIndex}`,
+    syntheticOutputPrefix,
+  }: NotebookViewStoreProjectorOptions = {}) {
+    this.syntheticExecutionId = syntheticExecutionId;
+    this.syntheticOutputId = syntheticOutputId;
+    this.syntheticOutputPrefix = syntheticOutputPrefix ?? (() => null);
+  }
+
+  projectCells(cells: readonly NotebookViewStoreProjectionCell[]): void {
+    const projectedCells = cells.map((cell) => {
+      const outputs =
+        cell.cellType === "code"
+          ? cell.outputs.map((output, index) =>
+              this.normalizeOutputForNotebookView(output, cell.id, index),
+            )
+          : [];
+      return { cell, notebookCell: this.resolvedCellToNotebookCell(cell, outputs), outputs };
+    });
+
+    replaceNotebookCells(projectedCells.map(({ notebookCell }) => notebookCell));
+
+    const nextOwnedExecutionIds = new Set<string>();
+    const nextOwnedOutputIds = new Set<string>();
+
+    for (const { cell, outputs } of projectedCells) {
+      if (cell.cellType !== "code") {
+        setCellExecutionPointer(cell.id, null);
+        continue;
+      }
+
+      for (const output of outputs) {
+        if (output.output_id) {
+          nextOwnedOutputIds.add(output.output_id);
+          setOutput(output.output_id, output);
+        }
+      }
+
+      const outputIds = outputs
+        .map((output) => output.output_id)
+        .filter((outputId): outputId is string => typeof outputId === "string");
+      const syntheticExecutionId = outputIds.length > 0 ? this.syntheticExecutionId(cell.id) : null;
+      const executionId = cell.executionId ?? syntheticExecutionId;
+      const existingExecution = executionId ? getExecutionById(executionId) : undefined;
+      const projectorOwnsExecution =
+        executionId !== null && (this.ownedExecutionIds.has(executionId) || !existingExecution);
+      setCellExecutionPointer(cell.id, executionId);
+      if (executionId && projectorOwnsExecution) {
+        nextOwnedExecutionIds.add(executionId);
+      }
+      if (executionId && !existingExecution) {
+        // Snapshot/live cell materialization can seed a display placeholder,
+        // but it must never downgrade a real RuntimeStateDoc execution snapshot.
+        setExecution(executionId, {
+          execution_count: cell.executionCount,
+          status: "done",
+          success: null,
+          output_ids: outputIds,
+        });
+      }
+    }
+
+    deleteOutputs(difference(this.ownedOutputIds, nextOwnedOutputIds));
+    deleteExecutions(difference(this.ownedExecutionIds, nextOwnedExecutionIds));
+    this.ownedOutputIds = nextOwnedOutputIds;
+    this.ownedExecutionIds = nextOwnedExecutionIds;
+  }
+
+  cleanupRemovedCells(removedCellIds: readonly string[]): void {
+    const outputIdsToDelete = new Set<string>();
+    const executionIdsToDelete = new Set<string>();
+
+    for (const cellId of removedCellIds) {
+      const syntheticExecutionId = this.syntheticExecutionId(cellId);
+      const executionId =
+        getCellExecutionId(cellId) ??
+        (getExecutionById(syntheticExecutionId) ? syntheticExecutionId : null);
+
+      if (executionId) {
+        const execution = getExecutionById(executionId);
+        if (execution) {
+          for (const outputId of execution.output_ids) {
+            if (this.ownedOutputIds.has(outputId)) {
+              outputIdsToDelete.add(outputId);
+            }
+          }
+        }
+        if (this.ownedExecutionIds.has(executionId)) {
+          executionIdsToDelete.add(executionId);
+        }
+      }
+
+      const syntheticOutputPrefix = this.syntheticOutputPrefix(cellId);
+      if (syntheticOutputPrefix) {
+        for (const outputId of this.ownedOutputIds) {
+          if (outputId.startsWith(syntheticOutputPrefix)) {
+            outputIdsToDelete.add(outputId);
+          }
+        }
+      }
+
+      setCellExecutionPointer(cellId, null);
+    }
+
+    if (outputIdsToDelete.size > 0) {
+      deleteOutputs(outputIdsToDelete);
+      for (const outputId of outputIdsToDelete) {
+        this.ownedOutputIds.delete(outputId);
+      }
+    }
+
+    if (executionIdsToDelete.size > 0) {
+      deleteExecutions(executionIdsToDelete);
+      for (const executionId of executionIdsToDelete) {
+        this.ownedExecutionIds.delete(executionId);
+      }
+    }
+  }
+
+  reset({ resetQueue = false }: ResetNotebookViewStoreProjectionOptions = {}): void {
+    replaceNotebookCells([]);
+    if (resetQueue) {
+      setNotebookQueueProjection({
+        executing_cell_id: null,
+        queued_cell_ids: [],
+      });
+    }
+    deleteOutputs([...this.ownedOutputIds]);
+    deleteExecutions([...this.ownedExecutionIds]);
+    this.ownedOutputIds = new Set<string>();
+    this.ownedExecutionIds = new Set<string>();
+  }
+
+  private resolvedCellToNotebookCell(
+    cell: NotebookViewStoreProjectionCell,
+    outputs: readonly NotebookStoreOutput[],
+  ): NotebookStoreCell {
+    const metadata = cell.metadata ?? {};
+    if (cell.cellType === "code") {
+      return {
+        cell_type: "code",
+        id: cell.id,
+        source: cell.source,
+        execution_count: cell.executionCount,
+        outputs: [...outputs],
+        metadata,
+      };
+    }
+
+    if (cell.cellType === "markdown") {
+      return {
+        cell_type: "markdown",
+        id: cell.id,
+        source: cell.source,
+        metadata,
+        markdownProjection: projectMarkdownPlan(cell.source) ?? undefined,
+      };
+    }
+
+    return {
+      cell_type: "raw",
+      id: cell.id,
+      source: cell.source,
+      metadata,
+    };
+  }
+
+  private normalizeOutputForNotebookView(
+    output: JupyterOutput,
+    cellId: string,
+    index: number,
+  ): NotebookStoreOutput {
+    const output_id = output.output_id ?? this.syntheticOutputId(cellId, index);
+    const previous = getOutputById(output_id);
+    let normalized: NotebookStoreOutput;
+
+    if (output.output_type === "stream") {
+      const text = Array.isArray(output.text) ? output.text.join("") : output.text;
+      normalized =
+        output.output_id === output_id && output.text === text
+          ? (output as NotebookStoreOutput)
+          : {
+              ...output,
+              output_id,
+              text,
+            };
+      return this.finalizeOutputForNotebookView(
+        this.reusePreviousOutputIfEqual(previous, normalized),
+      );
+    }
+
+    normalized =
+      output.output_id === output_id
+        ? (output as NotebookStoreOutput)
+        : ({
+            ...output,
+            output_id,
+          } as NotebookStoreOutput);
+    return this.finalizeOutputForNotebookView(
+      this.reusePreviousOutputIfEqual(previous, normalized),
+    );
+  }
+
+  private reusePreviousOutputIfEqual(
+    previous: NotebookStoreOutput | undefined,
+    next: NotebookStoreOutput,
+  ): NotebookStoreOutput {
+    if (!previous || previous === next) return next;
+    const previousCacheKey = this.outputCacheKeyForEquality(previous);
+    const nextCacheKey = this.outputCacheKeyForEquality(next);
+    if (previousCacheKey !== null && nextCacheKey !== null) {
+      return previousCacheKey === nextCacheKey ? previous : next;
+    }
+    const previousSerialized = serializedOutput(previous);
+    return previousSerialized !== null && previousSerialized === serializedOutput(next)
+      ? previous
+      : next;
+  }
+
+  private finalizeOutputForNotebookView(output: NotebookStoreOutput): NotebookStoreOutput {
+    const cacheKey = this.outputCacheKeyForEquality(output);
+    const stripped = stripOutputCacheKey(output);
+    if (cacheKey !== null) {
+      this.outputCacheKeys.set(stripped, cacheKey);
+    }
+    return stripped;
+  }
+
+  private outputCacheKeyForEquality(output: NotebookStoreOutput): string | null {
+    return stampedOutputCacheKey(output) ?? this.outputCacheKeys.get(output) ?? null;
+  }
+}
+
+export function createNotebookViewStoreProjector(
+  options?: NotebookViewStoreProjectorOptions,
+): NotebookViewStoreProjector {
+  return new NotebookViewStoreProjector(options);
+}
+
+function stampedOutputCacheKey(output: unknown): string | null {
+  if (typeof output !== "object" || output === null) return null;
+  const key = (output as Record<string, unknown>)[RUNT_OUTPUT_CACHE_KEY];
+  return typeof key === "string" ? key : null;
+}
+
+function stripOutputCacheKey(output: NotebookStoreOutput): NotebookStoreOutput {
+  if (!Object.prototype.hasOwnProperty.call(output, RUNT_OUTPUT_CACHE_KEY)) {
+    return output;
+  }
+  const { [RUNT_OUTPUT_CACHE_KEY]: _cacheKey, ...stripped } = output as NotebookStoreOutput &
+    Record<string, unknown>;
+  return stripped as NotebookStoreOutput;
+}
+
+function serializedOutput(output: NotebookStoreOutput): string | null {
+  try {
+    return JSON.stringify(output);
+  } catch {
+    return null;
+  }
+}
+
+function difference(previous: ReadonlySet<string>, next: ReadonlySet<string>): string[] {
+  const removed: string[] = [];
+  for (const id of previous) {
+    if (!next.has(id)) {
+      removed.push(id);
+    }
+  }
+  return removed;
+}


### PR DESCRIPTION
## Summary
- Extract a host-neutral NotebookView store projector for materialized cells, synthetic outputs/executions, markdown projection, cache-key reuse, and projector-owned cleanup.
- Replace duplicated desktop/cloud rail and outline selection React state with a shared useSyncExternalStore-backed rail UI store.
- Update cloud/desktop wiring tests and the shared-store projection ADR to record what landed and what remains.

## Verification
- pnpm test:run src/components/notebook/__tests__/view-store-projection.test.ts src/components/notebook/__tests__/rail-ui-state.test.ts src/components/notebook/__tests__/outline-interaction.test.ts apps/notebook/src/components/__tests__/notebook-toolbar.test.tsx
- pnpm --dir apps/notebook-cloud exec node --import tsx --test test/cloud-projection-flicker.test.ts test/notebook-view-store-bridge.test.ts test/viewer-shared-cell-surface.test.ts test/viewer-render-props.test.ts
- pnpm --dir apps/notebook exec tsc -b --pretty false
- pnpm --dir apps/notebook-cloud typecheck
- cargo xtask lint --fix