### PR TITLE
fix(notebook): project raster outputs into outline

### DIFF
--- a/apps/notebook/src/lib/__tests__/cell-outputs-decoupling.test.tsx
+++ b/apps/notebook/src/lib/__tests__/cell-outputs-decoupling.test.tsx
@@ -25,6 +25,7 @@ import {
   setOutput,
   useCellOutputs,
 } from "../notebook-outputs";
+import { useNotebookViewModel } from "../notebook-view-model";
 
 // ---------------------------------------------------------------------------
 // Phase C-lite acceptance: decoupling cell subscriptions from outputs.
@@ -51,6 +52,15 @@ function errorOutput(ename: string): JupyterOutput {
     ename,
     evalue: "boom",
     traceback: [],
+  };
+}
+
+function imageOutput(): JupyterOutput {
+  return {
+    output_id: "plot-output",
+    output_type: "display_data",
+    data: { "image/png": "iVBORw0KGgo=" },
+    metadata: {},
   };
 }
 
@@ -177,6 +187,43 @@ describe("Phase C-lite: cell subscription / outputs decoupling", () => {
 
     expect(result.current.cell).toBe(initialCell);
     expect(result.current.outputs).toHaveLength(2);
+  });
+
+  it("refreshes notebook view model outline items when a raster output lands", () => {
+    act(() => {
+      replaceNotebookCells([codeCell("plot")]);
+      setExecution("exec-plot", {
+        execution_count: 1,
+        status: "running",
+        success: null,
+        output_ids: [],
+      });
+      setCellExecutionPointer("plot", "exec-plot");
+    });
+
+    const { result } = renderHook(() => useNotebookViewModel());
+
+    expect(result.current.outlineItems.some((item) => item.kind === "output")).toBe(false);
+
+    act(() => {
+      setOutput("plot-output", imageOutput());
+      setExecution("exec-plot", {
+        execution_count: 1,
+        status: "done",
+        success: true,
+        output_ids: ["plot-output"],
+      });
+    });
+
+    expect(result.current.outlineItems).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          id: "plot:output:plot-output",
+          kind: "output",
+          imagePreview: expect.objectContaining({ mimeType: "image/png" }),
+        }),
+      ]),
+    );
   });
 
   it("does not re-render cell A when only cell B's outputs change", () => {

--- a/apps/notebook/src/lib/__tests__/notebook-executions.test.ts
+++ b/apps/notebook/src/lib/__tests__/notebook-executions.test.ts
@@ -11,6 +11,7 @@ import {
   setNotebookQueueProjection,
   useCellExecutionId,
   useExecution,
+  useExecutionStructureVersion,
   useNotebookQueueProjection,
   type ExecutionSnapshot,
 } from "../notebook-executions";
@@ -119,6 +120,7 @@ describe("notebook-executions store", () => {
     // Compile-time guard; React hook testing lives in the component suites.
     expect(typeof useExecution).toBe("function");
     expect(typeof useCellExecutionId).toBe("function");
+    expect(typeof useExecutionStructureVersion).toBe("function");
     expect(typeof useNotebookQueueProjection).toBe("function");
   });
 

--- a/apps/notebook/src/lib/__tests__/notebook-view-model.test.ts
+++ b/apps/notebook/src/lib/__tests__/notebook-view-model.test.ts
@@ -5,6 +5,12 @@ import {
   updateCellById,
   updateCellSourceById,
 } from "../notebook-cells";
+import {
+  resetNotebookExecutions,
+  setCellExecutionPointer,
+  setExecution,
+} from "../notebook-executions";
+import { resetNotebookOutputs, setOutput } from "../notebook-outputs";
 import { createNotebookViewModelFromNotebookCells } from "../notebook-view-model";
 import { setMarkdownProjectionProjector } from "../markdown-projection";
 import type { NotebookCell } from "../../types";
@@ -32,6 +38,8 @@ afterEach(() => {
   restoreMarkdownProjectionProjector?.();
   restoreMarkdownProjectionProjector = undefined;
   resetNotebookCells();
+  resetNotebookOutputs();
+  resetNotebookExecutions();
 });
 
 describe("createNotebookViewModelFromNotebookCells", () => {
@@ -82,6 +90,60 @@ describe("createNotebookViewModelFromNotebookCells", () => {
     );
 
     expect(createNotebookViewModelFromNotebookCells().outlineItems[0].statusLabel).toBe("run 7");
+  });
+
+  it("projects raster output waypoints from the execution and output stores", () => {
+    replaceNotebookCells([markdownCell("intro", "# Results"), codeCell("plot", "plot()", 2)]);
+
+    setOutput("plot-output", {
+      output_id: "plot-output",
+      output_type: "display_data",
+      data: { "image/png": "iVBORw0KGgo=" },
+      metadata: {},
+    });
+    setExecution("exec-plot", {
+      execution_count: 2,
+      status: "done",
+      success: true,
+      output_ids: ["plot-output"],
+    });
+    setCellExecutionPointer("plot", "exec-plot");
+
+    const outline = createNotebookViewModelFromNotebookCells().outlineItems;
+
+    expect(outline.map((item) => [item.id, item.kind, item.title])).toEqual([
+      ["intro:heading:0", "heading", "Results"],
+      ["plot:output:plot-output", "output", "Image output"],
+    ]);
+    expect(outline[1]).toMatchObject({
+      href: "#notebook-cell-plot-output-plot-output",
+      imagePreview: { mimeType: "image/png" },
+      outputId: "plot-output",
+    });
+  });
+
+  it("falls back to legacy cell outputs when no execution pointer exists", () => {
+    replaceNotebookCells([
+      {
+        ...codeCell("legacy-plot", "plot()", 1),
+        outputs: [
+          {
+            output_id: "legacy-output",
+            output_type: "display_data",
+            data: { "image/png": "iVBORw0KGgo=" },
+            metadata: {},
+          },
+        ],
+      },
+    ]);
+
+    const outline = createNotebookViewModelFromNotebookCells().outlineItems;
+
+    expect(outline[0]).toMatchObject({
+      id: "legacy-plot:output:legacy-output",
+      kind: "output",
+      imagePreview: { mimeType: "image/png" },
+    });
   });
 });
 

--- a/apps/notebook/src/lib/notebook-executions.ts
+++ b/apps/notebook/src/lib/notebook-executions.ts
@@ -12,6 +12,7 @@ export {
   setNotebookQueueProjection,
   useCellExecutionId,
   useExecution,
+  useExecutionStructureVersion,
   useNotebookQueueProjection,
   type ExecutionSnapshot,
   type NotebookQueueProjectionSnapshot,

--- a/src/components/notebook/index.ts
+++ b/src/components/notebook/index.ts
@@ -258,6 +258,7 @@ export {
   setNotebookQueueProjection,
   useCellExecutionId,
   useExecution,
+  useExecutionStructureVersion,
   useNotebookQueueProjection,
   type ExecutionSnapshot,
   type NotebookQueueProjectionSnapshot,

--- a/src/components/notebook/state/execution-store.ts
+++ b/src/components/notebook/state/execution-store.ts
@@ -44,6 +44,8 @@ let _notebookQueueProjection: NotebookQueueProjectionSnapshot = {
 const _subscribers = new Map<string, Set<() => void>>();
 const _cellExecutionSubscribers = new Map<string, Set<() => void>>();
 const _queueProjectionSubscribers = new Set<() => void>();
+let _executionStructureVersion = 0;
+const _executionStructureVersionSubscribers = new Set<() => void>();
 
 function emitExecutionChange(execution_id: string): void {
   const subs = _subscribers.get(execution_id);
@@ -75,6 +77,15 @@ function emitQueueProjectionChange(): void {
   }
 }
 
+function emitExecutionStructureChange(): void {
+  _executionStructureVersion = (_executionStructureVersion + 1) | 0;
+  for (const cb of _executionStructureVersionSubscribers) {
+    try {
+      cb();
+    } catch {}
+  }
+}
+
 function snapshotsEqual(a: ExecutionSnapshot, b: ExecutionSnapshot): boolean {
   if (a === b) return true;
   if (
@@ -90,6 +101,12 @@ function snapshotsEqual(a: ExecutionSnapshot, b: ExecutionSnapshot): boolean {
     if (a.output_ids[i] !== b.output_ids[i]) return false;
   }
   return true;
+}
+
+function executionStructureEqual(a: ExecutionSnapshot | undefined, b: ExecutionSnapshot): boolean {
+  if (!a) return false;
+  if (a.execution_count !== b.execution_count) return false;
+  return stringArraysEqual(a.output_ids, b.output_ids);
 }
 
 // ── Hooks ───────────────────────────────────────────────────────────────
@@ -117,6 +134,18 @@ export function useCellExecutionId(cell_id: string): string | null {
 
 export function useNotebookQueueProjection(): NotebookQueueProjectionSnapshot {
   return useSyncExternalStore(subscribeNotebookQueueProjection, getNotebookQueueProjection);
+}
+
+/**
+ * Subscribe to execution facts that cross-cell derived views consume:
+ * current execution counts, cell execution pointers, and output-id
+ * membership. Status-only changes stay on the per-execution path.
+ */
+export function useExecutionStructureVersion(): number {
+  return useSyncExternalStore(
+    subscribeExecutionStructureVersion,
+    getExecutionStructureVersionSnapshot,
+  );
 }
 
 // ── Subscription helpers ────────────────────────────────────────────────
@@ -172,6 +201,17 @@ export function getNotebookQueueProjection(): NotebookQueueProjectionSnapshot {
   return _notebookQueueProjection;
 }
 
+function subscribeExecutionStructureVersion(callback: () => void): () => void {
+  _executionStructureVersionSubscribers.add(callback);
+  return () => {
+    _executionStructureVersionSubscribers.delete(callback);
+  };
+}
+
+function getExecutionStructureVersionSnapshot(): number {
+  return _executionStructureVersion;
+}
+
 // ── Write operations ────────────────────────────────────────────────────
 
 /**
@@ -188,6 +228,9 @@ export function setExecution(execution_id: string, snap: ExecutionSnapshot): voi
   if (prev && snapshotsEqual(prev, snap)) return;
   _executionMap.set(execution_id, snap);
   emitExecutionChange(execution_id);
+  if (!executionStructureEqual(prev, snap)) {
+    emitExecutionStructureChange();
+  }
 }
 
 /**
@@ -225,6 +268,7 @@ export function setCellExecutionPointer(cell_id: string, execution_id: string | 
     _executionToCell.set(execution_id, cell_id);
   }
   emitCellExecutionPointerChange(cell_id);
+  emitExecutionStructureChange();
 }
 
 export function setNotebookQueueProjection(projection: NotebookQueueProjectionSnapshot): void {
@@ -261,6 +305,7 @@ export function deleteExecutions(execution_ids: Iterable<string>): void {
       _cellToExecution.delete(cellId);
       emitCellExecutionPointerChange(cellId);
     }
+    emitExecutionStructureChange();
   }
 }
 
@@ -294,6 +339,9 @@ export function resetNotebookExecutions(): void {
   for (const eid of eids) emitExecutionChange(eid);
   for (const cid of cells) emitCellExecutionPointerChange(cid);
   emitQueueProjectionChange();
+  if (eids.length > 0 || cells.length > 0) {
+    emitExecutionStructureChange();
+  }
 }
 
 function stringArraysEqual(a: readonly string[], b: readonly string[]): boolean {

--- a/src/components/notebook/state/output-store.ts
+++ b/src/components/notebook/state/output-store.ts
@@ -172,6 +172,25 @@ function getOutputSnapshot(output_id: string): () => JupyterOutput | undefined {
   return () => _outputMap.get(output_id);
 }
 
+function outputStructureKey(output: JupyterOutput): string {
+  if (output.output_type !== "display_data" && output.output_type !== "execute_result") {
+    return output.output_type;
+  }
+  return `${output.output_type}:${Object.keys(output.data).sort().join("\u0000")}`;
+}
+
+function hasRasterImagePreview(output: JupyterOutput | undefined): boolean {
+  if (
+    !output ||
+    (output.output_type !== "display_data" && output.output_type !== "execute_result")
+  ) {
+    return false;
+  }
+  return Object.keys(output.data).some(
+    (mimeType) => mimeType.startsWith("image/") && mimeType !== "image/svg+xml",
+  );
+}
+
 // ── Write operations ────────────────────────────────────────────────────
 
 /**
@@ -183,7 +202,11 @@ function getOutputSnapshot(output_id: string): () => JupyterOutput | undefined {
 export function setOutput(output_id: string, output: JupyterOutput): void {
   const prev = _outputMap.get(output_id);
   if (prev === output) return;
-  const structureChanged = prev === undefined || prev.output_type !== output.output_type;
+  const structureChanged =
+    prev === undefined ||
+    outputStructureKey(prev) !== outputStructureKey(output) ||
+    hasRasterImagePreview(prev) ||
+    hasRasterImagePreview(output);
   _outputMap.set(output_id, output);
   emitOutputChange(output_id);
   if (structureChanged) emitOutputStructureChange();

--- a/src/components/notebook/state/view-model-store.ts
+++ b/src/components/notebook/state/view-model-store.ts
@@ -6,6 +6,12 @@ import {
   type NotebookViewModel,
 } from "../view-model";
 import {
+  getCellExecutionId,
+  getExecutionById,
+  useExecutionStructureVersion,
+} from "./execution-store";
+import { getCellOutputsSnapshot, useOutputStructureVersion } from "./output-store";
+import {
   getNotebookCellsSnapshot,
   useCellIds,
   useMaterializeVersion,
@@ -17,17 +23,29 @@ export function useNotebookViewModel<TCell extends NotebookViewCell = NotebookVi
 ): NotebookViewModel<TCell> {
   const cellIds = useCellIds();
   const materializeVersion = useMaterializeVersion();
+  const executionStructureVersion = useExecutionStructureVersion();
+  const outputStructureVersion = useOutputStructureVersion();
   const { getOutlineStatusLabel, metadata, resolveLanguage } = options;
 
   return useMemo(() => {
     void cellIds;
     void materializeVersion;
+    void executionStructureVersion;
+    void outputStructureVersion;
     return createNotebookViewModelFromNotebookCells({
       getOutlineStatusLabel,
       metadata,
       resolveLanguage,
     }) as NotebookViewModel<TCell>;
-  }, [cellIds, getOutlineStatusLabel, materializeVersion, metadata, resolveLanguage]);
+  }, [
+    cellIds,
+    executionStructureVersion,
+    getOutlineStatusLabel,
+    materializeVersion,
+    metadata,
+    outputStructureVersion,
+    resolveLanguage,
+  ]);
 }
 
 export function createNotebookViewModelFromNotebookCells(
@@ -37,14 +55,19 @@ export function createNotebookViewModelFromNotebookCells(
 }
 
 export function notebookCellToViewCell(cell: NotebookStoreCell): NotebookViewCell {
+  const executionId = cell.cell_type === "code" ? getCellExecutionId(cell.id) : null;
+  const execution = executionId ? getExecutionById(executionId) : undefined;
+  const outputs =
+    cell.cell_type === "code" ? (executionId ? getCellOutputsSnapshot(cell.id) : cell.outputs) : [];
   return {
     id: cell.id,
     cellType: cell.cell_type,
     source: cell.source,
     language: cell.cell_type === "code" ? notebookCellLanguage(cell.metadata) : null,
-    executionId: null,
-    executionCount: cell.cell_type === "code" ? cell.execution_count : null,
-    outputs: cell.cell_type === "code" ? cell.outputs : [],
+    executionId,
+    executionCount:
+      cell.cell_type === "code" ? (execution?.execution_count ?? cell.execution_count) : null,
+    outputs,
     metadata: cell.metadata,
     markdownProjection: cell.cell_type === "markdown" ? cell.markdownProjection : undefined,
   };


### PR DESCRIPTION
## Summary

- Reconnect the shared notebook view model to execution/output stores so raster outputs feed outline projection after the output-store split.
- Add an execution-structure subscription for cross-cell derived views without subscribing them to stream payload churn.
- Keep legacy `cell.outputs` as a fallback when a saved code cell has outputs but no execution pointer.

## Verification

- `pnpm test:run apps/notebook/src/lib/__tests__/notebook-view-model.test.ts apps/notebook/src/lib/__tests__/cell-outputs-decoupling.test.tsx apps/notebook/src/lib/__tests__/notebook-executions.test.ts src/components/notebook/__tests__/view-model.test.ts packages/runtimed/tests/notebook-outline.test.ts`
- `cargo xtask lint --fix`
- Browser cloud smoke: rebuilt `apps/notebook-cloud` with `dev:browser --rebuild`, opened the notebook outline, and verified a raster outline `<img>` with nonzero dimensions.
- Browser desktop smoke: started `cargo xtask dev-daemon` plus `cargo xtask vite`, ran a matplotlib cell in the Vite desktop UI, opened the outline, and verified a raster outline `<img>` with nonzero dimensions.
