### PR TITLE
refactor(sift): extract reusable odometer primitive

### DIFF
--- a/packages/odometer/package.json
+++ b/packages/odometer/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "@nteract/odometer",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "main": "./src/index.ts",
+  "types": "./src/index.ts",
+  "exports": {
+    ".": "./src/index.ts",
+    "./style.css": "./src/style.css"
+  },
+  "devDependencies": {
+    "vitest": "catalog:",
+    "vite-plus": "catalog:",
+    "typescript": "~5.9.3"
+  }
+}

--- a/packages/odometer/src/index.ts
+++ b/packages/odometer/src/index.ts
@@ -1,0 +1,278 @@
+export type OdometerOptions = {
+  /** Force reduced-motion behavior. Defaults to prefers-reduced-motion. */
+  reducedMotion?: boolean;
+};
+
+export type Odometer = {
+  update(text: string): void;
+  destroy(): void;
+};
+
+type Slot = {
+  el: HTMLSpanElement;
+  sizer: HTMLSpanElement;
+  face: HTMLSpanElement | null;
+  strip: HTMLSpanElement | null;
+  current: string;
+  pos: number;
+  pendingSnapPos: number | null;
+  cleanupTransition: (() => void) | null;
+};
+
+const STRIP_DIGITS = [9, 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 0];
+
+function prefersReducedMotion(): boolean {
+  return (
+    typeof window !== "undefined" &&
+    typeof window.matchMedia === "function" &&
+    window.matchMedia("(prefers-reduced-motion: reduce)").matches
+  );
+}
+
+function isDigit(ch: string): boolean {
+  return ch >= "0" && ch <= "9";
+}
+
+function canonicalPos(digit: number): number {
+  return digit + 1;
+}
+
+function createDigitStrip(): HTMLSpanElement {
+  const strip = document.createElement("span");
+  strip.className = "nteract-odo-strip";
+  for (const d of STRIP_DIGITS) {
+    const digit = document.createElement("span");
+    digit.className = "nteract-odo-num";
+    digit.textContent = String(d);
+    strip.appendChild(digit);
+  }
+  return strip;
+}
+
+function createFace(text: string): HTMLSpanElement {
+  const face = document.createElement("span");
+  face.className = "nteract-odo-face";
+  face.textContent = text;
+  return face;
+}
+
+function createSlot(ch: string): Slot {
+  const el = document.createElement("span");
+  el.className = "nteract-odo-slot";
+  el.setAttribute("aria-hidden", "true");
+  el.dataset.odometerSlot = "";
+  el.dataset.char = ch;
+
+  const sizer = document.createElement("span");
+  sizer.className = "nteract-odo-sizer";
+  sizer.textContent = ch;
+  el.appendChild(sizer);
+
+  return {
+    el,
+    sizer,
+    face: null,
+    strip: null,
+    current: "",
+    pos: -1,
+    pendingSnapPos: null,
+    cleanupTransition: null,
+  };
+}
+
+function numericValue(text: string): number {
+  const numStr = text.replace(/[^0-9]/g, "");
+  return numStr ? Number.parseInt(numStr, 10) : 0;
+}
+
+export function createOdometer(host: HTMLElement, options: OdometerOptions = {}): Odometer {
+  host.textContent = "";
+  host.classList.add("nteract-odometer");
+  const slots: Slot[] = [];
+  let previousNumericValue = 0;
+  let currentText = "";
+  let plainTextMode = false;
+
+  function setValue(text: string): void {
+    host.dataset.value = text;
+    host.setAttribute("aria-label", text);
+    currentText = text;
+  }
+
+  function removeSlot(slot: Slot): void {
+    slot.cleanupTransition?.();
+    slot.cleanupTransition = null;
+    slot.el.remove();
+  }
+
+  function clearSlots(): void {
+    for (const slot of slots) {
+      removeSlot(slot);
+    }
+    slots.splice(0, slots.length);
+  }
+
+  function setPlainText(text: string): void {
+    clearSlots();
+    host.textContent = text;
+    plainTextMode = true;
+    setValue(text);
+  }
+
+  function reconcileSlots(text: string): void {
+    if (plainTextMode) {
+      host.textContent = "";
+      plainTextMode = false;
+      currentText = "";
+    }
+
+    if (text.length === currentText.length) return;
+
+    let prefix = 0;
+    while (
+      prefix < currentText.length &&
+      prefix < text.length &&
+      currentText[prefix] === text[prefix]
+    ) {
+      prefix++;
+    }
+
+    let suffix = 0;
+    while (
+      suffix < currentText.length - prefix &&
+      suffix < text.length - prefix &&
+      currentText[currentText.length - 1 - suffix] === text[text.length - 1 - suffix]
+    ) {
+      suffix++;
+    }
+
+    const oldMiddle = currentText.length - prefix - suffix;
+    const newMiddle = text.length - prefix - suffix;
+
+    for (let i = 0; i < oldMiddle; i++) {
+      const removed = slots.splice(prefix, 1)[0];
+      if (removed) removeSlot(removed);
+    }
+
+    const before = slots[prefix]?.el ?? null;
+    for (let i = 0; i < newMiddle; i++) {
+      const slot = createSlot("");
+      slots.splice(prefix + i, 0, slot);
+      host.insertBefore(slot.el, before);
+    }
+  }
+
+  function snapSlot(slot: Slot): void {
+    if (!slot.strip || slot.pendingSnapPos === null) return;
+    slot.cleanupTransition?.();
+    slot.cleanupTransition = null;
+    const canonical = slot.pendingSnapPos;
+    slot.pendingSnapPos = null;
+    slot.strip.style.transition = "none";
+    slot.strip.style.transform = `translateY(${-canonical * 1.2}em)`;
+    slot.pos = canonical;
+    void slot.strip.offsetHeight;
+    slot.strip.style.transition = "";
+  }
+
+  function apply(text: string): void {
+    if (options.reducedMotion ?? prefersReducedMotion()) {
+      setPlainText(text);
+      return;
+    }
+
+    const increasing = numericValue(text) >= previousNumericValue;
+    previousNumericValue = numericValue(text);
+    reconcileSlots(text);
+
+    for (let i = 0; i < text.length; i++) {
+      const ch = text[i] ?? "";
+      const slot = slots[i];
+      if (!slot) continue;
+      if (ch === slot.current) continue;
+      snapSlot(slot);
+      slot.el.dataset.char = ch;
+      slot.sizer.textContent = ch;
+
+      if (isDigit(ch)) {
+        if (slot.face) {
+          slot.el.removeChild(slot.face);
+          slot.face = null;
+        }
+        if (!slot.strip) {
+          slot.strip = createDigitStrip();
+          slot.el.appendChild(slot.strip);
+        }
+        const target = Number.parseInt(ch, 10);
+        const prev = isDigit(slot.current) ? Number.parseInt(slot.current, 10) : -1;
+        let targetPos: number;
+        if (prev === -1 || slot.pos === -1) targetPos = canonicalPos(target);
+        else if (increasing && prev === 9 && target === 0) targetPos = 11;
+        else if (!increasing && prev === 0 && target === 9) targetPos = 0;
+        else targetPos = canonicalPos(target);
+
+        const strip = slot.strip;
+        strip.style.transform = `translateY(${-targetPos * 1.2}em)`;
+        slot.pos = targetPos;
+        slot.pendingSnapPos = null;
+
+        slot.cleanupTransition?.();
+        slot.cleanupTransition = null;
+        if (targetPos === 0 || targetPos === 11) {
+          slot.pendingSnapPos = canonicalPos(target);
+          const onEnd = (event: Event) => {
+            if (event.target !== strip) return;
+            if (
+              "propertyName" in event &&
+              typeof event.propertyName === "string" &&
+              event.propertyName !== "" &&
+              event.propertyName !== "transform"
+            ) {
+              return;
+            }
+            strip.removeEventListener("transitionend", onEnd);
+            if (slot.strip === strip) {
+              snapSlot(slot);
+            }
+          };
+          strip.addEventListener("transitionend", onEnd);
+          slot.cleanupTransition = () => strip.removeEventListener("transitionend", onEnd);
+        }
+      } else {
+        slot.cleanupTransition?.();
+        slot.cleanupTransition = null;
+        slot.pendingSnapPos = null;
+        if (slot.strip) {
+          slot.el.removeChild(slot.strip);
+          slot.strip = null;
+          slot.pos = -1;
+        }
+        if (!slot.face) {
+          slot.face = createFace(ch);
+          slot.el.appendChild(slot.face);
+        } else {
+          slot.face.textContent = ch;
+        }
+      }
+      slot.current = ch;
+    }
+
+    setValue(text);
+  }
+
+  function update(text: string): void {
+    apply(text);
+  }
+
+  function destroy(): void {
+    clearSlots();
+    host.textContent = "";
+    host.classList.remove("nteract-odometer");
+    delete host.dataset.value;
+    host.removeAttribute("aria-label");
+    currentText = "";
+    plainTextMode = false;
+  }
+
+  return { update, destroy };
+}

--- a/packages/odometer/src/style.css
+++ b/packages/odometer/src/style.css
@@ -1,0 +1,49 @@
+.nteract-odometer {
+  display: inline-flex;
+  align-items: baseline;
+  gap: 0;
+  font-variant-numeric: tabular-nums;
+  font-feature-settings: "tnum";
+}
+
+.nteract-odo-slot {
+  position: relative;
+  display: inline-block;
+  height: 1.2em;
+  overflow: hidden;
+  vertical-align: baseline;
+  line-height: 1.2;
+  white-space: pre;
+  contain: layout style paint;
+}
+
+.nteract-odo-sizer {
+  visibility: hidden;
+  white-space: pre;
+}
+
+.nteract-odo-face {
+  position: absolute;
+  inset: 0 auto auto 0;
+  white-space: pre;
+}
+
+.nteract-odo-strip {
+  position: absolute;
+  inset: 0 auto auto 0;
+  display: flex;
+  flex-direction: column;
+  transition: transform 400ms cubic-bezier(0.22, 1, 0.36, 1);
+}
+
+.nteract-odo-num {
+  display: block;
+  height: 1.2em;
+  line-height: 1.2;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .nteract-odo-strip {
+    transition: none;
+  }
+}

--- a/packages/odometer/tests/index.test.ts
+++ b/packages/odometer/tests/index.test.ts
@@ -1,0 +1,115 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { createOdometer } from "../src/index";
+
+function slotTexts(host: HTMLElement): string[] {
+  return Array.from(host.querySelectorAll<HTMLElement>("[data-odometer-slot]")).map(
+    (slot) => slot.dataset.char ?? "",
+  );
+}
+
+function sizerTexts(host: HTMLElement): string[] {
+  return Array.from(host.querySelectorAll<HTMLElement>(".nteract-odo-sizer")).map(
+    (slot) => slot.textContent ?? "",
+  );
+}
+
+describe("createOdometer", () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("renders the visible value and exposes it for tests/accessibility", () => {
+    const host = document.createElement("span");
+    const odometer = createOdometer(host);
+
+    odometer.update("999 rows");
+
+    expect(host.dataset.value).toBe("999 rows");
+    expect(host.getAttribute("aria-label")).toBe("999 rows");
+    expect(slotTexts(host)).toEqual(["9", "9", "9", " ", "r", "o", "w", "s"]);
+    expect(
+      Array.from(host.querySelectorAll<HTMLElement>("[data-odometer-slot]")).every(
+        (slot) => slot.getAttribute("aria-hidden") === "true",
+      ),
+    ).toBe(true);
+  });
+
+  it("keeps unchanged suffix slots stable and resizes slots for changing-length labels", () => {
+    const host = document.createElement("span");
+    const odometer = createOdometer(host);
+
+    odometer.update("999 rows");
+    const before = Array.from(host.querySelectorAll<HTMLElement>("[data-odometer-slot]"));
+
+    odometer.update("1,000 rows");
+    const after = Array.from(host.querySelectorAll<HTMLElement>("[data-odometer-slot]"));
+
+    expect(host.dataset.value).toBe("1,000 rows");
+    expect(slotTexts(host)).toEqual(["1", ",", "0", "0", "0", " ", "r", "o", "w", "s"]);
+    expect(sizerTexts(host)).toEqual(["1", ",", "0", "0", "0", " ", "r", "o", "w", "s"]);
+    expect(after.at(-4)).toBe(before.at(-4));
+    expect(after.at(-3)).toBe(before.at(-3));
+    expect(after.at(-2)).toBe(before.at(-2));
+    expect(after.at(-1)).toBe(before.at(-1));
+  });
+
+  it("applies repeated updates immediately", () => {
+    const host = document.createElement("span");
+    const odometer = createOdometer(host);
+
+    odometer.update("10 rows");
+    odometer.update("11 rows");
+    odometer.update("12 rows");
+
+    expect(host.dataset.value).toBe("12 rows");
+    expect(slotTexts(host)).toEqual(["1", "2", " ", "r", "o", "w", "s"]);
+  });
+
+  it("uses plain text when reduced motion is requested", () => {
+    const host = document.createElement("span");
+    const odometer = createOdometer(host, { reducedMotion: true });
+
+    odometer.update("25 of 1,000 rows");
+
+    expect(host.textContent).toBe("25 of 1,000 rows");
+    expect(host.querySelector("[data-odometer-slot]")).toBeNull();
+    expect(host.dataset.value).toBe("25 of 1,000 rows");
+  });
+
+  it("rebuilds animated slots after the reduced-motion preference turns off", () => {
+    let reducedMotion = true;
+    vi.stubGlobal(
+      "matchMedia",
+      vi.fn(() => ({ matches: reducedMotion })),
+    );
+    const host = document.createElement("span");
+    const odometer = createOdometer(host);
+
+    odometer.update("25 rows");
+    expect(host.textContent).toBe("25 rows");
+    expect(host.querySelector("[data-odometer-slot]")).toBeNull();
+
+    reducedMotion = false;
+    odometer.update("26 rows");
+
+    expect(host.textContent).not.toBe("26 rows");
+    expect(host.dataset.value).toBe("26 rows");
+    expect(slotTexts(host)).toEqual(["2", "6", " ", "r", "o", "w", "s"]);
+  });
+
+  it("snaps wrapped digits back to canonical strip positions after transition", () => {
+    const host = document.createElement("span");
+    const odometer = createOdometer(host);
+
+    odometer.update("19 rows");
+    odometer.update("20 rows");
+
+    const strips = host.querySelectorAll<HTMLElement>(".nteract-odo-strip");
+    const wrappedZero = strips[1];
+    expect(wrappedZero.style.transform).toBe("translateY(-13.2em)");
+
+    wrappedZero.dispatchEvent(new Event("transitionend", { bubbles: true }));
+
+    expect(wrappedZero.style.transform).toBe("translateY(-1.2em)");
+  });
+});

--- a/packages/sift/package.json
+++ b/packages/sift/package.json
@@ -34,7 +34,7 @@
     "generate": "npx tsx src/generate-data.ts",
     "dev": "vp dev",
     "build": "tsc && vp build",
-    "build:lib": "tsc && vp build --config vite.lib.config.ts && npx @tailwindcss/cli -i src/style.css -o lib/style.css --minify && cp src/handoff.css lib/handoff.css",
+    "build:lib": "tsc && vp build --config vite.lib.config.ts && node scripts/build-lib-css.mjs && cp src/handoff.css lib/handoff.css",
     "preview": "vp preview",
     "test": "vp test run",
     "test:watch": "vp test",
@@ -72,6 +72,7 @@
   },
   "dependencies": {
     "@chenglou/pretext": ">=0.0.6",
+    "@nteract/odometer": "workspace:*",
     "@radix-ui/react-context-menu": "^2.2.16",
     "@radix-ui/react-dropdown-menu": "^2.1.16",
     "@radix-ui/react-popover": "^1.1.15",

--- a/packages/sift/scripts/build-lib-css.mjs
+++ b/packages/sift/scripts/build-lib-css.mjs
@@ -1,0 +1,53 @@
+import { existsSync } from "node:fs";
+import { mkdir, readFile, writeFile } from "node:fs/promises";
+import { createRequire } from "node:module";
+import { dirname, resolve } from "node:path";
+
+const require = createRequire(import.meta.url);
+
+function packageRoot(specifier) {
+  let dir = dirname(require.resolve(specifier, { paths: [process.cwd()] }));
+  while (dir !== dirname(dir)) {
+    if (existsSync(resolve(dir, "package.json"))) return dir;
+    dir = dirname(dir);
+  }
+  throw new Error(`Could not resolve package root for ${specifier}`);
+}
+
+// Reuse the Tailwind compiler that the package already gets through the Vite plugin.
+const tailwindViteRoot = packageRoot("@tailwindcss/vite");
+const { compile, optimize, Features } = require(
+  require.resolve("@tailwindcss/node", {
+    paths: [tailwindViteRoot],
+  }),
+);
+const { Scanner } = require(require.resolve("@tailwindcss/oxide", { paths: [tailwindViteRoot] }));
+
+const inputPath = resolve("src/style.css");
+const outputPath = resolve("lib/style.css");
+const css = await readFile(inputPath, "utf8");
+
+const compiler = await compile(css, {
+  base: dirname(inputPath),
+  from: inputPath,
+  shouldRewriteUrls: true,
+  onDependency() {},
+});
+
+let candidates = [];
+if (compiler.features & Features.Utilities) {
+  const sources = (
+    compiler.root === "none"
+      ? []
+      : compiler.root === null
+        ? [{ base: process.cwd(), pattern: "**/*", negated: false }]
+        : [{ ...compiler.root, negated: false }]
+  ).concat(compiler.sources);
+  candidates = new Scanner({ sources }).scan();
+}
+
+const output = compiler.build(candidates);
+const optimized = optimize(output, { file: inputPath, minify: true });
+
+await mkdir(dirname(outputPath), { recursive: true });
+await writeFile(outputPath, optimized.code);

--- a/packages/sift/src/library.css
+++ b/packages/sift/src/library.css
@@ -1043,38 +1043,6 @@
   }
 }
 
-/* --- Odometer FPS counter --- */
-
-.sift-odometer {
-  display: inline-flex;
-  align-items: baseline;
-  gap: 0;
-  font-variant-numeric: tabular-nums;
-  font-feature-settings: "tnum";
-}
-
-.sift-odo-slot {
-  display: inline-block;
-  height: 1.2em;
-  overflow: hidden;
-  vertical-align: baseline;
-  line-height: 1.2;
-  white-space: pre; /* preserve space characters */
-  contain: layout style paint;
-}
-
-.sift-odo-strip {
-  display: flex;
-  flex-direction: column;
-  transition: transform 400ms cubic-bezier(0.22, 1, 0.36, 1);
-}
-
-.sift-odo-num {
-  display: block;
-  height: 1.2em;
-  line-height: 1.2;
-}
-
 /* --- Status indicator --- */
 
 .sift-status-indicator {

--- a/packages/sift/src/style.css
+++ b/packages/sift/src/style.css
@@ -1,2 +1,3 @@
 @import "tailwindcss";
+@import "@nteract/odometer/style.css";
 @import "./library.css";

--- a/packages/sift/src/table.ts
+++ b/packages/sift/src/table.ts
@@ -1,4 +1,5 @@
 import { layout, type PreparedText, prepare } from "@chenglou/pretext";
+import { createOdometer } from "@nteract/odometer";
 import {
   animationFrameScheduler,
   distinctUntilChanged,
@@ -954,131 +955,6 @@ export function createTable(
   debugGroup.style.display = "none";
   const statDom = makeStatSpan("sift-stat-dom");
   const statFrame = makeStatSpan("sift-stat-frame");
-
-  // Reusable odometer — rolling digit strips for any numeric display
-  type OdometerSlot = {
-    el: HTMLSpanElement;
-    strip: HTMLSpanElement | null;
-    current: string;
-    pos: number;
-  };
-
-  function createOdometer(host: HTMLElement): {
-    update: (text: string) => void;
-  } {
-    host.classList.add("sift-odometer");
-    const slots: OdometerSlot[] = [];
-    // Track the previous numeric value to determine roll direction
-    let prevNumericValue = 0;
-
-    // Strip layout: 9-0-1-2-3-4-5-6-7-8-9-0 (12 positions)
-    // Canonical positions 1-10 map to digits 0-9
-    // Position 0 = extra 9 (for wrapping down past 0)
-    // Position 11 = extra 0 (for wrapping up past 9)
-    const STRIP_DIGITS = [9, 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 0];
-
-    function createDigitStrip(): HTMLSpanElement {
-      const strip = document.createElement("span");
-      strip.className = "sift-odo-strip";
-      for (const d of STRIP_DIGITS) {
-        const digit = document.createElement("span");
-        digit.className = "sift-odo-num";
-        digit.textContent = String(d);
-        strip.appendChild(digit);
-      }
-      return strip;
-    }
-
-    // Canonical position for a digit (1-10)
-    function canonicalPos(d: number): number {
-      return d + 1;
-    }
-
-    function update(text: string) {
-      // Extract numeric value from text to determine direction
-      const numStr = text.replace(/[^0-9]/g, "");
-      const numericValue = numStr ? parseInt(numStr) : 0;
-      const increasing = numericValue >= prevNumericValue;
-      prevNumericValue = numericValue;
-
-      while (slots.length < text.length) {
-        const el = document.createElement("span");
-        el.className = "sift-odo-slot";
-        host.appendChild(el);
-        slots.push({ el, strip: null, current: "", pos: -1 });
-      }
-      while (slots.length > text.length) {
-        const removed = slots.pop()!;
-        host.removeChild(removed.el);
-      }
-
-      for (let i = 0; i < text.length; i++) {
-        const ch = text[i];
-        const slot = slots[i];
-
-        if (ch === slot.current) continue;
-
-        const isDigit = ch >= "0" && ch <= "9";
-
-        if (isDigit) {
-          if (!slot.strip) {
-            slot.el.textContent = "";
-            slot.strip = createDigitStrip();
-            slot.el.appendChild(slot.strip);
-            slot.pos = -1;
-          }
-          const target = parseInt(ch);
-          const prev = slot.current >= "0" && slot.current <= "9" ? parseInt(slot.current) : -1;
-
-          let targetPos: number;
-          if (prev === -1 || slot.pos === -1) {
-            // First time — go directly to canonical position
-            targetPos = canonicalPos(target);
-          } else if (increasing && prev === 9 && target === 0) {
-            // Wrapping up: 9→0, roll to position 11 (extra 0 at bottom)
-            targetPos = 11;
-          } else if (!increasing && prev === 0 && target === 9) {
-            // Wrapping down: 0→9, roll to position 0 (extra 9 at top)
-            targetPos = 0;
-          } else {
-            targetPos = canonicalPos(target);
-          }
-
-          slot.strip.style.transform = `translateY(${-targetPos * 1.2}em)`;
-          slot.pos = targetPos;
-
-          // After wrap transitions, snap back to canonical position
-          if (targetPos === 0 || targetPos === 11) {
-            const canonical = canonicalPos(target);
-            const strip = slot.strip;
-            const onEnd = () => {
-              strip.removeEventListener("transitionend", onEnd);
-              // Disable transition, snap, re-enable
-              strip.style.transition = "none";
-              strip.style.transform = `translateY(${-canonical * 1.2}em)`;
-              slot.pos = canonical;
-              // Force reflow then restore transition
-              void strip.offsetHeight;
-              strip.style.transition = "";
-            };
-            slot.strip.addEventListener("transitionend", onEnd);
-          }
-        } else {
-          if (slot.strip) {
-            slot.el.removeChild(slot.strip);
-            slot.strip = null;
-            slot.pos = -1;
-          }
-          slot.el.textContent = ch;
-        }
-        slot.current = ch;
-      }
-      // Expose visible text for testing (textContent includes hidden strip digits)
-      host.dataset.value = text;
-    }
-
-    return { update };
-  }
 
   const rowsOdometer = createOdometer(statRows);
 
@@ -2425,6 +2301,8 @@ export function createTable(
       scheduledRaf = null;
     }
     fpsSub.unsubscribe();
+    rowsOdometer.destroy();
+    fpsOdometer.destroy();
     if (summaryDebounceTimer !== null) clearTimeout(summaryDebounceTimer);
 
     // Remove event listeners and observers

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -410,7 +410,7 @@ importers:
         version: '@voidzero-dev/vite-plus-core@0.1.16(@types/node@24.12.2)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.21.0)(typescript@5.9.3)(yaml@2.8.3)'
       vite-plus:
         specifier: 'catalog:'
-        version: 0.1.16(@opentelemetry/api@1.9.1)(@types/node@24.12.2)(@voidzero-dev/vite-plus-core@0.1.16(@types/node@24.12.2)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.21.0)(typescript@5.9.3)(yaml@2.8.3))(esbuild@0.28.0)(jiti@2.7.0)(jsdom@29.0.2)(tsx@4.21.0)(typescript@5.9.3)(yaml@2.8.3)
+        version: 0.1.16(@opentelemetry/api@1.9.1)(@types/node@24.12.2)(esbuild@0.28.0)(jiti@2.7.0)(jsdom@29.0.2)(tsx@4.21.0)(typescript@5.9.3)(vite@7.3.2(@types/node@24.12.2)(jiti@2.7.0)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.8.3))(yaml@2.8.3)
 
   apps/notebook:
     dependencies:
@@ -671,7 +671,7 @@ importers:
         version: '@voidzero-dev/vite-plus-core@0.1.16(@types/node@24.12.2)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.21.0)(typescript@5.9.3)(yaml@2.8.3)'
       vite-plus:
         specifier: 'catalog:'
-        version: 0.1.16(@opentelemetry/api@1.9.1)(@types/node@24.12.2)(@voidzero-dev/vite-plus-core@0.1.16(@types/node@24.12.2)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.21.0)(typescript@5.9.3)(yaml@2.8.3))(esbuild@0.28.0)(jiti@2.7.0)(jsdom@29.0.2)(tsx@4.21.0)(typescript@5.9.3)(yaml@2.8.3)
+        version: 0.1.16(@opentelemetry/api@1.9.1)(@types/node@24.12.2)(esbuild@0.28.0)(jiti@2.7.0)(jsdom@29.0.2)(tsx@4.21.0)(typescript@5.9.3)(vite@7.3.2(@types/node@24.12.2)(jiti@2.7.0)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.8.3))(yaml@2.8.3)
 
   packages/notebook-host:
     dependencies:
@@ -699,6 +699,18 @@ importers:
       rxjs:
         specifier: ^7.8.2
         version: 7.8.2
+
+  packages/odometer:
+    devDependencies:
+      typescript:
+        specifier: ~5.9.3
+        version: 5.9.3
+      vite-plus:
+        specifier: 'catalog:'
+        version: 0.1.16(@opentelemetry/api@1.9.1)(@types/node@24.12.2)(esbuild@0.28.0)(jiti@2.7.0)(jsdom@29.0.2)(tsx@4.21.0)(typescript@5.9.3)(vite@7.3.2(@types/node@24.12.2)(jiti@2.7.0)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.8.3))(yaml@2.8.3)
+      vitest:
+        specifier: 'catalog:'
+        version: '@voidzero-dev/vite-plus-test@0.1.16(@opentelemetry/api@1.9.1)(@types/node@24.12.2)(esbuild@0.28.0)(jiti@2.7.0)(jsdom@29.0.2)(tsx@4.21.0)(typescript@5.9.3)(vite@7.3.2(@types/node@24.12.2)(jiti@2.7.0)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.8.3))(yaml@2.8.3)'
 
   packages/runtimed:
     dependencies:
@@ -741,6 +753,9 @@ importers:
       '@chenglou/pretext':
         specifier: '>=0.0.6'
         version: 0.0.6
+      '@nteract/odometer':
+        specifier: workspace:*
+        version: link:../odometer
       '@radix-ui/react-context-menu':
         specifier: ^2.2.16
         version: 2.2.16(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
@@ -816,10 +831,10 @@ importers:
         version: '@voidzero-dev/vite-plus-core@0.1.16(@types/node@24.12.2)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.21.0)(typescript@5.9.3)(yaml@2.8.3)'
       vite-plus:
         specifier: 'catalog:'
-        version: 0.1.16(@opentelemetry/api@1.9.1)(@types/node@24.12.2)(@voidzero-dev/vite-plus-core@0.1.16(@types/node@24.12.2)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.21.0)(typescript@5.9.3)(yaml@2.8.3))(esbuild@0.28.0)(jiti@2.7.0)(jsdom@29.0.2)(tsx@4.21.0)(typescript@5.9.3)(yaml@2.8.3)
+        version: 0.1.16(@opentelemetry/api@1.9.1)(@types/node@24.12.2)(esbuild@0.28.0)(jiti@2.7.0)(jsdom@29.0.2)(tsx@4.21.0)(typescript@5.9.3)(vite@7.3.2(@types/node@24.12.2)(jiti@2.7.0)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.8.3))(yaml@2.8.3)
       vitest:
         specifier: 'catalog:'
-        version: '@voidzero-dev/vite-plus-test@0.1.16(@opentelemetry/api@1.9.1)(@types/node@24.12.2)(@voidzero-dev/vite-plus-core@0.1.16(@types/node@24.12.2)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.21.0)(typescript@5.9.3)(yaml@2.8.3))(esbuild@0.28.0)(jiti@2.7.0)(jsdom@29.0.2)(tsx@4.21.0)(typescript@5.9.3)(yaml@2.8.3)'
+        version: '@voidzero-dev/vite-plus-test@0.1.16(@opentelemetry/api@1.9.1)(@types/node@24.12.2)(esbuild@0.28.0)(jiti@2.7.0)(jsdom@29.0.2)(tsx@4.21.0)(typescript@5.9.3)(vite@7.3.2(@types/node@24.12.2)(jiti@2.7.0)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.8.3))(yaml@2.8.3)'
 
   plugins/nteract/pi:
     dependencies:
@@ -9932,10 +9947,6 @@ packages:
   tinyexec@0.3.2:
     resolution: {integrity: sha512-KQQR9yN7R5+OSwaK0XQoj22pwHoTlgYqmUscPYoknOoWCWfj/5/ABTMRi69FrKU5ffPVh5QcFikpWJI/P1ocHA==}
 
-  tinyexec@1.1.1:
-    resolution: {integrity: sha512-VKS/ZaQhhkKFMANmAOhhXVoIfBXblQxGX1myCQ2faQrfmobMftXeJPcZGp0gS07ocvGJWDLZGyOZDadDBqYIJg==}
-    engines: {node: '>=18'}
-
   tinyexec@1.2.2:
     resolution: {integrity: sha512-M/Q0B2cp4K7kynaT/vnED1j8TlLY+Pp7C6Wl2bl/7u/F0mUVwdyOpwomQb8JpYLitHUssAJRmLZdMCGsrx7i+g==}
     engines: {node: '>=18'}
@@ -11004,7 +11015,7 @@ snapshots:
   '@antfu/install-pkg@1.1.0':
     dependencies:
       package-manager-detector: 1.6.0
-      tinyexec: 1.1.1
+      tinyexec: 1.2.2
 
   '@anthropic-ai/sdk@0.91.1(zod@4.4.3)':
     dependencies:
@@ -12224,7 +12235,7 @@ snapshots:
       google-auth-library: 10.6.2
       p-retry: 4.6.2
       protobufjs: 7.5.4
-      ws: 8.20.0
+      ws: 8.20.1
     optionalDependencies:
       '@modelcontextprotocol/sdk': 1.29.0(zod@4.4.3)
     transitivePeerDependencies:
@@ -12808,7 +12819,7 @@ snapshots:
 
   '@mistralai/mistralai@2.2.1':
     dependencies:
-      ws: 8.20.0
+      ws: 8.20.1
       zod: 4.3.6
       zod-to-json-schema: 3.25.2(zod@4.3.6)
     transitivePeerDependencies:
@@ -16933,10 +16944,10 @@ snapshots:
       sirv: 3.0.2
       std-env: 4.0.0
       tinybench: 2.9.0
-      tinyexec: 1.1.1
+      tinyexec: 1.2.2
       tinyglobby: 0.2.16
       vite: '@voidzero-dev/vite-plus-core@0.1.16(@types/node@20.19.37)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.21.0)(typescript@5.8.3)(yaml@2.8.3)'
-      ws: 8.20.0
+      ws: 8.20.1
     optionalDependencies:
       '@opentelemetry/api': 1.9.1
       '@types/node': 20.19.37
@@ -16974,10 +16985,10 @@ snapshots:
       sirv: 3.0.2
       std-env: 4.0.0
       tinybench: 2.9.0
-      tinyexec: 1.1.1
+      tinyexec: 1.2.2
       tinyglobby: 0.2.16
       vite: '@voidzero-dev/vite-plus-core@0.1.16(@types/node@20.19.37)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.21.0)(typescript@5.8.3)(yaml@2.8.3)'
-      ws: 8.20.0
+      ws: 8.20.1
     optionalDependencies:
       '@opentelemetry/api': 1.9.1
       '@types/node': 20.19.37
@@ -17015,10 +17026,10 @@ snapshots:
       sirv: 3.0.2
       std-env: 4.0.0
       tinybench: 2.9.0
-      tinyexec: 1.1.1
+      tinyexec: 1.2.2
       tinyglobby: 0.2.16
       vite: '@voidzero-dev/vite-plus-core@0.1.16(@types/node@24.12.2)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.21.0)(typescript@5.8.3)(yaml@2.8.3)'
-      ws: 8.20.0
+      ws: 8.20.1
     optionalDependencies:
       '@opentelemetry/api': 1.9.1
       '@types/node': 24.12.2
@@ -17044,7 +17055,7 @@ snapshots:
       - utf-8-validate
       - yaml
 
-  '@voidzero-dev/vite-plus-test@0.1.16(@opentelemetry/api@1.9.1)(@types/node@24.12.2)(@voidzero-dev/vite-plus-core@0.1.16(@types/node@24.12.2)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.21.0)(typescript@5.9.3)(yaml@2.8.3))(esbuild@0.28.0)(jiti@2.7.0)(jsdom@29.0.2)(tsx@4.21.0)(typescript@5.9.3)(yaml@2.8.3)':
+  '@voidzero-dev/vite-plus-test@0.1.16(@opentelemetry/api@1.9.1)(@types/node@24.12.2)(esbuild@0.28.0)(jiti@2.7.0)(jsdom@29.0.2)(tsx@4.21.0)(typescript@5.9.3)(vite@7.3.2(@types/node@24.12.2)(jiti@2.7.0)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.8.3))(yaml@2.8.3)':
     dependencies:
       '@standard-schema/spec': 1.1.0
       '@types/chai': 5.2.3
@@ -17056,10 +17067,10 @@ snapshots:
       sirv: 3.0.2
       std-env: 4.0.0
       tinybench: 2.9.0
-      tinyexec: 1.1.1
+      tinyexec: 1.2.2
       tinyglobby: 0.2.16
-      vite: '@voidzero-dev/vite-plus-core@0.1.16(@types/node@24.12.2)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.21.0)(typescript@5.9.3)(yaml@2.8.3)'
-      ws: 8.20.0
+      vite: 7.3.2(@types/node@24.12.2)(jiti@2.7.0)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.8.3)
+      ws: 8.20.1
     optionalDependencies:
       '@opentelemetry/api': 1.9.1
       '@types/node': 24.12.2
@@ -22143,8 +22154,6 @@ snapshots:
 
   tinyexec@0.3.2: {}
 
-  tinyexec@1.1.1: {}
-
   tinyexec@1.2.2: {}
 
   tinyglobby@0.2.16:
@@ -22261,7 +22270,7 @@ snapshots:
       rolldown: 1.0.0-rc.13
       rolldown-plugin-dts: 0.13.14(rolldown@1.0.0-rc.13)(typescript@5.8.3)
       semver: 7.7.4
-      tinyexec: 1.1.1
+      tinyexec: 1.2.2
       tinyglobby: 0.2.16
       unconfig: 7.5.0
     optionalDependencies:
@@ -22957,11 +22966,11 @@ snapshots:
       - vite
       - yaml
 
-  vite-plus@0.1.16(@opentelemetry/api@1.9.1)(@types/node@24.12.2)(@voidzero-dev/vite-plus-core@0.1.16(@types/node@24.12.2)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.21.0)(typescript@5.9.3)(yaml@2.8.3))(esbuild@0.28.0)(jiti@2.7.0)(jsdom@29.0.2)(tsx@4.21.0)(typescript@5.9.3)(yaml@2.8.3):
+  vite-plus@0.1.16(@opentelemetry/api@1.9.1)(@types/node@24.12.2)(esbuild@0.28.0)(jiti@2.7.0)(jsdom@29.0.2)(tsx@4.21.0)(typescript@5.9.3)(vite@7.3.2(@types/node@24.12.2)(jiti@2.7.0)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.8.3))(yaml@2.8.3):
     dependencies:
       '@oxc-project/types': 0.123.0
       '@voidzero-dev/vite-plus-core': 0.1.16(@types/node@24.12.2)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.21.0)(typescript@5.9.3)(yaml@2.8.3)
-      '@voidzero-dev/vite-plus-test': 0.1.16(@opentelemetry/api@1.9.1)(@types/node@24.12.2)(@voidzero-dev/vite-plus-core@0.1.16(@types/node@24.12.2)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.21.0)(typescript@5.9.3)(yaml@2.8.3))(esbuild@0.28.0)(jiti@2.7.0)(jsdom@29.0.2)(tsx@4.21.0)(typescript@5.9.3)(yaml@2.8.3)
+      '@voidzero-dev/vite-plus-test': 0.1.16(@opentelemetry/api@1.9.1)(@types/node@24.12.2)(esbuild@0.28.0)(jiti@2.7.0)(jsdom@29.0.2)(tsx@4.21.0)(typescript@5.9.3)(vite@7.3.2(@types/node@24.12.2)(jiti@2.7.0)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.8.3))(yaml@2.8.3)
       oxfmt: 0.43.0
       oxlint: 1.58.0(oxlint-tsgolint@0.20.0)
       oxlint-tsgolint: 0.20.0
@@ -23012,6 +23021,22 @@ snapshots:
       tinyglobby: 0.2.16
     optionalDependencies:
       '@types/node': 20.19.37
+      fsevents: 2.3.3
+      jiti: 2.7.0
+      lightningcss: 1.32.0
+      tsx: 4.21.0
+      yaml: 2.8.3
+
+  vite@7.3.2(@types/node@24.12.2)(jiti@2.7.0)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.8.3):
+    dependencies:
+      esbuild: 0.27.0
+      fdir: 6.5.0(picomatch@4.0.4)
+      picomatch: 4.0.4
+      postcss: 8.5.9
+      rollup: 4.59.0
+      tinyglobby: 0.2.16
+    optionalDependencies:
+      '@types/node': 24.12.2
       fsevents: 2.3.3
       jiti: 2.7.0
       lightningcss: 1.32.0
@@ -23114,7 +23139,7 @@ snapshots:
       deepmerge-ts: 5.1.0
       got: 12.6.1
       ky: 0.33.3
-      ws: 8.20.0
+      ws: 8.20.1
     transitivePeerDependencies:
       - bare-abort-controller
       - bare-buffer


### PR DESCRIPTION
## Summary

- Extract Sift's row-count odometer into a reusable `@nteract/odometer` workspace package.
- Wire Sift's stats bar to the shared primitive and remove the Sift-local odometer implementation/styles.
- Add odometer tests for accessibility metadata, changing-length labels, reduced motion, preference toggling, and digit wrap snapping.
- Replace Sift's `build:lib` Tailwind CSS step with an in-repo script so the build uses the workspace-installed Tailwind compiler instead of `npx` installing a different CLI version.

## Verification

- [x] `pnpm exec vp test run packages/odometer/tests/index.test.ts --environment jsdom`
  - 6 passed
- [x] `pnpm --filter @nteract/sift test -- --run src/table.test.ts --environment jsdom`
  - 177 passed
- [x] `pnpm --filter @nteract/sift build`
- [x] `pnpm --filter @nteract/sift build:lib`
- [x] `UV_CACHE_DIR=/tmp/uv-cache cargo xtask lint --fix`

## Notes

- `@nteract/odometer` is currently private workspace package metadata. Follow-up can decide if/when to publish it externally.
- The visible animated slots are marked `aria-hidden`; the host carries the readable `aria-label` and `data-value` for tests.
