### PR TITLE
refactor(notebook): share runtime store projection

### DIFF
--- a/apps/notebook-cloud/test/viewer-shared-cell-surface.test.ts
+++ b/apps/notebook-cloud/test/viewer-shared-cell-surface.test.ts
@@ -82,10 +82,7 @@ test("cloud viewer imports desktop notebook code only through public surfaces", 
         // behavior for shared notebook components.
         (fileName === "index.tsx" &&
           (importPath.endsWith("/lib/logger") || importPath.endsWith("/lib/open-url"))) ||
-        importPath.endsWith("/notebook-surface") ||
-        // Headless store surface: same public symbols, no component/CSS
-        // imports, so node-run tests can exercise the bridge directly.
-        importPath.endsWith("/notebook-surface-stores")
+        importPath.endsWith("/notebook-surface")
       ) {
         continue;
       }
@@ -144,6 +141,37 @@ test("cloud live changesets gate stale post-await status writes", () => {
     sessionSourceText,
     /const materializeLiveChangeset = async[\s\S]*const sequence = materializeSequence;[\s\S]*await materializeChangeset[\s\S]*if \(disposed \|\| sequence !== materializeSequence\) return;[\s\S]*applyExecutionViewChangeset/,
   );
+});
+
+test("cloud runtime store projection comes from the shared store module", () => {
+  const bridgeSourcePath = new URL("../viewer/notebook-view-store-bridge.ts", import.meta.url);
+  const bridgeSourceText = readFileSync(bridgeSourcePath, "utf8");
+  const sessionSourcePath = new URL("../viewer/cloud-viewer-session.ts", import.meta.url);
+  const sessionSourceText = readFileSync(sessionSourcePath, "utf8");
+
+  assert.match(
+    bridgeSourceText,
+    /from ["']@\/components\/notebook\/state\/runtime-store-projection["']/,
+  );
+  assert.match(
+    sessionSourceText,
+    /from ["']@\/components\/notebook\/state\/runtime-store-projection["']/,
+  );
+  assert.doesNotMatch(bridgeSourceText, /notebook-surface-stores/);
+  assert.doesNotMatch(sessionSourceText, /notebook-surface-stores/);
+
+  const notebookSurfaceImports = [
+    ...sessionSourceText.matchAll(
+      /import\s+{([^}]*)}\s+from\s+["']\.\.\/\.\.\/notebook\/src\/notebook-surface["']/g,
+    ),
+  ];
+  for (const importMatch of notebookSurfaceImports) {
+    const importList = importMatch[1] ?? "";
+    assert.doesNotMatch(
+      importList,
+      /\b(applyExecutionViewChangeset|applyOutputChangeset|resetRuntimeStoresProjection)\b/,
+    );
+  }
 });
 
 test("cloud notebook mutations route through the shared notebook controller", () => {

--- a/apps/notebook-cloud/viewer/cloud-viewer-session.ts
+++ b/apps/notebook-cloud/viewer/cloud-viewer-session.ts
@@ -12,20 +12,22 @@ import {
 import { setCrdtCommWriter } from "@/components/widgets/crdt-comm-writer";
 import type { WidgetStore } from "@/components/widgets/widget-store";
 import {
+  applyExecutionViewChangeset,
+  applyOutputChangeset,
+  resetRuntimeStoresProjection,
+} from "@/components/notebook/state/runtime-store-projection";
+import {
   cloudConnectionErrorAcceptsAccessDiagnostic,
   cloudConnectionErrorWithAccessDiagnostic,
   diagnoseCloudConnectionAccess,
   isCloudConnectionAccessDiagnostic,
 } from "./connection-diagnostics";
 import {
-  applyExecutionViewChangeset,
-  applyOutputChangeset,
   emitBroadcast,
   emitPresence,
   getCellIdsSnapshot,
   materializeChangeset,
   resetPoolState,
-  resetRuntimeStoresProjection,
   startCursorDispatch,
   setPoolState,
   type CellChangeset,

--- a/apps/notebook-cloud/viewer/notebook-view-store-bridge.ts
+++ b/apps/notebook-cloud/viewer/notebook-view-store-bridge.ts
@@ -1,7 +1,7 @@
 import { shouldPreserveCurrentNotebookProjection } from "@/components/notebook/state/projection-lifecycle";
 import { createNotebookViewStoreProjector } from "@/components/notebook/state/view-store-projection";
 import { resetRuntimeState } from "@/components/notebook/state/runtime-state";
-import { resetRuntimeStoresProjection } from "../../notebook/src/notebook-surface-stores";
+import { resetRuntimeStoresProjection } from "@/components/notebook/state/runtime-store-projection";
 import type { ResolvedCell } from "./render-resolution";
 
 const cloudViewStoreProjector = createNotebookViewStoreProjector();

--- a/apps/notebook/src/components/NotebookView.tsx
+++ b/apps/notebook/src/components/NotebookView.tsx
@@ -43,7 +43,7 @@ import {
   useOutputFocusedCellId,
 } from "@/components/notebook/state/output-focus-store";
 import { logger } from "../lib/logger";
-import { useOutputProjectionFailures } from "../lib/project-runtime-stores";
+import { useOutputProjectionFailures } from "@/components/notebook/state/runtime-store-projection";
 import { computeCanMutateCells } from "@/components/notebook/mutation-gate";
 import {
   getCellById,

--- a/apps/notebook/src/lib/project-runtime-stores.ts
+++ b/apps/notebook/src/lib/project-runtime-stores.ts
@@ -1,200 +1,65 @@
 /**
- * Projection glue between the SyncEngine and the per-execution / per-output
- * React stores.
+ * Desktop glue between SyncEngine events and the shared runtime/output stores.
  *
- * Splitting this out of `useAutomergeNotebook` keeps the hook focused on
- * React wiring and avoids pulling the outputs store's imports into the
- * materialization pipeline.
+ * The store mutation and retry logic lives in shared notebook state so desktop
+ * and cloud render from the same facts. This module supplies desktop-only
+ * concerns: blob resolver discovery, logging, and performance marks.
  *
- * `output_id` is a daemon-side invariant — `create_manifest` always
- * stamps one (and `outputs_to_manifest_refs` stamps a fallback on the
- * error path). Every output that reaches the frontend has a real id, so
- * there is no synthetic `legacy:<eid>:<idx>` key in these stores.
+ * `output_id` is a daemon-side invariant — `create_manifest` always stamps one
+ * (and `outputs_to_manifest_refs` stamps a fallback on the error path). Every
+ * output that reaches the frontend has a real id, so there is no synthetic
+ * `legacy:<eid>:<idx>` key in these stores.
  */
 
-import { useSyncExternalStore } from "react";
 import type { ExecutionViewChangeset } from "runtimed";
-import type { HostBlobResolver } from "@nteract/notebook-host";
-import type { JupyterOutput } from "../types";
 import type { NotebookHandle } from "../wasm/runtimed-wasm/runtimed_wasm.js";
 import { getBlobResolver, refreshBlobResolver } from "./blob-port";
+import { getExecutionById, setExecution } from "@/components/notebook/state/execution-store";
+import { getOutputById, setOutput } from "@/components/notebook/state/output-store";
+import { markExecutionPerformance } from "./execution-performance";
 import { logger } from "./logger";
 import {
-  type OutputManifest,
-  resolveManifest,
-  resolveManifestSync,
-} from "./manifest-resolution";
-import { isOutputManifest } from "./materialize-cells";
-import {
-  deleteExecutions,
-  getExecutionById,
-  markExecutionsRuntimeOwned,
-  resetNotebookExecutions,
-  setCellExecutionPointer,
-  setExecution,
-  setNotebookQueueProjection,
-} from "@/components/notebook/state/execution-store";
-import {
-  deleteOutputs,
-  getOutputById,
-  resetNotebookOutputs,
-  setOutput,
-} from "@/components/notebook/state/output-store";
-import { markExecutionPerformance } from "./execution-performance";
+  applyExecutionViewChangeset as applyExecutionViewChangesetToStores,
+  applyOutputChangeset as applyOutputChangesetToStores,
+  getOutputProjectionFailures,
+  resetRuntimeStoresProjection,
+  resolveOutputProjectionSync,
+  subscribeOutputProjectionFailures,
+  useOutputProjectionFailures,
+  type ApplyOutputChangesetOptions as SharedApplyOutputChangesetOptions,
+} from "@/components/notebook/state/runtime-store-projection";
 
-export interface ApplyOutputChangesetOptions {
-  /**
-   * Host-provided resolver for callers that already own blob access.
-   *
-   * Desktop leaves this unset and falls back to the blob-port store. Cloud
-   * passes its authenticated HTTP resolver so runtime-state projection does
-   * not depend on desktop host discovery.
-   */
-  blobResolver?: HostBlobResolver | null;
-  refreshBlobResolver?: () => Promise<HostBlobResolver | null>;
-  /** Test hook: per-attempt retry delay override (default 250ms, 1s). */
-  retryDelaysMs?: readonly number[];
-}
+export {
+  getOutputProjectionFailures,
+  resetRuntimeStoresProjection,
+  subscribeOutputProjectionFailures,
+  useOutputProjectionFailures,
+};
 
-// ── Output projection failure surface (FSB-1) ────────────────────────
-//
-// A failed manifest resolution used to be swallowed at `warn`, leaving the
-// output store silently stale. Failures are now retried with bounded
-// backoff, and outputs that still fail are recorded here so UI and
-// diagnostics can see "N outputs failed to load" instead of nothing.
-// A later successful resolution (next changeset tick, reconnect) clears
-// the entry.
+export interface ApplyOutputChangesetOptions
+  extends Omit<SharedApplyOutputChangesetOptions, "logger" | "onOutputApplied"> {}
 
-const OUTPUT_RETRY_DELAYS_MS: readonly number[] = [250, 1000];
-
-// ── Per-output write generations ─────────────────────────────────────
-//
-// `applyOutputChangeset` calls are NOT serialized (desktop bridge and the
-// cloud session both fire-and-forget each outputIdChanges$ tick), and the
-// retry backoff suspends mid-loop. Without a guard, an older tick's retry
-// can resume after a newer tick removed or replaced the same output id and
-// unconditionally write — resurrecting a deleted output or downgrading a
-// newer manifest to an older one. Each tick stamps a fresh generation per
-// output id it touches; a write only lands if its generation is still
-// current when the async work completes.
-
-const outputGenerations = new Map<string, number>();
-let nextOutputGeneration = 0;
-
-function stampOutputGeneration(output_id: string): number {
-  const generation = ++nextOutputGeneration;
-  outputGenerations.set(output_id, generation);
-  return generation;
-}
-
-function outputGenerationIsCurrent(output_id: string, generation: number): boolean {
-  return outputGenerations.get(output_id) === generation;
-}
-
-const failedOutputIds = new Set<string>();
-const failureSubscribers = new Set<() => void>();
-let failureSnapshot: readonly string[] = [];
-
-function notifyFailureSubscribers(): void {
-  failureSnapshot = [...failedOutputIds];
-  for (const cb of failureSubscribers) {
-    try {
-      cb();
-    } catch {
-      // Subscriber errors must not break the dispatch loop.
-    }
-  }
-}
-
-function recordOutputProjectionFailure(output_id: string): void {
-  if (failedOutputIds.has(output_id)) return;
-  failedOutputIds.add(output_id);
-  notifyFailureSubscribers();
-}
-
-function clearOutputProjectionFailure(output_id: string): void {
-  if (!failedOutputIds.delete(output_id)) return;
-  notifyFailureSubscribers();
-}
-
-/** Output ids whose projection failed after retries (stale in the store). */
-export function getOutputProjectionFailures(): readonly string[] {
-  return failureSnapshot;
-}
-
-/** Subscribe to projection-failure changes. Returns an unsubscribe fn. */
-export function subscribeOutputProjectionFailures(cb: () => void): () => void {
-  failureSubscribers.add(cb);
-  return () => {
-    failureSubscribers.delete(cb);
-  };
-}
-
-/**
- * Subscribe to the projection-failure list. NotebookView renders the
- * "N outputs failed to load" banner from this; both hosts project through
- * `applyOutputChangeset`, so the surface is cross-host by construction.
- */
-export function useOutputProjectionFailures(): readonly string[] {
-  return useSyncExternalStore(
-    subscribeOutputProjectionFailures,
-    getOutputProjectionFailures,
-    getOutputProjectionFailures,
-  );
-}
-
-function sleep(ms: number): Promise<void> {
-  return new Promise((resolve) => setTimeout(resolve, ms));
-}
-
-/**
- * Apply the cross-document execution materialized-view changeset emitted by
- * WASM.
- *
- * Rust owns the diff between NotebookDoc cell pointers and RuntimeStateDoc
- * execution entries. The React stores are intentionally thin subscription
- * containers; they no longer rescan RuntimeStateDoc snapshots or ask the
- * handle to refresh every cell pointer after each sync tick.
- */
 export function applyExecutionViewChangeset(
   changeset: ExecutionViewChangeset | null | undefined,
 ): void {
-  if (!changeset) return;
-
-  for (const [execution_id, snapshot] of changeset.execution_upserts ?? []) {
-    markExecutionsRuntimeOwned([execution_id]);
-    setExecution(execution_id, snapshot);
-    markExecutionPerformance(`runtime.execution.snapshot.${snapshot.status}`, {
-      executionId: execution_id,
-      outputCount: snapshot.output_ids.length,
-      executionCount: snapshot.execution_count,
-    });
-  }
-
-  const removedExecutionIds = changeset.removed_execution_ids ?? [];
-  if (removedExecutionIds.length > 0) {
-    deleteExecutions(removedExecutionIds);
-  }
-
-  for (const [cell_id, execution_id] of changeset.cell_pointer_changes ?? []) {
-    setCellExecutionPointer(cell_id, execution_id);
-  }
-
-  if (changeset.queue?.notebook) {
-    setNotebookQueueProjection({
-      executing_cell_id: changeset.queue.notebook.executing_cell_id ?? null,
-      queued_cell_ids: changeset.queue.notebook.queued_cell_ids,
-    });
-  }
+  applyExecutionViewChangesetToStores(changeset, {
+    onExecutionSnapshot: (executionId, snapshot) => {
+      markExecutionPerformance(`runtime.execution.snapshot.${snapshot.status}`, {
+        executionId,
+        outputCount: snapshot.output_ids.length,
+        executionCount: snapshot.execution_count,
+      });
+    },
+  });
 }
 
 /**
  * Seed the outputs / executions stores directly from the WASM handle.
  *
- * `initialSyncComplete$` can fire before the RuntimeStateDoc sync frame
- * lands. Walking the handle for each cell's current `execution_id` keeps
- * any outputs already stored in the notebook doc visible immediately rather
- * than waiting for the runtime-state catch-up tick.
+ * `initialSyncComplete$` can fire before the RuntimeStateDoc sync frame lands.
+ * Walking the handle for each cell's current `execution_id` keeps any outputs
+ * already stored in the notebook doc visible immediately rather than waiting
+ * for the runtime-state catch-up tick.
  */
 export function seedOutputStoresFromHandle(
   handle: NotebookHandle,
@@ -206,8 +71,8 @@ export function seedOutputStoresFromHandle(
     const rawOutputs = (handle.get_cell_outputs(cellId) as unknown[]) ?? [];
     if (rawOutputs.length === 0) continue;
 
-    const output_ids = collectOutputIds(rawOutputs);
-    if (output_ids.length === 0) continue;
+    const outputIds = collectOutputIds(rawOutputs);
+    if (outputIds.length === 0) continue;
 
     // Build a minimal execution snapshot only when Rust has not already
     // projected the authoritative RuntimeStateDoc entry. Runtime sync can
@@ -218,169 +83,43 @@ export function seedOutputStoresFromHandle(
         execution_count: null,
         status: "done",
         success: null,
-        output_ids,
+        output_ids: outputIds,
       });
     }
 
     // Populate the outputs store for each output. Plain JupyterOutputs
-    // (already resolved by full materialization) go in directly;
-    // manifests kick through the sync resolver.
+    // (already resolved by full materialization) go in directly; manifests kick
+    // through a sync resolver when possible.
     for (let i = 0; i < rawOutputs.length; i++) {
       const output = rawOutputs[i];
       if (!output || typeof output !== "object") continue;
-      const oid = output_ids[i];
-      if (!oid) continue;
-      const existing = getOutputById(oid);
+      const outputId = outputIds[i];
+      if (!outputId) continue;
+      const existing = getOutputById(outputId);
       if (existing === output) continue;
-      const sync = tryResolveSync(output, getBlobResolver());
-      if (sync) setOutput(oid, sync);
+      const sync = resolveOutputProjectionSync(output, getBlobResolver());
+      if (sync) setOutput(outputId, sync);
     }
   }
 }
 
-// ── Outputs store projection ─────────────────────────────────────────
-
-/**
- * Apply the per-output changeset emitted by WASM.
- *
- * `changed` carries `(output_id, narrowed_manifest)` pairs — manifests
- * are already MIME-narrowed and have binary ContentRefs resolved to
- * `{url}` variants. The only remaining work here is fetching text blob
- * refs (which still require an HTTP round trip) before handing the
- * fully-resolved `JupyterOutput` to the store.
- *
- * Removed output_ids are dropped from the store.
- */
 export async function applyOutputChangeset(
   changed: Array<[string, unknown]>,
   removed_ids: string[],
   options: ApplyOutputChangesetOptions = {},
 ): Promise<void> {
-  if (removed_ids.length > 0) {
-    deleteOutputs(removed_ids);
-    // Removal supersedes any in-flight resolution for these ids: bump the
-    // generation so a suspended older tick cannot resurrect them.
-    for (const output_id of removed_ids) {
-      stampOutputGeneration(output_id);
-    }
-    let droppedFailure = false;
-    for (const output_id of removed_ids) {
-      droppedFailure = failedOutputIds.delete(output_id) || droppedFailure;
-    }
-    if (droppedFailure) notifyFailureSubscribers();
-  }
-  if (changed.length === 0) return;
-
-  // Stamp this tick's generation for every output it will write — before
-  // the first await, so a later tick that touches the same ids invalidates
-  // this one even while it is suspended in resolver discovery or retry.
-  const generations = new Map<string, number>();
-  for (const [output_id] of changed) {
-    generations.set(output_id, stampOutputGeneration(output_id));
-  }
-  const writeIsCurrent = (output_id: string) =>
-    outputGenerationIsCurrent(output_id, generations.get(output_id) ?? -1);
-
-  // Stream/display-update manifests with text blob refs need host blob access.
-  // Fetch it on demand so a race between the first manifest and resolver
-  // discovery doesn't drop outputs on the floor.
-  let blobResolver =
+  const blobResolver =
     "blobResolver" in options ? options.blobResolver ?? null : getBlobResolver();
-  if (blobResolver === null && changed.some(([, raw]) => isOutputManifest(raw))) {
-    blobResolver = options.refreshBlobResolver
-      ? await options.refreshBlobResolver()
-      : await refreshBlobResolver();
-  }
 
-  const retryDelays = options.retryDelaysMs ?? OUTPUT_RETRY_DELAYS_MS;
-  for (const [output_id, raw] of changed) {
-    if (!writeIsCurrent(output_id)) continue;
-    const sync = tryResolveSync(raw, blobResolver);
-    if (sync) {
-      setOutput(output_id, sync);
-      clearOutputProjectionFailure(output_id);
-      markExecutionPerformance("runtime.output.applied", { outputId: output_id });
-      continue;
-    }
-    if (blobResolver === null) {
-      logger.warn(
-        `[outputs-store] blob resolver unavailable; deferring output ${output_id}`,
-      );
-      recordOutputProjectionFailure(output_id);
-      continue;
-    }
-    if (!isOutputManifest(raw)) continue;
-    // Retry transient resolution failures (blob HTTP blips) with bounded
-    // backoff before declaring the output stale (FSB-1). Only the final
-    // outcome is logged; per-attempt noise stays at debug. Every resume
-    // from an await re-checks the generation: a newer tick that wrote or
-    // removed this output id makes this older attempt a silent no-op.
-    let resolvedOk = false;
-    for (let attempt = 0; attempt <= retryDelays.length; attempt++) {
-      try {
-        const resolved = await resolveManifest(raw, blobResolver);
-        if (!writeIsCurrent(output_id)) {
-          resolvedOk = true; // superseded, not failed
-          break;
-        }
-        setOutput(output_id, resolved);
-        clearOutputProjectionFailure(output_id);
-        markExecutionPerformance("runtime.output.applied", { outputId: output_id });
-        resolvedOk = true;
-        break;
-      } catch (err) {
-        if (attempt < retryDelays.length) {
-          logger.debug(
-            `[outputs-store] resolve attempt ${attempt + 1} failed for ${output_id}; retrying`,
-          );
-          await sleep(retryDelays[attempt]);
-          if (!writeIsCurrent(output_id)) {
-            resolvedOk = true; // superseded while sleeping
-            break;
-          }
-        } else {
-          logger.warn(
-            `[outputs-store] Failed to resolve output ${output_id} after ${attempt + 1} attempts:`,
-            err,
-          );
-        }
-      }
-    }
-    if (!resolvedOk && writeIsCurrent(output_id)) {
-      recordOutputProjectionFailure(output_id);
-    }
-  }
-}
-
-function tryResolveSync(
-  raw: unknown,
-  blobResolver: HostBlobResolver | null,
-): JupyterOutput | null {
-  if (isOutputManifest(raw)) {
-    if (blobResolver === null) return null;
-    return resolveManifestSync(raw as OutputManifest, blobResolver);
-  }
-  // Plain JupyterOutput object — no refs, no resolution needed.
-  if (typeof raw === "object" && raw !== null && "output_type" in raw) {
-    return raw as JupyterOutput;
-  }
-  if (typeof raw === "string") {
-    try {
-      return JSON.parse(raw) as JupyterOutput;
-    } catch {
-      return null;
-    }
-  }
-  return null;
-}
-
-export function resetRuntimeStoresProjection(): void {
-  resetNotebookExecutions();
-  resetNotebookOutputs();
-  if (failedOutputIds.size > 0) {
-    failedOutputIds.clear();
-    notifyFailureSubscribers();
-  }
+  await applyOutputChangesetToStores(changed, removed_ids, {
+    ...options,
+    blobResolver,
+    refreshBlobResolver: options.refreshBlobResolver ?? refreshBlobResolver,
+    logger,
+    onOutputApplied: (outputId) => {
+      markExecutionPerformance("runtime.output.applied", { outputId });
+    },
+  });
 }
 
 function collectOutputIds(outputs: readonly unknown[] | undefined): string[] {

--- a/apps/notebook/src/notebook-surface-stores.ts
+++ b/apps/notebook/src/notebook-surface-stores.ts
@@ -1,8 +1,0 @@
-/**
- * Temporary headless slice of the notebook public surface for runtime
- * execution/output projection reset.
- *
- * TODO: move this reset path with the runtime execution/output projection
- * failure store so cloud no longer needs a desktop-app headless facade.
- */
-export { resetRuntimeStoresProjection } from "./lib/project-runtime-stores";

--- a/docs/adr/shared-store-projection-convergence.md
+++ b/docs/adr/shared-store-projection-convergence.md
@@ -86,6 +86,14 @@ the flush strands the update (marked dirty, never emitted).
   for raster-preview payload updates under an existing output id. There is no
   rendered-view fallback to materialized `cell.outputs`; hosts and import paths
   must seed execution/output stores for output-bearing code cells.
+- **Runtime/output changeset projection → shared store projection.**
+  `src/components/notebook/state/runtime-store-projection.ts` now owns
+  RuntimeStateDoc execution changeset application, output changeset application,
+  projection-failure subscriptions, and runtime/output store reset. Hosts inject
+  blob resolution, logging, and observability callbacks; the shared reset
+  invalidates suspended output retries so stale async blob resolutions cannot
+  repaint after notebook teardown or switch. Cloud imports these headless
+  helpers directly instead of reaching through a desktop-only store facade.
 
 ## Remaining work (ranked)
 

--- a/docs/plans/notebook-surface-library-refactor-checklist.md
+++ b/docs/plans/notebook-surface-library-refactor-checklist.md
@@ -28,13 +28,14 @@ concerns.
 
 ## Active Checklist
 
-- [ ] Remove cloud-to-desktop app imports for headless projection/store/reset
+- [x] Remove cloud-to-desktop app imports for headless projection/store/reset
       behavior. Cloud may keep the intentional component bridge through
       `notebook-surface` while shared component packaging is still app-owned,
       but headless store/projection helpers should live in shared modules.
       Runtime-state reads/writes now import from
-      `src/components/notebook/state/runtime-state.ts`; remaining blockers are
-      the heavier runtime store projection reset.
+      `src/components/notebook/state/runtime-state.ts`; runtime/output store
+      projection and reset now import from
+      `src/components/notebook/state/runtime-store-projection.ts`.
 - [x] Make output identity strict for modern cloud/runtime paths: missing
       `output_id` values now render as invariant errors instead of receiving
       `cloud-output:*` positional IDs in the cloud resolver.
@@ -54,9 +55,10 @@ concerns.
 - [ ] Extract reusable RxJS projection-store patterns only after concrete
       duplicated stores prove the shape. Avoid generic factories that hide
       simple store logic without reducing real coupling.
-- [ ] Add import guard tests so Cloud cannot depend on Desktop app internals
-      for shared headless behavior. The current guard still allows
-      `notebook-surface-stores` as a temporary exception.
+- [x] Add import guard tests so Cloud cannot depend on Desktop app internals
+      for shared headless behavior. The guard no longer allows
+      `notebook-surface-stores` and asserts runtime/output projection helpers
+      come from shared state rather than the desktop surface import.
 - [ ] Keep durable docs updated as boundaries become real decisions. Amend this
       checklist for execution status; amend ADRs only when the boundary becomes
       durable architecture.
@@ -76,6 +78,13 @@ concerns.
 
 ## Completed Slices
 
+- 2026-06-14: Promoted runtime/output store projection to
+  `src/components/notebook/state/runtime-store-projection.ts`. Desktop keeps a
+  thin wrapper for blob resolver discovery, logging, and execution performance
+  marks; Cloud imports execution changesets, output changesets, and runtime
+  store reset directly from the shared module. Reset now invalidates in-flight
+  async output projection retries so stale blob resolutions cannot repaint a
+  switched or unmounted notebook.
 - 2026-06-14: Cloud render resolution no longer stamps missing output IDs with
   `cloud-output:*`; missing IDs are visible invariant errors with diagnostic
   `resolution-error:missing-output-id:*` identities.

--- a/src/components/notebook/__tests__/runtime-store-projection.test.ts
+++ b/src/components/notebook/__tests__/runtime-store-projection.test.ts
@@ -1,0 +1,164 @@
+import { afterEach, describe, expect, it, vi } from "vite-plus/test";
+import {
+  getCellExecutionId,
+  getExecutionById,
+  getNotebookQueueProjection,
+  isExecutionRuntimeOwned,
+} from "@/components/notebook/state/execution-store";
+import { getOutputById } from "@/components/notebook/state/output-store";
+import {
+  applyExecutionViewChangeset,
+  applyOutputChangeset,
+  getOutputProjectionFailures,
+  resetRuntimeStoresProjection,
+  subscribeOutputProjectionFailures,
+} from "@/components/notebook/state/runtime-store-projection";
+
+afterEach(() => {
+  resetRuntimeStoresProjection();
+});
+
+describe("runtime store projection", () => {
+  it("upserts runtime-owned execution snapshots and reports them to observers", () => {
+    const observed: string[] = [];
+
+    applyExecutionViewChangeset(
+      {
+        execution_upserts: [
+          [
+            "exec-1",
+            {
+              execution_count: 1,
+              status: "running",
+              success: null,
+              output_ids: ["out-1"],
+            },
+          ],
+        ],
+      },
+      {
+        onExecutionSnapshot: (executionId, snapshot) => {
+          observed.push(`${executionId}:${snapshot.status}:${snapshot.output_ids.length}`);
+        },
+      },
+    );
+
+    expect(getExecutionById("exec-1")).toEqual({
+      execution_count: 1,
+      status: "running",
+      success: null,
+      output_ids: ["out-1"],
+    });
+    expect(isExecutionRuntimeOwned("exec-1")).toBe(true);
+    expect(observed).toEqual(["exec-1:running:1"]);
+  });
+
+  it("applies execution pointers, removals, and queue projection", () => {
+    applyExecutionViewChangeset({
+      execution_upserts: [
+        [
+          "exec-1",
+          {
+            execution_count: 1,
+            status: "done",
+            success: true,
+            output_ids: [],
+          },
+        ],
+      ],
+      cell_pointer_changes: [["cell-1", "exec-1"]],
+      queue: {
+        executing_execution_id: "exec-1",
+        queued_execution_ids: [],
+        notebook: {
+          executing_cell_id: "cell-1",
+          queued_cell_ids: ["cell-2"],
+        },
+      },
+    });
+
+    expect(getCellExecutionId("cell-1")).toBe("exec-1");
+    expect(getNotebookQueueProjection()).toEqual({
+      executing_cell_id: "cell-1",
+      queued_cell_ids: ["cell-2"],
+    });
+
+    applyExecutionViewChangeset({ removed_execution_ids: ["exec-1"] });
+
+    expect(getExecutionById("exec-1")).toBeUndefined();
+    expect(getCellExecutionId("cell-1")).toBeNull();
+    expect(isExecutionRuntimeOwned("exec-1")).toBe(false);
+  });
+
+  it("surfaces output projection failures and clears them on removal", async () => {
+    const failureEvents: number[] = [];
+    const unsubscribe = subscribeOutputProjectionFailures(() => {
+      failureEvents.push(getOutputProjectionFailures().length);
+    });
+
+    await applyOutputChangeset(
+      [
+        [
+          "out-fail",
+          {
+            output_id: "out-fail",
+            output_type: "stream",
+            name: "stdout",
+            text: { blob: "blob-f", size: 5 },
+          },
+        ],
+      ],
+      [],
+      { blobResolver: null },
+    );
+
+    expect(getOutputProjectionFailures()).toEqual(["out-fail"]);
+    await applyOutputChangeset([], ["out-fail"]);
+
+    expect(getOutputProjectionFailures()).toEqual([]);
+    expect(failureEvents).toEqual([1, 0]);
+    unsubscribe();
+  });
+
+  it("reset invalidates suspended output projection writes", async () => {
+    let releaseFirstAttempt: (() => void) | undefined;
+    const firstAttemptStarted = new Promise<void>((resolve) => {
+      releaseFirstAttempt = () => resolve();
+    });
+    let failFirst = true;
+    const blobResolver = {
+      url: (ref: { blob: string }) => `https://example.test/blob/${ref.blob}`,
+      fetch: vi.fn(async () => {
+        if (failFirst) {
+          failFirst = false;
+          releaseFirstAttempt?.();
+          throw new Error("transient");
+        }
+        return new Response("stale payload");
+      }),
+    };
+
+    const suspendedProjection = applyOutputChangeset(
+      [
+        [
+          "out-stale",
+          {
+            output_id: "out-stale",
+            output_type: "stream",
+            name: "stdout",
+            text: { blob: "blob-stale", size: 13 },
+          },
+        ],
+      ],
+      [],
+      { blobResolver, retryDelaysMs: [20] },
+    );
+
+    await firstAttemptStarted;
+    resetRuntimeStoresProjection();
+    await suspendedProjection;
+
+    expect(getOutputById("out-stale")).toBeUndefined();
+    expect(getOutputProjectionFailures()).toEqual([]);
+  });
+});

--- a/src/components/notebook/index.ts
+++ b/src/components/notebook/index.ts
@@ -78,6 +78,17 @@ export {
   type ProjectNotebookWorkstationLaunchReadinessOptions,
   type ProjectNotebookWorkstationSelectionOptions,
 } from "./capabilities";
+export {
+  applyExecutionViewChangeset,
+  applyOutputChangeset,
+  getOutputProjectionFailures,
+  resetRuntimeStoresProjection,
+  resolveOutputProjectionSync,
+  subscribeOutputProjectionFailures,
+  useOutputProjectionFailures,
+  type ApplyExecutionViewChangesetOptions,
+  type ApplyOutputChangesetOptions,
+} from "./state/runtime-store-projection";
 export { NotebookDocumentShell, type NotebookDocumentShellProps } from "./NotebookDocumentShell";
 export { NotebookDocumentHeader, type NotebookDocumentHeaderProps } from "./NotebookDocumentHeader";
 export {

--- a/src/components/notebook/state/runtime-store-projection.ts
+++ b/src/components/notebook/state/runtime-store-projection.ts
@@ -1,0 +1,293 @@
+import { useSyncExternalStore } from "react";
+import type { ExecutionViewChangeset } from "runtimed";
+import {
+  isOutputManifest,
+  resolveManifest,
+  resolveManifestSync,
+  type BlobResolverInput,
+  type OutputManifest,
+} from "@/components/isolated/output-manifest";
+import {
+  deleteExecutions,
+  markExecutionsRuntimeOwned,
+  resetNotebookExecutions,
+  setCellExecutionPointer,
+  setExecution,
+  setNotebookQueueProjection,
+  type ExecutionSnapshot,
+} from "./execution-store";
+import { deleteOutputs, resetNotebookOutputs, setOutput } from "./output-store";
+import type { NotebookStoreOutput } from "./cell-store";
+
+export interface ApplyExecutionViewChangesetOptions {
+  onExecutionSnapshot?: (executionId: string, snapshot: ExecutionSnapshot) => void;
+}
+
+type ProjectionLogFn = (message?: unknown, ...optionalParams: unknown[]) => void;
+
+export interface ApplyOutputChangesetOptions {
+  /**
+   * Host-provided resolver for callers that already own blob access.
+   *
+   * Desktop callers can omit this and wrap the shared applier with local blob
+   * resolver discovery. Cloud passes its authenticated HTTP resolver so output
+   * projection stays host-neutral.
+   */
+  blobResolver?: BlobResolverInput | null;
+  refreshBlobResolver?: () => Promise<BlobResolverInput | null>;
+  retryDelaysMs?: readonly number[];
+  logger?: {
+    debug?: ProjectionLogFn;
+    warn?: ProjectionLogFn;
+  };
+  onOutputApplied?: (outputId: string) => void;
+}
+
+// Failed manifest resolutions are owned by the shared runtime/output
+// projection, not by a host shell. Desktop and cloud both render the same
+// failure signal from this store.
+const failedOutputIds = new Set<string>();
+const failureSubscribers = new Set<() => void>();
+let failureSnapshot: readonly string[] = [];
+
+function notifyFailureSubscribers(): void {
+  failureSnapshot = [...failedOutputIds];
+  for (const cb of failureSubscribers) {
+    try {
+      cb();
+    } catch {
+      // Subscriber errors must not break the dispatch loop.
+    }
+  }
+}
+
+const OUTPUT_RETRY_DELAYS_MS: readonly number[] = [250, 1000];
+
+// `applyOutputChangeset` calls are not serialized everywhere. Resetting a
+// notebook must invalidate suspended retries, so writes require both the
+// current reset epoch and the per-output generation stamped by the changeset.
+const outputGenerations = new Map<string, number>();
+let nextOutputGeneration = 0;
+let outputProjectionEpoch = 0;
+
+function stampOutputGeneration(outputId: string): number {
+  const generation = ++nextOutputGeneration;
+  outputGenerations.set(outputId, generation);
+  return generation;
+}
+
+function outputGenerationIsCurrent(outputId: string, generation: number, epoch: number): boolean {
+  return outputProjectionEpoch === epoch && outputGenerations.get(outputId) === generation;
+}
+
+function resetOutputProjectionState(): void {
+  outputProjectionEpoch = (outputProjectionEpoch + 1) | 0;
+  outputGenerations.clear();
+  if (failedOutputIds.size === 0) return;
+  failedOutputIds.clear();
+  notifyFailureSubscribers();
+}
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+export function recordOutputProjectionFailure(outputId: string): void {
+  if (failedOutputIds.has(outputId)) return;
+  failedOutputIds.add(outputId);
+  notifyFailureSubscribers();
+}
+
+export function clearOutputProjectionFailure(outputId: string): void {
+  if (!failedOutputIds.delete(outputId)) return;
+  notifyFailureSubscribers();
+}
+
+export function clearOutputProjectionFailures(outputIds: Iterable<string>): void {
+  let changed = false;
+  for (const outputId of outputIds) {
+    changed = failedOutputIds.delete(outputId) || changed;
+  }
+  if (changed) notifyFailureSubscribers();
+}
+
+/** Output ids whose projection failed after retries (stale in the store). */
+export function getOutputProjectionFailures(): readonly string[] {
+  return failureSnapshot;
+}
+
+/** Subscribe to projection-failure changes. Returns an unsubscribe fn. */
+export function subscribeOutputProjectionFailures(cb: () => void): () => void {
+  failureSubscribers.add(cb);
+  return () => {
+    failureSubscribers.delete(cb);
+  };
+}
+
+/**
+ * Subscribe to the projection-failure list. NotebookView renders the
+ * "N outputs failed to load" banner from this; both hosts project through
+ * the shared runtime/output stores.
+ */
+export function useOutputProjectionFailures(): readonly string[] {
+  return useSyncExternalStore(
+    subscribeOutputProjectionFailures,
+    getOutputProjectionFailures,
+    getOutputProjectionFailures,
+  );
+}
+
+export function resolveOutputProjectionSync(
+  raw: unknown,
+  blobResolver: BlobResolverInput | null,
+): NotebookStoreOutput | null {
+  if (isOutputManifest(raw)) {
+    if (blobResolver === null) return null;
+    return resolveManifestSync(raw as OutputManifest, blobResolver);
+  }
+  // Plain JupyterOutput object — no refs, no resolution needed.
+  if (typeof raw === "object" && raw !== null && "output_type" in raw) {
+    return raw as NotebookStoreOutput;
+  }
+  if (typeof raw === "string") {
+    try {
+      return JSON.parse(raw) as NotebookStoreOutput;
+    } catch {
+      return null;
+    }
+  }
+  return null;
+}
+
+/**
+ * Apply the per-output changeset emitted by WASM.
+ *
+ * `changed` carries `(output_id, narrowed_manifest)` pairs. Hosts provide blob
+ * access and optional observability hooks; the store write, failure signal, and
+ * async stale-write suppression are shared across desktop and cloud.
+ */
+export async function applyOutputChangeset(
+  changed: Array<[string, unknown]>,
+  removedIds: string[],
+  options: ApplyOutputChangesetOptions = {},
+): Promise<void> {
+  if (removedIds.length > 0) {
+    deleteOutputs(removedIds);
+    for (const outputId of removedIds) {
+      stampOutputGeneration(outputId);
+    }
+    clearOutputProjectionFailures(removedIds);
+  }
+  if (changed.length === 0) return;
+
+  const epoch = outputProjectionEpoch;
+  const generations = new Map<string, number>();
+  for (const [outputId] of changed) {
+    generations.set(outputId, stampOutputGeneration(outputId));
+  }
+  const writeIsCurrent = (outputId: string) =>
+    outputGenerationIsCurrent(outputId, generations.get(outputId) ?? -1, epoch);
+
+  let blobResolver = options.blobResolver ?? null;
+  if (blobResolver === null && changed.some(([, raw]) => isOutputManifest(raw))) {
+    blobResolver = options.refreshBlobResolver ? await options.refreshBlobResolver() : null;
+  }
+
+  const retryDelays = options.retryDelaysMs ?? OUTPUT_RETRY_DELAYS_MS;
+  for (const [outputId, raw] of changed) {
+    if (!writeIsCurrent(outputId)) continue;
+    const sync = resolveOutputProjectionSync(raw, blobResolver);
+    if (sync) {
+      setOutput(outputId, sync);
+      clearOutputProjectionFailure(outputId);
+      options.onOutputApplied?.(outputId);
+      continue;
+    }
+    if (blobResolver === null) {
+      options.logger?.warn?.(
+        `[outputs-store] blob resolver unavailable; deferring output ${outputId}`,
+      );
+      recordOutputProjectionFailure(outputId);
+      continue;
+    }
+    if (!isOutputManifest(raw)) continue;
+    let resolvedOk = false;
+    for (let attempt = 0; attempt <= retryDelays.length; attempt++) {
+      try {
+        const resolved = await resolveManifest(raw, blobResolver);
+        if (!writeIsCurrent(outputId)) {
+          resolvedOk = true;
+          break;
+        }
+        setOutput(outputId, resolved);
+        clearOutputProjectionFailure(outputId);
+        options.onOutputApplied?.(outputId);
+        resolvedOk = true;
+        break;
+      } catch (err) {
+        if (attempt < retryDelays.length) {
+          options.logger?.debug?.(
+            `[outputs-store] resolve attempt ${attempt + 1} failed for ${outputId}; retrying`,
+          );
+          await sleep(retryDelays[attempt]);
+          if (!writeIsCurrent(outputId)) {
+            resolvedOk = true;
+            break;
+          }
+        } else {
+          options.logger?.warn?.(
+            `[outputs-store] Failed to resolve output ${outputId} after ${attempt + 1} attempts:`,
+            err,
+          );
+        }
+      }
+    }
+    if (!resolvedOk && writeIsCurrent(outputId)) {
+      recordOutputProjectionFailure(outputId);
+    }
+  }
+}
+
+/**
+ * Apply the cross-document execution materialized-view changeset emitted by
+ * WASM.
+ *
+ * Rust owns the diff between NotebookDoc cell pointers and RuntimeStateDoc
+ * execution entries. The React stores are intentionally thin subscription
+ * containers; they no longer rescan RuntimeStateDoc snapshots or ask the
+ * handle to refresh every cell pointer after each sync tick.
+ */
+export function applyExecutionViewChangeset(
+  changeset: ExecutionViewChangeset | null | undefined,
+  options: ApplyExecutionViewChangesetOptions = {},
+): void {
+  if (!changeset) return;
+
+  for (const [executionId, snapshot] of changeset.execution_upserts ?? []) {
+    markExecutionsRuntimeOwned([executionId]);
+    setExecution(executionId, snapshot);
+    options.onExecutionSnapshot?.(executionId, snapshot);
+  }
+
+  const removedExecutionIds = changeset.removed_execution_ids ?? [];
+  if (removedExecutionIds.length > 0) {
+    deleteExecutions(removedExecutionIds);
+  }
+
+  for (const [cellId, executionId] of changeset.cell_pointer_changes ?? []) {
+    setCellExecutionPointer(cellId, executionId);
+  }
+
+  if (changeset.queue?.notebook) {
+    setNotebookQueueProjection({
+      executing_cell_id: changeset.queue.notebook.executing_cell_id ?? null,
+      queued_cell_ids: changeset.queue.notebook.queued_cell_ids,
+    });
+  }
+}
+
+export function resetRuntimeStoresProjection(): void {
+  resetNotebookExecutions();
+  resetNotebookOutputs();
+  resetOutputProjectionState();
+}


### PR DESCRIPTION
## Summary

- Move runtime execution changeset projection, output changeset projection, projection-failure subscriptions, and runtime/output store reset into `src/components/notebook/state/runtime-store-projection.ts`.
- Keep desktop-specific blob discovery, logging, and execution performance marks in a thin `apps/notebook/src/lib/project-runtime-stores.ts` wrapper.
- Point cloud runtime/output projection imports at the shared module, delete the temporary `notebook-surface-stores` facade, and tighten the cloud import guard.
- Invalidate in-flight async output projection retries on reset so stale blob resolutions cannot repaint after notebook teardown or switch.
- Update the shared-store convergence ADR and refactor checklist.

## Verification

- `pnpm test:run -- src/components/notebook/__tests__/runtime-store-projection.test.ts apps/notebook/src/lib/__tests__/project-runtime-stores.test.ts apps/notebook/src/lib/__tests__/notebook-sync-store-bridge.test.ts`
- `pnpm --dir apps/notebook-cloud exec node --import tsx --test test/viewer-shared-cell-surface.test.ts test/cloud-projection-flicker.test.ts`
- `pnpm --dir apps/notebook exec tsc -b --pretty false`
- `pnpm --dir apps/notebook-cloud typecheck`
- `pnpm --dir apps/notebook-cloud build:viewer`
- `cargo xtask lint --fix`
