### PR TITLE
feat(notebook-cloud): wake workstations through SSE control stream

### DIFF
--- a/apps/notebook-cloud/scripts/hosted-workstation-agent.mjs
+++ b/apps/notebook-cloud/scripts/hosted-workstation-agent.mjs
@@ -42,12 +42,12 @@ const workingDirectory = path.resolve(process.env.NOTEBOOK_CLOUD_WORKSTATION_CWD
 const pollIntervalMs = parsePositiveInteger(
   process.env.NOTEBOOK_CLOUD_WORKSTATION_POLL_MS,
   "NOTEBOOK_CLOUD_WORKSTATION_POLL_MS",
-  2_000,
+  60_000,
 );
 const heartbeatIntervalMs = parsePositiveInteger(
   process.env.NOTEBOOK_CLOUD_WORKSTATION_HEARTBEAT_MS,
   "NOTEBOOK_CLOUD_WORKSTATION_HEARTBEAT_MS",
-  20_000,
+  60_000,
 );
 const runtimedBin = path.resolve(
   workspaceRoot,

--- a/apps/notebook-cloud/src/cloudflare-types.ts
+++ b/apps/notebook-cloud/src/cloudflare-types.ts
@@ -1,5 +1,6 @@
 export interface Env {
   NOTEBOOK_ROOMS: DurableObjectNamespace;
+  WORKSTATION_EVENTS?: DurableObjectNamespace;
   DB?: D1Database;
   NOTEBOOK_SNAPSHOTS?: R2Bucket;
   ASSETS?: WorkerAssets;

--- a/apps/notebook-cloud/src/index.ts
+++ b/apps/notebook-cloud/src/index.ts
@@ -1,4 +1,10 @@
-import type { Env, ExecutionContext, ExportedHandler, WorkerAssets } from "./cloudflare-types.ts";
+import type {
+  DurableObjectStub,
+  Env,
+  ExecutionContext,
+  ExportedHandler,
+  WorkerAssets,
+} from "./cloudflare-types.ts";
 import { projectNotebookWorkstationAttachmentFromClaim, type BlobRef } from "runtimed";
 import { NotebookRoom } from "./notebook-room.ts";
 import {
@@ -70,6 +76,11 @@ import {
   workstationCredentialTokenFromRequest,
   workstationPairingStatus,
 } from "./workstation-credentials.ts";
+import {
+  WorkstationEvents,
+  workstationEventsObjectName,
+  type WorkstationAttachJobNotification,
+} from "./workstation-events.ts";
 import { materializeSnapshotPairRender } from "./snapshot-render.ts";
 import { notebookRouteSegmentTitle } from "./notebook-route-title.ts";
 import {
@@ -140,7 +151,7 @@ import {
   trustsLoopbackRequestHeaders,
 } from "./loopback.ts";
 
-export { NotebookRoom };
+export { NotebookRoom, WorkstationEvents };
 
 // `/plugins/*` is a raw static asset path in deployed Workers. Use a
 // Worker-owned route by default so sandboxed srcdoc iframes can fetch sidecar
@@ -317,6 +328,14 @@ const NOTEBOOK_CLOUD_ROUTES: readonly WorkerRoute[] = [
     methods: ["POST"],
     handler: ({ params }, request, env) =>
       routeWorkstationCredentialRevoke(request, env, params.credentialId),
+  },
+  {
+    match: routePath("/api/workstations/:workstationId/events", {
+      trailingSlash: "optional",
+    }),
+    methods: ["GET"],
+    handler: ({ params }, request, env) =>
+      routeWorkstationEvents(request, env, params.workstationId),
   },
   {
     match: routePath("/api/workstations/:workstationId/attach-jobs/:jobId", {
@@ -1192,7 +1211,7 @@ function parseNotebookListLimit(request: Request): number | Response {
   return Math.min(limit, MAX_NOTEBOOK_LIST_LIMIT);
 }
 
-const WORKSTATION_HEARTBEAT_STALE_MS = 90_000;
+const WORKSTATION_HEARTBEAT_STALE_MS = 3 * 60_000;
 const MAX_WORKSTATION_ATTACH_JOBS_LIMIT = 25;
 
 async function routeWorkstations(request: Request, env: Env): Promise<Response> {
@@ -1616,6 +1635,7 @@ async function routeNotebookWorkstationAttachment(
     closeRuntimePeers: replaceExisting,
     closeReason: replaceExisting ? "workstation restart requested" : undefined,
   });
+  await notifyWorkstationAttachJob(env, ownerPrincipal, job);
 
   cloudLog("info", "workstation.attach.requested", {
     notebook_id: notebookId,
@@ -1699,6 +1719,39 @@ async function routeNotebookRuntimeStateRepair(
   return json(body, response.status);
 }
 
+async function routeWorkstationEvents(
+  request: Request,
+  env: Env,
+  workstationId: string,
+): Promise<Response> {
+  if (!env.DB) {
+    return json({ error: "D1 binding DB is not configured" }, 503);
+  }
+  if (!env.WORKSTATION_EVENTS) {
+    return json({ error: "workstation event stream is not configured" }, 503);
+  }
+
+  const identity = await authenticateRequestOrResponse(request, env, {
+    allowWorkstationCredential: true,
+  });
+  if (identity instanceof Response) {
+    return identity;
+  }
+  if (isAnonymousViewer(identity)) {
+    return json({ error: "sign in to stream workstation events" }, 401);
+  }
+
+  const ownerPrincipal = await canonicalPrincipalForIdentity(env, identity);
+  const workstation = await getWorkstationRow(env, ownerPrincipal, workstationId);
+  if (!workstation) {
+    return json({ error: "workstation not found" }, 404);
+  }
+
+  const stub = workstationEventsStub(env, ownerPrincipal, workstationId);
+  const response = await stub.fetch(new Request("https://workstation-events.internal/stream"));
+  return withCors(response);
+}
+
 async function routeWorkstationAttachJobs(
   request: Request,
   env: Env,
@@ -1737,6 +1790,65 @@ async function routeWorkstationAttachJobs(
     }),
     jobs: jobs.map((job) => workstationAttachJobResponseRow(request, job)),
   });
+}
+
+async function notifyWorkstationAttachJob(
+  env: Env,
+  ownerPrincipal: string,
+  job: WorkstationAttachJobRow,
+): Promise<void> {
+  if (!env.WORKSTATION_EVENTS) {
+    return;
+  }
+  const notification: WorkstationAttachJobNotification = {
+    event: "attach_jobs",
+    workstation_id: job.workstation_id,
+    job_id: job.id,
+    notebook_id: job.notebook_id,
+    status: job.status,
+    requested_at: job.requested_at,
+    updated_at: job.updated_at,
+  };
+  try {
+    const response = await workstationEventsStub(env, ownerPrincipal, job.workstation_id).fetch(
+      new Request("https://workstation-events.internal/notify", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(notification),
+      }),
+    );
+    if (response.ok) {
+      return;
+    }
+    cloudLog("warn", "workstation.events.notify_failed", {
+      principal: ownerPrincipal,
+      workstation_id: job.workstation_id,
+      job_id: job.id,
+      response_status: response.status,
+      counter: "workstation_events_notify_failed",
+      counter_delta: 1,
+    });
+  } catch (error) {
+    cloudLog("warn", "workstation.events.notify_failed", {
+      principal: ownerPrincipal,
+      workstation_id: job.workstation_id,
+      job_id: job.id,
+      error: error instanceof Error ? error.message : String(error),
+      counter: "workstation_events_notify_failed",
+      counter_delta: 1,
+    });
+  }
+}
+
+function workstationEventsStub(
+  env: Env,
+  ownerPrincipal: string,
+  workstationId: string,
+): DurableObjectStub {
+  const id = env.WORKSTATION_EVENTS!.idFromName(
+    workstationEventsObjectName(ownerPrincipal, workstationId),
+  );
+  return env.WORKSTATION_EVENTS!.get(id);
 }
 
 async function routeWorkstationAttachJob(

--- a/apps/notebook-cloud/src/workstation-events.ts
+++ b/apps/notebook-cloud/src/workstation-events.ts
@@ -1,0 +1,183 @@
+import type { DurableObjectState, Env } from "./cloudflare-types.ts";
+
+const WORKSTATION_EVENTS_KEEPALIVE_MS = 25_000;
+
+interface EventListener {
+  readonly id: string;
+  readonly writer: WritableStreamDefaultWriter<Uint8Array>;
+  closed: boolean;
+  keepalive: ReturnType<typeof setInterval> | null;
+}
+
+export interface WorkstationAttachJobNotification {
+  event: "attach_jobs";
+  workstation_id: string;
+  job_id: string;
+  notebook_id: string;
+  status: string;
+  requested_at: string;
+  updated_at: string;
+}
+
+export function workstationEventsObjectName(ownerPrincipal: string, workstationId: string): string {
+  return `${ownerPrincipal}\n${workstationId}`;
+}
+
+export class WorkstationEvents {
+  private readonly encoder = new TextEncoder();
+  private readonly listeners = new Map<string, EventListener>();
+
+  constructor(
+    private readonly state: DurableObjectState,
+    private readonly env: Env,
+  ) {
+    void this.state;
+    void this.env;
+  }
+
+  async fetch(request: Request): Promise<Response> {
+    const url = new URL(request.url);
+    if (request.method === "GET" && url.pathname === "/stream") {
+      return this.openStream(request);
+    }
+    if (request.method === "GET" && url.pathname === "/status") {
+      return Response.json({
+        ok: true,
+        connected: this.listeners.size > 0,
+        connections: this.listeners.size,
+      });
+    }
+    if (request.method === "POST" && url.pathname === "/notify") {
+      const notification = await readNotification(request);
+      if (notification instanceof Response) {
+        return notification;
+      }
+      await this.broadcast(notification.event, notification);
+      return Response.json({
+        ok: true,
+        delivered: this.listeners.size,
+      });
+    }
+    return Response.json({ error: "not found" }, { status: 404 });
+  }
+
+  private openStream(request: Request): Response {
+    const { readable, writable } = new TransformStream<Uint8Array, Uint8Array>();
+    const listener: EventListener = {
+      id: crypto.randomUUID(),
+      writer: writable.getWriter(),
+      closed: false,
+      keepalive: null,
+    };
+    const close = () => {
+      this.closeListener(listener);
+    };
+    request.signal.addEventListener("abort", close, { once: true });
+
+    this.listeners.set(listener.id, listener);
+    void this.writeEvent(listener, "ready", {
+      ok: true,
+      connected_at: new Date().toISOString(),
+    }).catch(close);
+    listener.keepalive = setInterval(() => {
+      void this.writeComment(listener, "keepalive").catch(close);
+    }, WORKSTATION_EVENTS_KEEPALIVE_MS);
+
+    return new Response(readable, {
+      status: 200,
+      headers: {
+        "Cache-Control": "no-store",
+        "Content-Type": "text/event-stream; charset=utf-8",
+      },
+    });
+  }
+
+  private async broadcast(event: string, data: unknown): Promise<void> {
+    await Promise.all(
+      Array.from(this.listeners.values(), async (listener) => {
+        try {
+          await this.writeEvent(listener, event, data);
+        } catch {
+          this.closeListener(listener);
+        }
+      }),
+    );
+  }
+
+  private async writeEvent(listener: EventListener, event: string, data: unknown): Promise<void> {
+    if (listener.closed) {
+      return;
+    }
+    await listener.writer.write(this.encoder.encode(formatServerSentEvent(event, data)));
+  }
+
+  private async writeComment(listener: EventListener, comment: string): Promise<void> {
+    if (listener.closed) {
+      return;
+    }
+    await listener.writer.write(this.encoder.encode(`: ${comment}\n\n`));
+  }
+
+  private closeListener(listener: EventListener): void {
+    if (listener.closed) {
+      return;
+    }
+    listener.closed = true;
+    if (listener.keepalive) {
+      clearInterval(listener.keepalive);
+      listener.keepalive = null;
+    }
+    this.listeners.delete(listener.id);
+    void listener.writer.close().catch(() => undefined);
+  }
+}
+
+function formatServerSentEvent(event: string, data: unknown): string {
+  const payload = JSON.stringify(data);
+  const dataLines = payload.split(/\r?\n/).map((line) => `data: ${line}`);
+  return [`event: ${event}`, ...dataLines, ""].join("\n") + "\n";
+}
+
+async function readNotification(
+  request: Request,
+): Promise<WorkstationAttachJobNotification | Response> {
+  let body: unknown;
+  try {
+    body = await request.json();
+  } catch {
+    return Response.json({ error: "notification body must be JSON" }, { status: 400 });
+  }
+  if (!isRecord(body)) {
+    return Response.json({ error: "notification body must be an object" }, { status: 400 });
+  }
+  const event = stringField(body.event);
+  const notification = {
+    event,
+    workstation_id: stringField(body.workstation_id),
+    job_id: stringField(body.job_id),
+    notebook_id: stringField(body.notebook_id),
+    status: stringField(body.status),
+    requested_at: stringField(body.requested_at),
+    updated_at: stringField(body.updated_at),
+  };
+  if (
+    event !== "attach_jobs" ||
+    !notification.workstation_id ||
+    !notification.job_id ||
+    !notification.notebook_id ||
+    !notification.status ||
+    !notification.requested_at ||
+    !notification.updated_at
+  ) {
+    return Response.json({ error: "invalid notification body" }, { status: 400 });
+  }
+  return { ...notification, event };
+}
+
+function stringField(value: unknown): string {
+  return typeof value === "string" ? value : "";
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}

--- a/apps/notebook-cloud/test/worker-routes.test.ts
+++ b/apps/notebook-cloud/test/worker-routes.test.ts
@@ -47,6 +47,7 @@ import type {
   WorkstationCredentialRow,
   WorkstationPairingCodeRow,
 } from "../src/workstation-credentials.ts";
+import { workstationEventsObjectName } from "../src/workstation-events.ts";
 import { oidcTokenFixture } from "./oidc-jwt-fixture.ts";
 
 const wasmBytes = await readFile(
@@ -5281,6 +5282,69 @@ describe("Workstation pairing", () => {
     );
   });
 
+  it("lets a paired workstation credential open the workstation event stream", async () => {
+    const events = new FakeWorkstationEventsNamespace();
+    const env = fakeEnv({ WORKSTATION_EVENTS: events });
+    const pairing = await mintPairingCode(env);
+    const token = await redeemedCredentialToken(env, pairing.code);
+    const register = await registerWorkstationWithToken(env, token, "ws-paired");
+    assert.equal(register.status, 201);
+
+    const response = await worker.fetch(
+      new Request("http://localhost/api/workstations/ws-paired/events", {
+        headers: { Authorization: `Bearer ${token}` },
+      }),
+      env,
+      fakeContext(),
+    );
+
+    assert.equal(response.status, 200);
+    assert.equal(response.headers.get("Content-Type"), "text/event-stream; charset=utf-8");
+    assert.equal(events.requests.length, 1);
+    assert.equal(
+      events.requests[0]?.objectName,
+      workstationEventsObjectName("user:dev:alice", "ws-paired"),
+    );
+    assert.equal(new URL(events.requests[0]!.url).pathname, "/stream");
+  });
+
+  it("notifies the paired workstation event stream when an owner creates an attach job", async () => {
+    const events = new FakeWorkstationEventsNamespace();
+    const env = fakeEnv({ WORKSTATION_EVENTS: events });
+    seedNotebook(env, "pairing-events-demo");
+    seedAcl(env, { notebookId: "pairing-events-demo", subject: "user:dev:alice", scope: "owner" });
+
+    const pairing = await mintPairingCode(env);
+    const token = await redeemedCredentialToken(env, pairing.code);
+    const register = await registerWorkstationWithToken(env, token, "ws-paired");
+    assert.equal(register.status, 201);
+
+    const attach = await worker.fetch(
+      new Request("http://localhost/api/n/pairing-events-demo/workstation-attachments", {
+        method: "POST",
+        headers: { "Content-Type": "application/json", ...OWNER_HEADERS },
+        body: JSON.stringify({ workstation_id: "ws-paired" }),
+      }),
+      env,
+      fakeContext(),
+    );
+
+    assert.equal(attach.status, 202);
+    const attachBody = (await attach.json()) as { job: { job_id: string } };
+    const notify = events.requests.find((entry) => new URL(entry.url).pathname === "/notify");
+    assert.ok(notify);
+    assert.equal(notify.objectName, workstationEventsObjectName("user:dev:alice", "ws-paired"));
+    assert.deepEqual(notify.body, {
+      event: "attach_jobs",
+      workstation_id: "ws-paired",
+      job_id: attachBody.job.job_id,
+      notebook_id: "pairing-events-demo",
+      status: "pending",
+      requested_at: env.DB.workstationAttachJobs.get(attachBody.job.job_id)?.requested_at,
+      updated_at: env.DB.workstationAttachJobs.get(attachBody.job.job_id)?.updated_at,
+    });
+  });
+
   it("lets a paired workstation credential upload runtime output blobs", async () => {
     const env = fakeEnv();
     seedNotebook(env, "pairing-blob-demo");
@@ -6058,6 +6122,50 @@ class FakeD1 implements D1Database {
       results.push(await statement.run<T>());
     }
     return results;
+  }
+}
+
+interface FakeWorkstationEventsRequest {
+  objectName: string;
+  url: string;
+  method: string;
+  body: unknown;
+}
+
+class FakeWorkstationEventsNamespace implements DurableObjectNamespace {
+  readonly requests: FakeWorkstationEventsRequest[] = [];
+
+  idFromName(name: string): { toString(): string } {
+    return { toString: () => name };
+  }
+
+  get(id: { toString(): string }) {
+    const requests = this.requests;
+    const objectName = id.toString();
+    return {
+      fetch: async (request: Request) => {
+        let body: unknown = null;
+        if (request.method !== "GET") {
+          body = await request.json().catch(() => null);
+        }
+        requests.push({
+          objectName,
+          url: request.url,
+          method: request.method,
+          body,
+        });
+        const pathname = new URL(request.url).pathname;
+        if (pathname === "/stream") {
+          return new Response('event: ready\ndata: {"ok":true}\n\n', {
+            headers: { "Content-Type": "text/event-stream; charset=utf-8" },
+          });
+        }
+        if (pathname === "/notify") {
+          return Response.json({ ok: true, delivered: 1 });
+        }
+        return Response.json({ error: "not found" }, { status: 404 });
+      },
+    };
   }
 }
 

--- a/apps/notebook-cloud/wrangler.toml
+++ b/apps/notebook-cloud/wrangler.toml
@@ -13,9 +13,17 @@ port = 8787
 name = "NOTEBOOK_ROOMS"
 class_name = "NotebookRoom"
 
+[[durable_objects.bindings]]
+name = "WORKSTATION_EVENTS"
+class_name = "WorkstationEvents"
+
 [[migrations]]
 tag = "v1"
 new_sqlite_classes = ["NotebookRoom"]
+
+[[migrations]]
+tag = "v2"
+new_sqlite_classes = ["WorkstationEvents"]
 
 [[d1_databases]]
 binding = "DB"

--- a/crates/runtimed/src/workstation/agent_loop.rs
+++ b/crates/runtimed/src/workstation/agent_loop.rs
@@ -2,8 +2,9 @@
 //!
 //! Rust port of `apps/notebook-cloud/scripts/hosted-workstation-agent.mjs`:
 //! registers/heartbeats this machine against the hosted workstation surface
-//! (`POST /api/workstations`), polls the attach-job queue
-//! (`GET /api/workstations/{id}/attach-jobs`), and serves each pending job by
+//! (`POST /api/workstations`), keeps a server-sent event wakeup stream open,
+//! and falls back to polling the attach-job queue
+//! (`GET /api/workstations/{id}/attach-jobs`). It serves each pending job by
 //! spawning a `runtimed cloud-runtime-agent` runtime peer (the agent *is*
 //! `runtimed`, so it spawns `std::env::current_exe()`).
 //!
@@ -33,6 +34,7 @@ use std::time::{Duration, Instant};
 use anyhow::{Context, Result};
 use serde::Deserialize;
 use serde_json::{json, Value};
+use tokio::sync::mpsc;
 use tracing::{error, info, warn};
 
 pub use super::cloud_agent_cli::CLOUD_TOKEN_ENV;
@@ -43,10 +45,12 @@ pub use super::cloud_agent_cli::CLOUD_TOKEN_ENV;
 /// `.mjs` agent keys on the same string).
 pub const READINESS_LINE: &str = "Infrastructure ready, entering main loop";
 
-/// Default attach-job poll interval (mirrors the `.mjs` agent).
-pub const DEFAULT_POLL_MS: u64 = 2_000;
-/// Default registration-heartbeat interval (mirrors the `.mjs` agent).
-pub const DEFAULT_HEARTBEAT_MS: u64 = 20_000;
+/// Default attach-job fallback poll interval. The fast path is the workstation
+/// event stream; polling is recovery for missed events or older servers.
+pub const DEFAULT_POLL_MS: u64 = 60_000;
+/// Default registration-heartbeat interval. Active job status patches share
+/// this interval, so it must stay below the hosted attach-job stale window.
+pub const DEFAULT_HEARTBEAT_MS: u64 = 60_000;
 
 /// Cooldown applied to 429/503 responses without a usable `Retry-After`.
 const DEFAULT_RETRY_AFTER_MS: u64 = 60_000;
@@ -55,6 +59,10 @@ const MAX_RETRY_AFTER_MS: u64 = 15 * 60_000;
 /// How often active children are checked for exit/readiness between polls
 /// (the `.mjs` agent's `readyPoll` interval).
 const CHILD_TICK_MS: u64 = 250;
+/// Server keepalives are 25s today. Recycle half-open SSE streams that stop
+/// delivering bytes so the agent falls back/reconnects instead of waiting
+/// forever on a dead TCP connection.
+const WORKSTATION_EVENTS_IDLE_TIMEOUT_MS: u64 = 60_000;
 
 /// Configuration for [`run_workstation_agent`]. All fields are non-secret;
 /// the credential travels separately.
@@ -333,6 +341,39 @@ pub fn normalize_jobs(body: &Value) -> Vec<AttachJob> {
         .collect()
 }
 
+fn drain_sse_event_names(buffer: &mut String, chunk: &[u8]) -> Vec<String> {
+    buffer.push_str(&String::from_utf8_lossy(chunk));
+    let mut events = Vec::new();
+    while let Some((boundary, boundary_len)) = find_sse_event_boundary(buffer) {
+        let block = buffer[..boundary].to_string();
+        buffer.drain(..boundary + boundary_len);
+        if let Some(event_name) = parse_sse_event_name(&block) {
+            events.push(event_name);
+        }
+    }
+    events
+}
+
+fn find_sse_event_boundary(buffer: &str) -> Option<(usize, usize)> {
+    match (buffer.find("\n\n"), buffer.find("\r\n\r\n")) {
+        (Some(lf), Some(crlf)) if lf < crlf => Some((lf, 2)),
+        (Some(_lf), Some(crlf)) => Some((crlf, 4)),
+        (Some(lf), None) => Some((lf, 2)),
+        (None, Some(crlf)) => Some((crlf, 4)),
+        (None, None) => None,
+    }
+}
+
+fn parse_sse_event_name(block: &str) -> Option<String> {
+    for line in block.lines() {
+        let line = line.trim_end_matches('\r');
+        if let Some(event_name) = line.strip_prefix("event:") {
+            return Some(event_name.trim().to_string());
+        }
+    }
+    None
+}
+
 /// Cooldown hint from a response: nonzero only for 429/503. `Retry-After`
 /// may be delta-seconds or an HTTP date; absent/unparseable falls back to
 /// [`DEFAULT_RETRY_AFTER_MS`]. Mirrors `retryAfterMs` in the `.mjs` agent.
@@ -442,6 +483,7 @@ impl std::error::Error for AgentHttpError {}
 
 /// Thin client for the three workstation-surface endpoints. All calls carry
 /// `Authorization: Bearer <workstation credential>`.
+#[derive(Clone)]
 struct CloudApi {
     client: reqwest::Client,
     base: String,
@@ -451,7 +493,7 @@ struct CloudApi {
 impl CloudApi {
     fn new(cloud_url: &str, token: String) -> Result<Self> {
         let client = reqwest::Client::builder()
-            .timeout(Duration::from_secs(30))
+            .connect_timeout(Duration::from_secs(30))
             .build()
             .context("build HTTP client")?;
         Ok(Self {
@@ -487,6 +529,68 @@ impl CloudApi {
         Ok(normalize_jobs(&body))
     }
 
+    async fn stream_workstation_events(
+        &self,
+        workstation_id: &str,
+        tx: mpsc::Sender<WorkstationControlEvent>,
+    ) -> Result<(), AgentHttpError> {
+        let url = format!(
+            "{}/api/workstations/{}/events",
+            self.base,
+            encode_path_segment(workstation_id)
+        );
+        let mut response = self
+            .client
+            .get(&url)
+            .bearer_auth(&self.token)
+            .header("Accept", "text/event-stream")
+            .send()
+            .await
+            .map_err(|e| AgentHttpError::local(format!("stream workstation events failed: {e}")))?;
+        let status = response.status().as_u16();
+        let retry_after_header = response
+            .headers()
+            .get("retry-after")
+            .and_then(|value| value.to_str().ok())
+            .map(str::to_string);
+        if status != 200 {
+            let text = response.text().await.unwrap_or_default();
+            let body = parse_response_body(&text);
+            let snippet: String = serde_json::to_string(&body)
+                .unwrap_or_default()
+                .chars()
+                .take(500)
+                .collect();
+            return Err(AgentHttpError {
+                message: format!("stream workstation events failed: HTTP {status} {snippet}"),
+                retry_after_ms: retry_after_ms(status, retry_after_header.as_deref()),
+                status: Some(status),
+                body,
+            });
+        }
+
+        let mut buffer = String::new();
+        loop {
+            let chunk = tokio::time::timeout(
+                Duration::from_millis(WORKSTATION_EVENTS_IDLE_TIMEOUT_MS),
+                response.chunk(),
+            )
+            .await
+            .map_err(|_| AgentHttpError::local("workstation event stream idle timeout".into()))?
+            .map_err(|e| AgentHttpError::local(format!("read workstation event stream: {e}")))?;
+            let Some(chunk) = chunk else {
+                return Ok(());
+            };
+            for event_name in drain_sse_event_names(&mut buffer, &chunk) {
+                if event_name == "attach_jobs"
+                    && tx.send(WorkstationControlEvent::AttachJobs).await.is_err()
+                {
+                    return Ok(());
+                }
+            }
+        }
+    }
+
     async fn patch_attach_job(
         &self,
         workstation_id: &str,
@@ -520,6 +624,7 @@ impl CloudApi {
         expected_statuses: &[u16],
     ) -> Result<Value, AgentHttpError> {
         let response = request
+            .timeout(Duration::from_secs(30))
             .bearer_auth(&self.token)
             .send()
             .await
@@ -547,6 +652,55 @@ impl CloudApi {
             body,
         })
     }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum WorkstationControlEvent {
+    AttachJobs,
+}
+
+async fn run_workstation_event_listener(
+    api: CloudApi,
+    workstation_id: String,
+    tx: mpsc::Sender<WorkstationControlEvent>,
+) {
+    let mut reconnect_delay = Duration::from_secs(1);
+    loop {
+        if tx.is_closed() {
+            return;
+        }
+        match api
+            .stream_workstation_events(&workstation_id, tx.clone())
+            .await
+        {
+            Ok(()) => {
+                warn!("[workstation-agent] workstation event stream closed; reconnecting");
+                reconnect_delay = Duration::from_secs(1);
+            }
+            Err(error) => {
+                if error.status == Some(404) || error.status == Some(503) {
+                    warn!(
+                        "[workstation-agent] workstation event stream unavailable; using fallback polling: {}",
+                        error.message
+                    );
+                } else {
+                    warn!(
+                        "[workstation-agent] workstation event stream failed; reconnecting: {}",
+                        error.message
+                    );
+                }
+                reconnect_delay = retry_event_stream_delay(reconnect_delay, error.retry_after_ms);
+            }
+        }
+        tokio::time::sleep(reconnect_delay).await;
+    }
+}
+
+fn retry_event_stream_delay(previous: Duration, retry_after_ms: u64) -> Duration {
+    if retry_after_ms > 0 {
+        return Duration::from_millis(retry_after_ms).min(Duration::from_secs(60));
+    }
+    previous.saturating_mul(2).min(Duration::from_secs(60))
 }
 
 /// One job this agent is responsible for. `child` is `Some` for peers this
@@ -648,7 +802,16 @@ pub async fn run_workstation_agent(opts: WorkstationAgentOptions, token: String)
 
     let mut active: HashMap<String, ActiveJob> = HashMap::new();
     let mut last_heartbeat: Option<Instant> = None;
+    let mut last_poll: Option<Instant> = None;
+    let mut poll_requested = true;
+    let mut event_stream_closed = false;
     let mut tracker = StepTracker::default();
+    let (event_tx, mut event_rx) = mpsc::channel(16);
+    let _event_listener = tokio::spawn(run_workstation_event_listener(
+        api.clone(),
+        opts.workstation_id.clone(),
+        event_tx,
+    ));
 
     loop {
         if let Some(remaining) = tracker.cooldown_remaining() {
@@ -668,24 +831,58 @@ pub async fn run_workstation_agent(opts: WorkstationAgentOptions, token: String)
             continue;
         }
 
-        // Accept/adopt attach jobs.
-        let result = poll_attach_jobs(&api, &opts, &token, &mut active).await;
-        tracker.record("poll_attach_jobs", result);
+        if !event_stream_closed {
+            while let Ok(WorkstationControlEvent::AttachJobs) = event_rx.try_recv() {
+                poll_requested = true;
+            }
+        }
+
+        // Accept/adopt attach jobs. SSE is the fast wakeup path; this fallback
+        // poll catches missed events, server versions without /events, and
+        // jobs that existed before this agent started.
+        if poll_requested || last_poll.is_none_or(|at| at.elapsed() >= opts.poll_interval) {
+            let result = poll_attach_jobs(&api, &opts, &token, &mut active).await;
+            last_poll = Some(Instant::now());
+            poll_requested = false;
+            tracker.record("poll_attach_jobs", result);
+        }
 
         // Periodic status re-patch so the cloud sees active jobs as live.
         let result = heartbeat_active_jobs(&api, &opts, &mut active).await;
         tracker.record("heartbeat_active_jobs", result);
 
-        // Watch children at a finer tick than the poll interval so readiness
-        // and exits land promptly (the `.mjs` agent's 250ms readyPoll).
-        let deadline = Instant::now() + opts.poll_interval;
+        // Watch children at a finer tick than the fallback poll interval so
+        // readiness and exits land promptly (the `.mjs` agent's 250ms
+        // readyPoll), but sleep cheaply while idle.
+        let next_poll_at = last_poll.map_or_else(Instant::now, |at| at + opts.poll_interval);
+        let next_heartbeat_at =
+            last_heartbeat.map_or_else(Instant::now, |at| at + opts.heartbeat_interval);
+        let deadline = next_poll_at.min(next_heartbeat_at);
         loop {
             tick_active_jobs(&api, &opts, &mut active).await;
             let now = Instant::now();
             if now >= deadline {
                 break;
             }
-            tokio::time::sleep(Duration::from_millis(CHILD_TICK_MS).min(deadline - now)).await;
+            let sleep_for = if active.is_empty() {
+                deadline - now
+            } else {
+                Duration::from_millis(CHILD_TICK_MS).min(deadline - now)
+            };
+            tokio::select! {
+                event = event_rx.recv(), if !event_stream_closed => {
+                    match event {
+                        Some(WorkstationControlEvent::AttachJobs) => {
+                            poll_requested = true;
+                            break;
+                        }
+                        None => {
+                            event_stream_closed = true;
+                        }
+                    }
+                }
+                _ = tokio::time::sleep(sleep_for) => {}
+            }
         }
     }
 }
@@ -1519,6 +1716,41 @@ mod tests {
         let payload = registration_payload("ws", "ws", "/w", "/usr/bin/python3", None, None);
         assert!(payload.get("cpu_count").is_none());
         assert!(payload.get("memory_bytes").is_none());
+    }
+
+    #[test]
+    fn sse_parser_drains_complete_event_names() {
+        let mut buffer = String::new();
+        let events = drain_sse_event_names(
+            &mut buffer,
+            b"event: ready\ndata: {}\n\nevent: attach_jobs\ndata: {\"job_id\":\"j\"}\n\n",
+        );
+
+        assert_eq!(events, vec!["ready", "attach_jobs"]);
+        assert!(buffer.is_empty());
+    }
+
+    #[test]
+    fn sse_parser_keeps_partial_event_until_boundary() {
+        let mut buffer = String::new();
+        assert!(drain_sse_event_names(&mut buffer, b"event: attach_").is_empty());
+        assert_eq!(
+            drain_sse_event_names(&mut buffer, b"jobs\r\ndata: {}\r\n\r\n"),
+            vec!["attach_jobs"]
+        );
+        assert!(buffer.is_empty());
+    }
+
+    #[test]
+    fn event_stream_retry_delay_uses_retry_after_and_caps_backoff() {
+        assert_eq!(
+            retry_event_stream_delay(Duration::from_secs(1), 42_000),
+            Duration::from_secs(42)
+        );
+        assert_eq!(
+            retry_event_stream_delay(Duration::from_secs(45), 0),
+            Duration::from_secs(60)
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- Add a workstation event-stream Durable Object and `/api/workstations/:id/events` route authenticated by existing workstation credentials.
- Notify the stream when an owner creates an attach job, while keeping D1 attach jobs as the source of truth.
- Update the Rust workstation agent to use SSE as the fast wakeup path with 60s fallback polling, and stretch heartbeat defaults/stale UI window to match.

## Request-cost shape
Before this slice, one idle workstation did roughly 43,200 attach-job polls/day plus 4,320 registration heartbeats/day. After this slice, idle cost is one long-lived SSE stream plus roughly one heartbeat and one recovery poll per minute, before real runtime sync work.

This is a large reduction, not the final hundreds-of-idle-workstations model. The next reduction should split live stream presence from active job status heartbeats so idle connected workstations do not need minute heartbeats.

## Validation
- `cargo xtask lint --fix`
- `cargo test -p runtimed --lib`
- `pnpm --dir apps/notebook-cloud typecheck`
- `pnpm --dir apps/notebook-cloud exec node --import tsx --test test/worker-routes.test.ts`
- `pnpm --dir apps/notebook-cloud exec wrangler deploy --dry-run --config wrangler.toml`

No preview deploy in this pass; validation stayed local to avoid spending Worker requests while the account is near the daily limit.