### PR TITLE
perf(notebook-cloud): use workstation stream presence for online status

### DIFF
--- a/apps/notebook-cloud/scripts/hosted-workstation-agent.mjs
+++ b/apps/notebook-cloud/scripts/hosted-workstation-agent.mjs
@@ -142,7 +142,9 @@ async function runAgentStep(step, fn) {
 
 async function heartbeatIfNeeded(pythonPath) {
   const now = Date.now();
-  if (now - lastHeartbeatAt < heartbeatIntervalMs) {
+  const shouldRegister =
+    lastHeartbeatAt === 0 || (activeJobs.size > 0 && now - lastHeartbeatAt >= heartbeatIntervalMs);
+  if (!shouldRegister) {
     return false;
   }
   await registerWorkstation(pythonPath);

--- a/apps/notebook-cloud/src/index.ts
+++ b/apps/notebook-cloud/src/index.ts
@@ -1214,6 +1214,11 @@ function parseNotebookListLimit(request: Request): number | Response {
 const WORKSTATION_HEARTBEAT_STALE_MS = 3 * 60_000;
 const MAX_WORKSTATION_ATTACH_JOBS_LIMIT = 25;
 
+interface WorkstationEventPresence {
+  connected: boolean;
+  connections: number;
+}
+
 async function routeWorkstations(request: Request, env: Env): Promise<Response> {
   if (!env.DB) {
     return json({ error: "D1 binding DB is not configured" }, 503);
@@ -1246,6 +1251,11 @@ async function routeWorkstations(request: Request, env: Env): Promise<Response> 
       listWorkstationsForPrincipal(env, ownerPrincipal),
       getDefaultWorkstationId(env, ownerPrincipal),
     ]);
+    const presenceByWorkstationId = await workstationEventPresenceById(
+      env,
+      ownerPrincipal,
+      workstations,
+    );
     return json({
       ok: true,
       default_workstation_id: defaultWorkstationId,
@@ -1253,6 +1263,7 @@ async function routeWorkstations(request: Request, env: Env): Promise<Response> 
         workstationResponseRow(workstation, {
           defaultWorkstationId,
           now: Date.now(),
+          eventPresence: presenceByWorkstationId.get(workstation.workstation_id) ?? null,
         }),
       ),
     });
@@ -1299,6 +1310,7 @@ async function routeWorkstations(request: Request, env: Env): Promise<Response> 
       workstation: workstationResponseRow(workstation, {
         defaultWorkstationId,
         now: Date.now(),
+        eventPresence: null,
       }),
     },
     201,
@@ -1600,7 +1612,8 @@ async function routeNotebookWorkstationAttachment(
     return json({ error: "workstation not found" }, 404);
   }
 
-  const projectedStatus = workstationStatusForResponse(workstation, Date.now());
+  const eventPresence = await workstationEventPresence(env, ownerPrincipal, workstationId);
+  const projectedStatus = workstationStatusForResponse(workstation, Date.now(), eventPresence);
   if (projectedStatus !== "online") {
     return json(
       {
@@ -1608,6 +1621,7 @@ async function routeNotebookWorkstationAttachment(
         workstation: workstationResponseRow(workstation, {
           defaultWorkstationId: workstationId,
           now: Date.now(),
+          eventPresence,
         }),
       },
       409,
@@ -1653,6 +1667,7 @@ async function routeNotebookWorkstationAttachment(
       workstation: workstationResponseRow(workstation, {
         defaultWorkstationId: workstationId,
         now: Date.now(),
+        eventPresence,
       }),
     },
     202,
@@ -1849,6 +1864,69 @@ function workstationEventsStub(
     workstationEventsObjectName(ownerPrincipal, workstationId),
   );
   return env.WORKSTATION_EVENTS!.get(id);
+}
+
+async function workstationEventPresenceById(
+  env: Env,
+  ownerPrincipal: string,
+  workstations: readonly WorkstationRow[],
+): Promise<Map<string, WorkstationEventPresence | null>> {
+  if (!env.WORKSTATION_EVENTS || workstations.length === 0) {
+    return new Map();
+  }
+  const entries = await Promise.all(
+    workstations.map(async (workstation) => {
+      const presence = await workstationEventPresence(
+        env,
+        ownerPrincipal,
+        workstation.workstation_id,
+      );
+      return [workstation.workstation_id, presence] as const;
+    }),
+  );
+  return new Map(entries);
+}
+
+async function workstationEventPresence(
+  env: Env,
+  ownerPrincipal: string,
+  workstationId: string,
+): Promise<WorkstationEventPresence | null> {
+  if (!env.WORKSTATION_EVENTS) {
+    return null;
+  }
+  try {
+    const response = await workstationEventsStub(env, ownerPrincipal, workstationId).fetch(
+      new Request("https://workstation-events.internal/status"),
+    );
+    if (!response.ok) {
+      cloudLog("warn", "workstation.events.status_failed", {
+        principal: ownerPrincipal,
+        workstation_id: workstationId,
+        response_status: response.status,
+        counter: "workstation_events_status_failed",
+        counter_delta: 1,
+      });
+      return null;
+    }
+    const body = await response.json().catch(() => null);
+    if (!isRecord(body)) {
+      return null;
+    }
+    return {
+      connected: body.connected === true,
+      connections: typeof body.connections === "number" ? body.connections : 0,
+    };
+  } catch (error) {
+    cloudLog("warn", "workstation.events.status_failed", {
+      principal: ownerPrincipal,
+      workstation_id: workstationId,
+      error: error instanceof Error ? error.message : String(error),
+      counter: "workstation_events_status_failed",
+      counter_delta: 1,
+    });
+    return null;
+  }
 }
 
 async function routeWorkstationAttachJob(
@@ -2148,9 +2226,13 @@ function normalizeWorkstationEnvironmentsJson(value: unknown): string | null | R
 
 function workstationResponseRow(
   workstation: WorkstationRow,
-  options: { defaultWorkstationId: string | null; now: number },
+  options: {
+    defaultWorkstationId: string | null;
+    now: number;
+    eventPresence?: WorkstationEventPresence | null;
+  },
 ): Record<string, unknown> {
-  const status = workstationStatusForResponse(workstation, options.now);
+  const status = workstationStatusForResponse(workstation, options.now, options.eventPresence);
   return {
     workstation_id: workstation.workstation_id,
     display_name: workstation.display_name,
@@ -2158,9 +2240,13 @@ function workstationResponseRow(
     provider_label: workstation.provider_label,
     status,
     status_message:
-      status === "offline" && workstation.status === "online"
-        ? "No heartbeat from this workstation recently."
-        : workstation.status_message,
+      status === "offline" && options.eventPresence?.connected === false
+        ? "Workstation event stream is not connected."
+        : status === "online" && options.eventPresence?.connected === true
+          ? workstation.status_message
+          : status === "offline" && workstation.status === "online"
+            ? "No heartbeat from this workstation recently."
+            : workstation.status_message,
     default_environment_label: workstation.default_environment_label,
     environment_policy: workstation.environment_policy,
     working_directory: workstation.working_directory,
@@ -2174,7 +2260,17 @@ function workstationResponseRow(
   };
 }
 
-function workstationStatusForResponse(workstation: WorkstationRow, now: number): WorkstationStatus {
+function workstationStatusForResponse(
+  workstation: WorkstationRow,
+  now: number,
+  eventPresence: WorkstationEventPresence | null | undefined = null,
+): WorkstationStatus {
+  if (
+    eventPresence?.connected === true &&
+    (workstation.status === "online" || workstation.status === "offline")
+  ) {
+    return "online";
+  }
   if (workstation.status === "online" && workstation.last_seen_at) {
     const lastSeen = Date.parse(workstation.last_seen_at);
     if (Number.isFinite(lastSeen) && now - lastSeen > WORKSTATION_HEARTBEAT_STALE_MS) {

--- a/apps/notebook-cloud/src/index.ts
+++ b/apps/notebook-cloud/src/index.ts
@@ -1251,10 +1251,12 @@ async function routeWorkstations(request: Request, env: Env): Promise<Response> 
       listWorkstationsForPrincipal(env, ownerPrincipal),
       getDefaultWorkstationId(env, ownerPrincipal),
     ]);
+    const now = Date.now();
     const presenceByWorkstationId = await workstationEventPresenceById(
       env,
       ownerPrincipal,
       workstations,
+      now,
     );
     return json({
       ok: true,
@@ -1262,7 +1264,7 @@ async function routeWorkstations(request: Request, env: Env): Promise<Response> 
       workstations: workstations.map((workstation) =>
         workstationResponseRow(workstation, {
           defaultWorkstationId,
-          now: Date.now(),
+          now,
           eventPresence: presenceByWorkstationId.get(workstation.workstation_id) ?? null,
         }),
       ),
@@ -1870,12 +1872,19 @@ async function workstationEventPresenceById(
   env: Env,
   ownerPrincipal: string,
   workstations: readonly WorkstationRow[],
+  now: number,
 ): Promise<Map<string, WorkstationEventPresence | null>> {
   if (!env.WORKSTATION_EVENTS || workstations.length === 0) {
     return new Map();
   }
+  const staleWorkstations = workstations.filter((workstation) =>
+    workstationListNeedsEventPresence(workstation, now),
+  );
+  if (staleWorkstations.length === 0) {
+    return new Map();
+  }
   const entries = await Promise.all(
-    workstations.map(async (workstation) => {
+    staleWorkstations.map(async (workstation) => {
       const presence = await workstationEventPresence(
         env,
         ownerPrincipal,
@@ -1885,6 +1894,14 @@ async function workstationEventPresenceById(
     }),
   );
   return new Map(entries);
+}
+
+function workstationListNeedsEventPresence(workstation: WorkstationRow, now: number): boolean {
+  if (workstation.status !== "online" || !workstation.last_seen_at) {
+    return false;
+  }
+  const lastSeen = Date.parse(workstation.last_seen_at);
+  return Number.isFinite(lastSeen) && now - lastSeen > WORKSTATION_HEARTBEAT_STALE_MS;
 }
 
 async function workstationEventPresence(

--- a/apps/notebook-cloud/test/worker-routes.test.ts
+++ b/apps/notebook-cloud/test/worker-routes.test.ts
@@ -1927,6 +1927,45 @@ describe("Worker artifact routes", () => {
     assert.equal(body.workstations[0]?.is_default, true);
   });
 
+  it("projects a stale workstation as online when its event stream is connected", async () => {
+    const objectName = workstationEventsObjectName("user:dev:alice", "ws-lab2");
+    const events = new FakeWorkstationEventsNamespace({ connectedObjectNames: [objectName] });
+    const env = fakeEnv({ WORKSTATION_EVENTS: events });
+    seedWorkstation(env, {
+      ownerPrincipal: "user:dev:alice",
+      workstationId: "ws-lab2",
+      lastSeenAt: "2026-05-22T00:00:00.000Z",
+    });
+
+    const list = await worker.fetch(
+      new Request("http://localhost/api/workstations", {
+        headers: {
+          "X-Operator": "browser:tab",
+          "X-Scope": "owner",
+          "X-User": "alice",
+        },
+      }),
+      env,
+      fakeContext(),
+    );
+
+    assert.equal(list.status, 200);
+    const body = (await list.json()) as {
+      workstations: Array<{
+        workstation_id: string;
+        status: string;
+        status_message: string | null;
+      }>;
+    };
+    assert.equal(body.workstations[0]?.workstation_id, "ws-lab2");
+    assert.equal(body.workstations[0]?.status, "online");
+    assert.equal(body.workstations[0]?.status_message, null);
+    const statusRequest = events.requests.find(
+      (entry) => new URL(entry.url).pathname === "/status",
+    );
+    assert.equal(statusRequest?.objectName, objectName);
+  });
+
   it("keeps an existing default workstation when another host heartbeats", async () => {
     const env = fakeEnv();
     seedWorkstation(env, { ownerPrincipal: "user:dev:alice", workstationId: "ws-default" });
@@ -2200,6 +2239,49 @@ describe("Worker artifact routes", () => {
       ),
       false,
     );
+  });
+
+  it("allows attach requests for stale workstations with a connected event stream", async () => {
+    const objectName = workstationEventsObjectName("user:dev:alice", "ws-lab2");
+    const events = new FakeWorkstationEventsNamespace({ connectedObjectNames: [objectName] });
+    const env = fakeEnv({ WORKSTATION_EVENTS: events });
+    seedNotebook(env, "attach-stream-presence-demo");
+    seedAcl(env, {
+      notebookId: "attach-stream-presence-demo",
+      subject: "user:dev:alice",
+      scope: "owner",
+    });
+    seedWorkstation(env, {
+      ownerPrincipal: "user:dev:alice",
+      workstationId: "ws-lab2",
+      lastSeenAt: "2026-05-22T00:00:00.000Z",
+    });
+
+    const attach = await worker.fetch(
+      new Request("http://localhost/api/n/attach-stream-presence-demo/workstation-attachments", {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          "X-Operator": "browser:tab",
+          "X-Scope": "owner",
+          "X-User": "alice",
+        },
+        body: JSON.stringify({ workstation_id: "ws-lab2" }),
+      }),
+      env,
+      fakeContext(),
+    );
+
+    assert.equal(attach.status, 202);
+    const body = (await attach.json()) as {
+      workstation: { status: string; status_message: string | null };
+      job: { job_id: string };
+    };
+    assert.equal(body.workstation.status, "online");
+    assert.equal(body.workstation.status_message, null);
+    assert.equal(env.DB.workstationAttachJobs.get(body.job.job_id)?.workstation_id, "ws-lab2");
+    assert.ok(events.requests.some((entry) => new URL(entry.url).pathname === "/status"));
+    assert.ok(events.requests.some((entry) => new URL(entry.url).pathname === "/notify"));
   });
 
   it("reuses the active workstation attach job for repeated owner requests", async () => {
@@ -5708,6 +5790,7 @@ function seedWorkstation(
     ownerPrincipal: string;
     workstationId: string;
     status?: WorkstationRow["status"];
+    lastSeenAt?: string;
   },
 ): void {
   env.DB.workstations.set(workstationKey(input.ownerPrincipal, input.workstationId), {
@@ -5726,7 +5809,7 @@ function seedWorkstation(
     environments_json: null,
     created_at: "2026-05-22T00:00:00.000Z",
     updated_at: "2026-05-22T00:00:00.000Z",
-    last_seen_at: new Date().toISOString(),
+    last_seen_at: input.lastSeenAt ?? new Date().toISOString(),
   });
 }
 
@@ -6134,6 +6217,15 @@ interface FakeWorkstationEventsRequest {
 
 class FakeWorkstationEventsNamespace implements DurableObjectNamespace {
   readonly requests: FakeWorkstationEventsRequest[] = [];
+  readonly connectedObjectNames: Set<string>;
+
+  constructor({
+    connectedObjectNames = [],
+  }: {
+    connectedObjectNames?: readonly string[];
+  } = {}) {
+    this.connectedObjectNames = new Set(connectedObjectNames);
+  }
 
   idFromName(name: string): { toString(): string } {
     return { toString: () => name };
@@ -6162,6 +6254,14 @@ class FakeWorkstationEventsNamespace implements DurableObjectNamespace {
         }
         if (pathname === "/notify") {
           return Response.json({ ok: true, delivered: 1 });
+        }
+        if (pathname === "/status") {
+          const connected = this.connectedObjectNames.has(objectName);
+          return Response.json({
+            ok: true,
+            connected,
+            connections: connected ? 1 : 0,
+          });
         }
         return Response.json({ error: "not found" }, { status: 404 });
       },

--- a/apps/notebook-cloud/test/worker-routes.test.ts
+++ b/apps/notebook-cloud/test/worker-routes.test.ts
@@ -1966,6 +1966,78 @@ describe("Worker artifact routes", () => {
     assert.equal(statusRequest?.objectName, objectName);
   });
 
+  it("does not fan out event-stream status checks for fresh workstation rows", async () => {
+    const objectName = workstationEventsObjectName("user:dev:alice", "ws-lab2");
+    const events = new FakeWorkstationEventsNamespace({ connectedObjectNames: [objectName] });
+    const env = fakeEnv({ WORKSTATION_EVENTS: events });
+    seedWorkstation(env, {
+      ownerPrincipal: "user:dev:alice",
+      workstationId: "ws-lab2",
+      lastSeenAt: new Date().toISOString(),
+    });
+
+    const list = await worker.fetch(
+      new Request("http://localhost/api/workstations", {
+        headers: {
+          "X-Operator": "browser:tab",
+          "X-Scope": "owner",
+          "X-User": "alice",
+        },
+      }),
+      env,
+      fakeContext(),
+    );
+
+    assert.equal(list.status, 200);
+    const body = (await list.json()) as {
+      workstations: Array<{
+        workstation_id: string;
+        status: string;
+        status_message: string | null;
+      }>;
+    };
+    assert.equal(body.workstations[0]?.workstation_id, "ws-lab2");
+    assert.equal(body.workstations[0]?.status, "online");
+    assert.equal(body.workstations[0]?.status_message, null);
+    assert.ok(!events.requests.some((entry) => new URL(entry.url).pathname === "/status"));
+  });
+
+  it("does not fan out event-stream status checks for explicitly offline rows", async () => {
+    const objectName = workstationEventsObjectName("user:dev:alice", "ws-lab2");
+    const events = new FakeWorkstationEventsNamespace({ connectedObjectNames: [objectName] });
+    const env = fakeEnv({ WORKSTATION_EVENTS: events });
+    seedWorkstation(env, {
+      ownerPrincipal: "user:dev:alice",
+      workstationId: "ws-lab2",
+      status: "offline",
+      lastSeenAt: "2026-05-22T00:00:00.000Z",
+    });
+
+    const list = await worker.fetch(
+      new Request("http://localhost/api/workstations", {
+        headers: {
+          "X-Operator": "browser:tab",
+          "X-Scope": "owner",
+          "X-User": "alice",
+        },
+      }),
+      env,
+      fakeContext(),
+    );
+
+    assert.equal(list.status, 200);
+    const body = (await list.json()) as {
+      workstations: Array<{
+        workstation_id: string;
+        status: string;
+        status_message: string | null;
+      }>;
+    };
+    assert.equal(body.workstations[0]?.workstation_id, "ws-lab2");
+    assert.equal(body.workstations[0]?.status, "offline");
+    assert.ok(!events.requests.some((entry) => new URL(entry.url).pathname === "/status"));
+  });
+
   it("keeps an existing default workstation when another host heartbeats", async () => {
     const env = fakeEnv();
     seedWorkstation(env, { ownerPrincipal: "user:dev:alice", workstationId: "ws-default" });

--- a/crates/runtimed/src/workstation/agent_loop.rs
+++ b/crates/runtimed/src/workstation/agent_loop.rs
@@ -48,8 +48,9 @@ pub const READINESS_LINE: &str = "Infrastructure ready, entering main loop";
 /// Default attach-job fallback poll interval. The fast path is the workstation
 /// event stream; polling is recovery for missed events or older servers.
 pub const DEFAULT_POLL_MS: u64 = 60_000;
-/// Default registration-heartbeat interval. Active job status patches share
-/// this interval, so it must stay below the hosted attach-job stale window.
+/// Default active-job heartbeat interval. The workstation registration is sent
+/// on startup and while active jobs exist; idle online presence comes from the
+/// hosted workstation event stream rather than repeated D1 writes.
 pub const DEFAULT_HEARTBEAT_MS: u64 = 60_000;
 
 /// Cooldown applied to 429/503 responses without a usable `Retry-After`.
@@ -801,7 +802,7 @@ pub async fn run_workstation_agent(opts: WorkstationAgentOptions, token: String)
     );
 
     let mut active: HashMap<String, ActiveJob> = HashMap::new();
-    let mut last_heartbeat: Option<Instant> = None;
+    let mut last_registration: Option<Instant> = None;
     let mut last_poll: Option<Instant> = None;
     let mut poll_requested = true;
     let mut event_stream_closed = false;
@@ -819,11 +820,14 @@ pub async fn run_workstation_agent(opts: WorkstationAgentOptions, token: String)
             continue;
         }
 
-        // Registration heartbeat.
-        if last_heartbeat.is_none_or(|at| at.elapsed() >= opts.heartbeat_interval) {
+        // Register on startup and refresh workstation metadata while active
+        // jobs exist. Idle connected presence is carried by the SSE stream; a
+        // no-workstation heartbeat loop would burn one Worker/D1 write per
+        // workstation per interval.
+        if should_register_workstation(last_registration, active.len(), opts.heartbeat_interval) {
             let result = heartbeat(&api, &opts).await;
             if result.is_ok() {
-                last_heartbeat = Some(Instant::now());
+                last_registration = Some(Instant::now());
             }
             tracker.record("heartbeat", result.map(|()| true));
         }
@@ -855,9 +859,11 @@ pub async fn run_workstation_agent(opts: WorkstationAgentOptions, token: String)
         // readiness and exits land promptly (the `.mjs` agent's 250ms
         // readyPoll), but sleep cheaply while idle.
         let next_poll_at = last_poll.map_or_else(Instant::now, |at| at + opts.poll_interval);
-        let next_heartbeat_at =
-            last_heartbeat.map_or_else(Instant::now, |at| at + opts.heartbeat_interval);
-        let deadline = next_poll_at.min(next_heartbeat_at);
+        let deadline =
+            next_registration_deadline(last_registration, active.len(), opts.heartbeat_interval)
+                .map_or(next_poll_at, |next_registration_at| {
+                    next_poll_at.min(next_registration_at)
+                });
         loop {
             tick_active_jobs(&api, &opts, &mut active).await;
             let now = Instant::now();
@@ -995,6 +1001,29 @@ async fn heartbeat(api: &CloudApi, opts: &WorkstationAgentOptions) -> Result<(),
         total_memory_bytes(),
     );
     api.register_workstation(&payload).await
+}
+
+fn should_register_workstation(
+    last_registration: Option<Instant>,
+    active_job_count: usize,
+    heartbeat_interval: Duration,
+) -> bool {
+    if last_registration.is_none() {
+        return true;
+    }
+    active_job_count > 0 && last_registration.is_some_and(|at| at.elapsed() >= heartbeat_interval)
+}
+
+fn next_registration_deadline(
+    last_registration: Option<Instant>,
+    active_job_count: usize,
+    heartbeat_interval: Duration,
+) -> Option<Instant> {
+    match last_registration {
+        None => Some(Instant::now()),
+        Some(at) if active_job_count > 0 => Some(at + heartbeat_interval),
+        Some(_) => None,
+    }
 }
 
 async fn poll_attach_jobs(
@@ -1716,6 +1745,47 @@ mod tests {
         let payload = registration_payload("ws", "ws", "/w", "/usr/bin/python3", None, None);
         assert!(payload.get("cpu_count").is_none());
         assert!(payload.get("memory_bytes").is_none());
+    }
+
+    #[test]
+    fn workstation_registration_is_startup_and_active_job_only() {
+        let heartbeat_interval = Duration::from_secs(60);
+        let stale_registration = Instant::now() - Duration::from_secs(120);
+        let fresh_registration = Instant::now();
+
+        assert!(should_register_workstation(None, 0, heartbeat_interval));
+        assert!(should_register_workstation(None, 1, heartbeat_interval));
+        assert!(!should_register_workstation(
+            Some(stale_registration),
+            0,
+            heartbeat_interval
+        ));
+        assert!(!should_register_workstation(
+            Some(fresh_registration),
+            1,
+            heartbeat_interval
+        ));
+        assert!(should_register_workstation(
+            Some(stale_registration),
+            1,
+            heartbeat_interval
+        ));
+    }
+
+    #[test]
+    fn idle_workstation_registration_has_no_wakeup_deadline() {
+        let heartbeat_interval = Duration::from_secs(60);
+        let registered = Instant::now();
+
+        assert!(next_registration_deadline(None, 0, heartbeat_interval).is_some());
+        assert_eq!(
+            next_registration_deadline(Some(registered), 0, heartbeat_interval),
+            None
+        );
+        assert_eq!(
+            next_registration_deadline(Some(registered), 1, heartbeat_interval),
+            Some(registered + heartbeat_interval)
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Follow-up to #3689. This keeps the SSE control stream as the live workstation presence signal so idle connected workstations do not need to keep writing D1 heartbeats just to remain visible as online.

- Overlay WORKSTATION_EVENTS /status onto user-facing workstation list and attach-request decisions.
- Allow attach requests for stale last_seen_at rows when the workstation event stream is connected.
- Stop the Rust workstation agent, and the legacy JS smoke agent, from re-registering while idle; startup registration and active-job status heartbeats remain intact.
- Avoid adding DO /status lookups to the agent attach-job polling path, so idle fallback remains one poll/minute rather than poll plus presence check.

## Request-budget effect

After #3689, an idle workstation still had:

- one long-lived SSE stream;
- one fallback attach-job poll per minute;
- one registration heartbeat/write per minute.

This PR removes the idle registration heartbeat/write. Online status for connected workstations comes from the stream DO, and last_seen_at remains the fallback when the stream binding/status path is unavailable.

## Validation

- cargo xtask lint --fix
- cargo test -p runtimed workstation::agent_loop --lib
- pnpm --dir apps/notebook-cloud typecheck
- pnpm --dir apps/notebook-cloud exec node --import tsx --test test/worker-routes.test.ts
- pnpm --dir apps/notebook-cloud exec wrangler deploy --dry-run --config wrangler.toml

No preview deploy from this branch while the Cloudflare request budget is hot.
