### PR TITLE
fix(notebook): preserve runtime session targets

### DIFF
--- a/packages/runtimed/src/notebook-shell-capabilities.ts
+++ b/packages/runtimed/src/notebook-shell-capabilities.ts
@@ -764,6 +764,7 @@ function stableNotebookShellRuntimeTarget(
 
   const stableTarget = Object.freeze({
     id: target.id ?? null,
+    runtimeSessionId: target.runtimeSessionId ?? null,
     kind: target.kind,
     status: target.status,
     label: target.label,

--- a/packages/runtimed/tests/notebook-shell-capabilities.test.ts
+++ b/packages/runtimed/tests/notebook-shell-capabilities.test.ts
@@ -367,6 +367,50 @@ describe("projectNotebookShellCapabilities", () => {
     expect(Object.isFrozen(first.runtime)).toBe(true);
     expect(Object.isFrozen(first.runtime.target)).toBe(true);
   });
+
+  it("preserves runtime session replacements in stabilized runtime targets", () => {
+    const interaction = projectNotebookRoomEditAccess({
+      accessLevel: "owner",
+      requestedScope: "editor",
+      selectedMode: "edit",
+      canAcceptDocumentMutations: true,
+      canRequestEdit: true,
+    });
+    const first = projectNotebookShellCapabilities({
+      interaction,
+      access: access({ level: "owner", source: "cloud" }),
+      runtime: runtime({
+        connected: true,
+        executionAvailable: true,
+        target: {
+          id: "attached-workstation",
+          runtimeSessionId: "job-123",
+          kind: "cloud_workstation",
+          status: "ready",
+          label: "Connected workstation",
+        },
+      }),
+    });
+    const second = projectNotebookShellCapabilities({
+      interaction,
+      access: access({ level: "owner", source: "cloud" }),
+      runtime: runtime({
+        connected: true,
+        executionAvailable: true,
+        target: {
+          id: "attached-workstation",
+          runtimeSessionId: "job-456",
+          kind: "cloud_workstation",
+          status: "ready",
+          label: "Connected workstation",
+        },
+      }),
+    });
+
+    expect(first.runtime.target).not.toBe(second.runtime.target);
+    expect(first.runtime.target?.runtimeSessionId).toBe("job-123");
+    expect(second.runtime.target?.runtimeSessionId).toBe("job-456");
+  });
 });
 
 describe("projectNotebookRuntimeTargetFromWorkstationAttachment", () => {


### PR DESCRIPTION
## Summary

- keep `runtimeSessionId` on stabilized notebook shell runtime targets
- add a regression test for replacing a workstation runtime session under the same target id

## Why

The cache key already included `runtimeSessionId`, but the frozen target object dropped it. Downstream workstation projections key on this fact, so replacing a stale runtime session could lose the session identity after stabilization.

## Verification

- `pnpm test:run -- packages/runtimed/tests/notebook-shell-capabilities.test.ts packages/runtimed/tests/notebook-workstation-panel.test.ts packages/runtimed/tests/notebook-workstation-launch.test.ts` (runner executed full Vitest suite: 218 files passed, 1 skipped)
- `cargo xtask lint --fix`
