### PR TITLE
docs: reconcile stale architecture guidance

### DIFF
--- a/crates/notebook-doc/src/pool_state.rs
+++ b/crates/notebook-doc/src/pool_state.rs
@@ -1,7 +1,8 @@
 //! PoolDoc — global daemon-authoritative Automerge document for pool state.
 //!
-//! One per daemon (not per notebook). Describes the UV and Conda prewarm pool
-//! status: available environments, warming count, pool size, and error state.
+//! One per daemon (not per notebook). Describes the UV, Conda, and Pixi
+//! prewarm pool status: available environments, warming count, pool size, and
+//! error state.
 //! Clients sync read-only via the Automerge sync protocol — the daemon strips
 //! any client-side changes.
 //!
@@ -15,6 +16,7 @@
 //!     consecutive_failures: u64
 //!     retry_in_secs: u64
 //!     error: Str (optional — deleted when None)
+//!     failed_package: Str (optional — deleted when None)
 //!     error_kind: Str (optional — "timeout"|"invalid_package"|"import_error"|"setup_failed")
 //!   conda/
 //!     available: u64
@@ -23,6 +25,16 @@
 //!     consecutive_failures: u64
 //!     retry_in_secs: u64
 //!     error: Str (optional — deleted when None)
+//!     failed_package: Str (optional — deleted when None)
+//!     error_kind: Str (optional — "timeout"|"invalid_package"|"import_error"|"setup_failed")
+//!   pixi/
+//!     available: u64
+//!     warming: u64
+//!     pool_size: u64
+//!     consecutive_failures: u64
+//!     retry_in_secs: u64
+//!     error: Str (optional — deleted when None)
+//!     failed_package: Str (optional — deleted when None)
 //!     error_kind: Str (optional — "timeout"|"invalid_package"|"import_error"|"setup_failed")
 //! ```
 

--- a/crates/notebook-doc/src/pool_state.rs
+++ b/crates/notebook-doc/src/pool_state.rs
@@ -50,7 +50,7 @@ use serde::{Deserialize, Serialize};
 
 // ── Snapshot types ───────────────────────────────────────────────────
 
-/// State of a single runtime pool (UV or Conda).
+/// State of a single runtime pool.
 #[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
 pub struct RuntimePoolState {
     pub available: u64,

--- a/docs/adr/document-split.md
+++ b/docs/adr/document-split.md
@@ -328,7 +328,7 @@ The split was designed for the desktop topology (one daemon per user, same-UID t
 - `crates/notebook-doc/AGENTS.md` - mutation rules for NotebookDoc.
 - `crates/runtime-doc/src/doc.rs` - RuntimeStateDoc schema v2.
 - `crates/runtime-doc/src/comms.rs` - CommsDoc schema v1.
-- `crates/notebook-doc/src/pool_state.rs:8-27, :128-141` - PoolDoc schema. The doc-comment at 8-27 names `uv` and `conda` only; the live scaffold at 128-141 also includes `pixi` and a per-pool `failed_package` field (`pool_state.rs:52, :223`). The doc-comment is stale.
+- `crates/notebook-doc/src/pool_state.rs:8-34, :128-141` - PoolDoc schema. The doc-comment and live scaffold both model `uv`, `conda`, and `pixi` counters with optional per-pool error fields, including `failed_package`.
 - `crates/notebook-wire/src/lib.rs:9-44` - frame type constants and per-type caps.
 - `crates/notebook-wire/AGENTS.md` - wire protocol overview.
 - `crates/runtimed/src/notebook_sync_server/peer_loop.rs` - the sync select loop holding per-document peer-state objects.

--- a/docs/adr/document-split.md
+++ b/docs/adr/document-split.md
@@ -328,7 +328,7 @@ The split was designed for the desktop topology (one daemon per user, same-UID t
 - `crates/notebook-doc/AGENTS.md` - mutation rules for NotebookDoc.
 - `crates/runtime-doc/src/doc.rs` - RuntimeStateDoc schema v2.
 - `crates/runtime-doc/src/comms.rs` - CommsDoc schema v1.
-- `crates/notebook-doc/src/pool_state.rs:8-34, :128-141` - PoolDoc schema. The doc-comment and live scaffold both model `uv`, `conda`, and `pixi` counters with optional per-pool error fields, including `failed_package`.
+- `crates/notebook-doc/src/pool_state.rs:8-39, :128-141` - PoolDoc schema. The doc-comment and live scaffold both model `uv`, `conda`, and `pixi` counters with optional per-pool error fields, including `failed_package`.
 - `crates/notebook-wire/src/lib.rs:9-44` - frame type constants and per-type caps.
 - `crates/notebook-wire/AGENTS.md` - wire protocol overview.
 - `crates/runtimed/src/notebook_sync_server/peer_loop.rs` - the sync select loop holding per-document peer-state objects.

--- a/docs/adr/document-split.md
+++ b/docs/adr/document-split.md
@@ -328,7 +328,7 @@ The split was designed for the desktop topology (one daemon per user, same-UID t
 - `crates/notebook-doc/AGENTS.md` - mutation rules for NotebookDoc.
 - `crates/runtime-doc/src/doc.rs` - RuntimeStateDoc schema v2.
 - `crates/runtime-doc/src/comms.rs` - CommsDoc schema v1.
-- `crates/notebook-doc/src/pool_state.rs:8-39, :128-141` - PoolDoc schema. The doc-comment and live scaffold both model `uv`, `conda`, and `pixi` counters with optional per-pool error fields, including `failed_package`.
+- `crates/notebook-doc/src/pool_state.rs:8-39, :110-153, :234-251` - PoolDoc schema. The doc-comment and live scaffold both model `uv`, `conda`, and `pixi` counters with optional per-pool error fields, including `failed_package`.
 - `crates/notebook-wire/src/lib.rs:9-44` - frame type constants and per-type caps.
 - `crates/notebook-wire/AGENTS.md` - wire protocol overview.
 - `crates/runtimed/src/notebook_sync_server/peer_loop.rs` - the sync select loop holding per-document peer-state objects.

--- a/docs/adr/execution-pipeline.md
+++ b/docs/adr/execution-pipeline.md
@@ -82,12 +82,20 @@ blocking `.send().await` does not compile. The remaining ordering questions
 are about when lifecycle signals are drained, not about accidentally routing
 widget replay work onto the lifecycle path or blocking the reader on it.
 
-The runtime agent's `select!` loop has two arms for these channels (`crates/runtimed/src/runtime_agent.rs:592-639`):
+The runtime agent's `select!` loop includes separate arms for these channels
+(`crates/runtimed/src/runtime_agent.rs`):
 
+- The loop uses `tokio::select! { biased; ... }` so lifecycle/control work is
+  polled before the bounded output/work channel when both are ready.
 - The lifecycle arm runs whenever a lifecycle command is ready.
 - The work arm, before processing its own command, drains every pending lifecycle command via `drain_lifecycle_commands`. This prevents the work arm from being chosen while lifecycle signals sit unprocessed.
 
-The `biased;` modifier is intentionally **not** used here. The reordering is at the body level, not the arm level. Both arms compete fairly for selection, but once the work arm wins it still defers to lifecycle. A `biased;` strict-priority loop would starve work entirely whenever lifecycle signals arrive faster than they can be drained, which we don't want.
+This is the EP-10 resolution: the loop now makes polling order deterministic
+and still keeps the work-arm drain as a second guard. The strict-priority risk
+is bounded by the lifecycle channel's cardinality (`KernelIdle`,
+`ExecutionDone`, `CellError`, `KernelDied` are rare and finite per execution),
+while the failure mode of randomly choosing output work ahead of a ready
+lifecycle signal is user-visible interrupt or queue-release latency.
 
 ### Why separate channels
 
@@ -300,9 +308,11 @@ If lifecycle and work shared one channel, the interrupt's `KernelIdle` would hav
 3. **What if `set_execution_done` is never written?** A panic or task drop between the final output write and `set_execution_done` leaves the execution in `running` forever. Consumers time out. There is no per-execution timeout or watchdog at the daemon side. `KernelDied` clears the queue but only fires when IOPub disconnects or a committer task panics (see `crates/runtimed/src/stream_committer.rs:227`, `display_update_committer.rs:259`). The framing of a *fix* for this — divergence detection rather than a wall-clock watchdog, since multi-hour training jobs are legitimate — is explored in `docs/memos/execution-liveness.md`.
 
 4. ~~**The `is_lifecycle()` discipline is a runtime check.**~~ **Resolved by
-   EP-2.** `LifecycleSignal` and `WorkCommand` are now separate types, so the
-   lifecycle channel no longer accepts widget replay work. Remaining lifecycle
-   select-ordering concerns are tracked as EP-10.
+   EP-2 and EP-10.** `LifecycleSignal` and `WorkCommand` are now separate
+   types, so the lifecycle channel no longer accepts widget replay work. The
+   runtime agent also uses a biased select loop with the lifecycle arm before
+   the bounded work arm, while the work arm drains lifecycle commands before
+   handling output work.
 
 5. **`required_heads` is `NotebookDoc`-only.** A request that semantically depends on a recent RuntimeStateDoc write (rare in v1, but conceivable for future request types) has no causal gate.
 

--- a/docs/handoffs/16-decisions-log.md
+++ b/docs/handoffs/16-decisions-log.md
@@ -38,11 +38,13 @@ decision: what, the alternative, why.
    stripping silently discards the room's queued executions and stalls convergence.
 
 7. **A lifecycle safety net is required before relying on cloud hosting (Phase 3).**
-   Why: `kernel.lifecycle` is `runtime_peer`-only-writable (`policy.rs:403-405`), so when
-   the runtime itself vanishes no surviving room participant can correct the doc and the
-   room has no watchdog. A dropped workstation strands the room with a phantom-live
-   kernel. Needs a cloud-room watchdog plus a narrow policy relaxation (or a `Disconnected`
-   lifecycle the room can stamp). See `16-lifecycle-analysis.md`.
+   Historical reason: when the runtime itself vanished, the room had no watchdog
+   and could strand viewers with phantom-live executions. Phase 3d later built
+   the Durable Object watchdog and `RoomHostHandle::reconcile_runtime_peer_gone`;
+   no policy relaxation was needed because the room host authors the
+   reconciliation directly on its state doc. Remaining work is live preview
+   peer-drop re-proof and hosted REQUEST dispatch for interrupt/restart delivery.
+   See `16-lifecycle-analysis.md` and the Phase 3d/3f notes below.
 
 8. **Output path: plain nbformat manifest + a minted `output_id` is sufficient.**
    Verified live: it persists across peer disconnect and renders in the cloud viewer

--- a/docs/handoffs/16-decisions-log.md
+++ b/docs/handoffs/16-decisions-log.md
@@ -43,7 +43,8 @@ decision: what, the alternative, why.
    the Durable Object watchdog and `RoomHostHandle::reconcile_runtime_peer_gone`;
    no policy relaxation was needed because the room host authors the
    reconciliation directly on its state doc. Remaining work is live preview
-   peer-drop re-proof and hosted REQUEST dispatch for interrupt/restart delivery.
+   peer-drop re-proof and hosted REQUEST dispatch for restart, launch, and other
+   response-bearing runtime requests.
    See `16-lifecycle-analysis.md` and the Phase 3d/3f notes below.
 
 8. **Output path: plain nbformat manifest + a minted `output_id` is sufficient.**
@@ -411,9 +412,12 @@ change. Decide (2) when 3d's mechanism is chosen.
 
 34. **3f is split: req 6 (writer-error must not kill the kernel on a recoverable
     transport) lands now; req 5 (inbound request channel) defers — it needs the
-    3d worker.** req 5 routes interrupt/restart `RuntimeAgentRequest`s from the
-    cloud room to the agent, which requires a hosted REQUEST dispatch on the
-    DurableObject (3d, Deferred). req 6 is pure Rust in `runtime_agent` and is the
+    3d worker.** req 5 was originally framed as routing interrupt/restart
+    `RuntimeAgentRequest`s from the cloud room to the agent. Interrupt is now
+    forwarded as a fire-and-forget runtime-peer command; the remaining req 5 gap
+    is restart, launch, and other response-bearing runtime requests that need a
+    hosted REQUEST dispatch contract on the DurableObject. req 6 is pure Rust in
+    `runtime_agent` and is the
     last place a transient cloud blip still destroys a healthy kernel after 3a:
     the two outbound (writer) `select!` arms — the `state_changed_rx`
     RuntimeStateSync send and the `async_response_rx` reply send — `break` the loop
@@ -444,11 +448,13 @@ Phase 3f(req 6) verification: `cargo test -p runtimed` 891 lib (was 888) +
 integration suites green (UDS unchanged); `cargo xtask lint --fix` clean; clippy
 `-D warnings` clean.
 
-**Deferred (3f req 5):** the inbound request channel — needs the 3d DurableObject
-hosted REQUEST dispatch to deliver interrupt/restart `RuntimeAgentRequest`s to the
-cloud agent. Detection of the kernel-side *effect* already survives (decision/req
-analysis); only the trigger path is missing, and it can't be built or verified
-without the worker (3d) + a live room. Build it alongside 3d.
+**Deferred (3f req 5):** the response-bearing inbound request channel — needs the
+DurableObject hosted REQUEST dispatch contract to deliver restart, launch, and
+other response-bearing `RuntimeAgentRequest`s to the cloud agent. Interrupt is
+already forwarded as a fire-and-forget runtime-peer command. Detection of the
+kernel-side *effect* already survives (decision/req analysis); the remaining
+trigger/response path can't be built or verified without the worker + a live
+room.
 
 ## Phase 3d (CODE): cloud-room DurableObject watchdog
 
@@ -517,10 +523,12 @@ storage backend without alarms (or the desktop/UDS path) is unaffected.
 3a (req 1), 3b (req 2), 3c CODE (doc-actor identity), 3d CODE (watchdog), 3e model
 half (`last_seen`), and 3f req 6 (writer-error recovery) are done. Remaining:
 
-- **3f req 5: inbound request channel.** Route interrupt/restart
-  `RuntimeAgentRequest`s to the cloud agent via the 3d DurableObject hosted REQUEST
-  dispatch. req 6 (don't tear the kernel down on a writer error) is DONE
-  (decisions 34–35); req 5's trigger path needs the worker + a live room.
+- **3f req 5: response-bearing inbound request channel.** Route restart,
+  launch, and other response-bearing `RuntimeAgentRequest`s to the cloud agent
+  via the DurableObject hosted REQUEST dispatch contract. Interrupt is already
+  forwarded as a fire-and-forget runtime-peer command. req 6 (don't tear the
+  kernel down on a writer error) is DONE (decisions 34–35); req 5's
+  trigger/response path needs the worker + a live room.
 
 ## Workstation endpoint (the second half of 16): scoping
 

--- a/docs/handoffs/16-lifecycle-analysis.md
+++ b/docs/handoffs/16-lifecycle-analysis.md
@@ -1,5 +1,19 @@
 # Runtime lifecycle analysis: transport-agnostic `runtime_agent`
 
+> **Current status (2026-06-15): partially superseded.** This analysis is a
+> historical input to the transport-agnostic runtime-agent work, not a live P0
+> backlog as written. The cloud-room runtime-peer departure watchdog now exists:
+> `apps/notebook-cloud/src/notebook-room.ts` tracks `runtime_peer` membership and
+> arms a Durable Object alarm, while
+> `crates/runtimed-wasm/src/lib.rs::reconcile_runtime_peer_gone_inner` reconciles
+> in-flight executions and live kernel lifecycle when the runtime peer is gone.
+> The runtime agent also has transport-specific clean-EOF reconnect behavior for
+> recoverable sinks. Remaining live gaps are the hosted REQUEST dispatch for
+> interrupt/restart delivery, live preview peer-drop re-proof with real
+> Cloudflare alarms, and tuning the grace window against real reconnect latency.
+> See `16-decisions-log.md` Phase 3d/3f for the implementation evidence and
+> deferred verification.
+
 With the daemon still managing the kernel but syncing to a cloud room instead of the local socket, which kernel lifecycle events are missed? This grounds that question in file:line evidence.
 
 ## Verdict
@@ -168,4 +182,3 @@ Transport-COUPLED (lives in the local daemon, does NOT travel to a cloud room): 
 | restart | partial | set_lifecycle walks Resolving -> PreparingEnv -> Launching -> Connecting -> Running(Idle) (launch_kernel.rs:95,538,1504,1649,1727; metadata. |
 | clean shutdown | partial | set_lifecycle(Shutdown) (shutdown_kernel.rs:26; jupyter_kernel.rs:1415 IoPubStateUpdate::Lifecycle(Shutdown)). Viewer maps Shutdown -> Execu |
 | runtime_peer itself disconnects (the new failure mode) | no | No doc write on disconnect itself. Doc retains the dead peer's last lifecycle (e.g. Running(Idle)) indefinitely. Per policy, neither Editor, |
-

--- a/docs/handoffs/16-lifecycle-analysis.md
+++ b/docs/handoffs/16-lifecycle-analysis.md
@@ -8,9 +8,10 @@
 > `crates/runtimed-wasm/src/lib.rs::reconcile_runtime_peer_gone_inner` reconciles
 > in-flight executions and live kernel lifecycle when the runtime peer is gone.
 > The runtime agent also has transport-specific clean-EOF reconnect behavior for
-> recoverable sinks. Remaining live gaps are the hosted REQUEST dispatch for
-> interrupt/restart delivery, live preview peer-drop re-proof with real
-> Cloudflare alarms, and tuning the grace window against real reconnect latency.
+> recoverable sinks. Remaining live gaps are hosted dispatch for restart,
+> launch, and other response-bearing runtime requests, live preview peer-drop
+> re-proof with real Cloudflare alarms, and tuning the grace window against real
+> reconnect latency.
 > See `16-decisions-log.md` Phase 3d/3f for the implementation evidence and
 > deferred verification.
 

--- a/docs/handoffs/README.md
+++ b/docs/handoffs/README.md
@@ -1,0 +1,14 @@
+# Handoffs
+
+Handoffs are time-bound transfer notes. They preserve investigation context, but
+they are not live architecture specs unless their current-status block says so.
+When a handoff conflicts with a newer ADR, audit, runbook, or source file, prefer
+the newer durable document or the source file and update the handoff status
+instead of letting stale findings look current.
+
+| File | Current use |
+|------|-------------|
+| [`16-decisions-log.md`](16-decisions-log.md) | Historical decision trail for the transport-agnostic runtime-agent and workstation attach work. Use its current status and later phase notes before treating early decisions as open backlog. |
+| [`16-lifecycle-analysis.md`](16-lifecycle-analysis.md) | Historical lifecycle risk analysis. Partially superseded by the runtime-peer departure watchdog and reconnect work; remaining live gaps are called out at the top. |
+| [`2026-06-01-host-convergence-deep-dive.md`](2026-06-01-host-convergence-deep-dive.md) | Historical deep dive on rejected local-first writes and recovery policy. Still useful as source evidence for sync-divergence recovery decisions. |
+| [`2026-06-01-notebook-host-convergence.md`](2026-06-01-notebook-host-convergence.md) | Historical host-convergence handoff. Read with the deep dive and newer ADRs before treating rows as current work. |


### PR DESCRIPTION
## Summary

This is the first small PR from the repo-houseclean goal. It removes stale guidance that future agents/readers were likely to rediscover as current truth:

- updates the `PoolDoc` crate-level schema comment to include `pixi` and `failed_package`, then updates the document-split ADR reference that previously called the comment stale;
- updates the execution-pipeline ADR to match the current EP-10 implementation: the runtime agent now uses `tokio::select! { biased; ... }` plus lifecycle draining to keep lifecycle/control work ahead of bounded output work;
- adds a handoffs index and marks the old lifecycle handoff as partially superseded by the runtime-peer departure watchdog/reconnect work, while preserving the remaining live gaps.

## Why

The broader cleanup pass found that time-bound handoffs and older ADR prose are still easy to treat as live backlog. This PR does not delete historical material yet; it adds current-status context where the replacement source of truth is clear.

## Verification

- `cargo test -p notebook-doc pool_state --lib`
- `cargo xtask lint --fix`
- `git diff --check`
