### PR TITLE
fix(cloud): reject hosted restart request no-op

### DIFF
--- a/apps/notebook-cloud/src/notebook-room.ts
+++ b/apps/notebook-cloud/src/notebook-room.ts
@@ -87,6 +87,7 @@ type RuntimePeerForwardedRequestAction = "interrupt_execution" | "send_comm";
 type RuntimePeerQueryRequestAction = "complete";
 type UnsupportedHostedRuntimeRequestAction =
   | "launch_kernel"
+  | "restart_kernel"
   | "shutdown_kernel"
   | "sync_environment"
   | "get_history";
@@ -127,6 +128,7 @@ const runtimePeerForwardedRequestActions = new Set<RuntimePeerForwardedRequestAc
 const runtimePeerQueryRequestActions = new Set<RuntimePeerQueryRequestAction>(["complete"]);
 const unsupportedHostedRuntimeRequestActions = new Set<UnsupportedHostedRuntimeRequestAction>([
   "launch_kernel",
+  "restart_kernel",
   "shutdown_kernel",
   "sync_environment",
   "get_history",

--- a/apps/notebook-cloud/test/notebook-room.test.ts
+++ b/apps/notebook-cloud/test/notebook-room.test.ts
@@ -2433,24 +2433,34 @@ describe("NotebookRoom materialized sync routing", () => {
       removePeer: async () => undefined,
     });
 
-    await harness.handleMessage(
-      "demo",
-      peer,
-      encodeTypedFrame(
-        FrameType.REQUEST,
-        new TextEncoder().encode(JSON.stringify({ id: "request-1", action: "shutdown_kernel" })),
-      ),
-    );
+    const unsupportedActions = [
+      "launch_kernel",
+      "restart_kernel",
+      "shutdown_kernel",
+      "sync_environment",
+      "get_history",
+    ] as const;
 
-    assert.equal(materialized, 0);
-    assert.equal(peer.consecutiveRejectedFrames, 0);
-    assert.equal(socket.sent.length, 1);
-    const rejected = decodeJsonPayload<Record<string, unknown>>(socket.sent[0].slice(1));
-    assert.equal(rejected.type, "cloud_frame_rejected");
-    assert.equal(
-      rejected.reason,
-      "hosted cloud rooms do not yet support response-bearing runtime request shutdown_kernel",
-    );
+    for (const action of unsupportedActions) {
+      await harness.handleMessage(
+        "demo",
+        peer,
+        encodeTypedFrame(
+          FrameType.REQUEST,
+          new TextEncoder().encode(JSON.stringify({ id: `request-${action}`, action })),
+        ),
+      );
+
+      assert.equal(materialized, 0);
+      assert.equal(peer.consecutiveRejectedFrames, 0);
+      assert.equal(socket.sent.length, unsupportedActions.indexOf(action) + 1);
+      const rejected = decodeJsonPayload<Record<string, unknown>>(socket.sent.at(-1)!.slice(1));
+      assert.equal(rejected.type, "cloud_frame_rejected");
+      assert.equal(
+        rejected.reason,
+        `hosted cloud rooms do not yet support response-bearing runtime request ${action}`,
+      );
+    }
   });
 
   it("rejects non-owner REQUEST frames on the WebSocket path", async () => {

--- a/docs/adr/remote-workstation-doc-agents.md
+++ b/docs/adr/remote-workstation-doc-agents.md
@@ -790,12 +790,13 @@ sequence:
   disconnect-aware, and non-durable until runtime generations and room-owned
   lifecycle transitions are explicit.
 - **Unsupported response-bearing runtime requests fail honestly.** Hosted cloud
-  rooms reject direct `launch_kernel`, `shutdown_kernel`, `sync_environment`,
-  and `get_history` request frames instead of acknowledging them as empty
-  room-host no-ops. The cloud viewer still handles current hosted history in
-  `CloudNotebookHostTransport`; a real kernel-backed history implementation
-  needs a product decision about whether history is notebook-wide, user-wide,
-  or kernel-local before routing it through the runtime peer.
+  rooms reject direct `launch_kernel`, `restart_kernel`, `shutdown_kernel`,
+  `sync_environment`, and `get_history` request frames instead of acknowledging
+  them as empty room-host no-ops. The cloud viewer still handles current hosted
+  history in `CloudNotebookHostTransport`; a real kernel-backed history
+  implementation needs a product decision about whether history is
+  notebook-wide, user-wide, or kernel-local before routing it through the
+  runtime peer.
 
 Runtime request subtleties to keep visible:
 


### PR DESCRIPTION
## Summary

Hardens hosted room REQUEST handling so raw `restart_kernel` frames fail honestly instead of falling through to materialization as accepted no-ops.

- adds `restart_kernel` to the unsupported response-bearing runtime request set;
- expands the notebook-room regression test to cover all unsupported response-bearing actions;
- updates the remote-workstation ADR list so it names `restart_kernel` explicitly.

This keeps direct restart routing behind the lifecycle design called out in the ADR. Interrupt remains a fire-and-forget runtime-peer command and is not changed here.

## Verification

- `node --import tsx --test test/notebook-room.test.ts` from `apps/notebook-cloud` (61 tests passed)
- `pnpm --dir apps/notebook-cloud typecheck`
- `cargo xtask lint --fix`
- `git diff --check`
