### PR TITLE
feat(markdown-doc): add hosted Markdown documents

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4395,6 +4395,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "markdown-doc"
+version = "0.1.0"
+dependencies = [
+ "automerge",
+ "automerge-recovery",
+ "serde",
+ "thiserror 2.0.18",
+]
+
+[[package]]
 name = "markup5ever"
 version = "0.14.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7747,6 +7757,7 @@ dependencies = [
  "getrandom 0.3.4",
  "getrandom 0.4.2",
  "hex",
+ "markdown-doc",
  "notebook-doc",
  "notebook-wire",
  "nteract-identity",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4400,6 +4400,7 @@ version = "0.1.0"
 dependencies = [
  "automerge",
  "automerge-recovery",
+ "hex",
  "serde",
  "thiserror 2.0.18",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,6 +6,7 @@ members = [
     "crates/runt-workspace",
     "crates/kernel-launch",
     "crates/kernel-env",
+    "crates/markdown-doc",
     "crates/automerge-recovery",
     "crates/notebook",
     "crates/automunge",

--- a/apps/notebook-cloud/migrations/0008_markdown_documents.sql
+++ b/apps/notebook-cloud/migrations/0008_markdown_documents.sql
@@ -1,0 +1,35 @@
+CREATE TABLE IF NOT EXISTS markdown_documents (
+  id TEXT PRIMARY KEY,
+  owner_principal TEXT NOT NULL,
+  title TEXT,
+  body_doc_id TEXT NOT NULL,
+  created_at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ', 'now')),
+  updated_at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ', 'now')),
+  latest_revision_id TEXT
+);
+
+CREATE TABLE IF NOT EXISTS markdown_document_revisions (
+  id TEXT PRIMARY KEY,
+  document_id TEXT NOT NULL,
+  body_heads_hash TEXT NOT NULL,
+  snapshot_key TEXT NOT NULL,
+  actor_label TEXT NOT NULL,
+  created_at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ', 'now')),
+  FOREIGN KEY (document_id) REFERENCES markdown_documents(id)
+);
+
+CREATE TABLE IF NOT EXISTS markdown_document_acl (
+  document_id TEXT NOT NULL,
+  subject_kind TEXT NOT NULL CHECK (subject_kind IN ('principal', 'public')),
+  subject TEXT NOT NULL,
+  scope TEXT NOT NULL CHECK (scope IN ('viewer', 'editor', 'owner')),
+  created_at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ', 'now')),
+  updated_at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ', 'now')),
+  created_by_actor_label TEXT NOT NULL,
+  PRIMARY KEY (document_id, subject_kind, subject, scope),
+  FOREIGN KEY (document_id) REFERENCES markdown_documents(id),
+  CHECK (subject_kind != 'public' OR (subject = 'anonymous' AND scope = 'viewer'))
+);
+
+CREATE INDEX IF NOT EXISTS markdown_document_acl_subject_idx
+  ON markdown_document_acl (subject_kind, subject, document_id);

--- a/apps/notebook-cloud/migrations/0009_markdown_document_sharing.sql
+++ b/apps/notebook-cloud/migrations/0009_markdown_document_sharing.sql
@@ -1,0 +1,55 @@
+CREATE TABLE IF NOT EXISTS markdown_document_invites (
+  id TEXT PRIMARY KEY,
+  document_id TEXT NOT NULL,
+  email_normalized TEXT NOT NULL,
+  provider_hint TEXT,
+  scope TEXT NOT NULL CHECK (scope IN ('viewer', 'editor')),
+  status TEXT NOT NULL CHECK (status IN ('pending', 'accepted', 'revoked', 'expired')),
+  invited_by_actor_label TEXT NOT NULL,
+  accepted_by_principal TEXT,
+  token_hash TEXT,
+  created_at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ', 'now')),
+  expires_at TEXT,
+  accepted_at TEXT,
+  revoked_at TEXT,
+  revoked_by_actor_label TEXT,
+  FOREIGN KEY (document_id) REFERENCES markdown_documents(id)
+);
+
+CREATE INDEX IF NOT EXISTS markdown_document_invites_pending_lookup_idx
+  ON markdown_document_invites(email_normalized, status, provider_hint);
+
+CREATE UNIQUE INDEX IF NOT EXISTS markdown_document_invites_pending_provider_unique_idx
+  ON markdown_document_invites(document_id, email_normalized, provider_hint, scope)
+  WHERE status = 'pending' AND provider_hint IS NOT NULL;
+
+CREATE UNIQUE INDEX IF NOT EXISTS markdown_document_invites_pending_wildcard_unique_idx
+  ON markdown_document_invites(document_id, email_normalized, scope)
+  WHERE status = 'pending' AND provider_hint IS NULL;
+
+CREATE INDEX IF NOT EXISTS markdown_document_invites_document_idx
+  ON markdown_document_invites(document_id, status);
+
+CREATE TABLE IF NOT EXISTS markdown_document_access_requests (
+  id TEXT PRIMARY KEY,
+  document_id TEXT NOT NULL,
+  requester_principal TEXT NOT NULL,
+  scope TEXT NOT NULL CHECK (scope IN ('editor')),
+  status TEXT NOT NULL CHECK (status IN ('pending', 'approved', 'denied', 'dismissed')),
+  requested_by_actor_label TEXT NOT NULL,
+  resolved_by_actor_label TEXT,
+  created_at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ', 'now')),
+  updated_at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ', 'now')),
+  resolved_at TEXT,
+  FOREIGN KEY (document_id) REFERENCES markdown_documents(id)
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS markdown_document_access_requests_pending_unique_idx
+  ON markdown_document_access_requests(document_id, requester_principal, scope)
+  WHERE status = 'pending';
+
+CREATE INDEX IF NOT EXISTS markdown_document_access_requests_document_idx
+  ON markdown_document_access_requests(document_id, status, created_at);
+
+CREATE INDEX IF NOT EXISTS markdown_document_access_requests_requester_idx
+  ON markdown_document_access_requests(requester_principal, document_id, created_at);

--- a/apps/notebook-cloud/package.json
+++ b/apps/notebook-cloud/package.json
@@ -31,6 +31,7 @@
     "smoke:hosted:browser-execute": "node scripts/hosted-browser-execute-smoke.mjs",
     "smoke:hosted:runtime-browser-execute": "node scripts/hosted-runtime-browser-execute-smoke.mjs",
     "smoke:hosted:collab": "node --import tsx scripts/hosted-collab-smoke.mjs",
+    "smoke:hosted:markdown-doc": "node scripts/hosted-markdown-document-smoke.mjs",
     "smoke:hosted:install": "playwright install chromium",
     "smoke:hosted:source-room": "node scripts/hosted-source-room-smoke.mjs",
     "publish:demo": "node scripts/publish-demo.mjs",

--- a/apps/notebook-cloud/scripts/copy-viewer-assets.mjs
+++ b/apps/notebook-cloud/scripts/copy-viewer-assets.mjs
@@ -3,7 +3,10 @@ import { access } from "node:fs/promises";
 import { fileURLToPath } from "node:url";
 import { copyRendererSidecarAssets } from "./renderer-sidecar-assets.mjs";
 import { copyRuntimeWasmAssets } from "./runtime-wasm-assets.mjs";
-import { writeNotebookRouteAssetsManifest } from "./notebook-route-assets.mjs";
+import {
+  writeMarkdownDocumentRouteAssetsManifest,
+  writeNotebookRouteAssetsManifest,
+} from "./notebook-route-assets.mjs";
 import { writeViewerCssManifest } from "./viewer-css-assets.mjs";
 
 const siftWasmUrl = new URL("../../../crates/sift-wasm/pkg/sift_wasm_bg.wasm", import.meta.url);
@@ -57,6 +60,8 @@ const { manifest, manifestUrl } = await writeViewerCssManifest(
 );
 const { manifest: notebookRouteManifest, manifestUrl: notebookRouteManifestUrl } =
   await writeNotebookRouteAssetsManifest(new URL("../dist/assets/", import.meta.url));
+const { manifest: markdownDocumentRouteManifest, manifestUrl: markdownDocumentRouteManifestUrl } =
+  await writeMarkdownDocumentRouteAssetsManifest(new URL("../dist/assets/", import.meta.url));
 
 for (const copy of rendererSidecarAssets.copies) {
   console.log(`copied ${fileURLToPath(copy.sourceUrl)} -> ${fileURLToPath(copy.outputUrl)}`);
@@ -75,6 +80,10 @@ console.log(`wrote viewer CSS manifest ${fileURLToPath(manifestUrl)}`);
 console.log(`viewer CSS assets: ${JSON.stringify(manifest)}`);
 console.log(`wrote notebook route asset manifest ${fileURLToPath(notebookRouteManifestUrl)}`);
 console.log(`notebook route assets: ${JSON.stringify(notebookRouteManifest)}`);
+console.log(
+  `wrote Markdown document route asset manifest ${fileURLToPath(markdownDocumentRouteManifestUrl)}`,
+);
+console.log(`Markdown document route assets: ${JSON.stringify(markdownDocumentRouteManifest)}`);
 
 async function assertExists(url) {
   try {

--- a/apps/notebook-cloud/scripts/hosted-markdown-document-smoke.mjs
+++ b/apps/notebook-cloud/scripts/hosted-markdown-document-smoke.mjs
@@ -1,0 +1,448 @@
+import { readFile } from "node:fs/promises";
+import os from "node:os";
+
+import { chromium } from "@playwright/test";
+
+import { firstPositionalArg } from "./cli-args.mjs";
+import {
+  notebookCloudBaseUrl,
+  notebookCloudLocalAuthUrl,
+  notebookCloudLoopbackUrl,
+} from "./local-dev.mjs";
+import {
+  saveSmokeScreenshot,
+  smokeJsonReportPath,
+  smokeOutputPath,
+  writeSmokeJsonReport,
+} from "./smoke-paths.mjs";
+
+const baseUrl = normalizeBaseUrl(firstPositionalArg() ?? notebookCloudBaseUrl());
+const timeoutMs = parsePositiveInteger(
+  process.env.NOTEBOOK_CLOUD_MARKDOWN_SMOKE_TIMEOUT_MS,
+  60_000,
+);
+const headed = process.env.NOTEBOOK_CLOUD_HEADED === "1";
+const localUser = process.env.NOTEBOOK_CLOUD_MARKDOWN_SMOKE_LOCAL_USER ?? "markdown-browser";
+const sharePrincipal =
+  process.env.NOTEBOOK_CLOUD_MARKDOWN_SMOKE_SHARE_PRINCIPAL ??
+  `user:dev:markdown-smoke-${Date.now()}`;
+const screenshotPath = smokeOutputPath(process.env.NOTEBOOK_CLOUD_MARKDOWN_SMOKE_SCREENSHOT);
+const reportPath = smokeJsonReportPath("hosted-markdown-document-smoke");
+const tokenPath =
+  process.env.NTERACT_PREVIEW_OIDC_TOKEN_PATH ??
+  process.env.NOTEBOOK_CLOUD_OIDC_TOKEN_PATH ??
+  `${os.homedir()}/token.preview.json`;
+
+const editableMarkdownEditorSelector = ".cloud-markdown-editor .cm-content[contenteditable='true']";
+const smokeTitle = `Markdown smoke ${new Date().toISOString()}`;
+const smokeMarker = `markdown-smoke-marker-${Date.now()}`;
+const smokeBody = `# Markdown smoke
+
+${smokeMarker}
+
+## Outline from source
+
+This document is backed by one Automerge text source.
+
+### Nested detail
+
+No compute involved.
+`;
+
+main().catch((error) => {
+  console.error(error instanceof Error ? error.message : String(error));
+  process.exitCode = 1;
+});
+
+async function main() {
+  const browser = await chromium.launch({ headless: !headed, timeout: timeoutMs });
+  const context = await browser.newContext({
+    viewport: { width: 1440, height: 1000 },
+    deviceScaleFactor: 1,
+  });
+  const page = await context.newPage();
+  const failures = [];
+  const visitedUrls = new Set();
+  const checks = [];
+  const timingsMs = {};
+  const startedAt = performance.now();
+  let snapshotUrl = null;
+
+  instrumentPage({ page, failures, visitedUrls });
+
+  try {
+    await timed(timingsMs, "authenticate", () => authenticateMarkdownSmokePage(page));
+    checks.push(isLoopbackOrigin(baseUrl) ? "local_dev_auth_established" : "oidc_token_seeded");
+
+    await timed(timingsMs, "dashboard_ready", async () => {
+      await page.getByRole("heading", { name: "Documents" }).waitFor({ timeout: timeoutMs });
+      await page.getByRole("button", { name: "New Markdown" }).waitFor({ timeout: timeoutMs });
+    });
+    checks.push("markdown_dashboard_ready");
+
+    await timed(timingsMs, "create_document", async () => {
+      await page.getByRole("button", { name: "New Markdown" }).click({ timeout: timeoutMs });
+      await page.getByLabel("Title").fill(smokeTitle, { timeout: timeoutMs });
+      await page.getByRole("button", { name: "Create" }).click({ timeout: timeoutMs });
+      await page.waitForURL(/\/m\/[^/]+(?:\/.*)?$/, { timeout: timeoutMs });
+    });
+    const documentUrl = page.url();
+    checks.push("markdown_document_created");
+
+    await timed(timingsMs, "source_editor_ready", async () => {
+      await page.getByRole("button", { name: "Source" }).waitFor({ timeout: timeoutMs });
+      await page.locator(editableMarkdownEditorSelector).first().waitFor({
+        state: "visible",
+        timeout: timeoutMs,
+      });
+    });
+    checks.push("source_editor_ready");
+
+    await timed(timingsMs, "edit_source", () => replaceMarkdownSource(page, smokeBody));
+    await timed(timingsMs, "outline_updated", async () => {
+      const outline = page.getByRole("navigation", { name: "Document outline" });
+      await outline.getByRole("link", { name: "Markdown smoke" }).waitFor({ timeout: timeoutMs });
+      await outline
+        .getByRole("link", { name: "Outline from source" })
+        .waitFor({ timeout: timeoutMs });
+      await outline.getByRole("link", { name: "Nested detail" }).waitFor({ timeout: timeoutMs });
+    });
+    checks.push("source_edit_reflected_in_outline");
+
+    await timed(timingsMs, "read_mode_rendered", async () => {
+      await page.getByRole("button", { name: "Read" }).click({ timeout: timeoutMs });
+      const preview = page.locator(".cloud-markdown-preview").first();
+      await preview
+        .getByRole("heading", { name: "Markdown smoke" })
+        .waitFor({ timeout: timeoutMs });
+      await waitForPageText(page, smokeMarker, "read mode");
+    });
+    checks.push("read_mode_rendered_from_markdown_projection");
+
+    await timed(timingsMs, "responsive_layout", () => assertResponsiveMarkdownRoute(page));
+    checks.push("responsive_layout_no_document_overflow");
+
+    await timed(timingsMs, "share_document", async () => {
+      await page.getByTitle("Share Markdown document").click({ timeout: timeoutMs });
+      await page.getByRole("heading", { name: "Share document" }).waitFor({
+        timeout: timeoutMs,
+      });
+      await page.locator("#cloud-markdown-share-principal").fill(sharePrincipal, {
+        timeout: timeoutMs,
+      });
+      await page.locator("#cloud-markdown-share-scope").selectOption("editor", {
+        timeout: timeoutMs,
+      });
+      await page.getByRole("button", { name: "Grant" }).click({ timeout: timeoutMs });
+      await waitForPageText(page, `Access granted to ${sharePrincipal}.`, "share panel");
+      await waitForPageText(page, sharePrincipal, "share panel");
+    });
+    checks.push("principal_access_granted_from_share_panel");
+
+    await timed(timingsMs, "publish_document", async () => {
+      const [response] = await Promise.all([
+        page.waitForResponse(
+          (candidate) =>
+            candidate.request().method() === "PUT" &&
+            /\/api\/m\/[^/]+\/snapshots\/heads-/.test(new URL(candidate.url()).pathname),
+          { timeout: timeoutMs },
+        ),
+        page.getByRole("button", { name: /^Publish$/ }).click({ timeout: timeoutMs }),
+      ]);
+      snapshotUrl = response.url();
+      if (response.status() !== 201) {
+        throw new Error(`Markdown publish returned HTTP ${response.status()}`);
+      }
+      await waitForPageText(page, "Public link updated.", "publish notice");
+      await page.getByRole("button", { name: "Publish update" }).waitFor({
+        timeout: timeoutMs,
+      });
+    });
+    checks.push("markdown_document_published");
+
+    const snapshotCheck = await timed(timingsMs, "anonymous_snapshot_read", () =>
+      readPublishedSnapshot(snapshotUrl),
+    );
+    checks.push("published_snapshot_read_without_browser_credentials");
+
+    if (screenshotPath) {
+      await saveSmokeScreenshot(page, screenshotPath);
+      checks.push("screenshot_saved");
+    }
+
+    await page.goto(new URL("/m", baseUrl).href, {
+      waitUntil: "domcontentloaded",
+      timeout: timeoutMs,
+    });
+    checks.push("returned_to_markdown_dashboard_to_close_live_socket");
+
+    if (failures.length > 0) {
+      throw new Error(`Markdown document smoke failures:\n${JSON.stringify(failures, null, 2)}`);
+    }
+
+    const report = {
+      ok: true,
+      baseUrl,
+      documentUrl,
+      snapshotUrl,
+      title: smokeTitle,
+      sharePrincipal,
+      checks,
+      snapshot: snapshotCheck,
+      timings_ms: {
+        ...timingsMs,
+        total: elapsedMs(startedAt),
+      },
+      screenshot: screenshotPath ?? null,
+    };
+    await writeSmokeJsonReport(report, reportPath);
+    console.log(JSON.stringify(report, null, 2));
+  } finally {
+    await context.close().catch(() => {});
+    await browser.close().catch(() => {});
+  }
+}
+
+async function authenticateMarkdownSmokePage(page) {
+  if (isLoopbackOrigin(baseUrl)) {
+    const loopbackUrl = notebookCloudLoopbackUrl();
+    if (new URL(baseUrl).origin !== new URL(loopbackUrl).origin) {
+      throw new Error(
+        `Loopback smoke base ${baseUrl} does not match local dev auth origin ${loopbackUrl}`,
+      );
+    }
+    await page.goto(
+      notebookCloudLocalAuthUrl({
+        user: localUser,
+        scope: "owner",
+        next: "/m",
+      }),
+      { waitUntil: "domcontentloaded", timeout: timeoutMs },
+    );
+    return;
+  }
+
+  const tokenJson = await readOidcTokenStorageJson(tokenPath);
+  const token = JSON.parse(tokenJson);
+  const tokenSecondsRemaining = Number(token.expiresAt) - Math.floor(Date.now() / 1000);
+  if (!Number.isFinite(tokenSecondsRemaining) || tokenSecondsRemaining <= 60) {
+    throw new Error(
+      `${tokenPath} is expired or near expiry; refresh it before running the Markdown smoke`,
+    );
+  }
+  await page.addInitScript(
+    ({ origin, tokenStorageJson }) => {
+      if (globalThis.location?.origin !== origin) return;
+      globalThis.localStorage?.setItem("nteract:notebook-cloud:oidc-token", tokenStorageJson);
+      globalThis.localStorage?.setItem("nteract:notebook-cloud:scope", "owner");
+    },
+    { origin: new URL(baseUrl).origin, tokenStorageJson: tokenJson },
+  );
+  await page.goto(new URL("/m", baseUrl).href, {
+    waitUntil: "domcontentloaded",
+    timeout: timeoutMs,
+  });
+}
+
+async function replaceMarkdownSource(page, source) {
+  const editor = page.locator(editableMarkdownEditorSelector).first();
+  await editor.waitFor({ state: "visible", timeout: timeoutMs });
+  await editor.click({ timeout: timeoutMs });
+  await page.keyboard.press(process.platform === "darwin" ? "Meta+A" : "Control+A");
+  await page.keyboard.insertText(source);
+  await waitForEditorText(page, smokeMarker);
+}
+
+async function waitForEditorText(page, expectedText) {
+  await page.waitForFunction(
+    ([selector, expected]) => document.querySelector(selector)?.textContent?.includes(expected),
+    [editableMarkdownEditorSelector, expectedText],
+    { timeout: timeoutMs },
+  );
+}
+
+async function waitForPageText(page, expectedText, label) {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    if (await pageContainsText(page, expectedText)) {
+      return;
+    }
+    await page.waitForTimeout(200);
+  }
+  throw new Error(`${label} did not show expected text: ${expectedText}`);
+}
+
+async function pageContainsText(page, expectedText) {
+  const text = await page
+    .locator("body")
+    .innerText({ timeout: 1_000 })
+    .catch(() => "");
+  return text.includes(expectedText);
+}
+
+async function assertResponsiveMarkdownRoute(page) {
+  const viewports = [
+    { name: "desktop", width: 1440, height: 1000 },
+    { name: "constrained", width: 720, height: 900 },
+    { name: "mobile", width: 390, height: 860 },
+  ];
+  const failures = [];
+  for (const viewport of viewports) {
+    await page.setViewportSize({ width: viewport.width, height: viewport.height });
+    await page.waitForTimeout(100);
+    const metrics = await page.evaluate(() => {
+      const root = document.documentElement;
+      const body = document.body;
+      return {
+        rootClientWidth: root.clientWidth,
+        rootScrollWidth: root.scrollWidth,
+        bodyClientWidth: body.clientWidth,
+        bodyScrollWidth: body.scrollWidth,
+      };
+    });
+    const overflow = Math.max(
+      metrics.rootScrollWidth - metrics.rootClientWidth,
+      metrics.bodyScrollWidth - metrics.bodyClientWidth,
+    );
+    if (overflow > 2) {
+      failures.push({ viewport: viewport.name, overflow, metrics });
+    }
+  }
+  await page.setViewportSize({ width: 1440, height: 1000 });
+  if (failures.length > 0) {
+    throw new Error(
+      `Markdown route has horizontal overflow:\n${JSON.stringify(failures, null, 2)}`,
+    );
+  }
+}
+
+async function readPublishedSnapshot(url) {
+  if (!url) {
+    throw new Error("Markdown publish did not record a snapshot URL");
+  }
+  const response = await fetch(url, { headers: { Accept: "application/octet-stream" } });
+  const bytes = new Uint8Array(await response.arrayBuffer());
+  if (response.status !== 200) {
+    throw new Error(`anonymous Markdown snapshot GET returned HTTP ${response.status}`);
+  }
+  if (bytes.byteLength === 0) {
+    throw new Error("published Markdown snapshot was empty");
+  }
+  const cacheControl = response.headers.get("cache-control") ?? "";
+  if (!cacheControl.includes("immutable")) {
+    throw new Error(`published Markdown snapshot was not immutable: ${cacheControl}`);
+  }
+  return {
+    status: response.status,
+    byteLength: bytes.byteLength,
+    cacheControl,
+  };
+}
+
+function instrumentPage({ page, failures, visitedUrls }) {
+  page.on("request", (request) => {
+    visitedUrls.add(request.url());
+  });
+  page.on("response", (response) => {
+    visitedUrls.add(response.url());
+  });
+  page.on("requestfailed", (request) => {
+    const url = request.url();
+    visitedUrls.add(url);
+    if (!isRelevantRequestUrl(url)) {
+      return;
+    }
+    failures.push({
+      kind: "request-failed",
+      url: safeDiagnosticUrl(url),
+      error: request.failure()?.errorText ?? "unknown",
+    });
+  });
+  page.on("pageerror", (error) => {
+    failures.push({ kind: "page-error", text: error.message });
+  });
+  page.on("console", (message) => {
+    const text = message.text();
+    if (message.type() === "error" && !isBenignConsoleError(text)) {
+      failures.push({ kind: "console-error", text });
+    }
+  });
+}
+
+function normalizeBaseUrl(value) {
+  const url = new URL(value);
+  url.pathname = "/";
+  url.search = "";
+  url.hash = "";
+  return url.href.replace(/\/$/, "");
+}
+
+async function readOidcTokenStorageJson(path) {
+  const raw = await readFile(path, "utf8");
+  const parsed = JSON.parse(raw);
+  if (typeof parsed === "string") {
+    JSON.parse(parsed);
+    return parsed;
+  }
+  if (parsed && typeof parsed === "object") {
+    if (typeof parsed.token === "string" && typeof parsed.expiresAt === "number") {
+      return JSON.stringify(parsed);
+    }
+    if (typeof parsed.value === "string") {
+      JSON.parse(parsed.value);
+      return parsed.value;
+    }
+  }
+  throw new Error(`${path} did not contain an OIDC localStorage token JSON string`);
+}
+
+async function timed(timings, name, fn) {
+  const started = performance.now();
+  try {
+    return await fn();
+  } finally {
+    timings[name] = elapsedMs(started);
+  }
+}
+
+function elapsedMs(started) {
+  return Math.max(0, Math.round((performance.now() - started) * 100) / 100);
+}
+
+function parsePositiveInteger(value, fallback) {
+  if (value === undefined || value === "") {
+    return fallback;
+  }
+  const parsed = Number(value);
+  if (!Number.isInteger(parsed) || parsed <= 0) {
+    throw new Error(`Expected positive integer, got ${JSON.stringify(value)}`);
+  }
+  return parsed;
+}
+
+function isLoopbackOrigin(value) {
+  const hostname = new URL(value).hostname;
+  return hostname === "localhost" || hostname === "127.0.0.1" || hostname === "::1";
+}
+
+function isRelevantRequestUrl(url) {
+  const parsed = new URL(url);
+  const target = new URL(baseUrl);
+  return parsed.origin === target.origin;
+}
+
+function safeDiagnosticUrl(url) {
+  const parsed = new URL(url);
+  for (const key of parsed.searchParams.keys()) {
+    if (/token|code|state/i.test(key)) {
+      parsed.searchParams.set(key, "<redacted>");
+    }
+  }
+  return parsed.toString();
+}
+
+function isBenignConsoleError(text) {
+  return /ResizeObserver loop completed|message channel closed before a response|runtime\.lastError/i.test(
+    text,
+  );
+}

--- a/apps/notebook-cloud/scripts/hosted-markdown-document-smoke.mjs
+++ b/apps/notebook-cloud/scripts/hosted-markdown-document-smoke.mjs
@@ -67,7 +67,6 @@ async function main() {
   const checks = [];
   const timingsMs = {};
   const startedAt = performance.now();
-  let snapshotUrl = null;
 
   instrumentPage({ page, failures, visitedUrls });
 
@@ -166,32 +165,6 @@ async function main() {
     });
     checks.push("principal_access_granted_from_share_panel");
 
-    await timed(timingsMs, "publish_document", async () => {
-      const [response] = await Promise.all([
-        page.waitForResponse(
-          (candidate) =>
-            candidate.request().method() === "PUT" &&
-            /\/api\/m\/[^/]+\/snapshots\/heads-/.test(new URL(candidate.url()).pathname),
-          { timeout: timeoutMs },
-        ),
-        page.getByRole("button", { name: /^Publish$/ }).click({ timeout: timeoutMs }),
-      ]);
-      snapshotUrl = response.url();
-      if (response.status() !== 201) {
-        throw new Error(`Markdown publish returned HTTP ${response.status()}`);
-      }
-      await waitForPageText(page, "Public version saved.", "publish notice");
-      await page.getByRole("button", { name: "Update public version" }).waitFor({
-        timeout: timeoutMs,
-      });
-    });
-    checks.push("markdown_document_published");
-
-    const snapshotCheck = await timed(timingsMs, "anonymous_snapshot_read", () =>
-      readPublishedSnapshot(snapshotUrl),
-    );
-    checks.push("published_snapshot_read_without_browser_credentials");
-
     if (screenshotPath) {
       await saveSmokeScreenshot(page, screenshotPath);
       checks.push("screenshot_saved");
@@ -211,11 +184,9 @@ async function main() {
       ok: true,
       baseUrl,
       documentUrl,
-      snapshotUrl,
       title: smokeTitle,
       sharePrincipal,
       checks,
-      snapshot: snapshotCheck,
       timings_ms: {
         ...timingsMs,
         total: elapsedMs(startedAt),
@@ -357,29 +328,6 @@ async function assertResponsiveMarkdownRoute(page) {
       `Markdown route has horizontal overflow:\n${JSON.stringify(failures, null, 2)}`,
     );
   }
-}
-
-async function readPublishedSnapshot(url) {
-  if (!url) {
-    throw new Error("Markdown publish did not record a snapshot URL");
-  }
-  const response = await fetch(url, { headers: { Accept: "application/octet-stream" } });
-  const bytes = new Uint8Array(await response.arrayBuffer());
-  if (response.status !== 200) {
-    throw new Error(`anonymous Markdown snapshot GET returned HTTP ${response.status}`);
-  }
-  if (bytes.byteLength === 0) {
-    throw new Error("published Markdown snapshot was empty");
-  }
-  const cacheControl = response.headers.get("cache-control") ?? "";
-  if (!cacheControl.includes("immutable")) {
-    throw new Error(`published Markdown snapshot was not immutable: ${cacheControl}`);
-  }
-  return {
-    status: response.status,
-    byteLength: bytes.byteLength,
-    cacheControl,
-  };
 }
 
 function instrumentPage({ page, failures, visitedUrls }) {

--- a/apps/notebook-cloud/scripts/hosted-markdown-document-smoke.mjs
+++ b/apps/notebook-cloud/scripts/hosted-markdown-document-smoke.mjs
@@ -83,8 +83,24 @@ async function main() {
     await timed(timingsMs, "create_document", async () => {
       await page.getByRole("button", { name: "New Markdown" }).click({ timeout: timeoutMs });
       await page.getByLabel("Title").fill(smokeTitle, { timeout: timeoutMs });
-      await page.getByRole("button", { name: "Create" }).click({ timeout: timeoutMs });
-      await page.waitForURL(/\/m\/[^/]+(?:\/.*)?$/, { timeout: timeoutMs });
+      const [response] = await Promise.all([
+        page.waitForResponse(
+          (candidate) =>
+            candidate.request().method() === "POST" &&
+            new URL(candidate.url()).pathname === "/api/m",
+          { timeout: timeoutMs },
+        ),
+        page.getByRole("button", { name: "Create" }).click({ timeout: timeoutMs }),
+      ]);
+      if (response.status() !== 201) {
+        throw new Error(
+          `Markdown create returned HTTP ${response.status()}: ${await response.text()}`,
+        );
+      }
+      await page.waitForURL(/\/m\/[^/]+(?:\/.*)?$/, {
+        waitUntil: "domcontentloaded",
+        timeout: timeoutMs,
+      });
     });
     const documentUrl = page.url();
     checks.push("markdown_document_created");
@@ -385,6 +401,13 @@ async function readOidcTokenStorageJson(path) {
     return parsed;
   }
   if (parsed && typeof parsed === "object") {
+    if (
+      typeof parsed.accessToken === "string" &&
+      parsed.accessToken.length > 0 &&
+      typeof parsed.expiresAt === "number"
+    ) {
+      return JSON.stringify(parsed);
+    }
     if (typeof parsed.token === "string" && typeof parsed.expiresAt === "number") {
       return JSON.stringify(parsed);
     }

--- a/apps/notebook-cloud/scripts/hosted-markdown-document-smoke.mjs
+++ b/apps/notebook-cloud/scripts/hosted-markdown-document-smoke.mjs
@@ -365,7 +365,7 @@ function instrumentPage({ page, failures, visitedUrls }) {
   page.on("requestfailed", (request) => {
     const url = request.url();
     visitedUrls.add(url);
-    if (!isRelevantRequestUrl(url)) {
+    if (!isRelevantRequestUrl(url) || isBenignRequestFailureUrl(url)) {
       return;
     }
     failures.push({
@@ -452,6 +452,10 @@ function isRelevantRequestUrl(url) {
   const parsed = new URL(url);
   const target = new URL(baseUrl);
   return parsed.origin === target.origin;
+}
+
+function isBenignRequestFailureUrl(url) {
+  return new URL(url).pathname === "/cdn-cgi/rum";
 }
 
 function safeDiagnosticUrl(url) {

--- a/apps/notebook-cloud/scripts/hosted-markdown-document-smoke.mjs
+++ b/apps/notebook-cloud/scripts/hosted-markdown-document-smoke.mjs
@@ -125,6 +125,16 @@ async function main() {
     });
     checks.push("source_edit_reflected_in_outline");
 
+    await timed(timingsMs, "outline_source_navigation", async () => {
+      const outline = page.getByRole("navigation", { name: "Document outline" });
+      await outline.getByRole("link", { name: "Nested detail" }).click({ timeout: timeoutMs });
+      await page.waitForFunction(() => window.location.hash === "#nested-detail", {
+        timeout: timeoutMs,
+      });
+      await waitForSourceSelection(page, "### Nested detail");
+    });
+    checks.push("outline_navigates_mono_source_editor");
+
     await timed(timingsMs, "read_mode_rendered", async () => {
       await page.getByRole("button", { name: "Read" }).click({ timeout: timeoutMs });
       const preview = page.locator(".cloud-markdown-preview").first();
@@ -272,6 +282,22 @@ async function replaceMarkdownSource(page, source) {
 async function waitForEditorText(page, expectedText) {
   await page.waitForFunction(
     ([selector, expected]) => document.querySelector(selector)?.textContent?.includes(expected),
+    [editableMarkdownEditorSelector, expectedText],
+    { timeout: timeoutMs },
+  );
+}
+
+async function waitForSourceSelection(page, expectedText) {
+  await page.waitForFunction(
+    ([selector, expected]) => {
+      const editor = document.querySelector(selector);
+      const activeElement = document.activeElement;
+      const editorIsFocused =
+        editor instanceof HTMLElement &&
+        activeElement instanceof HTMLElement &&
+        (editor === activeElement || editor.contains(activeElement));
+      return editorIsFocused && document.getSelection()?.toString().includes(expected);
+    },
     [editableMarkdownEditorSelector, expectedText],
     { timeout: timeoutMs },
   );

--- a/apps/notebook-cloud/scripts/hosted-markdown-document-smoke.mjs
+++ b/apps/notebook-cloud/scripts/hosted-markdown-document-smoke.mjs
@@ -33,7 +33,8 @@ const tokenPath =
   process.env.NOTEBOOK_CLOUD_OIDC_TOKEN_PATH ??
   `${os.homedir()}/token.preview.json`;
 
-const editableMarkdownEditorSelector = ".cloud-markdown-editor .cm-content[contenteditable='true']";
+const editableMarkdownEditorSelector =
+  ".markdown-document-editor .cm-content[contenteditable='true']";
 const smokeTitle = `Markdown smoke ${new Date().toISOString()}`;
 const smokeMarker = `markdown-smoke-marker-${Date.now()}`;
 const smokeBody = `# Markdown smoke
@@ -105,14 +106,14 @@ async function main() {
     const documentUrl = page.url();
     checks.push("markdown_document_created");
 
-    await timed(timingsMs, "source_editor_ready", async () => {
-      await page.getByRole("button", { name: "Source" }).waitFor({ timeout: timeoutMs });
+    await timed(timingsMs, "edit_editor_ready", async () => {
+      await page.getByRole("button", { name: "Edit" }).waitFor({ timeout: timeoutMs });
       await page.locator(editableMarkdownEditorSelector).first().waitFor({
         state: "visible",
         timeout: timeoutMs,
       });
     });
-    checks.push("source_editor_ready");
+    checks.push("edit_editor_ready");
 
     await timed(timingsMs, "edit_source", () => replaceMarkdownSource(page, smokeBody));
     await timed(timingsMs, "outline_updated", async () => {
@@ -135,15 +136,15 @@ async function main() {
     });
     checks.push("outline_navigates_mono_source_editor");
 
-    await timed(timingsMs, "read_mode_rendered", async () => {
-      await page.getByRole("button", { name: "Read" }).click({ timeout: timeoutMs });
-      const preview = page.locator(".cloud-markdown-preview").first();
+    await timed(timingsMs, "view_mode_rendered", async () => {
+      await page.getByRole("button", { name: "View" }).click({ timeout: timeoutMs });
+      const preview = page.locator(".markdown-document-preview").first();
       await preview
         .getByRole("heading", { name: "Markdown smoke" })
         .waitFor({ timeout: timeoutMs });
-      await waitForPageText(page, smokeMarker, "read mode");
+      await waitForPageText(page, smokeMarker, "view mode");
     });
-    checks.push("read_mode_rendered_from_markdown_projection");
+    checks.push("view_mode_rendered_from_markdown_projection");
 
     await timed(timingsMs, "responsive_layout", () => assertResponsiveMarkdownRoute(page));
     checks.push("responsive_layout_no_document_overflow");
@@ -179,8 +180,8 @@ async function main() {
       if (response.status() !== 201) {
         throw new Error(`Markdown publish returned HTTP ${response.status()}`);
       }
-      await waitForPageText(page, "Public link updated.", "publish notice");
-      await page.getByRole("button", { name: "Publish update" }).waitFor({
+      await waitForPageText(page, "Public version saved.", "publish notice");
+      await page.getByRole("button", { name: "Update public version" }).waitFor({
         timeout: timeoutMs,
       });
     });

--- a/apps/notebook-cloud/scripts/notebook-route-assets.mjs
+++ b/apps/notebook-cloud/scripts/notebook-route-assets.mjs
@@ -12,7 +12,11 @@ const MODULE_PRELOAD_STEMS = [
 ];
 const STYLE_PRELOAD_STEMS = ["notebook-route", "katex"];
 const REQUIRED_MODULE_PRELOAD_STEMS = ["notebook-route", "katex.min"];
-const REQUIRED_STYLE_PRELOAD_STEMS = ["notebook-route", "katex"];
+// Route CSS is optional here because Vite may fold route-owned styles into the
+// primary notebook-cloud-viewer.css asset. That primary stylesheet is guarded by
+// viewer-css-assets.mjs; if Vite splits notebook-route.css again, we still
+// collect and preload it through STYLE_PRELOAD_STEMS.
+const REQUIRED_STYLE_PRELOAD_STEMS = ["katex"];
 
 export async function collectNotebookRouteAssets(
   assetsDirUrl,

--- a/apps/notebook-cloud/scripts/notebook-route-assets.mjs
+++ b/apps/notebook-cloud/scripts/notebook-route-assets.mjs
@@ -1,8 +1,9 @@
 import { readdir, writeFile } from "node:fs/promises";
 
 export const NOTEBOOK_ROUTE_ASSETS_MANIFEST = "notebook-route-assets.json";
+export const MARKDOWN_DOCUMENT_ROUTE_ASSETS_MANIFEST = "markdown-document-route-assets.json";
 
-const MODULE_PRELOAD_STEMS = [
+const NOTEBOOK_MODULE_PRELOAD_STEMS = [
   "notebook-route",
   "MarkdownText",
   "markdown",
@@ -10,39 +11,105 @@ const MODULE_PRELOAD_STEMS = [
   "katex.min",
   "utils",
 ];
-const STYLE_PRELOAD_STEMS = ["notebook-route", "katex"];
-const REQUIRED_MODULE_PRELOAD_STEMS = ["notebook-route", "katex.min"];
+const NOTEBOOK_MODULE_PRELOAD_EXCLUDE_STEMS = ["markdown-document", "markdown-projection"];
+const NOTEBOOK_STYLE_PRELOAD_STEMS = ["notebook-route", "katex"];
+const REQUIRED_NOTEBOOK_MODULE_PRELOAD_STEMS = ["notebook-route", "katex.min"];
 // Route CSS is optional here because Vite may fold route-owned styles into the
 // primary notebook-cloud-viewer.css asset. That primary stylesheet is guarded by
 // viewer-css-assets.mjs; if Vite splits notebook-route.css again, we still
-// collect and preload it through STYLE_PRELOAD_STEMS.
-const REQUIRED_STYLE_PRELOAD_STEMS = ["katex"];
+// collect and preload it through NOTEBOOK_STYLE_PRELOAD_STEMS.
+const REQUIRED_NOTEBOOK_STYLE_PRELOAD_STEMS = ["katex"];
+
+const MARKDOWN_DOCUMENT_MODULE_PRELOAD_STEMS = [
+  "markdown-document-route",
+  "markdown-projection",
+  "MarkdownText",
+  "katex.min",
+  "utils",
+  "cloud-notebook-title",
+  "cloud-response",
+  "use-cloud-auth",
+];
+const MARKDOWN_DOCUMENT_MODULE_PRELOAD_EXCLUDE_STEMS = [
+  "markdown-document-live-sync",
+  "codemirror-editor",
+];
+const MARKDOWN_DOCUMENT_STYLE_PRELOAD_STEMS = ["katex"];
+const REQUIRED_MARKDOWN_DOCUMENT_MODULE_PRELOAD_STEMS = [
+  "markdown-document-route",
+  "markdown-projection",
+  "katex.min",
+];
+const REQUIRED_MARKDOWN_DOCUMENT_STYLE_PRELOAD_STEMS = ["katex"];
 
 export async function collectNotebookRouteAssets(
   assetsDirUrl,
-  { modulePreloadStems = MODULE_PRELOAD_STEMS, stylePreloadStems = STYLE_PRELOAD_STEMS } = {},
+  {
+    modulePreloadStems = NOTEBOOK_MODULE_PRELOAD_STEMS,
+    modulePreloadExcludeStems = NOTEBOOK_MODULE_PRELOAD_EXCLUDE_STEMS,
+    stylePreloadStems = NOTEBOOK_STYLE_PRELOAD_STEMS,
+  } = {},
 ) {
   const entries = await readdir(assetsDirUrl);
   return {
-    modulepreload: collectAssetNames(entries, modulePreloadStems, ".js"),
+    modulepreload: collectAssetNames(entries, modulePreloadStems, ".js", {
+      excludeStems: modulePreloadExcludeStems,
+    }),
+    stylepreload: collectAssetNames(entries, stylePreloadStems, ".css"),
+  };
+}
+
+export async function collectMarkdownDocumentRouteAssets(
+  assetsDirUrl,
+  {
+    modulePreloadStems = MARKDOWN_DOCUMENT_MODULE_PRELOAD_STEMS,
+    modulePreloadExcludeStems = MARKDOWN_DOCUMENT_MODULE_PRELOAD_EXCLUDE_STEMS,
+    stylePreloadStems = MARKDOWN_DOCUMENT_STYLE_PRELOAD_STEMS,
+  } = {},
+) {
+  const entries = await readdir(assetsDirUrl);
+  return {
+    modulepreload: collectAssetNames(entries, modulePreloadStems, ".js", {
+      excludeStems: modulePreloadExcludeStems,
+    }),
     stylepreload: collectAssetNames(entries, stylePreloadStems, ".css"),
   };
 }
 
 export async function writeNotebookRouteAssetsManifest(assetsDirUrl) {
   const manifest = await collectNotebookRouteAssets(assetsDirUrl);
-  assertRequiredRouteAssets(manifest);
+  assertRequiredRouteAssets(manifest, {
+    manifestName: NOTEBOOK_ROUTE_ASSETS_MANIFEST,
+    modulePreloadStems: REQUIRED_NOTEBOOK_MODULE_PRELOAD_STEMS,
+    stylePreloadStems: REQUIRED_NOTEBOOK_STYLE_PRELOAD_STEMS,
+  });
   const manifestUrl = new URL(NOTEBOOK_ROUTE_ASSETS_MANIFEST, assetsDirUrl);
   await writeFile(manifestUrl, `${JSON.stringify(manifest, null, 2)}\n`);
   return { manifest, manifestUrl };
 }
 
-function collectAssetNames(entries, stems, extension) {
+export async function writeMarkdownDocumentRouteAssetsManifest(assetsDirUrl) {
+  const manifest = await collectMarkdownDocumentRouteAssets(assetsDirUrl);
+  assertRequiredRouteAssets(manifest, {
+    manifestName: MARKDOWN_DOCUMENT_ROUTE_ASSETS_MANIFEST,
+    modulePreloadStems: REQUIRED_MARKDOWN_DOCUMENT_MODULE_PRELOAD_STEMS,
+    stylePreloadStems: REQUIRED_MARKDOWN_DOCUMENT_STYLE_PRELOAD_STEMS,
+  });
+  const manifestUrl = new URL(MARKDOWN_DOCUMENT_ROUTE_ASSETS_MANIFEST, assetsDirUrl);
+  await writeFile(manifestUrl, `${JSON.stringify(manifest, null, 2)}\n`);
+  return { manifest, manifestUrl };
+}
+
+function collectAssetNames(entries, stems, extension, { excludeStems = [] } = {}) {
   const names = new Set();
   for (const stem of stems) {
     for (const entry of entries
       .filter((entry) => entry.endsWith(extension))
       .filter((entry) => assetNameMatchesStem(entry, stem, extension))
+      .filter(
+        (entry) =>
+          !excludeStems.some((excludeStem) => assetNameMatchesStem(entry, excludeStem, extension)),
+      )
       .sort()) {
       names.add(entry);
     }
@@ -52,10 +119,7 @@ function collectAssetNames(entries, stems, extension) {
 
 function assertRequiredRouteAssets(
   manifest,
-  {
-    modulePreloadStems = REQUIRED_MODULE_PRELOAD_STEMS,
-    stylePreloadStems = REQUIRED_STYLE_PRELOAD_STEMS,
-  } = {},
+  { manifestName, modulePreloadStems, stylePreloadStems } = {},
 ) {
   const missingModuleStems = missingAssetStems(manifest.modulepreload, modulePreloadStems, ".js");
   const missingStyleStems = missingAssetStems(manifest.stylepreload, stylePreloadStems, ".css");
@@ -68,7 +132,7 @@ function assertRequiredRouteAssets(
     ...missingStyleStems.map((stem) => `${stem}.css`),
   ];
   throw new Error(
-    `Unable to write ${NOTEBOOK_ROUTE_ASSETS_MANIFEST}: missing required route preload assets: ${missing.join(", ")}`,
+    `Unable to write ${manifestName}: missing required route preload assets: ${missing.join(", ")}`,
   );
 }
 

--- a/apps/notebook-cloud/src/access-requests-storage.ts
+++ b/apps/notebook-cloud/src/access-requests-storage.ts
@@ -1,11 +1,14 @@
 import type { D1Database, D1PreparedStatement, Env } from "./cloudflare-types.ts";
 import {
   ensureCatalogSchema,
+  type MarkdownDocumentAccessRequestRow,
+  type MarkdownDocumentAccessRequestStatus,
   type NotebookAccessRequestRow,
   type NotebookAccessRequestStatus,
 } from "./storage.ts";
 
 const NOTEBOOK_ACCESS_REQUEST_LIST_LIMIT = 200;
+const MARKDOWN_DOCUMENT_ACCESS_REQUEST_LIST_LIMIT = 200;
 
 export interface NotebookAccessRequestInput {
   id?: string;
@@ -17,6 +20,19 @@ export interface NotebookAccessRequestInput {
 
 export interface NotebookAccessRequestCreateResult {
   request: NotebookAccessRequestRow;
+  created: boolean;
+}
+
+export interface MarkdownDocumentAccessRequestInput {
+  id?: string;
+  documentId: string;
+  requesterPrincipal: string;
+  actorLabel: string;
+  timestamp?: string;
+}
+
+export interface MarkdownDocumentAccessRequestCreateResult {
+  request: MarkdownDocumentAccessRequestRow;
   created: boolean;
 }
 
@@ -79,6 +95,65 @@ export async function createNotebookAccessRequest(
   return created ? { request: created, created: true } : null;
 }
 
+export async function createMarkdownDocumentAccessRequest(
+  env: Env,
+  input: MarkdownDocumentAccessRequestInput,
+): Promise<MarkdownDocumentAccessRequestCreateResult | null> {
+  if (!env.DB) {
+    return null;
+  }
+
+  await ensureCatalogSchema(env);
+  const timestamp = input.timestamp ?? new Date().toISOString();
+  const existing = await getExistingPendingMarkdownDocumentAccessRequest(env, {
+    documentId: input.documentId,
+    requesterPrincipal: input.requesterPrincipal,
+  });
+  if (existing) {
+    return { request: existing, created: false };
+  }
+
+  const requestId = input.id ?? crypto.randomUUID();
+  try {
+    await env.DB.prepare(
+      `INSERT INTO markdown_document_access_requests (
+       id,
+       document_id,
+       requester_principal,
+       scope,
+       status,
+       requested_by_actor_label,
+       created_at,
+       updated_at
+     ) VALUES (?, ?, ?, 'editor', 'pending', ?, ?, ?)`,
+    )
+      .bind(
+        requestId,
+        input.documentId,
+        input.requesterPrincipal,
+        input.actorLabel,
+        timestamp,
+        timestamp,
+      )
+      .run();
+  } catch (error) {
+    if (!isUniqueConstraintError(error)) {
+      throw error;
+    }
+    const raced = await getExistingPendingMarkdownDocumentAccessRequest(env, {
+      documentId: input.documentId,
+      requesterPrincipal: input.requesterPrincipal,
+    });
+    if (raced) {
+      return { request: raced, created: false };
+    }
+    throw error;
+  }
+
+  const created = await getMarkdownDocumentAccessRequest(env, input.documentId, requestId);
+  return created ? { request: created, created: true } : null;
+}
+
 export async function getNotebookAccessRequest(
   env: Env,
   notebookId: string,
@@ -92,6 +167,23 @@ export async function getNotebookAccessRequest(
   return await env.DB.prepare(accessRequestSelectSql("WHERE notebook_id = ? AND id = ?"))
     .bind(notebookId, requestId)
     .first<NotebookAccessRequestRow>();
+}
+
+export async function getMarkdownDocumentAccessRequest(
+  env: Env,
+  documentId: string,
+  requestId: string,
+): Promise<MarkdownDocumentAccessRequestRow | null> {
+  if (!env.DB) {
+    return null;
+  }
+
+  await ensureCatalogSchema(env);
+  return await env.DB.prepare(
+    markdownDocumentAccessRequestSelectSql("WHERE document_id = ? AND id = ?"),
+  )
+    .bind(documentId, requestId)
+    .first<MarkdownDocumentAccessRequestRow>();
 }
 
 export async function getLatestNotebookAccessRequestForRequester(
@@ -115,6 +207,27 @@ export async function getLatestNotebookAccessRequestForRequester(
     .first<NotebookAccessRequestRow>();
 }
 
+export async function getLatestMarkdownDocumentAccessRequestForRequester(
+  env: Env,
+  input: {
+    documentId: string;
+    requesterPrincipal: string;
+  },
+): Promise<MarkdownDocumentAccessRequestRow | null> {
+  if (!env.DB) {
+    return null;
+  }
+
+  await ensureCatalogSchema(env);
+  return await env.DB.prepare(
+    `${markdownDocumentAccessRequestSelectSql("WHERE document_id = ? AND requester_principal = ?")}
+       ORDER BY created_at DESC, id DESC
+       LIMIT 1`,
+  )
+    .bind(input.documentId, input.requesterPrincipal)
+    .first<MarkdownDocumentAccessRequestRow>();
+}
+
 export async function listNotebookAccessRequests(
   env: Env,
   notebookId: string,
@@ -131,6 +244,25 @@ export async function listNotebookAccessRequests(
   )
     .bind(notebookId, NOTEBOOK_ACCESS_REQUEST_LIST_LIMIT)
     .all<NotebookAccessRequestRow>();
+  return rows.results ?? [];
+}
+
+export async function listMarkdownDocumentAccessRequests(
+  env: Env,
+  documentId: string,
+): Promise<MarkdownDocumentAccessRequestRow[]> {
+  if (!env.DB) {
+    return [];
+  }
+
+  await ensureCatalogSchema(env);
+  const rows = await env.DB.prepare(
+    `${markdownDocumentAccessRequestSelectSql("WHERE document_id = ?")}
+       ORDER BY created_at DESC, id DESC
+       LIMIT ?`,
+  )
+    .bind(documentId, MARKDOWN_DOCUMENT_ACCESS_REQUEST_LIST_LIMIT)
+    .all<MarkdownDocumentAccessRequestRow>();
   return rows.results ?? [];
 }
 
@@ -167,6 +299,39 @@ export async function resolveNotebookAccessRequest(
   return await getNotebookAccessRequest(env, input.notebookId, input.requestId);
 }
 
+export async function resolveMarkdownDocumentAccessRequest(
+  env: Env,
+  input: {
+    documentId: string;
+    requestId: string;
+    status: Exclude<MarkdownDocumentAccessRequestStatus, "pending">;
+    actorLabel: string;
+    timestamp?: string;
+  },
+): Promise<MarkdownDocumentAccessRequestRow | null> {
+  const db = env.DB;
+  if (!db) {
+    return null;
+  }
+
+  await ensureCatalogSchema(env);
+  const timestamp = input.timestamp ?? new Date().toISOString();
+  const result =
+    input.status === "approved"
+      ? (
+          await db.batch([
+            approvedMarkdownDocumentAccessRequestAclInsert(db, input, timestamp),
+            markdownDocumentAccessRequestResolutionUpdate(db, input, timestamp),
+          ])
+        )[1]
+      : await markdownDocumentAccessRequestResolutionUpdate(db, input, timestamp).run();
+  if (d1Changes(result) === 0) {
+    return null;
+  }
+
+  return await getMarkdownDocumentAccessRequest(env, input.documentId, input.requestId);
+}
+
 async function getExistingPendingNotebookAccessRequest(
   env: Env,
   input: {
@@ -191,6 +356,30 @@ async function getExistingPendingNotebookAccessRequest(
     .first<NotebookAccessRequestRow>();
 }
 
+async function getExistingPendingMarkdownDocumentAccessRequest(
+  env: Env,
+  input: {
+    documentId: string;
+    requesterPrincipal: string;
+  },
+): Promise<MarkdownDocumentAccessRequestRow | null> {
+  const db = env.DB;
+  if (!db) {
+    return null;
+  }
+
+  return await db
+    .prepare(
+      `${markdownDocumentAccessRequestSelectSql(
+        "WHERE document_id = ? AND requester_principal = ? AND scope = 'editor' AND status = 'pending'",
+      )}
+       ORDER BY created_at
+       LIMIT 1`,
+    )
+    .bind(input.documentId, input.requesterPrincipal)
+    .first<MarkdownDocumentAccessRequestRow>();
+}
+
 function accessRequestResolutionUpdate(
   db: D1Database,
   input: {
@@ -213,6 +402,30 @@ function accessRequestResolutionUpdate(
           AND status = 'pending'`,
     )
     .bind(input.status, input.actorLabel, timestamp, timestamp, input.notebookId, input.requestId);
+}
+
+function markdownDocumentAccessRequestResolutionUpdate(
+  db: D1Database,
+  input: {
+    documentId: string;
+    requestId: string;
+    status: Exclude<MarkdownDocumentAccessRequestStatus, "pending">;
+    actorLabel: string;
+  },
+  timestamp: string,
+): D1PreparedStatement {
+  return db
+    .prepare(
+      `UPDATE markdown_document_access_requests
+          SET status = ?,
+              resolved_by_actor_label = ?,
+              resolved_at = ?,
+              updated_at = ?
+        WHERE document_id = ?
+          AND id = ?
+          AND status = 'pending'`,
+    )
+    .bind(input.status, input.actorLabel, timestamp, timestamp, input.documentId, input.requestId);
 }
 
 function approvedAccessRequestAclInsert(
@@ -252,6 +465,43 @@ function approvedAccessRequestAclInsert(
     .bind(timestamp, timestamp, input.actorLabel, input.notebookId, input.requestId);
 }
 
+function approvedMarkdownDocumentAccessRequestAclInsert(
+  db: D1Database,
+  input: {
+    documentId: string;
+    requestId: string;
+    actorLabel: string;
+  },
+  timestamp: string,
+): D1PreparedStatement {
+  return db
+    .prepare(
+      `INSERT INTO markdown_document_acl (
+         document_id,
+         subject_kind,
+         subject,
+         scope,
+         created_at,
+         updated_at,
+         created_by_actor_label
+       )
+       SELECT document_id,
+              'principal',
+              requester_principal,
+              scope,
+              ?,
+              ?,
+              ?
+         FROM markdown_document_access_requests
+        WHERE document_id = ?
+          AND id = ?
+          AND status = 'pending'
+       ON CONFLICT(document_id, subject_kind, subject, scope) DO UPDATE SET
+         updated_at = excluded.updated_at`,
+    )
+    .bind(timestamp, timestamp, input.actorLabel, input.documentId, input.requestId);
+}
+
 function accessRequestSelectSql(whereClause: string): string {
   return `SELECT id,
                  notebook_id,
@@ -264,6 +514,21 @@ function accessRequestSelectSql(whereClause: string): string {
                  updated_at,
                  resolved_at
             FROM notebook_access_requests
+            ${whereClause}`;
+}
+
+function markdownDocumentAccessRequestSelectSql(whereClause: string): string {
+  return `SELECT id,
+                 document_id,
+                 requester_principal,
+                 scope,
+                 status,
+                 requested_by_actor_label,
+                 resolved_by_actor_label,
+                 created_at,
+                 updated_at,
+                 resolved_at
+            FROM markdown_document_access_requests
             ${whereClause}`;
 }
 

--- a/apps/notebook-cloud/src/app-session.ts
+++ b/apps/notebook-cloud/src/app-session.ts
@@ -5,6 +5,7 @@ export interface AppSessionEnvironment {
 }
 
 export interface CloudAppSession {
+  cacheKey: string;
   displayName?: string;
   expiresAt: number;
   issuedAt: number;
@@ -20,6 +21,7 @@ interface CloudAppSessionPayload {
   ns: string;
   principal: string;
   provider: "oidc";
+  sid?: string;
   v: 1;
 }
 
@@ -50,6 +52,7 @@ export async function createCloudAppSessionCookie(
     ns: identity.metadata.principalNamespace,
     iat: nowSeconds,
     exp: nowSeconds + NOTEBOOK_CLOUD_APP_SESSION_MAX_AGE_SECONDS,
+    sid: crypto.randomUUID(),
     ...(displayName ? { display_name: displayName } : {}),
   };
   const value = await signCloudAppSession(env, payload);
@@ -81,8 +84,29 @@ export async function readCloudAppSession(
     principalNamespace: payload.ns,
     issuedAt: payload.iat,
     expiresAt: payload.exp,
+    cacheKey: await appSessionCacheKey(env, payload),
     ...(payload.display_name ? { displayName: payload.display_name } : {}),
   };
+}
+
+async function appSessionCacheKey(
+  env: AppSessionEnvironment,
+  payload: CloudAppSessionPayload,
+): Promise<string> {
+  const signature = await hmacSha256(
+    env,
+    [
+      "app-session-cache",
+      "v1",
+      payload.provider,
+      payload.ns,
+      payload.principal,
+      String(payload.iat),
+      String(payload.exp),
+      payload.sid ?? "legacy",
+    ].join(":"),
+  );
+  return base64UrlEncodeBytes(signature);
 }
 
 async function signCloudAppSession(
@@ -178,6 +202,7 @@ function isCloudAppSessionPayload(value: unknown): value is CloudAppSessionPaylo
     typeof payload.ns === "string" &&
     Number.isFinite(payload.iat) &&
     Number.isFinite(payload.exp) &&
+    (payload.sid === undefined || typeof payload.sid === "string") &&
     (payload.display_name === undefined || typeof payload.display_name === "string")
   );
 }

--- a/apps/notebook-cloud/src/cloudflare-types.ts
+++ b/apps/notebook-cloud/src/cloudflare-types.ts
@@ -1,5 +1,6 @@
 export interface Env {
   NOTEBOOK_ROOMS: DurableObjectNamespace;
+  MARKDOWN_DOCUMENT_ROOMS?: DurableObjectNamespace;
   WORKSTATION_EVENTS?: DurableObjectNamespace;
   DB?: D1Database;
   NOTEBOOK_SNAPSHOTS?: R2Bucket;

--- a/apps/notebook-cloud/src/identity.ts
+++ b/apps/notebook-cloud/src/identity.ts
@@ -560,6 +560,14 @@ export function stampTrustedIdentity(request: Request, identity: AuthenticatedCo
   return new Request(request, { headers });
 }
 
+export function webSocketUpgradeHeaders(identity: AuthenticatedConnection): Headers {
+  const headers = new Headers();
+  if (identity.webSocketProtocol) {
+    headers.set("Sec-WebSocket-Protocol", identity.webSocketProtocol);
+  }
+  return headers;
+}
+
 export function readTrustedIdentity(request: Request): AuthenticatedConnection {
   const principal = request.headers.get(TRUSTED_PRINCIPAL_HEADER);
   const operator = request.headers.get(TRUSTED_OPERATOR_HEADER);

--- a/apps/notebook-cloud/src/index.ts
+++ b/apps/notebook-cloud/src/index.ts
@@ -5461,14 +5461,25 @@ async function markdownDocumentViewer(
     return viewerShellHead(env);
   }
 
-  const shellMetadata = await publicMarkdownDocumentShellMetadata(
+  const documentApiBasePath = `/api/m/${encodeURIComponent(documentId)}`;
+  const shellMetadataPromise = publicMarkdownDocumentShellMetadata(
     env,
     documentId,
     routeTitleSegment,
   );
-  const documentApiBasePath = `/api/m/${encodeURIComponent(documentId)}`;
-  const runtimeWasmAssets = await runtimeWasmAssetNames(env);
-  const session = await readCloudAppSession(env, request).catch(() => null);
+  const runtimeWasmAssetsPromise = runtimeWasmAssetNames(env);
+  const routeAssetsPromise = notebookRouteAssetNames(env);
+  const sessionPromise = readCloudAppSession(env, request).catch(() => null);
+  const bootstrapPromise = sessionPromise.then((session) =>
+    markdownDocumentViewerBootstrap(env, documentId, session),
+  );
+  const [shellMetadata, runtimeWasmAssets, routeAssets, session, bootstrap] = await Promise.all([
+    shellMetadataPromise,
+    runtimeWasmAssetsPromise,
+    routeAssetsPromise,
+    sessionPromise,
+    bootstrapPromise,
+  ]);
   const config = {
     documentKind: "markdown",
     documentId,
@@ -5480,14 +5491,49 @@ async function markdownDocumentViewer(
       canManageSharing: true,
       canPublish: true,
     },
+    bootstrap,
     session: session ? appSessionResponse(session) : null,
     runtimedWasmModulePath: runtimedWasmAssetPath(env, runtimeWasmAssets.module),
     runtimedWasmPath: runtimedWasmAssetPath(env, runtimeWasmAssets.wasm),
   };
   return responseForRequestMethod(
     request,
-    viewerShell(shellMetadata, env, authConfigForRequest(request, env), config),
+    viewerShell(shellMetadata, env, authConfigForRequest(request, env), config, null, {
+      notebookRouteAssets: routeAssets,
+      runtimedWasmModulePath: config.runtimedWasmModulePath,
+      runtimedWasmPath: config.runtimedWasmPath,
+    }),
   );
+}
+
+async function markdownDocumentViewerBootstrap(
+  env: Env,
+  documentId: string,
+  session: CloudAppSession | null,
+): Promise<Record<string, unknown> | null> {
+  if (!session) {
+    return null;
+  }
+  const identity = appSessionConnectionIdentity(session, "browser:http", "viewer");
+  const authorized = await authorizeMarkdownDocumentReadWithBestScope(
+    env,
+    documentId,
+    identity,
+  ).catch(() => null);
+  if (!authorized) {
+    return null;
+  }
+  const document = await getMarkdownDocumentRow(env, documentId);
+  if (!document) {
+    return null;
+  }
+  return {
+    body_doc_id: document.body_doc_id,
+    latest_revision_id: document.latest_revision_id,
+    scope: authorized.scope,
+    title: document.title,
+    updated_at: document.updated_at,
+  };
 }
 
 function oidcCallbackViewer(request: Request, env: Env): Response {
@@ -5786,7 +5832,7 @@ function notebookRouteResourceHints(
   const styleRel =
     styleHint === "prefetch"
       ? (name: string) => `<link rel="prefetch" href="/assets/${escapeHtml(name)}" as="style" />`
-      : (name: string) => `<link rel="preload" href="/assets/${escapeHtml(name)}" as="style" />`;
+      : (name: string) => `<link rel="stylesheet" href="/assets/${escapeHtml(name)}" />`;
   return [
     ...assets.modulepreload.map(
       (name) => `<link rel="modulepreload" href="/assets/${escapeHtml(name)}" />`,

--- a/apps/notebook-cloud/src/index.ts
+++ b/apps/notebook-cloud/src/index.ts
@@ -2848,6 +2848,7 @@ async function routeSnapshot(
   }
   const runtimeKey = runtimeStateSnapshotKey(runtimeStateDocId, runtimeHeadsHash);
   const commsKey = commsHeadsHash ? commsDocSnapshotKey(runtimeStateDocId, commsHeadsHash) : null;
+  const existingSnapshot = await env.NOTEBOOK_SNAPSHOTS.head(key);
   await env.NOTEBOOK_SNAPSHOTS.put(key, body, {
     httpMetadata: {
       contentType: request.headers.get("content-type") ?? "application/octet-stream",
@@ -2915,7 +2916,9 @@ async function routeSnapshot(
       publishPublic: true,
     });
   } catch (error) {
-    await env.NOTEBOOK_SNAPSHOTS.delete(key).catch(() => undefined);
+    if (!existingSnapshot) {
+      await env.NOTEBOOK_SNAPSHOTS.delete(key).catch(() => undefined);
+    }
     throw error;
   }
 
@@ -2988,6 +2991,7 @@ async function routeMarkdownDocumentSnapshot(
     return json(validation.body, validation.status);
   }
 
+  const snapshotAlreadyExisted = (await env.NOTEBOOK_SNAPSHOTS.head(key)) !== null;
   await env.NOTEBOOK_SNAPSHOTS.put(key, body, {
     httpMetadata: {
       contentType: request.headers.get("content-type") ?? "application/octet-stream",
@@ -3009,7 +3013,9 @@ async function routeMarkdownDocumentSnapshot(
       publishPublic: true,
     });
   } catch (error) {
-    await env.NOTEBOOK_SNAPSHOTS.delete(key).catch(() => undefined);
+    if (!snapshotAlreadyExisted) {
+      await env.NOTEBOOK_SNAPSHOTS.delete(key).catch(() => undefined);
+    }
     throw error;
   }
 

--- a/apps/notebook-cloud/src/index.ts
+++ b/apps/notebook-cloud/src/index.ts
@@ -74,6 +74,7 @@ import {
   updateWorkstationAttachJobStatus,
   type ListedMarkdownDocumentRow,
   type ListedNotebookRow,
+  type MarkdownDocumentCatalog,
   type MarkdownDocumentAclRow,
   type MarkdownDocumentScope,
   type NotebookAclRow,
@@ -102,7 +103,7 @@ import {
   type WorkstationAttachJobNotification,
 } from "./workstation-events.ts";
 import { materializeSnapshotPairRender } from "./snapshot-render.ts";
-import { loadMarkdownRoomHostSnapshot } from "./runtimed-wasm.ts";
+import { loadMarkdownRoomHostSnapshot, projectMarkdownJson } from "./runtimed-wasm.ts";
 import { notebookRouteSegmentTitle } from "./notebook-route-title.ts";
 import {
   createNotebookCloudBlobResolver,
@@ -5401,6 +5402,8 @@ interface ViewerShellResourceHints {
   runtimedWasmPath?: string | null;
 }
 
+const MARKDOWN_DOCUMENT_BOOTSTRAP_BODY_MAX_BYTES = 128 * 1024;
+
 function rootNotebookListRedirect(request: Request): Response {
   const url = new URL(request.url);
   url.pathname = "/n";
@@ -5530,17 +5533,82 @@ async function markdownDocumentViewerBootstrap(
   if (!authorized) {
     return null;
   }
-  const document = await getMarkdownDocumentRow(env, documentId);
-  if (!document) {
+  const catalog = await getMarkdownDocumentCatalog(env, documentId);
+  if (!catalog) {
     return null;
   }
+  const document = catalog.document;
+  const renderSeed = await markdownDocumentBootstrapRenderSeed(env, catalog);
   return {
     body_doc_id: document.body_doc_id,
     latest_revision_id: document.latest_revision_id,
+    ...(renderSeed ? { render_seed: renderSeed } : {}),
     scope: authorized.scope,
     title: document.title,
     updated_at: document.updated_at,
   };
+}
+
+async function markdownDocumentBootstrapRenderSeed(
+  env: Env,
+  catalog: MarkdownDocumentCatalog,
+): Promise<Record<string, unknown> | null> {
+  if (!env.NOTEBOOK_SNAPSHOTS || !catalog.document.latest_revision_id) {
+    return null;
+  }
+  const revision =
+    catalog.revisions.find((candidate) => candidate.id === catalog.document.latest_revision_id) ??
+    null;
+  if (!revision) {
+    return null;
+  }
+  try {
+    const object = await env.NOTEBOOK_SNAPSHOTS.get(revision.snapshot_key);
+    if (!object || object.size > MARKDOWN_DOCUMENT_BOOTSTRAP_BODY_MAX_BYTES) {
+      return null;
+    }
+    const bytes = new Uint8Array(await object.arrayBuffer());
+    const handle = await loadMarkdownRoomHostSnapshot(bytes);
+    try {
+      const body = handle.body() ?? "";
+      return {
+        source: "latest_revision",
+        revision_id: revision.id,
+        body_heads_hash: revision.body_heads_hash,
+        byte_length: object.size,
+        title: handle.title()?.trim() || catalog.document.title?.trim() || null,
+        body,
+        markdown_plan: await markdownBootstrapProjection(body),
+      };
+    } finally {
+      handle.free();
+    }
+  } catch (error) {
+    cloudLog("warn", "markdown_document.bootstrap_render_seed.failed", {
+      document_id: catalog.document.id,
+      revision_id: revision.id,
+      snapshot_key: revision.snapshot_key,
+      error: errorMessage(error),
+      counter: "markdown_bootstrap_render_seed_failures",
+      counter_delta: 1,
+    });
+    return null;
+  }
+}
+
+async function markdownBootstrapProjection(body: string): Promise<Record<string, unknown> | null> {
+  if (!body.trim()) {
+    return null;
+  }
+  try {
+    const plan = JSON.parse(await projectMarkdownJson(body)) as Record<string, unknown>;
+    if (typeof plan.error === "string" && plan.error.length > 0) {
+      return null;
+    }
+    return { ...plan, source: body };
+  } catch {
+    return null;
+  }
 }
 
 function oidcCallbackViewer(request: Request, env: Env): Response {

--- a/apps/notebook-cloud/src/index.ts
+++ b/apps/notebook-cloud/src/index.ts
@@ -30,18 +30,28 @@ import {
   type AuthorizeNotebookAccessOptions,
 } from "./authorization.ts";
 import {
+  MarkdownAuthorizationError,
+  authorizeMarkdownDocumentAccess,
+  authorizeMarkdownDocumentReadWithBestScope,
+} from "./markdown-authorization.ts";
+import {
   blobKey,
   commsDocSnapshotKey,
+  createMarkdownDocumentWithOwnerAcl,
   createNotebookWithOwnerAcl,
   createWorkstationAttachJob,
   ensureCatalogSchema,
   getCanonicalPrincipalForTransport,
   getDefaultWorkstationId,
+  getMarkdownDocumentCatalog,
+  getMarkdownDocumentRow,
   getNotebookAclRows,
   getNotebookRow,
   getNotebookCatalog,
+  getPublicPublishedMarkdownDocumentRow,
   getPublicPublishedNotebookRow,
   getWorkstationRow,
+  listMarkdownDocumentsForPrincipal,
   grantNotebookAclRow,
   listActiveWorkstationAttachJobs,
   listNotebooksForPrincipal,
@@ -53,9 +63,12 @@ import {
   runtimeStateSnapshotKey,
   snapshotKey,
   setDefaultWorkstation,
+  updateMarkdownDocumentTitle,
   updateNotebookTitle,
   updateWorkstationAttachJobStatus,
+  type ListedMarkdownDocumentRow,
   type ListedNotebookRow,
+  type MarkdownDocumentScope,
   type NotebookAclRow,
   type NotebookAccessRequestRow,
   type NotebookAccessRequestStatus,
@@ -254,6 +267,11 @@ const NOTEBOOK_CLOUD_ROUTES: readonly WorkerRoute[] = [
     handler: (_match, request, env) => notebookListViewer(request, env),
   },
   {
+    match: exactPath("/m", "/m/"),
+    methods: ["GET", "HEAD"],
+    handler: (_match, request, env) => markdownDocumentListViewer(request, env),
+  },
+  {
     match: exactPath("/oidc"),
     methods: ["GET", "HEAD"],
     handler: (_match, request, env) => oidcCallbackViewer(request, env),
@@ -279,6 +297,17 @@ const NOTEBOOK_CLOUD_ROUTES: readonly WorkerRoute[] = [
       viewer(params.notebookId, request, env, undefined, params.vanityName),
   },
   {
+    match: routePath("/m/:documentId/:vanityName", { trailingSlash: "optional" }),
+    methods: ["GET", "HEAD"],
+    handler: ({ params }, request, env) =>
+      markdownDocumentViewer(params.documentId, request, env, params.vanityName),
+  },
+  {
+    match: routePath("/m/:documentId", { trailingSlash: "optional" }),
+    methods: ["GET", "HEAD"],
+    handler: ({ params }, request, env) => markdownDocumentViewer(params.documentId, request, env),
+  },
+  {
     match: exactPath("/api/n"),
     methods: ["POST"],
     handler: (_match, request, env) => routeCreateNotebook(request, env),
@@ -287,6 +316,16 @@ const NOTEBOOK_CLOUD_ROUTES: readonly WorkerRoute[] = [
     match: exactPath("/api/n"),
     methods: ["GET"],
     handler: (_match, request, env) => routeListNotebooks(request, env),
+  },
+  {
+    match: exactPath("/api/m"),
+    methods: ["POST"],
+    handler: (_match, request, env) => routeCreateMarkdownDocument(request, env),
+  },
+  {
+    match: exactPath("/api/m"),
+    methods: ["GET"],
+    handler: (_match, request, env) => routeListMarkdownDocuments(request, env),
   },
   {
     match: exactPath("/api/workstations"),
@@ -363,6 +402,18 @@ const NOTEBOOK_CLOUD_ROUTES: readonly WorkerRoute[] = [
     methods: ["PATCH"],
     handler: ({ params }, request, env) =>
       routeUpdateNotebookMetadata(request, env, params.notebookId),
+  },
+  {
+    match: routePath("/api/m/:documentId", { trailingSlash: "optional" }),
+    methods: ["GET"],
+    handler: ({ params }, request, env) =>
+      routeMarkdownDocumentCatalog(request, env, params.documentId),
+  },
+  {
+    match: routePath("/api/m/:documentId", { trailingSlash: "optional" }),
+    methods: ["PATCH"],
+    handler: ({ params }, request, env) =>
+      routeUpdateMarkdownDocumentMetadata(request, env, params.documentId),
   },
   {
     match: routePath("/api/n/:notebookId/acl", { trailingSlash: "optional" }),
@@ -1211,6 +1262,148 @@ function parseNotebookListLimit(request: Request): number | Response {
   return Math.min(limit, MAX_NOTEBOOK_LIST_LIMIT);
 }
 
+type CreateMarkdownDocumentPayload = Record<string, unknown>;
+
+async function routeCreateMarkdownDocument(request: Request, env: Env): Promise<Response> {
+  if (request.method !== "POST") {
+    return json({ error: "method not allowed" }, 405);
+  }
+
+  const originRejection = rejectUntrustedMutationOrigin(request, env);
+  if (originRejection) {
+    return originRejection;
+  }
+  if (!env.DB) {
+    return json({ error: "D1 binding DB is not configured" }, 503);
+  }
+
+  const identity = await authenticateRequestOrAppSessionOrResponse(request, env, "owner");
+  if (identity instanceof Response) {
+    return identity;
+  }
+  if (!allowsPublish(identity.scope)) {
+    return json({ error: `${identity.scope} cannot create Markdown documents` }, 403);
+  }
+
+  const payload = await readCreateMarkdownDocumentPayload(request);
+  if (payload instanceof Response) {
+    return payload;
+  }
+  const title = optionalPayloadString(payload, ["title"], {
+    field: "title",
+    maxLength: 160,
+  });
+  if (title instanceof Response) {
+    return title;
+  }
+
+  const documentId = await createUniqueMarkdownDocumentId(env);
+  if (!documentId) {
+    return json({ error: "could not allocate Markdown document id" }, 500);
+  }
+  const creation = await createMarkdownDocumentWithOwnerAcl(env, documentId, identity, {
+    title,
+  });
+  if (!creation.created) {
+    return json({ error: "could not allocate Markdown document id" }, 500);
+  }
+
+  cloudLog("info", "markdown_document.created", {
+    document_id: documentId,
+    owner_principal: creation.ownerPrincipal,
+    actor_label: identity.actorLabel,
+    counter: "markdown_documents_created",
+    counter_delta: 1,
+  });
+
+  const viewerUrl = markdownDocumentViewerUrlForRequest(request, documentId, title, env);
+  const apiBasePath = `/api/m/${encodeURIComponent(documentId)}`;
+  return json(
+    {
+      ok: true,
+      document_id: documentId,
+      title,
+      body_doc_id: documentId,
+      viewer_url: viewerUrl,
+      endpoints: {
+        catalog: apiBasePath,
+        snapshots: `${apiBasePath}/snapshots/{bodyHeadsHash}`,
+      },
+    },
+    201,
+  );
+}
+
+async function routeListMarkdownDocuments(request: Request, env: Env): Promise<Response> {
+  if (request.method !== "GET") {
+    return json({ error: "method not allowed" }, 405);
+  }
+  if (!env.DB) {
+    return json({ error: "D1 binding DB is not configured" }, 503);
+  }
+
+  const limit = parseNotebookListLimit(request);
+  if (limit instanceof Response) {
+    return limit;
+  }
+
+  let principal: string | null = null;
+  let appSession: CloudAppSession | null = null;
+  const identity = await authenticateRequestOrResponse(request, env);
+  if (identity instanceof Response) {
+    return identity;
+  }
+  if (!isAnonymousViewer(identity)) {
+    principal = identity.principal;
+  } else {
+    appSession = await readCloudAppSession(env, request);
+    principal = appSession?.principal ?? null;
+  }
+  if (!principal) {
+    return json({ error: "sign in to list Markdown documents" }, 401);
+  }
+  if (appSession) {
+    await syncStoredAppSessionProfile(env, appSession);
+  }
+
+  const documents = await listMarkdownDocumentsForPrincipal(env, principal, limit);
+  return json({
+    ok: true,
+    documents: markdownDocumentListResponseRows(request, documents, env),
+  });
+}
+
+function markdownDocumentListResponseRows(
+  request: Request,
+  documents: ListedMarkdownDocumentRow[],
+  env?: Env,
+): Array<Record<string, unknown>> {
+  return documents.map((document) => markdownDocumentListResponseRow(request, document, env));
+}
+
+function markdownDocumentListResponseRow(
+  request: Request,
+  document: ListedMarkdownDocumentRow,
+  env?: Env,
+): Record<string, unknown> {
+  const documentPathId = encodeURIComponent(document.id);
+  const apiBasePath = `/api/m/${documentPathId}`;
+  return {
+    document_id: document.id,
+    title: document.title,
+    owner_principal: document.owner_principal,
+    body_doc_id: document.body_doc_id,
+    scope: document.scope,
+    created_at: document.created_at,
+    updated_at: document.updated_at,
+    latest_revision_id: document.latest_revision_id,
+    viewer_url: markdownDocumentViewerUrlForRequest(request, document.id, document.title, env),
+    endpoints: {
+      catalog: apiBasePath,
+    },
+  };
+}
+
 const WORKSTATION_HEARTBEAT_STALE_MS = 3 * 60_000;
 const MAX_WORKSTATION_ATTACH_JOBS_LIMIT = 25;
 
@@ -2045,6 +2238,12 @@ async function readCreateNotebookPayload(
   return payload;
 }
 
+async function readCreateMarkdownDocumentPayload(
+  request: Request,
+): Promise<CreateMarkdownDocumentPayload | Response> {
+  return readCreateNotebookPayload(request);
+}
+
 function optionalPayloadString(
   payload: Record<string, unknown>,
   keys: string[],
@@ -2446,6 +2645,16 @@ async function createUniqueNotebookId(env: Env): Promise<string | null> {
   return null;
 }
 
+async function createUniqueMarkdownDocumentId(env: Env): Promise<string | null> {
+  for (let attempt = 0; attempt < CREATE_NOTEBOOK_ID_ATTEMPTS; attempt += 1) {
+    const documentId = createUlid();
+    if (!(await getMarkdownDocumentRow(env, documentId))) {
+      return documentId;
+    }
+  }
+  return null;
+}
+
 function createUlid(now = Date.now(), random = randomBytes(10)): string {
   let time = BigInt(Math.max(0, Math.min(now, 0xffffffffffff)));
   let encodedTime = "";
@@ -2482,6 +2691,20 @@ function viewerUrlForRequest(
   const url = new URL(trustedLoopbackBrowserOrigin(request, env) ?? request.url);
   const vanitySegment = vanityName?.trim() || "notebook";
   url.pathname = `/n/${encodeURIComponent(notebookId)}/${encodeURIComponent(vanitySegment)}`;
+  url.search = "";
+  url.hash = "";
+  return url.href;
+}
+
+function markdownDocumentViewerUrlForRequest(
+  request: Request,
+  documentId: string,
+  title: string | null,
+  env?: Env,
+): string {
+  const url = new URL(trustedLoopbackBrowserOrigin(request, env) ?? request.url);
+  const vanitySegment = title?.trim() || "document";
+  url.pathname = `/m/${encodeURIComponent(documentId)}/${encodeURIComponent(vanitySegment)}`;
   url.search = "";
   url.hash = "";
   return url.href;
@@ -3548,6 +3771,63 @@ async function routeCatalog(request: Request, env: Env, notebookId: string): Pro
   return json(catalog);
 }
 
+async function routeMarkdownDocumentCatalog(
+  request: Request,
+  env: Env,
+  documentId: string,
+): Promise<Response> {
+  if (!env.DB) {
+    return json({ error: "D1 binding DB is not configured" }, 503);
+  }
+  const identity = await authenticateRequestOrAppSessionOrResponse(request, env, "viewer");
+  if (identity instanceof Response) {
+    return identity;
+  }
+  const authorized = await authorizeMarkdownIdentityReadOrResponse(env, documentId, identity);
+  if (authorized instanceof Response) {
+    return authorized;
+  }
+
+  const catalog = await getMarkdownDocumentCatalog(env, documentId);
+  if (!catalog) {
+    return json({ error: "Markdown document not found" }, 404);
+  }
+
+  return json(markdownDocumentCatalogResponse(request, catalog, authorized.scope, env));
+}
+
+function markdownDocumentCatalogResponse(
+  request: Request,
+  catalog: NonNullable<Awaited<ReturnType<typeof getMarkdownDocumentCatalog>>>,
+  scope: MarkdownDocumentScope,
+  env?: Env,
+): Record<string, unknown> {
+  const apiBasePath = `/api/m/${encodeURIComponent(catalog.document.id)}`;
+  return {
+    document: {
+      document_id: catalog.document.id,
+      title: catalog.document.title,
+      owner_principal: catalog.document.owner_principal,
+      body_doc_id: catalog.document.body_doc_id,
+      scope,
+      created_at: catalog.document.created_at,
+      updated_at: catalog.document.updated_at,
+      latest_revision_id: catalog.document.latest_revision_id,
+      viewer_url: markdownDocumentViewerUrlForRequest(
+        request,
+        catalog.document.id,
+        catalog.document.title,
+        env,
+      ),
+      endpoints: {
+        catalog: apiBasePath,
+        snapshots: `${apiBasePath}/snapshots/{bodyHeadsHash}`,
+      },
+    },
+    revisions: catalog.revisions,
+  };
+}
+
 async function routeUpdateNotebookMetadata(
   request: Request,
   env: Env,
@@ -3605,6 +3885,66 @@ async function routeUpdateNotebookMetadata(
     title: notebook.title,
     updated_at: notebook.updated_at,
     viewer_url: viewerUrlForRequest(request, notebook.id, notebook.title, env),
+  });
+}
+
+async function routeUpdateMarkdownDocumentMetadata(
+  request: Request,
+  env: Env,
+  documentId: string,
+): Promise<Response> {
+  const originRejection = rejectUntrustedMutationOrigin(request, env);
+  if (originRejection) {
+    return originRejection;
+  }
+  if (!env.DB) {
+    return json({ error: "D1 binding DB is not configured" }, 503);
+  }
+
+  const identity = await authenticateAndAuthorizeMarkdownOrAppSessionOrResponse(
+    request,
+    env,
+    documentId,
+    "editor",
+  );
+  if (identity instanceof Response) {
+    return identity;
+  }
+
+  const payload = await readCreateMarkdownDocumentPayload(request);
+  if (payload instanceof Response) {
+    return payload;
+  }
+  if (!Object.hasOwn(payload, "title")) {
+    return json({ error: "title is required" }, 400);
+  }
+  const title = optionalPayloadString(payload, ["title"], {
+    field: "title",
+    maxLength: 160,
+  });
+  if (title instanceof Response) {
+    return title;
+  }
+
+  const document = await updateMarkdownDocumentTitle(env, documentId, title);
+  if (!document) {
+    return json({ error: "Markdown document not found" }, 404);
+  }
+  cloudLog("info", "markdown_document.metadata.updated", {
+    document_id: documentId,
+    principal: identity.principal,
+    actor_label: identity.actorLabel,
+    title_present: title !== null,
+    counter: "markdown_document_metadata_updates",
+    counter_delta: 1,
+  });
+
+  return json({
+    ok: true,
+    document_id: document.id,
+    title: document.title,
+    updated_at: document.updated_at,
+    viewer_url: markdownDocumentViewerUrlForRequest(request, document.id, document.title, env),
   });
 }
 
@@ -4385,6 +4725,52 @@ async function authenticateAndAuthorizeOrAppSessionOrResponse(
   return authorizeIdentityOrResponse(env, notebookId, identity, requestedScope);
 }
 
+async function authenticateAndAuthorizeMarkdownOrAppSessionOrResponse(
+  request: Request,
+  env: Env,
+  documentId: string,
+  requestedScope: MarkdownDocumentScope,
+): Promise<(AuthenticatedConnection & { scope: MarkdownDocumentScope }) | Response> {
+  const identity = await authenticateRequestOrAppSessionOrResponse(request, env, requestedScope);
+  if (identity instanceof Response) {
+    return identity;
+  }
+  return authorizeMarkdownIdentityOrResponse(env, documentId, identity, requestedScope);
+}
+
+async function authorizeMarkdownIdentityOrResponse(
+  env: Env,
+  documentId: string,
+  identity: AuthenticatedConnection,
+  requestedScope: MarkdownDocumentScope = identity.scope === "runtime_peer"
+    ? "viewer"
+    : identity.scope,
+): Promise<(AuthenticatedConnection & { scope: MarkdownDocumentScope }) | Response> {
+  try {
+    return await authorizeMarkdownDocumentAccess(env, documentId, identity, requestedScope);
+  } catch (error) {
+    if (error instanceof MarkdownAuthorizationError) {
+      return json({ error: error.message }, error.status);
+    }
+    throw error;
+  }
+}
+
+async function authorizeMarkdownIdentityReadOrResponse(
+  env: Env,
+  documentId: string,
+  identity: AuthenticatedConnection,
+): Promise<(AuthenticatedConnection & { scope: MarkdownDocumentScope }) | Response> {
+  try {
+    return await authorizeMarkdownDocumentReadWithBestScope(env, documentId, identity);
+  } catch (error) {
+    if (error instanceof MarkdownAuthorizationError) {
+      return json({ error: error.message }, error.status);
+    }
+    throw error;
+  }
+}
+
 async function authorizeIdentityOrResponse(
   env: Env,
   notebookId: string,
@@ -4580,8 +4966,8 @@ interface ViewerShellConfig extends Record<string, unknown> {
   outputDocumentBaseUrl?: string | null;
   rendererAssetsBasePath?: string;
   rendererAssets?: RendererSidecarAssetNames;
-  runtimedWasmModulePath: string;
-  runtimedWasmPath: string;
+  runtimedWasmModulePath?: string;
+  runtimedWasmPath?: string;
   workstationAttachEndpoint?: string;
   workstationDefaultEndpoint?: string;
   workstationsEndpoint?: string;
@@ -4627,6 +5013,65 @@ async function notebookListViewer(request: Request, env: Env): Promise<Response>
       bootstrap,
       resourceHints,
     ),
+  );
+}
+
+async function markdownDocumentListViewer(request: Request, env: Env): Promise<Response> {
+  if (request.method === "HEAD") {
+    return viewerShellHead(env);
+  }
+
+  const bootstrap = await markdownDocumentListBootstrap(request, env);
+  return responseForRequestMethod(
+    request,
+    viewerShell(
+      {
+        title: "nteract Markdown documents",
+        description: "Open, create, and manage hosted nteract Markdown documents.",
+      },
+      env,
+      authConfigForRequest(request, env),
+      null,
+      bootstrap,
+      null,
+    ),
+  );
+}
+
+async function markdownDocumentViewer(
+  documentId: string,
+  request: Request,
+  env: Env,
+  routeTitleSegment?: string,
+): Promise<Response> {
+  if (request.method === "HEAD") {
+    return viewerShellHead(env);
+  }
+
+  const shellMetadata = await publicMarkdownDocumentShellMetadata(
+    env,
+    documentId,
+    routeTitleSegment,
+  );
+  const documentApiBasePath = `/api/m/${encodeURIComponent(documentId)}`;
+  const runtimeWasmAssets = await runtimeWasmAssetNames(env);
+  const session = await readCloudAppSession(env, request).catch(() => null);
+  const config = {
+    documentKind: "markdown",
+    documentId,
+    catalogEndpoint: documentApiBasePath,
+    snapshotBasePath: `${documentApiBasePath}/snapshots/`,
+    hostCapabilities: {
+      canManageSharing: false,
+      canPublish: false,
+    },
+    session: session ? appSessionResponse(session) : null,
+    runtimedWasmModulePath: runtimedWasmAssetPath(env, runtimeWasmAssets.module),
+    runtimedWasmPath: runtimedWasmAssetPath(env, runtimeWasmAssets.wasm),
+  };
+  return responseForRequestMethod(
+    request,
+    viewerShell(shellMetadata, env, authConfigForRequest(request, env), config),
   );
 }
 
@@ -4698,6 +5143,47 @@ async function publicViewerShellMetadata(
   return {
     title: `nteract notebook: ${displayTitle}`,
     description: `${displayTitle} is a public nteract notebook at ${revisionPart}.`,
+  };
+}
+
+async function publicMarkdownDocumentShellMetadata(
+  env: Env,
+  documentId: string,
+  routeTitleSegment?: string,
+): Promise<ViewerShellMetadata> {
+  const generic = genericMarkdownDocumentShellMetadata(documentId, routeTitleSegment);
+  if (!env.DB) {
+    return generic;
+  }
+
+  const row = await getPublicPublishedMarkdownDocumentRow(env, documentId);
+  if (!row?.latest_revision_id) {
+    return generic;
+  }
+
+  const displayTitle = row.title?.trim() || `Markdown ${shortNotebookId(documentId)}`;
+  return {
+    title: `nteract Markdown: ${displayTitle}`,
+    description: `${displayTitle} is a public nteract Markdown document.`,
+  };
+}
+
+function genericMarkdownDocumentShellMetadata(
+  documentId: string,
+  routeTitleSegment?: string,
+): ViewerShellMetadata {
+  const routeTitle = notebookRouteSegmentTitle(routeTitleSegment);
+  if (routeTitle) {
+    return {
+      title: `nteract Markdown: ${routeTitle}`,
+      description:
+        "A hosted nteract Markdown document. Private document metadata is shown after access is verified.",
+    };
+  }
+  return {
+    title: `nteract Markdown document ${documentId}`,
+    description:
+      "A hosted nteract Markdown document. Private document metadata is shown after access is verified.",
   };
 }
 
@@ -4808,6 +5294,31 @@ async function notebookListBootstrap(
     kind: "notebook-list",
     session: appSessionResponse(session),
     notebooks: notebookListResponseRows(request, notebooks, env),
+    saved_at: new Date().toISOString(),
+  };
+}
+
+async function markdownDocumentListBootstrap(
+  request: Request,
+  env: Env,
+): Promise<Record<string, unknown> | null> {
+  if (!env.DB) {
+    return null;
+  }
+  const session = await readCloudAppSession(env, request);
+  if (!session) {
+    return null;
+  }
+  await syncStoredAppSessionProfile(env, session);
+  const documents = await listMarkdownDocumentsForPrincipal(
+    env,
+    session.principal,
+    DEFAULT_NOTEBOOK_LIST_LIMIT,
+  );
+  return {
+    kind: "markdown-document-list",
+    session: appSessionResponse(session),
+    documents: markdownDocumentListResponseRows(request, documents, env),
     saved_at: new Date().toISOString(),
   };
 }

--- a/apps/notebook-cloud/src/index.ts
+++ b/apps/notebook-cloud/src/index.ts
@@ -6034,11 +6034,9 @@ async function markdownDocumentViewer(
     aclEndpoint: `${documentApiBasePath}/acl`,
     invitesEndpoint: `${documentApiBasePath}/invites`,
     accessRequestsEndpoint: `${documentApiBasePath}/access-requests`,
-    snapshotBasePath: `${documentApiBasePath}/snapshots/`,
     syncEndpoint: `/m/${encodeURIComponent(documentId)}/sync`,
     hostCapabilities: {
       canManageSharing: true,
-      canPublish: true,
     },
     bootstrap,
     session: session ? appSessionResponse(session) : null,

--- a/apps/notebook-cloud/src/index.ts
+++ b/apps/notebook-cloud/src/index.ts
@@ -116,6 +116,7 @@ import {
   createPendingNotebookInvite,
   getPrincipalProfile,
   getPrincipalProfiles,
+  getPrincipalProfilesForVerifiedEmail,
   listNotebookInvites,
   resolveNotebookInvitesForLogin,
   revokePendingNotebookInvite,
@@ -3917,7 +3918,7 @@ async function routeMarkdownDocumentAcl(
     return json({ error: "method not allowed" }, 405);
   }
 
-  const aclInput = await parseMarkdownDocumentAclInput(request);
+  const aclInput = await parseMarkdownDocumentAclInput(request, env);
   if (aclInput instanceof Response) {
     return aclInput;
   }
@@ -3961,6 +3962,16 @@ async function routeMarkdownDocumentAcl(
     scope: aclInput.scope,
     actorLabel: identity.actorLabel,
   });
+  if (request.method === "POST" && aclInput.sameEmailAliasSubjects?.length) {
+    for (const aliasSubject of aclInput.sameEmailAliasSubjects) {
+      await revokeMarkdownDocumentAclRow(env, {
+        documentId,
+        subjectKind: "principal",
+        subject: aliasSubject,
+        scope: aclInput.scope,
+      });
+    }
+  }
   cloudLog("info", "markdown_acl.grant.completed", {
     document_id: documentId,
     principal: identity.principal,
@@ -4745,6 +4756,7 @@ interface NotebookAclPayload {
   subject_kind?: unknown;
   subjectKind?: unknown;
   subject?: unknown;
+  email?: unknown;
   scope?: unknown;
 }
 
@@ -4758,6 +4770,7 @@ interface ParsedMarkdownDocumentAclInput {
   subject_kind: MarkdownDocumentAclRow["subject_kind"];
   subject: string;
   scope: MarkdownDocumentAclRow["scope"];
+  sameEmailAliasSubjects?: string[];
 }
 
 async function parseNotebookAclInput(request: Request): Promise<ParsedNotebookAclInput | Response> {
@@ -4823,15 +4836,105 @@ async function parseNotebookAclInput(request: Request): Promise<ParsedNotebookAc
 
 async function parseMarkdownDocumentAclInput(
   request: Request,
+  env: Env,
 ): Promise<ParsedMarkdownDocumentAclInput | Response> {
-  const input = await parseNotebookAclInput(request);
-  if (input instanceof Response) {
-    return input;
+  let payload: NotebookAclPayload;
+  try {
+    payload = (await request.json()) as NotebookAclPayload;
+  } catch {
+    return json({ error: "ACL mutation body must be JSON" }, 400);
   }
-  if (input.scope === "runtime_peer") {
+
+  const subjectKind = stringField(payload.subject_kind ?? payload.subjectKind, "subject_kind");
+  if (subjectKind instanceof Response) {
+    return subjectKind;
+  }
+  if (subjectKind !== "principal" && subjectKind !== "public") {
+    return json({ error: "subject_kind must be 'principal' or 'public'" }, 400);
+  }
+
+  const scopeValue = stringField(payload.scope, "scope");
+  if (scopeValue instanceof Response) {
+    return scopeValue;
+  }
+  if (scopeValue === "runtime_peer") {
     return json({ error: "Markdown document ACL scope cannot be runtime_peer" }, 400);
   }
-  return input as ParsedMarkdownDocumentAclInput;
+  if (scopeValue !== "viewer" && scopeValue !== "editor" && scopeValue !== "owner") {
+    return json({ error: "Markdown document ACL scope must be viewer, editor, or owner" }, 400);
+  }
+
+  if (subjectKind === "public") {
+    const subject = stringField(payload.subject, "subject");
+    if (subject instanceof Response) {
+      return subject;
+    }
+    if (subject !== "anonymous") {
+      return json({ error: "public ACL rows must use subject 'anonymous'" }, 400);
+    }
+    if (scopeValue !== "viewer") {
+      return json({ error: "public ACL rows may only grant viewer scope" }, 400);
+    }
+    return {
+      subject_kind: subjectKind,
+      subject,
+      scope: scopeValue,
+    };
+  }
+
+  const email = optionalStringField(payload.email, "email");
+  if (email instanceof Response) {
+    return email;
+  }
+  if (email) {
+    let normalizedEmail: string;
+    try {
+      normalizedEmail = normalizeInviteEmail(email);
+    } catch (error) {
+      return json({ error: errorMessage(error) }, 400);
+    }
+    const profiles = await getPrincipalProfilesForVerifiedEmail(env, normalizedEmail);
+    const profile =
+      profiles.find((candidate) => candidate.principal.startsWith("account:")) ??
+      profiles[0] ??
+      null;
+    if (!profile) {
+      return json(
+        {
+          error:
+            "Markdown document email sharing currently requires the recipient to have signed in once.",
+        },
+        404,
+      );
+    }
+    return {
+      subject_kind: subjectKind,
+      subject: profile.principal,
+      scope: scopeValue,
+      sameEmailAliasSubjects: profiles
+        .map((candidate) => candidate.principal)
+        .filter((principal) => principal !== profile.principal),
+    };
+  }
+
+  const subject = stringField(payload.subject, "subject");
+  if (subject instanceof Response) {
+    return subject;
+  }
+  try {
+    validatePrincipal(subject);
+  } catch (error) {
+    return json({ error: errorMessage(error) }, 400);
+  }
+  if (subject === "system" || subject.startsWith("anonymous:")) {
+    return json({ error: "principal ACL rows cannot target system or anonymous principals" }, 400);
+  }
+
+  return {
+    subject_kind: subjectKind,
+    subject,
+    scope: scopeValue,
+  };
 }
 
 function stringField(value: unknown, fieldName: string): string | Response {

--- a/apps/notebook-cloud/src/index.ts
+++ b/apps/notebook-cloud/src/index.ts
@@ -119,6 +119,8 @@ import {
   getPrincipalProfile,
   getPrincipalProfiles,
   getPrincipalProfilesForVerifiedEmail,
+  getPendingMarkdownDocumentInvitesForLogin,
+  getPendingNotebookInvitesForLogin,
   createPendingMarkdownDocumentInvite,
   listNotebookInvites,
   listMarkdownDocumentInvites,
@@ -292,12 +294,12 @@ const NOTEBOOK_CLOUD_ROUTES: readonly WorkerRoute[] = [
   {
     match: exactPath("/n", "/n/"),
     methods: ["GET", "HEAD"],
-    handler: (_match, request, env, ctx) => notebookListViewer(request, env, ctx),
+    handler: (_match, request, env) => notebookListViewer(request, env),
   },
   {
     match: exactPath("/m", "/m/"),
     methods: ["GET", "HEAD"],
-    handler: (_match, request, env, ctx) => markdownDocumentListViewer(request, env, ctx),
+    handler: (_match, request, env) => markdownDocumentListViewer(request, env),
   },
   {
     match: exactPath("/oidc"),
@@ -5607,8 +5609,22 @@ async function syncStoredAppSessionProfile(env: Env, session: CloudAppSession): 
       emailVerified: true,
       displayName: session.displayName ?? profile.display_name,
     };
-    const notebookResolution = await resolveNotebookInvitesForLogin(env, loginProfile);
-    const markdownResolution = await resolveMarkdownDocumentInvitesForLogin(env, loginProfile);
+    const [pendingNotebookInvites, pendingMarkdownDocumentInvites] = await Promise.all([
+      getPendingNotebookInvitesForLogin(env, loginProfile),
+      getPendingMarkdownDocumentInvitesForLogin(env, loginProfile),
+    ]);
+    if (pendingNotebookInvites.length === 0 && pendingMarkdownDocumentInvites.length === 0) {
+      return;
+    }
+
+    const [notebookResolution, markdownResolution] = await Promise.all([
+      pendingNotebookInvites.length > 0
+        ? resolveNotebookInvitesForLogin(env, loginProfile)
+        : Promise.resolve({ acceptedInvites: [], aclGrants: [] }),
+      pendingMarkdownDocumentInvites.length > 0
+        ? resolveMarkdownDocumentInvitesForLogin(env, loginProfile)
+        : Promise.resolve({ acceptedInvites: [], aclGrants: [] }),
+    ]);
     logInviteResolutionCompleted({
       principal: session.principal,
       provider: profile.provider,
@@ -5948,16 +5964,12 @@ function rootNotebookListRedirect(request: Request): Response {
   return Response.redirect(url.toString(), 302);
 }
 
-async function notebookListViewer(
-  request: Request,
-  env: Env,
-  ctx: ExecutionContext,
-): Promise<Response> {
+async function notebookListViewer(request: Request, env: Env): Promise<Response> {
   if (request.method === "HEAD") {
     return viewerShellHead(env);
   }
 
-  const bootstrap = await notebookListBootstrap(request, env, ctx);
+  const bootstrap = await notebookListBootstrap(request, env);
   const resourceHints = notebookListBootstrapHasNotebooks(bootstrap)
     ? {
         notebookRouteAssets: await notebookRouteAssetNames(env),
@@ -5980,16 +5992,12 @@ async function notebookListViewer(
   );
 }
 
-async function markdownDocumentListViewer(
-  request: Request,
-  env: Env,
-  ctx: ExecutionContext,
-): Promise<Response> {
+async function markdownDocumentListViewer(request: Request, env: Env): Promise<Response> {
   if (request.method === "HEAD") {
     return viewerShellHead(env);
   }
 
-  const bootstrap = await markdownDocumentListBootstrap(request, env, ctx);
+  const bootstrap = await markdownDocumentListBootstrap(request, env);
   return responseForRequestMethod(
     request,
     viewerShell(
@@ -6358,7 +6366,6 @@ function viewerShell(
 async function notebookListBootstrap(
   request: Request,
   env: Env,
-  ctx: ExecutionContext,
 ): Promise<Record<string, unknown> | null> {
   if (!env.DB) {
     return null;
@@ -6367,7 +6374,7 @@ async function notebookListBootstrap(
   if (!session) {
     return null;
   }
-  scheduleStoredAppSessionProfileSync(env, ctx, session);
+  await syncStoredAppSessionProfile(env, session);
   const notebooks = await listNotebooksForPrincipal(
     env,
     session.principal,
@@ -6384,7 +6391,6 @@ async function notebookListBootstrap(
 async function markdownDocumentListBootstrap(
   request: Request,
   env: Env,
-  ctx: ExecutionContext,
 ): Promise<Record<string, unknown> | null> {
   if (!env.DB) {
     return null;
@@ -6393,7 +6399,7 @@ async function markdownDocumentListBootstrap(
   if (!session) {
     return null;
   }
-  scheduleStoredAppSessionProfileSync(env, ctx, session);
+  await syncStoredAppSessionProfile(env, session);
   const documents = await listMarkdownDocumentsForPrincipal(
     env,
     session.principal,
@@ -6405,14 +6411,6 @@ async function markdownDocumentListBootstrap(
     documents: markdownDocumentListResponseRows(request, documents, env),
     saved_at: new Date().toISOString(),
   };
-}
-
-function scheduleStoredAppSessionProfileSync(
-  env: Env,
-  ctx: ExecutionContext,
-  session: CloudAppSession,
-): void {
-  ctx.waitUntil(syncStoredAppSessionProfile(env, session));
 }
 
 function notebookListBootstrapHasNotebooks(bootstrap: Record<string, unknown> | null): boolean {

--- a/apps/notebook-cloud/src/index.ts
+++ b/apps/notebook-cloud/src/index.ts
@@ -59,7 +59,9 @@ import {
   listActiveWorkstationAttachJobs,
   listNotebooksForPrincipal,
   listWorkstationsForPrincipal,
+  markdownDocumentSnapshotKey,
   recordBlob,
+  recordMarkdownDocumentRevision,
   recordRevision,
   revokeMarkdownDocumentAclRow,
   registerWorkstation,
@@ -100,6 +102,7 @@ import {
   type WorkstationAttachJobNotification,
 } from "./workstation-events.ts";
 import { materializeSnapshotPairRender } from "./snapshot-render.ts";
+import { loadMarkdownRoomHostSnapshot } from "./runtimed-wasm.ts";
 import { notebookRouteSegmentTitle } from "./notebook-route-title.ts";
 import {
   createNotebookCloudBlobResolver,
@@ -423,6 +426,11 @@ const NOTEBOOK_CLOUD_ROUTES: readonly WorkerRoute[] = [
     methods: ["PATCH"],
     handler: ({ params }, request, env) =>
       routeUpdateMarkdownDocumentMetadata(request, env, params.documentId),
+  },
+  {
+    match: routePath("/api/m/:documentId/snapshots/:headsHash"),
+    handler: ({ params }, request, env) =>
+      routeMarkdownDocumentSnapshot(request, env, params.documentId, params.headsHash),
   },
   {
     match: routePath("/api/m/:documentId/acl", { trailingSlash: "optional" }),
@@ -2923,6 +2931,170 @@ async function routeSnapshot(
   );
 }
 
+async function routeMarkdownDocumentSnapshot(
+  request: Request,
+  env: Env,
+  documentId: string,
+  headsHash: string,
+): Promise<Response> {
+  const key = markdownDocumentSnapshotKey(documentId, headsHash);
+
+  if (request.method === "GET") {
+    const identity = await authenticateAndAuthorizeMarkdownOrAppSessionOrResponse(
+      request,
+      env,
+      documentId,
+      "viewer",
+    );
+    if (identity instanceof Response) {
+      return identity;
+    }
+    const object = await env.NOTEBOOK_SNAPSHOTS?.get(key);
+    if (!object) {
+      return json({ error: "Markdown snapshot not found" }, 404);
+    }
+    return immutableR2ObjectResponse(object);
+  }
+
+  if (request.method !== "PUT") {
+    return json({ error: "method not allowed" }, 405);
+  }
+
+  const originRejection = rejectUntrustedMutationOrigin(request, env);
+  if (originRejection) {
+    return originRejection;
+  }
+  if (!env.NOTEBOOK_SNAPSHOTS) {
+    return json({ error: "R2 binding NOTEBOOK_SNAPSHOTS is not configured" }, 503);
+  }
+
+  const identity = await authenticateAndAuthorizeMarkdownOrAppSessionOrResponse(
+    request,
+    env,
+    documentId,
+    "owner",
+  );
+  if (identity instanceof Response) {
+    return identity;
+  }
+
+  const body = await request.arrayBuffer();
+  const validation = await validateMarkdownSnapshot({
+    documentId,
+    bodyHeadsHash: headsHash,
+    body: new Uint8Array(body),
+  });
+  if (!validation.ok) {
+    return json(validation.body, validation.status);
+  }
+
+  await env.NOTEBOOK_SNAPSHOTS.put(key, body, {
+    httpMetadata: {
+      contentType: request.headers.get("content-type") ?? "application/octet-stream",
+      cacheControl: "public, max-age=31536000, immutable",
+    },
+    customMetadata: {
+      document_id: documentId,
+      body_heads_hash: headsHash,
+    },
+  });
+
+  let revisionId: string;
+  try {
+    revisionId = await recordMarkdownDocumentRevision(env, {
+      documentId,
+      bodyHeadsHash: headsHash,
+      snapshotKey: key,
+      actorLabel: identity.actorLabel,
+      publishPublic: true,
+    });
+  } catch (error) {
+    await env.NOTEBOOK_SNAPSHOTS.delete(key).catch(() => undefined);
+    throw error;
+  }
+
+  cloudLog("info", "markdown_snapshot.published", {
+    document_id: documentId,
+    body_heads_hash: headsHash,
+    revision_id: revisionId,
+    principal: identity.principal,
+    actor_label: identity.actorLabel,
+    byte_length: body.byteLength,
+    counter: "markdown_snapshot_publishes",
+    counter_delta: 1,
+  });
+
+  return json(
+    {
+      ok: true,
+      revision_id: revisionId,
+      key,
+      body_heads_hash: headsHash,
+    },
+    201,
+  );
+}
+
+async function validateMarkdownSnapshot(options: {
+  documentId: string;
+  bodyHeadsHash: string;
+  body: Uint8Array;
+}): Promise<SnapshotPairValidationResult> {
+  const startedAt = Date.now();
+  let handle: Awaited<ReturnType<typeof loadMarkdownRoomHostSnapshot>> | null = null;
+  try {
+    handle = await loadMarkdownRoomHostSnapshot(options.body);
+    const actualHeadsHash = await markdownDocumentHeadsHash(handle.get_heads_hex());
+    if (actualHeadsHash !== options.bodyHeadsHash) {
+      cloudLog("warn", "markdown_snapshot.validation.heads_mismatch", {
+        document_id: options.documentId,
+        expected_body_heads_hash: options.bodyHeadsHash,
+        actual_body_heads_hash: actualHeadsHash,
+        duration_ms: durationMs(startedAt),
+        counter: "markdown_snapshot_validation_heads_mismatches",
+        counter_delta: 1,
+      });
+      return {
+        ok: false,
+        status: 409,
+        body: {
+          error: "Markdown snapshot heads mismatch",
+          expected_body_heads_hash: options.bodyHeadsHash,
+          actual_body_heads_hash: actualHeadsHash,
+        },
+      };
+    }
+    return { ok: true };
+  } catch (error) {
+    cloudLog("warn", "markdown_snapshot.validation.failed", {
+      document_id: options.documentId,
+      body_heads_hash: options.bodyHeadsHash,
+      duration_ms: durationMs(startedAt),
+      error: errorMessage(error),
+      counter: "markdown_snapshot_validation_failures",
+      counter_delta: 1,
+    });
+    return {
+      ok: false,
+      status: 422,
+      body: {
+        error: "Markdown snapshot validation failed",
+        details: errorMessage(error),
+      },
+    };
+  } finally {
+    handle?.free();
+  }
+}
+
+async function markdownDocumentHeadsHash(heads: string[]): Promise<string> {
+  const input = heads.length > 0 ? [...heads].sort().join("\n") : "empty";
+  const digest = await crypto.subtle.digest("SHA-256", new TextEncoder().encode(input));
+  return `heads-${Array.from(new Uint8Array(digest), (byte) => byte.toString(16).padStart(2, "0"))
+    .join("")
+    .slice(0, 24)}`;
+}
+
 async function routeCommsSnapshot(
   request: Request,
   env: Env,
@@ -5300,7 +5472,7 @@ async function markdownDocumentViewer(
     syncEndpoint: `/m/${encodeURIComponent(documentId)}/sync`,
     hostCapabilities: {
       canManageSharing: true,
-      canPublish: false,
+      canPublish: true,
     },
     session: session ? appSessionResponse(session) : null,
     runtimedWasmModulePath: runtimedWasmAssetPath(env, runtimeWasmAssets.module),

--- a/apps/notebook-cloud/src/index.ts
+++ b/apps/notebook-cloud/src/index.ts
@@ -181,6 +181,8 @@ const DEFAULT_RENDERER_ASSETS_BASE_PATH = "/renderer-assets/";
 const DEFAULT_RUNTIMED_WASM_BASE_PATH = "/assets/";
 const VIEWER_RUNTIME_WASM_ASSET_MANIFEST_PATH = "/assets/runtime-wasm-assets.json";
 const VIEWER_NOTEBOOK_ROUTE_ASSET_MANIFEST_PATH = "/assets/notebook-route-assets.json";
+const VIEWER_MARKDOWN_DOCUMENT_ROUTE_ASSET_MANIFEST_PATH =
+  "/assets/markdown-document-route-assets.json";
 const VIEWER_RUNTIMED_WASM_MODULE_NAME = "runtimed_wasm.js";
 const VIEWER_RUNTIMED_WASM_NAME = "runtimed_wasm_bg.wasm";
 const VIEWER_RENDERER_SIDECAR_MANIFEST_PATH = "/assets/renderer-sidecar-assets.json";
@@ -224,6 +226,10 @@ interface RendererSidecarAssetNames {
 }
 
 const notebookRouteAssetNamesCache = new WeakMap<
+  WorkerAssets,
+  Promise<ViewerNotebookRouteAssets>
+>();
+const markdownDocumentRouteAssetNamesCache = new WeakMap<
   WorkerAssets,
   Promise<ViewerNotebookRouteAssets>
 >();
@@ -5468,7 +5474,7 @@ async function markdownDocumentViewer(
     routeTitleSegment,
   );
   const runtimeWasmAssetsPromise = runtimeWasmAssetNames(env);
-  const routeAssetsPromise = notebookRouteAssetNames(env);
+  const routeAssetsPromise = markdownDocumentRouteAssetNames(env);
   const sessionPromise = readCloudAppSession(env, request).catch(() => null);
   const bootstrapPromise = sessionPromise.then((session) =>
     markdownDocumentViewerBootstrap(env, documentId, session),
@@ -5500,6 +5506,7 @@ async function markdownDocumentViewer(
     request,
     viewerShell(shellMetadata, env, authConfigForRequest(request, env), config, null, {
       notebookRouteAssets: routeAssets,
+      notebookRouteStyleHint: "prefetch",
       runtimedWasmModulePath: config.runtimedWasmModulePath,
       runtimedWasmPath: config.runtimedWasmPath,
     }),
@@ -5936,13 +5943,41 @@ async function notebookRouteAssetNames(env: Env): Promise<ViewerNotebookRouteAss
   return cached;
 }
 
+async function markdownDocumentRouteAssetNames(env: Env): Promise<ViewerNotebookRouteAssets> {
+  const assets = env.ASSETS;
+  if (!assets) {
+    return defaultNotebookRouteAssetNames();
+  }
+
+  let cached = markdownDocumentRouteAssetNamesCache.get(assets);
+  if (!cached) {
+    cached = readViewerRouteAssetNames(
+      assets,
+      VIEWER_MARKDOWN_DOCUMENT_ROUTE_ASSET_MANIFEST_PATH,
+      "viewer.markdown_document_route_manifest",
+    );
+    markdownDocumentRouteAssetNamesCache.set(assets, cached);
+  }
+  return cached;
+}
+
 async function readNotebookRouteAssetNames(
   assets: WorkerAssets,
 ): Promise<ViewerNotebookRouteAssets> {
+  return readViewerRouteAssetNames(
+    assets,
+    VIEWER_NOTEBOOK_ROUTE_ASSET_MANIFEST_PATH,
+    "viewer.notebook_route_manifest",
+  );
+}
+
+async function readViewerRouteAssetNames(
+  assets: WorkerAssets,
+  manifestPath: string,
+  logEventPrefix: string,
+): Promise<ViewerNotebookRouteAssets> {
   try {
-    const manifestRequest = new Request(
-      `https://notebook-cloud.local${VIEWER_NOTEBOOK_ROUTE_ASSET_MANIFEST_PATH}`,
-    );
+    const manifestRequest = new Request(`https://notebook-cloud.local${manifestPath}`);
     const response = await assets.fetch(manifestRequest);
     if (!response.ok) {
       return defaultNotebookRouteAssetNames();
@@ -5951,12 +5986,12 @@ async function readNotebookRouteAssetNames(
     if (isNotebookRouteAssetManifest(manifest)) {
       return manifest;
     }
-    cloudLog("warn", "viewer.notebook_route_manifest.invalid", {
-      manifest_path: VIEWER_NOTEBOOK_ROUTE_ASSET_MANIFEST_PATH,
+    cloudLog("warn", `${logEventPrefix}.invalid`, {
+      manifest_path: manifestPath,
     });
   } catch (error) {
-    cloudLog("warn", "viewer.notebook_route_manifest.failed", {
-      manifest_path: VIEWER_NOTEBOOK_ROUTE_ASSET_MANIFEST_PATH,
+    cloudLog("warn", `${logEventPrefix}.failed`, {
+      manifest_path: manifestPath,
       error: errorMessage(error),
     });
   }

--- a/apps/notebook-cloud/src/index.ts
+++ b/apps/notebook-cloud/src/index.ts
@@ -44,6 +44,7 @@ import {
   ensureCatalogSchema,
   getCanonicalPrincipalForTransport,
   getDefaultWorkstationId,
+  getMarkdownDocumentAclRows,
   getMarkdownDocumentCatalog,
   getMarkdownDocumentRow,
   getNotebookAclRows,
@@ -52,6 +53,7 @@ import {
   getPublicPublishedMarkdownDocumentRow,
   getPublicPublishedNotebookRow,
   getWorkstationRow,
+  grantMarkdownDocumentAclRow,
   listMarkdownDocumentsForPrincipal,
   grantNotebookAclRow,
   listActiveWorkstationAttachJobs,
@@ -59,6 +61,7 @@ import {
   listWorkstationsForPrincipal,
   recordBlob,
   recordRevision,
+  revokeMarkdownDocumentAclRow,
   registerWorkstation,
   revokeNotebookAclRow,
   runtimeStateSnapshotKey,
@@ -69,6 +72,7 @@ import {
   updateWorkstationAttachJobStatus,
   type ListedMarkdownDocumentRow,
   type ListedNotebookRow,
+  type MarkdownDocumentAclRow,
   type MarkdownDocumentScope,
   type NotebookAclRow,
   type NotebookAccessRequestRow,
@@ -419,6 +423,11 @@ const NOTEBOOK_CLOUD_ROUTES: readonly WorkerRoute[] = [
     methods: ["PATCH"],
     handler: ({ params }, request, env) =>
       routeUpdateMarkdownDocumentMetadata(request, env, params.documentId),
+  },
+  {
+    match: routePath("/api/m/:documentId/acl", { trailingSlash: "optional" }),
+    handler: ({ params }, request, env) =>
+      routeMarkdownDocumentAcl(request, env, params.documentId),
   },
   {
     match: routePath("/api/n/:notebookId/acl", { trailingSlash: "optional" }),
@@ -3637,6 +3646,43 @@ function aclRowResponse(
   };
 }
 
+async function markdownAclResponseRows(
+  env: Env,
+  rows: MarkdownDocumentAclRow[],
+): Promise<Array<MarkdownDocumentAclRow & { display: ReturnType<typeof shareTargetDisplay> }>> {
+  const principals = rows
+    .filter((row) => row.subject_kind === "principal")
+    .map((row) => row.subject);
+  const profilesByPrincipal = new Map(
+    (await getPrincipalProfiles(env, principals)).map((profile) => [profile.principal, profile]),
+  );
+  return rows.map((row) => markdownAclRowResponse(row, profilesByPrincipal.get(row.subject)));
+}
+
+function markdownAclRowResponse(
+  row: MarkdownDocumentAclRow,
+  profile?: PrincipalProfileRow,
+): MarkdownDocumentAclRow & { display: ReturnType<typeof shareTargetDisplay> } {
+  if (row.subject_kind === "public") {
+    return {
+      ...row,
+      display: shareTargetDisplay({ publicViewer: true }),
+    };
+  }
+
+  return {
+    ...row,
+    display: profile
+      ? shareTargetDisplay({ profile: principalProfileFromRow(profile) })
+      : {
+          kind: "principal",
+          label: row.subject,
+          principal: row.subject,
+          email: null,
+        },
+  };
+}
+
 function principalProfileFromRow(row: PrincipalProfileRow): PrincipalProfile {
   return {
     principal: row.principal,
@@ -3646,6 +3692,108 @@ function principalProfileFromRow(row: PrincipalProfileRow): PrincipalProfile {
     firstSeenAt: row.first_seen_at,
     lastSeenAt: row.last_seen_at,
   };
+}
+
+async function routeMarkdownDocumentAcl(
+  request: Request,
+  env: Env,
+  documentId: string,
+): Promise<Response> {
+  if (!env.DB) {
+    return json({ error: "D1 binding DB is not configured" }, 503);
+  }
+
+  if (request.method === "POST" || request.method === "DELETE") {
+    const originRejection = rejectUntrustedMutationOrigin(request, env);
+    if (originRejection) {
+      return originRejection;
+    }
+  }
+
+  const identity = await authenticateAndAuthorizeMarkdownOrAppSessionOrResponse(
+    request,
+    env,
+    documentId,
+    "owner",
+  );
+  if (identity instanceof Response) {
+    return identity;
+  }
+
+  if (request.method === "GET") {
+    const acl = await getMarkdownDocumentAclRows(env, documentId);
+    return json({
+      document_id: documentId,
+      acl: await markdownAclResponseRows(env, acl),
+    });
+  }
+
+  if (request.method !== "POST" && request.method !== "DELETE") {
+    return json({ error: "method not allowed" }, 405);
+  }
+
+  const aclInput = await parseMarkdownDocumentAclInput(request);
+  if (aclInput instanceof Response) {
+    return aclInput;
+  }
+
+  if (request.method === "DELETE") {
+    const revoked = await revokeMarkdownDocumentAclRow(env, {
+      documentId,
+      subjectKind: aclInput.subject_kind,
+      subject: aclInput.subject,
+      scope: aclInput.scope,
+    });
+    const acl = await getMarkdownDocumentAclRows(env, documentId);
+    if (!revoked && isMarkdownOwnerAclInput(aclInput) && markdownAclContainsInput(acl, aclInput)) {
+      if (isOnlyMarkdownOwnerAclRow(acl, aclInput)) {
+        return json({ error: "cannot remove the last owner ACL row" }, 409);
+      }
+      return json({ error: "owner ACL row was not removed; retry the request" }, 409);
+    }
+    cloudLog("info", "markdown_acl.revoke.completed", {
+      document_id: documentId,
+      principal: identity.principal,
+      actor_label: identity.actorLabel,
+      acl_subject_kind: aclInput.subject_kind,
+      acl_subject: aclInput.subject,
+      acl_scope: aclInput.scope,
+      revoked,
+      counter: "markdown_acl_revocations",
+      counter_delta: 1,
+    });
+    return json({
+      ok: true,
+      document_id: documentId,
+      acl: await markdownAclResponseRows(env, acl),
+    });
+  }
+
+  await grantMarkdownDocumentAclRow(env, {
+    documentId,
+    subjectKind: aclInput.subject_kind,
+    subject: aclInput.subject,
+    scope: aclInput.scope,
+    actorLabel: identity.actorLabel,
+  });
+  cloudLog("info", "markdown_acl.grant.completed", {
+    document_id: documentId,
+    principal: identity.principal,
+    actor_label: identity.actorLabel,
+    acl_subject_kind: aclInput.subject_kind,
+    acl_subject: aclInput.subject,
+    acl_scope: aclInput.scope,
+    counter: "markdown_acl_grants",
+    counter_delta: 1,
+  });
+  return json(
+    {
+      ok: true,
+      document_id: documentId,
+      acl: await markdownAclResponseRows(env, await getMarkdownDocumentAclRows(env, documentId)),
+    },
+    201,
+  );
 }
 
 async function routeNotebookAcl(request: Request, env: Env, notebookId: string): Promise<Response> {
@@ -4421,6 +4569,12 @@ interface ParsedNotebookAclInput {
   scope: NotebookAclRow["scope"];
 }
 
+interface ParsedMarkdownDocumentAclInput {
+  subject_kind: MarkdownDocumentAclRow["subject_kind"];
+  subject: string;
+  scope: MarkdownDocumentAclRow["scope"];
+}
+
 async function parseNotebookAclInput(request: Request): Promise<ParsedNotebookAclInput | Response> {
   let payload: NotebookAclPayload;
   try {
@@ -4480,6 +4634,19 @@ async function parseNotebookAclInput(request: Request): Promise<ParsedNotebookAc
     subject,
     scope,
   };
+}
+
+async function parseMarkdownDocumentAclInput(
+  request: Request,
+): Promise<ParsedMarkdownDocumentAclInput | Response> {
+  const input = await parseNotebookAclInput(request);
+  if (input instanceof Response) {
+    return input;
+  }
+  if (input.scope === "runtime_peer") {
+    return json({ error: "Markdown document ACL scope cannot be runtime_peer" }, 400);
+  }
+  return input as ParsedMarkdownDocumentAclInput;
 }
 
 function stringField(value: unknown, fieldName: string): string | Response {
@@ -4544,6 +4711,10 @@ function isOwnerAclInput(row: ParsedNotebookAclInput): boolean {
   return row.subject_kind === "principal" && row.scope === "owner";
 }
 
+function isMarkdownOwnerAclInput(row: ParsedMarkdownDocumentAclInput): boolean {
+  return row.subject_kind === "principal" && row.scope === "owner";
+}
+
 function isPublicViewerAclInput(row: ParsedNotebookAclInput): boolean {
   return row.subject_kind === "public" && row.subject === "anonymous" && row.scope === "viewer";
 }
@@ -4557,7 +4728,33 @@ function aclContainsInput(rows: NotebookAclRow[], row: ParsedNotebookAclInput): 
   );
 }
 
+function markdownAclContainsInput(
+  rows: MarkdownDocumentAclRow[],
+  row: ParsedMarkdownDocumentAclInput,
+): boolean {
+  return rows.some(
+    (candidate) =>
+      candidate.subject_kind === row.subject_kind &&
+      candidate.subject === row.subject &&
+      candidate.scope === row.scope,
+  );
+}
+
 function isOnlyOwnerAclRow(rows: NotebookAclRow[], row: ParsedNotebookAclInput): boolean {
+  if (row.subject_kind !== "principal" || row.scope !== "owner") {
+    return false;
+  }
+
+  const ownerRows = rows.filter(
+    (candidate) => candidate.subject_kind === "principal" && candidate.scope === "owner",
+  );
+  return ownerRows.length === 1 && ownerRows[0]?.subject === row.subject;
+}
+
+function isOnlyMarkdownOwnerAclRow(
+  rows: MarkdownDocumentAclRow[],
+  row: ParsedMarkdownDocumentAclInput,
+): boolean {
   if (row.subject_kind !== "principal" || row.scope !== "owner") {
     return false;
   }
@@ -5098,10 +5295,11 @@ async function markdownDocumentViewer(
     documentKind: "markdown",
     documentId,
     catalogEndpoint: documentApiBasePath,
+    aclEndpoint: `${documentApiBasePath}/acl`,
     snapshotBasePath: `${documentApiBasePath}/snapshots/`,
     syncEndpoint: `/m/${encodeURIComponent(documentId)}/sync`,
     hostCapabilities: {
-      canManageSharing: false,
+      canManageSharing: true,
       canPublish: false,
     },
     session: session ? appSessionResponse(session) : null,

--- a/apps/notebook-cloud/src/index.ts
+++ b/apps/notebook-cloud/src/index.ts
@@ -76,6 +76,8 @@ import {
   type ListedNotebookRow,
   type MarkdownDocumentCatalog,
   type MarkdownDocumentAclRow,
+  type MarkdownDocumentAccessRequestRow,
+  type MarkdownDocumentAccessRequestStatus,
   type MarkdownDocumentScope,
   type NotebookAclRow,
   type NotebookAccessRequestRow,
@@ -117,10 +119,16 @@ import {
   getPrincipalProfile,
   getPrincipalProfiles,
   getPrincipalProfilesForVerifiedEmail,
+  createPendingMarkdownDocumentInvite,
   listNotebookInvites,
+  listMarkdownDocumentInvites,
+  resolveMarkdownDocumentInvitesForLogin,
   resolveNotebookInvitesForLogin,
+  revokePendingMarkdownDocumentInvite,
   revokePendingNotebookInvite,
+  type ListedPendingMarkdownDocumentInviteRow,
   type ListedPendingNotebookInviteRow,
+  type PendingMarkdownDocumentInviteRow,
   type PendingNotebookInviteRow,
   type PrincipalProfileRow,
 } from "./sharing-storage.ts";
@@ -132,8 +140,12 @@ import {
 } from "./sharing.ts";
 import {
   createNotebookAccessRequest,
+  createMarkdownDocumentAccessRequest,
+  getLatestMarkdownDocumentAccessRequestForRequester,
   getLatestNotebookAccessRequestForRequester,
+  listMarkdownDocumentAccessRequests,
   listNotebookAccessRequests,
+  resolveMarkdownDocumentAccessRequest,
   resolveNotebookAccessRequest,
 } from "./access-requests-storage.ts";
 import {
@@ -444,6 +456,28 @@ const NOTEBOOK_CLOUD_ROUTES: readonly WorkerRoute[] = [
     match: routePath("/api/m/:documentId/acl", { trailingSlash: "optional" }),
     handler: ({ params }, request, env) =>
       routeMarkdownDocumentAcl(request, env, params.documentId),
+  },
+  {
+    match: routePath("/api/m/:documentId/invites", { trailingSlash: "optional" }),
+    handler: ({ params }, request, env) =>
+      routeMarkdownDocumentInvites(request, env, params.documentId),
+  },
+  {
+    match: routePath("/api/m/:documentId/invites/:inviteId", { trailingSlash: "optional" }),
+    handler: ({ params }, request, env) =>
+      routeMarkdownDocumentInvite(request, env, params.documentId, params.inviteId),
+  },
+  {
+    match: routePath("/api/m/:documentId/access-requests", { trailingSlash: "optional" }),
+    handler: ({ params }, request, env) =>
+      routeMarkdownDocumentAccessRequests(request, env, params.documentId),
+  },
+  {
+    match: routePath("/api/m/:documentId/access-requests/:accessRequestId", {
+      trailingSlash: "optional",
+    }),
+    handler: ({ params }, request, env) =>
+      routeMarkdownDocumentAccessRequest(request, env, params.documentId, params.accessRequestId),
   },
   {
     match: routePath("/api/n/:notebookId/acl", { trailingSlash: "optional" }),
@@ -3650,6 +3684,12 @@ async function parseAccessRequestResolutionStatus(
   }
 }
 
+async function parseMarkdownAccessRequestResolutionStatus(
+  request: Request,
+): Promise<Exclude<MarkdownDocumentAccessRequestStatus, "pending"> | Response> {
+  return parseAccessRequestResolutionStatus(request);
+}
+
 async function accessRequestResponseRows(
   env: Env,
   rows: NotebookAccessRequestRow[],
@@ -3689,6 +3729,45 @@ function accessRequestResponse(
   };
 }
 
+async function markdownAccessRequestResponseRows(
+  env: Env,
+  rows: MarkdownDocumentAccessRequestRow[],
+): Promise<Array<Record<string, unknown>>> {
+  const principals = rows.map((row) => row.requester_principal);
+  const profilesByPrincipal = new Map(
+    (await getPrincipalProfiles(env, principals)).map((profile) => [profile.principal, profile]),
+  );
+  return rows.map((row) =>
+    markdownAccessRequestResponse(row, profilesByPrincipal.get(row.requester_principal)),
+  );
+}
+
+function markdownAccessRequestResponse(
+  row: MarkdownDocumentAccessRequestRow,
+  profile?: PrincipalProfileRow,
+): Record<string, unknown> {
+  return {
+    id: row.id,
+    document_id: row.document_id,
+    requester_principal: row.requester_principal,
+    scope: row.scope,
+    status: row.status,
+    requested_by_actor_label: row.requested_by_actor_label,
+    resolved_by_actor_label: row.resolved_by_actor_label,
+    created_at: row.created_at,
+    updated_at: row.updated_at,
+    resolved_at: row.resolved_at,
+    display: profile
+      ? shareTargetDisplay({ profile: principalProfileFromRow(profile) })
+      : {
+          kind: "principal",
+          label: row.requester_principal,
+          principal: row.requester_principal,
+          email: null,
+        },
+  };
+}
+
 async function tryAuthorizeNotebookAccess(
   env: Env,
   notebookId: string,
@@ -3704,6 +3783,28 @@ async function tryAuthorizeNotebookAccess(
     };
   } catch (error) {
     if (error instanceof AuthorizationError) {
+      return { ok: false, error };
+    }
+    throw error;
+  }
+}
+
+async function tryAuthorizeMarkdownDocumentAccess(
+  env: Env,
+  documentId: string,
+  identity: AuthenticatedConnection,
+  requestedScope: MarkdownDocumentScope,
+): Promise<
+  | { ok: true; identity: AuthenticatedConnection & { scope: MarkdownDocumentScope } }
+  | { ok: false; error: MarkdownAuthorizationError }
+> {
+  try {
+    return {
+      ok: true,
+      identity: await authorizeMarkdownDocumentAccess(env, documentId, identity, requestedScope),
+    };
+  } catch (error) {
+    if (error instanceof MarkdownAuthorizationError) {
       return { ok: false, error };
     }
     throw error;
@@ -3772,6 +3873,26 @@ async function parsePendingInviteInput(
     provider_hint: normalizedProviderHint,
     scope: scopeValue,
     expires_at: expiresAt,
+  };
+}
+
+function markdownInviteResponse(
+  row: PendingMarkdownDocumentInviteRow | ListedPendingMarkdownDocumentInviteRow,
+): Record<string, unknown> {
+  return {
+    id: row.id,
+    document_id: row.document_id,
+    email: row.email_normalized,
+    provider_hint: row.provider_hint,
+    scope: row.scope,
+    status: row.status,
+    invited_by_actor_label: row.invited_by_actor_label,
+    accepted_by_principal: row.accepted_by_principal,
+    created_at: row.created_at,
+    expires_at: row.expires_at,
+    accepted_at: row.accepted_at,
+    revoked_at: row.revoked_at,
+    revoked_by_actor_label: row.revoked_by_actor_label,
   };
 }
 
@@ -3990,6 +4111,312 @@ async function routeMarkdownDocumentAcl(
     },
     201,
   );
+}
+
+async function routeMarkdownDocumentInvites(
+  request: Request,
+  env: Env,
+  documentId: string,
+): Promise<Response> {
+  if (!env.DB) {
+    return json({ error: "D1 binding DB is not configured" }, 503);
+  }
+
+  if (request.method === "POST") {
+    const originRejection = rejectUntrustedMutationOrigin(request, env);
+    if (originRejection) {
+      return originRejection;
+    }
+  }
+
+  const identity = await authenticateAndAuthorizeMarkdownOrAppSessionOrResponse(
+    request,
+    env,
+    documentId,
+    "owner",
+  );
+  if (identity instanceof Response) {
+    return identity;
+  }
+
+  if (request.method === "GET") {
+    return json({
+      document_id: documentId,
+      invites: (await listMarkdownDocumentInvites(env, documentId)).map(markdownInviteResponse),
+    });
+  }
+
+  if (request.method !== "POST") {
+    return json({ error: "method not allowed" }, 405);
+  }
+
+  const inviteInput = await parsePendingInviteInput(request);
+  if (inviteInput instanceof Response) {
+    return inviteInput;
+  }
+
+  const invite = await createPendingMarkdownDocumentInvite(env, {
+    documentId,
+    email: inviteInput.email,
+    providerHint: inviteInput.provider_hint,
+    scope: inviteInput.scope,
+    expiresAt: inviteInput.expires_at,
+    actorLabel: identity.actorLabel,
+  });
+
+  if (!invite) {
+    return json({ error: "invite was not created" }, 500);
+  }
+
+  cloudLog("info", "markdown_invite.create.completed", {
+    document_id: documentId,
+    principal: identity.principal,
+    actor_label: identity.actorLabel,
+    invite_id: invite.id,
+    invite_scope: invite.scope,
+    provider_hint: invite.provider_hint,
+    counter: "markdown_invite_creates",
+    counter_delta: 1,
+  });
+
+  return json(
+    {
+      ok: true,
+      document_id: documentId,
+      invite: markdownInviteResponse(invite),
+    },
+    201,
+  );
+}
+
+async function routeMarkdownDocumentInvite(
+  request: Request,
+  env: Env,
+  documentId: string,
+  inviteId: string,
+): Promise<Response> {
+  if (!env.DB) {
+    return json({ error: "D1 binding DB is not configured" }, 503);
+  }
+
+  if (request.method === "DELETE") {
+    const originRejection = rejectUntrustedMutationOrigin(request, env);
+    if (originRejection) {
+      return originRejection;
+    }
+  }
+
+  const identity = await authenticateAndAuthorizeMarkdownOrAppSessionOrResponse(
+    request,
+    env,
+    documentId,
+    "owner",
+  );
+  if (identity instanceof Response) {
+    return identity;
+  }
+
+  if (request.method !== "DELETE") {
+    return json({ error: "method not allowed" }, 405);
+  }
+
+  const revoked = await revokePendingMarkdownDocumentInvite(env, {
+    documentId,
+    inviteId,
+    actorLabel: identity.actorLabel,
+  });
+  if (!revoked) {
+    return json({ error: "pending invite not found" }, 404);
+  }
+
+  cloudLog("info", "markdown_invite.revoke.completed", {
+    document_id: documentId,
+    principal: identity.principal,
+    actor_label: identity.actorLabel,
+    invite_id: inviteId,
+    counter: "markdown_invite_revocations",
+    counter_delta: 1,
+  });
+
+  return json({
+    ok: true,
+    document_id: documentId,
+    invites: (await listMarkdownDocumentInvites(env, documentId)).map(markdownInviteResponse),
+  });
+}
+
+async function routeMarkdownDocumentAccessRequests(
+  request: Request,
+  env: Env,
+  documentId: string,
+): Promise<Response> {
+  if (!env.DB) {
+    return json({ error: "D1 binding DB is not configured" }, 503);
+  }
+
+  if (request.method === "POST") {
+    const originRejection = rejectUntrustedMutationOrigin(request, env);
+    if (originRejection) {
+      return originRejection;
+    }
+  }
+
+  const identity = await authenticateRequestOrAppSessionOrResponse(request, env, "viewer");
+  if (identity instanceof Response) {
+    return identity;
+  }
+
+  if (request.method === "GET") {
+    const owner = await tryAuthorizeMarkdownDocumentAccess(env, documentId, identity, "owner");
+    if (owner.ok) {
+      return json({
+        document_id: documentId,
+        access_requests: await markdownAccessRequestResponseRows(
+          env,
+          await listMarkdownDocumentAccessRequests(env, documentId),
+        ),
+      });
+    }
+
+    if (isAnonymousViewer(identity)) {
+      return json({ error: "sign in to view access requests" }, 401);
+    }
+
+    const viewer = await tryAuthorizeMarkdownDocumentAccess(env, documentId, identity, "viewer");
+    if (!viewer.ok) {
+      return json({ error: viewer.error.message }, viewer.error.status);
+    }
+
+    const latest = await getLatestMarkdownDocumentAccessRequestForRequester(env, {
+      documentId,
+      requesterPrincipal: identity.principal,
+    });
+    return json({
+      document_id: documentId,
+      access_requests: latest ? [markdownAccessRequestResponse(latest)] : [],
+    });
+  }
+
+  if (request.method !== "POST") {
+    return json({ error: "method not allowed" }, 405);
+  }
+
+  if (isAnonymousViewer(identity)) {
+    return json({ error: "sign in to request edit access" }, 401);
+  }
+
+  const viewer = await tryAuthorizeMarkdownDocumentAccess(env, documentId, identity, "viewer");
+  if (!viewer.ok) {
+    return json({ error: viewer.error.message }, viewer.error.status);
+  }
+
+  const editor = await tryAuthorizeMarkdownDocumentAccess(env, documentId, identity, "editor");
+  if (editor.ok) {
+    return json({
+      ok: true,
+      document_id: documentId,
+      access_status: "granted",
+      access_request: null,
+    });
+  }
+
+  const accessRequestResult = await createMarkdownDocumentAccessRequest(env, {
+    documentId,
+    requesterPrincipal: identity.principal,
+    actorLabel: identity.actorLabel,
+  });
+  if (!accessRequestResult) {
+    return json({ error: "access request was not created" }, 500);
+  }
+  const accessRequest = accessRequestResult.request;
+
+  if (accessRequestResult.created) {
+    cloudLog("info", "markdown_access_request.create.completed", {
+      document_id: documentId,
+      principal: identity.principal,
+      actor_label: identity.actorLabel,
+      access_request_id: accessRequest.id,
+      counter: "markdown_access_request_creates",
+      counter_delta: 1,
+    });
+  }
+
+  return json(
+    {
+      ok: true,
+      document_id: documentId,
+      access_status: accessRequest.status,
+      access_request: markdownAccessRequestResponse(accessRequest),
+    },
+    accessRequestResult.created ? 201 : 200,
+  );
+}
+
+async function routeMarkdownDocumentAccessRequest(
+  request: Request,
+  env: Env,
+  documentId: string,
+  requestId: string,
+): Promise<Response> {
+  if (!env.DB) {
+    return json({ error: "D1 binding DB is not configured" }, 503);
+  }
+
+  if (request.method === "POST") {
+    const originRejection = rejectUntrustedMutationOrigin(request, env);
+    if (originRejection) {
+      return originRejection;
+    }
+  }
+
+  const identity = await authenticateAndAuthorizeMarkdownOrAppSessionOrResponse(
+    request,
+    env,
+    documentId,
+    "owner",
+  );
+  if (identity instanceof Response) {
+    return identity;
+  }
+
+  if (request.method !== "POST") {
+    return json({ error: "method not allowed" }, 405);
+  }
+
+  const status = await parseMarkdownAccessRequestResolutionStatus(request);
+  if (status instanceof Response) {
+    return status;
+  }
+
+  const resolved = await resolveMarkdownDocumentAccessRequest(env, {
+    documentId,
+    requestId,
+    status,
+    actorLabel: identity.actorLabel,
+  });
+  if (!resolved) {
+    return json({ error: "pending access request not found" }, 404);
+  }
+
+  cloudLog("info", "markdown_access_request.resolve.completed", {
+    document_id: documentId,
+    principal: identity.principal,
+    actor_label: identity.actorLabel,
+    access_request_id: requestId,
+    access_request_status: resolved.status,
+    counter: "markdown_access_request_resolutions",
+    counter_delta: 1,
+  });
+
+  return json({
+    ok: true,
+    document_id: documentId,
+    access_request: markdownAccessRequestResponse(resolved),
+    access_requests: await markdownAccessRequestResponseRows(
+      env,
+      await listMarkdownDocumentAccessRequests(env, documentId),
+    ),
+  });
 }
 
 async function routeNotebookAcl(request: Request, env: Env, notebookId: string): Promise<Response> {
@@ -5126,19 +5553,22 @@ async function syncAuthenticatedProfile(
     // trusted to return only server-verified account emails. If that backend
     // contract changes, API-key email claims must stop feeding invite
     // resolution and account canonicalization.
-    const resolution = await resolveNotebookInvitesForLogin(env, {
+    const loginProfile = {
       ...profile,
       principalNamespace: identity.metadata.principalNamespace,
       emailVerified:
         identity.metadata.provider === "anaconda-api-key"
           ? Boolean(identity.metadata.email)
           : identity.metadata.emailVerified === true,
-    });
+    };
+    const notebookResolution = await resolveNotebookInvitesForLogin(env, loginProfile);
+    const markdownResolution = await resolveMarkdownDocumentInvitesForLogin(env, loginProfile);
     logInviteResolutionCompleted({
       principal: identity.principal,
       provider: identity.metadata.provider,
-      acceptedInviteCount: resolution.acceptedInvites.length,
-      aclGrantCount: resolution.aclGrants.length,
+      acceptedInviteCount:
+        notebookResolution.acceptedInvites.length + markdownResolution.acceptedInvites.length,
+      aclGrantCount: notebookResolution.aclGrants.length + markdownResolution.aclGrants.length,
     });
   } catch (error) {
     cloudLog("warn", "profile.sync.failed", {
@@ -5167,19 +5597,22 @@ async function syncStoredAppSessionProfile(env: Env, session: CloudAppSession): 
       return;
     }
 
-    const resolution = await resolveNotebookInvitesForLogin(env, {
+    const loginProfile = {
       principal: session.principal,
       provider: profile.provider,
       principalNamespace: session.principalNamespace,
       email: profile.email_normalized,
       emailVerified: true,
       displayName: session.displayName ?? profile.display_name,
-    });
+    };
+    const notebookResolution = await resolveNotebookInvitesForLogin(env, loginProfile);
+    const markdownResolution = await resolveMarkdownDocumentInvitesForLogin(env, loginProfile);
     logInviteResolutionCompleted({
       principal: session.principal,
       provider: profile.provider,
-      acceptedInviteCount: resolution.acceptedInvites.length,
-      aclGrantCount: resolution.aclGrants.length,
+      acceptedInviteCount:
+        notebookResolution.acceptedInvites.length + markdownResolution.acceptedInvites.length,
+      aclGrantCount: notebookResolution.aclGrants.length + markdownResolution.aclGrants.length,
     });
   } catch (error) {
     cloudLog("warn", "profile.sync.failed", {
@@ -5597,6 +6030,8 @@ async function markdownDocumentViewer(
     documentId,
     catalogEndpoint: documentApiBasePath,
     aclEndpoint: `${documentApiBasePath}/acl`,
+    invitesEndpoint: `${documentApiBasePath}/invites`,
+    accessRequestsEndpoint: `${documentApiBasePath}/access-requests`,
     snapshotBasePath: `${documentApiBasePath}/snapshots/`,
     syncEndpoint: `/m/${encodeURIComponent(documentId)}/sync`,
     hostCapabilities: {

--- a/apps/notebook-cloud/src/index.ts
+++ b/apps/notebook-cloud/src/index.ts
@@ -7,6 +7,7 @@ import type {
 } from "./cloudflare-types.ts";
 import { projectNotebookWorkstationAttachmentFromClaim, type BlobRef } from "runtimed";
 import { NotebookRoom } from "./notebook-room.ts";
+import { MarkdownDocumentRoom } from "./markdown-document-room.ts";
 import {
   AuthError,
   BEARER_AUTH_TOKEN_PROTOCOL_PREFIX,
@@ -164,7 +165,7 @@ import {
   trustsLoopbackRequestHeaders,
 } from "./loopback.ts";
 
-export { NotebookRoom, WorkstationEvents };
+export { NotebookRoom, MarkdownDocumentRoom, WorkstationEvents };
 
 // `/plugins/*` is a raw static asset path in deployed Workers. Use a
 // Worker-owned route by default so sandboxed srcdoc iframes can fetch sidecar
@@ -279,6 +280,10 @@ const NOTEBOOK_CLOUD_ROUTES: readonly WorkerRoute[] = [
   {
     match: routePath("/n/:notebookId/sync", { trailingSlash: "optional" }),
     handler: (_match, request, env) => routeRoomSync(request, env),
+  },
+  {
+    match: routePath("/m/:documentId/sync", { trailingSlash: "optional" }),
+    handler: (_match, request, env) => routeMarkdownDocumentSync(request, env),
   },
   {
     match: routePath("/n/:notebookId/debug", { trailingSlash: "optional" }),
@@ -763,6 +768,39 @@ async function routeRoomSync(request: Request, env: Env): Promise<Response> {
 
   const id = env.NOTEBOOK_ROOMS.idFromName(notebookId);
   const room = env.NOTEBOOK_ROOMS.get(id);
+  return room.fetch(stampTrustedIdentity(request, authorizedIdentity));
+}
+
+async function routeMarkdownDocumentSync(request: Request, env: Env): Promise<Response> {
+  if (request.headers.get("Upgrade")?.toLowerCase() !== "websocket") {
+    return json({ error: "expected WebSocket upgrade" }, 426);
+  }
+  if (!env.MARKDOWN_DOCUMENT_ROOMS) {
+    return json({ error: "Markdown document rooms are not configured" }, 503);
+  }
+
+  const originRejection = rejectUntrustedWebSocketOrigin(request, env);
+  if (originRejection) {
+    return originRejection;
+  }
+
+  const url = new URL(request.url);
+  const documentId = decodeURIComponent(url.pathname.match(/^\/m\/([^/]+)\/sync\/?$/)?.[1] ?? "");
+  if (!documentId) {
+    return json({ error: "Markdown document id is required" }, 400);
+  }
+  const appSessionIdentity = await appSessionIdentityFromWebSocketRequest(request, env);
+  const identity = appSessionIdentity ?? (await authenticateRequestOrResponse(request, env));
+  if (identity instanceof Response) {
+    return identity;
+  }
+  const authorizedIdentity = await authorizeMarkdownIdentityOrResponse(env, documentId, identity);
+  if (authorizedIdentity instanceof Response) {
+    return authorizedIdentity;
+  }
+
+  const id = env.MARKDOWN_DOCUMENT_ROOMS.idFromName(documentId);
+  const room = env.MARKDOWN_DOCUMENT_ROOMS.get(id);
   return room.fetch(stampTrustedIdentity(request, authorizedIdentity));
 }
 
@@ -5061,6 +5099,7 @@ async function markdownDocumentViewer(
     documentId,
     catalogEndpoint: documentApiBasePath,
     snapshotBasePath: `${documentApiBasePath}/snapshots/`,
+    syncEndpoint: `/m/${encodeURIComponent(documentId)}/sync`,
     hostCapabilities: {
       canManageSharing: false,
       canPublish: false,

--- a/apps/notebook-cloud/src/index.ts
+++ b/apps/notebook-cloud/src/index.ts
@@ -1135,6 +1135,7 @@ function appSessionResponse(session: CloudAppSession): Record<string, unknown> {
   return {
     provider: session.provider,
     expires_at: session.expiresAt,
+    cache_key: session.cacheKey,
   };
 }
 

--- a/apps/notebook-cloud/src/index.ts
+++ b/apps/notebook-cloud/src/index.ts
@@ -292,12 +292,12 @@ const NOTEBOOK_CLOUD_ROUTES: readonly WorkerRoute[] = [
   {
     match: exactPath("/n", "/n/"),
     methods: ["GET", "HEAD"],
-    handler: (_match, request, env) => notebookListViewer(request, env),
+    handler: (_match, request, env, ctx) => notebookListViewer(request, env, ctx),
   },
   {
     match: exactPath("/m", "/m/"),
     methods: ["GET", "HEAD"],
-    handler: (_match, request, env) => markdownDocumentListViewer(request, env),
+    handler: (_match, request, env, ctx) => markdownDocumentListViewer(request, env, ctx),
   },
   {
     match: exactPath("/oidc"),
@@ -5948,12 +5948,16 @@ function rootNotebookListRedirect(request: Request): Response {
   return Response.redirect(url.toString(), 302);
 }
 
-async function notebookListViewer(request: Request, env: Env): Promise<Response> {
+async function notebookListViewer(
+  request: Request,
+  env: Env,
+  ctx: ExecutionContext,
+): Promise<Response> {
   if (request.method === "HEAD") {
     return viewerShellHead(env);
   }
 
-  const bootstrap = await notebookListBootstrap(request, env);
+  const bootstrap = await notebookListBootstrap(request, env, ctx);
   const resourceHints = notebookListBootstrapHasNotebooks(bootstrap)
     ? {
         notebookRouteAssets: await notebookRouteAssetNames(env),
@@ -5976,12 +5980,16 @@ async function notebookListViewer(request: Request, env: Env): Promise<Response>
   );
 }
 
-async function markdownDocumentListViewer(request: Request, env: Env): Promise<Response> {
+async function markdownDocumentListViewer(
+  request: Request,
+  env: Env,
+  ctx: ExecutionContext,
+): Promise<Response> {
   if (request.method === "HEAD") {
     return viewerShellHead(env);
   }
 
-  const bootstrap = await markdownDocumentListBootstrap(request, env);
+  const bootstrap = await markdownDocumentListBootstrap(request, env, ctx);
   return responseForRequestMethod(
     request,
     viewerShell(
@@ -6350,6 +6358,7 @@ function viewerShell(
 async function notebookListBootstrap(
   request: Request,
   env: Env,
+  ctx: ExecutionContext,
 ): Promise<Record<string, unknown> | null> {
   if (!env.DB) {
     return null;
@@ -6358,7 +6367,7 @@ async function notebookListBootstrap(
   if (!session) {
     return null;
   }
-  await syncStoredAppSessionProfile(env, session);
+  scheduleStoredAppSessionProfileSync(env, ctx, session);
   const notebooks = await listNotebooksForPrincipal(
     env,
     session.principal,
@@ -6375,6 +6384,7 @@ async function notebookListBootstrap(
 async function markdownDocumentListBootstrap(
   request: Request,
   env: Env,
+  ctx: ExecutionContext,
 ): Promise<Record<string, unknown> | null> {
   if (!env.DB) {
     return null;
@@ -6383,7 +6393,7 @@ async function markdownDocumentListBootstrap(
   if (!session) {
     return null;
   }
-  await syncStoredAppSessionProfile(env, session);
+  scheduleStoredAppSessionProfileSync(env, ctx, session);
   const documents = await listMarkdownDocumentsForPrincipal(
     env,
     session.principal,
@@ -6395,6 +6405,14 @@ async function markdownDocumentListBootstrap(
     documents: markdownDocumentListResponseRows(request, documents, env),
     saved_at: new Date().toISOString(),
   };
+}
+
+function scheduleStoredAppSessionProfileSync(
+  env: Env,
+  ctx: ExecutionContext,
+  session: CloudAppSession,
+): void {
+  ctx.waitUntil(syncStoredAppSessionProfile(env, session));
 }
 
 function notebookListBootstrapHasNotebooks(bootstrap: Record<string, unknown> | null): boolean {

--- a/apps/notebook-cloud/src/index.ts
+++ b/apps/notebook-cloud/src/index.ts
@@ -4085,12 +4085,14 @@ async function routeMarkdownDocumentAcl(
   });
   if (request.method === "POST" && aclInput.sameEmailAliasSubjects?.length) {
     for (const aliasSubject of aclInput.sameEmailAliasSubjects) {
-      await revokeMarkdownDocumentAclRow(env, {
-        documentId,
-        subjectKind: "principal",
-        subject: aliasSubject,
-        scope: aclInput.scope,
-      });
+      for (const scope of ["viewer", "editor", "owner"] as const) {
+        await revokeMarkdownDocumentAclRow(env, {
+          documentId,
+          subjectKind: "principal",
+          subject: aliasSubject,
+          scope,
+        });
+      }
     }
   }
   cloudLog("info", "markdown_acl.grant.completed", {

--- a/apps/notebook-cloud/src/index.ts
+++ b/apps/notebook-cloud/src/index.ts
@@ -2059,7 +2059,7 @@ async function routeWorkstationEvents(
 
   const stub = workstationEventsStub(env, ownerPrincipal, workstationId);
   const response = await stub.fetch(new Request("https://workstation-events.internal/stream"));
-  return withCors(response);
+  return withCors(new Response(response.body, response));
 }
 
 async function routeWorkstationAttachJobs(

--- a/apps/notebook-cloud/src/markdown-authorization.ts
+++ b/apps/notebook-cloud/src/markdown-authorization.ts
@@ -1,0 +1,123 @@
+import type { Env } from "./cloudflare-types.ts";
+import {
+  type AuthenticatedConnection,
+  type ConnectionScope,
+  isAnonymousViewer,
+} from "./identity.ts";
+import {
+  ensureCatalogSchema,
+  getMarkdownDocumentAclRowsForPrincipal,
+  getMarkdownDocumentRow,
+  getPublicMarkdownDocumentAclRows,
+  type MarkdownDocumentAclRow,
+  type MarkdownDocumentScope,
+} from "./storage.ts";
+
+const CAP_READ = 1 << 0;
+const CAP_MARKDOWN_WRITE = 1 << 1;
+const CAP_PUBLISH = 1 << 2;
+const CAP_MANAGE_ACL = 1 << 3;
+
+export class MarkdownAuthorizationError extends Error {
+  constructor(
+    message: string,
+    readonly status = 403,
+  ) {
+    super(message);
+    this.name = "MarkdownAuthorizationError";
+  }
+}
+
+export async function authorizeMarkdownDocumentAccess(
+  env: Env,
+  documentId: string,
+  identity: AuthenticatedConnection,
+  requestedScope: ConnectionScope = identity.scope,
+): Promise<AuthenticatedConnection & { scope: MarkdownDocumentScope }> {
+  if (!env.DB) {
+    throw new MarkdownAuthorizationError("D1 binding DB is not configured", 503);
+  }
+  if (requestedScope === "runtime_peer") {
+    throw new MarkdownAuthorizationError(
+      "Markdown documents do not accept runtime_peer scope",
+      403,
+    );
+  }
+
+  await ensureCatalogSchema(env);
+  const document = await getMarkdownDocumentRow(env, documentId);
+  if (!document) {
+    throw new MarkdownAuthorizationError("Markdown document not found", 404);
+  }
+
+  if (isAnonymousViewer(identity)) {
+    if (requestedScope !== "viewer") {
+      throw new MarkdownAuthorizationError("anonymous viewers may only request viewer scope", 403);
+    }
+    const publicRows = await getPublicMarkdownDocumentAclRows(env, documentId);
+    if (!markdownAclRowsCoverScope(publicRows, "viewer")) {
+      throw new MarkdownAuthorizationError("Markdown document not found", 404);
+    }
+    return { ...identity, scope: "viewer" };
+  }
+
+  const principalRows = await getMarkdownDocumentAclRowsForPrincipal(
+    env,
+    documentId,
+    identity.principal,
+  );
+  if (markdownAclRowsCoverScope(principalRows, requestedScope)) {
+    return { ...identity, scope: requestedScope };
+  }
+
+  const publicRows = await getPublicMarkdownDocumentAclRows(env, documentId);
+  if (requestedScope === "viewer" && markdownAclRowsCoverScope(publicRows, "viewer")) {
+    return { ...identity, scope: "viewer" };
+  }
+
+  throw new MarkdownAuthorizationError(`${identity.principal} cannot access ${documentId}`, 403);
+}
+
+export async function authorizeMarkdownDocumentReadWithBestScope(
+  env: Env,
+  documentId: string,
+  identity: AuthenticatedConnection,
+): Promise<AuthenticatedConnection & { scope: MarkdownDocumentScope }> {
+  const readable = await authorizeMarkdownDocumentAccess(env, documentId, identity, "viewer");
+  if (isAnonymousViewer(readable)) {
+    return readable;
+  }
+
+  const principalRows = await getMarkdownDocumentAclRowsForPrincipal(
+    env,
+    documentId,
+    readable.principal,
+  );
+  if (markdownAclRowsCoverScope(principalRows, "owner")) {
+    return { ...readable, scope: "owner" };
+  }
+  if (markdownAclRowsCoverScope(principalRows, "editor")) {
+    return { ...readable, scope: "editor" };
+  }
+  return readable;
+}
+
+export function markdownAclRowsCoverScope(
+  rows: MarkdownDocumentAclRow[],
+  requestedScope: MarkdownDocumentScope,
+): boolean {
+  const granted = rows.reduce((mask, row) => mask | markdownCapabilityMask(row.scope), 0);
+  const requested = markdownCapabilityMask(requestedScope);
+  return (granted & requested) === requested;
+}
+
+export function markdownCapabilityMask(scope: MarkdownDocumentScope): number {
+  switch (scope) {
+    case "viewer":
+      return CAP_READ;
+    case "editor":
+      return CAP_READ | CAP_MARKDOWN_WRITE;
+    case "owner":
+      return CAP_READ | CAP_MARKDOWN_WRITE | CAP_PUBLISH | CAP_MANAGE_ACL;
+  }
+}

--- a/apps/notebook-cloud/src/markdown-document-room.ts
+++ b/apps/notebook-cloud/src/markdown-document-room.ts
@@ -1,0 +1,492 @@
+import type { CloudflareWebSocket, DurableObjectState, Env } from "./cloudflare-types.ts";
+import { identityDisplayLabel } from "./display-label.ts";
+import { readTrustedIdentity, type AuthenticatedConnection } from "./identity.ts";
+import {
+  encodeTypedFrame,
+  FrameType,
+  frameSizeLimits,
+  frameTypeName,
+  isClientWritableFrame,
+  LIVENESS_PING,
+  LIVENESS_PONG,
+  splitTypedFrame,
+  type SessionControlMessage,
+  type TypedFrame,
+} from "./protocol.ts";
+import { cloudLog, durationMs, errorMessage } from "./observability.ts";
+import {
+  isMarkdownMaterializedSyncFrame,
+  MarkdownRoomMaterializer,
+  typedFrameFromMarkdownRoomOutbound,
+  type MarkdownRoomFrameResult,
+} from "./markdown-room-materializer.ts";
+import { json } from "./http-responses.ts";
+
+interface Peer {
+  id: string;
+  socket: CloudflareWebSocket;
+  identity: AuthenticatedConnection;
+  connectedAt: string;
+  consecutiveRejectedFrames: number;
+}
+
+interface PeerAttachment {
+  documentId: string;
+  peerId: string;
+  identity: AuthenticatedConnection;
+  connectedAt: string;
+}
+
+const MAX_CONSECUTIVE_REJECTED_FRAMES = 8;
+const REJECTED_FRAME_POLICY_CLOSE_CODE = 1008;
+const REJECTED_FRAME_POLICY_CLOSE_REASON = "too many rejected frames";
+
+export class MarkdownDocumentRoom {
+  private readonly peers = new Map<string, Peer>();
+  private readonly materializers = new Map<string, MarkdownRoomMaterializer>();
+  private readonly restoredPeersReady: Promise<void>;
+
+  constructor(
+    private readonly state: DurableObjectState,
+    private readonly env: Env,
+  ) {
+    const pairCtor = (
+      globalThis as {
+        WebSocketRequestResponsePair?: new (
+          request: string,
+          response: string,
+        ) => { readonly request: string; readonly response: string };
+      }
+    ).WebSocketRequestResponsePair;
+    if (pairCtor && this.state.setWebSocketAutoResponse) {
+      this.state.setWebSocketAutoResponse(new pairCtor(LIVENESS_PING, LIVENESS_PONG));
+    }
+    this.restoredPeersReady = this.restoreHibernatedPeers();
+    this.state.waitUntil(this.restoredPeersReady);
+  }
+
+  async fetch(request: Request): Promise<Response> {
+    const url = new URL(request.url);
+    const documentId = markdownDocumentIdFromPath(url.pathname);
+    if (!documentId) {
+      return json({ error: "Markdown document id is required" }, 400);
+    }
+    if (request.headers.get("Upgrade")?.toLowerCase() !== "websocket") {
+      return json({ error: "expected WebSocket upgrade" }, 426);
+    }
+
+    const identity = readTrustedIdentity(request);
+    if (!identity) {
+      return json({ error: "missing trusted identity" }, 401);
+    }
+
+    const pair = new WebSocketPair();
+    const peer: Peer = {
+      id: crypto.randomUUID(),
+      socket: pair[1],
+      identity,
+      connectedAt: new Date().toISOString(),
+      consecutiveRejectedFrames: 0,
+    };
+    this.peers.set(peer.id, peer);
+    this.acceptPeerSocket(documentId, peer);
+    this.sendControl(documentId, peer, {
+      type: "cloud_room_ready",
+      protocol: "v4",
+      notebook_id: documentId,
+      peer_id: peer.id,
+      actor_label: identity.actorLabel,
+      connection_scope: identity.scope,
+      identity_provider: identity.metadata.provider,
+      principal_namespace: identity.metadata.principalNamespace,
+      display_name: identityDisplayLabel({
+        displayName: identity.metadata.displayName,
+        email: identity.metadata.email,
+        principal: identity.principal,
+      }),
+      email: identity.metadata.email,
+      room_peer_count: this.peers.size,
+      timestamp: new Date().toISOString(),
+    });
+    this.state.waitUntil(this.syncPeerFromRoomHost(documentId, peer));
+    return new Response(null, {
+      status: 101,
+      webSocket: pair[0],
+    } as ResponseInit & { webSocket: CloudflareWebSocket });
+  }
+
+  async webSocketMessage(
+    socket: CloudflareWebSocket,
+    message: string | ArrayBuffer | ArrayBufferView,
+  ): Promise<void> {
+    const peer = this.peerForSocket(socket);
+    if (!peer) {
+      return;
+    }
+    const attachment = socketAttachment(socket);
+    if (!attachment) {
+      return;
+    }
+    await this.restoredPeersReady;
+    await this.handleMessage(attachment.documentId, peer, message);
+  }
+
+  webSocketClose(socket: CloudflareWebSocket): void {
+    this.removeAttachedPeer(socket);
+  }
+
+  webSocketError(socket: CloudflareWebSocket): void {
+    this.removeAttachedPeer(socket);
+  }
+
+  private async restoreHibernatedPeers(): Promise<void> {
+    const sockets = this.state.getWebSockets?.() ?? [];
+    for (const socket of sockets) {
+      const attachment = socketAttachment(socket);
+      if (!attachment) {
+        continue;
+      }
+      const peer: Peer = {
+        id: attachment.peerId,
+        socket,
+        identity: attachment.identity,
+        connectedAt: attachment.connectedAt,
+        consecutiveRejectedFrames: 0,
+      };
+      this.peers.set(peer.id, peer);
+      await this.syncPeerFromRoomHost(attachment.documentId, peer);
+    }
+  }
+
+  private acceptPeerSocket(documentId: string, peer: Peer): void {
+    const attachment: PeerAttachment = {
+      documentId,
+      peerId: peer.id,
+      identity: peer.identity,
+      connectedAt: peer.connectedAt,
+    };
+    if (this.state.acceptWebSocket && peer.socket.serializeAttachment) {
+      this.state.acceptWebSocket(peer.socket);
+      peer.socket.serializeAttachment(attachment);
+      return;
+    }
+
+    peer.socket.accept();
+    peer.socket.addEventListener("message", (event) => {
+      this.state.waitUntil(this.handleMessage(documentId, peer, event.data));
+    });
+    peer.socket.addEventListener("close", () => {
+      this.removePeer(documentId, peer);
+    });
+    peer.socket.addEventListener("error", () => {
+      this.removePeer(documentId, peer);
+    });
+  }
+
+  private peerForSocket(socket: CloudflareWebSocket): Peer | undefined {
+    const attachment = socketAttachment(socket);
+    if (!attachment) {
+      return undefined;
+    }
+    return this.peers.get(attachment.peerId);
+  }
+
+  private removeAttachedPeer(socket: CloudflareWebSocket): void {
+    const attachment = socketAttachment(socket);
+    if (!attachment) {
+      return;
+    }
+    const peer = this.peers.get(attachment.peerId);
+    if (!peer) {
+      return;
+    }
+    this.removePeer(attachment.documentId, peer);
+  }
+
+  private async handleMessage(
+    documentId: string,
+    peer: Peer,
+    message: string | ArrayBuffer | ArrayBufferView,
+  ): Promise<void> {
+    if (message === LIVENESS_PING) {
+      try {
+        peer.socket.send(LIVENESS_PONG);
+      } catch {
+        // socket is closing; close/error hooks own cleanup.
+      }
+      return;
+    }
+    if (typeof message === "string") {
+      this.rejectFrame(
+        documentId,
+        peer,
+        undefined,
+        "typed-frame WebSocket messages must be binary",
+      );
+      return;
+    }
+
+    let frame: TypedFrame;
+    try {
+      frame = splitTypedFrame(message);
+    } catch (error) {
+      this.rejectFrame(documentId, peer, undefined, String(error));
+      return;
+    }
+
+    const sizeLimits = frameSizeLimits(frame.type);
+    if (frame.payload.byteLength > sizeLimits.cap) {
+      this.rejectFrame(
+        documentId,
+        peer,
+        frame.type,
+        `${frameTypeName(frame.type)} frame payload exceeds ${sizeLimits.cap} byte limit`,
+      );
+      return;
+    }
+
+    if (!isClientWritableFrame(frame.type) || !isMarkdownMaterializedSyncFrame(frame.type)) {
+      this.rejectFrame(
+        documentId,
+        peer,
+        frame.type,
+        `${frameTypeName(frame.type)} is not supported for Markdown documents`,
+      );
+      return;
+    }
+
+    const receivedAt = new Date().toISOString();
+    const materializer = this.materializerFor(documentId);
+    const startedAt = Date.now();
+    let result: MarkdownRoomFrameResult;
+    try {
+      result = await materializer.receiveFrame(peer, frame);
+    } catch (error) {
+      this.rejectFrame(
+        documentId,
+        peer,
+        frame.type,
+        `Markdown room rejected ${frameTypeName(frame.type)} frame: ${String(error)}`,
+        false,
+      );
+      return;
+    }
+
+    cloudLog("debug", "markdown_room.materialized_frame.applied", {
+      document_id: documentId,
+      peer_id: peer.id,
+      principal: peer.identity.principal,
+      scope: peer.identity.scope,
+      frame_type: frameTypeName(frame.type),
+      byte_length: frame.payload.byteLength,
+      duration_ms: durationMs(startedAt),
+      changed: result.changed,
+      outbound_frame_count: result.outbound.length,
+      counter: "markdown_materialized_frames_applied",
+      counter_delta: 1,
+    });
+
+    this.deliverRoomHostFrames(documentId, result);
+    if (result.changed) {
+      this.state.waitUntil(this.checkpointRoomHost(documentId, materializer, "materialized_frame"));
+    }
+    this.sendControl(documentId, peer, {
+      type: "cloud_frame_accepted",
+      notebook_id: documentId,
+      peer_id: peer.id,
+      frame_type: frame.type,
+      byte_length: frame.payload.byteLength,
+      timestamp: receivedAt,
+    });
+    peer.consecutiveRejectedFrames = 0;
+  }
+
+  private async syncPeerFromRoomHost(documentId: string, peer: Peer): Promise<void> {
+    const startedAt = Date.now();
+    try {
+      const result = await this.materializerFor(documentId).syncPeer(peer);
+      cloudLog("debug", "markdown_room.peer_sync.completed", {
+        document_id: documentId,
+        peer_id: peer.id,
+        principal: peer.identity.principal,
+        scope: peer.identity.scope,
+        duration_ms: durationMs(startedAt),
+        outbound_frame_count: result.outbound.length,
+        counter: "markdown_peer_sync_completed",
+        counter_delta: 1,
+      });
+      this.deliverRoomHostFrames(documentId, result);
+    } catch (error) {
+      cloudLog("warn", "markdown_room.peer_sync.failed", {
+        document_id: documentId,
+        peer_id: peer.id,
+        principal: peer.identity.principal,
+        scope: peer.identity.scope,
+        duration_ms: durationMs(startedAt),
+        error: errorMessage(error),
+        counter: "markdown_peer_sync_failed",
+        counter_delta: 1,
+      });
+      this.removePeer(documentId, peer, { code: 1011, reason: "Markdown room sync failed" });
+    }
+  }
+
+  private async checkpointRoomHost(
+    documentId: string,
+    materializer: MarkdownRoomMaterializer,
+    operation: string,
+  ): Promise<void> {
+    try {
+      await materializer.checkpoint();
+    } catch (error) {
+      cloudLog("warn", "markdown_room.materializer.checkpoint_failed", {
+        document_id: documentId,
+        operation,
+        error: errorMessage(error),
+        counter: "markdown_materializer_checkpoint_failures",
+        counter_delta: 1,
+      });
+    }
+  }
+
+  private deliverRoomHostFrames(documentId: string, result: MarkdownRoomFrameResult): void {
+    for (const frame of result.outbound) {
+      const peer = this.peers.get(frame.peer_id);
+      if (!peer) {
+        continue;
+      }
+      try {
+        peer.socket.send(typedFrameFromMarkdownRoomOutbound(frame));
+      } catch (error) {
+        cloudLog("warn", "markdown_room.outbound_frame_failed", {
+          document_id: documentId,
+          peer_id: peer.id,
+          frame_type: frameTypeName(frame.frame_type),
+          error: errorMessage(error),
+          counter: "markdown_outbound_frame_failures",
+          counter_delta: 1,
+        });
+        this.removePeer(documentId, peer);
+      }
+    }
+  }
+
+  private rejectFrame(
+    documentId: string,
+    peer: Peer,
+    frameType: number | undefined,
+    reason: string,
+    countsTowardStreak = true,
+  ): void {
+    if (countsTowardStreak) {
+      peer.consecutiveRejectedFrames += 1;
+    }
+    const shouldClose = peer.consecutiveRejectedFrames >= MAX_CONSECUTIVE_REJECTED_FRAMES;
+    cloudLog(
+      "warn",
+      shouldClose
+        ? "markdown_room.peer.closed_for_rejected_frames"
+        : "markdown_room.frame.rejected",
+      {
+        document_id: documentId,
+        peer_id: peer.id,
+        principal: peer.identity.principal,
+        scope: peer.identity.scope,
+        frame_type: frameType === undefined ? "unknown" : frameTypeName(frameType),
+        reason,
+        consecutive_rejected_frames: peer.consecutiveRejectedFrames,
+        counter: shouldClose
+          ? "markdown_peers_closed_for_rejected_frames"
+          : "markdown_frames_rejected",
+        counter_delta: 1,
+      },
+    );
+    if (shouldClose) {
+      this.removePeer(documentId, peer, {
+        code: REJECTED_FRAME_POLICY_CLOSE_CODE,
+        reason: REJECTED_FRAME_POLICY_CLOSE_REASON,
+      });
+      return;
+    }
+    this.sendControl(documentId, peer, {
+      type: "cloud_frame_rejected",
+      notebook_id: documentId,
+      peer_id: peer.id,
+      ...(frameType === undefined ? {} : { frame_type: frameType }),
+      reason,
+      timestamp: new Date().toISOString(),
+    });
+  }
+
+  private sendControl(documentId: string, peer: Peer, message: SessionControlMessage): void {
+    try {
+      peer.socket.send(
+        encodeTypedFrame(
+          FrameType.SESSION_CONTROL,
+          new TextEncoder().encode(JSON.stringify(message)),
+        ),
+      );
+    } catch (error) {
+      cloudLog("warn", "markdown_room.control_frame_failed", {
+        document_id: documentId,
+        peer_id: peer.id,
+        error: errorMessage(error),
+        counter: "markdown_control_frame_failures",
+        counter_delta: 1,
+      });
+      this.removePeer(documentId, peer);
+    }
+  }
+
+  private removePeer(
+    documentId: string,
+    peer: Peer,
+    closeOptions: { code?: number; reason?: string } = {},
+  ): void {
+    if (!this.peers.delete(peer.id)) {
+      return;
+    }
+    this.state.waitUntil(this.materializerFor(documentId).removePeer(peer.id));
+    try {
+      peer.socket.close(closeOptions.code, closeOptions.reason);
+    } catch {
+      // already closed
+    }
+  }
+
+  private materializerFor(documentId: string): MarkdownRoomMaterializer {
+    let materializer = this.materializers.get(documentId);
+    if (!materializer) {
+      materializer = new MarkdownRoomMaterializer(documentId, this.state, this.env);
+      this.materializers.set(documentId, materializer);
+    }
+    return materializer;
+  }
+}
+
+function socketAttachment(socket: CloudflareWebSocket): PeerAttachment | null {
+  const value = socket.deserializeAttachment?.();
+  if (!value || typeof value !== "object") {
+    return null;
+  }
+  const record = value as Partial<PeerAttachment>;
+  if (
+    typeof record.documentId !== "string" ||
+    typeof record.peerId !== "string" ||
+    typeof record.connectedAt !== "string" ||
+    !record.identity
+  ) {
+    return null;
+  }
+  return {
+    documentId: record.documentId,
+    peerId: record.peerId,
+    identity: record.identity,
+    connectedAt: record.connectedAt,
+  };
+}
+
+function markdownDocumentIdFromPath(pathname: string): string | null {
+  const documentId = decodeURIComponent(pathname.match(/^\/m\/([^/]+)\/sync\/?$/)?.[1] ?? "");
+  return documentId || null;
+}

--- a/apps/notebook-cloud/src/markdown-document-room.ts
+++ b/apps/notebook-cloud/src/markdown-document-room.ts
@@ -1,6 +1,10 @@
 import type { CloudflareWebSocket, DurableObjectState, Env } from "./cloudflare-types.ts";
 import { identityDisplayLabel } from "./display-label.ts";
-import { readTrustedIdentity, type AuthenticatedConnection } from "./identity.ts";
+import {
+  readTrustedIdentity,
+  webSocketUpgradeHeaders,
+  type AuthenticatedConnection,
+} from "./identity.ts";
 import {
   encodeTypedFrame,
   FrameType,
@@ -111,6 +115,7 @@ export class MarkdownDocumentRoom {
     this.state.waitUntil(this.syncPeerFromRoomHost(documentId, peer));
     return new Response(null, {
       status: 101,
+      headers: webSocketUpgradeHeaders(identity),
       webSocket: pair[0],
     } as ResponseInit & { webSocket: CloudflareWebSocket });
   }

--- a/apps/notebook-cloud/src/markdown-room-materializer.ts
+++ b/apps/notebook-cloud/src/markdown-room-materializer.ts
@@ -1,0 +1,219 @@
+import type { DurableObjectState, Env } from "./cloudflare-types.ts";
+import { FrameType, encodeTypedFrame, type FrameTypeValue, type TypedFrame } from "./protocol.ts";
+import {
+  createEmptyMarkdownRoomHost,
+  loadMarkdownRoomHostSnapshot,
+  type MarkdownRoomHostHandle,
+} from "./runtimed-wasm.ts";
+import { getMarkdownDocumentCatalog } from "./storage.ts";
+import type { AuthenticatedConnection } from "./identity.ts";
+import { cloudLog, durationMs, errorMessage } from "./observability.ts";
+
+const MARKDOWN_ROOM_ACTOR_PRINCIPAL = "system:notebook-cloud-markdown-room";
+const CHECKPOINT_DOC_KEY = "markdown-room:doc";
+const CHECKPOINT_META_KEY = "markdown-room:checkpoint";
+const CHECKPOINT_VERSION = 1;
+
+interface RoomHostOutboundFrame {
+  peer_id: string;
+  frame_type: FrameTypeValue;
+  payload: Uint8Array | number[];
+}
+
+export interface MarkdownRoomFrameResult {
+  changed: boolean;
+  outbound: RoomHostOutboundFrame[];
+}
+
+interface MarkdownRoomCheckpointMetadata {
+  version: number;
+  heads: string[];
+  saved_at: string;
+}
+
+interface MarkdownRoomPeer {
+  id: string;
+  identity: AuthenticatedConnection;
+}
+
+export class MarkdownRoomMaterializer {
+  private hostReady: Promise<MarkdownRoomHostHandle> | undefined;
+  private operationQueue: Promise<void> = Promise.resolve();
+
+  constructor(
+    private readonly documentId: string,
+    private readonly state: DurableObjectState,
+    private readonly env: Env,
+  ) {}
+
+  async syncPeer(peer: MarkdownRoomPeer): Promise<MarkdownRoomFrameResult> {
+    return this.withHost((host) =>
+      normalizeMarkdownRoomResult(host.sync_peer(peer.id, peer.identity.scope)),
+    );
+  }
+
+  async receiveFrame(peer: MarkdownRoomPeer, frame: TypedFrame): Promise<MarkdownRoomFrameResult> {
+    const encoded = encodeTypedFrame(frame.type, frame.payload);
+    return this.withHost((host) =>
+      normalizeMarkdownRoomResult(
+        host.receive_peer_frame(peer.id, peer.identity.principal, peer.identity.scope, encoded),
+      ),
+    );
+  }
+
+  async removePeer(peerId: string): Promise<void> {
+    await this.withHost((host) => {
+      host.remove_peer(peerId);
+    });
+  }
+
+  async checkpoint(): Promise<void> {
+    const startedAt = Date.now();
+    await this.withHost(async (host) => {
+      const bytes = toStoredArrayBuffer(host.save_doc());
+      const metadata: MarkdownRoomCheckpointMetadata = {
+        version: CHECKPOINT_VERSION,
+        heads: Array.from(host.get_heads_hex()),
+        saved_at: new Date().toISOString(),
+      };
+      await Promise.all([
+        this.state.storage.put(CHECKPOINT_DOC_KEY, bytes),
+        this.state.storage.put(CHECKPOINT_META_KEY, metadata),
+      ]);
+      cloudLog("debug", "markdown_room.materializer.checkpoint.saved", {
+        document_id: this.documentId,
+        duration_ms: durationMs(startedAt),
+        byte_length: bytes.byteLength,
+        head_count: metadata.heads.length,
+        counter: "markdown_materializer_checkpoints_saved",
+        counter_delta: 1,
+      });
+    });
+  }
+
+  private async withHost<T>(
+    operation: (host: MarkdownRoomHostHandle) => T | Promise<T>,
+  ): Promise<T> {
+    const run = this.operationQueue.then(async () => operation(await this.loadHost()));
+    this.operationQueue = run.then(
+      () => undefined,
+      () => undefined,
+    );
+    return run;
+  }
+
+  private async loadHost(): Promise<MarkdownRoomHostHandle> {
+    this.hostReady ??= this.loadHostFromStorage().catch((error: unknown) => {
+      this.hostReady = undefined;
+      throw error;
+    });
+    return this.hostReady;
+  }
+
+  private async loadHostFromStorage(): Promise<MarkdownRoomHostHandle> {
+    const startedAt = Date.now();
+    const checkpoint = await this.loadCheckpoint().catch((error: unknown) => {
+      cloudLog("warn", "markdown_room.materializer.checkpoint_load_failed", {
+        document_id: this.documentId,
+        duration_ms: durationMs(startedAt),
+        error: errorMessage(error),
+        counter: "markdown_materializer_checkpoint_load_failures",
+        counter_delta: 1,
+      });
+      return null;
+    });
+    if (checkpoint) {
+      const host = await loadMarkdownRoomHostSnapshot(checkpoint.bytes);
+      cloudLog("info", "markdown_room.materializer.loaded", {
+        document_id: this.documentId,
+        source: "durable_object_checkpoint",
+        duration_ms: durationMs(startedAt),
+        byte_length: checkpoint.bytes.byteLength,
+        counter: "markdown_materializer_loads",
+        counter_delta: 1,
+      });
+      return host;
+    }
+
+    const catalog = await getMarkdownDocumentCatalog(this.env, this.documentId);
+    if (!catalog) {
+      throw new Error(`Markdown document not found: ${this.documentId}`);
+    }
+    const title = catalog.document.title?.trim() || "Untitled Markdown";
+    const host = await createEmptyMarkdownRoomHost(
+      this.documentId,
+      title,
+      markdownRoomActorLabel(this.documentId),
+    );
+    cloudLog("info", "markdown_room.materializer.loaded", {
+      document_id: this.documentId,
+      source: "empty_room",
+      duration_ms: durationMs(startedAt),
+      counter: "markdown_materializer_loads",
+      counter_delta: 1,
+    });
+    return host;
+  }
+
+  private async loadCheckpoint(): Promise<{
+    bytes: Uint8Array;
+    metadata: MarkdownRoomCheckpointMetadata | null;
+  } | null> {
+    const [storedBytes, metadata] = await Promise.all([
+      this.state.storage.get<ArrayBuffer>(CHECKPOINT_DOC_KEY),
+      this.state.storage.get<MarkdownRoomCheckpointMetadata>(CHECKPOINT_META_KEY),
+    ]);
+    if (!storedBytes) {
+      return null;
+    }
+    return { bytes: new Uint8Array(storedBytes), metadata: metadata ?? null };
+  }
+}
+
+export function isMarkdownMaterializedSyncFrame(type: FrameTypeValue): boolean {
+  return type === FrameType.AUTOMERGE_SYNC;
+}
+
+export function typedFrameFromMarkdownRoomOutbound(frame: RoomHostOutboundFrame): Uint8Array {
+  return encodeTypedFrame(frame.frame_type, Uint8Array.from(frame.payload));
+}
+
+function markdownRoomActorLabel(documentId: string): string {
+  return `${MARKDOWN_ROOM_ACTOR_PRINCIPAL}/room:${documentId}`;
+}
+
+function normalizeMarkdownRoomResult(value: unknown): MarkdownRoomFrameResult {
+  if (!value || typeof value !== "object") {
+    return { changed: false, outbound: [] };
+  }
+  const record = value as Record<string, unknown>;
+  return {
+    changed: Boolean(record.changed),
+    outbound: Array.isArray(record.outbound)
+      ? record.outbound.flatMap((frame) => normalizeOutboundFrame(frame))
+      : [],
+  };
+}
+
+function normalizeOutboundFrame(value: unknown): RoomHostOutboundFrame[] {
+  if (!value || typeof value !== "object") {
+    return [];
+  }
+  const record = value as Record<string, unknown>;
+  const peerId = typeof record.peer_id === "string" ? record.peer_id : null;
+  const frameType = Number(record.frame_type);
+  const payload = Array.isArray(record.payload)
+    ? (record.payload.filter((byte) => Number.isInteger(byte)) as number[])
+    : record.payload instanceof Uint8Array
+      ? record.payload
+      : null;
+  if (!peerId || !Number.isInteger(frameType) || !payload) {
+    return [];
+  }
+  return [{ peer_id: peerId, frame_type: frameType as FrameTypeValue, payload }];
+}
+
+function toStoredArrayBuffer(bytes: Uint8Array | number[]): ArrayBuffer {
+  const view = Uint8Array.from(bytes);
+  return view.buffer.slice(view.byteOffset, view.byteOffset + view.byteLength);
+}

--- a/apps/notebook-cloud/src/notebook-room.ts
+++ b/apps/notebook-cloud/src/notebook-room.ts
@@ -11,6 +11,7 @@ import {
   allowsExecutionRequestSubmit,
   isAnonymousViewer,
   readTrustedIdentity,
+  webSocketUpgradeHeaders,
   type AuthenticatedConnection,
 } from "./identity.ts";
 import {
@@ -1978,14 +1979,6 @@ function normalizeNonNegativeInteger(value: number, fallback: number): number {
     return fallback;
   }
   return Math.max(0, Math.trunc(value));
-}
-
-export function webSocketUpgradeHeaders(identity: AuthenticatedConnection): Headers {
-  const headers = new Headers();
-  if (identity.webSocketProtocol) {
-    headers.set("Sec-WebSocket-Protocol", identity.webSocketProtocol);
-  }
-  return headers;
 }
 
 export function rewritePresenceFrame(

--- a/apps/notebook-cloud/src/room-materializer.ts
+++ b/apps/notebook-cloud/src/room-materializer.ts
@@ -101,6 +101,27 @@ export class RoomMaterializer {
   }
 
   async receiveFrame(peer: RoomPeer, frame: TypedFrame): Promise<RoomHostFrameResult> {
+    try {
+      return await this.receiveFrameWithCurrentHost(peer, frame);
+    } catch (error) {
+      if (!shouldRecoverReceiveFrame(frame, error)) {
+        throw error;
+      }
+      const recovered = await this.recoverHostFromLatestPublishedSnapshot(
+        `receive_${frameTypeNameForRecovery(frame.type)}`,
+        error,
+      );
+      if (!recovered) {
+        throw error;
+      }
+      return this.syncPeerWithCurrentHost(peer);
+    }
+  }
+
+  private async receiveFrameWithCurrentHost(
+    peer: RoomPeer,
+    frame: TypedFrame,
+  ): Promise<RoomHostFrameResult> {
     const canWriteAllNotebookChanges = peer.identity.scope === "owner";
     const encoded = encodeTypedFrame(frame.type, frame.payload);
     return this.withHost((host) =>
@@ -568,6 +589,42 @@ function stableRoomKey(value: string): string {
     hash = BigInt.asUintN(64, hash * 0x100000001b3n);
   }
   return hash.toString(16).padStart(16, "0");
+}
+
+function shouldRecoverReceiveFrame(frame: TypedFrame, error: unknown): boolean {
+  if (!isMaterializedSyncFrameForRecovery(frame.type)) {
+    return false;
+  }
+  return isRecoverableAutomergeSyncBoundaryError(errorMessage(error));
+}
+
+function isMaterializedSyncFrameForRecovery(type: FrameTypeValue): boolean {
+  return (
+    type === FrameType.AUTOMERGE_SYNC ||
+    type === FrameType.RUNTIME_STATE_SYNC ||
+    type === FrameType.COMMS_DOC_SYNC
+  );
+}
+
+function isRecoverableAutomergeSyncBoundaryError(message: string): boolean {
+  return (
+    /recursive use of an object detected which would lead to unsafe aliasing/i.test(message) ||
+    /\bPatchLogMismatch\b/i.test(message) ||
+    /patch logs cannot be shared between documents/i.test(message)
+  );
+}
+
+function frameTypeNameForRecovery(type: FrameTypeValue): string {
+  switch (type) {
+    case FrameType.AUTOMERGE_SYNC:
+      return "notebook_sync";
+    case FrameType.RUNTIME_STATE_SYNC:
+      return "runtime_state_sync";
+    case FrameType.COMMS_DOC_SYNC:
+      return "comms_doc_sync";
+    default:
+      return `frame_${type}`;
+  }
 }
 
 export function isMaterializedSyncFrame(type: FrameTypeValue): boolean {

--- a/apps/notebook-cloud/src/runtimed-wasm.ts
+++ b/apps/notebook-cloud/src/runtimed-wasm.ts
@@ -5,6 +5,7 @@ import initWasm, {
   encode_interaction_presence,
   encode_presence_frame,
   encode_selection_presence,
+  project_markdown_json,
   rewrite_presence_ingress,
   NotebookHandle,
   RoomHostHandle,
@@ -207,6 +208,11 @@ export async function loadMarkdownRoomHostSnapshot(
 ): Promise<MarkdownRoomHostHandle> {
   await initializeRuntimedWasm();
   return MarkdownRoomHostHandle.load_snapshot(markdownBytes);
+}
+
+export async function projectMarkdownJson(source: string): Promise<string> {
+  await initializeRuntimedWasm();
+  return project_markdown_json(source);
 }
 
 export {

--- a/apps/notebook-cloud/src/runtimed-wasm.ts
+++ b/apps/notebook-cloud/src/runtimed-wasm.ts
@@ -8,6 +8,8 @@ import initWasm, {
   rewrite_presence_ingress,
   NotebookHandle,
   RoomHostHandle,
+  MarkdownRoomHostHandle,
+  MarkdownHandle,
   RuntimeStatePeerHandle,
 } from "../../notebook/src/wasm/runtimed-wasm/runtimed_wasm.js";
 
@@ -191,4 +193,26 @@ export async function loadRoomHostSnapshot(
   return host;
 }
 
-export { NotebookHandle, RoomHostHandle, RuntimeStatePeerHandle };
+export async function createEmptyMarkdownRoomHost(
+  documentId: string,
+  title: string,
+  actorLabel: string,
+): Promise<MarkdownRoomHostHandle> {
+  await initializeRuntimedWasm();
+  return MarkdownRoomHostHandle.create_empty(documentId, title, actorLabel);
+}
+
+export async function loadMarkdownRoomHostSnapshot(
+  markdownBytes: Uint8Array,
+): Promise<MarkdownRoomHostHandle> {
+  await initializeRuntimedWasm();
+  return MarkdownRoomHostHandle.load_snapshot(markdownBytes);
+}
+
+export {
+  NotebookHandle,
+  RoomHostHandle,
+  RuntimeStatePeerHandle,
+  MarkdownRoomHostHandle,
+  MarkdownHandle,
+};

--- a/apps/notebook-cloud/src/sharing-storage.ts
+++ b/apps/notebook-cloud/src/sharing-storage.ts
@@ -68,6 +68,28 @@ export interface PendingNotebookInviteRow {
 
 export type ListedPendingNotebookInviteRow = Omit<PendingNotebookInviteRow, "token_hash">;
 
+export interface PendingMarkdownDocumentInviteRow {
+  id: string;
+  document_id: string;
+  email_normalized: string;
+  provider_hint: string | null;
+  scope: PendingNotebookInvite["scope"];
+  status: PendingNotebookInvite["status"];
+  invited_by_actor_label: string;
+  accepted_by_principal: string | null;
+  token_hash: string | null;
+  created_at: string;
+  expires_at: string | null;
+  accepted_at: string | null;
+  revoked_at: string | null;
+  revoked_by_actor_label: string | null;
+}
+
+export type ListedPendingMarkdownDocumentInviteRow = Omit<
+  PendingMarkdownDocumentInviteRow,
+  "token_hash"
+>;
+
 export interface PendingNotebookInviteInput {
   id?: string;
   notebookId: string;
@@ -80,7 +102,20 @@ export interface PendingNotebookInviteInput {
   timestamp?: string;
 }
 
+export interface PendingMarkdownDocumentInviteInput {
+  id?: string;
+  documentId: string;
+  email: string;
+  providerHint?: string | null;
+  scope: PendingNotebookInvite["scope"];
+  actorLabel: string;
+  expiresAt?: string | null;
+  tokenHash?: string | null;
+  timestamp?: string;
+}
+
 const NOTEBOOK_INVITE_LIST_LIMIT = 200;
+const MARKDOWN_DOCUMENT_INVITE_LIST_LIMIT = 200;
 
 export async function upsertPrincipalProfile(
   env: Env,
@@ -645,6 +680,170 @@ export async function revokePendingNotebookInvite(
   return d1Changes(result) > 0;
 }
 
+export async function createPendingMarkdownDocumentInvite(
+  env: Env,
+  input: PendingMarkdownDocumentInviteInput,
+): Promise<PendingMarkdownDocumentInviteRow | null> {
+  if (!env.DB) {
+    return null;
+  }
+
+  await ensureCatalogSchema(env);
+  const inviteId = input.id ?? crypto.randomUUID();
+  const timestamp = input.timestamp ?? new Date().toISOString();
+  const providerHint = normalizeProviderHint(input.providerHint ?? null);
+  const scope = normalizeInviteScope(input.scope);
+  const email = normalizeInviteEmail(input.email);
+  const expiresAt = normalizeInviteExpiresAt(input.expiresAt ?? null);
+  const existing = await getExistingPendingMarkdownDocumentInvite(env, {
+    documentId: input.documentId,
+    email,
+    providerHint,
+    scope,
+  });
+  if (existing) {
+    return existing;
+  }
+
+  try {
+    await env.DB.prepare(
+      `INSERT INTO markdown_document_invites (
+       id,
+       document_id,
+       email_normalized,
+       provider_hint,
+       scope,
+       status,
+       invited_by_actor_label,
+       token_hash,
+       created_at,
+       expires_at
+     ) VALUES (?, ?, ?, ?, ?, 'pending', ?, ?, ?, ?)`,
+    )
+      .bind(
+        inviteId,
+        input.documentId,
+        email,
+        providerHint,
+        scope,
+        input.actorLabel,
+        input.tokenHash ?? null,
+        timestamp,
+        expiresAt,
+      )
+      .run();
+  } catch (error) {
+    if (!isUniqueConstraintError(error)) {
+      throw error;
+    }
+    const raced = await getExistingPendingMarkdownDocumentInvite(env, {
+      documentId: input.documentId,
+      email,
+      providerHint,
+      scope,
+    });
+    if (raced) {
+      return raced;
+    }
+    throw error;
+  }
+
+  return await getPendingMarkdownDocumentInvite(env, inviteId);
+}
+
+export async function getPendingMarkdownDocumentInvite(
+  env: Env,
+  inviteId: string,
+): Promise<PendingMarkdownDocumentInviteRow | null> {
+  if (!env.DB) {
+    return null;
+  }
+
+  await ensureCatalogSchema(env);
+  return await env.DB.prepare(
+    `SELECT id,
+            document_id,
+            email_normalized,
+            provider_hint,
+            scope,
+            status,
+            invited_by_actor_label,
+            accepted_by_principal,
+            token_hash,
+            created_at,
+            expires_at,
+            accepted_at,
+            revoked_at,
+            revoked_by_actor_label
+       FROM markdown_document_invites
+       WHERE id = ?`,
+  )
+    .bind(inviteId)
+    .first<PendingMarkdownDocumentInviteRow>();
+}
+
+export async function listMarkdownDocumentInvites(
+  env: Env,
+  documentId: string,
+): Promise<ListedPendingMarkdownDocumentInviteRow[]> {
+  if (!env.DB) {
+    return [];
+  }
+
+  await ensureCatalogSchema(env);
+  const rows = await env.DB.prepare(
+    `SELECT id,
+            document_id,
+            email_normalized,
+            provider_hint,
+            scope,
+            status,
+            invited_by_actor_label,
+            accepted_by_principal,
+            created_at,
+            expires_at,
+            accepted_at,
+            revoked_at,
+            revoked_by_actor_label
+       FROM markdown_document_invites
+       WHERE document_id = ?
+       ORDER BY created_at DESC, id DESC
+       LIMIT ?`,
+  )
+    .bind(documentId, MARKDOWN_DOCUMENT_INVITE_LIST_LIMIT)
+    .all<ListedPendingMarkdownDocumentInviteRow>();
+  return rows.results ?? [];
+}
+
+export async function revokePendingMarkdownDocumentInvite(
+  env: Env,
+  input: {
+    documentId: string;
+    inviteId: string;
+    actorLabel: string;
+    timestamp?: string;
+  },
+): Promise<boolean> {
+  if (!env.DB) {
+    return false;
+  }
+
+  await ensureCatalogSchema(env);
+  const timestamp = input.timestamp ?? new Date().toISOString();
+  const result = await env.DB.prepare(
+    `UPDATE markdown_document_invites
+        SET status = 'revoked',
+            revoked_at = ?,
+            revoked_by_actor_label = ?
+      WHERE document_id = ?
+        AND id = ?
+        AND status = 'pending'`,
+  )
+    .bind(timestamp, input.actorLabel, input.documentId, input.inviteId)
+    .run();
+  return d1Changes(result) > 0;
+}
+
 async function getExistingPendingNotebookInvite(
   env: Env,
   input: {
@@ -681,6 +880,44 @@ async function getExistingPendingNotebookInvite(
     )
     .bind(input.notebookId, input.email, input.scope, input.providerHint, input.providerHint)
     .first<PendingNotebookInviteRow>();
+}
+
+async function getExistingPendingMarkdownDocumentInvite(
+  env: Env,
+  input: {
+    documentId: string;
+    email: string;
+    providerHint: string | null;
+    scope: PendingNotebookInvite["scope"];
+  },
+): Promise<PendingMarkdownDocumentInviteRow | null> {
+  return await env
+    .DB!.prepare(
+      `SELECT id,
+              document_id,
+              email_normalized,
+              provider_hint,
+              scope,
+              status,
+              invited_by_actor_label,
+              accepted_by_principal,
+              token_hash,
+              created_at,
+              expires_at,
+              accepted_at,
+              revoked_at,
+              revoked_by_actor_label
+         FROM markdown_document_invites
+        WHERE document_id = ?
+          AND email_normalized = ?
+          AND scope = ?
+          AND status = 'pending'
+          AND ((provider_hint IS NULL AND ? IS NULL) OR provider_hint = ?)
+        ORDER BY created_at
+        LIMIT 1`,
+    )
+    .bind(input.documentId, input.email, input.scope, input.providerHint, input.providerHint)
+    .first<PendingMarkdownDocumentInviteRow>();
 }
 
 export async function getPendingNotebookInvitesForLogin(
@@ -724,6 +961,49 @@ export async function getPendingNotebookInvitesForLogin(
     .bind(email, provider, now)
     .all<PendingNotebookInviteRow>();
   return (rows.results ?? []).map(pendingInviteFromRow);
+}
+
+export async function getPendingMarkdownDocumentInvitesForLogin(
+  env: Env,
+  login: Pick<AuthenticatedLoginProfile, "provider" | "email" | "emailVerified">,
+  now = new Date().toISOString(),
+): Promise<PendingNotebookInvite[]> {
+  if (!env.DB || !login.emailVerified) {
+    return [];
+  }
+
+  const email = normalizeMaybeInviteEmail(login.email);
+  if (!email) {
+    return [];
+  }
+
+  await ensureCatalogSchema(env);
+  const provider = normalizeRequiredProvider(login.provider);
+  const rows = await env.DB.prepare(
+    `SELECT id,
+            document_id,
+            email_normalized,
+            provider_hint,
+            scope,
+            status,
+            invited_by_actor_label,
+            accepted_by_principal,
+            token_hash,
+            created_at,
+            expires_at,
+            accepted_at,
+            revoked_at,
+            revoked_by_actor_label
+       FROM markdown_document_invites
+       WHERE email_normalized = ?
+         AND status = 'pending'
+         AND (provider_hint = ? OR provider_hint IS NULL)
+         AND (expires_at IS NULL OR unixepoch(expires_at) > unixepoch(?))
+       ORDER BY created_at`,
+  )
+    .bind(email, provider, now)
+    .all<PendingMarkdownDocumentInviteRow>();
+  return (rows.results ?? []).map(pendingMarkdownDocumentInviteFromRow);
 }
 
 export async function resolveNotebookInvitesForLogin(
@@ -807,6 +1087,87 @@ export async function resolveNotebookInvitesForLogin(
   return { ...resolutionWithProfile, acceptedInvites, aclGrants };
 }
 
+export async function resolveMarkdownDocumentInvitesForLogin(
+  env: Env,
+  login: AuthenticatedLoginProfile,
+  now = new Date().toISOString(),
+): Promise<InviteResolution> {
+  // Trust boundary: callers must pass identity-provider verified claims.
+  // Invite acceptance is derived from login.email plus login.emailVerified.
+  const account = await upsertPrincipalProfileWithAccount(env, {
+    principal: login.principal,
+    provider: login.provider,
+    principalNamespace: login.principalNamespace,
+    email: login.email,
+    emailVerified: login.emailVerified,
+    displayName: login.displayName,
+    timestamp: now,
+  });
+
+  const invites = await getPendingMarkdownDocumentInvitesForLogin(env, login, now);
+  const resolution = resolvePendingInvitesForLogin({
+    invites,
+    login,
+    aclSubject: account.canonicalPrincipal ?? login.principal,
+    now,
+  });
+  const resolutionWithProfile = {
+    ...resolution,
+    profile: profileFromRow(account.profile) ?? resolution.profile,
+  };
+  if (!env.DB || resolution.aclGrants.length === 0) {
+    return resolutionWithProfile;
+  }
+
+  const operations: {
+    invite: PendingNotebookInvite;
+    grant: InviteResolution["aclGrants"][number];
+    insertAcl: D1PreparedStatement;
+    acceptInvite: D1PreparedStatement;
+  }[] = [];
+  for (const grant of resolution.aclGrants) {
+    const invite = resolution.acceptedInvites.find((candidate) => candidate.id === grant.inviteId);
+    if (!invite) {
+      continue;
+    }
+    operations.push({
+      invite,
+      grant,
+      insertAcl: markdownInviteAclInsert(env, grant, invite, now),
+      acceptInvite: markdownInviteAcceptedUpdate(env, grant, invite, now),
+    });
+  }
+  if (operations.length === 0) {
+    return resolutionWithProfile;
+  }
+
+  const results = await env.DB.batch(
+    operations.flatMap((operation) => [operation.acceptInvite, operation.insertAcl]),
+  );
+  const acceptedInvites: PendingNotebookInvite[] = [];
+  const aclGrants: InviteResolution["aclGrants"] = [];
+  for (let index = 0; index < operations.length; index += 1) {
+    const acceptInviteResult = results[index * 2];
+    const insertAclResult = results[index * 2 + 1];
+    if (
+      !acceptInviteResult ||
+      !insertAclResult ||
+      d1Changes(acceptInviteResult) === 0 ||
+      d1Changes(insertAclResult) === 0
+    ) {
+      continue;
+    }
+    acceptedInvites.push({
+      ...operations[index].invite,
+      status: "accepted",
+      acceptedByPrincipal: login.principal,
+      acceptedAt: now,
+    });
+    aclGrants.push(operations[index].grant);
+  }
+  return { ...resolutionWithProfile, acceptedInvites, aclGrants };
+}
+
 function inviteAclInsert(
   env: Env,
   grant: InviteResolution["aclGrants"][number],
@@ -837,6 +1198,52 @@ function inviteAclInsert(
           SELECT 1 FROM notebooks WHERE notebooks.id = notebook_invites.notebook_id
         )
      ON CONFLICT(notebook_id, subject_kind, subject, scope) DO UPDATE SET
+       updated_at = excluded.updated_at`,
+    )
+    .bind(
+      grant.subject,
+      timestamp,
+      timestamp,
+      grant.actorLabel,
+      invite.id,
+      grant.acceptedByPrincipal,
+      timestamp,
+      normalizeInviteEmail(invite.email),
+      normalizeProviderHint(invite.providerHint),
+      timestamp,
+    );
+}
+
+function markdownInviteAclInsert(
+  env: Env,
+  grant: InviteResolution["aclGrants"][number],
+  invite: PendingNotebookInvite,
+  timestamp: string,
+): D1PreparedStatement {
+  return env
+    .DB!.prepare(
+      `INSERT INTO markdown_document_acl (
+       document_id,
+       subject_kind,
+       subject,
+       scope,
+       created_at,
+       updated_at,
+       created_by_actor_label
+     )
+     SELECT document_id, 'principal', ?, scope, ?, ?, ?
+       FROM markdown_document_invites
+      WHERE id = ?
+        AND status = 'accepted'
+        AND accepted_by_principal = ?
+        AND accepted_at = ?
+        AND email_normalized = ?
+        AND (provider_hint = ? OR provider_hint IS NULL)
+        AND (expires_at IS NULL OR unixepoch(expires_at) > unixepoch(?))
+        AND EXISTS (
+          SELECT 1 FROM markdown_documents WHERE markdown_documents.id = markdown_document_invites.document_id
+        )
+     ON CONFLICT(document_id, subject_kind, subject, scope) DO UPDATE SET
        updated_at = excluded.updated_at`,
     )
     .bind(
@@ -884,10 +1291,59 @@ function inviteAcceptedUpdate(
     );
 }
 
+function markdownInviteAcceptedUpdate(
+  env: Env,
+  grant: InviteResolution["aclGrants"][number],
+  invite: PendingNotebookInvite,
+  timestamp: string,
+): D1PreparedStatement {
+  return env
+    .DB!.prepare(
+      `UPDATE markdown_document_invites
+          SET status = 'accepted',
+              accepted_by_principal = ?,
+              accepted_at = ?
+        WHERE id = ?
+          AND status = 'pending'
+          AND email_normalized = ?
+          AND (provider_hint = ? OR provider_hint IS NULL)
+          AND (expires_at IS NULL OR unixepoch(expires_at) > unixepoch(?))
+          AND EXISTS (
+            SELECT 1 FROM markdown_documents WHERE markdown_documents.id = markdown_document_invites.document_id
+          )`,
+    )
+    .bind(
+      grant.acceptedByPrincipal,
+      timestamp,
+      invite.id,
+      normalizeInviteEmail(invite.email),
+      normalizeProviderHint(invite.providerHint),
+      timestamp,
+    );
+}
+
 function pendingInviteFromRow(row: PendingNotebookInviteRow): PendingNotebookInvite {
   return {
     id: row.id,
     notebookId: row.notebook_id,
+    email: row.email_normalized,
+    providerHint: row.provider_hint,
+    scope: row.scope,
+    status: row.status,
+    createdByActorLabel: row.invited_by_actor_label,
+    createdAt: row.created_at,
+    expiresAt: row.expires_at,
+    acceptedByPrincipal: row.accepted_by_principal,
+    acceptedAt: row.accepted_at,
+  };
+}
+
+function pendingMarkdownDocumentInviteFromRow(
+  row: PendingMarkdownDocumentInviteRow,
+): PendingNotebookInvite {
+  return {
+    id: row.id,
+    notebookId: row.document_id,
     email: row.email_normalized,
     providerHint: row.provider_hint,
     scope: row.scope,

--- a/apps/notebook-cloud/src/sharing-storage.ts
+++ b/apps/notebook-cloud/src/sharing-storage.ts
@@ -440,6 +440,47 @@ export async function getPrincipalProfiles(
   return profiles;
 }
 
+export async function getPrincipalProfilesForVerifiedEmail(
+  env: Env,
+  email: string,
+): Promise<PrincipalProfileRow[]> {
+  if (!env.DB) {
+    return [];
+  }
+
+  const normalizedEmail = normalizeInviteEmail(email);
+  await ensureCatalogSchema(env);
+  const rows = await env.DB.prepare(
+    `SELECT principal,
+            provider,
+            provider_subject,
+            email_normalized,
+            email_verified,
+            display_name,
+            avatar_url,
+            first_seen_at,
+            last_seen_at,
+            raw_claims_json
+       FROM principal_profiles
+      WHERE email_normalized = ?
+        AND email_verified = 1
+      ORDER BY last_seen_at DESC`,
+  )
+    .bind(normalizedEmail)
+    .all<PrincipalProfileRow>();
+  return rows.results ?? [];
+}
+
+export async function getPreferredPrincipalProfileForVerifiedEmail(
+  env: Env,
+  email: string,
+): Promise<PrincipalProfileRow | null> {
+  const profiles = await getPrincipalProfilesForVerifiedEmail(env, email);
+  return (
+    profiles.find((profile) => profile.principal.startsWith("account:")) ?? profiles[0] ?? null
+  );
+}
+
 export async function createPendingNotebookInvite(
   env: Env,
   input: PendingNotebookInviteInput,

--- a/apps/notebook-cloud/src/storage.ts
+++ b/apps/notebook-cloud/src/storage.ts
@@ -7,6 +7,11 @@ export interface NotebookCatalog {
   blobs: BlobRow[];
 }
 
+export interface MarkdownDocumentCatalog {
+  document: MarkdownDocumentRow;
+  revisions: MarkdownDocumentRevisionRow[];
+}
+
 export interface NotebookRow {
   id: string;
   owner_principal: string;
@@ -51,6 +56,49 @@ export interface NotebookAclRow {
 
 export interface ListedNotebookRow extends NotebookRow {
   scope: NotebookAclRow["scope"];
+}
+
+export type MarkdownDocumentScope = Exclude<AuthenticatedConnection["scope"], "runtime_peer">;
+
+export interface MarkdownDocumentRow {
+  id: string;
+  owner_principal: string;
+  title: string | null;
+  body_doc_id: string;
+  created_at: string;
+  updated_at: string;
+  latest_revision_id: string | null;
+}
+
+export interface MarkdownDocumentRevisionRow {
+  id: string;
+  document_id: string;
+  body_heads_hash: string;
+  snapshot_key: string;
+  actor_label: string;
+  created_at: string;
+}
+
+export interface MarkdownDocumentAclRow {
+  document_id: string;
+  subject_kind: "principal" | "public";
+  subject: string;
+  scope: MarkdownDocumentScope;
+  created_at: string;
+  updated_at: string;
+  created_by_actor_label: string;
+}
+
+export interface ListedMarkdownDocumentRow extends MarkdownDocumentRow {
+  scope: MarkdownDocumentAclRow["scope"];
+}
+
+export interface MarkdownDocumentAclInput {
+  documentId: string;
+  subjectKind: MarkdownDocumentAclRow["subject_kind"];
+  subject: string;
+  scope: MarkdownDocumentAclRow["scope"];
+  actorLabel: string;
 }
 
 export interface NotebookAclInput {
@@ -177,6 +225,38 @@ const SCHEMA_STATEMENTS = [
     PRIMARY KEY (notebook_id, hash),
     FOREIGN KEY (notebook_id) REFERENCES notebooks(id)
   )`,
+  `CREATE TABLE IF NOT EXISTS markdown_documents (
+    id TEXT PRIMARY KEY,
+    owner_principal TEXT NOT NULL,
+    title TEXT,
+    body_doc_id TEXT NOT NULL,
+    created_at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ', 'now')),
+    updated_at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ', 'now')),
+    latest_revision_id TEXT
+  )`,
+  `CREATE TABLE IF NOT EXISTS markdown_document_revisions (
+    id TEXT PRIMARY KEY,
+    document_id TEXT NOT NULL,
+    body_heads_hash TEXT NOT NULL,
+    snapshot_key TEXT NOT NULL,
+    actor_label TEXT NOT NULL,
+    created_at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ', 'now')),
+    FOREIGN KEY (document_id) REFERENCES markdown_documents(id)
+  )`,
+  `CREATE TABLE IF NOT EXISTS markdown_document_acl (
+    document_id TEXT NOT NULL,
+    subject_kind TEXT NOT NULL CHECK (subject_kind IN ('principal', 'public')),
+    subject TEXT NOT NULL,
+    scope TEXT NOT NULL CHECK (scope IN ('viewer', 'editor', 'owner')),
+    created_at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ', 'now')),
+    updated_at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ', 'now')),
+    created_by_actor_label TEXT NOT NULL,
+    PRIMARY KEY (document_id, subject_kind, subject, scope),
+    FOREIGN KEY (document_id) REFERENCES markdown_documents(id),
+    CHECK (subject_kind != 'public' OR (subject = 'anonymous' AND scope = 'viewer'))
+  )`,
+  `CREATE INDEX IF NOT EXISTS markdown_document_acl_subject_idx
+    ON markdown_document_acl (subject_kind, subject, document_id)`,
   `CREATE TABLE IF NOT EXISTS notebook_acl (
     notebook_id TEXT NOT NULL,
     subject_kind TEXT NOT NULL CHECK (subject_kind IN ('principal', 'public')),
@@ -383,6 +463,10 @@ export function blobKey(notebookId: string, hash: string): string {
   return `n/${encodePathComponent(notebookId)}/blobs/${encodePathComponent(hash)}`;
 }
 
+export function markdownDocumentSnapshotKey(documentId: string, headsHash: string): string {
+  return `m/${encodePathComponent(documentId)}/snapshots/${encodePathComponent(headsHash)}.am`;
+}
+
 export async function ensureCatalogSchema(env: Env): Promise<void> {
   if (!env.DB) {
     return;
@@ -480,6 +564,61 @@ export async function getNotebookRow(env: Env, notebookId: string): Promise<Note
     .first<NotebookRow>();
 }
 
+export async function getMarkdownDocumentRow(
+  env: Env,
+  documentId: string,
+): Promise<MarkdownDocumentRow | null> {
+  if (!env.DB) {
+    return null;
+  }
+
+  await ensureCatalogSchema(env);
+  return await env.DB.prepare(
+    `SELECT id,
+            owner_principal,
+            title,
+            body_doc_id,
+            created_at,
+            updated_at,
+            latest_revision_id
+       FROM markdown_documents
+       WHERE id = ?`,
+  )
+    .bind(documentId)
+    .first<MarkdownDocumentRow>();
+}
+
+export async function getPublicPublishedMarkdownDocumentRow(
+  env: Env,
+  documentId: string,
+): Promise<MarkdownDocumentRow | null> {
+  if (!env.DB) {
+    return null;
+  }
+
+  await ensureCatalogSchema(env);
+  return await env.DB.prepare(
+    `SELECT d.id,
+            d.owner_principal,
+            d.title,
+            d.body_doc_id,
+            d.created_at,
+            d.updated_at,
+            d.latest_revision_id
+       FROM markdown_documents d
+       JOIN markdown_document_acl a
+         ON a.document_id = d.id
+      WHERE d.id = ?
+        AND d.latest_revision_id IS NOT NULL
+        AND a.subject_kind = 'public'
+        AND a.subject = 'anonymous'
+        AND a.scope = 'viewer'
+      LIMIT 1`,
+  )
+    .bind(documentId)
+    .first<MarkdownDocumentRow>();
+}
+
 export async function getPublicPublishedNotebookRow(
   env: Env,
   notebookId: string,
@@ -535,6 +674,31 @@ export async function updateNotebookTitle(
   return await getNotebookRow(env, notebookId);
 }
 
+export async function updateMarkdownDocumentTitle(
+  env: Env,
+  documentId: string,
+  title: string | null,
+): Promise<MarkdownDocumentRow | null> {
+  if (!env.DB) {
+    return null;
+  }
+
+  await ensureCatalogSchema(env);
+  const updatedAt = new Date().toISOString();
+  const result = await env.DB.prepare(
+    `UPDATE markdown_documents
+        SET title = ?,
+            updated_at = ?
+      WHERE id = ?`,
+  )
+    .bind(title, updatedAt, documentId)
+    .run();
+  if (d1Changes(result) === 0) {
+    return null;
+  }
+  return await getMarkdownDocumentRow(env, documentId);
+}
+
 export async function getNotebookAclRowsForPrincipal(
   env: Env,
   notebookId: string,
@@ -568,6 +732,42 @@ export async function getNotebookAclRowsForPrincipal(
   )
     .bind(notebookId, principal, principal)
     .all<NotebookAclRow>();
+  return rows.results ?? [];
+}
+
+export async function getMarkdownDocumentAclRowsForPrincipal(
+  env: Env,
+  documentId: string,
+  principal: string,
+): Promise<MarkdownDocumentAclRow[]> {
+  if (!env.DB) {
+    return [];
+  }
+
+  await ensureCatalogSchema(env);
+  const rows = await env.DB.prepare(
+    `SELECT document_id,
+            subject_kind,
+            subject,
+            scope,
+            created_at,
+            updated_at,
+            created_by_actor_label
+       FROM markdown_document_acl
+       WHERE document_id = ?
+         AND subject_kind = 'principal'
+         AND (
+           subject = ?
+           OR subject IN (
+             SELECT canonical_principal
+               FROM principal_account_links
+              WHERE transport_principal = ?
+           )
+         )
+       ORDER BY scope`,
+  )
+    .bind(documentId, principal, principal)
+    .all<MarkdownDocumentAclRow>();
   return rows.results ?? [];
 }
 
@@ -628,6 +828,63 @@ export async function listNotebooksForPrincipal(
   return rows.results ?? [];
 }
 
+export async function listMarkdownDocumentsForPrincipal(
+  env: Env,
+  principal: string,
+  limit: number,
+): Promise<ListedMarkdownDocumentRow[]> {
+  if (!env.DB) {
+    return [];
+  }
+
+  await ensureCatalogSchema(env);
+  const rows = await env.DB.prepare(
+    `SELECT d.id,
+            d.owner_principal,
+            d.title,
+            d.body_doc_id,
+            d.created_at,
+            d.updated_at,
+            d.latest_revision_id,
+            CASE MAX(
+              CASE a.scope
+                WHEN 'owner' THEN 3
+                WHEN 'editor' THEN 2
+                WHEN 'viewer' THEN 1
+                ELSE 0
+              END
+            )
+              WHEN 3 THEN 'owner'
+              WHEN 2 THEN 'editor'
+              ELSE 'viewer'
+            END AS scope
+       FROM markdown_documents d
+       JOIN markdown_document_acl a
+         ON a.document_id = d.id
+      WHERE a.subject_kind = 'principal'
+        AND (
+          a.subject = ?
+          OR a.subject IN (
+            SELECT canonical_principal
+              FROM principal_account_links
+             WHERE transport_principal = ?
+          )
+        )
+      GROUP BY d.id,
+               d.owner_principal,
+               d.title,
+               d.body_doc_id,
+               d.created_at,
+               d.updated_at,
+               d.latest_revision_id
+      ORDER BY d.updated_at DESC, d.created_at DESC, d.id DESC
+      LIMIT ?`,
+  )
+    .bind(principal, principal, limit)
+    .all<ListedMarkdownDocumentRow>();
+  return rows.results ?? [];
+}
+
 export async function getPublicNotebookAclRows(
   env: Env,
   notebookId: string,
@@ -656,6 +913,34 @@ export async function getPublicNotebookAclRows(
   return rows.results ?? [];
 }
 
+export async function getPublicMarkdownDocumentAclRows(
+  env: Env,
+  documentId: string,
+): Promise<MarkdownDocumentAclRow[]> {
+  if (!env.DB) {
+    return [];
+  }
+
+  await ensureCatalogSchema(env);
+  const rows = await env.DB.prepare(
+    `SELECT document_id,
+            subject_kind,
+            subject,
+            scope,
+            created_at,
+            updated_at,
+            created_by_actor_label
+       FROM markdown_document_acl
+       WHERE document_id = ?
+         AND subject_kind = 'public'
+         AND subject = 'anonymous'
+       ORDER BY scope`,
+  )
+    .bind(documentId)
+    .all<MarkdownDocumentAclRow>();
+  return rows.results ?? [];
+}
+
 export async function getNotebookAclRows(env: Env, notebookId: string): Promise<NotebookAclRow[]> {
   if (!env.DB) {
     return [];
@@ -679,6 +964,32 @@ export async function getNotebookAclRows(env: Env, notebookId: string): Promise<
   return rows.results ?? [];
 }
 
+export async function getMarkdownDocumentAclRows(
+  env: Env,
+  documentId: string,
+): Promise<MarkdownDocumentAclRow[]> {
+  if (!env.DB) {
+    return [];
+  }
+
+  await ensureCatalogSchema(env);
+  const rows = await env.DB.prepare(
+    `SELECT document_id,
+            subject_kind,
+            subject,
+            scope,
+            created_at,
+            updated_at,
+            created_by_actor_label
+       FROM markdown_document_acl
+       WHERE document_id = ?
+       ORDER BY subject_kind, subject, scope`,
+  )
+    .bind(documentId)
+    .all<MarkdownDocumentAclRow>();
+  return rows.results ?? [];
+}
+
 export async function grantNotebookAclRow(env: Env, row: NotebookAclInput): Promise<void> {
   if (!env.DB) {
     return;
@@ -687,6 +998,25 @@ export async function grantNotebookAclRow(env: Env, row: NotebookAclInput): Prom
   await ensureCatalogSchema(env);
   await notebookAclInsert(env, {
     notebookId: row.notebookId,
+    subjectKind: row.subjectKind,
+    subject: row.subject,
+    scope: row.scope,
+    actorLabel: row.actorLabel,
+    timestamp: new Date().toISOString(),
+  }).run();
+}
+
+export async function grantMarkdownDocumentAclRow(
+  env: Env,
+  row: MarkdownDocumentAclInput,
+): Promise<void> {
+  if (!env.DB) {
+    return;
+  }
+
+  await ensureCatalogSchema(env);
+  await markdownDocumentAclInsert(env, {
+    documentId: row.documentId,
     subjectKind: row.subjectKind,
     subject: row.subject,
     scope: row.scope,
@@ -724,6 +1054,39 @@ export async function revokeNotebookAclRow(
          )`,
   )
     .bind(row.notebookId, row.subjectKind, row.subject, row.scope, row.notebookId, row.subject)
+    .run();
+  return d1Changes(result) > 0;
+}
+
+export async function revokeMarkdownDocumentAclRow(
+  env: Env,
+  row: Omit<MarkdownDocumentAclInput, "actorLabel">,
+): Promise<boolean> {
+  if (!env.DB) {
+    return false;
+  }
+
+  await ensureCatalogSchema(env);
+  const result = await env.DB.prepare(
+    `DELETE FROM markdown_document_acl
+       WHERE document_id = ?
+         AND subject_kind = ?
+         AND subject = ?
+         AND scope = ?
+         AND (
+           subject_kind != 'principal'
+           OR scope != 'owner'
+           OR (
+             SELECT COUNT(*)
+               FROM markdown_document_acl
+              WHERE document_id = ?
+                AND subject_kind = 'principal'
+                AND scope = 'owner'
+                AND subject != ?
+           ) > 0
+         )`,
+  )
+    .bind(row.documentId, row.subjectKind, row.subject, row.scope, row.documentId, row.subject)
     .run();
   return d1Changes(result) > 0;
 }
@@ -1198,6 +1561,11 @@ export interface CreateNotebookWithOwnerAclResult {
   created: boolean;
 }
 
+export interface CreateMarkdownDocumentWithOwnerAclResult {
+  ownerPrincipal: string;
+  created: boolean;
+}
+
 export async function createNotebookWithOwnerAcl(
   env: Env,
   notebookId: string,
@@ -1228,6 +1596,46 @@ export async function createNotebookWithOwnerAcl(
   return {
     ownerPrincipal: ownerSubject,
     created: d1Changes(notebookInsertResult) > 0,
+  };
+}
+
+export async function createMarkdownDocumentWithOwnerAcl(
+  env: Env,
+  documentId: string,
+  identity: AuthenticatedConnection,
+  options: { title?: string | null; bodyDocId?: string | null } = {},
+): Promise<CreateMarkdownDocumentWithOwnerAclResult> {
+  if (!env.DB) {
+    return { ownerPrincipal: identity.principal, created: true };
+  }
+
+  await ensureCatalogSchema(env);
+  const now = new Date().toISOString();
+  const ownerSubject =
+    (await getCanonicalPrincipalForTransport(env, identity.principal)) ?? identity.principal;
+  const bodyDocId = options.bodyDocId?.trim() || documentId;
+  const [documentInsertResult] = await env.DB.batch([
+    env.DB.prepare(
+      `INSERT INTO markdown_documents (
+         id,
+         owner_principal,
+         title,
+         body_doc_id,
+         created_at,
+         updated_at
+       ) VALUES (?, ?, ?, ?, ?, ?)
+       ON CONFLICT(id) DO NOTHING`,
+    ).bind(documentId, ownerSubject, options.title ?? null, bodyDocId, now, now),
+    markdownDocumentOwnerAclInsert(env, {
+      documentId,
+      subject: ownerSubject,
+      actorLabel: identity.actorLabel,
+      timestamp: now,
+    }),
+  ]);
+  return {
+    ownerPrincipal: ownerSubject,
+    created: d1Changes(documentInsertResult) > 0,
   };
 }
 
@@ -1366,6 +1774,83 @@ export function copyNotebookAclForPrincipalStatement(
        updated_at = excluded.updated_at`,
     )
     .bind(input.targetPrincipal, input.timestamp, input.sourcePrincipal);
+}
+
+function markdownDocumentAclInsert(
+  env: Env,
+  row: {
+    documentId: string;
+    subjectKind: MarkdownDocumentAclRow["subject_kind"];
+    subject: string;
+    scope: MarkdownDocumentAclRow["scope"];
+    actorLabel: string;
+    timestamp: string;
+  },
+): D1PreparedStatement {
+  return env
+    .DB!.prepare(
+      `INSERT INTO markdown_document_acl (
+       document_id,
+       subject_kind,
+       subject,
+       scope,
+       created_at,
+       updated_at,
+       created_by_actor_label
+     ) VALUES (?, ?, ?, ?, ?, ?, ?)
+     ON CONFLICT(document_id, subject_kind, subject, scope) DO UPDATE SET
+       updated_at = excluded.updated_at`,
+    )
+    .bind(
+      row.documentId,
+      row.subjectKind,
+      row.subject,
+      row.scope,
+      row.timestamp,
+      row.timestamp,
+      row.actorLabel,
+    );
+}
+
+function markdownDocumentOwnerAclInsert(
+  env: Env,
+  row: {
+    documentId: string;
+    subject: string;
+    actorLabel: string;
+    timestamp: string;
+  },
+): D1PreparedStatement {
+  return env
+    .DB!.prepare(
+      `INSERT INTO markdown_document_acl (
+       document_id,
+       subject_kind,
+       subject,
+       scope,
+       created_at,
+       updated_at,
+       created_by_actor_label
+     )
+     SELECT ?, 'principal', ?, 'owner', ?, ?, ?
+      WHERE EXISTS (
+        SELECT 1
+          FROM markdown_documents
+         WHERE id = ?
+           AND owner_principal = ?
+      )
+     ON CONFLICT(document_id, subject_kind, subject, scope) DO UPDATE SET
+       updated_at = excluded.updated_at`,
+    )
+    .bind(
+      row.documentId,
+      row.subject,
+      row.timestamp,
+      row.timestamp,
+      row.actorLabel,
+      row.documentId,
+      row.subject,
+    );
 }
 
 function notebookAclInsert(
@@ -1514,6 +1999,60 @@ export async function recordRevision(
   return revisionId;
 }
 
+export async function recordMarkdownDocumentRevision(
+  env: Env,
+  revision: {
+    documentId: string;
+    bodyHeadsHash: string;
+    snapshotKey: string;
+    actorLabel: string;
+    publishPublic?: boolean;
+  },
+): Promise<string> {
+  if (!env.DB) {
+    return crypto.randomUUID();
+  }
+
+  await ensureCatalogSchema(env);
+  const revisionId = crypto.randomUUID();
+  const createdAt = new Date().toISOString();
+  await env.DB.batch([
+    env.DB.prepare(
+      `INSERT INTO markdown_document_revisions (
+       id,
+       document_id,
+       body_heads_hash,
+       snapshot_key,
+       actor_label
+     ) VALUES (?, ?, ?, ?, ?)`,
+    ).bind(
+      revisionId,
+      revision.documentId,
+      revision.bodyHeadsHash,
+      revision.snapshotKey,
+      revision.actorLabel,
+    ),
+    env.DB.prepare(
+      `UPDATE markdown_documents
+       SET latest_revision_id = ?, updated_at = ?
+       WHERE id = ?`,
+    ).bind(revisionId, createdAt, revision.documentId),
+    ...(revision.publishPublic
+      ? [
+          markdownDocumentAclInsert(env, {
+            documentId: revision.documentId,
+            subjectKind: "public",
+            subject: "anonymous",
+            scope: "viewer",
+            actorLabel: revision.actorLabel,
+            timestamp: createdAt,
+          }),
+        ]
+      : []),
+  ]);
+  return revisionId;
+}
+
 export async function recordBlob(
   env: Env,
   blob: {
@@ -1600,6 +2139,41 @@ export async function getNotebookCatalog(
     notebook,
     revisions: revisions.results ?? [],
     blobs: blobs.results ?? [],
+  };
+}
+
+export async function getMarkdownDocumentCatalog(
+  env: Env,
+  documentId: string,
+): Promise<MarkdownDocumentCatalog | null> {
+  if (!env.DB) {
+    return null;
+  }
+
+  await ensureCatalogSchema(env);
+  const document = await getMarkdownDocumentRow(env, documentId);
+  if (!document) {
+    return null;
+  }
+
+  const revisions = await env.DB.prepare(
+    `SELECT id,
+            document_id,
+            body_heads_hash,
+            snapshot_key,
+            actor_label,
+            created_at
+       FROM markdown_document_revisions
+       WHERE document_id = ?
+       ORDER BY created_at DESC
+       LIMIT 50`,
+  )
+    .bind(documentId)
+    .all<MarkdownDocumentRevisionRow>();
+
+  return {
+    document,
+    revisions: revisions.results ?? [],
   };
 }
 

--- a/apps/notebook-cloud/src/storage.ts
+++ b/apps/notebook-cloud/src/storage.ts
@@ -110,6 +110,7 @@ export interface NotebookAclInput {
 }
 
 export type NotebookAccessRequestStatus = "pending" | "approved" | "denied" | "dismissed";
+export type MarkdownDocumentAccessRequestStatus = NotebookAccessRequestStatus;
 
 export interface NotebookAccessRequestRow {
   id: string;
@@ -117,6 +118,19 @@ export interface NotebookAccessRequestRow {
   requester_principal: string;
   scope: "editor";
   status: NotebookAccessRequestStatus;
+  requested_by_actor_label: string;
+  resolved_by_actor_label: string | null;
+  created_at: string;
+  updated_at: string;
+  resolved_at: string | null;
+}
+
+export interface MarkdownDocumentAccessRequestRow {
+  id: string;
+  document_id: string;
+  requester_principal: string;
+  scope: "editor";
+  status: MarkdownDocumentAccessRequestStatus;
   requested_by_actor_label: string;
   resolved_by_actor_label: string | null;
   created_at: string;
@@ -257,6 +271,53 @@ const SCHEMA_STATEMENTS = [
   )`,
   `CREATE INDEX IF NOT EXISTS markdown_document_acl_subject_idx
     ON markdown_document_acl (subject_kind, subject, document_id)`,
+  `CREATE TABLE IF NOT EXISTS markdown_document_invites (
+    id TEXT PRIMARY KEY,
+    document_id TEXT NOT NULL,
+    email_normalized TEXT NOT NULL,
+    provider_hint TEXT,
+    scope TEXT NOT NULL CHECK (scope IN ('viewer', 'editor')),
+    status TEXT NOT NULL CHECK (status IN ('pending', 'accepted', 'revoked', 'expired')),
+    invited_by_actor_label TEXT NOT NULL,
+    accepted_by_principal TEXT,
+    token_hash TEXT,
+    created_at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ', 'now')),
+    expires_at TEXT,
+    accepted_at TEXT,
+    revoked_at TEXT,
+    revoked_by_actor_label TEXT,
+    FOREIGN KEY (document_id) REFERENCES markdown_documents(id)
+  )`,
+  `CREATE INDEX IF NOT EXISTS markdown_document_invites_pending_lookup_idx
+    ON markdown_document_invites(email_normalized, status, provider_hint)`,
+  `CREATE UNIQUE INDEX IF NOT EXISTS markdown_document_invites_pending_provider_unique_idx
+    ON markdown_document_invites(document_id, email_normalized, provider_hint, scope)
+    WHERE status = 'pending' AND provider_hint IS NOT NULL`,
+  `CREATE UNIQUE INDEX IF NOT EXISTS markdown_document_invites_pending_wildcard_unique_idx
+    ON markdown_document_invites(document_id, email_normalized, scope)
+    WHERE status = 'pending' AND provider_hint IS NULL`,
+  `CREATE INDEX IF NOT EXISTS markdown_document_invites_document_idx
+    ON markdown_document_invites(document_id, status)`,
+  `CREATE TABLE IF NOT EXISTS markdown_document_access_requests (
+    id TEXT PRIMARY KEY,
+    document_id TEXT NOT NULL,
+    requester_principal TEXT NOT NULL,
+    scope TEXT NOT NULL CHECK (scope IN ('editor')),
+    status TEXT NOT NULL CHECK (status IN ('pending', 'approved', 'denied', 'dismissed')),
+    requested_by_actor_label TEXT NOT NULL,
+    resolved_by_actor_label TEXT,
+    created_at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ', 'now')),
+    updated_at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ', 'now')),
+    resolved_at TEXT,
+    FOREIGN KEY (document_id) REFERENCES markdown_documents(id)
+  )`,
+  `CREATE UNIQUE INDEX IF NOT EXISTS markdown_document_access_requests_pending_unique_idx
+    ON markdown_document_access_requests(document_id, requester_principal, scope)
+    WHERE status = 'pending'`,
+  `CREATE INDEX IF NOT EXISTS markdown_document_access_requests_document_idx
+    ON markdown_document_access_requests(document_id, status, created_at)`,
+  `CREATE INDEX IF NOT EXISTS markdown_document_access_requests_requester_idx
+    ON markdown_document_access_requests(requester_principal, document_id, created_at)`,
   `CREATE TABLE IF NOT EXISTS notebook_acl (
     notebook_id TEXT NOT NULL,
     subject_kind TEXT NOT NULL CHECK (subject_kind IN ('principal', 'public')),

--- a/apps/notebook-cloud/test/app-session-client.test.ts
+++ b/apps/notebook-cloud/test/app-session-client.test.ts
@@ -17,14 +17,14 @@ describe("cloud app session client", () => {
         assert.deepEqual(init?.headers, { Accept: "application/json" });
         return Response.json({
           ok: true,
-          session: { provider: "oidc", expires_at: 1_800 },
+          session: { provider: "oidc", expires_at: 1_800, cache_key: "cache-a" },
         });
       },
     });
 
     assert.deepEqual(status, {
       ok: true,
-      session: { provider: "oidc", expires_at: 1_800 },
+      session: { provider: "oidc", expires_at: 1_800, cache_key: "cache-a" },
     });
   });
 
@@ -37,17 +37,32 @@ describe("cloud app session client", () => {
   });
 
   it("checks app session freshness with the same renewal skew as the viewer", () => {
-    assert.equal(cloudAppSessionIsFresh({ provider: "oidc", expires_at: 1_300 }, 1_000), true);
-    assert.equal(cloudAppSessionIsFresh({ provider: "oidc", expires_at: 1_060 }, 1_000), false);
+    assert.equal(
+      cloudAppSessionIsFresh({ provider: "oidc", expires_at: 1_300, cache_key: "cache-a" }, 1_000),
+      true,
+    );
+    assert.equal(
+      cloudAppSessionIsFresh({ provider: "oidc", expires_at: 1_060, cache_key: "cache-a" }, 1_000),
+      false,
+    );
     assert.equal(cloudAppSessionIsFresh(null, 1_000), false);
   });
 
   it("renews app sessions before the browser cookie expires", () => {
     assert.equal(
-      cloudAppSessionNeedsRenewal({ provider: "oidc", expires_at: 3_000 }, 1_000),
+      cloudAppSessionNeedsRenewal(
+        { provider: "oidc", expires_at: 3_000, cache_key: "cache-a" },
+        1_000,
+      ),
       false,
     );
-    assert.equal(cloudAppSessionNeedsRenewal({ provider: "oidc", expires_at: 2_700 }, 1_000), true);
+    assert.equal(
+      cloudAppSessionNeedsRenewal(
+        { provider: "oidc", expires_at: 2_700, cache_key: "cache-a" },
+        1_000,
+      ),
+      true,
+    );
     assert.equal(cloudAppSessionNeedsRenewal(null, 1_000), true);
   });
 
@@ -58,6 +73,7 @@ describe("cloud app session client", () => {
         session: {
           provider: "oidc",
           expires_at: 1_800,
+          cache_key: "cache-a",
           email: "private@example.test",
         },
       }),
@@ -69,6 +85,7 @@ describe("cloud app session client", () => {
         session: {
           provider: "oidc",
           expires_at: 1_800,
+          cache_key: "cache-a",
           display_name: "Private User",
         },
       }),
@@ -80,7 +97,8 @@ describe("cloud app session client", () => {
     await assert.rejects(
       () =>
         readCloudAppSessionStatus({
-          fetchImpl: async () => Response.json({ ok: true, session: { provider: "oidc" } }),
+          fetchImpl: async () =>
+            Response.json({ ok: true, session: { provider: "oidc", expires_at: 1_800 } }),
         }),
       /response shape was invalid/,
     );

--- a/apps/notebook-cloud/test/app-session.test.ts
+++ b/apps/notebook-cloud/test/app-session.test.ts
@@ -45,14 +45,16 @@ describe("cloud app session cookies", () => {
       2_100,
     );
 
-    assert.deepEqual(session, {
-      provider: "oidc",
-      principal: "user:anaconda:subject-a",
-      principalNamespace: "user:anaconda",
-      issuedAt: 2_000,
-      expiresAt: 2_000 + NOTEBOOK_CLOUD_APP_SESSION_MAX_AGE_SECONDS,
-      displayName: "OIDC User",
-    });
+    assert.ok(session);
+    assert.equal(session.provider, "oidc");
+    assert.equal(session.principal, "user:anaconda:subject-a");
+    assert.equal(session.principalNamespace, "user:anaconda");
+    assert.equal(session.issuedAt, 2_000);
+    assert.equal(session.expiresAt, 2_000 + NOTEBOOK_CLOUD_APP_SESSION_MAX_AGE_SECONDS);
+    assert.equal(session.displayName, "OIDC User");
+    assert.equal(typeof session.cacheKey, "string");
+    assert.ok(session.cacheKey.length > 20);
+    assert.doesNotMatch(session.cacheKey, /subject-a|anaconda|user@example\.test|OIDC User/);
   });
 
   it("caps the display name signed into the cookie", async () => {

--- a/apps/notebook-cloud/test/cloud-access-request-state.test.ts
+++ b/apps/notebook-cloud/test/cloud-access-request-state.test.ts
@@ -184,6 +184,23 @@ describe("cloud access-request state projection", () => {
     );
   });
 
+  it("can project edit-request copy for non-notebook hosted documents", () => {
+    assert.deepEqual(
+      projectCloudAccessRequestNotice({
+        documentLabel: "document",
+        error: null,
+        request: { status: "denied" },
+        selectedMode: "edit",
+      }),
+      {
+        kind: "denied",
+        tone: "warning",
+        title: "Edit request denied.",
+        message: "The document stays in view mode.",
+      },
+    );
+  });
+
   it("loads own edit-request state only for explicit editable viewer intent", () => {
     assert.equal(
       shouldLoadOwnCloudAccessRequest({

--- a/apps/notebook-cloud/test/cloud-access-request-state.test.ts
+++ b/apps/notebook-cloud/test/cloud-access-request-state.test.ts
@@ -6,6 +6,7 @@ import {
   projectCloudAccessRequestTransition,
   shouldFallbackCloudEditUrlToView,
   shouldLoadOwnCloudAccessRequest,
+  shouldUseCloudCatalogBootstrap,
 } from "../viewer/cloud-access-request-state";
 import type { CloudPrototypeAuthState } from "../viewer/collaborator-auth";
 
@@ -305,5 +306,10 @@ describe("cloud access-request state projection", () => {
       }),
       false,
     );
+  });
+
+  it("uses route bootstrap only before deliberate access refreshes", () => {
+    assert.equal(shouldUseCloudCatalogBootstrap({ catalogRefreshVersion: 0 }), true);
+    assert.equal(shouldUseCloudCatalogBootstrap({ catalogRefreshVersion: 1 }), false);
   });
 });

--- a/apps/notebook-cloud/test/cloud-notebook-mode.test.ts
+++ b/apps/notebook-cloud/test/cloud-notebook-mode.test.ts
@@ -1,8 +1,10 @@
 import assert from "node:assert/strict";
 import { test } from "node:test";
 import {
+  cloudNotebookModeFromSearch,
   cloudNotebookInteractionModeForAccess,
   cloudNotebookSelectedModeCorrectionForAccess,
+  cloudNotebookUrlWithMode,
 } from "../viewer/cloud-notebook-mode";
 
 test("cloud notebook edit links stay view-only for viewers without an access request", () => {
@@ -140,5 +142,21 @@ test("cloud notebook mode correction normalizes owner edit links for view-only a
       selectedMode: "view",
     }),
     null,
+  );
+});
+
+test("cloud document mode helpers default to view and preserve route URLs", () => {
+  assert.equal(cloudNotebookModeFromSearch(""), "view");
+  assert.equal(cloudNotebookModeFromSearch("?mode=view"), "view");
+  assert.equal(cloudNotebookModeFromSearch("?mode=edit"), "edit");
+  assert.equal(cloudNotebookModeFromSearch("?mode=source"), "view");
+
+  assert.equal(
+    cloudNotebookUrlWithMode("/m/doc-title/Title?mode=view#intro", "edit"),
+    "/m/doc-title/Title?mode=edit#intro",
+  );
+  assert.equal(
+    cloudNotebookUrlWithMode("https://preview.runt.run/m/doc-title/Title#intro", "view"),
+    "https://preview.runt.run/m/doc-title/Title?mode=view#intro",
   );
 });

--- a/apps/notebook-cloud/test/cloud-notebook-title-state.test.ts
+++ b/apps/notebook-cloud/test/cloud-notebook-title-state.test.ts
@@ -2,6 +2,7 @@ import assert from "node:assert/strict";
 import { describe, it } from "node:test";
 import {
   cloudNotebookCatalogResponseTitle,
+  cloudDocumentUrlAfterRename,
   cloudNotebookDocumentTitle,
   cloudNotebookRouteTitleFromPathname,
   cloudNotebookTitleDisplay,
@@ -87,6 +88,17 @@ describe("cloud notebook title state", () => {
         "https://worker.example/n/abc/New%20Title",
       ),
       "https://preview.runt.run/n/abc/New%20Title?mode=edit#intro",
+    );
+  });
+
+  it("updates Markdown vanity paths with the shared document rename helper", () => {
+    assert.equal(
+      cloudDocumentUrlAfterRename({
+        currentHref: "https://preview.runt.run/m/abc/old-title?mode=edit#intro",
+        routePrefix: "/m",
+        viewerUrl: "https://worker.example/m/abc/New%20Title",
+      }),
+      "https://preview.runt.run/m/abc/New%20Title?mode=edit#intro",
     );
   });
 

--- a/apps/notebook-cloud/test/hosted-document-app-shell-parity.test.ts
+++ b/apps/notebook-cloud/test/hosted-document-app-shell-parity.test.ts
@@ -44,6 +44,12 @@ describe("hosted document app-shell parity", () => {
     assert.doesNotMatch(markdownListSource, /Search notebooks/);
     assert.doesNotMatch(markdownListSource, /recent work/i);
   });
+
+  it("keeps Markdown sharing copy active instead of publish-version oriented", () => {
+    assert.match(markdownListSource, /Draft, review, and share Markdown without compute\./);
+    assert.doesNotMatch(markdownListSource, /publish Markdown/i);
+    assert.doesNotMatch(markdownListSource, /public version/i);
+  });
 });
 
 function readViewerModule(name: string): string {

--- a/apps/notebook-cloud/test/hosted-document-app-shell-parity.test.ts
+++ b/apps/notebook-cloud/test/hosted-document-app-shell-parity.test.ts
@@ -1,0 +1,51 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { describe, it } from "node:test";
+
+const notebookListSource = readViewerModule("notebook-list-view.tsx");
+const markdownListSource = readViewerModule("markdown-document-list-view.tsx");
+
+describe("hosted document app-shell parity", () => {
+  it("uses the shared auth projection for notebook and Markdown catalog authority", () => {
+    for (const sourceText of [notebookListSource, markdownListSource]) {
+      assert.match(sourceText, /import \{ projectHostedDocumentAuthState \}/);
+      assert.match(sourceText, /const hostedAuth = projectHostedDocumentAuthState\(authState, \{/);
+      assert.match(sourceText, /canFetchCatalog: canFetch/);
+      assert.match(sourceText, /\bsignedIn,/);
+      assert.match(sourceText, /\bwaitingForAppSession,/);
+    }
+  });
+
+  it("keeps dashboard shell, create, and state primitives shared", () => {
+    for (const sourceText of [notebookListSource, markdownListSource]) {
+      assert.match(sourceText, /className="cloud-notebook-list-page/);
+      assert.match(sourceText, /className="cloud-notebook-list-header"/);
+      assert.match(sourceText, /className="cloud-notebook-list-actions"/);
+      assert.match(sourceText, /className="cloud-new-notebook-form"/);
+      assert.match(sourceText, /className="cloud-notebook-list-content/);
+      assert.match(sourceText, /className="cloud-notebook-list-state" data-kind="loading"/);
+      assert.match(sourceText, /className="cloud-notebook-list-state" data-kind="error"/);
+      assert.match(sourceText, /className="cloud-notebook-list-state" data-kind="empty"/);
+    }
+  });
+
+  it("uses the shared signed-out panel with route-specific copy", () => {
+    assert.match(notebookListSource, /<CloudHostedDocumentSignedOutPanel/);
+    assert.match(markdownListSource, /<CloudHostedDocumentSignedOutPanel/);
+    assert.match(notebookListSource, /cloudTitle="Bring computation to life\."/);
+    assert.match(markdownListSource, /cloudTitle="Write live Markdown\."/);
+    assert.match(notebookListSource, /localTitle="Open local notebooks\."/);
+    assert.match(markdownListSource, /localTitle="Open local Markdown\."/);
+  });
+
+  it("does not force notebook-specific dashboard features onto Markdown documents", () => {
+    assert.match(notebookListSource, /<CloudNotebookDashboard/);
+    assert.doesNotMatch(markdownListSource, /<CloudNotebookDashboard/);
+    assert.doesNotMatch(markdownListSource, /Search notebooks/);
+    assert.doesNotMatch(markdownListSource, /recent work/i);
+  });
+});
+
+function readViewerModule(name: string): string {
+  return readFileSync(new URL(`../viewer/${name}`, import.meta.url), "utf8");
+}

--- a/apps/notebook-cloud/test/hosted-document-app-shell-parity.test.ts
+++ b/apps/notebook-cloud/test/hosted-document-app-shell-parity.test.ts
@@ -55,6 +55,7 @@ describe("hosted document app-shell parity", () => {
   it("routes Markdown edit requests through the shared cloud edit chrome", () => {
     assert.match(markdownDocumentRouteSource, /CloudNotebookEditModeButton/);
     assert.match(markdownDocumentRouteSource, /shouldLoadOwnCloudAccessRequest/);
+    assert.match(markdownDocumentRouteSource, /shouldUseCloudCatalogBootstrap/);
     assert.match(markdownDocumentRouteSource, /projectCloudAccessRequestNotice/);
     assert.match(markdownDocumentRouteSource, /onRequestEditAccess=\{requestMarkdownEditAccess\}/);
     assert.doesNotMatch(markdownDocumentRouteSource, /<MarkdownDocumentModeToggle/);

--- a/apps/notebook-cloud/test/hosted-document-app-shell-parity.test.ts
+++ b/apps/notebook-cloud/test/hosted-document-app-shell-parity.test.ts
@@ -62,16 +62,20 @@ describe("hosted document app-shell parity", () => {
     assert.doesNotMatch(markdownDocumentRouteSource, /<MarkdownDocumentModeToggle/);
   });
 
-  it("keeps dashboard profile sync off the first HTML response path", () => {
-    assert.match(workerSource, /function scheduleStoredAppSessionProfileSync/);
-    assert.match(workerSource, /ctx\.waitUntil\(syncStoredAppSessionProfile\(env, session\)\)/);
+  it("keeps repeated dashboard profile sync cheap when there are no pending invites", () => {
+    assert.match(workerSource, /getPendingNotebookInvitesForLogin\(env, loginProfile\)/);
+    assert.match(workerSource, /getPendingMarkdownDocumentInvitesForLogin\(env, loginProfile\)/);
     assert.match(
       workerSource,
-      /async function notebookListBootstrap\([\s\S]*scheduleStoredAppSessionProfileSync\(env, ctx, session\);[\s\S]*listNotebooksForPrincipal/,
+      /if \(pendingNotebookInvites\.length === 0 && pendingMarkdownDocumentInvites\.length === 0\) \{[\s\S]*return;[\s\S]*\}/,
     );
     assert.match(
       workerSource,
-      /async function markdownDocumentListBootstrap\([\s\S]*scheduleStoredAppSessionProfileSync\(env, ctx, session\);[\s\S]*listMarkdownDocumentsForPrincipal/,
+      /pendingNotebookInvites\.length > 0[\s\S]*resolveNotebookInvitesForLogin\(env, loginProfile\)/,
+    );
+    assert.match(
+      workerSource,
+      /pendingMarkdownDocumentInvites\.length > 0[\s\S]*resolveMarkdownDocumentInvitesForLogin\(env, loginProfile\)/,
     );
   });
 });

--- a/apps/notebook-cloud/test/hosted-document-app-shell-parity.test.ts
+++ b/apps/notebook-cloud/test/hosted-document-app-shell-parity.test.ts
@@ -5,6 +5,7 @@ import { describe, it } from "node:test";
 const notebookListSource = readViewerModule("notebook-list-view.tsx");
 const markdownListSource = readViewerModule("markdown-document-list-view.tsx");
 const markdownDocumentRouteSource = readViewerModule("markdown-document-route.tsx");
+const workerSource = readFileSync(new URL("../src/index.ts", import.meta.url), "utf8");
 
 describe("hosted document app-shell parity", () => {
   it("uses the shared auth projection for notebook and Markdown catalog authority", () => {
@@ -59,6 +60,19 @@ describe("hosted document app-shell parity", () => {
     assert.match(markdownDocumentRouteSource, /projectCloudAccessRequestNotice/);
     assert.match(markdownDocumentRouteSource, /onRequestEditAccess=\{requestMarkdownEditAccess\}/);
     assert.doesNotMatch(markdownDocumentRouteSource, /<MarkdownDocumentModeToggle/);
+  });
+
+  it("keeps dashboard profile sync off the first HTML response path", () => {
+    assert.match(workerSource, /function scheduleStoredAppSessionProfileSync/);
+    assert.match(workerSource, /ctx\.waitUntil\(syncStoredAppSessionProfile\(env, session\)\)/);
+    assert.match(
+      workerSource,
+      /async function notebookListBootstrap\([\s\S]*scheduleStoredAppSessionProfileSync\(env, ctx, session\);[\s\S]*listNotebooksForPrincipal/,
+    );
+    assert.match(
+      workerSource,
+      /async function markdownDocumentListBootstrap\([\s\S]*scheduleStoredAppSessionProfileSync\(env, ctx, session\);[\s\S]*listMarkdownDocumentsForPrincipal/,
+    );
   });
 });
 

--- a/apps/notebook-cloud/test/hosted-document-app-shell-parity.test.ts
+++ b/apps/notebook-cloud/test/hosted-document-app-shell-parity.test.ts
@@ -4,6 +4,7 @@ import { describe, it } from "node:test";
 
 const notebookListSource = readViewerModule("notebook-list-view.tsx");
 const markdownListSource = readViewerModule("markdown-document-list-view.tsx");
+const markdownDocumentRouteSource = readViewerModule("markdown-document-route.tsx");
 
 describe("hosted document app-shell parity", () => {
   it("uses the shared auth projection for notebook and Markdown catalog authority", () => {
@@ -49,6 +50,14 @@ describe("hosted document app-shell parity", () => {
     assert.match(markdownListSource, /Draft, review, and share Markdown without compute\./);
     assert.doesNotMatch(markdownListSource, /publish Markdown/i);
     assert.doesNotMatch(markdownListSource, /public version/i);
+  });
+
+  it("routes Markdown edit requests through the shared cloud edit chrome", () => {
+    assert.match(markdownDocumentRouteSource, /CloudNotebookEditModeButton/);
+    assert.match(markdownDocumentRouteSource, /shouldLoadOwnCloudAccessRequest/);
+    assert.match(markdownDocumentRouteSource, /projectCloudAccessRequestNotice/);
+    assert.match(markdownDocumentRouteSource, /onRequestEditAccess=\{requestMarkdownEditAccess\}/);
+    assert.doesNotMatch(markdownDocumentRouteSource, /<MarkdownDocumentModeToggle/);
   });
 });
 

--- a/apps/notebook-cloud/test/hosted-document-auth.test.ts
+++ b/apps/notebook-cloud/test/hosted-document-auth.test.ts
@@ -1,0 +1,71 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+import { projectHostedDocumentAuthState } from "../viewer/hosted-document-auth.ts";
+import type { CloudPrototypeAuthState } from "../viewer/collaborator-auth.ts";
+
+describe("hosted document auth projection", () => {
+  it("lets app-session cookies drive catalog access when localStorage auth is stale", () => {
+    const projection = projectHostedDocumentAuthState(authState("oidc_expired"), {
+      appSession: { provider: "oidc", expires_at: 4_102_444_800 },
+    });
+
+    assert.equal(projection.hasAppSession, true);
+    assert.equal(projection.signedIn, true);
+    assert.equal(projection.canFetchCatalog, true);
+    assert.equal(projection.waitingForAppSession, false);
+    assert.equal(projection.showSignIn, false);
+  });
+
+  it("suppresses signed-out chrome while checking for an app-session cookie", () => {
+    const projection = projectHostedDocumentAuthState(authState("anonymous"), {
+      appSessionLoading: true,
+    });
+
+    assert.equal(projection.signedIn, false);
+    assert.equal(projection.canFetchCatalog, false);
+    assert.equal(projection.waitingForAppSession, true);
+    assert.equal(projection.showSignIn, false);
+  });
+
+  it("waits for the browser app session before using OIDC-backed catalog APIs", () => {
+    const projection = projectHostedDocumentAuthState(authState("oidc", { token: "token" }));
+
+    assert.equal(projection.signedIn, true);
+    assert.equal(projection.canFetchCatalog, false);
+    assert.equal(projection.waitingForAppSession, true);
+    assert.equal(projection.showSignIn, false);
+  });
+
+  it("keeps local dev auth as an immediate catalog authority", () => {
+    const projection = projectHostedDocumentAuthState(authState("dev"));
+
+    assert.equal(projection.signedIn, true);
+    assert.equal(projection.canFetchCatalog, true);
+    assert.equal(projection.waitingForAppSession, false);
+    assert.equal(projection.showSignIn, false);
+  });
+
+  it("surfaces sign-in only after the anonymous session check resolves empty", () => {
+    const projection = projectHostedDocumentAuthState(authState("anonymous"));
+
+    assert.equal(projection.signedIn, false);
+    assert.equal(projection.canFetchCatalog, false);
+    assert.equal(projection.waitingForAppSession, false);
+    assert.equal(projection.showSignIn, true);
+  });
+});
+
+function authState(
+  mode: CloudPrototypeAuthState["mode"],
+  overrides: Partial<CloudPrototypeAuthState> = {},
+): CloudPrototypeAuthState {
+  return {
+    mode,
+    token: null,
+    user: null,
+    oidcClaims: null,
+    requestedScope: null,
+    problem: null,
+    ...overrides,
+  };
+}

--- a/apps/notebook-cloud/test/hosted-document-auth.test.ts
+++ b/apps/notebook-cloud/test/hosted-document-auth.test.ts
@@ -6,7 +6,7 @@ import type { CloudPrototypeAuthState } from "../viewer/collaborator-auth.ts";
 describe("hosted document auth projection", () => {
   it("lets app-session cookies drive catalog access when localStorage auth is stale", () => {
     const projection = projectHostedDocumentAuthState(authState("oidc_expired"), {
-      appSession: { provider: "oidc", expires_at: 4_102_444_800 },
+      appSession: { provider: "oidc", expires_at: 4_102_444_800, cache_key: "cache-a" },
     });
 
     assert.equal(projection.hasAppSession, true);

--- a/apps/notebook-cloud/test/html.test.ts
+++ b/apps/notebook-cloud/test/html.test.ts
@@ -390,10 +390,10 @@ describe("HTML script serialization", () => {
     assert.match(html, /"documentId":"doc-123"/);
     assert.match(html, /"catalogEndpoint":"\/api\/m\/doc-123"/);
     assert.match(html, /"snapshotBasePath":"\/api\/m\/doc-123\/snapshots\/"/);
+    assert.match(html, /"syncEndpoint":"\/m\/doc-123\/sync"/);
     assert.match(html, /"runtimedWasmModulePath":"\/assets\/runtimed_wasm\.js"/);
     assert.match(html, /"runtimedWasmPath":"\/assets\/runtimed_wasm_bg\.wasm"/);
     assert.doesNotMatch(html, /"notebookId"/);
-    assert.doesNotMatch(html, /"syncEndpoint"/);
     assert.doesNotMatch(html, /"workstationAttachEndpoint"/);
   });
 

--- a/apps/notebook-cloud/test/html.test.ts
+++ b/apps/notebook-cloud/test/html.test.ts
@@ -360,6 +360,43 @@ describe("HTML script serialization", () => {
     );
   });
 
+  it("serves the Markdown document list shell without notebook route config", async () => {
+    const response = await worker.fetch(
+      new Request("https://cloud.test/m"),
+      fakeEnv(),
+      fakeContext(),
+    );
+    const html = await response.text();
+
+    assert.equal(response.status, 200);
+    assert.match(html, /<title>nteract Markdown documents<\/title>/);
+    assert.match(html, /id="nteract-cloud-auth-config"/);
+    assert.doesNotMatch(html, /id="nteract-cloud-viewer-config"/);
+    assert.doesNotMatch(html, /notebookRoute/);
+    assert.doesNotMatch(html, /"notebookId"/);
+  });
+
+  it("serves Markdown document viewers with Markdown config, not notebook config", async () => {
+    const response = await worker.fetch(
+      new Request("https://cloud.test/m/doc-123/Research%20Plan"),
+      fakeEnv(),
+      fakeContext(),
+    );
+    const html = await response.text();
+
+    assert.equal(response.status, 200);
+    assert.match(html, /<title>nteract Markdown: Research Plan<\/title>/);
+    assert.match(html, /"documentKind":"markdown"/);
+    assert.match(html, /"documentId":"doc-123"/);
+    assert.match(html, /"catalogEndpoint":"\/api\/m\/doc-123"/);
+    assert.match(html, /"snapshotBasePath":"\/api\/m\/doc-123\/snapshots\/"/);
+    assert.match(html, /"runtimedWasmModulePath":"\/assets\/runtimed_wasm\.js"/);
+    assert.match(html, /"runtimedWasmPath":"\/assets\/runtimed_wasm_bg\.wasm"/);
+    assert.doesNotMatch(html, /"notebookId"/);
+    assert.doesNotMatch(html, /"syncEndpoint"/);
+    assert.doesNotMatch(html, /"workstationAttachEndpoint"/);
+  });
+
   it("does not serve legacy one-segment notebook viewer URLs", async () => {
     const response = await worker.fetch(
       new Request("https://cloud.test/n/demo"),

--- a/apps/notebook-cloud/test/html.test.ts
+++ b/apps/notebook-cloud/test/html.test.ts
@@ -380,14 +380,14 @@ describe("HTML script serialization", () => {
       fakeEnv({
         ASSETS: fakeViewerAssetManifests(
           {
-            notebookRoute: {
+            markdownDocumentRoute: {
               modulepreload: [
-                "notebook-route.0123456789abcdef.js",
+                "markdown-document-route.0123456789abcdef.js",
+                "markdown-projection.0123456789abcdef.js",
                 "MarkdownText.0123456789abcdef.js",
-                "markdown.0123456789abcdef.js",
                 "katex.min.0123456789abcdef.js",
               ],
-              stylepreload: ["notebook-route.0123456789abcdef.css", "katex.0123456789abcdef.css"],
+              stylepreload: ["katex.0123456789abcdef.css"],
             },
           },
           seenPaths,
@@ -398,14 +398,22 @@ describe("HTML script serialization", () => {
     const html = await response.text();
 
     assert.equal(response.status, 200);
-    assert.ok(seenPaths.includes("/assets/notebook-route-assets.json"));
+    assert.ok(seenPaths.includes("/assets/markdown-document-route-assets.json"));
+    assert.ok(!seenPaths.includes("/assets/notebook-route-assets.json"));
     assert.match(html, /<title>nteract Markdown: Research Plan<\/title>/);
-    assert.match(html, /rel="modulepreload" href="\/assets\/notebook-route\.0123456789abcdef\.js"/);
+    assert.match(
+      html,
+      /rel="modulepreload" href="\/assets\/markdown-document-route\.0123456789abcdef\.js"/,
+    );
+    assert.match(
+      html,
+      /rel="modulepreload" href="\/assets\/markdown-projection\.0123456789abcdef\.js"/,
+    );
     assert.match(html, /rel="modulepreload" href="\/assets\/MarkdownText\.0123456789abcdef\.js"/);
-    assert.match(html, /rel="modulepreload" href="\/assets\/markdown\.0123456789abcdef\.js"/);
     assert.match(html, /rel="modulepreload" href="\/assets\/katex\.min\.0123456789abcdef\.js"/);
-    assert.match(html, /rel="stylesheet" href="\/assets\/notebook-route\.0123456789abcdef\.css"/);
-    assert.match(html, /rel="stylesheet" href="\/assets\/katex\.0123456789abcdef\.css"/);
+    assert.match(html, /rel="prefetch" href="\/assets\/katex\.0123456789abcdef\.css" as="style"/);
+    assert.doesNotMatch(html, /rel="stylesheet" href="\/assets\/katex\.0123456789abcdef\.css"/);
+    assert.doesNotMatch(html, /notebook-route\.0123456789abcdef/);
     assert.match(html, /"documentKind":"markdown"/);
     assert.match(html, /"documentId":"doc-123"/);
     assert.match(html, /"catalogEndpoint":"\/api\/m\/doc-123"/);
@@ -674,6 +682,9 @@ function fakeEnv(overrides: Partial<Env> = {}): Env {
 function fakeViewerAssetManifests(
   manifests: {
     notebookRoute?: { modulepreload: string[]; stylepreload: string[] } | Record<string, unknown>;
+    markdownDocumentRoute?:
+      | { modulepreload: string[]; stylepreload: string[] }
+      | Record<string, unknown>;
     runtimeWasm?: { module: string; wasm: string };
     rendererSidecar?: { js: string; css: string; siftWasm: string } | Record<string, unknown>;
   },
@@ -695,6 +706,14 @@ function fakeViewerAssetManifests(
       }
       if (manifests.notebookRoute && pathname === "/assets/notebook-route-assets.json") {
         return new Response(JSON.stringify(manifests.notebookRoute), {
+          headers: { "Content-Type": "application/json" },
+        });
+      }
+      if (
+        manifests.markdownDocumentRoute &&
+        pathname === "/assets/markdown-document-route-assets.json"
+      ) {
+        return new Response(JSON.stringify(manifests.markdownDocumentRoute), {
           headers: { "Content-Type": "application/json" },
         });
       }

--- a/apps/notebook-cloud/test/html.test.ts
+++ b/apps/notebook-cloud/test/html.test.ts
@@ -417,6 +417,9 @@ describe("HTML script serialization", () => {
     assert.match(html, /"documentKind":"markdown"/);
     assert.match(html, /"documentId":"doc-123"/);
     assert.match(html, /"catalogEndpoint":"\/api\/m\/doc-123"/);
+    assert.match(html, /"aclEndpoint":"\/api\/m\/doc-123\/acl"/);
+    assert.match(html, /"invitesEndpoint":"\/api\/m\/doc-123\/invites"/);
+    assert.match(html, /"accessRequestsEndpoint":"\/api\/m\/doc-123\/access-requests"/);
     assert.match(html, /"snapshotBasePath":"\/api\/m\/doc-123\/snapshots\/"/);
     assert.match(html, /"syncEndpoint":"\/m\/doc-123\/sync"/);
     assert.match(html, /"runtimedWasmModulePath":"\/assets\/runtimed_wasm\.js"/);

--- a/apps/notebook-cloud/test/html.test.ts
+++ b/apps/notebook-cloud/test/html.test.ts
@@ -146,11 +146,8 @@ describe("HTML script serialization", () => {
     assert.match(html, /rel="modulepreload" href="\/assets\/MarkdownText\.0123456789abcdef\.js"/);
     assert.match(html, /rel="modulepreload" href="\/assets\/markdown\.0123456789abcdef\.js"/);
     assert.match(html, /rel="modulepreload" href="\/assets\/katex\.min\.0123456789abcdef\.js"/);
-    assert.match(
-      html,
-      /rel="preload" href="\/assets\/notebook-route\.0123456789abcdef\.css" as="style"/,
-    );
-    assert.match(html, /rel="preload" href="\/assets\/katex\.0123456789abcdef\.css" as="style"/);
+    assert.match(html, /rel="stylesheet" href="\/assets\/notebook-route\.0123456789abcdef\.css"/);
+    assert.match(html, /rel="stylesheet" href="\/assets\/katex\.0123456789abcdef\.css"/);
     assert.ok(
       html.indexOf('rel="modulepreload" href="/assets/notebook-cloud-viewer.js"') <
         html.indexOf('rel="modulepreload" href="/assets/notebook-route.0123456789abcdef.js"'),
@@ -377,15 +374,38 @@ describe("HTML script serialization", () => {
   });
 
   it("serves Markdown document viewers with Markdown config, not notebook config", async () => {
+    const seenPaths: string[] = [];
     const response = await worker.fetch(
       new Request("https://cloud.test/m/doc-123/Research%20Plan"),
-      fakeEnv(),
+      fakeEnv({
+        ASSETS: fakeViewerAssetManifests(
+          {
+            notebookRoute: {
+              modulepreload: [
+                "notebook-route.0123456789abcdef.js",
+                "MarkdownText.0123456789abcdef.js",
+                "markdown.0123456789abcdef.js",
+                "katex.min.0123456789abcdef.js",
+              ],
+              stylepreload: ["notebook-route.0123456789abcdef.css", "katex.0123456789abcdef.css"],
+            },
+          },
+          seenPaths,
+        ),
+      }),
       fakeContext(),
     );
     const html = await response.text();
 
     assert.equal(response.status, 200);
+    assert.ok(seenPaths.includes("/assets/notebook-route-assets.json"));
     assert.match(html, /<title>nteract Markdown: Research Plan<\/title>/);
+    assert.match(html, /rel="modulepreload" href="\/assets\/notebook-route\.0123456789abcdef\.js"/);
+    assert.match(html, /rel="modulepreload" href="\/assets\/MarkdownText\.0123456789abcdef\.js"/);
+    assert.match(html, /rel="modulepreload" href="\/assets\/markdown\.0123456789abcdef\.js"/);
+    assert.match(html, /rel="modulepreload" href="\/assets\/katex\.min\.0123456789abcdef\.js"/);
+    assert.match(html, /rel="stylesheet" href="\/assets\/notebook-route\.0123456789abcdef\.css"/);
+    assert.match(html, /rel="stylesheet" href="\/assets\/katex\.0123456789abcdef\.css"/);
     assert.match(html, /"documentKind":"markdown"/);
     assert.match(html, /"documentId":"doc-123"/);
     assert.match(html, /"catalogEndpoint":"\/api\/m\/doc-123"/);
@@ -393,7 +413,9 @@ describe("HTML script serialization", () => {
     assert.match(html, /"syncEndpoint":"\/m\/doc-123\/sync"/);
     assert.match(html, /"runtimedWasmModulePath":"\/assets\/runtimed_wasm\.js"/);
     assert.match(html, /"runtimedWasmPath":"\/assets\/runtimed_wasm_bg\.wasm"/);
+    assert.match(html, /"bootstrap":null/);
     assert.doesNotMatch(html, /"notebookId"/);
+    assert.doesNotMatch(html, /"notebookRouteAssets"/);
     assert.doesNotMatch(html, /"workstationAttachEndpoint"/);
   });
 

--- a/apps/notebook-cloud/test/html.test.ts
+++ b/apps/notebook-cloud/test/html.test.ts
@@ -420,7 +420,8 @@ describe("HTML script serialization", () => {
     assert.match(html, /"aclEndpoint":"\/api\/m\/doc-123\/acl"/);
     assert.match(html, /"invitesEndpoint":"\/api\/m\/doc-123\/invites"/);
     assert.match(html, /"accessRequestsEndpoint":"\/api\/m\/doc-123\/access-requests"/);
-    assert.match(html, /"snapshotBasePath":"\/api\/m\/doc-123\/snapshots\/"/);
+    assert.doesNotMatch(html, /"snapshotBasePath":"\/api\/m\/doc-123\/snapshots\/"/);
+    assert.doesNotMatch(html, /"canPublish"/);
     assert.match(html, /"syncEndpoint":"\/m\/doc-123\/sync"/);
     assert.match(html, /"runtimedWasmModulePath":"\/assets\/runtimed_wasm\.js"/);
     assert.match(html, /"runtimedWasmPath":"\/assets\/runtimed_wasm_bg\.wasm"/);

--- a/apps/notebook-cloud/test/live-sync.test.ts
+++ b/apps/notebook-cloud/test/live-sync.test.ts
@@ -120,6 +120,14 @@ describe("cloud live sync", () => {
         FrameType.COMMS_DOC_SYNC,
         "room host rejected COMMS_DOC_SYNC frame: [cloud-room-comms-receive-sync] automerge operation failed: patch logs cannot be shared between documents; this probably means a PatchLog created for one document was reused with another",
       ],
+      [
+        FrameType.RUNTIME_STATE_SYNC,
+        "room host rejected RUNTIME_STATE_SYNC frame: Error: recursive use of an object detected which would lead to unsafe aliasing in rust",
+      ],
+      [
+        FrameType.COMMS_DOC_SYNC,
+        "room host rejected COMMS_DOC_SYNC frame: Error: recursive use of an object detected which would lead to unsafe aliasing in rust",
+      ],
     ] as const) {
       assert.equal(
         isRecoverableCloudFrameRejection({

--- a/apps/notebook-cloud/test/markdown-document-dashboard.test.ts
+++ b/apps/notebook-cloud/test/markdown-document-dashboard.test.ts
@@ -1,0 +1,54 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+import {
+  cloudMarkdownDocumentOpenUrl,
+  cloudMarkdownDocumentUrlOnCurrentOrigin,
+  type CloudMarkdownDocumentListItem,
+} from "../viewer/markdown-document-dashboard";
+
+describe("cloud Markdown document dashboard projection", () => {
+  it("opens hosted Markdown document paths on the current browser origin", () => {
+    assert.equal(
+      cloudMarkdownDocumentUrlOnCurrentOrigin(
+        "https://preview.runt.run/m/doc-123/Research%20Plan",
+        { browserOrigin: "http://127.0.0.1:45540" },
+      ),
+      "/m/doc-123/Research%20Plan",
+    );
+  });
+
+  it("keeps unrelated external URLs external", () => {
+    assert.equal(
+      cloudMarkdownDocumentUrlOnCurrentOrigin("https://example.com/docs/research", {
+        browserOrigin: "http://127.0.0.1:45540",
+      }),
+      "https://example.com/docs/research",
+    );
+  });
+
+  it("normalizes listed Markdown documents with the same route rule", () => {
+    const document = markdownDocument({
+      viewerUrl: "https://preview.runt.run/m/doc-456/Shared%20Notes#heading",
+    });
+
+    assert.equal(
+      cloudMarkdownDocumentOpenUrl(document, { browserOrigin: "http://localhost:45540" }),
+      "/m/doc-456/Shared%20Notes#heading",
+    );
+  });
+});
+
+function markdownDocument({ viewerUrl }: { viewerUrl: string }): CloudMarkdownDocumentListItem {
+  return {
+    body_doc_id: "doc-456",
+    created_at: "2026-06-15T00:00:00.000Z",
+    document_id: "doc-456",
+    endpoints: { catalog: "/api/m/doc-456" },
+    latest_revision_id: null,
+    owner_principal: "user:dev:alice",
+    scope: "owner",
+    title: "Shared Notes",
+    updated_at: "2026-06-15T00:00:00.000Z",
+    viewer_url: viewerUrl,
+  };
+}

--- a/apps/notebook-cloud/test/markdown-document-dashboard.test.ts
+++ b/apps/notebook-cloud/test/markdown-document-dashboard.test.ts
@@ -2,6 +2,7 @@ import assert from "node:assert/strict";
 import { describe, it } from "node:test";
 import {
   cloudMarkdownDocumentOpenUrl,
+  cloudMarkdownDocumentOpenUrlWithMode,
   cloudMarkdownDocumentUrlOnCurrentOrigin,
   type CloudMarkdownDocumentListItem,
 } from "../viewer/markdown-document-dashboard";
@@ -33,12 +34,55 @@ describe("cloud Markdown document dashboard projection", () => {
 
     assert.equal(
       cloudMarkdownDocumentOpenUrl(document, { browserOrigin: "http://localhost:45540" }),
-      "/m/doc-456/Shared%20Notes#heading",
+      "/m/doc-456/Shared%20Notes?mode=edit#heading",
+    );
+  });
+
+  it("opens editable Markdown documents ready for source editing", () => {
+    const owner = markdownDocument({
+      scope: "owner",
+      viewerUrl: "https://preview.runt.run/m/owner-doc/Owner%20Notes?mode=view#section-a",
+    });
+    const editor = markdownDocument({
+      scope: "editor",
+      viewerUrl: "https://preview.runt.run/m/editor-doc/Editor%20Notes",
+    });
+    const viewer = markdownDocument({
+      scope: "viewer",
+      viewerUrl: "https://preview.runt.run/m/viewer-doc/Viewer%20Notes?mode=edit",
+    });
+
+    assert.equal(
+      cloudMarkdownDocumentOpenUrl(owner, { browserOrigin: "http://localhost:45540" }),
+      "/m/owner-doc/Owner%20Notes?mode=edit#section-a",
+    );
+    assert.equal(
+      cloudMarkdownDocumentOpenUrl(editor, { browserOrigin: "http://localhost:45540" }),
+      "/m/editor-doc/Editor%20Notes?mode=edit",
+    );
+    assert.equal(
+      cloudMarkdownDocumentOpenUrl(viewer, { browserOrigin: "http://localhost:45540" }),
+      "/m/viewer-doc/Viewer%20Notes?mode=view",
+    );
+  });
+
+  it("can force newly-created Markdown documents into edit mode", () => {
+    assert.equal(
+      cloudMarkdownDocumentOpenUrlWithMode("https://preview.runt.run/m/new-doc/New%20Doc", "edit", {
+        browserOrigin: "http://localhost:45540",
+      }),
+      "/m/new-doc/New%20Doc?mode=edit",
     );
   });
 });
 
-function markdownDocument({ viewerUrl }: { viewerUrl: string }): CloudMarkdownDocumentListItem {
+function markdownDocument({
+  scope = "owner",
+  viewerUrl,
+}: {
+  scope?: CloudMarkdownDocumentListItem["scope"];
+  viewerUrl: string;
+}): CloudMarkdownDocumentListItem {
   return {
     body_doc_id: "doc-456",
     created_at: "2026-06-15T00:00:00.000Z",
@@ -46,7 +90,7 @@ function markdownDocument({ viewerUrl }: { viewerUrl: string }): CloudMarkdownDo
     endpoints: { catalog: "/api/m/doc-456" },
     latest_revision_id: null,
     owner_principal: "user:dev:alice",
-    scope: "owner",
+    scope,
     title: "Shared Notes",
     updated_at: "2026-06-15T00:00:00.000Z",
     viewer_url: viewerUrl,

--- a/apps/notebook-cloud/test/markdown-document-list-cache.test.ts
+++ b/apps/notebook-cloud/test/markdown-document-list-cache.test.ts
@@ -8,6 +8,7 @@ import {
   writeCachedCloudMarkdownDocumentList,
 } from "../viewer/markdown-document-list-cache";
 import type { CloudPrototypeAuthState } from "../viewer/collaborator-auth";
+import type { CloudAppSession } from "../viewer/app-session";
 import type { CloudMarkdownDocumentListItem } from "../viewer/markdown-document-dashboard";
 
 describe("cloud Markdown document list cache", () => {
@@ -16,27 +17,72 @@ describe("cloud Markdown document list cache", () => {
     const auth = oidcAuth("user-a");
     const documents = [document("doc-a")];
 
-    writeCachedCloudMarkdownDocumentList(storage, auth, documents, 1_000);
+    writeCachedCloudMarkdownDocumentList(storage, auth, null, documents, 1_000);
 
-    assert.deepEqual(readCachedCloudMarkdownDocumentList(storage, auth, 2_000), documents);
+    assert.deepEqual(readCachedCloudMarkdownDocumentList(storage, auth, null, 2_000), documents);
+  });
+
+  it("round-trips Markdown documents for a cookie app-session cache identity", () => {
+    const storage = new MemoryStorage();
+    const auth = anonymousAuth();
+    const appSession = session("session-a");
+    const documents = [document("doc-a")];
+
+    writeCachedCloudMarkdownDocumentList(storage, auth, appSession, documents, 1_000);
+
+    assert.deepEqual(
+      readCachedCloudMarkdownDocumentList(storage, auth, appSession, 2_000),
+      documents,
+    );
+    assert.doesNotMatch(
+      storage.getItem(CLOUD_MARKDOWN_DOCUMENT_LIST_CACHE_STORAGE_KEY) ?? "",
+      /user-a|subject|example|anaconda/,
+    );
   });
 
   it("does not reuse cached Markdown documents for another identity", () => {
     const storage = new MemoryStorage();
-    writeCachedCloudMarkdownDocumentList(storage, oidcAuth("user-a"), [document("doc-a")], 1_000);
+    writeCachedCloudMarkdownDocumentList(
+      storage,
+      oidcAuth("user-a"),
+      null,
+      [document("doc-a")],
+      1_000,
+    );
 
-    assert.equal(readCachedCloudMarkdownDocumentList(storage, oidcAuth("user-b"), 2_000), null);
+    assert.equal(
+      readCachedCloudMarkdownDocumentList(storage, oidcAuth("user-b"), null, 2_000),
+      null,
+    );
+  });
+
+  it("does not reuse cached Markdown documents for another app session", () => {
+    const storage = new MemoryStorage();
+    const auth = anonymousAuth();
+    writeCachedCloudMarkdownDocumentList(
+      storage,
+      auth,
+      session("session-a"),
+      [document("doc-a")],
+      1_000,
+    );
+
+    assert.equal(
+      readCachedCloudMarkdownDocumentList(storage, auth, session("session-b"), 2_000),
+      null,
+    );
   });
 
   it("expires retained Markdown catalog rows", () => {
     const storage = new MemoryStorage();
     const auth = oidcAuth("user-a");
-    writeCachedCloudMarkdownDocumentList(storage, auth, [document("doc-a")], 1_000);
+    writeCachedCloudMarkdownDocumentList(storage, auth, null, [document("doc-a")], 1_000);
 
     assert.equal(
       readCachedCloudMarkdownDocumentList(
         storage,
         auth,
+        null,
         1_000 + CLOUD_MARKDOWN_DOCUMENT_LIST_CACHE_TTL_MS + 1,
       ),
       null,
@@ -54,17 +100,20 @@ describe("cloud Markdown document list cache", () => {
       }),
     );
 
-    assert.equal(readCachedCloudMarkdownDocumentList(storage, oidcAuth("user-a"), 2_000), null);
+    assert.equal(
+      readCachedCloudMarkdownDocumentList(storage, oidcAuth("user-a"), null, 2_000),
+      null,
+    );
   });
 
   it("clears retained Markdown catalog rows", () => {
     const storage = new MemoryStorage();
     const auth = oidcAuth("user-a");
-    writeCachedCloudMarkdownDocumentList(storage, auth, [document("doc-a")], 1_000);
+    writeCachedCloudMarkdownDocumentList(storage, auth, null, [document("doc-a")], 1_000);
 
     clearCachedCloudMarkdownDocumentList(storage);
 
-    assert.equal(readCachedCloudMarkdownDocumentList(storage, auth, 2_000), null);
+    assert.equal(readCachedCloudMarkdownDocumentList(storage, auth, null, 2_000), null);
   });
 });
 
@@ -78,6 +127,25 @@ function oidcAuth(subject: string): CloudPrototypeAuthState {
     },
     requestedScope: "viewer",
     problem: null,
+  };
+}
+
+function anonymousAuth(): CloudPrototypeAuthState {
+  return {
+    mode: "anonymous",
+    token: null,
+    user: null,
+    oidcClaims: null,
+    requestedScope: "viewer",
+    problem: null,
+  };
+}
+
+function session(cacheKey: string): CloudAppSession {
+  return {
+    provider: "oidc",
+    expires_at: 4_102_444_800,
+    cache_key: cacheKey,
   };
 }
 

--- a/apps/notebook-cloud/test/markdown-document-list-cache.test.ts
+++ b/apps/notebook-cloud/test/markdown-document-list-cache.test.ts
@@ -1,0 +1,115 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+import {
+  CLOUD_MARKDOWN_DOCUMENT_LIST_CACHE_STORAGE_KEY,
+  CLOUD_MARKDOWN_DOCUMENT_LIST_CACHE_TTL_MS,
+  clearCachedCloudMarkdownDocumentList,
+  readCachedCloudMarkdownDocumentList,
+  writeCachedCloudMarkdownDocumentList,
+} from "../viewer/markdown-document-list-cache";
+import type { CloudPrototypeAuthState } from "../viewer/collaborator-auth";
+import type { CloudMarkdownDocumentListItem } from "../viewer/markdown-document-dashboard";
+
+describe("cloud Markdown document list cache", () => {
+  it("round-trips Markdown documents for the same browser identity", () => {
+    const storage = new MemoryStorage();
+    const auth = oidcAuth("user-a");
+    const documents = [document("doc-a")];
+
+    writeCachedCloudMarkdownDocumentList(storage, auth, documents, 1_000);
+
+    assert.deepEqual(readCachedCloudMarkdownDocumentList(storage, auth, 2_000), documents);
+  });
+
+  it("does not reuse cached Markdown documents for another identity", () => {
+    const storage = new MemoryStorage();
+    writeCachedCloudMarkdownDocumentList(storage, oidcAuth("user-a"), [document("doc-a")], 1_000);
+
+    assert.equal(readCachedCloudMarkdownDocumentList(storage, oidcAuth("user-b"), 2_000), null);
+  });
+
+  it("expires retained Markdown catalog rows", () => {
+    const storage = new MemoryStorage();
+    const auth = oidcAuth("user-a");
+    writeCachedCloudMarkdownDocumentList(storage, auth, [document("doc-a")], 1_000);
+
+    assert.equal(
+      readCachedCloudMarkdownDocumentList(
+        storage,
+        auth,
+        1_000 + CLOUD_MARKDOWN_DOCUMENT_LIST_CACHE_TTL_MS + 1,
+      ),
+      null,
+    );
+  });
+
+  it("rejects malformed cached Markdown rows", () => {
+    const storage = new MemoryStorage();
+    storage.setItem(
+      CLOUD_MARKDOWN_DOCUMENT_LIST_CACHE_STORAGE_KEY,
+      JSON.stringify({
+        authKey: "oidc:user-a",
+        savedAt: 1_000,
+        documents: [{ document_id: "doc-a" }],
+      }),
+    );
+
+    assert.equal(readCachedCloudMarkdownDocumentList(storage, oidcAuth("user-a"), 2_000), null);
+  });
+
+  it("clears retained Markdown catalog rows", () => {
+    const storage = new MemoryStorage();
+    const auth = oidcAuth("user-a");
+    writeCachedCloudMarkdownDocumentList(storage, auth, [document("doc-a")], 1_000);
+
+    clearCachedCloudMarkdownDocumentList(storage);
+
+    assert.equal(readCachedCloudMarkdownDocumentList(storage, auth, 2_000), null);
+  });
+});
+
+function oidcAuth(subject: string): CloudPrototypeAuthState {
+  return {
+    mode: "oidc",
+    token: "token",
+    user: subject,
+    oidcClaims: {
+      sub: subject,
+    },
+    requestedScope: "viewer",
+    problem: null,
+  };
+}
+
+function document(id: string): CloudMarkdownDocumentListItem {
+  return {
+    document_id: id,
+    title: null,
+    owner_principal: "user:dev:alice",
+    body_doc_id: `${id}-body`,
+    scope: "owner",
+    created_at: "2026-05-01T00:00:00.000Z",
+    updated_at: "2026-06-01T00:00:00.000Z",
+    latest_revision_id: null,
+    viewer_url: `/m/${id}/document`,
+    endpoints: {
+      catalog: `/api/m/${id}`,
+    },
+  };
+}
+
+class MemoryStorage {
+  private values = new Map<string, string>();
+
+  getItem(key: string): string | null {
+    return this.values.get(key) ?? null;
+  }
+
+  removeItem(key: string): void {
+    this.values.delete(key);
+  }
+
+  setItem(key: string, value: string): void {
+    this.values.set(key, value);
+  }
+}

--- a/apps/notebook-cloud/test/markdown-document-route.test.ts
+++ b/apps/notebook-cloud/test/markdown-document-route.test.ts
@@ -1,0 +1,24 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+import { markdownConnectionCopy } from "../viewer/markdown-document-connection-copy";
+
+describe("Markdown document route connection copy", () => {
+  it("keeps seeded content stable while live sync connects", () => {
+    assert.equal(markdownConnectionCopy("connecting", true), null);
+  });
+
+  it("shows body sync copy before any body is ready", () => {
+    assert.equal(markdownConnectionCopy("connecting", false), "Syncing Markdown document body.");
+  });
+
+  it("keeps meaningful post-load connectivity warnings", () => {
+    assert.equal(
+      markdownConnectionCopy("reconnecting", true),
+      "Reconnecting to the live Markdown document.",
+    );
+    assert.equal(
+      markdownConnectionCopy("offline", true),
+      "Markdown document is offline. Local changes will wait for reconnection.",
+    );
+  });
+});

--- a/apps/notebook-cloud/test/markdown-document-route.test.ts
+++ b/apps/notebook-cloud/test/markdown-document-route.test.ts
@@ -1,7 +1,10 @@
 import assert from "node:assert/strict";
 import { describe, it } from "node:test";
 import { markdownConnectionCopy } from "../viewer/markdown-document-connection-copy";
-import { selectMarkdownInstantPaintRecord } from "../viewer/markdown-document-live-sync";
+import {
+  selectMarkdownInstantPaintRecord,
+  shouldLoadMarkdownInstantPaintSnapshot,
+} from "../viewer/markdown-document-live-sync";
 
 describe("Markdown document route connection copy", () => {
   it("keeps seeded content stable while live sync connects", () => {
@@ -25,6 +28,28 @@ describe("Markdown document route connection copy", () => {
 });
 
 describe("Markdown document instant paint persistence selection", () => {
+  it("does not let local instant paint displace a server body seed", () => {
+    assert.equal(
+      shouldLoadMarkdownInstantPaintSnapshot({
+        bootstrap: {
+          render_seed: {
+            body: "server body",
+          },
+        },
+      }),
+      false,
+    );
+    assert.equal(shouldLoadMarkdownInstantPaintSnapshot({ bootstrap: null }), true);
+    assert.equal(
+      shouldLoadMarkdownInstantPaintSnapshot({
+        bootstrap: {
+          render_seed: null,
+        },
+      }),
+      true,
+    );
+  });
+
   it("selects only same-principal Markdown document snapshots", () => {
     const selected = selectMarkdownInstantPaintRecord(
       [

--- a/apps/notebook-cloud/test/markdown-document-route.test.ts
+++ b/apps/notebook-cloud/test/markdown-document-route.test.ts
@@ -1,6 +1,7 @@
 import assert from "node:assert/strict";
 import { describe, it } from "node:test";
 import { markdownConnectionCopy } from "../viewer/markdown-document-connection-copy";
+import { selectMarkdownInstantPaintRecord } from "../viewer/markdown-document-live-sync";
 
 describe("Markdown document route connection copy", () => {
   it("keeps seeded content stable while live sync connects", () => {
@@ -20,5 +21,51 @@ describe("Markdown document route connection copy", () => {
       markdownConnectionCopy("offline", true),
       "Markdown document is offline. Local changes will wait for reconnection.",
     );
+  });
+});
+
+describe("Markdown document instant paint persistence selection", () => {
+  it("selects only same-principal Markdown document snapshots", () => {
+    const selected = selectMarkdownInstantPaintRecord(
+      [
+        {
+          key: ["markdown-doc", "doc-1", "user:anaconda:other", "snapshot"],
+          data: new Uint8Array([1]),
+        },
+        {
+          key: ["markdown-doc", "doc-1", "user:anaconda:kyle", "snapshot"],
+          data: new Uint8Array([2, 3]),
+        },
+      ],
+      (principal) => principal === "user:anaconda:kyle",
+    );
+
+    assert.deepEqual(selected, new Uint8Array([2, 3]));
+  });
+
+  it("ignores malformed or foreign records", () => {
+    const selected = selectMarkdownInstantPaintRecord(
+      [
+        {
+          key: ["markdown-doc", "doc-1", "user:anaconda:kyle", "not-snapshot"],
+          data: new Uint8Array([1]),
+        },
+        {
+          key: ["markdown-doc", "doc-1", "user:anaconda:kyle", "snapshot", "extra"],
+          data: new Uint8Array([2]),
+        },
+        {
+          key: ["not-markdown", "doc-1", "user:anaconda:kyle", "snapshot"],
+          data: new Uint8Array([3]),
+        },
+        {
+          key: ["markdown-doc", "doc-1", "user:anaconda:other", "snapshot"],
+          data: new Uint8Array([4]),
+        },
+      ],
+      (principal) => principal === "user:anaconda:kyle",
+    );
+
+    assert.equal(selected, undefined);
   });
 });

--- a/apps/notebook-cloud/test/markdown-sharing.test.ts
+++ b/apps/notebook-cloud/test/markdown-sharing.test.ts
@@ -1,0 +1,63 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+import {
+  buildCloudMarkdownShareProjection,
+  type CloudMarkdownDocumentAclRow,
+} from "../viewer/markdown-sharing";
+
+describe("cloud Markdown sharing projection", () => {
+  it("keeps owners first and summarizes principal access", () => {
+    const projection = buildCloudMarkdownShareProjection({
+      acl: [
+        aclRow({ subject: "user:dev:bob", scope: "viewer" }),
+        aclRow({ subject: "user:dev:alice", scope: "owner" }),
+        aclRow({ subject: "user:dev:carol", scope: "editor" }),
+      ],
+    });
+
+    assert.deepEqual(
+      projection.rows.map((row) => [row.label, row.badge, row.removable]),
+      [
+        ["user:dev:alice", "Owner", false],
+        ["user:dev:carol", "Can edit", true],
+        ["user:dev:bob", "Can view", true],
+      ],
+    );
+    assert.equal(projection.summary, "3 people");
+  });
+
+  it("uses profile display metadata when available", () => {
+    const projection = buildCloudMarkdownShareProjection({
+      acl: [
+        aclRow({
+          subject: "user:dev:bob",
+          scope: "editor",
+          display: {
+            kind: "principal",
+            label: "Bob Example",
+            principal: "user:dev:bob",
+            email: "bob@example.com",
+          },
+        }),
+      ],
+    });
+
+    assert.deepEqual(
+      projection.rows.map((row) => [row.label, row.detail, row.badge]),
+      [["Bob Example", "bob@example.com", "Can edit"]],
+    );
+  });
+});
+
+function aclRow(overrides: Partial<CloudMarkdownDocumentAclRow>): CloudMarkdownDocumentAclRow {
+  return {
+    document_id: "doc-1",
+    subject_kind: "principal",
+    subject: "user:dev:alice",
+    scope: "owner",
+    created_at: "2026-06-15T00:00:00.000Z",
+    updated_at: "2026-06-15T00:00:00.000Z",
+    created_by_actor_label: "user:dev:alice/browser:tab",
+    ...overrides,
+  };
+}

--- a/apps/notebook-cloud/test/markdown-sharing.test.ts
+++ b/apps/notebook-cloud/test/markdown-sharing.test.ts
@@ -3,6 +3,8 @@ import { describe, it } from "node:test";
 import {
   buildCloudMarkdownShareProjection,
   type CloudMarkdownDocumentAclRow,
+  type CloudMarkdownDocumentInvite,
+  type CloudMarkdownAccessRequest,
 } from "../viewer/markdown-sharing";
 
 describe("cloud Markdown sharing projection", () => {
@@ -47,6 +49,41 @@ describe("cloud Markdown sharing projection", () => {
       [["Bob Example", "bob@example.com", "Can edit"]],
     );
   });
+
+  it("includes pending invites and edit requests in the access summary", () => {
+    const projection = buildCloudMarkdownShareProjection({
+      acl: [aclRow({ subject: "user:dev:alice", scope: "owner" })],
+      invites: [
+        inviteRow({
+          id: "invite-bob",
+          email: "bob@example.com",
+          scope: "editor",
+        }),
+      ],
+      accessRequests: [
+        accessRequestRow({
+          id: "request-carol",
+          requester_principal: "user:dev:carol",
+          display: {
+            kind: "principal",
+            label: "Carol Example",
+            principal: "user:dev:carol",
+            email: "carol@example.com",
+          },
+        }),
+      ],
+    });
+
+    assert.deepEqual(
+      projection.rows.map((row) => [row.kind, row.label, row.badge, row.stateLabel]),
+      [
+        ["acl", "user:dev:alice", "Owner", null],
+        ["invite", "b...b@example.com", "Can edit", "Pending"],
+        ["access_request", "Carol Example", "Can edit", "Requested"],
+      ],
+    );
+    assert.equal(projection.summary, "1 person, 1 invite, 1 request");
+  });
 });
 
 function aclRow(overrides: Partial<CloudMarkdownDocumentAclRow>): CloudMarkdownDocumentAclRow {
@@ -58,6 +95,43 @@ function aclRow(overrides: Partial<CloudMarkdownDocumentAclRow>): CloudMarkdownD
     created_at: "2026-06-15T00:00:00.000Z",
     updated_at: "2026-06-15T00:00:00.000Z",
     created_by_actor_label: "user:dev:alice/browser:tab",
+    ...overrides,
+  };
+}
+
+function inviteRow(overrides: Partial<CloudMarkdownDocumentInvite>): CloudMarkdownDocumentInvite {
+  return {
+    id: "invite-1",
+    document_id: "doc-1",
+    email: "invitee@example.com",
+    provider_hint: null,
+    scope: "viewer",
+    status: "pending",
+    invited_by_actor_label: "user:dev:alice/browser:tab",
+    accepted_by_principal: null,
+    created_at: "2026-06-15T00:00:00.000Z",
+    expires_at: null,
+    accepted_at: null,
+    revoked_at: null,
+    revoked_by_actor_label: null,
+    ...overrides,
+  };
+}
+
+function accessRequestRow(
+  overrides: Partial<CloudMarkdownAccessRequest>,
+): CloudMarkdownAccessRequest {
+  return {
+    id: "request-1",
+    document_id: "doc-1",
+    requester_principal: "user:dev:requester",
+    scope: "editor",
+    status: "pending",
+    requested_by_actor_label: "user:dev:requester/browser:tab",
+    resolved_by_actor_label: null,
+    created_at: "2026-06-15T00:00:00.000Z",
+    updated_at: "2026-06-15T00:00:00.000Z",
+    resolved_at: null,
     ...overrides,
   };
 }

--- a/apps/notebook-cloud/test/notebook-list-cache.test.ts
+++ b/apps/notebook-cloud/test/notebook-list-cache.test.ts
@@ -8,6 +8,7 @@ import {
   writeCachedCloudNotebookList,
 } from "../viewer/notebook-list-cache";
 import type { CloudPrototypeAuthState } from "../viewer/collaborator-auth";
+import type { CloudAppSession } from "../viewer/app-session";
 import type { CloudNotebookListItem } from "../viewer/notebook-dashboard";
 
 describe("cloud notebook list cache", () => {
@@ -16,25 +17,53 @@ describe("cloud notebook list cache", () => {
     const auth = oidcAuth("user-a");
     const notebooks = [notebook("nb-a")];
 
-    writeCachedCloudNotebookList(storage, auth, notebooks, 1_000);
+    writeCachedCloudNotebookList(storage, auth, null, notebooks, 1_000);
 
-    assert.deepEqual(readCachedCloudNotebookList(storage, auth, 2_000), notebooks);
+    assert.deepEqual(readCachedCloudNotebookList(storage, auth, null, 2_000), notebooks);
+  });
+
+  it("round-trips notebooks for a cookie app-session cache identity", () => {
+    const storage = new MemoryStorage();
+    const auth = anonymousAuth();
+    const appSession = session("session-a");
+    const notebooks = [notebook("nb-a")];
+
+    writeCachedCloudNotebookList(storage, auth, appSession, notebooks, 1_000);
+
+    assert.deepEqual(readCachedCloudNotebookList(storage, auth, appSession, 2_000), notebooks);
+    assert.doesNotMatch(
+      storage.getItem(CLOUD_NOTEBOOK_LIST_CACHE_STORAGE_KEY) ?? "",
+      /user-a|subject|example|anaconda/,
+    );
   });
 
   it("does not reuse cached catalog rows for another identity", () => {
     const storage = new MemoryStorage();
-    writeCachedCloudNotebookList(storage, oidcAuth("user-a"), [notebook("nb-a")], 1_000);
+    writeCachedCloudNotebookList(storage, oidcAuth("user-a"), null, [notebook("nb-a")], 1_000);
 
-    assert.equal(readCachedCloudNotebookList(storage, oidcAuth("user-b"), 2_000), null);
+    assert.equal(readCachedCloudNotebookList(storage, oidcAuth("user-b"), null, 2_000), null);
+  });
+
+  it("does not reuse cached catalog rows for another app session", () => {
+    const storage = new MemoryStorage();
+    const auth = anonymousAuth();
+    writeCachedCloudNotebookList(storage, auth, session("session-a"), [notebook("nb-a")], 1_000);
+
+    assert.equal(readCachedCloudNotebookList(storage, auth, session("session-b"), 2_000), null);
   });
 
   it("expires retained catalog rows", () => {
     const storage = new MemoryStorage();
     const auth = oidcAuth("user-a");
-    writeCachedCloudNotebookList(storage, auth, [notebook("nb-a")], 1_000);
+    writeCachedCloudNotebookList(storage, auth, null, [notebook("nb-a")], 1_000);
 
     assert.equal(
-      readCachedCloudNotebookList(storage, auth, 1_000 + CLOUD_NOTEBOOK_LIST_CACHE_TTL_MS + 1),
+      readCachedCloudNotebookList(
+        storage,
+        auth,
+        null,
+        1_000 + CLOUD_NOTEBOOK_LIST_CACHE_TTL_MS + 1,
+      ),
       null,
     );
   });
@@ -50,17 +79,17 @@ describe("cloud notebook list cache", () => {
       }),
     );
 
-    assert.equal(readCachedCloudNotebookList(storage, oidcAuth("user-a"), 2_000), null);
+    assert.equal(readCachedCloudNotebookList(storage, oidcAuth("user-a"), null, 2_000), null);
   });
 
   it("clears retained catalog rows", () => {
     const storage = new MemoryStorage();
     const auth = oidcAuth("user-a");
-    writeCachedCloudNotebookList(storage, auth, [notebook("nb-a")], 1_000);
+    writeCachedCloudNotebookList(storage, auth, null, [notebook("nb-a")], 1_000);
 
     clearCachedCloudNotebookList(storage);
 
-    assert.equal(readCachedCloudNotebookList(storage, auth, 2_000), null);
+    assert.equal(readCachedCloudNotebookList(storage, auth, null, 2_000), null);
   });
 });
 
@@ -74,6 +103,25 @@ function oidcAuth(subject: string): CloudPrototypeAuthState {
     },
     requestedScope: "viewer",
     problem: null,
+  };
+}
+
+function anonymousAuth(): CloudPrototypeAuthState {
+  return {
+    mode: "anonymous",
+    token: null,
+    user: null,
+    oidcClaims: null,
+    requestedScope: "viewer",
+    problem: null,
+  };
+}
+
+function session(cacheKey: string): CloudAppSession {
+  return {
+    provider: "oidc",
+    expires_at: 4_102_444_800,
+    cache_key: cacheKey,
   };
 }
 

--- a/apps/notebook-cloud/test/notebook-room.test.ts
+++ b/apps/notebook-cloud/test/notebook-room.test.ts
@@ -8,6 +8,7 @@ import {
   authenticateAnonymousViewer,
   authenticateDevRequest,
   stampTrustedIdentity,
+  webSocketUpgradeHeaders,
 } from "../src/identity.ts";
 import {
   NotebookRoom,
@@ -16,7 +17,6 @@ import {
   runtimePeerWorkstationMetadataFromRequest,
   rewritePresenceFrame,
   shouldBroadcastFrame,
-  webSocketUpgradeHeaders,
 } from "../src/notebook-room.ts";
 import {
   FrameType,

--- a/apps/notebook-cloud/test/notebook-route-assets.test.mjs
+++ b/apps/notebook-cloud/test/notebook-route-assets.test.mjs
@@ -5,7 +5,9 @@ import { pathToFileURL } from "node:url";
 import { describe, it } from "node:test";
 import assert from "node:assert/strict";
 import {
+  collectMarkdownDocumentRouteAssets,
   collectNotebookRouteAssets,
+  writeMarkdownDocumentRouteAssetsManifest,
   writeNotebookRouteAssetsManifest,
 } from "../scripts/notebook-route-assets.mjs";
 
@@ -18,6 +20,9 @@ describe("notebook route asset manifest", () => {
     await writeFile(new URL("notebook-route-abc123.css", assetsUrl), "");
     await writeFile(new URL("MarkdownText-def456.js", assetsUrl), "");
     await writeFile(new URL("markdown-ghi789.js", assetsUrl), "");
+    await writeFile(new URL("markdown-document-route-doc001.js", assetsUrl), "");
+    await writeFile(new URL("markdown-document-live-sync-doc002.js", assetsUrl), "");
+    await writeFile(new URL("markdown-projection-doc003.js", assetsUrl), "");
     await writeFile(new URL("katex.min-jkl012.js", assetsUrl), "");
     await writeFile(new URL("katex-mno345.css", assetsUrl), "");
     await writeFile(new URL("plotly-pqr678.js", assetsUrl), "");
@@ -31,6 +36,36 @@ describe("notebook route asset manifest", () => {
         "katex.min-jkl012.js",
       ],
       stylepreload: ["notebook-route-abc123.css", "katex-mno345.css"],
+    });
+  });
+
+  it("collects Markdown document route chunks without pulling the editor or live sync", async () => {
+    const dir = await mkdtemp(path.join(tmpdir(), "notebook-cloud-markdown-route-assets-"));
+    const assetsUrl = pathToFileURL(`${dir}/`);
+
+    await writeFile(new URL("markdown-document-route-doc001.js", assetsUrl), "");
+    await writeFile(new URL("markdown-document-live-sync-doc002.js", assetsUrl), "");
+    await writeFile(new URL("markdown-projection-doc003.js", assetsUrl), "");
+    await writeFile(new URL("codemirror-editor-doc004.js", assetsUrl), "");
+    await writeFile(new URL("cloud-notebook-title-doc005.js", assetsUrl), "");
+    await writeFile(new URL("cloud-response-doc006.js", assetsUrl), "");
+    await writeFile(new URL("use-cloud-auth-doc007.js", assetsUrl), "");
+    await writeFile(new URL("MarkdownText-def456.js", assetsUrl), "");
+    await writeFile(new URL("katex.min-jkl012.js", assetsUrl), "");
+    await writeFile(new URL("katex-mno345.css", assetsUrl), "");
+    await writeFile(new URL("notebook-route-abc123.js", assetsUrl), "");
+
+    assert.deepEqual(await collectMarkdownDocumentRouteAssets(assetsUrl), {
+      modulepreload: [
+        "markdown-document-route-doc001.js",
+        "markdown-projection-doc003.js",
+        "MarkdownText-def456.js",
+        "katex.min-jkl012.js",
+        "cloud-notebook-title-doc005.js",
+        "cloud-response-doc006.js",
+        "use-cloud-auth-doc007.js",
+      ],
+      stylepreload: ["katex-mno345.css"],
     });
   });
 
@@ -48,6 +83,29 @@ describe("notebook route asset manifest", () => {
     assert.deepEqual(written, manifest);
     assert.deepEqual(written, {
       modulepreload: ["notebook-route-abc123.js", "katex.min-jkl012.js"],
+      stylepreload: ["katex-mno345.css"],
+    });
+  });
+
+  it("writes the Markdown document route manifest beside the built viewer assets", async () => {
+    const dir = await mkdtemp(path.join(tmpdir(), "notebook-cloud-markdown-route-manifest-"));
+    const assetsUrl = pathToFileURL(`${dir}/`);
+
+    await writeFile(new URL("markdown-document-route-doc001.js", assetsUrl), "");
+    await writeFile(new URL("markdown-projection-doc003.js", assetsUrl), "");
+    await writeFile(new URL("katex.min-jkl012.js", assetsUrl), "");
+    await writeFile(new URL("katex-mno345.css", assetsUrl), "");
+
+    const { manifest, manifestUrl } = await writeMarkdownDocumentRouteAssetsManifest(assetsUrl);
+    const written = JSON.parse(await readFile(manifestUrl, "utf8"));
+
+    assert.deepEqual(written, manifest);
+    assert.deepEqual(written, {
+      modulepreload: [
+        "markdown-document-route-doc001.js",
+        "markdown-projection-doc003.js",
+        "katex.min-jkl012.js",
+      ],
       stylepreload: ["katex-mno345.css"],
     });
   });

--- a/apps/notebook-cloud/test/notebook-route-assets.test.mjs
+++ b/apps/notebook-cloud/test/notebook-route-assets.test.mjs
@@ -39,7 +39,6 @@ describe("notebook route asset manifest", () => {
     const assetsUrl = pathToFileURL(`${dir}/`);
 
     await writeFile(new URL("notebook-route-abc123.js", assetsUrl), "");
-    await writeFile(new URL("notebook-route-abc123.css", assetsUrl), "");
     await writeFile(new URL("katex.min-jkl012.js", assetsUrl), "");
     await writeFile(new URL("katex-mno345.css", assetsUrl), "");
 
@@ -48,6 +47,23 @@ describe("notebook route asset manifest", () => {
 
     assert.deepEqual(written, manifest);
     assert.deepEqual(written, {
+      modulepreload: ["notebook-route-abc123.js", "katex.min-jkl012.js"],
+      stylepreload: ["katex-mno345.css"],
+    });
+  });
+
+  it("keeps a split notebook-route stylesheet optional but preloaded when present", async () => {
+    const dir = await mkdtemp(path.join(tmpdir(), "notebook-cloud-route-manifest-css-"));
+    const assetsUrl = pathToFileURL(`${dir}/`);
+
+    await writeFile(new URL("notebook-route-abc123.js", assetsUrl), "");
+    await writeFile(new URL("notebook-route-abc123.css", assetsUrl), "");
+    await writeFile(new URL("katex.min-jkl012.js", assetsUrl), "");
+    await writeFile(new URL("katex-mno345.css", assetsUrl), "");
+
+    const { manifest } = await writeNotebookRouteAssetsManifest(assetsUrl);
+
+    assert.deepEqual(manifest, {
       modulepreload: ["notebook-route-abc123.js", "katex.min-jkl012.js"],
       stylepreload: ["notebook-route-abc123.css", "katex-mno345.css"],
     });
@@ -62,7 +78,7 @@ describe("notebook route asset manifest", () => {
 
     await assert.rejects(
       writeNotebookRouteAssetsManifest(assetsUrl),
-      /missing required route preload assets: notebook-route\.js, katex\.min\.js, notebook-route\.css, katex\.css/,
+      /missing required route preload assets: notebook-route\.js, katex\.min\.js, katex\.css/,
     );
   });
 });

--- a/apps/notebook-cloud/test/room-materializer.test.ts
+++ b/apps/notebook-cloud/test/room-materializer.test.ts
@@ -1345,6 +1345,106 @@ describe("RoomMaterializer", () => {
     assert.deepEqual([...(await state.storage.list({ prefix: "room-host:" })).keys()], []);
   });
 
+  it("recovers from a checkpoint host that fails while receiving a peer sync frame", async () => {
+    const state = fakeState();
+    const checkpointSnapshot = await createNotebookRoomSnapshot(
+      "demo",
+      "checkpoint-cell",
+      "Unreachable checkpoint edit\n",
+    );
+    const publishedSnapshot = await createNotebookRoomSnapshot(
+      "demo",
+      "published-cell",
+      "Recovered published snapshot after receive\n",
+    );
+    await Promise.all([
+      state.storage.put(
+        "room-host:notebook-doc",
+        arrayBufferFromBytes(checkpointSnapshot.notebookBytes),
+      ),
+      state.storage.put(
+        "room-host:runtime-state-doc",
+        arrayBufferFromBytes(checkpointSnapshot.runtimeStateBytes),
+      ),
+      state.storage.put("room-host:checkpoint", {
+        version: 4,
+        notebook_heads: checkpointSnapshot.notebookHeads,
+        runtime_state_heads: checkpointSnapshot.runtimeStateHeads,
+        saved_at: "2026-05-28T00:00:00.000Z",
+        published_revision_id: "revision-current",
+        published_notebook_heads: publishedSnapshot.notebookHeads,
+        published_runtime_state_heads: publishedSnapshot.runtimeStateHeads,
+      }),
+    ]);
+
+    const env = fakePublishedSnapshotEnv({
+      notebookId: "demo",
+      revisionId: "revision-current",
+      actorLabel: "user:dev:publisher/agent:runt-publish",
+      notebookBytes: publishedSnapshot.notebookBytes,
+      runtimeStateBytes: publishedSnapshot.runtimeStateBytes,
+    });
+
+    const materializer = new RoomMaterializer("demo", state, env);
+    const checkpointHost = await (
+      materializer as unknown as {
+        loadHost(): Promise<{
+          receive_peer_frame: (
+            peerId: string,
+            principal: string,
+            actorLabel: string,
+            connectionScope: string,
+            canWriteAllNotebookChanges: boolean,
+            encoded: Uint8Array,
+          ) => unknown;
+        }>;
+      }
+    ).loadHost();
+    checkpointHost.receive_peer_frame = () => {
+      throw new Error("recursive use of an object detected which would lead to unsafe aliasing");
+    };
+
+    const peer = {
+      id: "peer-viewer",
+      identity: authenticateDevRequest(
+        new Request("https://cloud.test/n/demo/sync?user=bob&operator=desktop:b&scope=viewer"),
+      ),
+    };
+    const viewer = NotebookHandle.create_bootstrap("user:dev:bob/desktop:b");
+
+    let result = await materializer.receiveFrame(peer, {
+      type: FrameType.AUTOMERGE_SYNC,
+      payload: new Uint8Array([1, 2, 3]),
+    });
+    for (let round = 0; round < 8; round += 1) {
+      const replies = applyOutboundToClient(result.outbound, peer.id, viewer);
+      if (replies.length === 0) {
+        break;
+      }
+      const outbound = [];
+      for (const reply of replies) {
+        const next = await materializer.receiveFrame(peer, {
+          type: FrameType.AUTOMERGE_SYNC,
+          payload: reply.slice(1),
+        });
+        outbound.push(...next.outbound);
+      }
+      result = {
+        changed: false,
+        notebook_changed: false,
+        runtime_state_changed: false,
+        outbound,
+      };
+    }
+
+    const cells = JSON.parse(viewer.get_cells_json()) as Array<{ id: string; source: string }>;
+    assert.deepEqual(
+      cells.map((cell) => [cell.id, cell.source]),
+      [["published-cell", "Recovered published snapshot after receive\n"]],
+    );
+    assert.deepEqual([...(await state.storage.list({ prefix: "room-host:" })).keys()], []);
+  });
+
   it("recovers from a published snapshot when stale checkpoint cleanup is over quota", async () => {
     const state = fakeState();
     const checkpointSnapshot = await createNotebookRoomSnapshot(

--- a/apps/notebook-cloud/test/use-cloud-auth-session-identity.test.ts
+++ b/apps/notebook-cloud/test/use-cloud-auth-session-identity.test.ts
@@ -17,6 +17,7 @@ describe("cloud app session identity stability", () => {
   const session = (overrides: Partial<CloudAppSession> = {}): CloudAppSession => ({
     provider: "oidc",
     expires_at: 1_750_000_000,
+    cache_key: "cache-a",
     ...overrides,
   });
 
@@ -32,6 +33,7 @@ describe("cloud app session identity stability", () => {
       assert.equal(cloudAppSessionsEqual(a, null), false);
       assert.equal(cloudAppSessionsEqual(null, a), false);
       assert.equal(cloudAppSessionsEqual(a, session({ expires_at: 1_750_000_001 })), false);
+      assert.equal(cloudAppSessionsEqual(a, session({ cache_key: "cache-b" })), false);
     });
   });
 

--- a/apps/notebook-cloud/test/viewer-render-props.test.ts
+++ b/apps/notebook-cloud/test/viewer-render-props.test.ts
@@ -578,6 +578,32 @@ test("Markdown document list reuses the hosted document catalog cache pattern", 
   assert.match(markdownCacheText, /itemsKey: "documents"/);
 });
 
+test("Markdown document home link can return to /m without a full document navigation", () => {
+  const markdownRouteText = readFileSync(
+    new URL("../viewer/markdown-document-route.tsx", import.meta.url),
+    "utf8",
+  );
+  const markdownListText = readFileSync(
+    new URL("../viewer/markdown-document-list-view.tsx", import.meta.url),
+    "utf8",
+  );
+  const notebookListText = readFileSync(
+    new URL("../viewer/notebook-list-view.tsx", import.meta.url),
+    "utf8",
+  );
+  const indexText = readFileSync(new URL("../viewer/index.tsx", import.meta.url), "utf8");
+
+  assert.ok(markdownRouteText.includes('homeHref="/m"'));
+  assert.ok(markdownRouteText.includes("onHomeClick={navigateToMarkdownDashboard}"));
+  assert.ok(markdownRouteText.includes("shouldHandleCloudViewerLinkClick(event)"));
+  assert.ok(markdownRouteText.includes('navigateCloudViewer("/m")'));
+  assert.ok(markdownListText.includes('document.title = "nteract Markdown documents"'));
+  assert.ok(notebookListText.includes('document.title = "nteract cloud notebooks"'));
+  assert.match(indexText, /CLOUD_VIEWER_ROUTE_CHANGE_EVENT/);
+  assert.match(indexText, /window\.addEventListener\("popstate", updateLocation\)/);
+  assert.match(indexText, /setLocationHref\(window\.location\.href\)/);
+});
+
 test("Markdown document sharing uses email-first collaborator input", () => {
   const markdownSharingText = readFileSync(
     new URL("../viewer/markdown-sharing-controls.tsx", import.meta.url),

--- a/apps/notebook-cloud/test/viewer-render-props.test.ts
+++ b/apps/notebook-cloud/test/viewer-render-props.test.ts
@@ -561,6 +561,25 @@ test("Markdown documents trust app sessions before surfacing sign-in chrome", ()
   );
 });
 
+test("Markdown document sharing uses email-first collaborator input", () => {
+  const markdownSharingText = readFileSync(
+    new URL("../viewer/markdown-sharing-controls.tsx", import.meta.url),
+    "utf8",
+  );
+
+  assert.match(markdownSharingText, /Share by email/);
+  assert.match(markdownSharingText, /id="cloud-markdown-share-email"/);
+  assert.match(markdownSharingText, /type="email"/);
+  assert.match(markdownSharingText, /autoComplete="email"/);
+  assert.match(markdownSharingText, /normalizeShareInviteEmail\(inviteEmail\)/);
+  assert.match(
+    markdownSharingText,
+    /JSON\.stringify\(\{[\s\S]*subject_kind: "principal",[\s\S]*email,[\s\S]*scope,[\s\S]*\}\)/,
+  );
+  assert.doesNotMatch(markdownSharingText, /cloud-markdown-share-principal/);
+  assert.doesNotMatch(markdownSharingText, /user:anaconda/);
+});
+
 test("cloud notebook shell keeps the rail and toolbar outside the cell scroller", () => {
   const sourcePath = new URL("../viewer/index.css", import.meta.url);
   const sourceText = readFileSync(sourcePath, "utf8");

--- a/apps/notebook-cloud/test/viewer-render-props.test.ts
+++ b/apps/notebook-cloud/test/viewer-render-props.test.ts
@@ -489,6 +489,15 @@ test("cloud viewer defers supplemental CSS loading until the notebook surface mo
     sourceText,
     /function CloudNotebookProviders[\s\S]*useEffect\(\(\) => \{\s*loadSupplementalViewerCss\(\);\s*\}, \[\]\);/,
   );
+
+  const markdownRouteText = readFileSync(
+    new URL("../viewer/markdown-document-route.tsx", import.meta.url),
+    "utf8",
+  );
+  assert.match(
+    markdownRouteText,
+    /useEffect\(\(\) => \{\s*loadSupplementalViewerCss\(\);\s*\}, \[\]\);/,
+  );
 });
 
 test("cloud notebook shell keeps the rail and toolbar outside the cell scroller", () => {

--- a/apps/notebook-cloud/test/viewer-render-props.test.ts
+++ b/apps/notebook-cloud/test/viewer-render-props.test.ts
@@ -500,6 +500,29 @@ test("cloud viewer defers supplemental CSS loading until the notebook surface mo
   );
 });
 
+test("Markdown documents honor the URL mode before loading the source editor", () => {
+  const markdownRouteText = readFileSync(
+    new URL("../viewer/markdown-document-route.tsx", import.meta.url),
+    "utf8",
+  );
+
+  assert.match(markdownRouteText, /cloudNotebookModeFromSearch/);
+  assert.match(markdownRouteText, /replaceCloudNotebookModeInCurrentUrl\(mode\)/);
+  assert.match(
+    markdownRouteText,
+    /const \[mode, setMode\] = useState<MarkdownDocumentMode>\(initialMarkdownDocumentMode\)/,
+  );
+  assert.match(markdownRouteText, /function initialMarkdownDocumentMode\(\): MarkdownDocumentMode/);
+  assert.match(
+    markdownRouteText,
+    /<MarkdownDocumentModeToggle[\s\S]*onModeChange=\{onModeChange\}/,
+  );
+  assert.doesNotMatch(
+    markdownRouteText,
+    /const \[mode, setMode\] = useState<MarkdownDocumentMode>\("edit"\)/,
+  );
+});
+
 test("cloud notebook shell keeps the rail and toolbar outside the cell scroller", () => {
   const sourcePath = new URL("../viewer/index.css", import.meta.url);
   const sourceText = readFileSync(sourcePath, "utf8");

--- a/apps/notebook-cloud/test/viewer-render-props.test.ts
+++ b/apps/notebook-cloud/test/viewer-render-props.test.ts
@@ -559,6 +559,25 @@ test("Markdown documents trust app sessions before surfacing sign-in chrome", ()
   );
 });
 
+test("Markdown document list reuses the hosted document catalog cache pattern", () => {
+  const markdownListText = readFileSync(
+    new URL("../viewer/markdown-document-list-view.tsx", import.meta.url),
+    "utf8",
+  );
+  const markdownCacheText = readFileSync(
+    new URL("../viewer/markdown-document-list-cache.ts", import.meta.url),
+    "utf8",
+  );
+
+  assert.match(markdownListText, /cloudMarkdownDocumentListSeedFromBootstrapOrCache/);
+  assert.match(markdownListText, /readCachedCloudMarkdownDocumentListFromWindow/);
+  assert.match(markdownListText, /writeCachedCloudMarkdownDocumentListToWindow/);
+  assert.match(markdownListText, /clearCachedCloudMarkdownDocumentListFromWindow/);
+  assert.match(markdownCacheText, /readCachedHostedDocumentList/);
+  assert.match(markdownCacheText, /writeCachedHostedDocumentList/);
+  assert.match(markdownCacheText, /itemsKey: "documents"/);
+});
+
 test("Markdown document sharing uses email-first collaborator input", () => {
   const markdownSharingText = readFileSync(
     new URL("../viewer/markdown-sharing-controls.tsx", import.meta.url),

--- a/apps/notebook-cloud/test/viewer-render-props.test.ts
+++ b/apps/notebook-cloud/test/viewer-render-props.test.ts
@@ -174,6 +174,11 @@ test("cloud viewer routes notebook header controls through the shared shell chro
   const sharingSourceText = readFileSync(sharingSourcePath, "utf8");
   const titleSourcePath = new URL("../viewer/cloud-notebook-title.tsx", import.meta.url);
   const titleSourceText = readFileSync(titleSourcePath, "utf8");
+  const documentTitleSourcePath = new URL(
+    "../../../src/components/notebook/DocumentTitle.tsx",
+    import.meta.url,
+  );
+  const documentTitleSourceText = readFileSync(documentTitleSourcePath, "utf8");
   const cssPath = new URL("../viewer/index.css", import.meta.url);
   const cssText = readFileSync(cssPath, "utf8");
 
@@ -198,9 +203,10 @@ test("cloud viewer routes notebook header controls through the shared shell chro
   );
   assert.match(sourceText, /cloudNotebookTitleDisplay,/);
   assert.match(sourceText, /cloudNotebookUrlAfterRename,/);
-  assert.match(titleSourceText, /className="cloud-notebook-home-link"/);
+  assert.match(titleSourceText, /homeLink: "cloud-notebook-home-link"/);
   assert.match(titleSourceText, /<House aria-hidden="true" \/>/);
-  assert.match(titleSourceText, /<PencilLine aria-hidden="true" \/>/);
+  assert.match(titleSourceText, /<DocumentTitle/);
+  assert.match(documentTitleSourceText, /<PencilLine aria-hidden="true" \/>/);
   assert.doesNotMatch(titleSourceText, /cloud-notebook-logo/);
   assert.doesNotMatch(sourceText, /function shouldShowCloudNotebookCommandToolbar/);
   assert.doesNotMatch(sourceText, /toolbarClassName="cloud-report-toolbar"/);

--- a/apps/notebook-cloud/test/viewer-render-props.test.ts
+++ b/apps/notebook-cloud/test/viewer-render-props.test.ts
@@ -513,10 +513,13 @@ test("Markdown documents honor the URL mode before loading the source editor", (
     /const \[mode, setMode\] = useState<MarkdownDocumentMode>\(initialMarkdownDocumentMode\)/,
   );
   assert.match(markdownRouteText, /function initialMarkdownDocumentMode\(\): MarkdownDocumentMode/);
+  assert.match(markdownRouteText, /import \{ NotebookToolbarFrame \}/);
+  assert.match(markdownRouteText, /import \{ NotebookDocumentHeader \}/);
   assert.match(
     markdownRouteText,
     /<MarkdownDocumentModeToggle[\s\S]*onModeChange=\{onModeChange\}/,
   );
+  assert.doesNotMatch(markdownRouteText, /NotebookDocumentToolbar/);
   assert.doesNotMatch(
     markdownRouteText,
     /const \[mode, setMode\] = useState<MarkdownDocumentMode>\("edit"\)/,

--- a/apps/notebook-cloud/test/viewer-render-props.test.ts
+++ b/apps/notebook-cloud/test/viewer-render-props.test.ts
@@ -519,6 +519,10 @@ test("Markdown documents honor the URL mode before loading the source editor", (
     markdownRouteText,
     /<MarkdownDocumentModeToggle[\s\S]*onModeChange=\{onModeChange\}/,
   );
+  assert.match(
+    markdownRouteText,
+    /<MarkdownDocumentRepresentationToolbar[\s\S]*onRepresentationChange=\{onRepresentationChange\}/,
+  );
   assert.doesNotMatch(markdownRouteText, /NotebookDocumentToolbar/);
   assert.doesNotMatch(
     markdownRouteText,

--- a/apps/notebook-cloud/test/viewer-render-props.test.ts
+++ b/apps/notebook-cloud/test/viewer-render-props.test.ts
@@ -500,7 +500,7 @@ test("cloud viewer defers supplemental CSS loading until the notebook surface mo
   );
 });
 
-test("Markdown documents honor the URL mode before loading the source editor", () => {
+test("Markdown documents keep interaction mode and representation controls in shared toolbar chrome", () => {
   const markdownRouteText = readFileSync(
     new URL("../viewer/markdown-document-route.tsx", import.meta.url),
     "utf8",
@@ -513,17 +513,18 @@ test("Markdown documents honor the URL mode before loading the source editor", (
     /const \[mode, setMode\] = useState<MarkdownDocumentMode>\(initialMarkdownDocumentMode\)/,
   );
   assert.match(markdownRouteText, /function initialMarkdownDocumentMode\(\): MarkdownDocumentMode/);
-  assert.match(markdownRouteText, /import \{ NotebookToolbarFrame \}/);
-  assert.match(markdownRouteText, /import \{ NotebookDocumentHeader \}/);
+  assert.match(markdownRouteText, /import \{ NotebookDocumentToolbar \}/);
+  assert.match(markdownRouteText, /<NotebookDocumentToolbar[\s\S]*reserveCommandToolbar/);
   assert.match(
     markdownRouteText,
     /<MarkdownDocumentModeToggle[\s\S]*onModeChange=\{onModeChange\}/,
   );
   assert.match(
     markdownRouteText,
-    /<MarkdownDocumentRepresentationToolbar[\s\S]*onRepresentationChange=\{onRepresentationChange\}/,
+    /commandToolbar=\{\{[\s\S]*leadingControls:[\s\S]*<MarkdownDocumentRepresentationToolbar[\s\S]*onRepresentationChange=\{onRepresentationChange\}/,
   );
-  assert.doesNotMatch(markdownRouteText, /NotebookDocumentToolbar/);
+  assert.doesNotMatch(markdownRouteText, /<NotebookToolbarFrame/);
+  assert.doesNotMatch(markdownRouteText, /<NotebookDocumentHeader/);
   assert.doesNotMatch(
     markdownRouteText,
     /const \[mode, setMode\] = useState<MarkdownDocumentMode>\("edit"\)/,

--- a/apps/notebook-cloud/test/viewer-render-props.test.ts
+++ b/apps/notebook-cloud/test/viewer-render-props.test.ts
@@ -531,6 +531,36 @@ test("Markdown documents keep interaction mode and representation controls in sh
   );
 });
 
+test("Markdown documents trust app sessions before surfacing sign-in chrome", () => {
+  const markdownListText = readFileSync(
+    new URL("../viewer/markdown-document-list-view.tsx", import.meta.url),
+    "utf8",
+  );
+  const markdownRouteText = readFileSync(
+    new URL("../viewer/markdown-document-route.tsx", import.meta.url),
+    "utf8",
+  );
+
+  assert.match(
+    markdownListText,
+    /const appSessionLoading = appSessionStatus\.status === "loading"/,
+  );
+  assert.match(
+    markdownListText,
+    /shouldShowCloudHeaderSignIn\(authState, \{[\s\S]*appSessionLoading,[\s\S]*hasAppSession,[\s\S]*\}\)/,
+  );
+  assert.match(markdownListText, /\{showSignIn \? \([\s\S]*<CloudNotebookSignInButton/);
+  assert.match(markdownRouteText, /hasAppSession: Boolean\(appSessionStatus\.session\)/);
+  assert.match(
+    markdownRouteText,
+    /hasAppSession \|\| authState\.mode === "dev" \|\| authState\.mode === "oidc"/,
+  );
+  assert.match(
+    markdownRouteText,
+    /!hasAppSession && \(authState\.mode === "invalid" \|\| authState\.mode === "oidc_expired"\)/,
+  );
+});
+
 test("cloud notebook shell keeps the rail and toolbar outside the cell scroller", () => {
   const sourcePath = new URL("../viewer/index.css", import.meta.url);
   const sourceText = readFileSync(sourcePath, "utf8");

--- a/apps/notebook-cloud/test/viewer-render-props.test.ts
+++ b/apps/notebook-cloud/test/viewer-render-props.test.ts
@@ -517,7 +517,7 @@ test("Markdown documents keep interaction mode and representation controls in sh
   assert.match(markdownRouteText, /<NotebookDocumentToolbar[\s\S]*reserveCommandToolbar/);
   assert.match(
     markdownRouteText,
-    /<MarkdownDocumentModeToggle[\s\S]*onModeChange=\{onModeChange\}/,
+    /editControls=\{[\s\S]*<CloudNotebookEditModeButton[\s\S]*onModeChange=\{onModeChange\}/,
   );
   assert.match(
     markdownRouteText,
@@ -548,7 +548,7 @@ test("Markdown documents trust app sessions before surfacing sign-in chrome", ()
   assert.match(markdownListText, /canFetchCatalog: canFetchDocumentList/);
   assert.match(markdownListText, /showSignIn/);
   assert.match(markdownListText, /\{showSignIn \? \([\s\S]*<CloudNotebookSignInButton/);
-  assert.match(markdownRouteText, /hasAppSession: Boolean\(appSessionStatus\.session\)/);
+  assert.match(markdownRouteText, /const hasAppSession = Boolean\(appSessionStatus\.session\)/);
   assert.match(
     markdownRouteText,
     /hasAppSession \|\| authState\.mode === "dev" \|\| authState\.mode === "oidc"/,
@@ -589,10 +589,7 @@ test("Markdown document sharing uses email-first collaborator input", () => {
   assert.match(markdownSharingText, /type="email"/);
   assert.match(markdownSharingText, /autoComplete="email"/);
   assert.match(markdownSharingText, /normalizeShareInviteEmail\(inviteEmail\)/);
-  assert.match(
-    markdownSharingText,
-    /JSON\.stringify\(\{[\s\S]*subject_kind: "principal",[\s\S]*email,[\s\S]*scope,[\s\S]*\}\)/,
-  );
+  assert.match(markdownSharingText, /JSON\.stringify\(\{ email, scope \}\)/);
   assert.doesNotMatch(markdownSharingText, /cloud-markdown-share-principal/);
   assert.doesNotMatch(markdownSharingText, /user:anaconda/);
 });

--- a/apps/notebook-cloud/test/viewer-render-props.test.ts
+++ b/apps/notebook-cloud/test/viewer-render-props.test.ts
@@ -543,12 +543,10 @@ test("Markdown documents trust app sessions before surfacing sign-in chrome", ()
 
   assert.match(
     markdownListText,
-    /const appSessionLoading = appSessionStatus\.status === "loading"/,
+    /projectHostedDocumentAuthState\(authState, \{[\s\S]*appSession: appSessionStatus\.session,[\s\S]*appSessionLoading: appSessionStatus\.status === "loading"/,
   );
-  assert.match(
-    markdownListText,
-    /shouldShowCloudHeaderSignIn\(authState, \{[\s\S]*appSessionLoading,[\s\S]*hasAppSession,[\s\S]*\}\)/,
-  );
+  assert.match(markdownListText, /canFetchCatalog: canFetchDocumentList/);
+  assert.match(markdownListText, /showSignIn/);
   assert.match(markdownListText, /\{showSignIn \? \([\s\S]*<CloudNotebookSignInButton/);
   assert.match(markdownRouteText, /hasAppSession: Boolean\(appSessionStatus\.session\)/);
   assert.match(

--- a/apps/notebook-cloud/test/viewer-shared-cell-surface.test.ts
+++ b/apps/notebook-cloud/test/viewer-shared-cell-surface.test.ts
@@ -719,7 +719,7 @@ test("cloud app-session bridge refreshes cookie-backed state after OIDC exchange
   );
   assert.match(
     routeSourceText,
-    /\[authState, bootstrap, canFetchNotebookList, refreshIndex, waitingForAppSession\]/,
+    /\[\s*appSessionStatus\.session,\s*authState,\s*bootstrap,\s*canFetchNotebookList,\s*refreshIndex,\s*waitingForAppSession,\s*\]/,
   );
 });
 
@@ -727,7 +727,8 @@ test("cloud notebook list refresh re-establishes app sessions before listing not
   const routeSourcePath = new URL("../viewer/notebook-list-view.tsx", import.meta.url);
   const routeSourceText = readFileSync(routeSourcePath, "utf8");
 
-  assert.match(routeSourceText, /import \{ clearCloudAppSession, establishCloudAppSession \}/);
+  assert.match(routeSourceText, /clearCloudAppSession/);
+  assert.match(routeSourceText, /establishCloudAppSession/);
   assert.match(
     routeSourceText,
     /const refreshList = \(\) => \{[\s\S]*authState\.mode === "oidc" && authState\.token[\s\S]*establishCloudAppSession\(authState\)[\s\S]*appSessionStatus\.refreshAppSessionStatus\(\)[\s\S]*setRefreshIndex/,
@@ -761,16 +762,16 @@ test("cloud notebook list trusts server bootstrap on initial app-session paint",
 
   assert.match(
     sourceText,
-    /const seededNotebooks = cloudNotebookListSeedFromBootstrapOrCache\(authState, bootstrap\);/,
+    /const seededNotebooks = cloudNotebookListSeedFromBootstrapOrCache\(\s*authState,\s*bootstrap,\s*appSessionStatus\.session,\s*\);/,
   );
   assert.match(
     sourceText,
-    /if \(refreshIndex === 0 && bootstrap\) \{[\s\S]*writeCachedCloudNotebookListToWindow\(authState, bootstrap\.notebooks\);[\s\S]*setListState\(\{ kind: "ready", notebooks: bootstrap\.notebooks \}\);[\s\S]*return;/,
+    /if \(refreshIndex === 0 && bootstrap\) \{[\s\S]*writeCachedCloudNotebookListToWindow\(\s*authState,\s*appSessionStatus\.session,\s*bootstrap\.notebooks,\s*\);[\s\S]*setListState\(\{ kind: "ready", notebooks: bootstrap\.notebooks \}\);[\s\S]*return;/,
     "fresh notebook-home bootstrap should satisfy the initial render without an immediate duplicate /api/n fetch",
   );
   assert.match(
     sourceText,
-    /return bootstrap\?\.notebooks \?\? readCachedCloudNotebookListFromWindow\(authState\);/,
+    /return bootstrap\?\.notebooks \?\? readCachedCloudNotebookListFromWindow\(authState, appSession\);/,
     "server bootstrap should beat stale sessionStorage cache when both are present",
   );
 });

--- a/apps/notebook-cloud/test/viewer-shared-cell-surface.test.ts
+++ b/apps/notebook-cloud/test/viewer-shared-cell-surface.test.ts
@@ -41,20 +41,26 @@ test("cloud notebook dashboard search input has stable form metadata", () => {
   assert.match(dashboardSourceText, /aria-label="Search notebooks"/);
 });
 
-test("cloud notebook list uses local auth copy in local mode", () => {
+test("cloud hosted document lists use shared signed-out auth chrome", () => {
   const listSourcePath = new URL("../viewer/notebook-list-view.tsx", import.meta.url);
   const listSourceText = readFileSync(listSourcePath, "utf8");
+  const markdownListSourceText = readFileSync(
+    new URL("../viewer/markdown-document-list-view.tsx", import.meta.url),
+    "utf8",
+  );
+  const signedOutSourceText = readFileSync(
+    new URL("../viewer/cloud-hosted-document-signed-out.tsx", import.meta.url),
+    "utf8",
+  );
 
-  assert.match(listSourceText, /const localMode = Boolean\(authConfig\.localDev\)/);
-  assert.match(listSourceText, /localMode \? "LOCAL MODE" : "NTERACT"/);
-  assert.match(
-    listSourceText,
-    /localMode \? "Open local notebooks\." : "Bring computation to life\."/,
-  );
-  assert.match(
-    listSourceText,
-    /Use local auth to create notebooks and test the live room on this machine\./,
-  );
+  assert.match(listSourceText, /<CloudHostedDocumentSignedOutPanel/);
+  assert.match(markdownListSourceText, /<CloudHostedDocumentSignedOutPanel/);
+  assert.match(signedOutSourceText, /const localMode = Boolean\(authConfig\.localDev\)/);
+  assert.match(signedOutSourceText, /localMode \? "LOCAL MODE" : "NTERACT"/);
+  assert.match(listSourceText, /localTitle="Open local notebooks\."/);
+  assert.match(listSourceText, /cloudTitle="Bring computation to life\."/);
+  assert.match(markdownListSourceText, /localTitle="Open local Markdown\."/);
+  assert.match(markdownListSourceText, /cloudTitle="Write live Markdown\."/);
   assert.match(listSourceText, /return authConfig\.localDev \? "Local auth" : "Cloud preview"/);
   assert.match(
     listSourceText,

--- a/apps/notebook-cloud/test/viewer-shared-cell-surface.test.ts
+++ b/apps/notebook-cloud/test/viewer-shared-cell-surface.test.ts
@@ -735,8 +735,9 @@ test("cloud notebook list waits for app-session cookies before catalog fetches",
 
   assert.match(
     sourceText,
-    /const canFetchNotebookList = authState\.mode === "dev" \|\| hasAppSession;/,
+    /projectHostedDocumentAuthState\(authState, \{[\s\S]*appSession: appSessionStatus\.session,[\s\S]*appSessionLoading: appSessionStatus\.status === "loading"/,
   );
+  assert.match(sourceText, /canFetchCatalog: canFetchNotebookList/);
   assert.match(
     sourceText,
     /if \(!canFetchNotebookList\) \{[\s\S]*if \(waitingForAppSession\) \{[\s\S]*\{ kind: "loading" \}[\s\S]*return;/,

--- a/apps/notebook-cloud/test/worker-routes.test.ts
+++ b/apps/notebook-cloud/test/worker-routes.test.ts
@@ -44,8 +44,13 @@ import {
   markdownDocumentSnapshotKey,
   runtimeStateSnapshotKey,
   snapshotKey,
+  type MarkdownDocumentAccessRequestRow,
 } from "../src/storage.ts";
-import type { PendingNotebookInviteRow, PrincipalProfileRow } from "../src/sharing-storage.ts";
+import type {
+  PendingMarkdownDocumentInviteRow,
+  PendingNotebookInviteRow,
+  PrincipalProfileRow,
+} from "../src/sharing-storage.ts";
 import { canonicalAccountPrincipalForProfile } from "../src/sharing-storage.ts";
 import type {
   MarkdownDocumentAclRow as StorageMarkdownDocumentAclRow,
@@ -824,6 +829,73 @@ describe("Worker artifact routes", () => {
       env.DB.acl.some(
         (row) =>
           row.notebook_id === "cookie-list-invited" &&
+          row.subject_kind === "principal" &&
+          row.subject === accountPrincipal &&
+          row.scope === "editor",
+      ),
+    );
+  });
+
+  it("resolves post-login pending invites for app-session Markdown document list APIs", async () => {
+    const { env: oidcEnv, token } = await oidcTokenFixture({
+      subject: "cookie-markdown-invite-list-user",
+      email: "cookie-markdown-invite-list@example.test",
+      extraPayload: { email_verified: true },
+      name: "Cookie Markdown Invite List User",
+    });
+    const env = fakeEnv({
+      ...oidcEnv,
+      NOTEBOOK_CLOUD_APP_SESSION_SECRET: APP_SESSION_SECRET,
+    });
+    const cookie = await oidcAppSessionCookie(env, token);
+    env.DB.markdownDocuments.set("cookie-markdown-list-invited", {
+      id: "cookie-markdown-list-invited",
+      owner_principal: "user:dev:alice",
+      title: "Cookie Markdown Invited",
+      body_doc_id: "cookie-markdown-list-invited-body",
+      created_at: "2026-06-15T00:00:00.000Z",
+      updated_at: "2026-06-15T00:00:00.000Z",
+      latest_revision_id: null,
+    });
+    seedPendingMarkdownInvite(env, {
+      id: "invite-cookie-markdown-list",
+      documentId: "cookie-markdown-list-invited",
+      email: "cookie-markdown-invite-list@example.test",
+      providerHint: null,
+      scope: "editor",
+    });
+
+    const response = await worker.fetch(
+      new Request("https://cloud.test/api/m", {
+        headers: { Cookie: cookie },
+      }),
+      env,
+      fakeContext(),
+    );
+
+    assert.equal(response.status, 200);
+    const body = (await response.json()) as {
+      documents: Array<{ document_id: string; scope: StorageMarkdownDocumentAclRow["scope"] }>;
+    };
+    assert.deepEqual(
+      body.documents.map((document) => [document.document_id, document.scope]),
+      [["cookie-markdown-list-invited", "editor"]],
+    );
+    const accountPrincipal = await canonicalAccountPrincipalForProfile({
+      provider: "oidc",
+      principalNamespace: "user:anaconda",
+      email: "cookie-markdown-invite-list@example.test",
+      emailVerified: true,
+    });
+    assert.ok(accountPrincipal);
+    assert.equal(
+      env.DB.markdownDocumentInvites.get("invite-cookie-markdown-list")?.status,
+      "accepted",
+    );
+    assert.ok(
+      env.DB.markdownDocumentAcl.some(
+        (row) =>
+          row.document_id === "cookie-markdown-list-invited" &&
           row.subject_kind === "principal" &&
           row.subject === accountPrincipal &&
           row.scope === "editor",
@@ -2113,6 +2185,56 @@ describe("Worker artifact routes", () => {
     assert.equal(bobCatalog.status, 200);
   });
 
+  it("lets Markdown document owners create and revoke pending email invites", async () => {
+    const env = fakeEnv();
+    env.DB.markdownDocuments.set("markdown-invite-demo", {
+      id: "markdown-invite-demo",
+      owner_principal: "user:dev:alice",
+      title: "Shared Markdown",
+      body_doc_id: "markdown-invite-demo-body",
+      created_at: "2026-06-15T00:00:00.000Z",
+      updated_at: "2026-06-15T00:00:00.000Z",
+      latest_revision_id: null,
+    });
+    env.DB.markdownDocumentAcl.push({
+      document_id: "markdown-invite-demo",
+      subject_kind: "principal",
+      subject: "user:dev:alice",
+      scope: "owner",
+      created_at: "2026-06-15T00:00:00.000Z",
+      updated_at: "2026-06-15T00:00:00.000Z",
+      created_by_actor_label: "user:dev:alice/browser:tab",
+    });
+
+    const create = await markdownInviteRequest(env, "POST", {
+      email: "future-reader@example.com",
+      scope: "viewer",
+    });
+
+    assert.equal(create.status, 201);
+    assert.equal(env.DB.markdownDocumentInvites.size, 1);
+    const createBody = (await create.json()) as {
+      invite: { email: string; document_id: string; status: string };
+    };
+    assert.equal(createBody.invite.document_id, "markdown-invite-demo");
+    assert.equal(createBody.invite.email, "future-reader@example.com");
+    assert.equal(createBody.invite.status, "pending");
+
+    const list = await markdownInviteRequest(env, "GET", undefined);
+    assert.equal(list.status, 200);
+    const listBody = (await list.json()) as {
+      invites: Array<{ id: string; email: string; status: string }>;
+    };
+    assert.deepEqual(
+      listBody.invites.map((invite) => [invite.email, invite.status]),
+      [["future-reader@example.com", "pending"]],
+    );
+
+    const revoke = await markdownInviteItemRequest(env, "DELETE", listBody.invites[0].id);
+    assert.equal(revoke.status, 200);
+    assert.equal(env.DB.markdownDocumentInvites.get(listBody.invites[0].id)?.status, "revoked");
+  });
+
   it("rejects Markdown document email grants for unknown recipients", async () => {
     const env = fakeEnv();
     env.DB.markdownDocuments.set("markdown-share-email-miss", {
@@ -2153,6 +2275,115 @@ describe("Worker artifact routes", () => {
     assert.equal(
       env.DB.markdownDocumentAcl.some((row) => row.subject === "missing@example.com"),
       false,
+    );
+  });
+
+  it("lets Markdown viewers request edit access and owners approve it", async () => {
+    const env = fakeEnv();
+    env.DB.markdownDocuments.set("markdown-access-request-demo", {
+      id: "markdown-access-request-demo",
+      owner_principal: "user:dev:alice",
+      title: "Shared Markdown",
+      body_doc_id: "markdown-access-request-demo-body",
+      created_at: "2026-06-15T00:00:00.000Z",
+      updated_at: "2026-06-15T00:00:00.000Z",
+      latest_revision_id: null,
+    });
+    env.DB.markdownDocumentAcl.push({
+      document_id: "markdown-access-request-demo",
+      subject_kind: "principal",
+      subject: "user:dev:alice",
+      scope: "owner",
+      created_at: "2026-06-15T00:00:00.000Z",
+      updated_at: "2026-06-15T00:00:00.000Z",
+      created_by_actor_label: "user:dev:alice/browser:tab",
+    });
+    env.DB.markdownDocumentAcl.push({
+      document_id: "markdown-access-request-demo",
+      subject_kind: "public",
+      subject: "anonymous",
+      scope: "viewer",
+      created_at: "2026-06-15T00:00:00.000Z",
+      updated_at: "2026-06-15T00:00:00.000Z",
+      created_by_actor_label: "user:dev:alice/browser:tab",
+    });
+    env.DB.profiles.set("user:dev:bob", {
+      principal: "user:dev:bob",
+      provider: "dev",
+      provider_subject: "bob",
+      email_normalized: "bob@example.com",
+      email_verified: 1,
+      display_name: "Bob Example",
+      avatar_url: null,
+      first_seen_at: "2026-06-15T00:00:00.000Z",
+      last_seen_at: "2026-06-15T00:00:00.000Z",
+      raw_claims_json: null,
+    });
+
+    const create = await markdownAccessRequestsRequest(
+      env,
+      "POST",
+      "markdown-access-request-demo",
+      undefined,
+      {
+        "X-User": "bob",
+        "X-Operator": "browser:tab",
+        "X-Scope": "viewer",
+      },
+    );
+
+    assert.equal(create.status, 201);
+    assert.equal(env.DB.markdownDocumentAccessRequests.size, 1);
+    const createBody = (await create.json()) as {
+      access_status: string;
+      access_request: { id: string; status: string; requester_principal: string };
+    };
+    assert.equal(createBody.access_status, "pending");
+    assert.equal(createBody.access_request.requester_principal, "user:dev:bob");
+
+    const ownerList = await markdownAccessRequestsRequest(
+      env,
+      "GET",
+      "markdown-access-request-demo",
+    );
+    assert.equal(ownerList.status, 200);
+    const ownerBody = (await ownerList.json()) as {
+      access_requests: Array<Record<string, unknown>>;
+    };
+    assert.deepEqual(
+      ownerBody.access_requests.map((row) => [row.status, row.display]),
+      [
+        [
+          "pending",
+          {
+            kind: "principal",
+            label: "Bob Example",
+            principal: "user:dev:bob",
+            email: "bob@example.com",
+          },
+        ],
+      ],
+    );
+
+    const approve = await markdownAccessRequestItemRequest(
+      env,
+      "POST",
+      "markdown-access-request-demo",
+      createBody.access_request.id,
+      "approve",
+    );
+    assert.equal(approve.status, 200);
+    assert.equal(
+      env.DB.markdownDocumentAccessRequests.get(createBody.access_request.id)?.status,
+      "approved",
+    );
+    assert.ok(
+      env.DB.markdownDocumentAcl.some(
+        (row) =>
+          row.document_id === "markdown-access-request-demo" &&
+          row.subject === "user:dev:bob" &&
+          row.scope === "editor",
+      ),
     );
   });
 
@@ -6501,6 +6732,57 @@ async function inviteItemRequest(
   );
 }
 
+async function markdownInviteRequest(
+  env: FakeEnv,
+  method: "GET" | "POST",
+  body: Record<string, unknown> | undefined,
+  documentId = "markdown-invite-demo",
+  headers: Record<string, string> = {},
+): Promise<Response> {
+  const init: RequestInit = {
+    method,
+    headers: {
+      "Content-Type": "application/json",
+      "X-User": "alice",
+      "X-Operator": "desktop:test",
+      "X-Scope": "owner",
+      ...headers,
+    },
+  };
+  if (body !== undefined) {
+    init.body = JSON.stringify(body);
+  }
+
+  return worker.fetch(
+    new Request(new URL(`/api/m/${documentId}/invites`, "http://localhost"), init),
+    env,
+    fakeContext(),
+  );
+}
+
+async function markdownInviteItemRequest(
+  env: FakeEnv,
+  method: "DELETE",
+  inviteId: string,
+  documentId = "markdown-invite-demo",
+  headers: Record<string, string> = {},
+): Promise<Response> {
+  return worker.fetch(
+    new Request(new URL(`/api/m/${documentId}/invites/${inviteId}`, "http://localhost"), {
+      method,
+      headers: {
+        "Content-Type": "application/json",
+        "X-User": "alice",
+        "X-Operator": "desktop:test",
+        "X-Scope": "owner",
+        ...headers,
+      },
+    }),
+    env,
+    fakeContext(),
+  );
+}
+
 async function accessRequestsRequest(
   env: FakeEnv,
   method: "GET" | "POST",
@@ -6529,6 +6811,34 @@ async function accessRequestsRequest(
   );
 }
 
+async function markdownAccessRequestsRequest(
+  env: FakeEnv,
+  method: "GET" | "POST",
+  documentId: string,
+  body: Record<string, unknown> | undefined = undefined,
+  headers: Record<string, string> = {},
+): Promise<Response> {
+  const init: RequestInit = {
+    method,
+    headers: {
+      "Content-Type": "application/json",
+      "X-User": "alice",
+      "X-Operator": "desktop:test",
+      "X-Scope": "owner",
+      ...headers,
+    },
+  };
+  if (body !== undefined) {
+    init.body = JSON.stringify(body);
+  }
+
+  return worker.fetch(
+    new Request(new URL(`/api/m/${documentId}/access-requests`, "http://localhost"), init),
+    env,
+    fakeContext(),
+  );
+}
+
 async function accessRequestItemRequest(
   env: FakeEnv,
   method: "POST",
@@ -6539,6 +6849,31 @@ async function accessRequestItemRequest(
 ): Promise<Response> {
   return worker.fetch(
     new Request(new URL(`/api/n/${notebookId}/access-requests/${requestId}`, "http://localhost"), {
+      method,
+      headers: {
+        "Content-Type": "application/json",
+        "X-User": "alice",
+        "X-Operator": "desktop:test",
+        "X-Scope": "owner",
+        ...headers,
+      },
+      body: JSON.stringify({ action }),
+    }),
+    env,
+    fakeContext(),
+  );
+}
+
+async function markdownAccessRequestItemRequest(
+  env: FakeEnv,
+  method: "POST",
+  documentId: string,
+  requestId: string,
+  action: "approve" | "deny" | "dismiss",
+  headers: Record<string, string> = {},
+): Promise<Response> {
+  return worker.fetch(
+    new Request(new URL(`/api/m/${documentId}/access-requests/${requestId}`, "http://localhost"), {
       method,
       headers: {
         "Content-Type": "application/json",
@@ -6702,6 +7037,34 @@ function seedPendingInvite(
   env.DB.invites.set(input.id, {
     id: input.id,
     notebook_id: input.notebookId,
+    email_normalized: input.email,
+    provider_hint: input.providerHint,
+    scope: input.scope,
+    status: "pending",
+    invited_by_actor_label: "user:oidc:alice/browser:tab",
+    accepted_by_principal: null,
+    token_hash: null,
+    created_at: "2026-05-22T00:00:00.000Z",
+    expires_at: null,
+    accepted_at: null,
+    revoked_at: null,
+    revoked_by_actor_label: null,
+  });
+}
+
+function seedPendingMarkdownInvite(
+  env: FakeEnv,
+  input: {
+    id: string;
+    documentId: string;
+    email: string;
+    providerHint: string | null;
+    scope: PendingMarkdownDocumentInviteRow["scope"];
+  },
+): void {
+  env.DB.markdownDocumentInvites.set(input.id, {
+    id: input.id,
+    document_id: input.documentId,
     email_normalized: input.email,
     provider_hint: input.providerHint,
     scope: input.scope,
@@ -7054,7 +7417,9 @@ class FakeD1 implements D1Database {
   readonly profiles = new Map<string, PrincipalProfileRow>();
   readonly accountLinks = new Map<string, PrincipalAccountLinkRow>();
   readonly invites = new Map<string, PendingNotebookInviteRow>();
+  readonly markdownDocumentInvites = new Map<string, PendingMarkdownDocumentInviteRow>();
   readonly accessRequests = new Map<string, NotebookAccessRequestRow>();
+  readonly markdownDocumentAccessRequests = new Map<string, MarkdownDocumentAccessRequestRow>();
   readonly workstations = new Map<string, WorkstationRow>();
   readonly workstationDefaults = new Map<string, string>();
   readonly workstationAttachJobs = new Map<string, WorkstationAttachJobRow>();
@@ -7179,6 +7544,85 @@ class FakeD1Statement implements D1PreparedStatement {
           created_by_actor_label: actorLabel,
         });
       }
+    } else if (
+      this.query.includes("INSERT INTO markdown_document_acl") &&
+      this.query.includes("FROM markdown_document_invites")
+    ) {
+      const [
+        subject,
+        createdAt,
+        updatedAt,
+        actorLabel,
+        inviteId,
+        acceptedByPrincipal,
+        acceptedAt,
+        email,
+        providerHint,
+        now,
+      ] = this.values as [
+        string,
+        string,
+        string,
+        string,
+        string,
+        string,
+        string,
+        string,
+        string | null,
+        string,
+      ];
+      const invite = this.db.markdownDocumentInvites.get(inviteId);
+      if (
+        invite &&
+        invite.status === "accepted" &&
+        invite.accepted_by_principal === acceptedByPrincipal &&
+        invite.accepted_at === acceptedAt &&
+        invite.email_normalized === email &&
+        (invite.provider_hint === providerHint || invite.provider_hint === null) &&
+        (!invite.expires_at || Date.parse(invite.expires_at) > Date.parse(now)) &&
+        this.db.markdownDocuments.has(invite.document_id)
+      ) {
+        this.insertMarkdownDocumentAclIfMissing({
+          document_id: invite.document_id,
+          subject_kind: "principal",
+          subject,
+          scope: invite.scope,
+          created_at: createdAt,
+          updated_at: updatedAt,
+          created_by_actor_label: actorLabel,
+        });
+        return okResult(undefined, { changes: 1 });
+      }
+      return okResult(undefined, { changes: 0 });
+    } else if (
+      this.query.includes("INSERT INTO markdown_document_acl") &&
+      this.query.includes("FROM markdown_document_access_requests")
+    ) {
+      const [createdAt, updatedAt, actorLabel, documentId, requestId] = this.values as [
+        string,
+        string,
+        string,
+        string,
+        string,
+      ];
+      const accessRequest = this.db.markdownDocumentAccessRequests.get(requestId);
+      if (
+        accessRequest &&
+        accessRequest.document_id === documentId &&
+        accessRequest.status === "pending"
+      ) {
+        this.insertMarkdownDocumentAclIfMissing({
+          document_id: documentId,
+          subject_kind: "principal",
+          subject: accessRequest.requester_principal,
+          scope: accessRequest.scope,
+          created_at: createdAt,
+          updated_at: updatedAt,
+          created_by_actor_label: actorLabel,
+        });
+        return okResult(undefined, { changes: 1 });
+      }
+      return okResult(undefined, { changes: 0 });
     } else if (this.query.includes("INSERT INTO markdown_document_acl")) {
       const [documentId, subjectKind, subject, scope, createdAt, updatedAt, actorLabel] = this
         .values as [
@@ -7218,6 +7662,124 @@ class FakeD1Statement implements D1PreparedStatement {
       );
       this.db.markdownDocumentAcl.splice(0, this.db.markdownDocumentAcl.length, ...retained);
       return okResult(undefined, { changes: countBefore - retained.length });
+    } else if (this.query.includes("INSERT INTO markdown_document_invites")) {
+      const [
+        id,
+        documentId,
+        emailNormalized,
+        providerHint,
+        scope,
+        actorLabel,
+        tokenHash,
+        createdAt,
+        expiresAt,
+      ] = this.values as [
+        string,
+        string,
+        string,
+        string | null,
+        PendingMarkdownDocumentInviteRow["scope"],
+        string,
+        string | null,
+        string,
+        string | null,
+      ];
+      const duplicate = [...this.db.markdownDocumentInvites.values()].find(
+        (invite) =>
+          invite.document_id === documentId &&
+          invite.email_normalized === emailNormalized &&
+          invite.provider_hint === providerHint &&
+          invite.scope === scope &&
+          invite.status === "pending",
+      );
+      if (duplicate) {
+        throw new Error(
+          "D1_ERROR: UNIQUE constraint failed: markdown_document_invites pending invite",
+        );
+      }
+      this.db.markdownDocumentInvites.set(id, {
+        id,
+        document_id: documentId,
+        email_normalized: emailNormalized,
+        provider_hint: providerHint,
+        scope,
+        status: "pending",
+        invited_by_actor_label: actorLabel,
+        accepted_by_principal: null,
+        token_hash: tokenHash,
+        created_at: createdAt,
+        expires_at: expiresAt,
+        accepted_at: null,
+        revoked_at: null,
+        revoked_by_actor_label: null,
+      });
+    } else if (
+      this.query.includes("UPDATE markdown_document_invites") &&
+      this.query.includes("revoked_by_actor_label")
+    ) {
+      const [revokedAt, revokedByActorLabel, documentId, inviteId] = this.values as [
+        string,
+        string,
+        string,
+        string,
+      ];
+      const invite = this.db.markdownDocumentInvites.get(inviteId);
+      if (invite && invite.document_id === documentId && invite.status === "pending") {
+        invite.status = "revoked";
+        invite.revoked_at = revokedAt;
+        invite.revoked_by_actor_label = revokedByActorLabel;
+        return okResult(undefined, { changes: 1 });
+      }
+      return okResult(undefined, { changes: 0 });
+    } else if (this.query.includes("INSERT INTO markdown_document_access_requests")) {
+      const [id, documentId, requesterPrincipal, actorLabel, createdAt, updatedAt] = this
+        .values as [string, string, string, string, string, string];
+      const duplicate = [...this.db.markdownDocumentAccessRequests.values()].find(
+        (accessRequest) =>
+          accessRequest.document_id === documentId &&
+          accessRequest.requester_principal === requesterPrincipal &&
+          accessRequest.scope === "editor" &&
+          accessRequest.status === "pending",
+      );
+      if (duplicate) {
+        throw new Error(
+          "D1_ERROR: UNIQUE constraint failed: markdown_document_access_requests pending request",
+        );
+      }
+      this.db.markdownDocumentAccessRequests.set(id, {
+        id,
+        document_id: documentId,
+        requester_principal: requesterPrincipal,
+        scope: "editor",
+        status: "pending",
+        requested_by_actor_label: actorLabel,
+        resolved_by_actor_label: null,
+        created_at: createdAt,
+        updated_at: updatedAt,
+        resolved_at: null,
+      });
+    } else if (this.query.includes("UPDATE markdown_document_access_requests")) {
+      const [status, actorLabel, resolvedAt, updatedAt, documentId, requestId] = this.values as [
+        MarkdownDocumentAccessRequestRow["status"],
+        string,
+        string,
+        string,
+        string,
+        string,
+      ];
+      const accessRequest = this.db.markdownDocumentAccessRequests.get(requestId);
+      if (
+        accessRequest &&
+        accessRequest.document_id === documentId &&
+        accessRequest.status === "pending"
+      ) {
+        accessRequest.status = status;
+        accessRequest.resolved_by_actor_label = actorLabel;
+        accessRequest.resolved_at = resolvedAt;
+        accessRequest.updated_at = updatedAt;
+        return okResult(undefined, { changes: 1 });
+      }
+      return okResult(undefined, { changes: 0 });
     } else if (this.query.includes("INSERT OR IGNORE INTO notebook_acl")) {
       if (this.query.includes("'principal'") && this.query.includes("owner_principal")) {
         for (const notebook of this.db.notebooks.values()) {
@@ -8073,6 +8635,30 @@ class FakeD1Statement implements D1PreparedStatement {
         first_seen_at: existing?.first_seen_at ?? firstSeenAt,
         last_seen_at: lastSeenAt,
       });
+    } else if (this.query.includes("UPDATE markdown_document_invites")) {
+      const [principal, acceptedAt, inviteId, email, providerHint, now] = this.values as [
+        string,
+        string,
+        string,
+        string,
+        string | null,
+        string,
+      ];
+      const invite = this.db.markdownDocumentInvites.get(inviteId);
+      if (
+        invite &&
+        invite.status === "pending" &&
+        invite.email_normalized === email &&
+        (invite.provider_hint === providerHint || invite.provider_hint === null) &&
+        (!invite.expires_at || Date.parse(invite.expires_at) > Date.parse(now)) &&
+        this.db.markdownDocuments.has(invite.document_id)
+      ) {
+        invite.status = "accepted";
+        invite.accepted_by_principal = principal;
+        invite.accepted_at = acceptedAt;
+        return okResult(undefined, { changes: 1 });
+      }
+      return okResult(undefined, { changes: 0 });
     } else if (this.query.includes("UPDATE notebook_invites")) {
       const [principal, acceptedAt, inviteId, email, providerHint, now] = this.values as [
         string,
@@ -8132,6 +8718,31 @@ class FakeD1Statement implements D1PreparedStatement {
   }
 
   async first<T = unknown>(): Promise<T | null> {
+    if (this.query.includes("FROM markdown_document_access_requests")) {
+      if (this.query.includes("requester_principal = ?")) {
+        const [documentId, requesterPrincipal] = this.values as [string, string];
+        return (
+          ([...this.db.markdownDocumentAccessRequests.values()]
+            .filter(
+              (accessRequest) =>
+                accessRequest.document_id === documentId &&
+                accessRequest.requester_principal === requesterPrincipal &&
+                (!this.query.includes("status = 'pending'") || accessRequest.status === "pending"),
+            )
+            .sort(
+              (left, right) =>
+                right.created_at.localeCompare(left.created_at) || right.id.localeCompare(left.id),
+            )[0] as T | undefined) ?? null
+        );
+      }
+      const [documentId, requestId] = this.values as [string, string];
+      return (
+        ([...this.db.markdownDocumentAccessRequests.values()].find(
+          (accessRequest) =>
+            accessRequest.document_id === documentId && accessRequest.id === requestId,
+        ) as T | undefined) ?? null
+      );
+    }
     if (this.query.includes("FROM notebook_access_requests")) {
       if (this.query.includes("requester_principal = ?")) {
         const [notebookId, requesterPrincipal] = this.values as [string, string];
@@ -8223,6 +8834,30 @@ class FakeD1Statement implements D1PreparedStatement {
       return job?.owner_principal === ownerPrincipal && job.workstation_id === workstationId
         ? (job as T)
         : null;
+    }
+    if (this.query.includes("FROM markdown_document_invites")) {
+      if (this.query.includes("WHERE document_id = ?")) {
+        const [documentId, email, scope, providerHint] = this.values as [
+          string,
+          string,
+          PendingMarkdownDocumentInviteRow["scope"],
+          string | null,
+          string | null,
+        ];
+        return (
+          ([...this.db.markdownDocumentInvites.values()].find(
+            (invite) =>
+              invite.document_id === documentId &&
+              invite.email_normalized === email &&
+              invite.scope === scope &&
+              invite.status === "pending" &&
+              invite.provider_hint === providerHint,
+          ) as T | undefined) ?? null
+        );
+      }
+      return (
+        (this.db.markdownDocumentInvites.get(this.values[0] as string) as T | undefined) ?? null
+      );
     }
     if (this.query.includes("FROM notebook_invites")) {
       if (this.query.includes("WHERE notebook_id = ?")) {
@@ -8339,6 +8974,35 @@ class FakeD1Statement implements D1PreparedStatement {
         [...this.db.profiles.values()].filter((profile) =>
           principals.has(profile.principal),
         ) as T[],
+      );
+    }
+    if (this.query.includes("FROM markdown_document_access_requests")) {
+      const documentId = this.values[0] as string;
+      const limit = typeof this.values[1] === "number" ? this.values[1] : Number.POSITIVE_INFINITY;
+      return okResult(
+        [...this.db.markdownDocumentAccessRequests.values()]
+          .filter((accessRequest) => accessRequest.document_id === documentId)
+          .sort(
+            (left, right) =>
+              right.created_at.localeCompare(left.created_at) || right.id.localeCompare(left.id),
+          )
+          .slice(0, limit) as T[],
+      );
+    }
+    if (
+      this.query.includes("FROM markdown_document_invites") &&
+      this.query.includes("WHERE document_id = ?")
+    ) {
+      const documentId = this.values[0] as string;
+      const limit = typeof this.values[1] === "number" ? this.values[1] : Number.POSITIVE_INFINITY;
+      return okResult(
+        [...this.db.markdownDocumentInvites.values()]
+          .filter((invite) => invite.document_id === documentId)
+          .sort(
+            (left, right) =>
+              right.created_at.localeCompare(left.created_at) || right.id.localeCompare(left.id),
+          )
+          .slice(0, limit) as T[],
       );
     }
     if (
@@ -8565,6 +9229,18 @@ class FakeD1Statement implements D1PreparedStatement {
       const [email, provider, now] = this.values as [string, string, string];
       return okResult(
         Array.from(this.db.invites.values()).filter(
+          (invite) =>
+            invite.email_normalized === email &&
+            invite.status === "pending" &&
+            (invite.provider_hint === provider || invite.provider_hint === null) &&
+            (!invite.expires_at || Date.parse(invite.expires_at) > Date.parse(now)),
+        ) as T[],
+      );
+    }
+    if (this.query.includes("FROM markdown_document_invites")) {
+      const [email, provider, now] = this.values as [string, string, string];
+      return okResult(
+        Array.from(this.db.markdownDocumentInvites.values()).filter(
           (invite) =>
             invite.email_normalized === email &&
             invite.status === "pending" &&

--- a/apps/notebook-cloud/test/worker-routes.test.ts
+++ b/apps/notebook-cloud/test/worker-routes.test.ts
@@ -2899,6 +2899,37 @@ describe("Worker artifact routes", () => {
     assert.equal(body.workstations[0]?.is_default, true);
   });
 
+  it("streams user-owned workstation events with CORS headers", async () => {
+    const objectName = workstationEventsObjectName("user:dev:alice", "ws-lab2");
+    const events = new FakeWorkstationEventsNamespace({ connectedObjectNames: [objectName] });
+    const env = fakeEnv({ WORKSTATION_EVENTS: events });
+    seedWorkstation(env, {
+      ownerPrincipal: "user:dev:alice",
+      workstationId: "ws-lab2",
+    });
+
+    const response = await worker.fetch(
+      new Request("http://localhost/api/workstations/ws-lab2/events", {
+        headers: {
+          "X-Operator": "workstation:lab2",
+          "X-Scope": "owner",
+          "X-User": "alice",
+        },
+      }),
+      env,
+      fakeContext(),
+    );
+
+    assert.equal(response.status, 200);
+    assert.equal(response.headers.get("Access-Control-Allow-Origin"), "*");
+    assert.equal(response.headers.get("Content-Type"), "text/event-stream; charset=utf-8");
+    assert.match(await response.text(), /event: ready/);
+    const streamRequest = events.requests.find(
+      (entry) => new URL(entry.url).pathname === "/stream",
+    );
+    assert.equal(streamRequest?.objectName, objectName);
+  });
+
   it("projects a stale workstation as online when its event stream is connected", async () => {
     const objectName = workstationEventsObjectName("user:dev:alice", "ws-lab2");
     const events = new FakeWorkstationEventsNamespace({ connectedObjectNames: [objectName] });

--- a/apps/notebook-cloud/test/worker-routes.test.ts
+++ b/apps/notebook-cloud/test/worker-routes.test.ts
@@ -1991,6 +1991,65 @@ describe("Worker artifact routes", () => {
     assert.deepEqual(new Uint8Array(await anonymousRead.arrayBuffer()), snapshotBytes);
   });
 
+  it("preserves an existing Markdown snapshot object if revision recording fails", async () => {
+    const env = fakeEnv();
+    env.DB.markdownDocuments.set("markdown-publish-existing", {
+      id: "markdown-publish-existing",
+      owner_principal: "user:dev:alice",
+      title: "Existing Markdown",
+      body_doc_id: "markdown-publish-existing",
+      created_at: "2026-06-15T00:00:00.000Z",
+      updated_at: "2026-06-15T00:00:00.000Z",
+      latest_revision_id: "previous-revision",
+    });
+    env.DB.markdownDocumentAcl.push({
+      document_id: "markdown-publish-existing",
+      subject_kind: "principal",
+      subject: "user:dev:alice",
+      scope: "owner",
+      created_at: "2026-06-15T00:00:00.000Z",
+      updated_at: "2026-06-15T00:00:00.000Z",
+      created_by_actor_label: "user:dev:alice/browser:tab",
+    });
+
+    const handle = MarkdownHandle.create(
+      "markdown-publish-existing",
+      "Existing Markdown",
+      "user:dev:alice/browser:test",
+    );
+    handle.replace_body_for_import("# Existing Markdown\n\nAlready published.");
+    const snapshotBytes = handle.save();
+    const bodyHeadsHash = await markdownTestHeadsDigest(handle.get_heads_hex());
+    handle.free();
+
+    const key = markdownDocumentSnapshotKey("markdown-publish-existing", bodyHeadsHash);
+    await env.NOTEBOOK_SNAPSHOTS.put(key, snapshotBytes, {
+      httpMetadata: {
+        contentType: "application/x-automerge",
+        cacheControl: "public, max-age=31536000, immutable",
+      },
+      customMetadata: {
+        document_id: "markdown-publish-existing",
+        body_heads_hash: bodyHeadsHash,
+      },
+    });
+    assert.equal((await env.NOTEBOOK_SNAPSHOTS.head(key)) !== null, true);
+    env.DB.failNextBatch = new Error("forced revision failure");
+
+    await assert.rejects(
+      ownerPut(env, `/api/m/markdown-publish-existing/snapshots/${bodyHeadsHash}`, snapshotBytes),
+      /forced revision failure/,
+    );
+
+    assert.equal(env.NOTEBOOK_SNAPSHOTS.objects.has(key), true);
+    assert.deepEqual(env.NOTEBOOK_SNAPSHOTS.headKeys.slice(-1), [key]);
+    assert.equal(
+      env.DB.markdownDocuments.get("markdown-publish-existing")?.latest_revision_id,
+      "previous-revision",
+    );
+    assert.equal(env.DB.markdownDocumentRevisions.length, 0);
+  });
+
   it("routes hosted Markdown document sync through the Markdown room binding", async () => {
     const { env: oidcEnv, token } = await oidcTokenFixture({ subject: "markdown-ws-user" });
     let forwardedRequest: Request | undefined;
@@ -6724,6 +6783,7 @@ class FakeD1 implements D1Database {
   readonly workstationCredentials = new Map<string, WorkstationCredentialRow>();
   readonly batchSizes: number[] = [];
   afterBlockedOwnerDelete?: () => void;
+  failNextBatch?: Error;
 
   prepare(query: string): D1PreparedStatement {
     return new FakeD1Statement(this, query);
@@ -6735,6 +6795,11 @@ class FakeD1 implements D1Database {
 
   async batch<T = unknown>(statements: D1PreparedStatement[]): Promise<D1Result<T>[]> {
     this.batchSizes.push(statements.length);
+    if (this.failNextBatch) {
+      const error = this.failNextBatch;
+      this.failNextBatch = undefined;
+      throw error;
+    }
     const results: D1Result<T>[] = [];
     for (const statement of statements) {
       results.push(await statement.run<T>());
@@ -8281,6 +8346,7 @@ function okResult<T = unknown>(results?: T[], meta: Record<string, unknown> = {}
 class FakeR2Bucket implements R2Bucket {
   readonly objects = new Map<string, FakeR2Object>();
   readonly getKeys: string[] = [];
+  readonly headKeys: string[] = [];
 
   async get(key: string): Promise<R2ObjectBody | null> {
     this.getKeys.push(key);
@@ -8288,6 +8354,7 @@ class FakeR2Bucket implements R2Bucket {
   }
 
   async head(key: string): Promise<R2Object | null> {
+    this.headKeys.push(key);
     return this.objects.get(key) ?? null;
   }
 

--- a/apps/notebook-cloud/test/worker-routes.test.ts
+++ b/apps/notebook-cloud/test/worker-routes.test.ts
@@ -1786,6 +1786,76 @@ describe("Worker artifact routes", () => {
     assert.equal("runtime_snapshots" in body.document.endpoints, false);
   });
 
+  it("routes hosted Markdown document sync through the Markdown room binding", async () => {
+    let forwardedRequest: Request | undefined;
+    const env = fakeEnv({
+      MARKDOWN_DOCUMENT_ROOMS: {
+        idFromName: (name: string) => ({ toString: () => name }),
+        get: () => ({
+          fetch: async (request: Request) => {
+            forwardedRequest = request;
+            return new Response("markdown room ok");
+          },
+        }),
+      } satisfies DurableObjectNamespace,
+    });
+    env.DB.markdownDocuments.set("markdown-sync", {
+      id: "markdown-sync",
+      owner_principal: "user:dev:alice",
+      title: "Synced Markdown",
+      body_doc_id: "markdown-sync",
+      created_at: "2026-06-15T00:00:00.000Z",
+      updated_at: "2026-06-15T00:00:00.000Z",
+      latest_revision_id: null,
+    });
+    env.DB.markdownDocumentAcl.push({
+      document_id: "markdown-sync",
+      subject_kind: "principal",
+      subject: "user:dev:alice",
+      scope: "editor",
+      created_at: "2026-06-15T00:00:00.000Z",
+      updated_at: "2026-06-15T00:00:00.000Z",
+      created_by_actor_label: "user:dev:alice/browser:tab",
+    });
+
+    const response = await worker.fetch(
+      new Request("http://localhost/m/markdown-sync/sync?scope=editor", {
+        headers: {
+          Origin: "http://localhost",
+          Upgrade: "websocket",
+          "X-Operator": "browser:tab",
+          "X-Scope": "editor",
+          "X-User": "alice",
+        },
+      }),
+      env,
+      fakeContext(),
+    );
+
+    assert.equal(response.status, 200);
+    assert.ok(forwardedRequest);
+    assert.equal(new URL(forwardedRequest.url).pathname, "/m/markdown-sync/sync");
+    assert.equal(forwardedRequest.headers.get(TRUSTED_SCOPE_HEADER), "editor");
+  });
+
+  it("fails Markdown document sync clearly when the room binding is absent", async () => {
+    const response = await worker.fetch(
+      new Request("http://localhost/m/missing-room/sync", {
+        headers: {
+          Origin: "http://localhost",
+          Upgrade: "websocket",
+        },
+      }),
+      fakeEnv(),
+      fakeContext(),
+    );
+
+    assert.equal(response.status, 503);
+    assert.deepEqual(await response.json(), {
+      error: "Markdown document rooms are not configured",
+    });
+  });
+
   it("keeps local Browser viewer URLs on loopback when Wrangler preserves the custom-domain URL", async () => {
     const env = fakeEnv({ NOTEBOOK_CLOUD_TRUST_LOOPBACK_HEADERS: "true" });
     const localBrowserHeaders = {

--- a/apps/notebook-cloud/test/worker-routes.test.ts
+++ b/apps/notebook-cloud/test/worker-routes.test.ts
@@ -1669,6 +1669,123 @@ describe("Worker artifact routes", () => {
     assert.equal(body.viewer_url, `http://localhost/n/${body.notebook_id}/Exploration%20Notes`);
   });
 
+  it("creates and lists hosted Markdown documents without notebook runtime fields", async () => {
+    const env = fakeEnv();
+
+    const createResponse = await worker.fetch(
+      new Request("http://localhost/api/m", {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          "X-Operator": "browser:tab",
+          "X-Scope": "owner",
+          "X-User": "alice",
+        },
+        body: JSON.stringify({ title: "Research Brief" }),
+      }),
+      env,
+      fakeContext(),
+    );
+
+    assert.equal(createResponse.status, 201);
+    const created = (await createResponse.json()) as {
+      body_doc_id: string;
+      document_id: string;
+      title: string;
+      viewer_url: string;
+    };
+    assert.match(created.document_id, /^[0-9A-HJKMNP-TV-Z]{26}$/);
+    assert.equal(created.body_doc_id, created.document_id);
+    assert.equal(created.title, "Research Brief");
+    assert.equal(created.viewer_url, `http://localhost/m/${created.document_id}/Research%20Brief`);
+    assert.equal(env.DB.markdownDocuments.get(created.document_id)?.title, "Research Brief");
+    assert.equal(
+      env.DB.markdownDocumentAcl.some(
+        (row) =>
+          row.document_id === created.document_id &&
+          row.subject === "user:dev:alice" &&
+          row.scope === "owner",
+      ),
+      true,
+    );
+
+    const listResponse = await worker.fetch(
+      new Request("http://localhost/api/m", {
+        headers: {
+          "X-Operator": "browser:tab",
+          "X-Scope": "viewer",
+          "X-User": "alice",
+        },
+      }),
+      env,
+      fakeContext(),
+    );
+
+    assert.equal(listResponse.status, 200);
+    const listBody = (await listResponse.json()) as {
+      documents: Array<{
+        body_doc_id: string;
+        document_id: string;
+        scope: string;
+        viewer_url: string;
+      }>;
+    };
+    assert.equal(listBody.documents.length, 1);
+    assert.equal(listBody.documents[0]?.document_id, created.document_id);
+    assert.equal(listBody.documents[0]?.body_doc_id, created.document_id);
+    assert.equal(listBody.documents[0]?.scope, "owner");
+    assert.equal(listBody.documents[0]?.viewer_url, created.viewer_url);
+    assert.equal("runtimeSnapshotBasePath" in listBody.documents[0]!, false);
+    assert.equal("workstationAttachEndpoint" in listBody.documents[0]!, false);
+  });
+
+  it("reports the best granted Markdown document scope from the catalog route", async () => {
+    const env = fakeEnv();
+    env.DB.markdownDocuments.set("markdown-owned", {
+      id: "markdown-owned",
+      owner_principal: "user:dev:alice",
+      title: "Owned Markdown",
+      body_doc_id: "markdown-owned",
+      created_at: "2026-06-15T00:00:00.000Z",
+      updated_at: "2026-06-15T00:00:00.000Z",
+      latest_revision_id: null,
+    });
+    env.DB.markdownDocumentAcl.push({
+      document_id: "markdown-owned",
+      subject_kind: "principal",
+      subject: "user:dev:alice",
+      scope: "owner",
+      created_at: "2026-06-15T00:00:00.000Z",
+      updated_at: "2026-06-15T00:00:00.000Z",
+      created_by_actor_label: "user:dev:alice/browser:tab",
+    });
+
+    const response = await worker.fetch(
+      new Request("http://localhost/api/m/markdown-owned", {
+        headers: {
+          "X-Operator": "browser:tab",
+          "X-Scope": "viewer",
+          "X-User": "alice",
+        },
+      }),
+      env,
+      fakeContext(),
+    );
+
+    assert.equal(response.status, 200);
+    const body = (await response.json()) as {
+      document: {
+        document_id: string;
+        scope: string;
+        endpoints: Record<string, string>;
+      };
+    };
+    assert.equal(body.document.document_id, "markdown-owned");
+    assert.equal(body.document.scope, "owner");
+    assert.equal(body.document.endpoints.catalog, "/api/m/markdown-owned");
+    assert.equal("runtime_snapshots" in body.document.endpoints, false);
+  });
+
   it("keeps local Browser viewer URLs on loopback when Wrangler preserves the custom-domain URL", async () => {
     const env = fakeEnv({ NOTEBOOK_CLOUD_TRUST_LOOPBACK_HEADERS: "true" });
     const localBrowserHeaders = {
@@ -6185,6 +6302,35 @@ interface NotebookAclRow {
   created_by_actor_label: string;
 }
 
+interface MarkdownDocumentRow {
+  id: string;
+  owner_principal: string;
+  title: string | null;
+  body_doc_id: string;
+  created_at: string;
+  updated_at: string;
+  latest_revision_id: string | null;
+}
+
+interface MarkdownDocumentAclRow {
+  document_id: string;
+  subject_kind: "principal" | "public";
+  subject: string;
+  scope: "viewer" | "editor" | "owner";
+  created_at: string;
+  updated_at: string;
+  created_by_actor_label: string;
+}
+
+interface MarkdownDocumentRevisionRow {
+  id: string;
+  document_id: string;
+  body_heads_hash: string;
+  snapshot_key: string;
+  actor_label: string;
+  created_at: string;
+}
+
 interface NotebookAccessRequestRow {
   id: string;
   notebook_id: string;
@@ -6247,6 +6393,9 @@ interface WorkstationAttachJobRow {
 
 class FakeD1 implements D1Database {
   readonly notebooks = new Map<string, NotebookRow>();
+  readonly markdownDocuments = new Map<string, MarkdownDocumentRow>();
+  readonly markdownDocumentRevisions: MarkdownDocumentRevisionRow[] = [];
+  readonly markdownDocumentAcl: MarkdownDocumentAclRow[] = [];
   readonly revisions: RevisionRow[] = [];
   readonly blobs = new Map<string, BlobRow>();
   readonly acl: NotebookAclRow[] = [];
@@ -6355,7 +6504,63 @@ class FakeD1Statement implements D1PreparedStatement {
   }
 
   async run<T = unknown>(): Promise<D1Result<T>> {
-    if (this.query.includes("INSERT OR IGNORE INTO notebook_acl")) {
+    if (
+      this.query.includes("INSERT INTO markdown_document_acl") &&
+      this.query.includes("WHERE EXISTS")
+    ) {
+      const [documentId, subject, createdAt, updatedAt, actorLabel, expectedDocumentId, owner] =
+        this.values as [string, string, string, string, string, string, string];
+      if (this.db.markdownDocuments.get(expectedDocumentId)?.owner_principal === owner) {
+        this.insertMarkdownDocumentAclIfMissing({
+          document_id: documentId,
+          subject_kind: "principal",
+          subject,
+          scope: "owner",
+          created_at: createdAt,
+          updated_at: updatedAt,
+          created_by_actor_label: actorLabel,
+        });
+      }
+    } else if (this.query.includes("INSERT INTO markdown_document_acl")) {
+      const [documentId, subjectKind, subject, scope, createdAt, updatedAt, actorLabel] = this
+        .values as [
+        string,
+        MarkdownDocumentAclRow["subject_kind"],
+        string,
+        MarkdownDocumentAclRow["scope"],
+        string,
+        string,
+        string,
+      ];
+      this.insertMarkdownDocumentAclIfMissing({
+        document_id: documentId,
+        subject_kind: subjectKind,
+        subject,
+        scope,
+        created_at: createdAt,
+        updated_at: updatedAt,
+        created_by_actor_label: actorLabel,
+      });
+    } else if (this.query.includes("DELETE FROM markdown_document_acl")) {
+      const [documentId, subjectKind, subject, scope] = this.values as [
+        string,
+        MarkdownDocumentAclRow["subject_kind"],
+        string,
+        MarkdownDocumentAclRow["scope"],
+      ];
+      const countBefore = this.db.markdownDocumentAcl.length;
+      const retained = this.db.markdownDocumentAcl.filter(
+        (row) =>
+          !(
+            row.document_id === documentId &&
+            row.subject_kind === subjectKind &&
+            row.subject === subject &&
+            row.scope === scope
+          ),
+      );
+      this.db.markdownDocumentAcl.splice(0, this.db.markdownDocumentAcl.length, ...retained);
+      return okResult(undefined, { changes: countBefore - retained.length });
+    } else if (this.query.includes("INSERT OR IGNORE INTO notebook_acl")) {
       if (this.query.includes("'principal'") && this.query.includes("owner_principal")) {
         for (const notebook of this.db.notebooks.values()) {
           this.insertAclIfMissing({
@@ -6977,6 +7182,29 @@ class FakeD1Statement implements D1PreparedStatement {
         return okResult(undefined, { changes: 1 });
       }
       return okResult(undefined, { changes: 0 });
+    } else if (this.query.includes("INSERT INTO markdown_documents")) {
+      const [id, ownerPrincipal, title, bodyDocId, createdAt, updatedAt] = this.values as [
+        string,
+        string,
+        string | null,
+        string,
+        string,
+        string,
+      ];
+      const existing = this.db.markdownDocuments.get(id);
+      if (existing && this.query.includes("DO NOTHING")) {
+        return okResult(undefined, { changes: 0 });
+      }
+      this.db.markdownDocuments.set(id, {
+        id,
+        owner_principal: existing?.owner_principal ?? ownerPrincipal,
+        title: existing?.title ?? title,
+        body_doc_id: existing?.body_doc_id ?? bodyDocId,
+        created_at: existing?.created_at ?? createdAt,
+        updated_at: updatedAt,
+        latest_revision_id: existing?.latest_revision_id ?? null,
+      });
+      return okResult(undefined, { changes: 1 });
     } else if (this.query.includes("INSERT INTO notebooks")) {
       const [id, ownerPrincipal, maybeTitleOrCreatedAt, createdAtOrUpdatedAt, maybeUpdatedAt] = this
         .values as [string, string, string | null, string | undefined, string | undefined];
@@ -7002,6 +7230,22 @@ class FakeD1Statement implements D1PreparedStatement {
         latest_revision_id: existing?.latest_revision_id ?? null,
       });
       return okResult(undefined, { changes: 1 });
+    } else if (this.query.includes("INSERT INTO markdown_document_revisions")) {
+      const [id, documentId, bodyHeadsHash, snapshotKey, actorLabel] = this.values as [
+        string,
+        string,
+        string,
+        string,
+        string,
+      ];
+      this.db.markdownDocumentRevisions.push({
+        id,
+        document_id: documentId,
+        body_heads_hash: bodyHeadsHash,
+        snapshot_key: snapshotKey,
+        actor_label: actorLabel,
+        created_at: new Date().toISOString(),
+      });
     } else if (this.query.includes("INSERT INTO notebook_revisions")) {
       const [
         id,
@@ -7039,6 +7283,28 @@ class FakeD1Statement implements D1PreparedStatement {
         actor_label: actorLabel,
         created_at: new Date().toISOString(),
       });
+    } else if (
+      this.query.includes("UPDATE markdown_documents") &&
+      this.query.includes("latest_revision_id")
+    ) {
+      const [revisionId, updatedAt, documentId] = this.values as [string, string, string];
+      const existing = this.db.markdownDocuments.get(documentId);
+      if (existing) {
+        existing.latest_revision_id = revisionId;
+        existing.updated_at = updatedAt;
+      }
+    } else if (
+      this.query.includes("UPDATE markdown_documents") &&
+      this.query.includes("SET title")
+    ) {
+      const [title, updatedAt, documentId] = this.values as [string | null, string, string];
+      const existing = this.db.markdownDocuments.get(documentId);
+      if (!existing) {
+        return okResult(undefined, { changes: 0 });
+      }
+      existing.title = title;
+      existing.updated_at = updatedAt;
+      return okResult(undefined, { changes: 1 });
     } else if (
       this.query.includes("UPDATE notebooks") &&
       this.query.includes("latest_revision_id")
@@ -7192,6 +7458,21 @@ class FakeD1Statement implements D1PreparedStatement {
     this.db.acl.push(row);
   }
 
+  private insertMarkdownDocumentAclIfMissing(row: MarkdownDocumentAclRow): void {
+    const existing = this.db.markdownDocumentAcl.find(
+      (candidate) =>
+        candidate.document_id === row.document_id &&
+        candidate.subject_kind === row.subject_kind &&
+        candidate.subject === row.subject &&
+        candidate.scope === row.scope,
+    );
+    if (existing) {
+      existing.updated_at = row.updated_at;
+      return;
+    }
+    this.db.markdownDocumentAcl.push(row);
+  }
+
   async first<T = unknown>(): Promise<T | null> {
     if (this.query.includes("FROM notebook_access_requests")) {
       if (this.query.includes("requester_principal = ?")) {
@@ -7322,6 +7603,25 @@ class FakeD1Statement implements D1PreparedStatement {
           row.scope === "viewer",
       );
       return (notebook?.latest_revision_id && publicViewer ? notebook : null) as T | null;
+    }
+    if (
+      this.query.includes("FROM markdown_documents d") &&
+      this.query.includes("JOIN markdown_document_acl a") &&
+      this.query.includes("a.subject_kind = 'public'")
+    ) {
+      const documentId = this.values[0] as string;
+      const document = this.db.markdownDocuments.get(documentId);
+      const publicViewer = this.db.markdownDocumentAcl.some(
+        (row) =>
+          row.document_id === documentId &&
+          row.subject_kind === "public" &&
+          row.subject === "anonymous" &&
+          row.scope === "viewer",
+      );
+      return (document?.latest_revision_id && publicViewer ? document : null) as T | null;
+    }
+    if (this.query.includes("FROM markdown_documents")) {
+      return (this.db.markdownDocuments.get(this.values[0] as string) as T | undefined) ?? null;
     }
     if (this.query.includes("FROM notebooks")) {
       return (this.db.notebooks.get(this.values[0] as string) as T | undefined) ?? null;
@@ -7473,6 +7773,84 @@ class FakeD1Statement implements D1PreparedStatement {
           .map(({ scopeRank: _scopeRank, ...row }) => row) as T[],
       );
     }
+    if (
+      this.query.includes("FROM markdown_documents d") &&
+      this.query.includes("JOIN markdown_document_acl a")
+    ) {
+      const [principal, linkedPrincipal, limitValue] = this.values as [string, string, number];
+      const linked = this.db.accountLinks.get(linkedPrincipal)?.canonical_principal;
+      const subjects = new Set([principal, ...(linked ? [linked] : [])]);
+      const byDocument = new Map<
+        string,
+        MarkdownDocumentRow & { scope: MarkdownDocumentAclRow["scope"]; scopeRank: number }
+      >();
+
+      for (const row of this.db.markdownDocumentAcl) {
+        if (row.subject_kind !== "principal" || !subjects.has(row.subject)) {
+          continue;
+        }
+        const document = this.db.markdownDocuments.get(row.document_id);
+        if (!document) {
+          continue;
+        }
+        const rank = markdownDocumentScopeRank(row.scope);
+        const existing = byDocument.get(document.id);
+        if (!existing || rank > existing.scopeRank) {
+          byDocument.set(document.id, {
+            ...document,
+            scope: row.scope,
+            scopeRank: rank,
+          });
+        }
+      }
+
+      const limit = Number.isFinite(limitValue) ? limitValue : Number.POSITIVE_INFINITY;
+      return okResult(
+        [...byDocument.values()]
+          .sort(
+            (left, right) =>
+              right.updated_at.localeCompare(left.updated_at) ||
+              right.created_at.localeCompare(left.created_at) ||
+              right.id.localeCompare(left.id),
+          )
+          .slice(0, limit)
+          .map(({ scopeRank: _scopeRank, ...row }) => row) as T[],
+      );
+    }
+    if (this.query.includes("FROM markdown_document_acl")) {
+      const documentId = this.values[0] as string;
+      if (
+        !this.query.includes("subject_kind = 'principal'") &&
+        !this.query.includes("subject_kind = 'public'")
+      ) {
+        return okResult(
+          this.db.markdownDocumentAcl.filter((row) => row.document_id === documentId) as T[],
+        );
+      }
+      if (this.query.includes("subject_kind = 'principal'")) {
+        const principal = this.values[1] as string;
+        const linked = this.db.accountLinks.get(principal)?.canonical_principal;
+        const subjects = new Set([principal, ...(linked ? [linked] : [])]);
+        return okResult(
+          this.db.markdownDocumentAcl.filter(
+            (row) =>
+              row.document_id === documentId &&
+              row.subject_kind === "principal" &&
+              subjects.has(row.subject),
+          ) as T[],
+        );
+      }
+      if (this.query.includes("subject_kind = 'public'")) {
+        return okResult(
+          this.db.markdownDocumentAcl.filter(
+            (row) =>
+              row.document_id === documentId &&
+              row.subject_kind === "public" &&
+              row.subject === "anonymous",
+          ) as T[],
+        );
+      }
+    }
     if (this.query.includes("FROM notebook_acl")) {
       const notebookId = this.values[0] as string;
       if (
@@ -7511,6 +7889,14 @@ class FakeD1Statement implements D1PreparedStatement {
         this.db.revisions.filter((revision) => revision.notebook_id === notebookId) as T[],
       );
     }
+    if (this.query.includes("FROM markdown_document_revisions")) {
+      const documentId = this.values[0] as string;
+      return okResult(
+        this.db.markdownDocumentRevisions.filter(
+          (revision) => revision.document_id === documentId,
+        ) as T[],
+      );
+    }
     if (this.query.includes("FROM notebook_blobs")) {
       const notebookId = this.values[0] as string;
       return okResult(
@@ -7540,6 +7926,17 @@ function scopeRank(scope: NotebookAclRow["scope"]): number {
     case "editor":
       return 3;
     case "runtime_peer":
+      return 2;
+    case "viewer":
+      return 1;
+  }
+}
+
+function markdownDocumentScopeRank(scope: MarkdownDocumentAclRow["scope"]): number {
+  switch (scope) {
+    case "owner":
+      return 3;
+    case "editor":
       return 2;
     case "viewer":
       return 1;

--- a/apps/notebook-cloud/test/worker-routes.test.ts
+++ b/apps/notebook-cloud/test/worker-routes.test.ts
@@ -1786,6 +1786,131 @@ describe("Worker artifact routes", () => {
     assert.equal("runtime_snapshots" in body.document.endpoints, false);
   });
 
+  it("lets Markdown document owners manage principal ACL rows", async () => {
+    const env = fakeEnv();
+    env.DB.markdownDocuments.set("markdown-share", {
+      id: "markdown-share",
+      owner_principal: "user:dev:alice",
+      title: "Shared Markdown",
+      body_doc_id: "markdown-share",
+      created_at: "2026-06-15T00:00:00.000Z",
+      updated_at: "2026-06-15T00:00:00.000Z",
+      latest_revision_id: null,
+    });
+    env.DB.markdownDocumentAcl.push({
+      document_id: "markdown-share",
+      subject_kind: "principal",
+      subject: "user:dev:alice",
+      scope: "owner",
+      created_at: "2026-06-15T00:00:00.000Z",
+      updated_at: "2026-06-15T00:00:00.000Z",
+      created_by_actor_label: "user:dev:alice/browser:tab",
+    });
+
+    const before = await markdownAclRequest(env, "GET", undefined, "markdown-share");
+    assert.equal(before.status, 200);
+    const beforeBody = (await before.json()) as {
+      document_id: string;
+      acl: MarkdownDocumentAclRow[];
+    };
+    assert.equal(beforeBody.document_id, "markdown-share");
+    assert.deepEqual(
+      beforeBody.acl.map((row) => [row.subject_kind, row.subject, row.scope]),
+      [["principal", "user:dev:alice", "owner"]],
+    );
+
+    const grant = await markdownAclRequest(
+      env,
+      "POST",
+      {
+        subject_kind: "principal",
+        subject: "user:dev:bob",
+        scope: "editor",
+      },
+      "markdown-share",
+    );
+    assert.equal(grant.status, 201);
+    assert.equal(
+      env.DB.markdownDocumentAcl.some(
+        (row) =>
+          row.document_id === "markdown-share" &&
+          row.subject === "user:dev:bob" &&
+          row.scope === "editor",
+      ),
+      true,
+    );
+
+    const bobCatalog = await worker.fetch(
+      new Request("http://localhost/api/m/markdown-share?user=bob&operator=desktop:b&scope=editor"),
+      env,
+      fakeContext(),
+    );
+    assert.equal(bobCatalog.status, 200);
+
+    const revoke = await markdownAclRequest(
+      env,
+      "DELETE",
+      {
+        subject_kind: "principal",
+        subject: "user:dev:bob",
+        scope: "editor",
+      },
+      "markdown-share",
+    );
+    assert.equal(revoke.status, 200);
+    assert.equal(
+      env.DB.markdownDocumentAcl.some(
+        (row) =>
+          row.document_id === "markdown-share" &&
+          row.subject === "user:dev:bob" &&
+          row.scope === "editor",
+      ),
+      false,
+    );
+  });
+
+  it("rejects runtime peer ACL rows for Markdown documents", async () => {
+    const env = fakeEnv();
+    env.DB.markdownDocuments.set("markdown-no-runtime", {
+      id: "markdown-no-runtime",
+      owner_principal: "user:dev:alice",
+      title: "No Runtime",
+      body_doc_id: "markdown-no-runtime",
+      created_at: "2026-06-15T00:00:00.000Z",
+      updated_at: "2026-06-15T00:00:00.000Z",
+      latest_revision_id: null,
+    });
+    env.DB.markdownDocumentAcl.push({
+      document_id: "markdown-no-runtime",
+      subject_kind: "principal",
+      subject: "user:dev:alice",
+      scope: "owner",
+      created_at: "2026-06-15T00:00:00.000Z",
+      updated_at: "2026-06-15T00:00:00.000Z",
+      created_by_actor_label: "user:dev:alice/browser:tab",
+    });
+
+    const response = await markdownAclRequest(
+      env,
+      "POST",
+      {
+        subject_kind: "principal",
+        subject: "user:dev:runtime-service",
+        scope: "runtime_peer",
+      },
+      "markdown-no-runtime",
+    );
+
+    assert.equal(response.status, 400);
+    assert.deepEqual(await response.json(), {
+      error: "Markdown document ACL scope cannot be runtime_peer",
+    });
+    assert.equal(
+      env.DB.markdownDocumentAcl.some((row) => row.subject === "user:dev:runtime-service"),
+      false,
+    );
+  });
+
   it("routes hosted Markdown document sync through the Markdown room binding", async () => {
     const { env: oidcEnv, token } = await oidcTokenFixture({ subject: "markdown-ws-user" });
     let forwardedRequest: Request | undefined;
@@ -5874,6 +5999,34 @@ async function aclRequest(
 
   return worker.fetch(
     new Request(new URL(`/api/n/${notebookId}/acl`, "http://localhost"), init),
+    env,
+    fakeContext(),
+  );
+}
+
+async function markdownAclRequest(
+  env: FakeEnv,
+  method: "GET" | "POST" | "DELETE",
+  body: Record<string, unknown> | undefined,
+  documentId = "markdown-acl-demo",
+  headers: Record<string, string> = {},
+): Promise<Response> {
+  const init: RequestInit = {
+    method,
+    headers: {
+      "Content-Type": "application/json",
+      "X-User": "alice",
+      "X-Operator": "desktop:test",
+      "X-Scope": "owner",
+      ...headers,
+    },
+  };
+  if (body !== undefined) {
+    init.body = JSON.stringify(body);
+  }
+
+  return worker.fetch(
+    new Request(new URL(`/api/m/${documentId}/acl`, "http://localhost"), init),
     env,
     fakeContext(),
   );

--- a/apps/notebook-cloud/test/worker-routes.test.ts
+++ b/apps/notebook-cloud/test/worker-routes.test.ts
@@ -1823,6 +1823,35 @@ describe("Worker artifact routes", () => {
       updated_at: "2026-06-15T00:00:00.000Z",
       created_by_actor_label: "user:anaconda:markdown-bootstrap-user/browser:tab",
     });
+    const markdownSeedBody = "# Bootstrapped Markdown\n\nSeeded before live sync.";
+    const seedHandle = MarkdownHandle.create(
+      "markdown-bootstrap",
+      "Bootstrapped Markdown",
+      "user:anaconda:markdown-bootstrap-user/browser:seed",
+    );
+    seedHandle.replace_body_for_import(markdownSeedBody);
+    const snapshotBytes = seedHandle.save();
+    const bodyHeadsHash = await markdownTestHeadsDigest(seedHandle.get_heads_hex());
+    seedHandle.free();
+    const snapshotKey = markdownDocumentSnapshotKey("markdown-bootstrap", bodyHeadsHash);
+    await env.NOTEBOOK_SNAPSHOTS.put(snapshotKey, snapshotBytes, {
+      httpMetadata: {
+        contentType: "application/x-automerge",
+        cacheControl: "public, max-age=31536000, immutable",
+      },
+      customMetadata: {
+        document_id: "markdown-bootstrap",
+        body_heads_hash: bodyHeadsHash,
+      },
+    });
+    env.DB.markdownDocumentRevisions.push({
+      id: "markdown-revision-123",
+      document_id: "markdown-bootstrap",
+      body_heads_hash: bodyHeadsHash,
+      snapshot_key: snapshotKey,
+      actor_label: "user:anaconda:markdown-bootstrap-user/browser:seed",
+      created_at: "2026-06-15T00:30:00.000Z",
+    });
     const cookie = await oidcAppSessionCookie(env, token);
 
     const response = await worker.fetch(
@@ -1838,15 +1867,41 @@ describe("Worker artifact routes", () => {
       bootstrap?: {
         body_doc_id: string;
         latest_revision_id: string | null;
+        render_seed?: {
+          body: string;
+          body_heads_hash: string;
+          byte_length: number;
+          markdown_plan: {
+            anchors?: Array<{ title?: string; slug?: string }>;
+            source?: string;
+            version?: number;
+          } | null;
+          revision_id: string;
+          source: string;
+          title: string | null;
+        };
         scope: string;
         title: string | null;
         updated_at: string;
       } | null;
       session?: { provider: string; expires_at: number } | null;
     };
+    const renderSeed = config.bootstrap?.render_seed;
+    assert.equal(renderSeed?.markdown_plan?.version, 1);
+    assert.equal(renderSeed?.markdown_plan?.source, markdownSeedBody);
+    assert.equal(renderSeed?.markdown_plan?.anchors?.[0]?.title, "Bootstrapped Markdown");
     assert.deepEqual(config.bootstrap, {
       body_doc_id: "markdown-bootstrap-body",
       latest_revision_id: "markdown-revision-123",
+      render_seed: {
+        body: markdownSeedBody,
+        body_heads_hash: bodyHeadsHash,
+        byte_length: snapshotBytes.byteLength,
+        markdown_plan: renderSeed?.markdown_plan,
+        revision_id: "markdown-revision-123",
+        source: "latest_revision",
+        title: "Bootstrapped Markdown",
+      },
       scope: "owner",
       title: "Bootstrapped Markdown",
       updated_at: "2026-06-15T01:02:03.000Z",

--- a/apps/notebook-cloud/test/worker-routes.test.ts
+++ b/apps/notebook-cloud/test/worker-routes.test.ts
@@ -29,7 +29,11 @@ import type {
   R2ObjectBody,
   R2PutOptions,
 } from "../src/cloudflare-types.ts";
-import { initializeRuntimedWasm, RuntimeStatePeerHandle } from "../src/runtimed-wasm.ts";
+import {
+  initializeRuntimedWasm,
+  MarkdownHandle,
+  RuntimeStatePeerHandle,
+} from "../src/runtimed-wasm.ts";
 import {
   WORKSTATION_ATTACH_JOB_STALE_MS,
   blobKey,
@@ -37,12 +41,16 @@ import {
   createNotebookWithOwnerAcl,
   getNotebookAclRows,
   getNotebookAclRowsForPrincipal,
+  markdownDocumentSnapshotKey,
   runtimeStateSnapshotKey,
   snapshotKey,
 } from "../src/storage.ts";
 import type { PendingNotebookInviteRow, PrincipalProfileRow } from "../src/sharing-storage.ts";
 import { canonicalAccountPrincipalForProfile } from "../src/sharing-storage.ts";
-import type { PrincipalAccountLinkRow } from "../src/storage.ts";
+import type {
+  MarkdownDocumentAclRow as StorageMarkdownDocumentAclRow,
+  PrincipalAccountLinkRow,
+} from "../src/storage.ts";
 import type {
   WorkstationCredentialRow,
   WorkstationPairingCodeRow,
@@ -1811,7 +1819,7 @@ describe("Worker artifact routes", () => {
     assert.equal(before.status, 200);
     const beforeBody = (await before.json()) as {
       document_id: string;
-      acl: MarkdownDocumentAclRow[];
+      acl: StorageMarkdownDocumentAclRow[];
     };
     assert.equal(beforeBody.document_id, "markdown-share");
     assert.deepEqual(
@@ -1909,6 +1917,78 @@ describe("Worker artifact routes", () => {
       env.DB.markdownDocumentAcl.some((row) => row.subject === "user:dev:runtime-service"),
       false,
     );
+  });
+
+  it("lets Markdown document owners publish public snapshots", async () => {
+    const env = fakeEnv();
+    env.DB.markdownDocuments.set("markdown-publish", {
+      id: "markdown-publish",
+      owner_principal: "user:dev:alice",
+      title: "Published Markdown",
+      body_doc_id: "markdown-publish",
+      created_at: "2026-06-15T00:00:00.000Z",
+      updated_at: "2026-06-15T00:00:00.000Z",
+      latest_revision_id: null,
+    });
+    env.DB.markdownDocumentAcl.push({
+      document_id: "markdown-publish",
+      subject_kind: "principal",
+      subject: "user:dev:alice",
+      scope: "owner",
+      created_at: "2026-06-15T00:00:00.000Z",
+      updated_at: "2026-06-15T00:00:00.000Z",
+      created_by_actor_label: "user:dev:alice/browser:tab",
+    });
+
+    const handle = MarkdownHandle.create(
+      "markdown-publish",
+      "Published Markdown",
+      "user:dev:alice/browser:test",
+    );
+    handle.replace_body_for_import("# Published Markdown\n\nA public draft.");
+    const snapshotBytes = handle.save();
+    const bodyHeadsHash = await markdownTestHeadsDigest(handle.get_heads_hex());
+    handle.free();
+    const response = await ownerPut(
+      env,
+      `/api/m/markdown-publish/snapshots/${bodyHeadsHash}`,
+      snapshotBytes,
+    );
+
+    assert.equal(response.status, 201);
+    const body = (await response.json()) as {
+      ok: boolean;
+      revision_id: string;
+      key: string;
+      body_heads_hash: string;
+    };
+    assert.equal(body.ok, true);
+    assert.equal(body.body_heads_hash, bodyHeadsHash);
+    const key = markdownDocumentSnapshotKey("markdown-publish", bodyHeadsHash);
+    assert.equal(body.key, key);
+    assert.equal(env.NOTEBOOK_SNAPSHOTS.objects.has(key), true);
+    assert.equal(
+      env.DB.markdownDocuments.get("markdown-publish")?.latest_revision_id,
+      body.revision_id,
+    );
+    assert.equal(
+      env.DB.markdownDocumentAcl.some(
+        (row) =>
+          row.document_id === "markdown-publish" &&
+          row.subject_kind === "public" &&
+          row.subject === "anonymous" &&
+          row.scope === "viewer",
+      ),
+      true,
+    );
+
+    const anonymousRead = await worker.fetch(
+      new Request(`http://localhost/api/m/markdown-publish/snapshots/${bodyHeadsHash}`),
+      env,
+      fakeContext(),
+    );
+    assert.equal(anonymousRead.status, 200);
+    assert.deepEqual(new Uint8Array(await anonymousRead.arrayBuffer()), snapshotBytes);
   });
 
   it("routes hosted Markdown document sync through the Markdown room binding", async () => {
@@ -8268,6 +8348,14 @@ class FakeR2Object implements R2ObjectBody {
       headers.set("Content-Type", this.httpMetadata.contentType);
     }
   }
+}
+
+async function markdownTestHeadsDigest(heads: string[]): Promise<string> {
+  const input = heads.length > 0 ? [...heads].sort().join("\n") : "empty";
+  const digest = await crypto.subtle.digest("SHA-256", new TextEncoder().encode(input));
+  return `heads-${Array.from(new Uint8Array(digest), (byte) => byte.toString(16).padStart(2, "0"))
+    .join("")
+    .slice(0, 24)}`;
 }
 
 async function toBytes(

--- a/apps/notebook-cloud/test/worker-routes.test.ts
+++ b/apps/notebook-cloud/test/worker-routes.test.ts
@@ -1787,8 +1787,11 @@ describe("Worker artifact routes", () => {
   });
 
   it("routes hosted Markdown document sync through the Markdown room binding", async () => {
+    const { env: oidcEnv, token } = await oidcTokenFixture({ subject: "markdown-ws-user" });
     let forwardedRequest: Request | undefined;
     const env = fakeEnv({
+      ...oidcEnv,
+      NOTEBOOK_CLOUD_APP_SESSION_SECRET: APP_SESSION_SECRET,
       MARKDOWN_DOCUMENT_ROOMS: {
         idFromName: (name: string) => ({ toString: () => name }),
         get: () => ({
@@ -1801,7 +1804,7 @@ describe("Worker artifact routes", () => {
     });
     env.DB.markdownDocuments.set("markdown-sync", {
       id: "markdown-sync",
-      owner_principal: "user:dev:alice",
+      owner_principal: "user:anaconda:markdown-ws-user",
       title: "Synced Markdown",
       body_doc_id: "markdown-sync",
       created_at: "2026-06-15T00:00:00.000Z",
@@ -1811,21 +1814,21 @@ describe("Worker artifact routes", () => {
     env.DB.markdownDocumentAcl.push({
       document_id: "markdown-sync",
       subject_kind: "principal",
-      subject: "user:dev:alice",
+      subject: "user:anaconda:markdown-ws-user",
       scope: "editor",
       created_at: "2026-06-15T00:00:00.000Z",
       updated_at: "2026-06-15T00:00:00.000Z",
-      created_by_actor_label: "user:dev:alice/browser:tab",
+      created_by_actor_label: "user:anaconda:markdown-ws-user/browser:tab",
     });
+    const cookie = await oidcAppSessionCookie(env, token);
 
     const response = await worker.fetch(
       new Request("http://localhost/m/markdown-sync/sync?scope=editor", {
         headers: {
+          Cookie: cookie,
           Origin: "http://localhost",
+          "Sec-WebSocket-Protocol": NOTEBOOK_CLOUD_WEBSOCKET_PROTOCOL,
           Upgrade: "websocket",
-          "X-Operator": "browser:tab",
-          "X-Scope": "editor",
-          "X-User": "alice",
         },
       }),
       env,
@@ -1835,6 +1838,14 @@ describe("Worker artifact routes", () => {
     assert.equal(response.status, 200);
     assert.ok(forwardedRequest);
     assert.equal(new URL(forwardedRequest.url).pathname, "/m/markdown-sync/sync");
+    assert.equal(
+      forwardedRequest.headers.get("Sec-WebSocket-Protocol"),
+      NOTEBOOK_CLOUD_WEBSOCKET_PROTOCOL,
+    );
+    assert.equal(
+      forwardedRequest.headers.get(TRUSTED_WEBSOCKET_PROTOCOL_HEADER),
+      NOTEBOOK_CLOUD_WEBSOCKET_PROTOCOL,
+    );
     assert.equal(forwardedRequest.headers.get(TRUSTED_SCOPE_HEADER), "editor");
   });
 

--- a/apps/notebook-cloud/test/worker-routes.test.ts
+++ b/apps/notebook-cloud/test/worker-routes.test.ts
@@ -2095,7 +2095,7 @@ describe("Worker artifact routes", () => {
       document_id: "markdown-share-email",
       subject_kind: "principal",
       subject: "user:dev:bob",
-      scope: "viewer",
+      scope: "editor",
       created_at: "2026-06-15T00:00:00.000Z",
       updated_at: "2026-06-15T00:00:00.000Z",
       created_by_actor_label: "user:dev:alice/browser:tab",
@@ -2170,7 +2170,7 @@ describe("Worker artifact routes", () => {
         (row) =>
           row.document_id === "markdown-share-email" &&
           row.subject === "user:dev:bob" &&
-          row.scope === "viewer",
+          (row.scope === "viewer" || row.scope === "editor"),
       ),
       false,
     );

--- a/apps/notebook-cloud/test/worker-routes.test.ts
+++ b/apps/notebook-cloud/test/worker-routes.test.ts
@@ -1992,6 +1992,170 @@ describe("Worker artifact routes", () => {
     );
   });
 
+  it("lets Markdown document owners grant access by known verified email", async () => {
+    const env = fakeEnv();
+    const accountPrincipal = await canonicalAccountPrincipalForProfile({
+      provider: "dev",
+      principalNamespace: "user:dev",
+      email: "bob@example.com",
+      emailVerified: true,
+    });
+    assert.ok(accountPrincipal);
+    env.DB.markdownDocuments.set("markdown-share-email", {
+      id: "markdown-share-email",
+      owner_principal: "user:dev:alice",
+      title: "Shared Markdown",
+      body_doc_id: "markdown-share-email",
+      created_at: "2026-06-15T00:00:00.000Z",
+      updated_at: "2026-06-15T00:00:00.000Z",
+      latest_revision_id: null,
+    });
+    env.DB.markdownDocumentAcl.push({
+      document_id: "markdown-share-email",
+      subject_kind: "principal",
+      subject: "user:dev:alice",
+      scope: "owner",
+      created_at: "2026-06-15T00:00:00.000Z",
+      updated_at: "2026-06-15T00:00:00.000Z",
+      created_by_actor_label: "user:dev:alice/browser:tab",
+    });
+    env.DB.markdownDocumentAcl.push({
+      document_id: "markdown-share-email",
+      subject_kind: "principal",
+      subject: "user:dev:bob",
+      scope: "viewer",
+      created_at: "2026-06-15T00:00:00.000Z",
+      updated_at: "2026-06-15T00:00:00.000Z",
+      created_by_actor_label: "user:dev:alice/browser:tab",
+    });
+    env.DB.profiles.set("user:dev:bob", {
+      principal: "user:dev:bob",
+      provider: "dev",
+      provider_subject: "bob",
+      email_normalized: "bob@example.com",
+      email_verified: 1,
+      display_name: "Bob Example",
+      avatar_url: null,
+      first_seen_at: "2026-06-15T00:00:00.000Z",
+      last_seen_at: "2026-06-15T00:00:00.000Z",
+      raw_claims_json: null,
+    });
+    env.DB.profiles.set(accountPrincipal, {
+      principal: accountPrincipal,
+      provider: "dev",
+      provider_subject: null,
+      email_normalized: "bob@example.com",
+      email_verified: 1,
+      display_name: "Bob Example",
+      avatar_url: null,
+      first_seen_at: "2026-06-15T00:00:00.000Z",
+      last_seen_at: "2026-06-15T00:00:01.000Z",
+      raw_claims_json: null,
+    });
+    env.DB.accountLinks.set("user:dev:bob", {
+      transport_principal: "user:dev:bob",
+      canonical_principal: accountPrincipal,
+      provider: "dev",
+      email_normalized: "bob@example.com",
+      first_seen_at: "2026-06-15T00:00:00.000Z",
+      last_seen_at: "2026-06-15T00:00:00.000Z",
+    });
+
+    const grant = await markdownAclRequest(
+      env,
+      "POST",
+      {
+        subject_kind: "principal",
+        email: " Bob@Example.COM ",
+        scope: "viewer",
+      },
+      "markdown-share-email",
+    );
+
+    assert.equal(grant.status, 201);
+    const body = (await grant.json()) as {
+      acl: Array<StorageMarkdownDocumentAclRow & { display: Record<string, unknown> }>;
+    };
+    const bobRow = body.acl.find((row) => row.subject === accountPrincipal);
+    assert.equal(bobRow?.scope, "viewer");
+    assert.equal(bobRow?.display.email, "bob@example.com");
+    assert.equal(bobRow?.display.label, "Bob Example");
+    assert.equal(
+      body.acl.some((row) => row.subject === "user:dev:bob"),
+      false,
+    );
+    assert.equal(
+      env.DB.markdownDocumentAcl.some(
+        (row) =>
+          row.document_id === "markdown-share-email" &&
+          row.subject === accountPrincipal &&
+          row.scope === "viewer",
+      ),
+      true,
+    );
+    assert.equal(
+      env.DB.markdownDocumentAcl.some(
+        (row) =>
+          row.document_id === "markdown-share-email" &&
+          row.subject === "user:dev:bob" &&
+          row.scope === "viewer",
+      ),
+      false,
+    );
+
+    const bobCatalog = await worker.fetch(
+      new Request(
+        "http://localhost/api/m/markdown-share-email?user=bob&operator=desktop:b&scope=viewer",
+      ),
+      env,
+      fakeContext(),
+    );
+    assert.equal(bobCatalog.status, 200);
+  });
+
+  it("rejects Markdown document email grants for unknown recipients", async () => {
+    const env = fakeEnv();
+    env.DB.markdownDocuments.set("markdown-share-email-miss", {
+      id: "markdown-share-email-miss",
+      owner_principal: "user:dev:alice",
+      title: "Shared Markdown",
+      body_doc_id: "markdown-share-email-miss",
+      created_at: "2026-06-15T00:00:00.000Z",
+      updated_at: "2026-06-15T00:00:00.000Z",
+      latest_revision_id: null,
+    });
+    env.DB.markdownDocumentAcl.push({
+      document_id: "markdown-share-email-miss",
+      subject_kind: "principal",
+      subject: "user:dev:alice",
+      scope: "owner",
+      created_at: "2026-06-15T00:00:00.000Z",
+      updated_at: "2026-06-15T00:00:00.000Z",
+      created_by_actor_label: "user:dev:alice/browser:tab",
+    });
+
+    const grant = await markdownAclRequest(
+      env,
+      "POST",
+      {
+        subject_kind: "principal",
+        email: "missing@example.com",
+        scope: "viewer",
+      },
+      "markdown-share-email-miss",
+    );
+
+    assert.equal(grant.status, 404);
+    assert.deepEqual(await grant.json(), {
+      error:
+        "Markdown document email sharing currently requires the recipient to have signed in once.",
+    });
+    assert.equal(
+      env.DB.markdownDocumentAcl.some((row) => row.subject === "missing@example.com"),
+      false,
+    );
+  });
+
   it("rejects runtime peer ACL rows for Markdown documents", async () => {
     const env = fakeEnv();
     env.DB.markdownDocuments.set("markdown-no-runtime", {

--- a/apps/notebook-cloud/test/worker-routes.test.ts
+++ b/apps/notebook-cloud/test/worker-routes.test.ts
@@ -1794,6 +1794,66 @@ describe("Worker artifact routes", () => {
     assert.equal("runtime_snapshots" in body.document.endpoints, false);
   });
 
+  it("bootstraps Markdown document chrome from app-session catalog facts", async () => {
+    const { env: oidcEnv, token } = await oidcTokenFixture({
+      subject: "markdown-bootstrap-user",
+      email: "markdown-bootstrap@example.test",
+      extraPayload: { email_verified: true },
+      name: "Markdown Bootstrap User",
+    });
+    const env = fakeEnv({
+      ...oidcEnv,
+      NOTEBOOK_CLOUD_APP_SESSION_SECRET: APP_SESSION_SECRET,
+    });
+    env.DB.markdownDocuments.set("markdown-bootstrap", {
+      id: "markdown-bootstrap",
+      owner_principal: "user:anaconda:markdown-bootstrap-user",
+      title: "Bootstrapped Markdown",
+      body_doc_id: "markdown-bootstrap-body",
+      created_at: "2026-06-15T00:00:00.000Z",
+      updated_at: "2026-06-15T01:02:03.000Z",
+      latest_revision_id: "markdown-revision-123",
+    });
+    env.DB.markdownDocumentAcl.push({
+      document_id: "markdown-bootstrap",
+      subject_kind: "principal",
+      subject: "user:anaconda:markdown-bootstrap-user",
+      scope: "owner",
+      created_at: "2026-06-15T00:00:00.000Z",
+      updated_at: "2026-06-15T00:00:00.000Z",
+      created_by_actor_label: "user:anaconda:markdown-bootstrap-user/browser:tab",
+    });
+    const cookie = await oidcAppSessionCookie(env, token);
+
+    const response = await worker.fetch(
+      new Request("https://cloud.test/m/markdown-bootstrap/Bootstrapped%20Markdown", {
+        headers: { Cookie: cookie },
+      }),
+      env,
+      fakeContext(),
+    );
+
+    assert.equal(response.status, 200);
+    const config = notebookViewerConfig(await response.text()) as {
+      bootstrap?: {
+        body_doc_id: string;
+        latest_revision_id: string | null;
+        scope: string;
+        title: string | null;
+        updated_at: string;
+      } | null;
+      session?: { provider: string; expires_at: number } | null;
+    };
+    assert.deepEqual(config.bootstrap, {
+      body_doc_id: "markdown-bootstrap-body",
+      latest_revision_id: "markdown-revision-123",
+      scope: "owner",
+      title: "Bootstrapped Markdown",
+      updated_at: "2026-06-15T01:02:03.000Z",
+    });
+    assert.equal(config.session?.provider, "oidc");
+  });
+
   it("lets Markdown document owners manage principal ACL rows", async () => {
     const env = fakeEnv();
     env.DB.markdownDocuments.set("markdown-share", {

--- a/apps/notebook-cloud/viewer/__tests__/use-cloud-app-session-status.test.tsx
+++ b/apps/notebook-cloud/viewer/__tests__/use-cloud-app-session-status.test.tsx
@@ -29,6 +29,7 @@ describe("useCloudAppSessionStatus", () => {
   const session = (overrides: Partial<CloudAppSession> = {}): CloudAppSession => ({
     provider: "oidc",
     expires_at: 4_000_000_000,
+    cache_key: "cache-a",
     ...overrides,
   });
 

--- a/apps/notebook-cloud/viewer/app-session.ts
+++ b/apps/notebook-cloud/viewer/app-session.ts
@@ -4,6 +4,7 @@ import type { CloudOidcTokenState } from "./oidc-auth";
 export const CLOUD_APP_SESSION_ENDPOINT = "/api/auth/session";
 
 export interface CloudAppSession {
+  cache_key: string;
   provider: "oidc";
   expires_at: number;
 }
@@ -92,8 +93,12 @@ export function isCloudAppSession(value: unknown): value is CloudAppSession {
   const candidate = value as Partial<CloudAppSession>;
   return (
     candidate.provider === "oidc" &&
+    typeof candidate.cache_key === "string" &&
+    candidate.cache_key.length > 0 &&
     Number.isFinite(candidate.expires_at) &&
-    Object.keys(candidate).every((key) => key === "provider" || key === "expires_at")
+    Object.keys(candidate).every(
+      (key) => key === "provider" || key === "expires_at" || key === "cache_key",
+    )
   );
 }
 

--- a/apps/notebook-cloud/viewer/cloud-access-request-state.ts
+++ b/apps/notebook-cloud/viewer/cloud-access-request-state.ts
@@ -42,6 +42,10 @@ export interface CloudEditModeFallbackProjectionInput {
   selectedMode: CloudNotebookUrlMode;
 }
 
+export interface CloudCatalogBootstrapProjectionInput {
+  catalogRefreshVersion: number;
+}
+
 const NO_CLOUD_ACCESS_REQUEST_TRANSITION: CloudAccessRequestTransition = Object.freeze({
   requestedScope: null,
   selectedMode: null,
@@ -131,6 +135,12 @@ export function shouldFallbackCloudEditUrlToView({
   return (
     selectedMode === "edit" && catalogResolved && !catalogGrantsDocumentEdit && !editAccessRequested
   );
+}
+
+export function shouldUseCloudCatalogBootstrap({
+  catalogRefreshVersion,
+}: CloudCatalogBootstrapProjectionInput): boolean {
+  return catalogRefreshVersion === 0;
 }
 
 export function projectCloudAccessRequestNotice({

--- a/apps/notebook-cloud/viewer/cloud-access-request-state.ts
+++ b/apps/notebook-cloud/viewer/cloud-access-request-state.ts
@@ -134,10 +134,12 @@ export function shouldFallbackCloudEditUrlToView({
 }
 
 export function projectCloudAccessRequestNotice({
+  documentLabel = "notebook",
   error,
   request,
   selectedMode,
 }: {
+  documentLabel?: string;
   error: string | null;
   request: Pick<CloudNotebookAccessRequest, "status"> | null;
   selectedMode: CloudNotebookUrlMode;
@@ -178,7 +180,7 @@ export function projectCloudAccessRequestNotice({
       kind: "denied",
       tone: "warning",
       title: "Edit request denied.",
-      message: "The notebook stays in view mode.",
+      message: `The ${documentLabel} stays in view mode.`,
     };
   }
 

--- a/apps/notebook-cloud/viewer/cloud-auth-controls.tsx
+++ b/apps/notebook-cloud/viewer/cloud-auth-controls.tsx
@@ -23,10 +23,12 @@ export function cloudNotebookSignInLabel(authConfig: CloudViewerAuthConfig): str
 export function CloudNotebookSignInButton({
   authConfig,
   authState,
+  documentLabel = "notebook",
   idleLabel,
 }: {
   authConfig: CloudViewerAuthConfig;
   authState: CloudPrototypeAuthState;
+  documentLabel?: string;
   idleLabel?: string;
 }) {
   const [authAction, setAuthAction] = useState<"idle" | "starting">("idle");
@@ -41,7 +43,7 @@ export function CloudNotebookSignInButton({
   if (!useLocalDevAuth && !useOidcAuth) {
     return null;
   }
-  const copy = cloudNotebookSignInCopy(authState, authAction, error);
+  const copy = cloudNotebookSignInCopy(authState, authAction, error, documentLabel);
   const label =
     authAction === "idle" && !error
       ? (idleLabel ?? cloudNotebookSignInLabel(authConfig))

--- a/apps/notebook-cloud/viewer/cloud-hosted-document-signed-out.tsx
+++ b/apps/notebook-cloud/viewer/cloud-hosted-document-signed-out.tsx
@@ -1,0 +1,44 @@
+import { ArrowUpRight, Sparkles } from "lucide-react";
+import type { CloudPrototypeAuthState } from "./collaborator-auth";
+import { CloudNotebookSignInButton } from "./cloud-auth-controls";
+import type { CloudViewerAuthConfig } from "./cloud-viewer-types";
+
+export function CloudHostedDocumentSignedOutPanel({
+  authConfig,
+  authState,
+  cloudDescription,
+  cloudTitle,
+  localDescription,
+  localTitle,
+}: {
+  authConfig: CloudViewerAuthConfig;
+  authState: CloudPrototypeAuthState;
+  cloudDescription: string;
+  cloudTitle: string;
+  localDescription: string;
+  localTitle: string;
+}) {
+  const localMode = Boolean(authConfig.localDev);
+  const title = localMode ? localTitle : cloudTitle;
+  const description = localMode ? localDescription : cloudDescription;
+
+  return (
+    <div className="cloud-notebook-signed-out" aria-labelledby="cloud-document-signed-out-title">
+      <div className="cloud-notebook-signed-out-copy">
+        <div className="cloud-notebook-signed-out-kicker">
+          <Sparkles aria-hidden="true" />
+          {localMode ? "LOCAL MODE" : "NTERACT"}
+        </div>
+        <h2 id="cloud-document-signed-out-title">{title}</h2>
+        <p>{description}</p>
+      </div>
+      <div className="cloud-notebook-signed-out-actions">
+        <CloudNotebookSignInButton authConfig={authConfig} authState={authState} />
+        <a href="https://nteract.io/" target="_blank" rel="noreferrer">
+          Visit nteract.io
+          <ArrowUpRight aria-hidden="true" />
+        </a>
+      </div>
+    </div>
+  );
+}

--- a/apps/notebook-cloud/viewer/cloud-notebook-title-state.ts
+++ b/apps/notebook-cloud/viewer/cloud-notebook-title-state.ts
@@ -75,11 +75,19 @@ export function cloudNotebookCatalogResponseTitle(
   throw new Error("Unable to load notebook title: response shape was invalid");
 }
 
-export function cloudNotebookUrlAfterRename(currentHref: string, viewerUrl: string): string {
+export function cloudDocumentUrlAfterRename({
+  currentHref,
+  routePrefix,
+  viewerUrl,
+}: {
+  currentHref: string;
+  routePrefix: "/n" | "/m";
+  viewerUrl: string;
+}): string {
   try {
     const currentUrl = new URL(currentHref);
     const renamedUrl = new URL(viewerUrl, currentUrl.origin);
-    if (!renamedUrl.pathname.startsWith("/n/")) {
+    if (!renamedUrl.pathname.startsWith(`${routePrefix}/`)) {
       return currentHref;
     }
     currentUrl.pathname = renamedUrl.pathname;
@@ -87,4 +95,8 @@ export function cloudNotebookUrlAfterRename(currentHref: string, viewerUrl: stri
   } catch {
     return currentHref;
   }
+}
+
+export function cloudNotebookUrlAfterRename(currentHref: string, viewerUrl: string): string {
+  return cloudDocumentUrlAfterRename({ currentHref, viewerUrl, routePrefix: "/n" });
 }

--- a/apps/notebook-cloud/viewer/cloud-notebook-title.tsx
+++ b/apps/notebook-cloud/viewer/cloud-notebook-title.tsx
@@ -1,5 +1,5 @@
 import { House } from "lucide-react";
-import { DocumentTitle } from "@/components/notebook";
+import { DocumentTitle } from "@/components/notebook/DocumentTitle";
 import {
   cloudNotebookRouteTitleFromPathname,
   type CloudNotebookTitleDisplay,

--- a/apps/notebook-cloud/viewer/cloud-notebook-title.tsx
+++ b/apps/notebook-cloud/viewer/cloud-notebook-title.tsx
@@ -1,5 +1,5 @@
-import { useEffect, useState, type FormEvent } from "react";
-import { Check, House, Loader2, PencilLine, X } from "lucide-react";
+import { House } from "lucide-react";
+import { DocumentTitle } from "@/components/notebook";
 import {
   cloudNotebookRouteTitleFromPathname,
   type CloudNotebookTitleDisplay,
@@ -20,111 +20,37 @@ export function CloudNotebookTitle({
   title: CloudNotebookTitleDisplay;
   onRename?: (title: string) => boolean | Promise<boolean>;
 }) {
-  const [editing, setEditing] = useState(false);
-  const [draftTitle, setDraftTitle] = useState(renameTitle);
-
-  useEffect(() => {
-    if (!editing) {
-      setDraftTitle(renameTitle);
-    }
-  }, [editing, renameTitle]);
-
-  const saveRename = (event: FormEvent<HTMLFormElement>) => {
-    event.preventDefault();
-    if (!onRename || renameSaving) {
-      return;
-    }
-    void Promise.resolve(onRename(draftTitle))
-      .then((saved) => {
-        if (saved) {
-          setEditing(false);
-        }
-      })
-      .catch(() => {});
-  };
-
-  const cancelRename = () => {
-    if (renameSaving) {
-      return;
-    }
-    setDraftTitle(renameTitle);
-    setEditing(false);
-  };
-
   return (
-    <div className="cloud-notebook-title-group">
-      <a
-        className="cloud-notebook-home-link"
-        href="/n"
-        aria-label="Open notebooks dashboard"
-        title="Notebooks"
-      >
-        <House aria-hidden="true" />
-      </a>
-      <div className="cloud-notebook-title" title={renameError ?? title.title}>
-        {editing ? (
-          <form className="cloud-notebook-title-form" onSubmit={saveRename}>
-            <input
-              aria-label="Notebook title"
-              autoFocus
-              disabled={renameSaving}
-              maxLength={160}
-              name="notebook-title"
-              placeholder="Untitled notebook"
-              type="text"
-              value={draftTitle}
-              onChange={(event) => setDraftTitle(event.currentTarget.value)}
-            />
-            <button
-              type="submit"
-              disabled={renameSaving}
-              title="Save title"
-              aria-label="Save title"
-            >
-              {renameSaving ? (
-                <Loader2 className="cloud-notebook-title-spinner" aria-hidden="true" />
-              ) : (
-                <Check aria-hidden="true" />
-              )}
-            </button>
-            <button
-              type="button"
-              disabled={renameSaving}
-              title="Cancel rename"
-              aria-label="Cancel rename"
-              onClick={cancelRename}
-            >
-              <X aria-hidden="true" />
-            </button>
-          </form>
-        ) : (
-          <div className="cloud-notebook-title-static">
-            <span>{title.label}</span>
-            {canRename && onRename ? (
-              <button
-                type="button"
-                className="cloud-notebook-title-edit-button"
-                disabled={renameSaving}
-                title="Rename notebook"
-                aria-label={`Rename ${title.label}`}
-                onClick={() => setEditing(true)}
-              >
-                <PencilLine aria-hidden="true" />
-              </button>
-            ) : null}
-          </div>
-        )}
-        {renameError ? (
-          <small className="cloud-notebook-title-status" role="status">
-            {renameError}
-          </small>
-        ) : title.detail ? (
-          <small>{title.detail}</small>
-        ) : null}
-      </div>
-    </div>
+    <DocumentTitle
+      title={title}
+      renameTitle={renameTitle}
+      canRename={canRename}
+      renameSaving={renameSaving}
+      renameError={renameError}
+      onRename={onRename}
+      homeHref="/n"
+      homeAriaLabel="Open notebooks dashboard"
+      homeTitle="Notebooks"
+      homeIcon={<House aria-hidden="true" />}
+      inputAriaLabel="Notebook title"
+      inputName="notebook-title"
+      placeholder="Untitled notebook"
+      renameButtonTitle="Rename notebook"
+      classNames={cloudNotebookTitleClassNames}
+    />
   );
 }
+
+export const cloudNotebookTitleClassNames = {
+  group: "cloud-notebook-title-group",
+  homeLink: "cloud-notebook-home-link",
+  title: "cloud-notebook-title",
+  staticTitle: "cloud-notebook-title-static",
+  form: "cloud-notebook-title-form",
+  editButton: "cloud-notebook-title-edit-button",
+  status: "cloud-notebook-title-status",
+  spinner: "cloud-notebook-title-spinner",
+};
 
 export function cloudNotebookRouteTitle(): CloudNotebookTitleDisplay {
   return cloudNotebookRouteTitleFromPathname(window.location.pathname);

--- a/apps/notebook-cloud/viewer/cloud-viewer-config.ts
+++ b/apps/notebook-cloud/viewer/cloud-viewer-config.ts
@@ -124,7 +124,6 @@ export function loadMarkdownDocumentConfig(): CloudMarkdownDocumentConfig | null
       !parsed.aclEndpoint ||
       !parsed.invitesEndpoint ||
       !parsed.accessRequestsEndpoint ||
-      !parsed.snapshotBasePath ||
       !parsed.syncEndpoint ||
       !parsed.runtimedWasmModulePath ||
       !parsed.runtimedWasmPath
@@ -138,7 +137,6 @@ export function loadMarkdownDocumentConfig(): CloudMarkdownDocumentConfig | null
       aclEndpoint: parsed.aclEndpoint,
       invitesEndpoint: parsed.invitesEndpoint,
       accessRequestsEndpoint: parsed.accessRequestsEndpoint,
-      snapshotBasePath: parsed.snapshotBasePath,
       syncEndpoint: parsed.syncEndpoint,
       runtimedWasmModulePath: parsed.runtimedWasmModulePath,
       runtimedWasmPath: parsed.runtimedWasmPath,
@@ -146,7 +144,6 @@ export function loadMarkdownDocumentConfig(): CloudMarkdownDocumentConfig | null
       session: isCloudAppSession(parsed.session) ? parsed.session : null,
       hostCapabilities: {
         canManageSharing: Boolean(parsed.hostCapabilities?.canManageSharing),
-        canPublish: Boolean(parsed.hostCapabilities?.canPublish),
       },
     };
   } catch {

--- a/apps/notebook-cloud/viewer/cloud-viewer-config.ts
+++ b/apps/notebook-cloud/viewer/cloud-viewer-config.ts
@@ -1,8 +1,11 @@
 import { isCloudAppSession } from "./app-session";
 import type { CloudRendererAssetNames, CloudViewerConfig } from "./cloud-viewer-session";
+import { isCloudMarkdownDocumentListItem } from "./markdown-document-dashboard";
 import { isCloudNotebookListItem } from "./notebook-dashboard";
 import { normalizeOidcAuthConfig, type CloudOidcAuthConfig } from "./oidc-auth";
 import type {
+  CloudMarkdownDocumentConfig,
+  CloudMarkdownDocumentListBootstrap,
   CloudNotebookListBootstrap,
   CloudViewerAuthConfig,
   CloudViewerLocalDevAuthConfig,
@@ -106,6 +109,41 @@ export function loadViewerRuntime(): ViewerRuntimeState {
   }
 }
 
+export function loadMarkdownDocumentConfig(): CloudMarkdownDocumentConfig | null {
+  const element = document.querySelector<HTMLScriptElement>("#nteract-cloud-viewer-config");
+  if (!element) {
+    return null;
+  }
+  try {
+    const parsed = JSON.parse(element.textContent ?? "{}") as Partial<CloudMarkdownDocumentConfig>;
+    if (
+      parsed.documentKind !== "markdown" ||
+      !parsed.documentId ||
+      !parsed.catalogEndpoint ||
+      !parsed.snapshotBasePath ||
+      !parsed.runtimedWasmModulePath ||
+      !parsed.runtimedWasmPath
+    ) {
+      return null;
+    }
+    return {
+      documentKind: "markdown",
+      documentId: parsed.documentId,
+      catalogEndpoint: parsed.catalogEndpoint,
+      snapshotBasePath: parsed.snapshotBasePath,
+      runtimedWasmModulePath: parsed.runtimedWasmModulePath,
+      runtimedWasmPath: parsed.runtimedWasmPath,
+      session: isCloudAppSession(parsed.session) ? parsed.session : null,
+      hostCapabilities: {
+        canManageSharing: Boolean(parsed.hostCapabilities?.canManageSharing),
+        canPublish: Boolean(parsed.hostCapabilities?.canPublish),
+      },
+    };
+  } catch {
+    return null;
+  }
+}
+
 export function loadAuthConfig(): CloudViewerAuthConfig {
   const element = document.querySelector<HTMLScriptElement>("#nteract-cloud-auth-config");
   if (!element) {
@@ -163,6 +201,22 @@ export function loadCloudNotebookListBootstrap(): CloudNotebookListBootstrap | n
   return null;
 }
 
+export function loadCloudMarkdownDocumentListBootstrap(): CloudMarkdownDocumentListBootstrap | null {
+  const element = document.querySelector<HTMLScriptElement>("#nteract-cloud-bootstrap");
+  if (!element) {
+    return null;
+  }
+  try {
+    const parsed = JSON.parse(element.textContent ?? "{}") as unknown;
+    if (isCloudMarkdownDocumentListBootstrap(parsed)) {
+      return parsed;
+    }
+  } catch {
+    return null;
+  }
+  return null;
+}
+
 export function isOidcCallbackPath(): boolean {
   return window.location.pathname.replace(/\/+$/, "") === "/oidc";
 }
@@ -176,6 +230,14 @@ export function isNotebookListPath(): boolean {
   return window.location.pathname.replace(/\/+$/, "") === "/n";
 }
 
+export function isMarkdownDocumentListPath(): boolean {
+  return window.location.pathname.replace(/\/+$/, "") === "/m";
+}
+
+export function isMarkdownDocumentRoutePath(): boolean {
+  return /^\/m\/[^/]+(?:\/.*)?\/?$/.test(window.location.pathname);
+}
+
 function isCloudNotebookListBootstrap(value: unknown): value is CloudNotebookListBootstrap {
   if (!value || typeof value !== "object") {
     return false;
@@ -186,6 +248,24 @@ function isCloudNotebookListBootstrap(value: unknown): value is CloudNotebookLis
     typeof candidate.saved_at === "string" &&
     Array.isArray(candidate.notebooks) &&
     candidate.notebooks.every(isCloudNotebookListItem) &&
+    (candidate.session === undefined ||
+      candidate.session === null ||
+      isCloudAppSession(candidate.session))
+  );
+}
+
+function isCloudMarkdownDocumentListBootstrap(
+  value: unknown,
+): value is CloudMarkdownDocumentListBootstrap {
+  if (!value || typeof value !== "object") {
+    return false;
+  }
+  const candidate = value as Partial<CloudMarkdownDocumentListBootstrap>;
+  return (
+    candidate.kind === "markdown-document-list" &&
+    typeof candidate.saved_at === "string" &&
+    Array.isArray(candidate.documents) &&
+    candidate.documents.every(isCloudMarkdownDocumentListItem) &&
     (candidate.session === undefined ||
       candidate.session === null ||
       isCloudAppSession(candidate.session))

--- a/apps/notebook-cloud/viewer/cloud-viewer-config.ts
+++ b/apps/notebook-cloud/viewer/cloud-viewer-config.ts
@@ -4,6 +4,7 @@ import { isCloudMarkdownDocumentListItem } from "./markdown-document-dashboard";
 import { isCloudNotebookListItem } from "./notebook-dashboard";
 import { normalizeOidcAuthConfig, type CloudOidcAuthConfig } from "./oidc-auth";
 import type {
+  CloudMarkdownDocumentBootstrap,
   CloudMarkdownDocumentConfig,
   CloudMarkdownDocumentListBootstrap,
   CloudNotebookListBootstrap,
@@ -137,6 +138,7 @@ export function loadMarkdownDocumentConfig(): CloudMarkdownDocumentConfig | null
       syncEndpoint: parsed.syncEndpoint,
       runtimedWasmModulePath: parsed.runtimedWasmModulePath,
       runtimedWasmPath: parsed.runtimedWasmPath,
+      bootstrap: isCloudMarkdownDocumentBootstrap(parsed.bootstrap) ? parsed.bootstrap : null,
       session: isCloudAppSession(parsed.session) ? parsed.session : null,
       hostCapabilities: {
         canManageSharing: Boolean(parsed.hostCapabilities?.canManageSharing),
@@ -240,6 +242,20 @@ export function isMarkdownDocumentListPath(): boolean {
 
 export function isMarkdownDocumentRoutePath(): boolean {
   return /^\/m\/[^/]+(?:\/.*)?\/?$/.test(window.location.pathname);
+}
+
+function isCloudMarkdownDocumentBootstrap(value: unknown): value is CloudMarkdownDocumentBootstrap {
+  if (!value || typeof value !== "object") {
+    return false;
+  }
+  const candidate = value as Partial<CloudMarkdownDocumentBootstrap>;
+  return (
+    typeof candidate.body_doc_id === "string" &&
+    typeof candidate.updated_at === "string" &&
+    (candidate.title === null || typeof candidate.title === "string") &&
+    (candidate.scope === "owner" || candidate.scope === "editor" || candidate.scope === "viewer") &&
+    (candidate.latest_revision_id === null || typeof candidate.latest_revision_id === "string")
+  );
 }
 
 function isCloudNotebookListBootstrap(value: unknown): value is CloudNotebookListBootstrap {

--- a/apps/notebook-cloud/viewer/cloud-viewer-config.ts
+++ b/apps/notebook-cloud/viewer/cloud-viewer-config.ts
@@ -224,25 +224,25 @@ export function loadCloudMarkdownDocumentListBootstrap(): CloudMarkdownDocumentL
   return null;
 }
 
-export function isOidcCallbackPath(): boolean {
-  return window.location.pathname.replace(/\/+$/, "") === "/oidc";
+export function isOidcCallbackPath(pathname = window.location.pathname): boolean {
+  return pathname.replace(/\/+$/, "") === "/oidc";
 }
 
-export function isHomePath(): boolean {
-  const pathname = window.location.pathname.replace(/\/+$/, "");
-  return pathname === "" || pathname === "/index.html";
+export function isHomePath(pathname = window.location.pathname): boolean {
+  const normalized = pathname.replace(/\/+$/, "");
+  return normalized === "" || normalized === "/index.html";
 }
 
-export function isNotebookListPath(): boolean {
-  return window.location.pathname.replace(/\/+$/, "") === "/n";
+export function isNotebookListPath(pathname = window.location.pathname): boolean {
+  return pathname.replace(/\/+$/, "") === "/n";
 }
 
-export function isMarkdownDocumentListPath(): boolean {
-  return window.location.pathname.replace(/\/+$/, "") === "/m";
+export function isMarkdownDocumentListPath(pathname = window.location.pathname): boolean {
+  return pathname.replace(/\/+$/, "") === "/m";
 }
 
-export function isMarkdownDocumentRoutePath(): boolean {
-  return /^\/m\/[^/]+(?:\/.*)?\/?$/.test(window.location.pathname);
+export function isMarkdownDocumentRoutePath(pathname = window.location.pathname): boolean {
+  return /^\/m\/[^/]+(?:\/.*)?\/?$/.test(pathname);
 }
 
 function isCloudMarkdownDocumentBootstrap(value: unknown): value is CloudMarkdownDocumentBootstrap {

--- a/apps/notebook-cloud/viewer/cloud-viewer-config.ts
+++ b/apps/notebook-cloud/viewer/cloud-viewer-config.ts
@@ -120,6 +120,7 @@ export function loadMarkdownDocumentConfig(): CloudMarkdownDocumentConfig | null
       parsed.documentKind !== "markdown" ||
       !parsed.documentId ||
       !parsed.catalogEndpoint ||
+      !parsed.aclEndpoint ||
       !parsed.snapshotBasePath ||
       !parsed.syncEndpoint ||
       !parsed.runtimedWasmModulePath ||
@@ -131,6 +132,7 @@ export function loadMarkdownDocumentConfig(): CloudMarkdownDocumentConfig | null
       documentKind: "markdown",
       documentId: parsed.documentId,
       catalogEndpoint: parsed.catalogEndpoint,
+      aclEndpoint: parsed.aclEndpoint,
       snapshotBasePath: parsed.snapshotBasePath,
       syncEndpoint: parsed.syncEndpoint,
       runtimedWasmModulePath: parsed.runtimedWasmModulePath,

--- a/apps/notebook-cloud/viewer/cloud-viewer-config.ts
+++ b/apps/notebook-cloud/viewer/cloud-viewer-config.ts
@@ -122,6 +122,8 @@ export function loadMarkdownDocumentConfig(): CloudMarkdownDocumentConfig | null
       !parsed.documentId ||
       !parsed.catalogEndpoint ||
       !parsed.aclEndpoint ||
+      !parsed.invitesEndpoint ||
+      !parsed.accessRequestsEndpoint ||
       !parsed.snapshotBasePath ||
       !parsed.syncEndpoint ||
       !parsed.runtimedWasmModulePath ||
@@ -134,6 +136,8 @@ export function loadMarkdownDocumentConfig(): CloudMarkdownDocumentConfig | null
       documentId: parsed.documentId,
       catalogEndpoint: parsed.catalogEndpoint,
       aclEndpoint: parsed.aclEndpoint,
+      invitesEndpoint: parsed.invitesEndpoint,
+      accessRequestsEndpoint: parsed.accessRequestsEndpoint,
       snapshotBasePath: parsed.snapshotBasePath,
       syncEndpoint: parsed.syncEndpoint,
       runtimedWasmModulePath: parsed.runtimedWasmModulePath,

--- a/apps/notebook-cloud/viewer/cloud-viewer-config.ts
+++ b/apps/notebook-cloud/viewer/cloud-viewer-config.ts
@@ -121,6 +121,7 @@ export function loadMarkdownDocumentConfig(): CloudMarkdownDocumentConfig | null
       !parsed.documentId ||
       !parsed.catalogEndpoint ||
       !parsed.snapshotBasePath ||
+      !parsed.syncEndpoint ||
       !parsed.runtimedWasmModulePath ||
       !parsed.runtimedWasmPath
     ) {
@@ -131,6 +132,7 @@ export function loadMarkdownDocumentConfig(): CloudMarkdownDocumentConfig | null
       documentId: parsed.documentId,
       catalogEndpoint: parsed.catalogEndpoint,
       snapshotBasePath: parsed.snapshotBasePath,
+      syncEndpoint: parsed.syncEndpoint,
       runtimedWasmModulePath: parsed.runtimedWasmModulePath,
       runtimedWasmPath: parsed.runtimedWasmPath,
       session: isCloudAppSession(parsed.session) ? parsed.session : null,

--- a/apps/notebook-cloud/viewer/cloud-viewer-navigation.ts
+++ b/apps/notebook-cloud/viewer/cloud-viewer-navigation.ts
@@ -1,0 +1,22 @@
+export const CLOUD_VIEWER_ROUTE_CHANGE_EVENT = "nteract-cloud-viewer-route-change";
+
+export function navigateCloudViewer(url: string): void {
+  window.history.pushState(null, "", url);
+  window.dispatchEvent(new Event(CLOUD_VIEWER_ROUTE_CHANGE_EVENT));
+}
+
+export function shouldHandleCloudViewerLinkClick(
+  event: Pick<
+    MouseEvent,
+    "button" | "defaultPrevented" | "metaKey" | "altKey" | "ctrlKey" | "shiftKey"
+  >,
+): boolean {
+  return (
+    !event.defaultPrevented &&
+    event.button === 0 &&
+    !event.metaKey &&
+    !event.altKey &&
+    !event.ctrlKey &&
+    !event.shiftKey
+  );
+}

--- a/apps/notebook-cloud/viewer/cloud-viewer-types.ts
+++ b/apps/notebook-cloud/viewer/cloud-viewer-types.ts
@@ -87,7 +87,6 @@ export interface CloudMarkdownDocumentConfig {
   aclEndpoint: string;
   invitesEndpoint: string;
   accessRequestsEndpoint: string;
-  snapshotBasePath: string;
   syncEndpoint: string;
   runtimedWasmModulePath: string;
   runtimedWasmPath: string;
@@ -95,7 +94,6 @@ export interface CloudMarkdownDocumentConfig {
   session?: CloudAppSession | null;
   hostCapabilities?: {
     canManageSharing?: boolean;
-    canPublish?: boolean;
   };
 }
 

--- a/apps/notebook-cloud/viewer/cloud-viewer-types.ts
+++ b/apps/notebook-cloud/viewer/cloud-viewer-types.ts
@@ -65,6 +65,7 @@ export interface CloudMarkdownDocumentConfig {
   documentId: string;
   catalogEndpoint: string;
   snapshotBasePath: string;
+  syncEndpoint: string;
   runtimedWasmModulePath: string;
   runtimedWasmPath: string;
   session?: CloudAppSession | null;

--- a/apps/notebook-cloud/viewer/cloud-viewer-types.ts
+++ b/apps/notebook-cloud/viewer/cloud-viewer-types.ts
@@ -3,6 +3,7 @@ import type { CloudViewerConfig } from "./cloud-viewer-session";
 import type { CloudMarkdownDocumentListItem } from "./markdown-document-dashboard";
 import type { CloudNotebookListItem } from "./notebook-dashboard";
 import type { CloudOidcAuthConfig } from "./oidc-auth";
+import type { MarkdownProjectionPlan } from "@/lib/markdown-projection";
 
 export interface CloudViewerAuthConfig {
   oidc: CloudOidcAuthConfig | null;
@@ -63,9 +64,20 @@ export interface CloudMarkdownDocumentUpdateResponse {
 export interface CloudMarkdownDocumentBootstrap {
   body_doc_id: string;
   latest_revision_id: string | null;
+  render_seed?: CloudMarkdownDocumentRenderSeed | null;
   scope: "owner" | "editor" | "viewer";
   title: string | null;
   updated_at: string;
+}
+
+export interface CloudMarkdownDocumentRenderSeed {
+  source: "latest_revision";
+  revision_id: string;
+  body_heads_hash: string;
+  byte_length: number;
+  title: string | null;
+  body: string;
+  markdown_plan: MarkdownProjectionPlan | null;
 }
 
 export interface CloudMarkdownDocumentConfig {

--- a/apps/notebook-cloud/viewer/cloud-viewer-types.ts
+++ b/apps/notebook-cloud/viewer/cloud-viewer-types.ts
@@ -60,6 +60,14 @@ export interface CloudMarkdownDocumentUpdateResponse {
   viewer_url?: string;
 }
 
+export interface CloudMarkdownDocumentBootstrap {
+  body_doc_id: string;
+  latest_revision_id: string | null;
+  scope: "owner" | "editor" | "viewer";
+  title: string | null;
+  updated_at: string;
+}
+
 export interface CloudMarkdownDocumentConfig {
   documentKind: "markdown";
   documentId: string;
@@ -69,6 +77,7 @@ export interface CloudMarkdownDocumentConfig {
   syncEndpoint: string;
   runtimedWasmModulePath: string;
   runtimedWasmPath: string;
+  bootstrap?: CloudMarkdownDocumentBootstrap | null;
   session?: CloudAppSession | null;
   hostCapabilities?: {
     canManageSharing?: boolean;

--- a/apps/notebook-cloud/viewer/cloud-viewer-types.ts
+++ b/apps/notebook-cloud/viewer/cloud-viewer-types.ts
@@ -64,6 +64,7 @@ export interface CloudMarkdownDocumentConfig {
   documentKind: "markdown";
   documentId: string;
   catalogEndpoint: string;
+  aclEndpoint: string;
   snapshotBasePath: string;
   syncEndpoint: string;
   runtimedWasmModulePath: string;

--- a/apps/notebook-cloud/viewer/cloud-viewer-types.ts
+++ b/apps/notebook-cloud/viewer/cloud-viewer-types.ts
@@ -1,5 +1,6 @@
 import type { CloudAppSession } from "./app-session";
 import type { CloudViewerConfig } from "./cloud-viewer-session";
+import type { CloudMarkdownDocumentListItem } from "./markdown-document-dashboard";
 import type { CloudNotebookListItem } from "./notebook-dashboard";
 import type { CloudOidcAuthConfig } from "./oidc-auth";
 
@@ -31,6 +32,46 @@ export interface CloudNotebookListBootstrap {
   notebooks: CloudNotebookListItem[];
   saved_at: string;
   session?: CloudAppSession | null;
+}
+
+export interface CloudMarkdownDocumentListResponse {
+  ok: boolean;
+  documents: CloudMarkdownDocumentListItem[];
+}
+
+export interface CloudMarkdownDocumentListBootstrap {
+  kind: "markdown-document-list";
+  documents: CloudMarkdownDocumentListItem[];
+  saved_at: string;
+  session?: CloudAppSession | null;
+}
+
+export interface CloudMarkdownDocumentCreateResponse {
+  ok: boolean;
+  title?: string | null;
+  viewer_url?: string;
+}
+
+export interface CloudMarkdownDocumentUpdateResponse {
+  ok: boolean;
+  document_id?: string;
+  title?: string | null;
+  updated_at?: string;
+  viewer_url?: string;
+}
+
+export interface CloudMarkdownDocumentConfig {
+  documentKind: "markdown";
+  documentId: string;
+  catalogEndpoint: string;
+  snapshotBasePath: string;
+  runtimedWasmModulePath: string;
+  runtimedWasmPath: string;
+  session?: CloudAppSession | null;
+  hostCapabilities?: {
+    canManageSharing?: boolean;
+    canPublish?: boolean;
+  };
 }
 
 export interface CloudNotebookCreateResponse {

--- a/apps/notebook-cloud/viewer/cloud-viewer-types.ts
+++ b/apps/notebook-cloud/viewer/cloud-viewer-types.ts
@@ -85,6 +85,8 @@ export interface CloudMarkdownDocumentConfig {
   documentId: string;
   catalogEndpoint: string;
   aclEndpoint: string;
+  invitesEndpoint: string;
+  accessRequestsEndpoint: string;
   snapshotBasePath: string;
   syncEndpoint: string;
   runtimedWasmModulePath: string;

--- a/apps/notebook-cloud/viewer/collaborator-auth.ts
+++ b/apps/notebook-cloud/viewer/collaborator-auth.ts
@@ -372,6 +372,7 @@ export function cloudNotebookSignInCopy(
   state: CloudPrototypeAuthState,
   action: CloudNotebookSignInAction,
   error: string | null = null,
+  documentLabel = "notebook",
 ): CloudNotebookSignInCopy {
   if (error) {
     return {
@@ -388,7 +389,7 @@ export function cloudNotebookSignInCopy(
   if (state.mode === "oidc_expired") {
     return {
       label: "Sign in again",
-      title: "Renew your sign-in for this notebook",
+      title: `Renew your sign-in for this ${documentLabel}`,
     };
   }
   if (state.mode === "invalid") {

--- a/apps/notebook-cloud/viewer/home-view.tsx
+++ b/apps/notebook-cloud/viewer/home-view.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useState } from "react";
 import {
   ArrowUpRight,
+  FileText,
   KeyRound,
   LogIn,
   LogOut,
@@ -149,6 +150,10 @@ export function CloudHomeView({ authConfig }: { authConfig: CloudViewerAuthConfi
 
           <div className="cloud-home-actions">
             <a href="/n">View notebooks</a>
+            <a href="/m">
+              View Markdown docs
+              <FileText aria-hidden="true" />
+            </a>
             <a href="https://nteract.io/" target="_blank" rel="noreferrer">
               Visit nteract.io
               <ArrowUpRight aria-hidden="true" />

--- a/apps/notebook-cloud/viewer/hosted-document-auth.ts
+++ b/apps/notebook-cloud/viewer/hosted-document-auth.ts
@@ -1,0 +1,48 @@
+import type { CloudAppSession } from "./app-session";
+import {
+  cloudBrowserCanUseAuthenticatedApi,
+  shouldShowCloudHeaderSignIn,
+  type CloudPrototypeAuthState,
+} from "./collaborator-auth";
+
+export interface HostedDocumentAuthProjection {
+  appSessionLoading: boolean;
+  canFetchCatalog: boolean;
+  hasAppSession: boolean;
+  hasExplicitAuth: boolean;
+  showSignIn: boolean;
+  signedIn: boolean;
+  waitingForAppSession: boolean;
+}
+
+export function projectHostedDocumentAuthState(
+  authState: CloudPrototypeAuthState,
+  options: {
+    appSession?: CloudAppSession | null;
+    appSessionLoading?: boolean;
+  } = {},
+): HostedDocumentAuthProjection {
+  const appSessionLoading = options.appSessionLoading === true;
+  const hasAppSession = Boolean(options.appSession);
+  const hasExplicitAuth = authState.mode === "dev" || authState.mode === "oidc";
+  const signedIn = hasExplicitAuth || hasAppSession;
+  const canFetchCatalog = cloudBrowserCanUseAuthenticatedApi({
+    authState,
+    hasAppSession,
+  });
+  const waitingForAppSession = appSessionLoading || (authState.mode === "oidc" && !hasAppSession);
+  const showSignIn = shouldShowCloudHeaderSignIn(authState, {
+    appSessionLoading,
+    hasAppSession,
+  });
+
+  return {
+    appSessionLoading,
+    canFetchCatalog,
+    hasAppSession,
+    hasExplicitAuth,
+    showSignIn,
+    signedIn,
+    waitingForAppSession,
+  };
+}

--- a/apps/notebook-cloud/viewer/hosted-document-list-cache.ts
+++ b/apps/notebook-cloud/viewer/hosted-document-list-cache.ts
@@ -1,0 +1,99 @@
+import type { CloudPrototypeAuthState } from "./collaborator-auth";
+
+export const CLOUD_HOSTED_DOCUMENT_LIST_CACHE_TTL_MS = 10 * 60 * 1000;
+
+export interface HostedDocumentListCacheStorage {
+  getItem(key: string): string | null;
+  removeItem(key: string): void;
+  setItem(key: string, value: string): void;
+}
+
+export interface HostedDocumentListCacheConfig<T> {
+  isItem: (value: unknown) => value is T;
+  itemsKey: string;
+  storageKey: string;
+}
+
+interface CachedHostedDocumentList {
+  authKey: string;
+  savedAt: number;
+  [key: string]: unknown;
+}
+
+export function readCachedHostedDocumentList<T>(
+  storage: Pick<HostedDocumentListCacheStorage, "getItem">,
+  authState: CloudPrototypeAuthState,
+  config: HostedDocumentListCacheConfig<T>,
+  now = Date.now(),
+): T[] | null {
+  const authKey = cloudHostedDocumentListCacheAuthKey(authState);
+  if (!authKey) {
+    return null;
+  }
+
+  const raw = storage.getItem(config.storageKey);
+  if (!raw) {
+    return null;
+  }
+
+  let parsed: Partial<CachedHostedDocumentList>;
+  try {
+    parsed = JSON.parse(raw) as Partial<CachedHostedDocumentList>;
+  } catch {
+    return null;
+  }
+
+  const items = parsed[config.itemsKey];
+  if (
+    parsed.authKey !== authKey ||
+    !Number.isFinite(parsed.savedAt) ||
+    now - Number(parsed.savedAt) > CLOUD_HOSTED_DOCUMENT_LIST_CACHE_TTL_MS ||
+    !Array.isArray(items) ||
+    !items.every(config.isItem)
+  ) {
+    return null;
+  }
+
+  return items;
+}
+
+export function writeCachedHostedDocumentList<T>(
+  storage: Pick<HostedDocumentListCacheStorage, "setItem">,
+  authState: CloudPrototypeAuthState,
+  items: T[],
+  config: HostedDocumentListCacheConfig<T>,
+  now = Date.now(),
+): void {
+  const authKey = cloudHostedDocumentListCacheAuthKey(authState);
+  if (!authKey) {
+    return;
+  }
+
+  storage.setItem(
+    config.storageKey,
+    JSON.stringify({
+      authKey,
+      [config.itemsKey]: items,
+      savedAt: now,
+    }),
+  );
+}
+
+export function clearCachedHostedDocumentList(
+  storage: Pick<HostedDocumentListCacheStorage, "removeItem">,
+  storageKey: string,
+): void {
+  storage.removeItem(storageKey);
+}
+
+export function cloudHostedDocumentListCacheAuthKey(
+  authState: CloudPrototypeAuthState,
+): string | null {
+  if (authState.mode === "oidc" && authState.oidcClaims?.sub) {
+    return `oidc:${authState.oidcClaims.sub}`;
+  }
+  if (authState.mode === "dev" && authState.user) {
+    return `dev:${authState.user}`;
+  }
+  return null;
+}

--- a/apps/notebook-cloud/viewer/hosted-document-list-cache.ts
+++ b/apps/notebook-cloud/viewer/hosted-document-list-cache.ts
@@ -1,4 +1,5 @@
 import type { CloudPrototypeAuthState } from "./collaborator-auth";
+import type { CloudAppSession } from "./app-session";
 
 export const CLOUD_HOSTED_DOCUMENT_LIST_CACHE_TTL_MS = 10 * 60 * 1000;
 
@@ -23,10 +24,11 @@ interface CachedHostedDocumentList {
 export function readCachedHostedDocumentList<T>(
   storage: Pick<HostedDocumentListCacheStorage, "getItem">,
   authState: CloudPrototypeAuthState,
+  appSession: CloudAppSession | null | undefined,
   config: HostedDocumentListCacheConfig<T>,
   now = Date.now(),
 ): T[] | null {
-  const authKey = cloudHostedDocumentListCacheAuthKey(authState);
+  const authKey = cloudHostedDocumentListCacheAuthKey(authState, appSession);
   if (!authKey) {
     return null;
   }
@@ -60,11 +62,12 @@ export function readCachedHostedDocumentList<T>(
 export function writeCachedHostedDocumentList<T>(
   storage: Pick<HostedDocumentListCacheStorage, "setItem">,
   authState: CloudPrototypeAuthState,
+  appSession: CloudAppSession | null | undefined,
   items: T[],
   config: HostedDocumentListCacheConfig<T>,
   now = Date.now(),
 ): void {
-  const authKey = cloudHostedDocumentListCacheAuthKey(authState);
+  const authKey = cloudHostedDocumentListCacheAuthKey(authState, appSession);
   if (!authKey) {
     return;
   }
@@ -88,7 +91,11 @@ export function clearCachedHostedDocumentList(
 
 export function cloudHostedDocumentListCacheAuthKey(
   authState: CloudPrototypeAuthState,
+  appSession?: CloudAppSession | null,
 ): string | null {
+  if (appSession?.cache_key) {
+    return `app-session:${appSession.cache_key}`;
+  }
   if (authState.mode === "oidc" && authState.oidcClaims?.sub) {
     return `oidc:${authState.oidcClaims.sub}`;
   }

--- a/apps/notebook-cloud/viewer/index.css
+++ b/apps/notebook-cloud/viewer/index.css
@@ -2140,52 +2140,6 @@ body {
   }
 }
 
-.cloud-dashboard-shell {
-  display: grid;
-  align-content: start;
-  justify-items: center;
-  gap: 1rem;
-  min-height: 100vh;
-  padding: clamp(1rem, 4vw, 2rem);
-  background: var(--background);
-  color: var(--foreground);
-}
-
-.cloud-dashboard-header {
-  display: flex;
-  align-items: end;
-  justify-content: space-between;
-  gap: 1rem;
-  width: min(100%, 56rem);
-}
-
-.cloud-dashboard-header h1,
-.cloud-dashboard-header p {
-  margin: 0;
-}
-
-.cloud-dashboard-header h1 {
-  margin-top: 0.25rem;
-  font-size: clamp(2rem, 5vw, 3.5rem);
-  font-weight: 740;
-  letter-spacing: 0;
-  line-height: 1;
-}
-
-.cloud-dashboard-header p,
-.cloud-dashboard-eyebrow {
-  color: color-mix(in srgb, var(--foreground) 62%, transparent);
-  font-size: 0.875rem;
-  line-height: 1.35;
-}
-
-.cloud-dashboard-actions {
-  display: flex;
-  flex-wrap: wrap;
-  justify-content: flex-end;
-  gap: 0.5rem;
-}
-
 .cloud-document-list {
   display: grid;
   gap: 0.5rem;
@@ -2232,75 +2186,6 @@ body {
   line-height: 1.25;
 }
 
-.cloud-dashboard-create {
-  display: grid;
-  gap: 0.75rem;
-  width: min(100%, 36rem);
-  border: 1px solid color-mix(in srgb, var(--foreground) 12%, transparent);
-  border-radius: 8px;
-  padding: 0.875rem;
-  background: color-mix(in srgb, var(--background) 94%, var(--foreground) 6%);
-}
-
-.cloud-dashboard-create label {
-  display: grid;
-  gap: 0.25rem;
-  color: color-mix(in srgb, var(--foreground) 65%, transparent);
-  font-size: 0.75rem;
-}
-
-.cloud-dashboard-create input {
-  min-height: 2.25rem;
-  border: 1px solid color-mix(in srgb, var(--foreground) 16%, transparent);
-  border-radius: 6px;
-  padding: 0 0.625rem;
-  background: var(--background);
-  color: var(--foreground);
-  font: inherit;
-}
-
-.cloud-dashboard-create-actions {
-  display: flex;
-  flex-wrap: wrap;
-  gap: 0.5rem;
-  justify-content: flex-end;
-}
-
-.cloud-dashboard-create-actions button,
-.cloud-dashboard-button,
-.cloud-dashboard-secondary-action {
-  display: inline-flex;
-  gap: 0.375rem;
-  align-items: center;
-  justify-content: center;
-  min-height: 2.25rem;
-  border: 1px solid color-mix(in srgb, var(--foreground) 14%, transparent);
-  border-radius: 6px;
-  padding: 0 0.75rem;
-  background: color-mix(in srgb, var(--background) 96%, var(--foreground) 4%);
-  color: var(--foreground);
-  font: inherit;
-  font-size: 0.8125rem;
-  font-weight: 620;
-  text-decoration: none;
-}
-
-.cloud-dashboard-create-actions button:hover,
-.cloud-dashboard-button:hover,
-.cloud-dashboard-secondary-action:hover {
-  background: color-mix(in srgb, var(--background) 88%, var(--foreground) 10%);
-}
-
-.cloud-dashboard-button svg,
-.cloud-dashboard-secondary-action svg {
-  width: 0.9375rem;
-  height: 0.9375rem;
-}
-
-.cloud-dashboard-secondary-action {
-  width: fit-content;
-}
-
 .cloud-markdown-shell {
   background: var(--background);
   color: var(--foreground);
@@ -2328,15 +2213,6 @@ body {
 }
 
 @media (max-width: 599.98px) {
-  .cloud-dashboard-header {
-    display: grid;
-    align-items: start;
-  }
-
-  .cloud-dashboard-actions {
-    justify-content: flex-start;
-  }
-
   .cloud-markdown-room-toolbar [data-slot="notebook-document-header-presence"] {
     flex-basis: auto;
     max-width: none;

--- a/apps/notebook-cloud/viewer/index.css
+++ b/apps/notebook-cloud/viewer/index.css
@@ -2120,3 +2120,231 @@ body {
     display: inline;
   }
 }
+
+.cloud-document-list {
+  display: grid;
+  gap: 0.5rem;
+  width: min(100%, 56rem);
+}
+
+.cloud-document-row {
+  display: grid;
+  grid-template-columns: auto minmax(0, 1fr);
+  gap: 0.75rem;
+  align-items: center;
+  border-top: 1px solid color-mix(in srgb, var(--foreground) 10%, transparent);
+  padding: 0.875rem 0;
+  color: inherit;
+  text-decoration: none;
+}
+
+.cloud-document-row svg {
+  color: color-mix(in srgb, var(--foreground) 55%, transparent);
+}
+
+.cloud-document-row span {
+  display: grid;
+  gap: 0.125rem;
+  min-width: 0;
+}
+
+.cloud-document-row strong,
+.cloud-document-row small {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.cloud-document-row strong {
+  font-size: 0.9375rem;
+  font-weight: 650;
+  line-height: 1.25;
+}
+
+.cloud-document-row small {
+  color: color-mix(in srgb, var(--foreground) 56%, transparent);
+  font-size: 0.75rem;
+  line-height: 1.25;
+}
+
+.cloud-dashboard-create {
+  display: grid;
+  gap: 0.75rem;
+  width: min(100%, 36rem);
+  border: 1px solid color-mix(in srgb, var(--foreground) 12%, transparent);
+  border-radius: 8px;
+  padding: 0.875rem;
+  background: color-mix(in srgb, var(--background) 94%, var(--foreground) 6%);
+}
+
+.cloud-dashboard-create label {
+  display: grid;
+  gap: 0.25rem;
+  color: color-mix(in srgb, var(--foreground) 65%, transparent);
+  font-size: 0.75rem;
+}
+
+.cloud-dashboard-create input {
+  min-height: 2.25rem;
+  border: 1px solid color-mix(in srgb, var(--foreground) 16%, transparent);
+  border-radius: 6px;
+  padding: 0 0.625rem;
+  background: var(--background);
+  color: var(--foreground);
+  font: inherit;
+}
+
+.cloud-dashboard-create-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+  justify-content: flex-end;
+}
+
+.cloud-dashboard-create-actions button,
+.cloud-dashboard-button,
+.cloud-dashboard-secondary-action,
+.cloud-markdown-toolbar-actions button {
+  display: inline-flex;
+  gap: 0.375rem;
+  align-items: center;
+  justify-content: center;
+  min-height: 2.25rem;
+  border: 1px solid color-mix(in srgb, var(--foreground) 14%, transparent);
+  border-radius: 6px;
+  padding: 0 0.75rem;
+  background: color-mix(in srgb, var(--background) 96%, var(--foreground) 4%);
+  color: var(--foreground);
+  font: inherit;
+  font-size: 0.8125rem;
+  font-weight: 620;
+}
+
+.cloud-dashboard-secondary-action {
+  width: fit-content;
+}
+
+.cloud-markdown-shell {
+  display: grid;
+  grid-template-rows: auto auto minmax(0, 1fr);
+  min-height: 100vh;
+  background: var(--background);
+  color: var(--foreground);
+}
+
+.cloud-markdown-toolbar {
+  display: grid;
+  grid-template-columns: auto minmax(0, 1fr) auto;
+  gap: 0.75rem;
+  align-items: center;
+  border-bottom: 1px solid color-mix(in srgb, var(--foreground) 10%, transparent);
+  padding: 0.75rem 1rem;
+}
+
+.cloud-markdown-toolbar h1,
+.cloud-markdown-toolbar p {
+  margin: 0;
+}
+
+.cloud-markdown-toolbar h1 {
+  overflow: hidden;
+  font-size: 1rem;
+  font-weight: 700;
+  line-height: 1.25;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.cloud-markdown-home-link {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 2.25rem;
+  height: 2.25rem;
+  border: 1px solid color-mix(in srgb, var(--foreground) 12%, transparent);
+  border-radius: 6px;
+  color: inherit;
+}
+
+.cloud-markdown-toolbar-actions {
+  display: inline-flex;
+  gap: 0.375rem;
+}
+
+.cloud-markdown-toolbar-actions button[aria-pressed="true"] {
+  border-color: color-mix(in srgb, var(--foreground) 28%, transparent);
+  background: color-mix(in srgb, var(--foreground) 9%, var(--background));
+}
+
+.cloud-markdown-notice {
+  border-bottom: 1px solid color-mix(in srgb, #b45309 18%, transparent);
+  padding: 0.5rem 1rem;
+  color: color-mix(in srgb, #92400e 78%, var(--foreground));
+  background: color-mix(in srgb, #f59e0b 8%, var(--background));
+  font-size: 0.8125rem;
+  line-height: 1.4;
+}
+
+.cloud-markdown-workspace {
+  display: grid;
+  grid-template-columns: minmax(13rem, 16rem) minmax(0, 1fr);
+  min-height: 0;
+}
+
+.cloud-markdown-rail {
+  min-height: 0;
+  border-right: 1px solid color-mix(in srgb, var(--foreground) 10%, transparent);
+  padding: 0.75rem;
+  overflow: auto;
+}
+
+.cloud-markdown-rail-title {
+  display: flex;
+  gap: 0.375rem;
+  align-items: center;
+  margin-bottom: 0.5rem;
+  color: color-mix(in srgb, var(--foreground) 62%, transparent);
+  font-size: 0.75rem;
+  font-weight: 700;
+  text-transform: uppercase;
+}
+
+.cloud-markdown-stage {
+  min-width: 0;
+  min-height: 0;
+  overflow: auto;
+  padding: clamp(1rem, 3vw, 2rem);
+}
+
+.cloud-markdown-editor,
+.cloud-markdown-preview {
+  width: min(100%, 52rem);
+  margin: 0 auto;
+}
+
+.cloud-markdown-editor {
+  border: 1px solid color-mix(in srgb, var(--foreground) 12%, transparent);
+  border-radius: 8px;
+  overflow: hidden;
+}
+
+@media (max-width: 760px) {
+  .cloud-markdown-toolbar {
+    grid-template-columns: auto minmax(0, 1fr);
+  }
+
+  .cloud-markdown-toolbar-actions {
+    grid-column: 1 / -1;
+    justify-self: start;
+  }
+
+  .cloud-markdown-workspace {
+    grid-template-columns: 1fr;
+  }
+
+  .cloud-markdown-rail {
+    max-height: 14rem;
+    border-right: 0;
+    border-bottom: 1px solid color-mix(in srgb, var(--foreground) 10%, transparent);
+  }
+}

--- a/apps/notebook-cloud/viewer/index.css
+++ b/apps/notebook-cloud/viewer/index.css
@@ -303,16 +303,18 @@ body {
   height: 1.125rem;
 }
 
-.cloud-notebook-title-static,
 .cloud-notebook-title-form {
-  display: flex;
+  --document-title-action-size: 1.625rem;
+  --document-title-action-gap: 0.25rem;
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto;
   min-width: 0;
   max-width: 100%;
   align-items: center;
   gap: 0.375rem;
 }
 
-.cloud-notebook-title span,
+.cloud-notebook-title [data-slot="document-title-label"],
 .cloud-notebook-title small {
   min-width: 0;
   overflow: hidden;
@@ -320,7 +322,13 @@ body {
   white-space: nowrap;
 }
 
-.cloud-notebook-title span {
+.cloud-notebook-title [data-slot="document-title-label"] {
+  display: inline-flex;
+  align-items: center;
+  min-height: 1.875rem;
+  border: 1px solid transparent;
+  border-radius: 6px;
+  padding: 0.1875rem 0.5rem;
   color: var(--foreground);
   font-size: 0.9375rem;
   font-weight: 650;
@@ -339,14 +347,23 @@ body {
   color: color-mix(in srgb, var(--destructive) 72%, var(--foreground) 28%);
 }
 
+.cloud-notebook-title [data-slot="document-title-actions"] {
+  display: inline-flex;
+  flex: 0 0 auto;
+  align-items: center;
+  justify-content: flex-start;
+  gap: var(--document-title-action-gap);
+  width: calc(var(--document-title-action-size) * 2 + var(--document-title-action-gap));
+}
+
 .cloud-notebook-title-edit-button,
 .cloud-notebook-title-form button {
   display: inline-flex;
   flex: 0 0 auto;
   align-items: center;
   justify-content: center;
-  width: 1.625rem;
-  height: 1.625rem;
+  width: var(--document-title-action-size);
+  height: var(--document-title-action-size);
   border: 0;
   border-radius: 6px;
   color: color-mix(in srgb, var(--foreground) 64%, transparent);
@@ -381,26 +398,23 @@ body {
 
 .cloud-notebook-title-form [contenteditable="true"],
 .cloud-notebook-title-form input {
-  min-width: 7rem;
-  width: min(18rem, 32vw);
-  max-width: min(100%, 32rem);
-  min-height: 1.875rem;
   border: 1px solid color-mix(in srgb, var(--foreground) 18%, transparent);
-  border-radius: 6px;
-  padding: 0.1875rem 0.5rem;
-  color: var(--foreground);
   background: color-mix(in srgb, var(--background) 94%, var(--foreground) 6%);
-  font-size: 0.875rem;
-  font-weight: 600;
-  line-height: 1.35;
   overflow: hidden;
   text-overflow: clip;
-  white-space: normal;
+  white-space: nowrap;
 }
 
 .cloud-notebook-title-form [contenteditable="true"]:empty::before {
   content: attr(data-placeholder);
   color: color-mix(in srgb, var(--foreground) 42%, transparent);
+}
+
+.cloud-notebook-title-action-placeholder {
+  display: inline-flex;
+  flex: 0 0 auto;
+  width: var(--document-title-action-size);
+  height: var(--document-title-action-size);
 }
 
 .cloud-notebook-title-spinner {
@@ -535,11 +549,6 @@ body {
     gap: 0.5rem;
   }
 
-  .cloud-notebook-title-form input {
-    min-width: 6rem;
-    width: min(12rem, 28vw);
-  }
-
   .cloud-notebook-title small {
     display: none;
   }
@@ -557,18 +566,14 @@ body {
   }
 
   .cloud-notebook-title-form {
+    --document-title-action-size: 1.5rem;
     gap: 0.25rem;
-  }
-
-  .cloud-notebook-title-form input {
-    min-width: 5.5rem;
-    width: min(9rem, 34vw);
   }
 
   .cloud-notebook-title-edit-button,
   .cloud-notebook-title-form button {
-    width: 1.5rem;
-    height: 1.5rem;
+    width: var(--document-title-action-size);
+    height: var(--document-title-action-size);
   }
 
   .cloud-room-toolbar [data-slot="notebook-document-header-controls"] {

--- a/apps/notebook-cloud/viewer/index.css
+++ b/apps/notebook-cloud/viewer/index.css
@@ -361,6 +361,7 @@ body {
 
 .cloud-notebook-title-edit-button:focus-visible,
 .cloud-notebook-title-form button:focus-visible,
+.cloud-notebook-title-form [contenteditable="true"]:focus-visible,
 .cloud-notebook-title-form input:focus-visible {
   outline: 2px solid color-mix(in srgb, var(--ring) 70%, transparent);
   outline-offset: 2px;
@@ -378,18 +379,28 @@ body {
   height: 0.9375rem;
 }
 
+.cloud-notebook-title-form [contenteditable="true"],
 .cloud-notebook-title-form input {
   min-width: 7rem;
   width: min(18rem, 32vw);
-  max-width: 100%;
-  height: 1.875rem;
+  max-width: min(100%, 32rem);
+  min-height: 1.875rem;
   border: 1px solid color-mix(in srgb, var(--foreground) 18%, transparent);
   border-radius: 6px;
-  padding: 0 0.5rem;
+  padding: 0.1875rem 0.5rem;
   color: var(--foreground);
   background: color-mix(in srgb, var(--background) 94%, var(--foreground) 6%);
   font-size: 0.875rem;
   font-weight: 600;
+  line-height: 1.35;
+  overflow: hidden;
+  text-overflow: clip;
+  white-space: normal;
+}
+
+.cloud-notebook-title-form [contenteditable="true"]:empty::before {
+  content: attr(data-placeholder);
+  color: color-mix(in srgb, var(--foreground) 42%, transparent);
 }
 
 .cloud-notebook-title-spinner {
@@ -719,6 +730,7 @@ body {
   gap: 0.5rem;
 }
 
+.cloud-notebook-list-actions a,
 .cloud-notebook-list-actions button,
 .cloud-notebook-list-actions .cloud-sign-in-button {
   display: inline-flex;
@@ -732,8 +744,10 @@ body {
   color: var(--foreground);
   background: color-mix(in srgb, var(--background) 94%, var(--foreground) 6%);
   font-size: 0.875rem;
+  text-decoration: none;
 }
 
+.cloud-notebook-list-actions a:hover,
 .cloud-notebook-list-actions button:hover,
 .cloud-notebook-list-actions .cloud-sign-in-button:hover {
   background: color-mix(in srgb, var(--background) 86%, var(--foreground) 10%);
@@ -2121,6 +2135,52 @@ body {
   }
 }
 
+.cloud-dashboard-shell {
+  display: grid;
+  align-content: start;
+  justify-items: center;
+  gap: 1rem;
+  min-height: 100vh;
+  padding: clamp(1rem, 4vw, 2rem);
+  background: var(--background);
+  color: var(--foreground);
+}
+
+.cloud-dashboard-header {
+  display: flex;
+  align-items: end;
+  justify-content: space-between;
+  gap: 1rem;
+  width: min(100%, 56rem);
+}
+
+.cloud-dashboard-header h1,
+.cloud-dashboard-header p {
+  margin: 0;
+}
+
+.cloud-dashboard-header h1 {
+  margin-top: 0.25rem;
+  font-size: clamp(2rem, 5vw, 3.5rem);
+  font-weight: 740;
+  letter-spacing: 0;
+  line-height: 1;
+}
+
+.cloud-dashboard-header p,
+.cloud-dashboard-eyebrow {
+  color: color-mix(in srgb, var(--foreground) 62%, transparent);
+  font-size: 0.875rem;
+  line-height: 1.35;
+}
+
+.cloud-dashboard-actions {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: flex-end;
+  gap: 0.5rem;
+}
+
 .cloud-document-list {
   display: grid;
   gap: 0.5rem;
@@ -2217,6 +2277,19 @@ body {
   font: inherit;
   font-size: 0.8125rem;
   font-weight: 620;
+  text-decoration: none;
+}
+
+.cloud-dashboard-create-actions button:hover,
+.cloud-dashboard-button:hover,
+.cloud-dashboard-secondary-action:hover {
+  background: color-mix(in srgb, var(--background) 88%, var(--foreground) 10%);
+}
+
+.cloud-dashboard-button svg,
+.cloud-dashboard-secondary-action svg {
+  width: 0.9375rem;
+  height: 0.9375rem;
 }
 
 .cloud-dashboard-secondary-action {
@@ -2250,6 +2323,15 @@ body {
 }
 
 @media (max-width: 599.98px) {
+  .cloud-dashboard-header {
+    display: grid;
+    align-items: start;
+  }
+
+  .cloud-dashboard-actions {
+    justify-content: flex-start;
+  }
+
   .cloud-markdown-room-toolbar [data-slot="notebook-document-header-presence"] {
     flex-basis: auto;
     max-width: none;

--- a/apps/notebook-cloud/viewer/index.css
+++ b/apps/notebook-cloud/viewer/index.css
@@ -2204,7 +2204,7 @@ body {
 .cloud-dashboard-create-actions button,
 .cloud-dashboard-button,
 .cloud-dashboard-secondary-action,
-.cloud-markdown-toolbar-actions button {
+.cloud-markdown-toolbar-actions > button {
   display: inline-flex;
   gap: 0.375rem;
   align-items: center;
@@ -2271,7 +2271,7 @@ body {
   gap: 0.375rem;
 }
 
-.cloud-markdown-toolbar-actions button[aria-pressed="true"] {
+.cloud-markdown-toolbar-actions > button[aria-pressed="true"] {
   border-color: color-mix(in srgb, var(--foreground) 28%, transparent);
   background: color-mix(in srgb, var(--foreground) 9%, var(--background));
 }

--- a/apps/notebook-cloud/viewer/index.css
+++ b/apps/notebook-cloud/viewer/index.css
@@ -2285,6 +2285,18 @@ body {
   line-height: 1.4;
 }
 
+.cloud-markdown-notice[data-kind="published"] {
+  border-bottom-color: color-mix(in srgb, #047857 18%, transparent);
+  color: color-mix(in srgb, #047857 72%, var(--foreground));
+  background: color-mix(in srgb, #10b981 7%, var(--background));
+}
+
+.cloud-markdown-notice[data-kind="error"] {
+  border-bottom-color: color-mix(in srgb, #b91c1c 20%, transparent);
+  color: color-mix(in srgb, #b91c1c 78%, var(--foreground));
+  background: color-mix(in srgb, #ef4444 7%, var(--background));
+}
+
 .cloud-markdown-workspace {
   display: grid;
   grid-template-columns: minmax(13rem, 16rem) minmax(0, 1fr);

--- a/apps/notebook-cloud/viewer/index.css
+++ b/apps/notebook-cloud/viewer/index.css
@@ -335,6 +335,14 @@ body {
   line-height: 1.15;
 }
 
+.cloud-notebook-title [data-slot="document-title-label"][data-renameable="true"] {
+  cursor: text;
+}
+
+.cloud-notebook-title [data-slot="document-title-label"][data-renameable="true"]:hover {
+  background: color-mix(in srgb, var(--background) 88%, var(--foreground) 8%);
+}
+
 .cloud-notebook-title small {
   margin-top: 0.125rem;
   color: color-mix(in srgb, var(--foreground) 58%, transparent);

--- a/apps/notebook-cloud/viewer/index.css
+++ b/apps/notebook-cloud/viewer/index.css
@@ -2203,8 +2203,7 @@ body {
 
 .cloud-dashboard-create-actions button,
 .cloud-dashboard-button,
-.cloud-dashboard-secondary-action,
-.cloud-markdown-toolbar-actions > button {
+.cloud-dashboard-secondary-action {
   display: inline-flex;
   gap: 0.375rem;
   align-items: center;
@@ -2225,138 +2224,38 @@ body {
 }
 
 .cloud-markdown-shell {
-  display: grid;
-  grid-template-rows: auto auto minmax(0, 1fr);
-  min-height: 100vh;
   background: var(--background);
   color: var(--foreground);
 }
 
-.cloud-markdown-toolbar {
-  display: grid;
-  grid-template-columns: auto minmax(0, 1fr) auto;
-  gap: 0.75rem;
-  align-items: center;
-  border-bottom: 1px solid color-mix(in srgb, var(--foreground) 10%, transparent);
-  padding: 0.75rem 1rem;
+.cloud-markdown-room-toolbar [data-slot="notebook-document-header-presence"] {
+  flex-basis: min(28rem, 48vw);
+  max-width: min(42rem, 52vw);
 }
 
-.cloud-markdown-toolbar h1,
-.cloud-markdown-toolbar p {
-  margin: 0;
-}
-
-.cloud-markdown-toolbar h1 {
-  overflow: hidden;
-  font-size: 1rem;
-  font-weight: 700;
-  line-height: 1.25;
-  text-overflow: ellipsis;
-  white-space: nowrap;
-}
-
-.cloud-markdown-home-link {
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  width: 2.25rem;
-  height: 2.25rem;
-  border: 1px solid color-mix(in srgb, var(--foreground) 12%, transparent);
-  border-radius: 6px;
-  color: inherit;
-}
-
-.cloud-markdown-toolbar-actions {
-  display: inline-flex;
-  gap: 0.375rem;
-}
-
-.cloud-markdown-toolbar-actions > button[aria-pressed="true"] {
-  border-color: color-mix(in srgb, var(--foreground) 28%, transparent);
-  background: color-mix(in srgb, var(--foreground) 9%, var(--background));
-}
-
-.cloud-markdown-notice {
-  border-bottom: 1px solid color-mix(in srgb, #b45309 18%, transparent);
-  padding: 0.5rem 1rem;
-  color: color-mix(in srgb, #92400e 78%, var(--foreground));
-  background: color-mix(in srgb, #f59e0b 8%, var(--background));
-  font-size: 0.8125rem;
-  line-height: 1.4;
-}
-
-.cloud-markdown-notice[data-kind="published"] {
-  border-bottom-color: color-mix(in srgb, #047857 18%, transparent);
-  color: color-mix(in srgb, #047857 72%, var(--foreground));
-  background: color-mix(in srgb, #10b981 7%, var(--background));
-}
-
-.cloud-markdown-notice[data-kind="error"] {
-  border-bottom-color: color-mix(in srgb, #b91c1c 20%, transparent);
-  color: color-mix(in srgb, #b91c1c 78%, var(--foreground));
-  background: color-mix(in srgb, #ef4444 7%, var(--background));
-}
-
-.cloud-markdown-workspace {
-  display: grid;
-  grid-template-columns: minmax(13rem, 16rem) minmax(0, 1fr);
-  min-height: 0;
+.cloud-markdown-title-group {
+  max-width: min(42rem, 56vw);
 }
 
 .cloud-markdown-rail {
-  min-height: 0;
-  border-right: 1px solid color-mix(in srgb, var(--foreground) 10%, transparent);
-  padding: 0.75rem;
-  overflow: auto;
+  height: 100%;
 }
 
-.cloud-markdown-rail-title {
-  display: flex;
-  gap: 0.375rem;
-  align-items: center;
-  margin-bottom: 0.5rem;
-  color: color-mix(in srgb, var(--foreground) 62%, transparent);
-  font-size: 0.75rem;
-  font-weight: 700;
-  text-transform: uppercase;
+.cloud-markdown-notices {
+  --cloud-notice-height: 3rem;
 }
 
 .cloud-markdown-stage {
-  min-width: 0;
-  min-height: 0;
-  overflow: auto;
-  padding: clamp(1rem, 3vw, 2rem);
-}
-
-.cloud-markdown-editor,
-.cloud-markdown-preview {
-  width: min(100%, 52rem);
-  margin: 0 auto;
-}
-
-.cloud-markdown-editor {
-  border: 1px solid color-mix(in srgb, var(--foreground) 12%, transparent);
-  border-radius: 8px;
   overflow: hidden;
 }
 
-@media (max-width: 760px) {
-  .cloud-markdown-toolbar {
-    grid-template-columns: auto minmax(0, 1fr);
+@media (max-width: 599.98px) {
+  .cloud-markdown-room-toolbar [data-slot="notebook-document-header-presence"] {
+    flex-basis: auto;
+    max-width: none;
   }
 
-  .cloud-markdown-toolbar-actions {
-    grid-column: 1 / -1;
-    justify-self: start;
-  }
-
-  .cloud-markdown-workspace {
-    grid-template-columns: 1fr;
-  }
-
-  .cloud-markdown-rail {
-    max-height: 14rem;
-    border-right: 0;
-    border-bottom: 1px solid color-mix(in srgb, var(--foreground) 10%, transparent);
+  .cloud-markdown-title-group {
+    max-width: none;
   }
 }

--- a/apps/notebook-cloud/viewer/index.tsx
+++ b/apps/notebook-cloud/viewer/index.tsx
@@ -20,11 +20,16 @@ import type { CloudViewerAuthConfig, ViewerRuntimeState } from "./cloud-viewer-t
 import { cloudNotebookRouteTitleFromPathname } from "./cloud-notebook-title-state";
 import { CloudHomeView } from "./home-view";
 import { CloudMarkdownDocumentListView } from "./markdown-document-list-view";
-import { MarkdownDocumentRoute } from "./markdown-document-route";
 import { CloudNotebookListView } from "./notebook-list-view";
 import { loadNotebookRouteModule } from "./notebook-route-preload";
 import { OidcCallbackView } from "./oidc-callback-view";
 import "./index.css";
+
+const MarkdownDocumentRoute = lazy(() =>
+  import("./markdown-document-route").then((module) => ({
+    default: module.MarkdownDocumentRoute,
+  })),
+);
 
 const NotebookRoute = lazy(() =>
   loadNotebookRouteModule().then((module) => ({ default: module.NotebookRoute })),
@@ -83,7 +88,20 @@ function App() {
     if (!markdownConfig) {
       return <ViewerStartupError message="Unable to start Markdown document: missing config" />;
     }
-    return <MarkdownDocumentRoute config={markdownConfig} authConfig={authConfig} />;
+    return (
+      <Suspense
+        fallback={
+          <ViewerStartupLoading
+            title={markdownDocumentStartupTitle(markdownConfig)}
+            status="Loading"
+            homeHref="/m"
+            homeAriaLabel="Open Markdown documents"
+          />
+        }
+      >
+        <MarkdownDocumentRoute config={markdownConfig} authConfig={authConfig} />
+      </Suspense>
+    );
   }
 
   if (!runtimeState) {
@@ -119,19 +137,29 @@ function ViewerStartupError({ message }: { message: string }) {
   );
 }
 
-function ViewerStartupLoading({ title }: { title: string }) {
+function ViewerStartupLoading({
+  homeAriaLabel = "Open notebooks dashboard",
+  homeHref = "/n",
+  status = "Opening notebook",
+  title,
+}: {
+  homeAriaLabel?: string;
+  homeHref?: string;
+  status?: string;
+  title: string;
+}) {
   return (
     <main className="cloud-startup-shell" aria-busy="true">
       <header className="cloud-startup-toolbar">
         <div className="cloud-notebook-title-group">
-          <a className="cloud-notebook-home-link" href="/n" aria-label="Open notebooks dashboard">
+          <a className="cloud-notebook-home-link" href={homeHref} aria-label={homeAriaLabel}>
             <House aria-hidden="true" />
           </a>
           <div className="cloud-notebook-title">
             <h1 className="cloud-startup-title">{title}</h1>
             <p className="cloud-startup-status" role="status">
               <Loader2 aria-hidden="true" />
-              Opening notebook
+              {status}
             </p>
           </div>
         </div>
@@ -156,6 +184,12 @@ function ViewerStartupLoading({ title }: { title: string }) {
       </div>
     </main>
   );
+}
+
+function markdownDocumentStartupTitle(
+  config: ReturnType<typeof loadMarkdownDocumentConfig> | null,
+): string {
+  return config?.bootstrap?.title?.trim() || "Markdown document";
 }
 
 createRoot(requireElement("#root")).render(

--- a/apps/notebook-cloud/viewer/index.tsx
+++ b/apps/notebook-cloud/viewer/index.tsx
@@ -7,15 +7,20 @@ import { setOpenUrlHost } from "@/lib/open-url";
 import { installDocumentThemeSync } from "./theme";
 import {
   isHomePath,
+  isMarkdownDocumentListPath,
+  isMarkdownDocumentRoutePath,
   isNotebookListPath,
   isOidcCallbackPath,
   loadAuthConfig,
+  loadMarkdownDocumentConfig,
   loadViewerRuntime,
   requireElement,
 } from "./cloud-viewer-config";
 import type { CloudViewerAuthConfig, ViewerRuntimeState } from "./cloud-viewer-types";
 import { cloudNotebookRouteTitleFromPathname } from "./cloud-notebook-title-state";
 import { CloudHomeView } from "./home-view";
+import { CloudMarkdownDocumentListView } from "./markdown-document-list-view";
+import { MarkdownDocumentRoute } from "./markdown-document-route";
 import { CloudNotebookListView } from "./notebook-list-view";
 import { loadNotebookRouteModule } from "./notebook-route-preload";
 import { OidcCallbackView } from "./oidc-callback-view";
@@ -45,7 +50,14 @@ installDocumentThemeSync();
 function App() {
   const [authConfig] = useState<CloudViewerAuthConfig>(() => loadAuthConfig());
   const [runtimeState] = useState<ViewerRuntimeState | null>(() =>
-    isOidcCallbackPath() || isHomePath() || isNotebookListPath() ? null : loadViewerRuntime(),
+    isOidcCallbackPath() || isHomePath() || isNotebookListPath() || isMarkdownDocumentListPath()
+      ? null
+      : isMarkdownDocumentRoutePath()
+        ? null
+        : loadViewerRuntime(),
+  );
+  const [markdownConfig] = useState(() =>
+    isMarkdownDocumentRoutePath() ? loadMarkdownDocumentConfig() : null,
   );
 
   if (isHomePath()) {
@@ -59,8 +71,19 @@ function App() {
     return <CloudNotebookListView authConfig={authConfig} />;
   }
 
+  if (isMarkdownDocumentListPath()) {
+    return <CloudMarkdownDocumentListView authConfig={authConfig} />;
+  }
+
   if (isOidcCallbackPath()) {
     return <OidcCallbackView authConfig={authConfig} />;
+  }
+
+  if (isMarkdownDocumentRoutePath()) {
+    if (!markdownConfig) {
+      return <ViewerStartupError message="Unable to start Markdown document: missing config" />;
+    }
+    return <MarkdownDocumentRoute config={markdownConfig} authConfig={authConfig} />;
   }
 
   if (!runtimeState) {

--- a/apps/notebook-cloud/viewer/index.tsx
+++ b/apps/notebook-cloud/viewer/index.tsx
@@ -1,4 +1,4 @@
-import { lazy, Suspense, useState } from "react";
+import { lazy, Suspense, useEffect, useState } from "react";
 import { createRoot } from "react-dom/client";
 import { BookOpen, House, Loader2 } from "lucide-react";
 import { ErrorBoundary } from "@/lib/error-boundary";
@@ -19,6 +19,7 @@ import {
 import type { CloudViewerAuthConfig, ViewerRuntimeState } from "./cloud-viewer-types";
 import { cloudNotebookRouteTitleFromPathname } from "./cloud-notebook-title-state";
 import { CloudHomeView } from "./home-view";
+import { CLOUD_VIEWER_ROUTE_CHANGE_EVENT } from "./cloud-viewer-navigation";
 import { CloudMarkdownDocumentListView } from "./markdown-document-list-view";
 import { CloudNotebookListView } from "./notebook-list-view";
 import { loadNotebookRouteModule } from "./notebook-route-preload";
@@ -53,38 +54,53 @@ setOpenUrlHost({
 installDocumentThemeSync();
 
 function App() {
+  const [locationHref, setLocationHref] = useState(() => window.location.href);
+  const pathname = new URL(locationHref).pathname;
   const [authConfig] = useState<CloudViewerAuthConfig>(() => loadAuthConfig());
   const [runtimeState] = useState<ViewerRuntimeState | null>(() =>
-    isOidcCallbackPath() || isHomePath() || isNotebookListPath() || isMarkdownDocumentListPath()
+    isOidcCallbackPath(pathname) ||
+    isHomePath(pathname) ||
+    isNotebookListPath(pathname) ||
+    isMarkdownDocumentListPath(pathname)
       ? null
-      : isMarkdownDocumentRoutePath()
+      : isMarkdownDocumentRoutePath(pathname)
         ? null
         : loadViewerRuntime(),
   );
   const [markdownConfig] = useState(() =>
-    isMarkdownDocumentRoutePath() ? loadMarkdownDocumentConfig() : null,
+    isMarkdownDocumentRoutePath(pathname) ? loadMarkdownDocumentConfig() : null,
   );
 
-  if (isHomePath()) {
+  useEffect(() => {
+    const updateLocation = () => setLocationHref(window.location.href);
+    window.addEventListener("popstate", updateLocation);
+    window.addEventListener(CLOUD_VIEWER_ROUTE_CHANGE_EVENT, updateLocation);
+    return () => {
+      window.removeEventListener("popstate", updateLocation);
+      window.removeEventListener(CLOUD_VIEWER_ROUTE_CHANGE_EVENT, updateLocation);
+    };
+  }, []);
+
+  if (isHomePath(pathname)) {
     // The Worker currently redirects / and /index.html to /n. Keep this route
     // mounted for the temporary redirect's rollback path and future home-page
     // experiments that may serve the viewer shell directly again.
     return <CloudHomeView authConfig={authConfig} />;
   }
 
-  if (isNotebookListPath()) {
+  if (isNotebookListPath(pathname)) {
     return <CloudNotebookListView authConfig={authConfig} />;
   }
 
-  if (isMarkdownDocumentListPath()) {
+  if (isMarkdownDocumentListPath(pathname)) {
     return <CloudMarkdownDocumentListView authConfig={authConfig} />;
   }
 
-  if (isOidcCallbackPath()) {
+  if (isOidcCallbackPath(pathname)) {
     return <OidcCallbackView authConfig={authConfig} />;
   }
 
-  if (isMarkdownDocumentRoutePath()) {
+  if (isMarkdownDocumentRoutePath(pathname)) {
     if (!markdownConfig) {
       return <ViewerStartupError message="Unable to start Markdown document: missing config" />;
     }

--- a/apps/notebook-cloud/viewer/live-sync.ts
+++ b/apps/notebook-cloud/viewer/live-sync.ts
@@ -637,12 +637,22 @@ export function isRecoverableCloudFrameRejection(message: SessionControlMessage)
     return true;
   }
   if (message.frame_type === FrameType.RUNTIME_STATE_SYNC) {
-    return isSyncDivergenceRejectionReason(message.reason, "cloud-room-state-receive-sync");
+    return (
+      isSyncDivergenceRejectionReason(message.reason, "cloud-room-state-receive-sync") ||
+      isRecoverableRoomHostSyncBoundaryRejection(message.reason)
+    );
   }
   if (message.frame_type === FrameType.COMMS_DOC_SYNC) {
-    return isSyncDivergenceRejectionReason(message.reason, "cloud-room-comms-receive-sync");
+    return (
+      isSyncDivergenceRejectionReason(message.reason, "cloud-room-comms-receive-sync") ||
+      isRecoverableRoomHostSyncBoundaryRejection(message.reason)
+    );
   }
   return false;
+}
+
+function isRecoverableRoomHostSyncBoundaryRejection(reason: string): boolean {
+  return /recursive use of an object detected which would lead to unsafe aliasing/i.test(reason);
 }
 
 function isSyncDivergenceRejectionReason(reason: string, docTag: string): boolean {

--- a/apps/notebook-cloud/viewer/markdown-document-connection-copy.ts
+++ b/apps/notebook-cloud/viewer/markdown-document-connection-copy.ts
@@ -1,0 +1,20 @@
+import type { ConnectionStatus } from "runtimed";
+
+export function markdownConnectionCopy(
+  status: ConnectionStatus,
+  bodyReady: boolean,
+): string | null {
+  if (!bodyReady) {
+    return "Syncing Markdown document body.";
+  }
+  switch (status) {
+    case "connecting":
+      return null;
+    case "reconnecting":
+      return "Reconnecting to the live Markdown document.";
+    case "offline":
+      return "Markdown document is offline. Local changes will wait for reconnection.";
+    case "online":
+      return null;
+  }
+}

--- a/apps/notebook-cloud/viewer/markdown-document-dashboard.ts
+++ b/apps/notebook-cloud/viewer/markdown-document-dashboard.ts
@@ -1,3 +1,5 @@
+import { cloudNotebookUrlWithMode, type CloudNotebookUrlMode } from "./cloud-notebook-mode";
+
 export type CloudMarkdownDocumentScope = "owner" | "editor" | "viewer";
 
 export interface CloudMarkdownDocumentListItem {
@@ -23,7 +25,22 @@ export function cloudMarkdownDocumentOpenUrl(
   document: CloudMarkdownDocumentListItem,
   options: { browserOrigin?: string | null } = {},
 ): string {
-  return cloudMarkdownDocumentUrlOnCurrentOrigin(document.viewer_url, options);
+  return cloudMarkdownDocumentOpenUrlWithMode(
+    document.viewer_url,
+    cloudMarkdownDocumentDefaultOpenMode(document),
+    options,
+  );
+}
+
+export function cloudMarkdownDocumentOpenUrlWithMode(
+  viewerUrl: string,
+  mode: CloudNotebookUrlMode,
+  options: { browserOrigin?: string | null } = {},
+): string {
+  return cloudMarkdownDocumentUrlOnCurrentOrigin(
+    cloudNotebookUrlWithMode(viewerUrl, mode),
+    options,
+  );
 }
 
 export function cloudMarkdownDocumentUrlOnCurrentOrigin(
@@ -47,6 +64,12 @@ function currentBrowserOrigin(): string | null {
 
 function isHostedMarkdownDocumentPath(pathname: string): boolean {
   return /^\/m\/[^/]+(?:\/.*)?\/?$/.test(pathname);
+}
+
+function cloudMarkdownDocumentDefaultOpenMode(
+  document: Pick<CloudMarkdownDocumentListItem, "scope">,
+): CloudNotebookUrlMode {
+  return document.scope === "owner" || document.scope === "editor" ? "edit" : "view";
 }
 
 export function isCloudMarkdownDocumentListItem(

--- a/apps/notebook-cloud/viewer/markdown-document-dashboard.ts
+++ b/apps/notebook-cloud/viewer/markdown-document-dashboard.ts
@@ -1,0 +1,54 @@
+export type CloudMarkdownDocumentScope = "owner" | "editor" | "viewer";
+
+export interface CloudMarkdownDocumentListItem {
+  document_id: string;
+  title: string | null;
+  owner_principal: string;
+  body_doc_id: string;
+  scope: CloudMarkdownDocumentScope;
+  created_at: string;
+  updated_at: string;
+  latest_revision_id: string | null;
+  viewer_url: string;
+  endpoints: {
+    catalog: string;
+  };
+}
+
+export function cloudMarkdownDocumentDisplayTitle(document: CloudMarkdownDocumentListItem): string {
+  return document.title?.trim() || "Untitled Markdown";
+}
+
+export function cloudMarkdownDocumentOpenUrl(document: CloudMarkdownDocumentListItem): string {
+  const url = new URL(document.viewer_url, window.location.origin);
+  if (url.origin === window.location.origin) {
+    return `${url.pathname}${url.search}${url.hash}`;
+  }
+  return document.viewer_url;
+}
+
+export function isCloudMarkdownDocumentListItem(
+  value: unknown,
+): value is CloudMarkdownDocumentListItem {
+  if (!value || typeof value !== "object") {
+    return false;
+  }
+  const candidate = value as Partial<CloudMarkdownDocumentListItem>;
+  return (
+    typeof candidate.document_id === "string" &&
+    (candidate.title === null || typeof candidate.title === "string") &&
+    typeof candidate.owner_principal === "string" &&
+    typeof candidate.body_doc_id === "string" &&
+    isCloudMarkdownDocumentScope(candidate.scope) &&
+    typeof candidate.created_at === "string" &&
+    typeof candidate.updated_at === "string" &&
+    (candidate.latest_revision_id === null || typeof candidate.latest_revision_id === "string") &&
+    typeof candidate.viewer_url === "string" &&
+    Boolean(candidate.endpoints) &&
+    typeof candidate.endpoints?.catalog === "string"
+  );
+}
+
+function isCloudMarkdownDocumentScope(value: unknown): value is CloudMarkdownDocumentScope {
+  return value === "owner" || value === "editor" || value === "viewer";
+}

--- a/apps/notebook-cloud/viewer/markdown-document-dashboard.ts
+++ b/apps/notebook-cloud/viewer/markdown-document-dashboard.ts
@@ -19,12 +19,34 @@ export function cloudMarkdownDocumentDisplayTitle(document: CloudMarkdownDocumen
   return document.title?.trim() || "Untitled Markdown";
 }
 
-export function cloudMarkdownDocumentOpenUrl(document: CloudMarkdownDocumentListItem): string {
-  const url = new URL(document.viewer_url, window.location.origin);
-  if (url.origin === window.location.origin) {
+export function cloudMarkdownDocumentOpenUrl(
+  document: CloudMarkdownDocumentListItem,
+  options: { browserOrigin?: string | null } = {},
+): string {
+  return cloudMarkdownDocumentUrlOnCurrentOrigin(document.viewer_url, options);
+}
+
+export function cloudMarkdownDocumentUrlOnCurrentOrigin(
+  value: string,
+  options: { browserOrigin?: string | null } = {},
+): string {
+  const browserOrigin = options.browserOrigin ?? currentBrowserOrigin();
+  const url = new URL(value, browserOrigin ?? undefined);
+  if (
+    browserOrigin &&
+    (url.origin === browserOrigin || isHostedMarkdownDocumentPath(url.pathname))
+  ) {
     return `${url.pathname}${url.search}${url.hash}`;
   }
-  return document.viewer_url;
+  return value;
+}
+
+function currentBrowserOrigin(): string | null {
+  return typeof window === "undefined" ? null : window.location.origin;
+}
+
+function isHostedMarkdownDocumentPath(pathname: string): boolean {
+  return /^\/m\/[^/]+(?:\/.*)?\/?$/.test(pathname);
 }
 
 export function isCloudMarkdownDocumentListItem(

--- a/apps/notebook-cloud/viewer/markdown-document-list-cache.ts
+++ b/apps/notebook-cloud/viewer/markdown-document-list-cache.ts
@@ -6,6 +6,7 @@ import {
   type HostedDocumentListCacheStorage,
 } from "./hosted-document-list-cache";
 import type { CloudPrototypeAuthState } from "./collaborator-auth";
+import type { CloudAppSession } from "./app-session";
 import {
   isCloudMarkdownDocumentListItem,
   type CloudMarkdownDocumentListItem,
@@ -20,11 +21,13 @@ export type CloudMarkdownDocumentListCacheStorage = HostedDocumentListCacheStora
 export function readCachedCloudMarkdownDocumentList(
   storage: Pick<CloudMarkdownDocumentListCacheStorage, "getItem">,
   authState: CloudPrototypeAuthState,
+  appSession?: CloudAppSession | null,
   now = Date.now(),
 ): CloudMarkdownDocumentListItem[] | null {
   return readCachedHostedDocumentList(
     storage,
     authState,
+    appSession,
     cloudMarkdownDocumentListCacheConfig(),
     now,
   );
@@ -33,12 +36,14 @@ export function readCachedCloudMarkdownDocumentList(
 export function writeCachedCloudMarkdownDocumentList(
   storage: Pick<CloudMarkdownDocumentListCacheStorage, "setItem">,
   authState: CloudPrototypeAuthState,
+  appSession: CloudAppSession | null | undefined,
   documents: CloudMarkdownDocumentListItem[],
   now = Date.now(),
 ): void {
   writeCachedHostedDocumentList(
     storage,
     authState,
+    appSession,
     documents,
     cloudMarkdownDocumentListCacheConfig(),
     now,

--- a/apps/notebook-cloud/viewer/markdown-document-list-cache.ts
+++ b/apps/notebook-cloud/viewer/markdown-document-list-cache.ts
@@ -1,0 +1,60 @@
+import {
+  CLOUD_HOSTED_DOCUMENT_LIST_CACHE_TTL_MS,
+  clearCachedHostedDocumentList,
+  readCachedHostedDocumentList,
+  writeCachedHostedDocumentList,
+  type HostedDocumentListCacheStorage,
+} from "./hosted-document-list-cache";
+import type { CloudPrototypeAuthState } from "./collaborator-auth";
+import {
+  isCloudMarkdownDocumentListItem,
+  type CloudMarkdownDocumentListItem,
+} from "./markdown-document-dashboard";
+
+export const CLOUD_MARKDOWN_DOCUMENT_LIST_CACHE_STORAGE_KEY =
+  "nteract:notebook-cloud:markdown-document-list-cache:v1";
+export const CLOUD_MARKDOWN_DOCUMENT_LIST_CACHE_TTL_MS = CLOUD_HOSTED_DOCUMENT_LIST_CACHE_TTL_MS;
+
+export type CloudMarkdownDocumentListCacheStorage = HostedDocumentListCacheStorage;
+
+export function readCachedCloudMarkdownDocumentList(
+  storage: Pick<CloudMarkdownDocumentListCacheStorage, "getItem">,
+  authState: CloudPrototypeAuthState,
+  now = Date.now(),
+): CloudMarkdownDocumentListItem[] | null {
+  return readCachedHostedDocumentList(
+    storage,
+    authState,
+    cloudMarkdownDocumentListCacheConfig(),
+    now,
+  );
+}
+
+export function writeCachedCloudMarkdownDocumentList(
+  storage: Pick<CloudMarkdownDocumentListCacheStorage, "setItem">,
+  authState: CloudPrototypeAuthState,
+  documents: CloudMarkdownDocumentListItem[],
+  now = Date.now(),
+): void {
+  writeCachedHostedDocumentList(
+    storage,
+    authState,
+    documents,
+    cloudMarkdownDocumentListCacheConfig(),
+    now,
+  );
+}
+
+export function clearCachedCloudMarkdownDocumentList(
+  storage: Pick<CloudMarkdownDocumentListCacheStorage, "removeItem">,
+): void {
+  clearCachedHostedDocumentList(storage, CLOUD_MARKDOWN_DOCUMENT_LIST_CACHE_STORAGE_KEY);
+}
+
+function cloudMarkdownDocumentListCacheConfig() {
+  return {
+    isItem: isCloudMarkdownDocumentListItem,
+    itemsKey: "documents",
+    storageKey: CLOUD_MARKDOWN_DOCUMENT_LIST_CACHE_STORAGE_KEY,
+  };
+}

--- a/apps/notebook-cloud/viewer/markdown-document-list-view.tsx
+++ b/apps/notebook-cloud/viewer/markdown-document-list-view.tsx
@@ -13,7 +13,7 @@ import { loadCloudMarkdownDocumentListBootstrap } from "./cloud-viewer-config";
 import {
   cloudMarkdownDocumentDisplayTitle,
   cloudMarkdownDocumentOpenUrl,
-  cloudMarkdownDocumentUrlOnCurrentOrigin,
+  cloudMarkdownDocumentOpenUrlWithMode,
   isCloudMarkdownDocumentListItem,
   type CloudMarkdownDocumentListItem,
 } from "./markdown-document-dashboard";
@@ -170,7 +170,7 @@ export function CloudMarkdownDocumentListView({
       if (body.ok !== true || typeof body.viewer_url !== "string") {
         throw new Error("Unable to create Markdown document: response shape was invalid");
       }
-      window.location.assign(cloudMarkdownDocumentUrlOnCurrentOrigin(body.viewer_url));
+      window.location.assign(cloudMarkdownDocumentOpenUrlWithMode(body.viewer_url, "edit"));
     } catch (error) {
       setCreateState("idle");
       setCreateError(error instanceof Error ? error.message : String(error));

--- a/apps/notebook-cloud/viewer/markdown-document-list-view.tsx
+++ b/apps/notebook-cloud/viewer/markdown-document-list-view.tsx
@@ -1,0 +1,377 @@
+import { useEffect, useMemo, useState, type FormEvent } from "react";
+import { FileText, Loader2, Plus, RotateCcw } from "lucide-react";
+import { useTheme } from "@/hooks/useTheme";
+import {
+  clearCloudPrototypeDevAuth,
+  fetchWithCloudPrototypeAuth,
+  type CloudPrototypeAuthState,
+} from "./collaborator-auth";
+import { clearCloudAppSession, establishCloudAppSession } from "./app-session";
+import { CloudNotebookSignInButton } from "./cloud-auth-controls";
+import { cloudResponseError } from "./cloud-response";
+import { loadCloudMarkdownDocumentListBootstrap } from "./cloud-viewer-config";
+import {
+  cloudMarkdownDocumentDisplayTitle,
+  cloudMarkdownDocumentOpenUrl,
+  isCloudMarkdownDocumentListItem,
+  type CloudMarkdownDocumentListItem,
+} from "./markdown-document-dashboard";
+import type {
+  CloudMarkdownDocumentCreateResponse,
+  CloudMarkdownDocumentListBootstrap,
+  CloudMarkdownDocumentListResponse,
+  CloudViewerAuthConfig,
+} from "./cloud-viewer-types";
+import { applyDocumentTheme, CLOUD_VIEWER_THEME_STORAGE_KEY } from "./theme";
+import {
+  useCloudAppSessionBridge,
+  useCloudAppSessionStatus,
+  useCloudPrototypeAuth,
+} from "./use-cloud-auth";
+
+type MarkdownDocumentListState =
+  | { kind: "loading" }
+  | { kind: "ready"; documents: CloudMarkdownDocumentListItem[] }
+  | { kind: "signed_out" }
+  | { kind: "error"; message: string };
+
+export function CloudMarkdownDocumentListView({
+  authConfig,
+}: {
+  authConfig: CloudViewerAuthConfig;
+}) {
+  const { resolvedTheme } = useTheme(CLOUD_VIEWER_THEME_STORAGE_KEY);
+  const [bootstrap, setBootstrap] = useState<CloudMarkdownDocumentListBootstrap | null>(() =>
+    loadCloudMarkdownDocumentListBootstrap(),
+  );
+  const appSessionStatus = useCloudAppSessionStatus(bootstrap?.session ?? null);
+  const { authState } = useCloudPrototypeAuth(authConfig, {
+    appSessionRefreshFallback: true,
+    appSessionLoading: appSessionStatus.status === "loading",
+    appSession: appSessionStatus.session,
+  });
+  useCloudAppSessionBridge(
+    authState,
+    appSessionStatus.session,
+    appSessionStatus.status === "loading",
+    appSessionStatus.refreshAppSessionStatus,
+  );
+  const [listState, setListState] = useState<MarkdownDocumentListState>(() =>
+    initialMarkdownDocumentListState(bootstrap),
+  );
+  const [refreshIndex, setRefreshIndex] = useState(0);
+  const [createOpen, setCreateOpen] = useState(false);
+  const [createTitle, setCreateTitle] = useState(() => defaultMarkdownDocumentTitle());
+  const [createState, setCreateState] = useState<"idle" | "starting">("idle");
+  const [createError, setCreateError] = useState<string | null>(null);
+  const hasExplicitAuth = authState.mode === "dev" || authState.mode === "oidc";
+  const hasAppSession = Boolean(appSessionStatus.session);
+  const signedIn = hasExplicitAuth || hasAppSession;
+  const canFetchDocumentList = authState.mode === "dev" || hasAppSession;
+  const waitingForAppSession = authState.mode === "oidc" && !hasAppSession;
+  const documents = listState.kind === "ready" ? listState.documents : [];
+
+  useEffect(() => {
+    applyDocumentTheme(resolvedTheme);
+  }, [resolvedTheme]);
+
+  useEffect(() => {
+    if (!canFetchDocumentList) {
+      if (waitingForAppSession && bootstrap) {
+        setListState({ kind: "ready", documents: bootstrap.documents });
+        return;
+      }
+      setListState({ kind: "signed_out" });
+      return;
+    }
+    if (refreshIndex === 0 && bootstrap) {
+      setListState({ kind: "ready", documents: bootstrap.documents });
+      return;
+    }
+
+    const controller = new AbortController();
+    setListState(
+      bootstrap ? { kind: "ready", documents: bootstrap.documents } : { kind: "loading" },
+    );
+    void (async () => {
+      try {
+        const response = await fetchMarkdownDocumentList(authState, controller.signal);
+        if (controller.signal.aborted) return;
+        if (!response.ok) {
+          throw await cloudResponseError(response, "Unable to list Markdown documents");
+        }
+        const body = (await response.json()) as unknown;
+        if (!isCloudMarkdownDocumentListResponse(body)) {
+          throw new Error("Unable to list Markdown documents: response shape was invalid");
+        }
+        setListState({ kind: "ready", documents: body.documents });
+        setBootstrap({
+          kind: "markdown-document-list",
+          documents: body.documents,
+          saved_at: new Date().toISOString(),
+        });
+      } catch (error) {
+        if (controller.signal.aborted) return;
+        setListState({
+          kind: "error",
+          message: error instanceof Error ? error.message : String(error),
+        });
+      }
+    })();
+
+    return () => controller.abort();
+  }, [authState, bootstrap, canFetchDocumentList, refreshIndex, waitingForAppSession]);
+
+  const refreshList = () => {
+    if (authState.mode === "oidc" && authState.token) {
+      void establishCloudAppSession(authState)
+        .catch((error: unknown) => {
+          console.warn("[notebook-cloud] app session refresh before Markdown list failed", error);
+        })
+        .finally(() => {
+          appSessionStatus.refreshAppSessionStatus();
+          setRefreshIndex((value) => value + 1);
+        });
+      return;
+    }
+    setRefreshIndex((value) => value + 1);
+  };
+
+  const createDocument = async (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    if (!signedIn || createState === "starting") {
+      return;
+    }
+    const title = createTitle.trim() || defaultMarkdownDocumentTitle();
+    try {
+      setCreateError(null);
+      setCreateState("starting");
+      const response = await fetchWithCloudPrototypeAuth(
+        markdownDocumentCollectionEndpoint(),
+        {
+          method: "POST",
+          headers: {
+            Accept: "application/json",
+            "Content-Type": "application/json",
+          },
+          body: JSON.stringify({ title }),
+        },
+        cloudAuthWithScope(authState, "owner"),
+      );
+      if (!response.ok) {
+        throw await cloudResponseError(response, "Unable to create Markdown document");
+      }
+      const body = (await response.json()) as CloudMarkdownDocumentCreateResponse;
+      if (body.ok !== true || typeof body.viewer_url !== "string") {
+        throw new Error("Unable to create Markdown document: response shape was invalid");
+      }
+      window.location.assign(cloudMarkdownDocumentUrlOnCurrentOrigin(body.viewer_url));
+    } catch (error) {
+      setCreateState("idle");
+      setCreateError(error instanceof Error ? error.message : String(error));
+    }
+  };
+
+  const sortedDocuments = useMemo(
+    () =>
+      [...documents].sort(
+        (left, right) => Date.parse(right.updated_at) - Date.parse(left.updated_at),
+      ),
+    [documents],
+  );
+
+  return (
+    <main className="cloud-dashboard-shell">
+      <header className="cloud-dashboard-header">
+        <div>
+          <p className="cloud-dashboard-eyebrow">Markdown</p>
+          <h1>Documents</h1>
+          <p>
+            {signedIn
+              ? "Draft, review, and publish Markdown without compute."
+              : "Sign in to open Markdown documents."}
+          </p>
+        </div>
+        <div className="cloud-dashboard-actions">
+          <CloudNotebookSignInButton authConfig={authConfig} authState={authState} />
+          {signedIn ? (
+            <>
+              <button type="button" className="cloud-dashboard-button" onClick={refreshList}>
+                <RotateCcw aria-hidden="true" />
+                Refresh
+              </button>
+              <button
+                type="button"
+                className="cloud-dashboard-button"
+                onClick={() => setCreateOpen(true)}
+              >
+                <Plus aria-hidden="true" />
+                New Markdown
+              </button>
+            </>
+          ) : null}
+        </div>
+      </header>
+
+      {createOpen ? (
+        <form className="cloud-dashboard-create" onSubmit={createDocument}>
+          <label>
+            <span>Title</span>
+            <input
+              value={createTitle}
+              onChange={(event) => setCreateTitle(event.target.value)}
+              maxLength={160}
+              autoFocus
+            />
+          </label>
+          <div className="cloud-dashboard-create-actions">
+            <button
+              type="button"
+              onClick={() => setCreateOpen(false)}
+              disabled={createState === "starting"}
+            >
+              Cancel
+            </button>
+            <button type="submit" disabled={createState === "starting"}>
+              {createState === "starting" ? (
+                <Loader2 aria-hidden="true" />
+              ) : (
+                <Plus aria-hidden="true" />
+              )}
+              Create
+            </button>
+          </div>
+          {createError ? (
+            <p className="cloud-state" data-kind="error">
+              {createError}
+            </p>
+          ) : null}
+        </form>
+      ) : null}
+
+      <section className="cloud-document-list" aria-label="Markdown documents">
+        {listState.kind === "loading" ? (
+          <div className="cloud-state" data-kind="loading">
+            <Loader2 aria-hidden="true" />
+            Loading Markdown documents
+          </div>
+        ) : null}
+        {listState.kind === "signed_out" ? (
+          <div className="cloud-state" data-kind="empty">
+            Sign in to see Markdown documents.
+          </div>
+        ) : null}
+        {listState.kind === "error" ? (
+          <div className="cloud-state" data-kind="error">
+            {listState.message}
+          </div>
+        ) : null}
+        {listState.kind === "ready" && sortedDocuments.length === 0 ? (
+          <div className="cloud-state" data-kind="empty">
+            No Markdown documents yet.
+          </div>
+        ) : null}
+        {sortedDocuments.map((document) => (
+          <a
+            key={document.document_id}
+            className="cloud-document-row"
+            href={cloudMarkdownDocumentOpenUrl(document)}
+          >
+            <FileText aria-hidden="true" />
+            <span>
+              <strong>{cloudMarkdownDocumentDisplayTitle(document)}</strong>
+              <small>
+                {document.scope} · updated {formatShortDate(document.updated_at)}
+              </small>
+            </span>
+          </a>
+        ))}
+      </section>
+
+      {signedIn ? (
+        <button
+          type="button"
+          className="cloud-dashboard-secondary-action"
+          onClick={() => {
+            clearCloudPrototypeDevAuth(window.localStorage);
+            void clearCloudAppSession().finally(() => {
+              window.location.reload();
+            });
+          }}
+        >
+          Sign out
+        </button>
+      ) : null}
+    </main>
+  );
+}
+
+function initialMarkdownDocumentListState(
+  bootstrap: CloudMarkdownDocumentListBootstrap | null,
+): MarkdownDocumentListState {
+  return bootstrap ? { kind: "ready", documents: bootstrap.documents } : { kind: "loading" };
+}
+
+function fetchMarkdownDocumentList(
+  authState: CloudPrototypeAuthState,
+  signal: AbortSignal,
+): Promise<Response> {
+  return fetchWithCloudPrototypeAuth(
+    markdownDocumentListEndpoint(),
+    { headers: { Accept: "application/json" }, signal },
+    cloudAuthWithScope(authState, "viewer"),
+  );
+}
+
+function markdownDocumentListEndpoint(): string {
+  return new URL("api/m?limit=100", `${window.location.origin}/`).href;
+}
+
+function markdownDocumentCollectionEndpoint(): string {
+  return new URL("api/m", `${window.location.origin}/`).href;
+}
+
+function cloudMarkdownDocumentUrlOnCurrentOrigin(value: string): string {
+  const url = new URL(value, window.location.origin);
+  if (url.origin !== window.location.origin) {
+    return value;
+  }
+  return `${url.pathname}${url.search}${url.hash}`;
+}
+
+function cloudAuthWithScope(
+  authState: CloudPrototypeAuthState,
+  scope: "viewer" | "editor" | "owner",
+): CloudPrototypeAuthState {
+  return authState.mode === "dev" ? { ...authState, requestedScope: scope } : authState;
+}
+
+function defaultMarkdownDocumentTitle(): string {
+  return `Markdown ${new Date().toLocaleDateString(undefined, {
+    month: "short",
+    day: "numeric",
+    year: "numeric",
+  })}`;
+}
+
+function formatShortDate(value: string): string {
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) {
+    return value;
+  }
+  return date.toLocaleDateString(undefined, { month: "short", day: "numeric" });
+}
+
+function isCloudMarkdownDocumentListResponse(
+  value: unknown,
+): value is CloudMarkdownDocumentListResponse {
+  if (!value || typeof value !== "object") {
+    return false;
+  }
+  const candidate = value as Partial<CloudMarkdownDocumentListResponse>;
+  return (
+    candidate.ok === true &&
+    Array.isArray(candidate.documents) &&
+    candidate.documents.every(isCloudMarkdownDocumentListItem)
+  );
+}

--- a/apps/notebook-cloud/viewer/markdown-document-list-view.tsx
+++ b/apps/notebook-cloud/viewer/markdown-document-list-view.tsx
@@ -147,6 +147,10 @@ export function CloudMarkdownDocumentListView({
     try {
       setCreateError(null);
       setCreateState("starting");
+      if (authState.mode === "oidc" && authState.token && !hasAppSession) {
+        await establishCloudAppSession(authState);
+        appSessionStatus.refreshAppSessionStatus();
+      }
       const response = await fetchWithCloudPrototypeAuth(
         markdownDocumentCollectionEndpoint(),
         {

--- a/apps/notebook-cloud/viewer/markdown-document-list-view.tsx
+++ b/apps/notebook-cloud/viewer/markdown-document-list-view.tsx
@@ -8,6 +8,7 @@ import {
 } from "./collaborator-auth";
 import { clearCloudAppSession, establishCloudAppSession } from "./app-session";
 import { CloudNotebookSignInButton } from "./cloud-auth-controls";
+import { CloudHostedDocumentSignedOutPanel } from "./cloud-hosted-document-signed-out";
 import { cloudResponseError } from "./cloud-response";
 import { loadCloudMarkdownDocumentListBootstrap } from "./cloud-viewer-config";
 import {
@@ -290,9 +291,14 @@ export function CloudMarkdownDocumentListView({
           </div>
         ) : null}
         {listState.kind === "signed_out" ? (
-          <div className="cloud-state" data-kind="empty">
-            Sign in to see Markdown documents.
-          </div>
+          <CloudHostedDocumentSignedOutPanel
+            authConfig={authConfig}
+            authState={authState}
+            cloudTitle="Write live Markdown."
+            cloudDescription="Sign in to create realtime Markdown documents, review drafts, and share work."
+            localTitle="Open local Markdown."
+            localDescription="Use local auth to create Markdown documents and test the live editor on this machine."
+          />
         ) : null}
         {listState.kind === "error" ? (
           <div className="cloud-state" data-kind="error">

--- a/apps/notebook-cloud/viewer/markdown-document-list-view.tsx
+++ b/apps/notebook-cloud/viewer/markdown-document-list-view.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useMemo, useState, type FormEvent } from "react";
-import { BookOpen, FileText, Loader2, Plus, RotateCcw } from "lucide-react";
+import { AlertCircle, BookOpen, FileText, Loader2, LogOut, Plus, RotateCcw } from "lucide-react";
 import { useTheme } from "@/hooks/useTheme";
 import {
   clearCloudPrototypeDevAuth,
@@ -205,10 +205,12 @@ export function CloudMarkdownDocumentListView({
   );
 
   return (
-    <main className="cloud-dashboard-shell">
-      <header className="cloud-dashboard-header">
+    <main className="cloud-notebook-list-page cloud-markdown-list-page">
+      <header className="cloud-notebook-list-header">
         <div>
-          <p className="cloud-dashboard-eyebrow">Markdown</p>
+          <a className="cloud-notebook-list-brand" href="/m">
+            Markdown
+          </a>
           <h1>Documents</h1>
           <p>
             {signedIn
@@ -216,8 +218,8 @@ export function CloudMarkdownDocumentListView({
               : "Sign in to open Markdown documents."}
           </p>
         </div>
-        <div className="cloud-dashboard-actions">
-          <a className="cloud-dashboard-button" href="/n">
+        <div className="cloud-notebook-list-actions">
+          <a href="/n">
             <BookOpen aria-hidden="true" />
             Notebooks
           </a>
@@ -230,17 +232,26 @@ export function CloudMarkdownDocumentListView({
           ) : null}
           {signedIn ? (
             <>
-              <button type="button" className="cloud-dashboard-button" onClick={refreshList}>
+              <button type="button" onClick={refreshList}>
                 <RotateCcw aria-hidden="true" />
                 Refresh
               </button>
-              <button
-                type="button"
-                className="cloud-dashboard-button"
-                onClick={() => setCreateOpen(true)}
-              >
+              <button type="button" onClick={() => setCreateOpen(true)}>
                 <Plus aria-hidden="true" />
                 New Markdown
+              </button>
+              <button
+                type="button"
+                onClick={() => {
+                  clearCloudPrototypeDevAuth(window.localStorage);
+                  clearCachedCloudMarkdownDocumentListFromWindow();
+                  void clearCloudAppSession().finally(() => {
+                    window.location.reload();
+                  });
+                }}
+              >
+                <LogOut aria-hidden="true" />
+                Sign out
               </button>
             </>
           ) : null}
@@ -248,17 +259,24 @@ export function CloudMarkdownDocumentListView({
       </header>
 
       {createOpen ? (
-        <form className="cloud-dashboard-create" onSubmit={createDocument}>
-          <label>
-            <span>Title</span>
+        <>
+          <form className="cloud-new-notebook-form" onSubmit={createDocument}>
+            <label htmlFor="cloud-new-markdown-title">Document title</label>
             <input
+              id="cloud-new-markdown-title"
               value={createTitle}
               onChange={(event) => setCreateTitle(event.target.value)}
               maxLength={160}
               autoFocus
             />
-          </label>
-          <div className="cloud-dashboard-create-actions">
+            <button type="submit" disabled={createState === "starting"}>
+              {createState === "starting" ? (
+                <Loader2 className="cloud-home-status-spinner" aria-hidden="true" />
+              ) : (
+                <Plus aria-hidden="true" />
+              )}
+              Create
+            </button>
             <button
               type="button"
               onClick={() => setCreateOpen(false)}
@@ -266,28 +284,23 @@ export function CloudMarkdownDocumentListView({
             >
               Cancel
             </button>
-            <button type="submit" disabled={createState === "starting"}>
-              {createState === "starting" ? (
-                <Loader2 aria-hidden="true" />
-              ) : (
-                <Plus aria-hidden="true" />
-              )}
-              Create
-            </button>
-          </div>
+          </form>
           {createError ? (
-            <p className="cloud-state" data-kind="error">
+            <div className="cloud-notebook-list-banner" data-kind="error" role="alert">
               {createError}
-            </p>
+            </div>
           ) : null}
-        </form>
+        </>
       ) : null}
 
-      <section className="cloud-document-list" aria-label="Markdown documents">
+      <section
+        className="cloud-notebook-list-content cloud-document-list"
+        aria-label="Markdown documents"
+      >
         {listState.kind === "loading" ? (
-          <div className="cloud-state" data-kind="loading">
-            <Loader2 aria-hidden="true" />
-            Loading Markdown documents
+          <div className="cloud-notebook-list-state" data-kind="loading" role="status">
+            <Loader2 className="cloud-home-status-spinner" aria-hidden="true" />
+            <span>Loading Markdown documents</span>
           </div>
         ) : null}
         {listState.kind === "signed_out" ? (
@@ -301,13 +314,15 @@ export function CloudMarkdownDocumentListView({
           />
         ) : null}
         {listState.kind === "error" ? (
-          <div className="cloud-state" data-kind="error">
-            {listState.message}
+          <div className="cloud-notebook-list-state" data-kind="error" role="alert">
+            <AlertCircle aria-hidden="true" />
+            <span>{listState.message}</span>
           </div>
         ) : null}
         {listState.kind === "ready" && sortedDocuments.length === 0 ? (
-          <div className="cloud-state" data-kind="empty">
-            No Markdown documents yet.
+          <div className="cloud-notebook-list-state" data-kind="empty">
+            <FileText aria-hidden="true" />
+            <span>No Markdown documents yet.</span>
           </div>
         ) : null}
         {sortedDocuments.map((document) => (
@@ -326,22 +341,6 @@ export function CloudMarkdownDocumentListView({
           </a>
         ))}
       </section>
-
-      {signedIn ? (
-        <button
-          type="button"
-          className="cloud-dashboard-secondary-action"
-          onClick={() => {
-            clearCloudPrototypeDevAuth(window.localStorage);
-            clearCachedCloudMarkdownDocumentListFromWindow();
-            void clearCloudAppSession().finally(() => {
-              window.location.reload();
-            });
-          }}
-        >
-          Sign out
-        </button>
-      ) : null}
     </main>
   );
 }

--- a/apps/notebook-cloud/viewer/markdown-document-list-view.tsx
+++ b/apps/notebook-cloud/viewer/markdown-document-list-view.tsx
@@ -4,6 +4,7 @@ import { useTheme } from "@/hooks/useTheme";
 import {
   clearCloudPrototypeDevAuth,
   fetchWithCloudPrototypeAuth,
+  shouldShowCloudHeaderSignIn,
   type CloudPrototypeAuthState,
 } from "./collaborator-auth";
 import { clearCloudAppSession, establishCloudAppSession } from "./app-session";
@@ -69,7 +70,12 @@ export function CloudMarkdownDocumentListView({
   const hasAppSession = Boolean(appSessionStatus.session);
   const signedIn = hasExplicitAuth || hasAppSession;
   const canFetchDocumentList = authState.mode === "dev" || hasAppSession;
-  const waitingForAppSession = authState.mode === "oidc" && !hasAppSession;
+  const appSessionLoading = appSessionStatus.status === "loading";
+  const waitingForAppSession = appSessionLoading || (authState.mode === "oidc" && !hasAppSession);
+  const showSignIn = shouldShowCloudHeaderSignIn(authState, {
+    appSessionLoading,
+    hasAppSession,
+  });
   const documents = listState.kind === "ready" ? listState.documents : [];
 
   useEffect(() => {
@@ -202,11 +208,13 @@ export function CloudMarkdownDocumentListView({
             <BookOpen aria-hidden="true" />
             Notebooks
           </a>
-          <CloudNotebookSignInButton
-            authConfig={authConfig}
-            authState={authState}
-            documentLabel="document"
-          />
+          {showSignIn ? (
+            <CloudNotebookSignInButton
+              authConfig={authConfig}
+              authState={authState}
+              documentLabel="document"
+            />
+          ) : null}
           {signedIn ? (
             <>
               <button type="button" className="cloud-dashboard-button" onClick={refreshList}>

--- a/apps/notebook-cloud/viewer/markdown-document-list-view.tsx
+++ b/apps/notebook-cloud/viewer/markdown-document-list-view.tsx
@@ -13,6 +13,7 @@ import { loadCloudMarkdownDocumentListBootstrap } from "./cloud-viewer-config";
 import {
   cloudMarkdownDocumentDisplayTitle,
   cloudMarkdownDocumentOpenUrl,
+  cloudMarkdownDocumentUrlOnCurrentOrigin,
   isCloudMarkdownDocumentListItem,
   type CloudMarkdownDocumentListItem,
 } from "./markdown-document-dashboard";
@@ -329,14 +330,6 @@ function markdownDocumentListEndpoint(): string {
 
 function markdownDocumentCollectionEndpoint(): string {
   return new URL("api/m", `${window.location.origin}/`).href;
-}
-
-function cloudMarkdownDocumentUrlOnCurrentOrigin(value: string): string {
-  const url = new URL(value, window.location.origin);
-  if (url.origin !== window.location.origin) {
-    return value;
-  }
-  return `${url.pathname}${url.search}${url.hash}`;
 }
 
 function cloudAuthWithScope(

--- a/apps/notebook-cloud/viewer/markdown-document-list-view.tsx
+++ b/apps/notebook-cloud/viewer/markdown-document-list-view.tsx
@@ -6,7 +6,11 @@ import {
   fetchWithCloudPrototypeAuth,
   type CloudPrototypeAuthState,
 } from "./collaborator-auth";
-import { clearCloudAppSession, establishCloudAppSession } from "./app-session";
+import {
+  clearCloudAppSession,
+  establishCloudAppSession,
+  type CloudAppSession,
+} from "./app-session";
 import { CloudNotebookSignInButton } from "./cloud-auth-controls";
 import { CloudHostedDocumentSignedOutPanel } from "./cloud-hosted-document-signed-out";
 import { cloudResponseError } from "./cloud-response";
@@ -65,7 +69,7 @@ export function CloudMarkdownDocumentListView({
     appSessionStatus.refreshAppSessionStatus,
   );
   const [listState, setListState] = useState<MarkdownDocumentListState>(() =>
-    initialMarkdownDocumentListState(authState, bootstrap),
+    initialMarkdownDocumentListState(authState, bootstrap, appSessionStatus.session),
   );
   const [refreshIndex, setRefreshIndex] = useState(0);
   const [createOpen, setCreateOpen] = useState(false);
@@ -90,7 +94,15 @@ export function CloudMarkdownDocumentListView({
   }, [resolvedTheme]);
 
   useEffect(() => {
-    const seededDocuments = cloudMarkdownDocumentListSeedFromBootstrapOrCache(authState, bootstrap);
+    document.title = "nteract Markdown documents";
+  }, []);
+
+  useEffect(() => {
+    const seededDocuments = cloudMarkdownDocumentListSeedFromBootstrapOrCache(
+      authState,
+      bootstrap,
+      appSessionStatus.session,
+    );
     if (!canFetchDocumentList) {
       if (waitingForAppSession) {
         setListState(
@@ -103,7 +115,11 @@ export function CloudMarkdownDocumentListView({
       return;
     }
     if (refreshIndex === 0 && bootstrap) {
-      writeCachedCloudMarkdownDocumentListToWindow(authState, bootstrap.documents);
+      writeCachedCloudMarkdownDocumentListToWindow(
+        authState,
+        appSessionStatus.session,
+        bootstrap.documents,
+      );
       setListState({ kind: "ready", documents: bootstrap.documents });
       return;
     }
@@ -123,7 +139,11 @@ export function CloudMarkdownDocumentListView({
         if (!isCloudMarkdownDocumentListResponse(body)) {
           throw new Error("Unable to list Markdown documents: response shape was invalid");
         }
-        writeCachedCloudMarkdownDocumentListToWindow(authState, body.documents);
+        writeCachedCloudMarkdownDocumentListToWindow(
+          authState,
+          appSessionStatus.session,
+          body.documents,
+        );
         setListState({ kind: "ready", documents: body.documents });
         setBootstrap({
           kind: "markdown-document-list",
@@ -140,7 +160,14 @@ export function CloudMarkdownDocumentListView({
     })();
 
     return () => controller.abort();
-  }, [authState, bootstrap, canFetchDocumentList, refreshIndex, waitingForAppSession]);
+  }, [
+    appSessionStatus.session,
+    authState,
+    bootstrap,
+    canFetchDocumentList,
+    refreshIndex,
+    waitingForAppSession,
+  ]);
 
   const refreshList = () => {
     if (authState.mode === "oidc" && authState.token) {
@@ -348,8 +375,13 @@ export function CloudMarkdownDocumentListView({
 function initialMarkdownDocumentListState(
   authState: CloudPrototypeAuthState,
   bootstrap: CloudMarkdownDocumentListBootstrap | null,
+  appSession: CloudAppSession | null,
 ): MarkdownDocumentListState {
-  const seededDocuments = cloudMarkdownDocumentListSeedFromBootstrapOrCache(authState, bootstrap);
+  const seededDocuments = cloudMarkdownDocumentListSeedFromBootstrapOrCache(
+    authState,
+    bootstrap,
+    appSession,
+  );
   return seededDocuments ? { kind: "ready", documents: seededDocuments } : { kind: "loading" };
 }
 
@@ -357,6 +389,13 @@ function fetchMarkdownDocumentList(
   authState: CloudPrototypeAuthState,
   signal: AbortSignal,
 ): Promise<Response> {
+  if (authState.mode !== "dev" && authState.mode !== "oidc") {
+    return fetch(markdownDocumentListEndpoint(), {
+      credentials: "same-origin",
+      headers: { Accept: "application/json" },
+      signal,
+    });
+  }
   return fetchWithCloudPrototypeAuth(
     markdownDocumentListEndpoint(),
     { headers: { Accept: "application/json" }, signal },
@@ -382,26 +421,31 @@ function cloudAuthWithScope(
 function cloudMarkdownDocumentListSeedFromBootstrapOrCache(
   authState: CloudPrototypeAuthState,
   bootstrap: CloudMarkdownDocumentListBootstrap | null,
+  appSession: CloudAppSession | null,
 ): CloudMarkdownDocumentListItem[] | null {
-  return bootstrap?.documents ?? readCachedCloudMarkdownDocumentListFromWindow(authState);
+  return (
+    bootstrap?.documents ?? readCachedCloudMarkdownDocumentListFromWindow(authState, appSession)
+  );
 }
 
 function readCachedCloudMarkdownDocumentListFromWindow(
   authState: CloudPrototypeAuthState,
+  appSession: CloudAppSession | null,
 ): CloudMarkdownDocumentListItem[] | null {
   const storage = cloudMarkdownDocumentListCacheStorage();
-  return storage ? readCachedCloudMarkdownDocumentList(storage, authState) : null;
+  return storage ? readCachedCloudMarkdownDocumentList(storage, authState, appSession) : null;
 }
 
 function writeCachedCloudMarkdownDocumentListToWindow(
   authState: CloudPrototypeAuthState,
+  appSession: CloudAppSession | null,
   documents: CloudMarkdownDocumentListItem[],
 ): void {
   const storage = cloudMarkdownDocumentListCacheStorage();
   if (!storage) {
     return;
   }
-  writeCachedCloudMarkdownDocumentList(storage, authState, documents);
+  writeCachedCloudMarkdownDocumentList(storage, authState, appSession, documents);
 }
 
 function clearCachedCloudMarkdownDocumentListFromWindow(): void {

--- a/apps/notebook-cloud/viewer/markdown-document-list-view.tsx
+++ b/apps/notebook-cloud/viewer/markdown-document-list-view.tsx
@@ -214,7 +214,7 @@ export function CloudMarkdownDocumentListView({
           <h1>Documents</h1>
           <p>
             {signedIn
-              ? "Draft, review, and publish Markdown without compute."
+              ? "Draft, review, and share Markdown without compute."
               : "Sign in to open Markdown documents."}
           </p>
         </div>

--- a/apps/notebook-cloud/viewer/markdown-document-list-view.tsx
+++ b/apps/notebook-cloud/viewer/markdown-document-list-view.tsx
@@ -18,6 +18,11 @@ import {
   type CloudMarkdownDocumentListItem,
 } from "./markdown-document-dashboard";
 import { projectHostedDocumentAuthState } from "./hosted-document-auth";
+import {
+  clearCachedCloudMarkdownDocumentList,
+  readCachedCloudMarkdownDocumentList,
+  writeCachedCloudMarkdownDocumentList,
+} from "./markdown-document-list-cache";
 import type {
   CloudMarkdownDocumentCreateResponse,
   CloudMarkdownDocumentListBootstrap,
@@ -59,7 +64,7 @@ export function CloudMarkdownDocumentListView({
     appSessionStatus.refreshAppSessionStatus,
   );
   const [listState, setListState] = useState<MarkdownDocumentListState>(() =>
-    initialMarkdownDocumentListState(bootstrap),
+    initialMarkdownDocumentListState(authState, bootstrap),
   );
   const [refreshIndex, setRefreshIndex] = useState(0);
   const [createOpen, setCreateOpen] = useState(false);
@@ -84,22 +89,27 @@ export function CloudMarkdownDocumentListView({
   }, [resolvedTheme]);
 
   useEffect(() => {
+    const seededDocuments = cloudMarkdownDocumentListSeedFromBootstrapOrCache(authState, bootstrap);
     if (!canFetchDocumentList) {
-      if (waitingForAppSession && bootstrap) {
-        setListState({ kind: "ready", documents: bootstrap.documents });
+      if (waitingForAppSession) {
+        setListState(
+          seededDocuments ? { kind: "ready", documents: seededDocuments } : { kind: "loading" },
+        );
         return;
       }
+      clearCachedCloudMarkdownDocumentListFromWindow();
       setListState({ kind: "signed_out" });
       return;
     }
     if (refreshIndex === 0 && bootstrap) {
+      writeCachedCloudMarkdownDocumentListToWindow(authState, bootstrap.documents);
       setListState({ kind: "ready", documents: bootstrap.documents });
       return;
     }
 
     const controller = new AbortController();
     setListState(
-      bootstrap ? { kind: "ready", documents: bootstrap.documents } : { kind: "loading" },
+      seededDocuments ? { kind: "ready", documents: seededDocuments } : { kind: "loading" },
     );
     void (async () => {
       try {
@@ -112,6 +122,7 @@ export function CloudMarkdownDocumentListView({
         if (!isCloudMarkdownDocumentListResponse(body)) {
           throw new Error("Unable to list Markdown documents: response shape was invalid");
         }
+        writeCachedCloudMarkdownDocumentListToWindow(authState, body.documents);
         setListState({ kind: "ready", documents: body.documents });
         setBootstrap({
           kind: "markdown-document-list",
@@ -316,6 +327,7 @@ export function CloudMarkdownDocumentListView({
           className="cloud-dashboard-secondary-action"
           onClick={() => {
             clearCloudPrototypeDevAuth(window.localStorage);
+            clearCachedCloudMarkdownDocumentListFromWindow();
             void clearCloudAppSession().finally(() => {
               window.location.reload();
             });
@@ -329,9 +341,11 @@ export function CloudMarkdownDocumentListView({
 }
 
 function initialMarkdownDocumentListState(
+  authState: CloudPrototypeAuthState,
   bootstrap: CloudMarkdownDocumentListBootstrap | null,
 ): MarkdownDocumentListState {
-  return bootstrap ? { kind: "ready", documents: bootstrap.documents } : { kind: "loading" };
+  const seededDocuments = cloudMarkdownDocumentListSeedFromBootstrapOrCache(authState, bootstrap);
+  return seededDocuments ? { kind: "ready", documents: seededDocuments } : { kind: "loading" };
 }
 
 function fetchMarkdownDocumentList(
@@ -358,6 +372,47 @@ function cloudAuthWithScope(
   scope: "viewer" | "editor" | "owner",
 ): CloudPrototypeAuthState {
   return authState.mode === "dev" ? { ...authState, requestedScope: scope } : authState;
+}
+
+function cloudMarkdownDocumentListSeedFromBootstrapOrCache(
+  authState: CloudPrototypeAuthState,
+  bootstrap: CloudMarkdownDocumentListBootstrap | null,
+): CloudMarkdownDocumentListItem[] | null {
+  return bootstrap?.documents ?? readCachedCloudMarkdownDocumentListFromWindow(authState);
+}
+
+function readCachedCloudMarkdownDocumentListFromWindow(
+  authState: CloudPrototypeAuthState,
+): CloudMarkdownDocumentListItem[] | null {
+  const storage = cloudMarkdownDocumentListCacheStorage();
+  return storage ? readCachedCloudMarkdownDocumentList(storage, authState) : null;
+}
+
+function writeCachedCloudMarkdownDocumentListToWindow(
+  authState: CloudPrototypeAuthState,
+  documents: CloudMarkdownDocumentListItem[],
+): void {
+  const storage = cloudMarkdownDocumentListCacheStorage();
+  if (!storage) {
+    return;
+  }
+  writeCachedCloudMarkdownDocumentList(storage, authState, documents);
+}
+
+function clearCachedCloudMarkdownDocumentListFromWindow(): void {
+  const storage = cloudMarkdownDocumentListCacheStorage();
+  if (!storage) {
+    return;
+  }
+  clearCachedCloudMarkdownDocumentList(storage);
+}
+
+function cloudMarkdownDocumentListCacheStorage(): Storage | null {
+  try {
+    return window.sessionStorage;
+  } catch {
+    return null;
+  }
 }
 
 function defaultMarkdownDocumentTitle(): string {

--- a/apps/notebook-cloud/viewer/markdown-document-list-view.tsx
+++ b/apps/notebook-cloud/viewer/markdown-document-list-view.tsx
@@ -4,7 +4,6 @@ import { useTheme } from "@/hooks/useTheme";
 import {
   clearCloudPrototypeDevAuth,
   fetchWithCloudPrototypeAuth,
-  shouldShowCloudHeaderSignIn,
   type CloudPrototypeAuthState,
 } from "./collaborator-auth";
 import { clearCloudAppSession, establishCloudAppSession } from "./app-session";
@@ -18,6 +17,7 @@ import {
   isCloudMarkdownDocumentListItem,
   type CloudMarkdownDocumentListItem,
 } from "./markdown-document-dashboard";
+import { projectHostedDocumentAuthState } from "./hosted-document-auth";
 import type {
   CloudMarkdownDocumentCreateResponse,
   CloudMarkdownDocumentListBootstrap,
@@ -66,16 +66,17 @@ export function CloudMarkdownDocumentListView({
   const [createTitle, setCreateTitle] = useState(() => defaultMarkdownDocumentTitle());
   const [createState, setCreateState] = useState<"idle" | "starting">("idle");
   const [createError, setCreateError] = useState<string | null>(null);
-  const hasExplicitAuth = authState.mode === "dev" || authState.mode === "oidc";
-  const hasAppSession = Boolean(appSessionStatus.session);
-  const signedIn = hasExplicitAuth || hasAppSession;
-  const canFetchDocumentList = authState.mode === "dev" || hasAppSession;
-  const appSessionLoading = appSessionStatus.status === "loading";
-  const waitingForAppSession = appSessionLoading || (authState.mode === "oidc" && !hasAppSession);
-  const showSignIn = shouldShowCloudHeaderSignIn(authState, {
-    appSessionLoading,
-    hasAppSession,
+  const hostedAuth = projectHostedDocumentAuthState(authState, {
+    appSession: appSessionStatus.session,
+    appSessionLoading: appSessionStatus.status === "loading",
   });
+  const {
+    canFetchCatalog: canFetchDocumentList,
+    hasAppSession,
+    showSignIn,
+    signedIn,
+    waitingForAppSession,
+  } = hostedAuth;
   const documents = listState.kind === "ready" ? listState.documents : [];
 
   useEffect(() => {

--- a/apps/notebook-cloud/viewer/markdown-document-list-view.tsx
+++ b/apps/notebook-cloud/viewer/markdown-document-list-view.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useMemo, useState, type FormEvent } from "react";
-import { FileText, Loader2, Plus, RotateCcw } from "lucide-react";
+import { BookOpen, FileText, Loader2, Plus, RotateCcw } from "lucide-react";
 import { useTheme } from "@/hooks/useTheme";
 import {
   clearCloudPrototypeDevAuth,
@@ -198,7 +198,15 @@ export function CloudMarkdownDocumentListView({
           </p>
         </div>
         <div className="cloud-dashboard-actions">
-          <CloudNotebookSignInButton authConfig={authConfig} authState={authState} />
+          <a className="cloud-dashboard-button" href="/n">
+            <BookOpen aria-hidden="true" />
+            Notebooks
+          </a>
+          <CloudNotebookSignInButton
+            authConfig={authConfig}
+            authState={authState}
+            documentLabel="document"
+          />
           {signedIn ? (
             <>
               <button type="button" className="cloud-dashboard-button" onClick={refreshList}>

--- a/apps/notebook-cloud/viewer/markdown-document-live-sync.ts
+++ b/apps/notebook-cloud/viewer/markdown-document-live-sync.ts
@@ -1,12 +1,14 @@
-import { IndexedDbStorageAdapter, type ConnectionStatus } from "runtimed";
+import { IndexedDbStorageAdapter, type ConnectionStatus, type StorageChunk } from "runtimed";
 import type { CloudMarkdownDocumentConfig } from "./cloud-viewer-types";
 import type { CloudAppSession } from "./app-session";
 import {
   cloudPrincipalFromActorLabel,
   CloudWebSocketTransport,
   createCloudConnectTarget,
+  withReadyTimeout,
   type CloudRoomReady,
 } from "./live-sync";
+import { cloudInstantPaintPrincipalMatcher } from "./instant-paint";
 import {
   cloudSyncAuthFromAppSessionCookie,
   cloudSyncAuthFromPrototypeAuthState,
@@ -58,6 +60,73 @@ export interface StartMarkdownDocumentLiveSyncOptions {
 const MARKDOWN_PERSISTENCE_KEY_SEGMENT = "markdown-doc";
 const MARKDOWN_PERSISTENCE_SNAPSHOT_SEGMENT = "snapshot";
 const MARKDOWN_PERSISTENCE_SAVE_DELAY_MS = 500;
+const MARKDOWN_INSTANT_PAINT_READ_TIMEOUT_MS = 2_000;
+const MARKDOWN_INSTANT_PAINT_ACTOR_LABEL = "system:markdown-instant-paint/browser:local";
+
+export async function loadMarkdownDocumentInstantPaintSnapshot({
+  authState,
+  config,
+  appSession,
+  title,
+  onError,
+  readTimeoutMs = MARKDOWN_INSTANT_PAINT_READ_TIMEOUT_MS,
+}: Pick<StartMarkdownDocumentLiveSyncOptions, "authState" | "config" | "appSession" | "title"> & {
+  onError?: (error: unknown) => void;
+  readTimeoutMs?: number;
+}): Promise<MarkdownDocumentLiveSnapshot | null> {
+  const adapter = IndexedDbStorageAdapter.create({ onError });
+  if (!adapter) {
+    return null;
+  }
+  const matchesPrincipal = cloudInstantPaintPrincipalMatcher(authState, {
+    hasAppSession: Boolean(appSession),
+  });
+  if (!matchesPrincipal) {
+    return null;
+  }
+
+  let records: StorageChunk[];
+  try {
+    records = await withReadyTimeout(
+      adapter.loadRange([MARKDOWN_PERSISTENCE_KEY_SEGMENT, config.documentId]),
+      readTimeoutMs,
+      `persisted MarkdownDoc read did not settle within ${readTimeoutMs}ms`,
+    );
+  } catch (error) {
+    console.warn("[notebook-cloud] Markdown instant-paint read failed; skipping paint", error);
+    return null;
+  }
+
+  const seed = selectMarkdownInstantPaintRecord(records, matchesPrincipal);
+  if (!seed) {
+    return null;
+  }
+
+  const moduleUrl = new URL(config.runtimedWasmModulePath, location.href);
+  const wasmUrl = new URL(config.runtimedWasmPath, location.href);
+  let handle: MarkdownHandle | null = null;
+  try {
+    handle = await loadMarkdownHandleFromBytes(
+      seed,
+      MARKDOWN_INSTANT_PAINT_ACTOR_LABEL,
+      moduleUrl,
+      wasmUrl,
+    );
+    return {
+      body: handle.body() ?? "",
+      bodyReady: handle.body_len() != null,
+      title: handle.title()?.trim() || title,
+    };
+  } catch (error) {
+    console.warn(
+      "[notebook-cloud] Markdown instant-paint snapshot load failed; skipping paint",
+      error,
+    );
+    return null;
+  } finally {
+    handle?.free();
+  }
+}
 
 export async function startMarkdownDocumentLiveSync({
   authState,
@@ -337,6 +406,30 @@ function markdownPersistenceKey(documentId: string, principal: string): string[]
     principal,
     MARKDOWN_PERSISTENCE_SNAPSHOT_SEGMENT,
   ];
+}
+
+export function selectMarkdownInstantPaintRecord(
+  records: readonly StorageChunk[],
+  matchesPrincipal: (principal: string) => boolean,
+): Uint8Array | undefined {
+  return records.find((record) => isMatchingMarkdownPersistenceRecord(record, matchesPrincipal))
+    ?.data;
+}
+
+function isMatchingMarkdownPersistenceRecord(
+  record: StorageChunk,
+  matchesPrincipal: (principal: string) => boolean,
+): boolean {
+  const [kind, documentId, principal, segment, ...extra] = record.key;
+  return (
+    kind === MARKDOWN_PERSISTENCE_KEY_SEGMENT &&
+    typeof documentId === "string" &&
+    typeof principal === "string" &&
+    segment === MARKDOWN_PERSISTENCE_SNAPSHOT_SEGMENT &&
+    extra.length === 0 &&
+    Boolean(record.data) &&
+    matchesPrincipal(principal)
+  );
 }
 
 function markdownSnapshotEndpoint(basePath: string, headsHash: string): string {

--- a/apps/notebook-cloud/viewer/markdown-document-live-sync.ts
+++ b/apps/notebook-cloud/viewer/markdown-document-live-sync.ts
@@ -1,0 +1,310 @@
+import { IndexedDbStorageAdapter, type ConnectionStatus } from "runtimed";
+import type { CloudMarkdownDocumentConfig } from "./cloud-viewer-types";
+import type { CloudAppSession } from "./app-session";
+import {
+  cloudPrincipalFromActorLabel,
+  CloudWebSocketTransport,
+  createCloudConnectTarget,
+  type CloudRoomReady,
+} from "./live-sync";
+import {
+  cloudSyncAuthFromAppSessionCookie,
+  cloudSyncAuthFromPrototypeAuthState,
+  type CloudPrototypeAuthState,
+} from "./collaborator-auth";
+import {
+  createBootstrapMarkdownHandle,
+  loadMarkdownHandleFromBytes,
+  type MarkdownHandle,
+} from "./runtimed-wasm-client";
+import { FrameType } from "../src/protocol";
+
+export interface MarkdownDocumentLiveSnapshot {
+  body: string;
+  bodyReady: boolean;
+  title: string;
+}
+
+export interface MarkdownDocumentLiveSyncController {
+  readonly actorLabel: string;
+  readonly peerId: string;
+  readonly transport: CloudWebSocketTransport;
+  editBody(nextBody: string): void;
+  flushNow(): Promise<void>;
+  dispose(): void;
+}
+
+export interface StartMarkdownDocumentLiveSyncOptions {
+  authState: CloudPrototypeAuthState;
+  config: CloudMarkdownDocumentConfig;
+  appSession: CloudAppSession | null;
+  title: string;
+  scope: "owner" | "editor" | "viewer";
+  onConnectionLost?: (reason: Error) => void;
+  onError?: (error: unknown) => void;
+  onSnapshot: (snapshot: MarkdownDocumentLiveSnapshot) => void;
+  onStatus?: (status: ConnectionStatus) => void;
+}
+
+const MARKDOWN_PERSISTENCE_KEY_SEGMENT = "markdown-doc";
+const MARKDOWN_PERSISTENCE_SNAPSHOT_SEGMENT = "snapshot";
+const MARKDOWN_PERSISTENCE_SAVE_DELAY_MS = 500;
+
+export async function startMarkdownDocumentLiveSync({
+  authState,
+  config,
+  appSession,
+  title,
+  scope,
+  onConnectionLost,
+  onError,
+  onSnapshot,
+  onStatus,
+}: StartMarkdownDocumentLiveSyncOptions): Promise<MarkdownDocumentLiveSyncController> {
+  const transport = new CloudWebSocketTransport({
+    connectTarget: createCloudConnectTarget({
+      syncEndpoint: config.syncEndpoint,
+      resolveAuth: (sessionId) =>
+        appSession
+          ? cloudSyncAuthFromAppSessionCookie({ requestedScope: scope, sessionId })
+          : cloudSyncAuthFromPrototypeAuthState({ ...authState, requestedScope: scope }),
+    }),
+    onConnectionLost,
+  });
+  const statusSubscription = onStatus
+    ? transport.connectionStatus$.subscribe((status) => onStatus(status))
+    : null;
+  let roomReadySubscription: { unsubscribe(): void } | null = null;
+  let handle: MarkdownHandle | null = null;
+  let disposed = false;
+  let peerId: string | null = null;
+  let actorLabel: string | null = null;
+  let saveTimer: ReturnType<typeof setTimeout> | null = null;
+  let persistence: MarkdownPersistence | null = null;
+
+  const publishSnapshot = () => {
+    if (!handle) {
+      return;
+    }
+    onSnapshot({
+      body: handle.body() ?? "",
+      bodyReady: handle.body_len() != null,
+      title: handle.title()?.trim() || title,
+    });
+  };
+
+  const saveNow = async () => {
+    if (!handle || !persistence) {
+      return;
+    }
+    try {
+      await persistence.save(handle.save());
+    } catch (error) {
+      onError?.(error);
+    }
+  };
+
+  const scheduleSave = () => {
+    if (!persistence || disposed) {
+      return;
+    }
+    if (saveTimer !== null) {
+      clearTimeout(saveTimer);
+    }
+    saveTimer = setTimeout(() => {
+      saveTimer = null;
+      void saveNow();
+    }, MARKDOWN_PERSISTENCE_SAVE_DELAY_MS);
+  };
+
+  const flush = () => {
+    if (!handle) {
+      return;
+    }
+    const message = handle.flush_local_changes();
+    if (!message) {
+      return;
+    }
+    transport.sendFrame(FrameType.AUTOMERGE_SYNC, message).catch((error: unknown) => {
+      handle?.cancel_last_flush();
+      onError?.(error);
+    });
+  };
+
+  const applyRoomReady = (ready: CloudRoomReady) => {
+    if (!handle || ready.peer_id === peerId) {
+      return;
+    }
+    peerId = ready.peer_id;
+    actorLabel = ready.actor_label;
+    handle.set_actor(ready.actor_label);
+    handle.reset_sync_state();
+    flush();
+  };
+
+  try {
+    const ready = await transport.ready;
+    peerId = ready.peer_id;
+    actorLabel = ready.actor_label;
+    const principal = cloudPrincipalFromActorLabel(ready.actor_label);
+    persistence = createMarkdownPersistence(config.documentId, principal, onError);
+    const seed = await persistence?.load();
+    const moduleUrl = new URL(config.runtimedWasmModulePath, location.href);
+    const wasmUrl = new URL(config.runtimedWasmPath, location.href);
+    handle = seed
+      ? await loadMarkdownHandleFromBytes(seed, ready.actor_label, moduleUrl, wasmUrl)
+      : await createBootstrapMarkdownHandle(ready.actor_label, moduleUrl, wasmUrl);
+    if (disposed) {
+      handle.free();
+      handle = null;
+      transport.disconnect();
+      throw new Error("Markdown live sync disposed before ready");
+    }
+    publishSnapshot();
+    roomReadySubscription = transport.roomReady$.subscribe(applyRoomReady);
+    transport.onFrame((frame) => {
+      if (!handle) {
+        return;
+      }
+      const events = handle.receive_frame(new Uint8Array(frame)) as Array<{
+        type: string;
+        changed?: boolean;
+        reply?: number[];
+      }> | null;
+      if (!Array.isArray(events)) {
+        return;
+      }
+      let changed = false;
+      for (const event of events) {
+        if (event.reply) {
+          transport
+            .sendFrame(FrameType.AUTOMERGE_SYNC, new Uint8Array(event.reply))
+            .catch((error: unknown) => {
+              handle?.cancel_last_flush();
+              onError?.(error);
+            });
+        }
+        if (event.changed) {
+          changed = true;
+        }
+      }
+      if (changed) {
+        publishSnapshot();
+        scheduleSave();
+      }
+    });
+    flush();
+    return {
+      get actorLabel() {
+        return actorLabel ?? "";
+      },
+      get peerId() {
+        return peerId ?? "";
+      },
+      transport,
+      editBody: (nextBody) => {
+        if (!handle || handle.body_len() == null) {
+          return;
+        }
+        const previousBody = handle.body() ?? "";
+        const splice = diffAsSplice(previousBody, nextBody);
+        handle.splice_body(splice.index, splice.deleteCount, splice.insertText);
+        publishSnapshot();
+        scheduleSave();
+        flush();
+      },
+      flushNow: async () => {
+        if (saveTimer !== null) {
+          clearTimeout(saveTimer);
+          saveTimer = null;
+        }
+        await saveNow();
+      },
+      dispose: () => {
+        disposed = true;
+        statusSubscription?.unsubscribe();
+        roomReadySubscription?.unsubscribe();
+        if (saveTimer !== null) {
+          clearTimeout(saveTimer);
+          saveTimer = null;
+        }
+        void saveNow();
+        transport.disconnect();
+        handle?.free();
+        handle = null;
+      },
+    };
+  } catch (error) {
+    statusSubscription?.unsubscribe();
+    transport.disconnect();
+    handle?.free();
+    throw error;
+  }
+}
+
+interface MarkdownPersistence {
+  load(): Promise<Uint8Array | undefined>;
+  save(bytes: Uint8Array): Promise<void>;
+}
+
+function createMarkdownPersistence(
+  documentId: string,
+  principal: string,
+  onError?: (error: unknown) => void,
+): MarkdownPersistence | null {
+  const adapter = IndexedDbStorageAdapter.create({ onError });
+  if (!adapter) {
+    return null;
+  }
+  const key = markdownPersistenceKey(documentId, principal);
+  return {
+    load: () => adapter.load(key),
+    save: (bytes) => adapter.save(key, bytes),
+  };
+}
+
+function markdownPersistenceKey(documentId: string, principal: string): string[] {
+  return [
+    MARKDOWN_PERSISTENCE_KEY_SEGMENT,
+    documentId,
+    principal,
+    MARKDOWN_PERSISTENCE_SNAPSHOT_SEGMENT,
+  ];
+}
+
+function diffAsSplice(
+  previous: string,
+  next: string,
+): {
+  index: number;
+  deleteCount: number;
+  insertText: string;
+} {
+  if (previous === next) {
+    return { index: previous.length, deleteCount: 0, insertText: "" };
+  }
+  let prefix = 0;
+  const minLength = Math.min(previous.length, next.length);
+  while (prefix < minLength && previous[prefix] === next[prefix]) {
+    prefix += 1;
+  }
+  let previousSuffix = previous.length;
+  let nextSuffix = next.length;
+  while (
+    previousSuffix > prefix &&
+    nextSuffix > prefix &&
+    previous[previousSuffix - 1] === next[nextSuffix - 1]
+  ) {
+    previousSuffix -= 1;
+    nextSuffix -= 1;
+  }
+  return {
+    index: utf16Length(previous.slice(0, prefix)),
+    deleteCount: utf16Length(previous.slice(prefix, previousSuffix)),
+    insertText: next.slice(prefix, nextSuffix),
+  };
+}
+
+function utf16Length(value: string): number {
+  return value.length;
+}

--- a/apps/notebook-cloud/viewer/markdown-document-live-sync.ts
+++ b/apps/notebook-cloud/viewer/markdown-document-live-sync.ts
@@ -10,8 +10,10 @@ import {
 import {
   cloudSyncAuthFromAppSessionCookie,
   cloudSyncAuthFromPrototypeAuthState,
+  fetchWithCloudPrototypeAuth,
   type CloudPrototypeAuthState,
 } from "./collaborator-auth";
+import { cloudResponseError } from "./cloud-response";
 import {
   createBootstrapMarkdownHandle,
   loadMarkdownHandleFromBytes,
@@ -31,7 +33,13 @@ export interface MarkdownDocumentLiveSyncController {
   readonly transport: CloudWebSocketTransport;
   editBody(nextBody: string): void;
   flushNow(): Promise<void>;
+  publishSnapshot(): Promise<MarkdownDocumentPublishedSnapshot>;
   dispose(): void;
+}
+
+export interface MarkdownDocumentPublishedSnapshot {
+  headsHash: string;
+  revisionId: string;
 }
 
 export interface StartMarkdownDocumentLiveSyncOptions {
@@ -220,6 +228,42 @@ export async function startMarkdownDocumentLiveSync({
         }
         await saveNow();
       },
+      publishSnapshot: async () => {
+        if (!handle) {
+          throw new Error("Markdown document is not ready to publish");
+        }
+        flush();
+        if (saveTimer !== null) {
+          clearTimeout(saveTimer);
+          saveTimer = null;
+        }
+        const snapshotBytes = handle.save();
+        await saveNow();
+        const headsHash = await markdownHeadsDigest(handle.get_heads_hex());
+        const response = await fetchWithCloudPrototypeAuth(
+          markdownSnapshotEndpoint(config.snapshotBasePath, headsHash),
+          {
+            method: "PUT",
+            headers: {
+              Accept: "application/json",
+              "Content-Type": "application/octet-stream",
+            },
+            body: snapshotBytes,
+          },
+          authState.mode === "dev" ? { ...authState, requestedScope: "owner" } : authState,
+        );
+        if (!response.ok) {
+          throw await cloudResponseError(response, "Unable to publish Markdown document");
+        }
+        const body = (await response.json()) as { revision_id?: unknown };
+        if (typeof body.revision_id !== "string" || body.revision_id.trim() === "") {
+          throw new Error("Markdown publish response did not include a revision id");
+        }
+        return {
+          headsHash,
+          revisionId: body.revision_id,
+        };
+      },
       dispose: () => {
         disposed = true;
         statusSubscription?.unsubscribe();
@@ -270,6 +314,19 @@ function markdownPersistenceKey(documentId: string, principal: string): string[]
     principal,
     MARKDOWN_PERSISTENCE_SNAPSHOT_SEGMENT,
   ];
+}
+
+function markdownSnapshotEndpoint(basePath: string, headsHash: string): string {
+  const normalizedBasePath = basePath.endsWith("/") ? basePath : `${basePath}/`;
+  return `${normalizedBasePath}${encodeURIComponent(headsHash)}`;
+}
+
+async function markdownHeadsDigest(heads: string[]): Promise<string> {
+  const input = heads.length > 0 ? [...heads].sort().join("\n") : "empty";
+  const digest = await crypto.subtle.digest("SHA-256", new TextEncoder().encode(input));
+  return `heads-${Array.from(new Uint8Array(digest), (byte) => byte.toString(16).padStart(2, "0"))
+    .join("")
+    .slice(0, 24)}`;
 }
 
 function diffAsSplice(

--- a/apps/notebook-cloud/viewer/markdown-document-live-sync.ts
+++ b/apps/notebook-cloud/viewer/markdown-document-live-sync.ts
@@ -63,6 +63,12 @@ const MARKDOWN_PERSISTENCE_SAVE_DELAY_MS = 500;
 const MARKDOWN_INSTANT_PAINT_READ_TIMEOUT_MS = 2_000;
 const MARKDOWN_INSTANT_PAINT_ACTOR_LABEL = "system:markdown-instant-paint/browser:local";
 
+export function shouldLoadMarkdownInstantPaintSnapshot(config: {
+  bootstrap?: { render_seed?: { body?: unknown } | null } | null;
+}): boolean {
+  return typeof config.bootstrap?.render_seed?.body !== "string";
+}
+
 export async function loadMarkdownDocumentInstantPaintSnapshot({
   authState,
   config,

--- a/apps/notebook-cloud/viewer/markdown-document-live-sync.ts
+++ b/apps/notebook-cloud/viewer/markdown-document-live-sync.ts
@@ -32,6 +32,7 @@ export interface MarkdownDocumentLiveSyncController {
   readonly peerId: string;
   readonly transport: CloudWebSocketTransport;
   editBody(nextBody: string): void;
+  editTitle(nextTitle: string): void;
   flushNow(): Promise<void>;
   publishSnapshot(): Promise<MarkdownDocumentPublishedSnapshot>;
   dispose(): void;
@@ -139,6 +140,24 @@ export async function startMarkdownDocumentLiveSync({
     });
   };
 
+  const editTitle = (nextTitle: string) => {
+    if (!handle) {
+      return;
+    }
+    const normalizedTitle = nextTitle.trim() || "Untitled Markdown";
+    if ((handle.title()?.trim() || "Untitled Markdown") === normalizedTitle) {
+      return;
+    }
+    try {
+      handle.set_title(normalizedTitle);
+      publishSnapshot();
+      scheduleSave();
+      flush();
+    } catch (error) {
+      onError?.(error);
+    }
+  };
+
   const applyRoomReady = (ready: CloudRoomReady) => {
     if (!handle || ready.peer_id === peerId) {
       return;
@@ -167,6 +186,9 @@ export async function startMarkdownDocumentLiveSync({
       handle = null;
       transport.disconnect();
       throw new Error("Markdown live sync disposed before ready");
+    }
+    if (scope !== "viewer") {
+      editTitle(title);
     }
     publishSnapshot();
     roomReadySubscription = transport.roomReady$.subscribe(applyRoomReady);
@@ -221,6 +243,7 @@ export async function startMarkdownDocumentLiveSync({
         scheduleSave();
         flush();
       },
+      editTitle,
       flushNow: async () => {
         if (saveTimer !== null) {
           clearTimeout(saveTimer);

--- a/apps/notebook-cloud/viewer/markdown-document-live-sync.ts
+++ b/apps/notebook-cloud/viewer/markdown-document-live-sync.ts
@@ -12,10 +12,8 @@ import { cloudInstantPaintPrincipalMatcher } from "./instant-paint";
 import {
   cloudSyncAuthFromAppSessionCookie,
   cloudSyncAuthFromPrototypeAuthState,
-  fetchWithCloudPrototypeAuth,
   type CloudPrototypeAuthState,
 } from "./collaborator-auth";
-import { cloudResponseError } from "./cloud-response";
 import {
   createBootstrapMarkdownHandle,
   loadMarkdownHandleFromBytes,
@@ -36,13 +34,7 @@ export interface MarkdownDocumentLiveSyncController {
   editBody(nextBody: string): void;
   editTitle(nextTitle: string): void;
   flushNow(): Promise<void>;
-  publishSnapshot(): Promise<MarkdownDocumentPublishedSnapshot>;
   dispose(): void;
-}
-
-export interface MarkdownDocumentPublishedSnapshot {
-  headsHash: string;
-  revisionId: string;
 }
 
 export interface StartMarkdownDocumentLiveSyncOptions {
@@ -166,7 +158,7 @@ export async function startMarkdownDocumentLiveSync({
   let saveTimer: ReturnType<typeof setTimeout> | null = null;
   let persistence: MarkdownPersistence | null = null;
 
-  const publishSnapshot = () => {
+  const emitSnapshot = () => {
     if (!handle) {
       return;
     }
@@ -225,7 +217,7 @@ export async function startMarkdownDocumentLiveSync({
     }
     try {
       handle.set_title(normalizedTitle);
-      publishSnapshot();
+      emitSnapshot();
       scheduleSave();
       flush();
     } catch (error) {
@@ -265,7 +257,7 @@ export async function startMarkdownDocumentLiveSync({
     if (scope !== "viewer") {
       editTitle(title);
     }
-    publishSnapshot();
+    emitSnapshot();
     roomReadySubscription = transport.roomReady$.subscribe(applyRoomReady);
     transport.onFrame((frame) => {
       if (!handle) {
@@ -294,7 +286,7 @@ export async function startMarkdownDocumentLiveSync({
         }
       }
       if (changed) {
-        publishSnapshot();
+        emitSnapshot();
         scheduleSave();
       }
     });
@@ -314,7 +306,7 @@ export async function startMarkdownDocumentLiveSync({
         const previousBody = handle.body() ?? "";
         const splice = diffAsSplice(previousBody, nextBody);
         handle.splice_body(splice.index, splice.deleteCount, splice.insertText);
-        publishSnapshot();
+        emitSnapshot();
         scheduleSave();
         flush();
       },
@@ -325,42 +317,6 @@ export async function startMarkdownDocumentLiveSync({
           saveTimer = null;
         }
         await saveNow();
-      },
-      publishSnapshot: async () => {
-        if (!handle) {
-          throw new Error("Markdown document is not ready to publish");
-        }
-        flush();
-        if (saveTimer !== null) {
-          clearTimeout(saveTimer);
-          saveTimer = null;
-        }
-        const snapshotBytes = handle.save();
-        await saveNow();
-        const headsHash = await markdownHeadsDigest(handle.get_heads_hex());
-        const response = await fetchWithCloudPrototypeAuth(
-          markdownSnapshotEndpoint(config.snapshotBasePath, headsHash),
-          {
-            method: "PUT",
-            headers: {
-              Accept: "application/json",
-              "Content-Type": "application/octet-stream",
-            },
-            body: snapshotBytes,
-          },
-          authState.mode === "dev" ? { ...authState, requestedScope: "owner" } : authState,
-        );
-        if (!response.ok) {
-          throw await cloudResponseError(response, "Unable to publish Markdown document");
-        }
-        const body = (await response.json()) as { revision_id?: unknown };
-        if (typeof body.revision_id !== "string" || body.revision_id.trim() === "") {
-          throw new Error("Markdown publish response did not include a revision id");
-        }
-        return {
-          headsHash,
-          revisionId: body.revision_id,
-        };
       },
       dispose: () => {
         disposed = true;
@@ -436,19 +392,6 @@ function isMatchingMarkdownPersistenceRecord(
     Boolean(record.data) &&
     matchesPrincipal(principal)
   );
-}
-
-function markdownSnapshotEndpoint(basePath: string, headsHash: string): string {
-  const normalizedBasePath = basePath.endsWith("/") ? basePath : `${basePath}/`;
-  return `${normalizedBasePath}${encodeURIComponent(headsHash)}`;
-}
-
-async function markdownHeadsDigest(heads: string[]): Promise<string> {
-  const input = heads.length > 0 ? [...heads].sort().join("\n") : "empty";
-  const digest = await crypto.subtle.digest("SHA-256", new TextEncoder().encode(input));
-  return `heads-${Array.from(new Uint8Array(digest), (byte) => byte.toString(16).padStart(2, "0"))
-    .join("")
-    .slice(0, 24)}`;
 }
 
 function diffAsSplice(

--- a/apps/notebook-cloud/viewer/markdown-document-route.tsx
+++ b/apps/notebook-cloud/viewer/markdown-document-route.tsx
@@ -5,15 +5,15 @@ import type { ConnectionStatus, NotebookOutlineItem } from "runtimed";
 import { notebookRouteSegmentTitle } from "../src/notebook-route-title";
 import type { CodeMirrorEditorRef } from "@/components/editor/codemirror-editor";
 import { ProjectedMarkdownView } from "@/components/markdown/ProjectedMarkdownView";
+import { DocumentTitle } from "@/components/notebook/DocumentTitle";
+import { NotebookDocumentHeader } from "@/components/notebook/NotebookDocumentHeader";
+import { NotebookDocumentShell } from "@/components/notebook/NotebookDocumentShell";
+import { NotebookNotice, NotebookNoticeStack } from "@/components/notebook/NotebookNotice";
+import { NotebookToolbarFrame } from "@/components/notebook/NotebookToolbarFrame";
 import {
-  NotebookDocumentShell,
-  NotebookDocumentToolbar,
-  DocumentTitle,
-  NotebookNotice,
-  NotebookNoticeStack,
   projectNotebookShellCapabilities,
   type NotebookShellCapabilities,
-} from "@/components/notebook";
+} from "@/components/notebook/capabilities";
 import { NotebookOutlinePanel } from "@/components/notebook-rail/NotebookRail";
 import { Rail, RAIL_TAKEOVER_STAGE_CLASS_NAME } from "@/components/rail";
 import { MarkdownDocumentModeToggle } from "@/components/markdown/MarkdownDocumentModeToggle";
@@ -411,49 +411,50 @@ export function MarkdownDocumentRoute({
     </Rail>
   );
   const toolbar = (
-    <NotebookDocumentToolbar
-      capabilities={shellCapabilities}
-      frameClassName="z-20"
-      headerClassName="cloud-room-toolbar cloud-markdown-room-toolbar"
-      presence={
-        <DocumentTitle
-          title={markdownTitle}
-          renameTitle={projection.title === "Untitled Markdown" ? "" : projection.title}
-          canRename={projection.canEdit}
-          renameSaving={markdownTitleSaving}
-          renameError={markdownTitleError}
-          onRename={saveMarkdownDocumentTitle}
-          homeHref="/m"
-          homeAriaLabel="Open Markdown documents"
-          homeTitle="Markdown documents"
-          homeIcon={<House aria-hidden="true" />}
-          inputAriaLabel="Markdown document title"
-          inputName="markdown-document-title"
-          placeholder="Untitled Markdown"
-          renameButtonTitle="Rename Markdown document"
-          classNames={{
-            ...cloudNotebookTitleClassNames,
-            group: "cloud-notebook-title-group cloud-markdown-title-group",
-          }}
-        />
-      }
-      utilityControls={
-        <MarkdownDocumentModeToggle
-          mode={activeMode}
-          canEdit={canEdit}
-          onModeChange={onModeChange}
-        />
-      }
-      sharingControls={
-        canManageSharing ? (
-          <MarkdownSharingControls
-            aclEndpoint={config.aclEndpoint}
-            authState={authState}
-            publicLink={publicLink}
+    <NotebookToolbarFrame className="z-20">
+      <NotebookDocumentHeader
+        capabilities={shellCapabilities}
+        className="cloud-room-toolbar cloud-markdown-room-toolbar"
+        presence={
+          <DocumentTitle
+            title={markdownTitle}
+            renameTitle={projection.title === "Untitled Markdown" ? "" : projection.title}
+            canRename={projection.canEdit}
+            renameSaving={markdownTitleSaving}
+            renameError={markdownTitleError}
+            onRename={saveMarkdownDocumentTitle}
+            homeHref="/m"
+            homeAriaLabel="Open Markdown documents"
+            homeTitle="Markdown documents"
+            homeIcon={<House aria-hidden="true" />}
+            inputAriaLabel="Markdown document title"
+            inputName="markdown-document-title"
+            placeholder="Untitled Markdown"
+            renameButtonTitle="Rename Markdown document"
+            classNames={{
+              ...cloudNotebookTitleClassNames,
+              group: "cloud-notebook-title-group cloud-markdown-title-group",
+            }}
           />
-        ) : null
-      }
-    />
+        }
+        utilityControls={
+          <MarkdownDocumentModeToggle
+            mode={activeMode}
+            canEdit={canEdit}
+            onModeChange={onModeChange}
+          />
+        }
+        sharingControls={
+          canManageSharing ? (
+            <MarkdownSharingControls
+              aclEndpoint={config.aclEndpoint}
+              authState={authState}
+              publicLink={publicLink}
+            />
+          ) : null
+        }
+      />
+    </NotebookToolbarFrame>
   );
   const notices = connectionCopy ? (
     <NotebookNoticeStack>

--- a/apps/notebook-cloud/viewer/markdown-document-route.tsx
+++ b/apps/notebook-cloud/viewer/markdown-document-route.tsx
@@ -424,6 +424,7 @@ export function MarkdownDocumentRoute({
   const shellCapabilities = markdownDocumentShellCapabilities({
     access: routeState.scope,
     authState,
+    hasAppSession: Boolean(appSessionStatus.session),
     canEdit,
     canManageSharing,
     mode: activeMode,
@@ -675,17 +676,20 @@ function markdownDocumentBrowserTitle(title: string): string {
 function markdownDocumentShellCapabilities({
   access,
   authState,
+  hasAppSession,
   canEdit,
   canManageSharing,
   mode,
 }: {
   access: MarkdownDocumentAccessLevel;
   authState: CloudPrototypeAuthState;
+  hasAppSession: boolean;
   canEdit: boolean;
   canManageSharing: boolean;
   mode: MarkdownDocumentMode;
 }): NotebookShellCapabilities {
-  const canUseAuthenticatedIdentity = authState.mode === "dev" || authState.mode === "oidc";
+  const canUseAuthenticatedIdentity =
+    hasAppSession || authState.mode === "dev" || authState.mode === "oidc";
   const wantsEditMode = mode === "edit";
   const canEditMarkdown = wantsEditMode && canEdit;
   return projectNotebookShellCapabilities({
@@ -708,7 +712,8 @@ function markdownDocumentShellCapabilities({
     auth: {
       canSignIn: !canUseAuthenticatedIdentity,
       canUseAuthenticatedIdentity,
-      needsAttention: authState.mode === "invalid" || authState.mode === "oidc_expired",
+      needsAttention:
+        !hasAppSession && (authState.mode === "invalid" || authState.mode === "oidc_expired"),
     },
     runtime: {
       canWriteRuntimeState: false,

--- a/apps/notebook-cloud/viewer/markdown-document-route.tsx
+++ b/apps/notebook-cloud/viewer/markdown-document-route.tsx
@@ -1,13 +1,9 @@
-import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { lazy, Suspense, useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { House, ListTree } from "lucide-react";
 import type { EditorView } from "@codemirror/view";
 import type { ConnectionStatus, NotebookOutlineItem } from "runtimed";
 import { notebookRouteSegmentTitle } from "../src/notebook-route-title";
-import {
-  CodeMirrorEditor,
-  externalChangeAnnotation,
-  type CodeMirrorEditorRef,
-} from "@/components/editor/codemirror-editor";
+import type { CodeMirrorEditorRef } from "@/components/editor/codemirror-editor";
 import { ProjectedMarkdownView } from "@/components/markdown/ProjectedMarkdownView";
 import {
   NotebookDocumentShell,
@@ -35,16 +31,34 @@ import {
 import { cloudNotebookTitleClassNames } from "./cloud-notebook-title";
 import type { CloudMarkdownDocumentConfig, CloudViewerAuthConfig } from "./cloud-viewer-types";
 import { fetchWithCloudPrototypeAuth, type CloudPrototypeAuthState } from "./collaborator-auth";
-import {
-  startMarkdownDocumentLiveSync,
-  type MarkdownDocumentLiveSyncController,
-} from "./markdown-document-live-sync";
+import type { MarkdownDocumentLiveSyncController } from "./markdown-document-live-sync";
 import { MarkdownSharingControls } from "./markdown-sharing-controls";
 import {
   useCloudAppSessionBridge,
   useCloudAppSessionStatus,
   useCloudPrototypeAuth,
 } from "./use-cloud-auth";
+import { loadSupplementalViewerCss } from "./supplemental-css";
+
+type MarkdownEditorModule = typeof import("@/components/editor/codemirror-editor");
+type MarkdownDocumentLiveSyncModule = typeof import("./markdown-document-live-sync");
+
+const MarkdownCodeMirrorEditor = lazy(() =>
+  loadMarkdownEditorModule().then((module) => ({ default: module.CodeMirrorEditor })),
+);
+
+let markdownEditorModulePromise: Promise<MarkdownEditorModule> | null = null;
+let markdownDocumentLiveSyncModulePromise: Promise<MarkdownDocumentLiveSyncModule> | null = null;
+
+function loadMarkdownEditorModule(): Promise<MarkdownEditorModule> {
+  markdownEditorModulePromise ??= import("@/components/editor/codemirror-editor");
+  return markdownEditorModulePromise;
+}
+
+function loadMarkdownDocumentLiveSyncModule(): Promise<MarkdownDocumentLiveSyncModule> {
+  markdownDocumentLiveSyncModulePromise ??= import("./markdown-document-live-sync");
+  return markdownDocumentLiveSyncModulePromise;
+}
 
 interface MarkdownCatalogResponse {
   document: {
@@ -114,6 +128,10 @@ export function MarkdownDocumentRoute({
   const connectionStatusRef = useRef<ConnectionStatus>("connecting");
 
   useEffect(() => {
+    loadSupplementalViewerCss();
+  }, []);
+
+  useEffect(() => {
     if (typeof window === "undefined") {
       return;
     }
@@ -141,12 +159,17 @@ export function MarkdownDocumentRoute({
             ? { ...current, bodyReady: false, connectionStatus: "connecting" }
             : initialMarkdownDocumentRouteState(config),
         );
-        const catalog =
-          markdownCatalogFromBootstrap(config) ?? (await fetchMarkdownCatalog(config, authState));
+        const catalogPromise = Promise.resolve(
+          markdownCatalogFromBootstrap(config) ?? fetchMarkdownCatalog(config, authState),
+        );
+        const [catalog, liveSyncModule] = await Promise.all([
+          catalogPromise,
+          loadMarkdownDocumentLiveSyncModule(),
+        ]);
         if (disposed) return;
         const title = catalog.document.title?.trim() || "Untitled Markdown";
         const latestRevisionId = catalog.document.latest_revision_id;
-        controller = await startMarkdownDocumentLiveSync({
+        controller = await liveSyncModule.startMarkdownDocumentLiveSync({
           authState,
           config,
           appSession: appSessionStatus.session,
@@ -293,10 +316,19 @@ export function MarkdownDocumentRoute({
     if (currentBody === routeState.body) {
       return;
     }
-    editor.dispatch({
-      changes: { from: 0, to: editor.state.doc.length, insert: routeState.body },
-      annotations: externalChangeAnnotation.of(true),
+    let cancelled = false;
+    void loadMarkdownEditorModule().then(({ externalChangeAnnotation }) => {
+      if (cancelled || editorRef.current?.getEditor() !== editor) {
+        return;
+      }
+      editor.dispatch({
+        changes: { from: 0, to: editor.state.doc.length, insert: routeState.body },
+        annotations: externalChangeAnnotation.of(true),
+      });
     });
+    return () => {
+      cancelled = true;
+    };
   }, [mode, routeState]);
 
   if (routeState.kind === "error" || !projection) {
@@ -432,15 +464,23 @@ export function MarkdownDocumentRoute({
     >
       <div className="markdown-document-scroll" data-mode={activeMode}>
         {activeMode === "edit" && canEdit ? (
-          <CodeMirrorEditor
-            ref={editorRef}
-            key={config.documentId}
-            initialValue={projection.body}
-            language="markdown"
-            lineWrapping
-            className="markdown-document-editor"
-            onValueChange={onEditorValueChange}
-          />
+          <Suspense
+            fallback={
+              <div className="cloud-state markdown-document-editor" data-kind="loading">
+                Loading editor.
+              </div>
+            }
+          >
+            <MarkdownCodeMirrorEditor
+              ref={editorRef}
+              key={config.documentId}
+              initialValue={projection.body}
+              language="markdown"
+              lineWrapping
+              className="markdown-document-editor"
+              onValueChange={onEditorValueChange}
+            />
+          </Suspense>
         ) : projection.markdownPlan ? (
           <ProjectedMarkdownView
             plan={projection.markdownPlan}

--- a/apps/notebook-cloud/viewer/markdown-document-route.tsx
+++ b/apps/notebook-cloud/viewer/markdown-document-route.tsx
@@ -22,6 +22,7 @@ import {
   type MarkdownDocumentMode,
   type MarkdownDocumentProjection,
 } from "@/lib/markdown-document";
+import type { MarkdownProjectionPlan } from "@/lib/markdown-projection";
 import { cn } from "@/lib/utils";
 import { cloudResponseError } from "./cloud-response";
 import {
@@ -95,6 +96,8 @@ type RouteState =
       title: string;
       body: string;
       bodyReady: boolean;
+      markdownPlan: MarkdownProjectionPlan | null;
+      liveReady: boolean;
       scope: "owner" | "editor" | "viewer";
       connectionStatus: ConnectionStatus;
       latestRevisionId: string | null;
@@ -164,7 +167,7 @@ export function MarkdownDocumentRoute({
         connectionStatusRef.current = "connecting";
         setRouteState((current) =>
           current.kind === "ready"
-            ? { ...current, bodyReady: false, connectionStatus: "connecting" }
+            ? { ...current, connectionStatus: "connecting" }
             : initialMarkdownDocumentRouteState(config),
         );
         const catalogPromise = Promise.resolve(
@@ -201,8 +204,10 @@ export function MarkdownDocumentRoute({
               title: snapshot.title,
               body: snapshot.body,
               bodyReady: snapshot.bodyReady,
+              markdownPlan: null,
               scope: catalog.document.scope,
               connectionStatus: connectionStatusRef.current,
+              liveReady: true,
               latestRevisionId,
             });
           },
@@ -239,6 +244,7 @@ export function MarkdownDocumentRoute({
       id: config.documentId,
       title: routeState.title,
       body: routeState.body,
+      markdownPlan: routeState.markdownPlan,
       access: routeState.scope,
       requestedMode: mode,
       publishedRevisionId: routeState.latestRevisionId,
@@ -353,7 +359,7 @@ export function MarkdownDocumentRoute({
     );
   }
 
-  const canEdit = projection.canEdit && routeState.bodyReady;
+  const canEdit = projection.canEdit && routeState.liveReady;
   const canManageSharing =
     projection.canShare && config.hostCapabilities?.canManageSharing !== false;
   const activeMode = projection.mode;
@@ -528,11 +534,14 @@ function initialMarkdownDocumentMode(): MarkdownDocumentMode {
 function initialMarkdownDocumentRouteState(config: CloudMarkdownDocumentConfig): RouteState {
   const bootstrap = config.bootstrap;
   if (bootstrap) {
+    const renderSeed = bootstrap.render_seed ?? null;
     return {
       kind: "ready",
-      title: bootstrap.title?.trim() || "Untitled Markdown",
-      body: "",
-      bodyReady: false,
+      title: renderSeed?.title?.trim() || bootstrap.title?.trim() || "Untitled Markdown",
+      body: renderSeed?.body ?? "",
+      bodyReady: typeof renderSeed?.body === "string",
+      markdownPlan: renderSeed?.markdown_plan ?? null,
+      liveReady: false,
       scope: bootstrap.scope,
       connectionStatus: "connecting",
       latestRevisionId: bootstrap.latest_revision_id,
@@ -543,6 +552,8 @@ function initialMarkdownDocumentRouteState(config: CloudMarkdownDocumentConfig):
     title: markdownDocumentRouteTitle(),
     body: "",
     bodyReady: false,
+    markdownPlan: null,
+    liveReady: false,
     scope: "viewer",
     connectionStatus: "connecting",
     latestRevisionId: null,

--- a/apps/notebook-cloud/viewer/markdown-document-route.tsx
+++ b/apps/notebook-cloud/viewer/markdown-document-route.tsx
@@ -28,6 +28,10 @@ import {
   cloudDocumentUrlAfterRename,
   type CloudNotebookTitleDisplay,
 } from "./cloud-notebook-title-state";
+import {
+  cloudNotebookModeFromSearch,
+  replaceCloudNotebookModeInCurrentUrl,
+} from "./cloud-notebook-mode";
 import { cloudNotebookTitleClassNames } from "./cloud-notebook-title";
 import type { CloudMarkdownDocumentConfig, CloudViewerAuthConfig } from "./cloud-viewer-types";
 import { fetchWithCloudPrototypeAuth, type CloudPrototypeAuthState } from "./collaborator-auth";
@@ -119,7 +123,7 @@ export function MarkdownDocumentRoute({
   const [routeState, setRouteState] = useState<RouteState>(() =>
     initialMarkdownDocumentRouteState(config),
   );
-  const [mode, setMode] = useState<MarkdownDocumentMode>("edit");
+  const [mode, setMode] = useState<MarkdownDocumentMode>(initialMarkdownDocumentMode);
   const [railCollapsed, setRailCollapsed] = useState(initialMarkdownRailCollapsed);
   const [markdownTitleSaving, setMarkdownTitleSaving] = useState(false);
   const [markdownTitleError, setMarkdownTitleError] = useState<string | null>(null);
@@ -130,6 +134,10 @@ export function MarkdownDocumentRoute({
   useEffect(() => {
     loadSupplementalViewerCss();
   }, []);
+
+  useEffect(() => {
+    replaceCloudNotebookModeInCurrentUrl(mode);
+  }, [mode]);
 
   useEffect(() => {
     if (typeof window === "undefined") {
@@ -304,6 +312,10 @@ export function MarkdownDocumentRoute({
     syncControllerRef.current?.editBody(nextBody);
   }, []);
 
+  const onModeChange = useCallback((nextMode: MarkdownDocumentMode) => {
+    setMode(nextMode);
+  }, []);
+
   useEffect(() => {
     if (routeState.kind !== "ready" || mode !== "edit") {
       return;
@@ -426,7 +438,11 @@ export function MarkdownDocumentRoute({
         />
       }
       utilityControls={
-        <MarkdownDocumentModeToggle mode={activeMode} canEdit={canEdit} onModeChange={setMode} />
+        <MarkdownDocumentModeToggle
+          mode={activeMode}
+          canEdit={canEdit}
+          onModeChange={onModeChange}
+        />
       }
       sharingControls={
         canManageSharing ? (
@@ -499,6 +515,13 @@ export function MarkdownDocumentRoute({
 
 function initialMarkdownRailCollapsed(): boolean {
   return typeof window !== "undefined" && window.matchMedia("(max-width: 599.98px)").matches;
+}
+
+function initialMarkdownDocumentMode(): MarkdownDocumentMode {
+  if (typeof window === "undefined") {
+    return "view";
+  }
+  return cloudNotebookModeFromSearch(window.location.search);
 }
 
 function initialMarkdownDocumentRouteState(config: CloudMarkdownDocumentConfig): RouteState {

--- a/apps/notebook-cloud/viewer/markdown-document-route.tsx
+++ b/apps/notebook-cloud/viewer/markdown-document-route.tsx
@@ -1,5 +1,5 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
-import { ArrowLeft, Eye, FileText, Globe2, Loader2, PencilLine } from "lucide-react";
+import { Globe2, House, ListTree, Loader2 } from "lucide-react";
 import type { EditorView } from "@codemirror/view";
 import type { ConnectionStatus, NotebookOutlineItem } from "runtimed";
 import {
@@ -8,8 +8,23 @@ import {
   type CodeMirrorEditorRef,
 } from "@/components/editor/codemirror-editor";
 import { ProjectedMarkdownView } from "@/components/markdown/ProjectedMarkdownView";
+import {
+  NotebookDocumentShell,
+  NotebookDocumentToolbar,
+  NotebookNotice,
+  NotebookNoticeStack,
+  projectNotebookShellCapabilities,
+  type NotebookShellCapabilities,
+} from "@/components/notebook";
 import { NotebookOutlinePanel } from "@/components/notebook-rail/NotebookRail";
-import { projectMarkdownDocument, type MarkdownDocumentProjection } from "@/lib/markdown-document";
+import { Rail, RAIL_TAKEOVER_STAGE_CLASS_NAME } from "@/components/rail";
+import { MarkdownDocumentModeToggle } from "@/components/markdown/MarkdownDocumentModeToggle";
+import {
+  projectMarkdownDocument,
+  type MarkdownDocumentMode,
+  type MarkdownDocumentProjection,
+} from "@/lib/markdown-document";
+import { cn } from "@/lib/utils";
 import { cloudResponseError } from "./cloud-response";
 import type { CloudMarkdownDocumentConfig, CloudViewerAuthConfig } from "./cloud-viewer-types";
 import { fetchWithCloudPrototypeAuth, type CloudPrototypeAuthState } from "./collaborator-auth";
@@ -40,6 +55,12 @@ type PublishStatus =
   | { kind: "publishing"; message: string }
   | { kind: "published"; message: string; revisionId: string }
   | { kind: "error"; message: string };
+
+type MarkdownDocumentAccessLevel = "owner" | "editor" | "viewer";
+
+type MarkdownRailPanelId = "outline";
+
+const MARKDOWN_RAIL_ITEMS = [{ id: "outline" as const, label: "Outline", icon: ListTree }];
 
 type RouteState =
   | { kind: "loading" }
@@ -74,7 +95,8 @@ export function MarkdownDocumentRoute({
     appSessionStatus.refreshAppSessionStatus,
   );
   const [routeState, setRouteState] = useState<RouteState>({ kind: "loading" });
-  const [mode, setMode] = useState<"source" | "read">("source");
+  const [mode, setMode] = useState<MarkdownDocumentMode>("edit");
+  const [railCollapsed, setRailCollapsed] = useState(initialMarkdownRailCollapsed);
   const [publishStatus, setPublishStatus] = useState<PublishStatus>({
     kind: "idle",
     message: null,
@@ -83,6 +105,23 @@ export function MarkdownDocumentRoute({
   const editorRef = useRef<CodeMirrorEditorRef | null>(null);
   const connectionStatusRef = useRef<ConnectionStatus>("connecting");
   const latestRevisionIdRef = useRef<string | null>(null);
+
+  useEffect(() => {
+    if (typeof window === "undefined") {
+      return;
+    }
+    const media = window.matchMedia("(max-width: 599.98px)");
+    const collapseForNarrowViewport = () => {
+      if (media.matches) {
+        setRailCollapsed(true);
+      }
+    };
+    collapseForNarrowViewport();
+    media.addEventListener("change", collapseForNarrowViewport);
+    return () => {
+      media.removeEventListener("change", collapseForNarrowViewport);
+    };
+  }, []);
 
   useEffect(() => {
     let disposed = false;
@@ -180,9 +219,10 @@ export function MarkdownDocumentRoute({
       });
       return;
     }
+    const hadPublicVersion = latestRevisionIdRef.current !== null;
     setPublishStatus({
       kind: "publishing",
-      message: "Publishing Markdown document...",
+      message: hadPublicVersion ? "Updating public version..." : "Publishing Markdown document...",
     });
     try {
       const snapshot = await controller.publishSnapshot();
@@ -192,7 +232,7 @@ export function MarkdownDocumentRoute({
       );
       setPublishStatus({
         kind: "published",
-        message: "Public link updated.",
+        message: hadPublicVersion ? "Public version updated." : "Public version saved.",
         revisionId: snapshot.revisionId,
       });
     } catch (error) {
@@ -204,7 +244,7 @@ export function MarkdownDocumentRoute({
   }, [routeState.kind]);
 
   useEffect(() => {
-    if (routeState.kind !== "ready" || mode !== "source") {
+    if (routeState.kind !== "ready" || mode !== "edit") {
       return;
     }
     const editor = editorRef.current?.getEditor();
@@ -246,119 +286,274 @@ export function MarkdownDocumentRoute({
   const canManageSharing =
     projection.canShare && config.hostCapabilities?.canManageSharing !== false;
   const canPublish = projection.canPublish && config.hostCapabilities?.canPublish !== false;
+  const activeMode = projection.mode;
+  const shellCapabilities = markdownDocumentShellCapabilities({
+    access: routeState.scope,
+    authState,
+    canEdit,
+    canManageSharing,
+    mode: activeMode,
+  });
   const connectionCopy = markdownConnectionCopy(routeState.connectionStatus, routeState.bodyReady);
   const publicLink =
     typeof window === "undefined" ? "" : `${window.location.origin}${window.location.pathname}`;
   const publishCopy = publishStatus.message;
-
-  return (
-    <main className="cloud-markdown-shell">
-      <header className="cloud-markdown-toolbar">
-        <a href="/m" aria-label="Open Markdown documents" className="cloud-markdown-home-link">
-          <ArrowLeft aria-hidden="true" />
-        </a>
-        <div>
-          <p className="cloud-dashboard-eyebrow">Markdown</p>
-          <h1>{projection.title}</h1>
-        </div>
-        <div className="cloud-markdown-toolbar-actions">
-          {canManageSharing ? (
+  const markdownOutline = (
+    <NotebookOutlinePanel
+      items={markdownOutlineItems(projection)}
+      ariaLabel="Document outline"
+      emptyMessage="Add Markdown headings to structure this document. They will appear here."
+      getItemHref={(item) => item.href}
+      onNavigateItem={(item, href) => {
+        if (
+          activeMode === "edit" &&
+          canEdit &&
+          scrollEditorToMarkdownOutlineItem(
+            editorRef.current?.getEditor() ?? null,
+            projection.outlineItems,
+            item.id,
+          )
+        ) {
+          window.history.replaceState(null, "", href);
+          return true;
+        }
+        window.location.hash = href;
+        return true;
+      }}
+    />
+  );
+  const rail = (
+    <Rail<MarkdownRailPanelId>
+      activePanelId="outline"
+      collapsed={railCollapsed}
+      items={MARKDOWN_RAIL_ITEMS}
+      panelEyebrow="Markdown"
+      panelTitle="Outline"
+      panelClassName="w-[clamp(18rem,22vw,20rem)] min-w-72"
+      className="cloud-notebook-rail cloud-markdown-rail"
+      dataTestId="markdown-document-rail"
+      panelSlot="notebook-rail-panel"
+      panelTitleRowSlot="notebook-rail-panel-title-row"
+      onActivePanelChange={() => setRailCollapsed(false)}
+      onCollapsedChange={setRailCollapsed}
+    >
+      {markdownOutline}
+    </Rail>
+  );
+  const toolbar = (
+    <NotebookDocumentToolbar
+      capabilities={shellCapabilities}
+      frameClassName="z-20"
+      headerClassName="cloud-room-toolbar cloud-markdown-room-toolbar"
+      presence={<MarkdownDocumentTitle title={projection.title} access={projection.access} />}
+      utilityControls={
+        <MarkdownDocumentModeToggle mode={activeMode} canEdit={canEdit} onModeChange={setMode} />
+      }
+      sharingControls={
+        canManageSharing ? (
+          <>
             <MarkdownSharingControls
               aclEndpoint={config.aclEndpoint}
               authState={authState}
               publicLink={publicLink}
             />
-          ) : null}
-          {canPublish ? (
-            <button
-              type="button"
-              disabled={publishStatus.kind === "publishing" || !routeState.bodyReady}
-              onClick={() => void publishMarkdownDocumentSnapshot()}
-            >
-              {publishStatus.kind === "publishing" ? (
-                <Loader2 aria-hidden="true" />
-              ) : (
-                <Globe2 aria-hidden="true" />
-              )}
-              {projection.isPublished ? "Publish update" : "Publish"}
-            </button>
-          ) : null}
-          <button type="button" aria-pressed={mode === "read"} onClick={() => setMode("read")}>
-            <Eye aria-hidden="true" />
-            Read
-          </button>
-          <button
-            type="button"
-            aria-pressed={mode === "source"}
-            disabled={!canEdit}
-            onClick={() => setMode("source")}
-          >
-            <PencilLine aria-hidden="true" />
-            Source
-          </button>
-        </div>
-      </header>
-      {connectionCopy ? <div className="cloud-markdown-notice">{connectionCopy}</div> : null}
-      {publishCopy ? (
-        <div className="cloud-markdown-notice" data-kind={publishStatus.kind}>
-          {publishCopy}
-        </div>
-      ) : null}
-      <div className="cloud-markdown-workspace">
-        <aside className="cloud-markdown-rail">
-          <div className="cloud-markdown-rail-title">
-            <FileText aria-hidden="true" />
-            Outline
-          </div>
-          <NotebookOutlinePanel
-            items={markdownOutlineItems(projection)}
-            ariaLabel="Document outline"
-            emptyMessage="Add Markdown headings to structure this document. They will appear here."
-            getItemHref={(item) => item.href}
-            onNavigateItem={(item, href) => {
-              if (
-                mode === "source" &&
-                canEdit &&
-                scrollEditorToMarkdownOutlineItem(
-                  editorRef.current?.getEditor() ?? null,
-                  projection.outlineItems,
-                  item.id,
-                )
-              ) {
-                window.history.replaceState(null, "", href);
-                return true;
-              }
-              window.location.hash = href;
-              return true;
-            }}
-          />
-        </aside>
-        <section className="cloud-markdown-stage">
-          {mode === "source" && canEdit ? (
-            <CodeMirrorEditor
-              ref={editorRef}
-              key={config.documentId}
-              initialValue={projection.body}
-              language="markdown"
-              lineWrapping
-              className="cloud-markdown-editor"
-              onValueChange={onEditorValueChange}
-            />
-          ) : projection.markdownPlan ? (
-            <ProjectedMarkdownView
-              plan={projection.markdownPlan}
-              className="cloud-markdown-preview"
-              headingAnchors={projection.headingAnchors}
-            />
-          ) : (
-            <div className="cloud-state" data-kind="empty">
-              {routeState.bodyReady ? "Nothing to render yet." : "Syncing Markdown document body."}
-            </div>
-          )}
-        </section>
-      </div>
-    </main>
+            {canPublish ? (
+              <button
+                type="button"
+                className="markdown-document-toolbar-action"
+                disabled={publishStatus.kind === "publishing" || !routeState.bodyReady}
+                onClick={() => void publishMarkdownDocumentSnapshot()}
+              >
+                {publishStatus.kind === "publishing" ? (
+                  <Loader2 aria-hidden="true" />
+                ) : (
+                  <Globe2 aria-hidden="true" />
+                )}
+                <span>{projection.isPublished ? "Update public version" : "Publish"}</span>
+              </button>
+            ) : null}
+          </>
+        ) : null
+      }
+    />
   );
+  const notices =
+    connectionCopy || publishCopy ? (
+      <NotebookNoticeStack>
+        {connectionCopy ? (
+          <NotebookNotice tone="warning" title="Sync">
+            {connectionCopy}
+          </NotebookNotice>
+        ) : null}
+        {publishCopy ? (
+          <NotebookNotice tone={publishNoticeTone(publishStatus.kind)} title="Markdown">
+            {publishCopy}
+          </NotebookNotice>
+        ) : null}
+      </NotebookNoticeStack>
+    ) : null;
+
+  return (
+    <NotebookDocumentShell
+      rootElement="main"
+      className="cloud-notebook-shell cloud-markdown-shell"
+      toolbar={toolbar}
+      rail={rail}
+      notices={notices}
+      noticesClassName="cloud-notebook-notices cloud-markdown-notices"
+      stageClassName={cn(
+        "cloud-notebook-stage cloud-markdown-stage",
+        !railCollapsed && RAIL_TAKEOVER_STAGE_CLASS_NAME,
+      )}
+      stageLabel="Markdown document"
+      capabilities={shellCapabilities}
+    >
+      <div className="markdown-document-scroll" data-mode={activeMode}>
+        {activeMode === "edit" && canEdit ? (
+          <CodeMirrorEditor
+            ref={editorRef}
+            key={config.documentId}
+            initialValue={projection.body}
+            language="markdown"
+            lineWrapping
+            className="markdown-document-editor"
+            onValueChange={onEditorValueChange}
+          />
+        ) : projection.markdownPlan ? (
+          <ProjectedMarkdownView
+            plan={projection.markdownPlan}
+            className="markdown-document-preview"
+            headingAnchors={projection.headingAnchors}
+          />
+        ) : (
+          <div className="cloud-state" data-kind="empty">
+            {routeState.bodyReady ? "Nothing to render yet." : "Syncing Markdown document body."}
+          </div>
+        )}
+      </div>
+    </NotebookDocumentShell>
+  );
+}
+
+function initialMarkdownRailCollapsed(): boolean {
+  return typeof window !== "undefined" && window.matchMedia("(max-width: 599.98px)").matches;
+}
+
+function MarkdownDocumentTitle({
+  title,
+  access,
+}: {
+  title: string;
+  access: MarkdownDocumentProjection["access"];
+}) {
+  return (
+    <div className="cloud-notebook-title-group cloud-markdown-title-group">
+      <a
+        className="cloud-notebook-home-link"
+        href="/m"
+        aria-label="Open Markdown documents"
+        title="Markdown documents"
+      >
+        <House aria-hidden="true" />
+      </a>
+      <div className="cloud-notebook-title" title={title}>
+        <div className="cloud-notebook-title-static">
+          <span>{title}</span>
+        </div>
+        <small>{markdownTitleDetail(access)}</small>
+      </div>
+    </div>
+  );
+}
+
+function markdownDocumentShellCapabilities({
+  access,
+  authState,
+  canEdit,
+  canManageSharing,
+  mode,
+}: {
+  access: MarkdownDocumentAccessLevel;
+  authState: CloudPrototypeAuthState;
+  canEdit: boolean;
+  canManageSharing: boolean;
+  mode: MarkdownDocumentMode;
+}): NotebookShellCapabilities {
+  const canUseAuthenticatedIdentity = authState.mode === "dev" || authState.mode === "oidc";
+  const wantsEditMode = mode === "edit";
+  const canEditMarkdown = wantsEditMode && canEdit;
+  return projectNotebookShellCapabilities({
+    interaction: {
+      selectedMode: wantsEditMode ? "edit" : "view",
+      activeMode: canEditMarkdown ? "edit" : "view",
+      state: wantsEditMode ? (canEditMarkdown ? "editing" : "requested") : "viewing",
+      canRequestEdit: false,
+      canEditMarkdown,
+      canEditCells: false,
+      canEditStructure: false,
+    },
+    access: {
+      level: access,
+      source: "cloud",
+      isPublic: false,
+      actorLabel: null,
+      identityLabel: null,
+    },
+    auth: {
+      canSignIn: !canUseAuthenticatedIdentity,
+      canUseAuthenticatedIdentity,
+      needsAttention: authState.mode === "invalid" || authState.mode === "oidc_expired",
+    },
+    runtime: {
+      canWriteRuntimeState: false,
+      connected: false,
+      executionAvailable: false,
+      source: "cloud",
+      actorLabel: null,
+      identityLabel: null,
+      target: null,
+    },
+    controls: {
+      canToggleCode: false,
+    },
+    execution: {
+      available: false,
+      canSubmit: false,
+    },
+    packages: {
+      canView: false,
+      canManage: false,
+    },
+    sharing: {
+      canManage: canManageSharing,
+      requiresAuthenticatedIdentity: true,
+      requiredAccessLevels: ["owner"],
+      requiredSources: ["cloud"],
+    },
+  });
+}
+
+function markdownTitleDetail(access: MarkdownDocumentProjection["access"]): string {
+  if (access === "owner") {
+    return "Markdown document";
+  }
+  if (access === "editor") {
+    return "Markdown document · Editor";
+  }
+  if (access === "viewer") {
+    return "Markdown document · Viewer";
+  }
+  return "Markdown document";
+}
+
+function publishNoticeTone(kind: PublishStatus["kind"]) {
+  if (kind === "published") {
+    return "success";
+  }
+  if (kind === "error") {
+    return "error";
+  }
+  return "info";
 }
 
 async function fetchMarkdownCatalog(

--- a/apps/notebook-cloud/viewer/markdown-document-route.tsx
+++ b/apps/notebook-cloud/viewer/markdown-document-route.tsx
@@ -1,14 +1,21 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { ArrowLeft, Eye, FileText, Loader2, PencilLine } from "lucide-react";
-import type { NotebookOutlineItem } from "runtimed";
-import { CodeMirrorEditor } from "@/components/editor/codemirror-editor";
+import type { ConnectionStatus, NotebookOutlineItem } from "runtimed";
+import {
+  CodeMirrorEditor,
+  externalChangeAnnotation,
+  type CodeMirrorEditorRef,
+} from "@/components/editor/codemirror-editor";
 import { ProjectedMarkdownView } from "@/components/markdown/ProjectedMarkdownView";
 import { NotebookOutlinePanel } from "@/components/notebook-rail/NotebookRail";
 import { projectMarkdownDocument, type MarkdownDocumentProjection } from "@/lib/markdown-document";
 import { cloudResponseError } from "./cloud-response";
 import type { CloudMarkdownDocumentConfig, CloudViewerAuthConfig } from "./cloud-viewer-types";
 import { fetchWithCloudPrototypeAuth, type CloudPrototypeAuthState } from "./collaborator-auth";
-import { createMarkdownHandle, type MarkdownHandle } from "./runtimed-wasm-client";
+import {
+  startMarkdownDocumentLiveSync,
+  type MarkdownDocumentLiveSyncController,
+} from "./markdown-document-live-sync";
 import {
   useCloudAppSessionBridge,
   useCloudAppSessionStatus,
@@ -27,7 +34,14 @@ interface MarkdownCatalogResponse {
 
 type RouteState =
   | { kind: "loading" }
-  | { kind: "ready"; title: string; body: string; scope: "owner" | "editor" | "viewer" }
+  | {
+      kind: "ready";
+      title: string;
+      body: string;
+      bodyReady: boolean;
+      scope: "owner" | "editor" | "viewer";
+      connectionStatus: ConnectionStatus;
+    }
   | { kind: "error"; message: string };
 
 export function MarkdownDocumentRoute({
@@ -51,33 +65,52 @@ export function MarkdownDocumentRoute({
   );
   const [routeState, setRouteState] = useState<RouteState>({ kind: "loading" });
   const [mode, setMode] = useState<"source" | "read">("source");
-  const handleRef = useRef<MarkdownHandle | null>(null);
+  const syncControllerRef = useRef<MarkdownDocumentLiveSyncController | null>(null);
+  const editorRef = useRef<CodeMirrorEditorRef | null>(null);
 
   useEffect(() => {
     let disposed = false;
+    let controller: MarkdownDocumentLiveSyncController | null = null;
     void (async () => {
       try {
         setRouteState({ kind: "loading" });
         const catalog = await fetchMarkdownCatalog(config, authState);
         if (disposed) return;
         const title = catalog.document.title?.trim() || "Untitled Markdown";
-        const handle = await createMarkdownHandle(
-          catalog.document.body_doc_id,
+        controller = await startMarkdownDocumentLiveSync({
+          authState,
+          config,
+          appSession: appSessionStatus.session,
           title,
-          markdownActorLabel(authState),
-          config.runtimedWasmModulePath,
-          config.runtimedWasmPath,
-        );
-        const initialBody = `# ${title}\n\nStart writing.`;
-        handle.replace_body_for_import(initialBody);
-        handleRef.current?.free();
-        handleRef.current = handle;
-        setRouteState({
-          kind: "ready",
-          title,
-          body: handle.body() ?? "",
           scope: catalog.document.scope,
+          onConnectionLost: (reason) => {
+            console.warn("[notebook-cloud] Markdown document connection lost", reason);
+          },
+          onError: (error) => {
+            console.warn("[notebook-cloud] Markdown document sync failed", error);
+          },
+          onStatus: (connectionStatus) => {
+            setRouteState((current) =>
+              current.kind === "ready" ? { ...current, connectionStatus } : current,
+            );
+          },
+          onSnapshot: (snapshot) => {
+            setRouteState({
+              kind: "ready",
+              title: snapshot.title,
+              body: snapshot.body,
+              bodyReady: snapshot.bodyReady,
+              scope: catalog.document.scope,
+              connectionStatus: controller?.transport.connected ? "online" : "connecting",
+            });
+          },
         });
+        if (disposed) {
+          controller.dispose();
+          return;
+        }
+        syncControllerRef.current?.dispose();
+        syncControllerRef.current = controller;
       } catch (error) {
         if (disposed) return;
         setRouteState({
@@ -89,10 +122,12 @@ export function MarkdownDocumentRoute({
 
     return () => {
       disposed = true;
-      handleRef.current?.free();
-      handleRef.current = null;
+      controller?.dispose();
+      if (syncControllerRef.current === controller) {
+        syncControllerRef.current = null;
+      }
     };
-  }, [authState, config]);
+  }, [appSessionStatus.session, authState, config]);
 
   const projection = useMemo<MarkdownDocumentProjection | null>(() => {
     if (routeState.kind !== "ready") {
@@ -109,16 +144,26 @@ export function MarkdownDocumentRoute({
   }, [config.documentId, mode, routeState]);
 
   const onEditorValueChange = useCallback((nextBody: string) => {
-    const handle = handleRef.current;
-    if (!handle) {
+    syncControllerRef.current?.editBody(nextBody);
+  }, []);
+
+  useEffect(() => {
+    if (routeState.kind !== "ready" || mode !== "source") {
       return;
     }
-    const previousBody = handle.body() ?? "";
-    const splice = diffAsSplice(previousBody, nextBody);
-    handle.splice_body(splice.index, splice.deleteCount, splice.insertText);
-    const body = handle.body() ?? nextBody;
-    setRouteState((current) => (current.kind === "ready" ? { ...current, body } : current));
-  }, []);
+    const editor = editorRef.current?.getEditor();
+    if (!editor) {
+      return;
+    }
+    const currentBody = editor.state.doc.toString();
+    if (currentBody === routeState.body) {
+      return;
+    }
+    editor.dispatch({
+      changes: { from: 0, to: editor.state.doc.length, insert: routeState.body },
+      annotations: externalChangeAnnotation.of(true),
+    });
+  }, [mode, routeState]);
 
   if (routeState.kind === "loading") {
     return (
@@ -141,7 +186,8 @@ export function MarkdownDocumentRoute({
     );
   }
 
-  const canEdit = projection.canEdit;
+  const canEdit = projection.canEdit && routeState.bodyReady;
+  const connectionCopy = markdownConnectionCopy(routeState.connectionStatus, routeState.bodyReady);
 
   return (
     <main className="cloud-markdown-shell">
@@ -169,9 +215,7 @@ export function MarkdownDocumentRoute({
           </button>
         </div>
       </header>
-      <div className="cloud-markdown-notice">
-        Markdown body edits are local to this browser until the hosted Automerge sync channel lands.
-      </div>
+      {connectionCopy ? <div className="cloud-markdown-notice">{connectionCopy}</div> : null}
       <div className="cloud-markdown-workspace">
         <aside className="cloud-markdown-rail">
           <div className="cloud-markdown-rail-title">
@@ -191,6 +235,7 @@ export function MarkdownDocumentRoute({
         <section className="cloud-markdown-stage">
           {mode === "source" && canEdit ? (
             <CodeMirrorEditor
+              ref={editorRef}
               key={config.documentId}
               initialValue={projection.body}
               language="markdown"
@@ -206,7 +251,7 @@ export function MarkdownDocumentRoute({
             />
           ) : (
             <div className="cloud-state" data-kind="empty">
-              Nothing to render yet.
+              {routeState.bodyReady ? "Nothing to render yet." : "Syncing Markdown document body."}
             </div>
           )}
         </section>
@@ -264,39 +309,18 @@ function markdownOutlineItems(projection: MarkdownDocumentProjection): NotebookO
   }));
 }
 
-function markdownActorLabel(authState: CloudPrototypeAuthState): string {
-  const user = encodeURIComponent(authState.user ?? "browser");
-  return `user:markdown:${user}/browser:${crypto.randomUUID()}`;
-}
-
-function diffAsSplice(
-  previous: string,
-  next: string,
-): { index: number; deleteCount: number; insertText: string } {
-  if (previous === next) {
-    return { index: 0, deleteCount: 0, insertText: "" };
+function markdownConnectionCopy(status: ConnectionStatus, bodyReady: boolean): string | null {
+  if (!bodyReady) {
+    return "Syncing Markdown document body.";
   }
-  let prefix = 0;
-  while (
-    prefix < previous.length &&
-    prefix < next.length &&
-    previous.charCodeAt(prefix) === next.charCodeAt(prefix)
-  ) {
-    prefix += 1;
+  switch (status) {
+    case "connecting":
+      return "Connecting to the live Markdown document.";
+    case "reconnecting":
+      return "Reconnecting to the live Markdown document.";
+    case "offline":
+      return "Markdown document is offline. Local changes will wait for reconnection.";
+    case "online":
+      return null;
   }
-  let previousSuffix = previous.length;
-  let nextSuffix = next.length;
-  while (
-    previousSuffix > prefix &&
-    nextSuffix > prefix &&
-    previous.charCodeAt(previousSuffix - 1) === next.charCodeAt(nextSuffix - 1)
-  ) {
-    previousSuffix -= 1;
-    nextSuffix -= 1;
-  }
-  return {
-    index: prefix,
-    deleteCount: previousSuffix - prefix,
-    insertText: next.slice(prefix, nextSuffix),
-  };
 }

--- a/apps/notebook-cloud/viewer/markdown-document-route.tsx
+++ b/apps/notebook-cloud/viewer/markdown-document-route.tsx
@@ -283,7 +283,6 @@ export function MarkdownDocumentRoute({
       access: routeState.scope,
       requestedMode: mode,
       requestedRepresentation,
-      publishedRevisionId: routeState.latestRevisionId,
       updatedAt: null,
     });
   }, [config.documentId, mode, requestedRepresentation, routeState]);

--- a/apps/notebook-cloud/viewer/markdown-document-route.tsx
+++ b/apps/notebook-cloud/viewer/markdown-document-route.tsx
@@ -1,5 +1,6 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { ArrowLeft, Eye, FileText, Globe2, Loader2, PencilLine } from "lucide-react";
+import type { EditorView } from "@codemirror/view";
 import type { ConnectionStatus, NotebookOutlineItem } from "runtimed";
 import {
   CodeMirrorEditor,
@@ -314,7 +315,19 @@ export function MarkdownDocumentRoute({
             ariaLabel="Document outline"
             emptyMessage="Add Markdown headings to structure this document. They will appear here."
             getItemHref={(item) => item.href}
-            onNavigateItem={(_item, href) => {
+            onNavigateItem={(item, href) => {
+              if (
+                mode === "source" &&
+                canEdit &&
+                scrollEditorToMarkdownOutlineItem(
+                  editorRef.current?.getEditor() ?? null,
+                  projection.outlineItems,
+                  item.id,
+                )
+              ) {
+                window.history.replaceState(null, "", href);
+                return true;
+              }
               window.location.hash = href;
               return true;
             }}
@@ -396,6 +409,24 @@ function markdownOutlineItems(projection: MarkdownDocumentProjection): NotebookO
     href: item.href,
     anchor: item.anchor,
   }));
+}
+
+function scrollEditorToMarkdownOutlineItem(
+  editor: EditorView | null,
+  outlineItems: readonly MarkdownDocumentProjection["outlineItems"][number][],
+  itemId: string,
+): boolean {
+  const outlineItem = outlineItems.find((candidate) => candidate.id === itemId);
+  if (!editor || !outlineItem) {
+    return false;
+  }
+  const [anchor, head] = outlineItem.sourceSpanUtf16;
+  editor.focus();
+  editor.dispatch({
+    selection: { anchor, head },
+    scrollIntoView: true,
+  });
+  return true;
 }
 
 function markdownConnectionCopy(status: ConnectionStatus, bodyReady: boolean): string | null {

--- a/apps/notebook-cloud/viewer/markdown-document-route.tsx
+++ b/apps/notebook-cloud/viewer/markdown-document-route.tsx
@@ -41,6 +41,7 @@ import {
   projectCloudAccessRequestNotice,
   shouldFallbackCloudEditUrlToView,
   shouldLoadOwnCloudAccessRequest,
+  shouldUseCloudCatalogBootstrap,
 } from "./cloud-access-request-state";
 import {
   cloudBrowserCanUseAuthenticatedApi,
@@ -115,7 +116,6 @@ type RouteState =
       liveReady: boolean;
       scope: "owner" | "editor" | "viewer";
       connectionStatus: ConnectionStatus;
-      latestRevisionId: string | null;
     }
   | { kind: "error"; message: string };
 
@@ -212,7 +212,9 @@ export function MarkdownDocumentRoute({
             : initialMarkdownDocumentRouteState(config),
         );
         const catalogPromise = Promise.resolve(
-          markdownCatalogFromBootstrap(config) ?? fetchMarkdownCatalog(config, authState),
+          shouldUseCloudCatalogBootstrap({ catalogRefreshVersion })
+            ? (markdownCatalogFromBootstrap(config) ?? fetchMarkdownCatalog(config, authState))
+            : fetchMarkdownCatalog(config, authState),
         );
         const [catalog, liveSyncModule] = await Promise.all([
           catalogPromise,
@@ -220,7 +222,6 @@ export function MarkdownDocumentRoute({
         ]);
         if (disposed) return;
         const title = catalog.document.title?.trim() || "Untitled Markdown";
-        const latestRevisionId = catalog.document.latest_revision_id;
         if (liveSyncModule.shouldLoadMarkdownInstantPaintSnapshot(config)) {
           void liveSyncModule
             .loadMarkdownDocumentInstantPaintSnapshot({
@@ -245,7 +246,6 @@ export function MarkdownDocumentRoute({
                 scope: catalog.document.scope,
                 connectionStatus: connectionStatusRef.current,
                 liveReady: false,
-                latestRevisionId,
               });
             });
         }
@@ -278,7 +278,6 @@ export function MarkdownDocumentRoute({
               scope: catalog.document.scope,
               connectionStatus: connectionStatusRef.current,
               liveReady: true,
-              latestRevisionId,
             });
           },
         });
@@ -839,7 +838,6 @@ function initialMarkdownDocumentRouteState(config: CloudMarkdownDocumentConfig):
       liveReady: false,
       scope: bootstrap.scope,
       connectionStatus: "connecting",
-      latestRevisionId: bootstrap.latest_revision_id,
     };
   }
   return {
@@ -851,7 +849,6 @@ function initialMarkdownDocumentRouteState(config: CloudMarkdownDocumentConfig):
     liveReady: false,
     scope: "viewer",
     connectionStatus: "connecting",
-    latestRevisionId: null,
   };
 }
 

--- a/apps/notebook-cloud/viewer/markdown-document-route.tsx
+++ b/apps/notebook-cloud/viewer/markdown-document-route.tsx
@@ -15,7 +15,6 @@ import {
 } from "@/components/notebook/capabilities";
 import { NotebookOutlinePanel } from "@/components/notebook-rail/NotebookRail";
 import { Rail, RAIL_TAKEOVER_STAGE_CLASS_NAME } from "@/components/rail";
-import { MarkdownDocumentModeToggle } from "@/components/markdown/MarkdownDocumentModeToggle";
 import { MarkdownDocumentRepresentationToolbar } from "@/components/markdown/MarkdownDocumentModeToggle";
 import {
   projectMarkdownDocument,
@@ -37,8 +36,20 @@ import {
 import { cloudNotebookTitleClassNames } from "./cloud-notebook-title";
 import { markdownConnectionCopy } from "./markdown-document-connection-copy";
 import type { CloudMarkdownDocumentConfig, CloudViewerAuthConfig } from "./cloud-viewer-types";
-import { fetchWithCloudPrototypeAuth, type CloudPrototypeAuthState } from "./collaborator-auth";
+import { CloudNotebookEditModeButton } from "./cloud-edit-mode-button";
+import {
+  projectCloudAccessRequestNotice,
+  shouldFallbackCloudEditUrlToView,
+  shouldLoadOwnCloudAccessRequest,
+} from "./cloud-access-request-state";
+import {
+  cloudBrowserCanUseAuthenticatedApi,
+  fetchWithCloudPrototypeAuth,
+  type CloudPrototypeAuthState,
+} from "./collaborator-auth";
+import { cloudBrowserApiAuthStateForFetch } from "./session-auth-stability";
 import type { MarkdownDocumentLiveSyncController } from "./markdown-document-live-sync";
+import type { CloudMarkdownAccessRequest } from "./markdown-sharing";
 import { MarkdownSharingControls } from "./markdown-sharing-controls";
 import {
   useCloudAppSessionBridge,
@@ -53,6 +64,8 @@ type MarkdownDocumentLiveSyncModule = typeof import("./markdown-document-live-sy
 const MarkdownCodeMirrorEditor = lazy(() =>
   loadMarkdownEditorModule().then((module) => ({ default: module.CodeMirrorEditor })),
 );
+
+const MARKDOWN_ACCESS_REQUEST_POLL_INTERVAL_MS = 5_000;
 
 let markdownEditorModulePromise: Promise<MarkdownEditorModule> | null = null;
 let markdownDocumentLiveSyncModulePromise: Promise<MarkdownDocumentLiveSyncModule> | null = null;
@@ -114,10 +127,25 @@ export function MarkdownDocumentRoute({
   config: CloudMarkdownDocumentConfig;
 }) {
   const appSessionStatus = useCloudAppSessionStatus(config.session ?? null);
+  const hasAppSession = Boolean(appSessionStatus.session);
   const { authState } = useCloudPrototypeAuth(authConfig, {
     appSessionRefreshFallback: true,
     appSessionLoading: appSessionStatus.status === "loading",
     appSession: appSessionStatus.session,
+  });
+  const browserApiAuthState = useMemo(
+    () => cloudBrowserApiAuthStateForFetch(authState),
+    [
+      authState.mode,
+      authState.mode === "dev" ? authState.token : null,
+      authState.mode === "dev" ? authState.user : null,
+      authState.mode === "dev" ? authState.requestedScope : null,
+      authState.mode === "dev" ? authState.problem : null,
+    ],
+  );
+  const canUseAuthenticatedCloudApi = cloudBrowserCanUseAuthenticatedApi({
+    authState,
+    hasAppSession,
   });
   useCloudAppSessionBridge(
     authState,
@@ -134,10 +162,17 @@ export function MarkdownDocumentRoute({
   const [railCollapsed, setRailCollapsed] = useState(initialMarkdownRailCollapsed);
   const [markdownTitleSaving, setMarkdownTitleSaving] = useState(false);
   const [markdownTitleError, setMarkdownTitleError] = useState<string | null>(null);
+  const [latestAccessRequest, setLatestAccessRequest] = useState<CloudMarkdownAccessRequest | null>(
+    null,
+  );
+  const [accessRequestError, setAccessRequestError] = useState<string | null>(null);
+  const [editAccessRequestedByUser, setEditAccessRequestedByUser] = useState(false);
+  const [catalogRefreshVersion, setCatalogRefreshVersion] = useState(0);
   const syncControllerRef = useRef<MarkdownDocumentLiveSyncController | null>(null);
   const editorRef = useRef<CodeMirrorEditorRef | null>(null);
   const connectionStatusRef = useRef<ConnectionStatus>("connecting");
   const liveSnapshotSeenRef = useRef(false);
+  const accessApprovalRefreshRef = useRef<string | null>(null);
 
   useEffect(() => {
     loadSupplementalViewerCss();
@@ -269,7 +304,7 @@ export function MarkdownDocumentRoute({
         syncControllerRef.current = null;
       }
     };
-  }, [appSessionStatus.session, authState, config]);
+  }, [appSessionStatus.session, authState, catalogRefreshVersion, config]);
 
   const projection = useMemo<MarkdownDocumentProjection | null>(() => {
     if (routeState.kind !== "ready") {
@@ -294,6 +329,171 @@ export function MarkdownDocumentRoute({
     }
     document.title = markdownDocumentBrowserTitle(routeTitle);
   }, [routeTitle]);
+
+  const catalogResolved = routeState.kind === "ready";
+  const routeAccessScope = routeState.kind === "ready" ? routeState.scope : null;
+  const catalogGrantsDocumentEdit = routeAccessScope === "editor" || routeAccessScope === "owner";
+  const effectiveAccessRequest = catalogGrantsDocumentEdit ? null : latestAccessRequest;
+  const shouldLoadOwnEditAccessRequest = shouldLoadOwnCloudAccessRequest({
+    canUseAuthenticatedCloudApi,
+    catalogGrantsDocumentEdit,
+    connectionScope: routeAccessScope,
+    editAccessRequested: editAccessRequestedByUser,
+    hasBrowserAppIdentity: canUseAuthenticatedCloudApi,
+    selectedMode: mode,
+  });
+
+  useEffect(() => {
+    if (
+      shouldFallbackCloudEditUrlToView({
+        catalogGrantsDocumentEdit,
+        catalogResolved,
+        editAccessRequested: editAccessRequestedByUser,
+        selectedMode: mode,
+      })
+    ) {
+      setMode("view");
+    }
+  }, [catalogGrantsDocumentEdit, catalogResolved, editAccessRequestedByUser, mode]);
+
+  const applyLatestAccessRequest = useCallback(
+    (request: CloudMarkdownAccessRequest | null) => {
+      setLatestAccessRequest(request);
+      if (
+        request?.status === "approved" &&
+        routeAccessScope === "viewer" &&
+        accessApprovalRefreshRef.current !== request.id
+      ) {
+        accessApprovalRefreshRef.current = request.id;
+        setCatalogRefreshVersion((version) => version + 1);
+      }
+    },
+    [routeAccessScope],
+  );
+
+  const loadOwnAccessRequest = useCallback(
+    async (options?: { signal?: AbortSignal }) => {
+      if (!shouldLoadOwnEditAccessRequest) {
+        return;
+      }
+
+      try {
+        const response = await fetchWithCloudPrototypeAuth(
+          config.accessRequestsEndpoint,
+          { headers: { Accept: "application/json" }, signal: options?.signal },
+          browserApiAuthState,
+        );
+        if (options?.signal?.aborted || !response.ok) {
+          return;
+        }
+        const body = (await response.json()) as {
+          access_requests?: CloudMarkdownAccessRequest[];
+        };
+        setAccessRequestError(null);
+        applyLatestAccessRequest(
+          Array.isArray(body.access_requests) ? (body.access_requests[0] ?? null) : null,
+        );
+      } catch {
+        return;
+      }
+    },
+    [
+      applyLatestAccessRequest,
+      browserApiAuthState,
+      config.accessRequestsEndpoint,
+      shouldLoadOwnEditAccessRequest,
+    ],
+  );
+
+  useEffect(() => {
+    if (!shouldLoadOwnEditAccessRequest) {
+      setLatestAccessRequest(null);
+      return;
+    }
+    const controller = new AbortController();
+    void loadOwnAccessRequest({ signal: controller.signal });
+    return () => controller.abort();
+  }, [loadOwnAccessRequest, shouldLoadOwnEditAccessRequest]);
+
+  useEffect(() => {
+    if (effectiveAccessRequest?.status !== "pending" || !shouldLoadOwnEditAccessRequest) {
+      return;
+    }
+
+    const controller = new AbortController();
+    let pollInFlight = false;
+    const poll = () => {
+      if (pollInFlight) {
+        return;
+      }
+      pollInFlight = true;
+      void loadOwnAccessRequest({ signal: controller.signal }).finally(() => {
+        pollInFlight = false;
+      });
+    };
+    const intervalId = window.setInterval(poll, MARKDOWN_ACCESS_REQUEST_POLL_INTERVAL_MS);
+    const handleVisibilityChange = () => {
+      poll();
+    };
+    document.addEventListener("visibilitychange", handleVisibilityChange);
+    return () => {
+      controller.abort();
+      window.clearInterval(intervalId);
+      document.removeEventListener("visibilitychange", handleVisibilityChange);
+    };
+  }, [effectiveAccessRequest?.status, loadOwnAccessRequest, shouldLoadOwnEditAccessRequest]);
+
+  const requestMarkdownEditAccess = useCallback(() => {
+    void (async () => {
+      setMode("edit");
+      setEditAccessRequestedByUser(true);
+      setAccessRequestError(null);
+      try {
+        const response = await fetchWithCloudPrototypeAuth(
+          config.accessRequestsEndpoint,
+          {
+            method: "POST",
+            headers: {
+              Accept: "application/json",
+              "Content-Type": "application/json",
+            },
+            body: JSON.stringify({ scope: "editor" }),
+          },
+          browserApiAuthState,
+        );
+        if (!response.ok) {
+          throw await cloudResponseError(response, "Unable to request edit access");
+        }
+        const body = (await response.json()) as {
+          access_request?: CloudMarkdownAccessRequest | null;
+          access_status?: string;
+        };
+        if (body.access_status === "granted") {
+          applyLatestAccessRequest({
+            id: "already-granted",
+            document_id: config.documentId,
+            requester_principal: "",
+            scope: "editor",
+            status: "approved",
+            requested_by_actor_label: "",
+            resolved_by_actor_label: null,
+            created_at: new Date().toISOString(),
+            updated_at: new Date().toISOString(),
+            resolved_at: new Date().toISOString(),
+          });
+          return;
+        }
+        applyLatestAccessRequest(body.access_request ?? null);
+      } catch (error) {
+        setAccessRequestError(error instanceof Error ? error.message : String(error));
+      }
+    })();
+  }, [
+    applyLatestAccessRequest,
+    browserApiAuthState,
+    config.accessRequestsEndpoint,
+    config.documentId,
+  ]);
 
   const saveMarkdownDocumentTitle = useCallback(
     async (nextTitle: string): Promise<boolean> => {
@@ -421,14 +621,22 @@ export function MarkdownDocumentRoute({
   const canManageSharing =
     projection.canShare && config.hostCapabilities?.canManageSharing !== false;
   const activeMode = projection.mode;
+  const editAccessPending = mode === "edit" && effectiveAccessRequest?.status === "pending";
+  const accessRequestNotice = projectCloudAccessRequestNotice({
+    documentLabel: "document",
+    error: accessRequestError,
+    request: effectiveAccessRequest,
+    selectedMode: mode,
+  });
   const markdownTitle = markdownDocumentTitleDisplay(projection.title);
   const shellCapabilities = markdownDocumentShellCapabilities({
     access: routeState.scope,
     authState,
-    hasAppSession: Boolean(appSessionStatus.session),
+    hasAppSession,
     canEdit,
     canManageSharing,
-    mode: activeMode,
+    mode,
+    accessPending: editAccessPending,
   });
   const connectionCopy = markdownConnectionCopy(routeState.connectionStatus, routeState.bodyReady);
   const publicLink =
@@ -503,11 +711,15 @@ export function MarkdownDocumentRoute({
           }}
         />
       }
-      utilityControls={
-        <MarkdownDocumentModeToggle
-          mode={activeMode}
-          canEdit={canEdit}
+      editControls={
+        <CloudNotebookEditModeButton
+          authState={authState}
+          hasAppSession={hasAppSession}
+          interaction={shellCapabilities.interaction ?? null}
+          accessLevel={shellCapabilities.access.level}
+          accessPending={editAccessPending}
           onModeChange={onModeChange}
+          onRequestEditAccess={requestMarkdownEditAccess}
         />
       }
       commandToolbar={{
@@ -523,6 +735,8 @@ export function MarkdownDocumentRoute({
         canManageSharing ? (
           <MarkdownSharingControls
             aclEndpoint={config.aclEndpoint}
+            invitesEndpoint={config.invitesEndpoint}
+            accessRequestsEndpoint={config.accessRequestsEndpoint}
             authState={authState}
             publicLink={publicLink}
           />
@@ -530,13 +744,21 @@ export function MarkdownDocumentRoute({
       }
     />
   );
-  const notices = connectionCopy ? (
-    <NotebookNoticeStack>
-      <NotebookNotice tone="warning" title="Sync">
-        {connectionCopy}
-      </NotebookNotice>
-    </NotebookNoticeStack>
-  ) : null;
+  const notices =
+    connectionCopy || accessRequestNotice ? (
+      <NotebookNoticeStack>
+        {accessRequestNotice ? (
+          <NotebookNotice tone={accessRequestNotice.tone} title={accessRequestNotice.title}>
+            {accessRequestNotice.message}
+          </NotebookNotice>
+        ) : null}
+        {connectionCopy ? (
+          <NotebookNotice tone="warning" title="Sync">
+            {connectionCopy}
+          </NotebookNotice>
+        ) : null}
+      </NotebookNoticeStack>
+    ) : null;
 
   return (
     <NotebookDocumentShell
@@ -675,6 +897,7 @@ function markdownDocumentBrowserTitle(title: string): string {
 }
 
 function markdownDocumentShellCapabilities({
+  accessPending,
   access,
   authState,
   hasAppSession,
@@ -682,6 +905,7 @@ function markdownDocumentShellCapabilities({
   canManageSharing,
   mode,
 }: {
+  accessPending: boolean;
   access: MarkdownDocumentAccessLevel;
   authState: CloudPrototypeAuthState;
   hasAppSession: boolean;
@@ -693,12 +917,13 @@ function markdownDocumentShellCapabilities({
     hasAppSession || authState.mode === "dev" || authState.mode === "oidc";
   const wantsEditMode = mode === "edit";
   const canEditMarkdown = wantsEditMode && canEdit;
+  const canRequestEdit = canUseAuthenticatedIdentity;
   return projectNotebookShellCapabilities({
     interaction: {
       selectedMode: wantsEditMode ? "edit" : "view",
       activeMode: canEditMarkdown ? "edit" : "view",
-      state: wantsEditMode ? (canEditMarkdown ? "editing" : "requested") : "viewing",
-      canRequestEdit: false,
+      state: accessPending ? "requested" : wantsEditMode && canEditMarkdown ? "editing" : "viewing",
+      canRequestEdit,
       canEditMarkdown,
       canEditCells: false,
       canEditStructure: false,

--- a/apps/notebook-cloud/viewer/markdown-document-route.tsx
+++ b/apps/notebook-cloud/viewer/markdown-document-route.tsx
@@ -6,10 +6,9 @@ import { notebookRouteSegmentTitle } from "../src/notebook-route-title";
 import type { CodeMirrorEditorRef } from "@/components/editor/codemirror-editor";
 import { ProjectedMarkdownView } from "@/components/markdown/ProjectedMarkdownView";
 import { DocumentTitle } from "@/components/notebook/DocumentTitle";
-import { NotebookDocumentHeader } from "@/components/notebook/NotebookDocumentHeader";
 import { NotebookDocumentShell } from "@/components/notebook/NotebookDocumentShell";
+import { NotebookDocumentToolbar } from "@/components/notebook/NotebookDocumentToolbar";
 import { NotebookNotice, NotebookNoticeStack } from "@/components/notebook/NotebookNotice";
-import { NotebookToolbarFrame } from "@/components/notebook/NotebookToolbarFrame";
 import {
   projectNotebookShellCapabilities,
   type NotebookShellCapabilities,
@@ -364,6 +363,19 @@ export function MarkdownDocumentRoute({
     },
     [],
   );
+  const bodyReadyForEditorPreload = routeState.kind === "ready" && routeState.bodyReady;
+
+  useEffect(() => {
+    if (!bodyReadyForEditorPreload) {
+      return;
+    }
+    const timeout = window.setTimeout(() => {
+      void loadMarkdownEditorModule();
+    }, 0);
+    return () => {
+      window.clearTimeout(timeout);
+    };
+  }, [bodyReadyForEditorPreload]);
 
   useEffect(() => {
     if (routeState.kind !== "ready" || projection?.representation.active !== "source") {
@@ -408,7 +420,7 @@ export function MarkdownDocumentRoute({
   const canManageSharing =
     projection.canShare && config.hostCapabilities?.canManageSharing !== false;
   const activeMode = projection.mode;
-  const markdownTitle = markdownDocumentTitleDisplay(projection.title, projection.access);
+  const markdownTitle = markdownDocumentTitleDisplay(projection.title);
   const shellCapabilities = markdownDocumentShellCapabilities({
     access: routeState.scope,
     authState,
@@ -462,50 +474,59 @@ export function MarkdownDocumentRoute({
     </Rail>
   );
   const toolbar = (
-    <NotebookToolbarFrame className="z-20">
-      <NotebookDocumentHeader
-        capabilities={shellCapabilities}
-        className="cloud-room-toolbar cloud-markdown-room-toolbar"
-        presence={
-          <DocumentTitle
-            title={markdownTitle}
-            renameTitle={projection.title === "Untitled Markdown" ? "" : projection.title}
-            canRename={projection.canEdit}
-            renameSaving={markdownTitleSaving}
-            renameError={markdownTitleError}
-            onRename={saveMarkdownDocumentTitle}
-            homeHref="/m"
-            homeAriaLabel="Open Markdown documents"
-            homeTitle="Markdown documents"
-            homeIcon={<House aria-hidden="true" />}
-            inputAriaLabel="Markdown document title"
-            inputName="markdown-document-title"
-            placeholder="Untitled Markdown"
-            renameButtonTitle="Rename Markdown document"
-            classNames={{
-              ...cloudNotebookTitleClassNames,
-              group: "cloud-notebook-title-group cloud-markdown-title-group",
-            }}
+    <NotebookDocumentToolbar
+      capabilities={shellCapabilities}
+      frameClassName="z-20"
+      headerClassName="cloud-room-toolbar cloud-markdown-room-toolbar"
+      reserveCommandToolbar
+      presence={
+        <DocumentTitle
+          title={markdownTitle}
+          renameTitle={projection.title === "Untitled Markdown" ? "" : projection.title}
+          canRename={projection.canEdit}
+          renameSaving={markdownTitleSaving}
+          renameError={markdownTitleError}
+          onRename={saveMarkdownDocumentTitle}
+          homeHref="/m"
+          homeAriaLabel="Open Markdown documents"
+          homeTitle="Markdown documents"
+          homeIcon={<House aria-hidden="true" />}
+          inputAriaLabel="Markdown document title"
+          inputName="markdown-document-title"
+          placeholder="Untitled Markdown"
+          renameButtonTitle="Rename Markdown document"
+          classNames={{
+            ...cloudNotebookTitleClassNames,
+            group: "cloud-notebook-title-group cloud-markdown-title-group",
+          }}
+        />
+      }
+      utilityControls={
+        <MarkdownDocumentModeToggle
+          mode={activeMode}
+          canEdit={canEdit}
+          onModeChange={onModeChange}
+        />
+      }
+      commandToolbar={{
+        leadingControls: (
+          <MarkdownDocumentRepresentationToolbar
+            active={activeRepresentation}
+            options={projection.representation.options}
+            onRepresentationChange={onRepresentationChange}
           />
-        }
-        utilityControls={
-          <MarkdownDocumentModeToggle
-            mode={activeMode}
-            canEdit={canEdit}
-            onModeChange={onModeChange}
+        ),
+      }}
+      sharingControls={
+        canManageSharing ? (
+          <MarkdownSharingControls
+            aclEndpoint={config.aclEndpoint}
+            authState={authState}
+            publicLink={publicLink}
           />
-        }
-        sharingControls={
-          canManageSharing ? (
-            <MarkdownSharingControls
-              aclEndpoint={config.aclEndpoint}
-              authState={authState}
-              publicLink={publicLink}
-            />
-          ) : null
-        }
-      />
-    </NotebookToolbarFrame>
+        ) : null
+      }
+    />
   );
   const notices = connectionCopy ? (
     <NotebookNoticeStack>
@@ -535,11 +556,6 @@ export function MarkdownDocumentRoute({
         data-mode={activeMode}
         data-representation={activeRepresentation}
       >
-        <MarkdownDocumentRepresentationToolbar
-          active={activeRepresentation}
-          options={projection.representation.options}
-          onRepresentationChange={onRepresentationChange}
-        />
         {activeRepresentation === "source" ? (
           <Suspense
             fallback={
@@ -643,13 +659,10 @@ function markdownDocumentRouteTitle(): string {
   return notebookRouteSegmentTitle(routeSlug) ?? "Markdown document";
 }
 
-function markdownDocumentTitleDisplay(
-  title: string,
-  access: MarkdownDocumentProjection["access"],
-): CloudNotebookTitleDisplay {
+function markdownDocumentTitleDisplay(title: string): CloudNotebookTitleDisplay {
   return {
     label: title,
-    detail: markdownTitleDetail(access),
+    detail: null,
     title,
   };
 }
@@ -724,19 +737,6 @@ function markdownDocumentShellCapabilities({
       requiredSources: ["cloud"],
     },
   });
-}
-
-function markdownTitleDetail(access: MarkdownDocumentProjection["access"]): string {
-  if (access === "owner") {
-    return "Markdown document";
-  }
-  if (access === "editor") {
-    return "Markdown document · Editor";
-  }
-  if (access === "viewer") {
-    return "Markdown document · Viewer";
-  }
-  return "Markdown document";
 }
 
 async function fetchMarkdownCatalog(

--- a/apps/notebook-cloud/viewer/markdown-document-route.tsx
+++ b/apps/notebook-cloud/viewer/markdown-document-route.tsx
@@ -1,5 +1,5 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
-import { ArrowLeft, Eye, FileText, Loader2, PencilLine } from "lucide-react";
+import { ArrowLeft, Eye, FileText, Globe2, Loader2, PencilLine } from "lucide-react";
 import type { ConnectionStatus, NotebookOutlineItem } from "runtimed";
 import {
   CodeMirrorEditor,
@@ -30,8 +30,15 @@ interface MarkdownCatalogResponse {
     body_doc_id: string;
     scope: "owner" | "editor" | "viewer";
     updated_at: string;
+    latest_revision_id: string | null;
   };
 }
+
+type PublishStatus =
+  | { kind: "idle"; message: string | null }
+  | { kind: "publishing"; message: string }
+  | { kind: "published"; message: string; revisionId: string }
+  | { kind: "error"; message: string };
 
 type RouteState =
   | { kind: "loading" }
@@ -42,6 +49,7 @@ type RouteState =
       bodyReady: boolean;
       scope: "owner" | "editor" | "viewer";
       connectionStatus: ConnectionStatus;
+      latestRevisionId: string | null;
     }
   | { kind: "error"; message: string };
 
@@ -66,9 +74,14 @@ export function MarkdownDocumentRoute({
   );
   const [routeState, setRouteState] = useState<RouteState>({ kind: "loading" });
   const [mode, setMode] = useState<"source" | "read">("source");
+  const [publishStatus, setPublishStatus] = useState<PublishStatus>({
+    kind: "idle",
+    message: null,
+  });
   const syncControllerRef = useRef<MarkdownDocumentLiveSyncController | null>(null);
   const editorRef = useRef<CodeMirrorEditorRef | null>(null);
   const connectionStatusRef = useRef<ConnectionStatus>("connecting");
+  const latestRevisionIdRef = useRef<string | null>(null);
 
   useEffect(() => {
     let disposed = false;
@@ -79,6 +92,7 @@ export function MarkdownDocumentRoute({
         setRouteState({ kind: "loading" });
         const catalog = await fetchMarkdownCatalog(config, authState);
         if (disposed) return;
+        latestRevisionIdRef.current = catalog.document.latest_revision_id;
         const title = catalog.document.title?.trim() || "Untitled Markdown";
         controller = await startMarkdownDocumentLiveSync({
           authState,
@@ -106,6 +120,7 @@ export function MarkdownDocumentRoute({
               bodyReady: snapshot.bodyReady,
               scope: catalog.document.scope,
               connectionStatus: connectionStatusRef.current,
+              latestRevisionId: latestRevisionIdRef.current,
             });
           },
         });
@@ -143,13 +158,49 @@ export function MarkdownDocumentRoute({
       body: routeState.body,
       access: routeState.scope,
       requestedMode: mode,
+      publishedRevisionId: routeState.latestRevisionId,
       updatedAt: null,
     });
   }, [config.documentId, mode, routeState]);
 
   const onEditorValueChange = useCallback((nextBody: string) => {
     syncControllerRef.current?.editBody(nextBody);
+    setPublishStatus((current) =>
+      current.kind === "published" ? { kind: "idle", message: "Unpublished changes." } : current,
+    );
   }, []);
+
+  const publishMarkdownDocumentSnapshot = useCallback(async () => {
+    const controller = syncControllerRef.current;
+    if (!controller || routeState.kind !== "ready") {
+      setPublishStatus({
+        kind: "error",
+        message: "Markdown document is still connecting. Try publishing again in a moment.",
+      });
+      return;
+    }
+    setPublishStatus({
+      kind: "publishing",
+      message: "Publishing Markdown document...",
+    });
+    try {
+      const snapshot = await controller.publishSnapshot();
+      latestRevisionIdRef.current = snapshot.revisionId;
+      setRouteState((current) =>
+        current.kind === "ready" ? { ...current, latestRevisionId: snapshot.revisionId } : current,
+      );
+      setPublishStatus({
+        kind: "published",
+        message: "Public link updated.",
+        revisionId: snapshot.revisionId,
+      });
+    } catch (error) {
+      setPublishStatus({
+        kind: "error",
+        message: error instanceof Error ? error.message : String(error),
+      });
+    }
+  }, [routeState.kind]);
 
   useEffect(() => {
     if (routeState.kind !== "ready" || mode !== "source") {
@@ -193,9 +244,11 @@ export function MarkdownDocumentRoute({
   const canEdit = projection.canEdit && routeState.bodyReady;
   const canManageSharing =
     projection.canShare && config.hostCapabilities?.canManageSharing !== false;
+  const canPublish = projection.canPublish && config.hostCapabilities?.canPublish !== false;
   const connectionCopy = markdownConnectionCopy(routeState.connectionStatus, routeState.bodyReady);
   const publicLink =
     typeof window === "undefined" ? "" : `${window.location.origin}${window.location.pathname}`;
+  const publishCopy = publishStatus.message;
 
   return (
     <main className="cloud-markdown-shell">
@@ -215,6 +268,20 @@ export function MarkdownDocumentRoute({
               publicLink={publicLink}
             />
           ) : null}
+          {canPublish ? (
+            <button
+              type="button"
+              disabled={publishStatus.kind === "publishing" || !routeState.bodyReady}
+              onClick={() => void publishMarkdownDocumentSnapshot()}
+            >
+              {publishStatus.kind === "publishing" ? (
+                <Loader2 aria-hidden="true" />
+              ) : (
+                <Globe2 aria-hidden="true" />
+              )}
+              {projection.isPublished ? "Publish update" : "Publish"}
+            </button>
+          ) : null}
           <button type="button" aria-pressed={mode === "read"} onClick={() => setMode("read")}>
             <Eye aria-hidden="true" />
             Read
@@ -231,6 +298,11 @@ export function MarkdownDocumentRoute({
         </div>
       </header>
       {connectionCopy ? <div className="cloud-markdown-notice">{connectionCopy}</div> : null}
+      {publishCopy ? (
+        <div className="cloud-markdown-notice" data-kind={publishStatus.kind}>
+          {publishCopy}
+        </div>
+      ) : null}
       <div className="cloud-markdown-workspace">
         <aside className="cloud-markdown-rail">
           <div className="cloud-markdown-rail-title">
@@ -306,7 +378,8 @@ function isMarkdownCatalogResponse(value: unknown): value is MarkdownCatalogResp
     (document.title === null || typeof document.title === "string") &&
     typeof document.body_doc_id === "string" &&
     (document.scope === "owner" || document.scope === "editor" || document.scope === "viewer") &&
-    typeof document.updated_at === "string"
+    typeof document.updated_at === "string" &&
+    (document.latest_revision_id === null || typeof document.latest_revision_id === "string")
   );
 }
 

--- a/apps/notebook-cloud/viewer/markdown-document-route.tsx
+++ b/apps/notebook-cloud/viewer/markdown-document-route.tsx
@@ -1,0 +1,302 @@
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { ArrowLeft, Eye, FileText, Loader2, PencilLine } from "lucide-react";
+import type { NotebookOutlineItem } from "runtimed";
+import { CodeMirrorEditor } from "@/components/editor/codemirror-editor";
+import { ProjectedMarkdownView } from "@/components/markdown/ProjectedMarkdownView";
+import { NotebookOutlinePanel } from "@/components/notebook-rail/NotebookRail";
+import { projectMarkdownDocument, type MarkdownDocumentProjection } from "@/lib/markdown-document";
+import { cloudResponseError } from "./cloud-response";
+import type { CloudMarkdownDocumentConfig, CloudViewerAuthConfig } from "./cloud-viewer-types";
+import { fetchWithCloudPrototypeAuth, type CloudPrototypeAuthState } from "./collaborator-auth";
+import { createMarkdownHandle, type MarkdownHandle } from "./runtimed-wasm-client";
+import {
+  useCloudAppSessionBridge,
+  useCloudAppSessionStatus,
+  useCloudPrototypeAuth,
+} from "./use-cloud-auth";
+
+interface MarkdownCatalogResponse {
+  document: {
+    document_id: string;
+    title: string | null;
+    body_doc_id: string;
+    scope: "owner" | "editor" | "viewer";
+    updated_at: string;
+  };
+}
+
+type RouteState =
+  | { kind: "loading" }
+  | { kind: "ready"; title: string; body: string; scope: "owner" | "editor" | "viewer" }
+  | { kind: "error"; message: string };
+
+export function MarkdownDocumentRoute({
+  authConfig,
+  config,
+}: {
+  authConfig: CloudViewerAuthConfig;
+  config: CloudMarkdownDocumentConfig;
+}) {
+  const appSessionStatus = useCloudAppSessionStatus(config.session ?? null);
+  const { authState } = useCloudPrototypeAuth(authConfig, {
+    appSessionRefreshFallback: true,
+    appSessionLoading: appSessionStatus.status === "loading",
+    appSession: appSessionStatus.session,
+  });
+  useCloudAppSessionBridge(
+    authState,
+    appSessionStatus.session,
+    appSessionStatus.status === "loading",
+    appSessionStatus.refreshAppSessionStatus,
+  );
+  const [routeState, setRouteState] = useState<RouteState>({ kind: "loading" });
+  const [mode, setMode] = useState<"source" | "read">("source");
+  const handleRef = useRef<MarkdownHandle | null>(null);
+
+  useEffect(() => {
+    let disposed = false;
+    void (async () => {
+      try {
+        setRouteState({ kind: "loading" });
+        const catalog = await fetchMarkdownCatalog(config, authState);
+        if (disposed) return;
+        const title = catalog.document.title?.trim() || "Untitled Markdown";
+        const handle = await createMarkdownHandle(
+          catalog.document.body_doc_id,
+          title,
+          markdownActorLabel(authState),
+          config.runtimedWasmModulePath,
+          config.runtimedWasmPath,
+        );
+        const initialBody = `# ${title}\n\nStart writing.`;
+        handle.replace_body_for_import(initialBody);
+        handleRef.current?.free();
+        handleRef.current = handle;
+        setRouteState({
+          kind: "ready",
+          title,
+          body: handle.body() ?? "",
+          scope: catalog.document.scope,
+        });
+      } catch (error) {
+        if (disposed) return;
+        setRouteState({
+          kind: "error",
+          message: error instanceof Error ? error.message : String(error),
+        });
+      }
+    })();
+
+    return () => {
+      disposed = true;
+      handleRef.current?.free();
+      handleRef.current = null;
+    };
+  }, [authState, config]);
+
+  const projection = useMemo<MarkdownDocumentProjection | null>(() => {
+    if (routeState.kind !== "ready") {
+      return null;
+    }
+    return projectMarkdownDocument({
+      id: config.documentId,
+      title: routeState.title,
+      body: routeState.body,
+      access: routeState.scope,
+      requestedMode: mode,
+      updatedAt: null,
+    });
+  }, [config.documentId, mode, routeState]);
+
+  const onEditorValueChange = useCallback((nextBody: string) => {
+    const handle = handleRef.current;
+    if (!handle) {
+      return;
+    }
+    const previousBody = handle.body() ?? "";
+    const splice = diffAsSplice(previousBody, nextBody);
+    handle.splice_body(splice.index, splice.deleteCount, splice.insertText);
+    const body = handle.body() ?? nextBody;
+    setRouteState((current) => (current.kind === "ready" ? { ...current, body } : current));
+  }, []);
+
+  if (routeState.kind === "loading") {
+    return (
+      <main className="cloud-markdown-shell">
+        <div className="cloud-state" data-kind="loading">
+          <Loader2 aria-hidden="true" />
+          Opening Markdown document
+        </div>
+      </main>
+    );
+  }
+
+  if (routeState.kind === "error" || !projection) {
+    return (
+      <main className="cloud-markdown-shell">
+        <div className="cloud-state" data-kind="error">
+          {routeState.kind === "error" ? routeState.message : "Markdown document did not project"}
+        </div>
+      </main>
+    );
+  }
+
+  const canEdit = projection.canEdit;
+
+  return (
+    <main className="cloud-markdown-shell">
+      <header className="cloud-markdown-toolbar">
+        <a href="/m" aria-label="Open Markdown documents" className="cloud-markdown-home-link">
+          <ArrowLeft aria-hidden="true" />
+        </a>
+        <div>
+          <p className="cloud-dashboard-eyebrow">Markdown</p>
+          <h1>{projection.title}</h1>
+        </div>
+        <div className="cloud-markdown-toolbar-actions">
+          <button type="button" aria-pressed={mode === "read"} onClick={() => setMode("read")}>
+            <Eye aria-hidden="true" />
+            Read
+          </button>
+          <button
+            type="button"
+            aria-pressed={mode === "source"}
+            disabled={!canEdit}
+            onClick={() => setMode("source")}
+          >
+            <PencilLine aria-hidden="true" />
+            Source
+          </button>
+        </div>
+      </header>
+      <div className="cloud-markdown-notice">
+        Markdown body edits are local to this browser until the hosted Automerge sync channel lands.
+      </div>
+      <div className="cloud-markdown-workspace">
+        <aside className="cloud-markdown-rail">
+          <div className="cloud-markdown-rail-title">
+            <FileText aria-hidden="true" />
+            Outline
+          </div>
+          <NotebookOutlinePanel
+            items={markdownOutlineItems(projection)}
+            emptyMessage="Add Markdown headings to structure this document. They will appear here."
+            getItemHref={(item) => item.href}
+            onNavigateItem={(_item, href) => {
+              window.location.hash = href;
+              return true;
+            }}
+          />
+        </aside>
+        <section className="cloud-markdown-stage">
+          {mode === "source" && canEdit ? (
+            <CodeMirrorEditor
+              key={config.documentId}
+              initialValue={projection.body}
+              language="markdown"
+              lineWrapping
+              className="cloud-markdown-editor"
+              onValueChange={onEditorValueChange}
+            />
+          ) : projection.markdownPlan ? (
+            <ProjectedMarkdownView
+              plan={projection.markdownPlan}
+              className="cloud-markdown-preview"
+              headingAnchors={projection.headingAnchors}
+            />
+          ) : (
+            <div className="cloud-state" data-kind="empty">
+              Nothing to render yet.
+            </div>
+          )}
+        </section>
+      </div>
+    </main>
+  );
+}
+
+async function fetchMarkdownCatalog(
+  config: CloudMarkdownDocumentConfig,
+  authState: CloudPrototypeAuthState,
+): Promise<MarkdownCatalogResponse> {
+  const response = await fetchWithCloudPrototypeAuth(
+    new URL(config.catalogEndpoint, window.location.origin).href,
+    { headers: { Accept: "application/json" } },
+    authState.mode === "dev" ? { ...authState, requestedScope: "viewer" } : authState,
+  );
+  if (!response.ok) {
+    throw await cloudResponseError(response, "Unable to open Markdown document");
+  }
+  const body = (await response.json()) as MarkdownCatalogResponse;
+  if (!isMarkdownCatalogResponse(body)) {
+    throw new Error("Unable to open Markdown document: response shape was invalid");
+  }
+  return body;
+}
+
+function isMarkdownCatalogResponse(value: unknown): value is MarkdownCatalogResponse {
+  if (!value || typeof value !== "object") {
+    return false;
+  }
+  const document = (value as Partial<MarkdownCatalogResponse>).document;
+  return (
+    Boolean(document) &&
+    typeof document?.document_id === "string" &&
+    (document.title === null || typeof document.title === "string") &&
+    typeof document.body_doc_id === "string" &&
+    (document.scope === "owner" || document.scope === "editor" || document.scope === "viewer") &&
+    typeof document.updated_at === "string"
+  );
+}
+
+function markdownOutlineItems(projection: MarkdownDocumentProjection): NotebookOutlineItem[] {
+  return projection.outlineItems.map((item) => ({
+    id: item.id,
+    cellId: item.blockId,
+    cellType: "markdown",
+    title: item.title,
+    level: item.level,
+    kind: "heading",
+    cellAnchorId: item.blockId,
+    headingAnchorId: item.anchor,
+    href: item.href,
+    anchor: item.anchor,
+  }));
+}
+
+function markdownActorLabel(authState: CloudPrototypeAuthState): string {
+  const user = encodeURIComponent(authState.user ?? "browser");
+  return `user:markdown:${user}/browser:${crypto.randomUUID()}`;
+}
+
+function diffAsSplice(
+  previous: string,
+  next: string,
+): { index: number; deleteCount: number; insertText: string } {
+  if (previous === next) {
+    return { index: 0, deleteCount: 0, insertText: "" };
+  }
+  let prefix = 0;
+  while (
+    prefix < previous.length &&
+    prefix < next.length &&
+    previous.charCodeAt(prefix) === next.charCodeAt(prefix)
+  ) {
+    prefix += 1;
+  }
+  let previousSuffix = previous.length;
+  let nextSuffix = next.length;
+  while (
+    previousSuffix > prefix &&
+    nextSuffix > prefix &&
+    previous.charCodeAt(previousSuffix - 1) === next.charCodeAt(nextSuffix - 1)
+  ) {
+    previousSuffix -= 1;
+    nextSuffix -= 1;
+  }
+  return {
+    index: prefix,
+    deleteCount: previousSuffix - prefix,
+    insertText: next.slice(prefix, nextSuffix),
+  };
+}

--- a/apps/notebook-cloud/viewer/markdown-document-route.tsx
+++ b/apps/notebook-cloud/viewer/markdown-document-route.tsx
@@ -495,55 +495,72 @@ export function MarkdownDocumentRoute({
   ]);
 
   const saveMarkdownDocumentTitle = useCallback(
-    async (nextTitle: string): Promise<boolean> => {
+    (nextTitle: string): boolean => {
       if (routeState.kind !== "ready" || routeState.scope === "viewer" || markdownTitleSaving) {
         return false;
       }
 
-      try {
-        setMarkdownTitleSaving(true);
+      const displayTitle = nextTitle.trim() || "Untitled Markdown";
+      if (routeState.title === displayTitle) {
         setMarkdownTitleError(null);
-        const response = await fetchWithCloudPrototypeAuth(
-          new URL(config.catalogEndpoint, window.location.origin).href,
-          {
-            method: "PATCH",
-            headers: {
-              Accept: "application/json",
-              "Content-Type": "application/json",
-            },
-            body: JSON.stringify({ title: nextTitle.trim() || null }),
-          },
-          authState.mode === "dev" ? { ...authState, requestedScope: "editor" } : authState,
-        );
-        if (!response.ok) {
-          throw await cloudResponseError(response, "Unable to rename Markdown document");
-        }
-        const body = (await response.json()) as MarkdownDocumentMetadataUpdateResponse;
-        if (body.ok !== true || body.document_id !== config.documentId) {
-          throw new Error("Unable to rename Markdown document: response shape was invalid");
-        }
-        const displayTitle = body.title?.trim() || "Untitled Markdown";
-        syncControllerRef.current?.editTitle(displayTitle);
-        setRouteState((current) =>
-          current.kind === "ready" ? { ...current, title: displayTitle } : current,
-        );
-        if (body.viewer_url) {
-          const nextHref = cloudDocumentUrlAfterRename({
-            currentHref: window.location.href,
-            routePrefix: "/m",
-            viewerUrl: body.viewer_url,
-          });
-          if (nextHref !== window.location.href) {
-            window.history.replaceState(window.history.state, "", nextHref);
-          }
-        }
         return true;
-      } catch (error) {
-        setMarkdownTitleError(error instanceof Error ? error.message : String(error));
-        return false;
-      } finally {
-        setMarkdownTitleSaving(false);
       }
+
+      setMarkdownTitleError(null);
+      syncControllerRef.current?.editTitle(displayTitle);
+      setRouteState((current) =>
+        current.kind === "ready" ? { ...current, title: displayTitle } : current,
+      );
+
+      setMarkdownTitleSaving(true);
+      void (async () => {
+        try {
+          const response = await fetchWithCloudPrototypeAuth(
+            new URL(config.catalogEndpoint, window.location.origin).href,
+            {
+              method: "PATCH",
+              headers: {
+                Accept: "application/json",
+                "Content-Type": "application/json",
+              },
+              body: JSON.stringify({
+                title: displayTitle === "Untitled Markdown" ? null : displayTitle,
+              }),
+            },
+            authState.mode === "dev" ? { ...authState, requestedScope: "editor" } : authState,
+          );
+          if (!response.ok) {
+            throw await cloudResponseError(response, "Unable to rename Markdown document");
+          }
+          const body = (await response.json()) as MarkdownDocumentMetadataUpdateResponse;
+          if (body.ok !== true || body.document_id !== config.documentId) {
+            throw new Error("Unable to rename Markdown document: response shape was invalid");
+          }
+          const serverTitle = body.title?.trim() || "Untitled Markdown";
+          if (serverTitle !== displayTitle) {
+            syncControllerRef.current?.editTitle(serverTitle);
+          }
+          setRouteState((current) =>
+            current.kind === "ready" ? { ...current, title: serverTitle } : current,
+          );
+          if (body.viewer_url) {
+            const nextHref = cloudDocumentUrlAfterRename({
+              currentHref: window.location.href,
+              routePrefix: "/m",
+              viewerUrl: body.viewer_url,
+            });
+            if (nextHref !== window.location.href) {
+              window.history.replaceState(window.history.state, "", nextHref);
+            }
+          }
+        } catch (error) {
+          setMarkdownTitleError(error instanceof Error ? error.message : String(error));
+        } finally {
+          setMarkdownTitleSaving(false);
+        }
+      })();
+
+      return true;
     },
     [authState, config.catalogEndpoint, config.documentId, markdownTitleSaving, routeState],
   );

--- a/apps/notebook-cloud/viewer/markdown-document-route.tsx
+++ b/apps/notebook-cloud/viewer/markdown-document-route.tsx
@@ -134,6 +134,7 @@ export function MarkdownDocumentRoute({
   const syncControllerRef = useRef<MarkdownDocumentLiveSyncController | null>(null);
   const editorRef = useRef<CodeMirrorEditorRef | null>(null);
   const connectionStatusRef = useRef<ConnectionStatus>("connecting");
+  const liveSnapshotSeenRef = useRef(false);
 
   useEffect(() => {
     loadSupplementalViewerCss();
@@ -163,6 +164,7 @@ export function MarkdownDocumentRoute({
   useEffect(() => {
     let disposed = false;
     let controller: MarkdownDocumentLiveSyncController | null = null;
+    liveSnapshotSeenRef.current = false;
     void (async () => {
       try {
         connectionStatusRef.current = "connecting";
@@ -181,6 +183,32 @@ export function MarkdownDocumentRoute({
         if (disposed) return;
         const title = catalog.document.title?.trim() || "Untitled Markdown";
         const latestRevisionId = catalog.document.latest_revision_id;
+        void liveSyncModule
+          .loadMarkdownDocumentInstantPaintSnapshot({
+            authState,
+            config,
+            appSession: appSessionStatus.session,
+            title,
+            onError: (error) => {
+              console.warn("[notebook-cloud] Markdown instant paint failed", error);
+            },
+          })
+          .then((snapshot) => {
+            if (!snapshot || disposed || liveSnapshotSeenRef.current) {
+              return;
+            }
+            setRouteState({
+              kind: "ready",
+              title: snapshot.title,
+              body: snapshot.body,
+              bodyReady: snapshot.bodyReady,
+              markdownPlan: null,
+              scope: catalog.document.scope,
+              connectionStatus: connectionStatusRef.current,
+              liveReady: false,
+              latestRevisionId,
+            });
+          });
         controller = await liveSyncModule.startMarkdownDocumentLiveSync({
           authState,
           config,
@@ -200,6 +228,7 @@ export function MarkdownDocumentRoute({
             );
           },
           onSnapshot: (snapshot) => {
+            liveSnapshotSeenRef.current = true;
             setRouteState({
               kind: "ready",
               title: snapshot.title,

--- a/apps/notebook-cloud/viewer/markdown-document-route.tsx
+++ b/apps/notebook-cloud/viewer/markdown-document-route.tsx
@@ -34,6 +34,7 @@ import {
   replaceCloudNotebookModeInCurrentUrl,
 } from "./cloud-notebook-mode";
 import { cloudNotebookTitleClassNames } from "./cloud-notebook-title";
+import { markdownConnectionCopy } from "./markdown-document-connection-copy";
 import type { CloudMarkdownDocumentConfig, CloudViewerAuthConfig } from "./cloud-viewer-types";
 import { fetchWithCloudPrototypeAuth, type CloudPrototypeAuthState } from "./collaborator-auth";
 import type { MarkdownDocumentLiveSyncController } from "./markdown-document-live-sync";
@@ -750,20 +751,4 @@ function scrollEditorToMarkdownOutlineItem(
     scrollIntoView: true,
   });
   return true;
-}
-
-function markdownConnectionCopy(status: ConnectionStatus, bodyReady: boolean): string | null {
-  if (!bodyReady) {
-    return "Syncing Markdown document body.";
-  }
-  switch (status) {
-    case "connecting":
-      return "Connecting to the live Markdown document.";
-    case "reconnecting":
-      return "Reconnecting to the live Markdown document.";
-    case "offline":
-      return "Markdown document is offline. Local changes will wait for reconnection.";
-    case "online":
-      return null;
-  }
 }

--- a/apps/notebook-cloud/viewer/markdown-document-route.tsx
+++ b/apps/notebook-cloud/viewer/markdown-document-route.tsx
@@ -1,7 +1,8 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
-import { Globe2, House, ListTree, Loader2 } from "lucide-react";
+import { House, ListTree } from "lucide-react";
 import type { EditorView } from "@codemirror/view";
 import type { ConnectionStatus, NotebookOutlineItem } from "runtimed";
+import { notebookRouteSegmentTitle } from "../src/notebook-route-title";
 import {
   CodeMirrorEditor,
   externalChangeAnnotation,
@@ -11,6 +12,7 @@ import { ProjectedMarkdownView } from "@/components/markdown/ProjectedMarkdownVi
 import {
   NotebookDocumentShell,
   NotebookDocumentToolbar,
+  DocumentTitle,
   NotebookNotice,
   NotebookNoticeStack,
   projectNotebookShellCapabilities,
@@ -26,6 +28,11 @@ import {
 } from "@/lib/markdown-document";
 import { cn } from "@/lib/utils";
 import { cloudResponseError } from "./cloud-response";
+import {
+  cloudDocumentUrlAfterRename,
+  type CloudNotebookTitleDisplay,
+} from "./cloud-notebook-title-state";
+import { cloudNotebookTitleClassNames } from "./cloud-notebook-title";
 import type { CloudMarkdownDocumentConfig, CloudViewerAuthConfig } from "./cloud-viewer-types";
 import { fetchWithCloudPrototypeAuth, type CloudPrototypeAuthState } from "./collaborator-auth";
 import {
@@ -50,11 +57,13 @@ interface MarkdownCatalogResponse {
   };
 }
 
-type PublishStatus =
-  | { kind: "idle"; message: string | null }
-  | { kind: "publishing"; message: string }
-  | { kind: "published"; message: string; revisionId: string }
-  | { kind: "error"; message: string };
+interface MarkdownDocumentMetadataUpdateResponse {
+  ok: true;
+  document_id: string;
+  title: string | null;
+  updated_at: string;
+  viewer_url?: string;
+}
 
 type MarkdownDocumentAccessLevel = "owner" | "editor" | "viewer";
 
@@ -63,7 +72,6 @@ type MarkdownRailPanelId = "outline";
 const MARKDOWN_RAIL_ITEMS = [{ id: "outline" as const, label: "Outline", icon: ListTree }];
 
 type RouteState =
-  | { kind: "loading" }
   | {
       kind: "ready";
       title: string;
@@ -94,17 +102,16 @@ export function MarkdownDocumentRoute({
     appSessionStatus.status === "loading",
     appSessionStatus.refreshAppSessionStatus,
   );
-  const [routeState, setRouteState] = useState<RouteState>({ kind: "loading" });
+  const [routeState, setRouteState] = useState<RouteState>(() =>
+    initialMarkdownDocumentRouteState(config),
+  );
   const [mode, setMode] = useState<MarkdownDocumentMode>("edit");
   const [railCollapsed, setRailCollapsed] = useState(initialMarkdownRailCollapsed);
-  const [publishStatus, setPublishStatus] = useState<PublishStatus>({
-    kind: "idle",
-    message: null,
-  });
+  const [markdownTitleSaving, setMarkdownTitleSaving] = useState(false);
+  const [markdownTitleError, setMarkdownTitleError] = useState<string | null>(null);
   const syncControllerRef = useRef<MarkdownDocumentLiveSyncController | null>(null);
   const editorRef = useRef<CodeMirrorEditorRef | null>(null);
   const connectionStatusRef = useRef<ConnectionStatus>("connecting");
-  const latestRevisionIdRef = useRef<string | null>(null);
 
   useEffect(() => {
     if (typeof window === "undefined") {
@@ -129,11 +136,16 @@ export function MarkdownDocumentRoute({
     void (async () => {
       try {
         connectionStatusRef.current = "connecting";
-        setRouteState({ kind: "loading" });
-        const catalog = await fetchMarkdownCatalog(config, authState);
+        setRouteState((current) =>
+          current.kind === "ready"
+            ? { ...current, bodyReady: false, connectionStatus: "connecting" }
+            : initialMarkdownDocumentRouteState(config),
+        );
+        const catalog =
+          markdownCatalogFromBootstrap(config) ?? (await fetchMarkdownCatalog(config, authState));
         if (disposed) return;
-        latestRevisionIdRef.current = catalog.document.latest_revision_id;
         const title = catalog.document.title?.trim() || "Untitled Markdown";
+        const latestRevisionId = catalog.document.latest_revision_id;
         controller = await startMarkdownDocumentLiveSync({
           authState,
           config,
@@ -160,7 +172,7 @@ export function MarkdownDocumentRoute({
               bodyReady: snapshot.bodyReady,
               scope: catalog.document.scope,
               connectionStatus: connectionStatusRef.current,
-              latestRevisionId: latestRevisionIdRef.current,
+              latestRevisionId,
             });
           },
         });
@@ -202,46 +214,72 @@ export function MarkdownDocumentRoute({
       updatedAt: null,
     });
   }, [config.documentId, mode, routeState]);
+  const routeTitle = routeState.kind === "ready" ? routeState.title : null;
+
+  useEffect(() => {
+    if (!routeTitle || typeof document === "undefined") {
+      return;
+    }
+    document.title = markdownDocumentBrowserTitle(routeTitle);
+  }, [routeTitle]);
+
+  const saveMarkdownDocumentTitle = useCallback(
+    async (nextTitle: string): Promise<boolean> => {
+      if (routeState.kind !== "ready" || routeState.scope === "viewer" || markdownTitleSaving) {
+        return false;
+      }
+
+      try {
+        setMarkdownTitleSaving(true);
+        setMarkdownTitleError(null);
+        const response = await fetchWithCloudPrototypeAuth(
+          new URL(config.catalogEndpoint, window.location.origin).href,
+          {
+            method: "PATCH",
+            headers: {
+              Accept: "application/json",
+              "Content-Type": "application/json",
+            },
+            body: JSON.stringify({ title: nextTitle.trim() || null }),
+          },
+          authState.mode === "dev" ? { ...authState, requestedScope: "editor" } : authState,
+        );
+        if (!response.ok) {
+          throw await cloudResponseError(response, "Unable to rename Markdown document");
+        }
+        const body = (await response.json()) as MarkdownDocumentMetadataUpdateResponse;
+        if (body.ok !== true || body.document_id !== config.documentId) {
+          throw new Error("Unable to rename Markdown document: response shape was invalid");
+        }
+        const displayTitle = body.title?.trim() || "Untitled Markdown";
+        syncControllerRef.current?.editTitle(displayTitle);
+        setRouteState((current) =>
+          current.kind === "ready" ? { ...current, title: displayTitle } : current,
+        );
+        if (body.viewer_url) {
+          const nextHref = cloudDocumentUrlAfterRename({
+            currentHref: window.location.href,
+            routePrefix: "/m",
+            viewerUrl: body.viewer_url,
+          });
+          if (nextHref !== window.location.href) {
+            window.history.replaceState(window.history.state, "", nextHref);
+          }
+        }
+        return true;
+      } catch (error) {
+        setMarkdownTitleError(error instanceof Error ? error.message : String(error));
+        return false;
+      } finally {
+        setMarkdownTitleSaving(false);
+      }
+    },
+    [authState, config.catalogEndpoint, config.documentId, markdownTitleSaving, routeState],
+  );
 
   const onEditorValueChange = useCallback((nextBody: string) => {
     syncControllerRef.current?.editBody(nextBody);
-    setPublishStatus((current) =>
-      current.kind === "published" ? { kind: "idle", message: "Unpublished changes." } : current,
-    );
   }, []);
-
-  const publishMarkdownDocumentSnapshot = useCallback(async () => {
-    const controller = syncControllerRef.current;
-    if (!controller || routeState.kind !== "ready") {
-      setPublishStatus({
-        kind: "error",
-        message: "Markdown document is still connecting. Try publishing again in a moment.",
-      });
-      return;
-    }
-    const hadPublicVersion = latestRevisionIdRef.current !== null;
-    setPublishStatus({
-      kind: "publishing",
-      message: hadPublicVersion ? "Updating public version..." : "Publishing Markdown document...",
-    });
-    try {
-      const snapshot = await controller.publishSnapshot();
-      latestRevisionIdRef.current = snapshot.revisionId;
-      setRouteState((current) =>
-        current.kind === "ready" ? { ...current, latestRevisionId: snapshot.revisionId } : current,
-      );
-      setPublishStatus({
-        kind: "published",
-        message: hadPublicVersion ? "Public version updated." : "Public version saved.",
-        revisionId: snapshot.revisionId,
-      });
-    } catch (error) {
-      setPublishStatus({
-        kind: "error",
-        message: error instanceof Error ? error.message : String(error),
-      });
-    }
-  }, [routeState.kind]);
 
   useEffect(() => {
     if (routeState.kind !== "ready" || mode !== "edit") {
@@ -261,17 +299,6 @@ export function MarkdownDocumentRoute({
     });
   }, [mode, routeState]);
 
-  if (routeState.kind === "loading") {
-    return (
-      <main className="cloud-markdown-shell">
-        <div className="cloud-state" data-kind="loading">
-          <Loader2 aria-hidden="true" />
-          Opening Markdown document
-        </div>
-      </main>
-    );
-  }
-
   if (routeState.kind === "error" || !projection) {
     return (
       <main className="cloud-markdown-shell">
@@ -285,8 +312,8 @@ export function MarkdownDocumentRoute({
   const canEdit = projection.canEdit && routeState.bodyReady;
   const canManageSharing =
     projection.canShare && config.hostCapabilities?.canManageSharing !== false;
-  const canPublish = projection.canPublish && config.hostCapabilities?.canPublish !== false;
   const activeMode = projection.mode;
+  const markdownTitle = markdownDocumentTitleDisplay(projection.title, projection.access);
   const shellCapabilities = markdownDocumentShellCapabilities({
     access: routeState.scope,
     authState,
@@ -297,7 +324,6 @@ export function MarkdownDocumentRoute({
   const connectionCopy = markdownConnectionCopy(routeState.connectionStatus, routeState.bodyReady);
   const publicLink =
     typeof window === "undefined" ? "" : `${window.location.origin}${window.location.pathname}`;
-  const publishCopy = publishStatus.message;
   const markdownOutline = (
     <NotebookOutlinePanel
       items={markdownOutlineItems(projection)}
@@ -345,53 +371,49 @@ export function MarkdownDocumentRoute({
       capabilities={shellCapabilities}
       frameClassName="z-20"
       headerClassName="cloud-room-toolbar cloud-markdown-room-toolbar"
-      presence={<MarkdownDocumentTitle title={projection.title} access={projection.access} />}
+      presence={
+        <DocumentTitle
+          title={markdownTitle}
+          renameTitle={projection.title === "Untitled Markdown" ? "" : projection.title}
+          canRename={projection.canEdit}
+          renameSaving={markdownTitleSaving}
+          renameError={markdownTitleError}
+          onRename={saveMarkdownDocumentTitle}
+          homeHref="/m"
+          homeAriaLabel="Open Markdown documents"
+          homeTitle="Markdown documents"
+          homeIcon={<House aria-hidden="true" />}
+          inputAriaLabel="Markdown document title"
+          inputName="markdown-document-title"
+          placeholder="Untitled Markdown"
+          renameButtonTitle="Rename Markdown document"
+          classNames={{
+            ...cloudNotebookTitleClassNames,
+            group: "cloud-notebook-title-group cloud-markdown-title-group",
+          }}
+        />
+      }
       utilityControls={
         <MarkdownDocumentModeToggle mode={activeMode} canEdit={canEdit} onModeChange={setMode} />
       }
       sharingControls={
         canManageSharing ? (
-          <>
-            <MarkdownSharingControls
-              aclEndpoint={config.aclEndpoint}
-              authState={authState}
-              publicLink={publicLink}
-            />
-            {canPublish ? (
-              <button
-                type="button"
-                className="markdown-document-toolbar-action"
-                disabled={publishStatus.kind === "publishing" || !routeState.bodyReady}
-                onClick={() => void publishMarkdownDocumentSnapshot()}
-              >
-                {publishStatus.kind === "publishing" ? (
-                  <Loader2 aria-hidden="true" />
-                ) : (
-                  <Globe2 aria-hidden="true" />
-                )}
-                <span>{projection.isPublished ? "Update public version" : "Publish"}</span>
-              </button>
-            ) : null}
-          </>
+          <MarkdownSharingControls
+            aclEndpoint={config.aclEndpoint}
+            authState={authState}
+            publicLink={publicLink}
+          />
         ) : null
       }
     />
   );
-  const notices =
-    connectionCopy || publishCopy ? (
-      <NotebookNoticeStack>
-        {connectionCopy ? (
-          <NotebookNotice tone="warning" title="Sync">
-            {connectionCopy}
-          </NotebookNotice>
-        ) : null}
-        {publishCopy ? (
-          <NotebookNotice tone={publishNoticeTone(publishStatus.kind)} title="Markdown">
-            {publishCopy}
-          </NotebookNotice>
-        ) : null}
-      </NotebookNoticeStack>
-    ) : null;
+  const notices = connectionCopy ? (
+    <NotebookNoticeStack>
+      <NotebookNotice tone="warning" title="Sync">
+        {connectionCopy}
+      </NotebookNotice>
+    </NotebookNoticeStack>
+  ) : null;
 
   return (
     <NotebookDocumentShell
@@ -439,31 +461,72 @@ function initialMarkdownRailCollapsed(): boolean {
   return typeof window !== "undefined" && window.matchMedia("(max-width: 599.98px)").matches;
 }
 
-function MarkdownDocumentTitle({
-  title,
-  access,
-}: {
-  title: string;
-  access: MarkdownDocumentProjection["access"];
-}) {
-  return (
-    <div className="cloud-notebook-title-group cloud-markdown-title-group">
-      <a
-        className="cloud-notebook-home-link"
-        href="/m"
-        aria-label="Open Markdown documents"
-        title="Markdown documents"
-      >
-        <House aria-hidden="true" />
-      </a>
-      <div className="cloud-notebook-title" title={title}>
-        <div className="cloud-notebook-title-static">
-          <span>{title}</span>
-        </div>
-        <small>{markdownTitleDetail(access)}</small>
-      </div>
-    </div>
-  );
+function initialMarkdownDocumentRouteState(config: CloudMarkdownDocumentConfig): RouteState {
+  const bootstrap = config.bootstrap;
+  if (bootstrap) {
+    return {
+      kind: "ready",
+      title: bootstrap.title?.trim() || "Untitled Markdown",
+      body: "",
+      bodyReady: false,
+      scope: bootstrap.scope,
+      connectionStatus: "connecting",
+      latestRevisionId: bootstrap.latest_revision_id,
+    };
+  }
+  return {
+    kind: "ready",
+    title: markdownDocumentRouteTitle(),
+    body: "",
+    bodyReady: false,
+    scope: "viewer",
+    connectionStatus: "connecting",
+    latestRevisionId: null,
+  };
+}
+
+function markdownCatalogFromBootstrap(
+  config: CloudMarkdownDocumentConfig,
+): MarkdownCatalogResponse | null {
+  const bootstrap = config.bootstrap;
+  if (!bootstrap) {
+    return null;
+  }
+  return {
+    document: {
+      document_id: config.documentId,
+      title: bootstrap.title,
+      body_doc_id: bootstrap.body_doc_id,
+      scope: bootstrap.scope,
+      updated_at: bootstrap.updated_at,
+      latest_revision_id: bootstrap.latest_revision_id,
+    },
+  };
+}
+
+function markdownDocumentRouteTitle(): string {
+  if (typeof window === "undefined") {
+    return "Markdown document";
+  }
+  const pathParts = window.location.pathname.split("/").filter(Boolean);
+  const routeSlug = pathParts[0] === "m" ? pathParts[2] : null;
+  return notebookRouteSegmentTitle(routeSlug) ?? "Markdown document";
+}
+
+function markdownDocumentTitleDisplay(
+  title: string,
+  access: MarkdownDocumentProjection["access"],
+): CloudNotebookTitleDisplay {
+  return {
+    label: title,
+    detail: markdownTitleDetail(access),
+    title,
+  };
+}
+
+function markdownDocumentBrowserTitle(title: string): string {
+  const displayTitle = title.trim() || "Untitled Markdown";
+  return `nteract Markdown: ${displayTitle}`;
 }
 
 function markdownDocumentShellCapabilities({
@@ -544,16 +607,6 @@ function markdownTitleDetail(access: MarkdownDocumentProjection["access"]): stri
     return "Markdown document · Viewer";
   }
   return "Markdown document";
-}
-
-function publishNoticeTone(kind: PublishStatus["kind"]) {
-  if (kind === "published") {
-    return "success";
-  }
-  if (kind === "error") {
-    return "error";
-  }
-  return "info";
 }
 
 async function fetchMarkdownCatalog(

--- a/apps/notebook-cloud/viewer/markdown-document-route.tsx
+++ b/apps/notebook-cloud/viewer/markdown-document-route.tsx
@@ -186,32 +186,34 @@ export function MarkdownDocumentRoute({
         if (disposed) return;
         const title = catalog.document.title?.trim() || "Untitled Markdown";
         const latestRevisionId = catalog.document.latest_revision_id;
-        void liveSyncModule
-          .loadMarkdownDocumentInstantPaintSnapshot({
-            authState,
-            config,
-            appSession: appSessionStatus.session,
-            title,
-            onError: (error) => {
-              console.warn("[notebook-cloud] Markdown instant paint failed", error);
-            },
-          })
-          .then((snapshot) => {
-            if (!snapshot || disposed || liveSnapshotSeenRef.current) {
-              return;
-            }
-            setRouteState({
-              kind: "ready",
-              title: snapshot.title,
-              body: snapshot.body,
-              bodyReady: snapshot.bodyReady,
-              markdownPlan: null,
-              scope: catalog.document.scope,
-              connectionStatus: connectionStatusRef.current,
-              liveReady: false,
-              latestRevisionId,
+        if (liveSyncModule.shouldLoadMarkdownInstantPaintSnapshot(config)) {
+          void liveSyncModule
+            .loadMarkdownDocumentInstantPaintSnapshot({
+              authState,
+              config,
+              appSession: appSessionStatus.session,
+              title,
+              onError: (error) => {
+                console.warn("[notebook-cloud] Markdown instant paint failed", error);
+              },
+            })
+            .then((snapshot) => {
+              if (!snapshot || disposed || liveSnapshotSeenRef.current) {
+                return;
+              }
+              setRouteState({
+                kind: "ready",
+                title: snapshot.title,
+                body: snapshot.body,
+                bodyReady: snapshot.bodyReady,
+                markdownPlan: null,
+                scope: catalog.document.scope,
+                connectionStatus: connectionStatusRef.current,
+                liveReady: false,
+                latestRevisionId,
+              });
             });
-          });
+        }
         controller = await liveSyncModule.startMarkdownDocumentLiveSync({
           authState,
           config,

--- a/apps/notebook-cloud/viewer/markdown-document-route.tsx
+++ b/apps/notebook-cloud/viewer/markdown-document-route.tsx
@@ -67,12 +67,14 @@ export function MarkdownDocumentRoute({
   const [mode, setMode] = useState<"source" | "read">("source");
   const syncControllerRef = useRef<MarkdownDocumentLiveSyncController | null>(null);
   const editorRef = useRef<CodeMirrorEditorRef | null>(null);
+  const connectionStatusRef = useRef<ConnectionStatus>("connecting");
 
   useEffect(() => {
     let disposed = false;
     let controller: MarkdownDocumentLiveSyncController | null = null;
     void (async () => {
       try {
+        connectionStatusRef.current = "connecting";
         setRouteState({ kind: "loading" });
         const catalog = await fetchMarkdownCatalog(config, authState);
         if (disposed) return;
@@ -90,6 +92,7 @@ export function MarkdownDocumentRoute({
             console.warn("[notebook-cloud] Markdown document sync failed", error);
           },
           onStatus: (connectionStatus) => {
+            connectionStatusRef.current = connectionStatus;
             setRouteState((current) =>
               current.kind === "ready" ? { ...current, connectionStatus } : current,
             );
@@ -101,7 +104,7 @@ export function MarkdownDocumentRoute({
               body: snapshot.body,
               bodyReady: snapshot.bodyReady,
               scope: catalog.document.scope,
-              connectionStatus: controller?.transport.connected ? "online" : "connecting",
+              connectionStatus: connectionStatusRef.current,
             });
           },
         });
@@ -224,6 +227,7 @@ export function MarkdownDocumentRoute({
           </div>
           <NotebookOutlinePanel
             items={markdownOutlineItems(projection)}
+            ariaLabel="Document outline"
             emptyMessage="Add Markdown headings to structure this document. They will appear here."
             getItemHref={(item) => item.href}
             onNavigateItem={(_item, href) => {

--- a/apps/notebook-cloud/viewer/markdown-document-route.tsx
+++ b/apps/notebook-cloud/viewer/markdown-document-route.tsx
@@ -17,10 +17,12 @@ import {
 import { NotebookOutlinePanel } from "@/components/notebook-rail/NotebookRail";
 import { Rail, RAIL_TAKEOVER_STAGE_CLASS_NAME } from "@/components/rail";
 import { MarkdownDocumentModeToggle } from "@/components/markdown/MarkdownDocumentModeToggle";
+import { MarkdownDocumentRepresentationToolbar } from "@/components/markdown/MarkdownDocumentModeToggle";
 import {
   projectMarkdownDocument,
   type MarkdownDocumentMode,
   type MarkdownDocumentProjection,
+  type MarkdownDocumentRepresentation,
 } from "@/lib/markdown-document";
 import type { MarkdownProjectionPlan } from "@/lib/markdown-projection";
 import { cn } from "@/lib/utils";
@@ -128,6 +130,8 @@ export function MarkdownDocumentRoute({
     initialMarkdownDocumentRouteState(config),
   );
   const [mode, setMode] = useState<MarkdownDocumentMode>(initialMarkdownDocumentMode);
+  const [requestedRepresentation, setRequestedRepresentation] =
+    useState<MarkdownDocumentRepresentation | null>(null);
   const [railCollapsed, setRailCollapsed] = useState(initialMarkdownRailCollapsed);
   const [markdownTitleSaving, setMarkdownTitleSaving] = useState(false);
   const [markdownTitleError, setMarkdownTitleError] = useState<string | null>(null);
@@ -277,10 +281,11 @@ export function MarkdownDocumentRoute({
       markdownPlan: routeState.markdownPlan,
       access: routeState.scope,
       requestedMode: mode,
+      requestedRepresentation,
       publishedRevisionId: routeState.latestRevisionId,
       updatedAt: null,
     });
-  }, [config.documentId, mode, routeState]);
+  }, [config.documentId, mode, requestedRepresentation, routeState]);
   const routeTitle = routeState.kind === "ready" ? routeState.title : null;
 
   useEffect(() => {
@@ -350,10 +355,18 @@ export function MarkdownDocumentRoute({
 
   const onModeChange = useCallback((nextMode: MarkdownDocumentMode) => {
     setMode(nextMode);
+    setRequestedRepresentation(null);
   }, []);
 
+  const onRepresentationChange = useCallback(
+    (nextRepresentation: MarkdownDocumentRepresentation) => {
+      setRequestedRepresentation(nextRepresentation);
+    },
+    [],
+  );
+
   useEffect(() => {
-    if (routeState.kind !== "ready" || mode !== "edit") {
+    if (routeState.kind !== "ready" || projection?.representation.active !== "source") {
       return;
     }
     const editor = editorRef.current?.getEditor();
@@ -377,7 +390,7 @@ export function MarkdownDocumentRoute({
     return () => {
       cancelled = true;
     };
-  }, [mode, routeState]);
+  }, [projection?.representation.active, routeState]);
 
   if (routeState.kind === "error" || !projection) {
     return (
@@ -390,6 +403,8 @@ export function MarkdownDocumentRoute({
   }
 
   const canEdit = projection.canEdit && routeState.liveReady;
+  const activeRepresentation = projection.representation.active;
+  const sourceEditable = canEdit && projection.representation.sourceEditable;
   const canManageSharing =
     projection.canShare && config.hostCapabilities?.canManageSharing !== false;
   const activeMode = projection.mode;
@@ -515,8 +530,17 @@ export function MarkdownDocumentRoute({
       stageLabel="Markdown document"
       capabilities={shellCapabilities}
     >
-      <div className="markdown-document-scroll" data-mode={activeMode}>
-        {activeMode === "edit" && canEdit ? (
+      <div
+        className="markdown-document-scroll"
+        data-mode={activeMode}
+        data-representation={activeRepresentation}
+      >
+        <MarkdownDocumentRepresentationToolbar
+          active={activeRepresentation}
+          options={projection.representation.options}
+          onRepresentationChange={onRepresentationChange}
+        />
+        {activeRepresentation === "source" ? (
           <Suspense
             fallback={
               <div className="cloud-state markdown-document-editor" data-kind="loading">
@@ -530,8 +554,9 @@ export function MarkdownDocumentRoute({
               initialValue={projection.body}
               language="markdown"
               lineWrapping
+              readOnly={!sourceEditable}
               className="markdown-document-editor"
-              onValueChange={onEditorValueChange}
+              onValueChange={sourceEditable ? onEditorValueChange : undefined}
             />
           </Suspense>
         ) : projection.markdownPlan ? (

--- a/apps/notebook-cloud/viewer/markdown-document-route.tsx
+++ b/apps/notebook-cloud/viewer/markdown-document-route.tsx
@@ -16,6 +16,7 @@ import {
   startMarkdownDocumentLiveSync,
   type MarkdownDocumentLiveSyncController,
 } from "./markdown-document-live-sync";
+import { MarkdownSharingControls } from "./markdown-sharing-controls";
 import {
   useCloudAppSessionBridge,
   useCloudAppSessionStatus,
@@ -190,7 +191,11 @@ export function MarkdownDocumentRoute({
   }
 
   const canEdit = projection.canEdit && routeState.bodyReady;
+  const canManageSharing =
+    projection.canShare && config.hostCapabilities?.canManageSharing !== false;
   const connectionCopy = markdownConnectionCopy(routeState.connectionStatus, routeState.bodyReady);
+  const publicLink =
+    typeof window === "undefined" ? "" : `${window.location.origin}${window.location.pathname}`;
 
   return (
     <main className="cloud-markdown-shell">
@@ -203,6 +208,13 @@ export function MarkdownDocumentRoute({
           <h1>{projection.title}</h1>
         </div>
         <div className="cloud-markdown-toolbar-actions">
+          {canManageSharing ? (
+            <MarkdownSharingControls
+              aclEndpoint={config.aclEndpoint}
+              authState={authState}
+              publicLink={publicLink}
+            />
+          ) : null}
           <button type="button" aria-pressed={mode === "read"} onClick={() => setMode("read")}>
             <Eye aria-hidden="true" />
             Read

--- a/apps/notebook-cloud/viewer/markdown-document-route.tsx
+++ b/apps/notebook-cloud/viewer/markdown-document-route.tsx
@@ -1,4 +1,13 @@
-import { lazy, Suspense, useCallback, useEffect, useMemo, useRef, useState } from "react";
+import {
+  lazy,
+  Suspense,
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+  type MouseEvent,
+} from "react";
 import { House, ListTree } from "lucide-react";
 import type { EditorView } from "@codemirror/view";
 import type { ConnectionStatus, NotebookOutlineItem } from "runtimed";
@@ -58,6 +67,7 @@ import {
   useCloudPrototypeAuth,
 } from "./use-cloud-auth";
 import { loadSupplementalViewerCss } from "./supplemental-css";
+import { navigateCloudViewer, shouldHandleCloudViewerLinkClick } from "./cloud-viewer-navigation";
 
 type MarkdownEditorModule = typeof import("@/components/editor/codemirror-editor");
 type MarkdownDocumentLiveSyncModule = typeof import("./markdown-document-live-sync");
@@ -580,6 +590,13 @@ export function MarkdownDocumentRoute({
     },
     [],
   );
+  const navigateToMarkdownDashboard = useCallback((event: MouseEvent<HTMLAnchorElement>) => {
+    if (!shouldHandleCloudViewerLinkClick(event)) {
+      return;
+    }
+    event.preventDefault();
+    navigateCloudViewer("/m");
+  }, []);
   const bodyReadyForEditorPreload = routeState.kind === "ready" && routeState.bodyReady;
 
   useEffect(() => {
@@ -714,6 +731,7 @@ export function MarkdownDocumentRoute({
           renameError={markdownTitleError}
           onRename={saveMarkdownDocumentTitle}
           homeHref="/m"
+          onHomeClick={navigateToMarkdownDashboard}
           homeAriaLabel="Open Markdown documents"
           homeTitle="Markdown documents"
           homeIcon={<House aria-hidden="true" />}

--- a/apps/notebook-cloud/viewer/markdown-sharing-controls.tsx
+++ b/apps/notebook-cloud/viewer/markdown-sharing-controls.tsx
@@ -1,17 +1,22 @@
 import { useCallback, useEffect, useMemo, useRef, useState, type FormEvent } from "react";
-import { Link2, Mail, Share2, Trash2, UserRound } from "lucide-react";
+import { Check, Globe2, Link2, Mail, Share2, Trash2, UserRound, X } from "lucide-react";
 import { fetchWithCloudPrototypeAuth, type CloudPrototypeAuthState } from "./collaborator-auth";
-import { cloudResponseError } from "./cloud-response";
+import { appendEndpointPathSegment, cloudResponseError } from "./cloud-response";
 import {
   buildCloudMarkdownShareProjection,
+  type CloudMarkdownAccessRequest,
   type CloudMarkdownDocumentAclRow,
-  type CloudMarkdownShareScope,
+  type CloudMarkdownDocumentInvite,
+  type CloudMarkdownShareAccessRow,
+  type CloudMarkdownShareInviteScope,
 } from "./markdown-sharing";
 import { normalizeShareInviteEmail } from "./sharing-client";
 
 interface MarkdownSharingControlsProps {
+  accessRequestsEndpoint: string;
   aclEndpoint: string;
   authState: CloudPrototypeAuthState;
+  invitesEndpoint: string;
   publicLink: string;
 }
 
@@ -19,21 +24,31 @@ type MarkdownSharingLoadState = "idle" | "loading" | "ready" | "error";
 type MarkdownSharingMessageKind = "info" | "error";
 
 export function MarkdownSharingControls({
+  accessRequestsEndpoint,
   aclEndpoint,
   authState,
+  invitesEndpoint,
   publicLink,
 }: MarkdownSharingControlsProps) {
   const [open, setOpen] = useState(false);
   const [acl, setAcl] = useState<CloudMarkdownDocumentAclRow[]>([]);
+  const [invites, setInvites] = useState<CloudMarkdownDocumentInvite[]>([]);
+  const [accessRequests, setAccessRequests] = useState<CloudMarkdownAccessRequest[]>([]);
   const [loadState, setLoadState] = useState<MarkdownSharingLoadState>("idle");
   const [message, setMessage] = useState<string | null>(null);
   const [messageKind, setMessageKind] = useState<MarkdownSharingMessageKind>("info");
   const [inviteEmail, setInviteEmail] = useState("");
-  const [scope, setScope] = useState<Exclude<CloudMarkdownShareScope, "owner">>("viewer");
+  const [scope, setScope] = useState<CloudMarkdownShareInviteScope>("viewer");
   const [formError, setFormError] = useState<string | null>(null);
   const [busyAction, setBusyAction] = useState<string | null>(null);
   const submitLockRef = useRef(false);
-  const accessProjection = useMemo(() => buildCloudMarkdownShareProjection({ acl }), [acl]);
+  const accessProjection = useMemo(
+    () => buildCloudMarkdownShareProjection({ acl, invites, accessRequests }),
+    [accessRequests, acl, invites],
+  );
+  const publicEnabled = acl.some(
+    (row) => row.subject_kind === "public" && row.subject === "anonymous" && row.scope === "viewer",
+  );
 
   const ownerAuth = useMemo(
     () =>
@@ -48,24 +63,64 @@ export function MarkdownSharingControls({
         setMessage(null);
       }
       try {
-        const response = await fetchWithCloudPrototypeAuth(
-          aclEndpoint,
-          { headers: { Accept: "application/json" }, signal: options?.signal },
-          ownerAuth,
-        );
+        const [aclResponse, invitesResponse, accessRequestsResponse] = await Promise.all([
+          fetchWithCloudPrototypeAuth(
+            aclEndpoint,
+            { headers: { Accept: "application/json" }, signal: options?.signal },
+            ownerAuth,
+          ),
+          fetchWithCloudPrototypeAuth(
+            invitesEndpoint,
+            { headers: { Accept: "application/json" }, signal: options?.signal },
+            ownerAuth,
+          ),
+          fetchWithCloudPrototypeAuth(
+            accessRequestsEndpoint,
+            { headers: { Accept: "application/json" }, signal: options?.signal },
+            ownerAuth,
+          ),
+        ]);
         if (options?.signal?.aborted) {
           return;
         }
-        if (!response.ok) {
+        if (!aclResponse.ok) {
           throw await cloudResponseError(
-            response,
-            response.status === 403
+            aclResponse,
+            aclResponse.status === 403
               ? "Only the document owner can manage sharing"
               : "Unable to load access",
           );
         }
-        const body = (await response.json()) as { acl?: CloudMarkdownDocumentAclRow[] };
-        setAcl(Array.isArray(body.acl) ? body.acl : []);
+        if (!invitesResponse.ok) {
+          throw await cloudResponseError(
+            invitesResponse,
+            invitesResponse.status === 403
+              ? "Only the document owner can manage invites"
+              : "Unable to load invites",
+          );
+        }
+        if (!accessRequestsResponse.ok) {
+          throw await cloudResponseError(
+            accessRequestsResponse,
+            accessRequestsResponse.status === 403
+              ? "Only the document owner can manage access requests"
+              : "Unable to load access requests",
+          );
+        }
+        const aclBody = (await aclResponse.json()) as { acl?: CloudMarkdownDocumentAclRow[] };
+        const invitesBody = (await invitesResponse.json()) as {
+          invites?: CloudMarkdownDocumentInvite[];
+        };
+        const accessRequestsBody = (await accessRequestsResponse.json()) as {
+          access_requests?: CloudMarkdownAccessRequest[];
+        };
+        setAcl(Array.isArray(aclBody.acl) ? aclBody.acl : []);
+        setInvites(Array.isArray(invitesBody.invites) ? invitesBody.invites : []);
+        setAccessRequests(
+          Array.isArray(accessRequestsBody.access_requests)
+            ? accessRequestsBody.access_requests
+            : [],
+        );
         setLoadState("ready");
       } catch (error) {
         if (options?.signal?.aborted) {
@@ -76,7 +131,7 @@ export function MarkdownSharingControls({
         setMessage(error instanceof Error ? error.message : String(error));
       }
     },
-    [aclEndpoint, ownerAuth],
+    [accessRequestsEndpoint, aclEndpoint, invitesEndpoint, ownerAuth],
   );
 
   useEffect(() => {
@@ -97,7 +152,7 @@ export function MarkdownSharingControls({
     }
   };
 
-  const submitAccess = async (event: FormEvent<HTMLFormElement>) => {
+  const submitInvite = async (event: FormEvent<HTMLFormElement>) => {
     event.preventDefault();
     if (submitLockRef.current) {
       return;
@@ -114,27 +169,23 @@ export function MarkdownSharingControls({
     setMessage(null);
     try {
       const response = await fetchWithCloudPrototypeAuth(
-        aclEndpoint,
+        invitesEndpoint,
         {
           method: "POST",
           headers: {
             Accept: "application/json",
             "Content-Type": "application/json",
           },
-          body: JSON.stringify({
-            subject_kind: "principal",
-            email,
-            scope,
-          }),
+          body: JSON.stringify({ email, scope }),
         },
         ownerAuth,
       );
       if (!response.ok) {
-        throw await cloudResponseError(response, "Unable to grant document access");
+        throw await cloudResponseError(response, "Unable to create invite");
       }
       setInviteEmail("");
       setMessageKind("info");
-      setMessage(`Access granted to ${email}.`);
+      setMessage(`Invite created for ${email}.`);
       await loadSharingState({ preserveMessage: true });
     } catch (error) {
       setFormError(error instanceof Error ? error.message : String(error));
@@ -144,31 +195,113 @@ export function MarkdownSharingControls({
     }
   };
 
-  const removeAccessRow = async (row: CloudMarkdownDocumentAclRow) => {
-    setBusyAction(`remove:${row.subject_kind}:${row.subject}:${row.scope}`);
+  const togglePublicAccess = async () => {
+    setBusyAction("public");
     setMessage(null);
     try {
       const response = await fetchWithCloudPrototypeAuth(
         aclEndpoint,
         {
-          method: "DELETE",
+          method: publicEnabled ? "DELETE" : "POST",
           headers: {
             Accept: "application/json",
             "Content-Type": "application/json",
           },
           body: JSON.stringify({
-            subject_kind: row.subject_kind,
-            subject: row.subject,
-            scope: row.scope,
+            subject_kind: "public",
+            subject: "anonymous",
+            scope: "viewer",
           }),
         },
         ownerAuth,
       );
       if (!response.ok) {
-        throw await cloudResponseError(response, "Unable to remove document access");
+        throw await cloudResponseError(
+          response,
+          publicEnabled ? "Unable to disable public link" : "Unable to enable public link",
+        );
       }
       setMessageKind("info");
-      setMessage("Access removed.");
+      setMessage(publicEnabled ? "Public link disabled." : "Public link enabled.");
+      await loadSharingState({ preserveMessage: true });
+    } catch (error) {
+      setMessageKind("error");
+      setMessage(error instanceof Error ? error.message : String(error));
+    } finally {
+      setBusyAction(null);
+    }
+  };
+
+  const removeAccessRow = async (row: CloudMarkdownShareAccessRow) => {
+    if (!row.removable) return;
+
+    setBusyAction(row.id);
+    setMessage(null);
+    try {
+      const response =
+        row.kind === "invite"
+          ? await fetchWithCloudPrototypeAuth(
+              appendEndpointPathSegment(invitesEndpoint, row.invite.id),
+              {
+                method: "DELETE",
+                headers: { Accept: "application/json" },
+              },
+              ownerAuth,
+            )
+          : await fetchWithCloudPrototypeAuth(
+              aclEndpoint,
+              {
+                method: "DELETE",
+                headers: {
+                  Accept: "application/json",
+                  "Content-Type": "application/json",
+                },
+                body: JSON.stringify({
+                  subject_kind: row.acl.subject_kind,
+                  subject: row.acl.subject,
+                  scope: row.acl.scope,
+                }),
+              },
+              ownerAuth,
+            );
+      if (!response.ok) {
+        throw await cloudResponseError(response, "Unable to remove access");
+      }
+      setMessageKind("info");
+      setMessage(`${row.label} removed.`);
+      await loadSharingState({ preserveMessage: true });
+    } catch (error) {
+      setMessageKind("error");
+      setMessage(error instanceof Error ? error.message : String(error));
+    } finally {
+      setBusyAction(null);
+    }
+  };
+
+  const resolveAccessRequest = async (
+    row: Extract<CloudMarkdownShareAccessRow, { kind: "access_request" }>,
+    action: "approve" | "deny" | "dismiss",
+  ) => {
+    setBusyAction(`${row.id}:${action}`);
+    setMessage(null);
+    try {
+      const response = await fetchWithCloudPrototypeAuth(
+        appendEndpointPathSegment(accessRequestsEndpoint, row.accessRequest.id),
+        {
+          method: "POST",
+          headers: {
+            Accept: "application/json",
+            "Content-Type": "application/json",
+          },
+          body: JSON.stringify({ action }),
+        },
+        ownerAuth,
+      );
+      if (!response.ok) {
+        throw await cloudResponseError(response, "Unable to update access request");
+      }
+      setMessageKind("info");
+      setMessage(accessRequestActionMessage(row.label, action));
       await loadSharingState({ preserveMessage: true });
     } catch (error) {
       setMessageKind("error");
@@ -201,7 +334,28 @@ export function MarkdownSharingControls({
           </button>
         </header>
 
-        <form className="cloud-share-invite" onSubmit={submitAccess}>
+        <section className="cloud-share-public" aria-label="Public link access">
+          <div>
+            <Globe2 aria-hidden="true" />
+            <div>
+              <strong>Anyone with the link</strong>
+              <span>
+                {publicEnabled
+                  ? "Can view this document without signing in"
+                  : "Link access is off. Only listed people can open this document"}
+              </span>
+            </div>
+          </div>
+          <button
+            type="button"
+            disabled={busyAction === "public" || loadState === "loading"}
+            onClick={() => void togglePublicAccess()}
+          >
+            {publicEnabled ? "Disable" : "Enable"}
+          </button>
+        </section>
+
+        <form className="cloud-share-invite" onSubmit={submitInvite}>
           <label htmlFor="cloud-markdown-share-email">
             <span>Share by email</span>
             <input
@@ -223,9 +377,7 @@ export function MarkdownSharingControls({
               id="cloud-markdown-share-scope"
               name="share-scope"
               value={scope}
-              onChange={(event) =>
-                setScope(event.target.value as Exclude<CloudMarkdownShareScope, "owner">)
-              }
+              onChange={(event) => setScope(event.target.value as CloudMarkdownShareInviteScope)}
             >
               <option value="viewer">Can view</option>
               <option value="editor">Can edit</option>
@@ -265,16 +417,40 @@ export function MarkdownSharingControls({
                   </div>
                   <div className="cloud-share-row-actions">
                     <span className="cloud-share-badge">{row.badge}</span>
+                    {row.stateLabel ? (
+                      <span className="cloud-share-state" data-tone="pending">
+                        {row.stateLabel}
+                      </span>
+                    ) : null}
+                    {row.kind === "access_request" ? (
+                      <>
+                        <button
+                          type="button"
+                          aria-label={`Approve ${row.label}`}
+                          title={`Approve ${row.label}`}
+                          disabled={busyAction === `${row.id}:approve`}
+                          onClick={() => void resolveAccessRequest(row, "approve")}
+                        >
+                          <Check aria-hidden="true" />
+                        </button>
+                        <button
+                          type="button"
+                          aria-label={`Deny ${row.label}`}
+                          title={`Deny ${row.label}`}
+                          disabled={busyAction === `${row.id}:deny`}
+                          onClick={() => void resolveAccessRequest(row, "deny")}
+                        >
+                          <X aria-hidden="true" />
+                        </button>
+                      </>
+                    ) : null}
                     {row.removable ? (
                       <button
                         type="button"
                         aria-label={`Remove ${row.label}`}
                         title={`Remove ${row.label}`}
-                        disabled={
-                          busyAction ===
-                          `remove:${row.acl.subject_kind}:${row.acl.subject}:${row.acl.scope}`
-                        }
-                        onClick={() => void removeAccessRow(row.acl)}
+                        disabled={busyAction === row.id}
+                        onClick={() => void removeAccessRow(row)}
                       >
                         <Trash2 aria-hidden="true" />
                       </button>
@@ -299,4 +475,15 @@ export function MarkdownSharingControls({
       </div>
     </details>
   );
+}
+
+function accessRequestActionMessage(label: string, action: "approve" | "deny" | "dismiss"): string {
+  switch (action) {
+    case "approve":
+      return `${label} can now edit.`;
+    case "deny":
+      return `${label}'s request was denied.`;
+    case "dismiss":
+      return `${label}'s request was dismissed.`;
+  }
 }

--- a/apps/notebook-cloud/viewer/markdown-sharing-controls.tsx
+++ b/apps/notebook-cloud/viewer/markdown-sharing-controls.tsx
@@ -1,0 +1,298 @@
+import { useCallback, useEffect, useMemo, useRef, useState, type FormEvent } from "react";
+import { Link2, Share2, Trash2, UserRound } from "lucide-react";
+import { fetchWithCloudPrototypeAuth, type CloudPrototypeAuthState } from "./collaborator-auth";
+import { cloudResponseError } from "./cloud-response";
+import {
+  buildCloudMarkdownShareProjection,
+  type CloudMarkdownDocumentAclRow,
+  type CloudMarkdownShareScope,
+} from "./markdown-sharing";
+
+interface MarkdownSharingControlsProps {
+  aclEndpoint: string;
+  authState: CloudPrototypeAuthState;
+  publicLink: string;
+}
+
+type MarkdownSharingLoadState = "idle" | "loading" | "ready" | "error";
+type MarkdownSharingMessageKind = "info" | "error";
+
+export function MarkdownSharingControls({
+  aclEndpoint,
+  authState,
+  publicLink,
+}: MarkdownSharingControlsProps) {
+  const [open, setOpen] = useState(false);
+  const [acl, setAcl] = useState<CloudMarkdownDocumentAclRow[]>([]);
+  const [loadState, setLoadState] = useState<MarkdownSharingLoadState>("idle");
+  const [message, setMessage] = useState<string | null>(null);
+  const [messageKind, setMessageKind] = useState<MarkdownSharingMessageKind>("info");
+  const [principal, setPrincipal] = useState("");
+  const [scope, setScope] = useState<Exclude<CloudMarkdownShareScope, "owner">>("viewer");
+  const [formError, setFormError] = useState<string | null>(null);
+  const [busyAction, setBusyAction] = useState<string | null>(null);
+  const submitLockRef = useRef(false);
+  const accessProjection = useMemo(() => buildCloudMarkdownShareProjection({ acl }), [acl]);
+
+  const ownerAuth = useMemo(
+    () =>
+      authState.mode === "dev" ? { ...authState, requestedScope: "owner" as const } : authState,
+    [authState],
+  );
+
+  const loadSharingState = useCallback(
+    async (options?: { preserveMessage?: boolean; signal?: AbortSignal }) => {
+      setLoadState("loading");
+      if (!options?.preserveMessage) {
+        setMessage(null);
+      }
+      try {
+        const response = await fetchWithCloudPrototypeAuth(
+          aclEndpoint,
+          { headers: { Accept: "application/json" }, signal: options?.signal },
+          ownerAuth,
+        );
+        if (options?.signal?.aborted) {
+          return;
+        }
+        if (!response.ok) {
+          throw await cloudResponseError(
+            response,
+            response.status === 403
+              ? "Only the document owner can manage sharing"
+              : "Unable to load access",
+          );
+        }
+        const body = (await response.json()) as { acl?: CloudMarkdownDocumentAclRow[] };
+        setAcl(Array.isArray(body.acl) ? body.acl : []);
+        setLoadState("ready");
+      } catch (error) {
+        if (options?.signal?.aborted) {
+          return;
+        }
+        setLoadState("error");
+        setMessageKind("error");
+        setMessage(error instanceof Error ? error.message : String(error));
+      }
+    },
+    [aclEndpoint, ownerAuth],
+  );
+
+  useEffect(() => {
+    if (!open) return;
+    const controller = new AbortController();
+    void loadSharingState({ signal: controller.signal });
+    return () => controller.abort();
+  }, [loadSharingState, open]);
+
+  const copyLink = async () => {
+    try {
+      await navigator.clipboard.writeText(publicLink);
+      setMessageKind("info");
+      setMessage("Link copied.");
+    } catch {
+      setMessageKind("error");
+      setMessage("Unable to copy the link.");
+    }
+  };
+
+  const submitAccess = async (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    if (submitLockRef.current) {
+      return;
+    }
+    const subject = principal.trim();
+    if (!subject) {
+      setFormError("Enter a principal.");
+      return;
+    }
+
+    submitLockRef.current = true;
+    setBusyAction("grant");
+    setFormError(null);
+    setMessage(null);
+    try {
+      const response = await fetchWithCloudPrototypeAuth(
+        aclEndpoint,
+        {
+          method: "POST",
+          headers: {
+            Accept: "application/json",
+            "Content-Type": "application/json",
+          },
+          body: JSON.stringify({
+            subject_kind: "principal",
+            subject,
+            scope,
+          }),
+        },
+        ownerAuth,
+      );
+      if (!response.ok) {
+        throw await cloudResponseError(response, "Unable to grant document access");
+      }
+      setPrincipal("");
+      setMessageKind("info");
+      setMessage(`Access granted to ${subject}.`);
+      await loadSharingState({ preserveMessage: true });
+    } catch (error) {
+      setFormError(error instanceof Error ? error.message : String(error));
+    } finally {
+      submitLockRef.current = false;
+      setBusyAction(null);
+    }
+  };
+
+  const removeAccessRow = async (row: CloudMarkdownDocumentAclRow) => {
+    setBusyAction(`remove:${row.subject_kind}:${row.subject}:${row.scope}`);
+    setMessage(null);
+    try {
+      const response = await fetchWithCloudPrototypeAuth(
+        aclEndpoint,
+        {
+          method: "DELETE",
+          headers: {
+            Accept: "application/json",
+            "Content-Type": "application/json",
+          },
+          body: JSON.stringify({
+            subject_kind: row.subject_kind,
+            subject: row.subject,
+            scope: row.scope,
+          }),
+        },
+        ownerAuth,
+      );
+      if (!response.ok) {
+        throw await cloudResponseError(response, "Unable to remove document access");
+      }
+      setMessageKind("info");
+      setMessage("Access removed.");
+      await loadSharingState({ preserveMessage: true });
+    } catch (error) {
+      setMessageKind("error");
+      setMessage(error instanceof Error ? error.message : String(error));
+    } finally {
+      setBusyAction(null);
+    }
+  };
+
+  return (
+    <details
+      className="cloud-share-menu cloud-markdown-share-menu"
+      open={open}
+      onToggle={(event) => setOpen(event.currentTarget.open)}
+    >
+      <summary title="Share Markdown document">
+        <Share2 aria-hidden="true" />
+        <span>Share</span>
+      </summary>
+      <div className="cloud-share-panel">
+        <header>
+          <div>
+            <h2>Share document</h2>
+            <p>Grant document access to another nteract principal.</p>
+          </div>
+          <button type="button" aria-label="Copy document link" onClick={() => void copyLink()}>
+            <Link2 aria-hidden="true" />
+            <span className="cloud-share-copy-label-full">Copy link</span>
+            <span className="cloud-share-copy-label-compact">Copy</span>
+          </button>
+        </header>
+
+        <form className="cloud-share-invite" onSubmit={submitAccess}>
+          <label htmlFor="cloud-markdown-share-principal">
+            <span>Principal</span>
+            <input
+              id="cloud-markdown-share-principal"
+              name="share-principal"
+              type="text"
+              value={principal}
+              placeholder="user:anaconda:..."
+              autoComplete="off"
+              onChange={(event) => {
+                setPrincipal(event.target.value);
+                setFormError(null);
+              }}
+            />
+          </label>
+          <label htmlFor="cloud-markdown-share-scope">
+            <span>Access</span>
+            <select
+              id="cloud-markdown-share-scope"
+              name="share-scope"
+              value={scope}
+              onChange={(event) =>
+                setScope(event.target.value as Exclude<CloudMarkdownShareScope, "owner">)
+              }
+            >
+              <option value="viewer">Can view</option>
+              <option value="editor">Can edit</option>
+            </select>
+          </label>
+          <button type="submit" disabled={!principal.trim() || busyAction === "grant"}>
+            <UserRound aria-hidden="true" />
+            Grant
+          </button>
+          {formError ? (
+            <div className="cloud-auth-form-error" role="alert">
+              {formError}
+            </div>
+          ) : null}
+        </form>
+
+        <section className="cloud-share-current" aria-label="Current document access">
+          <div className="cloud-share-current-heading">
+            <h3>Current access</h3>
+            {accessProjection.summary ? <span>{accessProjection.summary}</span> : null}
+          </div>
+          {loadState === "loading" && accessProjection.rows.length === 0 ? (
+            <div className="cloud-share-empty">Loading access...</div>
+          ) : accessProjection.rows.length === 0 ? (
+            <div className="cloud-share-empty">Only the owner can access this document.</div>
+          ) : (
+            <ul>
+              {accessProjection.rows.map((row) => (
+                <li key={row.id} title={row.title}>
+                  <UserRound aria-hidden="true" />
+                  <div>
+                    <strong>{row.label}</strong>
+                    <span>{row.detail}</span>
+                  </div>
+                  <div className="cloud-share-row-actions">
+                    <span className="cloud-share-badge">{row.badge}</span>
+                    {row.removable ? (
+                      <button
+                        type="button"
+                        aria-label={`Remove ${row.label}`}
+                        title={`Remove ${row.label}`}
+                        disabled={
+                          busyAction ===
+                          `remove:${row.acl.subject_kind}:${row.acl.subject}:${row.acl.scope}`
+                        }
+                        onClick={() => void removeAccessRow(row.acl)}
+                      >
+                        <Trash2 aria-hidden="true" />
+                      </button>
+                    ) : null}
+                  </div>
+                </li>
+              ))}
+            </ul>
+          )}
+        </section>
+
+        {message ? (
+          <div className="cloud-share-message" data-kind={messageKind}>
+            {message}
+          </div>
+        ) : null}
+        {loadState === "error" && !message ? (
+          <div className="cloud-share-message" data-kind="error">
+            Unable to load document sharing.
+          </div>
+        ) : null}
+      </div>
+    </details>
+  );
+}

--- a/apps/notebook-cloud/viewer/markdown-sharing-controls.tsx
+++ b/apps/notebook-cloud/viewer/markdown-sharing-controls.tsx
@@ -1,5 +1,5 @@
 import { useCallback, useEffect, useMemo, useRef, useState, type FormEvent } from "react";
-import { Link2, Share2, Trash2, UserRound } from "lucide-react";
+import { Link2, Mail, Share2, Trash2, UserRound } from "lucide-react";
 import { fetchWithCloudPrototypeAuth, type CloudPrototypeAuthState } from "./collaborator-auth";
 import { cloudResponseError } from "./cloud-response";
 import {
@@ -7,6 +7,7 @@ import {
   type CloudMarkdownDocumentAclRow,
   type CloudMarkdownShareScope,
 } from "./markdown-sharing";
+import { normalizeShareInviteEmail } from "./sharing-client";
 
 interface MarkdownSharingControlsProps {
   aclEndpoint: string;
@@ -27,7 +28,7 @@ export function MarkdownSharingControls({
   const [loadState, setLoadState] = useState<MarkdownSharingLoadState>("idle");
   const [message, setMessage] = useState<string | null>(null);
   const [messageKind, setMessageKind] = useState<MarkdownSharingMessageKind>("info");
-  const [principal, setPrincipal] = useState("");
+  const [inviteEmail, setInviteEmail] = useState("");
   const [scope, setScope] = useState<Exclude<CloudMarkdownShareScope, "owner">>("viewer");
   const [formError, setFormError] = useState<string | null>(null);
   const [busyAction, setBusyAction] = useState<string | null>(null);
@@ -101,9 +102,9 @@ export function MarkdownSharingControls({
     if (submitLockRef.current) {
       return;
     }
-    const subject = principal.trim();
-    if (!subject) {
-      setFormError("Enter a principal.");
+    const email = normalizeShareInviteEmail(inviteEmail);
+    if (!email) {
+      setFormError("Enter a valid email address.");
       return;
     }
 
@@ -122,7 +123,7 @@ export function MarkdownSharingControls({
           },
           body: JSON.stringify({
             subject_kind: "principal",
-            subject,
+            email,
             scope,
           }),
         },
@@ -131,9 +132,9 @@ export function MarkdownSharingControls({
       if (!response.ok) {
         throw await cloudResponseError(response, "Unable to grant document access");
       }
-      setPrincipal("");
+      setInviteEmail("");
       setMessageKind("info");
-      setMessage(`Access granted to ${subject}.`);
+      setMessage(`Access granted to ${email}.`);
       await loadSharingState({ preserveMessage: true });
     } catch (error) {
       setFormError(error instanceof Error ? error.message : String(error));
@@ -191,7 +192,7 @@ export function MarkdownSharingControls({
         <header>
           <div>
             <h2>Share document</h2>
-            <p>Grant document access to another nteract principal.</p>
+            <p>Invite people and manage document access.</p>
           </div>
           <button type="button" aria-label="Copy document link" onClick={() => void copyLink()}>
             <Link2 aria-hidden="true" />
@@ -201,17 +202,17 @@ export function MarkdownSharingControls({
         </header>
 
         <form className="cloud-share-invite" onSubmit={submitAccess}>
-          <label htmlFor="cloud-markdown-share-principal">
-            <span>Principal</span>
+          <label htmlFor="cloud-markdown-share-email">
+            <span>Share by email</span>
             <input
-              id="cloud-markdown-share-principal"
-              name="share-principal"
-              type="text"
-              value={principal}
-              placeholder="user:anaconda:..."
-              autoComplete="off"
+              id="cloud-markdown-share-email"
+              name="share-email"
+              type="email"
+              value={inviteEmail}
+              placeholder="name@example.com"
+              autoComplete="email"
               onChange={(event) => {
-                setPrincipal(event.target.value);
+                setInviteEmail(event.target.value);
                 setFormError(null);
               }}
             />
@@ -230,9 +231,12 @@ export function MarkdownSharingControls({
               <option value="editor">Can edit</option>
             </select>
           </label>
-          <button type="submit" disabled={!principal.trim() || busyAction === "grant"}>
-            <UserRound aria-hidden="true" />
-            Grant
+          <button
+            type="submit"
+            disabled={normalizeShareInviteEmail(inviteEmail) === null || busyAction === "grant"}
+          >
+            <Mail aria-hidden="true" />
+            Share
           </button>
           {formError ? (
             <div className="cloud-auth-form-error" role="alert">

--- a/apps/notebook-cloud/viewer/markdown-sharing.ts
+++ b/apps/notebook-cloud/viewer/markdown-sharing.ts
@@ -1,6 +1,9 @@
 import type { CloudShareDisplay } from "./sharing-client";
 
 export type CloudMarkdownShareScope = "viewer" | "editor" | "owner";
+export type CloudMarkdownInviteStatus = "pending" | "accepted" | "revoked" | "expired";
+export type CloudMarkdownAccessRequestStatus = "pending" | "approved" | "denied" | "dismissed";
+export type CloudMarkdownShareInviteScope = "viewer" | "editor";
 
 export interface CloudMarkdownDocumentAclRow {
   document_id: string;
@@ -13,15 +16,71 @@ export interface CloudMarkdownDocumentAclRow {
   display?: CloudShareDisplay;
 }
 
-export interface CloudMarkdownShareAccessRow {
+export interface CloudMarkdownDocumentInvite {
   id: string;
-  acl: CloudMarkdownDocumentAclRow;
-  label: string;
-  detail: string;
-  title: string;
-  badge: string;
-  removable: boolean;
+  document_id: string;
+  email: string;
+  provider_hint: string | null;
+  scope: CloudMarkdownShareInviteScope;
+  status: CloudMarkdownInviteStatus;
+  invited_by_actor_label: string;
+  accepted_by_principal: string | null;
+  created_at: string;
+  expires_at: string | null;
+  accepted_at: string | null;
+  revoked_at: string | null;
+  revoked_by_actor_label: string | null;
+  display?: CloudShareDisplay;
 }
+
+export interface CloudMarkdownAccessRequest {
+  id: string;
+  document_id: string;
+  requester_principal: string;
+  scope: "editor";
+  status: CloudMarkdownAccessRequestStatus;
+  requested_by_actor_label: string;
+  resolved_by_actor_label: string | null;
+  created_at: string;
+  updated_at: string;
+  resolved_at: string | null;
+  display?: Extract<CloudShareDisplay, { kind: "principal" }>;
+}
+
+export type CloudMarkdownShareAccessRow =
+  | {
+      id: string;
+      kind: "acl";
+      acl: CloudMarkdownDocumentAclRow;
+      label: string;
+      detail: string;
+      title: string;
+      badge: string;
+      stateLabel: string | null;
+      removable: boolean;
+    }
+  | {
+      id: string;
+      kind: "invite";
+      invite: CloudMarkdownDocumentInvite;
+      label: string;
+      detail: string;
+      title: string;
+      badge: string;
+      stateLabel: string | null;
+      removable: boolean;
+    }
+  | {
+      id: string;
+      kind: "access_request";
+      accessRequest: CloudMarkdownAccessRequest;
+      label: string;
+      detail: string;
+      title: string;
+      badge: string;
+      stateLabel: string | null;
+      removable: false;
+    };
 
 export interface CloudMarkdownShareProjection {
   rows: CloudMarkdownShareAccessRow[];
@@ -30,8 +89,18 @@ export interface CloudMarkdownShareProjection {
 
 export function buildCloudMarkdownShareProjection(input: {
   acl: CloudMarkdownDocumentAclRow[];
+  invites?: CloudMarkdownDocumentInvite[];
+  accessRequests?: CloudMarkdownAccessRequest[];
 }): CloudMarkdownShareProjection {
-  const rows = [...input.acl].sort(compareMarkdownAclRows).map(markdownAclRowToAccessRow);
+  const rows = [
+    ...[...input.acl].sort(compareMarkdownAclRows).map(markdownAclRowToAccessRow),
+    ...(input.invites ?? [])
+      .filter((invite) => invite.status === "pending")
+      .map(markdownInviteToAccessRow),
+    ...(input.accessRequests ?? [])
+      .filter((request) => request.status === "pending")
+      .map(markdownAccessRequestToAccessRow),
+  ];
   return {
     rows,
     summary: markdownShareSummary(rows),
@@ -43,12 +112,56 @@ function markdownAclRowToAccessRow(row: CloudMarkdownDocumentAclRow): CloudMarkd
   const detail = detailForMarkdownAcl(row);
   return {
     id: `acl:${row.subject_kind}:${row.subject}:${row.scope}`,
+    kind: "acl",
     acl: row,
     label,
     detail,
     title: `${label}: ${detail}`,
     badge: scopeLabel(row.scope),
+    stateLabel: row.subject_kind === "public" ? "Enabled" : null,
     removable: row.subject_kind === "public" || row.scope !== "owner",
+  };
+}
+
+function markdownInviteToAccessRow(
+  invite: CloudMarkdownDocumentInvite,
+): CloudMarkdownShareAccessRow {
+  const label = displayEmail(invite.display?.label || invite.email);
+  const detail = invite.provider_hint
+    ? `Pending invite via ${invite.provider_hint}`
+    : "Pending invite";
+  return {
+    id: `invite:${invite.id}`,
+    kind: "invite",
+    invite,
+    label,
+    detail,
+    title: invite.email,
+    badge: scopeLabel(invite.scope),
+    stateLabel: "Pending",
+    removable: true,
+  };
+}
+
+function markdownAccessRequestToAccessRow(
+  accessRequest: CloudMarkdownAccessRequest,
+): CloudMarkdownShareAccessRow {
+  const displayLabel = accessRequest.display?.label?.trim();
+  const label =
+    displayLabel && displayLabel !== accessRequest.requester_principal
+      ? displayEmail(displayLabel)
+      : displayEmail(labelForPrincipalSubject(accessRequest.requester_principal));
+  const title = accessRequest.display?.email || accessRequest.requester_principal;
+  return {
+    id: `access-request:${accessRequest.id}`,
+    kind: "access_request",
+    accessRequest,
+    label,
+    detail: "Requested edit access",
+    title,
+    badge: scopeLabel(accessRequest.scope),
+    stateLabel: "Requested",
+    removable: false,
   };
 }
 
@@ -56,14 +169,26 @@ function markdownShareSummary(rows: CloudMarkdownShareAccessRow[]): string | nul
   if (rows.length === 0) {
     return null;
   }
-  const principalCount = rows.filter((row) => row.acl.subject_kind === "principal").length;
-  const publicCount = rows.length - principalCount;
+  const principalCount = rows.filter(
+    (row) => row.kind === "acl" && row.acl.subject_kind === "principal",
+  ).length;
+  const publicCount = rows.filter(
+    (row) => row.kind === "acl" && row.acl.subject_kind === "public",
+  ).length;
+  const inviteCount = rows.filter((row) => row.kind === "invite").length;
+  const requestCount = rows.filter((row) => row.kind === "access_request").length;
   const parts: string[] = [];
   if (principalCount > 0) {
     parts.push(`${principalCount} ${principalCount === 1 ? "person" : "people"}`);
   }
   if (publicCount > 0) {
     parts.push("public link");
+  }
+  if (inviteCount > 0) {
+    parts.push(`${inviteCount} ${inviteCount === 1 ? "invite" : "invites"}`);
+  }
+  if (requestCount > 0) {
+    parts.push(`${requestCount} ${requestCount === 1 ? "request" : "requests"}`);
   }
   return parts.join(", ");
 }
@@ -93,6 +218,29 @@ function scopeLabel(scope: CloudMarkdownShareScope): string {
       return "Can edit";
     case "viewer":
       return "Can view";
+  }
+}
+
+function displayEmail(value: string): string {
+  const trimmed = value.trim();
+  const parts = trimmed.split("@");
+  if (parts.length !== 2 || !parts[0] || !parts[1] || parts[1].includes(" ")) {
+    return trimmed;
+  }
+
+  const local = parts[0];
+  const first = local.at(0) ?? "";
+  const last = local.length > 2 ? (local.at(-1) ?? "") : "";
+  return `${first}...${last}@${parts[1]}`;
+}
+
+function labelForPrincipalSubject(subject: string): string {
+  const tail = subject.split(":").at(-1)?.trim();
+  if (!tail) return subject;
+  try {
+    return decodeURIComponent(tail) || tail;
+  } catch {
+    return tail;
   }
 }
 

--- a/apps/notebook-cloud/viewer/markdown-sharing.ts
+++ b/apps/notebook-cloud/viewer/markdown-sharing.ts
@@ -1,0 +1,114 @@
+import type { CloudShareDisplay } from "./sharing-client";
+
+export type CloudMarkdownShareScope = "viewer" | "editor" | "owner";
+
+export interface CloudMarkdownDocumentAclRow {
+  document_id: string;
+  subject_kind: "principal" | "public";
+  subject: string;
+  scope: CloudMarkdownShareScope;
+  created_at: string;
+  updated_at: string;
+  created_by_actor_label: string;
+  display?: CloudShareDisplay;
+}
+
+export interface CloudMarkdownShareAccessRow {
+  id: string;
+  acl: CloudMarkdownDocumentAclRow;
+  label: string;
+  detail: string;
+  title: string;
+  badge: string;
+  removable: boolean;
+}
+
+export interface CloudMarkdownShareProjection {
+  rows: CloudMarkdownShareAccessRow[];
+  summary: string | null;
+}
+
+export function buildCloudMarkdownShareProjection(input: {
+  acl: CloudMarkdownDocumentAclRow[];
+}): CloudMarkdownShareProjection {
+  const rows = [...input.acl].sort(compareMarkdownAclRows).map(markdownAclRowToAccessRow);
+  return {
+    rows,
+    summary: markdownShareSummary(rows),
+  };
+}
+
+function markdownAclRowToAccessRow(row: CloudMarkdownDocumentAclRow): CloudMarkdownShareAccessRow {
+  const label = labelForMarkdownAcl(row);
+  const detail = detailForMarkdownAcl(row);
+  return {
+    id: `acl:${row.subject_kind}:${row.subject}:${row.scope}`,
+    acl: row,
+    label,
+    detail,
+    title: `${label}: ${detail}`,
+    badge: scopeLabel(row.scope),
+    removable: row.subject_kind === "public" || row.scope !== "owner",
+  };
+}
+
+function markdownShareSummary(rows: CloudMarkdownShareAccessRow[]): string | null {
+  if (rows.length === 0) {
+    return null;
+  }
+  const principalCount = rows.filter((row) => row.acl.subject_kind === "principal").length;
+  const publicCount = rows.length - principalCount;
+  const parts: string[] = [];
+  if (principalCount > 0) {
+    parts.push(`${principalCount} ${principalCount === 1 ? "person" : "people"}`);
+  }
+  if (publicCount > 0) {
+    parts.push("public link");
+  }
+  return parts.join(", ");
+}
+
+function labelForMarkdownAcl(row: CloudMarkdownDocumentAclRow): string {
+  if (row.subject_kind === "public") {
+    return "Public link";
+  }
+  return row.display?.label || row.subject;
+}
+
+function detailForMarkdownAcl(row: CloudMarkdownDocumentAclRow): string {
+  if (row.subject_kind === "public") {
+    return "Anyone with the link can view";
+  }
+  if (row.display?.kind === "principal" && row.display.email) {
+    return row.display.email;
+  }
+  return row.subject;
+}
+
+function scopeLabel(scope: CloudMarkdownShareScope): string {
+  switch (scope) {
+    case "owner":
+      return "Owner";
+    case "editor":
+      return "Can edit";
+    case "viewer":
+      return "Can view";
+  }
+}
+
+function compareMarkdownAclRows(
+  left: CloudMarkdownDocumentAclRow,
+  right: CloudMarkdownDocumentAclRow,
+): number {
+  const rank = (row: CloudMarkdownDocumentAclRow): number => {
+    if (row.scope === "owner") return 0;
+    if (row.scope === "editor") return 1;
+    if (row.subject_kind === "public") return 3;
+    return 2;
+  };
+  return (
+    rank(left) - rank(right) ||
+    labelForMarkdownAcl(left).localeCompare(labelForMarkdownAcl(right)) ||
+    left.scope.localeCompare(right.scope)
+  );
+}

--- a/apps/notebook-cloud/viewer/notebook-list-cache.ts
+++ b/apps/notebook-cloud/viewer/notebook-list-cache.ts
@@ -7,6 +7,7 @@ import {
   type HostedDocumentListCacheStorage,
 } from "./hosted-document-list-cache";
 import type { CloudPrototypeAuthState } from "./collaborator-auth";
+import type { CloudAppSession } from "./app-session";
 import { isCloudNotebookListItem, type CloudNotebookListItem } from "./notebook-dashboard";
 
 export const CLOUD_NOTEBOOK_LIST_CACHE_STORAGE_KEY =
@@ -18,18 +19,33 @@ export type CloudNotebookListCacheStorage = HostedDocumentListCacheStorage;
 export function readCachedCloudNotebookList(
   storage: Pick<CloudNotebookListCacheStorage, "getItem">,
   authState: CloudPrototypeAuthState,
+  appSession?: CloudAppSession | null,
   now = Date.now(),
 ): CloudNotebookListItem[] | null {
-  return readCachedHostedDocumentList(storage, authState, cloudNotebookListCacheConfig(), now);
+  return readCachedHostedDocumentList(
+    storage,
+    authState,
+    appSession,
+    cloudNotebookListCacheConfig(),
+    now,
+  );
 }
 
 export function writeCachedCloudNotebookList(
   storage: Pick<CloudNotebookListCacheStorage, "setItem">,
   authState: CloudPrototypeAuthState,
+  appSession: CloudAppSession | null | undefined,
   notebooks: CloudNotebookListItem[],
   now = Date.now(),
 ): void {
-  writeCachedHostedDocumentList(storage, authState, notebooks, cloudNotebookListCacheConfig(), now);
+  writeCachedHostedDocumentList(
+    storage,
+    authState,
+    appSession,
+    notebooks,
+    cloudNotebookListCacheConfig(),
+    now,
+  );
 }
 
 export function clearCachedCloudNotebookList(
@@ -38,8 +54,11 @@ export function clearCachedCloudNotebookList(
   clearCachedHostedDocumentList(storage, CLOUD_NOTEBOOK_LIST_CACHE_STORAGE_KEY);
 }
 
-export function cloudNotebookListCacheAuthKey(authState: CloudPrototypeAuthState): string | null {
-  return cloudHostedDocumentListCacheAuthKey(authState);
+export function cloudNotebookListCacheAuthKey(
+  authState: CloudPrototypeAuthState,
+  appSession?: CloudAppSession | null,
+): string | null {
+  return cloudHostedDocumentListCacheAuthKey(authState, appSession);
 }
 
 function cloudNotebookListCacheConfig() {

--- a/apps/notebook-cloud/viewer/notebook-list-cache.ts
+++ b/apps/notebook-cloud/viewer/notebook-list-cache.ts
@@ -1,55 +1,26 @@
+import {
+  CLOUD_HOSTED_DOCUMENT_LIST_CACHE_TTL_MS,
+  clearCachedHostedDocumentList,
+  cloudHostedDocumentListCacheAuthKey,
+  readCachedHostedDocumentList,
+  writeCachedHostedDocumentList,
+  type HostedDocumentListCacheStorage,
+} from "./hosted-document-list-cache";
 import type { CloudPrototypeAuthState } from "./collaborator-auth";
 import { isCloudNotebookListItem, type CloudNotebookListItem } from "./notebook-dashboard";
 
 export const CLOUD_NOTEBOOK_LIST_CACHE_STORAGE_KEY =
   "nteract:notebook-cloud:notebook-list-cache:v1";
-export const CLOUD_NOTEBOOK_LIST_CACHE_TTL_MS = 10 * 60 * 1000;
+export const CLOUD_NOTEBOOK_LIST_CACHE_TTL_MS = CLOUD_HOSTED_DOCUMENT_LIST_CACHE_TTL_MS;
 
-export interface CloudNotebookListCacheStorage {
-  getItem(key: string): string | null;
-  removeItem(key: string): void;
-  setItem(key: string, value: string): void;
-}
-
-interface CachedCloudNotebookList {
-  authKey: string;
-  notebooks: CloudNotebookListItem[];
-  savedAt: number;
-}
+export type CloudNotebookListCacheStorage = HostedDocumentListCacheStorage;
 
 export function readCachedCloudNotebookList(
   storage: Pick<CloudNotebookListCacheStorage, "getItem">,
   authState: CloudPrototypeAuthState,
   now = Date.now(),
 ): CloudNotebookListItem[] | null {
-  const authKey = cloudNotebookListCacheAuthKey(authState);
-  if (!authKey) {
-    return null;
-  }
-
-  const raw = storage.getItem(CLOUD_NOTEBOOK_LIST_CACHE_STORAGE_KEY);
-  if (!raw) {
-    return null;
-  }
-
-  let parsed: Partial<CachedCloudNotebookList>;
-  try {
-    parsed = JSON.parse(raw) as Partial<CachedCloudNotebookList>;
-  } catch {
-    return null;
-  }
-
-  if (
-    parsed.authKey !== authKey ||
-    !Number.isFinite(parsed.savedAt) ||
-    now - Number(parsed.savedAt) > CLOUD_NOTEBOOK_LIST_CACHE_TTL_MS ||
-    !Array.isArray(parsed.notebooks) ||
-    !parsed.notebooks.every(isCloudNotebookListItem)
-  ) {
-    return null;
-  }
-
-  return parsed.notebooks;
+  return readCachedHostedDocumentList(storage, authState, cloudNotebookListCacheConfig(), now);
 }
 
 export function writeCachedCloudNotebookList(
@@ -58,33 +29,23 @@ export function writeCachedCloudNotebookList(
   notebooks: CloudNotebookListItem[],
   now = Date.now(),
 ): void {
-  const authKey = cloudNotebookListCacheAuthKey(authState);
-  if (!authKey) {
-    return;
-  }
-
-  storage.setItem(
-    CLOUD_NOTEBOOK_LIST_CACHE_STORAGE_KEY,
-    JSON.stringify({
-      authKey,
-      notebooks,
-      savedAt: now,
-    } satisfies CachedCloudNotebookList),
-  );
+  writeCachedHostedDocumentList(storage, authState, notebooks, cloudNotebookListCacheConfig(), now);
 }
 
 export function clearCachedCloudNotebookList(
   storage: Pick<CloudNotebookListCacheStorage, "removeItem">,
 ): void {
-  storage.removeItem(CLOUD_NOTEBOOK_LIST_CACHE_STORAGE_KEY);
+  clearCachedHostedDocumentList(storage, CLOUD_NOTEBOOK_LIST_CACHE_STORAGE_KEY);
 }
 
 export function cloudNotebookListCacheAuthKey(authState: CloudPrototypeAuthState): string | null {
-  if (authState.mode === "oidc" && authState.oidcClaims?.sub) {
-    return `oidc:${authState.oidcClaims.sub}`;
-  }
-  if (authState.mode === "dev" && authState.user) {
-    return `dev:${authState.user}`;
-  }
-  return null;
+  return cloudHostedDocumentListCacheAuthKey(authState);
+}
+
+function cloudNotebookListCacheConfig() {
+  return {
+    isItem: isCloudNotebookListItem,
+    itemsKey: "notebooks",
+    storageKey: CLOUD_NOTEBOOK_LIST_CACHE_STORAGE_KEY,
+  };
 }

--- a/apps/notebook-cloud/viewer/notebook-list-view.tsx
+++ b/apps/notebook-cloud/viewer/notebook-list-view.tsx
@@ -34,6 +34,7 @@ import {
   projectCloudNotebookDashboard,
   type CloudNotebookListItem,
 } from "./notebook-dashboard";
+import { projectHostedDocumentAuthState } from "./hosted-document-auth";
 import {
   clearCachedCloudNotebookList,
   readCachedCloudNotebookList,
@@ -76,11 +77,16 @@ export function CloudNotebookListView({ authConfig }: { authConfig: CloudViewerA
   const [renameState, setRenameState] = useState<CloudNotebookRenameState | null>(null);
   const [renameSavingId, setRenameSavingId] = useState<string | null>(null);
   const [renameError, setRenameError] = useState<string | null>(null);
-  const hasExplicitAuth = authState.mode === "dev" || authState.mode === "oidc";
-  const hasAppSession = Boolean(appSessionStatus.session);
-  const signedIn = hasExplicitAuth || hasAppSession;
-  const canFetchNotebookList = authState.mode === "dev" || hasAppSession;
-  const waitingForAppSession = authState.mode === "oidc" && !hasAppSession;
+  const hostedAuth = projectHostedDocumentAuthState(authState, {
+    appSession: appSessionStatus.session,
+    appSessionLoading: appSessionStatus.status === "loading",
+  });
+  const {
+    canFetchCatalog: canFetchNotebookList,
+    hasAppSession,
+    signedIn,
+    waitingForAppSession,
+  } = hostedAuth;
   const dashboardModel = useMemo(
     () => (listState.kind === "ready" ? projectCloudNotebookDashboard(listState.notebooks) : null),
     [listState],

--- a/apps/notebook-cloud/viewer/notebook-list-view.tsx
+++ b/apps/notebook-cloud/viewer/notebook-list-view.tsx
@@ -1,14 +1,12 @@
 import { useCallback, useEffect, useMemo, useState, type FormEvent } from "react";
 import {
   AlertCircle,
-  ArrowUpRight,
   BookOpen,
   FileText,
   FilePlus2,
   Loader2,
   LogOut,
   RotateCcw,
-  Sparkles,
 } from "lucide-react";
 import { useTheme } from "@/hooks/useTheme";
 import {
@@ -46,8 +44,8 @@ import {
   useCloudAppSessionStatus,
   useCloudPrototypeAuth,
 } from "./use-cloud-auth";
-import { CloudNotebookSignInButton } from "./cloud-auth-controls";
 import { preloadNotebookRoute, scheduleNotebookRoutePreload } from "./notebook-route-preload";
+import { CloudHostedDocumentSignedOutPanel } from "./cloud-hosted-document-signed-out";
 
 export function CloudNotebookListView({ authConfig }: { authConfig: CloudViewerAuthConfig }) {
   const { resolvedTheme } = useTheme(CLOUD_VIEWER_THEME_STORAGE_KEY);
@@ -402,7 +400,14 @@ export function CloudNotebookListView({ authConfig }: { authConfig: CloudViewerA
             <span>Loading notebooks</span>
           </div>
         ) : listState.kind === "signed_out" ? (
-          <CloudNotebookSignedOutPanel authConfig={authConfig} authState={authState} />
+          <CloudHostedDocumentSignedOutPanel
+            authConfig={authConfig}
+            authState={authState}
+            cloudTitle="Bring computation to life."
+            cloudDescription="Sign in to create live notebooks, share work with colleagues, and attach compute."
+            localTitle="Open local notebooks."
+            localDescription="Use local auth to create notebooks and test the live room on this machine."
+          />
         ) : listState.kind === "error" ? (
           <div className="cloud-notebook-list-state" data-kind="error" role="alert">
             <AlertCircle aria-hidden="true" />
@@ -435,41 +440,6 @@ export function CloudNotebookListView({ authConfig }: { authConfig: CloudViewerA
         )}
       </section>
     </main>
-  );
-}
-
-function CloudNotebookSignedOutPanel({
-  authConfig,
-  authState,
-}: {
-  authConfig: CloudViewerAuthConfig;
-  authState: CloudPrototypeAuthState;
-}) {
-  const localMode = Boolean(authConfig.localDev);
-  return (
-    <div className="cloud-notebook-signed-out" aria-labelledby="cloud-notebook-signed-out-title">
-      <div className="cloud-notebook-signed-out-copy">
-        <div className="cloud-notebook-signed-out-kicker">
-          <Sparkles aria-hidden="true" />
-          {localMode ? "LOCAL MODE" : "NTERACT"}
-        </div>
-        <h2 id="cloud-notebook-signed-out-title">
-          {localMode ? "Open local notebooks." : "Bring computation to life."}
-        </h2>
-        <p>
-          {localMode
-            ? "Use local auth to create notebooks and test the live room on this machine."
-            : "Sign in to create live notebooks, share work with colleagues, and attach compute."}
-        </p>
-      </div>
-      <div className="cloud-notebook-signed-out-actions">
-        <CloudNotebookSignInButton authConfig={authConfig} authState={authState} />
-        <a href="https://nteract.io/" target="_blank" rel="noreferrer">
-          Visit nteract.io
-          <ArrowUpRight aria-hidden="true" />
-        </a>
-      </div>
-    </div>
   );
 }
 

--- a/apps/notebook-cloud/viewer/notebook-list-view.tsx
+++ b/apps/notebook-cloud/viewer/notebook-list-view.tsx
@@ -15,7 +15,11 @@ import {
   type CloudPrototypeAuthState,
 } from "./collaborator-auth";
 import { cloudResponseError } from "./cloud-response";
-import { clearCloudAppSession, establishCloudAppSession } from "./app-session";
+import {
+  clearCloudAppSession,
+  establishCloudAppSession,
+  type CloudAppSession,
+} from "./app-session";
 import { CloudNotebookDashboard } from "./cloud-notebook-dashboard-view";
 import { loadCloudNotebookListBootstrap } from "./cloud-viewer-config";
 import type {
@@ -65,7 +69,7 @@ export function CloudNotebookListView({ authConfig }: { authConfig: CloudViewerA
     appSessionStatus.refreshAppSessionStatus,
   );
   const [listState, setListState] = useState<CloudNotebookListState>(() =>
-    initialCloudNotebookListState(authState, bootstrap),
+    initialCloudNotebookListState(authState, bootstrap, appSessionStatus.session),
   );
   const [refreshIndex, setRefreshIndex] = useState(0);
   const [createState, setCreateState] = useState<"idle" | "starting">("idle");
@@ -95,13 +99,21 @@ export function CloudNotebookListView({ authConfig }: { authConfig: CloudViewerA
   }, [resolvedTheme]);
 
   useEffect(() => {
+    document.title = "nteract cloud notebooks";
+  }, []);
+
+  useEffect(() => {
     if (listState.kind === "ready" && listState.notebooks.length > 0) {
       scheduleNotebookRoutePreload();
     }
   }, [listState]);
 
   useEffect(() => {
-    const seededNotebooks = cloudNotebookListSeedFromBootstrapOrCache(authState, bootstrap);
+    const seededNotebooks = cloudNotebookListSeedFromBootstrapOrCache(
+      authState,
+      bootstrap,
+      appSessionStatus.session,
+    );
     if (!canFetchNotebookList) {
       if (waitingForAppSession) {
         setListState(
@@ -115,7 +127,11 @@ export function CloudNotebookListView({ authConfig }: { authConfig: CloudViewerA
     }
 
     if (refreshIndex === 0 && bootstrap) {
-      writeCachedCloudNotebookListToWindow(authState, bootstrap.notebooks);
+      writeCachedCloudNotebookListToWindow(
+        authState,
+        appSessionStatus.session,
+        bootstrap.notebooks,
+      );
       setListState({ kind: "ready", notebooks: bootstrap.notebooks });
       return;
     }
@@ -135,7 +151,7 @@ export function CloudNotebookListView({ authConfig }: { authConfig: CloudViewerA
         if (!isCloudNotebookListResponse(body)) {
           throw new Error("Unable to list notebooks: response shape was invalid");
         }
-        writeCachedCloudNotebookListToWindow(authState, body.notebooks);
+        writeCachedCloudNotebookListToWindow(authState, appSessionStatus.session, body.notebooks);
         setListState({ kind: "ready", notebooks: body.notebooks });
       } catch (error) {
         if (controller.signal.aborted) return;
@@ -149,7 +165,14 @@ export function CloudNotebookListView({ authConfig }: { authConfig: CloudViewerA
     return () => {
       controller.abort();
     };
-  }, [authState, bootstrap, canFetchNotebookList, refreshIndex, waitingForAppSession]);
+  }, [
+    appSessionStatus.session,
+    authState,
+    bootstrap,
+    canFetchNotebookList,
+    refreshIndex,
+    waitingForAppSession,
+  ]);
 
   const refreshList = () => {
     if (authState.mode === "oidc" && authState.token) {
@@ -282,7 +305,7 @@ export function CloudNotebookListView({ authConfig }: { authConfig: CloudViewerA
               }
             : notebook,
         );
-        writeCachedCloudNotebookListToWindow(authState, notebooks);
+        writeCachedCloudNotebookListToWindow(authState, appSessionStatus.session, notebooks);
         return {
           kind: "ready",
           notebooks,
@@ -497,8 +520,13 @@ function cloudAuthWithScope(
 function initialCloudNotebookListState(
   authState: CloudPrototypeAuthState,
   bootstrap: CloudNotebookListBootstrap | null,
+  appSession: CloudAppSession | null,
 ): CloudNotebookListState {
-  const seededNotebooks = cloudNotebookListSeedFromBootstrapOrCache(authState, bootstrap);
+  const seededNotebooks = cloudNotebookListSeedFromBootstrapOrCache(
+    authState,
+    bootstrap,
+    appSession,
+  );
   return seededNotebooks ? { kind: "ready", notebooks: seededNotebooks } : { kind: "loading" };
 }
 
@@ -523,26 +551,29 @@ function fetchCloudNotebookList(
 function cloudNotebookListSeedFromBootstrapOrCache(
   authState: CloudPrototypeAuthState,
   bootstrap: CloudNotebookListBootstrap | null,
+  appSession: CloudAppSession | null,
 ): CloudNotebookListItem[] | null {
-  return bootstrap?.notebooks ?? readCachedCloudNotebookListFromWindow(authState);
+  return bootstrap?.notebooks ?? readCachedCloudNotebookListFromWindow(authState, appSession);
 }
 
 function readCachedCloudNotebookListFromWindow(
   authState: CloudPrototypeAuthState,
+  appSession: CloudAppSession | null,
 ): CloudNotebookListItem[] | null {
   const storage = cloudNotebookListCacheStorage();
-  return storage ? readCachedCloudNotebookList(storage, authState) : null;
+  return storage ? readCachedCloudNotebookList(storage, authState, appSession) : null;
 }
 
 function writeCachedCloudNotebookListToWindow(
   authState: CloudPrototypeAuthState,
+  appSession: CloudAppSession | null,
   notebooks: CloudNotebookListItem[],
 ): void {
   const storage = cloudNotebookListCacheStorage();
   if (!storage) {
     return;
   }
-  writeCachedCloudNotebookList(storage, authState, notebooks);
+  writeCachedCloudNotebookList(storage, authState, appSession, notebooks);
 }
 
 function clearCachedCloudNotebookListFromWindow(): void {

--- a/apps/notebook-cloud/viewer/notebook-list-view.tsx
+++ b/apps/notebook-cloud/viewer/notebook-list-view.tsx
@@ -3,6 +3,7 @@ import {
   AlertCircle,
   ArrowUpRight,
   BookOpen,
+  FileText,
   FilePlus2,
   Loader2,
   LogOut,
@@ -317,6 +318,10 @@ export function CloudNotebookListView({ authConfig }: { authConfig: CloudViewerA
           <p>{headerDetail}</p>
         </div>
         <div className="cloud-notebook-list-actions">
+          <a href="/m">
+            <FileText aria-hidden="true" />
+            Markdown docs
+          </a>
           {signedIn ? (
             <>
               <button type="button" disabled={listState.kind === "loading"} onClick={refreshList}>

--- a/apps/notebook-cloud/viewer/runtimed-wasm-client.ts
+++ b/apps/notebook-cloud/viewer/runtimed-wasm-client.ts
@@ -3,7 +3,10 @@ import {
   type NotebookInteractionTarget,
 } from "runtimed";
 import { setMarkdownProjectionProjector } from "../../../src/lib/markdown-projection";
-import type { NotebookHandle } from "../../notebook/src/wasm/runtimed-wasm/runtimed_wasm.js";
+import type {
+  MarkdownHandle,
+  NotebookHandle,
+} from "../../notebook/src/wasm/runtimed-wasm/runtimed_wasm.js";
 import {
   asRuntimedWasmAssetFailure,
   RUNTIMED_WASM_ASSET_FAILURE_PREFIX,
@@ -125,6 +128,27 @@ export async function createBootstrapNotebookHandle(
   return module.NotebookHandle.create_bootstrap(actorLabel);
 }
 
+export async function createMarkdownHandle(
+  documentId: string,
+  title: string,
+  actorLabel: string,
+  modulePath: string | URL,
+  moduleOrPath: WasmModuleOrPath,
+): Promise<MarkdownHandle> {
+  const module = await initializeRuntimedWasmClient(modulePath, moduleOrPath);
+  return module.MarkdownHandle.create(documentId, title, actorLabel);
+}
+
+export async function loadMarkdownHandleFromBytes(
+  bytes: Uint8Array,
+  actorLabel: string,
+  modulePath: string | URL,
+  moduleOrPath: WasmModuleOrPath,
+): Promise<MarkdownHandle> {
+  const module = await initializeRuntimedWasmClient(modulePath, moduleOrPath);
+  return module.MarkdownHandle.load_with_actor(bytes, actorLabel);
+}
+
 export async function loadNotebookHandleFromBytes(
   notebookBytes: Uint8Array,
   actorLabel: string,
@@ -242,7 +266,7 @@ export function encodeInteractionPresenceAfterInit(
   );
 }
 
-export type { NotebookHandle };
+export type { MarkdownHandle, NotebookHandle };
 
 function loadRuntimedWasmModule(modulePath: string | URL): Promise<RuntimedWasmModule> {
   const href = normalizedWasmSource(typeof modulePath === "string" ? modulePath : modulePath.href);

--- a/apps/notebook-cloud/viewer/runtimed-wasm-client.ts
+++ b/apps/notebook-cloud/viewer/runtimed-wasm-client.ts
@@ -139,6 +139,15 @@ export async function createMarkdownHandle(
   return module.MarkdownHandle.create(documentId, title, actorLabel);
 }
 
+export async function createBootstrapMarkdownHandle(
+  actorLabel: string,
+  modulePath: string | URL,
+  moduleOrPath: WasmModuleOrPath,
+): Promise<MarkdownHandle> {
+  const module = await initializeRuntimedWasmClient(modulePath, moduleOrPath);
+  return module.MarkdownHandle.create_bootstrap(actorLabel);
+}
+
 export async function loadMarkdownHandleFromBytes(
   bytes: Uint8Array,
   actorLabel: string,

--- a/apps/notebook-cloud/viewer/use-cloud-auth.ts
+++ b/apps/notebook-cloud/viewer/use-cloud-auth.ts
@@ -34,7 +34,7 @@ export function cloudAppSessionsEqual(
 ): boolean {
   if (a === b) return true;
   if (!a || !b) return false;
-  return a.provider === b.provider && a.expires_at === b.expires_at;
+  return a.provider === b.provider && a.expires_at === b.expires_at && a.cache_key === b.cache_key;
 }
 
 /**

--- a/apps/notebook-cloud/wrangler.toml
+++ b/apps/notebook-cloud/wrangler.toml
@@ -14,6 +14,10 @@ name = "NOTEBOOK_ROOMS"
 class_name = "NotebookRoom"
 
 [[durable_objects.bindings]]
+name = "MARKDOWN_DOCUMENT_ROOMS"
+class_name = "MarkdownDocumentRoom"
+
+[[durable_objects.bindings]]
 name = "WORKSTATION_EVENTS"
 class_name = "WorkstationEvents"
 
@@ -24,6 +28,10 @@ new_sqlite_classes = ["NotebookRoom"]
 [[migrations]]
 tag = "v2"
 new_sqlite_classes = ["WorkstationEvents"]
+
+[[migrations]]
+tag = "v3"
+new_sqlite_classes = ["MarkdownDocumentRoom"]
 
 [[d1_databases]]
 binding = "DB"

--- a/crates/markdown-doc/Cargo.toml
+++ b/crates/markdown-doc/Cargo.toml
@@ -9,6 +9,7 @@ license.workspace = true
 [dependencies]
 automerge = { workspace = true }
 automerge-recovery = { path = "../automerge-recovery" }
+hex = "0.4"
 serde = { version = "1", features = ["derive"] }
 thiserror = { workspace = true }
 

--- a/crates/markdown-doc/Cargo.toml
+++ b/crates/markdown-doc/Cargo.toml
@@ -1,0 +1,16 @@
+[package]
+name = "markdown-doc"
+version = "0.1.0"
+edition.workspace = true
+description = "Shared Automerge Markdown document model for desktop and hosted nteract Markdown surfaces"
+repository.workspace = true
+license.workspace = true
+
+[dependencies]
+automerge = { workspace = true }
+automerge-recovery = { path = "../automerge-recovery" }
+serde = { version = "1", features = ["derive"] }
+thiserror = { workspace = true }
+
+[lints]
+workspace = true

--- a/crates/markdown-doc/src/lib.rs
+++ b/crates/markdown-doc/src/lib.rs
@@ -98,6 +98,10 @@ impl MarkdownDoc {
         &mut self.doc
     }
 
+    pub fn from_doc(doc: AutoCommit) -> Self {
+        Self { doc }
+    }
+
     pub fn save(&mut self) -> Vec<u8> {
         self.doc.save()
     }
@@ -120,6 +124,17 @@ impl MarkdownDoc {
 
     pub fn set_actor(&mut self, actor_label: &str) {
         self.doc.set_actor(ActorId::from(actor_label.as_bytes()));
+    }
+
+    pub fn get_heads(&mut self) -> Vec<automerge::ChangeHash> {
+        self.doc.get_heads()
+    }
+
+    pub fn get_heads_hex(&mut self) -> Vec<String> {
+        self.get_heads()
+            .into_iter()
+            .map(|head| hex::encode(head.as_ref()))
+            .collect()
     }
 
     pub fn actor_label(&self) -> String {

--- a/crates/markdown-doc/src/lib.rs
+++ b/crates/markdown-doc/src/lib.rs
@@ -1,0 +1,431 @@
+//! First-class Automerge-backed Markdown document.
+//!
+//! Cloud can wrap this document in hosted rooms and ACLs; Desktop can wrap it
+//! in `.md` file load/save and file watching. The body is an Automerge Text
+//! object edited through positional splices, not a replace-whole-body string
+//! column.
+
+#![cfg_attr(test, allow(clippy::unwrap_used, clippy::expect_used))]
+
+use automerge::sync;
+use automerge::sync::SyncDoc;
+use automerge::transaction::Transactable;
+use automerge::{ActorId, AutoCommit, AutomergeError, LoadOptions, ObjId, ObjType, ReadDoc};
+use automerge_recovery::{
+    is_recoverable_sync_error, recoverable_automerge_operation, AutomergeOperationError,
+    AutomergeRebuildError,
+};
+use serde::{Deserialize, Serialize};
+use thiserror::Error;
+
+pub use automerge::TextEncoding;
+
+pub const SCHEMA_VERSION: u64 = 1;
+
+#[derive(Debug, Error)]
+pub enum MarkdownDocError {
+    #[error("automerge operation failed: {0}")]
+    Automerge(#[from] AutomergeError),
+    #[error("body splice delete_count is too large: {0}")]
+    DeleteCountTooLarge(usize),
+    #[error("markdown document rebuild failed: {0}")]
+    Rebuild(#[from] AutomergeRebuildError),
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct MarkdownDocumentSnapshot {
+    pub document_id: Option<String>,
+    pub title: Option<String>,
+    pub body: Option<String>,
+    pub comments_doc_id: Option<String>,
+}
+
+/// Host-neutral Markdown document wrapper.
+pub struct MarkdownDoc {
+    doc: AutoCommit,
+}
+
+impl MarkdownDoc {
+    /// Create a fully seeded Markdown document.
+    ///
+    /// Call this from exactly one authority for a given document id. Other
+    /// peers should call [`bootstrap_with_actor`](Self::bootstrap_with_actor),
+    /// sync this seeded body object in, then write body splices.
+    pub fn try_new_with_actor(
+        document_id: &str,
+        title: &str,
+        actor_label: &str,
+    ) -> Result<Self, MarkdownDocError> {
+        let mut doc = empty_doc(actor_label);
+        doc.put(automerge::ROOT, "schema_version", SCHEMA_VERSION)?;
+        doc.put(automerge::ROOT, "document_id", document_id)?;
+        doc.put(automerge::ROOT, "title", title)?;
+        doc.put_object(automerge::ROOT, "body", ObjType::Text)?;
+        doc.put_object(automerge::ROOT, "metadata", ObjType::Map)?;
+        doc.put_object(automerge::ROOT, "artifact_refs", ObjType::Map)?;
+        Ok(Self { doc })
+    }
+
+    /// Create an empty peer handle with only the actor set.
+    ///
+    /// A bootstrap peer cannot write body splices until it receives the seeded
+    /// body object over Automerge sync.
+    pub fn bootstrap_with_actor(actor_label: &str) -> Self {
+        Self {
+            doc: empty_doc(actor_label),
+        }
+    }
+
+    pub fn load(data: &[u8]) -> Result<Self, AutomergeError> {
+        let doc = AutoCommit::load_with_options(
+            data,
+            LoadOptions::new().text_encoding(TextEncoding::Utf16CodeUnit),
+        )?;
+        Ok(Self { doc })
+    }
+
+    pub fn load_with_actor(data: &[u8], actor_label: &str) -> Result<Self, AutomergeError> {
+        let mut doc = Self::load(data)?;
+        doc.set_actor(actor_label);
+        Ok(doc)
+    }
+
+    pub fn doc(&self) -> &AutoCommit {
+        &self.doc
+    }
+
+    pub fn doc_mut(&mut self) -> &mut AutoCommit {
+        &mut self.doc
+    }
+
+    pub fn save(&mut self) -> Vec<u8> {
+        self.doc.save()
+    }
+
+    pub fn rebuild_from_save(&mut self) -> Result<(), AutomergeRebuildError> {
+        let actor = self.doc.get_actor().clone();
+        let bytes = self.doc.save();
+        match AutoCommit::load_with_options(
+            &bytes,
+            LoadOptions::new().text_encoding(TextEncoding::Utf16CodeUnit),
+        ) {
+            Ok(mut doc) => {
+                doc.set_actor(actor);
+                self.doc = doc;
+                Ok(())
+            }
+            Err(source) => Err(AutomergeRebuildError::load(source)),
+        }
+    }
+
+    pub fn set_actor(&mut self, actor_label: &str) {
+        self.doc.set_actor(ActorId::from(actor_label.as_bytes()));
+    }
+
+    pub fn actor_label(&self) -> String {
+        actor_label_from_id(self.doc.get_actor())
+    }
+
+    pub fn document_id(&self) -> Option<String> {
+        read_str(&self.doc, automerge::ROOT, "document_id")
+    }
+
+    pub fn title(&self) -> Option<String> {
+        read_str(&self.doc, automerge::ROOT, "title")
+    }
+
+    pub fn set_title(&mut self, title: &str) -> Result<(), MarkdownDocError> {
+        self.doc.put(automerge::ROOT, "title", title)?;
+        Ok(())
+    }
+
+    pub fn comments_doc_id(&self) -> Option<String> {
+        read_str(&self.doc, automerge::ROOT, "comments_doc_id")
+    }
+
+    pub fn set_comments_doc_id(
+        &mut self,
+        comments_doc_id: Option<&str>,
+    ) -> Result<(), MarkdownDocError> {
+        match comments_doc_id {
+            Some(value) => self.doc.put(automerge::ROOT, "comments_doc_id", value)?,
+            None => {
+                if self.doc.get(automerge::ROOT, "comments_doc_id")?.is_some() {
+                    self.doc.delete(automerge::ROOT, "comments_doc_id")?;
+                }
+            }
+        }
+        Ok(())
+    }
+
+    pub fn body(&self) -> Option<String> {
+        let body_id = self.body_text_id()?;
+        self.doc.text(&body_id).ok()
+    }
+
+    /// Read a UTF-16 slice of the current body. Positions are the same units
+    /// CodeMirror uses in the browser.
+    pub fn slice_body(&self, start: usize, end: usize) -> Option<String> {
+        let body = self.body()?;
+        let units: Vec<u16> = body.encode_utf16().collect();
+        let clamped_start = start.min(units.len());
+        let clamped_end = end.min(units.len()).max(clamped_start);
+        Some(String::from_utf16_lossy(&units[clamped_start..clamped_end]))
+    }
+
+    pub fn body_len(&self) -> Option<usize> {
+        let body_id = self.body_text_id()?;
+        Some(self.doc.length(&body_id))
+    }
+
+    /// Splice the Automerge Text body. Returns `Ok(false)` when this peer has
+    /// not yet synced the seeded body object.
+    pub fn splice_body(
+        &mut self,
+        index: usize,
+        delete_count: usize,
+        text: &str,
+    ) -> Result<bool, MarkdownDocError> {
+        let Some(body_id) = self.body_text_id() else {
+            return Ok(false);
+        };
+        let delete_count: isize = delete_count
+            .try_into()
+            .map_err(|_| MarkdownDocError::DeleteCountTooLarge(delete_count))?;
+        self.doc.splice_text(&body_id, index, delete_count, text)?;
+        Ok(true)
+    }
+
+    /// Import/bootstrap helper. Live editor paths should use
+    /// [`splice_body`](Self::splice_body), not whole-body replacement.
+    pub fn replace_body_for_import(&mut self, body: &str) -> Result<bool, MarkdownDocError> {
+        let Some(body_id) = self.body_text_id() else {
+            return Ok(false);
+        };
+        self.doc.update_text(&body_id, body)?;
+        Ok(true)
+    }
+
+    pub fn snapshot(&self) -> MarkdownDocumentSnapshot {
+        MarkdownDocumentSnapshot {
+            document_id: self.document_id(),
+            title: self.title(),
+            body: self.body(),
+            comments_doc_id: self.comments_doc_id(),
+        }
+    }
+
+    pub fn generate_sync_message(&mut self, peer_state: &mut sync::State) -> Option<sync::Message> {
+        self.doc.sync().generate_sync_message(peer_state)
+    }
+
+    pub fn receive_sync_message(
+        &mut self,
+        peer_state: &mut sync::State,
+        message: sync::Message,
+    ) -> Result<(), AutomergeError> {
+        self.doc.sync().receive_sync_message(peer_state, message)
+    }
+
+    pub fn generate_sync_message_recovering(
+        &mut self,
+        peer_state: &mut sync::State,
+        label: &str,
+    ) -> Result<Option<sync::Message>, AutomergeOperationError> {
+        let mut context = SyncRecoveryContext {
+            doc: self,
+            peer_state,
+        };
+        recoverable_automerge_operation(
+            label,
+            &mut context,
+            |context| Ok(context.doc.generate_sync_message(context.peer_state)),
+            |_| false,
+            |context| {
+                *context.peer_state = sync::State::new();
+                context.doc.rebuild_from_save()
+            },
+        )
+    }
+
+    pub fn receive_sync_message_recovering(
+        &mut self,
+        peer_state: &mut sync::State,
+        message: sync::Message,
+        label: &str,
+    ) -> Result<(), AutomergeOperationError> {
+        let mut context = SyncReceiveRecoveryContext {
+            doc: self,
+            peer_state,
+            next_message: Some(message.clone()),
+            retry_message: message,
+        };
+        recoverable_automerge_operation(
+            label,
+            &mut context,
+            |context| {
+                let message = context
+                    .next_message
+                    .take()
+                    .unwrap_or_else(|| context.retry_message.clone());
+                context
+                    .doc
+                    .receive_sync_message(context.peer_state, message)
+            },
+            is_recoverable_sync_error,
+            |context| {
+                *context.peer_state = sync::State::new();
+                context.doc.rebuild_from_save()
+            },
+        )
+    }
+
+    fn body_text_id(&self) -> Option<ObjId> {
+        match self.doc.get(automerge::ROOT, "body").ok().flatten()? {
+            (automerge::Value::Object(ObjType::Text), id) => Some(id),
+            _ => None,
+        }
+    }
+}
+
+struct SyncRecoveryContext<'a> {
+    doc: &'a mut MarkdownDoc,
+    peer_state: &'a mut sync::State,
+}
+
+struct SyncReceiveRecoveryContext<'a> {
+    doc: &'a mut MarkdownDoc,
+    peer_state: &'a mut sync::State,
+    next_message: Option<sync::Message>,
+    retry_message: sync::Message,
+}
+
+fn empty_doc(actor_label: &str) -> AutoCommit {
+    let mut doc = AutoCommit::new_with_encoding(TextEncoding::Utf16CodeUnit);
+    doc.set_actor(ActorId::from(actor_label.as_bytes()));
+    doc
+}
+
+fn read_str<O: AsRef<automerge::ObjId>, P: Into<automerge::Prop>>(
+    doc: &AutoCommit,
+    obj: O,
+    prop: P,
+) -> Option<String> {
+    doc.get(obj, prop)
+        .ok()
+        .flatten()
+        .and_then(|(value, _)| match value {
+            automerge::Value::Scalar(s) => match s.as_ref() {
+                automerge::ScalarValue::Str(s) => Some(s.to_string()),
+                _ => None,
+            },
+            _ => None,
+        })
+}
+
+pub fn actor_label_from_id(actor: &ActorId) -> String {
+    std::str::from_utf8(actor.to_bytes())
+        .map(|s| s.to_string())
+        .unwrap_or_else(|_| actor.to_hex_string())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn sync_pair(a: &mut MarkdownDoc, b: &mut MarkdownDoc) {
+        let mut a_state = sync::State::new();
+        let mut b_state = sync::State::new();
+        for _ in 0..100 {
+            let mut progressed = false;
+            if let Some(message) = a.generate_sync_message(&mut a_state) {
+                b.receive_sync_message(&mut b_state, message).unwrap();
+                progressed = true;
+            }
+            if let Some(message) = b.generate_sync_message(&mut b_state) {
+                a.receive_sync_message(&mut a_state, message).unwrap();
+                progressed = true;
+            }
+            if !progressed {
+                return;
+            }
+        }
+        panic!("sync did not quiesce");
+    }
+
+    #[test]
+    fn seeded_markdown_doc_has_spliceable_body() {
+        let mut doc =
+            MarkdownDoc::try_new_with_actor("m-1", "Plan", "user:dev:kyle/browser:a").unwrap();
+        assert_eq!(doc.document_id().as_deref(), Some("m-1"));
+        assert_eq!(doc.title().as_deref(), Some("Plan"));
+        assert_eq!(doc.body().as_deref(), Some(""));
+
+        assert!(doc.splice_body(0, 0, "# Plan\n").unwrap());
+        assert!(doc.splice_body(7, 0, "\nBody").unwrap());
+        assert_eq!(doc.body().as_deref(), Some("# Plan\n\nBody"));
+        assert_eq!(doc.slice_body(0, 6).as_deref(), Some("# Plan"));
+    }
+
+    #[test]
+    fn bootstrap_peer_waits_for_seeded_body_before_writing() {
+        let mut owner =
+            MarkdownDoc::try_new_with_actor("m-1", "Plan", "user:dev:kyle/browser:a").unwrap();
+        owner.splice_body(0, 0, "hello").unwrap();
+
+        let mut peer = MarkdownDoc::bootstrap_with_actor("user:dev:kyle/codex:b");
+        assert_eq!(peer.body(), None);
+        assert!(!peer.splice_body(0, 0, "nope").unwrap());
+
+        sync_pair(&mut owner, &mut peer);
+        assert_eq!(peer.body().as_deref(), Some("hello"));
+        assert!(peer.splice_body(5, 0, " world").unwrap());
+        sync_pair(&mut owner, &mut peer);
+        assert_eq!(owner.body().as_deref(), Some("hello world"));
+    }
+
+    #[test]
+    fn concurrent_body_splices_converge() {
+        let mut left =
+            MarkdownDoc::try_new_with_actor("m-1", "Plan", "user:dev:kyle/browser:a").unwrap();
+        left.splice_body(0, 0, "hello").unwrap();
+        let mut right = MarkdownDoc::bootstrap_with_actor("user:dev:kyle/codex:b");
+        sync_pair(&mut left, &mut right);
+
+        left.splice_body(5, 0, " from browser").unwrap();
+        right.splice_body(5, 0, " from agent").unwrap();
+        sync_pair(&mut left, &mut right);
+
+        let left_body = left.body().unwrap();
+        let right_body = right.body().unwrap();
+        assert_eq!(left_body, right_body);
+        assert!(left_body.contains("hello"));
+        assert!(left_body.contains("from browser"));
+        assert!(left_body.contains("from agent"));
+    }
+
+    #[test]
+    fn save_load_preserves_body_and_actor_can_change() {
+        let mut doc =
+            MarkdownDoc::try_new_with_actor("m-1", "Plan", "user:dev:kyle/browser:a").unwrap();
+        doc.splice_body(0, 0, "line 1\nline 2").unwrap();
+        let bytes = doc.save();
+
+        let loaded = MarkdownDoc::load_with_actor(&bytes, "user:dev:kyle/codex:b").unwrap();
+        assert_eq!(loaded.body().as_deref(), Some("line 1\nline 2"));
+        assert_eq!(loaded.actor_label(), "user:dev:kyle/codex:b");
+    }
+
+    #[test]
+    fn utf16_slice_and_splice_match_browser_positions() {
+        let mut doc =
+            MarkdownDoc::try_new_with_actor("m-1", "Plan", "user:dev:kyle/browser:a").unwrap();
+        doc.splice_body(0, 0, "a😀c").unwrap();
+        assert_eq!(doc.body_len(), Some(4));
+        assert_eq!(doc.slice_body(0, 1).as_deref(), Some("a"));
+        assert_eq!(doc.slice_body(3, 4).as_deref(), Some("c"));
+
+        doc.splice_body(3, 0, "b").unwrap();
+        assert_eq!(doc.body().as_deref(), Some("a😀bc"));
+    }
+}

--- a/crates/notebook-cloud-transport/src/lib.rs
+++ b/crates/notebook-cloud-transport/src/lib.rs
@@ -302,6 +302,37 @@ fn cloud_frame_rejection_error(payload: &[u8]) -> Option<std::io::Error> {
     ))
 }
 
+fn is_recoverable_cloud_frame_rejection_error(error: &std::io::Error) -> bool {
+    if error.kind() != std::io::ErrorKind::PermissionDenied {
+        return false;
+    }
+
+    let message = error.to_string();
+    if !message.starts_with("cloud room rejected frame:") {
+        return false;
+    }
+    let sync_frame = [
+        "frame_type=0 ",
+        "frame_type=5 ",
+        "frame_type=9 ",
+        "frame_type=automerge_sync ",
+        "frame_type=runtime_state_sync ",
+        "frame_type=comms_doc_sync ",
+        "frame_type=AUTOMERGE_SYNC ",
+        "frame_type=RUNTIME_STATE_SYNC ",
+        "frame_type=COMMS_DOC_SYNC ",
+    ]
+    .iter()
+    .any(|needle| message.contains(needle));
+    if !sync_frame {
+        return false;
+    }
+
+    message.contains("recursive use of an object detected which would lead to unsafe aliasing")
+        || message.contains("PatchLogMismatch")
+        || message.contains("patch logs cannot be shared between documents")
+}
+
 fn terminal_cloud_close_error(code: Option<u16>, reason: &str) -> Option<std::io::Error> {
     let reason = reason.trim();
     let terminal_by_reason = matches!(
@@ -742,6 +773,9 @@ impl FrameTransport for CloudWsFrameTransport {
     }
 
     fn stream_error_is_recoverable(&self, error: &std::io::Error) -> bool {
+        if is_recoverable_cloud_frame_rejection_error(error) {
+            return true;
+        }
         error.kind() != std::io::ErrorKind::PermissionDenied
     }
 
@@ -877,7 +911,7 @@ mod tests {
     }
 
     #[test]
-    fn cloud_frame_rejection_error_is_non_recoverable_shape() {
+    fn cloud_frame_rejection_error_surfaces_rejection_reason() {
         let payload = serde_json::to_vec(&serde_json::json!({
             "type": "cloud_frame_rejected",
             "frame_type": 5,
@@ -895,6 +929,39 @@ mod tests {
         }))
         .unwrap();
         assert!(cloud_frame_rejection_error(&accepted).is_none());
+    }
+
+    #[test]
+    fn sync_frame_rejection_from_automerge_boundary_is_recoverable() {
+        let transport = CloudWsFrameTransport::new(test_config());
+        let payload = serde_json::to_vec(&serde_json::json!({
+            "type": "cloud_frame_rejected",
+            "frame_type": 5,
+            "reason": "room host rejected runtime_state_sync frame: Error: recursive use of an object detected which would lead to unsafe aliasing in rust",
+        }))
+        .unwrap();
+        let error = cloud_frame_rejection_error(&payload).expect("rejection becomes an error");
+        assert_eq!(error.kind(), std::io::ErrorKind::PermissionDenied);
+        assert!(
+            transport.stream_error_is_recoverable(&error),
+            "sync divergence rejections should reconnect instead of killing the runtime peer",
+        );
+    }
+
+    #[test]
+    fn authz_frame_rejection_remains_terminal() {
+        let transport = CloudWsFrameTransport::new(test_config());
+        let payload = serde_json::to_vec(&serde_json::json!({
+            "type": "cloud_frame_rejected",
+            "frame_type": 5,
+            "reason": "actor label must be '<principal>/<operator>'",
+        }))
+        .unwrap();
+        let error = cloud_frame_rejection_error(&payload).expect("rejection becomes an error");
+        assert!(
+            !transport.stream_error_is_recoverable(&error),
+            "permission and authority rejects should still stop the runtime peer",
+        );
     }
 
     #[test]

--- a/crates/runtimed-wasm/Cargo.toml
+++ b/crates/runtimed-wasm/Cargo.toml
@@ -11,6 +11,7 @@ crate-type = ["cdylib", "rlib"]
 
 [dependencies]
 automerge = { workspace = true }
+markdown-doc = { path = "../markdown-doc" }
 notebook-doc = { path = "../notebook-doc" }
 notebook-wire = { path = "../notebook-wire" }
 nteract-identity = { path = "../nteract-identity", default-features = false }

--- a/crates/runtimed-wasm/src/lib.rs
+++ b/crates/runtimed-wasm/src/lib.rs
@@ -401,6 +401,14 @@ impl MarkdownRoomHostHandle {
         })
     }
 
+    pub fn title(&self) -> Option<String> {
+        self.doc.title()
+    }
+
+    pub fn body(&self) -> Option<String> {
+        self.doc.body()
+    }
+
     pub fn remove_peer(&mut self, peer_id: &str) {
         self.peer_states.remove(peer_id);
     }

--- a/crates/runtimed-wasm/src/lib.rs
+++ b/crates/runtimed-wasm/src/lib.rs
@@ -2213,6 +2213,10 @@ impl MarkdownHandle {
         self.doc.save()
     }
 
+    pub fn get_heads_hex(&mut self) -> Vec<String> {
+        self.doc.get_heads_hex()
+    }
+
     pub fn flush_local_changes(&mut self) -> Option<Vec<u8>> {
         self.doc
             .generate_sync_message(&mut self.sync_state)

--- a/crates/runtimed-wasm/src/lib.rs
+++ b/crates/runtimed-wasm/src/lib.rs
@@ -367,6 +367,198 @@ impl RoomHostFrameResult {
     }
 }
 
+/// Durable-Object room host for a first-class MarkdownDoc sync stream.
+///
+/// This intentionally mirrors the Notebook room host's per-peer sync-state
+/// shape without pulling in RuntimeStateDoc, CommsDoc, requests, or presence.
+/// A hosted Markdown room is a single Automerge text document with ACL-backed
+/// read/write authority.
+#[wasm_bindgen]
+pub struct MarkdownRoomHostHandle {
+    doc: MarkdownDoc,
+    peer_states: HashMap<String, sync::State>,
+}
+
+#[wasm_bindgen]
+impl MarkdownRoomHostHandle {
+    pub fn create_empty(
+        document_id: &str,
+        title: &str,
+        actor_label: &str,
+    ) -> Result<MarkdownRoomHostHandle, JsError> {
+        Ok(MarkdownRoomHostHandle {
+            doc: MarkdownDoc::try_new_with_actor(document_id, title, actor_label)
+                .map_err(|e| JsError::new(&format!("create markdown room failed: {e}")))?,
+            peer_states: HashMap::new(),
+        })
+    }
+
+    pub fn load_snapshot(bytes: &[u8]) -> Result<MarkdownRoomHostHandle, JsError> {
+        Ok(MarkdownRoomHostHandle {
+            doc: MarkdownDoc::load(bytes)
+                .map_err(|e| JsError::new(&format!("load markdown room failed: {e}")))?,
+            peer_states: HashMap::new(),
+        })
+    }
+
+    pub fn remove_peer(&mut self, peer_id: &str) {
+        self.peer_states.remove(peer_id);
+    }
+
+    pub fn sync_peer(&mut self, peer_id: &str, connection_scope: &str) -> Result<JsValue, JsError> {
+        let connection_scope = parse_connection_scope(connection_scope)?;
+        let mut result = RoomHostFrameResult::empty();
+        self.queue_markdown_sync_for_peer(
+            peer_id,
+            markdown_scope_allows_write(connection_scope),
+            &mut result.outbound,
+        )?;
+        serialize_to_js(&result)
+            .map_err(|e| JsError::new(&format!("serialize markdown room result: {e}")))
+    }
+
+    pub fn receive_peer_frame(
+        &mut self,
+        peer_id: &str,
+        principal: &str,
+        connection_scope: &str,
+        frame_bytes: &[u8],
+    ) -> Result<JsValue, JsError> {
+        if frame_bytes.is_empty() {
+            return Err(JsError::new("typed frame cannot be empty"));
+        }
+
+        let connection_scope = parse_connection_scope(connection_scope)?;
+        let frame_type = frame_bytes[0];
+        let payload = &frame_bytes[1..];
+        let result = match frame_type {
+            frame_types::AUTOMERGE_SYNC => self.receive_markdown_sync(
+                peer_id,
+                principal,
+                markdown_scope_allows_write(connection_scope),
+                payload,
+            )?,
+            _ => RoomHostFrameResult::empty(),
+        };
+
+        serialize_to_js(&result)
+            .map_err(|e| JsError::new(&format!("serialize markdown room result: {e}")))
+    }
+
+    pub fn save_doc(&mut self) -> Vec<u8> {
+        self.doc.save()
+    }
+
+    pub fn get_heads_hex(&mut self) -> Vec<String> {
+        self.doc.get_heads_hex()
+    }
+}
+
+impl MarkdownRoomHostHandle {
+    fn receive_markdown_sync(
+        &mut self,
+        peer_id: &str,
+        principal: &str,
+        can_write: bool,
+        payload: &[u8],
+    ) -> Result<RoomHostFrameResult, JsError> {
+        let message = sync::Message::decode(payload)
+            .map_err(|e| JsError::new(&format!("decode markdown sync: {e}")))?;
+        let has_changes = !message.changes.is_empty();
+        if has_changes && !can_write {
+            return Err(JsError::new(
+                "connection scope cannot write MarkdownDoc changes",
+            ));
+        }
+        if has_changes {
+            let heads_before = self.doc.get_heads();
+            let peer_state = self
+                .peer_states
+                .entry(peer_id.to_string())
+                .or_insert_with(|| room_peer_sync_state(can_write));
+            let mut preview = MarkdownDoc::from_doc(self.doc.doc().clone());
+            let mut preview_peer_state = peer_state.clone();
+            preview
+                .receive_sync_message_recovering(
+                    &mut preview_peer_state,
+                    message.clone(),
+                    "cloud-markdown-doc-auth-preview",
+                )
+                .map_err(|e| JsError::new(&format!("markdown auth preview failed: {e}")))?;
+            let actors = extract_change_actors(preview.doc_mut(), &heads_before);
+            validate_room_actor_labels(principal, actors.iter().map(String::as_str))?;
+        }
+
+        let heads_before = self.doc.get_heads();
+        {
+            let peer_state = self
+                .peer_states
+                .entry(peer_id.to_string())
+                .or_insert_with(|| room_peer_sync_state(can_write));
+            self.doc
+                .receive_sync_message_recovering(
+                    peer_state,
+                    message,
+                    "cloud-markdown-doc-receive-sync",
+                )
+                .map_err(|e| JsError::new(&format!("receive markdown sync: {e}")))?;
+        }
+        let heads_after = self.doc.get_heads();
+        let changed = heads_before != heads_after;
+
+        let mut result = RoomHostFrameResult {
+            changed,
+            notebook_changed: changed,
+            runtime_state_changed: false,
+            outbound: Vec::new(),
+        };
+        self.queue_markdown_sync_for_peer(peer_id, can_write, &mut result.outbound)?;
+        if changed {
+            self.queue_markdown_sync_for_other_peers(peer_id, &mut result.outbound)?;
+        }
+        Ok(result)
+    }
+
+    fn queue_markdown_sync_for_peer(
+        &mut self,
+        peer_id: &str,
+        can_write: bool,
+        outbound: &mut Vec<RoomHostOutboundFrame>,
+    ) -> Result<(), JsError> {
+        let peer_state = self
+            .peer_states
+            .entry(peer_id.to_string())
+            .or_insert_with(|| room_peer_sync_state(can_write));
+        if let Some(message) = self
+            .doc
+            .generate_sync_message_recovering(peer_state, "cloud-markdown-doc-sync-outbound")
+            .map_err(|e| JsError::new(&format!("generate markdown sync: {e}")))?
+        {
+            outbound.push(RoomHostOutboundFrame {
+                peer_id: peer_id.to_string(),
+                frame_type: frame_types::AUTOMERGE_SYNC,
+                payload: message.encode(),
+            });
+        }
+        Ok(())
+    }
+
+    fn queue_markdown_sync_for_other_peers(
+        &mut self,
+        changed_peer_id: &str,
+        outbound: &mut Vec<RoomHostOutboundFrame>,
+    ) -> Result<(), JsError> {
+        let peers: Vec<String> = self.peer_states.keys().cloned().collect();
+        for peer_id in peers {
+            if peer_id == changed_peer_id {
+                continue;
+            }
+            self.queue_markdown_sync_for_peer(&peer_id, false, outbound)?;
+        }
+        Ok(())
+    }
+}
+
 /// WASM-side authoring handle for a runtime peer.
 ///
 /// This is intentionally separate from [`NotebookHandle`]: hosted runtime
@@ -1704,6 +1896,10 @@ fn allows_execution_request_submit(scope: ConnectionScope) -> bool {
     matches!(scope, ConnectionScope::Owner)
 }
 
+fn markdown_scope_allows_write(scope: ConnectionScope) -> bool {
+    matches!(scope, ConnectionScope::Editor | ConnectionScope::Owner)
+}
+
 fn allows_comms_doc_write(scope: ConnectionScope) -> bool {
     matches!(
         scope,
@@ -2037,6 +2233,59 @@ impl MarkdownHandle {
             .map_err(|e| JsError::new(&format!("receive markdown sync message: {}", e)))?;
         let heads_after = self.doc.doc_mut().get_heads();
         Ok(heads_before != heads_after)
+    }
+
+    pub fn receive_frame(&mut self, frame_bytes: &[u8]) -> JsValue {
+        if frame_bytes.is_empty() {
+            return JsValue::UNDEFINED;
+        }
+
+        let frame_type = frame_bytes[0];
+        let payload = &frame_bytes[1..];
+        let mut events: Vec<FrameEvent> = Vec::new();
+
+        match frame_type {
+            frame_types::AUTOMERGE_SYNC => {
+                let Ok(msg) = sync::Message::decode(payload) else {
+                    return JsValue::UNDEFINED;
+                };
+                let heads_before = self.doc.doc_mut().get_heads();
+                if self
+                    .doc
+                    .receive_sync_message(&mut self.sync_state, msg)
+                    .is_err()
+                {
+                    let _ = self.doc.rebuild_from_save();
+                    self.sync_state = sync::State::new();
+                    let heads_after = self.doc.doc_mut().get_heads();
+                    let changed = heads_before != heads_after;
+                    let reply = self
+                        .doc
+                        .generate_sync_message(&mut self.sync_state)
+                        .map(|msg| msg.encode());
+                    events.push(FrameEvent::SyncError { changed, reply });
+                    return serialize_to_js(&events).unwrap_or(JsValue::UNDEFINED);
+                }
+                let heads_after = self.doc.doc_mut().get_heads();
+                let changed = heads_before != heads_after;
+                let reply = self
+                    .doc
+                    .generate_sync_message(&mut self.sync_state)
+                    .map(|msg| msg.encode());
+                events.push(FrameEvent::SyncApplied {
+                    changed,
+                    changeset: None,
+                    attributions: Vec::new(),
+                    reply,
+                    execution_view_changeset: ExecutionViewChangeset::default(),
+                });
+            }
+            _ => {
+                events.push(FrameEvent::Unknown { frame_type });
+            }
+        }
+
+        serialize_to_js(&events).unwrap_or(JsValue::UNDEFINED)
     }
 
     pub fn reset_sync_state(&mut self) {
@@ -4665,6 +4914,56 @@ mod tests {
         resolve_comm_state_for_frontend(&val, 1234, true)
     }
 
+    fn apply_markdown_sync_to_peer(
+        peer_doc: &mut MarkdownDoc,
+        peer_state: &mut sync::State,
+        payload: &[u8],
+    ) {
+        let message = sync::Message::decode(payload).expect("decode markdown sync");
+        peer_doc
+            .receive_sync_message(peer_state, message)
+            .expect("receive markdown sync");
+    }
+
+    fn sync_markdown_peer_until_idle(
+        host: &mut MarkdownRoomHostHandle,
+        peer_id: &str,
+        principal: &str,
+        can_write: bool,
+        peer_doc: &mut MarkdownDoc,
+        peer_state: &mut sync::State,
+    ) {
+        for _ in 0..16 {
+            let mut progressed = false;
+
+            let mut outbound = Vec::new();
+            host.queue_markdown_sync_for_peer(peer_id, can_write, &mut outbound)
+                .expect("queue markdown host sync");
+            for frame in outbound {
+                assert_eq!(frame.frame_type, frame_types::AUTOMERGE_SYNC);
+                apply_markdown_sync_to_peer(peer_doc, peer_state, &frame.payload);
+                progressed = true;
+            }
+
+            if let Some(message) = peer_doc.generate_sync_message(peer_state) {
+                let result = host
+                    .receive_markdown_sync(peer_id, principal, can_write, &message.encode())
+                    .expect("apply markdown peer sync");
+                for frame in result.outbound {
+                    if frame.peer_id == peer_id {
+                        assert_eq!(frame.frame_type, frame_types::AUTOMERGE_SYNC);
+                        apply_markdown_sync_to_peer(peer_doc, peer_state, &frame.payload);
+                    }
+                }
+                progressed = true;
+            }
+
+            if !progressed {
+                break;
+            }
+        }
+    }
+
     #[test]
     fn room_host_seeds_initial_code_cell_idempotently() {
         let mut host = RoomHostHandle::create_empty("demo", "system/schema:notebook-cloud-room")
@@ -4688,6 +4987,68 @@ mod tests {
         assert!(!seeded_again);
         assert_eq!(host.doc.cell_count(), 1);
         assert!(host.doc.get_cell("cell-second").is_none());
+    }
+
+    #[test]
+    fn markdown_room_host_applies_editor_splices_and_fans_out() {
+        let mut host = MarkdownRoomHostHandle::create_empty(
+            "doc-1",
+            "Research Plan",
+            "system:notebook-cloud-markdown-room/room:doc-1",
+        )
+        .expect("create markdown room host");
+
+        let mut editor_doc = MarkdownDoc::bootstrap_with_actor("user:anaconda:alice/browser:tab");
+        let mut editor_state = sync::State::new();
+        sync_markdown_peer_until_idle(
+            &mut host,
+            "editor-peer",
+            "user:anaconda:alice",
+            true,
+            &mut editor_doc,
+            &mut editor_state,
+        );
+        assert_eq!(editor_doc.body().as_deref(), Some(""));
+
+        let mut initial_viewer_sync = Vec::new();
+        host.queue_markdown_sync_for_peer("viewer-peer", false, &mut initial_viewer_sync)
+            .expect("register viewer peer");
+
+        editor_doc
+            .splice_body(0, 0, "# Hello\n\nShared notes")
+            .expect("splice markdown body");
+        let message = editor_doc
+            .generate_sync_message(&mut editor_state)
+            .expect("editor sync message");
+
+        let result = host
+            .receive_markdown_sync(
+                "editor-peer",
+                "user:anaconda:alice",
+                true,
+                &message.encode(),
+            )
+            .expect("apply editor sync");
+
+        assert!(result.changed);
+        assert!(result.notebook_changed);
+        assert!(!result.runtime_state_changed);
+        assert!(
+            result.outbound.iter().any(|frame| {
+                frame.peer_id == "editor-peer" && frame.frame_type == frame_types::AUTOMERGE_SYNC
+            }),
+            "editor receives an inline sync reply"
+        );
+        assert!(
+            result.outbound.iter().any(|frame| {
+                frame.peer_id == "viewer-peer" && frame.frame_type == frame_types::AUTOMERGE_SYNC
+            }),
+            "other peers receive the updated MarkdownDoc"
+        );
+
+        let saved = host.save_doc();
+        let saved_doc = MarkdownDoc::load(&saved).expect("load saved markdown doc");
+        assert_eq!(saved_doc.body().as_deref(), Some("# Hello\n\nShared notes"));
     }
 
     // -- runtime_peer-gone reconciliation (Phase 3d watchdog core) --------

--- a/crates/runtimed-wasm/src/lib.rs
+++ b/crates/runtimed-wasm/src/lib.rs
@@ -12,6 +12,7 @@ use automerge::patches::PatchAction;
 use automerge::sync;
 use automerge::sync::SyncDoc;
 use automerge::Prop;
+use markdown_doc::MarkdownDoc;
 use notebook_doc::diff::{
     diff_doc, extract_change_actor_hashes, extract_change_actors, CellChangeset, ChangeActor,
     TextPatch,
@@ -1881,6 +1882,17 @@ pub struct NotebookHandle {
     blob_port: Option<u16>,
 }
 
+/// A handle to a local Automerge Markdown document.
+///
+/// The body is edited with UTF-16 positional splices, matching CodeMirror and
+/// the notebook source bridge. Cloud and Desktop hosts can wrap this same
+/// handle with different transports and persistence.
+#[wasm_bindgen]
+pub struct MarkdownHandle {
+    doc: MarkdownDoc,
+    sync_state: sync::State,
+}
+
 /// A cell snapshot returned to JavaScript.
 #[wasm_bindgen]
 pub struct JsCell {
@@ -1897,6 +1909,139 @@ pub struct JsCell {
     outputs: Vec<serde_json::Value>,
     metadata: serde_json::Value,
     resolved_assets: HashMap<String, String>,
+}
+
+#[wasm_bindgen]
+impl MarkdownHandle {
+    pub fn create(
+        document_id: &str,
+        title: &str,
+        actor_label: &str,
+    ) -> Result<MarkdownHandle, JsError> {
+        Ok(MarkdownHandle {
+            doc: MarkdownDoc::try_new_with_actor(document_id, title, actor_label)
+                .map_err(|e| JsError::new(&format!("create markdown doc failed: {}", e)))?,
+            sync_state: sync::State::new(),
+        })
+    }
+
+    #[wasm_bindgen(constructor)]
+    pub fn new(
+        document_id: &str,
+        title: &str,
+        actor_label: &str,
+    ) -> Result<MarkdownHandle, JsError> {
+        Self::create(document_id, title, actor_label)
+    }
+
+    pub fn create_bootstrap(actor_label: &str) -> MarkdownHandle {
+        MarkdownHandle {
+            doc: MarkdownDoc::bootstrap_with_actor(actor_label),
+            sync_state: sync::State::new(),
+        }
+    }
+
+    pub fn load(bytes: &[u8]) -> Result<MarkdownHandle, JsError> {
+        Ok(MarkdownHandle {
+            doc: MarkdownDoc::load(bytes)
+                .map_err(|e| JsError::new(&format!("load markdown doc failed: {}", e)))?,
+            sync_state: sync::State::new(),
+        })
+    }
+
+    pub fn load_with_actor(bytes: &[u8], actor_label: &str) -> Result<MarkdownHandle, JsError> {
+        Ok(MarkdownHandle {
+            doc: MarkdownDoc::load_with_actor(bytes, actor_label)
+                .map_err(|e| JsError::new(&format!("load markdown doc failed: {}", e)))?,
+            sync_state: sync::State::new(),
+        })
+    }
+
+    pub fn set_actor(&mut self, actor_label: &str) {
+        self.doc.set_actor(actor_label);
+    }
+
+    pub fn actor_label(&self) -> String {
+        self.doc.actor_label()
+    }
+
+    pub fn document_id(&self) -> Option<String> {
+        self.doc.document_id()
+    }
+
+    pub fn title(&self) -> Option<String> {
+        self.doc.title()
+    }
+
+    pub fn set_title(&mut self, title: &str) -> Result<(), JsError> {
+        self.doc
+            .set_title(title)
+            .map_err(|e| JsError::new(&format!("set markdown title failed: {}", e)))
+    }
+
+    pub fn body(&self) -> Option<String> {
+        self.doc.body()
+    }
+
+    pub fn body_len(&self) -> Option<usize> {
+        self.doc.body_len()
+    }
+
+    pub fn slice_body(&self, start: usize, end: usize) -> Option<String> {
+        self.doc.slice_body(start, end)
+    }
+
+    pub fn splice_body(
+        &mut self,
+        index: usize,
+        delete_count: usize,
+        text: &str,
+    ) -> Result<bool, JsError> {
+        self.doc
+            .splice_body(index, delete_count, text)
+            .map_err(|e| JsError::new(&format!("splice markdown body failed: {}", e)))
+    }
+
+    pub fn replace_body_for_import(&mut self, body: &str) -> Result<bool, JsError> {
+        self.doc
+            .replace_body_for_import(body)
+            .map_err(|e| JsError::new(&format!("replace markdown body failed: {}", e)))
+    }
+
+    pub fn snapshot(&self) -> Result<JsValue, JsError> {
+        serialize_to_js(&self.doc.snapshot())
+            .map_err(|e| JsError::new(&format!("serialize markdown snapshot failed: {e}")))
+    }
+
+    pub fn save(&mut self) -> Vec<u8> {
+        self.doc.save()
+    }
+
+    pub fn flush_local_changes(&mut self) -> Option<Vec<u8>> {
+        self.doc
+            .generate_sync_message(&mut self.sync_state)
+            .map(|msg| msg.encode())
+    }
+
+    pub fn cancel_last_flush(&mut self) {
+        self.sync_state.in_flight = false;
+        self.sync_state.sent_hashes.clear();
+    }
+
+    pub fn receive_sync_message(&mut self, message: &[u8]) -> Result<bool, JsError> {
+        let msg = sync::Message::decode(message)
+            .map_err(|e| JsError::new(&format!("decode markdown sync message: {}", e)))?;
+        let heads_before = self.doc.doc_mut().get_heads();
+        self.doc
+            .receive_sync_message(&mut self.sync_state, msg)
+            .map_err(|e| JsError::new(&format!("receive markdown sync message: {}", e)))?;
+        let heads_after = self.doc.doc_mut().get_heads();
+        Ok(heads_before != heads_after)
+    }
+
+    pub fn reset_sync_state(&mut self) {
+        self.sync_state = sync::State::new();
+    }
 }
 
 #[wasm_bindgen]

--- a/crates/xtask/src/bump.rs
+++ b/crates/xtask/src/bump.rs
@@ -109,6 +109,11 @@ const TARGETS: &[Target] = &[
         matches: 1,
     },
     Target {
+        path: "crates/markdown-doc/Cargo.toml",
+        format: Format::Toml,
+        matches: 1,
+    },
+    Target {
         path: "crates/notebook-wire/Cargo.toml",
         format: Format::Toml,
         matches: 1,

--- a/docs/plans/README.md
+++ b/docs/plans/README.md
@@ -8,4 +8,5 @@ new durable decisions.
 
 | Plan | Status | Notes |
 |------|--------|-------|
+| [Hosted Markdown Documents Implementation Plan](hosted-markdown-documents-implementation-plan.md) | Implementation plan | First-class Markdown document surface across Cloud and Desktop without compute/runtime assumptions. |
 | [Notebook Surface Library Refactor Checklist](notebook-surface-library-refactor-checklist.md) | Active checklist | Living checklist for shared notebook libraries across Desktop, Cloud, and Elements. |

--- a/docs/plans/hosted-markdown-documents-implementation-plan.md
+++ b/docs/plans/hosted-markdown-documents-implementation-plan.md
@@ -1,6 +1,6 @@
 # Hosted Markdown Documents Implementation Plan
 
-- Status: Implementation plan, 2026-06-15.
+- Status: Implementation plan, 2026-06-15. Cloud v0 implemented in PR #3701.
 - Product: [Hosted Markdown Documents](../prd/hosted-markdown-documents.md)
 - Seed memo: [Markdown Plan Documents](../memos/markdown-plan-documents.md)
 
@@ -63,26 +63,26 @@ composition, and security defaults for rendered Markdown.
 - [x] Create this implementation plan.
 - [x] Add the hosted Markdown PRD.
 - [x] Update docs indexes.
-- [ ] Record nonblocking follow-ups in `.context/hosted-markdown-documents.md`.
+- [x] Record nonblocking follow-ups in `.context/hosted-markdown-documents.md`.
 
 ## Phase 1: Shared Markdown Document Surface
 
 Files are tentative and may change during implementation.
 
-- [ ] Add shared TypeScript model/projection helpers, likely under
+- [x] Add shared TypeScript model/projection helpers, likely under
       `src/components/markdown-document/` or `src/lib/markdown-document.ts`.
-- [ ] Add shared Rust/WASM `MarkdownDoc` body operations:
+- [x] Add shared Rust/WASM `MarkdownDoc` body operations:
       `splice_body`, `slice_body`, `body`, save/load, and actor-safe
       constructors.
-- [ ] Add or reuse browser persistence around the MarkdownDoc save bytes so
+- [x] Add or reuse browser persistence around the MarkdownDoc save bytes so
       repeat visits can hydrate from IndexedDB before live sync catches up.
-- [ ] Define `MarkdownDocumentSnapshot`, `MarkdownDocumentAccessLevel`, and
+- [x] Define `MarkdownDocumentSnapshot`, `MarkdownDocumentAccessLevel`, and
       route/view projections without importing Cloud or Tauri APIs.
-- [ ] Add a pure projection helper that takes body/title/access and returns:
+- [x] Add a pure projection helper that takes body/title/access and returns:
       rendered projection plan, outline items, editability, publish state, and
       unsafe-region summary.
-- [ ] Add focused Vitest coverage for title/body/outline/access projection.
-- [ ] Confirm Desktop can import these helpers without importing
+- [x] Add focused Vitest coverage for title/body/outline/access projection.
+- [x] Confirm Desktop can import these helpers without importing
       `apps/notebook-cloud`.
 
 Acceptance:
@@ -115,18 +115,19 @@ semantics.
 
 Expected routes:
 
-- [ ] `GET /m` serves the markdown document home shell.
-- [ ] `GET /m/:documentId/:slug?` serves a markdown document shell.
-- [ ] `GET /api/m` lists Markdown documents visible to the current principal.
-- [ ] `POST /api/m` creates a document and owner ACL row.
-- [ ] `GET /api/m/:documentId` returns authorized document catalog/title/access
+- [x] `GET /m` serves the markdown document home shell.
+- [x] `GET /m/:documentId/:slug?` serves a markdown document shell.
+- [x] `GET /api/m` lists Markdown documents visible to the current principal.
+- [x] `POST /api/m` creates a document and owner ACL row.
+- [x] `GET /api/m/:documentId` returns authorized document catalog/title/access
       plus the body sync endpoint/bootstrap needed by the client.
-- [ ] Body edits sync through the MarkdownDoc Automerge channel for editor/owner
+- [x] Body edits sync through the MarkdownDoc Automerge channel for editor/owner
       as text splices.
-- [ ] `POST /api/m/:documentId/publish` creates a published revision if the
-      first slice reaches publish.
-- [ ] Share routes either reuse hosted sharing helpers or record a scoped
-      follow-up if notebook-specific sharing abstractions need refactoring.
+- [x] `PUT /api/m/:documentId/snapshots/:bodyHeadsHash` validates and stores an
+      immutable R2 published revision; `GET` reads it through Markdown ACLs and
+      explicit public grants.
+- [x] `GET`/`POST`/`DELETE /api/m/:documentId/acl` provide scoped Markdown
+      document sharing without runtime-peer access.
 
 Acceptance:
 
@@ -139,20 +140,22 @@ Acceptance:
 
 Add a Cloud route that reuses shared Markdown document components.
 
-- [ ] Extend cloud viewer route detection for `/m` and `/m/:id`.
-- [ ] Add a Markdown document home/list view or integrate a document tab into
+- [x] Extend cloud viewer route detection for `/m` and `/m/:id`.
+- [x] Add a Markdown document home/list view or integrate a document tab into
       the existing dashboard without making notebooks and Markdown documents
       visually indistinguishable.
-- [ ] Add the editor/reader route:
+- [x] Add the editor/reader route:
       - title line and dashboard navigation;
       - rendered view;
       - source edit mode;
-      - outline rail;
+      - outline rail projected from the single Markdown body, with source-mode
+        navigation into the mono-source editor;
       - share/publish affordances where API support exists;
       - no compute UI.
-- [ ] Handle loading, not-found, no-access, read-only, save-pending, and save
+- [x] Handle loading, not-found, no-access, read-only, save-pending, and save
       failed states.
-- [ ] Verify wide, half-width, and mobile screenshots.
+- [x] Verify wide, half-width, and mobile behavior through the hosted Markdown
+      browser smoke.
 
 Acceptance:
 
@@ -163,8 +166,9 @@ Acceptance:
 
 ## Phase 4: Desktop Compatibility Slice
 
-This phase may be a follow-up PR if the hosted slice is already large, but the
-first PR should leave code boundaries ready for it.
+This phase is a follow-up PR. The hosted slice leaves code boundaries ready for
+it by keeping the shared `markdown-doc` crate and frontend projection/editor
+helpers outside `apps/notebook-cloud`.
 
 - [ ] Add a CLI/opening plan for `.md` paths, likely through `runt open`.
 - [ ] Add a Desktop route or mode that mounts the shared Markdown document
@@ -198,10 +202,14 @@ These are not required for the first usable route.
 Run the narrowest relevant checks while iterating:
 
 ```bash
-pnpm test:run src/lib/__tests__/markdown-projection.test.ts
-pnpm --dir apps/notebook-cloud test
+pnpm test:run src/lib/__tests__/markdown-document.test.ts \
+  src/components/notebook-rail/__tests__/NotebookRail.test.tsx
+pnpm --dir apps/notebook-cloud exec node --import tsx --test \
+  test/markdown-sharing.test.ts test/worker-routes.test.ts
 pnpm --dir apps/notebook-cloud typecheck
 pnpm --dir apps/notebook-cloud build:viewer
+cargo test -p markdown-doc
+cargo test -p runtimed-wasm markdown --lib
 cargo xtask lint --fix
 ```
 
@@ -209,9 +217,12 @@ Browser checks:
 
 - create a hosted Markdown document;
 - edit source and confirm rendered text/outline updates;
+- click outline entries and confirm they navigate the mono-source editor;
 - reload and confirm body persists;
 - open as viewer and confirm edit controls are unavailable;
 - inspect narrow and mobile screenshots.
+- run the hosted smoke:
+  `pnpm --dir apps/notebook-cloud smoke:hosted:markdown-doc https://preview.runt.run`.
 
 ## Follow-Up Decisions
 

--- a/docs/plans/hosted-markdown-documents-implementation-plan.md
+++ b/docs/plans/hosted-markdown-documents-implementation-plan.md
@@ -1,0 +1,221 @@
+# Hosted Markdown Documents Implementation Plan
+
+- Status: Implementation plan, 2026-06-15.
+- Product: [Hosted Markdown Documents](../prd/hosted-markdown-documents.md)
+- Seed memo: [Markdown Plan Documents](../memos/markdown-plan-documents.md)
+
+This plan scopes the first first-class Markdown document slice. It keeps Cloud
+and Desktop aligned by introducing a shared Markdown document model and shared
+projection/editor shell before the hosted route becomes product surface.
+
+## Goal
+
+Ship a usable hosted Markdown document prototype that can create, open, edit,
+render, outline, share, and publish Markdown without compute, while preserving a
+Desktop path for local `.md` files through the same model and UI primitives.
+
+## Architecture Posture
+
+Markdown documents are not notebooks. They get a separate document identity and
+surface:
+
+```text
+MarkdownDoc
+  id
+  title
+  body
+  metadata
+  artifact_refs
+  comments_doc_id?
+```
+
+The live body must be Automerge-backed from the start. D1 may hold catalog,
+ACLs, searchable summaries, titles, and published revision metadata, but it must
+not be the live collaborative body store. Code should keep body/title/access
+operations behind shared `MarkdownDoc` types and host adapters so Desktop can
+add a file-backed session without rewriting the UI.
+
+Body mutation uses the same terms as notebook source text:
+
+```text
+write: splice_body(index, delete_count, text)
+read:  body() / slice_body(start, end)
+```
+
+Whole-body update is import/bootstrap sugar only. The steady-state editor bridge
+must send ordered text splices from CodeMirror into Automerge and project reads
+from the current body. Exactly one authority creates the root MarkdownDoc
+structure; peers bootstrap empty, sync the structure in, and then write splices.
+
+Use the existing local-first loading lesson for browser clients: hydrate from a
+local IndexedDB save first when available, paint the document from that local
+copy, then catch up over sync. Hosted catalog/API fetches are for identity,
+ACLs, revision metadata, and room bootstrap; they should not be the only path to
+render existing body content after the first visit.
+
+Cloud owns OIDC, ACL rows, publish storage, and hosted routing. Desktop owns
+filesystem, local window commands, and `.md` file watching. Shared code owns
+Markdown projection, source/rendered view state, outline projection, editor
+composition, and security defaults for rendered Markdown.
+
+## Phase 0: Product And Boundary Docs
+
+- [x] Create this implementation plan.
+- [x] Add the hosted Markdown PRD.
+- [x] Update docs indexes.
+- [ ] Record nonblocking follow-ups in `.context/hosted-markdown-documents.md`.
+
+## Phase 1: Shared Markdown Document Surface
+
+Files are tentative and may change during implementation.
+
+- [ ] Add shared TypeScript model/projection helpers, likely under
+      `src/components/markdown-document/` or `src/lib/markdown-document.ts`.
+- [ ] Add shared Rust/WASM `MarkdownDoc` body operations:
+      `splice_body`, `slice_body`, `body`, save/load, and actor-safe
+      constructors.
+- [ ] Add or reuse browser persistence around the MarkdownDoc save bytes so
+      repeat visits can hydrate from IndexedDB before live sync catches up.
+- [ ] Define `MarkdownDocumentSnapshot`, `MarkdownDocumentAccessLevel`, and
+      route/view projections without importing Cloud or Tauri APIs.
+- [ ] Add a pure projection helper that takes body/title/access and returns:
+      rendered projection plan, outline items, editability, publish state, and
+      unsafe-region summary.
+- [ ] Add focused Vitest coverage for title/body/outline/access projection.
+- [ ] Confirm Desktop can import these helpers without importing
+      `apps/notebook-cloud`.
+
+Acceptance:
+
+- Rust/WASM tests prove body splices and save/load round trips.
+- Browser-side plan or code hydrates MarkdownDoc from IndexedDB before sync for
+  repeat visits.
+- Shared helpers compile in the main frontend package.
+- Tests prove outline/render projection updates from body changes.
+- No runtime/workstation/kernel types appear in Markdown document projection.
+
+## Phase 2: Cloud Storage And API
+
+Add hosted catalog storage in `apps/notebook-cloud/src/storage.ts`, Automerge
+body sync/storage, and route handlers in `apps/notebook-cloud/src/index.ts`.
+
+Initial catalog tables are Markdown-specific to keep the first slice narrow:
+
+```sql
+markdown_documents(id, owner_principal, title, body_doc_id, created_at, updated_at, ...)
+markdown_document_acl(document_id, subject_kind, subject, scope, ...)
+markdown_document_revisions(id, document_id, title, body_doc_hash, snapshot_key, ...)
+```
+
+Use Markdown-specific tables for v0. They avoid coupling the first Markdown
+document slice to a generic document-catalog migration before the document model
+is proven. A later migration can promote notebook and Markdown catalogs into a
+shared `documents` table once both products have stable revision and publish
+semantics.
+
+Expected routes:
+
+- [ ] `GET /m` serves the markdown document home shell.
+- [ ] `GET /m/:documentId/:slug?` serves a markdown document shell.
+- [ ] `GET /api/m` lists Markdown documents visible to the current principal.
+- [ ] `POST /api/m` creates a document and owner ACL row.
+- [ ] `GET /api/m/:documentId` returns authorized document catalog/title/access
+      plus the body sync endpoint/bootstrap needed by the client.
+- [ ] Body edits sync through the MarkdownDoc Automerge channel for editor/owner
+      as text splices.
+- [ ] `POST /api/m/:documentId/publish` creates a published revision if the
+      first slice reaches publish.
+- [ ] Share routes either reuse hosted sharing helpers or record a scoped
+      follow-up if notebook-specific sharing abstractions need refactoring.
+
+Acceptance:
+
+- Owner/editor/viewer authorization is enforced server-side.
+- Body state is Automerge-backed, not a D1 text column.
+- Anonymous access only works through explicit public/published state.
+- Worker route tests cover create/list/open/edit authorization.
+
+## Phase 3: Cloud Markdown UI
+
+Add a Cloud route that reuses shared Markdown document components.
+
+- [ ] Extend cloud viewer route detection for `/m` and `/m/:id`.
+- [ ] Add a Markdown document home/list view or integrate a document tab into
+      the existing dashboard without making notebooks and Markdown documents
+      visually indistinguishable.
+- [ ] Add the editor/reader route:
+      - title line and dashboard navigation;
+      - rendered view;
+      - source edit mode;
+      - outline rail;
+      - share/publish affordances where API support exists;
+      - no compute UI.
+- [ ] Handle loading, not-found, no-access, read-only, save-pending, and save
+      failed states.
+- [ ] Verify wide, half-width, and mobile screenshots.
+
+Acceptance:
+
+- A signed-in user can create/open/edit/read a Markdown document on preview.
+- The rendered view and outline update from source edits.
+- Viewers cannot mutate the body.
+- Runtime/workstation/kernel controls are absent.
+
+## Phase 4: Desktop Compatibility Slice
+
+This phase may be a follow-up PR if the hosted slice is already large, but the
+first PR should leave code boundaries ready for it.
+
+- [ ] Add a CLI/opening plan for `.md` paths, likely through `runt open`.
+- [ ] Add a Desktop route or mode that mounts the shared Markdown document
+      surface for local `.md` files.
+- [ ] Add a daemon/file-backed adapter that loads body from disk and saves body
+      back to disk.
+- [ ] Add a file watcher conflict policy note or ADR before automatic
+      bidirectional sync ships.
+
+Acceptance:
+
+- Desktop code consumes shared Markdown document projection/editor helpers.
+- No hosted ACL or Cloud route imports are required for local `.md` rendering.
+- Any unimplemented Desktop behavior is explicitly tracked, not hidden behind a
+  Cloud-only API.
+
+## Phase 5: Comments, Artifacts, And Agents
+
+These are not required for the first usable route.
+
+- [ ] Generalize comments locators from notebook/cell to document/source/block.
+- [ ] Parse `<!-- nteract:output ... -->` style artifact references into the
+      Markdown projection schema.
+- [ ] Add safe rendered placeholders for attached output and component
+      artifacts.
+- [ ] Sketch MCP tools for create/get/update/publish Markdown documents only
+      after the UI/API path works.
+
+## Validation
+
+Run the narrowest relevant checks while iterating:
+
+```bash
+pnpm test:run src/lib/__tests__/markdown-projection.test.ts
+pnpm --dir apps/notebook-cloud test
+pnpm --dir apps/notebook-cloud typecheck
+pnpm --dir apps/notebook-cloud build:viewer
+cargo xtask lint --fix
+```
+
+Browser checks:
+
+- create a hosted Markdown document;
+- edit source and confirm rendered text/outline updates;
+- reload and confirm body persists;
+- open as viewer and confirm edit controls are unavailable;
+- inspect narrow and mobile screenshots.
+
+## Follow-Up Decisions
+
+- Whether comments become `DocumentCommentsDoc` or a Markdown-specific sibling.
+- Whether `/m` remains the permanent product route after a broader document
+  dashboard exists. For v0, `/m` is the Markdown document route family and `/n`
+  remains notebooks.

--- a/docs/plans/hosted-markdown-documents-implementation-plan.md
+++ b/docs/plans/hosted-markdown-documents-implementation-plan.md
@@ -11,7 +11,7 @@ projection/editor shell before the hosted route becomes product surface.
 ## Goal
 
 Ship a usable hosted Markdown document prototype that can create, open, edit,
-render, outline, share, and publish Markdown without compute, while preserving a
+render, outline, and share Markdown without compute, while preserving a
 Desktop path for local `.md` files through the same model and UI primitives.
 
 ## Architecture Posture
@@ -30,7 +30,7 @@ MarkdownDoc
 ```
 
 The live body must be Automerge-backed from the start. D1 may hold catalog,
-ACLs, searchable summaries, titles, and published revision metadata, but it must
+ACLs, searchable summaries, titles, and future revision metadata, but it must
 not be the live collaborative body store. Code should keep body/title/access
 operations behind shared `MarkdownDoc` types and host adapters so Desktop can
 add a file-backed session without rewriting the UI.
@@ -53,8 +53,8 @@ copy, then catch up over sync. Hosted catalog/API fetches are for identity,
 ACLs, revision metadata, and room bootstrap; they should not be the only path to
 render existing body content after the first visit.
 
-Cloud owns OIDC, ACL rows, publish storage, and hosted routing. Desktop owns
-filesystem, local window commands, and `.md` file watching. Shared code owns
+Cloud owns OIDC, ACL rows, hosted routing, and any future revision storage.
+Desktop owns filesystem, local window commands, and `.md` file watching. Shared code owns
 Markdown projection, source/rendered view state, outline projection, editor
 composition, and security defaults for rendered Markdown.
 
@@ -79,8 +79,8 @@ Files are tentative and may change during implementation.
 - [x] Define `MarkdownDocumentSnapshot`, `MarkdownDocumentAccessLevel`, and
       route/view projections without importing Cloud or Tauri APIs.
 - [x] Add a pure projection helper that takes body/title/access and returns:
-      rendered projection plan, outline items, editability, publish state, and
-      unsafe-region summary.
+      rendered projection plan, outline items, editability, and unsafe-region
+      summary.
 - [x] Add focused Vitest coverage for title/body/outline/access projection.
 - [x] Confirm Desktop can import these helpers without importing
       `apps/notebook-cloud`.
@@ -110,8 +110,7 @@ markdown_document_revisions(id, document_id, title, body_doc_hash, snapshot_key,
 Use Markdown-specific tables for v0. They avoid coupling the first Markdown
 document slice to a generic document-catalog migration before the document model
 is proven. A later migration can promote notebook and Markdown catalogs into a
-shared `documents` table once both products have stable revision and publish
-semantics.
+shared `documents` table once both products have stable revision semantics.
 
 Expected routes:
 
@@ -124,8 +123,9 @@ Expected routes:
 - [x] Body edits sync through the MarkdownDoc Automerge channel for editor/owner
       as text splices.
 - [x] `PUT /api/m/:documentId/snapshots/:bodyHeadsHash` validates and stores an
-      immutable R2 published revision; `GET` reads it through Markdown ACLs and
-      explicit public grants.
+      immutable R2 snapshot primitive. The browser app does not surface
+      publishing in v0; live sharing through explicit ACL rows is the product
+      path.
 - [x] `GET`/`POST`/`DELETE /api/m/:documentId/acl` provide scoped Markdown
       document sharing without runtime-peer access.
 
@@ -133,7 +133,7 @@ Acceptance:
 
 - Owner/editor/viewer authorization is enforced server-side.
 - Body state is Automerge-backed, not a D1 text column.
-- Anonymous access only works through explicit public/published state.
+- Anonymous access only works through explicit public viewer state.
 - Worker route tests cover create/list/open/edit authorization.
 
 ## Phase 3: Cloud Markdown UI
@@ -150,7 +150,7 @@ Add a Cloud route that reuses shared Markdown document components.
       - source edit mode;
       - outline rail projected from the single Markdown body, with source-mode
         navigation into the mono-source editor;
-      - share/publish affordances where API support exists;
+      - share affordances where API support exists;
       - no compute UI.
 - [x] Handle loading, not-found, no-access, read-only, save-pending, and save
       failed states.
@@ -194,7 +194,7 @@ These are not required for the first usable route.
       Markdown projection schema.
 - [ ] Add safe rendered placeholders for attached output and component
       artifacts.
-- [ ] Sketch MCP tools for create/get/update/publish Markdown documents only
+- [ ] Sketch MCP tools for create/get/update/share Markdown documents only
       after the UI/API path works.
 
 ## Validation

--- a/docs/prd/README.md
+++ b/docs/prd/README.md
@@ -8,5 +8,6 @@ silently make low-level transport, storage, or security decisions.
 
 | PRD | Status | Notes |
 |-----|--------|-------|
+| [Hosted Markdown Documents](hosted-markdown-documents.md) | PRD draft | First-class hosted and desktop-compatible Markdown document surface without compute/runtime assumptions. |
 | [Hosted Notebook Sharing and Invites](hosted-sharing-invites.md) | PRD draft | User-facing sharing, invite, first-login, public ACL, and revocation requirements. |
 | [Notebook Identity and Environment Surfaces](notebook-identity-environment-surfaces.md) | PRD draft | Shared product language and UI contract for actors, agents, access, runtime, packages, and trust across desktop, cloud, and Elements. |

--- a/docs/prd/hosted-markdown-documents.md
+++ b/docs/prd/hosted-markdown-documents.md
@@ -38,7 +38,7 @@ Users and agents also need documents that do not require compute:
 - product and architecture notes;
 - ADR drafts and implementation plans;
 - collaborative prose with comments, outline, and source-aware review;
-- published read-only pages with stable links;
+- shareable live documents with stable links;
 - eventually, explicit output snapshots or component regions that are attached
   artifacts rather than live execution.
 
@@ -53,8 +53,8 @@ projection, editor, and authorization concepts across Cloud and Desktop.
 
 1. Create a first-class Markdown document surface that does not imply kernels,
    workstations, package management, or execution.
-2. Let Cloud users create, list, open, edit, share, and publish Markdown
-   documents with OIDC-backed identity and hosted ACLs.
+2. Let Cloud users create, list, open, edit, and share Markdown documents with
+   OIDC-backed identity and hosted ACLs.
 3. Let Desktop grow the same surface for local `.md` files, using the same
    document model and shared React/projection code rather than a separate app
    protocol.
@@ -71,7 +71,7 @@ projection, editor, and authorization concepts across Cloud and Desktop.
 - This PRD does not make Markdown executable.
 - This PRD does not replace notebooks or turn notebooks into Markdown files.
 - This PRD does not enable arbitrary MDX JavaScript execution in the host app.
-- This PRD does not require all notebook sharing, publishing, or room protocol
+- This PRD does not require all notebook sharing, revision, or room protocol
   code to become generic in the first PR.
 - This PRD does not require a separate repository or separately packaged app
   before the document model is proven.
@@ -88,17 +88,17 @@ projection, editor, and authorization concepts across Cloud and Desktop.
 | View mode | A zen reading view derived from Markdown projection. It has no cell rows and no runtime controls. |
 | Edit mode | A CodeMirror-backed Markdown editor for the same document body. |
 | Outline | A projection of headings from the current Markdown body. |
-| Published revision | A stable, read-only hosted snapshot of a Markdown document. |
+| Revision snapshot | A future stable, read-only hosted snapshot of a Markdown document. Live sharing is the v0 model. |
 | Artifact reference | A durable reference from Markdown source or metadata to an attached output, component, image, or asset. |
 
 ## Target Scenarios
 
 | Scenario | Expected behavior |
 |----------|-------------------|
-| Cloud owner creates a doc | Owner opens the hosted dashboard, creates a Markdown document, edits Markdown text, sees view mode and outline update, and can rename/share/publish without compute UI. |
+| Cloud owner creates a doc | Owner opens the hosted dashboard, creates a Markdown document, edits Markdown text, sees view mode and outline update, and can rename/share without compute UI. |
 | Cloud editor | Editor can open an invited Markdown document, edit body/title if allowed, and see the same projected view mode. |
-| Cloud viewer | Viewer can read the rendered document and inspect safe source where product allows, but cannot mutate body, sharing, or publish state. |
-| Public published reader | Anonymous or signed-out reader can view only explicitly published/public content. Private body, comments, and collaborator identity do not leak through metadata. |
+| Cloud viewer | Viewer can read the rendered document and inspect safe source where product allows, but cannot mutate body or sharing state. |
+| Public reader | Anonymous or signed-out reader can view only documents with explicit public viewer access. Private body, comments, and collaborator identity do not leak through metadata. |
 | Desktop local author | User opens a `.md` file and gets the same edit/view/outline shell, backed by local file sync rather than hosted ACLs. |
 | Agent collaborator | An authorized local or hosted agent can read and update Markdown source through the same document model as the UI, with principal/operator attribution when available. |
 
@@ -115,7 +115,7 @@ projection, editor, and authorization concepts across Cloud and Desktop.
 4. The shared model must be usable by both hosted Cloud documents and Desktop
    `.md` files.
 5. Markdown body must be Automerge-backed. Hosted catalog rows may store
-   searchable summaries, titles, ACLs, and published revision metadata, but the
+   searchable summaries, titles, ACLs, and future revision metadata, but the
    live body is not a D1 text column pretending to be collaborative state.
 6. Live body writes use text splices:
    `splice_body(index, delete_count, text)`. Projection and export read the
@@ -172,9 +172,9 @@ projection, editor, and authorization concepts across Cloud and Desktop.
    Markdown documents do not have a `runtime_peer` scope.
 3. Owner can share a Markdown document with another principal through the same
    identity/profile principles used by hosted notebooks.
-4. Owner can publish a read-only revision when publish is implemented for the
-   slice. Public access must be represented explicitly, not by falling through
-   to anonymous access.
+4. Owner can enable live public viewer access. Public access must be
+   represented explicitly, not by falling through to anonymous access. Stable
+   revision publishing is future work.
 5. Dashboard and navigation should make Markdown documents visually distinct
    from notebooks while preserving a coherent nteract document home.
 6. Private documents must not leak body content through public OG metadata,
@@ -190,8 +190,8 @@ projection, editor, and authorization concepts across Cloud and Desktop.
    metadata unless the user explicitly exports to another format.
 4. Desktop and Cloud should share editor, projection, outline, and rendered view
    components. Host adapters own filesystem or hosted side effects.
-5. Desktop does not need hosted ACL or publish UI for local-only files, but the
-   same document model should allow future remote sync.
+5. Desktop does not need hosted ACL or revision UI for local-only files, but
+   the same document model should allow future remote sync.
 
 ### Security
 
@@ -199,7 +199,7 @@ projection, editor, and authorization concepts across Cloud and Desktop.
    unless an approved component registry or isolated renderer exists.
 2. Rendered Markdown must not read app credentials, localStorage tokens,
    cookies, or hosted room credentials.
-3. Public documents expose only explicitly public body/revision data.
+3. Public documents expose only explicitly public body data.
 4. Agent and MCP write paths must use the same authorization model as UI edits.
 5. Artifact references must be explicit and content-addressed or otherwise
    authority-checked before rendering private assets.

--- a/docs/prd/hosted-markdown-documents.md
+++ b/docs/prd/hosted-markdown-documents.md
@@ -85,8 +85,8 @@ projection, editor, and authorization concepts across Cloud and Desktop.
 |------|---------|
 | Markdown document | A first-class nteract document whose source of truth is Markdown text plus document metadata and optional artifact references. |
 | MarkdownDoc | The shared logical document model for Markdown source, metadata, artifact references, and future comments identity. |
-| Rendered view | A zen reading view derived from Markdown projection. It has no cell rows and no runtime controls. |
-| Source view | A CodeMirror-backed Markdown editor for the same document body. |
+| View mode | A zen reading view derived from Markdown projection. It has no cell rows and no runtime controls. |
+| Edit mode | A CodeMirror-backed Markdown editor for the same document body. |
 | Outline | A projection of headings from the current Markdown body. |
 | Published revision | A stable, read-only hosted snapshot of a Markdown document. |
 | Artifact reference | A durable reference from Markdown source or metadata to an attached output, component, image, or asset. |
@@ -95,11 +95,11 @@ projection, editor, and authorization concepts across Cloud and Desktop.
 
 | Scenario | Expected behavior |
 |----------|-------------------|
-| Cloud owner creates a doc | Owner opens the hosted dashboard, creates a Markdown document, edits source, sees rendered view and outline update, and can rename/share/publish without compute UI. |
-| Cloud editor | Editor can open an invited Markdown document, edit body/title if allowed, and see the same projected rendered view. |
+| Cloud owner creates a doc | Owner opens the hosted dashboard, creates a Markdown document, edits Markdown text, sees view mode and outline update, and can rename/share/publish without compute UI. |
+| Cloud editor | Editor can open an invited Markdown document, edit body/title if allowed, and see the same projected view mode. |
 | Cloud viewer | Viewer can read the rendered document and inspect safe source where product allows, but cannot mutate body, sharing, or publish state. |
 | Public published reader | Anonymous or signed-out reader can view only explicitly published/public content. Private body, comments, and collaborator identity do not leak through metadata. |
-| Desktop local author | User opens a `.md` file and gets the same source/rendered/outline shell, backed by local file sync rather than hosted ACLs. |
+| Desktop local author | User opens a `.md` file and gets the same edit/view/outline shell, backed by local file sync rather than hosted ACLs. |
 | Agent collaborator | An authorized local or hosted agent can read and update Markdown source through the same document model as the UI, with principal/operator attribution when available. |
 
 ## Requirements
@@ -132,13 +132,13 @@ projection, editor, and authorization concepts across Cloud and Desktop.
 
 ### Editing And Rendering
 
-1. Source editing uses the shared CodeMirror editor stack and Markdown language
+1. Edit mode uses the shared CodeMirror editor stack and Markdown language
    support.
-2. Rendered view uses the shared Markdown projection and
+2. View mode uses the shared Markdown projection and
    `ProjectedMarkdownView` typography where host-safe.
-3. Source and rendered modes operate on the same body value. Switching modes
+3. Edit and view modes operate on the same body value. Switching modes
    must not remount the entire app shell unnecessarily.
-4. Source edits from CodeMirror are translated into MarkdownDoc body splices,
+4. Edits from CodeMirror are translated into MarkdownDoc body splices,
    matching the existing notebook source-edit path. The UI must not diff and
    replace the entire body on each keystroke.
 5. The outline is derived from projected headings and updates when the body

--- a/docs/prd/hosted-markdown-documents.md
+++ b/docs/prd/hosted-markdown-documents.md
@@ -1,0 +1,222 @@
+# Hosted Markdown Documents
+
+**Status:** PRD draft, 2026-06-15.
+
+**Owners:** Markdown document surface, Cloud/Auth, Desktop document hosting,
+shared editor/projection UI.
+
+This PRD defines the first-class Markdown document product surface for nteract.
+It promotes the product-facing parts of
+`docs/memos/markdown-plan-documents.md` into requirements while leaving low-level
+sync and storage decisions to ADRs and implementation plans.
+
+Related docs:
+
+- `docs/memos/markdown-plan-documents.md`
+- `docs/adr/identity-and-trust.md`
+- `docs/adr/hosted-room-authorization.md`
+- `docs/adr/hosted-output-origin-isolation.md`
+- `docs/adr/notebook-comments-document.md`
+- `docs/plans/notebook-surface-library-refactor-checklist.md`
+
+Prototype and shared component surfaces:
+
+- `src/lib/markdown-projection.ts`
+- `src/components/markdown/ProjectedMarkdownView.tsx`
+- `src/components/markdown/markdown-typography.ts`
+- `src/components/editor/codemirror-editor.tsx`
+- `apps/elements/content/docs/markdown-typography.mdx`
+
+## Problem
+
+nteract notebooks are live, executable documents with explicit runtime state.
+That is the right model for code, outputs, widgets, kernels, and workstations,
+but it is too much surface area for calm long-form Markdown authoring.
+
+Users and agents also need documents that do not require compute:
+
+- product and architecture notes;
+- ADR drafts and implementation plans;
+- collaborative prose with comments, outline, and source-aware review;
+- published read-only pages with stable links;
+- eventually, explicit output snapshots or component regions that are attached
+  artifacts rather than live execution.
+
+If Markdown documents are implemented as notebooks with one giant Markdown cell,
+the product inherits cell chrome, runtime affordances, notebook-specific
+presence targets, and runtime state confusion. If Cloud implements Markdown as a
+private route and Desktop stays notebook-only, nteract grows a second document
+protocol. The product needs a first-class document kind with shared source,
+projection, editor, and authorization concepts across Cloud and Desktop.
+
+## Goals
+
+1. Create a first-class Markdown document surface that does not imply kernels,
+   workstations, package management, or execution.
+2. Let Cloud users create, list, open, edit, share, and publish Markdown
+   documents with OIDC-backed identity and hosted ACLs.
+3. Let Desktop grow the same surface for local `.md` files, using the same
+   document model and shared React/projection code rather than a separate app
+   protocol.
+4. Reuse existing Markdown projection, typography, CodeMirror editor, outline,
+   presence, and security primitives where they fit.
+5. Preserve raw HTML and MDX safety boundaries by treating unapproved regions as
+   isolated or inert.
+6. Leave room for future comments, source-range review, output artifacts,
+   component artifacts, and MCP authoring tools without overbuilding them in
+   the first slice.
+
+## Non-Goals
+
+- This PRD does not make Markdown executable.
+- This PRD does not replace notebooks or turn notebooks into Markdown files.
+- This PRD does not enable arbitrary MDX JavaScript execution in the host app.
+- This PRD does not require all notebook sharing, publishing, or room protocol
+  code to become generic in the first PR.
+- This PRD does not require a separate repository or separately packaged app
+  before the document model is proven.
+- This PRD does not define the final comments protocol. It only requires that
+  document anchors and source ranges are compatible with a future comments
+  document.
+
+## Product Language
+
+| Term | Meaning |
+|------|---------|
+| Markdown document | A first-class nteract document whose source of truth is Markdown text plus document metadata and optional artifact references. |
+| MarkdownDoc | The shared logical document model for Markdown source, metadata, artifact references, and future comments identity. |
+| Rendered view | A zen reading view derived from Markdown projection. It has no cell rows and no runtime controls. |
+| Source view | A CodeMirror-backed Markdown editor for the same document body. |
+| Outline | A projection of headings from the current Markdown body. |
+| Published revision | A stable, read-only hosted snapshot of a Markdown document. |
+| Artifact reference | A durable reference from Markdown source or metadata to an attached output, component, image, or asset. |
+
+## Target Scenarios
+
+| Scenario | Expected behavior |
+|----------|-------------------|
+| Cloud owner creates a doc | Owner opens the hosted dashboard, creates a Markdown document, edits source, sees rendered view and outline update, and can rename/share/publish without compute UI. |
+| Cloud editor | Editor can open an invited Markdown document, edit body/title if allowed, and see the same projected rendered view. |
+| Cloud viewer | Viewer can read the rendered document and inspect safe source where product allows, but cannot mutate body, sharing, or publish state. |
+| Public published reader | Anonymous or signed-out reader can view only explicitly published/public content. Private body, comments, and collaborator identity do not leak through metadata. |
+| Desktop local author | User opens a `.md` file and gets the same source/rendered/outline shell, backed by local file sync rather than hosted ACLs. |
+| Agent collaborator | An authorized local or hosted agent can read and update Markdown source through the same document model as the UI, with principal/operator attribution when available. |
+
+## Requirements
+
+### Document Model
+
+1. Markdown documents must be first-class documents, not hidden notebooks.
+2. The logical source of truth is `MarkdownDoc.body`, an Automerge text value.
+   Frontmatter remains Markdown source when present.
+3. `MarkdownDoc` carries document metadata such as title and optional sidecar
+   identifiers. Derived facts such as headings and outline are projections, not
+   stored UI state.
+4. The shared model must be usable by both hosted Cloud documents and Desktop
+   `.md` files.
+5. Markdown body must be Automerge-backed. Hosted catalog rows may store
+   searchable summaries, titles, ACLs, and published revision metadata, but the
+   live body is not a D1 text column pretending to be collaborative state.
+6. Live body writes use text splices:
+   `splice_body(index, delete_count, text)`. Projection and export read the
+   current body through `body()` or `slice_body(start, end)`. Whole-body
+   replacement is import/bootstrap sugar only, not the steady-state editor
+   synchronization primitive.
+7. Exactly one authority creates the root MarkdownDoc structure for a document.
+   Other peers bootstrap an empty handle, receive the structure through
+   Automerge sync, then apply splices. This keeps document lineage meaningful
+   and avoids duplicate root object creation.
+8. A Desktop implementation must be able to map a canonical `.md` path to a
+   document room or equivalent live document session without treating the file
+   as `.ipynb`.
+
+### Editing And Rendering
+
+1. Source editing uses the shared CodeMirror editor stack and Markdown language
+   support.
+2. Rendered view uses the shared Markdown projection and
+   `ProjectedMarkdownView` typography where host-safe.
+3. Source and rendered modes operate on the same body value. Switching modes
+   must not remount the entire app shell unnecessarily.
+4. Source edits from CodeMirror are translated into MarkdownDoc body splices,
+   matching the existing notebook source-edit path. The UI must not diff and
+   replace the entire body on each keystroke.
+5. The outline is derived from projected headings and updates when the body
+   changes.
+6. The UI must remain useful at wide desktop, half-width desktop, tablet, and
+   mobile widths.
+7. The surface must not show runtime, workstation, kernel, dependency, run,
+   interrupt, restart, or output-clearing controls.
+
+### Cloud Hosting
+
+1. Cloud provides authenticated create/list/open routes for Markdown documents
+   under `/m`. `/n` remains the notebook route family.
+2. Cloud ACLs support owner, editor, and viewer scopes for Markdown documents.
+   Markdown documents do not have a `runtime_peer` scope.
+3. Owner can share a Markdown document with another principal through the same
+   identity/profile principles used by hosted notebooks.
+4. Owner can publish a read-only revision when publish is implemented for the
+   slice. Public access must be represented explicitly, not by falling through
+   to anonymous access.
+5. Dashboard and navigation should make Markdown documents visually distinct
+   from notebooks while preserving a coherent nteract document home.
+6. Private documents must not leak body content through public OG metadata,
+   screenshots, or unauthenticated route bootstrap data.
+
+### Desktop Local Files
+
+1. Desktop should be able to open `.md` files through a dedicated Markdown
+   document path, not by importing them into notebook cells by default.
+2. The local file path is the persistence anchor. External file changes should
+   be imported as document changes when safe.
+3. Saving writes Markdown body back to the `.md` file without adding notebook
+   metadata unless the user explicitly exports to another format.
+4. Desktop and Cloud should share editor, projection, outline, and rendered view
+   components. Host adapters own filesystem or hosted side effects.
+5. Desktop does not need hosted ACL or publish UI for local-only files, but the
+   same document model should allow future remote sync.
+
+### Security
+
+1. Raw HTML, MDX, and component-like regions are preserved but not host-executed
+   unless an approved component registry or isolated renderer exists.
+2. Rendered Markdown must not read app credentials, localStorage tokens,
+   cookies, or hosted room credentials.
+3. Public documents expose only explicitly public body/revision data.
+4. Agent and MCP write paths must use the same authorization model as UI edits.
+5. Artifact references must be explicit and content-addressed or otherwise
+   authority-checked before rendering private assets.
+
+### Future Comments And Artifacts
+
+1. Projection must preserve enough source positions and stable block anchors for
+   future comments on source ranges, headings, projected blocks, artifacts, and
+   components.
+2. Output snapshots are attached artifacts, not live execution. A code block may
+   later reference an output artifact with explicit metadata.
+3. Component artifacts and MDX-like regions remain future work until the
+   registry and sandbox model are defined.
+
+## Launch Criteria For First Usable Slice
+
+1. A user can create a hosted Markdown document from the app.
+2. A user can open the document, edit Markdown source, and see rendered view and
+   outline update.
+3. The document can be listed from a hosted document home or dashboard.
+4. An owner can grant at least viewer/editor access to another authenticated
+   principal, or the PR explicitly records the missing share slice as blocked by
+   existing sharing abstractions.
+5. The UI has no runtime/workstation/kernel affordances.
+6. The shared source/projection/editor pieces are used in a way Desktop can
+   consume for `.md` files.
+7. Focused route/projection tests and at least one browser smoke cover
+   create/open/edit/render behavior.
+
+## Open Questions
+
+1. How should Desktop resolve conflicts when an open `.md` file changes on
+   disk while the user is editing?
+2. Should comments become a generic `DocumentCommentsDoc`, or should Markdown
+   add a sibling comments document while notebook comments remain notebook
+   named?

--- a/docs/prd/hosted-markdown-documents.md
+++ b/docs/prd/hosted-markdown-documents.md
@@ -147,6 +147,15 @@ projection, editor, and authorization concepts across Cloud and Desktop.
    mobile widths.
 7. The surface must not show runtime, workstation, kernel, dependency, run,
    interrupt, restart, or output-clearing controls.
+8. View and edit modes share one document line. Rendered Markdown, editor
+   text, and future artifact regions should align to the same left gutter used
+   by notebook prose/code/output surfaces rather than switching between a
+   centered article layout and an editor layout.
+9. First paint should prefer safe local-first document bytes over older hosted
+   render seeds. A route may paint persisted Markdown bytes before the room
+   handshake only when local auth material can prove they belong to the same
+   principal; otherwise it waits for the hosted room and must not let a stale
+   seed overwrite newer live content.
 
 ### Cloud Hosting
 

--- a/docs/prd/hosted-markdown-documents.md
+++ b/docs/prd/hosted-markdown-documents.md
@@ -156,6 +156,13 @@ projection, editor, and authorization concepts across Cloud and Desktop.
    handshake only when local auth material can prove they belong to the same
    principal; otherwise it waits for the hosted room and must not let a stale
    seed overwrite newer live content.
+10. Document interaction mode and document representation are separate. The
+    shell-level `View` / `Edit` control describes whether the current principal
+    is reading or mutating the document. A Markdown-stage control may then
+    choose the representation of the same body, such as `Rendered`, `Source`,
+    or future side-by-side `Split`. Comments and rich editing must attach to
+    source ranges or projected block anchors from the same Automerge body, not
+    to a second stored rich-text document.
 
 ### Cloud Hosting
 

--- a/src/components/markdown/MarkdownDocumentModeToggle.tsx
+++ b/src/components/markdown/MarkdownDocumentModeToggle.tsx
@@ -1,4 +1,5 @@
-import { BookOpen, Code2, Columns2, PencilLine } from "lucide-react";
+import { BookOpen, Code2, Columns2 } from "lucide-react";
+import { NotebookEditModeButton } from "@/components/notebook/NotebookEditModeButton";
 import type {
   MarkdownDocumentMode,
   MarkdownDocumentRepresentation,
@@ -20,40 +21,28 @@ export function MarkdownDocumentModeToggle({
   className,
 }: MarkdownDocumentModeToggleProps) {
   return (
-    <div
+    <NotebookEditModeButton
+      ariaLabel="Markdown document mode"
       className={cn("markdown-document-mode-toggle", className)}
-      role="group"
-      aria-label="Markdown document mode"
-      data-slot="markdown-document-mode-toggle"
-    >
-      <button
-        type="button"
-        aria-pressed={mode === "view"}
-        title="View Markdown"
-        onClick={() => {
-          if (mode !== "view") {
-            onModeChange("view");
-          }
-        }}
-      >
-        <BookOpen aria-hidden="true" />
-        <span>View</span>
-      </button>
-      <button
-        type="button"
-        aria-pressed={mode === "edit"}
-        disabled={!canEdit}
-        title={canEdit ? "Edit Markdown" : "Editing requires edit access"}
-        onClick={() => {
-          if (canEdit && mode !== "edit") {
-            onModeChange("edit");
-          }
-        }}
-      >
-        <PencilLine aria-hidden="true" />
-        <span>Edit</span>
-      </button>
-    </div>
+      dataSlot="markdown-document-mode-toggle"
+      editDisabled={!canEdit}
+      editActiveTitle="Editing Markdown"
+      editLabel="Edit"
+      editTitle={canEdit ? "Edit Markdown" : "Editing requires edit access"}
+      mode={mode}
+      state={mode === "edit" && canEdit ? "editing" : "viewing"}
+      variant="segmented"
+      viewSegmentLabel="View"
+      viewTitle="View Markdown"
+      onModeChange={(nextMode) => {
+        if (nextMode === "edit" && !canEdit) {
+          return;
+        }
+        if (nextMode !== mode) {
+          onModeChange(nextMode);
+        }
+      }}
+    />
   );
 }
 

--- a/src/components/markdown/MarkdownDocumentModeToggle.tsx
+++ b/src/components/markdown/MarkdownDocumentModeToggle.tsx
@@ -1,5 +1,9 @@
-import { BookOpen, PencilLine } from "lucide-react";
-import type { MarkdownDocumentMode } from "@/lib/markdown-document";
+import { BookOpen, Code2, Columns2, PencilLine } from "lucide-react";
+import type {
+  MarkdownDocumentMode,
+  MarkdownDocumentRepresentation,
+  MarkdownDocumentRepresentationOption,
+} from "@/lib/markdown-document";
 import { cn } from "@/lib/utils";
 
 export interface MarkdownDocumentModeToggleProps {
@@ -49,6 +53,56 @@ export function MarkdownDocumentModeToggle({
         <PencilLine aria-hidden="true" />
         <span>Edit</span>
       </button>
+    </div>
+  );
+}
+
+const MARKDOWN_REPRESENTATION_ICONS = {
+  rendered: BookOpen,
+  source: Code2,
+  split: Columns2,
+} satisfies Record<MarkdownDocumentRepresentation, typeof BookOpen>;
+
+export interface MarkdownDocumentRepresentationToolbarProps {
+  active: MarkdownDocumentRepresentation;
+  options: readonly MarkdownDocumentRepresentationOption[];
+  onRepresentationChange: (representation: MarkdownDocumentRepresentation) => void;
+  className?: string;
+}
+
+export function MarkdownDocumentRepresentationToolbar({
+  active,
+  options,
+  onRepresentationChange,
+  className,
+}: MarkdownDocumentRepresentationToolbarProps) {
+  return (
+    <div
+      className={cn("markdown-document-representation-toolbar", className)}
+      role="group"
+      aria-label="Markdown representation"
+      data-slot="markdown-document-representation-toolbar"
+    >
+      {options.map((option) => {
+        const Icon = MARKDOWN_REPRESENTATION_ICONS[option.id];
+        return (
+          <button
+            key={option.id}
+            type="button"
+            aria-pressed={active === option.id}
+            disabled={option.disabled}
+            title={option.title}
+            onClick={() => {
+              if (!option.disabled && active !== option.id) {
+                onRepresentationChange(option.id);
+              }
+            }}
+          >
+            <Icon aria-hidden="true" />
+            <span>{option.label}</span>
+          </button>
+        );
+      })}
     </div>
   );
 }

--- a/src/components/markdown/MarkdownDocumentModeToggle.tsx
+++ b/src/components/markdown/MarkdownDocumentModeToggle.tsx
@@ -1,0 +1,54 @@
+import { BookOpen, PencilLine } from "lucide-react";
+import type { MarkdownDocumentMode } from "@/lib/markdown-document";
+import { cn } from "@/lib/utils";
+
+export interface MarkdownDocumentModeToggleProps {
+  mode: MarkdownDocumentMode;
+  canEdit: boolean;
+  onModeChange: (mode: MarkdownDocumentMode) => void;
+  className?: string;
+}
+
+export function MarkdownDocumentModeToggle({
+  mode,
+  canEdit,
+  onModeChange,
+  className,
+}: MarkdownDocumentModeToggleProps) {
+  return (
+    <div
+      className={cn("markdown-document-mode-toggle", className)}
+      role="group"
+      aria-label="Markdown document mode"
+      data-slot="markdown-document-mode-toggle"
+    >
+      <button
+        type="button"
+        aria-pressed={mode === "view"}
+        title="View Markdown"
+        onClick={() => {
+          if (mode !== "view") {
+            onModeChange("view");
+          }
+        }}
+      >
+        <BookOpen aria-hidden="true" />
+        <span>View</span>
+      </button>
+      <button
+        type="button"
+        aria-pressed={mode === "edit"}
+        disabled={!canEdit}
+        title={canEdit ? "Edit Markdown" : "Editing requires edit access"}
+        onClick={() => {
+          if (canEdit && mode !== "edit") {
+            onModeChange("edit");
+          }
+        }}
+      >
+        <PencilLine aria-hidden="true" />
+        <span>Edit</span>
+      </button>
+    </div>
+  );
+}

--- a/src/components/markdown/__tests__/MarkdownDocumentModeToggle.test.tsx
+++ b/src/components/markdown/__tests__/MarkdownDocumentModeToggle.test.tsx
@@ -1,6 +1,9 @@
 import { fireEvent, render, screen } from "@testing-library/react";
 import { describe, expect, it, vi } from "vite-plus/test";
-import { MarkdownDocumentModeToggle } from "../MarkdownDocumentModeToggle";
+import {
+  MarkdownDocumentModeToggle,
+  MarkdownDocumentRepresentationToolbar,
+} from "../MarkdownDocumentModeToggle";
 
 describe("MarkdownDocumentModeToggle", () => {
   it("switches from view to edit when editing is available", () => {
@@ -41,5 +44,76 @@ describe("MarkdownDocumentModeToggle", () => {
     fireEvent.click(editButton);
 
     expect(onModeChange).not.toHaveBeenCalled();
+  });
+});
+
+describe("MarkdownDocumentRepresentationToolbar", () => {
+  const options = [
+    {
+      id: "rendered" as const,
+      label: "Rendered",
+      title: "Show rendered Markdown",
+      disabled: false,
+    },
+    {
+      id: "source" as const,
+      label: "Source",
+      title: "Inspect Markdown source",
+      disabled: false,
+    },
+    {
+      id: "split" as const,
+      label: "Split",
+      title: "Side-by-side source and rendered Markdown is planned",
+      disabled: true,
+    },
+  ];
+
+  it("switches Markdown body representation", () => {
+    const onRepresentationChange = vi.fn();
+
+    render(
+      <MarkdownDocumentRepresentationToolbar
+        active="rendered"
+        options={options}
+        onRepresentationChange={onRepresentationChange}
+      />,
+    );
+
+    expect(screen.getByRole("group", { name: "Markdown representation" })).toHaveAttribute(
+      "data-slot",
+      "markdown-document-representation-toolbar",
+    );
+    expect(screen.getByRole("button", { name: "Rendered" })).toHaveAttribute(
+      "aria-pressed",
+      "true",
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "Source" }));
+
+    expect(onRepresentationChange).toHaveBeenCalledWith("source");
+  });
+
+  it("leaves planned split mode disabled", () => {
+    const onRepresentationChange = vi.fn();
+
+    render(
+      <MarkdownDocumentRepresentationToolbar
+        active="source"
+        options={options}
+        onRepresentationChange={onRepresentationChange}
+      />,
+    );
+
+    const splitButton = screen.getByRole("button", { name: "Split" });
+    expect(splitButton).toBeDisabled();
+    expect(splitButton).toHaveAttribute(
+      "title",
+      "Side-by-side source and rendered Markdown is planned",
+    );
+
+    fireEvent.click(splitButton);
+
+    expect(onRepresentationChange).not.toHaveBeenCalled();
   });
 });

--- a/src/components/markdown/__tests__/MarkdownDocumentModeToggle.test.tsx
+++ b/src/components/markdown/__tests__/MarkdownDocumentModeToggle.test.tsx
@@ -1,0 +1,45 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vite-plus/test";
+import { MarkdownDocumentModeToggle } from "../MarkdownDocumentModeToggle";
+
+describe("MarkdownDocumentModeToggle", () => {
+  it("switches from view to edit when editing is available", () => {
+    const onModeChange = vi.fn();
+
+    render(<MarkdownDocumentModeToggle mode="view" canEdit onModeChange={onModeChange} />);
+
+    expect(screen.getByRole("group", { name: "Markdown document mode" })).toHaveAttribute(
+      "data-slot",
+      "markdown-document-mode-toggle",
+    );
+    expect(screen.getByRole("button", { name: "View" })).toHaveAttribute("aria-pressed", "true");
+
+    fireEvent.click(screen.getByRole("button", { name: "Edit" }));
+
+    expect(onModeChange).toHaveBeenCalledWith("edit");
+  });
+
+  it("does not emit an event for the current mode", () => {
+    const onModeChange = vi.fn();
+
+    render(<MarkdownDocumentModeToggle mode="edit" canEdit onModeChange={onModeChange} />);
+
+    fireEvent.click(screen.getByRole("button", { name: "Edit" }));
+
+    expect(onModeChange).not.toHaveBeenCalled();
+  });
+
+  it("keeps edit disabled for read-only collaborators", () => {
+    const onModeChange = vi.fn();
+
+    render(<MarkdownDocumentModeToggle mode="view" canEdit={false} onModeChange={onModeChange} />);
+
+    const editButton = screen.getByRole("button", { name: "Edit" });
+    expect(editButton).toBeDisabled();
+    expect(editButton).toHaveAttribute("title", "Editing requires edit access");
+
+    fireEvent.click(editButton);
+
+    expect(onModeChange).not.toHaveBeenCalled();
+  });
+});

--- a/src/components/notebook-rail/NotebookRail.tsx
+++ b/src/components/notebook-rail/NotebookRail.tsx
@@ -121,6 +121,7 @@ export interface NotebookOutlinePanelProps {
   activeItemId?: string | null;
   selectedItemId?: string | null;
   selectedCellId?: string | null;
+  emptyMessage?: string;
   onSelectItem?: (item: NotebookOutlineItem) => void;
   onNavigateItem?: (item: NotebookOutlineItem, href: string) => boolean | void;
   getItemHref?: (item: NotebookOutlineItem) => string | null | undefined;
@@ -132,6 +133,7 @@ export function NotebookOutlinePanel({
   activeItemId = null,
   selectedItemId = null,
   selectedCellId = null,
+  emptyMessage = "Add Markdown headings to structure your notebook. They will appear here.",
   onSelectItem,
   onNavigateItem,
   getItemHref,
@@ -141,7 +143,7 @@ export function NotebookOutlinePanel({
   if (items.length === 0) {
     return (
       <div className="rounded-md border border-dashed px-3 py-4 text-sm text-muted-foreground">
-        Add Markdown headings to structure your notebook. They will appear here.
+        {emptyMessage}
       </div>
     );
   }

--- a/src/components/notebook-rail/NotebookRail.tsx
+++ b/src/components/notebook-rail/NotebookRail.tsx
@@ -121,6 +121,7 @@ export interface NotebookOutlinePanelProps {
   activeItemId?: string | null;
   selectedItemId?: string | null;
   selectedCellId?: string | null;
+  ariaLabel?: string;
   emptyMessage?: string;
   onSelectItem?: (item: NotebookOutlineItem) => void;
   onNavigateItem?: (item: NotebookOutlineItem, href: string) => boolean | void;
@@ -133,6 +134,7 @@ export function NotebookOutlinePanel({
   activeItemId = null,
   selectedItemId = null,
   selectedCellId = null,
+  ariaLabel = "Notebook outline",
   emptyMessage = "Add Markdown headings to structure your notebook. They will appear here.",
   onSelectItem,
   onNavigateItem,
@@ -162,7 +164,7 @@ export function NotebookOutlinePanel({
 
   return (
     <nav
-      aria-label="Notebook outline"
+      aria-label={ariaLabel}
       className="-ml-1"
       data-testid="notebook-outline-panel"
       data-drag-policy="navigation-only"

--- a/src/components/notebook-rail/__tests__/NotebookRail.test.tsx
+++ b/src/components/notebook-rail/__tests__/NotebookRail.test.tsx
@@ -4,6 +4,7 @@ import {
   NOTEBOOK_RAIL_TAKEOVER_MEDIA_QUERY,
   NOTEBOOK_RAIL_TAKEOVER_PANEL_CLASS_NAMES,
   NOTEBOOK_RAIL_TAKEOVER_STAGE_CLASS_NAME,
+  NotebookOutlinePanel,
   NotebookPackagesPanel,
   NotebookRail,
 } from "../NotebookRail";
@@ -85,6 +86,12 @@ describe("NotebookRail", () => {
 
     fireEvent.click(screen.getByRole("link", { name: "Clean columns" }));
     expect(onSelectOutlineItem).toHaveBeenCalledWith(outlineItems[1]);
+  });
+
+  it("allows non-notebook hosts to name the outline navigation", () => {
+    render(<NotebookOutlinePanel items={outlineItems} ariaLabel="Document outline" />);
+
+    expect(screen.getByRole("navigation", { name: "Document outline" })).toBeVisible();
   });
 
   it("switches to packages without owning package-management state", () => {

--- a/src/components/notebook/DocumentTitle.tsx
+++ b/src/components/notebook/DocumentTitle.tsx
@@ -5,6 +5,7 @@ import {
   useState,
   type ClipboardEvent,
   type KeyboardEvent,
+  type MouseEvent,
   type ReactNode,
 } from "react";
 import { Check, Loader2, PencilLine, X } from "lucide-react";
@@ -33,6 +34,7 @@ export interface DocumentTitleProps {
   homeAriaLabel?: string;
   homeHref?: string;
   homeIcon?: ReactNode;
+  onHomeClick?: (event: MouseEvent<HTMLAnchorElement>) => void;
   homeTitle?: string;
   inputAriaLabel?: string;
   inputName?: string;
@@ -51,6 +53,7 @@ export function DocumentTitle({
   homeAriaLabel = "Open documents",
   homeHref,
   homeIcon,
+  onHomeClick,
   homeTitle = "Documents",
   inputAriaLabel = "Document title",
   inputName = "document-title",
@@ -170,6 +173,7 @@ export function DocumentTitle({
           href={homeHref}
           aria-label={homeAriaLabel}
           title={homeTitle}
+          onClick={onHomeClick}
         >
           {homeIcon}
         </a>

--- a/src/components/notebook/DocumentTitle.tsx
+++ b/src/components/notebook/DocumentTitle.tsx
@@ -1,0 +1,166 @@
+import { useEffect, useState, type FormEvent, type ReactNode } from "react";
+import { Check, Loader2, PencilLine, X } from "lucide-react";
+import { cn } from "@/lib/utils";
+
+export interface DocumentTitleDisplay {
+  label: string;
+  detail: string | null;
+  title: string;
+}
+
+export interface DocumentTitleClassNames {
+  group?: string;
+  homeLink?: string;
+  title?: string;
+  staticTitle?: string;
+  form?: string;
+  editButton?: string;
+  status?: string;
+  spinner?: string;
+}
+
+export interface DocumentTitleProps {
+  canRename?: boolean;
+  classNames?: DocumentTitleClassNames;
+  homeAriaLabel?: string;
+  homeHref?: string;
+  homeIcon?: ReactNode;
+  homeTitle?: string;
+  inputAriaLabel?: string;
+  inputName?: string;
+  placeholder?: string;
+  renameButtonTitle?: string;
+  renameError?: string | null;
+  renameSaving?: boolean;
+  renameTitle: string;
+  title: DocumentTitleDisplay;
+  onRename?: (title: string) => boolean | Promise<boolean>;
+}
+
+export function DocumentTitle({
+  canRename = false,
+  classNames,
+  homeAriaLabel = "Open documents",
+  homeHref,
+  homeIcon,
+  homeTitle = "Documents",
+  inputAriaLabel = "Document title",
+  inputName = "document-title",
+  placeholder = "Untitled document",
+  renameButtonTitle = "Rename document",
+  renameError = null,
+  renameSaving = false,
+  renameTitle,
+  title,
+  onRename,
+}: DocumentTitleProps) {
+  const [editing, setEditing] = useState(false);
+  const [draftTitle, setDraftTitle] = useState(renameTitle);
+
+  useEffect(() => {
+    if (!editing) {
+      setDraftTitle(renameTitle);
+    }
+  }, [editing, renameTitle]);
+
+  const saveRename = (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    if (!onRename || renameSaving) {
+      return;
+    }
+    void Promise.resolve(onRename(draftTitle))
+      .then((saved) => {
+        if (saved) {
+          setEditing(false);
+        }
+      })
+      .catch(() => {});
+  };
+
+  const cancelRename = () => {
+    if (renameSaving) {
+      return;
+    }
+    setDraftTitle(renameTitle);
+    setEditing(false);
+  };
+
+  return (
+    <div className={cn("document-title-group", classNames?.group)}>
+      {homeHref ? (
+        <a
+          className={cn("document-title-home-link", classNames?.homeLink)}
+          href={homeHref}
+          aria-label={homeAriaLabel}
+          title={homeTitle}
+        >
+          {homeIcon}
+        </a>
+      ) : null}
+      <div className={cn("document-title", classNames?.title)} title={renameError ?? title.title}>
+        {editing ? (
+          <form className={cn("document-title-form", classNames?.form)} onSubmit={saveRename}>
+            <input
+              aria-label={inputAriaLabel}
+              autoFocus
+              disabled={renameSaving}
+              maxLength={160}
+              name={inputName}
+              placeholder={placeholder}
+              type="text"
+              value={draftTitle}
+              onChange={(event) => setDraftTitle(event.currentTarget.value)}
+            />
+            <button
+              type="submit"
+              disabled={renameSaving}
+              title="Save title"
+              aria-label="Save title"
+            >
+              {renameSaving ? (
+                <Loader2
+                  className={cn("document-title-spinner", classNames?.spinner)}
+                  aria-hidden="true"
+                />
+              ) : (
+                <Check aria-hidden="true" />
+              )}
+            </button>
+            <button
+              type="button"
+              disabled={renameSaving}
+              title="Cancel rename"
+              aria-label="Cancel rename"
+              onClick={cancelRename}
+            >
+              <X aria-hidden="true" />
+            </button>
+          </form>
+        ) : (
+          <div className={cn("document-title-static", classNames?.staticTitle)}>
+            <span>{title.label}</span>
+            {canRename && onRename ? (
+              <button
+                type="button"
+                className={cn("document-title-edit-button", classNames?.editButton)}
+                disabled={renameSaving}
+                title={renameButtonTitle}
+                aria-label={`Rename ${title.label}`}
+                onClick={() => setEditing(true)}
+              >
+                <PencilLine aria-hidden="true" />
+              </button>
+            ) : null}
+          </div>
+        )}
+        {renameError ? (
+          <small className={cn("document-title-status", classNames?.status)} role="status">
+            {renameError}
+          </small>
+        ) : title.detail ? (
+          <small>{title.detail}</small>
+        ) : null}
+      </div>
+    </div>
+  );
+}

--- a/src/components/notebook/DocumentTitle.tsx
+++ b/src/components/notebook/DocumentTitle.tsx
@@ -66,6 +66,7 @@ export function DocumentTitle({
   const [editing, setEditing] = useState(false);
   const [draftTitle, setDraftTitle] = useState(renameTitle);
   const editableRef = useRef<HTMLSpanElement | null>(null);
+  const canShowRename = canRename && Boolean(onRename);
 
   useEffect(() => {
     if (!editing) {
@@ -150,66 +151,76 @@ export function DocumentTitle({
         </a>
       ) : null}
       <div className={cn("document-title", classNames?.title)} title={renameError ?? title.title}>
-        {editing ? (
-          <form className={cn("document-title-form", classNames?.form)} onSubmit={saveRename}>
-            <span
-              aria-label={inputAriaLabel}
-              aria-disabled={renameSaving}
-              contentEditable={!renameSaving}
-              data-name={inputName}
-              data-placeholder={placeholder}
-              onInput={updateDraftFromEditable}
-              onKeyDown={handleEditableKeyDown}
-              onPaste={handleEditablePaste}
-              ref={editableRef}
-              role="textbox"
-              spellCheck="true"
-              suppressContentEditableWarning
-            >
-              {draftTitle}
-            </span>
-            <button
-              type="submit"
-              disabled={renameSaving}
-              title="Save title"
-              aria-label="Save title"
-            >
-              {renameSaving ? (
-                <Loader2
-                  className={cn("document-title-spinner", classNames?.spinner)}
-                  aria-hidden="true"
-                />
+        <form
+          className={cn("document-title-form", classNames?.form)}
+          data-editing={editing ? "true" : "false"}
+          onSubmit={saveRename}
+        >
+          <span
+            aria-disabled={editing ? renameSaving : undefined}
+            aria-label={editing ? inputAriaLabel : undefined}
+            className={cn(!editing && classNames?.staticTitle)}
+            contentEditable={editing && !renameSaving}
+            data-name={editing ? inputName : undefined}
+            data-placeholder={placeholder}
+            data-slot="document-title-label"
+            onInput={editing ? updateDraftFromEditable : undefined}
+            onKeyDown={editing ? handleEditableKeyDown : undefined}
+            onPaste={editing ? handleEditablePaste : undefined}
+            ref={editableRef}
+            role={editing ? "textbox" : undefined}
+            spellCheck={editing ? "true" : undefined}
+            suppressContentEditableWarning
+          >
+            {editing ? draftTitle : title.label}
+          </span>
+          {canShowRename ? (
+            <span className="document-title-actions" data-slot="document-title-actions">
+              {editing ? (
+                <>
+                  <button
+                    type="submit"
+                    disabled={renameSaving}
+                    title="Save title"
+                    aria-label="Save title"
+                  >
+                    {renameSaving ? (
+                      <Loader2
+                        className={cn("document-title-spinner", classNames?.spinner)}
+                        aria-hidden="true"
+                      />
+                    ) : (
+                      <Check aria-hidden="true" />
+                    )}
+                  </button>
+                  <button
+                    type="button"
+                    disabled={renameSaving}
+                    title="Cancel rename"
+                    aria-label="Cancel rename"
+                    onClick={cancelRename}
+                  >
+                    <X aria-hidden="true" />
+                  </button>
+                </>
               ) : (
-                <Check aria-hidden="true" />
+                <>
+                  <button
+                    type="button"
+                    className={cn("document-title-edit-button", classNames?.editButton)}
+                    disabled={renameSaving}
+                    title={renameButtonTitle}
+                    aria-label={`Rename ${title.label}`}
+                    onClick={() => setEditing(true)}
+                  >
+                    <PencilLine aria-hidden="true" />
+                  </button>
+                  <span className="document-title-action-placeholder" aria-hidden="true" />
+                </>
               )}
-            </button>
-            <button
-              type="button"
-              disabled={renameSaving}
-              title="Cancel rename"
-              aria-label="Cancel rename"
-              onClick={cancelRename}
-            >
-              <X aria-hidden="true" />
-            </button>
-          </form>
-        ) : (
-          <div className={cn("document-title-static", classNames?.staticTitle)}>
-            <span>{title.label}</span>
-            {canRename && onRename ? (
-              <button
-                type="button"
-                className={cn("document-title-edit-button", classNames?.editButton)}
-                disabled={renameSaving}
-                title={renameButtonTitle}
-                aria-label={`Rename ${title.label}`}
-                onClick={() => setEditing(true)}
-              >
-                <PencilLine aria-hidden="true" />
-              </button>
-            ) : null}
-          </div>
-        )}
+            </span>
+          ) : null}
+        </form>
         {renameError ? (
           <small className={cn("document-title-status", classNames?.status)} role="status">
             {renameError}

--- a/src/components/notebook/DocumentTitle.tsx
+++ b/src/components/notebook/DocumentTitle.tsx
@@ -157,7 +157,7 @@ export function DocumentTitle({
           onSubmit={saveRename}
         >
           <span
-            aria-disabled={editing ? renameSaving : undefined}
+            aria-disabled={editing && renameSaving ? true : undefined}
             aria-label={editing ? inputAriaLabel : undefined}
             className={cn(!editing && classNames?.staticTitle)}
             contentEditable={editing && !renameSaving}

--- a/src/components/notebook/DocumentTitle.tsx
+++ b/src/components/notebook/DocumentTitle.tsx
@@ -4,7 +4,6 @@ import {
   useRef,
   useState,
   type ClipboardEvent,
-  type FormEvent,
   type KeyboardEvent,
   type ReactNode,
 } from "react";
@@ -83,21 +82,39 @@ export function DocumentTitle({
     placeCaretAtEnd(editable);
   }, [editing]);
 
+  const beginEditing = () => {
+    if (!canShowRename || renameSaving) {
+      return;
+    }
+    setDraftTitle(renameTitle);
+    setEditing(true);
+  };
+
   const commitRename = (titleDraft = draftTitle) => {
     if (!onRename || renameSaving) {
       return;
     }
-    void Promise.resolve(onRename(normalizeTitleDraft(titleDraft)))
-      .then((saved) => {
-        if (saved) {
+    try {
+      const result = onRename(normalizeTitleDraft(titleDraft));
+      if (typeof result === "boolean") {
+        if (result) {
           setEditing(false);
         }
-      })
-      .catch(() => {});
+        return;
+      }
+      void result
+        .then((saved) => {
+          if (saved) {
+            setEditing(false);
+          }
+        })
+        .catch(() => {});
+    } catch {
+      // The host owns rename error state; keep editing so the user can retry.
+    }
   };
 
-  const saveRename = (event: FormEvent<HTMLFormElement>) => {
-    event.preventDefault();
+  const saveRename = () => {
     commitRename(updateDraftFromEditable());
   };
 
@@ -131,6 +148,13 @@ export function DocumentTitle({
     }
   };
 
+  const handleStaticTitleKeyDown = (event: KeyboardEvent<HTMLSpanElement>) => {
+    if (event.key === "Enter" || event.key === " ") {
+      event.preventDefault();
+      beginEditing();
+    }
+  };
+
   const handleEditablePaste = (event: ClipboardEvent<HTMLSpanElement>) => {
     event.preventDefault();
     const text = normalizeTitleDraft(event.clipboardData.getData("text/plain"));
@@ -151,10 +175,9 @@ export function DocumentTitle({
         </a>
       ) : null}
       <div className={cn("document-title", classNames?.title)} title={renameError ?? title.title}>
-        <form
+        <div
           className={cn("document-title-form", classNames?.form)}
           data-editing={editing ? "true" : "false"}
-          onSubmit={saveRename}
         >
           <span
             aria-disabled={editing && renameSaving ? true : undefined}
@@ -163,14 +186,17 @@ export function DocumentTitle({
             contentEditable={editing && !renameSaving}
             data-name={editing ? inputName : undefined}
             data-placeholder={placeholder}
+            data-renameable={!editing && canShowRename ? "true" : undefined}
             data-slot="document-title-label"
+            onClick={!editing && canShowRename ? beginEditing : undefined}
             onInput={editing ? updateDraftFromEditable : undefined}
-            onKeyDown={editing ? handleEditableKeyDown : undefined}
+            onKeyDown={editing ? handleEditableKeyDown : handleStaticTitleKeyDown}
             onPaste={editing ? handleEditablePaste : undefined}
             ref={editableRef}
-            role={editing ? "textbox" : undefined}
+            role={editing ? "textbox" : canShowRename ? "button" : undefined}
             spellCheck={editing ? "true" : undefined}
             suppressContentEditableWarning
+            tabIndex={editing || canShowRename ? 0 : undefined}
           >
             {editing ? draftTitle : title.label}
           </span>
@@ -179,10 +205,11 @@ export function DocumentTitle({
               {editing ? (
                 <>
                   <button
-                    type="submit"
+                    type="button"
                     disabled={renameSaving}
                     title="Save title"
                     aria-label="Save title"
+                    onClick={saveRename}
                   >
                     {renameSaving ? (
                       <Loader2
@@ -211,7 +238,7 @@ export function DocumentTitle({
                     disabled={renameSaving}
                     title={renameButtonTitle}
                     aria-label={`Rename ${title.label}`}
-                    onClick={() => setEditing(true)}
+                    onClick={beginEditing}
                   >
                     <PencilLine aria-hidden="true" />
                   </button>
@@ -220,7 +247,7 @@ export function DocumentTitle({
               )}
             </span>
           ) : null}
-        </form>
+        </div>
         {renameError ? (
           <small className={cn("document-title-status", classNames?.status)} role="status">
             {renameError}

--- a/src/components/notebook/DocumentTitle.tsx
+++ b/src/components/notebook/DocumentTitle.tsx
@@ -1,4 +1,13 @@
-import { useEffect, useState, type FormEvent, type ReactNode } from "react";
+import {
+  useEffect,
+  useLayoutEffect,
+  useRef,
+  useState,
+  type ClipboardEvent,
+  type FormEvent,
+  type KeyboardEvent,
+  type ReactNode,
+} from "react";
 import { Check, Loader2, PencilLine, X } from "lucide-react";
 import { cn } from "@/lib/utils";
 
@@ -56,6 +65,7 @@ export function DocumentTitle({
 }: DocumentTitleProps) {
   const [editing, setEditing] = useState(false);
   const [draftTitle, setDraftTitle] = useState(renameTitle);
+  const editableRef = useRef<HTMLSpanElement | null>(null);
 
   useEffect(() => {
     if (!editing) {
@@ -63,12 +73,20 @@ export function DocumentTitle({
     }
   }, [editing, renameTitle]);
 
-  const saveRename = (event: FormEvent<HTMLFormElement>) => {
-    event.preventDefault();
+  useLayoutEffect(() => {
+    if (!editing || !editableRef.current) {
+      return;
+    }
+    const editable = editableRef.current;
+    editable.focus();
+    placeCaretAtEnd(editable);
+  }, [editing]);
+
+  const commitRename = (titleDraft = draftTitle) => {
     if (!onRename || renameSaving) {
       return;
     }
-    void Promise.resolve(onRename(draftTitle))
+    void Promise.resolve(onRename(normalizeTitleDraft(titleDraft)))
       .then((saved) => {
         if (saved) {
           setEditing(false);
@@ -77,12 +95,46 @@ export function DocumentTitle({
       .catch(() => {});
   };
 
+  const saveRename = (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    commitRename(updateDraftFromEditable());
+  };
+
   const cancelRename = () => {
     if (renameSaving) {
       return;
     }
     setDraftTitle(renameTitle);
     setEditing(false);
+  };
+
+  const updateDraftFromEditable = (): string => {
+    const nextTitle = editableTitleDraft(editableRef.current?.textContent ?? "");
+    if ((editableRef.current?.textContent ?? "") !== nextTitle && editableRef.current) {
+      editableRef.current.textContent = nextTitle;
+      placeCaretAtEnd(editableRef.current);
+    }
+    setDraftTitle(nextTitle);
+    return nextTitle;
+  };
+
+  const handleEditableKeyDown = (event: KeyboardEvent<HTMLSpanElement>) => {
+    if (event.key === "Enter") {
+      event.preventDefault();
+      commitRename(updateDraftFromEditable());
+      return;
+    }
+    if (event.key === "Escape") {
+      event.preventDefault();
+      cancelRename();
+    }
+  };
+
+  const handleEditablePaste = (event: ClipboardEvent<HTMLSpanElement>) => {
+    event.preventDefault();
+    const text = normalizeTitleDraft(event.clipboardData.getData("text/plain"));
+    insertPlainTextAtSelection(event.currentTarget, text);
+    updateDraftFromEditable();
   };
 
   return (
@@ -100,17 +152,22 @@ export function DocumentTitle({
       <div className={cn("document-title", classNames?.title)} title={renameError ?? title.title}>
         {editing ? (
           <form className={cn("document-title-form", classNames?.form)} onSubmit={saveRename}>
-            <input
+            <span
               aria-label={inputAriaLabel}
-              autoFocus
-              disabled={renameSaving}
-              maxLength={160}
-              name={inputName}
-              placeholder={placeholder}
-              type="text"
-              value={draftTitle}
-              onChange={(event) => setDraftTitle(event.currentTarget.value)}
-            />
+              aria-disabled={renameSaving}
+              contentEditable={!renameSaving}
+              data-name={inputName}
+              data-placeholder={placeholder}
+              onInput={updateDraftFromEditable}
+              onKeyDown={handleEditableKeyDown}
+              onPaste={handleEditablePaste}
+              ref={editableRef}
+              role="textbox"
+              spellCheck="true"
+              suppressContentEditableWarning
+            >
+              {draftTitle}
+            </span>
             <button
               type="submit"
               disabled={renameSaving}
@@ -163,4 +220,39 @@ export function DocumentTitle({
       </div>
     </div>
   );
+}
+
+function normalizeTitleDraft(value: string): string {
+  return editableTitleDraft(value).trim();
+}
+
+function editableTitleDraft(value: string): string {
+  return value.replace(/[\r\n]+/g, " ").slice(0, 160);
+}
+
+function placeCaretAtEnd(editable: HTMLElement): void {
+  const selection = window.getSelection();
+  if (!selection) {
+    return;
+  }
+  const range = document.createRange();
+  range.selectNodeContents(editable);
+  range.collapse(false);
+  selection.removeAllRanges();
+  selection.addRange(range);
+}
+
+function insertPlainTextAtSelection(editable: HTMLElement, text: string): void {
+  const selection = window.getSelection();
+  if (!selection || selection.rangeCount === 0 || !editable.contains(selection.anchorNode)) {
+    editable.textContent = editableTitleDraft(`${editable.textContent ?? ""}${text}`);
+    placeCaretAtEnd(editable);
+    return;
+  }
+  const range = selection.getRangeAt(0);
+  range.deleteContents();
+  range.insertNode(document.createTextNode(text));
+  range.collapse(false);
+  selection.removeAllRanges();
+  selection.addRange(range);
 }

--- a/src/components/notebook/NotebookEditModeButton.tsx
+++ b/src/components/notebook/NotebookEditModeButton.tsx
@@ -9,24 +9,38 @@ export interface NotebookEditModeButtonProps {
   mode: NotebookEditMode;
   state: NotebookEditModeState;
   onModeChange: (mode: NotebookEditMode) => void;
+  ariaLabel?: string;
+  dataSlot?: string;
   disabled?: boolean;
+  editDisabled?: boolean;
+  editActiveTitle?: string;
   editLabel?: string;
   editTitle?: string;
   requestedEditLabel?: string;
   requestedEditTitle?: string;
+  viewLabel?: string;
+  viewSegmentLabel?: string;
+  viewTitle?: string;
   variant?: "button" | "segmented";
   className?: string;
 }
 
 export function NotebookEditModeButton({
+  ariaLabel = "Notebook interaction mode",
   className,
+  dataSlot = "notebook-edit-mode-button",
   disabled = false,
+  editDisabled = false,
+  editActiveTitle = "Editing notebook",
   editLabel: editLabelProp,
   editTitle = "Switch to edit mode",
   mode,
   onModeChange,
   requestedEditLabel = "Request sent",
   requestedEditTitle = "Edit access requested",
+  viewLabel = "View",
+  viewSegmentLabel = "Viewing",
+  viewTitle = "View notebook",
   state,
   variant = "button",
 }: NotebookEditModeButtonProps) {
@@ -51,8 +65,8 @@ export function NotebookEditModeButton({
           className,
         )}
         role="group"
-        aria-label="Notebook interaction mode"
-        data-slot="notebook-edit-mode-button"
+        aria-label={ariaLabel}
+        data-slot={dataSlot}
         data-state={state}
         data-variant={variant}
       >
@@ -64,7 +78,7 @@ export function NotebookEditModeButton({
             mode === "view" && "bg-background text-foreground shadow-sm",
           )}
           disabled={disabled}
-          title="View notebook"
+          title={viewTitle}
           onClick={() => {
             if (mode !== "view") {
               onModeChange("view");
@@ -73,7 +87,7 @@ export function NotebookEditModeButton({
         >
           <BookOpen className="size-3.5 shrink-0" aria-hidden="true" />
           <span className="sr-only sm:not-sr-only sm:min-w-0 sm:truncate sm:leading-none">
-            Viewing
+            {viewSegmentLabel}
           </span>
         </button>
         <button
@@ -86,13 +100,9 @@ export function NotebookEditModeButton({
                 ? "bg-background text-emerald-700 shadow-sm dark:text-emerald-300"
                 : "bg-background text-amber-700 shadow-sm dark:text-amber-300"),
           )}
-          disabled={disabled}
+          disabled={disabled || editDisabled}
           title={
-            state === "editing"
-              ? "Editing notebook"
-              : requestedEdit
-                ? requestedEditTitle
-                : editTitle
+            state === "editing" ? editActiveTitle : requestedEdit ? requestedEditTitle : editTitle
           }
           onClick={() => {
             if (mode !== "edit") {
@@ -123,10 +133,10 @@ export function NotebookEditModeButton({
         state === "requested" && "border-ring/50 text-foreground",
         className,
       )}
-      data-slot="notebook-edit-mode-button"
+      data-slot={dataSlot}
       data-state={state}
       data-variant={variant}
-      disabled={disabled}
+      disabled={disabled || (editDisabled && !requestingEdit)}
       title={title}
       onClick={() => onModeChange(nextMode)}
     >
@@ -135,7 +145,7 @@ export function NotebookEditModeButton({
       ) : (
         <Pencil className="size-4 shrink-0" aria-hidden="true" />
       )}
-      <span className="min-w-0 truncate leading-none">{label}</span>
+      <span className="min-w-0 truncate leading-none">{requestingEdit ? viewLabel : label}</span>
     </button>
   );
 }

--- a/src/components/notebook/__tests__/DocumentTitle.test.tsx
+++ b/src/components/notebook/__tests__/DocumentTitle.test.tsx
@@ -21,6 +21,7 @@ describe("DocumentTitle", () => {
     const editable = screen.getByRole("textbox", { name: "Document title" });
     expect(editable).toBe(titleNode);
     expect(editable).toHaveAttribute("contenteditable", "true");
+    expect(editable).not.toHaveAttribute("aria-disabled");
 
     editable.textContent = "Renamed";
     fireEvent.input(editable);

--- a/src/components/notebook/__tests__/DocumentTitle.test.tsx
+++ b/src/components/notebook/__tests__/DocumentTitle.test.tsx
@@ -15,9 +15,11 @@ describe("DocumentTitle", () => {
       />,
     );
 
+    const titleNode = screen.getByText("Existing");
     fireEvent.click(screen.getByRole("button", { name: "Rename Existing" }));
 
     const editable = screen.getByRole("textbox", { name: "Document title" });
+    expect(editable).toBe(titleNode);
     expect(editable).toHaveAttribute("contenteditable", "true");
 
     editable.textContent = "Renamed";

--- a/src/components/notebook/__tests__/DocumentTitle.test.tsx
+++ b/src/components/notebook/__tests__/DocumentTitle.test.tsx
@@ -3,6 +3,44 @@ import { describe, expect, it, vi } from "vite-plus/test";
 import { DocumentTitle } from "../DocumentTitle";
 
 describe("DocumentTitle", () => {
+  it("starts title editing from the title text itself", () => {
+    const onRename = vi.fn().mockResolvedValue(true);
+
+    render(
+      <DocumentTitle
+        canRename
+        renameTitle="Existing"
+        title={{ label: "Existing", detail: null, title: "Existing" }}
+        onRename={onRename}
+      />,
+    );
+
+    const titleNode = screen.getByRole("button", { name: "Existing" });
+    fireEvent.click(titleNode);
+
+    expect(screen.getByRole("textbox", { name: "Document title" })).toBe(titleNode);
+    expect(onRename).not.toHaveBeenCalled();
+  });
+
+  it("starts title editing from the keyboard on the title text", () => {
+    const onRename = vi.fn().mockResolvedValue(true);
+
+    render(
+      <DocumentTitle
+        canRename
+        renameTitle="Existing"
+        title={{ label: "Existing", detail: null, title: "Existing" }}
+        onRename={onRename}
+      />,
+    );
+
+    const titleNode = screen.getByRole("button", { name: "Existing" });
+    fireEvent.keyDown(titleNode, { key: "Enter" });
+
+    expect(screen.getByRole("textbox", { name: "Document title" })).toBe(titleNode);
+    expect(onRename).not.toHaveBeenCalled();
+  });
+
   it("renames from an inline contenteditable title field", async () => {
     const onRename = vi.fn().mockResolvedValue(true);
 
@@ -31,6 +69,29 @@ describe("DocumentTitle", () => {
     await waitFor(() => {
       expect(screen.queryByRole("textbox", { name: "Document title" })).toBeNull();
     });
+  });
+
+  it("closes inline title editing immediately when rename saves synchronously", () => {
+    const onRename = vi.fn().mockReturnValue(true);
+
+    render(
+      <DocumentTitle
+        canRename
+        renameTitle="Existing"
+        title={{ label: "Existing", detail: null, title: "Existing" }}
+        onRename={onRename}
+      />,
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "Existing" }));
+
+    const editable = screen.getByRole("textbox", { name: "Document title" });
+    editable.textContent = "Renamed";
+    fireEvent.input(editable);
+    fireEvent.keyDown(editable, { key: "Enter" });
+
+    expect(onRename).toHaveBeenCalledWith("Renamed");
+    expect(screen.queryByRole("textbox", { name: "Document title" })).toBeNull();
   });
 
   it("cancels inline title editing with Escape", () => {

--- a/src/components/notebook/__tests__/DocumentTitle.test.tsx
+++ b/src/components/notebook/__tests__/DocumentTitle.test.tsx
@@ -1,0 +1,56 @@
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { describe, expect, it, vi } from "vite-plus/test";
+import { DocumentTitle } from "../DocumentTitle";
+
+describe("DocumentTitle", () => {
+  it("renames from an inline contenteditable title field", async () => {
+    const onRename = vi.fn().mockResolvedValue(true);
+
+    render(
+      <DocumentTitle
+        canRename
+        renameTitle="Existing"
+        title={{ label: "Existing", detail: null, title: "Existing" }}
+        onRename={onRename}
+      />,
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "Rename Existing" }));
+
+    const editable = screen.getByRole("textbox", { name: "Document title" });
+    expect(editable).toHaveAttribute("contenteditable", "true");
+
+    editable.textContent = "Renamed";
+    fireEvent.input(editable);
+    fireEvent.keyDown(editable, { key: "Enter" });
+
+    expect(onRename).toHaveBeenCalledWith("Renamed");
+    await waitFor(() => {
+      expect(screen.queryByRole("textbox", { name: "Document title" })).toBeNull();
+    });
+  });
+
+  it("cancels inline title editing with Escape", () => {
+    const onRename = vi.fn();
+
+    render(
+      <DocumentTitle
+        canRename
+        renameTitle="Existing"
+        title={{ label: "Existing", detail: null, title: "Existing" }}
+        onRename={onRename}
+      />,
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "Rename Existing" }));
+
+    const editable = screen.getByRole("textbox", { name: "Document title" });
+    editable.textContent = "Discarded";
+    fireEvent.input(editable);
+    fireEvent.keyDown(editable, { key: "Escape" });
+
+    expect(onRename).not.toHaveBeenCalled();
+    expect(screen.queryByRole("textbox", { name: "Document title" })).toBeNull();
+    expect(screen.getByText("Existing")).toBeVisible();
+  });
+});

--- a/src/components/notebook/index.ts
+++ b/src/components/notebook/index.ts
@@ -107,6 +107,12 @@ export {
 export { NotebookDocumentShell, type NotebookDocumentShellProps } from "./NotebookDocumentShell";
 export { NotebookDocumentHeader, type NotebookDocumentHeaderProps } from "./NotebookDocumentHeader";
 export {
+  DocumentTitle,
+  type DocumentTitleClassNames,
+  type DocumentTitleDisplay,
+  type DocumentTitleProps,
+} from "./DocumentTitle";
+export {
   NotebookNotice,
   NotebookNoticeAction,
   NotebookNoticeStack,

--- a/src/lib/__tests__/markdown-document.test.ts
+++ b/src/lib/__tests__/markdown-document.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from "vite-plus/test";
+import { describe, expect, it, vi } from "vite-plus/test";
 import {
   normalizeMarkdownDocumentAccess,
   projectMarkdownDocument,
@@ -124,6 +124,39 @@ describe("markdown document projection", () => {
     expect(projection.markdownPlan).toBeNull();
     expect(projection.outlineItems).toEqual([]);
     expect(projection.headingAnchors).toEqual([]);
+  });
+
+  it("uses a matching attached Markdown plan before the projector is initialized", () => {
+    const source = "# Seeded\n\nRendered from a persisted snapshot.";
+    const attachedPlan = projectDoc({
+      id: "seeded-doc",
+      title: "Seeded",
+      body: source,
+      access: "viewer",
+    }).markdownPlan;
+    expect(attachedPlan).not.toBeNull();
+
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    try {
+      const projection = projectMarkdownDocument({
+        id: "seeded-doc",
+        title: "Seeded",
+        body: source,
+        markdownPlan: attachedPlan,
+        access: "viewer",
+      });
+
+      expect(projection.markdownPlan).toBe(attachedPlan);
+      expect(projection.outlineItems).toEqual([
+        expect.objectContaining({
+          title: "Seeded",
+          href: "#seeded",
+        }),
+      ]);
+      expect(warn).not.toHaveBeenCalled();
+    } finally {
+      warn.mockRestore();
+    }
   });
 
   it("treats invalid access as none", () => {

--- a/src/lib/__tests__/markdown-document.test.ts
+++ b/src/lib/__tests__/markdown-document.test.ts
@@ -169,6 +169,23 @@ describe("markdown document projection", () => {
     );
   });
 
+  it("keeps rendered representation available for empty documents", () => {
+    const projection = projectDoc({
+      id: "empty-doc",
+      title: "Empty",
+      body: "",
+      access: "owner",
+      requestedMode: "edit",
+      requestedRepresentation: "rendered",
+    });
+
+    expect(projection.markdownPlan).toBeNull();
+    expect(projection.representation.active).toBe("rendered");
+    expect(projection.representation.options.find((option) => option.id === "rendered")).toEqual(
+      expect.objectContaining({ disabled: false, title: "Show rendered Markdown" }),
+    );
+  });
+
   it("normalizes absent title and access", () => {
     const projection = projectDoc({
       id: "01KTMARKDOWNDOC",

--- a/src/lib/__tests__/markdown-document.test.ts
+++ b/src/lib/__tests__/markdown-document.test.ts
@@ -111,6 +111,64 @@ describe("markdown document projection", () => {
     expect(projection.canPublish).toBe(false);
   });
 
+  it("defaults editors to source representation in edit mode", () => {
+    const projection = projectDoc({
+      id: "editable-doc",
+      title: "Editable",
+      body: "# Editable",
+      access: "owner",
+      requestedMode: "edit",
+    });
+
+    expect(projection.representation).toMatchObject({
+      active: "source",
+      sourceEditable: true,
+    });
+    expect(projection.representation.options).toEqual([
+      expect.objectContaining({ id: "rendered", disabled: false }),
+      expect.objectContaining({ id: "source", disabled: false, title: "Edit Markdown source" }),
+      expect.objectContaining({ id: "split", disabled: true }),
+    ]);
+  });
+
+  it("allows read-only source inspection without edit authority", () => {
+    const projection = projectDoc({
+      id: "viewer-source-doc",
+      title: "Shared",
+      body: "# Shared",
+      access: "viewer",
+      requestedRepresentation: "source",
+    });
+
+    expect(projection.mode).toBe("view");
+    expect(projection.representation).toMatchObject({
+      active: "source",
+      sourceEditable: false,
+    });
+    expect(projection.representation.options.find((option) => option.id === "source")).toEqual(
+      expect.objectContaining({ title: "Inspect Markdown source", disabled: false }),
+    );
+  });
+
+  it("keeps split visible but inactive until side-by-side editing is implemented", () => {
+    const projection = projectDoc({
+      id: "split-doc",
+      title: "Split",
+      body: "# Split",
+      access: "editor",
+      requestedMode: "edit",
+      requestedRepresentation: "split",
+    });
+
+    expect(projection.representation.active).toBe("source");
+    expect(projection.representation.options.find((option) => option.id === "split")).toEqual(
+      expect.objectContaining({
+        disabled: true,
+        title: "Side-by-side source and rendered Markdown is planned",
+      }),
+    );
+  });
+
   it("normalizes absent title and access", () => {
     const projection = projectDoc({
       id: "01KTMARKDOWNDOC",

--- a/src/lib/__tests__/markdown-document.test.ts
+++ b/src/lib/__tests__/markdown-document.test.ts
@@ -1,0 +1,129 @@
+import { describe, expect, it } from "vite-plus/test";
+import {
+  normalizeMarkdownDocumentAccess,
+  projectMarkdownDocument,
+  type MarkdownDocumentProjectionInput,
+} from "../markdown-document";
+import { setMarkdownProjectionProjector } from "../markdown-projection";
+
+function withMarkdownProjector<T>(fn: () => T): T {
+  const restore = setMarkdownProjectionProjector((source) => {
+    const anchors = source
+      .split("\n")
+      .map((line, lineIndex) => ({ line, lineIndex }))
+      .filter(({ line }) => line.startsWith("#"))
+      .map(({ line, lineIndex }, index) => {
+        const title = line.replace(/^#+\s*/, "");
+        const level = line.match(/^#+/)?.[0]?.length ?? 1;
+        const start = source.split("\n").slice(0, lineIndex).join("\n").length + (lineIndex === 0 ? 0 : 1);
+        const end = start + line.length;
+        return {
+          anchorId: `anchor:${index}`,
+          blockId: `block:${index}`,
+          level,
+          slug: title.toLowerCase().replace(/[^a-z0-9]+/g, "-").replace(/^-|-$/g, ""),
+          sourceSpanByte: [start, end],
+          sourceSpanUtf16: [start, end],
+          title,
+        };
+      });
+    return JSON.stringify({
+      version: 1,
+      engine: "test",
+      byteLength: source.length,
+      utf16Length: source.length,
+      source,
+      measurement: { estimatedHeight: 24, confidence: "high", width: 720 },
+      anchors,
+      blocks: anchors.map((anchor, index) => ({
+        anchorSlug: anchor.slug,
+        blockId: anchor.blockId,
+        blockIndex: index,
+        element: `h${anchor.level}`,
+        kind: "heading",
+        measurement: { estimatedHeight: 24, confidence: "high", width: 720 },
+        sourceSpanByte: anchor.sourceSpanByte,
+        sourceSpanUtf16: anchor.sourceSpanUtf16,
+        syntaxSpans: [],
+        text: anchor.title,
+      })),
+      runs: [],
+    });
+  });
+  try {
+    return fn();
+  } finally {
+    restore();
+  }
+}
+
+describe("markdown document projection", () => {
+  it("derives editable capabilities from access without runtime concepts", () => {
+    const projection = projectDoc({
+      id: "01KTMD",
+      title: "Research note",
+      body: "# Research\n\nBody",
+      access: "editor",
+      requestedMode: "source",
+    });
+
+    expect(projection).toMatchObject({
+      id: "01KTMD",
+      title: "Research note",
+      access: "editor",
+      mode: "source",
+      canEdit: true,
+      canShare: false,
+      canPublish: false,
+    });
+    expect(projection).not.toHaveProperty("runtime");
+    expect(projection).not.toHaveProperty("workstation");
+    expect(projection.outlineItems).toEqual([
+      expect.objectContaining({
+        title: "Research",
+        level: 1,
+        href: "#research",
+      }),
+    ]);
+  });
+
+  it("forces read mode for viewers", () => {
+    const projection = projectDoc({
+      id: "viewer-doc",
+      title: "Shared",
+      body: "# Shared",
+      access: "viewer",
+      requestedMode: "source",
+    });
+
+    expect(projection.mode).toBe("read");
+    expect(projection.canEdit).toBe(false);
+    expect(projection.canShare).toBe(false);
+    expect(projection.canPublish).toBe(false);
+  });
+
+  it("normalizes absent title and access", () => {
+    const projection = projectDoc({
+      id: "01KTMARKDOWNDOC",
+      title: "  ",
+      body: "",
+      access: null,
+    });
+
+    expect(projection.title).toBe("Markdown 01KTMARK");
+    expect(projection.access).toBe("none");
+    expect(projection.markdownPlan).toBeNull();
+    expect(projection.outlineItems).toEqual([]);
+  });
+
+  it("treats invalid access as none", () => {
+    expect(normalizeMarkdownDocumentAccess("owner")).toBe("owner");
+    expect(normalizeMarkdownDocumentAccess("editor")).toBe("editor");
+    expect(normalizeMarkdownDocumentAccess("viewer")).toBe("viewer");
+    expect(normalizeMarkdownDocumentAccess("runtime_peer" as never)).toBe("none");
+  });
+});
+
+function projectDoc(input: MarkdownDocumentProjectionInput) {
+  return withMarkdownProjector(() => projectMarkdownDocument(input));
+}

--- a/src/lib/__tests__/markdown-document.test.ts
+++ b/src/lib/__tests__/markdown-document.test.ts
@@ -74,7 +74,6 @@ describe("markdown document projection", () => {
       mode: "edit",
       canEdit: true,
       canShare: false,
-      canPublish: false,
     });
     expect(projection).not.toHaveProperty("runtime");
     expect(projection).not.toHaveProperty("workstation");
@@ -108,7 +107,8 @@ describe("markdown document projection", () => {
     expect(projection.mode).toBe("view");
     expect(projection.canEdit).toBe(false);
     expect(projection.canShare).toBe(false);
-    expect(projection.canPublish).toBe(false);
+    expect(projection).not.toHaveProperty("canPublish");
+    expect(projection).not.toHaveProperty("isPublished");
   });
 
   it("defaults editors to source representation in edit mode", () => {

--- a/src/lib/__tests__/markdown-document.test.ts
+++ b/src/lib/__tests__/markdown-document.test.ts
@@ -85,6 +85,15 @@ describe("markdown document projection", () => {
         href: "#research",
       }),
     ]);
+    expect(projection.headingAnchors).toEqual([
+      {
+        itemId: "anchor:0",
+        title: "Research",
+        level: 1,
+        anchor: "research",
+        headingAnchorId: "research",
+      },
+    ]);
   });
 
   it("forces read mode for viewers", () => {
@@ -114,6 +123,7 @@ describe("markdown document projection", () => {
     expect(projection.access).toBe("none");
     expect(projection.markdownPlan).toBeNull();
     expect(projection.outlineItems).toEqual([]);
+    expect(projection.headingAnchors).toEqual([]);
   });
 
   it("treats invalid access as none", () => {

--- a/src/lib/__tests__/markdown-document.test.ts
+++ b/src/lib/__tests__/markdown-document.test.ts
@@ -64,14 +64,14 @@ describe("markdown document projection", () => {
       title: "Research note",
       body: "# Research\n\nBody",
       access: "editor",
-      requestedMode: "source",
+      requestedMode: "edit",
     });
 
     expect(projection).toMatchObject({
       id: "01KTMD",
       title: "Research note",
       access: "editor",
-      mode: "source",
+      mode: "edit",
       canEdit: true,
       canShare: false,
       canPublish: false,
@@ -96,16 +96,16 @@ describe("markdown document projection", () => {
     ]);
   });
 
-  it("forces read mode for viewers", () => {
+  it("forces view mode for viewers", () => {
     const projection = projectDoc({
       id: "viewer-doc",
       title: "Shared",
       body: "# Shared",
       access: "viewer",
-      requestedMode: "source",
+      requestedMode: "edit",
     });
 
-    expect(projection.mode).toBe("read");
+    expect(projection.mode).toBe("view");
     expect(projection.canEdit).toBe(false);
     expect(projection.canShare).toBe(false);
     expect(projection.canPublish).toBe(false);

--- a/src/lib/markdown-document.ts
+++ b/src/lib/markdown-document.ts
@@ -103,7 +103,6 @@ export function projectMarkdownDocument(
     canRenderInHost,
     representation: projectMarkdownDocumentRepresentation({
       canEdit,
-      canRender: true,
       mode,
       requestedRepresentation: input.requestedRepresentation,
     }),
@@ -114,12 +113,10 @@ export function projectMarkdownDocument(
 
 export function projectMarkdownDocumentRepresentation({
   canEdit,
-  canRender,
   mode,
   requestedRepresentation,
 }: {
   canEdit: boolean;
-  canRender: boolean;
   mode: MarkdownDocumentMode;
   requestedRepresentation?: MarkdownDocumentRepresentation | null;
 }): MarkdownDocumentRepresentationProjection {
@@ -141,8 +138,8 @@ export function projectMarkdownDocumentRepresentation({
       {
         id: "rendered",
         label: "Rendered",
-        title: canRender ? "Show rendered Markdown" : "Rendered Markdown is not available yet",
-        disabled: !canRender,
+        title: "Show rendered Markdown",
+        disabled: false,
       },
       {
         id: "source",

--- a/src/lib/markdown-document.ts
+++ b/src/lib/markdown-document.ts
@@ -8,6 +8,7 @@ import {
 
 export type MarkdownDocumentAccessLevel = "owner" | "editor" | "viewer" | "none";
 export type MarkdownDocumentMode = "view" | "edit";
+export type MarkdownDocumentRepresentation = "rendered" | "source" | "split";
 
 export interface MarkdownDocumentSnapshot {
   id: string;
@@ -25,8 +26,22 @@ export interface MarkdownDocumentProjectionInput {
   markdownPlan?: MarkdownProjectionPlan | null;
   access?: MarkdownDocumentAccessLevel | null;
   requestedMode?: MarkdownDocumentMode | null;
+  requestedRepresentation?: MarkdownDocumentRepresentation | null;
   publishedRevisionId?: string | null;
   updatedAt?: string | null;
+}
+
+export interface MarkdownDocumentRepresentationOption {
+  id: MarkdownDocumentRepresentation;
+  label: string;
+  title: string;
+  disabled: boolean;
+}
+
+export interface MarkdownDocumentRepresentationProjection {
+  active: MarkdownDocumentRepresentation;
+  sourceEditable: boolean;
+  options: readonly MarkdownDocumentRepresentationOption[];
 }
 
 export interface MarkdownDocumentOutlineItem {
@@ -61,6 +76,7 @@ export interface MarkdownDocumentProjection {
   updatedAt: string | null;
   markdownPlan: MarkdownProjectionPlan | null;
   canRenderInHost: boolean;
+  representation: MarkdownDocumentRepresentationProjection;
   outlineItems: readonly MarkdownDocumentOutlineItem[];
   headingAnchors: readonly MarkdownDocumentHeadingAnchor[];
 }
@@ -76,6 +92,7 @@ export function projectMarkdownDocument(
     ? resolveMarkdownProjection(input.markdownPlan, body)
     : projectMarkdownPlan(body);
   const publishedRevisionId = input.publishedRevisionId ?? null;
+  const canRenderInHost = canRenderMarkdownProjectionInHost(markdownPlan);
 
   const outlineItems = markdownPlan ? projectMarkdownDocumentOutline(markdownPlan) : [];
 
@@ -92,9 +109,64 @@ export function projectMarkdownDocument(
     publishedRevisionId,
     updatedAt: input.updatedAt ?? null,
     markdownPlan,
-    canRenderInHost: canRenderMarkdownProjectionInHost(markdownPlan),
+    canRenderInHost,
+    representation: projectMarkdownDocumentRepresentation({
+      canEdit,
+      canRender: canRenderInHost,
+      mode,
+      requestedRepresentation: input.requestedRepresentation,
+    }),
     outlineItems,
     headingAnchors: markdownDocumentHeadingAnchors(outlineItems),
+  };
+}
+
+export function projectMarkdownDocumentRepresentation({
+  canEdit,
+  canRender,
+  mode,
+  requestedRepresentation,
+}: {
+  canEdit: boolean;
+  canRender: boolean;
+  mode: MarkdownDocumentMode;
+  requestedRepresentation?: MarkdownDocumentRepresentation | null;
+}): MarkdownDocumentRepresentationProjection {
+  const sourceEditable = canEdit && mode === "edit";
+  const defaultRepresentation: MarkdownDocumentRepresentation =
+    mode === "edit" && sourceEditable ? "source" : "rendered";
+  const requested =
+    requestedRepresentation === "source" ||
+    requestedRepresentation === "rendered" ||
+    requestedRepresentation === "split"
+      ? requestedRepresentation
+      : defaultRepresentation;
+  const active: MarkdownDocumentRepresentation =
+    requested === "split" || (requested === "rendered" && !canRender) ? "source" : requested;
+
+  return {
+    active,
+    sourceEditable,
+    options: [
+      {
+        id: "rendered",
+        label: "Rendered",
+        title: canRender ? "Show rendered Markdown" : "Rendered Markdown is not available yet",
+        disabled: !canRender,
+      },
+      {
+        id: "source",
+        label: "Source",
+        title: sourceEditable ? "Edit Markdown source" : "Inspect Markdown source",
+        disabled: false,
+      },
+      {
+        id: "split",
+        label: "Split",
+        title: "Side-by-side source and rendered Markdown is planned",
+        disabled: true,
+      },
+    ],
   };
 }
 

--- a/src/lib/markdown-document.ts
+++ b/src/lib/markdown-document.ts
@@ -6,7 +6,7 @@ import {
 } from "./markdown-projection";
 
 export type MarkdownDocumentAccessLevel = "owner" | "editor" | "viewer" | "none";
-export type MarkdownDocumentMode = "read" | "source";
+export type MarkdownDocumentMode = "view" | "edit";
 
 export interface MarkdownDocumentSnapshot {
   id: string;
@@ -69,7 +69,7 @@ export function projectMarkdownDocument(
   const access = normalizeMarkdownDocumentAccess(input.access);
   const body = input.body ?? "";
   const canEdit = access === "owner" || access === "editor";
-  const mode = canEdit ? (input.requestedMode ?? "read") : "read";
+  const mode = canEdit ? (input.requestedMode ?? "view") : "view";
   const markdownPlan = projectMarkdownPlan(body);
   const publishedRevisionId = input.publishedRevisionId ?? null;
 

--- a/src/lib/markdown-document.ts
+++ b/src/lib/markdown-document.ts
@@ -37,6 +37,14 @@ export interface MarkdownDocumentOutlineItem {
   blockId: string;
 }
 
+export interface MarkdownDocumentHeadingAnchor {
+  itemId: string;
+  title: string;
+  level: number;
+  anchor: string;
+  headingAnchorId: string;
+}
+
 export interface MarkdownDocumentProjection {
   id: string;
   title: string;
@@ -52,6 +60,7 @@ export interface MarkdownDocumentProjection {
   markdownPlan: MarkdownProjectionPlan | null;
   canRenderInHost: boolean;
   outlineItems: readonly MarkdownDocumentOutlineItem[];
+  headingAnchors: readonly MarkdownDocumentHeadingAnchor[];
 }
 
 export function projectMarkdownDocument(
@@ -63,6 +72,8 @@ export function projectMarkdownDocument(
   const mode = canEdit ? (input.requestedMode ?? "read") : "read";
   const markdownPlan = projectMarkdownPlan(body);
   const publishedRevisionId = input.publishedRevisionId ?? null;
+
+  const outlineItems = markdownPlan ? projectMarkdownDocumentOutline(markdownPlan) : [];
 
   return {
     id: input.id,
@@ -78,7 +89,8 @@ export function projectMarkdownDocument(
     updatedAt: input.updatedAt ?? null,
     markdownPlan,
     canRenderInHost: canRenderMarkdownProjectionInHost(markdownPlan),
-    outlineItems: markdownPlan ? projectMarkdownDocumentOutline(markdownPlan) : [],
+    outlineItems,
+    headingAnchors: markdownDocumentHeadingAnchors(outlineItems),
   };
 }
 
@@ -86,6 +98,18 @@ export function projectMarkdownDocumentOutline(
   plan: MarkdownProjectionPlan,
 ): MarkdownDocumentOutlineItem[] {
   return plan.anchors.map((anchor, index) => markdownAnchorToOutlineItem(anchor, index));
+}
+
+export function markdownDocumentHeadingAnchors(
+  outlineItems: readonly MarkdownDocumentOutlineItem[],
+): MarkdownDocumentHeadingAnchor[] {
+  return outlineItems.map((item) => ({
+    itemId: item.id,
+    title: item.title,
+    level: item.level,
+    anchor: item.anchor,
+    headingAnchorId: item.anchor,
+  }));
 }
 
 export function normalizeMarkdownDocumentAccess(

--- a/src/lib/markdown-document.ts
+++ b/src/lib/markdown-document.ts
@@ -1,0 +1,123 @@
+import {
+  canRenderMarkdownProjectionInHost,
+  projectMarkdownPlan,
+  type MarkdownProjectionAnchor,
+  type MarkdownProjectionPlan,
+} from "./markdown-projection";
+
+export type MarkdownDocumentAccessLevel = "owner" | "editor" | "viewer" | "none";
+export type MarkdownDocumentMode = "read" | "source";
+
+export interface MarkdownDocumentSnapshot {
+  id: string;
+  title: string;
+  body: string;
+  access: MarkdownDocumentAccessLevel;
+  publishedRevisionId?: string | null;
+  updatedAt?: string | null;
+}
+
+export interface MarkdownDocumentProjectionInput {
+  id: string;
+  title?: string | null;
+  body?: string | null;
+  access?: MarkdownDocumentAccessLevel | null;
+  requestedMode?: MarkdownDocumentMode | null;
+  publishedRevisionId?: string | null;
+  updatedAt?: string | null;
+}
+
+export interface MarkdownDocumentOutlineItem {
+  id: string;
+  title: string;
+  level: number;
+  anchor: string;
+  href: string;
+  sourceSpanUtf16: readonly [number, number];
+  blockId: string;
+}
+
+export interface MarkdownDocumentProjection {
+  id: string;
+  title: string;
+  body: string;
+  access: MarkdownDocumentAccessLevel;
+  mode: MarkdownDocumentMode;
+  canEdit: boolean;
+  canShare: boolean;
+  canPublish: boolean;
+  isPublished: boolean;
+  publishedRevisionId: string | null;
+  updatedAt: string | null;
+  markdownPlan: MarkdownProjectionPlan | null;
+  canRenderInHost: boolean;
+  outlineItems: readonly MarkdownDocumentOutlineItem[];
+}
+
+export function projectMarkdownDocument(
+  input: MarkdownDocumentProjectionInput,
+): MarkdownDocumentProjection {
+  const access = normalizeMarkdownDocumentAccess(input.access);
+  const body = input.body ?? "";
+  const canEdit = access === "owner" || access === "editor";
+  const mode = canEdit ? (input.requestedMode ?? "read") : "read";
+  const markdownPlan = projectMarkdownPlan(body);
+  const publishedRevisionId = input.publishedRevisionId ?? null;
+
+  return {
+    id: input.id,
+    title: normalizeMarkdownDocumentTitle(input.title, input.id),
+    body,
+    access,
+    mode,
+    canEdit,
+    canShare: access === "owner",
+    canPublish: access === "owner",
+    isPublished: publishedRevisionId !== null,
+    publishedRevisionId,
+    updatedAt: input.updatedAt ?? null,
+    markdownPlan,
+    canRenderInHost: canRenderMarkdownProjectionInHost(markdownPlan),
+    outlineItems: markdownPlan ? projectMarkdownDocumentOutline(markdownPlan) : [],
+  };
+}
+
+export function projectMarkdownDocumentOutline(
+  plan: MarkdownProjectionPlan,
+): MarkdownDocumentOutlineItem[] {
+  return plan.anchors.map((anchor, index) => markdownAnchorToOutlineItem(anchor, index));
+}
+
+export function normalizeMarkdownDocumentAccess(
+  access: MarkdownDocumentAccessLevel | null | undefined,
+): MarkdownDocumentAccessLevel {
+  return access === "owner" || access === "editor" || access === "viewer" ? access : "none";
+}
+
+export function normalizeMarkdownDocumentTitle(
+  title: string | null | undefined,
+  fallbackId: string,
+): string {
+  const trimmed = title?.trim();
+  return trimmed && trimmed.length > 0 ? trimmed : `Markdown ${fallbackId.slice(0, 8)}`;
+}
+
+function markdownAnchorToOutlineItem(
+  anchor: MarkdownProjectionAnchor,
+  index: number,
+): MarkdownDocumentOutlineItem {
+  const cleanAnchor = cleanMarkdownAnchor(anchor.slug) || `heading-${index + 1}`;
+  return {
+    id: anchor.anchorId || `${anchor.blockId}:heading:${index}`,
+    title: anchor.title,
+    level: anchor.level,
+    anchor: cleanAnchor,
+    href: `#${cleanAnchor}`,
+    sourceSpanUtf16: anchor.sourceSpanUtf16,
+    blockId: anchor.blockId,
+  };
+}
+
+function cleanMarkdownAnchor(anchor: string): string {
+  return anchor.replace(/^#+/, "").trim();
+}

--- a/src/lib/markdown-document.ts
+++ b/src/lib/markdown-document.ts
@@ -112,7 +112,7 @@ export function projectMarkdownDocument(
     canRenderInHost,
     representation: projectMarkdownDocumentRepresentation({
       canEdit,
-      canRender: canRenderInHost,
+      canRender: true,
       mode,
       requestedRepresentation: input.requestedRepresentation,
     }),
@@ -141,8 +141,7 @@ export function projectMarkdownDocumentRepresentation({
     requestedRepresentation === "split"
       ? requestedRepresentation
       : defaultRepresentation;
-  const active: MarkdownDocumentRepresentation =
-    requested === "split" || (requested === "rendered" && !canRender) ? "source" : requested;
+  const active: MarkdownDocumentRepresentation = requested === "split" ? "source" : requested;
 
   return {
     active,

--- a/src/lib/markdown-document.ts
+++ b/src/lib/markdown-document.ts
@@ -1,6 +1,7 @@
 import {
   canRenderMarkdownProjectionInHost,
   projectMarkdownPlan,
+  resolveMarkdownProjection,
   type MarkdownProjectionAnchor,
   type MarkdownProjectionPlan,
 } from "./markdown-projection";
@@ -21,6 +22,7 @@ export interface MarkdownDocumentProjectionInput {
   id: string;
   title?: string | null;
   body?: string | null;
+  markdownPlan?: MarkdownProjectionPlan | null;
   access?: MarkdownDocumentAccessLevel | null;
   requestedMode?: MarkdownDocumentMode | null;
   publishedRevisionId?: string | null;
@@ -70,7 +72,9 @@ export function projectMarkdownDocument(
   const body = input.body ?? "";
   const canEdit = access === "owner" || access === "editor";
   const mode = canEdit ? (input.requestedMode ?? "view") : "view";
-  const markdownPlan = projectMarkdownPlan(body);
+  const markdownPlan = input.markdownPlan
+    ? resolveMarkdownProjection(input.markdownPlan, body)
+    : projectMarkdownPlan(body);
   const publishedRevisionId = input.publishedRevisionId ?? null;
 
   const outlineItems = markdownPlan ? projectMarkdownDocumentOutline(markdownPlan) : [];

--- a/src/lib/markdown-document.ts
+++ b/src/lib/markdown-document.ts
@@ -15,7 +15,6 @@ export interface MarkdownDocumentSnapshot {
   title: string;
   body: string;
   access: MarkdownDocumentAccessLevel;
-  publishedRevisionId?: string | null;
   updatedAt?: string | null;
 }
 
@@ -27,7 +26,6 @@ export interface MarkdownDocumentProjectionInput {
   access?: MarkdownDocumentAccessLevel | null;
   requestedMode?: MarkdownDocumentMode | null;
   requestedRepresentation?: MarkdownDocumentRepresentation | null;
-  publishedRevisionId?: string | null;
   updatedAt?: string | null;
 }
 
@@ -70,9 +68,6 @@ export interface MarkdownDocumentProjection {
   mode: MarkdownDocumentMode;
   canEdit: boolean;
   canShare: boolean;
-  canPublish: boolean;
-  isPublished: boolean;
-  publishedRevisionId: string | null;
   updatedAt: string | null;
   markdownPlan: MarkdownProjectionPlan | null;
   canRenderInHost: boolean;
@@ -91,7 +86,6 @@ export function projectMarkdownDocument(
   const markdownPlan = input.markdownPlan
     ? resolveMarkdownProjection(input.markdownPlan, body)
     : projectMarkdownPlan(body);
-  const publishedRevisionId = input.publishedRevisionId ?? null;
   const canRenderInHost = canRenderMarkdownProjectionInHost(markdownPlan);
 
   const outlineItems = markdownPlan ? projectMarkdownDocumentOutline(markdownPlan) : [];
@@ -104,9 +98,6 @@ export function projectMarkdownDocument(
     mode,
     canEdit,
     canShare: access === "owner",
-    canPublish: access === "owner",
-    isPublished: publishedRevisionId !== null,
-    publishedRevisionId,
     updatedAt: input.updatedAt ?? null,
     markdownPlan,
     canRenderInHost,

--- a/src/styles/markdown-document.css
+++ b/src/styles/markdown-document.css
@@ -67,11 +67,6 @@
   font-size: 0.75rem;
 }
 
-.markdown-document-representation-toolbar {
-  align-self: flex-start;
-  margin-bottom: clamp(0.75rem, 2vw, 1.25rem);
-}
-
 .markdown-document-mode-toggle button,
 .markdown-document-representation-toolbar button {
   display: inline-flex;

--- a/src/styles/markdown-document.css
+++ b/src/styles/markdown-document.css
@@ -1,22 +1,28 @@
 .markdown-document-scroll {
+  --markdown-document-content-width: 52rem;
+  --markdown-document-content-block-padding: clamp(1.25rem, 4vw, 3rem);
+  --markdown-document-content-inline-padding: clamp(1.25rem, 4vw, 3rem);
   display: flex;
   flex: 1;
   flex-direction: column;
+  box-sizing: border-box;
   min-height: 0;
   overflow: auto;
+  padding: var(--markdown-document-content-block-padding)
+    var(--markdown-document-content-inline-padding);
   scroll-behavior: smooth;
 }
 
 .markdown-document-scroll[data-mode="view"] {
-  padding: clamp(1.25rem, 4vw, 3rem);
+  background: var(--background);
 }
 
 .markdown-document-scroll[data-mode="edit"] {
-  padding: 0;
+  background: var(--background);
 }
 
 .markdown-document-preview {
-  width: min(100%, 52rem);
+  width: min(100%, var(--markdown-document-content-width));
   margin: 0 auto;
 }
 
@@ -24,12 +30,14 @@
   display: flex;
   flex: 1;
   min-height: 100%;
-  width: 100%;
-  background: var(--background);
+  width: min(100%, var(--markdown-document-content-width));
+  margin: 0 auto;
+  background: transparent;
 }
 
 .markdown-document-editor .cm-editor {
   flex: 1;
+  margin-top: 0;
   min-height: 100%;
   width: 100%;
 }
@@ -40,7 +48,7 @@
 
 .markdown-document-editor .cm-content {
   min-height: 100%;
-  padding: clamp(1rem, 3vw, 2.5rem) clamp(1rem, 5vw, 4rem);
+  padding: 0;
 }
 
 .markdown-document-mode-toggle {
@@ -106,12 +114,9 @@
 }
 
 @media (max-width: 599.98px) {
-  .markdown-document-scroll[data-mode="view"] {
-    padding: 1rem;
-  }
-
-  .markdown-document-editor .cm-content {
-    padding: 1rem;
+  .markdown-document-scroll {
+    --markdown-document-content-block-padding: 1rem;
+    --markdown-document-content-inline-padding: 1rem;
   }
 
   .markdown-document-mode-toggle span {

--- a/src/styles/markdown-document.css
+++ b/src/styles/markdown-document.css
@@ -52,7 +52,8 @@
   padding: 0;
 }
 
-.markdown-document-mode-toggle {
+.markdown-document-mode-toggle,
+.markdown-document-representation-toolbar {
   display: inline-flex;
   align-items: center;
   min-width: 0;
@@ -66,7 +67,13 @@
   font-size: 0.75rem;
 }
 
-.markdown-document-mode-toggle button {
+.markdown-document-representation-toolbar {
+  align-self: flex-start;
+  margin-bottom: clamp(0.75rem, 2vw, 1.25rem);
+}
+
+.markdown-document-mode-toggle button,
+.markdown-document-representation-toolbar button {
   display: inline-flex;
   align-items: center;
   justify-content: center;
@@ -84,7 +91,8 @@
     color 120ms ease;
 }
 
-.markdown-document-mode-toggle button[aria-pressed="true"] {
+.markdown-document-mode-toggle button[aria-pressed="true"],
+.markdown-document-representation-toolbar button[aria-pressed="true"] {
   background: var(--background);
   color: var(--foreground);
   box-shadow: 0 1px 2px color-mix(in srgb, #000 9%, transparent);
@@ -94,21 +102,25 @@
   color: color-mix(in srgb, #047857 82%, var(--foreground));
 }
 
-.markdown-document-mode-toggle button:hover:not(:disabled) {
+.markdown-document-mode-toggle button:hover:not(:disabled),
+.markdown-document-representation-toolbar button:hover:not(:disabled) {
   color: var(--foreground);
 }
 
-.markdown-document-mode-toggle button:disabled {
+.markdown-document-mode-toggle button:disabled,
+.markdown-document-representation-toolbar button:disabled {
   cursor: not-allowed;
   opacity: 0.5;
 }
 
-.markdown-document-mode-toggle button:focus-visible {
+.markdown-document-mode-toggle button:focus-visible,
+.markdown-document-representation-toolbar button:focus-visible {
   outline: 2px solid color-mix(in srgb, var(--ring) 70%, transparent);
   outline-offset: 2px;
 }
 
-.markdown-document-mode-toggle svg {
+.markdown-document-mode-toggle svg,
+.markdown-document-representation-toolbar svg {
   width: 0.875rem;
   height: 0.875rem;
   flex: 0 0 auto;
@@ -120,7 +132,8 @@
     --markdown-document-content-inline-padding: 1rem;
   }
 
-  .markdown-document-mode-toggle span {
+  .markdown-document-mode-toggle span,
+  .markdown-document-representation-toolbar span {
     position: absolute;
     width: 1px;
     height: 1px;
@@ -131,11 +144,13 @@
     border: 0;
   }
 
-  .markdown-document-mode-toggle {
+  .markdown-document-mode-toggle,
+  .markdown-document-representation-toolbar {
     max-width: none;
   }
 
-  .markdown-document-mode-toggle button {
+  .markdown-document-mode-toggle button,
+  .markdown-document-representation-toolbar button {
     width: 2rem;
     padding-inline: 0;
   }

--- a/src/styles/markdown-document.css
+++ b/src/styles/markdown-document.css
@@ -105,49 +105,6 @@
   flex: 0 0 auto;
 }
 
-.markdown-document-toolbar-action {
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  min-width: 0;
-  height: 2rem;
-  gap: 0.375rem;
-  border: 1px solid color-mix(in srgb, var(--foreground) 14%, transparent);
-  border-radius: 4px;
-  padding: 0 0.625rem;
-  background: color-mix(in srgb, var(--background) 94%, var(--foreground) 6%);
-  color: inherit;
-  font: inherit;
-  font-size: 0.8125rem;
-  font-weight: 600;
-  transition:
-    background-color 120ms ease,
-    color 120ms ease,
-    border-color 120ms ease;
-}
-
-.markdown-document-toolbar-action:hover:not(:disabled) {
-  border-color: color-mix(in srgb, var(--foreground) 22%, transparent);
-  background: color-mix(in srgb, var(--background) 88%, var(--foreground) 12%);
-  color: var(--foreground);
-}
-
-.markdown-document-toolbar-action:focus-visible {
-  outline: 2px solid color-mix(in srgb, var(--ring) 70%, transparent);
-  outline-offset: 2px;
-}
-
-.markdown-document-toolbar-action:disabled {
-  cursor: wait;
-  opacity: 0.65;
-}
-
-.markdown-document-toolbar-action svg {
-  width: 0.875rem;
-  height: 0.875rem;
-  flex: 0 0 auto;
-}
-
 @media (max-width: 599.98px) {
   .markdown-document-scroll[data-mode="view"] {
     padding: 1rem;
@@ -157,8 +114,7 @@
     padding: 1rem;
   }
 
-  .markdown-document-mode-toggle span,
-  .markdown-document-toolbar-action span {
+  .markdown-document-mode-toggle span {
     position: absolute;
     width: 1px;
     height: 1px;
@@ -173,8 +129,7 @@
     max-width: none;
   }
 
-  .markdown-document-mode-toggle button,
-  .markdown-document-toolbar-action {
+  .markdown-document-mode-toggle button {
     width: 2rem;
     padding-inline: 0;
   }

--- a/src/styles/markdown-document.css
+++ b/src/styles/markdown-document.css
@@ -1,5 +1,4 @@
 .markdown-document-scroll {
-  --markdown-document-content-width: 52rem;
   --markdown-document-content-block-padding: clamp(1.25rem, 4vw, 3rem);
   --markdown-document-content-inline-padding: clamp(1.25rem, 4vw, 3rem);
   display: flex;
@@ -22,16 +21,18 @@
 }
 
 .markdown-document-preview {
-  width: min(100%, var(--markdown-document-content-width));
-  margin: 0 auto;
+  width: 100%;
+  min-width: 0;
+  margin: 0;
 }
 
 .markdown-document-editor {
   display: flex;
   flex: 1;
   min-height: 100%;
-  width: min(100%, var(--markdown-document-content-width));
-  margin: 0 auto;
+  width: 100%;
+  min-width: 0;
+  margin: 0;
   background: transparent;
 }
 

--- a/src/styles/markdown-document.css
+++ b/src/styles/markdown-document.css
@@ -1,0 +1,181 @@
+.markdown-document-scroll {
+  display: flex;
+  flex: 1;
+  flex-direction: column;
+  min-height: 0;
+  overflow: auto;
+  scroll-behavior: smooth;
+}
+
+.markdown-document-scroll[data-mode="view"] {
+  padding: clamp(1.25rem, 4vw, 3rem);
+}
+
+.markdown-document-scroll[data-mode="edit"] {
+  padding: 0;
+}
+
+.markdown-document-preview {
+  width: min(100%, 52rem);
+  margin: 0 auto;
+}
+
+.markdown-document-editor {
+  display: flex;
+  flex: 1;
+  min-height: 100%;
+  width: 100%;
+  background: var(--background);
+}
+
+.markdown-document-editor .cm-editor {
+  flex: 1;
+  min-height: 100%;
+  width: 100%;
+}
+
+.markdown-document-editor .cm-scroller {
+  min-height: 100%;
+}
+
+.markdown-document-editor .cm-content {
+  min-height: 100%;
+  padding: clamp(1rem, 3vw, 2.5rem) clamp(1rem, 5vw, 4rem);
+}
+
+.markdown-document-mode-toggle {
+  display: inline-flex;
+  align-items: center;
+  min-width: 0;
+  height: 2rem;
+  max-width: min(14rem, 42vw);
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  padding: 0.125rem;
+  background: var(--background);
+  color: var(--muted-foreground);
+  font-size: 0.75rem;
+}
+
+.markdown-document-mode-toggle button {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-width: 0;
+  height: 1.5rem;
+  gap: 0.25rem;
+  border: 0;
+  border-radius: 4px;
+  padding: 0 0.5rem;
+  background: transparent;
+  color: inherit;
+  font: inherit;
+  transition:
+    background-color 120ms ease,
+    color 120ms ease;
+}
+
+.markdown-document-mode-toggle button[aria-pressed="true"] {
+  background: var(--background);
+  color: var(--foreground);
+  box-shadow: 0 1px 2px color-mix(in srgb, #000 9%, transparent);
+}
+
+.markdown-document-mode-toggle button[aria-pressed="true"]:last-child {
+  color: color-mix(in srgb, #047857 82%, var(--foreground));
+}
+
+.markdown-document-mode-toggle button:hover:not(:disabled) {
+  color: var(--foreground);
+}
+
+.markdown-document-mode-toggle button:disabled {
+  cursor: not-allowed;
+  opacity: 0.5;
+}
+
+.markdown-document-mode-toggle button:focus-visible {
+  outline: 2px solid color-mix(in srgb, var(--ring) 70%, transparent);
+  outline-offset: 2px;
+}
+
+.markdown-document-mode-toggle svg {
+  width: 0.875rem;
+  height: 0.875rem;
+  flex: 0 0 auto;
+}
+
+.markdown-document-toolbar-action {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-width: 0;
+  height: 2rem;
+  gap: 0.375rem;
+  border: 1px solid color-mix(in srgb, var(--foreground) 14%, transparent);
+  border-radius: 4px;
+  padding: 0 0.625rem;
+  background: color-mix(in srgb, var(--background) 94%, var(--foreground) 6%);
+  color: inherit;
+  font: inherit;
+  font-size: 0.8125rem;
+  font-weight: 600;
+  transition:
+    background-color 120ms ease,
+    color 120ms ease,
+    border-color 120ms ease;
+}
+
+.markdown-document-toolbar-action:hover:not(:disabled) {
+  border-color: color-mix(in srgb, var(--foreground) 22%, transparent);
+  background: color-mix(in srgb, var(--background) 88%, var(--foreground) 12%);
+  color: var(--foreground);
+}
+
+.markdown-document-toolbar-action:focus-visible {
+  outline: 2px solid color-mix(in srgb, var(--ring) 70%, transparent);
+  outline-offset: 2px;
+}
+
+.markdown-document-toolbar-action:disabled {
+  cursor: wait;
+  opacity: 0.65;
+}
+
+.markdown-document-toolbar-action svg {
+  width: 0.875rem;
+  height: 0.875rem;
+  flex: 0 0 auto;
+}
+
+@media (max-width: 599.98px) {
+  .markdown-document-scroll[data-mode="view"] {
+    padding: 1rem;
+  }
+
+  .markdown-document-editor .cm-content {
+    padding: 1rem;
+  }
+
+  .markdown-document-mode-toggle span,
+  .markdown-document-toolbar-action span {
+    position: absolute;
+    width: 1px;
+    height: 1px;
+    padding: 0;
+    overflow: hidden;
+    clip: rect(0, 0, 0, 0);
+    white-space: nowrap;
+    border: 0;
+  }
+
+  .markdown-document-mode-toggle {
+    max-width: none;
+  }
+
+  .markdown-document-mode-toggle button,
+  .markdown-document-toolbar-action {
+    width: 2rem;
+    padding-inline: 0;
+  }
+}

--- a/src/styles/notebook-base.css
+++ b/src/styles/notebook-base.css
@@ -1,4 +1,5 @@
 @import "./notebook-tokens.css";
+@import "./markdown-document.css";
 
 /* Fallback: apply dark theme when system prefers dark and no explicit light class */
 @media (prefers-color-scheme: dark) {


### PR DESCRIPTION
## Summary
- add hosted Markdown document storage, sync, routing, dashboard, and sharing surfaces under `/m`
- align Markdown app chrome with hosted notebooks: title editing, URL mode semantics, shared toolbar placement, first-paint behavior, shared app-session auth projection, hosted catalog cache mechanics, signed-out auth chrome, dashboard shell primitives, and the shared document mode control
- make Markdown sharing email-first: known verified collaborators resolve to canonical principals, unknown emails become pending invites, and same-email legacy ACL duplicates are cleaned up on re-share
- add Markdown edit-access requests so view-only signed-in collaborators can request edit access, owners can approve or deny from the share panel, and approved requests retry the document in edit mode
- fix approval refresh for app-session users by bypassing stale server bootstrap after an approved edit request and re-fetching current catalog scope
- keep Markdown sharing active/live-version oriented: browser config no longer advertises `snapshotBasePath` or `canPublish`, and the client live-sync controller no longer has a publish method
- add a focused hosted-document app-shell parity guard so `/n` and `/m` keep sharing the intended route-shell primitives without forcing notebook-specific dashboard features into Markdown
- keep the server-rendered Markdown body seed authoritative over older same-principal IndexedDB instant-paint snapshots, avoiding the visible stale-body-then-catch-up flash when bootstrap already has the body
- add an opaque server-issued app-session cache key so cookie-backed `/n` and `/m` catalog caches can warm-paint without exposing email, principal, display name, or tokens to browser-visible session payloads
- make the Markdown document home affordance return to `/m` through the app shell instead of a full page teardown, and ensure list routes own their `document.title` during in-app navigation
- remove dead Markdown dashboard CSS and stale route/projection fields left behind by earlier iterations
- update the hosted Markdown PRD/plan to describe live sharing as v0 and stable revision snapshots as future/internal primitives

## Validation
- `pnpm --dir apps/notebook-cloud exec node --import tsx --test test/viewer-render-props.test.ts`
- `pnpm --dir apps/notebook-cloud exec node --import tsx --test test/viewer-shared-cell-surface.test.ts`
- `pnpm --dir apps/notebook-cloud exec node --import tsx --test test/app-session.test.ts test/app-session-client.test.ts test/notebook-list-cache.test.ts test/markdown-document-list-cache.test.ts test/use-cloud-auth-session-identity.test.ts test/hosted-document-auth.test.ts test/viewer-render-props.test.ts test/viewer-shared-cell-surface.test.ts test/worker-routes.test.ts` (254 tests)
- `pnpm --dir apps/notebook-cloud exec tsc --noEmit`
- `pnpm --dir apps/notebook-cloud run test` (1182 tests)
- `pnpm test:run src/components/notebook/__tests__/DocumentTitle.test.tsx apps/notebook-cloud/viewer/__tests__/use-cloud-app-session-status.test.tsx`
- `cargo xtask lint --fix`
- `pnpm --dir apps/notebook-cloud run build`
- `pnpm --workspace-root exec wrangler d1 migrations apply nteract-notebook-cloud-prototype-db --config apps/notebook-cloud/wrangler.toml --remote`
- `pnpm --dir apps/notebook-cloud run deploy`
- `curl -s https://preview.runt.run/api/health` reports `1a19f05d49aa996ab851942d81df468c3b898f30`
- Chrome DevTools dogfood: `/m` loads signed in with a clean console; opening the parity-audit Markdown doc and clicking the title-bar home affordance returns to `/m` without adding a new browser navigation entry; the only expected post-click network refreshes are `/api/auth/session` and `/api/m?limit=100`; document title updates back to `nteract Markdown documents`
- Chrome screenshot: https://img.runt.run/2026/06/17/7b8aadbad539.png
- browser dogfood before the invite/access-request slice: `/n` and `/m` reload with cookie-backed app session and no sign-in prompt; isolated signed-out `/n` and `/m` both render the shared sign-in panel with route-specific copy; Markdown dashboard uses notebook-list header/create/state primitives at narrow and wide widths; Markdown share panel accepts email, canonicalizes a known collaborator, and removes duplicate legacy principal rows on re-share; Markdown parity-audit document was edited through Source mode, rendered, reloaded, and persisted without console errors; latest smoke confirmed the shared View/Edit control, active sharing copy, updated parity-audit content, quiet console, and clean desktop/narrow layouts

## Notes
- The Markdown body remains Automerge-backed and runtime-free; notebook compute controls are intentionally not surfaced here.
- App-session status exposes only `{ provider, expires_at, cache_key }`. The `cache_key` is an HMAC-derived opaque identifier scoped to the signed app-session cookie and is not a credential or human identity field.
- The Markdown invite implementation intentionally mirrors the notebook invite flow in this PR. A later cleanup should extract a generic hosted-document invite primitive rather than keeping parallel notebook/Markdown SQL helpers.
- The server-side immutable Markdown snapshot route remains a tested primitive for future revision/recovery work, but it is not advertised to the browser shell or surfaced as product UI in this slice.
