### PR TITLE
test(cloud): exhaust protocol helper coverage

### DIFF
--- a/apps/notebook-cloud/src/protocol.ts
+++ b/apps/notebook-cloud/src/protocol.ts
@@ -123,48 +123,42 @@ export function splitTypedFrame(message: ArrayBuffer | ArrayBufferView): TypedFr
   };
 }
 
+const KNOWN_FRAME_TYPE_ENTRIES = Object.entries(FrameType) as Array<
+  readonly [keyof typeof FrameType, FrameTypeValue]
+>;
+const KNOWN_FRAME_TYPES = KNOWN_FRAME_TYPE_ENTRIES.map(([, value]) => value);
+const KNOWN_FRAME_TYPE_SET = new Set<number>(KNOWN_FRAME_TYPES);
+
+const FRAME_TYPE_NAMES = Object.fromEntries(
+  KNOWN_FRAME_TYPE_ENTRIES.map(([name, value]) => [value, name.toLowerCase()]),
+) as Readonly<Record<FrameTypeValue, string>>;
+
+const CLIENT_WRITABLE_FRAME_TYPES = {
+  [FrameType.AUTOMERGE_SYNC]: true,
+  [FrameType.REQUEST]: true,
+  [FrameType.RESPONSE]: true,
+  [FrameType.BROADCAST]: false,
+  [FrameType.PRESENCE]: true,
+  [FrameType.RUNTIME_STATE_SYNC]: true,
+  [FrameType.COMMS_DOC_SYNC]: true,
+  [FrameType.POOL_STATE_SYNC]: true,
+  [FrameType.SESSION_CONTROL]: false,
+  [FrameType.PUT_BLOB]: true,
+} as const satisfies Readonly<Record<FrameTypeValue, boolean>>;
+
 export function frameTypeName(type: number): string {
-  switch (type) {
-    case FrameType.AUTOMERGE_SYNC:
-      return "automerge_sync";
-    case FrameType.REQUEST:
-      return "request";
-    case FrameType.RESPONSE:
-      return "response";
-    case FrameType.BROADCAST:
-      return "broadcast";
-    case FrameType.PRESENCE:
-      return "presence";
-    case FrameType.RUNTIME_STATE_SYNC:
-      return "runtime_state_sync";
-    case FrameType.COMMS_DOC_SYNC:
-      return "comms_doc_sync";
-    case FrameType.POOL_STATE_SYNC:
-      return "pool_state_sync";
-    case FrameType.SESSION_CONTROL:
-      return "session_control";
-    case FrameType.PUT_BLOB:
-      return "put_blob";
-    default:
-      return `unknown_${type}`;
+  if (isKnownFrameType(type)) {
+    return FRAME_TYPE_NAMES[type];
   }
+  return `unknown_${type}`;
 }
 
 export function isKnownFrameType(type: number): type is FrameTypeValue {
-  return Object.values(FrameType).includes(type as FrameTypeValue);
+  return KNOWN_FRAME_TYPE_SET.has(type);
 }
 
 export function isClientWritableFrame(type: FrameTypeValue): boolean {
-  return (
-    type === FrameType.AUTOMERGE_SYNC ||
-    type === FrameType.REQUEST ||
-    type === FrameType.RESPONSE ||
-    type === FrameType.PRESENCE ||
-    type === FrameType.RUNTIME_STATE_SYNC ||
-    type === FrameType.COMMS_DOC_SYNC ||
-    type === FrameType.POOL_STATE_SYNC ||
-    type === FrameType.PUT_BLOB
-  );
+  return CLIENT_WRITABLE_FRAME_TYPES[type];
 }
 
 export function toUint8Array(message: ArrayBuffer | ArrayBufferView): Uint8Array {

--- a/apps/notebook-cloud/test/protocol.test.ts
+++ b/apps/notebook-cloud/test/protocol.test.ts
@@ -13,21 +13,32 @@ import {
   type FrameTypeValue,
 } from "../src/protocol.ts";
 
-const KNOWN_FRAME_TYPE_ENTRIES = Object.entries(FrameType) as Array<
-  readonly [string, FrameTypeValue]
+const EXPECTED_FRAME_TYPE_ENTRIES = [
+  ["AUTOMERGE_SYNC", 0x00, "automerge_sync", true],
+  ["REQUEST", 0x01, "request", true],
+  ["RESPONSE", 0x02, "response", true],
+  ["BROADCAST", 0x03, "broadcast", false],
+  ["PRESENCE", 0x04, "presence", true],
+  ["RUNTIME_STATE_SYNC", 0x05, "runtime_state_sync", true],
+  ["POOL_STATE_SYNC", 0x06, "pool_state_sync", true],
+  ["SESSION_CONTROL", 0x07, "session_control", false],
+  ["PUT_BLOB", 0x08, "put_blob", true],
+  ["COMMS_DOC_SYNC", 0x09, "comms_doc_sync", true],
+] as const satisfies ReadonlyArray<
+  readonly [keyof typeof FrameType, FrameTypeValue, string, boolean]
 >;
 
 const EXPECTED_CLIENT_WRITABLE = {
-  [FrameType.AUTOMERGE_SYNC]: true,
-  [FrameType.REQUEST]: true,
-  [FrameType.RESPONSE]: true,
-  [FrameType.BROADCAST]: false,
-  [FrameType.PRESENCE]: true,
-  [FrameType.RUNTIME_STATE_SYNC]: true,
-  [FrameType.COMMS_DOC_SYNC]: true,
-  [FrameType.POOL_STATE_SYNC]: true,
-  [FrameType.SESSION_CONTROL]: false,
-  [FrameType.PUT_BLOB]: true,
+  0x00: true,
+  0x01: true,
+  0x02: true,
+  0x03: false,
+  0x04: true,
+  0x05: true,
+  0x06: true,
+  0x07: false,
+  0x08: true,
+  0x09: true,
 } as const satisfies Readonly<Record<FrameTypeValue, boolean>>;
 
 describe("typed-frame protocol helpers", () => {
@@ -72,9 +83,21 @@ describe("typed-frame protocol helpers", () => {
   });
 
   it("names and gates every known frame type", () => {
-    for (const [name, frameType] of KNOWN_FRAME_TYPE_ENTRIES) {
+    const expectedKeys = EXPECTED_FRAME_TYPE_ENTRIES.map(([key]) => key);
+    const expectedWireOrder = EXPECTED_FRAME_TYPE_ENTRIES.map(([, frameType]) => frameType);
+
+    assert.deepEqual(Object.keys(FrameType).sort(), [...expectedKeys].sort());
+    assert.deepEqual([...new Set(expectedWireOrder)], expectedWireOrder);
+    assert.deepEqual(
+      Object.values(FrameType).sort((left, right) => left - right),
+      expectedWireOrder,
+    );
+
+    for (const [key, frameType, displayName, clientWritable] of EXPECTED_FRAME_TYPE_ENTRIES) {
+      assert.equal(FrameType[key], frameType);
       assert.equal(isKnownFrameType(frameType), true);
-      assert.equal(frameTypeName(frameType), name.toLowerCase());
+      assert.equal(frameTypeName(frameType), displayName);
+      assert.equal(isClientWritableFrame(frameType), clientWritable);
       assert.equal(isClientWritableFrame(frameType), EXPECTED_CLIENT_WRITABLE[frameType]);
       assert.deepEqual(splitTypedFrame(new Uint8Array([frameType, 42])), {
         type: frameType,

--- a/apps/notebook-cloud/test/protocol.test.ts
+++ b/apps/notebook-cloud/test/protocol.test.ts
@@ -8,8 +8,27 @@ import {
   frameSizeLimits,
   frameTypeName,
   isClientWritableFrame,
+  isKnownFrameType,
   splitTypedFrame,
+  type FrameTypeValue,
 } from "../src/protocol.ts";
+
+const KNOWN_FRAME_TYPE_ENTRIES = Object.entries(FrameType) as Array<
+  readonly [string, FrameTypeValue]
+>;
+
+const EXPECTED_CLIENT_WRITABLE = {
+  [FrameType.AUTOMERGE_SYNC]: true,
+  [FrameType.REQUEST]: true,
+  [FrameType.RESPONSE]: true,
+  [FrameType.BROADCAST]: false,
+  [FrameType.PRESENCE]: true,
+  [FrameType.RUNTIME_STATE_SYNC]: true,
+  [FrameType.COMMS_DOC_SYNC]: true,
+  [FrameType.POOL_STATE_SYNC]: true,
+  [FrameType.SESSION_CONTROL]: false,
+  [FrameType.PUT_BLOB]: true,
+} as const satisfies Readonly<Record<FrameTypeValue, boolean>>;
 
 describe("typed-frame protocol helpers", () => {
   it("encodes and splits v4-shaped typed frames", () => {
@@ -52,12 +71,18 @@ describe("typed-frame protocol helpers", () => {
     );
   });
 
-  it("names and gates client writable frames", () => {
-    assert.equal(frameTypeName(FrameType.RUNTIME_STATE_SYNC), "runtime_state_sync");
-    assert.equal(frameTypeName(FrameType.COMMS_DOC_SYNC), "comms_doc_sync");
-    assert.equal(isClientWritableFrame(FrameType.AUTOMERGE_SYNC), true);
-    assert.equal(isClientWritableFrame(FrameType.COMMS_DOC_SYNC), true);
-    assert.equal(isClientWritableFrame(FrameType.SESSION_CONTROL), false);
+  it("names and gates every known frame type", () => {
+    for (const [name, frameType] of KNOWN_FRAME_TYPE_ENTRIES) {
+      assert.equal(isKnownFrameType(frameType), true);
+      assert.equal(frameTypeName(frameType), name.toLowerCase());
+      assert.equal(isClientWritableFrame(frameType), EXPECTED_CLIENT_WRITABLE[frameType]);
+      assert.deepEqual(splitTypedFrame(new Uint8Array([frameType, 42])), {
+        type: frameType,
+        payload: new Uint8Array([42]),
+      });
+    }
+    assert.equal(isKnownFrameType(255), false);
+    assert.equal(frameTypeName(255), "unknown_255");
   });
 
   it("mirrors notebook-wire per-frame payload size limits", () => {


### PR DESCRIPTION
## Summary

- derive cloud frame names from the generated `FrameType` keys instead of maintaining a switch
- make the cloud client-writable frame policy an exhaustive `Record<FrameTypeValue, boolean>` table
- update protocol helper tests to iterate every generated frame type, including name lookup, writable policy, and typed-frame split acceptance

## Verification

- `pnpm --dir apps/notebook-cloud exec node --import tsx --test test/protocol.test.ts`
- `pnpm --dir apps/notebook-cloud typecheck`
- `git diff --check`
- `cargo xtask lint --fix`

## Notes

This preserves the existing writable policy. `BROADCAST` and `SESSION_CONTROL` remain server-originated from cloud clients' perspective; `POOL_STATE_SYNC` remains writable because the current cloud policy already allowed it.
