### PR TITLE
refactor(kernel-env): centralize base package lists

### DIFF
--- a/crates/kernel-env/AGENTS.md
+++ b/crates/kernel-env/AGENTS.md
@@ -100,7 +100,7 @@ Pool warmer and capture step strip a base set so captured metadata records only 
 | Constant | Value |
 |----------|-------|
 | `kernel_env::uv::UV_BASE_PACKAGES` | `[ipykernel, ipywidgets, anywidget, nbformat, pyarrow>=14, uv]` |
-| `kernel_env::conda::CONDA_BASE_PACKAGES` | `[ipykernel, ipywidgets, anywidget, nbformat]` |
+| `kernel_env::conda::CONDA_BASE_PACKAGES` | `[ipykernel, ipywidgets, anywidget, pip, nbformat, pyarrow>=14]` |
 
 ## Prewarming and daemon pool
 

--- a/crates/kernel-env/src/conda.rs
+++ b/crates/kernel-env/src/conda.rs
@@ -51,9 +51,8 @@ pub fn default_cache_dir_conda() -> PathBuf {
 /// Base package set every Conda kernel env is warmed with.
 ///
 /// Used by the daemon's Conda pool warmer (`conda_prewarmed_packages` in
-/// runtimed) and by the unified env design's capture step (`strip_base`) so
-/// the notebook's metadata records only user-level deps. Keep this in sync
-/// with the warmer.
+/// runtimed), kernel-env install paths, and the unified env design's capture
+/// step (`strip_base`) so the notebook's metadata records only user-level deps.
 pub const CONDA_BASE_PACKAGES: &[&str] = &[
     "ipykernel",
     "ipywidgets",
@@ -62,6 +61,18 @@ pub const CONDA_BASE_PACKAGES: &[&str] = &[
     "nbformat",
     "pyarrow>=14",
 ];
+
+/// Return [`CONDA_BASE_PACKAGES`] as owned package spec strings for install paths.
+pub fn conda_base_packages() -> Vec<String> {
+    CONDA_BASE_PACKAGES
+        .iter()
+        .map(|package| (*package).to_string())
+        .collect()
+}
+
+fn is_conda_base_package(dep: &str) -> bool {
+    CONDA_BASE_PACKAGES.contains(&dep)
+}
 
 const CONDA_GIL_SELECTOR: &str = "python-gil";
 
@@ -479,21 +490,12 @@ async fn install_conda_env(
         specs.push(MatchSpec::from_str(CONDA_GIL_SELECTOR, match_spec_options)?);
     }
 
-    specs.push(MatchSpec::from_str("ipykernel", match_spec_options)?);
-    specs.push(MatchSpec::from_str("ipywidgets", match_spec_options)?);
-    specs.push(MatchSpec::from_str("anywidget", match_spec_options)?);
-    specs.push(MatchSpec::from_str("pip", match_spec_options)?);
-    specs.push(MatchSpec::from_str("nbformat", match_spec_options)?);
-    specs.push(MatchSpec::from_str("pyarrow>=14", match_spec_options)?);
+    for package in CONDA_BASE_PACKAGES {
+        specs.push(MatchSpec::from_str(package, match_spec_options)?);
+    }
 
     for dep in &deps.dependencies {
-        if dep != "ipykernel"
-            && dep != "ipywidgets"
-            && dep != "anywidget"
-            && dep != "pip"
-            && dep != "nbformat"
-            && dep != "pyarrow>=14"
-        {
+        if !is_conda_base_package(dep) {
             specs.push(MatchSpec::from_str(dep, match_spec_options)?);
         }
     }
@@ -632,8 +634,8 @@ async fn install_conda_env(
     Ok(())
 }
 
-/// Create a prewarmed conda environment with ipykernel, ipywidgets,
-/// and any caller-supplied extra packages.
+/// Create a prewarmed conda environment with [`CONDA_BASE_PACKAGES`] and any
+/// caller-supplied extra packages.
 ///
 /// Returns an environment at `prewarm-{uuid}` that can later be claimed
 /// via [`claim_prewarmed_environment`].
@@ -665,11 +667,7 @@ pub async fn create_prewarmed_environment_in(
 
     tokio::fs::create_dir_all(cache_dir).await?;
 
-    let mut deps_list = vec![
-        "ipykernel".to_string(),
-        "ipywidgets".to_string(),
-        "pip".to_string(),
-    ];
+    let mut deps_list = conda_base_packages();
     if !extra_packages.is_empty() {
         info!("[prewarm] Including extra packages: {:?}", extra_packages);
         deps_list.extend(extra_packages.iter().cloned());
@@ -922,14 +920,10 @@ pub async fn sync_dependencies(
     // Always include base runtime packages — the solver only returns packages
     // needed to satisfy specs, and locked_packages are "preferred" not "required".
     // Without these, the Installer will remove ipykernel etc from the env.
-    let mut specs: Vec<MatchSpec> = vec![
-        MatchSpec::from_str("ipykernel", match_spec_options)?,
-        MatchSpec::from_str("ipywidgets", match_spec_options)?,
-        MatchSpec::from_str("anywidget", match_spec_options)?,
-        MatchSpec::from_str("pip", match_spec_options)?,
-        MatchSpec::from_str("nbformat", match_spec_options)?,
-        MatchSpec::from_str("pyarrow>=14", match_spec_options)?,
-    ];
+    let mut specs: Vec<MatchSpec> = CONDA_BASE_PACKAGES
+        .iter()
+        .map(|package| MatchSpec::from_str(package, match_spec_options))
+        .collect::<std::result::Result<Vec<_>, _>>()?;
 
     if let Some(ref py_ver) = installed_python_version {
         info!("Pinning Python to installed version: {}", py_ver);
@@ -958,13 +952,7 @@ pub async fn sync_dependencies(
     }
 
     for dep in &deps.dependencies {
-        if dep != "ipykernel"
-            && dep != "ipywidgets"
-            && dep != "anywidget"
-            && dep != "pip"
-            && dep != "nbformat"
-            && dep != "pyarrow>=14"
-        {
+        if !is_conda_base_package(dep) {
             specs.push(MatchSpec::from_str(dep, match_spec_options)?);
         }
     }
@@ -1142,21 +1130,10 @@ fn build_spec_strings(deps: &CondaDependencies) -> Vec<String> {
         specs.push(CONDA_GIL_SELECTOR.to_string());
     }
 
-    specs.push("ipykernel".to_string());
-    specs.push("ipywidgets".to_string());
-    specs.push("anywidget".to_string());
-    specs.push("pip".to_string());
-    specs.push("nbformat".to_string());
-    specs.push("pyarrow>=14".to_string());
+    specs.extend(conda_base_packages());
 
     for dep in &deps.dependencies {
-        if dep != "ipykernel"
-            && dep != "ipywidgets"
-            && dep != "anywidget"
-            && dep != "pip"
-            && dep != "nbformat"
-            && dep != "pyarrow>=14"
-        {
+        if !is_conda_base_package(dep) {
             specs.push(dep.clone());
         }
     }

--- a/crates/kernel-env/src/lib.rs
+++ b/crates/kernel-env/src/lib.rs
@@ -45,10 +45,10 @@ pub mod warmup;
 
 // Re-export key types
 #[cfg(feature = "runtime")]
-pub use conda::{CondaDependencies, CondaEnvironment, CONDA_BASE_PACKAGES};
+pub use conda::{conda_base_packages, CondaDependencies, CondaEnvironment, CONDA_BASE_PACKAGES};
 pub use progress::{EnvProgressPhase, LogHandler, ProgressHandler};
 #[cfg(feature = "runtime")]
-pub use uv::{UvDependencies, UvEnvironment, UV_BASE_PACKAGES};
+pub use uv::{uv_base_packages, UvDependencies, UvEnvironment, UV_BASE_PACKAGES};
 
 /// Return the subset of `installed` that isn't in `base`, preserving input order.
 ///

--- a/crates/kernel-env/src/uv.rs
+++ b/crates/kernel-env/src/uv.rs
@@ -59,9 +59,9 @@ pub async fn check_uv_available() -> bool {
 
 /// Base package set every UV kernel env is warmed with.
 ///
-/// Used by the daemon's UV pool warmer (`uv_prewarmed_packages` in runtimed) and
-/// by the unified env design's capture step (`strip_base`) so the notebook's
-/// metadata records only user-level deps. Keep this in sync with the warmer.
+/// Used by the daemon's UV pool warmer (`uv_prewarmed_packages` in runtimed),
+/// kernel-env install paths, and the unified env design's capture step
+/// (`strip_base`) so the notebook's metadata records only user-level deps.
 ///
 /// The `dx` PyPI package is no longer installed — its behavior (DataFrame
 /// formatters, buffer hooks, nteract renderers) is provided by the vendored
@@ -77,6 +77,14 @@ pub const UV_BASE_PACKAGES: &[&str] = &[
     "pyarrow>=14",
     "uv",
 ];
+
+/// Return [`UV_BASE_PACKAGES`] as owned package spec strings for install paths.
+pub fn uv_base_packages() -> Vec<String> {
+    UV_BASE_PACKAGES
+        .iter()
+        .map(|package| (*package).to_string())
+        .collect()
+}
 
 /// Compute the unified env hash for a notebook. Used by the captured-deps
 /// reopen path from the unified env resolution design.
@@ -277,14 +285,7 @@ pub async fn prepare_environment_in(
     }
 
     // Build list of packages to install (for progress reporting)
-    let mut packages = vec![
-        "ipykernel".to_string(),
-        "ipywidgets".to_string(),
-        "anywidget".to_string(),
-        "nbformat".to_string(),
-        "pyarrow>=14".to_string(),
-        "uv".to_string(), // For %uv magic in notebooks
-    ];
+    let mut packages = uv_base_packages();
     packages.extend(deps.dependencies.iter().cloned());
 
     // Build install command args.
@@ -520,7 +521,7 @@ pub async fn prepare_environment_unified(
     // `deps.dependencies` is the user-level set (with base already stripped
     // at capture time). This ensures a reopen-path rebuild produces the same
     // installed set as the original pool env.
-    let mut packages: Vec<String> = UV_BASE_PACKAGES.iter().map(|p| p.to_string()).collect();
+    let mut packages = uv_base_packages();
     packages.extend(deps.dependencies.iter().cloned());
 
     let mut install_args = vec![
@@ -728,8 +729,8 @@ pub async fn sync_dependencies(
     Ok(())
 }
 
-/// Create a prewarmed environment with ipykernel, ipywidgets, and
-/// any caller-supplied extra packages.
+/// Create a prewarmed environment with [`UV_BASE_PACKAGES`] and any
+/// caller-supplied extra packages.
 ///
 /// Returns an environment at `prewarm-{uuid}` that can later be claimed
 /// via [`claim_prewarmed_environment`].
@@ -784,8 +785,10 @@ pub async fn create_prewarmed_environment_in(
         ));
     }
 
-    // Install ipykernel, ipywidgets, uv, and any extra packages.
+    // Install the managed UV base and any extra packages.
     // Use hardlink mode to share files from uv's global cache.
+    let mut packages = uv_base_packages();
+    packages.extend(extra_packages.iter().cloned());
     let mut install_args = vec![
         "pip".to_string(),
         "install".to_string(),
@@ -793,13 +796,10 @@ pub async fn create_prewarmed_environment_in(
         "hardlink".to_string(),
         "--python".to_string(),
         python_path.to_string_lossy().to_string(),
-        "ipykernel".to_string(),
-        "ipywidgets".to_string(),
-        "uv".to_string(), // For %uv magic in notebooks
     ];
-    if !extra_packages.is_empty() {
-        info!("[prewarm] Including extra packages: {:?}", extra_packages);
-        install_args.extend(extra_packages.iter().cloned());
+    if !packages.is_empty() {
+        info!("[prewarm] Installing packages: {:?}", packages);
+        install_args.extend(packages.iter().cloned());
     }
 
     handler.on_progress(

--- a/crates/runtimed/src/daemon.rs
+++ b/crates/runtimed/src/daemon.rs
@@ -456,27 +456,28 @@ fn extend_default_packages(
     }
 }
 
+fn base_packages_without_display_overrides(base_packages: Vec<String>) -> Vec<String> {
+    base_packages
+        .into_iter()
+        .filter(|package| {
+            crate::inline_env::extract_conda_package_name(package)
+                .map(crate::inline_env::normalize_package_name)
+                .is_none_or(|name| name != "nbformat" && name != "pyarrow")
+        })
+        .collect()
+}
+
 fn uv_prewarmed_packages(extra: &[String], install_default_data_packages: bool) -> Vec<String> {
     // The launcher package is vendored post-creation. pyarrow and nbformat are
     // part of the managed notebook runtime so rich display formatters work by
     // default; user defaults can still override either package by name.
-    let mut packages = vec![
-        "ipykernel".to_string(),
-        "ipywidgets".to_string(),
-        "anywidget".to_string(),
-        "uv".to_string(),
-    ];
+    let mut packages = base_packages_without_display_overrides(kernel_env::uv_base_packages());
     extend_default_packages(&mut packages, extra, install_default_data_packages);
     packages
 }
 
 fn conda_prewarmed_packages(extra: &[String], install_default_data_packages: bool) -> Vec<String> {
-    let mut packages = vec![
-        "ipykernel".to_string(),
-        "ipywidgets".to_string(),
-        "anywidget".to_string(),
-        "pip".to_string(),
-    ];
+    let mut packages = base_packages_without_display_overrides(kernel_env::conda_base_packages());
     extend_default_packages(&mut packages, extra, install_default_data_packages);
     packages
 }
@@ -5828,6 +5829,25 @@ mod tests {
 
     #[cfg(unix)]
     use std::os::unix::fs::PermissionsExt;
+
+    #[test]
+    fn test_prewarmed_packages_derive_from_kernel_env_base_constants() {
+        assert_eq!(
+            uv_prewarmed_packages(&[], false),
+            vec![
+                "ipykernel".to_string(),
+                "ipywidgets".to_string(),
+                "anywidget".to_string(),
+                "uv".to_string(),
+                "nbformat".to_string(),
+                "pyarrow>=14".to_string(),
+            ]
+        );
+        assert_eq!(
+            conda_prewarmed_packages(&[], false),
+            kernel_env::conda_base_packages()
+        );
+    }
 
     #[test]
     fn test_uv_prewarmed_packages_include_required_display_deps() {


### PR DESCRIPTION
## Summary
- expose owned UV/Conda base-package helpers from `kernel-env` and reuse them in install/prewarm paths
- derive daemon UV/Conda prewarm bases from the `kernel-env` constants while preserving the existing `nbformat`/`pyarrow` override behavior and UV package order
- refresh the kernel-env agent guidance table for the Conda base package set

No daemon package set changes are intended. The daemon still re-adds display packages after user defaults so `nbformat`/`pyarrow` overrides keep the prior behavior.

One latent helper behavior does intentionally change with the centralization: the currently uncalled `create_prewarmed_environment_in` helpers now draw from the full `kernel-env` base package constants instead of their previous narrower inline lists. Pullfrog verified this has no runtime impact today because the daemon prewarms through `spawn_warm_env` and the derived `*_prewarmed_packages(...)` path.

## Verification
- `cargo test -p kernel-env strip_base --lib`
- `cargo test -p kernel-env managed_specs --lib`
- `cargo test -p runtimed prewarmed_packages --lib`
- `cargo test -p runtimed effective_user_deps_from_launched --lib`
- `git diff --check`
- `cargo xtask lint --fix`
