### PR TITLE
ci: route mcp widget through artifact guard

### DIFF
--- a/.agents/skills/daemon-dev/SKILL.md
+++ b/.agents/skills/daemon-dev/SKILL.md
@@ -43,12 +43,12 @@ The daemon (`runtimed`) is a singleton coordinating notebook windows over a Unix
 
 ### How `cargo xtask build` works (4 phases)
 
-0. **Artifact guard** — verify gitignored WASM + renderer-plugin outputs. Build/dev commands fingerprint workspace inputs and skip wasm-pack when outputs are current; rebuild only when outputs are missing, invalid, or stale.
+0. **Artifact guard** — verify gitignored WASM, renderer-plugin, and MCP widget outputs. Build/dev commands fingerprint workspace inputs and skip wasm-pack when outputs are current; rebuild only when outputs are missing, invalid, or stale.
 1. **Single Rust compilation** — `cargo build -p runtimed -p runt -p mcp-supervisor -p notebook`. Sidecars copied to `crates/notebook/binaries/`.
 2. **Frontend build** — `pnpm build` (TypeScript + Vite). `--rust-only` skips this.
 3. **Tauri link** — `cargo tauri build --debug --no-bundle` with embedded frontend assets. Use `--skip-tauri` only for fast edit checks where updated sidecar binaries are enough; run a normal build before launching the bundled app.
 
-All Rust targets build in one `cargo build` call to avoid feature-unification recompilation. WASM outputs are gitignored; `runtimed`'s `build.rs` panics if missing.
+All Rust targets build in one `cargo build` call to avoid feature-unification recompilation. WASM outputs are gitignored; `runtimed`'s `build.rs` panics if missing. `nteract-mcp` embeds the MCP widget HTML; prepare it with `cargo xtask artifacts ensure mcp-widget`.
 
 ### WASM rebuild
 

--- a/.github/actions/build-runtime-artifacts/action.yml
+++ b/.github/actions/build-runtime-artifacts/action.yml
@@ -5,9 +5,10 @@ description: >-
   them on every workflow run.
 
   Idempotent: pnpm install --frozen-lockfile / wasm-pack install /
-  cargo xtask artifacts ensure runtime,sift,renderer tolerate a re-run. Caller
-  is responsible for setting up Rust toolchain + rust-cache before invoking;
-  this action only adds Node, pnpm, wasm-pack, and runs the build.
+  cargo xtask artifacts ensure runtime,sift,renderer and optional mcp-widget
+  builds tolerate a re-run. Caller is responsible for setting up Rust toolchain
+  + rust-cache before invoking; this action only adds Node, pnpm, wasm-pack,
+  and runs the build.
 
   Pass skip-wasm: true when pre-built WASM artifacts have already been
   downloaded from an earlier job (the build-wasm pattern). The downloaded
@@ -28,6 +29,11 @@ inputs:
     description: >-
       Skip WASM + renderer-plugin builds. Use when pre-built artifacts
       have been downloaded from a build-wasm job.
+    required: false
+    default: "false"
+  include-mcp-widget:
+    description: >-
+      Also ensure the MCP output widget artifact used by runt-mcp's include_str!.
     required: false
     default: "false"
 
@@ -106,3 +112,8 @@ runs:
       if: inputs.skip-wasm != 'true'
       shell: bash
       run: cargo xtask artifacts ensure runtime,sift,renderer
+
+    - name: Build MCP output widget artifact
+      if: inputs.include-mcp-widget == 'true'
+      shell: bash
+      run: cargo xtask artifacts ensure mcp-widget

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -297,11 +297,10 @@ jobs:
           APT
           rustup target add x86_64-pc-windows-gnu
 
-      # Build wasm + renderer plugins (gitignored; runtimed embeds them)
+      # Build wasm + renderer plugins and MCP widget HTML (gitignored; runtimed/runt-mcp embed them)
       - uses: ./.github/actions/build-runtime-artifacts
-
-      # Build MCP output widget HTML (needed by runt-mcp's include_str!)
-      - run: pnpm --filter nteract-mcp-app install --frozen-lockfile && pnpm exec vp run nteract-mcp-app#build
+        with:
+          include-mcp-widget: true
 
       - name: Clippy (Windows cross-check)
         # runtimed-node stays excluded here: napi's build script needs libnode.dll
@@ -399,8 +398,11 @@ jobs:
 
       # The notebook Vite build imports from apps/notebook/src/renderer-plugins/
       # and apps/notebook/src/wasm/runtimed-wasm/, both gitignored. Rebuild
-      # before pnpm build.
+      # before pnpm build. Also build the MCP widget so apps/mcp-app changes
+      # get a frontend build signal in PR CI.
       - uses: ./.github/actions/build-runtime-artifacts
+        with:
+          include-mcp-widget: true
 
       - name: Build UIs
         run: |
@@ -558,9 +560,7 @@ jobs:
       - uses: ./.github/actions/build-runtime-artifacts
         with:
           skip-wasm: true
-
-      # Build MCP output widget HTML (needed by runt-mcp's include_str!)
-      - run: pnpm --filter nteract-mcp-app install --frozen-lockfile && pnpm exec vp run nteract-mcp-app#build
+          include-mcp-widget: true
 
       - name: Build external binaries
         shell: bash
@@ -649,11 +649,10 @@ jobs:
         with:
           shared-key: ubuntu-clippy
 
-      # Build wasm + renderer plugins (gitignored; runtimed embeds them)
+      # Build wasm + renderer plugins and MCP widget HTML (gitignored; runtimed/runt-mcp embed them)
       - uses: ./.github/actions/build-runtime-artifacts
-
-      # Build MCP output widget HTML (needed by runt-mcp's include_str!)
-      - run: pnpm --filter nteract-mcp-app install --frozen-lockfile && pnpm exec vp run nteract-mcp-app#build
+        with:
+          include-mcp-widget: true
 
       # Excludes: notebook (needs bundled binaries, checked in build-linux),
       # runtimed-wasm (needs wasm-pack, tested in wasm-deno),
@@ -691,11 +690,10 @@ jobs:
         with:
           shared-key: ubuntu-clippy
 
-      # Build wasm + renderer plugins (gitignored; runtimed embeds them)
+      # Build wasm + renderer plugins and MCP widget HTML (gitignored; runtimed/runt-mcp embed them)
       - uses: ./.github/actions/build-runtime-artifacts
-
-      # Build MCP output widget HTML (needed by runt-mcp's include_str!)
-      - run: pnpm --filter nteract-mcp-app install --frozen-lockfile && pnpm exec vp run nteract-mcp-app#build
+        with:
+          include-mcp-widget: true
 
       - name: Run tests
         run: cargo test --workspace --exclude notebook --exclude runtimed-wasm --exclude sift-wasm --exclude runtimed-py --exclude runtimed-node --verbose
@@ -848,10 +846,7 @@ jobs:
         if: needs.changes.outputs.source_changed == 'true' && (github.event_name != 'pull_request' || matrix.platform.run_on_pr)
         with:
           skip-wasm: true
-
-      # Build MCP output widget HTML (needed by runt-mcp's include_str!)
-      - run: pnpm --filter nteract-mcp-app install --frozen-lockfile && pnpm exec vp run nteract-mcp-app#build
-        if: needs.changes.outputs.source_changed == 'true' && (github.event_name != 'pull_request' || matrix.platform.run_on_pr)
+          include-mcp-widget: true
 
       - name: Build external binaries
         if: needs.changes.outputs.source_changed == 'true' && (github.event_name != 'pull_request' || matrix.platform.run_on_pr)

--- a/.github/workflows/pr-binary-generation.yml
+++ b/.github/workflows/pr-binary-generation.yml
@@ -96,6 +96,8 @@ jobs:
       # Build wasm + renderer plugins (gitignored; runtimed embeds them).
       # Also handles node + pnpm + vp + pnpm install --frozen-lockfile setup.
       - uses: ./.github/actions/build-runtime-artifacts
+        with:
+          include-mcp-widget: true
 
       - name: Build frontend
         run: pnpm build
@@ -143,12 +145,6 @@ jobs:
 
       - name: Generate icons
         run: cargo xtask icons
-
-      # Build MCP output widget HTML (needed by runt-mcp's include_str!).
-      # build-runtime-artifacts already ran the cargo xtask wasm chain
-      # earlier in this job; this only adds the small _output.html file.
-      - name: Build MCP output widget
-        run: pnpm --filter nteract-mcp-app install --frozen-lockfile && pnpm exec vp run nteract-mcp-app#build
 
       - name: Build external binaries (Unix)
         if: runner.os != 'Windows'

--- a/.github/workflows/release-common.yml
+++ b/.github/workflows/release-common.yml
@@ -151,6 +151,7 @@ jobs:
       - uses: ./.github/actions/build-runtime-artifacts
         with:
           skip-wasm: true
+          include-mcp-widget: true
 
       - name: Set version in Cargo.toml
         run: |
@@ -158,10 +159,6 @@ jobs:
           echo "Setting version to: ${VERSION}"
           sed -i "s/^version = .*/version = \"${VERSION}\"/" crates/runt/Cargo.toml
           sed -i "s/^version = .*/version = \"${VERSION}\"/" crates/runtimed/Cargo.toml
-
-      # Build MCP output widget HTML (needed by runt-mcp's include_str!)
-      - name: Build MCP output widget
-        run: pnpm --filter nteract-mcp-app install --frozen-lockfile && pnpm exec vp run nteract-mcp-app#build
 
       - name: Build for Linux x64
         run: cargo build --release --target x86_64-unknown-linux-gnu -p runt -p runtimed -p nteract-mcp
@@ -215,6 +212,7 @@ jobs:
       - uses: ./.github/actions/build-runtime-artifacts
         with:
           skip-wasm: true
+          include-mcp-widget: true
 
       - name: Set version in Cargo.toml
         run: |
@@ -222,10 +220,6 @@ jobs:
           echo "Setting version to: ${VERSION}"
           sed -i '' "s/^version = .*/version = \"${VERSION}\"/" crates/runt/Cargo.toml
           sed -i '' "s/^version = .*/version = \"${VERSION}\"/" crates/runtimed/Cargo.toml
-
-      # Build MCP output widget HTML (needed by runt-mcp's include_str!)
-      - name: Build MCP output widget
-        run: pnpm --filter nteract-mcp-app install --frozen-lockfile && pnpm exec vp run nteract-mcp-app#build
 
       - name: Build for macOS ARM64
         run: cargo build --release --target aarch64-apple-darwin -p runt
@@ -276,6 +270,7 @@ jobs:
       - uses: ./.github/actions/build-runtime-artifacts
         with:
           skip-wasm: true
+          include-mcp-widget: true
 
       - name: Build frontend
         run: pnpm build
@@ -339,10 +334,6 @@ jobs:
             ICON_SOURCE="crates/notebook/icons/source-nightly.png"
           fi
           cargo xtask icons "$ICON_SOURCE"
-
-      # Build MCP output widget HTML (needed by runt-mcp's include_str!)
-      - name: Build MCP output widget
-        run: pnpm --filter nteract-mcp-app install --frozen-lockfile && pnpm exec vp run nteract-mcp-app#build
 
       - name: Build external binaries
         run: |
@@ -450,6 +441,7 @@ jobs:
       - uses: ./.github/actions/build-runtime-artifacts
         with:
           skip-wasm: true
+          include-mcp-widget: true
 
       - name: Build frontend
         run: pnpm build
@@ -513,10 +505,6 @@ jobs:
             ICON_SOURCE="crates/notebook/icons/source-nightly.png"
           fi
           cargo xtask icons "$ICON_SOURCE"
-
-      # Build MCP output widget HTML (needed by runt-mcp's include_str!)
-      - name: Build MCP output widget
-        run: pnpm --filter nteract-mcp-app install --frozen-lockfile && pnpm exec vp run nteract-mcp-app#build
 
       - name: Build external binaries
         run: |
@@ -628,6 +616,7 @@ jobs:
       - uses: ./.github/actions/build-runtime-artifacts
         with:
           skip-wasm: true
+          include-mcp-widget: true
 
       - name: Build frontend
         run: pnpm build
@@ -681,10 +670,6 @@ jobs:
             $iconSource = "crates/notebook/icons/source-nightly.png"
           }
           cargo xtask icons $iconSource
-
-      # Build MCP output widget HTML (needed by runt-mcp's include_str!)
-      - name: Build MCP output widget
-        run: pnpm --filter nteract-mcp-app install --frozen-lockfile && pnpm exec vp run nteract-mcp-app#build
 
       - name: Build external binaries
         shell: bash
@@ -808,6 +793,7 @@ jobs:
       - uses: ./.github/actions/build-runtime-artifacts
         with:
           skip-wasm: true
+          include-mcp-widget: true
 
       - name: Build frontend
         run: pnpm build
@@ -843,10 +829,6 @@ jobs:
             ICON_SOURCE="crates/notebook/icons/source-nightly.png"
           fi
           cargo xtask icons "$ICON_SOURCE"
-
-      # Build MCP output widget HTML (needed by runt-mcp's include_str!)
-      - name: Build MCP output widget
-        run: pnpm --filter nteract-mcp-app install --frozen-lockfile && pnpm exec vp run nteract-mcp-app#build
 
       - name: Build external binaries
         run: |

--- a/.github/workflows/smoke.yml
+++ b/.github/workflows/smoke.yml
@@ -47,19 +47,16 @@ jobs:
         with:
           shared-key: windows-smoke
 
-      - name: Build runtime artifacts (wasm + renderer plugins)
+      - name: Build runtime artifacts (wasm + renderer plugins + MCP widget)
         uses: ./.github/actions/build-runtime-artifacts
+        with:
+          include-mcp-widget: true
 
       - name: Build frontend
         run: pnpm build
 
       - name: Install Tauri CLI
         uses: ./.github/actions/install-tauri-cli
-
-      # Build the MCP output widget HTML. runt-mcp's include_str! needs it
-      # before we compile the Rust binaries.
-      - name: Build MCP output widget
-        run: pnpm --filter nteract-mcp-app install --frozen-lockfile && pnpm exec vp run nteract-mcp-app#build
 
       - name: Build external binaries
         shell: bash
@@ -416,13 +413,10 @@ jobs:
         with:
           shared-key: linux-smoke
 
-      - name: Build runtime artifacts (wasm + renderer plugins)
+      - name: Build runtime artifacts (wasm + renderer plugins + MCP widget)
         uses: ./.github/actions/build-runtime-artifacts
-
-      # runt-mcp's include_str! pulls in the MCP output widget HTML. Build
-      # before compiling Rust so the assets/_output.html target exists.
-      - name: Build MCP output widget
-        run: pnpm --filter nteract-mcp-app install --frozen-lockfile && pnpm exec vp run nteract-mcp-app#build
+        with:
+          include-mcp-widget: true
 
       - name: Build runtimed and runt
         run: cargo build --release -p runtimed -p runt -p nteract-mcp

--- a/crates/runt-mcp/build.rs
+++ b/crates/runt-mcp/build.rs
@@ -1,9 +1,9 @@
 //! Ensure `assets/_output.html` exists so `include_str!` in `resources.rs`
 //! never fails during `cargo check` or `cargo build` in a fresh worktree.
 //!
-//! The real asset is built by `apps/mcp-app/build-html.js` (via `cargo xtask
-//! build` or `pnpm build` in `apps/mcp-app`). This build script only creates
-//! a minimal placeholder when the file is missing.
+//! The real asset is built by `apps/mcp-app/build-html.js` through
+//! `cargo xtask artifacts ensure mcp-widget`. This build script only creates a
+//! minimal placeholder when the file is missing.
 //!
 //! **Release builds refuse the placeholder** — shipping a stub instead of the
 //! real output renderer would be a silent regression.
@@ -22,7 +22,8 @@ fn main() {
         if is_release {
             panic!(
                 "assets/_output.html is missing — cannot build runt-mcp in release mode \
-                 without the real output renderer. Run `cargo xtask build` first."
+                 without the real output renderer. Run \
+                 `cargo xtask artifacts ensure mcp-widget` first."
             );
         }
         std::fs::create_dir_all("assets").ok();

--- a/crates/runt-mcp/src/resources.rs
+++ b/crates/runt-mcp/src/resources.rs
@@ -19,7 +19,7 @@ const CELLS_MIME_TYPE: &str = "application/json";
 const NOTEBOOK_CONTEXT_PRIORITY: f32 = 0.8;
 
 /// The compiled output renderer HTML, built by `apps/mcp-app/build-html.js`.
-/// Build with: `cd apps/mcp-app && pnpm build`
+/// Build with: `cargo xtask artifacts ensure mcp-widget`
 /// The build script copies the file to `crates/runt-mcp/assets/_output.html`.
 const OUTPUT_HTML: &str = include_str!("../assets/_output.html");
 

--- a/crates/xtask/src/main.rs
+++ b/crates/xtask/src/main.rs
@@ -616,7 +616,7 @@ fn cmd_vite() {
 fn ensure_pnpm_install() {
     if let Some(reason) = pnpm_install_reason() {
         println!("Running pnpm install ({reason})...");
-        run_cmd("pnpm", &["install"]);
+        run_cmd(pnpm_bin(), &["install"]);
     } else {
         println!("Skipping pnpm install (node_modules is up to date).");
     }


### PR DESCRIPTION
## Summary
- add an opt-in `include-mcp-widget` input to the reusable runtime-artifact action
- replace duplicated raw MCP widget `pnpm` workflow steps with `cargo xtask artifacts ensure mcp-widget` through that action
- make `ensure_pnpm_install()` use the Windows-safe `pnpm_bin()` helper and refresh stale runt-mcp/daemon guidance comments

This keeps the widget build immediately before `nteract-mcp` consumers while giving `apps/mcp-app/**` frontend changes a CI build signal through `build-ui`.

## Verification
- `cargo xtask artifacts status mcp-widget`
- `cargo xtask artifacts ensure mcp-widget`
- `cargo xtask artifacts verify mcp-widget`
- `cargo build -p nteract-mcp`
- `cargo build --release -p nteract-mcp`
- `cargo test -p xtask parse_artifact_command --bin xtask`
- `cargo test -p nteract-mcp`
- `actionlint -color .github/workflows/build.yml .github/workflows/release-common.yml .github/workflows/smoke.yml .github/workflows/pr-binary-generation.yml`
- composite action YAML parse/import check for `include-mcp-widget`
- `git diff --check`
- `cargo xtask lint --fix`

Note: `cargo test -p nteract-mcp --lib` is not applicable because the package has no library target; `cargo test -p nteract-mcp` passed.