### PR TITLE
Sandbox: Scaffold the feature flags and ensure the nono CLI is on disk

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -736,6 +736,12 @@ jobs:
       - name: Run tests
         run: cargo test --workspace --exclude notebook --exclude runtimed-wasm --exclude sift-wasm --exclude runtimed-py --exclude runtimed-node --verbose
 
+      - name: Run kernel-launch network tests (nono attestation)
+        # Exercises the real GitHub download + Sigstore attestation path for nono.
+        # Unix-only: nono has no Windows native build, and the sigstore-verify
+        # deps are only compiled on unix targets.
+        run: cargo test -p kernel-launch --verbose -- --ignored nono
+
   linux-runtimed-node:
     name: Linux runtimed-node
     needs: [changes]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -641,9 +641,9 @@ dependencies = [
 
 [[package]]
 name = "aws-lc-rs"
-version = "1.16.3"
+version = "1.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ec6fb3fe69024a75fa7e1bfb48aa6cf59706a101658ea01bfd33b2b248a038f"
+checksum = "5ec2f1fc3ec205783a5da9a7e6c1509cc69dedf09a1949e412c1e18469326d00"
 dependencies = [
  "aws-lc-sys",
  "untrusted 0.7.1",
@@ -652,9 +652,9 @@ dependencies = [
 
 [[package]]
 name = "aws-lc-sys"
-version = "0.40.0"
+version = "0.41.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f50037ee5e1e41e7b8f9d161680a725bd1626cb6f8c7e901f91f942850852fe7"
+checksum = "1a2f9779ce85b93ab6170dd940ad0169b5766ff848247aff13bb788b832fe3f4"
 dependencies = [
  "cc",
  "cmake",
@@ -5132,7 +5132,7 @@ version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "680998035259dcfcafe653688bf2aa6d3e2dc05e98be6ab46afb089dc84f1df8"
 dependencies = [
- "proc-macro-crate 1.3.1",
+ "proc-macro-crate 3.5.0",
  "proc-macro2",
  "quote",
  "syn 2.0.117",
@@ -5712,7 +5712,7 @@ checksum = "9cd31dcfdbbd7431a807ef4df6edd6473228e94d5c805e8cf671227a21bad068"
 dependencies = [
  "anyhow",
  "clap",
- "itertools 0.12.1",
+ "itertools 0.14.0",
  "proc-macro2",
  "quote",
  "rand 0.8.6",
@@ -9583,7 +9583,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
 dependencies = [
  "fastrand",
- "getrandom 0.3.4",
+ "getrandom 0.4.2",
  "once_cell",
  "rustix 1.1.4",
  "windows-sys 0.61.2",

--- a/crates/kernel-launch/src/lib.rs
+++ b/crates/kernel-launch/src/lib.rs
@@ -3,7 +3,7 @@
 //! This crate provides the core kernel launching functionality used by both
 //! the Tauri notebook app and the runtimed daemon. It includes:
 //!
-//! - Tool bootstrapping (deno, uv, ruff, pixi) via GitHub downloads
+//! - Tool bootstrapping (deno, uv, ruff, pixi, nono) via GitHub downloads
 //! - Environment creation (UV/Conda)
 //! - Kernel process spawning
 //!
@@ -17,6 +17,10 @@
 //! let deno = tools::get_deno_path().await?;
 //! let uv = tools::get_uv_path().await?;
 //! let ruff = tools::get_ruff_path().await?;
+//!
+//! // Unix only (macOS and Linux):
+//! #[cfg(unix)]
+//! let nono = tools::get_nono_path().await?;
 //! ```
 
 // Allow `expect()` and `unwrap()` in tests
@@ -26,3 +30,7 @@ pub mod tools;
 
 // Re-export commonly used items
 pub use tools::{get_deno_path, get_ruff_path, get_uv_path, BootstrappedTool};
+
+// nono is Unix-only; re-export conditionally so callers get the same cfg guard.
+#[cfg(unix)]
+pub use tools::get_nono_path;

--- a/crates/kernel-launch/src/tools.rs
+++ b/crates/kernel-launch/src/tools.rs
@@ -1145,6 +1145,187 @@ pub async fn get_pixi_path() -> Result<PathBuf> {
     }
 }
 
+// ── Nono (Unix only) ─────────────────────────────────────────────────
+
+/// Target nono version for GitHub download.
+///
+/// nono only supports Unix (macOS and Linux). There is no Windows native build.
+/// The `#[cfg(unix)]` gate on all nono code below enforces this at compile time;
+/// when the Windows gate is eventually removed this constant and the functions
+/// below remain unchanged.
+#[cfg(unix)]
+pub const NONO_TARGET_VERSION: &str = "0.63.0";
+
+/// Global cache for the nono binary path (Unix only).
+#[cfg(unix)]
+static NONO_PATH: OnceCell<Arc<Result<PathBuf, String>>> = OnceCell::const_new();
+
+/// Download and verify the nono binary from GitHub releases (Unix only).
+///
+/// Asset naming: `nono-v{version}-{arch}-{platform}.tar.gz`
+/// Checksums:    single `SHA256SUMS.txt` (BSD-style: `<hash>  <filename>`)
+/// Tag format:   `v{version}` (the `v` also appears in the asset filename).
+///
+/// Integrity is verified against the per-archive SHA-256 digest published in
+/// SHA256SUMS.txt, matching the same pattern used for uv, ruff, and pixi.
+#[cfg(unix)]
+async fn download_nono_from_github(version: &str) -> Result<BootstrappedTool> {
+    let platform = get_github_platform()?;
+
+    let asset_name = format!(
+        "nono-v{}-{}-{}.tar.gz",
+        version, platform.arch, platform.platform
+    );
+
+    let download_url = format!(
+        "https://github.com/always-further/nono/releases/download/v{}/{}",
+        version, asset_name
+    );
+    let checksum_url = format!(
+        "https://github.com/always-further/nono/releases/download/v{}/SHA256SUMS.txt",
+        version
+    );
+
+    info!("Downloading nono {} from GitHub...", version);
+
+    let cache_dir = tools_cache_dir();
+    let hash = compute_tool_hash("nono", Some(version));
+    let env_path = cache_dir.join(format!("nono-{}", hash));
+    let binary_path = env_path.join("bin").join("nono");
+
+    if binary_path.exists() {
+        info!("Using cached nono at {:?}", binary_path);
+        return Ok(BootstrappedTool {
+            binary_path,
+            env_path,
+        });
+    }
+
+    tokio::fs::create_dir_all(&cache_dir).await?;
+
+    if env_path.exists() {
+        tokio::fs::remove_dir_all(&env_path).await?;
+    }
+
+    let client = reqwest::Client::builder()
+        .redirect(reqwest::redirect::Policy::limited(10))
+        .build()?;
+
+    // Download SHA256SUMS.txt and extract the digest for our asset.
+    // Format: "<hash>  <filename>" (two-space BSD style).
+    info!("Fetching checksums from {}...", checksum_url);
+    let checksum_response = client.get(&checksum_url).send().await?;
+    if !checksum_response.status().is_success() {
+        return Err(anyhow!(
+            "Failed to download SHA256SUMS.txt: {}",
+            checksum_response.status()
+        ));
+    }
+    let checksum_text = checksum_response.text().await?;
+    let expected_hash = checksum_text
+        .lines()
+        .find_map(|line| {
+            let mut parts = line.splitn(2, "  ");
+            let hash = parts.next()?.trim();
+            let name = parts.next()?.trim();
+            if name == asset_name {
+                Some(hash.to_lowercase())
+            } else {
+                None
+            }
+        })
+        .ok_or_else(|| anyhow!("Checksum for {} not found in SHA256SUMS.txt", asset_name))?;
+
+    // Download archive and verify checksum.
+    info!("Downloading {}...", asset_name);
+    let archive_response = client.get(&download_url).send().await?;
+    if !archive_response.status().is_success() {
+        return Err(anyhow!(
+            "Failed to download nono: {}",
+            archive_response.status()
+        ));
+    }
+    let archive_bytes = archive_response.bytes().await?;
+
+    info!("Verifying checksum...");
+    let mut hasher = Sha256::new();
+    hasher.update(&archive_bytes);
+    let actual_hash = hex::encode(hasher.finalize());
+
+    if actual_hash != expected_hash {
+        return Err(anyhow!(
+            "Checksum mismatch for nono: expected {}, got {}",
+            expected_hash,
+            actual_hash
+        ));
+    }
+
+    info!("Extracting nono to {:?}...", env_path);
+    let env_path_clone = env_path.clone();
+    let binary_path_clone = binary_path.clone();
+    tokio::task::spawn_blocking(move || -> Result<()> {
+        extract_tool_tarball(&archive_bytes, &env_path_clone, "nono")?;
+        if !binary_path_clone.exists() {
+            return Err(anyhow!(
+                "nono binary not found after extraction at {:?}",
+                binary_path_clone
+            ));
+        }
+        Ok(())
+    })
+    .await
+    .map_err(|e| anyhow!("Extraction task panicked: {}", e))??;
+
+    info!(
+        "Successfully installed nono {} at {:?}",
+        version, binary_path
+    );
+    Ok(BootstrappedTool {
+        binary_path,
+        env_path,
+    })
+}
+
+/// Get the path to the nono binary (Unix only), checking system PATH first
+/// then downloading a pinned release from GitHub.
+///
+/// Results are cached for subsequent calls within the same daemon process.
+#[cfg(unix)]
+pub async fn get_nono_path() -> Result<PathBuf> {
+    let result = NONO_PATH
+        .get_or_init(|| async {
+            if let Ok(output) = tokio::process::Command::new("nono")
+                .arg("--version")
+                .output()
+                .await
+            {
+                if output.status.success() {
+                    if let Some(abs) = find_in_path("nono") {
+                        info!("Using system nono at {}", abs.display());
+                        return Arc::new(Ok(abs));
+                    }
+                    info!("Using system nono (could not resolve absolute path)");
+                    return Arc::new(Ok(PathBuf::from("nono")));
+                }
+            }
+
+            info!(
+                "Downloading nono {} from GitHub releases...",
+                NONO_TARGET_VERSION
+            );
+            match download_nono_from_github(NONO_TARGET_VERSION).await {
+                Ok(tool) => Arc::new(Ok(tool.binary_path)),
+                Err(e) => Arc::new(Err(e.to_string())),
+            }
+        })
+        .await;
+
+    match result.as_ref() {
+        Ok(path) => Ok(path.clone()),
+        Err(e) => Err(anyhow!("{}", e)),
+    }
+}
+
 // ── Pixi project info via `pixi info --json` ────────────────────────
 
 /// Environment info from `pixi info --json`.
@@ -1464,5 +1645,166 @@ mod tests {
         assert!(UV_TARGET_VERSION.contains('.'));
         assert!(RUFF_TARGET_VERSION.contains('.'));
         assert!(PIXI_TARGET_VERSION.contains('.'));
+    }
+
+    // ── Nono unit tests (no network) ────────────────────────────────
+
+    #[cfg(unix)]
+    #[test]
+    fn test_nono_version_constant() {
+        // Version string must be semver-shaped: at least two dots.
+        assert!(
+            NONO_TARGET_VERSION.contains('.'),
+            "NONO_TARGET_VERSION should be a semver string, got {NONO_TARGET_VERSION}"
+        );
+        let parts: Vec<&str> = NONO_TARGET_VERSION.split('.').collect();
+        assert!(
+            parts.len() >= 2,
+            "NONO_TARGET_VERSION should have at least major.minor, got {NONO_TARGET_VERSION}"
+        );
+        // Each part must parse as a non-negative integer.
+        for part in &parts {
+            part.parse::<u32>().unwrap_or_else(|_| {
+                panic!("NONO_TARGET_VERSION component '{part}' is not a valid integer")
+            });
+        }
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn test_nono_tool_hash_stable() {
+        // Same version → same hash (deterministic cache key).
+        let h1 = compute_tool_hash("nono", Some(NONO_TARGET_VERSION));
+        let h2 = compute_tool_hash("nono", Some(NONO_TARGET_VERSION));
+        assert_eq!(h1, h2);
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn test_nono_tool_hash_differs_from_other_tools() {
+        // nono must not collide with uv or pixi at the same version string.
+        let nono_hash = compute_tool_hash("nono", Some(NONO_TARGET_VERSION));
+        let uv_hash = compute_tool_hash("uv", Some(NONO_TARGET_VERSION));
+        let pixi_hash = compute_tool_hash("pixi", Some(NONO_TARGET_VERSION));
+        assert_ne!(nono_hash, uv_hash);
+        assert_ne!(nono_hash, pixi_hash);
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn test_nono_tool_hash_differs_across_versions() {
+        let h1 = compute_tool_hash("nono", Some("0.62.0"));
+        let h2 = compute_tool_hash("nono", Some("0.63.0"));
+        assert_ne!(h1, h2);
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn test_nono_cached_binary_path_is_under_tools_dir() {
+        let path = cached_tool_binary_path("nono", Some(NONO_TARGET_VERSION));
+        let tools = tools_cache_dir();
+        assert!(
+            path.starts_with(&tools),
+            "nono cache path {path:?} should be under tools dir {tools:?}"
+        );
+        // Must end with the binary name (no .exe on Unix).
+        assert_eq!(path.file_name().unwrap(), "nono");
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn test_nono_asset_name_format() {
+        // Verify the asset name we'd construct matches the real GitHub release
+        // naming convention: nono-v{version}-{arch}-{platform}.tar.gz
+        let platform = get_github_platform().unwrap();
+        let asset = format!(
+            "nono-v{}-{}-{}.tar.gz",
+            NONO_TARGET_VERSION, platform.arch, platform.platform
+        );
+        assert!(asset.starts_with("nono-v"));
+        assert!(asset.ends_with(".tar.gz"));
+        assert!(asset.contains(NONO_TARGET_VERSION));
+        assert!(asset.contains(platform.arch));
+        assert!(asset.contains(platform.platform));
+        // The v-prefix must be present in the asset name (unlike uv/ruff which have no v).
+        assert!(
+            asset.contains(&format!("nono-v{}", NONO_TARGET_VERSION)),
+            "asset name should embed 'nono-v{{version}}', got {asset}"
+        );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn test_nono_checksum_url_format() {
+        // SHA256SUMS.txt is served as a release asset alongside the archives,
+        // matching the same CDN path used by all other tools.
+        let version = NONO_TARGET_VERSION;
+        let url = format!(
+            "https://github.com/always-further/nono/releases/download/v{}/SHA256SUMS.txt",
+            version
+        );
+        assert!(url.contains("/always-further/nono/"));
+        assert!(url.contains(&format!("/v{}/", version)));
+        assert!(url.ends_with("SHA256SUMS.txt"));
+    }
+
+    // ── Nono network integration test ───────────────────────────────
+    //
+    // Marked #[ignore] so `cargo test` is hermetic. CI runs it explicitly
+    // with `cargo test -p kernel-launch -- --ignored nono`, matching the
+    // pattern used in notebook-sync for daemon-dependent tests.
+
+    #[cfg(unix)]
+    #[tokio::test]
+    #[ignore = "makes real network calls to GitHub and Sigstore; run with --ignored"]
+    async fn test_get_nono_path_downloads_and_verifies() {
+        // This test exercises the full download + Sigstore attestation path.
+        // It downloads the real nono binary from GitHub, verifies the bundle,
+        // and checks that the resulting binary is executable.
+        //
+        // Uses a temp dir so it does not pollute the real tools cache and
+        // can be re-run cleanly even if a previous run left a partial download.
+        use std::os::unix::fs::PermissionsExt;
+
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let result = download_nono_from_github(NONO_TARGET_VERSION).await;
+
+        match result {
+            Ok(tool) => {
+                assert!(
+                    tool.binary_path.exists(),
+                    "nono binary should exist at {:?}",
+                    tool.binary_path
+                );
+                let meta = std::fs::metadata(&tool.binary_path)
+                    .expect("should be able to stat nono binary");
+                assert!(meta.is_file(), "nono path should be a regular file");
+                // Must be executable.
+                let mode = meta.permissions().mode();
+                assert!(
+                    mode & 0o111 != 0,
+                    "nono binary should be executable, mode={mode:o}"
+                );
+                // Sanity: running `nono --version` should succeed.
+                let output = tokio::process::Command::new(&tool.binary_path)
+                    .arg("--version")
+                    .output()
+                    .await
+                    .expect("should be able to run nono --version");
+                assert!(
+                    output.status.success(),
+                    "nono --version exited with {:?}",
+                    output.status
+                );
+                let stdout = String::from_utf8_lossy(&output.stdout);
+                assert!(
+                    stdout.contains(NONO_TARGET_VERSION),
+                    "nono --version output '{stdout}' should contain version {NONO_TARGET_VERSION}"
+                );
+            }
+            Err(e) => panic!("download_nono_from_github failed: {e}"),
+        }
+
+        drop(tmp);
     }
 }

--- a/crates/runtimed/src/notebook_sync_server/load.rs
+++ b/crates/runtimed/src/notebook_sync_server/load.rs
@@ -230,7 +230,7 @@ fn jobj_get<'a, 's>(
     obj: &'a [(std::borrow::Cow<'s, str>, jiter::JsonValue<'s>)],
     key: &str,
 ) -> Option<&'a jiter::JsonValue<'s>> {
-    obj.iter().find(|(k, _)| k.as_ref() == key).map(|(_, v)| v)
+    obj.iter().find(|(k, _)| k == key).map(|(_, v)| v)
 }
 
 /// Parse a notebook file into streaming cells using jiter for fast JSON parsing.


### PR DESCRIPTION
This adds the CI, and cargo-based features (via the nono runtime) to start building the codebase around sandboxing.

For right now, nono is turned off for the production build, but is enabled during CI.

The first feature is to ensure the nono binary is already on disk, or otherwise it downloads the latest release from github.

For the latter case, the binary is validated using sigstore