### PR TITLE
chore(review): switch bedrock reviewer to glm

### DIFF
--- a/.github/workflows/pullfrog.yml
+++ b/.github/workflows/pullfrog.yml
@@ -32,4 +32,4 @@ jobs:
         env:
           PULLFROG_AGENT: opencode
           AWS_REGION: us-east-1
-          BEDROCK_MODEL_ID: us.anthropic.claude-opus-4-8
+          BEDROCK_MODEL_ID: zai.glm-5

--- a/python/pr-reviewer/README.md
+++ b/python/pr-reviewer/README.md
@@ -35,8 +35,18 @@ opencode normally, then select a model using opencode's provider/model format.
 `AWS_REGION` can come from the environment or `--aws-region`, and credentials
 come from the AWS SDK credential chain used by opencode's Bedrock provider.
 
-The default model is `amazon-bedrock/us.anthropic.claude-opus-4-8`.
+The default model is `amazon-bedrock/zai.glm-5`.
 Set `PR_REVIEWER_OPENCODE=/path/to/opencode` to use a non-default binary.
 If opencode's Bedrock adapter returns an empty response for an `amazon-bedrock/`
-model, the reviewer falls back to a direct `aws bedrock-runtime invoke-model`
+model, the reviewer falls back to a direct `aws bedrock-runtime converse`
 call with the same model ID.
+
+## Model selection
+
+Use `amazon-bedrock/zai.glm-5` as the default cost/performance reviewer. For
+cheaper routine alignment passes, try `amazon-bedrock/zai.glm-4.7`; for quick
+smoke checks, try `amazon-bedrock/zai.glm-4.7-flash`. Promote newer models only
+after they appear in Bedrock and pass both `pr-review doctor` and real PR review
+comparisons. Keep model changes explicit in review metadata with `--model` or
+`PR_REVIEWER_MODEL` so adversarial review quality can be compared across real
+PRs instead of inferred from catalog pricing alone.

--- a/python/pr-reviewer/src/pr_reviewer/agent.py
+++ b/python/pr-reviewer/src/pr_reviewer/agent.py
@@ -257,34 +257,34 @@ async def run_bedrock_direct(
     model_id = config.model.removeprefix("amazon-bedrock/")
     with tempfile.TemporaryDirectory(prefix="pr-review-bedrock-") as temp_dir:
         temp_path = Path(temp_dir)
-        request_path = temp_path / "request.json"
-        response_path = temp_path / "response.json"
-        request_path.write_text(
+        messages_path = temp_path / "messages.json"
+        inference_config_path = temp_path / "inference-config.json"
+        messages_path.write_text(
             json.dumps(
-                {
-                    "anthropic_version": "bedrock-2023-05-31",
-                    "max_tokens": 4096,
-                    "messages": [
-                        {
-                            "role": "user",
-                            "content": [{"type": "text", "text": prompt}],
-                        }
-                    ],
-                }
+                [
+                    {
+                        "role": "user",
+                        "content": [{"text": prompt}],
+                    }
+                ]
             )
             + "\n"
         )
+        inference_config_path.write_text(json.dumps({"maxTokens": 4096}) + "\n")
         command = [
             "aws",
             "bedrock-runtime",
-            "invoke-model",
+            "converse",
             "--region",
             config.aws_region,
             "--model-id",
             model_id,
-            "--body",
-            f"fileb://{request_path}",
-            str(response_path),
+            "--messages",
+            f"file://{messages_path}",
+            "--inference-config",
+            f"file://{inference_config_path}",
+            "--output",
+            "json",
         ]
         proc = await asyncio.create_subprocess_exec(
             *command,
@@ -294,64 +294,59 @@ async def run_bedrock_direct(
         stdout_bytes, stderr_bytes = await communicate_with_timeout(
             proc,
             timeout_seconds=config.effective_timeout_seconds(),
-            timeout_label="direct Bedrock invoke",
+            timeout_label="direct Bedrock converse",
         )
         stdout = stdout_bytes.decode("utf-8", errors="replace")
         stderr = stderr_bytes.decode("utf-8", errors="replace")
         if proc.returncode != 0:
             raise RuntimeError(
-                f"direct Bedrock invoke exited with status {proc.returncode}: "
+                f"direct Bedrock converse exited with status {proc.returncode}: "
                 f"{stderr.strip() or stdout.strip()} "
                 f"(fallback reason: {fallback_reason})"
             )
         try:
-            response = json.loads(response_path.read_text())
-        except FileNotFoundError as exc:
-            raise RuntimeError(
-                "direct Bedrock invoke succeeded but did not create a response file "
-                f"(fallback reason: {fallback_reason})"
-            ) from exc
+            response = json.loads(stdout)
         except json.JSONDecodeError as exc:
             raise RuntimeError(
-                f"direct Bedrock invoke returned invalid JSON (fallback reason: {fallback_reason})"
+                "direct Bedrock converse returned invalid JSON "
+                f"(fallback reason: {fallback_reason})"
             ) from exc
         if not isinstance(response, dict):
             raise RuntimeError(
-                "direct Bedrock invoke response JSON was not an object "
+                "direct Bedrock converse response JSON was not an object "
                 f"(fallback reason: {fallback_reason})"
             )
-        content = response.get("content")
+        output = response.get("output")
+        message = output.get("message") if isinstance(output, dict) else None
+        content = message.get("content") if isinstance(message, dict) else None
         if not isinstance(content, list):
             raise RuntimeError(
-                "direct Bedrock invoke response did not include a content list "
+                "direct Bedrock converse response did not include message content "
                 f"(fallback reason: {fallback_reason})"
             )
         text = "".join(
             item["text"]
             for item in content
-            if isinstance(item, dict)
-            and item.get("type") == "text"
-            and isinstance(item.get("text"), str)
+            if isinstance(item, dict) and isinstance(item.get("text"), str)
         ).strip()
         if not text:
             raise RuntimeError(
-                "direct Bedrock invoke returned no text content "
+                "direct Bedrock converse returned no text content "
                 f"(fallback reason: {fallback_reason})"
             )
         usage = response.get("usage")
-        cost_usd = 0.0 if isinstance(usage, dict) else None
-        session_id = response.get("id") if isinstance(response.get("id"), str) else None
         return OpencodeRunResult(
             text=text,
-            session_id=session_id,
-            cost_usd=cost_usd,
+            session_id=opencode_session_id,
+            cost_usd=None,
             raw_metadata={
                 "fallback": {
                     "reason": fallback_reason,
                     "from": "opencode",
-                    "to": "aws bedrock-runtime invoke-model",
+                    "to": "aws bedrock-runtime converse",
                     "opencode_session_id": opencode_session_id,
                     "bedrock_model_id": model_id,
+                    "usage": usage if isinstance(usage, dict) else None,
                 }
             },
         )
@@ -442,5 +437,9 @@ async def run_architecture_review(
 
 
 async def run_doctor(config: ReviewerConfig) -> str:
-    run = await run_opencode("Reply exactly OK.", cwd=None, config=config)
+    run = await run_opencode(
+        "This is an automated smoke test. Reply with exactly OK and no other text.",
+        cwd=None,
+        config=config,
+    )
     return run.text

--- a/python/pr-reviewer/src/pr_reviewer/config.py
+++ b/python/pr-reviewer/src/pr_reviewer/config.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import os
 from dataclasses import dataclass
 
-DEFAULT_MODEL = "amazon-bedrock/us.anthropic.claude-opus-4-8"
+DEFAULT_MODEL = "amazon-bedrock/zai.glm-5"
 DEFAULT_OPENCODE_PATH = "opencode"
 DEFAULT_AWS_REGION = "us-east-1"
 DEFAULT_DOCTOR_MAX_TURNS = 1

--- a/python/pr-reviewer/tests/test_agent.py
+++ b/python/pr-reviewer/tests/test_agent.py
@@ -177,7 +177,13 @@ def test_run_doctor_uses_opencode(monkeypatch) -> None:
     result = asyncio.run(run_doctor(config))
 
     assert result == "OK."
-    assert calls == [("Reply exactly OK.", None, config)]
+    assert calls == [
+        (
+            "This is an automated smoke test. Reply with exactly OK and no other text.",
+            None,
+            config,
+        )
+    ]
 
 
 def test_build_opencode_env_writes_read_only_config(monkeypatch, tmp_path: Path) -> None:
@@ -263,17 +269,20 @@ def test_run_opencode_falls_back_to_direct_bedrock_when_empty(monkeypatch, tmp_p
         async def communicate(self, *args: bytes) -> tuple[bytes, bytes]:
             calls.append(("communicate", self.command, args))
             if self.command[0] == "aws":
-                response_path = Path(self.command[-1])
-                response_path.write_text(
+                return (
                     json.dumps(
                         {
-                            "id": "msg-direct",
-                            "content": [{"type": "text", "text": "DIRECT_OK"}],
-                            "usage": {"input_tokens": 1, "output_tokens": 1},
+                            "output": {
+                                "message": {
+                                    "role": "assistant",
+                                    "content": [{"text": "DIRECT_OK"}],
+                                }
+                            },
+                            "usage": {"inputTokens": 1, "outputTokens": 1, "totalTokens": 2},
                         }
-                    )
+                    ).encode(),
+                    b"",
                 )
-                return b"{}", b""
             return (
                 b'{"type":"step_finish","sessionID":"ses-empty","part":{"type":"step-finish","cost":0}}\n',
                 b"",
@@ -285,32 +294,33 @@ def test_run_opencode_falls_back_to_direct_bedrock_when_empty(monkeypatch, tmp_p
 
     monkeypatch.setattr(asyncio, "create_subprocess_exec", fake_create_subprocess_exec)
     config = ReviewerConfig(
-        model="amazon-bedrock/us.anthropic.claude-opus-4-8",
+        model="amazon-bedrock/zai.glm-5",
         aws_region="us-east-1",
     )
 
     result = asyncio.run(agent.run_opencode("prompt", cwd=tmp_path, config=config))
 
     assert result.text == "DIRECT_OK"
-    assert result.session_id == "msg-direct"
+    assert result.session_id == "ses-empty"
     assert result.raw_metadata == {
         "fallback": {
             "reason": agent.DIRECT_BEDROCK_FALLBACK_REASON,
             "from": "opencode",
-            "to": "aws bedrock-runtime invoke-model",
+            "to": "aws bedrock-runtime converse",
             "opencode_session_id": "ses-empty",
-            "bedrock_model_id": "us.anthropic.claude-opus-4-8",
+            "bedrock_model_id": "zai.glm-5",
+            "usage": {"inputTokens": 1, "outputTokens": 1, "totalTokens": 2},
         }
     }
     aws_command = calls[2][1]
     assert aws_command[:5] == (
         "aws",
         "bedrock-runtime",
-        "invoke-model",
+        "converse",
         "--region",
         "us-east-1",
     )
-    assert "us.anthropic.claude-opus-4-8" in aws_command
+    assert "zai.glm-5" in aws_command
 
 
 def test_run_opencode_reports_direct_bedrock_failure_reason(monkeypatch, tmp_path: Path) -> None:
@@ -332,14 +342,14 @@ def test_run_opencode_reports_direct_bedrock_failure_reason(monkeypatch, tmp_pat
 
     monkeypatch.setattr(asyncio, "create_subprocess_exec", fake_create_subprocess_exec)
     config = ReviewerConfig(
-        model="amazon-bedrock/us.anthropic.claude-opus-4-8",
+        model="amazon-bedrock/zai.glm-5",
         aws_region="us-east-1",
     )
 
     with pytest.raises(RuntimeError) as exc_info:
         asyncio.run(agent.run_opencode("prompt", cwd=tmp_path, config=config))
 
-    assert "direct Bedrock invoke exited with status 1: AccessDeniedException" in str(
+    assert "direct Bedrock converse exited with status 1: AccessDeniedException" in str(
         exc_info.value
     )
     assert "fallback reason: opencode produced empty text output" in str(exc_info.value)
@@ -350,20 +360,21 @@ def test_run_bedrock_direct_rejects_malformed_response(monkeypatch) -> None:
         returncode = 0
 
         async def communicate(self) -> tuple[bytes, bytes]:
-            return b"{}", b""
+            return (
+                json.dumps({"output": {"message": {"content": [{"toolUse": {}}]}}}).encode(),
+                b"",
+            )
 
     async def fake_create_subprocess_exec(*command: str, **kwargs: object) -> FakeProcess:
-        response_path = Path(command[-1])
-        response_path.write_text(json.dumps({"content": [{"type": "tool_use"}]}))
         return FakeProcess()
 
     monkeypatch.setattr(asyncio, "create_subprocess_exec", fake_create_subprocess_exec)
     config = ReviewerConfig(
-        model="amazon-bedrock/us.anthropic.claude-opus-4-8",
+        model="amazon-bedrock/zai.glm-5",
         aws_region="us-east-1",
     )
 
-    with pytest.raises(RuntimeError, match="direct Bedrock invoke returned no text content"):
+    with pytest.raises(RuntimeError, match="direct Bedrock converse returned no text content"):
         asyncio.run(
             agent.run_bedrock_direct(
                 "prompt",
@@ -395,12 +406,12 @@ def test_run_bedrock_direct_times_out_and_kills_process(monkeypatch) -> None:
 
     monkeypatch.setattr(asyncio, "create_subprocess_exec", fake_create_subprocess_exec)
     config = ReviewerConfig(
-        model="amazon-bedrock/us.anthropic.claude-opus-4-8",
+        model="amazon-bedrock/zai.glm-5",
         aws_region="us-east-1",
         timeout_seconds=0.01,
     )
 
-    with pytest.raises(RuntimeError, match="direct Bedrock invoke timed out after 0.0 seconds"):
+    with pytest.raises(RuntimeError, match="direct Bedrock converse timed out after 0.0 seconds"):
         asyncio.run(
             agent.run_bedrock_direct(
                 "prompt",

--- a/python/pr-reviewer/tests/test_config.py
+++ b/python/pr-reviewer/tests/test_config.py
@@ -4,7 +4,7 @@ from pr_reviewer.config import DEFAULT_MODEL, ReviewerConfig, estimate_review_tu
 def test_config_sets_default_opencode_model() -> None:
     config = ReviewerConfig(model=DEFAULT_MODEL, aws_region="us-west-2")
 
-    assert config.model == "amazon-bedrock/us.anthropic.claude-opus-4-8"
+    assert config.model == "amazon-bedrock/zai.glm-5"
     assert config.aws_region == "us-west-2"
     assert not hasattr(config, "effort")
     assert not hasattr(config, "setting_sources")


### PR DESCRIPTION
## Summary

- switch Pullfrog's Bedrock model from Claude Opus 4.8 to Z.AI GLM 5
- switch `pr-reviewer`'s default opencode model to `amazon-bedrock/zai.glm-5`
- move the direct Bedrock fallback from Anthropic-shaped `invoke-model` payloads to provider-neutral `bedrock-runtime converse`
- document the current review-model selection strategy for GLM 5, GLM 4.7, and GLM 4.7 Flash

## Verification

- `uv run pytest python/pr-reviewer/tests/test_config.py python/pr-reviewer/tests/test_agent.py -q`
- `uv run pr-review doctor`
- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/pullfrog.yml"); puts "yaml ok"'`
- `cargo xtask lint --fix`
- `git diff --check`

## Notes

GLM 5.2 is not currently exposed in the queried Bedrock catalog, so this PR uses `zai.glm-5` as the best available GLM reviewer on Bedrock.
