### PR TITLE
fix(release): pin nightly installer notes to release asset

### DIFF
--- a/.github/workflows/release-common.yml
+++ b/.github/workflows/release-common.yml
@@ -1402,6 +1402,8 @@ jobs:
           VERSION_SUFFIX: ${{ inputs.version_suffix }}
           COMMIT_SHA: ${{ github.sha }}
           RELEASE_INTRO: ${{ inputs.release_intro }}
+          RELEASE_REPO: ${{ github.repository }}
+          TAG_NAME: v${{ needs.compute-version.outputs.version }}
         run: |
           CLI_NAME="runt"
           DAEMON_NAME="runtimed"
@@ -1411,6 +1413,7 @@ jobs:
             DAEMON_NAME="runtimed-nightly"
             MCP_NAME="nteract-mcp-nightly"
           fi
+          INSTALLER_URL="https://github.com/${RELEASE_REPO}/releases/download/${TAG_NAME}/install-linux-release"
           {
             echo "$RELEASE_INTRO"
             echo ''
@@ -1433,12 +1436,26 @@ jobs:
             echo ''
             echo "macOS and Windows builds are signed. macOS builds are also notarized. Linux AppImage: \`chmod +x\` and run. DEB/RPM packages are not currently supported because runtimed is a per-user daemon managed by the app and CLI, not by system package-manager scripts."
             echo ''
-            echo "For Linux shell installs, download \`install-linux-release\` from this release or run:"
+            echo "For Linux/macOS shell installs, run the installer pinned to this release:"
             echo ''
             echo '```bash'
-            echo 'curl -fsSL https://sh.nteract.io | bash'
+            echo "curl -fsSL ${INSTALLER_URL} | bash"
             echo '```'
             echo ''
+            echo 'Headless workstation install:'
+            echo ''
+            echo '```bash'
+            echo "curl -fsSL ${INSTALLER_URL} | bash -s -- --headless"
+            echo '```'
+            echo ''
+            if [ "$VERSION_SUFFIX" != "nightly" ]; then
+              echo 'Latest stable shortcut:'
+              echo ''
+              echo '```bash'
+              echo 'curl -fsSL https://sh.nteract.io | bash'
+              echo '```'
+              echo ''
+            fi
             echo 'This release includes auto-update support. Existing installations will be notified of this update automatically.'
             echo ''
             echo "## ${CLI_NAME} (CLI)"

--- a/scripts/install-linux-release
+++ b/scripts/install-linux-release
@@ -102,6 +102,8 @@ case "$(uname -s):$(uname -m)" in
 esac
 
 REPO="nteract/nteract"
+# release-common.yml stamps these in the uploaded release asset so a copied
+# release installer with no args installs the exact channel and tag it came from.
 DEFAULT_CHANNEL="stable"
 DEFAULT_TAG=""
 CHANNEL="$DEFAULT_CHANNEL"

--- a/scripts/test-install-release
+++ b/scripts/test-install-release
@@ -59,6 +59,16 @@ make_linux_fixtures() {
   echo "fake appimage" > "$dir/nteract-stable-linux-x64.AppImage"
 }
 
+make_nightly_linux_fixtures() {
+  local dir="$1"
+  local log="$2"
+  mkdir -p "$dir"
+  make_fake_tool "$dir/runt-nightly-linux-x64" "$log"
+  make_fake_tool "$dir/runtimed-nightly-linux-x64" "$log"
+  make_fake_tool "$dir/nteract-mcp-nightly-linux-x64" "$log"
+  echo "fake nightly appimage" > "$dir/nteract-nightly-linux-x64.AppImage"
+}
+
 make_darwin_fixtures() {
   local dir="$1"
   local log="$2"
@@ -93,14 +103,16 @@ run_installer() {
   local home="$1"
   shift
   mkdir -p "$home"
-  HOME="$home" XDG_DATA_HOME="" bash "$INSTALLER" "$@"
+  HOME="$home" XDG_DATA_HOME="" bash "${INSTALLER_UNDER_TEST:-$INSTALLER}" "$@"
 }
 
 note "linux desktop install"
 LINUX_HOME="$WORK/linux-home"
 LINUX_LOG="$WORK/linux-calls.log"
 make_linux_fixtures "$WORK/linux-assets" "$LINUX_LOG"
-run_installer "$LINUX_HOME" --from-dir "$WORK/linux-assets" --no-start > "$WORK/linux-out.log"
+make_uname_shim "$WORK/shim-linux" "Linux" "x86_64"
+PATH="$WORK/shim-linux:$PATH" run_installer "$LINUX_HOME" \
+  --from-dir "$WORK/linux-assets" --no-start > "$WORK/linux-out.log"
 PREFIX="$LINUX_HOME/.local/share/nteract/stable"
 assert_file "$PREFIX/nteract.AppImage"
 assert_link "$LINUX_HOME/.local/bin/runt" "$PREFIX/bin/runt"
@@ -108,6 +120,26 @@ assert_link "$LINUX_HOME/.local/bin/runtimed" "$PREFIX/bin/runtimed"
 assert_link "$LINUX_HOME/.local/bin/nteract-mcp" "$PREFIX/bin/nteract-mcp"
 assert_link "$LINUX_HOME/.local/bin/nteract" "$PREFIX/nteract.AppImage"
 grep -q "runt daemon doctor --fix --no-start" "$LINUX_LOG" || fail "linux: daemon doctor --fix --no-start not invoked"
+
+note "linux nightly desktop install"
+NIGHTLY_HOME="$WORK/nightly-home"
+NIGHTLY_LOG="$WORK/nightly-calls.log"
+make_nightly_linux_fixtures "$WORK/nightly-assets" "$NIGHTLY_LOG"
+STAMPED_NIGHTLY_INSTALLER="$WORK/install-linux-release-nightly"
+sed \
+  -e 's/^DEFAULT_CHANNEL="stable"$/DEFAULT_CHANNEL="nightly"/' \
+  -e 's/^DEFAULT_TAG=""$/DEFAULT_TAG="v9.9.9-nightly.202601010101"/' \
+  "$INSTALLER" > "$STAMPED_NIGHTLY_INSTALLER"
+chmod 0755 "$STAMPED_NIGHTLY_INSTALLER"
+INSTALLER_UNDER_TEST="$STAMPED_NIGHTLY_INSTALLER" PATH="$WORK/shim-linux:$PATH" \
+  run_installer "$NIGHTLY_HOME" --from-dir "$WORK/nightly-assets" --no-start > "$WORK/nightly-out.log"
+NIGHTLY_PREFIX="$NIGHTLY_HOME/.local/share/nteract/nightly"
+assert_file "$NIGHTLY_PREFIX/nteract-nightly.AppImage"
+assert_link "$NIGHTLY_HOME/.local/bin/runt-nightly" "$NIGHTLY_PREFIX/bin/runt-nightly"
+assert_link "$NIGHTLY_HOME/.local/bin/runtimed-nightly" "$NIGHTLY_PREFIX/bin/runtimed-nightly"
+assert_link "$NIGHTLY_HOME/.local/bin/nteract-mcp-nightly" "$NIGHTLY_PREFIX/bin/nteract-mcp-nightly"
+assert_link "$NIGHTLY_HOME/.local/bin/nteract-nightly" "$NIGHTLY_PREFIX/nteract-nightly.AppImage"
+grep -q "runt-nightly daemon doctor --fix --no-start" "$NIGHTLY_LOG" || fail "nightly: daemon doctor --fix --no-start not invoked"
 
 note "darwin desktop install (explicit --applications-dir)"
 DARWIN_HOME="$WORK/darwin-home"


### PR DESCRIPTION
## Summary

- Change generated release notes to point Linux/macOS shell installs at the installer asset pinned to the current release tag.
- Keep the `https://sh.nteract.io` shortcut only on stable release notes so nightly users do not accidentally install latest stable.
- Add installer fixture coverage for the release-stamped nightly installer path.

## Verification

- `cargo xtask lint --fix`
- `bash -n scripts/install-linux-release && bash -n scripts/test-install-release`
- `bash scripts/test-install-release`
- `actionlint .github/workflows/release-common.yml`
- `git diff --check`

## Notes

- This remains draft pending GitHub CI.
