### PR TITLE
fix(cloud): recover materialized sync frame divergence

### DIFF
--- a/apps/notebook-cloud/src/room-materializer.ts
+++ b/apps/notebook-cloud/src/room-materializer.ts
@@ -101,6 +101,27 @@ export class RoomMaterializer {
   }
 
   async receiveFrame(peer: RoomPeer, frame: TypedFrame): Promise<RoomHostFrameResult> {
+    try {
+      return await this.receiveFrameWithCurrentHost(peer, frame);
+    } catch (error) {
+      if (!shouldRecoverReceiveFrame(frame, error)) {
+        throw error;
+      }
+      const recovered = await this.recoverHostFromLatestPublishedSnapshot(
+        `receive_${frameTypeNameForRecovery(frame.type)}`,
+        error,
+      );
+      if (!recovered) {
+        throw error;
+      }
+      return this.syncPeerWithCurrentHost(peer);
+    }
+  }
+
+  private async receiveFrameWithCurrentHost(
+    peer: RoomPeer,
+    frame: TypedFrame,
+  ): Promise<RoomHostFrameResult> {
     const canWriteAllNotebookChanges = peer.identity.scope === "owner";
     const encoded = encodeTypedFrame(frame.type, frame.payload);
     return this.withHost((host) =>
@@ -568,6 +589,42 @@ function stableRoomKey(value: string): string {
     hash = BigInt.asUintN(64, hash * 0x100000001b3n);
   }
   return hash.toString(16).padStart(16, "0");
+}
+
+function shouldRecoverReceiveFrame(frame: TypedFrame, error: unknown): boolean {
+  if (!isMaterializedSyncFrameForRecovery(frame.type)) {
+    return false;
+  }
+  return isRecoverableAutomergeSyncBoundaryError(errorMessage(error));
+}
+
+function isMaterializedSyncFrameForRecovery(type: FrameTypeValue): boolean {
+  return (
+    type === FrameType.AUTOMERGE_SYNC ||
+    type === FrameType.RUNTIME_STATE_SYNC ||
+    type === FrameType.COMMS_DOC_SYNC
+  );
+}
+
+function isRecoverableAutomergeSyncBoundaryError(message: string): boolean {
+  return (
+    /recursive use of an object detected which would lead to unsafe aliasing/i.test(message) ||
+    /\bPatchLogMismatch\b/i.test(message) ||
+    /patch logs cannot be shared between documents/i.test(message)
+  );
+}
+
+function frameTypeNameForRecovery(type: FrameTypeValue): string {
+  switch (type) {
+    case FrameType.AUTOMERGE_SYNC:
+      return "notebook_sync";
+    case FrameType.RUNTIME_STATE_SYNC:
+      return "runtime_state_sync";
+    case FrameType.COMMS_DOC_SYNC:
+      return "comms_doc_sync";
+    default:
+      return `frame_${type}`;
+  }
 }
 
 export function isMaterializedSyncFrame(type: FrameTypeValue): boolean {

--- a/apps/notebook-cloud/test/live-sync.test.ts
+++ b/apps/notebook-cloud/test/live-sync.test.ts
@@ -120,6 +120,14 @@ describe("cloud live sync", () => {
         FrameType.COMMS_DOC_SYNC,
         "room host rejected COMMS_DOC_SYNC frame: [cloud-room-comms-receive-sync] automerge operation failed: patch logs cannot be shared between documents; this probably means a PatchLog created for one document was reused with another",
       ],
+      [
+        FrameType.RUNTIME_STATE_SYNC,
+        "room host rejected RUNTIME_STATE_SYNC frame: Error: recursive use of an object detected which would lead to unsafe aliasing in rust",
+      ],
+      [
+        FrameType.COMMS_DOC_SYNC,
+        "room host rejected COMMS_DOC_SYNC frame: Error: recursive use of an object detected which would lead to unsafe aliasing in rust",
+      ],
     ] as const) {
       assert.equal(
         isRecoverableCloudFrameRejection({

--- a/apps/notebook-cloud/test/room-materializer.test.ts
+++ b/apps/notebook-cloud/test/room-materializer.test.ts
@@ -1345,6 +1345,106 @@ describe("RoomMaterializer", () => {
     assert.deepEqual([...(await state.storage.list({ prefix: "room-host:" })).keys()], []);
   });
 
+  it("recovers from a checkpoint host that fails while receiving a peer sync frame", async () => {
+    const state = fakeState();
+    const checkpointSnapshot = await createNotebookRoomSnapshot(
+      "demo",
+      "checkpoint-cell",
+      "Unreachable checkpoint edit\n",
+    );
+    const publishedSnapshot = await createNotebookRoomSnapshot(
+      "demo",
+      "published-cell",
+      "Recovered published snapshot after receive\n",
+    );
+    await Promise.all([
+      state.storage.put(
+        "room-host:notebook-doc",
+        arrayBufferFromBytes(checkpointSnapshot.notebookBytes),
+      ),
+      state.storage.put(
+        "room-host:runtime-state-doc",
+        arrayBufferFromBytes(checkpointSnapshot.runtimeStateBytes),
+      ),
+      state.storage.put("room-host:checkpoint", {
+        version: 4,
+        notebook_heads: checkpointSnapshot.notebookHeads,
+        runtime_state_heads: checkpointSnapshot.runtimeStateHeads,
+        saved_at: "2026-05-28T00:00:00.000Z",
+        published_revision_id: "revision-current",
+        published_notebook_heads: publishedSnapshot.notebookHeads,
+        published_runtime_state_heads: publishedSnapshot.runtimeStateHeads,
+      }),
+    ]);
+
+    const env = fakePublishedSnapshotEnv({
+      notebookId: "demo",
+      revisionId: "revision-current",
+      actorLabel: "user:dev:publisher/agent:runt-publish",
+      notebookBytes: publishedSnapshot.notebookBytes,
+      runtimeStateBytes: publishedSnapshot.runtimeStateBytes,
+    });
+
+    const materializer = new RoomMaterializer("demo", state, env);
+    const checkpointHost = await (
+      materializer as unknown as {
+        loadHost(): Promise<{
+          receive_peer_frame: (
+            peerId: string,
+            principal: string,
+            actorLabel: string,
+            connectionScope: string,
+            canWriteAllNotebookChanges: boolean,
+            encoded: Uint8Array,
+          ) => unknown;
+        }>;
+      }
+    ).loadHost();
+    checkpointHost.receive_peer_frame = () => {
+      throw new Error("recursive use of an object detected which would lead to unsafe aliasing");
+    };
+
+    const peer = {
+      id: "peer-viewer",
+      identity: authenticateDevRequest(
+        new Request("https://cloud.test/n/demo/sync?user=bob&operator=desktop:b&scope=viewer"),
+      ),
+    };
+    const viewer = NotebookHandle.create_bootstrap("user:dev:bob/desktop:b");
+
+    let result = await materializer.receiveFrame(peer, {
+      type: FrameType.AUTOMERGE_SYNC,
+      payload: new Uint8Array([1, 2, 3]),
+    });
+    for (let round = 0; round < 8; round += 1) {
+      const replies = applyOutboundToClient(result.outbound, peer.id, viewer);
+      if (replies.length === 0) {
+        break;
+      }
+      const outbound = [];
+      for (const reply of replies) {
+        const next = await materializer.receiveFrame(peer, {
+          type: FrameType.AUTOMERGE_SYNC,
+          payload: reply.slice(1),
+        });
+        outbound.push(...next.outbound);
+      }
+      result = {
+        changed: false,
+        notebook_changed: false,
+        runtime_state_changed: false,
+        outbound,
+      };
+    }
+
+    const cells = JSON.parse(viewer.get_cells_json()) as Array<{ id: string; source: string }>;
+    assert.deepEqual(
+      cells.map((cell) => [cell.id, cell.source]),
+      [["published-cell", "Recovered published snapshot after receive\n"]],
+    );
+    assert.deepEqual([...(await state.storage.list({ prefix: "room-host:" })).keys()], []);
+  });
+
   it("recovers from a published snapshot when stale checkpoint cleanup is over quota", async () => {
     const state = fakeState();
     const checkpointSnapshot = await createNotebookRoomSnapshot(

--- a/apps/notebook-cloud/viewer/live-sync.ts
+++ b/apps/notebook-cloud/viewer/live-sync.ts
@@ -637,12 +637,22 @@ export function isRecoverableCloudFrameRejection(message: SessionControlMessage)
     return true;
   }
   if (message.frame_type === FrameType.RUNTIME_STATE_SYNC) {
-    return isSyncDivergenceRejectionReason(message.reason, "cloud-room-state-receive-sync");
+    return (
+      isSyncDivergenceRejectionReason(message.reason, "cloud-room-state-receive-sync") ||
+      isRecoverableRoomHostSyncBoundaryRejection(message.reason)
+    );
   }
   if (message.frame_type === FrameType.COMMS_DOC_SYNC) {
-    return isSyncDivergenceRejectionReason(message.reason, "cloud-room-comms-receive-sync");
+    return (
+      isSyncDivergenceRejectionReason(message.reason, "cloud-room-comms-receive-sync") ||
+      isRecoverableRoomHostSyncBoundaryRejection(message.reason)
+    );
   }
   return false;
+}
+
+function isRecoverableRoomHostSyncBoundaryRejection(reason: string): boolean {
+  return /recursive use of an object detected which would lead to unsafe aliasing/i.test(reason);
 }
 
 function isSyncDivergenceRejectionReason(reason: string, docTag: string): boolean {

--- a/crates/notebook-cloud-transport/src/lib.rs
+++ b/crates/notebook-cloud-transport/src/lib.rs
@@ -302,6 +302,37 @@ fn cloud_frame_rejection_error(payload: &[u8]) -> Option<std::io::Error> {
     ))
 }
 
+fn is_recoverable_cloud_frame_rejection_error(error: &std::io::Error) -> bool {
+    if error.kind() != std::io::ErrorKind::PermissionDenied {
+        return false;
+    }
+
+    let message = error.to_string();
+    if !message.starts_with("cloud room rejected frame:") {
+        return false;
+    }
+    let sync_frame = [
+        "frame_type=0 ",
+        "frame_type=5 ",
+        "frame_type=9 ",
+        "frame_type=automerge_sync ",
+        "frame_type=runtime_state_sync ",
+        "frame_type=comms_doc_sync ",
+        "frame_type=AUTOMERGE_SYNC ",
+        "frame_type=RUNTIME_STATE_SYNC ",
+        "frame_type=COMMS_DOC_SYNC ",
+    ]
+    .iter()
+    .any(|needle| message.contains(needle));
+    if !sync_frame {
+        return false;
+    }
+
+    message.contains("recursive use of an object detected which would lead to unsafe aliasing")
+        || message.contains("PatchLogMismatch")
+        || message.contains("patch logs cannot be shared between documents")
+}
+
 fn terminal_cloud_close_error(code: Option<u16>, reason: &str) -> Option<std::io::Error> {
     let reason = reason.trim();
     let terminal_by_reason = matches!(
@@ -742,6 +773,9 @@ impl FrameTransport for CloudWsFrameTransport {
     }
 
     fn stream_error_is_recoverable(&self, error: &std::io::Error) -> bool {
+        if is_recoverable_cloud_frame_rejection_error(error) {
+            return true;
+        }
         error.kind() != std::io::ErrorKind::PermissionDenied
     }
 
@@ -877,7 +911,7 @@ mod tests {
     }
 
     #[test]
-    fn cloud_frame_rejection_error_is_non_recoverable_shape() {
+    fn cloud_frame_rejection_error_surfaces_rejection_reason() {
         let payload = serde_json::to_vec(&serde_json::json!({
             "type": "cloud_frame_rejected",
             "frame_type": 5,
@@ -895,6 +929,39 @@ mod tests {
         }))
         .unwrap();
         assert!(cloud_frame_rejection_error(&accepted).is_none());
+    }
+
+    #[test]
+    fn sync_frame_rejection_from_automerge_boundary_is_recoverable() {
+        let transport = CloudWsFrameTransport::new(test_config());
+        let payload = serde_json::to_vec(&serde_json::json!({
+            "type": "cloud_frame_rejected",
+            "frame_type": 5,
+            "reason": "room host rejected runtime_state_sync frame: Error: recursive use of an object detected which would lead to unsafe aliasing in rust",
+        }))
+        .unwrap();
+        let error = cloud_frame_rejection_error(&payload).expect("rejection becomes an error");
+        assert_eq!(error.kind(), std::io::ErrorKind::PermissionDenied);
+        assert!(
+            transport.stream_error_is_recoverable(&error),
+            "sync divergence rejections should reconnect instead of killing the runtime peer",
+        );
+    }
+
+    #[test]
+    fn authz_frame_rejection_remains_terminal() {
+        let transport = CloudWsFrameTransport::new(test_config());
+        let payload = serde_json::to_vec(&serde_json::json!({
+            "type": "cloud_frame_rejected",
+            "frame_type": 5,
+            "reason": "actor label must be '<principal>/<operator>'",
+        }))
+        .unwrap();
+        let error = cloud_frame_rejection_error(&payload).expect("rejection becomes an error");
+        assert!(
+            !transport.stream_error_is_recoverable(&error),
+            "permission and authority rejects should still stop the runtime peer",
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Fix the hosted room recovery path that showed up on `Where Can Notebooks Go?` as:

> Room rejected a frame: room host rejected comms_doc_sync frame: Error: recursive use of an object detected which would lead to unsafe aliasing in rust

Local runtime logs showed the same room also rejecting `runtime_state_sync` with that unsafe-aliasing error, after repeated `1011 room sync failed` websocket closes. A fresh diagnostic peer could later connect, so this looked like a recoverable room-host/WASM sync boundary issue rather than permanent NotebookDoc corruption.

## Changes

- Recover `RoomMaterializer.receiveFrame()` from known Automerge sync-boundary failures by rebuilding from the latest published snapshot, then re-syncing the peer against the rebuilt host.
- Keep recovery narrow: NotebookDoc, RuntimeStateDoc, and CommsDoc sync frames only; request/permission/authority failures stay terminal.
- Treat the same unsafe-aliasing rejection as recoverable in the browser viewer so it resyncs instead of surfacing fatal notebook load UI.
- Treat matching cloud runtime-peer frame rejections as recoverable in `notebook-cloud-transport`, so the runtime peer reconnects instead of shutting down.
- Add regression tests at the room materializer, browser live-sync classifier, and Rust transport boundary.

## Verification

- `pnpm --dir apps/notebook-cloud test -- room-materializer.test.ts` (this command ran the full notebook-cloud suite: 1120/1120 passing)
- `cd apps/notebook-cloud && node --import tsx --test test/live-sync.test.ts`
- `cargo test -p notebook-cloud-transport sync_frame_rejection_from_automerge_boundary_is_recoverable`
- `cargo test -p notebook-cloud-transport authz_frame_rejection_remains_terminal`
- `cargo test -p notebook-cloud-transport cloud_permission_denied_stream_error_is_terminal`
- `cargo test -p notebook-cloud-transport cloud_frame_rejection_error_surfaces_rejection_reason`
- `cargo xtask lint --fix`

## Deployment note

A direct deploy from this main-based branch is intentionally not safe while preview is running the markdown branch, because the live Worker already depends on `MarkdownDocumentRoom`. To deploy the fix before merge, cherry-pick this commit onto `quod/hosted-markdown-documents`, which carries the correct `v3` MarkdownDocumentRoom migration/export.
