### PR TITLE
fix(notebook-cloud): clone workstation event stream responses

### DIFF
--- a/apps/notebook-cloud/src/index.ts
+++ b/apps/notebook-cloud/src/index.ts
@@ -1766,7 +1766,7 @@ async function routeWorkstationEvents(
 
   const stub = workstationEventsStub(env, ownerPrincipal, workstationId);
   const response = await stub.fetch(new Request("https://workstation-events.internal/stream"));
-  return withCors(response);
+  return withCors(new Response(response.body, response));
 }
 
 async function routeWorkstationAttachJobs(

--- a/apps/notebook-cloud/test/worker-routes.test.ts
+++ b/apps/notebook-cloud/test/worker-routes.test.ts
@@ -1927,6 +1927,37 @@ describe("Worker artifact routes", () => {
     assert.equal(body.workstations[0]?.is_default, true);
   });
 
+  it("streams user-owned workstation events with CORS headers", async () => {
+    const objectName = workstationEventsObjectName("user:dev:alice", "ws-lab2");
+    const events = new FakeWorkstationEventsNamespace({ connectedObjectNames: [objectName] });
+    const env = fakeEnv({ WORKSTATION_EVENTS: events });
+    seedWorkstation(env, {
+      ownerPrincipal: "user:dev:alice",
+      workstationId: "ws-lab2",
+    });
+
+    const response = await worker.fetch(
+      new Request("http://localhost/api/workstations/ws-lab2/events", {
+        headers: {
+          "X-Operator": "workstation:lab2",
+          "X-Scope": "owner",
+          "X-User": "alice",
+        },
+      }),
+      env,
+      fakeContext(),
+    );
+
+    assert.equal(response.status, 200);
+    assert.equal(response.headers.get("Access-Control-Allow-Origin"), "*");
+    assert.equal(response.headers.get("Content-Type"), "text/event-stream; charset=utf-8");
+    assert.match(await response.text(), /event: ready/);
+    const streamRequest = events.requests.find(
+      (entry) => new URL(entry.url).pathname === "/stream",
+    );
+    assert.equal(streamRequest?.objectName, objectName);
+  });
+
   it("projects a stale workstation as online when its event stream is connected", async () => {
     const objectName = workstationEventsObjectName("user:dev:alice", "ws-lab2");
     const events = new FakeWorkstationEventsNamespace({ connectedObjectNames: [objectName] });


### PR DESCRIPTION
## Summary

- clones Durable Object workstation event stream responses before applying CORS headers
- adds route coverage that opens the paired workstation SSE stream and asserts CORS headers survive

## Why

`routeWorkstationEvents` forwarded the Durable Object response directly into `withCors()`. Those response headers are immutable, so the live route failed with Cloudflare 1101 / HTTP 500:

```text
TypeError: Can't modify immutable headers.
    at withCors
    at routeWorkstationEvents
```

That caused the workstation agent to reconnect the event stream repeatedly even after the SSE rollout. Cloning the response body/status/headers into a fresh `Response` preserves the stream while making headers mutable for CORS.

## Verification

- `node --import tsx --test test/worker-routes.test.ts --test-name-pattern "streams user-owned workstation events with CORS headers"` (worker-route runner selected the broader route suites; 150/150 passed)
- `cargo xtask lint --fix`
- deployed on preview via the markdown stack, build `542ae9afd950678c68c613bc59d742fdbf8c7cb5`
- verified `GET /api/workstations/ws-lab2/events` returns `HTTP/2 200` with `content-type: text/event-stream` and `access-control-allow-origin: *`
- restarted `ws-lab2`; registry shows online with fresh heartbeat at `2026-06-17T20:29:47Z`
