### PR TITLE
refactor(notebook): share document title chrome

### DIFF
--- a/apps/notebook-cloud/viewer/cloud-notebook-title.tsx
+++ b/apps/notebook-cloud/viewer/cloud-notebook-title.tsx
@@ -1,5 +1,5 @@
-import { useEffect, useState, type FormEvent } from "react";
-import { Check, House, Loader2, PencilLine, X } from "lucide-react";
+import { House } from "lucide-react";
+import { DocumentTitle } from "@/components/notebook/DocumentTitle";
 import {
   cloudNotebookRouteTitleFromPathname,
   type CloudNotebookTitleDisplay,
@@ -20,111 +20,37 @@ export function CloudNotebookTitle({
   title: CloudNotebookTitleDisplay;
   onRename?: (title: string) => boolean | Promise<boolean>;
 }) {
-  const [editing, setEditing] = useState(false);
-  const [draftTitle, setDraftTitle] = useState(renameTitle);
-
-  useEffect(() => {
-    if (!editing) {
-      setDraftTitle(renameTitle);
-    }
-  }, [editing, renameTitle]);
-
-  const saveRename = (event: FormEvent<HTMLFormElement>) => {
-    event.preventDefault();
-    if (!onRename || renameSaving) {
-      return;
-    }
-    void Promise.resolve(onRename(draftTitle))
-      .then((saved) => {
-        if (saved) {
-          setEditing(false);
-        }
-      })
-      .catch(() => {});
-  };
-
-  const cancelRename = () => {
-    if (renameSaving) {
-      return;
-    }
-    setDraftTitle(renameTitle);
-    setEditing(false);
-  };
-
   return (
-    <div className="cloud-notebook-title-group">
-      <a
-        className="cloud-notebook-home-link"
-        href="/n"
-        aria-label="Open notebooks dashboard"
-        title="Notebooks"
-      >
-        <House aria-hidden="true" />
-      </a>
-      <div className="cloud-notebook-title" title={renameError ?? title.title}>
-        {editing ? (
-          <form className="cloud-notebook-title-form" onSubmit={saveRename}>
-            <input
-              aria-label="Notebook title"
-              autoFocus
-              disabled={renameSaving}
-              maxLength={160}
-              name="notebook-title"
-              placeholder="Untitled notebook"
-              type="text"
-              value={draftTitle}
-              onChange={(event) => setDraftTitle(event.currentTarget.value)}
-            />
-            <button
-              type="submit"
-              disabled={renameSaving}
-              title="Save title"
-              aria-label="Save title"
-            >
-              {renameSaving ? (
-                <Loader2 className="cloud-notebook-title-spinner" aria-hidden="true" />
-              ) : (
-                <Check aria-hidden="true" />
-              )}
-            </button>
-            <button
-              type="button"
-              disabled={renameSaving}
-              title="Cancel rename"
-              aria-label="Cancel rename"
-              onClick={cancelRename}
-            >
-              <X aria-hidden="true" />
-            </button>
-          </form>
-        ) : (
-          <div className="cloud-notebook-title-static">
-            <span>{title.label}</span>
-            {canRename && onRename ? (
-              <button
-                type="button"
-                className="cloud-notebook-title-edit-button"
-                disabled={renameSaving}
-                title="Rename notebook"
-                aria-label={`Rename ${title.label}`}
-                onClick={() => setEditing(true)}
-              >
-                <PencilLine aria-hidden="true" />
-              </button>
-            ) : null}
-          </div>
-        )}
-        {renameError ? (
-          <small className="cloud-notebook-title-status" role="status">
-            {renameError}
-          </small>
-        ) : title.detail ? (
-          <small>{title.detail}</small>
-        ) : null}
-      </div>
-    </div>
+    <DocumentTitle
+      title={title}
+      renameTitle={renameTitle}
+      canRename={canRename}
+      renameSaving={renameSaving}
+      renameError={renameError}
+      onRename={onRename}
+      homeHref="/n"
+      homeAriaLabel="Open notebooks dashboard"
+      homeTitle="Notebooks"
+      homeIcon={<House aria-hidden="true" />}
+      inputAriaLabel="Notebook title"
+      inputName="notebook-title"
+      placeholder="Untitled notebook"
+      renameButtonTitle="Rename notebook"
+      classNames={cloudNotebookTitleClassNames}
+    />
   );
 }
+
+export const cloudNotebookTitleClassNames = {
+  group: "cloud-notebook-title-group",
+  homeLink: "cloud-notebook-home-link",
+  title: "cloud-notebook-title",
+  staticTitle: "cloud-notebook-title-static",
+  form: "cloud-notebook-title-form",
+  editButton: "cloud-notebook-title-edit-button",
+  status: "cloud-notebook-title-status",
+  spinner: "cloud-notebook-title-spinner",
+};
 
 export function cloudNotebookRouteTitle(): CloudNotebookTitleDisplay {
   return cloudNotebookRouteTitleFromPathname(window.location.pathname);

--- a/apps/notebook-cloud/viewer/index.css
+++ b/apps/notebook-cloud/viewer/index.css
@@ -303,16 +303,18 @@ body {
   height: 1.125rem;
 }
 
-.cloud-notebook-title-static,
 .cloud-notebook-title-form {
-  display: flex;
+  --document-title-action-size: 1.625rem;
+  --document-title-action-gap: 0.25rem;
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto;
   min-width: 0;
   max-width: 100%;
   align-items: center;
   gap: 0.375rem;
 }
 
-.cloud-notebook-title span,
+.cloud-notebook-title [data-slot="document-title-label"],
 .cloud-notebook-title small {
   min-width: 0;
   overflow: hidden;
@@ -320,11 +322,25 @@ body {
   white-space: nowrap;
 }
 
-.cloud-notebook-title span {
+.cloud-notebook-title [data-slot="document-title-label"] {
+  display: inline-flex;
+  align-items: center;
+  min-height: 1.875rem;
+  border: 1px solid transparent;
+  border-radius: 6px;
+  padding: 0.1875rem 0.5rem;
   color: var(--foreground);
   font-size: 0.9375rem;
   font-weight: 650;
   line-height: 1.15;
+}
+
+.cloud-notebook-title [data-slot="document-title-label"][data-renameable="true"] {
+  cursor: text;
+}
+
+.cloud-notebook-title [data-slot="document-title-label"][data-renameable="true"]:hover {
+  background: color-mix(in srgb, var(--background) 88%, var(--foreground) 8%);
 }
 
 .cloud-notebook-title small {
@@ -339,14 +355,23 @@ body {
   color: color-mix(in srgb, var(--destructive) 72%, var(--foreground) 28%);
 }
 
+.cloud-notebook-title [data-slot="document-title-actions"] {
+  display: inline-flex;
+  flex: 0 0 auto;
+  align-items: center;
+  justify-content: flex-start;
+  gap: var(--document-title-action-gap);
+  width: calc(var(--document-title-action-size) * 2 + var(--document-title-action-gap));
+}
+
 .cloud-notebook-title-edit-button,
 .cloud-notebook-title-form button {
   display: inline-flex;
   flex: 0 0 auto;
   align-items: center;
   justify-content: center;
-  width: 1.625rem;
-  height: 1.625rem;
+  width: var(--document-title-action-size);
+  height: var(--document-title-action-size);
   border: 0;
   border-radius: 6px;
   color: color-mix(in srgb, var(--foreground) 64%, transparent);
@@ -361,6 +386,7 @@ body {
 
 .cloud-notebook-title-edit-button:focus-visible,
 .cloud-notebook-title-form button:focus-visible,
+.cloud-notebook-title-form [contenteditable="true"]:focus-visible,
 .cloud-notebook-title-form input:focus-visible {
   outline: 2px solid color-mix(in srgb, var(--ring) 70%, transparent);
   outline-offset: 2px;
@@ -378,18 +404,25 @@ body {
   height: 0.9375rem;
 }
 
+.cloud-notebook-title-form [contenteditable="true"],
 .cloud-notebook-title-form input {
-  min-width: 7rem;
-  width: min(18rem, 32vw);
-  max-width: 100%;
-  height: 1.875rem;
   border: 1px solid color-mix(in srgb, var(--foreground) 18%, transparent);
-  border-radius: 6px;
-  padding: 0 0.5rem;
-  color: var(--foreground);
   background: color-mix(in srgb, var(--background) 94%, var(--foreground) 6%);
-  font-size: 0.875rem;
-  font-weight: 600;
+  overflow: hidden;
+  text-overflow: clip;
+  white-space: nowrap;
+}
+
+.cloud-notebook-title-form [contenteditable="true"]:empty::before {
+  content: attr(data-placeholder);
+  color: color-mix(in srgb, var(--foreground) 42%, transparent);
+}
+
+.cloud-notebook-title-action-placeholder {
+  display: inline-flex;
+  flex: 0 0 auto;
+  width: var(--document-title-action-size);
+  height: var(--document-title-action-size);
 }
 
 .cloud-notebook-title-spinner {
@@ -524,11 +557,6 @@ body {
     gap: 0.5rem;
   }
 
-  .cloud-notebook-title-form input {
-    min-width: 6rem;
-    width: min(12rem, 28vw);
-  }
-
   .cloud-notebook-title small {
     display: none;
   }
@@ -546,18 +574,14 @@ body {
   }
 
   .cloud-notebook-title-form {
+    --document-title-action-size: 1.5rem;
     gap: 0.25rem;
-  }
-
-  .cloud-notebook-title-form input {
-    min-width: 5.5rem;
-    width: min(9rem, 34vw);
   }
 
   .cloud-notebook-title-edit-button,
   .cloud-notebook-title-form button {
-    width: 1.5rem;
-    height: 1.5rem;
+    width: var(--document-title-action-size);
+    height: var(--document-title-action-size);
   }
 
   .cloud-room-toolbar [data-slot="notebook-document-header-controls"] {

--- a/src/components/notebook/DocumentTitle.tsx
+++ b/src/components/notebook/DocumentTitle.tsx
@@ -1,0 +1,300 @@
+import {
+  useEffect,
+  useLayoutEffect,
+  useRef,
+  useState,
+  type ClipboardEvent,
+  type KeyboardEvent,
+  type MouseEvent,
+  type ReactNode,
+} from "react";
+import { Check, Loader2, PencilLine, X } from "lucide-react";
+import { cn } from "@/lib/utils";
+
+export interface DocumentTitleDisplay {
+  label: string;
+  detail: string | null;
+  title: string;
+}
+
+export interface DocumentTitleClassNames {
+  group?: string;
+  homeLink?: string;
+  title?: string;
+  staticTitle?: string;
+  form?: string;
+  editButton?: string;
+  status?: string;
+  spinner?: string;
+}
+
+export interface DocumentTitleProps {
+  canRename?: boolean;
+  classNames?: DocumentTitleClassNames;
+  homeAriaLabel?: string;
+  homeHref?: string;
+  homeIcon?: ReactNode;
+  homeTitle?: string;
+  inputAriaLabel?: string;
+  inputName?: string;
+  onHomeClick?: (event: MouseEvent<HTMLAnchorElement>) => void;
+  onRename?: (title: string) => boolean | Promise<boolean>;
+  placeholder?: string;
+  renameButtonTitle?: string;
+  renameError?: string | null;
+  renameSaving?: boolean;
+  renameTitle: string;
+  title: DocumentTitleDisplay;
+}
+
+export function DocumentTitle({
+  canRename = false,
+  classNames,
+  homeAriaLabel = "Open documents",
+  homeHref,
+  homeIcon,
+  homeTitle = "Documents",
+  inputAriaLabel = "Document title",
+  inputName = "document-title",
+  onHomeClick,
+  onRename,
+  placeholder = "Untitled document",
+  renameButtonTitle = "Rename document",
+  renameError = null,
+  renameSaving = false,
+  renameTitle,
+  title,
+}: DocumentTitleProps) {
+  const [editing, setEditing] = useState(false);
+  const [draftTitle, setDraftTitle] = useState(renameTitle);
+  const editableRef = useRef<HTMLSpanElement | null>(null);
+  const canShowRename = canRename && Boolean(onRename);
+
+  useEffect(() => {
+    if (!editing) {
+      setDraftTitle(renameTitle);
+    }
+  }, [editing, renameTitle]);
+
+  useLayoutEffect(() => {
+    if (!editing || !editableRef.current) {
+      return;
+    }
+    const editable = editableRef.current;
+    editable.focus();
+    placeCaretAtEnd(editable);
+  }, [editing]);
+
+  const beginEditing = () => {
+    if (!canShowRename || renameSaving) {
+      return;
+    }
+    setDraftTitle(renameTitle);
+    setEditing(true);
+  };
+
+  const commitRename = (titleDraft = draftTitle) => {
+    if (!onRename || renameSaving) {
+      return;
+    }
+    try {
+      const result = onRename(normalizeTitleDraft(titleDraft));
+      if (typeof result === "boolean") {
+        if (result) {
+          setEditing(false);
+        }
+        return;
+      }
+      void result
+        .then((saved) => {
+          if (saved) {
+            setEditing(false);
+          }
+        })
+        .catch(() => {});
+    } catch {
+      // The host owns rename error state; keep editing so the user can retry.
+    }
+  };
+
+  const saveRename = () => {
+    commitRename(updateDraftFromEditable());
+  };
+
+  const cancelRename = () => {
+    if (renameSaving) {
+      return;
+    }
+    setDraftTitle(renameTitle);
+    setEditing(false);
+  };
+
+  const updateDraftFromEditable = (): string => {
+    const nextTitle = editableTitleDraft(editableRef.current?.textContent ?? "");
+    if ((editableRef.current?.textContent ?? "") !== nextTitle && editableRef.current) {
+      editableRef.current.textContent = nextTitle;
+      placeCaretAtEnd(editableRef.current);
+    }
+    setDraftTitle(nextTitle);
+    return nextTitle;
+  };
+
+  const handleEditableKeyDown = (event: KeyboardEvent<HTMLSpanElement>) => {
+    if (event.key === "Enter") {
+      event.preventDefault();
+      commitRename(updateDraftFromEditable());
+      return;
+    }
+    if (event.key === "Escape") {
+      event.preventDefault();
+      cancelRename();
+    }
+  };
+
+  const handleStaticTitleKeyDown = (event: KeyboardEvent<HTMLSpanElement>) => {
+    if (event.key === "Enter" || event.key === " ") {
+      event.preventDefault();
+      beginEditing();
+    }
+  };
+
+  const handleEditablePaste = (event: ClipboardEvent<HTMLSpanElement>) => {
+    event.preventDefault();
+    const text = normalizeTitleDraft(event.clipboardData.getData("text/plain"));
+    insertPlainTextAtSelection(event.currentTarget, text);
+    updateDraftFromEditable();
+  };
+
+  return (
+    <div className={cn("document-title-group", classNames?.group)}>
+      {homeHref ? (
+        <a
+          className={cn("document-title-home-link", classNames?.homeLink)}
+          href={homeHref}
+          aria-label={homeAriaLabel}
+          title={homeTitle}
+          onClick={onHomeClick}
+        >
+          {homeIcon}
+        </a>
+      ) : null}
+      <div className={cn("document-title", classNames?.title)} title={renameError ?? title.title}>
+        <div
+          className={cn("document-title-form", classNames?.form)}
+          data-editing={editing ? "true" : "false"}
+        >
+          <span
+            aria-disabled={editing && renameSaving ? true : undefined}
+            aria-label={editing ? inputAriaLabel : undefined}
+            className={cn(!editing && classNames?.staticTitle)}
+            contentEditable={editing && !renameSaving}
+            data-name={editing ? inputName : undefined}
+            data-placeholder={placeholder}
+            data-renameable={!editing && canShowRename ? "true" : undefined}
+            data-slot="document-title-label"
+            onClick={!editing && canShowRename ? beginEditing : undefined}
+            onInput={editing ? updateDraftFromEditable : undefined}
+            onKeyDown={editing ? handleEditableKeyDown : handleStaticTitleKeyDown}
+            onPaste={editing ? handleEditablePaste : undefined}
+            ref={editableRef}
+            role={editing ? "textbox" : canShowRename ? "button" : undefined}
+            spellCheck={editing ? "true" : undefined}
+            suppressContentEditableWarning
+            tabIndex={editing || canShowRename ? 0 : undefined}
+          >
+            {editing ? draftTitle : title.label}
+          </span>
+          {canShowRename ? (
+            <span className="document-title-actions" data-slot="document-title-actions">
+              {editing ? (
+                <>
+                  <button
+                    type="button"
+                    disabled={renameSaving}
+                    title="Save title"
+                    aria-label="Save title"
+                    onClick={saveRename}
+                  >
+                    {renameSaving ? (
+                      <Loader2
+                        className={cn("document-title-spinner", classNames?.spinner)}
+                        aria-hidden="true"
+                      />
+                    ) : (
+                      <Check aria-hidden="true" />
+                    )}
+                  </button>
+                  <button
+                    type="button"
+                    disabled={renameSaving}
+                    title="Cancel rename"
+                    aria-label="Cancel rename"
+                    onClick={cancelRename}
+                  >
+                    <X aria-hidden="true" />
+                  </button>
+                </>
+              ) : (
+                <>
+                  <button
+                    type="button"
+                    className={cn("document-title-edit-button", classNames?.editButton)}
+                    disabled={renameSaving}
+                    title={renameButtonTitle}
+                    aria-label={`Rename ${title.label}`}
+                    onClick={beginEditing}
+                  >
+                    <PencilLine aria-hidden="true" />
+                  </button>
+                  <span className="document-title-action-placeholder" aria-hidden="true" />
+                </>
+              )}
+            </span>
+          ) : null}
+        </div>
+        {renameError ? (
+          <small className={cn("document-title-status", classNames?.status)} role="status">
+            {renameError}
+          </small>
+        ) : title.detail ? (
+          <small>{title.detail}</small>
+        ) : null}
+      </div>
+    </div>
+  );
+}
+
+function normalizeTitleDraft(value: string): string {
+  return editableTitleDraft(value).trim();
+}
+
+function editableTitleDraft(value: string): string {
+  return value.replace(/[\r\n]+/g, " ").slice(0, 160);
+}
+
+function placeCaretAtEnd(editable: HTMLElement): void {
+  const selection = window.getSelection();
+  if (!selection) {
+    return;
+  }
+  const range = document.createRange();
+  range.selectNodeContents(editable);
+  range.collapse(false);
+  selection.removeAllRanges();
+  selection.addRange(range);
+}
+
+function insertPlainTextAtSelection(editable: HTMLElement, text: string): void {
+  const selection = window.getSelection();
+  if (!selection || selection.rangeCount === 0 || !editable.contains(selection.anchorNode)) {
+    editable.textContent = editableTitleDraft(`${editable.textContent ?? ""}${text}`);
+    placeCaretAtEnd(editable);
+    return;
+  }
+  const range = selection.getRangeAt(0);
+  range.deleteContents();
+  range.insertNode(document.createTextNode(text));
+  range.collapse(false);
+  selection.removeAllRanges();
+  selection.addRange(range);
+}

--- a/src/components/notebook/__tests__/DocumentTitle.test.tsx
+++ b/src/components/notebook/__tests__/DocumentTitle.test.tsx
@@ -1,0 +1,120 @@
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { describe, expect, it, vi } from "vite-plus/test";
+import { DocumentTitle } from "../DocumentTitle";
+
+describe("DocumentTitle", () => {
+  it("starts title editing from the title text itself", () => {
+    const onRename = vi.fn().mockResolvedValue(true);
+
+    render(
+      <DocumentTitle
+        canRename
+        renameTitle="Existing"
+        title={{ label: "Existing", detail: null, title: "Existing" }}
+        onRename={onRename}
+      />,
+    );
+
+    const titleNode = screen.getByRole("button", { name: "Existing" });
+    fireEvent.click(titleNode);
+
+    expect(screen.getByRole("textbox", { name: "Document title" })).toBe(titleNode);
+    expect(onRename).not.toHaveBeenCalled();
+  });
+
+  it("starts title editing from the keyboard on the title text", () => {
+    const onRename = vi.fn().mockResolvedValue(true);
+
+    render(
+      <DocumentTitle
+        canRename
+        renameTitle="Existing"
+        title={{ label: "Existing", detail: null, title: "Existing" }}
+        onRename={onRename}
+      />,
+    );
+
+    const titleNode = screen.getByRole("button", { name: "Existing" });
+    fireEvent.keyDown(titleNode, { key: "Enter" });
+
+    expect(screen.getByRole("textbox", { name: "Document title" })).toBe(titleNode);
+    expect(onRename).not.toHaveBeenCalled();
+  });
+
+  it("renames from an inline contenteditable title field", async () => {
+    const onRename = vi.fn().mockResolvedValue(true);
+
+    render(
+      <DocumentTitle
+        canRename
+        renameTitle="Existing"
+        title={{ label: "Existing", detail: null, title: "Existing" }}
+        onRename={onRename}
+      />,
+    );
+
+    const titleNode = screen.getByText("Existing");
+    fireEvent.click(screen.getByRole("button", { name: "Rename Existing" }));
+
+    const editable = screen.getByRole("textbox", { name: "Document title" });
+    expect(editable).toBe(titleNode);
+    expect(editable).toHaveAttribute("contenteditable", "true");
+    expect(editable).not.toHaveAttribute("aria-disabled");
+
+    editable.textContent = "Renamed";
+    fireEvent.input(editable);
+    fireEvent.keyDown(editable, { key: "Enter" });
+
+    expect(onRename).toHaveBeenCalledWith("Renamed");
+    await waitFor(() => {
+      expect(screen.queryByRole("textbox", { name: "Document title" })).toBeNull();
+    });
+  });
+
+  it("closes inline title editing immediately when rename saves synchronously", () => {
+    const onRename = vi.fn().mockReturnValue(true);
+
+    render(
+      <DocumentTitle
+        canRename
+        renameTitle="Existing"
+        title={{ label: "Existing", detail: null, title: "Existing" }}
+        onRename={onRename}
+      />,
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "Existing" }));
+
+    const editable = screen.getByRole("textbox", { name: "Document title" });
+    editable.textContent = "Renamed";
+    fireEvent.input(editable);
+    fireEvent.keyDown(editable, { key: "Enter" });
+
+    expect(onRename).toHaveBeenCalledWith("Renamed");
+    expect(screen.queryByRole("textbox", { name: "Document title" })).toBeNull();
+  });
+
+  it("cancels inline title editing with Escape", () => {
+    const onRename = vi.fn();
+
+    render(
+      <DocumentTitle
+        canRename
+        renameTitle="Existing"
+        title={{ label: "Existing", detail: null, title: "Existing" }}
+        onRename={onRename}
+      />,
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "Rename Existing" }));
+
+    const editable = screen.getByRole("textbox", { name: "Document title" });
+    editable.textContent = "Discarded";
+    fireEvent.input(editable);
+    fireEvent.keyDown(editable, { key: "Escape" });
+
+    expect(onRename).not.toHaveBeenCalled();
+    expect(screen.queryByRole("textbox", { name: "Document title" })).toBeNull();
+    expect(screen.getByText("Existing")).toBeVisible();
+  });
+});

--- a/src/components/notebook/index.ts
+++ b/src/components/notebook/index.ts
@@ -105,6 +105,12 @@ export {
   type ApplyOutputChangesetOptions,
 } from "./state/runtime-store-projection";
 export { NotebookDocumentShell, type NotebookDocumentShellProps } from "./NotebookDocumentShell";
+export {
+  DocumentTitle,
+  type DocumentTitleClassNames,
+  type DocumentTitleDisplay,
+  type DocumentTitleProps,
+} from "./DocumentTitle";
 export { NotebookDocumentHeader, type NotebookDocumentHeaderProps } from "./NotebookDocumentHeader";
 export {
   NotebookNotice,


### PR DESCRIPTION
## Summary

- extracts reusable `DocumentTitle` chrome from the hosted notebook title control
- switches `CloudNotebookTitle` to consume the shared component without adding new document routes
- keeps the existing cloud notebook styling while moving rename editing to inline contenteditable title text

## Why

The hosted Markdown prototype found useful shared document chrome, but the full `/m` surface is not ready to bring to main. This PR carves out the low-risk title component so notebook chrome can improve independently and future document surfaces do not need to reimplement title/home/rename behavior.

## Verification

- `pnpm test:run src/components/notebook/__tests__/DocumentTitle.test.tsx src/components/notebook/__tests__/NotebookEditModeButton.test.tsx`
- `pnpm --dir apps/notebook-cloud exec node --import tsx --test test/cloud-notebook-title-state.test.ts`
- `pnpm test:run src/components/notebook/__tests__/DocumentTitle.test.tsx apps/notebook-cloud/viewer/__tests__/use-cloud-app-session-status.test.tsx`
- `cargo xtask lint --fix`

Note: I accidentally invoked the broad notebook-cloud test runner once while trying to target the title-state file. It selected the full cloud suite and reported one unrelated failure in the large TAP output; the intended narrow cloud title-state test above passed cleanly.
