### PR TITLE
refactor(notebook): parameterize document controls

### DIFF
--- a/src/components/notebook-rail/NotebookRail.tsx
+++ b/src/components/notebook-rail/NotebookRail.tsx
@@ -121,6 +121,8 @@ export interface NotebookOutlinePanelProps {
   activeItemId?: string | null;
   selectedItemId?: string | null;
   selectedCellId?: string | null;
+  ariaLabel?: string;
+  emptyMessage?: string;
   onSelectItem?: (item: NotebookOutlineItem) => void;
   onNavigateItem?: (item: NotebookOutlineItem, href: string) => boolean | void;
   getItemHref?: (item: NotebookOutlineItem) => string | null | undefined;
@@ -132,6 +134,8 @@ export function NotebookOutlinePanel({
   activeItemId = null,
   selectedItemId = null,
   selectedCellId = null,
+  ariaLabel = "Notebook outline",
+  emptyMessage = "Add Markdown headings to structure your notebook. They will appear here.",
   onSelectItem,
   onNavigateItem,
   getItemHref,
@@ -141,7 +145,7 @@ export function NotebookOutlinePanel({
   if (items.length === 0) {
     return (
       <div className="rounded-md border border-dashed px-3 py-4 text-sm text-muted-foreground">
-        Add Markdown headings to structure your notebook. They will appear here.
+        {emptyMessage}
       </div>
     );
   }
@@ -160,7 +164,7 @@ export function NotebookOutlinePanel({
 
   return (
     <nav
-      aria-label="Notebook outline"
+      aria-label={ariaLabel}
       className="-ml-1"
       data-testid="notebook-outline-panel"
       data-drag-policy="navigation-only"

--- a/src/components/notebook-rail/__tests__/NotebookRail.test.tsx
+++ b/src/components/notebook-rail/__tests__/NotebookRail.test.tsx
@@ -5,6 +5,7 @@ import {
   NOTEBOOK_RAIL_TAKEOVER_PANEL_CLASS_NAMES,
   NOTEBOOK_RAIL_TAKEOVER_STAGE_CLASS_NAME,
   NotebookPackagesPanel,
+  NotebookOutlinePanel,
   NotebookRail,
 } from "../NotebookRail";
 
@@ -50,6 +51,18 @@ describe("NotebookRail", () => {
       screen.getByText("Add Markdown headings to structure your notebook. They will appear here."),
     ).toBeVisible();
     expect(screen.queryByText("No headings yet.")).not.toBeInTheDocument();
+  });
+
+  it("accepts document-specific outline labels", () => {
+    render(
+      <NotebookOutlinePanel
+        items={[]}
+        ariaLabel="Document outline"
+        emptyMessage="Add headings to structure this document."
+      />,
+    );
+
+    expect(screen.getByText("Add headings to structure this document.")).toBeVisible();
   });
 
   it("renders outline items and reports selection through the adapter callback", () => {

--- a/src/components/notebook/NotebookEditModeButton.tsx
+++ b/src/components/notebook/NotebookEditModeButton.tsx
@@ -9,24 +9,38 @@ export interface NotebookEditModeButtonProps {
   mode: NotebookEditMode;
   state: NotebookEditModeState;
   onModeChange: (mode: NotebookEditMode) => void;
+  ariaLabel?: string;
+  dataSlot?: string;
   disabled?: boolean;
+  editActiveTitle?: string;
+  editDisabled?: boolean;
   editLabel?: string;
   editTitle?: string;
   requestedEditLabel?: string;
   requestedEditTitle?: string;
+  viewLabel?: string;
+  viewSegmentLabel?: string;
+  viewTitle?: string;
   variant?: "button" | "segmented";
   className?: string;
 }
 
 export function NotebookEditModeButton({
+  ariaLabel = "Notebook interaction mode",
   className,
+  dataSlot = "notebook-edit-mode-button",
   disabled = false,
+  editActiveTitle = "Editing notebook",
+  editDisabled = false,
   editLabel: editLabelProp,
   editTitle = "Switch to edit mode",
   mode,
   onModeChange,
   requestedEditLabel = "Request sent",
   requestedEditTitle = "Edit access requested",
+  viewLabel = "View",
+  viewSegmentLabel = "Viewing",
+  viewTitle = "View notebook",
   state,
   variant = "button",
 }: NotebookEditModeButtonProps) {
@@ -34,7 +48,7 @@ export function NotebookEditModeButton({
   const requestedEdit = requestingEdit && state === "requested";
   const nextMode: NotebookEditMode = requestingEdit ? "view" : "edit";
   const editLabel = editLabelProp ?? "Editing";
-  const label = requestingEdit ? "View" : "Edit";
+  const label = requestingEdit ? viewLabel : "Edit";
   const editSegmentLabel = requestedEdit ? requestedEditLabel : editLabel;
   const title = requestingEdit
     ? state === "editing"
@@ -51,8 +65,8 @@ export function NotebookEditModeButton({
           className,
         )}
         role="group"
-        aria-label="Notebook interaction mode"
-        data-slot="notebook-edit-mode-button"
+        aria-label={ariaLabel}
+        data-slot={dataSlot}
         data-state={state}
         data-variant={variant}
       >
@@ -64,7 +78,7 @@ export function NotebookEditModeButton({
             mode === "view" && "bg-background text-foreground shadow-sm",
           )}
           disabled={disabled}
-          title="View notebook"
+          title={viewTitle}
           onClick={() => {
             if (mode !== "view") {
               onModeChange("view");
@@ -73,7 +87,7 @@ export function NotebookEditModeButton({
         >
           <BookOpen className="size-3.5 shrink-0" aria-hidden="true" />
           <span className="sr-only sm:not-sr-only sm:min-w-0 sm:truncate sm:leading-none">
-            Viewing
+            {viewSegmentLabel}
           </span>
         </button>
         <button
@@ -86,13 +100,9 @@ export function NotebookEditModeButton({
                 ? "bg-background text-emerald-700 shadow-sm dark:text-emerald-300"
                 : "bg-background text-amber-700 shadow-sm dark:text-amber-300"),
           )}
-          disabled={disabled}
+          disabled={disabled || editDisabled}
           title={
-            state === "editing"
-              ? "Editing notebook"
-              : requestedEdit
-                ? requestedEditTitle
-                : editTitle
+            state === "editing" ? editActiveTitle : requestedEdit ? requestedEditTitle : editTitle
           }
           onClick={() => {
             if (mode !== "edit") {
@@ -123,7 +133,7 @@ export function NotebookEditModeButton({
         state === "requested" && "border-ring/50 text-foreground",
         className,
       )}
-      data-slot="notebook-edit-mode-button"
+      data-slot={dataSlot}
       data-state={state}
       data-variant={variant}
       disabled={disabled}

--- a/src/components/notebook/__tests__/NotebookEditModeButton.test.tsx
+++ b/src/components/notebook/__tests__/NotebookEditModeButton.test.tsx
@@ -146,4 +146,33 @@ describe("NotebookEditModeButton", () => {
       "Offline while the room reconnects",
     );
   });
+
+  it("accepts document-specific segmented labels and edit disabled state", () => {
+    const onModeChange = vi.fn();
+
+    render(
+      <NotebookEditModeButton
+        ariaLabel="Markdown document mode"
+        dataSlot="markdown-document-mode-toggle"
+        editDisabled
+        editLabel="Edit"
+        editTitle="Editing requires edit access"
+        mode="view"
+        state="viewing"
+        variant="segmented"
+        viewSegmentLabel="View"
+        viewTitle="View Markdown"
+        onModeChange={onModeChange}
+      />,
+    );
+
+    const group = screen.getByRole("group", { name: "Markdown document mode" });
+    expect(group).toHaveAttribute("data-slot", "markdown-document-mode-toggle");
+    expect(screen.getByRole("button", { name: "View" })).toHaveAttribute("title", "View Markdown");
+    expect(screen.getByRole("button", { name: "Edit" })).toBeDisabled();
+
+    fireEvent.click(screen.getByRole("button", { name: "Edit" }));
+
+    expect(onModeChange).not.toHaveBeenCalled();
+  });
 });


### PR DESCRIPTION
## Summary

- lets `NotebookEditModeButton` accept document-specific labels, aria/data-slot values, and a disabled edit segment
- lets `NotebookOutlinePanel` accept document-specific aria and empty-state copy
- keeps notebook defaults unchanged and adds focused tests for the new knobs

## Why

The markdown prototype needed these as shared document affordances, but the useful part is smaller than the `/m` product surface. This PR makes the existing notebook controls reusable for future document surfaces without adding new routes or document models.

## Verification

- `pnpm test:run src/components/notebook/__tests__/NotebookEditModeButton.test.tsx src/components/notebook-rail/__tests__/NotebookRail.test.tsx`
- `cargo xtask lint --fix`
