### PR TITLE
refactor(notebook-cloud): key catalog cache from app sessions

### DIFF
--- a/apps/notebook-cloud/src/app-session.ts
+++ b/apps/notebook-cloud/src/app-session.ts
@@ -5,6 +5,7 @@ export interface AppSessionEnvironment {
 }
 
 export interface CloudAppSession {
+  cacheKey: string;
   displayName?: string;
   expiresAt: number;
   issuedAt: number;
@@ -20,6 +21,7 @@ interface CloudAppSessionPayload {
   ns: string;
   principal: string;
   provider: "oidc";
+  sid?: string;
   v: 1;
 }
 
@@ -50,6 +52,7 @@ export async function createCloudAppSessionCookie(
     ns: identity.metadata.principalNamespace,
     iat: nowSeconds,
     exp: nowSeconds + NOTEBOOK_CLOUD_APP_SESSION_MAX_AGE_SECONDS,
+    sid: crypto.randomUUID(),
     ...(displayName ? { display_name: displayName } : {}),
   };
   const value = await signCloudAppSession(env, payload);
@@ -77,6 +80,7 @@ export async function readCloudAppSession(
 
   return {
     provider: payload.provider,
+    cacheKey: await appSessionCacheKey(env, payload),
     principal: payload.principal,
     principalNamespace: payload.ns,
     issuedAt: payload.iat,
@@ -92,6 +96,25 @@ async function signCloudAppSession(
   const encodedPayload = base64UrlEncodeString(JSON.stringify(payload));
   const signature = await hmacSha256(env, encodedPayload);
   return `${encodedPayload}.${base64UrlEncodeBytes(signature)}`;
+}
+
+async function appSessionCacheKey(
+  env: AppSessionEnvironment,
+  payload: CloudAppSessionPayload,
+): Promise<string> {
+  const signature = await hmacSha256(
+    env,
+    [
+      "app-session-cache:v1",
+      payload.provider,
+      payload.ns,
+      payload.principal,
+      String(payload.iat),
+      String(payload.exp),
+      payload.sid ?? "",
+    ].join(":"),
+  );
+  return base64UrlEncodeBytes(signature);
 }
 
 async function verifyCloudAppSession(
@@ -178,6 +201,7 @@ function isCloudAppSessionPayload(value: unknown): value is CloudAppSessionPaylo
     typeof payload.ns === "string" &&
     Number.isFinite(payload.iat) &&
     Number.isFinite(payload.exp) &&
+    (payload.sid === undefined || typeof payload.sid === "string") &&
     (payload.display_name === undefined || typeof payload.display_name === "string")
   );
 }

--- a/apps/notebook-cloud/src/index.ts
+++ b/apps/notebook-cloud/src/index.ts
@@ -985,6 +985,7 @@ function appSessionResponse(session: CloudAppSession): Record<string, unknown> {
   return {
     provider: session.provider,
     expires_at: session.expiresAt,
+    cache_key: session.cacheKey,
   };
 }
 

--- a/apps/notebook-cloud/test/app-session-client.test.ts
+++ b/apps/notebook-cloud/test/app-session-client.test.ts
@@ -17,14 +17,14 @@ describe("cloud app session client", () => {
         assert.deepEqual(init?.headers, { Accept: "application/json" });
         return Response.json({
           ok: true,
-          session: { provider: "oidc", expires_at: 1_800 },
+          session: { provider: "oidc", expires_at: 1_800, cache_key: "cache-a" },
         });
       },
     });
 
     assert.deepEqual(status, {
       ok: true,
-      session: { provider: "oidc", expires_at: 1_800 },
+      session: { provider: "oidc", expires_at: 1_800, cache_key: "cache-a" },
     });
   });
 
@@ -37,17 +37,14 @@ describe("cloud app session client", () => {
   });
 
   it("checks app session freshness with the same renewal skew as the viewer", () => {
-    assert.equal(cloudAppSessionIsFresh({ provider: "oidc", expires_at: 1_300 }, 1_000), true);
-    assert.equal(cloudAppSessionIsFresh({ provider: "oidc", expires_at: 1_060 }, 1_000), false);
+    assert.equal(cloudAppSessionIsFresh(session(1_300), 1_000), true);
+    assert.equal(cloudAppSessionIsFresh(session(1_060), 1_000), false);
     assert.equal(cloudAppSessionIsFresh(null, 1_000), false);
   });
 
   it("renews app sessions before the browser cookie expires", () => {
-    assert.equal(
-      cloudAppSessionNeedsRenewal({ provider: "oidc", expires_at: 3_000 }, 1_000),
-      false,
-    );
-    assert.equal(cloudAppSessionNeedsRenewal({ provider: "oidc", expires_at: 2_700 }, 1_000), true);
+    assert.equal(cloudAppSessionNeedsRenewal(session(3_000), 1_000), false);
+    assert.equal(cloudAppSessionNeedsRenewal(session(2_700), 1_000), true);
     assert.equal(cloudAppSessionNeedsRenewal(null, 1_000), true);
   });
 
@@ -58,6 +55,7 @@ describe("cloud app session client", () => {
         session: {
           provider: "oidc",
           expires_at: 1_800,
+          cache_key: "cache-a",
           email: "private@example.test",
         },
       }),
@@ -69,6 +67,7 @@ describe("cloud app session client", () => {
         session: {
           provider: "oidc",
           expires_at: 1_800,
+          cache_key: "cache-a",
           display_name: "Private User",
         },
       }),
@@ -80,7 +79,8 @@ describe("cloud app session client", () => {
     await assert.rejects(
       () =>
         readCloudAppSessionStatus({
-          fetchImpl: async () => Response.json({ ok: true, session: { provider: "oidc" } }),
+          fetchImpl: async () =>
+            Response.json({ ok: true, session: { provider: "oidc", expires_at: 1_800 } }),
         }),
       /response shape was invalid/,
     );
@@ -93,3 +93,7 @@ describe("cloud app session client", () => {
     );
   });
 });
+
+function session(expiresAt: number) {
+  return { provider: "oidc" as const, expires_at: expiresAt, cache_key: "cache-a" };
+}

--- a/apps/notebook-cloud/test/app-session.test.ts
+++ b/apps/notebook-cloud/test/app-session.test.ts
@@ -45,14 +45,13 @@ describe("cloud app session cookies", () => {
       2_100,
     );
 
-    assert.deepEqual(session, {
-      provider: "oidc",
-      principal: "user:anaconda:subject-a",
-      principalNamespace: "user:anaconda",
-      issuedAt: 2_000,
-      expiresAt: 2_000 + NOTEBOOK_CLOUD_APP_SESSION_MAX_AGE_SECONDS,
-      displayName: "OIDC User",
-    });
+    assert.equal(session?.provider, "oidc");
+    assert.equal(session?.principal, "user:anaconda:subject-a");
+    assert.equal(session?.principalNamespace, "user:anaconda");
+    assert.equal(session?.issuedAt, 2_000);
+    assert.equal(session?.expiresAt, 2_000 + NOTEBOOK_CLOUD_APP_SESSION_MAX_AGE_SECONDS);
+    assert.equal(session?.displayName, "OIDC User");
+    assert.match(session?.cacheKey ?? "", /^[A-Za-z0-9_-]+$/);
   });
 
   it("caps the display name signed into the cookie", async () => {

--- a/apps/notebook-cloud/test/hosted-catalog-auth.test.ts
+++ b/apps/notebook-cloud/test/hosted-catalog-auth.test.ts
@@ -1,0 +1,72 @@
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import { projectHostedCatalogAuthState } from "../viewer/hosted-catalog-auth";
+import type { CloudAppSession } from "../viewer/app-session";
+import type { CloudPrototypeAuthState } from "../viewer/collaborator-auth";
+
+describe("hosted catalog auth projection", () => {
+  it("keeps anonymous visitors signed out", () => {
+    const projection = projectHostedCatalogAuthState(auth("anonymous"));
+
+    assert.deepEqual(projection, {
+      appSessionLoading: false,
+      canFetchCatalog: false,
+      hasAppSession: false,
+      hasExplicitAuth: false,
+      showSignIn: true,
+      signedIn: false,
+      waitingForAppSession: false,
+    });
+  });
+
+  it("waits for an OIDC browser to exchange an app-session cookie", () => {
+    const projection = projectHostedCatalogAuthState(auth("oidc"), {
+      appSessionLoading: true,
+    });
+
+    assert.equal(projection.signedIn, true);
+    assert.equal(projection.canFetchCatalog, false);
+    assert.equal(projection.showSignIn, false);
+    assert.equal(projection.waitingForAppSession, true);
+  });
+
+  it("allows catalog fetches once an app session exists", () => {
+    const projection = projectHostedCatalogAuthState(auth("oidc"), {
+      appSession: appSession(),
+    });
+
+    assert.equal(projection.signedIn, true);
+    assert.equal(projection.canFetchCatalog, true);
+    assert.equal(projection.hasAppSession, true);
+    assert.equal(projection.showSignIn, false);
+    assert.equal(projection.waitingForAppSession, false);
+  });
+
+  it("keeps local dev auth usable without app sessions", () => {
+    const projection = projectHostedCatalogAuthState(auth("dev"));
+
+    assert.equal(projection.signedIn, true);
+    assert.equal(projection.canFetchCatalog, true);
+    assert.equal(projection.hasExplicitAuth, true);
+    assert.equal(projection.showSignIn, false);
+  });
+});
+
+function auth(mode: CloudPrototypeAuthState["mode"]): CloudPrototypeAuthState {
+  return {
+    mode,
+    token: mode === "dev" || mode === "oidc" ? "token" : null,
+    user: mode === "dev" ? "local-user" : mode === "oidc" ? "OIDC User" : null,
+    oidcClaims: mode === "oidc" ? { sub: "user-a" } : null,
+    requestedScope: mode === "anonymous" ? null : "viewer",
+    problem: null,
+  };
+}
+
+function appSession(): CloudAppSession {
+  return {
+    provider: "oidc",
+    expires_at: 1_750_000_000,
+    cache_key: "cache-a",
+  };
+}

--- a/apps/notebook-cloud/test/notebook-list-cache.test.ts
+++ b/apps/notebook-cloud/test/notebook-list-cache.test.ts
@@ -16,25 +16,52 @@ describe("cloud notebook list cache", () => {
     const auth = oidcAuth("user-a");
     const notebooks = [notebook("nb-a")];
 
-    writeCachedCloudNotebookList(storage, auth, notebooks, 1_000);
+    writeCachedCloudNotebookList(storage, auth, null, notebooks, 1_000);
 
-    assert.deepEqual(readCachedCloudNotebookList(storage, auth, 2_000), notebooks);
+    assert.deepEqual(readCachedCloudNotebookList(storage, auth, null, 2_000), notebooks);
   });
 
   it("does not reuse cached catalog rows for another identity", () => {
     const storage = new MemoryStorage();
-    writeCachedCloudNotebookList(storage, oidcAuth("user-a"), [notebook("nb-a")], 1_000);
+    writeCachedCloudNotebookList(storage, oidcAuth("user-a"), null, [notebook("nb-a")], 1_000);
 
-    assert.equal(readCachedCloudNotebookList(storage, oidcAuth("user-b"), 2_000), null);
+    assert.equal(readCachedCloudNotebookList(storage, oidcAuth("user-b"), null, 2_000), null);
+  });
+
+  it("prefers the app session cache key over local OIDC claims", () => {
+    const storage = new MemoryStorage();
+    const notebooks = [notebook("nb-a")];
+
+    writeCachedCloudNotebookList(
+      storage,
+      oidcAuth("user-a"),
+      appSession("session-a"),
+      notebooks,
+      1_000,
+    );
+
+    assert.deepEqual(
+      readCachedCloudNotebookList(storage, oidcAuth("user-b"), appSession("session-a"), 2_000),
+      notebooks,
+    );
+    assert.equal(
+      readCachedCloudNotebookList(storage, oidcAuth("user-a"), appSession("session-b"), 2_000),
+      null,
+    );
   });
 
   it("expires retained catalog rows", () => {
     const storage = new MemoryStorage();
     const auth = oidcAuth("user-a");
-    writeCachedCloudNotebookList(storage, auth, [notebook("nb-a")], 1_000);
+    writeCachedCloudNotebookList(storage, auth, null, [notebook("nb-a")], 1_000);
 
     assert.equal(
-      readCachedCloudNotebookList(storage, auth, 1_000 + CLOUD_NOTEBOOK_LIST_CACHE_TTL_MS + 1),
+      readCachedCloudNotebookList(
+        storage,
+        auth,
+        null,
+        1_000 + CLOUD_NOTEBOOK_LIST_CACHE_TTL_MS + 1,
+      ),
       null,
     );
   });
@@ -50,17 +77,17 @@ describe("cloud notebook list cache", () => {
       }),
     );
 
-    assert.equal(readCachedCloudNotebookList(storage, oidcAuth("user-a"), 2_000), null);
+    assert.equal(readCachedCloudNotebookList(storage, oidcAuth("user-a"), null, 2_000), null);
   });
 
   it("clears retained catalog rows", () => {
     const storage = new MemoryStorage();
     const auth = oidcAuth("user-a");
-    writeCachedCloudNotebookList(storage, auth, [notebook("nb-a")], 1_000);
+    writeCachedCloudNotebookList(storage, auth, null, [notebook("nb-a")], 1_000);
 
     clearCachedCloudNotebookList(storage);
 
-    assert.equal(readCachedCloudNotebookList(storage, auth, 2_000), null);
+    assert.equal(readCachedCloudNotebookList(storage, auth, null, 2_000), null);
   });
 });
 
@@ -92,6 +119,14 @@ function notebook(id: string): CloudNotebookListItem {
       acl: `/api/n/${id}/acl`,
       access_requests: `/api/n/${id}/access-requests`,
     },
+  };
+}
+
+function appSession(cacheKey: string) {
+  return {
+    provider: "oidc" as const,
+    expires_at: 1_750_000_000,
+    cache_key: cacheKey,
   };
 }
 

--- a/apps/notebook-cloud/test/use-cloud-auth-session-identity.test.ts
+++ b/apps/notebook-cloud/test/use-cloud-auth-session-identity.test.ts
@@ -17,6 +17,7 @@ describe("cloud app session identity stability", () => {
   const session = (overrides: Partial<CloudAppSession> = {}): CloudAppSession => ({
     provider: "oidc",
     expires_at: 1_750_000_000,
+    cache_key: "cache-a",
     ...overrides,
   });
 
@@ -32,6 +33,7 @@ describe("cloud app session identity stability", () => {
       assert.equal(cloudAppSessionsEqual(a, null), false);
       assert.equal(cloudAppSessionsEqual(null, a), false);
       assert.equal(cloudAppSessionsEqual(a, session({ expires_at: 1_750_000_001 })), false);
+      assert.equal(cloudAppSessionsEqual(a, session({ cache_key: "cache-b" })), false);
     });
   });
 

--- a/apps/notebook-cloud/test/viewer-shared-cell-surface.test.ts
+++ b/apps/notebook-cloud/test/viewer-shared-cell-surface.test.ts
@@ -713,7 +713,7 @@ test("cloud app-session bridge refreshes cookie-backed state after OIDC exchange
   );
   assert.match(
     routeSourceText,
-    /\[authState, bootstrap, canFetchNotebookList, refreshIndex, waitingForAppSession\]/,
+    /\[\s*appSessionStatus\.session,[\s\S]*authState,[\s\S]*bootstrap,[\s\S]*canFetchNotebookList,[\s\S]*refreshIndex,[\s\S]*waitingForAppSession,[\s\S]*\]/,
   );
 });
 
@@ -735,7 +735,11 @@ test("cloud notebook list waits for app-session cookies before catalog fetches",
 
   assert.match(
     sourceText,
-    /const canFetchNotebookList = authState\.mode === "dev" \|\| hasAppSession;/,
+    /const \{[\s\S]*canFetchCatalog: canFetchNotebookList,[\s\S]*hasAppSession,[\s\S]*signedIn,[\s\S]*waitingForAppSession,[\s\S]*\} = hostedAuth;/,
+  );
+  assert.match(
+    sourceText,
+    /projectHostedCatalogAuthState\(authState,[\s\S]*appSession: appSessionStatus\.session,[\s\S]*appSessionLoading: appSessionStatus\.status === "loading"/,
   );
   assert.match(
     sourceText,
@@ -754,16 +758,16 @@ test("cloud notebook list trusts server bootstrap on initial app-session paint",
 
   assert.match(
     sourceText,
-    /const seededNotebooks = cloudNotebookListSeedFromBootstrapOrCache\(authState, bootstrap\);/,
+    /const seededNotebooks = cloudNotebookListSeedFromBootstrapOrCache\([\s\S]*authState,[\s\S]*appSessionStatus\.session,[\s\S]*bootstrap,[\s\S]*\);/,
   );
   assert.match(
     sourceText,
-    /if \(refreshIndex === 0 && bootstrap\) \{[\s\S]*writeCachedCloudNotebookListToWindow\(authState, bootstrap\.notebooks\);[\s\S]*setListState\(\{ kind: "ready", notebooks: bootstrap\.notebooks \}\);[\s\S]*return;/,
+    /if \(refreshIndex === 0 && bootstrap\) \{[\s\S]*writeCachedCloudNotebookListToWindow\([\s\S]*authState,[\s\S]*appSessionStatus\.session,[\s\S]*bootstrap\.notebooks,[\s\S]*\);[\s\S]*setListState\(\{ kind: "ready", notebooks: bootstrap\.notebooks \}\);[\s\S]*return;/,
     "fresh notebook-home bootstrap should satisfy the initial render without an immediate duplicate /api/n fetch",
   );
   assert.match(
     sourceText,
-    /return bootstrap\?\.notebooks \?\? readCachedCloudNotebookListFromWindow\(authState\);/,
+    /return bootstrap\?\.notebooks \?\? readCachedCloudNotebookListFromWindow\(authState, appSession\);/,
     "server bootstrap should beat stale sessionStorage cache when both are present",
   );
 });

--- a/apps/notebook-cloud/test/worker-routes.test.ts
+++ b/apps/notebook-cloud/test/worker-routes.test.ts
@@ -499,11 +499,12 @@ describe("Worker artifact routes", () => {
     assert.doesNotMatch(bodyText, /session-status-user/);
     const body = JSON.parse(bodyText) as {
       ok: boolean;
-      session: { provider: string; expires_at: number } | null;
+      session: { provider: string; expires_at: number; cache_key: string } | null;
     };
     assert.equal(body.ok, true);
     assert.equal(body.session?.provider, "oidc");
     assert.equal(typeof body.session?.expires_at, "number");
+    assert.equal(typeof body.session?.cache_key, "string");
   });
 
   it("rejects cross-origin app session exchange attempts", async () => {
@@ -581,6 +582,7 @@ describe("Worker artifact routes", () => {
     assert.equal(bootstrap.notebooks[0]?.title, "Bootstrap Visible");
     assert.equal(bootstrap.session?.provider, "oidc");
     assert.equal(typeof bootstrap.session?.expires_at, "number");
+    assert.equal(typeof bootstrap.session?.cache_key, "string");
     assert.doesNotMatch(html, new RegExp(token.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")));
     assert.doesNotMatch(html, /bootstrap@example\.test|bootstrap-user|Bootstrap User/);
   });
@@ -659,6 +661,7 @@ describe("Worker artifact routes", () => {
     const config = notebookViewerConfig(html);
     assert.equal(config.session?.provider, "oidc");
     assert.equal(typeof config.session?.expires_at, "number");
+    assert.equal(typeof config.session?.cache_key, "string");
     assert.doesNotMatch(html, new RegExp(token.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")));
     assert.doesNotMatch(html, /viewer-bootstrap@example\.test|viewer-bootstrap-user/);
     assert.doesNotMatch(html, /Viewer Bootstrap User/);
@@ -6156,6 +6159,7 @@ function notebookHomeBootstrap(html: string): {
   session?: {
     provider: string;
     expires_at: number;
+    cache_key: string;
   };
 } {
   const match = html.match(
@@ -6171,6 +6175,7 @@ function notebookHomeBootstrap(html: string): {
     session?: {
       provider: string;
       expires_at: number;
+      cache_key: string;
     };
   };
 }
@@ -6179,6 +6184,7 @@ function notebookViewerConfig(html: string): {
   session?: {
     provider: string;
     expires_at: number;
+    cache_key: string;
   } | null;
 } {
   const match = html.match(
@@ -6189,6 +6195,7 @@ function notebookViewerConfig(html: string): {
     session?: {
       provider: string;
       expires_at: number;
+      cache_key: string;
     } | null;
   };
 }

--- a/apps/notebook-cloud/viewer/__tests__/use-cloud-app-session-status.test.tsx
+++ b/apps/notebook-cloud/viewer/__tests__/use-cloud-app-session-status.test.tsx
@@ -29,6 +29,7 @@ describe("useCloudAppSessionStatus", () => {
   const session = (overrides: Partial<CloudAppSession> = {}): CloudAppSession => ({
     provider: "oidc",
     expires_at: 4_000_000_000,
+    cache_key: "cache-a",
     ...overrides,
   });
 
@@ -76,10 +77,26 @@ describe("useCloudAppSessionStatus", () => {
 
   it("adopts a genuinely renewed session", async () => {
     const initial = session({ expires_at: 1 });
-    const renewed = session({ expires_at: 4_000_009_999 });
+    const renewed = session({ expires_at: 4_000_009_999, cache_key: "cache-b" });
     mocks.readCloudAppSessionStatus.mockResolvedValue({ ok: true, session: renewed });
 
     const { result } = renderHook(() => useCloudAppSessionStatus(initial));
+    await waitFor(() => expect(mocks.readCloudAppSessionStatus).toHaveBeenCalledTimes(1));
+    await act(async () => {});
+
+    expect(result.current.status).toBe("ready");
+    expect(result.current.session).toBe(renewed);
+  });
+
+  it("adopts a session when only the cache boundary changes", async () => {
+    const initial = session({ expires_at: 4_000_000_000, cache_key: "cache-a" });
+    const renewed = session({ expires_at: 4_000_000_000, cache_key: "cache-b" });
+    mocks.readCloudAppSessionStatus.mockResolvedValue({ ok: true, session: renewed });
+
+    const { result } = renderHook(() => useCloudAppSessionStatus(initial));
+    act(() => {
+      result.current.refreshAppSessionStatus();
+    });
     await waitFor(() => expect(mocks.readCloudAppSessionStatus).toHaveBeenCalledTimes(1));
     await act(async () => {});
 

--- a/apps/notebook-cloud/viewer/app-session.ts
+++ b/apps/notebook-cloud/viewer/app-session.ts
@@ -6,6 +6,7 @@ export const CLOUD_APP_SESSION_ENDPOINT = "/api/auth/session";
 export interface CloudAppSession {
   provider: "oidc";
   expires_at: number;
+  cache_key: string;
 }
 
 export interface CloudAppSessionStatus {
@@ -93,7 +94,10 @@ export function isCloudAppSession(value: unknown): value is CloudAppSession {
   return (
     candidate.provider === "oidc" &&
     Number.isFinite(candidate.expires_at) &&
-    Object.keys(candidate).every((key) => key === "provider" || key === "expires_at")
+    typeof candidate.cache_key === "string" &&
+    Object.keys(candidate).every(
+      (key) => key === "provider" || key === "expires_at" || key === "cache_key",
+    )
   );
 }
 

--- a/apps/notebook-cloud/viewer/hosted-catalog-auth.ts
+++ b/apps/notebook-cloud/viewer/hosted-catalog-auth.ts
@@ -1,0 +1,45 @@
+import type { CloudAppSession } from "./app-session";
+import {
+  cloudBrowserCanUseAuthenticatedApi,
+  shouldShowCloudHeaderSignIn,
+  type CloudPrototypeAuthState,
+} from "./collaborator-auth";
+
+export interface HostedCatalogAuthProjection {
+  appSessionLoading: boolean;
+  canFetchCatalog: boolean;
+  hasAppSession: boolean;
+  hasExplicitAuth: boolean;
+  showSignIn: boolean;
+  signedIn: boolean;
+  waitingForAppSession: boolean;
+}
+
+export function projectHostedCatalogAuthState(
+  authState: CloudPrototypeAuthState,
+  options: {
+    appSession?: CloudAppSession | null;
+    appSessionLoading?: boolean;
+  } = {},
+): HostedCatalogAuthProjection {
+  const appSessionLoading = options.appSessionLoading === true;
+  const hasAppSession = Boolean(options.appSession);
+  const hasExplicitAuth = authState.mode === "dev" || authState.mode === "oidc";
+  const canFetchCatalog = cloudBrowserCanUseAuthenticatedApi({
+    authState,
+    hasAppSession,
+  });
+  const waitingForAppSession = authState.mode === "oidc" && !hasAppSession;
+  return {
+    appSessionLoading,
+    canFetchCatalog,
+    hasAppSession,
+    hasExplicitAuth,
+    showSignIn: shouldShowCloudHeaderSignIn(authState, {
+      appSessionLoading,
+      hasAppSession,
+    }),
+    signedIn: hasExplicitAuth || hasAppSession,
+    waitingForAppSession,
+  };
+}

--- a/apps/notebook-cloud/viewer/notebook-list-cache.ts
+++ b/apps/notebook-cloud/viewer/notebook-list-cache.ts
@@ -1,3 +1,4 @@
+import type { CloudAppSession } from "./app-session";
 import type { CloudPrototypeAuthState } from "./collaborator-auth";
 import { isCloudNotebookListItem, type CloudNotebookListItem } from "./notebook-dashboard";
 
@@ -20,9 +21,10 @@ interface CachedCloudNotebookList {
 export function readCachedCloudNotebookList(
   storage: Pick<CloudNotebookListCacheStorage, "getItem">,
   authState: CloudPrototypeAuthState,
+  appSession: CloudAppSession | null | undefined,
   now = Date.now(),
 ): CloudNotebookListItem[] | null {
-  const authKey = cloudNotebookListCacheAuthKey(authState);
+  const authKey = cloudNotebookListCacheAuthKey(authState, appSession);
   if (!authKey) {
     return null;
   }
@@ -55,10 +57,11 @@ export function readCachedCloudNotebookList(
 export function writeCachedCloudNotebookList(
   storage: Pick<CloudNotebookListCacheStorage, "setItem">,
   authState: CloudPrototypeAuthState,
+  appSession: CloudAppSession | null | undefined,
   notebooks: CloudNotebookListItem[],
   now = Date.now(),
 ): void {
-  const authKey = cloudNotebookListCacheAuthKey(authState);
+  const authKey = cloudNotebookListCacheAuthKey(authState, appSession);
   if (!authKey) {
     return;
   }
@@ -79,7 +82,13 @@ export function clearCachedCloudNotebookList(
   storage.removeItem(CLOUD_NOTEBOOK_LIST_CACHE_STORAGE_KEY);
 }
 
-export function cloudNotebookListCacheAuthKey(authState: CloudPrototypeAuthState): string | null {
+export function cloudNotebookListCacheAuthKey(
+  authState: CloudPrototypeAuthState,
+  appSession: CloudAppSession | null | undefined,
+): string | null {
+  if (appSession?.cache_key) {
+    return `app-session:${appSession.cache_key}`;
+  }
   if (authState.mode === "oidc" && authState.oidcClaims?.sub) {
     return `oidc:${authState.oidcClaims.sub}`;
   }

--- a/apps/notebook-cloud/viewer/notebook-list-view.tsx
+++ b/apps/notebook-cloud/viewer/notebook-list-view.tsx
@@ -18,7 +18,9 @@ import {
 import { cloudResponseError } from "./cloud-response";
 import { clearCloudAppSession, establishCloudAppSession } from "./app-session";
 import { CloudNotebookDashboard } from "./cloud-notebook-dashboard-view";
+import { projectHostedCatalogAuthState } from "./hosted-catalog-auth";
 import { loadCloudNotebookListBootstrap } from "./cloud-viewer-config";
+import type { CloudAppSession } from "./app-session";
 import type {
   CloudNotebookCreateResponse,
   CloudNotebookListBootstrap,
@@ -75,11 +77,16 @@ export function CloudNotebookListView({ authConfig }: { authConfig: CloudViewerA
   const [renameState, setRenameState] = useState<CloudNotebookRenameState | null>(null);
   const [renameSavingId, setRenameSavingId] = useState<string | null>(null);
   const [renameError, setRenameError] = useState<string | null>(null);
-  const hasExplicitAuth = authState.mode === "dev" || authState.mode === "oidc";
-  const hasAppSession = Boolean(appSessionStatus.session);
-  const signedIn = hasExplicitAuth || hasAppSession;
-  const canFetchNotebookList = authState.mode === "dev" || hasAppSession;
-  const waitingForAppSession = authState.mode === "oidc" && !hasAppSession;
+  const hostedAuth = projectHostedCatalogAuthState(authState, {
+    appSession: appSessionStatus.session,
+    appSessionLoading: appSessionStatus.status === "loading",
+  });
+  const {
+    canFetchCatalog: canFetchNotebookList,
+    hasAppSession,
+    signedIn,
+    waitingForAppSession,
+  } = hostedAuth;
   const dashboardModel = useMemo(
     () => (listState.kind === "ready" ? projectCloudNotebookDashboard(listState.notebooks) : null),
     [listState],
@@ -96,7 +103,11 @@ export function CloudNotebookListView({ authConfig }: { authConfig: CloudViewerA
   }, [listState]);
 
   useEffect(() => {
-    const seededNotebooks = cloudNotebookListSeedFromBootstrapOrCache(authState, bootstrap);
+    const seededNotebooks = cloudNotebookListSeedFromBootstrapOrCache(
+      authState,
+      appSessionStatus.session,
+      bootstrap,
+    );
     if (!canFetchNotebookList) {
       if (waitingForAppSession) {
         setListState(
@@ -110,7 +121,11 @@ export function CloudNotebookListView({ authConfig }: { authConfig: CloudViewerA
     }
 
     if (refreshIndex === 0 && bootstrap) {
-      writeCachedCloudNotebookListToWindow(authState, bootstrap.notebooks);
+      writeCachedCloudNotebookListToWindow(
+        authState,
+        appSessionStatus.session,
+        bootstrap.notebooks,
+      );
       setListState({ kind: "ready", notebooks: bootstrap.notebooks });
       return;
     }
@@ -130,7 +145,7 @@ export function CloudNotebookListView({ authConfig }: { authConfig: CloudViewerA
         if (!isCloudNotebookListResponse(body)) {
           throw new Error("Unable to list notebooks: response shape was invalid");
         }
-        writeCachedCloudNotebookListToWindow(authState, body.notebooks);
+        writeCachedCloudNotebookListToWindow(authState, appSessionStatus.session, body.notebooks);
         setListState({ kind: "ready", notebooks: body.notebooks });
       } catch (error) {
         if (controller.signal.aborted) return;
@@ -144,7 +159,14 @@ export function CloudNotebookListView({ authConfig }: { authConfig: CloudViewerA
     return () => {
       controller.abort();
     };
-  }, [authState, bootstrap, canFetchNotebookList, refreshIndex, waitingForAppSession]);
+  }, [
+    appSessionStatus.session,
+    authState,
+    bootstrap,
+    canFetchNotebookList,
+    refreshIndex,
+    waitingForAppSession,
+  ]);
 
   const refreshList = () => {
     if (authState.mode === "oidc" && authState.token) {
@@ -277,7 +299,7 @@ export function CloudNotebookListView({ authConfig }: { authConfig: CloudViewerA
               }
             : notebook,
         );
-        writeCachedCloudNotebookListToWindow(authState, notebooks);
+        writeCachedCloudNotebookListToWindow(authState, appSessionStatus.session, notebooks);
         return {
           kind: "ready",
           notebooks,
@@ -517,7 +539,11 @@ function initialCloudNotebookListState(
   authState: CloudPrototypeAuthState,
   bootstrap: CloudNotebookListBootstrap | null,
 ): CloudNotebookListState {
-  const seededNotebooks = cloudNotebookListSeedFromBootstrapOrCache(authState, bootstrap);
+  const seededNotebooks = cloudNotebookListSeedFromBootstrapOrCache(
+    authState,
+    bootstrap?.session ?? null,
+    bootstrap,
+  );
   return seededNotebooks ? { kind: "ready", notebooks: seededNotebooks } : { kind: "loading" };
 }
 
@@ -541,27 +567,30 @@ function fetchCloudNotebookList(
 
 function cloudNotebookListSeedFromBootstrapOrCache(
   authState: CloudPrototypeAuthState,
+  appSession: CloudAppSession | null | undefined,
   bootstrap: CloudNotebookListBootstrap | null,
 ): CloudNotebookListItem[] | null {
-  return bootstrap?.notebooks ?? readCachedCloudNotebookListFromWindow(authState);
+  return bootstrap?.notebooks ?? readCachedCloudNotebookListFromWindow(authState, appSession);
 }
 
 function readCachedCloudNotebookListFromWindow(
   authState: CloudPrototypeAuthState,
+  appSession: CloudAppSession | null | undefined,
 ): CloudNotebookListItem[] | null {
   const storage = cloudNotebookListCacheStorage();
-  return storage ? readCachedCloudNotebookList(storage, authState) : null;
+  return storage ? readCachedCloudNotebookList(storage, authState, appSession) : null;
 }
 
 function writeCachedCloudNotebookListToWindow(
   authState: CloudPrototypeAuthState,
+  appSession: CloudAppSession | null | undefined,
   notebooks: CloudNotebookListItem[],
 ): void {
   const storage = cloudNotebookListCacheStorage();
   if (!storage) {
     return;
   }
-  writeCachedCloudNotebookList(storage, authState, notebooks);
+  writeCachedCloudNotebookList(storage, authState, appSession, notebooks);
 }
 
 function clearCachedCloudNotebookListFromWindow(): void {

--- a/apps/notebook-cloud/viewer/use-cloud-auth.ts
+++ b/apps/notebook-cloud/viewer/use-cloud-auth.ts
@@ -34,7 +34,7 @@ export function cloudAppSessionsEqual(
 ): boolean {
   if (a === b) return true;
   if (!a || !b) return false;
-  return a.provider === b.provider && a.expires_at === b.expires_at;
+  return a.provider === b.provider && a.expires_at === b.expires_at && a.cache_key === b.cache_key;
 }
 
 /**


### PR DESCRIPTION
## Summary

- adds an opaque app-session cache key to the first-party session status payload
- keys the hosted notebook list cache from that app-session boundary before falling back to local OIDC/dev auth
- extracts hosted catalog auth state into a pure projection for notebook home and future document catalogs

## Validation

- `pnpm --dir apps/notebook-cloud exec node --import tsx --test test/app-session.test.ts test/app-session-client.test.ts test/notebook-list-cache.test.ts test/use-cloud-auth-session-identity.test.ts test/hosted-catalog-auth.test.ts test/viewer-shared-cell-surface.test.ts`
- `pnpm test:run apps/notebook-cloud/viewer/__tests__/use-cloud-app-session-status.test.tsx`
- `pnpm --dir apps/notebook-cloud exec node --import tsx --test test/worker-routes.test.ts`
- `pnpm --dir apps/notebook-cloud run typecheck`
- `cargo xtask lint --fix`