### PR TITLE
fix(notebook-cloud): retire hosted markdown durable object

### DIFF
--- a/apps/notebook-cloud/wrangler.toml
+++ b/apps/notebook-cloud/wrangler.toml
@@ -25,6 +25,14 @@ new_sqlite_classes = ["NotebookRoom"]
 tag = "v2"
 new_sqlite_classes = ["WorkstationEvents"]
 
+[[migrations]]
+tag = "v3"
+new_sqlite_classes = ["MarkdownDocumentRoom"]
+
+[[migrations]]
+tag = "v4"
+deleted_classes = ["MarkdownDocumentRoom"]
+
 [[d1_databases]]
 binding = "DB"
 database_name = "nteract-notebook-cloud-prototype-db"


### PR DESCRIPTION
## Summary
- preserve the deployed Markdown document Durable Object migration tag (`v3`) in history
- add a `v4` delete migration for `MarkdownDocumentRoom` now that the full Markdown prototype PR is closed
- unblock clean preview deployments from `origin/main` after the prototype had been deployed

## Context
The full hosted Markdown prototype was deployed to preview and added `MarkdownDocumentRoom` as Durable Object migration `v3`. After closing that prototype branch, `origin/main` only had migrations `v1` and `v2`, so Wrangler treated the live `v3` tag as deleted history and tried to replay existing migrations. Cloudflare rejected that with `Cannot apply new-sqlite-class migration to class NotebookRoom...` because the class already exists.

## Validation
- `pnpm --dir apps/notebook-cloud exec wrangler deploy --dry-run -c wrangler.toml`
- `cargo xtask lint --fix`
- `pnpm --dir apps/notebook-cloud run deploy`
- `curl https://preview.runt.run/api/health` reports build SHA `7b916b91f308d36913ba3bad33cd8912e9f25427`
- `curl https://preview.runt.run/m` returns `404 {"error":"not found"}`
