### PR TITLE
fix(outputs): keep JavaScript outputs with HTML frames

### DIFF
--- a/src/components/cell/__tests__/OutputArea.test.tsx
+++ b/src/components/cell/__tests__/OutputArea.test.tsx
@@ -240,6 +240,44 @@ function makeMixedDocumentOutputs(): JupyterOutput[] {
   ];
 }
 
+function makeBokehDocumentOutputs(): JupyterOutput[] {
+  return [
+    {
+      output_id: "bokeh-loading-html",
+      output_type: "display_data",
+      data: { "text/html": '<span id="bokeh-loading">Loading BokehJS ...</span>' },
+      metadata: {},
+    },
+    {
+      output_id: "bokeh-load-js",
+      output_type: "display_data",
+      data: {
+        "application/javascript":
+          'document.getElementById("bokeh-loading").textContent = "BokehJS loaded";',
+        "application/vnd.bokehjs_load.v0+json": "",
+      },
+      metadata: {},
+    },
+    {
+      output_id: "bokeh-root-html",
+      output_type: "display_data",
+      data: { "text/html": '<div id="bokeh-root"></div>' },
+      metadata: {},
+    },
+    {
+      output_id: "bokeh-exec-js",
+      output_type: "display_data",
+      data: {
+        "application/javascript": 'document.getElementById("bokeh-root").textContent = "plot";',
+        "application/vnd.bokehjs_exec.v0+json": "",
+      },
+      metadata: {
+        "application/vnd.bokehjs_exec.v0+json": { id: "p1011" },
+      },
+    },
+  ];
+}
+
 function makeParquetOutput(): JupyterOutput[] {
   return [
     {
@@ -922,6 +960,39 @@ describe("OutputArea iframe theme sync", () => {
         expect.objectContaining({
           mimeType: "application/vnd.apache.parquet",
           outputId: "parquet-output",
+        }),
+      ]);
+    });
+  });
+
+  it("keeps Bokeh's related HTML and JavaScript outputs in one iframe document", async () => {
+    render(<OutputArea outputs={makeBokehDocumentOutputs()} />);
+
+    const frames = screen.getAllByTestId("isolated-frame");
+    expect(frames).toHaveLength(1);
+    expect(frames[0].getAttribute("data-scroll-passthrough")).toBe("true");
+
+    await waitFor(() => {
+      expect(mockFrameHandle.renderBatch).toHaveBeenCalledWith([
+        expect.objectContaining({
+          mimeType: "text/html",
+          outputId: "bokeh-loading-html",
+          outputIndex: 0,
+        }),
+        expect.objectContaining({
+          mimeType: "application/javascript",
+          outputId: "bokeh-load-js",
+          outputIndex: 1,
+        }),
+        expect.objectContaining({
+          mimeType: "text/html",
+          outputId: "bokeh-root-html",
+          outputIndex: 2,
+        }),
+        expect.objectContaining({
+          mimeType: "application/javascript",
+          outputId: "bokeh-exec-js",
+          outputIndex: 3,
         }),
       ]);
     });

--- a/src/components/isolated/__tests__/output-lane-policy.test.ts
+++ b/src/components/isolated/__tests__/output-lane-policy.test.ts
@@ -180,6 +180,41 @@ describe("output lane policy", () => {
     expect(outputSegmentLane(output)).toBe("vega-frame");
   });
 
+  it("keeps Bokeh's HTML and JavaScript display outputs in one document lane", () => {
+    const outputs = [
+      displayOutput("bokeh-loading-html", {
+        "text/html": '<span id="bokeh-loading">Loading BokehJS ...</span>',
+      }),
+      displayOutput("bokeh-load-js", {
+        "application/javascript": 'document.getElementById("bokeh-loading").textContent = "ok";',
+        "application/vnd.bokehjs_load.v0+json": "",
+      }),
+      displayOutput("bokeh-root-html", {
+        "text/html": '<div id="bokeh-root"></div>',
+      }),
+      displayOutput("bokeh-exec-js", {
+        "application/javascript": 'document.getElementById("bokeh-root").textContent = "plot";',
+        "application/vnd.bokehjs_exec.v0+json": "",
+      }),
+    ];
+
+    const segments = splitOutputSegments(outputs);
+
+    expect(outputs.map((output) => outputAllowsScrollPassthrough(output))).toEqual([
+      true,
+      true,
+      true,
+      true,
+    ]);
+    expect(segments.map((segment) => segment.lane)).toEqual(["static-frame"]);
+    expect(segments[0].outputs.map((output) => output.output_id)).toEqual([
+      "bokeh-loading-html",
+      "bokeh-load-js",
+      "bokeh-root-html",
+      "bokeh-exec-js",
+    ]);
+  });
+
   it("keeps pan/zoom charts standalone instead of coalescing with sibling document outputs", () => {
     withMarkdownProjection("isolated");
     const markdown = displayOutput("markdown-1", { "text/markdown": "# heading" });

--- a/src/components/isolated/output-lane-policy.ts
+++ b/src/components/isolated/output-lane-policy.ts
@@ -35,6 +35,9 @@ const SCROLL_PASSTHROUGH_MIME_TYPES = new Set([
   "text/markdown",
   "text/html",
   "image/svg+xml",
+  // JavaScript display outputs often act on adjacent HTML display outputs in
+  // the same cell (Bokeh's notebook loader/root pair is the common case).
+  "application/javascript",
   // Sift's interactive tables are also click-to-engage (see SIFT_MIME_TYPES).
   "application/vnd.apache.parquet",
   "application/vnd.apache.arrow.stream",


### PR DESCRIPTION
## Summary

- keep `application/javascript` display outputs in the same document-style isolated lane as adjacent HTML/SVG outputs
- add Bokeh-shaped output lane and `OutputArea` regression coverage
- fix Bokeh notebook output sequences that need loader/root HTML and JavaScript to share one iframe document

## Verification

- `pnpm test:run src/components/isolated/__tests__/output-lane-policy.test.ts src/components/cell/__tests__/OutputArea.test.tsx`
- `cargo xtask lint --fix`
- Loaded `/Users/kylekelley/notebooks/bokeh-3723.ipynb` through local Vite; one isolated frame rendered `BokehJS 3.9.1 successfully loaded.` and the scatter plot; filtered browser logs had no Bokeh/isolated-renderer errors.
