### PR TITLE
feat(elements): add comment surfaces to the design system

### DIFF
--- a/apps/elements/components/comment-surfaces-example.tsx
+++ b/apps/elements/components/comment-surfaces-example.tsx
@@ -1,0 +1,230 @@
+"use client";
+
+import { useEffect, useRef, useState } from "react";
+import { NotebookCommentsPanel, type CommentAuthor } from "@/components/notebook";
+import type { CommentsProjection } from "@/components/notebook/comment-types";
+import { cn } from "@/lib/utils";
+
+// Fixture actors. The panel itself is presentational. Attribution (name,
+// color, AI-on-behalf) is resolved by the host through resolveCommentAuthor,
+// so the design-system view declares the contract with a small fixture map.
+const ADA = "local:ada/desktop:1";
+const CLAUDE = "local:ada/agent:claude-code:1";
+const ADA_COLOR = "#16a34a";
+const CLAUDE_COLOR = "#7c3aed";
+
+function resolveCommentAuthor(actorLabel: string): CommentAuthor {
+  if (actorLabel === CLAUDE) {
+    return {
+      displayName: "Claude Code",
+      color: CLAUDE_COLOR,
+      isAgent: true,
+      onBehalfOf: "Ada",
+      onBehalfOfColor: ADA_COLOR,
+    };
+  }
+  return { displayName: "Ada", color: ADA_COLOR };
+}
+
+function resolveSourceLanguage(): string {
+  return "python";
+}
+
+const INITIAL: CommentsProjection = {
+  comments_doc_id: "comments:elements-fixture",
+  threads: [
+    {
+      id: "thread-diff",
+      anchor: {
+        kind: "source_range",
+        cell_id: "cell-1",
+        start_line: 9,
+        start_column: 5,
+        end_line: 9,
+        end_column: 18,
+        exact_quote: "sp.diff(f, x)",
+        prefix_quote: "df = ",
+      },
+      position: "10",
+      status: "open",
+      mutation_state: "accepted",
+      trusted: true,
+      badge_cell_ids: ["cell-1"],
+      created_at: "2026-06-18T15:00:00Z",
+      created_by_actor_label: ADA,
+      messages: [
+        {
+          id: "m1",
+          position: "10",
+          body: "This derivative could read more clearly. Maybe name the result?",
+          mutation_state: "accepted",
+          trusted: true,
+          created_at: "2026-06-18T15:00:00Z",
+          created_by_actor_label: ADA,
+        },
+        {
+          id: "m2",
+          position: "20",
+          body: "Agreed. Want me to pull it into a `derivative` variable and add a docstring?",
+          mutation_state: "accepted",
+          trusted: true,
+          created_at: "2026-06-18T15:02:00Z",
+          created_by_actor_label: CLAUDE,
+        },
+      ],
+    },
+    {
+      id: "thread-doc",
+      anchor: { kind: "notebook" },
+      position: "20",
+      status: "open",
+      mutation_state: "accepted",
+      trusted: true,
+      badge_cell_ids: [],
+      created_at: "2026-06-18T15:20:00Z",
+      created_by_actor_label: ADA,
+      messages: [
+        {
+          id: "m-doc",
+          position: "10",
+          body: "Let's keep this notebook as the worked example for the docs.",
+          mutation_state: "accepted",
+          trusted: true,
+          created_at: "2026-06-18T15:20:00Z",
+          created_by_actor_label: ADA,
+        },
+      ],
+    },
+    {
+      id: "thread-import",
+      anchor: {
+        kind: "source_range",
+        cell_id: "cell-1",
+        start_line: 2,
+        start_column: 0,
+        end_line: 2,
+        end_column: 18,
+        exact_quote: "import sympy as sp",
+      },
+      position: "5",
+      status: "resolved",
+      mutation_state: "accepted",
+      trusted: true,
+      badge_cell_ids: ["cell-1"],
+      created_at: "2026-06-18T14:00:00Z",
+      created_by_actor_label: ADA,
+      resolved_at: "2026-06-18T14:10:00Z",
+      resolved_by_actor_label: ADA,
+      messages: [
+        {
+          id: "m3",
+          position: "10",
+          body: "Should we pin the SymPy version for reproducibility?",
+          mutation_state: "accepted",
+          trusted: true,
+          created_at: "2026-06-18T14:00:00Z",
+          created_by_actor_label: ADA,
+        },
+      ],
+    },
+  ],
+};
+
+let counter = 0;
+function nextId(prefix: string): string {
+  counter += 1;
+  return `${prefix}-${counter}`;
+}
+
+export function CommentSurfacesExample() {
+  const [projection, setProjection] = useState<CommentsProjection>(INITIAL);
+  const nowRef = useRef("2026-06-18T15:30:00Z");
+
+  // Quote syntax highlighting is theme-dependent, so the server (light) and the
+  // hydrated client (the reader's theme) disagree on colors. Gate on mount so
+  // SSR and the first client paint render the same placeholder, then upgrade.
+  const [mounted, setMounted] = useState(false);
+  useEffect(() => setMounted(true), []);
+
+  const appendMessage = (threadId: string, body: string) =>
+    setProjection((current) => ({
+      ...current,
+      threads: current.threads.map((thread) =>
+        thread.id === threadId
+          ? {
+              ...thread,
+              status: "open",
+              messages: [
+                ...thread.messages,
+                {
+                  id: nextId("m"),
+                  position: nextId("p"),
+                  body,
+                  mutation_state: "accepted",
+                  trusted: true,
+                  created_at: nowRef.current,
+                  created_by_actor_label: ADA,
+                },
+              ],
+            }
+          : thread,
+      ),
+    }));
+
+  const setStatus = (threadId: string, status: "open" | "resolved") =>
+    setProjection((current) => ({
+      ...current,
+      threads: current.threads.map((thread) =>
+        thread.id === threadId ? { ...thread, status } : thread,
+      ),
+    }));
+
+  return (
+    <div className={cn("not-prose my-6 flex justify-center")}>
+      <div className="w-[340px] rounded-xl border bg-background p-3.5 shadow-sm">
+        {!mounted ? (
+          <div className="h-[420px]" aria-hidden />
+        ) : (
+          <NotebookCommentsPanel
+            projection={projection}
+            resolveCommentAuthor={resolveCommentAuthor}
+            resolveSourceLanguage={resolveSourceLanguage}
+            onCreateThread={(body) =>
+              setProjection((current) => ({
+                ...current,
+                threads: [
+                  ...current.threads,
+                  {
+                    id: nextId("thread"),
+                    anchor: { kind: "notebook" },
+                    position: nextId("p"),
+                    status: "open",
+                    mutation_state: "accepted",
+                    trusted: true,
+                    badge_cell_ids: [],
+                    created_at: nowRef.current,
+                    created_by_actor_label: ADA,
+                    messages: [
+                      {
+                        id: nextId("m"),
+                        position: nextId("p"),
+                        body,
+                        mutation_state: "accepted",
+                        trusted: true,
+                        created_at: nowRef.current,
+                        created_by_actor_label: ADA,
+                      },
+                    ],
+                  },
+                ],
+              }))
+            }
+            onReplyThread={appendMessage}
+            onResolveThread={(id) => setStatus(id, "resolved")}
+            onReopenThread={(id) => setStatus(id, "open")}
+          />
+        )}
+      </div>
+    </div>
+  );
+}

--- a/apps/elements/content/docs/comment-surfaces.mdx
+++ b/apps/elements/content/docs/comment-surfaces.mdx
@@ -1,0 +1,49 @@
+---
+title: Comment surfaces
+description: Anchored notebook comments. The rail panel, attribution, and AI-on-behalf authorship.
+---
+
+import { CommentSurfacesExample } from "@/components/comment-surfaces-example";
+
+People and AI agents work the same live notebook, and comments are how they
+talk about it: a thread anchored to a source range, a cell, an output, or the
+whole document. The rail below is rendered from fixtures, no daemon and no
+kernel, so the surface and its rationale stand on their own.
+
+<CommentSurfacesExample />
+
+## Presentational by design
+
+The panel takes a comments projection plus callbacks and never touches the
+daemon. The host resolves two things for it:
+
+- `resolveCommentAuthor(actorLabel)` → name, color, and whether the author is an
+  AI agent acting on someone's behalf.
+- `resolveSourceLanguage(cellId)` → the language to highlight a quoted source
+  range in (markdown and raw quotes stay plain prose).
+
+That split is what lets the panel render here from a fixture map, and lets the
+notebook app wire the same props to live presence and the runtime.
+
+## AI on behalf of a person
+
+Authorship is legible at a glance and impossible to fake. Each message shows an
+identity-colored avatar (the same color as that author's cursor and edits),
+name, and time. An agent additionally carries an `AI` chip, a `· for <person>`
+note, and a small principal badge on its avatar, the "acting on behalf of"
+cue. In the app, trust is earned: the daemon finalizes a comment against the
+authenticated connection before it's marked trusted, so "Claude Code · for Ada"
+is provable, not asserted.
+
+## Anchors
+
+A source-range comment quotes the code it's about, highlighted in the cell's
+language and tinted with the author's color; other comments anchor to a cell,
+an output, or the document. If the document shifts past an anchor, the comment
+degrades to a dangling document comment rather than vanishing.
+
+## Resolution
+
+Open threads lead; resolved ones tuck behind **Show resolved** so the rail stays
+on active discussion. The demo is live. Reply, resolve, or add a document
+comment.

--- a/src/components/notebook/NotebookCommentsPanel.tsx
+++ b/src/components/notebook/NotebookCommentsPanel.tsx
@@ -1,0 +1,809 @@
+import {
+  Bot,
+  CheckCircle2,
+  ChevronDown,
+  ChevronRight,
+  LocateFixed,
+  MessageSquare,
+  Plus,
+  RotateCcw,
+  Send,
+  X,
+} from "lucide-react";
+import { useEffect, useRef, useState, type FormEvent } from "react";
+import type {
+  CommentAnchor,
+  CommentMessageSnapshot,
+  CommentThreadSnapshot,
+  CommentsProjection,
+} from "./comment-types";
+import { projectMarkdownPlan } from "../../lib/markdown-projection";
+import { useColorTheme, useDarkMode } from "@/lib/dark-mode";
+import { cn } from "@/lib/utils";
+import { highlight } from "@/components/editor/static-highlight";
+import { ProjectedMarkdownView } from "../markdown/ProjectedMarkdownView";
+
+export interface NotebookCommentDraftTarget {
+  anchor: CommentAnchor;
+  quote?: string | null;
+}
+
+/** Rendered attribution for a comment author. */
+export interface CommentAuthor {
+  /** Display name (e.g. "Claude Code" or "kylekelley"). */
+  displayName: string;
+  /** Author color (hex), shared with cursors/attribution/highlights. */
+  color?: string;
+  /** True when the author is an AI agent rather than a person. */
+  isAgent?: boolean;
+  /** Principal the agent is acting for, when operating on someone's behalf. */
+  onBehalfOf?: string | null;
+  /** Color of the principal the agent acts for (for the on-behalf-of badge). */
+  onBehalfOfColor?: string;
+}
+
+export interface NotebookCommentsPanelProps {
+  projection: CommentsProjection | null;
+  readOnly?: boolean;
+  draftTarget?: NotebookCommentDraftTarget | null;
+  statusMessage?: string | null;
+  errorMessage?: string | null;
+  onClearDraftTarget?: () => void;
+  onCreateThread?: (body: string) => void | Promise<void>;
+  onReplyThread?: (threadId: string, body: string) => void | Promise<void>;
+  onResolveThread?: (threadId: string) => void | Promise<void>;
+  onReopenThread?: (threadId: string) => void | Promise<void>;
+  onFocusThreadAnchor?: (thread: CommentThreadSnapshot) => void;
+  /**
+   * Resolve attribution for a comment author's actor label: display name,
+   * color, whether it's an AI agent, and the principal it acts for. Falls back
+   * to parsing the actor label when not provided.
+   */
+  resolveCommentAuthor?: (actorLabel: string) => CommentAuthor;
+  /**
+   * Language for syntax-highlighting a quoted source range, by anchored cell.
+   * Returns undefined for cells whose quotes should not be code-highlighted
+   * (e.g. markdown prose, raw cells).
+   */
+  resolveSourceLanguage?: (cellId: string) => string | undefined;
+  /** Thread to scroll to and flash (e.g. after clicking its editor highlight). */
+  focusedThreadId?: string | null;
+  /** Bumped each focus request so repeat focuses of the same thread re-flash. */
+  focusNonce?: number;
+}
+
+export function NotebookCommentsPanel({
+  projection,
+  readOnly = false,
+  draftTarget = null,
+  statusMessage = null,
+  errorMessage = null,
+  onClearDraftTarget,
+  onCreateThread,
+  onReplyThread,
+  onResolveThread,
+  onReopenThread,
+  onFocusThreadAnchor,
+  resolveCommentAuthor,
+  resolveSourceLanguage,
+  focusedThreadId = null,
+  focusNonce = 0,
+}: NotebookCommentsPanelProps) {
+  const threads = projection?.threads ?? [];
+  const labeledThreads = labelCommentThreads(threads);
+  const openThreads = labeledThreads.filter(({ thread }) => thread.status !== "resolved");
+  const resolvedThreads = labeledThreads.filter(({ thread }) => thread.status === "resolved");
+  const [showResolved, setShowResolved] = useState(false);
+
+  // Reveal resolved threads when the focus target is one of them, so a click
+  // on a resolved thread's highlight can scroll to it.
+  const focusedIsResolved = resolvedThreads.some(({ thread }) => thread.id === focusedThreadId);
+  useEffect(() => {
+    if (focusedIsResolved) setShowResolved(true);
+  }, [focusedIsResolved, focusNonce]);
+  const canCreate = !readOnly && Boolean(onCreateThread);
+  const canReply = !readOnly && Boolean(onReplyThread);
+  const canUpdateStatus = !readOnly && (Boolean(onResolveThread) || Boolean(onReopenThread));
+
+  const renderThread = ({
+    thread,
+    threadLabel,
+  }: {
+    thread: CommentThreadSnapshot;
+    threadLabel: string;
+  }) => (
+    <CommentThreadItem
+      key={thread.id}
+      thread={thread}
+      threadLabel={threadLabel}
+      canReply={canReply}
+      canUpdateStatus={canUpdateStatus}
+      onReplyThread={onReplyThread}
+      onResolveThread={onResolveThread}
+      onReopenThread={onReopenThread}
+      onFocusThreadAnchor={onFocusThreadAnchor}
+      resolveCommentAuthor={resolveCommentAuthor}
+      resolveSourceLanguage={resolveSourceLanguage}
+      focused={thread.id === focusedThreadId}
+      focusNonce={focusNonce}
+    />
+  );
+
+  return (
+    <section className="flex min-h-0 flex-col gap-3" data-testid="notebook-comments-panel">
+      {statusMessage ? (
+        <div
+          className="rounded-md border border-dashed px-3 py-2 text-sm text-muted-foreground"
+          role="status"
+        >
+          {statusMessage}
+        </div>
+      ) : null}
+      {errorMessage ? (
+        <div
+          className="rounded-md border border-destructive/40 bg-destructive/5 px-3 py-2 text-sm text-destructive"
+          role="alert"
+        >
+          {errorMessage}
+        </div>
+      ) : null}
+
+      {draftTarget ? (
+        <CommentDraftTargetView target={draftTarget} onClear={onClearDraftTarget} />
+      ) : null}
+
+      <CommentComposer
+        ariaLabel={
+          draftTarget
+            ? `New ${anchorLabelForDraft(draftTarget.anchor)} comment`
+            : "New document comment"
+        }
+        buttonLabel="Add comment"
+        icon="plus"
+        disabled={!canCreate}
+        autoFocusKey={draftTarget ? draftAutoFocusKey(draftTarget) : null}
+        placeholder={
+          draftTarget
+            ? `Add a ${anchorLabelForDraft(draftTarget.anchor)} comment`
+            : "Add a document comment"
+        }
+        compact={!draftTarget}
+        onSubmit={onCreateThread}
+      />
+
+      {projection && threads.length === 0 ? (
+        <div className="flex flex-col items-center gap-2 rounded-md border border-dashed px-3 py-6 text-center text-sm text-muted-foreground">
+          <MessageSquare className="size-4" aria-hidden="true" />
+          <span>No comments yet.</span>
+        </div>
+      ) : (
+        <div className="space-y-3">
+          {openThreads.length > 0 ? (
+            <ol className="space-y-3">{openThreads.map(renderThread)}</ol>
+          ) : resolvedThreads.length > 0 ? (
+            <p className="px-1 py-4 text-center text-sm text-muted-foreground">No open comments.</p>
+          ) : null}
+
+          {resolvedThreads.length > 0 ? (
+            <div className="space-y-3">
+              <button
+                type="button"
+                onClick={() => setShowResolved((value) => !value)}
+                aria-expanded={showResolved}
+                className="inline-flex items-center gap-1 text-xs font-medium text-muted-foreground transition-colors hover:text-foreground"
+              >
+                {showResolved ? (
+                  <ChevronDown className="size-3.5" aria-hidden="true" />
+                ) : (
+                  <ChevronRight className="size-3.5" aria-hidden="true" />
+                )}
+                {showResolved ? "Hide" : "Show"} resolved ({resolvedThreads.length})
+              </button>
+              {showResolved ? (
+                <ol className="space-y-3">{resolvedThreads.map(renderThread)}</ol>
+              ) : null}
+            </div>
+          ) : null}
+        </div>
+      )}
+    </section>
+  );
+}
+
+function CommentDraftTargetView({
+  target,
+  onClear,
+}: {
+  target: NotebookCommentDraftTarget;
+  onClear?: () => void;
+}) {
+  const quote = formatQuotePreview(target.quote ?? sourceQuoteFromAnchor(target.anchor));
+
+  return (
+    <div
+      className="rounded-md border bg-muted/25 px-3 py-2 text-sm"
+      data-testid="comment-draft-target"
+    >
+      <div className="flex min-w-0 items-start justify-between gap-2">
+        <div className="min-w-0">
+          <div className="text-xs font-medium text-muted-foreground">
+            {formatStateLabel(anchorLabelForDraft(target.anchor))} selection
+          </div>
+          {quote ? (
+            <blockquote className="mt-1 max-h-24 overflow-hidden whitespace-pre-wrap break-words border-l-2 border-border pl-2 text-xs leading-5 text-foreground">
+              {quote}
+            </blockquote>
+          ) : null}
+        </div>
+        {onClear ? (
+          <button
+            type="button"
+            aria-label="Use document target"
+            title="Use document target"
+            onClick={onClear}
+            className="inline-flex size-6 shrink-0 items-center justify-center rounded-md text-muted-foreground transition-colors hover:bg-muted hover:text-foreground"
+          >
+            <X className="size-3.5" aria-hidden="true" />
+          </button>
+        ) : null}
+      </div>
+    </div>
+  );
+}
+
+function CommentThreadItem({
+  thread,
+  threadLabel,
+  canReply,
+  canUpdateStatus,
+  onReplyThread,
+  onResolveThread,
+  onReopenThread,
+  onFocusThreadAnchor,
+  resolveCommentAuthor,
+  resolveSourceLanguage,
+  focused,
+  focusNonce,
+}: {
+  thread: CommentThreadSnapshot;
+  threadLabel: string;
+  canReply: boolean;
+  canUpdateStatus: boolean;
+  onReplyThread?: (threadId: string, body: string) => void | Promise<void>;
+  onResolveThread?: (threadId: string) => void | Promise<void>;
+  onReopenThread?: (threadId: string) => void | Promise<void>;
+  onFocusThreadAnchor?: (thread: CommentThreadSnapshot) => void;
+  resolveCommentAuthor?: (actorLabel: string) => CommentAuthor;
+  resolveSourceLanguage?: (cellId: string) => string | undefined;
+  focused?: boolean;
+  focusNonce?: number;
+}) {
+  const itemRef = useRef<HTMLLIElement>(null);
+  const [flashing, setFlashing] = useState(false);
+  // On a focus request for this thread, scroll it into view and flash a ring.
+  useEffect(() => {
+    if (!focused) return;
+    itemRef.current?.scrollIntoView?.({ block: "nearest", behavior: "smooth" });
+    setFlashing(true);
+    const timer = setTimeout(() => setFlashing(false), 1100);
+    return () => clearTimeout(timer);
+  }, [focused, focusNonce]);
+  const [statusSubmitting, setStatusSubmitting] = useState(false);
+  const hasUnsettledMessages = thread.messages.some(
+    (message) => message.mutation_state === "pending" || message.mutation_state === "unverified",
+  );
+  const statusActionEnabled =
+    canUpdateStatus && thread.mutation_state === "accepted" && !hasUnsettledMessages;
+  const statusAction =
+    thread.status === "resolved"
+      ? {
+          label: "Reopen",
+          icon: RotateCcw,
+          onClick: () => onReopenThread?.(thread.id),
+          ariaLabel: `Reopen ${threadLabel}`,
+          disabled: !statusActionEnabled || !onReopenThread,
+        }
+      : {
+          label: "Resolve",
+          icon: CheckCircle2,
+          onClick: () => onResolveThread?.(thread.id),
+          ariaLabel: `Resolve ${threadLabel}`,
+          disabled: !statusActionEnabled || !onResolveThread,
+        };
+  const StatusIcon = statusAction.icon;
+  const handleStatusAction = async () => {
+    if (statusAction.disabled) return;
+    setStatusSubmitting(true);
+    try {
+      await statusAction.onClick();
+    } finally {
+      setStatusSubmitting(false);
+    }
+  };
+
+  const quote = sourceQuoteFromAnchor(thread.anchor);
+  const threadAuthor = thread.created_by_actor_label
+    ? resolveCommentAuthor?.(thread.created_by_actor_label)
+    : undefined;
+  const canShowCell = Boolean(commentThreadTargetCellId(thread) && onFocusThreadAnchor);
+
+  return (
+    <li
+      ref={itemRef}
+      className={cn(
+        "rounded-lg border bg-card text-card-foreground shadow-sm transition-shadow duration-700",
+        flashing && "ring-2 ring-primary/60",
+      )}
+    >
+      <div className="space-y-3 p-3">
+        <div className="flex items-center gap-2">
+          {quote ? (
+            <CommentSourceQuote
+              quote={quote}
+              language={
+                resolveSourceLanguage
+                  ? resolveSourceLanguage(commentThreadTargetCellId(thread) ?? "")
+                  : undefined
+              }
+              color={threadAuthor?.color}
+            />
+          ) : (
+            <div className="min-w-0 flex-1 text-xs text-muted-foreground">
+              {anchorLabel(thread)}
+            </div>
+          )}
+          {thread.status === "resolved" ? <CommentBadge state="resolved" /> : null}
+          {thread.mutation_state === "rejected" ? (
+            <span className="text-[11px] font-medium text-destructive">Couldn't post</span>
+          ) : null}
+          <div className="flex shrink-0 items-center gap-0.5">
+            {canShowCell ? (
+              <button
+                type="button"
+                onClick={() => onFocusThreadAnchor?.(thread)}
+                aria-label={`Show cell for ${threadLabel}`}
+                title="Show cell"
+                className="inline-grid size-7 place-items-center rounded-md text-muted-foreground transition-colors hover:bg-muted hover:text-foreground"
+              >
+                <LocateFixed className="size-3.5" aria-hidden="true" />
+              </button>
+            ) : null}
+            <button
+              type="button"
+              onClick={handleStatusAction}
+              disabled={statusAction.disabled || statusSubmitting}
+              aria-label={statusAction.ariaLabel}
+              title={statusAction.label}
+              className="inline-grid size-7 place-items-center rounded-md text-muted-foreground transition-colors hover:bg-muted hover:text-foreground disabled:cursor-not-allowed disabled:opacity-40"
+            >
+              <StatusIcon className="size-3.5" aria-hidden="true" />
+            </button>
+          </div>
+        </div>
+
+        <div className="space-y-3">
+          {thread.messages.map((message) => (
+            <CommentMessage
+              key={message.id}
+              message={message}
+              resolveCommentAuthor={resolveCommentAuthor}
+            />
+          ))}
+        </div>
+
+        <CommentComposer
+          ariaLabel={`Reply to ${threadLabel}`}
+          buttonAriaLabel={`Submit reply to ${threadLabel}`}
+          buttonLabel="Reply"
+          icon="send"
+          disabled={!canReply}
+          placeholder="Reply…"
+          compact
+          onSubmit={onReplyThread ? (body) => onReplyThread(thread.id, body) : undefined}
+        />
+      </div>
+    </li>
+  );
+}
+
+function CommentMessage({
+  message,
+  resolveCommentAuthor,
+}: {
+  message: CommentMessageSnapshot;
+  resolveCommentAuthor?: (actorLabel: string) => CommentAuthor;
+}) {
+  const author: CommentAuthor | null = message.created_by_actor_label
+    ? (resolveCommentAuthor?.(message.created_by_actor_label) ?? {
+        displayName: formatActorLabel(message.created_by_actor_label),
+      })
+    : null;
+
+  return (
+    <article className="flex gap-2.5">
+      {author ? (
+        <CommentAuthorAvatar author={author} />
+      ) : (
+        <div className="mt-0.5 size-5 shrink-0 rounded-full bg-muted" aria-hidden="true" />
+      )}
+      <div className="min-w-0 flex-1 space-y-0.5">
+        <div className="flex flex-wrap items-baseline gap-x-1.5">
+          <span
+            className="text-xs font-semibold text-foreground"
+            title={message.created_by_actor_label ?? undefined}
+          >
+            {author?.displayName ?? "Unknown"}
+          </span>
+          {author?.isAgent ? (
+            <span
+              className="inline-flex shrink-0 items-center gap-0.5 rounded bg-muted px-1 py-px text-[9px] font-medium uppercase tracking-wide text-muted-foreground"
+              title="AI agent"
+            >
+              <Bot className="size-2.5" aria-hidden="true" />
+              AI
+            </span>
+          ) : null}
+          {author?.isAgent && author.onBehalfOf ? (
+            <span className="text-[10px] text-muted-foreground">· for {author.onBehalfOf}</span>
+          ) : null}
+          <span className="ml-auto shrink-0 text-[10px] text-muted-foreground">
+            {formatRelativeTime(message.created_at)}
+          </span>
+        </div>
+        <CommentBody body={message.body} />
+        {message.mutation_state === "rejected" ? (
+          <div className="text-[10px] font-medium text-destructive">Couldn't post</div>
+        ) : null}
+      </div>
+    </article>
+  );
+}
+
+function CommentAuthorAvatar({ author }: { author: CommentAuthor }) {
+  const face = (
+    <div
+      className="flex size-5 items-center justify-center rounded-full text-[9px] font-semibold text-white"
+      style={{ backgroundColor: author.color ?? "hsl(var(--muted-foreground))" }}
+    >
+      {author.isAgent ? <Bot className="size-3" /> : authorInitials(author.displayName)}
+    </div>
+  );
+
+  // When an agent acts for someone, badge the principal in the corner — the
+  // recognizable "on behalf of" cue — tinted with the principal's own color.
+  if (author.isAgent && author.onBehalfOf) {
+    return (
+      <div className="relative mt-0.5 size-5 shrink-0" aria-hidden="true">
+        {face}
+        <span
+          className="absolute -bottom-1 -right-1 flex size-3 items-center justify-center rounded-full text-[6px] font-bold text-white ring-2 ring-card"
+          style={{ backgroundColor: author.onBehalfOfColor ?? "hsl(var(--muted-foreground))" }}
+          title={`on behalf of ${author.onBehalfOf}`}
+        >
+          {authorInitials(author.onBehalfOf).slice(0, 1)}
+        </span>
+      </div>
+    );
+  }
+
+  return (
+    <div className="mt-0.5 shrink-0" aria-hidden="true">
+      {face}
+    </div>
+  );
+}
+
+/**
+ * Render a comment body through the shared markdown engine so inline code,
+ * emphasis, links, and lists match the rest of the app. The projector returns
+ * a structured plan (never raw HTML), so this is safe by construction; falls
+ * back to plain text when the projector is unavailable.
+ */
+/**
+ * The selected source a thread is anchored to, rendered as a single-line,
+ * syntax-highlighted snippet with a left bar tinted to the thread author's
+ * color. Uses the same static highlighter as markdown code blocks.
+ */
+function CommentSourceQuote({
+  quote,
+  language,
+  color,
+}: {
+  quote: string;
+  language?: string;
+  color?: string;
+}) {
+  const isDark = useDarkMode();
+  const colorTheme = useColorTheme() === "cream" ? "cream" : "classic";
+  const nodes = highlight(quote, language, isDark, colorTheme);
+  return (
+    <code
+      className="min-w-0 flex-1 truncate border-l-2 pl-2 font-mono text-xs"
+      style={{ borderColor: color ?? "hsl(var(--border))" }}
+      data-testid="comment-thread-source-quote"
+      title={quote}
+    >
+      {nodes}
+    </code>
+  );
+}
+
+function CommentBody({ body }: { body: string }) {
+  const plan = projectMarkdownPlan(body);
+  if (!plan) {
+    return (
+      <p className="whitespace-pre-wrap break-words text-sm leading-5 text-foreground">{body}</p>
+    );
+  }
+  return <ProjectedMarkdownView plan={plan} className="text-sm leading-5" />;
+}
+
+function CommentComposer({
+  ariaLabel,
+  buttonAriaLabel,
+  buttonLabel,
+  icon,
+  disabled,
+  autoFocusKey = null,
+  placeholder,
+  compact = false,
+  onSubmit,
+}: {
+  ariaLabel: string;
+  buttonAriaLabel?: string;
+  buttonLabel: string;
+  icon: "plus" | "send";
+  disabled: boolean;
+  autoFocusKey?: string | null;
+  placeholder: string;
+  /** Collapse to a single line until focused or non-empty (used for replies). */
+  compact?: boolean;
+  onSubmit?: (body: string) => void | Promise<void>;
+}) {
+  const [body, setBody] = useState("");
+  const [submitting, setSubmitting] = useState(false);
+  const [focused, setFocused] = useState(false);
+  const textareaRef = useRef<HTMLTextAreaElement>(null);
+  const Icon = icon === "plus" ? Plus : Send;
+  // Collapsed only while compact, blurred, empty, and idle.
+  const expanded = !compact || focused || submitting || body.length > 0;
+
+  useEffect(() => {
+    if (!autoFocusKey || disabled) return;
+    let cancelled = false;
+    const focus = () => {
+      if (!cancelled) textareaRef.current?.focus();
+    };
+    if (typeof window !== "undefined" && window.requestAnimationFrame) {
+      const frame = window.requestAnimationFrame(focus);
+      return () => {
+        cancelled = true;
+        window.cancelAnimationFrame(frame);
+      };
+    }
+    focus();
+    return () => {
+      cancelled = true;
+    };
+  }, [autoFocusKey, disabled]);
+
+  const handleSubmit = async (event: FormEvent) => {
+    event.preventDefault();
+    const trimmed = body.trim();
+    if (!trimmed || disabled || !onSubmit) return;
+    setBody("");
+    setSubmitting(true);
+    try {
+      await onSubmit(trimmed);
+    } catch {
+      setBody(trimmed);
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  return (
+    <form className="space-y-2" onSubmit={handleSubmit}>
+      <textarea
+        ref={textareaRef}
+        aria-label={ariaLabel}
+        value={body}
+        disabled={disabled || submitting}
+        placeholder={placeholder}
+        onChange={(event) => setBody(event.target.value)}
+        onFocus={() => setFocused(true)}
+        onBlur={() => setFocused(false)}
+        rows={expanded ? 3 : 1}
+        className={cn(
+          "w-full resize-y border bg-background px-3 text-sm leading-5",
+          expanded ? "min-h-20 rounded-md py-2" : "min-h-0 resize-none rounded-full py-1.5",
+          "placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/30",
+          (disabled || submitting) && "cursor-not-allowed opacity-60",
+        )}
+      />
+      {expanded ? (
+        <div className="flex justify-end">
+          <button
+            type="submit"
+            disabled={disabled || submitting || body.trim().length === 0}
+            aria-label={buttonAriaLabel}
+            className="inline-flex min-h-8 items-center gap-1.5 rounded-md border bg-background px-2.5 text-xs font-medium text-foreground transition-colors hover:bg-muted disabled:cursor-not-allowed disabled:opacity-50"
+          >
+            <Icon className="size-3.5" aria-hidden="true" />
+            {buttonLabel}
+          </button>
+        </div>
+      ) : null}
+    </form>
+  );
+}
+
+function CommentBadge({ state, compact = false }: { state: string; compact?: boolean }) {
+  return (
+    <span
+      className={cn(
+        "rounded border px-1.5 py-0.5 font-medium",
+        compact ? "text-[10px]" : "text-[11px]",
+        stateToneClassName(state),
+      )}
+    >
+      {formatStateLabel(state)}
+    </span>
+  );
+}
+
+function anchorLabel(thread: CommentThreadSnapshot): string {
+  switch (thread.anchor.kind) {
+    case "cell":
+      return "Cell";
+    case "cell_range":
+      return "Cell range";
+    case "source_range":
+      return "Source";
+    case "output":
+      return "Output";
+    case "notebook":
+    default:
+      return "Document";
+  }
+}
+
+function anchorLabelForDraft(anchor: CommentAnchor): string {
+  switch (anchor.kind) {
+    case "source_range":
+      return "source";
+    case "cell":
+      return "cell";
+    case "cell_range":
+      return "cell range";
+    case "output":
+      return "output";
+    case "notebook":
+    default:
+      return "document";
+  }
+}
+
+function sourceQuoteFromAnchor(anchor: CommentAnchor): string | null {
+  return anchor.kind === "source_range" ? (anchor.exact_quote ?? null) : null;
+}
+
+function commentThreadTargetCellId(thread: CommentThreadSnapshot): string | null {
+  switch (thread.anchor.kind) {
+    case "cell":
+    case "source_range":
+    case "output":
+      return thread.anchor.cell_id;
+    case "cell_range":
+      return thread.anchor.start_cell_id;
+    case "notebook":
+    default:
+      return thread.badge_cell_ids[0] ?? null;
+  }
+}
+
+function labelCommentThreads(
+  threads: readonly CommentThreadSnapshot[],
+): Array<{ thread: CommentThreadSnapshot; threadLabel: string }> {
+  const counts = new Map<string, number>();
+  return threads.map((thread) => {
+    const label = anchorLabel(thread);
+    const count = (counts.get(label) ?? 0) + 1;
+    counts.set(label, count);
+    return {
+      thread,
+      threadLabel: `${label} comment ${count}`,
+    };
+  });
+}
+
+function draftAutoFocusKey(target: NotebookCommentDraftTarget): string {
+  return `${draftAnchorKey(target.anchor)}:${target.quote ?? ""}`;
+}
+
+function draftAnchorKey(anchor: CommentAnchor): string {
+  switch (anchor.kind) {
+    case "cell":
+      return `cell:${anchor.cell_id}`;
+    case "source_range":
+      return `source:${anchor.cell_id}:${anchor.start_line}:${anchor.start_column}:${anchor.end_line}:${anchor.end_column}`;
+    case "output":
+      return `output:${anchor.cell_id}:${anchor.execution_id ?? ""}:${anchor.output_id ?? ""}`;
+    case "cell_range":
+      return `cell_range:${anchor.start_cell_id}:${anchor.end_cell_id}`;
+    case "notebook":
+    default:
+      return "notebook";
+  }
+}
+
+function authorInitials(displayName: string): string {
+  const words = displayName.trim().split(/\s+/).filter(Boolean);
+  if (words.length === 0) return "?";
+  if (words.length === 1) return words[0].slice(0, 2).toUpperCase();
+  return (words[0][0] + words[words.length - 1][0]).toUpperCase();
+}
+
+function formatRelativeTime(iso: string | null | undefined): string {
+  if (!iso) return "";
+  const then = new Date(iso).getTime();
+  if (Number.isNaN(then)) return "";
+  const seconds = Math.round((Date.now() - then) / 1000);
+  if (seconds < 45) return "now";
+  const minutes = Math.round(seconds / 60);
+  if (minutes < 60) return `${minutes}m`;
+  const hours = Math.round(minutes / 60);
+  if (hours < 24) return `${hours}h`;
+  const days = Math.round(hours / 24);
+  if (days < 7) return `${days}d`;
+  return new Date(iso).toLocaleDateString();
+}
+
+function formatQuotePreview(quote: string | null | undefined): string | null {
+  if (!quote) return null;
+  if (quote.trim().length === 0) return null;
+  if (quote.length <= 240) return quote;
+  return `${quote.slice(0, 237)}...`;
+}
+
+function formatStateLabel(state: string): string {
+  if (state.length === 0) return state;
+  return state.charAt(0).toUpperCase() + state.slice(1).replace(/_/g, " ");
+}
+
+function formatActorLabel(actorLabel: string): string {
+  if (actorLabel.startsWith("local:")) {
+    const localLabel = actorLabel.slice("local:".length);
+    const [principal, operator] = localLabel.split("/", 2);
+    if (operator?.startsWith("desktop:")) {
+      return principal ? `${principal} desktop` : "Local desktop";
+    }
+    if (operator?.startsWith("agent:")) {
+      const agentName = operator.split(":")[1];
+      return agentName ? `${principal} ${agentName}` : principal;
+    }
+    return principal || "Local";
+  }
+
+  if (actorLabel.startsWith("agent:nteract-mcp:")) {
+    return "nteract MCP";
+  }
+
+  return actorLabel;
+}
+
+function stateToneClassName(state: string): string {
+  switch (state) {
+    case "accepted":
+    case "open":
+      return "border-emerald-300 bg-emerald-50 text-emerald-800 dark:border-emerald-800 dark:bg-emerald-950/25 dark:text-emerald-300";
+    case "pending":
+      return "border-amber-300 bg-amber-50 text-amber-800 dark:border-amber-800 dark:bg-amber-950/25 dark:text-amber-300";
+    case "rejected":
+      return "border-rose-300 bg-rose-50 text-rose-800 dark:border-rose-800 dark:bg-rose-950/25 dark:text-rose-300";
+    case "resolved":
+      return "border-sky-300 bg-sky-50 text-sky-800 dark:border-sky-800 dark:bg-sky-950/25 dark:text-sky-300";
+    default:
+      return "border-border bg-muted text-muted-foreground";
+  }
+}

--- a/src/components/notebook/__tests__/NotebookCommentsPanel.test.tsx
+++ b/src/components/notebook/__tests__/NotebookCommentsPanel.test.tsx
@@ -1,0 +1,462 @@
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { describe, expect, it, vi } from "vite-plus/test";
+import { NotebookCommentsPanel } from "../NotebookCommentsPanel";
+import type { CommentsProjection } from "../comment-types";
+
+const projection: CommentsProjection = {
+  comments_doc_id: "comments:local-room:notebook-1",
+  threads: [
+    {
+      id: "thread-1",
+      anchor: { kind: "notebook" },
+      position: "80",
+      status: "open",
+      mutation_state: "accepted",
+      trusted: true,
+      messages: [
+        {
+          id: "message-1",
+          position: "80",
+          body: "Check the framing before publishing.",
+          mutation_state: "accepted",
+          trusted: true,
+          created_at: "2026-06-16T00:00:00.000Z",
+          created_by_actor_label: "alice",
+        },
+      ],
+      badge_cell_ids: [],
+      created_at: "2026-06-16T00:00:00.000Z",
+    },
+    {
+      id: "thread-cell",
+      anchor: { kind: "cell", cell_id: "cell-1" },
+      position: "80",
+      status: "open",
+      mutation_state: "accepted",
+      trusted: true,
+      messages: [
+        {
+          id: "message-cell",
+          position: "80",
+          body: "Cell-scoped comment",
+          mutation_state: "accepted",
+          trusted: true,
+          created_at: "2026-06-16T00:00:00.000Z",
+        },
+      ],
+      badge_cell_ids: ["cell-1"],
+      created_at: "2026-06-16T00:00:00.000Z",
+    },
+  ],
+};
+
+describe("NotebookCommentsPanel", () => {
+  it("renders the unavailable state with disabled composer", () => {
+    render(
+      <NotebookCommentsPanel
+        projection={null}
+        readOnly
+        statusMessage="Comments sync unavailable."
+        errorMessage="Comment request failed."
+      />,
+    );
+
+    expect(screen.getByRole("status")).toHaveTextContent("Comments sync unavailable.");
+    expect(screen.getByRole("alert")).toHaveTextContent("Comment request failed.");
+    expect(screen.queryByText("No comments yet.")).not.toBeInTheDocument();
+    expect(screen.getByLabelText("New document comment")).toBeDisabled();
+  });
+
+  it("submits a new document comment", async () => {
+    const onCreateThread = vi.fn();
+    render(
+      <NotebookCommentsPanel
+        projection={{ ...projection, threads: [] }}
+        onCreateThread={onCreateThread}
+      />,
+    );
+
+    fireEvent.change(screen.getByLabelText("New document comment"), {
+      target: { value: "Add this to the review notes" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: "Add comment" }));
+
+    await waitFor(() =>
+      expect(onCreateThread).toHaveBeenCalledWith("Add this to the review notes"),
+    );
+    expect(screen.getByLabelText("New document comment")).toHaveValue("");
+  });
+
+  it("submits a selected source draft comment", async () => {
+    const onCreateThread = vi.fn();
+    const onClearDraftTarget = vi.fn();
+    render(
+      <NotebookCommentsPanel
+        projection={{ ...projection, threads: [] }}
+        draftTarget={{
+          anchor: {
+            kind: "source_range",
+            cell_id: "cell-1",
+            start_line: 1,
+            start_column: 0,
+            end_line: 1,
+            end_column: 4,
+            exact_quote: "beta",
+          },
+          quote: "beta",
+        }}
+        onClearDraftTarget={onClearDraftTarget}
+        onCreateThread={onCreateThread}
+      />,
+    );
+
+    expect(screen.getByTestId("comment-draft-target")).toHaveTextContent("Source selection");
+    expect(screen.getByTestId("comment-draft-target")).toHaveTextContent("beta");
+    await waitFor(() => expect(screen.getByLabelText("New source comment")).toHaveFocus());
+
+    fireEvent.change(screen.getByLabelText("New source comment"), {
+      target: { value: "This line needs a note" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: "Add comment" }));
+
+    await waitFor(() => expect(onCreateThread).toHaveBeenCalledWith("This line needs a note"));
+
+    fireEvent.click(screen.getByRole("button", { name: "Use document target" }));
+    expect(onClearDraftTarget).toHaveBeenCalled();
+  });
+
+  it("preserves leading whitespace in selected source previews", () => {
+    render(
+      <NotebookCommentsPanel
+        projection={{ ...projection, threads: [] }}
+        draftTarget={{
+          anchor: {
+            kind: "source_range",
+            cell_id: "cell-1",
+            start_line: 1,
+            start_column: 0,
+            end_line: 1,
+            end_column: 8,
+            exact_quote: "    beta",
+          },
+          quote: "    beta",
+        }}
+        onCreateThread={vi.fn()}
+      />,
+    );
+
+    const quote = screen.getByTestId("comment-draft-target").querySelector("blockquote");
+    expect(quote?.textContent).toBe("    beta");
+  });
+
+  it("preserves draft text when changing a source draft back to document", async () => {
+    const onCreateThread = vi.fn();
+    const onClearDraftTarget = vi.fn();
+    const draftTarget = {
+      anchor: {
+        kind: "source_range" as const,
+        cell_id: "cell-1",
+        start_line: 1,
+        start_column: 0,
+        end_line: 1,
+        end_column: 4,
+        exact_quote: "beta",
+      },
+      quote: "beta",
+    };
+    const renderPanel = (target: typeof draftTarget | null) => (
+      <NotebookCommentsPanel
+        projection={{ ...projection, threads: [] }}
+        draftTarget={target}
+        onClearDraftTarget={onClearDraftTarget}
+        onCreateThread={onCreateThread}
+      />
+    );
+    const { rerender } = render(renderPanel(draftTarget));
+
+    fireEvent.change(screen.getByLabelText("New source comment"), {
+      target: { value: "Keep this body while retargeting" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: "Use document target" }));
+    expect(onClearDraftTarget).toHaveBeenCalled();
+
+    rerender(renderPanel(null));
+    expect(screen.getByLabelText("New document comment")).toHaveValue(
+      "Keep this body while retargeting",
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "Add comment" }));
+    await waitFor(() =>
+      expect(onCreateThread).toHaveBeenCalledWith("Keep this body while retargeting"),
+    );
+  });
+
+  it("clears submitted text while a comment request is in flight", async () => {
+    let resolveCreate: (() => void) | null = null;
+    const onCreateThread = vi.fn(
+      () =>
+        new Promise<void>((resolve) => {
+          resolveCreate = resolve;
+        }),
+    );
+    render(
+      <NotebookCommentsPanel
+        projection={{ ...projection, threads: [] }}
+        onCreateThread={onCreateThread}
+      />,
+    );
+
+    fireEvent.change(screen.getByLabelText("New document comment"), {
+      target: { value: "Do not leave duplicate text in the composer" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: "Add comment" }));
+
+    await waitFor(() =>
+      expect(onCreateThread).toHaveBeenCalledWith("Do not leave duplicate text in the composer"),
+    );
+    expect(screen.getByLabelText("New document comment")).toHaveValue("");
+    expect(screen.getByRole("button", { name: "Add comment" })).toBeDisabled();
+
+    resolveCreate?.();
+    await waitFor(() => expect(screen.getByLabelText("New document comment")).toBeEnabled());
+  });
+
+  it("restores submitted text when a comment request fails", async () => {
+    const onCreateThread = vi.fn(() => Promise.reject(new Error("sync failed")));
+    render(
+      <NotebookCommentsPanel
+        projection={{ ...projection, threads: [] }}
+        onCreateThread={onCreateThread}
+      />,
+    );
+
+    fireEvent.change(screen.getByLabelText("New document comment"), {
+      target: { value: "Keep this draft if submit fails" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: "Add comment" }));
+
+    await waitFor(() =>
+      expect(onCreateThread).toHaveBeenCalledWith("Keep this draft if submit fails"),
+    );
+    await waitFor(() =>
+      expect(screen.getByLabelText("New document comment")).toHaveValue(
+        "Keep this draft if submit fails",
+      ),
+    );
+  });
+
+  it("renders threads and submits replies", async () => {
+    const onReplyThread = vi.fn();
+    const onResolveThread = vi.fn();
+    render(
+      <NotebookCommentsPanel
+        projection={projection}
+        onReplyThread={onReplyThread}
+        onResolveThread={onResolveThread}
+      />,
+    );
+
+    expect(screen.getByText("Check the framing before publishing.")).toBeVisible();
+    expect(screen.getByText("alice")).toBeVisible();
+    expect(screen.getByText("Cell-scoped comment")).toBeVisible();
+
+    fireEvent.change(screen.getByLabelText("Reply to Document comment 1"), {
+      target: { value: "Looks ready locally" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: "Submit reply to Document comment 1" }));
+
+    await waitFor(() =>
+      expect(onReplyThread).toHaveBeenCalledWith("thread-1", "Looks ready locally"),
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "Resolve Document comment 1" }));
+    expect(onResolveThread).toHaveBeenCalledWith("thread-1");
+  });
+
+  it("renders source excerpts on source range threads", () => {
+    const onFocusThreadAnchor = vi.fn();
+    const sourceThread = {
+      ...projection.threads[0],
+      id: "thread-source",
+      anchor: {
+        kind: "source_range" as const,
+        cell_id: "cell-1",
+        start_line: 2,
+        start_column: 0,
+        end_line: 2,
+        end_column: 14,
+        exact_quote: "important_call()",
+      },
+    };
+    render(
+      <NotebookCommentsPanel
+        projection={{
+          ...projection,
+          threads: [sourceThread],
+        }}
+        onFocusThreadAnchor={onFocusThreadAnchor}
+      />,
+    );
+
+    expect(screen.getByTestId("comment-thread-source-quote")).toHaveTextContent("important_call()");
+    fireEvent.click(screen.getByRole("button", { name: "Show cell for Source comment 1" }));
+    expect(onFocusThreadAnchor).toHaveBeenCalledWith(sourceThread);
+  });
+
+  it("does not allow status actions while a reply is pending", () => {
+    const onResolveThread = vi.fn();
+    render(
+      <NotebookCommentsPanel
+        projection={{
+          ...projection,
+          threads: [
+            {
+              ...projection.threads[0],
+              messages: [
+                ...projection.threads[0].messages,
+                {
+                  id: "message-pending",
+                  position: "81",
+                  body: "Still syncing",
+                  mutation_state: "pending",
+                  trusted: false,
+                  created_at: "2026-06-16T00:01:00.000Z",
+                },
+              ],
+            },
+          ],
+        }}
+        onResolveThread={onResolveThread}
+      />,
+    );
+
+    const resolve = screen.getByRole("button", { name: "Resolve Document comment 1" });
+    expect(resolve).toBeDisabled();
+    fireEvent.click(resolve);
+    expect(onResolveThread).not.toHaveBeenCalled();
+  });
+
+  it("formats local actor labels without exposing the raw durable id", () => {
+    render(
+      <NotebookCommentsPanel
+        projection={{
+          ...projection,
+          threads: [
+            {
+              ...projection.threads[0],
+              messages: [
+                {
+                  ...projection.threads[0].messages[0],
+                  created_by_actor_label: "local:ubuntu/desktop:d47eea7d",
+                },
+              ],
+            },
+          ],
+        }}
+      />,
+    );
+
+    expect(screen.getByText("ubuntu desktop")).toBeVisible();
+    expect(screen.queryByText("local:ubuntu/desktop:d47eea7d")).not.toBeInTheDocument();
+  });
+
+  it("renders resolved author attribution with the on-behalf-of principal", () => {
+    const resolveCommentAuthor = vi.fn((actorLabel: string) => ({
+      displayName: actorLabel.includes("agent") ? "Claude Code" : actorLabel,
+      isAgent: true,
+      onBehalfOf: "kylekelley",
+      color: "#3b82f6",
+    }));
+    render(
+      <NotebookCommentsPanel
+        projection={{
+          ...projection,
+          threads: [
+            {
+              ...projection.threads[0],
+              messages: [
+                {
+                  ...projection.threads[0].messages[0],
+                  created_by_actor_label: "local:kylekelley/agent:nteract-mcp:6483cc03",
+                },
+              ],
+            },
+          ],
+        }}
+        resolveCommentAuthor={resolveCommentAuthor}
+      />,
+    );
+
+    expect(screen.getByText("Claude Code")).toBeVisible();
+    expect(screen.getByText("AI")).toBeVisible();
+    expect(screen.getByText("· for kylekelley")).toBeVisible();
+  });
+
+  it("falls back to the parsed actor label when no author resolver is given", () => {
+    render(
+      <NotebookCommentsPanel
+        projection={{
+          ...projection,
+          threads: [
+            {
+              ...projection.threads[0],
+              messages: [
+                {
+                  ...projection.threads[0].messages[0],
+                  created_by_actor_label: "local:kylekelley/agent:nteract-mcp:6483cc03",
+                },
+              ],
+            },
+          ],
+        }}
+      />,
+    );
+
+    expect(screen.getByText("kylekelley nteract-mcp")).toBeVisible();
+  });
+
+  it("reveals resolved threads behind a toggle and reopens them", () => {
+    const onReopenThread = vi.fn();
+    render(
+      <NotebookCommentsPanel
+        projection={{
+          ...projection,
+          threads: [{ ...projection.threads[0], status: "resolved" }],
+        }}
+        onReopenThread={onReopenThread}
+      />,
+    );
+
+    // Resolved threads are hidden until revealed.
+    expect(screen.queryByRole("button", { name: "Reopen Document comment 1" })).toBeNull();
+    fireEvent.click(screen.getByRole("button", { name: "Show resolved (1)" }));
+    fireEvent.click(screen.getByRole("button", { name: "Reopen Document comment 1" }));
+    expect(onReopenThread).toHaveBeenCalledWith("thread-1");
+  });
+
+  it("does not allow status actions for pending threads", () => {
+    const onResolveThread = vi.fn();
+    render(
+      <NotebookCommentsPanel
+        projection={{
+          ...projection,
+          threads: [{ ...projection.threads[0], mutation_state: "pending" }],
+        }}
+        onResolveThread={onResolveThread}
+      />,
+    );
+
+    const resolve = screen.getByRole("button", { name: "Resolve Document comment 1" });
+    expect(resolve).toBeDisabled();
+    fireEvent.click(resolve);
+    expect(onResolveThread).not.toHaveBeenCalled();
+  });
+
+  it("flashes the focused thread", () => {
+    const { container } = render(
+      <NotebookCommentsPanel projection={projection} focusedThreadId="thread-1" focusNonce={1} />,
+    );
+    // The focused thread's card gets the flash ring.
+    expect(container.querySelector("li.ring-2")).not.toBeNull();
+  });
+});

--- a/src/components/notebook/__tests__/NotebookCommentsPanel.test.tsx
+++ b/src/components/notebook/__tests__/NotebookCommentsPanel.test.tsx
@@ -1,5 +1,5 @@
 import { fireEvent, render, screen, waitFor } from "@testing-library/react";
-import { describe, expect, it, vi } from "vite-plus/test";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vite-plus/test";
 import { NotebookCommentsPanel } from "../NotebookCommentsPanel";
 import type { CommentsProjection } from "../comment-types";
 
@@ -51,6 +51,29 @@ const projection: CommentsProjection = {
 };
 
 describe("NotebookCommentsPanel", () => {
+  // jsdom has no matchMedia; the dark-mode/color-theme hooks read it when a
+  // source-range quote highlights. Stub it for the lifetime of the suite.
+  const originalMatchMedia = Object.getOwnPropertyDescriptor(window, "matchMedia");
+
+  beforeEach(() => {
+    Object.defineProperty(window, "matchMedia", {
+      configurable: true,
+      value: vi.fn(() => ({
+        matches: false,
+        addEventListener: vi.fn(),
+        removeEventListener: vi.fn(),
+      })),
+    });
+  });
+
+  afterEach(() => {
+    if (originalMatchMedia) {
+      Object.defineProperty(window, "matchMedia", originalMatchMedia);
+    } else {
+      delete (window as Partial<Window>).matchMedia;
+    }
+  });
+
   it("renders the unavailable state with disabled composer", () => {
     render(
       <NotebookCommentsPanel

--- a/src/components/notebook/comment-types.ts
+++ b/src/components/notebook/comment-types.ts
@@ -1,0 +1,74 @@
+/**
+ * View-model types for the comments UI.
+ *
+ * These mirror the shapes the daemon's comments projection produces, but are
+ * declared here so the comment UI components stand alone as design-system
+ * elements, renderable from fixtures without depending on the runtime/daemon
+ * package. The app maps the wire projection onto these at the edge.
+ */
+
+export type CommentAnchor =
+  | { kind: "notebook" }
+  | { kind: "cell"; cell_id: string; observed_cell_position?: string | null }
+  | {
+      kind: "cell_range";
+      start_cell_id: string;
+      end_cell_id: string;
+      start_position?: string | null;
+      end_position?: string | null;
+    }
+  | {
+      kind: "source_range";
+      cell_id: string;
+      start_line: number;
+      start_column: number;
+      end_line: number;
+      end_column: number;
+      prefix_quote?: string | null;
+      exact_quote?: string | null;
+      suffix_quote?: string | null;
+    }
+  | {
+      kind: "output";
+      cell_id: string;
+      execution_id?: string | null;
+      output_id?: string | null;
+    };
+
+export type CommentMutationState = "pending" | "accepted" | "rejected" | "unverified";
+export type CommentThreadStatus = "open" | "resolved" | "unverified";
+
+export interface CommentMessageSnapshot {
+  id: string;
+  position: string;
+  body: string;
+  mutation_state: CommentMutationState;
+  trusted: boolean;
+  created_at: string;
+  created_by_actor_label?: string | null;
+  created_by_authority?: string | null;
+  rejection_reason?: string | null;
+}
+
+export interface CommentThreadSnapshot {
+  id: string;
+  anchor: CommentAnchor;
+  position: string;
+  status: CommentThreadStatus;
+  mutation_state: CommentMutationState;
+  trusted: boolean;
+  messages: CommentMessageSnapshot[];
+  badge_cell_ids: string[];
+  created_at: string;
+  created_by_actor_label?: string | null;
+  created_by_authority?: string | null;
+  rejection_reason?: string | null;
+  resolved_at?: string | null;
+  resolved_by_actor_label?: string | null;
+  resolved_by_authority?: string | null;
+}
+
+export interface CommentsProjection {
+  comments_doc_id: string;
+  threads: CommentThreadSnapshot[];
+}

--- a/src/components/notebook/index.ts
+++ b/src/components/notebook/index.ts
@@ -365,3 +365,17 @@ export {
   type NotebookViewLanguageResolver,
   type NotebookTracebackCellTarget,
 } from "./view-model";
+export {
+  type CommentAuthor,
+  NotebookCommentsPanel,
+  type NotebookCommentDraftTarget,
+  type NotebookCommentsPanelProps,
+} from "./NotebookCommentsPanel";
+export type {
+  CommentAnchor,
+  CommentMessageSnapshot,
+  CommentMutationState,
+  CommentsProjection,
+  CommentThreadSnapshot,
+  CommentThreadStatus,
+} from "./comment-types";


### PR DESCRIPTION
Carve the notebook comment UI out as a standalone design-system element and document it in the Elements app. The whole surface renders from fixtures, so it stands on its own with no daemon or kernel, and can be inspected in the browser at `/docs/comment-surfaces`.

## Design decision

The panel was coupled to the `runtimed` projection types. This adds `comment-types.ts` as a self-contained view model (anchors, thread/message snapshots, projection) so `NotebookCommentsPanel` depends only on local types. The app maps the wire projection onto these at the edge; the design-system view declares the same contract with a small fixture map.

Attribution is the point of the surface, so it's resolved by the host rather than baked in:

- `resolveCommentAuthor(actorLabel)` returns name, identity color, and whether the author is an AI agent acting on someone's behalf.
- `resolveSourceLanguage(cellId)` picks the highlight language per cell, so markdown and raw quotes stay plain prose.

Each message shows an identity-colored avatar matching that author's cursor and edits. An agent additionally carries an `AI` chip, a `· for <person>` note, and a principal badge on its avatar. In the app, the daemon finalizes a comment against the authenticated connection before it's trusted, so "Claude Code · for Ada" is provable, not asserted.

## Behavioral coverage

The showcase is interactive (reply, resolve, reopen, add a document comment) and exercises:

| Anchor state | Rendering |
|---|---|
| Source range | Syntax-highlighted quote, tinted with the author's color |
| Document | Notebook-level thread, no quote |
| Resolved | Tucked behind a Show resolved toggle |

Quote highlighting is theme-dependent, so the example gates on mount to keep the server render and the first client paint identical (no hydration mismatch).

## Test plan

- [x] `NotebookCommentsPanel` unit tests pass (16)
- [x] `cargo xtask lint --fix` clean
- [x] Rendered at `/docs/comment-surfaces` in light and dark, hydration warning gone
