### PR TITLE
feat(outputs): render Bokeh notebook MIME bundles

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -77,6 +77,7 @@ python/nteract/src/nteract/_widget.html
 /apps/notebook/src/renderer-plugins/isolated-renderer.css
 /apps/notebook/src/renderer-plugins/markdown.js
 /apps/notebook/src/renderer-plugins/markdown.css
+/apps/notebook/src/renderer-plugins/bokeh.js
 /apps/notebook/src/renderer-plugins/sift.js
 /apps/notebook/src/renderer-plugins/sift.css
 # wasm-pack outputs, rebuilt by `cargo xtask wasm`. xtask build/dev commands

--- a/apps/mcp-app/src/vite-env.d.ts
+++ b/apps/mcp-app/src/vite-env.d.ts
@@ -20,6 +20,11 @@ declare module "virtual:renderer-plugin/plotly" {
   export const css: string;
 }
 
+declare module "virtual:renderer-plugin/bokeh" {
+  export const code: string;
+  export const css: string;
+}
+
 declare module "virtual:renderer-plugin/leaflet" {
   export const code: string;
   export const css: string;

--- a/apps/mcp-app/vite.config.ts
+++ b/apps/mcp-app/vite.config.ts
@@ -13,6 +13,7 @@ const siftWasmPath = path.join(repoRoot, "crates/sift-wasm/pkg/sift_wasm_bg.wasm
 const daemonPluginAssets = [
   "markdown.js",
   "markdown.css",
+  "bokeh.js",
   "plotly.js",
   "vega.js",
   "leaflet.js",

--- a/apps/notebook-cloud/viewer/vite-env.d.ts
+++ b/apps/notebook-cloud/viewer/vite-env.d.ts
@@ -23,6 +23,11 @@ declare module "virtual:renderer-plugin/plotly" {
   export const css: string;
 }
 
+declare module "virtual:renderer-plugin/bokeh" {
+  export const code: string;
+  export const css: string;
+}
+
 declare module "virtual:renderer-plugin/leaflet" {
   export const code: string;
   export const css: string;

--- a/apps/notebook/src/vite-env.d.ts
+++ b/apps/notebook/src/vite-env.d.ts
@@ -20,6 +20,11 @@ declare module "virtual:renderer-plugin/plotly" {
   export const css: string;
 }
 
+declare module "virtual:renderer-plugin/bokeh" {
+  export const code: string;
+  export const css: string;
+}
+
 declare module "virtual:renderer-plugin/leaflet" {
   export const code: string;
   export const css: string;

--- a/apps/notebook/vite-plugin-isolated-renderer.ts
+++ b/apps/notebook/vite-plugin-isolated-renderer.ts
@@ -37,7 +37,7 @@ const RESOLVED_PLUGIN_PREFIX = "\0virtual:renderer-plugin/";
 const PREBUILT_DIR = path.resolve(__dirname, "../notebook/src/renderer-plugins");
 
 /** Plugin names that have pre-built artifacts. */
-const PLUGIN_NAMES = ["markdown", "plotly", "vega", "leaflet", "sift"];
+const PLUGIN_NAMES = ["markdown", "plotly", "bokeh", "vega", "leaflet", "sift"];
 const PLUGIN_CSS_NAMES = new Set(["markdown", "leaflet", "sift"]);
 
 interface IsolatedRendererPluginOptions {
@@ -55,7 +55,7 @@ interface IsolatedRendererPluginOptions {
    * Plugin artifacts to require during production build startup.
    * Consumers that provide their own plugin loader can set this to `[]` and
    * still use the core isolated renderer bundle.
-   * @default ["markdown", "plotly", "vega", "leaflet", "sift"]
+   * @default ["markdown", "plotly", "bokeh", "vega", "leaflet", "sift"]
    */
   prebuiltPluginNames?: readonly string[];
 }

--- a/apps/renderer-test/src/vite-env.d.ts
+++ b/apps/renderer-test/src/vite-env.d.ts
@@ -20,6 +20,11 @@ declare module "virtual:renderer-plugin/plotly" {
   export const css: string;
 }
 
+declare module "virtual:renderer-plugin/bokeh" {
+  export const code: string;
+  export const css: string;
+}
+
 declare module "virtual:renderer-plugin/leaflet" {
   export const code: string;
   export const css: string;

--- a/crates/runtimed-wasm/src/lib.rs
+++ b/crates/runtimed-wasm/src/lib.rs
@@ -34,6 +34,10 @@ use wasm_bindgen::prelude::*;
 
 const MARKDOWN_PROJECTION_MIME: &str = "application/vnd.nteract.markdown+json";
 const MARKDOWN_SOURCE_MIME: &str = "text/markdown";
+const BOKEHJS_EXEC_MIME: &str = "application/vnd.bokehjs_exec.v0+json";
+const BOKEHJS_LOAD_MIME: &str = "application/vnd.bokehjs_load.v0+json";
+const BOKEHJS_SCRIPT_MIME: &str = "application/javascript";
+const BOKEHJS_HTML_MIME: &str = "text/html";
 const RUNT_OUTPUT_CACHE_KEY: &str = "_runt_output_cache_key";
 
 /// Install the panic hook on module init so Rust panics inside WASM
@@ -2621,6 +2625,8 @@ impl NotebookHandle {
 
     /// Narrow an output manifest's data bundle to the winning MIME type,
     /// plus all binary MIME refs and text/plain as a fallback candidate.
+    /// Multi-MIME renderer plugins may keep a small set of sibling refs that
+    /// are required to render the selected MIME.
     ///
     /// Resolves ContentRefs into `ResolvedContentRef` variants:
     /// - Binary MIME types → `Url` (blob server URL, zero fetch cost)
@@ -2651,11 +2657,24 @@ impl NotebookHandle {
 
             if let Some(winner_mime) = winner {
                 let mut narrowed = serde_json::Map::new();
+                let bokeh_bundle = data.contains_key(BOKEHJS_EXEC_MIME)
+                    || data.contains_key(BOKEHJS_LOAD_MIME)
+                    || winner_mime == BOKEHJS_EXEC_MIME
+                    || winner_mime == BOKEHJS_LOAD_MIME;
+
                 for (mime, val) in data {
                     if mime == winner_mime
                         || mime == "text/plain"
                         || is_binary_mime(mime)
                         || (winner_mime == MARKDOWN_PROJECTION_MIME && mime == MARKDOWN_SOURCE_MIME)
+                        || (bokeh_bundle
+                            && matches!(
+                                mime.as_str(),
+                                BOKEHJS_EXEC_MIME
+                                    | BOKEHJS_LOAD_MIME
+                                    | BOKEHJS_SCRIPT_MIME
+                                    | BOKEHJS_HTML_MIME
+                            ))
                     {
                         let resolved = self.resolve_content_ref(mime, val);
                         narrowed.insert(mime.clone(), resolved);
@@ -5285,6 +5304,37 @@ mod tests {
             !data.contains_key("text/html"),
             "non-winning rich text fallbacks should still be dropped"
         );
+    }
+
+    #[test]
+    fn bokeh_narrowing_keeps_marker_javascript_and_html_bundle() {
+        let mut handle = NotebookHandle::create_empty().expect("create handle");
+        handle.mime_priority = vec![
+            BOKEHJS_EXEC_MIME.to_string(),
+            BOKEHJS_LOAD_MIME.to_string(),
+            "text/html".to_string(),
+            BOKEHJS_SCRIPT_MIME.to_string(),
+            "text/plain".to_string(),
+        ];
+
+        let narrowed = handle.narrow_output_data(json!({
+            "output_type": "display_data",
+            "data": {
+                BOKEHJS_EXEC_MIME: { "inline": "" },
+                BOKEHJS_SCRIPT_MIME: { "inline": "Bokeh.embed.embed_items_notebook([]);" },
+                BOKEHJS_HTML_MIME: { "inline": "<div id=\"p1011\"></div>" },
+                "text/plain": { "inline": "fallback" },
+            },
+            "metadata": {
+                BOKEHJS_EXEC_MIME: { "id": "p1011" },
+            },
+        }));
+        let data = narrowed["data"].as_object().expect("narrowed data object");
+
+        assert!(data.contains_key(BOKEHJS_EXEC_MIME));
+        assert!(data.contains_key(BOKEHJS_SCRIPT_MIME));
+        assert!(data.contains_key(BOKEHJS_HTML_MIME));
+        assert!(data.contains_key("text/plain"));
     }
 
     #[test]

--- a/crates/runtimed/src/output_store.rs
+++ b/crates/runtimed/src/output_store.rs
@@ -2473,6 +2473,33 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn bokeh_display_data_preserves_exec_marker_mime() {
+        let dir = TempDir::new().unwrap();
+        let store = test_store(&dir);
+
+        let output = serde_json::json!({
+            "output_type": "display_data",
+            "data": {
+                "text/html": "<div id=\"p1011\"></div>",
+                "application/javascript": "Bokeh.embed.embed_items_notebook([]);",
+                "application/vnd.bokehjs_exec.v0+json": ""
+            },
+            "metadata": {
+                "application/vnd.bokehjs_exec.v0+json": { "id": "p1011" }
+            }
+        });
+
+        let manifest = create_manifest(&output, &store, DEFAULT_INLINE_THRESHOLD)
+            .await
+            .unwrap();
+        let OutputManifest::DisplayData { data, .. } = manifest else {
+            panic!("expected DisplayData");
+        };
+
+        assert!(data.contains_key("application/vnd.bokehjs_exec.v0+json"));
+    }
+
+    #[tokio::test]
     async fn markdown_display_data_adds_projected_plan_sibling() {
         let dir = TempDir::new().unwrap();
         let store = test_store(&dir);

--- a/crates/xtask/src/main.rs
+++ b/crates/xtask/src/main.rs
@@ -3337,6 +3337,7 @@ fn ensure_renderer_artifacts_current(sift_wasm_rebuilt: bool) {
         "isolated-renderer.css",
         "markdown.js",
         "markdown.css",
+        "bokeh.js",
     ];
     let missing_lfs_tracked: Vec<&str> = lfs_tracked_probes
         .iter()
@@ -3428,6 +3429,9 @@ fn ensure_renderer_artifacts_current(sift_wasm_rebuilt: bool) {
             {
                 targets.push("markdown");
             }
+            if generated_needs_rebuild.contains(&"bokeh.js") {
+                targets.push("bokeh");
+            }
             if sift_missing || sift_source_changed || sift_wasm_rebuilt {
                 targets.push("sift");
             }
@@ -3510,6 +3514,7 @@ const GENERATED_RENDERER_PLUGIN_OUTPUTS: &[&str] = &[
     "apps/notebook/src/renderer-plugins/isolated-renderer.css",
     "apps/notebook/src/renderer-plugins/markdown.js",
     "apps/notebook/src/renderer-plugins/markdown.css",
+    "apps/notebook/src/renderer-plugins/bokeh.js",
     "apps/notebook/src/renderer-plugins/sift.js",
     "apps/notebook/src/renderer-plugins/sift.css",
 ];
@@ -3519,6 +3524,7 @@ const RENDERER_PLUGIN_OUTPUTS: &[&str] = &[
     "apps/notebook/src/renderer-plugins/isolated-renderer.css",
     "apps/notebook/src/renderer-plugins/markdown.js",
     "apps/notebook/src/renderer-plugins/markdown.css",
+    "apps/notebook/src/renderer-plugins/bokeh.js",
     "apps/notebook/src/renderer-plugins/plotly.js",
     "apps/notebook/src/renderer-plugins/vega.js",
     "apps/notebook/src/renderer-plugins/leaflet.js",
@@ -4112,6 +4118,7 @@ fn mcp_widget_needs_rebuild() -> Option<&'static str> {
         Path::new("src/build/renderer-plugin-builder.ts"),
         Path::new("apps/notebook/src/renderer-plugins/markdown.js"),
         Path::new("apps/notebook/src/renderer-plugins/markdown.css"),
+        Path::new("apps/notebook/src/renderer-plugins/bokeh.js"),
         Path::new("apps/notebook/src/renderer-plugins/plotly.js"),
         Path::new("apps/notebook/src/renderer-plugins/vega.js"),
         Path::new("apps/notebook/src/renderer-plugins/leaflet.js"),

--- a/docs/adr/generated-runtime-artifacts.md
+++ b/docs/adr/generated-runtime-artifacts.md
@@ -73,6 +73,7 @@ Volatile artifacts stay gitignored and are regenerated:
 - `apps/notebook/src/renderer-plugins/isolated-renderer.css`
 - `apps/notebook/src/renderer-plugins/markdown.js`
 - `apps/notebook/src/renderer-plugins/markdown.css`
+- `apps/notebook/src/renderer-plugins/bokeh.js`
 - `apps/notebook/src/renderer-plugins/sift.js`
 - `apps/notebook/src/renderer-plugins/sift.css`
 - `apps/notebook/src/wasm/runtimed-wasm/`

--- a/packages/runtimed/src/mime-priority.ts
+++ b/packages/runtimed/src/mime-priority.ts
@@ -9,6 +9,10 @@ export const DEFAULT_MIME_PRIORITY = [
   // Rich formats first
   "application/vnd.jupyter.widget-view+json",
   "application/vnd.plotly.v1+json",
+  // Bokeh emits marker MIMEs alongside application/javascript and text/html.
+  // These must win so the frontend can keep the bundle together.
+  "application/vnd.bokehjs_exec.v0+json",
+  "application/vnd.bokehjs_load.v0+json",
   "application/vnd.vegalite.v6+json",
   "application/vnd.vegalite.v6.json",
   "application/vnd.vegalite.v5+json",

--- a/scripts/build-renderer-plugins.ts
+++ b/scripts/build-renderer-plugins.ts
@@ -3,8 +3,8 @@
  *
  * Output: `apps/notebook/src/renderer-plugins/` - core IIFE + CJS plugins.
  * Stable third-party bundles (plotly, vega, leaflet) are LFS-tracked.
- * Owned/generated bundles (isolated-renderer, markdown, sift) stay gitignored
- * because they are local build outputs. Sift also re-embeds sift-wasm's
+ * Owned/generated bundles (isolated-renderer, markdown, bokeh, sift) stay
+ * gitignored because they are local build outputs. Sift also re-embeds sift-wasm's
  * wasm-bindgen glue and must be rebuilt in lockstep.
  *
  * The notebook Vite app loads these CJS bundles directly. runtimed
@@ -47,6 +47,7 @@ Targets:
   core               Alias for isolated-renderer
   markdown           Markdown renderer plugin
   plotly             Plotly renderer plugin
+  bokeh              Bokeh renderer plugin
   vega               Vega renderer plugin
   leaflet            Leaflet renderer plugin
   sift               Sift renderer plugin

--- a/scripts/cloud-bootstrap.sh
+++ b/scripts/cloud-bootstrap.sh
@@ -60,6 +60,7 @@ ARTIFACT_PROBES=(
   apps/notebook/src/renderer-plugins/isolated-renderer.css
   apps/notebook/src/renderer-plugins/markdown.js
   apps/notebook/src/renderer-plugins/markdown.css
+  apps/notebook/src/renderer-plugins/bokeh.js
   apps/notebook/src/renderer-plugins/sift.js
 )
 NEEDS_BUILD=0

--- a/src/build/renderer-plugin-builder.ts
+++ b/src/build/renderer-plugin-builder.ts
@@ -1,8 +1,9 @@
 /**
  * Shared renderer plugin builder
  *
- * Centralizes the build logic for renderer plugins (markdown, plotly, vega, leaflet)
- * used by both the notebook Vite plugin and MCP app build scripts.
+ * Centralizes the build logic for renderer plugins (markdown, plotly, bokeh,
+ * vega, leaflet) used by both the notebook Vite plugin and MCP app build
+ * scripts.
  *
  * Plugins are built as CJS with React externalized (React is provided by the
  * isolated renderer's IIFE). Always minified — these contain entire libraries
@@ -58,6 +59,7 @@ export const RENDERER_ROLLDOWN_CHECKS = {
 export const RENDERER_PLUGINS: RendererPluginDef[] = [
   { name: "markdown", entry: path.resolve(srcDir, "isolated-renderer/markdown-renderer.tsx") },
   { name: "plotly", entry: path.resolve(srcDir, "isolated-renderer/plotly-renderer.tsx") },
+  { name: "bokeh", entry: path.resolve(srcDir, "isolated-renderer/bokeh-renderer.tsx") },
   { name: "vega", entry: path.resolve(srcDir, "isolated-renderer/vega-renderer.tsx") },
   { name: "leaflet", entry: path.resolve(srcDir, "isolated-renderer/leaflet-renderer.tsx") },
   { name: "sift", entry: path.resolve(srcDir, "isolated-renderer/sift-renderer.tsx") },

--- a/src/components/cell/__tests__/OutputArea.test.tsx
+++ b/src/components/cell/__tests__/OutputArea.test.tsx
@@ -1,6 +1,7 @@
 import { act, createEvent, fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vite-plus/test";
 import { injectPluginsForMimes, needsPlugin } from "@/components/isolated/iframe-libraries";
+import { BOKEHJS_EXEC_MIME_TYPE, BOKEHJS_LOAD_MIME_TYPE } from "@/components/outputs/bokeh-mime";
 import { setMarkdownProjectionProjector } from "@/lib/markdown-projection";
 import { OutputArea, type JupyterOutput } from "../OutputArea";
 
@@ -273,6 +274,28 @@ function makeBokehDocumentOutputs(): JupyterOutput[] {
       },
       metadata: {
         "application/vnd.bokehjs_exec.v0+json": { id: "p1011" },
+      },
+    },
+  ];
+}
+
+function makeBokehShowOnlyOutputs(): JupyterOutput[] {
+  return [
+    {
+      output_id: "bokeh-show-root-html",
+      output_type: "display_data",
+      data: { "text/html": '<div id="bokeh-root"></div>' },
+      metadata: {},
+    },
+    {
+      output_id: "bokeh-show-exec-js",
+      output_type: "display_data",
+      data: {
+        "application/javascript": 'document.getElementById("bokeh-root").textContent = "plot";',
+        [BOKEHJS_EXEC_MIME_TYPE]: "",
+      },
+      metadata: {
+        [BOKEHJS_EXEC_MIME_TYPE]: { id: "p1011" },
       },
     },
   ];
@@ -980,7 +1003,12 @@ describe("OutputArea iframe theme sync", () => {
           outputIndex: 0,
         }),
         expect.objectContaining({
-          mimeType: "application/javascript",
+          data: expect.objectContaining({
+            "application/javascript":
+              'document.getElementById("bokeh-loading").textContent = "BokehJS loaded";',
+            [BOKEHJS_LOAD_MIME_TYPE]: "",
+          }),
+          mimeType: BOKEHJS_LOAD_MIME_TYPE,
           outputId: "bokeh-load-js",
           outputIndex: 1,
         }),
@@ -990,9 +1018,42 @@ describe("OutputArea iframe theme sync", () => {
           outputIndex: 2,
         }),
         expect.objectContaining({
-          mimeType: "application/javascript",
+          data: expect.objectContaining({
+            "application/javascript": 'document.getElementById("bokeh-root").textContent = "plot";',
+            [BOKEHJS_EXEC_MIME_TYPE]: "",
+          }),
+          metadata: { id: "p1011" },
+          mimeType: BOKEHJS_EXEC_MIME_TYPE,
           outputId: "bokeh-exec-js",
           outputIndex: 3,
+        }),
+      ]);
+    });
+  });
+
+  it("keeps show(p) root HTML with the Bokeh exec renderer payload", async () => {
+    render(<OutputArea outputs={makeBokehShowOnlyOutputs()} />);
+
+    const frames = screen.getAllByTestId("isolated-frame");
+    expect(frames).toHaveLength(1);
+    expect(frames[0].getAttribute("data-scroll-passthrough")).toBe("true");
+
+    await waitFor(() => {
+      expect(mockFrameHandle.renderBatch).toHaveBeenCalledWith([
+        expect.objectContaining({
+          mimeType: "text/html",
+          outputId: "bokeh-show-root-html",
+          outputIndex: 0,
+        }),
+        expect.objectContaining({
+          data: expect.objectContaining({
+            "application/javascript": 'document.getElementById("bokeh-root").textContent = "plot";',
+            [BOKEHJS_EXEC_MIME_TYPE]: "",
+          }),
+          metadata: { id: "p1011" },
+          mimeType: BOKEHJS_EXEC_MIME_TYPE,
+          outputId: "bokeh-show-exec-js",
+          outputIndex: 1,
         }),
       ]);
     });

--- a/src/components/isolated/AGENTS.md
+++ b/src/components/isolated/AGENTS.md
@@ -122,6 +122,7 @@ Heavy renderers (markdown, plotly, vega, leaflet, sift) are **not** in the core 
 | Markdown | `text/markdown` | `virtual:renderer-plugin/markdown` | ~2.2 MB |
 | Vega | `application/vnd.vega*.v*` | `virtual:renderer-plugin/vega` | ~865 KB |
 | Plotly | `application/vnd.plotly.v1+json` | `virtual:renderer-plugin/plotly` | ~4.8 MB |
+| Bokeh | `application/vnd.bokehjs_*` | `virtual:renderer-plugin/bokeh` | generated wrapper; loads BokehJS on demand |
 | Leaflet | `application/geo+json` | `virtual:renderer-plugin/leaflet` | ~194 KB |
 | Sift | `application/vnd.apache.parquet` | `virtual:renderer-plugin/sift` | ~380 KB JS + 138 KB CSS |
 

--- a/src/components/isolated/__tests__/output-lane-policy.test.ts
+++ b/src/components/isolated/__tests__/output-lane-policy.test.ts
@@ -1,5 +1,6 @@
 import { afterEach, describe, expect, it } from "vite-plus/test";
 import type { JupyterOutput } from "@/components/cell/jupyter-output";
+import { BOKEHJS_EXEC_MIME_TYPE, BOKEHJS_LOAD_MIME_TYPE } from "@/components/outputs/bokeh-mime";
 import {
   MARKDOWN_PROJECTION_MIME_TYPE,
   setMarkdownProjectionProjector,
@@ -9,6 +10,7 @@ import {
   hasWidgetOutputs,
   outputAllowsScrollPassthrough,
   outputSegmentLane,
+  outputUsesBokeh,
   outputUsesPlotly,
   outputUsesSift,
   outputUsesVega,
@@ -187,19 +189,28 @@ describe("output lane policy", () => {
       }),
       displayOutput("bokeh-load-js", {
         "application/javascript": 'document.getElementById("bokeh-loading").textContent = "ok";',
-        "application/vnd.bokehjs_load.v0+json": "",
+        [BOKEHJS_LOAD_MIME_TYPE]: "",
       }),
       displayOutput("bokeh-root-html", {
         "text/html": '<div id="bokeh-root"></div>',
       }),
       displayOutput("bokeh-exec-js", {
         "application/javascript": 'document.getElementById("bokeh-root").textContent = "plot";',
-        "application/vnd.bokehjs_exec.v0+json": "",
+        [BOKEHJS_EXEC_MIME_TYPE]: "",
       }),
     ];
 
     const segments = splitOutputSegments(outputs);
 
+    expect(outputs.map((output) => selectedOutputMimeType(output))).toEqual([
+      "text/html",
+      BOKEHJS_LOAD_MIME_TYPE,
+      "text/html",
+      BOKEHJS_EXEC_MIME_TYPE,
+    ]);
+    expect(outputUsesBokeh(outputs[1])).toBe(true);
+    expect(outputUsesBokeh(outputs[3])).toBe(true);
+    expect(outputUsesWheelOwningFrame(outputs[3])).toBe(true);
     expect(outputs.map((output) => outputAllowsScrollPassthrough(output))).toEqual([
       true,
       true,
@@ -210,6 +221,26 @@ describe("output lane policy", () => {
     expect(segments[0].outputs.map((output) => output.output_id)).toEqual([
       "bokeh-loading-html",
       "bokeh-load-js",
+      "bokeh-root-html",
+      "bokeh-exec-js",
+    ]);
+  });
+
+  it("keeps show(p) root HTML and Bokeh exec output in one document lane", () => {
+    const outputs = [
+      displayOutput("bokeh-root-html", {
+        "text/html": '<div id="bokeh-root"></div>',
+      }),
+      displayOutput("bokeh-exec-js", {
+        "application/javascript": 'document.getElementById("bokeh-root").textContent = "plot";',
+        [BOKEHJS_EXEC_MIME_TYPE]: "",
+      }),
+    ];
+
+    const segments = splitOutputSegments(outputs);
+
+    expect(segments.map((segment) => segment.lane)).toEqual(["static-frame"]);
+    expect(segments[0].outputs.map((output) => output.output_id)).toEqual([
       "bokeh-root-html",
       "bokeh-exec-js",
     ]);

--- a/src/components/isolated/__tests__/output-payloads.test.ts
+++ b/src/components/isolated/__tests__/output-payloads.test.ts
@@ -1,0 +1,59 @@
+import { describe, expect, it } from "vite-plus/test";
+import type { IdentifiedJupyterOutput } from "../output-payloads";
+import { jupyterOutputToRenderPayload } from "../output-payloads";
+import { BOKEHJS_EXEC_MIME_TYPE, BOKEHJS_LOAD_MIME_TYPE } from "@/components/outputs/bokeh-mime";
+
+describe("isolated output payload conversion", () => {
+  it("remaps Bokeh load bundles to the Bokeh MIME while preserving sibling JavaScript", () => {
+    const output: IdentifiedJupyterOutput = {
+      output_id: "bokeh-load",
+      output_type: "display_data",
+      data: {
+        "application/javascript": "window.Bokeh = {};",
+        [BOKEHJS_LOAD_MIME_TYPE]: "",
+      },
+      metadata: {},
+    };
+
+    expect(jupyterOutputToRenderPayload(output, 0)).toEqual(
+      expect.objectContaining({
+        data: {
+          "application/javascript": "window.Bokeh = {};",
+          "text/html": undefined,
+          [BOKEHJS_LOAD_MIME_TYPE]: "",
+        },
+        mimeType: BOKEHJS_LOAD_MIME_TYPE,
+        outputId: "bokeh-load",
+      }),
+    );
+  });
+
+  it("remaps Bokeh exec bundles to the Bokeh MIME while preserving sibling HTML and JavaScript", () => {
+    const output: IdentifiedJupyterOutput = {
+      output_id: "bokeh-exec",
+      output_type: "display_data",
+      data: {
+        "text/html": "<script>server output</script>",
+        "application/javascript": "window.__bokehExecRan = true;",
+        [BOKEHJS_EXEC_MIME_TYPE]: "",
+      },
+      metadata: {
+        [BOKEHJS_EXEC_MIME_TYPE]: { id: "p1011" },
+      },
+    };
+
+    expect(jupyterOutputToRenderPayload(output, 1)).toEqual(
+      expect.objectContaining({
+        data: {
+          "application/javascript": "window.__bokehExecRan = true;",
+          "text/html": "<script>server output</script>",
+          [BOKEHJS_EXEC_MIME_TYPE]: "",
+        },
+        metadata: { id: "p1011" },
+        mimeType: BOKEHJS_EXEC_MIME_TYPE,
+        outputId: "bokeh-exec",
+        outputIndex: 1,
+      }),
+    );
+  });
+});

--- a/src/components/isolated/__tests__/renderer-plugin-info.test.ts
+++ b/src/components/isolated/__tests__/renderer-plugin-info.test.ts
@@ -4,6 +4,7 @@ import {
   rendererPluginInfoForMime,
   rendererPluginNameForMime,
 } from "../renderer-plugin-info";
+import { BOKEHJS_EXEC_MIME_TYPE, BOKEHJS_LOAD_MIME_TYPE } from "@/components/outputs/bokeh-mime";
 
 describe("renderer plugin metadata", () => {
   it("maps exact MIME types to the shared renderer plugin names", () => {
@@ -13,6 +14,14 @@ describe("renderer plugin metadata", () => {
     });
     expect(rendererPluginInfoForMime("application/vnd.plotly.v1+json")).toEqual({
       name: "plotly",
+      hasCss: false,
+    });
+    expect(rendererPluginInfoForMime(BOKEHJS_LOAD_MIME_TYPE)).toEqual({
+      name: "bokeh",
+      hasCss: false,
+    });
+    expect(rendererPluginInfoForMime(BOKEHJS_EXEC_MIME_TYPE)).toEqual({
+      name: "bokeh",
       hasCss: false,
     });
     expect(rendererPluginInfoForMime("application/vnd.apache.parquet")).toEqual({

--- a/src/components/isolated/iframe-libraries.ts
+++ b/src/components/isolated/iframe-libraries.ts
@@ -40,6 +40,7 @@ function normalize(m: { code: string; css?: string }): PluginModule {
 const PLUGIN_LOADERS: Record<RendererPluginName, () => Promise<PluginModule>> = {
   markdown: () => import("virtual:renderer-plugin/markdown").then(normalize),
   plotly: () => import("virtual:renderer-plugin/plotly").then(normalize),
+  bokeh: () => import("virtual:renderer-plugin/bokeh").then(normalize),
   vega: () => import("virtual:renderer-plugin/vega").then(normalize),
   leaflet: () => import("virtual:renderer-plugin/leaflet").then(normalize),
   sift: () => import("virtual:renderer-plugin/sift").then(normalize),

--- a/src/components/isolated/output-lane-policy.ts
+++ b/src/components/isolated/output-lane-policy.ts
@@ -1,4 +1,9 @@
 import type { JupyterOutput } from "@/components/cell/jupyter-output";
+import {
+  BOKEHJS_EXEC_MIME_TYPE,
+  BOKEHJS_LOAD_MIME_TYPE,
+  isBokehMimeType,
+} from "@/components/outputs/bokeh-mime";
 import { DEFAULT_PRIORITY, selectMimeType } from "@/components/outputs/mime-priority";
 import { isSafeForMainDom } from "@/components/outputs/safe-mime-types";
 import { isVegaMimeType } from "@/components/outputs/vega-mime";
@@ -38,6 +43,8 @@ const SCROLL_PASSTHROUGH_MIME_TYPES = new Set([
   // JavaScript display outputs often act on adjacent HTML display outputs in
   // the same cell (Bokeh's notebook loader/root pair is the common case).
   "application/javascript",
+  BOKEHJS_LOAD_MIME_TYPE,
+  BOKEHJS_EXEC_MIME_TYPE,
   // Sift's interactive tables are also click-to-engage (see SIFT_MIME_TYPES).
   "application/vnd.apache.parquet",
   "application/vnd.apache.arrow.stream",
@@ -109,10 +116,18 @@ export function outputUsesPlotly(
   return mimeType === "application/vnd.plotly.v1+json";
 }
 
+export function outputUsesBokeh(
+  output: JupyterOutput,
+  priority: readonly string[] = DEFAULT_PRIORITY,
+): boolean {
+  const mimeType = selectedOutputMimeType(output, priority);
+  return mimeType !== null && isBokehMimeType(mimeType);
+}
+
 /**
  * Outputs whose iframe must own the wheel once the user engages it: Sift's
  * crossfilter tables scroll internally, and chart surfaces like Vega/Altair
- * and Plotly pan or zoom. While engaged the wheel-boundary forwarding is
+ * Plotly, and Bokeh pan or zoom. While engaged the wheel-boundary forwarding is
  * locked so the page does not steal the gesture.
  */
 export function outputUsesWheelOwningFrame(
@@ -122,7 +137,8 @@ export function outputUsesWheelOwningFrame(
   return (
     outputUsesSift(output, priority) ||
     outputUsesVega(output, priority) ||
-    outputUsesPlotly(output, priority)
+    outputUsesPlotly(output, priority) ||
+    outputUsesBokeh(output, priority)
   );
 }
 

--- a/src/components/isolated/output-payloads.ts
+++ b/src/components/isolated/output-payloads.ts
@@ -1,8 +1,13 @@
 import type { RenderPayload } from "./frame-bridge";
 import type { JupyterOutput } from "@/components/cell/jupyter-output";
+import { isBokehMimeType } from "@/components/outputs/bokeh-mime";
 import { DEFAULT_PRIORITY, selectMimeType } from "@/components/outputs/mime-priority";
 
 export type IdentifiedJupyterOutput = JupyterOutput & { output_id: string };
+type DataJupyterOutput = Extract<
+  IdentifiedJupyterOutput,
+  { output_type: "execute_result" | "display_data" }
+>;
 
 export interface RenderPayloadOptions {
   cellId?: string;
@@ -31,6 +36,18 @@ function requireOutputId(output: IdentifiedJupyterOutput): string {
   return output.output_id;
 }
 
+function dataForSelectedMime(output: DataJupyterOutput, mimeType: string): unknown {
+  if (!isBokehMimeType(mimeType)) {
+    return output.data[mimeType];
+  }
+
+  return {
+    [mimeType]: output.data[mimeType],
+    "application/javascript": output.data["application/javascript"],
+    "text/html": output.data["text/html"],
+  };
+}
+
 export function jupyterOutputToRenderPayload(
   output: IdentifiedJupyterOutput,
   outputIndex: number,
@@ -44,7 +61,7 @@ export function jupyterOutputToRenderPayload(
     if (!mimeType) return null;
     return {
       mimeType,
-      data: output.data[mimeType],
+      data: dataForSelectedMime(output, mimeType),
       metadata: output.metadata?.[mimeType] as Record<string, unknown> | undefined,
       outputId,
       cellId,

--- a/src/components/isolated/renderer-plugin-info.ts
+++ b/src/components/isolated/renderer-plugin-info.ts
@@ -1,6 +1,7 @@
 import { isVegaMimeType } from "@/components/outputs/vega-mime";
+import { BOKEHJS_EXEC_MIME_TYPE, BOKEHJS_LOAD_MIME_TYPE } from "@/components/outputs/bokeh-mime";
 
-export type RendererPluginName = "markdown" | "plotly" | "vega" | "leaflet" | "sift";
+export type RendererPluginName = "markdown" | "plotly" | "bokeh" | "vega" | "leaflet" | "sift";
 
 export interface RendererPluginInfo {
   name: RendererPluginName;
@@ -11,6 +12,8 @@ const MIME_TO_PLUGIN: Record<string, RendererPluginInfo> = {
   "text/markdown": { name: "markdown", hasCss: true },
   "text/latex": { name: "markdown", hasCss: true },
   "application/vnd.plotly.v1+json": { name: "plotly", hasCss: false },
+  [BOKEHJS_LOAD_MIME_TYPE]: { name: "bokeh", hasCss: false },
+  [BOKEHJS_EXEC_MIME_TYPE]: { name: "bokeh", hasCss: false },
   "application/geo+json": { name: "leaflet", hasCss: true },
   "application/vnd.apache.parquet": { name: "sift", hasCss: true },
   "application/vnd.apache.arrow.stream": { name: "sift", hasCss: true },

--- a/src/components/outputs/bokeh-mime.ts
+++ b/src/components/outputs/bokeh-mime.ts
@@ -1,0 +1,8 @@
+export const BOKEHJS_LOAD_MIME_TYPE = "application/vnd.bokehjs_load.v0+json";
+export const BOKEHJS_EXEC_MIME_TYPE = "application/vnd.bokehjs_exec.v0+json";
+
+const BOKEH_MIME_TYPES = new Set([BOKEHJS_LOAD_MIME_TYPE, BOKEHJS_EXEC_MIME_TYPE]);
+
+export function isBokehMimeType(mimeType: string): boolean {
+  return BOKEH_MIME_TYPES.has(mimeType);
+}

--- a/src/components/outputs/mime-priority.ts
+++ b/src/components/outputs/mime-priority.ts
@@ -1,3 +1,5 @@
+import { BOKEHJS_EXEC_MIME_TYPE, BOKEHJS_LOAD_MIME_TYPE } from "./bokeh-mime";
+
 /**
  * Default MIME type priority order for rendering.
  * Higher priority types are preferred when multiple are available.
@@ -13,6 +15,10 @@ export const DEFAULT_PRIORITY = [
   // outrank source markdown and HTML fallbacks when a host supplies it.
   "application/vnd.nteract.markdown+json",
   "application/vnd.plotly.v1+json",
+  // Bokeh emits these alongside text/html and application/javascript. They
+  // must win so the Bokeh renderer can coordinate the sibling payloads.
+  BOKEHJS_EXEC_MIME_TYPE,
+  BOKEHJS_LOAD_MIME_TYPE,
   "application/vnd.vegalite.v6+json",
   "application/vnd.vegalite.v6.json",
   "application/vnd.vegalite.v5+json",

--- a/src/isolated-renderer/__tests__/bokeh-renderer.test.tsx
+++ b/src/isolated-renderer/__tests__/bokeh-renderer.test.tsx
@@ -1,0 +1,145 @@
+import { cleanup, render, waitFor } from "@testing-library/react";
+import type { ComponentType } from "react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vite-plus/test";
+import { BOKEHJS_EXEC_MIME_TYPE, BOKEHJS_LOAD_MIME_TYPE } from "@/components/outputs/bokeh-mime";
+import type { RendererProps } from "@/lib/renderer-registry";
+import { install } from "../bokeh-renderer";
+
+function installBokehRenderer() {
+  let Renderer: ComponentType<RendererProps> | undefined;
+  let registeredMimeTypes: string[] = [];
+
+  install({
+    register: (mimeTypes, component) => {
+      registeredMimeTypes = mimeTypes;
+      Renderer = component;
+    },
+  });
+
+  expect(Renderer).toBeDefined();
+  return { Renderer: Renderer!, registeredMimeTypes };
+}
+
+function stubAnimationFrames() {
+  vi.stubGlobal("requestAnimationFrame", (callback: FrameRequestCallback) => {
+    callback(0);
+    return 0;
+  });
+}
+
+function stubBokehCdnLoads() {
+  const appendedSrcs: string[] = [];
+  const appendChild = vi.spyOn(HTMLHeadElement.prototype, "appendChild");
+
+  appendChild.mockImplementation(function appendBokehScript(
+    this: HTMLHeadElement,
+    node: Node,
+  ): Node {
+    if (node instanceof HTMLScriptElement && node.src) {
+      appendedSrcs.push(node.src);
+      if (node.src.includes("bokeh-3.9.1.min.js")) {
+        window.Bokeh = {};
+      }
+      queueMicrotask(() => node.onload?.(new Event("load")));
+    }
+    return Node.prototype.appendChild.call(this, node);
+  });
+
+  return appendedSrcs;
+}
+
+function renderedScripts(container: HTMLElement): HTMLScriptElement[] {
+  return Array.from(container.querySelectorAll("script"));
+}
+
+describe("Bokeh renderer plugin", () => {
+  beforeEach(() => {
+    stubAnimationFrames();
+    window.Bokeh = undefined;
+    window.__nteractBokehLoadPromise__ = undefined;
+  });
+
+  afterEach(() => {
+    cleanup();
+    vi.restoreAllMocks();
+    vi.unstubAllGlobals();
+    window.Bokeh = undefined;
+    window.__nteractBokehLoadPromise__ = undefined;
+  });
+
+  it("registers Bokeh load and exec MIME types", () => {
+    const { registeredMimeTypes } = installBokehRenderer();
+
+    expect(registeredMimeTypes).toEqual([BOKEHJS_LOAD_MIME_TYPE, BOKEHJS_EXEC_MIME_TYPE]);
+  });
+
+  it("loads matching BokehJS resources before appending standalone exec output", async () => {
+    const appendedSrcs = stubBokehCdnLoads();
+    const { Renderer } = installBokehRenderer();
+    const { container } = render(
+      <Renderer
+        data={{
+          "application/javascript": `
+            const docs_json = {"docid": {"version": "3.9.1"}};
+            window.__bokehExecRan = true;
+          `,
+          [BOKEHJS_EXEC_MIME_TYPE]: "",
+        }}
+        metadata={{ id: "p1011" }}
+        mimeType={BOKEHJS_EXEC_MIME_TYPE}
+      />,
+    );
+
+    await waitFor(() => {
+      expect(renderedScripts(container).at(-1)?.textContent).toContain("__bokehExecRan");
+    });
+
+    expect(appendedSrcs).toEqual([
+      "https://cdn.bokeh.org/bokeh/release/bokeh-3.9.1.min.js",
+      "https://cdn.bokeh.org/bokeh/release/bokeh-gl-3.9.1.min.js",
+      "https://cdn.bokeh.org/bokeh/release/bokeh-widgets-3.9.1.min.js",
+      "https://cdn.bokeh.org/bokeh/release/bokeh-tables-3.9.1.min.js",
+      "https://cdn.bokeh.org/bokeh/release/bokeh-mathjax-3.9.1.min.js",
+    ]);
+  });
+
+  it("uses an already-loaded BokehJS runtime without adding CDN scripts", async () => {
+    const appendedSrcs = stubBokehCdnLoads();
+    const { Renderer } = installBokehRenderer();
+    window.Bokeh = {};
+
+    const { container } = render(
+      <Renderer
+        data={{
+          "application/javascript": "window.__bokehExecRan = true;",
+          [BOKEHJS_EXEC_MIME_TYPE]: "",
+        }}
+        metadata={{ id: "p1011" }}
+        mimeType={BOKEHJS_EXEC_MIME_TYPE}
+      />,
+    );
+
+    await waitFor(() => {
+      expect(renderedScripts(container).at(-1)?.textContent).toContain("__bokehExecRan");
+    });
+
+    expect(appendedSrcs).toEqual([]);
+  });
+
+  it("appends Bokeh load MIME JavaScript directly", async () => {
+    const { Renderer } = installBokehRenderer();
+    const { container } = render(
+      <Renderer
+        data={{
+          "application/javascript": "window.Bokeh = {};",
+          [BOKEHJS_LOAD_MIME_TYPE]: "window.Bokeh = {};",
+        }}
+        mimeType={BOKEHJS_LOAD_MIME_TYPE}
+      />,
+    );
+
+    await waitFor(() => {
+      expect(renderedScripts(container).at(-1)?.textContent).toBe("window.Bokeh = {};");
+    });
+  });
+});

--- a/src/isolated-renderer/bokeh-renderer.tsx
+++ b/src/isolated-renderer/bokeh-renderer.tsx
@@ -1,0 +1,229 @@
+/**
+ * Bokeh Renderer Plugin
+ *
+ * Bokeh's notebook protocol emits a custom MIME marker alongside sibling
+ * text/html and application/javascript payloads. The marker selects this
+ * plugin; the nteract payload remaps the sibling data into one object.
+ */
+
+import { useEffect, useRef, useState, type ComponentType } from "react";
+import type { RendererProps } from "@/lib/renderer-registry";
+import { BOKEHJS_EXEC_MIME_TYPE, BOKEHJS_LOAD_MIME_TYPE } from "@/components/outputs/bokeh-mime";
+import { measureDocumentHeight } from "./layout-measure";
+
+type BokehPayload = {
+  [BOKEHJS_LOAD_MIME_TYPE]?: unknown;
+  [BOKEHJS_EXEC_MIME_TYPE]?: unknown;
+  "application/javascript"?: unknown;
+  "text/html"?: unknown;
+};
+
+declare global {
+  interface Window {
+    Bokeh?: {
+      embed?: {
+        kernels?: Record<string, unknown>;
+      };
+      index?: {
+        get_by_id?: (id: string) => { model?: { document?: { clear?: () => void } } } | null;
+        delete?: (view: unknown) => void;
+      };
+    };
+    __nteractBokehLoadPromise__?: Promise<void>;
+  }
+}
+
+const BOKEH_RESOURCE_SUFFIXES = ["", "-gl", "-widgets", "-tables", "-mathjax"];
+
+function normalizeText(value: unknown): string | null {
+  if (typeof value === "string") return value;
+  if (Array.isArray(value)) return value.map(String).join("");
+  return null;
+}
+
+function asBokehPayload(value: unknown): BokehPayload {
+  return value !== null && typeof value === "object" ? (value as BokehPayload) : {};
+}
+
+function bokehDocumentId(metadata?: Record<string, unknown>): string | null {
+  const id = metadata?.id;
+  return typeof id === "string" ? id : null;
+}
+
+function bokehServerId(metadata?: Record<string, unknown>): string | null {
+  const serverId = metadata?.server_id;
+  return typeof serverId === "string" ? serverId : null;
+}
+
+function extractBokehVersion(script: string): string | null {
+  return script.match(/"version"\s*:\s*"([^"]+)"/)?.[1] ?? null;
+}
+
+function loadScript(src: string, required: boolean): Promise<void> {
+  return new Promise((resolve, reject) => {
+    const existing = document.querySelector(`script[data-nteract-bokeh-src="${src}"]`);
+    if (existing) {
+      resolve();
+      return;
+    }
+
+    const script = document.createElement("script");
+    script.async = false;
+    script.dataset.nteractBokehSrc = src;
+    script.onload = () => resolve();
+    script.onerror = () => {
+      const error = new Error(`Failed to load BokehJS resource: ${src}`);
+      if (required) reject(error);
+      else {
+        console.warn(error.message);
+        resolve();
+      }
+    };
+    script.src = src;
+    document.head.appendChild(script);
+  });
+}
+
+async function ensureBokeh(version: string | null): Promise<void> {
+  if (window.Bokeh !== undefined) return;
+  if (window.__nteractBokehLoadPromise__) return window.__nteractBokehLoadPromise__;
+  if (!version) {
+    throw new Error("BokehJS is missing and no Bokeh document version was found");
+  }
+
+  window.__nteractBokehLoadPromise__ = (async () => {
+    for (const [index, suffix] of BOKEH_RESOURCE_SUFFIXES.entries()) {
+      const src = `https://cdn.bokeh.org/bokeh/release/bokeh${suffix}-${version}.min.js`;
+      await loadScript(src, index === 0);
+    }
+    if (window.Bokeh === undefined) {
+      throw new Error(`BokehJS ${version} loaded without defining window.Bokeh`);
+    }
+  })().catch((error) => {
+    window.__nteractBokehLoadPromise__ = undefined;
+    throw error;
+  });
+
+  return window.__nteractBokehLoadPromise__;
+}
+
+function requestHostResize(): void {
+  requestAnimationFrame(() => {
+    requestAnimationFrame(() => {
+      window.parent.postMessage(
+        {
+          type: "resize",
+          payload: { height: measureDocumentHeight() },
+        },
+        "*",
+      );
+    });
+  });
+}
+
+function appendExecutableScript(container: HTMLElement, code: string): HTMLScriptElement {
+  const script = document.createElement("script");
+  script.textContent = code;
+  container.appendChild(script);
+  requestHostResize();
+  return script;
+}
+
+function scriptFromServerHtml(html: string): HTMLScriptElement {
+  const wrapper = document.createElement("div");
+  wrapper.innerHTML = html;
+  const source = wrapper.querySelector("script");
+  const script = document.createElement("script");
+  if (source) {
+    for (const attr of Array.from(source.attributes)) {
+      script.setAttribute(attr.name, attr.value);
+    }
+    script.textContent = source.textContent ?? "";
+  } else {
+    script.textContent = html;
+  }
+  return script;
+}
+
+function cleanupBokehDocument(documentId: string | null): void {
+  if (!documentId || window.Bokeh?.index == null) return;
+  const view = window.Bokeh.index.get_by_id?.(documentId);
+  if (!view) return;
+  view.model?.document?.clear?.();
+  window.Bokeh.index.delete?.(view);
+}
+
+function BokehRenderer({ data: rawData, metadata, mimeType }: RendererProps) {
+  const containerRef = useRef<HTMLDivElement>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    const container = containerRef.current;
+    if (!container) return;
+
+    setError(null);
+    const payload = asBokehPayload(rawData);
+    const documentId = bokehDocumentId(metadata);
+    let script: HTMLScriptElement | null = null;
+    let cancelled = false;
+
+    async function renderBokeh() {
+      if (mimeType === BOKEHJS_LOAD_MIME_TYPE) {
+        const code =
+          normalizeText(payload[BOKEHJS_LOAD_MIME_TYPE]) ??
+          normalizeText(payload["application/javascript"]);
+        if (!code) return;
+        script = appendExecutableScript(container, code);
+        return;
+      }
+
+      if (mimeType !== BOKEHJS_EXEC_MIME_TYPE) return;
+
+      const serverId = bokehServerId(metadata);
+      if (serverId) {
+        const html = normalizeText(payload["text/html"]);
+        if (!html) throw new Error("Bokeh server output did not include text/html script data");
+        script = scriptFromServerHtml(html);
+        container.appendChild(script);
+        requestHostResize();
+        return;
+      }
+
+      const code = normalizeText(payload["application/javascript"]);
+      if (!code) throw new Error("Bokeh output did not include application/javascript data");
+      await ensureBokeh(extractBokehVersion(code));
+      if (cancelled) return;
+      script = appendExecutableScript(container, code);
+    }
+
+    void renderBokeh().catch((renderError) => {
+      if (!cancelled) {
+        setError(renderError instanceof Error ? renderError.message : String(renderError));
+      }
+    });
+
+    return () => {
+      cancelled = true;
+      if (script?.parentElement === container) {
+        container.removeChild(script);
+      }
+      cleanupBokehDocument(documentId);
+    };
+  }, [rawData, metadata, mimeType]);
+
+  return (
+    <div data-slot="bokeh-output" ref={containerRef}>
+      {error ? (
+        <pre className="whitespace-pre-wrap rounded border border-destructive/30 bg-destructive/10 p-3 text-sm text-destructive">
+          {error}
+        </pre>
+      ) : null}
+    </div>
+  );
+}
+
+export function install(ctx: {
+  register: (mimeTypes: string[], component: ComponentType<RendererProps>) => void;
+}) {
+  ctx.register([BOKEHJS_LOAD_MIME_TYPE, BOKEHJS_EXEC_MIME_TYPE], BokehRenderer);
+}


### PR DESCRIPTION
## Summary

- add a Bokeh isolated renderer plugin for Bokeh's notebook load/exec MIME markers
- remap Bokeh MIME bundles into an nteract-owned payload that preserves sibling `application/javascript` for `show(p)` output
- teach runtime/WASM output projection to keep Bokeh marker MIMEs instead of narrowing them away to plain JavaScript
- wire the generated `bokeh.js` renderer artifact through Vite, xtask, MCP app assets, and docs

## Root Cause

Bokeh notebook output uses marker MIME types:

- `application/vnd.bokehjs_load.v0+json`
- `application/vnd.bokehjs_exec.v0+json`

The saved notebook had those markers, and daemon manifest creation preserved them. The browser-facing RuntimeState projection narrowed rich bundles before React saw them. Because the runtime MIME priority did not know Bokeh, it picked `application/javascript` as the winner and dropped the Bokeh marker. That meant the isolated renderer plugin was never requested, so standalone `show(p)` stayed as a tiny blank JavaScript frame.

## Fix

This patch treats Bokeh's marker MIME as the renderer MIME and keeps the JavaScript sibling in the payload. The Bokeh renderer loads matching BokehJS resources when needed, then appends Bokeh's generated exec script inside the isolated frame.

The runtime projection also now includes Bokeh in the default MIME priority and preserves the marker/JavaScript/HTML bundle during WASM narrowing, so live RuntimeState output-store updates reach React with enough information to select the Bokeh renderer.

## Verification

- `pnpm test:run src/components/isolated/__tests__/output-payloads.test.ts src/components/isolated/__tests__/renderer-plugin-info.test.ts src/components/isolated/__tests__/output-lane-policy.test.ts src/components/cell/__tests__/OutputArea.test.tsx src/isolated-renderer/__tests__/bokeh-renderer.test.tsx`
- `cargo test -p runtimed-wasm bokeh_narrowing_keeps_marker_javascript_and_html_bundle -- --nocapture`
- `cargo test -p runtimed bokeh_display_data_preserves_exec_marker_mime -- --nocapture`
- `cargo xtask renderer-plugins --only bokeh`
- `cargo xtask wasm runtimed --skip-renderer-plugins`
- `cargo xtask lint --fix`
- `cargo clippy --workspace --exclude notebook --exclude runtimed-wasm --exclude sift-wasm --exclude runtimed-py --all-targets -- -D warnings`
- `cargo xtask wasm-verify`
- `cargo xtask artifacts verify renderer`
- `cargo xtask artifacts ensure mcp-widget`
- `pnpm --dir apps/notebook build && pnpm --dir apps/elements build`

## Browser Verification

Verified in the in-app Browser at:

`http://localhost:5579/?path=%2FUsers%2Fkylekelley%2Fnotebooks%2Fbokeh-3723.ipynb&environment_mode=notebook`

After rebuilding `runtimed-wasm` and reloading the tab, the standalone `show(p)` output frame expanded from the previous 24px blank frame to a 418px rendered Bokeh scatter plot. The setup-cell Bokeh output remained rendered as well.
