### PR TITLE
fix(python): keep workspace packages out of root install

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,20 +3,10 @@ name = "nteract-workspace"
 version = "0.0.0"
 description = "Development workspace for nteract Python packages"
 requires-python = ">=3.10,<3.14"
-dependencies = [
-    "nteract",
-    "gremlin ; sys_platform == 'darwin'",
-    "dx",
-    "nteract-kernel-launcher",
-    "pr-reviewer ; sys_platform == 'darwin'",
-    "safari-timeline",
-    "pandas",
-    "polars",
-    "pyarrow>=14",
-    "numpy>=2.2.6",
-    "narwhals>=1.0",
-    "anywidget>=0.9.21",
-]
+# Keep the root package installable without resolving workspace-only packages
+# from PyPI. `uv sync` uses the `dev` dependency group below for the local
+# workspace environment.
+dependencies = []
 
 [build-system]
 requires = ["setuptools"]
@@ -67,15 +57,24 @@ known-first-party = ["runtimed", "nteract", "prewarm", "pr_reviewer", "safari_ti
 
 [dependency-groups]
 dev = [
+    "nteract",
+    "gremlin ; sys_platform == 'darwin'",
+    "dx",
+    "nteract-kernel-launcher",
+    "pr-reviewer ; sys_platform == 'darwin'",
+    "safari-timeline",
+    "pandas",
+    "polars>=1.39.3",
+    "pyarrow>=14",
+    "numpy>=2.2.6",
+    "narwhals>=1.0",
+    "anywidget>=0.9.21",
     "ruff==0.15.10",
     "ty>=0.0.22",
     "pytest>=8.0",
     "pyzmq>=26.0",
-    "numpy>=1.26",
     "matplotlib>=3.8",
-    "anywidget>=0.9.21",
     "quak>=0.3.4",
-    "polars>=1.39.3",
     "plotly>=6.0",
     "nbformat>=5.0",
     "datasets>=2.0",

--- a/python/README.md
+++ b/python/README.md
@@ -1,19 +1,31 @@
 # Python Packages
 
-Development home for nteract Python packages. The UV workspace root (`pyproject.toml` and `.venv`) lives at the **repo root**, with three workspace members:
+Development home for nteract Python packages. The UV workspace root (`pyproject.toml` and `.venv`) lives at the **repo root**.
 
 | Package | Description |
 |---------|-------------|
 | `python/runtimed/` | Low-level Python bindings for the runtimed daemon (maturin/PyO3) |
 | `python/nteract/` | MCP server for AI agents — composes runtimed primitives |
+| `python/dx/` | Display and blob-store helpers used from Python kernels |
+| `python/nteract-kernel-launcher/` | Embedded launcher package vendored by the daemon into kernel environments |
+| `python/prewarm/` | Environment warm-up utility for Python kernels |
 | `python/gremlin/` | Autonomous notebook agent for stress testing |
+| `python/pr-reviewer/` | Internal opencode-backed PR reviewer |
+| `python/safari-timeline/` | Safari Web Inspector timeline unpacking utilities |
+
+The root project keeps install metadata empty. Workspace-local packages live in
+the default `dev` dependency group so plain `pip install .` does not try to
+resolve unpublished packages from PyPI. `nteract-kernel-launcher` is especially
+important here: the packaged daemon embeds its sources and vendors them into
+kernel environments, so use explicit `uv --package nteract-kernel-launcher`
+commands when working on or testing that package directly.
 
 ## Dev Setup
 
 The virtual environment lives at the repo root (`.venv`), not inside `python/`.
 
 ```bash
-# From the repo root — creates .venv and installs all workspace members
+# From the repo root — creates .venv and installs the default dev workspace
 uv sync
 ```
 


### PR DESCRIPTION
## Summary

- Keep the root `nteract-workspace` package installable with empty runtime dependency metadata.
- Move workspace-local Python packages into the default `dev` dependency group so `uv sync` still installs them from local workspace sources.
- Document why `nteract-kernel-launcher` is not a root install dependency: the daemon embeds and vendors it into kernel environments.

## Verification

- `/tmp/nteract-pipcheck-venv/bin/python -m pip install . --dry-run --ignore-installed --disable-pip-version-check`
- `uv sync --dry-run --package nteract-kernel-launcher --group dev`
- `git diff --check`
- `cargo xtask lint --fix`

## Notes

This keeps generic automation that runs plain `pip install .` from trying to resolve unpublished workspace-only packages such as `nteract-kernel-launcher`, `gremlin`, or `safari-timeline` from PyPI.
