### PR TITLE
fix(outputs): embed Bokeh renderer asset

### DIFF
--- a/crates/runtimed/src/embedded_plugins.rs
+++ b/crates/runtimed/src/embedded_plugins.rs
@@ -1,6 +1,6 @@
 //! Embedded renderer plugin assets for MCP App output rendering.
 //!
-//! Heavy visualization renderers (plotly, vega, leaflet, markdown, sift) ship
+//! Heavy visualization renderers (plotly, vega, leaflet, markdown, bokeh, sift) ship
 //! inside the daemon binary via `include_bytes!`. The blob server serves raw
 //! JS/CSS assets at `GET /renderer-plugins/{name}` for the shared isolated
 //! renderer. It also keeps `GET /plugins/{name}` for legacy MCP App plugin
@@ -53,6 +53,7 @@ pub const EMBEDDED_PLUGINS: &[EmbeddedPlugin] = &[
     plugin!("vega.js"),
     plugin!("leaflet.js"),
     plugin!("leaflet.css"),
+    plugin!("bokeh.js"),
     plugin!("sift.js"),
     plugin!("sift.css"),
     EmbeddedPlugin {


### PR DESCRIPTION
## Summary

- add `bokeh.js` to the daemon embedded renderer plugin manifest
- keep the embedded renderer comment aligned with the actual bundled plugin set

## Context

PR #3727 added the Bokeh isolated renderer and was squash-merged before the embedded daemon manifest fix landed locally. The generated `renderer-plugins/bokeh.js` asset exists on disk, so `EMBEDDED_PLUGINS` needs to include it for the daemon asset drift test and MCP app output serving path.

## Verification

- `cargo xtask lint --fix`
- `cargo test -p runtimed embedded_plugins_match_assets_dir -- --nocapture`
