### PR TITLE
fix(runtimed): declare comments-doc dependency to unbreak main

### DIFF
--- a/crates/runtimed/Cargo.toml
+++ b/crates/runtimed/Cargo.toml
@@ -27,6 +27,7 @@ nteract-markdown-wasm = { path = "../nteract-markdown-wasm" }
 notebook-protocol = { path = "../notebook-protocol" }
 notebook-wire = { path = "../notebook-wire" }
 notebook-cloud-transport = { path = "../notebook-cloud-transport" }
+comments-doc = { path = "../comments-doc" }
 nteract-identity = { path = "../nteract-identity" }
 tokio = { workspace = true }
 serde = { workspace = true }


### PR DESCRIPTION
Fast-follow fix: `main` does not compile after #3732.

`crates/runtimed/src/notebook_sync_server/comments_store.rs` imports the `comments_doc` crate, but `crates/runtimed/Cargo.toml` never declared the dependency, so `runtimed` fails to build:

```
error[E0432]: unresolved import `comments_doc`
  --> crates/runtimed/src/notebook_sync_server/comments_store.rs:13:5
```

plus cascading type-inference errors in the `with_doc` closures, all downstream of the unresolved crate. The store and its tests compiled locally in #3732 only because the working tree carried the dependency edge; it was staged into the wrong `Cargo.toml` and never committed. Auto-merge then landed #3732 before the Clippy job finished.

This adds the one missing line:

```toml
comments-doc = { path = "../comments-doc" }
```

Cargo.lock already referenced the edge (committed in #3732), so only the manifest needed the entry.

## Verification
- [x] `cargo clippy -p runtimed` clean
- [x] `cargo test -p runtimed notebook_sync_server::comments_store` (9 passed)
