### PR TITLE
feat(notebook-cloud): add room-host comments sync (server side)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7760,6 +7760,7 @@ name = "runtimed-wasm"
 version = "0.4.2"
 dependencies = [
  "automerge",
+ "comments-doc",
  "console_error_panic_hook",
  "getrandom 0.2.17",
  "getrandom 0.3.4",

--- a/apps/notebook-cloud/src/notebook-room.ts
+++ b/apps/notebook-cloud/src/notebook-room.ts
@@ -1128,6 +1128,7 @@ export class NotebookRoom {
       case FrameType.AUTOMERGE_SYNC:
       case FrameType.RUNTIME_STATE_SYNC:
       case FrameType.COMMS_DOC_SYNC:
+      case FrameType.COMMENTS_DOC_SYNC:
         // These frames are both data and protocol control. Read-only peers may
         // send empty sync acks/needs; RoomMaterializer rejects messages carrying
         // document changes when the connection lacks write scope.

--- a/apps/notebook-cloud/src/protocol.ts
+++ b/apps/notebook-cloud/src/protocol.ts
@@ -141,9 +141,7 @@ const CLIENT_WRITABLE_FRAME_TYPES = {
   [FrameType.PRESENCE]: true,
   [FrameType.RUNTIME_STATE_SYNC]: true,
   [FrameType.COMMS_DOC_SYNC]: true,
-  // Hosted Cloud comments sync is server-originated until the room-host comments
-  // path lands (ADR Phase 4); client-authored comment frames are not admitted yet.
-  [FrameType.COMMENTS_DOC_SYNC]: false,
+  [FrameType.COMMENTS_DOC_SYNC]: true,
   [FrameType.POOL_STATE_SYNC]: true,
   [FrameType.SESSION_CONTROL]: false,
   [FrameType.PUT_BLOB]: true,

--- a/apps/notebook-cloud/src/room-materializer.ts
+++ b/apps/notebook-cloud/src/room-materializer.ts
@@ -10,8 +10,9 @@ const ROOM_HOST_ACTOR_PRINCIPAL = "system:notebook-cloud-room";
 const CHECKPOINT_NOTEBOOK_KEY = "room-host:notebook-doc";
 const CHECKPOINT_RUNTIME_STATE_KEY = "room-host:runtime-state-doc";
 const CHECKPOINT_COMMS_DOC_KEY = "room-host:comms-doc";
+const CHECKPOINT_COMMENTS_DOC_KEY = "room-host:comments-doc";
 const CHECKPOINT_META_KEY = "room-host:checkpoint";
-const CHECKPOINT_VERSION = 5;
+const CHECKPOINT_VERSION = 6;
 
 interface RoomHostOutboundFrame {
   peer_id: string;
@@ -31,11 +32,13 @@ interface RoomCheckpointMetadata {
   notebook_heads: string[];
   runtime_state_heads: string[];
   comms_doc_heads: string[];
+  comments_doc_heads: string[];
   saved_at: string;
   published_revision_id: string | null;
   published_notebook_heads: string[] | null;
   published_runtime_state_heads: string[] | null;
   published_comms_doc_heads: string[] | null;
+  published_comments_doc_heads: string[] | null;
 }
 
 interface RoomPeer {
@@ -50,6 +53,7 @@ export class RoomMaterializer {
   private loadedPublishedNotebookHeads: string[] | null = null;
   private loadedPublishedRuntimeStateHeads: string[] | null = null;
   private loadedPublishedCommsDocHeads: string[] | null = null;
+  private loadedPublishedCommentsDocHeads: string[] | null = null;
 
   constructor(
     private readonly notebookId: string,
@@ -141,26 +145,30 @@ export class RoomMaterializer {
   async checkpoint(): Promise<void> {
     const startedAt = Date.now();
     await this.withHost(async (host) => {
-      const [notebookBytes, runtimeStateBytes, commsDocBytes] = [
+      const [notebookBytes, runtimeStateBytes, commsDocBytes, commentsDocBytes] = [
         toStoredArrayBuffer(host.save_notebook()),
         toStoredArrayBuffer(host.save_runtime_state_doc()),
         toStoredArrayBuffer(host.save_comms_doc()),
+        toStoredArrayBuffer(host.save_comments_doc()),
       ];
       const metadata: RoomCheckpointMetadata = {
         version: CHECKPOINT_VERSION,
         notebook_heads: Array.from(host.get_heads_hex()),
         runtime_state_heads: Array.from(host.get_runtime_state_heads_hex()),
         comms_doc_heads: Array.from(host.get_comms_doc_heads_hex()),
+        comments_doc_heads: Array.from(host.get_comments_doc_heads_hex()),
         saved_at: new Date().toISOString(),
         published_revision_id: this.loadedPublishedRevisionId,
         published_notebook_heads: this.loadedPublishedNotebookHeads,
         published_runtime_state_heads: this.loadedPublishedRuntimeStateHeads,
         published_comms_doc_heads: this.loadedPublishedCommsDocHeads,
+        published_comments_doc_heads: this.loadedPublishedCommentsDocHeads,
       };
       await Promise.all([
         this.state.storage.put(CHECKPOINT_NOTEBOOK_KEY, notebookBytes),
         this.state.storage.put(CHECKPOINT_RUNTIME_STATE_KEY, runtimeStateBytes),
         this.state.storage.put(CHECKPOINT_COMMS_DOC_KEY, commsDocBytes),
+        this.state.storage.put(CHECKPOINT_COMMENTS_DOC_KEY, commentsDocBytes),
         this.state.storage.put(CHECKPOINT_META_KEY, metadata),
       ]);
       cloudLog("debug", "room.materializer.checkpoint.saved", {
@@ -169,9 +177,11 @@ export class RoomMaterializer {
         notebook_byte_length: notebookBytes.byteLength,
         runtime_state_byte_length: runtimeStateBytes.byteLength,
         comms_doc_byte_length: commsDocBytes.byteLength,
+        comments_doc_byte_length: commentsDocBytes.byteLength,
         notebook_head_count: metadata.notebook_heads.length,
         runtime_state_head_count: metadata.runtime_state_heads.length,
         comms_doc_head_count: metadata.comms_doc_heads.length,
+        comments_doc_head_count: metadata.comments_doc_heads.length,
         counter: "materializer_checkpoints_saved",
         counter_delta: 1,
       });
@@ -220,6 +230,7 @@ export class RoomMaterializer {
               checkpoint.notebookBytes,
               checkpoint.runtimeStateBytes,
               checkpoint.commsDocBytes,
+              checkpoint.commentsDocBytes,
             );
             cloudLog("info", "room.materializer.loaded", {
               notebook_id: this.notebookId,
@@ -240,6 +251,7 @@ export class RoomMaterializer {
             latestPublished.notebookBytes,
             latestPublished.runtimeStateBytes,
             latestPublished.commsDocBytes,
+            latestPublished.commentsDocBytes,
           );
           this.markLoadedPublishedSnapshot(latestPublished.revisionId, host);
           cloudLog("info", "room.materializer.loaded", {
@@ -262,6 +274,7 @@ export class RoomMaterializer {
           checkpoint.notebookBytes,
           checkpoint.runtimeStateBytes,
           checkpoint.commsDocBytes,
+          checkpoint.commentsDocBytes,
         );
         cloudLog("info", "room.materializer.loaded", {
           notebook_id: this.notebookId,
@@ -282,6 +295,7 @@ export class RoomMaterializer {
           published.notebookBytes,
           published.runtimeStateBytes,
           published.commsDocBytes,
+          published.commentsDocBytes,
         );
         this.markLoadedPublishedSnapshot(published.revisionId, host);
         cloudLog("info", "room.materializer.loaded", {
@@ -305,6 +319,7 @@ export class RoomMaterializer {
       this.loadedPublishedNotebookHeads = null;
       this.loadedPublishedRuntimeStateHeads = null;
       this.loadedPublishedCommsDocHeads = null;
+      this.loadedPublishedCommentsDocHeads = null;
       const host = await createEmptyRoomHost(this.notebookId, roomHostActorLabel(this.notebookId));
       host.seed_initial_code_cell_if_empty(initialHostedCellId(this.notebookId));
       cloudLog("info", "room.materializer.loaded", {
@@ -332,6 +347,7 @@ export class RoomMaterializer {
       notebookBytes: Uint8Array;
       runtimeStateBytes: Uint8Array;
       commsDocBytes?: Uint8Array;
+      commentsDocBytes?: Uint8Array;
       metadata: RoomCheckpointMetadata;
     } | null;
     error: unknown | null;
@@ -387,6 +403,7 @@ export class RoomMaterializer {
         published.notebookBytes,
         published.runtimeStateBytes,
         published.commsDocBytes,
+        published.commentsDocBytes,
       );
       this.markLoadedPublishedSnapshot(published.revisionId, host);
       await this.clearCheckpoint().catch((clearError: unknown) => {
@@ -432,6 +449,7 @@ export class RoomMaterializer {
       this.state.storage.delete(CHECKPOINT_NOTEBOOK_KEY),
       this.state.storage.delete(CHECKPOINT_RUNTIME_STATE_KEY),
       this.state.storage.delete(CHECKPOINT_COMMS_DOC_KEY),
+      this.state.storage.delete(CHECKPOINT_COMMENTS_DOC_KEY),
       this.state.storage.delete(CHECKPOINT_META_KEY),
     ]);
   }
@@ -440,12 +458,14 @@ export class RoomMaterializer {
     notebookBytes: Uint8Array;
     runtimeStateBytes: Uint8Array;
     commsDocBytes?: Uint8Array;
+    commentsDocBytes?: Uint8Array;
     metadata: RoomCheckpointMetadata;
   } | null> {
-    const [notebookBytes, runtimeStateBytes, commsDocBytes] = await Promise.all([
+    const [notebookBytes, runtimeStateBytes, commsDocBytes, commentsDocBytes] = await Promise.all([
       this.state.storage.get<ArrayBuffer>(CHECKPOINT_NOTEBOOK_KEY),
       this.state.storage.get<ArrayBuffer>(CHECKPOINT_RUNTIME_STATE_KEY),
       this.state.storage.get<ArrayBuffer>(CHECKPOINT_COMMS_DOC_KEY),
+      this.state.storage.get<ArrayBuffer>(CHECKPOINT_COMMENTS_DOC_KEY),
     ]);
     const metadata =
       await this.state.storage.get<Partial<RoomCheckpointMetadata>>(CHECKPOINT_META_KEY);
@@ -455,17 +475,22 @@ export class RoomMaterializer {
       (metadata?.version !== 2 &&
         metadata?.version !== 3 &&
         metadata?.version !== 4 &&
+        metadata?.version !== 5 &&
         metadata?.version !== CHECKPOINT_VERSION)
     ) {
       return null;
     }
-    if (metadata.version === CHECKPOINT_VERSION && !commsDocBytes) {
+    if (metadata.version >= 5 && !commsDocBytes) {
+      return null;
+    }
+    if (metadata.version === CHECKPOINT_VERSION && !commentsDocBytes) {
       return null;
     }
     return {
       notebookBytes: new Uint8Array(notebookBytes),
       runtimeStateBytes: new Uint8Array(runtimeStateBytes),
       commsDocBytes: commsDocBytes ? new Uint8Array(commsDocBytes) : undefined,
+      commentsDocBytes: commentsDocBytes ? new Uint8Array(commentsDocBytes) : undefined,
       metadata: {
         version: typeof metadata.version === "number" ? metadata.version : CHECKPOINT_VERSION,
         notebook_heads: Array.isArray(metadata.notebook_heads) ? metadata.notebook_heads : [],
@@ -473,6 +498,9 @@ export class RoomMaterializer {
           ? metadata.runtime_state_heads
           : [],
         comms_doc_heads: Array.isArray(metadata.comms_doc_heads) ? metadata.comms_doc_heads : [],
+        comments_doc_heads: Array.isArray(metadata.comments_doc_heads)
+          ? metadata.comments_doc_heads
+          : [],
         saved_at: typeof metadata.saved_at === "string" ? metadata.saved_at : "",
         published_revision_id:
           typeof metadata.published_revision_id === "string"
@@ -487,6 +515,9 @@ export class RoomMaterializer {
         published_comms_doc_heads: Array.isArray(metadata.published_comms_doc_heads)
           ? metadata.published_comms_doc_heads
           : null,
+        published_comments_doc_heads: Array.isArray(metadata.published_comments_doc_heads)
+          ? metadata.published_comments_doc_heads
+          : null,
       },
     };
   }
@@ -497,6 +528,7 @@ export class RoomMaterializer {
     notebookBytes: Uint8Array;
     runtimeStateBytes: Uint8Array;
     commsDocBytes?: Uint8Array;
+    commentsDocBytes?: Uint8Array;
   } | null> {
     try {
       return await this.loadLatestPublishedSnapshotPair();
@@ -516,6 +548,7 @@ export class RoomMaterializer {
     this.loadedPublishedNotebookHeads = metadata.published_notebook_heads;
     this.loadedPublishedRuntimeStateHeads = metadata.published_runtime_state_heads;
     this.loadedPublishedCommsDocHeads = metadata.published_comms_doc_heads;
+    this.loadedPublishedCommentsDocHeads = metadata.published_comments_doc_heads;
   }
 
   private markLoadedPublishedSnapshot(revisionId: string, host: RoomHostHandle): void {
@@ -523,6 +556,7 @@ export class RoomMaterializer {
     this.loadedPublishedNotebookHeads = Array.from(host.get_heads_hex());
     this.loadedPublishedRuntimeStateHeads = Array.from(host.get_runtime_state_heads_hex());
     this.loadedPublishedCommsDocHeads = Array.from(host.get_comms_doc_heads_hex());
+    this.loadedPublishedCommentsDocHeads = Array.from(host.get_comments_doc_heads_hex());
   }
 
   private async loadLatestPublishedSnapshotPair(): Promise<{
@@ -531,6 +565,7 @@ export class RoomMaterializer {
     notebookBytes: Uint8Array;
     runtimeStateBytes: Uint8Array;
     commsDocBytes?: Uint8Array;
+    commentsDocBytes?: Uint8Array;
   } | null> {
     if (!this.env.DB || !this.env.NOTEBOOK_SNAPSHOTS) {
       return null;
@@ -544,17 +579,26 @@ export class RoomMaterializer {
       return null;
     }
 
-    const [notebookObject, runtimeObject, commsObject] = await Promise.all([
+    const [notebookObject, runtimeObject, commsObject, commentsObject] = await Promise.all([
       this.env.NOTEBOOK_SNAPSHOTS.get(latest.snapshot_key),
       this.env.NOTEBOOK_SNAPSHOTS.get(latest.runtime_snapshot_key),
       latest.comms_snapshot_key ? this.env.NOTEBOOK_SNAPSHOTS.get(latest.comms_snapshot_key) : null,
+      latest.comments_snapshot_key
+        ? this.env.NOTEBOOK_SNAPSHOTS.get(latest.comments_snapshot_key)
+        : null,
     ]);
-    if (!notebookObject || !runtimeObject || (latest.comms_snapshot_key && !commsObject)) {
+    if (
+      !notebookObject ||
+      !runtimeObject ||
+      (latest.comms_snapshot_key && !commsObject) ||
+      (latest.comments_snapshot_key && !commentsObject)
+    ) {
       cloudLog("warn", "room.materializer.snapshot_pair_missing", {
         notebook_id: this.notebookId,
         notebook_snapshot_missing: !notebookObject,
         runtime_state_snapshot_missing: !runtimeObject,
         comms_doc_snapshot_missing: Boolean(latest.comms_snapshot_key && !commsObject),
+        comments_doc_snapshot_missing: Boolean(latest.comments_snapshot_key && !commentsObject),
         counter: "materializer_snapshot_pair_missing",
         counter_delta: 1,
       });
@@ -567,6 +611,9 @@ export class RoomMaterializer {
       notebookBytes: new Uint8Array(await notebookObject.arrayBuffer()),
       runtimeStateBytes: new Uint8Array(await runtimeObject.arrayBuffer()),
       commsDocBytes: commsObject ? new Uint8Array(await commsObject.arrayBuffer()) : undefined,
+      commentsDocBytes: commentsObject
+        ? new Uint8Array(await commentsObject.arrayBuffer())
+        : undefined,
     };
   }
 }
@@ -602,7 +649,8 @@ function isMaterializedSyncFrameForRecovery(type: FrameTypeValue): boolean {
   return (
     type === FrameType.AUTOMERGE_SYNC ||
     type === FrameType.RUNTIME_STATE_SYNC ||
-    type === FrameType.COMMS_DOC_SYNC
+    type === FrameType.COMMS_DOC_SYNC ||
+    type === FrameType.COMMENTS_DOC_SYNC
   );
 }
 
@@ -622,6 +670,8 @@ function frameTypeNameForRecovery(type: FrameTypeValue): string {
       return "runtime_state_sync";
     case FrameType.COMMS_DOC_SYNC:
       return "comms_doc_sync";
+    case FrameType.COMMENTS_DOC_SYNC:
+      return "comments_doc_sync";
     default:
       return `frame_${type}`;
   }
@@ -635,6 +685,7 @@ export function isMaterializedSyncFrame(type: FrameTypeValue): boolean {
     type === FrameType.AUTOMERGE_SYNC ||
     type === FrameType.RUNTIME_STATE_SYNC ||
     type === FrameType.COMMS_DOC_SYNC ||
+    type === FrameType.COMMENTS_DOC_SYNC ||
     type === FrameType.REQUEST
   );
 }
@@ -693,7 +744,8 @@ function hasUnpublishedCheckpointChanges(metadata: RoomCheckpointMetadata): bool
   return (
     headsChanged(metadata.notebook_heads, metadata.published_notebook_heads) ||
     headsChanged(metadata.runtime_state_heads, metadata.published_runtime_state_heads) ||
-    headsChanged(metadata.comms_doc_heads, metadata.published_comms_doc_heads)
+    headsChanged(metadata.comms_doc_heads, metadata.published_comms_doc_heads) ||
+    headsChanged(metadata.comments_doc_heads, metadata.published_comments_doc_heads)
   );
 }
 

--- a/apps/notebook-cloud/src/runtimed-wasm.generated.d.ts
+++ b/apps/notebook-cloud/src/runtimed-wasm.generated.d.ts
@@ -88,9 +88,11 @@ declare module "../../notebook/src/wasm/runtimed-wasm/runtimed_wasm.js" {
     static create_empty(notebookId: string, actorLabel: string): RoomHostHandle;
     static load_snapshot(notebookBytes: Uint8Array, runtimeStateBytes: Uint8Array): RoomHostHandle;
     get_comms_doc_heads_hex(): string[];
+    get_comments_doc_heads_hex(): string[];
     get_heads_hex(): string[];
     get_runtime_state_heads_hex(): string[];
     load_comms_doc(commsBytes: Uint8Array): void;
+    load_comments_doc(commentsBytes: Uint8Array): void;
     receive_peer_frame(
       peerId: string,
       principal: string,
@@ -101,6 +103,7 @@ declare module "../../notebook/src/wasm/runtimed-wasm/runtimed_wasm.js" {
     remove_peer(peerId: string): void;
     save_notebook(): Uint8Array;
     save_comms_doc(): Uint8Array;
+    save_comments_doc(): Uint8Array;
     save_runtime_state_doc(): Uint8Array;
     seed_initial_code_cell_if_empty(cellId: string): boolean;
     sync_peer(

--- a/apps/notebook-cloud/src/runtimed-wasm.ts
+++ b/apps/notebook-cloud/src/runtimed-wasm.ts
@@ -182,11 +182,15 @@ export async function loadRoomHostSnapshot(
   notebookBytes: Uint8Array,
   runtimeStateBytes: Uint8Array,
   commsBytes?: Uint8Array,
+  commentsBytes?: Uint8Array,
 ): Promise<RoomHostHandle> {
   await initializeRuntimedWasm();
   const host = RoomHostHandle.load_snapshot(notebookBytes, runtimeStateBytes);
   if (commsBytes) {
     host.load_comms_doc(commsBytes);
+  }
+  if (commentsBytes) {
+    host.load_comments_doc(commentsBytes);
   }
   return host;
 }

--- a/apps/notebook-cloud/src/storage.ts
+++ b/apps/notebook-cloud/src/storage.ts
@@ -23,9 +23,11 @@ export interface RevisionRow {
   notebook_heads_hash: string;
   runtime_heads_hash: string | null;
   comms_heads_hash: string | null;
+  comments_heads_hash: string | null;
   snapshot_key: string;
   runtime_snapshot_key: string | null;
   comms_snapshot_key: string | null;
+  comments_snapshot_key: string | null;
   actor_label: string;
   created_at: string;
 }
@@ -160,9 +162,11 @@ const SCHEMA_STATEMENTS = [
     notebook_heads_hash TEXT NOT NULL,
     runtime_heads_hash TEXT,
     comms_heads_hash TEXT,
+    comments_heads_hash TEXT,
     snapshot_key TEXT NOT NULL,
     runtime_snapshot_key TEXT,
     comms_snapshot_key TEXT,
+    comments_snapshot_key TEXT,
     actor_label TEXT NOT NULL,
     created_at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ', 'now')),
     FOREIGN KEY (notebook_id) REFERENCES notebooks(id)
@@ -356,6 +360,16 @@ const SCHEMA_MIGRATIONS = [
     table: "notebook_revisions",
     column: "comms_snapshot_key",
     statement: `ALTER TABLE notebook_revisions ADD COLUMN comms_snapshot_key TEXT`,
+  },
+  {
+    table: "notebook_revisions",
+    column: "comments_heads_hash",
+    statement: `ALTER TABLE notebook_revisions ADD COLUMN comments_heads_hash TEXT`,
+  },
+  {
+    table: "notebook_revisions",
+    column: "comments_snapshot_key",
+    statement: `ALTER TABLE notebook_revisions ADD COLUMN comments_snapshot_key TEXT`,
   },
 ];
 
@@ -1453,9 +1467,11 @@ export async function recordRevision(
     notebookHeadsHash: string;
     runtimeHeadsHash: string | null;
     commsHeadsHash: string | null;
+    commentsHeadsHash?: string | null;
     snapshotKey: string;
     runtimeSnapshotKey: string | null;
     commsSnapshotKey: string | null;
+    commentsSnapshotKey?: string | null;
     actorLabel: string;
     publishPublic?: boolean;
   },
@@ -1476,11 +1492,13 @@ export async function recordRevision(
        notebook_heads_hash,
        runtime_heads_hash,
        comms_heads_hash,
+       comments_heads_hash,
        snapshot_key,
        runtime_snapshot_key,
        comms_snapshot_key,
+       comments_snapshot_key,
        actor_label
-     ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+     ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
     ).bind(
       revisionId,
       revision.notebookId,
@@ -1488,9 +1506,11 @@ export async function recordRevision(
       revision.notebookHeadsHash,
       revision.runtimeHeadsHash,
       revision.commsHeadsHash,
+      revision.commentsHeadsHash ?? null,
       revision.snapshotKey,
       revision.runtimeSnapshotKey,
       revision.commsSnapshotKey,
+      revision.commentsSnapshotKey ?? null,
       revision.actorLabel,
     ),
     env.DB.prepare(
@@ -1573,9 +1593,11 @@ export async function getNotebookCatalog(
             notebook_heads_hash,
             runtime_heads_hash,
             comms_heads_hash,
+            comments_heads_hash,
             snapshot_key,
             runtime_snapshot_key,
             comms_snapshot_key,
+            comments_snapshot_key,
             actor_label,
             created_at
        FROM notebook_revisions

--- a/apps/notebook-cloud/test/protocol.test.ts
+++ b/apps/notebook-cloud/test/protocol.test.ts
@@ -24,7 +24,7 @@ const EXPECTED_FRAME_TYPE_ENTRIES = [
   ["SESSION_CONTROL", 0x07, "session_control", false],
   ["PUT_BLOB", 0x08, "put_blob", true],
   ["COMMS_DOC_SYNC", 0x09, "comms_doc_sync", true],
-  ["COMMENTS_DOC_SYNC", 0x0a, "comments_doc_sync", false],
+  ["COMMENTS_DOC_SYNC", 0x0a, "comments_doc_sync", true],
 ] as const satisfies ReadonlyArray<
   readonly [keyof typeof FrameType, FrameTypeValue, string, boolean]
 >;
@@ -40,7 +40,7 @@ const EXPECTED_CLIENT_WRITABLE = {
   0x07: false,
   0x08: true,
   0x09: true,
-  0x0a: false,
+  0x0a: true,
 } as const satisfies Readonly<Record<FrameTypeValue, boolean>>;
 
 describe("typed-frame protocol helpers", () => {
@@ -114,6 +114,7 @@ describe("typed-frame protocol helpers", () => {
     assert.equal(frameSizeLimits(FrameType.AUTOMERGE_SYNC).cap, 64 * 1024 * 1024);
     assert.equal(frameSizeLimits(FrameType.RUNTIME_STATE_SYNC).cap, 64 * 1024 * 1024);
     assert.equal(frameSizeLimits(FrameType.COMMS_DOC_SYNC).cap, 64 * 1024 * 1024);
+    assert.equal(frameSizeLimits(FrameType.COMMENTS_DOC_SYNC).cap, 64 * 1024 * 1024);
     assert.equal(frameSizeLimits(FrameType.PUT_BLOB).cap, 32 * 1024 * 1024);
     assert.equal(frameSizeLimits(FrameType.REQUEST).cap, 16 * 1024 * 1024);
     assert.equal(frameSizeLimits(FrameType.PRESENCE).cap, 4 * 1024);

--- a/apps/notebook-cloud/test/room-materializer.test.ts
+++ b/apps/notebook-cloud/test/room-materializer.test.ts
@@ -723,6 +723,7 @@ describe("RoomMaterializer", () => {
     const keys = [...(await state.storage.list({ prefix: "room-host:" })).keys()].sort();
     assert.deepEqual(keys, [
       "room-host:checkpoint",
+      "room-host:comments-doc",
       "room-host:comms-doc",
       "room-host:notebook-doc",
       "room-host:runtime-state-doc",
@@ -2529,9 +2530,11 @@ function fakePublishedSnapshotEnv(input: {
         notebook_heads_hash: "heads-published",
         runtime_heads_hash: "runtime-published",
         comms_heads_hash: null,
+        comments_heads_hash: null,
         snapshot_key: snapshotKey,
         runtime_snapshot_key: runtimeSnapshotKey,
         comms_snapshot_key: null,
+        comments_snapshot_key: null,
         actor_label: input.actorLabel,
         created_at: "2026-05-28T00:00:00.000Z",
       },
@@ -2580,9 +2583,11 @@ class FakeCatalogD1 implements D1Database {
         notebook_heads_hash: string;
         runtime_heads_hash: string;
         comms_heads_hash: string | null;
+        comments_heads_hash: string | null;
         snapshot_key: string;
         runtime_snapshot_key: string;
         comms_snapshot_key: string | null;
+        comments_snapshot_key: string | null;
         actor_label: string;
         created_at: string;
       };
@@ -2634,6 +2639,8 @@ class FakeCatalogStatement implements D1PreparedStatement {
         { name: "runtime_state_doc_id" },
         { name: "comms_heads_hash" },
         { name: "comms_snapshot_key" },
+        { name: "comments_heads_hash" },
+        { name: "comments_snapshot_key" },
       ] as T[]);
     }
     if (/FROM notebook_revisions/s.test(this.query)) {

--- a/apps/notebook-cloud/test/sharing-storage.test.ts
+++ b/apps/notebook-cloud/test/sharing-storage.test.ts
@@ -1177,6 +1177,8 @@ class FakeD1Statement implements D1PreparedStatement {
         { name: "runtime_state_doc_id" },
         { name: "comms_heads_hash" },
         { name: "comms_snapshot_key" },
+        { name: "comments_heads_hash" },
+        { name: "comments_snapshot_key" },
       ] as T[]);
     }
     if (this.query.includes("FROM principal_profiles")) {

--- a/apps/notebook-cloud/test/worker-routes.test.ts
+++ b/apps/notebook-cloud/test/worker-routes.test.ts
@@ -6243,9 +6243,11 @@ interface RevisionRow {
   notebook_heads_hash: string;
   runtime_heads_hash: string | null;
   comms_heads_hash: string | null;
+  comments_heads_hash: string | null;
   snapshot_key: string;
   runtime_snapshot_key: string | null;
   comms_snapshot_key: string | null;
+  comments_snapshot_key: string | null;
   actor_label: string;
   created_at: string;
 }
@@ -7048,9 +7050,11 @@ class FakeD1Statement implements D1PreparedStatement {
         notebookHeadsHash,
         runtimeHeadsHash,
         commsHeadsHash,
+        commentsHeadsHash,
         snapshotKey,
         runtimeSnapshotKey,
         commsSnapshotKey,
+        commentsSnapshotKey,
         actorLabel,
       ] = this.values as [
         string,
@@ -7059,7 +7063,9 @@ class FakeD1Statement implements D1PreparedStatement {
         string,
         string | null,
         string | null,
+        string | null,
         string,
+        string | null,
         string | null,
         string | null,
         string,
@@ -7071,9 +7077,11 @@ class FakeD1Statement implements D1PreparedStatement {
         notebook_heads_hash: notebookHeadsHash,
         runtime_heads_hash: runtimeHeadsHash,
         comms_heads_hash: commsHeadsHash,
+        comments_heads_hash: commentsHeadsHash,
         snapshot_key: snapshotKey,
         runtime_snapshot_key: runtimeSnapshotKey,
         comms_snapshot_key: commsSnapshotKey,
+        comments_snapshot_key: commentsSnapshotKey,
         actor_label: actorLabel,
         created_at: new Date().toISOString(),
       });

--- a/crates/comments-doc/src/doc.rs
+++ b/crates/comments-doc/src/doc.rs
@@ -29,7 +29,7 @@ const COMMENTS_DOC_SCHEMA_VERSION: u64 = 1;
 const COMMENTS_DOC_GENESIS_V1_BYTES: &[u8] = include_bytes!("../assets/comments_doc_genesis_v1.am");
 const DEFAULT_POSITION: &str = "80";
 
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct CommentsDoc {
     doc: AutoCommit,
     comments_doc_id: String,

--- a/crates/runtimed-wasm/Cargo.toml
+++ b/crates/runtimed-wasm/Cargo.toml
@@ -11,6 +11,7 @@ crate-type = ["cdylib", "rlib"]
 
 [dependencies]
 automerge = { workspace = true }
+comments-doc = { path = "../comments-doc" }
 notebook-doc = { path = "../notebook-doc" }
 notebook-wire = { path = "../notebook-wire" }
 nteract-identity = { path = "../nteract-identity", default-features = false }

--- a/crates/runtimed-wasm/src/lib.rs
+++ b/crates/runtimed-wasm/src/lib.rs
@@ -12,6 +12,7 @@ use automerge::patches::PatchAction;
 use automerge::sync;
 use automerge::sync::SyncDoc;
 use automerge::Prop;
+use comments_doc::{CommentsDoc, NotebookCommentRef};
 use notebook_doc::diff::{
     diff_doc, extract_change_actor_hashes, extract_change_actors, CellChangeset, ChangeActor,
     TextPatch,
@@ -343,7 +344,7 @@ pub enum FrameEvent {
 /// The Worker owns WebSocket I/O; the WASM room host owns document state and
 /// per-peer Automerge sync state. Each event tells the Worker which peer should
 /// receive which typed-frame payload.
-#[derive(Serialize)]
+#[derive(Serialize, Debug)]
 pub struct RoomHostOutboundFrame {
     pub peer_id: String,
     pub frame_type: u8,
@@ -351,7 +352,7 @@ pub struct RoomHostOutboundFrame {
 }
 
 /// Result returned after the room host processes one peer frame.
-#[derive(Serialize)]
+#[derive(Serialize, Debug)]
 pub struct RoomHostFrameResult {
     pub changed: bool,
     pub notebook_changed: bool,
@@ -625,7 +626,7 @@ impl RuntimeStatePeerHandle {
     }
 }
 
-/// Durable-Object room host for NotebookDoc + RuntimeStateDoc + CommsDoc sync.
+/// Durable-Object room host for NotebookDoc + RuntimeStateDoc + CommsDoc + CommentsDoc sync.
 ///
 /// Unlike [`NotebookHandle`], this is not a frontend/client handle. It owns the
 /// authoritative document pair for one room and keeps a separate Automerge
@@ -637,24 +638,30 @@ pub struct RoomHostHandle {
     doc: NotebookDoc,
     state_doc: RuntimeStateDoc,
     comms_doc: CommsDoc,
+    comments_doc: CommentsDoc,
     notebook_peer_states: HashMap<String, sync::State>,
     runtime_peer_states: HashMap<String, sync::State>,
     comms_peer_states: HashMap<String, sync::State>,
+    comments_peer_states: HashMap<String, sync::State>,
 }
 
 #[wasm_bindgen]
 impl RoomHostHandle {
     /// Create an empty room host from the canonical schema seeds.
     pub fn create_empty(notebook_id: &str, actor_label: &str) -> Result<RoomHostHandle, JsError> {
+        let (comments_doc_id, comments_ref) = hosted_comments_identity(notebook_id);
         Ok(RoomHostHandle {
             doc: NotebookDoc::new_with_actor(notebook_id, actor_label),
             state_doc: RuntimeStateDoc::try_new_empty()
                 .map_err(|e| JsError::new(&format!("create runtime state doc failed: {e}")))?,
             comms_doc: CommsDoc::try_new_empty()
                 .map_err(|e| JsError::new(&format!("create comms doc failed: {e}")))?,
+            comments_doc: CommentsDoc::try_new_empty(&comments_doc_id, &comments_ref)
+                .map_err(|e| JsError::new(&format!("create comments doc failed: {e}")))?,
             notebook_peer_states: HashMap::new(),
             runtime_peer_states: HashMap::new(),
             comms_peer_states: HashMap::new(),
+            comments_peer_states: HashMap::new(),
         })
     }
 
@@ -685,14 +692,21 @@ impl RoomHostHandle {
         .map_err(|e| JsError::new(&format!("load notebook snapshot failed: {e}")))?;
         let runtime_doc = automerge::AutoCommit::load(runtime_state_bytes)
             .map_err(|e| JsError::new(&format!("load runtime snapshot failed: {e}")))?;
+        let notebook_id = doc
+            .notebook_id()
+            .ok_or_else(|| JsError::new("load room host snapshot missing notebook_id"))?;
+        let (comments_doc_id, comments_ref) = hosted_comments_identity(&notebook_id);
         Ok(RoomHostHandle {
             doc,
             state_doc: RuntimeStateDoc::from_doc(runtime_doc),
             comms_doc: CommsDoc::try_new_empty()
                 .map_err(|e| JsError::new(&format!("create comms doc failed: {e}")))?,
+            comments_doc: CommentsDoc::try_new_empty(&comments_doc_id, &comments_ref)
+                .map_err(|e| JsError::new(&format!("create comments doc failed: {e}")))?,
             notebook_peer_states: HashMap::new(),
             runtime_peer_states: HashMap::new(),
             comms_peer_states: HashMap::new(),
+            comments_peer_states: HashMap::new(),
         })
     }
 
@@ -701,6 +715,7 @@ impl RoomHostHandle {
         self.notebook_peer_states.remove(peer_id);
         self.runtime_peer_states.remove(peer_id);
         self.comms_peer_states.remove(peer_id);
+        self.comments_peer_states.remove(peer_id);
     }
 
     /// Reconcile the authoritative RuntimeStateDoc after the room's
@@ -784,6 +799,7 @@ impl RoomHostHandle {
             connection_scope.allows_notebook_write(),
             allows_runtime_state_doc_write(connection_scope),
             allows_comms_doc_write(connection_scope),
+            allows_comments_doc_write(connection_scope),
             &mut result.outbound,
         )?;
         serialize_to_js(&result).map_err(|e| JsError::new(&format!("serialize room result: {e}")))
@@ -813,6 +829,7 @@ impl RoomHostHandle {
         let can_write_notebook = connection_scope.allows_notebook_write();
         let can_submit_execution_requests = allows_execution_request_submit(connection_scope);
         let can_write_comms = allows_comms_doc_write(connection_scope);
+        let can_write_comments = allows_comments_doc_write(connection_scope);
         let frame_type = frame_bytes[0];
         let payload = &frame_bytes[1..];
         let result = match frame_type {
@@ -828,6 +845,9 @@ impl RoomHostHandle {
             }
             frame_types::COMMS_DOC_SYNC => {
                 self.receive_comms_doc_sync(peer_id, principal, can_write_comms, payload)?
+            }
+            frame_types::COMMENTS_DOC_SYNC => {
+                self.receive_comments_doc_sync(peer_id, principal, can_write_comments, payload)?
             }
             frame_types::REQUEST => self.receive_request(
                 peer_id,
@@ -856,6 +876,11 @@ impl RoomHostHandle {
         self.comms_doc.doc_mut().save()
     }
 
+    /// Export the current CommentsDoc bytes for room checkpointing.
+    pub fn save_comments_doc(&mut self) -> Vec<u8> {
+        self.comments_doc.save()
+    }
+
     /// Replace the current CommsDoc from checkpointed bytes.
     pub fn load_comms_doc(&mut self, comms_bytes: &[u8]) -> Result<(), JsError> {
         let comms_doc = automerge::AutoCommit::load(comms_bytes)
@@ -863,6 +888,12 @@ impl RoomHostHandle {
         self.comms_doc = CommsDoc::from_doc(comms_doc);
         self.comms_peer_states.clear();
         Ok(())
+    }
+
+    /// Replace the current CommentsDoc from checkpointed bytes.
+    pub fn load_comments_doc(&mut self, comments_bytes: &[u8]) -> Result<(), JsError> {
+        self.load_comments_doc_inner(comments_bytes)
+            .map_err(|error| JsError::new(&error))
     }
 
     /// Current NotebookDoc heads as hex strings.
@@ -887,9 +918,36 @@ impl RoomHostHandle {
             .map(|head| hex::encode(head.as_ref()))
             .collect()
     }
+
+    /// Current CommentsDoc heads as hex strings.
+    pub fn get_comments_doc_heads_hex(&mut self) -> Vec<String> {
+        self.comments_doc
+            .get_heads()
+            .into_iter()
+            .map(|head| hex::encode(head.as_ref()))
+            .collect()
+    }
 }
 
 impl RoomHostHandle {
+    fn expected_comments_doc_id_string(&self) -> Result<String, String> {
+        self.doc
+            .notebook_id()
+            .map(|notebook_id| hosted_comments_doc_id(&notebook_id))
+            .ok_or_else(|| "room host notebook is missing notebook_id".to_string())
+    }
+
+    fn load_comments_doc_inner(&mut self, comments_bytes: &[u8]) -> Result<(), String> {
+        let expected_comments_doc_id = self.expected_comments_doc_id_string()?;
+        let actor = notebook_doc::actor_label_from_id(self.comments_doc.doc().get_actor());
+        let comments_doc =
+            CommentsDoc::load_with_actor(comments_bytes, &expected_comments_doc_id, &actor)
+                .map_err(|e| format!("load comments snapshot failed: {e}"))?;
+        self.comments_doc = comments_doc;
+        self.comments_peer_states.clear();
+        Ok(())
+    }
+
     fn receive_notebook_sync(
         &mut self,
         peer_id: &str,
@@ -1087,6 +1145,81 @@ impl RoomHostHandle {
         self.queue_comms_doc_sync_for_peer(peer_id, can_write, &mut result.outbound)?;
         if changed {
             self.queue_comms_doc_sync_for_other_peers(peer_id, &mut result.outbound)?;
+        }
+        Ok(result)
+    }
+
+    fn receive_comments_doc_sync(
+        &mut self,
+        peer_id: &str,
+        principal: &str,
+        can_write: bool,
+        payload: &[u8],
+    ) -> Result<RoomHostFrameResult, JsError> {
+        self.receive_comments_doc_sync_inner(peer_id, principal, can_write, payload)
+            .map_err(|error| JsError::new(&error))
+    }
+
+    fn receive_comments_doc_sync_inner(
+        &mut self,
+        peer_id: &str,
+        principal: &str,
+        can_write: bool,
+        payload: &[u8],
+    ) -> Result<RoomHostFrameResult, String> {
+        let message =
+            sync::Message::decode(payload).map_err(|e| format!("decode comments doc sync: {e}"))?;
+        let has_changes = !message.changes.is_empty();
+        if has_changes && !can_write {
+            return Err("connection scope cannot write CommentsDoc changes".to_string());
+        }
+        if has_changes {
+            let heads_before = self.comments_doc.get_heads();
+            let peer_state = self
+                .comments_peer_states
+                .entry(peer_id.to_string())
+                .or_insert_with(|| room_peer_sync_state(can_write));
+            let mut preview = self.comments_doc.clone();
+            let mut preview_peer_state = peer_state.clone();
+            preview
+                .receive_sync_message_with_changes_recovering(
+                    &mut preview_peer_state,
+                    message.clone(),
+                    "cloud-room-comments-auth-preview",
+                )
+                .map_err(|e| format!("comments auth preview failed: {e}"))?;
+            let actors = extract_change_actors(preview.doc_mut(), &heads_before);
+            validate_room_actor_labels_inner(principal, actors.iter().map(String::as_str))?;
+        }
+
+        let heads_before = self.comments_doc.get_heads();
+        {
+            let peer_state = self
+                .comments_peer_states
+                .entry(peer_id.to_string())
+                .or_insert_with(|| room_peer_sync_state(can_write));
+            self.comments_doc
+                .receive_sync_message_with_changes_recovering(
+                    peer_state,
+                    message,
+                    "cloud-room-comments-receive-sync",
+                )
+                .map_err(|e| format!("receive comments doc sync: {e}"))?;
+        }
+        let heads_after = self.comments_doc.get_heads();
+        let changed = heads_before != heads_after;
+
+        let mut result = RoomHostFrameResult {
+            changed,
+            notebook_changed: false,
+            runtime_state_changed: false,
+            outbound: Vec::new(),
+        };
+        self.queue_comments_doc_sync_for_peer(peer_id, can_write, &mut result.outbound)
+            .map_err(|error| format!("{error:?}"))?;
+        if changed {
+            self.queue_comments_doc_sync_for_other_peers(peer_id, &mut result.outbound)
+                .map_err(|error| format!("{error:?}"))?;
         }
         Ok(result)
     }
@@ -1398,11 +1531,13 @@ impl RoomHostHandle {
         can_write_notebook: bool,
         can_write_runtime_state: bool,
         can_write_comms: bool,
+        can_write_comments: bool,
         outbound: &mut Vec<RoomHostOutboundFrame>,
     ) -> Result<(), JsError> {
         self.queue_notebook_sync_for_peer(peer_id, can_write_notebook, outbound)?;
         self.queue_runtime_state_sync_for_peer(peer_id, can_write_runtime_state, outbound)?;
         self.queue_comms_doc_sync_for_peer(peer_id, can_write_comms, outbound)?;
+        self.queue_comments_doc_sync_for_peer(peer_id, can_write_comments, outbound)?;
         Ok(())
     }
 
@@ -1519,6 +1654,45 @@ impl RoomHostHandle {
                 continue;
             }
             self.queue_comms_doc_sync_for_peer(&peer_id, true, outbound)?;
+        }
+        Ok(())
+    }
+
+    fn queue_comments_doc_sync_for_peer(
+        &mut self,
+        peer_id: &str,
+        can_write: bool,
+        outbound: &mut Vec<RoomHostOutboundFrame>,
+    ) -> Result<(), JsError> {
+        let peer_state = self
+            .comments_peer_states
+            .entry(peer_id.to_string())
+            .or_insert_with(|| room_peer_sync_state(can_write));
+        if let Some(message) = self
+            .comments_doc
+            .generate_sync_message_recovering(peer_state, "cloud-room-comments-sync-outbound")
+            .map_err(|e| JsError::new(&format!("generate comments doc sync: {e}")))?
+        {
+            outbound.push(RoomHostOutboundFrame {
+                peer_id: peer_id.to_string(),
+                frame_type: frame_types::COMMENTS_DOC_SYNC,
+                payload: message.encode(),
+            });
+        }
+        Ok(())
+    }
+
+    fn queue_comments_doc_sync_for_other_peers(
+        &mut self,
+        changed_peer_id: &str,
+        outbound: &mut Vec<RoomHostOutboundFrame>,
+    ) -> Result<(), JsError> {
+        let peers: Vec<String> = self.comments_peer_states.keys().cloned().collect();
+        for peer_id in peers {
+            if peer_id == changed_peer_id {
+                continue;
+            }
+            self.queue_comments_doc_sync_for_peer(&peer_id, true, outbound)?;
         }
         Ok(())
     }
@@ -1714,26 +1888,48 @@ fn allows_comms_doc_write(scope: ConnectionScope) -> bool {
     )
 }
 
+fn allows_comments_doc_write(scope: ConnectionScope) -> bool {
+    matches!(scope, ConnectionScope::Editor | ConnectionScope::Owner)
+}
+
+fn hosted_comments_doc_id(notebook_id: &str) -> String {
+    format!("comments:{notebook_id}")
+}
+
+fn hosted_comments_identity(notebook_id: &str) -> (String, NotebookCommentRef) {
+    (
+        hosted_comments_doc_id(notebook_id),
+        NotebookCommentRef::HostedRoom {
+            room_locator: notebook_id.to_string(),
+        },
+    )
+}
+
 fn validate_room_actor_labels<'a>(
     principal: &str,
     labels: impl IntoIterator<Item = &'a str>,
 ) -> Result<(), JsError> {
+    validate_room_actor_labels_inner(principal, labels).map_err(|error| JsError::new(&error))
+}
+
+fn validate_room_actor_labels_inner<'a>(
+    principal: &str,
+    labels: impl IntoIterator<Item = &'a str>,
+) -> Result<(), String> {
     let expected = Principal::new(principal.to_string())
-        .map_err(|e| JsError::new(&format!("authenticated principal is invalid: {e}")))?;
+        .map_err(|e| format!("authenticated principal is invalid: {e}"))?;
     for label in labels {
         match ActorLabel::parse(label.to_string()) {
             Ok(actor) if actor.principal() == expected.as_str() => {}
             Ok(actor) => {
-                return Err(JsError::new(&format!(
+                return Err(format!(
                     "actor principal {} is not authorized for authenticated principal {}",
                     actor.principal(),
                     expected
-                )));
+                ));
             }
             Err(error) => {
-                return Err(JsError::new(&format!(
-                    "actor label {label:?} is invalid: {error}"
-                )));
+                return Err(format!("actor label {label:?} is invalid: {error}"));
             }
         }
     }
@@ -4564,6 +4760,299 @@ mod tests {
         assert!(host.doc.get_cell("cell-second").is_none());
     }
 
+    #[test]
+    fn room_host_accepts_editor_comments_doc_change_fans_out_and_persists() {
+        let mut host = RoomHostHandle::create_empty("demo", "system/schema:notebook-cloud-room")
+            .expect("create room host");
+        let mut editor = hosted_comments_client("demo", "user:dev:alice/browser:a");
+        let mut editor_state = sync::State::new();
+        let mut viewer = hosted_comments_client("demo", "user:dev:bob/browser:b");
+        let mut viewer_state = sync::State::new();
+
+        sync_comments_doc_with_host(
+            &mut host,
+            "peer-editor",
+            "user:dev:alice",
+            true,
+            &mut editor,
+            &mut editor_state,
+        );
+        sync_comments_doc_with_host(
+            &mut host,
+            "peer-viewer",
+            "user:dev:bob",
+            true,
+            &mut viewer,
+            &mut viewer_state,
+        );
+
+        editor
+            .create_thread(
+                "thread-1",
+                "message-1",
+                &comments_doc::CommentAnchor::Notebook,
+                "ship the comments path",
+                None,
+                "2026-06-18T00:00:00Z",
+            )
+            .expect("create comment");
+
+        let accepted = apply_comments_client_change_to_host(
+            &mut host,
+            "peer-editor",
+            "user:dev:alice",
+            true,
+            &mut editor,
+            &mut editor_state,
+        )
+        .expect("editor comment accepted");
+        assert!(accepted.changed);
+        assert!(accepted.outbound.iter().any(|frame| {
+            frame.peer_id == "peer-viewer" && frame.frame_type == frame_types::COMMENTS_DOC_SYNC
+        }));
+
+        apply_comments_outbound_to_client(
+            &accepted.outbound,
+            "peer-viewer",
+            &mut viewer,
+            &mut viewer_state,
+        );
+        let viewer_projection = viewer.read_projection(None).expect("viewer projection");
+        assert_eq!(viewer_projection.threads.len(), 1);
+        assert_eq!(
+            viewer_projection.threads[0]
+                .created_by_actor_label
+                .as_deref(),
+            Some("user:dev:alice/browser:a")
+        );
+        assert_eq!(
+            viewer_projection.threads[0].messages[0].body,
+            "ship the comments path"
+        );
+
+        let saved = host.save_comments_doc();
+        let mut reloaded =
+            RoomHostHandle::create_empty("demo", "system/schema:notebook-cloud-room")
+                .expect("create reloaded room host");
+        reloaded
+            .load_comments_doc(&saved)
+            .expect("load saved comments doc");
+        let projection = reloaded
+            .comments_doc
+            .read_projection(None)
+            .expect("reloaded projection");
+        assert_eq!(projection.threads.len(), 1);
+        assert_eq!(projection.threads[0].id, "thread-1");
+    }
+
+    #[test]
+    fn room_host_rejects_forged_comments_doc_change_without_applying() {
+        let mut host = RoomHostHandle::create_empty("demo", "system/schema:notebook-cloud-room")
+            .expect("create room host");
+        let mut forged = comments_doc_from_host(&mut host, "user:dev:mallory/browser:m");
+        let mut forged_state = sync::State::new();
+        sync_comments_doc_with_host(
+            &mut host,
+            "peer-alice",
+            "user:dev:alice",
+            true,
+            &mut forged,
+            &mut forged_state,
+        );
+        forged
+            .create_thread(
+                "thread-forged",
+                "message-forged",
+                &comments_doc::CommentAnchor::Notebook,
+                "not alice",
+                None,
+                "2026-06-18T00:00:00Z",
+            )
+            .expect("create forged comment");
+
+        let error = apply_comments_client_change_to_host(
+            &mut host,
+            "peer-alice",
+            "user:dev:alice",
+            true,
+            &mut forged,
+            &mut forged_state,
+        )
+        .expect_err("forged actor should be rejected");
+        let error_text = format!("{error:?}");
+        assert!(
+            error_text.contains("authenticated principal user:dev:alice"),
+            "unexpected error: {error:?}"
+        );
+        assert!(host
+            .comments_doc
+            .read_projection(None)
+            .expect("host projection")
+            .threads
+            .is_empty());
+    }
+
+    #[test]
+    fn room_host_rejects_mixed_author_comments_doc_payload_wholesale() {
+        let mut host = RoomHostHandle::create_empty("demo", "system/schema:notebook-cloud-room")
+            .expect("create room host");
+        let mut mixed = comments_doc_from_host(&mut host, "user:dev:alice/browser:a");
+        let mut mixed_state = sync::State::new();
+        sync_comments_doc_with_host(
+            &mut host,
+            "peer-alice",
+            "user:dev:alice",
+            true,
+            &mut mixed,
+            &mut mixed_state,
+        );
+        mixed
+            .create_thread(
+                "thread-alice",
+                "message-alice",
+                &comments_doc::CommentAnchor::Notebook,
+                "from alice",
+                None,
+                "2026-06-18T00:00:00Z",
+            )
+            .expect("create alice comment");
+        mixed.doc_mut().set_actor(automerge::ActorId::from(
+            "user:dev:mallory/browser:m".as_bytes(),
+        ));
+        mixed
+            .create_thread(
+                "thread-mallory",
+                "message-mallory",
+                &comments_doc::CommentAnchor::Notebook,
+                "from mallory",
+                None,
+                "2026-06-18T00:00:01Z",
+            )
+            .expect("create mallory comment");
+
+        let error = apply_comments_client_change_to_host(
+            &mut host,
+            "peer-alice",
+            "user:dev:alice",
+            true,
+            &mut mixed,
+            &mut mixed_state,
+        )
+        .expect_err("mixed actor payload should be rejected");
+        let error_text = format!("{error:?}");
+        assert!(
+            error_text.contains("user:dev:mallory"),
+            "unexpected error: {error:?}"
+        );
+        assert!(host
+            .comments_doc
+            .read_projection(None)
+            .expect("host projection")
+            .threads
+            .is_empty());
+    }
+
+    #[test]
+    fn room_host_rejects_viewer_comments_doc_change() {
+        let mut host = RoomHostHandle::create_empty("demo", "system/schema:notebook-cloud-room")
+            .expect("create room host");
+        let mut viewer = comments_doc_from_host(&mut host, "user:dev:bob/browser:b");
+        let heads_before = host.comments_doc.get_heads();
+        viewer
+            .create_thread(
+                "thread-viewer",
+                "message-viewer",
+                &comments_doc::CommentAnchor::Notebook,
+                "viewer cannot write",
+                None,
+                "2026-06-18T00:00:00Z",
+            )
+            .expect("create viewer comment");
+        let payload = comments_change_payload(&mut viewer, &heads_before);
+        let error = host
+            .receive_comments_doc_sync_inner("peer-viewer", "user:dev:bob", false, &payload)
+            .expect_err("viewer comment should be rejected");
+        let error_text = format!("{error:?}");
+        assert!(
+            error_text.contains("cannot write CommentsDoc"),
+            "unexpected error: {error:?}"
+        );
+        assert!(host
+            .comments_doc
+            .read_projection(None)
+            .expect("host projection")
+            .threads
+            .is_empty());
+    }
+
+    #[test]
+    fn room_host_rejects_runtime_peer_comments_doc_change() {
+        let mut host = RoomHostHandle::create_empty("demo", "system/schema:notebook-cloud-room")
+            .expect("create room host");
+        let mut runtime_peer = comments_doc_from_host(&mut host, "user:dev:runtime/runtime:py");
+        let mut runtime_state = sync::State::new();
+        sync_comments_doc_with_host(
+            &mut host,
+            "peer-runtime",
+            "user:dev:runtime",
+            true,
+            &mut runtime_peer,
+            &mut runtime_state,
+        );
+        runtime_peer
+            .create_thread(
+                "thread-runtime",
+                "message-runtime",
+                &comments_doc::CommentAnchor::Notebook,
+                "runtime peer cannot write",
+                None,
+                "2026-06-18T00:00:00Z",
+            )
+            .expect("create runtime peer comment");
+        runtime_state = sync::State::new();
+
+        let error = apply_comments_client_change_to_host(
+            &mut host,
+            "peer-runtime",
+            "user:dev:runtime",
+            false,
+            &mut runtime_peer,
+            &mut runtime_state,
+        )
+        .expect_err("runtime peer comment should be rejected");
+        let error_text = format!("{error:?}");
+        assert!(
+            error_text.contains("cannot write CommentsDoc"),
+            "unexpected error: {error:?}"
+        );
+        assert!(host
+            .comments_doc
+            .read_projection(None)
+            .expect("host projection")
+            .threads
+            .is_empty());
+    }
+
+    #[test]
+    fn room_host_rejects_comments_doc_checkpoint_with_wrong_id() {
+        let mut host = RoomHostHandle::create_empty("demo", "system/schema:notebook-cloud-room")
+            .expect("create room host");
+        let wrong_ref = NotebookCommentRef::HostedRoom {
+            room_locator: "other".to_string(),
+        };
+        let mut wrong_doc =
+            CommentsDoc::new_with_actor("comments:other", &wrong_ref, "user:dev:alice/browser:a");
+        let bytes = wrong_doc.save();
+
+        let error = host
+            .load_comments_doc_inner(&bytes)
+            .expect_err("wrong comments_doc_id should be rejected");
+        assert!(
+            error.contains("comments_doc_id mismatch"),
+            "unexpected error: {error:?}"
+        );
+    }
+
     // -- runtime_peer-gone reconciliation (Phase 3d watchdog core) --------
 
     use runtime_doc::KernelActivity;
@@ -4608,6 +5097,131 @@ mod tests {
             updated_at: Some("2026-06-07T00:00:00.000Z".to_string()),
             runtime_session_id: Some("job-runtime".to_string()),
         }
+    }
+
+    fn hosted_comments_client(notebook_id: &str, actor_label: &str) -> CommentsDoc {
+        let (comments_doc_id, notebook_ref) = hosted_comments_identity(notebook_id);
+        CommentsDoc::new_with_actor(&comments_doc_id, &notebook_ref, actor_label)
+    }
+
+    fn comments_doc_from_host(host: &mut RoomHostHandle, actor_label: &str) -> CommentsDoc {
+        let comments_doc_id = host
+            .expected_comments_doc_id_string()
+            .expect("host comments doc id");
+        let bytes = host.save_comments_doc();
+        CommentsDoc::load_with_actor(&bytes, &comments_doc_id, actor_label)
+            .expect("load comments doc from host")
+    }
+
+    fn sync_comments_doc_with_host(
+        host: &mut RoomHostHandle,
+        peer_id: &str,
+        principal: &str,
+        can_write: bool,
+        client: &mut CommentsDoc,
+        client_state: &mut sync::State,
+    ) {
+        let mut outbound = Vec::new();
+        host.queue_comments_doc_sync_for_peer(peer_id, can_write, &mut outbound)
+            .expect("queue comments sync");
+        for _ in 0..8 {
+            let replies =
+                apply_comments_outbound_to_client(&outbound, peer_id, client, client_state);
+            if replies.is_empty() {
+                return;
+            }
+            outbound = Vec::new();
+            for reply in replies {
+                let result = host
+                    .receive_comments_doc_sync(peer_id, principal, can_write, &reply)
+                    .expect("apply comments sync reply");
+                outbound.extend(result.outbound);
+            }
+        }
+    }
+
+    fn apply_comments_client_change_to_host(
+        host: &mut RoomHostHandle,
+        peer_id: &str,
+        principal: &str,
+        can_write: bool,
+        client: &mut CommentsDoc,
+        client_state: &mut sync::State,
+    ) -> Result<RoomHostFrameResult, String> {
+        let mut last = RoomHostFrameResult::empty();
+        for _ in 0..8 {
+            let Some(message) = client.generate_sync_message(client_state) else {
+                continue;
+            };
+            let result = host.receive_comments_doc_sync_inner(
+                peer_id,
+                principal,
+                can_write,
+                &message.encode(),
+            )?;
+            if result.changed {
+                return Ok(result);
+            }
+            let replies =
+                apply_comments_outbound_to_client(&result.outbound, peer_id, client, client_state);
+            last = result;
+            for reply in replies {
+                let next =
+                    host.receive_comments_doc_sync_inner(peer_id, principal, can_write, &reply)?;
+                if next.changed {
+                    return Ok(next);
+                }
+                last = next;
+            }
+        }
+        if last.outbound.is_empty() {
+            Err("comments doc change did not produce sync message".to_string())
+        } else {
+            Ok(last)
+        }
+    }
+
+    fn apply_comments_outbound_to_client(
+        outbound: &[RoomHostOutboundFrame],
+        peer_id: &str,
+        client: &mut CommentsDoc,
+        client_state: &mut sync::State,
+    ) -> Vec<Vec<u8>> {
+        let mut replies = Vec::new();
+        for frame in outbound {
+            if frame.peer_id != peer_id || frame.frame_type != frame_types::COMMENTS_DOC_SYNC {
+                continue;
+            }
+            let message = sync::Message::decode(&frame.payload).expect("decode comments sync");
+            let _ = client
+                .receive_sync_message_with_changes_recovering(
+                    client_state,
+                    message,
+                    "comments-test-client-receive",
+                )
+                .expect("client receive comments sync");
+            if let Some(reply) = client.generate_sync_message(client_state) {
+                replies.push(reply.encode());
+            }
+        }
+        replies
+    }
+
+    fn comments_change_payload(
+        client: &mut CommentsDoc,
+        heads_before: &[automerge::ChangeHash],
+    ) -> Vec<u8> {
+        let changes = client.doc_mut().save_after(heads_before);
+        assert!(!changes.is_empty(), "expected incremental comments changes");
+        sync::Message {
+            heads: client.get_heads(),
+            need: Vec::new(),
+            have: Vec::new(),
+            changes: sync::ChunkList::from(changes),
+            flags: None,
+            version: sync::MessageVersion::V1,
+        }
+        .encode()
     }
 
     #[test]
@@ -4942,7 +5556,7 @@ mod tests {
         // Register a runtime peer so the accepted queue is fanned out to the
         // executor as well as visible to the browser peer.
         let mut initial = Vec::new();
-        host.queue_current_sync_for_peer("runtime-peer", false, true, true, &mut initial)
+        host.queue_current_sync_for_peer("runtime-peer", false, true, true, false, &mut initial)
             .expect("initial runtime peer sync");
 
         let supplied = "22222222-2222-4222-8222-222222222222";
@@ -5032,7 +5646,7 @@ mod tests {
         // the initial sync advances that peer's room-host sync state, so a
         // later ExecuteCell should fan out only the new queued execution.
         let mut initial = Vec::new();
-        host.queue_current_sync_for_peer("runtime-peer", false, true, true, &mut initial)
+        host.queue_current_sync_for_peer("runtime-peer", false, true, true, false, &mut initial)
             .expect("initial runtime peer sync");
         assert!(
             initial

--- a/crates/xtask/src/main.rs
+++ b/crates/xtask/src/main.rs
@@ -1883,6 +1883,10 @@ const GENESIS_SEEDS_IN_WASM: &[(&str, &str)] = &[
         "comms-doc genesis",
         "crates/runtime-doc/assets/comms_doc_genesis_v1.am",
     ),
+    (
+        "comments-doc genesis",
+        "crates/comments-doc/assets/comments_doc_genesis_v1.am",
+    ),
 ];
 
 const RUNTIMED_WASM_BINARY: &str = "apps/notebook/src/wasm/runtimed-wasm/runtimed_wasm_bg.wasm";
@@ -3460,6 +3464,9 @@ const RUNTIMED_WASM_INPUTS: &[&str] = &[
     "crates/automerge-recovery/src",
     "crates/automunge/Cargo.toml",
     "crates/automunge/src",
+    "crates/comments-doc/Cargo.toml",
+    "crates/comments-doc/assets",
+    "crates/comments-doc/src",
     "crates/notebook-doc/Cargo.toml",
     "crates/notebook-doc/assets",
     "crates/notebook-doc/src",


### PR DESCRIPTION
Wire the hosted (cloud) room host to hold, validate, persist, and fan out a per-room `CommentsDoc`, mirroring the existing `CommsDoc` path. Slice of the [comments rollout](https://github.com/nteract/nteract/blob/main/docs/plans/comments-rollout.md); the cloud rung, on top of the merged comments-doc core.

## Server half, standalone, on purpose

This is the **room-host (server) side only**. The browser client does not yet handle frame `0x0a`, so the room host emits comment frames that current clients harmlessly ignore (unknown frames are tolerated, the property the `0x0a` reservation established). Landing it standalone is intentional: it lets us deploy and observe lagging-client behavior in the prototype before the client lands. The client receive / render / send path is the next slice.

## Gates move together

Per review, the four cloud gates open in one change so an admitted frame is never left to fall through to an unguarded broadcast:
- `protocol.ts`: `COMMENTS_DOC_SYNC` becomes client-writable.
- `notebook-room.ts`: `scopeAllowsFrame` admits it (enforcement deferred to the WASM host).
- `room-materializer.ts`: routed through `isMaterializedSyncFrame` (+ the recovery path), plus DO checkpoint and R2 published-snapshot wiring.
- `runtimed-wasm`: a `CommentsDoc` replica + `receive_comments_doc_sync` + per-peer fan-out.

## Trust is inherited, not reinvented

`receive_comments_doc_sync` mirrors `receive_comms_doc_sync`'s actor-binding: it applies the inbound payload to a clone, extracts the change actors, and rejects the whole payload unless every actor matches the authenticated connection principal, all before any live apply. A forged or mixed-author payload touches nothing.

## Where it differs from CommsDoc (by design)

- `comments_doc_id` = `comments:<notebook_id>`, supplied at construction (the strong hosted identity).
- `runtime_peer` connections may **not** write comments (only editor/owner); CommsDoc allows runtime peers for widget state.
- A restored sidecar is validated with `load_with_actor`.
- `CHECKPOINT_VERSION` bumps to 6; the comments-doc crate + genesis asset are added to the `runtimed-wasm` rebuild fingerprint and genesis-seed verification so a future comments change can't ship a stale wasm bundle.

## Verification

- [x] `cargo build --workspace` clean
- [x] `cargo test -p runtimed-wasm` (67 passed), including the comment ingress security suite: forged-actor, mixed-author-wholesale, viewer, runtime_peer, and wrong-id-checkpoint rejection, plus the editor accept/fan-out/persist round-trip
- [x] `cargo clippy -p runtimed-wasm` / `xtask` clean, `cargo fmt` applied
- [x] cloud `protocol.test.ts` (5/5)
- [x] `codex review` (its findings addressed: the wasm fingerprint fix is included; the client-side gap is this PR's explicit non-goal)
- Cloud room-materializer/worker tests verify in CI (need the built wasm bundle)
