### PR TITLE
feat(notebook-cloud): resolve comment author display names from presence

### DIFF
--- a/apps/notebook-cloud/viewer/notebook-viewer.tsx
+++ b/apps/notebook-cloud/viewer/notebook-viewer.tsx
@@ -38,10 +38,12 @@ import {
   setFocusedCellId,
   useFocusedCellId,
   useNotebookViewModel,
+  type CommentAuthor,
   type CommentAnchor,
   type CommentThreadSnapshot,
   type CommentsProjection,
 } from "@/components/notebook";
+import { peerColor } from "@/components/editor/remote-cursors";
 import {
   openNotebookRailPanel,
   setActiveNotebookRailPanel,
@@ -53,6 +55,7 @@ import { useTheme } from "@/hooks/useTheme";
 import { EnvironmentSummary } from "@/components/environment";
 import {
   NotebookClient,
+  resolveActorDisplay,
   workstationAttachmentCanExecute,
   workstationAttachmentIsConnected,
   type CellChangeset,
@@ -537,6 +540,33 @@ export function NotebookViewer({
     presenceStore.subscribe,
     presenceStore.getSnapshot,
     presenceStore.getSnapshot,
+  );
+  const commentAuthorPeers = useMemo(
+    () =>
+      presenceSnapshot.peers.map((peer) => ({
+        participantKey: peer.participantKey,
+        label: peer.label,
+      })),
+    [presenceSnapshot.peers],
+  );
+  const resolveCloudCommentAuthor = useCallback(
+    (actorLabel: string): CommentAuthor => {
+      const display = resolveActorDisplay({
+        actorLabel,
+        peers: commentAuthorPeers,
+        source: "cloud",
+      });
+      const principalColor = peerColor(display.principalId);
+
+      return {
+        displayName: display.displayName,
+        color: principalColor,
+        isAgent: display.isAgent,
+        onBehalfOf: display.onBehalfOf,
+        onBehalfOfColor: display.onBehalfOf ? principalColor : undefined,
+      };
+    },
+    [commentAuthorPeers],
   );
   const runtimeState = useRuntimeState();
   // Deduplicated shared projection — re-renders only when attachment facts
@@ -1489,6 +1519,7 @@ export function NotebookViewer({
       onResolveThread={canWriteComments ? handleResolveCommentThread : undefined}
       onReopenThread={canWriteComments ? handleReopenCommentThread : undefined}
       onFocusThreadAnchor={handleFocusCommentAnchor}
+      resolveCommentAuthor={resolveCloudCommentAuthor}
     />
   );
   const rail = (

--- a/packages/runtimed/src/index.ts
+++ b/packages/runtimed/src/index.ts
@@ -290,6 +290,14 @@ export {
   type ParsedNotebookActorLabel,
 } from "./notebook-actor-projection";
 
+// Notebook actor display
+export {
+  resolveActorDisplay,
+  type ActorDisplay,
+  type ActorDisplayPeer,
+  type ResolveActorDisplayOptions,
+} from "./notebook-actor-display";
+
 // Notebook shell capability projection
 export {
   notebookShellRuntimeTargetSummary,

--- a/packages/runtimed/src/notebook-actor-display.ts
+++ b/packages/runtimed/src/notebook-actor-display.ts
@@ -1,0 +1,54 @@
+import {
+  notebookActorIdentityFromProjection,
+  notebookActorProjectionFromLabel,
+  type NotebookActorKind,
+} from "./notebook-actor-projection";
+
+export interface ActorDisplayPeer {
+  participantKey: string;
+  label: string;
+}
+
+export interface ResolveActorDisplayOptions {
+  actorLabel: string;
+  peers: ReadonlyArray<ActorDisplayPeer>;
+  source: "cloud" | "local";
+}
+
+export interface ActorDisplay {
+  displayName: string;
+  principalId: string;
+  kind: NotebookActorKind;
+  isAgent: boolean;
+  onBehalfOf: string | null;
+}
+
+export function resolveActorDisplay({
+  actorLabel,
+  peers,
+  source,
+}: ResolveActorDisplayOptions): ActorDisplay {
+  const projection = notebookActorProjectionFromLabel(actorLabel, { source });
+  const identity = notebookActorIdentityFromProjection(projection);
+  const principalId = projection.principal.id;
+  const peerLabel = peerLabelForPrincipal(peers, principalId);
+  const principalDisplayName = peerLabel ?? projection.principal.label;
+  const isAgent = identity.kind === "agent";
+
+  return {
+    displayName: isAgent ? (identity.operatorLabel ?? identity.label) : principalDisplayName,
+    principalId,
+    kind: identity.kind,
+    isAgent,
+    onBehalfOf: isAgent ? (peerLabel ?? identity.principalLabel ?? null) : null,
+  };
+}
+
+function peerLabelForPrincipal(
+  peers: ReadonlyArray<ActorDisplayPeer>,
+  principalId: string,
+): string | null {
+  const peer = peers.find((candidate) => candidate.participantKey === principalId);
+  const label = peer?.label.trim();
+  return label ? label : null;
+}

--- a/packages/runtimed/tests/notebook-actor-display.test.ts
+++ b/packages/runtimed/tests/notebook-actor-display.test.ts
@@ -1,0 +1,59 @@
+import { describe, expect, it } from "vite-plus/test";
+import { resolveActorDisplay } from "../src/notebook-actor-display";
+
+const ANACONDA_PRINCIPAL = "user:anaconda:550e8400-e29b-41d4-a716-446655440000";
+const ANACONDA_ACTOR = `${ANACONDA_PRINCIPAL}/browser:tab-a`;
+
+describe("resolveActorDisplay", () => {
+  it("uses the matching presence peer label for an anaconda principal", () => {
+    expect(
+      resolveActorDisplay({
+        actorLabel: ANACONDA_ACTOR,
+        peers: [{ participantKey: ANACONDA_PRINCIPAL, label: "Kyle Kelley" }],
+        source: "cloud",
+      }),
+    ).toMatchObject({
+      displayName: "Kyle Kelley",
+      principalId: ANACONDA_PRINCIPAL,
+      kind: "human",
+      isAgent: false,
+      onBehalfOf: null,
+    });
+  });
+
+  it("falls back to the friendly anaconda principal label without a peer", () => {
+    expect(
+      resolveActorDisplay({
+        actorLabel: ANACONDA_ACTOR,
+        peers: [],
+        source: "cloud",
+      }).displayName,
+    ).toBe("Anaconda user");
+  });
+
+  it("projects agent authors with an on-behalf-of principal", () => {
+    expect(
+      resolveActorDisplay({
+        actorLabel: "user:dev:kyle%40example.com/agent:codex:s1",
+        peers: [{ participantKey: "user:dev:kyle%40example.com", label: "Kyle Kelley" }],
+        source: "cloud",
+      }),
+    ).toMatchObject({
+      displayName: "Codex",
+      principalId: "user:dev:kyle%40example.com",
+      kind: "agent",
+      isAgent: true,
+      onBehalfOf: "Kyle Kelley",
+    });
+  });
+
+  it("uses a friendly display name for a local human principal", () => {
+    expect(
+      resolveActorDisplay({
+        actorLabel: "user:local:ada/desktop:app",
+        peers: [],
+        source: "local",
+      }).displayName,
+    ).toBe("Ada");
+  });
+});


### PR DESCRIPTION
The cloud comment panel rendered raw actor labels (`user:anaconda:<uuid>/browser:<uuid>`) instead of names: the viewer never passed `resolveCommentAuthor`, and an anaconda principal label carries no human name, the real name lives in presence.

## What it does
- Adds a canonical `resolveActorDisplay({ actorLabel, peers, source })` in `packages/runtimed`: parses the actor projection, looks up the principal in the presence roster (peers keyed by `participantKey == principal id`) for the real display name, falls back to the friendly principal label otherwise. For an agent it returns the operator as the display name and the principal as `onBehalfOf`.
- Wires it into the cloud viewer's `NotebookCommentsPanel` via `resolveCommentAuthor`, pairing the name with `peerColor` for a cursor-consistent color.

## Why this shape
`peers` is a plain `{ participantKey, label }` list, so the resolver is source-agnostic: cloud presence today, an IdP identity map later (ties to the planned principal→IdP direction). `principalId` is the stable hash key shared with cursor colors.

This establishes the single path for label→name conversion; migrating the other five ad hoc sites to it is a follow-up (kept out to stay focused).

## Verification
- [x] `resolveActorDisplay` unit tests (4: human-with-peer, human-fallback "Anaconda user", agent on-behalf-of, local human)
- [x] `packages/runtimed` + `apps/notebook-cloud` typecheck clean
- [x] `vp check` clean
- Reviewed Claude-side (codex implemented); the one finding (test placement) fixed: test follows the `packages/runtimed/tests/` convention rather than broadening the global vitest glob.
