### PR TITLE
fix(comments): soften resolved thread attribution

### DIFF
--- a/apps/elements/components/comment-surfaces-example.tsx
+++ b/apps/elements/components/comment-surfaces-example.tsx
@@ -1,7 +1,11 @@
 "use client";
 
 import { useEffect, useRef, useState } from "react";
-import { NotebookCommentsPanel, type CommentAuthor } from "@/components/notebook";
+import {
+  NotebookCommentsPanel,
+  type CommentAuthor,
+  type ResolvedThreadPresentation,
+} from "@/components/notebook";
 import type { CommentsProjection } from "@/components/notebook/comment-types";
 import { cn } from "@/lib/utils";
 
@@ -12,6 +16,14 @@ const ADA = "local:ada/desktop:1";
 const CLAUDE = "local:ada/agent:claude-code:1";
 const ADA_COLOR = "#16a34a";
 const CLAUDE_COLOR = "#7c3aed";
+const RESOLVED_PRESENTATIONS: Array<{
+  value: ResolvedThreadPresentation;
+  label: string;
+}> = [
+  { value: "timeline", label: "Marked" },
+  { value: "receipt", label: "Compact" },
+  { value: "header", label: "Header" },
+];
 
 function resolveCommentAuthor(actorLabel: string): CommentAuthor {
   if (actorLabel === CLAUDE) {
@@ -102,7 +114,7 @@ const INITIAL: CommentsProjection = {
       created_at: "2026-06-18T14:00:00Z",
       created_by_actor_label: ADA,
       resolved_at: "2026-06-18T14:10:00Z",
-      resolved_by_actor_label: ADA,
+      resolved_by_actor_label: CLAUDE,
       messages: [
         {
           id: "m3",
@@ -124,6 +136,8 @@ function nextId(prefix: string): string {
 
 export function CommentSurfacesExample() {
   const [projection, setProjection] = useState<CommentsProjection>(INITIAL);
+  const [resolvedPresentation, setResolvedPresentation] =
+    useState<ResolvedThreadPresentation>("receipt");
   const nowRef = useRef("2026-06-18T15:30:00Z");
 
   // Quote syntax highlighting is theme-dependent, so the server (light) and the
@@ -140,6 +154,8 @@ export function CommentSurfacesExample() {
           ? {
               ...thread,
               status: "open",
+              resolved_at: null,
+              resolved_by_actor_label: null,
               messages: [
                 ...thread.messages,
                 {
@@ -159,51 +175,94 @@ export function CommentSurfacesExample() {
     setProjection((current) => ({
       ...current,
       threads: current.threads.map((thread) =>
-        thread.id === threadId ? { ...thread, status } : thread,
+        thread.id === threadId
+          ? status === "resolved"
+            ? {
+                ...thread,
+                status,
+                resolved_at: nowRef.current,
+                resolved_by_actor_label: ADA,
+              }
+            : {
+                ...thread,
+                status,
+                resolved_at: null,
+                resolved_by_actor_label: null,
+              }
+          : thread,
       ),
     }));
 
   return (
     <div className={cn("not-prose my-6 flex justify-center")}>
-      <div className="w-[340px] rounded-xl border bg-background p-3.5 shadow-sm">
-        {!mounted ? (
-          <div className="h-[420px]" aria-hidden />
-        ) : (
-          <NotebookCommentsPanel
-            projection={projection}
-            resolveCommentAuthor={resolveCommentAuthor}
-            resolveSourceLanguage={resolveSourceLanguage}
-            onCreateThread={(body) =>
-              setProjection((current) => ({
-                ...current,
-                threads: [
-                  ...current.threads,
-                  {
-                    id: nextId("thread"),
-                    anchor: { kind: "notebook" },
-                    position: nextId("p"),
-                    status: "open",
-                    badge_cell_ids: [],
-                    created_at: nowRef.current,
-                    created_by_actor_label: ADA,
-                    messages: [
-                      {
-                        id: nextId("m"),
-                        position: nextId("p"),
-                        body,
-                        created_at: nowRef.current,
-                        created_by_actor_label: ADA,
-                      },
-                    ],
-                  },
-                ],
-              }))
-            }
-            onReplyThread={appendMessage}
-            onResolveThread={(id) => setStatus(id, "resolved")}
-            onReopenThread={(id) => setStatus(id, "open")}
-          />
-        )}
+      <div className="w-[340px] space-y-3">
+        <div
+          className="grid grid-cols-3 rounded-lg border bg-muted/30 p-1"
+          role="radiogroup"
+          aria-label="Resolved comment treatment"
+        >
+          {RESOLVED_PRESENTATIONS.map((option) => {
+            const selected = resolvedPresentation === option.value;
+            return (
+              <button
+                key={option.value}
+                type="button"
+                role="radio"
+                aria-checked={selected}
+                onClick={() => setResolvedPresentation(option.value)}
+                className={cn(
+                  "rounded-md px-2 py-1.5 text-xs font-medium text-muted-foreground transition-colors",
+                  selected
+                    ? "bg-background text-foreground shadow-sm"
+                    : "hover:bg-background/70 hover:text-foreground",
+                )}
+              >
+                {option.label}
+              </button>
+            );
+          })}
+        </div>
+        <div className="rounded-xl border bg-background p-3.5 shadow-sm">
+          {!mounted ? (
+            <div className="h-[420px]" aria-hidden />
+          ) : (
+            <NotebookCommentsPanel
+              projection={projection}
+              resolveCommentAuthor={resolveCommentAuthor}
+              resolveSourceLanguage={resolveSourceLanguage}
+              resolvedThreadPresentation={resolvedPresentation}
+              onCreateThread={(body) =>
+                setProjection((current) => ({
+                  ...current,
+                  threads: [
+                    ...current.threads,
+                    {
+                      id: nextId("thread"),
+                      anchor: { kind: "notebook" },
+                      position: nextId("p"),
+                      status: "open",
+                      badge_cell_ids: [],
+                      created_at: nowRef.current,
+                      created_by_actor_label: ADA,
+                      messages: [
+                        {
+                          id: nextId("m"),
+                          position: nextId("p"),
+                          body,
+                          created_at: nowRef.current,
+                          created_by_actor_label: ADA,
+                        },
+                      ],
+                    },
+                  ],
+                }))
+              }
+              onReplyThread={appendMessage}
+              onResolveThread={(id) => setStatus(id, "resolved")}
+              onReopenThread={(id) => setStatus(id, "open")}
+            />
+          )}
+        </div>
       </div>
     </div>
   );

--- a/apps/elements/components/comment-surfaces-example.tsx
+++ b/apps/elements/components/comment-surfaces-example.tsx
@@ -1,11 +1,7 @@
 "use client";
 
 import { useEffect, useRef, useState } from "react";
-import {
-  NotebookCommentsPanel,
-  type CommentAuthor,
-  type ResolvedThreadPresentation,
-} from "@/components/notebook";
+import { NotebookCommentsPanel, type CommentAuthor } from "@/components/notebook";
 import type { CommentsProjection } from "@/components/notebook/comment-types";
 import { cn } from "@/lib/utils";
 
@@ -16,14 +12,6 @@ const ADA = "local:ada/desktop:1";
 const CLAUDE = "local:ada/agent:claude-code:1";
 const ADA_COLOR = "#16a34a";
 const CLAUDE_COLOR = "#7c3aed";
-const RESOLVED_PRESENTATIONS: Array<{
-  value: ResolvedThreadPresentation;
-  label: string;
-}> = [
-  { value: "timeline", label: "Marked" },
-  { value: "receipt", label: "Compact" },
-  { value: "header", label: "Header" },
-];
 
 function resolveCommentAuthor(actorLabel: string): CommentAuthor {
   if (actorLabel === CLAUDE) {
@@ -136,8 +124,6 @@ function nextId(prefix: string): string {
 
 export function CommentSurfacesExample() {
   const [projection, setProjection] = useState<CommentsProjection>(INITIAL);
-  const [resolvedPresentation, setResolvedPresentation] =
-    useState<ResolvedThreadPresentation>("receipt");
   const nowRef = useRef("2026-06-18T15:30:00Z");
 
   // Quote syntax highlighting is theme-dependent, so the server (light) and the
@@ -195,74 +181,45 @@ export function CommentSurfacesExample() {
 
   return (
     <div className={cn("not-prose my-6 flex justify-center")}>
-      <div className="w-[340px] space-y-3">
-        <div
-          className="grid grid-cols-3 rounded-lg border bg-muted/30 p-1"
-          role="radiogroup"
-          aria-label="Resolved comment treatment"
-        >
-          {RESOLVED_PRESENTATIONS.map((option) => {
-            const selected = resolvedPresentation === option.value;
-            return (
-              <button
-                key={option.value}
-                type="button"
-                role="radio"
-                aria-checked={selected}
-                onClick={() => setResolvedPresentation(option.value)}
-                className={cn(
-                  "rounded-md px-2 py-1.5 text-xs font-medium text-muted-foreground transition-colors",
-                  selected
-                    ? "bg-background text-foreground shadow-sm"
-                    : "hover:bg-background/70 hover:text-foreground",
-                )}
-              >
-                {option.label}
-              </button>
-            );
-          })}
-        </div>
-        <div className="rounded-xl border bg-background p-3.5 shadow-sm">
-          {!mounted ? (
-            <div className="h-[420px]" aria-hidden />
-          ) : (
-            <NotebookCommentsPanel
-              projection={projection}
-              resolveCommentAuthor={resolveCommentAuthor}
-              resolveSourceLanguage={resolveSourceLanguage}
-              resolvedThreadPresentation={resolvedPresentation}
-              onCreateThread={(body) =>
-                setProjection((current) => ({
-                  ...current,
-                  threads: [
-                    ...current.threads,
-                    {
-                      id: nextId("thread"),
-                      anchor: { kind: "notebook" },
-                      position: nextId("p"),
-                      status: "open",
-                      badge_cell_ids: [],
-                      created_at: nowRef.current,
-                      created_by_actor_label: ADA,
-                      messages: [
-                        {
-                          id: nextId("m"),
-                          position: nextId("p"),
-                          body,
-                          created_at: nowRef.current,
-                          created_by_actor_label: ADA,
-                        },
-                      ],
-                    },
-                  ],
-                }))
-              }
-              onReplyThread={appendMessage}
-              onResolveThread={(id) => setStatus(id, "resolved")}
-              onReopenThread={(id) => setStatus(id, "open")}
-            />
-          )}
-        </div>
+      <div className="w-[340px] rounded-xl border bg-background p-3.5 shadow-sm">
+        {!mounted ? (
+          <div className="h-[420px]" aria-hidden />
+        ) : (
+          <NotebookCommentsPanel
+            projection={projection}
+            resolveCommentAuthor={resolveCommentAuthor}
+            resolveSourceLanguage={resolveSourceLanguage}
+            onCreateThread={(body) =>
+              setProjection((current) => ({
+                ...current,
+                threads: [
+                  ...current.threads,
+                  {
+                    id: nextId("thread"),
+                    anchor: { kind: "notebook" },
+                    position: nextId("p"),
+                    status: "open",
+                    badge_cell_ids: [],
+                    created_at: nowRef.current,
+                    created_by_actor_label: ADA,
+                    messages: [
+                      {
+                        id: nextId("m"),
+                        position: nextId("p"),
+                        body,
+                        created_at: nowRef.current,
+                        created_by_actor_label: ADA,
+                      },
+                    ],
+                  },
+                ],
+              }))
+            }
+            onReplyThread={appendMessage}
+            onResolveThread={(id) => setStatus(id, "resolved")}
+            onReopenThread={(id) => setStatus(id, "open")}
+          />
+        )}
       </div>
     </div>
   );

--- a/apps/elements/content/docs/comment-surfaces.mdx
+++ b/apps/elements/content/docs/comment-surfaces.mdx
@@ -45,5 +45,6 @@ degrades to a dangling document comment rather than vanishing.
 ## Resolution
 
 Open threads lead; resolved ones tuck behind **Show resolved** so the rail stays
-on active discussion. The demo is live. Reply, resolve, or add a document
-comment.
+on active discussion. A compact receipt records who resolved the thread and
+when, while replies still make it clear that adding a comment will reopen the
+discussion.

--- a/apps/elements/content/docs/comment-surfaces.mdx
+++ b/apps/elements/content/docs/comment-surfaces.mdx
@@ -29,9 +29,9 @@ notebook app wire the same props to live presence and the runtime.
 
 Authorship is legible at a glance and impossible to fake. Each message shows an
 identity-colored avatar (the same color as that author's cursor and edits),
-name, and time. An agent additionally carries an `AI` chip, a `· for <person>`
-note, and a small principal badge on its avatar, the "acting on behalf of"
-cue. In the app, trust is earned: the daemon finalizes a comment against the
+name, and time. An agent uses the bot avatar plus a quiet `· for <person>` note,
+with a small principal badge on its avatar as the "acting on behalf of" cue. In
+the app, trust is earned: the daemon finalizes a comment against the
 authenticated connection before it's marked trusted, so "Claude Code · for Ada"
 is provable, not asserted.
 

--- a/src/components/notebook/NotebookCommentsPanel.tsx
+++ b/src/components/notebook/NotebookCommentsPanel.tsx
@@ -28,6 +28,8 @@ export interface NotebookCommentDraftTarget {
   quote?: string | null;
 }
 
+export type ResolvedThreadPresentation = "timeline" | "receipt" | "header";
+
 /** Rendered attribution for a comment author. */
 export interface CommentAuthor {
   /** Display name (e.g. "Claude Code" or "kylekelley"). */
@@ -70,6 +72,8 @@ export interface NotebookCommentsPanelProps {
   focusedThreadId?: string | null;
   /** Bumped each focus request so repeat focuses of the same thread re-flash. */
   focusNonce?: number;
+  /** Design-system switch for resolved-thread treatment. */
+  resolvedThreadPresentation?: ResolvedThreadPresentation;
 }
 
 export function NotebookCommentsPanel({
@@ -88,6 +92,7 @@ export function NotebookCommentsPanel({
   resolveSourceLanguage,
   focusedThreadId = null,
   focusNonce = 0,
+  resolvedThreadPresentation = "timeline",
 }: NotebookCommentsPanelProps) {
   const threads = projection?.threads ?? [];
   const labeledThreads = labelCommentThreads(threads);
@@ -126,6 +131,7 @@ export function NotebookCommentsPanel({
       resolveSourceLanguage={resolveSourceLanguage}
       focused={thread.id === focusedThreadId}
       focusNonce={focusNonce}
+      resolvedThreadPresentation={resolvedThreadPresentation}
     />
   );
 
@@ -264,6 +270,7 @@ function CommentThreadItem({
   resolveSourceLanguage,
   focused,
   focusNonce,
+  resolvedThreadPresentation,
 }: {
   thread: CommentThreadSnapshot;
   threadLabel: string;
@@ -277,6 +284,7 @@ function CommentThreadItem({
   resolveSourceLanguage?: (cellId: string) => string | undefined;
   focused?: boolean;
   focusNonce?: number;
+  resolvedThreadPresentation: ResolvedThreadPresentation;
 }) {
   const itemRef = useRef<HTMLLIElement>(null);
   const [flashing, setFlashing] = useState(false);
@@ -293,7 +301,7 @@ function CommentThreadItem({
   const statusAction =
     thread.status === "resolved"
       ? {
-          label: "Reopen",
+          label: "Re-open",
           icon: RotateCcw,
           onClick: () => onReopenThread?.(thread.id),
           ariaLabel: `Reopen ${threadLabel}`,
@@ -322,12 +330,14 @@ function CommentThreadItem({
     ? resolveCommentAuthor?.(thread.created_by_actor_label)
     : undefined;
   const canShowCell = Boolean(commentThreadTargetCellId(thread) && onFocusThreadAnchor);
+  const showHeaderReceipt = thread.status === "resolved" && resolvedThreadPresentation === "header";
 
   return (
     <li
       ref={itemRef}
       className={cn(
         "rounded-lg border bg-card text-card-foreground shadow-sm transition-shadow duration-700",
+        thread.status === "resolved" && "border-border/70 bg-muted/10 shadow-none",
         flashing && "ring-2 ring-primary/60",
       )}
     >
@@ -348,7 +358,12 @@ function CommentThreadItem({
               {anchorLabel(thread)}
             </div>
           )}
-          {thread.status === "resolved" ? <CommentBadge state="resolved" /> : null}
+          {showHeaderReceipt ? (
+            <CommentResolutionHeaderReceipt
+              thread={thread}
+              resolveCommentAuthor={resolveCommentAuthor}
+            />
+          ) : null}
           <div className="flex shrink-0 items-center gap-0.5">
             {canShowCell ? (
               <button
@@ -382,6 +397,12 @@ function CommentThreadItem({
               resolveCommentAuthor={resolveCommentAuthor}
             />
           ))}
+          {thread.status === "resolved" && resolvedThreadPresentation === "timeline" ? (
+            <CommentResolutionEvent thread={thread} resolveCommentAuthor={resolveCommentAuthor} />
+          ) : null}
+          {thread.status === "resolved" && resolvedThreadPresentation === "receipt" ? (
+            <CommentResolutionReceipt thread={thread} resolveCommentAuthor={resolveCommentAuthor} />
+          ) : null}
         </div>
 
         <CommentComposer
@@ -390,12 +411,118 @@ function CommentThreadItem({
           buttonLabel="Reply"
           icon="send"
           disabled={!canReply}
-          placeholder="Reply…"
+          placeholder={thread.status === "resolved" ? "Reply to reopen…" : "Reply…"}
           compact
           onSubmit={onReplyThread ? (body) => onReplyThread(thread.id, body) : undefined}
         />
       </div>
     </li>
+  );
+}
+
+function resolveThreadResolutionAuthor(
+  thread: CommentThreadSnapshot,
+  resolveCommentAuthor?: (actorLabel: string) => CommentAuthor,
+): { actorLabel: string | null; author: CommentAuthor | null } {
+  const actorLabel = thread.resolved_by_actor_label ?? thread.created_by_actor_label ?? null;
+  return {
+    actorLabel,
+    author: actorLabel
+      ? (resolveCommentAuthor?.(actorLabel) ?? { displayName: formatActorLabel(actorLabel) })
+      : null,
+  };
+}
+
+function CommentResolutionEvent({
+  thread,
+  resolveCommentAuthor,
+}: {
+  thread: CommentThreadSnapshot;
+  resolveCommentAuthor?: (actorLabel: string) => CommentAuthor;
+}) {
+  const { actorLabel, author } = resolveThreadResolutionAuthor(thread, resolveCommentAuthor);
+  const resolvedTime = formatRelativeTime(thread.resolved_at);
+
+  return (
+    <article className="flex gap-2.5 text-muted-foreground" data-testid="comment-resolution-event">
+      {author ? (
+        <CommentAuthorAvatar author={author} />
+      ) : (
+        <div className="mt-0.5 size-5 shrink-0 rounded-full bg-muted" aria-hidden="true" />
+      )}
+      <div className="min-w-0 flex-1 space-y-0.5">
+        <div className="flex flex-wrap items-baseline gap-x-1.5">
+          <span className="text-xs font-semibold text-foreground" title={actorLabel ?? undefined}>
+            {author?.displayName ?? "Unknown"}
+          </span>
+          {author?.isAgent && author.onBehalfOf ? (
+            <span className="text-[10px] text-muted-foreground">· for {author.onBehalfOf}</span>
+          ) : null}
+          {resolvedTime ? (
+            <span className="ml-auto shrink-0 text-[10px] text-muted-foreground">
+              {resolvedTime}
+            </span>
+          ) : null}
+        </div>
+        <p className="text-sm leading-5">Marked as resolved</p>
+      </div>
+    </article>
+  );
+}
+
+function CommentResolutionReceipt({
+  thread,
+  resolveCommentAuthor,
+}: {
+  thread: CommentThreadSnapshot;
+  resolveCommentAuthor?: (actorLabel: string) => CommentAuthor;
+}) {
+  const { author } = resolveThreadResolutionAuthor(thread, resolveCommentAuthor);
+  const resolvedTime = formatRelativeTime(thread.resolved_at);
+  const resolverName = author?.displayName ?? "Someone";
+  const resolverIdentity =
+    author?.isAgent && author.onBehalfOf
+      ? `${resolverName} for ${author.onBehalfOf}`
+      : resolverName;
+  const resolutionLabel = `${resolverIdentity} marked as resolved${resolvedTime ? ` · ${resolvedTime}` : ""}`;
+  return (
+    <div
+      className="flex min-w-0 items-center gap-1.5 text-xs text-muted-foreground"
+      data-testid="comment-resolution-receipt"
+      aria-label={resolutionLabel}
+      title={resolutionLabel}
+    >
+      <CheckCircle2 className="size-3.5 shrink-0" aria-hidden="true" />
+      <span className="min-w-0 truncate" title={resolverIdentity}>
+        {resolverIdentity}
+      </span>
+      <span className="shrink-0">marked as resolved</span>
+      {resolvedTime ? <span className="shrink-0">· {resolvedTime}</span> : null}
+    </div>
+  );
+}
+
+function CommentResolutionHeaderReceipt({
+  thread,
+  resolveCommentAuthor,
+}: {
+  thread: CommentThreadSnapshot;
+  resolveCommentAuthor?: (actorLabel: string) => CommentAuthor;
+}) {
+  const { author } = resolveThreadResolutionAuthor(thread, resolveCommentAuthor);
+  const resolvedTime = formatRelativeTime(thread.resolved_at);
+  return (
+    <span
+      className="hidden max-w-24 shrink-0 truncate text-[11px] text-muted-foreground sm:inline"
+      title={[
+        author?.displayName ? `${author.displayName} marked as resolved` : "Marked as resolved",
+        resolvedTime,
+      ]
+        .filter(Boolean)
+        .join(" · ")}
+    >
+      {resolvedTime ? `Resolved ${resolvedTime}` : "Resolved"}
+    </span>
   );
 }
 
@@ -427,15 +554,6 @@ function CommentMessage({
           >
             {author?.displayName ?? "Unknown"}
           </span>
-          {author?.isAgent ? (
-            <span
-              className="inline-flex shrink-0 items-center gap-0.5 rounded bg-muted px-1 py-px text-[9px] font-medium uppercase tracking-wide text-muted-foreground"
-              title="AI agent"
-            >
-              <Bot className="size-2.5" aria-hidden="true" />
-              AI
-            </span>
-          ) : null}
           {author?.isAgent && author.onBehalfOf ? (
             <span className="text-[10px] text-muted-foreground">· for {author.onBehalfOf}</span>
           ) : null}
@@ -628,20 +746,6 @@ function CommentComposer({
   );
 }
 
-function CommentBadge({ state, compact = false }: { state: string; compact?: boolean }) {
-  return (
-    <span
-      className={cn(
-        "rounded border px-1.5 py-0.5 font-medium",
-        compact ? "text-[10px]" : "text-[11px]",
-        stateToneClassName(state),
-      )}
-    >
-      {formatStateLabel(state)}
-    </span>
-  );
-}
-
 function anchorLabel(thread: CommentThreadSnapshot): string {
   switch (thread.anchor.kind) {
     case "cell":
@@ -780,15 +884,4 @@ function formatActorLabel(actorLabel: string): string {
   }
 
   return actorLabel;
-}
-
-function stateToneClassName(state: string): string {
-  switch (state) {
-    case "open":
-      return "border-emerald-300 bg-emerald-50 text-emerald-800 dark:border-emerald-800 dark:bg-emerald-950/25 dark:text-emerald-300";
-    case "resolved":
-      return "border-sky-300 bg-sky-50 text-sky-800 dark:border-sky-800 dark:bg-sky-950/25 dark:text-sky-300";
-    default:
-      return "border-border bg-muted text-muted-foreground";
-  }
 }

--- a/src/components/notebook/NotebookCommentsPanel.tsx
+++ b/src/components/notebook/NotebookCommentsPanel.tsx
@@ -28,8 +28,6 @@ export interface NotebookCommentDraftTarget {
   quote?: string | null;
 }
 
-export type ResolvedThreadPresentation = "timeline" | "receipt" | "header";
-
 /** Rendered attribution for a comment author. */
 export interface CommentAuthor {
   /** Display name (e.g. "Claude Code" or "kylekelley"). */
@@ -72,8 +70,6 @@ export interface NotebookCommentsPanelProps {
   focusedThreadId?: string | null;
   /** Bumped each focus request so repeat focuses of the same thread re-flash. */
   focusNonce?: number;
-  /** Design-system switch for resolved-thread treatment. */
-  resolvedThreadPresentation?: ResolvedThreadPresentation;
 }
 
 export function NotebookCommentsPanel({
@@ -92,7 +88,6 @@ export function NotebookCommentsPanel({
   resolveSourceLanguage,
   focusedThreadId = null,
   focusNonce = 0,
-  resolvedThreadPresentation = "timeline",
 }: NotebookCommentsPanelProps) {
   const threads = projection?.threads ?? [];
   const labeledThreads = labelCommentThreads(threads);
@@ -131,7 +126,6 @@ export function NotebookCommentsPanel({
       resolveSourceLanguage={resolveSourceLanguage}
       focused={thread.id === focusedThreadId}
       focusNonce={focusNonce}
-      resolvedThreadPresentation={resolvedThreadPresentation}
     />
   );
 
@@ -270,7 +264,6 @@ function CommentThreadItem({
   resolveSourceLanguage,
   focused,
   focusNonce,
-  resolvedThreadPresentation,
 }: {
   thread: CommentThreadSnapshot;
   threadLabel: string;
@@ -284,7 +277,6 @@ function CommentThreadItem({
   resolveSourceLanguage?: (cellId: string) => string | undefined;
   focused?: boolean;
   focusNonce?: number;
-  resolvedThreadPresentation: ResolvedThreadPresentation;
 }) {
   const itemRef = useRef<HTMLLIElement>(null);
   const [flashing, setFlashing] = useState(false);
@@ -330,7 +322,6 @@ function CommentThreadItem({
     ? resolveCommentAuthor?.(thread.created_by_actor_label)
     : undefined;
   const canShowCell = Boolean(commentThreadTargetCellId(thread) && onFocusThreadAnchor);
-  const showHeaderReceipt = thread.status === "resolved" && resolvedThreadPresentation === "header";
 
   return (
     <li
@@ -358,12 +349,6 @@ function CommentThreadItem({
               {anchorLabel(thread)}
             </div>
           )}
-          {showHeaderReceipt ? (
-            <CommentResolutionHeaderReceipt
-              thread={thread}
-              resolveCommentAuthor={resolveCommentAuthor}
-            />
-          ) : null}
           <div className="flex shrink-0 items-center gap-0.5">
             {canShowCell ? (
               <button
@@ -397,10 +382,7 @@ function CommentThreadItem({
               resolveCommentAuthor={resolveCommentAuthor}
             />
           ))}
-          {thread.status === "resolved" && resolvedThreadPresentation === "timeline" ? (
-            <CommentResolutionEvent thread={thread} resolveCommentAuthor={resolveCommentAuthor} />
-          ) : null}
-          {thread.status === "resolved" && resolvedThreadPresentation === "receipt" ? (
+          {thread.status === "resolved" ? (
             <CommentResolutionReceipt thread={thread} resolveCommentAuthor={resolveCommentAuthor} />
           ) : null}
         </div>
@@ -433,43 +415,6 @@ function resolveThreadResolutionAuthor(
   };
 }
 
-function CommentResolutionEvent({
-  thread,
-  resolveCommentAuthor,
-}: {
-  thread: CommentThreadSnapshot;
-  resolveCommentAuthor?: (actorLabel: string) => CommentAuthor;
-}) {
-  const { actorLabel, author } = resolveThreadResolutionAuthor(thread, resolveCommentAuthor);
-  const resolvedTime = formatRelativeTime(thread.resolved_at);
-
-  return (
-    <article className="flex gap-2.5 text-muted-foreground" data-testid="comment-resolution-event">
-      {author ? (
-        <CommentAuthorAvatar author={author} />
-      ) : (
-        <div className="mt-0.5 size-5 shrink-0 rounded-full bg-muted" aria-hidden="true" />
-      )}
-      <div className="min-w-0 flex-1 space-y-0.5">
-        <div className="flex flex-wrap items-baseline gap-x-1.5">
-          <span className="text-xs font-semibold text-foreground" title={actorLabel ?? undefined}>
-            {author?.displayName ?? "Unknown"}
-          </span>
-          {author?.isAgent && author.onBehalfOf ? (
-            <span className="text-[10px] text-muted-foreground">· for {author.onBehalfOf}</span>
-          ) : null}
-          {resolvedTime ? (
-            <span className="ml-auto shrink-0 text-[10px] text-muted-foreground">
-              {resolvedTime}
-            </span>
-          ) : null}
-        </div>
-        <p className="text-sm leading-5">Marked as resolved</p>
-      </div>
-    </article>
-  );
-}
-
 function CommentResolutionReceipt({
   thread,
   resolveCommentAuthor,
@@ -499,30 +444,6 @@ function CommentResolutionReceipt({
       <span className="shrink-0">marked as resolved</span>
       {resolvedTime ? <span className="shrink-0">· {resolvedTime}</span> : null}
     </div>
-  );
-}
-
-function CommentResolutionHeaderReceipt({
-  thread,
-  resolveCommentAuthor,
-}: {
-  thread: CommentThreadSnapshot;
-  resolveCommentAuthor?: (actorLabel: string) => CommentAuthor;
-}) {
-  const { author } = resolveThreadResolutionAuthor(thread, resolveCommentAuthor);
-  const resolvedTime = formatRelativeTime(thread.resolved_at);
-  return (
-    <span
-      className="hidden max-w-24 shrink-0 truncate text-[11px] text-muted-foreground sm:inline"
-      title={[
-        author?.displayName ? `${author.displayName} marked as resolved` : "Marked as resolved",
-        resolvedTime,
-      ]
-        .filter(Boolean)
-        .join(" · ")}
-    >
-      {resolvedTime ? `Resolved ${resolvedTime}` : "Resolved"}
-    </span>
   );
 }
 

--- a/src/components/notebook/__tests__/NotebookCommentsPanel.test.tsx
+++ b/src/components/notebook/__tests__/NotebookCommentsPanel.test.tsx
@@ -423,8 +423,10 @@ describe("NotebookCommentsPanel", () => {
     // Resolved threads are hidden until revealed.
     expect(screen.queryByRole("button", { name: "Reopen Document comment 1" })).toBeNull();
     fireEvent.click(screen.getByRole("button", { name: "Show resolved (1)" }));
-    expect(screen.getByTestId("comment-resolution-event")).toHaveTextContent("Marked as resolved");
-    expect(screen.getByText("Reviewer")).toBeVisible();
+    expect(screen.getByTestId("comment-resolution-receipt")).toHaveAttribute(
+      "aria-label",
+      expect.stringContaining("Reviewer marked as resolved"),
+    );
     fireEvent.click(screen.getByRole("button", { name: "Reopen Document comment 1" }));
     expect(onReopenThread).toHaveBeenCalledWith("thread-1");
   });
@@ -443,7 +445,6 @@ describe("NotebookCommentsPanel", () => {
             },
           ],
         }}
-        resolvedThreadPresentation="receipt"
         resolveCommentAuthor={(actorLabel) => ({
           displayName: actorLabel === "reviewer" ? "Reviewer" : actorLabel,
         })}
@@ -471,7 +472,6 @@ describe("NotebookCommentsPanel", () => {
             },
           ],
         }}
-        resolvedThreadPresentation="receipt"
         resolveCommentAuthor={() => ({
           displayName: "Claude Code",
           isAgent: true,

--- a/src/components/notebook/__tests__/NotebookCommentsPanel.test.tsx
+++ b/src/components/notebook/__tests__/NotebookCommentsPanel.test.tsx
@@ -370,7 +370,7 @@ describe("NotebookCommentsPanel", () => {
     );
 
     expect(screen.getByText("Claude Code")).toBeVisible();
-    expect(screen.getByText("AI")).toBeVisible();
+    expect(screen.queryByText("AI")).not.toBeInTheDocument();
     expect(screen.getByText("· for kylekelley")).toBeVisible();
   });
 
@@ -399,12 +399,23 @@ describe("NotebookCommentsPanel", () => {
 
   it("reveals resolved threads behind a toggle and reopens them", () => {
     const onReopenThread = vi.fn();
+    const resolveCommentAuthor = vi.fn((actorLabel: string) => ({
+      displayName: actorLabel === "reviewer" ? "Reviewer" : actorLabel,
+    }));
     render(
       <NotebookCommentsPanel
         projection={{
           ...projection,
-          threads: [{ ...projection.threads[0], status: "resolved" }],
+          threads: [
+            {
+              ...projection.threads[0],
+              status: "resolved",
+              resolved_at: "2026-06-16T00:05:00.000Z",
+              resolved_by_actor_label: "reviewer",
+            },
+          ],
         }}
+        resolveCommentAuthor={resolveCommentAuthor}
         onReopenThread={onReopenThread}
       />,
     );
@@ -412,8 +423,68 @@ describe("NotebookCommentsPanel", () => {
     // Resolved threads are hidden until revealed.
     expect(screen.queryByRole("button", { name: "Reopen Document comment 1" })).toBeNull();
     fireEvent.click(screen.getByRole("button", { name: "Show resolved (1)" }));
+    expect(screen.getByTestId("comment-resolution-event")).toHaveTextContent("Marked as resolved");
+    expect(screen.getByText("Reviewer")).toBeVisible();
     fireEvent.click(screen.getByRole("button", { name: "Reopen Document comment 1" }));
     expect(onReopenThread).toHaveBeenCalledWith("thread-1");
+  });
+
+  it("uses the resolver identity in the compact resolution receipt", () => {
+    render(
+      <NotebookCommentsPanel
+        projection={{
+          ...projection,
+          threads: [
+            {
+              ...projection.threads[0],
+              status: "resolved",
+              resolved_at: "2026-06-16T00:05:00.000Z",
+              resolved_by_actor_label: "reviewer",
+            },
+          ],
+        }}
+        resolvedThreadPresentation="receipt"
+        resolveCommentAuthor={(actorLabel) => ({
+          displayName: actorLabel === "reviewer" ? "Reviewer" : actorLabel,
+        })}
+      />,
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "Show resolved (1)" }));
+    expect(screen.getByTestId("comment-resolution-receipt")).toHaveAttribute(
+      "aria-label",
+      expect.stringContaining("Reviewer marked as resolved"),
+    );
+  });
+
+  it("includes the on-behalf-of principal in the compact resolver identity", () => {
+    render(
+      <NotebookCommentsPanel
+        projection={{
+          ...projection,
+          threads: [
+            {
+              ...projection.threads[0],
+              status: "resolved",
+              resolved_at: "2026-06-16T00:05:00.000Z",
+              resolved_by_actor_label: "agent",
+            },
+          ],
+        }}
+        resolvedThreadPresentation="receipt"
+        resolveCommentAuthor={() => ({
+          displayName: "Claude Code",
+          isAgent: true,
+          onBehalfOf: "Ada",
+        })}
+      />,
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "Show resolved (1)" }));
+    expect(screen.getByTestId("comment-resolution-receipt")).toHaveAttribute(
+      "aria-label",
+      expect.stringContaining("Claude Code for Ada marked as resolved"),
+    );
   });
 
   it("flashes the focused thread", () => {

--- a/src/components/notebook/index.ts
+++ b/src/components/notebook/index.ts
@@ -370,7 +370,6 @@ export {
   NotebookCommentsPanel,
   type NotebookCommentDraftTarget,
   type NotebookCommentsPanelProps,
-  type ResolvedThreadPresentation,
 } from "./NotebookCommentsPanel";
 export type {
   CommentAnchor,

--- a/src/components/notebook/index.ts
+++ b/src/components/notebook/index.ts
@@ -370,6 +370,7 @@ export {
   NotebookCommentsPanel,
   type NotebookCommentDraftTarget,
   type NotebookCommentsPanelProps,
+  type ResolvedThreadPresentation,
 } from "./NotebookCommentsPanel";
 export type {
   CommentAnchor,


### PR DESCRIPTION
## Summary

- Rework resolved comment presentation so resolved threads read as compact receipt metadata instead of a loud `Resolved` badge.
- Use resolver identity in the receipt, including `Claude Code for Ada`, with the full phrase available on hover and accessibility labels.
- Update the Elements comment-surfaces fixture with resolver metadata so the chosen compact treatment can be reviewed live.
- Remove the separate `AI` chip from comment attribution in favor of the bot avatar plus quiet `for <person>` cue.

## Verification

- `pnpm test:run src/components/notebook/__tests__/NotebookCommentsPanel.test.tsx`
- `pnpm --dir apps/elements exec tsc --noEmit --pretty false`
- `cargo xtask lint --fix`
- `git diff --check`
- Playwright smoke via `pnpm --filter notebook-ui exec node`: desktop and narrow `http://localhost:5177/docs/comment-surfaces`

## Notes

- Draft while CI and design review are pending.
