### PR TITLE
refactor(runtimed): consolidate actor identity-display core

### DIFF
--- a/apps/notebook-cloud/viewer/notebook-viewer.tsx
+++ b/apps/notebook-cloud/viewer/notebook-viewer.tsx
@@ -43,7 +43,6 @@ import {
   type CommentThreadSnapshot,
   type CommentsProjection,
 } from "@/components/notebook";
-import { peerColor } from "@/components/editor/remote-cursors";
 import {
   openNotebookRailPanel,
   setActiveNotebookRailPanel,
@@ -556,14 +555,13 @@ export function NotebookViewer({
         peers: commentAuthorPeers,
         source: "cloud",
       });
-      const principalColor = peerColor(display.principalId);
 
       return {
         displayName: display.displayName,
-        color: principalColor,
+        color: display.color,
         isAgent: display.isAgent,
         onBehalfOf: display.onBehalfOf,
-        onBehalfOfColor: display.onBehalfOf ? principalColor : undefined,
+        onBehalfOfColor: display.onBehalfOf ? display.color : undefined,
       };
     },
     [commentAuthorPeers],

--- a/packages/runtimed/src/index.ts
+++ b/packages/runtimed/src/index.ts
@@ -290,8 +290,17 @@ export {
   type ParsedNotebookActorLabel,
 } from "./notebook-actor-projection";
 
+// Notebook actor colors
+export {
+  CURSOR_COLORS,
+  colorForActorIdentity,
+  identityColorKey,
+  peerColor,
+} from "./notebook-actor-color";
+
 // Notebook actor display
 export {
+  actorInitials,
   resolveActorDisplay,
   type ActorDisplay,
   type ActorDisplayPeer,

--- a/packages/runtimed/src/notebook-actor-color.ts
+++ b/packages/runtimed/src/notebook-actor-color.ts
@@ -1,0 +1,42 @@
+export const CURSOR_COLORS = [
+  "#2563eb", // blue
+  "#e11d48", // rose
+  "#d97706", // amber
+  "#059669", // emerald
+  "#7c3aed", // violet
+  "#0891b2", // cyan
+  "#db2777", // pink
+  "#65a30d", // lime
+] as const;
+
+/** Deterministic color from peer ID. */
+export function peerColor(peerId: string): string {
+  let hash = 0;
+  for (let i = 0; i < peerId.length; i++) {
+    hash = (hash * 31 + peerId.charCodeAt(i)) | 0;
+  }
+  return CURSOR_COLORS[Math.abs(hash) % CURSOR_COLORS.length];
+}
+
+/**
+ * Reduce an actor label to its durable identity key: principal plus operator
+ * kind/name, without the per-connection or per-device instance id.
+ */
+export function identityColorKey(actorLabel: string): string {
+  const slash = actorLabel.indexOf("/");
+  if (slash === -1) return actorLabel;
+  const principal = actorLabel.slice(0, slash);
+  const operator = actorLabel.slice(slash + 1);
+  const segments = operator.split(":");
+  const kind = segments[0];
+  const operatorKey =
+    kind === "agent" || kind === "runtime" || kind === "system"
+      ? segments.slice(0, 2).join(":")
+      : kind;
+  return `${principal}/${operatorKey}`;
+}
+
+/** Deterministic color for an actor's durable identity. */
+export function colorForActorIdentity(actorLabel: string): string {
+  return peerColor(identityColorKey(actorLabel));
+}

--- a/packages/runtimed/src/notebook-actor-display.ts
+++ b/packages/runtimed/src/notebook-actor-display.ts
@@ -3,10 +3,12 @@ import {
   notebookActorProjectionFromLabel,
   type NotebookActorKind,
 } from "./notebook-actor-projection";
+import { colorForActorIdentity } from "./notebook-actor-color";
 
 export interface ActorDisplayPeer {
   participantKey: string;
   label: string;
+  imageUrl?: string | null;
 }
 
 export interface ResolveActorDisplayOptions {
@@ -21,6 +23,9 @@ export interface ActorDisplay {
   kind: NotebookActorKind;
   isAgent: boolean;
   onBehalfOf: string | null;
+  color: string;
+  initials: string;
+  imageUrl: string | null;
 }
 
 export function resolveActorDisplay({
@@ -31,24 +36,52 @@ export function resolveActorDisplay({
   const projection = notebookActorProjectionFromLabel(actorLabel, { source });
   const identity = notebookActorIdentityFromProjection(projection);
   const principalId = projection.principal.id;
-  const peerLabel = peerLabelForPrincipal(peers, principalId);
+  const peer = peerForPrincipal(peers, principalId);
+  const peerLabel = labelForPeer(peer);
   const principalDisplayName = peerLabel ?? projection.principal.label;
   const isAgent = identity.kind === "agent";
+  const displayName = isAgent ? (identity.operatorLabel ?? identity.label) : principalDisplayName;
 
   return {
-    displayName: isAgent ? (identity.operatorLabel ?? identity.label) : principalDisplayName,
+    displayName,
     principalId,
     kind: identity.kind,
     isAgent,
     onBehalfOf: isAgent ? (peerLabel ?? identity.principalLabel ?? null) : null,
+    color: colorForActorIdentity(actorLabel),
+    initials: actorInitials(displayName),
+    imageUrl: peer?.imageUrl ?? null,
   };
 }
 
-function peerLabelForPrincipal(
+function peerForPrincipal(
   peers: ReadonlyArray<ActorDisplayPeer>,
   principalId: string,
-): string | null {
-  const peer = peers.find((candidate) => candidate.participantKey === principalId);
+): ActorDisplayPeer | null {
+  return peers.find((candidate) => candidate.participantKey === principalId) ?? null;
+}
+
+function labelForPeer(peer: ActorDisplayPeer | null): string | null {
   const label = peer?.label.trim();
   return label ? label : null;
+}
+
+export function actorInitials(name: string): string {
+  const trimmed = name.trim();
+  if (looksLikeEmailAddress(trimmed)) {
+    return "U";
+  }
+  const words = trimmed
+    .split(/[\s@._-]+/g)
+    .map((word) => word.trim())
+    .filter(Boolean);
+  const initials = words
+    .slice(0, 2)
+    .map((word) => word[0]?.toUpperCase() ?? "")
+    .join("");
+  return initials || "U";
+}
+
+function looksLikeEmailAddress(label: string): boolean {
+  return /^[^@\s]+@[^@\s]+\.[^@\s]+$/.test(label);
 }

--- a/packages/runtimed/tests/notebook-actor-display.test.ts
+++ b/packages/runtimed/tests/notebook-actor-display.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "vite-plus/test";
-import { resolveActorDisplay } from "../src/notebook-actor-display";
+import { colorForActorIdentity } from "../src/notebook-actor-color";
+import { actorInitials, resolveActorDisplay } from "../src/notebook-actor-display";
 
 const ANACONDA_PRINCIPAL = "user:anaconda:550e8400-e29b-41d4-a716-446655440000";
 const ANACONDA_ACTOR = `${ANACONDA_PRINCIPAL}/browser:tab-a`;
@@ -9,7 +10,13 @@ describe("resolveActorDisplay", () => {
     expect(
       resolveActorDisplay({
         actorLabel: ANACONDA_ACTOR,
-        peers: [{ participantKey: ANACONDA_PRINCIPAL, label: "Kyle Kelley" }],
+        peers: [
+          {
+            participantKey: ANACONDA_PRINCIPAL,
+            label: "Kyle Kelley",
+            imageUrl: "https://profiles.example/kyle.png",
+          },
+        ],
         source: "cloud",
       }),
     ).toMatchObject({
@@ -18,6 +25,9 @@ describe("resolveActorDisplay", () => {
       kind: "human",
       isAgent: false,
       onBehalfOf: null,
+      color: colorForActorIdentity(ANACONDA_ACTOR),
+      initials: "KK",
+      imageUrl: "https://profiles.example/kyle.png",
     });
   });
 
@@ -44,6 +54,7 @@ describe("resolveActorDisplay", () => {
       kind: "agent",
       isAgent: true,
       onBehalfOf: "Kyle Kelley",
+      initials: "C",
     });
   });
 
@@ -55,5 +66,12 @@ describe("resolveActorDisplay", () => {
         source: "local",
       }).displayName,
     ).toBe("Ada");
+  });
+
+  it("derives initials across names, delimiters, and email-like labels", () => {
+    expect(actorInitials("Kyle Kelley")).toBe("KK");
+    expect(actorInitials("kyle.kelley")).toBe("KK");
+    expect(actorInitials("rgbkrk@gmail.com")).toBe("U");
+    expect(actorInitials("")).toBe("U");
   });
 });

--- a/src/components/editor/remote-cursors.ts
+++ b/src/components/editor/remote-cursors.ts
@@ -30,6 +30,8 @@ import {
   layer,
 } from "@codemirror/view";
 
+export { CURSOR_COLORS, colorForActorIdentity, identityColorKey, peerColor } from "runtimed";
+
 // ── Types ────────────────────────────────────────────────────────────
 
 export interface RemoteCursorState {
@@ -50,28 +52,6 @@ export interface RemoteSelectionState {
   headLine: number;
   headCol: number;
   color: string;
-}
-
-// ── Color palette ────────────────────────────────────────────────────
-
-const CURSOR_COLORS = [
-  "#2563eb", // blue
-  "#e11d48", // rose
-  "#d97706", // amber
-  "#059669", // emerald
-  "#7c3aed", // violet
-  "#0891b2", // cyan
-  "#db2777", // pink
-  "#65a30d", // lime
-];
-
-/** Deterministic color from peer ID. */
-export function peerColor(peerId: string): string {
-  let hash = 0;
-  for (let i = 0; i < peerId.length; i++) {
-    hash = (hash * 31 + peerId.charCodeAt(i)) | 0;
-  }
-  return CURSOR_COLORS[Math.abs(hash) % CURSOR_COLORS.length];
 }
 
 // ── State effects ────────────────────────────────────────────────────


### PR DESCRIPTION
PR 1 of the identity-display consolidation: build the canonical core in `packages/runtimed` and fix one real color inconsistency. Follow-on to the merged `resolveActorDisplay` (#3736).

## What it does
- **Moves the per-actor color derivation into the package**: `CURSOR_COLORS`, `peerColor`, `identityColorKey`, `colorForActorIdentity` go from `src/components/editor/remote-cursors.ts` (UI layer) into a new framework-agnostic `packages/runtimed/src/notebook-actor-color.ts`. `remote-cursors` re-exports them, so the ~9 cursor importers are unchanged (behavior-preserving). Correct layering: the app depends on the package, not vice versa.
- **One canonical `actorInitials`** added to the package.
- **Extends `resolveActorDisplay`**: `ActorDisplay` now carries `color` (`colorForActorIdentity`), `initials`, and `imageUrl`, so the whole identity projection comes from one place.
- **Fixes the cloud comment color**: it hashed the principal id directly (a different key than cursors), so a user's comment avatar and cursor diverged. It now uses `ActorDisplay.color`, matching the cursor.

## Scope
This is the core only. Migrating the remaining consumers (desktop `resolveCommentAuthor`, the text-attribution tooltip that still shows raw labels, the comment-highlight tooltip, the four ad-hoc initials call sites) onto this core follows in separate PRs. Deliberately clear of the comments-panel surface in flight in #3737.

## Verification
- [x] `resolveActorDisplay` tests (color matches `colorForActorIdentity`, initials, imageUrl) and the `remote-cursors` color tests, 9 passing
- [x] typecheck + build for `packages/runtimed`, `apps/notebook-cloud`, `apps/notebook`, `apps/elements`
- [x] `vp check` clean
- Reviewed Claude-side (codex implemented): confirmed the re-export has no duplicate-definition conflict and the move keeps all importers resolving.
