### PR TITLE
refactor(elements): keep notebook surface render-only

### DIFF
--- a/apps/elements/components/cell-anatomy-example.tsx
+++ b/apps/elements/components/cell-anatomy-example.tsx
@@ -134,7 +134,7 @@ function InsertionRibbonFixture({
 export function CellAnatomyExample() {
   return (
     <div className="not-prose space-y-6">
-      <section className="rounded-lg border border-sky-500/30 bg-sky-500/10 p-4 text-sky-900 dark:text-sky-900">
+      <section className="border-l border-fd-border py-1 pl-4 text-fd-muted-foreground">
         <div className="flex items-start gap-3">
           <ShieldCheck className="mt-0.5 size-4 flex-none" aria-hidden="true" />
           <div>

--- a/apps/elements/components/cell-execution-language-example.tsx
+++ b/apps/elements/components/cell-execution-language-example.tsx
@@ -86,7 +86,7 @@ const componentRows = [
 export function CellExecutionLanguageExample() {
   return (
     <div className="not-prose space-y-6">
-      <section className="rounded-lg border border-emerald-500/30 bg-emerald-500/10 p-4 text-emerald-900 dark:text-emerald-100">
+      <section className="border-l border-fd-border py-1 pl-4 text-fd-muted-foreground">
         <div className="flex items-start gap-3">
           <CheckCircle2 className="mt-0.5 size-4 flex-none" aria-hidden="true" />
           <div>

--- a/apps/elements/components/cell-insertion-affordances-example.tsx
+++ b/apps/elements/components/cell-insertion-affordances-example.tsx
@@ -47,7 +47,7 @@ const noopInsert = () => undefined;
 export function CellInsertionAffordancesExample() {
   return (
     <div className="not-prose space-y-6">
-      <section className="rounded-lg border border-emerald-500/30 bg-emerald-500/10 p-4 text-emerald-900 dark:text-emerald-100">
+      <section className="border-l border-fd-border py-1 pl-4 text-fd-muted-foreground">
         <div className="flex items-start gap-3">
           <CheckCircle2 className="mt-0.5 size-4 flex-none" aria-hidden="true" />
           <div>

--- a/apps/elements/components/editor-surfaces-example.tsx
+++ b/apps/elements/components/editor-surfaces-example.tsx
@@ -210,7 +210,7 @@ function SectionHeader({
           </div>
         </div>
       </div>
-      <span className="rounded-full border border-emerald-500/30 bg-emerald-500/10 px-2 py-1 text-[11px] font-medium text-emerald-700 dark:text-emerald-300">
+      <span className="text-[11px] font-medium text-emerald-700 dark:text-emerald-300">
         rendered
       </span>
     </div>
@@ -306,7 +306,7 @@ export function EditorSurfacesExample() {
 
   return (
     <div className="not-prose space-y-6" data-testid="editor-surfaces-example">
-      <section className="rounded-lg border border-sky-500/30 bg-sky-500/10 p-4 text-sky-900 dark:text-sky-100">
+      <section className="border-l border-fd-border py-1 pl-4 text-fd-muted-foreground">
         <div className="flex items-start gap-3">
           <TextCursorInput className="mt-0.5 size-4 flex-none" aria-hidden="true" />
           <div>

--- a/apps/elements/components/full-cell-surfaces-example.tsx
+++ b/apps/elements/components/full-cell-surfaces-example.tsx
@@ -426,7 +426,7 @@ export function FullCellSurfacesExample() {
   return (
     <NotebookHostProvider host={notebookHost}>
       <div className="not-prose space-y-6">
-        <section className="rounded-lg border border-emerald-500/30 bg-emerald-500/10 p-4 text-emerald-900 dark:text-emerald-100">
+        <section className="border-l border-fd-border py-1 pl-4 text-fd-muted-foreground">
           <div className="flex items-start gap-3">
             <ShieldCheck className="mt-0.5 size-4 flex-none" aria-hidden="true" />
             <div>
@@ -463,11 +463,6 @@ export function FullCellSurfacesExample() {
                 onFocusPrevious={noop}
                 onFocusNext={() => focusFixtureCell(markdownCell.id)}
                 onInsertCellAfter={noop}
-                rightGutterContent={
-                  <span className="rounded-full border border-emerald-500/30 bg-emerald-500/10 px-2 py-1 text-[11px] font-medium text-emerald-700 dark:text-emerald-300">
-                    seeded runtime
-                  </span>
-                }
               />
             </div>
           </section>
@@ -535,11 +530,6 @@ export function FullCellSurfacesExample() {
                   onFocusPrevious={() => focusFixtureCell(codeCell.id)}
                   onFocusNext={() => focusFixtureCell(rawCell.id)}
                   onInsertCellAfter={noop}
-                  rightGutterContent={
-                    <span className="rounded-full border border-sky-500/30 bg-sky-500/10 px-2 py-1 text-[11px] font-medium text-sky-700 dark:text-sky-300">
-                      preview adapter
-                    </span>
-                  }
                 />
               </div>
               <div className="rounded-lg border border-fd-border bg-fd-background p-3">
@@ -573,11 +563,6 @@ export function FullCellSurfacesExample() {
                 onFocusPrevious={() => focusFixtureCell(markdownCell.id)}
                 onFocusNext={noop}
                 onInsertCellAfter={noop}
-                rightGutterContent={
-                  <span className="rounded-full border border-fd-border bg-fd-background px-2 py-1 font-mono text-[11px] text-fd-muted-foreground">
-                    yaml
-                  </span>
-                }
               />
             </div>
           </section>

--- a/apps/elements/components/identity-environment-surfaces-example.tsx
+++ b/apps/elements/components/identity-environment-surfaces-example.tsx
@@ -106,7 +106,7 @@ export function IdentityEnvironmentSurfacesExample() {
 
   return (
     <div className="not-prose space-y-6" data-elements-slot="identity-environment-surfaces">
-      <section className="rounded-lg border border-emerald-500/30 bg-emerald-500/10 p-4 text-fd-foreground">
+      <section className="border-l border-fd-border py-1 pl-4 text-fd-muted-foreground">
         <div className="flex items-start gap-3">
           <CheckCircle2
             className="mt-0.5 size-4 flex-none text-emerald-700 dark:text-emerald-300"
@@ -315,10 +315,10 @@ function AccessPill({ scenario }: { scenario: ElementsNotebookScenario }) {
   return (
     <span
       className={cn(
-        "shrink-0 rounded-full border px-2 py-0.5 text-[11px] font-medium",
+        "shrink-0 text-[11px] font-medium uppercase tracking-[0.08em]",
         scenario.capabilities.access.isPublic
-          ? "border-amber-500/30 bg-amber-500/10 text-amber-700 dark:text-amber-300"
-          : "border-emerald-500/30 bg-emerald-500/10 text-emerald-700 dark:text-emerald-300",
+          ? "text-amber-700 dark:text-amber-300"
+          : "text-emerald-700 dark:text-emerald-300",
       )}
     >
       {scenario.capabilities.access.isPublic ? "public" : scenario.capabilities.access.level}

--- a/apps/elements/components/isolated-output-surfaces-example.tsx
+++ b/apps/elements/components/isolated-output-surfaces-example.tsx
@@ -892,7 +892,7 @@ export function IsolatedOutputSurfacesExample() {
                 {(mcpFrameEvents.length > 0 ? mcpFrameEvents : ["waiting"]).map((event, index) => (
                   <span
                     key={`${index}-${event}`}
-                    className="rounded-full border border-fd-border bg-fd-card px-2 py-1 font-mono text-[11px] text-fd-muted-foreground"
+                    className="font-mono text-[11px] text-fd-muted-foreground"
                   >
                     {event}
                   </span>

--- a/apps/elements/components/notebook-shell-capabilities-example.tsx
+++ b/apps/elements/components/notebook-shell-capabilities-example.tsx
@@ -211,7 +211,7 @@ export function NotebookShellCapabilitiesExample() {
 
   return (
     <div className="not-prose space-y-6" data-elements-slot="notebook-shell-capabilities">
-      <section className="rounded-lg border border-emerald-500/30 bg-emerald-500/10 p-4 text-emerald-900 dark:text-emerald-200">
+      <section className="border-l border-fd-border py-1 pl-4 text-fd-muted-foreground">
         <div className="flex items-start gap-3">
           <ShieldCheck className="mt-0.5 size-4 flex-none" aria-hidden="true" />
           <div>

--- a/apps/elements/components/notebook-toolbar-surfaces-example.tsx
+++ b/apps/elements/components/notebook-toolbar-surfaces-example.tsx
@@ -389,9 +389,5 @@ function ToolbarIdentityControls({ scenario }: { scenario: ElementsNotebookScena
 }
 
 function ScenarioPill({ label }: { label: string }) {
-  return (
-    <span className="rounded-full border border-fd-border bg-fd-background px-2 py-0.5">
-      {label}
-    </span>
-  );
+  return <span className="text-[11px] font-medium text-fd-muted-foreground">{label}</span>;
 }

--- a/apps/elements/components/output-renderers-example.tsx
+++ b/apps/elements/components/output-renderers-example.tsx
@@ -809,7 +809,7 @@ function RendererCard({
             </div>
           </div>
         </div>
-        <span className="rounded-full border border-emerald-500/30 bg-emerald-500/10 px-2 py-1 text-[11px] font-medium text-emerald-700 dark:text-emerald-300">
+        <span className="text-[11px] font-medium text-emerald-700 dark:text-emerald-300">
           rendered
         </span>
       </div>
@@ -890,7 +890,7 @@ export function OutputRenderersExample() {
 
   return (
     <div className="not-prose space-y-6" data-testid="output-renderers-example">
-      <section className="rounded-lg border border-sky-500/30 bg-sky-500/10 p-4 text-sky-900 dark:text-sky-100">
+      <section className="border-l border-fd-border py-1 pl-4 text-fd-muted-foreground">
         <div className="flex items-start gap-3">
           <ListFilter className="mt-0.5 size-4 flex-none" aria-hidden="true" />
           <div>
@@ -1293,10 +1293,10 @@ export function OutputRenderersExample() {
                 <div>
                   <span
                     className={[
-                      "inline-flex rounded-full border px-2 py-1 text-[11px] font-medium",
+                      "inline-flex text-[11px] font-medium",
                       safe
-                        ? "border-emerald-500/30 bg-emerald-500/10 text-emerald-700 dark:text-emerald-300"
-                        : "border-amber-500/30 bg-amber-500/10 text-amber-700 dark:text-amber-300",
+                        ? "text-emerald-700 dark:text-emerald-300"
+                        : "text-amber-700 dark:text-amber-300",
                     ].join(" ")}
                   >
                     {safe ? "main DOM" : "iframe adapter"}

--- a/apps/elements/components/package-manager-surfaces-example.tsx
+++ b/apps/elements/components/package-manager-surfaces-example.tsx
@@ -102,7 +102,7 @@ export function PackageManagerSurfacesExample() {
         {packageSurfaces.map((surface) => (
           <div key={surface.name} className="rounded-lg border border-fd-border bg-fd-card p-4">
             <div className="mb-3 flex items-center justify-between gap-3">
-              <span className="rounded-full border border-fd-border bg-fd-muted px-2 py-1 text-[11px] font-medium uppercase text-fd-muted-foreground">
+              <span className="text-[11px] font-medium uppercase tracking-[0.08em] text-fd-muted-foreground">
                 {surface.manager}
               </span>
               <CheckCircle2 className="size-4 text-emerald-500" aria-hidden="true" />

--- a/apps/elements/components/rail-outline-example.tsx
+++ b/apps/elements/components/rail-outline-example.tsx
@@ -247,7 +247,7 @@ function ScenarioNotice({
 }) {
   return (
     <div className="grid gap-3 xl:grid-cols-[minmax(0,1fr)_minmax(280px,420px)]">
-      <div className="rounded-lg border border-emerald-500/30 bg-emerald-500/10 p-3 text-xs leading-5 text-emerald-900 dark:text-emerald-300">
+      <div className="border-l border-fd-border py-1 pl-3 text-xs leading-5 text-fd-muted-foreground">
         <div className="mb-1 flex items-center gap-2 font-semibold">
           <ShieldCheck className="size-3.5" aria-hidden="true" />
           NotebookDocumentShell, NotebookRail, and NotebookView render from current sources.

--- a/apps/elements/components/read-only-notebook-surfaces-example.tsx
+++ b/apps/elements/components/read-only-notebook-surfaces-example.tsx
@@ -16,7 +16,7 @@ export function ReadOnlyNotebookSurfacesExample() {
 
   return (
     <div className="not-prose space-y-6" data-testid="read-only-notebook-surfaces-example">
-      <section className="rounded-lg border border-sky-500/30 bg-sky-500/10 p-4 text-sky-900 dark:text-sky-100">
+      <section className="border-l border-fd-border py-1 pl-4 text-fd-muted-foreground">
         <div className="flex items-start gap-3">
           <Cloud className="mt-0.5 size-4 flex-none" aria-hidden="true" />
           <div>
@@ -42,7 +42,7 @@ export function ReadOnlyNotebookSurfacesExample() {
               </div>
             </div>
           </div>
-          <span className="shrink-0 rounded-full border border-emerald-500/30 bg-emerald-500/10 px-2 py-1 text-[11px] font-medium text-emerald-700 dark:text-emerald-300">
+          <span className="shrink-0 text-[11px] font-medium text-emerald-700 dark:text-emerald-300">
             rendered
           </span>
         </div>
@@ -69,7 +69,7 @@ export function ReadOnlyNotebookSurfacesExample() {
                 </div>
               </div>
             </div>
-            <span className="shrink-0 rounded-full border border-emerald-500/30 bg-emerald-500/10 px-2 py-1 text-[11px] font-medium text-emerald-700 dark:text-emerald-300">
+            <span className="shrink-0 text-[11px] font-medium text-emerald-700 dark:text-emerald-300">
               rendered
             </span>
           </div>
@@ -98,7 +98,7 @@ export function ReadOnlyNotebookSurfacesExample() {
                 </div>
               </div>
             </div>
-            <span className="shrink-0 rounded-full border border-emerald-500/30 bg-emerald-500/10 px-2 py-1 text-[11px] font-medium text-emerald-700 dark:text-emerald-300">
+            <span className="shrink-0 text-[11px] font-medium text-emerald-700 dark:text-emerald-300">
               rendered
             </span>
           </div>

--- a/apps/elements/components/runtime-surfaces-example.tsx
+++ b/apps/elements/components/runtime-surfaces-example.tsx
@@ -398,7 +398,7 @@ export function RuntimeSurfacesExample() {
 
   return (
     <div className="not-prose space-y-6">
-      <section className="rounded-lg border border-emerald-500/30 bg-emerald-500/10 p-4 text-emerald-900 dark:text-emerald-900">
+      <section className="border-l border-fd-border py-1 pl-4 text-fd-muted-foreground">
         <div className="flex items-start gap-3">
           <PackageCheck className="mt-0.5 size-4 flex-none" aria-hidden="true" />
           <div>
@@ -446,7 +446,7 @@ export function RuntimeSurfacesExample() {
                 </div>
                 <p className="text-xs leading-5 text-fd-muted-foreground">{piece.role}</p>
                 <div>
-                  <span className="inline-flex items-center gap-1 rounded-full border border-fd-border bg-fd-background px-2 py-1 text-[11px] text-fd-muted-foreground">
+                  <span className="inline-flex items-center gap-1 text-[11px] font-medium text-fd-muted-foreground">
                     {piece.status === "rendered" ? (
                       <PackageCheck className="size-3 text-emerald-600" aria-hidden="true" />
                     ) : (

--- a/apps/elements/components/widget-surfaces-example.tsx
+++ b/apps/elements/components/widget-surfaces-example.tsx
@@ -1046,22 +1046,22 @@ const widgetSurfaceToneClasses: Record<
 > = {
   emerald: {
     bar: "bg-emerald-400",
-    badge: "bg-emerald-500/10 text-emerald-700 dark:text-emerald-300",
+    badge: "text-emerald-700 dark:text-emerald-300",
     icon: "text-emerald-600 dark:text-emerald-300",
   },
   sky: {
     bar: "bg-sky-400",
-    badge: "bg-sky-500/10 text-sky-700 dark:text-sky-300",
+    badge: "text-sky-700 dark:text-sky-300",
     icon: "text-sky-600 dark:text-sky-300",
   },
   amber: {
     bar: "bg-amber-400",
-    badge: "bg-amber-500/10 text-amber-700 dark:text-amber-300",
+    badge: "text-amber-700 dark:text-amber-300",
     icon: "text-amber-600 dark:text-amber-300",
   },
   neutral: {
     bar: "bg-fd-muted-foreground/35",
-    badge: "bg-fd-muted text-fd-muted-foreground",
+    badge: "text-fd-muted-foreground",
     icon: "text-fd-muted-foreground",
   },
 };
@@ -1532,18 +1532,16 @@ function ControllerPollingFixture() {
         {gamepadFixtureReady ? (
           <WidgetView modelId="widget-controller" />
         ) : (
-          <div className="rounded-md border border-amber-500/30 bg-amber-500/10 p-3 text-xs text-fd-muted-foreground">
+          <div className="border-l border-amber-500/50 py-1 pl-3 text-xs text-fd-muted-foreground">
             Gamepad fixture unavailable{gamepadFixtureError ? `: ${gamepadFixtureError}` : "."}
           </div>
         )}
       </div>
-      <div className="flex flex-wrap gap-2 text-xs text-fd-muted-foreground">
-        <span className="rounded-full border border-fd-border bg-fd-card px-2 py-1">
+      <div className="flex flex-wrap gap-x-3 gap-y-1 text-xs text-fd-muted-foreground">
+        <span>
           fixture frame <span className="font-mono">{frame}</span>
         </span>
-        <span className="rounded-full border border-fd-border bg-fd-card px-2 py-1">
-          navigator.getGamepads
-        </span>
+        <span>navigator.getGamepads</span>
       </div>
     </div>
   );
@@ -1684,13 +1682,9 @@ function WidgetInventory() {
   );
 
   return (
-    <div className="flex flex-wrap gap-2 text-xs text-fd-muted-foreground">
-      <span className="rounded-full border border-fd-border bg-fd-card px-2 py-1">
-        {visibleModels.length} rendered models
-      </span>
-      <span className="rounded-full border border-fd-border bg-fd-card px-2 py-1">
-        {models.size} fixture comms
-      </span>
+    <div className="flex flex-wrap gap-x-3 gap-y-1 text-xs text-fd-muted-foreground">
+      <span>{visibleModels.length} rendered models</span>
+      <span>{models.size} fixture comms</span>
     </div>
   );
 }
@@ -1724,12 +1718,7 @@ function WidgetSurfaceGrammar() {
                 <item.icon className={cn("mt-0.5 size-4 shrink-0", tone.icon)} aria-hidden="true" />
                 <div>
                   <h3 className="text-sm font-semibold">{item.label}</h3>
-                  <div
-                    className={cn(
-                      "mt-2 inline-flex rounded-full px-2 py-0.5 text-[11px] font-medium leading-none",
-                      tone.badge,
-                    )}
-                  >
+                  <div className={cn("mt-2 text-[11px] font-medium leading-none", tone.badge)}>
                     {item.state}
                   </div>
                 </div>
@@ -1922,7 +1911,7 @@ export function WidgetSurfacesExample() {
         ))}
       </section>
 
-      <section className="rounded-lg border border-amber-500/30 bg-amber-500/10 p-4">
+      <section className="border-l border-fd-border py-1 pl-4">
         <div className="flex items-start gap-3">
           <CircleDotDashed className="mt-0.5 size-4 flex-none text-amber-600" aria-hidden="true" />
           <div className="min-w-0 flex-1">
@@ -1932,7 +1921,7 @@ export function WidgetSurfacesExample() {
               transport, kernel-originated anywidget asset URLs, and production daemon blob resolver
               lifecycle need explicit iframe/runtime adapters before they can render here.
             </p>
-            <div className="mt-4 overflow-hidden rounded-md border border-amber-500/25 bg-fd-card/70">
+            <div className="mt-4 overflow-hidden border border-fd-border">
               <div className="hidden grid-cols-[190px_210px_230px_minmax(0,1fr)] gap-3 border-b border-amber-500/20 px-3 py-2 text-[11px] font-medium uppercase text-fd-muted-foreground xl:grid">
                 <span>Adapter</span>
                 <span>Catalog path</span>

--- a/apps/elements/content/docs/cell-anatomy.mdx
+++ b/apps/elements/content/docs/cell-anatomy.mdx
@@ -22,12 +22,13 @@ chrome.
 
 This cell slice imports the notebook app cell components directly and feeds
 them fixture state through the same stores they use in the desktop app. It also
-mounts the production `NotebookView` workspace shell with local visual order so
-stable DOM ordering, hidden-cell grouping, cell adders, and navigation chrome
-are visible without opening a notebook document. Catalog fixtures seed cell,
+mounts the production `NotebookView` workspace shell through the render-only
+`apps/notebook/src/notebook-surface.ts` seam with local visual order so stable
+DOM ordering, hidden-cell grouping, cell adders, and navigation chrome are
+visible without opening a notebook document. Catalog fixtures seed cell,
 execution, output, focus, CRDT-provider state, and local order, while notebook
-document projection, kernel execution, iframe bootstrap, DnD persistence, and
-Automerge sync remain production boundaries.
+document projection, kernel execution, iframe bootstrap, DnD persistence,
+generated WASM, and Automerge sync remain production boundaries.
 
 <FullCellSurfacesClient />
 

--- a/apps/elements/content/docs/notebook-outline.mdx
+++ b/apps/elements/content/docs/notebook-outline.mdx
@@ -27,9 +27,10 @@ outline rail.
   moving cells into the sidebar.
 - `NotebookCommandToolbar` is imported from `src/components/notebook` with inert
   fixture callbacks and runtime status props.
-- `NotebookView` renders the scenario cells from seeded notebook, execution,
-  and cell UI stores. The outline page does not add its own markdown,
-  queued, running, or run-count badges around cells.
+- `NotebookView` renders the scenario cells from the render-only
+  `apps/notebook/src/notebook-surface.ts` seam plus seeded notebook, execution,
+  and cell UI stores. The outline page does not add its own markdown, queued,
+  running, or run-count badges around cells.
 - Output renderer fixtures stay on output-specific catalog pages; this rail
   page keeps code cells output-free so renderer adapter chrome does not read as
   notebook design.

--- a/apps/notebook/src/components/CodeCell.tsx
+++ b/apps/notebook/src/components/CodeCell.tsx
@@ -14,7 +14,7 @@ import { textAttributionExtension } from "@/components/editor/text-attribution";
 import type { NteractEmbedHostContextPatch } from "@/components/isolated/host-context";
 import type { TracebackCellTarget } from "@/components/outputs/traceback-output";
 import { cn } from "@/lib/utils";
-import { usePresenceContext } from "../contexts/PresenceContext";
+import { usePresenceContext } from "@/components/notebook/presence-context";
 import { useCellKeyboardNavigation } from "../hooks/useCellKeyboardNavigation";
 import { useCrdtBridge } from "../hooks/useCrdtBridge";
 import {

--- a/apps/notebook/src/components/MarkdownCell.tsx
+++ b/apps/notebook/src/components/MarkdownCell.tsx
@@ -31,7 +31,7 @@ import {
   resolveMarkdownProjection,
 } from "../lib/markdown-projection";
 import { cn } from "@/lib/utils";
-import { usePresenceContext } from "../contexts/PresenceContext";
+import { usePresenceContext } from "@/components/notebook/presence-context";
 import { useCellKeyboardNavigation } from "../hooks/useCellKeyboardNavigation";
 import { useCrdtBridge } from "../hooks/useCrdtBridge";
 import { useBlobResolver } from "../lib/blob-port";

--- a/apps/notebook/src/components/NotebookView.tsx
+++ b/apps/notebook/src/components/NotebookView.tsx
@@ -29,7 +29,7 @@ import type { Runtime } from "@/hooks/useSyncedSettings";
 import { ErrorBoundary } from "@/lib/error-boundary";
 import { cn } from "@/lib/utils";
 import type { TracebackCellTarget } from "@/components/outputs/traceback-output";
-import { usePresenceContext } from "../contexts/PresenceContext";
+import { usePresenceContext } from "@/components/notebook/presence-context";
 import { EditorRegistryProvider, useEditorRegistry } from "../hooks/useEditorRegistry";
 import {
   flushCellUIState,

--- a/apps/notebook/src/components/RawCell.tsx
+++ b/apps/notebook/src/components/RawCell.tsx
@@ -5,7 +5,7 @@ import { CodeMirrorEditor, type CodeMirrorEditorRef } from "@/components/editor/
 import { remoteCursorsExtension } from "@/components/editor/remote-cursors";
 import { searchHighlight } from "@/components/editor/search-highlight";
 import { textAttributionExtension } from "@/components/editor/text-attribution";
-import { usePresenceContext } from "../contexts/PresenceContext";
+import { usePresenceContext } from "@/components/notebook/presence-context";
 import { useCellKeyboardNavigation } from "../hooks/useCellKeyboardNavigation";
 import { useCrdtBridge } from "../hooks/useCrdtBridge";
 import {

--- a/apps/notebook/src/components/__tests__/elements-style-boundary.test.ts
+++ b/apps/notebook/src/components/__tests__/elements-style-boundary.test.ts
@@ -1,0 +1,50 @@
+import { readdirSync, readFileSync } from "node:fs";
+import { join } from "node:path";
+import { describe, expect, it } from "vite-plus/test";
+
+const elementsComponentsDir = join(process.cwd(), "apps/elements/components");
+
+function sourceFiles(dir: string): string[] {
+  return readdirSync(dir, { withFileTypes: true }).flatMap((entry) => {
+    const fullPath = join(dir, entry.name);
+    if (entry.isDirectory()) return sourceFiles(fullPath);
+    return /\.(ts|tsx)$/.test(entry.name) ? [fullPath] : [];
+  });
+}
+
+function matchingLines(pattern: RegExp): string[] {
+  const matches: string[] = [];
+
+  for (const filePath of sourceFiles(elementsComponentsDir)) {
+    const relativePath = filePath.slice(`${process.cwd()}/`.length);
+    const lines = readFileSync(filePath, "utf8").split("\n");
+
+    lines.forEach((line, index) => {
+      if (pattern.test(line)) {
+        matches.push(`${relativePath}:${index + 1}: ${line.trim()}`);
+      }
+    });
+  }
+
+  return matches;
+}
+
+describe("Elements visual style boundary", () => {
+  it("does not use rounded pill labels for fixture metadata", () => {
+    expect(matchingLines(/rounded-full[^\n]*(?:border|px-2|py-1|py-0\.5|text-\[11px\])/)).toEqual(
+      [],
+    );
+  });
+
+  it("does not use colored rounded callout boxes in fixture pages", () => {
+    expect(
+      matchingLines(
+        /rounded-(?:lg|md)[^\n]*border-(?:emerald|sky|amber)-500\/(?:25|30)[^\n]*bg-(?:emerald|sky|amber)-500\/10/,
+      ),
+    ).toEqual([]);
+  });
+
+  it("keeps catalog-only labels out of production cell gutters", () => {
+    expect(matchingLines(/rightGutterContent=\{\s*<span/)).toEqual([]);
+  });
+});

--- a/apps/notebook/src/components/__tests__/notebook-surface-boundary.test.ts
+++ b/apps/notebook/src/components/__tests__/notebook-surface-boundary.test.ts
@@ -1,0 +1,39 @@
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import { describe, expect, it } from "vite-plus/test";
+
+describe("notebook-surface render boundary", () => {
+  const sourceText = readFileSync(
+    join(process.cwd(), "apps/notebook/src/notebook-surface.ts"),
+    "utf8",
+  );
+  const renderSurfaceComponentPaths = [
+    "apps/notebook/src/components/NotebookView.tsx",
+    "apps/notebook/src/components/CodeCell.tsx",
+    "apps/notebook/src/components/MarkdownCell.tsx",
+    "apps/notebook/src/components/RawCell.tsx",
+  ] as const;
+
+  it("exports the production render surface without app materialization glue", () => {
+    expect(sourceText).toContain("Render-only notebook surface");
+    expect(sourceText).toMatch(/export \{ CodeCell, type HiddenGroupCellSummary \}/);
+    expect(sourceText).toMatch(/export \{ MarkdownCell \}/);
+    expect(sourceText).toMatch(/export \{ NotebookView, type NotebookViewProps \}/);
+    expect(sourceText).toMatch(/export \{ RawCell \}/);
+
+    expect(sourceText).not.toContain("materializeChangeset");
+    expect(sourceText).not.toContain("frame-pipeline");
+    expect(sourceText).not.toMatch(/from\s+["'][^"']*runtimed-wasm/);
+    expect(sourceText).not.toContain("useAutomergeNotebook");
+    expect(sourceText).not.toContain("NotebookHandle");
+  });
+
+  it("keeps render components on the shared presence context", () => {
+    for (const componentPath of renderSurfaceComponentPaths) {
+      const componentSource = readFileSync(join(process.cwd(), componentPath), "utf8");
+
+      expect(componentSource).not.toContain("../contexts/PresenceContext");
+      expect(componentSource).toContain("@/components/notebook/presence-context");
+    }
+  });
+});

--- a/apps/notebook/src/notebook-surface.ts
+++ b/apps/notebook/src/notebook-surface.ts
@@ -1,5 +1,9 @@
+// Render-only notebook surface for Elements and other fixture-backed hosts.
+//
+// Keep this module free of notebook document materialization, controller, sync,
+// and generated WASM imports. Fixture hosts should be able to render the
+// production cell surface without building or loading runtimed-wasm.
 export { CodeCell, type HiddenGroupCellSummary } from "./components/CodeCell";
 export { MarkdownCell } from "./components/MarkdownCell";
 export { NotebookView, type NotebookViewProps } from "./components/NotebookView";
 export { RawCell } from "./components/RawCell";
-export { materializeChangeset } from "./lib/frame-pipeline";


### PR DESCRIPTION
## Summary

- Keep `apps/notebook/src/notebook-surface.ts` render-only for Elements and fixture-backed hosts.
- Remove `materializeChangeset` from that surface so importing production cells does not pull app materialization or generated `runtimed-wasm` paths.
- Point NotebookView and cell render components at the shared presence context instead of the app presence wrapper that owns outbound presence frames.
- Add a source guard for the render-only boundary and update Elements docs to name the seam.

## Verification

- `pnpm test:run apps/notebook/src/components/__tests__/notebook-surface-boundary.test.ts apps/notebook/src/components/__tests__/notebook-view-capabilities-source.test.ts apps/notebook/src/components/__tests__/notebook-view-stable-dom-order.test.ts apps/notebook/src/components/__tests__/code-cell-output-focus.test.tsx apps/notebook/src/components/__tests__/markdown-cell-theme.test.tsx`
- `pnpm --dir apps/elements exec tsc --noEmit --pretty false`
- `pnpm --dir apps/elements exec tsc --noEmit --pretty false` with ignored `apps/notebook/src/wasm/runtimed-wasm` temporarily moved aside
- `cargo xtask lint --fix`
- `git diff --check`

## Notes

- Draft while CI and follow-up design exploration are pending.
