### PR TITLE
refactor: migrate initials and attribution tooltip onto the identity core

### DIFF
--- a/apps/notebook-cloud/viewer/presence.ts
+++ b/apps/notebook-cloud/viewer/presence.ts
@@ -1,6 +1,10 @@
 import type { CloudRoomPeerRosterEntry, SessionControlMessage } from "../src/protocol";
 import type { ConnectionScope } from "../src/auth-shared";
-import { notebookActorIdentityFromProjection, notebookActorProjectionFromLabel } from "runtimed";
+import {
+  actorInitials,
+  notebookActorIdentityFromProjection,
+  notebookActorProjectionFromLabel,
+} from "runtimed";
 
 export type CloudViewerPresenceConnection = "connecting" | "connected" | "disconnected";
 
@@ -357,21 +361,7 @@ export function cloudPresenceRuntimePeerCount(state: CloudViewerPresenceState): 
   return Math.max(state.runtimePeerCount, visibleRuntimePeers);
 }
 
-export function cloudPresenceInitials(label: string): string {
-  const trimmed = label.trim();
-  if (looksLikeEmailAddress(trimmed)) {
-    return "U";
-  }
-  const words = trimmed
-    .split(/[\s@._-]+/g)
-    .map((word) => word.trim())
-    .filter(Boolean);
-  const initials = words
-    .slice(0, 2)
-    .map((word) => word[0]?.toUpperCase() ?? "")
-    .join("");
-  return initials || "?";
-}
+export const cloudPresenceInitials: (label: string) => string = actorInitials;
 
 export interface CloudFriendlyPeerLabelInput {
   displayName?: string | null;

--- a/packages/runtimed/src/notebook-actor-display.ts
+++ b/packages/runtimed/src/notebook-actor-display.ts
@@ -75,11 +75,19 @@ export function actorInitials(name: string): string {
     .split(/[\s@._-]+/g)
     .map((word) => word.trim())
     .filter(Boolean);
-  const initials = words
-    .slice(0, 2)
-    .map((word) => word[0]?.toUpperCase() ?? "")
-    .join("");
-  return initials || "U";
+  if (words.length === 0) {
+    return "U";
+  }
+  // A single word keeps two letters ("Alice" -> "AL"); multiple words take the
+  // first letter of the first two ("Kyle Kelley" -> "KK").
+  const initials =
+    words.length === 1
+      ? words[0].slice(0, 2)
+      : words
+          .slice(0, 2)
+          .map((word) => word[0] ?? "")
+          .join("");
+  return initials.toUpperCase() || "U";
 }
 
 function looksLikeEmailAddress(label: string): boolean {

--- a/packages/runtimed/tests/notebook-actor-display.test.ts
+++ b/packages/runtimed/tests/notebook-actor-display.test.ts
@@ -54,7 +54,7 @@ describe("resolveActorDisplay", () => {
       kind: "agent",
       isAgent: true,
       onBehalfOf: "Kyle Kelley",
-      initials: "C",
+      initials: "CO",
     });
   });
 
@@ -71,6 +71,8 @@ describe("resolveActorDisplay", () => {
   it("derives initials across names, delimiters, and email-like labels", () => {
     expect(actorInitials("Kyle Kelley")).toBe("KK");
     expect(actorInitials("kyle.kelley")).toBe("KK");
+    expect(actorInitials("Alice")).toBe("AL");
+    expect(actorInitials("a")).toBe("A");
     expect(actorInitials("rgbkrk@gmail.com")).toBe("U");
     expect(actorInitials("")).toBe("U");
   });

--- a/src/components/editor/__tests__/text-attribution.test.ts
+++ b/src/components/editor/__tests__/text-attribution.test.ts
@@ -1,0 +1,76 @@
+import { EditorState } from "@codemirror/state";
+import { EditorView } from "@codemirror/view";
+import { afterEach, describe, expect, it } from "vite-plus/test";
+import {
+  addTextAttributions,
+  textAttributionExtension,
+  type TextAttributionExtensionOptions,
+} from "../text-attribution";
+
+const views: EditorView[] = [];
+
+afterEach(() => {
+  for (const view of views) {
+    view.destroy();
+  }
+  views.length = 0;
+  document.body.replaceChildren();
+});
+
+function createEditor(options?: TextAttributionExtensionOptions): EditorView {
+  const parent = document.createElement("div");
+  document.body.appendChild(parent);
+
+  const view = new EditorView({
+    state: EditorState.create({
+      doc: "hello world",
+      extensions: textAttributionExtension(options),
+    }),
+    parent,
+  });
+  views.push(view);
+  return view;
+}
+
+function textAttributionElement(): HTMLElement {
+  const element = document.querySelector(".cm-text-attribution");
+  expect(element).not.toBeNull();
+  return element as HTMLElement;
+}
+
+describe("text attribution", () => {
+  it("humanizes and dedupes actor labels in the tooltip", () => {
+    const view = createEditor();
+
+    addTextAttributions(view, [
+      {
+        from: 0,
+        to: 5,
+        actors: [
+          "user:anaconda:550e8400-e29b-41d4-a716-446655440000/browser:tab-a",
+          "user:anaconda:550e8400-e29b-41d4-a716-446655440000/browser:tab-b",
+          "anonymous:viewer:session-a/browser:tab",
+          " ",
+        ],
+      },
+    ]);
+
+    expect(textAttributionElement().getAttribute("title")).toBe("Anaconda user, Anonymous");
+  });
+
+  it("uses a custom actor name resolver when provided", () => {
+    const view = createEditor({
+      resolveActorName: (label) => (label === "known-actor" ? "Known actor" : ""),
+    });
+
+    addTextAttributions(view, [
+      {
+        from: 6,
+        to: 11,
+        actors: ["unknown-actor", "known-actor", "known-actor"],
+      },
+    ]);
+
+    expect(textAttributionElement().getAttribute("title")).toBe("Known actor");
+  });
+});

--- a/src/components/editor/text-attribution.ts
+++ b/src/components/editor/text-attribution.ts
@@ -42,6 +42,7 @@ import {
   ViewPlugin,
   type ViewUpdate,
 } from "@codemirror/view";
+import { friendlyNotebookActorLabel } from "runtimed";
 
 // ── Toggles ──────────────────────────────────────────────────────────
 // Flip these to compare effects independently. Vite HMR picks up changes.
@@ -106,11 +107,17 @@ export interface AttributionMark {
   color?: string;
 }
 
+type ResolveActorName = (label: string) => string;
+
+export interface TextAttributionExtensionOptions {
+  resolveActorName?: ResolveActorName;
+}
+
 /** Internal mark with a creation timestamp for fade calculation. */
 interface TimedMark {
   from: number;
   to: number;
-  actors: string[];
+  tooltip: string;
   /** Pre-parsed "R, G, B" string for rgba(). */
   color: string;
   /** `performance.now()` when this mark was created. */
@@ -130,6 +137,26 @@ function hexToRgb(hex: string): string {
   const b = Number.parseInt(h.slice(4, 6), 16);
   if (Number.isNaN(r) || Number.isNaN(g) || Number.isNaN(b)) return DEFAULT_COLOR;
   return `${r}, ${g}, ${b}`;
+}
+
+function defaultResolveActorName(label: string): string {
+  return friendlyNotebookActorLabel(label) ?? "";
+}
+
+function attributionTooltip(actors: readonly string[], resolveActorName: ResolveActorName): string {
+  const names: string[] = [];
+  const seen = new Set<string>();
+
+  for (const actor of actors) {
+    const name = resolveActorName(actor).trim();
+    if (!name || seen.has(name)) {
+      continue;
+    }
+    seen.add(name);
+    names.push(name);
+  }
+
+  return names.join(", ");
 }
 
 // ── Curves ───────────────────────────────────────────────────────────
@@ -174,49 +201,51 @@ const tickEffect = StateEffect.define<null>();
  * Document changes remap `from`/`to` through the change set so highlights
  * track their text even as the document is edited around them.
  */
-const marksField = StateField.define<TimedMark[]>({
-  create: () => [],
-  update(marks: TimedMark[], tr: Transaction): TimedMark[] {
-    let updated = marks;
+function createMarksField(resolveActorName: ResolveActorName): StateField<TimedMark[]> {
+  return StateField.define<TimedMark[]>({
+    create: () => [],
+    update(marks: TimedMark[], tr: Transaction): TimedMark[] {
+      let updated = marks;
 
-    // Remap positions through document changes.
-    // Marks whose range collapses to empty (fully deleted) are dropped.
-    if (tr.docChanged) {
-      updated = updated
-        .map((m) => ({
-          ...m,
-          from: tr.changes.mapPos(m.from, 1),
-          to: tr.changes.mapPos(m.to, -1),
-        }))
-        .filter((m) => m.from < m.to);
-    }
-
-    // Add new marks from effects.
-    for (const effect of tr.effects) {
-      if (effect.is(addAttributionsEffect)) {
-        const now = performance.now();
-        const newMarks: TimedMark[] = effect.value
-          .filter((m) => m.from < m.to)
+      // Remap positions through document changes.
+      // Marks whose range collapses to empty (fully deleted) are dropped.
+      if (tr.docChanged) {
+        updated = updated
           .map((m) => ({
-            from: m.from,
-            to: m.to,
-            actors: m.actors,
-            color: m.color ? hexToRgb(m.color) : DEFAULT_COLOR,
-            createdAt: now,
-          }));
-        updated = [...updated, ...newMarks];
+            ...m,
+            from: tr.changes.mapPos(m.from, 1),
+            to: tr.changes.mapPos(m.to, -1),
+          }))
+          .filter((m) => m.from < m.to);
       }
 
-      // On tick, prune expired marks.
-      if (effect.is(tickEffect)) {
-        const now = performance.now();
-        updated = updated.filter((m) => now - m.createdAt < TOTAL_MS);
-      }
-    }
+      // Add new marks from effects.
+      for (const effect of tr.effects) {
+        if (effect.is(addAttributionsEffect)) {
+          const now = performance.now();
+          const newMarks: TimedMark[] = effect.value
+            .filter((m) => m.from < m.to)
+            .map((m) => ({
+              from: m.from,
+              to: m.to,
+              tooltip: attributionTooltip(m.actors, resolveActorName),
+              color: m.color ? hexToRgb(m.color) : DEFAULT_COLOR,
+              createdAt: now,
+            }));
+          updated = [...updated, ...newMarks];
+        }
 
-    return updated;
-  },
-});
+        // On tick, prune expired marks.
+        if (effect.is(tickEffect)) {
+          const now = performance.now();
+          updated = updated.filter((m) => now - m.createdAt < TOTAL_MS);
+        }
+      }
+
+      return updated;
+    },
+  });
+}
 
 // ── Decoration builder ───────────────────────────────────────────────
 
@@ -267,17 +296,19 @@ function buildDecorations(marks: TimedMark[]): DecorationSet {
       }
     }
 
-    const tooltip = mark.actors.join(", ");
+    const attributes: Record<string, string> = {
+      style: `${opacityStyle} ${underlineStyle} transition: opacity ${TICK_MS}ms linear;`,
+    };
+    if (mark.tooltip) {
+      attributes.title = mark.tooltip;
+    }
 
     builder.add(
       mark.from,
       mark.to,
       Decoration.mark({
         class: "cm-text-attribution",
-        attributes: {
-          style: `${opacityStyle} ${underlineStyle} transition: opacity ${TICK_MS}ms linear;`,
-          title: tooltip,
-        },
+        attributes,
       }),
     );
   }
@@ -287,18 +318,20 @@ function buildDecorations(marks: TimedMark[]): DecorationSet {
 
 // ── Decoration state field ───────────────────────────────────────────
 
-const decorationsField = StateField.define<DecorationSet>({
-  create: () => Decoration.none,
-  update(decos, tr) {
-    const needsRebuild =
-      tr.docChanged || tr.effects.some((e) => e.is(addAttributionsEffect) || e.is(tickEffect));
+function createDecorationsField(marksField: StateField<TimedMark[]>): StateField<DecorationSet> {
+  return StateField.define<DecorationSet>({
+    create: () => Decoration.none,
+    update(decos, tr) {
+      const needsRebuild =
+        tr.docChanged || tr.effects.some((e) => e.is(addAttributionsEffect) || e.is(tickEffect));
 
-    if (!needsRebuild) return decos;
+      if (!needsRebuild) return decos;
 
-    return buildDecorations(tr.state.field(marksField));
-  },
-  provide: (f) => EditorView.decorations.from(f),
-});
+      return buildDecorations(tr.state.field(marksField));
+    },
+    provide: (f) => EditorView.decorations.from(f),
+  });
+}
 
 // ── Tick / prune plugin ──────────────────────────────────────────────
 
@@ -306,48 +339,50 @@ const decorationsField = StateField.define<DecorationSet>({
  * Runs a periodic timer that dispatches `tickEffect` to fade and prune
  * expired marks. The timer only runs while there are active marks.
  */
-const attributionTickPlugin = ViewPlugin.fromClass(
-  class {
-    timer: ReturnType<typeof setInterval> | null = null;
-    view: EditorView;
+function createAttributionTickPlugin(marksField: StateField<TimedMark[]>): Extension {
+  return ViewPlugin.fromClass(
+    class {
+      timer: ReturnType<typeof setInterval> | null = null;
+      view: EditorView;
 
-    constructor(view: EditorView) {
-      this.view = view;
-      this.maybeStartTimer();
-    }
-
-    update(update: ViewUpdate) {
-      for (const effect of update.transactions.flatMap((t) => t.effects)) {
-        if (effect.is(addAttributionsEffect)) {
-          this.maybeStartTimer();
-          return;
-        }
+      constructor(view: EditorView) {
+        this.view = view;
+        this.maybeStartTimer();
       }
-    }
 
-    maybeStartTimer() {
-      if (this.timer !== null) return;
-      this.timer = setInterval(() => {
-        const marks = this.view.state.field(marksField);
-        if (marks.length === 0) {
-          if (this.timer !== null) {
-            clearInterval(this.timer);
-            this.timer = null;
+      update(update: ViewUpdate) {
+        for (const effect of update.transactions.flatMap((t) => t.effects)) {
+          if (effect.is(addAttributionsEffect)) {
+            this.maybeStartTimer();
+            return;
           }
-          return;
         }
-        this.view.dispatch({ effects: tickEffect.of(null) });
-      }, TICK_MS);
-    }
-
-    destroy() {
-      if (this.timer !== null) {
-        clearInterval(this.timer);
-        this.timer = null;
       }
-    }
-  },
-);
+
+      maybeStartTimer() {
+        if (this.timer !== null) return;
+        this.timer = setInterval(() => {
+          const marks = this.view.state.field(marksField);
+          if (marks.length === 0) {
+            if (this.timer !== null) {
+              clearInterval(this.timer);
+              this.timer = null;
+            }
+            return;
+          }
+          this.view.dispatch({ effects: tickEffect.of(null) });
+        }, TICK_MS);
+      }
+
+      destroy() {
+        if (this.timer !== null) {
+          clearInterval(this.timer);
+          this.timer = null;
+        }
+      }
+    },
+  );
+}
 
 // ── Theme ────────────────────────────────────────────────────────────
 
@@ -367,8 +402,13 @@ const attributionTheme = EditorView.theme({
  * Add to the editor's extensions array. Then call `addTextAttributions()`
  * to push highlight ranges from outside React.
  */
-export function textAttributionExtension(): Extension[] {
+export function textAttributionExtension(
+  options: TextAttributionExtensionOptions = {},
+): Extension[] {
   injectKeyframes();
+  const marksField = createMarksField(options.resolveActorName ?? defaultResolveActorName);
+  const decorationsField = createDecorationsField(marksField);
+  const attributionTickPlugin = createAttributionTickPlugin(marksField);
 
   return [marksField, decorationsField, attributionTickPlugin, attributionTheme];
 }

--- a/src/components/notebook/NotebookCommentsPanel.tsx
+++ b/src/components/notebook/NotebookCommentsPanel.tsx
@@ -10,6 +10,7 @@ import {
   Send,
   X,
 } from "lucide-react";
+import { actorInitials } from "runtimed";
 import { useEffect, useRef, useState, type FormEvent } from "react";
 import type {
   CommentAnchor,
@@ -494,7 +495,7 @@ function CommentAuthorAvatar({ author }: { author: CommentAuthor }) {
       className="flex size-5 items-center justify-center rounded-full text-[9px] font-semibold text-white"
       style={{ backgroundColor: author.color ?? "hsl(var(--muted-foreground))" }}
     >
-      {author.isAgent ? <Bot className="size-3" /> : authorInitials(author.displayName)}
+      {author.isAgent ? <Bot className="size-3" /> : actorInitials(author.displayName)}
     </div>
   );
 
@@ -509,7 +510,7 @@ function CommentAuthorAvatar({ author }: { author: CommentAuthor }) {
           style={{ backgroundColor: author.onBehalfOfColor ?? "hsl(var(--muted-foreground))" }}
           title={`on behalf of ${author.onBehalfOf}`}
         >
-          {authorInitials(author.onBehalfOf).slice(0, 1)}
+          {actorInitials(author.onBehalfOf).slice(0, 1)}
         </span>
       </div>
     );
@@ -750,13 +751,6 @@ function draftAnchorKey(anchor: CommentAnchor): string {
     default:
       return "notebook";
   }
-}
-
-function authorInitials(displayName: string): string {
-  const words = displayName.trim().split(/\s+/).filter(Boolean);
-  if (words.length === 0) return "?";
-  if (words.length === 1) return words[0].slice(0, 2).toUpperCase();
-  return (words[0][0] + words[words.length - 1][0]).toUpperCase();
 }
 
 function formatRelativeTime(iso: string | null | undefined): string {

--- a/src/components/notebook/NotebookIdentity.tsx
+++ b/src/components/notebook/NotebookIdentity.tsx
@@ -8,6 +8,7 @@ import {
   UsersRound,
   type LucideIcon,
 } from "lucide-react";
+import { actorInitials } from "runtimed";
 import { cn } from "@/lib/utils";
 import {
   Avatar,
@@ -171,7 +172,7 @@ export function NotebookActorAvatar({
       {actor.imageUrl ? <AvatarImage src={actor.imageUrl} alt="" /> : null}
       <AvatarFallback>
         {actor.kind === "human" || actor.kind === "local" ? (
-          initials(actor.label)
+          actorInitials(actor.label)
         ) : (
           <Icon className="size-3.5" aria-hidden="true" />
         )}
@@ -232,17 +233,6 @@ function statusTone(status: NonNullable<NotebookActorIdentity["status"]>): strin
     case "offline":
       return "bg-muted";
   }
-}
-
-function initials(label: string): string {
-  const trimmed = label.trim();
-  if (looksLikeEmailAddress(trimmed)) {
-    return "U";
-  }
-  const parts = trimmed.split(/\s+/).filter(Boolean);
-  if (parts.length === 0) return "?";
-  if (parts.length === 1) return parts[0].slice(0, 2).toUpperCase();
-  return `${parts[0][0]}${parts[1][0]}`.toUpperCase();
 }
 
 function looksLikeEmailAddress(label: string): boolean {


### PR DESCRIPTION
Next step of the identity-display consolidation (after the merged core #3738): point the safe ad-hoc display consumers at the canonical core in `packages/runtimed`.

## What it does
- **Initials unified** onto `actorInitials`: `NotebookCommentsPanel` and `NotebookIdentity` import it; the exported `cloudPresenceInitials` becomes a thin alias so its importers are unchanged. (The fourth helper lives in the unmerged in-editor highlight layer and will adopt it when that lands.)
- **Text-attribution tooltip** no longer shows raw `user:anaconda:<uuid>` labels: names resolve through `friendlyNotebookActorLabel`, via an optional `resolveActorName` option so a presence-aware resolver can be wired later. Dedup + empty-filtering applied.

## Behavior refinement (caught in review)
Collapsing onto the canonical function exposed a real divergence: `actorInitials` (modeled on `cloudPresenceInitials`) gave a single-word name **one** letter ("Alice" → "A"), while `NotebookIdentity` gave **two** ("AL"). That regressed identity avatars and broke a test. Fixed by making `actorInitials` keep two letters for a single word, which also richens cloud presence avatars (they previously showed one). Multi-word ("Kyle Kelley" → "KK") and email ("U") behavior unchanged.

## Deferred (with the 2.7 desktop-UI track)
The desktop `resolveCommentAuthor` migration (it carries a localStorage name-cache better solved server-side) and the comment-highlight tooltip stay out, they're not rendered yet.

## Verification
- [x] 56 tests across the affected component/resolver/attribution/cursor suites, plus cloud presence (12), all pass
- [x] typecheck/build for `packages/runtimed`, `apps/notebook`, `apps/notebook-cloud`, `apps/elements`
- [x] `vp check` clean
- Reviewed Claude-side (codex implemented); the single-word initials regression was caught and fixed here.
