### PR TITLE
feat(comments): in-editor source-range comment layer

### DIFF
--- a/apps/notebook-cloud/viewer/cloud-viewer-session.ts
+++ b/apps/notebook-cloud/viewer/cloud-viewer-session.ts
@@ -26,7 +26,7 @@ import {
   diagnoseCloudConnectionAccess,
   isCloudConnectionAccessDiagnostic,
 } from "./connection-diagnostics";
-import { materializeChangeset } from "../../notebook/src/notebook-surface";
+import { materializeChangeset } from "../../notebook/src/lib/frame-pipeline";
 import { startCursorDispatch } from "@/components/notebook/cursor-registry";
 import { emitBroadcast, emitPresence } from "@/components/notebook/state/notebook-frame-bus";
 import { resetPoolState, setPoolState } from "@/components/notebook/state/pool-state";

--- a/apps/notebook-cloud/viewer/notebook-viewer.tsx
+++ b/apps/notebook-cloud/viewer/notebook-viewer.tsx
@@ -42,6 +42,7 @@ import {
   type CommentAnchor,
   type CommentThreadSnapshot,
   type CommentsProjection,
+  type NotebookCommentDraftTarget,
 } from "@/components/notebook";
 import {
   openNotebookRailPanel,
@@ -80,6 +81,16 @@ import {
   cloudSyncAuthConnectionKey,
 } from "./session-auth-stability";
 import { NotebookView } from "../../notebook/src/notebook-surface";
+import { InlineCommentComposer } from "../../notebook/src/components/InlineCommentComposer";
+import {
+  setSourceCommentThreads,
+  type SourceCommentThread,
+} from "../../notebook/src/lib/comment-highlights";
+import {
+  resolveSourceRangeAnchor,
+  type SourceCommentSelectionRect,
+  type SourceRangeCommentAnchor,
+} from "../../notebook/src/lib/comment-source-anchor";
 import {
   CrdtBridgeProvider,
   createNotebookCellId,
@@ -272,6 +283,16 @@ export function NotebookViewer({
   const { activePanelId: activeRailPanel, collapsed: railCollapsed } = useNotebookRailUiState();
   const [commentsProjection, setCommentsProjection] = useState<CommentsProjection | null>(null);
   const [commentsError, setCommentsError] = useState<string | null>(null);
+  const [commentDraftTarget, setCommentDraftTarget] = useState<NotebookCommentDraftTarget | null>(
+    null,
+  );
+  const [sourceCommentRequest, setSourceCommentRequest] = useState<{
+    anchor: SourceRangeCommentAnchor;
+    rect: SourceCommentSelectionRect;
+  } | null>(null);
+  const [commentFocus, setCommentFocus] = useState<{ threadId: string; nonce: number } | null>(
+    null,
+  );
   const handledHeadingHashRef = useRef<string | null>(null);
   const [latestAccessRequest, setLatestAccessRequest] = useState<CloudNotebookAccessRequest | null>(
     null,
@@ -1175,6 +1196,22 @@ export function NotebookViewer({
     [shellCapabilities.canEditCells, shellCapabilities.canEditMarkdown, noteLocalCellEdit],
   );
   const canWriteComments = connectionScope === "editor" || connectionScope === "owner";
+  useEffect(() => {
+    if (!canWriteComments) {
+      setCommentDraftTarget(null);
+      setSourceCommentRequest(null);
+    }
+  }, [canWriteComments]);
+
+  const refreshCloudCommentsProjection = useCallback(() => {
+    const liveRuntime = liveRuntimeRef.current;
+    const projection = liveRuntime?.handle.get_comments_projection?.() as
+      | CommentsProjection
+      | undefined;
+    setCommentsProjection(projection ?? null);
+    return projection ?? null;
+  }, [liveRuntimeRef]);
+
   const applyLocalCommentEvent = useCallback(
     (event: unknown): boolean => {
       const liveRuntime = liveRuntimeRef.current;
@@ -1191,26 +1228,36 @@ export function NotebookViewer({
       }
       setCommentsError(null);
       liveRuntime.engine.scheduleFlush();
+      refreshCloudCommentsProjection();
       return true;
     },
-    [liveRuntimeRef],
+    [liveRuntimeRef, refreshCloudCommentsProjection],
   );
-  const handleCreateCommentThread = useCallback(
-    async (body: string) => {
-      if (!canWriteComments) return;
+
+  const handleCreateAnchoredCommentThread = useCallback(
+    async (anchor: CommentAnchor, body: string) => {
+      if (!canWriteComments) {
+        setCommentsError("Comments are read-only.");
+        return;
+      }
       const liveRuntime = liveRuntimeRef.current;
       if (!liveRuntime || typeof liveRuntime.handle.create_comment_thread !== "function") {
         setCommentsError("Comments are not ready.");
         return;
       }
       try {
-        const anchor: CommentAnchor = { kind: "notebook" };
+        const projection = refreshCloudCommentsProjection() ?? commentsProjection;
+        const orderScope = commentAnchorThreadOrderScope(anchor);
+        const afterThreadId =
+          projection?.threads
+            .filter((thread) => commentAnchorThreadOrderScope(thread.anchor) === orderScope)
+            .at(-1)?.id ?? null;
         const event = liveRuntime.handle.create_comment_thread(
           createCloudCommentId("thread"),
           createCloudCommentId("message"),
           anchor,
           body,
-          null,
+          afterThreadId,
           new Date().toISOString(),
         );
         applyLocalCommentEvent(event);
@@ -1218,8 +1265,124 @@ export function NotebookViewer({
         setCommentsError(error instanceof Error ? error.message : String(error));
       }
     },
-    [applyLocalCommentEvent, canWriteComments, liveRuntimeRef],
+    [
+      applyLocalCommentEvent,
+      canWriteComments,
+      commentsProjection,
+      liveRuntimeRef,
+      refreshCloudCommentsProjection,
+    ],
   );
+
+  const handleCreateCommentThread = useCallback(
+    async (body: string) => {
+      await handleCreateAnchoredCommentThread({ kind: "notebook" }, body);
+    },
+    [handleCreateAnchoredCommentThread],
+  );
+
+  const handleCreatePanelComment = useCallback(
+    async (body: string) => {
+      if (!commentDraftTarget) {
+        await handleCreateCommentThread(body);
+        return;
+      }
+      if (
+        commentDraftTarget.anchor.kind === "source_range" &&
+        !sourceRangeAnchorMatchesCurrentCell(commentDraftTarget.anchor)
+      ) {
+        setCommentsError("Selected source changed. Select the text again before commenting.");
+        return;
+      }
+      await handleCreateAnchoredCommentThread(commentDraftTarget.anchor, body);
+      setCommentDraftTarget(null);
+    },
+    [commentDraftTarget, handleCreateAnchoredCommentThread, handleCreateCommentThread],
+  );
+
+  const handleRequestSourceComment = useCallback(
+    (anchor: SourceRangeCommentAnchor, rect: SourceCommentSelectionRect | null) => {
+      setCommentsError(null);
+      if (rect) {
+        setSourceCommentRequest({ anchor, rect });
+        return;
+      }
+      setSourceCommentRequest(null);
+      setCommentDraftTarget({ anchor, quote: anchor.exact_quote ?? null });
+      openNotebookRailPanel("comments");
+    },
+    [],
+  );
+
+  const handleSubmitSourceComment = useCallback(
+    async (body: string) => {
+      if (!sourceCommentRequest) return;
+      if (!sourceRangeAnchorMatchesCurrentCell(sourceCommentRequest.anchor)) {
+        setSourceCommentRequest(null);
+        setCommentsError("Selected source changed. Select the text again before commenting.");
+        return;
+      }
+      await handleCreateAnchoredCommentThread(sourceCommentRequest.anchor, body);
+      setSourceCommentRequest(null);
+    },
+    [handleCreateAnchoredCommentThread, sourceCommentRequest],
+  );
+
+  const handleCancelSourceComment = useCallback(() => {
+    setSourceCommentRequest(null);
+  }, []);
+
+  const handleClearCommentDraftTarget = useCallback(() => {
+    setCommentDraftTarget(null);
+  }, []);
+
+  const sourceCommentThreadsByCell = useMemo(() => {
+    const map = new Map<string, SourceCommentThread[]>();
+    for (const thread of commentsProjection?.threads ?? []) {
+      if (thread.anchor.kind !== "source_range") continue;
+      const list = map.get(thread.anchor.cell_id) ?? [];
+      const firstMessage = thread.messages[0];
+      const author = thread.created_by_actor_label
+        ? resolveCloudCommentAuthor(thread.created_by_actor_label)
+        : undefined;
+      list.push({
+        threadId: thread.id,
+        anchor: thread.anchor,
+        resolved: thread.status === "resolved",
+        color: author?.color,
+        preview: firstMessage
+          ? {
+              authorName: author?.displayName ?? "Unknown",
+              authorColor: author?.color,
+              isAgent: author?.isAgent,
+              onBehalfOf: author?.onBehalfOf,
+              onBehalfOfColor: author?.onBehalfOfColor,
+              body: firstMessage.body,
+              replyCount: Math.max(0, thread.messages.length - 1),
+            }
+          : undefined,
+      });
+      map.set(thread.anchor.cell_id, list);
+    }
+    return map;
+  }, [commentsProjection, resolveCloudCommentAuthor]);
+
+  useEffect(() => {
+    setSourceCommentThreads(sourceCommentThreadsByCell);
+  }, [sourceCommentThreadsByCell]);
+
+  const handleActivateCommentThread = useCallback((threadId: string) => {
+    openNotebookRailPanel("comments");
+    setCommentFocus((previous) => ({ threadId, nonce: (previous?.nonce ?? 0) + 1 }));
+  }, []);
+
+  const resolveCommentSourceLanguage = useCallback((cellId: string): string | undefined => {
+    const cell = getCellById(cellId);
+    if (cell?.cell_type !== "code") return undefined;
+    const language = typeof cell.metadata.language === "string" ? cell.metadata.language : null;
+    return cloudSourceLanguage(language);
+  }, []);
+
   const handleReplyCommentThread = useCallback(
     async (threadId: string, body: string) => {
       if (!canWriteComments) return;
@@ -1229,11 +1392,14 @@ export function NotebookViewer({
         return;
       }
       try {
+        const projection = refreshCloudCommentsProjection() ?? commentsProjection;
+        const afterMessageId =
+          projection?.threads.find((thread) => thread.id === threadId)?.messages.at(-1)?.id ?? null;
         const event = liveRuntime.handle.reply_comment_thread(
           threadId,
           createCloudCommentId("message"),
           body,
-          null,
+          afterMessageId,
           new Date().toISOString(),
         );
         applyLocalCommentEvent(event);
@@ -1241,7 +1407,13 @@ export function NotebookViewer({
         setCommentsError(error instanceof Error ? error.message : String(error));
       }
     },
-    [applyLocalCommentEvent, canWriteComments, liveRuntimeRef],
+    [
+      applyLocalCommentEvent,
+      canWriteComments,
+      commentsProjection,
+      liveRuntimeRef,
+      refreshCloudCommentsProjection,
+    ],
   );
   const handleResolveCommentThread = useCallback(
     async (threadId: string) => {
@@ -1506,18 +1678,24 @@ export function NotebookViewer({
     !shouldShowCloudWorkstationsPanel && activeRailPanel === "workstations"
       ? "outline"
       : activeRailPanel;
+  const commentsPanelStatus = commentsProjection ? null : "Syncing comments...";
   const commentsPanel = (
     <NotebookCommentsPanel
       projection={commentsProjection}
       readOnly={!canWriteComments}
-      statusMessage={commentsProjection ? null : "Syncing comments..."}
+      draftTarget={canWriteComments ? commentDraftTarget : null}
+      statusMessage={commentsPanelStatus}
       errorMessage={commentsError}
-      onCreateThread={canWriteComments ? handleCreateCommentThread : undefined}
+      onClearDraftTarget={commentDraftTarget ? handleClearCommentDraftTarget : undefined}
+      onCreateThread={canWriteComments ? handleCreatePanelComment : undefined}
       onReplyThread={canWriteComments ? handleReplyCommentThread : undefined}
       onResolveThread={canWriteComments ? handleResolveCommentThread : undefined}
       onReopenThread={canWriteComments ? handleReopenCommentThread : undefined}
       onFocusThreadAnchor={handleFocusCommentAnchor}
       resolveCommentAuthor={resolveCloudCommentAuthor}
+      focusedThreadId={commentFocus?.threadId ?? null}
+      focusNonce={commentFocus?.nonce ?? 0}
+      resolveSourceLanguage={resolveCommentSourceLanguage}
     />
   );
   const rail = (
@@ -1793,6 +1971,8 @@ export function NotebookViewer({
                 onMoveCell={handleCloudMoveCell}
                 onSetCellSourceHidden={handleCloudSetCellSourceHidden}
                 onSetCellOutputsHidden={handleCloudSetCellOutputsHidden}
+                onCreateSourceComment={canWriteComments ? handleRequestSourceComment : undefined}
+                onActivateCommentThread={handleActivateCommentThread}
                 markdownHeadingAnchorsByCellId={notebookViewModel.markdownHeadingAnchorsByCellId}
                 outputHostContext={outputHostContext}
                 deferOutputIsolatedFramesUntilVisible={!shellCapabilities.canEditCells}
@@ -1803,6 +1983,15 @@ export function NotebookViewer({
           </CrdtBridgeProvider>
         </PresenceValueProvider>
       </NotebookDocumentShell>
+      {sourceCommentRequest ? (
+        <InlineCommentComposer
+          rect={sourceCommentRequest.rect}
+          quote={sourceCommentRequest.anchor.exact_quote}
+          disabled={!canWriteComments}
+          onSubmit={handleSubmitSourceComment}
+          onCancel={handleCancelSourceComment}
+        />
+      ) : null}
     </NotebookHostProvider>
   );
 }
@@ -1816,6 +2005,28 @@ function cloudNotebookEnvironmentManager(
     }
   }
   return null;
+}
+
+function commentAnchorThreadOrderScope(anchor: CommentAnchor): string {
+  switch (anchor.kind) {
+    case "notebook":
+      return "notebook";
+    case "cell":
+    case "source_range":
+      return `cell:${anchor.cell_id}`;
+    case "cell_range":
+      return `cell_range:${anchor.start_cell_id}:${anchor.end_cell_id}`;
+    case "output":
+      return `output:${anchor.cell_id}:${anchor.execution_id ?? ""}:${anchor.output_id ?? ""}`;
+  }
+}
+
+function sourceRangeAnchorMatchesCurrentCell(anchor: SourceRangeCommentAnchor): boolean {
+  const cell = getCellById(anchor.cell_id);
+  if (!cell || (cell.cell_type !== "code" && cell.cell_type !== "raw")) {
+    return false;
+  }
+  return resolveSourceRangeAnchor(cell.source, anchor) !== null;
 }
 
 function createCloudCommentId(prefix: string): string {

--- a/apps/notebook/src/App.tsx
+++ b/apps/notebook/src/App.tsx
@@ -3,6 +3,10 @@ import {
   deriveEnvManager,
   deriveRuntimeKind,
   NotebookClient,
+  resolveActorDisplay,
+  type CommentAnchor,
+  type CommentThreadSnapshot,
+  type CommentsProjection,
   type ExecuteCellOptions,
   type NotebookResponse,
   type NotebookOutlineItem,
@@ -43,6 +47,7 @@ import {
   DebugBanner,
   EnvBuildDecisionDialog,
   KernelLaunchErrorBanner,
+  NotebookCommentsPanel,
   NotebookConnectionIdentity,
   NotebookDocumentRail,
   NotebookDocumentShell,
@@ -50,8 +55,21 @@ import {
   shouldShowKernelLaunchErrorBanner,
   TrustDialog,
   UntrustedBanner,
+  type CommentAuthor,
+  type NotebookCommentDraftTarget,
 } from "@/components/notebook";
 import { GlobalFindBar } from "@/components/search";
+import { InlineCommentComposer } from "./components/InlineCommentComposer";
+import { setSourceCommentThreads, type SourceCommentThread } from "./lib/comment-highlights";
+import {
+  resolveSourceRangeAnchor,
+  type SourceCommentSelectionRect,
+  type SourceRangeCommentAnchor,
+} from "./lib/comment-source-anchor";
+import {
+  setCommentsProjectionSnapshot,
+  useCommentsProjection,
+} from "./lib/comments-projection-store";
 import { createDesktopConnectionStatusSource } from "./lib/desktop-connection-status";
 import {
   CondaDependencyPanel as CondaDependencyHeader,
@@ -104,7 +122,7 @@ import {
   markExecutionPerformance,
   startExecutionPerformanceTrace,
 } from "./lib/execution-performance";
-import { getNotebookCellsSnapshot } from "@/components/notebook/state/cell-store";
+import { getCellById, getNotebookCellsSnapshot } from "@/components/notebook/state/cell-store";
 import { useNotebookViewModel } from "@/components/notebook/state/view-model-store";
 import { useDetectRuntime, useNotebookMetadata } from "./lib/notebook-metadata";
 import { useNotebookHost } from "@nteract/notebook-host";
@@ -176,6 +194,35 @@ async function sendMessage(message: unknown): Promise<void> {
 
 function createClientExecutionId(): string {
   return globalThis.crypto.randomUUID();
+}
+
+function createLocalCommentEntityId(prefix: "thread" | "message"): string {
+  return `${prefix}-${globalThis.crypto.randomUUID()}`;
+}
+
+function canConnectionScopeMutateComments(connectionScope: string | null): boolean {
+  return connectionScope === null || connectionScope === "editor" || connectionScope === "owner";
+}
+
+function commentAnchorThreadOrderScope(anchor: CommentAnchor): string {
+  switch (anchor.kind) {
+    case "notebook":
+      return "notebook";
+    case "cell":
+    case "source_range":
+      return `cell:${anchor.cell_id}`;
+    case "output":
+      return `output:${anchor.cell_id}:${anchor.execution_id ?? ""}:${anchor.output_id ?? ""}`;
+    case "cell_range":
+      return `cell_range:${anchor.start_cell_id}:${anchor.end_cell_id}`;
+  }
+}
+
+function sourceRangeAnchorMatchesCurrentCell(anchor: CommentAnchor): boolean {
+  if (anchor.kind !== "source_range") return false;
+  const cell = getCellById(anchor.cell_id);
+  if (!cell || (cell.cell_type !== "code" && cell.cell_type !== "raw")) return false;
+  return resolveSourceRangeAnchor(cell.source, anchor) !== null;
 }
 
 function markClientExecuteResponse(
@@ -313,6 +360,37 @@ function AppContent() {
   // `useObservable` seeds with `null` until the engine emits.
   const sessionStatus = useObservable<SessionStatus | null>(sessionStatus$, null);
   const sessionReady = sessionStatus?.runtime_state === "ready";
+  const commentsProjection = useCommentsProjection();
+  const [commentsError, setCommentsError] = useState<string | null>(null);
+  const [commentDraftTarget, setCommentDraftTarget] = useState<NotebookCommentDraftTarget | null>(
+    null,
+  );
+  const [sourceCommentRequest, setSourceCommentRequest] = useState<{
+    anchor: SourceRangeCommentAnchor;
+    rect: SourceCommentSelectionRect;
+  } | null>(null);
+  const [commentFocus, setCommentFocus] = useState<{ threadId: string; nonce: number } | null>(
+    null,
+  );
+
+  const refreshCommentsProjection = useCallback(() => {
+    const projection =
+      (getHandle()?.get_comments_projection?.() as CommentsProjection | undefined) ?? null;
+    setCommentsProjectionSnapshot(projection);
+    return projection;
+  }, [getHandle]);
+
+  useEffect(() => {
+    refreshCommentsProjection();
+    const engine = getEngine();
+    if (!engine) return;
+    const subscription = engine.commentsProjection$.subscribe((projection) => {
+      setCommentsProjectionSnapshot(projection);
+      setCommentsError(null);
+    });
+    return () => subscription.unsubscribe();
+  }, [getEngine, refreshCommentsProjection, sessionStatus?.notebook_doc]);
+
   // Global find (Cmd+F)
   const globalFind = useGlobalFind(cellIds);
 
@@ -531,6 +609,319 @@ function AppContent() {
       sessionReady,
       statusKey,
     ],
+  );
+  const canMutateComments =
+    Boolean(commentsProjection) && canConnectionScopeMutateComments(connectionScope);
+  const commentsPanelStatus =
+    commentsProjection === null
+      ? "Comments sync unavailable."
+      : canMutateComments
+        ? null
+        : "Read-only connection.";
+  const failCommentAction = useCallback((message: string): never => {
+    setCommentsError(message);
+    throw new Error(message);
+  }, []);
+
+  useEffect(() => {
+    if (!canMutateComments) {
+      setCommentDraftTarget(null);
+      setSourceCommentRequest(null);
+    }
+  }, [canMutateComments]);
+
+  const applyLocalCommentEvent = useCallback(
+    (event: unknown): boolean => {
+      const engine = getEngine();
+      if (!engine) {
+        setCommentsError("Comments are not connected.");
+        return false;
+      }
+      const applied = engine.applyLocalMutationEvent(
+        event as Parameters<typeof engine.applyLocalMutationEvent>[0],
+      );
+      if (!applied) {
+        setCommentsError("Unable to update comments.");
+        return false;
+      }
+      setCommentsError(null);
+      engine.scheduleFlush();
+      refreshCommentsProjection();
+      return true;
+    },
+    [getEngine, refreshCommentsProjection],
+  );
+
+  const handleCreateCommentThread = useCallback(
+    async (anchor: CommentAnchor, body: string) => {
+      if (!canMutateComments) {
+        return failCommentAction("Comments are read-only.");
+      }
+      const handle = getHandle();
+      if (!handle || typeof handle.create_comment_thread !== "function") {
+        return failCommentAction("Comments sync unavailable.");
+      }
+      setCommentsError(null);
+      const projection = refreshCommentsProjection() ?? commentsProjection;
+      const orderScope = commentAnchorThreadOrderScope(anchor);
+      const afterThreadId =
+        projection?.threads
+          .filter((thread) => commentAnchorThreadOrderScope(thread.anchor) === orderScope)
+          .at(-1)?.id ?? null;
+      try {
+        const event = handle.create_comment_thread(
+          createLocalCommentEntityId("thread"),
+          createLocalCommentEntityId("message"),
+          anchor,
+          body,
+          afterThreadId,
+          new Date().toISOString(),
+        );
+        if (!applyLocalCommentEvent(event)) {
+          throw new Error("Unable to update comments.");
+        }
+      } catch (error) {
+        const message = error instanceof Error ? error.message : "Create comment failed.";
+        setCommentsError(message);
+        throw error instanceof Error ? error : new Error(message);
+      }
+    },
+    [
+      applyLocalCommentEvent,
+      canMutateComments,
+      commentsProjection,
+      failCommentAction,
+      getHandle,
+      refreshCommentsProjection,
+    ],
+  );
+
+  const handleCreateDocumentComment = useCallback(
+    (body: string) => handleCreateCommentThread({ kind: "notebook" }, body),
+    [handleCreateCommentThread],
+  );
+
+  const handleCreatePanelComment = useCallback(
+    async (body: string) => {
+      if (!commentDraftTarget) {
+        await handleCreateDocumentComment(body);
+        return;
+      }
+      if (!sourceRangeAnchorMatchesCurrentCell(commentDraftTarget.anchor)) {
+        failCommentAction("Selected source changed. Select the text again before commenting.");
+        return;
+      }
+      await handleCreateCommentThread(commentDraftTarget.anchor, body);
+      setCommentDraftTarget(null);
+    },
+    [commentDraftTarget, failCommentAction, handleCreateCommentThread, handleCreateDocumentComment],
+  );
+
+  const handleRequestSourceComment = useCallback(
+    (anchor: SourceRangeCommentAnchor, rect: SourceCommentSelectionRect | null) => {
+      setCommentsError(null);
+      if (rect) {
+        setSourceCommentRequest({ anchor, rect });
+        return;
+      }
+      setSourceCommentRequest(null);
+      setCommentDraftTarget({ anchor, quote: anchor.exact_quote ?? null });
+      openNotebookRailPanel("comments");
+    },
+    [],
+  );
+
+  const handleSubmitSourceComment = useCallback(
+    async (body: string) => {
+      if (!sourceCommentRequest) return;
+      if (!sourceRangeAnchorMatchesCurrentCell(sourceCommentRequest.anchor)) {
+        setSourceCommentRequest(null);
+        setCommentsError("Selected source changed. Select the text again before commenting.");
+        return;
+      }
+      await handleCreateCommentThread(sourceCommentRequest.anchor, body);
+      setSourceCommentRequest(null);
+    },
+    [handleCreateCommentThread, sourceCommentRequest],
+  );
+
+  const handleCancelSourceComment = useCallback(() => {
+    setSourceCommentRequest(null);
+  }, []);
+
+  const resolveCommentAuthor = useCallback(
+    (actorLabel: string): CommentAuthor => {
+      const display = resolveActorDisplay({
+        actorLabel,
+        peers: [],
+        source: connectionScope ? "cloud" : "local",
+      });
+      return {
+        displayName: display.displayName,
+        color: display.color,
+        isAgent: display.isAgent,
+        onBehalfOf: display.onBehalfOf,
+        onBehalfOfColor: display.onBehalfOf ? display.color : undefined,
+      };
+    },
+    [connectionScope],
+  );
+
+  const resolveSourceLanguage = useCallback(
+    (cellId: string): string | undefined => {
+      const cell = getCellById(cellId);
+      if (cell?.cell_type !== "code") return undefined;
+      return runtime === "python" ? "python" : runtime === "deno" ? "typescript" : undefined;
+    },
+    [runtime],
+  );
+
+  const sourceCommentThreadsByCell = useMemo(() => {
+    const map = new Map<string, SourceCommentThread[]>();
+    for (const thread of commentsProjection?.threads ?? []) {
+      if (thread.anchor.kind !== "source_range") continue;
+      const list = map.get(thread.anchor.cell_id) ?? [];
+      const firstMessage = thread.messages[0];
+      const author = thread.created_by_actor_label
+        ? resolveCommentAuthor(thread.created_by_actor_label)
+        : undefined;
+      list.push({
+        threadId: thread.id,
+        anchor: thread.anchor,
+        resolved: thread.status === "resolved",
+        color: author?.color,
+        preview: firstMessage
+          ? {
+              authorName: author?.displayName ?? "Unknown",
+              authorColor: author?.color,
+              isAgent: author?.isAgent,
+              onBehalfOf: author?.onBehalfOf,
+              onBehalfOfColor: author?.onBehalfOfColor,
+              body: firstMessage.body,
+              replyCount: Math.max(0, thread.messages.length - 1),
+            }
+          : undefined,
+      });
+      map.set(thread.anchor.cell_id, list);
+    }
+    return map;
+  }, [commentsProjection, resolveCommentAuthor]);
+
+  useEffect(() => {
+    setSourceCommentThreads(sourceCommentThreadsByCell);
+  }, [sourceCommentThreadsByCell]);
+
+  const handleActivateCommentThread = useCallback((threadId: string) => {
+    openNotebookRailPanel("comments");
+    setCommentFocus((previous) => ({ threadId, nonce: (previous?.nonce ?? 0) + 1 }));
+  }, []);
+
+  const handleClearCommentDraftTarget = useCallback(() => {
+    setCommentDraftTarget(null);
+  }, []);
+
+  const handleReplyCommentThread = useCallback(
+    async (threadId: string, body: string) => {
+      if (!canMutateComments) return;
+      const handle = getHandle();
+      if (!handle || typeof handle.reply_comment_thread !== "function") {
+        return failCommentAction("Comments sync unavailable.");
+      }
+      setCommentsError(null);
+      const projection = refreshCommentsProjection() ?? commentsProjection;
+      const afterMessageId =
+        projection?.threads.find((thread) => thread.id === threadId)?.messages.at(-1)?.id ?? null;
+      try {
+        const event = handle.reply_comment_thread(
+          threadId,
+          createLocalCommentEntityId("message"),
+          body,
+          afterMessageId,
+          new Date().toISOString(),
+        );
+        if (!applyLocalCommentEvent(event)) {
+          throw new Error("Unable to update comments.");
+        }
+      } catch (error) {
+        const message = error instanceof Error ? error.message : "Reply failed.";
+        setCommentsError(message);
+        throw error instanceof Error ? error : new Error(message);
+      }
+    },
+    [
+      applyLocalCommentEvent,
+      canMutateComments,
+      commentsProjection,
+      failCommentAction,
+      getHandle,
+      refreshCommentsProjection,
+    ],
+  );
+
+  const handleResolveCommentThread = useCallback(
+    async (threadId: string) => {
+      if (!canMutateComments) return;
+      const handle = getHandle();
+      if (!handle || typeof handle.resolve_comment_thread !== "function") {
+        return failCommentAction("Comments sync unavailable.");
+      }
+      try {
+        const event = handle.resolve_comment_thread(threadId, new Date().toISOString());
+        if (!applyLocalCommentEvent(event)) {
+          throw new Error("Unable to update comments.");
+        }
+      } catch (error) {
+        setCommentsError(error instanceof Error ? error.message : String(error));
+      }
+    },
+    [applyLocalCommentEvent, canMutateComments, failCommentAction, getHandle],
+  );
+
+  const handleReopenCommentThread = useCallback(
+    async (threadId: string) => {
+      if (!canMutateComments) return;
+      const handle = getHandle();
+      if (!handle || typeof handle.reopen_comment_thread !== "function") {
+        return failCommentAction("Comments sync unavailable.");
+      }
+      try {
+        const event = handle.reopen_comment_thread(threadId);
+        if (!applyLocalCommentEvent(event)) {
+          throw new Error("Unable to update comments.");
+        }
+      } catch (error) {
+        setCommentsError(error instanceof Error ? error.message : String(error));
+      }
+    },
+    [applyLocalCommentEvent, canMutateComments, failCommentAction, getHandle],
+  );
+
+  const handleFocusCommentThreadAnchor = useCallback((thread: CommentThreadSnapshot) => {
+    const cellId = thread.badge_cell_ids[0];
+    if (cellId) {
+      setFocusedCellId(cellId);
+      flushCellUIState();
+    }
+  }, []);
+
+  const commentsPanel = (
+    <NotebookCommentsPanel
+      projection={commentsProjection}
+      readOnly={!canMutateComments}
+      draftTarget={canMutateComments ? commentDraftTarget : null}
+      statusMessage={commentsPanelStatus}
+      errorMessage={commentsError}
+      onClearDraftTarget={commentDraftTarget ? handleClearCommentDraftTarget : undefined}
+      onCreateThread={canMutateComments ? handleCreatePanelComment : undefined}
+      onReplyThread={canMutateComments ? handleReplyCommentThread : undefined}
+      onResolveThread={canMutateComments ? handleResolveCommentThread : undefined}
+      onReopenThread={canMutateComments ? handleReopenCommentThread : undefined}
+      onFocusThreadAnchor={handleFocusCommentThreadAnchor}
+      resolveCommentAuthor={resolveCommentAuthor}
+      focusedThreadId={commentFocus?.threadId ?? null}
+      focusNonce={commentFocus?.nonce ?? 0}
+      resolveSourceLanguage={resolveSourceLanguage}
+    />
   );
 
   // Connection/identity slot source: daemon lifecycle, stable for the
@@ -1457,6 +1848,7 @@ function AppContent() {
               onCollapsedChange={setNotebookRailCollapsed}
               onSelectOutlineItem={handleSelectOutlineItem}
               onNavigateOutlineItem={handleNavigateOutlineItem}
+              commentsPanel={commentsPanel}
               packagesPanel={
                 <NotebookPackagesPanel readOnly={!shellCapabilities.canManagePackages}>
                   {runtime === "python" && hasUvDependencies && hasCondaDependencies && (
@@ -1609,12 +2001,23 @@ function AppContent() {
                 onReportOutputMatchCount={globalFind.reportOutputMatchCount}
                 onSetCellSourceHidden={setCellSourceHidden}
                 onSetCellOutputsHidden={setCellOutputsHidden}
+                onCreateSourceComment={canMutateComments ? handleRequestSourceComment : undefined}
+                onActivateCommentThread={handleActivateCommentThread}
                 markdownHeadingAnchorsByCellId={markdownHeadingAnchorsByCellId}
               />
             </CrdtBridgeProvider>
           </div>
         </NotebookDocumentShell>
       </div>
+      {sourceCommentRequest ? (
+        <InlineCommentComposer
+          rect={sourceCommentRequest.rect}
+          quote={sourceCommentRequest.anchor.exact_quote}
+          disabled={!canMutateComments}
+          onSubmit={handleSubmitSourceComment}
+          onCancel={handleCancelSourceComment}
+        />
+      ) : null}
     </PresenceProvider>
   );
 }

--- a/apps/notebook/src/components/CodeCell.tsx
+++ b/apps/notebook/src/components/CodeCell.tsx
@@ -41,6 +41,13 @@ import { logNotebookIsolatedDiagnostic } from "../lib/isolated-diagnostics";
 import { useCellOutputs } from "@/components/notebook/state/output-store";
 import { openUrl } from "../lib/open-url";
 import { presenceSenderExtension } from "../lib/presence-sender";
+import { commentHighlightExtension } from "../lib/comment-highlight-extension";
+import { refreshCellCommentHighlights } from "../lib/comment-highlights";
+import type {
+  SourceCommentSelectionRect,
+  SourceRangeCommentAnchor,
+} from "../lib/comment-source-anchor";
+import { sourceCommentExtension } from "../lib/source-comment-extension";
 import { tabCompletionKeymap } from "../lib/tab-completion";
 import type { CodeCell as CodeCellType, JupyterOutput } from "../types";
 import { CellPresenceIndicators } from "./cell/CellPresenceIndicators";
@@ -96,6 +103,11 @@ interface CodeCellProps {
   rightGutterContent?: ReactNode;
   readOnly?: boolean;
   canExecute?: boolean;
+  onCreateSourceComment?: (
+    anchor: SourceRangeCommentAnchor,
+    rect: SourceCommentSelectionRect | null,
+  ) => void;
+  onActivateCommentThread?: (threadId: string) => void;
   outputHostContext?: NteractEmbedHostContextPatch;
   deferOutputIsolatedFrameUntilVisible?: boolean;
   deferredOutputIsolatedFrameRootMargin?: string;
@@ -347,6 +359,8 @@ export const CodeCell = memo(function CodeCell({
   rightGutterContent,
   readOnly = false,
   canExecute = !readOnly,
+  onCreateSourceComment,
+  onActivateCommentThread,
   outputHostContext,
   deferOutputIsolatedFrameUntilVisible = false,
   deferredOutputIsolatedFrameRootMargin,
@@ -445,6 +459,7 @@ export const CodeCell = memo(function CodeCell({
         registeredViewRef.current = view;
         registerCellEditor(cell.id, view);
         onEditorRegistered(cell.id);
+        refreshCellCommentHighlights(cell.id);
         return true;
       }
       return false;
@@ -603,7 +618,25 @@ export const CodeCell = memo(function CodeCell({
     ];
   }, [cell.id, presence]);
 
-  // CodeMirror extensions: CRDT bridge + kernel completion + tab completion + search highlighting + remote cursors + presence sender
+  const sourceCommentExt = useMemo(() => {
+    // The create affordance (selection tooltip + keymap) needs editor focus,
+    // which a read-only editor never takes, so offer it only on editable cells.
+    // Reading existing threads stays open to everyone via commentHighlightExt.
+    if (readOnly || !onCreateSourceComment) return [];
+    return [sourceCommentExtension(cell.id, onCreateSourceComment)];
+  }, [cell.id, onCreateSourceComment, readOnly]);
+
+  const commentHighlightExt = useMemo(() => {
+    if (!onActivateCommentThread) return [];
+    return [
+      commentHighlightExtension({
+        onActivate: onActivateCommentThread,
+        onReady: () => refreshCellCommentHighlights(cell.id),
+      }),
+    ];
+  }, [cell.id, onActivateCommentThread]);
+
+  // CodeMirror extensions: CRDT bridge, completion, search, presence, and comments.
   const editorExtensions = useMemo(
     () => [
       crdtBridgeExt,
@@ -613,6 +646,8 @@ export const CodeCell = memo(function CodeCell({
       ...remoteCursorsExt,
       ...textAttributionExt,
       ...presenceSenderExt,
+      ...sourceCommentExt,
+      ...commentHighlightExt,
     ],
     [
       crdtBridgeExt,
@@ -622,6 +657,8 @@ export const CodeCell = memo(function CodeCell({
       remoteCursorsExt,
       textAttributionExt,
       presenceSenderExt,
+      sourceCommentExt,
+      commentHighlightExt,
     ],
   );
 

--- a/apps/notebook/src/components/InlineCommentComposer.tsx
+++ b/apps/notebook/src/components/InlineCommentComposer.tsx
@@ -1,0 +1,150 @@
+import { MessageSquarePlus } from "lucide-react";
+import {
+  type CSSProperties,
+  type FormEvent,
+  type KeyboardEvent,
+  useEffect,
+  useRef,
+  useState,
+} from "react";
+import { Popover, PopoverAnchor, PopoverContent } from "@/components/ui/popover";
+import { cn } from "@/lib/utils";
+import type { SourceCommentSelectionRect } from "../lib/comment-source-anchor";
+
+export interface InlineCommentComposerProps {
+  /** Viewport-space rectangle of the selection the comment is anchored to. */
+  rect: SourceCommentSelectionRect;
+  /** Selected source text, shown as a quote preview above the input. */
+  quote?: string | null;
+  disabled?: boolean;
+  onSubmit: (body: string) => void | Promise<void>;
+  onCancel: () => void;
+}
+
+const MAX_QUOTE_PREVIEW_CHARS = 160;
+
+export function InlineCommentComposer({
+  rect,
+  quote,
+  disabled = false,
+  onSubmit,
+  onCancel,
+}: InlineCommentComposerProps) {
+  const [body, setBody] = useState("");
+  const [submitting, setSubmitting] = useState(false);
+  const textareaRef = useRef<HTMLTextAreaElement>(null);
+
+  useEffect(() => {
+    textareaRef.current?.focus();
+  }, []);
+
+  const submit = async () => {
+    const trimmed = body.trim();
+    if (!trimmed || disabled || submitting) return;
+    setSubmitting(true);
+    try {
+      await onSubmit(trimmed);
+    } catch {
+      setSubmitting(false);
+    }
+  };
+
+  const handleSubmit = (event: FormEvent) => {
+    event.preventDefault();
+    void submit();
+  };
+
+  const handleKeyDown = (event: KeyboardEvent<HTMLTextAreaElement>) => {
+    if (event.key === "Enter" && (event.metaKey || event.ctrlKey)) {
+      event.preventDefault();
+      void submit();
+    }
+  };
+
+  const anchorStyle: CSSProperties = {
+    position: "fixed",
+    left: rect.left,
+    top: rect.top,
+    width: Math.max(1, rect.right - rect.left),
+    height: Math.max(1, rect.bottom - rect.top),
+    pointerEvents: "none",
+  };
+
+  const preview = formatQuotePreview(quote);
+
+  return (
+    <Popover
+      open
+      onOpenChange={(open) => {
+        if (!open) onCancel();
+      }}
+    >
+      <PopoverAnchor asChild>
+        <div aria-hidden style={anchorStyle} />
+      </PopoverAnchor>
+      <PopoverContent
+        side="top"
+        align="start"
+        sideOffset={8}
+        collisionPadding={12}
+        className="w-80 space-y-2 p-3"
+        data-testid="inline-comment-composer"
+        onOpenAutoFocus={(event) => {
+          event.preventDefault();
+          textareaRef.current?.focus();
+        }}
+      >
+        <div className="flex items-center gap-1.5 text-xs font-medium text-muted-foreground">
+          <MessageSquarePlus className="size-3.5" aria-hidden="true" />
+          Comment on selection
+        </div>
+        {preview ? (
+          <blockquote className="max-h-16 overflow-hidden whitespace-pre-wrap break-words border-l-2 border-border pl-2 text-xs leading-5 text-foreground">
+            {preview}
+          </blockquote>
+        ) : null}
+        <form className="space-y-2" onSubmit={handleSubmit}>
+          <textarea
+            ref={textareaRef}
+            aria-label="Comment on selection"
+            value={body}
+            disabled={disabled || submitting}
+            placeholder="Add a comment"
+            onChange={(event) => setBody(event.target.value)}
+            onKeyDown={handleKeyDown}
+            rows={3}
+            className={cn(
+              "min-h-16 w-full resize-y rounded-md border bg-background px-2.5 py-2 text-sm leading-5",
+              "placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/30",
+              (disabled || submitting) && "cursor-not-allowed opacity-60",
+            )}
+          />
+          <div className="flex items-center justify-end gap-2">
+            <button
+              type="button"
+              onClick={onCancel}
+              className="inline-flex min-h-8 items-center rounded-md px-2.5 text-xs font-medium text-muted-foreground transition-colors hover:bg-muted hover:text-foreground"
+            >
+              Cancel
+            </button>
+            <button
+              type="submit"
+              disabled={disabled || submitting || body.trim().length === 0}
+              className="inline-flex min-h-8 items-center rounded-md border bg-background px-2.5 text-xs font-medium text-foreground transition-colors hover:bg-muted disabled:cursor-not-allowed disabled:opacity-50"
+            >
+              Comment
+            </button>
+          </div>
+        </form>
+      </PopoverContent>
+    </Popover>
+  );
+}
+
+function formatQuotePreview(quote: string | null | undefined): string | null {
+  if (!quote) return null;
+  const trimmed = quote.trim();
+  if (trimmed.length === 0) return null;
+  if (quote.length <= MAX_QUOTE_PREVIEW_CHARS) return quote;
+  return `${quote.slice(0, MAX_QUOTE_PREVIEW_CHARS - 3)}...`;
+}

--- a/apps/notebook/src/components/NotebookView.tsx
+++ b/apps/notebook/src/components/NotebookView.tsx
@@ -60,6 +60,10 @@ import type { CodeCell as CodeCellType, NotebookCell } from "../types";
 import { CodeCell, type HiddenGroupCellSummary } from "./CodeCell";
 import { MarkdownCell } from "./MarkdownCell";
 import { RawCell } from "./RawCell";
+import type {
+  SourceCommentSelectionRect,
+  SourceRangeCommentAnchor,
+} from "../lib/comment-source-anchor";
 
 type AddCellResult = NotebookCell | null;
 type AddCellHandler = (type: CellInsertionType, afterCellId?: string | null) => AddCellResult;
@@ -84,6 +88,11 @@ export interface NotebookViewProps {
   onReportOutputMatchCount?: (cellId: string, count: number) => void;
   onSetCellSourceHidden?: (cellId: string, hidden: boolean) => void;
   onSetCellOutputsHidden?: (cellId: string, hidden: boolean) => void;
+  onCreateSourceComment?: (
+    anchor: SourceRangeCommentAnchor,
+    rect: SourceCommentSelectionRect | null,
+  ) => void;
+  onActivateCommentThread?: (threadId: string) => void;
   markdownHeadingAnchorsByCellId?: ReadonlyMap<string, readonly MarkdownHeadingAnchor[]>;
   outputHostContext?: NteractEmbedHostContextPatch;
   deferOutputIsolatedFramesUntilVisible?: boolean;
@@ -360,6 +369,8 @@ function NotebookViewContent({
   onReportOutputMatchCount,
   onSetCellSourceHidden,
   onSetCellOutputsHidden,
+  onCreateSourceComment,
+  onActivateCommentThread,
   markdownHeadingAnchorsByCellId,
   outputHostContext,
   deferOutputIsolatedFramesUntilVisible = false,
@@ -934,6 +945,8 @@ function NotebookViewContent({
             rightGutterContent={rightGutterContent}
             readOnly={!canEditCodeCellSources}
             canExecute={canExecuteCells}
+            onCreateSourceComment={onCreateSourceComment}
+            onActivateCommentThread={onActivateCommentThread}
             outputHostContext={outputHostContext}
             deferOutputIsolatedFrameUntilVisible={deferOutputIsolatedFramesUntilVisible}
             deferredOutputIsolatedFrameRootMargin={deferredOutputIsolatedFrameRootMargin}
@@ -1029,6 +1042,8 @@ function NotebookViewContent({
           isDragging={isDragging}
           rightGutterContent={rightGutterContent}
           readOnly={!canEditCodeCellSources}
+          onCreateSourceComment={onCreateSourceComment}
+          onActivateCommentThread={onActivateCommentThread}
         />
       );
     },
@@ -1044,6 +1059,8 @@ function NotebookViewContent({
       onReportOutputMatchCount,
       onSetCellSourceHidden,
       onSetCellOutputsHidden,
+      onCreateSourceComment,
+      onActivateCommentThread,
       markdownHeadingAnchorsByCellId,
       canEditCodeCellSources,
       canEditMarkdownSources,

--- a/apps/notebook/src/components/RawCell.tsx
+++ b/apps/notebook/src/components/RawCell.tsx
@@ -18,6 +18,13 @@ import { onEditorRegistered, onEditorUnregistered } from "../lib/cursor-registry
 import { detectRawFormat } from "../lib/detect-raw-format";
 import { registerCellEditor, unregisterCellEditor } from "../lib/editor-registry";
 import { presenceSenderExtension } from "../lib/presence-sender";
+import { commentHighlightExtension } from "../lib/comment-highlight-extension";
+import { refreshCellCommentHighlights } from "../lib/comment-highlights";
+import type {
+  SourceCommentSelectionRect,
+  SourceRangeCommentAnchor,
+} from "../lib/comment-source-anchor";
+import { sourceCommentExtension } from "../lib/source-comment-extension";
 import type { RawCell as RawCellType } from "../types";
 import { CellPresenceIndicators } from "./cell/CellPresenceIndicators";
 
@@ -36,6 +43,11 @@ interface RawCellProps {
   /** Content for the right gutter (e.g., delete button) */
   rightGutterContent?: ReactNode;
   readOnly?: boolean;
+  onCreateSourceComment?: (
+    anchor: SourceRangeCommentAnchor,
+    rect: SourceCommentSelectionRect | null,
+  ) => void;
+  onActivateCommentThread?: (threadId: string) => void;
 }
 
 export const RawCell = memo(function RawCell({
@@ -50,6 +62,8 @@ export const RawCell = memo(function RawCell({
   isDragging,
   rightGutterContent,
   readOnly = false,
+  onCreateSourceComment,
+  onActivateCommentThread,
 }: RawCellProps) {
   const isFocused = useIsCellFocused(cell.id);
   const isPreviousCellFromFocused = useIsPreviousCellFromFocused(cell.id);
@@ -68,6 +82,7 @@ export const RawCell = memo(function RawCell({
         registeredViewRef.current = view;
         registerCellEditor(cell.id, view);
         onEditorRegistered(cell.id);
+        refreshCellCommentHighlights(cell.id);
         return true;
       }
       return false;
@@ -153,15 +168,42 @@ export const RawCell = memo(function RawCell({
     ];
   }, [cell.id, presence]);
 
-  // Search highlight extension + remote cursors + presence sender
+  const sourceCommentExt = useMemo(() => {
+    // The create affordance (selection tooltip + keymap) needs editor focus,
+    // which a read-only editor never takes, so offer it only on editable cells.
+    // Reading existing threads stays open to everyone via commentHighlightExt.
+    if (readOnly || !onCreateSourceComment) return [];
+    return [sourceCommentExtension(cell.id, onCreateSourceComment)];
+  }, [cell.id, onCreateSourceComment, readOnly]);
+
+  const commentHighlightExt = useMemo(() => {
+    if (!onActivateCommentThread) return [];
+    return [
+      commentHighlightExtension({
+        onActivate: onActivateCommentThread,
+        onReady: () => refreshCellCommentHighlights(cell.id),
+      }),
+    ];
+  }, [cell.id, onActivateCommentThread]);
+
+  // Search highlight extension, remote cursors, presence, and comments.
   const searchExtensions = useMemo(
     () => [
       ...searchHighlight(searchQuery || ""),
       ...remoteCursorsExt,
       ...textAttributionExt,
       ...presenceSenderExt,
+      ...sourceCommentExt,
+      ...commentHighlightExt,
     ],
-    [searchQuery, remoteCursorsExt, textAttributionExt, presenceSenderExt],
+    [
+      searchQuery,
+      remoteCursorsExt,
+      textAttributionExt,
+      presenceSenderExt,
+      sourceCommentExt,
+      commentHighlightExt,
+    ],
   );
 
   // Get keyboard navigation bindings

--- a/apps/notebook/src/components/__tests__/InlineCommentComposer.test.tsx
+++ b/apps/notebook/src/components/__tests__/InlineCommentComposer.test.tsx
@@ -1,0 +1,63 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vite-plus/test";
+import { InlineCommentComposer } from "../InlineCommentComposer";
+
+const rect = { left: 20, top: 40, right: 120, bottom: 60 };
+
+describe("InlineCommentComposer", () => {
+  it("shows the selected source as a quote preview", () => {
+    render(
+      <InlineCommentComposer
+        rect={rect}
+        quote="sp.diff(f, x)"
+        onSubmit={vi.fn()}
+        onCancel={vi.fn()}
+      />,
+    );
+    expect(screen.getByText("sp.diff(f, x)")).toBeVisible();
+  });
+
+  it("keeps submit disabled until the body has content", () => {
+    render(<InlineCommentComposer rect={rect} onSubmit={vi.fn()} onCancel={vi.fn()} />);
+    const submit = screen.getByRole("button", { name: "Comment" });
+    expect(submit).toBeDisabled();
+    fireEvent.change(screen.getByLabelText("Comment on selection"), {
+      target: { value: "looks off" },
+    });
+    expect(submit).toBeEnabled();
+  });
+
+  it("submits the trimmed body", () => {
+    const onSubmit = vi.fn();
+    render(<InlineCommentComposer rect={rect} onSubmit={onSubmit} onCancel={vi.fn()} />);
+    fireEvent.change(screen.getByLabelText("Comment on selection"), {
+      target: { value: "  needs a docstring  " },
+    });
+    fireEvent.click(screen.getByRole("button", { name: "Comment" }));
+    expect(onSubmit).toHaveBeenCalledWith("needs a docstring");
+  });
+
+  it("submits on Cmd/Ctrl+Enter", () => {
+    const onSubmit = vi.fn();
+    render(<InlineCommentComposer rect={rect} onSubmit={onSubmit} onCancel={vi.fn()} />);
+    const textarea = screen.getByLabelText("Comment on selection");
+    fireEvent.change(textarea, { target: { value: "ship it" } });
+    fireEvent.keyDown(textarea, { key: "Enter", metaKey: true });
+    expect(onSubmit).toHaveBeenCalledWith("ship it");
+  });
+
+  it("cancels without submitting", () => {
+    const onSubmit = vi.fn();
+    const onCancel = vi.fn();
+    render(<InlineCommentComposer rect={rect} onSubmit={onSubmit} onCancel={onCancel} />);
+    fireEvent.click(screen.getByRole("button", { name: "Cancel" }));
+    expect(onCancel).toHaveBeenCalledTimes(1);
+    expect(onSubmit).not.toHaveBeenCalled();
+  });
+
+  it("disables input when read-only", () => {
+    render(<InlineCommentComposer rect={rect} disabled onSubmit={vi.fn()} onCancel={vi.fn()} />);
+    expect(screen.getByLabelText("Comment on selection")).toBeDisabled();
+    expect(screen.getByRole("button", { name: "Comment" })).toBeDisabled();
+  });
+});

--- a/apps/notebook/src/components/__tests__/code-cell-output-focus.test.tsx
+++ b/apps/notebook/src/components/__tests__/code-cell-output-focus.test.tsx
@@ -140,6 +140,7 @@ vi.mock("../../lib/cursor-registry", () => ({
 vi.mock("../../lib/editor-registry", () => ({
   registerCellEditor: vi.fn(),
   unregisterCellEditor: vi.fn(),
+  getCellEditor: vi.fn(() => null),
 }));
 
 vi.mock("../../lib/kernel-completion", () => ({

--- a/apps/notebook/src/components/__tests__/markdown-cell-theme.test.tsx
+++ b/apps/notebook/src/components/__tests__/markdown-cell-theme.test.tsx
@@ -193,6 +193,7 @@ vi.mock("../../lib/cursor-registry", () => ({
 vi.mock("../../lib/editor-registry", () => ({
   registerCellEditor: vi.fn(),
   unregisterCellEditor: vi.fn(),
+  getCellEditor: vi.fn(() => null),
 }));
 
 vi.mock("../../lib/logger", () => ({

--- a/apps/notebook/src/hooks/useAutomergeNotebook.ts
+++ b/apps/notebook/src/hooks/useAutomergeNotebook.ts
@@ -66,6 +66,11 @@ function scopeAllowsNotebookWrite(scope: string | null): boolean {
   return scope === null || scope === "editor" || scope === "owner";
 }
 
+function commentsDocIdFromNotebookId(notebookId: string | undefined): string | null {
+  const trimmed = notebookId?.trim();
+  return trimmed ? `comments:${trimmed}` : null;
+}
+
 let warnedMissingExecutionViewProjector = false;
 
 function projectExecutionViewChangeset(handle: NotebookHandle) {
@@ -123,6 +128,7 @@ export function useNotebook() {
   const outputCacheRef = useRef<Map<string, JupyterOutput>>(new Map());
   const prevPathRef = useRef<string | null>(null);
   const actorLabelRef = useRef(`desktop:${sessionIdRef.current}`);
+  const commentsDocIdRef = useRef<string | null>(null);
   const [localActor, setLocalActor] = useState(actorLabelRef.current);
   const [connectionScope, setConnectionScope] = useState<string | null>(null);
   const canWriteNotebookRef = useRef(true);
@@ -132,7 +138,12 @@ export function useNotebook() {
     () =>
       new NotebookHandleHost<NotebookHandle>({
         actorLabel: () => actorLabelRef.current,
-        createHandle: (actorLabel) => NotebookHandle.create_empty_with_actor(actorLabel),
+        createHandle: (actorLabel) => {
+          const commentsDocId = commentsDocIdRef.current;
+          return commentsDocId
+            ? NotebookHandle.create_bootstrap_with_comments(actorLabel, commentsDocId)
+            : NotebookHandle.create_empty_with_actor(actorLabel);
+        },
         getBlobPort,
         publishHandle: setNotebookHandle,
         ready: waitForNotebookWasmReady,
@@ -330,6 +341,7 @@ export function useNotebook() {
           actorLabelRef.current = trigger.payload.actor_label;
           setLocalActor(trigger.payload.actor_label);
         }
+        commentsDocIdRef.current = commentsDocIdFromNotebookId(trigger.payload.notebook_id);
         const connectionScope = trigger.payload.connection_scope ?? null;
         setConnectionScope(connectionScope);
         canWriteNotebookRef.current = scopeAllowsNotebookWrite(connectionScope);

--- a/apps/notebook/src/lib/__tests__/comment-source-anchor.test.ts
+++ b/apps/notebook/src/lib/__tests__/comment-source-anchor.test.ts
@@ -1,0 +1,170 @@
+// @vitest-environment jsdom
+import { EditorState } from "@codemirror/state";
+import { EditorView } from "@codemirror/view";
+import { afterEach, describe, expect, it } from "vite-plus/test";
+import {
+  offsetFromSourcePoint,
+  resolveSourceRangeAnchor,
+  type SourceRangeCommentAnchor,
+  sourceRangeAnchorFromOffsets,
+  sourceRangeAnchorFromSelection,
+  sourcePointFromOffset,
+  sourcePointFromStringOffset,
+} from "../comment-source-anchor";
+
+let view: EditorView | null = null;
+
+function viewWithSelection(doc: string, anchor: number, head: number): EditorView {
+  view = new EditorView({
+    state: EditorState.create({
+      doc,
+      selection: { anchor, head },
+    }),
+  });
+  return view;
+}
+
+describe("comment-source-anchor", () => {
+  afterEach(() => {
+    view?.destroy();
+    view = null;
+  });
+
+  it("converts source offsets to zero-based line and column points", () => {
+    const state = EditorState.create({ doc: "alpha\nbeta" });
+
+    expect(sourcePointFromOffset(state.doc, 0)).toEqual({ line: 0, column: 0 });
+    expect(sourcePointFromOffset(state.doc, 8)).toEqual({ line: 1, column: 2 });
+    expect(sourcePointFromStringOffset("alpha\nbeta", 8)).toEqual({ line: 1, column: 2 });
+  });
+
+  it("builds a normalized source_range anchor for a selection", () => {
+    const source = "first line\nsecond line\nthird line";
+    const from = source.indexOf("second");
+    const to = source.indexOf("third") - 1;
+    const selectedView = viewWithSelection(source, to, from);
+
+    expect(sourceRangeAnchorFromSelection("cell-1", selectedView, 6)).toEqual({
+      kind: "source_range",
+      cell_id: "cell-1",
+      start_line: 1,
+      start_column: 0,
+      end_line: 1,
+      end_column: "second line".length,
+      prefix_quote: " line\n",
+      exact_quote: "second line",
+      suffix_quote: "\nthird",
+    });
+  });
+
+  it("does not create an anchor for a collapsed selection", () => {
+    const selectedView = viewWithSelection("alpha", 2, 2);
+
+    expect(sourceRangeAnchorFromSelection("cell-1", selectedView)).toBeNull();
+  });
+
+  it("does not create an anchor for whitespace-only selections", () => {
+    const selectedView = viewWithSelection("alpha\n  \nomega", 6, 8);
+
+    expect(sourceRangeAnchorFromSelection("cell-1", selectedView)).toBeNull();
+  });
+
+  it("does not create an anchor for oversized selections", () => {
+    const selectedView = viewWithSelection("abcdef", 0, 6);
+
+    expect(sourceRangeAnchorFromSelection("cell-1", selectedView, 6, 4)).toBeNull();
+  });
+
+  it("checks oversized selections by UTF-8 bytes", () => {
+    const source = "éé";
+    const selectedView = viewWithSelection(source, 0, source.length);
+
+    expect(sourceRangeAnchorFromSelection("cell-1", selectedView, 6, 3)).toBeNull();
+    expect(sourceRangeAnchorFromSelection("cell-1", selectedView, 6, 4)?.exact_quote).toBe(source);
+  });
+
+  it("builds source_range anchors from raw source offsets", () => {
+    const source = "alpha\nbeta\n";
+    const from = source.indexOf("beta");
+    const to = from + "beta".length;
+
+    expect(sourceRangeAnchorFromOffsets("cell-1", source, from, to, 6)).toEqual({
+      kind: "source_range",
+      cell_id: "cell-1",
+      start_line: 1,
+      start_column: 0,
+      end_line: 1,
+      end_column: 4,
+      prefix_quote: "alpha\n",
+      exact_quote: "beta",
+      suffix_quote: "\n",
+    });
+  });
+});
+
+describe("resolveSourceRangeAnchor", () => {
+  const source = "import sympy as sp\nf = sp.sin(x) * sp.exp(x)\ndf = sp.diff(f, x)\n";
+
+  function anchorFor(quote: string): SourceRangeCommentAnchor {
+    const from = source.indexOf(quote);
+    const start = sourcePointFromStringOffset(source, from);
+    const end = sourcePointFromStringOffset(source, from + quote.length);
+    return {
+      kind: "source_range",
+      cell_id: "cell-1",
+      start_line: start.line,
+      start_column: start.column,
+      end_line: end.line,
+      end_column: end.column,
+      prefix_quote: source.slice(Math.max(0, from - 12), from),
+      exact_quote: quote,
+      suffix_quote: source.slice(from + quote.length, from + quote.length + 12),
+    };
+  }
+
+  it("maps stored line/column straight through when the text is unchanged", () => {
+    const anchor = anchorFor("sp.diff(f, x)");
+    const expected = source.indexOf("sp.diff(f, x)");
+    expect(resolveSourceRangeAnchor(source, anchor)).toEqual({
+      from: expected,
+      to: expected + "sp.diff(f, x)".length,
+    });
+  });
+
+  it("repairs the offset after the document shifts above the quote", () => {
+    const anchor = anchorFor("sp.diff(f, x)");
+    const shifted = `# added a comment line\n${source}`;
+    const expected = shifted.indexOf("sp.diff(f, x)");
+    expect(resolveSourceRangeAnchor(shifted, anchor)).toEqual({
+      from: expected,
+      to: expected + "sp.diff(f, x)".length,
+    });
+  });
+
+  it("uses prefix/suffix to disambiguate repeated quotes", () => {
+    const repeated = "value = 1\nvalue = 1\n";
+    const second = repeated.lastIndexOf("value");
+    const anchor: SourceRangeCommentAnchor = {
+      kind: "source_range",
+      cell_id: "cell-1",
+      start_line: 1,
+      start_column: 0,
+      end_line: 1,
+      end_column: 5,
+      prefix_quote: "value = 1\n",
+      exact_quote: "value",
+      suffix_quote: " = 1",
+    };
+    expect(resolveSourceRangeAnchor(repeated, anchor)).toEqual({ from: second, to: second + 5 });
+  });
+
+  it("returns null when the quoted text no longer exists", () => {
+    const anchor = anchorFor("sp.diff(f, x)");
+    expect(resolveSourceRangeAnchor("totally different source", anchor)).toBeNull();
+  });
+
+  it("computes offsets from zero-based points", () => {
+    expect(offsetFromSourcePoint("alpha\nbeta", 1, 2)).toBe(8);
+    expect(offsetFromSourcePoint("alpha\nbeta", 0, 0)).toBe(0);
+  });
+});

--- a/apps/notebook/src/lib/comment-highlight-extension.ts
+++ b/apps/notebook/src/lib/comment-highlight-extension.ts
@@ -1,0 +1,247 @@
+import { type Extension, RangeSetBuilder, StateEffect, StateField } from "@codemirror/state";
+import {
+  Decoration,
+  type DecorationSet,
+  EditorView,
+  hoverTooltip,
+  ViewPlugin,
+} from "@codemirror/view";
+import { actorInitials } from "runtimed";
+
+/** Compact thread summary shown when hovering a highlighted range. */
+export interface CommentHighlightPreview {
+  authorName: string;
+  authorColor?: string;
+  isAgent?: boolean;
+  onBehalfOf?: string | null;
+  onBehalfOfColor?: string;
+  body: string;
+  replyCount: number;
+}
+
+export interface CommentHighlight {
+  from: number;
+  to: number;
+  threadId: string;
+  resolved: boolean;
+  color?: string;
+  preview?: CommentHighlightPreview;
+}
+
+export type CommentHighlightActivateHandler = (threadId: string) => void;
+
+export const setCommentHighlightsEffect = StateEffect.define<CommentHighlight[]>();
+
+const highlightsField = StateField.define<CommentHighlight[]>({
+  create: () => [],
+  update(highlights, tr) {
+    let next = highlights;
+    if (tr.docChanged) {
+      next = next
+        .map((highlight) => ({
+          ...highlight,
+          from: tr.changes.mapPos(highlight.from, 1),
+          to: tr.changes.mapPos(highlight.to, -1),
+        }))
+        .filter((highlight) => highlight.from < highlight.to);
+    }
+    for (const effect of tr.effects) {
+      if (effect.is(setCommentHighlightsEffect)) {
+        next = effect.value.filter((highlight) => highlight.from < highlight.to);
+      }
+    }
+    return next;
+  },
+});
+
+function buildDecorations(highlights: CommentHighlight[]): DecorationSet {
+  if (highlights.length === 0) return Decoration.none;
+  const builder = new RangeSetBuilder<Decoration>();
+  const sorted = [...highlights].sort((a, b) => a.from - b.from || a.to - b.to);
+  for (const highlight of sorted) {
+    const attributes: Record<string, string> = {
+      "data-comment-thread-id": highlight.threadId,
+    };
+    if (highlight.color) {
+      attributes.style = `--cm-comment-color: ${highlight.color};`;
+    }
+    builder.add(
+      highlight.from,
+      highlight.to,
+      Decoration.mark({
+        class: highlight.resolved
+          ? "cm-comment-highlight cm-comment-highlight-resolved"
+          : "cm-comment-highlight",
+        attributes,
+      }),
+    );
+  }
+  return builder.finish();
+}
+
+const decorationsField = StateField.define<DecorationSet>({
+  create: () => Decoration.none,
+  update(decorations, tr) {
+    const changed =
+      tr.docChanged || tr.effects.some((effect) => effect.is(setCommentHighlightsEffect));
+    if (!changed) return decorations;
+    return buildDecorations(tr.state.field(highlightsField));
+  },
+  provide: (field) => EditorView.decorations.from(field),
+});
+
+const commentHighlightTheme = EditorView.baseTheme({
+  ".cm-comment-highlight": {
+    "--cm-comment-color": "hsl(45 93% 47%)",
+    backgroundColor: "color-mix(in srgb, var(--cm-comment-color) 22%, transparent)",
+    borderBottom: "2px solid color-mix(in srgb, var(--cm-comment-color) 70%, transparent)",
+    borderRadius: "2px",
+    cursor: "pointer",
+    transition: "background-color 120ms ease",
+  },
+  ".cm-comment-highlight:hover": {
+    backgroundColor: "color-mix(in srgb, var(--cm-comment-color) 38%, transparent)",
+  },
+  ".cm-comment-highlight-resolved": {
+    backgroundColor: "hsl(var(--muted-foreground) / 0.12)",
+    borderBottomColor: "hsl(var(--muted-foreground) / 0.4)",
+  },
+  ".cm-tooltip.cm-tooltip-hover": {
+    border: "none",
+    backgroundColor: "transparent",
+    color: "hsl(var(--popover-foreground, 222 47% 11%))",
+    padding: "0",
+  },
+});
+
+function highlightAt(view: EditorView, pos: number): CommentHighlight | undefined {
+  const highlights = view.state.field(highlightsField, false);
+  if (!highlights) return undefined;
+  return highlights
+    .filter((highlight) => pos >= highlight.from && pos <= highlight.to)
+    .sort((a, b) => a.to - a.from - (b.to - b.from))[0];
+}
+
+function activateThreadAt(
+  view: EditorView,
+  pos: number,
+  onActivateThread: CommentHighlightActivateHandler,
+): boolean {
+  const match = highlightAt(view, pos);
+  if (!match) return false;
+  onActivateThread(match.threadId);
+  return true;
+}
+
+const BOT_ICON_SVG =
+  '<svg width="11" height="11" viewBox="0 0 24 24" fill="none" stroke="#fff" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M12 8V4H8"/><rect width="16" height="12" x="4" y="8" rx="2"/><path d="M2 14h2"/><path d="M20 14h2"/><path d="M15 13v2"/><path d="M9 13v2"/></svg>';
+
+function buildPreviewDom(preview: CommentHighlightPreview): HTMLElement {
+  const root = document.createElement("div");
+  root.style.cssText =
+    "width:min(300px,80vw);padding:10px 12px;border:1px solid hsl(var(--border, 214 32% 91%));border-radius:10px;background:hsl(var(--popover, 0 0% 100%));color:hsl(var(--popover-foreground, 222 47% 11%));box-shadow:0 8px 24px rgb(0 0 0 / 0.14);font:inherit;";
+
+  const head = document.createElement("div");
+  head.style.cssText = "display:flex;align-items:center;gap:6px;margin-bottom:5px;";
+
+  const avatar = document.createElement("span");
+  avatar.style.cssText =
+    "position:relative;flex:none;width:18px;height:18px;border-radius:50%;color:#fff;font-size:9px;font-weight:600;display:grid;place-items:center;";
+  avatar.style.backgroundColor = preview.authorColor ?? "hsl(var(--muted-foreground, 215 16% 47%))";
+  if (preview.isAgent) {
+    avatar.innerHTML = BOT_ICON_SVG;
+  } else {
+    avatar.textContent = actorInitials(preview.authorName);
+  }
+
+  if (preview.isAgent && preview.onBehalfOf) {
+    const badge = document.createElement("span");
+    badge.style.cssText =
+      "position:absolute;bottom:-3px;right:-3px;width:11px;height:11px;border-radius:50%;display:grid;place-items:center;color:#fff;font-size:6px;font-weight:700;box-shadow:0 0 0 2px hsl(var(--popover, 0 0% 100%));";
+    badge.style.backgroundColor =
+      preview.onBehalfOfColor ?? "hsl(var(--muted-foreground, 215 16% 47%))";
+    badge.textContent = actorInitials(preview.onBehalfOf).slice(0, 1);
+    avatar.appendChild(badge);
+  }
+  head.appendChild(avatar);
+
+  const name = document.createElement("span");
+  name.style.cssText = "font-size:12px;font-weight:600;";
+  name.textContent = preview.authorName;
+  head.appendChild(name);
+
+  if (preview.isAgent) {
+    const meta = document.createElement("span");
+    meta.style.cssText = "font-size:10px;color:hsl(var(--muted-foreground, 215 16% 47%));";
+    meta.textContent = preview.onBehalfOf ? `AI for ${preview.onBehalfOf}` : "AI";
+    head.appendChild(meta);
+  }
+  root.appendChild(head);
+
+  const body = document.createElement("div");
+  body.style.cssText =
+    "font-size:13px;line-height:1.45;display:-webkit-box;-webkit-line-clamp:4;-webkit-box-orient:vertical;overflow:hidden;white-space:pre-wrap;word-break:break-word;";
+  body.textContent = preview.body;
+  root.appendChild(body);
+
+  if (preview.replyCount > 0) {
+    const replies = document.createElement("div");
+    replies.style.cssText =
+      "margin-top:6px;font-size:10px;color:hsl(var(--muted-foreground, 215 16% 47%));";
+    replies.textContent = `+${preview.replyCount} ${preview.replyCount === 1 ? "reply" : "replies"}`;
+    root.appendChild(replies);
+  }
+
+  return root;
+}
+
+const commentHoverTooltip = hoverTooltip(
+  (view, pos) => {
+    const match = highlightAt(view, pos);
+    if (!match?.preview) return null;
+    return {
+      pos: match.from,
+      end: match.to,
+      above: true,
+      create() {
+        return { dom: buildPreviewDom(match.preview as CommentHighlightPreview) };
+      },
+    };
+  },
+  { hoverTime: 250 },
+);
+
+export interface CommentHighlightExtensionOptions {
+  onActivate: CommentHighlightActivateHandler;
+  onReady?: (view: EditorView) => void;
+}
+
+export function commentHighlightExtension(options: CommentHighlightExtensionOptions): Extension {
+  const extensions: Extension[] = [
+    highlightsField,
+    decorationsField,
+    commentHighlightTheme,
+    commentHoverTooltip,
+    EditorView.domEventHandlers({
+      mousedown(event, view) {
+        const target = event.target as HTMLElement | null;
+        if (!target?.closest(".cm-comment-highlight")) return false;
+        const pos = view.posAtCoords({ x: event.clientX, y: event.clientY });
+        if (pos === null) return false;
+        return activateThreadAt(view, pos, options.onActivate);
+      },
+    }),
+  ];
+
+  const { onReady } = options;
+  if (onReady) {
+    extensions.push(
+      ViewPlugin.define((view) => {
+        onReady(view);
+        return {};
+      }),
+    );
+  }
+
+  return extensions;
+}

--- a/apps/notebook/src/lib/comment-highlights.ts
+++ b/apps/notebook/src/lib/comment-highlights.ts
@@ -1,0 +1,55 @@
+import {
+  type CommentHighlight,
+  type CommentHighlightPreview,
+  setCommentHighlightsEffect,
+} from "./comment-highlight-extension";
+import { resolveSourceRangeAnchor, type SourceRangeCommentAnchor } from "./comment-source-anchor";
+import { getCellEditor } from "./editor-registry";
+
+export interface SourceCommentThread {
+  threadId: string;
+  anchor: SourceRangeCommentAnchor;
+  resolved: boolean;
+  color?: string;
+  preview?: CommentHighlightPreview;
+}
+
+let threadsByCell = new Map<string, SourceCommentThread[]>();
+let dispatchedCells = new Set<string>();
+
+/** Replace the full set of source-comment threads and refresh affected cells. */
+export function setSourceCommentThreads(next: Map<string, SourceCommentThread[]>): void {
+  threadsByCell = next;
+  const affected = new Set<string>([...dispatchedCells, ...next.keys()]);
+  for (const cellId of affected) {
+    dispatchCell(cellId);
+  }
+  dispatchedCells = new Set(next.keys());
+}
+
+/** Re-resolve and push highlights for one cell after its editor mounts. */
+export function refreshCellCommentHighlights(cellId: string): void {
+  dispatchCell(cellId);
+}
+
+function dispatchCell(cellId: string): void {
+  const view = getCellEditor(cellId);
+  if (!view) return;
+
+  const threads = threadsByCell.get(cellId) ?? [];
+  const source = view.state.doc.toString();
+  const highlights: CommentHighlight[] = [];
+  for (const thread of threads) {
+    const range = resolveSourceRangeAnchor(source, thread.anchor);
+    if (!range) continue;
+    highlights.push({
+      from: range.from,
+      to: range.to,
+      threadId: thread.threadId,
+      resolved: thread.resolved,
+      color: thread.color,
+      preview: thread.preview,
+    });
+  }
+  view.dispatch({ effects: setCommentHighlightsEffect.of(highlights) });
+}

--- a/apps/notebook/src/lib/comment-source-anchor.ts
+++ b/apps/notebook/src/lib/comment-source-anchor.ts
@@ -1,0 +1,201 @@
+import type { Text } from "@codemirror/state";
+import type { EditorView } from "@codemirror/view";
+import type { CommentAnchor } from "runtimed";
+
+export type SourceRangeCommentAnchor = Extract<CommentAnchor, { kind: "source_range" }>;
+
+/**
+ * Viewport-space rectangle bounding a comment-worthy selection. Used to anchor
+ * the inline comment composer next to the text the comment is about.
+ */
+export interface SourceCommentSelectionRect {
+  left: number;
+  top: number;
+  right: number;
+  bottom: number;
+}
+
+const DEFAULT_CONTEXT_CHARS = 40;
+export const MAX_SOURCE_COMMENT_EXACT_QUOTE_BYTES = 4096;
+const utf8Encoder = new TextEncoder();
+
+export interface SourcePoint {
+  line: number;
+  column: number;
+}
+
+export function sourcePointFromOffset(doc: Text, offset: number): SourcePoint {
+  const line = doc.lineAt(offset);
+  return {
+    line: line.number - 1,
+    column: offset - line.from,
+  };
+}
+
+export function sourceRangeAnchorFromSelection(
+  cellId: string,
+  view: EditorView,
+  contextChars = DEFAULT_CONTEXT_CHARS,
+  maxExactQuoteBytes = MAX_SOURCE_COMMENT_EXACT_QUOTE_BYTES,
+): SourceRangeCommentAnchor | null {
+  const selection = view.state.selection.main;
+  const from = Math.min(selection.anchor, selection.head);
+  const to = Math.max(selection.anchor, selection.head);
+  if (from === to) return null;
+
+  return sourceRangeAnchorFromOffsets(
+    cellId,
+    view.state.doc.toString(),
+    from,
+    to,
+    contextChars,
+    maxExactQuoteBytes,
+  );
+}
+
+/**
+ * Bounding rectangle of the current selection in viewport coordinates, or null
+ * when the selection is empty or off-screen.
+ */
+export function selectionRectFromView(view: EditorView): SourceCommentSelectionRect | null {
+  const selection = view.state.selection.main;
+  const from = Math.min(selection.anchor, selection.head);
+  const to = Math.max(selection.anchor, selection.head);
+  if (from === to) return null;
+
+  const startCoords = view.coordsAtPos(from);
+  const endCoords = view.coordsAtPos(to);
+  if (!startCoords || !endCoords) return null;
+
+  return {
+    left: Math.min(startCoords.left, endCoords.left),
+    top: Math.min(startCoords.top, endCoords.top),
+    right: Math.max(startCoords.right, endCoords.right),
+    bottom: Math.max(startCoords.bottom, endCoords.bottom),
+  };
+}
+
+export function sourcePointFromStringOffset(source: string, offset: number): SourcePoint {
+  const normalizedOffset = Math.min(source.length, Math.max(0, offset));
+  let line = 0;
+  let lineStart = 0;
+  for (let index = 0; index < normalizedOffset; index += 1) {
+    if (source.charCodeAt(index) === 10) {
+      line += 1;
+      lineStart = index + 1;
+    }
+  }
+  return {
+    line,
+    column: normalizedOffset - lineStart,
+  };
+}
+
+export function sourceRangeAnchorFromOffsets(
+  cellId: string,
+  source: string,
+  fromOffset: number,
+  toOffset: number,
+  contextChars = DEFAULT_CONTEXT_CHARS,
+  maxExactQuoteBytes = MAX_SOURCE_COMMENT_EXACT_QUOTE_BYTES,
+): SourceRangeCommentAnchor | null {
+  const from = Math.min(fromOffset, toOffset);
+  const to = Math.max(fromOffset, toOffset);
+  if (
+    !Number.isInteger(from) ||
+    !Number.isInteger(to) ||
+    from < 0 ||
+    to > source.length ||
+    from === to
+  ) {
+    return null;
+  }
+
+  const exactQuote = source.slice(from, to);
+  if (
+    exactQuote.trim().length === 0 ||
+    utf8Encoder.encode(exactQuote).length > maxExactQuoteBytes
+  ) {
+    return null;
+  }
+
+  const start = sourcePointFromStringOffset(source, from);
+  const end = sourcePointFromStringOffset(source, to);
+
+  return {
+    kind: "source_range",
+    cell_id: cellId,
+    start_line: start.line,
+    start_column: start.column,
+    end_line: end.line,
+    end_column: end.column,
+    prefix_quote: source.slice(Math.max(0, from - contextChars), from),
+    exact_quote: exactQuote,
+    suffix_quote: source.slice(to, Math.min(source.length, to + contextChars)),
+  };
+}
+
+/** Character offset for a zero-based line/column point in `source`. */
+export function offsetFromSourcePoint(source: string, line: number, column: number): number {
+  let offset = 0;
+  let currentLine = 0;
+  while (currentLine < line && offset < source.length) {
+    const newline = source.indexOf("\n", offset);
+    if (newline === -1) {
+      offset = source.length;
+      break;
+    }
+    offset = newline + 1;
+    currentLine += 1;
+  }
+  return Math.min(source.length, offset + Math.max(0, column));
+}
+
+export interface ResolvedSourceRange {
+  from: number;
+  to: number;
+}
+
+/**
+ * Resolve a stored source-range anchor to live character offsets in the current
+ * source, repairing the position when the document has shifted.
+ */
+export function resolveSourceRangeAnchor(
+  source: string,
+  anchor: SourceRangeCommentAnchor,
+): ResolvedSourceRange | null {
+  const quote = anchor.exact_quote ?? "";
+  if (quote.length === 0) return null;
+
+  const expectedFrom = offsetFromSourcePoint(source, anchor.start_line, anchor.start_column);
+  if (source.slice(expectedFrom, expectedFrom + quote.length) === quote) {
+    return { from: expectedFrom, to: expectedFrom + quote.length };
+  }
+
+  const occurrences: number[] = [];
+  for (let index = source.indexOf(quote); index !== -1; index = source.indexOf(quote, index + 1)) {
+    occurrences.push(index);
+  }
+  if (occurrences.length === 0) return null;
+  if (occurrences.length === 1) {
+    return { from: occurrences[0], to: occurrences[0] + quote.length };
+  }
+
+  const prefix = anchor.prefix_quote ?? "";
+  const suffix = anchor.suffix_quote ?? "";
+  let best = occurrences[0];
+  let bestScore = Number.NEGATIVE_INFINITY;
+  for (const index of occurrences) {
+    const before = source.slice(Math.max(0, index - prefix.length), index);
+    const after = source.slice(index + quote.length, index + quote.length + suffix.length);
+    let score = 0;
+    if (prefix.length > 0 && before.endsWith(prefix)) score += 2;
+    if (suffix.length > 0 && after.startsWith(suffix)) score += 2;
+    score -= Math.abs(index - expectedFrom) / Math.max(1, source.length);
+    if (score > bestScore) {
+      bestScore = score;
+      best = index;
+    }
+  }
+  return { from: best, to: best + quote.length };
+}

--- a/apps/notebook/src/lib/comments-projection-store.ts
+++ b/apps/notebook/src/lib/comments-projection-store.ts
@@ -1,0 +1,28 @@
+import { useSyncExternalStore } from "react";
+import type { CommentsProjection } from "runtimed";
+
+let snapshot: CommentsProjection | null = null;
+const listeners = new Set<() => void>();
+
+/** Replace the current projection snapshot and notify subscribers. */
+export function setCommentsProjectionSnapshot(next: CommentsProjection | null): void {
+  if (next === snapshot) return;
+  snapshot = next;
+  for (const listener of listeners) listener();
+}
+
+function subscribe(listener: () => void): () => void {
+  listeners.add(listener);
+  return () => {
+    listeners.delete(listener);
+  };
+}
+
+function getSnapshot(): CommentsProjection | null {
+  return snapshot;
+}
+
+/** Subscribe a component to the comments projection. */
+export function useCommentsProjection(): CommentsProjection | null {
+  return useSyncExternalStore(subscribe, getSnapshot, getSnapshot);
+}

--- a/apps/notebook/src/lib/source-comment-extension.ts
+++ b/apps/notebook/src/lib/source-comment-extension.ts
@@ -1,0 +1,144 @@
+import { StateEffect, StateField, type Extension } from "@codemirror/state";
+import { EditorView, keymap, showTooltip, type Tooltip } from "@codemirror/view";
+import {
+  MAX_SOURCE_COMMENT_EXACT_QUOTE_BYTES,
+  selectionRectFromView,
+  sourceRangeAnchorFromSelection,
+  type SourceCommentSelectionRect,
+  type SourceRangeCommentAnchor,
+} from "./comment-source-anchor";
+
+export type SourceCommentRequestHandler = (
+  anchor: SourceRangeCommentAnchor,
+  rect: SourceCommentSelectionRect | null,
+) => void;
+
+const setSourceCommentFocusEffect = StateEffect.define<boolean>();
+const utf8Encoder = new TextEncoder();
+
+interface SourceCommentTooltipState {
+  focused: boolean;
+  tooltips: readonly Tooltip[];
+}
+
+export function sourceCommentExtension(
+  cellId: string,
+  onCreateSourceComment: SourceCommentRequestHandler,
+): Extension {
+  const tooltipField = StateField.define<SourceCommentTooltipState>({
+    create() {
+      return { focused: false, tooltips: [] };
+    },
+    update(value, transaction) {
+      let focused = value.focused;
+      let focusChanged = false;
+      for (const effect of transaction.effects) {
+        if (effect.is(setSourceCommentFocusEffect)) {
+          focused = effect.value;
+          focusChanged = true;
+        }
+      }
+
+      if (!focusChanged && !transaction.selection && !transaction.docChanged) return value;
+      return {
+        focused,
+        tooltips: focused
+          ? sourceCommentTooltips(transaction.state, cellId, onCreateSourceComment)
+          : [],
+      };
+    },
+    provide: (field) => showTooltip.computeN([field], (state) => state.field(field).tooltips),
+  });
+
+  const focusSync = EditorView.updateListener.of((update) => {
+    if (!update.focusChanged && !update.selectionSet && !update.docChanged) return;
+    const current = update.state.field(tooltipField, false);
+    if (!current || current.focused === update.view.hasFocus) return;
+    update.view.dispatch({
+      effects: setSourceCommentFocusEffect.of(update.view.hasFocus),
+    });
+  });
+
+  const shortcut = keymap.of([
+    {
+      key: "Mod-Alt-m",
+      run(view) {
+        return requestSourceComment(cellId, view, onCreateSourceComment);
+      },
+    },
+  ]);
+
+  return [sourceCommentTheme, tooltipField, focusSync, shortcut];
+}
+
+function sourceCommentTooltips(
+  state: EditorView["state"],
+  cellId: string,
+  onCreateSourceComment: SourceCommentRequestHandler,
+): readonly Tooltip[] {
+  const selection = state.selection.main;
+  if (selection.empty) return [];
+  const selectedText = state.doc.sliceString(selection.from, selection.to);
+  if (selectedText.trim().length === 0) return [];
+  if (utf8Encoder.encode(selectedText).length > MAX_SOURCE_COMMENT_EXACT_QUOTE_BYTES) return [];
+
+  return [
+    {
+      pos: selection.to,
+      above: true,
+      strictSide: false,
+      create(view) {
+        const button = document.createElement("button");
+        button.type = "button";
+        button.className = "cm-source-comment-button";
+        button.textContent = "Comment";
+        button.title = "Comment on selected source (Ctrl/Cmd+Alt+M)";
+        button.setAttribute("aria-label", "Comment on selected source");
+        button.setAttribute("data-testid", "source-comment-button");
+        button.addEventListener("mousedown", (event) => {
+          event.preventDefault();
+        });
+        button.addEventListener("click", (event) => {
+          event.preventDefault();
+          requestSourceComment(cellId, view, onCreateSourceComment);
+        });
+        return { dom: button };
+      },
+    },
+  ];
+}
+
+function requestSourceComment(
+  cellId: string,
+  view: EditorView,
+  onCreateSourceComment: SourceCommentRequestHandler,
+): boolean {
+  const anchor = sourceRangeAnchorFromSelection(cellId, view);
+  if (!anchor) return false;
+
+  onCreateSourceComment(anchor, selectionRectFromView(view));
+  return true;
+}
+
+const sourceCommentTheme = EditorView.baseTheme({
+  ".cm-source-comment-button": {
+    border: "1px solid hsl(var(--border))",
+    borderRadius: "0.375rem",
+    backgroundColor: "hsl(var(--background))",
+    color: "hsl(var(--foreground))",
+    boxShadow: "0 1px 4px rgb(0 0 0 / 0.14)",
+    cursor: "pointer",
+    fontFamily: "inherit",
+    fontSize: "11px",
+    fontWeight: "500",
+    lineHeight: "1",
+    padding: "5px 7px",
+  },
+  ".cm-source-comment-button:hover": {
+    backgroundColor: "hsl(var(--muted))",
+  },
+  ".cm-source-comment-button:focus-visible": {
+    outline: "2px solid hsl(var(--ring))",
+    outlineOffset: "2px",
+  },
+});

--- a/crates/comments-doc/src/doc.rs
+++ b/crates/comments-doc/src/doc.rs
@@ -15,8 +15,8 @@ use loro_fractional_index::FractionalIndex;
 
 use crate::error::CommentsDocError;
 use crate::types::{
-    CommentAnchor, CommentCreated, CommentMessageSnapshot, CommentReplied, CommentThreadSnapshot,
-    CommentsProjection, NotebookCommentRef, ProjectedThreadStatus,
+    validate_comment_anchor, CommentAnchor, CommentCreated, CommentMessageSnapshot, CommentReplied,
+    CommentThreadSnapshot, CommentsProjection, NotebookCommentRef, ProjectedThreadStatus,
 };
 
 #[cfg(test)]
@@ -212,6 +212,7 @@ impl CommentsDoc {
         after_thread_id: Option<&str>,
         created_at: &str,
     ) -> Result<CommentCreated, CommentsDocError> {
+        validate_comment_anchor(anchor).map_err(CommentsDocError::InvalidAnchor)?;
         if self.thread_obj(thread_id).is_some() {
             return Err(CommentsDocError::ThreadAlreadyExists(thread_id.to_string()));
         }
@@ -275,6 +276,24 @@ impl CommentsDoc {
     pub fn reopen_thread(&mut self, thread_id: &str) -> Result<(), CommentsDocError> {
         let thread = self.thread_or_error(thread_id)?;
         self.doc.put(&thread, "status", "open")?;
+        Ok(())
+    }
+
+    /// Demote a thread's anchor to a notebook-level comment.
+    ///
+    /// Used when a source-range thread's quoted text no longer exists. The
+    /// comment remains visible as a dangling document comment instead of
+    /// disappearing with its lost source target.
+    pub fn demote_thread_anchor_to_notebook(
+        &mut self,
+        thread_id: &str,
+    ) -> Result<(), CommentsDocError> {
+        let thread = self.thread_or_error(thread_id)?;
+        let anchor = CommentAnchor::Notebook;
+        let anchor_value = serde_json::to_value(&anchor)?;
+        automunge::put_json_at_key_batched(&mut self.doc, &thread, "anchor", &anchor_value)?;
+        self.doc
+            .put(&thread, "thread_order_scope", anchor.thread_order_scope())?;
         Ok(())
     }
 
@@ -829,6 +848,25 @@ mod tests {
         }
     }
 
+    fn source_anchor(
+        start_line: u64,
+        start_column: u64,
+        end_line: u64,
+        end_column: u64,
+        exact_quote: Option<&str>,
+    ) -> CommentAnchor {
+        CommentAnchor::SourceRange {
+            cell_id: "cell-a".to_string(),
+            start_line,
+            start_column,
+            end_line,
+            end_column,
+            prefix_quote: None,
+            exact_quote: exact_quote.map(str::to_string),
+            suffix_quote: None,
+        }
+    }
+
     fn change_hashes_for_actor(doc: &mut AutoCommit, actor: &str) -> Vec<automerge::ChangeHash> {
         doc.get_changes(&[])
             .into_iter()
@@ -879,6 +917,49 @@ mod tests {
             err,
             CommentsDocError::CommentsDocIdMismatch { .. }
         ));
+    }
+
+    #[test]
+    fn create_thread_rejects_invalid_source_range_anchor() {
+        let mut doc = CommentsDoc::new_with_actor(DOC_ID, &notebook_ref(), CLIENT);
+        let err = doc
+            .create_thread(
+                "thread-1",
+                "msg-1",
+                &source_anchor(3, 0, 2, 0, Some("quote")),
+                "body",
+                None,
+                "2026-06-16T00:00:00Z",
+            )
+            .expect_err("inverted source range should be rejected");
+
+        assert!(matches!(err, CommentsDocError::InvalidAnchor(_)));
+        assert!(doc.read_projection(None).unwrap().threads.is_empty());
+    }
+
+    #[test]
+    fn demote_thread_anchor_to_notebook_makes_it_a_document_comment() {
+        let mut doc = CommentsDoc::new_with_actor(DOC_ID, &notebook_ref(), CLIENT);
+        doc.create_thread(
+            "thread-1",
+            "msg-1",
+            &source_anchor(0, 0, 0, 4, Some("beta")),
+            "anchored comment",
+            None,
+            "2026-06-16T00:00:00Z",
+        )
+        .unwrap();
+
+        doc.demote_thread_anchor_to_notebook("thread-1").unwrap();
+
+        let projection = doc.read_projection(None).unwrap();
+        let thread = projection
+            .threads
+            .iter()
+            .find(|thread| thread.id == "thread-1")
+            .expect("thread present after demote");
+        assert!(matches!(thread.anchor, CommentAnchor::Notebook));
+        assert!(thread.badge_cell_ids.is_empty());
     }
 
     #[test]

--- a/crates/comments-doc/src/error.rs
+++ b/crates/comments-doc/src/error.rs
@@ -32,6 +32,8 @@ pub enum CommentsDocError {
     AfterMessageNotFound(String),
     #[error("invalid comment position: {0}")]
     InvalidPosition(String),
+    #[error("invalid comment anchor: {0}")]
+    InvalidAnchor(String),
     #[error("automerge: {0}")]
     Automerge(#[from] AutomergeError),
     #[error("automerge recovery: {0}")]

--- a/crates/comments-doc/src/lib.rs
+++ b/crates/comments-doc/src/lib.rs
@@ -12,6 +12,7 @@ pub use identity::{
     local_room_comments_identity, LocalCommentsIdentity,
 };
 pub use types::{
-    CommentAnchor, CommentCreated, CommentMessageSnapshot, CommentReplied, CommentThreadSnapshot,
+    validate_comment_anchor, validate_source_range_anchor_against_source, CommentAnchor,
+    CommentCreated, CommentMessageSnapshot, CommentReplied, CommentThreadSnapshot,
     CommentsProjection, NotebookCommentRef, ProjectedThreadStatus,
 };

--- a/crates/comments-doc/src/types.rs
+++ b/crates/comments-doc/src/types.rs
@@ -1,5 +1,7 @@
 use serde::{Deserialize, Serialize};
 
+pub const MAX_SOURCE_COMMENT_QUOTE_BYTES: usize = 4096;
+
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(tag = "kind", rename_all = "snake_case")]
 pub enum NotebookCommentRef {
@@ -100,6 +102,137 @@ impl CommentAnchor {
     }
 }
 
+pub fn validate_comment_anchor(anchor: &CommentAnchor) -> Result<(), String> {
+    let CommentAnchor::SourceRange {
+        start_line,
+        start_column,
+        end_line,
+        end_column,
+        prefix_quote,
+        exact_quote,
+        suffix_quote,
+        ..
+    } = anchor
+    else {
+        return Ok(());
+    };
+
+    validate_source_range_order(*start_line, *start_column, *end_line, *end_column)?;
+    validate_source_quote_bound("prefix_quote", prefix_quote.as_deref())?;
+    validate_source_quote_bound("exact_quote", exact_quote.as_deref())?;
+    validate_source_quote_bound("suffix_quote", suffix_quote.as_deref())?;
+    Ok(())
+}
+
+pub fn validate_source_range_anchor_against_source(
+    anchor: &CommentAnchor,
+    source: &str,
+) -> Result<(), String> {
+    validate_comment_anchor(anchor)?;
+
+    let CommentAnchor::SourceRange {
+        start_line,
+        start_column,
+        end_line,
+        end_column,
+        exact_quote,
+        ..
+    } = anchor
+    else {
+        return Ok(());
+    };
+
+    if let (Ok(start), Ok(end)) = (
+        source_byte_offset_from_utf16_point(source, *start_line, *start_column),
+        source_byte_offset_from_utf16_point(source, *end_line, *end_column),
+    ) {
+        if start <= end {
+            match exact_quote {
+                None => return Ok(()),
+                Some(quote) if &source[start..end] == quote => return Ok(()),
+                Some(_) => {}
+            }
+        }
+    }
+
+    match exact_quote {
+        Some(quote) if !quote.is_empty() && source.contains(quote.as_str()) => Ok(()),
+        Some(_) => {
+            Err("source_range exact_quote no longer present in current cell source".to_string())
+        }
+        None => Err(format!(
+            "source_range position ({start_line}:{start_column}) is outside current cell source"
+        )),
+    }
+}
+
+fn validate_source_range_order(
+    start_line: u64,
+    start_column: u64,
+    end_line: u64,
+    end_column: u64,
+) -> Result<(), String> {
+    if start_line > end_line || (start_line == end_line && start_column > end_column) {
+        return Err(format!(
+            "source_range start ({start_line}:{start_column}) must be before or equal to end ({end_line}:{end_column})"
+        ));
+    }
+    Ok(())
+}
+
+fn validate_source_quote_bound(field: &str, quote: Option<&str>) -> Result<(), String> {
+    let Some(quote) = quote else {
+        return Ok(());
+    };
+    if quote.len() > MAX_SOURCE_COMMENT_QUOTE_BYTES {
+        return Err(format!(
+            "source_range {field} exceeds {MAX_SOURCE_COMMENT_QUOTE_BYTES} bytes"
+        ));
+    }
+    Ok(())
+}
+
+fn source_byte_offset_from_utf16_point(
+    source: &str,
+    line: u64,
+    column: u64,
+) -> Result<usize, String> {
+    let mut line_start = 0;
+    for _ in 0..line {
+        let Some(relative_newline) = source[line_start..].find('\n') else {
+            return Err(format!(
+                "source_range line {line} is outside current cell source"
+            ));
+        };
+        line_start += relative_newline + 1;
+    }
+
+    let line_end = source[line_start..]
+        .find('\n')
+        .map(|relative_newline| line_start + relative_newline)
+        .unwrap_or(source.len());
+    let line_text = &source[line_start..line_end];
+    let mut utf16_offset = 0_u64;
+    for (byte_offset, ch) in line_text.char_indices() {
+        if utf16_offset == column {
+            return Ok(line_start + byte_offset);
+        }
+        utf16_offset += ch.len_utf16() as u64;
+        if utf16_offset > column {
+            return Err(format!(
+                "source_range column {column} is outside a UTF-16 character boundary"
+            ));
+        }
+    }
+    if utf16_offset == column {
+        return Ok(line_end);
+    }
+
+    Err(format!(
+        "source_range column {column} is outside current cell source line"
+    ))
+}
+
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct CommentMessageSnapshot {
     pub id: String,
@@ -165,4 +298,69 @@ fn sorted_unique<const N: usize>(values: [String; N]) -> Vec<String> {
     values.sort();
     values.dedup();
     values
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn source_anchor(
+        start_line: u64,
+        start_column: u64,
+        end_line: u64,
+        end_column: u64,
+        exact_quote: Option<&str>,
+    ) -> CommentAnchor {
+        CommentAnchor::SourceRange {
+            cell_id: "cell-1".into(),
+            start_line,
+            start_column,
+            end_line,
+            end_column,
+            prefix_quote: None,
+            exact_quote: exact_quote.map(str::to_string),
+            suffix_quote: None,
+        }
+    }
+
+    #[test]
+    fn validates_source_range_anchor_against_current_source() {
+        let anchor = source_anchor(1, 0, 1, 4, Some("beta"));
+
+        assert!(validate_source_range_anchor_against_source(&anchor, "alpha\nbeta\n").is_ok());
+        assert!(validate_source_range_anchor_against_source(&anchor, "alpha\ngamma\n").is_err());
+    }
+
+    #[test]
+    fn repairs_source_range_anchor_when_document_shifted() {
+        let anchor = source_anchor(1, 0, 1, 4, Some("beta"));
+
+        assert!(
+            validate_source_range_anchor_against_source(&anchor, "added\nalpha\nbeta\n").is_ok()
+        );
+
+        let out_of_bounds = source_anchor(0, 40, 0, 44, Some("beta"));
+        assert!(validate_source_range_anchor_against_source(&out_of_bounds, "x\nbeta\n").is_ok());
+        assert!(validate_source_range_anchor_against_source(&anchor, "added\nalpha\n").is_err());
+    }
+
+    #[test]
+    fn validates_source_range_columns_as_utf16_offsets() {
+        let anchor = source_anchor(0, 2, 0, 3, Some("x"));
+
+        assert!(validate_source_range_anchor_against_source(&anchor, "🙂x\n").is_ok());
+    }
+
+    #[test]
+    fn rejects_source_quotes_over_storage_bound() {
+        let anchor = source_anchor(
+            0,
+            0,
+            0,
+            0,
+            Some(&"x".repeat(MAX_SOURCE_COMMENT_QUOTE_BYTES + 1)),
+        );
+
+        assert!(validate_comment_anchor(&anchor).is_err());
+    }
 }

--- a/packages/runtimed/src/index.ts
+++ b/packages/runtimed/src/index.ts
@@ -123,6 +123,9 @@ export {
 
 // Handle
 export type {
+  CommentAnchor,
+  CommentThreadSnapshot,
+  CommentsProjection,
   ExecutionQueueProjection,
   ExecutionViewChangeset,
   ExecutionViewSnapshot,


### PR DESCRIPTION
Select text in a cell and comment on that exact source range, on both the desktop and hosted-cloud surfaces. The in-editor half of the [comments rollout](https://github.com/nteract/nteract/blob/main/docs/plans/comments-rollout.md); the panel and identity work landed in #3735, #3738, and #3740.

## What it does

- **Anchor on selection.** Selecting text raises an inline "Comment" affordance (also Ctrl/Cmd+Alt+M). The thread anchors by line/column plus prefix/exact/suffix quote context.
- **Survive edits.** Highlight decorations remap on every doc change. When line/column drift, the anchor repairs against the stored exact_quote, scoring candidates by surrounding context. When the quote is gone entirely, the thread demotes to a document-level comment instead of vanishing.
- **Read in place.** Anchored threads render as CodeMirror highlights; hover shows an author-attributed preview card, click opens the thread.

## Identity comes from the shared core

The preview card's author name, color, initials, and the on-behalf-of agent badge all resolve through `resolveActorDisplay` / `actorInitials` in `packages/runtimed`. No local initials or color-hash copy. This is what the recent identity consolidation was for.

## Trust and scope

- Crate validation (`validate_comment_anchor`, `validate_source_range_anchor_against_source`) bounds anchor fields and confirms a source-range anchor resolves against the cell text before it is trusted.
- The create affordance is gated to editable cells because it relies on editor focus. Reading and opening existing threads stays available to read-only viewers; cloud writes stay scoped to editor/owner.
- `demote_thread_anchor_to_notebook` is a plain authored mutation: the demoting actor becomes the change author, messages are preserved, no authority or finalization state.

## Follow-ups

- Comment-on-read-only (Google-Docs-style commenting without edit rights) needs read-only editors to stay focusable. Deferred.
- Rendered-markdown selection is the next slice.

Verified: `cargo build --workspace`, `cargo test -p comments-doc` (31), `vp check`, and the new `comment-source-anchor` / `InlineCommentComposer` suites (18) all pass.
