### PR TITLE
feat(elements): prototype notebook context controls

### DIFF
--- a/apps/elements/app/page.tsx
+++ b/apps/elements/app/page.tsx
@@ -9,6 +9,7 @@ import {
   IdCard,
   LayoutDashboard,
   ListPlus,
+  MousePointer2,
   PackageCheck,
   Palette,
   PanelLeft,
@@ -62,6 +63,12 @@ const catalogGroups = [
         description: "Rail, environment, and connect-flow options for workstations.",
         href: "/docs/compute-placement",
         icon: Workflow,
+      },
+      {
+        title: "Context controls",
+        description: "Target-specific notebook actions for menus and toolbars.",
+        href: "/docs/context-controls",
+        icon: MousePointer2,
       },
       {
         title: "Notebook toolbar",

--- a/apps/elements/components/context-controls-example.tsx
+++ b/apps/elements/components/context-controls-example.tsx
@@ -1,0 +1,533 @@
+"use client";
+
+import {
+  BookOpen,
+  Copy,
+  FileQuestion,
+  Link2,
+  Maximize2,
+  MessageSquarePlus,
+  PackageCheck,
+  Pencil,
+  Play,
+  Plus,
+  SearchCode,
+  Sparkles,
+  Trash2,
+} from "lucide-react";
+import { useMemo, useState, type ReactNode } from "react";
+import { CodeMirrorEditor } from "@/components/editor/codemirror-editor";
+import {
+  NotebookCommandToolbar,
+  NotebookContextMenu,
+  type NotebookContextMenuGroup,
+  type NotebookContextSurface,
+} from "@/components/notebook";
+import { Button } from "@/components/ui/button";
+import { cn } from "@/lib/utils";
+import { getElementsNotebookScenario } from "./notebook-scenarios";
+
+type ContextTargetKind = "source" | "markdown" | "output" | "package";
+
+interface ContextTargetFixture {
+  id: string;
+  kind: ContextTargetKind;
+  title: string;
+  body: string;
+  detail: string;
+  code?: string;
+}
+
+const contextTargets = [
+  {
+    id: "source-derivative",
+    kind: "source",
+    title: "Selected source range",
+    body: "derivative = sp.diff(f, x)",
+    detail: "Cell 4 · line 12",
+    code: [
+      "x = sp.symbols('x')",
+      "f = sp.sin(x) ** 2",
+      "derivative = sp.diff(f, x)",
+      "sp.simplify(derivative)",
+    ].join("\n"),
+  },
+  {
+    id: "markdown-heading",
+    kind: "markdown",
+    title: "Section heading",
+    body: "Forecast review",
+    detail: "Notebook outline · section 2",
+    code: [
+      "## Forecast review",
+      "",
+      "Compare the model output against recent station observations before publishing.",
+    ].join("\n"),
+  },
+  {
+    id: "output-chart",
+    kind: "output",
+    title: "Rendered chart output",
+    body: "Plotly trend chart with one warning attached to the output frame.",
+    detail: "Output 2 · text/html",
+  },
+  {
+    id: "package-sympy",
+    kind: "package",
+    title: "sympy >= 1.13",
+    body: "Dependency declared by the notebook environment summary.",
+    detail: "pyproject.toml · runtime restart required",
+  },
+] satisfies readonly ContextTargetFixture[];
+
+function icon(node: ReactNode) {
+  return node;
+}
+
+function surfaceForTarget(target: ContextTargetFixture): NotebookContextSurface {
+  return {
+    kind: target.kind,
+    title: target.title,
+    description: target.body,
+    detail: target.detail,
+  };
+}
+
+function groupsForTarget(
+  target: ContextTargetFixture,
+  onAction: (target: ContextTargetFixture, action: string) => void,
+): NotebookContextMenuGroup[] {
+  const select = (label: string) => () => onAction(target, label);
+
+  if (target.kind === "source") {
+    return [
+      {
+        id: "comment",
+        actions: [
+          {
+            id: "comment-selection",
+            label: "Add comment",
+            description: "Anchor a discussion to this source range.",
+            icon: icon(<MessageSquarePlus />),
+            shortcut: "C",
+            onSelect: select("Add comment"),
+          },
+          {
+            id: "explain-selection",
+            label: "Ask agent about selection",
+            description: "Send the selected code and cell context.",
+            icon: icon(<Sparkles />),
+            onSelect: select("Ask agent about selection"),
+          },
+        ],
+      },
+      {
+        id: "cell",
+        label: "Cell",
+        actions: [
+          {
+            id: "run-cell",
+            label: "Run cell",
+            icon: icon(<Play />),
+            shortcut: "Shift Enter",
+            onSelect: select("Run cell"),
+          },
+          {
+            id: "insert-code",
+            label: "Insert code cell below",
+            icon: icon(<Plus />),
+            onSelect: select("Insert code cell below"),
+          },
+        ],
+      },
+      {
+        id: "inspect",
+        label: "Inspect",
+        actions: [
+          {
+            id: "copy-link",
+            label: "Copy cell link",
+            icon: icon(<Link2 />),
+            onSelect: select("Copy cell link"),
+          },
+          {
+            id: "source-docs",
+            label: "Open source editing docs",
+            icon: icon(<BookOpen />),
+            onSelect: select("Open source editing docs"),
+          },
+        ],
+      },
+    ];
+  }
+
+  if (target.kind === "markdown") {
+    return [
+      {
+        id: "comment",
+        actions: [
+          {
+            id: "comment-heading",
+            label: "Add comment",
+            description: "Anchor feedback to the rendered heading.",
+            icon: icon(<MessageSquarePlus />),
+            shortcut: "C",
+            onSelect: select("Add comment"),
+          },
+          {
+            id: "copy-heading",
+            label: "Copy heading link",
+            icon: icon(<Link2 />),
+            onSelect: select("Copy heading link"),
+          },
+        ],
+      },
+      {
+        id: "edit",
+        label: "Edit",
+        actions: [
+          {
+            id: "edit-heading",
+            label: "Edit markdown source",
+            icon: icon(<Pencil />),
+            onSelect: select("Edit markdown source"),
+          },
+          {
+            id: "insert-markdown",
+            label: "Insert markdown below",
+            icon: icon(<Plus />),
+            onSelect: select("Insert markdown below"),
+          },
+        ],
+      },
+    ];
+  }
+
+  if (target.kind === "output") {
+    return [
+      {
+        id: "comment",
+        actions: [
+          {
+            id: "comment-output",
+            label: "Add comment",
+            description: "Attach discussion to the output frame.",
+            icon: icon(<MessageSquarePlus />),
+            shortcut: "C",
+            onSelect: select("Add comment"),
+          },
+          {
+            id: "expand-output",
+            label: "Open output",
+            icon: icon(<Maximize2 />),
+            onSelect: select("Open output"),
+          },
+        ],
+      },
+      {
+        id: "inspect",
+        label: "Inspect",
+        actions: [
+          {
+            id: "copy-output",
+            label: "Copy output",
+            icon: icon(<Copy />),
+            onSelect: select("Copy output"),
+          },
+          {
+            id: "renderer-docs",
+            label: "Open renderer docs",
+            icon: icon(<SearchCode />),
+            onSelect: select("Open renderer docs"),
+          },
+        ],
+      },
+    ];
+  }
+
+  return [
+    {
+      id: "package",
+      actions: [
+        {
+          id: "inspect-package",
+          label: "Open package details",
+          icon: icon(<PackageCheck />),
+          onSelect: select("Open package details"),
+        },
+        {
+          id: "comment-package",
+          label: "Add comment",
+          description: "Start a dependency-specific discussion.",
+          icon: icon(<MessageSquarePlus />),
+          onSelect: select("Add comment"),
+        },
+      ],
+    },
+    {
+      id: "edit",
+      label: "Edit",
+      actions: [
+        {
+          id: "pin-package",
+          label: "Pin version",
+          icon: icon(<Pencil />),
+          onSelect: select("Pin version"),
+        },
+        {
+          id: "remove-package",
+          label: "Remove dependency",
+          icon: icon(<Trash2 />),
+          destructive: true,
+          onSelect: select("Remove dependency"),
+        },
+      ],
+    },
+  ];
+}
+
+export function ContextControlsExample() {
+  const scenario = getElementsNotebookScenario("desktop-local-owner");
+  const sourceTarget = contextTargets[0];
+  const markdownTarget = contextTargets[1];
+  const outputTarget = contextTargets[2];
+  const packageTarget = contextTargets[3];
+  const [activeTargetId, setActiveTargetId] = useState(contextTargets[0].id);
+  const [lastAction, setLastAction] = useState("No context action selected");
+  const [source, setSource] = useState(sourceTarget.code ?? "");
+  const activeTarget = useMemo(
+    () => contextTargets.find((target) => target.id === activeTargetId) ?? contextTargets[0],
+    [activeTargetId],
+  );
+
+  const recordAction = (target: ContextTargetFixture, action: string) => {
+    setActiveTargetId(target.id);
+    setLastAction(`${action} · ${target.title}`);
+  };
+
+  return (
+    <div className="not-prose space-y-6">
+      <section className="border-l border-fd-border py-1 pl-4 text-fd-muted-foreground">
+        <div className="flex items-start gap-3">
+          <FileQuestion className="mt-0.5 size-4 flex-none" aria-hidden="true" />
+          <div>
+            <h2 className="text-sm font-semibold text-fd-foreground">Context controls boundary</h2>
+            <p className="mt-1 text-xs leading-5">
+              The shared menu receives a surface descriptor and grouped actions. The docs page owns
+              fixture actions only; notebook state, comments, runtime, package mutation, and docs
+              routing stay with the host.
+            </p>
+          </div>
+        </div>
+      </section>
+
+      <section className="mx-auto max-w-3xl overflow-hidden rounded-lg border border-fd-border bg-fd-card">
+        <div className="border-b border-fd-border">
+          <NotebookCommandToolbar
+            capabilities={scenario.capabilities}
+            runtime="python"
+            environmentManager="uv"
+            runtimeStatus={{
+              state: "idle",
+              label: "Ready",
+              ariaLabel: "Kernel ready",
+              title: "Kernel ready",
+            }}
+            onAddCell={() => recordAction(activeTarget, "Add cell from toolbar")}
+            onRunAllCells={() => recordAction(activeTarget, "Run all from toolbar")}
+            onRestartRuntime={() => recordAction(activeTarget, "Restart from toolbar")}
+            onTogglePackages={() => recordAction(activeTarget, "Open packages from toolbar")}
+            utilityControls={
+              <div className="flex items-center gap-1">
+                <Button
+                  type="button"
+                  variant="ghost"
+                  size="sm"
+                  className="h-7 px-2 text-xs"
+                  onClick={() => recordAction(activeTarget, "Add comment from toolbar")}
+                >
+                  <MessageSquarePlus className="size-3.5" aria-hidden="true" />
+                  Comment
+                </Button>
+                <Button
+                  type="button"
+                  variant="ghost"
+                  size="sm"
+                  className="h-7 px-2 text-xs"
+                  onClick={() => recordAction(activeTarget, "Open docs from toolbar")}
+                >
+                  <BookOpen className="size-3.5" aria-hidden="true" />
+                  Docs
+                </Button>
+              </div>
+            }
+          />
+        </div>
+
+        <div className="bg-background">
+          <div className="border-b border-fd-border px-4 py-3">
+            <h2 className="text-sm font-semibold">Forecast Review.ipynb</h2>
+            <div className="mt-1 text-xs text-fd-muted-foreground">
+              Right-click source, markdown, output, or package context.
+            </div>
+          </div>
+
+          <div className="divide-y divide-fd-border">
+            <NotebookContextRegion
+              active={activeTargetId === sourceTarget.id}
+              target={sourceTarget}
+              onAction={recordAction}
+              onOpenChange={(open) => {
+                if (open) setActiveTargetId(sourceTarget.id);
+              }}
+            >
+              <div className="grid gap-3 p-4">
+                <CellHeader label="Code" detail={sourceTarget.detail} />
+                <div className="min-w-0 border-l-2 border-emerald-500 pl-3">
+                  <CodeMirrorEditor
+                    initialValue={source}
+                    language="python"
+                    lineWrapping
+                    onValueChange={setSource}
+                    className="min-h-28"
+                  />
+                </div>
+              </div>
+            </NotebookContextRegion>
+
+            <NotebookContextRegion
+              active={activeTargetId === markdownTarget.id}
+              target={markdownTarget}
+              onAction={recordAction}
+              onOpenChange={(open) => {
+                if (open) setActiveTargetId(markdownTarget.id);
+              }}
+            >
+              <div className="grid gap-3 p-4">
+                <CellHeader label="Markdown" detail={markdownTarget.detail} />
+                <div className="border-l-2 border-sky-500 pl-3">
+                  <h2 className="text-xl font-semibold tracking-normal text-fd-foreground">
+                    Forecast review
+                  </h2>
+                  <p className="mt-2 text-sm leading-6 text-fd-muted-foreground">
+                    Compare the model output against recent station observations before publishing.
+                  </p>
+                </div>
+              </div>
+            </NotebookContextRegion>
+
+            <NotebookContextRegion
+              active={activeTargetId === outputTarget.id}
+              target={outputTarget}
+              onAction={recordAction}
+              onOpenChange={(open) => {
+                if (open) setActiveTargetId(outputTarget.id);
+              }}
+            >
+              <div className="grid gap-3 p-4">
+                <CellHeader label="Output" detail={outputTarget.detail} />
+                <div className="border-l-2 border-fd-border pl-3">
+                  <div className="rounded-md border border-fd-border bg-fd-card p-3">
+                    <div className="flex h-32 items-end gap-3">
+                      {[42, 72, 58, 91, 65, 80].map((height, index) => (
+                        <div
+                          key={height}
+                          className="flex h-full min-w-0 flex-1 items-end border-l border-fd-border/60 pl-1"
+                        >
+                          <div
+                            className="w-full bg-emerald-500/70"
+                            style={{ height: `${height}%` }}
+                            aria-label={`Series ${index + 1}`}
+                          />
+                        </div>
+                      ))}
+                    </div>
+                    <div className="mt-3 text-xs text-fd-muted-foreground">
+                      Forecast score by observation window
+                    </div>
+                  </div>
+                </div>
+              </div>
+            </NotebookContextRegion>
+
+            <NotebookContextRegion
+              active={activeTargetId === packageTarget.id}
+              target={packageTarget}
+              onAction={recordAction}
+              onOpenChange={(open) => {
+                if (open) setActiveTargetId(packageTarget.id);
+              }}
+            >
+              <div className="grid gap-3 p-4">
+                <CellHeader label="Environment" detail={packageTarget.detail} />
+                <div className="border-l-2 border-fd-border pl-3">
+                  <div className="grid gap-2 text-sm sm:grid-cols-[minmax(0,1fr)_auto]">
+                    <div className="min-w-0">
+                      <div className="font-mono text-sm text-fd-foreground">sympy &gt;= 1.13</div>
+                      <div className="mt-1 text-xs leading-5 text-fd-muted-foreground">
+                        Runtime package context follows the notebook rather than a separate package
+                        manager page.
+                      </div>
+                    </div>
+                    <div className="text-xs font-medium text-amber-700 dark:text-amber-300">
+                      restart required
+                    </div>
+                  </div>
+                </div>
+              </div>
+            </NotebookContextRegion>
+          </div>
+
+          <div className="border-t border-fd-border px-4 py-3 text-xs leading-5 text-fd-muted-foreground">
+            <span className="font-medium text-fd-foreground">{activeTarget.title}</span>
+            <span> · {activeTarget.detail}</span>
+            <span className="block">{lastAction}</span>
+          </div>
+        </div>
+      </section>
+    </div>
+  );
+}
+
+function CellHeader({ detail, label }: { detail: string; label: string }) {
+  return (
+    <div className="flex min-w-0 items-center justify-between gap-3">
+      <div className="text-xs font-medium uppercase tracking-normal text-fd-muted-foreground">
+        {label}
+      </div>
+      <div className="truncate text-xs text-fd-muted-foreground">{detail}</div>
+    </div>
+  );
+}
+
+function NotebookContextRegion({
+  active,
+  children,
+  target,
+  onAction,
+  onOpenChange,
+}: {
+  active: boolean;
+  children: ReactNode;
+  target: ContextTargetFixture;
+  onAction: (target: ContextTargetFixture, action: string) => void;
+  onOpenChange: (open: boolean) => void;
+}) {
+  return (
+    <NotebookContextMenu
+      surface={surfaceForTarget(target)}
+      groups={groupsForTarget(target, onAction)}
+      onOpenChange={onOpenChange}
+    >
+      <div
+        className={cn(
+          "min-w-0 transition-colors focus-within:bg-fd-muted/25 hover:bg-fd-muted/20",
+          active && "bg-fd-muted/30",
+        )}
+        onClick={() => onAction(target, "Selected")}
+      >
+        {children}
+      </div>
+    </NotebookContextMenu>
+  );
+}

--- a/apps/elements/content/docs/context-controls.mdx
+++ b/apps/elements/content/docs/context-controls.mdx
@@ -1,0 +1,25 @@
+---
+title: Context controls
+description: Right-click notebook actions fed by deterministic fixture context.
+---
+
+import { ContextControlsExample } from "@/components/context-controls-example";
+
+Context controls are supplemental notebook actions. The visible toolbar and
+cell affordances stay primary, while the context menu collects target-specific
+actions such as commenting, docs lookup, source inspection, output handling, and
+package edits.
+
+The fixture below renders the shared `NotebookContextMenu` component with
+deterministic source, markdown, output, and package targets. The menu is real
+Radix/shadcn UI, but every action is inert fixture state.
+
+<ContextControlsExample />
+
+## Boundary
+
+- The shared component owns menu grouping, target labels, disabled/destructive
+  presentation, shortcuts, and action invocation.
+- The host owns target detection, comment anchors, docs routes, notebook
+  mutation, package edits, runtime actions, and permission filtering.
+- Elements owns only the deterministic targets and action transcript for review.

--- a/apps/elements/content/docs/index.mdx
+++ b/apps/elements/content/docs/index.mdx
@@ -37,6 +37,7 @@ concepts and which boundaries still need a notebook-semantic wrapper.
 - [Cloud notebook shell](/docs/cloud-notebook-shell)
 - [Cloud dashboard](/docs/cloud-dashboard)
 - [Compute placement](/docs/compute-placement)
+- [Context controls](/docs/context-controls)
 - [Identity and environment surfaces](/docs/identity-environment-surfaces)
 - [Notebook toolbar surfaces](/docs/notebook-toolbar-surfaces)
 - [Notebook outline rail](/docs/notebook-outline)

--- a/package.json
+++ b/package.json
@@ -43,6 +43,7 @@
     "@radix-ui/react-avatar": "^1.1.11",
     "@radix-ui/react-checkbox": "^1.3.3",
     "@radix-ui/react-collapsible": "^1.1.12",
+    "@radix-ui/react-context-menu": "^2.2.16",
     "@radix-ui/react-dialog": "^1.1.15",
     "@radix-ui/react-dropdown-menu": "^2.1.16",
     "@radix-ui/react-hover-card": "^1.1.15",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -90,6 +90,9 @@ importers:
       '@radix-ui/react-collapsible':
         specifier: ^1.1.12
         version: 1.1.12(@types/react-dom@19.2.3(@types/react@19.2.15))(@types/react@19.2.15)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+      '@radix-ui/react-context-menu':
+        specifier: ^2.2.16
+        version: 2.2.16(@types/react-dom@19.2.3(@types/react@19.2.15))(@types/react@19.2.15)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       '@radix-ui/react-dialog':
         specifier: ^1.1.15
         version: 1.1.15(@types/react-dom@19.2.3(@types/react@19.2.15))(@types/react@19.2.15)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)

--- a/src/components/notebook/NotebookContextMenu.tsx
+++ b/src/components/notebook/NotebookContextMenu.tsx
@@ -1,0 +1,134 @@
+import type { ReactNode } from "react";
+import {
+  ContextMenu,
+  ContextMenuContent,
+  ContextMenuItem,
+  ContextMenuLabel,
+  ContextMenuSeparator,
+  ContextMenuShortcut,
+  ContextMenuTrigger,
+} from "@/components/ui/context-menu";
+import { cn } from "@/lib/utils";
+
+export type NotebookContextSurfaceKind =
+  | "notebook"
+  | "cell"
+  | "source"
+  | "markdown"
+  | "output"
+  | "package"
+  | "selection";
+
+export interface NotebookContextSurface {
+  kind: NotebookContextSurfaceKind;
+  title: string;
+  description?: ReactNode;
+  detail?: ReactNode;
+}
+
+export interface NotebookContextMenuAction {
+  id: string;
+  label: string;
+  description?: ReactNode;
+  icon?: ReactNode;
+  shortcut?: string;
+  disabled?: boolean;
+  destructive?: boolean;
+  onSelect?: () => void;
+}
+
+export interface NotebookContextMenuGroup {
+  id: string;
+  label?: string;
+  actions: readonly NotebookContextMenuAction[];
+}
+
+export interface NotebookContextMenuProps {
+  surface: NotebookContextSurface;
+  groups: readonly NotebookContextMenuGroup[];
+  children: ReactNode;
+  contentClassName?: string;
+  onOpenChange?: (open: boolean) => void;
+}
+
+export function NotebookContextMenu({
+  surface,
+  groups,
+  children,
+  contentClassName,
+  onOpenChange,
+}: NotebookContextMenuProps) {
+  const visibleGroups = groups
+    .map((group) => ({
+      ...group,
+      actions: group.actions.filter(Boolean),
+    }))
+    .filter((group) => group.actions.length > 0);
+
+  return (
+    <ContextMenu onOpenChange={onOpenChange}>
+      <ContextMenuTrigger asChild>{children}</ContextMenuTrigger>
+      <ContextMenuContent
+        className={cn("w-72 p-1.5", contentClassName)}
+        data-slot="notebook-context-menu"
+        data-context-kind={surface.kind}
+      >
+        <ContextMenuLabel className="px-2 py-2">
+          <span className="block text-[11px] font-medium uppercase tracking-normal text-muted-foreground">
+            {surface.kind}
+          </span>
+          <span className="mt-0.5 block truncate text-sm font-semibold text-foreground">
+            {surface.title}
+          </span>
+          {surface.description ? (
+            <span className="mt-1 block whitespace-normal text-xs font-normal leading-5 text-muted-foreground">
+              {surface.description}
+            </span>
+          ) : null}
+          {surface.detail ? (
+            <span className="mt-1 block truncate text-xs font-normal text-muted-foreground">
+              {surface.detail}
+            </span>
+          ) : null}
+        </ContextMenuLabel>
+
+        {visibleGroups.map((group, index) => (
+          <div key={group.id}>
+            {index > 0 ? <ContextMenuSeparator /> : null}
+            {group.label ? (
+              <ContextMenuLabel className="px-2 pb-1 pt-1.5 text-[11px] font-medium uppercase tracking-normal text-muted-foreground">
+                {group.label}
+              </ContextMenuLabel>
+            ) : null}
+            {group.actions.map((action) => (
+              <ContextMenuItem
+                key={action.id}
+                disabled={action.disabled}
+                variant={action.destructive ? "destructive" : "default"}
+                className="items-start gap-2 py-2"
+                onSelect={() => action.onSelect?.()}
+              >
+                {action.icon ? (
+                  <span className="mt-0.5 flex size-4 shrink-0 items-center justify-center text-muted-foreground">
+                    {action.icon}
+                  </span>
+                ) : null}
+                <span className="min-w-0 flex-1">
+                  <span className="block truncate">{action.label}</span>
+                  {action.description ? (
+                    <span className="mt-0.5 block whitespace-normal text-xs leading-4 text-muted-foreground">
+                      {action.description}
+                    </span>
+                  ) : null}
+                </span>
+                {action.shortcut ? (
+                  <ContextMenuShortcut>{action.shortcut}</ContextMenuShortcut>
+                ) : null}
+              </ContextMenuItem>
+            ))}
+          </div>
+        ))}
+      </ContextMenuContent>
+    </ContextMenu>
+  );
+}

--- a/src/components/notebook/__tests__/NotebookContextMenu.test.tsx
+++ b/src/components/notebook/__tests__/NotebookContextMenu.test.tsx
@@ -1,0 +1,76 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vite-plus/test";
+import { NotebookContextMenu } from "../NotebookContextMenu";
+
+describe("NotebookContextMenu", () => {
+  it("opens target-specific actions from the context trigger", async () => {
+    const onSelect = vi.fn();
+
+    render(
+      <NotebookContextMenu
+        surface={{
+          kind: "source",
+          title: "Selected source range",
+          description: "derivative = sp.diff(f, x)",
+          detail: "Cell 4 - line 12",
+        }}
+        groups={[
+          {
+            id: "comment",
+            actions: [
+              {
+                id: "add-comment",
+                label: "Add comment",
+                description: "Anchor a discussion to this source range.",
+                shortcut: "C",
+                onSelect,
+              },
+            ],
+          },
+        ]}
+      >
+        <button type="button">Forecast cell</button>
+      </NotebookContextMenu>,
+    );
+
+    fireEvent.contextMenu(screen.getByRole("button", { name: "Forecast cell" }));
+
+    expect(await screen.findByText("source")).toBeInTheDocument();
+    expect(screen.getByText("Selected source range")).toBeInTheDocument();
+    expect(screen.getByRole("menuitem", { name: /Add comment/ })).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole("menuitem", { name: /Add comment/ }));
+
+    expect(onSelect).toHaveBeenCalledTimes(1);
+  });
+
+  it("keeps disabled actions visible but unavailable", async () => {
+    render(
+      <NotebookContextMenu
+        surface={{ kind: "package", title: "sympy >= 1.13" }}
+        groups={[
+          {
+            id: "edit",
+            actions: [
+              {
+                id: "remove-package",
+                label: "Remove dependency",
+                disabled: true,
+                destructive: true,
+              },
+            ],
+          },
+        ]}
+      >
+        <button type="button">Package row</button>
+      </NotebookContextMenu>,
+    );
+
+    fireEvent.contextMenu(screen.getByRole("button", { name: "Package row" }));
+
+    expect(await screen.findByRole("menuitem", { name: "Remove dependency" })).toHaveAttribute(
+      "aria-disabled",
+      "true",
+    );
+  });
+});

--- a/src/components/notebook/index.ts
+++ b/src/components/notebook/index.ts
@@ -204,6 +204,14 @@ export {
   type NotebookEditModeButtonProps,
   type NotebookEditModeState,
 } from "./NotebookEditModeButton";
+export {
+  NotebookContextMenu,
+  type NotebookContextMenuAction,
+  type NotebookContextMenuGroup,
+  type NotebookContextMenuProps,
+  type NotebookContextSurface,
+  type NotebookContextSurfaceKind,
+} from "./NotebookContextMenu";
 export { computeCanMutateCells } from "./mutation-gate";
 export {
   createNotebookInteractionModeProjection,

--- a/src/components/ui/context-menu.tsx
+++ b/src/components/ui/context-menu.tsx
@@ -1,0 +1,188 @@
+import * as ContextMenuPrimitive from "@radix-ui/react-context-menu";
+import { Check, ChevronRight, Circle } from "lucide-react";
+import * as React from "react";
+
+import { cn } from "@/lib/utils";
+
+const ContextMenu = ContextMenuPrimitive.Root;
+
+const ContextMenuTrigger = ContextMenuPrimitive.Trigger;
+
+const ContextMenuGroup = ContextMenuPrimitive.Group;
+
+const ContextMenuPortal = ContextMenuPrimitive.Portal;
+
+const ContextMenuSub = ContextMenuPrimitive.Sub;
+
+const ContextMenuRadioGroup = ContextMenuPrimitive.RadioGroup;
+
+const ContextMenuSubTrigger = React.forwardRef<
+  React.ElementRef<typeof ContextMenuPrimitive.SubTrigger>,
+  React.ComponentPropsWithoutRef<typeof ContextMenuPrimitive.SubTrigger> & {
+    inset?: boolean;
+  }
+>(({ className, inset, children, ...props }, ref) => (
+  <ContextMenuPrimitive.SubTrigger
+    ref={ref}
+    className={cn(
+      "flex cursor-default select-none items-center gap-2 rounded-sm px-2 py-1.5 text-sm outline-none focus:bg-accent data-[state=open]:bg-accent [&_svg]:pointer-events-none [&_svg]:size-4 [&_svg]:shrink-0",
+      inset && "pl-8",
+      className,
+    )}
+    {...props}
+  >
+    {children}
+    <ChevronRight className="ml-auto" />
+  </ContextMenuPrimitive.SubTrigger>
+));
+ContextMenuSubTrigger.displayName = ContextMenuPrimitive.SubTrigger.displayName;
+
+const ContextMenuSubContent = React.forwardRef<
+  React.ElementRef<typeof ContextMenuPrimitive.SubContent>,
+  React.ComponentPropsWithoutRef<typeof ContextMenuPrimitive.SubContent>
+>(({ className, ...props }, ref) => (
+  <ContextMenuPrimitive.SubContent
+    ref={ref}
+    className={cn(
+      "z-50 min-w-[8rem] overflow-hidden rounded-md border bg-popover p-1 text-popover-foreground shadow-lg data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 origin-[--radix-context-menu-content-transform-origin]",
+      className,
+    )}
+    {...props}
+  />
+));
+ContextMenuSubContent.displayName = ContextMenuPrimitive.SubContent.displayName;
+
+const ContextMenuContent = React.forwardRef<
+  React.ElementRef<typeof ContextMenuPrimitive.Content>,
+  React.ComponentPropsWithoutRef<typeof ContextMenuPrimitive.Content>
+>(({ className, ...props }, ref) => (
+  <ContextMenuPrimitive.Portal>
+    <ContextMenuPrimitive.Content
+      ref={ref}
+      className={cn(
+        "z-50 max-h-[var(--radix-context-menu-content-available-height)] min-w-[8rem] overflow-y-auto overflow-x-hidden rounded-md border bg-popover p-1 text-popover-foreground shadow-md",
+        "data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 origin-[--radix-context-menu-content-transform-origin]",
+        className,
+      )}
+      {...props}
+    />
+  </ContextMenuPrimitive.Portal>
+));
+ContextMenuContent.displayName = ContextMenuPrimitive.Content.displayName;
+
+const ContextMenuItem = React.forwardRef<
+  React.ElementRef<typeof ContextMenuPrimitive.Item>,
+  React.ComponentPropsWithoutRef<typeof ContextMenuPrimitive.Item> & {
+    inset?: boolean;
+    variant?: "default" | "destructive";
+  }
+>(({ className, inset, variant = "default", ...props }, ref) => (
+  <ContextMenuPrimitive.Item
+    ref={ref}
+    data-variant={variant}
+    className={cn(
+      "relative flex cursor-default select-none items-center gap-2 rounded-sm px-2 py-1.5 text-sm outline-none transition-colors focus:bg-accent focus:text-accent-foreground data-[disabled]:pointer-events-none data-[disabled]:opacity-50 [&>svg]:size-4 [&>svg]:shrink-0",
+      "data-[variant=destructive]:text-destructive data-[variant=destructive]:focus:bg-destructive/10 dark:data-[variant=destructive]:focus:bg-destructive/20 data-[variant=destructive]:focus:text-destructive",
+      inset && "pl-8",
+      className,
+    )}
+    {...props}
+  />
+));
+ContextMenuItem.displayName = ContextMenuPrimitive.Item.displayName;
+
+const ContextMenuCheckboxItem = React.forwardRef<
+  React.ElementRef<typeof ContextMenuPrimitive.CheckboxItem>,
+  React.ComponentPropsWithoutRef<typeof ContextMenuPrimitive.CheckboxItem>
+>(({ className, children, checked, ...props }, ref) => (
+  <ContextMenuPrimitive.CheckboxItem
+    ref={ref}
+    className={cn(
+      "relative flex cursor-default select-none rounded-sm py-1.5 pl-8 pr-2 text-sm outline-none transition-colors focus:bg-accent focus:text-accent-foreground data-[disabled]:pointer-events-none data-[disabled]:opacity-50",
+      className,
+    )}
+    checked={checked}
+    {...props}
+  >
+    <span className="absolute left-2 flex h-3.5 w-3.5 items-center justify-center">
+      <ContextMenuPrimitive.ItemIndicator>
+        <Check className="h-4 w-4" />
+      </ContextMenuPrimitive.ItemIndicator>
+    </span>
+    {children}
+  </ContextMenuPrimitive.CheckboxItem>
+));
+ContextMenuCheckboxItem.displayName = ContextMenuPrimitive.CheckboxItem.displayName;
+
+const ContextMenuRadioItem = React.forwardRef<
+  React.ElementRef<typeof ContextMenuPrimitive.RadioItem>,
+  React.ComponentPropsWithoutRef<typeof ContextMenuPrimitive.RadioItem>
+>(({ className, children, ...props }, ref) => (
+  <ContextMenuPrimitive.RadioItem
+    ref={ref}
+    className={cn(
+      "relative flex cursor-default select-none rounded-sm py-1.5 pl-8 pr-2 text-sm outline-none transition-colors focus:bg-accent focus:text-accent-foreground data-[disabled]:pointer-events-none data-[disabled]:opacity-50",
+      className,
+    )}
+    {...props}
+  >
+    <span className="absolute left-2 flex h-3.5 w-3.5 items-center justify-center">
+      <ContextMenuPrimitive.ItemIndicator>
+        <Circle className="h-2 w-2 fill-current" />
+      </ContextMenuPrimitive.ItemIndicator>
+    </span>
+    {children}
+  </ContextMenuPrimitive.RadioItem>
+));
+ContextMenuRadioItem.displayName = ContextMenuPrimitive.RadioItem.displayName;
+
+const ContextMenuLabel = React.forwardRef<
+  React.ElementRef<typeof ContextMenuPrimitive.Label>,
+  React.ComponentPropsWithoutRef<typeof ContextMenuPrimitive.Label> & {
+    inset?: boolean;
+  }
+>(({ className, inset, ...props }, ref) => (
+  <ContextMenuPrimitive.Label
+    ref={ref}
+    className={cn("px-2 py-1.5 text-sm font-semibold", inset && "pl-8", className)}
+    {...props}
+  />
+));
+ContextMenuLabel.displayName = ContextMenuPrimitive.Label.displayName;
+
+const ContextMenuSeparator = React.forwardRef<
+  React.ElementRef<typeof ContextMenuPrimitive.Separator>,
+  React.ComponentPropsWithoutRef<typeof ContextMenuPrimitive.Separator>
+>(({ className, ...props }, ref) => (
+  <ContextMenuPrimitive.Separator
+    ref={ref}
+    className={cn("-mx-1 my-1 h-px bg-muted", className)}
+    {...props}
+  />
+));
+ContextMenuSeparator.displayName = ContextMenuPrimitive.Separator.displayName;
+
+const ContextMenuShortcut = ({ className, ...props }: React.HTMLAttributes<HTMLSpanElement>) => {
+  return (
+    <span className={cn("ml-auto text-xs tracking-widest opacity-60", className)} {...props} />
+  );
+};
+ContextMenuShortcut.displayName = "ContextMenuShortcut";
+
+export {
+  ContextMenu,
+  ContextMenuTrigger,
+  ContextMenuContent,
+  ContextMenuItem,
+  ContextMenuCheckboxItem,
+  ContextMenuRadioItem,
+  ContextMenuLabel,
+  ContextMenuSeparator,
+  ContextMenuShortcut,
+  ContextMenuGroup,
+  ContextMenuPortal,
+  ContextMenuSub,
+  ContextMenuSubContent,
+  ContextMenuSubTrigger,
+  ContextMenuRadioGroup,
+};


### PR DESCRIPTION
## Summary

- add a shared `NotebookContextMenu` wrapper backed by the shadcn/Radix context menu primitive
- add an Elements `Context controls` page with a linear notebook fixture using real `CodeMirrorEditor`
- wire source, markdown, output, and package context actions through deterministic fixture callbacks

## Verification

- `pnpm test:run src/components/notebook/__tests__/NotebookContextMenu.test.tsx`
- `pnpm --dir apps/elements exec tsc --noEmit --pretty false`
- `cargo xtask lint --fix`
- `curl -fsS http://localhost:5177/docs/context-controls`
- Playwright screenshot pass for desktop, menu-open, and mobile states

## Notes

This is intentionally draft while the context-control interaction is still being reviewed in Elements.
