### PR TITLE
refactor(comments): consolidate agent attribution onto the identity core

### DIFF
--- a/apps/elements/components/comment-surfaces-example.tsx
+++ b/apps/elements/components/comment-surfaces-example.tsx
@@ -18,12 +18,13 @@ function resolveCommentAuthor(actorLabel: string): CommentAuthor {
     return {
       displayName: "Claude Code",
       color: CLAUDE_COLOR,
+      imageUrl: null,
       isAgent: true,
       onBehalfOf: "Ada",
       onBehalfOfColor: ADA_COLOR,
     };
   }
-  return { displayName: "Ada", color: ADA_COLOR };
+  return { displayName: "Ada", color: ADA_COLOR, imageUrl: null };
 }
 
 function resolveSourceLanguage(): string {

--- a/apps/notebook-cloud/viewer/notebook-viewer.tsx
+++ b/apps/notebook-cloud/viewer/notebook-viewer.tsx
@@ -580,9 +580,10 @@ export function NotebookViewer({
       return {
         displayName: display.displayName,
         color: display.color,
+        imageUrl: display.imageUrl,
         isAgent: display.isAgent,
         onBehalfOf: display.onBehalfOf,
-        onBehalfOfColor: display.onBehalfOf ? display.color : undefined,
+        onBehalfOfColor: display.onBehalfOfColor,
       };
     },
     [commentAuthorPeers],
@@ -1354,6 +1355,7 @@ export function NotebookViewer({
           ? {
               authorName: author?.displayName ?? "Unknown",
               authorColor: author?.color,
+              imageUrl: author?.imageUrl,
               isAgent: author?.isAgent,
               onBehalfOf: author?.onBehalfOf,
               onBehalfOfColor: author?.onBehalfOfColor,

--- a/apps/notebook/src/App.tsx
+++ b/apps/notebook/src/App.tsx
@@ -759,9 +759,10 @@ function AppContent() {
       return {
         displayName: display.displayName,
         color: display.color,
+        imageUrl: display.imageUrl,
         isAgent: display.isAgent,
         onBehalfOf: display.onBehalfOf,
-        onBehalfOfColor: display.onBehalfOf ? display.color : undefined,
+        onBehalfOfColor: display.onBehalfOfColor,
       };
     },
     [connectionScope],
@@ -794,6 +795,7 @@ function AppContent() {
           ? {
               authorName: author?.displayName ?? "Unknown",
               authorColor: author?.color,
+              imageUrl: author?.imageUrl,
               isAgent: author?.isAgent,
               onBehalfOf: author?.onBehalfOf,
               onBehalfOfColor: author?.onBehalfOfColor,

--- a/apps/notebook/src/lib/comment-highlight-extension.ts
+++ b/apps/notebook/src/lib/comment-highlight-extension.ts
@@ -6,15 +6,16 @@ import {
   hoverTooltip,
   ViewPlugin,
 } from "@codemirror/view";
-import { actorInitials } from "runtimed";
+import { actorInitials, onBehalfOfText } from "runtimed";
 
 /** Compact thread summary shown when hovering a highlighted range. */
 export interface CommentHighlightPreview {
   authorName: string;
   authorColor?: string;
+  imageUrl?: string | null;
   isAgent?: boolean;
   onBehalfOf?: string | null;
-  onBehalfOfColor?: string;
+  onBehalfOfColor?: string | null;
   body: string;
   replyCount: number;
 }
@@ -148,7 +149,13 @@ function buildPreviewDom(preview: CommentHighlightPreview): HTMLElement {
   avatar.style.cssText =
     "position:relative;flex:none;width:18px;height:18px;border-radius:50%;color:#fff;font-size:9px;font-weight:600;display:grid;place-items:center;";
   avatar.style.backgroundColor = preview.authorColor ?? "hsl(var(--muted-foreground, 215 16% 47%))";
-  if (preview.isAgent) {
+  if (preview.imageUrl) {
+    const image = document.createElement("img");
+    image.src = preview.imageUrl;
+    image.alt = "";
+    image.style.cssText = "width:100%;height:100%;border-radius:50%;object-fit:cover;";
+    avatar.appendChild(image);
+  } else if (preview.isAgent) {
     avatar.innerHTML = BOT_ICON_SVG;
   } else {
     avatar.textContent = actorInitials(preview.authorName);
@@ -173,7 +180,7 @@ function buildPreviewDom(preview: CommentHighlightPreview): HTMLElement {
   if (preview.isAgent) {
     const meta = document.createElement("span");
     meta.style.cssText = "font-size:10px;color:hsl(var(--muted-foreground, 215 16% 47%));";
-    meta.textContent = preview.onBehalfOf ? `AI for ${preview.onBehalfOf}` : "AI";
+    meta.textContent = `AI${onBehalfOfText(preview.onBehalfOf)}`;
     head.appendChild(meta);
   }
   root.appendChild(head);

--- a/packages/runtimed/src/index.ts
+++ b/packages/runtimed/src/index.ts
@@ -302,6 +302,7 @@ export {
 } from "./notebook-actor-color";
 
 // Notebook actor display
+export { onBehalfOfText } from "./notebook-actor-attribution";
 export {
   actorInitials,
   resolveActorDisplay,

--- a/packages/runtimed/src/notebook-actor-attribution.ts
+++ b/packages/runtimed/src/notebook-actor-attribution.ts
@@ -1,0 +1,4 @@
+export function onBehalfOfText(name: string | null | undefined): string {
+  const trimmed = name?.trim();
+  return trimmed ? ` for ${trimmed}` : "";
+}

--- a/packages/runtimed/src/notebook-actor-display.ts
+++ b/packages/runtimed/src/notebook-actor-display.ts
@@ -3,7 +3,7 @@ import {
   notebookActorProjectionFromLabel,
   type NotebookActorKind,
 } from "./notebook-actor-projection";
-import { colorForActorIdentity } from "./notebook-actor-color";
+import { CURSOR_COLORS, colorForActorIdentity } from "./notebook-actor-color";
 
 export interface ActorDisplayPeer {
   participantKey: string;
@@ -23,6 +23,7 @@ export interface ActorDisplay {
   kind: NotebookActorKind;
   isAgent: boolean;
   onBehalfOf: string | null;
+  onBehalfOfColor: string | null;
   color: string;
   initials: string;
   imageUrl: string | null;
@@ -41,17 +42,29 @@ export function resolveActorDisplay({
   const principalDisplayName = peerLabel ?? projection.principal.label;
   const isAgent = identity.kind === "agent";
   const displayName = isAgent ? (identity.operatorLabel ?? identity.label) : principalDisplayName;
+  const onBehalfOf = isAgent ? (peerLabel ?? identity.principalLabel ?? null) : null;
+  const color = colorForActorIdentity(actorLabel);
 
   return {
     displayName,
     principalId,
     kind: identity.kind,
     isAgent,
-    onBehalfOf: isAgent ? (peerLabel ?? identity.principalLabel ?? null) : null,
-    color: colorForActorIdentity(actorLabel),
+    onBehalfOf,
+    onBehalfOfColor: onBehalfOf
+      ? distinctActorColor(colorForActorIdentity(projection.principal.id), color)
+      : null,
+    color,
     initials: actorInitials(displayName),
     imageUrl: peer?.imageUrl ?? null,
   };
+}
+
+function distinctActorColor(candidate: string, actorColor: string): string {
+  if (candidate !== actorColor) return candidate;
+  const index = CURSOR_COLORS.findIndex((color) => color === candidate);
+  if (index === -1) return candidate;
+  return CURSOR_COLORS[(index + 1) % CURSOR_COLORS.length];
 }
 
 function peerForPrincipal(

--- a/packages/runtimed/src/notebook-actor-projection.ts
+++ b/packages/runtimed/src/notebook-actor-projection.ts
@@ -4,6 +4,7 @@ import type {
   NotebookShellAuthCapabilities,
   NotebookShellRuntimeCapabilities,
 } from "./notebook-shell-capabilities";
+import { onBehalfOfText } from "./notebook-actor-attribution";
 import { getBoundedCacheValue, setBoundedCacheValue, stableCacheKey } from "./projection-cache";
 
 export type ParsedNotebookActorKind = "agent" | "runtime" | "system";
@@ -593,7 +594,7 @@ function operatorActorLabel(actor: NotebookActorProjection): string {
     principalLabel !== actor.operator.label &&
     !isGenericPrincipalLabel(principalLabel)
   ) {
-    return `${actor.operator.label} for ${principalLabel}`;
+    return `${actor.operator.label}${onBehalfOfText(principalLabel)}`;
   }
   return actor.operator.label;
 }

--- a/src/components/notebook/NotebookCommentsPanel.tsx
+++ b/src/components/notebook/NotebookCommentsPanel.tsx
@@ -10,7 +10,7 @@ import {
   Send,
   X,
 } from "lucide-react";
-import { actorInitials } from "runtimed";
+import { actorInitials, onBehalfOfText } from "runtimed";
 import { useEffect, useRef, useState, type FormEvent } from "react";
 import type {
   CommentAnchor,
@@ -35,12 +35,14 @@ export interface CommentAuthor {
   displayName: string;
   /** Author color (hex), shared with cursors/attribution/highlights. */
   color?: string;
+  /** Profile image URL when the host can resolve one for this author. */
+  imageUrl?: string | null;
   /** True when the author is an AI agent rather than a person. */
   isAgent?: boolean;
   /** Principal the agent is acting for, when operating on someone's behalf. */
   onBehalfOf?: string | null;
   /** Color of the principal the agent acts for (for the on-behalf-of badge). */
-  onBehalfOfColor?: string;
+  onBehalfOfColor?: string | null;
 }
 
 export interface NotebookCommentsPanelProps {
@@ -428,7 +430,7 @@ function CommentResolutionReceipt({
   const resolverName = author?.displayName ?? "Someone";
   const resolverIdentity =
     author?.isAgent && author.onBehalfOf
-      ? `${resolverName} for ${author.onBehalfOf}`
+      ? `${resolverName}${onBehalfOfText(author.onBehalfOf)}`
       : resolverName;
   const resolutionLabel = `${resolverIdentity} marked as resolved${resolvedTime ? ` · ${resolvedTime}` : ""}`;
   return (
@@ -477,7 +479,9 @@ function CommentMessage({
             {author?.displayName ?? "Unknown"}
           </span>
           {author?.isAgent && author.onBehalfOf ? (
-            <span className="text-[10px] text-muted-foreground">· for {author.onBehalfOf}</span>
+            <span className="text-[10px] text-muted-foreground">
+              ·{onBehalfOfText(author.onBehalfOf)}
+            </span>
           ) : null}
           <span className="ml-auto shrink-0 text-[10px] text-muted-foreground">
             {formatRelativeTime(message.created_at)}
@@ -492,15 +496,21 @@ function CommentMessage({
 function CommentAuthorAvatar({ author }: { author: CommentAuthor }) {
   const face = (
     <div
-      className="flex size-5 items-center justify-center rounded-full text-[9px] font-semibold text-white"
+      className="flex size-5 items-center justify-center overflow-hidden rounded-full text-[9px] font-semibold text-white"
       style={{ backgroundColor: author.color ?? "hsl(var(--muted-foreground))" }}
     >
-      {author.isAgent ? <Bot className="size-3" /> : actorInitials(author.displayName)}
+      {author.imageUrl ? (
+        <img className="size-full rounded-full object-cover" src={author.imageUrl} alt="" />
+      ) : author.isAgent ? (
+        <Bot className="size-3" />
+      ) : (
+        actorInitials(author.displayName)
+      )}
     </div>
   );
 
-  // When an agent acts for someone, badge the principal in the corner — the
-  // recognizable "on behalf of" cue — tinted with the principal's own color.
+  // When an agent acts for someone, badge the principal in the corner,
+  // tinted with the principal's own color.
   if (author.isAgent && author.onBehalfOf) {
     return (
       <div className="relative mt-0.5 size-5 shrink-0" aria-hidden="true">
@@ -508,7 +518,7 @@ function CommentAuthorAvatar({ author }: { author: CommentAuthor }) {
         <span
           className="absolute -bottom-1 -right-1 flex size-3 items-center justify-center rounded-full text-[6px] font-bold text-white ring-2 ring-card"
           style={{ backgroundColor: author.onBehalfOfColor ?? "hsl(var(--muted-foreground))" }}
-          title={`on behalf of ${author.onBehalfOf}`}
+          title={`${author.displayName}${onBehalfOfText(author.onBehalfOf)}`}
         >
           {actorInitials(author.onBehalfOf).slice(0, 1)}
         </span>


### PR DESCRIPTION
Comment surfaces rendered "AI operating on behalf of a user" four different ways. This routes them all through the shared `runtimed` identity core so the agent and on-behalf-of treatment is consistent, and fixes two correctness gaps along the way. Display-only: no document or crate changes. Follows #3741.

## What was fragmented

- Four on-behalf phrasings: hover card `"AI for X"`, panel `"· for X"`, resolution receipt `"X for Y"`, avatar badge title `"on behalf of X"`. The identity core already had a canonical `" for "` form.
- `imageUrl` was resolved by the core but dropped by `CommentAuthor` / `CommentHighlightPreview`, so comment avatars never showed a profile photo even when one existed.
- The on-behalf badge color was set to the agent's own color, so the badge and the avatar were the same color (only the Elements fixture passed a distinct one).

## What changed

- New `onBehalfOfText()` helper in `packages/runtimed`, the single source for the `" for {name}"` phrasing. All four surfaces and the projection's canonical label route through it.
- `ActorDisplay` gains `onBehalfOfColor`: the principal's own identity color, guaranteed distinct from the agent's color (bumped to the next palette slot on the 1-in-8 collision). Hosts pass it through instead of reusing the agent color.
- `imageUrl` plumbed through `CommentAuthor` and `CommentHighlightPreview`. Comment avatars (panel and hover card) render the photo when present, else fall back to color + initials/bot. Cloud resolves real photos via presence peers; desktop is ready for when peers are wired.

## Verification

`vp check` clean (format + lint), full `vp test` green (2402 tests), `apps/notebook-cloud` typecheck clean.
