### PR TITLE
feat(editor): right-click context menu with copy, cut, paste, and comment

### DIFF
--- a/apps/notebook/src/components/CodeCell.tsx
+++ b/apps/notebook/src/components/CodeCell.tsx
@@ -51,6 +51,7 @@ import { sourceCommentExtension } from "../lib/source-comment-extension";
 import { tabCompletionKeymap } from "../lib/tab-completion";
 import type { CodeCell as CodeCellType, JupyterOutput } from "../types";
 import { CellPresenceIndicators } from "./cell/CellPresenceIndicators";
+import { EditorContextMenu } from "./EditorContextMenu";
 import { HistorySearchDialog } from "./HistorySearchDialog";
 
 const SIMPLE_OUTPUT_MAX_CHARS = 2000;
@@ -383,7 +384,7 @@ export const CodeCell = memo(function CodeCell({
   const kernelCompletionExt = useKernelCompletionExtension();
   // Subscribe to outputs via the per-execution / per-output stores rather
   // than `cell.outputs`. Content changes no longer invalidate the cell
-  // snapshot — CodeCell re-renders only when its chrome state changes.
+  // snapshot. CodeCell re-renders only when its chrome state changes.
   const outputs = useCellOutputs(cell.id);
   const executionId = useCellExecutionId(cell.id);
   const execution = useExecution(executionId);
@@ -601,13 +602,13 @@ export const CodeCell = memo(function CodeCell({
     [navigationKeyMap, historyKeyBinding],
   );
 
-  // Remote cursors extension (stable — no deps that change)
+  // Remote cursors extension, stable with no deps that change.
   const remoteCursorsExt = useMemo(() => remoteCursorsExtension(), []);
 
-  // Text attribution extension (stable — no deps that change)
+  // Text attribution extension, stable with no deps that change.
   const textAttributionExt = useMemo(() => textAttributionExtension(), []);
 
-  // Presence sender extension — broadcasts local cursor/selection to other peers
+  // Presence sender extension broadcasts local cursor/selection to other peers.
   const presenceSenderExt = useMemo(() => {
     if (!presence) return [];
     return [
@@ -820,16 +821,22 @@ export const CodeCell = memo(function CodeCell({
               </>
             ) : (
               <>
-                <CodeMirrorEditor
-                  ref={editorRef}
-                  initialValue={cell.source}
-                  language={language}
-                  keyMap={keyMap}
-                  extensions={editorExtensions}
-                  placeholder="Enter code..."
-                  autoFocus={isFocused}
+                <EditorContextMenu
+                  cellId={cell.id}
                   readOnly={readOnly}
-                />
+                  onCreateSourceComment={onCreateSourceComment}
+                >
+                  <CodeMirrorEditor
+                    ref={editorRef}
+                    initialValue={cell.source}
+                    language={language}
+                    keyMap={keyMap}
+                    extensions={editorExtensions}
+                    placeholder="Enter code..."
+                    autoFocus={isFocused}
+                    readOnly={readOnly}
+                  />
+                </EditorContextMenu>
                 {currentLine}
               </>
             )}

--- a/apps/notebook/src/components/EditorContextMenu.tsx
+++ b/apps/notebook/src/components/EditorContextMenu.tsx
@@ -1,0 +1,201 @@
+import type { EditorView } from "@codemirror/view";
+import { ClipboardPaste, Copy, MessageSquarePlus, Scissors } from "lucide-react";
+import { useCallback, useState, type ReactNode } from "react";
+import {
+  NotebookContextMenu,
+  type NotebookContextMenuAction,
+  type NotebookContextMenuGroup,
+} from "@/components/notebook/NotebookContextMenu";
+import {
+  selectionRectFromView,
+  sourceRangeAnchorFromSelection,
+  type SourceCommentSelectionRect,
+  type SourceRangeCommentAnchor,
+} from "../lib/comment-source-anchor";
+import { getCellEditor } from "../lib/editor-registry";
+
+interface EditorSelectionRange {
+  from: number;
+  to: number;
+  empty: boolean;
+}
+
+interface EditorContextMenuProps {
+  cellId: string;
+  readOnly?: boolean;
+  onCreateSourceComment?: (
+    anchor: SourceRangeCommentAnchor,
+    rect: SourceCommentSelectionRect | null,
+  ) => void;
+  children: ReactNode;
+}
+
+export interface BuildEditorContextGroupsOptions {
+  editable: boolean;
+  hasSelection: boolean;
+  canComment: boolean;
+  onCopy?: () => void;
+  onCut?: () => void;
+  onPaste?: () => void;
+  onAddComment?: () => void;
+}
+
+export function buildEditorContextGroups({
+  editable,
+  hasSelection,
+  canComment,
+  onCopy,
+  onCut,
+  onPaste,
+  onAddComment,
+}: BuildEditorContextGroupsOptions): NotebookContextMenuGroup[] {
+  const actions: NotebookContextMenuAction[] = [];
+
+  if (hasSelection) {
+    actions.push({
+      id: "copy",
+      label: "Copy",
+      icon: <Copy className="size-4" aria-hidden="true" />,
+      shortcut: "⌘C",
+      onSelect: onCopy,
+    });
+  }
+
+  if (editable && hasSelection) {
+    actions.push({
+      id: "cut",
+      label: "Cut",
+      icon: <Scissors className="size-4" aria-hidden="true" />,
+      shortcut: "⌘X",
+      onSelect: onCut,
+    });
+  }
+
+  if (editable) {
+    actions.push({
+      id: "paste",
+      label: "Paste",
+      icon: <ClipboardPaste className="size-4" aria-hidden="true" />,
+      shortcut: "⌘V",
+      onSelect: onPaste,
+    });
+  }
+
+  if (editable && hasSelection && canComment) {
+    actions.push({
+      id: "add-comment",
+      label: "Add comment",
+      icon: <MessageSquarePlus className="size-4" aria-hidden="true" />,
+      shortcut: "C",
+      separatorBefore: actions.length > 0,
+      onSelect: onAddComment,
+    });
+  }
+
+  if (actions.length === 0) return [];
+
+  return [
+    {
+      id: "editor",
+      actions,
+    },
+  ];
+}
+
+export function EditorContextMenu({
+  cellId,
+  readOnly,
+  onCreateSourceComment,
+  children,
+}: EditorContextMenuProps) {
+  const [groups, setGroups] = useState<NotebookContextMenuGroup[]>([]);
+
+  const refreshGroups = useCallback(() => {
+    const view = getCellEditor(cellId);
+    const selection = view?.state.selection.main;
+    const hasSelection = !!selection && !selection.empty;
+    const editable = !readOnly;
+
+    setGroups(
+      buildEditorContextGroups({
+        editable,
+        hasSelection,
+        canComment: !!onCreateSourceComment,
+        onCopy: view && selection ? () => copySelection(view, selection) : undefined,
+        onCut: editable && view && selection ? () => cutSelection(view, selection) : undefined,
+        onPaste: editable && view ? () => pasteIntoSelection(view) : undefined,
+        onAddComment:
+          editable && view && onCreateSourceComment
+            ? () => {
+                const anchor = sourceRangeAnchorFromSelection(cellId, view);
+                if (!anchor) return;
+                onCreateSourceComment(anchor, selectionRectFromView(view));
+              }
+            : undefined,
+      }),
+    );
+  }, [cellId, onCreateSourceComment, readOnly]);
+
+  const handleOpenChange = useCallback(
+    (open: boolean) => {
+      if (open) refreshGroups();
+    },
+    [refreshGroups],
+  );
+
+  return (
+    <NotebookContextMenu groups={groups} contentClassName="w-48" onOpenChange={handleOpenChange}>
+      <div className="w-full min-w-0" onContextMenuCapture={refreshGroups}>
+        {children}
+      </div>
+    </NotebookContextMenu>
+  );
+}
+
+function copySelection(view: EditorView, selection: EditorSelectionRange): void {
+  if (selection.empty) return;
+  const clipboard = currentClipboard();
+  if (!clipboard) return;
+
+  const selectedText = view.state.sliceDoc(selection.from, selection.to);
+  if (!selectedText) return;
+  void clipboard.writeText(selectedText).catch(() => undefined);
+}
+
+function cutSelection(view: EditorView, selection: EditorSelectionRange): void {
+  if (selection.empty) return;
+  const clipboard = currentClipboard();
+  if (!clipboard) return;
+
+  const selectedText = view.state.sliceDoc(selection.from, selection.to);
+  if (!selectedText) return;
+
+  void clipboard
+    .writeText(selectedText)
+    .then(() => {
+      view.dispatch({
+        changes: { from: selection.from, to: selection.to, insert: "" },
+      });
+      view.focus();
+    })
+    .catch(() => undefined);
+}
+
+function pasteIntoSelection(view: EditorView): void {
+  const clipboard = currentClipboard();
+  if (!clipboard) return;
+
+  void clipboard
+    .readText()
+    .then((text) => {
+      if (!text) return;
+      view.dispatch(view.state.replaceSelection(text));
+      view.focus();
+    })
+    .catch(() => undefined);
+}
+
+function currentClipboard(): Clipboard | undefined {
+  if (typeof navigator === "undefined") return undefined;
+  return navigator.clipboard;
+}

--- a/apps/notebook/src/components/InlineCommentComposer.tsx
+++ b/apps/notebook/src/components/InlineCommentComposer.tsx
@@ -33,9 +33,17 @@ export function InlineCommentComposer({
   const [body, setBody] = useState("");
   const [submitting, setSubmitting] = useState(false);
   const textareaRef = useRef<HTMLTextAreaElement>(null);
+  const justOpenedRef = useRef(true);
 
   useEffect(() => {
     textareaRef.current?.focus();
+    // Ignore outside-interactions for a beat after opening, so the event that
+    // opened this composer (a context menu closing and returning focus to the
+    // editor) does not immediately dismiss it.
+    const settle = window.setTimeout(() => {
+      justOpenedRef.current = false;
+    }, 300);
+    return () => window.clearTimeout(settle);
   }, []);
 
   const submit = async () => {
@@ -92,6 +100,15 @@ export function InlineCommentComposer({
         onOpenAutoFocus={(event) => {
           event.preventDefault();
           textareaRef.current?.focus();
+        }}
+        onPointerDownOutside={(event) => {
+          if (justOpenedRef.current) event.preventDefault();
+        }}
+        onFocusOutside={(event) => {
+          if (justOpenedRef.current) event.preventDefault();
+        }}
+        onInteractOutside={(event) => {
+          if (justOpenedRef.current) event.preventDefault();
         }}
       >
         <div className="flex items-center gap-1.5 text-xs font-medium text-muted-foreground">

--- a/apps/notebook/src/components/RawCell.tsx
+++ b/apps/notebook/src/components/RawCell.tsx
@@ -27,6 +27,7 @@ import type {
 import { sourceCommentExtension } from "../lib/source-comment-extension";
 import type { RawCell as RawCellType } from "../types";
 import { CellPresenceIndicators } from "./cell/CellPresenceIndicators";
+import { EditorContextMenu } from "./EditorContextMenu";
 
 interface RawCellProps {
   cell: RawCellType;
@@ -151,13 +152,13 @@ export const RawCell = memo(function RawCell({
     [isLastCell, onFocusNext, onInsertCellAfter, readOnly],
   );
 
-  // Remote cursors extension (stable — no deps that change)
+  // Remote cursors extension, stable with no deps that change.
   const remoteCursorsExt = useMemo(() => remoteCursorsExtension(), []);
 
-  // Text attribution extension (stable — no deps that change)
+  // Text attribution extension, stable with no deps that change.
   const textAttributionExt = useMemo(() => textAttributionExtension(), []);
 
-  // Presence sender extension — broadcasts local cursor/selection to other peers
+  // Presence sender extension broadcasts local cursor/selection to other peers.
   const presenceSenderExt = useMemo(() => {
     if (!presence) return [];
     return [
@@ -247,18 +248,24 @@ export const RawCell = memo(function RawCell({
             </span>
           </div>
           <div>
-            <CodeMirrorEditor
-              ref={editorRef}
-              initialValue={cell.source}
-              language={language}
-              lineWrapping
-              keyMap={keyMap}
-              extensions={[crdtBridgeExt, ...searchExtensions]}
-              placeholder="Enter raw content..."
-              className="min-h-[2rem]"
-              autoFocus={isFocused}
+            <EditorContextMenu
+              cellId={cell.id}
               readOnly={readOnly}
-            />
+              onCreateSourceComment={onCreateSourceComment}
+            >
+              <CodeMirrorEditor
+                ref={editorRef}
+                initialValue={cell.source}
+                language={language}
+                lineWrapping
+                keyMap={keyMap}
+                extensions={[crdtBridgeExt, ...searchExtensions]}
+                placeholder="Enter raw content..."
+                className="min-h-[2rem]"
+                autoFocus={isFocused}
+                readOnly={readOnly}
+              />
+            </EditorContextMenu>
           </div>
         </>
       }

--- a/apps/notebook/src/components/__tests__/EditorContextMenu.test.tsx
+++ b/apps/notebook/src/components/__tests__/EditorContextMenu.test.tsx
@@ -1,0 +1,64 @@
+import { describe, expect, it, vi } from "vite-plus/test";
+import {
+  buildEditorContextGroups,
+  type BuildEditorContextGroupsOptions,
+} from "../EditorContextMenu";
+
+function buildActions(overrides: Partial<BuildEditorContextGroupsOptions> = {}) {
+  const groups = buildEditorContextGroups({
+    editable: false,
+    hasSelection: false,
+    canComment: false,
+    onCopy: vi.fn(),
+    onCut: vi.fn(),
+    onPaste: vi.fn(),
+    onAddComment: vi.fn(),
+    ...overrides,
+  });
+
+  return groups[0]?.actions ?? [];
+}
+
+describe("buildEditorContextGroups", () => {
+  it("shows copy, cut, paste, and comment for editable selections that can comment", () => {
+    const actions = buildActions({
+      editable: true,
+      hasSelection: true,
+      canComment: true,
+    });
+
+    expect(actions.map((action) => action.id)).toEqual(["copy", "cut", "paste", "add-comment"]);
+    expect(actions.map((action) => action.shortcut)).toEqual(["⌘C", "⌘X", "⌘V", "C"]);
+    expect(actions.find((action) => action.id === "add-comment")?.separatorBefore).toBe(true);
+  });
+
+  it("shows paste only for editable editors without a selection", () => {
+    const actions = buildActions({
+      editable: true,
+      hasSelection: false,
+      canComment: true,
+    });
+
+    expect(actions.map((action) => action.id)).toEqual(["paste"]);
+  });
+
+  it("shows copy only for read-only selections", () => {
+    const actions = buildActions({
+      editable: false,
+      hasSelection: true,
+      canComment: true,
+    });
+
+    expect(actions.map((action) => action.id)).toEqual(["copy"]);
+  });
+
+  it("returns no editor actions for read-only editors without a selection", () => {
+    expect(
+      buildEditorContextGroups({
+        editable: false,
+        hasSelection: false,
+        canComment: true,
+      }),
+    ).toEqual([]);
+  });
+});

--- a/apps/notebook/src/lib/comment-highlight-extension.ts
+++ b/apps/notebook/src/lib/comment-highlight-extension.ts
@@ -104,13 +104,13 @@ const commentHighlightTheme = EditorView.baseTheme({
     backgroundColor: "color-mix(in srgb, var(--cm-comment-color) 38%, transparent)",
   },
   ".cm-comment-highlight-resolved": {
-    backgroundColor: "hsl(var(--muted-foreground) / 0.12)",
-    borderBottomColor: "hsl(var(--muted-foreground) / 0.4)",
+    backgroundColor: "color-mix(in srgb, var(--muted-foreground, #737373) 12%, transparent)",
+    borderBottomColor: "color-mix(in srgb, var(--muted-foreground, #737373) 40%, transparent)",
   },
   ".cm-tooltip.cm-tooltip-hover": {
     border: "none",
     backgroundColor: "transparent",
-    color: "hsl(var(--popover-foreground, 222 47% 11%))",
+    color: "var(--popover-foreground, #1e1e1e)",
     padding: "0",
   },
 });
@@ -140,7 +140,7 @@ const BOT_ICON_SVG =
 function buildPreviewDom(preview: CommentHighlightPreview): HTMLElement {
   const root = document.createElement("div");
   root.style.cssText =
-    "width:min(300px,80vw);padding:10px 12px;border:1px solid hsl(var(--border, 214 32% 91%));border-radius:10px;background:hsl(var(--popover, 0 0% 100%));color:hsl(var(--popover-foreground, 222 47% 11%));box-shadow:0 8px 24px rgb(0 0 0 / 0.14);font:inherit;";
+    "width:min(300px,80vw);padding:10px 12px;border:1px solid var(--border, #ebebeb);border-radius:10px;background:var(--popover, #ffffff);color:var(--popover-foreground, #1e1e1e);box-shadow:0 8px 24px rgb(0 0 0 / 0.14);font:inherit;";
 
   const head = document.createElement("div");
   head.style.cssText = "display:flex;align-items:center;gap:6px;margin-bottom:5px;";
@@ -148,7 +148,7 @@ function buildPreviewDom(preview: CommentHighlightPreview): HTMLElement {
   const avatar = document.createElement("span");
   avatar.style.cssText =
     "position:relative;flex:none;width:18px;height:18px;border-radius:50%;color:#fff;font-size:9px;font-weight:600;display:grid;place-items:center;";
-  avatar.style.backgroundColor = preview.authorColor ?? "hsl(var(--muted-foreground, 215 16% 47%))";
+  avatar.style.backgroundColor = preview.authorColor ?? "var(--muted-foreground, #737373)";
   if (preview.imageUrl) {
     const image = document.createElement("img");
     image.src = preview.imageUrl;
@@ -164,9 +164,9 @@ function buildPreviewDom(preview: CommentHighlightPreview): HTMLElement {
   if (preview.isAgent && preview.onBehalfOf) {
     const badge = document.createElement("span");
     badge.style.cssText =
-      "position:absolute;bottom:-3px;right:-3px;width:11px;height:11px;border-radius:50%;display:grid;place-items:center;color:#fff;font-size:6px;font-weight:700;box-shadow:0 0 0 2px hsl(var(--popover, 0 0% 100%));";
+      "position:absolute;bottom:-3px;right:-3px;width:11px;height:11px;border-radius:50%;display:grid;place-items:center;color:#fff;font-size:6px;font-weight:700;box-shadow:0 0 0 2px var(--popover, #ffffff);";
     badge.style.backgroundColor =
-      preview.onBehalfOfColor ?? "hsl(var(--muted-foreground, 215 16% 47%))";
+      preview.onBehalfOfColor ?? "var(--muted-foreground, #737373)";
     badge.textContent = actorInitials(preview.onBehalfOf).slice(0, 1);
     avatar.appendChild(badge);
   }
@@ -179,7 +179,7 @@ function buildPreviewDom(preview: CommentHighlightPreview): HTMLElement {
 
   if (preview.isAgent) {
     const meta = document.createElement("span");
-    meta.style.cssText = "font-size:10px;color:hsl(var(--muted-foreground, 215 16% 47%));";
+    meta.style.cssText = "font-size:10px;color:var(--muted-foreground, #737373);";
     meta.textContent = `AI${onBehalfOfText(preview.onBehalfOf)}`;
     head.appendChild(meta);
   }
@@ -194,7 +194,7 @@ function buildPreviewDom(preview: CommentHighlightPreview): HTMLElement {
   if (preview.replyCount > 0) {
     const replies = document.createElement("div");
     replies.style.cssText =
-      "margin-top:6px;font-size:10px;color:hsl(var(--muted-foreground, 215 16% 47%));";
+      "margin-top:6px;font-size:10px;color:var(--muted-foreground, #737373);";
     replies.textContent = `+${preview.replyCount} ${preview.replyCount === 1 ? "reply" : "replies"}`;
     root.appendChild(replies);
   }

--- a/apps/notebook/src/lib/source-comment-extension.ts
+++ b/apps/notebook/src/lib/source-comment-extension.ts
@@ -150,10 +150,10 @@ function requestSourceComment(
 
 const sourceCommentTheme = EditorView.baseTheme({
   ".cm-source-comment-button": {
-    border: "1px solid hsl(var(--border))",
+    border: "1px solid var(--border, #ebebeb)",
     borderRadius: "0.375rem",
-    backgroundColor: "hsl(var(--background))",
-    color: "hsl(var(--foreground))",
+    backgroundColor: "var(--background, #ffffff)",
+    color: "var(--foreground, #1e1e1e)",
     boxShadow: "0 1px 4px rgb(0 0 0 / 0.14)",
     boxSizing: "border-box",
     cursor: "pointer",
@@ -165,10 +165,10 @@ const sourceCommentTheme = EditorView.baseTheme({
     width: "24px",
   },
   ".cm-source-comment-button:hover": {
-    backgroundColor: "hsl(var(--muted))",
+    backgroundColor: "var(--muted, #f5f5f5)",
   },
   ".cm-source-comment-button:focus-visible": {
-    outline: "2px solid hsl(var(--ring))",
+    outline: "2px solid var(--ring, #a3a3a3)",
     outlineOffset: "2px",
   },
 });

--- a/apps/notebook/src/lib/source-comment-extension.ts
+++ b/apps/notebook/src/lib/source-comment-extension.ts
@@ -91,9 +91,9 @@ function sourceCommentTooltips(
         const button = document.createElement("button");
         button.type = "button";
         button.className = "cm-source-comment-button";
-        button.textContent = "Comment";
-        button.title = "Comment on selected source (Ctrl/Cmd+Alt+M)";
-        button.setAttribute("aria-label", "Comment on selected source");
+        button.appendChild(createCommentIcon());
+        button.title = "Comment on selection";
+        button.setAttribute("aria-label", "Comment on selection");
         button.setAttribute("data-testid", "source-comment-button");
         button.addEventListener("mousedown", (event) => {
           event.preventDefault();
@@ -106,6 +106,34 @@ function sourceCommentTooltips(
       },
     },
   ];
+}
+
+function createCommentIcon(): SVGSVGElement {
+  const icon = document.createElementNS("http://www.w3.org/2000/svg", "svg");
+  icon.setAttribute("width", "15");
+  icon.setAttribute("height", "15");
+  icon.setAttribute("viewBox", "0 0 24 24");
+  icon.setAttribute("fill", "none");
+  icon.setAttribute("stroke", "currentColor");
+  icon.setAttribute("stroke-width", "2");
+  icon.setAttribute("stroke-linecap", "round");
+  icon.setAttribute("stroke-linejoin", "round");
+  icon.setAttribute("aria-hidden", "true");
+  icon.setAttribute("focusable", "false");
+
+  const bubble = document.createElementNS("http://www.w3.org/2000/svg", "path");
+  bubble.setAttribute("d", "M21 15a2 2 0 0 1-2 2H7l-4 4V5a2 2 0 0 1 2-2h14a2 2 0 0 1 2 2z");
+  icon.appendChild(bubble);
+
+  const vertical = document.createElementNS("http://www.w3.org/2000/svg", "path");
+  vertical.setAttribute("d", "M12 7v6");
+  icon.appendChild(vertical);
+
+  const horizontal = document.createElementNS("http://www.w3.org/2000/svg", "path");
+  horizontal.setAttribute("d", "M9 10h6");
+  icon.appendChild(horizontal);
+
+  return icon;
 }
 
 function requestSourceComment(
@@ -127,12 +155,14 @@ const sourceCommentTheme = EditorView.baseTheme({
     backgroundColor: "hsl(var(--background))",
     color: "hsl(var(--foreground))",
     boxShadow: "0 1px 4px rgb(0 0 0 / 0.14)",
+    boxSizing: "border-box",
     cursor: "pointer",
-    fontFamily: "inherit",
-    fontSize: "11px",
-    fontWeight: "500",
-    lineHeight: "1",
-    padding: "5px 7px",
+    display: "inline-flex",
+    alignItems: "center",
+    justifyContent: "center",
+    height: "24px",
+    padding: "0",
+    width: "24px",
   },
   ".cm-source-comment-button:hover": {
     backgroundColor: "hsl(var(--muted))",

--- a/src/components/notebook/NotebookContextMenu.tsx
+++ b/src/components/notebook/NotebookContextMenu.tsx
@@ -1,4 +1,4 @@
-import type { ReactNode } from "react";
+import { Fragment, type ReactNode } from "react";
 import {
   ContextMenu,
   ContextMenuContent,
@@ -32,6 +32,7 @@ export interface NotebookContextMenuAction {
   description?: ReactNode;
   icon?: ReactNode;
   shortcut?: string;
+  separatorBefore?: boolean;
   disabled?: boolean;
   destructive?: boolean;
   onSelect?: () => void;
@@ -44,7 +45,7 @@ export interface NotebookContextMenuGroup {
 }
 
 export interface NotebookContextMenuProps {
-  surface: NotebookContextSurface;
+  surface?: NotebookContextSurface;
   groups: readonly NotebookContextMenuGroup[];
   children: ReactNode;
   contentClassName?: string;
@@ -71,26 +72,28 @@ export function NotebookContextMenu({
       <ContextMenuContent
         className={cn("w-72 p-1.5", contentClassName)}
         data-slot="notebook-context-menu"
-        data-context-kind={surface.kind}
+        data-context-kind={surface?.kind}
       >
-        <ContextMenuLabel className="px-2 py-2">
-          <span className="block text-[11px] font-medium uppercase tracking-normal text-muted-foreground">
-            {surface.kind}
-          </span>
-          <span className="mt-0.5 block truncate text-sm font-semibold text-foreground">
-            {surface.title}
-          </span>
-          {surface.description ? (
-            <span className="mt-1 block whitespace-normal text-xs font-normal leading-5 text-muted-foreground">
-              {surface.description}
+        {surface ? (
+          <ContextMenuLabel className="px-2 py-2">
+            <span className="block text-[11px] font-medium uppercase tracking-normal text-muted-foreground">
+              {surface.kind}
             </span>
-          ) : null}
-          {surface.detail ? (
-            <span className="mt-1 block truncate text-xs font-normal text-muted-foreground">
-              {surface.detail}
+            <span className="mt-0.5 block truncate text-sm font-semibold text-foreground">
+              {surface.title}
             </span>
-          ) : null}
-        </ContextMenuLabel>
+            {surface.description ? (
+              <span className="mt-1 block whitespace-normal text-xs font-normal leading-5 text-muted-foreground">
+                {surface.description}
+              </span>
+            ) : null}
+            {surface.detail ? (
+              <span className="mt-1 block truncate text-xs font-normal text-muted-foreground">
+                {surface.detail}
+              </span>
+            ) : null}
+          </ContextMenuLabel>
+        ) : null}
 
         {visibleGroups.map((group, index) => (
           <div key={group.id}>
@@ -101,30 +104,32 @@ export function NotebookContextMenu({
               </ContextMenuLabel>
             ) : null}
             {group.actions.map((action) => (
-              <ContextMenuItem
-                key={action.id}
-                disabled={action.disabled}
-                variant={action.destructive ? "destructive" : "default"}
-                className="items-start gap-2 py-2"
-                onSelect={() => action.onSelect?.()}
-              >
-                {action.icon ? (
-                  <span className="mt-0.5 flex size-4 shrink-0 items-center justify-center text-muted-foreground">
-                    {action.icon}
-                  </span>
-                ) : null}
-                <span className="min-w-0 flex-1">
-                  <span className="block truncate">{action.label}</span>
-                  {action.description ? (
-                    <span className="mt-0.5 block whitespace-normal text-xs leading-4 text-muted-foreground">
-                      {action.description}
+              <Fragment key={action.id}>
+                {action.separatorBefore ? <ContextMenuSeparator /> : null}
+                <ContextMenuItem
+                  disabled={action.disabled}
+                  variant={action.destructive ? "destructive" : "default"}
+                  className="items-start gap-2 py-2"
+                  onSelect={() => action.onSelect?.()}
+                >
+                  {action.icon ? (
+                    <span className="mt-0.5 flex size-4 shrink-0 items-center justify-center text-muted-foreground">
+                      {action.icon}
                     </span>
                   ) : null}
-                </span>
-                {action.shortcut ? (
-                  <ContextMenuShortcut>{action.shortcut}</ContextMenuShortcut>
-                ) : null}
-              </ContextMenuItem>
+                  <span className="min-w-0 flex-1">
+                    <span className="block truncate">{action.label}</span>
+                    {action.description ? (
+                      <span className="mt-0.5 block whitespace-normal text-xs leading-4 text-muted-foreground">
+                        {action.description}
+                      </span>
+                    ) : null}
+                  </span>
+                  {action.shortcut ? (
+                    <ContextMenuShortcut>{action.shortcut}</ContextMenuShortcut>
+                  ) : null}
+                </ContextMenuItem>
+              </Fragment>
             ))}
           </div>
         ))}

--- a/src/components/notebook/__tests__/NotebookContextMenu.test.tsx
+++ b/src/components/notebook/__tests__/NotebookContextMenu.test.tsx
@@ -73,4 +73,24 @@ describe("NotebookContextMenu", () => {
       "true",
     );
   });
+
+  it("can render actions without a surface header", async () => {
+    render(
+      <NotebookContextMenu
+        groups={[
+          {
+            id: "clipboard",
+            actions: [{ id: "copy", label: "Copy" }],
+          },
+        ]}
+      >
+        <button type="button">Editor</button>
+      </NotebookContextMenu>,
+    );
+
+    fireEvent.contextMenu(screen.getByRole("button", { name: "Editor" }));
+
+    expect(await screen.findByRole("menuitem", { name: "Copy" })).toBeInTheDocument();
+    expect(screen.queryByText("source")).not.toBeInTheDocument();
+  });
 });


### PR DESCRIPTION
Right-clicking a code or raw cell now opens a minimal context menu: Copy / Cut / Paste plus Add comment. A custom menu replaces the browser's native one, so it carries the clipboard actions itself, which keeps selecting code useful for its natural purpose. The floating "Comment" pill on selection shrinks to a small icon so it stops dominating select-to-copy. Desktop and cloud both get it because CodeCell and RawCell are shared. Follows #3741, #3742, #3743.

## Behavior

- Pure action list, no header (the source-range echo is gone).
- Editable + selection: Copy, Cut, Paste, then Add comment below a divider.
- Editable, no selection: Paste.
- Read-only: Copy, when something is selected.
- Clipboard goes through the editor's own dispatch plus `navigator.clipboard`, not `execCommand`. Cut only deletes after the clipboard write resolves, so a clipboard failure can't lose text.
- Add comment reuses the existing source-comment create path, so there is no new host wiring.
- Agent action is deferred; it is the showcase half with no backend yet.

## Component changes

- New shared `EditorContextMenu` wrapper (`apps/notebook`) around the CodeMirror editor. Menu groups are computed from the live selection when the menu opens.
- `NotebookContextMenu` gains an optional `surface` (header-less mode, used here) and a `separatorBefore` flag on actions.
- The floating selection tooltip is now a 24x24 icon button instead of a text pill.

## Verification

`vp check` clean, full `vp test` green (2409 tests), `apps/notebook-cloud` typecheck clean.

The editor-wrapper layout and the Radix-over-CodeMirror open behavior are not covered by tests, so a right-click in the running app is worth a look before merge.
