### PR TITLE
fix(outputs): keep Bokeh renders stable across payload refreshes

### DIFF
--- a/src/isolated-renderer/__tests__/bokeh-renderer.test.tsx
+++ b/src/isolated-renderer/__tests__/bokeh-renderer.test.tsx
@@ -126,6 +126,50 @@ describe("Bokeh renderer plugin", () => {
     expect(appendedSrcs).toEqual([]);
   });
 
+  it("keeps an equivalent exec payload mounted without clearing the Bokeh document", async () => {
+    const { Renderer } = installBokehRenderer();
+    const clear = vi.fn();
+    const deleteView = vi.fn();
+    const view = { model: { document: { clear } } };
+    window.Bokeh = {
+      index: {
+        get_by_id: vi.fn(() => view),
+        delete: deleteView,
+      },
+    };
+
+    const code = "window.__bokehExecRan = true;";
+    const { container, rerender } = render(
+      <Renderer
+        data={{
+          "application/javascript": code,
+          [BOKEHJS_EXEC_MIME_TYPE]: "",
+        }}
+        metadata={{ id: "p1011" }}
+        mimeType={BOKEHJS_EXEC_MIME_TYPE}
+      />,
+    );
+
+    await waitFor(() => {
+      expect(renderedScripts(container).at(-1)?.textContent).toBe(code);
+    });
+
+    rerender(
+      <Renderer
+        data={{
+          "application/javascript": code,
+          [BOKEHJS_EXEC_MIME_TYPE]: "",
+        }}
+        metadata={{ id: "p1011" }}
+        mimeType={BOKEHJS_EXEC_MIME_TYPE}
+      />,
+    );
+
+    expect(clear).not.toHaveBeenCalled();
+    expect(deleteView).not.toHaveBeenCalled();
+    expect(renderedScripts(container)).toHaveLength(1);
+  });
+
   it("appends Bokeh load MIME JavaScript directly", async () => {
     const { Renderer } = installBokehRenderer();
     const { container } = render(

--- a/src/isolated-renderer/bokeh-renderer.tsx
+++ b/src/isolated-renderer/bokeh-renderer.tsx
@@ -156,44 +156,49 @@ function cleanupBokehDocument(documentId: string | null): void {
 function BokehRenderer({ data: rawData, metadata, mimeType }: RendererProps) {
   const containerRef = useRef<HTMLDivElement>(null);
   const [error, setError] = useState<string | null>(null);
+  const payload = asBokehPayload(rawData);
+  const documentId = bokehDocumentId(metadata);
+  const serverId = bokehServerId(metadata);
+  const loadCode =
+    mimeType === BOKEHJS_LOAD_MIME_TYPE
+      ? (normalizeText(payload[BOKEHJS_LOAD_MIME_TYPE]) ??
+        normalizeText(payload["application/javascript"]))
+      : null;
+  const execCode =
+    mimeType === BOKEHJS_EXEC_MIME_TYPE ? normalizeText(payload["application/javascript"]) : null;
+  const serverHtml =
+    mimeType === BOKEHJS_EXEC_MIME_TYPE && serverId ? normalizeText(payload["text/html"]) : null;
 
   useEffect(() => {
     const container = containerRef.current;
     if (!container) return;
 
     setError(null);
-    const payload = asBokehPayload(rawData);
-    const documentId = bokehDocumentId(metadata);
     let script: HTMLScriptElement | null = null;
     let cancelled = false;
 
     async function renderBokeh() {
       if (mimeType === BOKEHJS_LOAD_MIME_TYPE) {
-        const code =
-          normalizeText(payload[BOKEHJS_LOAD_MIME_TYPE]) ??
-          normalizeText(payload["application/javascript"]);
-        if (!code) return;
-        script = appendExecutableScript(container, code);
+        if (!loadCode) return;
+        script = appendExecutableScript(container, loadCode);
         return;
       }
 
       if (mimeType !== BOKEHJS_EXEC_MIME_TYPE) return;
 
-      const serverId = bokehServerId(metadata);
       if (serverId) {
-        const html = normalizeText(payload["text/html"]);
-        if (!html) throw new Error("Bokeh server output did not include text/html script data");
-        script = scriptFromServerHtml(html);
+        if (!serverHtml)
+          throw new Error("Bokeh server output did not include text/html script data");
+        script = scriptFromServerHtml(serverHtml);
         container.appendChild(script);
         requestHostResize();
         return;
       }
 
-      const code = normalizeText(payload["application/javascript"]);
-      if (!code) throw new Error("Bokeh output did not include application/javascript data");
-      await ensureBokeh(extractBokehVersion(code));
+      if (!execCode) throw new Error("Bokeh output did not include application/javascript data");
+      await ensureBokeh(extractBokehVersion(execCode));
       if (cancelled) return;
-      script = appendExecutableScript(container, code);
+      script = appendExecutableScript(container, execCode);
     }
 
     void renderBokeh().catch((renderError) => {
@@ -209,7 +214,7 @@ function BokehRenderer({ data: rawData, metadata, mimeType }: RendererProps) {
       }
       cleanupBokehDocument(documentId);
     };
-  }, [rawData, metadata, mimeType]);
+  }, [documentId, execCode, loadCode, mimeType, serverHtml, serverId]);
 
   return (
     <div data-slot="bokeh-output" ref={containerRef}>


### PR DESCRIPTION
## Summary

- Keep the Bokeh renderer mounted across equivalent payload refreshes.
- Derive the renderer effect dependencies from Bokeh content fields instead of payload object identity.
- Add a regression test that verifies an equivalent Bokeh exec payload does not clear/delete the live Bokeh document.

## Repro / Diagnosis

- Ran the Bokeh setup cell and a following `show(p)` cell through `runt nb`.
- Confirmed the daemon produced fresh Bokeh output IDs and expected HTML/JavaScript output pairs.
- The failure path was in the isolated renderer: React preserved the output key, but the Bokeh effect still reran because the payload object was rebuilt, triggering `cleanupBokehDocument()`.

## Verification

- `pnpm test:run src/isolated-renderer/__tests__/bokeh-renderer.test.tsx`
- `pnpm test:run src/components/cell/__tests__/OutputArea.test.tsx src/isolated-renderer/__tests__/output-identity.test.ts`
- `pnpm test:run src/components/isolated/__tests__/output-embed.test.ts src/components/isolated/__tests__/isolated-frame-runtime.test.ts`
- `cargo xtask lint --fix`
- `git diff --check`
- `./target/debug/runt nb call execute_cell --notebook-id d22c680c-8358-49bb-9b6d-65bd3a70e100 -a '{"cell_id":"69bbfe31-1611-482d-8d51-af354eb4b9e9","timeout_secs":120}' --json`
- `./target/debug/runt nb call execute_cell --notebook-id d22c680c-8358-49bb-9b6d-65bd3a70e100 -a '{"cell_id":"be91a624-f013-4cfc-af25-32058f619776","timeout_secs":120}' --json`
