### PR TITLE
fix(notebook): forward comments-doc sync frames through the Tauri bridge

### DIFF
--- a/crates/notebook/src/lib.rs
+++ b/crates/notebook/src/lib.rs
@@ -3006,6 +3006,7 @@ async fn send_frame_bytes(
         | frame_types::PRESENCE
         | frame_types::RUNTIME_STATE_SYNC
         | frame_types::COMMS_DOC_SYNC
+        | frame_types::COMMENTS_DOC_SYNC
         | frame_types::POOL_STATE_SYNC
         | frame_types::PUT_BLOB => handle
             .forward_frame(frame_type, payload.to_vec())


### PR DESCRIPTION
The desktop frontend-to-daemon frame bridge (`send_frame_bytes` in `crates/notebook/src/lib.rs`) allowlists the frame types it forwards. `COMMENTS_DOC_SYNC` (`0x0a`) was never added next to its sibling `COMMS_DOC_SYNC`, so every comments-doc flush was rejected as `Unsupported outgoing frame type: 0x0a` and rolled back.

Because the sync never completed, it stayed perpetually pending and re-fired on every flush cycle. In practice that meant a `[sync-engine] comments doc sync to relay failed` warning on every keystroke in a cell (each notebook-doc splice triggers a flush, which retried the stuck comments-doc sync).

This is a pre-existing gap, a line that lived in the original `pr-3713` comments draft but was dropped when it was decomposed into the small merged PRs. `0x0a` is already defined and wired through the wire crate, daemon, and frontend; only the Tauri bridge allowlist was missed.

Fix: forward `0x0a` like the other doc-sync frames.

## Verification

`cargo check -p notebook` clean. After rebuilding the desktop app, the per-keystroke warning stops and the comments-doc sync completes once.
