### PR TITLE
fix(runt): locate nightly workstation daemon

### DIFF
--- a/crates/runt/src/main.rs
+++ b/crates/runt/src/main.rs
@@ -2906,18 +2906,16 @@ fn get_binary_version(path: &Path) -> Option<String> {
 
 /// Find bundled runtimed binary in common app locations
 fn find_bundled_runtimed() -> Option<PathBuf> {
-    let binary_name = if cfg!(windows) {
-        "runtimed.exe"
-    } else {
-        "runtimed"
-    };
+    let binary_names = bundled_runtimed_binary_names();
 
     // Check if we're running from within an app bundle
     if let Ok(current_exe) = std::env::current_exe() {
         if let Some(parent) = current_exe.parent() {
-            let sibling = parent.join(binary_name);
-            if sibling.exists() {
-                return Some(sibling);
+            for binary_name in &binary_names {
+                let sibling = parent.join(binary_name);
+                if sibling.exists() {
+                    return Some(sibling);
+                }
             }
         }
     }
@@ -2927,12 +2925,14 @@ fn find_bundled_runtimed() -> Option<PathBuf> {
     {
         let mut locations = Vec::new();
         for app_name in runt_workspace::desktop_app_launch_candidates() {
-            locations.push(PathBuf::from(format!(
-                "/Applications/{app_name}.app/Contents/MacOS/{binary_name}"
-            )));
-            locations.push(dirs::home_dir().unwrap_or_default().join(format!(
-                "Applications/{app_name}.app/Contents/MacOS/{binary_name}"
-            )));
+            for binary_name in &binary_names {
+                locations.push(PathBuf::from(format!(
+                    "/Applications/{app_name}.app/Contents/MacOS/{binary_name}"
+                )));
+                locations.push(dirs::home_dir().unwrap_or_default().join(format!(
+                    "Applications/{app_name}.app/Contents/MacOS/{binary_name}"
+                )));
+            }
         }
         for path in &locations {
             if path.exists() {
@@ -2946,13 +2946,28 @@ fn find_bundled_runtimed() -> Option<PathBuf> {
     {
         let mut locations = Vec::new();
         for app_name in runt_workspace::desktop_app_launch_candidates() {
-            locations.push(PathBuf::from(format!(
-                "/usr/share/{app_name}/{binary_name}"
-            )));
-            locations.push(PathBuf::from(format!("/opt/{app_name}/{binary_name}")));
+            for binary_name in &binary_names {
+                locations.push(PathBuf::from(format!(
+                    "/usr/share/{app_name}/{binary_name}"
+                )));
+                locations.push(PathBuf::from(format!("/opt/{app_name}/{binary_name}")));
+            }
+        }
+        if let Some(data_dir) = dirs::data_dir() {
+            for binary_name in &binary_names {
+                locations.push(
+                    data_dir
+                        .join("nteract")
+                        .join(runt_workspace::channel_display_name())
+                        .join("bin")
+                        .join(binary_name),
+                );
+            }
         }
         // AppImage extracts to /tmp, check common paths
-        locations.push(PathBuf::from(format!("/usr/local/bin/{binary_name}")));
+        for binary_name in &binary_names {
+            locations.push(PathBuf::from(format!("/usr/local/bin/{binary_name}")));
+        }
         for path in &locations {
             if path.exists() {
                 return Some(path.clone());
@@ -2965,19 +2980,21 @@ fn find_bundled_runtimed() -> Option<PathBuf> {
     {
         let mut locations = Vec::new();
         for app_name in runt_workspace::desktop_app_launch_candidates() {
-            locations.push(
-                dirs::data_local_dir()
-                    .unwrap_or_default()
-                    .join("Programs")
-                    .join(app_name)
-                    .join(binary_name),
-            );
-            locations.push(PathBuf::from(format!(
-                "C:\\Program Files\\{app_name}\\{binary_name}"
-            )));
-            locations.push(PathBuf::from(format!(
-                "C:\\Program Files (x86)\\{app_name}\\{binary_name}"
-            )));
+            for binary_name in &binary_names {
+                locations.push(
+                    dirs::data_local_dir()
+                        .unwrap_or_default()
+                        .join("Programs")
+                        .join(app_name)
+                        .join(binary_name),
+                );
+                locations.push(PathBuf::from(format!(
+                    "C:\\Program Files\\{app_name}\\{binary_name}"
+                )));
+                locations.push(PathBuf::from(format!(
+                    "C:\\Program Files (x86)\\{app_name}\\{binary_name}"
+                )));
+            }
         }
         for path in &locations {
             if path.exists() {
@@ -2987,6 +3004,25 @@ fn find_bundled_runtimed() -> Option<PathBuf> {
     }
 
     None
+}
+
+fn bundled_runtimed_binary_names() -> Vec<String> {
+    let primary = if cfg!(windows) {
+        format!("{}.exe", runt_workspace::daemon_binary_basename())
+    } else {
+        runt_workspace::daemon_binary_basename().to_string()
+    };
+    let legacy = if cfg!(windows) {
+        "runtimed.exe".to_string()
+    } else {
+        "runtimed".to_string()
+    };
+
+    if primary == legacy {
+        vec![primary]
+    } else {
+        vec![primary, legacy]
+    }
 }
 
 // ============================================================================
@@ -4757,6 +4793,26 @@ mod tests {
                 extra_args: vec!["--runtime".to_string(), "deno".to_string()],
             }
         );
+    }
+
+    #[test]
+    fn bundled_runtimed_binary_names_try_channel_name_before_legacy_name() {
+        let names = bundled_runtimed_binary_names();
+        let expected_primary = if cfg!(windows) {
+            format!("{}.exe", runt_workspace::daemon_binary_basename())
+        } else {
+            runt_workspace::daemon_binary_basename().to_string()
+        };
+
+        assert_eq!(names.first(), Some(&expected_primary));
+        if runt_workspace::daemon_binary_basename() != "runtimed" {
+            let expected_legacy = if cfg!(windows) {
+                "runtimed.exe"
+            } else {
+                "runtimed"
+            };
+            assert_eq!(names.get(1).map(String::as_str), Some(expected_legacy));
+        }
     }
 
     /// Test that the shutdown command correctly identifies UUIDs vs file paths.

--- a/crates/runt/src/workstation_cli.rs
+++ b/crates/runt/src/workstation_cli.rs
@@ -168,16 +168,23 @@ async fn connect(
         }
         Ok(response) => {
             eprintln!(
-                "Warning: registration returned HTTP {}; `runt workstation run` will retry.",
-                response.status()
+                "Warning: registration returned HTTP {}; `{} workstation run` will retry.",
+                response.status(),
+                runt_workspace::cli_command_name()
             );
         }
         Err(error) => {
-            eprintln!("Warning: registration failed ({error}); `runt workstation run` will retry.");
+            eprintln!(
+                "Warning: registration failed ({error}); `{} workstation run` will retry.",
+                runt_workspace::cli_command_name()
+            );
         }
     }
 
-    println!("Run `runt workstation run` to serve attach requests.");
+    println!(
+        "Run `{} workstation run` to serve attach requests.",
+        runt_workspace::cli_command_name()
+    );
     Ok(())
 }
 
@@ -342,9 +349,10 @@ fn resolve_credentials() -> Result<ResolvedCredentials> {
     let cloud_url = env_url.or_else(|| stored.as_ref().map(|c| c.cloud_url.clone()));
     let (Some(token), Some(cloud_url)) = (token, cloud_url) else {
         bail!(
-            "no workstation credential found at {} — run `runt workstation connect <url>` first \
+            "no workstation credential found at {} — run `{} workstation connect <url>` first \
              (or set {CLOUD_TOKEN_ENV} and {CLOUD_URL_ENV})",
-            path.display()
+            path.display(),
+            runt_workspace::cli_command_name()
         );
     };
 
@@ -408,7 +416,8 @@ async fn status(json_output: bool) -> Result<()> {
     if status == 401 || status == 403 {
         bail!(
             "the workstation credential was rejected (HTTP {status}) — it may have been revoked; \
-             run `runt workstation connect {}` with a fresh pairing code",
+             run `{} workstation connect {}` with a fresh pairing code",
+            runt_workspace::cli_command_name(),
             resolved.cloud_url
         );
     }
@@ -436,7 +445,10 @@ async fn status(json_output: bool) -> Result<()> {
         .cloned()
         .unwrap_or_default();
     if workstations.is_empty() {
-        println!("No workstations registered yet. Run `runt workstation run` to register.");
+        println!(
+            "No workstations registered yet. Run `{} workstation run` to register.",
+            runt_workspace::cli_command_name()
+        );
         return Ok(());
     }
     println!(

--- a/docs/remote-workstation.md
+++ b/docs/remote-workstation.md
@@ -26,6 +26,13 @@ and installs the per-user daemon service (`runt daemon doctor --fix` —
 systemd on Linux, launchd on macOS). Everything is per-user; no root
 required. Re-run to upgrade.
 
+The examples below use the stable channel command names. Nightly releases use
+channel-suffixed commands instead: `runt-nightly`, `runtimed-nightly`, and
+`nteract-mcp-nightly`. If you install a nightly headless release, run
+`runt-nightly workstation ...` wherever this guide shows
+`runt workstation ...`; the workstation credential is stored under
+`~/.config/nteract-nightly/workstation.json`.
+
 For air-gapped installs, download the release assets yourself and use
 `--from-dir`.
 
@@ -107,6 +114,9 @@ RestartSec=5
 [Install]
 WantedBy=default.target
 ```
+
+For nightly, use `%h/.local/bin/runt-nightly workstation run ...` in
+`ExecStart`.
 
 ```bash
 systemctl --user enable --now nteract-workstation

--- a/scripts/install-linux-release
+++ b/scripts/install-linux-release
@@ -393,6 +393,6 @@ if [[ "$HEADLESS" == "1" ]]; then
   echo "notebook, mint a pairing code from the notebook's workstation panel, then:"
   echo "  $CLI_NAME workstation connect https://app.runt.run --code <code>"
   echo "  $CLI_NAME workstation run"
-  echo "(Releases without 'runt workstation' can use the cloud-runtime-agent flow"
+  echo "(Releases without '$CLI_NAME workstation' can use the cloud-runtime-agent flow"
   echo "in docs/remote-workstation.md.)"
 fi

--- a/scripts/test-install-release
+++ b/scripts/test-install-release
@@ -73,9 +73,14 @@ make_darwin_fixtures() {
   local dir="$1"
   local log="$2"
   local stage="$dir/.stage"
-  mkdir -p "$dir" "$stage/nteract.app/Contents/MacOS"
+  local recorders="$dir/.recorders"
+  mkdir -p "$dir" "$recorders" "$stage/nteract.app/Contents/MacOS"
   for tool in nteract runt runtimed nteract-mcp; do
-    make_fake_tool "$stage/nteract.app/Contents/MacOS/$tool" "$log"
+    # macOS kills shell scripts whose executed path is inside
+    # *.app/Contents/MacOS. Keep the recorder script outside the bundle and
+    # put an executable symlink where the app sidecar would be.
+    make_fake_tool "$recorders/$tool" "$log"
+    ln -s "$recorders/$tool" "$stage/nteract.app/Contents/MacOS/$tool"
   done
   tar -czf "$dir/nteract-stable-darwin-arm64.app.tar.gz" -C "$stage" "nteract.app"
   rm -rf "$stage"
@@ -140,6 +145,22 @@ assert_link "$NIGHTLY_HOME/.local/bin/runtimed-nightly" "$NIGHTLY_PREFIX/bin/run
 assert_link "$NIGHTLY_HOME/.local/bin/nteract-mcp-nightly" "$NIGHTLY_PREFIX/bin/nteract-mcp-nightly"
 assert_link "$NIGHTLY_HOME/.local/bin/nteract-nightly" "$NIGHTLY_PREFIX/nteract-nightly.AppImage"
 grep -q "runt-nightly daemon doctor --fix --no-start" "$NIGHTLY_LOG" || fail "nightly: daemon doctor --fix --no-start not invoked"
+
+note "linux nightly headless install"
+NIGHTLY_HEADLESS_HOME="$WORK/nightly-headless-home"
+NIGHTLY_HEADLESS_LOG="$WORK/nightly-headless-calls.log"
+make_nightly_linux_fixtures "$WORK/nightly-headless-assets" "$NIGHTLY_HEADLESS_LOG"
+INSTALLER_UNDER_TEST="$STAMPED_NIGHTLY_INSTALLER" PATH="$WORK/shim-linux:$PATH" \
+  run_installer "$NIGHTLY_HEADLESS_HOME" --from-dir "$WORK/nightly-headless-assets" \
+  --headless --no-start > "$WORK/nightly-headless-out.log"
+NIGHTLY_HEADLESS_PREFIX="$NIGHTLY_HEADLESS_HOME/.local/share/nteract/nightly"
+assert_missing "$NIGHTLY_HEADLESS_PREFIX/nteract-nightly.AppImage"
+assert_link "$NIGHTLY_HEADLESS_HOME/.local/bin/runt-nightly" "$NIGHTLY_HEADLESS_PREFIX/bin/runt-nightly"
+assert_link "$NIGHTLY_HEADLESS_HOME/.local/bin/runtimed-nightly" "$NIGHTLY_HEADLESS_PREFIX/bin/runtimed-nightly"
+assert_link "$NIGHTLY_HEADLESS_HOME/.local/bin/nteract-mcp-nightly" "$NIGHTLY_HEADLESS_PREFIX/bin/nteract-mcp-nightly"
+grep -q "runt-nightly daemon doctor --fix --no-start" "$NIGHTLY_HEADLESS_LOG" || fail "nightly headless: daemon doctor --fix --no-start not invoked"
+grep -q "runt-nightly workstation connect" "$WORK/nightly-headless-out.log" || fail "nightly headless: summary should name the channel-specific connect command"
+grep -q "runt-nightly workstation run" "$WORK/nightly-headless-out.log" || fail "nightly headless: summary should name the channel-specific run command"
 
 note "darwin desktop install (explicit --applications-dir)"
 DARWIN_HOME="$WORK/darwin-home"


### PR DESCRIPTION
## Summary

- teach `runt` to resolve channel-specific daemon sidecars, so nightly workstation flows find `runtimed-nightly`
- make workstation CLI guidance and headless installer fallback copy use the active channel command name
- document the stable-vs-nightly command substitution for remote workstation setup
- add release-installer fixture coverage for Linux nightly `--headless`

## Verification

- `pnpm install --frozen-lockfile`
- `cargo xtask lint --fix`
- `bash scripts/test-install-release`
- `cargo test -p runt bundled_runtimed_binary_names_try_channel_name_before_legacy_name`
- `cargo test -p runt workstation_agent_args`
- `git diff --check`

## Notes

This should address the headless nightly install path where `runt-nightly workstation run` registered credentials successfully but could not locate the installed `runtimed-nightly` sidecar.
