### PR TITLE
feat(runtimed): receive, apply, and persist comments-doc sync in the daemon

### DIFF
--- a/crates/runtimed/src/notebook_sync_server/comments_store.rs
+++ b/crates/runtimed/src/notebook_sync_server/comments_store.rs
@@ -94,6 +94,7 @@ impl CommentsSidecarStore {
         })
     }
 
+    #[allow(dead_code)]
     pub(crate) fn bind_doc_id_to_locator(
         &self,
         locator: &CommentsLocator,

--- a/crates/runtimed/src/notebook_sync_server/mod.rs
+++ b/crates/runtimed/src/notebook_sync_server/mod.rs
@@ -50,13 +50,13 @@ use runtime_doc::RuntimeStateDoc;
 mod attachments;
 mod blob_upload;
 mod catalog;
-#[allow(dead_code)]
 mod comments_store;
 mod identity;
 mod load;
 mod metadata;
 mod nbformat_convert;
 mod path_index;
+mod peer_comments_sync;
 mod peer_comms_sync;
 mod peer_connection;
 mod peer_eviction;

--- a/crates/runtimed/src/notebook_sync_server/peer_comments_sync.rs
+++ b/crates/runtimed/src/notebook_sync_server/peer_comments_sync.rs
@@ -1,0 +1,450 @@
+use std::sync::Arc;
+
+use automerge::sync;
+use nteract_identity::ConnectionScope;
+use tokio::io::AsyncWrite;
+use tokio::sync::broadcast;
+use tracing::{debug, warn};
+
+use comments_doc::{CommentsDoc, CommentsDocError};
+use notebook_doc::diff::extract_change_actors;
+use notebook_protocol::connection::{self, NotebookFrameType};
+
+use super::peer_writer::PeerWriter;
+use super::{NotebookRoom, RoomConnectionIdentity};
+
+pub(super) async fn send_initial_comments_doc_sync<W>(
+    writer: &mut W,
+    room: &Arc<NotebookRoom>,
+    comments_peer_state: &mut sync::State,
+) -> anyhow::Result<()>
+where
+    W: AsyncWrite + Unpin,
+{
+    let initial_comments_encoded = room
+        .comments
+        .generate_sync_message_recovering(comments_peer_state, "initial-comments-sync")
+        .map_err(|e| anyhow::anyhow!("initial CommentsDoc sync failed: {e}"))?
+        .map(|msg| msg.encode());
+    if let Some(encoded) = initial_comments_encoded {
+        connection::send_typed_frame(writer, NotebookFrameType::CommentsDocSync, &encoded).await?;
+    }
+
+    Ok(())
+}
+
+pub(super) async fn handle_comments_doc_frame(
+    room: &NotebookRoom,
+    comments_peer_state: &mut sync::State,
+    writer: &PeerWriter,
+    payload: &[u8],
+    connection_identity: &RoomConnectionIdentity,
+) -> anyhow::Result<bool> {
+    let mut message = sync::Message::decode(payload)
+        .map_err(|e| anyhow::anyhow!("decode comments sync: {}", e))?;
+    let has_client_changes = !message.changes.is_empty();
+    if has_client_changes && !allows_comments_doc_write(connection_identity.scope()) {
+        warn!(
+            "[notebook-sync] Stripping unauthorized CommentsDoc changes for scope {}",
+            connection_identity.scope()
+        );
+        message.changes = sync::ChunkList::empty();
+    }
+    let has_client_changes = !message.changes.is_empty();
+
+    if has_client_changes {
+        let (heads_before, comments_doc_id, bytes) = room.comments.with_doc(|comments_doc| {
+            let heads_before = comments_doc.get_heads();
+            let comments_doc_id = comments_doc
+                .comments_doc_id()
+                .ok_or(CommentsDocError::MissingCommentsDocId)?;
+            Ok((heads_before, comments_doc_id, comments_doc.save()))
+        })?;
+        let mut preview = CommentsDoc::load_with_actor(
+            &bytes,
+            &comments_doc_id,
+            "runtimed:comments-auth-preview",
+        )?;
+        let mut preview_peer_state = comments_peer_state.clone();
+        match preview.receive_sync_message_with_changes_recovering(
+            &mut preview_peer_state,
+            message.clone(),
+            "comments-auth-preview",
+        ) {
+            Ok(true) => {
+                let actors = extract_change_actors(preview.doc_mut(), &heads_before);
+                connection_identity
+                    .validate_actor_labels(actors.iter().map(std::string::String::as_str))?;
+            }
+            Ok(false) => {}
+            Err(e) => {
+                warn!("[notebook-sync] CommentsDoc auth preview failed: {}", e);
+                return Err(e.into());
+            }
+        }
+    }
+
+    let (reply_encoded, applied_client_changes) = room.comments.with_doc(|comments_doc| {
+        let applied_client_changes = match comments_doc
+            .receive_sync_message_with_changes_recovering(
+                comments_peer_state,
+                message,
+                "comments-receive-sync",
+            ) {
+            Ok(changed) => changed,
+            Err(e) => {
+                warn!(
+                    "[notebook-sync] CommentsDoc receive_sync_message error: {}",
+                    e
+                );
+                return Err(e);
+            }
+        };
+
+        let reply_encoded = generate_comments_doc_sync_message(
+            comments_doc,
+            comments_peer_state,
+            "comments-sync-reply",
+        )?;
+        Ok((reply_encoded, applied_client_changes))
+    })?;
+
+    if applied_client_changes {
+        if let Err(error) = room.comments_store.save_handle(&room.comments) {
+            warn!(
+                "[notebook-sync] Failed to persist CommentsDoc after sync frame: {}",
+                error
+            );
+        }
+    }
+
+    if let Some(encoded) = reply_encoded {
+        writer.send_frame(NotebookFrameType::CommentsDocSync, encoded)?;
+    }
+    Ok(true)
+}
+
+pub(super) async fn forward_comments_doc_broadcast(
+    room: &NotebookRoom,
+    peer_id: &str,
+    comments_peer_state: &mut sync::State,
+    writer: &PeerWriter,
+    result: Result<(), broadcast::error::RecvError>,
+) -> anyhow::Result<bool> {
+    match result {
+        Ok(()) => {
+            send_comments_doc_sync_update(room, comments_peer_state, writer, "comments-broadcast")?;
+        }
+        Err(broadcast::error::RecvError::Lagged(n)) => {
+            debug!(
+                "[notebook-sync] Peer {} lagged {} CommentsDoc updates",
+                peer_id, n
+            );
+            send_comments_doc_sync_update(
+                room,
+                comments_peer_state,
+                writer,
+                "comments-broadcast-lagged",
+            )?;
+        }
+        Err(broadcast::error::RecvError::Closed) => {
+            return Ok(false);
+        }
+    }
+    Ok(true)
+}
+
+fn send_comments_doc_sync_update(
+    room: &NotebookRoom,
+    comments_peer_state: &mut sync::State,
+    writer: &PeerWriter,
+    label: &str,
+) -> anyhow::Result<()> {
+    let encoded = room.comments.with_doc(|comments_doc| {
+        generate_comments_doc_sync_message(comments_doc, comments_peer_state, label)
+    })?;
+    if let Some(encoded) = encoded {
+        writer.send_frame(NotebookFrameType::CommentsDocSync, encoded)?;
+    }
+    Ok(())
+}
+
+fn generate_comments_doc_sync_message(
+    comments_doc: &mut CommentsDoc,
+    comments_peer_state: &mut sync::State,
+    label: &str,
+) -> Result<Option<Vec<u8>>, CommentsDocError> {
+    match comments_doc.generate_sync_message_recovering(comments_peer_state, label) {
+        Ok(message) => Ok(message.map(|msg| msg.encode())),
+        Err(e) => {
+            warn!("[notebook-sync] CommentsDoc sync generation failed: {}", e);
+            Err(e.into())
+        }
+    }
+}
+
+fn allows_comments_doc_write(scope: ConnectionScope) -> bool {
+    matches!(scope, ConnectionScope::Editor | ConnectionScope::Owner)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use automerge::ActorId;
+    use comments_doc::{CommentAnchor, NotebookCommentRef};
+    use notebook_protocol::connection;
+    use tokio::io::duplex;
+
+    use crate::blob_store::BlobStore;
+    use crate::notebook_sync_server::{comments_store::CommentsSidecarStore, NotebookRoom};
+
+    fn test_room(tmp: &tempfile::TempDir) -> Arc<NotebookRoom> {
+        let blob_store = Arc::new(BlobStore::new(tmp.path().join("blobs")));
+        Arc::new(NotebookRoom::new_fresh(
+            uuid::Uuid::new_v4(),
+            None,
+            &tmp.path().join("notebook-docs"),
+            blob_store,
+            false,
+        ))
+    }
+
+    fn make_sender(
+        comments_doc_id: &str,
+        actor_label: &str,
+        body: &str,
+    ) -> (CommentsDoc, sync::State) {
+        let notebook_ref = NotebookCommentRef::LocalRoom {
+            room_id: "room".to_string(),
+        };
+        let mut sender = CommentsDoc::new_with_actor(comments_doc_id, &notebook_ref, actor_label);
+        sender
+            .create_thread(
+                "thread-1",
+                "message-1",
+                &CommentAnchor::Notebook,
+                body,
+                None,
+                "2026-06-16T00:00:00Z",
+            )
+            .expect("create comment thread");
+        (sender, sync::State::new())
+    }
+
+    fn client_payload_after_initial_sync(
+        room: &NotebookRoom,
+        room_peer_state: &mut sync::State,
+        sender: &mut CommentsDoc,
+        sender_state: &mut sync::State,
+    ) -> Vec<u8> {
+        let initial_message = room
+            .comments
+            .generate_sync_message_recovering(room_peer_state, "comments-test-initial")
+            .unwrap()
+            .expect("initial comments sync message");
+        sender
+            .receive_sync_message_with_changes(sender_state, initial_message)
+            .expect("client receives initial comments sync");
+        let message = sender
+            .generate_sync_message(sender_state)
+            .expect("sender sync message");
+        assert!(
+            !message.changes.is_empty(),
+            "client payload should carry comment changes"
+        );
+        message.encode()
+    }
+
+    async fn read_comments_frame<R>(reader: &mut R) -> Vec<u8>
+    where
+        R: tokio::io::AsyncRead + Unpin,
+    {
+        let frame = tokio::time::timeout(
+            std::time::Duration::from_secs(1),
+            connection::recv_typed_frame(reader),
+        )
+        .await
+        .expect("comments frame timeout")
+        .expect("read comments frame")
+        .expect("read comments frame");
+        assert_eq!(frame.frame_type, NotebookFrameType::CommentsDocSync);
+        frame.payload
+    }
+
+    #[tokio::test]
+    async fn editor_comments_doc_changes_apply_reply_persist_and_fan_out() {
+        let tmp = tempfile::tempdir().unwrap();
+        let room = test_room(&tmp);
+        let comments_doc_id = room
+            .comments
+            .read(|doc| doc.comments_doc_id())
+            .unwrap()
+            .unwrap();
+        let identity = RoomConnectionIdentity::local_with_scope(
+            Some("desktop:window-1".to_string()),
+            ConnectionScope::Editor,
+        )
+        .await
+        .unwrap();
+        let actor_label = identity.actor_label().as_str().to_string();
+        let mut receiver_state = sync::State::new();
+        let (mut sender, mut sender_state) =
+            make_sender(&comments_doc_id, &actor_label, "persisted from sync");
+        let payload = client_payload_after_initial_sync(
+            &room,
+            &mut receiver_state,
+            &mut sender,
+            &mut sender_state,
+        );
+        let (client, mut reader) = duplex(8192);
+        let (peer_writer, writer_task) =
+            super::super::peer_writer::spawn_peer_writer(client, "notebook".into(), "peer".into());
+
+        assert!(handle_comments_doc_frame(
+            &room,
+            &mut receiver_state,
+            &peer_writer,
+            &payload,
+            &identity,
+        )
+        .await
+        .unwrap());
+        let reply = read_comments_frame(&mut reader).await;
+        assert!(!reply.is_empty());
+
+        let projection = room
+            .comments
+            .read(|doc| doc.read_projection(None))
+            .unwrap()
+            .unwrap();
+        assert_eq!(projection.threads.len(), 1);
+        assert_eq!(
+            projection.threads[0].messages[0].body,
+            "persisted from sync"
+        );
+
+        let notebook_ref = room
+            .comments
+            .read(|doc| doc.notebook_ref())
+            .unwrap()
+            .unwrap();
+        let reloaded = room
+            .comments_store
+            .load_or_create(&comments_doc_id, &notebook_ref)
+            .unwrap();
+        let reloaded_projection = reloaded
+            .read(|doc| doc.read_projection(None))
+            .unwrap()
+            .unwrap();
+        assert_eq!(reloaded_projection.threads.len(), 1);
+        assert_eq!(
+            reloaded_projection.threads[0].messages[0].body,
+            "persisted from sync"
+        );
+
+        let mut fanout_state = sync::State::new();
+        assert!(forward_comments_doc_broadcast(
+            &room,
+            "peer-2",
+            &mut fanout_state,
+            &peer_writer,
+            Ok(()),
+        )
+        .await
+        .unwrap());
+        let fanout = read_comments_frame(&mut reader).await;
+        assert!(!fanout.is_empty());
+
+        writer_task.handle.abort();
+    }
+
+    #[tokio::test]
+    async fn runtime_peer_comments_doc_changes_are_stripped() {
+        let tmp = tempfile::tempdir().unwrap();
+        let room = test_room(&tmp);
+        let comments_doc_id = room
+            .comments
+            .read(|doc| doc.comments_doc_id())
+            .unwrap()
+            .unwrap();
+        let identity = RoomConnectionIdentity::local_with_scope(
+            Some("runtime:agent-1".to_string()),
+            ConnectionScope::RuntimePeer,
+        )
+        .await
+        .unwrap();
+        let actor_label = identity.actor_label().as_str().to_string();
+        let mut receiver_state = sync::State::new();
+        let (mut sender, mut sender_state) =
+            make_sender(&comments_doc_id, &actor_label, "runtime peer write");
+        let payload = client_payload_after_initial_sync(
+            &room,
+            &mut receiver_state,
+            &mut sender,
+            &mut sender_state,
+        );
+        let (client, mut reader) = duplex(8192);
+        let (peer_writer, writer_task) =
+            super::super::peer_writer::spawn_peer_writer(client, "notebook".into(), "peer".into());
+
+        assert!(handle_comments_doc_frame(
+            &room,
+            &mut receiver_state,
+            &peer_writer,
+            &payload,
+            &identity,
+        )
+        .await
+        .unwrap());
+        let reply = read_comments_frame(&mut reader).await;
+        assert!(!reply.is_empty());
+
+        let projection = room
+            .comments
+            .read(|doc| doc.read_projection(None))
+            .unwrap()
+            .unwrap();
+        assert!(projection.threads.is_empty());
+
+        writer_task.handle.abort();
+    }
+
+    #[test]
+    fn comments_sidecar_store_round_trip_persists_handle() {
+        let tmp = tempfile::tempdir().unwrap();
+        let store = CommentsSidecarStore::new(tmp.path().join("comments"));
+        let comments_doc_id = "comments:local-room:test";
+        let notebook_ref = NotebookCommentRef::LocalRoom {
+            room_id: "test".to_string(),
+        };
+        let handle = store
+            .load_or_create(comments_doc_id, &notebook_ref)
+            .expect("load comments handle");
+        handle
+            .with_doc(|doc| {
+                doc.doc_mut()
+                    .set_actor(ActorId::from("client:alice".as_bytes()));
+                doc.create_thread(
+                    "thread-1",
+                    "message-1",
+                    &CommentAnchor::Notebook,
+                    "persisted",
+                    None,
+                    "2026-06-16T00:00:00Z",
+                )?;
+                Ok(())
+            })
+            .unwrap();
+        store.save_handle(&handle).unwrap();
+
+        let reloaded = store
+            .load_or_create(comments_doc_id, &notebook_ref)
+            .expect("reload comments handle");
+        let projection = reloaded
+            .read(|doc| doc.read_projection(None))
+            .unwrap()
+            .unwrap();
+        assert_eq!(projection.threads.len(), 1);
+        assert_eq!(projection.threads[0].messages[0].body, "persisted");
+    }
+}

--- a/crates/runtimed/src/notebook_sync_server/peer_loop.rs
+++ b/crates/runtimed/src/notebook_sync_server/peer_loop.rs
@@ -1,4 +1,7 @@
 use super::blob_upload::{enqueue_put_blob, spawn_put_blob_worker, MultipartUploadState};
+use super::peer_comments_sync::{
+    forward_comments_doc_broadcast, handle_comments_doc_frame, send_initial_comments_doc_sync,
+};
 use super::peer_comms_sync::{
     forward_comms_doc_broadcast, handle_comms_doc_frame, send_initial_comms_doc_sync,
 };
@@ -55,6 +58,7 @@ where
     let mut presence_rx = room.broadcasts.presence_tx.subscribe();
     let mut state_changed_rx = room.state.subscribe();
     let mut comms_changed_rx = room.comms.subscribe();
+    let mut comments_changed_rx = room.comments.subscribe();
 
     // PoolDoc — global daemon pool state (UV/Conda availability, errors).
     let mut pool_changed_rx = daemon.pool_doc_changed.subscribe();
@@ -92,6 +96,7 @@ where
 
     let mut state_peer_state = sync::State::new();
     let mut comms_peer_state = sync::State::new();
+    let mut comments_peer_state = sync::State::new();
     let mut pool_peer_state = sync::State::new();
     let mut persisted_execution_records: std::collections::HashMap<
         String,
@@ -114,6 +119,7 @@ where
     }
 
     send_initial_comms_doc_sync(&mut writer, room, &mut comms_peer_state).await?;
+    send_initial_comments_doc_sync(&mut writer, room, &mut comments_peer_state).await?;
 
     initial_load_phase = stream_initial_load(
         &mut reader,
@@ -347,14 +353,17 @@ where
                             }
 
                             NotebookFrameType::CommentsDocSync => {
-                                // The daemon does not yet hold a CommentsDoc replica, and no admitted
-                                // client opens a comments send path in this slice (the Tauri send gate
-                                // does not forward 0x0a). This defensive arm drops a stray frame; the
-                                // sidecar receive/apply handler and the send gate land together in the
-                                // daemon comments ingress slice so no sender can be silently dropped.
-                                debug!(
-                                    "[notebook-sync] CommentsDocSync received from peer {peer_id}; daemon comments ingress not yet wired"
-                                );
+                                if !handle_comments_doc_frame(
+                                    room,
+                                    &mut comments_peer_state,
+                                    &peer_writer,
+                                    &frame.payload,
+                                    connection_identity,
+                                )
+                                .await?
+                                {
+                                    continue;
+                                }
                             }
 
                             NotebookFrameType::PoolStateSync => {
@@ -436,6 +445,21 @@ where
                     room,
                     peer_id,
                     &mut comms_peer_state,
+                    &peer_writer,
+                    result,
+                )
+                .await?
+                {
+                    return Ok(());
+                }
+            }
+
+            // CommentsDoc changed. Push comment thread updates to this client.
+            result = comments_changed_rx.recv() => {
+                if !forward_comments_doc_broadcast(
+                    room,
+                    peer_id,
+                    &mut comments_peer_state,
                     &peer_writer,
                     result,
                 )

--- a/crates/runtimed/src/notebook_sync_server/room.rs
+++ b/crates/runtimed/src/notebook_sync_server/room.rs
@@ -2,6 +2,10 @@ use super::*;
 use crate::async_outcome::{recv_oneshot_with_timeout, TimedOneShot};
 use sha2::Digest as _;
 
+use super::comments_store::{
+    comments_locator_for_room, comments_ref_for_room, CommentsSidecarStore,
+};
+
 /// Per-room identity.
 ///
 /// Holds immutable identity and untitled working-directory context. The
@@ -761,6 +765,11 @@ pub struct NotebookRoom {
     /// Per-notebook CommsDoc handle — widget comm state keyed by comm_id.
     /// RuntimeStateDoc remains the topology/membership source of truth.
     pub comms: runtime_doc::CommsDocHandle,
+    /// Per-notebook CommentsDoc handle for authored comment threads.
+    pub comments: comments_doc::CommentsDocHandle,
+    /// Disk-backed sidecar store for CommentsDoc persistence.
+    #[allow(private_interfaces)]
+    pub comments_store: CommentsSidecarStore,
     /// Handle to the runtime agent subprocess that owns this notebook's kernel.
     /// Set by `LaunchKernel` or `auto_launch_kernel` when spawned.
     pub runtime_agent_handle: Arc<Mutex<Option<crate::runtime_agent_handle::RuntimeAgentHandle>>>,
@@ -962,6 +971,11 @@ impl NotebookRoom {
         let comms_doc = runtime_doc::CommsDoc::try_new()
             .map_err(|e| anyhow::anyhow!("create comms doc: {e}"))?;
         let comms = runtime_doc::CommsDocHandle::new(comms_doc, comms_changed_tx);
+        let comments_store = CommentsSidecarStore::for_notebook_docs_dir(docs_dir);
+        let comments_locator = comments_locator_for_room(id, path.as_deref());
+        let comments_doc_id = comments_store.resolve_doc_id(&comments_locator)?;
+        let comments_ref = comments_ref_for_room(id, path.as_deref());
+        let comments = comments_store.load_or_create(&comments_doc_id, &comments_ref)?;
 
         // Seed path on the runtime-state doc so connecting peers see it via sync.
         if let Some(p) = path.as_ref() {
@@ -991,6 +1005,8 @@ impl NotebookRoom {
             trusted_packages,
             state,
             comms,
+            comments,
+            comments_store,
             runtime_agent_handle: Arc::new(Mutex::new(None)),
             runtime_agent_env_path: Arc::new(RwLock::new(None)),
             runtime_agent_launched_config: Arc::new(RwLock::new(None)),
@@ -1079,6 +1095,15 @@ impl NotebookRoom {
         let (comms_changed_tx, _) = broadcast::channel(16);
         let comms =
             runtime_doc::CommsDocHandle::new(runtime_doc::CommsDoc::new(), comms_changed_tx);
+        let comments_store = CommentsSidecarStore::for_notebook_docs_dir(docs_dir);
+        let comments_locator = comments_locator_for_room(id, path.as_deref());
+        let comments_doc_id = comments_store
+            .resolve_doc_id(&comments_locator)
+            .expect("seed comments document id");
+        let comments_ref = comments_ref_for_room(id, path.as_deref());
+        let comments = comments_store
+            .load_or_create(&comments_doc_id, &comments_ref)
+            .expect("create test comments document");
         if let Some(p) = path.as_ref() {
             let path_str = p.to_string_lossy().into_owned();
             let _ = state.with_doc(|sd| sd.set_path(Some(&path_str)));
@@ -1100,6 +1125,8 @@ impl NotebookRoom {
             trusted_packages,
             state,
             comms,
+            comments,
+            comments_store,
             runtime_agent_handle: Arc::new(Mutex::new(None)),
             runtime_agent_env_path: Arc::new(RwLock::new(None)),
             runtime_agent_launched_config: Arc::new(RwLock::new(None)),

--- a/crates/runtimed/src/notebook_sync_server/tests.rs
+++ b/crates/runtimed/src/notebook_sync_server/tests.rs
@@ -1186,8 +1186,20 @@ fn test_room_with_path_and_store(
     let state = runtime_doc::RuntimeStateHandle::new(RuntimeStateDoc::new(), state_changed_tx);
     let (comms_changed_tx, _) = broadcast::channel(16);
     let comms = runtime_doc::CommsDocHandle::new(runtime_doc::CommsDoc::new(), comms_changed_tx);
+    let room_id = uuid::Uuid::new_v4();
+    let comments_store = comments_store::CommentsSidecarStore::for_notebook_docs_dir(
+        &tmp.path().join("notebook-docs"),
+    );
+    let comments_locator = comments_store::comments_locator_for_room(room_id, Some(&notebook_path));
+    let comments_doc_id = comments_store
+        .resolve_doc_id(&comments_locator)
+        .expect("seed comments document id");
+    let comments_ref = comments_store::comments_ref_for_room(room_id, Some(&notebook_path));
+    let comments = comments_store
+        .load_or_create(&comments_doc_id, &comments_ref)
+        .expect("create comments document");
     let room = NotebookRoom {
-        id: uuid::Uuid::new_v4(),
+        id: room_id,
         doc: Arc::new(RwLock::new(doc)),
         broadcasts: RoomBroadcasts::default(),
         persistence: RoomPersistence::with_debouncer(persist_tx, flush_request_tx),
@@ -1217,6 +1229,8 @@ fn test_room_with_path_and_store(
         trusted_packages,
         state,
         comms,
+        comments,
+        comments_store,
         runtime_agent_handle: Arc::new(Mutex::new(None)),
         runtime_agent_env_path: Arc::new(RwLock::new(None)),
         runtime_agent_launched_config: Arc::new(RwLock::new(None)),


### PR DESCRIPTION
The daemon dropped inbound `CommentsDoc` sync frames (a `peer_loop` TODO), so desktop comments never reached the daemon or other peers. This wires the ingress by mirroring the existing `CommsDoc` path, and completes the desktop comments sync the Tauri bridge forward started in #3746.

## What it does

- `NotebookRoom` holds a `CommentsDoc` replica plus a `CommentsSidecarStore`, loaded at construction so persisted comments are restored on open. (CommsDoc is in-memory and re-seeded; comments need disk persistence.)
- New `peer_comments_sync.rs` handles inbound frames: decode, gate writes to `Editor`/`Owner` scope, validate change authorship against the connection identity on a preview clone before the real apply, apply, generate a reply, fan out to other peers, and persist applied changes to the sidecar.
- `peer_loop.rs` replaces the drop arm with receive/apply/fan-out, plus the initial sync and a broadcast select arm, mirroring comms.

## Trust

Trust is the actor-binding at ingress plus the scope gate, no authority or finalization state. Before the real apply, inbound changes are applied to a preview clone, their actors extracted, and `validate_actor_labels` checks them against the authenticated connection, so forged authorship is rejected before anything lands. The gate is `Editor | Owner` only: unlike comms, the kernel (`RuntimePeer`) must not author comments.

## Verification

`cargo build -p runtimed` clean; `cargo test -p runtimed` (998 passed) including new tests for the scope gate, a persist reload round-trip, and fan-out; `cargo test -p comments-doc` (31); clippy clean; `cargo xtask lint` clean; tokio-mutex lint green. Independently reviewed for trust (gate enforced before apply, forged authorship rejected, no exploitable TOCTOU) and wiring (mirrors comms step-for-step, all room constructors initialized, no init panic on a fresh notebook).
