### PR TITLE
feat(comments): comment on rendered markdown selections and markdown source

### DIFF
--- a/apps/notebook/src/components/MarkdownCell.tsx
+++ b/apps/notebook/src/components/MarkdownCell.tsx
@@ -25,6 +25,7 @@ import { ProjectedMarkdownView } from "./markdown/ProjectedMarkdownView";
 import { useColorTheme, useDarkMode } from "@/lib/dark-mode";
 import {
   canRenderMarkdownProjectionInHost,
+  markdownProjectionMatchesSource,
   type MarkdownProjectionRun,
   projectedMarkdownPreviewHeight,
   projectMarkdownPlan,
@@ -53,6 +54,19 @@ import { rewriteMarkdownAssetRefs } from "../lib/markdown-assets";
 import { openUrl } from "../lib/open-url";
 import { toggleMarkdownTaskMarker } from "../lib/markdown-task-source";
 import { presenceSenderExtension } from "../lib/presence-sender";
+import {
+  sourceRangeAnchorFromRenderedMarkdownRuns,
+  sourceRangeAnchorFromRenderedMarkdownSelection,
+} from "../lib/rendered-markdown-source-comment";
+import { commentHighlightExtension } from "../lib/comment-highlight-extension";
+import { refreshCellCommentHighlights } from "../lib/comment-highlights";
+import {
+  selectionRectFromDomRect,
+  selectionRectFromDomSelection,
+  type SourceCommentSelectionRect,
+  type SourceRangeCommentAnchor,
+} from "../lib/comment-source-anchor";
+import { sourceCommentExtension } from "../lib/source-comment-extension";
 import type { MarkdownCell as MarkdownCellType } from "../types";
 import { CellPresenceIndicators } from "./cell/CellPresenceIndicators";
 
@@ -135,6 +149,11 @@ interface MarkdownCellProps {
   rightGutterContent?: ReactNode;
   headingAnchors?: readonly MarkdownHeadingAnchor[];
   readOnly?: boolean;
+  onCreateSourceComment?: (
+    anchor: SourceRangeCommentAnchor,
+    rect: SourceCommentSelectionRect | null,
+  ) => void;
+  onActivateCommentThread?: (threadId: string) => void;
   outputHostContext?: NteractEmbedHostContextPatch;
 }
 
@@ -152,6 +171,8 @@ export const MarkdownCell = memo(function MarkdownCell({
   rightGutterContent,
   headingAnchors = EMPTY_HEADING_ANCHORS,
   readOnly = false,
+  onCreateSourceComment,
+  onActivateCommentThread,
   outputHostContext,
 }: MarkdownCellProps) {
   const isFocused = useIsCellFocused(cell.id);
@@ -235,6 +256,11 @@ export const MarkdownCell = memo(function MarkdownCell({
   const frameRef = useRef<IsolatedFrameHandle>(null);
   const injectedLibsRef = useRef(new Set<string>());
   const viewRef = useRef<HTMLDivElement>(null);
+  const [renderedSourceCommentTarget, setRenderedSourceCommentTarget] = useState<{
+    anchor: SourceRangeCommentAnchor;
+    left: number;
+    top: number;
+  } | null>(null);
   const [previewFrameInteractionActive, setPreviewFrameInteractionActive] = useState(false);
   const [previewFrameReadyGeneration, setPreviewFrameReadyGeneration] = useState(0);
   const previewSource = draftPreviewSource ?? cell.source;
@@ -244,6 +270,10 @@ export const MarkdownCell = memo(function MarkdownCell({
       setDraftPreviewSource(null);
     }
   }, [cell.source, draftPreviewSource]);
+
+  useEffect(() => {
+    setRenderedSourceCommentTarget(null);
+  }, [editing, previewSource]);
 
   // Same resolution rule as the outline rail: a source-matching attached plan
   // wins, an edited source reprojects, never render a plan for source the
@@ -257,6 +287,12 @@ export const MarkdownCell = memo(function MarkdownCell({
     [cell.markdownProjection, cell.source, draftPreviewSource],
   );
   const canRenderProjectionInHost = canRenderMarkdownProjectionInHost(markdownProjection);
+  const canCommentOnRenderedMarkdown =
+    Boolean(onCreateSourceComment) &&
+    !readOnly &&
+    !editing &&
+    markdownProjection !== null &&
+    markdownProjectionMatchesSource(markdownProjection, previewSource);
   const previewMinHeight = useMemo(
     () =>
       projectedMarkdownPreviewHeight(
@@ -408,7 +444,133 @@ export const MarkdownCell = memo(function MarkdownCell({
 
   const handlePreviewWrapperPointerDown = useCallback(() => {
     activatePreviewFrameInteraction();
+    setRenderedSourceCommentTarget(null);
   }, [activatePreviewFrameInteraction]);
+
+  const clearRenderedSourceCommentTarget = useCallback(() => {
+    setRenderedSourceCommentTarget(null);
+  }, []);
+
+  const updateRenderedSourceCommentTarget = useCallback(() => {
+    if (!canCommentOnRenderedMarkdown) {
+      clearRenderedSourceCommentTarget();
+      return;
+    }
+
+    const root = viewRef.current;
+    if (!root || typeof window === "undefined") {
+      clearRenderedSourceCommentTarget();
+      return;
+    }
+
+    const selection = window.getSelection();
+    const anchor = sourceRangeAnchorFromRenderedMarkdownSelection(
+      cell.id,
+      previewSource,
+      root,
+      selection,
+    );
+    if (!anchor || !selection || selection.rangeCount === 0) {
+      clearRenderedSourceCommentTarget();
+      return;
+    }
+
+    const rangeRect = selection.getRangeAt(0).getBoundingClientRect();
+    const rootRect = root.getBoundingClientRect();
+    if (rangeRect.width === 0 && rangeRect.height === 0) {
+      clearRenderedSourceCommentTarget();
+      return;
+    }
+
+    setRenderedSourceCommentTarget({
+      anchor,
+      left: Math.min(
+        Math.max(0, rangeRect.right - rootRect.left + 6),
+        Math.max(0, rootRect.width - 84),
+      ),
+      top: Math.max(0, rangeRect.top - rootRect.top - 32),
+    });
+  }, [canCommentOnRenderedMarkdown, cell.id, clearRenderedSourceCommentTarget, previewSource]);
+
+  const requestRenderedSourceComment = useCallback(() => {
+    if (!canCommentOnRenderedMarkdown || !onCreateSourceComment) return false;
+
+    const root = viewRef.current;
+    if (!root || typeof window === "undefined") return false;
+
+    const anchor = sourceRangeAnchorFromRenderedMarkdownSelection(
+      cell.id,
+      previewSource,
+      root,
+      window.getSelection(),
+    );
+
+    if (!anchor) return false;
+    const rect = selectionRectFromDomSelection(window.getSelection());
+    onCreateSourceComment(anchor, rect);
+    window.getSelection()?.removeAllRanges();
+    clearRenderedSourceCommentTarget();
+    return true;
+  }, [
+    canCommentOnRenderedMarkdown,
+    cell.id,
+    clearRenderedSourceCommentTarget,
+    onCreateSourceComment,
+    previewSource,
+  ]);
+
+  const sourceRangeAnchorFromRenderedRuns = useCallback(
+    (runs: readonly MarkdownProjectionRun[]) => {
+      if (!canCommentOnRenderedMarkdown) return null;
+      return sourceRangeAnchorFromRenderedMarkdownRuns(cell.id, previewSource, runs);
+    },
+    [canCommentOnRenderedMarkdown, cell.id, previewSource],
+  );
+
+  const canCommentOnRenderedRuns = useCallback(
+    (runs: readonly MarkdownProjectionRun[]) => sourceRangeAnchorFromRenderedRuns(runs) !== null,
+    [sourceRangeAnchorFromRenderedRuns],
+  );
+
+  const handleRenderedRunsComment = useCallback(
+    (runs: readonly MarkdownProjectionRun[]) => {
+      const anchor = sourceRangeAnchorFromRenderedRuns(runs);
+      if (!anchor || !onCreateSourceComment) return;
+      const rect =
+        typeof window !== "undefined" ? selectionRectFromDomSelection(window.getSelection()) : null;
+      onCreateSourceComment(anchor, rect);
+      if (typeof window !== "undefined") {
+        window.getSelection()?.removeAllRanges();
+      }
+      clearRenderedSourceCommentTarget();
+    },
+    [clearRenderedSourceCommentTarget, onCreateSourceComment, sourceRangeAnchorFromRenderedRuns],
+  );
+
+  const handleRenderedSourceCommentClick = useCallback(
+    (event: MouseEvent<HTMLButtonElement>) => {
+      event.preventDefault();
+      event.stopPropagation();
+      if (requestRenderedSourceComment()) return;
+      const anchor = renderedSourceCommentTarget?.anchor;
+      if (!anchor || !onCreateSourceComment) return;
+      const rect =
+        selectionRectFromDomSelection(
+          typeof window !== "undefined" ? window.getSelection() : null,
+        ) ?? selectionRectFromDomRect(event.currentTarget.getBoundingClientRect());
+      onCreateSourceComment(anchor, rect);
+      if (typeof window !== "undefined") {
+        window.getSelection()?.removeAllRanges();
+      }
+      clearRenderedSourceCommentTarget();
+    },
+    [
+      clearRenderedSourceCommentTarget,
+      onCreateSourceComment,
+      renderedSourceCommentTarget,
+      requestRenderedSourceComment,
+    ],
+  );
 
   const handlePreviewFrameMouseUp = useCallback(
     ({ hasSelection }: { hasSelection?: boolean }) => {
@@ -613,6 +775,14 @@ export const MarkdownCell = memo(function MarkdownCell({
   // Handle keyboard navigation in view mode (when not editing)
   const handleViewKeyDown = useCallback(
     (e: React.KeyboardEvent) => {
+      const key = e.key.toLowerCase();
+      if (key === "m" && e.altKey && (e.metaKey || e.ctrlKey)) {
+        if (requestRenderedSourceComment()) {
+          e.preventDefault();
+          return;
+        }
+      }
+
       if (e.key === "ArrowDown") {
         onFocusNext?.("start");
         e.preventDefault();
@@ -635,7 +805,7 @@ export const MarkdownCell = memo(function MarkdownCell({
         e.preventDefault();
       }
     },
-    [enterEditing, onFocusNext, onFocusPrevious, readOnly],
+    [enterEditing, onFocusNext, onFocusPrevious, readOnly, requestRenderedSourceComment],
   );
 
   // Handle focus next, creating a new cell if at the end
@@ -676,15 +846,39 @@ export const MarkdownCell = memo(function MarkdownCell({
     ];
   }, [cell.id, presence]);
 
-  // Search highlight extension for edit mode + remote cursors + presence sender
+  const sourceCommentExt = useMemo(() => {
+    if (readOnly || !onCreateSourceComment) return [];
+    return [sourceCommentExtension(cell.id, onCreateSourceComment)];
+  }, [cell.id, onCreateSourceComment, readOnly]);
+
+  const commentHighlightExt = useMemo(() => {
+    if (!onActivateCommentThread) return [];
+    return [
+      commentHighlightExtension({
+        onActivate: onActivateCommentThread,
+        onReady: () => refreshCellCommentHighlights(cell.id),
+      }),
+    ];
+  }, [cell.id, onActivateCommentThread]);
+
+  // Search highlight extension for edit mode, remote cursors, presence, and comments.
   const searchExtensions = useMemo(
     () => [
       ...searchHighlight(searchQuery || ""),
       ...remoteCursorsExt,
       ...textAttributionExt,
       ...presenceSenderExt,
+      ...sourceCommentExt,
+      ...commentHighlightExt,
     ],
-    [searchQuery, remoteCursorsExt, textAttributionExt, presenceSenderExt],
+    [
+      searchQuery,
+      remoteCursorsExt,
+      textAttributionExt,
+      presenceSenderExt,
+      sourceCommentExt,
+      commentHighlightExt,
+    ],
   );
   const editorExtensions = useMemo(
     () => [crdtBridgeExt, ...searchExtensions],
@@ -856,10 +1050,12 @@ export const MarkdownCell = memo(function MarkdownCell({
             aria-readonly
             aria-label="Markdown cell content"
             tabIndex={0}
-            className={cn("py-2 cursor-text outline-none", editing && "hidden")}
+            className={cn("relative py-2 cursor-text outline-none", editing && "hidden")}
             onFocus={activatePreviewFrameInteraction}
             onDoubleClick={enterEditing}
             onPointerDown={handlePreviewWrapperPointerDown}
+            onMouseUp={updateRenderedSourceCommentTarget}
+            onKeyUp={updateRenderedSourceCommentTarget}
             onKeyDown={handleViewKeyDown}
           >
             {previewSource && canRenderProjectionInHost && markdownProjection ? (
@@ -867,6 +1063,10 @@ export const MarkdownCell = memo(function MarkdownCell({
                 plan={markdownProjection}
                 headingAnchors={headingAnchors}
                 onLinkClick={handleLinkClick}
+                canCommentOnRuns={
+                  canCommentOnRenderedMarkdown ? canCommentOnRenderedRuns : undefined
+                }
+                onCommentRuns={canCommentOnRenderedMarkdown ? handleRenderedRunsComment : undefined}
                 onTaskCheckedChange={
                   readOnly || !onUpdateSource ? undefined : handleTaskCheckedChange
                 }
@@ -902,6 +1102,30 @@ export const MarkdownCell = memo(function MarkdownCell({
               </div>
             )}
             {!previewSource && <p className="text-muted-foreground italic">Double-click to edit</p>}
+            {renderedSourceCommentTarget ? (
+              <button
+                type="button"
+                aria-label="Comment on selected markdown"
+                title="Comment on selected markdown"
+                data-testid="markdown-source-comment-button"
+                onPointerDown={(event) => {
+                  event.preventDefault();
+                  event.stopPropagation();
+                }}
+                onMouseDown={(event) => {
+                  event.preventDefault();
+                  event.stopPropagation();
+                }}
+                onClick={handleRenderedSourceCommentClick}
+                className="absolute z-20 rounded-md border bg-background px-2 py-1 text-[11px] font-medium leading-none text-foreground shadow-sm transition-colors hover:bg-muted focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/30"
+                style={{
+                  left: renderedSourceCommentTarget.left,
+                  top: renderedSourceCommentTarget.top,
+                }}
+              >
+                Comment
+              </button>
+            ) : null}
           </div>
         </>
       }

--- a/apps/notebook/src/components/NotebookView.tsx
+++ b/apps/notebook/src/components/NotebookView.tsx
@@ -1020,6 +1020,8 @@ function NotebookViewContent({
             rightGutterContent={rightGutterContent}
             headingAnchors={markdownHeadingAnchorsByCellId?.get(cell.id)}
             readOnly={!canEditMarkdownSources}
+            onCreateSourceComment={onCreateSourceComment}
+            onActivateCommentThread={onActivateCommentThread}
             outputHostContext={outputHostContext}
           />
         );

--- a/apps/notebook/src/lib/__tests__/comment-source-anchor.test.ts
+++ b/apps/notebook/src/lib/__tests__/comment-source-anchor.test.ts
@@ -11,6 +11,10 @@ import {
   sourcePointFromOffset,
   sourcePointFromStringOffset,
 } from "../comment-source-anchor";
+import {
+  sourceRangeAnchorFromRenderedMarkdownRuns,
+  sourceRangeAnchorFromRenderedMarkdownSelection,
+} from "../rendered-markdown-source-comment";
 
 let view: EditorView | null = null;
 
@@ -28,6 +32,7 @@ describe("comment-source-anchor", () => {
   afterEach(() => {
     view?.destroy();
     view = null;
+    window.getSelection()?.removeAllRanges();
   });
 
   it("converts source offsets to zero-based line and column points", () => {
@@ -99,6 +104,112 @@ describe("comment-source-anchor", () => {
       exact_quote: "beta",
       suffix_quote: "\n",
     });
+  });
+
+  it("maps rendered markdown text selections back to source_range anchors", () => {
+    const root = document.createElement("div");
+    root.innerHTML = `
+      <p>
+        <span data-markdown-source-run="true" data-rendered-start="0" data-rendered-end="11" data-source-start="0" data-source-end="11">plain prose</span>
+      </p>
+    `;
+    document.body.append(root);
+    const run = root.querySelector("[data-markdown-source-run='true']");
+    const text = run?.firstChild;
+    if (!text) throw new Error("missing run text");
+
+    const range = document.createRange();
+    range.setStart(text, "plain ".length);
+    range.setEnd(text, "plain prose".length);
+    window.getSelection()?.removeAllRanges();
+    window.getSelection()?.addRange(range);
+
+    expect(
+      sourceRangeAnchorFromRenderedMarkdownSelection(
+        "cell-1",
+        "plain prose",
+        root,
+        window.getSelection(),
+      ),
+    ).toMatchObject({
+      kind: "source_range",
+      cell_id: "cell-1",
+      start_line: 0,
+      start_column: "plain ".length,
+      end_line: 0,
+      end_column: "plain prose".length,
+      exact_quote: "prose",
+    });
+
+    root.remove();
+  });
+
+  it("rejects rendered markdown selections when hidden source markup changes selected text", () => {
+    const root = document.createElement("div");
+    root.innerHTML = `
+      <p>
+        <span data-markdown-source-run="true" data-rendered-start="0" data-rendered-end="4" data-source-start="0" data-source-end="8"><strong>bold</strong></span>
+      </p>
+    `;
+    document.body.append(root);
+    const run = root.querySelector("[data-markdown-source-run='true']");
+    const text = run?.textContent ? run.querySelector("strong")?.firstChild : null;
+    if (!text) throw new Error("missing strong text");
+
+    const range = document.createRange();
+    range.setStart(text, 1);
+    range.setEnd(text, 3);
+    window.getSelection()?.removeAllRanges();
+    window.getSelection()?.addRange(range);
+
+    expect(
+      sourceRangeAnchorFromRenderedMarkdownSelection(
+        "cell-1",
+        "**bold**",
+        root,
+        window.getSelection(),
+      ),
+    ).toBeNull();
+
+    root.remove();
+  });
+
+  it("maps rendered markdown runs back to keyboard-created source_range anchors", () => {
+    expect(
+      sourceRangeAnchorFromRenderedMarkdownRuns("cell-1", "plain prose", [
+        {
+          blockId: "p0",
+          inlineId: "r0",
+          listItemIndex: null,
+          renderedText: "plain prose",
+          renderedTextUtf16: [0, 11],
+          semantic: "text",
+          sourceSpanByte: [0, 11],
+          sourceSpanUtf16: [0, 11],
+        },
+      ]),
+    ).toMatchObject({
+      kind: "source_range",
+      cell_id: "cell-1",
+      exact_quote: "plain prose",
+    });
+  });
+
+  it("rejects rendered markdown runs when hidden source markup changes selected text", () => {
+    expect(
+      sourceRangeAnchorFromRenderedMarkdownRuns("cell-1", "**bold**", [
+        {
+          blockId: "p0",
+          inlineId: "r0",
+          listItemIndex: null,
+          renderedText: "bold",
+          renderedTextUtf16: [0, 4],
+          semantic: "strong",
+          sourceSpanByte: [0, 8],
+          sourceSpanUtf16: [0, 8],
+        },
+      ]),
+    ).toBeNull();
   });
 });
 

--- a/apps/notebook/src/lib/comment-source-anchor.ts
+++ b/apps/notebook/src/lib/comment-source-anchor.ts
@@ -75,6 +75,23 @@ export function selectionRectFromView(view: EditorView): SourceCommentSelectionR
   };
 }
 
+/**
+ * Bounding rectangle of a DOM selection in viewport coordinates, or null when
+ * the selection is empty or has no geometry.
+ */
+export function selectionRectFromDomSelection(
+  selection: Selection | null,
+): SourceCommentSelectionRect | null {
+  if (!selection || selection.rangeCount === 0 || selection.isCollapsed) return null;
+  const rect = selection.getRangeAt(0).getBoundingClientRect();
+  if (rect.width === 0 && rect.height === 0) return null;
+  return { left: rect.left, top: rect.top, right: rect.right, bottom: rect.bottom };
+}
+
+export function selectionRectFromDomRect(rect: DOMRect): SourceCommentSelectionRect {
+  return { left: rect.left, top: rect.top, right: rect.right, bottom: rect.bottom };
+}
+
 export function sourcePointFromStringOffset(source: string, offset: number): SourcePoint {
   const normalizedOffset = Math.min(source.length, Math.max(0, offset));
   let line = 0;

--- a/apps/notebook/src/lib/rendered-markdown-source-comment.ts
+++ b/apps/notebook/src/lib/rendered-markdown-source-comment.ts
@@ -1,0 +1,132 @@
+import {
+  sourceRangeAnchorFromOffsets,
+  type SourceRangeCommentAnchor,
+} from "./comment-source-anchor";
+import type { MarkdownProjectionRun } from "./markdown-projection";
+
+export const MARKDOWN_SOURCE_RUN_SELECTOR = "[data-markdown-source-run='true']";
+
+interface SourceRunElement extends HTMLElement {
+  dataset: DOMStringMap & {
+    renderedEnd?: string;
+    renderedStart?: string;
+    sourceEnd?: string;
+    sourceStart?: string;
+  };
+}
+
+interface SelectionPoint {
+  element: SourceRunElement;
+  offset: number;
+}
+
+export function sourceRangeAnchorFromRenderedMarkdownSelection(
+  cellId: string,
+  source: string,
+  root: HTMLElement,
+  selection: Selection | null,
+): SourceRangeCommentAnchor | null {
+  if (!selection || selection.rangeCount === 0 || selection.isCollapsed) return null;
+
+  const range = selection.getRangeAt(0);
+  if (!root.contains(range.commonAncestorContainer)) return null;
+  const selectedText = selection.toString();
+  if (selectedText.trim().length === 0) return null;
+
+  const start = selectionPointForRangeBoundary(root, range.startContainer, range.startOffset);
+  const end = selectionPointForRangeBoundary(root, range.endContainer, range.endOffset);
+  if (!start || !end) return null;
+
+  const from = sourceOffsetForRenderedPoint(start, "start");
+  const to = sourceOffsetForRenderedPoint(end, "end");
+  if (from === null || to === null) return null;
+
+  const anchor = sourceRangeAnchorFromOffsets(cellId, source, from, to);
+  if (!anchor || anchor.exact_quote !== selectedText) return null;
+  return anchor;
+}
+
+export function sourceRangeAnchorFromRenderedMarkdownRuns(
+  cellId: string,
+  source: string,
+  runs: readonly MarkdownProjectionRun[],
+): SourceRangeCommentAnchor | null {
+  const visibleRuns = [...runs]
+    .filter((run) => run.renderedText.trim().length > 0)
+    .sort((left, right) => left.renderedTextUtf16[0] - right.renderedTextUtf16[0]);
+  if (visibleRuns.length === 0) return null;
+
+  const from = Math.min(...visibleRuns.map((run) => run.sourceSpanUtf16[0]));
+  const to = Math.max(...visibleRuns.map((run) => run.sourceSpanUtf16[1]));
+  const selectedText = visibleRuns.map((run) => run.renderedText).join("");
+  const anchor = sourceRangeAnchorFromOffsets(cellId, source, from, to);
+  if (!anchor || anchor.exact_quote !== selectedText) return null;
+  return anchor;
+}
+
+function selectionPointForRangeBoundary(
+  root: HTMLElement,
+  node: Node,
+  nodeOffset: number,
+): SelectionPoint | null {
+  const element =
+    node.nodeType === Node.ELEMENT_NODE
+      ? (node as Element)
+      : (node.parentElement as Element | null);
+  const runElement = element?.closest(MARKDOWN_SOURCE_RUN_SELECTOR) as SourceRunElement | null;
+  if (!runElement || !root.contains(runElement)) return null;
+
+  const offset = textOffsetWithin(runElement, node, nodeOffset);
+  if (offset === null) return null;
+  return { element: runElement, offset };
+}
+
+function textOffsetWithin(root: HTMLElement, node: Node, nodeOffset: number): number | null {
+  const ownerDocument = root.ownerDocument;
+  try {
+    const range = ownerDocument.createRange();
+    range.selectNodeContents(root);
+    range.setEnd(node, nodeOffset);
+    return range.toString().length;
+  } catch {
+    return null;
+  }
+}
+
+function sourceOffsetForRenderedPoint(
+  point: SelectionPoint,
+  edge: "start" | "end",
+): number | null {
+  const sourceStart = numberDatasetValue(point.element.dataset.sourceStart);
+  const sourceEnd = numberDatasetValue(point.element.dataset.sourceEnd);
+  const renderedStart = numberDatasetValue(point.element.dataset.renderedStart);
+  const renderedEnd = numberDatasetValue(point.element.dataset.renderedEnd);
+  if (
+    sourceStart === null ||
+    sourceEnd === null ||
+    renderedStart === null ||
+    renderedEnd === null ||
+    sourceEnd < sourceStart ||
+    renderedEnd < renderedStart
+  ) {
+    return null;
+  }
+
+  const renderedLength = renderedEnd - renderedStart;
+  const sourceLength = sourceEnd - sourceStart;
+  const offset = Math.min(renderedLength, Math.max(0, point.offset));
+  if (renderedLength === sourceLength) {
+    return sourceStart + offset;
+  }
+
+  if (offset <= 0) return sourceStart;
+  if (offset >= renderedLength) return sourceEnd;
+  return edge === "start" ? sourceStart : sourceEnd;
+}
+
+function numberDatasetValue(value: string | undefined): number | null {
+  if (value === undefined || value.trim().length === 0) return null;
+  const parsed = Number(value);
+  if (!Number.isInteger(parsed)) return null;
+  return parsed;
+}

--- a/src/components/markdown/ProjectedMarkdownView.tsx
+++ b/src/components/markdown/ProjectedMarkdownView.tsx
@@ -1,5 +1,6 @@
-import { Fragment, type CSSProperties, type ReactNode } from "react";
+import { type CSSProperties, type ReactNode } from "react";
 import katex from "katex";
+import { MessageSquarePlus } from "lucide-react";
 import type {
   MarkdownProjectionBlock,
   MarkdownProjectionPlan,
@@ -51,6 +52,8 @@ interface ProjectedMarkdownViewProps {
   activeSourcePosition?: number;
   colorTheme?: "classic" | "cream";
   headingAnchors?: readonly MarkdownHeadingAnchor[];
+  canCommentOnRuns?: (runs: readonly MarkdownProjectionRun[]) => boolean;
+  onCommentRuns?: (runs: readonly MarkdownProjectionRun[]) => void;
   onLinkClick?: (url: string) => void;
   onTaskCheckedChange?: (run: MarkdownProjectionRun, checked: boolean) => void;
 }
@@ -60,7 +63,9 @@ export function ProjectedMarkdownView({
   className,
   activeSourcePosition,
   colorTheme: colorThemeOverride,
+  canCommentOnRuns,
   headingAnchors = [],
+  onCommentRuns,
   onLinkClick,
   onTaskCheckedChange,
 }: ProjectedMarkdownViewProps) {
@@ -95,6 +100,8 @@ export function ProjectedMarkdownView({
           colorTheme={colorTheme}
           isDark={isDark}
           runs={runsByBlock.get(block.blockId) ?? []}
+          canCommentOnRuns={canCommentOnRuns}
+          onCommentRuns={onCommentRuns}
           onLinkClick={onLinkClick}
           onTaskCheckedChange={onTaskCheckedChange}
         />
@@ -111,6 +118,8 @@ interface ProjectedMarkdownBlockProps {
   colorTheme: "classic" | "cream";
   isDark: boolean;
   runs: MarkdownProjectionRun[];
+  canCommentOnRuns?: (runs: readonly MarkdownProjectionRun[]) => boolean;
+  onCommentRuns?: (runs: readonly MarkdownProjectionRun[]) => void;
   onLinkClick?: (url: string) => void;
   onTaskCheckedChange?: (run: MarkdownProjectionRun, checked: boolean) => void;
 }
@@ -123,6 +132,8 @@ function ProjectedMarkdownBlock({
   colorTheme,
   isDark,
   runs,
+  canCommentOnRuns,
+  onCommentRuns,
   onLinkClick,
   onTaskCheckedChange,
 }: ProjectedMarkdownBlockProps) {
@@ -233,15 +244,46 @@ function ProjectedMarkdownBlock({
       );
     }
 
+    const canComment = Boolean(canCommentOnRuns?.(runs) && onCommentRuns);
     return (
       <p
         data-source-active={activeBlockId === block.blockId ? "true" : undefined}
         className={cn(
+          "group/markdown-comment",
           markdownParagraphClassName,
           activeBlockId === block.blockId && sourceActiveBlockClass,
         )}
       >
         {renderRuns(runs, onLinkClick, activeInlineId)}
+        {canComment ? (
+          <button
+            type="button"
+            aria-label="Comment on rendered paragraph"
+            title="Comment on rendered paragraph"
+            data-testid="markdown-block-comment-button"
+            onPointerDown={(event) => {
+              event.preventDefault();
+              event.stopPropagation();
+            }}
+            onMouseDown={(event) => {
+              event.preventDefault();
+              event.stopPropagation();
+            }}
+            onClick={(event) => {
+              event.preventDefault();
+              event.stopPropagation();
+              onCommentRuns?.(runs);
+            }}
+            onKeyDown={(event) => {
+              if (event.key === "Enter" || event.key === " ") {
+                event.stopPropagation();
+              }
+            }}
+            className="ml-1.5 inline-flex h-5 w-5 items-center justify-center rounded-md border bg-background align-middle text-muted-foreground opacity-0 transition-colors hover:bg-muted hover:text-foreground focus-visible:opacity-100 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/30 group-hover/markdown-comment:opacity-100 group-focus-within/markdown-comment:opacity-100"
+          >
+            <MessageSquarePlus className="h-3.5 w-3.5" aria-hidden="true" />
+          </button>
+        ) : null}
       </p>
     );
   }
@@ -669,15 +711,18 @@ function renderRuns(
   if (runs.length === 0) return null;
 
   return runs.map((run) => (
-    <Fragment key={run.inlineId}>
-      {activeInlineId === run.inlineId ? (
-        <span data-source-active-run="true" className={sourceActiveRunClass}>
-          {renderRun(run, onLinkClick)}
-        </span>
-      ) : (
-        renderRun(run, onLinkClick)
-      )}
-    </Fragment>
+    <span
+      key={run.inlineId}
+      data-markdown-source-run="true"
+      data-rendered-start={run.renderedTextUtf16[0]}
+      data-rendered-end={run.renderedTextUtf16[1]}
+      data-source-start={run.sourceSpanUtf16[0]}
+      data-source-end={run.sourceSpanUtf16[1]}
+      data-source-active-run={activeInlineId === run.inlineId ? "true" : undefined}
+      className={cn(activeInlineId === run.inlineId && sourceActiveRunClass)}
+    >
+      {renderRun(run, onLinkClick)}
+    </span>
   ));
 }
 

--- a/src/components/markdown/__tests__/ProjectedMarkdownView.test.tsx
+++ b/src/components/markdown/__tests__/ProjectedMarkdownView.test.tsx
@@ -39,6 +39,91 @@ describe("ProjectedMarkdownView", () => {
     }
   });
 
+  it("marks rendered runs with source spans for comment anchors", () => {
+    const { container } = render(
+      <ProjectedMarkdownView
+        plan={plan({
+          blocks: [
+            {
+              blockId: "p0",
+              blockIndex: 0,
+              element: "p",
+              kind: "paragraph",
+              measurement: { estimatedHeight: 32, confidence: "high", width: 720 },
+              sourceSpanByte: [0, 16],
+              sourceSpanUtf16: [0, 16],
+              syntaxSpans: [],
+              text: "alpha beta",
+            },
+          ],
+          runs: [
+            {
+              blockId: "p0",
+              inlineId: "r0",
+              listItemIndex: null,
+              renderedText: "alpha",
+              renderedTextUtf16: [0, 5],
+              semantic: "text",
+              sourceSpanByte: [0, 5],
+              sourceSpanUtf16: [0, 5],
+            },
+          ],
+        })}
+      />,
+    );
+
+    const run = container.querySelector("[data-markdown-source-run='true']");
+    expect(run).not.toBeNull();
+    expect(run).toHaveAttribute("data-rendered-start", "0");
+    expect(run).toHaveAttribute("data-rendered-end", "5");
+    expect(run).toHaveAttribute("data-source-start", "0");
+    expect(run).toHaveAttribute("data-source-end", "5");
+  });
+
+  it("renders keyboard-accessible comment actions for commentable paragraphs", () => {
+    const onCommentRuns = vi.fn();
+    render(
+      <ProjectedMarkdownView
+        canCommentOnRuns={() => true}
+        onCommentRuns={onCommentRuns}
+        plan={plan({
+          blocks: [
+            {
+              blockId: "p0",
+              blockIndex: 0,
+              element: "p",
+              kind: "paragraph",
+              measurement: { estimatedHeight: 32, confidence: "high", width: 720 },
+              sourceSpanByte: [0, 11],
+              sourceSpanUtf16: [0, 11],
+              syntaxSpans: [],
+              text: "plain prose",
+            },
+          ],
+          runs: [
+            {
+              blockId: "p0",
+              inlineId: "r0",
+              listItemIndex: null,
+              renderedText: "plain prose",
+              renderedTextUtf16: [0, 11],
+              semantic: "text",
+              sourceSpanByte: [0, 11],
+              sourceSpanUtf16: [0, 11],
+            },
+          ],
+        })}
+      />,
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "Comment on rendered paragraph" }));
+
+    expect(onCommentRuns).toHaveBeenCalledTimes(1);
+    expect(onCommentRuns.mock.calls[0]?.[0]).toMatchObject([
+      expect.objectContaining({ inlineId: "r0" }),
+    ]);
+  });
+
   it("matches the output document heading rhythm", () => {
     const { container } = render(
       <ProjectedMarkdownView
@@ -307,7 +392,7 @@ describe("ProjectedMarkdownView", () => {
       />,
     );
 
-    expect(screen.getByText("First paragraph")).toHaveClass("my-3", "leading-relaxed");
+    expect(screen.getByText("First paragraph").closest("p")).toHaveClass("my-3", "leading-relaxed");
     expect(screen.getByRole("list")).toHaveClass("my-3", "ml-6", "list-disc");
     expect(screen.getByText("quoted").closest("blockquote")).toHaveClass(
       "border-l-2",
@@ -1099,7 +1184,7 @@ describe("ProjectedMarkdownView", () => {
       />,
     );
 
-    expect(screen.getByText("K and note")).toBeInTheDocument();
+    expect(screen.getByText("K").closest("p")).toHaveTextContent("K and note");
     expect(document.querySelector("kbd")).toBeNull();
     expect(document.querySelector("[title='shortcut']")).toBeNull();
   });


### PR DESCRIPTION
Markdown cells now support select-to-comment in both rendered and source mode, harvested from the comments draft onto main.

## Rendered mode

Selecting prose raises a floating Comment affordance, with a per-paragraph hover button and `Ctrl/Cmd+Alt+M`. The comment anchors by a source range mapped from the rendered DOM selection through the projection's run spans (`ProjectedMarkdownView` stamps each run with `data-source-*` / `data-rendered-*` offsets). The exact-quote guard rejects selections whose rendered text diverges from source (markup like bold or links), so a comment never anchors to text that does not match the source.

## Source mode

The markdown CodeMirror editor mounts the same `sourceCommentExtension` / `commentHighlightExtension` as code cells, so commenting works while editing the markdown source too. `NotebookView` threads `onCreateSourceComment` / `onActivateCommentThread` to `MarkdownCell` (it already passes them to `CodeCell` and `RawCell`).

## Scope

This is the selection and anchor harvest. A follow-up adds the rendered-mode right-click context menu and rendered highlight overlays, and makes the rendered floating affordance a minimal icon to match the source one. The IsolatedFrame markdown path (complex or unsafe markdown) has no selection bridge and stays out of scope.

## Verification

`vp check` clean (format + lint); full `vp test` green (2412 passed), including new tests for the rendered DOM-selection anchor (with markup-mismatch rejection) and the ProjectedMarkdownView run spans. Independently reviewed: the `MarkdownCell` manual merge preserves the #3739 render refactor and #3741 comment-layer code, and the run-span attributes and button gating are correct.
