### PR TITLE
fix(outputs): render Panel notebook bundles

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -78,6 +78,7 @@ python/nteract/src/nteract/_widget.html
 /apps/notebook/src/renderer-plugins/markdown.js
 /apps/notebook/src/renderer-plugins/markdown.css
 /apps/notebook/src/renderer-plugins/bokeh.js
+/apps/notebook/src/renderer-plugins/panel.js
 /apps/notebook/src/renderer-plugins/sift.js
 /apps/notebook/src/renderer-plugins/sift.css
 # wasm-pack outputs, rebuilt by `cargo xtask wasm`. xtask build/dev commands

--- a/apps/mcp-app/src/vite-env.d.ts
+++ b/apps/mcp-app/src/vite-env.d.ts
@@ -25,6 +25,11 @@ declare module "virtual:renderer-plugin/bokeh" {
   export const css: string;
 }
 
+declare module "virtual:renderer-plugin/panel" {
+  export const code: string;
+  export const css: string;
+}
+
 declare module "virtual:renderer-plugin/leaflet" {
   export const code: string;
   export const css: string;

--- a/apps/mcp-app/vite.config.ts
+++ b/apps/mcp-app/vite.config.ts
@@ -14,6 +14,7 @@ const daemonPluginAssets = [
   "markdown.js",
   "markdown.css",
   "bokeh.js",
+  "panel.js",
   "plotly.js",
   "vega.js",
   "leaflet.js",

--- a/apps/notebook-cloud/viewer/vite-env.d.ts
+++ b/apps/notebook-cloud/viewer/vite-env.d.ts
@@ -28,6 +28,11 @@ declare module "virtual:renderer-plugin/bokeh" {
   export const css: string;
 }
 
+declare module "virtual:renderer-plugin/panel" {
+  export const code: string;
+  export const css: string;
+}
+
 declare module "virtual:renderer-plugin/leaflet" {
   export const code: string;
   export const css: string;

--- a/apps/notebook-cloud/viewer/widget-comm-projection.ts
+++ b/apps/notebook-cloud/viewer/widget-comm-projection.ts
@@ -27,6 +27,7 @@ export async function projectCloudWidgetComms(
         bufferPaths: comm.buffer_paths,
         commId: comm.comm_id,
         state,
+        targetName: comm.target_name,
       };
     }),
   );
@@ -34,11 +35,11 @@ export async function projectCloudWidgetComms(
   if (options.shouldContinue && !options.shouldContinue()) return;
 
   const projectedCommIds = new Set<string>();
-  for (const { bufferPaths, commId, state } of projected) {
+  for (const { bufferPaths, commId, state, targetName } of projected) {
     if (store.getModel(commId)) {
       store.updateModel(commId, state, bufferPaths);
     } else {
-      store.createModel(commId, state, bufferPaths);
+      store.createModel(commId, state, bufferPaths, targetName);
     }
     projectedCommIds.add(commId);
   }

--- a/apps/notebook/src/vite-env.d.ts
+++ b/apps/notebook/src/vite-env.d.ts
@@ -25,6 +25,11 @@ declare module "virtual:renderer-plugin/bokeh" {
   export const css: string;
 }
 
+declare module "virtual:renderer-plugin/panel" {
+  export const code: string;
+  export const css: string;
+}
+
 declare module "virtual:renderer-plugin/leaflet" {
   export const code: string;
   export const css: string;

--- a/apps/notebook/vite-plugin-isolated-renderer.ts
+++ b/apps/notebook/vite-plugin-isolated-renderer.ts
@@ -4,7 +4,7 @@
  * Loads pre-built renderer plugin artifacts from disk and exposes them as
  * virtual modules. The artifacts live under `apps/notebook/src/renderer-plugins/`.
  * Stable third-party plugin bundles are LFS-tracked; generated
- * isolated-renderer, markdown, and sift bundles are produced locally by
+ * isolated-renderer, markdown, bokeh, panel, and sift bundles are produced locally by
  * `cargo xtask renderer-plugins` or `cargo xtask artifacts ensure renderer`.
  *
  * In dev mode (Vite dev server), changes to isolated renderer source files
@@ -37,7 +37,7 @@ const RESOLVED_PLUGIN_PREFIX = "\0virtual:renderer-plugin/";
 const PREBUILT_DIR = path.resolve(__dirname, "../notebook/src/renderer-plugins");
 
 /** Plugin names that have pre-built artifacts. */
-const PLUGIN_NAMES = ["markdown", "plotly", "bokeh", "vega", "leaflet", "sift"];
+const PLUGIN_NAMES = ["markdown", "plotly", "bokeh", "panel", "vega", "leaflet", "sift"];
 const PLUGIN_CSS_NAMES = new Set(["markdown", "leaflet", "sift"]);
 
 interface IsolatedRendererPluginOptions {
@@ -55,7 +55,7 @@ interface IsolatedRendererPluginOptions {
    * Plugin artifacts to require during production build startup.
    * Consumers that provide their own plugin loader can set this to `[]` and
    * still use the core isolated renderer bundle.
-   * @default ["markdown", "plotly", "bokeh", "vega", "leaflet", "sift"]
+   * @default ["markdown", "plotly", "bokeh", "panel", "vega", "leaflet", "sift"]
    */
   prebuiltPluginNames?: readonly string[];
 }

--- a/apps/renderer-test/src/fixtures.ts
+++ b/apps/renderer-test/src/fixtures.ts
@@ -95,6 +95,26 @@ export const fixtures: Fixture[] = [
       },
     }),
   },
+  {
+    label: "Panel/PyViz exec (plugin)",
+    mimeType: "application/vnd.holoviews_exec.v0+json",
+    data: {
+      "text/html": [
+        '<div id="panel-fixture-root" style="font: 14px system-ui; padding: 12px; border: 1px solid #cbd5e1;">',
+        '<label for="panel-fixture-slider">Panel slider</label>',
+        '<input id="panel-fixture-slider" type="range" min="0" max="10" value="4" />',
+        '<output id="panel-fixture-value" for="panel-fixture-slider">4</output>',
+        "</div>",
+        "<script>",
+        "const slider = document.getElementById('panel-fixture-slider');",
+        "const value = document.getElementById('panel-fixture-value');",
+        "slider.addEventListener('input', () => { value.textContent = slider.value; });",
+        "</script>",
+      ].join(""),
+      "application/vnd.holoviews_exec.v0+json": "",
+    },
+    expectedText: ["Panel slider", "4"],
+  },
 ];
 
 export function getFixtureOutputs(fixture: Fixture): FixtureOutput[] {

--- a/apps/renderer-test/src/vite-env.d.ts
+++ b/apps/renderer-test/src/vite-env.d.ts
@@ -25,6 +25,11 @@ declare module "virtual:renderer-plugin/bokeh" {
   export const css: string;
 }
 
+declare module "virtual:renderer-plugin/panel" {
+  export const code: string;
+  export const css: string;
+}
+
 declare module "virtual:renderer-plugin/leaflet" {
   export const code: string;
   export const css: string;

--- a/crates/runtimed-wasm/src/lib.rs
+++ b/crates/runtimed-wasm/src/lib.rs
@@ -39,6 +39,8 @@ const BOKEHJS_EXEC_MIME: &str = "application/vnd.bokehjs_exec.v0+json";
 const BOKEHJS_LOAD_MIME: &str = "application/vnd.bokehjs_load.v0+json";
 const BOKEHJS_SCRIPT_MIME: &str = "application/javascript";
 const BOKEHJS_HTML_MIME: &str = "text/html";
+const PANEL_EXEC_MIME: &str = "application/vnd.holoviews_exec.v0+json";
+const PANEL_LOAD_MIME: &str = "application/vnd.holoviews_load.v0+json";
 const RUNT_OUTPUT_CACHE_KEY: &str = "_runt_output_cache_key";
 
 /// Install the panic hook on module init so Rust panics inside WASM
@@ -2916,6 +2918,10 @@ impl NotebookHandle {
                     || data.contains_key(BOKEHJS_LOAD_MIME)
                     || winner_mime == BOKEHJS_EXEC_MIME
                     || winner_mime == BOKEHJS_LOAD_MIME;
+                let panel_bundle = data.contains_key(PANEL_EXEC_MIME)
+                    || data.contains_key(PANEL_LOAD_MIME)
+                    || winner_mime == PANEL_EXEC_MIME
+                    || winner_mime == PANEL_LOAD_MIME;
 
                 for (mime, val) in data {
                     if mime == winner_mime
@@ -2927,6 +2933,14 @@ impl NotebookHandle {
                                 mime.as_str(),
                                 BOKEHJS_EXEC_MIME
                                     | BOKEHJS_LOAD_MIME
+                                    | BOKEHJS_SCRIPT_MIME
+                                    | BOKEHJS_HTML_MIME
+                            ))
+                        || (panel_bundle
+                            && matches!(
+                                mime.as_str(),
+                                PANEL_EXEC_MIME
+                                    | PANEL_LOAD_MIME
                                     | BOKEHJS_SCRIPT_MIME
                                     | BOKEHJS_HTML_MIME
                             ))
@@ -6259,6 +6273,37 @@ mod tests {
         let data = narrowed["data"].as_object().expect("narrowed data object");
 
         assert!(data.contains_key(BOKEHJS_EXEC_MIME));
+        assert!(data.contains_key(BOKEHJS_SCRIPT_MIME));
+        assert!(data.contains_key(BOKEHJS_HTML_MIME));
+        assert!(data.contains_key("text/plain"));
+    }
+
+    #[test]
+    fn panel_narrowing_keeps_marker_javascript_and_html_bundle() {
+        let mut handle = NotebookHandle::create_empty().expect("create handle");
+        handle.mime_priority = vec![
+            PANEL_EXEC_MIME.to_string(),
+            PANEL_LOAD_MIME.to_string(),
+            "text/html".to_string(),
+            BOKEHJS_SCRIPT_MIME.to_string(),
+            "text/plain".to_string(),
+        ];
+
+        let narrowed = handle.narrow_output_data(json!({
+            "output_type": "display_data",
+            "data": {
+                PANEL_EXEC_MIME: { "inline": "" },
+                BOKEHJS_SCRIPT_MIME: { "inline": "window.__panelExecRan = true;" },
+                BOKEHJS_HTML_MIME: { "inline": "<div id=\"p1011\"></div><script>window.__panelHtmlRan = true;</script>" },
+                "text/plain": { "inline": "fallback" },
+            },
+            "metadata": {
+                PANEL_EXEC_MIME: { "id": "p1011" },
+            },
+        }));
+        let data = narrowed["data"].as_object().expect("narrowed data object");
+
+        assert!(data.contains_key(PANEL_EXEC_MIME));
         assert!(data.contains_key(BOKEHJS_SCRIPT_MIME));
         assert!(data.contains_key(BOKEHJS_HTML_MIME));
         assert!(data.contains_key("text/plain"));

--- a/crates/runtimed/build.rs
+++ b/crates/runtimed/build.rs
@@ -4,7 +4,7 @@ fn main() {
     // Renderer plugin bundles live under `apps/notebook/src/renderer-plugins/`.
     // Stable third-party bundles (plotly, vega, leaflet) are LFS-tracked;
     // owned/generated renderer bundles (isolated-renderer.*, markdown.*,
-    // sift.*) are gitignored and rebuilt via
+    // bokeh.*, panel.*, sift.*) are gitignored and rebuilt via
     // `cargo xtask artifacts ensure renderer`.
     // sift_wasm.wasm is embedded directly from `crates/sift-wasm/pkg/`.
     // Probe each path before `include_bytes!` so a missing file points at
@@ -17,6 +17,8 @@ fn main() {
         "vega.js",
         "leaflet.js",
         "leaflet.css",
+        "bokeh.js",
+        "panel.js",
         "sift.js",
         "sift.css",
     ];
@@ -29,7 +31,7 @@ fn main() {
                  Stable bundles (plotly, vega, leaflet) \
                  are LFS-tracked - run `git lfs pull` if your checkout has pointer \
                  files only.\n\
-                 Generated bundles (isolated-renderer.*, markdown.*, sift.*) are gitignored - run \
+                 Generated bundles (isolated-renderer.*, markdown.*, bokeh.*, panel.*, sift.*) are gitignored - run \
                  `cargo xtask artifacts ensure sift,renderer` from the \
                  workspace root to rebuild.",
                 path.display(),

--- a/crates/runtimed/src/embedded_plugins.rs
+++ b/crates/runtimed/src/embedded_plugins.rs
@@ -1,6 +1,6 @@
 //! Embedded renderer plugin assets for MCP App output rendering.
 //!
-//! Heavy visualization renderers (plotly, vega, leaflet, markdown, bokeh, sift) ship
+//! Heavy visualization renderers (plotly, vega, leaflet, markdown, bokeh, panel, sift) ship
 //! inside the daemon binary via `include_bytes!`. The blob server serves raw
 //! JS/CSS assets at `GET /renderer-plugins/{name}` for the shared isolated
 //! renderer. It also keeps `GET /plugins/{name}` for legacy MCP App plugin
@@ -9,7 +9,7 @@
 //! The canonical source directory is `apps/notebook/src/renderer-plugins/` -
 //! the same raw CJS bundles the notebook Vite app loads via its
 //! isolated-renderer virtual modules. Stable third-party bundles (plotly, vega,
-//! leaflet) are LFS-tracked; isolated-renderer, markdown, and sift JS/CSS
+//! leaflet) are LFS-tracked; isolated-renderer, markdown, bokeh, panel, and sift JS/CSS
 //! bundles are generated locally by `cargo xtask renderer-plugins`. Sift's WASM
 //! blob comes straight from `crates/sift-wasm/pkg/sift_wasm_bg.wasm`.
 //!
@@ -54,6 +54,7 @@ pub const EMBEDDED_PLUGINS: &[EmbeddedPlugin] = &[
     plugin!("leaflet.js"),
     plugin!("leaflet.css"),
     plugin!("bokeh.js"),
+    plugin!("panel.js"),
     plugin!("sift.js"),
     plugin!("sift.css"),
     EmbeddedPlugin {

--- a/crates/runtimed/src/output_store.rs
+++ b/crates/runtimed/src/output_store.rs
@@ -2500,6 +2500,33 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn panel_display_data_preserves_exec_marker_mime() {
+        let dir = TempDir::new().unwrap();
+        let store = test_store(&dir);
+
+        let output = serde_json::json!({
+            "output_type": "display_data",
+            "data": {
+                "text/html": "<div id=\"p1011\"></div><script>window.__panelHtmlRan = true;</script>",
+                "application/javascript": "window.__panelExecRan = true;",
+                "application/vnd.holoviews_exec.v0+json": ""
+            },
+            "metadata": {
+                "application/vnd.holoviews_exec.v0+json": { "id": "p1011" }
+            }
+        });
+
+        let manifest = create_manifest(&output, &store, DEFAULT_INLINE_THRESHOLD)
+            .await
+            .unwrap();
+        let OutputManifest::DisplayData { data, .. } = manifest else {
+            panic!("expected DisplayData");
+        };
+
+        assert!(data.contains_key("application/vnd.holoviews_exec.v0+json"));
+    }
+
+    #[tokio::test]
     async fn markdown_display_data_adds_projected_plan_sibling() {
         let dir = TempDir::new().unwrap();
         let store = test_store(&dir);

--- a/crates/xtask/src/main.rs
+++ b/crates/xtask/src/main.rs
@@ -228,8 +228,8 @@ Other:
   renderer-plugins           Rebuild pre-built renderer plugins (notebook + MCP)
   renderer-plugins --only sift
                              Rebuild one renderer plugin target. Valid targets:
-                             isolated-renderer, core, markdown, plotly, vega,
-                             leaflet, sift.
+                             isolated-renderer, core, markdown, plotly, bokeh,
+                             panel, vega, leaflet, sift.
   verify-plugins             Check renderer plugin bundles match their wasm artifacts
                              (every wasm-bindgen import in the plugin JS must be
                              exported by the paired wasm binary). Catches #2048-style
@@ -1733,7 +1733,9 @@ fn parse_renderer_plugin_targets(args: &[String]) -> Vec<String> {
         if arg == "--help" || arg == "-h" {
             eprintln!("Usage: cargo xtask renderer-plugins [--only <target>[,<target>...]]");
             eprintln!();
-            eprintln!("Targets: isolated-renderer, core, markdown, plotly, vega, leaflet, sift");
+            eprintln!(
+                "Targets: isolated-renderer, core, markdown, plotly, bokeh, panel, vega, leaflet, sift"
+            );
             exit(0);
         }
         if arg == "--only" {
@@ -3317,7 +3319,7 @@ fn run_wasm_pack(needs_c_toolchain: bool, cmd: &str, args: &[&str]) {
 ///
 /// - **Renderer plugin bundles** split into stable LFS-tracked third-party
 ///   outputs (`plotly.js`, `vega.js`, `leaflet.*`) and generated local outputs
-///   (`isolated-renderer.*`, `markdown.*`, `sift.*`). We rebuild generated
+///   (`isolated-renderer.*`, `markdown.*`, `bokeh.js`, `panel.js`, `sift.*`). We rebuild generated
 ///   outputs when they're missing or pointer-shaped, and rebuild sift when it
 ///   is stale relative to sift-wasm source.
 ///
@@ -3342,6 +3344,7 @@ fn ensure_renderer_artifacts_current(sift_wasm_rebuilt: bool) {
         "markdown.js",
         "markdown.css",
         "bokeh.js",
+        "panel.js",
     ];
     let missing_lfs_tracked: Vec<&str> = lfs_tracked_probes
         .iter()
@@ -3436,6 +3439,9 @@ fn ensure_renderer_artifacts_current(sift_wasm_rebuilt: bool) {
             if generated_needs_rebuild.contains(&"bokeh.js") {
                 targets.push("bokeh");
             }
+            if generated_needs_rebuild.contains(&"panel.js") {
+                targets.push("panel");
+            }
             if sift_missing || sift_source_changed || sift_wasm_rebuilt {
                 targets.push("sift");
             }
@@ -3522,6 +3528,7 @@ const GENERATED_RENDERER_PLUGIN_OUTPUTS: &[&str] = &[
     "apps/notebook/src/renderer-plugins/markdown.js",
     "apps/notebook/src/renderer-plugins/markdown.css",
     "apps/notebook/src/renderer-plugins/bokeh.js",
+    "apps/notebook/src/renderer-plugins/panel.js",
     "apps/notebook/src/renderer-plugins/sift.js",
     "apps/notebook/src/renderer-plugins/sift.css",
 ];
@@ -3532,6 +3539,7 @@ const RENDERER_PLUGIN_OUTPUTS: &[&str] = &[
     "apps/notebook/src/renderer-plugins/markdown.js",
     "apps/notebook/src/renderer-plugins/markdown.css",
     "apps/notebook/src/renderer-plugins/bokeh.js",
+    "apps/notebook/src/renderer-plugins/panel.js",
     "apps/notebook/src/renderer-plugins/plotly.js",
     "apps/notebook/src/renderer-plugins/vega.js",
     "apps/notebook/src/renderer-plugins/leaflet.js",
@@ -4126,6 +4134,7 @@ fn mcp_widget_needs_rebuild() -> Option<&'static str> {
         Path::new("apps/notebook/src/renderer-plugins/markdown.js"),
         Path::new("apps/notebook/src/renderer-plugins/markdown.css"),
         Path::new("apps/notebook/src/renderer-plugins/bokeh.js"),
+        Path::new("apps/notebook/src/renderer-plugins/panel.js"),
         Path::new("apps/notebook/src/renderer-plugins/plotly.js"),
         Path::new("apps/notebook/src/renderer-plugins/vega.js"),
         Path::new("apps/notebook/src/renderer-plugins/leaflet.js"),

--- a/packages/runtimed/src/mime-priority.ts
+++ b/packages/runtimed/src/mime-priority.ts
@@ -9,10 +9,12 @@ export const DEFAULT_MIME_PRIORITY = [
   // Rich formats first
   "application/vnd.jupyter.widget-view+json",
   "application/vnd.plotly.v1+json",
-  // Bokeh emits marker MIMEs alongside application/javascript and text/html.
-  // These must win so the frontend can keep the bundle together.
+  // Bokeh and Panel emit marker MIMEs alongside application/javascript and
+  // text/html. These must win so the frontend can keep the bundle together.
   "application/vnd.bokehjs_exec.v0+json",
   "application/vnd.bokehjs_load.v0+json",
+  "application/vnd.holoviews_exec.v0+json",
+  "application/vnd.holoviews_load.v0+json",
   "application/vnd.vegalite.v6+json",
   "application/vnd.vegalite.v6.json",
   "application/vnd.vegalite.v5+json",

--- a/scripts/build-renderer-plugins.ts
+++ b/scripts/build-renderer-plugins.ts
@@ -3,7 +3,7 @@
  *
  * Output: `apps/notebook/src/renderer-plugins/` - core IIFE + CJS plugins.
  * Stable third-party bundles (plotly, vega, leaflet) are LFS-tracked.
- * Owned/generated bundles (isolated-renderer, markdown, bokeh, sift) stay
+ * Owned/generated bundles (isolated-renderer, markdown, bokeh, panel, sift) stay
  * gitignored because they are local build outputs. Sift also re-embeds sift-wasm's
  * wasm-bindgen glue and must be rebuilt in lockstep.
  *
@@ -48,6 +48,7 @@ Targets:
   markdown           Markdown renderer plugin
   plotly             Plotly renderer plugin
   bokeh              Bokeh renderer plugin
+  panel              Panel/PyViz renderer plugin
   vega               Vega renderer plugin
   leaflet            Leaflet renderer plugin
   sift               Sift renderer plugin

--- a/scripts/cloud-bootstrap.sh
+++ b/scripts/cloud-bootstrap.sh
@@ -61,6 +61,7 @@ ARTIFACT_PROBES=(
   apps/notebook/src/renderer-plugins/markdown.js
   apps/notebook/src/renderer-plugins/markdown.css
   apps/notebook/src/renderer-plugins/bokeh.js
+  apps/notebook/src/renderer-plugins/panel.js
   apps/notebook/src/renderer-plugins/sift.js
 )
 NEEDS_BUILD=0

--- a/src/build/renderer-plugin-builder.ts
+++ b/src/build/renderer-plugin-builder.ts
@@ -2,7 +2,7 @@
  * Shared renderer plugin builder
  *
  * Centralizes the build logic for renderer plugins (markdown, plotly, bokeh,
- * vega, leaflet) used by both the notebook Vite plugin and MCP app build
+ * panel, vega, leaflet) used by both the notebook Vite plugin and MCP app build
  * scripts.
  *
  * Plugins are built as CJS with React externalized (React is provided by the
@@ -60,6 +60,7 @@ export const RENDERER_PLUGINS: RendererPluginDef[] = [
   { name: "markdown", entry: path.resolve(srcDir, "isolated-renderer/markdown-renderer.tsx") },
   { name: "plotly", entry: path.resolve(srcDir, "isolated-renderer/plotly-renderer.tsx") },
   { name: "bokeh", entry: path.resolve(srcDir, "isolated-renderer/bokeh-renderer.tsx") },
+  { name: "panel", entry: path.resolve(srcDir, "isolated-renderer/panel-renderer.tsx") },
   { name: "vega", entry: path.resolve(srcDir, "isolated-renderer/vega-renderer.tsx") },
   { name: "leaflet", entry: path.resolve(srcDir, "isolated-renderer/leaflet-renderer.tsx") },
   { name: "sift", entry: path.resolve(srcDir, "isolated-renderer/sift-renderer.tsx") },

--- a/src/components/cell/__tests__/OutputArea.test.tsx
+++ b/src/components/cell/__tests__/OutputArea.test.tsx
@@ -2,6 +2,7 @@ import { act, createEvent, fireEvent, render, screen, waitFor } from "@testing-l
 import { afterEach, beforeEach, describe, expect, it, vi } from "vite-plus/test";
 import { injectPluginsForMimes, needsPlugin } from "@/components/isolated/iframe-libraries";
 import { BOKEHJS_EXEC_MIME_TYPE, BOKEHJS_LOAD_MIME_TYPE } from "@/components/outputs/bokeh-mime";
+import { PANEL_EXEC_MIME_TYPE, PANEL_LOAD_MIME_TYPE } from "@/components/outputs/panel-mime";
 import { setMarkdownProjectionProjector } from "@/lib/markdown-projection";
 import { OutputArea, type JupyterOutput } from "../OutputArea";
 
@@ -296,6 +297,45 @@ function makeBokehShowOnlyOutputs(): JupyterOutput[] {
       },
       metadata: {
         [BOKEHJS_EXEC_MIME_TYPE]: { id: "p1011" },
+      },
+    },
+  ];
+}
+
+function makePanelDocumentOutputs(): JupyterOutput[] {
+  return [
+    {
+      output_id: "panel-loading-html",
+      output_type: "display_data",
+      data: { "text/html": '<span id="panel-loading">Loading Panel ...</span>' },
+      metadata: {},
+    },
+    {
+      output_id: "panel-load-js",
+      output_type: "display_data",
+      data: {
+        "application/javascript":
+          'document.getElementById("panel-loading").textContent = "Panel loaded";',
+        [PANEL_LOAD_MIME_TYPE]: "",
+      },
+      metadata: {},
+    },
+    {
+      output_id: "panel-root-html",
+      output_type: "display_data",
+      data: { "text/html": '<div id="panel-root"></div>' },
+      metadata: {},
+    },
+    {
+      output_id: "panel-exec-html",
+      output_type: "display_data",
+      data: {
+        "text/html": '<div id="panel-widget"></div><script>window.__panelHtmlRan = true;</script>',
+        "application/javascript": 'document.getElementById("panel-root").textContent = "widget";',
+        [PANEL_EXEC_MIME_TYPE]: "",
+      },
+      metadata: {
+        [PANEL_EXEC_MIME_TYPE]: { id: "p1011" },
       },
     },
   ];
@@ -1054,6 +1094,52 @@ describe("OutputArea iframe theme sync", () => {
           mimeType: BOKEHJS_EXEC_MIME_TYPE,
           outputId: "bokeh-show-exec-js",
           outputIndex: 1,
+        }),
+      ]);
+    });
+  });
+
+  it("keeps Panel's related HTML and JavaScript outputs in one iframe document", async () => {
+    render(<OutputArea outputs={makePanelDocumentOutputs()} />);
+
+    const frames = screen.getAllByTestId("isolated-frame");
+    expect(frames).toHaveLength(1);
+    expect(frames[0].getAttribute("data-scroll-passthrough")).toBe("true");
+
+    await waitFor(() => {
+      expect(mockFrameHandle.renderBatch).toHaveBeenCalledWith([
+        expect.objectContaining({
+          mimeType: "text/html",
+          outputId: "panel-loading-html",
+          outputIndex: 0,
+        }),
+        expect.objectContaining({
+          data: expect.objectContaining({
+            "application/javascript":
+              'document.getElementById("panel-loading").textContent = "Panel loaded";',
+            [PANEL_LOAD_MIME_TYPE]: "",
+          }),
+          mimeType: PANEL_LOAD_MIME_TYPE,
+          outputId: "panel-load-js",
+          outputIndex: 1,
+        }),
+        expect.objectContaining({
+          mimeType: "text/html",
+          outputId: "panel-root-html",
+          outputIndex: 2,
+        }),
+        expect.objectContaining({
+          data: expect.objectContaining({
+            "text/html":
+              '<div id="panel-widget"></div><script>window.__panelHtmlRan = true;</script>',
+            "application/javascript":
+              'document.getElementById("panel-root").textContent = "widget";',
+            [PANEL_EXEC_MIME_TYPE]: "",
+          }),
+          metadata: { id: "p1011" },
+          mimeType: PANEL_EXEC_MIME_TYPE,
+          outputId: "panel-exec-html",
+          outputIndex: 3,
         }),
       ]);
     });

--- a/src/components/cell/__tests__/OutputArea.test.tsx
+++ b/src/components/cell/__tests__/OutputArea.test.tsx
@@ -321,6 +321,12 @@ function makePanelDocumentOutputs(): JupyterOutput[] {
       metadata: {},
     },
     {
+      output_id: "panel-empty-placeholder",
+      output_type: "display_data",
+      data: {},
+      metadata: {},
+    },
+    {
       output_id: "panel-root-html",
       output_type: "display_data",
       data: { "text/html": '<div id="panel-root"></div>' },
@@ -1126,7 +1132,7 @@ describe("OutputArea iframe theme sync", () => {
         expect.objectContaining({
           mimeType: "text/html",
           outputId: "panel-root-html",
-          outputIndex: 2,
+          outputIndex: 3,
         }),
         expect.objectContaining({
           data: expect.objectContaining({
@@ -1139,7 +1145,7 @@ describe("OutputArea iframe theme sync", () => {
           metadata: { id: "p1011" },
           mimeType: PANEL_EXEC_MIME_TYPE,
           outputId: "panel-exec-html",
-          outputIndex: 3,
+          outputIndex: 4,
         }),
       ]);
     });

--- a/src/components/isolated/AGENTS.md
+++ b/src/components/isolated/AGENTS.md
@@ -123,6 +123,7 @@ Heavy renderers (markdown, plotly, vega, leaflet, sift) are **not** in the core 
 | Vega | `application/vnd.vega*.v*` | `virtual:renderer-plugin/vega` | ~865 KB |
 | Plotly | `application/vnd.plotly.v1+json` | `virtual:renderer-plugin/plotly` | ~4.8 MB |
 | Bokeh | `application/vnd.bokehjs_*` | `virtual:renderer-plugin/bokeh` | generated wrapper; loads BokehJS on demand |
+| Panel | `application/vnd.holoviews_*` | `virtual:renderer-plugin/panel` | generated wrapper; runs Panel/PyViz notebook bundles |
 | Leaflet | `application/geo+json` | `virtual:renderer-plugin/leaflet` | ~194 KB |
 | Sift | `application/vnd.apache.parquet` | `virtual:renderer-plugin/sift` | ~380 KB JS + 138 KB CSS |
 

--- a/src/components/isolated/__tests__/comm-bridge-manager.test.ts
+++ b/src/components/isolated/__tests__/comm-bridge-manager.test.ts
@@ -87,10 +87,12 @@ function createModel(
   id: string,
   state: Record<string, unknown> = {},
   modelModule = "@jupyter-widgets/controls",
+  targetName = "jupyter.widget",
 ): WidgetModel {
   return {
     id,
     state: { _model_name: "TestModel", _model_module: modelModule, ...state },
+    targetName,
     modelName: "TestModel",
     modelModule,
   };
@@ -247,6 +249,28 @@ describe("CommBridgeManager", () => {
       expect(commSync.payload.models).toHaveLength(2);
     });
 
+    it("sends widget_snapshot with each model's stored comm target name", () => {
+      const models = new Map<string, WidgetModel>([
+        ["comm-panel", createModel("comm-panel", { value: 1 }, "", "hv-extension-comm")],
+      ]);
+      const storeWithModels = createMockStore(models);
+      const manager = new CommBridgeManager({
+        frame: mockFrame.frame,
+        store: storeWithModels.store,
+        sendUpdate,
+        sendCustom,
+        closeComm,
+      });
+
+      manager.handleIframeMessage({ type: "widget_ready" });
+
+      const commSync = mockFrame.sendCalls.find(
+        (msg: unknown) => (msg as { type: string }).type === "widget_snapshot",
+      ) as { type: string; payload: { models: Array<{ targetName: string }> } };
+
+      expect(commSync.payload.models[0].targetName).toBe("hv-extension-comm");
+    });
+
     it("tracks sent models to avoid duplicates in syncModels", () => {
       const models = new Map<string, WidgetModel>([
         ["comm-1", createModel("comm-1", { value: 1 })],
@@ -388,7 +412,7 @@ describe("CommBridgeManager", () => {
       manager.handleIframeMessage({ type: "widget_ready" });
 
       // Simulate adding a new model to the store
-      const newModel = createModel("new-comm", { value: 100 });
+      const newModel = createModel("new-comm", { value: 100 }, "", "hv-extension-comm");
       (mockStore.store.getSnapshot as ReturnType<typeof vi.fn>).mockReturnValue(
         new Map([["new-comm", newModel]]),
       );
@@ -403,6 +427,9 @@ describe("CommBridgeManager", () => {
           (msg as { payload: { commId: string } }).payload.commId === "new-comm",
       );
       expect(commOpen).toBeDefined();
+      expect((commOpen as { payload: { targetName: string } }).payload.targetName).toBe(
+        "hv-extension-comm",
+      );
     });
 
     it("sends comm_close for deleted models", () => {

--- a/src/components/isolated/__tests__/output-lane-policy.test.ts
+++ b/src/components/isolated/__tests__/output-lane-policy.test.ts
@@ -257,6 +257,7 @@ describe("output lane policy", () => {
         "application/javascript": 'document.getElementById("panel-loading").textContent = "ok";',
         [PANEL_LOAD_MIME_TYPE]: "",
       }),
+      displayOutput("panel-empty-placeholder", {}),
       displayOutput("panel-root-html", {
         "text/html": '<div id="panel-root"></div>',
       }),
@@ -272,13 +273,15 @@ describe("output lane policy", () => {
     expect(outputs.map((output) => selectedOutputMimeType(output))).toEqual([
       "text/html",
       PANEL_LOAD_MIME_TYPE,
+      null,
       "text/html",
       PANEL_EXEC_MIME_TYPE,
     ]);
     expect(outputUsesPanel(outputs[1])).toBe(true);
-    expect(outputUsesPanel(outputs[3])).toBe(true);
-    expect(outputUsesWheelOwningFrame(outputs[3])).toBe(true);
+    expect(outputUsesPanel(outputs[4])).toBe(true);
+    expect(outputUsesWheelOwningFrame(outputs[4])).toBe(true);
     expect(outputs.map((output) => outputAllowsScrollPassthrough(output))).toEqual([
+      true,
       true,
       true,
       true,
@@ -288,6 +291,7 @@ describe("output lane policy", () => {
     expect(segments[0].outputs.map((output) => output.output_id)).toEqual([
       "panel-loading-html",
       "panel-load-js",
+      "panel-empty-placeholder",
       "panel-root-html",
       "panel-exec-html",
     ]);
@@ -333,13 +337,13 @@ describe("output lane policy", () => {
     expect(anyOutputNeedsIsolation(outputs)).toBe(false);
   });
 
-  it("does not mark display outputs without a selected MIME as scroll passthrough", () => {
+  it("treats display outputs without a selected MIME as transparent", () => {
     const output = displayOutput("empty-display", {
       "text/plain": null,
     });
 
     expect(selectedOutputMimeType(output)).toBeNull();
-    expect(outputAllowsScrollPassthrough(output)).toBe(false);
+    expect(outputAllowsScrollPassthrough(output)).toBe(true);
     expect(outputSegmentLane(output)).toBe("dom");
   });
 

--- a/src/components/isolated/__tests__/output-lane-policy.test.ts
+++ b/src/components/isolated/__tests__/output-lane-policy.test.ts
@@ -1,6 +1,7 @@
 import { afterEach, describe, expect, it } from "vite-plus/test";
 import type { JupyterOutput } from "@/components/cell/jupyter-output";
 import { BOKEHJS_EXEC_MIME_TYPE, BOKEHJS_LOAD_MIME_TYPE } from "@/components/outputs/bokeh-mime";
+import { PANEL_EXEC_MIME_TYPE, PANEL_LOAD_MIME_TYPE } from "@/components/outputs/panel-mime";
 import {
   MARKDOWN_PROJECTION_MIME_TYPE,
   setMarkdownProjectionProjector,
@@ -11,6 +12,7 @@ import {
   outputAllowsScrollPassthrough,
   outputSegmentLane,
   outputUsesBokeh,
+  outputUsesPanel,
   outputUsesPlotly,
   outputUsesSift,
   outputUsesVega,
@@ -243,6 +245,51 @@ describe("output lane policy", () => {
     expect(segments[0].outputs.map((output) => output.output_id)).toEqual([
       "bokeh-root-html",
       "bokeh-exec-js",
+    ]);
+  });
+
+  it("keeps Panel's HTML and JavaScript display outputs in one document lane", () => {
+    const outputs = [
+      displayOutput("panel-loading-html", {
+        "text/html": '<span id="panel-loading">Loading Panel ...</span>',
+      }),
+      displayOutput("panel-load-js", {
+        "application/javascript": 'document.getElementById("panel-loading").textContent = "ok";',
+        [PANEL_LOAD_MIME_TYPE]: "",
+      }),
+      displayOutput("panel-root-html", {
+        "text/html": '<div id="panel-root"></div>',
+      }),
+      displayOutput("panel-exec-html", {
+        "text/html": '<div id="panel-widget"></div><script>window.__panelHtmlRan = true;</script>',
+        "application/javascript": 'document.getElementById("panel-root").textContent = "widget";',
+        [PANEL_EXEC_MIME_TYPE]: "",
+      }),
+    ];
+
+    const segments = splitOutputSegments(outputs);
+
+    expect(outputs.map((output) => selectedOutputMimeType(output))).toEqual([
+      "text/html",
+      PANEL_LOAD_MIME_TYPE,
+      "text/html",
+      PANEL_EXEC_MIME_TYPE,
+    ]);
+    expect(outputUsesPanel(outputs[1])).toBe(true);
+    expect(outputUsesPanel(outputs[3])).toBe(true);
+    expect(outputUsesWheelOwningFrame(outputs[3])).toBe(true);
+    expect(outputs.map((output) => outputAllowsScrollPassthrough(output))).toEqual([
+      true,
+      true,
+      true,
+      true,
+    ]);
+    expect(segments.map((segment) => segment.lane)).toEqual(["static-frame"]);
+    expect(segments[0].outputs.map((output) => output.output_id)).toEqual([
+      "panel-loading-html",
+      "panel-load-js",
+      "panel-root-html",
+      "panel-exec-html",
     ]);
   });
 

--- a/src/components/isolated/__tests__/output-payloads.test.ts
+++ b/src/components/isolated/__tests__/output-payloads.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "vite-plus/test";
 import type { IdentifiedJupyterOutput } from "../output-payloads";
 import { jupyterOutputToRenderPayload } from "../output-payloads";
 import { BOKEHJS_EXEC_MIME_TYPE, BOKEHJS_LOAD_MIME_TYPE } from "@/components/outputs/bokeh-mime";
+import { PANEL_EXEC_MIME_TYPE } from "@/components/outputs/panel-mime";
 
 describe("isolated output payload conversion", () => {
   it("remaps Bokeh load bundles to the Bokeh MIME while preserving sibling JavaScript", () => {
@@ -52,6 +53,35 @@ describe("isolated output payload conversion", () => {
         metadata: { id: "p1011" },
         mimeType: BOKEHJS_EXEC_MIME_TYPE,
         outputId: "bokeh-exec",
+        outputIndex: 1,
+      }),
+    );
+  });
+
+  it("remaps Panel exec bundles to the Panel MIME while preserving sibling HTML and JavaScript", () => {
+    const output: IdentifiedJupyterOutput = {
+      output_id: "panel-exec",
+      output_type: "display_data",
+      data: {
+        "text/html": '<div id="panel-root"></div><script>window.__panelHtmlRan = true;</script>',
+        "application/javascript": "window.__panelExecRan = true;",
+        [PANEL_EXEC_MIME_TYPE]: "",
+      },
+      metadata: {
+        [PANEL_EXEC_MIME_TYPE]: { id: "p1011" },
+      },
+    };
+
+    expect(jupyterOutputToRenderPayload(output, 1)).toEqual(
+      expect.objectContaining({
+        data: {
+          "application/javascript": "window.__panelExecRan = true;",
+          "text/html": '<div id="panel-root"></div><script>window.__panelHtmlRan = true;</script>',
+          [PANEL_EXEC_MIME_TYPE]: "",
+        },
+        metadata: { id: "p1011" },
+        mimeType: PANEL_EXEC_MIME_TYPE,
+        outputId: "panel-exec",
         outputIndex: 1,
       }),
     );

--- a/src/components/isolated/__tests__/renderer-plugin-info.test.ts
+++ b/src/components/isolated/__tests__/renderer-plugin-info.test.ts
@@ -5,6 +5,7 @@ import {
   rendererPluginNameForMime,
 } from "../renderer-plugin-info";
 import { BOKEHJS_EXEC_MIME_TYPE, BOKEHJS_LOAD_MIME_TYPE } from "@/components/outputs/bokeh-mime";
+import { PANEL_EXEC_MIME_TYPE, PANEL_LOAD_MIME_TYPE } from "@/components/outputs/panel-mime";
 
 describe("renderer plugin metadata", () => {
   it("maps exact MIME types to the shared renderer plugin names", () => {
@@ -22,6 +23,14 @@ describe("renderer plugin metadata", () => {
     });
     expect(rendererPluginInfoForMime(BOKEHJS_EXEC_MIME_TYPE)).toEqual({
       name: "bokeh",
+      hasCss: false,
+    });
+    expect(rendererPluginInfoForMime(PANEL_LOAD_MIME_TYPE)).toEqual({
+      name: "panel",
+      hasCss: false,
+    });
+    expect(rendererPluginInfoForMime(PANEL_EXEC_MIME_TYPE)).toEqual({
+      name: "panel",
       hasCss: false,
     });
     expect(rendererPluginInfoForMime("application/vnd.apache.parquet")).toEqual({

--- a/src/components/isolated/comm-bridge-manager.ts
+++ b/src/components/isolated/comm-bridge-manager.ts
@@ -231,7 +231,7 @@ export class CommBridgeManager {
     for (const [commId, model] of models) {
       modelArray.push({
         commId,
-        targetName: model.modelModule || "jupyter.widget",
+        targetName: model.targetName || model.modelModule || "jupyter.widget",
         state: model.state,
         bufferPaths: model.bufferPaths,
       });
@@ -340,7 +340,7 @@ export class CommBridgeManager {
         // New model - send comm_open
         this.sendCommOpen(
           commId,
-          model.modelModule || "jupyter.widget",
+          model.targetName || model.modelModule || "jupyter.widget",
           model.state,
           model.bufferPaths,
         );

--- a/src/components/isolated/iframe-libraries.ts
+++ b/src/components/isolated/iframe-libraries.ts
@@ -41,6 +41,7 @@ const PLUGIN_LOADERS: Record<RendererPluginName, () => Promise<PluginModule>> = 
   markdown: () => import("virtual:renderer-plugin/markdown").then(normalize),
   plotly: () => import("virtual:renderer-plugin/plotly").then(normalize),
   bokeh: () => import("virtual:renderer-plugin/bokeh").then(normalize),
+  panel: () => import("virtual:renderer-plugin/panel").then(normalize),
   vega: () => import("virtual:renderer-plugin/vega").then(normalize),
   leaflet: () => import("virtual:renderer-plugin/leaflet").then(normalize),
   sift: () => import("virtual:renderer-plugin/sift").then(normalize),

--- a/src/components/isolated/output-lane-policy.ts
+++ b/src/components/isolated/output-lane-policy.ts
@@ -4,6 +4,11 @@ import {
   BOKEHJS_LOAD_MIME_TYPE,
   isBokehMimeType,
 } from "@/components/outputs/bokeh-mime";
+import {
+  PANEL_EXEC_MIME_TYPE,
+  PANEL_LOAD_MIME_TYPE,
+  isPanelMimeType,
+} from "@/components/outputs/panel-mime";
 import { DEFAULT_PRIORITY, selectMimeType } from "@/components/outputs/mime-priority";
 import { isSafeForMainDom } from "@/components/outputs/safe-mime-types";
 import { isVegaMimeType } from "@/components/outputs/vega-mime";
@@ -41,10 +46,12 @@ const SCROLL_PASSTHROUGH_MIME_TYPES = new Set([
   "text/html",
   "image/svg+xml",
   // JavaScript display outputs often act on adjacent HTML display outputs in
-  // the same cell (Bokeh's notebook loader/root pair is the common case).
+  // the same cell (Bokeh and Panel notebook loader/root pairs are common).
   "application/javascript",
   BOKEHJS_LOAD_MIME_TYPE,
   BOKEHJS_EXEC_MIME_TYPE,
+  PANEL_LOAD_MIME_TYPE,
+  PANEL_EXEC_MIME_TYPE,
   // Sift's interactive tables are also click-to-engage (see SIFT_MIME_TYPES).
   "application/vnd.apache.parquet",
   "application/vnd.apache.arrow.stream",
@@ -124,11 +131,19 @@ export function outputUsesBokeh(
   return mimeType !== null && isBokehMimeType(mimeType);
 }
 
+export function outputUsesPanel(
+  output: JupyterOutput,
+  priority: readonly string[] = DEFAULT_PRIORITY,
+): boolean {
+  const mimeType = selectedOutputMimeType(output, priority);
+  return mimeType !== null && isPanelMimeType(mimeType);
+}
+
 /**
  * Outputs whose iframe must own the wheel once the user engages it: Sift's
  * crossfilter tables scroll internally, and chart surfaces like Vega/Altair
- * Plotly, and Bokeh pan or zoom. While engaged the wheel-boundary forwarding is
- * locked so the page does not steal the gesture.
+ * Plotly, Bokeh, and Panel pan or zoom. While engaged the wheel-boundary
+ * forwarding is locked so the page does not steal the gesture.
  */
 export function outputUsesWheelOwningFrame(
   output: JupyterOutput,
@@ -138,7 +153,8 @@ export function outputUsesWheelOwningFrame(
     outputUsesSift(output, priority) ||
     outputUsesVega(output, priority) ||
     outputUsesPlotly(output, priority) ||
-    outputUsesBokeh(output, priority)
+    outputUsesBokeh(output, priority) ||
+    outputUsesPanel(output, priority)
   );
 }
 

--- a/src/components/isolated/output-lane-policy.ts
+++ b/src/components/isolated/output-lane-policy.ts
@@ -96,6 +96,7 @@ export function outputAllowsScrollPassthrough(
   }
 
   const mimeType = selectedOutputMimeType(output, priority);
+  if (mimeType === null) return true;
   return mimeType !== null && isScrollPassthroughMimeType(mimeType);
 }
 
@@ -230,6 +231,16 @@ function laneStandsAlone(lane: OutputLane): boolean {
   return lane === "sift-frame" || lane === "vega-frame" || lane === "plotly-frame";
 }
 
+function isEmptyDisplayOutput(
+  output: JupyterOutput,
+  priority: readonly string[] = DEFAULT_PRIORITY,
+): boolean {
+  if (output.output_type !== "execute_result" && output.output_type !== "display_data") {
+    return false;
+  }
+  return selectedOutputMimeType(output, priority) === null;
+}
+
 export function splitOutputSegments(
   outputs: readonly JupyterOutput[],
   priority: readonly string[] = DEFAULT_PRIORITY,
@@ -240,7 +251,9 @@ export function splitOutputSegments(
     const lane = outputSegmentLane(output, priority);
     const previous = segments.at(-1);
 
-    if (!laneStandsAlone(lane) && previous && previous.lane === lane) {
+    if (previous?.lane === "static-frame" && isEmptyDisplayOutput(output, priority)) {
+      previous.outputs.push(output);
+    } else if (!laneStandsAlone(lane) && previous && previous.lane === lane) {
       previous.outputs.push(output);
     } else {
       segments.push({ lane, outputs: [output] });

--- a/src/components/isolated/output-payloads.ts
+++ b/src/components/isolated/output-payloads.ts
@@ -1,6 +1,7 @@
 import type { RenderPayload } from "./frame-bridge";
 import type { JupyterOutput } from "@/components/cell/jupyter-output";
 import { isBokehMimeType } from "@/components/outputs/bokeh-mime";
+import { isPanelMimeType } from "@/components/outputs/panel-mime";
 import { DEFAULT_PRIORITY, selectMimeType } from "@/components/outputs/mime-priority";
 
 export type IdentifiedJupyterOutput = JupyterOutput & { output_id: string };
@@ -36,8 +37,12 @@ function requireOutputId(output: IdentifiedJupyterOutput): string {
   return output.output_id;
 }
 
+function isJavascriptBundleMimeType(mimeType: string): boolean {
+  return isBokehMimeType(mimeType) || isPanelMimeType(mimeType);
+}
+
 function dataForSelectedMime(output: DataJupyterOutput, mimeType: string): unknown {
-  if (!isBokehMimeType(mimeType)) {
+  if (!isJavascriptBundleMimeType(mimeType)) {
     return output.data[mimeType];
   }
 

--- a/src/components/isolated/renderer-plugin-info.ts
+++ b/src/components/isolated/renderer-plugin-info.ts
@@ -1,7 +1,15 @@
 import { isVegaMimeType } from "@/components/outputs/vega-mime";
 import { BOKEHJS_EXEC_MIME_TYPE, BOKEHJS_LOAD_MIME_TYPE } from "@/components/outputs/bokeh-mime";
+import { PANEL_EXEC_MIME_TYPE, PANEL_LOAD_MIME_TYPE } from "@/components/outputs/panel-mime";
 
-export type RendererPluginName = "markdown" | "plotly" | "bokeh" | "vega" | "leaflet" | "sift";
+export type RendererPluginName =
+  | "markdown"
+  | "plotly"
+  | "bokeh"
+  | "panel"
+  | "vega"
+  | "leaflet"
+  | "sift";
 
 export interface RendererPluginInfo {
   name: RendererPluginName;
@@ -14,6 +22,8 @@ const MIME_TO_PLUGIN: Record<string, RendererPluginInfo> = {
   "application/vnd.plotly.v1+json": { name: "plotly", hasCss: false },
   [BOKEHJS_LOAD_MIME_TYPE]: { name: "bokeh", hasCss: false },
   [BOKEHJS_EXEC_MIME_TYPE]: { name: "bokeh", hasCss: false },
+  [PANEL_LOAD_MIME_TYPE]: { name: "panel", hasCss: false },
+  [PANEL_EXEC_MIME_TYPE]: { name: "panel", hasCss: false },
   "application/geo+json": { name: "leaflet", hasCss: true },
   "application/vnd.apache.parquet": { name: "sift", hasCss: true },
   "application/vnd.apache.arrow.stream": { name: "sift", hasCss: true },

--- a/src/components/outputs/mime-priority.ts
+++ b/src/components/outputs/mime-priority.ts
@@ -1,4 +1,5 @@
 import { BOKEHJS_EXEC_MIME_TYPE, BOKEHJS_LOAD_MIME_TYPE } from "./bokeh-mime";
+import { PANEL_EXEC_MIME_TYPE, PANEL_LOAD_MIME_TYPE } from "./panel-mime";
 
 /**
  * Default MIME type priority order for rendering.
@@ -15,10 +16,13 @@ export const DEFAULT_PRIORITY = [
   // outrank source markdown and HTML fallbacks when a host supplies it.
   "application/vnd.nteract.markdown+json",
   "application/vnd.plotly.v1+json",
-  // Bokeh emits these alongside text/html and application/javascript. They
-  // must win so the Bokeh renderer can coordinate the sibling payloads.
+  // Bokeh and Panel emit marker MIMEs alongside text/html and
+  // application/javascript. They must win so renderer plugins can coordinate
+  // the sibling payloads.
   BOKEHJS_EXEC_MIME_TYPE,
   BOKEHJS_LOAD_MIME_TYPE,
+  PANEL_EXEC_MIME_TYPE,
+  PANEL_LOAD_MIME_TYPE,
   "application/vnd.vegalite.v6+json",
   "application/vnd.vegalite.v6.json",
   "application/vnd.vegalite.v5+json",

--- a/src/components/outputs/panel-mime.ts
+++ b/src/components/outputs/panel-mime.ts
@@ -1,0 +1,8 @@
+export const PANEL_LOAD_MIME_TYPE = "application/vnd.holoviews_load.v0+json";
+export const PANEL_EXEC_MIME_TYPE = "application/vnd.holoviews_exec.v0+json";
+
+const PANEL_MIME_TYPES = new Set([PANEL_LOAD_MIME_TYPE, PANEL_EXEC_MIME_TYPE]);
+
+export function isPanelMimeType(mimeType: string): boolean {
+  return PANEL_MIME_TYPES.has(mimeType);
+}

--- a/src/components/widgets/AGENTS.md
+++ b/src/components/widgets/AGENTS.md
@@ -67,7 +67,12 @@ interface WidgetStore {
   getSnapshot(): Map<string, WidgetModel>;
 
   getModel(modelId: string): WidgetModel | undefined;
-  createModel(commId: string, state: Record<string, unknown>, bufferPaths?: string[][]): void;
+  createModel(
+    commId: string,
+    state: Record<string, unknown>,
+    bufferPaths?: string[][],
+    targetName?: string,
+  ): void;
   updateModel(commId: string, statePatch: Record<string, unknown>, bufferPaths?: string[][]): void;
   deleteModel(commId: string): void;
   wasModelClosed(commId: string): boolean;

--- a/src/components/widgets/__tests__/comm-changes-store-bridge.test.ts
+++ b/src/components/widgets/__tests__/comm-changes-store-bridge.test.ts
@@ -31,13 +31,14 @@ describe("comm changes store bridge", () => {
       _model_name: "IntSliderModel",
       value: 7,
     });
+    expect(store.getModel("comm-slider")?.targetName).toBe("jupyter.widget");
 
     applyWidgetCommChangesToStore(store, {
       opened: [],
       updated: [
         {
           commId: "comm-slider",
-          targetName: "jupyter.widget",
+          targetName: "hv-extension-comm",
           modelModule: "@jupyter-widgets/controls",
           modelName: "IntSliderModel",
           state: { value: 18 },
@@ -72,7 +73,7 @@ describe("comm changes store bridge", () => {
       updated: [
         {
           commId: "comm-slider",
-          targetName: "jupyter.widget",
+          targetName: "hv-extension-comm",
           modelModule: "@jupyter-widgets/controls",
           modelName: "IntSliderModel",
           state: { value: 18 },
@@ -87,6 +88,7 @@ describe("comm changes store bridge", () => {
     expect(model?.state.value).toBe(18);
     expect(model?.state._model_module).toBe("@jupyter-widgets/controls");
     expect(model?.state._model_name).toBe("IntSliderModel");
+    expect(model?.targetName).toBe("hv-extension-comm");
   });
 
   it("suppresses optimistic echoes while keeping output resolution hooks", () => {

--- a/src/components/widgets/__tests__/widget-store.test.ts
+++ b/src/components/widgets/__tests__/widget-store.test.ts
@@ -82,6 +82,7 @@ describe("resolveModelRef", () => {
       id: "abc123",
       state: { value: 42 },
       buffers: [],
+      targetName: "jupyter.widget",
       modelName: "IntSliderModel",
       modelModule: "@jupyter-widgets/controls",
     };
@@ -165,6 +166,7 @@ describe("createWidgetStore", () => {
       const model = store.getModel("comm-1");
       expect(model).toBeDefined();
       expect(model?.id).toBe("comm-1");
+      expect(model?.targetName).toBe("jupyter.widget");
       expect(model?.modelName).toBe("IntSliderModel");
       expect(model?.modelModule).toBe("@jupyter-widgets/controls");
       expect(model?.state.value).toBe(50);
@@ -179,6 +181,15 @@ describe("createWidgetStore", () => {
       const model = store.getModel("comm-1");
       expect(model?.modelName).toBe("UnknownModel");
       expect(model?.modelModule).toBe("");
+      expect(model?.targetName).toBe("jupyter.widget");
+    });
+
+    it("stores the comm target name when provided", () => {
+      const store = createWidgetStore();
+
+      store.createModel("comm-1", { value: 42 }, undefined, "hv-extension-comm");
+
+      expect(store.getModel("comm-1")?.targetName).toBe("hv-extension-comm");
     });
 
     it("stores bufferPaths with the model", () => {

--- a/src/components/widgets/anywidget-view.tsx
+++ b/src/components/widgets/anywidget-view.tsx
@@ -516,6 +516,7 @@ export function AnyWidgetView({ modelId, className }: AnyWidgetViewProps) {
           {
             id: stableModelId,
             state: {},
+            targetName: "jupyter.widget",
             modelName: "",
             modelModule: "",
           } as WidgetModel,

--- a/src/components/widgets/comm-changes-store-bridge.ts
+++ b/src/components/widgets/comm-changes-store-bridge.ts
@@ -28,13 +28,23 @@ export function applyWidgetCommChangesToStore(
   options: ApplyWidgetCommChangesOptions = {},
 ): void {
   for (const comm of changes.opened) {
-    store.createModel(comm.commId, widgetStateWithMetadata(comm), comm.bufferPaths);
+    store.createModel(
+      comm.commId,
+      widgetStateWithMetadata(comm),
+      comm.bufferPaths,
+      comm.targetName,
+    );
     maybeResolveCommOutputs(store, comm.commId, comm.unresolvedOutputs, options);
   }
 
   for (const comm of changes.updated) {
     if (!store.getModel(comm.commId)) {
-      store.createModel(comm.commId, widgetStateWithMetadata(comm), comm.bufferPaths);
+      store.createModel(
+        comm.commId,
+        widgetStateWithMetadata(comm),
+        comm.bufferPaths,
+        comm.targetName,
+      );
       maybeResolveCommOutputs(store, comm.commId, comm.unresolvedOutputs, options);
       continue;
     }

--- a/src/components/widgets/widget-store.ts
+++ b/src/components/widgets/widget-store.ts
@@ -10,6 +10,8 @@ export interface WidgetModel {
    * observes it. Empty / absent means no binary data.
    */
   bufferPaths?: string[][];
+  /** Comm target name, e.g., "jupyter.widget", "hv-extension-comm" */
+  targetName: string;
   /** Model class name, e.g., "IntSliderModel", "AnyModel" */
   modelName: string;
   /** Model module, e.g., "@jupyter-widgets/controls", "anywidget" */
@@ -30,7 +32,12 @@ export interface WidgetStore {
   /** Get a single model by ID */
   getModel: (modelId: string) => WidgetModel | undefined;
   /** Create a new model (on comm_open) */
-  createModel: (commId: string, state: Record<string, unknown>, bufferPaths?: string[][]) => void;
+  createModel: (
+    commId: string,
+    state: Record<string, unknown>,
+    bufferPaths?: string[][],
+    targetName?: string,
+  ) => void;
   /** Update a model's state (on comm_msg with method: "update") */
   updateModel: (
     commId: string,
@@ -157,7 +164,12 @@ export function createWidgetStore(): WidgetStore {
       return models.get(modelId);
     },
 
-    createModel(commId: string, state: Record<string, unknown>, bufferPaths?: string[][]): void {
+    createModel(
+      commId: string,
+      state: Record<string, unknown>,
+      bufferPaths?: string[][],
+      targetName = "jupyter.widget",
+    ): void {
       // Handle re-open: remove from closed set if re-opening
       closedModels.delete(commId);
 
@@ -169,6 +181,7 @@ export function createWidgetStore(): WidgetStore {
         id: commId,
         state,
         bufferPaths,
+        targetName,
         modelName,
         modelModule,
       };

--- a/src/isolated-renderer/__tests__/bokeh-renderer.test.tsx
+++ b/src/isolated-renderer/__tests__/bokeh-renderer.test.tsx
@@ -170,6 +170,35 @@ describe("Bokeh renderer plugin", () => {
     expect(renderedScripts(container)).toHaveLength(1);
   });
 
+  it("renders sibling Bokeh exec HTML before appending JavaScript", async () => {
+    const appendedSrcs = stubBokehCdnLoads();
+    const { Renderer } = installBokehRenderer();
+    window.Bokeh = {};
+
+    const { container } = render(
+      <Renderer
+        data={{
+          "text/html":
+            '<div id="bokeh-root">Bokeh root</div><script>window.__bokehHtmlRan = true;</script>',
+          "application/javascript": "window.__bokehExecRan = true;",
+          [BOKEHJS_EXEC_MIME_TYPE]: "",
+        }}
+        metadata={{ id: "p1011" }}
+        mimeType={BOKEHJS_EXEC_MIME_TYPE}
+      />,
+    );
+
+    await waitFor(() => {
+      expect(container.querySelector("#bokeh-root")?.textContent).toBe("Bokeh root");
+      expect(renderedScripts(container).map((script) => script.textContent)).toEqual([
+        "window.__bokehHtmlRan = true;",
+        "window.__bokehExecRan = true;",
+      ]);
+    });
+
+    expect(appendedSrcs).toEqual([]);
+  });
+
   it("appends Bokeh load MIME JavaScript directly", async () => {
     const { Renderer } = installBokehRenderer();
     const { container } = render(

--- a/src/isolated-renderer/__tests__/panel-renderer.test.tsx
+++ b/src/isolated-renderer/__tests__/panel-renderer.test.tsx
@@ -27,6 +27,41 @@ function stubAnimationFrames() {
   });
 }
 
+function stubPanelRuntime() {
+  (window as typeof window & { Bokeh?: unknown }).Bokeh = { Panel: {}, index: {} };
+}
+
+function stubPanelResourceLoads() {
+  const appendedSrcs: string[] = [];
+  const appendChild = vi.spyOn(HTMLHeadElement.prototype, "appendChild");
+
+  appendChild.mockImplementation(function appendPanelScript(
+    this: HTMLHeadElement,
+    node: Node,
+  ): Node {
+    if (node instanceof HTMLScriptElement && node.src) {
+      appendedSrcs.push(node.src);
+      if (node.src.includes("bokeh-3.9.1.min.js")) {
+        (window as typeof window & { Bokeh?: unknown }).Bokeh = {
+          version: "3.9.1",
+          index: {},
+        };
+      }
+      if (node.src.includes("panel.min.js")) {
+        const target = window as typeof window & {
+          Bokeh?: { Panel?: unknown; version?: string; index?: Record<string, unknown> };
+        };
+        target.Bokeh ??= { version: "3.9.1", index: {} };
+        target.Bokeh.Panel = {};
+      }
+      queueMicrotask(() => node.onload?.(new Event("load")));
+    }
+    return Node.prototype.appendChild.call(this, node);
+  });
+
+  return appendedSrcs;
+}
+
 function renderedScripts(container: HTMLElement): HTMLScriptElement[] {
   return Array.from(container.querySelectorAll("script"));
 }
@@ -35,6 +70,7 @@ describe("Panel renderer plugin", () => {
   beforeEach(() => {
     stubAnimationFrames();
     delete (window as typeof window & { PyViz?: unknown }).PyViz;
+    delete (window as typeof window & { Bokeh?: unknown }).Bokeh;
   });
 
   afterEach(() => {
@@ -42,6 +78,7 @@ describe("Panel renderer plugin", () => {
     vi.restoreAllMocks();
     vi.unstubAllGlobals();
     delete (window as typeof window & { PyViz?: unknown }).PyViz;
+    delete (window as typeof window & { Bokeh?: unknown }).Bokeh;
   });
 
   it("registers Panel load and exec MIME types", () => {
@@ -68,6 +105,7 @@ describe("Panel renderer plugin", () => {
   });
 
   it("renders Panel exec HTML and makes embedded scripts executable", async () => {
+    stubPanelRuntime();
     const { Renderer } = installPanelRenderer();
     const { container } = render(
       <Renderer
@@ -88,6 +126,7 @@ describe("Panel renderer plugin", () => {
   });
 
   it("appends sibling application/javascript after Panel exec HTML", async () => {
+    stubPanelRuntime();
     const { Renderer } = installPanelRenderer();
     const { container } = render(
       <Renderer
@@ -104,6 +143,61 @@ describe("Panel renderer plugin", () => {
     await waitFor(() => {
       expect(renderedScripts(container).at(-1)?.textContent).toBe("window.__panelExecRan = true;");
     });
+  });
+
+  it("executes id-less Panel exec bundles as auxiliary notebook setup", async () => {
+    const { Renderer } = installPanelRenderer();
+    const { container } = render(
+      <Renderer
+        data={{
+          "text/html": "<style>.panel-test-style { color: red; }</style>",
+          "application/javascript": "window.__panelAuxiliaryRan = true;",
+          [PANEL_EXEC_MIME_TYPE]: "",
+        }}
+        mimeType={PANEL_EXEC_MIME_TYPE}
+      />,
+    );
+
+    await waitFor(() => {
+      expect(container.querySelector("style")?.textContent).toContain("panel-test-style");
+      expect(renderedScripts(container).at(-1)?.textContent).toBe(
+        "window.__panelAuxiliaryRan = true;",
+      );
+    });
+  });
+
+  it("loads BokehJS and Panel resources derived from exec HTML before rendering", async () => {
+    const appendedSrcs = stubPanelResourceLoads();
+    const { Renderer } = installPanelRenderer();
+    const { container } = render(
+      <Renderer
+        data={{
+          "text/html": [
+            '<div id="panel-root"></div>',
+            '<script type="application/javascript">',
+            'var docs_json = {"docid":{"version":"3.9.1","roots":[{"attributes":{"stylesheets":[{"attributes":{"url":"https://cdn.holoviz.org/panel/1.9.3/dist/css/loading.css"}}]}}]}};',
+            "window.__panelHtmlRan = true;",
+            "</script>",
+          ].join(""),
+          [PANEL_EXEC_MIME_TYPE]: "",
+        }}
+        metadata={{ id: "p1011" }}
+        mimeType={PANEL_EXEC_MIME_TYPE}
+      />,
+    );
+
+    await waitFor(() => {
+      expect(renderedScripts(container).at(-1)?.textContent).toContain("__panelHtmlRan");
+    });
+
+    expect(appendedSrcs).toEqual([
+      "https://cdn.bokeh.org/bokeh/release/bokeh-3.9.1.min.js",
+      "https://cdn.bokeh.org/bokeh/release/bokeh-gl-3.9.1.min.js",
+      "https://cdn.bokeh.org/bokeh/release/bokeh-widgets-3.9.1.min.js",
+      "https://cdn.bokeh.org/bokeh/release/bokeh-tables-3.9.1.min.js",
+      "https://cdn.bokeh.org/bokeh/release/bokeh-mathjax-3.9.1.min.js",
+      "https://cdn.holoviz.org/panel/1.9.3/dist/panel.min.js",
+    ]);
   });
 
   it("copies script attributes for Panel server outputs", async () => {

--- a/src/isolated-renderer/__tests__/panel-renderer.test.tsx
+++ b/src/isolated-renderer/__tests__/panel-renderer.test.tsx
@@ -1,0 +1,128 @@
+import { cleanup, render, waitFor } from "@testing-library/react";
+import type { ComponentType } from "react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vite-plus/test";
+import { PANEL_EXEC_MIME_TYPE, PANEL_LOAD_MIME_TYPE } from "@/components/outputs/panel-mime";
+import type { RendererProps } from "@/lib/renderer-registry";
+import { install } from "../panel-renderer";
+
+function installPanelRenderer() {
+  let Renderer: ComponentType<RendererProps> | undefined;
+  let registeredMimeTypes: string[] = [];
+
+  install({
+    register: (mimeTypes, component) => {
+      registeredMimeTypes = mimeTypes;
+      Renderer = component;
+    },
+  });
+
+  expect(Renderer).toBeDefined();
+  return { Renderer: Renderer!, registeredMimeTypes };
+}
+
+function stubAnimationFrames() {
+  vi.stubGlobal("requestAnimationFrame", (callback: FrameRequestCallback) => {
+    callback(0);
+    return 0;
+  });
+}
+
+function renderedScripts(container: HTMLElement): HTMLScriptElement[] {
+  return Array.from(container.querySelectorAll("script"));
+}
+
+describe("Panel renderer plugin", () => {
+  beforeEach(() => {
+    stubAnimationFrames();
+    delete (window as typeof window & { PyViz?: unknown }).PyViz;
+  });
+
+  afterEach(() => {
+    cleanup();
+    vi.restoreAllMocks();
+    vi.unstubAllGlobals();
+    delete (window as typeof window & { PyViz?: unknown }).PyViz;
+  });
+
+  it("registers Panel load and exec MIME types", () => {
+    const { registeredMimeTypes } = installPanelRenderer();
+
+    expect(registeredMimeTypes).toEqual([PANEL_LOAD_MIME_TYPE, PANEL_EXEC_MIME_TYPE]);
+  });
+
+  it("appends Panel load MIME JavaScript directly", async () => {
+    const { Renderer } = installPanelRenderer();
+    const { container } = render(
+      <Renderer
+        data={{
+          "application/javascript": "window.__panelLoadRan = true;",
+          [PANEL_LOAD_MIME_TYPE]: "window.__panelLoadRan = true;",
+        }}
+        mimeType={PANEL_LOAD_MIME_TYPE}
+      />,
+    );
+
+    await waitFor(() => {
+      expect(renderedScripts(container).at(-1)?.textContent).toBe("window.__panelLoadRan = true;");
+    });
+  });
+
+  it("renders Panel exec HTML and makes embedded scripts executable", async () => {
+    const { Renderer } = installPanelRenderer();
+    const { container } = render(
+      <Renderer
+        data={{
+          "text/html":
+            '<div id="panel-root">Panel root</div><script>window.__panelHtmlRan = true;</script>',
+          [PANEL_EXEC_MIME_TYPE]: "",
+        }}
+        metadata={{ id: "p1011" }}
+        mimeType={PANEL_EXEC_MIME_TYPE}
+      />,
+    );
+
+    await waitFor(() => {
+      expect(container.querySelector("#panel-root")?.textContent).toBe("Panel root");
+      expect(renderedScripts(container).at(-1)?.textContent).toContain("__panelHtmlRan");
+    });
+  });
+
+  it("appends sibling application/javascript after Panel exec HTML", async () => {
+    const { Renderer } = installPanelRenderer();
+    const { container } = render(
+      <Renderer
+        data={{
+          "text/html": '<div id="panel-root"></div>',
+          "application/javascript": "window.__panelExecRan = true;",
+          [PANEL_EXEC_MIME_TYPE]: "",
+        }}
+        metadata={{ id: "p1011" }}
+        mimeType={PANEL_EXEC_MIME_TYPE}
+      />,
+    );
+
+    await waitFor(() => {
+      expect(renderedScripts(container).at(-1)?.textContent).toBe("window.__panelExecRan = true;");
+    });
+  });
+
+  it("copies script attributes for Panel server outputs", async () => {
+    const { Renderer } = installPanelRenderer();
+    const { container } = render(
+      <Renderer
+        data={{
+          "text/html": '<script src="https://example.test/panel-server.js" async></script>',
+          [PANEL_EXEC_MIME_TYPE]: "",
+        }}
+        metadata={{ server_id: "server-1" }}
+        mimeType={PANEL_EXEC_MIME_TYPE}
+      />,
+    );
+
+    await waitFor(() => {
+      const script = renderedScripts(container).at(-1);
+      expect(script?.src).toBe("https://example.test/panel-server.js");
+      expect(script?.hasAttribute("async")).toBe(true);
+    });
+  });
+});

--- a/src/isolated-renderer/__tests__/panel-renderer.test.tsx
+++ b/src/isolated-renderer/__tests__/panel-renderer.test.tsx
@@ -41,7 +41,7 @@ function stubPanelResourceLoads() {
   ): Node {
     if (node instanceof HTMLScriptElement && node.src) {
       appendedSrcs.push(node.src);
-      if (node.src.includes("bokeh-3.9.1.min.js")) {
+      if (node.src.includes("cdn.bokeh.org/bokeh/release/")) {
         (window as typeof window & { Bokeh?: unknown }).Bokeh = {
           version: "3.9.1",
           index: {},
@@ -66,19 +66,35 @@ function renderedScripts(container: HTMLElement): HTMLScriptElement[] {
   return Array.from(container.querySelectorAll("script"));
 }
 
+function removePanelLoaderScripts() {
+  for (const script of document.querySelectorAll("script[data-nteract-panel-src]")) {
+    script.remove();
+  }
+}
+
 describe("Panel renderer plugin", () => {
   beforeEach(() => {
     stubAnimationFrames();
+    removePanelLoaderScripts();
     delete (window as typeof window & { PyViz?: unknown }).PyViz;
     delete (window as typeof window & { Bokeh?: unknown }).Bokeh;
+    delete (window as typeof window & { __nteractBokehLoadPromise__?: unknown })
+      .__nteractBokehLoadPromise__;
+    delete (window as typeof window & { __nteractPanelLoadPromises__?: unknown })
+      .__nteractPanelLoadPromises__;
   });
 
   afterEach(() => {
     cleanup();
     vi.restoreAllMocks();
     vi.unstubAllGlobals();
+    removePanelLoaderScripts();
     delete (window as typeof window & { PyViz?: unknown }).PyViz;
     delete (window as typeof window & { Bokeh?: unknown }).Bokeh;
+    delete (window as typeof window & { __nteractBokehLoadPromise__?: unknown })
+      .__nteractBokehLoadPromise__;
+    delete (window as typeof window & { __nteractPanelLoadPromises__?: unknown })
+      .__nteractPanelLoadPromises__;
   });
 
   it("registers Panel load and exec MIME types", () => {
@@ -198,6 +214,89 @@ describe("Panel renderer plugin", () => {
       "https://cdn.bokeh.org/bokeh/release/bokeh-mathjax-3.9.1.min.js",
       "https://cdn.holoviz.org/panel/1.9.3/dist/panel.min.js",
     ]);
+  });
+
+  it("executes code-only Panel exec bundles after loading BokehJS", async () => {
+    const appendedSrcs = stubPanelResourceLoads();
+    const { Renderer } = installPanelRenderer();
+    const { container } = render(
+      <Renderer
+        data={{
+          "application/javascript": `
+            window.__panelCodeOnlyDocs = {"docid": {"version": "3.9.1"}};
+            window.__panelCodeOnlyRan = true;
+          `,
+          [PANEL_EXEC_MIME_TYPE]: "",
+        }}
+        metadata={{ id: "p1011" }}
+        mimeType={PANEL_EXEC_MIME_TYPE}
+      />,
+    );
+
+    await waitFor(() => {
+      expect(renderedScripts(container).at(-1)?.textContent).toContain("__panelCodeOnlyRan");
+    });
+
+    expect(appendedSrcs).toEqual([
+      "https://cdn.bokeh.org/bokeh/release/bokeh-3.9.1.min.js",
+      "https://cdn.bokeh.org/bokeh/release/bokeh-gl-3.9.1.min.js",
+      "https://cdn.bokeh.org/bokeh/release/bokeh-widgets-3.9.1.min.js",
+      "https://cdn.bokeh.org/bokeh/release/bokeh-tables-3.9.1.min.js",
+      "https://cdn.bokeh.org/bokeh/release/bokeh-mathjax-3.9.1.min.js",
+    ]);
+  });
+
+  it("does not re-register a Panel plot after cleanup", async () => {
+    const animationFrameCallbacks: FrameRequestCallback[] = [];
+    vi.stubGlobal("requestAnimationFrame", (callback: FrameRequestCallback) => {
+      animationFrameCallbacks.push(callback);
+      return animationFrameCallbacks.length;
+    });
+    const view = { model: { document: { clear: vi.fn() } } };
+    (
+      window as typeof window & {
+        Bokeh?: { Panel?: unknown; index?: { get_by_id: () => unknown; delete: () => void } };
+      }
+    ).Bokeh = {
+      Panel: {},
+      index: {
+        get_by_id: () => view,
+        delete: vi.fn(),
+      },
+    };
+    const { Renderer } = installPanelRenderer();
+    const { unmount } = render(
+      <Renderer
+        data={{
+          "text/html": '<div id="panel-root"></div>',
+          [PANEL_EXEC_MIME_TYPE]: "",
+        }}
+        metadata={{ id: "p1011" }}
+        mimeType={PANEL_EXEC_MIME_TYPE}
+      />,
+    );
+
+    await waitFor(() => {
+      expect(
+        (window as typeof window & { PyViz?: { plot_index?: Record<string, unknown> } }).PyViz
+          ?.plot_index?.p1011,
+      ).toBe(view);
+    });
+
+    unmount();
+    expect(
+      (window as typeof window & { PyViz?: { plot_index?: Record<string, unknown> } }).PyViz
+        ?.plot_index?.p1011,
+    ).toBeUndefined();
+
+    for (const callback of animationFrameCallbacks) {
+      callback(0);
+    }
+
+    expect(
+      (window as typeof window & { PyViz?: { plot_index?: Record<string, unknown> } }).PyViz
+        ?.plot_index?.p1011,
+    ).toBeUndefined();
   });
 
   it("copies script attributes for Panel server outputs", async () => {

--- a/src/isolated-renderer/bokeh-renderer.tsx
+++ b/src/isolated-renderer/bokeh-renderer.tsx
@@ -55,7 +55,8 @@ function bokehServerId(metadata?: Record<string, unknown>): string | null {
   return typeof serverId === "string" ? serverId : null;
 }
 
-function extractBokehVersion(script: string): string | null {
+function extractBokehVersion(script: string | null): string | null {
+  if (!script) return null;
   return script.match(/"version"\s*:\s*"([^"]+)"/)?.[1] ?? null;
 }
 
@@ -129,6 +130,29 @@ function appendExecutableScript(container: HTMLElement, code: string): HTMLScrip
   return script;
 }
 
+function copyScript(source: HTMLScriptElement): HTMLScriptElement {
+  const script = document.createElement("script");
+  for (const attr of Array.from(source.attributes)) {
+    script.setAttribute(attr.name, attr.value);
+  }
+  script.textContent = source.textContent ?? "";
+  return script;
+}
+
+function appendHtmlWithExecutableScripts(container: HTMLElement, html: string): HTMLElement {
+  const wrapper = document.createElement("div");
+  wrapper.innerHTML = html;
+  container.appendChild(wrapper);
+
+  const inertScripts = Array.from(wrapper.querySelectorAll("script"));
+  for (const inertScript of inertScripts) {
+    inertScript.replaceWith(copyScript(inertScript));
+  }
+
+  requestHostResize();
+  return wrapper;
+}
+
 function scriptFromServerHtml(html: string): HTMLScriptElement {
   const wrapper = document.createElement("div");
   wrapper.innerHTML = html;
@@ -166,6 +190,8 @@ function BokehRenderer({ data: rawData, metadata, mimeType }: RendererProps) {
       : null;
   const execCode =
     mimeType === BOKEHJS_EXEC_MIME_TYPE ? normalizeText(payload["application/javascript"]) : null;
+  const execHtml =
+    mimeType === BOKEHJS_EXEC_MIME_TYPE && !serverId ? normalizeText(payload["text/html"]) : null;
   const serverHtml =
     mimeType === BOKEHJS_EXEC_MIME_TYPE && serverId ? normalizeText(payload["text/html"]) : null;
 
@@ -174,13 +200,18 @@ function BokehRenderer({ data: rawData, metadata, mimeType }: RendererProps) {
     if (!container) return;
 
     setError(null);
-    let script: HTMLScriptElement | null = null;
+    const appendedNodes: ChildNode[] = [];
     let cancelled = false;
+
+    function trackNode<T extends ChildNode>(node: T): T {
+      appendedNodes.push(node);
+      return node;
+    }
 
     async function renderBokeh() {
       if (mimeType === BOKEHJS_LOAD_MIME_TYPE) {
         if (!loadCode) return;
-        script = appendExecutableScript(container, loadCode);
+        trackNode(appendExecutableScript(container, loadCode));
         return;
       }
 
@@ -189,16 +220,24 @@ function BokehRenderer({ data: rawData, metadata, mimeType }: RendererProps) {
       if (serverId) {
         if (!serverHtml)
           throw new Error("Bokeh server output did not include text/html script data");
-        script = scriptFromServerHtml(serverHtml);
+        const script = scriptFromServerHtml(serverHtml);
         container.appendChild(script);
+        trackNode(script);
         requestHostResize();
         return;
       }
 
-      if (!execCode) throw new Error("Bokeh output did not include application/javascript data");
-      await ensureBokeh(extractBokehVersion(execCode));
+      if (!execHtml && !execCode) {
+        throw new Error("Bokeh output did not include text/html or application/javascript data");
+      }
+      await ensureBokeh(extractBokehVersion(execCode ?? execHtml));
       if (cancelled) return;
-      script = appendExecutableScript(container, execCode);
+      if (execHtml) {
+        trackNode(appendHtmlWithExecutableScripts(container, execHtml));
+      }
+      if (execCode) {
+        trackNode(appendExecutableScript(container, execCode));
+      }
     }
 
     void renderBokeh().catch((renderError) => {
@@ -209,12 +248,14 @@ function BokehRenderer({ data: rawData, metadata, mimeType }: RendererProps) {
 
     return () => {
       cancelled = true;
-      if (script?.parentElement === container) {
-        container.removeChild(script);
+      for (const node of appendedNodes) {
+        if (node.parentNode === container) {
+          container.removeChild(node);
+        }
       }
       cleanupBokehDocument(documentId);
     };
-  }, [documentId, execCode, loadCode, mimeType, serverHtml, serverId]);
+  }, [documentId, execCode, execHtml, loadCode, mimeType, serverHtml, serverId]);
 
   return (
     <div data-slot="bokeh-output" ref={containerRef}>

--- a/src/isolated-renderer/panel-renderer.tsx
+++ b/src/isolated-renderer/panel-renderer.tsx
@@ -1,0 +1,273 @@
+/**
+ * Panel / PyViz Renderer Plugin
+ *
+ * Panel's notebook protocol emits HoloViews/PyViz marker MIMEs alongside
+ * text/html and sometimes application/javascript. The exec HTML contains
+ * inert script tags when inserted through React/innerHTML, so this renderer
+ * reparses those tags into executable script elements inside the sandbox.
+ */
+
+import { useEffect, useRef, useState, type ComponentType } from "react";
+import type { RendererProps } from "@/lib/renderer-registry";
+import { PANEL_EXEC_MIME_TYPE, PANEL_LOAD_MIME_TYPE } from "@/components/outputs/panel-mime";
+import { measureDocumentHeight } from "./layout-measure";
+
+type PanelPayload = {
+  [PANEL_LOAD_MIME_TYPE]?: unknown;
+  [PANEL_EXEC_MIME_TYPE]?: unknown;
+  "application/javascript"?: unknown;
+  "text/html"?: unknown;
+};
+
+type PyVizGlobal = {
+  comms?: Record<string, unknown>;
+  comm_status?: Record<string, unknown>;
+  kernels?: Record<string, unknown>;
+  receivers?: Record<string, unknown>;
+  plot_index?: Record<string, unknown>;
+};
+
+type BokehView = {
+  model?: {
+    document?: {
+      clear?: () => void;
+    };
+  };
+};
+
+type BokehIndex = Record<string, unknown> & {
+  get_by_id?: (id: string) => BokehView | null;
+  delete?: (view: unknown) => void;
+};
+
+type PanelWindow = Window &
+  typeof globalThis & {
+    Bokeh?: {
+      index?: BokehIndex;
+    };
+    PyViz?: PyVizGlobal | HTMLElement;
+  };
+
+function panelWindow(): PanelWindow {
+  return window as PanelWindow;
+}
+
+function normalizeText(value: unknown): string | null {
+  if (typeof value === "string") return value;
+  if (Array.isArray(value)) return value.map(String).join("");
+  return null;
+}
+
+function asPanelPayload(value: unknown): PanelPayload {
+  return value !== null && typeof value === "object" ? (value as PanelPayload) : {};
+}
+
+function panelDocumentId(metadata?: Record<string, unknown>): string | null {
+  const id = metadata?.id;
+  return typeof id === "string" ? id : null;
+}
+
+function panelServerId(metadata?: Record<string, unknown>): string | null {
+  const serverId = metadata?.server_id;
+  return typeof serverId === "string" ? serverId : null;
+}
+
+function ensurePyViz(): PyVizGlobal {
+  const target = panelWindow();
+  if (!target.PyViz || target.PyViz instanceof HTMLElement) {
+    target.PyViz = {};
+  }
+  const pyviz = target.PyViz;
+  pyviz.comms ??= {};
+  pyviz.comm_status ??= {};
+  pyviz.kernels ??= {};
+  pyviz.receivers ??= {};
+  pyviz.plot_index ??= {};
+  return pyviz;
+}
+
+function requestHostResize(): void {
+  requestAnimationFrame(() => {
+    requestAnimationFrame(() => {
+      window.parent.postMessage(
+        {
+          type: "resize",
+          payload: { height: measureDocumentHeight() },
+        },
+        "*",
+      );
+    });
+  });
+}
+
+function copyScript(source: HTMLScriptElement): HTMLScriptElement {
+  const script = document.createElement("script");
+  for (const attr of Array.from(source.attributes)) {
+    script.setAttribute(attr.name, attr.value);
+  }
+  script.textContent = source.textContent ?? "";
+  return script;
+}
+
+function appendExecutableScript(container: HTMLElement, code: string): HTMLScriptElement {
+  const script = document.createElement("script");
+  script.textContent = code;
+  container.appendChild(script);
+  requestHostResize();
+  return script;
+}
+
+function appendHtmlWithExecutableScripts(container: HTMLElement, html: string): HTMLElement {
+  const wrapper = document.createElement("div");
+  wrapper.innerHTML = html;
+  container.appendChild(wrapper);
+
+  const inertScripts = Array.from(wrapper.querySelectorAll("script"));
+  for (const inertScript of inertScripts) {
+    inertScript.replaceWith(copyScript(inertScript));
+  }
+
+  requestHostResize();
+  return wrapper;
+}
+
+function scriptFromServerHtml(html: string): HTMLScriptElement {
+  const wrapper = document.createElement("div");
+  wrapper.innerHTML = html;
+  const source = wrapper.querySelector("script");
+  if (!source) {
+    const script = document.createElement("script");
+    script.textContent = html;
+    return script;
+  }
+  return copyScript(source);
+}
+
+function bokehViewForDocument(documentId: string): BokehView | null {
+  const index = panelWindow().Bokeh?.index;
+  if (!index) return null;
+  const byId = index.get_by_id?.(documentId);
+  if (byId) return byId;
+  const legacy = index[documentId];
+  return legacy && typeof legacy === "object" ? (legacy as BokehView) : null;
+}
+
+function rememberPanelPlot(documentId: string | null): void {
+  if (!documentId) return;
+  const view = bokehViewForDocument(documentId);
+  if (view) {
+    ensurePyViz().plot_index![documentId] = view;
+  }
+}
+
+function cleanupPanelDocument(documentId: string | null): void {
+  if (!documentId) return;
+  const target = panelWindow();
+  const pyviz = target.PyViz instanceof HTMLElement ? undefined : target.PyViz;
+  delete pyviz?.kernels?.[documentId];
+  delete pyviz?.plot_index?.[documentId];
+
+  const index = target.Bokeh?.index;
+  const view = bokehViewForDocument(documentId);
+  view?.model?.document?.clear?.();
+  if (view) index?.delete?.(view);
+  if (index && Object.prototype.hasOwnProperty.call(index, documentId)) {
+    delete index[documentId];
+  }
+}
+
+function PanelRenderer({ data: rawData, metadata, mimeType }: RendererProps) {
+  const containerRef = useRef<HTMLDivElement>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    const container = containerRef.current;
+    if (!container) return;
+
+    setError(null);
+    const payload = asPanelPayload(rawData);
+    const documentId = panelDocumentId(metadata);
+    const appendedNodes: ChildNode[] = [];
+    let cancelled = false;
+
+    function trackNode<T extends ChildNode>(node: T): T {
+      appendedNodes.push(node);
+      return node;
+    }
+
+    async function renderPanel() {
+      if (mimeType === PANEL_LOAD_MIME_TYPE) {
+        const code =
+          normalizeText(payload[PANEL_LOAD_MIME_TYPE]) ??
+          normalizeText(payload["application/javascript"]);
+        if (!code) return;
+        trackNode(appendExecutableScript(container, code));
+        return;
+      }
+
+      if (mimeType !== PANEL_EXEC_MIME_TYPE) return;
+
+      ensurePyViz();
+      const serverId = panelServerId(metadata);
+      if (serverId) {
+        const html = normalizeText(payload["text/html"]);
+        if (!html) throw new Error("Panel server output did not include text/html script data");
+        const script = scriptFromServerHtml(html);
+        container.appendChild(script);
+        trackNode(script);
+        requestHostResize();
+        return;
+      }
+
+      const html = normalizeText(payload["text/html"]);
+      const code = normalizeText(payload["application/javascript"]);
+      if (!html && !code) {
+        throw new Error("Panel output did not include text/html or application/javascript data");
+      }
+
+      if (html) {
+        trackNode(appendHtmlWithExecutableScripts(container, html));
+      }
+      if (code) {
+        trackNode(appendExecutableScript(container, code));
+      }
+
+      rememberPanelPlot(documentId);
+      requestAnimationFrame(() => {
+        rememberPanelPlot(documentId);
+      });
+    }
+
+    void renderPanel().catch((renderError) => {
+      if (!cancelled) {
+        setError(renderError instanceof Error ? renderError.message : String(renderError));
+      }
+    });
+
+    return () => {
+      cancelled = true;
+      for (const node of appendedNodes) {
+        if (node.parentNode === container) {
+          container.removeChild(node);
+        }
+      }
+      cleanupPanelDocument(documentId);
+    };
+  }, [rawData, metadata, mimeType]);
+
+  return (
+    <div data-slot="panel-output" ref={containerRef}>
+      {error ? (
+        <pre className="whitespace-pre-wrap rounded border border-destructive/30 bg-destructive/10 p-3 text-sm text-destructive">
+          {error}
+        </pre>
+      ) : null}
+    </div>
+  );
+}
+
+export function install(ctx: {
+  register: (mimeTypes: string[], component: ComponentType<RendererProps>) => void;
+}) {
+  ctx.register([PANEL_LOAD_MIME_TYPE, PANEL_EXEC_MIME_TYPE], PanelRenderer);
+}

--- a/src/isolated-renderer/panel-renderer.tsx
+++ b/src/isolated-renderer/panel-renderer.tsx
@@ -43,10 +43,21 @@ type BokehIndex = Record<string, unknown> & {
 type PanelWindow = Window &
   typeof globalThis & {
     Bokeh?: {
+      Panel?: unknown;
+      version?: string;
+      versions?: {
+        get?: (version: string) => unknown;
+        has?: (version: string) => boolean;
+      };
       index?: BokehIndex;
     };
     PyViz?: PyVizGlobal | HTMLElement;
+    __nteractBokehLoadPromise__?: Promise<void>;
+    __nteractPanelLoadPromises__?: Record<string, Promise<void>>;
   };
+
+const BOKEH_RESOURCE_SUFFIXES = ["", "-gl", "-widgets", "-tables", "-mathjax"];
+const PANEL_DIST_BASE_RE = /https:\/\/cdn\.holoviz\.org\/panel\/[^/]+\/dist\//;
 
 function panelWindow(): PanelWindow {
   return window as PanelWindow;
@@ -70,6 +81,20 @@ function panelDocumentId(metadata?: Record<string, unknown>): string | null {
 function panelServerId(metadata?: Record<string, unknown>): string | null {
   const serverId = metadata?.server_id;
   return typeof serverId === "string" ? serverId : null;
+}
+
+function extractBokehVersion(script: string | null): string | null {
+  if (!script) return null;
+  return script.match(/"version"\s*:\s*"([^"]+)"/)?.[1] ?? null;
+}
+
+function normalizeBokehVersion(version: string | null): string | null {
+  return version?.replace("rc", "-rc.").replace(".dev", "-dev.") ?? null;
+}
+
+function extractPanelDistBase(html: string | null): string | null {
+  if (!html) return null;
+  return html.match(PANEL_DIST_BASE_RE)?.[0] ?? null;
 }
 
 function ensurePyViz(): PyVizGlobal {
@@ -129,6 +154,85 @@ function appendHtmlWithExecutableScripts(container: HTMLElement, html: string): 
 
   requestHostResize();
   return wrapper;
+}
+
+function loadScript(src: string, required: boolean): Promise<void> {
+  return new Promise((resolve, reject) => {
+    const existing = document.querySelector(`script[data-nteract-panel-src="${src}"]`);
+    if (existing) {
+      resolve();
+      return;
+    }
+
+    const script = document.createElement("script");
+    script.async = false;
+    script.dataset.nteractPanelSrc = src;
+    script.onload = () => resolve();
+    script.onerror = () => {
+      const error = new Error(`Failed to load Panel/BokehJS resource: ${src}`);
+      if (required) reject(error);
+      else {
+        console.warn(error.message);
+        resolve();
+      }
+    };
+    script.src = src;
+    document.head.appendChild(script);
+  });
+}
+
+async function ensureBokeh(version: string | null): Promise<void> {
+  const target = panelWindow();
+  const normalizedVersion = normalizeBokehVersion(version);
+  const bokeh = target.Bokeh;
+  if (
+    bokeh !== undefined &&
+    (!normalizedVersion ||
+      bokeh.version === normalizedVersion ||
+      bokeh.versions?.has?.(normalizedVersion))
+  ) {
+    return;
+  }
+  if (target.__nteractBokehLoadPromise__) return target.__nteractBokehLoadPromise__;
+  if (!normalizedVersion) {
+    throw new Error("BokehJS is missing and no Bokeh document version was found");
+  }
+
+  target.__nteractBokehLoadPromise__ = (async () => {
+    for (const [index, suffix] of BOKEH_RESOURCE_SUFFIXES.entries()) {
+      const src = `https://cdn.bokeh.org/bokeh/release/bokeh${suffix}-${normalizedVersion}.min.js`;
+      await loadScript(src, index === 0);
+    }
+    if (panelWindow().Bokeh === undefined) {
+      throw new Error(`BokehJS ${normalizedVersion} loaded without defining window.Bokeh`);
+    }
+  })().catch((error) => {
+    target.__nteractBokehLoadPromise__ = undefined;
+    throw error;
+  });
+
+  return target.__nteractBokehLoadPromise__;
+}
+
+async function ensurePanelRuntime(html: string | null, code: string | null): Promise<void> {
+  const target = panelWindow();
+  const version = extractBokehVersion(code ?? html);
+  await ensureBokeh(version);
+
+  if (target.Bokeh?.Panel !== undefined) return;
+
+  const panelDistBase = extractPanelDistBase(html);
+  if (!panelDistBase) {
+    throw new Error("Panel output did not include a Panel CDN resource URL");
+  }
+
+  target.__nteractPanelLoadPromises__ ??= {};
+  const panelSrc = `${panelDistBase}panel.min.js`;
+  target.__nteractPanelLoadPromises__[panelSrc] ??= loadScript(panelSrc, true).catch((error) => {
+    delete target.__nteractPanelLoadPromises__?.[panelSrc];
+    throw error;
+  });
+  await target.__nteractPanelLoadPromises__[panelSrc];
 }
 
 function scriptFromServerHtml(html: string): HTMLScriptElement {
@@ -225,8 +329,23 @@ function PanelRenderer({ data: rawData, metadata, mimeType }: RendererProps) {
         throw new Error("Panel output did not include text/html or application/javascript data");
       }
 
+      if (!documentId) {
+        if (html) {
+          trackNode(appendHtmlWithExecutableScripts(container, html));
+        }
+        if (code) {
+          trackNode(appendExecutableScript(container, code));
+        }
+        return;
+      }
+
       if (html) {
+        await ensurePanelRuntime(html, code);
+        if (cancelled) return;
         trackNode(appendHtmlWithExecutableScripts(container, html));
+      } else if (code) {
+        await ensurePanelRuntime(null, code);
+        if (cancelled) return;
       }
       if (code) {
         trackNode(appendExecutableScript(container, code));

--- a/src/isolated-renderer/panel-renderer.tsx
+++ b/src/isolated-renderer/panel-renderer.tsx
@@ -221,10 +221,8 @@ async function ensurePanelRuntime(html: string | null, code: string | null): Pro
 
   if (target.Bokeh?.Panel !== undefined) return;
 
-  const panelDistBase = extractPanelDistBase(html);
-  if (!panelDistBase) {
-    throw new Error("Panel output did not include a Panel CDN resource URL");
-  }
+  const panelDistBase = extractPanelDistBase(html ?? code);
+  if (!panelDistBase) return;
 
   target.__nteractPanelLoadPromises__ ??= {};
   const panelSrc = `${panelDistBase}panel.min.js`;
@@ -353,7 +351,7 @@ function PanelRenderer({ data: rawData, metadata, mimeType }: RendererProps) {
 
       rememberPanelPlot(documentId);
       requestAnimationFrame(() => {
-        rememberPanelPlot(documentId);
+        if (!cancelled) rememberPanelPlot(documentId);
       });
     }
 

--- a/src/isolated-renderer/widget-bridge-client.ts
+++ b/src/isolated-renderer/widget-bridge-client.ts
@@ -137,13 +137,14 @@ export function createWidgetBridgeClient(transport: JsonRpcTransport): WidgetBri
   });
 
   transport.onNotification(NTERACT_COMM_OPEN, async (params) => {
-    const { commId, state, bufferPaths } = params as {
+    const { commId, targetName, state, bufferPaths } = params as {
       commId: string;
+      targetName?: string;
       state: Record<string, unknown>;
       bufferPaths?: string[][];
     };
     await resolveBlobUrlsInPlace(state, bufferPaths);
-    store.createModel(commId, state, bufferPaths);
+    store.createModel(commId, state, bufferPaths, targetName);
   });
 
   transport.onNotification(NTERACT_COMM_MSG, async (params) => {
@@ -171,6 +172,7 @@ export function createWidgetBridgeClient(transport: JsonRpcTransport): WidgetBri
     const { models } = params as {
       models: Array<{
         commId: string;
+        targetName?: string;
         state: Record<string, unknown>;
         bufferPaths?: string[][];
       }>;
@@ -178,7 +180,7 @@ export function createWidgetBridgeClient(transport: JsonRpcTransport): WidgetBri
     await Promise.all(
       models.map(async (model) => {
         await resolveBlobUrlsInPlace(model.state, model.bufferPaths);
-        store.createModel(model.commId, model.state, model.bufferPaths);
+        store.createModel(model.commId, model.state, model.bufferPaths, model.targetName);
       }),
     );
   });


### PR DESCRIPTION
## Summary

- Add a Panel/PyViz isolated renderer for HoloViews load/exec MIME bundles.
- Preserve Panel sibling `text/html` and `application/javascript` payloads through output selection, runtime WASM narrowing, and daemon output manifests.
- Make Bokeh and Panel exec frames self-contained by executing sibling HTML scripts and deriving Panel/BokehJS resources from Panel's notebook bundle when the widget is displayed in a later cell.
- Treat id-less Panel exec bundles from `pn.extension()` as quiet auxiliary setup output instead of a failed render root.
- Wire `panel.js` into renderer plugin generation, daemon embedded assets, MCP app assets, and Vite virtual modules.
- Preserve comm `targetName` through the widget store and iframe bridge as groundwork for a future generic PyViz comm proxy.

## Notes

- This fixes static/notebook Panel rendering by executing Panel's embedded notebook HTML scripts inside the sandboxed iframe.
- Browser smoke now covers `pn.extension()` in one cell and a `pn.widgets.FloatSlider` display in a later cell.
- This does not fake a full PyViz kernel comm manager; Python-backed Panel callbacks still need a deliberate generic comm bridge.

## Verification

- `cargo xtask artifacts ensure sift,renderer`
- `pnpm test:run src/isolated-renderer/__tests__/panel-renderer.test.tsx src/components/isolated/__tests__/output-payloads.test.ts src/components/isolated/__tests__/output-lane-policy.test.ts src/components/isolated/__tests__/renderer-plugin-info.test.ts src/components/cell/__tests__/OutputArea.test.tsx src/components/widgets/__tests__/widget-store.test.ts src/components/widgets/__tests__/comm-changes-store-bridge.test.ts src/components/isolated/__tests__/comm-bridge-manager.test.ts`
- `cargo test -p runtimed panel_display_data_preserves_exec_marker_mime -- --nocapture`
- `cargo test -p runtimed-wasm panel_narrowing_keeps_marker_javascript_and_html_bundle -- --nocapture`
- `cargo test -p runtimed embedded_plugins_match_assets_dir -- --nocapture`
- `cargo xtask artifacts verify renderer`
- Browser smoke at `http://localhost:8784/?environment_mode=notebook&working_dir=%2Ftmp%2Fnteract-panel-smoke.baaYg5`: ran `pn.extension()` in cell 1, then `pn.widgets.FloatSlider(name="nteract-panel-separate", start=0, end=10, value=4)` in cell 2; iframe rendered `nteract-panel-separate: 4` with a slider role and no Panel renderer/import error.
- `pnpm test:run src/isolated-renderer/__tests__/bokeh-renderer.test.tsx src/isolated-renderer/__tests__/panel-renderer.test.tsx src/components/isolated/__tests__/output-payloads.test.ts src/components/isolated/__tests__/output-lane-policy.test.ts src/components/cell/__tests__/OutputArea.test.tsx`
- `cargo xtask lint --fix`
- `git diff --check`

## Follow-up Before Ready

- Let GitHub CI complete.
