### PR TITLE
ci(pullfrog): harden review workflow output

### DIFF
--- a/.github/workflows/pullfrog.yml
+++ b/.github/workflows/pullfrog.yml
@@ -38,22 +38,77 @@ jobs:
           push: disabled
           prompt: |
             Review this repository as a senior nteract code reviewer. Stay
-            read-only. Focus on concrete bugs, behavioral regressions, data
-            loss, security issues, concurrency hazards, broken tests, and
-            missing tests that could allow the diff to regress.
+            read-only. Inspect the diff first, then the nearest owning code,
+            tests, AGENTS.md files, ADRs/plans, and recent patterns when they
+            are relevant. Be terse, adversarial, and evidence-backed.
 
-            Do not report style-only comments. Do not invent findings. Every
-            finding must identify a concrete failure mode, why the diff
-            introduced or exposed it, and the affected file and line when
-            possible.
+            Primary goal:
+            - Find concrete bugs, behavioral regressions, data loss, security
+              issues, concurrency hazards, broken tests, and missing tests that
+              could allow the diff to regress.
+            - Also report repo-invariant architecture/style nits when they
+              protect maintainability or product behavior. Examples: state
+              being owned by a React component/app hook when it belongs in a
+              shared projection/store, packages/runtimed, or runtimed-wasm;
+              app-local code in apps/ duplicating a shared surface that belongs
+              under src/; direct host imports leaking into shared code; stale
+              generated artifacts; or stale docs/agent guidance that contradicts
+              current authority boundaries.
+
+            Suppress comments that are only subjective preference, formatting,
+            naming, Tailwind ordering, or "could be cleaner" with no concrete
+            owner, invariant, user-visible behavior, or test gap. Group repeated
+            instances under one finding. Prefer at most 12 findings.
+
+            nteract review checklist:
+            - State ownership: Notebook edits flow through NotebookDoc/WASM/CRDT
+              paths. Runtime lifecycle, queue, outputs, env, trust, execution
+              snapshots, and widget topology are daemon/runtime-owned
+              RuntimeStateDoc facts. Mutable widget values belong in CommsDoc.
+              React/app stores should be projections or local UI policy, not
+              durable sources of truth.
+            - Shared surfaces: reusable notebook UI, output rendering, identity
+              helpers, and headless state/projection logic belong under
+              src/components/**, src/lib/**, or packages/runtimed/**. Keep
+              apps/notebook/** and apps/notebook-cloud/** focused on host policy,
+              routes, shell wiring, and side effects.
+            - Host boundaries: shared libraries must stay free of Tauri,
+              Cloudflare, OIDC, D1/R2/Durable Object, ACL, credential, and daemon
+              launch policy. Host adapters own those effects.
+            - Authority boundaries: review every write path, including request
+              RPCs, room admission, materializer/checkpoint paths, WASM handlers,
+              broadcasts, persistence, and tests. Viewer and runtime_peer roles
+              must not gain unintended writes; client plumbing alone is not
+              enough evidence for hosted authority changes.
+            - Protocol changes: wire protocol, Rust handling, WASM bindings,
+              packages/runtimed types/stores, recovery, and tests should move
+              together.
+            - Outputs/widgets: RuntimeStateDoc is the durable output/runtime
+              record; output/control ordering must survive stdout floods and
+              display churn; MIME/blob/renderer plugin changes need artifact or
+              browser-backed evidence when possible.
+            - Async projection work: reject stale fire-and-forget updates that
+              can resurrect removed/replaced state without reset epochs,
+              generations, cancellation, or equivalent guards.
+            - Tests: require focused tests at the changed boundary. Treat deleted
+              tests as suspicious unless the behavior was removed and replacement
+              coverage exists.
 
             Verdict rules:
             - "✅" means the review completed and found no actionable issues.
             - "⚠️" means the review found non-blocking risk, missing coverage,
-              uncertainty, or a follow-up the human should consider.
+              uncertainty, or a repo-invariant architecture/style nit the human
+              should consider.
             - "🚨" means the review found a blocker/high-confidence regression,
-              security/data-loss risk, or the review could not be trusted
-              because of infrastructure/tooling uncertainty.
+              security/data-loss/authority risk, durable runtime/output
+              corruption risk, or the review could not be trusted because of
+              infrastructure/tooling uncertainty.
+
+            Every finding must name a concrete failure mode or invariant drift,
+            explain why the diff introduced or exposed it, identify the affected
+            file and line when possible, and suggest the smallest useful fix.
+            Use severity "nit" for non-blocking architecture/style findings.
+            Do not invent findings.
 
             Return the structured output by calling Pullfrog's set_output tool.
             The output must match the provided JSON schema exactly. Do not add
@@ -79,12 +134,14 @@ jobs:
                 },
                 "findings": {
                   "type": "array",
-                  "description": "Actionable findings only. Empty when verdict is ✅.",
+                  "maxItems": 12,
+                  "description": "Actionable findings only. Empty when verdict is ✅. Group repeated instances under one finding.",
                   "items": {
                     "type": "object",
                     "additionalProperties": false,
                     "required": [
                       "severity",
+                      "category",
                       "file",
                       "line",
                       "title",
@@ -95,7 +152,24 @@ jobs:
                     "properties": {
                       "severity": {
                         "type": "string",
-                        "enum": ["blocker", "high", "medium", "low"]
+                        "enum": ["blocker", "high", "medium", "low", "nit"]
+                      },
+                      "category": {
+                        "type": "string",
+                        "enum": [
+                          "correctness",
+                          "state_ownership",
+                          "shared_surface",
+                          "host_boundary",
+                          "authority_boundary",
+                          "protocol_sync",
+                          "output_widget_runtime",
+                          "async_ordering",
+                          "tests",
+                          "generated_artifact",
+                          "style_maintainability",
+                          "infra"
+                        ]
                       },
                       "file": {
                         "type": ["string", "null"],
@@ -110,7 +184,7 @@ jobs:
                       },
                       "evidence": {
                         "type": "string",
-                        "description": "Why this is a real bug, regression risk, or review blocker."
+                        "description": "Why this is a real bug, regression risk, review blocker, or repo-invariant architecture/style drift."
                       },
                       "suggested_fix": {
                         "type": ["string", "null"]
@@ -144,8 +218,9 @@ jobs:
               const location = finding.file
                 ? `${finding.file}${finding.line === null ? "" : `:${finding.line}`}`
                 : "workflow";
+              const category = finding.category ? ` [${finding.category}]` : "";
               lines.push(
-                `- ${finding.severity.toUpperCase()} ${location} - ${finding.title}`,
+                `- ${finding.severity.toUpperCase()}${category} ${location} - ${finding.title}`,
                 `  Evidence: ${finding.evidence}`,
               );
               if (finding.suggested_fix) {

--- a/.github/workflows/pullfrog.yml
+++ b/.github/workflows/pullfrog.yml
@@ -13,7 +13,7 @@ on:
         description: Run name
       model_id:
         type: string
-        description: Bedrock model or inference profile ID
+        description: Bedrock model or inference profile ID for OpenCode
         default: us.anthropic.claude-sonnet-4-6
 
 permissions:
@@ -125,6 +125,7 @@ jobs:
               }
             }
         env:
+          PULLFROG_AGENT: opencode
           AWS_REGION: us-east-1
           BEDROCK_MODEL_ID: ${{ inputs.model_id || 'us.anthropic.claude-sonnet-4-6' }}
       - name: Render review result

--- a/.github/workflows/pullfrog.yml
+++ b/.github/workflows/pullfrog.yml
@@ -6,10 +6,15 @@ on:
     inputs:
       prompt:
         type: string
-        description: Agent prompt
+        description: Review prompt
+        required: true
       name:
         type: string
         description: Run name
+      model_id:
+        type: string
+        description: Bedrock model or inference profile ID
+        default: us.anthropic.claude-sonnet-4-6
 
 permissions:
   contents: read
@@ -26,10 +31,134 @@ jobs:
         with:
           fetch-depth: 1
       - name: Run agent
+        id: review
         uses: pullfrog/pullfrog@v0
         with:
-          prompt: ${{ inputs.prompt }}
+          model: bedrock/byok
+          push: disabled
+          prompt: |
+            Review this repository as a senior nteract code reviewer. Stay
+            read-only. Focus on concrete bugs, behavioral regressions, data
+            loss, security issues, concurrency hazards, broken tests, and
+            missing tests that could allow the diff to regress.
+
+            Do not report style-only comments. Do not invent findings. Every
+            finding must identify a concrete failure mode, why the diff
+            introduced or exposed it, and the affected file and line when
+            possible.
+
+            Verdict rules:
+            - "✅" means the review completed and found no actionable issues.
+            - "⚠️" means the review found non-blocking risk, missing coverage,
+              uncertainty, or a follow-up the human should consider.
+            - "🚨" means the review found a blocker/high-confidence regression,
+              security/data-loss risk, or the review could not be trusted
+              because of infrastructure/tooling uncertainty.
+
+            Return the structured output by calling Pullfrog's set_output tool.
+            The output must match the provided JSON schema exactly. Do not add
+            markdown, prose, or extra keys outside the schema.
+
+            Caller prompt:
+            ${{ inputs.prompt }}
+          output_schema: |
+            {
+              "$schema": "http://json-schema.org/draft-07/schema#",
+              "type": "object",
+              "additionalProperties": false,
+              "required": ["verdict", "summary", "findings"],
+              "properties": {
+                "verdict": {
+                  "type": "string",
+                  "enum": ["✅", "⚠️", "🚨"],
+                  "description": "Overall review result."
+                },
+                "summary": {
+                  "type": "string",
+                  "description": "One concise sentence. Say there are no actionable findings when verdict is ✅."
+                },
+                "findings": {
+                  "type": "array",
+                  "description": "Actionable findings only. Empty when verdict is ✅.",
+                  "items": {
+                    "type": "object",
+                    "additionalProperties": false,
+                    "required": [
+                      "severity",
+                      "file",
+                      "line",
+                      "title",
+                      "evidence",
+                      "suggested_fix",
+                      "confidence"
+                    ],
+                    "properties": {
+                      "severity": {
+                        "type": "string",
+                        "enum": ["blocker", "high", "medium", "low"]
+                      },
+                      "file": {
+                        "type": ["string", "null"],
+                        "description": "Repo-relative file path, or null for infrastructure/tooling findings."
+                      },
+                      "line": {
+                        "type": ["integer", "null"],
+                        "description": "Changed or relevant line number, or null when not applicable."
+                      },
+                      "title": {
+                        "type": "string"
+                      },
+                      "evidence": {
+                        "type": "string",
+                        "description": "Why this is a real bug, regression risk, or review blocker."
+                      },
+                      "suggested_fix": {
+                        "type": ["string", "null"]
+                      },
+                      "confidence": {
+                        "type": "string",
+                        "enum": ["high", "medium", "low"]
+                      }
+                    }
+                  }
+                }
+              }
+            }
         env:
-          PULLFROG_AGENT: opencode
           AWS_REGION: us-east-1
-          BEDROCK_MODEL_ID: zai.glm-5
+          BEDROCK_MODEL_ID: ${{ inputs.model_id || 'us.anthropic.claude-sonnet-4-6' }}
+      - name: Render review result
+        if: ${{ always() && steps.review.outputs.result != '' }}
+        env:
+          REVIEW_RESULT: ${{ steps.review.outputs.result }}
+        run: |
+          node <<'NODE'
+          const result = JSON.parse(process.env.REVIEW_RESULT);
+          const findings = Array.isArray(result.findings) ? result.findings : [];
+          const lines = [`${result.verdict} ${result.summary}`];
+
+          if (findings.length > 0) {
+            lines.push("", "Findings:");
+            for (const finding of findings) {
+              const location = finding.file
+                ? `${finding.file}${finding.line === null ? "" : `:${finding.line}`}`
+                : "workflow";
+              lines.push(
+                `- ${finding.severity.toUpperCase()} ${location} - ${finding.title}`,
+                `  Evidence: ${finding.evidence}`,
+              );
+              if (finding.suggested_fix) {
+                lines.push(`  Fix: ${finding.suggested_fix}`);
+              }
+              lines.push(`  Confidence: ${finding.confidence}`);
+            }
+          }
+
+          const summary = `${lines.join("\n")}\n`;
+          console.log(summary);
+          require("node:fs").appendFileSync(process.env.GITHUB_STEP_SUMMARY, summary);
+
+          if (result.verdict === "🚨") {
+            process.exitCode = 1;
+          }
+          NODE


### PR DESCRIPTION
## Summary

- Pin Pullfrog review runs through `bedrock/byok` with a smoke-tested Sonnet 4.6 Bedrock inference profile default.
- Force Pullfrog to use OpenCode while still routing model calls through Bedrock.
- Require structured review output with `✅`, `⚠️`, or `🚨` plus categorized findings, then render that compact result into the Actions summary.
- Calibrate the prompt toward nteract-specific review lanes: state ownership, shared surfaces, host and authority boundaries, protocol sync, output/widget runtime behavior, async ordering, generated artifacts, tests, and invariant-backed style nits.

## Verification

- `aws bedrock-runtime converse --region us-east-1 --model-id zai.glm-5 ...`
- `aws bedrock-runtime converse --region us-east-1 --model-id us.anthropic.claude-sonnet-4-6 ...`
- `aws bedrock-runtime converse --region us-east-1 --model-id us.anthropic.claude-opus-4-8 ...`
- `ruby -ryaml -rjson -e '...'`
- renderer smoke test with `node`
- `actionlint .github/workflows/pullfrog.yml`
- `git diff --check`
- `cargo xtask lint --fix`

## Notes

- The PR remains draft until GitHub CI and any reviewer pass complete.
