### PR TITLE
fix(notebook-cloud): compose the package env summary outside the summary panel

### DIFF
--- a/apps/notebook-cloud/viewer/notebook-viewer.tsx
+++ b/apps/notebook-cloud/viewer/notebook-viewer.tsx
@@ -1726,20 +1726,20 @@ export function NotebookViewer({
         ) : undefined
       }
       packagesPanel={
-        <NotebookPackageSummaryPanel
-          packages={notebookViewModel.packages}
-          readOnly={!shellCapabilities.canManagePackages}
-          header={
-            shouldShowPackageEnvironmentSummary ? (
-              <EnvironmentSummary
-                capabilities={shellCapabilities}
-                packages={notebookViewModel.packages}
-                showPackageDetails={false}
-                className="cloud-package-summary-header"
-              />
-            ) : undefined
-          }
-        />
+        <>
+          {shouldShowPackageEnvironmentSummary ? (
+            <EnvironmentSummary
+              capabilities={shellCapabilities}
+              packages={notebookViewModel.packages}
+              showPackageDetails={false}
+              className="cloud-package-summary-header"
+            />
+          ) : null}
+          <NotebookPackageSummaryPanel
+            packages={notebookViewModel.packages}
+            readOnly={!shellCapabilities.canManagePackages}
+          />
+        </>
       }
       onActivePanelChange={setActiveNotebookRailPanel}
       onCollapsedChange={setNotebookRailCollapsed}


### PR DESCRIPTION
#3747 ("full shell composition") removed the `header` prop from `EnvironmentPackageSummaryPanel` (and `NotebookPackageSummaryPanel`, which extends it), making the panel just the package list. It updated the elements examples but not the cloud viewer, which still passed `header={<EnvironmentSummary/>}`. That broke the `apps/notebook-cloud` typecheck (`Property 'header' does not exist on type 'NotebookPackageSummaryPanelProps'`).

This composes the `EnvironmentSummary` above the panel in the same `packagesPanel` slot instead of through the removed prop. It restores the cloud's env-summary header display and matches #3747's pattern, where the header is composed outside the panel rather than injected into it.

## Verification

`pnpm --dir apps/notebook-cloud typecheck` clean; `vp check` clean.
