### PR TITLE
feat(comments): rendered-markdown right-click menu and icon affordance

### DIFF
--- a/apps/notebook/src/components/MarkdownCell.tsx
+++ b/apps/notebook/src/components/MarkdownCell.tsx
@@ -1,5 +1,5 @@
 import type { EditorView, KeyBinding } from "@codemirror/view";
-import { Check, Pencil } from "lucide-react";
+import { Check, MessageSquarePlus, Pencil } from "lucide-react";
 import {
   memo,
   type MouseEvent,
@@ -69,6 +69,7 @@ import {
 import { sourceCommentExtension } from "../lib/source-comment-extension";
 import type { MarkdownCell as MarkdownCellType } from "../types";
 import { CellPresenceIndicators } from "./cell/CellPresenceIndicators";
+import { RenderedMarkdownContextMenu } from "./RenderedMarkdownContextMenu";
 
 const handleIframeError = (err: { message: string; stack?: string }) =>
   logger.error("[MarkdownCell] iframe error:", err);
@@ -78,6 +79,7 @@ const MARKDOWN_EDITOR_CONTENT_ATTRIBUTES = {
   autocorrect: "on",
   spellcheck: "true",
 } as const;
+const MARKDOWN_RENDERED_COMMENT_BUTTON_SIZE = 24;
 const MARKDOWN_PREVIEW_MIN_HEIGHT = 24;
 const MARKDOWN_PREVIEW_MAX_INITIAL_HEIGHT = 720;
 
@@ -486,7 +488,7 @@ export const MarkdownCell = memo(function MarkdownCell({
       anchor,
       left: Math.min(
         Math.max(0, rangeRect.right - rootRect.left + 6),
-        Math.max(0, rootRect.width - 84),
+        Math.max(0, rootRect.width - MARKDOWN_RENDERED_COMMENT_BUTTON_SIZE),
       ),
       top: Math.max(0, rangeRect.top - rootRect.top - 32),
     });
@@ -669,7 +671,7 @@ export const MarkdownCell = memo(function MarkdownCell({
     const frame = frameRef.current;
     if (!frame || !previewSource) return;
 
-    // Clear injected set — a reloaded iframe has a fresh renderer registry.
+    // Clear injected set because a reloaded iframe has a fresh renderer registry.
     injectedLibsRef.current.clear();
     setPreviewFrameReadyGeneration((generation) => generation + 1);
     void renderMarkdownPreviewFrame(frame);
@@ -829,13 +831,13 @@ export const MarkdownCell = memo(function MarkdownCell({
     [getCurrentEditorSource, isLastCell, onFocusNext, onInsertCellAfter, readOnly],
   );
 
-  // Remote cursors extension (stable — no deps that change)
+  // Remote cursors extension (stable, no deps that change)
   const remoteCursorsExt = useMemo(() => remoteCursorsExtension(), []);
 
-  // Text attribution extension (stable — no deps that change)
+  // Text attribution extension (stable, no deps that change)
   const textAttributionExt = useMemo(() => textAttributionExtension(), []);
 
-  // Presence sender extension — broadcasts local cursor/selection to other peers
+  // Presence sender extension broadcasts local cursor/selection to other peers.
   const presenceSenderExt = useMemo(() => {
     if (!presence) return [];
     return [
@@ -1043,90 +1045,101 @@ export const MarkdownCell = memo(function MarkdownCell({
             </div>
           </div>
 
-          {/* View section - hidden when editing */}
-          <div
-            ref={viewRef}
-            role="textbox"
-            aria-readonly
-            aria-label="Markdown cell content"
-            tabIndex={0}
-            className={cn("relative py-2 cursor-text outline-none", editing && "hidden")}
-            onFocus={activatePreviewFrameInteraction}
-            onDoubleClick={enterEditing}
-            onPointerDown={handlePreviewWrapperPointerDown}
-            onMouseUp={updateRenderedSourceCommentTarget}
-            onKeyUp={updateRenderedSourceCommentTarget}
-            onKeyDown={handleViewKeyDown}
+          <RenderedMarkdownContextMenu
+            cellId={cell.id}
+            source={previewSource}
+            viewRef={viewRef}
+            onCreateSourceComment={canCommentOnRenderedMarkdown ? onCreateSourceComment : undefined}
           >
-            {previewSource && canRenderProjectionInHost && markdownProjection ? (
-              <ProjectedMarkdownView
-                plan={markdownProjection}
-                headingAnchors={headingAnchors}
-                onLinkClick={handleLinkClick}
-                canCommentOnRuns={
-                  canCommentOnRenderedMarkdown ? canCommentOnRenderedRuns : undefined
-                }
-                onCommentRuns={canCommentOnRenderedMarkdown ? handleRenderedRunsComment : undefined}
-                onTaskCheckedChange={
-                  readOnly || !onUpdateSource ? undefined : handleTaskCheckedChange
-                }
-                activeSourcePosition={activeSourcePosition}
-              />
-            ) : (
-              <div
-                className={previewSource ? undefined : "hidden"}
-                onPointerDown={handlePreviewWrapperPointerDown}
-                onPointerOut={deactivatePreviewFrameInteractionWhenIdle}
-              >
-                <IsolatedFrame
-                  ref={frameRef}
-                  name={`md-${cell.id}`}
-                  darkMode={darkMode}
-                  colorTheme={colorTheme}
-                  hostContext={outputHostContext}
-                  minHeight={previewMinHeight}
-                  autoHeight
-                  scrollPassthrough={!previewFrameInteractionActive}
-                  allowWheelBoundaryScroll={previewFrameInteractionActive}
-                  revealOnRender
-                  reserveHeightOnReveal
-                  onReady={handleFrameReady}
+            {/* View section - hidden when editing */}
+            <div
+              ref={viewRef}
+              role="textbox"
+              aria-readonly
+              aria-label="Markdown cell content"
+              tabIndex={0}
+              className={cn("relative py-2 cursor-text outline-none", editing && "hidden")}
+              onFocus={activatePreviewFrameInteraction}
+              onDoubleClick={enterEditing}
+              onPointerDown={handlePreviewWrapperPointerDown}
+              onMouseUp={updateRenderedSourceCommentTarget}
+              onKeyUp={updateRenderedSourceCommentTarget}
+              onKeyDown={handleViewKeyDown}
+            >
+              {previewSource && canRenderProjectionInHost && markdownProjection ? (
+                <ProjectedMarkdownView
+                  plan={markdownProjection}
+                  headingAnchors={headingAnchors}
                   onLinkClick={handleLinkClick}
-                  onMouseDown={activatePreviewFrameInteraction}
-                  onMouseUp={handlePreviewFrameMouseUp}
-                  onDoubleClick={enterEditing}
-                  onError={handleIframeError}
-                  onDiagnostic={logNotebookIsolatedDiagnostic}
-                  className="w-full"
+                  canCommentOnRuns={
+                    canCommentOnRenderedMarkdown ? canCommentOnRenderedRuns : undefined
+                  }
+                  onCommentRuns={
+                    canCommentOnRenderedMarkdown ? handleRenderedRunsComment : undefined
+                  }
+                  onTaskCheckedChange={
+                    readOnly || !onUpdateSource ? undefined : handleTaskCheckedChange
+                  }
+                  activeSourcePosition={activeSourcePosition}
                 />
-              </div>
-            )}
-            {!previewSource && <p className="text-muted-foreground italic">Double-click to edit</p>}
-            {renderedSourceCommentTarget ? (
-              <button
-                type="button"
-                aria-label="Comment on selected markdown"
-                title="Comment on selected markdown"
-                data-testid="markdown-source-comment-button"
-                onPointerDown={(event) => {
-                  event.preventDefault();
-                  event.stopPropagation();
-                }}
-                onMouseDown={(event) => {
-                  event.preventDefault();
-                  event.stopPropagation();
-                }}
-                onClick={handleRenderedSourceCommentClick}
-                className="absolute z-20 rounded-md border bg-background px-2 py-1 text-[11px] font-medium leading-none text-foreground shadow-sm transition-colors hover:bg-muted focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/30"
-                style={{
-                  left: renderedSourceCommentTarget.left,
-                  top: renderedSourceCommentTarget.top,
-                }}
-              >
-                Comment
-              </button>
-            ) : null}
-          </div>
+              ) : (
+                <div
+                  className={previewSource ? undefined : "hidden"}
+                  onPointerDown={handlePreviewWrapperPointerDown}
+                  onPointerOut={deactivatePreviewFrameInteractionWhenIdle}
+                >
+                  <IsolatedFrame
+                    ref={frameRef}
+                    name={`md-${cell.id}`}
+                    darkMode={darkMode}
+                    colorTheme={colorTheme}
+                    hostContext={outputHostContext}
+                    minHeight={previewMinHeight}
+                    autoHeight
+                    scrollPassthrough={!previewFrameInteractionActive}
+                    allowWheelBoundaryScroll={previewFrameInteractionActive}
+                    revealOnRender
+                    reserveHeightOnReveal
+                    onReady={handleFrameReady}
+                    onLinkClick={handleLinkClick}
+                    onMouseDown={activatePreviewFrameInteraction}
+                    onMouseUp={handlePreviewFrameMouseUp}
+                    onDoubleClick={enterEditing}
+                    onError={handleIframeError}
+                    onDiagnostic={logNotebookIsolatedDiagnostic}
+                    className="w-full"
+                  />
+                </div>
+              )}
+              {!previewSource && (
+                <p className="text-muted-foreground italic">Double-click to edit</p>
+              )}
+              {renderedSourceCommentTarget ? (
+                <button
+                  type="button"
+                  aria-label="Comment on selected markdown"
+                  title="Comment on selected markdown"
+                  data-testid="markdown-source-comment-button"
+                  onPointerDown={(event) => {
+                    event.preventDefault();
+                    event.stopPropagation();
+                  }}
+                  onMouseDown={(event) => {
+                    event.preventDefault();
+                    event.stopPropagation();
+                  }}
+                  onClick={handleRenderedSourceCommentClick}
+                  className="absolute z-20 inline-flex size-6 items-center justify-center rounded-md border bg-background p-0 text-foreground shadow-sm transition-colors hover:bg-muted focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/30"
+                  style={{
+                    left: renderedSourceCommentTarget.left,
+                    top: renderedSourceCommentTarget.top,
+                  }}
+                >
+                  <MessageSquarePlus className="h-[15px] w-[15px]" aria-hidden="true" />
+                </button>
+              ) : null}
+            </div>
+          </RenderedMarkdownContextMenu>
         </>
       }
     />

--- a/apps/notebook/src/components/RenderedMarkdownContextMenu.tsx
+++ b/apps/notebook/src/components/RenderedMarkdownContextMenu.tsx
@@ -1,0 +1,142 @@
+import { Copy, MessageSquarePlus } from "lucide-react";
+import { useCallback, useState, type ReactNode, type RefObject } from "react";
+import {
+  NotebookContextMenu,
+  type NotebookContextMenuAction,
+  type NotebookContextMenuGroup,
+} from "@/components/notebook/NotebookContextMenu";
+import {
+  selectionRectFromDomSelection,
+  type SourceCommentSelectionRect,
+  type SourceRangeCommentAnchor,
+} from "../lib/comment-source-anchor";
+import { sourceRangeAnchorFromRenderedMarkdownSelection } from "../lib/rendered-markdown-source-comment";
+
+interface RenderedMarkdownContextMenuProps {
+  cellId: string;
+  source: string;
+  viewRef: RefObject<HTMLDivElement | null>;
+  onCreateSourceComment?: (
+    anchor: SourceRangeCommentAnchor,
+    rect: SourceCommentSelectionRect | null,
+  ) => void;
+  children: ReactNode;
+}
+
+export interface BuildRenderedMarkdownContextGroupsOptions {
+  hasSelection: boolean;
+  canComment: boolean;
+  onCopy?: () => void;
+  onAddComment?: () => void;
+}
+
+export function buildRenderedMarkdownContextGroups({
+  hasSelection,
+  canComment,
+  onCopy,
+  onAddComment,
+}: BuildRenderedMarkdownContextGroupsOptions): NotebookContextMenuGroup[] {
+  const actions: NotebookContextMenuAction[] = [];
+
+  if (hasSelection) {
+    actions.push({
+      id: "copy",
+      label: "Copy",
+      icon: <Copy className="size-4" aria-hidden="true" />,
+      shortcut: "⌘C",
+      onSelect: onCopy,
+    });
+  }
+
+  if (hasSelection && canComment) {
+    actions.push({
+      id: "add-comment",
+      label: "Add comment",
+      icon: <MessageSquarePlus className="size-4" aria-hidden="true" />,
+      shortcut: "C",
+      separatorBefore: actions.length > 0,
+      onSelect: onAddComment,
+    });
+  }
+
+  if (actions.length === 0) return [];
+
+  return [
+    {
+      id: "rendered-markdown",
+      actions,
+    },
+  ];
+}
+
+export function RenderedMarkdownContextMenu({
+  cellId,
+  source,
+  viewRef,
+  onCreateSourceComment,
+  children,
+}: RenderedMarkdownContextMenuProps) {
+  const [groups, setGroups] = useState<NotebookContextMenuGroup[]>([]);
+
+  const refreshGroups = useCallback(() => {
+    const root = viewRef.current;
+    const selection = currentDomSelection();
+    const hasSelection = !!root && selectionIsInsideRoot(root, selection);
+    const selectedText = hasSelection ? (selection?.toString() ?? "") : "";
+    const anchor = root
+      ? sourceRangeAnchorFromRenderedMarkdownSelection(cellId, source, root, selection)
+      : null;
+
+    setGroups(
+      buildRenderedMarkdownContextGroups({
+        hasSelection,
+        canComment: !!anchor && !!onCreateSourceComment,
+        onCopy: hasSelection ? () => copyRenderedSelection(selectedText) : undefined,
+        onAddComment:
+          anchor && onCreateSourceComment
+            ? () =>
+                onCreateSourceComment(anchor, selectionRectFromDomSelection(currentDomSelection()))
+            : undefined,
+      }),
+    );
+  }, [cellId, onCreateSourceComment, source, viewRef]);
+
+  const handleOpenChange = useCallback(
+    (open: boolean) => {
+      if (open) refreshGroups();
+    },
+    [refreshGroups],
+  );
+
+  return (
+    <NotebookContextMenu groups={groups} contentClassName="w-48" onOpenChange={handleOpenChange}>
+      <div className="w-full min-w-0" onContextMenuCapture={refreshGroups}>
+        {children}
+      </div>
+    </NotebookContextMenu>
+  );
+}
+
+function selectionIsInsideRoot(root: HTMLElement, selection: Selection | null): boolean {
+  if (!selection || selection.rangeCount === 0 || selection.isCollapsed) return false;
+  if (selection.toString().length === 0) return false;
+
+  const range = selection.getRangeAt(0);
+  return root.contains(range.startContainer) && root.contains(range.endContainer);
+}
+
+function copyRenderedSelection(selectedText: string): void {
+  const clipboard = currentClipboard();
+  if (!clipboard || selectedText.length === 0) return;
+  void clipboard.writeText(selectedText).catch(() => undefined);
+}
+
+function currentDomSelection(): Selection | null {
+  if (typeof window === "undefined") return null;
+  return window.getSelection();
+}
+
+function currentClipboard(): Clipboard | undefined {
+  if (typeof navigator === "undefined") return undefined;
+  return navigator.clipboard;
+}

--- a/apps/notebook/src/components/__tests__/RenderedMarkdownContextMenu.test.tsx
+++ b/apps/notebook/src/components/__tests__/RenderedMarkdownContextMenu.test.tsx
@@ -1,0 +1,48 @@
+import { describe, expect, it, vi } from "vite-plus/test";
+import {
+  buildRenderedMarkdownContextGroups,
+  type BuildRenderedMarkdownContextGroupsOptions,
+} from "../RenderedMarkdownContextMenu";
+
+function buildActions(overrides: Partial<BuildRenderedMarkdownContextGroupsOptions> = {}) {
+  const groups = buildRenderedMarkdownContextGroups({
+    hasSelection: false,
+    canComment: false,
+    onCopy: vi.fn(),
+    onAddComment: vi.fn(),
+    ...overrides,
+  });
+
+  return groups[0]?.actions ?? [];
+}
+
+describe("buildRenderedMarkdownContextGroups", () => {
+  it("shows copy and comment for rendered selections that can comment", () => {
+    const actions = buildActions({
+      hasSelection: true,
+      canComment: true,
+    });
+
+    expect(actions.map((action) => action.id)).toEqual(["copy", "add-comment"]);
+    expect(actions.map((action) => action.shortcut)).toEqual(["⌘C", "C"]);
+    expect(actions.find((action) => action.id === "add-comment")?.separatorBefore).toBe(true);
+  });
+
+  it("shows copy only for rendered selections without a comment handler", () => {
+    const actions = buildActions({
+      hasSelection: true,
+      canComment: false,
+    });
+
+    expect(actions.map((action) => action.id)).toEqual(["copy"]);
+  });
+
+  it("returns no actions without a rendered selection", () => {
+    expect(
+      buildRenderedMarkdownContextGroups({
+        hasSelection: false,
+        canComment: true,
+      }),
+    ).toEqual([]);
+  });
+});


### PR DESCRIPTION
Markdown cells now have a rendered-mode right-click context menu, matching the code-cell right-click, and the rendered selection affordance is a minimal icon. Follows the Phase 1 harvest (#3751).

## Rendered right-click menu

`RenderedMarkdownContextMenu` wraps the rendered view and mirrors the code-cell `EditorContextMenu`: a custom menu replaces the browser's native one, so it carries Copy itself, plus Add comment when the DOM selection resolves to a source-range anchor. No Cut or Paste, rendered prose is read-only. The menu reads the live selection on open and only offers actions when the selection is inside the rendered view (both range endpoints contained). The group-builder is a pure, unit-tested function.

## Icon affordance

The floating selection button changes from a "Comment" text label to a compact comment icon, matching the source-editor selection affordance. The per-paragraph hover button already uses the same icon.

## Scope

The rendered highlight overlay (showing anchored threads on the prose) is the next follow-up. The IsolatedFrame markdown path stays out of scope.

## Verification

`vp check` clean (format + lint); full `vp test` green (2415 passed), including a new test for the rendered context-menu group gating. Reviewed: the menu mirrors EditorContextMenu, gates Copy/Add comment on a real in-view selection, and the MarkdownCell wrap preserves the existing rendered and iframe handlers.
