### PR TITLE
ci(reviewers): share nteract review rubric

### DIFF
--- a/.agents/reviewers/nteract-code-review-rubric.md
+++ b/.agents/reviewers/nteract-code-review-rubric.md
@@ -1,0 +1,87 @@
+# nteract Code Review Rubric
+
+Use this rubric for custom Claude, Codex, Pullfrog, and `pr-reviewer` review
+passes. It is reviewer guidance, not general implementation guidance.
+
+## Operating Mode
+
+Review as a senior nteract code reviewer. Stay read-only. Inspect the diff
+first, then the nearest owning code, tests, `AGENTS.md` files, ADRs/plans, and
+recent repository patterns when they are relevant. Be terse, adversarial, and
+evidence-backed.
+
+Primary goals:
+
+- Find concrete bugs, behavioral regressions, data loss, security issues,
+  concurrency hazards, broken tests, and missing tests that could allow the diff
+  to regress.
+- Also report repo-invariant architecture/style nits when they protect
+  maintainability or product behavior. Examples: state being owned by a React
+  component/app hook when it belongs in a shared projection/store,
+  `packages/runtimed`, or `runtimed-wasm`; app-local code in `apps/` duplicating
+  a shared surface that belongs under `src/`; direct host imports leaking into
+  shared code; stale generated artifacts; or stale docs/agent guidance that
+  contradicts current authority boundaries.
+
+Suppress comments that are only subjective preference, formatting, naming,
+Tailwind ordering, or "could be cleaner" with no concrete owner, invariant,
+user-visible behavior, or test gap. Group repeated instances under one finding.
+Prefer at most 12 findings.
+
+## nteract Checklist
+
+- State ownership: Notebook edits flow through NotebookDoc/WASM/CRDT paths.
+  Runtime lifecycle, queue, outputs, env, trust, execution snapshots, and widget
+  topology are daemon/runtime-owned RuntimeStateDoc facts. Mutable widget values
+  belong in CommsDoc. React/app stores should be projections or local UI policy,
+  not durable sources of truth.
+- Shared surfaces: reusable notebook UI, output rendering, identity helpers,
+  and headless state/projection logic belong under `src/components/**`,
+  `src/lib/**`, or `packages/runtimed/**`. Keep `apps/notebook/**` and
+  `apps/notebook-cloud/**` focused on host policy, routes, shell wiring, and
+  side effects.
+- Host boundaries: shared libraries must stay free of Tauri, Cloudflare, OIDC,
+  D1/R2/Durable Object, ACL, credential, and daemon launch policy. Host adapters
+  own those effects.
+- Authority boundaries: review every write path, including request RPCs, room
+  admission, materializer/checkpoint paths, WASM handlers, broadcasts,
+  persistence, and tests. Viewer and `runtime_peer` roles must not gain
+  unintended writes; client plumbing alone is not enough evidence for hosted
+  authority changes.
+- Protocol changes: wire protocol, Rust handling, WASM bindings,
+  `packages/runtimed` types/stores, recovery, and tests should move together.
+- Outputs/widgets: RuntimeStateDoc is the durable output/runtime record;
+  output/control ordering must survive stdout floods and display churn;
+  MIME/blob/renderer plugin changes need artifact or browser-backed evidence
+  when possible.
+- Async projection work: reject stale fire-and-forget updates that can resurrect
+  removed/replaced state without reset epochs, generations, cancellation, or
+  equivalent guards.
+- Tests: require focused tests at the changed boundary. Treat deleted tests as
+  suspicious unless the behavior was removed and replacement coverage exists.
+
+## Finding Contract
+
+Every finding must name a concrete failure mode or invariant drift, explain why
+the diff introduced or exposed it, identify the affected file and line when
+possible, and suggest the smallest useful fix. Do not invent findings. If there
+are no actionable issues, say there are no actionable findings.
+
+Use severity `nit` for non-blocking architecture/style findings. Use higher
+severity only when the finding can cause a bug, security issue, data loss,
+authority bypass, durable runtime/output corruption, or a serious review blocker.
+
+Use one of these categories for each finding:
+
+- `correctness`
+- `state_ownership`
+- `shared_surface`
+- `host_boundary`
+- `authority_boundary`
+- `protocol_sync`
+- `output_widget_runtime`
+- `async_ordering`
+- `tests`
+- `generated_artifact`
+- `style_maintainability`
+- `infra`

--- a/.agents/skills/pr-reviewer/SKILL.md
+++ b/.agents/skills/pr-reviewer/SKILL.md
@@ -7,6 +7,8 @@ description: Use the repository-local pr-review CLI for opencode-backed Bedrock 
 
 Use `pr-review` instead of shelling out to raw `claude` for PR reviews in this repository. It creates an isolated disposable git worktree, runs opencode against a Bedrock model, gives the reviewer the PR diff plus repo access, and writes structured JSON reports.
 
+The shared nteract reviewer rubric lives at `.agents/reviewers/nteract-code-review-rubric.md`. Use it when configuring custom Claude/Codex reviewer prompts, and keep `pr-reviewer`/Pullfrog review contracts aligned with it.
+
 ## When To Use
 
 - The user asks for a Claude, Bedrock, external, second-model, or structured PR review.

--- a/.github/workflows/pullfrog.yml
+++ b/.github/workflows/pullfrog.yml
@@ -30,71 +30,19 @@ jobs:
         uses: actions/checkout@v6
         with:
           fetch-depth: 1
-      - name: Run agent
-        id: review
-        uses: pullfrog/pullfrog@v0
-        with:
-          model: bedrock/byok
-          push: disabled
-          prompt: |
-            Review this repository as a senior nteract code reviewer. Stay
-            read-only. Inspect the diff first, then the nearest owning code,
-            tests, AGENTS.md files, ADRs/plans, and recent patterns when they
-            are relevant. Be terse, adversarial, and evidence-backed.
+      - name: Build review prompt
+        id: review_prompt
+        env:
+          CALLER_PROMPT: ${{ inputs.prompt }}
+        shell: bash
+        run: |
+          delimiter="pullfrog_prompt_${RANDOM}_${RANDOM}"
+          {
+            echo "prompt<<${delimiter}"
+            cat .agents/reviewers/nteract-code-review-rubric.md
+            cat <<'PULLFROG_PROMPT'
 
-            Primary goal:
-            - Find concrete bugs, behavioral regressions, data loss, security
-              issues, concurrency hazards, broken tests, and missing tests that
-              could allow the diff to regress.
-            - Also report repo-invariant architecture/style nits when they
-              protect maintainability or product behavior. Examples: state
-              being owned by a React component/app hook when it belongs in a
-              shared projection/store, packages/runtimed, or runtimed-wasm;
-              app-local code in apps/ duplicating a shared surface that belongs
-              under src/; direct host imports leaking into shared code; stale
-              generated artifacts; or stale docs/agent guidance that contradicts
-              current authority boundaries.
-
-            Suppress comments that are only subjective preference, formatting,
-            naming, Tailwind ordering, or "could be cleaner" with no concrete
-            owner, invariant, user-visible behavior, or test gap. Group repeated
-            instances under one finding. Prefer at most 12 findings.
-
-            nteract review checklist:
-            - State ownership: Notebook edits flow through NotebookDoc/WASM/CRDT
-              paths. Runtime lifecycle, queue, outputs, env, trust, execution
-              snapshots, and widget topology are daemon/runtime-owned
-              RuntimeStateDoc facts. Mutable widget values belong in CommsDoc.
-              React/app stores should be projections or local UI policy, not
-              durable sources of truth.
-            - Shared surfaces: reusable notebook UI, output rendering, identity
-              helpers, and headless state/projection logic belong under
-              src/components/**, src/lib/**, or packages/runtimed/**. Keep
-              apps/notebook/** and apps/notebook-cloud/** focused on host policy,
-              routes, shell wiring, and side effects.
-            - Host boundaries: shared libraries must stay free of Tauri,
-              Cloudflare, OIDC, D1/R2/Durable Object, ACL, credential, and daemon
-              launch policy. Host adapters own those effects.
-            - Authority boundaries: review every write path, including request
-              RPCs, room admission, materializer/checkpoint paths, WASM handlers,
-              broadcasts, persistence, and tests. Viewer and runtime_peer roles
-              must not gain unintended writes; client plumbing alone is not
-              enough evidence for hosted authority changes.
-            - Protocol changes: wire protocol, Rust handling, WASM bindings,
-              packages/runtimed types/stores, recovery, and tests should move
-              together.
-            - Outputs/widgets: RuntimeStateDoc is the durable output/runtime
-              record; output/control ordering must survive stdout floods and
-              display churn; MIME/blob/renderer plugin changes need artifact or
-              browser-backed evidence when possible.
-            - Async projection work: reject stale fire-and-forget updates that
-              can resurrect removed/replaced state without reset epochs,
-              generations, cancellation, or equivalent guards.
-            - Tests: require focused tests at the changed boundary. Treat deleted
-              tests as suspicious unless the behavior was removed and replacement
-              coverage exists.
-
-            Verdict rules:
+            Pullfrog output contract:
             - "✅" means the review completed and found no actionable issues.
             - "⚠️" means the review found non-blocking risk, missing coverage,
               uncertainty, or a repo-invariant architecture/style nit the human
@@ -104,18 +52,22 @@ jobs:
               corruption risk, or the review could not be trusted because of
               infrastructure/tooling uncertainty.
 
-            Every finding must name a concrete failure mode or invariant drift,
-            explain why the diff introduced or exposed it, identify the affected
-            file and line when possible, and suggest the smallest useful fix.
-            Use severity "nit" for non-blocking architecture/style findings.
-            Do not invent findings.
-
             Return the structured output by calling Pullfrog's set_output tool.
             The output must match the provided JSON schema exactly. Do not add
             markdown, prose, or extra keys outside the schema.
 
             Caller prompt:
-            ${{ inputs.prompt }}
+          PULLFROG_PROMPT
+            printf '%s\n' "$CALLER_PROMPT"
+            echo "${delimiter}"
+          } >> "$GITHUB_OUTPUT"
+      - name: Run agent
+        id: review
+        uses: pullfrog/pullfrog@v0
+        with:
+          model: bedrock/byok
+          push: disabled
+          prompt: ${{ steps.review_prompt.outputs.prompt }}
           output_schema: |
             {
               "$schema": "http://json-schema.org/draft-07/schema#",

--- a/python/pr-reviewer/README.md
+++ b/python/pr-reviewer/README.md
@@ -10,6 +10,9 @@ The opencode session runs in the disposable worktree with a generated
 read-only reviewer config that denies `edit` permissions while allowing shell
 inspection. Review prompts include the full diff up front so shell inspection
 can be used for deeper review instead of basic diff reconstruction.
+The shared nteract reviewer rubric lives at
+`.agents/reviewers/nteract-code-review-rubric.md`; keep custom Claude, Codex,
+Pullfrog, and `pr-reviewer` passes aligned with that file.
 
 ## Usage
 

--- a/python/pr-reviewer/src/pr_reviewer/prompt.py
+++ b/python/pr-reviewer/src/pr_reviewer/prompt.py
@@ -1,16 +1,33 @@
 from __future__ import annotations
 
+from pathlib import Path
+
 from pr_reviewer.workspace import ReviewWorkspace
 
-SYSTEM_PROMPT = """\
-You are an external senior code reviewer. You are reviewing a GitHub pull
-request in a dedicated checkout. Stay read-only. Focus on concrete bugs,
-behavioral regressions, security issues, data loss, concurrency hazards, and
-missing tests that could allow the diff to regress.
+REVIEW_RUBRIC_PATH = (
+    Path(__file__).resolve().parents[4] / ".agents" / "reviewers" / "nteract-code-review-rubric.md"
+)
 
-Do not report style-only comments. Do not invent findings. Each finding must
-identify the affected file, line when possible, the failure mode, and why the
-diff introduced or exposed it. If there are no actionable issues, say so.
+
+def load_nteract_review_rubric() -> str:
+    try:
+        return REVIEW_RUBRIC_PATH.read_text(encoding="utf-8").strip()
+    except FileNotFoundError:
+        return (
+            "Review against nteract ownership, authority, shared-surface, "
+            "runtime/output, async, generated-artifact, and test boundaries."
+        )
+
+
+NTERACT_REVIEW_RUBRIC = load_nteract_review_rubric()
+
+SYSTEM_PROMPT = f"""\
+You are an external senior code reviewer. You are reviewing a GitHub pull
+request in a dedicated checkout.
+
+Use this shared nteract reviewer rubric:
+
+{NTERACT_REVIEW_RUBRIC}
 
 Set terminal_reason to explain how the review ended:
 - review_complete: full review completed with no actionable findings.
@@ -25,6 +42,29 @@ context. Prefer read-only inspection when tools are available, but do not assume
 tool access. Do not intentionally edit source files; this review should produce
 findings, not patches.
 """
+
+REVIEW_JSON_SHAPE = """\
+{
+  "verdict": "clear" | "findings" | "needs_human" | "infra_uncertain",
+  "terminal_reason": "review_complete" | "actionable_findings" |
+    "needs_human" | "budget_exhausted" | "infra_uncertain",
+  "summary": "short review summary",
+  "findings": [
+    {
+      "severity": "blocker" | "high" | "medium" | "low" | "nit",
+      "category": "correctness" | "state_ownership" | "shared_surface" |
+        "host_boundary" | "authority_boundary" | "protocol_sync" |
+        "output_widget_runtime" | "async_ordering" | "tests" |
+        "generated_artifact" | "style_maintainability" | "infra",
+      "file": "path/to/file",
+      "line": 123,
+      "title": "short issue title",
+      "evidence": "why this is a real bug, risk, or invariant drift",
+      "suggested_fix": "concrete fix, or null",
+      "confidence": "high" | "medium" | "low"
+    }
+  ]
+}"""
 
 
 def build_review_prompt(workspace: ReviewWorkspace, *, extra_prompt: str | None = None) -> str:
@@ -49,23 +89,7 @@ Diff stat:
 You are in the PR workspace. Inspect files as needed and compare the PR against
 the full diff below. Return exactly one JSON object and no prose, markdown, or
 code fence. The JSON shape is:
-{{
-  "verdict": "clear" | "findings" | "needs_human" | "infra_uncertain",
-  "terminal_reason": "review_complete" | "actionable_findings" |
-    "needs_human" | "budget_exhausted" | "infra_uncertain",
-  "summary": "short review summary",
-  "findings": [
-    {{
-      "severity": "blocker" | "high" | "medium" | "low",
-      "file": "path/to/file",
-      "line": 123,
-      "title": "short issue title",
-      "evidence": "why this is a real bug or risk",
-      "suggested_fix": "concrete fix, or null",
-      "confidence": "high" | "medium" | "low"
-    }}
-  ]
-}}
+{REVIEW_JSON_SHAPE}
 
 Full diff:
 {workspace.diff_patch or "(empty)"}
@@ -96,23 +120,7 @@ Diff stat:
 You are in the workspace being reviewed. Inspect files as needed and compare the
 current local changes against the full diff below. Return exactly one JSON
 object and no prose, markdown, or code fence. The JSON shape is:
-{{
-  "verdict": "clear" | "findings" | "needs_human" | "infra_uncertain",
-  "terminal_reason": "review_complete" | "actionable_findings" |
-    "needs_human" | "budget_exhausted" | "infra_uncertain",
-  "summary": "short architecture review summary",
-  "findings": [
-    {{
-      "severity": "blocker" | "high" | "medium" | "low",
-      "file": "path/to/file",
-      "line": 123,
-      "title": "short issue title",
-      "evidence": "why this is a real architecture, security, product, or maintenance risk",
-      "suggested_fix": "concrete fix, or null",
-      "confidence": "high" | "medium" | "low"
-    }}
-  ]
-}}
+{REVIEW_JSON_SHAPE}
 
 Full diff:
 {workspace.diff_patch or "(empty)"}

--- a/python/pr-reviewer/src/pr_reviewer/schema.py
+++ b/python/pr-reviewer/src/pr_reviewer/schema.py
@@ -11,13 +11,44 @@ TerminalReason = Literal[
     "budget_exhausted",
     "infra_uncertain",
 ]
-Severity = Literal["blocker", "high", "medium", "low"]
+Severity = Literal["blocker", "high", "medium", "low", "nit"]
+Category = Literal[
+    "correctness",
+    "state_ownership",
+    "shared_surface",
+    "host_boundary",
+    "authority_boundary",
+    "protocol_sync",
+    "output_widget_runtime",
+    "async_ordering",
+    "tests",
+    "generated_artifact",
+    "style_maintainability",
+    "infra",
+]
 Confidence = Literal["high", "medium", "low"]
+
+VALID_SEVERITIES = {"blocker", "high", "medium", "low", "nit"}
+VALID_CATEGORIES = {
+    "correctness",
+    "state_ownership",
+    "shared_surface",
+    "host_boundary",
+    "authority_boundary",
+    "protocol_sync",
+    "output_widget_runtime",
+    "async_ordering",
+    "tests",
+    "generated_artifact",
+    "style_maintainability",
+    "infra",
+}
 
 
 @dataclass(frozen=True)
 class Finding:
     severity: Severity
+    category: Category
     file: str
     line: int | None
     title: str
@@ -86,6 +117,7 @@ def normalize_structured_output(data: Any) -> tuple[Verdict, TerminalReason, str
         finding_data = cast(dict[str, Any], item)
         try:
             severity = finding_data["severity"]
+            category = finding_data["category"]
             file = finding_data["file"]
             line = finding_data["line"]
             title = finding_data["title"]
@@ -95,8 +127,10 @@ def normalize_structured_output(data: Any) -> tuple[Verdict, TerminalReason, str
         except KeyError as exc:
             raise ValueError(f"finding {index} is missing required field {exc.args[0]!r}") from exc
 
-        if severity not in {"blocker", "high", "medium", "low"}:
+        if severity not in VALID_SEVERITIES:
             raise ValueError(f"finding {index} has invalid severity {severity!r}")
+        if category not in VALID_CATEGORIES:
+            raise ValueError(f"finding {index} has invalid category {category!r}")
         if not isinstance(file, str):
             raise ValueError(f"finding {index} file was not a string")
         if line is not None and not isinstance(line, int):
@@ -113,6 +147,7 @@ def normalize_structured_output(data: Any) -> tuple[Verdict, TerminalReason, str
         findings.append(
             Finding(
                 severity=cast(Severity, severity),
+                category=cast(Category, category),
                 file=file,
                 line=line,
                 title=title,

--- a/python/pr-reviewer/tests/test_agent.py
+++ b/python/pr-reviewer/tests/test_agent.py
@@ -109,7 +109,8 @@ def test_run_review_uses_opencode_output(monkeypatch, tmp_path: Path) -> None:
     assert report.cost_usd == 0.34
     assert report.raw_result is not None
     assert "diff --git a/src/a.py b/src/a.py" in calls[0][0]
-    assert "Do not report style-only comments." in calls[0][0]
+    assert "repo-invariant architecture/style nits" in calls[0][0]
+    assert '"category": "correctness" | "state_ownership"' in calls[0][0]
     assert calls[0][1] == tmp_path
     assert calls[0][2] == config
 

--- a/python/pr-reviewer/tests/test_prompt.py
+++ b/python/pr-reviewer/tests/test_prompt.py
@@ -1,7 +1,7 @@
 from pathlib import Path
 
 from pr_reviewer.git import PullRequestInfo
-from pr_reviewer.prompt import build_review_prompt
+from pr_reviewer.prompt import NTERACT_REVIEW_RUBRIC, build_review_prompt
 from pr_reviewer.schema import ReviewedDiff
 from pr_reviewer.workspace import ReviewWorkspace
 
@@ -35,4 +35,7 @@ def test_build_review_prompt_includes_pr_context() -> None:
     assert "https://github.com/nteract/nteract/pull/5" in prompt
     assert "- src/a.py" in prompt
     assert "diff --git a/src/a.py b/src/a.py" in prompt
+    assert "state_ownership" in prompt
+    assert '"severity": "blocker" | "high" | "medium" | "low" | "nit"' in prompt
+    assert "repo-invariant architecture/style nits" in NTERACT_REVIEW_RUBRIC
     assert "Only high confidence findings." in prompt

--- a/python/pr-reviewer/tests/test_schema.py
+++ b/python/pr-reviewer/tests/test_schema.py
@@ -12,6 +12,7 @@ def test_normalize_structured_output_returns_findings() -> None:
             "findings": [
                 {
                     "severity": "high",
+                    "category": "correctness",
                     "file": "src/lib.rs",
                     "line": 42,
                     "title": "Race",
@@ -29,6 +30,7 @@ def test_normalize_structured_output_returns_findings() -> None:
     assert findings == [
         Finding(
             severity="high",
+            category="correctness",
             file="src/lib.rs",
             line=42,
             title="Race",
@@ -71,5 +73,53 @@ def test_normalize_structured_output_wraps_missing_finding_field() -> None:
                 "terminal_reason": "actionable_findings",
                 "summary": "Bad finding.",
                 "findings": [{"file": "src/lib.rs"}],
+            }
+        )
+
+
+def test_normalize_structured_output_accepts_nit_findings() -> None:
+    _, _, _, findings = normalize_structured_output(
+        {
+            "verdict": "findings",
+            "terminal_reason": "actionable_findings",
+            "summary": "One nit.",
+            "findings": [
+                {
+                    "severity": "nit",
+                    "category": "shared_surface",
+                    "file": "apps/notebook/src/Foo.tsx",
+                    "line": 12,
+                    "title": "Duplicate shared surface behavior",
+                    "evidence": "The app-local code repeats a shared notebook surface invariant.",
+                    "suggested_fix": "Move the reusable behavior under src/components.",
+                    "confidence": "medium",
+                }
+            ],
+        }
+    )
+
+    assert findings[0].severity == "nit"
+    assert findings[0].category == "shared_surface"
+
+
+def test_normalize_structured_output_rejects_invalid_category() -> None:
+    with pytest.raises(ValueError, match="finding 0 has invalid category"):
+        normalize_structured_output(
+            {
+                "verdict": "findings",
+                "terminal_reason": "actionable_findings",
+                "summary": "Bad category.",
+                "findings": [
+                    {
+                        "severity": "low",
+                        "category": "style",
+                        "file": "src/lib.rs",
+                        "line": None,
+                        "title": "Vague",
+                        "evidence": "Not a real review category.",
+                        "suggested_fix": None,
+                        "confidence": "low",
+                    }
+                ],
             }
         )


### PR DESCRIPTION
## Summary

- Extract the nteract review rubric to `.agents/reviewers/nteract-code-review-rubric.md` so custom Claude/Codex reviewer prompts, Pullfrog, and `pr-reviewer` can share the same guidance.
- Update Pullfrog to build its prompt from that rubric file while preserving the forced OpenCode + Bedrock route.
- Extend `pr-reviewer` findings with `category` and `nit` severity so its structured output matches the review lanes from the shared rubric.

## Verification

- `uv run pytest python/pr-reviewer/tests`
- `actionlint .github/workflows/pullfrog.yml`
- `ruby -ryaml -rjson -e '...'`
- Pullfrog prompt-builder smoke test with `bash`
- `git diff --check origin/main..HEAD`
- `cargo xtask lint --fix`

## Notes

- Follow-up to #3753 after the Pullfrog prompt shape landed.
- The PR remains draft until GitHub CI and any reviewer pass complete.
