### PR TITLE
fix(runtimed): bound pool warmup timeouts

### DIFF
--- a/crates/runtimed/src/daemon.rs
+++ b/crates/runtimed/src/daemon.rs
@@ -389,6 +389,7 @@ struct Pool {
 
 const MIN_WARM_BASES: usize = 2;
 const POOL_PACKAGE_HASH_FILE: &str = ".runt-pool-packages.sha256";
+const POOL_READY_MARKER_FILE: &str = ".runt-pool-ready";
 /// How long a peer-less, kernel-less room may sit before the reaper
 /// removes it. Set to 24h so a user who returns within the same day
 /// reattaches to the same in-memory doc + outputs.
@@ -553,6 +554,16 @@ async fn pool_package_hash_matches(
     }
 }
 
+fn pool_env_ready_marker_exists(venv_path: &Path) -> bool {
+    venv_path.join(".warmed").exists() || venv_path.join(POOL_READY_MARKER_FILE).exists()
+}
+
+fn pool_entry_paths_are_ready(entry: &PoolEntry) -> bool {
+    entry.env.venv_path.exists()
+        && entry.env.python_path.exists()
+        && pool_env_ready_marker_exists(&entry.env.venv_path)
+}
+
 /// Settings changes that arrive close together (e.g. a user adding several
 /// default packages in the Settings panel, each dispatching its own sync
 /// round trip) would otherwise trigger a separate pool eviction + rewarm
@@ -591,10 +602,7 @@ impl Pool {
         let mut removed_paths = Vec::new();
         let mut healthy = VecDeque::new();
         for entry in self.available.drain(..) {
-            if entry.env.venv_path.exists()
-                && entry.env.python_path.exists()
-                && entry.env.venv_path.join(".warmed").exists()
-            {
+            if pool_entry_paths_are_ready(&entry) {
                 healthy.push_back(entry);
             } else {
                 removed_paths.push(entry.env.venv_path.clone());
@@ -664,13 +672,10 @@ impl Pool {
     fn take(&mut self) -> (Option<PooledEnv>, Vec<PathBuf>) {
         let stale_paths = self.prune_stale();
 
-        // Try to get a valid environment, skipping any with missing paths or missing warmup
+        // Try to get a valid environment, skipping any with missing paths or readiness marker.
         let mut invalid_paths = Vec::new();
         while let Some(entry) = self.available.pop_front() {
-            if entry.env.venv_path.exists()
-                && entry.env.python_path.exists()
-                && entry.env.venv_path.join(".warmed").exists()
-            {
+            if pool_entry_paths_are_ready(&entry) {
                 self.leased_paths
                     .insert(pool_env_root(&entry.env.venv_path));
                 let mut all_paths = stale_paths;
@@ -678,7 +683,7 @@ impl Pool {
                 return (Some(entry.env), all_paths);
             }
             warn!(
-                "[runtimed] Skipping env with missing path or warmup marker: {:?}",
+                "[runtimed] Skipping env with missing path or readiness marker: {:?}",
                 entry.env.venv_path
             );
             invalid_paths.push(entry.env.venv_path);
@@ -688,10 +693,7 @@ impl Pool {
         all_paths.extend(invalid_paths);
         while let Some(entry) = self.retired_available.pop_front() {
             let root = pool_env_root(&entry.env.venv_path);
-            if entry.env.venv_path.exists()
-                && entry.env.python_path.exists()
-                && entry.env.venv_path.join(".warmed").exists()
-            {
+            if pool_entry_paths_are_ready(&entry) {
                 info!(
                     "[runtimed] Pool empty; falling back to retired environment {:?}",
                     entry.env.venv_path
@@ -701,7 +703,7 @@ impl Pool {
                 return (Some(entry.env), all_paths);
             }
             warn!(
-                "[runtimed] Skipping retired env with missing path or warmup marker: {:?}",
+                "[runtimed] Skipping retired env with missing path or readiness marker: {:?}",
                 entry.env.venv_path
             );
             self.retired_paths.remove(&root);
@@ -2258,7 +2260,7 @@ impl Daemon {
                 #[cfg(not(target_os = "windows"))]
                 let python_path = env_path.join("bin").join("python");
 
-                if python_path.exists() && env_path.join(".warmed").exists() {
+                if python_path.exists() && pool_env_ready_marker_exists(&env_path) {
                     let hash_matches =
                         pool_package_hash_matches(&env_path, EnvType::Uv, &uv_prewarmed).await;
                     let mut pool = self.uv_pool.lock().await;
@@ -2306,7 +2308,7 @@ impl Daemon {
                 #[cfg(not(target_os = "windows"))]
                 let python_path = env_path.join("bin").join("python");
 
-                if python_path.exists() {
+                if python_path.exists() && pool_env_ready_marker_exists(&env_path) {
                     let hash_matches =
                         pool_package_hash_matches(&env_path, EnvType::Conda, &conda_prewarmed)
                             .await;
@@ -2354,7 +2356,7 @@ impl Daemon {
                 #[cfg(not(target_os = "windows"))]
                 let python_path = venv_path.join("bin").join("python");
 
-                if python_path.exists() && venv_path.join(".warmed").exists() {
+                if python_path.exists() && pool_env_ready_marker_exists(&venv_path) {
                     let hash_matches =
                         pool_package_hash_matches(&env_path, EnvType::Pixi, &pixi_prewarmed).await;
                     let mut pool = self.pixi_pool.lock().await;
@@ -6041,7 +6043,7 @@ mod tests {
         }
         std::fs::write(&python_path, "").unwrap();
 
-        // Create warmup marker so take() accepts this env
+        // Create warmup marker so take() accepts this env.
         std::fs::write(venv_path.join(".warmed"), "").unwrap();
 
         PooledEnv {
@@ -6855,11 +6857,11 @@ mod tests {
     }
 
     #[test]
-    fn test_pool_take_skips_unwarmed() {
+    fn test_pool_take_requires_readiness_marker() {
         let temp_dir = TempDir::new().unwrap();
         let mut pool = Pool::new(3, 3600);
 
-        // Create an env with valid paths but NO .warmed marker
+        // Create an env with valid paths but no readiness marker.
         let venv_path = temp_dir.path().join("unwarmed-env");
         std::fs::create_dir_all(&venv_path).unwrap();
         #[cfg(windows)]
@@ -6882,6 +6884,30 @@ mod tests {
         // take() should skip the unwarmed env
         let (taken, _stale) = pool.take();
         assert!(taken.is_none());
+
+        // A validated env without the full `.warmed` marker remains leaseable.
+        let ready_venv_path = temp_dir.path().join("ready-env");
+        std::fs::create_dir_all(&ready_venv_path).unwrap();
+        #[cfg(windows)]
+        let ready_python_path = ready_venv_path.join("Scripts").join("python.exe");
+        #[cfg(not(windows))]
+        let ready_python_path = ready_venv_path.join("bin").join("python");
+        if let Some(parent) = ready_python_path.parent() {
+            std::fs::create_dir_all(parent).unwrap();
+        }
+        std::fs::write(&ready_python_path, "").unwrap();
+        std::fs::write(ready_venv_path.join(POOL_READY_MARKER_FILE), "").unwrap();
+        let ready_env = PooledEnv {
+            env_type: EnvType::Uv,
+            venv_path: ready_venv_path.clone(),
+            python_path: ready_python_path,
+            prewarmed_packages: vec![],
+        };
+        pool.add(ready_env);
+
+        let (taken, _stale) = pool.take();
+        assert!(taken.is_some());
+        assert_eq!(taken.unwrap().venv_path, ready_venv_path);
 
         // Add a properly warmed env
         let warmed_env = create_test_env(&temp_dir, "warmed-env");
@@ -7764,6 +7790,31 @@ mod tests {
 
         let pool = daemon.uv_pool.lock().await;
         assert_eq!(pool.available.len(), 1);
+        assert!(pool.retired_paths.is_empty());
+    }
+
+    #[tokio::test]
+    async fn find_existing_environments_recovers_ready_marker_with_matching_package_hash() {
+        let temp_dir = TempDir::new().unwrap();
+        let config = DaemonConfig {
+            uv_pool_size: 1,
+            ..lease_test_config(&temp_dir)
+        };
+        std::fs::create_dir_all(&config.cache_dir).unwrap();
+        let expected = uv_prewarmed_packages(&[], true);
+        let env = create_test_env_in(&config.cache_dir, "runtimed-uv-ready-marker");
+        std::fs::remove_file(env.venv_path.join(".warmed")).unwrap();
+        std::fs::write(env.venv_path.join(POOL_READY_MARKER_FILE), "").unwrap();
+        write_pool_package_hash(&env.venv_path, EnvType::Uv, &expected)
+            .await
+            .unwrap();
+
+        let daemon = Daemon::new_for_test(config).unwrap();
+        daemon.find_existing_environments().await;
+
+        let pool = daemon.uv_pool.lock().await;
+        assert_eq!(pool.available.len(), 1);
+        assert_eq!(pool.available.front().unwrap().env.venv_path, env.venv_path);
         assert!(pool.retired_paths.is_empty());
     }
 

--- a/crates/runtimed/src/warm_env.rs
+++ b/crates/runtimed/src/warm_env.rs
@@ -235,12 +235,9 @@ where
 async fn collect_reader(
     handle: tokio::task::JoinHandle<io::Result<Vec<u8>>>,
 ) -> io::Result<Vec<u8>> {
-    handle.await.map_err(|error| {
-        io::Error::new(
-            io::ErrorKind::Other,
-            format!("failed to join child output reader: {error}"),
-        )
-    })?
+    handle
+        .await
+        .map_err(|error| io::Error::other(format!("failed to join child output reader: {error}")))?
 }
 
 async fn run_output_with_timeout(

--- a/crates/runtimed/src/warm_env.rs
+++ b/crates/runtimed/src/warm_env.rs
@@ -5,13 +5,15 @@
 //! writes structured JSON events to stdout, and exits. All of rattler's
 //! in-process memory is reclaimed by the OS when the process exits.
 
+use std::io;
 use std::path::{Path, PathBuf};
-use std::process::Stdio;
+use std::process::{Output, Stdio};
+use std::time::Duration;
 
 use serde::{Deserialize, Serialize};
 use tracing::{error, info, warn};
 
-use crate::async_outcome::{await_result_with_timeout, TimedResult};
+use crate::async_outcome::TimedResult;
 use crate::EnvType;
 
 // -- IPC protocol --------------------------------------------------------
@@ -115,6 +117,7 @@ fn emit_failure(error: String, error_kind: &str, failed_package: Option<String>)
 
 const POOL_PACKAGE_HASH_FILE: &str = ".runt-pool-packages.sha256";
 const POOL_PACKAGE_HASH_VERSION: &str = "v1";
+const POOL_READY_MARKER_FILE: &str = ".runt-pool-ready";
 
 fn expected_pool_package_hash(env_type: EnvType, packages: &[String]) -> String {
     use sha2::{Digest, Sha256};
@@ -149,6 +152,10 @@ async fn write_pool_package_hash(
     .await
 }
 
+async fn write_pool_ready_marker(env_root: &Path) -> std::io::Result<()> {
+    tokio::fs::write(env_root.join(POOL_READY_MARKER_FILE), "").await
+}
+
 // -- site-packages discovery ----------------------------------------------
 
 fn find_site_packages(env_path: &Path) -> Option<String> {
@@ -169,8 +176,13 @@ fn find_site_packages(env_path: &Path) -> Option<String> {
 
 // -- UV env creation ------------------------------------------------------
 
-const UV_OFFLINE_INSTALL_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(30);
-const UV_ONLINE_INSTALL_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(180);
+const UV_OFFLINE_INSTALL_TIMEOUT: Duration = Duration::from_secs(30);
+const UV_ONLINE_INSTALL_TIMEOUT: Duration = Duration::from_secs(180);
+const UV_VENV_TIMEOUT: Duration = Duration::from_secs(60);
+const PYTHON_RUNTIME_VALIDATION_TIMEOUT: Duration = Duration::from_secs(60);
+// Keep optional warming below the daemon's 120s pool-take wait. Long compileall
+// runs should not keep a validated environment out of the pool.
+const PYTHON_WARMUP_TIMEOUT: Duration = Duration::from_secs(30);
 
 fn uv_pip_install_args(python_path: &Path, packages: &[String], offline: bool) -> Vec<String> {
     let mut args = vec![
@@ -197,19 +209,193 @@ enum UvInstallAttempt {
 async fn run_uv_pip_install(
     uv_path: &Path,
     install_args: &[String],
-    timeout: std::time::Duration,
+    timeout: Duration,
 ) -> UvInstallAttempt {
     let mut command = tokio::process::Command::new(uv_path);
+    command.args(install_args);
+
+    match run_output_with_timeout(command, timeout).await {
+        TimedResult::Completed(output) => UvInstallAttempt::Completed(output),
+        TimedResult::Failed(e) => UvInstallAttempt::SpawnError(e),
+        TimedResult::TimedOut => UvInstallAttempt::Timeout,
+    }
+}
+
+async fn read_pipe_to_end<R>(mut reader: R) -> io::Result<Vec<u8>>
+where
+    R: tokio::io::AsyncRead + Unpin,
+{
+    use tokio::io::AsyncReadExt;
+
+    let mut output = Vec::new();
+    reader.read_to_end(&mut output).await?;
+    Ok(output)
+}
+
+async fn collect_reader(
+    handle: tokio::task::JoinHandle<io::Result<Vec<u8>>>,
+) -> io::Result<Vec<u8>> {
+    handle.await.map_err(|error| {
+        io::Error::new(
+            io::ErrorKind::Other,
+            format!("failed to join child output reader: {error}"),
+        )
+    })?
+}
+
+async fn run_output_with_timeout(
+    mut command: tokio::process::Command,
+    timeout: Duration,
+) -> TimedResult<Output, io::Error> {
     command
-        .args(install_args)
         .kill_on_drop(true)
         .stdout(Stdio::piped())
         .stderr(Stdio::piped());
 
-    match await_result_with_timeout(command.output(), timeout).await {
-        TimedResult::Completed(output) => UvInstallAttempt::Completed(output),
-        TimedResult::Failed(e) => UvInstallAttempt::SpawnError(e),
-        TimedResult::TimedOut => UvInstallAttempt::Timeout,
+    let mut child = match command.spawn() {
+        Ok(child) => child,
+        Err(error) => return TimedResult::Failed(error),
+    };
+
+    let stdout = child
+        .stdout
+        .take()
+        .map(|pipe| tokio::spawn(read_pipe_to_end(pipe)));
+    let stderr = child
+        .stderr
+        .take()
+        .map(|pipe| tokio::spawn(read_pipe_to_end(pipe)));
+
+    let status = match tokio::time::timeout(timeout, child.wait()).await {
+        Ok(Ok(status)) => status,
+        Ok(Err(error)) => return TimedResult::Failed(error),
+        Err(_) => {
+            // Dropping `Command::output()` on timeout can leave the spawned
+            // process running. Keep ownership of the child handle and kill it
+            // before reporting the timeout so warmup retries do not accumulate
+            // orphaned Python processes.
+            let _ = child.kill().await;
+            let _ = child.wait().await;
+            if let Some(stdout) = stdout {
+                let _ = collect_reader(stdout).await;
+            }
+            if let Some(stderr) = stderr {
+                let _ = collect_reader(stderr).await;
+            }
+            return TimedResult::TimedOut;
+        }
+    };
+
+    let stdout = match stdout {
+        Some(stdout) => match collect_reader(stdout).await {
+            Ok(output) => output,
+            Err(error) => return TimedResult::Failed(error),
+        },
+        None => Vec::new(),
+    };
+    let stderr = match stderr {
+        Some(stderr) => match collect_reader(stderr).await {
+            Ok(output) => output,
+            Err(error) => return TimedResult::Failed(error),
+        },
+        None => Vec::new(),
+    };
+
+    TimedResult::Completed(Output {
+        status,
+        stdout,
+        stderr,
+    })
+}
+
+fn stderr_excerpt(output: &Output) -> String {
+    String::from_utf8_lossy(&output.stderr)
+        .chars()
+        .take(200)
+        .collect::<String>()
+}
+
+async fn run_python_script(
+    python_path: &Path,
+    script: &str,
+    timeout: Duration,
+) -> TimedResult<Output, io::Error> {
+    let mut command = tokio::process::Command::new(python_path);
+    command.args(["-c", script]);
+    run_output_with_timeout(command, timeout).await
+}
+
+async fn validate_python_runtime(
+    python_path: &Path,
+    env_label: &str,
+) -> Result<(), (String, &'static str)> {
+    let validation_script = kernel_env::warmup::build_warmup_command(&[], false, None);
+
+    match run_python_script(
+        python_path,
+        &validation_script,
+        PYTHON_RUNTIME_VALIDATION_TIMEOUT,
+    )
+    .await
+    {
+        TimedResult::Completed(output) if output.status.success() => Ok(()),
+        TimedResult::Completed(output) => Err((
+            format!(
+                "{env_label} runtime validation failed: {}",
+                stderr_excerpt(&output)
+            ),
+            "import_error",
+        )),
+        TimedResult::Failed(error) => Err((
+            format!("{env_label} runtime validation failed: {error}"),
+            "import_error",
+        )),
+        TimedResult::TimedOut => Err((
+            format!(
+                "{env_label} runtime validation timed out after {} seconds",
+                PYTHON_RUNTIME_VALIDATION_TIMEOUT.as_secs()
+            ),
+            "timeout",
+        )),
+    }
+}
+
+async fn run_best_effort_python_warmup(
+    env_dir: &Path,
+    python_path: &Path,
+    packages: &[String],
+    include_conda: bool,
+    env_label: &str,
+) {
+    let site_packages = find_site_packages(env_dir);
+    let warmup_script =
+        kernel_env::warmup::build_warmup_command(packages, include_conda, site_packages.as_deref());
+
+    match run_python_script(python_path, &warmup_script, PYTHON_WARMUP_TIMEOUT).await {
+        TimedResult::Completed(output) if output.status.success() => {
+            tokio::fs::write(env_dir.join(".warmed"), "").await.ok();
+        }
+        TimedResult::Completed(output) => {
+            warn!(
+                "[warm-env] {env_label} warmup failed; keeping validated environment usable without .warmed marker: {}",
+                stderr_excerpt(&output)
+            );
+        }
+        TimedResult::Failed(error) => {
+            warn!(
+                "[warm-env] {env_label} warmup failed; keeping validated environment usable without .warmed marker: {error}"
+            );
+        }
+        TimedResult::TimedOut => {
+            // The pool warmer is already a background optimization. Detaching
+            // compileall/import work after this point would race with env
+            // claims, eviction, and cleanup, so keep it bounded and admit the
+            // validated env without the warmed marker when it runs long.
+            warn!(
+                "[warm-env] {env_label} warmup timed out after {} seconds; keeping validated environment usable without .warmed marker",
+                PYTHON_WARMUP_TIMEOUT.as_secs()
+            );
+        }
     }
 }
 
@@ -279,18 +465,13 @@ async fn create_uv(env_dir: &Path, packages: &[String]) {
 
     // Create venv
     progress("venv", "creating virtual environment");
-    let venv_result = await_result_with_timeout(
-        tokio::process::Command::new(&uv_path)
-            .arg("venv")
-            .arg(env_dir)
-            .arg("--python")
-            .arg("3.13")
-            .stdout(Stdio::piped())
-            .stderr(Stdio::piped())
-            .output(),
-        std::time::Duration::from_secs(60),
-    )
-    .await;
+    let mut venv_command = tokio::process::Command::new(&uv_path);
+    venv_command
+        .arg("venv")
+        .arg(env_dir)
+        .arg("--python")
+        .arg("3.13");
+    let venv_result = run_output_with_timeout(venv_command, UV_VENV_TIMEOUT).await;
 
     match venv_result {
         TimedResult::Completed(output) if output.status.success() => {}
@@ -368,55 +549,28 @@ async fn create_uv(env_dir: &Path, packages: &[String]) {
         return;
     }
 
+    // Required runtime validation comes before the expensive best-effort
+    // warmup. The env should not enter the pool if core kernel imports hang or
+    // fail, but compileall/import warming is only a performance optimization.
+    progress("validating", "checking kernel imports");
+    if let Err((error, kind)) = validate_python_runtime(&python_path, "UV").await {
+        cleanup_and_fail(env_dir, error, kind, None).await;
+        return;
+    }
+    if let Err(e) = write_pool_ready_marker(env_dir).await {
+        cleanup_and_fail(
+            env_dir,
+            format!("Failed to write pool readiness marker: {e}"),
+            "setup_failed",
+            None,
+        )
+        .await;
+        return;
+    }
+
     // Warmup (.pyc compilation)
     progress("warming", "compiling .pyc files");
-    let site_packages = find_site_packages(env_dir);
-    let warmup_script =
-        kernel_env::warmup::build_warmup_command(packages, false, site_packages.as_deref());
-
-    let warmup_result = await_result_with_timeout(
-        tokio::process::Command::new(&python_path)
-            .args(["-c", &warmup_script])
-            .stdout(Stdio::piped())
-            .stderr(Stdio::piped())
-            .output(),
-        std::time::Duration::from_secs(180),
-    )
-    .await;
-
-    match warmup_result {
-        TimedResult::Completed(output) if output.status.success() => {
-            tokio::fs::write(env_dir.join(".warmed"), "").await.ok();
-        }
-        TimedResult::Completed(output) => {
-            let stderr = String::from_utf8_lossy(&output.stderr);
-            cleanup_and_fail(
-                env_dir,
-                format!(
-                    "UV warmup failed: {}",
-                    stderr.chars().take(200).collect::<String>()
-                ),
-                "import_error",
-                None,
-            )
-            .await;
-            return;
-        }
-        TimedResult::Failed(e) => {
-            cleanup_and_fail(
-                env_dir,
-                format!("UV warmup failed: {e}"),
-                "import_error",
-                None,
-            )
-            .await;
-            return;
-        }
-        TimedResult::TimedOut => {
-            cleanup_and_fail(env_dir, "UV warmup timed out".into(), "timeout", None).await;
-            return;
-        }
-    }
+    run_best_effort_python_warmup(env_dir, &python_path, packages, false, "UV").await;
 
     // Write package hash marker
     if let Err(e) = write_pool_package_hash(env_dir, EnvType::Uv, packages).await {
@@ -643,55 +797,25 @@ async fn create_conda(env_dir: &Path, packages: &[String], channels: &[String]) 
         return;
     }
 
+    progress("validating", "checking kernel imports");
+    if let Err((error, kind)) = validate_python_runtime(&python_path, "Conda").await {
+        cleanup_and_fail(env_dir, error, kind, None).await;
+        return;
+    }
+    if let Err(e) = write_pool_ready_marker(env_dir).await {
+        cleanup_and_fail(
+            env_dir,
+            format!("Failed to write pool readiness marker: {e}"),
+            "setup_failed",
+            None,
+        )
+        .await;
+        return;
+    }
+
     // Warmup
     progress("warming", "compiling .pyc files");
-    let site_packages = find_site_packages(env_dir);
-    let warmup_script =
-        kernel_env::warmup::build_warmup_command(packages, true, site_packages.as_deref());
-
-    let warmup_result = await_result_with_timeout(
-        tokio::process::Command::new(&python_path)
-            .args(["-c", &warmup_script])
-            .stdout(Stdio::piped())
-            .stderr(Stdio::piped())
-            .output(),
-        std::time::Duration::from_secs(180),
-    )
-    .await;
-
-    match warmup_result {
-        TimedResult::Completed(output) if output.status.success() => {
-            tokio::fs::write(env_dir.join(".warmed"), "").await.ok();
-        }
-        TimedResult::Completed(output) => {
-            let stderr = String::from_utf8_lossy(&output.stderr);
-            cleanup_and_fail(
-                env_dir,
-                format!(
-                    "Conda warmup failed: {}",
-                    stderr.chars().take(200).collect::<String>()
-                ),
-                "import_error",
-                None,
-            )
-            .await;
-            return;
-        }
-        TimedResult::Failed(e) => {
-            cleanup_and_fail(
-                env_dir,
-                format!("Conda warmup failed: {e}"),
-                "import_error",
-                None,
-            )
-            .await;
-            return;
-        }
-        TimedResult::TimedOut => {
-            cleanup_and_fail(env_dir, "Conda warmup timed out".into(), "timeout", None).await;
-            return;
-        }
-    }
+    run_best_effort_python_warmup(env_dir, &python_path, packages, true, "Conda").await;
 
     if let Err(e) = write_pool_package_hash(env_dir, EnvType::Conda, packages).await {
         warn!("[warm-env] Failed to write Conda pool package marker: {e}");
@@ -861,6 +985,35 @@ mod tests {
         let h1 = expected_pool_package_hash(EnvType::Uv, &["b".into(), "a".into()]);
         let h2 = expected_pool_package_hash(EnvType::Uv, &["a".into(), "b".into()]);
         assert_eq!(h1, h2, "hash should be order-independent");
+    }
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn run_output_with_timeout_captures_stdout_and_stderr() {
+        let mut command = tokio::process::Command::new("sh");
+        command.args(["-c", "printf ok; printf err >&2"]);
+
+        let result = run_output_with_timeout(command, Duration::from_secs(5)).await;
+
+        match result {
+            TimedResult::Completed(output) => {
+                assert!(output.status.success());
+                assert_eq!(output.stdout, b"ok");
+                assert_eq!(output.stderr, b"err");
+            }
+            other => panic!("expected completed output, got {other:?}"),
+        }
+    }
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn run_output_with_timeout_kills_slow_child() {
+        let mut command = tokio::process::Command::new("sh");
+        command.args(["-c", "sleep 30"]);
+
+        let result = run_output_with_timeout(command, Duration::from_millis(25)).await;
+
+        assert!(matches!(result, TimedResult::TimedOut));
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- split required Python runtime validation from optional pool warmup work
- add a pool readiness marker so validated environments can be leased even when full `.pyc` warmup does not finish
- replace timeout-wrapped `Command::output()` with explicit child ownership so timed-out warmup children are killed and drained
- cap optional Python compile/import warmup at 30s and log it as a warning instead of reporting a pool failure

## Verification

- `cargo xtask lint --fix`
- `cargo test -p runtimed`

## Notes

The current approach avoids detaching `compileall`: a detached compiler can race with pool leasing, eviction, and cleanup. Instead, the env is validated, marked ready, and allowed into the pool after a short best-effort warmup window. Full `.warmed` remains the marker for environments that completed the optional warmup.
