### PR TITLE
feat(comments): shared comment-highlight surface across editor and rendered markdown

### DIFF
--- a/apps/elements/app/global.css
+++ b/apps/elements/app/global.css
@@ -5,6 +5,7 @@
 @import "../../../src/styles/ansi.css";
 @import "../../../src/styles/notebook-base.css";
 @import "../../../src/styles/cream-theme.css";
+@import "../../../src/styles/comment-highlight.css";
 
 @source "../**/*.{ts,tsx,mdx}";
 @source "../../../src/components/cell/**/*.{ts,tsx}";

--- a/apps/elements/app/page.tsx
+++ b/apps/elements/app/page.tsx
@@ -9,6 +9,7 @@ import {
   IdCard,
   LayoutDashboard,
   ListPlus,
+  MessageSquareText,
   MousePointer2,
   PackageCheck,
   Palette,
@@ -75,6 +76,12 @@ const catalogGroups = [
         description: "Target-specific notebook actions for menus and toolbars.",
         href: "/docs/context-controls",
         icon: MousePointer2,
+      },
+      {
+        title: "Comment surfaces",
+        description: "Anchored discussion, attribution, and rendered markdown highlights.",
+        href: "/docs/comment-surfaces",
+        icon: MessageSquareText,
       },
       {
         title: "Notebook toolbar",

--- a/apps/elements/components/comment-highlight-surfaces-example.tsx
+++ b/apps/elements/components/comment-highlight-surfaces-example.tsx
@@ -1,0 +1,95 @@
+"use client";
+
+import { ProjectedMarkdownView } from "@/components/markdown/ProjectedMarkdownView";
+import type { MarkdownProjectionPlan } from "../../../src/lib/markdown-projection";
+
+const commentHighlightPlan: MarkdownProjectionPlan = {
+  version: 1,
+  engine: "elements-fixture",
+  byteLength: 113,
+  utf16Length: 113,
+  measurement: { estimatedHeight: 96, confidence: "high", width: 760 },
+  anchors: [],
+  blocks: [
+    {
+      blockId: "open-paragraph",
+      blockIndex: 0,
+      element: "p",
+      kind: "paragraph",
+      measurement: { estimatedHeight: 40, confidence: "high", width: 760 },
+      sourceSpanByte: [0, 53],
+      sourceSpanUtf16: [0, 53],
+      syntaxSpans: [],
+      text: "Open thread text is highlighted in rendered markdown.",
+    },
+    {
+      blockId: "resolved-paragraph",
+      blockIndex: 1,
+      element: "p",
+      kind: "paragraph",
+      measurement: { estimatedHeight: 40, confidence: "high", width: 760 },
+      sourceSpanByte: [60, 113],
+      sourceSpanUtf16: [60, 113],
+      syntaxSpans: [],
+      text: "Resolved thread keeps the same surface in muted state.",
+    },
+  ],
+  runs: [
+    {
+      blockId: "open-paragraph",
+      inlineId: "open-highlight",
+      listItemIndex: null,
+      renderedText: "Open thread text",
+      renderedTextUtf16: [0, 16],
+      semantic: "text",
+      sourceSpanByte: [0, 16],
+      sourceSpanUtf16: [0, 16],
+    },
+    {
+      blockId: "open-paragraph",
+      inlineId: "open-rest",
+      listItemIndex: null,
+      renderedText: " is highlighted in rendered markdown.",
+      renderedTextUtf16: [16, 53],
+      semantic: "text",
+      sourceSpanByte: [16, 53],
+      sourceSpanUtf16: [16, 53],
+    },
+    {
+      blockId: "resolved-paragraph",
+      inlineId: "resolved-highlight",
+      listItemIndex: null,
+      renderedText: "Resolved thread",
+      renderedTextUtf16: [60, 75],
+      semantic: "text",
+      sourceSpanByte: [60, 75],
+      sourceSpanUtf16: [60, 75],
+    },
+    {
+      blockId: "resolved-paragraph",
+      inlineId: "resolved-rest",
+      listItemIndex: null,
+      renderedText: " keeps the same surface in muted state.",
+      renderedTextUtf16: [75, 113],
+      semantic: "text",
+      sourceSpanByte: [75, 113],
+      sourceSpanUtf16: [75, 113],
+    },
+  ],
+};
+
+export function CommentHighlightSurfacesExample() {
+  return (
+    <div className="not-prose my-6">
+      <article className="mx-auto max-w-[760px] border border-border bg-background px-6 py-5 text-foreground shadow-sm max-sm:px-4">
+        <ProjectedMarkdownView
+          plan={commentHighlightPlan}
+          commentHighlights={[
+            { from: 0, to: 16, color: "#16a34a", resolved: false },
+            { from: 60, to: 75, color: "#7c3aed", resolved: true },
+          ]}
+        />
+      </article>
+    </div>
+  );
+}

--- a/apps/elements/content/docs/comment-surfaces.mdx
+++ b/apps/elements/content/docs/comment-surfaces.mdx
@@ -4,6 +4,7 @@ description: Anchored notebook comments. The rail panel, attribution, and AI-on-
 ---
 
 import { CommentSurfacesExample } from "@/components/comment-surfaces-example";
+import { CommentHighlightSurfacesExample } from "@/components/comment-highlight-surfaces-example";
 
 People and AI agents work the same live notebook, and comments are how they
 talk about it: a thread anchored to a source range, a cell, an output, or the
@@ -11,6 +12,14 @@ whole document. The rail below is rendered from fixtures, no daemon and no
 kernel, so the surface and its rationale stand on their own.
 
 <CommentSurfacesExample />
+
+## Rendered markdown highlights
+
+Rendered markdown uses the same comment-highlight surface as the CodeMirror
+editor, so author color and resolved state stay aligned between edit and
+preview mode.
+
+<CommentHighlightSurfacesExample />
 
 ## Presentational by design
 

--- a/apps/elements/content/docs/index.mdx
+++ b/apps/elements/content/docs/index.mdx
@@ -39,6 +39,7 @@ concepts and which boundaries still need a notebook-semantic wrapper.
 - [Cloud dashboard](/docs/cloud-dashboard)
 - [Compute placement](/docs/compute-placement)
 - [Context controls](/docs/context-controls)
+- [Comment surfaces](/docs/comment-surfaces)
 - [Identity and environment surfaces](/docs/identity-environment-surfaces)
 - [Notebook toolbar surfaces](/docs/notebook-toolbar-surfaces)
 - [Notebook outline rail](/docs/notebook-outline)

--- a/apps/notebook-cloud/viewer/notebook-viewer.tsx
+++ b/apps/notebook-cloud/viewer/notebook-viewer.tsx
@@ -1975,6 +1975,7 @@ export function NotebookViewer({
                 onSetCellOutputsHidden={handleCloudSetCellOutputsHidden}
                 onCreateSourceComment={canWriteComments ? handleRequestSourceComment : undefined}
                 onActivateCommentThread={handleActivateCommentThread}
+                commentThreadsByCell={sourceCommentThreadsByCell}
                 markdownHeadingAnchorsByCellId={notebookViewModel.markdownHeadingAnchorsByCellId}
                 outputHostContext={outputHostContext}
                 deferOutputIsolatedFramesUntilVisible={!shellCapabilities.canEditCells}

--- a/apps/notebook/src/App.tsx
+++ b/apps/notebook/src/App.tsx
@@ -2005,6 +2005,7 @@ function AppContent() {
                 onSetCellOutputsHidden={setCellOutputsHidden}
                 onCreateSourceComment={canMutateComments ? handleRequestSourceComment : undefined}
                 onActivateCommentThread={handleActivateCommentThread}
+                commentThreadsByCell={sourceCommentThreadsByCell}
                 markdownHeadingAnchorsByCellId={markdownHeadingAnchorsByCellId}
               />
             </CrdtBridgeProvider>

--- a/apps/notebook/src/components/MarkdownCell.tsx
+++ b/apps/notebook/src/components/MarkdownCell.tsx
@@ -59,8 +59,9 @@ import {
   sourceRangeAnchorFromRenderedMarkdownSelection,
 } from "../lib/rendered-markdown-source-comment";
 import { commentHighlightExtension } from "../lib/comment-highlight-extension";
-import { refreshCellCommentHighlights } from "../lib/comment-highlights";
+import { refreshCellCommentHighlights, type SourceCommentThread } from "../lib/comment-highlights";
 import {
+  resolveSourceRangeAnchor,
   selectionRectFromDomRect,
   selectionRectFromDomSelection,
   type SourceCommentSelectionRect,
@@ -156,6 +157,7 @@ interface MarkdownCellProps {
     rect: SourceCommentSelectionRect | null,
   ) => void;
   onActivateCommentThread?: (threadId: string) => void;
+  commentThreads?: readonly SourceCommentThread[];
   outputHostContext?: NteractEmbedHostContextPatch;
 }
 
@@ -175,6 +177,7 @@ export const MarkdownCell = memo(function MarkdownCell({
   readOnly = false,
   onCreateSourceComment,
   onActivateCommentThread,
+  commentThreads,
   outputHostContext,
 }: MarkdownCellProps) {
   const isFocused = useIsCellFocused(cell.id);
@@ -289,12 +292,27 @@ export const MarkdownCell = memo(function MarkdownCell({
     [cell.markdownProjection, cell.source, draftPreviewSource],
   );
   const canRenderProjectionInHost = canRenderMarkdownProjectionInHost(markdownProjection);
-  const canCommentOnRenderedMarkdown =
-    Boolean(onCreateSourceComment) &&
-    !readOnly &&
-    !editing &&
+  const projectionMatchesPreview =
     markdownProjection !== null &&
     markdownProjectionMatchesSource(markdownProjection, previewSource);
+  const canCommentOnRenderedMarkdown =
+    Boolean(onCreateSourceComment) && !readOnly && !editing && projectionMatchesPreview;
+  const renderedCommentHighlights = useMemo(() => {
+    if (editing || !projectionMatchesPreview || !commentThreads?.length) return undefined;
+    const highlights = commentThreads.flatMap((thread) => {
+      const range = resolveSourceRangeAnchor(previewSource, thread.anchor);
+      if (!range) return [];
+      return [
+        {
+          from: range.from,
+          to: range.to,
+          resolved: thread.resolved,
+          ...(thread.color ? { color: thread.color } : {}),
+        },
+      ];
+    });
+    return highlights.length > 0 ? highlights : undefined;
+  }, [commentThreads, editing, previewSource, projectionMatchesPreview]);
   const previewMinHeight = useMemo(
     () =>
       projectedMarkdownPreviewHeight(
@@ -1069,6 +1087,7 @@ export const MarkdownCell = memo(function MarkdownCell({
               {previewSource && canRenderProjectionInHost && markdownProjection ? (
                 <ProjectedMarkdownView
                   plan={markdownProjection}
+                  commentHighlights={renderedCommentHighlights}
                   headingAnchors={headingAnchors}
                   onLinkClick={handleLinkClick}
                   canCommentOnRuns={

--- a/apps/notebook/src/components/NotebookView.tsx
+++ b/apps/notebook/src/components/NotebookView.tsx
@@ -60,6 +60,7 @@ import type { CodeCell as CodeCellType, NotebookCell } from "../types";
 import { CodeCell, type HiddenGroupCellSummary } from "./CodeCell";
 import { MarkdownCell } from "./MarkdownCell";
 import { RawCell } from "./RawCell";
+import type { SourceCommentThread } from "../lib/comment-highlights";
 import type {
   SourceCommentSelectionRect,
   SourceRangeCommentAnchor,
@@ -93,6 +94,7 @@ export interface NotebookViewProps {
     rect: SourceCommentSelectionRect | null,
   ) => void;
   onActivateCommentThread?: (threadId: string) => void;
+  commentThreadsByCell?: ReadonlyMap<string, readonly SourceCommentThread[]>;
   markdownHeadingAnchorsByCellId?: ReadonlyMap<string, readonly MarkdownHeadingAnchor[]>;
   outputHostContext?: NteractEmbedHostContextPatch;
   deferOutputIsolatedFramesUntilVisible?: boolean;
@@ -371,6 +373,7 @@ function NotebookViewContent({
   onSetCellOutputsHidden,
   onCreateSourceComment,
   onActivateCommentThread,
+  commentThreadsByCell,
   markdownHeadingAnchorsByCellId,
   outputHostContext,
   deferOutputIsolatedFramesUntilVisible = false,
@@ -1019,6 +1022,7 @@ function NotebookViewContent({
             isDragging={isDragging}
             rightGutterContent={rightGutterContent}
             headingAnchors={markdownHeadingAnchorsByCellId?.get(cell.id)}
+            commentThreads={commentThreadsByCell?.get(cell.id)}
             readOnly={!canEditMarkdownSources}
             onCreateSourceComment={onCreateSourceComment}
             onActivateCommentThread={onActivateCommentThread}
@@ -1063,6 +1067,7 @@ function NotebookViewContent({
       onSetCellOutputsHidden,
       onCreateSourceComment,
       onActivateCommentThread,
+      commentThreadsByCell,
       markdownHeadingAnchorsByCellId,
       canEditCodeCellSources,
       canEditMarkdownSources,

--- a/apps/notebook/src/index.css
+++ b/apps/notebook/src/index.css
@@ -7,6 +7,7 @@
 @import "../../../src/styles/ansi.css";
 @import "../../../src/styles/notebook-base.css";
 @import "../../../src/styles/cream-theme.css";
+@import "../../../src/styles/comment-highlight.css";
 
 html,
 body,

--- a/apps/notebook/src/lib/comment-highlight-extension.ts
+++ b/apps/notebook/src/lib/comment-highlight-extension.ts
@@ -71,8 +71,8 @@ function buildDecorations(highlights: CommentHighlight[]): DecorationSet {
       highlight.to,
       Decoration.mark({
         class: highlight.resolved
-          ? "cm-comment-highlight cm-comment-highlight-resolved"
-          : "cm-comment-highlight",
+          ? "cm-comment-highlight comment-highlight cm-comment-highlight-resolved comment-highlight-resolved"
+          : "cm-comment-highlight comment-highlight",
         attributes,
       }),
     );
@@ -92,21 +92,6 @@ const decorationsField = StateField.define<DecorationSet>({
 });
 
 const commentHighlightTheme = EditorView.baseTheme({
-  ".cm-comment-highlight": {
-    "--cm-comment-color": "hsl(45 93% 47%)",
-    backgroundColor: "color-mix(in srgb, var(--cm-comment-color) 22%, transparent)",
-    borderBottom: "2px solid color-mix(in srgb, var(--cm-comment-color) 70%, transparent)",
-    borderRadius: "2px",
-    cursor: "pointer",
-    transition: "background-color 120ms ease",
-  },
-  ".cm-comment-highlight:hover": {
-    backgroundColor: "color-mix(in srgb, var(--cm-comment-color) 38%, transparent)",
-  },
-  ".cm-comment-highlight-resolved": {
-    backgroundColor: "color-mix(in srgb, var(--muted-foreground, #737373) 12%, transparent)",
-    borderBottomColor: "color-mix(in srgb, var(--muted-foreground, #737373) 40%, transparent)",
-  },
   ".cm-tooltip.cm-tooltip-hover": {
     border: "none",
     backgroundColor: "transparent",

--- a/src/components/markdown/ProjectedMarkdownView.tsx
+++ b/src/components/markdown/ProjectedMarkdownView.tsx
@@ -46,10 +46,18 @@ import {
 
 import "katex/dist/katex.min.css";
 
+export interface MarkdownCommentHighlight {
+  from: number;
+  to: number;
+  color?: string;
+  resolved: boolean;
+}
+
 interface ProjectedMarkdownViewProps {
   plan: MarkdownProjectionPlan;
   className?: string;
   activeSourcePosition?: number;
+  commentHighlights?: ReadonlyArray<MarkdownCommentHighlight>;
   colorTheme?: "classic" | "cream";
   headingAnchors?: readonly MarkdownHeadingAnchor[];
   canCommentOnRuns?: (runs: readonly MarkdownProjectionRun[]) => boolean;
@@ -62,6 +70,7 @@ export function ProjectedMarkdownView({
   plan,
   className,
   activeSourcePosition,
+  commentHighlights,
   colorTheme: colorThemeOverride,
   canCommentOnRuns,
   headingAnchors = [],
@@ -98,6 +107,7 @@ export function ProjectedMarkdownView({
           activeBlockId={activeBlockId}
           activeInlineId={activeInlineId}
           colorTheme={colorTheme}
+          commentHighlights={commentHighlights}
           isDark={isDark}
           runs={runsByBlock.get(block.blockId) ?? []}
           canCommentOnRuns={canCommentOnRuns}
@@ -116,6 +126,7 @@ interface ProjectedMarkdownBlockProps {
   activeBlockId?: string;
   activeInlineId?: string;
   colorTheme: "classic" | "cream";
+  commentHighlights?: ReadonlyArray<MarkdownCommentHighlight>;
   isDark: boolean;
   runs: MarkdownProjectionRun[];
   canCommentOnRuns?: (runs: readonly MarkdownProjectionRun[]) => boolean;
@@ -130,6 +141,7 @@ function ProjectedMarkdownBlock({
   activeBlockId,
   activeInlineId,
   colorTheme,
+  commentHighlights,
   isDark,
   runs,
   canCommentOnRuns,
@@ -151,7 +163,7 @@ function ProjectedMarkdownBlock({
         data-source-active={activeBlockId === block.blockId ? "true" : undefined}
         className={cn(activeBlockId === block.blockId && sourceActiveBlockClass)}
       >
-        {renderRuns(runs, onLinkClick, activeInlineId)}
+        {renderRuns(runs, { activeInlineId, commentHighlights, onLinkClick })}
       </MarkdownHeading>
     );
   }
@@ -164,6 +176,7 @@ function ProjectedMarkdownBlock({
         items={items}
         activeBlock={activeBlockId === block.blockId}
         activeInlineId={activeInlineId}
+        commentHighlights={commentHighlights}
         ordered={ordered}
         onLinkClick={onLinkClick}
         onTaskCheckedChange={onTaskCheckedChange}
@@ -207,7 +220,7 @@ function ProjectedMarkdownBlock({
         data-source-active={activeBlockId === block.blockId ? "true" : undefined}
         className={cn(activeBlockId === block.blockId && sourceActiveBlockClass)}
       >
-        {renderRuns(runs, onLinkClick, activeInlineId)}
+        {renderRuns(runs, { activeInlineId, commentHighlights, onLinkClick })}
       </MarkdownBlockquote>
     );
   }
@@ -221,6 +234,7 @@ function ProjectedMarkdownBlock({
       <ProjectedTable
         activeBlock={activeBlockId === block.blockId}
         activeInlineId={activeInlineId}
+        commentHighlights={commentHighlights}
         runs={runs}
         fallbackText={block.text}
         onLinkClick={onLinkClick}
@@ -239,6 +253,7 @@ function ProjectedMarkdownBlock({
         <ProjectedFigure
           active={activeBlockId === block.blockId}
           activeInlineId={activeInlineId}
+          commentHighlights={commentHighlights}
           run={figureRun}
         />
       );
@@ -254,7 +269,7 @@ function ProjectedMarkdownBlock({
           activeBlockId === block.blockId && sourceActiveBlockClass,
         )}
       >
-        {renderRuns(runs, onLinkClick, activeInlineId)}
+        {renderRuns(runs, { activeInlineId, commentHighlights, onLinkClick })}
         {canComment ? (
           <button
             type="button"
@@ -293,7 +308,7 @@ function ProjectedMarkdownBlock({
       data-source-active={activeBlockId === block.blockId ? "true" : undefined}
       className={cn("my-2", activeBlockId === block.blockId && sourceActiveBlockClass)}
     >
-      {renderRuns(runs, onLinkClick, activeInlineId)}
+      {renderRuns(runs, { activeInlineId, commentHighlights, onLinkClick })}
     </div>
   ) : null;
 }
@@ -326,6 +341,7 @@ function ProjectedList({
   items,
   activeBlock,
   activeInlineId,
+  commentHighlights,
   ordered,
   onLinkClick,
   onTaskCheckedChange,
@@ -333,6 +349,7 @@ function ProjectedList({
   items: ProjectedListItem[];
   activeBlock: boolean;
   activeInlineId?: string;
+  commentHighlights?: ReadonlyArray<MarkdownCommentHighlight>;
   ordered: boolean;
   onLinkClick?: (url: string) => void;
   onTaskCheckedChange?: (run: MarkdownProjectionRun, checked: boolean) => void;
@@ -359,6 +376,7 @@ function ProjectedList({
           key={item.key}
           item={item}
           activeInlineId={activeInlineId}
+          commentHighlights={commentHighlights}
           taskProtocol={allItemsAreTasks}
           onLinkClick={onLinkClick}
           onTaskCheckedChange={onTaskCheckedChange}
@@ -371,12 +389,14 @@ function ProjectedList({
 function ProjectedListItem({
   item,
   activeInlineId,
+  commentHighlights,
   taskProtocol,
   onLinkClick,
   onTaskCheckedChange,
 }: {
   item: ProjectedListItem;
   activeInlineId?: string;
+  commentHighlights?: ReadonlyArray<MarkdownCommentHighlight>;
   taskProtocol: boolean;
   onLinkClick?: (url: string) => void;
   onTaskCheckedChange?: (run: MarkdownProjectionRun, checked: boolean) => void;
@@ -401,7 +421,7 @@ function ProjectedListItem({
         />
       ) : null}
       <ProjectedTaskContent checked={checked}>
-        {renderRuns(item.runs, onLinkClick, activeInlineId)}
+        {renderRuns(item.runs, { activeInlineId, commentHighlights, onLinkClick })}
       </ProjectedTaskContent>
     </>
   );
@@ -434,6 +454,7 @@ function ProjectedListItem({
           items={item.children}
           activeBlock={false}
           activeInlineId={activeInlineId}
+          commentHighlights={commentHighlights}
           ordered={item.children[0]?.ordered ?? false}
           onLinkClick={onLinkClick}
           onTaskCheckedChange={onTaskCheckedChange}
@@ -557,12 +578,14 @@ function ProjectedTaskContent({
 function ProjectedTable({
   activeBlock,
   activeInlineId,
+  commentHighlights,
   fallbackText,
   onLinkClick,
   runs,
 }: {
   activeBlock: boolean;
   activeInlineId?: string;
+  commentHighlights?: ReadonlyArray<MarkdownCommentHighlight>;
   fallbackText: string;
   onLinkClick?: (url: string) => void;
   runs: MarkdownProjectionRun[];
@@ -601,7 +624,11 @@ function ProjectedTable({
                   key={cell.key}
                   style={tableCellStyle(columnAlign.get(cell.cellIndex))}
                 >
-                  {renderRuns(cell.runs, onLinkClick, activeInlineId)}
+                  {renderRuns(cell.runs, {
+                    activeInlineId,
+                    commentHighlights,
+                    onLinkClick,
+                  })}
                 </MarkdownTableHeaderCell>
               ))}
             </MarkdownTableHeaderRow>
@@ -615,7 +642,11 @@ function ProjectedTable({
                   key={cell.key}
                   style={tableCellStyle(columnAlign.get(cell.cellIndex))}
                 >
-                  {renderRuns(cell.runs, onLinkClick, activeInlineId)}
+                  {renderRuns(cell.runs, {
+                    activeInlineId,
+                    commentHighlights,
+                    onLinkClick,
+                  })}
                 </MarkdownTableCell>
               ))}
             </MarkdownTableRow>
@@ -703,27 +734,71 @@ function tableCellStyle(align: MarkdownProjectionRun["tableCellAlign"]): CSSProp
   return undefined;
 }
 
-function renderRuns(
-  runs: MarkdownProjectionRun[],
-  onLinkClick?: (url: string) => void,
-  activeInlineId?: string,
-) {
+interface RenderRunsOptions {
+  activeInlineId?: string;
+  commentHighlights?: ReadonlyArray<MarkdownCommentHighlight>;
+  onLinkClick?: (url: string) => void;
+}
+
+function renderRuns(runs: MarkdownProjectionRun[], options: RenderRunsOptions = {}) {
   if (runs.length === 0) return null;
 
-  return runs.map((run) => (
-    <span
-      key={run.inlineId}
-      data-markdown-source-run="true"
-      data-rendered-start={run.renderedTextUtf16[0]}
-      data-rendered-end={run.renderedTextUtf16[1]}
-      data-source-start={run.sourceSpanUtf16[0]}
-      data-source-end={run.sourceSpanUtf16[1]}
-      data-source-active-run={activeInlineId === run.inlineId ? "true" : undefined}
-      className={cn(activeInlineId === run.inlineId && sourceActiveRunClass)}
-    >
-      {renderRun(run, onLinkClick)}
-    </span>
-  ));
+  const { activeInlineId, commentHighlights, onLinkClick } = options;
+  return runs.map((run) => {
+    const highlight = commentHighlightForRun(run, commentHighlights);
+    return (
+      <span
+        key={run.inlineId}
+        data-markdown-source-run="true"
+        data-rendered-start={run.renderedTextUtf16[0]}
+        data-rendered-end={run.renderedTextUtf16[1]}
+        data-source-start={run.sourceSpanUtf16[0]}
+        data-source-end={run.sourceSpanUtf16[1]}
+        data-source-active-run={activeInlineId === run.inlineId ? "true" : undefined}
+        className={cn(
+          activeInlineId === run.inlineId && sourceActiveRunClass,
+          highlight && "comment-highlight",
+          highlight?.resolved && "comment-highlight-resolved",
+        )}
+        style={commentHighlightStyle(highlight)}
+      >
+        {renderRun(run, onLinkClick)}
+      </span>
+    );
+  });
+}
+
+function commentHighlightForRun(
+  run: MarkdownProjectionRun,
+  commentHighlights: ReadonlyArray<MarkdownCommentHighlight> | undefined,
+): MarkdownCommentHighlight | null {
+  if (!commentHighlights?.length) return null;
+  const [runStart, runEnd] = run.sourceSpanUtf16;
+  let best: MarkdownCommentHighlight | null = null;
+  let bestLength = Number.POSITIVE_INFINITY;
+  let bestStart = Number.POSITIVE_INFINITY;
+
+  for (const highlight of commentHighlights) {
+    const start = Math.min(highlight.from, highlight.to);
+    const end = Math.max(highlight.from, highlight.to);
+    if (start === end) continue;
+    if (runStart >= end || runEnd <= start) continue;
+    const length = end - start;
+    if (length < bestLength || (length === bestLength && start < bestStart)) {
+      best = highlight;
+      bestLength = length;
+      bestStart = start;
+    }
+  }
+
+  return best;
+}
+
+function commentHighlightStyle(
+  highlight: MarkdownCommentHighlight | null,
+): CSSProperties | undefined {
+  if (!highlight?.color) return undefined;
+  return { "--cm-comment-color": highlight.color } as CSSProperties;
 }
 
 function renderRun(run: MarkdownProjectionRun, onLinkClick?: (url: string) => void) {
@@ -779,21 +854,32 @@ function imageOnlyRun(runs: MarkdownProjectionRun[]): MarkdownProjectionRun | nu
 function ProjectedFigure({
   active,
   activeInlineId,
+  commentHighlights,
   run,
 }: {
   active: boolean;
   activeInlineId?: string;
+  commentHighlights?: ReadonlyArray<MarkdownCommentHighlight>;
   run: MarkdownProjectionRun;
 }) {
   const image = <ProjectedImage run={run} />;
+  const highlight = commentHighlightForRun(run, commentHighlights);
   const title = run.imageTitle?.trim();
   return (
     <MarkdownFigure
       data-source-active={active ? "true" : undefined}
       className={cn(active && sourceActiveBlockClass)}
     >
-      {activeInlineId === run.inlineId ? (
-        <span data-source-active-run="true" className={sourceActiveRunClass}>
+      {activeInlineId === run.inlineId || highlight ? (
+        <span
+          data-source-active-run={activeInlineId === run.inlineId ? "true" : undefined}
+          className={cn(
+            activeInlineId === run.inlineId && sourceActiveRunClass,
+            highlight && "comment-highlight",
+            highlight?.resolved && "comment-highlight-resolved",
+          )}
+          style={commentHighlightStyle(highlight)}
+        >
           {image}
         </span>
       ) : (

--- a/src/components/markdown/__tests__/ProjectedMarkdownView.test.tsx
+++ b/src/components/markdown/__tests__/ProjectedMarkdownView.test.tsx
@@ -80,6 +80,61 @@ describe("ProjectedMarkdownView", () => {
     expect(run).toHaveAttribute("data-source-end", "5");
   });
 
+  it("renders open and resolved comment highlights for overlapping source ranges", () => {
+    const { container } = render(
+      <ProjectedMarkdownView
+        commentHighlights={[
+          { from: 0, to: 20, color: "#d97706", resolved: false },
+          { from: 6, to: 10, color: "#52525b", resolved: true },
+        ]}
+        plan={plan({
+          blocks: [
+            {
+              blockId: "p0",
+              blockIndex: 0,
+              element: "p",
+              kind: "paragraph",
+              measurement: { estimatedHeight: 32, confidence: "high", width: 720 },
+              sourceSpanByte: [0, 10],
+              sourceSpanUtf16: [0, 10],
+              syntaxSpans: [],
+              text: "alpha beta",
+            },
+          ],
+          runs: [
+            {
+              blockId: "p0",
+              inlineId: "r0",
+              listItemIndex: null,
+              renderedText: "alpha",
+              renderedTextUtf16: [0, 5],
+              semantic: "text",
+              sourceSpanByte: [0, 5],
+              sourceSpanUtf16: [0, 5],
+            },
+            {
+              blockId: "p0",
+              inlineId: "r1",
+              listItemIndex: null,
+              renderedText: "beta",
+              renderedTextUtf16: [6, 10],
+              semantic: "text",
+              sourceSpanByte: [6, 10],
+              sourceSpanUtf16: [6, 10],
+            },
+          ],
+        })}
+      />,
+    );
+
+    const runs = container.querySelectorAll<HTMLElement>("[data-markdown-source-run='true']");
+    expect(runs[0]).toHaveClass("comment-highlight");
+    expect(runs[0]).not.toHaveClass("comment-highlight-resolved");
+    expect(runs[0]?.style.getPropertyValue("--cm-comment-color")).toBe("#d97706");
+    expect(runs[1]).toHaveClass("comment-highlight", "comment-highlight-resolved");
+    expect(runs[1]?.style.getPropertyValue("--cm-comment-color")).toBe("#52525b");
+  });
+
   it("renders keyboard-accessible comment actions for commentable paragraphs", () => {
     const onCommentRuns = vi.fn();
     render(

--- a/src/index.css
+++ b/src/index.css
@@ -1,5 +1,6 @@
 @import "tailwindcss";
 @import "./styles/ansi.css";
+@import "./styles/comment-highlight.css";
 
 @custom-variant dark (&:is(.dark *));
 

--- a/src/lib/__tests__/markdown-projection.test.ts
+++ b/src/lib/__tests__/markdown-projection.test.ts
@@ -7,10 +7,13 @@ import { beforeAll, describe, expect, it } from "vite-plus/test";
 import {
   canRenderMarkdownProjectionInHost,
   findMarkdownProjectionAtSourcePosition,
+  markdownRunsForSourceRange,
   markdownProjectionMatchesSource,
   projectMarkdownPlan,
   resolveMarkdownProjection,
   setMarkdownProjectionProjector,
+  type MarkdownProjectionPlan,
+  type MarkdownProjectionRun,
 } from "../markdown-projection";
 
 function readMarkdownFixture(name: string): string {
@@ -18,6 +21,35 @@ function readMarkdownFixture(name: string): string {
     join(process.cwd(), "src/lib/__tests__/fixtures", name),
     "utf8",
   );
+}
+
+function testRun(
+  inlineId: string,
+  sourceSpanUtf16: readonly [number, number],
+): MarkdownProjectionRun {
+  return {
+    blockId: "block:0",
+    inlineId,
+    listItemIndex: null,
+    renderedText: inlineId,
+    renderedTextUtf16: sourceSpanUtf16,
+    semantic: "text",
+    sourceSpanByte: sourceSpanUtf16,
+    sourceSpanUtf16,
+  };
+}
+
+function testPlan(runs: readonly MarkdownProjectionRun[]): MarkdownProjectionPlan {
+  return {
+    version: 1,
+    engine: "test",
+    byteLength: 30,
+    utf16Length: 30,
+    measurement: { estimatedHeight: 24, confidence: "high", width: 720 },
+    anchors: [],
+    blocks: [],
+    runs,
+  };
 }
 
 describe("markdown projection", () => {
@@ -332,5 +364,35 @@ describe("markdown projection", () => {
         }),
       }),
     );
+  });
+
+  it("returns projected runs whose source spans overlap a source range", () => {
+    const plan = testPlan([
+      testRun("before", [0, 4]),
+      testRun("left-edge", [4, 9]),
+      testRun("inside", [9, 14]),
+      testRun("right-edge", [14, 20]),
+      testRun("after", [20, 24]),
+    ]);
+
+    expect(markdownRunsForSourceRange(plan, 8, 15).map((run) => run.inlineId)).toEqual([
+      "left-edge",
+      "inside",
+      "right-edge",
+    ]);
+  });
+
+  it("returns no projected runs for null plans and empty source ranges", () => {
+    const plan = testPlan([testRun("run", [0, 5])]);
+
+    expect(markdownRunsForSourceRange(null, 0, 5)).toEqual([]);
+    expect(markdownRunsForSourceRange(plan, 3, 3)).toEqual([]);
+    expect(markdownRunsForSourceRange(plan, 5, 10)).toEqual([]);
+  });
+
+  it("normalizes reversed source ranges before matching projected runs", () => {
+    const plan = testPlan([testRun("run", [4, 9])]);
+
+    expect(markdownRunsForSourceRange(plan, 8, 2).map((run) => run.inlineId)).toEqual(["run"]);
   });
 });

--- a/src/lib/markdown-projection.ts
+++ b/src/lib/markdown-projection.ts
@@ -257,6 +257,21 @@ export function findMarkdownProjectionAtSourcePosition(
   return { block, position: normalizedPosition, run };
 }
 
+export function markdownRunsForSourceRange(
+  plan: MarkdownProjectionPlan | null,
+  from: number,
+  to: number,
+): MarkdownProjectionRun[] {
+  if (!plan) return [];
+  const start = Math.min(from, to);
+  const end = Math.max(from, to);
+  if (start === end) return [];
+  return plan.runs.filter((run) => {
+    const [runStart, runEnd] = run.sourceSpanUtf16;
+    return runStart < end && runEnd > start;
+  });
+}
+
 export function canRenderMarkdownProjectionInHost(plan: MarkdownProjectionPlan | null): boolean {
   return plan != null;
 }

--- a/src/styles/comment-highlight.css
+++ b/src/styles/comment-highlight.css
@@ -13,5 +13,7 @@
 
 .comment-highlight-resolved {
   background-color: color-mix(in srgb, var(--muted-foreground, #737373) 12%, transparent);
-  border-bottom-color: color-mix(in srgb, var(--muted-foreground, #737373) 40%, transparent);
+  /* Resolved threads keep only a faint tint. The underline is the open-comment
+     "needs attention" cue, so a resolved thread drops it. */
+  border-bottom: none;
 }

--- a/src/styles/comment-highlight.css
+++ b/src/styles/comment-highlight.css
@@ -1,0 +1,17 @@
+.comment-highlight {
+  --cm-comment-color: hsl(45 93% 47%);
+  background-color: color-mix(in srgb, var(--cm-comment-color) 22%, transparent);
+  border-bottom: 2px solid color-mix(in srgb, var(--cm-comment-color) 70%, transparent);
+  border-radius: 2px;
+  cursor: pointer;
+  transition: background-color 120ms ease;
+}
+
+.comment-highlight:hover {
+  background-color: color-mix(in srgb, var(--cm-comment-color) 38%, transparent);
+}
+
+.comment-highlight-resolved {
+  background-color: color-mix(in srgb, var(--muted-foreground, #737373) 12%, transparent);
+  border-bottom-color: color-mix(in srgb, var(--muted-foreground, #737373) 40%, transparent);
+}


### PR DESCRIPTION
The comment highlight is now one shared visual surface across planes: the CodeMirror editor and rendered markdown prose use the same definition, so they look identical and tune in one place. This also adds comment highlights to rendered markdown. Completes Phase 2 of rendered-markdown commenting (after #3751, #3755).

## Shared surface

The tint and open/resolved treatment move from the CodeMirror `baseTheme` into a shared stylesheet (`src/styles/comment-highlight.css`: `.comment-highlight` / `.comment-highlight-resolved`, driven by `--cm-comment-color`), imported by both the notebook and cloud-viewer entrypoints. The editor decoration co-classes onto it and no color rules remain in the theme, so tuning the stylesheet updates both planes. The editor highlight is visually unchanged.

## Rendered highlights

`ProjectedMarkdownView` gains a `commentHighlights` prop and tints the overlapping run spans (via `markdownRunsForSourceRange`, harvested here). The hosts pass per-cell threads through `NotebookView` to `MarkdownCell`, which resolves each anchor against the rendered source and builds the highlights. The rendered view has no editor, so it cannot use the CodeMirror highlight bridge.

## Elements

A fixture renders the highlight on prose (open + resolved) so the shared surface is tunable in the design system.

## Verification

`vp check` clean; full `vp test` green (2419), including new tests for `markdownRunsForSourceRange` overlap and the `ProjectedMarkdownView` highlight rendering, with the existing comment-highlight tests still passing; `apps/notebook-cloud` typecheck clean; `apps/elements` build clean (28/28 pages).
