### PR TITLE
fix(comments): QA pass on comment UI/UX (markdown comments, Discussions, rail UX)

### DIFF
--- a/apps/notebook-cloud/viewer/notebook-viewer.tsx
+++ b/apps/notebook-cloud/viewer/notebook-viewer.tsx
@@ -2026,7 +2026,10 @@ function commentAnchorThreadOrderScope(anchor: CommentAnchor): string {
 
 function sourceRangeAnchorMatchesCurrentCell(anchor: SourceRangeCommentAnchor): boolean {
   const cell = getCellById(anchor.cell_id);
-  if (!cell || (cell.cell_type !== "code" && cell.cell_type !== "raw")) {
+  if (
+    !cell ||
+    (cell.cell_type !== "code" && cell.cell_type !== "raw" && cell.cell_type !== "markdown")
+  ) {
     return false;
   }
   return resolveSourceRangeAnchor(cell.source, anchor) !== null;

--- a/apps/notebook/src/App.tsx
+++ b/apps/notebook/src/App.tsx
@@ -221,7 +221,11 @@ function commentAnchorThreadOrderScope(anchor: CommentAnchor): string {
 function sourceRangeAnchorMatchesCurrentCell(anchor: CommentAnchor): boolean {
   if (anchor.kind !== "source_range") return false;
   const cell = getCellById(anchor.cell_id);
-  if (!cell || (cell.cell_type !== "code" && cell.cell_type !== "raw")) return false;
+  if (
+    !cell ||
+    (cell.cell_type !== "code" && cell.cell_type !== "raw" && cell.cell_type !== "markdown")
+  )
+    return false;
   return resolveSourceRangeAnchor(cell.source, anchor) !== null;
 }
 

--- a/apps/notebook/src/components/MarkdownCell.tsx
+++ b/apps/notebook/src/components/MarkdownCell.tsx
@@ -54,10 +54,7 @@ import { rewriteMarkdownAssetRefs } from "../lib/markdown-assets";
 import { openUrl } from "../lib/open-url";
 import { toggleMarkdownTaskMarker } from "../lib/markdown-task-source";
 import { presenceSenderExtension } from "../lib/presence-sender";
-import {
-  sourceRangeAnchorFromRenderedMarkdownRuns,
-  sourceRangeAnchorFromRenderedMarkdownSelection,
-} from "../lib/rendered-markdown-source-comment";
+import { sourceRangeAnchorFromRenderedMarkdownSelection } from "../lib/rendered-markdown-source-comment";
 import { commentHighlightExtension } from "../lib/comment-highlight-extension";
 import { refreshCellCommentHighlights, type SourceCommentThread } from "../lib/comment-highlights";
 import {
@@ -538,34 +535,6 @@ export const MarkdownCell = memo(function MarkdownCell({
     onCreateSourceComment,
     previewSource,
   ]);
-
-  const sourceRangeAnchorFromRenderedRuns = useCallback(
-    (runs: readonly MarkdownProjectionRun[]) => {
-      if (!canCommentOnRenderedMarkdown) return null;
-      return sourceRangeAnchorFromRenderedMarkdownRuns(cell.id, previewSource, runs);
-    },
-    [canCommentOnRenderedMarkdown, cell.id, previewSource],
-  );
-
-  const canCommentOnRenderedRuns = useCallback(
-    (runs: readonly MarkdownProjectionRun[]) => sourceRangeAnchorFromRenderedRuns(runs) !== null,
-    [sourceRangeAnchorFromRenderedRuns],
-  );
-
-  const handleRenderedRunsComment = useCallback(
-    (runs: readonly MarkdownProjectionRun[]) => {
-      const anchor = sourceRangeAnchorFromRenderedRuns(runs);
-      if (!anchor || !onCreateSourceComment) return;
-      const rect =
-        typeof window !== "undefined" ? selectionRectFromDomSelection(window.getSelection()) : null;
-      onCreateSourceComment(anchor, rect);
-      if (typeof window !== "undefined") {
-        window.getSelection()?.removeAllRanges();
-      }
-      clearRenderedSourceCommentTarget();
-    },
-    [clearRenderedSourceCommentTarget, onCreateSourceComment, sourceRangeAnchorFromRenderedRuns],
-  );
 
   const handleRenderedSourceCommentClick = useCallback(
     (event: MouseEvent<HTMLButtonElement>) => {
@@ -1090,12 +1059,6 @@ export const MarkdownCell = memo(function MarkdownCell({
                   commentHighlights={renderedCommentHighlights}
                   headingAnchors={headingAnchors}
                   onLinkClick={handleLinkClick}
-                  canCommentOnRuns={
-                    canCommentOnRenderedMarkdown ? canCommentOnRenderedRuns : undefined
-                  }
-                  onCommentRuns={
-                    canCommentOnRenderedMarkdown ? handleRenderedRunsComment : undefined
-                  }
                   onTaskCheckedChange={
                     readOnly || !onUpdateSource ? undefined : handleTaskCheckedChange
                   }

--- a/apps/notebook/src/lib/source-comment-extension.ts
+++ b/apps/notebook/src/lib/source-comment-extension.ts
@@ -165,7 +165,9 @@ const sourceCommentTheme = EditorView.baseTheme({
     width: "24px",
   },
   ".cm-source-comment-button:hover": {
-    backgroundColor: "var(--muted, #f5f5f5)",
+    borderColor: "var(--primary, #2563eb)",
+    backgroundColor: "var(--primary, #2563eb)",
+    color: "var(--primary-foreground, #ffffff)",
   },
   ".cm-source-comment-button:focus-visible": {
     outline: "2px solid var(--ring, #a3a3a3)",

--- a/src/components/markdown/ProjectedMarkdownView.tsx
+++ b/src/components/markdown/ProjectedMarkdownView.tsx
@@ -1,6 +1,5 @@
 import { type CSSProperties, type ReactNode } from "react";
 import katex from "katex";
-import { MessageSquarePlus } from "lucide-react";
 import type {
   MarkdownProjectionBlock,
   MarkdownProjectionPlan,
@@ -60,8 +59,6 @@ interface ProjectedMarkdownViewProps {
   commentHighlights?: ReadonlyArray<MarkdownCommentHighlight>;
   colorTheme?: "classic" | "cream";
   headingAnchors?: readonly MarkdownHeadingAnchor[];
-  canCommentOnRuns?: (runs: readonly MarkdownProjectionRun[]) => boolean;
-  onCommentRuns?: (runs: readonly MarkdownProjectionRun[]) => void;
   onLinkClick?: (url: string) => void;
   onTaskCheckedChange?: (run: MarkdownProjectionRun, checked: boolean) => void;
 }
@@ -72,9 +69,7 @@ export function ProjectedMarkdownView({
   activeSourcePosition,
   commentHighlights,
   colorTheme: colorThemeOverride,
-  canCommentOnRuns,
   headingAnchors = [],
-  onCommentRuns,
   onLinkClick,
   onTaskCheckedChange,
 }: ProjectedMarkdownViewProps) {
@@ -110,8 +105,6 @@ export function ProjectedMarkdownView({
           commentHighlights={commentHighlights}
           isDark={isDark}
           runs={runsByBlock.get(block.blockId) ?? []}
-          canCommentOnRuns={canCommentOnRuns}
-          onCommentRuns={onCommentRuns}
           onLinkClick={onLinkClick}
           onTaskCheckedChange={onTaskCheckedChange}
         />
@@ -129,8 +122,6 @@ interface ProjectedMarkdownBlockProps {
   commentHighlights?: ReadonlyArray<MarkdownCommentHighlight>;
   isDark: boolean;
   runs: MarkdownProjectionRun[];
-  canCommentOnRuns?: (runs: readonly MarkdownProjectionRun[]) => boolean;
-  onCommentRuns?: (runs: readonly MarkdownProjectionRun[]) => void;
   onLinkClick?: (url: string) => void;
   onTaskCheckedChange?: (run: MarkdownProjectionRun, checked: boolean) => void;
 }
@@ -144,8 +135,6 @@ function ProjectedMarkdownBlock({
   commentHighlights,
   isDark,
   runs,
-  canCommentOnRuns,
-  onCommentRuns,
   onLinkClick,
   onTaskCheckedChange,
 }: ProjectedMarkdownBlockProps) {
@@ -259,46 +248,15 @@ function ProjectedMarkdownBlock({
       );
     }
 
-    const canComment = Boolean(canCommentOnRuns?.(runs) && onCommentRuns);
     return (
       <p
         data-source-active={activeBlockId === block.blockId ? "true" : undefined}
         className={cn(
-          "group/markdown-comment",
           markdownParagraphClassName,
           activeBlockId === block.blockId && sourceActiveBlockClass,
         )}
       >
         {renderRuns(runs, { activeInlineId, commentHighlights, onLinkClick })}
-        {canComment ? (
-          <button
-            type="button"
-            aria-label="Comment on rendered paragraph"
-            title="Comment on rendered paragraph"
-            data-testid="markdown-block-comment-button"
-            onPointerDown={(event) => {
-              event.preventDefault();
-              event.stopPropagation();
-            }}
-            onMouseDown={(event) => {
-              event.preventDefault();
-              event.stopPropagation();
-            }}
-            onClick={(event) => {
-              event.preventDefault();
-              event.stopPropagation();
-              onCommentRuns?.(runs);
-            }}
-            onKeyDown={(event) => {
-              if (event.key === "Enter" || event.key === " ") {
-                event.stopPropagation();
-              }
-            }}
-            className="ml-1.5 inline-flex h-5 w-5 items-center justify-center rounded-md border bg-background align-middle text-muted-foreground opacity-0 transition-colors hover:bg-muted hover:text-foreground focus-visible:opacity-100 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/30 group-hover/markdown-comment:opacity-100 group-focus-within/markdown-comment:opacity-100"
-          >
-            <MessageSquarePlus className="h-3.5 w-3.5" aria-hidden="true" />
-          </button>
-        ) : null}
       </p>
     );
   }

--- a/src/components/markdown/__tests__/ProjectedMarkdownView.test.tsx
+++ b/src/components/markdown/__tests__/ProjectedMarkdownView.test.tsx
@@ -135,50 +135,6 @@ describe("ProjectedMarkdownView", () => {
     expect(runs[1]?.style.getPropertyValue("--cm-comment-color")).toBe("#52525b");
   });
 
-  it("renders keyboard-accessible comment actions for commentable paragraphs", () => {
-    const onCommentRuns = vi.fn();
-    render(
-      <ProjectedMarkdownView
-        canCommentOnRuns={() => true}
-        onCommentRuns={onCommentRuns}
-        plan={plan({
-          blocks: [
-            {
-              blockId: "p0",
-              blockIndex: 0,
-              element: "p",
-              kind: "paragraph",
-              measurement: { estimatedHeight: 32, confidence: "high", width: 720 },
-              sourceSpanByte: [0, 11],
-              sourceSpanUtf16: [0, 11],
-              syntaxSpans: [],
-              text: "plain prose",
-            },
-          ],
-          runs: [
-            {
-              blockId: "p0",
-              inlineId: "r0",
-              listItemIndex: null,
-              renderedText: "plain prose",
-              renderedTextUtf16: [0, 11],
-              semantic: "text",
-              sourceSpanByte: [0, 11],
-              sourceSpanUtf16: [0, 11],
-            },
-          ],
-        })}
-      />,
-    );
-
-    fireEvent.click(screen.getByRole("button", { name: "Comment on rendered paragraph" }));
-
-    expect(onCommentRuns).toHaveBeenCalledTimes(1);
-    expect(onCommentRuns.mock.calls[0]?.[0]).toMatchObject([
-      expect.objectContaining({ inlineId: "r0" }),
-    ]);
-  });
-
   it("matches the output document heading rhythm", () => {
     const { container } = render(
       <ProjectedMarkdownView

--- a/src/components/notebook-rail/NotebookRail.tsx
+++ b/src/components/notebook-rail/NotebookRail.tsx
@@ -70,7 +70,9 @@ export function NotebookRail({
 }: NotebookRailProps) {
   const railButtons = [
     ...baseRailButtons,
-    ...(commentsPanel ? [{ id: "comments" as const, label: "Comments", icon: MessageSquare }] : []),
+    ...(commentsPanel
+      ? [{ id: "comments" as const, label: "Discussions", icon: MessageSquare }]
+      : []),
     ...(workstationsPanel
       ? [{ id: "workstations" as const, label: "Workstations", icon: Server }]
       : []),
@@ -79,7 +81,7 @@ export function NotebookRail({
     activePanelId === "packages"
       ? "Packages"
       : activePanelId === "comments"
-        ? "Comments"
+        ? "Discussions"
         : activePanelId === "workstations"
           ? "Workstations"
           : "Outline";

--- a/src/components/notebook-rail/__tests__/NotebookRail.test.tsx
+++ b/src/components/notebook-rail/__tests__/NotebookRail.test.tsx
@@ -124,6 +124,24 @@ describe("NotebookRail", () => {
     expect(onCollapsedChange).toHaveBeenCalledWith(false);
   });
 
+  it("labels the comments rail as Discussions", () => {
+    render(
+      <NotebookRail
+        activePanelId="comments"
+        collapsed={false}
+        outlineItems={outlineItems}
+        packagesPanel={<NotebookPackagesPanel>Packages</NotebookPackagesPanel>}
+        commentsPanel={<div>Thread list</div>}
+        onActivePanelChange={vi.fn()}
+        onCollapsedChange={vi.fn()}
+      />,
+    );
+
+    expect(screen.getByRole("button", { name: "Discussions" })).toBeVisible();
+    expect(screen.getByRole("heading", { name: "Discussions" })).toBeVisible();
+    expect(screen.getByText("Thread list")).toBeVisible();
+  });
+
   it("does not show the workstations rail item until the host supplies a panel", () => {
     render(
       <NotebookRail

--- a/src/components/notebook/NotebookCommentsPanel.tsx
+++ b/src/components/notebook/NotebookCommentsPanel.tsx
@@ -11,7 +11,7 @@ import {
   X,
 } from "lucide-react";
 import { actorInitials, onBehalfOfText } from "runtimed";
-import { useEffect, useRef, useState, type FormEvent } from "react";
+import { useEffect, useRef, useState, type FormEvent, type KeyboardEvent } from "react";
 import type {
   CommentAnchor,
   CommentMessageSnapshot,
@@ -164,7 +164,7 @@ export function NotebookCommentsPanel({
         buttonLabel="Add comment"
         icon="plus"
         disabled={!canCreate}
-        autoFocusKey={draftTarget ? draftAutoFocusKey(draftTarget) : null}
+        autoFocusKey={draftTarget ? draftAutoFocusKey(draftTarget) : "document"}
         placeholder={
           draftTarget
             ? `Add a ${anchorLabelForDraft(draftTarget.anchor)} comment`
@@ -396,6 +396,7 @@ function CommentThreadItem({
           buttonLabel="Reply"
           icon="send"
           disabled={!canReply}
+          autoFocusKey={focused ? `${thread.id}:${focusNonce}` : null}
           placeholder={thread.status === "resolved" ? "Reply to reopen…" : "Reply…"}
           compact
           onSubmit={onReplyThread ? (body) => onReplyThread(thread.id, body) : undefined}
@@ -627,10 +628,9 @@ function CommentComposer({
     };
   }, [autoFocusKey, disabled]);
 
-  const handleSubmit = async (event: FormEvent) => {
-    event.preventDefault();
+  const submitBody = async () => {
     const trimmed = body.trim();
-    if (!trimmed || disabled || !onSubmit) return;
+    if (!trimmed || disabled || submitting || !onSubmit) return;
     setBody("");
     setSubmitting(true);
     try {
@@ -640,6 +640,17 @@ function CommentComposer({
     } finally {
       setSubmitting(false);
     }
+  };
+
+  const handleSubmit = async (event: FormEvent) => {
+    event.preventDefault();
+    await submitBody();
+  };
+
+  const handleKeyDown = (event: KeyboardEvent<HTMLTextAreaElement>) => {
+    if (event.key !== "Enter" || (!event.metaKey && !event.ctrlKey)) return;
+    event.preventDefault();
+    void submitBody();
   };
 
   return (
@@ -653,6 +664,7 @@ function CommentComposer({
         onChange={(event) => setBody(event.target.value)}
         onFocus={() => setFocused(true)}
         onBlur={() => setFocused(false)}
+        onKeyDown={handleKeyDown}
         rows={expanded ? 3 : 1}
         className={cn(
           "w-full resize-y border bg-background px-3 text-sm leading-5",

--- a/src/components/notebook/__tests__/NotebookCommentsPanel.test.tsx
+++ b/src/components/notebook/__tests__/NotebookCommentsPanel.test.tsx
@@ -102,6 +102,35 @@ describe("NotebookCommentsPanel", () => {
     expect(screen.getByLabelText("New document comment")).toHaveValue("");
   });
 
+  it("focuses the document composer when opened", async () => {
+    render(
+      <NotebookCommentsPanel
+        projection={{ ...projection, threads: [] }}
+        onCreateThread={vi.fn()}
+      />,
+    );
+
+    await waitFor(() => expect(screen.getByLabelText("New document comment")).toHaveFocus());
+  });
+
+  it("submits a new document comment with Cmd Enter", async () => {
+    const onCreateThread = vi.fn();
+    render(
+      <NotebookCommentsPanel
+        projection={{ ...projection, threads: [] }}
+        onCreateThread={onCreateThread}
+      />,
+    );
+
+    const composer = screen.getByLabelText("New document comment");
+    fireEvent.change(composer, {
+      target: { value: "Submit from the keyboard" },
+    });
+    fireEvent.keyDown(composer, { key: "Enter", metaKey: true });
+
+    await waitFor(() => expect(onCreateThread).toHaveBeenCalledWith("Submit from the keyboard"));
+  });
+
   it("submits a selected source draft comment", async () => {
     const onCreateThread = vi.fn();
     const onClearDraftTarget = vi.fn();
@@ -286,6 +315,34 @@ describe("NotebookCommentsPanel", () => {
 
     fireEvent.click(screen.getByRole("button", { name: "Resolve Document comment 1" }));
     expect(onResolveThread).toHaveBeenCalledWith("thread-1");
+  });
+
+  it("focuses the reply composer for a focused thread", async () => {
+    render(
+      <NotebookCommentsPanel
+        projection={projection}
+        focusedThreadId="thread-1"
+        focusNonce={1}
+        onReplyThread={vi.fn()}
+      />,
+    );
+
+    await waitFor(() => expect(screen.getByLabelText("Reply to Document comment 1")).toHaveFocus());
+  });
+
+  it("submits replies with Ctrl Enter", async () => {
+    const onReplyThread = vi.fn();
+    render(<NotebookCommentsPanel projection={projection} onReplyThread={onReplyThread} />);
+
+    const reply = screen.getByLabelText("Reply to Document comment 1");
+    fireEvent.change(reply, {
+      target: { value: "Reply from the keyboard" },
+    });
+    fireEvent.keyDown(reply, { key: "Enter", ctrlKey: true });
+
+    await waitFor(() =>
+      expect(onReplyThread).toHaveBeenCalledWith("thread-1", "Reply from the keyboard"),
+    );
   });
 
   it("renders source excerpts on source range threads", () => {


### PR DESCRIPTION
A batch of fixes from desktop QA of the comment surfaces.

- **Commenting on markdown was broken.** `sourceRangeAnchorMatchesCurrentCell` only allowed `code`/`raw` cells, so a valid markdown comment was always rejected with "Selected source changed". Now allows `markdown` too, on both the desktop and cloud hosts.
- **Code-cell selection-bubble hover contrast.** The floating comment icon went low-contrast (invisible) on hover; the hover state now keeps the icon and background contrast.
- **Rail composer auto-focus.** Opening the document-comment or reply input now focuses it so you can type immediately.
- **Cmd/Ctrl+Enter in the rail.** The rail composers submit on Cmd/Ctrl+Enter, matching the inline composer.
- **Removed the redundant end-of-line paragraph comment button** on rendered markdown; the selection affordance covers it. Run-span attributes, the selection affordance, and the comment highlights are untouched.
- **Renamed the rail to "Discussions"** (these are threaded conversations). Visible label + aria only; internal ids/route keys unchanged.

## Verification

`vp check` clean (format + lint); full `vp test` green (2438 passed); `apps/notebook-cloud` typecheck clean. New tests cover the rail autofocus, the Cmd/Ctrl+Enter submit, the Discussions label, and the removed paragraph button.
