### PR TITLE
fix: address quick quillaid issue guardrails

### DIFF
--- a/apps/notebook-cloud/viewer/__tests__/use-sustained-reconnecting.test.tsx
+++ b/apps/notebook-cloud/viewer/__tests__/use-sustained-reconnecting.test.tsx
@@ -2,6 +2,7 @@ import { act, renderHook } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vite-plus/test";
 import type { ConnectionStatus } from "runtimed";
 import {
+  SustainedReconnectAccessDiagnosticTracker,
   useSustainedReconnecting,
   type ReconnectingStatusSource,
 } from "../use-sustained-reconnecting";
@@ -128,5 +129,133 @@ describe("useSustainedReconnecting", () => {
       vi.advanceTimersByTime(1);
     });
     expect(result.current).toBe(true);
+  });
+});
+
+describe("SustainedReconnectAccessDiagnosticTracker", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("runs one access diagnostic after reconnecting outlives the debounce", async () => {
+    const diagnose = vi.fn(async () => "Sign in again to open this notebook.");
+    const onDiagnostic = vi.fn();
+    const tracker = new SustainedReconnectAccessDiagnosticTracker({
+      debounceMs: 1_000,
+      diagnose,
+      onDiagnostic,
+    });
+
+    act(() => {
+      tracker.next("reconnecting");
+      vi.advanceTimersByTime(999);
+    });
+    expect(diagnose).not.toHaveBeenCalled();
+
+    await act(async () => {
+      vi.advanceTimersByTime(1);
+      await Promise.resolve();
+    });
+    expect(diagnose).toHaveBeenCalledTimes(1);
+    expect(onDiagnostic).toHaveBeenCalledWith("Sign in again to open this notebook.");
+
+    act(() => {
+      tracker.next("reconnecting");
+      vi.advanceTimersByTime(10_000);
+    });
+    expect(diagnose).toHaveBeenCalledTimes(1);
+
+    tracker.dispose();
+  });
+
+  it("keeps plain outages calm when the access probe has no diagnostic", async () => {
+    const diagnose = vi.fn(async () => null);
+    const onDiagnostic = vi.fn();
+    const tracker = new SustainedReconnectAccessDiagnosticTracker({
+      debounceMs: 1_000,
+      diagnose,
+      onDiagnostic,
+    });
+
+    await act(async () => {
+      tracker.next("reconnecting");
+      vi.advanceTimersByTime(1_000);
+      await Promise.resolve();
+    });
+
+    expect(diagnose).toHaveBeenCalledTimes(1);
+    expect(onDiagnostic).not.toHaveBeenCalled();
+    tracker.dispose();
+  });
+
+  it("ignores stale diagnostics after reconnect recovery", async () => {
+    let resolveDiagnostic: (diagnostic: string | null) => void = () => {};
+    const pendingDiagnostic = new Promise<string | null>((resolve) => {
+      resolveDiagnostic = resolve;
+    });
+    const diagnose = vi.fn(() => pendingDiagnostic);
+    const onDiagnostic = vi.fn();
+    const tracker = new SustainedReconnectAccessDiagnosticTracker({
+      debounceMs: 1_000,
+      diagnose,
+      onDiagnostic,
+    });
+
+    act(() => {
+      tracker.next("reconnecting");
+      vi.advanceTimersByTime(1_000);
+    });
+    expect(diagnose).toHaveBeenCalledTimes(1);
+
+    act(() => {
+      tracker.next("online");
+    });
+    await act(async () => {
+      resolveDiagnostic("Sign in again to open this notebook.");
+      await pendingDiagnostic;
+      await Promise.resolve();
+    });
+
+    expect(onDiagnostic).not.toHaveBeenCalled();
+    tracker.dispose();
+  });
+
+  it("allows a fresh diagnostic after recovery starts a new reconnect cycle", async () => {
+    const diagnose = vi
+      .fn<() => Promise<string | null>>()
+      .mockResolvedValueOnce(null)
+      .mockResolvedValueOnce("This account does not have access to this notebook.");
+    const onDiagnostic = vi.fn();
+    const tracker = new SustainedReconnectAccessDiagnosticTracker({
+      debounceMs: 1_000,
+      diagnose,
+      onDiagnostic,
+    });
+
+    await act(async () => {
+      tracker.next("reconnecting");
+      vi.advanceTimersByTime(1_000);
+      await Promise.resolve();
+    });
+    expect(diagnose).toHaveBeenCalledTimes(1);
+
+    act(() => {
+      tracker.next("online");
+      tracker.next("reconnecting");
+    });
+    await act(async () => {
+      vi.advanceTimersByTime(1_000);
+      await Promise.resolve();
+    });
+
+    expect(diagnose).toHaveBeenCalledTimes(2);
+    expect(onDiagnostic).toHaveBeenCalledWith(
+      "This account does not have access to this notebook.",
+    );
+    tracker.dispose();
   });
 });

--- a/apps/notebook-cloud/viewer/cloud-viewer-session.ts
+++ b/apps/notebook-cloud/viewer/cloud-viewer-session.ts
@@ -78,6 +78,10 @@ import {
   type OfflineMergeNoticeData,
 } from "./offline-merge-tracker";
 import {
+  SUSTAINED_RECONNECTING_DEBOUNCE_MS,
+  SustainedReconnectAccessDiagnosticTracker,
+} from "./use-sustained-reconnecting";
+import {
   cleanupNotebookProjectionForRemovedCells,
   projectNotebookCellsIntoViewStores,
   resetNotebookProjectionStores,
@@ -321,6 +325,30 @@ export function useCloudViewerSession({
   authRenewalKindRef.current = authRenewalKind;
   const previousAuthRenewalKindRef = useRef(authRenewalKind);
   const syncAuthConnectionKey = cloudSyncAuthConnectionKey(authState, { hasAppSession });
+
+  useEffect(() => {
+    const tracker = new SustainedReconnectAccessDiagnosticTracker({
+      debounceMs: SUSTAINED_RECONNECTING_DEBOUNCE_MS,
+      diagnose: () =>
+        diagnoseCloudConnectionAccess({
+          accessRequestsEndpoint: config.accessRequestsEndpoint,
+          authState: authStateRef.current,
+          hasAppSession: hasAppSessionRef.current,
+        }),
+      onDiagnostic: (diagnostic) => {
+        setConnectionError((current) =>
+          cloudConnectionErrorWithAccessDiagnostic(current, diagnostic),
+        );
+      },
+    });
+    const subscription = connectionStatusBridge.subscribe((connectionStatus) => {
+      tracker.next(connectionStatus);
+    });
+    return () => {
+      subscription.unsubscribe();
+      tracker.dispose();
+    };
+  }, [connectionStatusBridge, config.accessRequestsEndpoint]);
 
   useEffect(() => {
     const previousKind = previousAuthRenewalKindRef.current;

--- a/apps/notebook-cloud/viewer/cloud-viewer-session.ts
+++ b/apps/notebook-cloud/viewer/cloud-viewer-session.ts
@@ -336,6 +336,10 @@ export function useCloudViewerSession({
           hasAppSession: hasAppSessionRef.current,
         }),
       onDiagnostic: (diagnostic) => {
+        // Sustained reconnect diagnostics run after a runtime has gone live.
+        // Pre-ready access diagnostics still stop their scoped pendingTransport;
+        // once live, the runtime retry loop owns transport teardown while we
+        // replace generic reconnect copy with the access-specific failure.
         setConnectionError((current) =>
           cloudConnectionErrorWithAccessDiagnostic(current, diagnostic),
         );

--- a/apps/notebook-cloud/viewer/use-sustained-reconnecting.ts
+++ b/apps/notebook-cloud/viewer/use-sustained-reconnecting.ts
@@ -13,6 +13,12 @@ export interface ReconnectingStatusSource {
   subscribe(next: (status: ConnectionStatus) => void): { unsubscribe(): void };
 }
 
+export interface SustainedReconnectAccessDiagnosticTrackerOptions {
+  debounceMs: number;
+  diagnose: () => Promise<string | null>;
+  onDiagnostic: (diagnostic: string) => void;
+}
+
 /**
  * Debounce "reconnecting" into a single sustained flag:
  *
@@ -66,6 +72,60 @@ export class SustainedReconnectingTracker {
       clearTimeout(this.timer);
       this.timer = null;
     }
+  }
+}
+
+/**
+ * Runs at most one access diagnostic per sustained reconnect window.
+ *
+ * Transport reconnect errors are intentionally calm at first. If the room
+ * stays unreachable past the sustained-reconnect threshold, this probes the
+ * catalog/access endpoint so cookie revocation and lost sharing permissions
+ * can replace generic socket copy with an actionable diagnostic.
+ */
+export class SustainedReconnectAccessDiagnosticTracker {
+  private disposed = false;
+  private diagnosedThisCycle = false;
+  private generation = 0;
+  private readonly reconnecting: SustainedReconnectingTracker;
+
+  constructor(private readonly options: SustainedReconnectAccessDiagnosticTrackerOptions) {
+    this.reconnecting = new SustainedReconnectingTracker({
+      debounceMs: options.debounceMs,
+      onChange: (sustained) => {
+        if (sustained) {
+          this.runDiagnostic();
+        }
+      },
+    });
+  }
+
+  next(status: ConnectionStatus): void {
+    if (status === "online" || status === "offline") {
+      this.generation += 1;
+      this.diagnosedThisCycle = false;
+    }
+    this.reconnecting.next(status);
+  }
+
+  dispose(): void {
+    this.disposed = true;
+    this.generation += 1;
+    this.reconnecting.dispose();
+  }
+
+  private runDiagnostic(): void {
+    if (this.diagnosedThisCycle) return;
+    this.diagnosedThisCycle = true;
+    const generation = this.generation;
+
+    void this.options
+      .diagnose()
+      .then((diagnostic) => {
+        if (this.disposed || generation !== this.generation || !diagnostic) return;
+        this.options.onDiagnostic(diagnostic);
+      })
+      .catch(() => undefined);
   }
 }
 

--- a/apps/notebook/src/components/__tests__/elements-isolated-shim-boundary.test.ts
+++ b/apps/notebook/src/components/__tests__/elements-isolated-shim-boundary.test.ts
@@ -1,0 +1,86 @@
+import { readdirSync, readFileSync } from "node:fs";
+import { join, relative } from "node:path";
+import { describe, expect, it } from "vite-plus/test";
+
+const isolatedBarrelImport =
+  /import\s+(?:type\s+)?\{([^}]*)\}\s+from\s+["']@\/components\/isolated["']/g;
+const namedExport = /export\s+(?:type\s+)?\{([^}]*)\}/g;
+const declarationExport =
+  /export\s+(?:interface|class|function|const|let|var|type|enum)\s+([A-Za-z_$][\w$]*)/g;
+
+function sourceFiles(dir: string): string[] {
+  return readdirSync(dir, { withFileTypes: true }).flatMap((entry) => {
+    const fullPath = join(dir, entry.name);
+    if (entry.isDirectory()) return sourceFiles(fullPath);
+    return /\.(ts|tsx)$/.test(entry.name) ? [fullPath] : [];
+  });
+}
+
+function importedName(specifier: string): string | null {
+  const name = specifier
+    .replace(/\/\*[\s\S]*?\*\//g, "")
+    .replace(/\/\/.*$/gm, "")
+    .trim()
+    .replace(/^type\s+/, "")
+    .split(/\s+as\s+/)[0]
+    .trim();
+  return name || null;
+}
+
+function namedSpecifiers(block: string): string[] {
+  return block.split(",").map(importedName).filter(Boolean) as string[];
+}
+
+function collectIsolatedBarrelImports(files: string[]): Map<string, Set<string>> {
+  const imports = new Map<string, Set<string>>();
+
+  for (const filePath of files) {
+    const source = readFileSync(filePath, "utf8");
+    const relativePath = relative(process.cwd(), filePath);
+
+    for (const match of source.matchAll(isolatedBarrelImport)) {
+      for (const name of namedSpecifiers(match[1] ?? "")) {
+        const users = imports.get(name) ?? new Set<string>();
+        users.add(relativePath);
+        imports.set(name, users);
+      }
+    }
+  }
+
+  return imports;
+}
+
+function collectShimExports(filePath: string): Set<string> {
+  const source = readFileSync(filePath, "utf8");
+  const exports = new Set<string>();
+
+  for (const match of source.matchAll(namedExport)) {
+    for (const name of namedSpecifiers(match[1] ?? "")) {
+      exports.add(name);
+    }
+  }
+
+  for (const match of source.matchAll(declarationExport)) {
+    if (match[1]) exports.add(match[1]);
+  }
+
+  return exports;
+}
+
+describe("Elements isolated shim boundary", () => {
+  it("exports every isolated barrel name imported by shared consumers", () => {
+    const roots = ["src/components", "apps/elements/components"];
+    const consumerFiles = roots.flatMap((root) => sourceFiles(join(process.cwd(), root)));
+    const imports = collectIsolatedBarrelImports(consumerFiles);
+    const shimExports = collectShimExports(
+      join(process.cwd(), "apps/elements/components/isolated/index.tsx"),
+    );
+
+    const missing = [...imports.entries()]
+      .filter(([name]) => !shimExports.has(name))
+      .map(([name, users]) => `${name} imported by ${[...users].sort().join(", ")}`)
+      .sort();
+
+    expect(missing).toEqual([]);
+  });
+});

--- a/crates/xtask/src/main.rs
+++ b/crates/xtask/src/main.rs
@@ -3056,6 +3056,12 @@ fn cmd_lint(fix: bool) {
     }
     println!();
 
+    println!("=== Raw control bytes ===");
+    if !check_raw_control_bytes() {
+        failed = true;
+    }
+    println!();
+
     // JavaScript/TypeScript with Vite Plus
     println!("=== JavaScript/TypeScript (vp check) ===");
     let vp_ok = if fix {
@@ -3126,6 +3132,194 @@ fn cmd_lint(fix: bool) {
     }
 
     println!("All checks passed!");
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct RawControlByte {
+    byte: u8,
+    offset: usize,
+    line: usize,
+    column: usize,
+}
+
+fn first_raw_control_byte(bytes: &[u8]) -> Option<RawControlByte> {
+    let mut line = 1usize;
+    let mut column = 1usize;
+
+    for (offset, &byte) in bytes.iter().enumerate() {
+        if byte < 0x20 && !matches!(byte, b'\t' | b'\n' | b'\r') {
+            return Some(RawControlByte {
+                byte,
+                offset,
+                line,
+                column,
+            });
+        }
+
+        if byte == b'\n' {
+            line += 1;
+            column = 1;
+        } else {
+            column += 1;
+        }
+    }
+
+    None
+}
+
+fn normalized_repo_path(path: &Path) -> String {
+    path.to_string_lossy().replace('\\', "/")
+}
+
+fn is_known_generated_text_bundle(path: &Path) -> bool {
+    let path = normalized_repo_path(path);
+    path.starts_with("apps/notebook/src/renderer-plugins/")
+        || path.starts_with("crates/runt-mcp/assets/plugins/")
+        || path.starts_with("apps/elements/public/wasm/")
+}
+
+fn should_scan_for_raw_control_bytes(path: &Path) -> bool {
+    if is_known_generated_text_bundle(path) {
+        return false;
+    }
+
+    let file_name = path
+        .file_name()
+        .and_then(|name| name.to_str())
+        .unwrap_or("");
+    if matches!(
+        file_name,
+        ".env"
+            | ".env.example"
+            | ".gitattributes"
+            | ".gitignore"
+            | ".npmrc"
+            | ".yarnrc"
+            | "AGENTS.md"
+            | "Cargo.lock"
+            | "Dockerfile"
+            | "README.md"
+            | "package.json"
+            | "pnpm-lock.yaml"
+            | "pyproject.toml"
+    ) {
+        return true;
+    }
+
+    matches!(
+        path.extension()
+            .and_then(|extension| extension.to_str())
+            .map(str::to_ascii_lowercase)
+            .as_deref(),
+        Some(
+            "bash"
+                | "cfg"
+                | "cjs"
+                | "css"
+                | "env"
+                | "fish"
+                | "html"
+                | "ini"
+                | "js"
+                | "json"
+                | "jsonl"
+                | "jsx"
+                | "lock"
+                | "md"
+                | "mdx"
+                | "mjs"
+                | "py"
+                | "rs"
+                | "sh"
+                | "sql"
+                | "toml"
+                | "ts"
+                | "tsx"
+                | "txt"
+                | "yaml"
+                | "yml"
+                | "zsh"
+        )
+    )
+}
+
+fn tracked_files() -> Result<Vec<PathBuf>, String> {
+    let output = Command::new("git")
+        .args(["ls-files", "-z"])
+        .output()
+        .map_err(|error| format!("failed to run git ls-files: {error}"))?;
+
+    if !output.status.success() {
+        return Err(format!("git ls-files failed with status {}", output.status));
+    }
+
+    Ok(output
+        .stdout
+        .split(|byte| *byte == 0)
+        .filter(|path| !path.is_empty())
+        .map(|path| PathBuf::from(String::from_utf8_lossy(path).into_owned()))
+        .collect())
+}
+
+fn check_raw_control_bytes() -> bool {
+    let files = match tracked_files() {
+        Ok(files) => files,
+        Err(error) => {
+            eprintln!("{error}");
+            return false;
+        }
+    };
+
+    let mut violations = Vec::new();
+    let mut read_errors = Vec::new();
+
+    for path in files {
+        if !should_scan_for_raw_control_bytes(&path) {
+            continue;
+        }
+
+        let metadata = match fs::symlink_metadata(&path) {
+            Ok(metadata) => metadata,
+            Err(error) => {
+                read_errors.push(format!("{}: {error}", path.display()));
+                continue;
+            }
+        };
+
+        if !metadata.file_type().is_file() {
+            continue;
+        }
+
+        match fs::read(&path) {
+            Ok(bytes) => {
+                if let Some(control) = first_raw_control_byte(&bytes) {
+                    violations.push((path, control));
+                }
+            }
+            Err(error) => read_errors.push(format!("{}: {error}", path.display())),
+        }
+    }
+
+    if read_errors.is_empty() && violations.is_empty() {
+        println!("No raw control bytes found in tracked source text.");
+        return true;
+    }
+
+    for error in read_errors {
+        eprintln!("Failed to read tracked source text file: {error}");
+    }
+
+    for (path, control) in violations {
+        eprintln!(
+            "{}:{}:{}: raw control byte 0x{:02X}; use the \\u escape instead of a literal control character",
+            path.display(),
+            control.line,
+            control.column,
+            control.byte
+        );
+    }
+
+    false
 }
 
 fn cmd_clippy() {
@@ -4888,6 +5082,48 @@ mod tests {
                 skip_build: true,
             }
         );
+    }
+
+    #[test]
+    fn raw_control_byte_detector_allows_common_whitespace() {
+        assert_eq!(first_raw_control_byte(b"alpha\tbeta\r\ngamma"), None);
+    }
+
+    #[test]
+    fn raw_control_byte_detector_reports_literal_control_bytes() {
+        assert_eq!(
+            first_raw_control_byte(b"alpha\nbe\0ta"),
+            Some(RawControlByte {
+                byte: 0,
+                offset: 8,
+                line: 2,
+                column: 3,
+            })
+        );
+        assert_eq!(
+            first_raw_control_byte(b"alpha\x1fbeta").map(|control| control.byte),
+            Some(0x1f)
+        );
+    }
+
+    #[test]
+    fn raw_control_byte_path_filter_scans_source_not_generated_bundles() {
+        assert!(should_scan_for_raw_control_bytes(Path::new(
+            "apps/notebook/src/App.tsx"
+        )));
+        assert!(should_scan_for_raw_control_bytes(Path::new(
+            ".github/workflows/build.yml"
+        )));
+        assert!(should_scan_for_raw_control_bytes(Path::new("Cargo.lock")));
+        assert!(!should_scan_for_raw_control_bytes(Path::new(
+            "crates/comments-doc/assets/comments_doc_genesis_v1.am"
+        )));
+        assert!(!should_scan_for_raw_control_bytes(Path::new(
+            "apps/notebook/src/renderer-plugins/plotly.js"
+        )));
+        assert!(!should_scan_for_raw_control_bytes(Path::new(
+            "crates/runt-mcp/assets/plugins/plotly.js"
+        )));
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- add `cargo xtask lint` guardrail for raw control bytes in tracked source text, with generated bundle exclusions
- add a static Vitest boundary test so the Elements isolated shim exports every isolated barrel name imported by shared consumers
- escalate sustained cloud live-room reconnects through access diagnostics so revoked access/sign-in state replaces generic socket copy

Fixes #3602.
Fixes #3597.

## Verification

- `cargo test -p xtask raw_control`
- `cargo test -p xtask`
- `pnpm test:run apps/notebook/src/components/__tests__/elements-isolated-shim-boundary.test.ts apps/notebook-cloud/viewer/__tests__/use-sustained-reconnecting.test.tsx`
- `cargo xtask lint --fix`