### PR TITLE
feat(comments): show the local author's macOS full name

### DIFF
--- a/apps/notebook/src/App.tsx
+++ b/apps/notebook/src/App.tsx
@@ -757,6 +757,7 @@ function AppContent() {
     (actorLabel: string): CommentAuthor => {
       const display = resolveActorDisplay({
         actorLabel,
+        identityLabel: peerLabel,
         peers: [],
         source: connectionScope ? "cloud" : "local",
       });

--- a/apps/notebook/src/App.tsx
+++ b/apps/notebook/src/App.tsx
@@ -4,6 +4,8 @@ import {
   deriveRuntimeKind,
   NotebookClient,
   resolveActorDisplay,
+  splitNotebookActorPrincipalOperator,
+  type ActorDisplayPeer,
   type CommentAnchor,
   type CommentThreadSnapshot,
   type CommentsProjection,
@@ -753,12 +755,22 @@ function AppContent() {
     setSourceCommentRequest(null);
   }, []);
 
+  // The OS full name only labels the local author. We feed it through a peers
+  // entry keyed by the local principal, mirroring the cloud presence model, so
+  // synced peers and agents resolve their own labels instead of inheriting this
+  // machine's user name.
+  const commentAuthorPeers = useMemo<ActorDisplayPeer[]>(() => {
+    const label = peerLabel.trim();
+    if (!localActor || !label) return [];
+    const [localPrincipal] = splitNotebookActorPrincipalOperator(localActor);
+    return [{ participantKey: localPrincipal, label }];
+  }, [localActor, peerLabel]);
+
   const resolveCommentAuthor = useCallback(
     (actorLabel: string): CommentAuthor => {
       const display = resolveActorDisplay({
         actorLabel,
-        identityLabel: peerLabel,
-        peers: [],
+        peers: commentAuthorPeers,
         source: connectionScope ? "cloud" : "local",
       });
       return {
@@ -770,7 +782,7 @@ function AppContent() {
         onBehalfOfColor: display.onBehalfOfColor,
       };
     },
-    [connectionScope],
+    [commentAuthorPeers, connectionScope],
   );
 
   const resolveSourceLanguage = useCallback(

--- a/crates/notebook/src/lib.rs
+++ b/crates/notebook/src/lib.rs
@@ -1969,9 +1969,50 @@ async fn get_blob_port() -> Result<u16, String> {
 /// Get the OS username for peer presence labels.
 #[tauri::command]
 fn get_username() -> String {
+    #[cfg(target_os = "macos")]
+    if let Some(full_name) = macos_full_user_name() {
+        return full_name;
+    }
+
+    fallback_username()
+}
+
+fn fallback_username() -> String {
     std::env::var("USER")
         .or_else(|_| std::env::var("USERNAME"))
         .unwrap_or_default()
+}
+
+#[cfg(target_os = "macos")]
+#[allow(deprecated)]
+fn macos_full_user_name() -> Option<String> {
+    use cocoa::base::{id, nil};
+    use cocoa::foundation::NSString;
+    use std::ffi::CStr;
+
+    #[link(name = "Foundation", kind = "framework")]
+    extern "C" {
+        fn NSFullUserName() -> id;
+    }
+
+    unsafe {
+        let full_name = NSFullUserName();
+        if full_name == nil {
+            return None;
+        }
+
+        let bytes = full_name.UTF8String();
+        if bytes.is_null() {
+            return None;
+        }
+
+        let name = CStr::from_ptr(bytes).to_string_lossy().trim().to_string();
+        if name.is_empty() {
+            None
+        } else {
+            Some(name)
+        }
+    }
 }
 
 /// Complete onboarding and open a fresh notebook window.

--- a/packages/runtimed/src/notebook-actor-display.ts
+++ b/packages/runtimed/src/notebook-actor-display.ts
@@ -15,7 +15,6 @@ export interface ResolveActorDisplayOptions {
   actorLabel: string;
   peers: ReadonlyArray<ActorDisplayPeer>;
   source: "cloud" | "local";
-  identityLabel?: string;
 }
 
 export interface ActorDisplay {
@@ -34,9 +33,8 @@ export function resolveActorDisplay({
   actorLabel,
   peers,
   source,
-  identityLabel,
 }: ResolveActorDisplayOptions): ActorDisplay {
-  const projection = notebookActorProjectionFromLabel(actorLabel, { identityLabel, source });
+  const projection = notebookActorProjectionFromLabel(actorLabel, { source });
   const identity = notebookActorIdentityFromProjection(projection);
   const principalId = projection.principal.id;
   const peer = peerForPrincipal(peers, principalId);

--- a/packages/runtimed/src/notebook-actor-display.ts
+++ b/packages/runtimed/src/notebook-actor-display.ts
@@ -15,6 +15,7 @@ export interface ResolveActorDisplayOptions {
   actorLabel: string;
   peers: ReadonlyArray<ActorDisplayPeer>;
   source: "cloud" | "local";
+  identityLabel?: string;
 }
 
 export interface ActorDisplay {
@@ -33,8 +34,9 @@ export function resolveActorDisplay({
   actorLabel,
   peers,
   source,
+  identityLabel,
 }: ResolveActorDisplayOptions): ActorDisplay {
-  const projection = notebookActorProjectionFromLabel(actorLabel, { source });
+  const projection = notebookActorProjectionFromLabel(actorLabel, { identityLabel, source });
   const identity = notebookActorIdentityFromProjection(projection);
   const principalId = projection.principal.id;
   const peer = peerForPrincipal(peers, principalId);

--- a/packages/runtimed/tests/notebook-actor-display.test.ts
+++ b/packages/runtimed/tests/notebook-actor-display.test.ts
@@ -68,6 +68,17 @@ describe("resolveActorDisplay", () => {
     ).toBe("Ada");
   });
 
+  it("uses the identity label before the friendly principal label", () => {
+    expect(
+      resolveActorDisplay({
+        actorLabel: "user:local:kylekelley/desktop:app",
+        identityLabel: "Kyle Kelley",
+        peers: [],
+        source: "local",
+      }).displayName,
+    ).toBe("Kyle Kelley");
+  });
+
   it("derives initials across names, delimiters, and email-like labels", () => {
     expect(actorInitials("Kyle Kelley")).toBe("KK");
     expect(actorInitials("kyle.kelley")).toBe("KK");

--- a/packages/runtimed/tests/notebook-actor-display.test.ts
+++ b/packages/runtimed/tests/notebook-actor-display.test.ts
@@ -68,12 +68,16 @@ describe("resolveActorDisplay", () => {
     ).toBe("Ada");
   });
 
-  it("uses the identity label before the friendly principal label", () => {
+  it("uses the local presence peer label for the local principal", () => {
+    // The desktop host feeds the OS full name through a peers entry keyed by the
+    // local principal, so only the local author is relabeled; other principals
+    // keep their own friendly labels.
+    const localActor = "user:local:kylekelley/desktop:app";
+    const [localPrincipal] = localActor.split("/");
     expect(
       resolveActorDisplay({
-        actorLabel: "user:local:kylekelley/desktop:app",
-        identityLabel: "Kyle Kelley",
-        peers: [],
+        actorLabel: localActor,
+        peers: [{ participantKey: localPrincipal, label: "Kyle Kelley" }],
         source: "local",
       }).displayName,
     ).toBe("Kyle Kelley");


### PR DESCRIPTION
Desktop comment authors showed the humanized OS account name (e.g. "Kylekelley") instead of a real name, because the local actor label derives from `$USER`.

`get_username()` now returns the macOS full name via `NSFullUserName()`, falling back to `$USER`/`$USERNAME` when it is empty or off-macOS. That value already flows through `__NTERACT_USERNAME__` into the local peer label.

`resolveCommentAuthor` feeds that name through a `peers` entry keyed by the local principal, mirroring the cloud presence model. Only the local author is relabeled; synced peers and agents resolve their own friendly labels. A first pass applied the name as an `identityLabel` for every author, which would have relabeled remote and agent comments with this machine's user name; the peer-scoped approach avoids that and drops the unused `identityLabel` option.

Verified: `vp check`, the actor-display unit test, notebook-app and cloud typecheck, and `cargo check -p notebook` for the Rust change.
