### PR TITLE
fix(reconnect): survive a daemon restart during initial materialize

### DIFF
--- a/apps/notebook/src/hooks/useAutomergeNotebook.ts
+++ b/apps/notebook/src/hooks/useAutomergeNotebook.ts
@@ -178,33 +178,39 @@ export function useNotebook() {
   // ── Core helpers ───────────────────────────────────────────────────
 
   /** Full materialization: WASM doc → resolve manifests → write to store. */
-  const materializeCells = useCallback(async (handle: NotebookHandle) => {
-    const start = performance.now();
-    // Resolve blob port BEFORE reading cells — WASM needs it to
-    // convert binary ContentRefs to Url variants in get_cells_json().
-    let blobResolver = getBlobResolver();
-    if (blobResolver === null) {
-      blobResolver = await refreshBlobResolver();
-    }
-    const blobPort = blobResolver?.port ?? null;
-    if (blobPort !== null) {
-      handle.set_blob_port(blobPort);
-    }
-    const json = handle.get_cells_json();
-    const snapshots: CellSnapshot[] = JSON.parse(json);
-    const newCells = await cellSnapshotsToNotebookCells(
-      snapshots,
-      blobResolver,
-      outputCacheRef.current,
-    );
-    // Pre-warm renderer plugins before cells paint so document-like markdown
-    // and output iframes do not wait for async chunk loads on first render.
-    preWarmCellRenderers(newCells);
-    replaceNotebookCells(newCells);
-    logger.debug(
-      `[automerge-notebook] Full materialization: ${snapshots.length} cells in ${(performance.now() - start).toFixed(1)}ms`,
-    );
-  }, []);
+  const materializeCells = useCallback(
+    async (handle: NotebookHandle) => {
+      const start = performance.now();
+      const isCurrentHandle = () => handleHost.current === handle;
+      // Resolve blob port BEFORE reading cells — WASM needs it to
+      // convert binary ContentRefs to Url variants in get_cells_json().
+      let blobResolver = getBlobResolver();
+      if (blobResolver === null) {
+        blobResolver = await refreshBlobResolver();
+        if (!isCurrentHandle()) return;
+      }
+      const blobPort = blobResolver?.port ?? null;
+      if (blobPort !== null) {
+        handle.set_blob_port(blobPort);
+      }
+      const json = handle.get_cells_json();
+      const snapshots: CellSnapshot[] = JSON.parse(json);
+      const newCells = await cellSnapshotsToNotebookCells(
+        snapshots,
+        blobResolver,
+        outputCacheRef.current,
+      );
+      if (!isCurrentHandle()) return;
+      // Pre-warm renderer plugins before cells paint so document-like markdown
+      // and output iframes do not wait for async chunk loads on first render.
+      preWarmCellRenderers(newCells);
+      replaceNotebookCells(newCells);
+      logger.debug(
+        `[automerge-notebook] Full materialization: ${snapshots.length} cells in ${(performance.now() - start).toFixed(1)}ms`,
+      );
+    },
+    [handleHost],
+  );
 
   /** Sync re-read cells from WASM (cache-only, no blob fetches). */
   const rematerializeCellsSync = useCallback((handle: NotebookHandle) => {

--- a/apps/notebook/src/lib/__tests__/notebook-sync-store-bridge.test.ts
+++ b/apps/notebook/src/lib/__tests__/notebook-sync-store-bridge.test.ts
@@ -395,6 +395,36 @@ describe("startNotebookSyncStoreBridge", () => {
     expect(setLoadError).not.toHaveBeenCalled();
   });
 
+  it("ignores in-flight materializeCells result if the handle is replaced before it resolves", async () => {
+    const materialize = deferred();
+    const materializeCells = vi.fn(() => materialize.promise);
+    const firstHandle = createHandle();
+    const secondHandle = createHandle();
+    let liveHandle = firstHandle;
+    const { bridge, setIsLoading, subjects } = startBridge({
+      materializeCells,
+      getHandle: () => liveHandle,
+    });
+
+    subjects.initialSyncComplete$.next();
+    await flushMicrotasks();
+    expect(materializeCells).toHaveBeenCalledWith(firstHandle);
+    setIsLoading.mockClear();
+
+    // A daemon restart frees gen1 and installs gen2 while materialize is in
+    // flight. The gen1 continuation must bail; gen2 drives its own cycle.
+    liveHandle = secondHandle;
+    materialize.resolve();
+    await flushMicrotasks();
+
+    expect(mocks.applyExecutionViewChangeset).not.toHaveBeenCalled();
+    expect(mocks.seedOutputStoresFromHandle).not.toHaveBeenCalled();
+    expect(mocks.notifyMetadataChanged).not.toHaveBeenCalled();
+    expect(setIsLoading).not.toHaveBeenCalled();
+
+    bridge.stop();
+  });
+
   it("ignores in-flight materializeChangeset result if stopped before it resolves", async () => {
     const work = deferred();
     mocks.materializeChangeset.mockImplementationOnce(() => work.promise);

--- a/apps/notebook/src/lib/frame-pipeline.ts
+++ b/apps/notebook/src/lib/frame-pipeline.ts
@@ -102,6 +102,7 @@ export async function materializeChangeset(
 ): Promise<void> {
   const handle = deps.getHandle();
   if (!handle) return;
+  const isCurrentHandle = () => deps.getHandle() === handle;
 
   // ── Full materialization fallback ──────────────────────────────────
 
@@ -117,6 +118,7 @@ export async function materializeChangeset(
       );
     }
     await deps.materializeCells(handle);
+    if (!isCurrentHandle()) return;
     notifyMetadataChanged();
     return;
   }
@@ -136,6 +138,7 @@ export async function materializeChangeset(
         "[frame-pipeline] full materialization: structural changeset without get_cell_ids",
       );
       await deps.materializeCells(handle);
+      if (!isCurrentHandle()) return;
       notifyMetadataChanged();
       return;
     }
@@ -160,6 +163,7 @@ export async function materializeChangeset(
           `[frame-pipeline] full materialization: structural added cell ${cellId.slice(0, 8)} unavailable`,
         );
         await deps.materializeCells(handle);
+        if (!isCurrentHandle()) return;
         notifyMetadataChanged();
         return;
       }
@@ -187,6 +191,7 @@ export async function materializeChangeset(
           `[frame-pipeline] full materialization: structural ordered cell ${cellId.slice(0, 8)} unavailable`,
         );
         await deps.materializeCells(handle);
+        if (!isCurrentHandle()) return;
         notifyMetadataChanged();
         return;
       }

--- a/apps/notebook/src/lib/notebook-sync-store-bridge.ts
+++ b/apps/notebook/src/lib/notebook-sync-store-bridge.ts
@@ -91,6 +91,10 @@ export function startNotebookSyncStoreBridge(
         .materializeCells(handle)
         .then(() => {
           if (stopped) return;
+          // A daemon restart can free this handle during the await (gen1 -> gen2
+          // relay reset). Bail if the live handle was replaced; the gen2
+          // bootstrap drives its own initialSyncComplete materialize cycle.
+          if (options.getHandle() !== handle) return;
           interactiveReady = true;
           const cellIdList = [...handle.get_cell_ids()];
           // `initialSyncComplete$` fires when the notebook doc is interactive,


### PR DESCRIPTION
A daemon restart while the notebook was connected froze the open document: the rendered cells vanished even though the daemon still held them, and only a reload recovered.

The cause is a use-after-free of the WASM notebook handle across a reconnect. A restart cycles the relay generation (gen1 to gen2); the gen2 bootstrap frees the gen1 handle while an in-flight materialize is still awaiting blob resolution. After the await, the materialize calls back into the freed handle (`set_blob_port`, `get_cells_json`) and wasm-bindgen panics on `assert_not_null`, so the initial materialize fails and the cells disappear.

`materializeCells` and `materializeChangeset` now re-check live handle identity after each await and bail before any WASM call. The `initialSyncComplete` continuation does the same before it reuses the captured handle for `get_cell_ids` / output seeding / projection; otherwise the same panic could fire one frame downstream. The guard mirrors the existing `cellChanges` continuation, which already re-reads the live handle. When the handle was replaced, the gen2 bootstrap drives its own materialize cycle, so bailing loses nothing.

Verified: `vp check`, notebook-app typecheck, and the sync-store-bridge test suite, including a new case that proves the continuation bails when the handle is replaced mid-await.
