### PR TITLE
feat(comments): dot selection affordance shared across editor and rendered markdown

### DIFF
--- a/apps/elements/app/global.css
+++ b/apps/elements/app/global.css
@@ -6,6 +6,7 @@
 @import "../../../src/styles/notebook-base.css";
 @import "../../../src/styles/cream-theme.css";
 @import "../../../src/styles/comment-highlight.css";
+@import "../../../src/styles/comment-affordance.css";
 
 @source "../**/*.{ts,tsx,mdx}";
 @source "../../../src/components/cell/**/*.{ts,tsx}";

--- a/apps/elements/components/comment-selection-affordance-example.tsx
+++ b/apps/elements/components/comment-selection-affordance-example.tsx
@@ -1,0 +1,21 @@
+"use client";
+
+import { CommentSelectionAffordance } from "@/components/comments/CommentSelectionAffordance";
+
+export function CommentSelectionAffordanceExample() {
+  return (
+    <div className="not-prose my-6">
+      <div className="mx-auto max-w-[760px] border border-border bg-background px-6 py-5 text-foreground shadow-sm max-sm:px-4">
+        <p className="mb-4 text-sm text-muted-foreground">
+          Resting, the affordance is a quiet dot that stays out of the way while you select and copy
+          text. Hover it, or focus it with the keyboard, and it grows in place into a comment
+          button. The editor and rendered-markdown planes share this one surface.
+        </p>
+        <div className="flex items-center gap-3 text-sm">
+          <CommentSelectionAffordance label="Add comment" onActivate={() => undefined} />
+          <span>Hover the dot, or tab to it.</span>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/apps/elements/content/docs/comment-surfaces.mdx
+++ b/apps/elements/content/docs/comment-surfaces.mdx
@@ -5,6 +5,7 @@ description: Anchored notebook comments. The rail panel, attribution, and AI-on-
 
 import { CommentSurfacesExample } from "@/components/comment-surfaces-example";
 import { CommentHighlightSurfacesExample } from "@/components/comment-highlight-surfaces-example";
+import { CommentSelectionAffordanceExample } from "@/components/comment-selection-affordance-example";
 
 People and AI agents work the same live notebook, and comments are how they
 talk about it: a thread anchored to a source range, a cell, an output, or the
@@ -12,6 +13,15 @@ whole document. The rail below is rendered from fixtures, no daemon and no
 kernel, so the surface and its rationale stand on their own.
 
 <CommentSurfacesExample />
+
+## Commenting on a selection
+
+Selecting text is for reading and copying first, so the entry point to a comment
+stays quiet: a small dot near the selection that grows in place into a comment
+button on hover or keyboard focus. The same affordance appears in the CodeMirror
+editor and in rendered markdown.
+
+<CommentSelectionAffordanceExample />
 
 ## Rendered markdown highlights
 

--- a/apps/elements/tsconfig.json
+++ b/apps/elements/tsconfig.json
@@ -7,6 +7,7 @@
     "jsx": "preserve",
     "paths": {
       "@/components/cell/*": ["../../src/components/cell/*"],
+      "@/components/comments/*": ["../../src/components/comments/*"],
       "@/bindings": ["../../src/bindings/index.ts"],
       "@/bindings/*": ["../../src/bindings/*"],
       "@/components/editor/*": ["../../src/components/editor/*"],

--- a/apps/notebook/src/components/MarkdownCell.tsx
+++ b/apps/notebook/src/components/MarkdownCell.tsx
@@ -1,5 +1,5 @@
 import type { EditorView, KeyBinding } from "@codemirror/view";
-import { Check, MessageSquarePlus, Pencil } from "lucide-react";
+import { Check, Pencil } from "lucide-react";
 import {
   memo,
   type MouseEvent,
@@ -12,6 +12,7 @@ import {
   useState,
 } from "react";
 import { CellContainer } from "@/components/cell/CellContainer";
+import { CommentSelectionAffordance } from "@/components/comments/CommentSelectionAffordance";
 import { CodeMirrorEditor, type CodeMirrorEditorRef } from "@/components/editor/codemirror-editor";
 import { remoteCursorsExtension } from "@/components/editor/remote-cursors";
 import { searchHighlight } from "@/components/editor/search-highlight";
@@ -1097,28 +1098,16 @@ export const MarkdownCell = memo(function MarkdownCell({
                 <p className="text-muted-foreground italic">Double-click to edit</p>
               )}
               {renderedSourceCommentTarget ? (
-                <button
-                  type="button"
-                  aria-label="Comment on selected markdown"
-                  title="Comment on selected markdown"
-                  data-testid="markdown-source-comment-button"
-                  onPointerDown={(event) => {
-                    event.preventDefault();
-                    event.stopPropagation();
-                  }}
-                  onMouseDown={(event) => {
-                    event.preventDefault();
-                    event.stopPropagation();
-                  }}
-                  onClick={handleRenderedSourceCommentClick}
-                  className="absolute z-20 inline-flex size-6 items-center justify-center rounded-md border bg-background p-0 text-foreground shadow-sm transition-colors hover:bg-muted focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/30"
+                <CommentSelectionAffordance
+                  className="absolute z-20"
                   style={{
                     left: renderedSourceCommentTarget.left,
                     top: renderedSourceCommentTarget.top,
                   }}
-                >
-                  <MessageSquarePlus className="h-[15px] w-[15px]" aria-hidden="true" />
-                </button>
+                  label="Comment on selected markdown"
+                  testId="markdown-source-comment-button"
+                  onActivate={handleRenderedSourceCommentClick}
+                />
               ) : null}
             </div>
           </RenderedMarkdownContextMenu>

--- a/apps/notebook/src/lib/source-comment-extension.ts
+++ b/apps/notebook/src/lib/source-comment-extension.ts
@@ -68,7 +68,7 @@ export function sourceCommentExtension(
     },
   ]);
 
-  return [sourceCommentTheme, tooltipField, focusSync, shortcut];
+  return [tooltipField, focusSync, shortcut];
 }
 
 function sourceCommentTooltips(
@@ -88,13 +88,20 @@ function sourceCommentTooltips(
       above: true,
       strictSide: false,
       create(view) {
+        // Shared dot affordance (styles/comment-affordance.css), matching the
+        // rendered-markdown plane. CodeMirror wraps this in a .cm-tooltip; the
+        // shared CSS strips that wrapper's chrome so only the dot shows.
         const button = document.createElement("button");
         button.type = "button";
-        button.className = "cm-source-comment-button";
-        button.appendChild(createCommentIcon());
+        button.className = "comment-affordance";
         button.title = "Comment on selection";
         button.setAttribute("aria-label", "Comment on selection");
         button.setAttribute("data-testid", "source-comment-button");
+        const dot = document.createElement("span");
+        dot.className = "comment-affordance-dot";
+        dot.setAttribute("aria-hidden", "true");
+        dot.appendChild(createCommentIcon());
+        button.appendChild(dot);
         button.addEventListener("mousedown", (event) => {
           event.preventDefault();
         });
@@ -110,8 +117,9 @@ function sourceCommentTooltips(
 
 function createCommentIcon(): SVGSVGElement {
   const icon = document.createElementNS("http://www.w3.org/2000/svg", "svg");
-  icon.setAttribute("width", "15");
-  icon.setAttribute("height", "15");
+  icon.setAttribute("class", "comment-affordance-icon");
+  icon.setAttribute("width", "14");
+  icon.setAttribute("height", "14");
   icon.setAttribute("viewBox", "0 0 24 24");
   icon.setAttribute("fill", "none");
   icon.setAttribute("stroke", "currentColor");
@@ -147,30 +155,3 @@ function requestSourceComment(
   onCreateSourceComment(anchor, selectionRectFromView(view));
   return true;
 }
-
-const sourceCommentTheme = EditorView.baseTheme({
-  ".cm-source-comment-button": {
-    border: "1px solid var(--border, #ebebeb)",
-    borderRadius: "0.375rem",
-    backgroundColor: "var(--background, #ffffff)",
-    color: "var(--foreground, #1e1e1e)",
-    boxShadow: "0 1px 4px rgb(0 0 0 / 0.14)",
-    boxSizing: "border-box",
-    cursor: "pointer",
-    display: "inline-flex",
-    alignItems: "center",
-    justifyContent: "center",
-    height: "24px",
-    padding: "0",
-    width: "24px",
-  },
-  ".cm-source-comment-button:hover": {
-    borderColor: "var(--primary, #2563eb)",
-    backgroundColor: "var(--primary, #2563eb)",
-    color: "var(--primary-foreground, #ffffff)",
-  },
-  ".cm-source-comment-button:focus-visible": {
-    outline: "2px solid var(--ring, #a3a3a3)",
-    outlineOffset: "2px",
-  },
-});

--- a/src/components/comments/CommentSelectionAffordance.tsx
+++ b/src/components/comments/CommentSelectionAffordance.tsx
@@ -1,0 +1,57 @@
+import { MessageSquarePlus } from "lucide-react";
+import type { CSSProperties, MouseEvent as ReactMouseEvent } from "react";
+import { cn } from "@/lib/utils";
+
+export interface CommentSelectionAffordanceProps {
+  /** Fires on click or keyboard activation. Receives the button event so the
+   *  host can fall back to the button rect when there is no selection rect. */
+  onActivate: (event: ReactMouseEvent<HTMLButtonElement>) => void;
+  /** Positioning and any extra classes from the host plane. */
+  className?: string;
+  style?: CSSProperties;
+  label?: string;
+  testId?: string;
+}
+
+/**
+ * The "comment on selection" affordance: a small resting dot that grows in place
+ * into a comment button on hover or focus. Shared by the code-editor and
+ * rendered-markdown planes; the visual lives in styles/comment-affordance.css so
+ * both surfaces match and stay tunable in one place (shown in Elements).
+ */
+export function CommentSelectionAffordance({
+  onActivate,
+  className,
+  style,
+  label = "Add comment",
+  testId,
+}: CommentSelectionAffordanceProps) {
+  return (
+    <button
+      type="button"
+      aria-label={label}
+      title={label}
+      data-testid={testId}
+      className={cn("comment-affordance", className)}
+      style={style}
+      onPointerDown={(event) => {
+        // Keep the active text selection while the affordance is pressed.
+        event.preventDefault();
+        event.stopPropagation();
+      }}
+      onMouseDown={(event) => {
+        event.preventDefault();
+        event.stopPropagation();
+      }}
+      onClick={(event) => {
+        event.preventDefault();
+        event.stopPropagation();
+        onActivate(event);
+      }}
+    >
+      <span className="comment-affordance-dot" aria-hidden="true">
+        <MessageSquarePlus className="comment-affordance-icon" aria-hidden="true" />
+      </span>
+    </button>
+  );
+}

--- a/src/index.css
+++ b/src/index.css
@@ -1,6 +1,7 @@
 @import "tailwindcss";
 @import "./styles/ansi.css";
 @import "./styles/comment-highlight.css";
+@import "./styles/comment-affordance.css";
 
 @custom-variant dark (&:is(.dark *));
 

--- a/src/styles/comment-affordance.css
+++ b/src/styles/comment-affordance.css
@@ -1,0 +1,81 @@
+/* The "comment on selection" affordance, shared across the CodeMirror editor
+   plane and the rendered-markdown plane. One definition so both surfaces match
+   and the look is tunable in one place (cataloged in Elements).
+
+   Resting state is a small unobtrusive dot that sits out of the way while a
+   reader selects and copies text. On hover or keyboard focus the dot grows in
+   place into a labeled comment button. Growing the same element (rather than
+   revealing a separate floating panel) keeps the target under the cursor, so
+   there is no gap to cross and nothing to flicker out as you reach for it. */
+.comment-affordance {
+  --comment-affordance-color: var(--primary, #2563eb);
+  box-sizing: border-box;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  /* A stable 22px hit area around a 9px dot: easy to hit without enlarging the
+     resting footprint. */
+  width: 22px;
+  height: 22px;
+  padding: 0;
+  margin: 0;
+  border: none;
+  background: transparent;
+  color: var(--primary-foreground, #ffffff);
+  cursor: pointer;
+}
+
+.comment-affordance-dot {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 9px;
+  height: 9px;
+  border-radius: 9999px;
+  background-color: color-mix(in srgb, var(--comment-affordance-color) 50%, transparent);
+  box-shadow: 0 1px 3px rgb(0 0 0 / 0.18);
+  transition:
+    width 120ms ease,
+    height 120ms ease,
+    border-radius 120ms ease,
+    background-color 120ms ease;
+}
+
+.comment-affordance-icon {
+  width: 14px;
+  height: 14px;
+  opacity: 0;
+  transform: scale(0.6);
+  transition:
+    opacity 120ms ease,
+    transform 120ms ease;
+}
+
+.comment-affordance:hover .comment-affordance-dot,
+.comment-affordance:focus-visible .comment-affordance-dot {
+  width: 22px;
+  height: 22px;
+  border-radius: 0.5rem;
+  background-color: var(--comment-affordance-color);
+}
+
+.comment-affordance:hover .comment-affordance-icon,
+.comment-affordance:focus-visible .comment-affordance-icon {
+  opacity: 1;
+  transform: scale(1);
+}
+
+.comment-affordance:focus-visible {
+  outline: 2px solid var(--ring, #a3a3a3);
+  outline-offset: 2px;
+  border-radius: 0.5rem;
+}
+
+/* The CodeMirror editor plane renders this button inside a CM tooltip wrapper.
+   Strip the default tooltip chrome so only the dot shows. */
+.cm-tooltip:has(.comment-affordance) {
+  border: none;
+  background: transparent;
+  box-shadow: none;
+  padding: 0;
+}


### PR DESCRIPTION
The "comment on selection" affordance was a 24px icon button that sat heavily over the selected text, and it was built twice: a CodeMirror tooltip button in the editor and a separate React button in rendered markdown.

This replaces both with a small resting dot that grows in place into a comment button on hover or keyboard focus. The visual is defined once in `src/styles/comment-affordance.css` and reused across both planes: a shared `CommentSelectionAffordance` component (`src/components/comments/`) for the rendered-markdown plane, and the same classes applied to the CodeMirror tooltip button for the editor. It's cataloged in Elements under Comment surfaces so the look stays tunable in one place.

Design notes:

- The dot stays quiet while you select and copy text, which is the common case. It only becomes a button when you reach for it.
- Growing the same element (rather than revealing a separate floating panel) keeps the target under the cursor. There's no gap to cross and nothing to flicker out as you move toward it, which is the hover-intent problem a "safe triangle" would otherwise solve.
- A 22px hit area wraps the 9px dot, so it's easy to land on without enlarging the resting footprint.
- The shared CSS strips the CodeMirror tooltip chrome so only the dot shows in the editor.

Both planes feed the same `onCreateSourceComment(anchor, rect)` path as before; only the trigger's look and shared definition changed.

Verified: `vp check`, notebook / cloud / Elements typecheck, and the full `vp test` suite (2445 passed). Worth an interactive look in Elements (Comment surfaces) and the running app for the hover and focus growth on both planes.
