### PR TITLE
fix(comments): a comments-doc sync error must not tear down the notebook connection

### DIFF
--- a/crates/runtimed/src/notebook_sync_server/peer_loop.rs
+++ b/crates/runtimed/src/notebook_sync_server/peer_loop.rs
@@ -353,16 +353,27 @@ where
                             }
 
                             NotebookFrameType::CommentsDocSync => {
-                                if !handle_comments_doc_frame(
+                                // A comments-sync failure must never take down the
+                                // notebook connection. Drop the offending frame and
+                                // keep the peer editing; comments degrade alone.
+                                match handle_comments_doc_frame(
                                     room,
                                     &mut comments_peer_state,
                                     &peer_writer,
                                     &frame.payload,
                                     connection_identity,
                                 )
-                                .await?
+                                .await
                                 {
-                                    continue;
+                                    Ok(true) => {}
+                                    Ok(false) => continue,
+                                    Err(e) => {
+                                        warn!(
+                                            "[notebook-sync] CommentsDoc frame error (dropping frame, keeping connection): {}",
+                                            e
+                                        );
+                                        continue;
+                                    }
                                 }
                             }
 


### PR DESCRIPTION
A comments-doc sync error was taking down notebook editing.

When a `CommentsDocSync` frame failed validation, its error propagated out of the peer loop (`handle_comments_doc_frame(...).await?`). The daemon treats that as a fatal connection error and closes the connection. The frontend then reconnects into a fresh, empty handle, and local edits can no longer splice into cells that aren't in that handle yet, so the whole notebook becomes uneditable. In the field this showed up as repeated `[crdt-bridge] splice_source failed ... at 0..0`.

The trigger was a `comments_doc_id` with conflicting visible values - concurrent seeds writing different ids during reconnect churn - which the comments-doc layer rejects by design:

```
WARN  peer_comments_sync: CommentsDoc auth preview failed: comments_doc_id has conflicting visible values
ERROR runtimed::daemon: Connection error: comments_doc_id has conflicting visible values
```

This handles a `CommentsDocSync` frame error non-fatally: log it, drop the frame, and keep the peer connected. Comments degrade on their own; notebook editing and sync are unaffected. The comments-doc identity invariant stays strict at the doc layer (a doc with a conflicting or mismatched `comments_doc_id` is still rejected, and the existing rejection tests are unchanged). This only bounds the blast radius of that rejection so it can never break editing. It is the same principle the codebase already applies elsewhere: comments sync is not allowed to backpressure or break notebook state.

## Follow-up

The conflicting `comments_doc_id` itself has a root cause worth a separate fix: the daemon derives the id via `comments_store.resolve_doc_id` (`room.rs`) while the frontend derives it via `hosted_comments_doc_id` (`runtimed-wasm`). Under abnormal reconnect/restart sequences these can seed the comments doc with different ids. That fix makes comments sync on an affected notebook again; this PR makes sure such a state never blocks editing in the first place.

## Verification

`cargo check -p runtimed`, `cargo test -p comments-doc` (31 passing, identity-conflict rejection tests unchanged), `cargo xtask lint --fix` clean. Reproduced the failure on a conflicted untitled notebook, applied the fix, rebuilt the daemon, and confirmed editing recovers. A peer-loop-level automated test would need new harness scaffolding and is noted as a follow-up.
