### PR TITLE
feat(comments): comment on cell outputs with demote-to-notebook on detach

### DIFF
--- a/apps/notebook-cloud/src/runtimed-wasm.generated.d.ts
+++ b/apps/notebook-cloud/src/runtimed-wasm.generated.d.ts
@@ -65,6 +65,7 @@ declare module "../../notebook/src/wasm/runtimed-wasm/runtimed_wasm.js" {
       afterThreadId: string | null | undefined,
       createdAt: string,
     ): unknown;
+    demote_comment_thread_to_notebook(threadId: string): void;
     flush_comms_doc_sync(): Uint8Array | undefined;
     flush_comments_doc_sync(): Uint8Array | undefined;
     flush_local_changes(): Uint8Array | undefined;

--- a/apps/notebook-cloud/viewer/live-sync.ts
+++ b/apps/notebook-cloud/viewer/live-sync.ts
@@ -1741,6 +1741,7 @@ export function syncableCloudHandle(handle: NotebookHandle): SyncableHandle {
     get_comments_doc_heads_hex: commentsSync.get_comments_doc_heads_hex,
     init_comments_sync_target: commentsSync.init_comments_sync_target,
     create_comment_thread: commentsSync.create_comment_thread,
+    demote_comment_thread_to_notebook: commentsSync.demote_comment_thread_to_notebook,
     reply_comment_thread: commentsSync.reply_comment_thread,
     resolve_comment_thread: commentsSync.resolve_comment_thread,
     reopen_comment_thread: commentsSync.reopen_comment_thread,
@@ -1817,6 +1818,7 @@ type CloudCommentsDocSyncMethods = Pick<
   | "get_comments_doc_heads_hex"
   | "init_comments_sync_target"
   | "create_comment_thread"
+  | "demote_comment_thread_to_notebook"
   | "reply_comment_thread"
   | "resolve_comment_thread"
   | "reopen_comment_thread"
@@ -1834,6 +1836,7 @@ function cloudCommentsDocSyncMethods(handle: NotebookHandle): CloudCommentsDocSy
         | "get_comments_doc_heads_hex"
         | "init_comments_sync_target"
         | "create_comment_thread"
+        | "demote_comment_thread_to_notebook"
         | "reply_comment_thread"
         | "resolve_comment_thread"
         | "reopen_comment_thread"
@@ -1876,6 +1879,10 @@ function cloudCommentsDocSyncMethods(handle: NotebookHandle): CloudCommentsDocSy
                 afterThreadId,
                 createdAt,
               ) as ReturnType<NonNullable<SyncableHandle["create_comment_thread"]>>
+          : undefined,
+      demote_comment_thread_to_notebook:
+        typeof candidate.demote_comment_thread_to_notebook === "function"
+          ? (threadId) => candidate.demote_comment_thread_to_notebook?.(threadId)
           : undefined,
       reply_comment_thread:
         typeof candidate.reply_comment_thread === "function"

--- a/apps/notebook-cloud/viewer/notebook-viewer.tsx
+++ b/apps/notebook-cloud/viewer/notebook-viewer.tsx
@@ -50,6 +50,10 @@ import {
   setNotebookRailCollapsed,
   useNotebookRailUiState,
 } from "@/components/notebook/state/rail-ui-state";
+import {
+  outputCommentAnchorMatchesLiveState,
+  useDemoteDetachedOutputCommentThreads,
+} from "@/components/notebook/output-comment-demotion";
 import { useWidgetStoreRequired } from "@/components/widgets/widget-store-context";
 import { useTheme } from "@/hooks/useTheme";
 import { EnvironmentSummary } from "@/components/environment";
@@ -88,6 +92,7 @@ import {
 } from "../../notebook/src/lib/comment-highlights";
 import {
   resolveSourceRangeAnchor,
+  type OutputCommentAnchor,
   type SourceCommentSelectionRect,
   type SourceRangeCommentAnchor,
 } from "../../notebook/src/lib/comment-source-anchor";
@@ -1295,6 +1300,13 @@ export function NotebookViewer({
         setCommentsError("Selected source changed. Select the text again before commenting.");
         return;
       }
+      if (
+        commentDraftTarget.anchor.kind === "output" &&
+        !outputCommentAnchorMatchesLiveState(commentDraftTarget.anchor)
+      ) {
+        setCommentsError(OUTPUT_COMMENT_STALE_MESSAGE);
+        return;
+      }
       await handleCreateAnchoredCommentThread(commentDraftTarget.anchor, body);
       setCommentDraftTarget(null);
     },
@@ -1314,6 +1326,17 @@ export function NotebookViewer({
     },
     [],
   );
+
+  const handleRequestOutputComment = useCallback((anchor: OutputCommentAnchor) => {
+    setCommentsError(null);
+    if (!outputCommentAnchorMatchesLiveState(anchor)) {
+      setCommentsError(OUTPUT_COMMENT_STALE_MESSAGE);
+      return;
+    }
+    setSourceCommentRequest(null);
+    setCommentDraftTarget({ anchor, quote: null });
+    openNotebookRailPanel("comments");
+  }, []);
 
   const handleSubmitSourceComment = useCallback(
     async (body: string) => {
@@ -1451,6 +1474,36 @@ export function NotebookViewer({
     },
     [applyLocalCommentEvent, canWriteComments, liveRuntimeRef],
   );
+
+  const handleDemoteDetachedOutputCommentThread = useCallback(
+    (threadId: string) => {
+      if (!canWriteComments) return;
+      const liveRuntime = liveRuntimeRef.current;
+      if (
+        !liveRuntime ||
+        typeof liveRuntime.handle.demote_comment_thread_to_notebook !== "function"
+      ) {
+        setCommentsError("Comments are not ready.");
+        return;
+      }
+      try {
+        liveRuntime.handle.demote_comment_thread_to_notebook(threadId);
+        setCommentsError(null);
+        refreshCloudCommentsProjection();
+        liveRuntime.engine.scheduleFlush();
+      } catch (error) {
+        setCommentsError(error instanceof Error ? error.message : String(error));
+      }
+    },
+    [canWriteComments, liveRuntimeRef, refreshCloudCommentsProjection],
+  );
+
+  useDemoteDetachedOutputCommentThreads({
+    commentsProjection,
+    enabled: canWriteComments,
+    demoteThreadToNotebook: handleDemoteDetachedOutputCommentThread,
+  });
+
   const handleFocusCommentAnchor = useCallback(
     (thread: CommentThreadSnapshot) => {
       const cellId = thread.badge_cell_ids[0];
@@ -1974,6 +2027,7 @@ export function NotebookViewer({
                 onSetCellSourceHidden={handleCloudSetCellSourceHidden}
                 onSetCellOutputsHidden={handleCloudSetCellOutputsHidden}
                 onCreateSourceComment={canWriteComments ? handleRequestSourceComment : undefined}
+                onCreateOutputComment={canWriteComments ? handleRequestOutputComment : undefined}
                 onActivateCommentThread={handleActivateCommentThread}
                 commentThreadsByCell={sourceCommentThreadsByCell}
                 markdownHeadingAnchorsByCellId={notebookViewModel.markdownHeadingAnchorsByCellId}
@@ -2034,6 +2088,9 @@ function sourceRangeAnchorMatchesCurrentCell(anchor: SourceRangeCommentAnchor): 
   }
   return resolveSourceRangeAnchor(cell.source, anchor) !== null;
 }
+
+const OUTPUT_COMMENT_STALE_MESSAGE =
+  "Selected outputs changed. Comment on the current outputs before submitting.";
 
 function createCloudCommentId(prefix: string): string {
   if (typeof crypto !== "undefined" && typeof crypto.randomUUID === "function") {

--- a/apps/notebook-cloud/viewer/notebook-viewer.tsx
+++ b/apps/notebook-cloud/viewer/notebook-viewer.tsx
@@ -1476,23 +1476,24 @@ export function NotebookViewer({
   );
 
   const handleDemoteDetachedOutputCommentThread = useCallback(
-    (threadId: string) => {
-      if (!canWriteComments) return;
+    (threadId: string): boolean => {
+      // Background auto-repair: report success so the hook only stops retrying
+      // once the demote commits, and stay quiet on the user-facing error state.
+      if (!canWriteComments) return false;
       const liveRuntime = liveRuntimeRef.current;
       if (
         !liveRuntime ||
         typeof liveRuntime.handle.demote_comment_thread_to_notebook !== "function"
       ) {
-        setCommentsError("Comments are not ready.");
-        return;
+        return false;
       }
       try {
         liveRuntime.handle.demote_comment_thread_to_notebook(threadId);
-        setCommentsError(null);
         refreshCloudCommentsProjection();
         liveRuntime.engine.scheduleFlush();
-      } catch (error) {
-        setCommentsError(error instanceof Error ? error.message : String(error));
+        return true;
+      } catch {
+        return false;
       }
     },
     [canWriteComments, liveRuntimeRef, refreshCloudCommentsProjection],

--- a/apps/notebook/src/App.tsx
+++ b/apps/notebook/src/App.tsx
@@ -945,20 +945,21 @@ function AppContent() {
   );
 
   const handleDemoteDetachedOutputCommentThread = useCallback(
-    (threadId: string) => {
-      if (!canMutateComments) return;
+    (threadId: string): boolean => {
+      // Background auto-repair: report success so the hook only stops retrying
+      // once the demote commits, and stay quiet on the user-facing error state.
+      if (!canMutateComments) return false;
       const handle = getHandle();
       if (!handle || typeof handle.demote_comment_thread_to_notebook !== "function") {
-        setCommentsError("Comments sync unavailable.");
-        return;
+        return false;
       }
       try {
         handle.demote_comment_thread_to_notebook(threadId);
-        setCommentsError(null);
         refreshCommentsProjection();
         getEngine()?.scheduleFlush();
-      } catch (error) {
-        setCommentsError(error instanceof Error ? error.message : String(error));
+        return true;
+      } catch {
+        return false;
       }
     },
     [canMutateComments, getEngine, getHandle, refreshCommentsProjection],

--- a/apps/notebook/src/App.tsx
+++ b/apps/notebook/src/App.tsx
@@ -65,6 +65,7 @@ import { InlineCommentComposer } from "./components/InlineCommentComposer";
 import { setSourceCommentThreads, type SourceCommentThread } from "./lib/comment-highlights";
 import {
   resolveSourceRangeAnchor,
+  type OutputCommentAnchor,
   type SourceCommentSelectionRect,
   type SourceRangeCommentAnchor,
 } from "./lib/comment-source-anchor";
@@ -100,6 +101,10 @@ import { useUpdater } from "./hooks/useUpdater";
 import { startAttributionDispatch } from "./lib/attribution-registry";
 import { getBlobResolver, useBlobPort } from "./lib/blob-port";
 import { useRuntimeState } from "./lib/runtime-state";
+import {
+  outputCommentAnchorMatchesLiveState,
+  useDemoteDetachedOutputCommentThreads,
+} from "@/components/notebook/output-comment-demotion";
 import {
   flushCellUIState,
   getFocusedCellId,
@@ -230,6 +235,9 @@ function sourceRangeAnchorMatchesCurrentCell(anchor: CommentAnchor): boolean {
     return false;
   return resolveSourceRangeAnchor(cell.source, anchor) !== null;
 }
+
+const OUTPUT_COMMENT_STALE_MESSAGE =
+  "Selected outputs changed. Comment on the current outputs before submitting.";
 
 function markClientExecuteResponse(
   phase: string,
@@ -713,8 +721,18 @@ function AppContent() {
         await handleCreateDocumentComment(body);
         return;
       }
-      if (!sourceRangeAnchorMatchesCurrentCell(commentDraftTarget.anchor)) {
+      if (
+        commentDraftTarget.anchor.kind === "source_range" &&
+        !sourceRangeAnchorMatchesCurrentCell(commentDraftTarget.anchor)
+      ) {
         failCommentAction("Selected source changed. Select the text again before commenting.");
+        return;
+      }
+      if (
+        commentDraftTarget.anchor.kind === "output" &&
+        !outputCommentAnchorMatchesLiveState(commentDraftTarget.anchor)
+      ) {
+        failCommentAction(OUTPUT_COMMENT_STALE_MESSAGE);
         return;
       }
       await handleCreateCommentThread(commentDraftTarget.anchor, body);
@@ -736,6 +754,17 @@ function AppContent() {
     },
     [],
   );
+
+  const handleRequestOutputComment = useCallback((anchor: OutputCommentAnchor) => {
+    setCommentsError(null);
+    if (!outputCommentAnchorMatchesLiveState(anchor)) {
+      setCommentsError(OUTPUT_COMMENT_STALE_MESSAGE);
+      return;
+    }
+    setSourceCommentRequest(null);
+    setCommentDraftTarget({ anchor, quote: null });
+    openNotebookRailPanel("comments");
+  }, []);
 
   const handleSubmitSourceComment = useCallback(
     async (body: string) => {
@@ -914,6 +943,32 @@ function AppContent() {
     },
     [applyLocalCommentEvent, canMutateComments, failCommentAction, getHandle],
   );
+
+  const handleDemoteDetachedOutputCommentThread = useCallback(
+    (threadId: string) => {
+      if (!canMutateComments) return;
+      const handle = getHandle();
+      if (!handle || typeof handle.demote_comment_thread_to_notebook !== "function") {
+        setCommentsError("Comments sync unavailable.");
+        return;
+      }
+      try {
+        handle.demote_comment_thread_to_notebook(threadId);
+        setCommentsError(null);
+        refreshCommentsProjection();
+        getEngine()?.scheduleFlush();
+      } catch (error) {
+        setCommentsError(error instanceof Error ? error.message : String(error));
+      }
+    },
+    [canMutateComments, getEngine, getHandle, refreshCommentsProjection],
+  );
+
+  useDemoteDetachedOutputCommentThreads({
+    commentsProjection,
+    enabled: canMutateComments,
+    demoteThreadToNotebook: handleDemoteDetachedOutputCommentThread,
+  });
 
   const handleFocusCommentThreadAnchor = useCallback((thread: CommentThreadSnapshot) => {
     const cellId = thread.badge_cell_ids[0];
@@ -2021,6 +2076,7 @@ function AppContent() {
                 onSetCellSourceHidden={setCellSourceHidden}
                 onSetCellOutputsHidden={setCellOutputsHidden}
                 onCreateSourceComment={canMutateComments ? handleRequestSourceComment : undefined}
+                onCreateOutputComment={canMutateComments ? handleRequestOutputComment : undefined}
                 onActivateCommentThread={handleActivateCommentThread}
                 commentThreadsByCell={sourceCommentThreadsByCell}
                 markdownHeadingAnchorsByCellId={markdownHeadingAnchorsByCellId}

--- a/apps/notebook/src/components/CodeCell.tsx
+++ b/apps/notebook/src/components/CodeCell.tsx
@@ -1,5 +1,5 @@
 import type { EditorView, KeyBinding } from "@codemirror/view";
-import { ChevronRight, Code2, Eye, EyeOff, type LucideIcon } from "lucide-react";
+import { ChevronRight, Code2, Eye, EyeOff, MessageSquarePlus, type LucideIcon } from "lucide-react";
 import { memo, type ReactNode, useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { CellContainer } from "@/components/cell/CellContainer";
 import { cellOutputInnerInset } from "@/components/cell/cell-layout";
@@ -44,6 +44,7 @@ import { presenceSenderExtension } from "../lib/presence-sender";
 import { commentHighlightExtension } from "../lib/comment-highlight-extension";
 import { refreshCellCommentHighlights } from "../lib/comment-highlights";
 import type {
+  OutputCommentAnchor,
   SourceCommentSelectionRect,
   SourceRangeCommentAnchor,
 } from "../lib/comment-source-anchor";
@@ -108,6 +109,7 @@ interface CodeCellProps {
     anchor: SourceRangeCommentAnchor,
     rect: SourceCommentSelectionRect | null,
   ) => void;
+  onCreateOutputComment?: (anchor: OutputCommentAnchor) => void;
   onActivateCommentThread?: (threadId: string) => void;
   outputHostContext?: NteractEmbedHostContextPatch;
   deferOutputIsolatedFrameUntilVisible?: boolean;
@@ -361,6 +363,7 @@ export const CodeCell = memo(function CodeCell({
   readOnly = false,
   canExecute = !readOnly,
   onCreateSourceComment,
+  onCreateOutputComment,
   onActivateCommentThread,
   outputHostContext,
   deferOutputIsolatedFrameUntilVisible = false,
@@ -664,6 +667,14 @@ export const CodeCell = memo(function CodeCell({
   );
 
   const handleLinkClick = useCallback((url: string) => openUrl(url), []);
+  const handleCreateOutputComment = useCallback(() => {
+    onCreateOutputComment?.({
+      kind: "output",
+      cell_id: cell.id,
+      execution_id: executionId ?? undefined,
+      output_id: undefined,
+    });
+  }, [cell.id, executionId, onCreateOutputComment]);
   const handleOutputMouseDown = useCallback(() => {
     editorRef.current?.getEditor()?.contentDOM.blur();
     onFocus();
@@ -687,6 +698,8 @@ export const CodeCell = memo(function CodeCell({
     isExecutionErrored ||
     submittedByActorLabel !== null;
   const showExecutionControl = canExecute || hasExecutionReadout;
+  const canCreateOutputComment =
+    outputs.length > 0 && !isOutputsHidden && !readOnly && Boolean(onCreateOutputComment);
   const hasCurrentLine =
     !isSourceEmpty ||
     visibleOutputCount > 0 ||
@@ -878,16 +891,33 @@ export const CodeCell = memo(function CodeCell({
           )
         }
         outputRightGutterContent={
-          outputs.length > 0 && !isOutputsHidden && onToggleOutputsHidden && !readOnly ? (
-            <button
-              type="button"
-              tabIndex={-1}
-              onClick={() => onToggleOutputsHidden(true)}
-              className="flex items-center justify-center rounded p-1 text-muted-foreground/40 transition-colors hover:text-foreground"
-              title="Hide outputs"
-            >
-              <EyeOff className="h-3.5 w-3.5" />
-            </button>
+          outputs.length > 0 && !isOutputsHidden && !readOnly ? (
+            <>
+              {canCreateOutputComment ? (
+                <button
+                  type="button"
+                  tabIndex={-1}
+                  onClick={handleCreateOutputComment}
+                  className="flex items-center justify-center rounded p-1 text-muted-foreground/40 transition-colors hover:text-foreground"
+                  title="Comment on outputs"
+                  aria-label="Comment on outputs"
+                >
+                  <MessageSquarePlus className="h-3.5 w-3.5" />
+                </button>
+              ) : null}
+              {onToggleOutputsHidden ? (
+                <button
+                  type="button"
+                  tabIndex={-1}
+                  onClick={() => onToggleOutputsHidden(true)}
+                  className="flex items-center justify-center rounded p-1 text-muted-foreground/40 transition-colors hover:text-foreground"
+                  title="Hide outputs"
+                  aria-label="Hide outputs"
+                >
+                  <EyeOff className="h-3.5 w-3.5" />
+                </button>
+              ) : null}
+            </>
           ) : undefined
         }
         hideOutput={outputs.length === 0 || bothHidden || (readOnly && isOutputsHidden)}

--- a/apps/notebook/src/components/CodeCell.tsx
+++ b/apps/notebook/src/components/CodeCell.tsx
@@ -891,7 +891,10 @@ export const CodeCell = memo(function CodeCell({
           )
         }
         outputRightGutterContent={
-          outputs.length > 0 && !isOutputsHidden && !readOnly ? (
+          outputs.length > 0 &&
+          !isOutputsHidden &&
+          !readOnly &&
+          (canCreateOutputComment || onToggleOutputsHidden) ? (
             <>
               {canCreateOutputComment ? (
                 <button

--- a/apps/notebook/src/components/NotebookView.tsx
+++ b/apps/notebook/src/components/NotebookView.tsx
@@ -62,6 +62,7 @@ import { MarkdownCell } from "./MarkdownCell";
 import { RawCell } from "./RawCell";
 import type { SourceCommentThread } from "../lib/comment-highlights";
 import type {
+  OutputCommentAnchor,
   SourceCommentSelectionRect,
   SourceRangeCommentAnchor,
 } from "../lib/comment-source-anchor";
@@ -93,6 +94,7 @@ export interface NotebookViewProps {
     anchor: SourceRangeCommentAnchor,
     rect: SourceCommentSelectionRect | null,
   ) => void;
+  onCreateOutputComment?: (anchor: OutputCommentAnchor) => void;
   onActivateCommentThread?: (threadId: string) => void;
   commentThreadsByCell?: ReadonlyMap<string, readonly SourceCommentThread[]>;
   markdownHeadingAnchorsByCellId?: ReadonlyMap<string, readonly MarkdownHeadingAnchor[]>;
@@ -372,6 +374,7 @@ function NotebookViewContent({
   onSetCellSourceHidden,
   onSetCellOutputsHidden,
   onCreateSourceComment,
+  onCreateOutputComment,
   onActivateCommentThread,
   commentThreadsByCell,
   markdownHeadingAnchorsByCellId,
@@ -949,6 +952,7 @@ function NotebookViewContent({
             readOnly={!canEditCodeCellSources}
             canExecute={canExecuteCells}
             onCreateSourceComment={onCreateSourceComment}
+            onCreateOutputComment={onCreateOutputComment}
             onActivateCommentThread={onActivateCommentThread}
             outputHostContext={outputHostContext}
             deferOutputIsolatedFrameUntilVisible={deferOutputIsolatedFramesUntilVisible}
@@ -1066,6 +1070,7 @@ function NotebookViewContent({
       onSetCellSourceHidden,
       onSetCellOutputsHidden,
       onCreateSourceComment,
+      onCreateOutputComment,
       onActivateCommentThread,
       commentThreadsByCell,
       markdownHeadingAnchorsByCellId,

--- a/apps/notebook/src/lib/comment-source-anchor.ts
+++ b/apps/notebook/src/lib/comment-source-anchor.ts
@@ -3,6 +3,7 @@ import type { EditorView } from "@codemirror/view";
 import type { CommentAnchor } from "runtimed";
 
 export type SourceRangeCommentAnchor = Extract<CommentAnchor, { kind: "source_range" }>;
+export type OutputCommentAnchor = Extract<CommentAnchor, { kind: "output" }>;
 
 /**
  * Viewport-space rectangle bounding a comment-worthy selection. Used to anchor

--- a/apps/notebook/src/lib/comment-source-anchor.ts
+++ b/apps/notebook/src/lib/comment-source-anchor.ts
@@ -3,7 +3,8 @@ import type { EditorView } from "@codemirror/view";
 import type { CommentAnchor } from "runtimed";
 
 export type SourceRangeCommentAnchor = Extract<CommentAnchor, { kind: "source_range" }>;
-export type OutputCommentAnchor = Extract<CommentAnchor, { kind: "output" }>;
+// Single source of truth lives with the demote-on-detach logic that consumes it.
+export type { OutputCommentAnchor } from "@/components/notebook/output-comment-demotion";
 
 /**
  * Viewport-space rectangle bounding a comment-worthy selection. Used to anchor

--- a/crates/comments-doc/src/doc.rs
+++ b/crates/comments-doc/src/doc.rs
@@ -281,9 +281,9 @@ impl CommentsDoc {
 
     /// Demote a thread's anchor to a notebook-level comment.
     ///
-    /// Used when a source-range thread's quoted text no longer exists. The
-    /// comment remains visible as a dangling document comment instead of
-    /// disappearing with its lost source target.
+    /// Used when an anchored thread's target no longer exists. The comment
+    /// remains visible as a document comment instead of staying attached to a
+    /// missing target.
     pub fn demote_thread_anchor_to_notebook(
         &mut self,
         thread_id: &str,
@@ -867,6 +867,18 @@ mod tests {
         }
     }
 
+    fn output_anchor(
+        cell_id: &str,
+        execution_id: Option<&str>,
+        output_id: Option<&str>,
+    ) -> CommentAnchor {
+        CommentAnchor::Output {
+            cell_id: cell_id.to_string(),
+            execution_id: execution_id.map(str::to_string),
+            output_id: output_id.map(str::to_string),
+        }
+    }
+
     fn change_hashes_for_actor(doc: &mut AutoCommit, actor: &str) -> Vec<automerge::ChangeHash> {
         doc.get_changes(&[])
             .into_iter()
@@ -945,6 +957,31 @@ mod tests {
             "msg-1",
             &source_anchor(0, 0, 0, 4, Some("beta")),
             "anchored comment",
+            None,
+            "2026-06-16T00:00:00Z",
+        )
+        .unwrap();
+
+        doc.demote_thread_anchor_to_notebook("thread-1").unwrap();
+
+        let projection = doc.read_projection(None).unwrap();
+        let thread = projection
+            .threads
+            .iter()
+            .find(|thread| thread.id == "thread-1")
+            .expect("thread present after demote");
+        assert!(matches!(thread.anchor, CommentAnchor::Notebook));
+        assert!(thread.badge_cell_ids.is_empty());
+    }
+
+    #[test]
+    fn demote_output_thread_anchor_to_notebook_makes_it_a_document_comment() {
+        let mut doc = CommentsDoc::new_with_actor(DOC_ID, &notebook_ref(), CLIENT);
+        doc.create_thread(
+            "thread-1",
+            "msg-1",
+            &output_anchor("cell-a", Some("execution-1"), Some("output-1")),
+            "anchored output comment",
             None,
             "2026-06-16T00:00:00Z",
         )

--- a/crates/runtimed-wasm/src/lib.rs
+++ b/crates/runtimed-wasm/src/lib.rs
@@ -4113,6 +4113,14 @@ impl NotebookHandle {
         self.serialize_comments_projection_event()
     }
 
+    /// Demote a comment thread to a notebook-level comment.
+    pub fn demote_comment_thread_to_notebook(&mut self, thread_id: String) -> Result<(), JsError> {
+        let comments_doc = self.comments_doc_mut()?;
+        comments_doc
+            .demote_thread_anchor_to_notebook(&thread_id)
+            .map_err(|e| JsError::new(&format!("demote comment thread: {e}")))
+    }
+
     /// Add a local reply to a comment thread in CommentsDoc.
     pub fn reply_comment_thread(
         &mut self,

--- a/packages/runtimed/src/handle.ts
+++ b/packages/runtimed/src/handle.ts
@@ -309,6 +309,9 @@ export interface SyncableHandle {
     createdAt: string,
   ): FrameEvent;
 
+  /** Demote a comment thread to a notebook-level comment. */
+  demote_comment_thread_to_notebook?(threadId: string): void;
+
   /** Add a local reply to a comment thread. */
   reply_comment_thread?(
     threadId: string,

--- a/src/components/notebook/__tests__/output-comment-demotion.test.ts
+++ b/src/components/notebook/__tests__/output-comment-demotion.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, it } from "vitest";
+import {
+  shouldDemoteOutputCommentAnchor,
+  type OutputCommentAnchor,
+  type OutputCommentAnchorRuntimeState,
+} from "../output-comment-demotion";
+
+function outputAnchor(
+  executionId: string | null = "execution-1",
+  outputId: string | null = "output-1",
+): OutputCommentAnchor {
+  return {
+    kind: "output",
+    cell_id: "cell-1",
+    execution_id: executionId,
+    output_id: outputId,
+  };
+}
+
+function runtimeState(
+  currentExecutionId = "execution-1",
+  currentOutputIds: readonly string[] = ["output-1"],
+): OutputCommentAnchorRuntimeState {
+  return {
+    cellExists: true,
+    currentExecutionId,
+    currentOutputIds,
+  };
+}
+
+describe("shouldDemoteOutputCommentAnchor", () => {
+  it("demotes when the anchored execution is stale", () => {
+    expect(
+      shouldDemoteOutputCommentAnchor(outputAnchor("execution-1"), runtimeState("execution-2")),
+    ).toBe(true);
+  });
+
+  it("keeps anchors that still point at the current execution", () => {
+    expect(shouldDemoteOutputCommentAnchor(outputAnchor(), runtimeState())).toBe(false);
+  });
+
+  it("demotes when the anchored output id is missing from the current execution", () => {
+    expect(
+      shouldDemoteOutputCommentAnchor(outputAnchor("execution-1", "output-2"), runtimeState()),
+    ).toBe(true);
+  });
+});

--- a/src/components/notebook/__tests__/output-comment-demotion.test.ts
+++ b/src/components/notebook/__tests__/output-comment-demotion.test.ts
@@ -57,6 +57,17 @@ describe("shouldDemoteOutputCommentAnchor", () => {
     ).toBe(false);
   });
 
+  it("does not demote an output anchor that is not pinned to an execution", () => {
+    // execution_id absent: the current execution is a different run, so a missing
+    // output id must not be read as detachment of the run the comment was made on.
+    expect(
+      shouldDemoteOutputCommentAnchor(
+        outputAnchor(null, "output-1"),
+        runtimeState("execution-9", ["output-2"]),
+      ),
+    ).toBe(false);
+  });
+
   it("does not demote while the runtime state has no loaded execution yet", () => {
     // Cell is back but RuntimeStateDoc execution pointers have not landed.
     // A stale-looking anchor must wait, not demote on the empty window.

--- a/src/components/notebook/__tests__/output-comment-demotion.test.ts
+++ b/src/components/notebook/__tests__/output-comment-demotion.test.ts
@@ -44,4 +44,28 @@ describe("shouldDemoteOutputCommentAnchor", () => {
       shouldDemoteOutputCommentAnchor(outputAnchor("execution-1", "output-2"), runtimeState()),
     ).toBe(true);
   });
+
+  it("does not demote while the cell store has not loaded the cell yet", () => {
+    // Reconnect / notebook switch: comments projection is preserved while the
+    // cell store is momentarily empty. Absence is not detachment.
+    expect(
+      shouldDemoteOutputCommentAnchor(outputAnchor("execution-1"), {
+        cellExists: false,
+        currentExecutionId: null,
+        currentOutputIds: [],
+      }),
+    ).toBe(false);
+  });
+
+  it("does not demote while the runtime state has no loaded execution yet", () => {
+    // Cell is back but RuntimeStateDoc execution pointers have not landed.
+    // A stale-looking anchor must wait, not demote on the empty window.
+    expect(
+      shouldDemoteOutputCommentAnchor(outputAnchor("execution-1", "output-1"), {
+        cellExists: true,
+        currentExecutionId: null,
+        currentOutputIds: [],
+      }),
+    ).toBe(false);
+  });
 });

--- a/src/components/notebook/output-comment-demotion.ts
+++ b/src/components/notebook/output-comment-demotion.ts
@@ -1,0 +1,91 @@
+import { useEffect, useRef } from "react";
+import type { CommentAnchor, CommentsProjection } from "./comment-types";
+import { getCellById } from "./state/cell-store";
+import {
+  getCellExecutionId,
+  getExecutionById,
+  useExecutionStructureVersion,
+} from "./state/execution-store";
+import { useOutputStructureVersion } from "./state/output-store";
+
+export type OutputCommentAnchor = Extract<CommentAnchor, { kind: "output" }>;
+
+export interface OutputCommentAnchorRuntimeState {
+  cellExists: boolean;
+  currentExecutionId: string | null;
+  currentOutputIds: readonly string[];
+}
+
+export function shouldDemoteOutputCommentAnchor(
+  anchor: OutputCommentAnchor,
+  state: OutputCommentAnchorRuntimeState,
+): boolean {
+  if (!state.cellExists) return true;
+  if (anchor.execution_id && anchor.execution_id !== state.currentExecutionId) return true;
+  if (anchor.output_id && !state.currentOutputIds.includes(anchor.output_id)) return true;
+  return false;
+}
+
+export function outputCommentAnchorMatchesRuntimeState(
+  anchor: OutputCommentAnchor,
+  state: OutputCommentAnchorRuntimeState,
+): boolean {
+  return !shouldDemoteOutputCommentAnchor(anchor, state);
+}
+
+export function outputCommentAnchorRuntimeState(
+  anchor: OutputCommentAnchor,
+): OutputCommentAnchorRuntimeState {
+  const cell = getCellById(anchor.cell_id);
+  const currentExecutionId = getCellExecutionId(anchor.cell_id);
+  const currentExecution = currentExecutionId ? getExecutionById(currentExecutionId) : undefined;
+  return {
+    cellExists: Boolean(cell),
+    currentExecutionId,
+    currentOutputIds: currentExecution?.output_ids ?? [],
+  };
+}
+
+export function outputCommentAnchorMatchesLiveState(anchor: OutputCommentAnchor): boolean {
+  return outputCommentAnchorMatchesRuntimeState(anchor, outputCommentAnchorRuntimeState(anchor));
+}
+
+interface UseDemoteDetachedOutputCommentThreadsOptions {
+  commentsProjection: CommentsProjection | null;
+  enabled: boolean;
+  demoteThreadToNotebook: (threadId: string) => void;
+}
+
+export function useDemoteDetachedOutputCommentThreads({
+  commentsProjection,
+  enabled,
+  demoteThreadToNotebook,
+}: UseDemoteDetachedOutputCommentThreadsOptions): void {
+  const attemptedThreadIds = useRef(new Set<string>());
+  const executionStructureVersion = useExecutionStructureVersion();
+  const outputStructureVersion = useOutputStructureVersion();
+
+  useEffect(() => {
+    if (!enabled || !commentsProjection) return;
+    for (const thread of commentsProjection.threads) {
+      if (thread.anchor.kind !== "output") continue;
+      if (attemptedThreadIds.current.has(thread.id)) continue;
+      if (
+        !shouldDemoteOutputCommentAnchor(
+          thread.anchor,
+          outputCommentAnchorRuntimeState(thread.anchor),
+        )
+      ) {
+        continue;
+      }
+      attemptedThreadIds.current.add(thread.id);
+      demoteThreadToNotebook(thread.id);
+    }
+  }, [
+    commentsProjection,
+    demoteThreadToNotebook,
+    enabled,
+    executionStructureVersion,
+    outputStructureVersion,
+  ]);
+}

--- a/src/components/notebook/output-comment-demotion.ts
+++ b/src/components/notebook/output-comment-demotion.ts
@@ -30,10 +30,17 @@ export function shouldDemoteOutputCommentAnchor(
   // Need a loaded current execution to compare against; null means the runtime
   // state has not bootstrapped yet.
   if (state.currentExecutionId === null) return false;
-  // The cell re-ran: the execution this comment was anchored to is gone.
-  if (anchor.execution_id && anchor.execution_id !== state.currentExecutionId) return true;
-  // The specific output is gone from the loaded current execution.
-  if (anchor.output_id && !state.currentOutputIds.includes(anchor.output_id)) return true;
+  if (anchor.execution_id) {
+    // Pinned to an execution: demote once that execution is replaced by a re-run,
+    // or once the specific output is gone from that still-current execution.
+    if (anchor.execution_id !== state.currentExecutionId) return true;
+    if (anchor.output_id && !state.currentOutputIds.includes(anchor.output_id)) return true;
+    return false;
+  }
+  // No execution pinned (a cell-outputs-level anchor): never demote on output id
+  // alone, because the current execution's outputs are a different run than the
+  // one the comment was made against. The create path always pins an execution,
+  // so this is a guard against a future unpinned anchor, not today's behavior.
   return false;
 }
 
@@ -64,7 +71,10 @@ export function outputCommentAnchorMatchesLiveState(anchor: OutputCommentAnchor)
 interface UseDemoteDetachedOutputCommentThreadsOptions {
   commentsProjection: CommentsProjection | null;
   enabled: boolean;
-  demoteThreadToNotebook: (threadId: string) => void;
+  /** Returns true once the demote has committed. A false result is retried on
+   *  the next execution/output change, so a transient failure never strands a
+   *  thread in the wrong state. */
+  demoteThreadToNotebook: (threadId: string) => boolean;
 }
 
 export function useDemoteDetachedOutputCommentThreads({
@@ -89,8 +99,11 @@ export function useDemoteDetachedOutputCommentThreads({
       ) {
         continue;
       }
-      attemptedThreadIds.current.add(thread.id);
-      demoteThreadToNotebook(thread.id);
+      // Mark attempted only after the demote commits, so a failed write is
+      // retried on the next structure-version bump instead of being silenced.
+      if (demoteThreadToNotebook(thread.id)) {
+        attemptedThreadIds.current.add(thread.id);
+      }
     }
   }, [
     commentsProjection,

--- a/src/components/notebook/output-comment-demotion.ts
+++ b/src/components/notebook/output-comment-demotion.ts
@@ -20,8 +20,19 @@ export function shouldDemoteOutputCommentAnchor(
   anchor: OutputCommentAnchor,
   state: OutputCommentAnchorRuntimeState,
 ): boolean {
-  if (!state.cellExists) return true;
+  // Only demote on positive evidence that the anchored execution is gone.
+  // Absence of data is "not loaded yet", never "detached": during a reconnect or
+  // notebook switch the comments projection is preserved while the cell and
+  // execution stores momentarily reset to empty. Treating that emptiness as
+  // detachment would permanently demote a valid comment and sync the wrong
+  // anchor to every peer. A genuinely deleted cell keeps its (now inert) anchor.
+  if (!state.cellExists) return false;
+  // Need a loaded current execution to compare against; null means the runtime
+  // state has not bootstrapped yet.
+  if (state.currentExecutionId === null) return false;
+  // The cell re-ran: the execution this comment was anchored to is gone.
   if (anchor.execution_id && anchor.execution_id !== state.currentExecutionId) return true;
+  // The specific output is gone from the loaded current execution.
   if (anchor.output_id && !state.currentOutputIds.includes(anchor.output_id)) return true;
   return false;
 }


### PR DESCRIPTION
Comment on a cell's outputs.

A small "comment on outputs" button in the output gutter creates a comment anchored to the cell and its current execution. Anchoring uses the stable IDs we already have - `cell_id` + `execution_id` (+ an optional `output_id`) - rather than text ranges, so the anchor survives scrolling and re-rendering and degrades predictably when the execution changes. The `CommentAnchor::Output` variant already existed end to end (Rust, TS, validation, panel routing); this wires up the create path and detach handling.

The button is gated exactly like the existing source and rendered-markdown affordances (hidden when comments are off or read-only) and works on both the desktop app and the cloud viewer.

## Detach handling

When a cell re-runs, the execution an output comment was anchored to is gone. Rather than stranding the comment on a dead execution, it auto-demotes to a notebook-level comment (the existing `demote_thread_anchor_to_notebook`, newly exposed to the frontend through a wasm binding).

The important part is *when* it demotes. Demotion treats absence of data as "not loaded yet", never as detachment: it fires only on positive evidence - the cell is loaded and a current execution has landed, and the anchored execution differs from the current one (or the anchored output is gone from the loaded execution). This matters because on a reconnect or notebook switch the comments projection is preserved while the cell and execution stores momentarily reset to empty; treating that window as detachment would permanently demote a valid comment and sync the wrong anchor to every peer. The decision is a pure, tested function, and the once-per-thread guard only triggers on a genuine detach.

Validation before creation mirrors the source-range liveness check: you can't anchor an output comment to a stale execution.

## Verification

`cargo check -p runtimed-wasm`, `cargo test -p comments-doc` (incl. the Output demote test), full `vp test` (2450 passing, with load-window cases that assert no demote), and notebook / cloud / Elements typecheck. The new wasm binding is reflected in the generated and checked-in declarations.

Manual UX of the gutter button hasn't been exercised in a browser yet; worth a look when checking out.
