### PR TITLE
fix(comments): carry daemon comments doc identity

### DIFF
--- a/apps/notebook/src/hooks/useAutomergeNotebook.ts
+++ b/apps/notebook/src/hooks/useAutomergeNotebook.ts
@@ -82,6 +82,15 @@ function serializeCommentsNotebookRef(commentsNotebookRef: unknown): string | nu
 }
 
 let warnedMissingExecutionViewProjector = false;
+let warnedCommentsBootstrapContractViolation = false;
+
+function warnCommentsBootstrapContractViolation(field: string, actorLabel: string) {
+  if (warnedCommentsBootstrapContractViolation) return;
+  warnedCommentsBootstrapContractViolation = true;
+  logger.warn(
+    `[automerge-notebook] daemon:ready did not provide ${field} before bootstrap for ${actorLabel}; comments sync is disabled for this handle`,
+  );
+}
 
 function projectExecutionViewChangeset(handle: NotebookHandle) {
   const projector = (handle as unknown as SyncableHandle).project_execution_view_changeset;
@@ -151,15 +160,20 @@ export function useNotebook() {
         actorLabel: () => actorLabelRef.current,
         createHandle: (actorLabel) => {
           const commentsDocId = commentsDocIdRef.current;
-          if (!commentsDocId) return NotebookHandle.create_empty_with_actor(actorLabel);
+          if (!commentsDocId) {
+            warnCommentsBootstrapContractViolation("comments_doc_id", actorLabel);
+            return NotebookHandle.create_empty_with_actor(actorLabel);
+          }
           const commentsNotebookRefJson = commentsNotebookRefJsonRef.current;
-          return commentsNotebookRefJson
-            ? NotebookHandle.create_bootstrap_with_comments_ref(
-                actorLabel,
-                commentsDocId,
-                commentsNotebookRefJson,
-              )
-            : NotebookHandle.create_bootstrap_with_comments(actorLabel, commentsDocId);
+          if (!commentsNotebookRefJson) {
+            warnCommentsBootstrapContractViolation("comments_notebook_ref", actorLabel);
+            return NotebookHandle.create_empty_with_actor(actorLabel);
+          }
+          return NotebookHandle.create_bootstrap_with_comments_ref(
+            actorLabel,
+            commentsDocId,
+            commentsNotebookRefJson,
+          );
         },
         getBlobPort,
         publishHandle: setNotebookHandle,

--- a/apps/notebook/src/hooks/useAutomergeNotebook.ts
+++ b/apps/notebook/src/hooks/useAutomergeNotebook.ts
@@ -71,6 +71,16 @@ function normalizeCommentsDocId(commentsDocId: string | null | undefined): strin
   return trimmed || null;
 }
 
+function serializeCommentsNotebookRef(commentsNotebookRef: unknown): string | null {
+  if (commentsNotebookRef === null || commentsNotebookRef === undefined) return null;
+  try {
+    return JSON.stringify(commentsNotebookRef);
+  } catch (error) {
+    logger.warn("[automerge-notebook] failed to serialize comments notebook ref", error);
+    return null;
+  }
+}
+
 let warnedMissingExecutionViewProjector = false;
 
 function projectExecutionViewChangeset(handle: NotebookHandle) {
@@ -129,6 +139,7 @@ export function useNotebook() {
   const prevPathRef = useRef<string | null>(null);
   const actorLabelRef = useRef(`desktop:${sessionIdRef.current}`);
   const commentsDocIdRef = useRef<string | null>(null);
+  const commentsNotebookRefJsonRef = useRef<string | null>(null);
   const [localActor, setLocalActor] = useState(actorLabelRef.current);
   const [connectionScope, setConnectionScope] = useState<string | null>(null);
   const canWriteNotebookRef = useRef(true);
@@ -140,9 +151,15 @@ export function useNotebook() {
         actorLabel: () => actorLabelRef.current,
         createHandle: (actorLabel) => {
           const commentsDocId = commentsDocIdRef.current;
-          return commentsDocId
-            ? NotebookHandle.create_bootstrap_with_comments(actorLabel, commentsDocId)
-            : NotebookHandle.create_empty_with_actor(actorLabel);
+          if (!commentsDocId) return NotebookHandle.create_empty_with_actor(actorLabel);
+          const commentsNotebookRefJson = commentsNotebookRefJsonRef.current;
+          return commentsNotebookRefJson
+            ? NotebookHandle.create_bootstrap_with_comments_ref(
+                actorLabel,
+                commentsDocId,
+                commentsNotebookRefJson,
+              )
+            : NotebookHandle.create_bootstrap_with_comments(actorLabel, commentsDocId);
         },
         getBlobPort,
         publishHandle: setNotebookHandle,
@@ -348,6 +365,9 @@ export function useNotebook() {
           setLocalActor(trigger.payload.actor_label);
         }
         commentsDocIdRef.current = normalizeCommentsDocId(trigger.payload.comments_doc_id);
+        commentsNotebookRefJsonRef.current = serializeCommentsNotebookRef(
+          trigger.payload.comments_notebook_ref,
+        );
         const connectionScope = trigger.payload.connection_scope ?? null;
         setConnectionScope(connectionScope);
         canWriteNotebookRef.current = scopeAllowsNotebookWrite(connectionScope);

--- a/apps/notebook/src/hooks/useAutomergeNotebook.ts
+++ b/apps/notebook/src/hooks/useAutomergeNotebook.ts
@@ -66,9 +66,9 @@ function scopeAllowsNotebookWrite(scope: string | null): boolean {
   return scope === null || scope === "editor" || scope === "owner";
 }
 
-function commentsDocIdFromNotebookId(notebookId: string | undefined): string | null {
-  const trimmed = notebookId?.trim();
-  return trimmed ? `comments:${trimmed}` : null;
+function normalizeCommentsDocId(commentsDocId: string | null | undefined): string | null {
+  const trimmed = commentsDocId?.trim();
+  return trimmed || null;
 }
 
 let warnedMissingExecutionViewProjector = false;
@@ -347,7 +347,7 @@ export function useNotebook() {
           actorLabelRef.current = trigger.payload.actor_label;
           setLocalActor(trigger.payload.actor_label);
         }
-        commentsDocIdRef.current = commentsDocIdFromNotebookId(trigger.payload.notebook_id);
+        commentsDocIdRef.current = normalizeCommentsDocId(trigger.payload.comments_doc_id);
         const connectionScope = trigger.payload.connection_scope ?? null;
         setConnectionScope(connectionScope);
         canWriteNotebookRef.current = scopeAllowsNotebookWrite(connectionScope);

--- a/apps/notebook/vite-plugin-browser-relay.ts
+++ b/apps/notebook/vite-plugin-browser-relay.ts
@@ -42,9 +42,12 @@ interface NotebookConnectionInfoJson {
   actor_label?: string;
   connection_scope?: string;
   comments_doc_id?: string | null;
+  comments_notebook_ref?: unknown;
   capabilities?: {
     actor_label?: string;
     connection_scope?: string;
+    comments_doc_id?: string | null;
+    comments_notebook_ref?: unknown;
   };
 }
 
@@ -307,6 +310,9 @@ async function handleRelayConnection(
     if (info.error) throw new Error(info.error);
     const actorLabel = info.actor_label ?? info.capabilities?.actor_label;
     const connectionScope = info.connection_scope ?? info.capabilities?.connection_scope;
+    const commentsDocId = info.comments_doc_id ?? info.capabilities?.comments_doc_id ?? null;
+    const commentsNotebookRef =
+      info.comments_notebook_ref ?? info.capabilities?.comments_notebook_ref ?? null;
 
     const daemonInfoJson = readDaemonInfo(socketPath);
     control(ws, {
@@ -320,7 +326,8 @@ async function handleRelayConnection(
         runtime: info.runtime,
         actor_label: actorLabel,
         connection_scope: connectionScope,
-        comments_doc_id: info.comments_doc_id ?? null,
+        comments_doc_id: commentsDocId,
+        comments_notebook_ref: commentsNotebookRef,
       },
       blob_port: daemonInfoJson?.blob_port ?? null,
       daemon: daemonInfoJson

--- a/apps/notebook/vite-plugin-browser-relay.ts
+++ b/apps/notebook/vite-plugin-browser-relay.ts
@@ -41,6 +41,7 @@ interface NotebookConnectionInfoJson {
   runtime?: string;
   actor_label?: string;
   connection_scope?: string;
+  comments_doc_id?: string | null;
   capabilities?: {
     actor_label?: string;
     connection_scope?: string;
@@ -319,6 +320,7 @@ async function handleRelayConnection(
         runtime: info.runtime,
         actor_label: actorLabel,
         connection_scope: connectionScope,
+        comments_doc_id: info.comments_doc_id ?? null,
       },
       blob_port: daemonInfoJson?.blob_port ?? null,
       daemon: daemonInfoJson

--- a/crates/comments-doc/src/doc.rs
+++ b/crates/comments-doc/src/doc.rs
@@ -88,6 +88,38 @@ impl CommentsDoc {
         Ok(comments)
     }
 
+    pub fn load_with_actor_repairing_identity(
+        bytes: &[u8],
+        expected_comments_doc_id: &str,
+        expected_notebook_ref: &NotebookCommentRef,
+        actor_label: &str,
+    ) -> Result<(Self, bool), CommentsDocError> {
+        validate_comments_doc_id(expected_comments_doc_id)?;
+        let mut doc = AutoCommit::load(bytes)?;
+        doc.set_actor(ActorId::from(actor_label.as_bytes()));
+        let mut comments = Self {
+            doc,
+            comments_doc_id: expected_comments_doc_id.to_string(),
+        };
+
+        let mut repaired = match comments.ensure_raw_comments_doc_id_matches() {
+            Ok(()) => false,
+            Err(CommentsDocError::CommentsDocIdConflict) => {
+                comments.set_comments_doc_id(expected_comments_doc_id)?;
+                true
+            }
+            Err(err) => return Err(err),
+        };
+
+        if comments.notebook_ref().as_ref() != Some(expected_notebook_ref) {
+            comments.set_notebook_ref(expected_notebook_ref)?;
+            repaired = true;
+        }
+
+        comments.ensure_raw_comments_doc_id_matches()?;
+        Ok((comments, repaired))
+    }
+
     pub fn new(comments_doc_id: &str, notebook_ref: &NotebookCommentRef) -> Self {
         Self::try_new(comments_doc_id, notebook_ref)
             .unwrap_or_else(|err| panic!("seed comments doc schema: {err}"))

--- a/crates/notebook-protocol/src/connection.rs
+++ b/crates/notebook-protocol/src/connection.rs
@@ -326,6 +326,7 @@ mod tests {
                 actor_label: None,
                 connection_scope: None,
                 comments_doc_id: None,
+                comments_notebook_ref: None,
             }
         }
 
@@ -398,11 +399,15 @@ mod tests {
         let json = serde_json::to_string(&info).unwrap();
         assert!(json.contains(r#""notebook_path":"/home/user/notebook.ipynb""#));
 
-        // With comments_doc_id
+        // With CommentsDoc identity
         let info = NotebookConnectionInfo {
-            capabilities: capabilities(None, None).with_comments_doc_id(Some(
-                "comments:local-room:550e8400-e29b-41d4-a716-446655440000".into(),
-            )),
+            capabilities: capabilities(None, None).with_comments_doc_identity(
+                Some("comments:local-room:550e8400-e29b-41d4-a716-446655440000".into()),
+                Some(serde_json::json!({
+                    "kind": "local_room",
+                    "room_id": "550e8400-e29b-41d4-a716-446655440000"
+                })),
+            ),
             notebook_id: "550e8400-e29b-41d4-a716-446655440000".into(),
             cell_count: 5,
             needs_trust_approval: false,
@@ -414,6 +419,7 @@ mod tests {
         assert!(json.contains(
             r#""comments_doc_id":"comments:local-room:550e8400-e29b-41d4-a716-446655440000""#
         ));
+        assert!(json.contains(r#""comments_notebook_ref":{"kind":"local_room","room_id":"550e8400-e29b-41d4-a716-446655440000"}"#));
 
         // With identity metadata
         let info = NotebookConnectionInfo {

--- a/crates/notebook-protocol/src/connection.rs
+++ b/crates/notebook-protocol/src/connection.rs
@@ -325,6 +325,7 @@ mod tests {
                 put_blob: None,
                 actor_label: None,
                 connection_scope: None,
+                comments_doc_id: None,
             }
         }
 
@@ -396,6 +397,23 @@ mod tests {
         };
         let json = serde_json::to_string(&info).unwrap();
         assert!(json.contains(r#""notebook_path":"/home/user/notebook.ipynb""#));
+
+        // With comments_doc_id
+        let info = NotebookConnectionInfo {
+            capabilities: capabilities(None, None).with_comments_doc_id(Some(
+                "comments:local-room:550e8400-e29b-41d4-a716-446655440000".into(),
+            )),
+            notebook_id: "550e8400-e29b-41d4-a716-446655440000".into(),
+            cell_count: 5,
+            needs_trust_approval: false,
+            error: None,
+            ephemeral: true,
+            notebook_path: None,
+        };
+        let json = serde_json::to_string(&info).unwrap();
+        assert!(json.contains(
+            r#""comments_doc_id":"comments:local-room:550e8400-e29b-41d4-a716-446655440000""#
+        ));
 
         // With identity metadata
         let info = NotebookConnectionInfo {

--- a/crates/notebook-protocol/src/connection/handshake.rs
+++ b/crates/notebook-protocol/src/connection/handshake.rs
@@ -156,6 +156,9 @@ pub struct ProtocolCapabilities {
     /// room hosts still enforce scope server-side.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub connection_scope: Option<String>,
+    /// Daemon-authoritative CommentsDoc identity for this notebook room.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub comments_doc_id: Option<String>,
 }
 
 impl ProtocolCapabilities {
@@ -175,6 +178,7 @@ impl ProtocolCapabilities {
             }),
             actor_label: None,
             connection_scope: None,
+            comments_doc_id: None,
         }
     }
 
@@ -186,6 +190,12 @@ impl ProtocolCapabilities {
     ) -> Self {
         self.actor_label = Some(actor_label.into());
         self.connection_scope = Some(connection_scope.into());
+        self
+    }
+
+    /// Attach the daemon-authoritative CommentsDoc identity for this room.
+    pub fn with_comments_doc_id(mut self, comments_doc_id: Option<String>) -> Self {
+        self.comments_doc_id = comments_doc_id;
         self
     }
 }

--- a/crates/notebook-protocol/src/connection/handshake.rs
+++ b/crates/notebook-protocol/src/connection/handshake.rs
@@ -159,6 +159,9 @@ pub struct ProtocolCapabilities {
     /// Daemon-authoritative CommentsDoc identity for this notebook room.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub comments_doc_id: Option<String>,
+    /// Daemon-authoritative notebook reference stored inside the CommentsDoc.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub comments_notebook_ref: Option<serde_json::Value>,
 }
 
 impl ProtocolCapabilities {
@@ -179,6 +182,7 @@ impl ProtocolCapabilities {
             actor_label: None,
             connection_scope: None,
             comments_doc_id: None,
+            comments_notebook_ref: None,
         }
     }
 
@@ -196,6 +200,17 @@ impl ProtocolCapabilities {
     /// Attach the daemon-authoritative CommentsDoc identity for this room.
     pub fn with_comments_doc_id(mut self, comments_doc_id: Option<String>) -> Self {
         self.comments_doc_id = comments_doc_id;
+        self
+    }
+
+    /// Attach the daemon-authoritative CommentsDoc identity and notebook ref.
+    pub fn with_comments_doc_identity(
+        mut self,
+        comments_doc_id: Option<String>,
+        comments_notebook_ref: Option<serde_json::Value>,
+    ) -> Self {
+        self.comments_doc_id = comments_doc_id;
+        self.comments_notebook_ref = comments_notebook_ref;
         self
     }
 }

--- a/crates/notebook/src/lib.rs
+++ b/crates/notebook/src/lib.rs
@@ -433,6 +433,8 @@ struct DaemonReadyPayload {
     connection_scope: Option<String>,
     /// Daemon-authoritative CommentsDoc identity for this room.
     comments_doc_id: Option<String>,
+    /// Daemon-authoritative notebook reference stored inside the CommentsDoc.
+    comments_notebook_ref: Option<serde_json::Value>,
 }
 
 /// How to connect a new window to the daemon.
@@ -618,6 +620,7 @@ async fn initialize_notebook_sync_open(
         actor_label: info.capabilities.actor_label.clone(),
         connection_scope: info.capabilities.connection_scope.clone(),
         comments_doc_id: info.capabilities.comments_doc_id.clone(),
+        comments_notebook_ref: info.capabilities.comments_notebook_ref.clone(),
     };
 
     setup_sync_receivers(
@@ -699,6 +702,7 @@ async fn initialize_notebook_sync_create(
         actor_label: info.capabilities.actor_label.clone(),
         connection_scope: info.capabilities.connection_scope.clone(),
         comments_doc_id: info.capabilities.comments_doc_id.clone(),
+        comments_notebook_ref: info.capabilities.comments_notebook_ref.clone(),
     };
 
     setup_sync_receivers(
@@ -772,6 +776,7 @@ async fn initialize_notebook_sync_attach(
         actor_label: capabilities.actor_label.clone(),
         connection_scope: capabilities.connection_scope.clone(),
         comments_doc_id: capabilities.comments_doc_id.clone(),
+        comments_notebook_ref: capabilities.comments_notebook_ref.clone(),
     };
 
     setup_sync_receivers(

--- a/crates/notebook/src/lib.rs
+++ b/crates/notebook/src/lib.rs
@@ -431,6 +431,8 @@ struct DaemonReadyPayload {
     actor_label: Option<String>,
     /// Server-enforced scope for this connection.
     connection_scope: Option<String>,
+    /// Daemon-authoritative CommentsDoc identity for this room.
+    comments_doc_id: Option<String>,
 }
 
 /// How to connect a new window to the daemon.
@@ -615,6 +617,7 @@ async fn initialize_notebook_sync_open(
         runtime: None,
         actor_label: info.capabilities.actor_label.clone(),
         connection_scope: info.capabilities.connection_scope.clone(),
+        comments_doc_id: info.capabilities.comments_doc_id.clone(),
     };
 
     setup_sync_receivers(
@@ -695,6 +698,7 @@ async fn initialize_notebook_sync_create(
         runtime: Some(runtime),
         actor_label: info.capabilities.actor_label.clone(),
         connection_scope: info.capabilities.connection_scope.clone(),
+        comments_doc_id: info.capabilities.comments_doc_id.clone(),
     };
 
     setup_sync_receivers(
@@ -767,6 +771,7 @@ async fn initialize_notebook_sync_attach(
         runtime: Some(runtime),
         actor_label: capabilities.actor_label.clone(),
         connection_scope: capabilities.connection_scope.clone(),
+        comments_doc_id: capabilities.comments_doc_id.clone(),
     };
 
     setup_sync_receivers(

--- a/crates/runtimed-wasm/src/lib.rs
+++ b/crates/runtimed-wasm/src/lib.rs
@@ -70,14 +70,24 @@ fn serialize_to_js<T: Serialize>(value: &T) -> Result<JsValue, serde_wasm_bindge
     value.serialize(&serializer)
 }
 
-fn create_comments_doc_sync_target(
+fn create_comments_doc_sync_target_with_ref(
     comments_doc_id: &str,
+    notebook_ref: &NotebookCommentRef,
     actor_label: &str,
 ) -> Result<CommentsDoc, JsError> {
-    let notebook_ref = comments_sync_target_ref(comments_doc_id);
-    CommentsDoc::try_new_with_actor(comments_doc_id, &notebook_ref, actor_label).map_err(|e| {
+    CommentsDoc::try_new_with_actor(comments_doc_id, notebook_ref, actor_label).map_err(|e| {
         JsError::new(&format!(
             "create comments doc sync target failed for {comments_doc_id}: {e}"
+        ))
+    })
+}
+
+fn parse_comments_notebook_ref_json(
+    notebook_ref_json: &str,
+) -> Result<NotebookCommentRef, JsError> {
+    serde_json::from_str(notebook_ref_json).map_err(|e| {
+        JsError::new(&format!(
+            "parse comments notebook ref failed for {notebook_ref_json}: {e}"
         ))
     })
 }
@@ -2431,6 +2441,17 @@ impl NotebookHandle {
         Ok(handle)
     }
 
+    /// Create a bootstrap handle with daemon-provided CommentsDoc identity and notebook ref.
+    pub fn create_bootstrap_with_comments_ref(
+        actor_label: &str,
+        comments_doc_id: &str,
+        notebook_ref_json: &str,
+    ) -> Result<NotebookHandle, JsError> {
+        let mut handle = Self::create_bootstrap(actor_label)?;
+        handle.init_comments_sync_target_ref(comments_doc_id, notebook_ref_json)?;
+        Ok(handle)
+    }
+
     /// Create a handle with the bootstrap skeleton for sync.
     ///
     /// Deprecated — use [`create_bootstrap()`](Self::create_bootstrap) which
@@ -3993,6 +4014,25 @@ impl NotebookHandle {
 
     /// Initialize CommentsDoc sync from daemon-provided room identity.
     pub fn init_comments_sync_target(&mut self, comments_doc_id: &str) -> Result<(), JsError> {
+        let notebook_ref = comments_sync_target_ref(comments_doc_id);
+        self.init_comments_sync_target_inner(comments_doc_id, &notebook_ref)
+    }
+
+    /// Initialize CommentsDoc sync from daemon-provided room identity and notebook ref.
+    pub fn init_comments_sync_target_ref(
+        &mut self,
+        comments_doc_id: &str,
+        notebook_ref_json: &str,
+    ) -> Result<(), JsError> {
+        let notebook_ref = parse_comments_notebook_ref_json(notebook_ref_json)?;
+        self.init_comments_sync_target_inner(comments_doc_id, &notebook_ref)
+    }
+
+    fn init_comments_sync_target_inner(
+        &mut self,
+        comments_doc_id: &str,
+        notebook_ref: &NotebookCommentRef,
+    ) -> Result<(), JsError> {
         let actor_label = self.doc.get_actor_id();
         if self
             .comments_doc
@@ -4008,8 +4048,9 @@ impl NotebookHandle {
             }
             return Ok(());
         }
-        self.comments_doc = Some(create_comments_doc_sync_target(
+        self.comments_doc = Some(create_comments_doc_sync_target_with_ref(
             comments_doc_id,
+            notebook_ref,
             &actor_label,
         )?);
         self.comments_sync_state = sync::State::new();
@@ -5068,6 +5109,43 @@ mod tests {
         val: serde_json::Value,
     ) -> (serde_json::Value, Vec<Vec<String>>, Vec<Vec<String>>) {
         resolve_comm_state_for_frontend(&val, 1234, true)
+    }
+
+    #[test]
+    fn comments_bootstrap_uses_daemon_provided_notebook_ref() {
+        for (comments_doc_id, notebook_ref) in [
+            (
+                "comments:local-room:room-1",
+                NotebookCommentRef::LocalRoom {
+                    room_id: "room-1".to_string(),
+                },
+            ),
+            (
+                "comments:local-path:63bbd3f2251d51b5bde4331cdcd8a860e338635079eb34f9572bd7d039113550",
+                NotebookCommentRef::LocalPath {
+                    canonical_path: "/tmp/notebook.ipynb".to_string(),
+                },
+            ),
+            (
+                "comments:hosted-room-1",
+                NotebookCommentRef::HostedRoom {
+                    room_locator: "hosted-room-1".to_string(),
+                },
+            ),
+        ] {
+            let notebook_ref_json =
+                serde_json::to_string(&notebook_ref).expect("serialize notebook ref");
+            let handle = NotebookHandle::create_bootstrap_with_comments_ref(
+                "user:dev:alice/browser:a",
+                comments_doc_id,
+                &notebook_ref_json,
+            )
+            .expect("create comments bootstrap handle");
+            assert_eq!(
+                handle.comments_doc.as_ref().and_then(CommentsDoc::notebook_ref),
+                Some(notebook_ref)
+            );
+        }
     }
 
     #[test]

--- a/crates/runtimed/src/daemon.rs
+++ b/crates/runtimed/src/daemon.rs
@@ -3080,6 +3080,13 @@ impl Daemon {
             .comments
             .read(|doc| doc.comments_doc_id())
             .context("read comments doc id for open notebook response")?;
+        let comments_notebook_ref = room
+            .comments
+            .read(|doc| doc.notebook_ref())
+            .context("read comments notebook ref for open notebook response")?
+            .map(serde_json::to_value)
+            .transpose()
+            .context("serialize comments notebook ref for open notebook response")?;
 
         // Send NotebookConnectionInfo response. The wire notebook_id is the
         // room's UUID (stable across the life of the room); the local
@@ -3092,7 +3099,7 @@ impl Daemon {
                     connection_identity.actor_label().as_str(),
                     connection_identity.scope().as_str(),
                 )
-                .with_comments_doc_id(comments_doc_id),
+                .with_comments_doc_identity(comments_doc_id, comments_notebook_ref),
             notebook_id: room.id.to_string(),
             cell_count,
             needs_trust_approval,
@@ -3324,13 +3331,20 @@ impl Daemon {
             .comments
             .read(|doc| doc.comments_doc_id())
             .context("read comments doc id for create notebook response")?;
+        let comments_notebook_ref = room
+            .comments
+            .read(|doc| doc.notebook_ref())
+            .context("read comments notebook ref for create notebook response")?
+            .map(serde_json::to_value)
+            .transpose()
+            .context("serialize comments notebook ref for create notebook response")?;
         let response = NotebookConnectionInfo {
             capabilities: ProtocolCapabilities::v4(Some(crate::daemon_version().to_string()))
                 .with_identity(
                     connection_identity.actor_label().as_str(),
                     connection_identity.scope().as_str(),
                 )
-                .with_comments_doc_id(comments_doc_id),
+                .with_comments_doc_identity(comments_doc_id, comments_notebook_ref),
             notebook_id: room.id.to_string(),
             cell_count,
             needs_trust_approval,

--- a/crates/runtimed/src/daemon.rs
+++ b/crates/runtimed/src/daemon.rs
@@ -3076,6 +3076,10 @@ impl Daemon {
                 runt_trust::TrustStatus::Trusted | runt_trust::TrustStatus::NoDependencies
             )
         };
+        let comments_doc_id = room
+            .comments
+            .read(|doc| doc.comments_doc_id())
+            .context("read comments doc id for open notebook response")?;
 
         // Send NotebookConnectionInfo response. The wire notebook_id is the
         // room's UUID (stable across the life of the room); the local
@@ -3087,7 +3091,8 @@ impl Daemon {
                 .with_identity(
                     connection_identity.actor_label().as_str(),
                     connection_identity.scope().as_str(),
-                ),
+                )
+                .with_comments_doc_id(comments_doc_id),
             notebook_id: room.id.to_string(),
             cell_count,
             needs_trust_approval,
@@ -3315,12 +3320,17 @@ impl Daemon {
             .path()
             .await
             .map(|p| p.to_string_lossy().to_string());
+        let comments_doc_id = room
+            .comments
+            .read(|doc| doc.comments_doc_id())
+            .context("read comments doc id for create notebook response")?;
         let response = NotebookConnectionInfo {
             capabilities: ProtocolCapabilities::v4(Some(crate::daemon_version().to_string()))
                 .with_identity(
                     connection_identity.actor_label().as_str(),
                     connection_identity.scope().as_str(),
-                ),
+                )
+                .with_comments_doc_id(comments_doc_id),
             notebook_id: room.id.to_string(),
             cell_count,
             needs_trust_approval,

--- a/crates/runtimed/src/notebook_sync_server/comments_store.rs
+++ b/crates/runtimed/src/notebook_sync_server/comments_store.rs
@@ -130,14 +130,37 @@ impl CommentsSidecarStore {
     ) -> anyhow::Result<CommentsDocHandle> {
         let path = self.doc_path(comments_doc_id);
         let doc = match std::fs::read(&path) {
-            Ok(bytes) => CommentsDoc::load_with_actor(&bytes, comments_doc_id, COMMENTS_DOC_ACTOR)
+            Ok(bytes) => {
+                let (mut doc, repaired) = CommentsDoc::load_with_actor_repairing_identity(
+                    &bytes,
+                    comments_doc_id,
+                    notebook_ref,
+                    COMMENTS_DOC_ACTOR,
+                )
                 .with_context(|| {
                     format!(
                         "load CommentsDoc {} from {}",
                         comments_doc_id,
                         path.display()
                     )
-                })?,
+                })?;
+                if repaired {
+                    tracing::warn!(
+                        "[comments-store] repaired CommentsDoc identity for {} at {}",
+                        comments_doc_id,
+                        path.display()
+                    );
+                    let bytes = doc.save();
+                    write_file_atomic(&path, &bytes).with_context(|| {
+                        format!(
+                            "repair CommentsDoc {} at {}",
+                            comments_doc_id,
+                            path.display()
+                        )
+                    })?;
+                }
+                doc
+            }
             Err(err) if err.kind() == std::io::ErrorKind::NotFound => {
                 CommentsDoc::try_new_with_actor(comments_doc_id, notebook_ref, COMMENTS_DOC_ACTOR)
                     .with_context(|| format!("create CommentsDoc {comments_doc_id}"))?
@@ -402,8 +425,27 @@ fn sibling_temp_path(path: &Path) -> PathBuf {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use automerge::ActorId;
+    use automerge::{sync::SyncDoc, transaction::Transactable, ActorId, ROOT};
     use comments_doc::CommentAnchor;
+
+    fn sync_pair_without_projection_check(a: &mut CommentsDoc, b: &mut CommentsDoc) {
+        let mut a_state = automerge::sync::State::new();
+        let mut b_state = automerge::sync::State::new();
+        for _ in 0..8 {
+            if let Some(message) = a.generate_sync_message(&mut a_state) {
+                b.doc_mut()
+                    .sync()
+                    .receive_sync_message(&mut b_state, message)
+                    .unwrap();
+            }
+            if let Some(reply) = b.generate_sync_message(&mut b_state) {
+                a.doc_mut()
+                    .sync()
+                    .receive_sync_message(&mut a_state, reply)
+                    .unwrap();
+            }
+        }
+    }
 
     #[test]
     fn comments_dir_is_sibling_of_notebook_docs_dir() {
@@ -660,5 +702,63 @@ mod tests {
             format!("{err:#}").contains("comments_doc_id mismatch"),
             "{err:#}"
         );
+    }
+
+    #[test]
+    fn load_repairs_conflicting_sidecar_identity() {
+        let tmp = tempfile::tempdir().unwrap();
+        let store = CommentsSidecarStore::new(tmp.path().join("comments"));
+        let expected_id = "comments:local-room:room";
+        let expected_ref = NotebookCommentRef::LocalRoom {
+            room_id: "room".to_string(),
+        };
+        let stale_ref = NotebookCommentRef::HostedRoom {
+            room_locator: "room".to_string(),
+        };
+        let mut base = CommentsDoc::new_with_actor(expected_id, &stale_ref, "client:base");
+        base.create_thread(
+            "thread-1",
+            "message-1",
+            &CommentAnchor::Notebook,
+            "survives repair",
+            None,
+            "2026-06-16T00:00:00Z",
+        )
+        .unwrap();
+        let bytes = base.save();
+        let mut base = CommentsDoc::load_with_actor(&bytes, expected_id, "client:base").unwrap();
+        let mut other = CommentsDoc::load_with_actor(&bytes, expected_id, "client:other").unwrap();
+        base.doc_mut()
+            .put(&ROOT, "comments_doc_id", "comments:stale")
+            .unwrap();
+        other
+            .doc_mut()
+            .put(&ROOT, "comments_doc_id", "comments:other")
+            .unwrap();
+        sync_pair_without_projection_check(&mut other, &mut base);
+
+        let path = store.doc_path(expected_id);
+        write_file_atomic(&path, &base.save()).unwrap();
+
+        let repaired = store.load_or_create(expected_id, &expected_ref).unwrap();
+        repaired
+            .read(|doc| {
+                assert_eq!(doc.comments_doc_id().as_deref(), Some(expected_id));
+                assert_eq!(doc.raw_comments_doc_id().as_deref(), Some(expected_id));
+                assert_eq!(doc.notebook_ref(), Some(expected_ref.clone()));
+                let projection = doc.read_projection(None).unwrap();
+                assert_eq!(projection.comments_doc_id, expected_id);
+                assert_eq!(projection.threads.len(), 1);
+                assert_eq!(projection.threads[0].messages[0].body, "survives repair");
+            })
+            .unwrap();
+
+        let persisted = std::fs::read(&path).unwrap();
+        let persisted = CommentsDoc::load_with_actor(&persisted, expected_id, "strict").unwrap();
+        assert_eq!(
+            persisted.raw_comments_doc_id().as_deref(),
+            Some(expected_id)
+        );
+        assert_eq!(persisted.notebook_ref(), Some(expected_ref));
     }
 }

--- a/crates/runtimed/src/notebook_sync_server/peer_connection.rs
+++ b/crates/runtimed/src/notebook_sync_server/peer_connection.rs
@@ -2,6 +2,7 @@ use super::peer_eviction::handle_peer_disconnect;
 use super::peer_loop::run_sync_loop_v2;
 use super::peer_presence::cleanup_presence_on_disconnect;
 use super::*;
+use anyhow::Context;
 use runtime_doc::RuntimeLifecycle;
 
 /// Handle a single notebook sync client connection.
@@ -253,11 +254,16 @@ where
 
     // Send capabilities response unless already sent via NotebookConnectionInfo.
     if !skip_capabilities {
+        let comments_doc_id = room
+            .comments
+            .read(|doc| doc.comments_doc_id())
+            .context("read comments doc id for notebook sync capabilities")?;
         let caps = connection::ProtocolCapabilities::v4(Some(crate::daemon_version().to_string()))
             .with_identity(
                 connection_identity.actor_label().as_str(),
                 connection_identity.scope().as_str(),
-            );
+            )
+            .with_comments_doc_id(comments_doc_id);
         if typed_capabilities {
             connection::send_typed_bootstrap_frame(
                 &mut writer,

--- a/crates/runtimed/src/notebook_sync_server/peer_connection.rs
+++ b/crates/runtimed/src/notebook_sync_server/peer_connection.rs
@@ -258,12 +258,19 @@ where
             .comments
             .read(|doc| doc.comments_doc_id())
             .context("read comments doc id for notebook sync capabilities")?;
+        let comments_notebook_ref = room
+            .comments
+            .read(|doc| doc.notebook_ref())
+            .context("read comments notebook ref for notebook sync capabilities")?
+            .map(serde_json::to_value)
+            .transpose()
+            .context("serialize comments notebook ref for notebook sync capabilities")?;
         let caps = connection::ProtocolCapabilities::v4(Some(crate::daemon_version().to_string()))
             .with_identity(
                 connection_identity.actor_label().as_str(),
                 connection_identity.scope().as_str(),
             )
-            .with_comments_doc_id(comments_doc_id);
+            .with_comments_doc_identity(comments_doc_id, comments_notebook_ref);
         if typed_capabilities {
             connection::send_typed_bootstrap_frame(
                 &mut writer,

--- a/crates/runtimed/tests/integration.rs
+++ b/crates/runtimed/tests/integration.rs
@@ -768,6 +768,14 @@ async fn test_local_identity_handshake_and_presence_rewrite() {
         result.info.capabilities.comments_doc_id.as_deref(),
         Some(expected_comments_doc_id.as_str())
     );
+    let expected_comments_notebook_ref = serde_json::json!({
+        "kind": "local_room",
+        "room_id": result.info.notebook_id
+    });
+    assert_eq!(
+        result.info.capabilities.comments_notebook_ref.as_ref(),
+        Some(&expected_comments_notebook_ref)
+    );
     assert_eq!(
         notebook_sync::presence::actor_label(&result.handle).as_deref(),
         Some(actor_label)
@@ -794,6 +802,10 @@ async fn test_local_identity_handshake_and_presence_rewrite() {
     assert_eq!(
         relay.capabilities.comments_doc_id.as_deref(),
         Some(expected_comments_doc_id.as_str())
+    );
+    assert_eq!(
+        relay.capabilities.comments_notebook_ref.as_ref(),
+        Some(&expected_comments_notebook_ref)
     );
 
     let forged = notebook_doc::presence::encode_custom_update_labeled(
@@ -2887,6 +2899,14 @@ async fn test_streaming_load_via_open_notebook() {
     assert_eq!(
         info.capabilities.comments_doc_id.as_deref(),
         Some(expected_comments_doc_id.as_str())
+    );
+    let expected_comments_notebook_ref = serde_json::json!({
+        "kind": "local_path",
+        "canonical_path": canonical_path.to_string_lossy()
+    });
+    assert_eq!(
+        info.capabilities.comments_notebook_ref.as_ref(),
+        Some(&expected_comments_notebook_ref)
     );
 
     assert_session_ready(&handle, "OpenNotebook streaming load").await;

--- a/crates/runtimed/tests/integration.rs
+++ b/crates/runtimed/tests/integration.rs
@@ -7,6 +7,7 @@
 
 use std::time::Duration;
 
+use comments_doc::local_path_comments_doc_id;
 use notebook_doc::presence::PresenceMessage;
 use notebook_protocol::connection::LaunchSpec;
 use notebook_sync::connect;
@@ -762,6 +763,11 @@ async fn test_local_identity_handshake_and_presence_rewrite() {
         result.info.capabilities.connection_scope.as_deref(),
         Some("owner")
     );
+    let expected_comments_doc_id = format!("comments:local-room:{}", result.info.notebook_id);
+    assert_eq!(
+        result.info.capabilities.comments_doc_id.as_deref(),
+        Some(expected_comments_doc_id.as_str())
+    );
     assert_eq!(
         notebook_sync::presence::actor_label(&result.handle).as_deref(),
         Some(actor_label)
@@ -784,6 +790,10 @@ async fn test_local_identity_handshake_and_presence_rewrite() {
     assert_eq!(
         relay.capabilities.connection_scope.as_deref(),
         Some("owner")
+    );
+    assert_eq!(
+        relay.capabilities.comments_doc_id.as_deref(),
+        Some(expected_comments_doc_id.as_str())
     );
 
     let forged = notebook_doc::presence::encode_custom_update_labeled(
@@ -2872,6 +2882,12 @@ async fn test_streaming_load_via_open_notebook() {
     // Handshake reports 0 cells (streaming load is deferred)
     assert_eq!(info.cell_count, 0);
     assert!(info.error.is_none());
+    let canonical_path = std::fs::canonicalize(&nb_path).unwrap();
+    let expected_comments_doc_id = local_path_comments_doc_id(canonical_path.to_string_lossy());
+    assert_eq!(
+        info.capabilities.comments_doc_id.as_deref(),
+        Some(expected_comments_doc_id.as_str())
+    );
 
     assert_session_ready(&handle, "OpenNotebook streaming load").await;
     let mut cells = handle.get_cells();

--- a/packages/notebook-host/src/types.ts
+++ b/packages/notebook-host/src/types.ts
@@ -88,7 +88,14 @@ export interface DaemonReadyPayload {
   connection_scope?: string;
   /** Daemon-authoritative CommentsDoc identity for this room. */
   comments_doc_id?: string | null;
+  /** Daemon-authoritative notebook reference stored inside the CommentsDoc. */
+  comments_notebook_ref?: CommentsNotebookRef | null;
 }
+
+export type CommentsNotebookRef =
+  | { kind: "hosted_room"; room_locator: string }
+  | { kind: "local_path"; canonical_path: string }
+  | { kind: "local_room"; room_id: string };
 
 export interface DaemonProgressPayload {
   status: "checking" | "ready" | "failed" | string;

--- a/packages/notebook-host/src/types.ts
+++ b/packages/notebook-host/src/types.ts
@@ -86,6 +86,8 @@ export interface DaemonReadyPayload {
   actor_label?: string;
   /** Server-enforced connection scope for this room connection. */
   connection_scope?: string;
+  /** Daemon-authoritative CommentsDoc identity for this room. */
+  comments_doc_id?: string | null;
 }
 
 export interface DaemonProgressPayload {

--- a/packages/notebook-host/tests/browser-host.test.ts
+++ b/packages/notebook-host/tests/browser-host.test.ts
@@ -90,6 +90,7 @@ describe("createBrowserHost()", () => {
           cell_count: 0,
           ephemeral: true,
           comments_doc_id: "comments:local-room:nb-1",
+          comments_notebook_ref: { kind: "local_room", room_id: "nb-1" },
         },
         blob_port: 48124,
         daemon: config.daemon,
@@ -101,6 +102,7 @@ describe("createBrowserHost()", () => {
       cell_count: 0,
       ephemeral: true,
       comments_doc_id: "comments:local-room:nb-1",
+      comments_notebook_ref: { kind: "local_room", room_id: "nb-1" },
     });
     await expect(host.blobs.port()).resolves.toBe(48124);
     await expect(host.blobs.resolver()).resolves.toMatchObject({ port: 48124 });

--- a/packages/notebook-host/tests/browser-host.test.ts
+++ b/packages/notebook-host/tests/browser-host.test.ts
@@ -85,13 +85,23 @@ describe("createBrowserHost()", () => {
     ws.message(
       JSON.stringify({
         type: "ready",
-        payload: { notebook_id: "nb-1", cell_count: 0, ephemeral: true },
+        payload: {
+          notebook_id: "nb-1",
+          cell_count: 0,
+          ephemeral: true,
+          comments_doc_id: "comments:local-room:nb-1",
+        },
         blob_port: 48124,
         daemon: config.daemon,
       }),
     );
 
-    expect(ready).toHaveBeenCalledWith({ notebook_id: "nb-1", cell_count: 0, ephemeral: true });
+    expect(ready).toHaveBeenCalledWith({
+      notebook_id: "nb-1",
+      cell_count: 0,
+      ephemeral: true,
+      comments_doc_id: "comments:local-room:nb-1",
+    });
     await expect(host.blobs.port()).resolves.toBe(48124);
     await expect(host.blobs.resolver()).resolves.toMatchObject({ port: 48124 });
     expect((await host.blobs.resolver()).url({ blob: "abc123" })).toBe(

--- a/packages/notebook-host/tests/relay-bootstrap.test.ts
+++ b/packages/notebook-host/tests/relay-bootstrap.test.ts
@@ -166,13 +166,19 @@ describe("startRelayBootstrapCoordinator", () => {
     coordinator.stop();
   });
 
-  it("applies the daemon actor label before creating the notebook handle", async () => {
+  it("applies daemon ready metadata before creating the notebook handle", async () => {
     const ready = createReadySource();
     const authoritativeActor = "local:quill/desktop:daemon";
+    const authoritativeCommentsDocId = "comments:local-room:nb-1";
     let actorLabel = "desktop:fallback";
+    let commentsDocId: string | null = null;
+    let observedCommentsDocId: string | null = null;
     const handle = createHostedHandle();
     const slot: NotebookHandleSlot = { current: null };
-    const createHandle = vi.fn((_actor: string) => handle);
+    const createHandle = vi.fn((_actor: string) => {
+      observedCommentsDocId = commentsDocId;
+      return handle;
+    });
     const handleHost = new NotebookHandleHost({
       actorLabel: () => actorLabel,
       createHandle,
@@ -186,6 +192,7 @@ describe("startRelayBootstrapCoordinator", () => {
       onReady: ready.onReady,
       beforeBootstrap: (trigger) => {
         actorLabel = trigger.payload.actor_label ?? actorLabel;
+        commentsDocId = trigger.payload.comments_doc_id ?? null;
       },
       bootstrap: (isCancelled) => handleHost.bootstrap(isCancelled),
       notifyRelayReady,
@@ -195,12 +202,14 @@ describe("startRelayBootstrapCoordinator", () => {
       notebook_id: "nb-1",
       relay_generation: 8,
       actor_label: authoritativeActor,
+      comments_doc_id: authoritativeCommentsDocId,
     });
     await flushMicrotasks();
     await flushMicrotasks();
 
     expect(createHandle).toHaveBeenCalledWith(authoritativeActor);
     expect(createHandle).not.toHaveBeenCalledWith("desktop:fallback");
+    expect(observedCommentsDocId).toBe(authoritativeCommentsDocId);
     expect(notifyRelayReady).toHaveBeenCalledWith(8);
 
     coordinator.stop();

--- a/packages/notebook-host/tests/tauri-host.test.ts
+++ b/packages/notebook-host/tests/tauri-host.test.ts
@@ -46,6 +46,7 @@ vi.mock("@tauri-apps/api/core", () => ({
           notebook_path: null,
           runtime: "python",
           comments_doc_id: "comments:local-room:nb-1",
+          comments_notebook_ref: { kind: "local_room", room_id: "nb-1" },
         });
       case "get_default_save_directory":
         return Promise.resolve("/tmp/notebooks");
@@ -333,6 +334,7 @@ describe("createTauriHost()", () => {
       notebook_path: null,
       runtime: "python",
       comments_doc_id: "comments:local-room:nb-1",
+      comments_notebook_ref: { kind: "local_room", room_id: "nb-1" },
     });
   });
 

--- a/packages/notebook-host/tests/tauri-host.test.ts
+++ b/packages/notebook-host/tests/tauri-host.test.ts
@@ -45,6 +45,7 @@ vi.mock("@tauri-apps/api/core", () => ({
           ephemeral: true,
           notebook_path: null,
           runtime: "python",
+          comments_doc_id: "comments:local-room:nb-1",
         });
       case "get_default_save_directory":
         return Promise.resolve("/tmp/notebooks");
@@ -331,6 +332,7 @@ describe("createTauriHost()", () => {
       ephemeral: true,
       notebook_path: null,
       runtime: "python",
+      comments_doc_id: "comments:local-room:nb-1",
     });
   });
 


### PR DESCRIPTION
## Summary

Fixes the remaining comments sync identity root cause called out after #3764.

The daemon creates the authoritative local CommentsDoc identity and notebook reference:

- untitled rooms: `comments:local-room:<room_uuid>` with `NotebookCommentRef::LocalRoom`
- file-backed rooms: `comments:local-path:<sha256(canonical_path)>` with `NotebookCommentRef::LocalPath`

The frontend was deriving `comments:${notebook_id}` from the ready payload instead, which is the hosted-room identity shape. Under reconnect/restart churn this could seed a different CommentsDoc ID/ref than the daemon, leaving comments sync in the conflicted state that #3764 made non-fatal.

This PR carries the daemon's `comments_doc_id` and `comments_notebook_ref` through `ProtocolCapabilities`, which covers:

- `OpenNotebook` / `CreateNotebook` because `NotebookConnectionInfo` flattens capabilities.
- existing-room `NotebookSync` attach connections, which only receive capabilities.
- Tauri and browser ready payloads.

The frontend now initializes local comments sync only from daemon-provided comments identity fields. If either field is absent before bootstrap, it logs the daemon contract violation and creates a plain notebook handle instead of silently deriving a wrong comments target.

For already-affected notebooks, the sidecar store now performs a one-time load repair for recoverable persisted identity drift:

- conflicting visible `comments_doc_id` values are overwritten with the daemon-authoritative id
- stale `notebook_ref` is rewritten to the daemon-authoritative ref
- existing comment threads/messages are preserved
- a clean single-id mismatch still rejects the sidecar as the wrong file under the authoritative hash

## Verification

- `cargo test -p runtimed comments_store::tests::load_`
- `cargo test -p comments-doc comments_doc`
- `pnpm exec vp test run packages/notebook-host/tests/relay-bootstrap.test.ts packages/notebook-host/tests/browser-host.test.ts packages/notebook-host/tests/tauri-host.test.ts`
- `cargo test -p runtimed-wasm comments_bootstrap_uses_daemon_provided_notebook_ref`
- `cargo test -p notebook-protocol -p notebook-sync`
- `cargo test -p runtimed --test integration test_local_identity_handshake_and_presence_rewrite`
- `cargo test -p runtimed --test integration test_streaming_load_via_open_notebook`
- `cargo check -p notebook`
- `cargo xtask wasm runtimed`
- `cargo xtask lint --fix`
