### PR TITLE
fix(notebook-cloud): recover room hosts from checkpoints

### DIFF
--- a/apps/notebook-cloud/src/notebook-room.ts
+++ b/apps/notebook-cloud/src/notebook-room.ts
@@ -75,6 +75,7 @@ interface SelectedRuntimePeerSession {
 
 interface RejectFrameOptions {
   countsTowardStreak?: boolean;
+  sendControl?: boolean;
 }
 
 interface PeerCloseOptions {
@@ -861,6 +862,7 @@ export class NotebookRoom {
           peer,
           frame.type,
           `unsupported presence payload: ${String(error)}`,
+          { sendControl: false },
         );
         return;
       }
@@ -1637,6 +1639,9 @@ export class NotebookRoom {
       counter: "rejected_frames",
       counter_delta: 1,
     });
+    if (options.sendControl === false) {
+      return;
+    }
     this.sendControl(notebookId, peer, {
       type: "cloud_frame_rejected",
       notebook_id: notebookId,

--- a/apps/notebook-cloud/src/room-materializer.ts
+++ b/apps/notebook-cloud/src/room-materializer.ts
@@ -387,15 +387,7 @@ export class RoomMaterializer {
     const startedAt = Date.now();
     const published = await this.loadLatestPublishedSnapshotPairForCheckpoint();
     if (!published) {
-      cloudLog("warn", "room.materializer.recovery_skipped", {
-        notebook_id: this.notebookId,
-        operation,
-        reason: "latest_published_snapshot_unavailable",
-        error: errorMessage(cause),
-        counter: "materializer_recovery_skipped",
-        counter_delta: 1,
-      });
-      return false;
+      return this.recoverHostFromCheckpointNow(operation, cause, startedAt);
     }
 
     try {
@@ -438,6 +430,74 @@ export class RoomMaterializer {
         error: errorMessage(recoveryError),
         original_error: errorMessage(cause),
         counter: "materializer_recovery_failed",
+        counter_delta: 1,
+      });
+      return false;
+    }
+  }
+
+  private async recoverHostFromCheckpointNow(
+    operation: string,
+    cause: unknown,
+    startedAt: number,
+  ): Promise<boolean> {
+    let checkpoint: Awaited<ReturnType<RoomMaterializer["loadCheckpoint"]>>;
+    try {
+      checkpoint = await this.loadCheckpoint();
+    } catch (error) {
+      cloudLog("warn", "room.materializer.checkpoint_reload_lookup_failed", {
+        notebook_id: this.notebookId,
+        operation,
+        duration_ms: durationMs(startedAt),
+        error: errorMessage(error),
+        original_error: errorMessage(cause),
+        counter: "materializer_checkpoint_reload_lookup_failures",
+        counter_delta: 1,
+      });
+      return false;
+    }
+    if (!checkpoint) {
+      cloudLog("warn", "room.materializer.recovery_skipped", {
+        notebook_id: this.notebookId,
+        operation,
+        reason: "latest_published_snapshot_and_checkpoint_unavailable",
+        error: errorMessage(cause),
+        counter: "materializer_recovery_skipped",
+        counter_delta: 1,
+      });
+      return false;
+    }
+
+    try {
+      const host = await loadRoomHostSnapshot(
+        checkpoint.notebookBytes,
+        checkpoint.runtimeStateBytes,
+        checkpoint.commsDocBytes,
+        checkpoint.commentsDocBytes,
+      );
+      this.markLoadedCheckpoint(checkpoint.metadata);
+      this.hostReady = Promise.resolve(host);
+      cloudLog("warn", "room.materializer.recovered_from_checkpoint_reload", {
+        notebook_id: this.notebookId,
+        operation,
+        duration_ms: durationMs(startedAt),
+        notebook_byte_length: checkpoint.notebookBytes.byteLength,
+        runtime_state_byte_length: checkpoint.runtimeStateBytes.byteLength,
+        comms_doc_byte_length: checkpoint.commsDocBytes?.byteLength ?? 0,
+        comments_doc_byte_length: checkpoint.commentsDocBytes?.byteLength ?? 0,
+        error: errorMessage(cause),
+        counter: "materializer_recovered_from_checkpoint_reload",
+        counter_delta: 1,
+      });
+      return true;
+    } catch (recoveryError) {
+      cloudLog("warn", "room.materializer.checkpoint_reload_failed", {
+        notebook_id: this.notebookId,
+        operation,
+        duration_ms: durationMs(startedAt),
+        error: errorMessage(recoveryError),
+        original_error: errorMessage(cause),
+        counter: "materializer_checkpoint_reload_failures",
         counter_delta: 1,
       });
       return false;

--- a/apps/notebook-cloud/test/connection-diagnostics.test.ts
+++ b/apps/notebook-cloud/test/connection-diagnostics.test.ts
@@ -185,8 +185,8 @@ describe("late access diagnostics never displace a terminal WASM-failure notice"
   });
 
   // Session wiring pins (the hook cannot run under node): the kick-time
-  // guard on the connect-failure path, and BOTH late-resolution sites
-  // merging through the resolution-time guard.
+  // guard on the connect-failure path, the sustained-reconnect diagnostic,
+  // and both late-resolution sites merging through the resolution-time guard.
   it("the session guards at kick time and at every resolution site", () => {
     const sessionSource = readFileSync(
       new URL("../viewer/cloud-viewer-session.ts", import.meta.url),
@@ -199,8 +199,8 @@ describe("late access diagnostics never displace a terminal WASM-failure notice"
           /setConnectionError\(\(current\) =>\s*cloudConnectionErrorWithAccessDiagnostic\(current, diagnostic\),\s*\)/g,
         ) ?? []
       ).length,
-      2,
-      "both diagnostic resolution sites must merge through the resolution-time guard",
+      3,
+      "all diagnostic resolution sites must merge through the resolution-time guard",
     );
     assert.match(
       sessionSource,

--- a/apps/notebook-cloud/test/notebook-room.test.ts
+++ b/apps/notebook-cloud/test/notebook-room.test.ts
@@ -232,6 +232,36 @@ describe("NotebookRoom presence rewrite", () => {
     );
   });
 
+  it("drops unsupported presence payloads without surfacing a room load rejection", async () => {
+    const room = new NotebookRoom(fakeState(), {} as Env);
+    const identity = authenticateDevRequest(
+      new Request("https://cloud.test/n/demo/sync?user=alice&operator=desktop:a&scope=editor"),
+    );
+    const socket = new FakeSocket();
+    const peer = {
+      id: "peer-a",
+      socket: socket.asCloudflareWebSocket(),
+      identity,
+      connectedAt: "2026-05-22T00:00:00.000Z",
+      consecutiveRejectedFrames: 0,
+    };
+    const harness = roomHarness(room);
+    harness.peers.set(peer.id, peer);
+
+    await harness.handleMessage(
+      "demo",
+      peer,
+      encodeTypedFrame(
+        FrameType.PRESENCE,
+        new TextEncoder().encode(JSON.stringify({ actor_label: identity.actorLabel })),
+      ),
+    );
+
+    assert.equal(peer.consecutiveRejectedFrames, 1);
+    assert.equal(socket.sent.length, 0, "bad presence should not send cloud_frame_rejected");
+    assert.equal(socket.closed, false);
+  });
+
   it("keeps anonymous viewer presence local to the connection", async () => {
     const anonymous = authenticateAnonymousViewer(
       new Request("https://cloud.test/n/demo/sync?viewer_session=anon-a"),

--- a/apps/notebook-cloud/test/room-materializer.test.ts
+++ b/apps/notebook-cloud/test/room-materializer.test.ts
@@ -1346,6 +1346,67 @@ describe("RoomMaterializer", () => {
     assert.deepEqual([...(await state.storage.list({ prefix: "room-host:" })).keys()], []);
   });
 
+  it("recovers unpublished rooms by reloading the durable checkpoint", async () => {
+    const state = fakeState();
+    const checkpointSnapshot = await createNotebookRoomSnapshot(
+      "demo",
+      "checkpoint-cell",
+      "Recovered checkpoint without published snapshot\n",
+    );
+    await Promise.all([
+      state.storage.put(
+        "room-host:notebook-doc",
+        arrayBufferFromBytes(checkpointSnapshot.notebookBytes),
+      ),
+      state.storage.put(
+        "room-host:runtime-state-doc",
+        arrayBufferFromBytes(checkpointSnapshot.runtimeStateBytes),
+      ),
+      state.storage.put("room-host:checkpoint", {
+        version: 4,
+        notebook_heads: checkpointSnapshot.notebookHeads,
+        runtime_state_heads: checkpointSnapshot.runtimeStateHeads,
+        saved_at: "2026-05-28T00:00:00.000Z",
+        published_revision_id: null,
+        published_notebook_heads: null,
+        published_runtime_state_heads: null,
+      }),
+    ]);
+
+    const reloaded = new RoomMaterializer("demo", state, {} as Env);
+    const checkpointHost = await (
+      reloaded as unknown as {
+        loadHost(): Promise<{ sync_peer: (peerId: string, connectionScope: string) => unknown }>;
+      }
+    ).loadHost();
+    checkpointHost.sync_peer = () => {
+      throw new Error("recursive use of an object detected which would lead to unsafe aliasing");
+    };
+
+    const viewer = NotebookHandle.create_bootstrap("user:dev:bob/desktop:b");
+    await syncMaterializerWithClient(
+      reloaded,
+      {
+        id: "peer-viewer",
+        identity: authenticateDevRequest(
+          new Request("https://cloud.test/n/demo/sync?user=bob&operator=desktop:b&scope=viewer"),
+        ),
+      },
+      viewer,
+    );
+
+    const cells = JSON.parse(viewer.get_cells_json()) as Array<{ id: string; source: string }>;
+    assert.deepEqual(
+      cells.map((cell) => [cell.id, cell.source]),
+      [["checkpoint-cell", "Recovered checkpoint without published snapshot\n"]],
+    );
+    assert.deepEqual(
+      [...(await state.storage.list({ prefix: "room-host:" })).keys()].sort(),
+      ["room-host:checkpoint", "room-host:notebook-doc", "room-host:runtime-state-doc"],
+      "checkpoint reload should keep the durable checkpoint in place",
+    );
+  });
+
   it("recovers from a checkpoint host that fails while receiving a peer sync frame", async () => {
     const state = fakeState();
     const checkpointSnapshot = await createNotebookRoomSnapshot(

--- a/apps/notebook-cloud/test/viewer-render-props.test.ts
+++ b/apps/notebook-cloud/test/viewer-render-props.test.ts
@@ -198,9 +198,9 @@ test("cloud viewer routes notebook header controls through the shared shell chro
   );
   assert.match(sourceText, /cloudNotebookTitleDisplay,/);
   assert.match(sourceText, /cloudNotebookUrlAfterRename,/);
-  assert.match(titleSourceText, /className="cloud-notebook-home-link"/);
+  assert.match(titleSourceText, /homeLink: "cloud-notebook-home-link"/);
   assert.match(titleSourceText, /<House aria-hidden="true" \/>/);
-  assert.match(titleSourceText, /<PencilLine aria-hidden="true" \/>/);
+  assert.match(titleSourceText, /renameButtonTitle="Rename notebook"/);
   assert.doesNotMatch(titleSourceText, /cloud-notebook-logo/);
   assert.doesNotMatch(sourceText, /function shouldShowCloudNotebookCommandToolbar/);
   assert.doesNotMatch(sourceText, /toolbarClassName="cloud-report-toolbar"/);

--- a/apps/notebook-cloud/test/viewer-shared-cell-surface.test.ts
+++ b/apps/notebook-cloud/test/viewer-shared-cell-surface.test.ts
@@ -65,6 +65,12 @@ test("cloud notebook list uses local auth copy in local mode", () => {
 test("cloud viewer imports desktop notebook code only through public surfaces", () => {
   const viewerDir = new URL("../viewer", import.meta.url);
   const offenders: string[] = [];
+  const allowedSharedNotebookInternals = new Set([
+    "../../notebook/src/components/InlineCommentComposer",
+    "../../notebook/src/lib/comment-highlights",
+    "../../notebook/src/lib/comment-source-anchor",
+    "../../notebook/src/lib/frame-pipeline",
+  ]);
 
   for (const fileName of readdirSync(viewerDir)) {
     if (![".ts", ".tsx"].includes(extname(fileName))) continue;
@@ -76,7 +82,11 @@ test("cloud viewer imports desktop notebook code only through public surfaces", 
 
     for (const match of imports) {
       const importPath = match[1] ?? "";
-      if (importPath.includes("/wasm/") || importPath.endsWith("/notebook-surface")) {
+      if (
+        importPath.includes("/wasm/") ||
+        importPath.endsWith("/notebook-surface") ||
+        allowedSharedNotebookInternals.has(importPath)
+      ) {
         continue;
       }
       offenders.push(`${fileName}: ${importPath}`);


### PR DESCRIPTION
## Summary

- recover hosted room materializers from the durable room checkpoint when the live `RoomHostHandle` hits the recoverable WASM/Automerge aliasing boundary and no published snapshot exists
- keep malformed presence frames out of user-facing `cloud_frame_rejected` notices while still counting them toward the rejected-frame streak
- refresh current-main source guardrail tests that were stale after the shared title/comments work

## Why

Preview showed repeated websocket reconnects with `cloud sync socket closed (1011): room sync failed`. `wrangler tail` showed the room host repeatedly failing notebook/runtime/comms sync with:

```text
recursive use of an object detected which would lead to unsafe aliasing in rust
```

Recovery already fell back to a published snapshot, but live beta rooms without a published revision logged `latest_published_snapshot_unavailable` and stayed poisoned. Reloading the durable checkpoint creates a fresh room host from saved Automerge bytes, which preserves unpublished room state and clears the bad in-memory host object.

The visible `unsupported presence payload` banner was a separate symptom from an ephemeral presence frame. Bad cursor/focus/heartbeat payloads should not put the notebook in an unable-to-load state, so those rejects now avoid a `cloud_frame_rejected` control frame.

## Validation

- `node --import tsx --test test/room-materializer.test.ts test/notebook-room.test.ts` from `apps/notebook-cloud` (105/105)
- `pnpm --dir apps/notebook-cloud run test` (1128/1128)
- `pnpm --dir apps/notebook-cloud run typecheck`
- `cargo xtask lint --fix`
