### PR TITLE
feat(markdown): keep edit mode on blur, clean rendered copy, comment menu in source

### DIFF
--- a/apps/notebook/src/components/MarkdownCell.tsx
+++ b/apps/notebook/src/components/MarkdownCell.tsx
@@ -2,6 +2,7 @@ import type { EditorView, KeyBinding } from "@codemirror/view";
 import { Check, Pencil } from "lucide-react";
 import {
   memo,
+  type ClipboardEvent,
   type MouseEvent,
   type PointerEvent,
   type ReactNode,
@@ -68,7 +69,11 @@ import {
 import { sourceCommentExtension } from "../lib/source-comment-extension";
 import type { MarkdownCell as MarkdownCellType } from "../types";
 import { CellPresenceIndicators } from "./cell/CellPresenceIndicators";
-import { RenderedMarkdownContextMenu } from "./RenderedMarkdownContextMenu";
+import { EditorContextMenu } from "./EditorContextMenu";
+import {
+  cleanRenderedMarkdownClipboardHtml,
+  RenderedMarkdownContextMenu,
+} from "./RenderedMarkdownContextMenu";
 
 const handleIframeError = (err: { message: string; stack?: string }) =>
   logger.error("[MarkdownCell] iframe error:", err);
@@ -357,6 +362,7 @@ export const MarkdownCell = memo(function MarkdownCell({
         registeredViewRef.current = view;
         registerCellEditor(cell.id, view);
         onEditorRegistered(cell.id);
+        refreshCellCommentHighlights(cell.id);
         return true;
       }
       return false;
@@ -585,25 +591,15 @@ export const MarkdownCell = memo(function MarkdownCell({
     [releasePreviewFrameInteraction],
   );
 
-  // Derived boundary flag: re-run the focus effect only when source crosses
-  // empty↔non-empty, not on every keystroke.
-  const hasContent = previewSource.trim().length > 0;
   useEffect(() => {
     if (readOnly) {
       setEditing(false);
       return;
     }
-    if (!isFocused && editing && hasContent) {
-      setEditing(false);
-    }
     if (!isFocused || editing) {
       setPreviewFrameInteractionActive(false);
     }
-  }, [hasContent, isFocused, editing, readOnly]);
-
-  const handleBlur = useCallback(() => {
-    exitEditingToPreview();
-  }, [exitEditingToPreview]);
+  }, [isFocused, editing, readOnly]);
 
   const renderMarkdownPreviewFrame = useCallback(
     async (frame: IsolatedFrameHandle | null = frameRef.current) => {
@@ -796,6 +792,32 @@ export const MarkdownCell = memo(function MarkdownCell({
       }
     },
     [enterEditing, onFocusNext, onFocusPrevious, readOnly, requestRenderedSourceComment],
+  );
+
+  const handleRenderedMarkdownCopy = useCallback(
+    (event: ClipboardEvent<HTMLDivElement>) => {
+      if (editing || !canRenderProjectionInHost || !markdownProjection) return;
+
+      const root = viewRef.current;
+      const selection = typeof window === "undefined" ? null : window.getSelection();
+      if (!root || !selection || selection.rangeCount === 0 || selection.isCollapsed) return;
+
+      const range = selection.getRangeAt(0);
+      if (!root.contains(range.startContainer) || !root.contains(range.endContainer)) return;
+
+      const anchor = sourceRangeAnchorFromRenderedMarkdownSelection(
+        cell.id,
+        previewSource,
+        root,
+        selection,
+      );
+      if (!anchor?.exact_quote) return;
+
+      event.preventDefault();
+      event.clipboardData.setData("text/plain", anchor.exact_quote);
+      event.clipboardData.setData("text/html", cleanRenderedMarkdownClipboardHtml(range));
+    },
+    [canRenderProjectionInHost, cell.id, editing, markdownProjection, previewSource],
   );
 
   // Handle focus next, creating a new cell if at the end
@@ -1015,21 +1037,26 @@ export const MarkdownCell = memo(function MarkdownCell({
               <span className="text-xs text-muted-foreground font-mono">md</span>
             </div>
             <div>
-              <CodeMirrorEditor
-                ref={editorRef}
-                initialValue={cell.source}
-                language="markdown"
-                lineWrapping
-                onBlur={handleBlur}
-                onSelectionChange={noteEditorSourcePosition}
-                keyMap={keyMap}
-                extensions={editorExtensions}
-                contentAttributes={MARKDOWN_EDITOR_CONTENT_ATTRIBUTES}
-                placeholder="Enter markdown..."
-                className="min-h-[2rem]"
-                autoFocus={editing}
+              <EditorContextMenu
+                cellId={cell.id}
                 readOnly={readOnly}
-              />
+                onCreateSourceComment={onCreateSourceComment}
+              >
+                <CodeMirrorEditor
+                  ref={editorRef}
+                  initialValue={cell.source}
+                  language="markdown"
+                  lineWrapping
+                  onSelectionChange={noteEditorSourcePosition}
+                  keyMap={keyMap}
+                  extensions={editorExtensions}
+                  contentAttributes={MARKDOWN_EDITOR_CONTENT_ATTRIBUTES}
+                  placeholder="Enter markdown..."
+                  className="min-h-[2rem]"
+                  autoFocus={editing}
+                  readOnly={readOnly}
+                />
+              </EditorContextMenu>
             </div>
           </div>
 
@@ -1053,6 +1080,7 @@ export const MarkdownCell = memo(function MarkdownCell({
               onMouseUp={updateRenderedSourceCommentTarget}
               onKeyUp={updateRenderedSourceCommentTarget}
               onKeyDown={handleViewKeyDown}
+              onCopy={handleRenderedMarkdownCopy}
             >
               {previewSource && canRenderProjectionInHost && markdownProjection ? (
                 <ProjectedMarkdownView

--- a/apps/notebook/src/components/RenderedMarkdownContextMenu.tsx
+++ b/apps/notebook/src/components/RenderedMarkdownContextMenu.tsx
@@ -30,6 +30,11 @@ export interface BuildRenderedMarkdownContextGroupsOptions {
   onAddComment?: () => void;
 }
 
+export interface RenderedMarkdownClipboardPayload {
+  text: string;
+  html: string;
+}
+
 export function buildRenderedMarkdownContextGroups({
   hasSelection,
   canComment,
@@ -83,15 +88,21 @@ export function RenderedMarkdownContextMenu({
     const selection = currentDomSelection();
     const hasSelection = !!root && selectionIsInsideRoot(root, selection);
     const selectedText = hasSelection ? (selection?.toString() ?? "") : "";
+    const selectionRange = hasSelection && selection?.rangeCount ? selection.getRangeAt(0) : null;
     const anchor = root
       ? sourceRangeAnchorFromRenderedMarkdownSelection(cellId, source, root, selection)
       : null;
+    const clipboardPayload = buildRenderedMarkdownClipboardPayload({
+      anchor,
+      selectedText,
+      range: selectionRange,
+    });
 
     setGroups(
       buildRenderedMarkdownContextGroups({
         hasSelection,
         canComment: !!anchor && !!onCreateSourceComment,
-        onCopy: hasSelection ? () => copyRenderedSelection(selectedText) : undefined,
+        onCopy: clipboardPayload ? () => copyRenderedSelection(clipboardPayload) : undefined,
         onAddComment:
           anchor && onCreateSourceComment
             ? () =>
@@ -125,10 +136,73 @@ function selectionIsInsideRoot(root: HTMLElement, selection: Selection | null): 
   return root.contains(range.startContainer) && root.contains(range.endContainer);
 }
 
-function copyRenderedSelection(selectedText: string): void {
+export function buildRenderedMarkdownClipboardPayload({
+  anchor,
+  selectedText,
+  range,
+}: {
+  anchor: SourceRangeCommentAnchor | null;
+  selectedText: string;
+  range: Range | null;
+}): RenderedMarkdownClipboardPayload | null {
+  const text = anchor?.exact_quote ?? selectedText;
+  if (text.length === 0) return null;
+  return {
+    text,
+    html: range ? cleanRenderedMarkdownClipboardHtml(range) : "",
+  };
+}
+
+export function cleanRenderedMarkdownClipboardHtml(range: Range): string {
+  const container = document.createElement("div");
+  container.append(range.cloneContents());
+
+  container.querySelectorAll("a").forEach((anchor) => {
+    const label = anchor.getAttribute("aria-label") ?? "";
+    const href = anchor.getAttribute("href") ?? "";
+    if (
+      anchor.textContent?.trim() === "#" &&
+      href.startsWith("#") &&
+      label.startsWith("Link to ")
+    ) {
+      anchor.remove();
+    }
+  });
+
+  container.querySelectorAll("ul, ol, li").forEach((element) => {
+    element.classList.remove(
+      "list-disc",
+      "list-decimal",
+      "marker:text-primary/65",
+      "marker:font-semibold",
+    );
+    const existingStyle = element.getAttribute("style");
+    const markerlessStyle = "list-style-type: none";
+    element.setAttribute(
+      "style",
+      existingStyle ? `${existingStyle}; ${markerlessStyle}` : markerlessStyle,
+    );
+  });
+
+  return container.innerHTML;
+}
+
+function copyRenderedSelection(payload: RenderedMarkdownClipboardPayload): void {
   const clipboard = currentClipboard();
-  if (!clipboard || selectedText.length === 0) return;
-  void clipboard.writeText(selectedText).catch(() => undefined);
+  if (!clipboard) return;
+
+  if (typeof ClipboardItem !== "undefined" && typeof clipboard.write === "function") {
+    const item = new ClipboardItem({
+      "text/plain": new Blob([payload.text], { type: "text/plain" }),
+      "text/html": new Blob([payload.html], { type: "text/html" }),
+    });
+    void clipboard.write([item]).catch(() => {
+      void clipboard.writeText(payload.text).catch(() => undefined);
+    });
+    return;
+  }
+
+  void clipboard.writeText(payload.text).catch(() => undefined);
 }
 
 function currentDomSelection(): Selection | null {

--- a/apps/notebook/src/components/__tests__/RenderedMarkdownContextMenu.test.tsx
+++ b/apps/notebook/src/components/__tests__/RenderedMarkdownContextMenu.test.tsx
@@ -1,8 +1,11 @@
 import { describe, expect, it, vi } from "vite-plus/test";
 import {
+  buildRenderedMarkdownClipboardPayload,
   buildRenderedMarkdownContextGroups,
+  cleanRenderedMarkdownClipboardHtml,
   type BuildRenderedMarkdownContextGroupsOptions,
 } from "../RenderedMarkdownContextMenu";
+import type { SourceRangeCommentAnchor } from "../../lib/comment-source-anchor";
 
 function buildActions(overrides: Partial<BuildRenderedMarkdownContextGroupsOptions> = {}) {
   const groups = buildRenderedMarkdownContextGroups({
@@ -44,5 +47,67 @@ describe("buildRenderedMarkdownContextGroups", () => {
         canComment: true,
       }),
     ).toEqual([]);
+  });
+});
+
+describe("rendered markdown clipboard payload", () => {
+  function selectContents(element: HTMLElement): Range {
+    const range = document.createRange();
+    range.selectNodeContents(element);
+    return range;
+  }
+
+  it("uses the raw markdown exact quote for plain text", () => {
+    const root = document.createElement("div");
+    root.textContent = "Heading item";
+    const anchor = {
+      kind: "source_range",
+      cell_id: "md-1",
+      start_line: 0,
+      start_column: 0,
+      end_line: 1,
+      end_column: 8,
+      exact_quote: "## Heading\n- **item**",
+    } as SourceRangeCommentAnchor;
+
+    expect(
+      buildRenderedMarkdownClipboardPayload({
+        anchor,
+        selectedText: "Heading item",
+        range: selectContents(root),
+      })?.text,
+    ).toBe("## Heading\n- **item**");
+  });
+
+  it("falls back to selected visible text without an exact source anchor", () => {
+    expect(
+      buildRenderedMarkdownClipboardPayload({
+        anchor: null,
+        selectedText: "visible text",
+        range: null,
+      })?.text,
+    ).toBe("visible text");
+  });
+
+  it("cleans decorative heading anchors and rendered list markers from html", () => {
+    const root = document.createElement("div");
+    root.innerHTML = `
+      <h2>
+        Heading
+        <a href="#heading" aria-label="Link to Heading">#</a>
+      </h2>
+      <ul class="list-disc marker:text-primary/65">
+        <li class="marker:font-semibold">item</li>
+      </ul>
+    `;
+
+    const html = cleanRenderedMarkdownClipboardHtml(selectContents(root));
+
+    expect(html).toContain("Heading");
+    expect(html).toContain("item");
+    expect(html).not.toContain(">#</a>");
+    expect(html).not.toContain("list-disc");
+    expect(html).not.toContain("marker:text-primary/65");
+    expect(html).toContain("list-style-type: none");
   });
 });

--- a/apps/notebook/src/components/__tests__/markdown-cell-theme.test.tsx
+++ b/apps/notebook/src/components/__tests__/markdown-cell-theme.test.tsx
@@ -106,6 +106,7 @@ vi.mock("@/components/editor/codemirror-editor", () => ({
       contentAttributes?: Readonly<Record<string, string>>;
       initialValue?: string;
       keyMap?: Array<{ key: string; run: () => boolean }>;
+      onBlur?: () => void;
     },
     ref,
   ) {
@@ -133,6 +134,7 @@ vi.mock("@/components/editor/codemirror-editor", () => ({
         data-autocorrect={props.contentAttributes?.autocorrect}
         data-spellcheck={props.contentAttributes?.spellcheck}
         tabIndex={0}
+        onBlur={props.onBlur}
         onKeyDown={(event) => {
           const key = event.ctrlKey && event.key === "Enter" ? "Ctrl-Enter" : event.key;
           const binding = props.keyMap?.find((entry) => entry.key === key);
@@ -630,6 +632,27 @@ describe("MarkdownCell theme sync", () => {
     });
   });
 
+  it("keeps markdown editing open when the editor blurs", async () => {
+    const cell = { ...makeCell(), source: "# Has content" };
+
+    const { getByLabelText, getByTestId, getByTitle } = render(
+      <MarkdownCell cell={cell} onFocus={() => {}} onDelete={() => {}} />,
+    );
+
+    const preview = getByLabelText("Markdown cell content");
+    fireEvent.click(getByTitle("Edit"));
+
+    await waitFor(() => {
+      expect(preview.className).toContain("hidden");
+    });
+
+    fireEvent.blur(getByTestId("markdown-editor"));
+
+    await waitFor(() => {
+      expect(preview.className).toContain("hidden");
+    });
+  });
+
   it("Ctrl+Enter keeps markdown preview in view mode", () => {
     const { getByLabelText } = render(
       <MarkdownCell cell={makeCell()} onFocus={() => {}} onDelete={() => {}} />,
@@ -643,7 +666,7 @@ describe("MarkdownCell theme sync", () => {
     expect(preview.className).not.toContain("hidden");
   });
 
-  it("exits edit mode when a focused cell with content loses notebook focus", async () => {
+  it("keeps edit mode when a focused cell with content loses notebook focus", async () => {
     const cell = { ...makeCell(), source: "# Has content" };
     mockIsFocused = true;
 
@@ -659,13 +682,12 @@ describe("MarkdownCell theme sync", () => {
       expect(preview.className).toContain("hidden");
     });
 
-    // Notebook focus moves to another cell — the focus effect should drop
-    // this cell back to preview because it has content.
+    // Notebook focus can move away without rendering this cell.
     mockIsFocused = false;
     rerender(<MarkdownCell cell={cell} onFocus={() => {}} onDelete={() => {}} />);
 
     await waitFor(() => {
-      expect(preview.className).not.toContain("hidden");
+      expect(preview.className).toContain("hidden");
     });
   });
 
@@ -737,6 +759,34 @@ describe("MarkdownCell theme sync", () => {
     fireEvent.click(getByRole("checkbox", { name: "Mark task complete: ship checkboxes" }));
 
     expect(onUpdateSource).toHaveBeenCalledWith("- [x] ship checkboxes");
+  });
+
+  it("copies projected markdown selections with raw source text and html", () => {
+    const { getByLabelText, getByText } = render(
+      <MarkdownCell cell={makeTaskCell()} onFocus={() => {}} onDelete={() => {}} />,
+    );
+
+    const run = getByText("ship checkboxes").closest("[data-markdown-source-run]");
+    expect(run).toBeInstanceOf(HTMLElement);
+
+    const selection = window.getSelection();
+    const range = document.createRange();
+    range.selectNodeContents(run as HTMLElement);
+    selection?.removeAllRanges();
+    selection?.addRange(range);
+
+    const clipboardData = { setData: vi.fn() };
+    const copyEvent = createEvent.copy(getByLabelText("Markdown cell content"));
+    Object.defineProperty(copyEvent, "clipboardData", { value: clipboardData });
+    fireEvent(getByLabelText("Markdown cell content"), copyEvent);
+    selection?.removeAllRanges();
+
+    expect(copyEvent.defaultPrevented).toBe(true);
+    expect(clipboardData.setData).toHaveBeenCalledWith("text/plain", "ship checkboxes");
+    expect(clipboardData.setData).toHaveBeenCalledWith(
+      "text/html",
+      expect.stringContaining("ship checkboxes"),
+    );
   });
 
   it("carries the latest markdown source cursor into projected preview", async () => {

--- a/apps/notebook/src/components/__tests__/markdown-formatting.test.ts
+++ b/apps/notebook/src/components/__tests__/markdown-formatting.test.ts
@@ -221,29 +221,28 @@ describe("applyQuoteFormatting", () => {
 
 describe("edit/view toggle conditions", () => {
   /**
-   * Mirrors the handleBlur logic from MarkdownCell.tsx:
-   * Only exit edit mode if cell.source.trim() is non-empty.
-   * This prevents empty cells from being "stuck" in view mode
-   * with no content and no way to type.
+   * Mirrors explicit render actions in MarkdownCell.tsx.
+   * Passive blur and notebook focus loss keep markdown source editing open.
    */
-  function shouldExitEditOnBlur(source: string): boolean {
-    return source.trim().length > 0;
+  function shouldExitEditOnExplicitRender(source: string, allowEmpty = false): boolean {
+    return source.trim().length > 0 || allowEmpty;
   }
 
-  it("exits edit mode when cell has content", () => {
-    expect(shouldExitEditOnBlur("# Hello")).toBe(true);
+  it("exits edit mode on explicit render when cell has content", () => {
+    expect(shouldExitEditOnExplicitRender("# Hello")).toBe(true);
   });
 
-  it("stays in edit mode when cell is empty", () => {
-    expect(shouldExitEditOnBlur("")).toBe(false);
+  it("stays in edit mode for empty source unless explicit render allows empty", () => {
+    expect(shouldExitEditOnExplicitRender("")).toBe(false);
+    expect(shouldExitEditOnExplicitRender("", true)).toBe(true);
   });
 
   it("stays in edit mode when cell is only whitespace", () => {
-    expect(shouldExitEditOnBlur("   \n\t  ")).toBe(false);
+    expect(shouldExitEditOnExplicitRender("   \n\t  ")).toBe(false);
   });
 
-  it("exits edit mode for single character content", () => {
-    expect(shouldExitEditOnBlur("a")).toBe(true);
+  it("exits edit mode for single character content on explicit render", () => {
+    expect(shouldExitEditOnExplicitRender("a")).toBe(true);
   });
 
   /**

--- a/src/components/markdown/markdown-typography.ts
+++ b/src/components/markdown/markdown-typography.ts
@@ -107,7 +107,7 @@ export const markdownFootnoteRefClassName =
   "mx-0.5 inline-flex min-w-4 translate-y-[-0.22em] justify-center rounded-full border border-primary/20 bg-primary/6 px-1 font-[var(--output-ui-font)] text-[0.68em] leading-4 text-primary no-underline decoration-transparent hover:bg-primary/10 hover:decoration-transparent";
 
 export const markdownHeadingAnchorClassName =
-  "ml-2 inline-flex translate-y-[-0.08em] rounded-[2px] font-[var(--output-ui-font)] text-[0.58em] font-medium text-muted-foreground/40 no-underline decoration-transparent transition-colors hover:bg-primary/5 hover:text-primary focus-visible:text-primary focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/40";
+  "ml-2 inline-flex select-none translate-y-[-0.08em] rounded-[2px] font-[var(--output-ui-font)] text-[0.58em] font-medium text-muted-foreground/40 no-underline decoration-transparent transition-colors hover:bg-primary/5 hover:text-primary focus-visible:text-primary focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/40";
 
 export function markdownHeadingClassName(element: string) {
   if (element === "h1") {


### PR DESCRIPTION
Markdown cell editing and copy fixes from the preview review.

- **Stay in edit mode on blur.** A markdown cell no longer auto-flips back to rendered when you click away or focus another cell. The editing/rendered choice is local per-viewer state (not synced, not persisted); rendering now happens only on an explicit toggle (the render button, Escape, Ctrl+Enter, or Tab navigation). `readOnly` still forces rendered.
- **Clean copy of rendered markdown.** Selecting rendered markdown and copying now writes `text/plain` as the raw markdown source for the selection (reconstructed from the run-span source mappings) plus a cleaned `text/html`, on both the right-click menu and keyboard Cmd/Ctrl+C. The heading `#` anchor is `select-none` and list markers are stripped, so neither leaks into the copy.
- **Comment menu in the markdown source editor.** The CodeMirror editor shown when editing a markdown cell now has the right-click "Add comment" item (it was only on code cells) and refreshes comment highlights on entering edit mode. The selection affordance and Mod-Alt-m already worked there.

## Verification

`vp check`, full `vp test` (2456), notebook + cloud typecheck. Built by codex, reviewed by Claude (verdict: clean).
