### PR TITLE
feat(outputs): copy image from a context menu on raster outputs

### DIFF
--- a/src/components/outputs/__tests__/copy-image.test.ts
+++ b/src/components/outputs/__tests__/copy-image.test.ts
@@ -1,0 +1,86 @@
+import { afterEach, describe, expect, it, vi } from "vite-plus/test";
+import { logger } from "@/lib/logger";
+import { copyRasterImageToClipboard } from "../copy-image";
+
+vi.mock("@/lib/logger", () => ({
+  logger: { warn: vi.fn() },
+}));
+
+const originalClipboard = Object.getOwnPropertyDescriptor(navigator, "clipboard");
+const originalClipboardItem = Object.getOwnPropertyDescriptor(globalThis, "ClipboardItem");
+
+function readBlobBytes(blob: Blob): Promise<number[]> {
+  return new Promise((resolve, reject) => {
+    const reader = new FileReader();
+    reader.onload = () => {
+      resolve(Array.from(new Uint8Array(reader.result as ArrayBuffer)));
+    };
+    reader.onerror = () => reject(reader.error);
+    reader.readAsArrayBuffer(blob);
+  });
+}
+
+afterEach(() => {
+  vi.restoreAllMocks();
+
+  if (originalClipboard) {
+    Object.defineProperty(navigator, "clipboard", originalClipboard);
+  } else {
+    delete (navigator as Partial<Navigator>).clipboard;
+  }
+
+  if (originalClipboardItem) {
+    Object.defineProperty(globalThis, "ClipboardItem", originalClipboardItem);
+  } else {
+    delete (globalThis as Partial<typeof globalThis>).ClipboardItem;
+  }
+});
+
+describe("copyRasterImageToClipboard", () => {
+  it("writes a base64 data URL image through ClipboardItem", async () => {
+    const write = vi.fn().mockResolvedValue(undefined);
+    const ClipboardItemMock = vi.fn(function ClipboardItem(
+      this: { items: Record<string, Blob> },
+      items: Record<string, Blob>,
+    ) {
+      this.items = items;
+    });
+
+    Object.defineProperty(navigator, "clipboard", {
+      configurable: true,
+      value: { write },
+    });
+    Object.defineProperty(globalThis, "ClipboardItem", {
+      configurable: true,
+      value: ClipboardItemMock,
+    });
+
+    await copyRasterImageToClipboard("data:image/png;base64,AQID", "image/png");
+
+    expect(ClipboardItemMock).toHaveBeenCalledTimes(1);
+    const itemPayload = ClipboardItemMock.mock.calls[0]?.[0] as Record<string, Blob>;
+    const blob = itemPayload["image/png"];
+    expect(blob.type).toBe("image/png");
+    expect(await readBlobBytes(blob)).toEqual([1, 2, 3]);
+    expect(write).toHaveBeenCalledWith([expect.any(ClipboardItemMock)]);
+  });
+
+  it("logs and swallows clipboard failures", async () => {
+    const failure = new Error("denied");
+    const write = vi.fn().mockRejectedValue(failure);
+
+    Object.defineProperty(navigator, "clipboard", {
+      configurable: true,
+      value: { write },
+    });
+    Object.defineProperty(globalThis, "ClipboardItem", {
+      configurable: true,
+      value: vi.fn(function ClipboardItem() {}),
+    });
+
+    await expect(
+      copyRasterImageToClipboard("data:image/png;base64,AQID", "image/png"),
+    ).resolves.toBeUndefined();
+    expect(logger.warn).toHaveBeenCalledWith("[copy-image] Failed to copy raster image:", failure);
+  });
+});

--- a/src/components/outputs/__tests__/image-output.test.tsx
+++ b/src/components/outputs/__tests__/image-output.test.tsx
@@ -1,0 +1,34 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vite-plus/test";
+import { ImageOutput } from "../image-output";
+import { copyRasterImageToClipboard } from "../copy-image";
+
+vi.mock("../copy-image", () => ({
+  copyRasterImageToClipboard: vi.fn().mockResolvedValue(undefined),
+}));
+
+describe("ImageOutput", () => {
+  it("renders Copy image in the raster image context menu", async () => {
+    render(<ImageOutput data="AQID" mediaType="image/png" />);
+
+    fireEvent.contextMenu(screen.getByRole("img", { name: "Output image" }));
+
+    const copyImage = await screen.findByRole("menuitem", { name: "Copy image" });
+    expect(copyImage).toBeInTheDocument();
+
+    fireEvent.click(copyImage);
+
+    expect(copyRasterImageToClipboard).toHaveBeenCalledWith(
+      "data:image/png;base64,AQID",
+      "image/png",
+    );
+  });
+
+  it("does not add the raster image context menu to SVG image output", () => {
+    render(<ImageOutput data="<svg />" mediaType="image/svg+xml" />);
+
+    fireEvent.contextMenu(screen.getByRole("img", { name: "Output image" }));
+
+    expect(screen.queryByRole("menuitem", { name: "Copy image" })).not.toBeInTheDocument();
+  });
+});

--- a/src/components/outputs/copy-image.ts
+++ b/src/components/outputs/copy-image.ts
@@ -1,0 +1,44 @@
+import { logger } from "@/lib/logger";
+
+function dataUrlToBlob(src: string, fallbackType: string): Blob {
+  const match = /^data:([^;,]+)?((?:;[^,]*)*),(.*)$/i.exec(src);
+  if (!match) {
+    throw new Error("Invalid data URL");
+  }
+
+  const type = match[1] || fallbackType;
+  const parameters = match[2] || "";
+  const body = match[3] || "";
+  const decoded = /;base64/i.test(parameters)
+    ? atob(body.replace(/\s/g, ""))
+    : decodeURIComponent(body);
+  const bytes = new Uint8Array(decoded.length);
+
+  for (let index = 0; index < decoded.length; index += 1) {
+    bytes[index] = decoded.charCodeAt(index);
+  }
+
+  return new Blob([bytes], { type });
+}
+
+function ensureBlobType(blob: Blob, fallbackType: string): Blob {
+  return blob.type ? blob : new Blob([blob], { type: fallbackType });
+}
+
+async function sourceToBlob(src: string, mimeType: string): Promise<Blob> {
+  if (/^data:/i.test(src)) {
+    return dataUrlToBlob(src, mimeType);
+  }
+
+  const response = await fetch(src);
+  return ensureBlobType(await response.blob(), mimeType);
+}
+
+export async function copyRasterImageToClipboard(src: string, mimeType: string): Promise<void> {
+  try {
+    const blob = await sourceToBlob(src, mimeType);
+    await navigator.clipboard.write([new ClipboardItem({ [blob.type]: blob })]);
+  } catch (error) {
+    logger.warn("[copy-image] Failed to copy raster image:", error);
+  }
+}

--- a/src/components/outputs/copy-image.ts
+++ b/src/components/outputs/copy-image.ts
@@ -34,10 +34,39 @@ async function sourceToBlob(src: string, mimeType: string): Promise<Blob> {
   return ensureBlobType(await response.blob(), mimeType);
 }
 
+// Browsers only reliably accept image/png in ClipboardItem; jpeg/gif/webp/bmp
+// writes throw. Re-encode any non-PNG raster to PNG via a canvas so "copy image"
+// works for every raster type, not just matplotlib's PNG.
+async function toPngBlob(blob: Blob): Promise<Blob> {
+  if (blob.type === "image/png") {
+    return blob;
+  }
+  const bitmap = await createImageBitmap(blob);
+  try {
+    const canvas = document.createElement("canvas");
+    canvas.width = bitmap.width;
+    canvas.height = bitmap.height;
+    const context = canvas.getContext("2d");
+    if (!context) {
+      throw new Error("2d canvas context unavailable");
+    }
+    context.drawImage(bitmap, 0, 0);
+    const png = await new Promise<Blob | null>((resolve) => {
+      canvas.toBlob(resolve, "image/png");
+    });
+    if (!png) {
+      throw new Error("canvas toBlob produced no png");
+    }
+    return png;
+  } finally {
+    bitmap.close();
+  }
+}
+
 export async function copyRasterImageToClipboard(src: string, mimeType: string): Promise<void> {
   try {
-    const blob = await sourceToBlob(src, mimeType);
-    await navigator.clipboard.write([new ClipboardItem({ [blob.type]: blob })]);
+    const png = await toPngBlob(await sourceToBlob(src, mimeType));
+    await navigator.clipboard.write([new ClipboardItem({ "image/png": png })]);
   } catch (error) {
     logger.warn("[copy-image] Failed to copy raster image:", error);
   }

--- a/src/components/outputs/image-output.tsx
+++ b/src/components/outputs/image-output.tsx
@@ -1,5 +1,7 @@
 import { useEffect, useRef, useState } from "react";
+import { NotebookContextMenu } from "@/components/notebook/NotebookContextMenu";
 import { cn } from "@/lib/utils";
+import { copyRasterImageToClipboard } from "./copy-image";
 import { mediaDataToSource } from "./media-url";
 
 interface ImageOutputProps {
@@ -55,13 +57,48 @@ export function ImageOutput({
   // - If already a data URL or regular URL, use as-is
   // - Otherwise, assume base64 and construct data URL
   const targetSrc = mediaDataToSource(data, mediaType);
+  const canCopyImage = COPYABLE_RASTER_IMAGE_TYPES.has(mediaType);
+  const image = <PreloadedImage src={targetSrc} alt={alt} width={width} height={height} />;
 
   return (
     <div data-slot="image-output" className={cn("not-prose py-2", className)}>
-      <PreloadedImage src={targetSrc} alt={alt} width={width} height={height} />
+      {canCopyImage ? (
+        <NotebookContextMenu
+          surface={{ kind: "output", title: "Image output" }}
+          groups={[
+            {
+              id: "clipboard",
+              actions: [
+                {
+                  id: "copy-image",
+                  label: "Copy image",
+                  onSelect: () => {
+                    void copyRasterImageToClipboard(targetSrc, mediaType);
+                  },
+                },
+              ],
+            },
+          ]}
+          contentClassName="w-48"
+        >
+          <span className="inline-block max-w-full" data-slot="image-output-context-target">
+            {image}
+          </span>
+        </NotebookContextMenu>
+      ) : (
+        image
+      )}
     </div>
   );
 }
+
+const COPYABLE_RASTER_IMAGE_TYPES = new Set([
+  "image/png",
+  "image/jpeg",
+  "image/gif",
+  "image/webp",
+  "image/bmp",
+]);
 
 /**
  * Image element that preloads new sources before displaying them.


### PR DESCRIPTION
Adds a context menu with "Copy image" to inline raster image outputs, from the preview review.

Raster images (png/jpeg/gif/webp/bmp) already render inline as a real `<img>` in the host DOM (they are main-DOM-safe; svg stays isolated), so this is a UI-only change with no pipeline or isolation changes:

- `ImageOutput`'s image gets a `NotebookContextMenu` (surface `output`) with a "Copy image" action.
- `copy-image.ts` converts the image source (data URL or fetched blob) to a Blob and writes it via `navigator.clipboard.write([ClipboardItem])`, inside the user-gesture context-menu callback. Non-PNG rasters are re-encoded to PNG via a canvas first, since `ClipboardItem` image writes are effectively PNG-only in browsers. Failures are caught and logged, never thrown.

## Known limitation

For outputs that render inside the sandboxed iframe (isolated renderer), the frame lacks `clipboard-write` and a same-origin context, so the copy no-ops there (caught and logged). Raster images take the main-DOM path in the common case, where copy works. The iframe isolation model is intentionally left untouched.

## Verification

`vp check`, `vp test` (copy-image + image-output suites), notebook + cloud typecheck. Built by codex, reviewed by Claude (verdict: minor; the two findings - PNG-only writes and the sandbox-path no-op - are addressed/documented here).
