### PR TITLE
feat(comments): redesign the selection affordance as a dot, fix markdown anchoring

### DIFF
--- a/apps/elements/components/comment-selection-affordance-example.tsx
+++ b/apps/elements/components/comment-selection-affordance-example.tsx
@@ -1,20 +1,47 @@
 "use client";
 
+import type { CSSProperties } from "react";
 import { CommentSelectionAffordance } from "@/components/comments/CommentSelectionAffordance";
+
+function authorColor(color: string): CSSProperties {
+  return { "--comment-affordance-color": color } as CSSProperties;
+}
+
+const SAMPLES: Array<{ text: string; color: string }> = [
+  { text: "selected prose", color: "#6366f1" },
+  { text: "another author", color: "#16a34a" },
+  { text: "a third voice", color: "#ea580c" },
+];
 
 export function CommentSelectionAffordanceExample() {
   return (
     <div className="not-prose my-6">
       <div className="mx-auto max-w-[760px] border border-border bg-background px-6 py-5 text-foreground shadow-sm max-sm:px-4">
-        <p className="mb-4 text-sm text-muted-foreground">
-          Resting, the affordance is a quiet dot that stays out of the way while you select and copy
-          text. Hover it, or focus it with the keyboard, and it grows in place into a comment
-          button. The editor and rendered-markdown planes share this one surface.
+        <p className="mb-5 text-sm text-muted-foreground">
+          A small author-colored dot that breathes at rest, peeks open once when it appears so you
+          can tell what it is, then springs into a "Comment" speech bubble on hover or keyboard
+          focus. No icon: the bubble shape is the cue. The editor and rendered-markdown planes share
+          this one surface, tunable here via <code>--comment-affordance-color</code>.
         </p>
-        <div className="flex items-center gap-3 text-sm">
-          <CommentSelectionAffordance label="Add comment" onActivate={() => undefined} />
-          <span>Hover the dot, or tab to it.</span>
+        <div className="flex flex-wrap items-center gap-x-8 gap-y-4 text-sm">
+          {SAMPLES.map((sample) => (
+            <span
+              key={sample.color}
+              className="inline-flex items-center gap-1.5 rounded-[3px] px-1 py-0.5"
+              style={{ backgroundColor: `color-mix(in srgb, ${sample.color} 20%, transparent)` }}
+            >
+              <span>{sample.text}</span>
+              <CommentSelectionAffordance
+                label="Comment"
+                onActivate={() => undefined}
+                style={authorColor(sample.color)}
+              />
+            </span>
+          ))}
         </div>
+        <p className="mt-4 text-xs text-muted-foreground">
+          Hover a dot, or tab to it. Respects <code>prefers-reduced-motion</code>.
+        </p>
       </div>
     </div>
   );

--- a/apps/notebook/src/index.css
+++ b/apps/notebook/src/index.css
@@ -8,6 +8,7 @@
 @import "../../../src/styles/notebook-base.css";
 @import "../../../src/styles/cream-theme.css";
 @import "../../../src/styles/comment-highlight.css";
+@import "../../../src/styles/comment-affordance.css";
 
 html,
 body,

--- a/apps/notebook/src/lib/__tests__/comment-source-anchor.test.ts
+++ b/apps/notebook/src/lib/__tests__/comment-source-anchor.test.ts
@@ -106,7 +106,7 @@ describe("comment-source-anchor", () => {
     });
   });
 
-  it("maps rendered markdown text selections back to source_range anchors", () => {
+  it("maps plain rendered markdown text selections back to exact source text", () => {
     const root = document.createElement("div");
     root.innerHTML = `
       <p>
@@ -144,7 +144,7 @@ describe("comment-source-anchor", () => {
     root.remove();
   });
 
-  it("rejects rendered markdown selections when hidden source markup changes selected text", () => {
+  it("snaps styled rendered markdown selections to the full source markup run", () => {
     const root = document.createElement("div");
     root.innerHTML = `
       <p>
@@ -169,7 +169,51 @@ describe("comment-source-anchor", () => {
         root,
         window.getSelection(),
       ),
-    ).toBeNull();
+    ).toMatchObject({
+      kind: "source_range",
+      cell_id: "cell-1",
+      start_line: 0,
+      start_column: 0,
+      end_line: 0,
+      end_column: 8,
+      exact_quote: "**bold**",
+    });
+
+    root.remove();
+  });
+
+  it("maps rendered markdown selections spanning styled runs to the full source range", () => {
+    const source = "Intro **bold** and *em* outro";
+    const root = document.createElement("div");
+    root.innerHTML =
+      '<p><span data-markdown-source-run="true" data-rendered-start="0" data-rendered-end="6" data-source-start="0" data-source-end="6">Intro </span><span data-markdown-source-run="true" data-rendered-start="6" data-rendered-end="10" data-source-start="6" data-source-end="14"><strong>bold</strong></span><span data-markdown-source-run="true" data-rendered-start="10" data-rendered-end="15" data-source-start="14" data-source-end="19"> and </span><span data-markdown-source-run="true" data-rendered-start="15" data-rendered-end="17" data-source-start="19" data-source-end="23"><em>em</em></span><span data-markdown-source-run="true" data-rendered-start="17" data-rendered-end="23" data-source-start="23" data-source-end="29"> outro</span></p>';
+    document.body.append(root);
+    const strongText = root.querySelector("strong")?.firstChild;
+    const emText = root.querySelector("em")?.firstChild;
+    if (!strongText || !emText) throw new Error("missing styled text");
+
+    const range = document.createRange();
+    range.setStart(strongText, 0);
+    range.setEnd(emText, "em".length);
+    window.getSelection()?.removeAllRanges();
+    window.getSelection()?.addRange(range);
+
+    expect(
+      sourceRangeAnchorFromRenderedMarkdownSelection(
+        "cell-1",
+        source,
+        root,
+        window.getSelection(),
+      ),
+    ).toMatchObject({
+      kind: "source_range",
+      cell_id: "cell-1",
+      start_line: 0,
+      start_column: source.indexOf("**bold**"),
+      end_line: 0,
+      end_column: source.indexOf(" outro"),
+      exact_quote: "**bold** and *em*",
+    });
 
     root.remove();
   });
@@ -195,7 +239,7 @@ describe("comment-source-anchor", () => {
     });
   });
 
-  it("rejects rendered markdown runs when hidden source markup changes selected text", () => {
+  it("maps styled rendered markdown runs back to source markup", () => {
     expect(
       sourceRangeAnchorFromRenderedMarkdownRuns("cell-1", "**bold**", [
         {
@@ -209,7 +253,15 @@ describe("comment-source-anchor", () => {
           sourceSpanUtf16: [0, 8],
         },
       ]),
-    ).toBeNull();
+    ).toMatchObject({
+      kind: "source_range",
+      cell_id: "cell-1",
+      start_line: 0,
+      start_column: 0,
+      end_line: 0,
+      end_column: 8,
+      exact_quote: "**bold**",
+    });
   });
 });
 

--- a/apps/notebook/src/lib/rendered-markdown-source-comment.ts
+++ b/apps/notebook/src/lib/rendered-markdown-source-comment.ts
@@ -42,7 +42,7 @@ export function sourceRangeAnchorFromRenderedMarkdownSelection(
   if (from === null || to === null) return null;
 
   const anchor = sourceRangeAnchorFromOffsets(cellId, source, from, to);
-  if (!anchor || anchor.exact_quote !== selectedText) return null;
+  if (!anchor) return null;
   return anchor;
 }
 
@@ -58,9 +58,8 @@ export function sourceRangeAnchorFromRenderedMarkdownRuns(
 
   const from = Math.min(...visibleRuns.map((run) => run.sourceSpanUtf16[0]));
   const to = Math.max(...visibleRuns.map((run) => run.sourceSpanUtf16[1]));
-  const selectedText = visibleRuns.map((run) => run.renderedText).join("");
   const anchor = sourceRangeAnchorFromOffsets(cellId, source, from, to);
-  if (!anchor || anchor.exact_quote !== selectedText) return null;
+  if (!anchor) return null;
   return anchor;
 }
 

--- a/apps/notebook/src/lib/source-comment-extension.ts
+++ b/apps/notebook/src/lib/source-comment-extension.ts
@@ -16,6 +16,10 @@ export type SourceCommentRequestHandler = (
 const setSourceCommentFocusEffect = StateEffect.define<boolean>();
 const utf8Encoder = new TextEncoder();
 
+// How long the affordance peeks open when it first appears, so a fresh
+// selection can tell what it is before it settles to a quiet dot.
+const SOURCE_COMMENT_PEEK_MS = 1400;
+
 interface SourceCommentTooltipState {
   focused: boolean;
   tooltips: readonly Tooltip[];
@@ -90,18 +94,26 @@ function sourceCommentTooltips(
       create(view) {
         // Shared dot affordance (styles/comment-affordance.css), matching the
         // rendered-markdown plane. CodeMirror wraps this in a .cm-tooltip; the
-        // shared CSS strips that wrapper's chrome so only the dot shows.
+        // shared CSS strips that wrapper's chrome so only the dot shows. The dot
+        // peeks open once on appear so a fresh selection can tell what it is,
+        // then settles to a quiet dot.
         const button = document.createElement("button");
         button.type = "button";
-        button.className = "comment-affordance";
+        button.className = "comment-affordance comment-affordance-peek";
         button.title = "Comment on selection";
         button.setAttribute("aria-label", "Comment on selection");
         button.setAttribute("data-testid", "source-comment-button");
         const dot = document.createElement("span");
         dot.className = "comment-affordance-dot";
         dot.setAttribute("aria-hidden", "true");
-        dot.appendChild(createCommentIcon());
+        const label = document.createElement("span");
+        label.className = "comment-affordance-label";
+        label.textContent = "Comment";
+        dot.appendChild(label);
         button.appendChild(dot);
+        const peekTimer = setTimeout(() => {
+          button.classList.remove("comment-affordance-peek");
+        }, SOURCE_COMMENT_PEEK_MS);
         button.addEventListener("mousedown", (event) => {
           event.preventDefault();
         });
@@ -109,39 +121,15 @@ function sourceCommentTooltips(
           event.preventDefault();
           requestSourceComment(cellId, view, onCreateSourceComment);
         });
-        return { dom: button };
+        return {
+          dom: button,
+          destroy() {
+            clearTimeout(peekTimer);
+          },
+        };
       },
     },
   ];
-}
-
-function createCommentIcon(): SVGSVGElement {
-  const icon = document.createElementNS("http://www.w3.org/2000/svg", "svg");
-  icon.setAttribute("class", "comment-affordance-icon");
-  icon.setAttribute("width", "14");
-  icon.setAttribute("height", "14");
-  icon.setAttribute("viewBox", "0 0 24 24");
-  icon.setAttribute("fill", "none");
-  icon.setAttribute("stroke", "currentColor");
-  icon.setAttribute("stroke-width", "2");
-  icon.setAttribute("stroke-linecap", "round");
-  icon.setAttribute("stroke-linejoin", "round");
-  icon.setAttribute("aria-hidden", "true");
-  icon.setAttribute("focusable", "false");
-
-  const bubble = document.createElementNS("http://www.w3.org/2000/svg", "path");
-  bubble.setAttribute("d", "M21 15a2 2 0 0 1-2 2H7l-4 4V5a2 2 0 0 1 2-2h14a2 2 0 0 1 2 2z");
-  icon.appendChild(bubble);
-
-  const vertical = document.createElementNS("http://www.w3.org/2000/svg", "path");
-  vertical.setAttribute("d", "M12 7v6");
-  icon.appendChild(vertical);
-
-  const horizontal = document.createElementNS("http://www.w3.org/2000/svg", "path");
-  horizontal.setAttribute("d", "M9 10h6");
-  icon.appendChild(horizontal);
-
-  return icon;
 }
 
 function requestSourceComment(

--- a/apps/notebook/src/lib/source-comment-extension.ts
+++ b/apps/notebook/src/lib/source-comment-extension.ts
@@ -84,7 +84,7 @@ function sourceCommentTooltips(
 
   return [
     {
-      pos: selection.to,
+      pos: selection.head,
       above: true,
       strictSide: false,
       create(view) {

--- a/src/components/comments/CommentSelectionAffordance.tsx
+++ b/src/components/comments/CommentSelectionAffordance.tsx
@@ -1,4 +1,4 @@
-import { MessageSquarePlus } from "lucide-react";
+import { useEffect, useState } from "react";
 import type { CSSProperties, MouseEvent as ReactMouseEvent } from "react";
 import { cn } from "@/lib/utils";
 
@@ -9,30 +9,47 @@ export interface CommentSelectionAffordanceProps {
   /** Positioning and any extra classes from the host plane. */
   className?: string;
   style?: CSSProperties;
+  /** Accessible name (aria-label/title). The bubble always reads "Comment". */
   label?: string;
   testId?: string;
+  /** Play the one-time appear peek (the dot springs open, then settles to a dot)
+   *  so a fresh selection can tell what it is. Defaults to on. */
+  peekOnMount?: boolean;
 }
 
+const PEEK_MS = 1400;
+
 /**
- * The "comment on selection" affordance: a small resting dot that grows in place
- * into a comment button on hover or focus. Shared by the code-editor and
- * rendered-markdown planes; the visual lives in styles/comment-affordance.css so
- * both surfaces match and stay tunable in one place (shown in Elements).
+ * The "comment on selection" affordance: an author-colored dot that breathes at
+ * rest, peeks open once when it appears, and springs into a labeled "Comment"
+ * speech bubble on hover or focus. No icon: the bubble shape is the cue. Shared
+ * by the code-editor and rendered-markdown planes; the visual lives in
+ * styles/comment-affordance.css so both surfaces match and stay tunable in
+ * Elements.
  */
 export function CommentSelectionAffordance({
   onActivate,
   className,
   style,
-  label = "Add comment",
+  label = "Comment",
   testId,
+  peekOnMount = true,
 }: CommentSelectionAffordanceProps) {
+  const [peeking, setPeeking] = useState(peekOnMount);
+
+  useEffect(() => {
+    if (!peekOnMount) return;
+    const timer = setTimeout(() => setPeeking(false), PEEK_MS);
+    return () => clearTimeout(timer);
+  }, [peekOnMount]);
+
   return (
     <button
       type="button"
       aria-label={label}
       title={label}
       data-testid={testId}
-      className={cn("comment-affordance", className)}
+      className={cn("comment-affordance", peeking && "comment-affordance-peek", className)}
       style={style}
       onPointerDown={(event) => {
         // Keep the active text selection while the affordance is pressed.
@@ -50,7 +67,7 @@ export function CommentSelectionAffordance({
       }}
     >
       <span className="comment-affordance-dot" aria-hidden="true">
-        <MessageSquarePlus className="comment-affordance-icon" aria-hidden="true" />
+        <span className="comment-affordance-label">Comment</span>
       </span>
     </button>
   );

--- a/src/styles/comment-affordance.css
+++ b/src/styles/comment-affordance.css
@@ -2,21 +2,21 @@
    plane and the rendered-markdown plane. One definition so both surfaces match
    and the look is tunable in one place (cataloged in Elements).
 
-   Resting state is a small unobtrusive dot that sits out of the way while a
-   reader selects and copies text. On hover or keyboard focus the dot grows in
-   place into a labeled comment button. Growing the same element (rather than
-   revealing a separate floating panel) keeps the target under the cursor, so
-   there is no gap to cross and nothing to flicker out as you reach for it. */
+   Resting state is a small author-colored dot that breathes gently, sitting out
+   of the way while a reader selects and copies text. On appear it peeks open
+   once (so you can tell what it is), and on hover or keyboard focus it springs
+   into a labeled "Comment" speech bubble with a tail. The spring matches the
+   running motion (exec-squish). No icon: the bubble shape is the comment cue. */
 .comment-affordance {
   --comment-affordance-color: var(--primary, #2563eb);
+  --comment-affordance-spring: cubic-bezier(0.34, 1.56, 0.64, 1);
   box-sizing: border-box;
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  /* A stable 22px hit area around a 9px dot: easy to hit without enlarging the
-     resting footprint. */
-  width: 22px;
-  height: 22px;
+  /* Generous transparent hit area around the resting dot. */
+  width: 26px;
+  height: 26px;
   padding: 0;
   margin: 0;
   border: none;
@@ -26,49 +26,125 @@
 }
 
 .comment-affordance-dot {
+  position: relative;
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  width: 9px;
-  height: 9px;
-  border-radius: 9999px;
-  background-color: color-mix(in srgb, var(--comment-affordance-color) 50%, transparent);
-  box-shadow: 0 1px 3px rgb(0 0 0 / 0.18);
+  height: 14px;
+  width: 14px;
+  padding: 0;
+  border-radius: 999px;
+  background-color: var(--comment-affordance-color);
+  color: #ffffff;
+  overflow: hidden;
+  white-space: nowrap;
+  box-shadow: 0 1px 5px color-mix(in srgb, var(--comment-affordance-color) 50%, transparent);
   transition:
-    width 120ms ease,
-    height 120ms ease,
-    border-radius 120ms ease,
-    background-color 120ms ease;
+    width 260ms var(--comment-affordance-spring),
+    height 260ms var(--comment-affordance-spring),
+    padding 260ms var(--comment-affordance-spring),
+    border-radius 200ms ease;
+  animation: comment-affordance-breathe 2.8s ease-in-out infinite;
 }
 
-.comment-affordance-icon {
-  width: 14px;
-  height: 14px;
+.comment-affordance-label {
+  font-size: 12px;
+  font-weight: 600;
+  letter-spacing: -0.01em;
+  line-height: 1;
+  max-width: 0;
   opacity: 0;
-  transform: scale(0.6);
+  transform: translateY(2px);
+  transition:
+    opacity 130ms ease 60ms,
+    max-width 220ms var(--comment-affordance-spring),
+    transform 220ms var(--comment-affordance-spring) 40ms;
+}
+
+/* Speech-bubble tail, only while open. */
+.comment-affordance-dot::after {
+  content: "";
+  position: absolute;
+  left: 9px;
+  bottom: -4px;
+  width: 0;
+  height: 0;
+  border-left: 5px solid transparent;
+  border-right: 5px solid transparent;
+  border-top: 6px solid var(--comment-affordance-color);
+  opacity: 0;
+  transform: scale(0.4);
   transition:
     opacity 120ms ease,
-    transform 120ms ease;
+    transform 200ms var(--comment-affordance-spring);
 }
 
+/* OPEN: hover, keyboard focus, or the one-time appear peek. */
 .comment-affordance:hover .comment-affordance-dot,
-.comment-affordance:focus-visible .comment-affordance-dot {
-  width: 22px;
+.comment-affordance:focus-visible .comment-affordance-dot,
+.comment-affordance.comment-affordance-peek .comment-affordance-dot {
+  width: auto;
   height: 22px;
-  border-radius: 0.5rem;
-  background-color: var(--comment-affordance-color);
+  padding: 0 10px;
+  border-radius: 11px;
+  animation: comment-affordance-open 320ms var(--comment-affordance-spring);
 }
-
-.comment-affordance:hover .comment-affordance-icon,
-.comment-affordance:focus-visible .comment-affordance-icon {
+.comment-affordance:hover .comment-affordance-label,
+.comment-affordance:focus-visible .comment-affordance-label,
+.comment-affordance.comment-affordance-peek .comment-affordance-label {
+  max-width: 140px;
+  opacity: 1;
+  transform: translateY(0);
+}
+.comment-affordance:hover .comment-affordance-dot::after,
+.comment-affordance:focus-visible .comment-affordance-dot::after,
+.comment-affordance.comment-affordance-peek .comment-affordance-dot::after {
   opacity: 1;
   transform: scale(1);
 }
 
 .comment-affordance:focus-visible {
+  outline: none;
+}
+.comment-affordance:focus-visible .comment-affordance-dot {
   outline: 2px solid var(--ring, #a3a3a3);
   outline-offset: 2px;
-  border-radius: 0.5rem;
+}
+
+@keyframes comment-affordance-breathe {
+  0%,
+  100% {
+    box-shadow: 0 1px 4px color-mix(in srgb, var(--comment-affordance-color) 35%, transparent);
+    transform: scale(1);
+  }
+  50% {
+    box-shadow: 0 1px 9px color-mix(in srgb, var(--comment-affordance-color) 60%, transparent);
+    transform: scale(1.12);
+  }
+}
+
+@keyframes comment-affordance-open {
+  0% {
+    transform: scale(1, 1);
+  }
+  35% {
+    transform: scale(1.06, 0.94);
+  }
+  70% {
+    transform: scale(0.99, 1.01);
+  }
+  100% {
+    transform: scale(1, 1);
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .comment-affordance-dot,
+  .comment-affordance-label,
+  .comment-affordance-dot::after {
+    animation: none;
+    transition: none;
+  }
 }
 
 /* The CodeMirror editor plane renders this button inside a CM tooltip wrapper.

--- a/src/styles/comment-affordance.css
+++ b/src/styles/comment-affordance.css
@@ -8,8 +8,10 @@
    into a labeled "Comment" speech bubble with a tail. The spring matches the
    running motion (exec-squish). No icon: the bubble shape is the comment cue.
 
-   The label reveal animates a grid column from 0fr to 1fr so the bubble always
-   grows to the label's true content width. The word never clips. */
+   The reveal animates the bubble's own max-width while it clips its overflow, so
+   the bubble grows to its content (the label at its natural width) capped by a
+   generous ceiling. The word never clips, on every engine including iOS Safari
+   (grid fr tracks do not resolve to content width there). */
 .comment-affordance {
   --comment-affordance-color: var(--primary, #2563eb);
   --comment-affordance-spring: cubic-bezier(0.34, 1.56, 0.64, 1);
@@ -30,19 +32,19 @@
 
 .comment-affordance-dot {
   position: relative;
-  display: inline-grid;
-  grid-template-columns: 0fr;
+  display: inline-flex;
   align-items: center;
+  justify-content: center;
   height: 14px;
-  min-width: 14px;
+  max-width: 14px;
   padding: 0;
+  overflow: hidden;
   border-radius: 999px;
   background-color: var(--comment-affordance-color);
   color: #ffffff;
   box-shadow: 0 1px 5px color-mix(in srgb, var(--comment-affordance-color) 50%, transparent);
   transition:
-    grid-template-columns 260ms var(--comment-affordance-spring),
-    min-width 260ms var(--comment-affordance-spring),
+    max-width 280ms var(--comment-affordance-spring),
     height 260ms var(--comment-affordance-spring),
     padding 260ms var(--comment-affordance-spring),
     border-radius 200ms ease;
@@ -50,8 +52,6 @@
 }
 
 .comment-affordance-label {
-  overflow: hidden;
-  min-width: 0;
   white-space: nowrap;
   font-size: 12px;
   font-weight: 600;
@@ -79,12 +79,12 @@
     transform 200ms var(--comment-affordance-spring);
 }
 
-/* OPEN: hover, keyboard focus, or the one-time appear peek. */
+/* OPEN: hover, keyboard focus, or the one-time appear peek. The bubble grows to
+   fit its label (capped at 9rem) and the word is fully revealed. */
 .comment-affordance:hover .comment-affordance-dot,
 .comment-affordance:focus-visible .comment-affordance-dot,
 .comment-affordance.comment-affordance-peek .comment-affordance-dot {
-  grid-template-columns: 1fr;
-  min-width: 0;
+  max-width: 9rem;
   height: 22px;
   padding: 0 10px;
   border-radius: 11px;

--- a/src/styles/comment-affordance.css
+++ b/src/styles/comment-affordance.css
@@ -6,7 +6,10 @@
    of the way while a reader selects and copies text. On appear it peeks open
    once (so you can tell what it is), and on hover or keyboard focus it springs
    into a labeled "Comment" speech bubble with a tail. The spring matches the
-   running motion (exec-squish). No icon: the bubble shape is the comment cue. */
+   running motion (exec-squish). No icon: the bubble shape is the comment cue.
+
+   The label reveal animates a grid column from 0fr to 1fr so the bubble always
+   grows to the label's true content width. The word never clips. */
 .comment-affordance {
   --comment-affordance-color: var(--primary, #2563eb);
   --comment-affordance-spring: cubic-bezier(0.34, 1.56, 0.64, 1);
@@ -27,20 +30,19 @@
 
 .comment-affordance-dot {
   position: relative;
-  display: inline-flex;
+  display: inline-grid;
+  grid-template-columns: 0fr;
   align-items: center;
-  justify-content: center;
   height: 14px;
-  width: 14px;
+  min-width: 14px;
   padding: 0;
   border-radius: 999px;
   background-color: var(--comment-affordance-color);
   color: #ffffff;
-  overflow: hidden;
-  white-space: nowrap;
   box-shadow: 0 1px 5px color-mix(in srgb, var(--comment-affordance-color) 50%, transparent);
   transition:
-    width 260ms var(--comment-affordance-spring),
+    grid-template-columns 260ms var(--comment-affordance-spring),
+    min-width 260ms var(--comment-affordance-spring),
     height 260ms var(--comment-affordance-spring),
     padding 260ms var(--comment-affordance-spring),
     border-radius 200ms ease;
@@ -48,17 +50,15 @@
 }
 
 .comment-affordance-label {
+  overflow: hidden;
+  min-width: 0;
+  white-space: nowrap;
   font-size: 12px;
   font-weight: 600;
   letter-spacing: -0.01em;
   line-height: 1;
-  max-width: 0;
   opacity: 0;
-  transform: translateY(2px);
-  transition:
-    opacity 130ms ease 60ms,
-    max-width 220ms var(--comment-affordance-spring),
-    transform 220ms var(--comment-affordance-spring) 40ms;
+  transition: opacity 130ms ease 60ms;
 }
 
 /* Speech-bubble tail, only while open. */
@@ -83,7 +83,8 @@
 .comment-affordance:hover .comment-affordance-dot,
 .comment-affordance:focus-visible .comment-affordance-dot,
 .comment-affordance.comment-affordance-peek .comment-affordance-dot {
-  width: auto;
+  grid-template-columns: 1fr;
+  min-width: 0;
   height: 22px;
   padding: 0 10px;
   border-radius: 11px;
@@ -92,9 +93,7 @@
 .comment-affordance:hover .comment-affordance-label,
 .comment-affordance:focus-visible .comment-affordance-label,
 .comment-affordance.comment-affordance-peek .comment-affordance-label {
-  max-width: 140px;
   opacity: 1;
-  transform: translateY(0);
 }
 .comment-affordance:hover .comment-affordance-dot::after,
 .comment-affordance:focus-visible .comment-affordance-dot::after,


### PR DESCRIPTION
Two comment-affordance fixes from the preview review, plus the dot redesign.

## Markdown selections now anchor to the actual text
`sourceRangeAnchorFromRenderedMarkdownSelection`/`...Runs` rejected an anchor whenever `exact_quote !== selectedText`. But `exact_quote` is the markdown *source* slice (e.g. `**bold**`) while `selectedText` is the rendered DOM text (`bold`), so they differ for every styled run, and the affordance silently disappeared on styled or cross-run rendered selections. Removed that guard; the remaining `sourceRangeAnchorFromOffsets` guards (empty/zero-length/out-of-bounds/whitespace/oversize) still reject degenerate anchors. The CodeMirror source-view path was never affected. Tests updated to assert styled/cross-run selections now resolve.

## The dot affordance, redesigned (no icon)
The comment-plus icon is gone. The affordance is now an author-colored dot that breathes at rest, **peeks open once when it appears** (so a fresh selection can tell what it is), and springs into a "Comment" speech bubble with a tail on hover or keyboard focus, using the same spring as the running motion. The bubble shape is the cue; no icon.

- Fixes the import bug from #3763: the app entry `apps/notebook/src/index.css` never loaded `comment-affordance.css`, so the dot rendered as a full-size icon. Now imported.
- The CodeMirror tooltip anchors at `selection.head` (the live end of the selection) instead of `selection.to`, so it follows your pointer.
- Shared by the editor and rendered-markdown planes via one stylesheet; showcased in Elements (Comment surfaces) with a `--comment-affordance-color` knob.

Faithful preview (exact shipped CSS): https://img.runt.run/2026/06/20/7602654e12fd.html

## Verification
`vp check`, full `vp test` (2452), notebook + cloud + Elements typecheck. Anchor fix + tests built by codex and reviewed clean; the dot redesign is hand-built.
