### PR TITLE
fix(comments): grow the comment bubble past the hit-area on iOS Safari

### DIFF
--- a/src/styles/comment-affordance.css
+++ b/src/styles/comment-affordance.css
@@ -19,10 +19,10 @@
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  /* Generous transparent hit area around the resting dot. */
-  width: 26px;
-  height: 26px;
-  padding: 0;
+  /* Content-sized with padding for the hit area. A fixed width would cap the
+     dot's growth: on WebKit/iOS Safari a flex child cannot exceed a fixed-width
+     flex parent, which clipped the open bubble to one glyph on mobile. */
+  padding: 6px;
   margin: 0;
   border: none;
   background: transparent;
@@ -33,6 +33,7 @@
 .comment-affordance-dot {
   position: relative;
   display: inline-flex;
+  flex: none;
   align-items: center;
   justify-content: center;
   height: 14px;


### PR DESCRIPTION
Follow-up to #3770: the comment bubble clipped to a single glyph ("C"/"R") on iOS Safari.

The affordance button had a fixed `width: 26px` for the hit area. On WebKit/iOS Safari a flex child cannot exceed a fixed-width flex parent, so the open bubble was capped at the button width even though the dot's own `max-width` allowed more (Chromium let the child overflow, which is why desktop looked right). Make the button content-sized with `padding` for the hit area and `flex: none` on the dot, so the bubble grows to the full word on every engine.

Mobile preview (exact shipped CSS): https://img.runt.run/2026/06/20/3633437f8d0d.html

## Verification
`vp check` clean. CSS-only change to `src/styles/comment-affordance.css`.
