### PR TITLE
fix(outputs): keep copy image inside the user gesture (Safari)

### DIFF
--- a/src/components/outputs/__tests__/copy-image.test.ts
+++ b/src/components/outputs/__tests__/copy-image.test.ts
@@ -40,8 +40,8 @@ describe("copyRasterImageToClipboard", () => {
   it("writes a base64 data URL image through ClipboardItem", async () => {
     const write = vi.fn().mockResolvedValue(undefined);
     const ClipboardItemMock = vi.fn(function ClipboardItem(
-      this: { items: Record<string, Blob> },
-      items: Record<string, Blob>,
+      this: { items: Record<string, Promise<Blob> | Blob> },
+      items: Record<string, Promise<Blob> | Blob>,
     ) {
       this.items = items;
     });
@@ -55,14 +55,21 @@ describe("copyRasterImageToClipboard", () => {
       value: ClipboardItemMock,
     });
 
-    await copyRasterImageToClipboard("data:image/png;base64,AQID", "image/png");
+    // Synchronous call: write() must be invoked inside the gesture, with the
+    // blob deferred as a promise so the user activation is not lost.
+    copyRasterImageToClipboard("data:image/png;base64,AQID", "image/png");
 
     expect(ClipboardItemMock).toHaveBeenCalledTimes(1);
-    const itemPayload = ClipboardItemMock.mock.calls[0]?.[0] as Record<string, Blob>;
-    const blob = itemPayload["image/png"];
+    expect(write).toHaveBeenCalledWith([expect.any(ClipboardItemMock)]);
+    const itemPayload = ClipboardItemMock.mock.calls[0]?.[0] as Record<
+      string,
+      Promise<Blob> | Blob
+    >;
+    const value = itemPayload["image/png"];
+    expect(typeof (value as Promise<Blob>).then).toBe("function");
+    const blob = await value;
     expect(blob.type).toBe("image/png");
     expect(await readBlobBytes(blob)).toEqual([1, 2, 3]);
-    expect(write).toHaveBeenCalledWith([expect.any(ClipboardItemMock)]);
   });
 
   it("logs and swallows clipboard failures", async () => {
@@ -78,9 +85,10 @@ describe("copyRasterImageToClipboard", () => {
       value: vi.fn(function ClipboardItem() {}),
     });
 
-    await expect(
-      copyRasterImageToClipboard("data:image/png;base64,AQID", "image/png"),
-    ).resolves.toBeUndefined();
+    copyRasterImageToClipboard("data:image/png;base64,AQID", "image/png");
+    await Promise.resolve();
+    await Promise.resolve();
+
     expect(logger.warn).toHaveBeenCalledWith("[copy-image] Failed to copy raster image:", failure);
   });
 });

--- a/src/components/outputs/__tests__/copy-image.test.ts
+++ b/src/components/outputs/__tests__/copy-image.test.ts
@@ -86,9 +86,15 @@ describe("copyRasterImageToClipboard", () => {
     });
 
     copyRasterImageToClipboard("data:image/png;base64,AQID", "image/png");
-    await Promise.resolve();
-    await Promise.resolve();
 
-    expect(logger.warn).toHaveBeenCalledWith("[copy-image] Failed to copy raster image:", failure);
+    // Poll instead of counting microtask ticks: the write rejection propagates
+    // through the deferred ClipboardItem promise, so the exact tick count is not
+    // something the test should depend on.
+    await vi.waitFor(() => {
+      expect(logger.warn).toHaveBeenCalledWith(
+        "[copy-image] Failed to copy raster image:",
+        failure,
+      );
+    });
   });
 });

--- a/src/components/outputs/__tests__/image-output.test.tsx
+++ b/src/components/outputs/__tests__/image-output.test.tsx
@@ -4,7 +4,9 @@ import { ImageOutput } from "../image-output";
 import { copyRasterImageToClipboard } from "../copy-image";
 
 vi.mock("../copy-image", () => ({
-  copyRasterImageToClipboard: vi.fn().mockResolvedValue(undefined),
+  // copyRasterImageToClipboard is synchronous (void); it writes to the clipboard
+  // inside the user gesture and resolves the blob inside the ClipboardItem.
+  copyRasterImageToClipboard: vi.fn(),
 }));
 
 describe("ImageOutput", () => {

--- a/src/components/outputs/copy-image.ts
+++ b/src/components/outputs/copy-image.ts
@@ -63,10 +63,17 @@ async function toPngBlob(blob: Blob): Promise<Blob> {
   }
 }
 
-export async function copyRasterImageToClipboard(src: string, mimeType: string): Promise<void> {
+export function copyRasterImageToClipboard(src: string, mimeType: string): void {
   try {
-    const png = await toPngBlob(await sourceToBlob(src, mimeType));
-    await navigator.clipboard.write([new ClipboardItem({ "image/png": png })]);
+    // Resolve the PNG inside the ClipboardItem and call write() synchronously, so
+    // the clipboard write stays inside the user gesture. Safari drops the
+    // transient activation across an awaited fetch or canvas encode, which would
+    // silently reject the write; passing a Promise<Blob> to ClipboardItem defers
+    // that async work without leaving the gesture.
+    const png = (async () => toPngBlob(await sourceToBlob(src, mimeType)))();
+    void navigator.clipboard.write([new ClipboardItem({ "image/png": png })]).catch((error) => {
+      logger.warn("[copy-image] Failed to copy raster image:", error);
+    });
   } catch (error) {
     logger.warn("[copy-image] Failed to copy raster image:", error);
   }


### PR DESCRIPTION
Follow-up to #3769 (pullfrog's user-gesture concern).

`copyRasterImageToClipboard` awaited `fetch`/canvas encode before `navigator.clipboard.write`, so on Safari the transient user activation was already gone by the time `write` ran - the copy silently rejected for fetched (daemon blob-store) or non-PNG images. Matplotlib PNG data URLs happened to survive because their await is a single microtask.

Now `write()` is called synchronously inside the gesture with a `ClipboardItem` whose value is a `Promise<Blob>`; the fetch/canvas resolution is deferred inside the ClipboardItem, which keeps the activation. Failures are still caught and logged.

Tests updated to assert the ClipboardItem receives a promise and `write` fires synchronously.

## Verification
`vp check`, `copy-image` + `image-output` test suites green. (tsc in the fresh worktree only reports un-generated WASM bindings; the change is isolated to `copy-image.ts`.)
