### PR TITLE
fix(comments): author-color the selection affordance and clear resolved highlights

### DIFF
--- a/apps/notebook/src/App.tsx
+++ b/apps/notebook/src/App.tsx
@@ -1,5 +1,6 @@
 import { type ReactNode, useCallback, useEffect, useMemo, useRef, useState } from "react";
 import {
+  colorForActorIdentity,
   deriveEnvManager,
   deriveRuntimeKind,
   NotebookClient,
@@ -794,6 +795,19 @@ function AppContent() {
     const [localPrincipal] = splitNotebookActorPrincipalOperator(localActor);
     return [{ participantKey: localPrincipal, label }];
   }, [localActor, peerLabel]);
+
+  // Tint the comment-on-selection affordance with the local author's canonical
+  // color (the same color as their cursor and edits), exposed as a CSS var the
+  // shared affordance styles read. Without it the dot falls back to --primary,
+  // a near-black neutral.
+  useEffect(() => {
+    if (!localActor) return;
+    const color = colorForActorIdentity(localActor);
+    document.documentElement.style.setProperty("--comment-author-color", color);
+    return () => {
+      document.documentElement.style.removeProperty("--comment-author-color");
+    };
+  }, [localActor]);
 
   const resolveCommentAuthor = useCallback(
     (actorLabel: string): CommentAuthor => {

--- a/apps/notebook/src/components/MarkdownCell.tsx
+++ b/apps/notebook/src/components/MarkdownCell.tsx
@@ -303,6 +303,9 @@ export const MarkdownCell = memo(function MarkdownCell({
   const renderedCommentHighlights = useMemo(() => {
     if (editing || !projectionMatchesPreview || !commentThreads?.length) return undefined;
     const highlights = commentThreads.flatMap((thread) => {
+      // Resolved threads leave no rendered highlight; they stay in the rail
+      // under "Show resolved".
+      if (thread.resolved) return [];
       const range = resolveSourceRangeAnchor(previewSource, thread.anchor);
       if (!range) return [];
       return [

--- a/apps/notebook/src/lib/comment-highlights.ts
+++ b/apps/notebook/src/lib/comment-highlights.ts
@@ -58,6 +58,9 @@ function dispatchCell(cellId: string): void {
   const source = view.state.doc.toString();
   const highlights: CommentHighlight[] = [];
   for (const thread of threads) {
+    // Resolved threads leave no highlight in the document. They stay reachable
+    // under "Show resolved" in the rail, but the inline mark goes away.
+    if (thread.resolved) continue;
     const range = resolveSourceRangeAnchor(source, thread.anchor);
     if (!range) continue;
     highlights.push({

--- a/apps/notebook/src/lib/source-comment-extension.ts
+++ b/apps/notebook/src/lib/source-comment-extension.ts
@@ -100,7 +100,8 @@ function sourceCommentTooltips(
         const button = document.createElement("button");
         button.type = "button";
         button.className = "comment-affordance comment-affordance-peek";
-        button.title = "Comment on selection";
+        // No title attribute: the native browser tooltip duplicates the bubble's
+        // own "Comment" label. aria-label keeps it accessible.
         button.setAttribute("aria-label", "Comment on selection");
         button.setAttribute("data-testid", "source-comment-button");
         const dot = document.createElement("span");

--- a/src/components/comments/CommentSelectionAffordance.tsx
+++ b/src/components/comments/CommentSelectionAffordance.tsx
@@ -47,7 +47,6 @@ export function CommentSelectionAffordance({
     <button
       type="button"
       aria-label={label}
-      title={label}
       data-testid={testId}
       className={cn("comment-affordance", peeking && "comment-affordance-peek", className)}
       style={style}

--- a/src/styles/comment-affordance.css
+++ b/src/styles/comment-affordance.css
@@ -13,7 +13,11 @@
    generous ceiling. The word never clips, on every engine including iOS Safari
    (grid fr tracks do not resolve to content width there). */
 .comment-affordance {
-  --comment-affordance-color: var(--primary, #2563eb);
+  /* Tinted with the author's canonical color (the same color as their cursor and
+     edits), set on an ancestor as --comment-author-color. Falls back to the
+     theme accent only if no author color is in scope. --primary is a near-black
+     neutral in the default theme, so it is the fallback, not the default. */
+  --comment-affordance-color: var(--comment-author-color, var(--primary, #2563eb));
   --comment-affordance-spring: cubic-bezier(0.34, 1.56, 0.64, 1);
   box-sizing: border-box;
   display: inline-flex;
@@ -147,11 +151,13 @@
   }
 }
 
-/* The CodeMirror editor plane renders this button inside a CM tooltip wrapper.
-   Strip the default tooltip chrome so only the dot shows. */
-.cm-tooltip:has(.comment-affordance) {
-  border: none;
-  background: transparent;
-  box-shadow: none;
-  padding: 0;
+/* CodeMirror merges its tooltip classes onto the affordance button itself (the
+   element is both .comment-affordance and .cm-tooltip), so the tooltip chrome
+   paints a box around the dot. Strip that chrome on the shared element. The
+   theme sets it with editor-scoped specificity, so !important wins the cascade.
+   The hit-area padding from .comment-affordance is intentionally left intact. */
+.cm-tooltip.comment-affordance {
+  border: none !important;
+  background: transparent !important;
+  box-shadow: none !important;
 }


### PR DESCRIPTION
Polish for the comment-on-selection affordance and resolved-thread highlights, following the dot redesign in #3770 and the iOS clip fix in #3771. The affordance was rendering as a near-black bubble inside a boxed CodeMirror tooltip, a native "Comment on selection" tooltip duplicated its own label, and resolved threads kept their inline highlight.

## Fixes

**Author color.** The affordance tinted itself with `--primary`, a near-black neutral in the default theme. It now reads `--comment-author-color`, set on the document element from `colorForActorIdentity(localActor)`, the same color as the author's cursor and edits. `--primary` stays as the fallback when no author color is in scope.

**Tooltip chrome.** CodeMirror merges its `cm-tooltip` classes onto the affordance button itself, so the element is both `.comment-affordance` and `.cm-tooltip` and the tooltip border/background/shadow painted a box around the dot. The old `:has(.comment-affordance)` selector never matched, because the classes sit on the same element rather than a descendant. The chrome is now stripped on `.cm-tooltip.comment-affordance`; the theme sets it with editor-scoped specificity, so `!important` wins the cascade. The hit-area padding stays.

**Native tooltip.** Dropped the `title` attribute on both affordance planes (CodeMirror editor and rendered markdown). The bubble already labels itself "Comment", so the native title only duplicated it on hover. `aria-label` keeps the control accessible.

**Resolved highlights.** Resolved threads now leave no inline highlight in either the editor (`comment-highlights.ts`) or rendered markdown (`MarkdownCell.tsx`). They stay reachable under "Show resolved" in the rail.

## Behavioral coverage

| State | Before | After |
|-------|--------|-------|
| Affordance at rest | Near-black dot | Author-colored dot |
| Affordance open | "Comment" pill inside a dark tooltip box | Clean "Comment" pill, no box |
| Hover | Native title duplicates the label | Bubble label only |
| Thread resolved | Inline highlight stays | Highlight cleared, thread under "Show resolved" |

Verified live in the Vite dev app: author-colored dot springs to a "Comment" pill with no box and no native tooltip, and resolving a thread removes its inline highlight (confirmed zero highlight decorations remain in the editor).

The green left bar some builds show on a commented cell is the focused-cell ribbon (`colors.ribbon.focused`), driven by focus, not comments. Out of scope here.
