### PR TITLE
fix(outputs): bridge Panel widget comms

### DIFF
--- a/apps/elements/components/isolated/index.tsx
+++ b/apps/elements/components/isolated/index.tsx
@@ -16,12 +16,14 @@ import { useWidgetStore } from "@/components/widgets/widget-store-context";
 import { parseWidgetViewModelId, WIDGET_VIEW_MIME } from "@/components/widgets/widget-state";
 import {
   anyOutputNeedsIsolation,
+  hasCommBridgeOutputs,
   hasWidgetOutputs,
   isScrollPassthroughMimeType,
   isSiftMimeType,
   outputAllowsScrollPassthrough,
   outputNeedsIsolation,
   outputSegmentLane,
+  outputUsesCommBridge,
   outputUsesSift,
   outputUsesVega,
   outputUsesWheelOwningFrame,
@@ -44,12 +46,14 @@ import type { NteractMeasureElementResult } from "../../../../src/components/iso
 
 export {
   anyOutputNeedsIsolation,
+  hasCommBridgeOutputs,
   hasWidgetOutputs,
   isScrollPassthroughMimeType,
   isSiftMimeType,
   outputAllowsScrollPassthrough,
   outputNeedsIsolation,
   outputSegmentLane,
+  outputUsesCommBridge,
   outputUsesSift,
   outputUsesVega,
   outputUsesWheelOwningFrame,

--- a/crates/notebook-protocol/src/protocol.rs
+++ b/crates/notebook-protocol/src/protocol.rs
@@ -795,6 +795,9 @@ pub enum NotebookBroadcast {
         msg_type: String,
         /// Message content (comm_id, data, target_name, etc.)
         content: serde_json::Value,
+        /// Message metadata from the Jupyter envelope.
+        #[serde(default)]
+        metadata: serde_json::Value,
         /// Binary buffers (base64-encoded when serialized to JSON)
         #[serde(default)]
         buffers: Vec<Vec<u8>>,

--- a/crates/notebook-sync/src/sync_task.rs
+++ b/crates/notebook-sync/src/sync_task.rs
@@ -1955,6 +1955,7 @@ mod tests {
                 &NotebookBroadcast::Comm {
                     msg_type: "comm_msg".into(),
                     content: json!({"comm_id": "abc", "data": {}}),
+                    metadata: json!({}),
                     buffers: Vec::new(),
                 },
             )

--- a/crates/runtimed-client/src/protocol.rs
+++ b/crates/runtimed-client/src/protocol.rs
@@ -613,6 +613,7 @@ mod tests {
         let broadcast = NotebookBroadcast::Comm {
             msg_type: "comm_msg".into(),
             content: serde_json::json!({"comm_id": "abc"}),
+            metadata: serde_json::json!({}),
             buffers: vec![],
         };
         let json = serde_json::to_string(&broadcast).unwrap();

--- a/crates/runtimed/Cargo.toml
+++ b/crates/runtimed/Cargo.toml
@@ -47,6 +47,7 @@ aho-corasick = "1"
 jupyter-protocol = { workspace = true }
 nbformat = { workspace = true }
 jupyter-zmq-client = { workspace = true, features = ["tokio-runtime", "aws-lc-rs"] }
+zeromq = "0.6"
 petname = "2"
 chrono = { version = "0.4", default-features = false, features = ["std", "clock", "serde"] }
 clap = { version = "4", features = ["derive"] }
@@ -133,4 +134,3 @@ serial_test = "3"
 tokio = { version = "1.36.0", features = ["full", "test-util"] }
 notebook-sync = { path = "../notebook-sync" }
 async-rust-lsp = "0.3"
-zeromq = "0.6"

--- a/crates/runtimed/src/jupyter_kernel.rs
+++ b/crates/runtimed/src/jupyter_kernel.rs
@@ -18,8 +18,8 @@ use std::sync::{Arc, Mutex as StdMutex};
 use anyhow::Result;
 use bytes::Bytes;
 use jupyter_protocol::{
-    CompleteRequest, ConnectionInfo, ExecuteRequest, HistoryRequest, InterruptRequest,
-    JupyterMessage, JupyterMessageContent, KernelInfoRequest, ShutdownRequest,
+    Channel, CompleteRequest, ConnectionInfo, ExecuteRequest, HistoryRequest, InterruptRequest,
+    JupyterMessage, JupyterMessageContent, KernelInfoRequest, ShutdownRequest, UnknownMessage,
 };
 use runtime_doc::{KernelActivity, RuntimeLifecycle};
 use tokio::net::TcpListener;
@@ -27,6 +27,7 @@ use tokio::sync::{mpsc, oneshot};
 use tokio::task::JoinHandle;
 use tracing::{debug, error, info, warn};
 use uuid::Uuid;
+use zeromq::SocketRecv as _;
 
 use crate::async_outcome::{
     await_result_with_timeout, recv_oneshot_with_timeout, TimedOneShot, TimedResult,
@@ -66,6 +67,61 @@ fn is_tolerated_kernel_info_reply_parse_error(error: &jupyter_zmq_client::Runtim
         }
         _ => false,
     }
+}
+
+async fn read_iopub_message_lenient(
+    iopub: &mut jupyter_zmq_client::ClientIoPubConnection,
+) -> anyhow::Result<JupyterMessage> {
+    let raw_message =
+        jupyter_zmq_client::RawMessage::from_multipart(iopub.socket.recv().await?, &iopub.mac)?;
+    jupyter_message_from_raw_lenient(raw_message)
+}
+
+fn jupyter_message_from_raw_lenient(
+    raw_message: jupyter_zmq_client::RawMessage,
+) -> anyhow::Result<JupyterMessage> {
+    let jupyter_zmq_client::RawMessage {
+        zmq_identities,
+        jparts,
+    } = raw_message;
+    if jparts.len() < 4 {
+        anyhow::bail!("insufficient Jupyter message parts: {}", jparts.len());
+    }
+
+    let header: jupyter_protocol::Header = serde_json::from_slice(&jparts[0])?;
+    let parent_header = serde_json::from_slice(&jparts[1]).ok();
+    let metadata: serde_json::Value = serde_json::from_slice(&jparts[2])?;
+    let raw_content: serde_json::Value = serde_json::from_slice(&jparts[3])?;
+    let content =
+        match JupyterMessageContent::from_type_and_content(&header.msg_type, raw_content.clone()) {
+            Ok(content) => content,
+            Err(error) if header.msg_type == "comm_msg" => {
+                warn!(
+                    "[jupyter-kernel] Treating non-standard comm_msg payload as raw: {}",
+                    error
+                );
+                JupyterMessageContent::UnknownMessage(UnknownMessage {
+                    msg_type: header.msg_type.clone(),
+                    content: raw_content,
+                })
+            }
+            Err(error) => {
+                anyhow::bail!(
+                    "Error deserializing content for msg_type `{}`: {}",
+                    header.msg_type,
+                    error
+                );
+            }
+        };
+    Ok(JupyterMessage {
+        zmq_identities,
+        header,
+        parent_header,
+        metadata,
+        content,
+        buffers: jparts.into_iter().skip(4).collect(),
+        channel: Some(Channel::IOPub),
+    })
 }
 
 #[cfg(unix)]
@@ -1411,7 +1467,7 @@ impl KernelConnection for JupyterKernel {
                 let mut stream_flushes = StreamFlushBuffer::default();
 
                 loop {
-                    match iopub.read().await {
+                    match read_iopub_message_lenient(&mut iopub).await {
                         Ok(message) => {
                             let iopub_start = std::time::Instant::now();
                             let msg_type = message.header.msg_type.clone();
@@ -2298,9 +2354,44 @@ impl KernelConnection for JupyterKernel {
                                         let _ = broadcast_tx.send(NotebookBroadcast::Comm {
                                             msg_type: message.header.msg_type.clone(),
                                             content: content.clone(),
+                                            metadata: serde_json::to_value(&message.metadata)
+                                                .unwrap_or_default(),
                                             buffers: buffers.clone(),
                                         });
                                     }
+                                }
+
+                                JupyterMessageContent::UnknownMessage(raw)
+                                    if raw.msg_type == "comm_msg" =>
+                                {
+                                    let content = raw.content.clone();
+                                    let comm_id = content
+                                        .get("comm_id")
+                                        .and_then(|value| value.as_str())
+                                        .unwrap_or_default();
+                                    if comm_targets
+                                        .get(comm_id)
+                                        .map(|target_name| {
+                                            crate::dx_blob_comm::is_dx_target(target_name)
+                                        })
+                                        .unwrap_or(false)
+                                    {
+                                        debug!(
+                                            "[dx] raw comm_msg on reserved target for comm_id={} (dropped)",
+                                            comm_id
+                                        );
+                                        continue;
+                                    }
+
+                                    let buffers: Vec<Vec<u8>> =
+                                        message.buffers.iter().map(|b| b.to_vec()).collect();
+                                    let _ = broadcast_tx.send(NotebookBroadcast::Comm {
+                                        msg_type: message.header.msg_type.clone(),
+                                        content,
+                                        metadata: serde_json::to_value(&message.metadata)
+                                            .unwrap_or_default(),
+                                        buffers,
+                                    });
                                 }
 
                                 JupyterMessageContent::CommClose(close) => {
@@ -3461,6 +3552,45 @@ mod tests {
         };
 
         assert!(!is_tolerated_kernel_info_reply_parse_error(&error));
+    }
+
+    #[test]
+    fn lenient_iopub_reader_preserves_non_standard_comm_msg_payloads() {
+        let header = serde_json::json!({
+            "msg_id": "panel-msg",
+            "username": "kernel",
+            "session": "session",
+            "date": "2026-06-20T00:00:00Z",
+            "msg_type": "comm_msg",
+            "version": "5.3"
+        });
+        let content = serde_json::json!({
+            "comm_id": "panel-comm",
+            "data": "{\"msgid\":\"patch\",\"msgtype\":\"PATCH-DOC\"}"
+        });
+        let raw = jupyter_zmq_client::RawMessage {
+            zmq_identities: Vec::new(),
+            jparts: vec![
+                Bytes::from(serde_json::to_vec(&header).expect("header json")),
+                Bytes::from(b"{}".to_vec()),
+                Bytes::from(b"{}".to_vec()),
+                Bytes::from(serde_json::to_vec(&content).expect("content json")),
+            ],
+        };
+
+        let message = jupyter_message_from_raw_lenient(raw).expect("lenient comm_msg parse");
+
+        match message.content {
+            JupyterMessageContent::UnknownMessage(raw) => {
+                assert_eq!(raw.msg_type, "comm_msg");
+                assert_eq!(raw.content["comm_id"], "panel-comm");
+                assert_eq!(
+                    raw.content["data"],
+                    "{\"msgid\":\"patch\",\"msgtype\":\"PATCH-DOC\"}"
+                );
+            }
+            other => panic!("expected raw comm_msg fallback, got {other:?}"),
+        }
     }
 
     #[test]

--- a/crates/runtimed/src/notebook_sync_server/peer_runtime_agent.rs
+++ b/crates/runtimed/src/notebook_sync_server/peer_runtime_agent.rs
@@ -2,7 +2,7 @@ use std::path::PathBuf;
 use std::sync::Arc;
 
 use notebook_protocol::connection::{send_typed_frame, FramedReader, NotebookFrameType};
-use notebook_protocol::protocol::RuntimeAgentResponse;
+use notebook_protocol::protocol::{NotebookBroadcast, RuntimeAgentResponse};
 use tracing::{debug, info, warn};
 
 use crate::async_outcome::{flatten_joined_result, JoinedResult};
@@ -380,6 +380,19 @@ pub async fn handle_runtime_agent_sync_connection<R, W>(
                                 let _ = reply.send(envelope.response);
                             } else {
                                 debug!("[notebook-sync] Agent response for unknown id: {}", envelope.id);
+                            }
+                        }
+                    }
+                    NotebookFrameType::Broadcast => {
+                        match serde_json::from_slice::<NotebookBroadcast>(&typed_frame.payload) {
+                            Ok(broadcast) => {
+                                let _ = room.broadcasts.kernel_broadcast_tx.send(broadcast);
+                            }
+                            Err(e) => {
+                                warn!(
+                                    "[notebook-sync] Agent broadcast decode failed: {}",
+                                    e
+                                );
                             }
                         }
                     }

--- a/crates/runtimed/src/runtime_agent.rs
+++ b/crates/runtimed/src/runtime_agent.rs
@@ -18,6 +18,7 @@
 //! - Frame 0x00: AutomergeSync (NotebookDoc sync, for completions context)
 //! - Frame 0x01: RuntimeAgentRequest (coordinator -> runtime agent)
 //! - Frame 0x02: RuntimeAgentResponse (runtime agent -> coordinator)
+//! - Frame 0x03: NotebookBroadcast (runtime agent -> coordinator)
 //! - Frame 0x05: RuntimeStateSync (bidirectional, carries execution queue + outputs)
 //! - Frame 0x09: CommsDocSync (bidirectional, carries widget comm state)
 //!
@@ -450,7 +451,7 @@ where
     // -- 3. Create local infrastructure -------------------------------------
 
     let blob_store = Arc::new(BlobStore::new(blob_root.clone()));
-    let (broadcast_tx, _broadcast_rx) =
+    let (broadcast_tx, mut kernel_broadcast_rx) =
         broadcast::channel::<notebook_protocol::protocol::NotebookBroadcast>(16);
     let presence = Arc::new(RwLock::new(PresenceState::new()));
     let (presence_tx, _presence_rx) = broadcast::channel::<(String, Vec<u8>)>(16);
@@ -1256,6 +1257,67 @@ where
                 }
                 if let Err(e) = handle_work_command(command, &mut kernel).await {
                     warn!("[runtime-agent] Error handling work command: {}", e);
+                }
+            }
+
+            // Forward ephemeral kernel broadcasts (completion progress,
+            // kernel-originated widget comms) to the coordinator so notebook
+            // peers can receive them through the room broadcast bus.
+            broadcast = kernel_broadcast_rx.recv() => {
+                match broadcast {
+                    Ok(broadcast) => {
+                        let encoded = match serde_json::to_vec(&broadcast) {
+                            Ok(encoded) => encoded,
+                            Err(e) => {
+                                warn!("[runtime-agent] Failed to serialize kernel broadcast: {}", e);
+                                continue;
+                            }
+                        };
+                        if let Err(e) = frame_sink.send_frame(
+                            NotebookFrameType::Broadcast,
+                            &encoded,
+                        ).await {
+                            if !transport.clean_eof_is_recoverable() {
+                                warn!("[runtime-agent] Closing after kernel broadcast send failure: {}", e);
+                                break;
+                            }
+                            warn!(
+                                "[runtime-agent] Kernel broadcast send failed: {} — reconnecting \
+                                 (kernel stays running)",
+                                e
+                            );
+                            drop(frame_source);
+                            match reconnect_after_writer_error(
+                                &transport,
+                                &mut last_recoverable_reconnect,
+                            ).await {
+                                Ok((new_source, new_sink)) => {
+                                    frame_source = new_source;
+                                    frame_sink = new_sink;
+                                    coordinator_sync_state = automerge::sync::State::new();
+                                    comms_sync_state = automerge::sync::State::new();
+                                    let _ = state_kick_tx.send(());
+                                    let _ = comms_kick_tx.send(());
+                                    info!("[runtime-agent] Reconnected after kernel broadcast send failure");
+                                    continue;
+                                }
+                                Err(reconnect_err) => {
+                                    error!(
+                                        "[runtime-agent] Reconnect failed after retries: {}",
+                                        reconnect_err
+                                    );
+                                    break;
+                                }
+                            }
+                        }
+                    }
+                    Err(broadcast::error::RecvError::Lagged(count)) => {
+                        warn!("[runtime-agent] Dropped {count} lagged kernel broadcast(s)");
+                    }
+                    Err(broadcast::error::RecvError::Closed) => {
+                        warn!("[runtime-agent] Kernel broadcast channel closed");
+                        break;
+                    }
                 }
             }
 

--- a/docs/memos/README.md
+++ b/docs/memos/README.md
@@ -26,5 +26,6 @@ plans. Time-bound transfer notes belong in `docs/handoffs/`.
 | [Arrow Manifest Durable Storage](arrow-manifest-durable-storage-design.md) | Exploration | Durable storage design framing for Arrow manifest outputs. |
 | [Execution Liveness](execution-liveness.md) | Exploration | Divergence-detection framing; not a recovery decision yet. |
 | [Markdown Plan Documents](markdown-plan-documents.md) | Exploration | First pass on a first-class Markdown/MDX document surface, comments, presence, outputs, and hosted publishing. |
+| [Panel Native Comms](panel-native-comms-design.md) | Exploration | Source-grounded shape for Panel interactivity as a Bokeh patch channel instead of generic raw comm transport. |
 | [Runtime Redaction Refresh](runtime-redaction-refresh-design.md) | Exploration | Output redaction refresh design referenced by the traceback protocol. |
 | [Environment Sandbox Policy Design](env-sandbox-policy-design.md) | Exploration | nono integration for env build sandboxing: pack namespace, machine policy, notebook hints, denial flow, MCP context. |

--- a/docs/memos/panel-native-comms-design.md
+++ b/docs/memos/panel-native-comms-design.md
@@ -1,0 +1,162 @@
+# Panel Native Comms: Bokeh Patch Channel, Not Raw Comm State
+
+**Status:** Exploration, 2026-06-20.
+
+This is a design memo, not an ADR. It records what Panel and pyviz_comms need
+for live notebook interactivity and frames the nteract-native shape. Code in the
+current PR is a compatibility path; a durable decision can graduate into an ADR
+after we pick the runtime transport boundary.
+
+Source paths below are relative to the HoloViz `panel` and `pyviz_comms`
+repositories.
+
+## Context
+
+Panel notebook rendering already produces a rich Bokeh document bundle, but live
+widgets need a bidirectional callback channel. The tempting shortcut is to
+forward raw Jupyter `comm_open` / `comm_msg` / `comm_close` frames through
+nteract. That works as a compatibility bridge, but it is not the model Panel is
+trying to expose.
+
+Panel's live unit is a Bokeh document patch stream with Python-side callback
+execution and acknowledgements. Jupyter comms are the transport Panel happens to
+use in classic Notebook, JupyterLab, Colab, and VS Code.
+
+## Source Findings
+
+Panel's `_repr_mimebundle_` path selects Jupyter comms when it detects an
+IPython kernel, creates a server comm, renders the Panel object into a Bokeh
+document, and then calls `_render_mimebundle` (`panel/viewable.py`).
+
+`_render_mimebundle` creates a Bokeh `CommManager` model with a server `comm_id`
+and the root model `plot_id`, creates a separate client comm whose open handler
+initializes the server comm, stores the `(server_comm, client_comm)` pair, and
+records `client_comm_id` on the Bokeh model (`panel/viewable.py`).
+
+`render_mimebundle` adds that `CommManager` model to the Bokeh document before
+rendering the notebook MIME bundle. It also patches the client comm's `on_open`
+handler when another library created the client comm first (`panel/io/notebook.py`).
+
+On the browser side, `panel/models/comm_manager.ts` attaches to the Bokeh
+document, filters non-syncable model changes, buffers document events, converts
+them with `document.create_json_patch`, wraps them in a Bokeh `PATCH-DOC`
+protocol message, extracts binary buffers, and sends the message over the
+client comm. It blocks/debounces until Python sends an ACK.
+
+On the Python side, `pyviz_comms.Comm._handle_msg` decodes incoming data,
+removes `comm_id`, invokes the registered callback, captures stdout/errors, and
+sends a metadata-only ACK with `msg_type: "Ready"` or `"Error"` plus the
+`comm_id`. Panel's callback path runs `CommManager.assemble` to reconstruct the
+Bokeh protocol message and applies it to the server-side Bokeh document.
+
+`pyviz_comms.JupyterCommManager` is environment glue. It maps the same logical
+operations onto classic notebook comms, JupyterLab kernel proxies, or Colab.
+The JupyterLab renderer registers a `window.PyViz.kernels[plot_id]` proxy whose
+`connectToComm` and `registerCommTarget` methods delegate to the live kernel.
+
+Panel config currently exposes `PANEL_COMMS` choices for `default`,
+`ipywidgets`, `vscode`, and `colab`; there is no public `nteract` comm backend
+selector today.
+
+## Interpretation
+
+Panel widgets are not ipywidgets traitlets. The browser does not send small
+semantic state patches like `{value: 4}` to a CRDT model. It sends Bokeh
+document patch protocol messages, and Python remains authoritative for callbacks
+that may mutate more models, emit stdout, raise exceptions, or produce follow-up
+patches.
+
+So "raw comm" is the wrong long-term abstraction, but "fully CRDT-native Panel
+state" is also too strong if it means decomposing Bokeh model mutations into
+independent Automerge fields. The safer native boundary is a typed
+Panel/Bokeh patch channel:
+
+- `PanelChannelOpen`: plot id, server comm id, client comm id, output id/cell id.
+- `PanelClientPatch`: Bokeh `PATCH-DOC` message plus buffers, from iframe to
+  kernel.
+- `PanelServerPatch`: Bokeh message fragments or reconstructed patch plus
+  buffers, from kernel to iframe.
+- `PanelAck`: Ready/Error, stdout text, traceback, and channel id.
+- `PanelChannelClose`: lifecycle cleanup.
+
+That channel can be carried through nteract's runtime model and isolated iframe
+JSON-RPC without exposing an arbitrary Jupyter comm pipe as a general feature.
+
+## Proposed Direction
+
+### 1. Keep the compatibility bridge narrow
+
+The current bridge should be treated as a PyViz/Panel compatibility lane, not a
+general raw comm transport. It should be enabled only for outputs whose MIME
+bundle requires the comm bridge, and the code should name the reason: Panel
+needs a Bokeh patch channel that currently rides Jupyter comm frames.
+
+This keeps the risk bounded while restoring the user-visible workflow:
+
+```python
+import panel as pn
+pn.extension()
+pn.widgets.FloatSlider(name="nteract-panel-smoke", start=0, end=10, value=4)
+```
+
+### 2. Add a launcher-provided Python backend
+
+A nteract Python package can implement the same small surface Panel expects from
+`pyviz_comms.CommManager`:
+
+- `get_server_comm(on_msg, id, on_error, on_stdout, on_open)`
+- `get_client_comm(on_msg, id, on_error, on_stdout, on_open)`
+- comm objects with `id`, `send`, `close`, `init`, and `_handle_msg`-equivalent
+  ACK behavior
+
+The kernel launcher would import/install this package before user code and set
+`panel.io.state.state._comm_manager` when Panel is present. Because Panel's
+public config selector does not currently include `nteract`, this is either a
+local monkeypatch or an upstreamable Panel contribution that adds a backend
+registration hook.
+
+The package should not invent a new Panel model. It should preserve Bokeh's
+protocol payloads and send them to the daemon as typed Panel channel messages.
+
+### 3. Represent Panel runtime state explicitly in nteract
+
+The daemon/runtime layer should know this is Panel/Bokeh traffic, not an
+ipywidgets model update:
+
+- keep output identity tied to the cell's displayed Panel root;
+- order `open -> patch -> ack -> close` per channel;
+- preserve binary buffers;
+- surface Python callback stdout and traceback as output-adjacent diagnostics;
+- replay only what is safe after iframe remount.
+
+The CRDT can store channel descriptors, latest rendered output identity, and
+possibly a patch log or latest Bokeh document snapshot. The Python kernel still
+executes callbacks while it is alive. Offline replay without a live kernel is a
+separate "embedded Panel" mode, not the same as live callback interactivity.
+
+## ADR Candidate
+
+If this direction holds, the ADR should decide:
+
+1. nteract will support Panel through a typed Bokeh patch channel, not a generic
+   raw Jupyter comm bridge.
+2. The initial Python integration point is a launcher-provided comm manager
+   backend that implements Panel/pyviz_comms' existing `CommManager` surface.
+3. The browser still applies patches with BokehJS/PanelJS inside the sandboxed
+   isolated iframe; nteract does not reinterpret Bokeh patches into independent
+   widget trait state.
+4. The durable CRDT record is channel/output topology and safe replay metadata,
+   while live callback execution remains kernel-authoritative.
+
+## Open Questions
+
+1. Should we propose an upstream Panel backend registration hook instead of
+   monkeypatching `state._comm_manager` in the launcher?
+2. What is the minimum replay record needed when the iframe remounts: patch log,
+   latest serialized document, or a fresh kernel-side render?
+3. How should callback stdout/errors appear in the notebook output model?
+4. Can we share a typed Bokeh patch channel with existing Bokeh output support,
+   or does Panel's two-comm setup need its own runtime channel?
+5. What is the failure behavior when the kernel restarts while a Panel output is
+   visible: frozen last state, explicit disconnected overlay, or automatic
+   re-render on next execution?

--- a/packages/runtimed/src/broadcast-types.ts
+++ b/packages/runtimed/src/broadcast-types.ts
@@ -17,6 +17,7 @@ export interface CommBroadcast {
   event: "comm";
   msg_type: string;
   content: Record<string, unknown>;
+  metadata?: Record<string, unknown>;
   buffers: number[][];
 }
 

--- a/src/components/cell/OutputArea.tsx
+++ b/src/components/cell/OutputArea.tsx
@@ -13,6 +13,7 @@ import {
 import {
   anyOutputNeedsIsolation,
   CommBridgeManager,
+  hasCommBridgeOutputs,
   hasWidgetOutputs,
   type IframeToParentMessage,
   IsolatedFrame,
@@ -691,6 +692,7 @@ function OutputAreaSingle({
 
   // Check if we have widgets and should set up comm bridge
   const hasWidgets = hasWidgetOutputs(outputs, priority);
+  const hasCommBridge = hasCommBridgeOutputs(outputs, priority);
   const hasSiftOutputs = outputs.some((output) => outputUsesSift(output, priority));
   // Sift tables and Vega/Altair charts must own the wheel once engaged so the
   // page does not steal pan/zoom (the source of unintended Altair zoom while
@@ -698,7 +700,7 @@ function OutputAreaSingle({
   const hasWheelOwningOutputs = outputs.some((output) =>
     outputUsesWheelOwningFrame(output, priority),
   );
-  const shouldUseBridge = shouldIsolate && hasWidgets && widgetContext !== null;
+  const shouldUseBridge = shouldIsolate && hasCommBridge && widgetContext !== null;
   const shouldUseScrollPassthroughFrame =
     shouldIsolate &&
     !focused &&
@@ -867,7 +869,7 @@ function OutputAreaSingle({
       // previous outputs snapshot will bail out after it awaits.
       const gen = ++renderGenRef.current;
 
-      // Set up comm bridge if we have widgets and widget context
+      // Set up comm bridge if the iframe may emit widget or raw Panel comms.
       if (shouldUseBridge && widgetContext && !bridgeRef.current) {
         bridgeRef.current = new CommBridgeManager({
           frame: frameRef.current,
@@ -875,6 +877,9 @@ function OutputAreaSingle({
           sendUpdate: widgetContext.sendUpdate,
           sendCustom: widgetContext.sendCustom,
           closeComm: widgetContext.closeComm,
+          openRawComm: widgetContext.openRawComm,
+          sendRawComm: widgetContext.sendRawComm,
+          closeRawComm: widgetContext.closeRawComm,
         });
       }
 

--- a/src/components/isolated/__tests__/comm-bridge-manager.test.ts
+++ b/src/components/isolated/__tests__/comm-bridge-manager.test.ts
@@ -7,6 +7,7 @@
  */
 
 import { beforeEach, describe, expect, it, vi } from "vite-plus/test";
+import { RAW_COMM_BROADCAST_MARKER } from "@/components/widgets/comm-changes-store-bridge";
 import type { WidgetModel, WidgetStore } from "@/components/widgets/widget-store";
 import { CommBridgeManager, createCommBridgeManager } from "../comm-bridge-manager";
 import type { IsolatedFrameHandle } from "../isolated-frame";
@@ -58,6 +59,10 @@ function createMockStore(initialModels: Map<string, WidgetModel> = new Map()): {
   };
 }
 
+async function flushQueuedPromises(): Promise<void> {
+  await new Promise((resolve) => setTimeout(resolve, 0));
+}
+
 // Helper to create a mock IsolatedFrameHandle
 function createMockFrame(): {
   frame: IsolatedFrameHandle;
@@ -104,6 +109,9 @@ describe("CommBridgeManager", () => {
   let sendUpdate: ReturnType<typeof vi.fn>;
   let sendCustom: ReturnType<typeof vi.fn>;
   let closeComm: ReturnType<typeof vi.fn>;
+  let openRawComm: ReturnType<typeof vi.fn>;
+  let sendRawComm: ReturnType<typeof vi.fn>;
+  let closeRawComm: ReturnType<typeof vi.fn>;
 
   beforeEach(() => {
     mockStore = createMockStore();
@@ -111,6 +119,9 @@ describe("CommBridgeManager", () => {
     sendUpdate = vi.fn().mockResolvedValue(undefined);
     sendCustom = vi.fn();
     closeComm = vi.fn();
+    openRawComm = vi.fn();
+    sendRawComm = vi.fn();
+    closeRawComm = vi.fn();
     vi.clearAllMocks();
   });
 
@@ -121,6 +132,9 @@ describe("CommBridgeManager", () => {
       sendUpdate,
       sendCustom,
       closeComm,
+      openRawComm,
+      sendRawComm,
+      closeRawComm,
     });
   }
 
@@ -392,6 +406,97 @@ describe("CommBridgeManager", () => {
 
       expect(mockStore.store.deleteModel).toHaveBeenCalledWith("comm-1");
       expect(closeComm).toHaveBeenCalledWith("comm-1");
+    });
+
+    it("forwards raw comm messages to kernel callbacks", async () => {
+      const manager = createManager();
+
+      manager.handleIframeMessage({
+        type: "raw_comm_open",
+        payload: {
+          commId: "pyviz-client",
+          targetName: "pyviz-client",
+          data: "open-payload",
+          metadata: { opened: true },
+        },
+      });
+      manager.handleIframeMessage({
+        type: "raw_comm_msg",
+        payload: {
+          commId: "pyviz-client",
+          data: "patch-json",
+          metadata: { msg_type: "Ready" },
+        },
+      });
+      manager.handleIframeMessage({
+        type: "raw_comm_close",
+        payload: {
+          commId: "pyviz-client",
+          data: { reason: "done" },
+          metadata: { closed: true },
+        },
+      });
+
+      await flushQueuedPromises();
+
+      expect(openRawComm).toHaveBeenCalledWith(
+        "pyviz-client",
+        "pyviz-client",
+        "open-payload",
+        { opened: true },
+        undefined,
+      );
+      expect(sendRawComm).toHaveBeenCalledWith(
+        "pyviz-client",
+        "patch-json",
+        {
+          msg_type: "Ready",
+        },
+        undefined,
+      );
+      expect(closeRawComm).toHaveBeenCalledWith(
+        "pyviz-client",
+        { reason: "done" },
+        { closed: true },
+        undefined,
+      );
+    });
+
+    it("serializes raw comm messages per comm id", async () => {
+      const calls: string[] = [];
+      let resolveOpen: (() => void) | null = null;
+      openRawComm.mockImplementation(
+        () =>
+          new Promise<void>((resolve) => {
+            calls.push("open:start");
+            resolveOpen = () => {
+              calls.push("open:end");
+              resolve();
+            };
+          }),
+      );
+      sendRawComm.mockImplementation(() => {
+        calls.push("msg");
+      });
+
+      const manager = createManager();
+      manager.handleIframeMessage({
+        type: "raw_comm_open",
+        payload: { commId: "panel-client", targetName: "panel-client", data: {}, metadata: {} },
+      });
+      manager.handleIframeMessage({
+        type: "raw_comm_msg",
+        payload: { commId: "panel-client", data: "PATCH-DOC", metadata: {} },
+      });
+
+      await flushQueuedPromises();
+      expect(calls).toEqual(["open:start"]);
+
+      resolveOpen?.();
+      await flushQueuedPromises();
+
+      expect(calls).toEqual(["open:start", "open:end", "msg"]);
+      expect(sendRawComm).toHaveBeenCalledWith("panel-client", "PATCH-DOC", {}, undefined);
     });
 
     it("ignores unknown message types", () => {
@@ -685,6 +790,119 @@ describe("CommBridgeManager", () => {
       expect(commMsg).toBeDefined();
       // The buffer should be converted to ArrayBuffer
       expect(commMsg.payload.buffers?.[0]).toBe(buffer);
+    });
+
+    it("forwards marked raw comm broadcasts with metadata", () => {
+      const models = new Map<string, WidgetModel>([
+        ["pyviz-server", createModel("pyviz-server", {}, "", "pyviz-server")],
+      ]);
+      const storeWithModels = createMockStore(models);
+      const manager = new CommBridgeManager({
+        frame: mockFrame.frame,
+        store: storeWithModels.store,
+        sendUpdate,
+        sendCustom,
+        closeComm,
+      });
+
+      manager.handleIframeMessage({ type: "widget_ready" });
+
+      const subscribeCall = (
+        storeWithModels.store.subscribeToCustomMessage as ReturnType<typeof vi.fn>
+      ).mock.calls[0];
+      const callback = subscribeCall[1] as (
+        content: Record<string, unknown>,
+        buffers?: DataView[],
+      ) => void;
+      const buffer = new ArrayBuffer(4);
+
+      callback(
+        {
+          [RAW_COMM_BROADCAST_MARKER]: true,
+          data: "PATCH-DOC",
+          metadata: { msg_type: "Ready" },
+        },
+        [new DataView(buffer)],
+      );
+
+      const commMsg = mockFrame.sendCalls.find(
+        (msg: unknown) =>
+          (msg as { type: string; payload?: { method: string } }).type === "comm_msg" &&
+          (msg as { payload: { method: string } }).payload.method === "raw",
+      ) as {
+        payload: {
+          commId: string;
+          data: unknown;
+          metadata?: Record<string, unknown>;
+          buffers?: ArrayBuffer[];
+        };
+      };
+
+      expect(commMsg).toBeDefined();
+      expect(commMsg.payload.commId).toBe("pyviz-server");
+      expect(commMsg.payload.data).toBe("PATCH-DOC");
+      expect(commMsg.payload.metadata).toEqual({ msg_type: "Ready" });
+      expect(commMsg.payload.buffers?.[0]).toBe(buffer);
+    });
+
+    it("subscribes raw comm ids without requiring WidgetStore models", async () => {
+      const manager = createManager();
+      manager.handleIframeMessage({ type: "widget_ready" });
+
+      manager.handleIframeMessage({
+        type: "raw_comm_open",
+        payload: {
+          commId: "panel-client",
+          targetName: "panel-client",
+          data: {},
+          metadata: {},
+        },
+      });
+
+      await flushQueuedPromises();
+      expect(openRawComm).toHaveBeenCalledWith("panel-client", "panel-client", {}, {}, undefined);
+      expect(mockStore.store.subscribeToCustomMessage).toHaveBeenCalledWith(
+        "panel-client",
+        expect.any(Function),
+      );
+
+      const listeners = mockStore.customMessageListeners.get("panel-client");
+      expect(listeners?.size).toBe(1);
+      listeners?.forEach((listener) =>
+        listener({
+          [RAW_COMM_BROADCAST_MARKER]: true,
+          data: {},
+          metadata: { msg_type: "Ready", comm_id: "panel-client" },
+        }),
+      );
+
+      const commMsg = mockFrame.sendCalls.find(
+        (msg: unknown) =>
+          (msg as { type: string; payload?: { method: string } }).type === "comm_msg" &&
+          (msg as { payload: { method: string } }).payload.method === "raw",
+      ) as {
+        payload: {
+          commId: string;
+          data: unknown;
+          metadata?: Record<string, unknown>;
+        };
+      };
+
+      expect(commMsg).toBeDefined();
+      expect(commMsg.payload.commId).toBe("panel-client");
+      expect(commMsg.payload.metadata).toEqual({
+        msg_type: "Ready",
+        comm_id: "panel-client",
+      });
+
+      manager.handleIframeMessage({
+        type: "raw_comm_close",
+        payload: { commId: "panel-client", data: {}, metadata: {} },
+      });
+
+      await flushQueuedPromises();
+      expect(closeRawComm).toHaveBeenCalledWith("panel-client", {}, {}, undefined);
+      expect(mockStore.customMessageListeners.get("panel-client")?.size).toBe(0);
     });
 
     it("handles undefined buffers gracefully", () => {

--- a/src/components/isolated/__tests__/frame-bridge.test.ts
+++ b/src/components/isolated/__tests__/frame-bridge.test.ts
@@ -24,6 +24,9 @@ describe("isIframeMessage", () => {
     "widget_ready",
     "widget_comm_msg",
     "widget_comm_close",
+    "raw_comm_open",
+    "raw_comm_msg",
+    "raw_comm_close",
   ] as const;
 
   it.each(validMessageTypes)('returns true for valid message type "%s"', (type) => {
@@ -125,6 +128,9 @@ describe("message type whitelist completeness", () => {
       "widget_ready",
       "widget_comm_msg",
       "widget_comm_close",
+      "raw_comm_open",
+      "raw_comm_msg",
+      "raw_comm_close",
       "search_results",
     ];
 

--- a/src/components/isolated/__tests__/output-lane-policy.test.ts
+++ b/src/components/isolated/__tests__/output-lane-policy.test.ts
@@ -8,6 +8,7 @@ import {
 } from "@/lib/markdown-projection";
 import {
   anyOutputNeedsIsolation,
+  hasCommBridgeOutputs,
   hasWidgetOutputs,
   outputAllowsScrollPassthrough,
   outputSegmentLane,
@@ -279,6 +280,8 @@ describe("output lane policy", () => {
     ]);
     expect(outputUsesPanel(outputs[1])).toBe(true);
     expect(outputUsesPanel(outputs[4])).toBe(true);
+    expect(hasWidgetOutputs(outputs)).toBe(false);
+    expect(hasCommBridgeOutputs(outputs)).toBe(true);
     expect(outputUsesWheelOwningFrame(outputs[4])).toBe(true);
     expect(outputs.map((output) => outputAllowsScrollPassthrough(output))).toEqual([
       true,

--- a/src/components/isolated/comm-bridge-manager.ts
+++ b/src/components/isolated/comm-bridge-manager.ts
@@ -1,4 +1,5 @@
 import type { WidgetStore } from "@/components/widgets/widget-store";
+import { RAW_COMM_BROADCAST_MARKER } from "@/components/widgets/comm-changes-store-bridge";
 import type {
   CommCloseMessage,
   CommMsgMessage,
@@ -34,6 +35,28 @@ type SendCustom = (
 
 type CloseComm = (commId: string) => void;
 
+type OpenRawComm = (
+  commId: string,
+  targetName: string,
+  data?: unknown,
+  metadata?: Record<string, unknown>,
+  buffers?: ArrayBuffer[],
+) => void | Promise<void>;
+
+type SendRawComm = (
+  commId: string,
+  data: unknown,
+  metadata?: Record<string, unknown>,
+  buffers?: ArrayBuffer[],
+) => void | Promise<void>;
+
+type CloseRawComm = (
+  commId: string,
+  data?: unknown,
+  metadata?: Record<string, unknown>,
+  buffers?: ArrayBuffer[],
+) => void | Promise<void>;
+
 interface CommBridgeManagerOptions {
   /** The isolated frame handle for sending messages */
   frame: IsolatedFrameHandle;
@@ -45,6 +68,12 @@ interface CommBridgeManagerOptions {
   sendCustom: SendCustom;
   /** Function to close a comm with kernel */
   closeComm: CloseComm;
+  /** Function to open a raw Jupyter comm with kernel */
+  openRawComm?: OpenRawComm;
+  /** Function to send a raw Jupyter comm_msg to kernel */
+  sendRawComm?: SendRawComm;
+  /** Function to close a raw Jupyter comm with kernel */
+  closeRawComm?: CloseRawComm;
 }
 
 /**
@@ -62,6 +91,9 @@ export class CommBridgeManager {
   private sendUpdateToKernel: SendUpdate;
   private sendCustomToKernel: SendCustom;
   private closeCommWithKernel: CloseComm;
+  private openRawCommWithKernel: OpenRawComm;
+  private sendRawCommToKernel: SendRawComm;
+  private closeRawCommWithKernel: CloseRawComm;
 
   private isWidgetReady = false;
   private messageBuffer: Array<CommOpenMessage | CommMsgMessage | CommCloseMessage> = [];
@@ -79,12 +111,20 @@ export class CommBridgeManager {
   // Track custom message subscriptions for each model
   private customMessageUnsubscribers = new Map<string, () => void>();
 
+  // Keep raw comm shell messages ordered per comm id. Panel opens a client
+  // comm and immediately sends its initial PATCH-DOC; the kernel must see
+  // comm_open before comm_msg so PyViz can install the Python message handler.
+  private rawCommQueues = new Map<string, Promise<void>>();
+
   constructor(options: CommBridgeManagerOptions) {
     this.frame = options.frame;
     this.store = options.store;
     this.sendUpdateToKernel = options.sendUpdate;
     this.sendCustomToKernel = options.sendCustom;
     this.closeCommWithKernel = options.closeComm;
+    this.openRawCommWithKernel = options.openRawComm ?? (() => {});
+    this.sendRawCommToKernel = options.sendRawComm ?? (() => {});
+    this.closeRawCommWithKernel = options.closeRawComm ?? (() => {});
 
     // Subscribe to store changes to forward to iframe
     this.storeUnsubscribe = this.store.subscribe(() => {
@@ -115,6 +155,43 @@ export class CommBridgeManager {
 
       case "widget_comm_close":
         this.handleWidgetCommClose(message.payload);
+        break;
+
+      case "raw_comm_open":
+        this.subscribeToModelCustomMessages(message.payload.commId);
+        this.enqueueRawCommMessage(message.payload.commId, () =>
+          this.openRawCommWithKernel(
+            message.payload.commId,
+            message.payload.targetName,
+            message.payload.data,
+            message.payload.metadata,
+            message.payload.buffers,
+          ),
+        );
+        break;
+
+      case "raw_comm_msg":
+        this.subscribeToModelCustomMessages(message.payload.commId);
+        this.enqueueRawCommMessage(message.payload.commId, () =>
+          this.sendRawCommToKernel(
+            message.payload.commId,
+            message.payload.data,
+            message.payload.metadata,
+            message.payload.buffers,
+          ),
+        );
+        break;
+
+      case "raw_comm_close":
+        this.enqueueRawCommMessage(message.payload.commId, () =>
+          this.closeRawCommWithKernel(
+            message.payload.commId,
+            message.payload.data,
+            message.payload.metadata,
+            message.payload.buffers,
+          ),
+        );
+        this.unsubscribeFromModelCustomMessages(message.payload.commId);
         break;
     }
   }
@@ -171,6 +248,32 @@ export class CommBridgeManager {
         method,
         data,
         bufferPaths: opts.bufferPaths,
+        buffers: opts.buffers,
+      },
+    };
+
+    if (this.isWidgetReady) {
+      this.frame.send(msg);
+    } else {
+      this.messageBuffer.push(msg);
+    }
+  }
+
+  /**
+   * Forward a raw Jupyter comm_msg to the iframe.
+   */
+  sendRawCommMsg(
+    commId: string,
+    data: unknown,
+    opts: { metadata?: Record<string, unknown>; buffers?: ArrayBuffer[] } = {},
+  ): void {
+    const msg: CommMsgMessage = {
+      type: "comm_msg",
+      payload: {
+        commId,
+        method: "raw",
+        data,
+        metadata: opts.metadata,
         buffers: opts.buffers,
       },
     };
@@ -288,24 +391,25 @@ export class CommBridgeManager {
   private handleWidgetCommMsg(payload: {
     commId: string;
     method: "update" | "custom";
-    data: Record<string, unknown>;
+    data: unknown;
     bufferPaths?: string[][];
     buffers?: ArrayBuffer[];
   }): void {
     const { commId, method, data, buffers } = payload;
 
     if (method === "update") {
+      const patch = asRecord(data);
       // Set flag to prevent echoing this update back to iframe
       this.isProcessingIframeUpdate = true;
       try {
         // Update parent store first (so UI stays in sync). Binary state leaves
         // travel inside `data` and are extracted by WidgetUpdateManager.
-        this.store.updateModel(commId, data);
+        this.store.updateModel(commId, patch);
         // Update our tracked state
         const current = this.previousState.get(commId) ?? {};
-        this.previousState.set(commId, this.cloneStateSnapshot({ ...current, ...data }));
+        this.previousState.set(commId, this.cloneStateSnapshot({ ...current, ...patch }));
         // Then forward to kernel
-        void this.sendUpdateToKernel(commId, data).catch((error: unknown) => {
+        void this.sendUpdateToKernel(commId, patch).catch((error: unknown) => {
           console.error("[widgets] failed to persist iframe widget state update:", error);
         });
       } finally {
@@ -313,7 +417,7 @@ export class CommBridgeManager {
       }
     } else if (method === "custom") {
       // Custom messages go directly to kernel (no store update)
-      this.sendCustomToKernel(commId, data, buffers);
+      this.sendCustomToKernel(commId, asRecord(data), buffers);
     }
   }
 
@@ -392,6 +496,12 @@ export class CommBridgeManager {
     const unsubscribe = this.store.subscribeToCustomMessage(commId, (content, buffers) => {
       // Convert DataView[] to ArrayBuffer[] for postMessage
       const arrayBuffers = buffers?.map((dv) => dv.buffer as ArrayBuffer);
+      if (content[RAW_COMM_BROADCAST_MARKER] === true) {
+        const data = content.data;
+        const metadata = asRecord(content.metadata);
+        this.sendRawCommMsg(commId, data, { metadata, buffers: arrayBuffers });
+        return;
+      }
       // Forward custom message to iframe
       this.sendCommMsg(commId, "custom", content, { buffers: arrayBuffers });
     });
@@ -408,6 +518,21 @@ export class CommBridgeManager {
       unsubscribe();
       this.customMessageUnsubscribers.delete(commId);
     }
+  }
+
+  private enqueueRawCommMessage(commId: string, task: () => void | Promise<void>): Promise<void> {
+    const previous = this.rawCommQueues.get(commId) ?? Promise.resolve();
+    const runTask = () => Promise.resolve(task());
+    const next = previous.then(runTask, runTask).catch((error: unknown) => {
+      console.error("[widgets] failed to forward raw comm message:", error);
+    });
+    const queued = next.finally(() => {
+      if (this.rawCommQueues.get(commId) === queued) {
+        this.rawCommQueues.delete(commId);
+      }
+    });
+    this.rawCommQueues.set(commId, queued);
+    return next;
   }
 
   /**
@@ -468,4 +593,8 @@ export class CommBridgeManager {
  */
 export function createCommBridgeManager(options: CommBridgeManagerOptions): CommBridgeManager {
   return new CommBridgeManager(options);
+}
+
+function asRecord(value: unknown): Record<string, unknown> {
+  return value !== null && typeof value === "object" ? (value as Record<string, unknown>) : {};
 }

--- a/src/components/isolated/frame-bridge.ts
+++ b/src/components/isolated/frame-bridge.ts
@@ -160,10 +160,12 @@ export interface CommMsgMessage {
   payload: {
     /** Comm ID of the widget */
     commId: string;
-    /** Message method: "update" or "custom" */
-    method: "update" | "custom";
-    /** State patch (for update) or custom content (for custom) */
-    data: Record<string, unknown>;
+    /** Message method: widget "update"/"custom" or raw Jupyter comm payload */
+    method: "update" | "custom" | "raw";
+    /** State patch/custom content for widgets, raw Jupyter payload for raw comms. */
+    data: unknown;
+    /** Jupyter comm message metadata for raw comm payloads. */
+    metadata?: Record<string, unknown>;
     /**
      * JSON paths in `data` where binary blob URLs live. Only populated for
      * `method: "update"` — custom-method messages carry their own transient
@@ -456,6 +458,48 @@ export interface WidgetCommCloseMessage {
   };
 }
 
+/**
+ * Iframe opened a raw Jupyter comm.
+ * Used by renderer protocols such as PyViz/Panel that do not use the
+ * ipywidgets state-store method wrapper.
+ */
+export interface RawCommOpenMessage {
+  type: "raw_comm_open";
+  payload: {
+    commId: string;
+    targetName: string;
+    data?: unknown;
+    metadata?: Record<string, unknown>;
+    buffers?: ArrayBuffer[];
+  };
+}
+
+/**
+ * Iframe sent a raw Jupyter comm_msg payload.
+ */
+export interface RawCommMsgMessage {
+  type: "raw_comm_msg";
+  payload: {
+    commId: string;
+    data: unknown;
+    metadata?: Record<string, unknown>;
+    buffers?: ArrayBuffer[];
+  };
+}
+
+/**
+ * Iframe closed a raw Jupyter comm.
+ */
+export interface RawCommCloseMessage {
+  type: "raw_comm_close";
+  payload: {
+    commId: string;
+    data?: unknown;
+    metadata?: Record<string, unknown>;
+    buffers?: ArrayBuffer[];
+  };
+}
+
 // --- Global Find: Iframe → Parent ---
 
 /**
@@ -488,6 +532,9 @@ export type IframeToParentMessage =
   | WidgetReadyMessage
   | WidgetCommMsgMessage
   | WidgetCommCloseMessage
+  | RawCommOpenMessage
+  | RawCommMsgMessage
+  | RawCommCloseMessage
   | SearchResultsMessage;
 
 // --- Utility Types ---
@@ -525,6 +572,9 @@ export function isIframeMessage(data: unknown): data is IframeToParentMessage {
       "widget_ready",
       "widget_comm_msg",
       "widget_comm_close",
+      "raw_comm_open",
+      "raw_comm_msg",
+      "raw_comm_close",
       "search_results",
     ].includes(msg.type)
   );

--- a/src/components/isolated/index.ts
+++ b/src/components/isolated/index.ts
@@ -103,6 +103,7 @@ export {
 export type { OutputFrameSizingPolicy } from "./output-frame-sizing";
 export {
   anyOutputNeedsIsolation,
+  hasCommBridgeOutputs,
   hasWidgetOutputs,
   isScrollPassthroughMimeType,
   isSiftMimeType,
@@ -112,6 +113,7 @@ export {
   outputUsesSift,
   outputUsesVega,
   outputUsesWheelOwningFrame,
+  outputUsesCommBridge,
   outputUsesWidget,
   segmentedOutputLanes,
   selectedOutputMimeType,

--- a/src/components/isolated/isolated-frame-runtime.ts
+++ b/src/components/isolated/isolated-frame-runtime.ts
@@ -24,6 +24,9 @@ import {
   NTERACT_MOUSE_DOWN,
   NTERACT_MOUSE_UP,
   NTERACT_PING,
+  NTERACT_RAW_COMM_CLOSE,
+  NTERACT_RAW_COMM_MSG,
+  NTERACT_RAW_COMM_OPEN,
   NTERACT_RENDER_BATCH,
   NTERACT_RENDER_COMPLETE,
   NTERACT_RENDER_OUTPUT,
@@ -660,6 +663,24 @@ export class IsolatedFrameRuntime {
     transport.onNotification(NTERACT_WIDGET_COMM_CLOSE, (params) => {
       this.callbacks.onMessage({
         type: "widget_comm_close",
+        payload: params,
+      } as IframeToParentMessage);
+    });
+    transport.onNotification(NTERACT_RAW_COMM_OPEN, (params) => {
+      this.callbacks.onMessage({
+        type: "raw_comm_open",
+        payload: params,
+      } as IframeToParentMessage);
+    });
+    transport.onNotification(NTERACT_RAW_COMM_MSG, (params) => {
+      this.callbacks.onMessage({
+        type: "raw_comm_msg",
+        payload: params,
+      } as IframeToParentMessage);
+    });
+    transport.onNotification(NTERACT_RAW_COMM_CLOSE, (params) => {
+      this.callbacks.onMessage({
+        type: "raw_comm_close",
         payload: params,
       } as IframeToParentMessage);
     });

--- a/src/components/isolated/output-lane-policy.ts
+++ b/src/components/isolated/output-lane-policy.ts
@@ -167,6 +167,13 @@ export function outputUsesWidget(
   return mimeType === "application/vnd.jupyter.widget-view+json";
 }
 
+export function outputUsesCommBridge(
+  output: JupyterOutput,
+  priority: readonly string[] = DEFAULT_PRIORITY,
+): boolean {
+  return outputUsesWidget(output, priority) || outputUsesPanel(output, priority);
+}
+
 function outputMarkdownCanRenderInHost(
   output: JupyterOutput,
   priority: readonly string[] = DEFAULT_PRIORITY,
@@ -210,6 +217,13 @@ export function hasWidgetOutputs(
   priority: readonly string[] = DEFAULT_PRIORITY,
 ): boolean {
   return outputs.some((output) => outputUsesWidget(output, priority));
+}
+
+export function hasCommBridgeOutputs(
+  outputs: readonly JupyterOutput[],
+  priority: readonly string[] = DEFAULT_PRIORITY,
+): boolean {
+  return outputs.some((output) => outputUsesCommBridge(output, priority));
 }
 
 export function outputSegmentLane(

--- a/src/components/isolated/rpc-methods.ts
+++ b/src/components/isolated/rpc-methods.ts
@@ -51,6 +51,9 @@ export const NTERACT_ERROR = "nteract/error" as const;
 export const NTERACT_WIDGET_READY = "nteract/widgetReady" as const;
 export const NTERACT_WIDGET_COMM_MSG = "nteract/widgetCommMsg" as const;
 export const NTERACT_WIDGET_COMM_CLOSE = "nteract/widgetCommClose" as const;
+export const NTERACT_RAW_COMM_OPEN = "nteract/rawCommOpen" as const;
+export const NTERACT_RAW_COMM_MSG = "nteract/rawCommMsg" as const;
+export const NTERACT_RAW_COMM_CLOSE = "nteract/rawCommClose" as const;
 export const NTERACT_WIDGET_UPDATE = "nteract/widgetUpdate" as const;
 export const NTERACT_EVAL_RESULT = "nteract/evalResult" as const;
 export const NTERACT_PONG = "nteract/pong" as const;
@@ -134,8 +137,9 @@ export interface NteractCommOpenParams {
 
 export interface NteractCommMsgParams {
   commId: string;
-  method: "update" | "custom";
-  data: Record<string, unknown>;
+  method: "update" | "custom" | "raw";
+  data: unknown;
+  metadata?: Record<string, unknown>;
   bufferPaths?: string[][];
   buffers?: ArrayBuffer[];
 }
@@ -175,6 +179,28 @@ export interface NteractWidgetCommMsgParams {
 
 export interface NteractWidgetCommCloseParams {
   commId: string;
+}
+
+export interface NteractRawCommOpenParams {
+  commId: string;
+  targetName: string;
+  data?: unknown;
+  metadata?: Record<string, unknown>;
+  buffers?: ArrayBuffer[];
+}
+
+export interface NteractRawCommMsgParams {
+  commId: string;
+  data: unknown;
+  metadata?: Record<string, unknown>;
+  buffers?: ArrayBuffer[];
+}
+
+export interface NteractRawCommCloseParams {
+  commId: string;
+  data?: unknown;
+  metadata?: Record<string, unknown>;
+  buffers?: ArrayBuffer[];
 }
 
 export interface NteractWidgetUpdateParams {

--- a/src/components/widgets/__tests__/comm-changes-store-bridge.test.ts
+++ b/src/components/widgets/__tests__/comm-changes-store-bridge.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "vitest";
 import {
   applyWidgetCommBroadcastToStore,
   applyWidgetCommChangesToStore,
+  RAW_COMM_BROADCAST_MARKER,
 } from "../comm-changes-store-bridge";
 import { createWidgetStore } from "../widget-store";
 
@@ -148,6 +149,34 @@ describe("comm changes store bridge", () => {
 
     expect(messages).toHaveLength(1);
     expect(messages[0].content).toEqual({ event: "click" });
+    expect(messages[0].buffers?.[0].byteLength).toBe(3);
+  });
+
+  it("routes non-custom comm broadcasts as raw messages with metadata", () => {
+    const store = createWidgetStore();
+    const messages: Array<{ content: Record<string, unknown>; buffers?: DataView[] }> = [];
+
+    store.subscribeToCustomMessage("panel-comm", (content, buffers) => {
+      messages.push({ content, buffers });
+    });
+
+    applyWidgetCommBroadcastToStore(store, {
+      event: "comm",
+      msg_type: "comm_msg",
+      content: {
+        comm_id: "panel-comm",
+        data: "PATCH-DOC",
+      },
+      metadata: { msg_type: "Ready" },
+      buffers: [[4, 5, 6]],
+    });
+
+    expect(messages).toHaveLength(1);
+    expect(messages[0].content).toEqual({
+      [RAW_COMM_BROADCAST_MARKER]: true,
+      data: "PATCH-DOC",
+      metadata: { msg_type: "Ready" },
+    });
     expect(messages[0].buffers?.[0].byteLength).toBe(3);
   });
 });

--- a/src/components/widgets/comm-changes-store-bridge.ts
+++ b/src/components/widgets/comm-changes-store-bridge.ts
@@ -1,6 +1,8 @@
 import type { CommBroadcast, CommChanges } from "runtimed";
 import type { WidgetStore } from "./widget-store";
 
+export const RAW_COMM_BROADCAST_MARKER = "__nteract_raw_comm_broadcast__";
+
 export interface ApplyWidgetCommChangesOptions {
   /**
    * Return a filtered patch after suppressing optimistic CRDT echoes.
@@ -79,15 +81,30 @@ export function applyWidgetCommBroadcastToStore(
   store: WidgetStore,
   broadcast: CommBroadcast,
 ): void {
-  const data = broadcast.content.data as Record<string, unknown> | undefined;
-  if (data?.method !== "custom") return;
-
+  const data = broadcast.content.data;
   const commId = broadcast.content.comm_id;
   if (typeof commId !== "string") return;
 
-  const inner = (data.content as Record<string, unknown> | undefined) ?? {};
   const arrayBuffers = broadcast.buffers?.map((arr: number[]) => new Uint8Array(arr).buffer);
-  store.emitCustomMessage(commId, inner, arrayBuffers);
+  if (isRecord(data) && data.method === "custom") {
+    const inner = isRecord(data.content) ? data.content : {};
+    store.emitCustomMessage(commId, inner, arrayBuffers);
+    return;
+  }
+
+  store.emitCustomMessage(
+    commId,
+    {
+      [RAW_COMM_BROADCAST_MARKER]: true,
+      data: data ?? {},
+      metadata: broadcast.metadata ?? {},
+    },
+    arrayBuffers,
+  );
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return value !== null && typeof value === "object";
 }
 
 function widgetStateWithMetadata(comm: {

--- a/src/components/widgets/use-comm-router.ts
+++ b/src/components/widgets/use-comm-router.ts
@@ -43,15 +43,7 @@ interface OutgoingJupyterCommMessage {
   header: JupyterMessageHeader;
   parent_header: null;
   metadata: Record<string, unknown>;
-  content: {
-    comm_id: string;
-    data?: {
-      state?: Record<string, unknown>;
-      method?: string;
-      content?: Record<string, unknown>;
-      buffer_paths: string[][];
-    };
-  };
+  content: Record<string, unknown>;
   buffers: ArrayBuffer[];
   channel: string;
 }
@@ -59,7 +51,7 @@ interface OutgoingJupyterCommMessage {
 /**
  * Function type for sending messages to the kernel.
  */
-export type SendMessage = (msg: OutgoingJupyterCommMessage) => void;
+export type SendMessage = (msg: OutgoingJupyterCommMessage) => void | Promise<void>;
 
 export interface UseCommRouterOptions {
   /** Function to send messages to the kernel (used for custom messages and comm_close). */
@@ -79,6 +71,28 @@ export interface UseCommRouterReturn {
   sendCustom: (commId: string, content: Record<string, unknown>, buffers?: ArrayBuffer[]) => void;
   /** Close a comm channel */
   closeComm: (commId: string) => void;
+  /** Open a raw Jupyter comm channel. */
+  openRawComm: (
+    commId: string,
+    targetName: string,
+    data?: unknown,
+    metadata?: Record<string, unknown>,
+    buffers?: ArrayBuffer[],
+  ) => Promise<void>;
+  /** Send a raw Jupyter comm_msg payload. */
+  sendRawComm: (
+    commId: string,
+    data: unknown,
+    metadata?: Record<string, unknown>,
+    buffers?: ArrayBuffer[],
+  ) => Promise<void>;
+  /** Close a raw Jupyter comm channel. */
+  closeRawComm: (
+    commId: string,
+    data?: unknown,
+    metadata?: Record<string, unknown>,
+    buffers?: ArrayBuffer[],
+  ) => Promise<void>;
 }
 
 // Session ID for this frontend instance (stable across messages)
@@ -131,6 +145,68 @@ function createCloseMessage(commId: string, username: string): OutgoingJupyterCo
   };
 }
 
+function createRawOpenMessage(
+  commId: string,
+  targetName: string,
+  data: unknown,
+  metadata: Record<string, unknown> | undefined,
+  buffers: ArrayBuffer[] | undefined,
+  username: string,
+): OutgoingJupyterCommMessage {
+  return {
+    header: createHeader("comm_open", username),
+    parent_header: null,
+    metadata: metadata ?? {},
+    content: {
+      comm_id: commId,
+      target_name: targetName,
+      data: data ?? {},
+    },
+    buffers: buffers ?? [],
+    channel: "shell",
+  };
+}
+
+function createRawMessage(
+  commId: string,
+  data: unknown,
+  metadata: Record<string, unknown> | undefined,
+  buffers: ArrayBuffer[] | undefined,
+  username: string,
+): OutgoingJupyterCommMessage {
+  return {
+    header: createHeader("comm_msg", username),
+    parent_header: null,
+    metadata: metadata ?? {},
+    content: {
+      comm_id: commId,
+      data,
+    },
+    buffers: buffers ?? [],
+    channel: "shell",
+  };
+}
+
+function createRawCloseMessage(
+  commId: string,
+  data: unknown,
+  metadata: Record<string, unknown> | undefined,
+  buffers: ArrayBuffer[] | undefined,
+  username: string,
+): OutgoingJupyterCommMessage {
+  return {
+    header: createHeader("comm_close", username),
+    parent_header: null,
+    metadata: metadata ?? {},
+    content: {
+      comm_id: commId,
+      data: data ?? {},
+    },
+    buffers: buffers ?? [],
+    channel: "shell",
+  };
+}
+
 /**
  * Hook exposing outbound comm helpers.
  *
@@ -173,9 +249,61 @@ export function useCommRouter({
     storeRef.current.deleteModel(commId);
   }, []);
 
+  const openRawComm = useCallback(
+    (
+      commId: string,
+      targetName: string,
+      data?: unknown,
+      metadata?: Record<string, unknown>,
+      buffers?: ArrayBuffer[],
+    ) => {
+      return Promise.resolve(
+        sendMessageRef.current(
+          createRawOpenMessage(commId, targetName, data, metadata, buffers, usernameRef.current),
+        ),
+      );
+    },
+    [],
+  );
+
+  const sendRawComm = useCallback(
+    (
+      commId: string,
+      data: unknown,
+      metadata?: Record<string, unknown>,
+      buffers?: ArrayBuffer[],
+    ) => {
+      return Promise.resolve(
+        sendMessageRef.current(
+          createRawMessage(commId, data, metadata, buffers, usernameRef.current),
+        ),
+      );
+    },
+    [],
+  );
+
+  const closeRawComm = useCallback(
+    (
+      commId: string,
+      data?: unknown,
+      metadata?: Record<string, unknown>,
+      buffers?: ArrayBuffer[],
+    ) => {
+      return Promise.resolve(
+        sendMessageRef.current(
+          createRawCloseMessage(commId, data, metadata, buffers, usernameRef.current),
+        ),
+      );
+    },
+    [],
+  );
+
   return {
     sendUpdate,
     sendCustom,
     closeComm,
+    openRawComm,
+    sendRawComm,
+    closeRawComm,
   };
 }

--- a/src/components/widgets/widget-store-context.tsx
+++ b/src/components/widgets/widget-store-context.tsx
@@ -39,6 +39,28 @@ interface WidgetStoreContextValue {
   sendCustom: (commId: string, content: Record<string, unknown>, buffers?: ArrayBuffer[]) => void;
   /** Close a comm channel via the daemon shell channel. */
   closeComm: (commId: string) => void;
+  /** Open a raw Jupyter comm channel via the daemon shell channel. */
+  openRawComm?: (
+    commId: string,
+    targetName: string,
+    data?: unknown,
+    metadata?: Record<string, unknown>,
+    buffers?: ArrayBuffer[],
+  ) => Promise<void>;
+  /** Send a raw Jupyter comm_msg payload via the daemon shell channel. */
+  sendRawComm?: (
+    commId: string,
+    data: unknown,
+    metadata?: Record<string, unknown>,
+    buffers?: ArrayBuffer[],
+  ) => Promise<void>;
+  /** Close a raw Jupyter comm channel via the daemon shell channel. */
+  closeRawComm?: (
+    commId: string,
+    data?: unknown,
+    metadata?: Record<string, unknown>,
+    buffers?: ArrayBuffer[],
+  ) => Promise<void>;
 }
 
 // === Context ===
@@ -75,11 +97,12 @@ export function WidgetStoreProvider({
   const store = storeRef.current;
 
   // Outbound comm helpers (inbound is driven by SyncEngine.commChanges$)
-  const { sendUpdate, sendCustom, closeComm } = useCommRouter({
-    sendMessage,
-    store,
-    updateManager,
-  });
+  const { sendUpdate, sendCustom, closeComm, openRawComm, sendRawComm, closeRawComm } =
+    useCommRouter({
+      sendMessage,
+      store,
+      updateManager,
+    });
 
   // Manage link subscriptions (jslink/jsdlink) at the store level.
   // Headless widgets like LinkModel have _view_name: null and won't be
@@ -94,8 +117,11 @@ export function WidgetStoreProvider({
       sendUpdate,
       sendCustom,
       closeComm,
+      openRawComm,
+      sendRawComm,
+      closeRawComm,
     }),
-    [store, sendUpdate, sendCustom, closeComm],
+    [store, sendUpdate, sendCustom, closeComm, openRawComm, sendRawComm, closeRawComm],
   );
 
   return <WidgetStoreContext.Provider value={value}>{children}</WidgetStoreContext.Provider>;

--- a/src/isolated-renderer/__tests__/panel-renderer.test.tsx
+++ b/src/isolated-renderer/__tests__/panel-renderer.test.tsx
@@ -28,11 +28,16 @@ function stubAnimationFrames() {
 }
 
 function stubPanelRuntime() {
-  (window as typeof window & { Bokeh?: unknown }).Bokeh = { Panel: {}, index: {} };
+  (window as typeof window & { Bokeh?: unknown }).Bokeh = {
+    Panel: {},
+    index: {},
+    require: vi.fn(),
+  };
 }
 
 function stubPanelResourceLoads() {
   const appendedSrcs: string[] = [];
+  let widgetsReady = false;
   const appendChild = vi.spyOn(HTMLHeadElement.prototype, "appendChild");
 
   appendChild.mockImplementation(function appendPanelScript(
@@ -41,10 +46,16 @@ function stubPanelResourceLoads() {
   ): Node {
     if (node instanceof HTMLScriptElement && node.src) {
       appendedSrcs.push(node.src);
+      if (node.src.includes("bokeh-widgets-3.9.1.min.js")) {
+        widgetsReady = true;
+      }
       if (node.src.includes("cdn.bokeh.org/bokeh/release/")) {
         (window as typeof window & { Bokeh?: unknown }).Bokeh = {
           version: "3.9.1",
           index: {},
+          require: vi.fn(() => {
+            if (!widgetsReady) throw new Error("module missing");
+          }),
         };
       }
       if (node.src.includes("panel.min.js")) {
@@ -82,6 +93,8 @@ describe("Panel renderer plugin", () => {
       .__nteractBokehLoadPromise__;
     delete (window as typeof window & { __nteractPanelLoadPromises__?: unknown })
       .__nteractPanelLoadPromises__;
+    delete (window as typeof window & { __nteractEnsurePyVizCommManager?: unknown })
+      .__nteractEnsurePyVizCommManager;
   });
 
   afterEach(() => {
@@ -95,6 +108,8 @@ describe("Panel renderer plugin", () => {
       .__nteractBokehLoadPromise__;
     delete (window as typeof window & { __nteractPanelLoadPromises__?: unknown })
       .__nteractPanelLoadPromises__;
+    delete (window as typeof window & { __nteractEnsurePyVizCommManager?: unknown })
+      .__nteractEnsurePyVizCommManager;
   });
 
   it("registers Panel load and exec MIME types", () => {
@@ -104,6 +119,10 @@ describe("Panel renderer plugin", () => {
   });
 
   it("appends Panel load MIME JavaScript directly", async () => {
+    const ensureCommManager = vi.fn();
+    (
+      window as typeof window & { __nteractEnsurePyVizCommManager?: () => void }
+    ).__nteractEnsurePyVizCommManager = ensureCommManager;
     const { Renderer } = installPanelRenderer();
     const { container } = render(
       <Renderer
@@ -117,6 +136,7 @@ describe("Panel renderer plugin", () => {
 
     await waitFor(() => {
       expect(renderedScripts(container).at(-1)?.textContent).toBe("window.__panelLoadRan = true;");
+      expect(ensureCommManager).toHaveBeenCalled();
     });
   });
 
@@ -216,6 +236,77 @@ describe("Panel renderer plugin", () => {
     ]);
   });
 
+  it("waits for Panel's notebook autoload before executing the widget bundle", async () => {
+    let modulesReady = false;
+    const bokeh = {
+      version: "3.9.1",
+      index: {},
+      require: vi.fn(() => {
+        if (!modulesReady) throw new Error("module missing");
+      }),
+    };
+    (
+      window as typeof window & {
+        Bokeh?: unknown;
+        _bokeh_is_initializing?: boolean;
+        _bokeh_is_loading?: number;
+      }
+    ).Bokeh = bokeh;
+    (
+      window as typeof window & {
+        _bokeh_is_initializing?: boolean;
+        _bokeh_is_loading?: number;
+      }
+    )._bokeh_is_initializing = true;
+    (
+      window as typeof window & {
+        _bokeh_is_initializing?: boolean;
+        _bokeh_is_loading?: number;
+      }
+    )._bokeh_is_loading = 2;
+    const appendedSrcs = stubPanelResourceLoads();
+    const { Renderer } = installPanelRenderer();
+    const { container } = render(
+      <Renderer
+        data={{
+          "text/html": [
+            '<div id="panel-root"></div>',
+            '<script type="application/javascript">',
+            'var docs_json = {"docid":{"version":"3.9.1","roots":[{"attributes":{"stylesheets":[{"attributes":{"url":"https://cdn.holoviz.org/panel/1.9.3/dist/css/loading.css"}}]}}]}};',
+            "window.__panelHtmlRan = true;",
+            "</script>",
+          ].join(""),
+          [PANEL_EXEC_MIME_TYPE]: "",
+        }}
+        metadata={{ id: "p1011" }}
+        mimeType={PANEL_EXEC_MIME_TYPE}
+      />,
+    );
+
+    await Promise.resolve();
+    expect(appendedSrcs).toEqual([]);
+
+    modulesReady = true;
+    (bokeh as typeof bokeh & { Panel?: unknown }).Panel = {};
+    (
+      window as typeof window & {
+        _bokeh_is_initializing?: boolean;
+        _bokeh_is_loading?: number;
+      }
+    )._bokeh_is_initializing = false;
+    (
+      window as typeof window & {
+        _bokeh_is_initializing?: boolean;
+        _bokeh_is_loading?: number;
+      }
+    )._bokeh_is_loading = 0;
+
+    await waitFor(() => {
+      expect(renderedScripts(container).at(-1)?.textContent).toContain("__panelHtmlRan");
+    });
+    expect(appendedSrcs).toEqual([]);
+  });
+
   it("executes code-only Panel exec bundles after loading BokehJS", async () => {
     const appendedSrcs = stubPanelResourceLoads();
     const { Renderer } = installPanelRenderer();
@@ -255,10 +346,17 @@ describe("Panel renderer plugin", () => {
     const view = { model: { document: { clear: vi.fn() } } };
     (
       window as typeof window & {
-        Bokeh?: { Panel?: unknown; index?: { get_by_id: () => unknown; delete: () => void } };
+        Bokeh?: {
+          Panel?: unknown;
+          version?: string;
+          require?: () => unknown;
+          index?: { get_by_id: () => unknown; delete: () => void };
+        };
       }
     ).Bokeh = {
       Panel: {},
+      version: "3.9.1",
+      require: vi.fn(),
       index: {
         get_by_id: () => view,
         delete: vi.fn(),

--- a/src/isolated-renderer/__tests__/widget-bridge-client.test.ts
+++ b/src/isolated-renderer/__tests__/widget-bridge-client.test.ts
@@ -1,0 +1,347 @@
+import { afterEach, describe, expect, it, vi } from "vite-plus/test";
+import type { JsonRpcTransport } from "@/components/isolated/jsonrpc-transport";
+import {
+  NTERACT_COMM_MSG,
+  NTERACT_COMM_OPEN,
+  NTERACT_RAW_COMM_MSG,
+  NTERACT_RAW_COMM_OPEN,
+  NTERACT_WIDGET_READY,
+} from "@/components/isolated/rpc-methods";
+import {
+  createWidgetBridgeClient,
+  getCurrentWidgetBridgeClient,
+  registerPyVizKernelProxy,
+} from "../widget-bridge-client";
+
+function createMockTransport() {
+  const handlers = new Map<string, (params?: unknown) => void | Promise<void>>();
+  const notify = vi.fn();
+  const transport = {
+    notify,
+    onNotification: vi.fn((method: string, handler: (params?: unknown) => void | Promise<void>) => {
+      handlers.set(method, handler);
+    }),
+  } as unknown as JsonRpcTransport;
+
+  return { transport, handlers, notify };
+}
+
+describe("WidgetBridgeClient PyViz comm proxy", () => {
+  afterEach(() => {
+    getCurrentWidgetBridgeClient()?.dispose();
+    delete (window as typeof window & { PyViz?: unknown }).PyViz;
+    delete (window as typeof window & { __nteractRegisterPyVizKernel?: unknown })
+      .__nteractRegisterPyVizKernel;
+    delete (window as typeof window & { __nteractWidgetBridgeClient?: unknown })
+      .__nteractWidgetBridgeClient;
+    delete (window as typeof window & { __nteractEnsurePyVizCommManager?: unknown })
+      .__nteractEnsurePyVizCommManager;
+    delete (window as typeof window & { __nteractPendingPyVizKernelRegistrations?: unknown })
+      .__nteractPendingPyVizKernelRegistrations;
+    vi.restoreAllMocks();
+  });
+
+  it("attaches pending PyViz kernel registrations when the bridge client is created", () => {
+    const unregister = registerPyVizKernelProxy("plot-1");
+    expect(
+      (window as typeof window & { PyViz?: { kernels?: Record<string, unknown> } }).PyViz
+        ?.kernels?.["plot-1"],
+    ).toBeUndefined();
+
+    const { transport } = createMockTransport();
+    createWidgetBridgeClient(transport);
+
+    const pyviz = (window as typeof window & { PyViz?: { kernels?: Record<string, unknown> } })
+      .PyViz;
+    expect(pyviz?.kernels?.["plot-1"]).toEqual(
+      expect.objectContaining({
+        connectToComm: expect.any(Function),
+        registerCommTarget: expect.any(Function),
+      }),
+    );
+
+    unregister();
+    expect(pyviz?.kernels?.["plot-1"]).toBeUndefined();
+  });
+
+  it("uses the window-scoped registrar for renderer plugin bundle copies", () => {
+    const unregisterBridgeKernel = vi.fn();
+    const registerBridgeKernel = vi.fn(() => unregisterBridgeKernel);
+    (
+      window as typeof window & {
+        __nteractRegisterPyVizKernel?: (plotId: string) => () => void;
+      }
+    ).__nteractRegisterPyVizKernel = registerBridgeKernel;
+
+    const unregister = registerPyVizKernelProxy("panel-plot");
+
+    expect(registerBridgeKernel).toHaveBeenCalledWith("panel-plot");
+    unregister();
+    expect(unregisterBridgeKernel).toHaveBeenCalledTimes(1);
+  });
+
+  it("registers a PyViz kernel proxy and forwards frontend raw comm messages", () => {
+    const { transport, notify } = createMockTransport();
+    const client = createWidgetBridgeClient(transport);
+
+    const unregister = client.registerPyVizKernel("plot-1");
+    const pyviz = (window as typeof window & { PyViz?: { kernels?: Record<string, unknown> } })
+      .PyViz;
+    const kernel = pyviz?.kernels?.["plot-1"] as {
+      connectToComm: (
+        targetName: string,
+        commId?: string,
+      ) => {
+        open: (data?: unknown, metadata?: Record<string, unknown>, buffers?: ArrayBuffer[]) => void;
+        send: (data?: unknown, metadata?: Record<string, unknown>, buffers?: ArrayBuffer[]) => void;
+      };
+    };
+    const buffer = new ArrayBuffer(4);
+
+    const comm = kernel.connectToComm("panel-target", "panel-comm");
+    comm.open("open-data", { opened: true }, [buffer]);
+    comm.send("PATCH-DOC", { msg_type: "Ready" }, [buffer]);
+
+    expect(notify).toHaveBeenCalledWith(NTERACT_WIDGET_READY);
+    expect(notify).toHaveBeenCalledWith(NTERACT_RAW_COMM_OPEN, {
+      commId: "panel-comm",
+      targetName: "panel-target",
+      data: "open-data",
+      metadata: { opened: true },
+      buffers: [buffer],
+    });
+    expect(notify).toHaveBeenCalledWith(NTERACT_RAW_COMM_MSG, {
+      commId: "panel-comm",
+      data: "PATCH-DOC",
+      metadata: { msg_type: "Ready" },
+      buffers: [buffer],
+    });
+
+    unregister();
+    expect(pyviz?.kernels?.["plot-1"]).toBeUndefined();
+  });
+
+  it("exposes a pyviz_comms-compatible comm_manager for Panel", async () => {
+    const { transport, handlers, notify } = createMockTransport();
+    const client = createWidgetBridgeClient(transport);
+    client.registerPyVizKernel("panel-plot");
+    const pyviz = (
+      window as typeof window & {
+        PyViz?: {
+          comm_manager?: {
+            register_target: (
+              plotId: string,
+              commId: string,
+              msgHandler: (message: {
+                content: { comm_id: string; data: unknown };
+                metadata: Record<string, unknown>;
+                buffers: DataView[];
+              }) => void,
+            ) => void;
+            get_client_comm: (
+              plotId: string,
+              commId: string,
+              msgHandler: (message: {
+                content: { comm_id: string; data: unknown };
+                metadata: Record<string, unknown>;
+                buffers: DataView[];
+              }) => void,
+            ) => {
+              comm_id: string;
+              connected: boolean;
+              onMsg?: (message: {
+                content: { comm_id: string; data: unknown };
+                metadata: Record<string, unknown>;
+                buffers: DataView[];
+              }) => void;
+            };
+          };
+          comms?: Record<string, unknown>;
+        };
+      }
+    ).PyViz;
+    const serverHandler = vi.fn();
+    const ackHandler = vi.fn();
+
+    pyviz?.comm_manager?.register_target("panel-plot", "server-comm", serverHandler);
+    const clientComm = pyviz?.comm_manager?.get_client_comm(
+      "panel-plot",
+      "client-comm",
+      ackHandler,
+    );
+
+    expect(clientComm).toEqual(
+      expect.objectContaining({
+        comm_id: "client-comm",
+        connected: true,
+      }),
+    );
+    expect(pyviz?.comms?.["client-comm"]).toBe(clientComm);
+    expect(notify).toHaveBeenCalledWith(NTERACT_RAW_COMM_OPEN, {
+      commId: "client-comm",
+      targetName: "client-comm",
+      data: {},
+      metadata: {},
+      buffers: undefined,
+    });
+
+    await handlers.get(NTERACT_COMM_OPEN)?.({
+      commId: "server-comm",
+      targetName: "server-comm",
+      state: { initial: true },
+    });
+    await handlers.get(NTERACT_COMM_MSG)?.({
+      commId: "server-comm",
+      method: "raw",
+      data: "PATCH-DOC",
+      metadata: { msg_type: "PATCH-DOC" },
+    });
+    expect(serverHandler).toHaveBeenCalledWith({
+      content: { comm_id: "server-comm", data: "PATCH-DOC" },
+      metadata: { msg_type: "PATCH-DOC" },
+      buffers: [],
+    });
+
+    const buffer = new ArrayBuffer(8);
+    await handlers.get(NTERACT_COMM_MSG)?.({
+      commId: "client-comm",
+      method: "raw",
+      data: "",
+      metadata: { msg_type: "Ready", comm_id: "client-comm" },
+      buffers: [buffer],
+    });
+    expect(ackHandler).toHaveBeenCalledWith({
+      content: { comm_id: "client-comm", data: "" },
+      metadata: { msg_type: "Ready", comm_id: "client-comm" },
+      buffers: [expect.any(DataView)],
+    });
+    expect(ackHandler.mock.calls[0][0].buffers[0].buffer).toBe(buffer);
+  });
+
+  it("reattaches Panel ACK handlers when a client comm already exists", async () => {
+    const { transport, handlers } = createMockTransport();
+    const client = createWidgetBridgeClient(transport);
+    client.registerPyVizKernel("panel-plot");
+    const pyviz = (
+      window as typeof window & {
+        PyViz?: {
+          comm_manager?: {
+            get_client_comm: (
+              plotId: string,
+              commId: string,
+              msgHandler: (message: {
+                content: { comm_id: string; data: unknown };
+                metadata: Record<string, unknown>;
+                buffers: DataView[];
+              }) => void,
+            ) => {
+              comm_id: string;
+              onMsg?: (message: {
+                content: { comm_id: string; data: unknown };
+                metadata: Record<string, unknown>;
+                buffers: DataView[];
+              }) => void;
+            };
+          };
+        };
+      }
+    ).PyViz;
+    const staleAckHandler = vi.fn();
+    const currentAckHandler = vi.fn();
+
+    const comm = pyviz?.comm_manager?.get_client_comm("panel-plot", "client-comm", staleAckHandler);
+    pyviz?.comm_manager?.get_client_comm("panel-plot", "client-comm", currentAckHandler);
+
+    expect(comm?.onMsg).toBe(currentAckHandler);
+
+    await handlers.get(NTERACT_COMM_MSG)?.({
+      commId: "client-comm",
+      method: "raw",
+      data: {},
+      metadata: { msg_type: "Ready" },
+    });
+
+    expect(staleAckHandler).not.toHaveBeenCalled();
+    expect(currentAckHandler).toHaveBeenCalledWith({
+      content: { comm_id: "client-comm", data: {} },
+      metadata: { msg_type: "Ready" },
+      buffers: [],
+    });
+  });
+
+  it("delivers incoming raw comm messages to PyViz onMsg handlers", async () => {
+    const { transport, handlers } = createMockTransport();
+    const client = createWidgetBridgeClient(transport);
+    client.registerPyVizKernel("plot-1");
+    const pyviz = (window as typeof window & { PyViz?: { kernels?: Record<string, unknown> } })
+      .PyViz;
+    const kernel = pyviz?.kernels?.["plot-1"] as {
+      connectToComm: (
+        targetName: string,
+        commId?: string,
+      ) => {
+        onMsg?: (message: {
+          content: { comm_id: string; data: unknown };
+          metadata: Record<string, unknown>;
+          buffers: DataView[];
+        }) => void;
+      };
+    };
+    const received = vi.fn();
+    const comm = kernel.connectToComm("panel-target", "panel-comm");
+    comm.onMsg = received;
+    const buffer = new ArrayBuffer(8);
+
+    await handlers.get(NTERACT_COMM_MSG)?.({
+      commId: "panel-comm",
+      method: "raw",
+      data: "PATCH-DOC",
+      metadata: { msg_type: "Ready" },
+      buffers: [buffer],
+    });
+
+    expect(received).toHaveBeenCalledWith({
+      content: { comm_id: "panel-comm", data: "PATCH-DOC" },
+      metadata: { msg_type: "Ready" },
+      buffers: [expect.any(DataView)],
+    });
+    expect(received.mock.calls[0][0].buffers[0].buffer).toBe(buffer);
+  });
+
+  it("queues kernel-opened raw comms until PyViz registers the target", async () => {
+    const { transport, handlers } = createMockTransport();
+    const client = createWidgetBridgeClient(transport);
+
+    await handlers.get(NTERACT_COMM_OPEN)?.({
+      commId: "server-comm",
+      targetName: "server-target",
+      state: { ready: true },
+    });
+
+    client.registerPyVizKernel("plot-1");
+    const pyviz = (window as typeof window & { PyViz?: { kernels?: Record<string, unknown> } })
+      .PyViz;
+    const kernel = pyviz?.kernels?.["plot-1"] as {
+      registerCommTarget: (
+        targetName: string,
+        callback: (comm: unknown, msg: unknown) => void,
+      ) => void;
+    };
+    const callback = vi.fn();
+
+    kernel.registerCommTarget("server-target", callback);
+
+    expect(callback).toHaveBeenCalledWith(
+      expect.objectContaining({
+        comm_id: "server-comm",
+        target_name: "server-target",
+        connected: true,
+      }),
+      {
+        content: { comm_id: "server-comm", data: { ready: true } },
+        metadata: {},
+        buffers: [],
+      },
+    );
+  });
+});

--- a/src/isolated-renderer/panel-renderer.tsx
+++ b/src/isolated-renderer/panel-renderer.tsx
@@ -11,6 +11,7 @@ import { useEffect, useRef, useState, type ComponentType } from "react";
 import type { RendererProps } from "@/lib/renderer-registry";
 import { PANEL_EXEC_MIME_TYPE, PANEL_LOAD_MIME_TYPE } from "@/components/outputs/panel-mime";
 import { measureDocumentHeight } from "./layout-measure";
+import { ensurePyVizCommManagerProxy, registerPyVizKernelProxy } from "./widget-bridge-client";
 
 type PanelPayload = {
   [PANEL_LOAD_MIME_TYPE]?: unknown;
@@ -50,13 +51,18 @@ type PanelWindow = Window &
         has?: (version: string) => boolean;
       };
       index?: BokehIndex;
+      require?: (name: string) => unknown;
     };
     PyViz?: PyVizGlobal | HTMLElement;
     __nteractBokehLoadPromise__?: Promise<void>;
+    __nteractPanelNotebookLoadStarted__?: boolean;
     __nteractPanelLoadPromises__?: Record<string, Promise<void>>;
+    _bokeh_is_initializing?: boolean;
+    _bokeh_is_loading?: number;
   };
 
 const BOKEH_RESOURCE_SUFFIXES = ["", "-gl", "-widgets", "-tables", "-mathjax"];
+const REQUIRED_BOKEH_MODULES = ["models/widgets/widget"];
 const PANEL_DIST_BASE_RE = /https:\/\/cdn\.holoviz\.org\/panel\/[^/]+\/dist\//;
 
 function panelWindow(): PanelWindow {
@@ -78,6 +84,20 @@ function panelDocumentId(metadata?: Record<string, unknown>): string | null {
   return typeof id === "string" ? id : null;
 }
 
+function extractPanelPlotIds(...values: Array<string | null>): string[] {
+  const plotIds = new Set<string>();
+  const plotIdPattern = /"plot_id"\s*:\s*"([^"]+)"/g;
+
+  for (const value of values) {
+    if (!value) continue;
+    for (const match of value.matchAll(plotIdPattern)) {
+      plotIds.add(match[1]);
+    }
+  }
+
+  return Array.from(plotIds);
+}
+
 function panelServerId(metadata?: Record<string, unknown>): string | null {
   const serverId = metadata?.server_id;
   return typeof serverId === "string" ? serverId : null;
@@ -95,6 +115,67 @@ function normalizeBokehVersion(version: string | null): string | null {
 function extractPanelDistBase(html: string | null): string | null {
   if (!html) return null;
   return html.match(PANEL_DIST_BASE_RE)?.[0] ?? null;
+}
+
+function bokehVersionMatches(version: string | null): boolean {
+  const bokeh = panelWindow().Bokeh;
+  return (
+    bokeh !== undefined && (!version || bokeh.version === version || bokeh.versions?.has?.(version))
+  );
+}
+
+function hasRequiredBokehModules(): boolean {
+  const bokeh = panelWindow().Bokeh;
+  if (!bokehVersionMatches(null) || !bokeh?.require) return false;
+
+  return REQUIRED_BOKEH_MODULES.every((moduleName) => {
+    try {
+      bokeh.require?.(moduleName);
+      return true;
+    } catch {
+      return false;
+    }
+  });
+}
+
+function bokehAutoloadInProgress(): boolean {
+  const target = panelWindow();
+  return target._bokeh_is_initializing === true || (target._bokeh_is_loading ?? 0) > 0;
+}
+
+function delay(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+async function waitForPanelNotebookAutoloadStart(): Promise<void> {
+  const startedAt = Date.now();
+  while (Date.now() - startedAt < 250) {
+    const target = panelWindow();
+    if (
+      target.Bokeh?.Panel !== undefined ||
+      bokehAutoloadInProgress() ||
+      hasRequiredBokehModules()
+    ) {
+      return;
+    }
+    await delay(25);
+  }
+}
+
+function waitForBokehAutoload(): Promise<void> {
+  if (!bokehAutoloadInProgress()) return Promise.resolve();
+
+  return new Promise((resolve) => {
+    const startedAt = Date.now();
+    const poll = () => {
+      if (!bokehAutoloadInProgress() || Date.now() - startedAt > 30_000) {
+        resolve();
+        return;
+      }
+      setTimeout(poll, 25);
+    };
+    poll();
+  });
 }
 
 function ensurePyViz(): PyVizGlobal {
@@ -156,18 +237,60 @@ function appendHtmlWithExecutableScripts(container: HTMLElement, html: string): 
   return wrapper;
 }
 
-function loadScript(src: string, required: boolean): Promise<void> {
+function findExistingScript(src: string): HTMLScriptElement | null {
+  for (const script of Array.from(document.scripts)) {
+    if (script.dataset.nteractPanelSrc === src || script.src === src) return script;
+  }
+  return null;
+}
+
+function waitForReadiness(
+  readiness: (() => boolean) | undefined,
+  timeoutMs: number,
+  label: string,
+): Promise<void> {
   return new Promise((resolve, reject) => {
-    const existing = document.querySelector(`script[data-nteract-panel-src="${src}"]`);
-    if (existing) {
+    const startedAt = Date.now();
+    const poll = () => {
+      if (!readiness || readiness()) {
+        resolve();
+        return;
+      }
+      if (Date.now() - startedAt > timeoutMs) {
+        reject(new Error(`Timed out waiting for Panel/BokehJS resource readiness: ${label}`));
+        return;
+      }
+      setTimeout(poll, 25);
+    };
+    poll();
+  });
+}
+
+function loadScript(src: string, required: boolean, readiness?: () => boolean): Promise<void> {
+  return new Promise((resolve, reject) => {
+    if (readiness?.()) {
       resolve();
+      return;
+    }
+
+    const existing = findExistingScript(src);
+    if (existing) {
+      void waitForReadiness(readiness, 30_000, src).then(resolve, (error) => {
+        if (required) reject(error);
+        else resolve();
+      });
       return;
     }
 
     const script = document.createElement("script");
     script.async = false;
     script.dataset.nteractPanelSrc = src;
-    script.onload = () => resolve();
+    script.onload = () => {
+      void waitForReadiness(readiness, 30_000, src).then(resolve, (error) => {
+        if (required) reject(error);
+        else resolve();
+      });
+    };
     script.onerror = () => {
       const error = new Error(`Failed to load Panel/BokehJS resource: ${src}`);
       if (required) reject(error);
@@ -184,14 +307,14 @@ function loadScript(src: string, required: boolean): Promise<void> {
 async function ensureBokeh(version: string | null): Promise<void> {
   const target = panelWindow();
   const normalizedVersion = normalizeBokehVersion(version);
-  const bokeh = target.Bokeh;
-  if (
-    bokeh !== undefined &&
-    (!normalizedVersion ||
-      bokeh.version === normalizedVersion ||
-      bokeh.versions?.has?.(normalizedVersion))
-  ) {
+  if (bokehVersionMatches(normalizedVersion) && hasRequiredBokehModules()) {
     return;
+  }
+  if (bokehAutoloadInProgress()) {
+    await waitForBokehAutoload();
+    if (bokehVersionMatches(normalizedVersion) && hasRequiredBokehModules()) {
+      return;
+    }
   }
   if (target.__nteractBokehLoadPromise__) return target.__nteractBokehLoadPromise__;
   if (!normalizedVersion) {
@@ -201,10 +324,19 @@ async function ensureBokeh(version: string | null): Promise<void> {
   target.__nteractBokehLoadPromise__ = (async () => {
     for (const [index, suffix] of BOKEH_RESOURCE_SUFFIXES.entries()) {
       const src = `https://cdn.bokeh.org/bokeh/release/bokeh${suffix}-${normalizedVersion}.min.js`;
-      await loadScript(src, index === 0);
+      const readiness =
+        suffix === ""
+          ? () => bokehVersionMatches(normalizedVersion)
+          : suffix === "-widgets"
+            ? hasRequiredBokehModules
+            : undefined;
+      await loadScript(src, index === 0 || suffix === "-widgets", readiness);
     }
     if (panelWindow().Bokeh === undefined) {
       throw new Error(`BokehJS ${normalizedVersion} loaded without defining window.Bokeh`);
+    }
+    if (!hasRequiredBokehModules()) {
+      throw new Error(`BokehJS ${normalizedVersion} loaded without required widget modules`);
     }
   })().catch((error) => {
     target.__nteractBokehLoadPromise__ = undefined;
@@ -217,6 +349,7 @@ async function ensureBokeh(version: string | null): Promise<void> {
 async function ensurePanelRuntime(html: string | null, code: string | null): Promise<void> {
   const target = panelWindow();
   const version = extractBokehVersion(code ?? html);
+  await waitForPanelNotebookAutoloadStart();
   await ensureBokeh(version);
 
   if (target.Bokeh?.Panel !== undefined) return;
@@ -226,7 +359,11 @@ async function ensurePanelRuntime(html: string | null, code: string | null): Pro
 
   target.__nteractPanelLoadPromises__ ??= {};
   const panelSrc = `${panelDistBase}panel.min.js`;
-  target.__nteractPanelLoadPromises__[panelSrc] ??= loadScript(panelSrc, true).catch((error) => {
+  target.__nteractPanelLoadPromises__[panelSrc] ??= loadScript(
+    panelSrc,
+    true,
+    () => target.Bokeh?.Panel !== undefined,
+  ).catch((error) => {
     delete target.__nteractPanelLoadPromises__?.[panelSrc];
     throw error;
   });
@@ -266,7 +403,6 @@ function cleanupPanelDocument(documentId: string | null): void {
   if (!documentId) return;
   const target = panelWindow();
   const pyviz = target.PyViz instanceof HTMLElement ? undefined : target.PyViz;
-  delete pyviz?.kernels?.[documentId];
   delete pyviz?.plot_index?.[documentId];
 
   const index = target.Bokeh?.index;
@@ -290,11 +426,19 @@ function PanelRenderer({ data: rawData, metadata, mimeType }: RendererProps) {
     const payload = asPanelPayload(rawData);
     const documentId = panelDocumentId(metadata);
     const appendedNodes: ChildNode[] = [];
+    const registeredPlotIds = new Set<string>();
+    const unregisterPyVizKernels: Array<() => void> = [];
     let cancelled = false;
 
     function trackNode<T extends ChildNode>(node: T): T {
       appendedNodes.push(node);
       return node;
+    }
+
+    function registerPanelPlotId(plotId: string | null): void {
+      if (!plotId || registeredPlotIds.has(plotId)) return;
+      registeredPlotIds.add(plotId);
+      unregisterPyVizKernels.push(registerPyVizKernelProxy(plotId));
     }
 
     async function renderPanel() {
@@ -303,7 +447,9 @@ function PanelRenderer({ data: rawData, metadata, mimeType }: RendererProps) {
           normalizeText(payload[PANEL_LOAD_MIME_TYPE]) ??
           normalizeText(payload["application/javascript"]);
         if (!code) return;
+        panelWindow().__nteractPanelNotebookLoadStarted__ = true;
         trackNode(appendExecutableScript(container, code));
+        ensurePyVizCommManagerProxy();
         return;
       }
 
@@ -327,6 +473,11 @@ function PanelRenderer({ data: rawData, metadata, mimeType }: RendererProps) {
         throw new Error("Panel output did not include text/html or application/javascript data");
       }
 
+      registerPanelPlotId(documentId);
+      for (const plotId of extractPanelPlotIds(html, code)) {
+        registerPanelPlotId(plotId);
+      }
+
       if (!documentId) {
         if (html) {
           trackNode(appendHtmlWithExecutableScripts(container, html));
@@ -340,10 +491,12 @@ function PanelRenderer({ data: rawData, metadata, mimeType }: RendererProps) {
       if (html) {
         await ensurePanelRuntime(html, code);
         if (cancelled) return;
+        ensurePyVizCommManagerProxy();
         trackNode(appendHtmlWithExecutableScripts(container, html));
       } else if (code) {
         await ensurePanelRuntime(null, code);
         if (cancelled) return;
+        ensurePyVizCommManagerProxy();
       }
       if (code) {
         trackNode(appendExecutableScript(container, code));
@@ -369,6 +522,9 @@ function PanelRenderer({ data: rawData, metadata, mimeType }: RendererProps) {
         }
       }
       cleanupPanelDocument(documentId);
+      for (const unregisterPyVizKernel of unregisterPyVizKernels) {
+        unregisterPyVizKernel();
+      }
     };
   }, [rawData, metadata, mimeType]);
 

--- a/src/isolated-renderer/widget-bridge-client.ts
+++ b/src/isolated-renderer/widget-bridge-client.ts
@@ -21,12 +21,87 @@ import {
   NTERACT_COMM_CLOSE,
   NTERACT_COMM_MSG,
   NTERACT_COMM_OPEN,
+  NTERACT_RAW_COMM_CLOSE,
+  NTERACT_RAW_COMM_MSG,
+  NTERACT_RAW_COMM_OPEN,
   NTERACT_WIDGET_SNAPSHOT,
   NTERACT_WIDGET_COMM_CLOSE,
   NTERACT_WIDGET_COMM_MSG,
   NTERACT_WIDGET_READY,
 } from "@/components/isolated/rpc-methods";
 import { createWidgetStore, type WidgetStore } from "@/components/widgets/widget-store";
+
+type RawCommBuffer = ArrayBuffer | ArrayBufferView;
+
+interface RawCommMessage {
+  content: {
+    comm_id: string;
+    data: unknown;
+  };
+  metadata: Record<string, unknown>;
+  buffers: DataView[];
+}
+
+type RawCommHandler = (msg: RawCommMessage) => void;
+
+interface PyVizCommProxy {
+  comm_id: string;
+  target_name: string;
+  connected: boolean;
+  active: boolean;
+  onMsg?: RawCommHandler;
+  on_msg: (callback: RawCommHandler) => void;
+  open: (data?: unknown, metadata?: Record<string, unknown>, buffers?: RawCommBuffer[]) => void;
+  send: (
+    data?: unknown,
+    metadata?: Record<string, unknown>,
+    buffers?: RawCommBuffer[],
+    disposeOnDone?: boolean,
+  ) => void;
+  close: (data?: unknown, metadata?: Record<string, unknown>, buffers?: RawCommBuffer[]) => void;
+}
+
+type InternalPyVizCommProxy = PyVizCommProxy & {
+  _deliver: (data: unknown, metadata?: Record<string, unknown>, buffers?: ArrayBuffer[]) => void;
+  _close: () => void;
+};
+
+type PyVizCommOpenCallback = (comm: PyVizCommProxy, msg: RawCommMessage) => void;
+
+interface PyVizKernelProxy {
+  registerCommTarget: (targetName: string, callback: PyVizCommOpenCallback) => void;
+  connectToComm: (targetName: string, commId?: string) => PyVizCommProxy;
+}
+
+interface PyVizCommManagerProxy {
+  register_target: (plotId: string, commId: string, msgHandler: RawCommHandler) => void;
+  get_client_comm: (
+    plotIdOrCommId: string,
+    commIdOrHandler?: string | RawCommHandler,
+    msgHandler?: RawCommHandler,
+  ) => PyVizCommProxy;
+}
+
+interface PyVizGlobal {
+  comms?: Record<string, PyVizCommProxy>;
+  comm_status?: Record<string, unknown>;
+  kernels?: Record<string, PyVizKernelProxy>;
+  comm_manager?: PyVizCommManagerProxy;
+  receivers?: Record<string, unknown>;
+  plot_index?: Record<string, unknown>;
+}
+
+type WidgetBridgeWindow = Window &
+  typeof globalThis & {
+    PyViz?: PyVizGlobal | HTMLElement;
+    __nteractRegisterPyVizKernel?: (plotId: string) => () => void;
+    __nteractEnsurePyVizCommManager?: () => void;
+    __nteractWidgetBridgeClient?: WidgetBridgeClient;
+    __nteractPendingPyVizKernelRegistrations?: Map<
+      symbol,
+      { plotId: string; unregister?: () => void }
+    >;
+  };
 
 function isLocalDaemonBlobUrl(value: string): boolean {
   try {
@@ -110,9 +185,62 @@ export interface WidgetBridgeClient {
   closeComm: (commId: string) => void;
 
   /**
+   * Register a PyViz/JupyterLab-compatible kernel proxy for a Panel plot id.
+   */
+  registerPyVizKernel: (plotId: string) => () => void;
+
+  /**
    * Clean up the bridge.
    */
   dispose: () => void;
+}
+
+let currentWidgetBridgeClient: WidgetBridgeClient | null = null;
+
+export function getCurrentWidgetBridgeClient(): WidgetBridgeClient | null {
+  return (
+    currentWidgetBridgeClient ?? (window as WidgetBridgeWindow).__nteractWidgetBridgeClient ?? null
+  );
+}
+
+function pendingPyVizKernelRegistrations(): Map<
+  symbol,
+  { plotId: string; unregister?: () => void }
+> {
+  const target = window as WidgetBridgeWindow;
+  target.__nteractPendingPyVizKernelRegistrations ??= new Map();
+  return target.__nteractPendingPyVizKernelRegistrations;
+}
+
+function pyVizKernelRegistrar(): ((plotId: string) => () => void) | undefined {
+  const target = window as WidgetBridgeWindow;
+  return target.__nteractRegisterPyVizKernel ?? currentWidgetBridgeClient?.registerPyVizKernel;
+}
+
+function flushPendingPyVizKernelRegistrations(client: WidgetBridgeClient): void {
+  for (const registration of pendingPyVizKernelRegistrations().values()) {
+    if (!registration.unregister) {
+      registration.unregister = client.registerPyVizKernel(registration.plotId);
+    }
+  }
+}
+
+export function registerPyVizKernelProxy(plotId: string): () => void {
+  const token = Symbol(plotId);
+  const registration = { plotId, unregister: undefined as (() => void) | undefined };
+  pendingPyVizKernelRegistrations().set(token, registration);
+
+  registration.unregister = pyVizKernelRegistrar()?.(plotId);
+
+  return () => {
+    registration.unregister?.();
+    pendingPyVizKernelRegistrations().delete(token);
+  };
+}
+
+export function ensurePyVizCommManagerProxy(): void {
+  const target = window as WidgetBridgeWindow;
+  target.__nteractEnsurePyVizCommManager?.();
 }
 
 /**
@@ -126,9 +254,227 @@ export interface WidgetBridgeClient {
  */
 export function createWidgetBridgeClient(transport: JsonRpcTransport): WidgetBridgeClient {
   const store = createWidgetStore();
+  const rawComms = new Map<string, InternalPyVizCommProxy>();
+  const rawTargets = new Map<string, PyVizCommOpenCallback>();
+  const pendingRawOpens = new Map<
+    string,
+    Array<{
+      commId: string;
+      targetName: string;
+      data: unknown;
+      metadata?: Record<string, unknown>;
+      buffers?: ArrayBuffer[];
+    }>
+  >();
 
   function sendWidgetReady() {
     transport.notify(NTERACT_WIDGET_READY);
+  }
+
+  function ensurePyViz(): PyVizGlobal {
+    const target = window as WidgetBridgeWindow;
+    if (!target.PyViz || target.PyViz instanceof HTMLElement) {
+      target.PyViz = {};
+    }
+    const pyviz = target.PyViz as PyVizGlobal;
+    pyviz.comms ??= {};
+    pyviz.comm_status ??= {};
+    pyviz.kernels ??= {};
+    pyviz.receivers ??= {};
+    pyviz.plot_index ??= {};
+    pyviz.comm_manager ??= createPyVizCommManager(pyviz);
+    return pyviz;
+  }
+
+  function normalizeOutgoingBuffers(buffers?: RawCommBuffer[]): ArrayBuffer[] | undefined {
+    if (!buffers || buffers.length === 0) return undefined;
+    return buffers.map((buffer) => {
+      if (buffer instanceof ArrayBuffer) return buffer;
+      const view = buffer as ArrayBufferView;
+      if (view.byteOffset === 0 && view.byteLength === view.buffer.byteLength) {
+        return view.buffer as ArrayBuffer;
+      }
+      return view.buffer.slice(view.byteOffset, view.byteOffset + view.byteLength) as ArrayBuffer;
+    });
+  }
+
+  function incomingBufferViews(buffers?: ArrayBuffer[]): DataView[] {
+    return (buffers ?? []).map((buffer) => new DataView(buffer));
+  }
+
+  function rawCommMessage(
+    commId: string,
+    data: unknown,
+    metadata?: Record<string, unknown>,
+    buffers?: ArrayBuffer[],
+  ): RawCommMessage {
+    return {
+      content: {
+        comm_id: commId,
+        data,
+      },
+      metadata: metadata ?? {},
+      buffers: incomingBufferViews(buffers),
+    };
+  }
+
+  function createRawComm(commId: string, targetName: string, connected: boolean) {
+    let onMsg: RawCommHandler | undefined;
+    const comm: InternalPyVizCommProxy = {
+      comm_id: commId,
+      target_name: targetName,
+      connected,
+      active: true,
+      get onMsg() {
+        return onMsg;
+      },
+      set onMsg(callback) {
+        onMsg = callback;
+      },
+      on_msg(callback) {
+        onMsg = callback;
+      },
+      open(data = {}, metadata = {}, buffers) {
+        comm.connected = true;
+        transport.notify(NTERACT_RAW_COMM_OPEN, {
+          commId,
+          targetName,
+          data,
+          metadata,
+          buffers: normalizeOutgoingBuffers(buffers),
+        });
+      },
+      send(data = {}, metadata = {}, buffers) {
+        transport.notify(NTERACT_RAW_COMM_MSG, {
+          commId,
+          data,
+          metadata,
+          buffers: normalizeOutgoingBuffers(buffers),
+        });
+      },
+      close(data = {}, metadata = {}, buffers) {
+        comm.connected = false;
+        comm.active = false;
+        transport.notify(NTERACT_RAW_COMM_CLOSE, {
+          commId,
+          data,
+          metadata,
+          buffers: normalizeOutgoingBuffers(buffers),
+        });
+      },
+      _deliver(data, metadata, buffers) {
+        onMsg?.(rawCommMessage(commId, data, metadata, buffers));
+      },
+      _close() {
+        comm.connected = false;
+        comm.active = false;
+      },
+    };
+
+    rawComms.set(commId, comm);
+    ensurePyViz().comms![commId] = comm;
+    return comm;
+  }
+
+  function connectRawComm(targetName: string, commId = targetName): PyVizCommProxy {
+    return rawComms.get(commId) ?? createRawComm(commId, targetName, false);
+  }
+
+  function createPyVizCommManager(pyviz: PyVizGlobal): PyVizCommManagerProxy {
+    return {
+      register_target(plotId, commId, msgHandler) {
+        const kernel = pyviz.kernels?.[plotId];
+        if (kernel) {
+          kernel.registerCommTarget(commId, (comm) => {
+            comm.onMsg = msgHandler;
+          });
+          return;
+        }
+
+        registerRawTarget(commId, (comm) => {
+          comm.onMsg = msgHandler;
+        });
+      },
+
+      get_client_comm(plotIdOrCommId, commIdOrHandler, msgHandler) {
+        const hasExplicitPlotId = typeof commIdOrHandler === "string";
+        const plotId = hasExplicitPlotId ? plotIdOrCommId : undefined;
+        const commId = hasExplicitPlotId ? commIdOrHandler : plotIdOrCommId;
+        const handler = typeof commIdOrHandler === "function" ? commIdOrHandler : msgHandler;
+        const existing = pyviz.comms?.[commId];
+        const comm =
+          existing ??
+          (plotId && pyviz.kernels?.[plotId]
+            ? pyviz.kernels[plotId].connectToComm(commId)
+            : connectRawComm(commId));
+
+        if (handler) {
+          comm.onMsg = handler;
+        }
+        if (!existing && (comm.active || comm.active === undefined)) {
+          comm.open();
+        }
+        return comm;
+      },
+    };
+  }
+
+  function deliverRawOpen(
+    commId: string,
+    targetName: string,
+    data: unknown,
+    metadata?: Record<string, unknown>,
+    buffers?: ArrayBuffer[],
+  ): void {
+    const callback = rawTargets.get(targetName);
+    if (!callback) {
+      const pending = pendingRawOpens.get(targetName) ?? [];
+      pending.push({ commId, targetName, data, metadata, buffers });
+      pendingRawOpens.set(targetName, pending);
+      return;
+    }
+
+    const comm = rawComms.get(commId) ?? createRawComm(commId, targetName, true);
+    comm.connected = true;
+    comm.active = true;
+    callback(comm, rawCommMessage(commId, data, metadata, buffers));
+  }
+
+  function registerRawTarget(targetName: string, callback: PyVizCommOpenCallback): void {
+    rawTargets.set(targetName, callback);
+    const pending = pendingRawOpens.get(targetName);
+    if (!pending) return;
+    pendingRawOpens.delete(targetName);
+    for (const message of pending) {
+      deliverRawOpen(
+        message.commId,
+        message.targetName,
+        message.data,
+        message.metadata,
+        message.buffers,
+      );
+    }
+  }
+
+  function deliverRawMessage(
+    commId: string,
+    data: unknown,
+    metadata?: Record<string, unknown>,
+    buffers?: ArrayBuffer[],
+  ): boolean {
+    const comm = rawComms.get(commId);
+    if (!comm) return false;
+    comm._deliver(data, metadata, buffers);
+    return true;
+  }
+
+  function closeRawMessage(commId: string): boolean {
+    const comm = rawComms.get(commId);
+    if (!comm) return false;
+    comm._close();
+    rawComms.delete(commId);
+    delete ensurePyViz().comms?.[commId];
+    return true;
   }
 
   // Register handlers for parent → iframe comm messages
@@ -143,28 +489,46 @@ export function createWidgetBridgeClient(transport: JsonRpcTransport): WidgetBri
       state: Record<string, unknown>;
       bufferPaths?: string[][];
     };
+    if (targetName && targetName !== "jupyter.widget") {
+      deliverRawOpen(commId, targetName, state);
+      return;
+    }
     await resolveBlobUrlsInPlace(state, bufferPaths);
     store.createModel(commId, state, bufferPaths, targetName);
   });
 
   transport.onNotification(NTERACT_COMM_MSG, async (params) => {
-    const { commId, method, data, buffers, bufferPaths } = params as {
+    const { commId, method, data, metadata, buffers, bufferPaths } = params as {
       commId: string;
-      method: "update" | "custom";
-      data: Record<string, unknown>;
+      method: "update" | "custom" | "raw";
+      data: unknown;
+      metadata?: Record<string, unknown>;
       buffers?: ArrayBuffer[];
       bufferPaths?: string[][];
     };
+    if (method === "raw") {
+      deliverRawMessage(commId, data, metadata, buffers);
+      return;
+    }
+    if (rawComms.has(commId)) {
+      deliverRawMessage(commId, data, metadata, buffers);
+      return;
+    }
     if (method === "update") {
-      await resolveBlobUrlsInPlace(data, bufferPaths);
-      store.updateModel(commId, data, bufferPaths);
+      const update =
+        data !== null && typeof data === "object" ? (data as Record<string, unknown>) : {};
+      await resolveBlobUrlsInPlace(update, bufferPaths);
+      store.updateModel(commId, update, bufferPaths);
     } else if (method === "custom") {
-      store.emitCustomMessage(commId, data, buffers);
+      const content =
+        data !== null && typeof data === "object" ? (data as Record<string, unknown>) : {};
+      store.emitCustomMessage(commId, content, buffers);
     }
   });
 
   transport.onNotification(NTERACT_COMM_CLOSE, (params) => {
     const { commId } = params as { commId: string };
+    if (closeRawMessage(commId)) return;
     store.deleteModel(commId);
   });
 
@@ -179,6 +543,10 @@ export function createWidgetBridgeClient(transport: JsonRpcTransport): WidgetBri
     };
     await Promise.all(
       models.map(async (model) => {
+        if (model.targetName && model.targetName !== "jupyter.widget") {
+          deliverRawOpen(model.commId, model.targetName, model.state);
+          return;
+        }
         await resolveBlobUrlsInPlace(model.state, model.bufferPaths);
         store.createModel(model.commId, model.state, model.bufferPaths, model.targetName);
       }),
@@ -190,7 +558,16 @@ export function createWidgetBridgeClient(transport: JsonRpcTransport): WidgetBri
   // and we'll re-send via the handler above)
   sendWidgetReady();
 
-  return {
+  function registerPyVizKernel(plotId: string) {
+    return client.registerPyVizKernel(plotId);
+  }
+
+  function ensurePyVizCommManager() {
+    const pyviz = ensurePyViz();
+    pyviz.comm_manager = createPyVizCommManager(pyviz);
+  }
+
+  const client: WidgetBridgeClient = {
     store,
 
     sendUpdate(commId: string, state: Record<string, unknown>) {
@@ -216,8 +593,53 @@ export function createWidgetBridgeClient(transport: JsonRpcTransport): WidgetBri
       transport.notify(NTERACT_WIDGET_COMM_CLOSE, { commId });
     },
 
+    registerPyVizKernel(plotId: string) {
+      const pyviz = ensurePyViz();
+      const kernelProxy: PyVizKernelProxy = {
+        registerCommTarget(targetName, callback) {
+          registerRawTarget(targetName, callback);
+        },
+        connectToComm(targetName, commId = targetName) {
+          return connectRawComm(targetName, commId);
+        },
+      };
+      pyviz.kernels![plotId] = kernelProxy;
+      return () => {
+        if (pyviz.kernels?.[plotId] === kernelProxy) {
+          delete pyviz.kernels[plotId];
+        }
+      };
+    },
+
     dispose() {
       // Transport lifecycle is managed by index.tsx
+      rawComms.clear();
+      rawTargets.clear();
+      pendingRawOpens.clear();
+      if (currentWidgetBridgeClient === client) {
+        for (const registration of pendingPyVizKernelRegistrations().values()) {
+          registration.unregister?.();
+          registration.unregister = undefined;
+        }
+        currentWidgetBridgeClient = null;
+      }
+      const target = window as WidgetBridgeWindow;
+      if (target.__nteractWidgetBridgeClient === client) {
+        delete target.__nteractWidgetBridgeClient;
+      }
+      if (target.__nteractRegisterPyVizKernel === registerPyVizKernel) {
+        delete target.__nteractRegisterPyVizKernel;
+      }
+      if (target.__nteractEnsurePyVizCommManager === ensurePyVizCommManager) {
+        delete target.__nteractEnsurePyVizCommManager;
+      }
     },
   };
+  const target = window as WidgetBridgeWindow;
+  currentWidgetBridgeClient = client;
+  target.__nteractWidgetBridgeClient = client;
+  target.__nteractRegisterPyVizKernel = registerPyVizKernel;
+  target.__nteractEnsurePyVizCommManager = ensurePyVizCommManager;
+  flushPendingPyVizKernelRegistrations(client);
+  return client;
 }

--- a/src/isolated-renderer/widget-provider.tsx
+++ b/src/isolated-renderer/widget-provider.tsx
@@ -41,6 +41,8 @@ interface IframeWidgetStoreContextValue {
   sendCustom: (commId: string, content: Record<string, unknown>, buffers?: ArrayBuffer[]) => void;
   /** Close a comm channel via parent */
   closeComm: (commId: string) => void;
+  /** Register a PyViz-compatible kernel proxy for Panel document comms. */
+  registerPyVizKernel: (plotId: string) => () => void;
 }
 
 // === Context ===
@@ -101,6 +103,7 @@ export function IframeWidgetStoreProvider({ children }: IframeWidgetStoreProvide
       sendUpdate: client.sendUpdate,
       sendCustom: client.sendCustom,
       closeComm: client.closeComm,
+      registerPyVizKernel: client.registerPyVizKernel,
     }),
     [client],
   );


### PR DESCRIPTION
## Summary

- Route Panel/PyViz raw Jupyter comms through the isolated renderer bridge and kernel shell channel.
- Add a pyviz_comms-compatible `PyViz.comm_manager` facade so Panel managers attach live ACK/message handlers across re-renders.
- Forward runtime-agent kernel comm broadcasts back to notebook peers and preserve Panel's non-standard `comm_msg` payloads without killing IOPub.
- Harden Panel/Bokeh resource loading so Panel waits for notebook autoloaded Bokeh widgets before executing output bundles.

## Verification

- `vp test run src/components/isolated/__tests__/frame-bridge.test.ts src/components/isolated/__tests__/comm-bridge-manager.test.ts src/components/isolated/__tests__/output-lane-policy.test.ts src/components/widgets/__tests__/comm-changes-store-bridge.test.ts src/isolated-renderer/__tests__/widget-bridge-client.test.ts src/isolated-renderer/__tests__/panel-renderer.test.tsx`
- `cargo test -p runtimed lenient_iopub_reader_preserves_non_standard_comm_msg_payloads`
- `cargo test -p runtimed-client test_notebook_broadcast_comm`
- `cargo test -p notebook-sync concurrent_send_request_routes_responses_by_id`
- `cargo check -p notebook-protocol -p runtimed-client -p notebook-sync -p runtimed`
- `pnpm --dir apps/notebook build`
- `cargo xtask renderer-plugins --only isolated-renderer,panel`
- `cargo xtask artifacts verify renderer`
- `cargo xtask lint --fix`

## Browser smoke

- Playwright against `http://localhost:8784` initially reproduced the local env-selection blocker: the browser-launched kernel selected a transient conda env without `panel`, yielding `ModuleNotFoundError: No module named 'panel'`.
- After installing `panel>=1.9,<2` into that selected transient env, the same notebook rendered a Panel `FloatSlider` inside the isolated iframe. The iframe reported active PyViz comms, registered PyViz kernels, and the nteract-provided `PyViz.comm_manager` facade.
- I attempted an additional programmatic slider-value round trip, but that script did not get a clean DOM interaction signal from Bokeh's slider internals, so I am not counting that as verified browser interaction coverage.
