### PR TITLE
feat(comments): quiet the selection affordance and stage its open with WAAPI

### DIFF
--- a/apps/elements/components/comment-selection-affordance-example.tsx
+++ b/apps/elements/components/comment-selection-affordance-example.tsx
@@ -18,10 +18,11 @@ export function CommentSelectionAffordanceExample() {
     <div className="not-prose my-6">
       <div className="mx-auto max-w-[760px] border border-border bg-background px-6 py-5 text-foreground shadow-sm max-sm:px-4">
         <p className="mb-5 text-sm text-muted-foreground">
-          A small author-colored dot that breathes at rest, peeks open once when it appears so you
-          can tell what it is, then springs into a "Comment" speech bubble on hover or keyboard
-          focus. No icon: the bubble shape is the cue. The editor and rendered-markdown planes share
-          this one surface, tunable here via <code>--comment-affordance-color</code>.
+          A small, flat, author-colored dot that stays out of the way while you select. It opens
+          into a "Comment" pill only on hover or keyboard focus, a staged grow then spread then
+          reveal driven by the Web Animations API. No icon: the pill shape and label are the cue.
+          The editor and rendered-markdown planes share this one surface, tunable here via{" "}
+          <code>--comment-affordance-color</code>.
         </p>
         <div className="flex flex-wrap items-center gap-x-8 gap-y-4 text-sm">
           {SAMPLES.map((sample) => (

--- a/apps/notebook/src/lib/source-comment-extension.ts
+++ b/apps/notebook/src/lib/source-comment-extension.ts
@@ -1,5 +1,6 @@
 import { StateEffect, StateField, type Extension } from "@codemirror/state";
 import { EditorView, keymap, showTooltip, type Tooltip } from "@codemirror/view";
+import { wireCommentAffordanceMotion } from "@/components/comments/comment-affordance-motion";
 import {
   MAX_SOURCE_COMMENT_EXACT_QUOTE_BYTES,
   selectionRectFromView,
@@ -15,10 +16,6 @@ export type SourceCommentRequestHandler = (
 
 const setSourceCommentFocusEffect = StateEffect.define<boolean>();
 const utf8Encoder = new TextEncoder();
-
-// How long the affordance peeks open when it first appears, so a fresh
-// selection can tell what it is before it settles to a quiet dot.
-const SOURCE_COMMENT_PEEK_MS = 1400;
 
 interface SourceCommentTooltipState {
   focused: boolean;
@@ -86,6 +83,11 @@ function sourceCommentTooltips(
   if (selectedText.trim().length === 0) return [];
   if (utf8Encoder.encode(selectedText).length > MAX_SOURCE_COMMENT_EXACT_QUOTE_BYTES) return [];
 
+  // The tooltip anchors at the head, the moving end of the selection. When the
+  // selection runs leftward the head is at its start, so flip the dot to the left
+  // of the head instead of letting it sit on the right, over the selected text.
+  const leftward = selection.head < selection.anchor;
+
   return [
     {
       pos: selection.head,
@@ -94,12 +96,14 @@ function sourceCommentTooltips(
       create(view) {
         // Shared dot affordance (styles/comment-affordance.css), matching the
         // rendered-markdown plane. CodeMirror wraps this in a .cm-tooltip; the
-        // shared CSS strips that wrapper's chrome so only the dot shows. The dot
-        // peeks open once on appear so a fresh selection can tell what it is,
-        // then settles to a quiet dot.
+        // shared CSS strips that wrapper's chrome so only the dot shows. It stays
+        // a quiet dot while you select and folds out to a "Comment" pill only on
+        // hover or keyboard focus, so dragging a selection never flashes the pill.
         const button = document.createElement("button");
         button.type = "button";
-        button.className = "comment-affordance comment-affordance-peek";
+        button.className = leftward
+          ? "comment-affordance comment-affordance-flip"
+          : "comment-affordance";
         // No title attribute: the native browser tooltip duplicates the bubble's
         // own "Comment" label. aria-label keeps it accessible.
         button.setAttribute("aria-label", "Comment on selection");
@@ -112,9 +116,7 @@ function sourceCommentTooltips(
         label.textContent = "Comment";
         dot.appendChild(label);
         button.appendChild(dot);
-        const peekTimer = setTimeout(() => {
-          button.classList.remove("comment-affordance-peek");
-        }, SOURCE_COMMENT_PEEK_MS);
+        const disposeMotion = wireCommentAffordanceMotion(button);
         button.addEventListener("mousedown", (event) => {
           event.preventDefault();
         });
@@ -125,7 +127,7 @@ function sourceCommentTooltips(
         return {
           dom: button,
           destroy() {
-            clearTimeout(peekTimer);
+            disposeMotion();
           },
         };
       },

--- a/src/components/comments/CommentSelectionAffordance.tsx
+++ b/src/components/comments/CommentSelectionAffordance.tsx
@@ -1,6 +1,7 @@
-import { useEffect, useState } from "react";
+import { useEffect, useRef } from "react";
 import type { CSSProperties, MouseEvent as ReactMouseEvent } from "react";
 import { cn } from "@/lib/utils";
+import { wireCommentAffordanceMotion } from "./comment-affordance-motion";
 
 export interface CommentSelectionAffordanceProps {
   /** Fires on click or keyboard activation. Receives the button event so the
@@ -12,18 +13,14 @@ export interface CommentSelectionAffordanceProps {
   /** Accessible name (aria-label/title). The bubble always reads "Comment". */
   label?: string;
   testId?: string;
-  /** Play the one-time appear peek (the dot springs open, then settles to a dot)
-   *  so a fresh selection can tell what it is. Defaults to on. */
-  peekOnMount?: boolean;
 }
-
-const PEEK_MS = 1400;
 
 /**
  * The "comment on selection" affordance: an author-colored dot that breathes at
- * rest, peeks open once when it appears, and springs into a labeled "Comment"
- * speech bubble on hover or focus. No icon: the bubble shape is the cue. Shared
- * by the code-editor and rendered-markdown planes; the visual lives in
+ * rest and springs into a labeled "Comment" speech bubble on hover or focus. No
+ * icon: the bubble shape is the cue. It never folds out on its own, so dragging a
+ * selection (almost always to edit code, not to comment) stays quiet. Shared by
+ * the code-editor and rendered-markdown planes; the visual lives in
  * styles/comment-affordance.css so both surfaces match and stay tunable in
  * Elements.
  */
@@ -33,22 +30,24 @@ export function CommentSelectionAffordance({
   style,
   label = "Comment",
   testId,
-  peekOnMount = true,
 }: CommentSelectionAffordanceProps) {
-  const [peeking, setPeeking] = useState(peekOnMount);
+  const buttonRef = useRef<HTMLButtonElement>(null);
 
+  // Stage the hover/focus open through the shared Web Animations helper, the same
+  // one the editor plane uses, so both surfaces morph identically.
   useEffect(() => {
-    if (!peekOnMount) return;
-    const timer = setTimeout(() => setPeeking(false), PEEK_MS);
-    return () => clearTimeout(timer);
-  }, [peekOnMount]);
+    const el = buttonRef.current;
+    if (!el) return;
+    return wireCommentAffordanceMotion(el);
+  }, []);
 
   return (
     <button
+      ref={buttonRef}
       type="button"
       aria-label={label}
       data-testid={testId}
-      className={cn("comment-affordance", peeking && "comment-affordance-peek", className)}
+      className={cn("comment-affordance", className)}
       style={style}
       onPointerDown={(event) => {
         // Keep the active text selection while the affordance is pressed.

--- a/src/components/comments/comment-affordance-motion.ts
+++ b/src/components/comments/comment-affordance-motion.ts
@@ -1,0 +1,115 @@
+/**
+ * Motion for the comment-on-selection affordance, shared by the CodeMirror
+ * editor plane and the rendered-markdown plane.
+ *
+ * The open is a staged morph driven by the Web Animations API, not CSS: a dot
+ * grows to a circle, spreads to a pill, then reveals the label. WAAPI buys two
+ * things a CSS keyframe could not. It reverses cleanly with `reverse()` from
+ * wherever the open got to (CSS keyframes snap back, and a transition-reverse
+ * cannot replay the intermediate "circle" stop). And it lets us measure the
+ * label's natural width and animate to that, FLIP-style, instead of guessing a
+ * fixed cap that clips long labels.
+ *
+ * Events are the input, the Animation handle is the manifested state: hover and
+ * focus play it forward, leave and blur play it back. CSS owns the resting look;
+ * this owns the open.
+ */
+
+// Total open duration. The reverse uses the same handle, so close matches.
+const OPEN_DURATION_MS = 260;
+// Horizontal padding of the open pill, also the width we add when measuring.
+const PILL_PADDING_X = 10;
+// Height the dot grows to before it spreads (the pill height).
+const PILL_HEIGHT = 20;
+// Size of the resting dot, kept in sync with comment-affordance.css.
+const DOT_SIZE = 8;
+const FALLBACK_EASE = "cubic-bezier(0.16, 1, 0.3, 1)";
+
+/**
+ * Wire hover/focus motion onto an affordance button. Returns a disposer that
+ * removes the listeners and cancels the animations. Safe to call where WAAPI is
+ * absent (SSR, jsdom): it no-ops and returns a disposer.
+ */
+export function wireCommentAffordanceMotion(button: HTMLElement): () => void {
+  if (typeof window === "undefined" || typeof button.animate !== "function") {
+    return () => {};
+  }
+  const dot = button.querySelector<HTMLElement>(".comment-affordance-dot");
+  const label = button.querySelector<HTMLElement>(".comment-affordance-label");
+  if (!dot || !label) return () => {};
+
+  const reduceMotion = window.matchMedia?.("(prefers-reduced-motion: reduce)").matches ?? false;
+
+  let dotAnim: Animation | null = null;
+  let labelAnim: Animation | null = null;
+
+  const ensure = () => {
+    if (dotAnim) return;
+    // Read the design tokens from CSS so sizes and easing have one source of
+    // truth. Lazy, on first hover, when the button is in the DOM and these
+    // custom properties resolve.
+    const styles = getComputedStyle(button);
+    const easing = styles.getPropertyValue("--comment-affordance-ease").trim() || FALLBACK_EASE;
+    const dotSize =
+      parseFloat(styles.getPropertyValue("--comment-affordance-dot-size")) || DOT_SIZE;
+    const pillHeight =
+      parseFloat(styles.getPropertyValue("--comment-affordance-pill-height")) || PILL_HEIGHT;
+    const duration = reduceMotion ? 0 : OPEN_DURATION_MS;
+    // Measure the label at its natural width (nowrap, so scrollWidth is the full
+    // text even while the dot clips it), then grow the pill to fit it exactly.
+    const target = Math.ceil(label.scrollWidth) + PILL_PADDING_X * 2;
+    // Stage the open with per-keyframe easing: grow to a circle by 40%, then
+    // spread to the pill. Overall timing stays linear so each stage owns its
+    // own decelerating curve instead of one curve warping the whole sequence.
+    dotAnim = dot.animate(
+      [
+        { maxWidth: `${dotSize}px`, height: `${dotSize}px`, padding: "0px", easing },
+        {
+          maxWidth: `${pillHeight}px`,
+          height: `${pillHeight}px`,
+          padding: "0px",
+          offset: 0.4,
+          easing,
+        },
+        { maxWidth: `${target}px`, height: `${pillHeight}px`, padding: `0 ${PILL_PADDING_X}px` },
+      ],
+      { duration, easing: "linear", fill: "both" },
+    );
+    // Letters fade in only once there is room, in the back half of the spread.
+    labelAnim = label.animate([{ opacity: 0 }, { opacity: 0, offset: 0.6 }, { opacity: 1 }], {
+      duration,
+      easing: "linear",
+      fill: "both",
+    });
+    for (const anim of [dotAnim, labelAnim]) {
+      anim.currentTime = 0;
+      anim.pause();
+    }
+  };
+
+  const drive = (rate: number) => {
+    ensure();
+    for (const anim of [dotAnim, labelAnim]) {
+      if (!anim) continue;
+      anim.playbackRate = rate;
+      anim.play();
+    }
+  };
+
+  const open = () => drive(1);
+  const close = () => drive(-1);
+
+  button.addEventListener("pointerenter", open);
+  button.addEventListener("pointerleave", close);
+  button.addEventListener("focus", open);
+  button.addEventListener("blur", close);
+
+  return () => {
+    button.removeEventListener("pointerenter", open);
+    button.removeEventListener("pointerleave", close);
+    button.removeEventListener("focus", open);
+    button.removeEventListener("blur", close);
+    dotAnim?.cancel();
+    labelAnim?.cancel();
+  };
+}

--- a/src/components/comments/comment-affordance-motion.ts
+++ b/src/components/comments/comment-affordance-motion.ts
@@ -101,12 +101,17 @@ export function wireCommentAffordanceMotion(button: HTMLElement): () => void {
 
   button.addEventListener("pointerenter", open);
   button.addEventListener("pointerleave", close);
+  // pointercancel: an interrupted touch (the system takes over the pointer for a
+  // scroll or gesture) fires no pointerleave, so close here too or the pill
+  // would stay open.
+  button.addEventListener("pointercancel", close);
   button.addEventListener("focus", open);
   button.addEventListener("blur", close);
 
   return () => {
     button.removeEventListener("pointerenter", open);
     button.removeEventListener("pointerleave", close);
+    button.removeEventListener("pointercancel", close);
     button.removeEventListener("focus", open);
     button.removeEventListener("blur", close);
     dotAnim?.cancel();

--- a/src/styles/comment-affordance.css
+++ b/src/styles/comment-affordance.css
@@ -2,31 +2,39 @@
    plane and the rendered-markdown plane. One definition so both surfaces match
    and the look is tunable in one place (cataloged in Elements).
 
-   Resting state is a small author-colored dot that breathes gently, sitting out
-   of the way while a reader selects and copies text. On appear it peeks open
-   once (so you can tell what it is), and on hover or keyboard focus it springs
-   into a labeled "Comment" speech bubble with a tail. The spring matches the
-   running motion (exec-squish). No icon: the bubble shape is the comment cue.
-
-   The reveal animates the bubble's own max-width while it clips its overflow, so
-   the bubble grows to its content (the label at its natural width) capped by a
-   generous ceiling. The word never clips, on every engine including iOS Safari
-   (grid fr tracks do not resolve to content width there). */
+   Resting state is a small, flat, author-colored dot, sitting quietly out of the
+   way while a reader selects and copies text. It never opens on its own: most
+   selection is for editing code, not commenting. On hover or keyboard focus it
+   morphs into a labeled "Comment" pill, a staged grow -> spread -> reveal driven
+   by the Web Animations API (comment-affordance-motion.ts) so it reads as one
+   motion and reverses cleanly. CSS owns the resting look; the helper owns the
+   open. No icon: the pill shape and label are the cue. */
 .comment-affordance {
   /* Tinted with the author's canonical color (the same color as their cursor and
      edits), set on an ancestor as --comment-author-color. Falls back to the
      theme accent only if no author color is in scope. --primary is a near-black
      neutral in the default theme, so it is the fallback, not the default. */
   --comment-affordance-color: var(--comment-author-color, var(--primary, #2563eb));
-  --comment-affordance-spring: cubic-bezier(0.34, 1.56, 0.64, 1);
+  /* Per-stage easing for the open, read by comment-affordance-motion.ts. One
+     decelerating curve, no overshoot: a spring here read as thrashy. */
+  --comment-affordance-ease: cubic-bezier(0.16, 1, 0.3, 1);
+  /* Sizes are tokens so CSS and the motion helper share one source of truth;
+     the helper reads these to build the open keyframes. */
+  --comment-affordance-dot-size: 8px;
+  --comment-affordance-pill-height: 20px;
   box-sizing: border-box;
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  /* Content-sized with padding for the hit area. A fixed width would cap the
-     dot's growth: on WebKit/iOS Safari a flex child cannot exceed a fixed-width
-     flex parent, which clipped the open bubble to one glyph on mobile. */
+  /* Content-sized width with padding for the hit area. A fixed width would cap
+     the dot's growth: on WebKit/iOS Safari a flex child cannot exceed a
+     fixed-width flex parent, which clipped the open pill to one glyph on mobile.
+     Height is fixed to the open pill, though: it reserves the tooltip box so
+     CodeMirror measures and positions it once. Without it, growing the dot taller
+     re-anchors the tooltip above the line in an unanimated upward jump. The dot
+     is centered in the reserved height, so the open grows from the dot's center. */
   padding: 6px;
+  height: calc(var(--comment-affordance-pill-height) + 12px);
   margin: 0;
   border: none;
   background: transparent;
@@ -34,26 +42,23 @@
   cursor: pointer;
 }
 
+/* Resting dot and the box the open animates. The helper measures the label's
+   natural width and grows max-width to it, so the pill fits its content and the
+   word never clips (the overflow clip hides it until there is room). */
 .comment-affordance-dot {
-  position: relative;
   display: inline-flex;
   flex: none;
   align-items: center;
   justify-content: center;
-  height: 14px;
-  max-width: 14px;
+  height: 8px;
+  max-width: 8px;
   padding: 0;
   overflow: hidden;
-  border-radius: 999px;
+  border-radius: 999px; /* stadium: a circle at rest, a pill when open */
   background-color: var(--comment-affordance-color);
   color: #ffffff;
-  box-shadow: 0 1px 5px color-mix(in srgb, var(--comment-affordance-color) 50%, transparent);
-  transition:
-    max-width 280ms var(--comment-affordance-spring),
-    height 260ms var(--comment-affordance-spring),
-    padding 260ms var(--comment-affordance-spring),
-    border-radius 200ms ease;
-  animation: comment-affordance-breathe 2.8s ease-in-out infinite;
+  /* Flat at rest. No shadow, no breathe: a dot that pulses next to code is
+     noise, and the resting dot should read as barely there. */
 }
 
 .comment-affordance-label {
@@ -62,49 +67,15 @@
   font-weight: 600;
   letter-spacing: -0.01em;
   line-height: 1;
-  opacity: 0;
-  transition: opacity 130ms ease 60ms;
+  opacity: 0; /* revealed in the back half of the open animation */
 }
 
-/* Speech-bubble tail, only while open. */
-.comment-affordance-dot::after {
-  content: "";
-  position: absolute;
-  left: 9px;
-  bottom: -4px;
-  width: 0;
-  height: 0;
-  border-left: 5px solid transparent;
-  border-right: 5px solid transparent;
-  border-top: 6px solid var(--comment-affordance-color);
-  opacity: 0;
-  transform: scale(0.4);
-  transition:
-    opacity 120ms ease,
-    transform 200ms var(--comment-affordance-spring);
-}
-
-/* OPEN: hover, keyboard focus, or the one-time appear peek. The bubble grows to
-   fit its label (capped at 9rem) and the word is fully revealed. */
-.comment-affordance:hover .comment-affordance-dot,
-.comment-affordance:focus-visible .comment-affordance-dot,
-.comment-affordance.comment-affordance-peek .comment-affordance-dot {
-  max-width: 9rem;
-  height: 22px;
-  padding: 0 10px;
-  border-radius: 11px;
-  animation: comment-affordance-open 320ms var(--comment-affordance-spring);
-}
-.comment-affordance:hover .comment-affordance-label,
-.comment-affordance:focus-visible .comment-affordance-label,
-.comment-affordance.comment-affordance-peek .comment-affordance-label {
-  opacity: 1;
-}
-.comment-affordance:hover .comment-affordance-dot::after,
-.comment-affordance:focus-visible .comment-affordance-dot::after,
-.comment-affordance.comment-affordance-peek .comment-affordance-dot::after {
-  opacity: 1;
-  transform: scale(1);
+/* Leftward selection (editor plane): the head is at the selection start, so
+   anchor the button's right edge at the head and let it grow leftward, keeping
+   the dot on the cursor's outer side and off the selected text. translateX is a
+   percentage of the button's own width, so it re-anchors as the pill grows. */
+.comment-affordance-flip {
+  transform: translateX(-100%);
 }
 
 .comment-affordance:focus-visible {
@@ -113,42 +84,6 @@
 .comment-affordance:focus-visible .comment-affordance-dot {
   outline: 2px solid var(--ring, #a3a3a3);
   outline-offset: 2px;
-}
-
-@keyframes comment-affordance-breathe {
-  0%,
-  100% {
-    box-shadow: 0 1px 4px color-mix(in srgb, var(--comment-affordance-color) 35%, transparent);
-    transform: scale(1);
-  }
-  50% {
-    box-shadow: 0 1px 9px color-mix(in srgb, var(--comment-affordance-color) 60%, transparent);
-    transform: scale(1.12);
-  }
-}
-
-@keyframes comment-affordance-open {
-  0% {
-    transform: scale(1, 1);
-  }
-  35% {
-    transform: scale(1.06, 0.94);
-  }
-  70% {
-    transform: scale(0.99, 1.01);
-  }
-  100% {
-    transform: scale(1, 1);
-  }
-}
-
-@media (prefers-reduced-motion: reduce) {
-  .comment-affordance-dot,
-  .comment-affordance-label,
-  .comment-affordance-dot::after {
-    animation: none;
-    transition: none;
-  }
 }
 
 /* CodeMirror merges its tooltip classes onto the affordance button itself (the


### PR DESCRIPTION
The comment-on-selection affordance auto-folded into a "Comment" pill while you dragged a selection, sprang open on its own, and jumped into position before expanding. Most text selection is for editing code, not commenting, so this makes it stay out of the way and open deliberately when you reach for it. Follows #3773.

## Quiet at rest

A small (8px), flat, author-colored dot. No auto-peek, no breathe, no shadow. It stays a dot through the whole selection and opens only on hover or keyboard focus, on both the editor and rendered-markdown planes.

## Staged open via the Web Animations API

Hover and focus drive a staged morph: the dot grows to a circle, spreads to a pill, then the label fades in once there is room. WAAPI over a CSS keyframe for two reasons:

- It reverses cleanly from wherever the open got to. A CSS keyframe snaps back, and a transition-reverse cannot replay the intermediate "circle" stop.
- It measures the label's natural width and animates to that, so the pill fits its content instead of a guessed cap that clips long labels.

Events are the input, the `Animation` handle is the state: enter/focus play it forward, leave/blur play it back. Sizes and easing live in CSS custom properties the helper reads, so there is one source of truth.

## No reposition jump

The tooltip reserves the open pill's height, so CodeMirror measures and positions it once. The dot is centered in that height and grows from its center, instead of the box growing taller and re-anchoring above the line in an unanimated upward jump.

## Placement follows the cursor

In the editor the dot sits at the selection head; a leftward selection flips it to the left of the head and grows leftward, keeping it off the selected text. Rendered markdown has no cursor, so it stays to the right of the full selection.

## Scope

Removes the old peek capability (prop, state, timer, and CSS) rather than leaving it as dead code. The author-color tint and resolved-highlight behavior from #3773 are unchanged.

| State | Before | After |
|-------|--------|-------|
| Dragging a selection | "Comment" pill folded out | Quiet flat dot |
| Resting dot | 14px, breathing, shadowed | 8px, flat, still |
| Open | All dimensions tween at once, snaps back | Staged grow → spread → reveal, reverses cleanly |
| Tooltip on grow | Jumps up to re-anchor | Reserved height, grows from center |
| Leftward selection (editor) | Dot on the right, over the text | Dot flips left, off the text |

Verified live in the dev app across both planes; `vp check` and `vp test run` green (2461 passed, 0 failures).
