### PR TITLE
feat(panel): add lazy launcher runtime hook

### DIFF
--- a/apps/notebook/src/App.tsx
+++ b/apps/notebook/src/App.tsx
@@ -17,6 +17,10 @@ import {
   type SessionStatus,
 } from "runtimed";
 import { IsolationTest } from "@/components/isolated";
+import type {
+  PanelRuntimeIframeMessage,
+  PanelRuntimeMessageContext,
+} from "@/components/cell/OutputArea";
 import { MediaProvider } from "@/components/outputs/media-provider";
 import {
   applyWidgetCommBroadcastToStore,
@@ -1061,6 +1065,19 @@ function AppContent() {
     };
   }, [sendCommMessage]);
 
+  const handlePanelRuntimeMessage = useCallback(
+    (_message: PanelRuntimeIframeMessage, context: PanelRuntimeMessageContext) => {
+      const event = context.event;
+      logger.debug("[panel-runtime] Browser event reached notebook runtime boundary", {
+        type: event.type,
+        channelId: event.channel.channelId,
+        cellId: context.cellId ?? null,
+        outputIds: context.outputIds,
+      });
+    },
+    [],
+  );
+
   // Set up CRDT comm writer for widget state updates.
   // Writes directly to CommsDoc via WASM — no SendComm round-trip.
   useEffect(() => {
@@ -2088,6 +2105,7 @@ function AppContent() {
                 onAddCell={handleAddCell}
                 onMoveCell={moveCell}
                 onReportOutputMatchCount={globalFind.reportOutputMatchCount}
+                onPanelRuntimeMessage={handlePanelRuntimeMessage}
                 onSetCellSourceHidden={setCellSourceHidden}
                 onSetCellOutputsHidden={setCellOutputsHidden}
                 onCreateSourceComment={canMutateComments ? handleRequestSourceComment : undefined}

--- a/apps/notebook/src/App.tsx
+++ b/apps/notebook/src/App.tsx
@@ -13,14 +13,12 @@ import {
   type ExecuteCellOptions,
   type NotebookResponse,
   type NotebookOutlineItem,
+  type PanelRuntimeIframeMessage,
   putBlob,
   type SessionStatus,
 } from "runtimed";
 import { IsolationTest } from "@/components/isolated";
-import type {
-  PanelRuntimeIframeMessage,
-  PanelRuntimeMessageContext,
-} from "@/components/cell/OutputArea";
+import type { PanelRuntimeMessageContext } from "@/components/cell/OutputArea";
 import { MediaProvider } from "@/components/outputs/media-provider";
 import {
   applyWidgetCommBroadcastToStore,
@@ -1068,6 +1066,7 @@ function AppContent() {
   const handlePanelRuntimeMessage = useCallback(
     (_message: PanelRuntimeIframeMessage, context: PanelRuntimeMessageContext) => {
       const event = context.event;
+      // TODO(next slice): forward this typed event to the daemon Panel runtime transport.
       logger.debug("[panel-runtime] Browser event reached notebook runtime boundary", {
         type: event.type,
         channelId: event.channel.channelId,

--- a/apps/notebook/src/components/CodeCell.tsx
+++ b/apps/notebook/src/components/CodeCell.tsx
@@ -5,7 +5,11 @@ import { CellContainer } from "@/components/cell/CellContainer";
 import { cellOutputInnerInset } from "@/components/cell/cell-layout";
 import { CompactExecutionButton } from "@/components/cell/CompactExecutionButton";
 import { CodeCellCurrentLine } from "@/components/cell/CodeCellCurrentLine";
-import { OutputArea } from "@/components/cell/OutputArea";
+import {
+  OutputArea,
+  type PanelRuntimeIframeMessage,
+  type PanelRuntimeMessageContext,
+} from "@/components/cell/OutputArea";
 import { CodeMirrorEditor, type CodeMirrorEditorRef } from "@/components/editor/codemirror-editor";
 import { languageDisplayNames, type SupportedLanguage } from "@/components/editor/languages";
 import { remoteCursorsExtension } from "@/components/editor/remote-cursors";
@@ -114,6 +118,10 @@ interface CodeCellProps {
   outputHostContext?: NteractEmbedHostContextPatch;
   deferOutputIsolatedFrameUntilVisible?: boolean;
   deferredOutputIsolatedFrameRootMargin?: string;
+  onPanelRuntimeMessage?: (
+    message: PanelRuntimeIframeMessage,
+    context: PanelRuntimeMessageContext,
+  ) => void;
 }
 
 export interface HiddenGroupCellSummary {
@@ -368,6 +376,7 @@ export const CodeCell = memo(function CodeCell({
   outputHostContext,
   deferOutputIsolatedFrameUntilVisible = false,
   deferredOutputIsolatedFrameRootMargin,
+  onPanelRuntimeMessage,
 }: CodeCellProps) {
   // Read transient UI state from the store
   const isFocused = useIsCellFocused(cell.id);
@@ -881,6 +890,7 @@ export const CodeCell = memo(function CodeCell({
               onLinkClick={handleLinkClick}
               onIframeMouseDown={handleOutputMouseDown}
               onDiagnostic={logNotebookIsolatedDiagnostic}
+              onPanelRuntimeMessage={onPanelRuntimeMessage}
               layoutInset="cell-output"
               hostContext={outputHostContext}
               resolveTracebackExecutionTarget={resolveTracebackExecutionTarget}

--- a/apps/notebook/src/components/CodeCell.tsx
+++ b/apps/notebook/src/components/CodeCell.tsx
@@ -1,15 +1,12 @@
 import type { EditorView, KeyBinding } from "@codemirror/view";
 import { ChevronRight, Code2, Eye, EyeOff, MessageSquarePlus, type LucideIcon } from "lucide-react";
 import { memo, type ReactNode, useCallback, useEffect, useMemo, useRef, useState } from "react";
+import type { PanelRuntimeIframeMessage } from "runtimed";
 import { CellContainer } from "@/components/cell/CellContainer";
 import { cellOutputInnerInset } from "@/components/cell/cell-layout";
 import { CompactExecutionButton } from "@/components/cell/CompactExecutionButton";
 import { CodeCellCurrentLine } from "@/components/cell/CodeCellCurrentLine";
-import {
-  OutputArea,
-  type PanelRuntimeIframeMessage,
-  type PanelRuntimeMessageContext,
-} from "@/components/cell/OutputArea";
+import { OutputArea, type PanelRuntimeMessageContext } from "@/components/cell/OutputArea";
 import { CodeMirrorEditor, type CodeMirrorEditorRef } from "@/components/editor/codemirror-editor";
 import { languageDisplayNames, type SupportedLanguage } from "@/components/editor/languages";
 import { remoteCursorsExtension } from "@/components/editor/remote-cursors";

--- a/apps/notebook/src/components/NotebookView.tsx
+++ b/apps/notebook/src/components/NotebookView.tsx
@@ -18,13 +18,14 @@ import {
 import { CSS as DndCSS } from "@dnd-kit/utilities";
 import { Eye, EyeOff, Plus, RotateCcw, Trash2, X } from "lucide-react";
 import { memo, useCallback, useEffect, useMemo, useRef, useState } from "react";
-import { notebookCellAnchorId, type NotebookInteractionTarget } from "runtimed";
+import {
+  notebookCellAnchorId,
+  type NotebookInteractionTarget,
+  type PanelRuntimeIframeMessage,
+} from "runtimed";
 import { CellInsertionRibbon, type CellInsertionType } from "@/components/cell/CellInsertionRibbon";
 import { CellSkeleton } from "@/components/cell/CellSkeleton";
-import type {
-  PanelRuntimeIframeMessage,
-  PanelRuntimeMessageContext,
-} from "@/components/cell/OutputArea";
+import type { PanelRuntimeMessageContext } from "@/components/cell/OutputArea";
 import { Button } from "@/components/ui/button";
 import type { NteractEmbedHostContextPatch } from "@/components/isolated/host-context";
 import type { NotebookShellCapabilities } from "@/components/notebook";

--- a/apps/notebook/src/components/NotebookView.tsx
+++ b/apps/notebook/src/components/NotebookView.tsx
@@ -21,6 +21,10 @@ import { memo, useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { notebookCellAnchorId, type NotebookInteractionTarget } from "runtimed";
 import { CellInsertionRibbon, type CellInsertionType } from "@/components/cell/CellInsertionRibbon";
 import { CellSkeleton } from "@/components/cell/CellSkeleton";
+import type {
+  PanelRuntimeIframeMessage,
+  PanelRuntimeMessageContext,
+} from "@/components/cell/OutputArea";
 import { Button } from "@/components/ui/button";
 import type { NteractEmbedHostContextPatch } from "@/components/isolated/host-context";
 import type { NotebookShellCapabilities } from "@/components/notebook";
@@ -101,6 +105,10 @@ export interface NotebookViewProps {
   outputHostContext?: NteractEmbedHostContextPatch;
   deferOutputIsolatedFramesUntilVisible?: boolean;
   deferredOutputIsolatedFrameRootMargin?: string;
+  onPanelRuntimeMessage?: (
+    message: PanelRuntimeIframeMessage,
+    context: PanelRuntimeMessageContext,
+  ) => void;
   autoFocusFirstCell?: boolean;
 }
 
@@ -381,6 +389,7 @@ function NotebookViewContent({
   outputHostContext,
   deferOutputIsolatedFramesUntilVisible = false,
   deferredOutputIsolatedFrameRootMargin,
+  onPanelRuntimeMessage,
   autoFocusFirstCell = true,
 }: NotebookViewProps) {
   const presence = usePresenceContext();
@@ -955,6 +964,7 @@ function NotebookViewContent({
             onCreateOutputComment={onCreateOutputComment}
             onActivateCommentThread={onActivateCommentThread}
             outputHostContext={outputHostContext}
+            onPanelRuntimeMessage={onPanelRuntimeMessage}
             deferOutputIsolatedFrameUntilVisible={deferOutputIsolatedFramesUntilVisible}
             deferredOutputIsolatedFrameRootMargin={deferredOutputIsolatedFrameRootMargin}
             onToggleSourceHidden={

--- a/apps/notebook/src/components/__tests__/code-cell-output-focus.test.tsx
+++ b/apps/notebook/src/components/__tests__/code-cell-output-focus.test.tsx
@@ -53,6 +53,7 @@ vi.mock("@/components/cell/OutputArea", () => ({
     preloadIframe,
     deferIsolatedFrameUntilVisible,
     deferredIsolatedFrameRootMargin,
+    onPanelRuntimeMessage,
   }: {
     focused?: boolean;
     useOutputWell?: boolean;
@@ -60,6 +61,7 @@ vi.mock("@/components/cell/OutputArea", () => ({
     preloadIframe?: boolean;
     deferIsolatedFrameUntilVisible?: boolean;
     deferredIsolatedFrameRootMargin?: string;
+    onPanelRuntimeMessage?: (message: unknown, context: unknown) => void;
   }) => (
     <button
       data-focused={String(focused)}
@@ -70,6 +72,35 @@ vi.mock("@/components/cell/OutputArea", () => ({
       data-testid="output"
       type="button"
       onMouseDown={onIframeMouseDown}
+      onClick={() =>
+        onPanelRuntimeMessage?.(
+          {
+            type: "panel_client_patch",
+            payload: { commId: "client-comm", plotId: "plot-1", data: { events: [] } },
+          },
+          {
+            event: {
+              protocol: "nteract.panel.runtime.v1",
+              version: 1,
+              type: "panel_client_patch",
+              direction: "iframe_to_kernel",
+              channel: {
+                channelId: "cell:code-1|output:output-1|plot:plot-1|comm:client-comm",
+                commId: "client-comm",
+                plotId: "plot-1",
+                cellId: "code-1",
+                executionCount: null,
+                outputId: "output-1",
+                outputIds: ["output-1"],
+              },
+              patch: { data: { events: [] }, metadata: {}, buffers: [] },
+            },
+            cellId: "code-1",
+            outputIds: ["output-1"],
+            outputs: [],
+          },
+        )
+      }
     >
       output
     </button>
@@ -757,5 +788,49 @@ describe("CodeCell output focus", () => {
     fireEvent.keyDown(getByTitle("Show hidden cell 2: second()"), { key: "ArrowDown" });
 
     expect(onFocusNext).not.toHaveBeenCalled();
+  });
+
+  it("forwards typed Panel runtime output messages", () => {
+    const onPanelRuntimeMessage = vi.fn();
+
+    const { getByTestId } = render(
+      <CodeCell
+        cell={makeCell()}
+        onFocus={() => {}}
+        onExecute={() => {}}
+        onInterrupt={() => {}}
+        onPanelRuntimeMessage={onPanelRuntimeMessage}
+      />,
+    );
+
+    fireEvent.click(getByTestId("output"));
+
+    expect(onPanelRuntimeMessage).toHaveBeenCalledWith(
+      {
+        type: "panel_client_patch",
+        payload: { commId: "client-comm", plotId: "plot-1", data: { events: [] } },
+      },
+      {
+        event: {
+          protocol: "nteract.panel.runtime.v1",
+          version: 1,
+          type: "panel_client_patch",
+          direction: "iframe_to_kernel",
+          channel: {
+            channelId: "cell:code-1|output:output-1|plot:plot-1|comm:client-comm",
+            commId: "client-comm",
+            plotId: "plot-1",
+            cellId: "code-1",
+            executionCount: null,
+            outputId: "output-1",
+            outputIds: ["output-1"],
+          },
+          patch: { data: { events: [] }, metadata: {}, buffers: [] },
+        },
+        cellId: "code-1",
+        outputIds: ["output-1"],
+        outputs: [],
+      },
+    );
   });
 });

--- a/crates/runtimed-wasm/src/lib.rs
+++ b/crates/runtimed-wasm/src/lib.rs
@@ -39,6 +39,7 @@ const BOKEHJS_EXEC_MIME: &str = "application/vnd.bokehjs_exec.v0+json";
 const BOKEHJS_LOAD_MIME: &str = "application/vnd.bokehjs_load.v0+json";
 const BOKEHJS_SCRIPT_MIME: &str = "application/javascript";
 const BOKEHJS_HTML_MIME: &str = "text/html";
+const NTERACT_PANEL_RUNTIME_MIME: &str = "application/vnd.nteract.panel-runtime.v1+json";
 const PANEL_EXEC_MIME: &str = "application/vnd.holoviews_exec.v0+json";
 const PANEL_LOAD_MIME: &str = "application/vnd.holoviews_load.v0+json";
 const RUNT_OUTPUT_CACHE_KEY: &str = "_runt_output_cache_key";
@@ -2941,8 +2942,10 @@ impl NotebookHandle {
                     || winner_mime == BOKEHJS_LOAD_MIME;
                 let panel_bundle = data.contains_key(PANEL_EXEC_MIME)
                     || data.contains_key(PANEL_LOAD_MIME)
+                    || data.contains_key(NTERACT_PANEL_RUNTIME_MIME)
                     || winner_mime == PANEL_EXEC_MIME
-                    || winner_mime == PANEL_LOAD_MIME;
+                    || winner_mime == PANEL_LOAD_MIME
+                    || winner_mime == NTERACT_PANEL_RUNTIME_MIME;
 
                 for (mime, val) in data {
                     if mime == winner_mime
@@ -2960,7 +2963,8 @@ impl NotebookHandle {
                         || (panel_bundle
                             && matches!(
                                 mime.as_str(),
-                                PANEL_EXEC_MIME
+                                NTERACT_PANEL_RUNTIME_MIME
+                                    | PANEL_EXEC_MIME
                                     | PANEL_LOAD_MIME
                                     | BOKEHJS_SCRIPT_MIME
                                     | BOKEHJS_HTML_MIME
@@ -6390,6 +6394,38 @@ mod tests {
         let data = narrowed["data"].as_object().expect("narrowed data object");
 
         assert!(data.contains_key(PANEL_EXEC_MIME));
+        assert!(data.contains_key(BOKEHJS_SCRIPT_MIME));
+        assert!(data.contains_key(BOKEHJS_HTML_MIME));
+        assert!(data.contains_key("text/plain"));
+    }
+
+    #[test]
+    fn nteract_panel_runtime_narrowing_keeps_marker_javascript_and_html_bundle() {
+        let mut handle = NotebookHandle::create_empty().expect("create handle");
+        handle.mime_priority = vec![
+            NTERACT_PANEL_RUNTIME_MIME.to_string(),
+            PANEL_EXEC_MIME.to_string(),
+            PANEL_LOAD_MIME.to_string(),
+            "text/html".to_string(),
+            BOKEHJS_SCRIPT_MIME.to_string(),
+            "text/plain".to_string(),
+        ];
+
+        let narrowed = handle.narrow_output_data(json!({
+            "output_type": "display_data",
+            "data": {
+                NTERACT_PANEL_RUNTIME_MIME: { "inline": "{\"version\":1,\"document_id\":\"doc-1\",\"channel_id\":\"panel-1\"}" },
+                BOKEHJS_SCRIPT_MIME: { "inline": "window.__panelExecRan = true;" },
+                BOKEHJS_HTML_MIME: { "inline": "<div id=\"p1011\"></div><script>window.__panelHtmlRan = true;</script>" },
+                "text/plain": { "inline": "fallback" },
+            },
+            "metadata": {
+                NTERACT_PANEL_RUNTIME_MIME: { "id": "p1011" },
+            },
+        }));
+        let data = narrowed["data"].as_object().expect("narrowed data object");
+
+        assert!(data.contains_key(NTERACT_PANEL_RUNTIME_MIME));
         assert!(data.contains_key(BOKEHJS_SCRIPT_MIME));
         assert!(data.contains_key(BOKEHJS_HTML_MIME));
         assert!(data.contains_key("text/plain"));

--- a/docs/memos/panel-runtime-state.md
+++ b/docs/memos/panel-runtime-state.md
@@ -124,7 +124,10 @@ created the Bokeh root model, Bokeh `Document`, server comm, browser-side Bokeh
 `CommManager` model, and client comm. Wrapping
 `panel.viewable.MimeRenderMixin._render_mimebundle` lets the launcher detect
 Panel by type while preserving Panel's own notebook rendering path and stamping
-the returned bundle with the ids nteract needs.
+the returned bundle with the ids nteract needs. That is the render MIME
+boundary nteract should own: the frontend should prefer the explicit nteract
+marker MIME over legacy Panel/HoloViews markers, HTML, or JavaScript instead
+of sniffing generated output.
 
 ## Runtime Integration
 
@@ -154,7 +157,9 @@ The narrow marker-injection point is `panel.viewable.MimeRenderMixin._render_mim
 At that point Panel has already created the Bokeh root model, server comm, Bokeh
 `CommManager` model, and client comm, and it is about to return the notebook
 MIME bundle. A launcher wrapper can add `application/vnd.nteract.panel-runtime.v1+json`
-without replacing Panel's render machinery or parsing generated JavaScript.
+without replacing Panel's render machinery or parsing generated JavaScript. The
+shared MIME priority list should treat that marker as the canonical Panel
+runtime type when it appears in a bundle.
 
 That backend should emit and consume typed nteract Panel events at the daemon
 boundary. If the immediate transport still has to observe kernel comm messages,
@@ -238,6 +243,82 @@ RuntimeStateDoc. The first option is useful for compact channel topology and
 late-joiner discovery. A likely split is: channel topology and latest compacted
 snapshot pointer in RuntimeStateDoc; ordered patch records and binary buffer
 refs in a dedicated Panel runtime document or blob-indexed log.
+
+### Recommended Daemon Boundary
+
+The next implementation slice should add a typed Panel runtime request rather
+than reuse `NotebookRequest::SendComm`. This is an approval-gated wire change
+because it extends the notebook request/runtime-agent protocol, but it is the
+cleanest boundary:
+
+1. The isolated renderer emits `PanelRuntimeClientEvent` records only through
+   the Panel runtime callback path.
+2. The app sends those records with a new typed notebook request such as
+   `NotebookRequest::SendPanelRuntimeEvent { event }`.
+3. The daemon validates the channel against the output-local marker and
+   runtime-owned channel topology, resolves any blob refs, and forwards a typed
+   `RuntimeAgentRequest::PanelRuntimeEvent { event }`.
+4. The runtime agent delivers the event to the launcher-side Panel comm manager
+   through a nteract-specific event sink, where it is decoded into Panel's own
+   Bokeh `PATCH-DOC` callback surface.
+5. Python-origin server patches, ACKs, callback stdout/stderr, close, and
+   disconnect events return as typed Panel runtime events from the launcher to
+   the runtime agent, not as iframe-visible raw comm messages.
+6. The daemon commits runtime-owned channel state and callback outputs before
+   notifying the app to deliver server patches/ACKs back to the iframe.
+
+This keeps the frontend request surface semantically narrow: browser-origin
+Panel patches are commands addressed to an existing Panel runtime channel, not
+raw Jupyter comm envelopes. It also keeps `NotebookBroadcast::Comm` widget-only.
+If a low-latency delivery path is needed for Python-to-browser patches, add a
+dedicated `NotebookBroadcast::PanelRuntime` variant or an equivalent
+Panel-specific host event. Do not put Panel payloads on the existing generic
+comm broadcast.
+
+### Durable State Shape
+
+For performance, do not store an unbounded Bokeh patch log directly in
+RuntimeStateDoc. Use RuntimeStateDoc as the compact discovery and lifecycle
+index:
+
+- `panel_channels/{channel_id}/cell_id`
+- `panel_channels/{channel_id}/output_id`
+- `panel_channels/{channel_id}/execution_id`
+- `panel_channels/{channel_id}/plot_id`
+- `panel_channels/{channel_id}/document_id`
+- `panel_channels/{channel_id}/server_comm_id`
+- `panel_channels/{channel_id}/client_comm_id`
+- `panel_channels/{channel_id}/status`: `open`, `closed`, or `disconnected`
+- `panel_channels/{channel_id}/last_ack`
+- `panel_channels/{channel_id}/snapshot_ref`
+- `panel_channels/{channel_id}/patch_cursor`
+
+Patch bodies and binary buffers should live outside RuntimeStateDoc as
+blob-backed records. A compact snapshot blob should be written when the patch
+log grows past a small threshold or when an iframe unmount/remount boundary is
+observed. RuntimeStateDoc then points at the latest compacted snapshot and
+patch cursor. That gives late joiners and remounted iframes an O(1) discovery
+path, while preserving Bokeh patch ordering without amplifying the main runtime
+CRDT document.
+
+The daemon/runtime peer is the only author of this topology. The app may submit
+client patch commands, but it does not directly mutate RuntimeStateDoc. Hosted
+room policy should mirror the existing runtime-state authority model: editors
+can request a Panel channel mutation only through the notebook request path;
+runtime peers or the room host author accepted state.
+
+### Replay And Disconnect
+
+On iframe remount, the app should hydrate from the latest
+`snapshot_ref + patch_cursor` for the channel. If no snapshot exists yet, it can
+request a fresh kernel-side render only as a fallback; the native path should
+prefer replay from runtime-owned state so remounts do not execute user code.
+
+On kernel restart or runtime disconnect, the daemon should mark the channel
+`disconnected`, keep the last snapshot visible, and send a typed
+`panelDisconnected` host event to the iframe so the renderer can show an
+explicit frozen overlay. A later execution creates a new channel; it should not
+silently revive the old channel id.
 
 ## Output Semantics
 

--- a/docs/memos/panel-runtime-state.md
+++ b/docs/memos/panel-runtime-state.md
@@ -161,6 +161,12 @@ without replacing Panel's render machinery or parsing generated JavaScript. The
 shared MIME priority list should treat that marker as the canonical Panel
 runtime type when it appears in a bundle.
 
+The browser-side `window.PyViz.comm_manager` implementation should live in the
+isolated renderer TypeScript bundle, not in the launcher's Python
+`js_manager` string. The launcher owns Panel's Python manager class and marker
+injection; the renderer owns the browser comm-manager surface because it is the
+piece that talks to the typed iframe transport and needs TypeScript coverage.
+
 That backend should emit and consume typed nteract Panel events at the daemon
 boundary. If the immediate transport still has to observe kernel comm messages,
 the translation should terminate inside the daemon/runtime layer; the isolated

--- a/docs/memos/panel-runtime-state.md
+++ b/docs/memos/panel-runtime-state.md
@@ -117,6 +117,15 @@ and replay metadata. The marker is not the live patch transport; it is the
 output-local anchor that lets the renderer, runtime doc, and blob-backed patch
 records agree on the same Panel runtime instance.
 
+The marker belongs at Panel's render-mimebundle point rather than in a broad
+global IPython formatter. nteract controls the kernel launcher and can register
+display hooks, but the useful Panel identities do not exist until Panel has
+created the Bokeh root model, Bokeh `Document`, server comm, browser-side Bokeh
+`CommManager` model, and client comm. Wrapping
+`panel.viewable.MimeRenderMixin._render_mimebundle` lets the launcher detect
+Panel by type while preserving Panel's own notebook rendering path and stamping
+the returned bundle with the ids nteract needs.
+
 ## Runtime Integration
 
 The first Python integration can be a launcher-hosted monkeypatch. The launcher
@@ -158,6 +167,23 @@ retain the marker payload, `text/html`, `application/javascript`, and fallback
 text together so browser rendering and later runtime replay have one coherent
 output record instead of detached siblings.
 
+The parent-side iframe boundary should also stay typed. The isolated renderer
+can expose `window.__nteractPanelRuntime` to Panel's browser-side comm manager
+and convert its events into explicit JSON-RPC notifications:
+
+- `nteract/panelChannelOpen`
+- `nteract/panelClientPatch`
+- `nteract/panelChannelClose`
+- `nteract/panelServerPatch`
+- `nteract/panelAck`
+- `nteract/panelDisconnected`
+
+`OutputArea` should claim the iframe-to-parent Panel events before they reach
+`CommBridgeManager`, then surface them through a Panel-specific callback with
+the owning cell and output ids. This keeps the widget bridge widget-only and
+gives the daemon/runtime integration a single typed ingress for browser-origin
+Panel patches.
+
 If Panel exposes a clean backend registration hook while building the monkeypatch,
 use it. If not, keep the monkeypatch small and propose an upstream hook after
 the nteract shape is proven.
@@ -181,6 +207,26 @@ compact it when safe so remounts do not require replaying an unbounded history.
 When the kernel restarts while a Panel output is visible, keep the last rendered
 state frozen and show an explicit disconnected overlay. The next cell execution
 can open a new channel and replace the frozen state.
+
+The runtime-state write boundary needs its own explicit schema and policy
+decision. Today regular frontend clients read `RuntimeStateDoc`; they do not
+author it. Runtime peers may update accepted execution progress, outputs,
+kernel lifecycle, and empty comm topology, while room-host/daemon-owned facts
+and raw root-key changes are rejected. A durable Panel state map therefore
+should not be smuggled in as generic comm state or as an arbitrary root-key
+change. It needs either:
+
+- a `RuntimeStateDoc.panel_channels` subtree whose topology and patch cursors
+  are owned by the daemon/runtime peer under an updated policy, paired with
+  blob-backed patch payloads in a dedicated Panel/Bokeh runtime doc; or
+- a new dedicated Panel/Bokeh runtime doc synced alongside RuntimeStateDoc,
+  referenced by output marker ids and execution ids.
+
+The second option avoids unbounded patch logs inside the already busy
+RuntimeStateDoc. The first option is useful for compact channel topology and
+late-joiner discovery. A likely split is: channel topology and latest compacted
+snapshot pointer in RuntimeStateDoc; ordered patch records and binary buffer
+refs in a dedicated Panel runtime document or blob-indexed log.
 
 ## Output Semantics
 
@@ -210,20 +256,29 @@ runtime output commits.
 2. Add a launcher-side Panel import hook and a minimal nteract Panel comm
    manager replacement that logs typed channel events without enabling browser
    interactivity yet.
-3. Add daemon/runtime protocol types for Panel/Bokeh channel open, patch, ACK,
-   close, and disconnected state. Use blob refs for binary buffers.
-4. Add an iframe `window.PyViz.comm_manager` implementation backed by typed
-   Panel channel RPC, with tests for patch send, ACK unblocking, remount replay,
-   and disconnected overlay.
-5. Route Panel callback stdout/errors into execution-scoped notebook stream
+3. Add the nteract Panel marker MIME to Panel bundles and to Rust output
+   narrowing, preserving marker, HTML, JavaScript, and fallback text as one
+   coherent output record.
+4. Add the iframe `window.__nteractPanelRuntime` transport and parent
+   `OutputArea` ingress so browser-origin Panel events are typed and kept out
+   of `CommBridgeManager`.
+5. Add daemon/runtime protocol and CRDT state for Panel/Bokeh channel open,
+   patch, ACK, close, and disconnected state. Use blob refs for binary buffers
+   and make the write-authority policy explicit.
+6. Connect the launcher-side Panel comm manager to the daemon/runtime channel
+   so server patches and ACKs no longer depend on a generic raw comm bridge.
+7. Add tests for patch send, ACK unblocking, remount replay, and disconnected
+   overlay.
+8. Route Panel callback stdout/errors into execution-scoped notebook stream
    outputs.
-6. Evaluate whether Bokeh and Panel can share the typed patch channel, and
+9. Evaluate whether Bokeh and Panel can share the typed patch channel, and
    whether this model maps cleanly onto an anywidget-like state adapter that
    could be proposed upstream.
 
 ## Open Points
 
-- Exact CRDT placement: CommsDoc sub-tree versus a new Panel/Bokeh runtime doc.
+- Exact CRDT placement: RuntimeStateDoc topology plus a new Panel/Bokeh runtime
+  doc versus a single RuntimeStateDoc subtree.
 - Patch compaction strategy and retention policy.
 - Whether the first transport can avoid ipykernel comm observation entirely, or
   whether the daemon must translate kernel comms into typed Panel events during

--- a/docs/memos/panel-runtime-state.md
+++ b/docs/memos/panel-runtime-state.md
@@ -300,14 +300,27 @@ cleanest boundary:
 3. The daemon validates the channel against the output-local marker and
    runtime-owned channel topology, resolves any blob refs, and forwards a typed
    `RuntimeAgentRequest::PanelRuntimeEvent { event }`.
-4. The runtime agent delivers the event to the launcher-side Panel comm manager
-   through a nteract-specific event sink, where it is decoded into Panel's own
-   Bokeh `PATCH-DOC` callback surface.
-5. Python-origin server patches, ACKs, callback stdout/stderr, close, and
-   disconnect events return as typed Panel runtime events from the launcher to
-   the runtime agent, not as iframe-visible raw comm messages.
-6. The daemon commits runtime-owned channel state and callback outputs before
+4. The runtime agent or a sibling daemon-side Panel service delivers the event
+   to a nteract runtime channel owned by the Python kernel launcher. The
+   launcher is inside the kernel process, so this cannot be an in-process Rust
+   callback. The likely shape is a small per-kernel endpoint advertised through
+   launch environment variables, using the same room/runtime identity the
+   runtime agent already receives.
+5. The launcher decodes typed Panel client-patch events into Panel's own
+   Bokeh `PATCH-DOC` callback surface. The local `NteractPanelCommManager`
+   receive seam is the proof of that callback boundary; it is not the external
+   transport.
+6. Python-origin server patches, ACKs, callback stdout/stderr, close, and
+   disconnect events return as typed Panel runtime events from the launcher over
+   that nteract runtime channel, not as iframe-visible raw comm messages.
+7. The daemon commits runtime-owned channel state and callback outputs before
    notifying the app to deliver server patches/ACKs back to the iframe.
+
+This keeps the Rust runtime agent in its current role as kernel lifecycle,
+execution, and output owner while giving the launcher a native way to speak
+Panel/Bokeh runtime state. The endpoint should be scoped to one launched kernel
+and should authenticate with an unguessable token or inherited process-local
+capability so arbitrary user code cannot mutate unrelated notebook rooms.
 
 This keeps the frontend request surface semantically narrow: browser-origin
 Panel patches are commands addressed to an existing Panel runtime channel, not

--- a/docs/memos/panel-runtime-state.md
+++ b/docs/memos/panel-runtime-state.md
@@ -184,6 +184,14 @@ the owning cell and output ids. This keeps the widget bridge widget-only and
 gives the daemon/runtime integration a single typed ingress for browser-origin
 Panel patches.
 
+The shared JavaScript contract now lives in `packages/runtimed/src/panel-runtime.ts`.
+It normalizes iframe and host notifications into `PanelRuntimeEvent` records
+with a stable channel id derived from the notebook cell, output id, Panel plot
+id, and Bokeh/PyViz comm id. This is still a volatile transport contract rather
+than a CRDT schema commitment, but it gives the daemon and frontend the same
+typed state language before deciding whether the durable record belongs in
+RuntimeStateDoc, CommsDoc, or a dedicated Panel/Bokeh runtime doc.
+
 If Panel exposes a clean backend registration hook while building the monkeypatch,
 use it. If not, keep the monkeypatch small and propose an upstream hook after
 the nteract shape is proven.

--- a/docs/memos/panel-runtime-state.md
+++ b/docs/memos/panel-runtime-state.md
@@ -206,15 +206,23 @@ than a CRDT schema commitment, but it gives the daemon and frontend the same
 typed state language before deciding whether the durable record belongs in
 RuntimeStateDoc, CommsDoc, or a dedicated Panel/Bokeh runtime doc.
 
-If Panel exposes a clean backend registration hook while building the monkeypatch,
-use it. If not, keep the monkeypatch small and propose an upstream hook after
-the nteract shape is proven.
+The `PyViz.comm_manager` implementation in this branch should be treated as a
+compatibility adapter for Panel's current notebook API, not as the durable
+nteract architecture. If Panel exposes a clean backend registration hook while
+building the monkeypatch, use it. If not, keep the monkeypatch small and propose
+an upstream hook after the nteract shape is proven. The upstream hook we likely
+want is a notebook backend or Bokeh patch transport registration point: Panel
+should be able to ask a host for a typed channel carrying Bokeh `PATCH-DOC`
+messages, binary buffers, ACKs, and disconnect state without the host pretending
+to be an ipykernel comm manager outside the Panel compatibility boundary.
 
 ## Frontend Integration
 
-The Panel iframe should extend `window.PyViz.comm_manager` with a nteract
-implementation that sends and receives typed Panel channel events. It should
-still let Panel's own Bokeh `CommManager` construct and apply JSON patches, so
+The Panel iframe currently has to expose `window.PyViz.comm_manager` because
+Panel's browser-side Bokeh model looks for that name. Keep that surface as thin
+as possible: it should translate Panel's current calls into typed nteract Panel
+channel events, not become a general-purpose Jupyter comm layer. It should still
+let Panel's own Bokeh `CommManager` construct and apply JSON patches, so
 nteract does not need to model every Bokeh model property as a separate trait.
 
 This can share a typed Bokeh patch channel with the current Bokeh output

--- a/docs/memos/panel-runtime-state.md
+++ b/docs/memos/panel-runtime-state.md
@@ -208,13 +208,41 @@ RuntimeStateDoc, CommsDoc, or a dedicated Panel/Bokeh runtime doc.
 
 The `PyViz.comm_manager` implementation in this branch should be treated as a
 compatibility adapter for Panel's current notebook API, not as the durable
-nteract architecture. If Panel exposes a clean backend registration hook while
-building the monkeypatch, use it. If not, keep the monkeypatch small and propose
-an upstream hook after the nteract shape is proven. The upstream hook we likely
-want is a notebook backend or Bokeh patch transport registration point: Panel
-should be able to ask a host for a typed channel carrying Bokeh `PATCH-DOC`
-messages, binary buffers, ACKs, and disconnect state without the host pretending
-to be an ipykernel comm manager outside the Panel compatibility boundary.
+nteract architecture. The architecture is a typed Bokeh document-patch
+transport. The adapter is only the current place where Panel lets a notebook
+host intercept `register_target`, `get_client_comm`, and comm `send` calls
+without forking Panel's Bokeh model. It should stay as small as possible and
+should not leak raw comm envelopes into nteract's iframe, widget bridge, daemon
+request path, or runtime-state documents.
+
+If Panel exposes a clean backend registration hook while building the
+monkeypatch, use it. The local source does not currently show one:
+`panel.config.config.comms` selects among `default`, `ipywidgets`, `vscode`,
+and `colab`; `panel.viewable.MimeRenderMixin` directly constructs Panel's
+Bokeh `CommManager` model and asks `state._comm_manager` for PyViz-shaped
+server/client comm objects. That makes the monkeypatch a useful proof tool, but
+not a shape nteract should standardize around. After the nteract transport is
+proven, the upstream hook we likely want is a notebook backend or Bokeh patch
+transport registration point: Panel should be able to ask a host for a typed
+channel carrying Bokeh `PATCH-DOC` messages, binary buffers, ACKs, and
+disconnect state without the host pretending to be an ipykernel comm manager
+outside the Panel compatibility boundary.
+
+That upstream hook would sit at a different abstraction level than ipykernel
+comms:
+
+- Python side: create a host channel after Panel has a Bokeh `Document`, root
+  model id, server comm id, client comm id, and optional output/execution
+  identity; deliver browser-origin Bokeh protocol messages into Panel's
+  existing `_on_msg` callback surface; return ACK metadata plus captured
+  callback stdout/stderr.
+- Browser side: let Panel's Bokeh `CommManager` continue to build and apply
+  Bokeh patches, but allow the host to provide a transport object with
+  `open`, `sendPatch`, `sendAck`, `close`, and `disconnect` semantics instead
+  of a global `window.PyViz.comm_manager` that resembles Jupyter.
+- Buffer side: surface binary buffers as structured parts that can become blob
+  refs when the host has a blob store, rather than forcing everything through
+  JSON or base64 comm envelopes.
 
 ## Frontend Integration
 
@@ -359,9 +387,10 @@ runtime output commits.
 
 1. Land this memo and a CI-visible output-lane guard that keeps Panel outside
    the widget bridge.
-2. Add a launcher-side Panel import hook and a minimal nteract Panel comm
-   manager replacement that logs typed channel events without enabling browser
-   interactivity yet.
+2. Add a launcher-side Panel import hook and a minimal PyViz compatibility
+   adapter that logs typed channel events without enabling browser
+   interactivity yet. Keep this adapter local to the Panel compatibility
+   boundary; do not model it as nteract's native runtime API.
 3. Add the nteract Panel marker MIME to Panel bundles and to Rust output
    narrowing, preserving marker, HTML, JavaScript, and fallback text as one
    coherent output record.
@@ -371,8 +400,9 @@ runtime output commits.
 5. Add daemon/runtime protocol and CRDT state for Panel/Bokeh channel open,
    patch, ACK, close, and disconnected state. Use blob refs for binary buffers
    and make the write-authority policy explicit.
-6. Connect the launcher-side Panel comm manager to the daemon/runtime channel
-   so server patches and ACKs no longer depend on a generic raw comm bridge.
+6. Connect the launcher-side Panel adapter to the daemon/runtime channel so
+   server patches and ACKs flow as typed Panel/Bokeh events. This should be the
+   last place that knows Panel currently calls a PyViz comm-manager-shaped API.
 7. Add tests for patch send, ACK unblocking, remount replay, and disconnected
    overlay.
 8. Route Panel callback stdout/errors into execution-scoped notebook stream
@@ -389,4 +419,6 @@ runtime output commits.
 - Whether the first transport can avoid ipykernel comm observation entirely, or
   whether the daemon must translate kernel comms into typed Panel events during
   the prototype.
-- Upstream API shape for registering notebook comm backends in Panel.
+- Upstream API shape for registering notebook Bokeh patch transports in Panel,
+  preferably without requiring hosts to expose a global PyViz/Jupyter comm
+  manager surface.

--- a/docs/memos/panel-runtime-state.md
+++ b/docs/memos/panel-runtime-state.md
@@ -45,6 +45,46 @@ accepted pieces into ADRs once the prototype proves the shape.
   is only for ephemeral widget custom messages (`crates/notebook-protocol/src/protocol.rs`,
   `src/components/widgets/comm-changes-store-bridge.ts`).
 
+## Panel/PyViz/Bokeh Communication Model
+
+Panel is not an ipywidgets trait-state protocol. It renders Panel objects into
+a Bokeh `Document`, then uses PyViz comms as a transport for Bokeh document
+patches.
+
+The useful mental model is:
+
+1. **Bokeh `Document`**: a graph of Bokeh `Model` objects, with roots attached
+   to a document. A slider, layout, plot, or Panel component becomes one or
+   more Bokeh models with ids and properties.
+2. **Document change events**: when browser-side BokehJS changes a syncable
+   model property, the document records a `DocumentChangedEvent`. Panel's
+   browser `CommManager` ignores unsyncable properties, buffers the remaining
+   events, and turns them into a Bokeh JSON patch with
+   `document.create_json_patch`.
+3. **Bokeh protocol message**: the JSON patch is wrapped in a Bokeh
+   `PATCH-DOC` message. That message has `header`, `metadata`, `content`, and
+   optional binary buffers. Bokeh's `Receiver` can reassemble chunked messages
+   and buffers before applying the patch.
+4. **PyViz comm transport**: PyViz supplies two comms around that Bokeh message:
+   a server comm for Python-to-browser patches and a client comm for
+   browser-to-Python patches. In Jupyter, those are implemented with
+   ipykernel comm targets, but the payload is still Bokeh document protocol.
+5. **ACK and callback output**: Python callbacks may print or fail while
+   applying a browser patch. PyViz captures stdout/errors and sends a `Ready`
+   or `Error` ACK so the browser-side `CommManager` can unblock its event
+   queue.
+
+That means the nteract-native boundary should be a Bokeh patch channel:
+channel open, client patch, server patch, ACK, close, and disconnected state.
+The browser should still let Panel/BokehJS compute and apply Bokeh patches.
+nteract should own transport, ordering, durability, blob references, execution
+output routing, and reconnect semantics.
+
+This is also why mapping Panel to CommsDoc one Bokeh property at a time is the
+wrong grain. CommsDoc is a good fit for ipywidget model state because widget
+state already is a trait map keyed by comm id. Panel's coherent unit is the
+Bokeh document patch, including event ordering and binary buffers.
+
 ## Proposed Model
 
 Model Panel as a typed Bokeh patch channel, not as raw `comm_open`,
@@ -76,6 +116,12 @@ already auto-loads `nteract_kernel_launcher._bootstrap` before user code and
 uses lazy import hooks for optional renderers. The Panel hook should avoid
 importing Panel on kernel startup; when Panel is imported, it can replace the
 comm manager class that Panel's display path assigns.
+
+The first launcher slice lands as an opt-in scaffold behind
+`NTERACT_PANEL_RUNTIME_STATE`. It installs the lazy import hook by default but
+does not patch Panel unless the flag is enabled. That keeps current static
+Panel rendering unchanged until the daemon and iframe sides of the typed
+channel exist.
 
 Because Panel's `viewable.py` assigns the imported `JupyterCommManager` during
 rendering, patching only `state._comm_manager` is likely insufficient. The

--- a/docs/memos/panel-runtime-state.md
+++ b/docs/memos/panel-runtime-state.md
@@ -178,11 +178,14 @@ and convert its events into explicit JSON-RPC notifications:
 - `nteract/panelAck`
 - `nteract/panelDisconnected`
 
-`OutputArea` should claim the iframe-to-parent Panel events before they reach
-`CommBridgeManager`, then surface them through a Panel-specific callback with
-the owning cell and output ids. This keeps the widget bridge widget-only and
-gives the daemon/runtime integration a single typed ingress for browser-origin
-Panel patches.
+`OutputArea` claims the iframe-to-parent Panel events before they reach
+`CommBridgeManager`, then surfaces them through a Panel-specific callback with
+the owning cell and output ids. `CodeCell` and `NotebookView` preserve that
+callback to the notebook app boundary, where browser-origin Panel events are now
+observable as typed `PanelRuntimeEvent` records without calling the widget
+`SendComm` path. This keeps the widget bridge widget-only and gives the
+daemon/runtime integration a single typed ingress for browser-origin Panel
+patches.
 
 The shared JavaScript contract now lives in `packages/runtimed/src/panel-runtime.ts`.
 It normalizes iframe and host notifications into `PanelRuntimeEvent` records
@@ -268,8 +271,8 @@ runtime output commits.
    narrowing, preserving marker, HTML, JavaScript, and fallback text as one
    coherent output record.
 4. Add the iframe `window.__nteractPanelRuntime` transport and parent
-   `OutputArea` ingress so browser-origin Panel events are typed and kept out
-   of `CommBridgeManager`.
+   `OutputArea`/app ingress so browser-origin Panel events are typed and kept
+   out of `CommBridgeManager` and the widget `SendComm` path.
 5. Add daemon/runtime protocol and CRDT state for Panel/Bokeh channel open,
    patch, ACK, close, and disconnected state. Use blob refs for binary buffers
    and make the write-authority policy explicit.

--- a/docs/memos/panel-runtime-state.md
+++ b/docs/memos/panel-runtime-state.md
@@ -109,6 +109,14 @@ scoped to live visualization state, but a dedicated Panel/Bokeh runtime doc is
 also viable if patch-log ownership or retention diverges from ipywidget comm
 state.
 
+The initial display bundle can use a nteract-owned marker MIME:
+`application/vnd.nteract.panel-runtime.v1+json`. That marker should travel with
+Panel's HTML, JavaScript, and legacy HoloViews markers in the same output bundle,
+but it gives the Rust/runtime output path a typed place to carry channel identity
+and replay metadata. The marker is not the live patch transport; it is the
+output-local anchor that lets the renderer, runtime doc, and blob-backed patch
+records agree on the same Panel runtime instance.
+
 ## Runtime Integration
 
 The first Python integration can be a launcher-hosted monkeypatch. The launcher
@@ -133,10 +141,22 @@ bootstrap should patch the imported class binding or provide an equivalent
 - comm objects with `id`, `send`, `close`, `init`, and ACK behavior equivalent
   to PyViz comms.
 
+The narrow marker-injection point is `panel.viewable.MimeRenderMixin._render_mimebundle`.
+At that point Panel has already created the Bokeh root model, server comm, Bokeh
+`CommManager` model, and client comm, and it is about to return the notebook
+MIME bundle. A launcher wrapper can add `application/vnd.nteract.panel-runtime.v1+json`
+without replacing Panel's render machinery or parsing generated JavaScript.
+
 That backend should emit and consume typed nteract Panel events at the daemon
 boundary. If the immediate transport still has to observe kernel comm messages,
 the translation should terminate inside the daemon/runtime layer; the isolated
 iframe and widget bridge should never see generic raw comm traffic for Panel.
+
+The Rust output narrowing path should recognize the nteract Panel runtime MIME
+as a Panel bundle marker. When it wins MIME priority, the narrowed manifest must
+retain the marker payload, `text/html`, `application/javascript`, and fallback
+text together so browser rendering and later runtime replay have one coherent
+output record instead of detached siblings.
 
 If Panel exposes a clean backend registration hook while building the monkeypatch,
 use it. If not, keep the monkeypatch small and propose an upstream hook after

--- a/packages/runtimed/src/index.ts
+++ b/packages/runtimed/src/index.ts
@@ -202,6 +202,50 @@ export {
   diffExecutions,
 } from "./runtime-state";
 
+// Panel/Bokeh runtime event model
+export {
+  NTERACT_PANEL_RUNTIME_MIME_TYPE,
+  PANEL_RUNTIME_PROTOCOL,
+  PANEL_RUNTIME_PROTOCOL_VERSION,
+  createPanelRuntimeChannelRef,
+  createPanelRuntimePatchRecord,
+  isPanelRuntimeHostMessage,
+  isPanelRuntimeIframeMessage,
+  panelRuntimeChannelId,
+  panelRuntimeEventFromHostMessage,
+  panelRuntimeEventFromIframeMessage,
+  type PanelRuntimeAckEvent,
+  type PanelRuntimeAckMessage,
+  type PanelRuntimeAckMetadata,
+  type PanelRuntimeAckPayload,
+  type PanelRuntimeBlobRef,
+  type PanelRuntimeBuffer,
+  type PanelRuntimeChannelCloseEvent,
+  type PanelRuntimeChannelCloseMessage,
+  type PanelRuntimeChannelOpenEvent,
+  type PanelRuntimeChannelOpenMessage,
+  type PanelRuntimeChannelPayload,
+  type PanelRuntimeChannelRef,
+  type PanelRuntimeClientEvent,
+  type PanelRuntimeClientEventType,
+  type PanelRuntimeClientPatchEvent,
+  type PanelRuntimeClientPatchMessage,
+  type PanelRuntimeDirection,
+  type PanelRuntimeDisconnectedEvent,
+  type PanelRuntimeDisconnectedMessage,
+  type PanelRuntimeDisconnectedPayload,
+  type PanelRuntimeEvent,
+  type PanelRuntimeHostEvent,
+  type PanelRuntimeHostEventType,
+  type PanelRuntimeHostMessage,
+  type PanelRuntimeIframeMessage,
+  type PanelRuntimeOutputContext,
+  type PanelRuntimePatchPayload,
+  type PanelRuntimePatchRecord,
+  type PanelRuntimeServerPatchEvent,
+  type PanelRuntimeServerPatchMessage,
+} from "./panel-runtime";
+
 // Pool state
 export { type PoolState, type RuntimePoolState, DEFAULT_POOL_STATE } from "./pool-state";
 

--- a/packages/runtimed/src/mime-priority.ts
+++ b/packages/runtimed/src/mime-priority.ts
@@ -1,3 +1,5 @@
+import { NTERACT_PANEL_RUNTIME_MIME_TYPE } from "./panel-runtime";
+
 /**
  * Default MIME type display priority for notebook outputs.
  *
@@ -13,6 +15,7 @@ export const DEFAULT_MIME_PRIORITY = [
   // text/html. These must win so the frontend can keep the bundle together.
   "application/vnd.bokehjs_exec.v0+json",
   "application/vnd.bokehjs_load.v0+json",
+  NTERACT_PANEL_RUNTIME_MIME_TYPE,
   "application/vnd.holoviews_exec.v0+json",
   "application/vnd.holoviews_load.v0+json",
   "application/vnd.vegalite.v6+json",

--- a/packages/runtimed/src/panel-runtime.ts
+++ b/packages/runtimed/src/panel-runtime.ts
@@ -1,0 +1,353 @@
+/**
+ * Shared Panel/Bokeh runtime event model.
+ *
+ * This is deliberately not the ipykernel comm envelope. It names the Panel
+ * channel, the owning notebook output, and the Bokeh patch payload that needs
+ * to move between the isolated renderer and the Python runtime.
+ */
+
+export const NTERACT_PANEL_RUNTIME_MIME_TYPE =
+  "application/vnd.nteract.panel-runtime.v1+json" as const;
+export const PANEL_RUNTIME_PROTOCOL = "nteract.panel.runtime.v1" as const;
+export const PANEL_RUNTIME_PROTOCOL_VERSION = 1 as const;
+
+export type PanelRuntimeDirection = "iframe_to_kernel" | "kernel_to_iframe";
+export type PanelRuntimeClientEventType = "channel_open" | "client_patch" | "channel_close";
+export type PanelRuntimeHostEventType = "server_patch" | "ack" | "disconnected";
+
+export interface PanelRuntimeBlobRef {
+  blob: string;
+  size: number;
+  media_type?: string | null;
+}
+
+export type PanelRuntimeBuffer = ArrayBuffer | PanelRuntimeBlobRef;
+
+export interface PanelRuntimeChannelPayload {
+  plotId?: string | null;
+  commId: string;
+}
+
+export interface PanelRuntimePatchPayload extends PanelRuntimeChannelPayload {
+  data?: unknown;
+  metadata?: Record<string, unknown>;
+  buffers?: PanelRuntimeBuffer[];
+}
+
+export interface PanelRuntimeAckMetadata {
+  msg_type: "Ready" | "Error";
+  content?: string;
+  traceback?: string;
+  comm_id?: string;
+}
+
+export interface PanelRuntimeAckPayload extends PanelRuntimeChannelPayload {
+  metadata: PanelRuntimeAckMetadata;
+}
+
+export interface PanelRuntimeDisconnectedPayload {
+  plotId?: string | null;
+  commId?: string | null;
+  reason?: string;
+}
+
+export interface PanelRuntimeOutputContext {
+  cellId?: string;
+  executionCount?: number | null;
+  outputId?: string | null;
+  outputIds?: readonly string[];
+}
+
+export interface PanelRuntimeChannelRef {
+  channelId: string;
+  commId: string;
+  plotId?: string | null;
+  cellId?: string;
+  executionCount: number | null;
+  outputId: string | null;
+  outputIds: readonly string[];
+}
+
+export interface PanelRuntimePatchRecord {
+  data?: unknown;
+  metadata: Record<string, unknown>;
+  buffers: readonly PanelRuntimeBuffer[];
+}
+
+interface PanelRuntimeEventBase<TType extends string, TDirection extends PanelRuntimeDirection> {
+  protocol: typeof PANEL_RUNTIME_PROTOCOL;
+  version: typeof PANEL_RUNTIME_PROTOCOL_VERSION;
+  type: TType;
+  direction: TDirection;
+}
+
+export interface PanelRuntimeChannelOpenEvent extends PanelRuntimeEventBase<
+  "channel_open",
+  "iframe_to_kernel"
+> {
+  channel: PanelRuntimeChannelRef;
+}
+
+export interface PanelRuntimeClientPatchEvent extends PanelRuntimeEventBase<
+  "client_patch",
+  "iframe_to_kernel"
+> {
+  channel: PanelRuntimeChannelRef;
+  patch: PanelRuntimePatchRecord;
+}
+
+export interface PanelRuntimeChannelCloseEvent extends PanelRuntimeEventBase<
+  "channel_close",
+  "iframe_to_kernel"
+> {
+  channel: PanelRuntimeChannelRef;
+}
+
+export interface PanelRuntimeServerPatchEvent extends PanelRuntimeEventBase<
+  "server_patch",
+  "kernel_to_iframe"
+> {
+  channel: PanelRuntimeChannelRef;
+  patch: PanelRuntimePatchRecord;
+}
+
+export interface PanelRuntimeAckEvent extends PanelRuntimeEventBase<"ack", "kernel_to_iframe"> {
+  channel: PanelRuntimeChannelRef;
+  ack: PanelRuntimeAckMetadata;
+}
+
+export interface PanelRuntimeDisconnectedEvent extends PanelRuntimeEventBase<
+  "disconnected",
+  "kernel_to_iframe"
+> {
+  channel?: PanelRuntimeChannelRef;
+  reason?: string;
+}
+
+export type PanelRuntimeClientEvent =
+  | PanelRuntimeChannelOpenEvent
+  | PanelRuntimeClientPatchEvent
+  | PanelRuntimeChannelCloseEvent;
+
+export type PanelRuntimeHostEvent =
+  | PanelRuntimeServerPatchEvent
+  | PanelRuntimeAckEvent
+  | PanelRuntimeDisconnectedEvent;
+
+export type PanelRuntimeEvent = PanelRuntimeClientEvent | PanelRuntimeHostEvent;
+
+export interface PanelRuntimeChannelOpenMessage {
+  type: "panel_channel_open";
+  payload: PanelRuntimeChannelPayload;
+}
+
+export interface PanelRuntimeClientPatchMessage {
+  type: "panel_client_patch";
+  payload: PanelRuntimePatchPayload;
+}
+
+export interface PanelRuntimeChannelCloseMessage {
+  type: "panel_channel_close";
+  payload: PanelRuntimeChannelPayload;
+}
+
+export interface PanelRuntimeServerPatchMessage {
+  type: "panel_server_patch";
+  payload: PanelRuntimePatchPayload;
+}
+
+export interface PanelRuntimeAckMessage {
+  type: "panel_ack";
+  payload: PanelRuntimeAckPayload;
+}
+
+export interface PanelRuntimeDisconnectedMessage {
+  type: "panel_disconnected";
+  payload: PanelRuntimeDisconnectedPayload;
+}
+
+export type PanelRuntimeIframeMessage =
+  | PanelRuntimeChannelOpenMessage
+  | PanelRuntimeClientPatchMessage
+  | PanelRuntimeChannelCloseMessage;
+
+export type PanelRuntimeHostMessage =
+  | PanelRuntimeServerPatchMessage
+  | PanelRuntimeAckMessage
+  | PanelRuntimeDisconnectedMessage;
+
+const PANEL_RUNTIME_IFRAME_MESSAGE_TYPES = new Set([
+  "panel_channel_open",
+  "panel_client_patch",
+  "panel_channel_close",
+]);
+
+const PANEL_RUNTIME_HOST_MESSAGE_TYPES = new Set([
+  "panel_server_patch",
+  "panel_ack",
+  "panel_disconnected",
+]);
+
+function compactString(value: unknown): string | null {
+  if (typeof value !== "string") return null;
+  const trimmed = value.trim();
+  return trimmed.length > 0 ? trimmed : null;
+}
+
+function firstOutputId(context: PanelRuntimeOutputContext): string | null {
+  const explicit = compactString(context.outputId);
+  if (explicit) return explicit;
+  for (const id of context.outputIds ?? []) {
+    const candidate = compactString(id);
+    if (candidate) return candidate;
+  }
+  return null;
+}
+
+function channelKeyPart(label: string, value: string | null | undefined): string | null {
+  const compact = compactString(value);
+  return compact ? `${label}:${encodeURIComponent(compact)}` : null;
+}
+
+export function panelRuntimeChannelId(
+  payload: PanelRuntimeChannelPayload,
+  context: PanelRuntimeOutputContext = {},
+): string {
+  const outputId = firstOutputId(context);
+  const parts = [
+    channelKeyPart("cell", context.cellId),
+    channelKeyPart("output", outputId),
+    channelKeyPart("plot", payload.plotId),
+    channelKeyPart("comm", payload.commId),
+  ].filter((part): part is string => part !== null);
+
+  return parts.join("|");
+}
+
+export function createPanelRuntimeChannelRef(
+  payload: PanelRuntimeChannelPayload,
+  context: PanelRuntimeOutputContext = {},
+): PanelRuntimeChannelRef {
+  const outputIds = [...(context.outputIds ?? [])];
+  return {
+    channelId: panelRuntimeChannelId(payload, context),
+    commId: payload.commId,
+    plotId: payload.plotId ?? null,
+    cellId: compactString(context.cellId) ?? undefined,
+    executionCount: context.executionCount ?? null,
+    outputId: firstOutputId(context),
+    outputIds,
+  };
+}
+
+export function createPanelRuntimePatchRecord(
+  payload: PanelRuntimePatchPayload,
+): PanelRuntimePatchRecord {
+  return {
+    data: payload.data,
+    metadata: payload.metadata ?? {},
+    buffers: payload.buffers ?? [],
+  };
+}
+
+export function panelRuntimeEventFromIframeMessage(
+  message: PanelRuntimeIframeMessage,
+  context: PanelRuntimeOutputContext = {},
+): PanelRuntimeClientEvent {
+  const base = {
+    protocol: PANEL_RUNTIME_PROTOCOL,
+    version: PANEL_RUNTIME_PROTOCOL_VERSION,
+    direction: "iframe_to_kernel" as const,
+  };
+  const channel = createPanelRuntimeChannelRef(message.payload, context);
+
+  switch (message.type) {
+    case "panel_channel_open":
+      return { ...base, type: "channel_open", channel };
+    case "panel_client_patch":
+      return {
+        ...base,
+        type: "client_patch",
+        channel,
+        patch: createPanelRuntimePatchRecord(message.payload),
+      };
+    case "panel_channel_close":
+      return { ...base, type: "channel_close", channel };
+  }
+}
+
+export function panelRuntimeEventFromHostMessage(
+  message: PanelRuntimeHostMessage,
+  context: PanelRuntimeOutputContext = {},
+): PanelRuntimeHostEvent {
+  const base = {
+    protocol: PANEL_RUNTIME_PROTOCOL,
+    version: PANEL_RUNTIME_PROTOCOL_VERSION,
+    direction: "kernel_to_iframe" as const,
+  };
+
+  switch (message.type) {
+    case "panel_server_patch":
+      return {
+        ...base,
+        type: "server_patch",
+        channel: createPanelRuntimeChannelRef(message.payload, context),
+        patch: createPanelRuntimePatchRecord(message.payload),
+      };
+    case "panel_ack":
+      return {
+        ...base,
+        type: "ack",
+        channel: createPanelRuntimeChannelRef(message.payload, context),
+        ack: message.payload.metadata,
+      };
+    case "panel_disconnected": {
+      const channel = isPanelRuntimeChannelPayload(message.payload)
+        ? createPanelRuntimeChannelRef(message.payload, context)
+        : undefined;
+      return {
+        ...base,
+        type: "disconnected",
+        channel,
+        reason: message.payload.reason,
+      };
+    }
+  }
+}
+
+function hasObjectPayload(data: unknown): data is { type: string; payload: unknown } {
+  return (
+    typeof data === "object" &&
+    data !== null &&
+    typeof (data as { type?: unknown }).type === "string" &&
+    typeof (data as { payload?: unknown }).payload === "object" &&
+    (data as { payload?: unknown }).payload !== null
+  );
+}
+
+function isPanelRuntimeChannelPayload(payload: unknown): payload is PanelRuntimeChannelPayload {
+  return (
+    typeof payload === "object" &&
+    payload !== null &&
+    typeof (payload as { commId?: unknown }).commId === "string" &&
+    compactString((payload as { commId: string }).commId) !== null
+  );
+}
+
+export function isPanelRuntimeIframeMessage(data: unknown): data is PanelRuntimeIframeMessage {
+  return (
+    hasObjectPayload(data) &&
+    PANEL_RUNTIME_IFRAME_MESSAGE_TYPES.has(data.type) &&
+    isPanelRuntimeChannelPayload(data.payload)
+  );
+}
+
+export function isPanelRuntimeHostMessage(data: unknown): data is PanelRuntimeHostMessage {
+  if (!hasObjectPayload(data) || !PANEL_RUNTIME_HOST_MESSAGE_TYPES.has(data.type)) {
+    return false;
+  }
+  if (data.type === "panel_disconnected") {
+    return true;
+  }
+  return isPanelRuntimeChannelPayload(data.payload);
+}

--- a/packages/runtimed/tests/panel-runtime.test.ts
+++ b/packages/runtimed/tests/panel-runtime.test.ts
@@ -10,10 +10,23 @@ import {
   panelRuntimeEventFromIframeMessage,
   type PanelRuntimeBlobRef,
 } from "../src/panel-runtime";
+import { DEFAULT_MIME_PRIORITY } from "../src/mime-priority";
 
 describe("Panel runtime event model", () => {
   it("exports the nteract-owned marker MIME", () => {
     expect(NTERACT_PANEL_RUNTIME_MIME_TYPE).toBe("application/vnd.nteract.panel-runtime.v1+json");
+  });
+
+  it("prioritizes the nteract Panel marker over legacy Panel MIME markers", () => {
+    expect(DEFAULT_MIME_PRIORITY.indexOf(NTERACT_PANEL_RUNTIME_MIME_TYPE)).toBeGreaterThanOrEqual(
+      0,
+    );
+    expect(DEFAULT_MIME_PRIORITY.indexOf(NTERACT_PANEL_RUNTIME_MIME_TYPE)).toBeLessThan(
+      DEFAULT_MIME_PRIORITY.indexOf("application/vnd.holoviews_exec.v0+json"),
+    );
+    expect(DEFAULT_MIME_PRIORITY.indexOf(NTERACT_PANEL_RUNTIME_MIME_TYPE)).toBeLessThan(
+      DEFAULT_MIME_PRIORITY.indexOf("application/vnd.holoviews_load.v0+json"),
+    );
   });
 
   it("derives a stable channel id from notebook output and Panel ids", () => {

--- a/packages/runtimed/tests/panel-runtime.test.ts
+++ b/packages/runtimed/tests/panel-runtime.test.ts
@@ -1,0 +1,134 @@
+import { describe, expect, it } from "vite-plus/test";
+import {
+  NTERACT_PANEL_RUNTIME_MIME_TYPE,
+  PANEL_RUNTIME_PROTOCOL,
+  PANEL_RUNTIME_PROTOCOL_VERSION,
+  isPanelRuntimeHostMessage,
+  isPanelRuntimeIframeMessage,
+  panelRuntimeChannelId,
+  panelRuntimeEventFromHostMessage,
+  panelRuntimeEventFromIframeMessage,
+  type PanelRuntimeBlobRef,
+} from "../src/panel-runtime";
+
+describe("Panel runtime event model", () => {
+  it("exports the nteract-owned marker MIME", () => {
+    expect(NTERACT_PANEL_RUNTIME_MIME_TYPE).toBe("application/vnd.nteract.panel-runtime.v1+json");
+  });
+
+  it("derives a stable channel id from notebook output and Panel ids", () => {
+    expect(
+      panelRuntimeChannelId(
+        { plotId: "plot 1", commId: "client/comm" },
+        { cellId: "cell-a", outputIds: ["output-a"] },
+      ),
+    ).toBe("cell:cell-a|output:output-a|plot:plot%201|comm:client%2Fcomm");
+  });
+
+  it("normalizes browser-origin Panel patches into typed runtime events", () => {
+    const blobRef: PanelRuntimeBlobRef = {
+      blob: "sha256-buffer",
+      size: 4096,
+      media_type: "application/octet-stream",
+    };
+
+    const event = panelRuntimeEventFromIframeMessage(
+      {
+        type: "panel_client_patch",
+        payload: {
+          plotId: "p1011",
+          commId: "client-comm",
+          data: { events: [{ kind: "ModelChanged", attr: "value", new: 6 }] },
+          metadata: { msgid: "patch-1" },
+          buffers: [blobRef],
+        },
+      },
+      {
+        cellId: "panel-cell",
+        executionCount: 7,
+        outputIds: ["panel-output"],
+      },
+    );
+
+    expect(event).toEqual({
+      protocol: PANEL_RUNTIME_PROTOCOL,
+      version: PANEL_RUNTIME_PROTOCOL_VERSION,
+      direction: "iframe_to_kernel",
+      type: "client_patch",
+      channel: {
+        channelId: "cell:panel-cell|output:panel-output|plot:p1011|comm:client-comm",
+        commId: "client-comm",
+        plotId: "p1011",
+        cellId: "panel-cell",
+        executionCount: 7,
+        outputId: "panel-output",
+        outputIds: ["panel-output"],
+      },
+      patch: {
+        data: { events: [{ kind: "ModelChanged", attr: "value", new: 6 }] },
+        metadata: { msgid: "patch-1" },
+        buffers: [blobRef],
+      },
+    });
+  });
+
+  it("normalizes Python-origin ACKs without exposing raw comm envelopes", () => {
+    const event = panelRuntimeEventFromHostMessage(
+      {
+        type: "panel_ack",
+        payload: {
+          plotId: "p1011",
+          commId: "client-comm",
+          metadata: {
+            msg_type: "Ready",
+            content: "\n\tcallback stdout",
+          },
+        },
+      },
+      { cellId: "panel-cell", outputIds: ["panel-output"] },
+    );
+
+    expect(event).toMatchObject({
+      protocol: PANEL_RUNTIME_PROTOCOL,
+      version: PANEL_RUNTIME_PROTOCOL_VERSION,
+      direction: "kernel_to_iframe",
+      type: "ack",
+      channel: {
+        channelId: "cell:panel-cell|output:panel-output|plot:p1011|comm:client-comm",
+        commId: "client-comm",
+      },
+      ack: {
+        msg_type: "Ready",
+        content: "\n\tcallback stdout",
+      },
+    });
+  });
+
+  it("guards Panel runtime messages without accepting generic widget comm messages", () => {
+    expect(
+      isPanelRuntimeIframeMessage({
+        type: "panel_client_patch",
+        payload: { plotId: "p1011", commId: "client-comm" },
+      }),
+    ).toBe(true);
+    expect(
+      isPanelRuntimeHostMessage({
+        type: "panel_server_patch",
+        payload: { plotId: "p1011", commId: "server-comm" },
+      }),
+    ).toBe(true);
+
+    expect(
+      isPanelRuntimeIframeMessage({
+        type: "widget_comm_msg",
+        payload: { commId: "client-comm", data: {} },
+      }),
+    ).toBe(false);
+    expect(
+      isPanelRuntimeIframeMessage({
+        type: "panel_client_patch",
+        payload: { plotId: "p1011" },
+      }),
+    ).toBe(false);
+  });
+});

--- a/python/nteract-kernel-launcher/nteract_kernel_launcher/_bootstrap.py
+++ b/python/nteract-kernel-launcher/nteract_kernel_launcher/_bootstrap.py
@@ -21,8 +21,9 @@ user code runs. Four things happen on ``load_ipython_extension``:
 
 4. Third-party visualization libraries (altair, plotly) are flipped to
    their ``"nteract"`` renderer if they are already imported, or lazily
-   when they are first imported by user code. The bootstrap never imports
-   these optional packages on the kernel startup path.
+   when they are first imported by user code. The Panel runtime-state hook
+   follows the same lazy shape. The bootstrap never imports these optional
+   packages on the kernel startup path.
 
 No ``ipython_display_formatter`` handlers. The dx wheel needed one to
 divert bare-``df``-on-last-line from the bufferless displayhook path
@@ -48,6 +49,7 @@ from traitlets import ObjectName, Unicode
 
 import nteract_kernel_launcher._buffer_hook as _buffer_hook
 import nteract_kernel_launcher._output_redaction as _output_redaction
+import nteract_kernel_launcher._panel as _panel
 import nteract_kernel_launcher._traceback as _traceback
 from nteract_kernel_launcher._buffer_hook import pending_buffers
 from nteract_kernel_launcher._format import (
@@ -682,6 +684,7 @@ def load_ipython_extension(ip: Any) -> None:
     _run_bootstrap_step("buffer hook install", lambda: _install_buffer_hooks(ip))
     _run_bootstrap_step("output redaction install", lambda: _output_redaction.install(ip))
     _run_bootstrap_step("third-party renderer enable", _enable_third_party_renderers)
+    _run_bootstrap_step("panel runtime hook install", _panel.install)
 
     # Traceback install goes last so earlier failures can't prevent it.
     # The wrapper itself is bulletproof — see `_traceback.install`.
@@ -705,3 +708,4 @@ def unload_ipython_extension(ip: Any) -> None:
     except Exception as exc:  # noqa: BLE001
         log.debug("unload cleanup: %s", exc)
     _uninstall_renderer_import_hook()
+    _panel.uninstall()

--- a/python/nteract-kernel-launcher/nteract_kernel_launcher/_bootstrap.py
+++ b/python/nteract-kernel-launcher/nteract_kernel_launcher/_bootstrap.py
@@ -49,6 +49,8 @@ from traitlets import ObjectName, Unicode
 
 import nteract_kernel_launcher._buffer_hook as _buffer_hook
 import nteract_kernel_launcher._output_redaction as _output_redaction
+
+# nteract-internal; importing this module installs no third-party Panel package.
 import nteract_kernel_launcher._panel as _panel
 import nteract_kernel_launcher._traceback as _traceback
 from nteract_kernel_launcher._buffer_hook import pending_buffers

--- a/python/nteract-kernel-launcher/nteract_kernel_launcher/_panel.py
+++ b/python/nteract-kernel-launcher/nteract_kernel_launcher/_panel.py
@@ -63,8 +63,10 @@ class _CapturedStdout(list[str]):
         return self
 
     def __exit__(self, *_args: Any) -> None:
-        self.extend(self._stringio.getvalue().splitlines())
-        sys.stdout = self._stdout
+        try:
+            self.extend(self._stringio.getvalue().splitlines())
+        finally:
+            sys.stdout = self._stdout
 
 
 class NteractPanelComm:
@@ -324,6 +326,9 @@ class NteractPanelCommManager:
 
     @classmethod
     def clear_comms(cls) -> None:
+        for comm in list(cls._comms.values()):
+            with suppress(Exception):
+                comm.close()
         cls._comms.clear()
 
     @classmethod
@@ -427,7 +432,6 @@ def _patch_panel_modules() -> bool:
         return False
 
     patched = False
-    original_manager: Any | None = None
     notebook = sys.modules.get("panel.io.notebook")
     if notebook is not None:
         original_manager = getattr(notebook, "JupyterCommManagerBinary", None) or getattr(
@@ -443,7 +447,6 @@ def _patch_panel_modules() -> bool:
     if viewable is not None and hasattr(viewable, "JupyterCommManager"):
         current = viewable.JupyterCommManager
         if not getattr(current, "_nteract_panel_comm_manager", False):
-            original_manager = current
             # Keep the first original binding so a future restore path knows
             # which manager Panel exposed before nteract patched any module.
             NteractPanelCommManager._remember_original_manager(current)
@@ -455,7 +458,8 @@ def _patch_panel_modules() -> bool:
     state = getattr(state_module, "state", None) if state_module is not None else None
     if state is not None:
         current = getattr(state, "_comm_manager", None)
-        if current is original_manager or getattr(current, "_nteract_panel_comm_manager", False):
+        if not getattr(current, "_nteract_panel_comm_manager", False):
+            NteractPanelCommManager._remember_original_manager(current)
             state._comm_manager = NteractPanelCommManager
             patched = True
 
@@ -548,4 +552,5 @@ def install() -> None:
 def uninstall() -> None:
     """Remove the lazy import hook. Existing Panel monkeypatches are left intact."""
     NteractPanelCommManager.clear_comms()
+    NteractPanelCommManager._nteract_original_manager = None
     _uninstall_panel_import_hook()

--- a/python/nteract-kernel-launcher/nteract_kernel_launcher/_panel.py
+++ b/python/nteract-kernel-launcher/nteract_kernel_launcher/_panel.py
@@ -77,6 +77,7 @@ class NteractPanelComm:
         on_error: Callable[[Exception], None] | None = None,
         on_stdout: Callable[[list[str]], None] | None = None,
         on_open: Callable[[dict[str, Any]], None] | None = None,
+        on_close: Callable[[str], None] | None = None,
         *,
         role: str,
     ) -> None:
@@ -85,6 +86,7 @@ class NteractPanelComm:
         self._on_error = on_error
         self._on_stdout = on_stdout
         self._on_open = on_open
+        self._on_close = on_close
         self.role = role
         self.active = True
         self.connected = True
@@ -101,6 +103,9 @@ class NteractPanelComm:
         self.active = False
         self.connected = False
         _emit_panel_event({"type": "panel_channel_close", "comm_id": self.id, "role": self.role})
+        if self._on_close:
+            with suppress(Exception):
+                self._on_close(self.id)
 
     def send(
         self,
@@ -307,6 +312,21 @@ class NteractPanelCommManager:
     _nteract_original_manager: Any | None = None
 
     @classmethod
+    def _remember_original_manager(cls, manager: Any | None) -> None:
+        if manager is None or getattr(manager, "_nteract_panel_comm_manager", False):
+            return
+        if cls._nteract_original_manager is None:
+            cls._nteract_original_manager = manager
+
+    @classmethod
+    def _forget_comm(cls, comm_id: str) -> None:
+        cls._comms.pop(comm_id, None)
+
+    @classmethod
+    def clear_comms(cls) -> None:
+        cls._comms.clear()
+
+    @classmethod
     def get_server_comm(
         cls,
         on_msg: Callable[[dict[str, Any]], None] | None = None,
@@ -315,7 +335,7 @@ class NteractPanelCommManager:
         on_stdout: Callable[[list[str]], None] | None = None,
         on_open: Callable[[dict[str, Any]], None] | None = None,
     ) -> NteractPanelComm:
-        comm = cls.server_comm(id, on_msg, on_error, on_stdout, on_open)
+        comm = cls.server_comm(id, on_msg, on_error, on_stdout, on_open, on_close=cls._forget_comm)
         cls._comms[comm.id] = comm
         return comm
 
@@ -328,7 +348,7 @@ class NteractPanelCommManager:
         on_stdout: Callable[[list[str]], None] | None = None,
         on_open: Callable[[dict[str, Any]], None] | None = None,
     ) -> NteractPanelComm:
-        comm = cls.client_comm(id, on_msg, on_error, on_stdout, on_open)
+        comm = cls.client_comm(id, on_msg, on_error, on_stdout, on_open, on_close=cls._forget_comm)
         cls._comms[comm.id] = comm
         return comm
 
@@ -413,10 +433,7 @@ def _patch_panel_modules() -> bool:
         original_manager = getattr(notebook, "JupyterCommManagerBinary", None) or getattr(
             notebook, "_JupyterCommManager", None
         )
-        if original_manager is not None and not getattr(
-            original_manager, "_nteract_panel_comm_manager", False
-        ):
-            NteractPanelCommManager._nteract_original_manager = original_manager
+        NteractPanelCommManager._remember_original_manager(original_manager)
         for name in ("JupyterCommManagerBinary", "_JupyterCommManager"):
             if hasattr(notebook, name):
                 setattr(notebook, name, NteractPanelCommManager)
@@ -427,7 +444,9 @@ def _patch_panel_modules() -> bool:
         current = viewable.JupyterCommManager
         if not getattr(current, "_nteract_panel_comm_manager", False):
             original_manager = current
-            NteractPanelCommManager._nteract_original_manager = current
+            # Keep the first original binding so a future restore path knows
+            # which manager Panel exposed before nteract patched any module.
+            NteractPanelCommManager._remember_original_manager(current)
         viewable.JupyterCommManager = NteractPanelCommManager
         patched = True
         patched = _patch_panel_mimebundle(viewable) or patched
@@ -528,4 +547,5 @@ def install() -> None:
 
 def uninstall() -> None:
     """Remove the lazy import hook. Existing Panel monkeypatches are left intact."""
+    NteractPanelCommManager.clear_comms()
     _uninstall_panel_import_hook()

--- a/python/nteract-kernel-launcher/nteract_kernel_launcher/_panel.py
+++ b/python/nteract-kernel-launcher/nteract_kernel_launcher/_panel.py
@@ -200,112 +200,11 @@ class NteractPanelClientComm(NteractPanelComm):
 class NteractPanelCommManager:
     """Panel/PyViz comm manager backed by typed nteract runtime events."""
 
-    js_manager = """
-    (function() {
-      if ((window.PyViz === undefined) || (window.PyViz instanceof HTMLElement)) {
-        window.PyViz = {comms: {}, comm_status: {}, kernels: {}, receivers: {}, plot_index: []};
-      }
-
-      function runtime() {
-        return window.__nteractPanelRuntime || null;
-      }
-
-      function NteractPanelCommManager() {
-        this.targets = {};
-        this.comms = {};
-        var rt = runtime();
-        if (rt && rt.attachCommManager) {
-          rt.attachCommManager(this);
-        }
-      }
-
-      NteractPanelCommManager.prototype.register_target = function(plot_id, comm_id, msg_handler) {
-        this.targets[comm_id] = {plot_id: plot_id, msg_handler: msg_handler};
-        var rt = runtime();
-        if (rt && rt.registerTarget) {
-          rt.registerTarget({plotId: plot_id, commId: comm_id});
-        }
-      };
-
-      NteractPanelCommManager.prototype.get_client_comm = function(plot_id, comm_id, msg_handler) {
-        if (comm_id in this.comms) {
-          return this.comms[comm_id];
-        }
-        var comm = {
-          active: true,
-          connected: true,
-          onMsg: msg_handler,
-          on_msg: function(handler) { comm.onMsg = handler; },
-          send: function(data, metadata, buffers) {
-            var rt = runtime();
-            if (!rt || !rt.sendClientPatch) {
-              console.warn("nteract Panel runtime transport is not connected");
-              return;
-            }
-            rt.sendClientPatch({
-              plotId: plot_id,
-              commId: comm_id,
-              data: data,
-              metadata: metadata || {},
-              buffers: buffers || []
-            });
-          },
-          close: function() {
-            comm.active = false;
-            comm.connected = false;
-            var rt = runtime();
-            if (rt && rt.closeChannel) {
-              rt.closeChannel({plotId: plot_id, commId: comm_id});
-            }
-          }
-        };
-        if (msg_handler) {
-          comm.onMsg = msg_handler;
-        }
-        this.comms[comm_id] = comm;
-        window.PyViz.comms[comm_id] = comm;
-        return comm;
-      };
-
-      NteractPanelCommManager.prototype.receiveServerPatch = function(payload) {
-        var target = this.targets[payload.commId];
-        if (!target || !target.msg_handler) {
-          return;
-        }
-        target.msg_handler({
-          metadata: payload.metadata || {},
-          content: {data: payload.data},
-          buffers: payload.buffers || []
-        });
-      };
-
-      NteractPanelCommManager.prototype.receiveAck = function(payload) {
-        var comm = this.comms[payload.commId] || window.PyViz.comms[payload.commId];
-        if (!comm) {
-          return;
-        }
-        var handler = comm.onMsg || comm.on_msg;
-        if (handler) {
-          handler({
-            metadata: payload.metadata || {},
-            content: {data: payload.data},
-            buffers: payload.buffers || []
-          });
-        }
-      };
-
-      NteractPanelCommManager.prototype.setDisconnected = function(payload) {
-        var commId = payload && payload.commId;
-        if (commId && this.comms[commId]) {
-          this.comms[commId].active = false;
-          this.comms[commId].connected = false;
-        }
-        console.warn("Panel runtime channel disconnected", payload || {});
-      };
-
-      window.PyViz.comm_manager = new NteractPanelCommManager();
-    })();
-    """
+    # The browser-side comm manager is installed by the isolated renderer's
+    # TypeScript bundle so it can be type-checked and tested with the transport
+    # it uses. Panel still expects this attribute to exist when composing its
+    # extension JavaScript, so keep it as an empty no-op string.
+    js_manager = ""
 
     _comms: dict[str, NteractPanelComm] = {}
     server_comm = NteractPanelServerComm

--- a/python/nteract-kernel-launcher/nteract_kernel_launcher/_panel.py
+++ b/python/nteract-kernel-launcher/nteract_kernel_launcher/_panel.py
@@ -197,6 +197,46 @@ def _panel_event_type_for_send(role: str, metadata: dict[str, Any] | None) -> st
     return "panel_message"
 
 
+def _panel_event_comm_id(event: dict[str, Any]) -> str | None:
+    comm_id = event.get("comm_id")
+    if isinstance(comm_id, str) and comm_id:
+        return comm_id
+
+    payload = event.get("payload")
+    if isinstance(payload, dict):
+        comm_id = payload.get("commId") or payload.get("comm_id")
+        if isinstance(comm_id, str) and comm_id:
+            return comm_id
+
+    channel = event.get("channel")
+    if isinstance(channel, dict):
+        comm_id = channel.get("commId") or channel.get("comm_id")
+        if isinstance(comm_id, str) and comm_id:
+            return comm_id
+
+    return None
+
+
+def _panel_event_patch(event: dict[str, Any], comm_id: str) -> dict[str, Any]:
+    patch = event.get("patch")
+    if not isinstance(patch, dict):
+        payload = event.get("payload")
+        patch = payload if isinstance(payload, dict) else event
+
+    data = patch.get("data") if isinstance(patch, dict) else None
+    metadata = patch.get("metadata") if isinstance(patch, dict) else None
+    buffers = patch.get("buffers") if isinstance(patch, dict) else None
+
+    content_data = dict(data) if isinstance(data, dict) else {"data": data}
+    content_data.setdefault("comm_id", comm_id)
+
+    return {
+        "content": {"data": content_data},
+        "metadata": metadata if isinstance(metadata, dict) else {},
+        "buffers": buffers if isinstance(buffers, list) else [],
+    }
+
+
 class NteractPanelServerComm(NteractPanelComm):
     def __init__(self, *args: Any, **kwargs: Any) -> None:
         super().__init__(*args, role="server", **kwargs)
@@ -273,6 +313,24 @@ class NteractPanelCommManager:
         comm = cls.client_comm(id, on_msg, on_error, on_stdout, on_open, on_close=cls._forget_comm)
         cls._comms[comm.id] = comm
         return comm
+
+    @classmethod
+    def receive_runtime_event(cls, event: dict[str, Any]) -> bool:
+        """Deliver a typed nteract Panel runtime event into Panel's callbacks."""
+        event_type = event.get("type")
+        if event_type not in {"panel_client_patch", "client_patch"}:
+            return False
+
+        comm_id = _panel_event_comm_id(event)
+        if comm_id is None:
+            return False
+
+        comm = cls._comms.get(comm_id)
+        if comm is None:
+            return False
+
+        comm._handle_msg(_panel_event_patch(event, comm_id))
+        return True
 
 
 def _panel_runtime_marker(self: Any, model: Any, doc: Any, comm: Any) -> dict[str, Any]:

--- a/python/nteract-kernel-launcher/nteract_kernel_launcher/_panel.py
+++ b/python/nteract-kernel-launcher/nteract_kernel_launcher/_panel.py
@@ -1,0 +1,419 @@
+"""Panel runtime-state hook for the nteract kernel launcher.
+
+This module deliberately does not import Panel on kernel startup. It installs a
+small import hook that can patch Panel after user code imports it. The patched
+comm manager exposes Panel/PyViz's expected Python and JavaScript surfaces while
+emitting typed Panel/Bokeh channel events for a future daemon-backed transport.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import sys
+import traceback
+import uuid
+from collections.abc import Callable
+from contextlib import suppress
+from io import StringIO
+from typing import Any
+
+log = logging.getLogger("nteract_kernel_launcher")
+
+PANEL_RUNTIME_STATE_ENV = "NTERACT_PANEL_RUNTIME_STATE"
+_TRUE_VALUES = frozenset({"1", "true", "yes", "on", "enabled"})
+_PANEL_IMPORT_TARGETS = frozenset(
+    {"panel", "panel.viewable", "panel.io.notebook", "panel.io.state"}
+)
+_panel_import_hook: Any | None = None
+_event_sink: Callable[[dict[str, Any]], None] | None = None
+
+
+def panel_runtime_state_enabled() -> bool:
+    """Return whether the experimental native Panel runtime path is enabled."""
+    return os.environ.get(PANEL_RUNTIME_STATE_ENV, "").strip().lower() in _TRUE_VALUES
+
+
+def set_panel_runtime_event_sink(sink: Callable[[dict[str, Any]], None] | None) -> None:
+    """Install an in-process sink for typed Panel runtime events.
+
+    The daemon transport is a later slice. Tests and future launcher glue can
+    use this hook to observe the exact event surface without opening raw
+    Jupyter comms.
+    """
+    global _event_sink
+    _event_sink = sink
+
+
+def _emit_panel_event(event: dict[str, Any]) -> None:
+    event.setdefault("protocol", "nteract.panel.runtime.v1")
+    sink = _event_sink
+    if sink is not None:
+        sink(event)
+    else:
+        log.debug("panel runtime event: %s", event)
+
+
+class _CapturedStdout(list[str]):
+    def __enter__(self) -> _CapturedStdout:
+        self._stdout = sys.stdout
+        sys.stdout = self._stringio = StringIO()
+        return self
+
+    def __exit__(self, *_args: Any) -> None:
+        self.extend(self._stringio.getvalue().splitlines())
+        sys.stdout = self._stdout
+
+
+class NteractPanelComm:
+    """PyViz-compatible comm that emits typed nteract Panel runtime events."""
+
+    def __init__(
+        self,
+        id: str | None = None,
+        on_msg: Callable[[dict[str, Any]], None] | None = None,
+        on_error: Callable[[Exception], None] | None = None,
+        on_stdout: Callable[[list[str]], None] | None = None,
+        on_open: Callable[[dict[str, Any]], None] | None = None,
+        *,
+        role: str,
+    ) -> None:
+        self.id = id if id else uuid.uuid4().hex
+        self._on_msg = on_msg
+        self._on_error = on_error
+        self._on_stdout = on_stdout
+        self._on_open = on_open
+        self.role = role
+        self.active = True
+        self.connected = True
+        _emit_panel_event({"type": "panel_channel_open", "comm_id": self.id, "role": self.role})
+
+    def init(self, on_msg: Callable[[dict[str, Any]], None] | None = None) -> None:
+        if on_msg is not None:
+            self._on_msg = on_msg
+        if self._on_open:
+            self._on_open({})
+        _emit_panel_event({"type": "panel_comm_init", "comm_id": self.id, "role": self.role})
+
+    def close(self) -> None:
+        self.active = False
+        self.connected = False
+        _emit_panel_event({"type": "panel_channel_close", "comm_id": self.id, "role": self.role})
+
+    def send(
+        self,
+        data: Any = None,
+        metadata: dict[str, Any] | None = None,
+        buffers: list[Any] | None = None,
+    ) -> None:
+        _emit_panel_event(
+            {
+                "type": _panel_event_type_for_send(self.role, metadata),
+                "comm_id": self.id,
+                "role": self.role,
+                "data": data,
+                "metadata": metadata or {},
+                "buffers": buffers or [],
+            }
+        )
+
+    @classmethod
+    def decode(cls, msg: Any) -> dict[str, Any]:
+        if not isinstance(msg, dict):
+            return {"data": msg}
+
+        content = msg.get("content")
+        if isinstance(content, dict) and isinstance(content.get("data"), dict):
+            decoded = dict(content["data"])
+            buffers = msg.get("buffers")
+            if buffers:
+                decoded["_buffers"] = dict(enumerate(buffers))
+            return decoded
+
+        return dict(msg)
+
+    def _handle_msg(self, msg: Any) -> None:
+        """Mirror PyViz's callback/ACK behavior for future inbound patches."""
+        comm_id = None
+        stdout: list[str] = []
+        try:
+            decoded = self.decode(msg)
+            comm_id = decoded.pop("comm_id", None)
+            if self._on_msg:
+                with _CapturedStdout() as captured:
+                    self._on_msg(decoded)
+                stdout = list(captured)
+                if stdout:
+                    with suppress(Exception):
+                        if self._on_stdout:
+                            self._on_stdout(stdout)
+        except Exception as exc:  # noqa: BLE001
+            with suppress(Exception):
+                if self._on_error:
+                    self._on_error(exc)
+            frames = traceback.extract_tb(sys.exc_info()[2])
+            lines = [""] + [f"{fname} {fn} L{lineno}" for fname, lineno, fn, _text in frames[-20:]]
+            lines.append(f"\t{type(exc).__name__}: {exc!s}")
+            if stdout:
+                lines.insert(0, "\n\t" + "\n\t".join(stdout))
+            reply: dict[str, Any] = {"msg_type": "Error", "traceback": "\n".join(lines)}
+        else:
+            reply = {
+                "msg_type": "Ready",
+                "content": "\n\t" + "\n\t".join(stdout) if stdout else "",
+            }
+
+        if comm_id:
+            reply["comm_id"] = comm_id
+        self.send(metadata=reply)
+
+
+def _panel_event_type_for_send(role: str, metadata: dict[str, Any] | None) -> str:
+    if isinstance(metadata, dict) and metadata.get("msg_type") in {"Ready", "Error"}:
+        return "panel_ack"
+    if role == "server":
+        return "panel_server_patch"
+    if role == "client":
+        return "panel_client_patch"
+    return "panel_message"
+
+
+class NteractPanelServerComm(NteractPanelComm):
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
+        super().__init__(*args, role="server", **kwargs)
+
+
+class NteractPanelClientComm(NteractPanelComm):
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
+        super().__init__(*args, role="client", **kwargs)
+
+
+class NteractPanelCommManager:
+    """Panel/PyViz comm manager backed by typed nteract runtime events."""
+
+    js_manager = """
+    (function() {
+      if ((window.PyViz === undefined) || (window.PyViz instanceof HTMLElement)) {
+        window.PyViz = {comms: {}, comm_status: {}, kernels: {}, receivers: {}, plot_index: []};
+      }
+
+      function runtime() {
+        return window.__nteractPanelRuntime || null;
+      }
+
+      function NteractPanelCommManager() {
+        this.targets = {};
+        this.comms = {};
+      }
+
+      NteractPanelCommManager.prototype.register_target = function(plot_id, comm_id, msg_handler) {
+        this.targets[comm_id] = {plot_id: plot_id, msg_handler: msg_handler};
+        var rt = runtime();
+        if (rt && rt.registerTarget) {
+          rt.registerTarget({plotId: plot_id, commId: comm_id});
+        }
+      };
+
+      NteractPanelCommManager.prototype.get_client_comm = function(plot_id, comm_id, msg_handler) {
+        if (comm_id in this.comms) {
+          return this.comms[comm_id];
+        }
+        var comm = {
+          active: true,
+          connected: true,
+          onMsg: msg_handler,
+          on_msg: function(handler) { comm.onMsg = handler; },
+          send: function(data, metadata, buffers) {
+            var rt = runtime();
+            if (!rt || !rt.sendClientPatch) {
+              console.warn("nteract Panel runtime transport is not connected");
+              return;
+            }
+            rt.sendClientPatch({
+              plotId: plot_id,
+              commId: comm_id,
+              data: data,
+              metadata: metadata || {},
+              buffers: buffers || []
+            });
+          },
+          close: function() {
+            comm.active = false;
+            comm.connected = false;
+            var rt = runtime();
+            if (rt && rt.closeChannel) {
+              rt.closeChannel({plotId: plot_id, commId: comm_id});
+            }
+          }
+        };
+        if (msg_handler) {
+          comm.onMsg = msg_handler;
+        }
+        this.comms[comm_id] = comm;
+        window.PyViz.comms[comm_id] = comm;
+        return comm;
+      };
+
+      window.PyViz.comm_manager = new NteractPanelCommManager();
+    })();
+    """
+
+    _comms: dict[str, NteractPanelComm] = {}
+    server_comm = NteractPanelServerComm
+    client_comm = NteractPanelClientComm
+    _nteract_panel_comm_manager = True
+    _nteract_original_manager: Any | None = None
+
+    @classmethod
+    def get_server_comm(
+        cls,
+        on_msg: Callable[[dict[str, Any]], None] | None = None,
+        id: str | None = None,
+        on_error: Callable[[Exception], None] | None = None,
+        on_stdout: Callable[[list[str]], None] | None = None,
+        on_open: Callable[[dict[str, Any]], None] | None = None,
+    ) -> NteractPanelComm:
+        comm = cls.server_comm(id, on_msg, on_error, on_stdout, on_open)
+        cls._comms[comm.id] = comm
+        return comm
+
+    @classmethod
+    def get_client_comm(
+        cls,
+        on_msg: Callable[[dict[str, Any]], None] | None = None,
+        id: str | None = None,
+        on_error: Callable[[Exception], None] | None = None,
+        on_stdout: Callable[[list[str]], None] | None = None,
+        on_open: Callable[[dict[str, Any]], None] | None = None,
+    ) -> NteractPanelComm:
+        comm = cls.client_comm(id, on_msg, on_error, on_stdout, on_open)
+        cls._comms[comm.id] = comm
+        return comm
+
+
+def _patch_panel_modules() -> bool:
+    if not panel_runtime_state_enabled():
+        return False
+
+    patched = False
+    original_manager: Any | None = None
+    notebook = sys.modules.get("panel.io.notebook")
+    if notebook is not None:
+        original_manager = getattr(notebook, "JupyterCommManagerBinary", None) or getattr(
+            notebook, "_JupyterCommManager", None
+        )
+        if original_manager is not None and not getattr(
+            original_manager, "_nteract_panel_comm_manager", False
+        ):
+            NteractPanelCommManager._nteract_original_manager = original_manager
+        for name in ("JupyterCommManagerBinary", "_JupyterCommManager"):
+            if hasattr(notebook, name):
+                setattr(notebook, name, NteractPanelCommManager)
+                patched = True
+
+    viewable = sys.modules.get("panel.viewable")
+    if viewable is not None and hasattr(viewable, "JupyterCommManager"):
+        current = viewable.JupyterCommManager
+        if not getattr(current, "_nteract_panel_comm_manager", False):
+            original_manager = current
+            NteractPanelCommManager._nteract_original_manager = current
+        viewable.JupyterCommManager = NteractPanelCommManager
+        patched = True
+
+    state_module = sys.modules.get("panel.io.state")
+    state = getattr(state_module, "state", None) if state_module is not None else None
+    if state is not None:
+        current = getattr(state, "_comm_manager", None)
+        if current is original_manager or getattr(current, "_nteract_panel_comm_manager", False):
+            state._comm_manager = NteractPanelCommManager
+            patched = True
+
+    if patched:
+        log.debug("patched Panel comm manager for nteract runtime state")
+    return patched
+
+
+class _PanelLoader:
+    def __init__(self, loader: Any) -> None:
+        self._loader = loader
+
+    def create_module(self, spec: Any) -> Any:
+        create_module = getattr(self._loader, "create_module", None)
+        if create_module is None:
+            return None
+        return create_module(spec)
+
+    def exec_module(self, module: Any) -> None:
+        self._loader.exec_module(module)
+        _patch_panel_modules()
+
+    def load_module(self, fullname: str) -> Any:
+        module = self._loader.load_module(fullname)
+        _patch_panel_modules()
+        return module
+
+    def __getattr__(self, name: str) -> Any:
+        return getattr(self._loader, name)
+
+
+class _PanelImportHook:
+    _nteract_panel_import_hook = True
+
+    def find_spec(self, fullname: str, path: Any = None, target: Any = None) -> Any:
+        if fullname not in _PANEL_IMPORT_TARGETS:
+            return None
+
+        for finder in sys.meta_path:
+            if getattr(finder, "_nteract_panel_import_hook", False):
+                continue
+            find_spec = getattr(finder, "find_spec", None)
+            if find_spec is None:
+                continue
+            spec = find_spec(fullname, path, target)
+            if spec is None:
+                continue
+            loader = spec.loader
+            if (
+                loader is not None
+                and not isinstance(loader, _PanelLoader)
+                and getattr(loader, "exec_module", None) is not None
+            ):
+                spec.loader = _PanelLoader(loader)
+            return spec
+
+        return None
+
+
+def _install_panel_import_hook() -> None:
+    global _panel_import_hook
+
+    for finder in sys.meta_path:
+        if getattr(finder, "_nteract_panel_import_hook", False):
+            _panel_import_hook = finder
+            return
+
+    hook = _PanelImportHook()
+    sys.meta_path.insert(0, hook)
+    _panel_import_hook = hook
+
+
+def _uninstall_panel_import_hook() -> None:
+    global _panel_import_hook
+
+    sys.meta_path[:] = [
+        finder
+        for finder in sys.meta_path
+        if not getattr(finder, "_nteract_panel_import_hook", False)
+    ]
+    _panel_import_hook = None
+
+
+def install() -> None:
+    """Install the lazy Panel hook and patch already-loaded Panel modules."""
+    _patch_panel_modules()
+    _install_panel_import_hook()
+
+
+def uninstall() -> None:
+    """Remove the lazy import hook. Existing Panel monkeypatches are left intact."""
+    _uninstall_panel_import_hook()

--- a/python/nteract-kernel-launcher/nteract_kernel_launcher/_panel.py
+++ b/python/nteract-kernel-launcher/nteract_kernel_launcher/_panel.py
@@ -2,8 +2,9 @@
 
 This module deliberately does not import Panel on kernel startup. It installs a
 small import hook that can patch Panel after user code imports it. The patched
-comm manager exposes Panel/PyViz's expected Python and JavaScript surfaces while
-emitting typed Panel/Bokeh channel events for a future daemon-backed transport.
+manager is a compatibility adapter for Panel/PyViz's current notebook backend:
+it preserves the API Panel calls today while emitting typed Panel/Bokeh channel
+events for a future daemon-backed transport.
 """
 
 from __future__ import annotations
@@ -66,7 +67,8 @@ class _CapturedStdout(list[str]):
         try:
             self.extend(self._stringio.getvalue().splitlines())
         finally:
-            sys.stdout = self._stdout
+            if sys.stdout is self._stringio:
+                sys.stdout = self._stdout
 
 
 class NteractPanelComm:
@@ -149,14 +151,22 @@ class NteractPanelComm:
             decoded = self.decode(msg)
             comm_id = decoded.pop("comm_id", None)
             if self._on_msg:
-                with _CapturedStdout() as captured:
-                    self._on_msg(decoded)
-                stdout = list(captured)
+                captured = None
+                try:
+                    with _CapturedStdout() as captured:
+                        self._on_msg(decoded)
+                finally:
+                    if captured is not None:
+                        stdout = list(captured)
                 if stdout:
                     with suppress(Exception):
                         if self._on_stdout:
                             self._on_stdout(stdout)
         except Exception as exc:  # noqa: BLE001
+            if stdout:
+                with suppress(Exception):
+                    if self._on_stdout:
+                        self._on_stdout(stdout)
             with suppress(Exception):
                 if self._on_error:
                     self._on_error(exc)
@@ -198,7 +208,7 @@ class NteractPanelClientComm(NteractPanelComm):
 
 
 class NteractPanelCommManager:
-    """Panel/PyViz comm manager backed by typed nteract runtime events."""
+    """Panel/PyViz compatibility adapter backed by typed nteract runtime events."""
 
     # The browser-side comm manager is installed by the isolated renderer's
     # TypeScript bundle so it can be type-checked and tested with the transport
@@ -211,6 +221,7 @@ class NteractPanelCommManager:
     client_comm = NteractPanelClientComm
     _nteract_panel_comm_manager = True
     _nteract_original_manager: Any | None = None
+    _nteract_original_bindings: dict[tuple[str, str], Any] = {}
 
     @classmethod
     def _remember_original_manager(cls, manager: Any | None) -> None:
@@ -218,6 +229,13 @@ class NteractPanelCommManager:
             return
         if cls._nteract_original_manager is None:
             cls._nteract_original_manager = manager
+
+    @classmethod
+    def _remember_original_binding(cls, module_name: str, attr: str, value: Any) -> None:
+        if getattr(value, "_nteract_panel_comm_manager", False):
+            return
+        cls._remember_original_manager(value)
+        cls._nteract_original_bindings.setdefault((module_name, attr), value)
 
     @classmethod
     def _forget_comm(cls, comm_id: str) -> None:
@@ -290,15 +308,13 @@ def _add_panel_runtime_marker(
 
     marker = _panel_runtime_marker(self, model, doc, comm)
     data[NTERACT_PANEL_RUNTIME_MIME] = marker
-    metadata[NTERACT_PANEL_RUNTIME_MIME] = {
+    marker_metadata = {
         "id": marker.get("plot_id"),
         "server_comm_id": marker.get("server_comm_id"),
         "client_comm_id": marker.get("client_comm_id"),
     }
     metadata[NTERACT_PANEL_RUNTIME_MIME] = {
-        key: value
-        for key, value in metadata[NTERACT_PANEL_RUNTIME_MIME].items()
-        if value is not None
+        key: value for key, value in marker_metadata.items() if value is not None
     }
     return data, metadata
 
@@ -326,6 +342,17 @@ def _patch_panel_mimebundle(viewable: Any) -> bool:
     return True
 
 
+def _unpatch_panel_mimebundle(viewable: Any) -> bool:
+    mixin = getattr(viewable, "MimeRenderMixin", None)
+    render_mimebundle = getattr(mixin, "_render_mimebundle", None) if mixin is not None else None
+    original = getattr(render_mimebundle, "_nteract_original", None)
+    if original is None:
+        return False
+
+    type.__setattr__(mixin, "_render_mimebundle", original)
+    return True
+
+
 def _patch_panel_modules() -> bool:
     if not panel_runtime_state_enabled():
         return False
@@ -333,12 +360,13 @@ def _patch_panel_modules() -> bool:
     patched = False
     notebook = sys.modules.get("panel.io.notebook")
     if notebook is not None:
-        original_manager = getattr(notebook, "JupyterCommManagerBinary", None) or getattr(
-            notebook, "_JupyterCommManager", None
-        )
-        NteractPanelCommManager._remember_original_manager(original_manager)
         for name in ("JupyterCommManagerBinary", "_JupyterCommManager"):
             if hasattr(notebook, name):
+                NteractPanelCommManager._remember_original_binding(
+                    "panel.io.notebook",
+                    name,
+                    getattr(notebook, name),
+                )
                 setattr(notebook, name, NteractPanelCommManager)
                 patched = True
 
@@ -348,7 +376,11 @@ def _patch_panel_modules() -> bool:
         if not getattr(current, "_nteract_panel_comm_manager", False):
             # Keep the first original binding so a future restore path knows
             # which manager Panel exposed before nteract patched any module.
-            NteractPanelCommManager._remember_original_manager(current)
+            NteractPanelCommManager._remember_original_binding(
+                "panel.viewable",
+                "JupyterCommManager",
+                current,
+            )
         viewable.JupyterCommManager = NteractPanelCommManager
         patched = True
         patched = _patch_panel_mimebundle(viewable) or patched
@@ -358,13 +390,40 @@ def _patch_panel_modules() -> bool:
     if state is not None:
         current = getattr(state, "_comm_manager", None)
         if not getattr(current, "_nteract_panel_comm_manager", False):
-            NteractPanelCommManager._remember_original_manager(current)
+            NteractPanelCommManager._remember_original_binding(
+                "panel.io.state",
+                "state._comm_manager",
+                current,
+            )
             state._comm_manager = NteractPanelCommManager
             patched = True
 
     if patched:
         log.debug("patched Panel comm manager for nteract runtime state")
     return patched
+
+
+def _restore_panel_modules() -> None:
+    viewable = sys.modules.get("panel.viewable")
+    if viewable is not None:
+        _unpatch_panel_mimebundle(viewable)
+
+    for (module_name, attr), original in list(
+        NteractPanelCommManager._nteract_original_bindings.items()
+    ):
+        module = sys.modules.get(module_name)
+        if module is None:
+            continue
+        if attr == "state._comm_manager":
+            state = getattr(module, "state", None)
+            if (
+                state is not None
+                and getattr(state, "_comm_manager", None) is NteractPanelCommManager
+            ):
+                state._comm_manager = original
+            continue
+        if getattr(module, attr, None) is NteractPanelCommManager:
+            setattr(module, attr, original)
 
 
 class _PanelLoader:
@@ -449,7 +508,9 @@ def install() -> None:
 
 
 def uninstall() -> None:
-    """Remove the lazy import hook. Existing Panel monkeypatches are left intact."""
+    """Remove the lazy import hook and restore any loaded Panel monkeypatches."""
+    _restore_panel_modules()
     NteractPanelCommManager.clear_comms()
     NteractPanelCommManager._nteract_original_manager = None
+    NteractPanelCommManager._nteract_original_bindings.clear()
     _uninstall_panel_import_hook()

--- a/python/nteract-kernel-launcher/nteract_kernel_launcher/_panel.py
+++ b/python/nteract-kernel-launcher/nteract_kernel_launcher/_panel.py
@@ -15,12 +15,14 @@ import traceback
 import uuid
 from collections.abc import Callable
 from contextlib import suppress
+from functools import wraps
 from io import StringIO
 from typing import Any
 
 log = logging.getLogger("nteract_kernel_launcher")
 
 PANEL_RUNTIME_STATE_ENV = "NTERACT_PANEL_RUNTIME_STATE"
+NTERACT_PANEL_RUNTIME_MIME = "application/vnd.nteract.panel-runtime.v1+json"
 _TRUE_VALUES = frozenset({"1", "true", "yes", "on", "enabled"})
 _PANEL_IMPORT_TARGETS = frozenset(
     {"panel", "panel.viewable", "panel.io.notebook", "panel.io.state"}
@@ -204,6 +206,10 @@ class NteractPanelCommManager:
       function NteractPanelCommManager() {
         this.targets = {};
         this.comms = {};
+        var rt = runtime();
+        if (rt && rt.attachCommManager) {
+          rt.attachCommManager(this);
+        }
       }
 
       NteractPanelCommManager.prototype.register_target = function(plot_id, comm_id, msg_handler) {
@@ -254,6 +260,42 @@ class NteractPanelCommManager:
         return comm;
       };
 
+      NteractPanelCommManager.prototype.receiveServerPatch = function(payload) {
+        var target = this.targets[payload.commId];
+        if (!target || !target.msg_handler) {
+          return;
+        }
+        target.msg_handler({
+          metadata: payload.metadata || {},
+          content: {data: payload.data},
+          buffers: payload.buffers || []
+        });
+      };
+
+      NteractPanelCommManager.prototype.receiveAck = function(payload) {
+        var comm = this.comms[payload.commId] || window.PyViz.comms[payload.commId];
+        if (!comm) {
+          return;
+        }
+        var handler = comm.onMsg || comm.on_msg;
+        if (handler) {
+          handler({
+            metadata: payload.metadata || {},
+            content: {data: payload.data},
+            buffers: payload.buffers || []
+          });
+        }
+      };
+
+      NteractPanelCommManager.prototype.setDisconnected = function(payload) {
+        var commId = payload && payload.commId;
+        if (commId && this.comms[commId]) {
+          this.comms[commId].active = false;
+          this.comms[commId].connected = false;
+        }
+        console.warn("Panel runtime channel disconnected", payload || {});
+      };
+
       window.PyViz.comm_manager = new NteractPanelCommManager();
     })();
     """
@@ -291,6 +333,75 @@ class NteractPanelCommManager:
         return comm
 
 
+def _panel_runtime_marker(self: Any, model: Any, doc: Any, comm: Any) -> dict[str, Any]:
+    ref = getattr(model, "ref", {})
+    plot_id = ref.get("id") if isinstance(ref, dict) else getattr(ref, "id", None)
+    comms = getattr(self, "_comms", {})
+    pair = comms.get(plot_id) if plot_id is not None and hasattr(comms, "get") else None
+    client_comm = pair[1] if isinstance(pair, tuple) and len(pair) > 1 else None
+
+    marker = {
+        "version": 1,
+        "protocol": "nteract.panel.runtime.v1",
+        "plot_id": plot_id,
+        "server_comm_id": getattr(comm, "id", None),
+        "client_comm_id": getattr(client_comm, "id", None),
+    }
+    document_id = getattr(doc, "id", None)
+    if document_id is not None:
+        marker["document_id"] = document_id
+    return {key: value for key, value in marker.items() if value is not None}
+
+
+def _add_panel_runtime_marker(
+    mimebundle: tuple[dict[str, Any], dict[str, Any]],
+    self: Any,
+    model: Any,
+    doc: Any,
+    comm: Any,
+) -> tuple[dict[str, Any], dict[str, Any]]:
+    data, metadata = mimebundle
+    if not isinstance(data, dict) or not isinstance(metadata, dict):
+        return mimebundle
+
+    marker = _panel_runtime_marker(self, model, doc, comm)
+    data[NTERACT_PANEL_RUNTIME_MIME] = marker
+    metadata[NTERACT_PANEL_RUNTIME_MIME] = {
+        "id": marker.get("plot_id"),
+        "server_comm_id": marker.get("server_comm_id"),
+        "client_comm_id": marker.get("client_comm_id"),
+    }
+    metadata[NTERACT_PANEL_RUNTIME_MIME] = {
+        key: value
+        for key, value in metadata[NTERACT_PANEL_RUNTIME_MIME].items()
+        if value is not None
+    }
+    return data, metadata
+
+
+def _patch_panel_mimebundle(viewable: Any) -> bool:
+    mixin = getattr(viewable, "MimeRenderMixin", None)
+    render_mimebundle = getattr(mixin, "_render_mimebundle", None) if mixin is not None else None
+    if render_mimebundle is None or getattr(
+        render_mimebundle, "_nteract_panel_runtime_mime", False
+    ):
+        return False
+
+    @wraps(render_mimebundle)
+    def _nteract_render_mimebundle(
+        self: Any, model: Any, doc: Any, comm: Any, location: Any = None
+    ):
+        mimebundle = render_mimebundle(self, model, doc, comm, location)
+        if isinstance(mimebundle, tuple) and len(mimebundle) == 2:
+            return _add_panel_runtime_marker(mimebundle, self, model, doc, comm)
+        return mimebundle
+
+    _nteract_render_mimebundle._nteract_panel_runtime_mime = True  # type: ignore[attr-defined]
+    _nteract_render_mimebundle._nteract_original = render_mimebundle  # type: ignore[attr-defined]
+    type.__setattr__(mixin, "_render_mimebundle", _nteract_render_mimebundle)
+    return True
+
+
 def _patch_panel_modules() -> bool:
     if not panel_runtime_state_enabled():
         return False
@@ -319,6 +430,7 @@ def _patch_panel_modules() -> bool:
             NteractPanelCommManager._nteract_original_manager = current
         viewable.JupyterCommManager = NteractPanelCommManager
         patched = True
+        patched = _patch_panel_mimebundle(viewable) or patched
 
     state_module = sys.modules.get("panel.io.state")
     state = getattr(state_module, "state", None) if state_module is not None else None

--- a/python/nteract-kernel-launcher/tests/test_bootstrap.py
+++ b/python/nteract-kernel-launcher/tests/test_bootstrap.py
@@ -419,6 +419,8 @@ def _isolate_panel_import_hook(monkeypatch, _panel):
         ],
     )
     monkeypatch.setattr(_panel, "_panel_import_hook", None)
+    monkeypatch.setattr(_panel.NteractPanelCommManager, "_comms", {})
+    monkeypatch.setattr(_panel.NteractPanelCommManager, "_nteract_original_manager", None)
     for name in list(sys.modules):
         if name == "panel" or name.startswith("panel."):
             monkeypatch.delitem(sys.modules, name, raising=False)
@@ -499,6 +501,35 @@ def test_panel_runtime_hook_patches_loaded_panel_when_enabled(monkeypatch):
     }
 
 
+def test_panel_runtime_hook_keeps_first_original_manager(monkeypatch):
+    from nteract_kernel_launcher import _panel
+
+    _isolate_panel_import_hook(monkeypatch, _panel)
+    monkeypatch.setenv(_panel.PANEL_RUNTIME_STATE_ENV, "1")
+
+    class NotebookManager:
+        pass
+
+    class ViewableManager:
+        pass
+
+    notebook = types.ModuleType("panel.io.notebook")
+    notebook.JupyterCommManagerBinary = NotebookManager
+    viewable = types.ModuleType("panel.viewable")
+    viewable.JupyterCommManager = ViewableManager
+    state_mod = types.ModuleType("panel.io.state")
+    state_mod.state = SimpleNamespace(_comm_manager=ViewableManager)
+
+    monkeypatch.setitem(sys.modules, "panel.io.notebook", notebook)
+    monkeypatch.setitem(sys.modules, "panel.viewable", viewable)
+    monkeypatch.setitem(sys.modules, "panel.io.state", state_mod)
+
+    _panel.install()
+
+    assert _panel.NteractPanelCommManager._nteract_original_manager is NotebookManager
+    assert state_mod.state._comm_manager is _panel.NteractPanelCommManager
+
+
 def test_panel_runtime_hook_ignores_loaded_panel_by_default(monkeypatch):
     from nteract_kernel_launcher import _panel
 
@@ -545,6 +576,20 @@ def test_panel_comm_manager_emits_typed_events(monkeypatch):
     assert events[2]["protocol"] == "nteract.panel.runtime.v1"
     assert events[2]["comm_id"] == "server-comm"
     assert events[2]["buffers"] == [b"abc"]
+    assert "server-comm" not in _panel.NteractPanelCommManager._comms
+
+
+def test_panel_comm_manager_uninstall_clears_comms(monkeypatch):
+    from nteract_kernel_launcher import _panel
+
+    _isolate_panel_import_hook(monkeypatch, _panel)
+    _panel.NteractPanelCommManager.get_client_comm(id="client-comm")
+
+    assert "client-comm" in _panel.NteractPanelCommManager._comms
+
+    _panel.uninstall()
+
+    assert _panel.NteractPanelCommManager._comms == {}
 
 
 def test_panel_comm_manager_js_attaches_to_runtime():

--- a/python/nteract-kernel-launcher/tests/test_bootstrap.py
+++ b/python/nteract-kernel-launcher/tests/test_bootstrap.py
@@ -661,16 +661,10 @@ def test_panel_comm_manager_clear_closes_comms(monkeypatch):
     assert comm.connected is False
 
 
-def test_panel_comm_manager_js_attaches_to_runtime():
+def test_panel_comm_manager_js_is_frontend_owned():
     from nteract_kernel_launcher import _panel
 
-    manager_js = _panel.NteractPanelCommManager.js_manager
-
-    assert "window.__nteractPanelRuntime" in manager_js
-    assert "attachCommManager" in manager_js
-    assert "receiveServerPatch" in manager_js
-    assert "receiveAck" in manager_js
-    assert "setDisconnected" in manager_js
+    assert _panel.NteractPanelCommManager.js_manager == ""
 
 
 def test_enable_third_party_renderers_configures_loaded_modules(monkeypatch):

--- a/python/nteract-kernel-launcher/tests/test_bootstrap.py
+++ b/python/nteract-kernel-launcher/tests/test_bootstrap.py
@@ -449,6 +449,19 @@ def test_panel_runtime_hook_patches_loaded_panel_when_enabled(monkeypatch):
     notebook._JupyterCommManager = OriginalManager
     viewable = types.ModuleType("panel.viewable")
     viewable.JupyterCommManager = OriginalManager
+
+    class MimeRenderMixin:
+        def __init__(self):
+            self._comms = {}
+
+        def _render_mimebundle(self, model, doc, comm, location=None):
+            self._comms[model.ref["id"]] = (comm, SimpleNamespace(id="client-comm"))
+            return (
+                {"text/html": "<div id='panel-root'></div>"},
+                {"application/vnd.holoviews_exec.v0+json": {"id": model.ref["id"]}},
+            )
+
+    viewable.MimeRenderMixin = MimeRenderMixin
     state_mod = types.ModuleType("panel.io.state")
     state_mod.state = SimpleNamespace(_comm_manager=OriginalManager)
 
@@ -464,6 +477,26 @@ def test_panel_runtime_hook_patches_loaded_panel_when_enabled(monkeypatch):
     assert viewable.JupyterCommManager is _panel.NteractPanelCommManager
     assert state_mod.state._comm_manager is _panel.NteractPanelCommManager
     assert _panel.NteractPanelCommManager._nteract_original_manager is OriginalManager
+
+    mixin = viewable.MimeRenderMixin()
+    data, metadata = mixin._render_mimebundle(
+        SimpleNamespace(ref={"id": "plot-1"}),
+        SimpleNamespace(id="doc-1"),
+        SimpleNamespace(id="server-comm"),
+    )
+    assert data[_panel.NTERACT_PANEL_RUNTIME_MIME] == {
+        "version": 1,
+        "protocol": "nteract.panel.runtime.v1",
+        "plot_id": "plot-1",
+        "server_comm_id": "server-comm",
+        "client_comm_id": "client-comm",
+        "document_id": "doc-1",
+    }
+    assert metadata[_panel.NTERACT_PANEL_RUNTIME_MIME] == {
+        "id": "plot-1",
+        "server_comm_id": "server-comm",
+        "client_comm_id": "client-comm",
+    }
 
 
 def test_panel_runtime_hook_ignores_loaded_panel_by_default(monkeypatch):
@@ -512,6 +545,18 @@ def test_panel_comm_manager_emits_typed_events(monkeypatch):
     assert events[2]["protocol"] == "nteract.panel.runtime.v1"
     assert events[2]["comm_id"] == "server-comm"
     assert events[2]["buffers"] == [b"abc"]
+
+
+def test_panel_comm_manager_js_attaches_to_runtime():
+    from nteract_kernel_launcher import _panel
+
+    manager_js = _panel.NteractPanelCommManager.js_manager
+
+    assert "window.__nteractPanelRuntime" in manager_js
+    assert "attachCommManager" in manager_js
+    assert "receiveServerPatch" in manager_js
+    assert "receiveAck" in manager_js
+    assert "setDisconnected" in manager_js
 
 
 def test_enable_third_party_renderers_configures_loaded_modules(monkeypatch):

--- a/python/nteract-kernel-launcher/tests/test_bootstrap.py
+++ b/python/nteract-kernel-launcher/tests/test_bootstrap.py
@@ -530,6 +530,37 @@ def test_panel_runtime_hook_keeps_first_original_manager(monkeypatch):
     assert state_mod.state._comm_manager is _panel.NteractPanelCommManager
 
 
+def test_panel_runtime_hook_patches_distinct_state_manager(monkeypatch):
+    from nteract_kernel_launcher import _panel
+
+    _isolate_panel_import_hook(monkeypatch, _panel)
+    monkeypatch.setenv(_panel.PANEL_RUNTIME_STATE_ENV, "1")
+
+    class NotebookManager:
+        pass
+
+    class ViewableManager:
+        pass
+
+    class StateManager:
+        pass
+
+    notebook = types.ModuleType("panel.io.notebook")
+    notebook.JupyterCommManagerBinary = NotebookManager
+    viewable = types.ModuleType("panel.viewable")
+    viewable.JupyterCommManager = ViewableManager
+    state_mod = types.ModuleType("panel.io.state")
+    state_mod.state = SimpleNamespace(_comm_manager=StateManager)
+
+    monkeypatch.setitem(sys.modules, "panel.io.notebook", notebook)
+    monkeypatch.setitem(sys.modules, "panel.viewable", viewable)
+    monkeypatch.setitem(sys.modules, "panel.io.state", state_mod)
+
+    _panel.install()
+
+    assert state_mod.state._comm_manager is _panel.NteractPanelCommManager
+
+
 def test_panel_runtime_hook_ignores_loaded_panel_by_default(monkeypatch):
     from nteract_kernel_launcher import _panel
 
@@ -579,17 +610,55 @@ def test_panel_comm_manager_emits_typed_events(monkeypatch):
     assert "server-comm" not in _panel.NteractPanelCommManager._comms
 
 
+def test_panel_stdout_capture_restores_stdout_on_capture_error(monkeypatch):
+    from nteract_kernel_launcher import _panel
+
+    def raise_capture_error():
+        raise RuntimeError("boom")
+
+    original_stdout = sys.stdout
+    captured = _panel._CapturedStdout()
+    captured._stdout = original_stdout
+    captured._stringio = SimpleNamespace(getvalue=raise_capture_error)
+    sentinel_stdout = object()
+    monkeypatch.setattr(sys, "stdout", sentinel_stdout)
+
+    with pytest.raises(RuntimeError, match="boom"):
+        captured.__exit__(None, None, None)
+
+    assert sys.stdout is original_stdout
+
+
 def test_panel_comm_manager_uninstall_clears_comms(monkeypatch):
     from nteract_kernel_launcher import _panel
 
     _isolate_panel_import_hook(monkeypatch, _panel)
-    _panel.NteractPanelCommManager.get_client_comm(id="client-comm")
+    comm = _panel.NteractPanelCommManager.get_client_comm(id="client-comm")
+    _panel.NteractPanelCommManager._nteract_original_manager = object()
 
     assert "client-comm" in _panel.NteractPanelCommManager._comms
+    assert comm.active is True
+    assert comm.connected is True
 
     _panel.uninstall()
 
     assert _panel.NteractPanelCommManager._comms == {}
+    assert comm.active is False
+    assert comm.connected is False
+    assert _panel.NteractPanelCommManager._nteract_original_manager is None
+
+
+def test_panel_comm_manager_clear_closes_comms(monkeypatch):
+    from nteract_kernel_launcher import _panel
+
+    _isolate_panel_import_hook(monkeypatch, _panel)
+    comm = _panel.NteractPanelCommManager.get_server_comm(id="server-comm")
+
+    _panel.NteractPanelCommManager.clear_comms()
+
+    assert _panel.NteractPanelCommManager._comms == {}
+    assert comm.active is False
+    assert comm.connected is False
 
 
 def test_panel_comm_manager_js_attaches_to_runtime():

--- a/python/nteract-kernel-launcher/tests/test_bootstrap.py
+++ b/python/nteract-kernel-launcher/tests/test_bootstrap.py
@@ -421,6 +421,7 @@ def _isolate_panel_import_hook(monkeypatch, _panel):
     monkeypatch.setattr(_panel, "_panel_import_hook", None)
     monkeypatch.setattr(_panel.NteractPanelCommManager, "_comms", {})
     monkeypatch.setattr(_panel.NteractPanelCommManager, "_nteract_original_manager", None)
+    monkeypatch.setattr(_panel.NteractPanelCommManager, "_nteract_original_bindings", {})
     for name in list(sys.modules):
         if name == "panel" or name.startswith("panel."):
             monkeypatch.delitem(sys.modules, name, raising=False)
@@ -530,6 +531,50 @@ def test_panel_runtime_hook_keeps_first_original_manager(monkeypatch):
     assert state_mod.state._comm_manager is _panel.NteractPanelCommManager
 
 
+def test_panel_runtime_hook_uninstall_restores_loaded_panel(monkeypatch):
+    from nteract_kernel_launcher import _panel
+
+    _isolate_panel_import_hook(monkeypatch, _panel)
+    monkeypatch.setenv(_panel.PANEL_RUNTIME_STATE_ENV, "1")
+
+    class OriginalManager:
+        pass
+
+    notebook = types.ModuleType("panel.io.notebook")
+    notebook.JupyterCommManagerBinary = OriginalManager
+    notebook._JupyterCommManager = OriginalManager
+    viewable = types.ModuleType("panel.viewable")
+    viewable.JupyterCommManager = OriginalManager
+
+    class MimeRenderMixin:
+        def _render_mimebundle(self, model, doc, comm, location=None):
+            return ({"text/html": "<div></div>"}, {})
+
+    original_render = MimeRenderMixin._render_mimebundle
+    viewable.MimeRenderMixin = MimeRenderMixin
+    state_mod = types.ModuleType("panel.io.state")
+    state_mod.state = SimpleNamespace(_comm_manager=OriginalManager)
+
+    monkeypatch.setitem(sys.modules, "panel.io.notebook", notebook)
+    monkeypatch.setitem(sys.modules, "panel.viewable", viewable)
+    monkeypatch.setitem(sys.modules, "panel.io.state", state_mod)
+
+    _panel.install()
+    assert notebook.JupyterCommManagerBinary is _panel.NteractPanelCommManager
+    assert viewable.JupyterCommManager is _panel.NteractPanelCommManager
+    assert state_mod.state._comm_manager is _panel.NteractPanelCommManager
+    assert viewable.MimeRenderMixin._render_mimebundle is not original_render
+
+    _panel.uninstall()
+
+    assert notebook.JupyterCommManagerBinary is OriginalManager
+    assert notebook._JupyterCommManager is OriginalManager
+    assert viewable.JupyterCommManager is OriginalManager
+    assert state_mod.state._comm_manager is OriginalManager
+    assert viewable.MimeRenderMixin._render_mimebundle is original_render
+    assert _panel.NteractPanelCommManager._nteract_original_bindings == {}
+
+
 def test_panel_runtime_hook_patches_distinct_state_manager(monkeypatch):
     from nteract_kernel_launcher import _panel
 
@@ -610,7 +655,7 @@ def test_panel_comm_manager_emits_typed_events(monkeypatch):
     assert "server-comm" not in _panel.NteractPanelCommManager._comms
 
 
-def test_panel_stdout_capture_restores_stdout_on_capture_error(monkeypatch):
+def test_panel_stdout_capture_leaves_nested_stdout_alone_on_capture_error(monkeypatch):
     from nteract_kernel_launcher import _panel
 
     def raise_capture_error():
@@ -626,7 +671,58 @@ def test_panel_stdout_capture_restores_stdout_on_capture_error(monkeypatch):
     with pytest.raises(RuntimeError, match="boom"):
         captured.__exit__(None, None, None)
 
+    assert sys.stdout is sentinel_stdout
+
+
+def test_panel_stdout_capture_restores_own_stdout_on_capture_error(monkeypatch):
+    from nteract_kernel_launcher import _panel
+
+    def raise_capture_error():
+        raise RuntimeError("boom")
+
+    original_stdout = sys.stdout
+    captured = _panel._CapturedStdout()
+    captured._stdout = original_stdout
+    captured._stringio = SimpleNamespace(getvalue=raise_capture_error)
+    monkeypatch.setattr(sys, "stdout", captured._stringio)
+
+    with pytest.raises(RuntimeError, match="boom"):
+        captured.__exit__(None, None, None)
+
     assert sys.stdout is original_stdout
+
+
+def test_panel_comm_manager_preserves_partial_stdout_on_error(monkeypatch):
+    from nteract_kernel_launcher import _panel
+
+    events = []
+    stdout = []
+    errors = []
+    monkeypatch.setattr(_panel.NteractPanelCommManager, "_comms", {})
+    _panel.set_panel_runtime_event_sink(events.append)
+
+    def fail(_msg):
+        print("before failure")
+        raise ValueError("callback failed")
+
+    try:
+        comm = _panel.NteractPanelCommManager.get_client_comm(
+            id="client-comm",
+            on_msg=fail,
+            on_stdout=stdout.append,
+            on_error=errors.append,
+        )
+        comm._handle_msg({"content": {"data": {"comm_id": "client-comm"}}})
+    finally:
+        _panel.set_panel_runtime_event_sink(None)
+
+    ack = events[-1]
+    assert ack["type"] == "panel_ack"
+    assert ack["metadata"]["msg_type"] == "Error"
+    assert "before failure" in ack["metadata"]["traceback"]
+    assert ack["metadata"]["comm_id"] == "client-comm"
+    assert stdout == [["before failure"]]
+    assert len(errors) == 1
 
 
 def test_panel_comm_manager_uninstall_clears_comms(monkeypatch):

--- a/python/nteract-kernel-launcher/tests/test_bootstrap.py
+++ b/python/nteract-kernel-launcher/tests/test_bootstrap.py
@@ -725,6 +725,116 @@ def test_panel_comm_manager_preserves_partial_stdout_on_error(monkeypatch):
     assert len(errors) == 1
 
 
+def test_panel_comm_manager_receives_typed_client_patch(monkeypatch):
+    from nteract_kernel_launcher import _panel
+
+    events = []
+    received = []
+    stdout = []
+    monkeypatch.setattr(_panel.NteractPanelCommManager, "_comms", {})
+    _panel.set_panel_runtime_event_sink(events.append)
+
+    def on_msg(msg):
+        received.append(msg)
+        print("callback output")
+
+    try:
+        _panel.NteractPanelCommManager.get_client_comm(
+            id="client-comm",
+            on_msg=on_msg,
+            on_stdout=stdout.append,
+        )
+        handled = _panel.NteractPanelCommManager.receive_runtime_event(
+            {
+                "type": "client_patch",
+                "channel": {"commId": "client-comm"},
+                "patch": {
+                    "data": {"header": {}, "metadata": {}, "content": {"events": []}},
+                    "metadata": {"source": "browser"},
+                    "buffers": [b"abc"],
+                },
+            }
+        )
+    finally:
+        _panel.set_panel_runtime_event_sink(None)
+
+    assert handled is True
+    assert received == [
+        {
+            "header": {},
+            "metadata": {},
+            "content": {"events": []},
+            "_buffers": {0: b"abc"},
+        }
+    ]
+    assert stdout == [["callback output"]]
+
+    ack = events[-1]
+    assert ack["type"] == "panel_ack"
+    assert ack["comm_id"] == "client-comm"
+    assert ack["metadata"]["msg_type"] == "Ready"
+    assert ack["metadata"]["comm_id"] == "client-comm"
+    assert "callback output" in ack["metadata"]["content"]
+
+
+def test_panel_comm_manager_receives_iframe_client_patch_payload(monkeypatch):
+    from nteract_kernel_launcher import _panel
+
+    received = []
+    monkeypatch.setattr(_panel.NteractPanelCommManager, "_comms", {})
+
+    _panel.NteractPanelCommManager.get_client_comm(
+        id="client-comm",
+        on_msg=received.append,
+    )
+
+    handled = _panel.NteractPanelCommManager.receive_runtime_event(
+        {
+            "type": "panel_client_patch",
+            "payload": {
+                "commId": "client-comm",
+                "data": {"content": {"events": [{"kind": "ModelChanged"}]}},
+                "metadata": {},
+            },
+        }
+    )
+
+    assert handled is True
+    assert received == [{"content": {"events": [{"kind": "ModelChanged"}]}}]
+
+
+def test_panel_comm_manager_ignores_unmatched_runtime_event(monkeypatch):
+    from nteract_kernel_launcher import _panel
+
+    events = []
+    monkeypatch.setattr(_panel.NteractPanelCommManager, "_comms", {})
+    _panel.set_panel_runtime_event_sink(events.append)
+    try:
+        assert (
+            _panel.NteractPanelCommManager.receive_runtime_event(
+                {
+                    "type": "client_patch",
+                    "channel": {"commId": "missing-comm"},
+                    "patch": {"data": {}},
+                }
+            )
+            is False
+        )
+        assert (
+            _panel.NteractPanelCommManager.receive_runtime_event(
+                {
+                    "type": "channel_open",
+                    "channel": {"commId": "missing-comm"},
+                }
+            )
+            is False
+        )
+    finally:
+        _panel.set_panel_runtime_event_sink(None)
+
+    assert events == []
+
+
 def test_panel_comm_manager_uninstall_clears_comms(monkeypatch):
     from nteract_kernel_launcher import _panel
 

--- a/python/nteract-kernel-launcher/tests/test_bootstrap.py
+++ b/python/nteract-kernel-launcher/tests/test_bootstrap.py
@@ -359,6 +359,8 @@ def _isolate_renderer_import_hook(monkeypatch, _bootstrap):
             or name.startswith("altair.")
             or name == "plotly"
             or name.startswith("plotly.")
+            or name == "panel"
+            or name.startswith("panel.")
         ):
             monkeypatch.delitem(sys.modules, name, raising=False)
 
@@ -377,10 +379,11 @@ def test_load_extension_invokes_the_install_steps(monkeypatch):
     monkeypatch.setattr(
         _bootstrap, "_enable_third_party_renderers", lambda: calls.append("renderers")
     )
+    monkeypatch.setattr(_bootstrap._panel, "install", lambda: calls.append("panel"))
     monkeypatch.setattr(_bootstrap._traceback, "install", lambda ip: calls.append("traceback"))
 
     _bootstrap.load_ipython_extension(SimpleNamespace())
-    assert calls == ["llm", "formatters", "hooks", "redact", "renderers", "traceback"]
+    assert calls == ["llm", "formatters", "hooks", "redact", "renderers", "panel", "traceback"]
 
 
 def test_load_extension_swallows_per_step_failures(monkeypatch):
@@ -397,11 +400,118 @@ def test_load_extension_swallows_per_step_failures(monkeypatch):
     monkeypatch.setattr(_bootstrap, "_install_buffer_hooks", lambda ip: called.append("hooks"))
     monkeypatch.setattr(_bootstrap._output_redaction, "install", lambda ip: called.append("redact"))
     monkeypatch.setattr(_bootstrap, "_enable_third_party_renderers", lambda: called.append("r"))
+    monkeypatch.setattr(_bootstrap._panel, "install", lambda: called.append("panel"))
     monkeypatch.setattr(_bootstrap._traceback, "install", lambda ip: called.append("traceback"))
 
     # Must not raise.
     _bootstrap.load_ipython_extension(SimpleNamespace())
-    assert called == ["hooks", "redact", "r", "traceback"]
+    assert called == ["hooks", "redact", "r", "panel", "traceback"]
+
+
+def _isolate_panel_import_hook(monkeypatch, _panel):
+    monkeypatch.setattr(
+        sys,
+        "meta_path",
+        [
+            finder
+            for finder in sys.meta_path
+            if not getattr(finder, "_nteract_panel_import_hook", False)
+        ],
+    )
+    monkeypatch.setattr(_panel, "_panel_import_hook", None)
+    for name in list(sys.modules):
+        if name == "panel" or name.startswith("panel."):
+            monkeypatch.delitem(sys.modules, name, raising=False)
+
+
+def test_panel_runtime_hook_does_not_import_panel(monkeypatch):
+    from nteract_kernel_launcher import _panel
+
+    _isolate_panel_import_hook(monkeypatch, _panel)
+    _panel.install()
+
+    assert "panel" not in sys.modules
+    assert any(getattr(finder, "_nteract_panel_import_hook", False) for finder in sys.meta_path)
+
+
+def test_panel_runtime_hook_patches_loaded_panel_when_enabled(monkeypatch):
+    from nteract_kernel_launcher import _panel
+
+    _isolate_panel_import_hook(monkeypatch, _panel)
+    monkeypatch.setenv(_panel.PANEL_RUNTIME_STATE_ENV, "1")
+
+    class OriginalManager:
+        pass
+
+    panel = types.ModuleType("panel")
+    notebook = types.ModuleType("panel.io.notebook")
+    notebook.JupyterCommManagerBinary = OriginalManager
+    notebook._JupyterCommManager = OriginalManager
+    viewable = types.ModuleType("panel.viewable")
+    viewable.JupyterCommManager = OriginalManager
+    state_mod = types.ModuleType("panel.io.state")
+    state_mod.state = SimpleNamespace(_comm_manager=OriginalManager)
+
+    monkeypatch.setitem(sys.modules, "panel", panel)
+    monkeypatch.setitem(sys.modules, "panel.io.notebook", notebook)
+    monkeypatch.setitem(sys.modules, "panel.viewable", viewable)
+    monkeypatch.setitem(sys.modules, "panel.io.state", state_mod)
+
+    _panel.install()
+
+    assert notebook.JupyterCommManagerBinary is _panel.NteractPanelCommManager
+    assert notebook._JupyterCommManager is _panel.NteractPanelCommManager
+    assert viewable.JupyterCommManager is _panel.NteractPanelCommManager
+    assert state_mod.state._comm_manager is _panel.NteractPanelCommManager
+    assert _panel.NteractPanelCommManager._nteract_original_manager is OriginalManager
+
+
+def test_panel_runtime_hook_ignores_loaded_panel_by_default(monkeypatch):
+    from nteract_kernel_launcher import _panel
+
+    _isolate_panel_import_hook(monkeypatch, _panel)
+    monkeypatch.delenv(_panel.PANEL_RUNTIME_STATE_ENV, raising=False)
+
+    class OriginalManager:
+        pass
+
+    viewable = types.ModuleType("panel.viewable")
+    viewable.JupyterCommManager = OriginalManager
+    monkeypatch.setitem(sys.modules, "panel.viewable", viewable)
+
+    _panel.install()
+
+    assert viewable.JupyterCommManager is OriginalManager
+
+
+def test_panel_comm_manager_emits_typed_events(monkeypatch):
+    from nteract_kernel_launcher import _panel
+
+    events = []
+    monkeypatch.setattr(_panel.NteractPanelCommManager, "_comms", {})
+    _panel.set_panel_runtime_event_sink(events.append)
+    try:
+        opened = []
+        comm = _panel.NteractPanelCommManager.get_server_comm(
+            id="server-comm",
+            on_open=lambda msg: opened.append(msg),
+        )
+        comm.init()
+        comm.send({"content": []}, metadata={"msg_type": "PATCH-DOC"}, buffers=[b"abc"])
+        comm.close()
+    finally:
+        _panel.set_panel_runtime_event_sink(None)
+
+    assert opened == [{}]
+    assert [event["type"] for event in events] == [
+        "panel_channel_open",
+        "panel_comm_init",
+        "panel_server_patch",
+        "panel_channel_close",
+    ]
+    assert events[2]["protocol"] == "nteract.panel.runtime.v1"
+    assert events[2]["comm_id"] == "server-comm"
+    assert events[2]["buffers"] == [b"abc"]
 
 
 def test_enable_third_party_renderers_configures_loaded_modules(monkeypatch):

--- a/src/components/cell/OutputArea.tsx
+++ b/src/components/cell/OutputArea.tsx
@@ -190,7 +190,6 @@ import {
 } from "runtimed";
 // Re-export so existing imports continue to work.
 export type { JupyterOutput } from "./jupyter-output";
-export type { PanelRuntimeIframeMessage } from "runtimed";
 
 export interface PanelRuntimeMessageContext extends PanelRuntimeOutputContext {
   event: PanelRuntimeClientEvent;
@@ -870,7 +869,7 @@ function OutputAreaSingle({
   // Handle messages from iframe, routing widget messages to comm bridge
   const handleIframeMessage = useCallback(
     (message: IframeToParentMessage) => {
-      if (isPanelRuntimeMessage(message)) {
+      if (isPanelRuntimeMessage(message) && onPanelRuntimeMessage) {
         const currentOutputs = outputsRef.current;
         const outputIds = currentOutputs.flatMap((output) =>
           output.output_id ? [output.output_id] : [],
@@ -880,7 +879,7 @@ function OutputAreaSingle({
           executionCount: executionCount ?? null,
           outputIds,
         });
-        onPanelRuntimeMessage?.(message, {
+        onPanelRuntimeMessage(message, {
           event,
           cellId,
           executionCount: executionCount ?? null,

--- a/src/components/cell/OutputArea.tsx
+++ b/src/components/cell/OutputArea.tsx
@@ -184,6 +184,18 @@ import { notebookOutputAnchorId } from "runtimed";
 // Re-export so existing imports continue to work.
 export type { JupyterOutput } from "./jupyter-output";
 
+export type PanelRuntimeIframeMessage = Extract<
+  IframeToParentMessage,
+  { type: "panel_channel_open" | "panel_client_patch" | "panel_channel_close" }
+>;
+
+export interface PanelRuntimeMessageContext {
+  cellId?: string;
+  executionCount?: number | null;
+  outputIds: string[];
+  outputs: readonly JupyterOutput[];
+}
+
 interface OutputAreaProps {
   /**
    * Array of Jupyter outputs to render.
@@ -300,6 +312,15 @@ interface OutputAreaProps {
    */
   onIsolatedFrameHandleChange?: (handle: IsolatedFrameHandle | null) => void;
   /**
+   * Callback for typed Panel runtime messages emitted from the isolated
+   * iframe. Panel uses this separate path because its Bokeh document patches
+   * are not ipywidget comm state.
+   */
+  onPanelRuntimeMessage?: (
+    message: PanelRuntimeIframeMessage,
+    context: PanelRuntimeMessageContext,
+  ) => void;
+  /**
    * Callback for structured isolated renderer diagnostics.
    */
   onDiagnostic?: IsolatedDiagnosticHandler;
@@ -365,6 +386,16 @@ function requireIdentifiedOutputs(outputs: JupyterOutput[]): IdentifiedJupyterOu
     }
   }
   return outputs as IdentifiedJupyterOutput[];
+}
+
+function isPanelRuntimeMessage(
+  message: IframeToParentMessage,
+): message is PanelRuntimeIframeMessage {
+  return (
+    message.type === "panel_channel_open" ||
+    message.type === "panel_client_patch" ||
+    message.type === "panel_channel_close"
+  );
 }
 
 /**
@@ -607,6 +638,7 @@ function OutputAreaSingle({
   onSearchMatchCount,
   onIframeMouseDown,
   onIsolatedFrameHandleChange,
+  onPanelRuntimeMessage,
   onDiagnostic,
   hostContext,
   resolveTracebackExecutionTarget,
@@ -836,6 +868,16 @@ function OutputAreaSingle({
   // Handle messages from iframe, routing widget messages to comm bridge
   const handleIframeMessage = useCallback(
     (message: IframeToParentMessage) => {
+      if (isPanelRuntimeMessage(message)) {
+        onPanelRuntimeMessage?.(message, {
+          cellId,
+          executionCount: executionCount ?? null,
+          outputIds: outputs.flatMap((output) => (output.output_id ? [output.output_id] : [])),
+          outputs,
+        });
+        return;
+      }
+
       // Route widget messages to bridge
       if (bridgeRef.current) {
         bridgeRef.current.handleIframeMessage(message);
@@ -855,7 +897,15 @@ function OutputAreaSingle({
         onNavigateToTracebackCell?.(message.payload.target);
       }
     },
-    [onWidgetUpdate, onSearchMatchCount, onNavigateToTracebackCell],
+    [
+      cellId,
+      executionCount,
+      onWidgetUpdate,
+      onSearchMatchCount,
+      onNavigateToTracebackCell,
+      onPanelRuntimeMessage,
+      outputs,
+    ],
   );
 
   // Callback when frame is ready - set up bridge and render outputs

--- a/src/components/cell/OutputArea.tsx
+++ b/src/components/cell/OutputArea.tsx
@@ -651,6 +651,8 @@ function OutputAreaSingle({
   const staticFrameInteractionRef = useRef<HTMLDivElement>(null);
   const injectedLibsRef = useRef(new Set<string>());
   const renderGenRef = useRef(0);
+  const outputsRef = useRef(outputs);
+  outputsRef.current = outputs;
   const searchQueryRef = useRef(searchQuery);
   searchQueryRef.current = searchQuery;
   const [staticFrameInteractionActive, setStaticFrameInteractionActive] = useState(false);
@@ -869,7 +871,10 @@ function OutputAreaSingle({
   const handleIframeMessage = useCallback(
     (message: IframeToParentMessage) => {
       if (isPanelRuntimeMessage(message)) {
-        const outputIds = outputs.flatMap((output) => (output.output_id ? [output.output_id] : []));
+        const currentOutputs = outputsRef.current;
+        const outputIds = currentOutputs.flatMap((output) =>
+          output.output_id ? [output.output_id] : [],
+        );
         const event = panelRuntimeEventFromIframeMessage(message, {
           cellId,
           executionCount: executionCount ?? null,
@@ -880,7 +885,7 @@ function OutputAreaSingle({
           cellId,
           executionCount: executionCount ?? null,
           outputIds,
-          outputs,
+          outputs: currentOutputs,
         });
         return;
       }
@@ -911,7 +916,6 @@ function OutputAreaSingle({
       onSearchMatchCount,
       onNavigateToTracebackCell,
       onPanelRuntimeMessage,
-      outputs,
     ],
   );
 

--- a/src/components/cell/OutputArea.tsx
+++ b/src/components/cell/OutputArea.tsx
@@ -180,16 +180,20 @@ function useDeferredIsolatedFrame({
 }
 
 import type { JupyterOutput } from "./jupyter-output";
-import { notebookOutputAnchorId } from "runtimed";
+import {
+  isPanelRuntimeIframeMessage,
+  notebookOutputAnchorId,
+  panelRuntimeEventFromIframeMessage,
+  type PanelRuntimeClientEvent,
+  type PanelRuntimeIframeMessage,
+  type PanelRuntimeOutputContext,
+} from "runtimed";
 // Re-export so existing imports continue to work.
 export type { JupyterOutput } from "./jupyter-output";
+export type { PanelRuntimeIframeMessage } from "runtimed";
 
-export type PanelRuntimeIframeMessage = Extract<
-  IframeToParentMessage,
-  { type: "panel_channel_open" | "panel_client_patch" | "panel_channel_close" }
->;
-
-export interface PanelRuntimeMessageContext {
+export interface PanelRuntimeMessageContext extends PanelRuntimeOutputContext {
+  event: PanelRuntimeClientEvent;
   cellId?: string;
   executionCount?: number | null;
   outputIds: string[];
@@ -391,11 +395,7 @@ function requireIdentifiedOutputs(outputs: JupyterOutput[]): IdentifiedJupyterOu
 function isPanelRuntimeMessage(
   message: IframeToParentMessage,
 ): message is PanelRuntimeIframeMessage {
-  return (
-    message.type === "panel_channel_open" ||
-    message.type === "panel_client_patch" ||
-    message.type === "panel_channel_close"
-  );
+  return isPanelRuntimeIframeMessage(message);
 }
 
 /**
@@ -869,10 +869,17 @@ function OutputAreaSingle({
   const handleIframeMessage = useCallback(
     (message: IframeToParentMessage) => {
       if (isPanelRuntimeMessage(message)) {
-        onPanelRuntimeMessage?.(message, {
+        const outputIds = outputs.flatMap((output) => (output.output_id ? [output.output_id] : []));
+        const event = panelRuntimeEventFromIframeMessage(message, {
           cellId,
           executionCount: executionCount ?? null,
-          outputIds: outputs.flatMap((output) => (output.output_id ? [output.output_id] : [])),
+          outputIds,
+        });
+        onPanelRuntimeMessage?.(message, {
+          event,
+          cellId,
+          executionCount: executionCount ?? null,
+          outputIds,
           outputs,
         });
         return;

--- a/src/components/cell/__tests__/OutputArea.test.tsx
+++ b/src/components/cell/__tests__/OutputArea.test.tsx
@@ -1426,6 +1426,23 @@ describe("OutputArea iframe theme sync", () => {
     expect(mockCommBridgeHandleIframeMessage).toHaveBeenCalledWith(widgetMessage);
   });
 
+  it("falls back to the iframe bridge for Panel messages when no Panel handler exists", async () => {
+    renderWithWidgetContext(<OutputArea outputs={[makeWidgetOutput()]} />);
+
+    await waitFor(() => {
+      expect(lastFrameMessageHandler).toBeDefined();
+      expect(mockFrameHandle.renderBatch).toHaveBeenCalled();
+    });
+
+    const panelMessage = {
+      type: "panel_channel_open",
+      payload: { plotId: "p1011", commId: "panel-client-comm" },
+    } as const;
+    lastFrameMessageHandler?.(panelMessage);
+
+    expect(mockCommBridgeHandleIframeMessage).toHaveBeenCalledWith(panelMessage);
+  });
+
   it("does not preload hidden iframes for DOM-only segments", () => {
     render(
       <OutputArea

--- a/src/components/cell/__tests__/OutputArea.test.tsx
+++ b/src/components/cell/__tests__/OutputArea.test.tsx
@@ -1279,6 +1279,32 @@ describe("OutputArea iframe theme sync", () => {
     lastFrameMessageHandler?.(message);
 
     expect(onPanelRuntimeMessage).toHaveBeenCalledWith(message, {
+      event: {
+        protocol: "nteract.panel.runtime.v1",
+        version: 1,
+        direction: "iframe_to_kernel",
+        type: "client_patch",
+        channel: {
+          channelId: "cell:panel-cell|output:panel-loading-html|plot:p1011|comm:panel-client-comm",
+          commId: "panel-client-comm",
+          plotId: "p1011",
+          cellId: "panel-cell",
+          executionCount: 7,
+          outputId: "panel-loading-html",
+          outputIds: [
+            "panel-loading-html",
+            "panel-load-js",
+            "panel-empty-placeholder",
+            "panel-root-html",
+            "panel-exec-html",
+          ],
+        },
+        patch: {
+          data: { events: [{ kind: "ModelChanged", attr: "value" }] },
+          metadata: {},
+          buffers: [],
+        },
+      },
       cellId: "panel-cell",
       executionCount: 7,
       outputIds: [
@@ -1311,6 +1337,21 @@ describe("OutputArea iframe theme sync", () => {
     lastFrameMessageHandler?.(panelMessage);
 
     expect(onPanelRuntimeMessage).toHaveBeenCalledWith(panelMessage, {
+      event: {
+        protocol: "nteract.panel.runtime.v1",
+        version: 1,
+        direction: "iframe_to_kernel",
+        type: "channel_open",
+        channel: {
+          channelId: "output:widget-output|plot:p1011|comm:panel-client-comm",
+          commId: "panel-client-comm",
+          plotId: "p1011",
+          cellId: undefined,
+          executionCount: null,
+          outputId: "widget-output",
+          outputIds: ["widget-output"],
+        },
+      },
       cellId: undefined,
       executionCount: null,
       outputIds: ["widget-output"],

--- a/src/components/cell/__tests__/OutputArea.test.tsx
+++ b/src/components/cell/__tests__/OutputArea.test.tsx
@@ -1,8 +1,11 @@
 import { act, createEvent, fireEvent, render, screen, waitFor } from "@testing-library/react";
+import type { ReactElement } from "react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vite-plus/test";
 import { injectPluginsForMimes, needsPlugin } from "@/components/isolated/iframe-libraries";
 import { BOKEHJS_EXEC_MIME_TYPE, BOKEHJS_LOAD_MIME_TYPE } from "@/components/outputs/bokeh-mime";
 import { PANEL_EXEC_MIME_TYPE, PANEL_LOAD_MIME_TYPE } from "@/components/outputs/panel-mime";
+import type { WidgetStore } from "@/components/widgets/widget-store";
+import { WidgetStoreContext } from "@/components/widgets/widget-store-context";
 import { setMarkdownProjectionProjector } from "@/lib/markdown-projection";
 import { OutputArea, type JupyterOutput } from "../OutputArea";
 
@@ -13,6 +16,8 @@ let lastFrameMouseDown: (() => void) | undefined;
 let lastFrameMouseUp: ((params: { hasSelection?: boolean }) => void) | undefined;
 let isolatedFrameMountCount = 0;
 let restoreMarkdownProjector: (() => void) | undefined;
+const mockCommBridgeHandleIframeMessage = vi.fn();
+const mockCommBridgeDispose = vi.fn();
 
 const mockFrameHandle = {
   send: vi.fn(),
@@ -122,7 +127,10 @@ vi.mock("@/components/isolated", async (importOriginal) => {
 
   return {
     ...actual,
-    CommBridgeManager: class CommBridgeManager {},
+    CommBridgeManager: class CommBridgeManager {
+      handleIframeMessage = mockCommBridgeHandleIframeMessage;
+      dispose = mockCommBridgeDispose;
+    },
     IsolatedFrame: MockIsolatedFrame,
   };
 });
@@ -198,6 +206,36 @@ function makeWidgetOutput(outputId = "widget-output", modelId = "widget-model"):
     },
     metadata: {},
   };
+}
+
+function makeWidgetStoreStub(): WidgetStore {
+  return {
+    subscribe: vi.fn(() => () => {}),
+    getSnapshot: vi.fn(() => new Map()),
+    getModel: vi.fn(() => undefined),
+    createModel: vi.fn(),
+    updateModel: vi.fn(),
+    deleteModel: vi.fn(),
+    wasModelClosed: vi.fn(() => false),
+    subscribeToKey: vi.fn(() => () => {}),
+    emitCustomMessage: vi.fn(),
+    subscribeToCustomMessage: vi.fn(() => () => {}),
+  };
+}
+
+function renderWithWidgetContext(children: ReactElement) {
+  return render(
+    <WidgetStoreContext.Provider
+      value={{
+        store: makeWidgetStoreStub(),
+        sendUpdate: vi.fn(async () => {}),
+        sendCustom: vi.fn(),
+        closeComm: vi.fn(),
+      }}
+    >
+      {children}
+    </WidgetStoreContext.Provider>,
+  );
 }
 
 function makeMixedDocumentOutputs(): JupyterOutput[] {
@@ -410,6 +448,8 @@ describe("OutputArea iframe theme sync", () => {
     mockFrameHandle.search.mockClear();
     mockFrameHandle.searchNavigate.mockClear();
     mockFrameHandle.measureElement.mockClear();
+    mockCommBridgeHandleIframeMessage.mockClear();
+    mockCommBridgeDispose.mockClear();
     lastFrameMessageHandler = undefined;
     lastFrameMouseDown = undefined;
     lastFrameMouseUp = undefined;
@@ -1208,6 +1248,79 @@ describe("OutputArea iframe theme sync", () => {
     });
 
     expect(onSearchMatchCount).toHaveBeenLastCalledWith(3);
+  });
+
+  it("forwards Panel runtime messages with cell and output context", async () => {
+    const onPanelRuntimeMessage = vi.fn();
+    const outputs = makePanelDocumentOutputs();
+
+    render(
+      <OutputArea
+        cellId="panel-cell"
+        executionCount={7}
+        outputs={outputs}
+        onPanelRuntimeMessage={onPanelRuntimeMessage}
+      />,
+    );
+
+    await waitFor(() => {
+      expect(lastFrameMessageHandler).toBeDefined();
+    });
+
+    const message = {
+      type: "panel_client_patch",
+      payload: {
+        plotId: "p1011",
+        commId: "panel-client-comm",
+        data: { events: [{ kind: "ModelChanged", attr: "value" }] },
+      },
+    } as const;
+
+    lastFrameMessageHandler?.(message);
+
+    expect(onPanelRuntimeMessage).toHaveBeenCalledWith(message, {
+      cellId: "panel-cell",
+      executionCount: 7,
+      outputIds: [
+        "panel-loading-html",
+        "panel-load-js",
+        "panel-empty-placeholder",
+        "panel-root-html",
+        "panel-exec-html",
+      ],
+      outputs,
+    });
+  });
+
+  it("keeps Panel runtime messages out of the widget comm bridge", async () => {
+    const onPanelRuntimeMessage = vi.fn();
+
+    renderWithWidgetContext(
+      <OutputArea outputs={[makeWidgetOutput()]} onPanelRuntimeMessage={onPanelRuntimeMessage} />,
+    );
+
+    await waitFor(() => {
+      expect(lastFrameMessageHandler).toBeDefined();
+      expect(mockFrameHandle.renderBatch).toHaveBeenCalled();
+    });
+
+    const panelMessage = {
+      type: "panel_channel_open",
+      payload: { plotId: "p1011", commId: "panel-client-comm" },
+    } as const;
+    lastFrameMessageHandler?.(panelMessage);
+
+    expect(onPanelRuntimeMessage).toHaveBeenCalledWith(panelMessage, {
+      cellId: undefined,
+      executionCount: null,
+      outputIds: ["widget-output"],
+      outputs: [makeWidgetOutput()],
+    });
+    expect(mockCommBridgeHandleIframeMessage).not.toHaveBeenCalled();
+
+    const widgetMessage = { type: "widget_ready" } as const;
+    lastFrameMessageHandler?.(widgetMessage);
+    expect(mockCommBridgeHandleIframeMessage).toHaveBeenCalledWith(widgetMessage);
   });
 
   it("does not preload hidden iframes for DOM-only segments", () => {

--- a/src/components/cell/__tests__/OutputArea.test.tsx
+++ b/src/components/cell/__tests__/OutputArea.test.tsx
@@ -1318,6 +1318,68 @@ describe("OutputArea iframe theme sync", () => {
     });
   });
 
+  it("uses current outputs when an existing Panel iframe handler receives a message", async () => {
+    const onPanelRuntimeMessage = vi.fn();
+    const outputs = makePanelDocumentOutputs();
+    const nextOutputs: JupyterOutput[] = [
+      ...outputs,
+      {
+        output_type: "display_data",
+        output_id: "panel-extra-output",
+        data: { "text/html": "<div>extra</div>" },
+        metadata: {},
+      },
+    ];
+
+    const { rerender } = render(
+      <OutputArea
+        cellId="panel-cell"
+        executionCount={7}
+        outputs={outputs}
+        onPanelRuntimeMessage={onPanelRuntimeMessage}
+      />,
+    );
+
+    await waitFor(() => {
+      expect(lastFrameMessageHandler).toBeDefined();
+    });
+    const handler = lastFrameMessageHandler;
+
+    rerender(
+      <OutputArea
+        cellId="panel-cell"
+        executionCount={7}
+        outputs={nextOutputs}
+        onPanelRuntimeMessage={onPanelRuntimeMessage}
+      />,
+    );
+
+    const message = {
+      type: "panel_channel_open",
+      payload: {
+        plotId: "p1011",
+        commId: "panel-client-comm",
+      },
+    } as const;
+
+    handler?.(message);
+
+    expect(onPanelRuntimeMessage).toHaveBeenCalledWith(
+      message,
+      expect.objectContaining({
+        outputIds: [
+          "panel-loading-html",
+          "panel-load-js",
+          "panel-empty-placeholder",
+          "panel-root-html",
+          "panel-exec-html",
+          "panel-extra-output",
+        ],
+        outputs: nextOutputs,
+      }),
+    );
+  });
+
   it("keeps Panel runtime messages out of the widget comm bridge", async () => {
     const onPanelRuntimeMessage = vi.fn();
 

--- a/src/components/isolated/__tests__/frame-bridge.test.ts
+++ b/src/components/isolated/__tests__/frame-bridge.test.ts
@@ -24,6 +24,9 @@ describe("isIframeMessage", () => {
     "widget_ready",
     "widget_comm_msg",
     "widget_comm_close",
+    "panel_channel_open",
+    "panel_client_patch",
+    "panel_channel_close",
   ] as const;
 
   it.each(validMessageTypes)('returns true for valid message type "%s"', (type) => {
@@ -74,6 +77,9 @@ describe("isIframeMessage", () => {
     "comm_msg",
     "comm_close",
     "widget_snapshot",
+    "panel_server_patch",
+    "panel_ack",
+    "panel_disconnected",
   ];
 
   it.each(parentMessageTypes)('returns false for parent message type "%s"', (type) => {
@@ -125,6 +131,9 @@ describe("message type whitelist completeness", () => {
       "widget_ready",
       "widget_comm_msg",
       "widget_comm_close",
+      "panel_channel_open",
+      "panel_client_patch",
+      "panel_channel_close",
       "search_results",
     ];
 

--- a/src/components/isolated/__tests__/isolated-frame-runtime.test.ts
+++ b/src/components/isolated/__tests__/isolated-frame-runtime.test.ts
@@ -8,6 +8,9 @@ import {
   MCP_UI_SIZE_CHANGED,
   NTERACT_MEASURE_ELEMENT,
   NTERACT_MOUSE_UP,
+  NTERACT_PANEL_CHANNEL_CLOSE,
+  NTERACT_PANEL_CHANNEL_OPEN,
+  NTERACT_PANEL_CLIENT_PATCH,
   NTERACT_RENDER_OUTPUT,
   NTERACT_RENDERER_READY,
   NTERACT_THEME,
@@ -162,6 +165,40 @@ describe("IsolatedFrameRuntime", () => {
     transport.notificationHandlers.get(NTERACT_MOUSE_UP)?.({ hasSelection: true });
 
     expect(callbacks.onMouseUp).toHaveBeenCalledWith({ hasSelection: true });
+  });
+
+  it("forwards iframe Panel runtime notifications as typed messages", () => {
+    const { callbacks, frameWindow, runtime } = createRuntime();
+
+    runtime.handleWindowMessage(frameMessage(frameWindow, { type: "ready", payload: null }));
+    const transport = MockJsonRpcTransport.instances[0];
+    expect(transport).toBeDefined();
+    callbacks.onMessage.mockClear();
+
+    const open = { plotId: "plot-1", commId: "comm-1" };
+    const patch = {
+      plotId: "plot-1",
+      commId: "comm-1",
+      data: { events: [{ kind: "ModelChanged" }] },
+    };
+    const close = { plotId: "plot-1", commId: "comm-1" };
+
+    transport.notificationHandlers.get(NTERACT_PANEL_CHANNEL_OPEN)?.(open);
+    transport.notificationHandlers.get(NTERACT_PANEL_CLIENT_PATCH)?.(patch);
+    transport.notificationHandlers.get(NTERACT_PANEL_CHANNEL_CLOSE)?.(close);
+
+    expect(callbacks.onMessage).toHaveBeenNthCalledWith(1, {
+      type: "panel_channel_open",
+      payload: open,
+    });
+    expect(callbacks.onMessage).toHaveBeenNthCalledWith(2, {
+      type: "panel_client_patch",
+      payload: patch,
+    });
+    expect(callbacks.onMessage).toHaveBeenNthCalledWith(3, {
+      type: "panel_channel_close",
+      payload: close,
+    });
   });
 
   it("sends host context once per channel for equivalent content", () => {

--- a/src/components/isolated/__tests__/output-lane-policy.test.ts
+++ b/src/components/isolated/__tests__/output-lane-policy.test.ts
@@ -1,7 +1,11 @@
 import { afterEach, describe, expect, it } from "vite-plus/test";
 import type { JupyterOutput } from "@/components/cell/jupyter-output";
 import { BOKEHJS_EXEC_MIME_TYPE, BOKEHJS_LOAD_MIME_TYPE } from "@/components/outputs/bokeh-mime";
-import { PANEL_EXEC_MIME_TYPE, PANEL_LOAD_MIME_TYPE } from "@/components/outputs/panel-mime";
+import {
+  NTERACT_PANEL_RUNTIME_MIME_TYPE,
+  PANEL_EXEC_MIME_TYPE,
+  PANEL_LOAD_MIME_TYPE,
+} from "@/components/outputs/panel-mime";
 import {
   MARKDOWN_PROJECTION_MIME_TYPE,
   setMarkdownProjectionProjector,
@@ -296,6 +300,22 @@ describe("output lane policy", () => {
       "panel-root-html",
       "panel-exec-html",
     ]);
+  });
+
+  it("treats nteract Panel runtime outputs as Panel, not widget state", () => {
+    const output = displayOutput("panel-runtime", {
+      [NTERACT_PANEL_RUNTIME_MIME_TYPE]: { version: 1, channel_id: "panel-1" },
+      [PANEL_EXEC_MIME_TYPE]: "",
+      "text/html": '<div id="panel-root"></div>',
+      "application/javascript": 'document.getElementById("panel-root").textContent = "widget";',
+    });
+
+    expect(selectedOutputMimeType(output)).toBe(NTERACT_PANEL_RUNTIME_MIME_TYPE);
+    expect(outputUsesPanel(output)).toBe(true);
+    expect(hasWidgetOutputs([output])).toBe(false);
+    expect(outputUsesWheelOwningFrame(output)).toBe(true);
+    expect(outputAllowsScrollPassthrough(output)).toBe(true);
+    expect(outputSegmentLane(output)).toBe("static-frame");
   });
 
   it("keeps pan/zoom charts standalone instead of coalescing with sibling document outputs", () => {

--- a/src/components/isolated/__tests__/output-payloads.test.ts
+++ b/src/components/isolated/__tests__/output-payloads.test.ts
@@ -2,7 +2,10 @@ import { describe, expect, it } from "vite-plus/test";
 import type { IdentifiedJupyterOutput } from "../output-payloads";
 import { jupyterOutputToRenderPayload } from "../output-payloads";
 import { BOKEHJS_EXEC_MIME_TYPE, BOKEHJS_LOAD_MIME_TYPE } from "@/components/outputs/bokeh-mime";
-import { PANEL_EXEC_MIME_TYPE } from "@/components/outputs/panel-mime";
+import {
+  NTERACT_PANEL_RUNTIME_MIME_TYPE,
+  PANEL_EXEC_MIME_TYPE,
+} from "@/components/outputs/panel-mime";
 
 describe("isolated output payload conversion", () => {
   it("remaps Bokeh load bundles to the Bokeh MIME while preserving sibling JavaScript", () => {
@@ -82,6 +85,37 @@ describe("isolated output payload conversion", () => {
         metadata: { id: "p1011" },
         mimeType: PANEL_EXEC_MIME_TYPE,
         outputId: "panel-exec",
+        outputIndex: 1,
+      }),
+    );
+  });
+
+  it("remaps nteract Panel runtime bundles while preserving sibling HTML and JavaScript", () => {
+    const output: IdentifiedJupyterOutput = {
+      output_id: "panel-runtime",
+      output_type: "display_data",
+      data: {
+        "text/html": '<div id="panel-root"></div><script>window.__panelHtmlRan = true;</script>',
+        "application/javascript": "window.__panelRuntimeRan = true;",
+        [NTERACT_PANEL_RUNTIME_MIME_TYPE]: { version: 1, channel_id: "panel-1" },
+        [PANEL_EXEC_MIME_TYPE]: "",
+      },
+      metadata: {
+        [NTERACT_PANEL_RUNTIME_MIME_TYPE]: { id: "doc-1" },
+        [PANEL_EXEC_MIME_TYPE]: { id: "legacy-doc" },
+      },
+    };
+
+    expect(jupyterOutputToRenderPayload(output, 1)).toEqual(
+      expect.objectContaining({
+        data: {
+          "application/javascript": "window.__panelRuntimeRan = true;",
+          "text/html": '<div id="panel-root"></div><script>window.__panelHtmlRan = true;</script>',
+          [NTERACT_PANEL_RUNTIME_MIME_TYPE]: { version: 1, channel_id: "panel-1" },
+        },
+        metadata: { id: "doc-1" },
+        mimeType: NTERACT_PANEL_RUNTIME_MIME_TYPE,
+        outputId: "panel-runtime",
         outputIndex: 1,
       }),
     );

--- a/src/components/isolated/__tests__/renderer-plugin-info.test.ts
+++ b/src/components/isolated/__tests__/renderer-plugin-info.test.ts
@@ -5,7 +5,11 @@ import {
   rendererPluginNameForMime,
 } from "../renderer-plugin-info";
 import { BOKEHJS_EXEC_MIME_TYPE, BOKEHJS_LOAD_MIME_TYPE } from "@/components/outputs/bokeh-mime";
-import { PANEL_EXEC_MIME_TYPE, PANEL_LOAD_MIME_TYPE } from "@/components/outputs/panel-mime";
+import {
+  NTERACT_PANEL_RUNTIME_MIME_TYPE,
+  PANEL_EXEC_MIME_TYPE,
+  PANEL_LOAD_MIME_TYPE,
+} from "@/components/outputs/panel-mime";
 
 describe("renderer plugin metadata", () => {
   it("maps exact MIME types to the shared renderer plugin names", () => {
@@ -30,6 +34,10 @@ describe("renderer plugin metadata", () => {
       hasCss: false,
     });
     expect(rendererPluginInfoForMime(PANEL_EXEC_MIME_TYPE)).toEqual({
+      name: "panel",
+      hasCss: false,
+    });
+    expect(rendererPluginInfoForMime(NTERACT_PANEL_RUNTIME_MIME_TYPE)).toEqual({
       name: "panel",
       hasCss: false,
     });

--- a/src/components/isolated/__tests__/rpc-methods.test.ts
+++ b/src/components/isolated/__tests__/rpc-methods.test.ts
@@ -27,6 +27,12 @@ import {
   NTERACT_MEASURE_ELEMENT,
   NTERACT_MOUSE_DOWN,
   NTERACT_MOUSE_UP,
+  NTERACT_PANEL_ACK,
+  NTERACT_PANEL_CHANNEL_CLOSE,
+  NTERACT_PANEL_CHANNEL_OPEN,
+  NTERACT_PANEL_CLIENT_PATCH,
+  NTERACT_PANEL_DISCONNECTED,
+  NTERACT_PANEL_SERVER_PATCH,
   NTERACT_PING,
   NTERACT_PONG,
   NTERACT_READY,
@@ -76,6 +82,12 @@ describe("nteract JSON-RPC method constants", () => {
     NTERACT_WIDGET_COMM_MSG,
     NTERACT_WIDGET_COMM_CLOSE,
     NTERACT_WIDGET_UPDATE,
+    NTERACT_PANEL_SERVER_PATCH,
+    NTERACT_PANEL_ACK,
+    NTERACT_PANEL_DISCONNECTED,
+    NTERACT_PANEL_CHANNEL_OPEN,
+    NTERACT_PANEL_CLIENT_PATCH,
+    NTERACT_PANEL_CHANNEL_CLOSE,
     NTERACT_EVAL_RESULT,
     NTERACT_PONG,
     NTERACT_SEARCH_RESULTS,
@@ -133,5 +145,11 @@ describe("nteract JSON-RPC method constants", () => {
     expect(NTERACT_WIDGET_UPDATE).toBe("nteract/widgetUpdate");
     expect(NTERACT_WIDGET_STATE).toBe("nteract/widgetState");
     expect(NTERACT_SEARCH_NAVIGATE).toBe("nteract/searchNavigate");
+    expect(NTERACT_PANEL_SERVER_PATCH).toBe("nteract/panelServerPatch");
+    expect(NTERACT_PANEL_ACK).toBe("nteract/panelAck");
+    expect(NTERACT_PANEL_DISCONNECTED).toBe("nteract/panelDisconnected");
+    expect(NTERACT_PANEL_CHANNEL_OPEN).toBe("nteract/panelChannelOpen");
+    expect(NTERACT_PANEL_CLIENT_PATCH).toBe("nteract/panelClientPatch");
+    expect(NTERACT_PANEL_CHANNEL_CLOSE).toBe("nteract/panelChannelClose");
   });
 });

--- a/src/components/isolated/__tests__/type-to-method.test.ts
+++ b/src/components/isolated/__tests__/type-to-method.test.ts
@@ -28,6 +28,9 @@ describe("TYPE_TO_METHOD mapping", () => {
       "widget_snapshot",
       "bridge_ready",
       "widget_state",
+      "panel_server_patch",
+      "panel_ack",
+      "panel_disconnected",
     ];
 
     for (const type of requiredTypes) {
@@ -56,6 +59,9 @@ describe("TYPE_TO_METHOD mapping", () => {
     expect(TYPE_TO_METHOD.widget_snapshot).toBe("nteract/widgetSnapshot");
     expect(TYPE_TO_METHOD.bridge_ready).toBe("nteract/bridgeReady");
     expect(TYPE_TO_METHOD.widget_state).toBe("nteract/widgetState");
+    expect(TYPE_TO_METHOD.panel_server_patch).toBe("nteract/panelServerPatch");
+    expect(TYPE_TO_METHOD.panel_ack).toBe("nteract/panelAck");
+    expect(TYPE_TO_METHOD.panel_disconnected).toBe("nteract/panelDisconnected");
   });
 
   it("has no duplicate method values", () => {

--- a/src/components/isolated/frame-bridge.ts
+++ b/src/components/isolated/frame-bridge.ts
@@ -1,5 +1,11 @@
 import type { NteractEmbedHostContextPatch } from "./host-context";
 import type { WidgetViewStateHint } from "@/components/widgets/widget-state";
+import type {
+  PanelRuntimeAckPayload,
+  PanelRuntimeChannelPayload,
+  PanelRuntimeDisconnectedPayload,
+  PanelRuntimePatchPayload,
+} from "runtimed";
 
 export interface EvalMessage {
   type: "eval";
@@ -218,36 +224,17 @@ export interface BridgeReadyMessage {
 
 export interface PanelServerPatchMessage {
   type: "panel_server_patch";
-  payload: {
-    plotId?: string | null;
-    commId: string;
-    data?: unknown;
-    metadata?: Record<string, unknown>;
-    buffers?: ArrayBuffer[];
-  };
+  payload: PanelRuntimePatchPayload;
 }
 
 export interface PanelAckMessage {
   type: "panel_ack";
-  payload: {
-    plotId?: string | null;
-    commId: string;
-    metadata: {
-      msg_type: "Ready" | "Error";
-      content?: string;
-      traceback?: string;
-      comm_id?: string;
-    };
-  };
+  payload: PanelRuntimeAckPayload;
 }
 
 export interface PanelDisconnectedMessage {
   type: "panel_disconnected";
-  payload: {
-    plotId?: string | null;
-    commId?: string | null;
-    reason?: string;
-  };
+  payload: PanelRuntimeDisconnectedPayload;
 }
 
 // --- Global Find: Parent → Iframe ---
@@ -495,29 +482,17 @@ export interface WidgetCommCloseMessage {
 
 export interface PanelChannelOpenMessage {
   type: "panel_channel_open";
-  payload: {
-    plotId?: string | null;
-    commId: string;
-  };
+  payload: PanelRuntimeChannelPayload;
 }
 
 export interface PanelClientPatchMessage {
   type: "panel_client_patch";
-  payload: {
-    plotId?: string | null;
-    commId: string;
-    data?: unknown;
-    metadata?: Record<string, unknown>;
-    buffers?: ArrayBuffer[];
-  };
+  payload: PanelRuntimePatchPayload;
 }
 
 export interface PanelChannelCloseMessage {
   type: "panel_channel_close";
-  payload: {
-    plotId?: string | null;
-    commId: string;
-  };
+  payload: PanelRuntimeChannelPayload;
 }
 
 // --- Global Find: Iframe → Parent ---

--- a/src/components/isolated/frame-bridge.ts
+++ b/src/components/isolated/frame-bridge.ts
@@ -216,6 +216,40 @@ export interface BridgeReadyMessage {
   type: "bridge_ready";
 }
 
+export interface PanelServerPatchMessage {
+  type: "panel_server_patch";
+  payload: {
+    plotId?: string | null;
+    commId: string;
+    data?: unknown;
+    metadata?: Record<string, unknown>;
+    buffers?: ArrayBuffer[];
+  };
+}
+
+export interface PanelAckMessage {
+  type: "panel_ack";
+  payload: {
+    plotId?: string | null;
+    commId: string;
+    metadata: {
+      msg_type: "Ready" | "Error";
+      content?: string;
+      traceback?: string;
+      comm_id?: string;
+    };
+  };
+}
+
+export interface PanelDisconnectedMessage {
+  type: "panel_disconnected";
+  payload: {
+    plotId?: string | null;
+    commId?: string | null;
+    reason?: string;
+  };
+}
+
 // --- Global Find: Parent → Iframe ---
 
 /**
@@ -283,6 +317,9 @@ export type ParentToIframeMessage =
   | CommCloseMessage
   | WidgetSnapshotMessage
   | BridgeReadyMessage
+  | PanelServerPatchMessage
+  | PanelAckMessage
+  | PanelDisconnectedMessage
   | SearchMessage
   | SearchNavigateMessage
   | InteractionStateMessage
@@ -456,6 +493,33 @@ export interface WidgetCommCloseMessage {
   };
 }
 
+export interface PanelChannelOpenMessage {
+  type: "panel_channel_open";
+  payload: {
+    plotId?: string | null;
+    commId: string;
+  };
+}
+
+export interface PanelClientPatchMessage {
+  type: "panel_client_patch";
+  payload: {
+    plotId?: string | null;
+    commId: string;
+    data?: unknown;
+    metadata?: Record<string, unknown>;
+    buffers?: ArrayBuffer[];
+  };
+}
+
+export interface PanelChannelCloseMessage {
+  type: "panel_channel_close";
+  payload: {
+    plotId?: string | null;
+    commId: string;
+  };
+}
+
 // --- Global Find: Iframe → Parent ---
 
 /**
@@ -488,6 +552,9 @@ export type IframeToParentMessage =
   | WidgetReadyMessage
   | WidgetCommMsgMessage
   | WidgetCommCloseMessage
+  | PanelChannelOpenMessage
+  | PanelClientPatchMessage
+  | PanelChannelCloseMessage
   | SearchResultsMessage;
 
 // --- Utility Types ---
@@ -525,6 +592,9 @@ export function isIframeMessage(data: unknown): data is IframeToParentMessage {
       "widget_ready",
       "widget_comm_msg",
       "widget_comm_close",
+      "panel_channel_open",
+      "panel_client_patch",
+      "panel_channel_close",
       "search_results",
     ].includes(msg.type)
   );

--- a/src/components/isolated/isolated-frame-runtime.ts
+++ b/src/components/isolated/isolated-frame-runtime.ts
@@ -23,6 +23,12 @@ import {
   NTERACT_MEASURE_ELEMENT,
   NTERACT_MOUSE_DOWN,
   NTERACT_MOUSE_UP,
+  NTERACT_PANEL_ACK,
+  NTERACT_PANEL_CHANNEL_CLOSE,
+  NTERACT_PANEL_CHANNEL_OPEN,
+  NTERACT_PANEL_CLIENT_PATCH,
+  NTERACT_PANEL_DISCONNECTED,
+  NTERACT_PANEL_SERVER_PATCH,
   NTERACT_PING,
   NTERACT_RENDER_BATCH,
   NTERACT_RENDER_COMPLETE,
@@ -59,6 +65,9 @@ export const TYPE_TO_METHOD: Record<string, string> = {
   widget_snapshot: NTERACT_WIDGET_SNAPSHOT,
   bridge_ready: NTERACT_BRIDGE_READY,
   widget_state: NTERACT_WIDGET_STATE,
+  panel_server_patch: NTERACT_PANEL_SERVER_PATCH,
+  panel_ack: NTERACT_PANEL_ACK,
+  panel_disconnected: NTERACT_PANEL_DISCONNECTED,
 };
 
 export type IsolatedFrameRuntimeDiagnosticLevel = "debug" | "info" | "warn" | "error";
@@ -660,6 +669,24 @@ export class IsolatedFrameRuntime {
     transport.onNotification(NTERACT_WIDGET_COMM_CLOSE, (params) => {
       this.callbacks.onMessage({
         type: "widget_comm_close",
+        payload: params,
+      } as IframeToParentMessage);
+    });
+    transport.onNotification(NTERACT_PANEL_CHANNEL_OPEN, (params) => {
+      this.callbacks.onMessage({
+        type: "panel_channel_open",
+        payload: params,
+      } as IframeToParentMessage);
+    });
+    transport.onNotification(NTERACT_PANEL_CLIENT_PATCH, (params) => {
+      this.callbacks.onMessage({
+        type: "panel_client_patch",
+        payload: params,
+      } as IframeToParentMessage);
+    });
+    transport.onNotification(NTERACT_PANEL_CHANNEL_CLOSE, (params) => {
+      this.callbacks.onMessage({
+        type: "panel_channel_close",
         payload: params,
       } as IframeToParentMessage);
     });

--- a/src/components/isolated/output-lane-policy.ts
+++ b/src/components/isolated/output-lane-policy.ts
@@ -5,6 +5,7 @@ import {
   isBokehMimeType,
 } from "@/components/outputs/bokeh-mime";
 import {
+  NTERACT_PANEL_RUNTIME_MIME_TYPE,
   PANEL_EXEC_MIME_TYPE,
   PANEL_LOAD_MIME_TYPE,
   isPanelMimeType,
@@ -50,6 +51,7 @@ const SCROLL_PASSTHROUGH_MIME_TYPES = new Set([
   "application/javascript",
   BOKEHJS_LOAD_MIME_TYPE,
   BOKEHJS_EXEC_MIME_TYPE,
+  NTERACT_PANEL_RUNTIME_MIME_TYPE,
   PANEL_LOAD_MIME_TYPE,
   PANEL_EXEC_MIME_TYPE,
   // Sift's interactive tables are also click-to-engage (see SIFT_MIME_TYPES).

--- a/src/components/isolated/renderer-plugin-info.ts
+++ b/src/components/isolated/renderer-plugin-info.ts
@@ -1,6 +1,10 @@
 import { isVegaMimeType } from "@/components/outputs/vega-mime";
 import { BOKEHJS_EXEC_MIME_TYPE, BOKEHJS_LOAD_MIME_TYPE } from "@/components/outputs/bokeh-mime";
-import { PANEL_EXEC_MIME_TYPE, PANEL_LOAD_MIME_TYPE } from "@/components/outputs/panel-mime";
+import {
+  NTERACT_PANEL_RUNTIME_MIME_TYPE,
+  PANEL_EXEC_MIME_TYPE,
+  PANEL_LOAD_MIME_TYPE,
+} from "@/components/outputs/panel-mime";
 
 export type RendererPluginName =
   | "markdown"
@@ -22,6 +26,7 @@ const MIME_TO_PLUGIN: Record<string, RendererPluginInfo> = {
   "application/vnd.plotly.v1+json": { name: "plotly", hasCss: false },
   [BOKEHJS_LOAD_MIME_TYPE]: { name: "bokeh", hasCss: false },
   [BOKEHJS_EXEC_MIME_TYPE]: { name: "bokeh", hasCss: false },
+  [NTERACT_PANEL_RUNTIME_MIME_TYPE]: { name: "panel", hasCss: false },
   [PANEL_LOAD_MIME_TYPE]: { name: "panel", hasCss: false },
   [PANEL_EXEC_MIME_TYPE]: { name: "panel", hasCss: false },
   "application/geo+json": { name: "leaflet", hasCss: true },

--- a/src/components/isolated/rpc-methods.ts
+++ b/src/components/isolated/rpc-methods.ts
@@ -34,6 +34,9 @@ export const NTERACT_COMM_CLOSE = "nteract/commClose" as const;
 export const NTERACT_WIDGET_SNAPSHOT = "nteract/widgetSnapshot" as const;
 export const NTERACT_BRIDGE_READY = "nteract/bridgeReady" as const;
 export const NTERACT_WIDGET_STATE = "nteract/widgetState" as const;
+export const NTERACT_PANEL_SERVER_PATCH = "nteract/panelServerPatch" as const;
+export const NTERACT_PANEL_ACK = "nteract/panelAck" as const;
+export const NTERACT_PANEL_DISCONNECTED = "nteract/panelDisconnected" as const;
 
 // Host → Iframe (Notifications) — additional
 export const NTERACT_THEME = "nteract/theme" as const;
@@ -58,6 +61,9 @@ export const NTERACT_SEARCH_RESULTS = "nteract/searchResults" as const;
 export const NTERACT_MOUSE_DOWN = "nteract/mouseDown" as const;
 export const NTERACT_MOUSE_UP = "nteract/mouseUp" as const;
 export const NTERACT_WHEEL_BOUNDARY = "nteract/wheelBoundary" as const;
+export const NTERACT_PANEL_CHANNEL_OPEN = "nteract/panelChannelOpen" as const;
+export const NTERACT_PANEL_CLIENT_PATCH = "nteract/panelClientPatch" as const;
+export const NTERACT_PANEL_CHANNEL_CLOSE = "nteract/panelChannelClose" as const;
 
 // MCP Apps-compatible methods used by embedders. Notebook rendering commands
 // remain in the nteract/* namespace.
@@ -159,6 +165,31 @@ export interface NteractWidgetStateParams {
   buffers?: string[];
 }
 
+export interface NteractPanelServerPatchParams {
+  plotId?: string | null;
+  commId: string;
+  data?: unknown;
+  metadata?: Record<string, unknown>;
+  buffers?: ArrayBuffer[];
+}
+
+export interface NteractPanelAckParams {
+  plotId?: string | null;
+  commId: string;
+  metadata: {
+    msg_type: "Ready" | "Error";
+    content?: string;
+    traceback?: string;
+    comm_id?: string;
+  };
+}
+
+export interface NteractPanelDisconnectedParams {
+  plotId?: string | null;
+  commId?: string | null;
+  reason?: string;
+}
+
 // ── Iframe → Host: Notification Params ──────────────────────────────
 
 export interface NteractRenderCompleteParams {
@@ -181,6 +212,24 @@ export interface NteractWidgetUpdateParams {
   commId: string;
   state: Record<string, unknown>;
   buffers?: string[];
+}
+
+export interface NteractPanelChannelOpenParams {
+  plotId?: string | null;
+  commId: string;
+}
+
+export interface NteractPanelClientPatchParams {
+  plotId?: string | null;
+  commId: string;
+  data?: unknown;
+  metadata?: Record<string, unknown>;
+  buffers?: ArrayBuffer[];
+}
+
+export interface NteractPanelChannelCloseParams {
+  plotId?: string | null;
+  commId: string;
 }
 
 export interface NteractWheelBoundaryParams {

--- a/src/components/isolated/rpc-methods.ts
+++ b/src/components/isolated/rpc-methods.ts
@@ -15,6 +15,13 @@
  * Nteract extension methods use the "nteract/" namespace.
  */
 
+import type {
+  PanelRuntimeAckPayload,
+  PanelRuntimeChannelPayload,
+  PanelRuntimeDisconnectedPayload,
+  PanelRuntimePatchPayload,
+} from "runtimed";
+
 // ── Method Constants ────────────────────────────────────────────────
 
 // Host → Iframe (Requests — expect a response)
@@ -165,30 +172,11 @@ export interface NteractWidgetStateParams {
   buffers?: string[];
 }
 
-export interface NteractPanelServerPatchParams {
-  plotId?: string | null;
-  commId: string;
-  data?: unknown;
-  metadata?: Record<string, unknown>;
-  buffers?: ArrayBuffer[];
-}
+export interface NteractPanelServerPatchParams extends PanelRuntimePatchPayload {}
 
-export interface NteractPanelAckParams {
-  plotId?: string | null;
-  commId: string;
-  metadata: {
-    msg_type: "Ready" | "Error";
-    content?: string;
-    traceback?: string;
-    comm_id?: string;
-  };
-}
+export interface NteractPanelAckParams extends PanelRuntimeAckPayload {}
 
-export interface NteractPanelDisconnectedParams {
-  plotId?: string | null;
-  commId?: string | null;
-  reason?: string;
-}
+export interface NteractPanelDisconnectedParams extends PanelRuntimeDisconnectedPayload {}
 
 // ── Iframe → Host: Notification Params ──────────────────────────────
 
@@ -214,23 +202,11 @@ export interface NteractWidgetUpdateParams {
   buffers?: string[];
 }
 
-export interface NteractPanelChannelOpenParams {
-  plotId?: string | null;
-  commId: string;
-}
+export interface NteractPanelChannelOpenParams extends PanelRuntimeChannelPayload {}
 
-export interface NteractPanelClientPatchParams {
-  plotId?: string | null;
-  commId: string;
-  data?: unknown;
-  metadata?: Record<string, unknown>;
-  buffers?: ArrayBuffer[];
-}
+export interface NteractPanelClientPatchParams extends PanelRuntimePatchPayload {}
 
-export interface NteractPanelChannelCloseParams {
-  plotId?: string | null;
-  commId: string;
-}
+export interface NteractPanelChannelCloseParams extends PanelRuntimeChannelPayload {}
 
 export interface NteractWheelBoundaryParams {
   deltaY?: number;

--- a/src/components/isolated/rpc-methods.ts
+++ b/src/components/isolated/rpc-methods.ts
@@ -172,11 +172,11 @@ export interface NteractWidgetStateParams {
   buffers?: string[];
 }
 
-export interface NteractPanelServerPatchParams extends PanelRuntimePatchPayload {}
+export type NteractPanelServerPatchParams = PanelRuntimePatchPayload;
 
-export interface NteractPanelAckParams extends PanelRuntimeAckPayload {}
+export type NteractPanelAckParams = PanelRuntimeAckPayload;
 
-export interface NteractPanelDisconnectedParams extends PanelRuntimeDisconnectedPayload {}
+export type NteractPanelDisconnectedParams = PanelRuntimeDisconnectedPayload;
 
 // ── Iframe → Host: Notification Params ──────────────────────────────
 
@@ -202,11 +202,11 @@ export interface NteractWidgetUpdateParams {
   buffers?: string[];
 }
 
-export interface NteractPanelChannelOpenParams extends PanelRuntimeChannelPayload {}
+export type NteractPanelChannelOpenParams = PanelRuntimeChannelPayload;
 
-export interface NteractPanelClientPatchParams extends PanelRuntimePatchPayload {}
+export type NteractPanelClientPatchParams = PanelRuntimePatchPayload;
 
-export interface NteractPanelChannelCloseParams extends PanelRuntimeChannelPayload {}
+export type NteractPanelChannelCloseParams = PanelRuntimeChannelPayload;
 
 export interface NteractWheelBoundaryParams {
   deltaY?: number;

--- a/src/components/outputs/mime-priority.ts
+++ b/src/components/outputs/mime-priority.ts
@@ -1,5 +1,9 @@
 import { BOKEHJS_EXEC_MIME_TYPE, BOKEHJS_LOAD_MIME_TYPE } from "./bokeh-mime";
-import { PANEL_EXEC_MIME_TYPE, PANEL_LOAD_MIME_TYPE } from "./panel-mime";
+import {
+  NTERACT_PANEL_RUNTIME_MIME_TYPE,
+  PANEL_EXEC_MIME_TYPE,
+  PANEL_LOAD_MIME_TYPE,
+} from "./panel-mime";
 
 /**
  * Default MIME type priority order for rendering.
@@ -18,9 +22,11 @@ export const DEFAULT_PRIORITY = [
   "application/vnd.plotly.v1+json",
   // Bokeh and Panel emit marker MIMEs alongside text/html and
   // application/javascript. They must win so renderer plugins can coordinate
-  // the sibling payloads.
+  // the sibling payloads. The nteract Panel marker outranks the legacy
+  // HoloViews marker because it carries runtime channel identity.
   BOKEHJS_EXEC_MIME_TYPE,
   BOKEHJS_LOAD_MIME_TYPE,
+  NTERACT_PANEL_RUNTIME_MIME_TYPE,
   PANEL_EXEC_MIME_TYPE,
   PANEL_LOAD_MIME_TYPE,
   "application/vnd.vegalite.v6+json",

--- a/src/components/outputs/panel-mime.ts
+++ b/src/components/outputs/panel-mime.ts
@@ -1,7 +1,12 @@
+export const NTERACT_PANEL_RUNTIME_MIME_TYPE = "application/vnd.nteract.panel-runtime.v1+json";
 export const PANEL_LOAD_MIME_TYPE = "application/vnd.holoviews_load.v0+json";
 export const PANEL_EXEC_MIME_TYPE = "application/vnd.holoviews_exec.v0+json";
 
-const PANEL_MIME_TYPES = new Set([PANEL_LOAD_MIME_TYPE, PANEL_EXEC_MIME_TYPE]);
+const PANEL_MIME_TYPES = new Set([
+  NTERACT_PANEL_RUNTIME_MIME_TYPE,
+  PANEL_LOAD_MIME_TYPE,
+  PANEL_EXEC_MIME_TYPE,
+]);
 
 export function isPanelMimeType(mimeType: string): boolean {
   return PANEL_MIME_TYPES.has(mimeType);

--- a/src/components/outputs/panel-mime.ts
+++ b/src/components/outputs/panel-mime.ts
@@ -1,4 +1,6 @@
-export const NTERACT_PANEL_RUNTIME_MIME_TYPE = "application/vnd.nteract.panel-runtime.v1+json";
+import { NTERACT_PANEL_RUNTIME_MIME_TYPE } from "runtimed";
+
+export { NTERACT_PANEL_RUNTIME_MIME_TYPE };
 export const PANEL_LOAD_MIME_TYPE = "application/vnd.holoviews_load.v0+json";
 export const PANEL_EXEC_MIME_TYPE = "application/vnd.holoviews_exec.v0+json";
 

--- a/src/isolated-renderer/__tests__/panel-renderer.test.tsx
+++ b/src/isolated-renderer/__tests__/panel-renderer.test.tsx
@@ -190,6 +190,10 @@ describe("Panel renderer plugin", () => {
         "window.__panelRuntimeRan = true;",
       );
     });
+    expect(
+      (window.PyViz as { comm_manager?: { __nteractPanelCommManager?: true } } | undefined)
+        ?.comm_manager?.__nteractPanelCommManager,
+    ).toBe(true);
   });
 
   it("executes id-less Panel exec bundles as auxiliary notebook setup", async () => {

--- a/src/isolated-renderer/__tests__/panel-renderer.test.tsx
+++ b/src/isolated-renderer/__tests__/panel-renderer.test.tsx
@@ -1,7 +1,11 @@
 import { cleanup, render, waitFor } from "@testing-library/react";
 import type { ComponentType } from "react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vite-plus/test";
-import { PANEL_EXEC_MIME_TYPE, PANEL_LOAD_MIME_TYPE } from "@/components/outputs/panel-mime";
+import {
+  NTERACT_PANEL_RUNTIME_MIME_TYPE,
+  PANEL_EXEC_MIME_TYPE,
+  PANEL_LOAD_MIME_TYPE,
+} from "@/components/outputs/panel-mime";
 import type { RendererProps } from "@/lib/renderer-registry";
 import { install } from "../panel-renderer";
 
@@ -100,7 +104,11 @@ describe("Panel renderer plugin", () => {
   it("registers Panel load and exec MIME types", () => {
     const { registeredMimeTypes } = installPanelRenderer();
 
-    expect(registeredMimeTypes).toEqual([PANEL_LOAD_MIME_TYPE, PANEL_EXEC_MIME_TYPE]);
+    expect(registeredMimeTypes).toEqual([
+      PANEL_LOAD_MIME_TYPE,
+      PANEL_EXEC_MIME_TYPE,
+      NTERACT_PANEL_RUNTIME_MIME_TYPE,
+    ]);
   });
 
   it("appends Panel load MIME JavaScript directly", async () => {
@@ -158,6 +166,29 @@ describe("Panel renderer plugin", () => {
 
     await waitFor(() => {
       expect(renderedScripts(container).at(-1)?.textContent).toBe("window.__panelExecRan = true;");
+    });
+  });
+
+  it("renders nteract Panel runtime bundles with sibling HTML and JavaScript", async () => {
+    stubPanelRuntime();
+    const { Renderer } = installPanelRenderer();
+    const { container } = render(
+      <Renderer
+        data={{
+          "text/html": '<div id="panel-root"></div>',
+          "application/javascript": "window.__panelRuntimeRan = true;",
+          [NTERACT_PANEL_RUNTIME_MIME_TYPE]: { version: 1, channel_id: "panel-1" },
+        }}
+        metadata={{ id: "doc-1" }}
+        mimeType={NTERACT_PANEL_RUNTIME_MIME_TYPE}
+      />,
+    );
+
+    await waitFor(() => {
+      expect(container.querySelector("#panel-root")).not.toBeNull();
+      expect(renderedScripts(container).at(-1)?.textContent).toBe(
+        "window.__panelRuntimeRan = true;",
+      );
     });
   });
 

--- a/src/isolated-renderer/__tests__/panel-runtime-transport.test.ts
+++ b/src/isolated-renderer/__tests__/panel-runtime-transport.test.ts
@@ -8,6 +8,7 @@ import {
   NTERACT_PANEL_SERVER_PATCH,
 } from "@/components/isolated/rpc-methods";
 import {
+  ensureNteractPanelCommManager,
   installPanelRuntimeTransport,
   registerPanelRuntimeTransportHandlers,
 } from "../panel-runtime-transport";
@@ -28,6 +29,7 @@ function createTransport() {
 describe("Panel runtime transport", () => {
   afterEach(() => {
     delete window.__nteractPanelRuntime;
+    delete window.PyViz;
     vi.restoreAllMocks();
   });
 
@@ -58,6 +60,83 @@ describe("Panel runtime transport", () => {
       plotId: "plot-1",
       commId: "comm-1",
     });
+  });
+
+  it("installs the PyViz comm manager from TypeScript", () => {
+    const transport = createTransport();
+    installPanelRuntimeTransport(() => transport);
+
+    const manager = ensureNteractPanelCommManager() as {
+      __nteractPanelCommManager: true;
+      register_target: (plotId: string, commId: string, handler: NotificationHandler) => void;
+      get_client_comm: (
+        plotId: string,
+        commId: string,
+        handler?: NotificationHandler,
+      ) => {
+        active: boolean;
+        connected: boolean;
+        send: (data?: unknown, metadata?: Record<string, unknown>, buffers?: unknown[]) => void;
+        close: () => void;
+      };
+      receiveServerPatch: (payload: unknown) => void;
+      receiveAck: (payload: unknown) => void;
+      setDisconnected: (payload: { commId: string }) => void;
+    };
+    const serverHandler = vi.fn();
+    const ackHandler = vi.fn();
+
+    expect(window.PyViz?.comm_manager).toBe(manager);
+    expect(manager.__nteractPanelCommManager).toBe(true);
+
+    manager.register_target("plot-1", "server-comm", serverHandler);
+    const comm = manager.get_client_comm("plot-1", "client-comm", ackHandler);
+    comm.send({ events: [] }, { kind: "patch" }, ["buffer"]);
+    comm.close();
+
+    expect(transport.notify).toHaveBeenNthCalledWith(1, NTERACT_PANEL_CHANNEL_OPEN, {
+      plotId: "plot-1",
+      commId: "server-comm",
+    });
+    expect(transport.notify).toHaveBeenNthCalledWith(2, NTERACT_PANEL_CLIENT_PATCH, {
+      plotId: "plot-1",
+      commId: "client-comm",
+      data: { events: [] },
+      metadata: { kind: "patch" },
+      buffers: ["buffer"],
+    });
+    expect(transport.notify).toHaveBeenNthCalledWith(3, NTERACT_PANEL_CHANNEL_CLOSE, {
+      plotId: "plot-1",
+      commId: "client-comm",
+    });
+
+    manager.receiveServerPatch({
+      commId: "server-comm",
+      data: { events: [{ kind: "ModelChanged" }] },
+      metadata: { msgid: "server-patch" },
+      buffers: [],
+    });
+    expect(serverHandler).toHaveBeenCalledWith({
+      metadata: { msgid: "server-patch" },
+      content: { data: { events: [{ kind: "ModelChanged" }] } },
+      buffers: [],
+    });
+
+    manager.receiveAck({
+      commId: "client-comm",
+      metadata: { msg_type: "Ready" },
+    });
+    expect(ackHandler).toHaveBeenCalledWith({
+      metadata: { msg_type: "Ready" },
+      content: { data: undefined },
+      buffers: [],
+    });
+
+    expect(comm.active).toBe(false);
+    expect(comm.connected).toBe(false);
+    manager.setDisconnected({ commId: "client-comm" });
+    expect(comm.active).toBe(false);
+    expect(comm.connected).toBe(false);
   });
 
   it("routes host Panel notifications to the attached manager", () => {

--- a/src/isolated-renderer/__tests__/panel-runtime-transport.test.ts
+++ b/src/isolated-renderer/__tests__/panel-runtime-transport.test.ts
@@ -176,6 +176,16 @@ describe("Panel runtime transport", () => {
     expect(manager.setDisconnected).toHaveBeenCalledWith(disconnected);
   });
 
+  it("registers host Panel notification handlers once per transport", () => {
+    const transport = createTransport();
+    installPanelRuntimeTransport(() => transport);
+
+    registerPanelRuntimeTransportHandlers(transport);
+    registerPanelRuntimeTransportHandlers(transport);
+
+    expect(transport.onNotification).toHaveBeenCalledTimes(3);
+  });
+
   it("reuses the installed runtime while rebinding outbound transport and handlers", () => {
     const firstTransport = createTransport();
     const secondTransport = createTransport();

--- a/src/isolated-renderer/__tests__/panel-runtime-transport.test.ts
+++ b/src/isolated-renderer/__tests__/panel-runtime-transport.test.ts
@@ -97,11 +97,12 @@ describe("Panel runtime transport", () => {
     expect(manager.setDisconnected).toHaveBeenCalledWith(disconnected);
   });
 
-  it("reuses the installed runtime while rebinding host notification handlers", () => {
+  it("reuses the installed runtime while rebinding outbound transport and handlers", () => {
     const firstTransport = createTransport();
     const secondTransport = createTransport();
     const runtime = installPanelRuntimeTransport(() => firstTransport);
 
+    installPanelRuntimeTransport(() => secondTransport);
     registerPanelRuntimeTransportHandlers(secondTransport);
 
     expect(window.__nteractPanelRuntime).toBe(runtime);
@@ -114,5 +115,23 @@ describe("Panel runtime transport", () => {
     expect(secondTransport.notify).toHaveBeenCalledWith(NTERACT_PANEL_CHANNEL_OPEN, {
       commId: "comm-1",
     });
+  });
+
+  it("does not replace outbound transport while registering notification handlers", () => {
+    const firstTransport = createTransport();
+    const secondTransport = createTransport();
+    const runtime = installPanelRuntimeTransport(() => firstTransport);
+
+    registerPanelRuntimeTransportHandlers(secondTransport);
+
+    runtime.registerTarget({ commId: "comm-1" });
+    expect(firstTransport.notify).toHaveBeenCalledWith(NTERACT_PANEL_CHANNEL_OPEN, {
+      commId: "comm-1",
+    });
+    expect(secondTransport.notify).not.toHaveBeenCalled();
+    expect(secondTransport.onNotification).toHaveBeenCalledWith(
+      NTERACT_PANEL_SERVER_PATCH,
+      expect.any(Function),
+    );
   });
 });

--- a/src/isolated-renderer/__tests__/panel-runtime-transport.test.ts
+++ b/src/isolated-renderer/__tests__/panel-runtime-transport.test.ts
@@ -1,0 +1,118 @@
+import { afterEach, describe, expect, it, vi } from "vite-plus/test";
+import {
+  NTERACT_PANEL_ACK,
+  NTERACT_PANEL_CHANNEL_CLOSE,
+  NTERACT_PANEL_CHANNEL_OPEN,
+  NTERACT_PANEL_CLIENT_PATCH,
+  NTERACT_PANEL_DISCONNECTED,
+  NTERACT_PANEL_SERVER_PATCH,
+} from "@/components/isolated/rpc-methods";
+import {
+  installPanelRuntimeTransport,
+  registerPanelRuntimeTransportHandlers,
+} from "../panel-runtime-transport";
+
+type NotificationHandler = (params: unknown) => void;
+
+function createTransport() {
+  const handlers = new Map<string, NotificationHandler>();
+  return {
+    handlers,
+    notify: vi.fn(),
+    onNotification: vi.fn((method: string, handler: NotificationHandler) => {
+      handlers.set(method, handler);
+    }),
+  };
+}
+
+describe("Panel runtime transport", () => {
+  afterEach(() => {
+    delete window.__nteractPanelRuntime;
+    vi.restoreAllMocks();
+  });
+
+  it("publishes typed Panel channel notifications to the host", () => {
+    const transport = createTransport();
+    const runtime = installPanelRuntimeTransport(() => transport);
+
+    runtime.registerTarget({ plotId: "plot-1", commId: "comm-1" });
+    runtime.sendClientPatch({
+      plotId: "plot-1",
+      commId: "comm-1",
+      data: { events: [] },
+      metadata: { kind: "patch" },
+    });
+    runtime.closeChannel({ plotId: "plot-1", commId: "comm-1" });
+
+    expect(transport.notify).toHaveBeenNthCalledWith(1, NTERACT_PANEL_CHANNEL_OPEN, {
+      plotId: "plot-1",
+      commId: "comm-1",
+    });
+    expect(transport.notify).toHaveBeenNthCalledWith(2, NTERACT_PANEL_CLIENT_PATCH, {
+      plotId: "plot-1",
+      commId: "comm-1",
+      data: { events: [] },
+      metadata: { kind: "patch" },
+    });
+    expect(transport.notify).toHaveBeenNthCalledWith(3, NTERACT_PANEL_CHANNEL_CLOSE, {
+      plotId: "plot-1",
+      commId: "comm-1",
+    });
+  });
+
+  it("routes host Panel notifications to the attached manager", () => {
+    const transport = createTransport();
+    const manager = {
+      receiveServerPatch: vi.fn(),
+      receiveAck: vi.fn(),
+      setDisconnected: vi.fn(),
+    };
+
+    const runtime = installPanelRuntimeTransport(() => transport);
+    runtime.attachCommManager(manager);
+    registerPanelRuntimeTransportHandlers(transport);
+
+    const serverPatch = {
+      plotId: "plot-1",
+      commId: "comm-1",
+      data: { events: [{ kind: "ModelChanged" }] },
+    };
+    const ack = {
+      plotId: "plot-1",
+      commId: "comm-1",
+      metadata: { msg_type: "Ready" as const, comm_id: "comm-1" },
+    };
+    const disconnected = {
+      plotId: "plot-1",
+      commId: "comm-1",
+      reason: "kernel restarted",
+    };
+
+    transport.handlers.get(NTERACT_PANEL_SERVER_PATCH)?.(serverPatch);
+    transport.handlers.get(NTERACT_PANEL_ACK)?.(ack);
+    transport.handlers.get(NTERACT_PANEL_DISCONNECTED)?.(disconnected);
+
+    expect(manager.receiveServerPatch).toHaveBeenCalledWith(serverPatch);
+    expect(manager.receiveAck).toHaveBeenCalledWith(ack);
+    expect(manager.setDisconnected).toHaveBeenCalledWith(disconnected);
+  });
+
+  it("reuses the installed runtime while rebinding host notification handlers", () => {
+    const firstTransport = createTransport();
+    const secondTransport = createTransport();
+    const runtime = installPanelRuntimeTransport(() => firstTransport);
+
+    registerPanelRuntimeTransportHandlers(secondTransport);
+
+    expect(window.__nteractPanelRuntime).toBe(runtime);
+    expect(secondTransport.onNotification).toHaveBeenCalledWith(
+      NTERACT_PANEL_SERVER_PATCH,
+      expect.any(Function),
+    );
+    runtime.registerTarget({ commId: "comm-1" });
+    expect(firstTransport.notify).not.toHaveBeenCalled();
+    expect(secondTransport.notify).toHaveBeenCalledWith(NTERACT_PANEL_CHANNEL_OPEN, {
+      commId: "comm-1",
+    });
+  });
+});

--- a/src/isolated-renderer/index.tsx
+++ b/src/isolated-renderer/index.tsx
@@ -63,6 +63,10 @@ import { parseWidgetViewModelId, WIDGET_VIEW_MIME } from "@/components/widgets/w
 import { dispatchHostOutsideInteractionOnRelease } from "./host-interaction";
 import { measureDocumentHeight } from "./layout-measure";
 import { outputEntryIdForPayload } from "./output-identity";
+import {
+  installPanelRuntimeTransport,
+  registerPanelRuntimeTransportHandlers,
+} from "./panel-runtime-transport";
 // Import widget support
 import { IframeWidgetStoreProvider } from "./widget-provider";
 
@@ -405,6 +409,8 @@ function scheduleRendererLayoutPulses(): void {
 function setupMessageListener() {
   // Create JSON-RPC transport — handles nteract/* methods from the host
   rpcTransport = new JsonRpcTransport(window.parent, window.parent);
+  installPanelRuntimeTransport(() => rpcTransport);
+  registerPanelRuntimeTransportHandlers(rpcTransport);
 
   // Route JSON-RPC notifications to the React message handler
   rpcTransport.onNotification(NTERACT_RENDER_OUTPUT, (params) => {

--- a/src/isolated-renderer/panel-renderer.tsx
+++ b/src/isolated-renderer/panel-renderer.tsx
@@ -9,10 +9,15 @@
 
 import { useEffect, useRef, useState, type ComponentType } from "react";
 import type { RendererProps } from "@/lib/renderer-registry";
-import { PANEL_EXEC_MIME_TYPE, PANEL_LOAD_MIME_TYPE } from "@/components/outputs/panel-mime";
+import {
+  NTERACT_PANEL_RUNTIME_MIME_TYPE,
+  PANEL_EXEC_MIME_TYPE,
+  PANEL_LOAD_MIME_TYPE,
+} from "@/components/outputs/panel-mime";
 import { measureDocumentHeight } from "./layout-measure";
 
 type PanelPayload = {
+  [NTERACT_PANEL_RUNTIME_MIME_TYPE]?: unknown;
   [PANEL_LOAD_MIME_TYPE]?: unknown;
   [PANEL_EXEC_MIME_TYPE]?: unknown;
   "application/javascript"?: unknown;
@@ -307,7 +312,9 @@ function PanelRenderer({ data: rawData, metadata, mimeType }: RendererProps) {
         return;
       }
 
-      if (mimeType !== PANEL_EXEC_MIME_TYPE) return;
+      if (mimeType !== PANEL_EXEC_MIME_TYPE && mimeType !== NTERACT_PANEL_RUNTIME_MIME_TYPE) {
+        return;
+      }
 
       ensurePyViz();
       const serverId = panelServerId(metadata);
@@ -386,5 +393,8 @@ function PanelRenderer({ data: rawData, metadata, mimeType }: RendererProps) {
 export function install(ctx: {
   register: (mimeTypes: string[], component: ComponentType<RendererProps>) => void;
 }) {
-  ctx.register([PANEL_LOAD_MIME_TYPE, PANEL_EXEC_MIME_TYPE], PanelRenderer);
+  ctx.register(
+    [PANEL_LOAD_MIME_TYPE, PANEL_EXEC_MIME_TYPE, NTERACT_PANEL_RUNTIME_MIME_TYPE],
+    PanelRenderer,
+  );
 }

--- a/src/isolated-renderer/panel-renderer.tsx
+++ b/src/isolated-renderer/panel-renderer.tsx
@@ -15,6 +15,7 @@ import {
   PANEL_LOAD_MIME_TYPE,
 } from "@/components/outputs/panel-mime";
 import { measureDocumentHeight } from "./layout-measure";
+import { ensureNteractPanelCommManager } from "./panel-runtime-transport";
 
 type PanelPayload = {
   [NTERACT_PANEL_RUNTIME_MIME_TYPE]?: unknown;
@@ -317,6 +318,9 @@ function PanelRenderer({ data: rawData, metadata, mimeType }: RendererProps) {
       }
 
       ensurePyViz();
+      if (mimeType === NTERACT_PANEL_RUNTIME_MIME_TYPE) {
+        ensureNteractPanelCommManager();
+      }
       const serverId = panelServerId(metadata);
       if (serverId) {
         const html = normalizeText(payload["text/html"]);

--- a/src/isolated-renderer/panel-runtime-transport.ts
+++ b/src/isolated-renderer/panel-runtime-transport.ts
@@ -78,7 +78,9 @@ export function installPanelRuntimeTransport(
 }
 
 export function registerPanelRuntimeTransportHandlers(transport: PanelRuntimeTransport): void {
-  const runtime = installPanelRuntimeTransport(() => transport);
+  const runtime = window.__nteractPanelRuntime;
+  if (!runtime) return;
+
   transport.onNotification(NTERACT_PANEL_SERVER_PATCH, (params) => {
     runtime.receiveServerPatch(params as NteractPanelServerPatchParams);
   });

--- a/src/isolated-renderer/panel-runtime-transport.ts
+++ b/src/isolated-renderer/panel-runtime-transport.ts
@@ -1,0 +1,91 @@
+import type { JsonRpcTransport } from "@/components/isolated/jsonrpc-transport";
+import {
+  NTERACT_PANEL_ACK,
+  NTERACT_PANEL_CHANNEL_CLOSE,
+  NTERACT_PANEL_CHANNEL_OPEN,
+  NTERACT_PANEL_CLIENT_PATCH,
+  NTERACT_PANEL_DISCONNECTED,
+  NTERACT_PANEL_SERVER_PATCH,
+  type NteractPanelAckParams,
+  type NteractPanelChannelCloseParams,
+  type NteractPanelChannelOpenParams,
+  type NteractPanelClientPatchParams,
+  type NteractPanelDisconnectedParams,
+  type NteractPanelServerPatchParams,
+} from "@/components/isolated/rpc-methods";
+
+type PanelRuntimeTransport = Pick<JsonRpcTransport, "notify" | "onNotification">;
+type PanelRuntimeTransportGetter = () => PanelRuntimeTransport | null;
+
+interface PanelCommManager {
+  receiveServerPatch?: (payload: NteractPanelServerPatchParams) => void;
+  receiveAck?: (payload: NteractPanelAckParams) => void;
+  setDisconnected?: (payload: NteractPanelDisconnectedParams) => void;
+}
+
+export interface NteractPanelRuntime {
+  attachCommManager(manager: PanelCommManager): void;
+  registerTarget(payload: NteractPanelChannelOpenParams): void;
+  sendClientPatch(payload: NteractPanelClientPatchParams): void;
+  closeChannel(payload: NteractPanelChannelCloseParams): void;
+  receiveServerPatch(payload: NteractPanelServerPatchParams): void;
+  receiveAck(payload: NteractPanelAckParams): void;
+  setDisconnected(payload: NteractPanelDisconnectedParams): void;
+}
+
+let activeTransport: PanelRuntimeTransportGetter = () => null;
+
+declare global {
+  interface Window {
+    __nteractPanelRuntime?: NteractPanelRuntime;
+  }
+}
+
+export function installPanelRuntimeTransport(
+  getTransport: PanelRuntimeTransportGetter,
+): NteractPanelRuntime {
+  activeTransport = getTransport;
+  const existing = window.__nteractPanelRuntime;
+  if (existing) return existing;
+
+  let manager: PanelCommManager | null = null;
+  const runtime: NteractPanelRuntime = {
+    attachCommManager(nextManager) {
+      manager = nextManager;
+    },
+    registerTarget(payload) {
+      activeTransport()?.notify(NTERACT_PANEL_CHANNEL_OPEN, payload);
+    },
+    sendClientPatch(payload) {
+      activeTransport()?.notify(NTERACT_PANEL_CLIENT_PATCH, payload);
+    },
+    closeChannel(payload) {
+      activeTransport()?.notify(NTERACT_PANEL_CHANNEL_CLOSE, payload);
+    },
+    receiveServerPatch(payload) {
+      manager?.receiveServerPatch?.(payload);
+    },
+    receiveAck(payload) {
+      manager?.receiveAck?.(payload);
+    },
+    setDisconnected(payload) {
+      manager?.setDisconnected?.(payload);
+    },
+  };
+
+  window.__nteractPanelRuntime = runtime;
+  return runtime;
+}
+
+export function registerPanelRuntimeTransportHandlers(transport: PanelRuntimeTransport): void {
+  const runtime = installPanelRuntimeTransport(() => transport);
+  transport.onNotification(NTERACT_PANEL_SERVER_PATCH, (params) => {
+    runtime.receiveServerPatch(params as NteractPanelServerPatchParams);
+  });
+  transport.onNotification(NTERACT_PANEL_ACK, (params) => {
+    runtime.receiveAck(params as NteractPanelAckParams);
+  });
+  transport.onNotification(NTERACT_PANEL_DISCONNECTED, (params) => {
+    runtime.setDisconnected(params as NteractPanelDisconnectedParams);
+  });
+}

--- a/src/isolated-renderer/panel-runtime-transport.ts
+++ b/src/isolated-renderer/panel-runtime-transport.ts
@@ -17,7 +17,42 @@ import {
 type PanelRuntimeTransport = Pick<JsonRpcTransport, "notify" | "onNotification">;
 type PanelRuntimeTransportGetter = () => PanelRuntimeTransport | null;
 
+type PanelMessageHandler = (message: {
+  metadata: Record<string, unknown>;
+  content: { data: unknown };
+  buffers: NteractPanelServerPatchParams["buffers"];
+}) => void;
+
+interface PanelComm {
+  active: boolean;
+  connected: boolean;
+  onMsg?: PanelMessageHandler;
+  on_msg(handler: PanelMessageHandler): void;
+  send(
+    data?: unknown,
+    metadata?: Record<string, unknown>,
+    buffers?: NteractPanelClientPatchParams["buffers"],
+  ): void;
+  close(): void;
+}
+
+interface PanelCommTarget {
+  plotId?: string | null;
+  msgHandler: PanelMessageHandler;
+}
+
+interface PanelPyVizGlobal {
+  comms: Record<string, PanelComm>;
+  comm_status: Record<string, unknown>;
+  kernels: Record<string, unknown>;
+  receivers: Record<string, unknown>;
+  plot_index: Record<string, unknown>;
+  comm_manager?: PanelCommManager;
+  shared_views?: Map<string, unknown[]>;
+}
+
 interface PanelCommManager {
+  __nteractPanelCommManager?: true;
   receiveServerPatch?: (payload: NteractPanelServerPatchParams) => void;
   receiveAck?: (payload: NteractPanelAckParams) => void;
   setDisconnected?: (payload: NteractPanelDisconnectedParams) => void;
@@ -38,7 +73,140 @@ let activeTransport: PanelRuntimeTransportGetter = () => null;
 declare global {
   interface Window {
     __nteractPanelRuntime?: NteractPanelRuntime;
+    PyViz?: PanelPyVizGlobal | HTMLElement;
   }
+}
+
+function ensurePanelPyViz(): PanelPyVizGlobal {
+  if (!window.PyViz || window.PyViz instanceof HTMLElement) {
+    window.PyViz = {
+      comms: {},
+      comm_status: {},
+      kernels: {},
+      receivers: {},
+      plot_index: {},
+    };
+  }
+
+  const pyviz = window.PyViz;
+  pyviz.comms ??= {};
+  pyviz.comm_status ??= {};
+  pyviz.kernels ??= {};
+  pyviz.receivers ??= {};
+  pyviz.plot_index ??= {};
+  return pyviz;
+}
+
+function currentNteractPanelCommManager(): PanelCommManager | null {
+  const pyviz = window.PyViz;
+  if (!pyviz || pyviz instanceof HTMLElement) return null;
+  const manager = pyviz.comm_manager;
+  return manager?.__nteractPanelCommManager ? manager : null;
+}
+
+class NteractPanelCommManager implements PanelCommManager {
+  readonly __nteractPanelCommManager = true;
+  readonly targets: Record<string, PanelCommTarget> = {};
+  readonly comms: Record<string, PanelComm> = {};
+
+  constructor(private readonly pyviz: PanelPyVizGlobal) {
+    window.__nteractPanelRuntime?.attachCommManager(this);
+  }
+
+  register_target(
+    plotId: string | null | undefined,
+    commId: string,
+    msgHandler: PanelMessageHandler,
+  ) {
+    this.targets[commId] = { plotId, msgHandler };
+    window.__nteractPanelRuntime?.registerTarget({ plotId, commId });
+  }
+
+  get_client_comm(
+    plotIdOrCommId: string | null | undefined,
+    commIdOrHandler?: string | PanelMessageHandler,
+    maybeHandler?: PanelMessageHandler,
+  ): PanelComm {
+    const commId = typeof commIdOrHandler === "string" ? commIdOrHandler : plotIdOrCommId;
+    if (!commId) {
+      throw new Error("Panel client comm requested without a comm id");
+    }
+    const plotId = typeof commIdOrHandler === "string" ? plotIdOrCommId : undefined;
+    const msgHandler = typeof commIdOrHandler === "function" ? commIdOrHandler : maybeHandler;
+
+    if (this.comms[commId]) {
+      if (msgHandler) this.comms[commId].on_msg(msgHandler);
+      return this.comms[commId];
+    }
+
+    const comm: PanelComm = {
+      active: true,
+      connected: true,
+      onMsg: msgHandler,
+      on_msg(handler) {
+        comm.onMsg = handler;
+      },
+      send(data, metadata, buffers) {
+        window.__nteractPanelRuntime?.sendClientPatch({
+          plotId,
+          commId,
+          data,
+          metadata: metadata ?? {},
+          buffers: buffers ?? [],
+        });
+      },
+      close() {
+        comm.active = false;
+        comm.connected = false;
+        window.__nteractPanelRuntime?.closeChannel({ plotId, commId });
+      },
+    };
+
+    this.comms[commId] = comm;
+    this.pyviz.comms[commId] = comm;
+    return comm;
+  }
+
+  receiveServerPatch(payload: NteractPanelServerPatchParams): void {
+    const target = this.targets[payload.commId];
+    if (!target) return;
+    target.msgHandler({
+      metadata: payload.metadata ?? {},
+      content: { data: payload.data },
+      buffers: payload.buffers ?? [],
+    });
+  }
+
+  receiveAck(payload: NteractPanelAckParams): void {
+    const comm = this.comms[payload.commId] ?? this.pyviz.comms[payload.commId];
+    comm?.onMsg?.({
+      metadata: payload.metadata,
+      content: { data: undefined },
+      buffers: [],
+    });
+  }
+
+  setDisconnected(payload: NteractPanelDisconnectedParams): void {
+    const commId = payload.commId;
+    if (commId && this.comms[commId]) {
+      this.comms[commId].active = false;
+      this.comms[commId].connected = false;
+    }
+    console.warn("Panel runtime channel disconnected", payload);
+  }
+}
+
+export function ensureNteractPanelCommManager(): PanelCommManager {
+  const existing = currentNteractPanelCommManager();
+  if (existing) {
+    window.__nteractPanelRuntime?.attachCommManager(existing);
+    return existing;
+  }
+
+  const pyviz = ensurePanelPyViz();
+  const manager = new NteractPanelCommManager(pyviz);
+  pyviz.comm_manager = manager;
+  return manager;
 }
 
 export function installPanelRuntimeTransport(
@@ -74,6 +242,8 @@ export function installPanelRuntimeTransport(
   };
 
   window.__nteractPanelRuntime = runtime;
+  const currentManager = currentNteractPanelCommManager();
+  if (currentManager) runtime.attachCommManager(currentManager);
   return runtime;
 }
 

--- a/src/isolated-renderer/panel-runtime-transport.ts
+++ b/src/isolated-renderer/panel-runtime-transport.ts
@@ -69,6 +69,7 @@ export interface NteractPanelRuntime {
 }
 
 let activeTransport: PanelRuntimeTransportGetter = () => null;
+const registeredPanelRuntimeTransports = new WeakSet<PanelRuntimeTransport>();
 
 declare global {
   interface Window {
@@ -250,6 +251,8 @@ export function installPanelRuntimeTransport(
 export function registerPanelRuntimeTransportHandlers(transport: PanelRuntimeTransport): void {
   const runtime = window.__nteractPanelRuntime;
   if (!runtime) return;
+  if (registeredPanelRuntimeTransports.has(transport)) return;
+  registeredPanelRuntimeTransports.add(transport);
 
   transport.onNotification(NTERACT_PANEL_SERVER_PATCH, (params) => {
     runtime.receiveServerPatch(params as NteractPanelServerPatchParams);


### PR DESCRIPTION
## Summary

- Add an opt-in launcher-side Panel runtime hook behind `NTERACT_PANEL_RUNTIME_STATE`.
- Keep Panel lazy: bootstrap installs an import hook without importing Panel on kernel startup.
- Add a PyViz-compatible `NteractPanelCommManager` scaffold that emits typed Panel/Bokeh channel events instead of opening raw Jupyter comms through the iframe/widget bridge.
- Add `application/vnd.nteract.panel-runtime.v1+json` as a nteract-owned Panel marker MIME, including launcher marker injection at `panel.viewable.MimeRenderMixin._render_mimebundle` and Rust output narrowing that preserves the full Panel HTML/JS bundle.
- Add a typed isolated-frame Panel runtime transport for channel open, client patch, server patch, ACK, close, and disconnected events.
- Move the browser-side `window.PyViz.comm_manager` implementation out of the Python launcher `js_manager` string and into the isolated renderer TypeScript bundle, with tests for the Panel/PyViz manager surface.
- Add a typed Python receive seam so future daemon/runtime events can deliver browser-origin Panel client patches into Panel's existing `_on_msg` callback surface without a raw comm fallback.
- Add `packages/runtimed/src/panel-runtime.ts` as the shared typed Panel/Bokeh runtime-event model, including stable channel ids based on cell/output/plot/comm identity and blob-ref-capable patch payloads.
- Treat `application/vnd.nteract.panel-runtime.v1+json` as the canonical Panel runtime marker in both app and shared runtime MIME priority, so render selection uses the launcher-stamped type instead of sniffing generated HTML/JS.
- Surface iframe-origin Panel runtime messages through `OutputArea`, `CodeCell`, and `NotebookView` to the notebook app boundary with normalized `PanelRuntimeEvent` records while keeping them out of `CommBridgeManager` and the widget `SendComm` path.
- Close Pullfrog lifecycle gaps: robust stdout restoration, state manager patching when Panel's state binding differs from notebook/viewable bindings, comm close/clear on uninstall, and reconnect-safe Panel notification handler registration.
- Expand `docs/memos/panel-runtime-state.md` with an explainer of the Panel/PyViz/Bokeh communications model, the native nteract mapping, the need for a real kernel-launcher runtime channel endpoint, and the upstreamable Bokeh patch-transport hook we should prefer over standardizing on a comm-manager-shaped API.

## Verification

- `uv run --directory python/nteract-kernel-launcher pytest tests/test_bootstrap.py`
- Latest local focused pass on `43162e891`: `uv run --directory python/nteract-kernel-launcher pytest tests/test_bootstrap.py -q` (`48 passed in 1.16s`)
- Latest local lint pass on `73cb6c79e`: `cargo xtask lint --fix`
- `vp test run packages/runtimed/tests/panel-runtime.test.ts`
- `vp test run src/isolated-renderer/__tests__/panel-runtime-transport.test.ts src/isolated-renderer/__tests__/panel-renderer.test.tsx src/components/cell/__tests__/OutputArea.test.tsx apps/notebook/src/components/__tests__/code-cell-output-focus.test.tsx packages/runtimed/tests/panel-runtime.test.ts`
- `vp test run src/isolated-renderer/__tests__/panel-runtime-transport.test.ts src/components/cell/__tests__/OutputArea.test.tsx apps/notebook/src/components/__tests__/code-cell-output-focus.test.tsx packages/runtimed/tests/panel-runtime.test.ts`
- `vp test run src/isolated-renderer/__tests__/panel-runtime-transport.test.ts src/isolated-renderer/__tests__/panel-renderer.test.tsx packages/runtimed/tests/panel-runtime.test.ts src/components/cell/__tests__/OutputArea.test.tsx`
- `pnpm exec tsc -p apps/notebook/tsconfig.json --noEmit`
- `pnpm exec tsc -p packages/runtimed/tsconfig.json`
- `cargo xtask lint --fix`
- GitHub CI passed on `5f01bafaf`: Browser E2E, JS Tests & Benchmarks, Python Unit Tests, Linux Rust Tests, Linux Rust Clippy, WASM + Deno Tests, Lint & Format, shared UI artifacts, docs guidance.
- Earlier broader frontend pass on this branch: `vp test run packages/runtimed/tests/panel-runtime.test.ts src/components/cell/__tests__/OutputArea.test.tsx src/components/isolated/__tests__/rpc-methods.test.ts src/components/isolated/__tests__/frame-bridge.test.ts src/components/isolated/__tests__/type-to-method.test.ts src/components/isolated/__tests__/isolated-frame-runtime.test.ts src/isolated-renderer/__tests__/panel-runtime-transport.test.ts src/components/isolated/__tests__/renderer-plugin-info.test.ts src/components/isolated/__tests__/output-payloads.test.ts src/components/isolated/__tests__/output-lane-policy.test.ts src/isolated-renderer/__tests__/panel-renderer.test.tsx`
- Earlier Rust narrowing check on this branch: `cargo test -p runtimed-wasm nteract_panel_runtime_narrowing_keeps_marker_javascript_and_html_bundle`
- Earlier full launcher pass on this branch: `uv run --directory python/nteract-kernel-launcher pytest`

## Notes

This is still a draft slice for the native Panel runtime-state goal. It creates the launcher, output-marker, Rust narrowing, iframe transport, shared runtime-event contract, parent/app ingress scaffolding, and Python receive seam without exposing a generic raw Panel comm bridge at the iframe/widget boundary. A Bedrock Opus 4.8 advisory review called out the risk of the `PyViz.comm_manager` shape becoming the architecture; the branch now documents and comments that surface as a compatibility adapter for Panel's current notebook API, with the desired longer-term shape being a typed Bokeh patch transport or upstream Panel/Bokeh backend registration hook. The next slice should connect these typed events to daemon-owned runtime state through a real kernel-launcher runtime channel endpoint, then add callback stdout/stderr outputs and browser smoke verification.
