### PR TITLE
feat(comments): replace speech-bubble-plus with an author-colored comment mark

### DIFF
--- a/apps/elements/components/context-controls-example.tsx
+++ b/apps/elements/components/context-controls-example.tsx
@@ -6,7 +6,6 @@ import {
   FileQuestion,
   Link2,
   Maximize2,
-  MessageSquarePlus,
   PackageCheck,
   Pencil,
   Play,
@@ -16,6 +15,7 @@ import {
   Trash2,
 } from "lucide-react";
 import { useMemo, useState, type ReactNode } from "react";
+import { CommentMarkIcon } from "@/components/comments/CommentMarkIcon";
 import { CodeMirrorEditor } from "@/components/editor/codemirror-editor";
 import {
   NotebookCommandToolbar,
@@ -108,7 +108,7 @@ function groupsForTarget(
             id: "comment-selection",
             label: "Add comment",
             description: "Anchor a discussion to this source range.",
-            icon: icon(<MessageSquarePlus />),
+            icon: icon(<CommentMarkIcon />),
             shortcut: "C",
             onSelect: select("Add comment"),
           },
@@ -170,7 +170,7 @@ function groupsForTarget(
             id: "comment-heading",
             label: "Add comment",
             description: "Anchor feedback to the rendered heading.",
-            icon: icon(<MessageSquarePlus />),
+            icon: icon(<CommentMarkIcon />),
             shortcut: "C",
             onSelect: select("Add comment"),
           },
@@ -212,7 +212,7 @@ function groupsForTarget(
             id: "comment-output",
             label: "Add comment",
             description: "Attach discussion to the output frame.",
-            icon: icon(<MessageSquarePlus />),
+            icon: icon(<CommentMarkIcon />),
             shortcut: "C",
             onSelect: select("Add comment"),
           },
@@ -259,7 +259,7 @@ function groupsForTarget(
           id: "comment-package",
           label: "Add comment",
           description: "Start a dependency-specific discussion.",
-          icon: icon(<MessageSquarePlus />),
+          icon: icon(<CommentMarkIcon />),
           onSelect: select("Add comment"),
         },
       ],
@@ -346,7 +346,7 @@ export function ContextControlsExample() {
                   className="h-7 px-2 text-xs"
                   onClick={() => recordAction(activeTarget, "Add comment from toolbar")}
                 >
-                  <MessageSquarePlus className="size-3.5" aria-hidden="true" />
+                  <CommentMarkIcon className="size-3.5" aria-hidden="true" />
                   Comment
                 </Button>
                 <Button

--- a/apps/notebook/src/components/CodeCell.tsx
+++ b/apps/notebook/src/components/CodeCell.tsx
@@ -1,11 +1,12 @@
 import type { EditorView, KeyBinding } from "@codemirror/view";
-import { ChevronRight, Code2, Eye, EyeOff, MessageSquarePlus, type LucideIcon } from "lucide-react";
+import { ChevronRight, Code2, Eye, EyeOff, type LucideIcon } from "lucide-react";
 import { memo, type ReactNode, useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { CellContainer } from "@/components/cell/CellContainer";
 import { cellOutputInnerInset } from "@/components/cell/cell-layout";
 import { CompactExecutionButton } from "@/components/cell/CompactExecutionButton";
 import { CodeCellCurrentLine } from "@/components/cell/CodeCellCurrentLine";
 import { OutputArea } from "@/components/cell/OutputArea";
+import { CommentMarkIcon } from "@/components/comments/CommentMarkIcon";
 import { CodeMirrorEditor, type CodeMirrorEditorRef } from "@/components/editor/codemirror-editor";
 import { languageDisplayNames, type SupportedLanguage } from "@/components/editor/languages";
 import { remoteCursorsExtension } from "@/components/editor/remote-cursors";
@@ -905,7 +906,7 @@ export const CodeCell = memo(function CodeCell({
                   title="Comment on outputs"
                   aria-label="Comment on outputs"
                 >
-                  <MessageSquarePlus className="h-3.5 w-3.5" />
+                  <CommentMarkIcon className="h-3.5 w-3.5" aria-hidden="true" />
                 </button>
               ) : null}
               {onToggleOutputsHidden ? (

--- a/apps/notebook/src/components/EditorContextMenu.tsx
+++ b/apps/notebook/src/components/EditorContextMenu.tsx
@@ -1,6 +1,7 @@
 import type { EditorView } from "@codemirror/view";
-import { ClipboardPaste, Copy, MessageSquarePlus, Scissors } from "lucide-react";
+import { ClipboardPaste, Copy, Scissors } from "lucide-react";
 import { useCallback, useState, type ReactNode } from "react";
+import { CommentMarkIcon } from "@/components/comments/CommentMarkIcon";
 import {
   NotebookContextMenu,
   type NotebookContextMenuAction,
@@ -85,7 +86,7 @@ export function buildEditorContextGroups({
     actions.push({
       id: "add-comment",
       label: "Add comment",
-      icon: <MessageSquarePlus className="size-4" aria-hidden="true" />,
+      icon: <CommentMarkIcon className="size-4" aria-hidden="true" />,
       shortcut: "C",
       separatorBefore: actions.length > 0,
       onSelect: onAddComment,

--- a/apps/notebook/src/components/InlineCommentComposer.tsx
+++ b/apps/notebook/src/components/InlineCommentComposer.tsx
@@ -1,4 +1,3 @@
-import { MessageSquarePlus } from "lucide-react";
 import {
   type CSSProperties,
   type FormEvent,
@@ -7,6 +6,7 @@ import {
   useRef,
   useState,
 } from "react";
+import { CommentMarkIcon } from "@/components/comments/CommentMarkIcon";
 import { Popover, PopoverAnchor, PopoverContent } from "@/components/ui/popover";
 import { cn } from "@/lib/utils";
 import type { SourceCommentSelectionRect } from "../lib/comment-source-anchor";
@@ -112,7 +112,7 @@ export function InlineCommentComposer({
         }}
       >
         <div className="flex items-center gap-1.5 text-xs font-medium text-muted-foreground">
-          <MessageSquarePlus className="size-3.5" aria-hidden="true" />
+          <CommentMarkIcon className="size-3.5" aria-hidden="true" />
           Comment on selection
         </div>
         {preview ? (

--- a/apps/notebook/src/components/RenderedMarkdownContextMenu.tsx
+++ b/apps/notebook/src/components/RenderedMarkdownContextMenu.tsx
@@ -1,5 +1,6 @@
-import { Copy, MessageSquarePlus } from "lucide-react";
+import { Copy } from "lucide-react";
 import { useCallback, useState, type ReactNode, type RefObject } from "react";
+import { CommentMarkIcon } from "@/components/comments/CommentMarkIcon";
 import {
   NotebookContextMenu,
   type NotebookContextMenuAction,
@@ -57,7 +58,7 @@ export function buildRenderedMarkdownContextGroups({
     actions.push({
       id: "add-comment",
       label: "Add comment",
-      icon: <MessageSquarePlus className="size-4" aria-hidden="true" />,
+      icon: <CommentMarkIcon className="size-4" aria-hidden="true" />,
       shortcut: "C",
       separatorBefore: actions.length > 0,
       onSelect: onAddComment,

--- a/src/components/comments/CommentMarkIcon.tsx
+++ b/src/components/comments/CommentMarkIcon.tsx
@@ -1,0 +1,39 @@
+import { type SVGProps } from "react";
+
+/**
+ * The nteract comment mark: a speech bubble with the author's own colored dot
+ * inside. The bubble stroke inherits `currentColor` so it picks up the
+ * surrounding text color (muted at rest, foreground on hover), while the dot
+ * carries the author's identity color (`--comment-author-color`, the same token
+ * the selection affordance uses) with a `--primary` fallback - so the mark is
+ * the author's voice, not a generic action icon. Shared by the cell-gutter
+ * "comment on outputs" button, the editor and rendered-markdown context menus,
+ * and the inline composer header. The selection affordance itself stays a plain
+ * dot; this icon is for surfaces where a label or icon company needs the mark to
+ * read as "comment."
+ */
+export function CommentMarkIcon(props: SVGProps<SVGSVGElement>) {
+  return (
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+      width="24"
+      height="24"
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth={2}
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      {...props}
+    >
+      <path d="M4 5h12a2 2 0 0 1 2 2v6a2 2 0 0 1-2 2H9.5L6 18.5V15H4a2 2 0 0 1-2-2V7a2 2 0 0 1 2-2Z" />
+      <circle
+        cx="11"
+        cy="10"
+        r="2.6"
+        stroke="none"
+        style={{ fill: "var(--comment-author-color, var(--primary, #2563eb))" }}
+      />
+    </svg>
+  );
+}


### PR DESCRIPTION
## Overview

Replaces Lucide's `MessageSquarePlus` (a generic speech-bubble-plus) with a shared `CommentMarkIcon`: a speech bubble with the author's own colored dot inside. The dot carries `--comment-author-color` - the same token the selection affordance uses - so the mark reads as the author adding their voice, not a stock action icon.

The selection affordance itself stays a plain dot. The new icon covers the surfaces where a label or icon company needs the mark to read as "comment": the cell-gutter "comment on outputs" button, the editor and rendered-markdown context menus, the inline composer header, and the Elements catalog.

## Design decision

The comment system already has a signature mark: the author-colored dot, established across #3763-#3776 as the selection affordance (dot that morphs into a "Comment" pill via WAAPI). The affordance works standalone because the pill supplies the label. The other surfaces - a gutter button next to outputs, menu rows beside Cut/Copy/Paste, the composer header - need the mark to read as "comment" without a pill, and `MessageSquarePlus` read as generic.

The chosen mark is a synthesis: keep the recognizable speech-bubble shape (reads as "comment" instantly next to stock icons), but replace the generic `+` with the author's dot. The bubble stroke inherits `currentColor` so it tracks the surrounding text color (muted at rest, foreground on hover); the dot uses `--comment-author-color` with a `--primary` fallback. One icon across all five surfaces keeps the language coherent.

The dot-in-bubble was preferred over a "trailing dots" alternative because trailing dots risk reading as a scatter/bubble plot in the gutter next to outputs, where chart icons literally live.

## Behavioral coverage

| Surface | Before | After |
|---|---|---|
| Cell gutter "comment on outputs" | `MessageSquarePlus` 14px | `CommentMarkIcon` 14px, dot in author color |
| Editor context menu "Add comment" | `MessageSquarePlus` 16px | `CommentMarkIcon` 16px |
| Rendered-markdown context menu "Add comment" | `MessageSquarePlus` 16px | `CommentMarkIcon` 16px |
| Inline composer header | `MessageSquarePlus` 14px | `CommentMarkIcon` 14px |
| Elements catalog (4 menu rows + toolbar button) | `MessageSquarePlus` | `CommentMarkIcon` |
| Selection affordance (editor + rendered markdown) | plain author dot | unchanged |

## Test plan

- [x] `cargo xtask lint --fix` (Rust fmt, `vp check --fix`, raw-byte check)
- [x] `vp check` (format + lint + type check, the CI gate)
- [x] `EditorContextMenu` tests (4 passed)
- [x] `RenderedMarkdownContextMenu` tests (6 passed)
- [x] `InlineCommentComposer` tests (6 passed)
- [x] Broader comment suite: `NotebookRail`, `NotebookContextMenu`, `NotebookCommentsPanel`, `output-comment-demotion` (58 passed, 74 total)
- [ ] Visual QA: gutter button, both context menus, composer header in light + dark
