### PR TITLE
fix(onboarding): use normal telemetry link navigation

### DIFF
--- a/apps/notebook/onboarding/App.tsx
+++ b/apps/notebook/onboarding/App.tsx
@@ -1,8 +1,7 @@
 import { invoke } from "@tauri-apps/api/core";
 import { listen } from "@tauri-apps/api/event";
-import { open as openExternal } from "@tauri-apps/plugin-shell";
 import { AlertTriangle, ArrowLeft, Check, Loader2 } from "lucide-react";
-import { type MouseEvent, useCallback, useEffect, useState } from "react";
+import { useCallback, useEffect, useState } from "react";
 import { Button } from "@/components/ui/button";
 import { Progress } from "@/components/ui/progress";
 import { cn } from "@/lib/utils";
@@ -373,13 +372,6 @@ export default function App() {
     setPage((current) => (current === 3 ? 2 : 1));
   }, []);
 
-  const openTelemetryDetails = useCallback((e: MouseEvent<HTMLAnchorElement>) => {
-    e.preventDefault();
-    openExternal(LEARN_MORE_URL).catch(() => {
-      window.open(LEARN_MORE_URL, "_blank", "noopener,noreferrer");
-    });
-  }, []);
-
   // Record the user's telemetry decision and complete onboarding. Called from
   // either CTA on page 3. Both paths flip `telemetry_consent_recorded` to true
   // so heartbeats can fire when enabled.
@@ -597,7 +589,6 @@ export default function App() {
               </p>
               <a
                 href={LEARN_MORE_URL}
-                onClick={openTelemetryDetails}
                 rel="noreferrer"
                 target="_blank"
                 className="inline-block text-xs text-primary underline hover:text-foreground"

--- a/apps/notebook/src/__tests__/onboarding-flow.test.tsx
+++ b/apps/notebook/src/__tests__/onboarding-flow.test.tsx
@@ -11,10 +11,6 @@ vi.mock("@tauri-apps/api/event", () => ({
   listen: vi.fn(() => Promise.resolve(() => {})),
 }));
 
-vi.mock("@tauri-apps/plugin-shell", () => ({
-  open: vi.fn(),
-}));
-
 const invokeMock = vi.mocked(invoke);
 
 function chooseUvRuntime() {


### PR DESCRIPTION
## Summary
- remove the direct `@tauri-apps/plugin-shell` dependency from the onboarding telemetry learn-more link
- let the existing external anchor handle navigation
- remove the now-unused shell plugin mock from onboarding tests

## Verification
- `pnpm test:run apps/notebook/src/__tests__/onboarding-flow.test.tsx`
- `cargo xtask lint --fix`

## Audit context
This is a small host-boundary cleanup from the reviewer-guidelines consistency audit. Onboarding still has direct Tauri IPC/event usage that should move behind an auxiliary-window adapter in a larger follow-up.