### PR TITLE
test(wasm): centralize runtimed wasm artifact loaders

### DIFF
--- a/apps/notebook-cloud/scripts/copy-viewer-assets.mjs
+++ b/apps/notebook-cloud/scripts/copy-viewer-assets.mjs
@@ -5,16 +5,13 @@ import { copyRendererSidecarAssets } from "./renderer-sidecar-assets.mjs";
 import { copyRuntimeWasmAssets } from "./runtime-wasm-assets.mjs";
 import { writeNotebookRouteAssetsManifest } from "./notebook-route-assets.mjs";
 import { writeViewerCssManifest } from "./viewer-css-assets.mjs";
+import {
+  assertRuntimedWasmBuildExists,
+  runtimedWasmBinaryUrl,
+  runtimedWasmModuleUrl,
+} from "./runtimed-wasm-artifact.mjs";
 
 const siftWasmUrl = new URL("../../../crates/sift-wasm/pkg/sift_wasm_bg.wasm", import.meta.url);
-const runtimedWasmModuleUrl = new URL(
-  "../../notebook/src/wasm/runtimed-wasm/runtimed_wasm.js",
-  import.meta.url,
-);
-const runtimedWasmUrl = new URL(
-  "../../notebook/src/wasm/runtimed-wasm/runtimed_wasm_bg.wasm",
-  import.meta.url,
-);
 const isolatedRendererModuleUrl = new URL(
   "../../notebook/src/renderer-plugins/isolated-renderer.js",
   import.meta.url,
@@ -30,8 +27,7 @@ const outputDocumentFrameUrl = new URL(
 const outputDocumentOutputUrl = new URL("../dist-output-document/index.html", import.meta.url);
 
 await assertExists(siftWasmUrl);
-await assertExists(runtimedWasmModuleUrl);
-await assertExists(runtimedWasmUrl);
+await assertRuntimedWasmBuildExists();
 await assertExists(isolatedRendererModuleUrl);
 await assertExists(isolatedRendererCssUrl);
 await assertExists(outputDocumentFrameUrl);
@@ -47,7 +43,7 @@ const rendererSidecarAssets = await copyRendererSidecarAssets({
 });
 const runtimeWasmAssets = await copyRuntimeWasmAssets({
   moduleUrl: runtimedWasmModuleUrl,
-  wasmUrl: runtimedWasmUrl,
+  wasmUrl: runtimedWasmBinaryUrl,
   assetsDirUrl: new URL("../dist/assets/", import.meta.url),
   pluginsDirUrl: new URL("../dist/plugins/", import.meta.url),
 });

--- a/apps/notebook-cloud/scripts/publish-demo.mjs
+++ b/apps/notebook-cloud/scripts/publish-demo.mjs
@@ -1,6 +1,4 @@
 import { createHash } from "node:crypto";
-import { access, readFile } from "node:fs/promises";
-import { fileURLToPath } from "node:url";
 
 import {
   canonicalViewerUrl,
@@ -10,26 +8,15 @@ import {
 } from "./publish-notebook-id.mjs";
 import { notebookCloudBaseUrl } from "./local-dev.mjs";
 import { publishIdentityHeaders } from "./publish-auth.mjs";
+import { initializeRuntimedWasmSyncForNode } from "./runtimed-wasm-artifact.mjs";
 
 const baseUrl = notebookCloudBaseUrl();
 const notebookId = notebookIdFromEnvOrGenerated();
 const vanityName = vanityNameFromEnvOrNotebookName("demo.ipynb");
 const runtimeStateDocIdOverride = runtimeStateDocIdFromEnvOrDefault(notebookId);
 const actorLabel = "user:dev:demo/agent:publish-demo";
-const wasmJsUrl = new URL(
-  "../../notebook/src/wasm/runtimed-wasm/runtimed_wasm.js",
-  import.meta.url,
-);
-const wasmBytesUrl = new URL(
-  "../../notebook/src/wasm/runtimed-wasm/runtimed_wasm_bg.wasm",
-  import.meta.url,
-);
 
-await assertWasmBuildExists();
-
-const { initSync, NotebookHandle } = await import(wasmJsUrl.href);
-const wasmBytes = await readFile(wasmBytesUrl);
-initSync({ module: wasmBytes });
+const { NotebookHandle } = await initializeRuntimedWasmSyncForNode();
 
 const handle = new NotebookHandle(notebookId);
 handle.set_actor(actorLabel);
@@ -127,17 +114,6 @@ function requiredRuntimeStateDocId(handle) {
     "NotebookDoc snapshot is missing runtime_state_doc_id",
   );
   return runtimeStateDocId;
-}
-
-async function assertWasmBuildExists() {
-  try {
-    await access(fileURLToPath(wasmJsUrl));
-    await access(fileURLToPath(wasmBytesUrl));
-  } catch {
-    throw new Error(
-      "Missing apps/notebook/src/wasm/runtimed-wasm output. Run `cargo xtask wasm runtimed --skip-renderer-plugins` first.",
-    );
-  }
 }
 
 async function putBytes(pathname, body, contentType, extraHeaders = {}) {

--- a/apps/notebook-cloud/scripts/publish-fixture.mjs
+++ b/apps/notebook-cloud/scripts/publish-fixture.mjs
@@ -10,6 +10,7 @@ import {
 } from "./publish-notebook-id.mjs";
 import { notebookCloudBaseUrl } from "./local-dev.mjs";
 import { publishIdentityHeaders } from "./publish-auth.mjs";
+import { initializeRuntimedWasmSyncForNode } from "./runtimed-wasm-artifact.mjs";
 
 const baseUrl = notebookCloudBaseUrl();
 const fixtureName = process.env.NOTEBOOK_CLOUD_FIXTURE ?? "output_streaming";
@@ -20,24 +21,12 @@ const fixtureRoot = new URL(
   `../../../packages/runtimed/tests/fixtures/${fixtureName}/`,
   import.meta.url,
 );
-const wasmJsUrl = new URL(
-  "../../notebook/src/wasm/runtimed-wasm/runtimed_wasm.js",
-  import.meta.url,
-);
-const wasmBytesUrl = new URL(
-  "../../notebook/src/wasm/runtimed-wasm/runtimed_wasm_bg.wasm",
-  import.meta.url,
-);
 
-await assertExists(wasmJsUrl);
-await assertExists(wasmBytesUrl);
 await assertExists(new URL("manifest.json", fixtureRoot));
 await assertExists(new URL("doc.bin", fixtureRoot));
 await assertExists(new URL("state_doc.bin", fixtureRoot));
 
-const { initSync, NotebookHandle } = await import(wasmJsUrl.href);
-const wasmBytes = await readFile(wasmBytesUrl);
-initSync({ module: wasmBytes });
+const { NotebookHandle } = await initializeRuntimedWasmSyncForNode();
 
 const [snapshotBytes, runtimeSnapshotBytes] = await Promise.all([
   readFile(new URL("doc.bin", fixtureRoot)),

--- a/apps/notebook-cloud/scripts/publish-live.mjs
+++ b/apps/notebook-cloud/scripts/publish-live.mjs
@@ -1,7 +1,6 @@
 import { createHash } from "node:crypto";
-import { access, readFile } from "node:fs/promises";
+import { readFile } from "node:fs/promises";
 import path from "node:path";
-import { fileURLToPath } from "node:url";
 
 import { collectArrowStreamManifestBlobRefs, collectBlobRefs } from "../src/blob-refs.ts";
 import { createLiveNotebookFixture } from "./live-notebook-fixture.mjs";
@@ -14,6 +13,10 @@ import { notebookCloudBaseUrl } from "./local-dev.mjs";
 import { publishIdentityHeaders } from "./publish-auth.mjs";
 import { loadRuntimedNode } from "./runtimed-node-loader.mjs";
 import { summarizeCatalog } from "./hosted-render-smoke-catalog.mjs";
+import {
+  assertRuntimedWasmBuildExists,
+  initializeRuntimedWasmSyncForNode,
+} from "./runtimed-wasm-artifact.mjs";
 
 const rt = loadRuntimedNode();
 
@@ -24,16 +27,8 @@ const notebookId = notebookIdFromEnvOrGenerated();
 const vanityName = vanityNameFromEnvOrNotebookName(
   defaultLiveNotebookName({ preset, sourceNotebookId }),
 );
-const wasmJsUrl = new URL(
-  "../../notebook/src/wasm/runtimed-wasm/runtimed_wasm.js",
-  import.meta.url,
-);
-const wasmBytesUrl = new URL(
-  "../../notebook/src/wasm/runtimed-wasm/runtimed_wasm_bg.wasm",
-  import.meta.url,
-);
 
-await assertWasmBuildExists();
+await assertRuntimedWasmBuildExists();
 
 const session = sourceNotebookId
   ? await rt.openNotebook(sourceNotebookId, {
@@ -136,9 +131,7 @@ try {
 }
 
 async function snapshotPairMetadata(notebookBytes, runtimeStateBytes, commsBytes) {
-  const { initSync, NotebookHandle } = await import(wasmJsUrl.href);
-  const wasmBytes = await readFile(wasmBytesUrl);
-  initSync({ module: wasmBytes });
+  const { NotebookHandle } = await initializeRuntimedWasmSyncForNode();
   const handle = NotebookHandle.load_snapshot(notebookBytes, runtimeStateBytes);
   if (commsBytes) {
     handle.load_comms_doc(commsBytes);
@@ -268,17 +261,6 @@ async function fetchJson(pathname) {
 async function assertOk(response, pathname) {
   if (response.ok) return;
   throw new Error(`${pathname} returned ${response.status}: ${await response.text()}`);
-}
-
-async function assertWasmBuildExists() {
-  try {
-    await access(fileURLToPath(wasmJsUrl));
-    await access(fileURLToPath(wasmBytesUrl));
-  } catch {
-    throw new Error(
-      "Missing apps/notebook/src/wasm/runtimed-wasm output. Run `cargo xtask wasm runtimed --skip-renderer-plugins` first.",
-    );
-  }
 }
 
 function assert(condition, message) {

--- a/apps/notebook-cloud/scripts/runtimed-wasm-artifact.mjs
+++ b/apps/notebook-cloud/scripts/runtimed-wasm-artifact.mjs
@@ -1,0 +1,50 @@
+import { access, readFile } from "node:fs/promises";
+import { fileURLToPath } from "node:url";
+
+export const runtimedWasmModuleUrl = new URL(
+  "../../notebook/src/wasm/runtimed-wasm/runtimed_wasm.js",
+  import.meta.url,
+);
+export const runtimedWasmBinaryUrl = new URL(
+  "../../notebook/src/wasm/runtimed-wasm/runtimed_wasm_bg.wasm",
+  import.meta.url,
+);
+
+let initializedModule;
+
+export async function assertRuntimedWasmBuildExists() {
+  try {
+    await access(fileURLToPath(runtimedWasmModuleUrl));
+    await access(fileURLToPath(runtimedWasmBinaryUrl));
+  } catch {
+    throw new Error(
+      "Missing apps/notebook/src/wasm/runtimed-wasm output. Run `cargo xtask wasm runtimed --skip-renderer-plugins` first.",
+    );
+  }
+}
+
+export async function initializeRuntimedWasmForNode() {
+  initializedModule ??= (async () => {
+    await assertRuntimedWasmBuildExists();
+    const wasm = await import(runtimedWasmModuleUrl.href);
+    await wasm.default({ module_or_path: await readFile(runtimedWasmBinaryUrl) });
+    return wasm;
+  })().catch((error) => {
+    initializedModule = undefined;
+    throw error;
+  });
+  return initializedModule;
+}
+
+export async function initializeRuntimedWasmSyncForNode() {
+  initializedModule ??= (async () => {
+    await assertRuntimedWasmBuildExists();
+    const wasm = await import(runtimedWasmModuleUrl.href);
+    wasm.initSync({ module: await readFile(runtimedWasmBinaryUrl) });
+    return wasm;
+  })().catch((error) => {
+    initializedModule = undefined;
+    throw error;
+  });
+  return initializedModule;
+}

--- a/apps/notebook-cloud/scripts/smoke.mjs
+++ b/apps/notebook-cloud/scripts/smoke.mjs
@@ -4,17 +4,9 @@ import { FrameType } from "runtimed";
 import { notebookCloudBaseUrl } from "./local-dev.mjs";
 import { openWebSocket } from "./raw-websocket-client.mjs";
 import { credentialedSmokeOrigin } from "./wasm-roundtrip-env.mjs";
+import { initializeRuntimedWasmForNode } from "./runtimed-wasm-artifact.mjs";
 
-const wasmJsPath = new URL(
-  "../../notebook/src/wasm/runtimed-wasm/runtimed_wasm.js",
-  import.meta.url,
-);
-const wasmBinPath = new URL(
-  "../../notebook/src/wasm/runtimed-wasm/runtimed_wasm_bg.wasm",
-  import.meta.url,
-);
-const wasm = await import(wasmJsPath.href);
-await wasm.default({ module_or_path: await readFile(wasmBinPath) });
+const wasm = await initializeRuntimedWasmForNode();
 
 const baseUrl = notebookCloudBaseUrl();
 const devAuthToken = process.env.NOTEBOOK_CLOUD_DEV_TOKEN;

--- a/apps/notebook-cloud/scripts/wasm-roundtrip.mjs
+++ b/apps/notebook-cloud/scripts/wasm-roundtrip.mjs
@@ -1,6 +1,4 @@
-import { access, readFile } from "node:fs/promises";
 import { randomUUID } from "node:crypto";
-import { fileURLToPath } from "node:url";
 import { FrameType } from "runtimed";
 import { notebookCloudBaseUrl } from "./local-dev.mjs";
 import {
@@ -11,20 +9,16 @@ import {
   sendBinaryFrame,
 } from "./raw-websocket-client.mjs";
 import { assertWasmRoundtripAuthEnv, credentialedSmokeOrigin } from "./wasm-roundtrip-env.mjs";
+import {
+  assertRuntimedWasmBuildExists,
+  initializeRuntimedWasmSyncForNode,
+} from "./runtimed-wasm-artifact.mjs";
 
 const baseUrl = notebookCloudBaseUrl();
 const devAuthToken = process.env.NOTEBOOK_CLOUD_DEV_TOKEN;
 const roomId = `wasm-${Date.now()}`;
 const runtimeStateDocId = `runtime-state:${randomUUID()}`;
 const timingsMs = {};
-const wasmJsUrl = new URL(
-  "../../notebook/src/wasm/runtimed-wasm/runtimed_wasm.js",
-  import.meta.url,
-);
-const wasmBytesUrl = new URL(
-  "../../notebook/src/wasm/runtimed-wasm/runtimed_wasm_bg.wasm",
-  import.meta.url,
-);
 
 if (typeof WebSocket === "undefined") {
   throw new Error("This smoke script requires Node.js with a global WebSocket implementation");
@@ -32,11 +26,11 @@ if (typeof WebSocket === "undefined") {
 
 const startedAt = performance.now();
 assertWasmRoundtripAuthEnv({ baseUrl, devAuthToken });
-await assertWasmBuildExists();
+await assertRuntimedWasmBuildExists();
 
-const { initSync, NotebookHandle } = await import(wasmJsUrl.href);
-const wasmBytes = await readFile(wasmBytesUrl);
-await timed("runtimed_wasm_init", () => initSync({ module: wasmBytes }));
+const { NotebookHandle } = await timed("runtimed_wasm_init", () =>
+  initializeRuntimedWasmSyncForNode(),
+);
 
 await timed("owner_seed", () => seedNotebookOwner(roomId));
 await timed("acl_grants", async () => {
@@ -156,17 +150,6 @@ async function timed(name, fn) {
 
 function elapsedMs(started) {
   return Math.max(0, Math.round((performance.now() - started) * 100) / 100);
-}
-
-async function assertWasmBuildExists() {
-  try {
-    await access(fileURLToPath(wasmJsUrl));
-    await access(fileURLToPath(wasmBytesUrl));
-  } catch {
-    throw new Error(
-      "Missing apps/notebook/src/wasm/runtimed-wasm output. Run `cargo xtask wasm runtimed --skip-renderer-plugins` first.",
-    );
-  }
 }
 
 async function seedNotebookOwner(notebookId) {

--- a/apps/notebook-cloud/src/runtimed-wasm.ts
+++ b/apps/notebook-cloud/src/runtimed-wasm.ts
@@ -11,6 +11,9 @@ import initWasm, {
   RuntimeStatePeerHandle,
 } from "../../notebook/src/wasm/runtimed-wasm/runtimed_wasm.js";
 
+export type RuntimedWasmModule =
+  typeof import("../../notebook/src/wasm/runtimed-wasm/runtimed_wasm.js");
+
 let initialized: Promise<void> | undefined;
 
 type RuntimedWasmInitInput = Parameters<typeof initWasm>[0];

--- a/apps/notebook-cloud/test/notebook-room.test.ts
+++ b/apps/notebook-cloud/test/notebook-room.test.ts
@@ -1,6 +1,5 @@
 import { before, describe, it } from "node:test";
 import assert from "node:assert/strict";
-import { readFile } from "node:fs/promises";
 import type { CloudflareWebSocket, DurableObjectState, Env } from "../src/cloudflare-types.ts";
 import {
   NOTEBOOK_CLOUD_WEBSOCKET_PROTOCOL,
@@ -26,19 +25,12 @@ import {
   encodeTypedFrame,
   splitTypedFrame,
 } from "../src/protocol.ts";
-import {
-  decodePresenceFrame,
-  encodePresenceFrame,
-  initializeRuntimedWasm,
-} from "../src/runtimed-wasm.ts";
+import { decodePresenceFrame, encodePresenceFrame } from "../src/runtimed-wasm.ts";
 import type { RoomHostFrameResult } from "../src/room-materializer.ts";
-
-const wasmBytes = await readFile(
-  new URL("../../notebook/src/wasm/runtimed-wasm/runtimed_wasm_bg.wasm", import.meta.url),
-);
+import { initializeTestRuntimedWasm } from "./runtimed-wasm-test-loader.ts";
 
 before(async () => {
-  await initializeRuntimedWasm(wasmBytes);
+  await initializeTestRuntimedWasm();
 });
 
 describe("NotebookRoom presence rewrite", () => {

--- a/apps/notebook-cloud/test/room-materializer.test.ts
+++ b/apps/notebook-cloud/test/room-materializer.test.ts
@@ -1,6 +1,5 @@
 import { before, describe, it } from "node:test";
 import assert from "node:assert/strict";
-import { readFile } from "node:fs/promises";
 import type {
   D1Database,
   D1PreparedStatement,
@@ -18,18 +17,14 @@ import { FrameType, encodeTypedFrame, type FrameTypeValue } from "../src/protoco
 import { RoomMaterializer } from "../src/room-materializer.ts";
 import {
   createEmptyRoomHost,
-  initializeRuntimedWasm,
   loadRoomHostSnapshot,
   NotebookHandle,
   RuntimeStatePeerHandle,
 } from "../src/runtimed-wasm.ts";
-
-const wasmBytes = await readFile(
-  new URL("../../notebook/src/wasm/runtimed-wasm/runtimed_wasm_bg.wasm", import.meta.url),
-);
+import { initializeTestRuntimedWasm } from "./runtimed-wasm-test-loader.ts";
 
 before(async () => {
-  await initializeRuntimedWasm(wasmBytes);
+  await initializeTestRuntimedWasm();
 });
 
 type TestConnectionScope = "viewer" | "editor" | "runtime_peer" | "owner";

--- a/apps/notebook-cloud/test/runtimed-wasm-test-loader.ts
+++ b/apps/notebook-cloud/test/runtimed-wasm-test-loader.ts
@@ -1,0 +1,23 @@
+import { readFile } from "node:fs/promises";
+import { initializeRuntimedWasm } from "../src/runtimed-wasm.ts";
+
+const runtimedWasmBinaryUrl = new URL(
+  "../../notebook/src/wasm/runtimed-wasm/runtimed_wasm_bg.wasm",
+  import.meta.url,
+);
+
+let initialized: Promise<void> | undefined;
+
+export function initializeTestRuntimedWasm(): Promise<void> {
+  initialized ??= readTestRuntimedWasmBytes()
+    .then((wasmBytes) => initializeRuntimedWasm(wasmBytes))
+    .catch((error: unknown) => {
+      initialized = undefined;
+      throw error;
+    });
+  return initialized;
+}
+
+export function readTestRuntimedWasmBytes(): Promise<Uint8Array> {
+  return readFile(runtimedWasmBinaryUrl);
+}

--- a/apps/notebook-cloud/test/snapshot-render.test.ts
+++ b/apps/notebook-cloud/test/snapshot-render.test.ts
@@ -1,20 +1,18 @@
 import { before, describe, it } from "node:test";
 import assert from "node:assert/strict";
 import { readFile } from "node:fs/promises";
-import { initializeRuntimedWasm, RuntimeStatePeerHandle } from "../src/runtimed-wasm.ts";
+import { RuntimeStatePeerHandle } from "../src/runtimed-wasm.ts";
 import { materializeSnapshotPairRender } from "../src/snapshot-render.ts";
 import {
   createNotebookCloudBlobResolver,
   notebookCloudBlobBasePath,
 } from "../src/blob-resolver.ts";
+import { initializeTestRuntimedWasm } from "./runtimed-wasm-test-loader.ts";
 
-const wasmBytes = await readFile(
-  new URL("../../notebook/src/wasm/runtimed-wasm/runtimed_wasm_bg.wasm", import.meta.url),
-);
 const ARROW_STREAM_MANIFEST_MIME = "application/vnd.nteract.arrow-stream-manifest+json";
 
 before(async () => {
-  await initializeRuntimedWasm(wasmBytes);
+  await initializeTestRuntimedWasm();
 });
 
 describe("snapshot pair render materialization", () => {

--- a/apps/notebook-cloud/test/worker-routes.test.ts
+++ b/apps/notebook-cloud/test/worker-routes.test.ts
@@ -29,7 +29,7 @@ import type {
   R2ObjectBody,
   R2PutOptions,
 } from "../src/cloudflare-types.ts";
-import { initializeRuntimedWasm, RuntimeStatePeerHandle } from "../src/runtimed-wasm.ts";
+import { RuntimeStatePeerHandle } from "../src/runtimed-wasm.ts";
 import {
   WORKSTATION_ATTACH_JOB_STALE_MS,
   blobKey,
@@ -49,14 +49,12 @@ import type {
 } from "../src/workstation-credentials.ts";
 import { workstationEventsObjectName } from "../src/workstation-events.ts";
 import { oidcTokenFixture } from "./oidc-jwt-fixture.ts";
+import { initializeTestRuntimedWasm } from "./runtimed-wasm-test-loader.ts";
 
-const wasmBytes = await readFile(
-  new URL("../../notebook/src/wasm/runtimed-wasm/runtimed_wasm_bg.wasm", import.meta.url),
-);
 const APP_SESSION_SECRET = "0123456789abcdef0123456789abcdef";
 
 before(async () => {
-  await initializeRuntimedWasm(wasmBytes);
+  await initializeTestRuntimedWasm();
 });
 
 describe("Worker artifact routes", () => {

--- a/apps/notebook-cloud/viewer/runtimed-wasm-client.ts
+++ b/apps/notebook-cloud/viewer/runtimed-wasm-client.ts
@@ -3,13 +3,12 @@ import {
   type NotebookInteractionTarget,
 } from "runtimed";
 import { setMarkdownProjectionProjector } from "../../../src/lib/markdown-projection";
-import type { NotebookHandle } from "../../notebook/src/wasm/runtimed-wasm/runtimed_wasm.js";
+import type { NotebookHandle, RuntimedWasmModule } from "../src/runtimed-wasm.ts";
 import {
   asRuntimedWasmAssetFailure,
   RUNTIMED_WASM_ASSET_FAILURE_PREFIX,
 } from "./runtimed-wasm-failure";
 
-type RuntimedWasmModule = typeof import("../../notebook/src/wasm/runtimed-wasm/runtimed_wasm.js");
 type WasmModuleOrPath = string | URL | Request | Response | ArrayBuffer | WebAssembly.Module;
 
 let loadedModule: Promise<RuntimedWasmModule> | undefined;

--- a/crates/runtimed-wasm/tests/cross_impl_test.ts
+++ b/crates/runtimed-wasm/tests/cross_impl_test.ts
@@ -27,25 +27,10 @@ import {
   assertExists,
   assert,
 } from "https://deno.land/std@0.224.0/assert/mod.ts";
+import { loadRuntimedWasm } from "./wasm_loader.ts";
 
 // deno-lint-ignore no-explicit-any
-let init: any, NotebookHandle: any;
-
-const wasmJsPath = new URL(
-  "../../../apps/notebook/src/wasm/runtimed-wasm/runtimed_wasm.js",
-  import.meta.url,
-);
-const wasmBinPath = new URL(
-  "../../../apps/notebook/src/wasm/runtimed-wasm/runtimed_wasm_bg.wasm",
-  import.meta.url,
-);
-
-const mod = await import(wasmJsPath.href);
-init = mod.default;
-NotebookHandle = mod.NotebookHandle;
-
-const wasmBytes = await Deno.readFile(wasmBinPath);
-await init({ module_or_path: wasmBytes });
+const { NotebookHandle }: any = await loadRuntimedWasm();
 
 // ── Helpers ──────────────────────────────────────────────────────────
 

--- a/crates/runtimed-wasm/tests/deno_smoke_test.ts
+++ b/crates/runtimed-wasm/tests/deno_smoke_test.ts
@@ -19,28 +19,12 @@ import {
   assertEquals,
   assertExists,
 } from "https://deno.land/std@0.224.0/assert/mod.ts";
+import { loadRuntimedWasm } from "./wasm_loader.ts";
 
 // @ts-nocheck — wasm-bindgen output doesn't have Deno-compatible type declarations
 
-// Import the WASM module
 // deno-lint-ignore no-explicit-any
-let init: any, NotebookHandle: any;
-
-const wasmJsPath = new URL(
-  "../../../apps/notebook/src/wasm/runtimed-wasm/runtimed_wasm.js",
-  import.meta.url,
-);
-const wasmBinPath = new URL(
-  "../../../apps/notebook/src/wasm/runtimed-wasm/runtimed_wasm_bg.wasm",
-  import.meta.url,
-);
-
-const mod = await import(wasmJsPath.href);
-init = mod.default;
-NotebookHandle = mod.NotebookHandle;
-
-const wasmBytes = await Deno.readFile(wasmBinPath);
-await init({ module_or_path: wasmBytes });
+const { NotebookHandle }: any = await loadRuntimedWasm();
 
 // ── Helpers ──────────────────────────────────────────────────────────
 

--- a/crates/runtimed-wasm/tests/presence_test.ts
+++ b/crates/runtimed-wasm/tests/presence_test.ts
@@ -9,21 +9,11 @@ import {
   assertEquals,
   assertThrows,
 } from "https://deno.land/std@0.224.0/assert/mod.ts";
+import { loadRuntimedWasm } from "./wasm_loader.ts";
 
 // @ts-nocheck - wasm-bindgen output is browser-shaped, but Deno can run it.
 
-const wasmJsPath = new URL(
-  "../../../apps/notebook/src/wasm/runtimed-wasm/runtimed_wasm.js",
-  import.meta.url,
-);
-const wasmBinPath = new URL(
-  "../../../apps/notebook/src/wasm/runtimed-wasm/runtimed_wasm_bg.wasm",
-  import.meta.url,
-);
-
-const mod = await import(wasmJsPath.href);
-const wasmBytes = await Deno.readFile(wasmBinPath);
-await mod.default({ module_or_path: wasmBytes });
+const mod = await loadRuntimedWasm();
 
 Deno.test("Presence: standalone decoder reads real cursor CBOR", () => {
   const payload = mod.encode_cursor_presence(

--- a/crates/runtimed-wasm/tests/save_since_apply_test.ts
+++ b/crates/runtimed-wasm/tests/save_since_apply_test.ts
@@ -8,26 +8,12 @@
  */
 
 import { assert, assertEquals } from "https://deno.land/std@0.224.0/assert/mod.ts";
+import { loadRuntimedWasm } from "./wasm_loader.ts";
 
 // @ts-nocheck — wasm-bindgen output doesn't have Deno-compatible type declarations
 
 // deno-lint-ignore no-explicit-any
-let NotebookHandle: any;
-
-const wasmJsPath = new URL(
-  "../../../apps/notebook/src/wasm/runtimed-wasm/runtimed_wasm.js",
-  import.meta.url,
-);
-const wasmBinPath = new URL(
-  "../../../apps/notebook/src/wasm/runtimed-wasm/runtimed_wasm_bg.wasm",
-  import.meta.url,
-);
-
-const mod = await import(wasmJsPath.href);
-NotebookHandle = mod.NotebookHandle;
-
-const wasmBytes = await Deno.readFile(wasmBinPath);
-await mod.default({ module_or_path: wasmBytes });
+const { NotebookHandle }: any = await loadRuntimedWasm();
 
 function concat(...parts: Uint8Array[]): Uint8Array {
   const total = parts.reduce((sum, part) => sum + part.byteLength, 0);

--- a/crates/runtimed-wasm/tests/snapshot_test.ts
+++ b/crates/runtimed-wasm/tests/snapshot_test.ts
@@ -10,26 +10,11 @@ import {
   assertExists,
   assertThrows,
 } from "https://deno.land/std@0.224.0/assert/mod.ts";
+import { loadRuntimedWasm } from "./wasm_loader.ts";
 
 // deno-lint-ignore no-explicit-any
-let init: any, NotebookHandle: any;
-
-const wasmJsPath = new URL(
-  "../../../apps/notebook/src/wasm/runtimed-wasm/runtimed_wasm.js",
-  import.meta.url,
-);
-const wasmBinPath = new URL(
-  "../../../apps/notebook/src/wasm/runtimed-wasm/runtimed_wasm_bg.wasm",
-  import.meta.url,
-);
+const { NotebookHandle }: any = await loadRuntimedWasm();
 const fixturesDir = new URL("../../../packages/runtimed/tests/fixtures/", import.meta.url);
-
-const mod = await import(wasmJsPath.href);
-init = mod.default;
-NotebookHandle = mod.NotebookHandle;
-
-const wasmBytes = await Deno.readFile(wasmBinPath);
-await init({ module_or_path: wasmBytes });
 
 async function readFixtureBytes(scenario: string, name: string): Promise<Uint8Array> {
   return await Deno.readFile(new URL(`${scenario}/${name}`, fixturesDir));

--- a/crates/runtimed-wasm/tests/splice_source_test.ts
+++ b/crates/runtimed-wasm/tests/splice_source_test.ts
@@ -30,27 +30,12 @@ import {
   assertEquals,
   assertExists,
 } from "https://deno.land/std@0.224.0/assert/mod.ts";
+import { loadRuntimedWasm } from "./wasm_loader.ts";
 
 // @ts-nocheck — wasm-bindgen output doesn't have Deno-compatible type declarations
 
 // deno-lint-ignore no-explicit-any
-let init: any, NotebookHandle: any;
-
-const wasmJsPath = new URL(
-  "../../../apps/notebook/src/wasm/runtimed-wasm/runtimed_wasm.js",
-  import.meta.url,
-);
-const wasmBinPath = new URL(
-  "../../../apps/notebook/src/wasm/runtimed-wasm/runtimed_wasm_bg.wasm",
-  import.meta.url,
-);
-
-const mod = await import(wasmJsPath.href);
-init = mod.default;
-NotebookHandle = mod.NotebookHandle;
-
-const wasmBytes = await Deno.readFile(wasmBinPath);
-await init({ module_or_path: wasmBytes });
+const { NotebookHandle }: any = await loadRuntimedWasm();
 
 // ── Helpers ──────────────────────────────────────────────────────────
 

--- a/crates/runtimed-wasm/tests/wasm_loader.ts
+++ b/crates/runtimed-wasm/tests/wasm_loader.ts
@@ -1,0 +1,25 @@
+// deno-lint-ignore-file no-explicit-any
+
+const wasmJsPath = new URL(
+  "../../../apps/notebook/src/wasm/runtimed-wasm/runtimed_wasm.js",
+  import.meta.url,
+);
+const wasmBinPath = new URL(
+  "../../../apps/notebook/src/wasm/runtimed-wasm/runtimed_wasm_bg.wasm",
+  import.meta.url,
+);
+
+let wasmModuleReady: Promise<any> | undefined;
+
+export function loadRuntimedWasm(): Promise<any> {
+  wasmModuleReady ??= (async () => {
+    const mod = await import(wasmJsPath.href);
+    const wasmBytes = await Deno.readFile(wasmBinPath);
+    await mod.default({ module_or_path: wasmBytes });
+    return mod;
+  })().catch((error: unknown) => {
+    wasmModuleReady = undefined;
+    throw error;
+  });
+  return wasmModuleReady;
+}

--- a/packages/runtimed/tests/fixture-integration.test.ts
+++ b/packages/runtimed/tests/fixture-integration.test.ts
@@ -22,11 +22,10 @@ import { existsSync, readFileSync } from "node:fs";
 import { resolve } from "node:path";
 import { VirtualAction, VirtualTimeScheduler } from "rxjs";
 import { describe, expect, it } from "vite-plus/test";
-import type { NotebookHandle } from "../../../apps/notebook/src/wasm/runtimed-wasm/runtimed_wasm";
 import { DirectTransport, type ServerHandle } from "../src/direct-transport";
 import type { ExecutionViewChangeset, SyncableHandle } from "../src/handle";
 import { SyncEngine } from "../src/sync-engine";
-import { initWasm } from "./wasm-harness";
+import { initWasm, type NotebookHandle } from "./wasm-harness";
 
 // ── Fixture loading ──────────────────────────────────────────────────
 

--- a/packages/runtimed/tests/notebook-tab-bridge.test.ts
+++ b/packages/runtimed/tests/notebook-tab-bridge.test.ts
@@ -9,7 +9,6 @@
 
 import { Subject } from "rxjs";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vite-plus/test";
-import type { NotebookHandle } from "../../../apps/notebook/src/wasm/runtimed-wasm/runtimed_wasm";
 import type { SyncableHandle } from "../src/handle";
 import {
   NotebookTabBridge,
@@ -19,7 +18,7 @@ import {
 } from "../src/notebook-tab-bridge";
 import { SyncEngine } from "../src/sync-engine";
 import type { NotebookTransport } from "../src/transport";
-import { initWasm } from "./wasm-harness";
+import { initWasm, type NotebookHandle } from "./wasm-harness";
 
 // ── In-memory channel bus (deterministic, no realm hops) ─────────────
 

--- a/packages/runtimed/tests/wasm-harness.ts
+++ b/packages/runtimed/tests/wasm-harness.ts
@@ -16,20 +16,24 @@
 import { readFileSync } from "node:fs";
 import { resolve } from "node:path";
 import { VirtualAction, VirtualTimeScheduler } from "rxjs";
-import type { NotebookHandle } from "../../../apps/notebook/src/wasm/runtimed-wasm/runtimed_wasm";
 import { DirectTransport, type ServerHandle } from "../src/direct-transport";
 import type { SyncableHandle } from "../src/handle";
 import { SyncEngine } from "../src/sync-engine";
 
 // ── WASM initialization ──────────────────────────────────────────────
 
+type RuntimedWasmModule =
+  typeof import("../../../apps/notebook/src/wasm/runtimed-wasm/runtimed_wasm");
+type NotebookHandleConstructor = RuntimedWasmModule["NotebookHandle"];
+export type NotebookHandle = InstanceType<NotebookHandleConstructor>;
+
 let wasmInitialized = false;
-let WasmNotebookHandle: typeof NotebookHandle;
+let WasmNotebookHandle: NotebookHandleConstructor;
 
 /**
  * Load and initialize the WASM module once. Subsequent calls are no-ops.
  */
-export async function initWasm(): Promise<typeof NotebookHandle> {
+export async function initWasm(): Promise<NotebookHandleConstructor> {
   if (wasmInitialized) return WasmNotebookHandle;
 
   const wasmPath = resolve(
@@ -47,7 +51,7 @@ export async function initWasm(): Promise<typeof NotebookHandle> {
     wasmBuffer.byteOffset,
     wasmBuffer.byteOffset + wasmBuffer.byteLength,
   );
-  const mod = await import(jsPath);
+  const mod = (await import(jsPath)) as RuntimedWasmModule;
   mod.initSync({ module: new Uint8Array(wasmBytes) });
 
   wasmInitialized = true;

--- a/src/components/outputs/__tests__/media-router.test.tsx
+++ b/src/components/outputs/__tests__/media-router.test.tsx
@@ -7,16 +7,12 @@
  */
 
 import { render, screen, waitFor } from "@testing-library/react";
-import { readFileSync } from "node:fs";
-import { join } from "node:path";
 import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vite-plus/test";
-import initMarkdownWasm, {
-  project_markdown_json,
-} from "../../../../apps/notebook/src/wasm/runtimed-wasm/runtimed_wasm.js";
 import {
   MARKDOWN_PROJECTION_MIME_TYPE,
   setMarkdownProjectionProjector,
 } from "@/lib/markdown-projection";
+import { initializeMarkdownProjectionWasm } from "@/test/runtimed-wasm";
 import { MediaProvider } from "../media-provider";
 import { DEFAULT_PRIORITY, getSelectedMimeType, MediaRouter } from "../media-router";
 
@@ -24,16 +20,7 @@ let restoreMarkdownProjector: (() => void) | undefined;
 const originalMatchMedia = Object.getOwnPropertyDescriptor(window, "matchMedia");
 
 beforeAll(async () => {
-  const wasmBytes = readFileSync(
-    join(process.cwd(), "apps/notebook/src/wasm/runtimed-wasm/runtimed_wasm_bg.wasm"),
-  );
-  await initMarkdownWasm({
-    module_or_path: wasmBytes.buffer.slice(
-      wasmBytes.byteOffset,
-      wasmBytes.byteOffset + wasmBytes.byteLength,
-    ),
-  });
-  setMarkdownProjectionProjector(project_markdown_json);
+  await initializeMarkdownProjectionWasm();
 });
 
 function withMarkdownProjection({

--- a/src/lib/__tests__/markdown-projection.test.ts
+++ b/src/lib/__tests__/markdown-projection.test.ts
@@ -1,9 +1,7 @@
-import initMarkdownWasm, {
-  project_markdown_json,
-} from "../../../apps/notebook/src/wasm/runtimed-wasm/runtimed_wasm.js";
 import { readFileSync } from "node:fs";
 import { join } from "node:path";
 import { beforeAll, describe, expect, it } from "vite-plus/test";
+import { initializeMarkdownProjectionWasm } from "../../test/runtimed-wasm";
 import {
   canRenderMarkdownProjectionInHost,
   findMarkdownProjectionAtSourcePosition,
@@ -54,16 +52,7 @@ function testPlan(runs: readonly MarkdownProjectionRun[]): MarkdownProjectionPla
 
 describe("markdown projection", () => {
   beforeAll(async () => {
-    const wasmBytes = readFileSync(
-      join(process.cwd(), "apps/notebook/src/wasm/runtimed-wasm/runtimed_wasm_bg.wasm"),
-    );
-    await initMarkdownWasm({
-      module_or_path: wasmBytes.buffer.slice(
-        wasmBytes.byteOffset,
-        wasmBytes.byteOffset + wasmBytes.byteLength,
-      ),
-    });
-    setMarkdownProjectionProjector(project_markdown_json);
+    await initializeMarkdownProjectionWasm();
   });
 
   it("projects GFM task state from literal markdown source", () => {

--- a/src/test/runtimed-wasm.ts
+++ b/src/test/runtimed-wasm.ts
@@ -1,0 +1,31 @@
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import { setMarkdownProjectionProjector } from "@/lib/markdown-projection";
+import initRuntimedWasm, {
+  project_markdown_json,
+} from "../../apps/notebook/src/wasm/runtimed-wasm/runtimed_wasm.js";
+
+let markdownProjectionWasmReady: Promise<void> | undefined;
+
+export function initializeMarkdownProjectionWasm(): Promise<void> {
+  markdownProjectionWasmReady ??= Promise.resolve()
+    .then(async () => {
+      const wasmBytes = readFileSync(runtimedWasmBinaryPath());
+      await initRuntimedWasm({
+        module_or_path: wasmBytes.buffer.slice(
+          wasmBytes.byteOffset,
+          wasmBytes.byteOffset + wasmBytes.byteLength,
+        ),
+      });
+      setMarkdownProjectionProjector(project_markdown_json);
+    })
+    .catch((error: unknown) => {
+      markdownProjectionWasmReady = undefined;
+      throw error;
+    });
+  return markdownProjectionWasmReady;
+}
+
+function runtimedWasmBinaryPath(): string {
+  return join(process.cwd(), "apps/notebook/src/wasm/runtimed-wasm/runtimed_wasm_bg.wasm");
+}


### PR DESCRIPTION
## Summary
- Add named helpers for loading the app-owned generated runtimed WASM artifact in cloud scripts, cloud Node tests, Deno WASM tests, and shared Vitest tests.
- Replace repeated ad hoc generated-artifact paths with those helpers.
- Keep the current artifact ownership in place while reducing the number of call sites that know the app-local generated path.

## Verification
- `node -e 'import("./apps/notebook-cloud/scripts/runtimed-wasm-artifact.mjs").then(async (m) => { const asyncMod = await m.initializeRuntimedWasmForNode(); const syncMod = await m.initializeRuntimedWasmSyncForNode(); console.log(Boolean(asyncMod.NotebookHandle), asyncMod === syncMod); })'`\n- `pnpm test:run src/lib/__tests__/markdown-projection.test.ts src/components/outputs/__tests__/media-router.test.tsx packages/runtimed/tests/fixture-integration.test.ts packages/runtimed/tests/notebook-tab-bridge.test.ts`\n- `pnpm --dir apps/notebook-cloud exec node --import tsx --test test/notebook-room.test.ts test/room-materializer.test.ts test/snapshot-render.test.ts test/worker-routes.test.ts`\n- `pnpm --dir apps/notebook-cloud typecheck`\n- `cargo test -p runtimed-wasm`\n- `cargo xtask lint --fix`\n- `git diff --check`