### PR TITLE
fix(settings): ignore stale synced settings callbacks

### DIFF
--- a/src/hooks/__tests__/useSyncedSettings.test.tsx
+++ b/src/hooks/__tests__/useSyncedSettings.test.tsx
@@ -1,0 +1,104 @@
+import { act, renderHook, waitFor } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vite-plus/test";
+import { useSyncedSettings } from "../useSyncedSettings";
+
+const mocks = vi.hoisted(() => ({
+  invoke: vi.fn(),
+  listen: vi.fn(),
+}));
+
+vi.mock("@tauri-apps/api/core", () => ({
+  invoke: mocks.invoke,
+}));
+
+vi.mock("@tauri-apps/api/event", () => ({
+  listen: mocks.listen,
+}));
+
+type Deferred<T> = {
+  promise: Promise<T>;
+  resolve: (value: T) => void;
+  reject: (reason?: unknown) => void;
+};
+
+function deferred<T>(): Deferred<T> {
+  let resolve!: (value: T) => void;
+  let reject!: (reason?: unknown) => void;
+  const promise = new Promise<T>((res, rej) => {
+    resolve = res;
+    reject = rej;
+  });
+  return { promise, resolve, reject };
+}
+
+describe("useSyncedSettings", () => {
+  beforeEach(() => {
+    Object.defineProperty(window, "__TAURI_INTERNALS__", {
+      configurable: true,
+      value: {},
+    });
+    localStorage.clear();
+    mocks.invoke.mockReset();
+    mocks.listen.mockReset();
+    mocks.listen.mockResolvedValue(() => {});
+  });
+
+  afterEach(() => {
+    delete (window as Partial<Window> & { __TAURI_INTERNALS__?: unknown }).__TAURI_INTERNALS__;
+    localStorage.clear();
+  });
+
+  it("ignores initial daemon settings that resolve after unmount", async () => {
+    const load = deferred<unknown>();
+    mocks.invoke.mockReturnValue(load.promise);
+
+    const { unmount } = renderHook(() => useSyncedSettings());
+
+    await waitFor(() => {
+      expect(mocks.invoke).toHaveBeenCalledWith("get_synced_settings", undefined);
+    });
+
+    unmount();
+
+    await act(async () => {
+      load.resolve({ color_theme: "cream", theme: "dark" });
+      await load.promise;
+    });
+
+    expect(localStorage.getItem("notebook-theme")).toBeNull();
+    expect(localStorage.getItem("notebook-color-theme")).toBeNull();
+  });
+
+  it("ignores settings events after unmount while listener teardown is pending", async () => {
+    const listenReady = deferred<() => void>();
+    const unlisten = vi.fn();
+    let handler: ((event: { payload: unknown }) => void) | undefined;
+    mocks.invoke.mockResolvedValue({});
+    mocks.listen.mockImplementation((_eventName, eventHandler) => {
+      handler = eventHandler;
+      return listenReady.promise;
+    });
+
+    const { unmount } = renderHook(() => useSyncedSettings());
+
+    await waitFor(() => {
+      expect(mocks.listen).toHaveBeenCalledWith("settings:changed", expect.any(Function));
+    });
+
+    unmount();
+
+    act(() => {
+      handler?.({ payload: { color_theme: "cream", theme: "dark" } });
+    });
+
+    expect(localStorage.getItem("notebook-theme")).toBeNull();
+    expect(localStorage.getItem("notebook-color-theme")).toBeNull();
+
+    await act(async () => {
+      listenReady.resolve(unlisten);
+      await listenReady.promise;
+    });
+
+    expect(unlisten).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/hooks/useSyncedSettings.ts
+++ b/src/hooks/useSyncedSettings.ts
@@ -206,8 +206,12 @@ export function useSyncedSettings() {
 
   // Load initial settings from daemon
   useEffect(() => {
+    let active = true;
+
     invokeTauri<SyncedSettings>("get_synced_settings")
       .then((settings) => {
+        if (!active) return;
+
         if (isValidTheme(settings.theme)) {
           setThemeState(settings.theme);
           setStoredTheme(settings.theme);
@@ -269,11 +273,19 @@ export function useSyncedSettings() {
       .catch(() => {
         // Daemon unavailable — defaults are fine
       });
+
+    return () => {
+      active = false;
+    };
   }, []);
 
   // Listen for cross-window settings changes via Tauri events
   useEffect(() => {
+    let active = true;
+
     const unlisten = listenTauri<SyncedSettings>("settings:changed", (event) => {
+      if (!active) return;
+
       const {
         theme: newTheme,
         color_theme: newColorTheme,
@@ -332,6 +344,7 @@ export function useSyncedSettings() {
       // Last-ping timestamps change rarely; we only refresh them on mount.
     });
     return () => {
+      active = false;
       unlisten.then((u) => u());
     };
   }, []);


### PR DESCRIPTION
## Summary
- Guard the initial synced-settings load against applying daemon results after the hook unmounts.
- Guard the cross-window settings event handler while listener teardown is still pending.
- Add hook tests for both stale callback paths.

## Verification
- `pnpm test:run src/hooks/__tests__/useSyncedSettings.test.tsx`
- `cargo xtask lint --fix`
- `pnpm --dir apps/notebook build`
- `git diff --check`