### PR TITLE
refactor(elements): converge catalog on shared Eyebrow and SurfaceFrame primitives

### DIFF
--- a/apps/elements/components/cloud-dashboard-example.tsx
+++ b/apps/elements/components/cloud-dashboard-example.tsx
@@ -16,6 +16,7 @@ import {
   type LucideIcon,
 } from "lucide-react";
 import { cn } from "@/lib/utils";
+import { Eyebrow } from "@/components/surface-primitives";
 
 type NotebookAccess = "owner" | "editor" | "viewer";
 type ShareState = "private" | "shared" | "published";
@@ -184,10 +185,10 @@ function DashboardReviewFrame() {
     <div className="min-h-[48rem] bg-fd-background text-fd-foreground">
       <header className="flex flex-col gap-4 border-b border-fd-border px-4 py-4 md:flex-row md:items-end md:justify-between md:px-6">
         <div className="min-w-0">
-          <div className="flex items-center gap-2 text-xs font-medium uppercase tracking-normal text-fd-muted-foreground">
+          <Eyebrow className="flex items-center gap-2">
             <Command className="size-3.5" aria-hidden="true" />
             Notebook home
-          </div>
+          </Eyebrow>
           <h2 className="mt-2 text-2xl font-semibold tracking-normal md:text-3xl">
             Find a notebook
           </h2>
@@ -259,10 +260,10 @@ function DashboardReviewFrame() {
 
         <aside className="grid content-start gap-4">
           <section className="rounded-lg border border-fd-border p-4">
-            <div className="flex items-center gap-2 text-xs font-medium uppercase tracking-normal text-fd-muted-foreground">
+            <Eyebrow className="flex items-center gap-2">
               <Server className="size-3.5" aria-hidden="true" />
               Workstation context
-            </div>
+            </Eyebrow>
             <h3 className="mt-2 text-base font-semibold">Default workstation</h3>
             <p className="mt-2 text-sm leading-6 text-fd-muted-foreground">
               Host-owned readiness only. Run, restart, and interrupt controls stay inside the opened
@@ -270,10 +271,10 @@ function DashboardReviewFrame() {
             </p>
           </section>
           <section className="rounded-lg border border-fd-border p-4">
-            <div className="flex items-center gap-2 text-xs font-medium uppercase tracking-normal text-fd-muted-foreground">
+            <Eyebrow className="flex items-center gap-2">
               <Share2 className="size-3.5" aria-hidden="true" />
               Sharing metadata
-            </div>
+            </Eyebrow>
             <p className="mt-2 text-sm leading-6 text-fd-muted-foreground">
               Safe counts for inventory scan. Preview content comes only from explicit published
               revisions.
@@ -320,9 +321,7 @@ function FilterChip({
         active && "border-fd-foreground",
       )}
     >
-      <span className="text-xs font-medium uppercase tracking-normal text-fd-muted-foreground">
-        {label}
-      </span>
+      <Eyebrow>{label}</Eyebrow>
       <strong className="text-xl font-semibold leading-none tracking-normal">{value}</strong>
     </button>
   );

--- a/apps/elements/components/cloud-notebook-shell-example.tsx
+++ b/apps/elements/components/cloud-notebook-shell-example.tsx
@@ -53,6 +53,7 @@ import {
   getElementsNotebookScenario,
   type ElementsNotebookScenario,
 } from "@/components/notebook-scenarios";
+import { Eyebrow } from "@/components/surface-primitives";
 import { CodeCellCurrentLine } from "@/components/cell/CodeCellCurrentLine";
 
 type CloudConnectionState = "live" | "reconnecting" | "offline";
@@ -872,9 +873,7 @@ function CloudWorkstationSurface() {
 function WorkstationMetric({ label, value }: { label: string; value: string }) {
   return (
     <div className="min-w-0 rounded-md border border-emerald-500/20 bg-background/70 px-2 py-1.5">
-      <div className="truncate text-[10px] font-medium uppercase tracking-normal text-muted-foreground">
-        {label}
-      </div>
+      <Eyebrow className="truncate">{label}</Eyebrow>
       <div className="truncate text-xs font-semibold text-foreground">{value}</div>
     </div>
   );
@@ -971,9 +970,7 @@ function CloudEntrySurface() {
       </div>
       <div className="grid gap-4 p-4 lg:grid-cols-[minmax(0,1fr)_minmax(17rem,0.85fr)]">
         <div className="grid content-start gap-3">
-          <p className="m-0 text-xs font-semibold uppercase tracking-normal text-muted-foreground">
-            Notebook cloud
-          </p>
+          <Eyebrow as="p">Notebook cloud</Eyebrow>
           <h3 className="m-0 max-w-[12ch] text-4xl font-bold leading-none text-foreground">
             nteract
           </h3>
@@ -1061,9 +1058,7 @@ function CloudAuthHandoffSurface() {
 
       <div className="grid gap-4 p-4 lg:grid-cols-[minmax(0,1fr)_minmax(18rem,0.9fr)]">
         <div className="grid content-start gap-3">
-          <p className="m-0 text-xs font-semibold uppercase tracking-normal text-muted-foreground">
-            Cloud sign-in
-          </p>
+          <Eyebrow as="p">Cloud sign-in</Eyebrow>
           <h3 className="m-0 max-w-[18ch] text-4xl font-bold leading-none text-foreground">
             Returning to the notebook.
           </h3>
@@ -1284,9 +1279,7 @@ function CloudSharePanel({ variant }: { variant: CloudSharePanelVariant }) {
 
       <section className="border-t border-border/70 px-4 py-3" aria-label="Current access">
         <div className="mb-2 flex items-center justify-between gap-2">
-          <h4 className="text-xs font-semibold uppercase tracking-[0.12em] text-muted-foreground">
-            Current access
-          </h4>
+          <Eyebrow as="h4">Current access</Eyebrow>
           <span className="text-xs text-muted-foreground">2 people, public link, 1 invite</span>
         </div>
         <div className="divide-y divide-border/70">
@@ -1413,9 +1406,7 @@ function CloudAccessPathways() {
   return (
     <section className="border-t border-fd-border px-4 py-3" aria-label="Cloud access pathways">
       <div className="mb-2 flex flex-wrap items-center justify-between gap-2">
-        <h3 className="text-xs font-semibold uppercase tracking-[0.12em] text-muted-foreground">
-          What each role sees
-        </h3>
+        <Eyebrow as="h3">What each role sees</Eyebrow>
         <span className="text-xs text-muted-foreground">
           sharing appears only where the role can act
         </span>

--- a/apps/elements/components/compute-placement-example.tsx
+++ b/apps/elements/components/compute-placement-example.tsx
@@ -19,6 +19,7 @@ import {
 import { useState } from "react";
 import type { ReactNode } from "react";
 import { cn } from "@/lib/utils";
+import { Eyebrow } from "@/components/surface-primitives";
 
 type ComputePlacementId = "rail" | "environment" | "launcher";
 
@@ -230,15 +231,9 @@ function ComputeSourceBoundaryTable() {
     <section className="border-y border-fd-border" aria-label="Compute source boundaries">
       <div className="grid gap-2 border-b border-fd-border py-3 md:grid-cols-[minmax(10rem,0.24fr)_minmax(0,1fr)_minmax(8rem,0.18fr)_minmax(10rem,0.22fr)]">
         <h2 className="text-sm font-semibold">Compute source boundaries</h2>
-        <div className="hidden text-[10px] font-semibold uppercase tracking-normal text-fd-muted-foreground md:block">
-          Runtime boundary
-        </div>
-        <div className="hidden text-[10px] font-semibold uppercase tracking-normal text-fd-muted-foreground md:block">
-          Security
-        </div>
-        <div className="hidden text-[10px] font-semibold uppercase tracking-normal text-fd-muted-foreground md:block">
-          Protocol
-        </div>
+        <Eyebrow className="hidden md:block">Runtime boundary</Eyebrow>
+        <Eyebrow className="hidden md:block">Security</Eyebrow>
+        <Eyebrow className="hidden md:block">Protocol</Eyebrow>
       </div>
       <div className="divide-y divide-fd-border">
         {computeSourceGroups.map((group) => (
@@ -267,9 +262,7 @@ function ComputeSourceBoundaryRow({ group }: { group: (typeof computeSourceGroup
 function BoundaryFact({ label, value }: { label: string; value: string }) {
   return (
     <div className="min-w-0 text-xs">
-      <div className="font-semibold uppercase tracking-normal text-fd-muted-foreground md:hidden">
-        {label}
-      </div>
+      <Eyebrow className="md:hidden">{label}</Eyebrow>
       <div className="truncate text-xs font-semibold">{value}</div>
     </div>
   );
@@ -286,9 +279,7 @@ function PlacementComparison({
     <section className="border-y border-fd-border" aria-label="Placement comparison">
       <div className="grid gap-2 border-b border-fd-border py-3 md:grid-cols-[minmax(10rem,0.26fr)_minmax(0,1fr)]">
         <h2 className="text-sm font-semibold">Placement comparison</h2>
-        <div className="hidden text-[10px] font-semibold uppercase tracking-normal text-fd-muted-foreground md:block">
-          Read
-        </div>
+        <Eyebrow className="hidden md:block">Read</Eyebrow>
       </div>
       <div className="divide-y divide-fd-border">
         {placements.map((placement) => (
@@ -471,9 +462,7 @@ function PanelHeader({
     <div className="flex items-start gap-2">
       <Icon className="mt-0.5 size-4 text-fd-muted-foreground" aria-hidden="true" />
       <div>
-        <div className="text-xs font-semibold uppercase tracking-normal text-fd-muted-foreground">
-          {detail}
-        </div>
+        <Eyebrow>{detail}</Eyebrow>
         <h3 className="text-sm font-semibold">{label}</h3>
       </div>
     </div>
@@ -503,9 +492,9 @@ function EnvironmentBlock({
 function ComputeTargetGroup({ group }: { group: string }) {
   return (
     <section>
-      <h4 className="mb-1.5 text-[10px] font-semibold uppercase tracking-normal text-fd-muted-foreground">
+      <Eyebrow as="h4" className="mb-1.5">
         {group}
-      </h4>
+      </Eyebrow>
       <div className="grid gap-1.5">
         {computeTargets
           .filter((target) => target.group === group)

--- a/apps/elements/components/context-controls-example.tsx
+++ b/apps/elements/components/context-controls-example.tsx
@@ -25,7 +25,8 @@ import {
 } from "@/components/notebook";
 import { Button } from "@/components/ui/button";
 import { cn } from "@/lib/utils";
-import { getElementsNotebookScenario } from "./notebook-scenarios";
+import { Eyebrow } from "@/components/surface-primitives";
+import { getElementsNotebookScenario } from "@/components/notebook-scenarios";
 
 type ContextTargetKind = "source" | "markdown" | "output" | "package";
 
@@ -492,9 +493,7 @@ export function ContextControlsExample() {
 function CellHeader({ detail, label }: { detail: string; label: string }) {
   return (
     <div className="flex min-w-0 items-center justify-between gap-3">
-      <div className="text-xs font-medium uppercase tracking-normal text-fd-muted-foreground">
-        {label}
-      </div>
+      <Eyebrow>{label}</Eyebrow>
       <div className="truncate text-xs text-fd-muted-foreground">{detail}</div>
     </div>
   );

--- a/apps/elements/components/editor-surfaces-example.tsx
+++ b/apps/elements/components/editor-surfaces-example.tsx
@@ -1,6 +1,5 @@
 "use client";
 
-import type { LucideIcon } from "lucide-react";
 import {
   Braces,
   Code2,
@@ -35,6 +34,7 @@ import {
   getElementsNotebookScenario,
   resolveElementsNotebookLanguage,
 } from "@/components/notebook-scenarios";
+import { Eyebrow, SurfaceFrame } from "@/components/surface-primitives";
 
 type SampleKey = "python" | "sql" | "markdown" | "json";
 
@@ -190,30 +190,9 @@ function range(source: string, needle: string) {
   return from === -1 ? { from: 0, to: 0 } : { from, to: from + needle.length };
 }
 
-function SectionHeader({
-  title,
-  source,
-  icon: Icon,
-}: {
-  title: string;
-  source: string;
-  icon: LucideIcon;
-}) {
+function RenderedBadge() {
   return (
-    <div className="flex items-start justify-between gap-3 border-b border-fd-border p-4">
-      <div className="flex min-w-0 items-center gap-2">
-        <Icon className="size-4 flex-none text-fd-muted-foreground" aria-hidden="true" />
-        <div className="min-w-0">
-          <h2 className="text-sm font-semibold">{title}</h2>
-          <div className="mt-1 break-words font-mono text-[11px] leading-4 text-fd-muted-foreground [overflow-wrap:anywhere]">
-            {source}
-          </div>
-        </div>
-      </div>
-      <span className="text-[11px] font-medium text-emerald-700 dark:text-emerald-300">
-        rendered
-      </span>
-    </div>
+    <span className="text-[11px] font-medium text-emerald-700 dark:text-emerald-300">rendered</span>
   );
 }
 
@@ -321,113 +300,108 @@ export function EditorSurfacesExample() {
         </div>
       </section>
 
-      <section className="overflow-hidden rounded-lg border border-fd-border bg-fd-card">
-        <SectionHeader
-          title="Live source editor"
-          source="src/components/editor/codemirror-editor.tsx"
-          icon={Code2}
-        />
-        <div className="space-y-4 p-4">
-          <div className="flex flex-wrap items-center gap-2">
-            {Object.entries(codeSamples).map(([key, value]) => (
-              <button
-                key={key}
-                type="button"
-                aria-pressed={sampleKey === key}
-                onClick={() => setSampleKey(key as SampleKey)}
-                className={[
-                  "rounded-md border px-3 py-1.5 text-xs font-medium transition-colors",
-                  sampleKey === key
-                    ? "border-fd-primary bg-fd-primary text-fd-primary-foreground"
-                    : "border-fd-border bg-fd-background text-fd-muted-foreground hover:bg-fd-muted",
-                ].join(" ")}
-              >
-                {value.label}
-              </button>
-            ))}
-            <span className="mx-1 h-5 w-px bg-fd-border" aria-hidden="true" />
-            <span className="text-xs font-medium capitalize text-fd-muted-foreground">
-              {mode} / {colorTheme}
-            </span>
-          </div>
-          <div className="grid gap-2 sm:grid-cols-3">
-            {scenarioFacts.map((fact) => (
-              <div
-                key={fact.label}
-                className="rounded-md border border-fd-border bg-fd-background px-3 py-2"
-              >
-                <div className="text-[10px] font-medium uppercase text-fd-muted-foreground">
-                  {fact.label}
-                </div>
-                <div className="mt-1 break-words font-mono text-[11px] leading-4">{fact.value}</div>
-              </div>
-            ))}
-          </div>
-
-          <div className="overflow-hidden rounded-lg border border-border bg-background">
-            <div className="flex flex-wrap items-center justify-between gap-2 border-b border-border px-3 py-2">
-              <div className="flex items-center gap-2 text-xs text-muted-foreground">
-                <Languages className="size-3.5" aria-hidden="true" />
-                <span>{languageDisplayNames[sample.language]}</span>
-                <span aria-hidden="true">·</span>
-                <span>search: {sample.search}</span>
-              </div>
-              <div className="text-xs tabular-nums text-muted-foreground">
-                {draftSource.length} chars
-              </div>
-            </div>
-            <CodeMirrorEditor
-              key={`${sampleKey}-${mode}-${colorTheme}`}
-              ref={editorRef}
-              initialValue={sample.source}
-              language={sample.language}
-              lineWrapping
-              extensions={editorExtensions}
-              onValueChange={setDraftSource}
-              className="min-h-52"
-            />
-          </div>
+      <SurfaceFrame
+        title="Live source editor"
+        source="src/components/editor/codemirror-editor.tsx"
+        icon={<Code2 aria-hidden="true" />}
+        badge={<RenderedBadge />}
+        bodyClassName="space-y-4 p-4"
+      >
+        <div className="flex flex-wrap items-center gap-2">
+          {Object.entries(codeSamples).map(([key, value]) => (
+            <button
+              key={key}
+              type="button"
+              aria-pressed={sampleKey === key}
+              onClick={() => setSampleKey(key as SampleKey)}
+              className={[
+                "rounded-md border px-3 py-1.5 text-xs font-medium transition-colors",
+                sampleKey === key
+                  ? "border-fd-primary bg-fd-primary text-fd-primary-foreground"
+                  : "border-fd-border bg-fd-background text-fd-muted-foreground hover:bg-fd-muted",
+              ].join(" ")}
+            >
+              {value.label}
+            </button>
+          ))}
+          <span className="mx-1 h-5 w-px bg-fd-border" aria-hidden="true" />
+          <span className="text-xs font-medium capitalize text-fd-muted-foreground">
+            {mode} / {colorTheme}
+          </span>
         </div>
-      </section>
+        <div className="grid gap-2 sm:grid-cols-3">
+          {scenarioFacts.map((fact) => (
+            <div
+              key={fact.label}
+              className="rounded-md border border-fd-border bg-fd-background px-3 py-2"
+            >
+              <Eyebrow>{fact.label}</Eyebrow>
+              <div className="mt-1 break-words font-mono text-[11px] leading-4">{fact.value}</div>
+            </div>
+          ))}
+        </div>
+
+        <div className="overflow-hidden rounded-lg border border-border bg-background">
+          <div className="flex flex-wrap items-center justify-between gap-2 border-b border-border px-3 py-2">
+            <div className="flex items-center gap-2 text-xs text-muted-foreground">
+              <Languages className="size-3.5" aria-hidden="true" />
+              <span>{languageDisplayNames[sample.language]}</span>
+              <span aria-hidden="true">·</span>
+              <span>search: {sample.search}</span>
+            </div>
+            <div className="text-xs tabular-nums text-muted-foreground">
+              {draftSource.length} chars
+            </div>
+          </div>
+          <CodeMirrorEditor
+            key={`${sampleKey}-${mode}-${colorTheme}`}
+            ref={editorRef}
+            initialValue={sample.source}
+            language={sample.language}
+            lineWrapping
+            extensions={editorExtensions}
+            onValueChange={setDraftSource}
+            className="min-h-52"
+          />
+        </div>
+      </SurfaceFrame>
 
       <section className="grid gap-4 lg:grid-cols-2">
-        <div className="overflow-hidden rounded-lg border border-fd-border bg-fd-card">
-          <SectionHeader
-            title="Read-only source"
-            source="src/components/editor/readonly-codemirror.tsx"
-            icon={FileCode2}
-          />
-          <div className="p-4">
-            <div className="overflow-hidden rounded-lg border border-border bg-background">
-              <ReadOnlyCodeMirror
-                value={readOnlyScenarioCell.source}
-                language={readOnlyScenarioLanguage}
-                lineWrapping
-                className="min-h-36"
-              />
-            </div>
-          </div>
-        </div>
-
-        <div className="overflow-hidden rounded-lg border border-fd-border bg-fd-card">
-          <SectionHeader
-            title="Static highlighting"
-            source="src/components/editor/static-highlight.tsx"
-            icon={Braces}
-          />
-          <div className="space-y-3 p-4">
-            <StaticCodeBlock
-              code={magicSource}
-              language={magicLanguage}
-              isDark={mode === "dark"}
-              colorTheme={colorTheme}
+        <SurfaceFrame
+          title="Read-only source"
+          source="src/components/editor/readonly-codemirror.tsx"
+          icon={<FileCode2 aria-hidden="true" />}
+          badge={<RenderedBadge />}
+          bodyClassName="p-4"
+        >
+          <div className="overflow-hidden rounded-lg border border-border bg-background">
+            <ReadOnlyCodeMirror
+              value={readOnlyScenarioCell.source}
+              language={readOnlyScenarioLanguage}
+              lineWrapping
+              className="min-h-36"
             />
-            <div className="rounded-md border border-fd-border bg-fd-background px-3 py-2 text-xs text-fd-muted-foreground">
-              IPython cell magic <span className="font-mono">%%{detectedMagic}</span> resolves to{" "}
-              <span className="font-mono">{magicLanguage}</span> for static preview.
-            </div>
           </div>
-        </div>
+        </SurfaceFrame>
+
+        <SurfaceFrame
+          title="Static highlighting"
+          source="src/components/editor/static-highlight.tsx"
+          icon={<Braces aria-hidden="true" />}
+          badge={<RenderedBadge />}
+          bodyClassName="space-y-3 p-4"
+        >
+          <StaticCodeBlock
+            code={magicSource}
+            language={magicLanguage}
+            isDark={mode === "dark"}
+            colorTheme={colorTheme}
+          />
+          <div className="rounded-md border border-fd-border bg-fd-background px-3 py-2 text-xs text-fd-muted-foreground">
+            IPython cell magic <span className="font-mono">%%{detectedMagic}</span> resolves to{" "}
+            <span className="font-mono">{magicLanguage}</span> for static preview.
+          </div>
+        </SurfaceFrame>
       </section>
 
       <section className="grid gap-4 lg:grid-cols-2">

--- a/apps/elements/components/full-shell-composition-example.tsx
+++ b/apps/elements/components/full-shell-composition-example.tsx
@@ -49,7 +49,10 @@ import { resetNotebookOutputs, setOutput } from "@/components/notebook/state/out
 import { cn } from "@/lib/utils";
 import { NotebookView } from "../../notebook/src/notebook-surface";
 import { createFixtureNotebookHost } from "./fixture-notebook-host";
-import { getElementsNotebookScenario, type ElementsNotebookScenario } from "./notebook-scenarios";
+import {
+  getElementsNotebookScenario,
+  type ElementsNotebookScenario,
+} from "@/components/notebook-scenarios";
 import type {
   MarkdownProjectionAnchor,
   MarkdownProjectionBlock,

--- a/apps/elements/components/identity-environment-surfaces-example.tsx
+++ b/apps/elements/components/identity-environment-surfaces-example.tsx
@@ -24,6 +24,7 @@ import {
   type ElementsNotebookScenario,
   type ElementsNotebookScenarioId,
 } from "@/components/notebook-scenarios";
+import { Eyebrow } from "@/components/surface-primitives";
 
 const identityScenarioIds: ElementsNotebookScenarioId[] = [
   "desktop-local-owner",
@@ -276,9 +277,7 @@ function IdentityScenarioCard({ scenario }: { scenario: ElementsNotebookScenario
     <article className="rounded-lg border border-fd-border bg-fd-card p-4">
       <div className="mb-3 flex items-start justify-between gap-3">
         <div className="min-w-0">
-          <div className="text-[10px] font-medium uppercase tracking-[0.08em] text-fd-muted-foreground">
-            {scenario.eyebrow}
-          </div>
+          <Eyebrow>{scenario.eyebrow}</Eyebrow>
           <h2 className="mt-1 truncate text-sm font-semibold">{scenario.title}</h2>
         </div>
         <AccessPill scenario={scenario} />

--- a/apps/elements/components/isolated-output-surfaces-example.tsx
+++ b/apps/elements/components/isolated-output-surfaces-example.tsx
@@ -45,6 +45,7 @@ import {
   rendererPluginInfoForMime,
   rendererPluginNameForMime,
 } from "@/components/isolated/renderer-plugin-info";
+import { Eyebrow } from "@/components/surface-primitives";
 
 const laneOutputs: JupyterOutput[] = [
   {
@@ -579,9 +580,7 @@ export function IsolatedOutputSurfacesExample() {
           </p>
         </div>
         <div className="border-b border-fd-border p-4">
-          <h3 className="text-xs font-semibold uppercase text-fd-muted-foreground">
-            Output frame boundary map
-          </h3>
+          <Eyebrow as="h3">Output frame boundary map</Eyebrow>
           <p className="mt-2 text-xs leading-5 text-fd-muted-foreground">
             The catalog can preview the same decision points, but it does not serve the daemon
             output document. Production MCP hosts only switch to the daemon{" "}

--- a/apps/elements/components/notebook-scenarios.ts
+++ b/apps/elements/components/notebook-scenarios.ts
@@ -1091,9 +1091,9 @@ export const elementsNotebookScenarios: Record<
     eyebrow: "workstation fixture",
     summary:
       "A hosted owner has selected an nteract workstation backed by Outerbounds current Python.",
-    runtimeLabel: "Outerbounds workstation - current Python",
+    runtimeLabel: "Outerbounds workstation · current Python",
     runtimeStatus: "ready",
-    packageSummary: "current Python - package mutation disabled",
+    packageSummary: "current Python · package mutation disabled",
     packageSourceLabel: "provider current Python",
     syncLabel: "Workstation target ready",
     syncStatus: "synced",
@@ -1155,8 +1155,8 @@ export const elementsNotebookScenarios: Record<
     eyebrow: "operator fixture",
     summary:
       "A delegated Codex operator submits edits for Kyle through the cloud shell; the label records execution provenance, not model lineage.",
-    runtimeLabel: "Cloud notebook - delegated operator active",
-    packageSummary: "visible - 8 packages",
+    runtimeLabel: "Cloud notebook · delegated operator active",
+    packageSummary: "visible · 8 packages",
     capabilities: {
       canRead: true,
       canEditMarkdown: true,

--- a/apps/elements/components/notebook-shell-capabilities-example.tsx
+++ b/apps/elements/components/notebook-shell-capabilities-example.tsx
@@ -39,6 +39,7 @@ import {
   type ElementsNotebookScenario,
   type ElementsNotebookScenarioId,
 } from "@/components/notebook-scenarios";
+import { Eyebrow } from "@/components/surface-primitives";
 
 type BooleanCapabilityKey = {
   [Key in keyof NotebookShellCapabilities]-?: NotebookShellCapabilities[Key] extends boolean
@@ -232,23 +233,17 @@ export function NotebookShellCapabilitiesExample() {
             <h2 className="text-sm font-semibold">{flow.title}</h2>
             <dl className="mt-3 space-y-3 text-xs leading-5">
               <div>
-                <dt className="text-[10px] font-medium uppercase tracking-[0.08em] text-fd-muted-foreground">
-                  Source facts
-                </dt>
+                <Eyebrow as="dt">Source facts</Eyebrow>
                 <dd className="mt-1 text-fd-muted-foreground">{flow.facts}</dd>
               </div>
               <div>
-                <dt className="text-[10px] font-medium uppercase tracking-[0.08em] text-fd-muted-foreground">
-                  Adapter
-                </dt>
+                <Eyebrow as="dt">Adapter</Eyebrow>
                 <dd className="mt-1 break-words font-mono text-[11px] text-fd-foreground">
                   {flow.adapter}
                 </dd>
               </div>
               <div>
-                <dt className="text-[10px] font-medium uppercase tracking-[0.08em] text-fd-muted-foreground">
-                  Shared surface
-                </dt>
+                <Eyebrow as="dt">Shared surface</Eyebrow>
                 <dd className="mt-1 text-fd-muted-foreground">{flow.sharedSurface}</dd>
               </div>
             </dl>
@@ -337,15 +332,11 @@ export function NotebookShellCapabilitiesExample() {
                 </div>
                 <div className="grid gap-3 text-xs leading-5 md:grid-cols-2">
                   <div>
-                    <div className="text-[10px] font-medium uppercase tracking-[0.08em] text-fd-muted-foreground">
-                      Shared use
-                    </div>
+                    <Eyebrow>Shared use</Eyebrow>
                     <p className="mt-1 text-fd-muted-foreground">{row.use}</p>
                   </div>
                   <div>
-                    <div className="text-[10px] font-medium uppercase tracking-[0.08em] text-fd-muted-foreground">
-                      Host keeps
-                    </div>
+                    <Eyebrow>Host keeps</Eyebrow>
                     <p className="mt-1 text-fd-muted-foreground">{row.hostBoundary}</p>
                   </div>
                 </div>
@@ -439,9 +430,7 @@ function ElementsFixtureEnvironmentCard() {
           ) : null}
         </div>
         <div className="rounded-md border border-fd-border bg-fd-background p-3">
-          <div className="text-[10px] font-medium uppercase tracking-[0.08em] text-fd-muted-foreground">
-            Inert host callbacks
-          </div>
+          <Eyebrow>Inert host callbacks</Eyebrow>
           <div className="mt-3 flex flex-wrap gap-2">
             <FixtureActionButton
               label="Open packages"
@@ -479,9 +468,7 @@ function ElementsFixtureEnvironmentCard() {
 function FixtureFact({ label, value }: { label: string; value: string }) {
   return (
     <div>
-      <dt className="text-[10px] font-medium uppercase tracking-[0.08em] text-fd-muted-foreground">
-        {label}
-      </dt>
+      <Eyebrow as="dt">{label}</Eyebrow>
       <dd className="mt-1 text-fd-foreground">{value}</dd>
     </div>
   );
@@ -564,18 +551,14 @@ function ScenarioCard({ scenario }: { scenario: ElementsNotebookScenario }) {
       <dl className="grid gap-2 px-3 pt-3">
         {scenario.sourceFacts.map((fact) => (
           <div key={fact.label}>
-            <dt className="text-[10px] font-medium uppercase tracking-[0.08em] text-fd-muted-foreground">
-              {fact.label}
-            </dt>
+            <Eyebrow as="dt">{fact.label}</Eyebrow>
             <dd className="mt-0.5 text-[11px] leading-4 text-fd-foreground">{fact.value}</dd>
           </div>
         ))}
       </dl>
       {scenario.notices.length ? (
         <div className="mt-3 border-t border-fd-border px-3 pt-3">
-          <div className="text-[10px] font-medium uppercase tracking-[0.08em] text-fd-muted-foreground">
-            Projected notices
-          </div>
+          <Eyebrow>Projected notices</Eyebrow>
           <ul className="mt-2 space-y-1.5">
             {scenario.notices.map((notice) => (
               <li key={`${notice.tone}-${notice.title}`} className="text-[11px] leading-4">
@@ -587,9 +570,7 @@ function ScenarioCard({ scenario }: { scenario: ElementsNotebookScenario }) {
         </div>
       ) : null}
       <div className="mt-3 border-t border-fd-border px-3 py-3">
-        <div className="text-[10px] font-medium uppercase tracking-[0.08em] text-fd-muted-foreground">
-          Host boundary
-        </div>
+        <Eyebrow>Host boundary</Eyebrow>
         <ul className="mt-2 space-y-2">
           {scenario.hostBoundaries.map((boundary) => (
             <li key={boundary.surface} className="text-[11px] leading-4">
@@ -620,9 +601,7 @@ function NoticeIcon({ tone }: { tone: NotebookNoticeTone }) {
 function ScenarioSignal({ label, value }: { label: string; value: string }) {
   return (
     <div className="grid grid-cols-[5rem_minmax(0,1fr)] gap-3 px-3 py-1.5">
-      <div className="text-[10px] font-medium uppercase tracking-[0.08em] text-fd-muted-foreground">
-        {label}
-      </div>
+      <Eyebrow>{label}</Eyebrow>
       <div className="min-w-0 text-[11px] text-fd-foreground">{value}</div>
     </div>
   );

--- a/apps/elements/components/output-renderers-example.tsx
+++ b/apps/elements/components/output-renderers-example.tsx
@@ -39,6 +39,7 @@ import { VegaOutput } from "@/components/outputs/vega-output";
 import { VideoOutput } from "@/components/outputs/video-output";
 import { OutputArea } from "@/components/cell/OutputArea";
 import { getElementsNotebookScenario } from "@/components/notebook-scenarios";
+import { SurfaceFrame } from "@/components/surface-primitives";
 import "@/components/widgets/controls";
 import { WidgetStoreContext } from "@/components/widgets/widget-store-context";
 import { createWidgetStore, type WidgetStore } from "@/components/widgets/widget-store";
@@ -798,23 +799,21 @@ function RendererCard({
   children: React.ReactNode;
 }) {
   return (
-    <section className="rounded-lg border border-fd-border bg-fd-card">
-      <div className="flex items-start justify-between gap-3 border-b border-fd-border p-4">
-        <div className="flex min-w-0 items-center gap-2">
-          <Icon className="size-4 flex-none text-fd-muted-foreground" aria-hidden="true" />
-          <div className="min-w-0">
-            <h2 className="text-sm font-semibold">{title}</h2>
-            <div className="mt-1 break-words font-mono text-[11px] leading-4 text-fd-muted-foreground [overflow-wrap:anywhere]">
-              {source}
-            </div>
-          </div>
-        </div>
-        <span className="text-[11px] font-medium text-emerald-700 dark:text-emerald-300">
-          rendered
-        </span>
-      </div>
-      <div className="p-4">{children}</div>
-    </section>
+    <SurfaceFrame
+      title={title}
+      source={source}
+      icon={<Icon aria-hidden="true" />}
+      badge={<RenderedBadge />}
+      bodyClassName="p-4"
+    >
+      {children}
+    </SurfaceFrame>
+  );
+}
+
+function RenderedBadge() {
+  return (
+    <span className="text-[11px] font-medium text-emerald-700 dark:text-emerald-300">rendered</span>
   );
 }
 

--- a/apps/elements/components/package-manager-surfaces-example.tsx
+++ b/apps/elements/components/package-manager-surfaces-example.tsx
@@ -1,10 +1,10 @@
 "use client";
 
 import { CheckCircle2, FileCode2, PackageCheck } from "lucide-react";
-import type { ReactNode } from "react";
 import { EnvironmentPackageSummaryPanel } from "@/components/environment";
 import { NotebookPackageSummaryPanel } from "@/components/notebook";
 import { getElementsNotebookScenario } from "@/components/notebook-scenarios";
+import { Eyebrow, SurfaceFrame } from "@/components/surface-primitives";
 
 const packageSurfaces = [
   {
@@ -54,9 +54,7 @@ export function PackageManagerSurfacesExample() {
         {packageSurfaces.map((surface) => (
           <div key={surface.name} className="rounded-lg border border-fd-border bg-fd-card p-4">
             <div className="mb-3 flex items-center justify-between gap-3">
-              <span className="text-[11px] font-medium uppercase tracking-[0.08em] text-fd-muted-foreground">
-                {surface.manager}
-              </span>
+              <Eyebrow>{surface.manager}</Eyebrow>
               <CheckCircle2 className="size-4 text-emerald-500" aria-hidden="true" />
             </div>
             <h2 className="break-words text-sm font-semibold [overflow-wrap:anywhere]">
@@ -74,7 +72,7 @@ export function PackageManagerSurfacesExample() {
 
       <section className="grid items-start gap-4 xl:grid-cols-2">
         <SurfaceFrame
-          icon={<PackageCheck className="size-4 text-sky-500" aria-hidden="true" />}
+          iconSlot={<PackageCheck className="size-4 text-sky-500" aria-hidden="true" />}
           title="Shared package summary"
           detail="Pure package projection with no rail wrapper or host actions."
         >
@@ -84,7 +82,7 @@ export function PackageManagerSurfacesExample() {
         </SurfaceFrame>
 
         <SurfaceFrame
-          icon={<PackageCheck className="size-4 text-fuchsia-500" aria-hidden="true" />}
+          iconSlot={<PackageCheck className="size-4 text-fuchsia-500" aria-hidden="true" />}
           title="Notebook rail package listing"
           detail="Shared package listing inside the notebook rail wrapper."
         >
@@ -144,34 +142,5 @@ export function PackageManagerSurfacesExample() {
         </div>
       </section>
     </div>
-  );
-}
-
-function SurfaceFrame({
-  children,
-  detail,
-  icon,
-  title,
-}: {
-  children: ReactNode;
-  detail: string;
-  icon: ReactNode;
-  title: string;
-}) {
-  return (
-    <section className="overflow-hidden rounded-lg border border-fd-border bg-fd-card">
-      <div className="border-b border-fd-border p-4">
-        <div className="flex items-start gap-3">
-          <div className="mt-0.5 flex size-8 shrink-0 items-center justify-center rounded-md border border-fd-border bg-fd-muted">
-            {icon}
-          </div>
-          <div>
-            <h2 className="text-sm font-semibold">{title}</h2>
-            <p className="mt-1 text-xs leading-5 text-fd-muted-foreground">{detail}</p>
-          </div>
-        </div>
-      </div>
-      {children}
-    </section>
   );
 }

--- a/apps/elements/components/rail-outline-example.tsx
+++ b/apps/elements/components/rail-outline-example.tsx
@@ -247,16 +247,16 @@ function ScenarioNotice({
 }) {
   return (
     <div className="grid gap-3 xl:grid-cols-[minmax(0,1fr)_minmax(280px,420px)]">
-      <div className="border-l border-fd-border py-1 pl-3 text-xs leading-5 text-fd-muted-foreground">
-        <div className="mb-1 flex items-center gap-2 font-semibold">
+      <section className="border-l border-fd-border py-1 pl-4 text-fd-muted-foreground">
+        <div className="mb-1 flex items-center gap-2 text-xs font-semibold leading-5">
           <ShieldCheck className="size-3.5" aria-hidden="true" />
           NotebookDocumentShell, NotebookRail, and NotebookView render from current sources.
         </div>
-        <p>
+        <p className="text-xs leading-5">
           The docs app owns only scenario facts: capabilities, fixture cells, package details,
           focused cell, active panel, and inert navigation callbacks.
         </p>
-      </div>
+      </section>
 
       <div className="rounded-lg border border-fd-border bg-fd-background p-3 text-xs leading-5 text-fd-muted-foreground">
         <div className="mb-2 flex flex-wrap gap-1.5">

--- a/apps/elements/components/runtime-surfaces-example.tsx
+++ b/apps/elements/components/runtime-surfaces-example.tsx
@@ -11,7 +11,7 @@ import {
 } from "lucide-react";
 import { useState, type ReactNode } from "react";
 import { Button } from "@/components/ui/button";
-import { asyncTrue, noop } from "@/components/fixture-notebook-host";
+import { asyncTrue, noop } from "./fixture-notebook-host";
 import {
   DaemonStatusBanner,
   DebugBanner,
@@ -258,7 +258,7 @@ function RuntimeBanners() {
         >
           <NotebookNotice
             tone="warning"
-            icon={<AlertTriangle className="h-4 w-4" />}
+            icon={<AlertTriangle className="size-4" aria-hidden="true" />}
             title="Document attention needed."
             actions={<NotebookNoticeAction onClick={noop}>Review</NotebookNoticeAction>}
           >

--- a/apps/elements/components/surface-primitives.tsx
+++ b/apps/elements/components/surface-primitives.tsx
@@ -1,0 +1,113 @@
+import type { ElementType, ReactNode } from "react";
+import { cn } from "@/lib/utils";
+
+/**
+ * Small uppercase label used throughout the Elements catalog for card
+ * eyebrows, table column headers, and inline metadata labels. One
+ * component so the catalog stops drifting across three sizes
+ * (text-[10px]/text-[11px]/text-xs), four tracking values, and two
+ * color tokens. The default is the dominant convention: 11px, medium,
+ * 0.08em tracking, muted. Pass `className` to override color or sizing
+ * where a label genuinely needs to differ (e.g. a foreground label).
+ * Use `as` to keep semantic elements (`dt` inside a `<dl>`, `h3`/`h4`
+ * for section eyebrows) instead of the default `span`.
+ */
+export function Eyebrow({
+  as: Tag = "span",
+  children,
+  className,
+}: {
+  as?: ElementType;
+  children: ReactNode;
+  className?: string;
+}) {
+  return (
+    <Tag
+      className={cn(
+        "text-[11px] font-medium uppercase tracking-[0.08em] text-fd-muted-foreground",
+        className,
+      )}
+    >
+      {children}
+    </Tag>
+  );
+}
+
+/**
+ * The card chrome shared across Elements pages: a bordered card with an
+ * optional header strip (icon + title + detail or mono source + trailing
+ * badge), then a body. Replaces three local copies (SurfaceFrame,
+ * RendererCard, SectionHeader) and the ad-hoc inline variants.
+ *
+ * Header variants, all from this one component:
+ * - icon + title + detail (pass `detail`)
+ * - icon + title + mono source + trailing badge (pass `source` + `badge`)
+ * - icon + title only (pass neither `detail` nor `source`)
+ * - no header (omit `icon` and `title`); use for cards that own their own
+ *   top content
+ *
+ * The icon renders as an inline `size-4` glyph in the muted color. For the
+ * boxed-icon look (a size-8 swatch), pass `iconSlot` instead of `icon`.
+ */
+export function SurfaceFrame({
+  title,
+  icon,
+  iconSlot,
+  detail,
+  source,
+  badge,
+  headerClassName,
+  bodyClassName,
+  className,
+  children,
+}: {
+  title?: ReactNode;
+  icon?: ReactNode;
+  iconSlot?: ReactNode;
+  detail?: ReactNode;
+  source?: ReactNode;
+  badge?: ReactNode;
+  headerClassName?: string;
+  bodyClassName?: string;
+  className?: string;
+  children?: ReactNode;
+}) {
+  const hasHeader = Boolean(title || icon || iconSlot || detail || source || badge);
+  return (
+    <section
+      className={cn("overflow-hidden rounded-lg border border-fd-border bg-fd-card", className)}
+    >
+      {hasHeader ? (
+        <div className={cn("border-b border-fd-border p-4", headerClassName)}>
+          <div className="flex items-start justify-between gap-3">
+            <div className="flex min-w-0 items-start gap-2">
+              {iconSlot ? (
+                <div className="mt-0.5 flex size-8 shrink-0 items-center justify-center rounded-md border border-fd-border bg-fd-muted">
+                  {iconSlot}
+                </div>
+              ) : null}
+              {icon ? (
+                <span className="mt-0.5 flex size-4 shrink-none items-center text-fd-muted-foreground">
+                  {icon}
+                </span>
+              ) : null}
+              <div className="min-w-0">
+                {title ? <h2 className="text-sm font-semibold">{title}</h2> : null}
+                {detail ? (
+                  <p className="mt-1 text-xs leading-5 text-fd-muted-foreground">{detail}</p>
+                ) : null}
+                {source ? (
+                  <div className="mt-1 break-words font-mono text-[11px] leading-4 text-fd-muted-foreground [overflow-wrap:anywhere]">
+                    {source}
+                  </div>
+                ) : null}
+              </div>
+            </div>
+            {badge ? <div className="shrink-0">{badge}</div> : null}
+          </div>
+        </div>
+      ) : null}
+      <div className={bodyClassName}>{children}</div>
+    </section>
+  );
+}

--- a/apps/elements/components/widget-surfaces-example.tsx
+++ b/apps/elements/components/widget-surfaces-example.tsx
@@ -28,6 +28,7 @@ import { WidgetUpdateManager, type ContentRef } from "@/components/widgets/widge
 import { WidgetView } from "@/components/widgets/widget-view";
 import { parseWidgetViewModelId, WIDGET_VIEW_MIME } from "@/components/widgets/widget-state";
 import { cn } from "@/lib/utils";
+import { Eyebrow } from "@/components/surface-primitives";
 
 type FixtureModel = {
   id: string;
@@ -1662,7 +1663,7 @@ function WidgetFixtureProvider({ children }: { children: ReactNode }) {
             className="rounded-lg border border-fd-border bg-fd-background p-3"
             data-testid="widget-event-log"
           >
-            <div className="text-xs font-medium uppercase text-fd-muted-foreground">Comm log</div>
+            <Eyebrow>Comm log</Eyebrow>
             <div className="mt-2 space-y-1 font-mono text-xs text-fd-muted-foreground">
               {events.length > 0
                 ? events.map((event, index) => <div key={`${index}-${event}`}>{event}</div>)
@@ -1911,7 +1912,7 @@ export function WidgetSurfacesExample() {
         ))}
       </section>
 
-      <section className="border-l border-fd-border py-1 pl-4">
+      <section className="border-l border-fd-border py-1 pl-4 text-fd-muted-foreground">
         <div className="flex items-start gap-3">
           <CircleDotDashed className="mt-0.5 size-4 flex-none text-amber-600" aria-hidden="true" />
           <div className="min-w-0 flex-1">


### PR DESCRIPTION
## Overview

Converges the Elements catalog on two shared scaffolding primitives - `Eyebrow` and `SurfaceFrame` - and sweeps 15 files onto them. The catalog had drifted into hand-rolled chrome per page: seven-plus eyebrow className variants, three local card-wrapper copies, and a scatter of one-off token and separator choices. One system now owns the uppercase label and the card frame.

## Design decision

The audit found the bones consistent (`"use client"`, named exports, `size-N` icons, `text-sm font-semibold` section headings) but the scaffolding layer diverged in two places that a shared primitive collapses cleanly:

**Eyebrow labels** had seven variants across three sizes (`text-[10px]`/`text-[11px]`/`text-xs`), four tracking values (`[0.08em]`/`[0.12em]`/`normal`/none), two weights, and two color tokens (`text-fd-muted-foreground` vs `text-muted-foreground`). The `Eyebrow` primitive defaults to the dominant convention - 11px, medium, `0.08em` tracking, `fd-muted` - and takes an `as` prop so semantic elements (`dt` in a `<dl>`, `h3`/`h4` section eyebrows, `p`) keep their semantics instead of collapsing to `span`.

**Card wrappers** existed as three local copies (`SurfaceFrame`, `RendererCard`, `SectionHeader`) plus six inline className variants. The shared `SurfaceFrame` covers all three local shapes from one component: an optional header (icon, or boxed `iconSlot`, plus title with detail or mono source and a trailing badge) and a body. `RendererCard` stays as a 5-line adapter so its 17 icon-as-component call sites don't churn.

What's deliberately left as-is: table-header grid rows (composite layout with `grid-cols` and responsive variants, not standalone labels), and semantic status pills (amber/emerald access pills, the "rendered" badge) that carry deliberate color meaning.

## Behavioral coverage

| Surface | Before | After |
|---|---|---|
| Eyebrow labels (cloud-notebook-shell) | `text-muted-foreground` + `tracking-[0.12em]` + `font-semibold` | `<Eyebrow as="h3"/"h4"/"p">` (fd token, 0.08em, medium) |
| Eyebrow labels (compute-placement) | `text-[10px] font-semibold tracking-normal` (7 sites) | `<Eyebrow>` with responsive `className` preserved |
| Eyebrow labels (cloud-dashboard) | `text-xs font-medium tracking-normal` (4 sites, 3 with icons) | `<Eyebrow className="flex items-center gap-2">` |
| Eyebrow labels (shell-capabilities, identity, package, editor, isolated, widget, context) | `text-[10px]/[11px] font-medium tracking-[0.08em]` or no tracking | `<Eyebrow>` / `<Eyebrow as="dt"/"h3">` |
| Card wrapper (package-manager) | local `SurfaceFrame` (boxed icon) | shared `SurfaceFrame` with `iconSlot` |
| Card wrapper (output-renderers) | local `RendererCard` (17 sites) | shared `SurfaceFrame` via 5-line adapter |
| Card wrapper (editor-surfaces) | local `SectionHeader` + outer `<section>` (3 sites) | shared `SurfaceFrame` with `badge` + `bodyClassName` |
| Scenario labels (notebook-scenarios) | mixed ` - ` and `·` separators (4 vs 14) | all `·` |
| Left-border aside (rail-outline) | `<div>` + `pl-3` | canonical `<section>` + `pl-4` |
| Left-border aside (widget-surfaces) | missing `text-fd-muted-foreground` | canonical form |
| Icon (runtime-surfaces) | `h-4 w-4` without `aria-hidden` | `size-4` with `aria-hidden` |
| Import paths | `./notebook-scenarios` (2) vs `@/components/` (12); `@/components/fixture-notebook-host` (1) vs `./` (3) | all aligned to dominant convention |

## Test plan

- [x] `cargo xtask lint --fix` (Rust fmt, `vp check --fix`, raw-byte, ruff, ty) - all pass
- [x] `vp check` (format + lint + type, the CI gate) - clean
- [x] `next build` (elements app, all 28 static pages) - compiles and prerenders
- [ ] Visual QA: spot-check cloud-notebook-shell, compute-placement, cloud-dashboard, editor-surfaces, output-renderers in light + dark to confirm the eyebrow tracking/weight change reads right
