### PR TITLE
feat(comments): character-granular highlights and quotes for rendered-markdown comments

### DIFF
--- a/apps/notebook-cloud/viewer/notebook-viewer.tsx
+++ b/apps/notebook-cloud/viewer/notebook-viewer.tsx
@@ -16,6 +16,11 @@ import {
 } from "@/components/isolated/isolated-renderer-context";
 import { NotebookNotice } from "@/components/notebook/NotebookNotice";
 import {
+  markdownProjectionMatchesSource,
+  renderedTextForSourceRange,
+  resolveMarkdownProjection,
+} from "@/lib/markdown-projection";
+import {
   NotebookConnectionIdentity,
   NotebookCommentsPanel,
   NotebookDocumentToolbar,
@@ -294,6 +299,7 @@ export function NotebookViewer({
   const [sourceCommentRequest, setSourceCommentRequest] = useState<{
     anchor: SourceRangeCommentAnchor;
     rect: SourceCommentSelectionRect;
+    quote?: string | null;
   } | null>(null);
   const [commentFocus, setCommentFocus] = useState<{ threadId: string; nonce: number } | null>(
     null,
@@ -1314,14 +1320,18 @@ export function NotebookViewer({
   );
 
   const handleRequestSourceComment = useCallback(
-    (anchor: SourceRangeCommentAnchor, rect: SourceCommentSelectionRect | null) => {
+    (
+      anchor: SourceRangeCommentAnchor,
+      rect: SourceCommentSelectionRect | null,
+      quote?: string | null,
+    ) => {
       setCommentsError(null);
       if (rect) {
-        setSourceCommentRequest({ anchor, rect });
+        setSourceCommentRequest({ anchor, rect, quote });
         return;
       }
       setSourceCommentRequest(null);
-      setCommentDraftTarget({ anchor, quote: anchor.exact_quote ?? null });
+      setCommentDraftTarget({ anchor, quote: quote ?? anchor.exact_quote ?? null });
       openNotebookRailPanel("comments");
     },
     [],
@@ -1735,6 +1745,17 @@ export function NotebookViewer({
       ? "outline"
       : activeRailPanel;
   const commentsPanelStatus = commentsProjection ? null : "Syncing comments...";
+  const resolveSourceQuote = useCallback((anchor: SourceRangeCommentAnchor): string | null => {
+    const cell = getCellById(anchor.cell_id);
+    if (cell?.cell_type !== "markdown") return anchor.exact_quote ?? null;
+    const range = resolveSourceRangeAnchor(cell.source, anchor);
+    if (!range) return anchor.exact_quote ?? null;
+    const plan = resolveMarkdownProjection(cell.markdownProjection, cell.source);
+    if (!plan || !markdownProjectionMatchesSource(plan, cell.source)) {
+      return anchor.exact_quote ?? null;
+    }
+    return renderedTextForSourceRange(plan, range.from, range.to) ?? anchor.exact_quote ?? null;
+  }, []);
   const commentsPanel = (
     <NotebookCommentsPanel
       projection={commentsProjection}
@@ -1752,6 +1773,7 @@ export function NotebookViewer({
       focusedThreadId={commentFocus?.threadId ?? null}
       focusNonce={commentFocus?.nonce ?? 0}
       resolveSourceLanguage={resolveCommentSourceLanguage}
+      resolveSourceQuote={resolveSourceQuote}
     />
   );
   const rail = (
@@ -2044,7 +2066,7 @@ export function NotebookViewer({
       {sourceCommentRequest ? (
         <InlineCommentComposer
           rect={sourceCommentRequest.rect}
-          quote={sourceCommentRequest.anchor.exact_quote}
+          quote={sourceCommentRequest.quote ?? sourceCommentRequest.anchor.exact_quote}
           disabled={!canWriteComments}
           onSubmit={handleSubmitSourceComment}
           onCancel={handleCancelSourceComment}

--- a/apps/notebook/src/App.tsx
+++ b/apps/notebook/src/App.tsx
@@ -35,6 +35,11 @@ import { useSyncedTheme } from "@/hooks/useSyncedSettings";
 import { ErrorBoundary } from "@/lib/error-boundary";
 import { cn } from "@/lib/utils";
 import {
+  markdownProjectionMatchesSource,
+  renderedTextForSourceRange,
+  resolveMarkdownProjection,
+} from "@/lib/markdown-projection";
+import {
   NOTEBOOK_RAIL_TAKEOVER_MEDIA_QUERY,
   NOTEBOOK_RAIL_TAKEOVER_STAGE_CLASS_NAME,
   NotebookPackagesPanel,
@@ -383,6 +388,7 @@ function AppContent() {
   const [sourceCommentRequest, setSourceCommentRequest] = useState<{
     anchor: SourceRangeCommentAnchor;
     rect: SourceCommentSelectionRect;
+    quote?: string | null;
   } | null>(null);
   const [commentFocus, setCommentFocus] = useState<{ threadId: string; nonce: number } | null>(
     null,
@@ -743,14 +749,18 @@ function AppContent() {
   );
 
   const handleRequestSourceComment = useCallback(
-    (anchor: SourceRangeCommentAnchor, rect: SourceCommentSelectionRect | null) => {
+    (
+      anchor: SourceRangeCommentAnchor,
+      rect: SourceCommentSelectionRect | null,
+      quote?: string | null,
+    ) => {
       setCommentsError(null);
       if (rect) {
-        setSourceCommentRequest({ anchor, rect });
+        setSourceCommentRequest({ anchor, rect, quote });
         return;
       }
       setSourceCommentRequest(null);
-      setCommentDraftTarget({ anchor, quote: anchor.exact_quote ?? null });
+      setCommentDraftTarget({ anchor, quote: quote ?? anchor.exact_quote ?? null });
       openNotebookRailPanel("comments");
     },
     [],
@@ -836,6 +846,18 @@ function AppContent() {
     },
     [runtime],
   );
+
+  const resolveSourceQuote = useCallback((anchor: SourceRangeCommentAnchor): string | null => {
+    const cell = getCellById(anchor.cell_id);
+    if (cell?.cell_type !== "markdown") return anchor.exact_quote ?? null;
+    const range = resolveSourceRangeAnchor(cell.source, anchor);
+    if (!range) return anchor.exact_quote ?? null;
+    const plan = resolveMarkdownProjection(cell.markdownProjection, cell.source);
+    if (!plan || !markdownProjectionMatchesSource(plan, cell.source)) {
+      return anchor.exact_quote ?? null;
+    }
+    return renderedTextForSourceRange(plan, range.from, range.to) ?? anchor.exact_quote ?? null;
+  }, []);
 
   const sourceCommentThreadsByCell = useMemo(() => {
     const map = new Map<string, SourceCommentThread[]>();
@@ -1010,6 +1032,7 @@ function AppContent() {
       focusedThreadId={commentFocus?.threadId ?? null}
       focusNonce={commentFocus?.nonce ?? 0}
       resolveSourceLanguage={resolveSourceLanguage}
+      resolveSourceQuote={resolveSourceQuote}
     />
   );
 
@@ -2103,7 +2126,7 @@ function AppContent() {
       {sourceCommentRequest ? (
         <InlineCommentComposer
           rect={sourceCommentRequest.rect}
-          quote={sourceCommentRequest.anchor.exact_quote}
+          quote={sourceCommentRequest.quote ?? sourceCommentRequest.anchor.exact_quote}
           disabled={!canMutateComments}
           onSubmit={handleSubmitSourceComment}
           onCancel={handleCancelSourceComment}

--- a/apps/notebook/src/components/CodeCell.tsx
+++ b/apps/notebook/src/components/CodeCell.tsx
@@ -109,6 +109,7 @@ interface CodeCellProps {
   onCreateSourceComment?: (
     anchor: SourceRangeCommentAnchor,
     rect: SourceCommentSelectionRect | null,
+    quote?: string | null,
   ) => void;
   onCreateOutputComment?: (anchor: OutputCommentAnchor) => void;
   onActivateCommentThread?: (threadId: string) => void;

--- a/apps/notebook/src/components/EditorContextMenu.tsx
+++ b/apps/notebook/src/components/EditorContextMenu.tsx
@@ -27,6 +27,7 @@ interface EditorContextMenuProps {
   onCreateSourceComment?: (
     anchor: SourceRangeCommentAnchor,
     rect: SourceCommentSelectionRect | null,
+    quote?: string | null,
   ) => void;
   children: ReactNode;
 }

--- a/apps/notebook/src/components/MarkdownCell.tsx
+++ b/apps/notebook/src/components/MarkdownCell.tsx
@@ -28,6 +28,7 @@ import { useColorTheme, useDarkMode } from "@/lib/dark-mode";
 import {
   canRenderMarkdownProjectionInHost,
   markdownProjectionMatchesSource,
+  renderedTextForSourceRange,
   type MarkdownProjectionRun,
   projectedMarkdownPreviewHeight,
   projectMarkdownPlan,
@@ -158,6 +159,7 @@ interface MarkdownCellProps {
   onCreateSourceComment?: (
     anchor: SourceRangeCommentAnchor,
     rect: SourceCommentSelectionRect | null,
+    quote?: string | null,
   ) => void;
   onActivateCommentThread?: (threadId: string) => void;
   commentThreads?: readonly SourceCommentThread[];
@@ -534,7 +536,11 @@ export const MarkdownCell = memo(function MarkdownCell({
 
     if (!anchor) return false;
     const rect = selectionRectFromDomSelection(window.getSelection());
-    onCreateSourceComment(anchor, rect);
+    const range = resolveSourceRangeAnchor(previewSource, anchor);
+    const quote = range
+      ? renderedTextForSourceRange(markdownProjection, range.from, range.to)
+      : null;
+    onCreateSourceComment(anchor, rect, quote);
     window.getSelection()?.removeAllRanges();
     clearRenderedSourceCommentTarget();
     return true;
@@ -542,6 +548,7 @@ export const MarkdownCell = memo(function MarkdownCell({
     canCommentOnRenderedMarkdown,
     cell.id,
     clearRenderedSourceCommentTarget,
+    markdownProjection,
     onCreateSourceComment,
     previewSource,
   ]);
@@ -557,7 +564,11 @@ export const MarkdownCell = memo(function MarkdownCell({
         selectionRectFromDomSelection(
           typeof window !== "undefined" ? window.getSelection() : null,
         ) ?? selectionRectFromDomRect(event.currentTarget.getBoundingClientRect());
-      onCreateSourceComment(anchor, rect);
+      const range = resolveSourceRangeAnchor(previewSource, anchor);
+      const quote = range
+        ? renderedTextForSourceRange(markdownProjection, range.from, range.to)
+        : null;
+      onCreateSourceComment(anchor, rect, quote);
       if (typeof window !== "undefined") {
         window.getSelection()?.removeAllRanges();
       }
@@ -565,7 +576,9 @@ export const MarkdownCell = memo(function MarkdownCell({
     },
     [
       clearRenderedSourceCommentTarget,
+      markdownProjection,
       onCreateSourceComment,
+      previewSource,
       renderedSourceCommentTarget,
       requestRenderedSourceComment,
     ],
@@ -1066,6 +1079,7 @@ export const MarkdownCell = memo(function MarkdownCell({
           <RenderedMarkdownContextMenu
             cellId={cell.id}
             source={previewSource}
+            markdownProjection={markdownProjection}
             viewRef={viewRef}
             onCreateSourceComment={canCommentOnRenderedMarkdown ? onCreateSourceComment : undefined}
           >

--- a/apps/notebook/src/components/NotebookView.tsx
+++ b/apps/notebook/src/components/NotebookView.tsx
@@ -93,6 +93,7 @@ export interface NotebookViewProps {
   onCreateSourceComment?: (
     anchor: SourceRangeCommentAnchor,
     rect: SourceCommentSelectionRect | null,
+    quote?: string | null,
   ) => void;
   onCreateOutputComment?: (anchor: OutputCommentAnchor) => void;
   onActivateCommentThread?: (threadId: string) => void;

--- a/apps/notebook/src/components/RawCell.tsx
+++ b/apps/notebook/src/components/RawCell.tsx
@@ -47,6 +47,7 @@ interface RawCellProps {
   onCreateSourceComment?: (
     anchor: SourceRangeCommentAnchor,
     rect: SourceCommentSelectionRect | null,
+    quote?: string | null,
   ) => void;
   onActivateCommentThread?: (threadId: string) => void;
 }

--- a/apps/notebook/src/components/RenderedMarkdownContextMenu.tsx
+++ b/apps/notebook/src/components/RenderedMarkdownContextMenu.tsx
@@ -7,19 +7,26 @@ import {
   type NotebookContextMenuGroup,
 } from "@/components/notebook/NotebookContextMenu";
 import {
+  resolveSourceRangeAnchor,
   selectionRectFromDomSelection,
   type SourceCommentSelectionRect,
   type SourceRangeCommentAnchor,
 } from "../lib/comment-source-anchor";
+import {
+  renderedTextForSourceRange,
+  type MarkdownProjectionPlan,
+} from "../lib/markdown-projection";
 import { sourceRangeAnchorFromRenderedMarkdownSelection } from "../lib/rendered-markdown-source-comment";
 
 interface RenderedMarkdownContextMenuProps {
   cellId: string;
   source: string;
+  markdownProjection: MarkdownProjectionPlan | null;
   viewRef: RefObject<HTMLDivElement | null>;
   onCreateSourceComment?: (
     anchor: SourceRangeCommentAnchor,
     rect: SourceCommentSelectionRect | null,
+    quote?: string | null,
   ) => void;
   children: ReactNode;
 }
@@ -78,6 +85,7 @@ export function buildRenderedMarkdownContextGroups({
 export function RenderedMarkdownContextMenu({
   cellId,
   source,
+  markdownProjection,
   viewRef,
   onCreateSourceComment,
   children,
@@ -106,12 +114,21 @@ export function RenderedMarkdownContextMenu({
         onCopy: clipboardPayload ? () => copyRenderedSelection(clipboardPayload) : undefined,
         onAddComment:
           anchor && onCreateSourceComment
-            ? () =>
-                onCreateSourceComment(anchor, selectionRectFromDomSelection(currentDomSelection()))
+            ? () => {
+                const range = resolveSourceRangeAnchor(source, anchor);
+                const quote = range
+                  ? renderedTextForSourceRange(markdownProjection, range.from, range.to)
+                  : null;
+                onCreateSourceComment(
+                  anchor,
+                  selectionRectFromDomSelection(currentDomSelection()),
+                  quote,
+                );
+              }
             : undefined,
       }),
     );
-  }, [cellId, onCreateSourceComment, source, viewRef]);
+  }, [cellId, markdownProjection, onCreateSourceComment, source, viewRef]);
 
   const handleOpenChange = useCallback(
     (open: boolean) => {

--- a/apps/notebook/src/lib/__tests__/markdown-projection.test.ts
+++ b/apps/notebook/src/lib/__tests__/markdown-projection.test.ts
@@ -1,4 +1,8 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type {
+  MarkdownProjectionPlan,
+  MarkdownProjectionRun,
+} from "../markdown-projection";
 
 vi.mock("../../wasm/runtimed-wasm/runtimed_wasm.js", () => ({
   project_markdown_json: vi.fn(() => {
@@ -88,4 +92,114 @@ describe("markdown projection", () => {
     expect(module.projectMarkdownPlan("# Title")).toBeNull();
     expect(warnSpy).toHaveBeenCalledTimes(1);
   });
+
+  describe("renderedTextForSourceRange", () => {
+    it("slices transparent runs by source offsets", () => {
+      const source = "abcdef";
+      const plan = testPlan(source, [
+        testRun({ inlineId: "r0", renderedText: "abcdef", sourceSpanUtf16: [0, 6] }),
+      ]);
+
+      expect(module.renderedTextForSourceRange(plan, 2, 5)).toBe("cde");
+    });
+
+    it("skips markdown delimiters between transparent runs", () => {
+      const source = "some markdown text it is **good**";
+      const plan = testPlan(source, [
+        testRun({
+          inlineId: "plain",
+          renderedText: "some markdown text it is ",
+          sourceSpanUtf16: [0, 25],
+        }),
+        testRun({
+          inlineId: "strong",
+          renderedText: "good",
+          semantic: "strong",
+          sourceSpanUtf16: [27, 31],
+        }),
+      ]);
+
+      expect(module.renderedTextForSourceRange(plan, 2, 31)).toBe(
+        "me markdown text it is good",
+      );
+    });
+
+    it("uses the whole rendered text for opaque runs", () => {
+      const source = "![kitten](cat.png)";
+      const plan = testPlan(source, [
+        testRun({
+          inlineId: "image",
+          renderedText: "kitten",
+          semantic: "image",
+          sourceSpanUtf16: [0, source.length],
+        }),
+      ]);
+
+      expect(module.renderedTextForSourceRange(plan, 0, source.length)).toBe("kitten");
+    });
+
+    it("normalizes whitespace across runs", () => {
+      const source = "alpha \n\t beta";
+      const plan = testPlan(source, [
+        testRun({ inlineId: "r0", renderedText: "alpha \n", sourceSpanUtf16: [0, 7] }),
+        testRun({ inlineId: "r1", renderedText: "\t beta", sourceSpanUtf16: [7, 13] }),
+      ]);
+
+      expect(module.renderedTextForSourceRange(plan, 0, source.length)).toBe("alpha beta");
+    });
+
+    it("returns null for null plans and empty rendered ranges", () => {
+      const source = "abcdef";
+      const plan = testPlan(source, [
+        testRun({ inlineId: "r0", renderedText: "abcdef", sourceSpanUtf16: [0, 6] }),
+      ]);
+
+      expect(module.renderedTextForSourceRange(null, 0, 3)).toBeNull();
+      expect(module.renderedTextForSourceRange(plan, 2, 2)).toBeNull();
+      expect(module.renderedTextForSourceRange(plan, 6, 8)).toBeNull();
+    });
+  });
 });
+
+function testPlan(
+  source: string,
+  runs: readonly MarkdownProjectionRun[],
+): MarkdownProjectionPlan {
+  return {
+    version: 1,
+    engine: "test",
+    byteLength: source.length,
+    utf16Length: source.length,
+    measurement: {
+      estimatedHeight: 32,
+      confidence: "high",
+      width: 720,
+    },
+    anchors: [],
+    blocks: [],
+    runs,
+  };
+}
+
+function testRun({
+  inlineId,
+  renderedText,
+  sourceSpanUtf16,
+  semantic = "text",
+}: {
+  inlineId: string;
+  renderedText: string;
+  sourceSpanUtf16: readonly [number, number];
+  semantic?: string;
+}): MarkdownProjectionRun {
+  return {
+    blockId: "b0",
+    inlineId,
+    listItemIndex: null,
+    renderedText,
+    renderedTextUtf16: [0, renderedText.length],
+    semantic,
+    sourceSpanByte: sourceSpanUtf16,
+    sourceSpanUtf16,
+  };
+}

--- a/apps/notebook/src/lib/source-comment-extension.ts
+++ b/apps/notebook/src/lib/source-comment-extension.ts
@@ -12,6 +12,7 @@ import {
 export type SourceCommentRequestHandler = (
   anchor: SourceRangeCommentAnchor,
   rect: SourceCommentSelectionRect | null,
+  quote?: string | null,
 ) => void;
 
 const setSourceCommentFocusEffect = StateEffect.define<boolean>();

--- a/docs/memos/projection-source-rendered-correspondence.md
+++ b/docs/memos/projection-source-rendered-correspondence.md
@@ -95,7 +95,7 @@ assumption. The projector does **not** fold delimiters into styled runs:
   correspondence.
 
 So for the genuinely character-faithful cases (plain text, strong, emphasis,
-delete, inline code, and inline links written as `[label](url)`) a run is already
+delete, inline code, and inline links of the `[label]` + `(url)` form) a run is
 **transparent**: its rendered text equals its source slice, one to one. The host
 can sub-slice those by character with no projector change. Math, images,
 reference links, and runs that decode entities or escapes are not transparent and

--- a/docs/memos/projection-source-rendered-correspondence.md
+++ b/docs/memos/projection-source-rendered-correspondence.md
@@ -1,0 +1,198 @@
+# Source ↔ Rendered Projection Correspondence
+
+**Status:** Exploration
+**Created:** 2026-06-20
+**Audience:** Engineering, design, and AI collaborators
+**Promotes to:** ADR for the markdown projection contract (run granularity,
+fidelity marker, payload version) and a sibling note in
+[`markdown-plan-documents.md`](markdown-plan-documents.md) OC-2 / OC-3.
+
+## Why now
+
+Inline comments on rendered markdown surfaced a coordinate-space gap. Selecting
+"is some markdown text it is **good**" in the rendered plane captures the right
+range, but after the comment commits, the highlight balloons to the whole
+paragraph, and the quote preview reads `me markdown text it is **good**` with
+the source delimiters showing.
+
+The bug is not styling. It is that we have two coordinate spaces (raw markdown
+source and rendered text) and we cross between them at inconsistent granularity.
+The same crossing is the primitive a rich/WYSIWYG editor will need: map a
+rendered caret or edit back to a source offset, mutate the Automerge document,
+re-project. Getting the correspondence right for comments builds the thing
+editing needs anyway. This memo names the model and the one contract change that
+makes it robust.
+
+## The asymmetry
+
+The pipeline has two halves and only one is broken.
+
+**Read (selection → anchor) is character-granular and correct.** A DOM `Range`
+is mapped to source offsets per character.
+`rendered-markdown-source-comment.ts` walks up to the enclosing run span
+(`data-markdown-source-run`), measures the rendered-text offset within the run
+(`textOffsetWithin`, ~line 83), and maps it to a source offset
+(`sourceOffsetForRenderedPoint`, ~line 95). For runs where rendered length
+equals source length it interpolates linearly. The selection rectangle and the
+"Comment" affordance land exactly where the user dragged.
+
+**Write-back (anchor → highlight) is run-granular and balloons.**
+`ProjectedMarkdownView.commentHighlightForRun` (~line 729) does an *overlap*
+test between the resolved anchor span and each run's `sourceSpanUtf16`, then
+`renderRuns` (~line 701) applies the `.comment-highlight` class to the **entire
+run's `<span>`**. A run cannot be partially highlighted. An anchor that starts
+mid-run lights the whole run; an anchor spanning a plain run plus an adjacent
+strong run lights both runs end to end. That is the visible balloon.
+
+**Quote display is a raw source slice, so it carries syntax.** `exact_quote` is
+`source.slice(from, to)` (`comment-source-anchor.ts:133`). Delimiters live
+between runs (see below), so any slice spanning them includes the `**`,
+backticks, or link markup. The composer and rail render `exact_quote` verbatim,
+so the user sees source, not what they highlighted.
+
+## The three states and the bridge
+
+1. **Source text**. The Automerge document content, UTF-16 offsets. Anchors
+   are stored here (`source_range`: line/column + `exact_quote` + prefix/suffix
+   context) and must be, so a comment survives edits and re-resolves by quote.
+   This is correct and should not change.
+2. **The projection plan**. The bridge. The Rust projector emits per-run
+   `sourceSpanUtf16` ⇄ `renderedTextUtf16` plus `renderedText` and `semantic`
+   (`src/lib/markdown-projection.ts:44`). This is the only thing that knows how
+   source and rendered relate.
+3. **The rendered DOM**. What the user sees, selects, and (later) edits.
+
+Each rendering plane already re-projects the stored anchor independently
+(CodeMirror decorations in source mode, run overlap in rendered mode). That
+single-source-of-truth shape is right. The defect is purely the *granularity* at
+which the rendered plane crosses the bridge.
+
+## What the projector already gives us
+
+Grounding the emit side (`crates/nteract-markdown-wasm/src/lib.rs`,
+`crates/nteract-markdown-engine/src/lib.rs`) corrects a tempting but wrong
+assumption. The projector does **not** fold delimiters into styled runs:
+
+- For `**good**`, the `Strong` node spans the whole `[0,8]`, but the inner text
+  run is emitted with the content-only span `[2,6]` and `renderedText` `"good"`.
+  The `**` regions become `syntaxSpans` on the block, not runs (`add_run` ~745,
+  `add_outer_syntax_spans` ~585).
+- Inline code and inline math strip their delimiters too
+  (`collect_delimited_inline` ~515): a run's source span points at the content
+  inside the ticks or dollars.
+- The exception is images. `![alt](url)` emits one run whose source span covers
+  the full markup but whose `renderedText` is just the alt text. There is no
+  interior correspondence.
+
+So for the common cases (plain text, strong, emphasis, delete, inline code,
+math) a run is already **transparent**: its rendered text equals its source
+slice, one to one. The host can sub-slice it by character with no projector
+change. The work is to make the consumers do that, plus a small marker so the
+host stops guessing which runs are transparent.
+
+## Run fidelity classes
+
+Make the distinction explicit rather than inferred:
+
+- **Transparent run**. `renderedText` is the verbatim source slice of
+  `sourceSpan`. Character offsets interpolate linearly in both directions. The
+  majority of runs.
+- **Opaque run**. `renderedText` differs from the source slice (images today;
+  future: entities like `&amp;`, escapes like `\*`, autolinks where the label
+  differs from the target, hard breaks). No meaningful interior mapping.
+  Selection, highlight, and caret snap to run boundaries, which is acceptable
+  because there is no sub-position to land on.
+
+Today the host infers this with `renderedLength === sourceLength`. That is a
+heuristic, not ground truth: a run can have equal lengths yet not be a verbatim
+slice, or unequal lengths yet be a clean substring. The projector knows the
+truth (it built both strings). It should say so.
+
+**Contract change (the durable decision):** add an authoritative per-run
+fidelity signal to the projection. Smallest form is a boolean (`linearMap` /
+`transparent`); a richer form emits explicit `(sourceSpan, renderedSpan)`
+segments for runs that are piecewise-linear. Start with the boolean. It is an
+additive field on `MarkdownProjectionRun`, hand-mirrored on both sides (no
+ts-rs; `markdown-projection.ts:44` and `WasmRun::push_json` ~826). Bump the
+payload envelope `version` to `2` so prerendered
+`application/vnd.nteract.markdown+json` consumers do not silently misread it
+(`markdownProjectionPlanFromMimeData` ~279 currently rejects anything but `1`).
+
+## Both consumers, one primitive
+
+With fidelity known, both broken consumers derive from the same walk: *given an
+anchor source span, enumerate the covered runs and, for each, intersect at the
+character level.*
+
+- **Highlight (source span → rendered):** for each covered run, compute the
+  intra-run overlap `[max(anchorFrom, runStart), min(anchorTo, runEnd)]`. For a
+  transparent run, map those source offsets to rendered offsets linearly and
+  wrap only those characters in the highlight element. For an opaque run, wrap
+  the whole run. No more whole-paragraph balloon.
+- **Display quote (source span → rendered text):** concatenate the covered
+  runs' `renderedText`, sub-sliced for partial transparent runs. The reader sees
+  "is some markdown text it is good", not `me markdown text it is **good**`. The
+  raw-source `exact_quote` stays on the anchor for re-resolution; it is just no
+  longer what we display.
+- **Selection → anchor (rendered → source):** already character-correct for
+  transparent runs. Formalize it against the fidelity classes and delete the
+  generic snap fallback in `sourceOffsetForRenderedPoint`, replacing it with the
+  explicit transparent-interpolate / opaque-snap split.
+
+Note that the dominant fix (highlight no longer balloons, quote no longer shows
+syntax) is **host-side only** and needs no projector change, because the common
+runs are already transparent. The fidelity marker is what makes the opaque cases
+correct and removes the host heuristic. Sequence accordingly.
+
+## Why this is the rich-editing primitive
+
+A WYSIWYG layer over the same source/projection architecture (the direction
+[`markdown-plan-documents.md`](markdown-plan-documents.md) OC-3 commits to,
+staying on CodeMirror + projection rather than ProseMirror/Lexical) needs
+exactly this correspondence, just exercised for writes:
+
+- map a rendered caret to a source offset to place the insertion point
+- map a rendered edit to a source range to mutate the Automerge body
+- re-project and map the new source position back to a rendered caret
+
+Highlight and quote are the read-only consumers of that map. Building it at
+character granularity now, with an authoritative fidelity marker, means the
+editing work inherits a tested correspondence instead of reinventing it. The
+opaque-run set is also the set a rich editor must treat as atomic widgets
+(images, entities, components), so naming it here pays forward.
+
+## Open questions
+
+- **OQ-1 Fidelity granularity.** Boolean transparent/opaque first, or go
+  straight to piecewise `(sourceSpan, renderedSpan)` segments so autolinks and
+  entities are also character-faithful? Boolean covers the comment bug; segments
+  are what editing eventually wants. Lean boolean now, segments when the first
+  opaque-interior case actually blocks something.
+- **OQ-2 Highlight element shape.** Sub-wrapping a run means injecting highlight
+  spans inside the run span. Confirm this does not fight selection, copy
+  (`handleRenderedMarkdownCopy`), or the shared `--cm-comment-color` /
+  `.comment-highlight` surface used by both planes
+  (`src/styles/comment-highlight.css`).
+- **OQ-3 Overlapping anchors.** Two comments overlapping the same characters
+  need nested or layered highlights. Run-granular code sidestepped this by
+  picking the shortest overlapping highlight; character-granular has to decide
+  stacking.
+- **OQ-4 IsolatedFrame.** Cells that fall back to `IsolatedFrame` have no
+  comment affordance at all today. Out of scope here, tracked separately.
+- **OQ-5 Version handshake.** Confirm every `application/vnd.nteract.markdown+json`
+  producer and consumer moves to `version: 2` together; no older-daemon
+  fallback (repo policy is ship-together schema changes).
+
+## Suggested next steps
+
+1. Host-side character-granular highlight in `ProjectedMarkdownView`
+   (`commentHighlightForRun` / `renderRuns`): wrap only the overlapping
+   characters of each covered run. Fixes the balloon with no projector change.
+2. Host-side run-derived display quote: build the preview from covered runs'
+   rendered text; keep `exact_quote` as the anchor's re-resolution key.
+3. Projector fidelity marker (boolean) + payload `version: 2`; replace the host
+   `renderedLength === sourceLength` heuristic. Update the WASM delimiter-span
+   tests (`projects_multi_character_delimiter_source_spans` ~1347).
+4. Fold the read path onto the same fidelity classes; delete the generic snap.
+5. If this holds up, graduate the contract (run granularity, fidelity marker,
+   payload version) into an ADR and cross-link OC-2.

--- a/docs/memos/projection-source-rendered-correspondence.md
+++ b/docs/memos/projection-source-rendered-correspondence.md
@@ -77,46 +77,73 @@ assumption. The projector does **not** fold delimiters into styled runs:
   run is emitted with the content-only span `[2,6]` and `renderedText` `"good"`.
   The `**` regions become `syntaxSpans` on the block, not runs (`add_run` ~745,
   `add_outer_syntax_spans` ~585).
-- Inline code and inline math strip their delimiters too
-  (`collect_delimited_inline` ~515): a run's source span points at the content
-  inside the ticks or dollars.
-- The exception is images. `![alt](url)` emits one run whose source span covers
-  the full markup but whose `renderedText` is just the alt text. There is no
-  interior correspondence.
+- Inline code strips its delimiters too (`collect_delimited_inline` ~515): the
+  run's source span points at the content inside the ticks, and `renderedText`
+  is that same content.
+- Inline math also strips its `$` delimiters, but it is NOT character-faithful:
+  the run renders as KaTeX HTML, not as `renderedText` characters, so there is no
+  rendered character to map a source offset onto. Display math is further out:
+  `MathBlock` emits a run over the full `$$...$$` span and the host renders it
+  from `block.text` with no run spans at all (`ProjectedMarkdownView.tsx` ~195
+  and ~891, `crates/nteract-markdown-wasm/src/lib.rs:176`). Treat inline math as
+  atomic and display math as outside anchoring scope until a KaTeX-source
+  correspondence is designed.
+- Images are opaque. `![alt](url)` emits one run whose source span covers the
+  full markup but whose `renderedText` is just the alt text. Reference-style
+  links and images (`[label][ref]`, `![alt][ref]`) are the same: the source span
+  covers `[label][ref]` while `renderedText` is only the label. No interior
+  correspondence.
 
-So for the common cases (plain text, strong, emphasis, delete, inline code,
-math) a run is already **transparent**: its rendered text equals its source
-slice, one to one. The host can sub-slice it by character with no projector
-change. The work is to make the consumers do that, plus a small marker so the
-host stops guessing which runs are transparent.
+So for the genuinely character-faithful cases (plain text, strong, emphasis,
+delete, inline code, and inline links written as `[label](url)`) a run is already
+**transparent**: its rendered text equals its source slice, one to one. The host
+can sub-slice those by character with no projector change. Math, images,
+reference links, and runs that decode entities or escapes are not transparent and
+must be handled as atomic or piecewise. The work is to make the consumers respect
+that split, plus a small marker so the host stops guessing.
 
 ## Run fidelity classes
 
-Make the distinction explicit rather than inferred:
+Make the distinction explicit rather than inferred. There are three kinds, not
+two:
 
 - **Transparent run**. `renderedText` is the verbatim source slice of
-  `sourceSpan`. Character offsets interpolate linearly in both directions. The
-  majority of runs.
-- **Opaque run**. `renderedText` differs from the source slice (images today;
-  future: entities like `&amp;`, escapes like `\*`, autolinks where the label
-  differs from the target, hard breaks). No meaningful interior mapping.
+  `sourceSpan`, one to one. Character offsets interpolate linearly in both
+  directions. Plain text, strong, emphasis, delete, inline code, inline links.
+  The majority of prose.
+- **Piecewise run**. Partly verbatim, partly remapped: a text run that decodes an
+  entity (`&amp;` to `&`), unescapes a character (`\*` to `*`), or collapses a
+  soft line break (`\n` to a space). These keep useful prefix/suffix
+  correspondence around the remapped span, so they are not opaque, but a single
+  boolean cannot describe them; they need explicit `(sourceSpan, renderedSpan)`
+  segments to be character-faithful. A soft break is length-preserving (the `\n`
+  and the space are both one code unit), so positions still line up one to one
+  even though the displayed character differs.
+- **Opaque run**. No interior correspondence at all: images, reference-style
+  links and images, inline math (KaTeX HTML), and any host-rendered widget.
   Selection, highlight, and caret snap to run boundaries, which is acceptable
   because there is no sub-position to land on.
 
-Today the host infers this with `renderedLength === sourceLength`. That is a
+Today the host infers fidelity with `renderedLength === sourceLength`. That is a
 heuristic, not ground truth: a run can have equal lengths yet not be a verbatim
-slice, or unequal lengths yet be a clean substring. The projector knows the
-truth (it built both strings). It should say so.
+slice (a soft break), or unequal lengths yet be a clean substring. A stronger
+host-only guard is the content check `plan.source.slice(run.sourceSpan) ===
+run.renderedText`, but the host does not always carry `source`. The projector
+built both strings and knows the truth, so it should say so.
 
-**Contract change (the durable decision):** add an authoritative per-run
-fidelity signal to the projection. Smallest form is a boolean (`linearMap` /
-`transparent`); a richer form emits explicit `(sourceSpan, renderedSpan)`
-segments for runs that are piecewise-linear. Start with the boolean. It is an
-additive field on `MarkdownProjectionRun`, hand-mirrored on both sides (no
-ts-rs; `markdown-projection.ts:44` and `WasmRun::push_json` ~826). Bump the
-payload envelope `version` to `2` so prerendered
-`application/vnd.nteract.markdown+json` consumers do not silently misread it
-(`markdownProjectionPlanFromMimeData` ~279 currently rejects anything but `1`).
+**Contract change (the durable decision):** add an authoritative per-run fidelity
+signal to the projection. A boolean (`transparent`) is the narrow starter, honest
+only for plain text and strong/emphasis/delete/inline-code; piecewise runs
+(entities, escapes, soft breaks) and reference links need the richer form,
+explicit `(sourceSpan, renderedSpan)` segments. The field is **additive and
+optional** on `MarkdownProjectionRun`, hand-mirrored on both sides (no ts-rs;
+`markdown-projection.ts:44` and `WasmRun::push_json` ~826). Because it is
+additive it stays under payload `version: 1`: old consumers ignore an unknown
+field, so do NOT bump to `version: 2` for it. A bump is only warranted by a
+breaking run-granularity change, and even then note the gate is asymmetric, the
+MIME path rejects `version !== 1` (`markdown-projection.ts:279`) but direct
+`projectMarkdownPlan` does not validate version at all, so a bump must update both
+paths together.
 
 ## Both consumers, one primitive
 
@@ -126,23 +153,36 @@ character level.*
 
 - **Highlight (source span → rendered):** for each covered run, compute the
   intra-run overlap `[max(anchorFrom, runStart), min(anchorTo, runEnd)]`. For a
-  transparent run, map those source offsets to rendered offsets linearly and
-  wrap only those characters in the highlight element. For an opaque run, wrap
-  the whole run. No more whole-paragraph balloon.
-- **Display quote (source span → rendered text):** concatenate the covered
-  runs' `renderedText`, sub-sliced for partial transparent runs. The reader sees
-  "is some markdown text it is good", not `me markdown text it is **good**`. The
-  raw-source `exact_quote` stays on the anchor for re-resolution; it is just no
-  longer what we display.
+  transparent run, map those source offsets to rendered offsets linearly and wrap
+  only those characters in the highlight element. For a piecewise or opaque run,
+  wrap the whole run (acceptable, never beyond the run). Guard the transparent
+  path with a length (or, where `source` is available, content) check so a
+  remapped run never produces a wrong sub-range. No more whole-paragraph balloon.
+- **Display quote (source span → rendered text):** at creation, prefer the live
+  `Selection.toString()`; the browser already collapses CSS whitespace, so it is
+  exactly what the user saw. When re-deriving later without a selection (the
+  rail), concatenate the covered runs' `renderedText`, sub-sliced for partial
+  transparent runs, then normalize whitespace to match `white-space: normal`
+  (collapse runs of whitespace, trim). Deriving from `renderedText` rather than
+  `source.slice` is what keeps `**`, image markup, and `<url>` autolink brackets
+  out of the quote. The raw-source `exact_quote` stays on the anchor for
+  re-resolution; it is just no longer what we display.
 - **Selection → anchor (rendered → source):** already character-correct for
   transparent runs. Formalize it against the fidelity classes and delete the
   generic snap fallback in `sourceOffsetForRenderedPoint`, replacing it with the
   explicit transparent-interpolate / opaque-snap split.
 
-Note that the dominant fix (highlight no longer balloons, quote no longer shows
-syntax) is **host-side only** and needs no projector change, because the common
-runs are already transparent. The fidelity marker is what makes the opaque cases
-correct and removes the host heuristic. Sequence accordingly.
+Deriving from `renderedText` handles the cases that would otherwise leak source:
+an image-alt selection yields the alt text (opaque run, whole `renderedText`), an
+autolink yields the bare URL, and a soft-break selection yields a space. The
+residual imprecision is sub-run quote fidelity inside a piecewise run (an entity
+mid-selection), which waits on the segment form of the fidelity marker.
+
+The dominant fix (highlight no longer balloons, quote no longer shows syntax) is
+**host-side only** and needs no projector change, because the character-faithful
+runs are already transparent and the length guard keeps everything else at run
+granularity. The fidelity marker is what later makes piecewise runs
+character-faithful and removes the host heuristic. Sequence accordingly.
 
 ## Why this is the rich-editing primitive
 
@@ -156,10 +196,10 @@ exactly this correspondence, just exercised for writes:
 - re-project and map the new source position back to a rendered caret
 
 Highlight and quote are the read-only consumers of that map. Building it at
-character granularity now, with an authoritative fidelity marker, means the
-editing work inherits a tested correspondence instead of reinventing it. The
-opaque-run set is also the set a rich editor must treat as atomic widgets
-(images, entities, components), so naming it here pays forward.
+character granularity now means the editing work inherits a tested correspondence
+instead of reinventing it. The opaque-run set is also the set a rich editor must
+treat as atomic widgets (images, math, reference links, components), so naming it
+here pays forward.
 
 ## Open questions
 
@@ -168,31 +208,41 @@ opaque-run set is also the set a rich editor must treat as atomic widgets
   entities are also character-faithful? Boolean covers the comment bug; segments
   are what editing eventually wants. Lean boolean now, segments when the first
   opaque-interior case actually blocks something.
-- **OQ-2 Highlight element shape.** Sub-wrapping a run means injecting highlight
-  spans inside the run span. Confirm this does not fight selection, copy
-  (`handleRenderedMarkdownCopy`), or the shared `--cm-comment-color` /
-  `.comment-highlight` surface used by both planes
-  (`src/styles/comment-highlight.css`).
+- **OQ-2 Highlight element shape (required for step 1, not deferred).** Character
+  granularity means injecting highlight `<span>`s inside the run span. This is a
+  step-1 design item: the outer run span and its `data-markdown-source-run` /
+  `data-source-*` attributes must stay intact (selection mapping reads them), and
+  the nested spans must not change the run's text content, so
+  `handleRenderedMarkdownCopy` and the context-menu copy (both build the
+  clipboard from `exact_quote` via a `Selection`/`Range` measurement) keep
+  working. Verify copy explicitly. The shared `--cm-comment-color` /
+  `.comment-highlight` surface (`src/styles/comment-highlight.css`) moves from the
+  run span to the inner highlight span.
 - **OQ-3 Overlapping anchors.** Two comments overlapping the same characters
   need nested or layered highlights. Run-granular code sidestepped this by
   picking the shortest overlapping highlight; character-granular has to decide
-  stacking.
+  stacking. Step 1 keeps the single-best-highlight-per-run choice and highlights
+  only that sub-range; multiple-per-run is deferred.
 - **OQ-4 IsolatedFrame.** Cells that fall back to `IsolatedFrame` have no
   comment affordance at all today. Out of scope here, tracked separately.
-- **OQ-5 Version handshake.** Confirm every `application/vnd.nteract.markdown+json`
-  producer and consumer moves to `version: 2` together; no older-daemon
-  fallback (repo policy is ship-together schema changes).
+- **OQ-5 Marker rollout.** The fidelity marker is additive under `version: 1`, so
+  there is no daemon or consumer handshake to coordinate for it. Only a breaking
+  run-granularity change would need a `version` bump, and that bump must cover
+  both the MIME path and direct `projectMarkdownPlan` together (the version gate
+  is asymmetric today).
 
 ## Suggested next steps
 
 1. Host-side character-granular highlight in `ProjectedMarkdownView`
    (`commentHighlightForRun` / `renderRuns`): wrap only the overlapping
    characters of each covered run. Fixes the balloon with no projector change.
-2. Host-side run-derived display quote: build the preview from covered runs'
-   rendered text; keep `exact_quote` as the anchor's re-resolution key.
-3. Projector fidelity marker (boolean) + payload `version: 2`; replace the host
+2. Host-side display quote: `Selection.toString()` at creation, run-derived plus
+   whitespace-normalized when re-deriving in the rail; keep `exact_quote` as the
+   anchor's re-resolution key.
+3. Projector fidelity marker, additive under `version: 1` (no bump): a boolean
+   for the transparent runs, segments for piecewise runs. Replace the host
    `renderedLength === sourceLength` heuristic. Update the WASM delimiter-span
    tests (`projects_multi_character_delimiter_source_spans` ~1347).
 4. Fold the read path onto the same fidelity classes; delete the generic snap.
-5. If this holds up, graduate the contract (run granularity, fidelity marker,
-   payload version) into an ADR and cross-link OC-2.
+5. If this holds up, graduate the contract (run fidelity classes, the marker
+   shape) into an ADR and cross-link OC-2.

--- a/src/components/markdown/ProjectedMarkdownView.tsx
+++ b/src/components/markdown/ProjectedMarkdownView.tsx
@@ -703,6 +703,8 @@ function renderRuns(runs: MarkdownProjectionRun[], options: RenderRunsOptions = 
 
   const { activeInlineId, commentHighlights, onLinkClick } = options;
   return runs.map((run) => {
+    // Keep choosing one best highlight per run for now; multiple disjoint
+    // highlight fragments in the same run are intentionally deferred.
     const highlight = commentHighlightForRun(run, commentHighlights);
     return (
       <span
@@ -713,14 +715,9 @@ function renderRuns(runs: MarkdownProjectionRun[], options: RenderRunsOptions = 
         data-source-start={run.sourceSpanUtf16[0]}
         data-source-end={run.sourceSpanUtf16[1]}
         data-source-active-run={activeInlineId === run.inlineId ? "true" : undefined}
-        className={cn(
-          activeInlineId === run.inlineId && sourceActiveRunClass,
-          highlight && "comment-highlight",
-          highlight?.resolved && "comment-highlight-resolved",
-        )}
-        style={commentHighlightStyle(highlight)}
+        className={cn(activeInlineId === run.inlineId && sourceActiveRunClass)}
       >
-        {renderRun(run, onLinkClick)}
+        {renderRunWithHighlight(run, highlight, onLinkClick)}
       </span>
     );
   });
@@ -759,6 +756,78 @@ function commentHighlightStyle(
   return { "--cm-comment-color": highlight.color } as CSSProperties;
 }
 
+const splittableRunSemantics = new Set([
+  "text",
+  "heading-text",
+  "list-item",
+  "table-cell",
+  "strong",
+  "emphasis",
+  "delete",
+  "inline-code",
+  "link-label",
+]);
+
+function renderRunWithHighlight(
+  run: MarkdownProjectionRun,
+  highlight: MarkdownCommentHighlight | null,
+  onLinkClick?: (url: string) => void,
+) {
+  if (!highlight) return renderRun(run, onLinkClick);
+
+  if (!canSplitRunForHighlight(run)) {
+    return (
+      <span
+        className={cn("comment-highlight", highlight.resolved && "comment-highlight-resolved")}
+        style={commentHighlightStyle(highlight)}
+      >
+        {renderRun(run, onLinkClick)}
+      </span>
+    );
+  }
+
+  const [runStart, runEnd] = run.sourceSpanUtf16;
+  const highlightStart = Math.min(highlight.from, highlight.to);
+  const highlightEnd = Math.max(highlight.from, highlight.to);
+  const overlapStart = Math.max(highlightStart, runStart);
+  const overlapEnd = Math.min(highlightEnd, runEnd);
+  const length = run.renderedText.length;
+  const start = clamp(overlapStart - runStart, 0, length);
+  const end = clamp(overlapEnd - runStart, 0, length);
+
+  if (end <= start) return renderRun(run, onLinkClick);
+
+  const before = run.renderedText.slice(0, start);
+  const highlighted = run.renderedText.slice(start, end);
+  const after = run.renderedText.slice(end);
+
+  return (
+    <>
+      {before ? renderRunText(run, before, onLinkClick) : null}
+      <span
+        className={cn("comment-highlight", highlight.resolved && "comment-highlight-resolved")}
+        style={commentHighlightStyle(highlight)}
+      >
+        {renderRunText(run, highlighted, onLinkClick)}
+      </span>
+      {after ? renderRunText(run, after, onLinkClick) : null}
+    </>
+  );
+}
+
+function canSplitRunForHighlight(run: MarkdownProjectionRun) {
+  const sourceLength = run.sourceSpanUtf16[1] - run.sourceSpanUtf16[0];
+  return (
+    run.renderedText.length > 0 &&
+    run.renderedText.length === sourceLength &&
+    splittableRunSemantics.has(run.semantic)
+  );
+}
+
+function clamp(value: number, min: number, max: number) {
+  return Math.max(min, Math.min(max, value));
+}
+
 function renderRun(run: MarkdownProjectionRun, onLinkClick?: (url: string) => void) {
   const text = run.renderedText;
   if (run.semantic === "image" && run.imageSrc) {
@@ -775,6 +844,14 @@ function renderRun(run: MarkdownProjectionRun, onLinkClick?: (url: string) => vo
 
   if (!text) return null;
 
+  return renderRunText(run, text, onLinkClick);
+}
+
+function renderRunText(
+  run: MarkdownProjectionRun,
+  text: string,
+  onLinkClick?: (url: string) => void,
+) {
   if (run.href) {
     return (
       <a

--- a/src/components/markdown/__tests__/ProjectedMarkdownView.test.tsx
+++ b/src/components/markdown/__tests__/ProjectedMarkdownView.test.tsx
@@ -128,11 +128,237 @@ describe("ProjectedMarkdownView", () => {
     );
 
     const runs = container.querySelectorAll<HTMLElement>("[data-markdown-source-run='true']");
-    expect(runs[0]).toHaveClass("comment-highlight");
+    const highlights = container.querySelectorAll<HTMLElement>(".comment-highlight");
+    expect(highlights).toHaveLength(2);
+    expect(runs[0]).not.toHaveClass("comment-highlight");
     expect(runs[0]).not.toHaveClass("comment-highlight-resolved");
-    expect(runs[0]?.style.getPropertyValue("--cm-comment-color")).toBe("#d97706");
-    expect(runs[1]).toHaveClass("comment-highlight", "comment-highlight-resolved");
-    expect(runs[1]?.style.getPropertyValue("--cm-comment-color")).toBe("#52525b");
+    expect(highlights[0]).toHaveTextContent("alpha");
+    expect(highlights[0]).not.toHaveClass("comment-highlight-resolved");
+    expect(highlights[0]?.style.getPropertyValue("--cm-comment-color")).toBe("#d97706");
+    expect(runs[1]).not.toHaveClass("comment-highlight");
+    expect(runs[1]).not.toHaveClass("comment-highlight-resolved");
+    expect(highlights[1]).toHaveTextContent("beta");
+    expect(highlights[1]).toHaveClass("comment-highlight-resolved");
+    expect(highlights[1]?.style.getPropertyValue("--cm-comment-color")).toBe("#52525b");
+  });
+
+  it("wraps only the selected characters for partial paragraph highlights", () => {
+    const source = "This is some markdown text it is good";
+    const selected = "some markdown";
+    const { container } = render(
+      <ProjectedMarkdownView
+        commentHighlights={[{ from: 8, to: 21, color: "#d97706", resolved: false }]}
+        plan={plan({
+          blocks: [
+            {
+              blockId: "p0",
+              blockIndex: 0,
+              element: "p",
+              kind: "paragraph",
+              measurement: { estimatedHeight: 32, confidence: "high", width: 720 },
+              sourceSpanByte: [0, source.length],
+              sourceSpanUtf16: [0, source.length],
+              syntaxSpans: [],
+              text: source,
+            },
+          ],
+          runs: [
+            {
+              blockId: "p0",
+              inlineId: "r0",
+              listItemIndex: null,
+              renderedText: source,
+              renderedTextUtf16: [0, source.length],
+              semantic: "text",
+              sourceSpanByte: [0, source.length],
+              sourceSpanUtf16: [0, source.length],
+            },
+          ],
+        })}
+      />,
+    );
+
+    const paragraph = container.querySelector("p");
+    const highlighted = container.querySelector<HTMLElement>(".comment-highlight");
+    const run = container.querySelector<HTMLElement>("[data-markdown-source-run='true']");
+    expect(paragraph).toHaveTextContent(source);
+    expect(highlighted?.textContent).toBe(selected);
+    expect(highlighted).not.toHaveTextContent("This is");
+    expect(highlighted).not.toHaveTextContent("text it is good");
+    expect(run).not.toHaveClass("comment-highlight");
+  });
+
+  it("highlights transparent strong run characters without ballooning to siblings", () => {
+    const { container } = render(
+      <ProjectedMarkdownView
+        commentHighlights={[{ from: 8, to: 12, color: "#d97706", resolved: false }]}
+        plan={plan({
+          blocks: [
+            {
+              blockId: "p0",
+              blockIndex: 0,
+              element: "p",
+              kind: "paragraph",
+              measurement: { estimatedHeight: 32, confidence: "high", width: 720 },
+              sourceSpanByte: [0, 20],
+              sourceSpanUtf16: [0, 20],
+              syntaxSpans: [],
+              text: "alpha bold omega",
+            },
+          ],
+          runs: [
+            {
+              blockId: "p0",
+              inlineId: "before",
+              listItemIndex: null,
+              renderedText: "alpha ",
+              renderedTextUtf16: [0, 6],
+              semantic: "text",
+              sourceSpanByte: [0, 6],
+              sourceSpanUtf16: [0, 6],
+            },
+            {
+              blockId: "p0",
+              inlineId: "strong",
+              listItemIndex: null,
+              renderedText: "bold",
+              renderedTextUtf16: [6, 10],
+              semantic: "strong",
+              sourceSpanByte: [8, 12],
+              sourceSpanUtf16: [8, 12],
+            },
+            {
+              blockId: "p0",
+              inlineId: "after",
+              listItemIndex: null,
+              renderedText: " omega",
+              renderedTextUtf16: [10, 16],
+              semantic: "text",
+              sourceSpanByte: [14, 20],
+              sourceSpanUtf16: [14, 20],
+            },
+          ],
+        })}
+      />,
+    );
+
+    const paragraph = container.querySelector("p");
+    const highlighted = container.querySelector<HTMLElement>(".comment-highlight");
+    expect(paragraph).toHaveTextContent("alpha bold omega");
+    expect(highlighted?.textContent).toBe("bold");
+    expect(highlighted?.querySelector("strong")).toHaveTextContent("bold");
+    expect(highlighted).not.toHaveTextContent("alpha");
+    expect(highlighted).not.toHaveTextContent("omega");
+    expect(container.querySelector("[data-source-start='0'] .comment-highlight")).toBeNull();
+    expect(container.querySelector("[data-source-start='14'] .comment-highlight")).toBeNull();
+  });
+
+  it("keeps opaque image highlights scoped to the image run", () => {
+    const source = "before ![Plot alt](attachment:plot.png) after";
+    const { container } = render(
+      <ProjectedMarkdownView
+        commentHighlights={[{ from: 10, to: 20, color: "#d97706", resolved: false }]}
+        plan={plan({
+          blocks: [
+            {
+              blockId: "p0",
+              blockIndex: 0,
+              element: "p",
+              kind: "paragraph",
+              measurement: { estimatedHeight: 32, confidence: "high", width: 720 },
+              sourceSpanByte: [0, source.length],
+              sourceSpanUtf16: [0, source.length],
+              syntaxSpans: [],
+              text: "before  after",
+            },
+          ],
+          runs: [
+            {
+              blockId: "p0",
+              inlineId: "before",
+              listItemIndex: null,
+              renderedText: "before ",
+              renderedTextUtf16: [0, 7],
+              semantic: "text",
+              sourceSpanByte: [0, 7],
+              sourceSpanUtf16: [0, 7],
+            },
+            {
+              blockId: "p0",
+              imageAlt: "Plot alt",
+              imageSrc: "attachment:plot.png",
+              inlineId: "image",
+              listItemIndex: null,
+              renderedText: "Plot alt",
+              renderedTextUtf16: [7, 15],
+              semantic: "image",
+              sourceSpanByte: [7, 39],
+              sourceSpanUtf16: [7, 39],
+            },
+            {
+              blockId: "p0",
+              inlineId: "after",
+              listItemIndex: null,
+              renderedText: " after",
+              renderedTextUtf16: [15, 21],
+              semantic: "text",
+              sourceSpanByte: [39, 45],
+              sourceSpanUtf16: [39, 45],
+            },
+          ],
+        })}
+      />,
+    );
+
+    const image = screen.getByRole("img", { name: "Plot alt" });
+    const highlighted = image.closest<HTMLElement>(".comment-highlight");
+    const imageRun = highlighted?.parentElement;
+    expect(container.querySelectorAll(".comment-highlight")).toHaveLength(1);
+    expect(highlighted).not.toBeNull();
+    expect(highlighted?.textContent).toBe("");
+    expect(imageRun).toHaveAttribute("data-markdown-source-run", "true");
+    expect(imageRun).toHaveAttribute("data-source-start", "7");
+    expect(imageRun).toHaveAttribute("data-source-end", "39");
+    expect(imageRun).not.toHaveClass("comment-highlight");
+  });
+
+  it("renders runs without highlights without inserting highlight wrappers", () => {
+    const { container } = render(
+      <ProjectedMarkdownView
+        plan={plan({
+          blocks: [
+            {
+              blockId: "p0",
+              blockIndex: 0,
+              element: "p",
+              kind: "paragraph",
+              measurement: { estimatedHeight: 32, confidence: "high", width: 720 },
+              sourceSpanByte: [0, 10],
+              sourceSpanUtf16: [0, 10],
+              syntaxSpans: [],
+              text: "alpha beta",
+            },
+          ],
+          runs: [
+            {
+              blockId: "p0",
+              inlineId: "r0",
+              listItemIndex: null,
+              renderedText: "alpha beta",
+              renderedTextUtf16: [0, 10],
+              semantic: "text",
+              sourceSpanByte: [0, 10],
+              sourceSpanUtf16: [0, 10],
+            },
+          ],
+        })}
+      />,
+    );
+
+    const run = container.querySelector<HTMLElement>("[data-markdown-source-run='true']");
+    expect(container.querySelector(".comment-highlight")).toBeNull();
+    expect(run).toHaveTextContent("alpha beta");
+    expect(run?.children).toHaveLength(0);
   });
 
   it("matches the output document heading rhythm", () => {

--- a/src/components/notebook/NotebookCommentsPanel.tsx
+++ b/src/components/notebook/NotebookCommentsPanel.tsx
@@ -24,6 +24,8 @@ import { cn } from "@/lib/utils";
 import { highlight } from "@/components/editor/static-highlight";
 import { ProjectedMarkdownView } from "../markdown/ProjectedMarkdownView";
 
+type SourceRangeCommentAnchor = Extract<CommentAnchor, { kind: "source_range" }>;
+
 export interface NotebookCommentDraftTarget {
   anchor: CommentAnchor;
   quote?: string | null;
@@ -69,6 +71,11 @@ export interface NotebookCommentsPanelProps {
    * (e.g. markdown prose, raw cells).
    */
   resolveSourceLanguage?: (cellId: string) => string | undefined;
+  /**
+   * Rendered display quote for source-range anchors when the host can resolve
+   * the live cell projection. Falls back to the anchor's exact quote.
+   */
+  resolveSourceQuote?: (anchor: SourceRangeCommentAnchor) => string | null | undefined;
   /** Thread to scroll to and flash (e.g. after clicking its editor highlight). */
   focusedThreadId?: string | null;
   /** Bumped each focus request so repeat focuses of the same thread re-flash. */
@@ -89,6 +96,7 @@ export function NotebookCommentsPanel({
   onFocusThreadAnchor,
   resolveCommentAuthor,
   resolveSourceLanguage,
+  resolveSourceQuote,
   focusedThreadId = null,
   focusNonce = 0,
 }: NotebookCommentsPanelProps) {
@@ -127,6 +135,7 @@ export function NotebookCommentsPanel({
       onFocusThreadAnchor={onFocusThreadAnchor}
       resolveCommentAuthor={resolveCommentAuthor}
       resolveSourceLanguage={resolveSourceLanguage}
+      resolveSourceQuote={resolveSourceQuote}
       focused={thread.id === focusedThreadId}
       focusNonce={focusNonce}
     />
@@ -152,7 +161,11 @@ export function NotebookCommentsPanel({
       ) : null}
 
       {draftTarget ? (
-        <CommentDraftTargetView target={draftTarget} onClear={onClearDraftTarget} />
+        <CommentDraftTargetView
+          target={draftTarget}
+          onClear={onClearDraftTarget}
+          resolveSourceQuote={resolveSourceQuote}
+        />
       ) : null}
 
       <CommentComposer
@@ -216,11 +229,15 @@ export function NotebookCommentsPanel({
 function CommentDraftTargetView({
   target,
   onClear,
+  resolveSourceQuote,
 }: {
   target: NotebookCommentDraftTarget;
   onClear?: () => void;
+  resolveSourceQuote?: (anchor: SourceRangeCommentAnchor) => string | null | undefined;
 }) {
-  const quote = formatQuotePreview(target.quote ?? sourceQuoteFromAnchor(target.anchor));
+  const quote = formatQuotePreview(
+    target.quote ?? sourceQuoteFromAnchor(target.anchor, resolveSourceQuote),
+  );
 
   return (
     <div
@@ -265,6 +282,7 @@ function CommentThreadItem({
   onFocusThreadAnchor,
   resolveCommentAuthor,
   resolveSourceLanguage,
+  resolveSourceQuote,
   focused,
   focusNonce,
 }: {
@@ -278,6 +296,7 @@ function CommentThreadItem({
   onFocusThreadAnchor?: (thread: CommentThreadSnapshot) => void;
   resolveCommentAuthor?: (actorLabel: string) => CommentAuthor;
   resolveSourceLanguage?: (cellId: string) => string | undefined;
+  resolveSourceQuote?: (anchor: SourceRangeCommentAnchor) => string | null | undefined;
   focused?: boolean;
   focusNonce?: number;
 }) {
@@ -320,7 +339,7 @@ function CommentThreadItem({
     }
   };
 
-  const quote = sourceQuoteFromAnchor(thread.anchor);
+  const quote = sourceQuoteFromAnchor(thread.anchor, resolveSourceQuote);
   const threadAuthor = thread.created_by_actor_label
     ? resolveCommentAuthor?.(thread.created_by_actor_label)
     : undefined;
@@ -722,8 +741,12 @@ function anchorLabelForDraft(anchor: CommentAnchor): string {
   }
 }
 
-function sourceQuoteFromAnchor(anchor: CommentAnchor): string | null {
-  return anchor.kind === "source_range" ? (anchor.exact_quote ?? null) : null;
+function sourceQuoteFromAnchor(
+  anchor: CommentAnchor,
+  resolveSourceQuote?: (anchor: SourceRangeCommentAnchor) => string | null | undefined,
+): string | null {
+  if (anchor.kind !== "source_range") return null;
+  return resolveSourceQuote?.(anchor) ?? anchor.exact_quote ?? null;
 }
 
 function commentThreadTargetCellId(thread: CommentThreadSnapshot): string | null {

--- a/src/lib/markdown-projection.ts
+++ b/src/lib/markdown-projection.ts
@@ -272,6 +272,43 @@ export function markdownRunsForSourceRange(
   });
 }
 
+function clampSourceOffset(value: number, min: number, max: number): number {
+  return Math.min(max, Math.max(min, value));
+}
+
+export function renderedTextForSourceRange(
+  plan: MarkdownProjectionPlan | null,
+  from: number,
+  to: number,
+): string | null {
+  if (!plan) return null;
+
+  const start = Math.min(from, to);
+  const end = Math.max(from, to);
+  const parts: string[] = [];
+
+  for (const run of markdownRunsForSourceRange(plan, start, end)) {
+    const [runStart, runEnd] = run.sourceSpanUtf16;
+    const sourceLength = Math.max(0, runEnd - runStart);
+    const renderedLength = run.renderedText.length;
+    const transparent = renderedLength === sourceLength;
+
+    if (transparent) {
+      const sliceStart = clampSourceOffset(start - runStart, 0, renderedLength);
+      const sliceEnd = clampSourceOffset(end - runStart, 0, renderedLength);
+      if (sliceEnd > sliceStart) {
+        parts.push(run.renderedText.slice(sliceStart, sliceEnd));
+      }
+      continue;
+    }
+
+    parts.push(run.renderedText);
+  }
+
+  const rendered = parts.join("").replace(/\s+/g, " ").trim();
+  return rendered.length > 0 ? rendered : null;
+}
+
 export function canRenderMarkdownProjectionInHost(plan: MarkdownProjectionPlan | null): boolean {
   return plan != null;
 }


### PR DESCRIPTION
Rendered-markdown comments cross between two coordinate spaces (raw markdown source and rendered text) at inconsistent granularity. Selecting text captures the right range per character, but after a comment commits the highlight balloons to the whole paragraph and the quote preview shows source delimiters (`me markdown text it is **good**`). This branch fixes both and frames the projection model behind it.

## The model

Three states: source text (where anchors live, correct), the projection plan (the bridge, per-run `sourceSpanUtf16` paired with `renderedTextUtf16`), and the rendered DOM. The defect is only the granularity at which the rendered plane crosses the bridge.

The projector keeps inline delimiters in a block-level `syntaxSpans` side channel, so the common runs (plain text, strong, emphasis, inline code, inline links) are already *transparent*: rendered text equals the source slice, one to one. Math, images, and reference links are *opaque*. So the visible fixes are host-side and need no projector change.

Memo: `docs/memos/projection-source-rendered-correspondence.md`.

## What this does

- **Character-granular highlight.** `ProjectedMarkdownView` wraps only the overlapping characters of each covered run instead of painting the whole run span. The outer run span keeps its `data-*` attributes (selection mapping and copy are unaffected; the run's text content is unchanged, only nesting differs). Opaque runs keep the whole-run highlight. No more whole-paragraph balloon.
- **Run-derived display quote.** A new `renderedTextForSourceRange` helper walks the covered runs, sub-slices transparent runs at the character level, takes whole rendered text for opaque runs, and normalizes whitespace. The composer shows this for rendered-markdown selections; the discussions rail re-derives it per thread from the live cell projection (`resolveSourceQuote`, desktop and cloud), falling back to `exact_quote` for code cells and stale projections. `exact_quote` stays on the anchor as the re-resolution key.

## Behavioral coverage

| Selection | Before | After |
|---|---|---|
| Mid-paragraph plain text | Highlight covers whole paragraph | Highlight covers selected characters |
| Across a `**bold**` word | Quote shows `**bold**` | Quote shows `bold` |
| Partial transparent run | Whole run highlighted | Sub-run highlighted |
| Image alt / math (opaque) | Whole run | Whole run (snap, intended) |
| Rail thread quote | Raw source slice | Rendered text, re-derived from projection |

## Deferred to follow-up

The authoritative per-run fidelity marker (memo step 3) is the projector-contract change that makes piecewise runs (entities, escapes, soft breaks, reference links) character-faithful and removes the host `renderedText.length === sourceLength` heuristic. It is an additive optional field under payload `version: 1`, no version bump. Folding the read path (`sourceOffsetForRenderedPoint`) onto the same fidelity classes and deleting its generic snap also waits for that. The memo graduates to an ADR when the marker lands.

## Status

Draft, two host-side fixes plus the design memo. The memo was design-reviewed before the code (math reclassified as opaque, version bump dropped, piecewise class added, copy-safety promoted). Intended to be tried in-app.
