### PR TITLE
feat(comments): composer restyle, rendered-highlight activation, docked rail

### DIFF
--- a/apps/notebook-cloud/viewer/notebook-viewer.tsx
+++ b/apps/notebook-cloud/viewer/notebook-viewer.tsx
@@ -63,6 +63,8 @@ import { useWidgetStoreRequired } from "@/components/widgets/widget-store-contex
 import { useTheme } from "@/hooks/useTheme";
 import { EnvironmentSummary } from "@/components/environment";
 import {
+  colorForActorIdentity,
+  contrastColorForActorIdentity,
   NotebookClient,
   resolveActorDisplay,
   workstationAttachmentCanExecute,
@@ -528,6 +530,21 @@ export function NotebookViewer({
     resolveSyncAuth,
     widgetStore,
   });
+  // Mirror the desktop app: expose the local author's comment color and a
+  // legible foreground as CSS vars the shared affordance and composer styles
+  // read. The cloud viewer previously set neither, so cloud create surfaces fell
+  // back to the neutral --primary.
+  useEffect(() => {
+    if (!connectionActorLabel) return;
+    const color = colorForActorIdentity(connectionActorLabel);
+    const contrast = contrastColorForActorIdentity(connectionActorLabel);
+    document.documentElement.style.setProperty("--comment-author-color", color);
+    document.documentElement.style.setProperty("--comment-author-contrast", contrast);
+    return () => {
+      document.documentElement.style.removeProperty("--comment-author-color");
+      document.documentElement.style.removeProperty("--comment-author-contrast");
+    };
+  }, [connectionActorLabel]);
   useEffect(() => {
     const liveRuntime = liveRuntimeRef.current;
     if (!liveRuntime) {

--- a/apps/notebook/src/App.tsx
+++ b/apps/notebook/src/App.tsx
@@ -1,6 +1,7 @@
 import { type ReactNode, useCallback, useEffect, useMemo, useRef, useState } from "react";
 import {
   colorForActorIdentity,
+  contrastColorForActorIdentity,
   deriveEnvManager,
   deriveRuntimeKind,
   NotebookClient,
@@ -806,16 +807,20 @@ function AppContent() {
     return [{ participantKey: localPrincipal, label }];
   }, [localActor, peerLabel]);
 
-  // Tint the comment-on-selection affordance with the local author's canonical
-  // color (the same color as their cursor and edits), exposed as a CSS var the
-  // shared affordance styles read. Without it the dot falls back to --primary,
-  // a near-black neutral.
+  // Tint the comment surfaces with the local author's canonical color (the same
+  // color as their cursor and edits), plus a legible foreground for text/icons
+  // painted on that color. Both are CSS vars the shared affordance and composer
+  // styles read. Without them the affordance falls back to --primary (a
+  // near-black neutral) and white.
   useEffect(() => {
     if (!localActor) return;
     const color = colorForActorIdentity(localActor);
+    const contrast = contrastColorForActorIdentity(localActor);
     document.documentElement.style.setProperty("--comment-author-color", color);
+    document.documentElement.style.setProperty("--comment-author-contrast", contrast);
     return () => {
       document.documentElement.style.removeProperty("--comment-author-color");
+      document.documentElement.style.removeProperty("--comment-author-contrast");
     };
   }, [localActor]);
 

--- a/apps/notebook/src/components/InlineCommentComposer.tsx
+++ b/apps/notebook/src/components/InlineCommentComposer.tsx
@@ -21,14 +21,7 @@ export interface InlineCommentComposerProps {
   onCancel: () => void;
 }
 
-type ComposerStyleVariant = "border" | "solid";
-
-const COMMENT_COMPOSER_STYLE_STORAGE_KEY = "nteract.commentComposerStyle";
 const AUTHOR_COLOR = "var(--comment-author-color, var(--primary, #2563eb))";
-// Legible foreground for the author color. Set once on :root next to
-// --comment-author-color (App and the cloud viewer); the white fallback covers
-// the neutral --primary fallback in AUTHOR_COLOR.
-const AUTHOR_CONTRAST = "var(--comment-author-contrast, #ffffff)";
 
 export function InlineCommentComposer({
   rect,
@@ -38,7 +31,6 @@ export function InlineCommentComposer({
 }: InlineCommentComposerProps) {
   const [body, setBody] = useState("");
   const [submitting, setSubmitting] = useState(false);
-  const [composerStyle] = useState<ComposerStyleVariant>(readComposerStylePreference);
   const textareaRef = useRef<HTMLTextAreaElement>(null);
   const justOpenedRef = useRef(true);
 
@@ -88,26 +80,20 @@ export function InlineCommentComposer({
     pointerEvents: "none",
   };
 
-  const isSolidStyle = composerStyle === "solid";
-  const surfaceStyle: CSSProperties = isSolidStyle
-    ? {
-        background: AUTHOR_COLOR,
-        color: AUTHOR_CONTRAST,
-      }
-    : {
-        background: "var(--popover, #ffffff)",
-        border: `1.5px solid ${AUTHOR_COLOR}`,
-      };
-  const textareaStyle: CSSProperties = isSolidStyle
-    ? ({
-        "--comment-composer-placeholder-color": AUTHOR_CONTRAST,
-        caretColor: AUTHOR_CONTRAST,
-        color: AUTHOR_CONTRAST,
-      } as CSSProperties)
-    : { caretColor: AUTHOR_COLOR };
-  const buttonStyle: CSSProperties = isSolidStyle
-    ? { background: AUTHOR_CONTRAST, color: AUTHOR_COLOR }
-    : { background: AUTHOR_COLOR, color: AUTHOR_CONTRAST };
+  // The composer fills with the author color and reads as a colored button:
+  // white text and arrow, rather than the marginally-higher-contrast dark, which
+  // looks muddy on the saturated palette colors. The send chip is a subtle dark
+  // veil so the white arrow stays visible on any author color.
+  const surfaceStyle: CSSProperties = {
+    background: AUTHOR_COLOR,
+    color: "#ffffff",
+  };
+  const textareaStyle: CSSProperties = {
+    "--comment-composer-placeholder-color": "rgba(255, 255, 255, 0.72)",
+    caretColor: "#ffffff",
+    color: "#ffffff",
+  } as CSSProperties;
+  const buttonStyle: CSSProperties = { background: "rgba(0, 0, 0, 0.2)", color: "#ffffff" };
   const canSubmit = !disabled && !submitting && body.trim().length > 0;
 
   return (
@@ -125,10 +111,7 @@ export function InlineCommentComposer({
         align="start"
         sideOffset={8}
         collisionPadding={12}
-        className={cn(
-          "w-80 rounded-2xl p-2.5 shadow-none focus-visible:outline-none",
-          isSolidStyle ? "border-0" : "border",
-        )}
+        className="w-80 rounded-2xl border-0 p-2.5 shadow-none focus-visible:outline-none"
         style={surfaceStyle}
         data-testid="inline-comment-composer"
         onOpenAutoFocus={(event) => {
@@ -159,9 +142,7 @@ export function InlineCommentComposer({
               style={textareaStyle}
               className={cn(
                 "min-h-16 w-full resize-none border-0 bg-transparent py-1 pl-1 pr-10 text-sm leading-5",
-                isSolidStyle
-                  ? "placeholder:text-[var(--comment-composer-placeholder-color)]"
-                  : "text-foreground placeholder:text-muted-foreground",
+                "placeholder:text-[var(--comment-composer-placeholder-color)]",
                 "focus-visible:outline-none",
                 (disabled || submitting) && "cursor-not-allowed opacity-60",
               )}
@@ -183,15 +164,4 @@ export function InlineCommentComposer({
       </PopoverContent>
     </Popover>
   );
-}
-
-function readComposerStylePreference(): ComposerStyleVariant {
-  if (typeof window === "undefined") return "border";
-  try {
-    return window.localStorage?.getItem(COMMENT_COMPOSER_STYLE_STORAGE_KEY) === "solid"
-      ? "solid"
-      : "border";
-  } catch {
-    return "border";
-  }
 }

--- a/apps/notebook/src/components/InlineCommentComposer.tsx
+++ b/apps/notebook/src/components/InlineCommentComposer.tsx
@@ -14,29 +14,31 @@ import type { SourceCommentSelectionRect } from "../lib/comment-source-anchor";
 export interface InlineCommentComposerProps {
   /** Viewport-space rectangle of the selection the comment is anchored to. */
   rect: SourceCommentSelectionRect;
-  /** Selected source text, shown as a quote preview above the input. */
+  /** Selected source text; selection highlighting in the document carries the preview. */
   quote?: string | null;
   disabled?: boolean;
   onSubmit: (body: string) => void | Promise<void>;
   onCancel: () => void;
 }
 
-const MAX_QUOTE_PREVIEW_CHARS = 160;
+type ComposerStyleVariant = "border" | "solid";
 
-/** The author's canonical color, set on :root while a local actor exists, with a
- *  neutral fallback. Every tint below mixes from this so the composer reads as
- *  the author's own voice, not a generic popover. */
+const COMMENT_COMPOSER_STYLE_STORAGE_KEY = "nteract.commentComposerStyle";
 const AUTHOR_COLOR = "var(--comment-author-color, var(--primary, #2563eb))";
+// Legible foreground for the author color. Set once on :root next to
+// --comment-author-color (App and the cloud viewer); the white fallback covers
+// the neutral --primary fallback in AUTHOR_COLOR.
+const AUTHOR_CONTRAST = "var(--comment-author-contrast, #ffffff)";
 
 export function InlineCommentComposer({
   rect,
-  quote,
   disabled = false,
   onSubmit,
   onCancel,
 }: InlineCommentComposerProps) {
   const [body, setBody] = useState("");
   const [submitting, setSubmitting] = useState(false);
+  const [composerStyle] = useState<ComposerStyleVariant>(readComposerStylePreference);
   const textareaRef = useRef<HTMLTextAreaElement>(null);
   const justOpenedRef = useRef(true);
 
@@ -86,15 +88,26 @@ export function InlineCommentComposer({
     pointerEvents: "none",
   };
 
-  // The popover surface is the input: a soft wash of the author's color with a
-  // slightly stronger edge. No drop shadow or focus ring; the tint and the
-  // colored caret carry identity, and a glow read as heavy in-app.
-  const surfaceStyle: CSSProperties = {
-    background: `color-mix(in srgb, ${AUTHOR_COLOR} 6%, var(--popover, #ffffff))`,
-    borderColor: `color-mix(in srgb, ${AUTHOR_COLOR} 36%, var(--border, #e5e5e5))`,
-  };
-
-  const preview = formatQuotePreview(quote);
+  const isSolidStyle = composerStyle === "solid";
+  const surfaceStyle: CSSProperties = isSolidStyle
+    ? {
+        background: AUTHOR_COLOR,
+        color: AUTHOR_CONTRAST,
+      }
+    : {
+        background: "var(--popover, #ffffff)",
+        border: `1.5px solid ${AUTHOR_COLOR}`,
+      };
+  const textareaStyle: CSSProperties = isSolidStyle
+    ? ({
+        "--comment-composer-placeholder-color": AUTHOR_CONTRAST,
+        caretColor: AUTHOR_CONTRAST,
+        color: AUTHOR_CONTRAST,
+      } as CSSProperties)
+    : { caretColor: AUTHOR_COLOR };
+  const buttonStyle: CSSProperties = isSolidStyle
+    ? { background: AUTHOR_CONTRAST, color: AUTHOR_COLOR }
+    : { background: AUTHOR_COLOR, color: AUTHOR_CONTRAST };
   const canSubmit = !disabled && !submitting && body.trim().length > 0;
 
   return (
@@ -112,7 +125,10 @@ export function InlineCommentComposer({
         align="start"
         sideOffset={8}
         collisionPadding={12}
-        className="w-80 rounded-2xl border p-2.5 shadow-none"
+        className={cn(
+          "w-80 rounded-2xl p-2.5 shadow-none focus-visible:outline-none",
+          isSolidStyle ? "border-0" : "border",
+        )}
         style={surfaceStyle}
         data-testid="inline-comment-composer"
         onOpenAutoFocus={(event) => {
@@ -129,16 +145,6 @@ export function InlineCommentComposer({
           if (justOpenedRef.current) event.preventDefault();
         }}
       >
-        {preview ? (
-          <blockquote
-            className="mb-2 max-h-16 overflow-hidden whitespace-pre-wrap break-words pl-2 text-xs leading-5 text-foreground/80"
-            style={{
-              borderLeft: `2px solid color-mix(in srgb, ${AUTHOR_COLOR} 45%, transparent)`,
-            }}
-          >
-            {preview}
-          </blockquote>
-        ) : null}
         <form onSubmit={handleSubmit}>
           <div className="relative">
             <textarea
@@ -150,10 +156,13 @@ export function InlineCommentComposer({
               onChange={(event) => setBody(event.target.value)}
               onKeyDown={handleKeyDown}
               rows={3}
-              style={{ caretColor: AUTHOR_COLOR }}
+              style={textareaStyle}
               className={cn(
                 "min-h-16 w-full resize-none border-0 bg-transparent py-1 pl-1 pr-10 text-sm leading-5",
-                "placeholder:text-muted-foreground focus-visible:outline-none",
+                isSolidStyle
+                  ? "placeholder:text-[var(--comment-composer-placeholder-color)]"
+                  : "text-foreground placeholder:text-muted-foreground",
+                "focus-visible:outline-none",
                 (disabled || submitting) && "cursor-not-allowed opacity-60",
               )}
             />
@@ -161,9 +170,9 @@ export function InlineCommentComposer({
               type="submit"
               aria-label="Comment"
               disabled={!canSubmit}
-              style={{ background: AUTHOR_COLOR }}
+              style={buttonStyle}
               className={cn(
-                "absolute bottom-1 right-0 inline-flex size-8 items-center justify-center rounded-full text-white transition-opacity",
+                "absolute bottom-1 right-0 inline-flex size-8 items-center justify-center rounded-full transition-opacity",
                 !canSubmit && "cursor-not-allowed opacity-40",
               )}
             >
@@ -176,10 +185,13 @@ export function InlineCommentComposer({
   );
 }
 
-function formatQuotePreview(quote: string | null | undefined): string | null {
-  if (!quote) return null;
-  const trimmed = quote.trim();
-  if (trimmed.length === 0) return null;
-  if (quote.length <= MAX_QUOTE_PREVIEW_CHARS) return quote;
-  return `${quote.slice(0, MAX_QUOTE_PREVIEW_CHARS - 3)}...`;
+function readComposerStylePreference(): ComposerStyleVariant {
+  if (typeof window === "undefined") return "border";
+  try {
+    return window.localStorage?.getItem(COMMENT_COMPOSER_STYLE_STORAGE_KEY) === "solid"
+      ? "solid"
+      : "border";
+  } catch {
+    return "border";
+  }
 }

--- a/apps/notebook/src/components/MarkdownCell.tsx
+++ b/apps/notebook/src/components/MarkdownCell.tsx
@@ -314,7 +314,7 @@ export const MarkdownCell = memo(function MarkdownCell({
         {
           from: range.from,
           to: range.to,
-          threadId: thread.id,
+          threadId: thread.threadId,
           resolved: thread.resolved,
           ...(thread.color ? { color: thread.color } : {}),
         },

--- a/apps/notebook/src/components/MarkdownCell.tsx
+++ b/apps/notebook/src/components/MarkdownCell.tsx
@@ -314,6 +314,7 @@ export const MarkdownCell = memo(function MarkdownCell({
         {
           from: range.from,
           to: range.to,
+          threadId: thread.id,
           resolved: thread.resolved,
           ...(thread.color ? { color: thread.color } : {}),
         },
@@ -1104,6 +1105,7 @@ export const MarkdownCell = memo(function MarkdownCell({
                   plan={markdownProjection}
                   commentHighlights={renderedCommentHighlights}
                   headingAnchors={headingAnchors}
+                  onActivateCommentThread={onActivateCommentThread}
                   onLinkClick={handleLinkClick}
                   onTaskCheckedChange={
                     readOnly || !onUpdateSource ? undefined : handleTaskCheckedChange

--- a/apps/notebook/src/components/__tests__/InlineCommentComposer.test.tsx
+++ b/apps/notebook/src/components/__tests__/InlineCommentComposer.test.tsx
@@ -5,8 +5,8 @@ import { InlineCommentComposer } from "../InlineCommentComposer";
 const rect = { left: 20, top: 40, right: 120, bottom: 60 };
 
 describe("InlineCommentComposer", () => {
-  it("shows the selected source as a quote preview", () => {
-    render(
+  it("does not render the selected source as a quote preview", () => {
+    const { container } = render(
       <InlineCommentComposer
         rect={rect}
         quote="sp.diff(f, x)"
@@ -14,7 +14,8 @@ describe("InlineCommentComposer", () => {
         onCancel={vi.fn()}
       />,
     );
-    expect(screen.getByText("sp.diff(f, x)")).toBeVisible();
+    expect(container.querySelector("blockquote")).toBeNull();
+    expect(screen.queryByText("sp.diff(f, x)")).toBeNull();
   });
 
   it("keeps submit disabled until the body has content", () => {

--- a/docs/audits/comments-layer.md
+++ b/docs/audits/comments-layer.md
@@ -1,0 +1,90 @@
+# Commenting Layer Audit
+
+**Date:** 2026-06-21
+**Audience:** Engineering, design
+**Method:** Four read-only auditors over distinct facets (anchors + CommentsDoc sync/authority; selection + projection/highlight; UI flows + feature flag; consistency + a11y + identity), plus hands-on QA. Findings below cite `path:line` and carry a confidence note. Severity is P1 (data-loss / broken core action / wrong anchor), P2 (edge bug / gap), P3 (minor).
+
+This audit followed the rendered-comment projection work in PR #3791. Several findings are the deferred items named in `docs/memos/projection-source-rendered-correspondence.md`; they are marked **deferred (memo)** rather than counted as new.
+
+## Status legend
+
+- **slice** — addressed in the comments design slice that accompanies this audit (composer restyle, rendered-highlight activation, rail restructure).
+- **follow-up** — real, not yet fixed; needs its own change.
+- **deferred (memo)** — already named as deferred in the projection memo; waits on the projector fidelity marker.
+- **known** — intentional current state / planned but unbuilt.
+
+## P1
+
+### F-1 Ambiguous source quote can silently re-anchor to the wrong occurrence — follow-up
+`apps/notebook/src/lib/comment-source-anchor.ts:194`, `:203`; `apps/notebook/src/App.tsx:234`, `:780`.
+`resolveSourceRangeAnchor` returns a match whenever the quote exists anywhere in the cell source, picking the best-scoring occurrence even when prefix/suffix do not confidently disambiguate or scores tie. `sourceRangeAnchorMatchesCurrentCell` treats any non-null resolution as valid. Edit or move one of several identical snippets and a comment can rebind to the wrong one instead of going stale. Fix: tri-state resolution (`resolved` / `ambiguous` / `unresolved`); require a unique occurrence or strong prefix/suffix confirmation, otherwise refuse and surface stale/ambiguous. Confidence: verified in source; wrong-anchor manifestation needs a runtime test.
+
+### COMMENT-003 Rendered highlights look clickable but cannot activate a thread — slice
+`src/styles/comment-highlight.css:6`; `src/components/markdown/ProjectedMarkdownView.tsx:48`; `apps/notebook/src/components/MarkdownCell.tsx:1103`.
+`.comment-highlight` sets `cursor: pointer`, but rendered highlights carry no thread id and no click/keyboard/role; CodeMirror highlights do activate. Confirmed by hands-on QA (clicking a rendered highlight does nothing; the editor works). Fixed in the slice by carrying `threadId` into rendered highlights and wiring click + Enter/Space activation through `onActivateCommentThread`.
+
+### COMMENT-005 Output comment affordance is removed from tab order — follow-up
+`apps/notebook/src/components/CodeCell.tsx:672`, `:902`.
+The "Comment on outputs" button has `tabIndex={-1}`, so creating an output comment is mouse-only. No keyboard path found. Fix: make it keyboard-reachable when output gutter actions are available, or provide a command/context-menu path with visible focus.
+
+### CMT-UI-01 The comments UI feature flag is entirely unbuilt — known
+`src/hooks/useSyncedSettings.ts:98`; `apps/notebook/src/App.tsx:634`; `apps/notebook-cloud/viewer/notebook-viewer.tsx:1210`.
+`FEATURE_FLAG_METADATA` has only `disable_nteract_launcher`; there is no `comments_enabled`. Every entry point (rail, right-click, `Mod-Alt-m`, inline popover, output affordance) is always live in writable sessions. This matches the plan to gate all comment UI behind one switch before stable, but that switch does not exist yet. Fix: add a `comments_enabled` synced setting and gate panel construction, creation handlers, context-menu actions, the CodeMirror keymap/tooltip extensions, the rendered affordance, the inline composer, and the cloud equivalents. Daemon sync stays wired.
+
+## P2
+
+### Selection and projection edges
+- **F1 Images have no rendered-plane anchor — follow-up.** `src/components/markdown/ProjectedMarkdownView.tsx:238`, `:900`; `apps/notebook/src/lib/rendered-markdown-source-comment.ts:75`. `imageOnlyRun` / `ProjectedFigure` bypass `renderRuns` and never emit `data-markdown-source-run` / source offsets, so an image (or its alt text) cannot be selected to comment. Fix: route figures through the source-run-aware wrapper.
+- **F2 Fenced code blocks and display math have no rendered anchors or highlights — follow-up.** `ProjectedMarkdownView.tsx:176`, `:195`, `:701`. Block code and display math render directly, not via run-span wrappers, and `commentHighlights` is not applied. A comment on a code block shows no rendered highlight and the block cannot be selected to comment. Same architectural fix as F1.
+- **F3 Inline KaTeX math can mis-map a selection — follow-up (memo-aligned).** `ProjectedMarkdownView.tsx:875`; `rendered-markdown-source-comment.ts:83`, `:117`. The selection mapper treats `math-source` as transparent on length match, but the DOM is KaTeX HTML, so offsets skew. The memo already classes math as opaque; the selection path needs the same treatment the highlight path got. Confidence: suspected; needs a browser test.
+- **F4 Entities/escapes over-anchor and over-quote the whole run — deferred (memo).** The piecewise-run class. `A &amp; B` selecting the `&` grabs the whole node. Waits on the fidelity marker (segments).
+- **F5 Multiple highlights in one run collapse to one — deferred (memo, OQ-3).** Disjoint comments inside one run show only the best. Fix is to segment the run across all overlaps.
+
+### UI flows
+- **CMT-UI-03 Stale-source inline submit silently drops the draft — follow-up.** `apps/notebook/src/App.tsx:780`; `apps/notebook/src/components/InlineCommentComposer.tsx:54`; cloud `notebook-viewer.tsx:1351`. On a stale source, `handleSubmitSourceComment` clears the request and sets an error without throwing; the composer reads "no exception" as success, unmounts, and the typed body is gone. The error only shows in the rail. Fix: keep the popover open with a local error, or signal failure so the composer holds state.
+- **CMT-UI-02 Rail and reply composers have no cancel path — follow-up.** `src/components/notebook/NotebookCommentsPanel.tsx:623`. Only Cmd/Ctrl+Enter is handled; Escape does nothing and a non-empty draft persists with no discard control. Fix: Escape to clear/collapse + an accessible discard button.
+- **CMT-UI-04 "Show cell" can render and no-op for dangling anchors — follow-up.** `NotebookCommentsPanel.tsx:346`, `:752`; `App.tsx:1010`; cloud `:1518`. The panel decides to show the locate button via one helper, but hosts only use `badge_cell_ids[0]`; a valid-anchor / empty-badge thread renders a button that scrolls nowhere. Fix: share the resolver or hide the button for dangling threads.
+- **CMT-UI-05 `cell` / `cell_range` anchors render but no UI creates them — follow-up.** `src/components/notebook/comment-types.ts:10`; `NotebookCommentsPanel.tsx:712`; `App.tsx:720`. Daemon/agent-created cell threads display and resolve, but humans cannot create them. Fix: add affordances or document these as agent-only kinds.
+
+### Sync and reconnect
+- **F-2 Output comment creation treats unloaded runtime state as valid — follow-up.** `src/components/notebook/output-comment-demotion.ts:23`, `:47`; `App.tsx:739`, `:769`. `outputCommentAnchorMatchesRuntimeState` is `!shouldDemoteOutputCommentAnchor`, so "unknown because unloaded" reads as "valid" for creation during reconnect. The demotion guard for the empty-store window is correct; this is the narrower residual (creation should block on `unknown`, not just avoid demotion). Fix: split into `match` / `stale` / `unknown`; creation requires `match`.
+- **F-3 Rejected CommentsDoc optimistic mutations do not roll back locally — follow-up.** `App.tsx:654`; `crates/runtimed/src/notebook_sync_server/peer_comments_sync.rs:43`, `:55`; cloud `live-sync.ts:635`. Local UI applies a CommentsDoc change, then flushes; daemon strips non-writable changes and Cloud rejects the frame, but client recovery is scoped to sync divergence, not permission/actor rejection. Shared state is safe, but the originating client can render a comment that never landed. Fix: on non-recoverable `COMMENTS_DOC_SYNC` rejection, rebuild the local CommentsDoc from authoritative state; have the daemon return an explicit rejection rather than silent strip.
+
+### Identity and a11y
+- **COMMENT-001 Cloud viewer never sets `--comment-author-color` — follow-up.** `apps/notebook/src/App.tsx:815`; cloud `notebook-viewer.tsx:2066`. Desktop sets it from `colorForActorIdentity(localActor)`; cloud renders the same composer without it, so cloud create surfaces fall back to `--primary`. Fix: set/remove the variable in the cloud viewer the way desktop does.
+- **COMMENT-002 White foreground fails contrast on several author colors — slice (partial).** `packages/runtimed/src/notebook-actor-color.ts`; `src/styles/comment-affordance.css:58`; `InlineCommentComposer.tsx:164`; `NotebookCommentsPanel.tsx:519`. `#d97706`, `#059669`, `#0891b2`, `#65a30d` behind white text run ~3.1 to 3.8:1, under 4.5. Fixed for the composer in the slice via a luminance-based `readableForegroundForColor`; the rail avatars and the affordance pill still need the same helper (follow-up).
+- **COMMENT-004 CodeMirror highlights are mouse-only and screen-reader silent — follow-up.** `apps/notebook/src/lib/comment-highlight-extension.ts:63`, `:217`. Activation is `mousedown` only; no focus target, role, or label. Fix: keyboard activation + accessible annotation.
+- **COMMENT-006 AI attribution is thin and inconsistent — follow-up.** `packages/runtimed/src/notebook-actor-display.ts:43`; `NotebookCommentsPanel.tsx:501`; `comment-highlight-extension.ts:165`. The resolver distinguishes agents (hover shows "AI for ..."), but the rail shows only the agent name plus "· for ..." with an `aria-hidden` bot cue, and rail vs hover disagree. Screen-reader users never hear that a comment is AI-authored. This is the "better notation of AI operating on behalf of the user" goal. Fix: a consistent visible or `sr-only` "AI agent" marker on the byline and resolution receipts.
+- **COMMENT-007 Inline composer has no explicit focus restoration on close — follow-up.** `InlineCommentComposer.tsx:43`, `:101`. On Escape/outside-click the composer calls `onCancel` but does not return focus to the invoking element/selection. Fix: track the invoker and restore focus, or wire `onCloseAutoFocus`. Confidence: suspected; needs a keyboard session.
+
+## P3
+
+- **F6 Source-plane click activation off-by-one — follow-up.** `apps/notebook/src/lib/comment-highlight-extension.ts:69`, `:103`, `:217`. Uses `pos <= highlight.to`, so clicking the character right after a highlight opens that thread. Fix: `pos < highlight.to`, or drive activation from the decoration's `data-comment-thread-id`.
+- **COMMENT-008 Elements doc teaches a stale trust/finalization model — follow-up.** `apps/elements/content/docs/comment-surfaces.mdx:53`. The catalog says the daemon "finalizes" a comment as "trusted," but the shipped model has no visible trusted/finalized state; trust comes from ingress actor binding. Fix: reword to the shipped model.
+
+## Deferred to the projection memo
+
+`docs/memos/projection-source-rendered-correspondence.md` already names these; they wait on the per-run fidelity marker (additive, payload `version: 1`):
+
+- F4 piecewise runs (entities, escapes, soft breaks).
+- F5 multiple highlights per run (OQ-3).
+- F7 IsolatedFrame fallback has no comment affordance (OQ-4): `apps/notebook/src/components/MarkdownCell.tsx:1119`; `src/components/isolated/isolated-frame.tsx:137`. The iframe bridge forwards only mouse events and a `hasSelection` boolean, no source-range/keyup/context-menu/copy/highlight bridge.
+- F3 inline math, opaque treatment in the selection path.
+
+## What held up
+
+- The highlight surface is genuinely centralized: one `.comment-highlight` class + `--cm-comment-color`, shared by CodeMirror (`comment-highlight-extension.ts:66`) and rendered markdown (`ProjectedMarkdownView.tsx:752`), imported by both desktop and Elements, with an Elements catalog entry.
+- The reconnect empty-store window is guarded in the demotion path (the bug from #3762/#3764/#3765 did not recur); F-2 is the narrower creation-side residual.
+- Persistence looks correct: accepted CommentsDoc changes save to sidecar storage, Cloud checkpoints include comments bytes, and public publish records no comments snapshot (off by default).
+- The ADR's "daemon finalizes author/scope/resolve" language is not implemented; the shipped model (comments are authored Automerge changes, authority enforced at sync ingress) matches the ADR's current direction. COMMENT-008 is the stale doc.
+
+## Recommended order
+
+1. **F-1** (P1 wrong-anchor): tri-state anchor resolution. Highest correctness risk.
+2. **COMMENT-003** (P1, in the slice): rendered-highlight activation.
+3. **CMT-UI-03** (draft loss) and **F-3** (optimistic rollback): quiet data-loss / divergence.
+4. **F1 / F2**: route images and code/display-math blocks through source-run wrappers so whole content categories become commentable (same shape as the shipped highlight work).
+5. **COMMENT-001 / COMMENT-002 rail / COMMENT-006**: identity color in cloud, contrast everywhere, AI attribution.
+6. **a11y batch**: COMMENT-004, COMMENT-005, COMMENT-007, CMT-UI-02, F6.
+7. **CMT-UI-01**: the `comments_enabled` flag, before stable.
+8. Projection-memo items when the fidelity marker lands.

--- a/packages/runtimed/src/index.ts
+++ b/packages/runtimed/src/index.ts
@@ -297,8 +297,10 @@ export {
 export {
   CURSOR_COLORS,
   colorForActorIdentity,
+  contrastColorForActorIdentity,
   identityColorKey,
   peerColor,
+  readableForegroundForColor,
 } from "./notebook-actor-color";
 
 // Notebook actor display

--- a/packages/runtimed/src/notebook-actor-color.ts
+++ b/packages/runtimed/src/notebook-actor-color.ts
@@ -40,3 +40,69 @@ export function identityColorKey(actorLabel: string): string {
 export function colorForActorIdentity(actorLabel: string): string {
   return peerColor(identityColorKey(actorLabel));
 }
+
+type RgbColor = { red: number; green: number; blue: number };
+
+const DARK_FOREGROUND = "#111827";
+const LIGHT_FOREGROUND = "#ffffff";
+
+/** Choose the higher-contrast foreground for a hex color background. */
+export function readableForegroundForColor(color: string): "#ffffff" | "#111827" {
+  const background = parseHexColor(color);
+  if (!background) return LIGHT_FOREGROUND;
+
+  const backgroundLuminance = relativeLuminance(background);
+  const lightContrast = contrastRatio(backgroundLuminance, 1);
+  const darkContrast = contrastRatio(
+    backgroundLuminance,
+    relativeLuminance({ red: 17, green: 24, blue: 39 }),
+  );
+
+  return darkContrast > lightContrast ? DARK_FOREGROUND : LIGHT_FOREGROUND;
+}
+
+function parseHexColor(color: string): RgbColor | null {
+  const value = color.trim();
+  const shorthand = /^#([0-9a-f]{3})$/i.exec(value);
+  if (shorthand) {
+    const [red, green, blue] = shorthand[1]
+      .split("")
+      .map((channel) => parseInt(channel + channel, 16));
+    return { red, green, blue };
+  }
+
+  const full = /^#([0-9a-f]{6})$/i.exec(value);
+  if (!full) return null;
+
+  const hex = full[1];
+  return {
+    red: parseInt(hex.slice(0, 2), 16),
+    green: parseInt(hex.slice(2, 4), 16),
+    blue: parseInt(hex.slice(4, 6), 16),
+  };
+}
+
+function relativeLuminance(color: RgbColor): number {
+  const red = linearizedChannel(color.red);
+  const green = linearizedChannel(color.green);
+  const blue = linearizedChannel(color.blue);
+  return 0.2126 * red + 0.7152 * green + 0.0722 * blue;
+}
+
+function linearizedChannel(channel: number): number {
+  const srgb = channel / 255;
+  return srgb <= 0.03928 ? srgb / 12.92 : ((srgb + 0.055) / 1.055) ** 2.4;
+}
+
+function contrastRatio(firstLuminance: number, secondLuminance: number): number {
+  const lighter = Math.max(firstLuminance, secondLuminance);
+  const darker = Math.min(firstLuminance, secondLuminance);
+  return (lighter + 0.05) / (darker + 0.05);
+}
+
+/** Readable foreground (white or near-black) for an actor's identity color.
+ *  Pairs with `colorForActorIdentity` so any surface that paints with an actor's
+ *  color can pick legible text/icons without recomputing luminance per render. */
+export function contrastColorForActorIdentity(actorLabel: string): "#ffffff" | "#111827" {
+  return readableForegroundForColor(colorForActorIdentity(actorLabel));
+}

--- a/src/components/markdown/ProjectedMarkdownView.tsx
+++ b/src/components/markdown/ProjectedMarkdownView.tsx
@@ -1,4 +1,10 @@
-import { type CSSProperties, type ReactNode } from "react";
+import {
+  type CSSProperties,
+  type HTMLAttributes,
+  type KeyboardEvent,
+  type MouseEvent,
+  type ReactNode,
+} from "react";
 import katex from "katex";
 import type {
   MarkdownProjectionBlock,
@@ -48,6 +54,7 @@ import "katex/dist/katex.min.css";
 export interface MarkdownCommentHighlight {
   from: number;
   to: number;
+  threadId: string;
   color?: string;
   resolved: boolean;
 }
@@ -59,6 +66,7 @@ interface ProjectedMarkdownViewProps {
   commentHighlights?: ReadonlyArray<MarkdownCommentHighlight>;
   colorTheme?: "classic" | "cream";
   headingAnchors?: readonly MarkdownHeadingAnchor[];
+  onActivateCommentThread?: (threadId: string) => void;
   onLinkClick?: (url: string) => void;
   onTaskCheckedChange?: (run: MarkdownProjectionRun, checked: boolean) => void;
 }
@@ -70,6 +78,7 @@ export function ProjectedMarkdownView({
   commentHighlights,
   colorTheme: colorThemeOverride,
   headingAnchors = [],
+  onActivateCommentThread,
   onLinkClick,
   onTaskCheckedChange,
 }: ProjectedMarkdownViewProps) {
@@ -105,6 +114,7 @@ export function ProjectedMarkdownView({
           commentHighlights={commentHighlights}
           isDark={isDark}
           runs={runsByBlock.get(block.blockId) ?? []}
+          onActivateCommentThread={onActivateCommentThread}
           onLinkClick={onLinkClick}
           onTaskCheckedChange={onTaskCheckedChange}
         />
@@ -122,6 +132,7 @@ interface ProjectedMarkdownBlockProps {
   commentHighlights?: ReadonlyArray<MarkdownCommentHighlight>;
   isDark: boolean;
   runs: MarkdownProjectionRun[];
+  onActivateCommentThread?: (threadId: string) => void;
   onLinkClick?: (url: string) => void;
   onTaskCheckedChange?: (run: MarkdownProjectionRun, checked: boolean) => void;
 }
@@ -135,6 +146,7 @@ function ProjectedMarkdownBlock({
   commentHighlights,
   isDark,
   runs,
+  onActivateCommentThread,
   onLinkClick,
   onTaskCheckedChange,
 }: ProjectedMarkdownBlockProps) {
@@ -152,7 +164,12 @@ function ProjectedMarkdownBlock({
         data-source-active={activeBlockId === block.blockId ? "true" : undefined}
         className={cn(activeBlockId === block.blockId && sourceActiveBlockClass)}
       >
-        {renderRuns(runs, { activeInlineId, commentHighlights, onLinkClick })}
+        {renderRuns(runs, {
+          activeInlineId,
+          commentHighlights,
+          onActivateCommentThread,
+          onLinkClick,
+        })}
       </MarkdownHeading>
     );
   }
@@ -167,6 +184,7 @@ function ProjectedMarkdownBlock({
         activeInlineId={activeInlineId}
         commentHighlights={commentHighlights}
         ordered={ordered}
+        onActivateCommentThread={onActivateCommentThread}
         onLinkClick={onLinkClick}
         onTaskCheckedChange={onTaskCheckedChange}
       />
@@ -209,7 +227,12 @@ function ProjectedMarkdownBlock({
         data-source-active={activeBlockId === block.blockId ? "true" : undefined}
         className={cn(activeBlockId === block.blockId && sourceActiveBlockClass)}
       >
-        {renderRuns(runs, { activeInlineId, commentHighlights, onLinkClick })}
+        {renderRuns(runs, {
+          activeInlineId,
+          commentHighlights,
+          onActivateCommentThread,
+          onLinkClick,
+        })}
       </MarkdownBlockquote>
     );
   }
@@ -226,6 +249,7 @@ function ProjectedMarkdownBlock({
         commentHighlights={commentHighlights}
         runs={runs}
         fallbackText={block.text}
+        onActivateCommentThread={onActivateCommentThread}
         onLinkClick={onLinkClick}
       />
     );
@@ -243,6 +267,7 @@ function ProjectedMarkdownBlock({
           active={activeBlockId === block.blockId}
           activeInlineId={activeInlineId}
           commentHighlights={commentHighlights}
+          onActivateCommentThread={onActivateCommentThread}
           run={figureRun}
         />
       );
@@ -256,7 +281,12 @@ function ProjectedMarkdownBlock({
           activeBlockId === block.blockId && sourceActiveBlockClass,
         )}
       >
-        {renderRuns(runs, { activeInlineId, commentHighlights, onLinkClick })}
+        {renderRuns(runs, {
+          activeInlineId,
+          commentHighlights,
+          onActivateCommentThread,
+          onLinkClick,
+        })}
       </p>
     );
   }
@@ -266,7 +296,12 @@ function ProjectedMarkdownBlock({
       data-source-active={activeBlockId === block.blockId ? "true" : undefined}
       className={cn("my-2", activeBlockId === block.blockId && sourceActiveBlockClass)}
     >
-      {renderRuns(runs, { activeInlineId, commentHighlights, onLinkClick })}
+      {renderRuns(runs, {
+        activeInlineId,
+        commentHighlights,
+        onActivateCommentThread,
+        onLinkClick,
+      })}
     </div>
   ) : null;
 }
@@ -301,6 +336,7 @@ function ProjectedList({
   activeInlineId,
   commentHighlights,
   ordered,
+  onActivateCommentThread,
   onLinkClick,
   onTaskCheckedChange,
 }: {
@@ -309,6 +345,7 @@ function ProjectedList({
   activeInlineId?: string;
   commentHighlights?: ReadonlyArray<MarkdownCommentHighlight>;
   ordered: boolean;
+  onActivateCommentThread?: (threadId: string) => void;
   onLinkClick?: (url: string) => void;
   onTaskCheckedChange?: (run: MarkdownProjectionRun, checked: boolean) => void;
 }) {
@@ -336,6 +373,7 @@ function ProjectedList({
           activeInlineId={activeInlineId}
           commentHighlights={commentHighlights}
           taskProtocol={allItemsAreTasks}
+          onActivateCommentThread={onActivateCommentThread}
           onLinkClick={onLinkClick}
           onTaskCheckedChange={onTaskCheckedChange}
         />
@@ -349,6 +387,7 @@ function ProjectedListItem({
   activeInlineId,
   commentHighlights,
   taskProtocol,
+  onActivateCommentThread,
   onLinkClick,
   onTaskCheckedChange,
 }: {
@@ -356,6 +395,7 @@ function ProjectedListItem({
   activeInlineId?: string;
   commentHighlights?: ReadonlyArray<MarkdownCommentHighlight>;
   taskProtocol: boolean;
+  onActivateCommentThread?: (threadId: string) => void;
   onLinkClick?: (url: string) => void;
   onTaskCheckedChange?: (run: MarkdownProjectionRun, checked: boolean) => void;
 }) {
@@ -379,7 +419,12 @@ function ProjectedListItem({
         />
       ) : null}
       <ProjectedTaskContent checked={checked}>
-        {renderRuns(item.runs, { activeInlineId, commentHighlights, onLinkClick })}
+        {renderRuns(item.runs, {
+          activeInlineId,
+          commentHighlights,
+          onActivateCommentThread,
+          onLinkClick,
+        })}
       </ProjectedTaskContent>
     </>
   );
@@ -414,6 +459,7 @@ function ProjectedListItem({
           activeInlineId={activeInlineId}
           commentHighlights={commentHighlights}
           ordered={item.children[0]?.ordered ?? false}
+          onActivateCommentThread={onActivateCommentThread}
           onLinkClick={onLinkClick}
           onTaskCheckedChange={onTaskCheckedChange}
         />
@@ -538,6 +584,7 @@ function ProjectedTable({
   activeInlineId,
   commentHighlights,
   fallbackText,
+  onActivateCommentThread,
   onLinkClick,
   runs,
 }: {
@@ -545,6 +592,7 @@ function ProjectedTable({
   activeInlineId?: string;
   commentHighlights?: ReadonlyArray<MarkdownCommentHighlight>;
   fallbackText: string;
+  onActivateCommentThread?: (threadId: string) => void;
   onLinkClick?: (url: string) => void;
   runs: MarkdownProjectionRun[];
 }) {
@@ -585,6 +633,7 @@ function ProjectedTable({
                   {renderRuns(cell.runs, {
                     activeInlineId,
                     commentHighlights,
+                    onActivateCommentThread,
                     onLinkClick,
                   })}
                 </MarkdownTableHeaderCell>
@@ -603,6 +652,7 @@ function ProjectedTable({
                   {renderRuns(cell.runs, {
                     activeInlineId,
                     commentHighlights,
+                    onActivateCommentThread,
                     onLinkClick,
                   })}
                 </MarkdownTableCell>
@@ -695,13 +745,14 @@ function tableCellStyle(align: MarkdownProjectionRun["tableCellAlign"]): CSSProp
 interface RenderRunsOptions {
   activeInlineId?: string;
   commentHighlights?: ReadonlyArray<MarkdownCommentHighlight>;
+  onActivateCommentThread?: (threadId: string) => void;
   onLinkClick?: (url: string) => void;
 }
 
 function renderRuns(runs: MarkdownProjectionRun[], options: RenderRunsOptions = {}) {
   if (runs.length === 0) return null;
 
-  const { activeInlineId, commentHighlights, onLinkClick } = options;
+  const { activeInlineId, commentHighlights, onActivateCommentThread, onLinkClick } = options;
   return runs.map((run) => {
     // Keep choosing one best highlight per run for now; multiple disjoint
     // highlight fragments in the same run are intentionally deferred.
@@ -717,7 +768,7 @@ function renderRuns(runs: MarkdownProjectionRun[], options: RenderRunsOptions = 
         data-source-active-run={activeInlineId === run.inlineId ? "true" : undefined}
         className={cn(activeInlineId === run.inlineId && sourceActiveRunClass)}
       >
-        {renderRunWithHighlight(run, highlight, onLinkClick)}
+        {renderRunWithHighlight(run, highlight, onLinkClick, onActivateCommentThread)}
       </span>
     );
   });
@@ -756,6 +807,35 @@ function commentHighlightStyle(
   return { "--cm-comment-color": highlight.color } as CSSProperties;
 }
 
+type CommentHighlightActivationProps = Pick<
+  HTMLAttributes<HTMLSpanElement>,
+  "aria-label" | "onClick" | "onKeyDown" | "role" | "tabIndex"
+>;
+
+function commentHighlightActivationProps(
+  highlight: MarkdownCommentHighlight | null,
+  onActivateCommentThread?: (threadId: string) => void,
+): CommentHighlightActivationProps {
+  if (!highlight?.threadId || !onActivateCommentThread) return {};
+
+  const activate = () => onActivateCommentThread(highlight.threadId);
+  return {
+    "aria-label": "Open comment thread",
+    onClick: (event: MouseEvent<HTMLSpanElement>) => {
+      event.stopPropagation();
+      activate();
+    },
+    onKeyDown: (event: KeyboardEvent<HTMLSpanElement>) => {
+      if (event.key !== "Enter" && event.key !== " " && event.key !== "Spacebar") return;
+      event.stopPropagation();
+      event.preventDefault();
+      activate();
+    },
+    role: "button",
+    tabIndex: 0,
+  };
+}
+
 const splittableRunSemantics = new Set([
   "text",
   "heading-text",
@@ -772,6 +852,7 @@ function renderRunWithHighlight(
   run: MarkdownProjectionRun,
   highlight: MarkdownCommentHighlight | null,
   onLinkClick?: (url: string) => void,
+  onActivateCommentThread?: (threadId: string) => void,
 ) {
   if (!highlight) return renderRun(run, onLinkClick);
 
@@ -779,6 +860,7 @@ function renderRunWithHighlight(
     return (
       <span
         className={cn("comment-highlight", highlight.resolved && "comment-highlight-resolved")}
+        {...commentHighlightActivationProps(highlight, onActivateCommentThread)}
         style={commentHighlightStyle(highlight)}
       >
         {renderRun(run, onLinkClick)}
@@ -806,6 +888,7 @@ function renderRunWithHighlight(
       {before ? renderRunText(run, before, onLinkClick) : null}
       <span
         className={cn("comment-highlight", highlight.resolved && "comment-highlight-resolved")}
+        {...commentHighlightActivationProps(highlight, onActivateCommentThread)}
         style={commentHighlightStyle(highlight)}
       >
         {renderRunText(run, highlighted, onLinkClick)}
@@ -890,11 +973,13 @@ function ProjectedFigure({
   active,
   activeInlineId,
   commentHighlights,
+  onActivateCommentThread,
   run,
 }: {
   active: boolean;
   activeInlineId?: string;
   commentHighlights?: ReadonlyArray<MarkdownCommentHighlight>;
+  onActivateCommentThread?: (threadId: string) => void;
   run: MarkdownProjectionRun;
 }) {
   const image = <ProjectedImage run={run} />;
@@ -913,6 +998,7 @@ function ProjectedFigure({
             highlight && "comment-highlight",
             highlight?.resolved && "comment-highlight-resolved",
           )}
+          {...commentHighlightActivationProps(highlight, onActivateCommentThread)}
           style={commentHighlightStyle(highlight)}
         >
           {image}

--- a/src/components/markdown/ProjectedMarkdownView.tsx
+++ b/src/components/markdown/ProjectedMarkdownView.tsx
@@ -54,7 +54,9 @@ import "katex/dist/katex.min.css";
 export interface MarkdownCommentHighlight {
   from: number;
   to: number;
-  threadId: string;
+  /** Thread to open on click. Optional: static catalog/demo highlights and any
+   *  non-interactive surface can omit it; activation is wired only when present. */
+  threadId?: string;
   color?: string;
   resolved: boolean;
 }
@@ -816,9 +818,10 @@ function commentHighlightActivationProps(
   highlight: MarkdownCommentHighlight | null,
   onActivateCommentThread?: (threadId: string) => void,
 ): CommentHighlightActivationProps {
-  if (!highlight?.threadId || !onActivateCommentThread) return {};
+  const threadId = highlight?.threadId;
+  if (!threadId || !onActivateCommentThread) return {};
 
-  const activate = () => onActivateCommentThread(highlight.threadId);
+  const activate = () => onActivateCommentThread(threadId);
   return {
     "aria-label": "Open comment thread",
     onClick: (event: MouseEvent<HTMLSpanElement>) => {

--- a/src/components/markdown/__tests__/ProjectedMarkdownView.test.tsx
+++ b/src/components/markdown/__tests__/ProjectedMarkdownView.test.tsx
@@ -84,8 +84,8 @@ describe("ProjectedMarkdownView", () => {
     const { container } = render(
       <ProjectedMarkdownView
         commentHighlights={[
-          { from: 0, to: 20, color: "#d97706", resolved: false },
-          { from: 6, to: 10, color: "#52525b", resolved: true },
+          { from: 0, to: 20, threadId: "thread-open", color: "#d97706", resolved: false },
+          { from: 6, to: 10, threadId: "thread-resolved", color: "#52525b", resolved: true },
         ]}
         plan={plan({
           blocks: [
@@ -142,12 +142,111 @@ describe("ProjectedMarkdownView", () => {
     expect(highlights[1]?.style.getPropertyValue("--cm-comment-color")).toBe("#52525b");
   });
 
+  it("activates rendered comment highlights on click", () => {
+    const onActivateCommentThread = vi.fn();
+    const onOuterClick = vi.fn();
+    const { container } = render(
+      <div onClick={onOuterClick}>
+        <ProjectedMarkdownView
+          onActivateCommentThread={onActivateCommentThread}
+          commentHighlights={[
+            { from: 0, to: 5, threadId: "thread-alpha", color: "#d97706", resolved: false },
+          ]}
+          plan={plan({
+            blocks: [
+              {
+                blockId: "p0",
+                blockIndex: 0,
+                element: "p",
+                kind: "paragraph",
+                measurement: { estimatedHeight: 32, confidence: "high", width: 720 },
+                sourceSpanByte: [0, 10],
+                sourceSpanUtf16: [0, 10],
+                syntaxSpans: [],
+                text: "alpha beta",
+              },
+            ],
+            runs: [
+              {
+                blockId: "p0",
+                inlineId: "r0",
+                listItemIndex: null,
+                renderedText: "alpha beta",
+                renderedTextUtf16: [0, 10],
+                semantic: "text",
+                sourceSpanByte: [0, 10],
+                sourceSpanUtf16: [0, 10],
+              },
+            ],
+          })}
+        />
+      </div>,
+    );
+
+    const highlighted = container.querySelector<HTMLElement>(".comment-highlight");
+    expect(highlighted).not.toBeNull();
+
+    fireEvent.click(highlighted!);
+
+    expect(onActivateCommentThread).toHaveBeenCalledTimes(1);
+    expect(onActivateCommentThread).toHaveBeenCalledWith("thread-alpha");
+    expect(onOuterClick).not.toHaveBeenCalled();
+  });
+
+  it("activates rendered comment highlights with Enter", () => {
+    const onActivateCommentThread = vi.fn();
+    render(
+      <ProjectedMarkdownView
+        onActivateCommentThread={onActivateCommentThread}
+        commentHighlights={[
+          { from: 0, to: 5, threadId: "thread-alpha", color: "#d97706", resolved: false },
+        ]}
+        plan={plan({
+          blocks: [
+            {
+              blockId: "p0",
+              blockIndex: 0,
+              element: "p",
+              kind: "paragraph",
+              measurement: { estimatedHeight: 32, confidence: "high", width: 720 },
+              sourceSpanByte: [0, 10],
+              sourceSpanUtf16: [0, 10],
+              syntaxSpans: [],
+              text: "alpha beta",
+            },
+          ],
+          runs: [
+            {
+              blockId: "p0",
+              inlineId: "r0",
+              listItemIndex: null,
+              renderedText: "alpha beta",
+              renderedTextUtf16: [0, 10],
+              semantic: "text",
+              sourceSpanByte: [0, 10],
+              sourceSpanUtf16: [0, 10],
+            },
+          ],
+        })}
+      />,
+    );
+
+    fireEvent.keyDown(screen.getByRole("button", { name: "Open comment thread" }), {
+      key: "Enter",
+    });
+
+    expect(onActivateCommentThread).toHaveBeenCalledTimes(1);
+    expect(onActivateCommentThread).toHaveBeenCalledWith("thread-alpha");
+  });
+
   it("wraps only the selected characters for partial paragraph highlights", () => {
     const source = "This is some markdown text it is good";
     const selected = "some markdown";
     const { container } = render(
       <ProjectedMarkdownView
-        commentHighlights={[{ from: 8, to: 21, color: "#d97706", resolved: false }]}
+        commentHighlights={[
+          { from: 8, to: 21, threadId: "thread-partial", color: "#d97706", resolved: false },
+        ]}
         plan={plan({
           blocks: [
             {
@@ -191,7 +290,9 @@ describe("ProjectedMarkdownView", () => {
   it("highlights transparent strong run characters without ballooning to siblings", () => {
     const { container } = render(
       <ProjectedMarkdownView
-        commentHighlights={[{ from: 8, to: 12, color: "#d97706", resolved: false }]}
+        commentHighlights={[
+          { from: 8, to: 12, threadId: "thread-strong", color: "#d97706", resolved: false },
+        ]}
         plan={plan({
           blocks: [
             {
@@ -257,7 +358,9 @@ describe("ProjectedMarkdownView", () => {
     const source = "before ![Plot alt](attachment:plot.png) after";
     const { container } = render(
       <ProjectedMarkdownView
-        commentHighlights={[{ from: 10, to: 20, color: "#d97706", resolved: false }]}
+        commentHighlights={[
+          { from: 10, to: 20, threadId: "thread-image", color: "#d97706", resolved: false },
+        ]}
         plan={plan({
           blocks: [
             {

--- a/src/components/notebook/NotebookCommentsPanel.tsx
+++ b/src/components/notebook/NotebookCommentsPanel.tsx
@@ -142,86 +142,100 @@ export function NotebookCommentsPanel({
   );
 
   return (
-    <section className="flex min-h-0 flex-col gap-3" data-testid="notebook-comments-panel">
-      {statusMessage ? (
-        <div
-          className="rounded-md border border-dashed px-3 py-2 text-sm text-muted-foreground"
-          role="status"
-        >
-          {statusMessage}
-        </div>
-      ) : null}
-      {errorMessage ? (
-        <div
-          className="rounded-md border border-destructive/40 bg-destructive/5 px-3 py-2 text-sm text-destructive"
-          role="alert"
-        >
-          {errorMessage}
-        </div>
-      ) : null}
-
-      {draftTarget ? (
-        <CommentDraftTargetView
-          target={draftTarget}
-          onClear={onClearDraftTarget}
-          resolveSourceQuote={resolveSourceQuote}
-        />
-      ) : null}
-
-      <CommentComposer
-        ariaLabel={
-          draftTarget
-            ? `New ${anchorLabelForDraft(draftTarget.anchor)} comment`
-            : "New document comment"
-        }
-        buttonLabel="Add comment"
-        icon="plus"
-        disabled={!canCreate}
-        autoFocusKey={draftTarget ? draftAutoFocusKey(draftTarget) : "document"}
-        placeholder={
-          draftTarget
-            ? `Add a ${anchorLabelForDraft(draftTarget.anchor)} comment`
-            : "Add a document comment"
-        }
-        compact={!draftTarget}
-        onSubmit={onCreateThread}
-      />
-
-      {projection && threads.length === 0 ? (
-        <div className="flex flex-col items-center gap-2 rounded-md border border-dashed px-3 py-6 text-center text-sm text-muted-foreground">
-          <MessageSquare className="size-4" aria-hidden="true" />
-          <span>No comments yet.</span>
-        </div>
-      ) : (
-        <div className="space-y-3">
-          {openThreads.length > 0 ? (
-            <ol className="space-y-3">{openThreads.map(renderThread)}</ol>
-          ) : resolvedThreads.length > 0 ? (
-            <p className="px-1 py-4 text-center text-sm text-muted-foreground">No open comments.</p>
-          ) : null}
-
-          {resolvedThreads.length > 0 ? (
-            <div className="space-y-3">
-              <button
-                type="button"
-                onClick={() => setShowResolved((value) => !value)}
-                aria-expanded={showResolved}
-                className="inline-flex items-center gap-1 text-xs font-medium text-muted-foreground transition-colors hover:text-foreground"
-              >
-                {showResolved ? (
-                  <ChevronDown className="size-3.5" aria-hidden="true" />
-                ) : (
-                  <ChevronRight className="size-3.5" aria-hidden="true" />
-                )}
-                {showResolved ? "Hide" : "Show"} resolved ({resolvedThreads.length})
-              </button>
-              {showResolved ? (
-                <ol className="space-y-3">{resolvedThreads.map(renderThread)}</ol>
-              ) : null}
+    <section className="flex h-full min-h-0 flex-col" data-testid="notebook-comments-panel">
+      <div
+        className="min-h-0 flex-1 overflow-y-auto pr-1"
+        data-testid="notebook-comments-thread-scroll"
+      >
+        <div className="space-y-3 pb-3">
+          {statusMessage ? (
+            <div
+              className="rounded-md border border-dashed px-3 py-2 text-sm text-muted-foreground"
+              role="status"
+            >
+              {statusMessage}
             </div>
           ) : null}
+          {errorMessage ? (
+            <div
+              className="rounded-md border border-destructive/40 bg-destructive/5 px-3 py-2 text-sm text-destructive"
+              role="alert"
+            >
+              {errorMessage}
+            </div>
+          ) : null}
+
+          {projection && threads.length === 0 ? (
+            <div className="flex flex-col items-center gap-2 rounded-md border border-dashed px-3 py-6 text-center text-sm text-muted-foreground">
+              <MessageSquare className="size-4" aria-hidden="true" />
+              <span>No comments yet.</span>
+            </div>
+          ) : (
+            <div className="space-y-4">
+              {openThreads.length > 0 ? (
+                <ol className="space-y-4">{openThreads.map(renderThread)}</ol>
+              ) : resolvedThreads.length > 0 ? (
+                <p className="px-1 py-4 text-center text-sm text-muted-foreground">
+                  No open comments.
+                </p>
+              ) : null}
+
+              {resolvedThreads.length > 0 ? (
+                <div className="space-y-3">
+                  <button
+                    type="button"
+                    onClick={() => setShowResolved((value) => !value)}
+                    aria-expanded={showResolved}
+                    className="inline-flex items-center gap-1 text-xs font-medium text-muted-foreground transition-colors hover:text-foreground"
+                  >
+                    {showResolved ? (
+                      <ChevronDown className="size-3.5" aria-hidden="true" />
+                    ) : (
+                      <ChevronRight className="size-3.5" aria-hidden="true" />
+                    )}
+                    {showResolved ? "Hide" : "Show"} resolved ({resolvedThreads.length})
+                  </button>
+                  {showResolved ? (
+                    <ol className="space-y-4">{resolvedThreads.map(renderThread)}</ol>
+                  ) : null}
+                </div>
+              ) : null}
+            </div>
+          )}
         </div>
-      )}
+      </div>
+
+      <div
+        className="shrink-0 space-y-2 border-t bg-background pt-3"
+        data-testid="notebook-comments-composer-dock"
+      >
+        {draftTarget ? (
+          <CommentDraftTargetView
+            target={draftTarget}
+            onClear={onClearDraftTarget}
+            resolveSourceQuote={resolveSourceQuote}
+          />
+        ) : null}
+
+        <CommentComposer
+          ariaLabel={
+            draftTarget
+              ? `New ${anchorLabelForDraft(draftTarget.anchor)} comment`
+              : "Add a comment on the document"
+          }
+          buttonLabel="Add comment"
+          icon="plus"
+          disabled={!canCreate}
+          autoFocusKey={draftTarget ? draftAutoFocusKey(draftTarget) : "document"}
+          placeholder={
+            draftTarget
+              ? `Add a ${anchorLabelForDraft(draftTarget.anchor)} comment`
+              : "Add a comment"
+          }
+          compact={!draftTarget}
+          onSubmit={onCreateThread}
+        />
+      </div>
     </section>
   );
 }
@@ -349,12 +363,12 @@ function CommentThreadItem({
     <li
       ref={itemRef}
       className={cn(
-        "rounded-lg border bg-card text-card-foreground shadow-sm transition-shadow duration-700",
+        "rounded-md border bg-card text-card-foreground shadow-sm transition-shadow duration-700",
         thread.status === "resolved" && "border-border/70 bg-muted/10 shadow-none",
         flashing && "ring-2 ring-primary/60",
       )}
     >
-      <div className="space-y-3 p-3">
+      <div className="space-y-3.5 p-3">
         <div className="flex items-center gap-2">
           {quote ? (
             <CommentSourceQuote
@@ -396,7 +410,7 @@ function CommentThreadItem({
           </div>
         </div>
 
-        <div className="space-y-3">
+        <div className="space-y-3.5">
           {thread.messages.map((message) => (
             <CommentMessage
               key={message.id}

--- a/src/components/notebook/__tests__/NotebookCommentsPanel.test.tsx
+++ b/src/components/notebook/__tests__/NotebookCommentsPanel.test.tsx
@@ -3,6 +3,8 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vite-plus/test"
 import { NotebookCommentsPanel } from "../NotebookCommentsPanel";
 import type { CommentsProjection } from "../comment-types";
 
+const DOCUMENT_COMMENT_LABEL = "Add a comment on the document";
+
 const projection: CommentsProjection = {
   comments_doc_id: "comments:local-room:notebook-1",
   threads: [
@@ -79,7 +81,7 @@ describe("NotebookCommentsPanel", () => {
     expect(screen.getByRole("status")).toHaveTextContent("Comments sync unavailable.");
     expect(screen.getByRole("alert")).toHaveTextContent("Comment request failed.");
     expect(screen.queryByText("No comments yet.")).not.toBeInTheDocument();
-    expect(screen.getByLabelText("New document comment")).toBeDisabled();
+    expect(screen.getByLabelText(DOCUMENT_COMMENT_LABEL)).toBeDisabled();
   });
 
   it("submits a new document comment", async () => {
@@ -91,7 +93,10 @@ describe("NotebookCommentsPanel", () => {
       />,
     );
 
-    fireEvent.change(screen.getByLabelText("New document comment"), {
+    const composer = screen.getByLabelText(DOCUMENT_COMMENT_LABEL);
+    expect(composer).toHaveAttribute("placeholder", "Add a comment");
+
+    fireEvent.change(composer, {
       target: { value: "Add this to the review notes" },
     });
     fireEvent.click(screen.getByRole("button", { name: "Add comment" }));
@@ -99,7 +104,7 @@ describe("NotebookCommentsPanel", () => {
     await waitFor(() =>
       expect(onCreateThread).toHaveBeenCalledWith("Add this to the review notes"),
     );
-    expect(screen.getByLabelText("New document comment")).toHaveValue("");
+    expect(screen.getByLabelText(DOCUMENT_COMMENT_LABEL)).toHaveValue("");
   });
 
   it("focuses the document composer when opened", async () => {
@@ -110,7 +115,7 @@ describe("NotebookCommentsPanel", () => {
       />,
     );
 
-    await waitFor(() => expect(screen.getByLabelText("New document comment")).toHaveFocus());
+    await waitFor(() => expect(screen.getByLabelText(DOCUMENT_COMMENT_LABEL)).toHaveFocus());
   });
 
   it("submits a new document comment with Cmd Enter", async () => {
@@ -122,7 +127,7 @@ describe("NotebookCommentsPanel", () => {
       />,
     );
 
-    const composer = screen.getByLabelText("New document comment");
+    const composer = screen.getByLabelText(DOCUMENT_COMMENT_LABEL);
     fireEvent.change(composer, {
       target: { value: "Submit from the keyboard" },
     });
@@ -156,6 +161,12 @@ describe("NotebookCommentsPanel", () => {
 
     expect(screen.getByTestId("comment-draft-target")).toHaveTextContent("Source selection");
     expect(screen.getByTestId("comment-draft-target")).toHaveTextContent("beta");
+    expect(screen.getByTestId("notebook-comments-composer-dock")).toContainElement(
+      screen.getByTestId("comment-draft-target"),
+    );
+    expect(screen.getByTestId("notebook-comments-thread-scroll")).not.toContainElement(
+      screen.getByTestId("comment-draft-target"),
+    );
     await waitFor(() => expect(screen.getByLabelText("New source comment")).toHaveFocus());
 
     fireEvent.change(screen.getByLabelText("New source comment"), {
@@ -225,7 +236,7 @@ describe("NotebookCommentsPanel", () => {
     expect(onClearDraftTarget).toHaveBeenCalled();
 
     rerender(renderPanel(null));
-    expect(screen.getByLabelText("New document comment")).toHaveValue(
+    expect(screen.getByLabelText(DOCUMENT_COMMENT_LABEL)).toHaveValue(
       "Keep this body while retargeting",
     );
 
@@ -250,7 +261,7 @@ describe("NotebookCommentsPanel", () => {
       />,
     );
 
-    fireEvent.change(screen.getByLabelText("New document comment"), {
+    fireEvent.change(screen.getByLabelText(DOCUMENT_COMMENT_LABEL), {
       target: { value: "Do not leave duplicate text in the composer" },
     });
     fireEvent.click(screen.getByRole("button", { name: "Add comment" }));
@@ -258,11 +269,11 @@ describe("NotebookCommentsPanel", () => {
     await waitFor(() =>
       expect(onCreateThread).toHaveBeenCalledWith("Do not leave duplicate text in the composer"),
     );
-    expect(screen.getByLabelText("New document comment")).toHaveValue("");
+    expect(screen.getByLabelText(DOCUMENT_COMMENT_LABEL)).toHaveValue("");
     expect(screen.getByRole("button", { name: "Add comment" })).toBeDisabled();
 
     resolveCreate?.();
-    await waitFor(() => expect(screen.getByLabelText("New document comment")).toBeEnabled());
+    await waitFor(() => expect(screen.getByLabelText(DOCUMENT_COMMENT_LABEL)).toBeEnabled());
   });
 
   it("restores submitted text when a comment request fails", async () => {
@@ -274,7 +285,7 @@ describe("NotebookCommentsPanel", () => {
       />,
     );
 
-    fireEvent.change(screen.getByLabelText("New document comment"), {
+    fireEvent.change(screen.getByLabelText(DOCUMENT_COMMENT_LABEL), {
       target: { value: "Keep this draft if submit fails" },
     });
     fireEvent.click(screen.getByRole("button", { name: "Add comment" }));
@@ -283,10 +294,23 @@ describe("NotebookCommentsPanel", () => {
       expect(onCreateThread).toHaveBeenCalledWith("Keep this draft if submit fails"),
     );
     await waitFor(() =>
-      expect(screen.getByLabelText("New document comment")).toHaveValue(
+      expect(screen.getByLabelText(DOCUMENT_COMMENT_LABEL)).toHaveValue(
         "Keep this draft if submit fails",
       ),
     );
+  });
+
+  it("docks the document composer below the scrollable thread list", () => {
+    render(<NotebookCommentsPanel projection={projection} onCreateThread={vi.fn()} />);
+
+    const scroll = screen.getByTestId("notebook-comments-thread-scroll");
+    const dock = screen.getByTestId("notebook-comments-composer-dock");
+    const composer = screen.getByLabelText(DOCUMENT_COMMENT_LABEL);
+
+    expect(scroll).toContainElement(screen.getByText("Check the framing before publishing."));
+    expect(dock).toContainElement(composer);
+    expect(scroll).not.toContainElement(composer);
+    expect(composer).toHaveAttribute("placeholder", "Add a comment");
   });
 
   it("renders threads and submits replies", async () => {

--- a/src/styles/comment-affordance.css
+++ b/src/styles/comment-affordance.css
@@ -38,7 +38,10 @@
   margin: 0;
   border: none;
   background: transparent;
-  color: var(--primary-foreground, #ffffff);
+  /* The open pill paints the label on the author color, so the label needs the
+     author's legible foreground (set with --comment-author-color), not a flat
+     white that fails contrast on light author colors. */
+  color: var(--comment-author-contrast, var(--primary-foreground, #ffffff));
   cursor: pointer;
 }
 


### PR DESCRIPTION
A design pass on the commenting layer from hands-on QA, plus the audit that motivated it.

## What this does

- **Inline composer restyle.** Drops the redundant quote preview (the selection is already highlighted in the document) and the soft color wash. The composer fills with the author's color and reads as a colored button: white text, caret, and send arrow, with the arrow on a subtle dark veil so it stays visible on any author color.
- **Rendered-markdown highlights activate their thread.** Clicking a comment highlight in the rendered plane now opens its thread in the rail, matching the CodeMirror editor. Previously the highlight had `cursor: pointer` but no handler. Adds click + Enter/Space activation and `role="button"` / `aria-label`. The outer run span and its source-offset attributes are untouched, so selection and copy are unaffected.
- **Discussions rail reads like a chat window.** The document composer moves from the top to a docked region at the bottom; threads scroll above it. Tighter placeholder copy. The active draft target sits just above the docked composer.
- **Author contrast as a first-class color.** New `contrastColorForActorIdentity(actor)` pairs with `colorForActorIdentity(actor)` (built on a WCAG-luminance primitive). The local author's color and its legible foreground are set once on `:root` as `--comment-author-color` and `--comment-author-contrast`; surfaces read the vars instead of recomputing. The cloud viewer now sets both (it set neither before), and the affordance pill uses the contrast var.

## Audit included

`docs/audits/comments-layer.md` is the four-facet audit of the commenting layer (anchors + sync/authority, selection + projection, UI flows + flag, consistency + a11y). This PR closes the rendered-highlight activation (COMMENT-003), the cloud author color (COMMENT-001), and the composer/affordance contrast (COMMENT-002, composer + pill). The audit's remaining items, including a P1 ambiguous-re-anchor correctness bug (F-1) and the unbuilt `comments_enabled` flag, are prioritized there as follow-ups; several already-known projection edges cross-link to the projection-correspondence memo.

## Behavioral coverage

| Surface | Before | After |
|---|---|---|
| Click a rendered highlight | Nothing | Opens the thread (matches editor) |
| Inline composer | Quote preview + wash | Solid author-color fill, white text + arrow |
| Send arrow on a light author color | White, ~3:1 | White on a dark veil, always visible |
| Discussions rail | Composer pinned at top | Composer docked at bottom, threads scroll above |
| Cloud composer color | Generic `--primary` | Author color + contrast |

## Notes

The composer style was chosen in-app: the bolder solid fill over a neutral-border variant. The border variant and the dev toggle that compared them were removed; the contrast var and helper remain for the affordance pill and future per-author surfaces (rail avatars).

Known follow-up, not in this PR: selecting text in the rendered plane loses its visual selection when the composer opens (the affordance click collapses the DOM selection), whereas CodeMirror keeps it. The fix is a pending highlight drawn on the rendered range while composing, reusing the highlight machinery here.
