### PR TITLE
refactor(frontend): converge icon sizing from h-N w-N to size-N

### DIFF
--- a/apps/notebook/src/components/CodeCell.tsx
+++ b/apps/notebook/src/components/CodeCell.tsx
@@ -906,7 +906,7 @@ export const CodeCell = memo(function CodeCell({
                   title="Comment on outputs"
                   aria-label="Comment on outputs"
                 >
-                  <CommentMarkIcon className="h-3.5 w-3.5" aria-hidden="true" />
+                  <CommentMarkIcon className="size-3.5" aria-hidden="true" />
                 </button>
               ) : null}
               {onToggleOutputsHidden ? (
@@ -918,7 +918,7 @@ export const CodeCell = memo(function CodeCell({
                   title="Hide outputs"
                   aria-label="Hide outputs"
                 >
-                  <EyeOff className="h-3.5 w-3.5" />
+                  <EyeOff className="size-3.5" />
                 </button>
               ) : null}
             </>

--- a/apps/notebook/src/components/MarkdownCell.tsx
+++ b/apps/notebook/src/components/MarkdownCell.tsx
@@ -1013,7 +1013,7 @@ export const MarkdownCell = memo(function MarkdownCell({
               title="View rendered markdown"
               aria-label="View rendered markdown"
             >
-              <Check className="h-3.5 w-3.5" />
+              <Check className="size-3.5" />
             </button>
             {rightGutterContent}
           </div>
@@ -1026,7 +1026,7 @@ export const MarkdownCell = memo(function MarkdownCell({
               className="flex items-center justify-center rounded p-1 text-muted-foreground/40 transition-colors hover:text-foreground"
               title="Edit"
             >
-              <Pencil className="h-3.5 w-3.5" />
+              <Pencil className="size-3.5" />
             </button>
             {rightGutterContent}
           </div>

--- a/apps/notebook/src/components/NotebookToolbar.tsx
+++ b/apps/notebook/src/components/NotebookToolbar.tsx
@@ -208,7 +208,7 @@ export function NotebookToolbar({
       {showDenoInstallNotice && kernelErrorMessage && (
         <NotebookNotice
           tone="warning"
-          icon={<Info className="h-3.5 w-3.5" />}
+          icon={<Info className="size-3.5" />}
           title="Deno not available."
           className="border-t border-b-0"
         >
@@ -417,7 +417,7 @@ function CondaEnvYmlMissingBanner({
   return (
     <NotebookNotice
       tone="warning"
-      icon={<Info className="h-3.5 w-3.5" />}
+      icon={<Info className="size-3.5" />}
       title="Conda environment not built."
       className="border-t border-b-0"
       data-testid="conda-env-yml-missing-banner"
@@ -425,7 +425,7 @@ function CondaEnvYmlMissingBanner({
         command ? (
           <NotebookNoticeAction
             onClick={onCopyCommand}
-            icon={<Copy className="h-3 w-3" />}
+            icon={<Copy className="size-3" />}
             data-testid="copy-conda-env-command"
           >
             {copied ? "Copied" : "Copy command"}
@@ -452,7 +452,7 @@ function RuntimeErrorBanner({
   return (
     <NotebookNotice
       tone="warning"
-      icon={<Info className="h-3.5 w-3.5" />}
+      icon={<Info className="size-3.5" />}
       title={headline}
       className="border-t border-b-0"
       details={

--- a/apps/notebook/src/components/NotebookView.tsx
+++ b/apps/notebook/src/components/NotebookView.tsx
@@ -143,7 +143,7 @@ function CellErrorFallback({
             className="h-7 gap-1 px-2 text-xs"
             title="Retry rendering"
           >
-            <RotateCcw className="h-3 w-3" />
+            <RotateCcw className="size-3" />
             Retry
           </Button>
           {onDelete ? (
@@ -154,7 +154,7 @@ function CellErrorFallback({
               className="h-7 gap-1 px-2 text-xs text-destructive hover:text-destructive"
               title="Delete cell"
             >
-              <X className="h-3 w-3" />
+              <X className="size-3" />
               Delete
             </Button>
           ) : null}
@@ -833,7 +833,7 @@ function NotebookViewContent({
           className="flex items-center justify-center rounded p-1 text-muted-foreground/40 transition-colors hover:text-destructive"
           title="Delete cell"
         >
-          <Trash2 className="h-3.5 w-3.5" />
+          <Trash2 className="size-3.5" />
         </button>
       ) : null;
 
@@ -860,11 +860,7 @@ function NotebookViewContent({
               )}
               title={isSourceHidden ? "Show input" : "Hide input"}
             >
-              {isSourceHidden ? (
-                <Eye className="h-3.5 w-3.5" />
-              ) : (
-                <EyeOff className="h-3.5 w-3.5" />
-              )}
+              {isSourceHidden ? <Eye className="size-3.5" /> : <EyeOff className="size-3.5" />}
             </button>
           ) : null;
         const visibleDeleteButton = !isSourceHidden ? deleteButton : null;
@@ -1139,7 +1135,7 @@ function NotebookViewContent({
                     onClick={() => onAddCell("code")}
                     className="gap-1"
                   >
-                    <Plus className="h-3 w-3" />
+                    <Plus className="size-3" />
                     Code Cell
                   </Button>
                   <Button
@@ -1148,7 +1144,7 @@ function NotebookViewContent({
                     onClick={() => onAddCell("markdown")}
                     className="gap-1"
                   >
-                    <Plus className="h-3 w-3" />
+                    <Plus className="size-3" />
                     Markdown Cell
                   </Button>
                 </div>

--- a/apps/notebook/src/prototypes/sidebar-toc/SidebarTocPrototype.tsx
+++ b/apps/notebook/src/prototypes/sidebar-toc/SidebarTocPrototype.tsx
@@ -224,12 +224,12 @@ function ActivityButton({
       aria-label={label}
       title={label}
       className={cn(
-        "flex h-9 w-9 items-center justify-center rounded text-muted-foreground transition-colors",
+        "flex size-9 items-center justify-center rounded text-muted-foreground transition-colors",
         "hover:bg-muted hover:text-foreground focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring",
         selected && "bg-foreground text-background hover:bg-foreground hover:text-background",
       )}
     >
-      <Icon className="h-4 w-4" />
+      <Icon className="size-4" />
     </button>
   );
 }
@@ -387,16 +387,16 @@ function TopNotebookBar({ title = "forecast_readthrough.ipynb" }: { title?: stri
     <header className="flex h-10 shrink-0 items-center gap-2 border-b bg-background/95 px-3">
       <button
         type="button"
-        className="flex h-7 w-7 items-center justify-center rounded text-muted-foreground hover:bg-muted hover:text-foreground"
+        className="flex size-7 items-center justify-center rounded text-muted-foreground hover:bg-muted hover:text-foreground"
         title="Run all cells"
         aria-label="Run all cells"
       >
-        <Play className="h-3.5 w-3.5" />
+        <Play className="size-3.5" />
       </button>
       <div className="h-4 w-px bg-border" />
       <div className="min-w-0 truncate text-xs font-medium text-foreground">{title}</div>
       <div className="ml-auto flex items-center gap-2 text-[10px] text-muted-foreground">
-        <Circle className="h-2 w-2 fill-emerald-500 text-emerald-500" />
+        <Circle className="size-2 fill-emerald-500 text-emerald-500" />
         Python · idle
       </div>
     </header>
@@ -512,13 +512,13 @@ function VariantB({
                   activePanel === tab.key && "bg-background text-foreground shadow-sm",
                 )}
               >
-                <tab.icon className="h-4 w-4" />
+                <tab.icon className="size-4" />
               </button>
             ))}
           </div>
           <div className="border-b p-3">
             <div className="flex items-center gap-2 rounded border bg-background px-2 py-1.5 text-muted-foreground">
-              <Search className="h-3.5 w-3.5" />
+              <Search className="size-3.5" />
               <span className="text-xs">Search headings, packages, variables</span>
             </div>
           </div>
@@ -558,7 +558,7 @@ function VariantC({ activeHeading, setActiveHeading }: ReturnType<typeof useProt
       <aside className="flex min-h-0 flex-col border-r bg-zinc-950 text-zinc-100 dark:bg-zinc-950">
         <div className="border-b border-white/10 p-3">
           <div className="flex items-center gap-2 text-sm font-semibold">
-            <FileText className="h-4 w-4 text-sky-300" />
+            <FileText className="size-4 text-sky-300" />
             forecast_readthrough
           </div>
           <div className="mt-1 text-[11px] text-zinc-400">Reader map · Python idle</div>
@@ -585,7 +585,7 @@ function VariantC({ activeHeading, setActiveHeading }: ReturnType<typeof useProt
               >
                 <span
                   className={cn(
-                    "h-2.5 w-2.5 shrink-0 rounded-full border border-white/40 bg-zinc-950",
+                    "size-2.5 shrink-0 rounded-full border border-white/40 bg-zinc-950",
                     activeHeading === item.id && "border-sky-200 bg-sky-300",
                   )}
                 />
@@ -622,7 +622,7 @@ function VariantC({ activeHeading, setActiveHeading }: ReturnType<typeof useProt
 function Pill({ icon: Icon, label }: { icon: LucideIcon; label: string }) {
   return (
     <div className="flex min-w-0 items-center gap-1 rounded bg-white/10 px-1.5 py-1 text-[10px] text-zinc-300">
-      <Icon className="h-3 w-3 shrink-0" />
+      <Icon className="size-3 shrink-0" />
       <span className="truncate">{label}</span>
     </div>
   );
@@ -683,11 +683,11 @@ function PrototypeSwitcher({
         <button
           type="button"
           onClick={() => move(-1)}
-          className="flex h-8 w-8 items-center justify-center rounded-full text-zinc-300 hover:bg-white/10 hover:text-white"
+          className="flex size-8 items-center justify-center rounded-full text-zinc-300 hover:bg-white/10 hover:text-white"
           title="Previous variant"
           aria-label="Previous variant"
         >
-          <ChevronLeft className="h-4 w-4" />
+          <ChevronLeft className="size-4" />
         </button>
         <div className="min-w-0 px-2 text-center">
           <div className="truncate text-xs font-semibold">
@@ -701,11 +701,11 @@ function PrototypeSwitcher({
         <button
           type="button"
           onClick={() => move(1)}
-          className="flex h-8 w-8 items-center justify-center rounded-full text-zinc-300 hover:bg-white/10 hover:text-white"
+          className="flex size-8 items-center justify-center rounded-full text-zinc-300 hover:bg-white/10 hover:text-white"
           title="Next variant"
           aria-label="Next variant"
         >
-          <ChevronRight className="h-4 w-4" />
+          <ChevronRight className="size-4" />
         </button>
       </div>
     </div>

--- a/src/components/cell/CellInsertionRibbon.tsx
+++ b/src/components/cell/CellInsertionRibbon.tsx
@@ -259,7 +259,7 @@ export function CellInsertionRibbon({
                 aria-hidden="true"
               />
             ) : null}
-            <Code className="h-3 w-3" aria-hidden="true" />
+            <Code className="size-3" aria-hidden="true" />
             <span>Code</span>
           </button>
           <button
@@ -272,7 +272,7 @@ export function CellInsertionRibbon({
             onClick={() => onInsert("markdown")}
             className={actionButtonClass("markdown")}
           >
-            <LetterText className="h-3 w-3" aria-hidden="true" />
+            <LetterText className="size-3" aria-hidden="true" />
             <span>Markdown</span>
           </button>
         </div>

--- a/src/components/cell/CellPresenceIndicators.tsx
+++ b/src/components/cell/CellPresenceIndicators.tsx
@@ -62,7 +62,7 @@ export function CellPresenceIndicators({
 function PresenceDot({ peer }: { peer: CellPresencePeer }) {
   return (
     <div
-      className="w-2 h-2 rounded-full shrink-0 transition-colors"
+      className="size-2 rounded-full shrink-0 transition-colors"
       style={{ backgroundColor: peer.color }}
       title={peer.peerLabel || "Peer"}
     />

--- a/src/components/environment/CondaDependencyPanel.tsx
+++ b/src/components/environment/CondaDependencyPanel.tsx
@@ -179,7 +179,7 @@ export function CondaDependencyPanel({
         {envProgress?.error && (
           <div className="mb-3 rounded bg-red-500/10 border border-red-200 dark:border-red-900 px-2 py-2">
             <div className="flex items-start gap-2 text-xs text-red-700 dark:text-red-400">
-              <AlertCircle className="h-4 w-4 mt-0.5 shrink-0" />
+              <AlertCircle className="size-4 mt-0.5 shrink-0" />
               <div className="flex-1 min-w-0">
                 <div className="font-medium">Environment creation failed</div>
                 <pre className="mt-1 whitespace-pre-wrap font-mono text-[10px] opacity-80 overflow-x-auto">
@@ -203,7 +203,7 @@ export function CondaDependencyPanel({
                     className="flex items-center gap-1 rounded bg-red-600 px-2 py-0.5 text-white text-xs font-medium hover:bg-red-700 transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
                     title="Retry environment creation"
                   >
-                    <RefreshCw className="h-3 w-3" />
+                    <RefreshCw className="size-3" />
                     Retry
                   </button>
                   {onResetProgress && (
@@ -213,7 +213,7 @@ export function CondaDependencyPanel({
                       className="text-red-500 hover:text-red-700 dark:hover:text-red-300"
                       title="Dismiss"
                     >
-                      <X className="h-3 w-3" />
+                      <X className="size-3" />
                     </button>
                   )}
                 </div>
@@ -225,7 +225,7 @@ export function CondaDependencyPanel({
         {/* Success feedback after sync completed */}
         {justSynced && (
           <div className="mb-3 flex items-center gap-2 rounded bg-emerald-500/10 px-2 py-1.5 text-xs text-emerald-700 dark:text-emerald-400">
-            <Check className="h-3.5 w-3.5 shrink-0" />
+            <Check className="size-3.5 shrink-0" />
             <span>Environment synced — dependencies are ready to use</span>
           </div>
         )}
@@ -234,7 +234,7 @@ export function CondaDependencyPanel({
         {environmentYmlInfo && (
           <div className="mb-3 rounded bg-muted/80 px-2 py-1.5 text-xs text-muted-foreground">
             <div className="flex items-center gap-2">
-              <FileText className="h-3.5 w-3.5 shrink-0" />
+              <FileText className="size-3.5 shrink-0" />
               <span>
                 Using{" "}
                 <code className="rounded bg-muted px-1">{environmentYmlInfo.relative_path}</code>
@@ -311,7 +311,7 @@ export function CondaDependencyPanel({
             )}
           >
             <div className="flex items-start gap-2">
-              <Info className="h-3.5 w-3.5 shrink-0" />
+              <Info className="size-3.5 shrink-0" />
               <span>Dependencies changed — re-initialize environment to apply</span>
             </div>
             <button
@@ -324,7 +324,7 @@ export function CondaDependencyPanel({
                 isRail && "self-start py-1",
               )}
             >
-              <RefreshCw className={`h-3 w-3 ${loading ? "animate-spin" : ""}`} />
+              <RefreshCw className={`size-3 ${loading ? "animate-spin" : ""}`} />
               Re-initialize
             </button>
           </div>
@@ -353,7 +353,7 @@ export function CondaDependencyPanel({
                         disabled={loading}
                         title={`Remove ${channel}`}
                       >
-                        <X className="h-3 w-3" />
+                        <X className="size-3" />
                       </button>
                     )}
                   </div>
@@ -396,7 +396,7 @@ export function CondaDependencyPanel({
                     className="flex items-center gap-0.5 rounded bg-background px-1.5 py-0.5 text-xs border hover:bg-muted transition-colors"
                     disabled={loading}
                   >
-                    <Plus className="h-3 w-3" />
+                    <Plus className="size-3" />
                     channel
                   </button>
                 ) : null}
@@ -460,7 +460,7 @@ export function CondaDependencyPanel({
                         disabled={loading}
                         title={`Remove ${dep}`}
                       >
-                        <X className="h-3 w-3" />
+                        <X className="size-3" />
                       </button>
                     )}
                   </div>
@@ -494,7 +494,7 @@ export function CondaDependencyPanel({
                   data-testid="conda-deps-add-button"
                   className="flex items-center gap-1 rounded bg-emerald-600 px-2 py-1 text-xs text-white transition-colors hover:bg-emerald-700 disabled:opacity-50"
                 >
-                  <Plus className="h-3 w-3" />
+                  <Plus className="size-3" />
                   Add
                 </button>
               </div>

--- a/src/components/environment/DenoDependencyPanel.tsx
+++ b/src/components/environment/DenoDependencyPanel.tsx
@@ -74,7 +74,7 @@ export function DenoDependencyPanel({
         {/* Success feedback after sync completed */}
         {justSynced && (
           <div className="mb-3 flex items-center gap-2 rounded bg-emerald-500/10 px-2 py-1.5 text-xs text-emerald-700 dark:text-emerald-400">
-            <Check className="h-3.5 w-3.5 shrink-0" />
+            <Check className="size-3.5 shrink-0" />
             <span>Kernel restarted — configuration applied</span>
           </div>
         )}
@@ -90,7 +90,7 @@ export function DenoDependencyPanel({
             )}
           >
             <div className="flex items-start gap-2">
-              <Info className="h-3.5 w-3.5 shrink-0" />
+              <Info className="size-3.5 shrink-0" />
               <span>Configuration changed — restart kernel to apply</span>
             </div>
             <button
@@ -102,7 +102,7 @@ export function DenoDependencyPanel({
                 isRail && "self-start py-1",
               )}
             >
-              <RefreshCw className={`h-3 w-3 ${syncing ? "animate-spin" : ""}`} />
+              <RefreshCw className={`size-3 ${syncing ? "animate-spin" : ""}`} />
               Restart
             </button>
           </div>
@@ -112,7 +112,7 @@ export function DenoDependencyPanel({
         {denoConfigInfo && (
           <div className="mb-3 rounded bg-muted/80 px-2 py-1.5 text-xs text-muted-foreground">
             <div className="flex items-center gap-2">
-              <FileText className="h-3.5 w-3.5 shrink-0" />
+              <FileText className="size-3.5 shrink-0" />
               <span>
                 Using <code className="rounded bg-muted px-1">{denoConfigInfo.relative_path}</code>
                 {denoConfigInfo.name && (
@@ -136,7 +136,7 @@ export function DenoDependencyPanel({
         {/* No config file - explain how Deno handles deps */}
         {!denoConfigInfo && (
           <div className="mb-3 flex items-start gap-2 rounded bg-muted/50 px-2 py-1.5 text-xs text-muted-foreground">
-            <Info className="h-3.5 w-3.5 mt-0.5 shrink-0" />
+            <Info className="size-3.5 mt-0.5 shrink-0" />
             <span>
               No <code className="rounded bg-muted px-1">deno.json</code> found. Deno can import
               modules directly without configuration.
@@ -184,7 +184,7 @@ export function DenoDependencyPanel({
           {/* npm packages */}
           <div className="rounded border bg-background px-2.5 py-2">
             <div className="flex items-center gap-1.5 text-xs text-muted-foreground mb-1">
-              <Package className="h-3 w-3" />
+              <Package className="size-3" />
               <span className="font-medium">npm packages</span>
             </div>
             <code className="text-xs text-emerald-600 dark:text-emerald-400">
@@ -195,7 +195,7 @@ export function DenoDependencyPanel({
           {/* JSR (recommended) */}
           <div className="rounded border bg-background px-2.5 py-2">
             <div className="flex items-center gap-1.5 text-xs text-muted-foreground mb-1">
-              <Package className="h-3 w-3" />
+              <Package className="size-3" />
               <span className="font-medium">JSR</span>
               <span className="rounded bg-emerald-500/20 px-1 py-0.5 text-[10px] text-emerald-600 dark:text-emerald-400">
                 recommended
@@ -209,7 +209,7 @@ export function DenoDependencyPanel({
           {/* URL imports */}
           <div className="rounded border bg-background px-2.5 py-2">
             <div className="flex items-center gap-1.5 text-xs text-muted-foreground mb-1">
-              <ExternalLink className="h-3 w-3" />
+              <ExternalLink className="size-3" />
               <span className="font-medium">URL imports</span>
             </div>
             <code className="text-xs text-emerald-600 dark:text-emerald-400 break-all">

--- a/src/components/environment/PixiDependencyPanel.tsx
+++ b/src/components/environment/PixiDependencyPanel.tsx
@@ -97,7 +97,7 @@ export function PixiDependencyPanel({
         >
           <div className={cn("flex min-w-0 items-center gap-2", isRail && "shrink-0")}>
             <span className="flex items-center gap-1 rounded bg-amber-500/20 px-1.5 py-0.5 text-xs font-medium text-amber-600 dark:text-amber-400">
-              <PixiIcon className="h-2.5 w-2.5" />
+              <PixiIcon className="size-2.5" />
               Pixi
             </span>
             <span
@@ -119,7 +119,7 @@ export function PixiDependencyPanel({
         {/* Success feedback after sync */}
         {justSynced && (
           <div className="mb-3 flex items-center gap-2 rounded bg-amber-500/10 px-2 py-1.5 text-xs text-amber-700 dark:text-amber-400">
-            <Check className="h-3.5 w-3.5 shrink-0" />
+            <Check className="size-3.5 shrink-0" />
             <span>Kernel restarted — environment updated</span>
           </div>
         )}
@@ -135,7 +135,7 @@ export function PixiDependencyPanel({
             )}
           >
             <div className="flex items-start gap-2">
-              <Info className="h-3.5 w-3.5 shrink-0" />
+              <Info className="size-3.5 shrink-0" />
               <span>Dependencies changed.</span>
             </div>
             <button
@@ -147,7 +147,7 @@ export function PixiDependencyPanel({
                 isRail && "self-start py-1",
               )}
             >
-              <RefreshCw className={`h-3 w-3 ${isLoading ? "animate-spin" : ""}`} />
+              <RefreshCw className={`size-3 ${isLoading ? "animate-spin" : ""}`} />
               Restart
             </button>
           </div>
@@ -157,7 +157,7 @@ export function PixiDependencyPanel({
         {pixiInfo && !isInlineMode && (
           <div className="mb-3 rounded bg-muted/80 px-2 py-1.5 text-xs text-muted-foreground">
             <div className="flex items-center gap-2">
-              <FileText className="h-3.5 w-3.5 shrink-0" />
+              <FileText className="size-3.5 shrink-0" />
               <span>
                 Using <code className="rounded bg-muted px-1">{pixiInfo.relative_path}</code>
                 {pixiInfo.workspace_name && (
@@ -253,7 +253,7 @@ export function PixiDependencyPanel({
                         disabled={isLoading}
                         className="text-amber-500/50 hover:text-amber-700 dark:hover:text-amber-300 transition-colors disabled:opacity-50"
                       >
-                        <X className="h-3 w-3" />
+                        <X className="size-3" />
                       </button>
                     )}
                   </div>
@@ -278,7 +278,7 @@ export function PixiDependencyPanel({
                   disabled={isLoading || !newDep.trim()}
                   className="flex items-center gap-1 rounded bg-amber-500/20 px-2 py-1 text-xs text-amber-600 dark:text-amber-400 hover:bg-amber-500/30 transition-colors disabled:opacity-50"
                 >
-                  <Plus className="h-3 w-3" />
+                  <Plus className="size-3" />
                   Add
                 </button>
               </div>
@@ -289,7 +289,7 @@ export function PixiDependencyPanel({
         {/* No pixi.toml and no inline deps — show init tip */}
         {!pixiInfo && inlineDependencyValues.length === 0 && (
           <div className="mb-3 flex items-start gap-2 rounded bg-muted/50 px-2 py-1.5 text-xs text-muted-foreground">
-            <Info className="h-3.5 w-3.5 mt-0.5 shrink-0" />
+            <Info className="size-3.5 mt-0.5 shrink-0" />
             <span>
               No <code className="rounded bg-muted px-1">pixi.toml</code> found. Add packages above
               or run <code className="rounded bg-muted px-1">pixi init</code> in your terminal.
@@ -300,7 +300,7 @@ export function PixiDependencyPanel({
         {/* Tip for pixi:toml mode */}
         {!isInlineMode && !isRail && (
           <div className="flex items-start gap-2 rounded bg-muted/50 px-2 py-1.5 text-xs text-muted-foreground">
-            <Terminal className="h-3.5 w-3.5 mt-0.5 shrink-0" />
+            <Terminal className="size-3.5 mt-0.5 shrink-0" />
             <span>
               Manage dependencies with{" "}
               <code className="rounded bg-muted px-1">pixi add &lt;package&gt;</code> in your

--- a/src/components/environment/UvDependencyPanel.tsx
+++ b/src/components/environment/UvDependencyPanel.tsx
@@ -125,7 +125,7 @@ export function UvDependencyPanel({
         {/* Success feedback after sync completed */}
         {justSynced && (
           <div className="mb-3 flex items-center gap-2 rounded bg-emerald-500/10 px-2 py-1.5 text-xs text-emerald-700 dark:text-emerald-400">
-            <Check className="h-3.5 w-3.5 shrink-0" />
+            <Check className="size-3.5 shrink-0" />
             <span>Environment synced — dependencies are ready to use</span>
           </div>
         )}
@@ -141,7 +141,7 @@ export function UvDependencyPanel({
             )}
           >
             <div className="flex items-start gap-2">
-              <Info className="h-3.5 w-3.5 shrink-0" />
+              <Info className="size-3.5 shrink-0" />
               <span>Re-initialize the environment to apply dependency changes.</span>
             </div>
             <button
@@ -154,7 +154,7 @@ export function UvDependencyPanel({
                 isRail && "self-start py-1",
               )}
             >
-              <RefreshCw className={`h-3 w-3 ${loading ? "animate-spin" : ""}`} />
+              <RefreshCw className={`size-3 ${loading ? "animate-spin" : ""}`} />
               Re-initialize
             </button>
           </div>
@@ -170,7 +170,7 @@ export function UvDependencyPanel({
               className={cn(isRail ? "flex flex-col gap-2" : "flex items-center justify-between")}
             >
               <div className="flex min-w-0 items-start gap-2">
-                <FileText className="h-3.5 w-3.5 shrink-0" />
+                <FileText className="size-3.5 shrink-0" />
                 <span className="min-w-0">
                   <code className="rounded bg-muted px-1">{pyprojectPath}</code>
                   {pyprojectInfo?.project_name && (
@@ -208,7 +208,7 @@ export function UvDependencyPanel({
                     className="flex items-center gap-1 text-uv/70 hover:text-uv transition-colors disabled:opacity-50"
                     title="Copy deps into notebook metadata for portable sharing"
                   >
-                    <Download className="h-3 w-3" />
+                    <Download className="size-3" />
                     Copy to notebook
                   </button>
                 )}
@@ -255,7 +255,7 @@ export function UvDependencyPanel({
         {/* Project-managed state: read-only view when using uv run */}
         {isUsingProjectEnv && (
           <div className="mb-3 flex items-start gap-2 rounded bg-muted/80 px-2 py-1.5 text-xs text-muted-foreground">
-            <Info className="h-3.5 w-3.5 mt-0.5 shrink-0" />
+            <Info className="size-3.5 mt-0.5 shrink-0" />
             <div className="min-w-0 flex-1 space-y-1 leading-5">
               <div>
                 Using <code className="rounded bg-muted px-1">{pyprojectPath}</code>
@@ -341,7 +341,7 @@ export function UvDependencyPanel({
                       disabled={loading}
                       title={`Remove ${dep}`}
                     >
-                      <X className="h-3 w-3" />
+                      <X className="size-3" />
                     </button>
                   )}
                 </div>
@@ -375,7 +375,7 @@ export function UvDependencyPanel({
               data-testid="deps-add-button"
               className="flex items-center gap-1 rounded bg-uv px-2 py-1 text-xs text-white transition-colors hover:bg-uv/90 disabled:opacity-50"
             >
-              <Plus className="h-3 w-3" />
+              <Plus className="size-3" />
               Add
             </button>
           </div>

--- a/src/components/notebook/DaemonStatusBanner.tsx
+++ b/src/components/notebook/DaemonStatusBanner.tsx
@@ -40,12 +40,12 @@ export function DaemonStatusBanner({ status, onDismiss, onRetry }: DaemonStatusB
     return (
       <NotebookNotice
         tone="warning"
-        icon={<AlertTriangle className="h-3 w-3" />}
+        icon={<AlertTriangle className="size-3" />}
         title="Runtime unavailable"
         onDismiss={onDismiss}
         actions={
           onRetry ? (
-            <NotebookNoticeAction onClick={onRetry} icon={<RefreshCw className="h-3 w-3" />}>
+            <NotebookNoticeAction onClick={onRetry} icon={<RefreshCw className="size-3" />}>
               Retry
             </NotebookNoticeAction>
           ) : null
@@ -61,11 +61,7 @@ export function DaemonStatusBanner({ status, onDismiss, onRetry }: DaemonStatusB
   const message = getProgressMessage(status);
 
   return (
-    <NotebookNotice
-      tone="info"
-      icon={<Loader2 className="h-3 w-3 animate-spin" />}
-      className="py-1"
-    >
+    <NotebookNotice tone="info" icon={<Loader2 className="size-3 animate-spin" />} className="py-1">
       {message}
     </NotebookNotice>
   );

--- a/src/components/notebook/DebugBanner.tsx
+++ b/src/components/notebook/DebugBanner.tsx
@@ -21,7 +21,7 @@ export function DebugBanner({
 
   return (
     <div className="@container flex items-center justify-center gap-2 bg-violet-600/90 px-3 py-1 text-xs text-white">
-      <GitBranch className="h-3 w-3" />
+      <GitBranch className="size-3" />
       <span className="font-medium">{branch}</span>
       <span className="text-violet-200">@</span>
       <span className="font-mono text-violet-200">{commit}</span>
@@ -34,7 +34,7 @@ export function DebugBanner({
       {daemonVersion && (
         <span className="hidden @[40rem]:contents">
           <span className="text-violet-300">|</span>
-          <Server className="h-3 w-3 text-emerald-300" />
+          <Server className="size-3 text-emerald-300" />
           <span className="text-violet-100">
             {daemonLabel}
             {daemonCommit && (

--- a/src/components/notebook/KernelLaunchErrorBanner.tsx
+++ b/src/components/notebook/KernelLaunchErrorBanner.tsx
@@ -82,7 +82,7 @@ export function KernelLaunchErrorBanner({
   return (
     <NotebookNotice
       tone="error"
-      icon={<AlertCircle className="h-4 w-4" />}
+      icon={<AlertCircle className="size-4" />}
       title="Kernel failed to start"
       onDismiss={onDismiss}
       details={
@@ -99,11 +99,11 @@ export function KernelLaunchErrorBanner({
             onClick={copyDetails}
             data-testid="copy-kernel-launch-error"
           >
-            {copied ? <Check className="h-3 w-3 mr-1" /> : <Copy className="h-3 w-3 mr-1" />}
+            {copied ? <Check className="size-3 mr-1" /> : <Copy className="size-3 mr-1" />}
             {copied ? "Copied" : "Copy"}
           </Button>
           <Button size="sm" variant="secondary" className="h-6 px-2 text-xs" onClick={onRetry}>
-            <RotateCw className="h-3 w-3 mr-1" />
+            <RotateCw className="size-3 mr-1" />
             Retry
           </Button>
         </>

--- a/src/components/notebook/NotebookCommandToolbar.tsx
+++ b/src/components/notebook/NotebookCommandToolbar.tsx
@@ -154,7 +154,7 @@ export function NotebookCommandToolbar({
             aria-label="Add code cell"
             data-testid="add-code-cell-button"
           >
-            <Code className="h-3 w-3" />
+            <Code className="size-3" />
             <span className="hidden @[40rem]:inline">Code</span>
           </button>
           <button
@@ -166,7 +166,7 @@ export function NotebookCommandToolbar({
             aria-label="Add markdown cell"
             data-testid="add-markdown-cell-button"
           >
-            <LetterText className="h-3 w-3" />
+            <LetterText className="size-3" />
             <span className="hidden @[40rem]:inline">Markdown</span>
           </button>
         </>
@@ -186,7 +186,7 @@ export function NotebookCommandToolbar({
           aria-label="Start kernel"
           data-testid="start-kernel-button"
         >
-          <Play className="h-3 w-3" fill="currentColor" />
+          <Play className="size-3" fill="currentColor" />
           <span className="hidden @[40rem]:inline">Start kernel</span>
         </button>
       ) : null}
@@ -200,7 +200,7 @@ export function NotebookCommandToolbar({
           aria-label="Run all cells"
           data-testid="run-all-button"
         >
-          <ChevronsRight className="h-3.5 w-3.5" />
+          <ChevronsRight className="size-3.5" />
           <span className="hidden @[40rem]:inline">Run all</span>
         </button>
       ) : null}
@@ -214,7 +214,7 @@ export function NotebookCommandToolbar({
           aria-label="Restart kernel"
           data-testid="restart-kernel-button"
         >
-          <RotateCcw className="h-3 w-3" />
+          <RotateCcw className="size-3" />
           <span className="hidden @[40rem]:inline">Restart</span>
         </button>
       ) : null}
@@ -236,8 +236,8 @@ export function NotebookCommandToolbar({
           }
           data-testid="restart-run-all-button"
         >
-          <RotateCcw className="h-3 w-3" />
-          <ChevronsRight className="h-3 w-3 -ml-1" />
+          <RotateCcw className="size-3" />
+          <ChevronsRight className="size-3 -ml-1" />
         </button>
       ) : null}
 
@@ -256,7 +256,7 @@ export function NotebookCommandToolbar({
           data-testid="interrupt-kernel-button"
         >
           <Square
-            className="h-3 w-3"
+            className="size-3"
             fill={runtimeStatus?.state === "busy" ? "currentColor" : "none"}
           />
           <span className="hidden @[40rem]:inline">Interrupt</span>
@@ -274,9 +274,9 @@ export function NotebookCommandToolbar({
           data-testid="workstation-setup-button"
         >
           {workstationAction.pending ? (
-            <Loader2 className="h-3 w-3 animate-spin" />
+            <Loader2 className="size-3 animate-spin" />
           ) : (
-            <ServerCog className="h-3 w-3" />
+            <ServerCog className="size-3" />
           )}
           <span className="hidden @[40rem]:inline">{workstationAction.label}</span>
         </button>
@@ -294,7 +294,7 @@ export function NotebookCommandToolbar({
           className="flex items-center gap-1 rounded px-1.5 py-0.5 text-[10px] font-medium bg-violet-500/10 text-violet-600 hover:bg-violet-500/20 dark:text-violet-400 transition-colors"
           title={updateAction.title}
         >
-          <ArrowDownToLine className="h-3 w-3" />
+          <ArrowDownToLine className="size-3" />
           <span>{updateAction.label}</span>
         </button>
       ) : null}
@@ -324,12 +324,12 @@ export function NotebookCommandToolbar({
         >
           {runtime === "deno" ? (
             <>
-              <DenoIcon className="h-3 w-3" />
+              <DenoIcon className="size-3" />
               <span>Deno</span>
             </>
           ) : (
             <>
-              <PythonIcon className="h-3 w-3" />
+              <PythonIcon className="size-3" />
               <span>Python</span>
             </>
           )}
@@ -337,20 +337,20 @@ export function NotebookCommandToolbar({
             <>
               <span className="opacity-40">/</span>
               {environmentManager === "uv" ? (
-                <UvIcon className="h-2 w-2 text-fuchsia-600 dark:text-fuchsia-400" />
+                <UvIcon className="size-2 text-fuchsia-600 dark:text-fuchsia-400" />
               ) : null}
               {environmentManager === "conda" ? (
-                <CondaIcon className="h-2.5 w-2.5 text-emerald-600 dark:text-emerald-400" />
+                <CondaIcon className="size-2.5 text-emerald-600 dark:text-emerald-400" />
               ) : null}
               {environmentManager === "pixi" ? (
-                <PixiIcon className="h-2.5 w-2.5 text-amber-600 dark:text-amber-400" />
+                <PixiIcon className="size-2.5 text-amber-600 dark:text-amber-400" />
               ) : null}
             </>
           ) : null}
           {showRuntimePeerIndicator ? (
             <>
               <span className="opacity-40">/</span>
-              <ServerCog className="h-2.5 w-2.5" aria-hidden="true" />
+              <ServerCog className="size-2.5" aria-hidden="true" />
             </>
           ) : null}
         </button>
@@ -367,7 +367,7 @@ export function NotebookCommandToolbar({
         >
           <div
             className={cn(
-              "h-2 w-2 shrink-0 rounded-full",
+              "size-2 shrink-0 rounded-full",
               runtimeStatus.state === "idle" && "bg-green-500",
               runtimeStatus.state === "busy" && "bg-amber-500",
               (runtimeStatus.state === "starting" || runtimeStatus.state === "not_started") &&

--- a/src/components/notebook/NotebookNotice.tsx
+++ b/src/components/notebook/NotebookNotice.tsx
@@ -83,7 +83,7 @@ export function NotebookNotice({
       {icon ? (
         <span
           className={cn(
-            "mt-0.5 flex h-4 w-4 shrink-0 items-center justify-center",
+            "mt-0.5 flex size-4 shrink-0 items-center justify-center",
             iconClassName[tone],
           )}
           aria-hidden="true"
@@ -114,7 +114,7 @@ export function NotebookNotice({
               )}
               aria-label={dismissLabel}
             >
-              <X className="h-3 w-3" />
+              <X className="size-3" />
             </button>
           ) : null}
         </div>

--- a/src/components/notebook/PoolErrorBanner.tsx
+++ b/src/components/notebook/PoolErrorBanner.tsx
@@ -48,12 +48,12 @@ function PoolErrorItem({ envType, error, onDismiss, onOpenSettings }: PoolErrorI
   return (
     <NotebookNotice
       tone="warning"
-      icon={isTimeout ? <Clock className="h-3 w-3" /> : <AlertTriangle className="h-3 w-3" />}
+      icon={isTimeout ? <Clock className="size-3" /> : <AlertTriangle className="size-3" />}
       title={error.message}
       onDismiss={onDismiss}
       actions={
         showSettingsButton(error) && onOpenSettings ? (
-          <NotebookNoticeAction onClick={onOpenSettings} icon={<Settings className="h-3 w-3" />}>
+          <NotebookNoticeAction onClick={onOpenSettings} icon={<Settings className="size-3" />}>
             Settings
           </NotebookNoticeAction>
         ) : null

--- a/src/components/notebook/UntrustedBanner.tsx
+++ b/src/components/notebook/UntrustedBanner.tsx
@@ -10,7 +10,7 @@ export function UntrustedBanner({ onReviewClick }: UntrustedBannerProps) {
   return (
     <NotebookNotice
       tone="warning"
-      icon={<ShieldAlert className="h-4 w-4" />}
+      icon={<ShieldAlert className="size-4" />}
       actions={
         <Button
           size="sm"

--- a/src/components/outputs/ansi-output.tsx
+++ b/src/components/outputs/ansi-output.tsx
@@ -396,7 +396,7 @@ export function AnsiErrorOutput({
       )}
     >
       <div className="flex items-center gap-2 px-1 py-1.5 font-mono">
-        <X aria-hidden="true" className="h-3.5 w-3.5 shrink-0 text-destructive" strokeWidth={2.5} />
+        <X aria-hidden="true" className="size-3.5 shrink-0 text-destructive" strokeWidth={2.5} />
         <div className="min-w-0 truncate font-semibold text-destructive">{headline}</div>
         <div className="h-px min-w-6 flex-1 bg-destructive/10" />
       </div>

--- a/src/components/outputs/media-router.tsx
+++ b/src/components/outputs/media-router.tsx
@@ -137,7 +137,7 @@ function DefaultLoading() {
   return (
     <div className="flex items-center justify-center py-4 text-gray-400">
       <svg
-        className="h-5 w-5 animate-spin"
+        className="size-5 animate-spin"
         xmlns="http://www.w3.org/2000/svg"
         fill="none"
         viewBox="0 0 24 24"

--- a/src/components/outputs/traceback-output.tsx
+++ b/src/components/outputs/traceback-output.tsx
@@ -310,7 +310,7 @@ function Header({
   const canInline = inlineEvalue && Boolean(evalue);
   return (
     <div className="flex items-center gap-2 px-1 py-1.5 font-mono">
-      <X aria-hidden="true" className="h-3.5 w-3.5 shrink-0 text-destructive" strokeWidth={2.5} />
+      <X aria-hidden="true" className="size-3.5 shrink-0 text-destructive" strokeWidth={2.5} />
       <div className="flex min-w-0 flex-1 items-baseline gap-1.5">
         {canInline ? (
           <>
@@ -454,9 +454,9 @@ function CopyButton({
     >
       <span className="flex items-center gap-1">
         {copied ? (
-          <Check aria-hidden="true" className="h-3.5 w-3.5 text-green-600 dark:text-green-400" />
+          <Check aria-hidden="true" className="size-3.5 text-green-600 dark:text-green-400" />
         ) : (
-          <Copy aria-hidden="true" className="h-3.5 w-3.5" />
+          <Copy aria-hidden="true" className="size-3.5" />
         )}
         <span className="hidden sm:inline">{copied ? "Copied" : "Copy"}</span>
       </span>
@@ -610,7 +610,7 @@ function LocationLabel({
           aria-label={`Go to ${navigationLabel}, line ${line}`}
           title={`Go to ${navigationLabel}, line ${line}`}
         >
-          <LocateFixed aria-hidden="true" className="h-3.5 w-3.5" />
+          <LocateFixed aria-hidden="true" className="size-3.5" />
         </button>
       )}
     </span>

--- a/src/components/search/GlobalFindBar.tsx
+++ b/src/components/search/GlobalFindBar.tsx
@@ -60,7 +60,7 @@ export function GlobalFindBar({
       className="flex items-center gap-2 border-b bg-background/95 px-3 py-1.5"
     >
       <div className="flex min-w-0 max-w-md flex-[1_1_24rem] items-center gap-2">
-        <Search className="h-3.5 w-3.5 shrink-0 text-muted-foreground/70" aria-hidden="true" />
+        <Search className="size-3.5 shrink-0 text-muted-foreground/70" aria-hidden="true" />
         <input
           ref={inputRef}
           type="text"
@@ -93,30 +93,30 @@ export function GlobalFindBar({
         type="button"
         onClick={onPrevMatch}
         disabled={matchCount === 0}
-        className="flex h-6 w-6 items-center justify-center rounded-sm text-muted-foreground transition-colors hover:bg-muted hover:text-foreground disabled:pointer-events-none disabled:opacity-30"
+        className="flex size-6 items-center justify-center rounded-sm text-muted-foreground transition-colors hover:bg-muted hover:text-foreground disabled:pointer-events-none disabled:opacity-30"
         title="Previous match (Shift+Enter)"
         aria-label="Previous match"
       >
-        <ChevronUp className="h-4 w-4" />
+        <ChevronUp className="size-4" />
       </button>
       <button
         type="button"
         onClick={onNextMatch}
         disabled={matchCount === 0}
-        className="flex h-6 w-6 items-center justify-center rounded-sm text-muted-foreground transition-colors hover:bg-muted hover:text-foreground disabled:pointer-events-none disabled:opacity-30"
+        className="flex size-6 items-center justify-center rounded-sm text-muted-foreground transition-colors hover:bg-muted hover:text-foreground disabled:pointer-events-none disabled:opacity-30"
         title="Next match (Enter)"
         aria-label="Next match"
       >
-        <ChevronDown className="h-4 w-4" />
+        <ChevronDown className="size-4" />
       </button>
       <button
         type="button"
         onClick={onClose}
-        className="flex h-6 w-6 items-center justify-center rounded-sm text-muted-foreground transition-colors hover:bg-muted hover:text-foreground"
+        className="flex size-6 items-center justify-center rounded-sm text-muted-foreground transition-colors hover:bg-muted hover:text-foreground"
         title="Close (Escape)"
         aria-label="Close find bar"
       >
-        <X className="h-4 w-4" />
+        <X className="size-4" />
       </button>
     </div>
   );


### PR DESCRIPTION
## Overview

Converges icon sizing across the shared `src/components/**` and `apps/notebook/src/**` trees from the older `h-N w-N` form to the Tailwind v4 `size-N` shorthand. 113 equal `h-N w-N` pairs converted across 22 files, so the frontend reads as one convention instead of the ~50/50 split it had drifted into.

## Design decision

The audit found 113 icons using `h-N w-N` while newer code (NotebookCommentsPanel, TrustDialog, the Elements catalog, and the shadcn-generated `button`/`avatar` primitives) uses `size-N`. Tailwind v4 ships `size-N` as the shorthand for equal width + height. The split was purely historical - older files kept the long form, newer files adopted the shorthand. One mechanical pass collapses it.

Rectangle patterns (`h-N w-M` where N != M, e.g. `h-9 w-48` for a combobox, `h-32 w-2` for a vertical progress bar) are left as-is: `size-N` only represents square dimensions. Seven such patterns exist and are correct as written.

Scope excludes `src/components/ui/**` (upstream shadcn primitives, a few still use `h-N w-N` by design) and test files.

## Test plan

- [x] `cargo xtask lint --fix` (Rust fmt, `vp check --fix`, raw-byte, ruff, ty) - all pass
- [x] `vp check` (format + lint + type, the CI gate) - clean, 1055 files
- [x] Notebook component vitest suite - 257 tests pass across 33 files (NotebookNotice, PoolErrorBanner, NotebookContextMenu, NotebookDocumentRail, EnvBuildDecisionDialog, etc.)
- [ ] Visual QA: spot-check the command toolbar, dependency panels, and global find bar in light + dark to confirm icon sizes unchanged (the conversion is width+height equivalent, so no visual change is expected)
