### PR TITLE
feat(comments): lighter, chat-style discussion rail

### DIFF
--- a/apps/notebook/src/components/InlineCommentComposer.tsx
+++ b/apps/notebook/src/components/InlineCommentComposer.tsx
@@ -150,6 +150,7 @@ export function InlineCommentComposer({
             <button
               type="submit"
               aria-label="Comment"
+              title="Comment (⌘↵)"
               disabled={!canSubmit}
               style={buttonStyle}
               className={cn(

--- a/src/components/notebook/NotebookCommentsPanel.tsx
+++ b/src/components/notebook/NotebookCommentsPanel.tsx
@@ -228,7 +228,7 @@ export function NotebookCommentsPanel({
           placeholder={
             draftTarget
               ? `Add a ${anchorLabelForDraft(draftTarget.anchor)} comment`
-              : "Add a comment"
+              : "Add to the discussion"
           }
           compact={!draftTarget}
           onSubmit={onCreateThread}
@@ -357,26 +357,39 @@ function CommentThreadItem({
     ? resolveCommentAuthor?.(thread.created_by_actor_label)
     : undefined;
   const canShowCell = Boolean(commentThreadTargetCellId(thread) && onFocusThreadAnchor);
+  // Document-level threads carry no anchor context, so they show no header and
+  // read as a plain conversation; source/cell/output threads keep their label.
+  const showAnchorHeader = Boolean(quote) || thread.anchor.kind !== "notebook";
 
   return (
     <li
       ref={itemRef}
       className={cn(
-        "group rounded-lg px-2.5 py-2 transition-colors duration-700 hover:bg-muted/40",
+        "group relative rounded-lg px-2.5 py-2 transition-colors duration-700 hover:bg-muted/40",
         thread.status === "resolved" && "opacity-70",
         flashing && "bg-primary/5 hover:bg-primary/5",
       )}
     >
-      <div className="space-y-2.5">
-        <div className="flex items-center gap-2">
-          {quote ? (
+      <button
+        type="button"
+        onClick={handleStatusAction}
+        disabled={statusAction.disabled || statusSubmitting}
+        aria-label={statusAction.ariaLabel}
+        title={statusAction.label}
+        className="absolute right-1.5 top-1.5 inline-grid size-7 place-items-center rounded-md text-muted-foreground opacity-0 transition-all hover:bg-muted hover:text-foreground group-hover:opacity-100 focus-visible:opacity-100 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/30 disabled:cursor-not-allowed disabled:opacity-40"
+      >
+        <StatusIcon className="size-3.5" aria-hidden="true" />
+      </button>
+      <div className="space-y-2.5 pr-7">
+        {showAnchorHeader ? (
+          quote ? (
             canShowCell ? (
               <button
                 type="button"
                 onClick={() => onFocusThreadAnchor?.(thread)}
                 aria-label={`Show cell for ${threadLabel}`}
                 title="Show cell"
-                className="min-w-0 flex-1 rounded-sm py-0.5 text-left transition-colors hover:bg-muted/50 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/30"
+                className="block w-full rounded-sm py-0.5 text-left transition-colors hover:bg-muted/50 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/30"
               >
                 <CommentSourceQuote
                   quote={quote}
@@ -400,23 +413,9 @@ function CommentThreadItem({
               />
             )
           ) : (
-            <div className="min-w-0 flex-1 text-xs text-muted-foreground">
-              {anchorLabel(thread)}
-            </div>
-          )}
-          <div className="flex shrink-0 items-center gap-0.5">
-            <button
-              type="button"
-              onClick={handleStatusAction}
-              disabled={statusAction.disabled || statusSubmitting}
-              aria-label={statusAction.ariaLabel}
-              title={statusAction.label}
-              className="inline-grid size-7 place-items-center rounded-md text-muted-foreground opacity-0 transition-all hover:bg-muted hover:text-foreground group-hover:opacity-100 focus-visible:opacity-100 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/30 disabled:cursor-not-allowed disabled:opacity-40"
-            >
-              <StatusIcon className="size-3.5" aria-hidden="true" />
-            </button>
-          </div>
-        </div>
+            <div className="text-xs text-muted-foreground">{anchorLabel(thread)}</div>
+          )
+        ) : null}
 
         <div className="space-y-3">
           {thread.messages.map((message) => (
@@ -743,6 +742,7 @@ function CommentComposer({
           type="submit"
           disabled={!canSubmit}
           aria-label={submitAriaLabel}
+          title={`${submitAriaLabel} (⌘↵)`}
           style={{
             background: "var(--comment-author-color, var(--primary, #2563eb))",
             color: "var(--comment-author-contrast, #ffffff)",

--- a/src/components/notebook/NotebookCommentsPanel.tsx
+++ b/src/components/notebook/NotebookCommentsPanel.tsx
@@ -1,13 +1,12 @@
 import {
+  ArrowUp,
   Bot,
   CheckCircle2,
   ChevronDown,
   ChevronRight,
-  LocateFixed,
+  CornerDownRight,
   MessageSquare,
-  Plus,
   RotateCcw,
-  Send,
   X,
 } from "lucide-react";
 import { actorInitials, onBehalfOfText } from "runtimed";
@@ -223,8 +222,7 @@ export function NotebookCommentsPanel({
               ? `New ${anchorLabelForDraft(draftTarget.anchor)} comment`
               : "Add a comment on the document"
           }
-          buttonLabel="Add comment"
-          icon="plus"
+          submitAriaLabel="Add comment"
           disabled={!canCreate}
           autoFocusKey={draftTarget ? draftAutoFocusKey(draftTarget) : "document"}
           placeholder={
@@ -316,7 +314,8 @@ function CommentThreadItem({
 }) {
   const itemRef = useRef<HTMLLIElement>(null);
   const [flashing, setFlashing] = useState(false);
-  // On a focus request for this thread, scroll it into view and flash a ring.
+  const [replying, setReplying] = useState(false);
+  // On a focus request for this thread, scroll it into view and flash softly.
   useEffect(() => {
     if (!focused) return;
     itemRef.current?.scrollIntoView?.({ block: "nearest", behavior: "smooth" });
@@ -363,54 +362,63 @@ function CommentThreadItem({
     <li
       ref={itemRef}
       className={cn(
-        "rounded-md border bg-card text-card-foreground shadow-sm transition-shadow duration-700",
-        thread.status === "resolved" && "border-border/70 bg-muted/10 shadow-none",
-        flashing && "ring-2 ring-primary/60",
+        "group rounded-lg px-2.5 py-2 transition-colors duration-700 hover:bg-muted/40",
+        thread.status === "resolved" && "opacity-70",
+        flashing && "bg-primary/5 hover:bg-primary/5",
       )}
     >
-      <div className="space-y-3.5 p-3">
+      <div className="space-y-2.5">
         <div className="flex items-center gap-2">
           {quote ? (
-            <CommentSourceQuote
-              quote={quote}
-              language={
-                resolveSourceLanguage
-                  ? resolveSourceLanguage(commentThreadTargetCellId(thread) ?? "")
-                  : undefined
-              }
-              color={threadAuthor?.color}
-            />
+            canShowCell ? (
+              <button
+                type="button"
+                onClick={() => onFocusThreadAnchor?.(thread)}
+                aria-label={`Show cell for ${threadLabel}`}
+                title="Show cell"
+                className="min-w-0 flex-1 rounded-sm py-0.5 text-left transition-colors hover:bg-muted/50 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/30"
+              >
+                <CommentSourceQuote
+                  quote={quote}
+                  language={
+                    resolveSourceLanguage
+                      ? resolveSourceLanguage(commentThreadTargetCellId(thread) ?? "")
+                      : undefined
+                  }
+                  color={threadAuthor?.color}
+                />
+              </button>
+            ) : (
+              <CommentSourceQuote
+                quote={quote}
+                language={
+                  resolveSourceLanguage
+                    ? resolveSourceLanguage(commentThreadTargetCellId(thread) ?? "")
+                    : undefined
+                }
+                color={threadAuthor?.color}
+              />
+            )
           ) : (
             <div className="min-w-0 flex-1 text-xs text-muted-foreground">
               {anchorLabel(thread)}
             </div>
           )}
           <div className="flex shrink-0 items-center gap-0.5">
-            {canShowCell ? (
-              <button
-                type="button"
-                onClick={() => onFocusThreadAnchor?.(thread)}
-                aria-label={`Show cell for ${threadLabel}`}
-                title="Show cell"
-                className="inline-grid size-7 place-items-center rounded-md text-muted-foreground transition-colors hover:bg-muted hover:text-foreground"
-              >
-                <LocateFixed className="size-3.5" aria-hidden="true" />
-              </button>
-            ) : null}
             <button
               type="button"
               onClick={handleStatusAction}
               disabled={statusAction.disabled || statusSubmitting}
               aria-label={statusAction.ariaLabel}
               title={statusAction.label}
-              className="inline-grid size-7 place-items-center rounded-md text-muted-foreground transition-colors hover:bg-muted hover:text-foreground disabled:cursor-not-allowed disabled:opacity-40"
+              className="inline-grid size-7 place-items-center rounded-md text-muted-foreground opacity-0 transition-all hover:bg-muted hover:text-foreground group-hover:opacity-100 focus-visible:opacity-100 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/30 disabled:cursor-not-allowed disabled:opacity-40"
             >
               <StatusIcon className="size-3.5" aria-hidden="true" />
             </button>
           </div>
         </div>
 
-        <div className="space-y-3.5">
+        <div className="space-y-3">
           {thread.messages.map((message) => (
             <CommentMessage
               key={message.id}
@@ -423,17 +431,36 @@ function CommentThreadItem({
           ) : null}
         </div>
 
-        <CommentComposer
-          ariaLabel={`Reply to ${threadLabel}`}
-          buttonAriaLabel={`Submit reply to ${threadLabel}`}
-          buttonLabel="Reply"
-          icon="send"
-          disabled={!canReply}
-          autoFocusKey={focused ? `${thread.id}:${focusNonce}` : null}
-          placeholder={thread.status === "resolved" ? "Reply to reopen…" : "Reply…"}
-          compact
-          onSubmit={onReplyThread ? (body) => onReplyThread(thread.id, body) : undefined}
-        />
+        {canReply ? (
+          replying ? (
+            <CommentComposer
+              ariaLabel={`Reply to ${threadLabel}`}
+              submitAriaLabel={`Submit reply to ${threadLabel}`}
+              disabled={!canReply}
+              autoFocusKey={`${thread.id}:reply`}
+              placeholder={thread.status === "resolved" ? "Reply to reopen…" : "Reply…"}
+              compact
+              onCollapse={() => setReplying(false)}
+              onSubmit={
+                onReplyThread
+                  ? async (body) => {
+                      await onReplyThread(thread.id, body);
+                      setReplying(false);
+                    }
+                  : undefined
+              }
+            />
+          ) : (
+            <button
+              type="button"
+              onClick={() => setReplying(true)}
+              className="inline-flex items-center gap-1 text-xs font-medium text-muted-foreground transition-colors hover:text-foreground"
+            >
+              <CornerDownRight className="size-3.5" aria-hidden="true" />
+              Reply
+            </button>
+          )
+        ) : null}
       </div>
     </li>
   );
@@ -592,7 +619,7 @@ function CommentSourceQuote({
   const nodes = highlight(quote, language, isDark, colorTheme);
   return (
     <code
-      className="min-w-0 flex-1 truncate border-l-2 pl-2 font-mono text-xs"
+      className="block min-w-0 flex-1 truncate border-l-2 pl-2 font-mono text-xs"
       style={{ borderColor: color ?? "hsl(var(--border))" }}
       data-testid="comment-thread-source-quote"
       title={quote}
@@ -614,33 +641,31 @@ function CommentBody({ body }: { body: string }) {
 
 function CommentComposer({
   ariaLabel,
-  buttonAriaLabel,
-  buttonLabel,
-  icon,
+  submitAriaLabel,
   disabled,
   autoFocusKey = null,
   placeholder,
   compact = false,
   onSubmit,
+  onCollapse,
 }: {
   ariaLabel: string;
-  buttonAriaLabel?: string;
-  buttonLabel: string;
-  icon: "plus" | "send";
+  submitAriaLabel: string;
   disabled: boolean;
   autoFocusKey?: string | null;
   placeholder: string;
   /** Collapse to a single line until focused or non-empty (used for replies). */
   compact?: boolean;
   onSubmit?: (body: string) => void | Promise<void>;
+  onCollapse?: () => void;
 }) {
   const [body, setBody] = useState("");
   const [submitting, setSubmitting] = useState(false);
   const [focused, setFocused] = useState(false);
   const textareaRef = useRef<HTMLTextAreaElement>(null);
-  const Icon = icon === "plus" ? Plus : Send;
   // Collapsed only while compact, blurred, empty, and idle.
   const expanded = !compact || focused || submitting || body.length > 0;
+  const canSubmit = !disabled && !submitting && body.trim().length > 0 && Boolean(onSubmit);
 
   useEffect(() => {
     if (!autoFocusKey || disabled) return;
@@ -675,6 +700,11 @@ function CommentComposer({
     }
   };
 
+  const handleBlur = () => {
+    setFocused(false);
+    if (body.trim().length === 0) onCollapse?.();
+  };
+
   const handleSubmit = async (event: FormEvent) => {
     event.preventDefault();
     await submitBody();
@@ -687,38 +717,44 @@ function CommentComposer({
   };
 
   return (
-    <form className="space-y-2" onSubmit={handleSubmit}>
-      <textarea
-        ref={textareaRef}
-        aria-label={ariaLabel}
-        value={body}
-        disabled={disabled || submitting}
-        placeholder={placeholder}
-        onChange={(event) => setBody(event.target.value)}
-        onFocus={() => setFocused(true)}
-        onBlur={() => setFocused(false)}
-        onKeyDown={handleKeyDown}
-        rows={expanded ? 3 : 1}
-        className={cn(
-          "w-full resize-y border bg-background px-3 text-sm leading-5",
-          expanded ? "min-h-20 rounded-md py-2" : "min-h-0 resize-none rounded-full py-1.5",
-          "placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/30",
-          (disabled || submitting) && "cursor-not-allowed opacity-60",
-        )}
-      />
-      {expanded ? (
-        <div className="flex justify-end">
-          <button
-            type="submit"
-            disabled={disabled || submitting || body.trim().length === 0}
-            aria-label={buttonAriaLabel}
-            className="inline-flex min-h-8 items-center gap-1.5 rounded-md border bg-background px-2.5 text-xs font-medium text-foreground transition-colors hover:bg-muted disabled:cursor-not-allowed disabled:opacity-50"
-          >
-            <Icon className="size-3.5" aria-hidden="true" />
-            {buttonLabel}
-          </button>
-        </div>
-      ) : null}
+    <form onSubmit={handleSubmit}>
+      <div className="relative">
+        <textarea
+          ref={textareaRef}
+          aria-label={ariaLabel}
+          value={body}
+          disabled={disabled || submitting}
+          placeholder={placeholder}
+          onChange={(event) => setBody(event.target.value)}
+          onFocus={() => setFocused(true)}
+          onBlur={handleBlur}
+          onKeyDown={handleKeyDown}
+          rows={expanded ? 3 : 1}
+          className={cn(
+            "block w-full border bg-background pl-3 pr-10 text-sm leading-5",
+            expanded
+              ? "min-h-20 resize-y rounded-md py-2"
+              : "min-h-10 resize-none rounded-full py-2",
+            "placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/30",
+            (disabled || submitting) && "cursor-not-allowed opacity-60",
+          )}
+        />
+        <button
+          type="submit"
+          disabled={!canSubmit}
+          aria-label={submitAriaLabel}
+          style={{
+            background: "var(--comment-author-color, var(--primary, #2563eb))",
+            color: "var(--comment-author-contrast, #ffffff)",
+          }}
+          className={cn(
+            "absolute bottom-1.5 right-1.5 inline-flex size-7 items-center justify-center rounded-full transition-opacity",
+            !canSubmit && "cursor-not-allowed opacity-40",
+          )}
+        >
+          <ArrowUp className="size-4" aria-hidden="true" />
+        </button>
+      </div>
     </form>
   );
 }

--- a/src/components/notebook/__tests__/NotebookCommentsPanel.test.tsx
+++ b/src/components/notebook/__tests__/NotebookCommentsPanel.test.tsx
@@ -94,12 +94,15 @@ describe("NotebookCommentsPanel", () => {
     );
 
     const composer = screen.getByLabelText(DOCUMENT_COMMENT_LABEL);
+    const submit = screen.getByRole("button", { name: "Add comment" });
     expect(composer).toHaveAttribute("placeholder", "Add a comment");
+    expect(submit).toHaveAttribute("aria-label", "Add comment");
+    expect(submit).toBeDisabled();
 
     fireEvent.change(composer, {
       target: { value: "Add this to the review notes" },
     });
-    fireEvent.click(screen.getByRole("button", { name: "Add comment" }));
+    fireEvent.click(submit);
 
     await waitFor(() =>
       expect(onCreateThread).toHaveBeenCalledWith("Add this to the review notes"),
@@ -327,7 +330,10 @@ describe("NotebookCommentsPanel", () => {
     expect(screen.getByText("Check the framing before publishing.")).toBeVisible();
     expect(screen.getByText("alice")).toBeVisible();
     expect(screen.getByText("Cell-scoped comment")).toBeVisible();
+    expect(screen.queryByLabelText("Reply to Document comment 1")).not.toBeInTheDocument();
 
+    fireEvent.click(screen.getAllByRole("button", { name: "Reply" })[0]);
+    await waitFor(() => expect(screen.getByLabelText("Reply to Document comment 1")).toHaveFocus());
     fireEvent.change(screen.getByLabelText("Reply to Document comment 1"), {
       target: { value: "Looks ready locally" },
     });
@@ -341,7 +347,7 @@ describe("NotebookCommentsPanel", () => {
     expect(onResolveThread).toHaveBeenCalledWith("thread-1");
   });
 
-  it("focuses the reply composer for a focused thread", async () => {
+  it("does not open the reply composer for a focused thread", () => {
     render(
       <NotebookCommentsPanel
         projection={projection}
@@ -351,13 +357,16 @@ describe("NotebookCommentsPanel", () => {
       />,
     );
 
-    await waitFor(() => expect(screen.getByLabelText("Reply to Document comment 1")).toHaveFocus());
+    expect(screen.queryByLabelText("Reply to Document comment 1")).not.toBeInTheDocument();
+    expect(screen.getAllByRole("button", { name: "Reply" })[0]).toBeVisible();
   });
 
   it("submits replies with Ctrl Enter", async () => {
     const onReplyThread = vi.fn();
     render(<NotebookCommentsPanel projection={projection} onReplyThread={onReplyThread} />);
 
+    fireEvent.click(screen.getAllByRole("button", { name: "Reply" })[0]);
+    await waitFor(() => expect(screen.getByLabelText("Reply to Document comment 1")).toHaveFocus());
     const reply = screen.getByLabelText("Reply to Document comment 1");
     fireEvent.change(reply, {
       target: { value: "Reply from the keyboard" },
@@ -572,7 +581,7 @@ describe("NotebookCommentsPanel", () => {
     const { container } = render(
       <NotebookCommentsPanel projection={projection} focusedThreadId="thread-1" focusNonce={1} />,
     );
-    // The focused thread's card gets the flash ring.
-    expect(container.querySelector("li.ring-2")).not.toBeNull();
+    // The focused thread gets a soft background flash.
+    expect(container.querySelector("li")?.className).toContain("bg-primary/5");
   });
 });

--- a/src/components/notebook/__tests__/NotebookCommentsPanel.test.tsx
+++ b/src/components/notebook/__tests__/NotebookCommentsPanel.test.tsx
@@ -95,7 +95,7 @@ describe("NotebookCommentsPanel", () => {
 
     const composer = screen.getByLabelText(DOCUMENT_COMMENT_LABEL);
     const submit = screen.getByRole("button", { name: "Add comment" });
-    expect(composer).toHaveAttribute("placeholder", "Add a comment");
+    expect(composer).toHaveAttribute("placeholder", "Add to the discussion");
     expect(submit).toHaveAttribute("aria-label", "Add comment");
     expect(submit).toBeDisabled();
 
@@ -313,7 +313,7 @@ describe("NotebookCommentsPanel", () => {
     expect(scroll).toContainElement(screen.getByText("Check the framing before publishing."));
     expect(dock).toContainElement(composer);
     expect(scroll).not.toContainElement(composer);
-    expect(composer).toHaveAttribute("placeholder", "Add a comment");
+    expect(composer).toHaveAttribute("placeholder", "Add to the discussion");
   });
 
   it("renders threads and submits replies", async () => {


### PR DESCRIPTION
Reworks the Discussions rail from hands-on QA: the thread cards felt too heavy and the composer was redundant. Builds on #3792.

## What this does

- **Lighter, chat-style threads.** Thread items drop the `border` / `shadow` / `bg-card` box for a light hover-flow row (`group hover:bg-muted/40`). Resolved threads dim (`opacity-70`) instead of getting their own border, and the scroll-to-thread flash is a soft background tint rather than a ring.
- **Reply on demand.** A quiet `Reply` link replaces the persistent reply input on every thread. Clicking it reveals the composer; it collapses again when left empty. Focusing/scrolling to a thread no longer auto-opens a reply box.
- **One composer affordance.** The docked "Add a comment" and the reply composer are now a single field with the submit arrow *inside* it, author-colored like the inline composer, dropping the separate "Add comment"/"Reply" button that duplicated it.
- **Quote is the locate affordance.** The standalone locate crosshair is gone. When a thread targets a cell, clicking its anchored-quote header jumps to the cell. Resolve/reopen is hover-revealed so it is not always-on visual weight.

## Behavioral coverage

| Surface | Before | After |
|---|---|---|
| Thread item | Bordered card with shadow | Light hover row, no box |
| Reply | Persistent input on every thread | `Reply` link reveals the composer on demand |
| Composer submit | Field + separate button | Field with the author-color arrow inside |
| Jump to cell | Crosshair icon button | Click the anchored-quote header |
| Resolve | Always-visible icon | Hover-revealed |

## Notes

Internal-only change to `NotebookCommentsPanel`; the panel's public props are unchanged, so the desktop and cloud call sites are unaffected. The rendered-selection preview (selection disappearing under the composer in the rendered plane) is the next queued slice, not in this PR.
