### PR TITLE
feat(comments): multiple highlights per run + compose selection preview

### DIFF
--- a/apps/notebook-cloud/viewer/notebook-viewer.tsx
+++ b/apps/notebook-cloud/viewer/notebook-viewer.tsx
@@ -2070,6 +2070,7 @@ export function NotebookViewer({
                 onCreateOutputComment={canWriteComments ? handleRequestOutputComment : undefined}
                 onActivateCommentThread={handleActivateCommentThread}
                 commentThreadsByCell={sourceCommentThreadsByCell}
+                pendingCommentAnchor={sourceCommentRequest?.anchor ?? null}
                 markdownHeadingAnchorsByCellId={notebookViewModel.markdownHeadingAnchorsByCellId}
                 outputHostContext={outputHostContext}
                 deferOutputIsolatedFramesUntilVisible={!shellCapabilities.canEditCells}

--- a/apps/notebook/src/App.tsx
+++ b/apps/notebook/src/App.tsx
@@ -2122,6 +2122,7 @@ function AppContent() {
                 onCreateOutputComment={canMutateComments ? handleRequestOutputComment : undefined}
                 onActivateCommentThread={handleActivateCommentThread}
                 commentThreadsByCell={sourceCommentThreadsByCell}
+                pendingCommentAnchor={sourceCommentRequest?.anchor ?? null}
                 markdownHeadingAnchorsByCellId={markdownHeadingAnchorsByCellId}
               />
             </CrdtBridgeProvider>

--- a/apps/notebook/src/components/MarkdownCell.tsx
+++ b/apps/notebook/src/components/MarkdownCell.tsx
@@ -58,6 +58,7 @@ import { openUrl } from "../lib/open-url";
 import { toggleMarkdownTaskMarker } from "../lib/markdown-task-source";
 import { presenceSenderExtension } from "../lib/presence-sender";
 import { sourceRangeAnchorFromRenderedMarkdownSelection } from "../lib/rendered-markdown-source-comment";
+import { buildRenderedCommentHighlights } from "../lib/rendered-comment-highlights";
 import { commentHighlightExtension } from "../lib/comment-highlight-extension";
 import { refreshCellCommentHighlights, type SourceCommentThread } from "../lib/comment-highlights";
 import {
@@ -163,6 +164,7 @@ interface MarkdownCellProps {
   ) => void;
   onActivateCommentThread?: (threadId: string) => void;
   commentThreads?: readonly SourceCommentThread[];
+  pendingCommentAnchor?: SourceRangeCommentAnchor | null;
   outputHostContext?: NteractEmbedHostContextPatch;
 }
 
@@ -183,6 +185,7 @@ export const MarkdownCell = memo(function MarkdownCell({
   onCreateSourceComment,
   onActivateCommentThread,
   commentThreads,
+  pendingCommentAnchor,
   outputHostContext,
 }: MarkdownCellProps) {
   const isFocused = useIsCellFocused(cell.id);
@@ -302,26 +305,25 @@ export const MarkdownCell = memo(function MarkdownCell({
     markdownProjectionMatchesSource(markdownProjection, previewSource);
   const canCommentOnRenderedMarkdown =
     Boolean(onCreateSourceComment) && !readOnly && !editing && projectionMatchesPreview;
-  const renderedCommentHighlights = useMemo(() => {
-    if (editing || !projectionMatchesPreview || !commentThreads?.length) return undefined;
-    const highlights = commentThreads.flatMap((thread) => {
-      // Resolved threads leave no rendered highlight; they stay in the rail
-      // under "Show resolved".
-      if (thread.resolved) return [];
-      const range = resolveSourceRangeAnchor(previewSource, thread.anchor);
-      if (!range) return [];
-      return [
-        {
-          from: range.from,
-          to: range.to,
-          threadId: thread.threadId,
-          resolved: thread.resolved,
-          ...(thread.color ? { color: thread.color } : {}),
-        },
-      ];
-    });
-    return highlights.length > 0 ? highlights : undefined;
-  }, [commentThreads, editing, previewSource, projectionMatchesPreview]);
+  const renderedCommentHighlights = useMemo(
+    () =>
+      buildRenderedCommentHighlights({
+        cellId: cell.id,
+        source: previewSource,
+        editing,
+        projectionMatchesPreview,
+        commentThreads,
+        pendingCommentAnchor,
+      }),
+    [
+      cell.id,
+      commentThreads,
+      editing,
+      pendingCommentAnchor,
+      previewSource,
+      projectionMatchesPreview,
+    ],
+  );
   const previewMinHeight = useMemo(
     () =>
       projectedMarkdownPreviewHeight(

--- a/apps/notebook/src/components/NotebookView.tsx
+++ b/apps/notebook/src/components/NotebookView.tsx
@@ -1026,7 +1026,9 @@ function NotebookViewContent({
             rightGutterContent={rightGutterContent}
             headingAnchors={markdownHeadingAnchorsByCellId?.get(cell.id)}
             commentThreads={commentThreadsByCell?.get(cell.id)}
-            pendingCommentAnchor={pendingCommentAnchor}
+            pendingCommentAnchor={
+              pendingCommentAnchor?.cell_id === cell.id ? pendingCommentAnchor : null
+            }
             readOnly={!canEditMarkdownSources}
             onCreateSourceComment={onCreateSourceComment}
             onActivateCommentThread={onActivateCommentThread}

--- a/apps/notebook/src/components/NotebookView.tsx
+++ b/apps/notebook/src/components/NotebookView.tsx
@@ -98,6 +98,7 @@ export interface NotebookViewProps {
   onCreateOutputComment?: (anchor: OutputCommentAnchor) => void;
   onActivateCommentThread?: (threadId: string) => void;
   commentThreadsByCell?: ReadonlyMap<string, readonly SourceCommentThread[]>;
+  pendingCommentAnchor?: SourceRangeCommentAnchor | null;
   markdownHeadingAnchorsByCellId?: ReadonlyMap<string, readonly MarkdownHeadingAnchor[]>;
   outputHostContext?: NteractEmbedHostContextPatch;
   deferOutputIsolatedFramesUntilVisible?: boolean;
@@ -378,6 +379,7 @@ function NotebookViewContent({
   onCreateOutputComment,
   onActivateCommentThread,
   commentThreadsByCell,
+  pendingCommentAnchor,
   markdownHeadingAnchorsByCellId,
   outputHostContext,
   deferOutputIsolatedFramesUntilVisible = false,
@@ -1024,6 +1026,7 @@ function NotebookViewContent({
             rightGutterContent={rightGutterContent}
             headingAnchors={markdownHeadingAnchorsByCellId?.get(cell.id)}
             commentThreads={commentThreadsByCell?.get(cell.id)}
+            pendingCommentAnchor={pendingCommentAnchor}
             readOnly={!canEditMarkdownSources}
             onCreateSourceComment={onCreateSourceComment}
             onActivateCommentThread={onActivateCommentThread}
@@ -1070,6 +1073,7 @@ function NotebookViewContent({
       onCreateOutputComment,
       onActivateCommentThread,
       commentThreadsByCell,
+      pendingCommentAnchor,
       markdownHeadingAnchorsByCellId,
       canEditCodeCellSources,
       canEditMarkdownSources,

--- a/apps/notebook/src/components/__tests__/rendered-comment-highlights.test.ts
+++ b/apps/notebook/src/components/__tests__/rendered-comment-highlights.test.ts
@@ -1,0 +1,65 @@
+import { describe, expect, it } from "vitest";
+import {
+  buildRenderedCommentHighlights,
+  PENDING_RENDERED_COMMENT_HIGHLIGHT_COLOR,
+} from "../../lib/rendered-comment-highlights";
+import {
+  sourceRangeAnchorFromOffsets,
+  type SourceRangeCommentAnchor,
+} from "../../lib/comment-source-anchor";
+
+function makeAnchor(
+  cellId: string,
+  source: string,
+  from: number,
+  to: number,
+): SourceRangeCommentAnchor {
+  const anchor = sourceRangeAnchorFromOffsets(cellId, source, from, to);
+  if (!anchor) {
+    throw new Error("test fixture failed to create source-range anchor");
+  }
+  return anchor;
+}
+
+describe("buildRenderedCommentHighlights", () => {
+  it("adds a pending highlight for the matching cell anchor", () => {
+    const source = "Alpha **beta** gamma";
+    const from = source.indexOf("beta");
+    const to = from + "beta".length;
+    const pendingCommentAnchor = makeAnchor("cell-1", source, from, to);
+
+    expect(
+      buildRenderedCommentHighlights({
+        cellId: "cell-1",
+        source,
+        editing: false,
+        projectionMatchesPreview: true,
+        pendingCommentAnchor,
+      }),
+    ).toEqual([
+      {
+        from,
+        to,
+        resolved: false,
+        pending: true,
+        color: PENDING_RENDERED_COMMENT_HIGHLIGHT_COLOR,
+      },
+    ]);
+  });
+
+  it("does not add a pending highlight for a different cell anchor", () => {
+    const source = "Alpha **beta** gamma";
+    const from = source.indexOf("beta");
+    const pendingCommentAnchor = makeAnchor("cell-2", source, from, from + "beta".length);
+
+    expect(
+      buildRenderedCommentHighlights({
+        cellId: "cell-1",
+        source,
+        editing: false,
+        projectionMatchesPreview: true,
+        pendingCommentAnchor,
+      }),
+    ).toBeUndefined();
+  });
+});

--- a/apps/notebook/src/lib/rendered-comment-highlights.ts
+++ b/apps/notebook/src/lib/rendered-comment-highlights.ts
@@ -1,0 +1,57 @@
+import type { MarkdownCommentHighlight } from "@/components/markdown/ProjectedMarkdownView";
+import type { SourceCommentThread } from "./comment-highlights";
+import { resolveSourceRangeAnchor, type SourceRangeCommentAnchor } from "./comment-source-anchor";
+
+export const PENDING_RENDERED_COMMENT_HIGHLIGHT_COLOR =
+  "var(--comment-author-color, var(--primary, #2563eb))";
+
+interface RenderedCommentHighlightOptions {
+  cellId: string;
+  source: string;
+  editing: boolean;
+  projectionMatchesPreview: boolean;
+  commentThreads?: readonly SourceCommentThread[];
+  pendingCommentAnchor?: SourceRangeCommentAnchor | null;
+}
+
+export function buildRenderedCommentHighlights({
+  cellId,
+  source,
+  editing,
+  projectionMatchesPreview,
+  commentThreads,
+  pendingCommentAnchor,
+}: RenderedCommentHighlightOptions): MarkdownCommentHighlight[] | undefined {
+  if (editing || !projectionMatchesPreview) return undefined;
+
+  const highlights: MarkdownCommentHighlight[] = [];
+  for (const thread of commentThreads ?? []) {
+    // Resolved threads leave no rendered highlight; they stay in the rail
+    // under "Show resolved".
+    if (thread.resolved) continue;
+    const range = resolveSourceRangeAnchor(source, thread.anchor);
+    if (!range) continue;
+    highlights.push({
+      from: range.from,
+      to: range.to,
+      threadId: thread.threadId,
+      resolved: thread.resolved,
+      ...(thread.color ? { color: thread.color } : {}),
+    });
+  }
+
+  if (pendingCommentAnchor?.cell_id === cellId) {
+    const range = resolveSourceRangeAnchor(source, pendingCommentAnchor);
+    if (range) {
+      highlights.push({
+        from: range.from,
+        to: range.to,
+        resolved: false,
+        pending: true,
+        color: PENDING_RENDERED_COMMENT_HIGHLIGHT_COLOR,
+      });
+    }
+  }
+
+  return highlights.length > 0 ? highlights : undefined;
+}

--- a/src/components/markdown/ProjectedMarkdownView.tsx
+++ b/src/components/markdown/ProjectedMarkdownView.tsx
@@ -1,4 +1,5 @@
 import {
+  Fragment,
   type CSSProperties,
   type HTMLAttributes,
   type KeyboardEvent,
@@ -59,6 +60,7 @@ export interface MarkdownCommentHighlight {
   threadId?: string;
   color?: string;
   resolved: boolean;
+  pending?: boolean;
 }
 
 interface ProjectedMarkdownViewProps {
@@ -756,9 +758,7 @@ function renderRuns(runs: MarkdownProjectionRun[], options: RenderRunsOptions = 
 
   const { activeInlineId, commentHighlights, onActivateCommentThread, onLinkClick } = options;
   return runs.map((run) => {
-    // Keep choosing one best highlight per run for now; multiple disjoint
-    // highlight fragments in the same run are intentionally deferred.
-    const highlight = commentHighlightForRun(run, commentHighlights);
+    const highlights = commentHighlightsForRun(run, commentHighlights);
     return (
       <span
         key={run.inlineId}
@@ -770,36 +770,28 @@ function renderRuns(runs: MarkdownProjectionRun[], options: RenderRunsOptions = 
         data-source-active-run={activeInlineId === run.inlineId ? "true" : undefined}
         className={cn(activeInlineId === run.inlineId && sourceActiveRunClass)}
       >
-        {renderRunWithHighlight(run, highlight, onLinkClick, onActivateCommentThread)}
+        {renderRunWithHighlights(run, highlights, onLinkClick, onActivateCommentThread)}
       </span>
     );
   });
 }
 
-function commentHighlightForRun(
+function commentHighlightsForRun(
   run: MarkdownProjectionRun,
   commentHighlights: ReadonlyArray<MarkdownCommentHighlight> | undefined,
-): MarkdownCommentHighlight | null {
-  if (!commentHighlights?.length) return null;
+): MarkdownCommentHighlight[] {
+  if (!commentHighlights?.length) return [];
   const [runStart, runEnd] = run.sourceSpanUtf16;
-  let best: MarkdownCommentHighlight | null = null;
-  let bestLength = Number.POSITIVE_INFINITY;
-  let bestStart = Number.POSITIVE_INFINITY;
 
-  for (const highlight of commentHighlights) {
-    const start = Math.min(highlight.from, highlight.to);
-    const end = Math.max(highlight.from, highlight.to);
-    if (start === end) continue;
-    if (runStart >= end || runEnd <= start) continue;
-    const length = end - start;
-    if (length < bestLength || (length === bestLength && start < bestStart)) {
-      best = highlight;
-      bestLength = length;
-      bestStart = start;
-    }
-  }
-
-  return best;
+  return commentHighlights
+    .map((highlight) => {
+      const start = Math.min(highlight.from, highlight.to);
+      const end = Math.max(highlight.from, highlight.to);
+      return { end, highlight, length: end - start, start };
+    })
+    .filter(({ end, start }) => start !== end && runStart < end && runEnd > start)
+    .sort((left, right) => left.length - right.length || left.start - right.start)
+    .map(({ highlight }) => highlight);
 }
 
 function commentHighlightStyle(
@@ -851,54 +843,81 @@ const splittableRunSemantics = new Set([
   "link-label",
 ]);
 
-function renderRunWithHighlight(
+function renderRunWithHighlights(
   run: MarkdownProjectionRun,
-  highlight: MarkdownCommentHighlight | null,
+  highlights: ReadonlyArray<MarkdownCommentHighlight>,
   onLinkClick?: (url: string) => void,
   onActivateCommentThread?: (threadId: string) => void,
 ) {
-  if (!highlight) return renderRun(run, onLinkClick);
+  if (highlights.length === 0) return renderRun(run, onLinkClick);
+  const best = highlights[0];
 
   if (!canSplitRunForHighlight(run)) {
     return (
       <span
-        className={cn("comment-highlight", highlight.resolved && "comment-highlight-resolved")}
-        {...commentHighlightActivationProps(highlight, onActivateCommentThread)}
-        style={commentHighlightStyle(highlight)}
+        className={cn(
+          "comment-highlight",
+          best.resolved && "comment-highlight-resolved",
+          best.pending && "comment-highlight-pending",
+        )}
+        {...commentHighlightActivationProps(best, onActivateCommentThread)}
+        style={commentHighlightStyle(best)}
       >
         {renderRun(run, onLinkClick)}
       </span>
     );
   }
 
-  const [runStart, runEnd] = run.sourceSpanUtf16;
-  const highlightStart = Math.min(highlight.from, highlight.to);
-  const highlightEnd = Math.max(highlight.from, highlight.to);
-  const overlapStart = Math.max(highlightStart, runStart);
-  const overlapEnd = Math.min(highlightEnd, runEnd);
   const length = run.renderedText.length;
-  const start = clamp(overlapStart - runStart, 0, length);
-  const end = clamp(overlapEnd - runStart, 0, length);
+  const [runStart, runEnd] = run.sourceSpanUtf16;
+  const ranges = highlights
+    .map((highlight) => {
+      const start = Math.min(highlight.from, highlight.to);
+      const end = Math.max(highlight.from, highlight.to);
+      const s = clamp(Math.max(start, runStart) - runStart, 0, length);
+      const e = clamp(Math.min(end, runEnd) - runStart, 0, length);
+      return { e, h: highlight, s };
+    })
+    .filter(({ e, s }) => e > s);
 
-  if (end <= start) return renderRun(run, onLinkClick);
+  if (ranges.length === 0) return renderRun(run, onLinkClick);
 
-  const before = run.renderedText.slice(0, start);
-  const highlighted = run.renderedText.slice(start, end);
-  const after = run.renderedText.slice(end);
-
-  return (
-    <>
-      {before ? renderRunText(run, before, onLinkClick) : null}
-      <span
-        className={cn("comment-highlight", highlight.resolved && "comment-highlight-resolved")}
-        {...commentHighlightActivationProps(highlight, onActivateCommentThread)}
-        style={commentHighlightStyle(highlight)}
-      >
-        {renderRunText(run, highlighted, onLinkClick)}
-      </span>
-      {after ? renderRunText(run, after, onLinkClick) : null}
-    </>
+  const boundaries = Array.from(new Set([0, length, ...ranges.flatMap(({ e, s }) => [s, e])])).sort(
+    (left, right) => left - right,
   );
+
+  const pieces: ReactNode[] = [];
+  for (let index = 0; index < boundaries.length - 1; index += 1) {
+    const a = boundaries[index];
+    const b = boundaries[index + 1];
+    const text = run.renderedText.slice(a, b);
+    if (!text) continue;
+
+    const covering = ranges.filter(({ e, s }) => s <= a && e >= b);
+    const top = covering[0]?.h;
+
+    if (!top) {
+      pieces.push(<Fragment key={a}>{renderRunText(run, text, onLinkClick)}</Fragment>);
+      continue;
+    }
+
+    pieces.push(
+      <span
+        key={a}
+        className={cn(
+          "comment-highlight",
+          top.resolved && "comment-highlight-resolved",
+          top.pending && "comment-highlight-pending",
+        )}
+        {...commentHighlightActivationProps(top, onActivateCommentThread)}
+        style={commentHighlightStyle(top)}
+      >
+        {renderRunText(run, text, onLinkClick)}
+      </span>,
+    );
+  }
+
+  return <>{pieces}</>;
 }
 
 function canSplitRunForHighlight(run: MarkdownProjectionRun) {
@@ -986,7 +1005,7 @@ function ProjectedFigure({
   run: MarkdownProjectionRun;
 }) {
   const image = <ProjectedImage run={run} />;
-  const highlight = commentHighlightForRun(run, commentHighlights);
+  const highlight = commentHighlightsForRun(run, commentHighlights)[0] ?? null;
   const title = run.imageTitle?.trim();
   return (
     <MarkdownFigure
@@ -1000,6 +1019,7 @@ function ProjectedFigure({
             activeInlineId === run.inlineId && sourceActiveRunClass,
             highlight && "comment-highlight",
             highlight?.resolved && "comment-highlight-resolved",
+            highlight?.pending && "comment-highlight-pending",
           )}
           {...commentHighlightActivationProps(highlight, onActivateCommentThread)}
           style={commentHighlightStyle(highlight)}

--- a/src/components/markdown/__tests__/ProjectedMarkdownView.test.tsx
+++ b/src/components/markdown/__tests__/ProjectedMarkdownView.test.tsx
@@ -287,6 +287,125 @@ describe("ProjectedMarkdownView", () => {
     expect(run).not.toHaveClass("comment-highlight");
   });
 
+  it("renders two non-overlapping highlights in one transparent run", () => {
+    const source = "alpha beta gamma";
+    const { container } = render(
+      <ProjectedMarkdownView
+        commentHighlights={[
+          { from: 0, to: 5, threadId: "thread-alpha", color: "#d97706", resolved: false },
+          {
+            from: 11,
+            to: 16,
+            threadId: "thread-gamma",
+            color: "#2563eb",
+            resolved: false,
+            pending: true,
+          },
+        ]}
+        plan={plan({
+          blocks: [
+            {
+              blockId: "p0",
+              blockIndex: 0,
+              element: "p",
+              kind: "paragraph",
+              measurement: { estimatedHeight: 32, confidence: "high", width: 720 },
+              sourceSpanByte: [0, source.length],
+              sourceSpanUtf16: [0, source.length],
+              syntaxSpans: [],
+              text: source,
+            },
+          ],
+          runs: [
+            {
+              blockId: "p0",
+              inlineId: "r0",
+              listItemIndex: null,
+              renderedText: source,
+              renderedTextUtf16: [0, source.length],
+              semantic: "text",
+              sourceSpanByte: [0, source.length],
+              sourceSpanUtf16: [0, source.length],
+            },
+          ],
+        })}
+      />,
+    );
+
+    const run = container.querySelector<HTMLElement>("[data-markdown-source-run='true']");
+    const highlights = Array.from(container.querySelectorAll<HTMLElement>(".comment-highlight"));
+    const plainText = Array.from(run?.childNodes ?? [])
+      .filter((node) => node.nodeType === 3)
+      .map((node) => node.textContent)
+      .join("");
+
+    expect(highlights).toHaveLength(2);
+    expect(highlights.map((highlight) => highlight.textContent)).toEqual(["alpha", "gamma"]);
+    expect(plainText).toBe(" beta ");
+    expect(highlights[0]).not.toHaveTextContent("beta");
+    expect(highlights[1]).not.toHaveTextContent("beta");
+    expect(highlights[1]).toHaveClass("comment-highlight-pending");
+    expect(run).not.toHaveClass("comment-highlight");
+  });
+
+  it("uses the narrower highlight for overlapping segments in one transparent run", () => {
+    const source = "alpha beta gamma";
+    const onActivateCommentThread = vi.fn();
+    const { container } = render(
+      <ProjectedMarkdownView
+        onActivateCommentThread={onActivateCommentThread}
+        commentHighlights={[
+          { from: 0, to: 16, threadId: "thread-wide", color: "#d97706", resolved: false },
+          { from: 6, to: 10, threadId: "thread-beta", color: "#2563eb", resolved: false },
+        ]}
+        plan={plan({
+          blocks: [
+            {
+              blockId: "p0",
+              blockIndex: 0,
+              element: "p",
+              kind: "paragraph",
+              measurement: { estimatedHeight: 32, confidence: "high", width: 720 },
+              sourceSpanByte: [0, source.length],
+              sourceSpanUtf16: [0, source.length],
+              syntaxSpans: [],
+              text: source,
+            },
+          ],
+          runs: [
+            {
+              blockId: "p0",
+              inlineId: "r0",
+              listItemIndex: null,
+              renderedText: source,
+              renderedTextUtf16: [0, source.length],
+              semantic: "text",
+              sourceSpanByte: [0, source.length],
+              sourceSpanUtf16: [0, source.length],
+            },
+          ],
+        })}
+      />,
+    );
+
+    const highlights = Array.from(container.querySelectorAll<HTMLElement>(".comment-highlight"));
+    const betaHighlight = highlights.find((highlight) => highlight.textContent === "beta");
+
+    expect(highlights).toHaveLength(3);
+    expect(highlights.map((highlight) => highlight.textContent).join("")).toBe(source);
+    expect(highlights[0]?.textContent).toBe("alpha ");
+    expect(highlights[0]?.style.getPropertyValue("--cm-comment-color")).toBe("#d97706");
+    expect(betaHighlight).not.toBeUndefined();
+    expect(betaHighlight?.style.getPropertyValue("--cm-comment-color")).toBe("#2563eb");
+    expect(highlights[2]?.textContent).toBe(" gamma");
+    expect(highlights[2]?.style.getPropertyValue("--cm-comment-color")).toBe("#d97706");
+
+    fireEvent.click(betaHighlight!);
+
+    expect(onActivateCommentThread).toHaveBeenCalledTimes(1);
+    expect(onActivateCommentThread).toHaveBeenCalledWith("thread-beta");
+  });
+
   it("highlights transparent strong run characters without ballooning to siblings", () => {
     const { container } = render(
       <ProjectedMarkdownView

--- a/src/styles/comment-highlight.css
+++ b/src/styles/comment-highlight.css
@@ -17,3 +17,16 @@
      "needs attention" cue, so a resolved thread drops it. */
   border-bottom: none;
 }
+
+/* Compose preview: the range the open composer will attach to. It is tentative
+   and not yet a real comment, so it reads as a softer, dashed version of a
+   committed highlight and is not interactive. */
+.comment-highlight-pending {
+  background-color: color-mix(in srgb, var(--cm-comment-color) 14%, transparent);
+  border-bottom-style: dashed;
+  cursor: text;
+}
+
+.comment-highlight-pending:hover {
+  background-color: color-mix(in srgb, var(--cm-comment-color) 14%, transparent);
+}


### PR DESCRIPTION
Two rendered-markdown comment-highlight fixes from in-app review. Builds on the merged comment work (#3791/#3792/#3794).

## Multiple highlights per run

Rendered highlights collapsed to one per projection run. A short paragraph is a single run, so commenting two different words showed only one underline ("last one wins"). The renderer now character-segments a run across **all** overlapping highlights: it collects every highlight overlapping the run, splits the rendered text at each highlight boundary, and wraps each covered segment with the narrowest covering highlight (which wins color and click-activation where ranges overlap). Opaque runs (images) keep a single whole-run highlight.

## Compose selection preview

Selecting text in the rendered plane and opening the inline composer dropped the visible selection (clicking the affordance collapses the browser's DOM selection), unlike CodeMirror which keeps its own. Now, while the inline composer is open, the target range shows a **pending highlight** in the author's color, derived from the open compose request so it appears on open and clears itself on submit or cancel. A pure `buildRenderedCommentHighlights` helper merges committed thread highlights with the pending one (filtered by cell id); it reuses the multi-highlight renderer above, so the preview coexists with existing comment highlights.

## Behavioral coverage

| Case | Before | After |
|---|---|---|
| Two comments on different words in one paragraph | One underline (last/shortest wins) | Both underlined |
| Overlapping comment ranges in one run | One underline | Both shown; narrower wins the overlap |
| Composing on a rendered selection | Selection vanishes when composer opens | Range stays highlighted (author color) until submit/cancel |
| Image / opaque run | Whole-run highlight | Unchanged |

## Notes

`pendingCommentAnchor` is passed to all markdown cells and each self-filters by `cell.id`; the reference only changes when the composer opens/closes, so re-renders are limited to that. Scoped to the inline composer (`sourceCommentRequest`); the rail-draft path is unchanged.
