### PR TITLE
fix(comments): refuse ambiguous comment re-anchor

### DIFF
--- a/apps/notebook/src/lib/__tests__/comment-source-anchor.test.ts
+++ b/apps/notebook/src/lib/__tests__/comment-source-anchor.test.ts
@@ -285,6 +285,34 @@ describe("resolveSourceRangeAnchor", () => {
     };
   }
 
+  function anchorFromOccurrence(
+    sourceText: string,
+    quote: string,
+    occurrenceIndex: number,
+    contextChars = 12,
+  ): SourceRangeCommentAnchor {
+    let from = -1;
+    let searchFrom = 0;
+    for (let index = 0; index <= occurrenceIndex; index += 1) {
+      from = sourceText.indexOf(quote, searchFrom);
+      if (from === -1) throw new Error(`missing quote occurrence: ${quote}`);
+      searchFrom = from + quote.length;
+    }
+    const start = sourcePointFromStringOffset(sourceText, from);
+    const end = sourcePointFromStringOffset(sourceText, from + quote.length);
+    return {
+      kind: "source_range",
+      cell_id: "cell-1",
+      start_line: start.line,
+      start_column: start.column,
+      end_line: end.line,
+      end_column: end.column,
+      prefix_quote: sourceText.slice(Math.max(0, from - contextChars), from),
+      exact_quote: quote,
+      suffix_quote: sourceText.slice(from + quote.length, from + quote.length + contextChars),
+    };
+  }
+
   it("maps stored line/column straight through when the text is unchanged", () => {
     const anchor = anchorFor("sp.diff(f, x)");
     const expected = source.indexOf("sp.diff(f, x)");
@@ -294,7 +322,7 @@ describe("resolveSourceRangeAnchor", () => {
     });
   });
 
-  it("repairs the offset after the document shifts above the quote", () => {
+  it("repairs a single occurrence after the document shifts above the quote", () => {
     const anchor = anchorFor("sp.diff(f, x)");
     const shifted = `# added a comment line\n${source}`;
     const expected = shifted.indexOf("sp.diff(f, x)");
@@ -304,21 +332,56 @@ describe("resolveSourceRangeAnchor", () => {
     });
   });
 
-  it("uses prefix/suffix to disambiguate repeated quotes", () => {
-    const repeated = "value = 1\nvalue = 1\n";
-    const second = repeated.lastIndexOf("value");
+  it("uses context to reanchor a shifted repeated quote instead of a nearby stale occurrence", () => {
+    const original = "left foo right\nother foo other\n";
+    const anchor = anchorFromOccurrence(original, "foo", 1, 6);
+    const shifted = "left foo right\ninserted foo line\nother foo other\n";
+    const expected = shifted.lastIndexOf("foo");
+
+    expect(offsetFromSourcePoint(shifted, anchor.start_line, anchor.start_column)).not.toBe(
+      expected,
+    );
+    expect(resolveSourceRangeAnchor(shifted, anchor)).toEqual({
+      from: expected,
+      to: expected + "foo".length,
+    });
+  });
+
+  it("returns null for repeated quotes with no distinguishing prefix or suffix context", () => {
+    const repeated = "same\nsame\n";
     const anchor: SourceRangeCommentAnchor = {
       kind: "source_range",
       cell_id: "cell-1",
-      start_line: 1,
+      start_line: 99,
       start_column: 0,
-      end_line: 1,
-      end_column: 5,
-      prefix_quote: "value = 1\n",
-      exact_quote: "value",
-      suffix_quote: " = 1",
+      end_line: 99,
+      end_column: 4,
+      prefix_quote: "",
+      exact_quote: "same",
+      suffix_quote: "",
     };
-    expect(resolveSourceRangeAnchor(repeated, anchor)).toEqual({ from: second, to: second + 5 });
+
+    expect(resolveSourceRangeAnchor(repeated, anchor)).toBeNull();
+  });
+
+  it("uses prefix/suffix context to disambiguate repeated quotes", () => {
+    const repeated = "alpha foo\nbeta foo\n";
+    const second = repeated.lastIndexOf("foo");
+    const anchor: SourceRangeCommentAnchor = {
+      kind: "source_range",
+      cell_id: "cell-1",
+      start_line: 99,
+      start_column: 0,
+      end_line: 99,
+      end_column: 3,
+      prefix_quote: "beta ",
+      exact_quote: "foo",
+      suffix_quote: "\n",
+    };
+    expect(resolveSourceRangeAnchor(repeated, anchor)).toEqual({
+      from: second,
+      to: second + "foo".length,
+    });
   });
 
   it("returns null when the quoted text no longer exists", () => {

--- a/apps/notebook/src/lib/comment-source-anchor.ts
+++ b/apps/notebook/src/lib/comment-source-anchor.ts
@@ -202,19 +202,39 @@ export function resolveSourceRangeAnchor(
 
   const prefix = anchor.prefix_quote ?? "";
   const suffix = anchor.suffix_quote ?? "";
-  let best = occurrences[0];
-  let bestScore = Number.NEGATIVE_INFINITY;
-  for (const index of occurrences) {
+  const scoredOccurrences = occurrences.map((index) => {
     const before = source.slice(Math.max(0, index - prefix.length), index);
     const after = source.slice(index + quote.length, index + quote.length + suffix.length);
-    let score = 0;
-    if (prefix.length > 0 && before.endsWith(prefix)) score += 2;
-    if (suffix.length > 0 && after.startsWith(suffix)) score += 2;
-    score -= Math.abs(index - expectedFrom) / Math.max(1, source.length);
-    if (score > bestScore) {
-      bestScore = score;
-      best = index;
+    let contextScore = 0;
+    if (prefix.length > 0 && before.endsWith(prefix)) contextScore += 2;
+    if (suffix.length > 0 && after.startsWith(suffix)) contextScore += 2;
+    return { index, contextScore };
+  });
+
+  const maxContext = Math.max(...scoredOccurrences.map((occurrence) => occurrence.contextScore));
+  if (maxContext === 0) return null;
+
+  const bestContextMatches = scoredOccurrences.filter(
+    (occurrence) => occurrence.contextScore === maxContext,
+  );
+  if (bestContextMatches.length === 1) {
+    const best = bestContextMatches[0].index;
+    return { from: best, to: best + quote.length };
+  }
+
+  let best: number | null = null;
+  let bestDistance = Number.POSITIVE_INFINITY;
+  let tiedClosest = false;
+  for (const occurrence of bestContextMatches) {
+    const distance = Math.abs(occurrence.index - expectedFrom);
+    if (distance < bestDistance) {
+      best = occurrence.index;
+      bestDistance = distance;
+      tiedClosest = false;
+    } else if (distance === bestDistance) {
+      tiedClosest = true;
     }
   }
+  if (best === null || tiedClosest) return null;
   return { from: best, to: best + quote.length };
 }

--- a/apps/notebook/src/lib/comment-source-anchor.ts
+++ b/apps/notebook/src/lib/comment-source-anchor.ts
@@ -222,6 +222,10 @@ export function resolveSourceRangeAnchor(
     return { from: best, to: best + quote.length };
   }
 
+  // Context tied across these occurrences, so fall back to proximity. This is a
+  // weak last resort: expectedFrom is the stored (pre-repair) offset, so a large
+  // edit above the quote skews it. Refuse (null) if the closest distance is
+  // itself shared, rather than arbitrarily picking one equidistant match.
   let best: number | null = null;
   let bestDistance = Number.POSITIVE_INFINITY;
   let tiedClosest = false;


### PR DESCRIPTION
Audit P1 (F-1). A comment could rebind to the wrong copy of repeated text after an edit.

## The bug

`resolveSourceRangeAnchor` resolves a comment's stored quote back to a source range. When the stored line/col no longer matched (the source moved) and the quote appeared more than once, it always returned a best-scoring occurrence, where the score was prefix/suffix context plus a small proximity term. With no distinguishing context it fell back to proximity alone, so it would silently anchor the comment to the wrong occurrence.

## The fix

The multiple-occurrence path is now confident-only:

- Score each occurrence by prefix/suffix context only (0 to 4).
- No occurrence has any context support → return null (genuinely ambiguous; refuse).
- Among the best-context occurrences: exactly one → use it; a tie → break by proximity and use the strictly-closest; still tied → return null.

Proximity is only ever a tiebreak among equally-strong context matches, never the sole basis for a match. When resolution returns null the comment dangles, the rail shows its stored quote, rather than highlighting the wrong text. The exact-position and single-occurrence fast paths are unchanged.

## Behavioral coverage

| Case | Before | After |
|---|---|---|
| Quote at stored position | Resolves | Resolves (unchanged) |
| Single occurrence | Resolves | Resolves (unchanged) |
| Edit shifts quote, context matches one spot | Resolves (often) | Resolves to the context-matching spot |
| Repeated text, no distinguishing context | Guesses one (could be wrong) | Returns null → comment dangles |
| Repeated text, one spot has matching context | Could pick another by proximity | Resolves to the context-matching spot |
