### PR TITLE
[codex] Document Codex plugin cache reset

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,17 @@ Restart Codex, then open the plugin directory, choose the nteract marketplace, a
 
 The distribution repository also includes a `nightly` plugin entry for pre-release builds.
 
+If Codex still does not show notebook tools after restarting, refresh the marketplace and reinstall the selected plugin:
+
+```
+codex plugin marketplace upgrade nteract-plugins
+codex plugin remove nteract@nteract-plugins      # or nightly@nteract-plugins
+codex plugin add nteract@nteract-plugins         # or nightly@nteract-plugins
+codex mcp list
+```
+
+Start a new Codex session after reinstalling; running sessions do not hot-load newly installed MCP tools.
+
 ### Install the Claude Code plugin
 
 ```

--- a/plugins/nightly/skills/repl/SKILL.md
+++ b/plugins/nightly/skills/repl/SKILL.md
@@ -19,6 +19,17 @@ If only MCP tools are available, use `create_notebook`, `create_cell`, `execute_
 
 If you loaded this skill but neither the direct pi tools (`python`, `python_add_dependencies`) nor the MCP notebook tools are available, don't fall back to `python3 -c`. Ask the user to verify that the nteract plugin is installed and enabled in Codex, then restart Codex after any plugin or marketplace changes. The most common cause is that the plugin was installed or updated after the current Codex session started.
 
+If Codex reports the plugin is installed but the tools still do not appear, ask the user to refresh and reinstall the selected plugin to clear stale local cache state:
+
+```sh
+codex plugin marketplace upgrade nteract-plugins
+codex plugin remove nteract@nteract-plugins      # or nightly@nteract-plugins
+codex plugin add nteract@nteract-plugins         # or nightly@nteract-plugins
+codex mcp list
+```
+
+Start a new Codex session after reinstalling; running sessions do not hot-load newly installed MCP tools.
+
 If tools still don't appear after restarting Codex:
 
 - Confirm the nteract desktop app/daemon is running.

--- a/plugins/nteract/skills/repl/SKILL.md
+++ b/plugins/nteract/skills/repl/SKILL.md
@@ -19,6 +19,17 @@ If only MCP tools are available, use `create_notebook`, `create_cell`, `execute_
 
 If you loaded this skill but neither the direct pi tools (`python`, `python_add_dependencies`) nor the MCP notebook tools are available, don't fall back to `python3 -c`. Ask the user to verify that the nteract plugin is installed and enabled in Codex, then restart Codex after any plugin or marketplace changes. The most common cause is that the plugin was installed or updated after the current Codex session started.
 
+If Codex reports the plugin is installed but the tools still do not appear, ask the user to refresh and reinstall the selected plugin to clear stale local cache state:
+
+```sh
+codex plugin marketplace upgrade nteract-plugins
+codex plugin remove nteract@nteract-plugins      # or nightly@nteract-plugins
+codex plugin add nteract@nteract-plugins         # or nightly@nteract-plugins
+codex mcp list
+```
+
+Start a new Codex session after reinstalling; running sessions do not hot-load newly installed MCP tools.
+
 If tools still don't appear after restarting Codex:
 
 - Confirm the nteract desktop app/daemon is running.

--- a/scripts/assemble-plugin-dist.sh
+++ b/scripts/assemble-plugin-dist.sh
@@ -317,6 +317,17 @@ codex plugin marketplace upgrade nteract-plugins   # refresh to latest tag
 codex plugin marketplace remove  nteract-plugins   # uninstall
 ```
 
+If notebook tools still do not appear after restarting Codex, refresh the marketplace and reinstall the selected plugin:
+
+```
+codex plugin marketplace upgrade nteract-plugins
+codex plugin remove nteract@nteract-plugins      # or nightly@nteract-plugins
+codex plugin add nteract@nteract-plugins         # or nightly@nteract-plugins
+codex mcp list
+```
+
+Start a new Codex session after reinstalling; running sessions do not hot-load newly installed MCP tools.
+
 ## Install in Claude Code
 
 ```


### PR DESCRIPTION
## Summary

- document the Codex plugin cache reset path in the root README
- add the same reset guidance to the generated `agent-plugins` README template
- teach both bundled REPL skills how to route users through marketplace refresh, plugin reinstall, `codex mcp list`, and a fresh Codex session when tools do not appear

## Why

Codex can have a healthy `nteract/agent-plugins` marketplace checkout while the installed plugin cache or current session tool surface remains stale. The docs already covered restart-first troubleshooting, but not the practical local repair sequence.

## Validation

- `bash -n scripts/assemble-plugin-dist.sh`
- `python3 scripts/ci/check-docs-guidance.py`
- temp run of `scripts/assemble-plugin-dist.sh` with fake sidecars, confirming the generated README includes the new troubleshooting copy
