### PR TITLE
fix(comments): a11y batch (keyboard reach, focus restore, rail Escape, click boundary)

### DIFF
--- a/apps/notebook/src/components/CodeCell.tsx
+++ b/apps/notebook/src/components/CodeCell.tsx
@@ -901,9 +901,8 @@ export const CodeCell = memo(function CodeCell({
               {canCreateOutputComment ? (
                 <button
                   type="button"
-                  tabIndex={-1}
                   onClick={handleCreateOutputComment}
-                  className="flex items-center justify-center rounded p-1 text-muted-foreground/40 transition-colors hover:text-foreground"
+                  className="flex items-center justify-center rounded p-1 text-muted-foreground/40 transition-colors hover:text-foreground focus-visible:opacity-100 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/30 focus-visible:text-foreground"
                   title="Comment on outputs"
                   aria-label="Comment on outputs"
                 >

--- a/apps/notebook/src/components/InlineCommentComposer.tsx
+++ b/apps/notebook/src/components/InlineCommentComposer.tsx
@@ -23,6 +23,25 @@ export interface InlineCommentComposerProps {
 
 const AUTHOR_COLOR = "var(--comment-author-color, var(--primary, #2563eb))";
 
+function activeElementForFocusRestore(): HTMLElement | null {
+  if (typeof document === "undefined" || typeof HTMLElement === "undefined") return null;
+  const activeElement = document.activeElement;
+  if (!(activeElement instanceof HTMLElement) || activeElement === document.body) return null;
+  return activeElement;
+}
+
+function canRestoreFocus(element: HTMLElement): boolean {
+  if (!element.isConnected) return false;
+  if (element.getAttribute("aria-hidden") === "true") return false;
+  if (element.hasAttribute("disabled")) return false;
+  if (typeof element.matches === "function" && element.matches(":disabled")) return false;
+  if (typeof window !== "undefined") {
+    const style = window.getComputedStyle(element);
+    if (style.display === "none" || style.visibility === "hidden") return false;
+  }
+  return typeof element.focus === "function";
+}
+
 export function InlineCommentComposer({
   rect,
   disabled = false,
@@ -33,6 +52,13 @@ export function InlineCommentComposer({
   const [submitting, setSubmitting] = useState(false);
   const textareaRef = useRef<HTMLTextAreaElement>(null);
   const justOpenedRef = useRef(true);
+  const restoreFocusTargetRef = useRef<HTMLElement | null>(null);
+  const didCaptureFocusRef = useRef(false);
+
+  if (!didCaptureFocusRef.current) {
+    restoreFocusTargetRef.current = activeElementForFocusRestore();
+    didCaptureFocusRef.current = true;
+  }
 
   useEffect(() => {
     textareaRef.current?.focus();
@@ -42,7 +68,13 @@ export function InlineCommentComposer({
     const settle = window.setTimeout(() => {
       justOpenedRef.current = false;
     }, 300);
-    return () => window.clearTimeout(settle);
+    // On close, return focus to whatever the user came from (the Popover anchor
+    // is aria-hidden, so it cannot restore focus itself).
+    return () => {
+      window.clearTimeout(settle);
+      const restoreTarget = restoreFocusTargetRef.current;
+      if (restoreTarget && canRestoreFocus(restoreTarget)) restoreTarget.focus();
+    };
   }, []);
 
   const submit = async () => {

--- a/apps/notebook/src/components/__tests__/InlineCommentComposer.test.tsx
+++ b/apps/notebook/src/components/__tests__/InlineCommentComposer.test.tsx
@@ -47,6 +47,27 @@ describe("InlineCommentComposer", () => {
     expect(onSubmit).toHaveBeenCalledWith("ship it");
   });
 
+  it("restores focus to the previously focused element when it unmounts", () => {
+    const previousFocus = document.createElement("button");
+    previousFocus.textContent = "Editor";
+    document.body.appendChild(previousFocus);
+    previousFocus.focus();
+
+    try {
+      const { unmount } = render(
+        <InlineCommentComposer rect={rect} onSubmit={vi.fn()} onCancel={vi.fn()} />,
+      );
+
+      expect(screen.getByLabelText("Comment on selection")).toHaveFocus();
+
+      unmount();
+
+      expect(previousFocus).toHaveFocus();
+    } finally {
+      previousFocus.remove();
+    }
+  });
+
   it("cancels on Escape without submitting", () => {
     const onSubmit = vi.fn();
     const onCancel = vi.fn();

--- a/apps/notebook/src/components/__tests__/code-cell-output-focus.test.tsx
+++ b/apps/notebook/src/components/__tests__/code-cell-output-focus.test.tsx
@@ -632,6 +632,33 @@ describe("CodeCell output focus", () => {
     expect(getByTitle("Hide outputs")).toBeTruthy();
   });
 
+  it("keeps the output comment button reachable from keyboard navigation", () => {
+    const onCreateOutputComment = vi.fn();
+    const { getByRole } = render(
+      <CodeCell
+        cell={makeCell()}
+        onFocus={() => {}}
+        onExecute={() => {}}
+        onInterrupt={() => {}}
+        onDelete={() => {}}
+        onCreateOutputComment={onCreateOutputComment}
+      />,
+    );
+
+    const commentButton = getByRole("button", { name: "Comment on outputs" });
+    expect(commentButton).not.toHaveAttribute("tabindex", "-1");
+    expect(commentButton).toHaveClass("focus-visible:ring-2");
+
+    fireEvent.click(commentButton);
+
+    expect(onCreateOutputComment).toHaveBeenCalledWith({
+      kind: "output",
+      cell_id: "code-1",
+      execution_id: undefined,
+      output_id: undefined,
+    });
+  });
+
   it("keeps output chrome for a single sift table without layout mode controls", () => {
     mockOutputs = [
       {

--- a/apps/notebook/src/lib/comment-highlight-extension.ts
+++ b/apps/notebook/src/lib/comment-highlight-extension.ts
@@ -100,11 +100,18 @@ const commentHighlightTheme = EditorView.baseTheme({
   },
 });
 
-function highlightAt(view: EditorView, pos: number): CommentHighlight | undefined {
+function highlightAt(
+  view: EditorView,
+  pos: number,
+  options: { endExclusive?: boolean } = {},
+): CommentHighlight | undefined {
   const highlights = view.state.field(highlightsField, false);
   if (!highlights) return undefined;
+  const contains = options.endExclusive
+    ? (highlight: CommentHighlight) => pos >= highlight.from && pos < highlight.to
+    : (highlight: CommentHighlight) => pos >= highlight.from && pos <= highlight.to;
   return highlights
-    .filter((highlight) => pos >= highlight.from && pos <= highlight.to)
+    .filter(contains)
     .sort((a, b) => a.to - a.from - (b.to - b.from))[0];
 }
 
@@ -113,7 +120,7 @@ function activateThreadAt(
   pos: number,
   onActivateThread: CommentHighlightActivateHandler,
 ): boolean {
-  const match = highlightAt(view, pos);
+  const match = highlightAt(view, pos, { endExclusive: true });
   if (!match) return false;
   onActivateThread(match.threadId);
   return true;

--- a/src/components/notebook/NotebookCommentsPanel.tsx
+++ b/src/components/notebook/NotebookCommentsPanel.tsx
@@ -710,6 +710,15 @@ function CommentComposer({
   };
 
   const handleKeyDown = (event: KeyboardEvent<HTMLTextAreaElement>) => {
+    if (event.key === "Escape") {
+      event.preventDefault();
+      setBody("");
+      setFocused(false);
+      onCollapse?.();
+      textareaRef.current?.blur();
+      return;
+    }
+
     if (event.key !== "Enter" || (!event.metaKey && !event.ctrlKey)) return;
     event.preventDefault();
     void submitBody();

--- a/src/components/notebook/__tests__/NotebookCommentsPanel.test.tsx
+++ b/src/components/notebook/__tests__/NotebookCommentsPanel.test.tsx
@@ -378,6 +378,29 @@ describe("NotebookCommentsPanel", () => {
     );
   });
 
+  it("collapses a reply composer and discards its draft on Escape", async () => {
+    const onReplyThread = vi.fn();
+    render(<NotebookCommentsPanel projection={projection} onReplyThread={onReplyThread} />);
+
+    fireEvent.click(screen.getAllByRole("button", { name: "Reply" })[0]);
+    await waitFor(() => expect(screen.getByLabelText("Reply to Document comment 1")).toHaveFocus());
+    const reply = screen.getByLabelText("Reply to Document comment 1");
+    fireEvent.change(reply, {
+      target: { value: "Do not keep this draft" },
+    });
+
+    fireEvent.keyDown(reply, { key: "Escape" });
+
+    await waitFor(() =>
+      expect(screen.queryByLabelText("Reply to Document comment 1")).not.toBeInTheDocument(),
+    );
+    expect(onReplyThread).not.toHaveBeenCalled();
+
+    fireEvent.click(screen.getAllByRole("button", { name: "Reply" })[0]);
+    await waitFor(() => expect(screen.getByLabelText("Reply to Document comment 1")).toHaveFocus());
+    expect(screen.getByLabelText("Reply to Document comment 1")).toHaveValue("");
+  });
+
   it("renders source excerpts on source range threads", () => {
     const onFocusThreadAnchor = vi.fn();
     const sourceThread = {


### PR DESCRIPTION
Accessibility and small-fix batch for the comment surfaces, from the commenting-layer audit (`docs/audits/comments-layer.md`).

## Fixes

- **Output comment button is keyboard-reachable (COMMENT-005).** It had `tabIndex={-1}`, so commenting on outputs was mouse-only. Dropped that and added a focus-visible reveal + ring, matching the rail resolve button.
- **Inline composer restores focus on close (COMMENT-007).** The composer's Popover anchor is `aria-hidden`, so closing it dropped focus. It now captures the element the user came from on open and restores focus to it on close (guarded: still connected, visible, focusable).
- **Rail composer handles Escape (CMT-UI-02).** Escape now clears the draft, blurs, and collapses an open reply, so there's a keyboard cancel path instead of a draft that persists.
- **Source-plane click boundary (F6).** The click hit-test is now end-exclusive (`pos < highlight.to`), so clicking the character immediately after a highlighted range no longer opens that thread. Only the click hit-test changed; decoration ranges are untouched.

## Deferred

COMMENT-004 (full CodeMirror keyboard navigation of existing highlights, e.g. cycling comment ranges from the editor) is a larger change and stays on the audit backlog.
