### PR TITLE
feat(comments): disable_comments feature flag

### DIFF
--- a/apps/notebook-cloud/viewer/cloud-viewer-config.ts
+++ b/apps/notebook-cloud/viewer/cloud-viewer-config.ts
@@ -57,6 +57,9 @@ function loadConfig(): CloudViewerConfig {
       canManageSharing: Boolean(parsed.hostCapabilities?.canManageSharing),
       canSubmitExecutionRequests: Boolean(parsed.hostCapabilities?.canSubmitExecutionRequests),
     },
+    featureFlags: {
+      disable_comments: parsed.featureFlags?.disable_comments === true,
+    },
     session: isCloudAppSession(parsed.session) ? parsed.session : null,
     syncEndpoint: parsed.syncEndpoint,
     blobBasePath: parsed.blobBasePath,

--- a/apps/notebook-cloud/viewer/cloud-viewer-session.ts
+++ b/apps/notebook-cloud/viewer/cloud-viewer-session.ts
@@ -131,6 +131,9 @@ export interface CloudViewerConfig {
     canManageSharing?: boolean;
     canSubmitExecutionRequests?: boolean;
   };
+  featureFlags?: {
+    disable_comments?: boolean;
+  };
   session?: CloudAppSession | null;
   syncEndpoint: string;
   blobBasePath: string;

--- a/apps/notebook-cloud/viewer/notebook-viewer.tsx
+++ b/apps/notebook-cloud/viewer/notebook-viewer.tsx
@@ -49,6 +49,7 @@ import {
   type CommentsProjection,
   type NotebookCommentDraftTarget,
 } from "@/components/notebook";
+import { resolveCommentsUiSurface } from "@/components/notebook/comments-ui-gate";
 import {
   openNotebookRailPanel,
   setActiveNotebookRailPanel,
@@ -256,6 +257,8 @@ export function NotebookViewer({
   );
   const loadingPolicy = useMemo(() => cloudViewerLoadingPolicy(config), [config.headsHash]);
   const { resolvedTheme } = useTheme(CLOUD_VIEWER_THEME_STORAGE_KEY);
+  const disableComments = config.featureFlags?.disable_comments === true;
+  const commentsUiEnabled = !disableComments;
   const { store: widgetStore } = useWidgetStoreRequired();
   const appSessionStatus = useCloudAppSessionStatus(config.session ?? null);
   const hasAppSession = Boolean(appSessionStatus.session);
@@ -1758,9 +1761,11 @@ export function NotebookViewer({
     [],
   );
   const renderedActiveRailPanel =
-    !shouldShowCloudWorkstationsPanel && activeRailPanel === "workstations"
+    !commentsUiEnabled && activeRailPanel === "comments"
       ? "outline"
-      : activeRailPanel;
+      : !shouldShowCloudWorkstationsPanel && activeRailPanel === "workstations"
+        ? "outline"
+        : activeRailPanel;
   const commentsPanelStatus = commentsProjection ? null : "Syncing comments...";
   const resolveSourceQuote = useCallback((anchor: SourceRangeCommentAnchor): string | null => {
     const cell = getCellById(anchor.cell_id);
@@ -1793,6 +1798,14 @@ export function NotebookViewer({
       resolveSourceQuote={resolveSourceQuote}
     />
   );
+  const commentsUiSurface = resolveCommentsUiSurface({
+    commentsUiEnabled,
+    canCreateComments: canWriteComments,
+    commentsPanel,
+    onCreateSourceComment: handleRequestSourceComment,
+    onCreateOutputComment: handleRequestOutputComment,
+    onActivateCommentThread: handleActivateCommentThread,
+  });
   const rail = (
     <NotebookDocumentRail
       viewModel={notebookViewModel}
@@ -1802,7 +1815,7 @@ export function NotebookViewer({
       activeOutlineItemId={activeOutlineItemId}
       selectedOutlineItemId={selectedOutlineItemId}
       selectedOutlineCellId={focusedCellId}
-      commentsPanel={commentsPanel}
+      commentsPanel={commentsUiSurface.commentsPanel}
       workstationsPanel={
         shouldShowCloudWorkstationsPanel ? (
           <NotebookWorkstationsPanel
@@ -2066,9 +2079,9 @@ export function NotebookViewer({
                 onMoveCell={handleCloudMoveCell}
                 onSetCellSourceHidden={handleCloudSetCellSourceHidden}
                 onSetCellOutputsHidden={handleCloudSetCellOutputsHidden}
-                onCreateSourceComment={canWriteComments ? handleRequestSourceComment : undefined}
-                onCreateOutputComment={canWriteComments ? handleRequestOutputComment : undefined}
-                onActivateCommentThread={handleActivateCommentThread}
+                onCreateSourceComment={commentsUiSurface.onCreateSourceComment}
+                onCreateOutputComment={commentsUiSurface.onCreateOutputComment}
+                onActivateCommentThread={commentsUiSurface.onActivateCommentThread}
                 commentThreadsByCell={sourceCommentThreadsByCell}
                 pendingCommentAnchor={sourceCommentRequest?.anchor ?? null}
                 markdownHeadingAnchorsByCellId={notebookViewModel.markdownHeadingAnchorsByCellId}
@@ -2081,7 +2094,7 @@ export function NotebookViewer({
           </CrdtBridgeProvider>
         </PresenceValueProvider>
       </NotebookDocumentShell>
-      {sourceCommentRequest ? (
+      {commentsUiEnabled && sourceCommentRequest ? (
         <InlineCommentComposer
           rect={sourceCommentRequest.rect}
           quote={sourceCommentRequest.quote ?? sourceCommentRequest.anchor.exact_quote}

--- a/apps/notebook-cloud/viewer/notebook-viewer.tsx
+++ b/apps/notebook-cloud/viewer/notebook-viewer.tsx
@@ -14,6 +14,7 @@ import {
   useHasIsolatedOutputs,
   useIsolatedRenderer,
 } from "@/components/isolated/isolated-renderer-context";
+import type { NotebookRailPanelId } from "@/components/notebook-rail";
 import { NotebookNotice } from "@/components/notebook/NotebookNotice";
 import {
   markdownProjectionMatchesSource,
@@ -707,6 +708,13 @@ export function NotebookViewer({
     }
     openNotebookRailPanel("packages");
   }, [activeRailPanel, railCollapsed]);
+  const handleRailPanelChange = useCallback(
+    (panelId: NotebookRailPanelId) => {
+      if (!commentsUiEnabled && panelId === "comments") return;
+      setActiveNotebookRailPanel(panelId);
+    },
+    [commentsUiEnabled],
+  );
   const handleOpenMobileRail = useCallback(() => {
     setNotebookRailCollapsed(false);
   }, []);
@@ -1847,7 +1855,7 @@ export function NotebookViewer({
           />
         </>
       }
-      onActivePanelChange={setActiveNotebookRailPanel}
+      onActivePanelChange={handleRailPanelChange}
       onCollapsedChange={setNotebookRailCollapsed}
       onSelectOutlineItem={handleSelectOutlineItem}
       onNavigateOutlineItem={handleNavigateOutlineItem}
@@ -2082,7 +2090,7 @@ export function NotebookViewer({
                 onCreateSourceComment={commentsUiSurface.onCreateSourceComment}
                 onCreateOutputComment={commentsUiSurface.onCreateOutputComment}
                 onActivateCommentThread={commentsUiSurface.onActivateCommentThread}
-                commentThreadsByCell={sourceCommentThreadsByCell}
+                commentThreadsByCell={commentsUiEnabled ? sourceCommentThreadsByCell : undefined}
                 pendingCommentAnchor={sourceCommentRequest?.anchor ?? null}
                 markdownHeadingAnchorsByCellId={notebookViewModel.markdownHeadingAnchorsByCellId}
                 outputHostContext={outputHostContext}

--- a/apps/notebook/src/App.tsx
+++ b/apps/notebook/src/App.tsx
@@ -2138,7 +2138,7 @@ function AppContent() {
                 onCreateSourceComment={commentsUiSurface.onCreateSourceComment}
                 onCreateOutputComment={commentsUiSurface.onCreateOutputComment}
                 onActivateCommentThread={commentsUiSurface.onActivateCommentThread}
-                commentThreadsByCell={sourceCommentThreadsByCell}
+                commentThreadsByCell={commentsUiEnabled ? sourceCommentThreadsByCell : undefined}
                 pendingCommentAnchor={sourceCommentRequest?.anchor ?? null}
                 markdownHeadingAnchorsByCellId={markdownHeadingAnchorsByCellId}
               />

--- a/apps/notebook/src/App.tsx
+++ b/apps/notebook/src/App.tsx
@@ -67,6 +67,7 @@ import {
   type CommentAuthor,
   type NotebookCommentDraftTarget,
 } from "@/components/notebook";
+import { resolveCommentsUiSurface } from "@/components/notebook/comments-ui-gate";
 import { GlobalFindBar } from "@/components/search";
 import { InlineCommentComposer } from "./components/InlineCommentComposer";
 import { setSourceCommentThreads, type SourceCommentThread } from "./lib/comment-highlights";
@@ -324,7 +325,9 @@ function AppContent() {
   const daemonInfo = useDaemonInfo();
 
   // Apply theme to this window
-  const { defaultPythonEnv } = useSyncedTheme();
+  const { defaultPythonEnv, featureFlags } = useSyncedTheme();
+  const disableComments = featureFlags.disable_comments;
+  const commentsUiEnabled = !disableComments;
 
   // Stable peer ID for presence (generated once per window lifetime)
   const peerIdRef = useRef(crypto.randomUUID());
@@ -1040,6 +1043,14 @@ function AppContent() {
       resolveSourceQuote={resolveSourceQuote}
     />
   );
+  const commentsUiSurface = resolveCommentsUiSurface({
+    commentsUiEnabled,
+    canCreateComments: canMutateComments,
+    commentsPanel,
+    onCreateSourceComment: handleRequestSourceComment,
+    onCreateOutputComment: handleRequestOutputComment,
+    onActivateCommentThread: handleActivateCommentThread,
+  });
 
   // Connection/identity slot source: daemon lifecycle, stable for the
   // app's lifetime (the dot must transition on daemon restarts).
@@ -1325,11 +1336,17 @@ function AppContent() {
     return null;
   }, [envSource, envSyncState]);
 
-  const packagesRailOpen = !railCollapsed && activeRailPanel === "packages";
+  const renderedActiveRailPanel =
+    !commentsUiEnabled && activeRailPanel === "comments" ? "outline" : activeRailPanel;
+  const packagesRailOpen = !railCollapsed && renderedActiveRailPanel === "packages";
 
-  const handleRailPanelChange = useCallback((panelId: NotebookRailPanelId) => {
-    openNotebookRailPanel(panelId);
-  }, []);
+  const handleRailPanelChange = useCallback(
+    (panelId: NotebookRailPanelId) => {
+      if (!commentsUiEnabled && panelId === "comments") return;
+      openNotebookRailPanel(panelId);
+    },
+    [commentsUiEnabled],
+  );
 
   const handleTogglePackagesRail = useCallback(() => {
     if (!shellCapabilities.canViewPackages) {
@@ -1955,7 +1972,7 @@ function AppContent() {
           rail={
             <NotebookDocumentRail
               viewModel={notebookViewModel}
-              activePanelId={activeRailPanel}
+              activePanelId={renderedActiveRailPanel}
               collapsed={railCollapsed}
               outlineCellIds={cellIds}
               activeOutlineItemId={activeOutlineItemId}
@@ -1965,7 +1982,7 @@ function AppContent() {
               onCollapsedChange={setNotebookRailCollapsed}
               onSelectOutlineItem={handleSelectOutlineItem}
               onNavigateOutlineItem={handleNavigateOutlineItem}
-              commentsPanel={commentsPanel}
+              commentsPanel={commentsUiSurface.commentsPanel}
               packagesPanel={
                 <NotebookPackagesPanel readOnly={!shellCapabilities.canManagePackages}>
                   {runtime === "python" && hasUvDependencies && hasCondaDependencies && (
@@ -2118,9 +2135,9 @@ function AppContent() {
                 onReportOutputMatchCount={globalFind.reportOutputMatchCount}
                 onSetCellSourceHidden={setCellSourceHidden}
                 onSetCellOutputsHidden={setCellOutputsHidden}
-                onCreateSourceComment={canMutateComments ? handleRequestSourceComment : undefined}
-                onCreateOutputComment={canMutateComments ? handleRequestOutputComment : undefined}
-                onActivateCommentThread={handleActivateCommentThread}
+                onCreateSourceComment={commentsUiSurface.onCreateSourceComment}
+                onCreateOutputComment={commentsUiSurface.onCreateOutputComment}
+                onActivateCommentThread={commentsUiSurface.onActivateCommentThread}
                 commentThreadsByCell={sourceCommentThreadsByCell}
                 pendingCommentAnchor={sourceCommentRequest?.anchor ?? null}
                 markdownHeadingAnchorsByCellId={markdownHeadingAnchorsByCellId}
@@ -2129,7 +2146,7 @@ function AppContent() {
           </div>
         </NotebookDocumentShell>
       </div>
-      {sourceCommentRequest ? (
+      {commentsUiEnabled && sourceCommentRequest ? (
         <InlineCommentComposer
           rect={sourceCommentRequest.rect}
           quote={sourceCommentRequest.quote ?? sourceCommentRequest.anchor.exact_quote}

--- a/apps/notebook/src/components/__tests__/comments-ui-gate.test.tsx
+++ b/apps/notebook/src/components/__tests__/comments-ui-gate.test.tsx
@@ -1,0 +1,72 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vite-plus/test";
+import { resolveCommentsUiSurface } from "@/components/notebook/comments-ui-gate";
+import { NotebookPackagesPanel, NotebookRail } from "@/components/notebook-rail";
+
+describe("resolveCommentsUiSurface", () => {
+  it("passes the comments panel and callbacks when comments UI is enabled", () => {
+    const onCreateSourceComment = vi.fn();
+    const onCreateOutputComment = vi.fn();
+    const onActivateCommentThread = vi.fn();
+    const surface = resolveCommentsUiSurface({
+      commentsUiEnabled: true,
+      canCreateComments: true,
+      commentsPanel: "comments panel",
+      onCreateSourceComment,
+      onCreateOutputComment,
+      onActivateCommentThread,
+    });
+
+    expect(surface.commentsPanel).toBe("comments panel");
+    expect(surface.onCreateSourceComment).toBe(onCreateSourceComment);
+    expect(surface.onCreateOutputComment).toBe(onCreateOutputComment);
+    expect(surface.onActivateCommentThread).toBe(onActivateCommentThread);
+  });
+
+  it("suppresses the comments panel and every NotebookView callback when comments UI is disabled", () => {
+    const surface = resolveCommentsUiSurface({
+      commentsUiEnabled: false,
+      canCreateComments: true,
+      commentsPanel: "comments panel",
+      onCreateSourceComment: vi.fn(),
+      onCreateOutputComment: vi.fn(),
+      onActivateCommentThread: vi.fn(),
+    });
+
+    expect(surface.commentsPanel).toBeUndefined();
+    expect(surface.onCreateSourceComment).toBeUndefined();
+    expect(surface.onCreateOutputComment).toBeUndefined();
+    expect(surface.onActivateCommentThread).toBeUndefined();
+
+    render(
+      <NotebookRail
+        activePanelId="outline"
+        collapsed={false}
+        outlineItems={[]}
+        packagesPanel={<NotebookPackagesPanel>Packages</NotebookPackagesPanel>}
+        commentsPanel={surface.commentsPanel}
+        onActivePanelChange={vi.fn()}
+        onCollapsedChange={vi.fn()}
+      />,
+    );
+    expect(screen.queryByRole("button", { name: "Discussions" })).not.toBeInTheDocument();
+    expect(screen.queryByText("comments panel")).not.toBeInTheDocument();
+  });
+
+  it("keeps the panel and activation callback for read-only comments without create affordances", () => {
+    const onActivateCommentThread = vi.fn();
+    const surface = resolveCommentsUiSurface({
+      commentsUiEnabled: true,
+      canCreateComments: false,
+      commentsPanel: "comments panel",
+      onCreateSourceComment: vi.fn(),
+      onCreateOutputComment: vi.fn(),
+      onActivateCommentThread,
+    });
+
+    expect(surface.commentsPanel).toBe("comments panel");
+    expect(surface.onCreateSourceComment).toBeUndefined();
+    expect(surface.onCreateOutputComment).toBeUndefined();
+    expect(surface.onActivateCommentThread).toBe(onActivateCommentThread);
+  });
+});

--- a/crates/notebook/src/settings.rs
+++ b/crates/notebook/src/settings.rs
@@ -113,6 +113,10 @@ pub fn load_settings() -> SyncedSettings {
             .get("disable_nteract_launcher")
             .and_then(|v| v.as_bool())
             .unwrap_or(defaults.disable_nteract_launcher),
+        disable_comments: json
+            .get("disable_comments")
+            .and_then(|v| v.as_bool())
+            .unwrap_or(defaults.disable_comments),
         redact_env_values_in_outputs: json
             .get("redact_env_values_in_outputs")
             .and_then(|v| v.as_bool())
@@ -179,6 +183,7 @@ mod tests {
         assert!(settings.conda.default_packages.is_empty());
         assert!(settings.install_default_data_packages);
         assert!(!settings.disable_nteract_launcher);
+        assert!(!settings.disable_comments);
         assert!(settings.redact_env_values_in_outputs);
     }
 
@@ -201,6 +206,7 @@ mod tests {
             pixi_pool_size: 6,
             install_default_data_packages: true,
             disable_nteract_launcher: false,
+            disable_comments: true,
             ..SyncedSettings::default()
         };
 
@@ -211,6 +217,7 @@ mod tests {
         assert_eq!(parsed.default_runtime, Runtime::Deno);
         assert_eq!(parsed.default_python_env, PythonEnvType::Uv);
         assert_eq!(parsed.uv.default_packages, vec!["numpy", "pandas"]);
+        assert!(parsed.disable_comments);
     }
 
     #[test]
@@ -393,6 +400,7 @@ mod tests {
             pixi_pool_size: defaults.pixi_pool_size,
             install_default_data_packages: defaults.install_default_data_packages,
             disable_nteract_launcher: defaults.disable_nteract_launcher,
+            disable_comments: defaults.disable_comments,
             ..defaults
         };
         // Valid fields are preserved

--- a/crates/runtimed-client/src/settings_doc.rs
+++ b/crates/runtimed-client/src/settings_doc.rs
@@ -15,6 +15,7 @@
 //!   default_python_env: "uv"
 //!   install_default_data_packages: true
 //!   disable_nteract_launcher: false
+//!   disable_comments: false
 //!   uv/                           ← nested Map
 //!     default_packages: List[…]   ← List of Str
 //!   conda/                        ← nested Map
@@ -299,6 +300,10 @@ pub struct SyncedSettings {
     #[serde(default)]
     pub disable_nteract_launcher: bool,
 
+    /// Disable comments UI surfaces while keeping comments sync active.
+    #[serde(default)]
+    pub disable_comments: bool,
+
     /// Redact eligible environment variable values from text outputs for newly
     /// launched or restarted kernels.
     ///
@@ -374,6 +379,7 @@ impl Default for SyncedSettings {
             pixi_pool_size: pool_sizes.pixi_pool_size,
             install_default_data_packages: true,
             disable_nteract_launcher: false,
+            disable_comments: false,
             redact_env_values_in_outputs: true,
             import_shell_environment: true,
             install_id: String::new(),
@@ -579,6 +585,11 @@ impl SettingsDoc {
         );
         let _ = doc.put(
             automerge::ROOT,
+            "disable_comments",
+            defaults.disable_comments,
+        );
+        let _ = doc.put(
+            automerge::ROOT,
             "redact_env_values_in_outputs",
             defaults.redact_env_values_in_outputs,
         );
@@ -715,6 +726,10 @@ impl SettingsDoc {
             .and_then(|v| v.as_bool())
         {
             settings.put_bool("disable_nteract_launcher", disabled);
+        }
+        // disable_comments: boolean
+        if let Some(disabled) = json.get("disable_comments").and_then(|v| v.as_bool()) {
+            settings.put_bool("disable_comments", disabled);
         }
         if let Some(enabled) = json
             .get("redact_env_values_in_outputs")
@@ -1177,6 +1192,9 @@ impl SettingsDoc {
             disable_nteract_launcher: self
                 .get_bool("disable_nteract_launcher")
                 .unwrap_or(defaults.disable_nteract_launcher),
+            disable_comments: self
+                .get_bool("disable_comments")
+                .unwrap_or(defaults.disable_comments),
             redact_env_values_in_outputs: self
                 .get_bool("redact_env_values_in_outputs")
                 .unwrap_or(defaults.redact_env_values_in_outputs),
@@ -1384,6 +1402,18 @@ impl SettingsDoc {
                     current, disabled
                 );
                 self.put_bool("disable_nteract_launcher", disabled);
+                changed = true;
+            }
+        }
+        // disable_comments: boolean
+        if let Some(disabled) = json.get("disable_comments").and_then(|v| v.as_bool()) {
+            let current = self.get_bool("disable_comments");
+            if current != Some(disabled) {
+                info!(
+                    "[settings] apply_json_changes: disable_comments changed {:?} -> {}",
+                    current, disabled
+                );
+                self.put_bool("disable_comments", disabled);
                 changed = true;
             }
         }
@@ -1618,6 +1648,7 @@ mod tests {
         assert!(settings.pixi.default_packages.is_empty());
         assert!(settings.install_default_data_packages);
         assert!(!settings.disable_nteract_launcher);
+        assert!(!settings.disable_comments);
         assert!(settings.feature_flags().bootstrap_dx);
         assert!(settings.redact_env_values_in_outputs);
     }
@@ -1694,6 +1725,19 @@ mod tests {
         assert_eq!(doc.get_bool("disable_nteract_launcher"), Some(true));
         assert!(settings.disable_nteract_launcher);
         assert!(!settings.feature_flags().bootstrap_dx);
+    }
+
+    #[test]
+    fn test_disable_comments_can_be_enabled_from_json() {
+        let mut doc = SettingsDoc::new();
+
+        assert!(doc.apply_json_changes(&serde_json::json!({
+            "disable_comments": true
+        })));
+
+        let settings = doc.get_all();
+        assert_eq!(doc.get_bool("disable_comments"), Some(true));
+        assert!(settings.disable_comments);
     }
 
     #[test]
@@ -2087,6 +2131,7 @@ mod tests {
         assert!(schema_str.contains("default_python_env"));
         assert!(schema_str.contains("install_default_data_packages"));
         assert!(schema_str.contains("disable_nteract_launcher"));
+        assert!(schema_str.contains("disable_comments"));
         assert!(schema_str.contains("redact_env_values_in_outputs"));
         // Should have known values as examples for editor autocomplete
         assert!(schema_str.contains("python"));

--- a/crates/runtimed-settings-sync/src/lib.rs
+++ b/crates/runtimed-settings-sync/src/lib.rs
@@ -598,6 +598,7 @@ pub fn get_all_from_doc(doc: &AutoCommit) -> SyncedSettings {
             .unwrap_or(defaults.install_default_data_packages),
         disable_nteract_launcher: get_bool("disable_nteract_launcher")
             .unwrap_or(defaults.disable_nteract_launcher),
+        disable_comments: get_bool("disable_comments").unwrap_or(defaults.disable_comments),
         redact_env_values_in_outputs: get_bool("redact_env_values_in_outputs")
             .unwrap_or(defaults.redact_env_values_in_outputs),
         import_shell_environment: get_bool("import_shell_environment")
@@ -814,6 +815,15 @@ mod tests {
         let settings = get_all_from_doc(&doc);
         assert!(settings.disable_nteract_launcher);
         assert!(!settings.feature_flags().bootstrap_dx);
+    }
+
+    #[test]
+    fn test_get_all_reads_disable_comments() {
+        let mut doc = AutoCommit::new();
+        doc.put(automerge::ROOT, "disable_comments", true).unwrap();
+
+        let settings = get_all_from_doc(&doc);
+        assert!(settings.disable_comments);
     }
 
     #[test]

--- a/packages/notebook-host/src/types.ts
+++ b/packages/notebook-host/src/types.ts
@@ -365,6 +365,7 @@ export interface HostSyncedSettings {
   keep_alive_secs?: unknown;
   install_default_data_packages?: unknown;
   disable_nteract_launcher?: unknown;
+  disable_comments?: unknown;
   redact_env_values_in_outputs?: unknown;
   import_shell_environment?: unknown;
   install_id?: unknown;

--- a/src/bindings/SyncedSettings.ts
+++ b/src/bindings/SyncedSettings.ts
@@ -81,6 +81,10 @@ export type SyncedSettings = {
    */
   disable_nteract_launcher: boolean;
   /**
+   * Disable comments UI surfaces while keeping comments sync active.
+   */
+  disable_comments: boolean;
+  /**
    * Redact eligible environment variable values from text outputs for newly
    * launched or restarted kernels.
    *

--- a/src/components/notebook/comments-ui-gate.ts
+++ b/src/components/notebook/comments-ui-gate.ts
@@ -1,0 +1,38 @@
+import type { ReactNode } from "react";
+
+export interface CommentsUiSurfaceOptions<SourceHandler, OutputHandler, ActivateHandler> {
+  commentsUiEnabled: boolean;
+  canCreateComments: boolean;
+  commentsPanel: ReactNode;
+  onCreateSourceComment: SourceHandler;
+  onCreateOutputComment: OutputHandler;
+  onActivateCommentThread: ActivateHandler;
+}
+
+export interface CommentsUiSurface<SourceHandler, OutputHandler, ActivateHandler> {
+  commentsPanel: ReactNode | undefined;
+  onCreateSourceComment: SourceHandler | undefined;
+  onCreateOutputComment: OutputHandler | undefined;
+  onActivateCommentThread: ActivateHandler | undefined;
+}
+
+export function resolveCommentsUiSurface<SourceHandler, OutputHandler, ActivateHandler>({
+  commentsUiEnabled,
+  canCreateComments,
+  commentsPanel,
+  onCreateSourceComment,
+  onCreateOutputComment,
+  onActivateCommentThread,
+}: CommentsUiSurfaceOptions<SourceHandler, OutputHandler, ActivateHandler>): CommentsUiSurface<
+  SourceHandler,
+  OutputHandler,
+  ActivateHandler
+> {
+  const canShowCreateAffordances = commentsUiEnabled && canCreateComments;
+  return {
+    commentsPanel: commentsUiEnabled ? commentsPanel : undefined,
+    onCreateSourceComment: canShowCreateAffordances ? onCreateSourceComment : undefined,
+    onCreateOutputComment: canShowCreateAffordances ? onCreateOutputComment : undefined,
+    onActivateCommentThread: commentsUiEnabled ? onActivateCommentThread : undefined,
+  };
+}

--- a/src/hooks/useSyncedSettings.ts
+++ b/src/hooks/useSyncedSettings.ts
@@ -100,6 +100,10 @@ export const FEATURE_FLAG_METADATA = {
     label: "Use Legacy IPython Launcher",
     description: "Launch Python kernels with ipykernel_launcher instead of the nteract launcher.",
   },
+  disable_comments: {
+    label: "Disable Comments UI",
+    description: "Hide comment panels and creation affordances while keeping comments sync active.",
+  },
 } as const satisfies Record<string, { label: string; description: string }>;
 
 export type FeatureFlagId = keyof typeof FEATURE_FLAG_METADATA;
@@ -107,6 +111,7 @@ export type FeatureFlagValues = Record<FeatureFlagId, boolean>;
 
 const FEATURE_FLAG_DEFAULTS: FeatureFlagValues = {
   disable_nteract_launcher: false,
+  disable_comments: false,
 };
 
 export const FEATURE_FLAGS: ReadonlyArray<{
@@ -525,7 +530,8 @@ function numOrBigint(v: unknown): number | null {
  */
 export function useSyncedTheme() {
   const host = useNotebookHost();
-  const { theme, setTheme, colorTheme, setColorTheme, defaultPythonEnv } = useSyncedSettings();
+  const { theme, setTheme, colorTheme, setColorTheme, defaultPythonEnv, featureFlags } =
+    useSyncedSettings();
 
   const [resolvedTheme, setResolvedTheme] = useState<"light" | "dark">(() => resolveTheme(theme));
 
@@ -558,5 +564,13 @@ export function useSyncedTheme() {
     }
   }, [colorTheme]);
 
-  return { theme, setTheme, colorTheme, setColorTheme, resolvedTheme, defaultPythonEnv };
+  return {
+    theme,
+    setTheme,
+    colorTheme,
+    setColorTheme,
+    resolvedTheme,
+    defaultPythonEnv,
+    featureFlags,
+  };
 }


### PR DESCRIPTION
Audit CMT-UI-01. Adds a `disable_comments` feature flag so the comments UI can be turned off before it's stable, without unwiring comments sync.

## What this does

- New `disable_comments` flag in `FEATURE_FLAG_METADATA`, **default off** (comments stay enabled; this is purely additive, no behavior change).
- A shared pure helper `resolveCommentsUiSurface` gates the UI. When comments are disabled it:
  - suppresses the Discussions rail tab and panel (falling back to the outline panel if comments was the active panel), and
  - passes `undefined` for the source/output/activate comment callbacks, which cascades to remove the source gutter dot, the `Mod-Alt-m` keymap, the editor and rendered-markdown context-menu items, the output-comment button, and the inline composer.
- Desktop reads the flag from synced settings (surfaced via `useSyncedTheme`); the cloud viewer reads it from its viewer config (`config.featureFlags.disable_comments`).
- Daemon comment sync, the comments projection, pending-highlight, and highlight rendering are untouched, only the UI is gated.

## Coverage

`comments-ui-gate.test.tsx` covers: flag on (all surfaces live), flag off (panel + callbacks suppressed), read-only (callbacks suppressed regardless), and the rail fallback when comments is the active panel but the flag is off.

## Notes

Default-off means existing users see no change; flipping it hides comments everywhere in one place. The flag is a `disable_*` flag mirroring the existing `disable_nteract_launcher`.
