### PR TITLE
feat(settings): add disable_auto_format flag to opt out of ruff/deno fmt

### DIFF
--- a/apps/notebook-cloud/viewer/cloud-viewer-config.ts
+++ b/apps/notebook-cloud/viewer/cloud-viewer-config.ts
@@ -59,6 +59,7 @@ function loadConfig(): CloudViewerConfig {
     },
     featureFlags: {
       disable_comments: parsed.featureFlags?.disable_comments === true,
+      disable_auto_format: parsed.featureFlags?.disable_auto_format === true,
     },
     session: isCloudAppSession(parsed.session) ? parsed.session : null,
     syncEndpoint: parsed.syncEndpoint,

--- a/apps/notebook-cloud/viewer/cloud-viewer-session.ts
+++ b/apps/notebook-cloud/viewer/cloud-viewer-session.ts
@@ -133,6 +133,7 @@ export interface CloudViewerConfig {
   };
   featureFlags?: {
     disable_comments?: boolean;
+    disable_auto_format?: boolean;
   };
   session?: CloudAppSession | null;
   syncEndpoint: string;

--- a/crates/notebook/src/settings.rs
+++ b/crates/notebook/src/settings.rs
@@ -117,6 +117,10 @@ pub fn load_settings() -> SyncedSettings {
             .get("disable_comments")
             .and_then(|v| v.as_bool())
             .unwrap_or(defaults.disable_comments),
+        disable_auto_format: json
+            .get("disable_auto_format")
+            .and_then(|v| v.as_bool())
+            .unwrap_or(defaults.disable_auto_format),
         redact_env_values_in_outputs: json
             .get("redact_env_values_in_outputs")
             .and_then(|v| v.as_bool())
@@ -184,6 +188,7 @@ mod tests {
         assert!(settings.install_default_data_packages);
         assert!(!settings.disable_nteract_launcher);
         assert!(!settings.disable_comments);
+        assert!(!settings.disable_auto_format);
         assert!(settings.redact_env_values_in_outputs);
     }
 
@@ -207,6 +212,7 @@ mod tests {
             install_default_data_packages: true,
             disable_nteract_launcher: false,
             disable_comments: true,
+            disable_auto_format: true,
             ..SyncedSettings::default()
         };
 
@@ -218,6 +224,7 @@ mod tests {
         assert_eq!(parsed.default_python_env, PythonEnvType::Uv);
         assert_eq!(parsed.uv.default_packages, vec!["numpy", "pandas"]);
         assert!(parsed.disable_comments);
+        assert!(parsed.disable_auto_format);
     }
 
     #[test]
@@ -401,6 +408,7 @@ mod tests {
             install_default_data_packages: defaults.install_default_data_packages,
             disable_nteract_launcher: defaults.disable_nteract_launcher,
             disable_comments: defaults.disable_comments,
+            disable_auto_format: defaults.disable_auto_format,
             ..defaults
         };
         // Valid fields are preserved

--- a/crates/runtimed-client/src/settings_doc.rs
+++ b/crates/runtimed-client/src/settings_doc.rs
@@ -16,6 +16,7 @@
 //!   install_default_data_packages: true
 //!   disable_nteract_launcher: false
 //!   disable_comments: false
+//!   disable_auto_format: false
 //!   uv/                           ← nested Map
 //!     default_packages: List[…]   ← List of Str
 //!   conda/                        ← nested Map
@@ -304,6 +305,10 @@ pub struct SyncedSettings {
     #[serde(default)]
     pub disable_comments: bool,
 
+    /// Disable automatic code formatting on cell execution and notebook save.
+    #[serde(default)]
+    pub disable_auto_format: bool,
+
     /// Redact eligible environment variable values from text outputs for newly
     /// launched or restarted kernels.
     ///
@@ -380,6 +385,7 @@ impl Default for SyncedSettings {
             install_default_data_packages: true,
             disable_nteract_launcher: false,
             disable_comments: false,
+            disable_auto_format: false,
             redact_env_values_in_outputs: true,
             import_shell_environment: true,
             install_id: String::new(),
@@ -590,6 +596,11 @@ impl SettingsDoc {
         );
         let _ = doc.put(
             automerge::ROOT,
+            "disable_auto_format",
+            defaults.disable_auto_format,
+        );
+        let _ = doc.put(
+            automerge::ROOT,
             "redact_env_values_in_outputs",
             defaults.redact_env_values_in_outputs,
         );
@@ -730,6 +741,10 @@ impl SettingsDoc {
         // disable_comments: boolean
         if let Some(disabled) = json.get("disable_comments").and_then(|v| v.as_bool()) {
             settings.put_bool("disable_comments", disabled);
+        }
+        // disable_auto_format: boolean
+        if let Some(disabled) = json.get("disable_auto_format").and_then(|v| v.as_bool()) {
+            settings.put_bool("disable_auto_format", disabled);
         }
         if let Some(enabled) = json
             .get("redact_env_values_in_outputs")
@@ -1195,6 +1210,9 @@ impl SettingsDoc {
             disable_comments: self
                 .get_bool("disable_comments")
                 .unwrap_or(defaults.disable_comments),
+            disable_auto_format: self
+                .get_bool("disable_auto_format")
+                .unwrap_or(defaults.disable_auto_format),
             redact_env_values_in_outputs: self
                 .get_bool("redact_env_values_in_outputs")
                 .unwrap_or(defaults.redact_env_values_in_outputs),
@@ -1414,6 +1432,18 @@ impl SettingsDoc {
                     current, disabled
                 );
                 self.put_bool("disable_comments", disabled);
+                changed = true;
+            }
+        }
+        // disable_auto_format: boolean
+        if let Some(disabled) = json.get("disable_auto_format").and_then(|v| v.as_bool()) {
+            let current = self.get_bool("disable_auto_format");
+            if current != Some(disabled) {
+                info!(
+                    "[settings] apply_json_changes: disable_auto_format changed {:?} -> {}",
+                    current, disabled
+                );
+                self.put_bool("disable_auto_format", disabled);
                 changed = true;
             }
         }
@@ -1649,6 +1679,7 @@ mod tests {
         assert!(settings.install_default_data_packages);
         assert!(!settings.disable_nteract_launcher);
         assert!(!settings.disable_comments);
+        assert!(!settings.disable_auto_format);
         assert!(settings.feature_flags().bootstrap_dx);
         assert!(settings.redact_env_values_in_outputs);
     }
@@ -1738,6 +1769,19 @@ mod tests {
         let settings = doc.get_all();
         assert_eq!(doc.get_bool("disable_comments"), Some(true));
         assert!(settings.disable_comments);
+    }
+
+    #[test]
+    fn test_disable_auto_format_can_be_enabled_from_json() {
+        let mut doc = SettingsDoc::new();
+
+        assert!(doc.apply_json_changes(&serde_json::json!({
+            "disable_auto_format": true
+        })));
+
+        let settings = doc.get_all();
+        assert_eq!(doc.get_bool("disable_auto_format"), Some(true));
+        assert!(settings.disable_auto_format);
     }
 
     #[test]
@@ -2132,6 +2176,7 @@ mod tests {
         assert!(schema_str.contains("install_default_data_packages"));
         assert!(schema_str.contains("disable_nteract_launcher"));
         assert!(schema_str.contains("disable_comments"));
+        assert!(schema_str.contains("disable_auto_format"));
         assert!(schema_str.contains("redact_env_values_in_outputs"));
         // Should have known values as examples for editor autocomplete
         assert!(schema_str.contains("python"));

--- a/crates/runtimed-settings-sync/src/lib.rs
+++ b/crates/runtimed-settings-sync/src/lib.rs
@@ -599,6 +599,8 @@ pub fn get_all_from_doc(doc: &AutoCommit) -> SyncedSettings {
         disable_nteract_launcher: get_bool("disable_nteract_launcher")
             .unwrap_or(defaults.disable_nteract_launcher),
         disable_comments: get_bool("disable_comments").unwrap_or(defaults.disable_comments),
+        disable_auto_format: get_bool("disable_auto_format")
+            .unwrap_or(defaults.disable_auto_format),
         redact_env_values_in_outputs: get_bool("redact_env_values_in_outputs")
             .unwrap_or(defaults.redact_env_values_in_outputs),
         import_shell_environment: get_bool("import_shell_environment")
@@ -824,6 +826,16 @@ mod tests {
 
         let settings = get_all_from_doc(&doc);
         assert!(settings.disable_comments);
+    }
+
+    #[test]
+    fn test_get_all_reads_disable_auto_format() {
+        let mut doc = AutoCommit::new();
+        doc.put(automerge::ROOT, "disable_auto_format", true)
+            .unwrap();
+
+        let settings = get_all_from_doc(&doc);
+        assert!(settings.disable_auto_format);
     }
 
     #[test]

--- a/crates/runtimed/src/notebook_sync_server/peer_writer.rs
+++ b/crates/runtimed/src/notebook_sync_server/peer_writer.rs
@@ -647,6 +647,7 @@ mod tests {
                 &request_room,
                 "cell-1".to_string(),
                 None,
+                false,
                 Some("user:test/agent"),
             )
             .await

--- a/crates/runtimed/src/notebook_sync_server/tests.rs
+++ b/crates/runtimed/src/notebook_sync_server/tests.rs
@@ -1244,6 +1244,34 @@ fn test_room_with_path_and_store(
     (room, notebook_path)
 }
 
+fn test_daemon_config(tmp: &tempfile::TempDir) -> crate::daemon::DaemonConfig {
+    #[cfg(windows)]
+    let socket_path = {
+        let unique = tmp.path().file_name().unwrap_or_default().to_string_lossy();
+        std::path::PathBuf::from(format!(r"\\.\pipe\runtimed-format-test-{unique}"))
+    };
+    #[cfg(not(windows))]
+    let socket_path = tmp.path().join("runtimed-format-test.sock");
+
+    crate::daemon::DaemonConfig {
+        socket_path,
+        cache_dir: tmp.path().join("envs"),
+        blob_store_dir: tmp.path().join("daemon-blobs"),
+        execution_store_dir: tmp.path().join("executions"),
+        notebook_docs_dir: tmp.path().join("daemon-notebook-docs"),
+        trusted_packages_db_path: tmp.path().join("trusted-packages.sqlite"),
+        uv_pool_size: 0,
+        conda_pool_size: 0,
+        pixi_pool_size: 0,
+        max_age_secs: 3600,
+        lock_dir: Some(tmp.path().to_path_buf()),
+        room_eviction_delay_ms: Some(50),
+        use_preferred_blob_port: false,
+        settings_json_path: Some(tmp.path().join("settings.json")),
+        ..Default::default()
+    }
+}
+
 fn notebook_text_mime(value: Option<&serde_json::Value>) -> Option<String> {
     match value? {
         serde_json::Value::String(text) => Some(text.clone()),
@@ -2490,6 +2518,7 @@ async fn execute_cell_queues_in_runtime_doc_while_kernel_launch_is_resolving() {
         &room,
         "cell-1".to_string(),
         None,
+        false,
         Some("local:kyle/agent:codex:s1"),
     )
     .await;
@@ -3976,6 +4005,65 @@ async fn test_format_notebook_cells_skips_unknown_runtime() {
         doc.get_cells()
     };
     assert_eq!(cells[0].source, "x=1", "Source should remain unchanged");
+}
+
+#[tokio::test]
+async fn test_save_notebook_skips_format_when_disable_auto_format_enabled() {
+    let tmp = tempfile::TempDir::new().unwrap();
+    let (room, notebook_path) = test_room_with_path(&tmp, "disable-format.ipynb");
+    let room = Arc::new(room);
+    let daemon = crate::daemon::Daemon::new_for_test(test_daemon_config(&tmp)).unwrap();
+
+    assert_eq!(
+        format_source("x=1", "python").await.as_deref(),
+        Some("x = 1"),
+        "test requires the Python formatter to be available"
+    );
+
+    {
+        let mut settings = daemon.settings.write().await;
+        settings.put_bool("disable_auto_format", true);
+    }
+
+    {
+        let mut doc = room.doc.write().await;
+        let metadata = build_new_notebook_metadata(
+            "python",
+            "test-env-id",
+            crate::settings_doc::PythonEnvType::Uv,
+            None,
+            &[],
+        );
+        doc.set_metadata_snapshot(&metadata).unwrap();
+        doc.add_cell(0, "cell1", "code").unwrap();
+        doc.update_source("cell1", "x=1").unwrap();
+    }
+
+    let response = crate::requests::save_notebook::handle(&room, &daemon, true, None).await;
+    assert!(
+        matches!(
+            response,
+            crate::protocol::NotebookResponse::NotebookSaved { .. }
+        ),
+        "expected NotebookSaved, got {response:?}"
+    );
+
+    let cells = {
+        let doc = room.doc.read().await;
+        doc.get_cells()
+    };
+    assert_eq!(
+        cells[0].source, "x=1",
+        "CRDT source should remain unformatted"
+    );
+
+    let saved: serde_json::Value =
+        serde_json::from_str(&std::fs::read_to_string(&notebook_path).unwrap()).unwrap();
+    assert_eq!(
+        notebook_text_mime(saved["cells"][0].get("source")).as_deref(),
+        Some("x=1"),
+        "saved file source should remain unformatted"
+    );
 }
 
 // ========================================================================

--- a/crates/runtimed/src/requests/execute_cell.rs
+++ b/crates/runtimed/src/requests/execute_cell.rs
@@ -46,9 +46,18 @@ pub(crate) async fn handle_with_submitter(
     room: &Arc<NotebookRoom>,
     cell_id: String,
     execution_id: Option<String>,
+    disable_auto_format: bool,
     submitter_actor_label: Option<&str>,
 ) -> NotebookResponse {
-    handle_inner(room, cell_id, execution_id, None, submitter_actor_label).await
+    handle_inner(
+        room,
+        cell_id,
+        execution_id,
+        None,
+        disable_auto_format,
+        submitter_actor_label,
+    )
+    .await
 }
 
 pub(crate) async fn handle_guarded_with_submitter(
@@ -56,6 +65,7 @@ pub(crate) async fn handle_guarded_with_submitter(
     cell_id: String,
     execution_id: Option<String>,
     observed_heads: Vec<String>,
+    disable_auto_format: bool,
     submitter_actor_label: Option<&str>,
 ) -> NotebookResponse {
     if let Err(rejection) = guarded::ensure_trusted(room).await {
@@ -66,6 +76,7 @@ pub(crate) async fn handle_guarded_with_submitter(
         cell_id,
         execution_id,
         Some(observed_heads),
+        disable_auto_format,
         submitter_actor_label,
     )
     .await
@@ -76,6 +87,7 @@ async fn handle_inner(
     cell_id: String,
     requested_execution_id: Option<String>,
     observed_heads: Option<Vec<String>>,
+    disable_auto_format: bool,
     submitter_actor_label: Option<&str>,
 ) -> NotebookResponse {
     // Agent-backed kernel: write execution to RuntimeStateDoc queue. During
@@ -128,33 +140,35 @@ async fn handle_inner(
                 QueueCellResult::Response(response) => return *response,
             };
 
-            let room_clone = Arc::clone(room);
-            let cell_id_clone = cell_id.clone();
-            let source_clone = source.clone();
-            spawn_best_effort("cell-formatter", async move {
-                if let Some(runtime) = detect_room_runtime(&room_clone).await {
-                    if let Some(formatted) = format_source(&source_clone, &runtime).await {
-                        let mut doc = room_clone.doc.write().await;
-                        match doc.transact_at_heads_recovering(
-                            &format_heads,
-                            Some(&formatter_actor(&runtime)),
-                            "format-transaction",
-                            |doc| {
-                                let changed = doc.update_source(&cell_id_clone, &formatted)?;
-                                Ok(changed)
-                            },
-                        ) {
-                            Ok(true) => {
-                                let _ = room_clone.broadcasts.changed_tx.send(());
-                            }
-                            Ok(false) => {}
-                            Err(e) => {
-                                warn!("[format] transaction failed: {}", e);
+            if !disable_auto_format {
+                let room_clone = Arc::clone(room);
+                let cell_id_clone = cell_id.clone();
+                let source_clone = source.clone();
+                spawn_best_effort("cell-formatter", async move {
+                    if let Some(runtime) = detect_room_runtime(&room_clone).await {
+                        if let Some(formatted) = format_source(&source_clone, &runtime).await {
+                            let mut doc = room_clone.doc.write().await;
+                            match doc.transact_at_heads_recovering(
+                                &format_heads,
+                                Some(&formatter_actor(&runtime)),
+                                "format-transaction",
+                                |doc| {
+                                    let changed = doc.update_source(&cell_id_clone, &formatted)?;
+                                    Ok(changed)
+                                },
+                            ) {
+                                Ok(true) => {
+                                    let _ = room_clone.broadcasts.changed_tx.send(());
+                                }
+                                Ok(false) => {}
+                                Err(e) => {
+                                    warn!("[format] transaction failed: {}", e);
+                                }
                             }
                         }
                     }
-                }
-            });
+                });
+            }
 
             return NotebookResponse::CellQueued {
                 cell_id,

--- a/crates/runtimed/src/requests/mod.rs
+++ b/crates/runtimed/src/requests/mod.rs
@@ -175,8 +175,18 @@ pub(crate) async fn handle_notebook_request(
             cell_id,
             execution_id,
         } => {
-            execute_cell::handle_with_submitter(room, cell_id, execution_id, submitter_actor_label)
-                .await
+            let disable_auto_format = {
+                let settings = daemon.settings.read().await;
+                settings.get_all().disable_auto_format
+            };
+            execute_cell::handle_with_submitter(
+                room,
+                cell_id,
+                execution_id,
+                disable_auto_format,
+                submitter_actor_label,
+            )
+            .await
         }
 
         NotebookRequest::ExecuteCellGuarded {
@@ -184,11 +194,16 @@ pub(crate) async fn handle_notebook_request(
             execution_id,
             observed_heads,
         } => {
+            let disable_auto_format = {
+                let settings = daemon.settings.read().await;
+                settings.get_all().disable_auto_format
+            };
             execute_cell::handle_guarded_with_submitter(
                 room,
                 cell_id,
                 execution_id,
                 observed_heads,
+                disable_auto_format,
                 submitter_actor_label,
             )
             .await

--- a/crates/runtimed/src/requests/save_notebook.rs
+++ b/crates/runtimed/src/requests/save_notebook.rs
@@ -18,8 +18,13 @@ pub(crate) async fn handle(
     format_cells: bool,
     path: Option<String>,
 ) -> NotebookResponse {
+    let disable_auto_format = {
+        let settings = daemon.settings.read().await;
+        settings.get_all().disable_auto_format
+    };
+
     // Format cells if requested (before saving)
-    if format_cells {
+    if format_cells && !disable_auto_format {
         if let Err(e) = format_notebook_cells(room).await {
             warn!("[save] Format cells failed (continuing with save): {}", e);
         }

--- a/packages/notebook-host/src/types.ts
+++ b/packages/notebook-host/src/types.ts
@@ -366,6 +366,7 @@ export interface HostSyncedSettings {
   install_default_data_packages?: unknown;
   disable_nteract_launcher?: unknown;
   disable_comments?: unknown;
+  disable_auto_format?: unknown;
   redact_env_values_in_outputs?: unknown;
   import_shell_environment?: unknown;
   install_id?: unknown;

--- a/src/bindings/SyncedSettings.ts
+++ b/src/bindings/SyncedSettings.ts
@@ -85,6 +85,10 @@ export type SyncedSettings = {
    */
   disable_comments: boolean;
   /**
+   * Disable automatic code formatting on cell execution and notebook save.
+   */
+  disable_auto_format: boolean;
+  /**
    * Redact eligible environment variable values from text outputs for newly
    * launched or restarted kernels.
    *

--- a/src/hooks/useSyncedSettings.ts
+++ b/src/hooks/useSyncedSettings.ts
@@ -104,6 +104,11 @@ export const FEATURE_FLAG_METADATA = {
     label: "Disable Comments UI",
     description: "Hide comment panels and creation affordances while keeping comments sync active.",
   },
+  disable_auto_format: {
+    label: "Disable automatic formatting",
+    description:
+      "Stop nteract from running ruff / deno fmt automatically when you run or save a cell.",
+  },
 } as const satisfies Record<string, { label: string; description: string }>;
 
 export type FeatureFlagId = keyof typeof FEATURE_FLAG_METADATA;
@@ -112,6 +117,7 @@ export type FeatureFlagValues = Record<FeatureFlagId, boolean>;
 const FEATURE_FLAG_DEFAULTS: FeatureFlagValues = {
   disable_nteract_launcher: false,
   disable_comments: false,
+  disable_auto_format: false,
 };
 
 export const FEATURE_FLAGS: ReadonlyArray<{


### PR DESCRIPTION
Adds a `disable_auto_format` synced setting (#3795). When on, nteract stops running `ruff` (Python) and `deno fmt` (Deno) automatically. Default off, so existing behavior is unchanged.

It gates both auto-format triggers, daemon-side:

- **Format-on-run:** the post-queue `cell-formatter` task in `execute_cell` is skipped.
- **Format-on-save:** `save_notebook` skips `format_notebook_cells`.

The flag mirrors the existing `disable_comments` / `disable_nteract_launcher` settings across `SyncedSettings` (Rust + the regenerated ts-rs binding) and renders automatically in the settings feature-flag list.
