### PR TITLE
feat(notebook): switch cell type between code and Markdown from the menus

### DIFF
--- a/apps/notebook/src/App.tsx
+++ b/apps/notebook/src/App.tsx
@@ -361,6 +361,7 @@ function AppContent() {
     moveCell,
     deleteCell,
     clearOutputs,
+    setCellType,
     save,
     openNotebook,
     cloneNotebook,
@@ -1635,6 +1636,7 @@ function AppContent() {
     openNotebook,
     cloneNotebook,
     handleAddCell,
+    setCellType,
     clearOutputs,
     handleRunAllCells,
     handleRestartAndRunAll,
@@ -1645,6 +1647,7 @@ function AppContent() {
     openNotebook,
     cloneNotebook,
     handleAddCell,
+    setCellType,
     clearOutputs,
     handleRunAllCells,
     handleRestartAndRunAll,
@@ -1665,6 +1668,13 @@ function AppContent() {
       host.commands.register("notebook.insertCell", ({ type }) => {
         const h = commandHandlersRef.current;
         h.handleAddCell(type, getFocusedCellId());
+      }),
+      host.commands.register("notebook.changeCellType", ({ type }) => {
+        const focusedCellId = getFocusedCellId();
+        if (!focusedCellId) return;
+        const cell = getNotebookCellsSnapshot().find((c) => c.id === focusedCellId);
+        if (cell?.cell_type === type) return;
+        commandHandlersRef.current.setCellType(focusedCellId, type);
       }),
       host.commands.register("notebook.clearOutputs", async () => {
         const h = commandHandlersRef.current;
@@ -2132,6 +2142,7 @@ function AppContent() {
                 onUpdateCellSource={updateCellSource}
                 onAddCell={handleAddCell}
                 onMoveCell={moveCell}
+                onChangeCellType={setCellType}
                 onReportOutputMatchCount={globalFind.reportOutputMatchCount}
                 onSetCellSourceHidden={setCellSourceHidden}
                 onSetCellOutputsHidden={setCellOutputsHidden}

--- a/apps/notebook/src/components/CodeCell.tsx
+++ b/apps/notebook/src/components/CodeCell.tsx
@@ -75,6 +75,7 @@ interface CodeCellProps {
   onFocusNext?: (cursorPosition: "start" | "end") => void;
   onNavigateToCell?: (target: TracebackCellTarget) => void;
   onInsertCellAfter?: () => void;
+  onChangeCellType?: (type: "code" | "markdown") => void;
   isLastCell?: boolean;
   /** Props for dnd-kit drag handle (applied to ribbon) */
   dragHandleProps?: Record<string, unknown>;
@@ -347,6 +348,7 @@ export const CodeCell = memo(function CodeCell({
   onFocusNext,
   onNavigateToCell,
   onInsertCellAfter,
+  onChangeCellType,
   isLastCell = false,
   dragHandleProps,
   isDragging,
@@ -838,7 +840,9 @@ export const CodeCell = memo(function CodeCell({
               <>
                 <EditorContextMenu
                   cellId={cell.id}
+                  cellType="code"
                   readOnly={readOnly}
+                  onChangeCellType={onChangeCellType}
                   onCreateSourceComment={onCreateSourceComment}
                 >
                   <CodeMirrorEditor

--- a/apps/notebook/src/components/EditorContextMenu.tsx
+++ b/apps/notebook/src/components/EditorContextMenu.tsx
@@ -1,5 +1,5 @@
 import type { EditorView } from "@codemirror/view";
-import { ClipboardPaste, Copy, Scissors } from "lucide-react";
+import { ClipboardPaste, Code2, Copy, FileText, Scissors } from "lucide-react";
 import { useCallback, useState, type ReactNode } from "react";
 import { CommentMarkIcon } from "@/components/comments/CommentMarkIcon";
 import {
@@ -23,7 +23,9 @@ interface EditorSelectionRange {
 
 interface EditorContextMenuProps {
   cellId: string;
+  cellType: "code" | "markdown" | "raw";
   readOnly?: boolean;
+  onChangeCellType?: (type: "code" | "markdown") => void;
   onCreateSourceComment?: (
     anchor: SourceRangeCommentAnchor,
     rect: SourceCommentSelectionRect | null,
@@ -40,6 +42,8 @@ export interface BuildEditorContextGroupsOptions {
   onCut?: () => void;
   onPaste?: () => void;
   onAddComment?: () => void;
+  cellType?: "code" | "markdown" | "raw";
+  onChangeCellType?: (type: "code" | "markdown") => void;
 }
 
 export function buildEditorContextGroups({
@@ -50,6 +54,8 @@ export function buildEditorContextGroups({
   onCut,
   onPaste,
   onAddComment,
+  cellType,
+  onChangeCellType,
 }: BuildEditorContextGroupsOptions): NotebookContextMenuGroup[] {
   const actions: NotebookContextMenuAction[] = [];
 
@@ -94,6 +100,26 @@ export function buildEditorContextGroups({
     });
   }
 
+  if (onChangeCellType && (cellType === "markdown" || cellType === "raw")) {
+    actions.push({
+      id: "change-to-code",
+      label: "Change to Code",
+      icon: <Code2 className="size-4" aria-hidden="true" />,
+      separatorBefore: actions.length > 0,
+      onSelect: () => onChangeCellType("code"),
+    });
+  }
+
+  if (onChangeCellType && (cellType === "code" || cellType === "raw")) {
+    actions.push({
+      id: "change-to-markdown",
+      label: "Change to Markdown",
+      icon: <FileText className="size-4" aria-hidden="true" />,
+      separatorBefore: actions.length > 0,
+      onSelect: () => onChangeCellType("markdown"),
+    });
+  }
+
   if (actions.length === 0) return [];
 
   return [
@@ -106,7 +132,9 @@ export function buildEditorContextGroups({
 
 export function EditorContextMenu({
   cellId,
+  cellType,
   readOnly,
+  onChangeCellType,
   onCreateSourceComment,
   children,
 }: EditorContextMenuProps) {
@@ -126,6 +154,8 @@ export function EditorContextMenu({
         onCopy: view && selection ? () => copySelection(view, selection) : undefined,
         onCut: editable && view && selection ? () => cutSelection(view, selection) : undefined,
         onPaste: editable && view ? () => pasteIntoSelection(view) : undefined,
+        cellType: onChangeCellType ? cellType : undefined,
+        onChangeCellType,
         onAddComment:
           editable && view && onCreateSourceComment
             ? () => {
@@ -136,7 +166,7 @@ export function EditorContextMenu({
             : undefined,
       }),
     );
-  }, [cellId, onCreateSourceComment, readOnly]);
+  }, [cellId, cellType, onChangeCellType, onCreateSourceComment, readOnly]);
 
   const handleOpenChange = useCallback(
     (open: boolean) => {

--- a/apps/notebook/src/components/MarkdownCell.tsx
+++ b/apps/notebook/src/components/MarkdownCell.tsx
@@ -147,6 +147,7 @@ interface MarkdownCellProps {
   onFocusPrevious?: (cursorPosition: "start" | "end") => void;
   onFocusNext?: (cursorPosition: "start" | "end") => void;
   onInsertCellAfter?: () => void;
+  onChangeCellType?: (type: "code" | "markdown") => void;
   onUpdateSource?: (source: string) => void;
   isLastCell?: boolean;
   /** Props for dnd-kit drag handle (applied to ribbon) */
@@ -175,6 +176,7 @@ export const MarkdownCell = memo(function MarkdownCell({
   onFocusPrevious,
   onFocusNext,
   onInsertCellAfter,
+  onChangeCellType,
   onUpdateSource,
   isLastCell = false,
   dragHandleProps,
@@ -1058,7 +1060,9 @@ export const MarkdownCell = memo(function MarkdownCell({
             <div>
               <EditorContextMenu
                 cellId={cell.id}
+                cellType="markdown"
                 readOnly={readOnly}
+                onChangeCellType={onChangeCellType}
                 onCreateSourceComment={onCreateSourceComment}
               >
                 <CodeMirrorEditor
@@ -1084,6 +1088,7 @@ export const MarkdownCell = memo(function MarkdownCell({
             source={previewSource}
             markdownProjection={markdownProjection}
             viewRef={viewRef}
+            onChangeCellType={onChangeCellType}
             onCreateSourceComment={canCommentOnRenderedMarkdown ? onCreateSourceComment : undefined}
           >
             {/* View section - hidden when editing */}

--- a/apps/notebook/src/components/NotebookView.tsx
+++ b/apps/notebook/src/components/NotebookView.tsx
@@ -69,6 +69,7 @@ import type {
 
 type AddCellResult = NotebookCell | null;
 type AddCellHandler = (type: CellInsertionType, afterCellId?: string | null) => AddCellResult;
+type ChangeCellTypeHandler = (cellId: string, type: "code" | "markdown") => void;
 
 export interface NotebookViewProps {
   cellIds: string[];
@@ -87,6 +88,7 @@ export interface NotebookViewProps {
   onUpdateCellSource?: (cellId: string, source: string) => void;
   onAddCell: AddCellHandler;
   onMoveCell: (cellId: string, afterCellId?: string | null) => void;
+  onChangeCellType?: ChangeCellTypeHandler;
   onReportOutputMatchCount?: (cellId: string, count: number) => void;
   onSetCellSourceHidden?: (cellId: string, hidden: boolean) => void;
   onSetCellOutputsHidden?: (cellId: string, hidden: boolean) => void;
@@ -372,6 +374,7 @@ function NotebookViewContent({
   onUpdateCellSource,
   onAddCell,
   onMoveCell,
+  onChangeCellType,
   onReportOutputMatchCount,
   onSetCellSourceHidden,
   onSetCellOutputsHidden,
@@ -944,6 +947,11 @@ function NotebookViewContent({
             onFocusNext={onFocusNext}
             onNavigateToCell={onNavigateToCell}
             onInsertCellAfter={canMutateCells ? () => onAddCell("code", cell.id) : undefined}
+            onChangeCellType={
+              canMutateCells && onChangeCellType
+                ? (type: "code" | "markdown") => onChangeCellType(cell.id, type)
+                : undefined
+            }
             isLastCell={index === cellIdsRef.current.length - 1}
             dragHandleProps={dragHandleProps}
             isDragging={isDragging}
@@ -1020,6 +1028,11 @@ function NotebookViewContent({
             onFocusPrevious={onFocusPrevious}
             onFocusNext={onFocusNext}
             onInsertCellAfter={canMutateCells ? () => onAddCell("markdown", cell.id) : undefined}
+            onChangeCellType={
+              canMutateCells && onChangeCellType
+                ? (type: "code" | "markdown") => onChangeCellType(cell.id, type)
+                : undefined
+            }
             isLastCell={index === cellIdsRef.current.length - 1}
             dragHandleProps={dragHandleProps}
             isDragging={isDragging}
@@ -1049,6 +1062,11 @@ function NotebookViewContent({
           onFocusPrevious={onFocusPrevious}
           onFocusNext={onFocusNext}
           onInsertCellAfter={canMutateCells ? () => onAddCell("code", cell.id) : undefined}
+          onChangeCellType={
+            canMutateCells && onChangeCellType
+              ? (type: "code" | "markdown") => onChangeCellType(cell.id, type)
+              : undefined
+          }
           isLastCell={index === cellIdsRef.current.length - 1}
           dragHandleProps={dragHandleProps}
           isDragging={isDragging}
@@ -1068,6 +1086,7 @@ function NotebookViewContent({
       onDeleteCell,
       onUpdateCellSource,
       onAddCell,
+      onChangeCellType,
       onReportOutputMatchCount,
       onSetCellSourceHidden,
       onSetCellOutputsHidden,

--- a/apps/notebook/src/components/RawCell.tsx
+++ b/apps/notebook/src/components/RawCell.tsx
@@ -36,6 +36,7 @@ interface RawCellProps {
   onFocusPrevious?: (cursorPosition: "start" | "end") => void;
   onFocusNext?: (cursorPosition: "start" | "end") => void;
   onInsertCellAfter?: () => void;
+  onChangeCellType?: (type: "code" | "markdown") => void;
   isLastCell?: boolean;
   /** Props for dnd-kit drag handle (applied to ribbon) */
   dragHandleProps?: Record<string, unknown>;
@@ -59,6 +60,7 @@ export const RawCell = memo(function RawCell({
   onFocusPrevious,
   onFocusNext,
   onInsertCellAfter,
+  onChangeCellType,
   isLastCell = false,
   dragHandleProps,
   isDragging,
@@ -251,7 +253,9 @@ export const RawCell = memo(function RawCell({
           <div>
             <EditorContextMenu
               cellId={cell.id}
+              cellType="raw"
               readOnly={readOnly}
+              onChangeCellType={onChangeCellType}
               onCreateSourceComment={onCreateSourceComment}
             >
               <CodeMirrorEditor

--- a/apps/notebook/src/components/RenderedMarkdownContextMenu.tsx
+++ b/apps/notebook/src/components/RenderedMarkdownContextMenu.tsx
@@ -1,4 +1,4 @@
-import { Copy } from "lucide-react";
+import { Code2, Copy } from "lucide-react";
 import { useCallback, useState, type ReactNode, type RefObject } from "react";
 import { CommentMarkIcon } from "@/components/comments/CommentMarkIcon";
 import {
@@ -28,6 +28,7 @@ interface RenderedMarkdownContextMenuProps {
     rect: SourceCommentSelectionRect | null,
     quote?: string | null,
   ) => void;
+  onChangeCellType?: (type: "code" | "markdown") => void;
   children: ReactNode;
 }
 
@@ -36,6 +37,7 @@ export interface BuildRenderedMarkdownContextGroupsOptions {
   canComment: boolean;
   onCopy?: () => void;
   onAddComment?: () => void;
+  onChangeCellType?: (type: "code" | "markdown") => void;
 }
 
 export interface RenderedMarkdownClipboardPayload {
@@ -48,6 +50,7 @@ export function buildRenderedMarkdownContextGroups({
   canComment,
   onCopy,
   onAddComment,
+  onChangeCellType,
 }: BuildRenderedMarkdownContextGroupsOptions): NotebookContextMenuGroup[] {
   const actions: NotebookContextMenuAction[] = [];
 
@@ -72,6 +75,16 @@ export function buildRenderedMarkdownContextGroups({
     });
   }
 
+  if (onChangeCellType) {
+    actions.push({
+      id: "change-to-code",
+      label: "Change to Code",
+      icon: <Code2 className="size-4" aria-hidden="true" />,
+      separatorBefore: actions.length > 0,
+      onSelect: () => onChangeCellType("code"),
+    });
+  }
+
   if (actions.length === 0) return [];
 
   return [
@@ -88,6 +101,7 @@ export function RenderedMarkdownContextMenu({
   markdownProjection,
   viewRef,
   onCreateSourceComment,
+  onChangeCellType,
   children,
 }: RenderedMarkdownContextMenuProps) {
   const [groups, setGroups] = useState<NotebookContextMenuGroup[]>([]);
@@ -112,6 +126,7 @@ export function RenderedMarkdownContextMenu({
         hasSelection,
         canComment: !!anchor && !!onCreateSourceComment,
         onCopy: clipboardPayload ? () => copyRenderedSelection(clipboardPayload) : undefined,
+        onChangeCellType,
         onAddComment:
           anchor && onCreateSourceComment
             ? () => {
@@ -128,7 +143,7 @@ export function RenderedMarkdownContextMenu({
             : undefined,
       }),
     );
-  }, [cellId, markdownProjection, onCreateSourceComment, source, viewRef]);
+  }, [cellId, markdownProjection, onChangeCellType, onCreateSourceComment, source, viewRef]);
 
   const handleOpenChange = useCallback(
     (open: boolean) => {

--- a/apps/notebook/src/components/__tests__/EditorContextMenu.test.tsx
+++ b/apps/notebook/src/components/__tests__/EditorContextMenu.test.tsx
@@ -61,4 +61,47 @@ describe("buildEditorContextGroups", () => {
       }),
     ).toEqual([]);
   });
+
+  it("shows change to Markdown for code cells", () => {
+    const actions = buildActions({
+      editable: true,
+      cellType: "code",
+      onChangeCellType: vi.fn(),
+    });
+
+    expect(actions.map((action) => action.id)).toEqual(["paste", "change-to-markdown"]);
+    expect(actions.find((action) => action.id === "change-to-markdown")?.label).toBe(
+      "Change to Markdown",
+    );
+  });
+
+  it("shows change to Code for markdown cells", () => {
+    const actions = buildActions({
+      editable: true,
+      cellType: "markdown",
+      onChangeCellType: vi.fn(),
+    });
+
+    expect(actions.map((action) => action.id)).toEqual(["paste", "change-to-code"]);
+    expect(actions.find((action) => action.id === "change-to-code")?.label).toBe("Change to Code");
+  });
+
+  it("shows both code and Markdown targets for raw cells", () => {
+    const actions = buildActions({
+      editable: true,
+      cellType: "raw",
+      onChangeCellType: vi.fn(),
+    });
+
+    expect(actions.map((action) => action.id)).toEqual([
+      "paste",
+      "change-to-code",
+      "change-to-markdown",
+    ]);
+    expect(actions.map((action) => action.label)).toEqual([
+      "Paste",
+      "Change to Code",
+      "Change to Markdown",
+    ]);
+  });
 });

--- a/apps/notebook/src/components/__tests__/RenderedMarkdownContextMenu.test.tsx
+++ b/apps/notebook/src/components/__tests__/RenderedMarkdownContextMenu.test.tsx
@@ -48,6 +48,17 @@ describe("buildRenderedMarkdownContextGroups", () => {
       }),
     ).toEqual([]);
   });
+
+  it("shows change to Code when a change-type handler is available", () => {
+    const actions = buildActions({
+      hasSelection: false,
+      canComment: false,
+      onChangeCellType: vi.fn(),
+    });
+
+    expect(actions.map((action) => action.id)).toEqual(["change-to-code"]);
+    expect(actions[0]?.label).toBe("Change to Code");
+  });
 });
 
 describe("rendered markdown clipboard payload", () => {

--- a/apps/notebook/src/hooks/useAutomergeNotebook.ts
+++ b/apps/notebook/src/hooks/useAutomergeNotebook.ts
@@ -502,6 +502,13 @@ export function useNotebook() {
     [notebookController],
   );
 
+  const setCellType = useCallback(
+    (cellId: string, cellType: "code" | "markdown" | "raw") => {
+      notebookController.setCellType(cellId, cellType);
+    },
+    [notebookController],
+  );
+
   const setCellSourceHidden = useCallback(
     (cellId: string, hidden: boolean) => {
       notebookController.setCellSourceHidden(cellId, hidden);
@@ -596,6 +603,7 @@ export function useNotebook() {
     moveCell,
     deleteCell,
     clearOutputs,
+    setCellType,
     save,
     openNotebook,
     cloneNotebook,

--- a/apps/notebook/src/lib/__tests__/notebook-controller.test.ts
+++ b/apps/notebook/src/lib/__tests__/notebook-controller.test.ts
@@ -16,20 +16,24 @@ function codeCell(id: string, source = ""): NotebookCell {
 
 function createHandle(): NotebookControllerHandle & {
   sources: Map<string, string>;
+  cellTypes: Map<string, "code" | "markdown" | "raw">;
   cells: string[];
 } {
   const sources = new Map<string, string>([["cell-a", "old"]]);
+  const cellTypes = new Map<string, "code" | "markdown" | "raw">([["cell-a", "code"]]);
   const cells = ["cell-a"];
   return {
     sources,
+    cellTypes,
     cells,
     update_source(cellId, source) {
       if (!sources.has(cellId)) return false;
       sources.set(cellId, source);
       return true;
     },
-    add_cell_after(cellId) {
+    add_cell_after(cellId, cellType) {
       cells.push(cellId);
+      cellTypes.set(cellId, cellType);
     },
     move_cell(cellId, afterCellId) {
       const previousIndex = cells.indexOf(cellId);
@@ -44,9 +48,15 @@ function createHandle(): NotebookControllerHandle & {
       const index = cells.indexOf(cellId);
       if (index < 0) return false;
       cells.splice(index, 1);
+      cellTypes.delete(cellId);
       return true;
     },
     clear_outputs() {
+      return true;
+    },
+    set_cell_type(cellId, cellType) {
+      if (!cellTypes.has(cellId)) return false;
+      cellTypes.set(cellId, cellType);
       return true;
     },
     set_cell_source_hidden() {
@@ -216,6 +226,35 @@ describe("createNotebookController", () => {
     expect(applyMutationEvent).not.toHaveBeenCalled();
     expect(afterMutation).toHaveBeenCalledWith(handle, "structure");
     expect(engine.flush).toHaveBeenCalledTimes(1);
+  });
+
+  it("switches cell type through the changeset wrapper as a structural mutation", () => {
+    const handle = createHandle();
+    const engine = { flush: vi.fn(), scheduleFlush: vi.fn() };
+    const afterMutation = vi.fn();
+    const applyMutationEvent = vi.fn(() => true);
+    const event = { type: "sync_applied", changed: true };
+    handle.set_cell_type_with_changeset = vi.fn((cellId, cellType) => {
+      handle.set_cell_type(cellId, cellType);
+      return { result: true, event };
+    });
+    const controller = createNotebookController({
+      getHandle: () => handle,
+      getEngine: () => engine,
+      canWriteCellSource: () => true,
+      canEditStructure: () => true,
+      applyMutationEvent,
+      afterMutation,
+    });
+
+    controller.setCellType("cell-a", "markdown");
+
+    expect(handle.set_cell_type_with_changeset).toHaveBeenCalledWith("cell-a", "markdown");
+    expect(handle.cellTypes.get("cell-a")).toBe("markdown");
+    expect(applyMutationEvent).toHaveBeenCalledWith(event);
+    expect(afterMutation).not.toHaveBeenCalled();
+    expect(engine.flush).toHaveBeenCalledTimes(1);
+    expect(engine.scheduleFlush).not.toHaveBeenCalled();
   });
 
   it("keeps structural mutations closed when the host has not accepted the cells map", () => {

--- a/crates/notebook-doc/src/lib.rs
+++ b/crates/notebook-doc/src/lib.rs
@@ -6053,6 +6053,28 @@ mod tests {
     }
 
     #[test]
+    fn test_set_cell_type_preserves_cell_identity_source_and_position() {
+        let mut doc = NotebookDoc::new("nb-set-cell-type");
+
+        doc.add_cell_after("cell-a", "code", None).unwrap();
+        doc.add_cell_after("cell-b", "markdown", Some("cell-a"))
+            .unwrap();
+        doc.update_source("cell-a", "print('hello')").unwrap();
+        let position_before = doc.get_cell_position("cell-a");
+
+        assert!(doc.set_cell_type("cell-a", "markdown").unwrap());
+
+        assert_eq!(doc.get_cell_type("cell-a"), Some("markdown".to_string()));
+        assert_eq!(
+            doc.get_cell_source("cell-a"),
+            Some("print('hello')".to_string())
+        );
+        assert_eq!(doc.get_cell_position("cell-a"), position_before);
+        assert_eq!(doc.get_cell_ids(), vec!["cell-a", "cell-b"]);
+        assert!(!doc.set_cell_type("missing", "code").unwrap());
+    }
+
+    #[test]
     fn test_metadata_fingerprint_stable_when_unchanged() {
         let mut doc = NotebookDoc::new("nb-fp-stable");
 

--- a/crates/notebook/src/lib.rs
+++ b/crates/notebook/src/lib.rs
@@ -4581,6 +4581,26 @@ pub fn run(
                             emit_to_label::<_, _, _>(&window, window.label(), "menu:insert-cell", "raw");
                     }
                 }
+                crate::menu::MENU_CHANGE_CELL_TO_CODE => {
+                    if let Some(window) = focused_window(app) {
+                        let _ = emit_to_label::<_, _, _>(
+                            &window,
+                            window.label(),
+                            "menu:change-cell-type",
+                            "code",
+                        );
+                    }
+                }
+                crate::menu::MENU_CHANGE_CELL_TO_MARKDOWN => {
+                    if let Some(window) = focused_window(app) {
+                        let _ = emit_to_label::<_, _, _>(
+                            &window,
+                            window.label(),
+                            "menu:change-cell-type",
+                            "markdown",
+                        );
+                    }
+                }
                 crate::menu::MENU_CLEAR_OUTPUTS => {
                     if let Some(window) = focused_window(app) {
                         let _ =

--- a/crates/notebook/src/menu.rs
+++ b/crates/notebook/src/menu.rs
@@ -37,6 +37,8 @@ pub const MENU_RESTART_AND_RUN_ALL: &str = "restart_and_run_all";
 pub const MENU_INSERT_CODE_CELL: &str = "insert_code_cell";
 pub const MENU_INSERT_MARKDOWN_CELL: &str = "insert_markdown_cell";
 pub const MENU_INSERT_RAW_CELL: &str = "insert_raw_cell";
+pub const MENU_CHANGE_CELL_TO_CODE: &str = "change_cell_to_code";
+pub const MENU_CHANGE_CELL_TO_MARKDOWN: &str = "change_cell_to_markdown";
 pub const MENU_CLEAR_OUTPUTS: &str = "clear_outputs";
 pub const MENU_CLEAR_ALL_OUTPUTS: &str = "clear_all_outputs";
 
@@ -287,6 +289,21 @@ pub fn create_menu(
         "Insert Raw Cell",
         true,
         Some("CmdOrCtrl+Shift+R"),
+    )?)?;
+    cell_menu.append(&PredefinedMenuItem::separator(app)?)?;
+    cell_menu.append(&MenuItem::with_id(
+        app,
+        MENU_CHANGE_CELL_TO_CODE,
+        "Change Cell to Code",
+        true,
+        None::<&str>,
+    )?)?;
+    cell_menu.append(&MenuItem::with_id(
+        app,
+        MENU_CHANGE_CELL_TO_MARKDOWN,
+        "Change Cell to Markdown",
+        true,
+        None::<&str>,
     )?)?;
     cell_menu.append(&PredefinedMenuItem::separator(app)?)?;
     cell_menu.append(&MenuItem::with_id(

--- a/crates/runtimed-wasm/src/lib.rs
+++ b/crates/runtimed-wasm/src/lib.rs
@@ -3143,6 +3143,14 @@ impl NotebookHandle {
         })
     }
 
+    fn set_cell_type_with_changeset_inner(
+        &mut self,
+        cell_id: &str,
+        cell_type: &str,
+    ) -> Result<LocalMutationResult<bool>, JsError> {
+        self.run_local_mutation("set_cell_type", |doc| doc.set_cell_type(cell_id, cell_type))
+    }
+
     fn set_cell_outputs_hidden_with_changeset_inner(
         &mut self,
         cell_id: &str,
@@ -3254,6 +3262,16 @@ impl NotebookHandle {
         hidden: bool,
     ) -> Result<JsValue, JsError> {
         let result = self.set_cell_source_hidden_with_changeset_inner(cell_id, hidden)?;
+        serialize_to_js(&result)
+            .map_err(|e| JsError::new(&format!("serialize local mutation result: {e}")))
+    }
+
+    pub fn set_cell_type_with_changeset(
+        &mut self,
+        cell_id: &str,
+        cell_type: &str,
+    ) -> Result<JsValue, JsError> {
+        let result = self.set_cell_type_with_changeset_inner(cell_id, cell_type)?;
         serialize_to_js(&result)
             .map_err(|e| JsError::new(&format!("serialize local mutation result: {e}")))
     }
@@ -3450,6 +3468,15 @@ impl NotebookHandle {
         self.doc
             .set_cell_source_hidden(cell_id, hidden)
             .map_err(|e| JsError::new(&format!("set_cell_source_hidden failed: {}", e)))
+    }
+
+    /// Set the cell type for an existing cell. Valid values: "code", "markdown", or "raw".
+    ///
+    /// Returns true if the cell was found and updated.
+    pub fn set_cell_type(&mut self, cell_id: &str, cell_type: &str) -> Result<bool, JsError> {
+        self.doc
+            .set_cell_type(cell_id, cell_type)
+            .map_err(|e| JsError::new(&format!("set_cell_type failed: {}", e)))
     }
 
     /// Set whether the cell outputs should be hidden (JupyterLab convention).

--- a/packages/notebook-host/src/commands.ts
+++ b/packages/notebook-host/src/commands.ts
@@ -30,6 +30,7 @@ export interface CommandPayloads {
   "notebook.open": void;
   "notebook.clone": void;
   "notebook.insertCell": { type: "code" | "markdown" | "raw" };
+  "notebook.changeCellType": { type: "code" | "markdown" };
   "notebook.clearOutputs": void;
   "notebook.clearAllOutputs": void;
   "notebook.runAll": void;

--- a/packages/notebook-host/src/tauri/menu-bridge.ts
+++ b/packages/notebook-host/src/tauri/menu-bridge.ts
@@ -86,6 +86,14 @@ export function wireTauriMenuBridge(host: NotebookHost): () => void {
         return null; // unknown cell type — drop the event
       },
     }),
+    bind({
+      menuEvent: "menu:change-cell-type",
+      commandId: "notebook.changeCellType",
+      parse: (ev) => {
+        if (ev === "code" || ev === "markdown") return { type: ev };
+        return null; // unknown cell type — drop the event
+      },
+    }),
     bind({ menuEvent: "menu:clear-outputs", commandId: "notebook.clearOutputs" }),
     bind({ menuEvent: "menu:clear-all-outputs", commandId: "notebook.clearAllOutputs" }),
     bind({ menuEvent: "menu:run-all", commandId: "notebook.runAll" }),

--- a/packages/notebook-host/tests/commands.test.ts
+++ b/packages/notebook-host/tests/commands.test.ts
@@ -6,15 +6,19 @@ describe("createCommandRegistry()", () => {
     const registry = createCommandRegistry();
     const saved = vi.fn();
     const inserted = vi.fn();
+    const changedType = vi.fn();
     registry.register("notebook.save", saved);
     registry.register("notebook.insertCell", inserted);
+    registry.register("notebook.changeCellType", changedType);
 
     await registry.run("notebook.save", undefined);
     await registry.run("notebook.insertCell", { type: "markdown" });
+    await registry.run("notebook.changeCellType", { type: "code" });
 
     expect(saved).toHaveBeenCalledTimes(1);
     expect(saved).toHaveBeenCalledWith(undefined);
     expect(inserted).toHaveBeenCalledWith({ type: "markdown" });
+    expect(changedType).toHaveBeenCalledWith({ type: "code" });
   });
 
   it("awaits async handlers", async () => {

--- a/packages/notebook-host/tests/tauri-host.test.ts
+++ b/packages/notebook-host/tests/tauri-host.test.ts
@@ -476,6 +476,7 @@ describe("createTauriHost()", () => {
         "menu:open",
         "menu:clone",
         "menu:insert-cell",
+        "menu:change-cell-type",
         "menu:clear-outputs",
         "menu:clear-all-outputs",
         "menu:run-all",
@@ -726,6 +727,28 @@ describe("createTauriHost()", () => {
     entry?.cb({ payload: "gibberish" });
     await Promise.resolve();
     expect(handler).toHaveBeenCalledTimes(3); // still 3 — the 4th was skipped
+    expect(warnSpy).toHaveBeenCalled();
+    warnSpy.mockRestore();
+  });
+
+  it("menu bridge accepts code/markdown payloads on menu:change-cell-type and drops the rest", async () => {
+    const host = createTauriHost({ transport: stubTransport });
+    const handler = vi.fn();
+    host.commands.register("notebook.changeCellType", handler);
+    const entry = capturedListens.find((x) => x.event === "menu:change-cell-type");
+    await Promise.resolve();
+
+    entry?.cb({ payload: "markdown" });
+    entry?.cb({ payload: "code" });
+    await Promise.resolve();
+    expect(handler).toHaveBeenCalledTimes(2);
+    expect(handler).toHaveBeenNthCalledWith(1, { type: "markdown" });
+    expect(handler).toHaveBeenNthCalledWith(2, { type: "code" });
+
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+    entry?.cb({ payload: "raw" });
+    await Promise.resolve();
+    expect(handler).toHaveBeenCalledTimes(2);
     expect(warnSpy).toHaveBeenCalled();
     warnSpy.mockRestore();
   });

--- a/packages/runtimed/src/handle.ts
+++ b/packages/runtimed/src/handle.ts
@@ -394,6 +394,11 @@ export interface SyncableHandle {
 
   clear_outputs_with_changeset?(cell_id: string): LocalMutationResult<boolean>;
 
+  set_cell_type_with_changeset?(
+    cell_id: string,
+    cell_type: "code" | "markdown" | "raw",
+  ): LocalMutationResult<boolean>;
+
   set_cell_source_hidden_with_changeset?(
     cell_id: string,
     hidden: boolean,

--- a/src/components/notebook/state/notebook-controller.ts
+++ b/src/components/notebook/state/notebook-controller.ts
@@ -35,6 +35,11 @@ export interface NotebookControllerHandle {
   delete_cell_with_changeset?(cellId: string): LocalMutationResult<boolean>;
   clear_outputs(cellId: string): boolean;
   clear_outputs_with_changeset?(cellId: string): LocalMutationResult<boolean>;
+  set_cell_type(cellId: string, cellType: NotebookControllerCellType): boolean;
+  set_cell_type_with_changeset?(
+    cellId: string,
+    cellType: NotebookControllerCellType,
+  ): LocalMutationResult<boolean>;
   set_cell_source_hidden(cellId: string, hidden: boolean): boolean;
   set_cell_source_hidden_with_changeset?(
     cellId: string,
@@ -75,6 +80,7 @@ export interface NotebookController {
   moveCell: (cellId: string, afterCellId?: string | null) => void;
   deleteCell: (cellId: string) => void;
   clearOutputs: (cellIds: string | string[]) => boolean;
+  setCellType: (cellId: string, cellType: NotebookControllerCellType) => void;
   setCellSourceHidden: (cellId: string, hidden: boolean) => void;
   setCellOutputsHidden: (cellId: string, hidden: boolean) => void;
 }
@@ -260,6 +266,18 @@ export function createNotebookController<THandle extends NotebookControllerHandl
           if (cellChanged) eventApplied = false;
         }
         return { changed, eventApplied: changed && eventApplied };
+      });
+    },
+
+    setCellType(cellId, cellType) {
+      commit("structure", canEditStructure, (handle) => {
+        if (handle.set_cell_type_with_changeset && applyMutationEvent) {
+          return localMutationOutcome(
+            handle.set_cell_type_with_changeset(cellId, cellType),
+            Boolean,
+          );
+        }
+        return { changed: !!handle.set_cell_type(cellId, cellType), eventApplied: false };
       });
     },
 


### PR DESCRIPTION
Lets you switch a cell between code and Markdown (#3801) from the cell context menu and the main menu (Cell → Change Cell to Code / Markdown). The common write-a-notebook loop, Code ↔ Markdown, without deleting and recreating cells.

`set_cell_type` already existed in the document layer, so this is wiring: a WASM handle export (plus an optimistic changeset variant), a `setCellType` controller method on the structure path, a context-menu item gated by the current type, and the main-menu chain (menu → event → bridge → command → handler).

The switch edits the cell in place, so its id, source, position, and anchored comments survive, and `renderCell` swaps the editor for that one cell id without reordering the list. The context-menu item only offers the other type ("Change to Markdown" on code/raw, "Change to Code" on markdown/raw), and the main-menu handler no-ops when the focused cell is already that type.
