### PR TITLE
feat(comments): gate comments UI behind opt-in enable_comments (default off)

### DIFF
--- a/apps/notebook-cloud/viewer/cloud-viewer-config.ts
+++ b/apps/notebook-cloud/viewer/cloud-viewer-config.ts
@@ -58,7 +58,7 @@ function loadConfig(): CloudViewerConfig {
       canSubmitExecutionRequests: Boolean(parsed.hostCapabilities?.canSubmitExecutionRequests),
     },
     featureFlags: {
-      disable_comments: parsed.featureFlags?.disable_comments === true,
+      enable_comments: parsed.featureFlags?.enable_comments === true,
       disable_auto_format: parsed.featureFlags?.disable_auto_format === true,
     },
     session: isCloudAppSession(parsed.session) ? parsed.session : null,

--- a/apps/notebook-cloud/viewer/cloud-viewer-session.ts
+++ b/apps/notebook-cloud/viewer/cloud-viewer-session.ts
@@ -132,7 +132,7 @@ export interface CloudViewerConfig {
     canSubmitExecutionRequests?: boolean;
   };
   featureFlags?: {
-    disable_comments?: boolean;
+    enable_comments?: boolean;
     disable_auto_format?: boolean;
   };
   session?: CloudAppSession | null;

--- a/apps/notebook-cloud/viewer/notebook-viewer.tsx
+++ b/apps/notebook-cloud/viewer/notebook-viewer.tsx
@@ -258,8 +258,7 @@ export function NotebookViewer({
   );
   const loadingPolicy = useMemo(() => cloudViewerLoadingPolicy(config), [config.headsHash]);
   const { resolvedTheme } = useTheme(CLOUD_VIEWER_THEME_STORAGE_KEY);
-  const disableComments = config.featureFlags?.disable_comments === true;
-  const commentsUiEnabled = !disableComments;
+  const commentsUiEnabled = config.featureFlags?.enable_comments === true;
   const { store: widgetStore } = useWidgetStoreRequired();
   const appSessionStatus = useCloudAppSessionStatus(config.session ?? null);
   const hasAppSession = Boolean(appSessionStatus.session);

--- a/apps/notebook/src/App.tsx
+++ b/apps/notebook/src/App.tsx
@@ -326,8 +326,7 @@ function AppContent() {
 
   // Apply theme to this window
   const { defaultPythonEnv, featureFlags } = useSyncedTheme();
-  const disableComments = featureFlags.disable_comments;
-  const commentsUiEnabled = !disableComments;
+  const commentsUiEnabled = featureFlags.enable_comments;
 
   // Stable peer ID for presence (generated once per window lifetime)
   const peerIdRef = useRef(crypto.randomUUID());

--- a/crates/notebook/src/settings.rs
+++ b/crates/notebook/src/settings.rs
@@ -113,10 +113,10 @@ pub fn load_settings() -> SyncedSettings {
             .get("disable_nteract_launcher")
             .and_then(|v| v.as_bool())
             .unwrap_or(defaults.disable_nteract_launcher),
-        disable_comments: json
-            .get("disable_comments")
+        enable_comments: json
+            .get("enable_comments")
             .and_then(|v| v.as_bool())
-            .unwrap_or(defaults.disable_comments),
+            .unwrap_or(defaults.enable_comments),
         disable_auto_format: json
             .get("disable_auto_format")
             .and_then(|v| v.as_bool())
@@ -187,7 +187,7 @@ mod tests {
         assert!(settings.conda.default_packages.is_empty());
         assert!(settings.install_default_data_packages);
         assert!(!settings.disable_nteract_launcher);
-        assert!(!settings.disable_comments);
+        assert!(!settings.enable_comments);
         assert!(!settings.disable_auto_format);
         assert!(settings.redact_env_values_in_outputs);
     }
@@ -211,7 +211,7 @@ mod tests {
             pixi_pool_size: 6,
             install_default_data_packages: true,
             disable_nteract_launcher: false,
-            disable_comments: true,
+            enable_comments: true,
             disable_auto_format: true,
             ..SyncedSettings::default()
         };
@@ -223,7 +223,7 @@ mod tests {
         assert_eq!(parsed.default_runtime, Runtime::Deno);
         assert_eq!(parsed.default_python_env, PythonEnvType::Uv);
         assert_eq!(parsed.uv.default_packages, vec!["numpy", "pandas"]);
-        assert!(parsed.disable_comments);
+        assert!(parsed.enable_comments);
         assert!(parsed.disable_auto_format);
     }
 
@@ -407,7 +407,7 @@ mod tests {
             pixi_pool_size: defaults.pixi_pool_size,
             install_default_data_packages: defaults.install_default_data_packages,
             disable_nteract_launcher: defaults.disable_nteract_launcher,
-            disable_comments: defaults.disable_comments,
+            enable_comments: defaults.enable_comments,
             disable_auto_format: defaults.disable_auto_format,
             ..defaults
         };

--- a/crates/runtimed-client/src/settings_doc.rs
+++ b/crates/runtimed-client/src/settings_doc.rs
@@ -15,7 +15,7 @@
 //!   default_python_env: "uv"
 //!   install_default_data_packages: true
 //!   disable_nteract_launcher: false
-//!   disable_comments: false
+//!   enable_comments: false
 //!   disable_auto_format: false
 //!   uv/                           ← nested Map
 //!     default_packages: List[…]   ← List of Str
@@ -301,9 +301,10 @@ pub struct SyncedSettings {
     #[serde(default)]
     pub disable_nteract_launcher: bool,
 
-    /// Disable comments UI surfaces while keeping comments sync active.
+    /// Show the comments UI (panels and creation affordances). Comments sync stays
+    /// active regardless of this flag. Default off.
     #[serde(default)]
-    pub disable_comments: bool,
+    pub enable_comments: bool,
 
     /// Disable automatic code formatting on cell execution and notebook save.
     #[serde(default)]
@@ -384,7 +385,7 @@ impl Default for SyncedSettings {
             pixi_pool_size: pool_sizes.pixi_pool_size,
             install_default_data_packages: true,
             disable_nteract_launcher: false,
-            disable_comments: false,
+            enable_comments: false,
             disable_auto_format: false,
             redact_env_values_in_outputs: true,
             import_shell_environment: true,
@@ -589,11 +590,7 @@ impl SettingsDoc {
             "disable_nteract_launcher",
             defaults.disable_nteract_launcher,
         );
-        let _ = doc.put(
-            automerge::ROOT,
-            "disable_comments",
-            defaults.disable_comments,
-        );
+        let _ = doc.put(automerge::ROOT, "enable_comments", defaults.enable_comments);
         let _ = doc.put(
             automerge::ROOT,
             "disable_auto_format",
@@ -738,9 +735,9 @@ impl SettingsDoc {
         {
             settings.put_bool("disable_nteract_launcher", disabled);
         }
-        // disable_comments: boolean
-        if let Some(disabled) = json.get("disable_comments").and_then(|v| v.as_bool()) {
-            settings.put_bool("disable_comments", disabled);
+        // enable_comments: boolean
+        if let Some(enabled) = json.get("enable_comments").and_then(|v| v.as_bool()) {
+            settings.put_bool("enable_comments", enabled);
         }
         // disable_auto_format: boolean
         if let Some(disabled) = json.get("disable_auto_format").and_then(|v| v.as_bool()) {
@@ -1207,9 +1204,9 @@ impl SettingsDoc {
             disable_nteract_launcher: self
                 .get_bool("disable_nteract_launcher")
                 .unwrap_or(defaults.disable_nteract_launcher),
-            disable_comments: self
-                .get_bool("disable_comments")
-                .unwrap_or(defaults.disable_comments),
+            enable_comments: self
+                .get_bool("enable_comments")
+                .unwrap_or(defaults.enable_comments),
             disable_auto_format: self
                 .get_bool("disable_auto_format")
                 .unwrap_or(defaults.disable_auto_format),
@@ -1423,15 +1420,15 @@ impl SettingsDoc {
                 changed = true;
             }
         }
-        // disable_comments: boolean
-        if let Some(disabled) = json.get("disable_comments").and_then(|v| v.as_bool()) {
-            let current = self.get_bool("disable_comments");
-            if current != Some(disabled) {
+        // enable_comments: boolean
+        if let Some(enabled) = json.get("enable_comments").and_then(|v| v.as_bool()) {
+            let current = self.get_bool("enable_comments");
+            if current != Some(enabled) {
                 info!(
-                    "[settings] apply_json_changes: disable_comments changed {:?} -> {}",
-                    current, disabled
+                    "[settings] apply_json_changes: enable_comments changed {:?} -> {}",
+                    current, enabled
                 );
-                self.put_bool("disable_comments", disabled);
+                self.put_bool("enable_comments", enabled);
                 changed = true;
             }
         }
@@ -1678,7 +1675,7 @@ mod tests {
         assert!(settings.pixi.default_packages.is_empty());
         assert!(settings.install_default_data_packages);
         assert!(!settings.disable_nteract_launcher);
-        assert!(!settings.disable_comments);
+        assert!(!settings.enable_comments);
         assert!(!settings.disable_auto_format);
         assert!(settings.feature_flags().bootstrap_dx);
         assert!(settings.redact_env_values_in_outputs);
@@ -1759,16 +1756,16 @@ mod tests {
     }
 
     #[test]
-    fn test_disable_comments_can_be_enabled_from_json() {
+    fn test_enable_comments_can_be_set_from_json() {
         let mut doc = SettingsDoc::new();
 
         assert!(doc.apply_json_changes(&serde_json::json!({
-            "disable_comments": true
+            "enable_comments": true
         })));
 
         let settings = doc.get_all();
-        assert_eq!(doc.get_bool("disable_comments"), Some(true));
-        assert!(settings.disable_comments);
+        assert_eq!(doc.get_bool("enable_comments"), Some(true));
+        assert!(settings.enable_comments);
     }
 
     #[test]
@@ -2175,7 +2172,7 @@ mod tests {
         assert!(schema_str.contains("default_python_env"));
         assert!(schema_str.contains("install_default_data_packages"));
         assert!(schema_str.contains("disable_nteract_launcher"));
-        assert!(schema_str.contains("disable_comments"));
+        assert!(schema_str.contains("enable_comments"));
         assert!(schema_str.contains("disable_auto_format"));
         assert!(schema_str.contains("redact_env_values_in_outputs"));
         // Should have known values as examples for editor autocomplete

--- a/crates/runtimed-settings-sync/src/lib.rs
+++ b/crates/runtimed-settings-sync/src/lib.rs
@@ -598,7 +598,7 @@ pub fn get_all_from_doc(doc: &AutoCommit) -> SyncedSettings {
             .unwrap_or(defaults.install_default_data_packages),
         disable_nteract_launcher: get_bool("disable_nteract_launcher")
             .unwrap_or(defaults.disable_nteract_launcher),
-        disable_comments: get_bool("disable_comments").unwrap_or(defaults.disable_comments),
+        enable_comments: get_bool("enable_comments").unwrap_or(defaults.enable_comments),
         disable_auto_format: get_bool("disable_auto_format")
             .unwrap_or(defaults.disable_auto_format),
         redact_env_values_in_outputs: get_bool("redact_env_values_in_outputs")
@@ -820,12 +820,12 @@ mod tests {
     }
 
     #[test]
-    fn test_get_all_reads_disable_comments() {
+    fn test_get_all_reads_enable_comments() {
         let mut doc = AutoCommit::new();
-        doc.put(automerge::ROOT, "disable_comments", true).unwrap();
+        doc.put(automerge::ROOT, "enable_comments", true).unwrap();
 
         let settings = get_all_from_doc(&doc);
-        assert!(settings.disable_comments);
+        assert!(settings.enable_comments);
     }
 
     #[test]

--- a/packages/notebook-host/src/types.ts
+++ b/packages/notebook-host/src/types.ts
@@ -365,7 +365,7 @@ export interface HostSyncedSettings {
   keep_alive_secs?: unknown;
   install_default_data_packages?: unknown;
   disable_nteract_launcher?: unknown;
-  disable_comments?: unknown;
+  enable_comments?: unknown;
   disable_auto_format?: unknown;
   redact_env_values_in_outputs?: unknown;
   import_shell_environment?: unknown;

--- a/src/bindings/SyncedSettings.ts
+++ b/src/bindings/SyncedSettings.ts
@@ -81,9 +81,10 @@ export type SyncedSettings = {
    */
   disable_nteract_launcher: boolean;
   /**
-   * Disable comments UI surfaces while keeping comments sync active.
+   * Show the comments UI (panels and creation affordances). Comments sync stays
+   * active regardless of this flag. Default off.
    */
-  disable_comments: boolean;
+  enable_comments: boolean;
   /**
    * Disable automatic code formatting on cell execution and notebook save.
    */

--- a/src/hooks/useSyncedSettings.ts
+++ b/src/hooks/useSyncedSettings.ts
@@ -100,9 +100,10 @@ export const FEATURE_FLAG_METADATA = {
     label: "Use Legacy IPython Launcher",
     description: "Launch Python kernels with ipykernel_launcher instead of the nteract launcher.",
   },
-  disable_comments: {
-    label: "Disable Comments UI",
-    description: "Hide comment panels and creation affordances while keeping comments sync active.",
+  enable_comments: {
+    label: "Enable Comments UI",
+    description:
+      "Show comment panels and creation affordances. Comments sync stays active either way.",
   },
   disable_auto_format: {
     label: "Disable automatic formatting",
@@ -116,7 +117,7 @@ export type FeatureFlagValues = Record<FeatureFlagId, boolean>;
 
 const FEATURE_FLAG_DEFAULTS: FeatureFlagValues = {
   disable_nteract_launcher: false,
-  disable_comments: false,
+  enable_comments: false,
   disable_auto_format: false,
 };
 


### PR DESCRIPTION
Inverts the comments feature flag: comments are now hidden by default and shown only when you turn them on. The toggle reads **Enable Comments UI**.

Renames `disable_comments` → `enable_comments` across `SyncedSettings` (Rust + the regenerated ts-rs binding), flips the two derive sites (`App.tsx` and the cloud viewer) to source `commentsUiEnabled` directly from the flag, and relabels the setting. No back-compat alias; the flag only shipped to nightly.

This is the opt-in-to-try phase: early adopters flip it on. When comments go GA the flag flips back to a default-on, turn-off-able `disable_comments`, the same lifecycle as `disable_nteract_launcher`.
