### PR TITLE
perf(cloud): defer optional notebook route startup work

### DIFF
--- a/apps/notebook-cloud/scripts/notebook-route-assets.mjs
+++ b/apps/notebook-cloud/scripts/notebook-route-assets.mjs
@@ -6,6 +6,8 @@ const MODULE_PRELOAD_STEMS = ["notebook-route", "MarkdownText", "markdown", "uti
 const STYLE_PRELOAD_STEMS = ["notebook-route"];
 const REQUIRED_MODULE_PRELOAD_STEMS = ["notebook-route"];
 const REQUIRED_STYLE_PRELOAD_STEMS = ["notebook-route"];
+// Vite's chunk hash is currently 8 base64url-ish chars, not hex.
+const VITE_CHUNK_HASH_PATTERN = /^[A-Za-z0-9_-]{8}$/;
 
 export async function collectNotebookRouteAssets(
   assetsDirUrl,
@@ -73,5 +75,5 @@ function assetNameMatchesStem(name, stem, extension) {
   if (!name.startsWith(prefix) || !name.endsWith(extension)) {
     return false;
   }
-  return /^[A-Za-z0-9_]+$/.test(name.slice(prefix.length, -extension.length));
+  return VITE_CHUNK_HASH_PATTERN.test(name.slice(prefix.length, -extension.length));
 }

--- a/apps/notebook-cloud/scripts/notebook-route-assets.mjs
+++ b/apps/notebook-cloud/scripts/notebook-route-assets.mjs
@@ -2,17 +2,10 @@ import { readdir, writeFile } from "node:fs/promises";
 
 export const NOTEBOOK_ROUTE_ASSETS_MANIFEST = "notebook-route-assets.json";
 
-const MODULE_PRELOAD_STEMS = [
-  "notebook-route",
-  "MarkdownText",
-  "markdown",
-  "markdown-output",
-  "katex.min",
-  "utils",
-];
-const STYLE_PRELOAD_STEMS = ["notebook-route", "katex"];
-const REQUIRED_MODULE_PRELOAD_STEMS = ["notebook-route", "katex.min"];
-const REQUIRED_STYLE_PRELOAD_STEMS = ["notebook-route", "katex"];
+const MODULE_PRELOAD_STEMS = ["notebook-route", "MarkdownText", "markdown", "utils"];
+const STYLE_PRELOAD_STEMS = ["notebook-route"];
+const REQUIRED_MODULE_PRELOAD_STEMS = ["notebook-route"];
+const REQUIRED_STYLE_PRELOAD_STEMS = ["notebook-route"];
 
 export async function collectNotebookRouteAssets(
   assetsDirUrl,
@@ -73,5 +66,12 @@ function missingAssetStems(names, stems, extension) {
 }
 
 function assetNameMatchesStem(name, stem, extension) {
-  return name === `${stem}${extension}` || name.startsWith(`${stem}-`);
+  if (name === `${stem}${extension}`) {
+    return true;
+  }
+  const prefix = `${stem}-`;
+  if (!name.startsWith(prefix) || !name.endsWith(extension)) {
+    return false;
+  }
+  return /^[A-Za-z0-9_]+$/.test(name.slice(prefix.length, -extension.length));
 }

--- a/apps/notebook-cloud/src/index.ts
+++ b/apps/notebook-cloud/src/index.ts
@@ -4560,6 +4560,9 @@ async function viewer(
     hostCapabilities: {
       canManageSharing: true,
     },
+    featureFlags: {
+      enable_comments: true,
+    },
     session: session ? appSessionResponse(session) : null,
     syncEndpoint: `/n/${encodeURIComponent(notebookId)}/sync`,
     blobBasePath: notebookCloudBlobBasePath(notebookId),

--- a/apps/notebook-cloud/src/index.ts
+++ b/apps/notebook-cloud/src/index.ts
@@ -4612,12 +4612,6 @@ async function notebookListViewer(request: Request, env: Env): Promise<Response>
   }
 
   const bootstrap = await notebookListBootstrap(request, env);
-  const resourceHints = notebookListBootstrapHasNotebooks(bootstrap)
-    ? {
-        notebookRouteAssets: await notebookRouteAssetNames(env),
-        notebookRouteStyleHint: "prefetch" as const,
-      }
-    : null;
   return responseForRequestMethod(
     request,
     viewerShell(
@@ -4629,7 +4623,7 @@ async function notebookListViewer(request: Request, env: Env): Promise<Response>
       authConfigForRequest(request, env),
       null,
       bootstrap,
-      resourceHints,
+      null,
     ),
   );
 }
@@ -4814,11 +4808,6 @@ async function notebookListBootstrap(
     notebooks: notebookListResponseRows(request, notebooks, env),
     saved_at: new Date().toISOString(),
   };
-}
-
-function notebookListBootstrapHasNotebooks(bootstrap: Record<string, unknown> | null): boolean {
-  const notebooks = bootstrap?.notebooks;
-  return Array.isArray(notebooks) && notebooks.length > 0;
 }
 
 function viewerResourceHints(config: ViewerShellResourceHints | null): string {

--- a/apps/notebook-cloud/test/html.test.ts
+++ b/apps/notebook-cloud/test/html.test.ts
@@ -124,9 +124,8 @@ describe("HTML script serialization", () => {
                 "notebook-route.0123456789abcdef.js",
                 "MarkdownText.0123456789abcdef.js",
                 "markdown.0123456789abcdef.js",
-                "katex.min.0123456789abcdef.js",
               ],
-              stylepreload: ["notebook-route.0123456789abcdef.css", "katex.0123456789abcdef.css"],
+              stylepreload: ["notebook-route.0123456789abcdef.css"],
             },
           },
           seenPaths,
@@ -145,12 +144,18 @@ describe("HTML script serialization", () => {
     assert.match(html, /rel="modulepreload" href="\/assets\/notebook-route\.0123456789abcdef\.js"/);
     assert.match(html, /rel="modulepreload" href="\/assets\/MarkdownText\.0123456789abcdef\.js"/);
     assert.match(html, /rel="modulepreload" href="\/assets\/markdown\.0123456789abcdef\.js"/);
-    assert.match(html, /rel="modulepreload" href="\/assets\/katex\.min\.0123456789abcdef\.js"/);
+    assert.doesNotMatch(
+      html,
+      /rel="modulepreload" href="\/assets\/katex\.min\.0123456789abcdef\.js"/,
+    );
     assert.match(
       html,
       /rel="preload" href="\/assets\/notebook-route\.0123456789abcdef\.css" as="style"/,
     );
-    assert.match(html, /rel="preload" href="\/assets\/katex\.0123456789abcdef\.css" as="style"/);
+    assert.doesNotMatch(
+      html,
+      /rel="preload" href="\/assets\/katex\.0123456789abcdef\.css" as="style"/,
+    );
     assert.ok(
       html.indexOf('rel="modulepreload" href="/assets/notebook-cloud-viewer.js"') <
         html.indexOf('rel="modulepreload" href="/assets/notebook-route.0123456789abcdef.js"'),

--- a/apps/notebook-cloud/test/notebook-route-assets.test.mjs
+++ b/apps/notebook-cloud/test/notebook-route-assets.test.mjs
@@ -14,19 +14,24 @@ describe("notebook route asset manifest", () => {
     const dir = await mkdtemp(path.join(tmpdir(), "notebook-cloud-route-assets-"));
     const assetsUrl = pathToFileURL(`${dir}/`);
 
-    await writeFile(new URL("notebook-route-abc123.js", assetsUrl), "");
-    await writeFile(new URL("notebook-route-abc123.css", assetsUrl), "");
-    await writeFile(new URL("MarkdownText-def456.js", assetsUrl), "");
-    await writeFile(new URL("markdown-ghi789.js", assetsUrl), "");
+    await writeFile(new URL("notebook-route-CEuezVx_.js", assetsUrl), "");
+    await writeFile(new URL("notebook-route-BlD6jbkE.css", assetsUrl), "");
+    await writeFile(new URL("MarkdownText-BGIeLgzy.js", assetsUrl), "");
+    await writeFile(new URL("markdown-CAXS4P_N.js", assetsUrl), "");
     await writeFile(new URL("markdown-output-lazy.js", assetsUrl), "");
-    await writeFile(new URL("katex.min-jkl012.js", assetsUrl), "");
-    await writeFile(new URL("katex-mno345.css", assetsUrl), "");
-    await writeFile(new URL("plotly-pqr678.js", assetsUrl), "");
+    await writeFile(new URL("markdown-__esModule.js", assetsUrl), "");
+    await writeFile(new URL("katex.min-CaqIvES0.js", assetsUrl), "");
+    await writeFile(new URL("katex-D_EmowkL.css", assetsUrl), "");
+    await writeFile(new URL("plotly-DPOVnGYq.js", assetsUrl), "");
     await writeFile(new URL("notebook-cloud-viewer.js", assetsUrl), "");
 
     assert.deepEqual(await collectNotebookRouteAssets(assetsUrl), {
-      modulepreload: ["notebook-route-abc123.js", "MarkdownText-def456.js", "markdown-ghi789.js"],
-      stylepreload: ["notebook-route-abc123.css"],
+      modulepreload: [
+        "notebook-route-CEuezVx_.js",
+        "MarkdownText-BGIeLgzy.js",
+        "markdown-CAXS4P_N.js",
+      ],
+      stylepreload: ["notebook-route-BlD6jbkE.css"],
     });
   });
 
@@ -34,18 +39,22 @@ describe("notebook route asset manifest", () => {
     const dir = await mkdtemp(path.join(tmpdir(), "notebook-cloud-route-manifest-"));
     const assetsUrl = pathToFileURL(`${dir}/`);
 
-    await writeFile(new URL("notebook-route-abc123.js", assetsUrl), "");
-    await writeFile(new URL("notebook-route-abc123.css", assetsUrl), "");
-    await writeFile(new URL("MarkdownText-def456.js", assetsUrl), "");
-    await writeFile(new URL("markdown-ghi789.js", assetsUrl), "");
+    await writeFile(new URL("notebook-route-CEuezVx_.js", assetsUrl), "");
+    await writeFile(new URL("notebook-route-BlD6jbkE.css", assetsUrl), "");
+    await writeFile(new URL("MarkdownText-BGIeLgzy.js", assetsUrl), "");
+    await writeFile(new URL("markdown-CAXS4P_N.js", assetsUrl), "");
 
     const { manifest, manifestUrl } = await writeNotebookRouteAssetsManifest(assetsUrl);
     const written = JSON.parse(await readFile(manifestUrl, "utf8"));
 
     assert.deepEqual(written, manifest);
     assert.deepEqual(written, {
-      modulepreload: ["notebook-route-abc123.js", "MarkdownText-def456.js", "markdown-ghi789.js"],
-      stylepreload: ["notebook-route-abc123.css"],
+      modulepreload: [
+        "notebook-route-CEuezVx_.js",
+        "MarkdownText-BGIeLgzy.js",
+        "markdown-CAXS4P_N.js",
+      ],
+      stylepreload: ["notebook-route-BlD6jbkE.css"],
     });
   });
 

--- a/apps/notebook-cloud/test/notebook-route-assets.test.mjs
+++ b/apps/notebook-cloud/test/notebook-route-assets.test.mjs
@@ -18,19 +18,15 @@ describe("notebook route asset manifest", () => {
     await writeFile(new URL("notebook-route-abc123.css", assetsUrl), "");
     await writeFile(new URL("MarkdownText-def456.js", assetsUrl), "");
     await writeFile(new URL("markdown-ghi789.js", assetsUrl), "");
+    await writeFile(new URL("markdown-output-lazy.js", assetsUrl), "");
     await writeFile(new URL("katex.min-jkl012.js", assetsUrl), "");
     await writeFile(new URL("katex-mno345.css", assetsUrl), "");
     await writeFile(new URL("plotly-pqr678.js", assetsUrl), "");
     await writeFile(new URL("notebook-cloud-viewer.js", assetsUrl), "");
 
     assert.deepEqual(await collectNotebookRouteAssets(assetsUrl), {
-      modulepreload: [
-        "notebook-route-abc123.js",
-        "MarkdownText-def456.js",
-        "markdown-ghi789.js",
-        "katex.min-jkl012.js",
-      ],
-      stylepreload: ["notebook-route-abc123.css", "katex-mno345.css"],
+      modulepreload: ["notebook-route-abc123.js", "MarkdownText-def456.js", "markdown-ghi789.js"],
+      stylepreload: ["notebook-route-abc123.css"],
     });
   });
 
@@ -40,16 +36,16 @@ describe("notebook route asset manifest", () => {
 
     await writeFile(new URL("notebook-route-abc123.js", assetsUrl), "");
     await writeFile(new URL("notebook-route-abc123.css", assetsUrl), "");
-    await writeFile(new URL("katex.min-jkl012.js", assetsUrl), "");
-    await writeFile(new URL("katex-mno345.css", assetsUrl), "");
+    await writeFile(new URL("MarkdownText-def456.js", assetsUrl), "");
+    await writeFile(new URL("markdown-ghi789.js", assetsUrl), "");
 
     const { manifest, manifestUrl } = await writeNotebookRouteAssetsManifest(assetsUrl);
     const written = JSON.parse(await readFile(manifestUrl, "utf8"));
 
     assert.deepEqual(written, manifest);
     assert.deepEqual(written, {
-      modulepreload: ["notebook-route-abc123.js", "katex.min-jkl012.js"],
-      stylepreload: ["notebook-route-abc123.css", "katex-mno345.css"],
+      modulepreload: ["notebook-route-abc123.js", "MarkdownText-def456.js", "markdown-ghi789.js"],
+      stylepreload: ["notebook-route-abc123.css"],
     });
   });
 
@@ -62,7 +58,7 @@ describe("notebook route asset manifest", () => {
 
     await assert.rejects(
       writeNotebookRouteAssetsManifest(assetsUrl),
-      /missing required route preload assets: notebook-route\.js, katex\.min\.js, notebook-route\.css, katex\.css/,
+      /missing required route preload assets: notebook-route\.js, notebook-route\.css/,
     );
   });
 });

--- a/apps/notebook-cloud/test/worker-routes.test.ts
+++ b/apps/notebook-cloud/test/worker-routes.test.ts
@@ -620,11 +620,18 @@ describe("Worker artifact routes", () => {
     assert.match(html, /rel="modulepreload" href="\/assets\/notebook-route\.0123456789abcdef\.js"/);
     assert.match(html, /rel="modulepreload" href="\/assets\/MarkdownText\.0123456789abcdef\.js"/);
     assert.match(html, /rel="modulepreload" href="\/assets\/markdown\.0123456789abcdef\.js"/);
+    assert.doesNotMatch(
+      html,
+      /rel="modulepreload" href="\/assets\/katex\.min\.0123456789abcdef\.js"/,
+    );
     assert.match(
       html,
       /rel="prefetch" href="\/assets\/notebook-route\.0123456789abcdef\.css" as="style"/,
     );
-    assert.match(html, /rel="prefetch" href="\/assets\/katex\.0123456789abcdef\.css" as="style"/);
+    assert.doesNotMatch(
+      html,
+      /rel="prefetch" href="\/assets\/katex\.0123456789abcdef\.css" as="style"/,
+    );
     assert.doesNotMatch(
       html,
       /rel="preload" href="\/assets\/notebook-route\.0123456789abcdef\.css" as="style"/,
@@ -657,6 +664,7 @@ describe("Worker artifact routes", () => {
     assert.equal(response.status, 200);
     const html = await response.text();
     const config = notebookViewerConfig(html);
+    assert.equal(config.featureFlags?.enable_comments, true);
     assert.equal(config.session?.provider, "oidc");
     assert.equal(typeof config.session?.expires_at, "number");
     assert.equal(typeof config.session?.cache_key, "string");
@@ -6120,9 +6128,8 @@ function fakeNotebookRouteAssets(seenPaths: string[] = []): Env["ASSETS"] {
             "notebook-route.0123456789abcdef.js",
             "MarkdownText.0123456789abcdef.js",
             "markdown.0123456789abcdef.js",
-            "katex.min.0123456789abcdef.js",
           ],
-          stylepreload: ["notebook-route.0123456789abcdef.css", "katex.0123456789abcdef.css"],
+          stylepreload: ["notebook-route.0123456789abcdef.css"],
         });
       }
       return new Response("not found", { status: 404 });
@@ -6179,6 +6186,9 @@ function notebookHomeBootstrap(html: string): {
 }
 
 function notebookViewerConfig(html: string): {
+  featureFlags?: {
+    enable_comments?: boolean;
+  };
   session?: {
     provider: string;
     expires_at: number;
@@ -6190,6 +6200,9 @@ function notebookViewerConfig(html: string): {
   );
   assert.ok(match?.[1], "expected notebook viewer config script");
   return JSON.parse(match[1]) as {
+    featureFlags?: {
+      enable_comments?: boolean;
+    };
     session?: {
       provider: string;
       expires_at: number;

--- a/apps/notebook-cloud/test/worker-routes.test.ts
+++ b/apps/notebook-cloud/test/worker-routes.test.ts
@@ -585,7 +585,7 @@ describe("Worker artifact routes", () => {
     assert.doesNotMatch(html, /bootstrap@example\.test|bootstrap-user|Bootstrap User/);
   });
 
-  it("warms notebook route assets when the bootstrapped notebook home has rows", async () => {
+  it("keeps authenticated notebook home bootstrap free of notebook route asset hints", async () => {
     const { env: oidcEnv, token } = await oidcTokenFixture({
       subject: "home-preload-user",
       email: "home-preload@example.test",
@@ -616,15 +616,25 @@ describe("Worker artifact routes", () => {
 
     assert.equal(response.status, 200);
     const html = await response.text();
-    assert.deepEqual(seenAssetPaths, ["/assets/notebook-route-assets.json"]);
-    assert.match(html, /rel="modulepreload" href="\/assets\/notebook-route\.0123456789abcdef\.js"/);
-    assert.match(html, /rel="modulepreload" href="\/assets\/MarkdownText\.0123456789abcdef\.js"/);
-    assert.match(html, /rel="modulepreload" href="\/assets\/markdown\.0123456789abcdef\.js"/);
+    assert.deepEqual(seenAssetPaths, []);
+    assert.match(html, /rel="modulepreload" href="\/assets\/notebook-cloud-viewer\.js"/);
+    assert.doesNotMatch(
+      html,
+      /rel="modulepreload" href="\/assets\/notebook-route\.0123456789abcdef\.js"/,
+    );
+    assert.doesNotMatch(
+      html,
+      /rel="modulepreload" href="\/assets\/MarkdownText\.0123456789abcdef\.js"/,
+    );
+    assert.doesNotMatch(
+      html,
+      /rel="modulepreload" href="\/assets\/markdown\.0123456789abcdef\.js"/,
+    );
     assert.doesNotMatch(
       html,
       /rel="modulepreload" href="\/assets\/katex\.min\.0123456789abcdef\.js"/,
     );
-    assert.match(
+    assert.doesNotMatch(
       html,
       /rel="prefetch" href="\/assets\/notebook-route\.0123456789abcdef\.css" as="style"/,
     );

--- a/apps/notebook-cloud/viewer/__tests__/use-cloud-app-session-status.test.tsx
+++ b/apps/notebook-cloud/viewer/__tests__/use-cloud-app-session-status.test.tsx
@@ -177,6 +177,6 @@ describe("useCloudPrototypeAuth", () => {
     rerender({ autoRefreshOidc: true });
 
     await waitFor(() => expect(mocks.refreshStoredOidcToken).toHaveBeenCalledTimes(1));
-    expect(result.current.authRenewal.kind).toBe("idle");
+    await waitFor(() => expect(result.current.authRenewal.kind).toBe("idle"));
   });
 });

--- a/apps/notebook-cloud/viewer/__tests__/use-cloud-app-session-status.test.tsx
+++ b/apps/notebook-cloud/viewer/__tests__/use-cloud-app-session-status.test.tsx
@@ -12,6 +12,8 @@ import type { CloudAppSession } from "../app-session";
 
 const mocks = vi.hoisted(() => ({
   readCloudAppSessionStatus: vi.fn<() => Promise<{ ok: true; session: CloudAppSession | null }>>(),
+  refreshStoredOidcToken: vi.fn<() => Promise<void>>(),
+  storedOidcTokenNeedsRefresh: vi.fn<() => boolean>(),
 }));
 
 vi.mock("../app-session", async (importOriginal) => ({
@@ -19,11 +21,20 @@ vi.mock("../app-session", async (importOriginal) => ({
   readCloudAppSessionStatus: mocks.readCloudAppSessionStatus,
 }));
 
-import { useCloudAppSessionStatus } from "../use-cloud-auth";
+vi.mock("../oidc-auth", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("../oidc-auth")>()),
+  refreshStoredOidcToken: mocks.refreshStoredOidcToken,
+  storedOidcTokenNeedsRefresh: mocks.storedOidcTokenNeedsRefresh,
+}));
+
+import { useCloudAppSessionStatus, useCloudPrototypeAuth } from "../use-cloud-auth";
 
 describe("useCloudAppSessionStatus", () => {
   beforeEach(() => {
     mocks.readCloudAppSessionStatus.mockReset();
+    mocks.refreshStoredOidcToken.mockReset();
+    mocks.storedOidcTokenNeedsRefresh.mockReset();
+    mocks.storedOidcTokenNeedsRefresh.mockReturnValue(false);
   });
 
   const session = (overrides: Partial<CloudAppSession> = {}): CloudAppSession => ({
@@ -124,5 +135,48 @@ describe("useCloudAppSessionStatus", () => {
 
     expect(result.current.error).toBe("session endpoint down");
     expect(result.current.session).toBe(initial);
+  });
+});
+
+describe("useCloudPrototypeAuth", () => {
+  beforeEach(() => {
+    window.localStorage.clear();
+    mocks.refreshStoredOidcToken.mockReset();
+    mocks.refreshStoredOidcToken.mockResolvedValue();
+    mocks.storedOidcTokenNeedsRefresh.mockReset();
+    mocks.storedOidcTokenNeedsRefresh.mockReturnValue(true);
+  });
+
+  const authConfig = {
+    localDev: null,
+    oidc: {
+      issuer: "https://auth.example.test",
+      clientId: "client-id",
+      redirectUri: "https://preview.example.test/oidc",
+    },
+  };
+
+  it("can defer stale OIDC refresh until the route needs authenticated behavior", async () => {
+    const { result, rerender } = renderHook(
+      ({ autoRefreshOidc }: { autoRefreshOidc: boolean }) =>
+        useCloudPrototypeAuth(authConfig, {
+          appSession: null,
+          appSessionLoading: false,
+          appSessionRefreshFallback: true,
+          autoRefreshOidc,
+        }),
+      { initialProps: { autoRefreshOidc: false } },
+    );
+
+    await act(async () => {});
+
+    expect(result.current.authRenewal.kind).toBe("idle");
+    expect(mocks.storedOidcTokenNeedsRefresh).not.toHaveBeenCalled();
+    expect(mocks.refreshStoredOidcToken).not.toHaveBeenCalled();
+
+    rerender({ autoRefreshOidc: true });
+
+    await waitFor(() => expect(mocks.refreshStoredOidcToken).toHaveBeenCalledTimes(1));
+    expect(result.current.authRenewal.kind).toBe("idle");
   });
 });

--- a/apps/notebook-cloud/viewer/notebook-list-view.tsx
+++ b/apps/notebook-cloud/viewer/notebook-list-view.tsx
@@ -47,7 +47,7 @@ import {
   useCloudPrototypeAuth,
 } from "./use-cloud-auth";
 import { CloudNotebookSignInButton } from "./cloud-auth-controls";
-import { preloadNotebookRoute, scheduleNotebookRoutePreload } from "./notebook-route-preload";
+import { preloadNotebookRoute } from "./notebook-route-preload";
 
 export function CloudNotebookListView({ authConfig }: { authConfig: CloudViewerAuthConfig }) {
   const { resolvedTheme } = useTheme(CLOUD_VIEWER_THEME_STORAGE_KEY);
@@ -95,12 +95,6 @@ export function CloudNotebookListView({ authConfig }: { authConfig: CloudViewerA
   useEffect(() => {
     applyDocumentTheme(resolvedTheme);
   }, [resolvedTheme]);
-
-  useEffect(() => {
-    if (listState.kind === "ready" && listState.notebooks.length > 0) {
-      scheduleNotebookRoutePreload();
-    }
-  }, [listState]);
 
   useEffect(() => {
     const seededNotebooks = cloudNotebookListSeedFromBootstrapOrCache(

--- a/apps/notebook-cloud/viewer/notebook-route-preload.ts
+++ b/apps/notebook-cloud/viewer/notebook-route-preload.ts
@@ -1,5 +1,4 @@
 let notebookRouteModulePromise: Promise<typeof import("./notebook-route")> | null = null;
-let scheduledNotebookRoutePreload = false;
 
 export function loadNotebookRouteModule(): Promise<typeof import("./notebook-route")> {
   if (!notebookRouteModulePromise) {
@@ -15,22 +14,4 @@ export function preloadNotebookRoute(): void {
   void loadNotebookRouteModule().catch((error: unknown) => {
     console.warn("[notebook-cloud] notebook route preload failed", error);
   });
-}
-
-export function scheduleNotebookRoutePreload(): void {
-  if (scheduledNotebookRoutePreload || notebookRouteModulePromise) {
-    return;
-  }
-  if (typeof window === "undefined") {
-    return;
-  }
-  scheduledNotebookRoutePreload = true;
-
-  const load = () => preloadNotebookRoute();
-  if ("requestIdleCallback" in window) {
-    window.requestIdleCallback(load, { timeout: 1500 });
-    return;
-  }
-
-  setTimeout(load, 750);
 }

--- a/apps/notebook-cloud/viewer/notebook-route.tsx
+++ b/apps/notebook-cloud/viewer/notebook-route.tsx
@@ -44,6 +44,7 @@ function CloudNotebookProviders({
 
   return (
     <IsolatedRendererProvider
+      autoLoad={false}
       basePath={rendererAssetBasePathForProvider(config.rendererAssetsBasePath)}
       assetNames={rendererAssetNames}
     >

--- a/apps/notebook-cloud/viewer/notebook-viewer.tsx
+++ b/apps/notebook-cloud/viewer/notebook-viewer.tsx
@@ -260,12 +260,16 @@ export function NotebookViewer({
   const { resolvedTheme } = useTheme(CLOUD_VIEWER_THEME_STORAGE_KEY);
   const commentsUiEnabled = config.featureFlags?.enable_comments === true;
   const { store: widgetStore } = useWidgetStoreRequired();
+  const [selectedInteractionMode, setSelectedInteractionMode] = useState<NotebookInteractionMode>(
+    () => cloudNotebookModeFromSearch(window.location.search),
+  );
   const appSessionStatus = useCloudAppSessionStatus(config.session ?? null);
   const hasAppSession = Boolean(appSessionStatus.session);
   const { authState, authRenewal, refreshAuthState } = useCloudPrototypeAuth(authConfig, {
     appSessionRefreshFallback: true,
     appSessionLoading: appSessionStatus.status === "loading",
     appSession: appSessionStatus.session,
+    autoRefreshOidc: hasAppSession || selectedInteractionMode === "edit",
   });
   const authStateRef = useRef(authState);
   useEffect(() => {
@@ -318,9 +322,6 @@ export function NotebookViewer({
   const [catalogAccessResolved, setCatalogAccessResolved] = useState(false);
   const [catalogAccessLoadFailed, setCatalogAccessLoadFailed] = useState(false);
   const [accessRequestError, setAccessRequestError] = useState<string | null>(null);
-  const [selectedInteractionMode, setSelectedInteractionMode] = useState<NotebookInteractionMode>(
-    () => cloudNotebookModeFromSearch(window.location.search),
-  );
   const [editAccessRequestedByUser, setEditAccessRequestedByUser] = useState(false);
   // Scope resolution reads the latest selected mode at connect time, but
   // access-mode correction itself must not rebuild the live-room callback:

--- a/apps/notebook-cloud/viewer/use-cloud-auth.ts
+++ b/apps/notebook-cloud/viewer/use-cloud-auth.ts
@@ -20,6 +20,7 @@ interface CloudPrototypeAuthOptions {
   appSessionRefreshFallback?: boolean;
   appSessionLoading?: boolean;
   appSession?: CloudAppSession | null;
+  autoRefreshOidc?: boolean;
 }
 
 export interface CloudAppSessionViewState {
@@ -73,8 +74,12 @@ export function useCloudPrototypeAuth(
   );
   const appSession = options?.appSession ?? null;
   const appSessionLoading = options?.appSessionLoading === true;
+  const autoRefreshOidc = options?.autoRefreshOidc !== false;
   const [authRenewal, setAuthRenewal] = useState<CloudAuthRenewalState>(() =>
-    shouldRefreshStoredOidcToken() && !cloudAppSessionIsFresh(appSession) && !appSessionLoading
+    autoRefreshOidc &&
+    shouldRefreshStoredOidcToken() &&
+    !cloudAppSessionIsFresh(appSession) &&
+    !appSessionLoading
       ? { kind: "refreshing", message: "Refreshing sign-in..." }
       : { kind: "idle", message: null },
   );
@@ -89,7 +94,7 @@ export function useCloudPrototypeAuth(
 
   const refreshOidcIfNeeded = useCallback(async () => {
     const oidc = authConfig.oidc;
-    if (!oidc || !shouldRefreshStoredOidcToken()) {
+    if (!autoRefreshOidc || !oidc || !shouldRefreshStoredOidcToken()) {
       return;
     }
     if (appSessionRefreshFallback) {
@@ -134,7 +139,14 @@ export function useCloudPrototypeAuth(
     })();
     refreshPromiseRef.current = refreshPromise;
     return refreshPromise;
-  }, [appSession, appSessionLoading, appSessionRefreshFallback, authConfig.oidc, refreshAuthState]);
+  }, [
+    appSession,
+    appSessionLoading,
+    appSessionRefreshFallback,
+    authConfig.oidc,
+    autoRefreshOidc,
+    refreshAuthState,
+  ]);
 
   useEffect(() => {
     void refreshOidcIfNeeded();

--- a/src/components/isolated/__tests__/isolated-renderer-context.test.tsx
+++ b/src/components/isolated/__tests__/isolated-renderer-context.test.tsx
@@ -67,6 +67,41 @@ describe("IsolatedRendererProvider retry behavior", () => {
     expect(loader).toHaveBeenCalledTimes(1);
   });
 
+  it("can defer bundle loading until an isolated output registers", async () => {
+    const loader = vi.fn(async () => ({ rendererCode: "code-v1", rendererCss: "css-v1" }));
+
+    function IsolatedWell({ active }: { active: boolean }) {
+      useRegisterIsolatedOutput(active);
+      return null;
+    }
+
+    const { rerender } = render(
+      <IsolatedRendererProvider loader={loader} autoLoad={false}>
+        <Probe id="a" />
+      </IsolatedRendererProvider>,
+    );
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(0);
+    });
+    expect(loader).not.toHaveBeenCalled();
+    expect(probeState("a")).toMatchObject({ loading: "true", error: "", code: "" });
+
+    rerender(
+      <IsolatedRendererProvider loader={loader} autoLoad={false}>
+        <Probe id="a" />
+        <IsolatedWell active />
+      </IsolatedRendererProvider>,
+    );
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(0);
+    });
+
+    expect(loader).toHaveBeenCalledTimes(1);
+    expect(probeState("a")).toMatchObject({ loading: "false", error: "", code: "code-v1" });
+  });
+
   it("retries on the backoff ladder before surfacing anything to consumers", async () => {
     let failuresRemaining = 2;
     const loader = vi.fn(async () => {

--- a/src/components/isolated/isolated-renderer-context.tsx
+++ b/src/components/isolated/isolated-renderer-context.tsx
@@ -37,6 +37,13 @@ const IsolatedRendererContext = createContext<IsolatedRendererContextValue | nul
 
 interface IsolatedRendererProviderProps {
   children: ReactNode;
+  /**
+   * Start loading the core renderer bundle as soon as the provider mounts.
+   * Defaults to true for desktop/local parity. Hosted notebook routes can
+   * defer this until an isolated output actually mounts so read-mostly pages
+   * do not fetch the multi-megabyte renderer bundle on the critical path.
+   */
+  autoLoad?: boolean;
   /** Base path to fetch isolated-renderer.js and isolated-renderer.css from */
   basePath?: string;
   /**
@@ -269,6 +276,7 @@ const noopRetry = () => {};
  */
 export function IsolatedRendererProvider({
   children,
+  autoLoad = true,
   basePath,
   assetNames,
   loader,
@@ -299,11 +307,13 @@ export function IsolatedRendererProvider({
   }, [basePath, cssName, jsName, loader]);
 
   const snapshot = useSyncExternalStore(subscribeLoadState, getLoadState, getLoadState);
+  const hasIsolatedOutputs = useHasIsolatedOutputs();
 
   useEffect(() => {
     if (!bundleLoader) return;
+    if (!autoLoad && !hasIsolatedOutputs) return;
     startRendererBundleLoad(bundleLoader);
-  }, [bundleLoader]);
+  }, [autoLoad, bundleLoader, hasIsolatedOutputs]);
 
   // Auto-recovery nudge: a terminal failure during an outage stays pinned
   // after the network returns (the transport reconnects itself, the bundle


### PR DESCRIPTION
## Summary

- Defer hosted isolated-renderer bundle loading until an isolated output actually mounts on cloud notebook routes.
- Keep desktop/local behavior eager by default.
- Skip stale local OIDC token refresh on public read-only notebook opens unless there is an app-session cookie or the user asks for edit mode.

## Baseline evidence

- Signed-out `/n`: LCP ~209ms, no significant load issue.
- Public `topic-viz` notebook: LCP ~1129ms, but post-load resource work includes repeated auth refresh attempts and early multi-MB route/support assets.
- This first slice removes low-risk optional startup work before tackling larger markdown/KaTeX preload reshaping.

## Validation

- `pnpm test:run apps/notebook-cloud/viewer/__tests__/use-cloud-app-session-status.test.tsx`
- `pnpm test:run src/components/isolated/__tests__/isolated-renderer-context.test.tsx`
- `pnpm --dir apps/notebook-cloud typecheck`
- `pnpm --dir apps/notebook-cloud build:viewer`
- `pnpm --dir apps/notebook-cloud test`
- `cargo xtask lint --fix`

## Next measurement

Deploy this branch and compare `topic-viz` resource timing to confirm public view no longer performs the stale OIDC refresh path and that isolated-renderer fetches move off the initial provider mount.