### PR TITLE
fix(notebook-cloud): require live runtime peer for compute actions

### DIFF
--- a/apps/notebook-cloud/src/index.ts
+++ b/apps/notebook-cloud/src/index.ts
@@ -1618,6 +1618,10 @@ async function routeNotebookWorkstationAttachment(
   const eventPresence = await workstationEventPresence(env, ownerPrincipal, workstationId);
   const projectedStatus = workstationStatusForResponse(workstation, Date.now(), eventPresence);
   if (projectedStatus !== "online") {
+    await repairNotebookRuntimeStateIfNoRuntimePeer(env, notebookId, {
+      reason: `workstation ${workstationId} is not online while attaching compute`,
+      operation: "offline_workstation_attach",
+    });
     return json(
       {
         error: "workstation is not online",
@@ -2021,6 +2025,13 @@ async function routeWorkstationAttachJob(
   if (workstation) {
     await publishWorkstationAttachJobRuntimeState(env, job, workstation);
   }
+  if (job.status === "failed" || job.status === "cancelled") {
+    await repairNotebookRuntimeStateIfNoRuntimePeer(env, job.notebook_id, {
+      reason:
+        job.error_message ?? `workstation attach job ${job.status} before a runtime peer attached`,
+      operation: `workstation_attach_job_${job.status}`,
+    });
+  }
   return json({
     ok: true,
     job: workstationAttachJobResponseRow(request, job),
@@ -2385,6 +2396,50 @@ async function publishWorkstationAttachJobRuntimeState(
       status: job.status,
       error: error instanceof Error ? error.message : String(error),
       counter: "workstation_attach_runtime_state_publish_failed",
+      counter_delta: 1,
+    });
+  }
+}
+
+async function repairNotebookRuntimeStateIfNoRuntimePeer(
+  env: Env,
+  notebookId: string,
+  options: {
+    operation: string;
+    reason: string;
+  },
+): Promise<void> {
+  const id = env.NOTEBOOK_ROOMS.idFromName(notebookId);
+  const room = env.NOTEBOOK_ROOMS.get(id);
+  try {
+    const response = await room.fetch(
+      new Request(
+        `https://notebook-room.internal/internal/n/${encodeURIComponent(
+          notebookId,
+        )}/runtime-state-repair`,
+        {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ reason: options.reason }),
+        },
+      ),
+    );
+    if (response.ok || response.status === 409) {
+      return;
+    }
+    cloudLog("warn", "workstation.attach.runtime_state_repair_failed", {
+      notebook_id: notebookId,
+      operation: options.operation,
+      response_status: response.status,
+      counter: "workstation_attach_runtime_state_repair_failed",
+      counter_delta: 1,
+    });
+  } catch (error) {
+    cloudLog("warn", "workstation.attach.runtime_state_repair_failed", {
+      notebook_id: notebookId,
+      operation: options.operation,
+      error: error instanceof Error ? error.message : String(error),
+      counter: "workstation_attach_runtime_state_repair_failed",
       counter_delta: 1,
     });
   }

--- a/apps/notebook-cloud/src/index.ts
+++ b/apps/notebook-cloud/src/index.ts
@@ -1770,7 +1770,13 @@ async function routeWorkstationEvents(
   }
 
   const stub = workstationEventsStub(env, ownerPrincipal, workstationId);
-  const response = await stub.fetch(new Request("https://workstation-events.internal/stream"));
+  const response = await stub.fetch(
+    new Request(
+      `https://workstation-events.internal/stream?workstation_id=${encodeURIComponent(
+        workstationId,
+      )}`,
+    ),
+  );
   return withCors(new Response(response.body, response));
 }
 
@@ -1919,7 +1925,11 @@ async function workstationEventPresence(
   }
   try {
     const response = await workstationEventsStub(env, ownerPrincipal, workstationId).fetch(
-      new Request("https://workstation-events.internal/status"),
+      new Request(
+        `https://workstation-events.internal/status?workstation_id=${encodeURIComponent(
+          workstationId,
+        )}`,
+      ),
     );
     if (!response.ok) {
       cloudLog("warn", "workstation.events.status_failed", {

--- a/apps/notebook-cloud/src/notebook-room.ts
+++ b/apps/notebook-cloud/src/notebook-room.ts
@@ -86,6 +86,11 @@ interface PeerCloseOptions {
 
 type RuntimePeerForwardedRequestAction = "interrupt_execution" | "send_comm";
 type RuntimePeerQueryRequestAction = "complete";
+type HostedExecutionRequestAction =
+  | "execute_cell"
+  | "execute_cell_guarded"
+  | "run_all_cells"
+  | "run_all_cells_guarded";
 type UnsupportedHostedRuntimeRequestAction =
   | "launch_kernel"
   | "restart_kernel"
@@ -127,6 +132,12 @@ const runtimePeerForwardedRequestActions = new Set<RuntimePeerForwardedRequestAc
   "send_comm",
 ]);
 const runtimePeerQueryRequestActions = new Set<RuntimePeerQueryRequestAction>(["complete"]);
+const hostedExecutionRequestActions = new Set<HostedExecutionRequestAction>([
+  "execute_cell",
+  "execute_cell_guarded",
+  "run_all_cells",
+  "run_all_cells_guarded",
+]);
 const unsupportedHostedRuntimeRequestActions = new Set<UnsupportedHostedRuntimeRequestAction>([
   "launch_kernel",
   "restart_kernel",
@@ -185,6 +196,15 @@ function runtimePeerQueryRequestAction(
   }
   return runtimePeerQueryRequestActions.has(action as RuntimePeerQueryRequestAction)
     ? (action as RuntimePeerQueryRequestAction)
+    : null;
+}
+
+function hostedExecutionRequestAction(action: string | null): HostedExecutionRequestAction | null {
+  if (!action) {
+    return null;
+  }
+  return hostedExecutionRequestActions.has(action as HostedExecutionRequestAction)
+    ? (action as HostedExecutionRequestAction)
     : null;
 }
 
@@ -1043,6 +1063,29 @@ export class NotebookRoom {
       return;
     }
 
+    const hostedExecutionAction =
+      normalizedFrame.type === FrameType.REQUEST
+        ? hostedExecutionRequestAction(requestMetadata?.action ?? null)
+        : null;
+    if (hostedExecutionAction) {
+      const runtimePeer = await this.activeRuntimePeer(notebookId, peer.id);
+      if (!runtimePeer && !(await this.executionCanWaitForStartingRuntime(notebookId))) {
+        await this.reconcileMissingRuntimePeer(
+          notebookId,
+          `no runtime peer is attached for ${hostedExecutionAction}`,
+          "hosted_execution_without_runtime_peer",
+        );
+        this.rejectFrame(
+          notebookId,
+          peer,
+          normalizedFrame.type,
+          `no runtime peer is attached for ${hostedExecutionAction}`,
+          { countsTowardStreak: false },
+        );
+        return;
+      }
+    }
+
     const unsupportedRuntimeRequestAction =
       normalizedFrame.type === FrameType.REQUEST
         ? unsupportedHostedRuntimeRequestAction(requestMetadata?.action ?? null)
@@ -1428,6 +1471,48 @@ export class NotebookRoom {
       }
     }
     return selected;
+  }
+
+  private async executionCanWaitForStartingRuntime(notebookId: string): Promise<boolean> {
+    const materializer = this.materializerFor(notebookId);
+    if (typeof materializer.getWorkstationAttachment !== "function") {
+      return false;
+    }
+    const attachment = await materializer.getWorkstationAttachment();
+    return attachment?.status === "connecting";
+  }
+
+  private async reconcileMissingRuntimePeer(
+    notebookId: string,
+    reason: string,
+    operation: string,
+  ): Promise<boolean> {
+    try {
+      const materializer = this.materializerFor(notebookId);
+      const result = await materializer.reconcileRuntimePeerGone(reason);
+      this.invalidateSelectedRuntimePeerSession(notebookId);
+      if (result.changed) {
+        this.deliverRoomHostFrames(notebookId, result);
+        this.scheduleRoomHostCheckpoint(notebookId, materializer, operation);
+      }
+      cloudLog("info", "room.runtime_peer_missing.reconciled", {
+        notebook_id: notebookId,
+        operation,
+        changed: result.changed,
+        counter: "runtime_peer_missing_reconciled",
+        counter_delta: result.changed ? 1 : 0,
+      });
+      return result.changed;
+    } catch (error) {
+      cloudLog("warn", "room.runtime_peer_missing.reconcile_failed", {
+        notebook_id: notebookId,
+        operation,
+        error: errorMessage(error),
+        counter: "runtime_peer_missing_reconcile_failed",
+        counter_delta: 1,
+      });
+      return false;
+    }
   }
 
   private async selectedRuntimePeerSession(

--- a/apps/notebook-cloud/src/workstation-events.ts
+++ b/apps/notebook-cloud/src/workstation-events.ts
@@ -1,9 +1,11 @@
 import type { DurableObjectState, Env } from "./cloudflare-types.ts";
+import { cloudLog } from "./observability.ts";
 
 const WORKSTATION_EVENTS_KEEPALIVE_MS = 25_000;
 
 interface EventListener {
   readonly id: string;
+  readonly workstationId: string | null;
   readonly writer: WritableStreamDefaultWriter<Uint8Array>;
   closed: boolean;
   keepalive: ReturnType<typeof setInterval> | null;
@@ -41,6 +43,14 @@ export class WorkstationEvents {
       return this.openStream(request);
     }
     if (request.method === "GET" && url.pathname === "/status") {
+      const workstationId = workstationIdFromUrl(url);
+      cloudLog("debug", "workstation.events.status", {
+        workstation_id: workstationId,
+        connected: this.listeners.size > 0,
+        connections: this.listeners.size,
+        counter: "workstation_event_status_checks",
+        counter_delta: 1,
+      });
       return Response.json({
         ok: true,
         connected: this.listeners.size > 0,
@@ -62,9 +72,11 @@ export class WorkstationEvents {
   }
 
   private openStream(request: Request): Response {
+    const workstationId = workstationIdFromUrl(new URL(request.url));
     const { readable, writable } = new TransformStream<Uint8Array, Uint8Array>();
     const listener: EventListener = {
       id: crypto.randomUUID(),
+      workstationId,
       writer: writable.getWriter(),
       closed: false,
       keepalive: null,
@@ -75,6 +87,13 @@ export class WorkstationEvents {
     request.signal.addEventListener("abort", close, { once: true });
 
     this.listeners.set(listener.id, listener);
+    cloudLog("info", "workstation.events.stream_opened", {
+      workstation_id: workstationId,
+      listener_id: listener.id,
+      connections: this.listeners.size,
+      counter: "workstation_event_streams_opened",
+      counter_delta: 1,
+    });
     void this.writeEvent(listener, "ready", {
       ok: true,
       connected_at: new Date().toISOString(),
@@ -128,8 +147,20 @@ export class WorkstationEvents {
       listener.keepalive = null;
     }
     this.listeners.delete(listener.id);
+    cloudLog("info", "workstation.events.stream_closed", {
+      workstation_id: listener.workstationId,
+      listener_id: listener.id,
+      connections: this.listeners.size,
+      counter: "workstation_event_streams_closed",
+      counter_delta: 1,
+    });
     void listener.writer.close().catch(() => undefined);
   }
+}
+
+function workstationIdFromUrl(url: URL): string | null {
+  const workstationId = url.searchParams.get("workstation_id")?.trim();
+  return workstationId && workstationId.length <= 128 ? workstationId : null;
 }
 
 function formatServerSentEvent(event: string, data: unknown): string {

--- a/apps/notebook-cloud/test/notebook-room.test.ts
+++ b/apps/notebook-cloud/test/notebook-room.test.ts
@@ -2431,6 +2431,131 @@ describe("NotebookRoom materialized sync routing", () => {
     assert.equal(rejected.reason, "no runtime peer is attached for interrupt_execution");
   });
 
+  it("rejects hosted execution requests and repairs stale ready attachments with no runtime peer", async () => {
+    const room = new NotebookRoom(fakeState(), {} as Env);
+    const identity = authenticateDevRequest(
+      new Request("https://cloud.test/n/demo/sync?user=alice&operator=browser:a&scope=owner"),
+    );
+    const socket = new FakeSocket();
+    const peer = {
+      id: "owner",
+      socket: socket.asCloudflareWebSocket(),
+      identity,
+      connectedAt: "2026-05-22T00:00:00.000Z",
+      consecutiveRejectedFrames: 0,
+    };
+    const harness = roomHarness(room);
+    let materialized = 0;
+    let reconciledReason: string | null = null;
+    harness.materializers.set("demo", {
+      receiveFrame: async () => {
+        materialized += 1;
+        return noopMaterializedResult();
+      },
+      checkpoint: async () => undefined,
+      removePeer: async () => undefined,
+      getWorkstationAttachment: async () => ({
+        workstation_id: "ws-lab",
+        display_name: "Lab",
+        provider: "runtime_peer",
+        default_environment_label: "Current Python",
+        environment_policy: "current_python",
+        status: "ready",
+        status_message: null,
+        cpu_count: null,
+        memory_bytes: null,
+        working_directory: null,
+        updated_at: "2026-05-22T00:00:00.000Z",
+        runtime_session_id: "job-old",
+      }),
+      reconcileRuntimePeerGone: async (reason: string) => {
+        reconciledReason = reason;
+        return { ...noopMaterializedResult(), changed: true, runtime_state_changed: true };
+      },
+    } as never);
+
+    await harness.handleMessage(
+      "demo",
+      peer,
+      encodeTypedFrame(
+        FrameType.REQUEST,
+        new TextEncoder().encode(
+          JSON.stringify({ id: "request-1", action: "execute_cell", cell_id: "cell-1" }),
+        ),
+      ),
+    );
+
+    assert.equal(materialized, 0, "stale execution request should not queue new work");
+    assert.equal(reconciledReason, "no runtime peer is attached for execute_cell");
+    assert.equal(peer.consecutiveRejectedFrames, 0);
+    assert.equal(socket.sent.length, 1);
+    const rejected = decodeJsonPayload<Record<string, unknown>>(socket.sent[0].slice(1));
+    assert.equal(rejected.type, "cloud_frame_rejected");
+    assert.equal(rejected.reason, "no runtime peer is attached for execute_cell");
+  });
+
+  it("allows hosted execution requests to queue while attach is connecting", async () => {
+    const room = new NotebookRoom(fakeState(), {} as Env);
+    const identity = authenticateDevRequest(
+      new Request("https://cloud.test/n/demo/sync?user=alice&operator=browser:a&scope=owner"),
+    );
+    const socket = new FakeSocket();
+    const peer = {
+      id: "owner",
+      socket: socket.asCloudflareWebSocket(),
+      identity,
+      connectedAt: "2026-05-22T00:00:00.000Z",
+      consecutiveRejectedFrames: 0,
+    };
+    const harness = roomHarness(room);
+    let materialized = 0;
+    let reconciled = 0;
+    harness.materializers.set("demo", {
+      receiveFrame: async () => {
+        materialized += 1;
+        return noopMaterializedResult();
+      },
+      checkpoint: async () => undefined,
+      removePeer: async () => undefined,
+      getWorkstationAttachment: async () => ({
+        workstation_id: "ws-lab",
+        display_name: "Lab",
+        provider: "runtime_peer",
+        default_environment_label: "Current Python",
+        environment_policy: "current_python",
+        status: "connecting",
+        status_message: "Lab accepted the request and is starting compute.",
+        cpu_count: null,
+        memory_bytes: null,
+        working_directory: null,
+        updated_at: "2026-05-22T00:00:00.000Z",
+        runtime_session_id: "job-new",
+      }),
+      reconcileRuntimePeerGone: async () => {
+        reconciled += 1;
+        return noopMaterializedResult();
+      },
+    } as never);
+
+    await harness.handleMessage(
+      "demo",
+      peer,
+      encodeTypedFrame(
+        FrameType.REQUEST,
+        new TextEncoder().encode(
+          JSON.stringify({ id: "request-1", action: "execute_cell", cell_id: "cell-1" }),
+        ),
+      ),
+    );
+
+    assert.equal(materialized, 1, "connecting attach may queue initial execution");
+    assert.equal(reconciled, 0);
+    assert.equal(peer.consecutiveRejectedFrames, 0);
+    assert.equal(socket.sent.length, 1);
+    const accepted = decodeJsonPayload<Record<string, unknown>>(socket.sent[0].slice(1));
+    assert.equal(accepted.type, "cloud_frame_accepted");
+  });
+
   it("rejects response-bearing runtime REQUEST frames instead of acknowledging no-ops", async () => {
     const room = new NotebookRoom(fakeState(), {} as Env);
     const identity = authenticateDevRequest(

--- a/apps/notebook-cloud/test/viewer-shell-capabilities.test.ts
+++ b/apps/notebook-cloud/test/viewer-shell-capabilities.test.ts
@@ -220,6 +220,43 @@ test("cloud shell capabilities prefer RuntimeStateDoc workstation attachment ove
   assert.equal(capabilities.canExecute, true);
 });
 
+test("cloud shell capabilities require live runtime peer presence for executable attachments", () => {
+  const capabilities = cloudNotebookShellCapabilities({
+    authState: authState("oidc", "owner"),
+    connectionScope: "owner",
+    hasCodeCells: true,
+    selectedMode: "edit",
+    runtimeAvailable: false,
+    runtimePeerCount: 0,
+    workstationAttachment: {
+      workstation_id: "ws-lab2",
+      display_name: "Lab 2",
+      provider: "local_daemon",
+      default_environment_label: "Current Python",
+      environment_policy: "current_python",
+      status: "ready",
+      status_message: null,
+      cpu_count: 8,
+      memory_bytes: 32 * 1024 ** 3,
+      working_directory: "/home/ubuntu/notebooks",
+      updated_at: "2026-06-07T21:00:00Z",
+    },
+  });
+
+  assert.equal(capabilities.runtime.connected, true);
+  assert.equal(capabilities.runtime.executionAvailable, false);
+  assert.equal(capabilities.runtime.target?.id, "ws-lab2");
+  assert.equal(capabilities.runtime.target?.label, "Lab 2");
+  assert.equal(capabilities.runtime.target?.status, "attention");
+  assert.equal(capabilities.runtime.target?.statusLabel, "Needs attention");
+  assert.equal(
+    capabilities.runtime.target?.detail,
+    "Runtime peer disconnected: no compute session is currently attached to the room.",
+  );
+  assert.equal(capabilities.runtime.target?.runtimePeerCount, null);
+  assert.equal(capabilities.canExecute, false);
+});
+
 test("cloud shell capabilities surface RuntimeStateDoc kernel status on workstation targets", () => {
   const capabilities = cloudNotebookShellCapabilities({
     authState: authState("oidc", "owner"),
@@ -336,6 +373,7 @@ test("cloud shell capabilities hide execution in view mode even for owners with 
     connectionScope: "owner",
     hasCodeCells: true,
     selectedMode: "view",
+    runtimePeerCount: 1,
     workstationAttachment: {
       workstation_id: "ws-lab2",
       display_name: "Lab 2",
@@ -355,6 +393,7 @@ test("cloud shell capabilities hide execution in view mode even for owners with 
     connectionScope: "owner",
     hasCodeCells: true,
     selectedMode: "edit",
+    runtimePeerCount: 1,
     workstationAttachment: {
       workstation_id: "ws-lab2",
       display_name: "Lab 2",

--- a/apps/notebook-cloud/test/worker-routes.test.ts
+++ b/apps/notebook-cloud/test/worker-routes.test.ts
@@ -2319,7 +2319,21 @@ describe("Worker artifact routes", () => {
   });
 
   it("does not create attach jobs or runtime peer grants for offline workstations", async () => {
-    const env = fakeEnv();
+    const roomRequests: string[] = [];
+    const env = fakeEnv({
+      NOTEBOOK_ROOMS: {
+        idFromName: (name: string) => ({ toString: () => name }),
+        get: () => ({
+          fetch: async (request: Request) => {
+            roomRequests.push(new URL(request.url).pathname);
+            return new Response(JSON.stringify({ ok: true, changed: true }), {
+              status: 200,
+              headers: { "Content-Type": "application/json" },
+            });
+          },
+        }),
+      } satisfies DurableObjectNamespace,
+    });
     seedNotebook(env, "attach-demo");
     seedAcl(env, { notebookId: "attach-demo", subject: "user:dev:alice", scope: "owner" });
     seedWorkstation(env, {
@@ -2351,6 +2365,7 @@ describe("Worker artifact routes", () => {
     assert.equal(body.error, "workstation is not online");
     assert.equal(body.workstation?.workstation_id, "ws-lab2");
     assert.equal(body.workstation?.status, "offline");
+    assert.deepEqual(roomRequests, ["/internal/n/attach-demo/runtime-state-repair"]);
     assert.equal(env.DB.workstationAttachJobs.size, 0);
     assert.equal(
       env.DB.acl.some(
@@ -2774,6 +2789,52 @@ describe("Worker artifact routes", () => {
     assert.equal(response.status, 200);
     assert.equal(attachmentStatus, "connecting");
     assert.equal(attachmentMessage, "Lab2 accepted the request and is starting compute.");
+  });
+
+  it("repairs RuntimeStateDoc when a workstation attach job fails before runtime peer connects", async () => {
+    const roomRequests: string[] = [];
+    const env = fakeEnv({
+      NOTEBOOK_ROOMS: {
+        idFromName: (name: string) => ({ toString: () => name }),
+        get: () => ({
+          fetch: async (request: Request) => {
+            roomRequests.push(new URL(request.url).pathname);
+            return new Response(JSON.stringify({ ok: true, changed: true }), {
+              status: 200,
+              headers: { "Content-Type": "application/json" },
+            });
+          },
+        }),
+      } satisfies DurableObjectNamespace,
+    });
+    seedWorkstation(env, { ownerPrincipal: "user:dev:alice", workstationId: "ws-lab2" });
+    seedWorkstationAttachJob(env, {
+      id: "job-fail",
+      notebookId: "nb-fail",
+      ownerPrincipal: "user:dev:alice",
+      workstationId: "ws-lab2",
+    });
+
+    const response = await worker.fetch(
+      new Request("http://localhost/api/workstations/ws-lab2/attach-jobs/job-fail", {
+        method: "PATCH",
+        headers: {
+          "Content-Type": "application/json",
+          "X-Operator": "workstation:lab2",
+          "X-Scope": "owner",
+          "X-User": "alice",
+        },
+        body: JSON.stringify({ status: "failed", error_message: "spawn failed" }),
+      }),
+      env,
+      fakeContext(),
+    );
+
+    assert.equal(response.status, 200);
+    assert.deepEqual(roomRequests, [
+      "/internal/n/nb-fail/workstation-attachment",
+      "/internal/n/nb-fail/runtime-state-repair",
+    ]);
   });
 
   it("rejects late workstation status patches after a replacement cancelled the job", async () => {

--- a/apps/notebook-cloud/viewer/notebook-viewer.tsx
+++ b/apps/notebook-cloud/viewer/notebook-viewer.tsx
@@ -861,7 +861,7 @@ export function NotebookViewer({
     ? workstationAttachmentIsConnected(workstationAttachment)
     : runtimePeerAvailable;
   const cloudRuntimeExecutionAvailableForStatus = workstationAttachment
-    ? workstationAttachmentCanExecute(workstationAttachment)
+    ? workstationAttachmentCanExecute(workstationAttachment) && runtimePeerAvailable
     : runtimePeerAvailable;
   const cloudRuntimeStatus = useMemo<NotebookCommandToolbarStatus | null>(() => {
     if (!cloudRuntimeConnectedForStatus && !cloudRuntimeExecutionAvailableForStatus) {

--- a/apps/notebook-cloud/viewer/shell-capabilities.ts
+++ b/apps/notebook-cloud/viewer/shell-capabilities.ts
@@ -110,8 +110,11 @@ export function cloudNotebookShellCapabilities({
     ? cloudVisiblePeerLabel(connectionPeerLabel, connectionActorLabel)
     : cloudIdentityDisplayLabel(authState, connectionActorLabel);
   const identityImageUrl = cloudIdentityImageUrl(authState);
+  const visibleRuntimePeerCount = Math.max(0, Math.floor(runtimePeerCount));
+  const hasRuntimePeer = visibleRuntimePeerCount > 0;
   const attachmentConnected = workstationAttachmentIsConnected(workstationAttachment);
-  const attachmentExecutionAvailable = workstationAttachmentCanExecute(workstationAttachment);
+  const attachmentExecutionAvailable =
+    workstationAttachmentCanExecute(workstationAttachment) && hasRuntimePeer;
   const hasAttachmentSnapshot = workstationAttachment !== null;
   const effectiveRuntimeConnected = hasAttachmentSnapshot ? attachmentConnected : runtimeAvailable;
   const effectiveRuntimeAvailable = hasAttachmentSnapshot
@@ -219,7 +222,7 @@ function cloudRuntimeTarget({
   }
   const attachmentTarget = projectNotebookRuntimeTargetFromWorkstationAttachment(
     workstationAttachment,
-    { runtimePeerCount: visibleRuntimePeerCount, kernelStatusLabel },
+    { runtimePeerCount: visibleRuntimePeerCount, kernelStatusLabel, requireRuntimePeer: true },
   );
   if (attachmentTarget) {
     return attachmentTarget;

--- a/crates/runtimed/src/workstation/agent_loop.rs
+++ b/crates/runtimed/src/workstation/agent_loop.rs
@@ -48,9 +48,9 @@ pub const READINESS_LINE: &str = "Infrastructure ready, entering main loop";
 /// Default attach-job fallback poll interval. The fast path is the workstation
 /// event stream; polling is recovery for missed events or older servers.
 pub const DEFAULT_POLL_MS: u64 = 60_000;
-/// Default active-job heartbeat interval. The workstation registration is sent
-/// on startup and while active jobs exist; idle online presence comes from the
-/// hosted workstation event stream rather than repeated D1 writes.
+/// Default workstation heartbeat interval. The event stream is the fast wakeup
+/// path, but registration heartbeat remains the durable online-presence
+/// fallback for missed or wedged streams.
 pub const DEFAULT_HEARTBEAT_MS: u64 = 60_000;
 
 /// Cooldown applied to 429/503 responses without a usable `Retry-After`.
@@ -820,11 +820,11 @@ pub async fn run_workstation_agent(opts: WorkstationAgentOptions, token: String)
             continue;
         }
 
-        // Register on startup and refresh workstation metadata while active
-        // jobs exist. Idle connected presence is carried by the SSE stream; a
-        // no-workstation heartbeat loop would burn one Worker/D1 write per
-        // workstation per interval.
-        if should_register_workstation(last_registration, active.len(), opts.heartbeat_interval) {
+        // Register on startup and refresh workstation metadata periodically.
+        // The SSE stream is the fast attach-job wakeup path; this heartbeat is
+        // the durable fallback that keeps a locally-running workstation visible
+        // if that stream is missed, half-open, or blocked by an intermediary.
+        if should_register_workstation(last_registration, opts.heartbeat_interval) {
             let result = heartbeat(&api, &opts).await;
             if result.is_ok() {
                 last_registration = Some(Instant::now());
@@ -859,11 +859,10 @@ pub async fn run_workstation_agent(opts: WorkstationAgentOptions, token: String)
         // readiness and exits land promptly (the `.mjs` agent's 250ms
         // readyPoll), but sleep cheaply while idle.
         let next_poll_at = last_poll.map_or_else(Instant::now, |at| at + opts.poll_interval);
-        let deadline =
-            next_registration_deadline(last_registration, active.len(), opts.heartbeat_interval)
-                .map_or(next_poll_at, |next_registration_at| {
-                    next_poll_at.min(next_registration_at)
-                });
+        let deadline = next_registration_deadline(last_registration, opts.heartbeat_interval)
+            .map_or(next_poll_at, |next_registration_at| {
+                next_poll_at.min(next_registration_at)
+            });
         loop {
             tick_active_jobs(&api, &opts, &mut active).await;
             let now = Instant::now();
@@ -1005,24 +1004,21 @@ async fn heartbeat(api: &CloudApi, opts: &WorkstationAgentOptions) -> Result<(),
 
 fn should_register_workstation(
     last_registration: Option<Instant>,
-    active_job_count: usize,
     heartbeat_interval: Duration,
 ) -> bool {
     if last_registration.is_none() {
         return true;
     }
-    active_job_count > 0 && last_registration.is_some_and(|at| at.elapsed() >= heartbeat_interval)
+    last_registration.is_some_and(|at| at.elapsed() >= heartbeat_interval)
 }
 
 fn next_registration_deadline(
     last_registration: Option<Instant>,
-    active_job_count: usize,
     heartbeat_interval: Duration,
 ) -> Option<Instant> {
     match last_registration {
         None => Some(Instant::now()),
-        Some(at) if active_job_count > 0 => Some(at + heartbeat_interval),
-        Some(_) => None,
+        Some(at) => Some(at + heartbeat_interval),
     }
 }
 
@@ -1748,42 +1744,30 @@ mod tests {
     }
 
     #[test]
-    fn workstation_registration_is_startup_and_active_job_only() {
+    fn workstation_registration_is_startup_and_periodic() {
         let heartbeat_interval = Duration::from_secs(60);
         let stale_registration = Instant::now() - Duration::from_secs(120);
         let fresh_registration = Instant::now();
 
-        assert!(should_register_workstation(None, 0, heartbeat_interval));
-        assert!(should_register_workstation(None, 1, heartbeat_interval));
-        assert!(!should_register_workstation(
-            Some(stale_registration),
-            0,
-            heartbeat_interval
-        ));
         assert!(!should_register_workstation(
             Some(fresh_registration),
-            1,
             heartbeat_interval
         ));
         assert!(should_register_workstation(
             Some(stale_registration),
-            1,
             heartbeat_interval
         ));
+        assert!(should_register_workstation(None, heartbeat_interval));
     }
 
     #[test]
-    fn idle_workstation_registration_has_no_wakeup_deadline() {
+    fn workstation_registration_has_periodic_wakeup_deadline() {
         let heartbeat_interval = Duration::from_secs(60);
         let registered = Instant::now();
 
-        assert!(next_registration_deadline(None, 0, heartbeat_interval).is_some());
+        assert!(next_registration_deadline(None, heartbeat_interval).is_some());
         assert_eq!(
-            next_registration_deadline(Some(registered), 0, heartbeat_interval),
-            None
-        );
-        assert_eq!(
-            next_registration_deadline(Some(registered), 1, heartbeat_interval),
+            next_registration_deadline(Some(registered), heartbeat_interval),
             Some(registered + heartbeat_interval)
         );
     }

--- a/packages/runtimed/src/notebook-shell-capabilities.ts
+++ b/packages/runtimed/src/notebook-shell-capabilities.ts
@@ -136,6 +136,13 @@ export interface ProjectNotebookRuntimeTargetFromWorkstationAttachmentOptions {
    */
   kind?: NotebookShellRuntimeTargetKind;
   kernelStatusLabel?: string | null;
+  /**
+   * Hosted rooms can observe whether the runtime peer that owns a ready/busy
+   * attachment is still present. When this is true, a ready RuntimeStateDoc
+   * attachment without a live runtime peer is a previous compute session that
+   * needs attention, not an executable runtime.
+   */
+  requireRuntimePeer?: boolean;
   runtimePeerCount?: number | null;
 }
 
@@ -278,12 +285,17 @@ export function projectNotebookRuntimeTargetFromWorkstationAttachment(
 ): NotebookShellRuntimeTargetProjection | null {
   if (!attachment) return null;
 
-  const statusProjection = workstationAttachmentStatusProjection(attachment.status);
+  const runtimePeerCount = normalizePositiveInteger(options.runtimePeerCount);
+  const statusProjection = workstationAttachmentStatusProjection(
+    attachment.status,
+    Boolean(options.requireRuntimePeer) &&
+      workstationAttachmentCanExecute(attachment) &&
+      runtimePeerCount === null,
+  );
   const defaultEnvironmentLabel =
     trimToNull(attachment.default_environment_label) ??
     trimToNull(attachment.environment_policy) ??
     "Notebook runtime";
-  const runtimePeerCount = normalizePositiveInteger(options.runtimePeerCount);
 
   return {
     id: trimToNull(attachment.workstation_id) ?? "attached-workstation",
@@ -847,11 +859,22 @@ function notebookActorOperatorCacheKey(actor: NotebookActorProjection["operator"
   return projectionCacheKey(actor, NOTEBOOK_ACTOR_OPERATOR_CACHE_FIELDS);
 }
 
-function workstationAttachmentStatusProjection(status: string): {
+function workstationAttachmentStatusProjection(
+  status: string,
+  missingRequiredRuntimePeer = false,
+): {
   status: NotebookShellRuntimeTargetStatus;
   statusLabel: string;
   detail: string | null;
 } {
+  if (missingRequiredRuntimePeer) {
+    return {
+      status: "attention",
+      statusLabel: "Needs attention",
+      detail: "Runtime peer disconnected: no compute session is currently attached to the room.",
+    };
+  }
+
   switch (status) {
     case "ready":
       return { status: "ready", statusLabel: "Ready", detail: null };

--- a/packages/runtimed/src/notebook-shell-capabilities.ts
+++ b/packages/runtimed/src/notebook-shell-capabilities.ts
@@ -286,11 +286,13 @@ export function projectNotebookRuntimeTargetFromWorkstationAttachment(
   if (!attachment) return null;
 
   const runtimePeerCount = normalizePositiveInteger(options.runtimePeerCount);
+  const missingRequiredRuntimePeer =
+    Boolean(options.requireRuntimePeer) &&
+    workstationAttachmentCanExecute(attachment) &&
+    runtimePeerCount === null;
   const statusProjection = workstationAttachmentStatusProjection(
     attachment.status,
-    Boolean(options.requireRuntimePeer) &&
-      workstationAttachmentCanExecute(attachment) &&
-      runtimePeerCount === null,
+    missingRequiredRuntimePeer,
   );
   const defaultEnvironmentLabel =
     trimToNull(attachment.default_environment_label) ??
@@ -304,7 +306,9 @@ export function projectNotebookRuntimeTargetFromWorkstationAttachment(
     status: statusProjection.status,
     label: trimToNull(attachment.display_name) ?? "Attached workstation",
     statusLabel: statusProjection.statusLabel,
-    detail: trimToNull(attachment.status_message) ?? statusProjection.detail,
+    detail: missingRequiredRuntimePeer
+      ? statusProjection.detail
+      : (trimToNull(attachment.status_message) ?? statusProjection.detail),
     providerLabel: workstationAttachmentProviderLabel(attachment.provider),
     defaultEnvironmentLabel,
     environmentLabel: defaultEnvironmentLabel,

--- a/packages/runtimed/tests/notebook-shell-capabilities.test.ts
+++ b/packages/runtimed/tests/notebook-shell-capabilities.test.ts
@@ -485,10 +485,15 @@ describe("projectNotebookRuntimeTargetFromWorkstationAttachment", () => {
   });
 
   it("can project stale ready hosted attachments as needing attention", () => {
-    const target = projectNotebookRuntimeTargetFromWorkstationAttachment(attachment(), {
-      requireRuntimePeer: true,
-      runtimePeerCount: 0,
-    });
+    const target = projectNotebookRuntimeTargetFromWorkstationAttachment(
+      attachment({
+        status_message: "stale ready status message",
+      }),
+      {
+        requireRuntimePeer: true,
+        runtimePeerCount: 0,
+      },
+    );
 
     expect(target).toMatchObject({
       id: "ws-lab2",

--- a/packages/runtimed/tests/notebook-shell-capabilities.test.ts
+++ b/packages/runtimed/tests/notebook-shell-capabilities.test.ts
@@ -483,4 +483,19 @@ describe("projectNotebookRuntimeTargetFromWorkstationAttachment", () => {
       detail: "Waiting for runtime peer heartbeat",
     });
   });
+
+  it("can project stale ready hosted attachments as needing attention", () => {
+    const target = projectNotebookRuntimeTargetFromWorkstationAttachment(attachment(), {
+      requireRuntimePeer: true,
+      runtimePeerCount: 0,
+    });
+
+    expect(target).toMatchObject({
+      id: "ws-lab2",
+      status: "attention",
+      statusLabel: "Needs attention",
+      detail: "Runtime peer disconnected: no compute session is currently attached to the room.",
+      runtimePeerCount: null,
+    });
+  });
 });


### PR DESCRIPTION
## Summary

- treat a ready RuntimeStateDoc workstation attachment as executable only when the cloud room currently observes a live runtime peer
- keep stale attachments visible as previous compute needing attention instead of surfacing run/restart/interrupt controls
- hide stale kernel status labels when the runtime peer is gone so the toolbar does not report idle for an unreachable kernel

## Validation

- cargo xtask lint --fix
- pnpm test:run -- apps/notebook-cloud/test/viewer-shell-capabilities.test.ts packages/runtimed/tests/notebook-shell-capabilities.test.ts
