### PR TITLE
fix(notebook): preserve title editor caret order

### DIFF
--- a/src/components/notebook/DocumentTitle.tsx
+++ b/src/components/notebook/DocumentTitle.tsx
@@ -66,13 +66,13 @@ export function DocumentTitle({
   title,
 }: DocumentTitleProps) {
   const [editing, setEditing] = useState(false);
-  const [draftTitle, setDraftTitle] = useState(renameTitle);
+  const draftTitleRef = useRef(renameTitle);
   const editableRef = useRef<HTMLSpanElement | null>(null);
   const canShowRename = canRename && Boolean(onRename);
 
   useEffect(() => {
     if (!editing) {
-      setDraftTitle(renameTitle);
+      draftTitleRef.current = renameTitle;
     }
   }, [editing, renameTitle]);
 
@@ -81,6 +81,7 @@ export function DocumentTitle({
       return;
     }
     const editable = editableRef.current;
+    editable.textContent = draftTitleRef.current;
     editable.focus();
     placeCaretAtEnd(editable);
   }, [editing]);
@@ -89,11 +90,11 @@ export function DocumentTitle({
     if (!canShowRename || renameSaving) {
       return;
     }
-    setDraftTitle(renameTitle);
+    draftTitleRef.current = renameTitle;
     setEditing(true);
   };
 
-  const commitRename = (titleDraft = draftTitle) => {
+  const commitRename = (titleDraft = draftTitleRef.current) => {
     if (!onRename || renameSaving) {
       return;
     }
@@ -125,7 +126,7 @@ export function DocumentTitle({
     if (renameSaving) {
       return;
     }
-    setDraftTitle(renameTitle);
+    draftTitleRef.current = renameTitle;
     setEditing(false);
   };
 
@@ -135,7 +136,7 @@ export function DocumentTitle({
       editableRef.current.textContent = nextTitle;
       placeCaretAtEnd(editableRef.current);
     }
-    setDraftTitle(nextTitle);
+    draftTitleRef.current = nextTitle;
     return nextTitle;
   };
 
@@ -202,7 +203,7 @@ export function DocumentTitle({
             suppressContentEditableWarning
             tabIndex={editing || canShowRename ? 0 : undefined}
           >
-            {editing ? draftTitle : title.label}
+            {editing ? null : title.label}
           </span>
           {canShowRename ? (
             <span className="document-title-actions" data-slot="document-title-actions">

--- a/src/components/notebook/__tests__/DocumentTitle.test.tsx
+++ b/src/components/notebook/__tests__/DocumentTitle.test.tsx
@@ -1,4 +1,5 @@
 import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
 import { describe, expect, it, vi } from "vite-plus/test";
 import { DocumentTitle } from "../DocumentTitle";
 
@@ -69,6 +70,31 @@ describe("DocumentTitle", () => {
     await waitFor(() => {
       expect(screen.queryByRole("textbox", { name: "Document title" })).toBeNull();
     });
+  });
+
+  it("keeps typed characters in order while editing the title", async () => {
+    const user = userEvent.setup();
+    const onRename = vi.fn().mockResolvedValue(true);
+
+    render(
+      <DocumentTitle
+        canRename
+        renameTitle=""
+        title={{ label: "Untitled", detail: null, title: "Untitled" }}
+        onRename={onRename}
+      />,
+    );
+
+    await user.click(screen.getByRole("button", { name: "Rename Untitled" }));
+
+    const editable = screen.getByRole("textbox", { name: "Document title" });
+    await user.type(editable, "Outbound");
+
+    expect(editable).toHaveTextContent("Outbound");
+
+    fireEvent.keyDown(editable, { key: "Enter" });
+
+    expect(onRename).toHaveBeenCalledWith("Outbound");
   });
 
   it("closes inline title editing immediately when rename saves synchronously", () => {


### PR DESCRIPTION
## Summary

- Keep the notebook/cloud title `contentEditable` DOM-owned while editing so React does not replace the text node after each keystroke.
- Track the draft title in a ref and seed the editable DOM once when editing begins.
- Add a regression test that types `Outbound` into the title and asserts the visible/submitted order.

## Verification

- `pnpm test:run src/components/notebook/__tests__/DocumentTitle.test.tsx`
- `pnpm test:run`
- `cargo xtask lint --fix`
- `pnpm --dir apps/notebook-cloud dev:browser --rebuild --next /n/title-caret-smoke/Title%20Caret%20Smoke`
- Browser against local wrangler `http://127.0.0.1:45221`: created a local owner notebook, renamed the cloud title to `Outbound`, and verified the visible title, document title, route slug, and `/api/n/:id` catalog title all stayed `Outbound`.

