### PR TITLE
fix(mcp-app): inline small raster fallback outputs

### DIFF
--- a/apps/mcp-app/src/components/__tests__/shared-cell-outputs.test.tsx
+++ b/apps/mcp-app/src/components/__tests__/shared-cell-outputs.test.tsx
@@ -100,6 +100,38 @@ describe("SharedCellOutputs", () => {
     );
   });
 
+  it("waits for host CSP before enabling the raster image inline fallback", () => {
+    render(
+      <SharedCellOutputs
+        cell={{
+          cell_id: "cell-1",
+          cell_type: "code",
+          source: "display('hi')",
+          execution_count: 1,
+          status: "done",
+          outputs: [
+            {
+              output_id: "output-1",
+              output_type: "display_data",
+              data: {
+                "image/png": "http://localhost:47830/blob/image-hash",
+              },
+            },
+          ],
+        }}
+        blobBaseUrl="http://localhost:47830/"
+        hostCapabilities={null}
+      />,
+    );
+
+    expect(mcpAppOutputFrameSpy).toHaveBeenCalledWith(
+      expect.objectContaining({
+        outputDocumentUrl: null,
+        inlineRasterBlobImages: false,
+      }),
+    );
+  });
+
   it("warns the host when daemon output frames are blocked by frameDomains", async () => {
     const sendLog = vi.fn();
     setHostLogSink({ sendLog });

--- a/apps/mcp-app/src/components/__tests__/shared-cell-outputs.test.tsx
+++ b/apps/mcp-app/src/components/__tests__/shared-cell-outputs.test.tsx
@@ -1,5 +1,6 @@
-import { render } from "@testing-library/react";
+import { render, waitFor } from "@testing-library/react";
 import { afterEach, describe, expect, it, vi } from "vite-plus/test";
+import { setHostLogSink } from "../../lib/host-log";
 import { SharedCellOutputs } from "../shared-cell-outputs";
 
 vi.mock("virtual:isolated-renderer", () => ({
@@ -19,6 +20,7 @@ vi.mock("@/components/isolated/mcp-app-output-frame", () => ({
 describe("SharedCellOutputs", () => {
   afterEach(() => {
     vi.clearAllMocks();
+    setHostLogSink(null);
   });
 
   it("uses the daemon output document only when host frameDomains allow it", () => {
@@ -54,6 +56,7 @@ describe("SharedCellOutputs", () => {
     expect(mcpAppOutputFrameSpy).toHaveBeenCalledWith(
       expect.objectContaining({
         outputDocumentUrl: "http://localhost:47830/output-frame",
+        inlineRasterBlobImages: false,
         rendererAssetsBaseUrl: "http://localhost:47830/plugins/",
       }),
     );
@@ -92,6 +95,55 @@ describe("SharedCellOutputs", () => {
     expect(mcpAppOutputFrameSpy).toHaveBeenCalledWith(
       expect.objectContaining({
         outputDocumentUrl: null,
+        inlineRasterBlobImages: true,
+      }),
+    );
+  });
+
+  it("warns the host when daemon output frames are blocked by frameDomains", async () => {
+    const sendLog = vi.fn();
+    setHostLogSink({ sendLog });
+
+    render(
+      <SharedCellOutputs
+        cell={{
+          cell_id: "cell-1",
+          cell_type: "code",
+          source: "display('hi')",
+          execution_count: 1,
+          status: "done",
+          outputs: [
+            {
+              output_id: "output-1",
+              output_type: "display_data",
+              data: {
+                "image/png": "http://localhost:47830/blob/image-hash",
+              },
+            },
+          ],
+        }}
+        blobBaseUrl="http://localhost:47830/"
+        hostCapabilities={{
+          sandbox: {
+            csp: {
+              frameDomains: ["https://outputs.example.test"],
+            },
+          },
+        }}
+      />,
+    );
+
+    await waitFor(() => expect(sendLog).toHaveBeenCalledTimes(1));
+    expect(sendLog).toHaveBeenCalledWith(
+      expect.objectContaining({
+        level: "warning",
+        data: expect.objectContaining({
+          event: "shared-output-daemon-frame-blocked",
+          outputFrameOrigin: "http://localhost:47830",
+          frameDomains: ["https://outputs.example.test"],
+          fallback: "srcdoc-raster-image-data-uri",
+          maxInlineImageBytes: expect.any(Number),
+        }),
       }),
     );
   });

--- a/apps/mcp-app/src/components/shared-cell-outputs.tsx
+++ b/apps/mcp-app/src/components/shared-cell-outputs.tsx
@@ -49,7 +49,7 @@ export function SharedCellOutputs({
     () => daemonOutputFrameBlockedByHostCsp(blobBaseUrl, hostCsp),
     [blobBaseUrl, hostCsp],
   );
-  const inlineRasterBlobImages = Boolean(blobBaseUrl && outputDocumentUrl === null);
+  const inlineRasterBlobImages = daemonOutputFrameBlocked;
   const handleDiagnostic = useCallback(
     (
       phase: string,

--- a/apps/mcp-app/src/components/shared-cell-outputs.tsx
+++ b/apps/mcp-app/src/components/shared-cell-outputs.tsx
@@ -1,12 +1,15 @@
-import { useCallback, useMemo } from "react";
+import { useCallback, useEffect, useMemo } from "react";
 import type { McpUiHostCapabilities, McpUiHostContext } from "@modelcontextprotocol/ext-apps";
 import { rendererCode, rendererCss } from "virtual:isolated-renderer";
 import {
   createDaemonRendererPluginLoader,
+  daemonOutputFrameBlockedByHostCsp,
+  daemonOutputFrameOrigin,
   daemonOutputFrameUrl,
   daemonRendererAssetsBaseUrl,
 } from "@/components/isolated/daemon-renderer-assets";
 import { McpAppOutputFrame } from "@/components/isolated/mcp-app-output-frame";
+import { MCP_APP_INLINE_RASTER_IMAGE_MAX_BYTES } from "@/components/isolated/mcp-app-structured-content";
 import type { NteractOutputRendererBundleProvider } from "@/components/isolated/output-embed";
 import type { CellData } from "../types";
 import { errorDetails, hostLog } from "../lib/host-log";
@@ -37,10 +40,16 @@ export function SharedCellOutputs({
     () => daemonRendererAssetsBaseUrl(blobBaseUrl),
     [blobBaseUrl],
   );
+  const hostCsp = hostCapabilities?.sandbox?.csp;
   const outputDocumentUrl = useMemo(
-    () => daemonOutputFrameUrl(blobBaseUrl, hostCapabilities?.sandbox?.csp),
-    [blobBaseUrl, hostCapabilities],
+    () => daemonOutputFrameUrl(blobBaseUrl, hostCsp),
+    [blobBaseUrl, hostCsp],
   );
+  const daemonOutputFrameBlocked = useMemo(
+    () => daemonOutputFrameBlockedByHostCsp(blobBaseUrl, hostCsp),
+    [blobBaseUrl, hostCsp],
+  );
+  const inlineRasterBlobImages = Boolean(blobBaseUrl && outputDocumentUrl === null);
   const handleDiagnostic = useCallback(
     (
       phase: string,
@@ -63,6 +72,17 @@ export function SharedCellOutputs({
     });
   }, []);
 
+  useEffect(() => {
+    if (!blobBaseUrl || outputDocumentUrl !== null || !daemonOutputFrameBlocked) return;
+
+    hostLog("warning", "shared-output-daemon-frame-blocked", {
+      outputFrameOrigin: daemonOutputFrameOrigin(blobBaseUrl),
+      frameDomains: hostCsp?.frameDomains ?? [],
+      fallback: "srcdoc-raster-image-data-uri",
+      maxInlineImageBytes: MCP_APP_INLINE_RASTER_IMAGE_MAX_BYTES,
+    });
+  }, [blobBaseUrl, daemonOutputFrameBlocked, hostCsp, outputDocumentUrl]);
+
   return (
     <McpAppOutputFrame
       cell={cell}
@@ -72,6 +92,7 @@ export function SharedCellOutputs({
       rendererPluginLoader={rendererPluginLoader}
       rendererAssetsBaseUrl={rendererAssetsBaseUrl}
       outputDocumentUrl={outputDocumentUrl}
+      inlineRasterBlobImages={inlineRasterBlobImages}
       className="shared-output-frame"
       onDiagnostic={handleDiagnostic}
       onError={handleError}

--- a/crates/runt-mcp/src/structured.rs
+++ b/crates/runt-mcp/src/structured.rs
@@ -27,6 +27,13 @@ fn is_viz_mime(mime: &str) -> bool {
             && (mime.ends_with("+json") || mime.ends_with(".json")))
 }
 
+fn is_static_raster_mime(mime: &str) -> bool {
+    matches!(
+        mime,
+        "image/png" | "image/jpeg" | "image/gif" | "image/webp"
+    )
+}
+
 /// Inputs for [`cell_structured_content_from_manifests`].
 pub struct CellStructuredContentManifestInput<'a> {
     pub cell_id: &'a str,
@@ -154,12 +161,16 @@ fn manifest_output_to_structured(
             let mut data = serde_json::Map::new();
 
             if let Some(data_map) = manifest.get("data").and_then(|v| v.as_object()) {
-                // Check for renderable raster images to skip redundant text/html
-                let has_renderable_image = data_map.keys().any(|m| {
-                    matches!(
-                        m.as_str(),
-                        "image/png" | "image/jpeg" | "image/gif" | "image/webp"
-                    )
+                // Check for blob-backed raster images that will survive as
+                // Blob Store URLs, then skip redundant text/html. Inline
+                // rasters are intentionally omitted from MCP tool responses,
+                // so they must not suppress richer HTML fallbacks.
+                let has_renderable_image = data_map.iter().any(|(mime, content_ref)| {
+                    is_static_raster_mime(mime)
+                        && blob_base_url.is_some()
+                        && output_resolver::content_ref_meta(content_ref)
+                            .blob_hash
+                            .is_some()
                 });
 
                 for (mime, content_ref) in data_map {
@@ -191,13 +202,12 @@ fn manifest_output_to_structured(
 
                     let meta = output_resolver::content_ref_meta(content_ref);
 
-                    // Images are binary but their inline form is base64,
-                    // which renderers handle as data: URIs. Non-image binary
-                    // MIMEs (parquet, audio, video, application/octet-stream)
-                    // produce garbled text when inlined as JSON strings.
-                    let is_non_renderable_binary = notebook_doc::mime::mime_kind(mime)
+                    // Binary blobs can be rendered via Blob Store URLs. Inline
+                    // binary has no URL to hand to the MCP app, and inlining
+                    // raster base64 would expose image bytes in tool responses.
+                    let should_drop_inline_binary = notebook_doc::mime::mime_kind(mime)
                         == MimeKind::Binary
-                        && !mime.starts_with("image/");
+                        && (!mime.starts_with("image/") || is_static_raster_mime(mime));
 
                     let json_value = if let Some(hash) = meta.blob_hash {
                         // Blob-stored content — always emit blob URL regardless
@@ -205,11 +215,10 @@ fn manifest_output_to_structured(
                         blob_base_url
                             .as_ref()
                             .map(|base| Value::String(format!("{}/blob/{}", base, hash)))
-                    } else if meta.is_inline && !is_non_renderable_binary {
-                        // Inline text/JSON/image content — extract directly.
-                        // Non-renderable binary (parquet, audio, etc.) is
-                        // silently dropped; the client falls back to
-                        // text/plain or text/llm+plain.
+                    } else if meta.is_inline && !should_drop_inline_binary {
+                        // Inline text/JSON content — extract directly. Inline
+                        // binary/raster content is silently dropped; the client
+                        // falls back to text/plain or text/llm+plain.
                         content_ref.get("inline").cloned()
                     } else {
                         None
@@ -424,6 +433,26 @@ mod tests {
     }
 
     #[test]
+    fn structured_inline_image_does_not_suppress_html() {
+        let manifest = json!({
+            "output_type": "display_data",
+            "data": {
+                "text/html": inline_ref("<img src='data:...' />"),
+                "image/png": inline_ref("iVBORw0KGgoAAAA...base64..."),
+                "text/plain": inline_ref("<Figure>"),
+            },
+        });
+        let blob_base = Some("http://localhost:9999".to_string());
+        let result = manifest_output_to_structured(&manifest, &blob_base, None);
+        let Some(data) = result["data"].as_object() else {
+            panic!("data should be an object");
+        };
+        assert_eq!(data["text/html"], "<img src='data:...' />");
+        assert!(!data.contains_key("image/png"));
+        assert_eq!(data["text/plain"], "<Figure>");
+    }
+
+    #[test]
     fn structured_output_id_propagates_on_every_variant() {
         // The daemon stamps `output_id` on every manifest and the MCP App
         // uses it as a React key. Structured output must preserve it.
@@ -539,9 +568,9 @@ mod tests {
     }
 
     #[test]
-    fn structured_image_inline_passes_through() {
-        // Images are binary but inline as base64 which renderers handle
-        // as data: URIs. They must NOT be suppressed.
+    fn structured_image_inline_is_omitted() {
+        // Inline raster content would put image bytes directly in MCP tool
+        // responses. Blob-backed images still emit Blob Store URLs.
         let manifest = json!({
             "output_type": "display_data",
             "data": {
@@ -553,9 +582,9 @@ mod tests {
         let data = result["data"]
             .as_object()
             .expect("data should be an object");
-        assert_eq!(
-            data["image/png"], "iVBORw0KGgoAAAA...base64...",
-            "inline base64 images should pass through for data: URI rendering"
+        assert!(
+            !data.contains_key("image/png"),
+            "inline base64 images should not be serialized in structured content"
         );
         assert_eq!(data["text/plain"], "<Figure>");
     }

--- a/src/components/isolated/__tests__/daemon-renderer-assets.test.ts
+++ b/src/components/isolated/__tests__/daemon-renderer-assets.test.ts
@@ -1,6 +1,8 @@
 import { afterEach, describe, expect, it, vi } from "vite-plus/test";
 import {
   createDaemonRendererPluginLoader,
+  daemonOutputFrameBlockedByHostCsp,
+  daemonOutputFrameOrigin,
   daemonOutputFrameUrl,
   daemonRendererAssetsBaseUrl,
 } from "../daemon-renderer-assets";
@@ -51,6 +53,22 @@ describe("daemon renderer assets", () => {
       }),
     ).toBeNull();
     expect(daemonOutputFrameUrl("http://localhost:47830/", { frameDomains: [] })).toBeNull();
+  });
+
+  it("reports when the host CSP blocks the daemon output frame origin", () => {
+    expect(
+      daemonOutputFrameBlockedByHostCsp("http://localhost:47830/", {
+        frameDomains: ["http://localhost:47830"],
+      }),
+    ).toBe(false);
+    expect(
+      daemonOutputFrameBlockedByHostCsp("http://localhost:47830/", {
+        frameDomains: ["https://outputs.example.test"],
+      }),
+    ).toBe(true);
+    expect(daemonOutputFrameBlockedByHostCsp(undefined, { frameDomains: [] })).toBe(false);
+    expect(daemonOutputFrameBlockedByHostCsp("http://localhost:47830/", null)).toBe(false);
+    expect(daemonOutputFrameOrigin("http://localhost:47830/")).toBe("http://localhost:47830");
   });
 
   it("fetches raw renderer plugin assets from the daemon renderer-plugin route", async () => {

--- a/src/components/isolated/__tests__/mcp-app-output-frame.test.tsx
+++ b/src/components/isolated/__tests__/mcp-app-output-frame.test.tsx
@@ -115,4 +115,33 @@ describe("McpAppOutputFrame", () => {
       }),
     );
   });
+
+  it("replays outputs when the output frame URL changes", async () => {
+    const rendererBundle = { rendererCode: "renderer", rendererCss: "css" };
+    const cell = cellWithHtmlOutput();
+
+    const { rerender } = render(
+      <McpAppOutputFrame
+        cell={cell}
+        blobBaseUrl="http://localhost:47830"
+        rendererBundle={rendererBundle}
+        outputDocumentUrl="http://localhost:47830/output-frame"
+      />,
+    );
+
+    await waitFor(() => expect(mockHandle.renderBatch).toHaveBeenCalledTimes(1));
+
+    rerender(
+      <McpAppOutputFrame
+        cell={cell}
+        blobBaseUrl="http://localhost:47830"
+        rendererBundle={rendererBundle}
+        outputDocumentUrl={null}
+      />,
+    );
+
+    await waitFor(() => expect(createNteractOutputEmbed).toHaveBeenCalledTimes(2));
+    await waitFor(() => expect(mockHandle.renderBatch).toHaveBeenCalledTimes(2));
+    expect(mockHandle.dispose).toHaveBeenCalled();
+  });
 });

--- a/src/components/isolated/__tests__/mcp-app-structured-content.test.ts
+++ b/src/components/isolated/__tests__/mcp-app-structured-content.test.ts
@@ -126,6 +126,39 @@ describe("MCP App structured content adapter", () => {
     });
   });
 
+  it("inlines small raster image blobs when content length is absent", async () => {
+    const fetchImpl = vi.fn(async () => new Response(new Uint8Array([5, 6, 7, 8])));
+    vi.stubGlobal("fetch", fetchImpl);
+
+    const outputs = mcpAppCellsToSharedOutputs(
+      [
+        cellWithOutputs([
+          {
+            output_id: "image-output",
+            output_type: "display_data",
+            data: {
+              "image/png": "http://localhost:47830/blob/image-no-length",
+            },
+          },
+        ]),
+      ],
+      "http://localhost:47830",
+    );
+
+    const [payload] = await resolveEmbeddableOutputs(outputs, {
+      blobResolver: createMcpAppBlobResolver("http://localhost:47830", {
+        inlineRasterImageBlobs: true,
+      }),
+    });
+
+    expect(fetchImpl).toHaveBeenCalledWith("http://localhost:47830/blob/image-no-length");
+    expect(payload).toMatchObject({
+      mimeType: "image/png",
+      data: "data:image/png;base64,BQYHCA==",
+      outputId: "image-output",
+    });
+  });
+
   it("keeps large raster image blobs as URLs when the inline fallback is enabled", async () => {
     const fetchImpl = vi.fn(async () => {
       return new Response(new Uint8Array([1, 2, 3, 4]), {

--- a/src/components/isolated/__tests__/mcp-app-structured-content.test.ts
+++ b/src/components/isolated/__tests__/mcp-app-structured-content.test.ts
@@ -2,6 +2,7 @@ import { afterEach, describe, expect, it, vi } from "vite-plus/test";
 import { resolveEmbeddableOutputs } from "../embeddable-output";
 import {
   createMcpAppBlobResolver,
+  MCP_APP_INLINE_RASTER_IMAGE_MAX_BYTES,
   mcpAppCellHasRichOutput,
   mcpAppCellPreviewText,
   mcpAppCellsToSharedOutputs,
@@ -82,6 +83,126 @@ describe("MCP App structured content adapter", () => {
       data: "http://localhost:47830/blob/image-hash",
       outputId: "image-output",
     });
+  });
+
+  it("inlines small raster image blobs as data URIs when enabled", async () => {
+    const fetchImpl = vi.fn(async () => {
+      return new Response(new Uint8Array([1, 2, 3, 4]), {
+        headers: {
+          "content-length": "4",
+          "content-type": "image/png",
+        },
+      });
+    });
+    vi.stubGlobal("fetch", fetchImpl);
+
+    const outputs = mcpAppCellsToSharedOutputs(
+      [
+        cellWithOutputs([
+          {
+            output_id: "image-output",
+            output_type: "display_data",
+            data: {
+              "image/png": "http://localhost:47830/blob/image-hash",
+              "text/plain": "<Figure size 1100x520 with 1 Axes>",
+            },
+          },
+        ]),
+      ],
+      "http://localhost:47830",
+    );
+
+    const [payload] = await resolveEmbeddableOutputs(outputs, {
+      blobResolver: createMcpAppBlobResolver("http://localhost:47830", {
+        inlineRasterImageBlobs: true,
+      }),
+    });
+
+    expect(fetchImpl).toHaveBeenCalledWith("http://localhost:47830/blob/image-hash");
+    expect(payload).toMatchObject({
+      mimeType: "image/png",
+      data: "data:image/png;base64,AQIDBA==",
+      outputId: "image-output",
+    });
+  });
+
+  it("keeps large raster image blobs as URLs when the inline fallback is enabled", async () => {
+    const fetchImpl = vi.fn(async () => {
+      return new Response(new Uint8Array([1, 2, 3, 4]), {
+        headers: {
+          "content-length": String(MCP_APP_INLINE_RASTER_IMAGE_MAX_BYTES + 1),
+          "content-type": "image/png",
+        },
+      });
+    });
+    vi.stubGlobal("fetch", fetchImpl);
+
+    const outputs = mcpAppCellsToSharedOutputs(
+      [
+        cellWithOutputs([
+          {
+            output_id: "large-image-output",
+            output_type: "display_data",
+            data: {
+              "image/png": "http://localhost:47830/blob/large-image-hash",
+            },
+          },
+        ]),
+      ],
+      "http://localhost:47830",
+    );
+
+    const [payload] = await resolveEmbeddableOutputs(outputs, {
+      blobResolver: createMcpAppBlobResolver("http://localhost:47830", {
+        inlineRasterImageBlobs: true,
+      }),
+    });
+
+    expect(payload).toMatchObject({
+      mimeType: "image/png",
+      data: "http://localhost:47830/blob/large-image-hash",
+      outputId: "large-image-output",
+    });
+  });
+
+  it("does not data-URI inline blob-backed HTML outputs", async () => {
+    const fetchImpl = vi.fn(async () => {
+      return new Response("<button>interactive</button>", {
+        headers: {
+          "content-length": "28",
+          "content-type": "text/html",
+        },
+      });
+    });
+    vi.stubGlobal("fetch", fetchImpl);
+
+    const outputs = mcpAppCellsToSharedOutputs(
+      [
+        cellWithOutputs([
+          {
+            output_id: "html-output",
+            output_type: "display_data",
+            data: {
+              "text/html": "http://localhost:47830/blob/html-hash",
+            },
+          },
+        ]),
+      ],
+      "http://localhost:47830",
+    );
+
+    const [payload] = await resolveEmbeddableOutputs(outputs, {
+      blobResolver: createMcpAppBlobResolver("http://localhost:47830", {
+        inlineRasterImageBlobs: true,
+      }),
+    });
+
+    expect(payload).toMatchObject({
+      mimeType: "text/html",
+      data: "<button>interactive</button>",
+      outputId: "html-output",
+    });
+    expect(String(payload.data)).not.toMatch(/^data:text\/html/);
   });
 
   it("synthesizes stable output ids for legacy MCP structured content", () => {

--- a/src/components/isolated/daemon-renderer-assets.ts
+++ b/src/components/isolated/daemon-renderer-assets.ts
@@ -131,6 +131,24 @@ export function daemonOutputFrameUrl(
   return frameDomainsAllowUrl(hostCsp.frameDomains, url) ? url : null;
 }
 
+export function daemonOutputFrameBlockedByHostCsp(
+  blobBaseUrl: string | undefined,
+  hostCsp?: DaemonRendererAssetCsp | null,
+): boolean {
+  if (!blobBaseUrl || !hostCsp) return false;
+  const url = `${trimTrailingSlash(blobBaseUrl)}/output-frame`;
+  return !frameDomainsAllowUrl(hostCsp.frameDomains, url);
+}
+
+export function daemonOutputFrameOrigin(blobBaseUrl: string | undefined): string | null {
+  if (!blobBaseUrl) return null;
+  try {
+    return new URL(`${trimTrailingSlash(blobBaseUrl)}/output-frame`).origin;
+  } catch {
+    return null;
+  }
+}
+
 export function daemonRendererAssetsBaseUrl(blobBaseUrl: string | undefined): string | undefined {
   if (!blobBaseUrl) return undefined;
   return `${trimTrailingSlash(blobBaseUrl)}/plugins/`;

--- a/src/components/isolated/mcp-app-output-frame.tsx
+++ b/src/components/isolated/mcp-app-output-frame.tsx
@@ -25,6 +25,7 @@ export interface McpAppOutputFrameProps {
   rendererPluginLoader?: NteractOutputRendererPluginLoader;
   rendererAssetsBaseUrl?: string;
   outputDocumentUrl?: string | null;
+  inlineRasterBlobImages?: boolean;
   autoHeight?: boolean;
   maxHeight?: number;
   className?: string;
@@ -47,6 +48,7 @@ export function McpAppOutputFrame({
   rendererPluginLoader,
   rendererAssetsBaseUrl,
   outputDocumentUrl,
+  inlineRasterBlobImages,
   autoHeight,
   maxHeight,
   className,
@@ -62,8 +64,13 @@ export function McpAppOutputFrame({
     [outputCells, blobBaseUrl],
   );
   const blobResolver = useMemo(
-    () => (blobBaseUrl ? createMcpAppBlobResolver(blobBaseUrl) : createInlineOnlyBlobResolver()),
-    [blobBaseUrl],
+    () =>
+      blobBaseUrl
+        ? createMcpAppBlobResolver(blobBaseUrl, {
+            inlineRasterImageBlobs: inlineRasterBlobImages,
+          })
+        : createInlineOnlyBlobResolver(),
+    [blobBaseUrl, inlineRasterBlobImages],
   );
   const hostContextPatch = useMemo(
     () =>

--- a/src/components/isolated/mcp-app-output-frame.tsx
+++ b/src/components/isolated/mcp-app-output-frame.tsx
@@ -144,7 +144,7 @@ export function McpAppOutputFrame({
       setFailed(true);
       onErrorRef.current?.(details);
     });
-  }, [failed, outputs]);
+  }, [blobResolver, failed, outputDocumentUrl, outputs]);
 
   useEffect(() => {
     hostContextPatchRef.current = hostContextPatch;

--- a/src/components/isolated/mcp-app-structured-content.ts
+++ b/src/components/isolated/mcp-app-structured-content.ts
@@ -36,7 +36,15 @@ export interface McpSharedOutputInputs {
   resolveOptions: ResolveEmbeddableOutputsOptions;
 }
 
+export const MCP_APP_INLINE_RASTER_IMAGE_MAX_BYTES = 256 * 1024;
+
 const COLLAPSED_PREVIEW_MIME_TYPES = new Set(["text/plain", "text/llm+plain", "application/json"]);
+const INLINE_RASTER_IMAGE_MIME_TYPES = new Set([
+  "image/png",
+  "image/jpeg",
+  "image/webp",
+  "image/gif",
+]);
 
 function trimTrailingSlash(value: string): string {
   return value.endsWith("/") ? value.slice(0, -1) : value;
@@ -219,11 +227,87 @@ export function mcpAppCellPreviewText(cell: McpAppCellData): string {
   return cell.status || "";
 }
 
-export function createMcpAppBlobResolver(blobBaseUrl: string): OutputBlobResolver {
+interface McpAppBlobResolverOptions {
+  inlineRasterImageBlobs?: boolean;
+  maxInlineImageBytes?: number;
+}
+
+function parseContentLength(value: string | null): number | null {
+  if (!value) return null;
+  const parsed = Number(value);
+  return Number.isFinite(parsed) && parsed >= 0 ? parsed : null;
+}
+
+function bytesToBase64(bytes: Uint8Array): string {
+  let binary = "";
+  const chunkSize = 0x8000;
+  for (let offset = 0; offset < bytes.length; offset += chunkSize) {
+    binary += String.fromCharCode(...bytes.subarray(offset, offset + chunkSize));
+  }
+  return btoa(binary);
+}
+
+export function createMcpAppBlobResolver(
+  blobBaseUrl: string,
+  options: McpAppBlobResolverOptions = {},
+): OutputBlobResolver {
   const base = trimTrailingSlash(blobBaseUrl);
   const url = (ref: { blob: string }) => `${base}/blob/${encodeURIComponent(ref.blob)}`;
+  const maxInlineImageBytes = options.maxInlineImageBytes ?? MCP_APP_INLINE_RASTER_IMAGE_MAX_BYTES;
+  const displayUrlCache = new Map<string, Promise<string>>();
+
+  async function inlineRasterImageDisplayUrl(
+    ref: { blob: string; size?: number; media_type?: string },
+    mediaType?: string,
+  ): Promise<string> {
+    const resolvedUrl = url(ref);
+    const imageMimeType = mediaType ?? ref.media_type;
+    if (!imageMimeType || !INLINE_RASTER_IMAGE_MIME_TYPES.has(imageMimeType)) {
+      return resolvedUrl;
+    }
+    if (ref.size != null && ref.size > maxInlineImageBytes) {
+      return resolvedUrl;
+    }
+
+    const cacheKey = `${ref.blob}:${imageMimeType}`;
+    const cached = displayUrlCache.get(cacheKey);
+    if (cached) return cached;
+
+    const promise = (async () => {
+      try {
+        const response = await fetch(resolvedUrl);
+        if (!response.ok) return resolvedUrl;
+
+        const declaredBytes =
+          parseContentLength(response.headers.get("content-length")) ?? ref.size;
+        if (declaredBytes == null || declaredBytes > maxInlineImageBytes) {
+          void response.body?.cancel().catch(() => {});
+          return resolvedUrl;
+        }
+
+        const bytes = new Uint8Array(await response.arrayBuffer());
+        if (bytes.byteLength > maxInlineImageBytes) {
+          return resolvedUrl;
+        }
+
+        return `data:${imageMimeType};base64,${bytesToBase64(bytes)}`;
+      } catch {
+        return resolvedUrl;
+      }
+    })();
+
+    displayUrlCache.set(cacheKey, promise);
+    return promise;
+  }
+
   return {
     url,
+    ...(options.inlineRasterImageBlobs
+      ? {
+          displayUrl: inlineRasterImageDisplayUrl,
+          resolvesBinaryUrlsSynchronously: false,
+        }
+      : { resolvesBinaryUrlsSynchronously: true }),
     fetch(ref) {
       return fetch(url(ref));
     },

--- a/src/components/isolated/mcp-app-structured-content.ts
+++ b/src/components/isolated/mcp-app-structured-content.ts
@@ -280,7 +280,7 @@ export function createMcpAppBlobResolver(
 
         const declaredBytes =
           parseContentLength(response.headers.get("content-length")) ?? ref.size;
-        if (declaredBytes == null || declaredBytes > maxInlineImageBytes) {
+        if (declaredBytes != null && declaredBytes > maxInlineImageBytes) {
           void response.body?.cancel().catch(() => {});
           return resolvedUrl;
         }


### PR DESCRIPTION
## Summary

- warn MCP App hosts when daemon output frames are unavailable because `frameDomains` does not grant the daemon blob origin
- fall back to data URI rendering for small static raster image blobs when the app has to use `srcdoc`
- keep large raster images, HTML, widgets, and other interactive or binary outputs on the existing non-inline paths

## Verification

- `cargo xtask lint --fix`
- `pnpm test:run apps/mcp-app/src src/components/isolated/__tests__`
- `pnpm test:run src/isolated-renderer/__tests__`
- `git diff --check`

## Notes

This remains a draft while CI runs. The host-side fix is still to include the daemon blob/output-frame origin in MCP Apps `hostCapabilities.sandbox.csp.frameDomains`.
