### PR TITLE
feat(notebook-cloud): surface active compute on notebook home

### DIFF
--- a/apps/notebook-cloud/src/cloudflare-types.ts
+++ b/apps/notebook-cloud/src/cloudflare-types.ts
@@ -1,5 +1,6 @@
 export interface Env {
   NOTEBOOK_ROOMS: DurableObjectNamespace;
+  OWNER_COMPUTE_INDEX?: DurableObjectNamespace;
   WORKSTATION_EVENTS?: DurableObjectNamespace;
   DB?: D1Database;
   NOTEBOOK_SNAPSHOTS?: R2Bucket;

--- a/apps/notebook-cloud/src/compute-session-index.ts
+++ b/apps/notebook-cloud/src/compute-session-index.ts
@@ -1,0 +1,252 @@
+import type { DurableObjectNamespace, DurableObjectState, Env } from "./cloudflare-types.ts";
+import { isNotebookComputeSessionSummary, type NotebookComputeSessionSummary } from "runtimed";
+import { json } from "./http-responses.ts";
+import { cloudLog, errorMessage } from "./observability.ts";
+
+const COMPUTE_SESSION_KEY_PREFIX = "session:";
+const OWNER_COMPUTE_INDEX_OBJECT_PREFIX = "owner-compute:v1:";
+const MAX_NOTEBOOK_IDS_PER_LIST = 500;
+
+export class OwnerComputeIndex {
+  constructor(
+    private readonly state: DurableObjectState,
+    private readonly env: Env,
+  ) {
+    void this.env;
+  }
+
+  async fetch(request: Request): Promise<Response> {
+    const url = new URL(request.url);
+    if (request.method === "POST" && url.pathname === "/upsert") {
+      return this.handleUpsert(request);
+    }
+    if (request.method === "POST" && url.pathname === "/delete") {
+      return this.handleDelete(request);
+    }
+    if (request.method === "POST" && url.pathname === "/list") {
+      return this.handleList(request);
+    }
+    return json({ error: "not found" }, 404);
+  }
+
+  private async handleUpsert(request: Request): Promise<Response> {
+    const payload = await readJsonObject(request);
+    if (payload instanceof Response) {
+      return payload;
+    }
+    const summary = payload.summary;
+    if (!isNotebookComputeSessionSummary(summary)) {
+      return json({ error: "summary must be a valid notebook compute session summary" }, 400);
+    }
+
+    await this.state.storage.put(sessionKey(summary.notebook_id), summary);
+    return json({ ok: true });
+  }
+
+  private async handleDelete(request: Request): Promise<Response> {
+    const payload = await readJsonObject(request);
+    if (payload instanceof Response) {
+      return payload;
+    }
+    const notebookId = boundedString(payload.notebook_id ?? payload.notebookId, 160);
+    if (!notebookId) {
+      return json({ error: "notebook_id is required" }, 400);
+    }
+    await this.state.storage.delete(sessionKey(notebookId));
+    return json({ ok: true });
+  }
+
+  private async handleList(request: Request): Promise<Response> {
+    const payload = await readJsonObject(request);
+    if (payload instanceof Response) {
+      return payload;
+    }
+    const notebookIds = notebookIdsFromPayload(payload.notebook_ids ?? payload.notebookIds);
+    if (!notebookIds) {
+      return json({ error: "notebook_ids must be an array of notebook ids" }, 400);
+    }
+
+    const summaries: NotebookComputeSessionSummary[] = [];
+    await Promise.all(
+      notebookIds.map(async (notebookId) => {
+        const summary = await this.state.storage.get<unknown>(sessionKey(notebookId));
+        if (isNotebookComputeSessionSummary(summary)) {
+          summaries.push(summary);
+        }
+      }),
+    );
+    summaries.sort((left, right) => left.notebook_id.localeCompare(right.notebook_id));
+    return json({ ok: true, sessions: summaries });
+  }
+}
+
+export function ownerComputeIndexObjectName(ownerPrincipal: string): string {
+  return `${OWNER_COMPUTE_INDEX_OBJECT_PREFIX}${ownerPrincipal}`;
+}
+
+export async function upsertOwnerComputeSession(
+  env: Env,
+  summary: NotebookComputeSessionSummary,
+): Promise<boolean> {
+  const namespace = env.OWNER_COMPUTE_INDEX;
+  if (!namespace) {
+    return false;
+  }
+  return fetchOwnerComputeIndex(namespace, summary.owner_principal, "/upsert", { summary });
+}
+
+export async function deleteOwnerComputeSession(
+  env: Env,
+  ownerPrincipal: string,
+  notebookId: string,
+): Promise<boolean> {
+  const namespace = env.OWNER_COMPUTE_INDEX;
+  if (!namespace) {
+    return false;
+  }
+  return fetchOwnerComputeIndex(namespace, ownerPrincipal, "/delete", {
+    notebook_id: notebookId,
+  });
+}
+
+export async function listOwnerComputeSessions(
+  env: Env,
+  ownerPrincipal: string,
+  notebookIds: readonly string[],
+): Promise<Map<string, NotebookComputeSessionSummary>> {
+  const namespace = env.OWNER_COMPUTE_INDEX;
+  if (!namespace || notebookIds.length === 0) {
+    return new Map();
+  }
+  const boundedIds = Array.from(new Set(notebookIds.map((id) => id.trim()).filter(Boolean))).slice(
+    0,
+    MAX_NOTEBOOK_IDS_PER_LIST,
+  );
+  if (boundedIds.length === 0) {
+    return new Map();
+  }
+  try {
+    const response = await ownerComputeIndexStub(namespace, ownerPrincipal).fetch(
+      new Request("https://owner-compute-index.internal/list", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ notebook_ids: boundedIds }),
+      }),
+    );
+    if (!response.ok) {
+      cloudLog("warn", "owner_compute_index.list_failed", {
+        owner_principal: ownerPrincipal,
+        response_status: response.status,
+        counter: "owner_compute_index_list_failed",
+        counter_delta: 1,
+      });
+      return new Map();
+    }
+    const body = (await response.json()) as unknown;
+    if (
+      !body ||
+      typeof body !== "object" ||
+      !Array.isArray((body as { sessions?: unknown }).sessions)
+    ) {
+      return new Map();
+    }
+    const sessions = new Map<string, NotebookComputeSessionSummary>();
+    for (const session of (body as { sessions: unknown[] }).sessions) {
+      if (isNotebookComputeSessionSummary(session)) {
+        sessions.set(session.notebook_id, session);
+      }
+    }
+    return sessions;
+  } catch (error) {
+    cloudLog("warn", "owner_compute_index.list_failed", {
+      owner_principal: ownerPrincipal,
+      error: errorMessage(error),
+      counter: "owner_compute_index_list_failed",
+      counter_delta: 1,
+    });
+    return new Map();
+  }
+}
+
+function ownerComputeIndexStub(namespace: DurableObjectNamespace, ownerPrincipal: string) {
+  const id = namespace.idFromName(ownerComputeIndexObjectName(ownerPrincipal));
+  return namespace.get(id);
+}
+
+async function fetchOwnerComputeIndex(
+  namespace: DurableObjectNamespace,
+  ownerPrincipal: string,
+  pathname: "/upsert" | "/delete",
+  body: Record<string, unknown>,
+): Promise<boolean> {
+  try {
+    const response = await ownerComputeIndexStub(namespace, ownerPrincipal).fetch(
+      new Request(`https://owner-compute-index.internal${pathname}`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(body),
+      }),
+    );
+    if (response.ok) {
+      return true;
+    }
+    cloudLog("warn", "owner_compute_index.write_failed", {
+      owner_principal: ownerPrincipal,
+      pathname,
+      response_status: response.status,
+      counter: "owner_compute_index_write_failed",
+      counter_delta: 1,
+    });
+  } catch (error) {
+    cloudLog("warn", "owner_compute_index.write_failed", {
+      owner_principal: ownerPrincipal,
+      pathname,
+      error: errorMessage(error),
+      counter: "owner_compute_index_write_failed",
+      counter_delta: 1,
+    });
+  }
+  return false;
+}
+
+function sessionKey(notebookId: string): string {
+  return `${COMPUTE_SESSION_KEY_PREFIX}${notebookId}`;
+}
+
+async function readJsonObject(request: Request): Promise<Record<string, unknown> | Response> {
+  let value: unknown;
+  try {
+    value = await request.json();
+  } catch {
+    return json({ error: "body must be JSON" }, 400);
+  }
+  if (!value || typeof value !== "object" || Array.isArray(value)) {
+    return json({ error: "body must be a JSON object" }, 400);
+  }
+  return value as Record<string, unknown>;
+}
+
+function notebookIdsFromPayload(value: unknown): string[] | null {
+  if (!Array.isArray(value)) {
+    return null;
+  }
+  const ids: string[] = [];
+  for (const entry of value) {
+    const id = boundedString(entry, 160);
+    if (id) {
+      ids.push(id);
+    }
+    if (ids.length >= MAX_NOTEBOOK_IDS_PER_LIST) {
+      break;
+    }
+  }
+  return ids;
+}
+
+function boundedString(value: unknown, maxLength: number): string | null {
+  if (typeof value !== "string") {
+    return null;
+  }
+  const trimmed = value.trim();
+  return trimmed ? trimmed.slice(0, maxLength) : null;
+}

--- a/apps/notebook-cloud/src/index.ts
+++ b/apps/notebook-cloud/src/index.ts
@@ -5,6 +5,7 @@ import type {
   ExportedHandler,
   WorkerAssets,
 } from "./cloudflare-types.ts";
+import type { NotebookComputeSessionSummary } from "runtimed";
 import { projectNotebookWorkstationAttachmentFromClaim, type BlobRef } from "runtimed";
 import { NotebookRoom } from "./notebook-room.ts";
 import {
@@ -81,6 +82,7 @@ import {
   workstationEventsObjectName,
   type WorkstationAttachJobNotification,
 } from "./workstation-events.ts";
+import { OwnerComputeIndex, listOwnerComputeSessions } from "./compute-session-index.ts";
 import { materializeSnapshotPairRender } from "./snapshot-render.ts";
 import { notebookRouteSegmentTitle } from "./notebook-route-title.ts";
 import {
@@ -151,7 +153,7 @@ import {
   trustsLoopbackRequestHeaders,
 } from "./loopback.ts";
 
-export { NotebookRoom, WorkstationEvents };
+export { NotebookRoom, WorkstationEvents, OwnerComputeIndex };
 
 // `/plugins/*` is a raw static asset path in deployed Workers. Use a
 // Worker-owned route by default so sandboxed srcdoc iframes can fetch sidecar
@@ -1167,20 +1169,53 @@ async function routeListNotebooks(request: Request, env: Env): Promise<Response>
   }
 
   const notebooks = await listNotebooksForPrincipal(env, principal, limit);
+  const computeSessions = await listNotebookComputeSessionsForOwnedRows(env, notebooks);
   return json({
     ok: true,
-    notebooks: notebookListResponseRows(request, notebooks, env),
+    notebooks: notebookListResponseRows(request, notebooks, env, computeSessions),
   });
+}
+
+async function listNotebookComputeSessionsForOwnedRows(
+  env: Env,
+  notebooks: readonly ListedNotebookRow[],
+): Promise<Map<string, NotebookComputeSessionSummary>> {
+  const idsByOwner = new Map<string, string[]>();
+  for (const notebook of notebooks) {
+    if (notebook.scope !== "owner") {
+      continue;
+    }
+    const ids = idsByOwner.get(notebook.owner_principal) ?? [];
+    ids.push(notebook.id);
+    idsByOwner.set(notebook.owner_principal, ids);
+  }
+  const entries = await Promise.all(
+    Array.from(idsByOwner, async ([ownerPrincipal, notebookIds]) =>
+      listOwnerComputeSessions(env, ownerPrincipal, notebookIds),
+    ),
+  );
+  const sessions = new Map<string, NotebookComputeSessionSummary>();
+  for (const ownerSessions of entries) {
+    for (const [notebookId, session] of ownerSessions) {
+      sessions.set(notebookId, session);
+    }
+  }
+  return sessions;
 }
 
 function notebookListResponseRows(
   request: Request,
   notebooks: ListedNotebookRow[],
   env?: Env,
+  computeSessions: ReadonlyMap<string, NotebookComputeSessionSummary> = new Map(),
 ): Array<Record<string, unknown>> {
   return notebooks.map((notebook) => {
     const notebookPathId = encodeURIComponent(notebook.id);
     const apiBasePath = `/api/n/${notebookPathId}`;
+    const computeSession =
+      notebook.owner_principal === computeSessions.get(notebook.id)?.owner_principal
+        ? computeSessions.get(notebook.id)
+        : null;
     return {
       notebook_id: notebook.id,
       title: notebook.title,
@@ -1189,6 +1224,7 @@ function notebookListResponseRows(
       created_at: notebook.created_at,
       updated_at: notebook.updated_at,
       latest_revision_id: notebook.latest_revision_id,
+      compute_session: computeSession,
       viewer_url: viewerUrlForRequest(request, notebook.id, notebook.title, env),
       endpoints: {
         catalog: apiBasePath,
@@ -4867,10 +4903,11 @@ async function notebookListBootstrap(
     session.principal,
     DEFAULT_NOTEBOOK_LIST_LIMIT,
   );
+  const computeSessions = await listNotebookComputeSessionsForOwnedRows(env, notebooks);
   return {
     kind: "notebook-list",
     session: appSessionResponse(session),
-    notebooks: notebookListResponseRows(request, notebooks, env),
+    notebooks: notebookListResponseRows(request, notebooks, env, computeSessions),
     saved_at: new Date().toISOString(),
   };
 }

--- a/apps/notebook-cloud/src/notebook-room.ts
+++ b/apps/notebook-cloud/src/notebook-room.ts
@@ -4,7 +4,8 @@ import type {
   Env,
   WebSocketRequestResponsePair,
 } from "./cloudflare-types.ts";
-import type { WorkstationAttachmentState } from "runtimed";
+import { projectNotebookComputeSessionSummary, type WorkstationAttachmentState } from "runtimed";
+import { deleteOwnerComputeSession, upsertOwnerComputeSession } from "./compute-session-index.ts";
 import { identityDisplayLabel } from "./display-label.ts";
 import {
   allowsBlobUpload,
@@ -41,6 +42,7 @@ import {
   type SyncFrameBudgetDirection,
   type SyncFrameBudgetSummary,
 } from "./sync-frame-budget.ts";
+import { getNotebookRow } from "./storage.ts";
 
 interface Peer {
   id: string;
@@ -422,6 +424,7 @@ export class NotebookRoom {
           suppressRuntimePeerWatch: true,
         });
       }
+      this.state.waitUntil(this.publishCurrentComputeSessionSummary(notebookId, attachment));
       if (result.changed) {
         this.deliverRoomHostFrames(notebookId, result);
       }
@@ -501,6 +504,7 @@ export class NotebookRoom {
       if (result.changed) {
         this.deliverRoomHostFrames(notebookId, result);
       }
+      this.state.waitUntil(this.publishCurrentComputeSessionSummary(notebookId));
       const checkpointPersisted = result.changed
         ? await this.checkpointRoomHost(notebookId, materializer, "runtime_state_repair")
         : true;
@@ -1281,6 +1285,7 @@ export class NotebookRoom {
         this.deliverRoomHostFrames(notebookId, result);
         await this.checkpointRoomHost(notebookId, materializer, "runtime_peer_attachment");
       }
+      await this.publishCurrentComputeSessionSummary(notebookId, attachment);
       cloudLog("debug", "room.workstation_attachment.published", {
         notebook_id: notebookId,
         peer_id: peer.id,
@@ -1299,6 +1304,45 @@ export class NotebookRoom {
         duration_ms: durationMs(startedAt),
         error: errorMessage(error),
         counter: "workstation_attachment_publish_failed",
+        counter_delta: 1,
+      });
+    }
+  }
+
+  private async publishCurrentComputeSessionSummary(
+    notebookId: string,
+    attachment?: WorkstationAttachmentState | null,
+  ): Promise<void> {
+    if (!this.env.OWNER_COMPUTE_INDEX || !this.env.DB) {
+      return;
+    }
+    try {
+      const [notebook, currentAttachment] = await Promise.all([
+        getNotebookRow(this.env, notebookId),
+        attachment === undefined
+          ? this.materializerFor(notebookId).getWorkstationAttachment()
+          : Promise.resolve(attachment),
+      ]);
+      if (!notebook) {
+        return;
+      }
+      const summary = projectNotebookComputeSessionSummary({
+        attachment: currentAttachment,
+        notebookId,
+        ownerPrincipal: notebook.owner_principal,
+        runtimePeerCount: this.runtimePeerCount(),
+        updatedAt: new Date().toISOString(),
+      });
+      if (summary) {
+        await upsertOwnerComputeSession(this.env, summary);
+      } else {
+        await deleteOwnerComputeSession(this.env, notebook.owner_principal, notebookId);
+      }
+    } catch (error) {
+      cloudLog("warn", "room.compute_session_summary.publish_failed", {
+        notebook_id: notebookId,
+        error: errorMessage(error),
+        counter: "compute_session_summary_publish_failed",
         counter_delta: 1,
       });
     }
@@ -1895,6 +1939,7 @@ export class NotebookRoom {
     // runtime_peer behind.
     if (peer.identity.scope === "runtime_peer" && !closeOptions.suppressRuntimePeerWatch) {
       this.refreshRuntimePeerWatch(notebookId);
+      this.state.waitUntil(this.publishCurrentComputeSessionSummary(notebookId));
     }
   }
 
@@ -2014,6 +2059,7 @@ export class NotebookRoom {
         counter: "runtime_peer_gone_recovered",
         counter_delta: 1,
       });
+      this.state.waitUntil(this.publishCurrentComputeSessionSummary(notebookId));
       return;
     }
 
@@ -2030,6 +2076,7 @@ export class NotebookRoom {
           "runtime_peer_watch_reconcile",
         );
       }
+      this.state.waitUntil(this.publishCurrentComputeSessionSummary(notebookId));
       cloudLog("info", "room.runtime_peer_watch.reconciled", {
         notebook_id: notebookId,
         changed: result.changed,

--- a/apps/notebook-cloud/test/compute-session-index.test.ts
+++ b/apps/notebook-cloud/test/compute-session-index.test.ts
@@ -1,0 +1,110 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+import type { DurableObjectState, Env } from "../src/cloudflare-types.ts";
+import { OwnerComputeIndex, ownerComputeIndexObjectName } from "../src/compute-session-index.ts";
+import type { NotebookComputeSessionSummary } from "runtimed";
+
+describe("OwnerComputeIndex", () => {
+  it("stores and lists compute sessions by requested notebook ids", async () => {
+    const object = new OwnerComputeIndex(fakeState(), {} as Env);
+    const summary = computeSummary("topic-viz");
+
+    const upsert = await object.fetch(
+      new Request("https://compute.internal/upsert", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ summary }),
+      }),
+    );
+    assert.equal(upsert.status, 200);
+
+    const list = await object.fetch(
+      new Request("https://compute.internal/list", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ notebook_ids: ["missing", "topic-viz"] }),
+      }),
+    );
+
+    assert.equal(list.status, 200);
+    assert.deepEqual(await list.json(), {
+      ok: true,
+      sessions: [summary],
+    });
+  });
+
+  it("rejects malformed summaries and deletes notebook entries", async () => {
+    const object = new OwnerComputeIndex(fakeState(), {} as Env);
+    const invalid = await object.fetch(
+      new Request("https://compute.internal/upsert", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ summary: { notebook_id: "topic-viz" } }),
+      }),
+    );
+    assert.equal(invalid.status, 400);
+
+    await object.fetch(
+      new Request("https://compute.internal/upsert", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ summary: computeSummary("topic-viz") }),
+      }),
+    );
+    const deleted = await object.fetch(
+      new Request("https://compute.internal/delete", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ notebook_id: "topic-viz" }),
+      }),
+    );
+    assert.equal(deleted.status, 200);
+
+    const list = await object.fetch(
+      new Request("https://compute.internal/list", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ notebook_ids: ["topic-viz"] }),
+      }),
+    );
+    assert.deepEqual(await list.json(), { ok: true, sessions: [] });
+  });
+
+  it("uses deterministic per-owner object names", () => {
+    assert.equal(ownerComputeIndexObjectName("user:dev:alice"), "owner-compute:v1:user:dev:alice");
+  });
+});
+
+function computeSummary(notebookId: string): NotebookComputeSessionSummary {
+  return {
+    environment_label: "Current Python",
+    last_runtime_seen_at: "2026-06-23T00:00:00.000Z",
+    notebook_id: notebookId,
+    owner_principal: "user:dev:alice",
+    queue_depth: 0,
+    runtime_peer_count: 1,
+    runtime_session_id: "job-1",
+    status: "active",
+    status_message: null,
+    updated_at: "2026-06-23T00:00:00.000Z",
+    working_directory: "/home/ubuntu/project",
+    workstation_display_name: "lab2 workstation",
+    workstation_id: "ws-lab2",
+  };
+}
+
+function fakeState(): DurableObjectState {
+  const values = new Map<string, unknown>();
+  return {
+    id: { toString: () => "owner-compute" },
+    storage: {
+      get: async <T>(key: string) => values.get(key) as T | undefined,
+      put: async <T>(key: string, value: T) => {
+        values.set(key, value);
+      },
+      delete: async (key: string) => values.delete(key),
+      list: async <T>() => new Map(values as Map<string, T>),
+    },
+    waitUntil: () => undefined,
+  };
+}

--- a/apps/notebook-cloud/test/notebook-dashboard.test.ts
+++ b/apps/notebook-cloud/test/notebook-dashboard.test.ts
@@ -627,6 +627,65 @@ describe("cloud notebook dashboard projection", () => {
     assert.equal(generatedView.sections[0]?.notebooks.length, 7);
     assert.equal(generatedView.sections[0]?.overflowAction, null);
   });
+
+  it("surfaces active compute as a row fact and drill-in filter", () => {
+    const active = notebook({
+      id: "topic-viz",
+      title: "Topic Visualization",
+      scope: "owner",
+      updatedAt: "2026-06-23T00:00:00.000Z",
+      latestRevisionId: null,
+      computeSession: {
+        environment_label: "Current Python",
+        last_runtime_seen_at: "2026-06-23T00:00:00.000Z",
+        notebook_id: "topic-viz",
+        owner_principal: "user:dev:alice",
+        queue_depth: 1,
+        runtime_peer_count: 1,
+        runtime_session_id: "job-1",
+        status: "active",
+        status_message: null,
+        updated_at: "2026-06-23T00:00:00.000Z",
+        working_directory: "/home/ubuntu/project",
+        workstation_display_name: "lab2 workstation",
+        workstation_id: "ws-lab2",
+      },
+    });
+    const idle = notebook({
+      id: "notes",
+      title: "Notes",
+      scope: "owner",
+      updatedAt: "2026-06-22T00:00:00.000Z",
+      latestRevisionId: null,
+    });
+
+    const model = projectCloudNotebookDashboard([idle, active]);
+    const computeView = projectCloudNotebookDashboardView(model, { filterId: "compute" });
+
+    assert.deepEqual(
+      model.filters.map((filter) => [filter.id, filter.count]),
+      [
+        ["all", 2],
+        ["owned", 2],
+        ["compute", 1],
+      ],
+    );
+    assert.deepEqual(model.continueRow?.facts, [
+      {
+        kind: "compute",
+        label: "lab2 workstation running, 1 queued",
+        tone: "active",
+      },
+    ]);
+    assert.deepEqual(
+      computeView.sections.map((section) => [
+        section.id,
+        section.title,
+        section.notebooks.map((item) => item.notebook_id),
+      ]),
+      [["compute", "Active compute", ["topic-viz"]]],
+    );
+  });
 });
 
 function notebook(input: {
@@ -635,6 +694,7 @@ function notebook(input: {
   scope: CloudNotebookListItem["scope"];
   updatedAt: string;
   latestRevisionId: string | null;
+  computeSession?: CloudNotebookListItem["compute_session"];
 }): CloudNotebookListItem {
   return {
     notebook_id: input.id,
@@ -644,6 +704,7 @@ function notebook(input: {
     created_at: "2026-05-01T00:00:00.000Z",
     updated_at: input.updatedAt,
     latest_revision_id: input.latestRevisionId,
+    compute_session: input.computeSession ?? null,
     viewer_url: `/n/${input.id}/notebook`,
     endpoints: {
       catalog: `/api/n/${input.id}`,

--- a/apps/notebook-cloud/test/notebook-room.test.ts
+++ b/apps/notebook-cloud/test/notebook-room.test.ts
@@ -1,6 +1,14 @@
 import { before, describe, it } from "node:test";
 import assert from "node:assert/strict";
-import type { CloudflareWebSocket, DurableObjectState, Env } from "../src/cloudflare-types.ts";
+import type {
+  CloudflareWebSocket,
+  D1Database,
+  D1PreparedStatement,
+  D1Result,
+  DurableObjectNamespace,
+  DurableObjectState,
+  Env,
+} from "../src/cloudflare-types.ts";
 import {
   NOTEBOOK_CLOUD_WEBSOCKET_PROTOCOL,
   TRUSTED_WEBSOCKET_PROTOCOL_HEADER,
@@ -1054,7 +1062,8 @@ describe("NotebookRoom peer lifecycle", () => {
 
   it("disconnects runtime peers when replacement workstation attachment control is published", async () => {
     const state = alarmCapableState();
-    const room = new NotebookRoom(state.state, {} as Env);
+    const compute = new FakeOwnerComputeIndexNamespace();
+    const room = new NotebookRoom(state.state, roomEnvWithComputeIndex(compute));
     const harness = roomHarness(room);
     const runtimeSocket = new FakeSocket();
     const runtimePeer = {
@@ -1110,6 +1119,16 @@ describe("NotebookRoom peer lifecycle", () => {
     assert.equal(runtimeSocket.closeCode, 1012);
     assert.equal(runtimeSocket.closeReason, "workstation restart requested");
     assert.equal(await state.getAlarm(), null, "intentional replacement does not arm stale repair");
+    assert.deepEqual(
+      compute.requests.map((request) => [
+        request.objectName,
+        new URL(request.url).pathname,
+        request.body?.summary?.status,
+        request.body?.summary?.runtime_peer_count,
+        request.body?.summary?.workstation_id,
+      ]),
+      [["owner-compute:v1:user:dev:alice", "/upsert", "starting", 0, "ws-lab2"]],
+    );
   });
 
   it("disconnects anonymous viewers when public link access is revoked", async () => {
@@ -1667,6 +1686,15 @@ describe("NotebookRoom materialized sync routing", () => {
       connectedAt: "2026-05-22T00:00:00.000Z",
     };
     const harness = roomHarness(room);
+    harness.peers.set("runtime", {
+      ...peer,
+      id: "runtime",
+      identity: authenticateDevRequest(
+        new Request(
+          "https://cloud.test/n/demo/sync?user=alice&operator=runtime:py&scope=runtime_peer",
+        ),
+      ),
+    });
     let materialized = 0;
     harness.materializers.set("demo", {
       receiveFrame: async () => {
@@ -2795,6 +2823,83 @@ describe("NotebookRoom runtime_peer-gone watchdog", () => {
     assert.equal(reconcileCalls, 1, "alarm reconciles the orphaned room");
   });
 
+  it("publishes active runtime peers to the owner compute index", async () => {
+    const compute = new FakeOwnerComputeIndexNamespace();
+    const env = roomEnvWithComputeIndex(compute);
+    const room = new NotebookRoom(fakeState(), env);
+    const harness = roomHarness(room);
+    const runtimePeer = {
+      ...peerWithScope("rt", "runtime_peer"),
+      workstation: {
+        workstationId: "ws-lab2",
+        displayName: "lab2 workstation",
+        defaultEnvironmentLabel: "Current Python",
+        environmentPolicy: "current_python",
+        runtimeSessionId: "job-1",
+        workingDirectory: "/home/ubuntu/project",
+      },
+    };
+    harness.peers.set(runtimePeer.id, runtimePeer);
+    harness.materializers.set("demo", {
+      receiveFrame: async () => noopMaterializedResult(),
+      checkpoint: async () => undefined,
+      setWorkstationAttachment: async () => ({
+        ...noopMaterializedResult(),
+        changed: true,
+        runtime_state_changed: true,
+      }),
+    } as never);
+
+    await harness.publishRuntimePeerAttachment("demo", runtimePeer);
+
+    assert.deepEqual(
+      compute.requests.map((request) => [
+        request.objectName,
+        new URL(request.url).pathname,
+        request.body?.summary?.status,
+        request.body?.summary?.runtime_peer_count,
+        request.body?.summary?.workstation_id,
+      ]),
+      [["owner-compute:v1:user:dev:alice", "/upsert", "active", 1, "ws-lab2"]],
+    );
+  });
+
+  it("publishes stale compute when the last runtime peer leaves", async () => {
+    const state = hibernatedState([]);
+    const compute = new FakeOwnerComputeIndexNamespace();
+    const env = roomEnvWithComputeIndex(compute);
+    const room = new NotebookRoom(state.state, env);
+    const harness = roomHarness(room);
+    const runtimePeer = peerWithScope("rt", "runtime_peer");
+    harness.peers.set(runtimePeer.id, runtimePeer);
+    harness.materializers.set("demo", {
+      receiveFrame: async () => noopMaterializedResult(),
+      checkpoint: async () => undefined,
+      getWorkstationAttachment: async () => ({
+        workstation_id: "ws-lab2",
+        display_name: "lab2 workstation",
+        provider: "runtime_peer",
+        default_environment_label: "Current Python",
+        environment_policy: "current_python",
+        status: "ready",
+        status_message: null,
+        updated_at: "2026-06-23T00:00:00.000Z",
+        runtime_session_id: "job-1",
+      }),
+      removePeer: async () => undefined,
+      reconcileRuntimePeerGone: async () => noopMaterializedResult(),
+    } as never);
+
+    harness.removePeer("demo", runtimePeer);
+    await state.drain();
+
+    const staleRequest = compute.requests.find(
+      (request) => request.body?.summary?.status === "stale",
+    );
+    assert.equal(staleRequest?.objectName, "owner-compute:v1:user:dev:alice");
+    assert.equal(staleRequest?.body?.summary?.runtime_peer_count, 0);
+  });
+
   it("disarms (no reconcile) when a runtime_peer rejoins within the grace window", async () => {
     const state = alarmCapableState();
     const room = new NotebookRoom(state.state, {} as Env);
@@ -3065,6 +3170,99 @@ function fakeState(): DurableObjectState {
     },
     waitUntil: () => undefined,
   };
+}
+
+function roomEnvWithComputeIndex(computeIndex: DurableObjectNamespace): Env {
+  return {
+    DB: new NotebookOwnerD1(),
+    NOTEBOOK_ROOMS: {
+      idFromName: (name: string) => ({ toString: () => name }),
+      get: () => ({
+        fetch: async () => new Response("not implemented", { status: 501 }),
+      }),
+    },
+    OWNER_COMPUTE_INDEX: computeIndex,
+  } as Env;
+}
+
+interface FakeOwnerComputeIndexRequest {
+  body: { summary?: { runtime_peer_count?: number; status?: string; workstation_id?: string } };
+  objectName: string;
+  url: string;
+}
+
+class FakeOwnerComputeIndexNamespace implements DurableObjectNamespace {
+  readonly requests: FakeOwnerComputeIndexRequest[] = [];
+
+  idFromName(name: string): { toString(): string } {
+    return { toString: () => name };
+  }
+
+  get(id: { toString(): string }) {
+    const requests = this.requests;
+    const objectName = id.toString();
+    return {
+      fetch: async (request: Request) => {
+        const body = (await request
+          .json()
+          .catch(() => ({}))) as FakeOwnerComputeIndexRequest["body"];
+        requests.push({ body, objectName, url: request.url });
+        return Response.json({ ok: true });
+      },
+    };
+  }
+}
+
+class NotebookOwnerD1 implements D1Database {
+  prepare(query: string): D1PreparedStatement {
+    return new NotebookOwnerD1Statement(query);
+  }
+
+  async exec(): Promise<D1Result> {
+    return d1OkResult();
+  }
+
+  async batch<T = unknown>(): Promise<D1Result<T>[]> {
+    return [];
+  }
+}
+
+class NotebookOwnerD1Statement implements D1PreparedStatement {
+  private values: unknown[] = [];
+
+  constructor(private readonly query: string) {}
+
+  bind(...values: unknown[]): D1PreparedStatement {
+    this.values = values;
+    return this;
+  }
+
+  async first<T = unknown>(): Promise<T | null> {
+    if (this.query.includes("FROM notebooks") && this.query.includes("WHERE id = ?")) {
+      const notebookId = String(this.values[0] ?? "demo");
+      return {
+        id: notebookId,
+        owner_principal: "user:dev:alice",
+        title: "Demo",
+        created_at: "2026-06-23T00:00:00.000Z",
+        updated_at: "2026-06-23T00:00:00.000Z",
+        latest_revision_id: null,
+      } as T;
+    }
+    return null;
+  }
+
+  async run<T = unknown>(): Promise<D1Result<T>> {
+    return d1OkResult<T>();
+  }
+
+  async all<T = unknown>(): Promise<D1Result<T>> {
+    return d1OkResult<T>([]);
+  }
+}
+
+function d1OkResult<T = unknown>(results: T[] = []): D1Result<T> {
+  return { results, success: true, meta: {} };
 }
 
 function hibernatedState(sockets: CloudflareWebSocket[]): {

--- a/apps/notebook-cloud/test/worker-routes.test.ts
+++ b/apps/notebook-cloud/test/worker-routes.test.ts
@@ -29,6 +29,7 @@ import type {
   R2ObjectBody,
   R2PutOptions,
 } from "../src/cloudflare-types.ts";
+import type { NotebookComputeSessionSummary } from "runtimed";
 import { RuntimeStatePeerHandle } from "../src/runtimed-wasm.ts";
 import {
   WORKSTATION_ATTACH_JOB_STALE_MS,
@@ -1857,6 +1858,74 @@ describe("Worker artifact routes", () => {
     assert.equal(body.notebooks[1]?.title, "Editor Shared");
     assert.equal(body.notebooks[1]?.viewer_url, "http://localhost/n/editor-shared/Editor%20Shared");
     assert.equal(body.notebooks[1]?.endpoints.catalog, "/api/n/editor-shared");
+  });
+
+  it("enriches owned notebook rows with owner-scoped compute sessions", async () => {
+    const compute = new FakeOwnerComputeIndexNamespace();
+    const env = fakeEnv({ OWNER_COMPUTE_INDEX: compute });
+    seedNotebook(env, "owned-active");
+    seedNotebook(env, "shared-active");
+    env.DB.notebooks.get("shared-active")!.owner_principal = "user:dev:bob";
+    seedAcl(env, { notebookId: "owned-active", subject: "user:dev:alice", scope: "owner" });
+    seedAcl(env, { notebookId: "shared-active", subject: "user:dev:alice", scope: "editor" });
+    compute.sessions.set("owned-active", {
+      environment_label: "Current Python",
+      last_runtime_seen_at: "2026-06-23T00:00:00.000Z",
+      notebook_id: "owned-active",
+      owner_principal: "user:dev:alice",
+      queue_depth: 0,
+      runtime_peer_count: 1,
+      runtime_session_id: "job-1",
+      status: "active",
+      status_message: null,
+      updated_at: "2026-06-23T00:00:00.000Z",
+      working_directory: "/home/ubuntu/project",
+      workstation_display_name: "lab2 workstation",
+      workstation_id: "ws-lab2",
+    });
+    compute.sessions.set("shared-active", {
+      environment_label: "Current Python",
+      last_runtime_seen_at: "2026-06-23T00:00:00.000Z",
+      notebook_id: "shared-active",
+      owner_principal: "user:dev:bob",
+      queue_depth: 0,
+      runtime_peer_count: 1,
+      runtime_session_id: "job-2",
+      status: "active",
+      status_message: null,
+      updated_at: "2026-06-23T00:00:00.000Z",
+      working_directory: "/home/bob/project",
+      workstation_display_name: "bob workstation",
+      workstation_id: "ws-bob",
+    });
+
+    const response = await worker.fetch(
+      new Request("http://localhost/api/n", {
+        headers: {
+          "X-User": "alice",
+          "X-Operator": "desktop:test",
+          "X-Scope": "viewer",
+        },
+      }),
+      env,
+      fakeContext(),
+    );
+
+    assert.equal(response.status, 200);
+    const body = (await response.json()) as {
+      notebooks: Array<{
+        compute_session?: NotebookComputeSessionSummary | null;
+        notebook_id: string;
+      }>;
+    };
+    const owned = body.notebooks.find((notebook) => notebook.notebook_id === "owned-active");
+    const shared = body.notebooks.find((notebook) => notebook.notebook_id === "shared-active");
+    assert.equal(owned?.compute_session?.workstation_id, "ws-lab2");
+    assert.equal(shared?.compute_session, null);
+    assert.deepEqual(
+      compute.requests.map((request) => [request.objectName, request.notebookIds]),
+      [["owner-compute:v1:user:dev:alice", ["owned-active"]]],
+    );
   });
 
   it("requires sign-in before listing notebooks", async () => {
@@ -6458,6 +6527,43 @@ class FakeWorkstationEventsNamespace implements DurableObjectNamespace {
           });
         }
         return Response.json({ error: "not found" }, { status: 404 });
+      },
+    };
+  }
+}
+
+interface FakeOwnerComputeIndexRequest {
+  notebookIds: string[];
+  objectName: string;
+}
+
+class FakeOwnerComputeIndexNamespace implements DurableObjectNamespace {
+  readonly requests: FakeOwnerComputeIndexRequest[] = [];
+  readonly sessions = new Map<string, NotebookComputeSessionSummary>();
+
+  idFromName(name: string): { toString(): string } {
+    return { toString: () => name };
+  }
+
+  get(id: { toString(): string }) {
+    const requests = this.requests;
+    const sessions = this.sessions;
+    const objectName = id.toString();
+    return {
+      fetch: async (request: Request) => {
+        const pathname = new URL(request.url).pathname;
+        if (pathname !== "/list") {
+          return Response.json({ error: "not found" }, { status: 404 });
+        }
+        const payload = (await request.json().catch(() => ({}))) as {
+          notebook_ids?: string[];
+        };
+        const notebookIds = Array.isArray(payload.notebook_ids) ? payload.notebook_ids : [];
+        requests.push({ objectName, notebookIds });
+        return Response.json({
+          ok: true,
+          sessions: notebookIds.map((notebookId) => sessions.get(notebookId)).filter(Boolean),
+        });
       },
     };
   }

--- a/apps/notebook-cloud/viewer/cloud-notebook-dashboard-view.tsx
+++ b/apps/notebook-cloud/viewer/cloud-notebook-dashboard-view.tsx
@@ -7,6 +7,7 @@ import {
   Loader2,
   PencilLine,
   Search,
+  Server,
   Share2,
   UserRound,
   X,
@@ -372,6 +373,15 @@ function canRenameCloudNotebook(notebook: CloudNotebookListItem): boolean {
 }
 
 function CloudNotebookDashboardFact({ fact }: { fact: CloudNotebookDashboardRowFact }) {
+  if (fact.kind === "compute") {
+    return (
+      <span data-state={fact.tone ?? "active"}>
+        <Server aria-hidden="true" />
+        {fact.label}
+      </span>
+    );
+  }
+
   if (fact.kind === "published") {
     return (
       <span data-state="published">

--- a/apps/notebook-cloud/viewer/index.css
+++ b/apps/notebook-cloud/viewer/index.css
@@ -1331,6 +1331,26 @@ body {
   color: color-mix(in srgb, #0f766e 84%, var(--foreground));
 }
 
+.cloud-dashboard-continue-facts [data-state="active"],
+.cloud-notebook-list-row-facts [data-state="active"] {
+  color: color-mix(in srgb, #0f766e 82%, var(--foreground));
+}
+
+.cloud-dashboard-continue-facts [data-state="starting"],
+.cloud-notebook-list-row-facts [data-state="starting"] {
+  color: color-mix(in srgb, #0369a1 82%, var(--foreground));
+}
+
+.cloud-dashboard-continue-facts [data-state="stale"],
+.cloud-notebook-list-row-facts [data-state="stale"] {
+  color: color-mix(in srgb, var(--foreground) 58%, transparent);
+}
+
+.cloud-dashboard-continue-facts [data-state="error"],
+.cloud-notebook-list-row-facts [data-state="error"] {
+  color: color-mix(in srgb, #b42318 86%, var(--foreground));
+}
+
 .cloud-notebook-list-updated {
   display: inline-flex;
   align-items: center;

--- a/apps/notebook-cloud/viewer/notebook-dashboard.ts
+++ b/apps/notebook-cloud/viewer/notebook-dashboard.ts
@@ -1,4 +1,9 @@
 import { cloudNotebookUrlWithMode, type CloudNotebookUrlMode } from "./cloud-notebook-mode";
+import {
+  isNotebookComputeSessionSummary,
+  projectNotebookComputeSessionFact,
+  type NotebookComputeSessionSummary,
+} from "runtimed";
 
 export interface CloudNotebookListItem {
   notebook_id: string;
@@ -8,6 +13,7 @@ export interface CloudNotebookListItem {
   created_at: string;
   updated_at: string;
   latest_revision_id: string | null;
+  compute_session?: NotebookComputeSessionSummary | null;
   viewer_url: string;
   endpoints: {
     catalog: string;
@@ -20,6 +26,7 @@ export type CloudNotebookDashboardFilterId =
   | "all"
   | "owned"
   | "shared"
+  | "compute"
   | "published"
   | "generated"
   | "untitled";
@@ -66,8 +73,9 @@ export interface CloudNotebookDashboardRow {
 }
 
 export interface CloudNotebookDashboardRowFact {
-  kind: "access" | "published";
+  kind: "access" | "compute" | "published";
   label: string;
+  tone?: "active" | "starting" | "stale" | "error";
 }
 
 export interface CloudNotebookDashboardSectionFilterAction {
@@ -235,6 +243,9 @@ export function isCloudNotebookListItem(value: unknown): value is CloudNotebookL
     typeof candidate.created_at === "string" &&
     typeof candidate.updated_at === "string" &&
     (candidate.latest_revision_id === null || typeof candidate.latest_revision_id === "string") &&
+    (candidate.compute_session === undefined ||
+      candidate.compute_session === null ||
+      isNotebookComputeSessionSummary(candidate.compute_session)) &&
     typeof candidate.viewer_url === "string" &&
     Boolean(candidate.endpoints) &&
     typeof candidate.endpoints?.catalog === "string" &&
@@ -265,6 +276,7 @@ function cloudNotebookDashboardFilters(
 ): CloudNotebookDashboardFilter[] {
   const generatedCount = notebooks.filter(cloudNotebookIsGeneratedRun).length;
   const ownerCount = notebooks.filter((notebook) => notebook.scope === "owner").length;
+  const computeCount = notebooks.filter(cloudNotebookHasComputeSession).length;
   const publishedCount = notebooks.filter((notebook) =>
     Boolean(notebook.latest_revision_id),
   ).length;
@@ -278,6 +290,9 @@ function cloudNotebookDashboardFilters(
   }
   if (sharedCount > 0) {
     filters.push({ id: "shared", label: "Shared with me", count: sharedCount, group: "work" });
+  }
+  if (computeCount > 0) {
+    filters.push({ id: "compute", label: "Compute", count: computeCount, group: "work" });
   }
   if (publishedCount > 0) {
     filters.push({ id: "published", label: "Published", count: publishedCount, group: "work" });
@@ -348,6 +363,11 @@ function cloudNotebookDashboardSections(
 
   if (context.filterId === "generated") {
     sections.push(generatedNotebookSection(notebooks, { limit: null }));
+    return sections;
+  }
+
+  if (context.filterId === "compute") {
+    sections.push(computeNotebookSection(notebooks));
     return sections;
   }
 
@@ -466,6 +486,21 @@ function sharedWithMeNotebookSection(
   };
 }
 
+function computeNotebookSection(
+  notebooks: readonly CloudNotebookListItem[],
+): CloudNotebookDashboardSection {
+  return {
+    action: null,
+    detail: bucketDetail(notebooks.length, "with compute state"),
+    id: "compute",
+    notebooks,
+    overflowAction: null,
+    rows: dashboardRows(notebooks),
+    title: "Active compute",
+    totalCount: notebooks.length,
+  };
+}
+
 function generatedNotebookSection(
   notebooks: readonly CloudNotebookListItem[],
   options: { limit: number | null },
@@ -577,6 +612,14 @@ function cloudNotebookDashboardRowFacts(
   notebook: CloudNotebookListItem,
 ): CloudNotebookDashboardRowFact[] {
   const facts: CloudNotebookDashboardRowFact[] = [];
+  const computeFact = projectNotebookComputeSessionFact(notebook.compute_session);
+  if (computeFact) {
+    facts.push({
+      kind: "compute",
+      label: computeFact.label,
+      tone: computeFact.tone,
+    });
+  }
   switch (notebook.scope) {
     case "editor":
       facts.push({ kind: "access", label: "editor" });
@@ -605,6 +648,10 @@ function cloudNotebookIsGeneratedRun(notebook: CloudNotebookListItem): boolean {
   );
 }
 
+function cloudNotebookHasComputeSession(notebook: CloudNotebookListItem): boolean {
+  return Boolean(notebook.compute_session);
+}
+
 function cloudNotebookMatchesFilter(
   notebook: CloudNotebookListItem,
   filterId: CloudNotebookDashboardFilterId,
@@ -616,6 +663,8 @@ function cloudNotebookMatchesFilter(
       return notebook.scope === "owner";
     case "shared":
       return notebook.scope !== "owner";
+    case "compute":
+      return cloudNotebookHasComputeSession(notebook);
     case "published":
       return Boolean(notebook.latest_revision_id);
     case "generated":
@@ -633,6 +682,7 @@ function cloudNotebookMatchesSearch(notebook: CloudNotebookListItem, query: stri
     notebook.scope,
     notebook.latest_revision_id ? "published" : "private",
     cloudNotebookDisplayTitle(notebook),
+    notebook.compute_session ? "compute runtime workstation active starting stale" : null,
   ]
     .filter(Boolean)
     .join(" ")
@@ -655,6 +705,8 @@ function cloudNotebookDashboardEmptyMessage(
       return "No owned notebooks yet.";
     case "shared":
       return "No notebooks have been shared with this account.";
+    case "compute":
+      return "No notebooks have active compute state.";
     case "published":
       return "No published notebooks yet.";
     case "generated":

--- a/apps/notebook-cloud/wrangler.toml
+++ b/apps/notebook-cloud/wrangler.toml
@@ -17,6 +17,10 @@ class_name = "NotebookRoom"
 name = "WORKSTATION_EVENTS"
 class_name = "WorkstationEvents"
 
+[[durable_objects.bindings]]
+name = "OWNER_COMPUTE_INDEX"
+class_name = "OwnerComputeIndex"
+
 [[migrations]]
 tag = "v1"
 new_sqlite_classes = ["NotebookRoom"]
@@ -32,6 +36,10 @@ new_sqlite_classes = ["MarkdownDocumentRoom"]
 [[migrations]]
 tag = "v4"
 deleted_classes = ["MarkdownDocumentRoom"]
+
+[[migrations]]
+tag = "v5"
+new_sqlite_classes = ["OwnerComputeIndex"]
 
 [[d1_databases]]
 binding = "DB"

--- a/packages/runtimed/src/index.ts
+++ b/packages/runtimed/src/index.ts
@@ -377,6 +377,19 @@ export {
   type ProjectNotebookWorkstationAttachmentFromClaimOptions,
 } from "./notebook-workstation-attachment";
 
+// Notebook compute session projection
+export {
+  clearNotebookComputeSessionProjectionCacheForTests,
+  isNotebookComputeSessionStatus,
+  isNotebookComputeSessionSummary,
+  projectNotebookComputeSessionFact,
+  projectNotebookComputeSessionSummary,
+  type NotebookComputeSessionFactProjection,
+  type NotebookComputeSessionStatus,
+  type NotebookComputeSessionSummary,
+  type ProjectNotebookComputeSessionSummaryOptions,
+} from "./notebook-compute-session";
+
 // Notebook workstation launch-readiness projection
 export {
   clearNotebookWorkstationLaunchReadinessProjectionCacheForTests,

--- a/packages/runtimed/src/notebook-compute-session.ts
+++ b/packages/runtimed/src/notebook-compute-session.ts
@@ -1,0 +1,226 @@
+import type { WorkstationAttachmentState } from "./runtime-state";
+import { getBoundedCacheValue, setBoundedCacheValue, stableCacheKey } from "./projection-cache";
+
+export type NotebookComputeSessionStatus = "starting" | "active" | "stale" | "error";
+
+export interface NotebookComputeSessionSummary {
+  environment_label: string | null;
+  last_runtime_seen_at: string | null;
+  notebook_id: string;
+  owner_principal: string;
+  queue_depth: number;
+  runtime_peer_count: number;
+  runtime_session_id: string | null;
+  status: NotebookComputeSessionStatus;
+  status_message: string | null;
+  updated_at: string;
+  working_directory: string | null;
+  workstation_display_name: string;
+  workstation_id: string;
+}
+
+export interface ProjectNotebookComputeSessionSummaryOptions {
+  attachment: WorkstationAttachmentState | null;
+  notebookId: string;
+  ownerPrincipal: string;
+  queueDepth?: number | null;
+  runtimePeerCount?: number | null;
+  updatedAt?: string | null;
+}
+
+export interface NotebookComputeSessionFactProjection {
+  label: string;
+  status: NotebookComputeSessionStatus;
+  tone: "active" | "starting" | "stale" | "error";
+}
+
+const COMPUTE_SESSION_SUMMARY_CACHE = new Map<string, NotebookComputeSessionSummary | null>();
+const COMPUTE_SESSION_FACT_CACHE = new Map<string, NotebookComputeSessionFactProjection | null>();
+const COMPUTE_SESSION_CACHE_LIMIT = 192;
+
+export function projectNotebookComputeSessionSummary({
+  attachment,
+  notebookId,
+  ownerPrincipal,
+  queueDepth,
+  runtimePeerCount,
+  updatedAt,
+}: ProjectNotebookComputeSessionSummaryOptions): NotebookComputeSessionSummary | null {
+  const normalizedRuntimePeerCount = normalizeNonNegativeInteger(runtimePeerCount);
+  const normalizedQueueDepth = normalizeNonNegativeInteger(queueDepth);
+  const cacheKey = stableCacheKey([
+    notebookId,
+    ownerPrincipal,
+    attachment,
+    normalizedQueueDepth,
+    normalizedRuntimePeerCount,
+    updatedAt,
+  ]);
+  const cached = getBoundedCacheValue(COMPUTE_SESSION_SUMMARY_CACHE, cacheKey);
+  if (cached !== undefined) return cached;
+
+  if (!attachment) {
+    setBoundedCacheValue(
+      COMPUTE_SESSION_SUMMARY_CACHE,
+      cacheKey,
+      null,
+      COMPUTE_SESSION_CACHE_LIMIT,
+    );
+    return null;
+  }
+
+  const workstationId = attachment.workstation_id.trim();
+  if (!workstationId) {
+    setBoundedCacheValue(
+      COMPUTE_SESSION_SUMMARY_CACHE,
+      cacheKey,
+      null,
+      COMPUTE_SESSION_CACHE_LIMIT,
+    );
+    return null;
+  }
+
+  const status = computeSessionStatus(attachment.status, normalizedRuntimePeerCount);
+  const attachmentUpdatedAt = boundedString(attachment.updated_at) ?? null;
+  const summary = Object.freeze({
+    environment_label: boundedString(attachment.default_environment_label) ?? null,
+    last_runtime_seen_at:
+      normalizedRuntimePeerCount > 0 ? (updatedAt ?? attachmentUpdatedAt) : null,
+    notebook_id: notebookId,
+    owner_principal: ownerPrincipal,
+    queue_depth: normalizedQueueDepth,
+    runtime_peer_count: normalizedRuntimePeerCount,
+    runtime_session_id: boundedString(attachment.runtime_session_id) ?? null,
+    status,
+    status_message: boundedString(attachment.status_message) ?? null,
+    updated_at: updatedAt ?? attachmentUpdatedAt ?? new Date(0).toISOString(),
+    working_directory: boundedString(attachment.working_directory) ?? null,
+    workstation_display_name: boundedString(attachment.display_name) ?? "Attached workstation",
+    workstation_id: workstationId,
+  } satisfies NotebookComputeSessionSummary);
+
+  setBoundedCacheValue(
+    COMPUTE_SESSION_SUMMARY_CACHE,
+    cacheKey,
+    summary,
+    COMPUTE_SESSION_CACHE_LIMIT,
+  );
+  return summary;
+}
+
+export function projectNotebookComputeSessionFact(
+  summary: NotebookComputeSessionSummary | null | undefined,
+): NotebookComputeSessionFactProjection | null {
+  if (!summary) return null;
+  const cacheKey = stableCacheKey([
+    summary.status,
+    summary.workstation_display_name,
+    summary.queue_depth,
+    summary.runtime_peer_count,
+  ]);
+  const cached = getBoundedCacheValue(COMPUTE_SESSION_FACT_CACHE, cacheKey);
+  if (cached !== undefined) return cached;
+
+  const label = notebookComputeSessionLabel(summary);
+  const projection = Object.freeze({
+    label,
+    status: summary.status,
+    tone: summary.status,
+  } satisfies NotebookComputeSessionFactProjection);
+  setBoundedCacheValue(
+    COMPUTE_SESSION_FACT_CACHE,
+    cacheKey,
+    projection,
+    COMPUTE_SESSION_CACHE_LIMIT,
+  );
+  return projection;
+}
+
+export function isNotebookComputeSessionSummary(
+  value: unknown,
+): value is NotebookComputeSessionSummary {
+  if (!value || typeof value !== "object") {
+    return false;
+  }
+  const candidate = value as Partial<NotebookComputeSessionSummary>;
+  const queueDepth = candidate.queue_depth;
+  const runtimePeerCount = candidate.runtime_peer_count;
+  return (
+    typeof candidate.notebook_id === "string" &&
+    typeof candidate.owner_principal === "string" &&
+    isNotebookComputeSessionStatus(candidate.status) &&
+    typeof candidate.workstation_id === "string" &&
+    typeof candidate.workstation_display_name === "string" &&
+    (candidate.environment_label === null || typeof candidate.environment_label === "string") &&
+    (candidate.working_directory === null || typeof candidate.working_directory === "string") &&
+    (candidate.runtime_session_id === null || typeof candidate.runtime_session_id === "string") &&
+    (candidate.status_message === null || typeof candidate.status_message === "string") &&
+    (candidate.last_runtime_seen_at === null ||
+      typeof candidate.last_runtime_seen_at === "string") &&
+    typeof candidate.updated_at === "string" &&
+    typeof queueDepth === "number" &&
+    Number.isInteger(queueDepth) &&
+    queueDepth >= 0 &&
+    typeof runtimePeerCount === "number" &&
+    Number.isInteger(runtimePeerCount) &&
+    runtimePeerCount >= 0
+  );
+}
+
+export function clearNotebookComputeSessionProjectionCacheForTests(): void {
+  COMPUTE_SESSION_SUMMARY_CACHE.clear();
+  COMPUTE_SESSION_FACT_CACHE.clear();
+}
+
+function computeSessionStatus(
+  workstationStatus: string | null | undefined,
+  runtimePeerCount: number,
+): NotebookComputeSessionStatus {
+  const normalized = workstationStatus?.trim().toLowerCase() ?? "";
+  if (normalized === "error" || normalized === "failed" || normalized === "attention") {
+    return "error";
+  }
+  if (runtimePeerCount > 0) {
+    return "active";
+  }
+  if (normalized === "connecting" || normalized === "pending" || normalized === "accepted") {
+    return "starting";
+  }
+  return "stale";
+}
+
+function notebookComputeSessionLabel(summary: NotebookComputeSessionSummary): string {
+  const workstation = summary.workstation_display_name || "workstation";
+  switch (summary.status) {
+    case "active":
+      return summary.queue_depth > 0
+        ? `${workstation} running, ${summary.queue_depth} queued`
+        : `${workstation} active`;
+    case "starting":
+      return `${workstation} starting`;
+    case "stale":
+      return `${workstation} stale`;
+    case "error":
+      return `${workstation} needs attention`;
+  }
+}
+
+export function isNotebookComputeSessionStatus(
+  value: unknown,
+): value is NotebookComputeSessionStatus {
+  return value === "starting" || value === "active" || value === "stale" || value === "error";
+}
+
+function boundedString(value: unknown, maxLength = 256): string | undefined {
+  if (typeof value !== "string") return undefined;
+  const trimmed = value.trim();
+  if (!trimmed) return undefined;
+  return trimmed.slice(0, maxLength);
+}
+
+function normalizeNonNegativeInteger(value: number | null | undefined): number {
+  if (typeof value !== "number" || !Number.isFinite(value) || value < 0) {
+    return 0;
+  }
+  return Math.floor(value);
+}

--- a/packages/runtimed/tests/notebook-compute-session.test.ts
+++ b/packages/runtimed/tests/notebook-compute-session.test.ts
@@ -1,0 +1,124 @@
+import { beforeEach, describe, expect, it } from "vitest";
+import {
+  clearNotebookComputeSessionProjectionCacheForTests,
+  isNotebookComputeSessionSummary,
+  projectNotebookComputeSessionFact,
+  projectNotebookComputeSessionSummary,
+  type WorkstationAttachmentState,
+} from "../src";
+
+beforeEach(() => {
+  clearNotebookComputeSessionProjectionCacheForTests();
+});
+
+const attachment: WorkstationAttachmentState = {
+  workstation_id: "ws-lab2",
+  display_name: "lab2 workstation",
+  provider: "runtime_peer",
+  default_environment_label: "Current Python",
+  environment_policy: "current_python",
+  status: "ready",
+  status_message: null,
+  cpu_count: 8,
+  memory_bytes: 16_000_000_000,
+  working_directory: "/home/ubuntu/project",
+  updated_at: "2026-06-23T00:00:00.000Z",
+  runtime_session_id: "job-1",
+};
+
+describe("projectNotebookComputeSessionSummary", () => {
+  it("projects an attached runtime peer as active compute", () => {
+    const summary = projectNotebookComputeSessionSummary({
+      attachment,
+      notebookId: "topic-viz",
+      ownerPrincipal: "user:dev:alice",
+      queueDepth: 2,
+      runtimePeerCount: 1,
+      updatedAt: "2026-06-23T00:00:05.000Z",
+    });
+
+    expect(summary).toEqual({
+      environment_label: "Current Python",
+      last_runtime_seen_at: "2026-06-23T00:00:05.000Z",
+      notebook_id: "topic-viz",
+      owner_principal: "user:dev:alice",
+      queue_depth: 2,
+      runtime_peer_count: 1,
+      runtime_session_id: "job-1",
+      status: "active",
+      status_message: null,
+      updated_at: "2026-06-23T00:00:05.000Z",
+      working_directory: "/home/ubuntu/project",
+      workstation_display_name: "lab2 workstation",
+      workstation_id: "ws-lab2",
+    });
+    expect(isNotebookComputeSessionSummary(summary)).toBe(true);
+  });
+
+  it("keeps a disconnected ready attachment visible as stale", () => {
+    const summary = projectNotebookComputeSessionSummary({
+      attachment,
+      notebookId: "topic-viz",
+      ownerPrincipal: "user:dev:alice",
+      runtimePeerCount: 0,
+    });
+
+    expect(summary?.status).toBe("stale");
+    expect(summary?.last_runtime_seen_at).toBeNull();
+  });
+
+  it("projects accepted attach jobs as starting", () => {
+    const summary = projectNotebookComputeSessionSummary({
+      attachment: {
+        ...attachment,
+        status: "connecting",
+        status_message: "lab2 accepted the request and is starting compute.",
+      },
+      notebookId: "topic-viz",
+      ownerPrincipal: "user:dev:alice",
+      runtimePeerCount: 0,
+    });
+
+    expect(summary?.status).toBe("starting");
+    expect(projectNotebookComputeSessionFact(summary)?.label).toBe("lab2 workstation starting");
+  });
+
+  it("surfaces failed attachments as attention-worthy compute", () => {
+    const summary = projectNotebookComputeSessionSummary({
+      attachment: {
+        ...attachment,
+        status: "error",
+        status_message: "ipykernel is missing",
+      },
+      notebookId: "topic-viz",
+      ownerPrincipal: "user:dev:alice",
+      runtimePeerCount: 0,
+    });
+
+    expect(summary?.status).toBe("error");
+    expect(summary?.status_message).toBe("ipykernel is missing");
+    expect(projectNotebookComputeSessionFact(summary)).toEqual({
+      label: "lab2 workstation needs attention",
+      status: "error",
+      tone: "error",
+    });
+  });
+
+  it("returns stable frozen projections for equivalent inputs", () => {
+    const first = projectNotebookComputeSessionSummary({
+      attachment,
+      notebookId: "topic-viz",
+      ownerPrincipal: "user:dev:alice",
+      runtimePeerCount: 1,
+    });
+    const second = projectNotebookComputeSessionSummary({
+      attachment,
+      notebookId: "topic-viz",
+      ownerPrincipal: "user:dev:alice",
+      runtimePeerCount: 1,
+    });
+
+    expect(first).toBe(second);
+    expect(Object.isFrozen(first)).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary

- Add an owner-scoped `OwnerComputeIndex` Durable Object that stores advisory compute-session summaries for notebook dashboard hydration.
- Publish compute summaries from room runtime/workstation lifecycle edges: attach control updates, runtime peer attachment, runtime peer leave, and runtime peer recovery/reconcile.
- Enrich owned `/api/n` rows with compute state and surface it on the notebook home as a row fact plus a Compute filter.
- Add shared `runtimed` projection helpers for notebook compute session summaries/facts so the dashboard stays declarative.

## Notes

This index is live-ish product state for navigation and visibility. It is not execution authority; room/runtime validation remains the source of truth for compute control.

Queue depth is modeled in the summary but not populated yet. A follow-up can expose a focused RuntimeStateDoc queue projection to hydrate that without subscribing `/n` to live rooms.

## Validation

- `pnpm -s test:run packages/runtimed/tests/notebook-compute-session.test.ts apps/notebook-cloud/test/notebook-dashboard.test.ts`
- `pnpm --dir apps/notebook-cloud exec node --import tsx --test test/compute-session-index.test.ts test/notebook-dashboard.test.ts test/worker-routes.test.ts --test-name-pattern "compute|cloud notebook dashboard projection"`
- `pnpm --dir apps/notebook-cloud exec node --import tsx --test test/notebook-room.test.ts --test-name-pattern "compute|replacement workstation attachment|runtime_peer-gone watchdog|owner-scoped REQUEST frames"`
- `pnpm --dir apps/notebook-cloud typecheck`
- `cargo xtask lint --fix`
