### PR TITLE
fix(notebook-cloud): hydrate comment author profiles

### DIFF
--- a/apps/notebook-cloud/src/index.ts
+++ b/apps/notebook-cloud/src/index.ts
@@ -18,6 +18,7 @@ import {
   DEV_AUTH_TOKEN_PROTOCOL_PREFIX,
   isAnonymousViewer,
   NOTEBOOK_CLOUD_WEBSOCKET_PROTOCOL,
+  parseActorLabel,
   parseScope,
   stampTrustedIdentity,
   type AuthenticatedConnection,
@@ -383,6 +384,12 @@ const NOTEBOOK_CLOUD_ROUTES: readonly WorkerRoute[] = [
     match: routePath("/api/n/:notebookId/access-requests", { trailingSlash: "optional" }),
     handler: ({ params }, request, env) =>
       routeNotebookAccessRequests(request, env, params.notebookId),
+  },
+  {
+    match: routePath("/api/n/:notebookId/author-profiles", { trailingSlash: "optional" }),
+    methods: ["GET"],
+    handler: ({ params }, request, env) =>
+      routeNotebookAuthorProfiles(request, env, params.notebookId),
   },
   {
     match: routePath("/api/n/:notebookId/workstation-attachments", { trailingSlash: "optional" }),
@@ -3095,6 +3102,193 @@ interface AccessRequestActionPayload {
   action?: unknown;
 }
 
+const AUTHOR_PROFILE_LOOKUP_LIMIT = 100;
+const AUTHOR_PROFILE_ACTOR_LABEL_MAX_LENGTH = 512;
+
+async function routeNotebookAuthorProfiles(
+  request: Request,
+  env: Env,
+  notebookId: string,
+): Promise<Response> {
+  if (!env.DB) {
+    return json({ error: "D1 binding DB is not configured" }, 503);
+  }
+
+  const identity = await authenticateAndAuthorizeOrAppSessionOrResponse(
+    request,
+    env,
+    notebookId,
+    "viewer",
+  );
+  if (identity instanceof Response) {
+    return identity;
+  }
+
+  const principals = requestedAuthorProfilePrincipals(new URL(request.url).searchParams);
+  if (principals instanceof Response) {
+    return principals;
+  }
+
+  const allowedPrincipals = await notebookAuthorProfileAllowedPrincipals(env, notebookId);
+  const commentAuthorPrincipals = await notebookCommentAuthorPrincipals(env, notebookId);
+  const profileLookups = await allowedAuthorProfileLookups(
+    env,
+    principals,
+    allowedPrincipals,
+    commentAuthorPrincipals,
+  );
+  const profilePrincipals = Array.from(
+    new Set(profileLookups.flatMap((lookup) => lookup.profilePrincipals)),
+  );
+  const profilesByPrincipal = new Map(
+    (await getPrincipalProfiles(env, profilePrincipals)).map((profile) => [
+      profile.principal,
+      profile,
+    ]),
+  );
+  return json({
+    notebook_id: notebookId,
+    profiles: profileLookups
+      .map((lookup) =>
+        authorProfileResponse(
+          lookup.requestedPrincipal,
+          lookup.profilePrincipals.map((principal) => profilesByPrincipal.get(principal) ?? null),
+        ),
+      )
+      .filter((profile) => profile !== null),
+  });
+}
+
+function requestedAuthorProfilePrincipals(params: URLSearchParams): string[] | Response {
+  const principals = new Set<string>();
+  for (const actorLabel of params.getAll("actor_label")) {
+    const trimmed = actorLabel.trim();
+    if (!trimmed || trimmed.length > AUTHOR_PROFILE_ACTOR_LABEL_MAX_LENGTH) {
+      continue;
+    }
+    try {
+      principals.add(parseActorLabel(trimmed).principal);
+    } catch {
+      continue;
+    }
+  }
+
+  if (principals.size > AUTHOR_PROFILE_LOOKUP_LIMIT) {
+    return json(
+      {
+        error: `author profile lookup is limited to ${AUTHOR_PROFILE_LOOKUP_LIMIT} principals`,
+      },
+      400,
+    );
+  }
+  return Array.from(principals);
+}
+
+function authorProfileResponse(
+  principal: string,
+  rows: readonly (PrincipalProfileRow | null)[],
+): Record<string, unknown> | null {
+  const row = rows.find((candidate) => candidate?.display_name?.trim());
+  const label = row?.display_name?.trim() ?? null;
+  if (!row || !label) {
+    return null;
+  }
+  return {
+    principal,
+    label,
+    image_url: row.avatar_url,
+  };
+}
+
+async function notebookAuthorProfileAllowedPrincipals(
+  env: Env,
+  notebookId: string,
+): Promise<Set<string>> {
+  const allowed = new Set<string>();
+  const notebook = await getNotebookRow(env, notebookId);
+  if (notebook?.owner_principal) {
+    allowed.add(notebook.owner_principal);
+  }
+  for (const row of await getNotebookAclRows(env, notebookId)) {
+    if (row.subject_kind === "principal") {
+      allowed.add(row.subject);
+    }
+  }
+  return allowed;
+}
+
+async function notebookCommentAuthorPrincipals(env: Env, notebookId: string): Promise<Set<string>> {
+  const id = env.NOTEBOOK_ROOMS.idFromName(notebookId);
+  const room = env.NOTEBOOK_ROOMS.get(id);
+  const response = await room.fetch(
+    new Request(
+      `https://notebook-room.internal/internal/n/${encodeURIComponent(notebookId)}/comment-authors`,
+      { method: "GET" },
+    ),
+  );
+  if (!response.ok) {
+    return new Set();
+  }
+  let body: unknown;
+  try {
+    body = await response.json();
+  } catch {
+    return new Set();
+  }
+  if (!isRecord(body) || !Array.isArray(body.actor_labels)) {
+    return new Set();
+  }
+  const principals = new Set<string>();
+  for (const actorLabel of body.actor_labels) {
+    if (typeof actorLabel !== "string") {
+      continue;
+    }
+    try {
+      principals.add(parseActorLabel(actorLabel).principal);
+    } catch {
+      continue;
+    }
+  }
+  return principals;
+}
+
+interface AuthorProfileLookup {
+  requestedPrincipal: string;
+  profilePrincipals: string[];
+}
+
+async function allowedAuthorProfileLookups(
+  env: Env,
+  principals: string[],
+  allowedPrincipals: Set<string>,
+  commentAuthorPrincipals: Set<string>,
+): Promise<AuthorProfileLookup[]> {
+  if (
+    principals.length === 0 ||
+    allowedPrincipals.size === 0 ||
+    commentAuthorPrincipals.size === 0
+  ) {
+    return [];
+  }
+
+  const lookups: AuthorProfileLookup[] = [];
+  for (const principal of principals) {
+    if (!commentAuthorPrincipals.has(principal)) {
+      continue;
+    }
+    const canonical = await getCanonicalPrincipalForTransport(env, principal);
+    if (!allowedPrincipals.has(principal) && (!canonical || !allowedPrincipals.has(canonical))) {
+      continue;
+    }
+    lookups.push({
+      requestedPrincipal: principal,
+      profilePrincipals:
+        canonical && canonical !== principal ? [principal, canonical] : [principal],
+    });
+  }
+  return lookups;
+}
+
 async function routeNotebookAccessRequests(
   request: Request,
   env: Env,
@@ -4655,6 +4849,7 @@ async function viewer(
     aclEndpoint: `${notebookApiBasePath}/acl`,
     invitesEndpoint: `${notebookApiBasePath}/invites`,
     accessRequestsEndpoint: `${notebookApiBasePath}/access-requests`,
+    authorProfilesEndpoint: `${notebookApiBasePath}/author-profiles`,
     workstationsEndpoint: "/api/workstations",
     workstationDefaultEndpoint: "/api/workstations/default",
     workstationAttachEndpoint: `${notebookApiBasePath}/workstation-attachments`,

--- a/apps/notebook-cloud/src/notebook-room.ts
+++ b/apps/notebook-cloud/src/notebook-room.ts
@@ -276,6 +276,10 @@ export class NotebookRoom {
     if (runtimeStateRepairNotebookId) {
       return this.handleRuntimeStateRepairControl(runtimeStateRepairNotebookId, request);
     }
+    const commentAuthorsNotebookId = commentAuthorsControlNotebookId(url.pathname);
+    if (commentAuthorsNotebookId) {
+      return this.handleCommentAuthorsControl(commentAuthorsNotebookId, request);
+    }
     const accessControlNotebookId = accessRevocationControlNotebookId(url.pathname);
     if (accessControlNotebookId) {
       return this.handleAccessRevocationControl(accessControlNotebookId, request);
@@ -583,6 +587,20 @@ export class NotebookRoom {
       counter_delta: 1,
     });
     return json({ ok: true, closed_anonymous_viewers: closedAnonymousViewers }, 200);
+  }
+
+  private async handleCommentAuthorsControl(
+    notebookId: string,
+    request: Request,
+  ): Promise<Response> {
+    // Worker-internal read path only. The public author-profile API authorizes
+    // notebook viewing before asking the room to constrain profile hydration to
+    // actor labels that actually appear in the CommentsDoc projection.
+    if (request.method !== "GET") {
+      return json({ error: "method not allowed" }, 405);
+    }
+    const actorLabels = await this.materializerFor(notebookId).getCommentAuthorActorLabels();
+    return json({ notebook_id: notebookId, actor_labels: actorLabels }, 200);
   }
 
   async webSocketMessage(
@@ -2330,6 +2348,14 @@ function workstationAttachmentControlNotebookId(pathname: string): string | unde
 
 function runtimeStateRepairControlNotebookId(pathname: string): string | undefined {
   const match = pathname.match(/^\/internal\/n\/([^/]+)\/runtime-state-repair\/?$/);
+  if (!match) {
+    return undefined;
+  }
+  return decodeURIComponent(match[1]);
+}
+
+function commentAuthorsControlNotebookId(pathname: string): string | undefined {
+  const match = pathname.match(/^\/internal\/n\/([^/]+)\/comment-authors\/?$/);
   if (!match) {
     return undefined;
   }

--- a/apps/notebook-cloud/src/room-materializer.ts
+++ b/apps/notebook-cloud/src/room-materializer.ts
@@ -93,6 +93,12 @@ export class RoomMaterializer {
     );
   }
 
+  async getCommentAuthorActorLabels(): Promise<string[]> {
+    return this.withHost((host) =>
+      commentAuthorActorLabelsFromProjection(host.get_comments_projection()),
+    );
+  }
+
   /// Publish the room-host-owned active workstation attachment into the
   /// RuntimeStateDoc. Runtime peers do not mutate this map directly; the room
   /// host owns the notebook-visible selected-compute projection.
@@ -770,6 +776,39 @@ function normalizeWorkstationAttachmentJson(value: string): WorkstationAttachmen
     return parsed;
   }
   throw new Error("RoomHostHandle returned an invalid workstation attachment");
+}
+
+function commentAuthorActorLabelsFromProjection(projection: unknown): string[] {
+  if (!projection || typeof projection !== "object") {
+    return [];
+  }
+  const labels = new Set<string>();
+  const threads = (projection as Record<string, unknown>).threads;
+  if (!Array.isArray(threads)) {
+    return [];
+  }
+  for (const thread of threads) {
+    if (!thread || typeof thread !== "object") {
+      continue;
+    }
+    const record = thread as Record<string, unknown>;
+    addActorLabel(labels, record.created_by_actor_label);
+    addActorLabel(labels, record.resolved_by_actor_label);
+    if (Array.isArray(record.messages)) {
+      for (const message of record.messages) {
+        if (message && typeof message === "object") {
+          addActorLabel(labels, (message as Record<string, unknown>).created_by_actor_label);
+        }
+      }
+    }
+  }
+  return Array.from(labels);
+}
+
+function addActorLabel(labels: Set<string>, value: unknown): void {
+  if (typeof value === "string" && value.trim()) {
+    labels.add(value);
+  }
 }
 
 function isWorkstationAttachmentState(value: unknown): value is WorkstationAttachmentState {

--- a/apps/notebook-cloud/src/runtimed-wasm.generated.d.ts
+++ b/apps/notebook-cloud/src/runtimed-wasm.generated.d.ts
@@ -118,6 +118,7 @@ declare module "../../notebook/src/wasm/runtimed-wasm/runtimed_wasm.js" {
     static load_snapshot(notebookBytes: Uint8Array, runtimeStateBytes: Uint8Array): RoomHostHandle;
     get_comms_doc_heads_hex(): string[];
     get_comments_doc_heads_hex(): string[];
+    get_comments_projection(): unknown;
     get_heads_hex(): string[];
     get_runtime_state_heads_hex(): string[];
     load_comms_doc(commsBytes: Uint8Array): void;

--- a/apps/notebook-cloud/test/comment-author-profiles.test.ts
+++ b/apps/notebook-cloud/test/comment-author-profiles.test.ts
@@ -1,0 +1,109 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+import type { CommentsProjection } from "@/components/notebook";
+import {
+  commentAuthorActorLabels,
+  commentAuthorProfilePeers,
+  commentAuthorProfileUrls,
+  commentAuthorProfilesUrl,
+  mergeCommentAuthorPeers,
+} from "../viewer/comment-author-profiles.ts";
+
+describe("cloud comment author profiles", () => {
+  it("collects unique thread, message, and resolution actor labels", () => {
+    const projection: CommentsProjection = {
+      comments_doc_id: "comments:demo",
+      threads: [
+        {
+          id: "thread-1",
+          anchor: { kind: "notebook" },
+          position: "1",
+          status: "resolved",
+          messages: [
+            {
+              id: "message-1",
+              position: "1",
+              body: "hello",
+              created_at: "2026-06-23T00:00:00.000Z",
+              created_by_actor_label: "user:anaconda:greg/browser:tab",
+            },
+          ],
+          badge_cell_ids: [],
+          created_at: "2026-06-23T00:00:00.000Z",
+          created_by_actor_label: "user:anaconda:kyle/browser:tab",
+          resolved_at: "2026-06-23T00:01:00.000Z",
+          resolved_by_actor_label: "user:anaconda:greg/browser:tab",
+        },
+      ],
+    };
+
+    assert.deepEqual(commentAuthorActorLabels(projection), [
+      "user:anaconda:greg/browser:tab",
+      "user:anaconda:kyle/browser:tab",
+    ]);
+  });
+
+  it("builds a bounded profile lookup URL from actor labels", () => {
+    assert.equal(
+      commentAuthorProfilesUrl("/api/n/nb-1/author-profiles", ["user:anaconda:greg/browser:tab"]),
+      "/api/n/nb-1/author-profiles?actor_label=user%3Aanaconda%3Agreg%2Fbrowser%3Atab",
+    );
+  });
+
+  it("batches profile lookup URLs under the server principal limit", () => {
+    const labels = Array.from(
+      { length: 205 },
+      (_, index) => `user:anaconda:author-${index}/browser:tab`,
+    );
+    const urls = commentAuthorProfileUrls("/api/n/nb-1/author-profiles", labels);
+
+    assert.equal(urls.length, 3);
+    assert.deepEqual(
+      urls.map((url) => new URL(url, "http://localhost").searchParams.getAll("actor_label").length),
+      [100, 100, 5],
+    );
+  });
+
+  it("projects profile rows into author peers and keeps profile labels over generic presence", () => {
+    const profilePeers = commentAuthorProfilePeers({
+      profiles: [
+        {
+          principal: "user:anaconda:greg",
+          label: "Greg Jennings",
+          image_url: "https://profiles.example/greg.png",
+        },
+        {
+          principal: "user:anaconda:bad",
+          label: "",
+        },
+      ],
+    });
+
+    assert.deepEqual(profilePeers, [
+      {
+        participantKey: "user:anaconda:greg",
+        label: "Greg Jennings",
+        imageUrl: "https://profiles.example/greg.png",
+      },
+    ]);
+    assert.deepEqual(
+      mergeCommentAuthorPeers(profilePeers, [
+        {
+          participantKey: "user:anaconda:greg",
+          label: "Anaconda user",
+        },
+      ]),
+      profilePeers,
+    );
+  });
+
+  it("lets specific live presence refresh a stored profile label", () => {
+    assert.deepEqual(
+      mergeCommentAuthorPeers(
+        [{ participantKey: "user:anaconda:greg", label: "Greg Jennings" }],
+        [{ participantKey: "user:anaconda:greg", label: "Greg J." }],
+      ),
+      [{ participantKey: "user:anaconda:greg", label: "Greg J." }],
+    );
+  });
+});

--- a/apps/notebook-cloud/test/room-materializer.test.ts
+++ b/apps/notebook-cloud/test/room-materializer.test.ts
@@ -745,6 +745,35 @@ describe("RoomMaterializer", () => {
     assert.equal(cells[1].source, "");
   });
 
+  it("projects comment author labels from the room-host CommentsDoc", async () => {
+    const state = fakeState();
+    const materializer = new RoomMaterializer("demo", state, {} as Env);
+    const editorIdentity = authenticateDevRequest(
+      new Request("https://cloud.test/n/demo/sync?user=alice&operator=desktop:a&scope=editor"),
+    );
+    const editorPeer = {
+      id: "peer-editor",
+      identity: editorIdentity,
+    };
+    const editor = NotebookHandle.create_bootstrap(editorIdentity.actorLabel);
+    editor.init_comments_sync_target("comments:demo");
+
+    await syncCommentsMaterializerWithClient(materializer, editorPeer, editor);
+    editor.create_comment_thread(
+      "thread-1",
+      "message-1",
+      { kind: "notebook" },
+      "Can this profile be hydrated?",
+      undefined,
+      "2026-06-23T00:00:00.000Z",
+    );
+
+    const result = await applyCommentsClientChangesToMaterializer(materializer, editorPeer, editor);
+
+    assert.equal(result.changed, true);
+    assert.deepEqual(await materializer.getCommentAuthorActorLabels(), [editorIdentity.actorLabel]);
+  });
+
   it("ignores unversioned prototype checkpoints so published snapshots can hydrate rooms", async () => {
     const state = fakeState();
     const editorIdentity = authenticateDevRequest(
@@ -2061,6 +2090,75 @@ async function applyCommsClientChangesToMaterializer(
   return result;
 }
 
+async function syncCommentsMaterializerWithClient(
+  materializer: RoomMaterializer,
+  peer: { id: string; identity: ReturnType<typeof authenticateDevRequest> },
+  client: NotebookHandle,
+): Promise<void> {
+  let result = await materializer.syncPeer(peer);
+  for (let round = 0; round < 8; round += 1) {
+    const replies = applyCommentsOutboundToClient(result.outbound, peer.id, client);
+    if (replies.length === 0) {
+      return;
+    }
+    const outbound = [];
+    for (const reply of replies) {
+      const next = await materializer.receiveFrame(peer, {
+        type: FrameType.COMMENTS_DOC_SYNC,
+        payload: reply.slice(1),
+      });
+      outbound.push(...next.outbound);
+    }
+    result = {
+      changed: false,
+      notebook_changed: false,
+      runtime_state_changed: false,
+      outbound,
+    };
+  }
+}
+
+async function applyCommentsClientChangesToMaterializer(
+  materializer: RoomMaterializer,
+  peer: { id: string; identity: ReturnType<typeof authenticateDevRequest> },
+  client: NotebookHandle,
+) {
+  const message = client.flush_comments_doc_sync();
+  assert.ok(message);
+  let result = await materializer.receiveFrame(peer, {
+    type: FrameType.COMMENTS_DOC_SYNC,
+    payload: message,
+  });
+
+  for (let round = 0; round < 8 && !result.changed; round += 1) {
+    const replies = applyCommentsOutboundToClient(result.outbound, peer.id, client);
+    if (replies.length === 0) {
+      break;
+    }
+    const outbound = [];
+    for (const reply of replies) {
+      const next = await materializer.receiveFrame(peer, {
+        type: FrameType.COMMENTS_DOC_SYNC,
+        payload: reply.slice(1),
+      });
+      if (next.changed) {
+        result = next;
+      }
+      outbound.push(...next.outbound);
+    }
+    if (!result.changed) {
+      result = {
+        changed: false,
+        notebook_changed: false,
+        runtime_state_changed: false,
+        outbound,
+      };
+    }
+  }
+
+  return result;
+}
+
 async function applyRuntimePeerChangesToMaterializer(
   materializer: RoomMaterializer,
   peer: { id: string; identity: ReturnType<typeof authenticateDevRequest> },
@@ -2319,6 +2417,28 @@ function applyOutboundToClient(
     for (const event of events ?? []) {
       if (event.type === "sync_applied" && event.reply) {
         replies.push(encodeTypedFrame(FrameType.AUTOMERGE_SYNC, new Uint8Array(event.reply)));
+      }
+    }
+  }
+  return replies;
+}
+
+function applyCommentsOutboundToClient(
+  outbound: Array<{ peer_id: string; frame_type: FrameTypeValue; payload: Uint8Array | number[] }>,
+  peerId: string,
+  client: NotebookHandle,
+): Uint8Array[] {
+  const replies: Uint8Array[] = [];
+  for (const frame of outbound) {
+    if (frame.peer_id !== peerId || frame.frame_type !== FrameType.COMMENTS_DOC_SYNC) {
+      continue;
+    }
+    const events = client.receive_frame(
+      encodeTypedFrame(frame.frame_type, new Uint8Array(frame.payload)),
+    ) as Array<{ type: string; reply?: number[] }>;
+    for (const event of events ?? []) {
+      if (event.type === "comments_doc_sync_applied" && event.reply) {
+        replies.push(encodeTypedFrame(FrameType.COMMENTS_DOC_SYNC, new Uint8Array(event.reply)));
       }
     }
   }

--- a/apps/notebook-cloud/test/worker-routes.test.ts
+++ b/apps/notebook-cloud/test/worker-routes.test.ts
@@ -3904,6 +3904,184 @@ describe("Worker artifact routes", () => {
     );
   });
 
+  it("returns notebook-scoped author profiles for comment attribution", async () => {
+    const canonicalGreg = "account:user%3Aanaconda:email:greg-hash";
+    const gregTransport = "user:anaconda:6707d79f-4f39-403e-bb2f-1fccb520c09b";
+    const env = fakeEnv({
+      NOTEBOOK_ROOMS: fakeNotebookRoomsWithCommentAuthors([`${gregTransport}/browser:tab`]),
+    });
+    seedNotebook(env, "comment-author-demo");
+    const mallory = "user:anaconda:mallory";
+    seedAcl(env, {
+      notebookId: "comment-author-demo",
+      subject: "user:dev:alice",
+      scope: "owner",
+    });
+    seedAcl(env, {
+      notebookId: "comment-author-demo",
+      subject: canonicalGreg,
+      scope: "editor",
+    });
+    env.DB.accountLinks.set(gregTransport, {
+      transport_principal: gregTransport,
+      canonical_principal: canonicalGreg,
+      provider: "user:anaconda",
+      email_normalized: "greg@example.com",
+      first_seen_at: "2026-05-28T00:00:00.000Z",
+      last_seen_at: "2026-05-28T00:00:00.000Z",
+    });
+    env.DB.profiles.set(canonicalGreg, {
+      principal: canonicalGreg,
+      provider: "user:anaconda",
+      provider_subject: null,
+      email_normalized: "greg@example.com",
+      email_verified: 1,
+      display_name: "Greg Jennings",
+      avatar_url: "https://profiles.example/greg.png",
+      first_seen_at: "2026-05-28T00:00:00.000Z",
+      last_seen_at: "2026-05-28T00:00:00.000Z",
+      raw_claims_json: null,
+    });
+    env.DB.profiles.set(mallory, {
+      principal: mallory,
+      provider: "oidc",
+      provider_subject: "mallory",
+      email_normalized: "mallory@example.com",
+      email_verified: 1,
+      display_name: "Mallory Example",
+      avatar_url: null,
+      first_seen_at: "2026-05-28T00:00:00.000Z",
+      last_seen_at: "2026-05-28T00:00:00.000Z",
+      raw_claims_json: null,
+    });
+
+    const url = new URL("http://localhost/api/n/comment-author-demo/author-profiles");
+    url.searchParams.append("actor_label", `${gregTransport}/browser:tab`);
+    url.searchParams.append("actor_label", `${mallory}/browser:tab`);
+    url.searchParams.append("actor_label", "not-an-actor-label");
+    const response = await worker.fetch(
+      new Request(url, {
+        headers: {
+          "X-User": "alice",
+          "X-Operator": "desktop:test",
+          "X-Scope": "owner",
+        },
+      }),
+      env,
+      fakeContext(),
+    );
+
+    assert.equal(response.status, 200);
+    const body = (await response.json()) as { profiles: Array<Record<string, unknown>> };
+    assert.deepEqual(body.profiles, [
+      {
+        principal: gregTransport,
+        label: "Greg Jennings",
+        image_url: "https://profiles.example/greg.png",
+      },
+    ]);
+  });
+
+  it("does not expose email fallback labels to public comment viewers", async () => {
+    const env = fakeEnv({
+      NOTEBOOK_ROOMS: fakeNotebookRoomsWithCommentAuthors(["user:dev:alice/browser:tab"]),
+    });
+    seedNotebook(env, "public-author-demo");
+    seedAcl(env, {
+      notebookId: "public-author-demo",
+      subject: "user:dev:alice",
+      scope: "owner",
+    });
+    seedAcl(env, {
+      notebookId: "public-author-demo",
+      subjectKind: "public",
+      subject: "anonymous",
+      scope: "viewer",
+    });
+    env.DB.profiles.set("user:dev:alice", {
+      principal: "user:dev:alice",
+      provider: "dev",
+      provider_subject: "alice",
+      email_normalized: "alice@example.com",
+      email_verified: 1,
+      display_name: null,
+      avatar_url: null,
+      first_seen_at: "2026-05-28T00:00:00.000Z",
+      last_seen_at: "2026-05-28T00:00:00.000Z",
+      raw_claims_json: null,
+    });
+
+    const url = new URL("http://localhost/api/n/public-author-demo/author-profiles");
+    url.searchParams.append("actor_label", "user:dev:alice/browser:tab");
+    const response = await worker.fetch(new Request(url), env, fakeContext());
+
+    assert.equal(response.status, 200);
+    const body = (await response.json()) as { profiles: Array<Record<string, unknown>> };
+    assert.deepEqual(body.profiles, []);
+  });
+
+  it("does not expose ACL principal profiles unless they authored visible comments", async () => {
+    const env = fakeEnv({
+      NOTEBOOK_ROOMS: fakeNotebookRoomsWithCommentAuthors(["user:dev:alice/browser:tab"]),
+    });
+    seedNotebook(env, "public-comment-author-demo");
+    seedAcl(env, {
+      notebookId: "public-comment-author-demo",
+      subject: "user:dev:alice",
+      scope: "owner",
+    });
+    seedAcl(env, {
+      notebookId: "public-comment-author-demo",
+      subject: "user:dev:bob",
+      scope: "editor",
+    });
+    seedAcl(env, {
+      notebookId: "public-comment-author-demo",
+      subjectKind: "public",
+      subject: "anonymous",
+      scope: "viewer",
+    });
+    env.DB.profiles.set("user:dev:alice", {
+      principal: "user:dev:alice",
+      provider: "dev",
+      provider_subject: "alice",
+      email_normalized: "alice@example.com",
+      email_verified: 1,
+      display_name: "Alice Example",
+      avatar_url: null,
+      first_seen_at: "2026-05-28T00:00:00.000Z",
+      last_seen_at: "2026-05-28T00:00:00.000Z",
+      raw_claims_json: null,
+    });
+    env.DB.profiles.set("user:dev:bob", {
+      principal: "user:dev:bob",
+      provider: "dev",
+      provider_subject: "bob",
+      email_normalized: "bob@example.com",
+      email_verified: 1,
+      display_name: "Bob Example",
+      avatar_url: null,
+      first_seen_at: "2026-05-28T00:00:00.000Z",
+      last_seen_at: "2026-05-28T00:00:00.000Z",
+      raw_claims_json: null,
+    });
+
+    const url = new URL("http://localhost/api/n/public-comment-author-demo/author-profiles");
+    url.searchParams.append("actor_label", "user:dev:alice/browser:tab");
+    url.searchParams.append("actor_label", "user:dev:bob/browser:tab");
+    const response = await worker.fetch(new Request(url), env, fakeContext());
+
+    assert.equal(response.status, 200);
+    const body = (await response.json()) as { profiles: Array<Record<string, unknown>> };
+    assert.deepEqual(body.profiles, [
+      {
+        principal: "user:dev:alice",
+        label: "Alice Example",
+        image_url: null,
+      },
+    ]);
+  });
+
   it("closes anonymous live viewers when public link access is revoked", async () => {
     const roomRequests: Request[] = [];
     const env = fakeEnv({
@@ -6175,6 +6353,26 @@ function fakeEnv(overrides: Partial<Env> = {}): FakeEnv {
   };
   Object.assign(env, overrides);
   return env;
+}
+
+function fakeNotebookRoomsWithCommentAuthors(
+  actorLabels: readonly string[],
+): DurableObjectNamespace {
+  return {
+    idFromName: (name: string) => ({ toString: () => name }),
+    get: (id: { toString(): string }) => ({
+      fetch: async (request: Request) => {
+        const pathname = new URL(request.url).pathname;
+        if (pathname.endsWith("/comment-authors")) {
+          return Response.json({
+            notebook_id: id.toString(),
+            actor_labels: actorLabels,
+          });
+        }
+        return new Response("not implemented", { status: 501 });
+      },
+    }),
+  } satisfies DurableObjectNamespace;
 }
 
 function fakeContext(): ExecutionContext {

--- a/apps/notebook-cloud/viewer/cloud-viewer-config.ts
+++ b/apps/notebook-cloud/viewer/cloud-viewer-config.ts
@@ -50,6 +50,8 @@ function loadConfig(): CloudViewerConfig {
     aclEndpoint: parsed.aclEndpoint,
     invitesEndpoint: parsed.invitesEndpoint,
     accessRequestsEndpoint: parsed.accessRequestsEndpoint,
+    authorProfilesEndpoint:
+      typeof parsed.authorProfilesEndpoint === "string" ? parsed.authorProfilesEndpoint : undefined,
     workstationsEndpoint: parsed.workstationsEndpoint,
     workstationDefaultEndpoint: parsed.workstationDefaultEndpoint,
     workstationAttachEndpoint: parsed.workstationAttachEndpoint,

--- a/apps/notebook-cloud/viewer/cloud-viewer-session.ts
+++ b/apps/notebook-cloud/viewer/cloud-viewer-session.ts
@@ -124,6 +124,7 @@ export interface CloudViewerConfig {
   aclEndpoint: string;
   invitesEndpoint: string;
   accessRequestsEndpoint: string;
+  authorProfilesEndpoint?: string;
   workstationsEndpoint?: string;
   workstationDefaultEndpoint?: string;
   workstationAttachEndpoint?: string;

--- a/apps/notebook-cloud/viewer/comment-author-profiles.ts
+++ b/apps/notebook-cloud/viewer/comment-author-profiles.ts
@@ -1,0 +1,133 @@
+import type { ActorDisplayPeer } from "runtimed";
+import type { CommentsProjection } from "@/components/notebook";
+
+export interface CloudCommentAuthorProfile {
+  principal: string;
+  label: string;
+  image_url?: string | null;
+}
+
+export interface CloudCommentAuthorProfilesResponse {
+  notebook_id?: string;
+  profiles?: unknown;
+}
+
+export const COMMENT_AUTHOR_PROFILE_LOOKUP_BATCH_SIZE = 100;
+
+export function commentAuthorActorLabels(projection: CommentsProjection | null): string[] {
+  if (!projection) return [];
+
+  const labels = new Set<string>();
+  for (const thread of projection.threads) {
+    addActorLabel(labels, thread.created_by_actor_label);
+    addActorLabel(labels, thread.resolved_by_actor_label);
+    for (const message of thread.messages) {
+      addActorLabel(labels, message.created_by_actor_label);
+    }
+  }
+  return Array.from(labels).sort();
+}
+
+export function commentAuthorProfilesUrl(endpoint: string, actorLabels: readonly string[]): string {
+  const baseUrl = typeof window === "undefined" ? "http://localhost/" : window.location.href;
+  const url = new URL(endpoint, baseUrl);
+  for (const actorLabel of actorLabels) {
+    url.searchParams.append("actor_label", actorLabel);
+  }
+  return `${url.pathname}${url.search}${url.hash}`;
+}
+
+export function commentAuthorProfileUrls(
+  endpoint: string,
+  actorLabels: readonly string[],
+): string[] {
+  const urls: string[] = [];
+  for (
+    let index = 0;
+    index < actorLabels.length;
+    index += COMMENT_AUTHOR_PROFILE_LOOKUP_BATCH_SIZE
+  ) {
+    urls.push(
+      commentAuthorProfilesUrl(
+        endpoint,
+        actorLabels.slice(index, index + COMMENT_AUTHOR_PROFILE_LOOKUP_BATCH_SIZE),
+      ),
+    );
+  }
+  return urls;
+}
+
+export function commentAuthorProfilePeers(
+  response: CloudCommentAuthorProfilesResponse,
+): ActorDisplayPeer[] {
+  if (!Array.isArray(response.profiles)) return [];
+
+  const peers: ActorDisplayPeer[] = [];
+  for (const profile of response.profiles) {
+    if (!isCloudCommentAuthorProfile(profile)) continue;
+    peers.push({
+      participantKey: profile.principal,
+      label: profile.label,
+      imageUrl: profile.image_url ?? null,
+    });
+  }
+  return peers;
+}
+
+export function mergeCommentAuthorPeers(
+  profilePeers: readonly ActorDisplayPeer[],
+  presencePeers: readonly ActorDisplayPeer[],
+): ActorDisplayPeer[] {
+  const merged = new Map<string, ActorDisplayPeer>();
+  for (const peer of profilePeers) {
+    if (usableAuthorPeer(peer)) {
+      merged.set(peer.participantKey, peer);
+    }
+  }
+
+  for (const peer of presencePeers) {
+    if (!usableAuthorPeer(peer)) continue;
+    const existing = merged.get(peer.participantKey);
+    if (!existing || !isGenericAuthorLabel(peer.label)) {
+      merged.set(peer.participantKey, peer);
+    }
+  }
+
+  return Array.from(merged.values());
+}
+
+function addActorLabel(labels: Set<string>, value: string | null | undefined): void {
+  const trimmed = value?.trim();
+  if (trimmed) labels.add(trimmed);
+}
+
+function isCloudCommentAuthorProfile(value: unknown): value is CloudCommentAuthorProfile {
+  if (!value || typeof value !== "object") return false;
+  const profile = value as Partial<CloudCommentAuthorProfile>;
+  return (
+    typeof profile.principal === "string" &&
+    profile.principal.trim().length > 0 &&
+    typeof profile.label === "string" &&
+    profile.label.trim().length > 0 &&
+    (profile.image_url === undefined ||
+      profile.image_url === null ||
+      typeof profile.image_url === "string")
+  );
+}
+
+function usableAuthorPeer(peer: ActorDisplayPeer): boolean {
+  return peer.participantKey.trim().length > 0 && peer.label.trim().length > 0;
+}
+
+function isGenericAuthorLabel(label: string): boolean {
+  switch (label.trim()) {
+    case "Anaconda user":
+    case "OIDC user":
+    case "User":
+    case "Peer":
+    case "Unknown viewer":
+      return true;
+    default:
+      return false;
+  }
+}

--- a/apps/notebook-cloud/viewer/notebook-viewer.tsx
+++ b/apps/notebook-cloud/viewer/notebook-viewer.tsx
@@ -71,6 +71,7 @@ import {
   resolveActorDisplay,
   workstationAttachmentCanExecute,
   workstationAttachmentIsConnected,
+  type ActorDisplayPeer,
   type CellChangeset,
   type NotebookOutlineItem,
   type SyncEngineLogger,
@@ -120,6 +121,13 @@ import { beginOidcLogin } from "./oidc-auth";
 import { cloudViewerLoadingPolicy } from "./loading-policy";
 import { markCloudViewerLoadMilestone } from "./load-milestones";
 import { cloudPresenceHasRuntimePeer, cloudPresenceRuntimePeerCount } from "./presence";
+import {
+  commentAuthorActorLabels,
+  commentAuthorProfilePeers,
+  commentAuthorProfileUrls,
+  mergeCommentAuthorPeers,
+  type CloudCommentAuthorProfilesResponse,
+} from "./comment-author-profiles";
 import type { ResolvedCell } from "./render-resolution";
 import {
   CloudNotebookNotices,
@@ -593,13 +601,62 @@ export function NotebookViewer({
     presenceStore.getSnapshot,
     presenceStore.getSnapshot,
   );
-  const commentAuthorPeers = useMemo(
+  const liveCommentAuthorPeers = useMemo(
     () =>
       presenceSnapshot.peers.map((peer) => ({
         participantKey: peer.participantKey,
         label: peer.label,
       })),
     [presenceSnapshot.peers],
+  );
+  const commentAuthorLabels = useMemo(
+    () => commentAuthorActorLabels(commentsProjection),
+    [commentsProjection],
+  );
+  const commentAuthorLabelsKey = commentAuthorLabels.join("\u0000");
+  const [profileCommentAuthorPeers, setProfileCommentAuthorPeers] = useState<ActorDisplayPeer[]>(
+    [],
+  );
+  useEffect(() => {
+    const endpoint = config.authorProfilesEndpoint;
+    if (!endpoint || commentAuthorLabelsKey === "") {
+      setProfileCommentAuthorPeers([]);
+      return;
+    }
+    const actorLabels = commentAuthorLabelsKey.split("\u0000");
+
+    const controller = new AbortController();
+    void (async () => {
+      try {
+        const peers: ActorDisplayPeer[] = [];
+        for (const url of commentAuthorProfileUrls(endpoint, actorLabels)) {
+          const response = await fetchWithCloudPrototypeAuth(
+            url,
+            { headers: { Accept: "application/json" }, signal: controller.signal },
+            browserApiAuthState,
+          );
+          if (controller.signal.aborted) return;
+          if (!response.ok) {
+            setProfileCommentAuthorPeers([]);
+            return;
+          }
+          const body = (await response.json()) as CloudCommentAuthorProfilesResponse;
+          if (controller.signal.aborted) return;
+          peers.push(...commentAuthorProfilePeers(body));
+        }
+        setProfileCommentAuthorPeers(peers);
+      } catch {
+        if (!controller.signal.aborted) {
+          setProfileCommentAuthorPeers([]);
+        }
+      }
+    })();
+
+    return () => controller.abort();
+  }, [browserApiAuthState, commentAuthorLabelsKey, config.authorProfilesEndpoint]);
+  const commentAuthorPeers = useMemo(
+    () => mergeCommentAuthorPeers(profileCommentAuthorPeers, liveCommentAuthorPeers),
+    [liveCommentAuthorPeers, profileCommentAuthorPeers],
   );
   const resolveCloudCommentAuthor = useCallback(
     (actorLabel: string): CommentAuthor => {

--- a/crates/runtimed-wasm/src/lib.rs
+++ b/crates/runtimed-wasm/src/lib.rs
@@ -974,6 +974,20 @@ impl RoomHostHandle {
             .map(|head| hex::encode(head.as_ref()))
             .collect()
     }
+
+    /// Read the current CommentsDoc projection from the room-host document set.
+    pub fn get_comments_projection(&mut self) -> JsValue {
+        let cell_order: Vec<String> = self
+            .doc
+            .get_cells()
+            .into_iter()
+            .map(|cell| cell.id)
+            .collect();
+        match self.comments_doc.read_projection(Some(&cell_order)) {
+            Ok(projection) => serialize_to_js(&projection).unwrap_or(JsValue::UNDEFINED),
+            Err(_) => JsValue::UNDEFINED,
+        }
+    }
 }
 
 impl RoomHostHandle {


### PR DESCRIPTION
## Summary
- add a notebook-scoped author profile endpoint for cloud comment attribution
- hydrate comment author display names from stored principal profiles instead of relying only on live room presence
- keep lookups bounded to actor labels present in the room-host CommentsDoc projection and filtered to notebook owner/ACL principals
- avoid leaking email fallback labels to public/shared viewers; only stored display names are exposed
- resolve transport principals through canonical principal account links while returning profiles keyed to the requested actor principal
- constrain server profile hydration to actor principals present in visible comment thread/message/resolution authors

## Adversarial review
- reviewed against `.agents/reviewers/nteract-code-review-rubric.md` with read-only adversarial subagents
- fixed the initial findings: email fallback privacy leak, over-limit profile lookup clearing names, canonical-only profile rows not hydrating transport actor labels
- fixed the follow-up authority finding: ACL collaborators are not profile-hydratable unless they authored/resolved visible comments
- fixed the follow-up integration gap: `RoomMaterializer` now calls the typed WASM `get_comments_projection()` path directly, with focused materializer coverage
- final adversarial re-review on `1ca897f0`: no actionable findings; residual risk is fail-closed UX if a room cannot project comment authors
- `uv run pr-review doctor` is currently blocked by expired Bedrock credentials: `Credentials were refreshed, but the refreshed credentials are still expired`

## Preview validation
- deployed preview.runt.run at `1ca897f055d076859fad538e7e3fde7de82717ae`
- `pnpm --dir apps/notebook-cloud run deploy:check`
- live API lookup for `01KVC277SH3TNMQQRQPY6EP5DC` and the reported Greg actor label returns `Greg Jennings` from `/api/n/:notebookId/author-profiles`
- live API lookup for a non-comment actor label on that notebook returns no profiles

## Local validation
- `pnpm --dir apps/notebook-cloud exec node --import tsx --test test/comment-author-profiles.test.ts`
- `pnpm --dir apps/notebook-cloud exec node --import tsx --test --test-name-pattern "author profiles|email fallback|ACL principal profiles" test/worker-routes.test.ts`
- `pnpm --dir apps/notebook-cloud exec node --import tsx --test --test-reporter=spec test/worker-routes.test.ts`
- `pnpm --dir apps/notebook-cloud exec node --import tsx --test --test-reporter=spec test/room-materializer.test.ts`
- `pnpm --dir apps/notebook-cloud typecheck`
- `cargo test -p runtimed-wasm`
- `cargo xtask lint --fix`
