### PR TITLE
fix(notebook-cloud): publish compute queue depth

### DIFF
--- a/apps/notebook-cloud/src/notebook-room.ts
+++ b/apps/notebook-cloud/src/notebook-room.ts
@@ -86,6 +86,10 @@ interface PeerCloseOptions {
   suppressRuntimePeerWatch?: boolean;
 }
 
+interface PublishComputeSessionSummaryOptions {
+  onlyIfQueueDepthChanged?: boolean;
+}
+
 type RuntimePeerForwardedRequestAction = "interrupt_execution" | "send_comm";
 type RuntimePeerQueryRequestAction = "complete";
 type HostedExecutionRequestAction =
@@ -233,6 +237,9 @@ export class NotebookRoom {
     string,
     SelectedRuntimePeerSession | null
   >();
+  private readonly computeSessionQueueDepths = new Map<string, number>();
+  private readonly computeSessionSummaryPublishes = new Map<string, Promise<void>>();
+  private readonly dirtyComputeSessionSummaries = new Set<string>();
   private readonly restoredPeersReady: Promise<void>;
   private readonly pendingRuntimePeerResponses = new Map<string, PendingRuntimePeerResponse>();
   // In-memory only by design: persisting on the frame hot path would cost more
@@ -1145,6 +1152,13 @@ export class NotebookRoom {
       if (result.changed) {
         this.scheduleRoomHostCheckpoint(notebookId, materializer, "materialized_frame");
       }
+      if (result.runtime_state_changed) {
+        this.state.waitUntil(
+          this.publishCurrentComputeSessionSummary(notebookId, undefined, {
+            onlyIfQueueDepthChanged: true,
+          }),
+        );
+      }
       this.sendControl(notebookId, peer, {
         type: "cloud_frame_accepted",
         notebook_id: notebookId,
@@ -1285,7 +1299,7 @@ export class NotebookRoom {
         this.deliverRoomHostFrames(notebookId, result);
         await this.checkpointRoomHost(notebookId, materializer, "runtime_peer_attachment");
       }
-      await this.publishCurrentComputeSessionSummary(notebookId, attachment);
+      await this.publishCurrentComputeSessionSummary(notebookId);
       cloudLog("debug", "room.workstation_attachment.published", {
         notebook_id: notebookId,
         peer_id: peer.id,
@@ -1312,15 +1326,42 @@ export class NotebookRoom {
   private async publishCurrentComputeSessionSummary(
     notebookId: string,
     attachment?: WorkstationAttachmentState | null,
+    options?: PublishComputeSessionSummaryOptions,
+  ): Promise<void> {
+    const previous = this.computeSessionSummaryPublishes.get(notebookId) ?? Promise.resolve();
+    const publish = previous
+      .catch(() => undefined)
+      .then(() => this.publishCurrentComputeSessionSummaryNow(notebookId, attachment, options));
+    this.computeSessionSummaryPublishes.set(notebookId, publish);
+    await publish.finally(() => {
+      if (this.computeSessionSummaryPublishes.get(notebookId) === publish) {
+        this.computeSessionSummaryPublishes.delete(notebookId);
+      }
+    });
+  }
+
+  private async publishCurrentComputeSessionSummaryNow(
+    notebookId: string,
+    attachment?: WorkstationAttachmentState | null,
+    options?: PublishComputeSessionSummaryOptions,
   ): Promise<void> {
     if (!this.env.OWNER_COMPUTE_INDEX || !this.env.DB) {
       return;
     }
     try {
+      const materializer = this.materializerFor(notebookId);
+      const queueDepth = await materializer.getRuntimeQueueDepth();
+      if (
+        options?.onlyIfQueueDepthChanged &&
+        !this.dirtyComputeSessionSummaries.has(notebookId) &&
+        this.computeSessionQueueDepths.get(notebookId) === queueDepth
+      ) {
+        return;
+      }
       const [notebook, currentAttachment] = await Promise.all([
         getNotebookRow(this.env, notebookId),
         attachment === undefined
-          ? this.materializerFor(notebookId).getWorkstationAttachment()
+          ? materializer.getWorkstationAttachment()
           : Promise.resolve(attachment),
       ]);
       if (!notebook) {
@@ -1330,15 +1371,33 @@ export class NotebookRoom {
         attachment: currentAttachment,
         notebookId,
         ownerPrincipal: notebook.owner_principal,
+        queueDepth,
         runtimePeerCount: this.runtimePeerCount(),
         updatedAt: new Date().toISOString(),
       });
       if (summary) {
-        await upsertOwnerComputeSession(this.env, summary);
+        const published = await upsertOwnerComputeSession(this.env, summary);
+        if (published) {
+          this.computeSessionQueueDepths.set(notebookId, summary.queue_depth);
+          this.dirtyComputeSessionSummaries.delete(notebookId);
+        } else {
+          this.dirtyComputeSessionSummaries.add(notebookId);
+        }
       } else {
-        await deleteOwnerComputeSession(this.env, notebook.owner_principal, notebookId);
+        const deleted = await deleteOwnerComputeSession(
+          this.env,
+          notebook.owner_principal,
+          notebookId,
+        );
+        if (deleted) {
+          this.computeSessionQueueDepths.set(notebookId, queueDepth);
+          this.dirtyComputeSessionSummaries.delete(notebookId);
+        } else {
+          this.dirtyComputeSessionSummaries.add(notebookId);
+        }
       }
     } catch (error) {
+      this.dirtyComputeSessionSummaries.add(notebookId);
       cloudLog("warn", "room.compute_session_summary.publish_failed", {
         notebook_id: notebookId,
         error: errorMessage(error),

--- a/apps/notebook-cloud/src/room-materializer.ts
+++ b/apps/notebook-cloud/src/room-materializer.ts
@@ -87,14 +87,14 @@ export class RoomMaterializer {
     return this.withHost((host) => normalizeResult(host.reconcile_runtime_peer_gone(reason)));
   }
 
+  async getRuntimeQueueDepth(): Promise<number> {
+    return this.withHost((host) => Math.max(0, Math.trunc(host.get_runtime_queue_depth())));
+  }
+
   async getWorkstationAttachment(): Promise<WorkstationAttachmentState | null> {
     return this.withHost((host) =>
       normalizeWorkstationAttachmentJson(host.get_workstation_attachment_json()),
     );
-  }
-
-  async getRuntimeQueueDepth(): Promise<number> {
-    return this.withHost((host) => Math.max(0, Math.trunc(host.get_runtime_queue_depth())));
   }
 
   /// Publish the room-host-owned active workstation attachment into the

--- a/apps/notebook-cloud/src/room-materializer.ts
+++ b/apps/notebook-cloud/src/room-materializer.ts
@@ -93,6 +93,10 @@ export class RoomMaterializer {
     );
   }
 
+  async getRuntimeQueueDepth(): Promise<number> {
+    return this.withHost((host) => Math.max(0, Math.trunc(host.get_runtime_queue_depth())));
+  }
+
   /// Publish the room-host-owned active workstation attachment into the
   /// RuntimeStateDoc. Runtime peers do not mutate this map directly; the room
   /// host owns the notebook-visible selected-compute projection.

--- a/apps/notebook-cloud/src/runtimed-wasm.generated.d.ts
+++ b/apps/notebook-cloud/src/runtimed-wasm.generated.d.ts
@@ -119,6 +119,7 @@ declare module "../../notebook/src/wasm/runtimed-wasm/runtimed_wasm.js" {
     get_comms_doc_heads_hex(): string[];
     get_comments_doc_heads_hex(): string[];
     get_heads_hex(): string[];
+    get_runtime_queue_depth(): number;
     get_runtime_state_heads_hex(): string[];
     load_comms_doc(commsBytes: Uint8Array): void;
     load_comments_doc(commentsBytes: Uint8Array): void;

--- a/apps/notebook-cloud/test/notebook-room.test.ts
+++ b/apps/notebook-cloud/test/notebook-room.test.ts
@@ -1028,6 +1028,7 @@ describe("NotebookRoom peer lifecycle", () => {
         changed: true,
         runtime_state_changed: true,
       }),
+      getRuntimeQueueDepth: async () => 0,
     } as never);
 
     const response = await room.fetch(
@@ -1086,6 +1087,7 @@ describe("NotebookRoom peer lifecycle", () => {
         changed: true,
         runtime_state_changed: true,
       }),
+      getRuntimeQueueDepth: async () => 0,
     } as never);
 
     const response = await room.fetch(
@@ -1128,6 +1130,86 @@ describe("NotebookRoom peer lifecycle", () => {
         request.body?.summary?.workstation_id,
       ]),
       [["owner-compute:v1:user:dev:alice", "/upsert", "starting", 0, "ws-lab2"]],
+    );
+  });
+
+  it("does not resurrect a runtime-peer compute summary after attachment clear wins", async () => {
+    const state = hibernatedState([]);
+    const compute = new FakeOwnerComputeIndexNamespace();
+    const room = new NotebookRoom(state.state, roomEnvWithComputeIndex(compute));
+    const harness = roomHarness(room);
+    const runtimePeer: PeerForTest = {
+      id: "runtime",
+      socket: new FakeSocket().asCloudflareWebSocket(),
+      identity: authenticateDevRequest(
+        new Request(
+          "https://cloud.test/n/demo/sync?user=runtime&operator=runtime:py&scope=runtime_peer",
+        ),
+      ),
+      connectedAt: "2026-06-07T00:00:00.000Z",
+      workstation: {
+        workstationId: "ws-lab2",
+        displayName: "Lab2 workstation",
+        defaultEnvironmentLabel: "Current Python",
+        environmentPolicy: "current_python",
+        runtimeSessionId: "job-1",
+        workingDirectory: "/home/ubuntu/project",
+      },
+    };
+
+    let currentAttachment: unknown = null;
+    let checkpointCalls = 0;
+    let resolveFirstCheckpointStarted: () => void = () => undefined;
+    const firstCheckpointStarted = new Promise<void>((resolve) => {
+      resolveFirstCheckpointStarted = resolve;
+    });
+    let releaseFirstCheckpoint: () => void = () => undefined;
+    const firstCheckpointReleased = new Promise<void>((resolve) => {
+      releaseFirstCheckpoint = resolve;
+    });
+    harness.materializers.set("demo", {
+      receiveFrame: async () => noopMaterializedResult(),
+      checkpoint: async () => {
+        checkpointCalls += 1;
+        if (checkpointCalls === 1) {
+          resolveFirstCheckpointStarted();
+          await firstCheckpointReleased;
+        }
+      },
+      setWorkstationAttachment: async (attachment: unknown) => {
+        currentAttachment = attachment;
+        return {
+          ...noopMaterializedResult(),
+          changed: true,
+          runtime_state_changed: true,
+        };
+      },
+      getWorkstationAttachment: async () => currentAttachment,
+      getRuntimeQueueDepth: async () => 0,
+      removePeer: async () => undefined,
+    } as never);
+
+    const attachPublish = harness.publishRuntimePeerAttachment("demo", runtimePeer);
+    await firstCheckpointStarted;
+
+    const response = await room.fetch(
+      new Request("https://room.internal/internal/n/demo/workstation-attachment", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ attachment: null }),
+      }),
+    );
+    assert.equal(response.status, 200);
+    await state.drain();
+
+    releaseFirstCheckpoint();
+    await attachPublish;
+    await state.drain();
+
+    assert.deepEqual(
+      compute.requests.map((request) => new URL(request.url).pathname),
+      ["/delete", "/delete"],
+      "the delayed runtime-peer publish re-reads the cleared attachment instead of upserting stale compute",
     );
   });
 
@@ -1589,6 +1671,511 @@ describe("NotebookRoom materialized sync routing", () => {
       decodeJsonPayload<Record<string, unknown>>(socket.sent[0].slice(1)).type,
       "cloud_frame_accepted",
     );
+  });
+
+  it("republishes compute summary when execution changes queue depth", async () => {
+    const state = hibernatedState([]);
+    const compute = new FakeOwnerComputeIndexNamespace();
+    const room = new NotebookRoom(state.state, roomEnvWithComputeIndex(compute));
+    const harness = roomHarness(room);
+    const ownerSocket = new FakeSocket();
+    const ownerPeer: PeerForTest = {
+      id: "owner",
+      socket: ownerSocket.asCloudflareWebSocket(),
+      identity: authenticateDevRequest(
+        new Request("https://cloud.test/n/demo/sync?user=alice&operator=browser:a&scope=owner"),
+      ),
+      connectedAt: "2026-05-22T00:00:00.000Z",
+    };
+    const runtimePeer: PeerForTest = {
+      id: "runtime",
+      socket: new FakeSocket().asCloudflareWebSocket(),
+      identity: authenticateDevRequest(
+        new Request(
+          "https://cloud.test/n/demo/sync?user=runtime&operator=runtime:py&scope=runtime_peer",
+        ),
+      ),
+      connectedAt: "2026-05-22T00:00:01.000Z",
+      workstation: {
+        workstationId: "ws-lab2",
+        runtimeSessionId: "job-1",
+      },
+    };
+    harness.peers.set(ownerPeer.id, ownerPeer);
+    harness.peers.set(runtimePeer.id, runtimePeer);
+
+    let queueDepth = 0;
+    harness.materializers.set("demo", {
+      receiveFrame: async () => {
+        queueDepth = 1;
+        return {
+          ...noopMaterializedResult(),
+          changed: true,
+          runtime_state_changed: true,
+        };
+      },
+      checkpoint: async () => undefined,
+      getWorkstationAttachment: async () => ({
+        workstation_id: "ws-lab2",
+        display_name: "lab2 workstation",
+        provider: "runtime_peer",
+        default_environment_label: "Current Python",
+        environment_policy: "current_python",
+        status: "ready",
+        status_message: null,
+        cpu_count: null,
+        memory_bytes: null,
+        working_directory: "/home/ubuntu/project",
+        updated_at: "2026-06-23T00:00:00.000Z",
+        runtime_session_id: "job-1",
+      }),
+      getRuntimeQueueDepth: async () => queueDepth,
+      removePeer: async () => undefined,
+    } as never);
+
+    await harness.handleMessage(
+      "demo",
+      ownerPeer,
+      encodeTypedFrame(
+        FrameType.REQUEST,
+        new TextEncoder().encode(
+          JSON.stringify({ id: "request-1", action: "execute_cell", cell_id: "cell-1" }),
+        ),
+      ),
+    );
+    await state.drain();
+
+    assert.equal(compute.requests.length, 1);
+    assert.equal(compute.requests[0]?.body?.summary?.status, "active");
+    assert.equal(compute.requests[0]?.body?.summary?.queue_depth, 1);
+    assert.equal(compute.requests[0]?.body?.summary?.runtime_peer_count, 1);
+
+    await harness.handleMessage(
+      "demo",
+      runtimePeer,
+      encodeTypedFrame(FrameType.RUNTIME_STATE_SYNC, new Uint8Array([1])),
+    );
+    await state.drain();
+
+    assert.equal(
+      compute.requests.length,
+      1,
+      "runtime-state churn at the same queue depth does not rewrite the owner compute index",
+    );
+  });
+
+  it("coalesces same-depth compute summary publishes while an index write is pending", async () => {
+    const state = hibernatedState([]);
+    const compute = new BlockingOwnerComputeIndexNamespace();
+    const room = new NotebookRoom(state.state, roomEnvWithComputeIndex(compute));
+    const harness = roomHarness(room);
+    const ownerSocket = new FakeSocket();
+    const ownerPeer: PeerForTest = {
+      id: "owner",
+      socket: ownerSocket.asCloudflareWebSocket(),
+      identity: authenticateDevRequest(
+        new Request("https://cloud.test/n/demo/sync?user=alice&operator=browser:a&scope=owner"),
+      ),
+      connectedAt: "2026-05-22T00:00:00.000Z",
+    };
+    const runtimePeer: PeerForTest = {
+      id: "runtime",
+      socket: new FakeSocket().asCloudflareWebSocket(),
+      identity: authenticateDevRequest(
+        new Request(
+          "https://cloud.test/n/demo/sync?user=runtime&operator=runtime:py&scope=runtime_peer",
+        ),
+      ),
+      connectedAt: "2026-05-22T00:00:01.000Z",
+      workstation: {
+        workstationId: "ws-lab2",
+        runtimeSessionId: "job-1",
+      },
+    };
+    harness.peers.set(ownerPeer.id, ownerPeer);
+    harness.peers.set(runtimePeer.id, runtimePeer);
+
+    let queueDepth = 0;
+    harness.materializers.set("demo", {
+      receiveFrame: async () => {
+        queueDepth = 1;
+        return {
+          ...noopMaterializedResult(),
+          changed: true,
+          runtime_state_changed: true,
+        };
+      },
+      checkpoint: async () => undefined,
+      getWorkstationAttachment: async () => ({
+        workstation_id: "ws-lab2",
+        display_name: "lab2 workstation",
+        provider: "runtime_peer",
+        default_environment_label: "Current Python",
+        environment_policy: "current_python",
+        status: "ready",
+        status_message: null,
+        cpu_count: null,
+        memory_bytes: null,
+        working_directory: "/home/ubuntu/project",
+        updated_at: "2026-06-23T00:00:00.000Z",
+        runtime_session_id: "job-1",
+      }),
+      getRuntimeQueueDepth: async () => queueDepth,
+      removePeer: async () => undefined,
+    } as never);
+
+    await harness.handleMessage(
+      "demo",
+      ownerPeer,
+      encodeTypedFrame(
+        FrameType.REQUEST,
+        new TextEncoder().encode(
+          JSON.stringify({ id: "request-1", action: "execute_cell", cell_id: "cell-1" }),
+        ),
+      ),
+    );
+    await compute.firstStarted;
+    assert.equal(compute.requests.length, 1);
+
+    await harness.handleMessage(
+      "demo",
+      runtimePeer,
+      encodeTypedFrame(FrameType.RUNTIME_STATE_SYNC, new Uint8Array([1])),
+    );
+    assert.equal(
+      compute.requests.length,
+      1,
+      "same-depth runtime-state churn is serialized behind the in-flight publish",
+    );
+
+    compute.releaseFirst();
+    await state.drain();
+    assert.equal(
+      compute.requests.length,
+      1,
+      "same-depth runtime-state churn does not write the owner compute index after coalescing",
+    );
+  });
+
+  it("retries same-depth compute summary after owner index write failure", async () => {
+    const state = hibernatedState([]);
+    const compute = new FailingFirstOwnerComputeIndexNamespace();
+    const room = new NotebookRoom(state.state, roomEnvWithComputeIndex(compute));
+    const harness = roomHarness(room);
+    const ownerPeer: PeerForTest = {
+      id: "owner",
+      socket: new FakeSocket().asCloudflareWebSocket(),
+      identity: authenticateDevRequest(
+        new Request("https://cloud.test/n/demo/sync?user=alice&operator=browser:a&scope=owner"),
+      ),
+      connectedAt: "2026-05-22T00:00:00.000Z",
+    };
+    const runtimePeer: PeerForTest = {
+      id: "runtime",
+      socket: new FakeSocket().asCloudflareWebSocket(),
+      identity: authenticateDevRequest(
+        new Request(
+          "https://cloud.test/n/demo/sync?user=runtime&operator=runtime:py&scope=runtime_peer",
+        ),
+      ),
+      connectedAt: "2026-05-22T00:00:01.000Z",
+      workstation: {
+        workstationId: "ws-lab2",
+        runtimeSessionId: "job-1",
+      },
+    };
+    harness.peers.set(ownerPeer.id, ownerPeer);
+    harness.peers.set(runtimePeer.id, runtimePeer);
+
+    let queueDepth = 0;
+    harness.materializers.set("demo", {
+      receiveFrame: async () => {
+        queueDepth = 1;
+        return {
+          ...noopMaterializedResult(),
+          changed: true,
+          runtime_state_changed: true,
+        };
+      },
+      checkpoint: async () => undefined,
+      getWorkstationAttachment: async () => ({
+        workstation_id: "ws-lab2",
+        display_name: "lab2 workstation",
+        provider: "runtime_peer",
+        default_environment_label: "Current Python",
+        environment_policy: "current_python",
+        status: "ready",
+        status_message: null,
+        cpu_count: null,
+        memory_bytes: null,
+        working_directory: "/home/ubuntu/project",
+        updated_at: "2026-06-23T00:00:00.000Z",
+        runtime_session_id: "job-1",
+      }),
+      getRuntimeQueueDepth: async () => queueDepth,
+      removePeer: async () => undefined,
+    } as never);
+
+    await harness.handleMessage(
+      "demo",
+      ownerPeer,
+      encodeTypedFrame(
+        FrameType.REQUEST,
+        new TextEncoder().encode(
+          JSON.stringify({ id: "request-1", action: "execute_cell", cell_id: "cell-1" }),
+        ),
+      ),
+    );
+    await state.drain();
+    assert.equal(compute.requests.length, 1);
+
+    await harness.handleMessage(
+      "demo",
+      runtimePeer,
+      encodeTypedFrame(FrameType.RUNTIME_STATE_SYNC, new Uint8Array([1])),
+    );
+    await state.drain();
+
+    assert.equal(
+      compute.requests.length,
+      2,
+      "failed owner-index writes do not mark the queue depth as published",
+    );
+    assert.equal(compute.requests[1]?.body?.summary?.queue_depth, 1);
+  });
+
+  it("skips D1 and owner-index work for clean same-depth runtime-state churn", async () => {
+    const state = hibernatedState([]);
+    const compute = new FakeOwnerComputeIndexNamespace();
+    const db = new CountingNotebookOwnerD1();
+    const room = new NotebookRoom(state.state, roomEnvWithComputeIndex(compute, db));
+    const harness = roomHarness(room);
+    const ownerPeer: PeerForTest = {
+      id: "owner",
+      socket: new FakeSocket().asCloudflareWebSocket(),
+      identity: authenticateDevRequest(
+        new Request("https://cloud.test/n/demo/sync?user=alice&operator=browser:a&scope=owner"),
+      ),
+      connectedAt: "2026-05-22T00:00:00.000Z",
+    };
+    const runtimePeer: PeerForTest = {
+      id: "runtime",
+      socket: new FakeSocket().asCloudflareWebSocket(),
+      identity: authenticateDevRequest(
+        new Request(
+          "https://cloud.test/n/demo/sync?user=runtime&operator=runtime:py&scope=runtime_peer",
+        ),
+      ),
+      connectedAt: "2026-05-22T00:00:01.000Z",
+      workstation: {
+        workstationId: "ws-lab2",
+        runtimeSessionId: "job-1",
+      },
+    };
+    harness.peers.set(ownerPeer.id, ownerPeer);
+    harness.peers.set(runtimePeer.id, runtimePeer);
+
+    let queueDepth = 0;
+    harness.materializers.set("demo", {
+      receiveFrame: async () => {
+        queueDepth = 1;
+        return {
+          ...noopMaterializedResult(),
+          changed: true,
+          runtime_state_changed: true,
+        };
+      },
+      checkpoint: async () => undefined,
+      getWorkstationAttachment: async () => ({
+        workstation_id: "ws-lab2",
+        display_name: "lab2 workstation",
+        provider: "runtime_peer",
+        default_environment_label: "Current Python",
+        environment_policy: "current_python",
+        status: "ready",
+        status_message: null,
+        cpu_count: null,
+        memory_bytes: null,
+        working_directory: "/home/ubuntu/project",
+        updated_at: "2026-06-23T00:00:00.000Z",
+        runtime_session_id: "job-1",
+      }),
+      getRuntimeQueueDepth: async () => queueDepth,
+      removePeer: async () => undefined,
+    } as never);
+
+    await harness.handleMessage(
+      "demo",
+      ownerPeer,
+      encodeTypedFrame(
+        FrameType.REQUEST,
+        new TextEncoder().encode(
+          JSON.stringify({ id: "request-1", action: "execute_cell", cell_id: "cell-1" }),
+        ),
+      ),
+    );
+    await state.drain();
+    assert.equal(compute.requests.length, 1);
+    assert.equal(db.notebookLookupCount, 1);
+
+    db.notebookLookupCount = 0;
+    await harness.handleMessage(
+      "demo",
+      runtimePeer,
+      encodeTypedFrame(FrameType.RUNTIME_STATE_SYNC, new Uint8Array([1])),
+    );
+    await state.drain();
+
+    assert.equal(compute.requests.length, 1);
+    assert.equal(
+      db.notebookLookupCount,
+      0,
+      "same-depth runtime-state churn returns before D1 notebook lookup",
+    );
+  });
+
+  it("skips D1 and owner-index delete work after clean same-depth no-summary publish", async () => {
+    const state = hibernatedState([]);
+    const compute = new FakeOwnerComputeIndexNamespace();
+    const db = new CountingNotebookOwnerD1();
+    const room = new NotebookRoom(state.state, roomEnvWithComputeIndex(compute, db));
+    const harness = roomHarness(room);
+    const runtimePeer: PeerForTest = {
+      id: "runtime",
+      socket: new FakeSocket().asCloudflareWebSocket(),
+      identity: authenticateDevRequest(
+        new Request(
+          "https://cloud.test/n/demo/sync?user=runtime&operator=runtime:py&scope=runtime_peer",
+        ),
+      ),
+      connectedAt: "2026-05-22T00:00:01.000Z",
+      workstation: {
+        workstationId: "ws-lab2",
+        runtimeSessionId: "job-1",
+      },
+    };
+    harness.peers.set(runtimePeer.id, runtimePeer);
+
+    harness.materializers.set("demo", {
+      receiveFrame: async () => ({
+        ...noopMaterializedResult(),
+        changed: true,
+        runtime_state_changed: true,
+      }),
+      checkpoint: async () => undefined,
+      getWorkstationAttachment: async () => null,
+      getRuntimeQueueDepth: async () => 0,
+      removePeer: async () => undefined,
+    } as never);
+
+    await harness.handleMessage(
+      "demo",
+      runtimePeer,
+      encodeTypedFrame(FrameType.RUNTIME_STATE_SYNC, new Uint8Array([1])),
+    );
+    await state.drain();
+    assert.equal(compute.requests.length, 1);
+    assert.match(compute.requests[0]?.url ?? "", /\/delete$/);
+    assert.equal(db.notebookLookupCount, 1);
+
+    db.notebookLookupCount = 0;
+    await harness.handleMessage(
+      "demo",
+      runtimePeer,
+      encodeTypedFrame(FrameType.RUNTIME_STATE_SYNC, new Uint8Array([1])),
+    );
+    await state.drain();
+
+    assert.equal(compute.requests.length, 1);
+    assert.equal(
+      db.notebookLookupCount,
+      0,
+      "same-depth no-summary churn returns before D1 notebook lookup",
+    );
+  });
+
+  it("retries same-depth dirty summary after failed active update", async () => {
+    const state = hibernatedState([]);
+    const compute = new FailingNumberedOwnerComputeIndexNamespace(2);
+    const room = new NotebookRoom(state.state, roomEnvWithComputeIndex(compute));
+    const harness = roomHarness(room);
+    const runtimePeer: PeerForTest = {
+      id: "runtime",
+      socket: new FakeSocket().asCloudflareWebSocket(),
+      identity: authenticateDevRequest(
+        new Request(
+          "https://cloud.test/n/demo/sync?user=runtime&operator=runtime:py&scope=runtime_peer",
+        ),
+      ),
+      connectedAt: "2026-05-22T00:00:01.000Z",
+      workstation: {
+        workstationId: "ws-lab2",
+        runtimeSessionId: "job-1",
+      },
+    };
+    let currentAttachment: unknown = {
+      workstation_id: "ws-lab2",
+      display_name: "lab2 workstation",
+      provider: "runtime_peer",
+      default_environment_label: "Current Python",
+      environment_policy: "current_python",
+      status: "connecting",
+      status_message: "Waiting for lab2.",
+      cpu_count: null,
+      memory_bytes: null,
+      working_directory: "/home/ubuntu/project",
+      updated_at: "2026-06-23T00:00:00.000Z",
+      runtime_session_id: "job-1",
+    };
+    harness.materializers.set("demo", {
+      receiveFrame: async () => ({
+        ...noopMaterializedResult(),
+        changed: true,
+        runtime_state_changed: true,
+      }),
+      checkpoint: async () => undefined,
+      getWorkstationAttachment: async () => currentAttachment,
+      getRuntimeQueueDepth: async () => 0,
+      setWorkstationAttachment: async (attachment: unknown) => {
+        currentAttachment = attachment;
+        return {
+          ...noopMaterializedResult(),
+          changed: true,
+          runtime_state_changed: true,
+        };
+      },
+      removePeer: async () => undefined,
+    } as never);
+
+    const response = await room.fetch(
+      new Request("https://room.internal/internal/n/demo/workstation-attachment", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ attachment: currentAttachment }),
+      }),
+    );
+    assert.equal(response.status, 200);
+    await state.drain();
+    assert.equal(compute.requests[0]?.body?.summary?.status, "starting");
+
+    harness.peers.set(runtimePeer.id, runtimePeer);
+    await harness.publishRuntimePeerAttachment("demo", runtimePeer);
+    assert.equal(compute.requests[1]?.body?.summary?.status, "active");
+
+    await harness.handleMessage(
+      "demo",
+      runtimePeer,
+      encodeTypedFrame(FrameType.RUNTIME_STATE_SYNC, new Uint8Array([1])),
+    );
+    await state.drain();
+
+    assert.equal(
+      compute.requests.length,
+      3,
+      "failed same-depth active update leaves the summary dirty for retry",
+    );
+    assert.equal(compute.requests[2]?.body?.summary?.status, "active");
+    assert.equal(compute.requests[2]?.body?.summary?.queue_depth, 0);
   });
 
   it("delivers materialized sync outbound frames to connected viewer peers", async () => {
@@ -2840,14 +3427,20 @@ describe("NotebookRoom runtime_peer-gone watchdog", () => {
       },
     };
     harness.peers.set(runtimePeer.id, runtimePeer);
+    let currentAttachment: unknown = null;
     harness.materializers.set("demo", {
       receiveFrame: async () => noopMaterializedResult(),
       checkpoint: async () => undefined,
-      setWorkstationAttachment: async () => ({
-        ...noopMaterializedResult(),
-        changed: true,
-        runtime_state_changed: true,
-      }),
+      setWorkstationAttachment: async (attachment: unknown) => {
+        currentAttachment = attachment;
+        return {
+          ...noopMaterializedResult(),
+          changed: true,
+          runtime_state_changed: true,
+        };
+      },
+      getWorkstationAttachment: async () => currentAttachment,
+      getRuntimeQueueDepth: async () => 2,
     } as never);
 
     await harness.publishRuntimePeerAttachment("demo", runtimePeer);
@@ -2857,10 +3450,11 @@ describe("NotebookRoom runtime_peer-gone watchdog", () => {
         request.objectName,
         new URL(request.url).pathname,
         request.body?.summary?.status,
+        request.body?.summary?.queue_depth,
         request.body?.summary?.runtime_peer_count,
         request.body?.summary?.workstation_id,
       ]),
-      [["owner-compute:v1:user:dev:alice", "/upsert", "active", 1, "ws-lab2"]],
+      [["owner-compute:v1:user:dev:alice", "/upsert", "active", 2, 1, "ws-lab2"]],
     );
   });
 
@@ -2886,6 +3480,7 @@ describe("NotebookRoom runtime_peer-gone watchdog", () => {
         updated_at: "2026-06-23T00:00:00.000Z",
         runtime_session_id: "job-1",
       }),
+      getRuntimeQueueDepth: async () => 1,
       removePeer: async () => undefined,
       reconcileRuntimePeerGone: async () => noopMaterializedResult(),
     } as never);
@@ -2897,6 +3492,7 @@ describe("NotebookRoom runtime_peer-gone watchdog", () => {
       (request) => request.body?.summary?.status === "stale",
     );
     assert.equal(staleRequest?.objectName, "owner-compute:v1:user:dev:alice");
+    assert.equal(staleRequest?.body?.summary?.queue_depth, 1);
     assert.equal(staleRequest?.body?.summary?.runtime_peer_count, 0);
   });
 
@@ -3119,6 +3715,7 @@ interface RoomHarness {
       syncPeer?(): Promise<RoomHostFrameResult>;
       receiveFrame(): Promise<RoomHostFrameResult>;
       checkpoint(): Promise<void>;
+      getRuntimeQueueDepth?(): Promise<number>;
       getWorkstationAttachment?(): Promise<unknown>;
       removePeer?(peerId: string): Promise<void>;
       reconcileRuntimePeerGone?(reason: string): Promise<RoomHostFrameResult>;
@@ -3172,9 +3769,12 @@ function fakeState(): DurableObjectState {
   };
 }
 
-function roomEnvWithComputeIndex(computeIndex: DurableObjectNamespace): Env {
+function roomEnvWithComputeIndex(
+  computeIndex: DurableObjectNamespace,
+  db: D1Database = new NotebookOwnerD1(),
+): Env {
   return {
-    DB: new NotebookOwnerD1(),
+    DB: db,
     NOTEBOOK_ROOMS: {
       idFromName: (name: string) => ({ toString: () => name }),
       get: () => ({
@@ -3186,7 +3786,14 @@ function roomEnvWithComputeIndex(computeIndex: DurableObjectNamespace): Env {
 }
 
 interface FakeOwnerComputeIndexRequest {
-  body: { summary?: { runtime_peer_count?: number; status?: string; workstation_id?: string } };
+  body: {
+    summary?: {
+      queue_depth?: number;
+      runtime_peer_count?: number;
+      status?: string;
+      workstation_id?: string;
+    };
+  };
   objectName: string;
   url: string;
 }
@@ -3213,6 +3820,81 @@ class FakeOwnerComputeIndexNamespace implements DurableObjectNamespace {
   }
 }
 
+class BlockingOwnerComputeIndexNamespace extends FakeOwnerComputeIndexNamespace {
+  private resolveFirstStarted: () => void = () => undefined;
+  private resolveReleaseFirst: () => void = () => undefined;
+  readonly firstStarted = new Promise<void>((resolve) => {
+    this.resolveFirstStarted = resolve;
+  });
+  private readonly firstRelease = new Promise<void>((resolve) => {
+    this.resolveReleaseFirst = resolve;
+  });
+
+  releaseFirst(): void {
+    this.resolveReleaseFirst();
+  }
+
+  get(id: { toString(): string }) {
+    const requests = this.requests;
+    const objectName = id.toString();
+    return {
+      fetch: async (request: Request) => {
+        const body = (await request
+          .json()
+          .catch(() => ({}))) as FakeOwnerComputeIndexRequest["body"];
+        requests.push({ body, objectName, url: request.url });
+        if (requests.length === 1) {
+          this.resolveFirstStarted();
+          await this.firstRelease;
+        }
+        return Response.json({ ok: true });
+      },
+    };
+  }
+}
+
+class FailingFirstOwnerComputeIndexNamespace extends FakeOwnerComputeIndexNamespace {
+  get(id: { toString(): string }) {
+    const requests = this.requests;
+    const objectName = id.toString();
+    return {
+      fetch: async (request: Request) => {
+        const body = (await request
+          .json()
+          .catch(() => ({}))) as FakeOwnerComputeIndexRequest["body"];
+        requests.push({ body, objectName, url: request.url });
+        if (requests.length === 1) {
+          return new Response("owner compute index unavailable", { status: 503 });
+        }
+        return Response.json({ ok: true });
+      },
+    };
+  }
+}
+
+class FailingNumberedOwnerComputeIndexNamespace extends FakeOwnerComputeIndexNamespace {
+  constructor(private readonly failOnRequestNumber: number) {
+    super();
+  }
+
+  get(id: { toString(): string }) {
+    const requests = this.requests;
+    const objectName = id.toString();
+    return {
+      fetch: async (request: Request) => {
+        const body = (await request
+          .json()
+          .catch(() => ({}))) as FakeOwnerComputeIndexRequest["body"];
+        requests.push({ body, objectName, url: request.url });
+        if (requests.length === this.failOnRequestNumber) {
+          return new Response("owner compute index unavailable", { status: 503 });
+        }
+        return Response.json({ ok: true });
+      },
+    };
+  }
+}
+
 class NotebookOwnerD1 implements D1Database {
   prepare(query: string): D1PreparedStatement {
     return new NotebookOwnerD1Statement(query);
@@ -3224,6 +3906,17 @@ class NotebookOwnerD1 implements D1Database {
 
   async batch<T = unknown>(): Promise<D1Result<T>[]> {
     return [];
+  }
+}
+
+class CountingNotebookOwnerD1 extends NotebookOwnerD1 {
+  notebookLookupCount = 0;
+
+  override prepare(query: string): D1PreparedStatement {
+    if (query.includes("FROM notebooks") && query.includes("WHERE id = ?")) {
+      this.notebookLookupCount += 1;
+    }
+    return super.prepare(query);
   }
 }
 

--- a/crates/runtimed-wasm/src/lib.rs
+++ b/crates/runtimed-wasm/src/lib.rs
@@ -833,6 +833,14 @@ impl RoomHostHandle {
             .map_err(|e| JsError::new(&format!("serialize workstation attachment: {e}")))
     }
 
+    /// Number of executions currently waiting behind any active execution.
+    ///
+    /// Dashboard summaries use this for "N queued" without materializing a
+    /// browser-side shadow of RuntimeStateDoc queue state.
+    pub fn get_runtime_queue_depth(&self) -> usize {
+        self.state_doc.read_state().queue.queued.len()
+    }
+
     /// Generate current sync frames for a peer.
     ///
     /// The Worker calls this immediately after accepting a socket and after the
@@ -5955,6 +5963,11 @@ mod tests {
             "accepted hosted execution intent is immediately visible in the queue projection"
         );
         assert_eq!(
+            host.get_runtime_queue_depth(),
+            1,
+            "queue-depth accessor reflects RuntimeStateDoc queued executions"
+        );
+        assert_eq!(
             host.doc.get_execution_id("cell-1").as_deref(),
             Some(eid.as_str()),
             "the cell points at its queued execution"
@@ -6069,6 +6082,11 @@ mod tests {
                 },
             ],
             "run-all publishes the visible queue in notebook order"
+        );
+        assert_eq!(
+            host.get_runtime_queue_depth(),
+            2,
+            "queue-depth accessor reflects every queued run-all execution"
         );
     }
 


### PR DESCRIPTION
## Summary

- expose RuntimeStateDoc queue depth from the hosted room WASM handle
- publish queue depth into owner compute-session summaries for `/n` dashboard active compute facts
- republish compute summaries when materialized RuntimeStateDoc queue depth changes
- serialize per-notebook compute-summary publishes so same-depth output/widget/runtime-state churn coalesces while an owner-index write is in flight
- re-read the current RuntimeStateDoc workstation attachment after runtime-peer attach checkpointing so stale attach publishes cannot resurrect cleared/replaced compute
- only advance the queue-depth publish cache after confirmed owner-index writes, allowing retry after transient failures
- mark compute summaries dirty after failed owner-index writes so same-depth runtime-state churn retries the publish instead of suppressing it
- skip D1 notebook lookup and owner-index work for clean same-depth runtime-state churn once queue depth has already been published
- cover active/stale compute-index publishing, execution-driven queue-depth publishing, in-flight same-depth coalescing, attach/clear ordering, failed-write retry, dirty same-depth retry, early same-depth D1 skip, no-summary delete coalescing, and hosted queue accessors

## Validation

- pnpm --dir apps/notebook-cloud exec node --import tsx --test --test-name-pattern "does not resurrect|retries same-depth|coalesces same-depth|republishes compute summary|publishes active runtime peers|publishes stale compute|disconnects runtime peers when replacement workstation|skips D1|retries dirty|no-summary" test/notebook-room.test.ts
- pnpm --dir apps/notebook-cloud exec node --import tsx --test test/notebook-room.test.ts
- cargo test -p runtimed-wasm
- pnpm --dir apps/notebook-cloud typecheck
- post-follow-up conflict-avoidance check: `git merge-tree --write-tree quillaid/fix/comment-author-display HEAD` exits `0`
- pnpm test:run -- packages/runtimed/tests/notebook-compute-session.test.ts apps/notebook-cloud/test/notebook-dashboard.test.ts
- cargo xtask lint --fix
- preview smoke: `NOTEBOOK_CLOUD_WORKSTATION_TOOLBAR_SMOKE_WORKSTATION_ID=ws-lab2 NOTEBOOK_CLOUD_WORKSTATION_TOOLBAR_SMOKE_TIMEOUT_MS=90000 pnpm --dir apps/notebook-cloud smoke:hosted:workstation-toolbar`
- preview `/api/n?limit=20` confirmed the smoke notebook has `compute_session.status = active`, `queue_depth = 0`, `runtime_peer_count = 1`, `workstation_id = ws-lab2`

## Review notes

This is intentionally scoped to RuntimeStateDoc-derived queue depth. It does not introduce dashboard-local queue state; the room host reads the queue from the materialized RuntimeStateDoc and passes it through the existing shared compute-session projection. RuntimeStateDoc changes trigger compute-summary republish only when queue depth changes, failed publishes leave the notebook summary dirty for retry, successful no-summary deletes mark that queue depth as reconciled, and publish operations are serialized per notebook so same-depth churn does not fan out concurrent owner-index writes.

## Adversarial review

- reviewed against `.agents/reviewers/nteract-code-review-rubric.md`, focusing on state ownership, authority boundaries, protocol/WASM binding consistency, async stale-publish ordering, output/runtime ownership, and boundary-level tests
- `uv run pr-review doctor` is currently blocked locally by expired refreshed Bedrock credentials: `Credentials were refreshed, but the refreshed credentials are still expired`
- used read-only adversarial GPT subagents with the same rubric as Pullfrog; initial findings were fixed in-branch:
  - failed same-depth writes now remain dirty and retry
  - clean same-depth active churn returns before D1/owner-index work
  - clean same-depth no-summary/delete churn also returns before repeated D1/delete work
- final adversarial re-review on `26fc92ce`: no actionable findings; reviewer verified RuntimeStateDoc ownership, generated artifact consistency, stale-publish ordering, dirty retry/dedupe behavior, focused tests, and clean automatic merge with #3812
- residual risk: live restart/reattach latency is still a product/perf follow-up, but it is outside this queue-depth/indexing patch


