### PR TITLE
feat(notebook): persistent path→id registry so reopening a file keeps its id (NIP-1)

### DIFF
--- a/crates/runtimed/src/daemon.rs
+++ b/crates/runtimed/src/daemon.rs
@@ -27,6 +27,7 @@ use tokio::sync::RwLock;
 use crate::async_outcome::{await_result_with_timeout, TimedResult};
 use crate::blob_server;
 use crate::blob_store::BlobStore;
+use crate::notebook_registry::NotebookRegistry;
 use crate::notebook_sync_server::{NotebookRooms, RoomRegistry};
 use crate::paths::{default_cache_dir, default_socket_path, pool_env_root};
 use crate::protocol::{Request, Response};
@@ -53,6 +54,8 @@ pub struct DaemonConfig {
     pub notebook_docs_dir: PathBuf,
     /// SQLite database storing package names the user has approved before.
     pub trusted_packages_db_path: PathBuf,
+    /// SQLite database mapping canonical notebook paths to stable notebook ids.
+    pub notebook_registry_db_path: PathBuf,
     /// Target number of UV environments to maintain.
     pub uv_pool_size: usize,
     /// Target number of Conda environments to maintain.
@@ -106,6 +109,7 @@ impl Default for DaemonConfig {
             execution_store_dir: crate::default_execution_store_dir(),
             notebook_docs_dir: crate::default_notebook_docs_dir(),
             trusted_packages_db_path: crate::trusted_packages_db_path(),
+            notebook_registry_db_path: crate::notebook_registry_db_path(),
             // These config defaults gate whether each warmer is enabled. The
             // effective target comes from synced settings so the selected
             // Python environment can default to a larger pool.
@@ -1123,6 +1127,8 @@ pub struct Daemon {
     execution_store: runtimed_client::execution_store::ExecutionStore,
     /// Local package allowlist used to auto-approve familiar dependencies.
     pub(crate) trusted_packages: TrustedPackageStore,
+    /// Persistent canonical-path -> stable notebook-id registry.
+    pub(crate) notebook_registry: NotebookRegistry,
     /// HTTP port for the blob server (set after startup).
     blob_port: Mutex<Option<u16>>,
     /// When the daemon process began. Reported via Ping for diagnostics.
@@ -1465,6 +1471,12 @@ impl Daemon {
         };
         log_store_unavailable(&trusted_packages);
 
+        let notebook_registry = NotebookRegistry::open(config.notebook_registry_db_path.clone())
+            .unwrap_or_else(|error| NotebookRegistry::unavailable(error.to_string()));
+        if let Some(reason) = notebook_registry.unavailable_reason() {
+            warn!("[notebook-registry] unavailable; notebook ids will be fresh per run: {reason}");
+        }
+
         let initial_pool_settings = settings.get_all();
         let initial_uv_pool_size =
             effective_pool_target(config.uv_pool_size, initial_pool_settings.uv_pool_size);
@@ -1493,6 +1505,7 @@ impl Daemon {
             blob_store,
             execution_store,
             trusted_packages,
+            notebook_registry,
             blob_port: Mutex::new(None),
             started_at: chrono::Utc::now(),
             notebook_rooms: Arc::new(RoomRegistry::new()),
@@ -2579,9 +2592,15 @@ impl Daemon {
                     {
                         found
                     } else {
+                        // Resolve a stable id for this file so reopening it (even
+                        // across a daemon restart) lands on the same id, instead
+                        // of minting a fresh UUID per run. See NIP-1.
+                        let stable_id = self
+                            .notebook_registry
+                            .resolve_or_assign(&canonical, &chrono::Utc::now().to_rfc3339());
                         crate::notebook_sync_server::get_or_create_room_result(
                             &self.notebook_rooms,
-                            uuid::Uuid::new_v4(),
+                            stable_id,
                             crate::notebook_sync_server::RoomCreationOptions {
                                 path: Some(canonical),
                                 docs_dir: &docs_dir,
@@ -2975,7 +2994,11 @@ impl Daemon {
         {
             existing
         } else {
-            let uuid = uuid::Uuid::new_v4();
+            // Reopening the same file resolves to the same id across daemon
+            // restarts instead of minting a fresh UUID per run. See NIP-1.
+            let uuid = self
+                .notebook_registry
+                .resolve_or_assign(&canonical_path, &chrono::Utc::now().to_rfc3339());
             let path = Some(canonical_path.clone());
             crate::notebook_sync_server::get_or_create_room_result(
                 &self.notebook_rooms,

--- a/crates/runtimed/src/lib.rs
+++ b/crates/runtimed/src/lib.rs
@@ -42,6 +42,7 @@ pub(crate) mod kernel_ports;
 pub mod kernel_state;
 pub mod launcher_cache;
 pub mod markdown_assets;
+pub(crate) mod notebook_registry;
 pub mod notebook_sync_server;
 pub(crate) mod output_blob_publisher;
 pub(crate) mod output_commit_context;
@@ -77,6 +78,10 @@ pub mod workstation;
 
 pub fn trusted_packages_db_path() -> std::path::PathBuf {
     runt_workspace::daemon_base_dir().join("trusted-packages.sqlite")
+}
+
+pub fn notebook_registry_db_path() -> std::path::PathBuf {
+    runt_workspace::daemon_base_dir().join("notebook-registry.sqlite")
 }
 
 /// Get the daemon version string (e.g., "0.1.0-dev.10+abc123").

--- a/crates/runtimed/src/notebook_registry.rs
+++ b/crates/runtimed/src/notebook_registry.rs
@@ -92,7 +92,7 @@ impl NotebookRegistry {
             Inner::Sqlite { conn } => conn,
             Inner::Unavailable { .. } => return None,
         };
-        let key = canonical.to_string_lossy();
+        let key = path_key(canonical)?;
         let guard = conn.lock().unwrap_or_else(|e| e.into_inner());
         let stored: Option<String> = guard
             .query_row(
@@ -124,7 +124,9 @@ impl NotebookRegistry {
             Inner::Sqlite { conn } => conn,
             Inner::Unavailable { .. } => return Uuid::new_v4(),
         };
-        let key = canonical.to_string_lossy();
+        let Some(key) = path_key(canonical) else {
+            return Uuid::new_v4();
+        };
         let candidate = Uuid::new_v4();
         let guard = conn.lock().unwrap_or_else(|e| e.into_inner());
 
@@ -153,6 +155,56 @@ impl NotebookRegistry {
             None => candidate,
         }
     }
+
+    /// Bind `canonical` to `id`, overwriting any prior binding. Used when a save
+    /// claims a path for a room (untitled->save, save-as): the file at that path
+    /// is now this room, so the registry must reflect it. Best-effort.
+    pub fn record(&self, canonical: &Path, id: Uuid, recorded_at: &str) {
+        let conn = match self.inner.as_ref() {
+            Inner::Sqlite { conn } => conn,
+            Inner::Unavailable { .. } => return,
+        };
+        let Some(key) = path_key(canonical) else {
+            return;
+        };
+        let guard = conn.lock().unwrap_or_else(|e| e.into_inner());
+        if let Err(e) = guard.execute(
+            "INSERT INTO notebook_paths (canonical_path, notebook_id, recorded_at) \
+             VALUES (?1, ?2, ?3) \
+             ON CONFLICT(canonical_path) DO UPDATE SET \
+                 notebook_id = excluded.notebook_id, recorded_at = excluded.recorded_at",
+            params![key, id.to_string(), recorded_at],
+        ) {
+            warn!("[notebook-registry] record({key}) failed: {e}");
+        }
+    }
+
+    /// Drop the binding for `canonical`. Used on save-as so the old path no
+    /// longer resolves to the moved room's id (a future file at that path is a
+    /// new notebook). Best-effort.
+    pub fn forget(&self, canonical: &Path) {
+        let conn = match self.inner.as_ref() {
+            Inner::Sqlite { conn } => conn,
+            Inner::Unavailable { .. } => return,
+        };
+        let Some(key) = path_key(canonical) else {
+            return;
+        };
+        let guard = conn.lock().unwrap_or_else(|e| e.into_inner());
+        if let Err(e) = guard.execute(
+            "DELETE FROM notebook_paths WHERE canonical_path = ?1",
+            params![key],
+        ) {
+            warn!("[notebook-registry] forget({key}) failed: {e}");
+        }
+    }
+}
+
+/// The sqlite key for a path: its UTF-8 form. Non-UTF8 paths return `None` and
+/// degrade to mint-fresh / no-op, rather than risk two distinct paths colliding
+/// on the same lossy `U+FFFD` key.
+fn path_key(canonical: &Path) -> Option<&str> {
+    canonical.to_str()
 }
 
 #[cfg(test)]
@@ -208,6 +260,65 @@ mod tests {
         let tmp = tempfile::TempDir::new().unwrap();
         let store = NotebookRegistry::open(tmp.path().join("r.sqlite")).unwrap();
         assert_eq!(store.lookup(Path::new("/never-seen.ipynb")), None);
+    }
+
+    #[test]
+    fn record_binds_and_overwrites_then_survives_reopen() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        let db = tmp.path().join("r.sqlite");
+        let p = Path::new("/Users/me/saved.ipynb");
+        let first = Uuid::new_v4();
+        let second = Uuid::new_v4();
+
+        {
+            let store = NotebookRegistry::open(db.clone()).unwrap();
+            store.record(p, first, TS);
+            assert_eq!(store.lookup(p), Some(first));
+            // A later save of a different room to the same path wins.
+            store.record(p, second, TS);
+            assert_eq!(store.lookup(p), Some(second));
+        }
+        // Survives a "restart".
+        let reopened = NotebookRegistry::open(db).unwrap();
+        assert_eq!(reopened.lookup(p), Some(second));
+        // And a recorded id is what a subsequent open-by-path resolves to.
+        assert_eq!(reopened.resolve_or_assign(p, TS), second);
+    }
+
+    #[test]
+    fn save_as_forgets_old_path_and_binds_new() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        let store = NotebookRegistry::open(tmp.path().join("r.sqlite")).unwrap();
+        let old = Path::new("/old.ipynb");
+        let new = Path::new("/new.ipynb");
+        let id = store.resolve_or_assign(old, TS);
+
+        // Save-as: move the binding to the new path.
+        store.forget(old);
+        store.record(new, id, TS);
+
+        assert_eq!(store.lookup(new), Some(id));
+        // The old path is free: a new file there gets a fresh id, not the moved one.
+        let reused = store.resolve_or_assign(old, TS);
+        assert_ne!(reused, id);
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn non_utf8_path_degrades_to_fresh_and_never_persists() {
+        use std::os::unix::ffi::OsStrExt;
+        let tmp = tempfile::TempDir::new().unwrap();
+        let store = NotebookRegistry::open(tmp.path().join("r.sqlite")).unwrap();
+        // A path with an invalid UTF-8 byte must not be keyed by its lossy form
+        // (which could collide with another bad path); it degrades to fresh.
+        let bad = PathBuf::from(std::ffi::OsStr::from_bytes(b"/tmp/\xff.ipynb"));
+        let a = store.resolve_or_assign(&bad, TS);
+        let b = store.resolve_or_assign(&bad, TS);
+        assert_ne!(
+            a, b,
+            "non-UTF8 paths are not persisted; each open mints fresh"
+        );
+        assert_eq!(store.lookup(&bad), None);
     }
 
     #[test]

--- a/crates/runtimed/src/notebook_registry.rs
+++ b/crates/runtimed/src/notebook_registry.rs
@@ -1,0 +1,224 @@
+//! Daemon-local persistent path -> notebook id registry.
+//!
+//! A `notebook_id` is otherwise a fresh UUID minted per daemon process for each
+//! file open (`daemon.rs`, `Uuid::new_v4()` at the open-by-path sites). The same
+//! `.ipynb` therefore gets a different id every daemon lifetime, which churns the
+//! id-keyed Automerge doc in `docs_dir`, the room identity, and any by-id
+//! reference. This store records `canonical path -> id` in a daemon-local sqlite
+//! file (mirroring `trusted-packages.sqlite`) so opening the same file always
+//! resolves to the same id, across restarts and upgrades.
+//!
+//! It is best-effort: any sqlite failure degrades to today's mint-a-fresh-UUID
+//! behavior. A notebook open never fails because the registry is unavailable.
+//!
+//! See `docs/adr/notebook-identity-and-path-binding.md` (NIP-1).
+
+use std::path::{Path, PathBuf};
+use std::sync::{Arc, Mutex};
+
+use anyhow::{Context, Result};
+use rusqlite::{params, Connection, OptionalExtension};
+use tracing::warn;
+use uuid::Uuid;
+
+#[derive(Debug)]
+enum Inner {
+    Sqlite { conn: Mutex<Connection> },
+    Unavailable { reason: String },
+}
+
+/// Persistent canonical-path -> notebook-id registry. Cheap to clone (an `Arc`
+/// inside); shared across the daemon.
+#[derive(Debug, Clone)]
+pub struct NotebookRegistry {
+    inner: Arc<Inner>,
+}
+
+impl Default for NotebookRegistry {
+    fn default() -> Self {
+        Self::unavailable("not configured")
+    }
+}
+
+impl NotebookRegistry {
+    /// Open (creating if needed) the registry at `path`.
+    pub fn open(path: PathBuf) -> Result<Self> {
+        if let Some(parent) = path.parent() {
+            std::fs::create_dir_all(parent)
+                .with_context(|| format!("create notebook registry dir {}", parent.display()))?;
+        }
+        let conn = Connection::open(&path)
+            .with_context(|| format!("open notebook registry {}", path.display()))?;
+        conn.execute_batch(
+            r#"
+            CREATE TABLE IF NOT EXISTS notebook_paths (
+                canonical_path TEXT PRIMARY KEY,
+                notebook_id    TEXT NOT NULL,
+                recorded_at    TEXT NOT NULL
+            );
+            "#,
+        )
+        .with_context(|| format!("initialize notebook registry {}", path.display()))?;
+
+        Ok(Self {
+            inner: Arc::new(Inner::Sqlite {
+                conn: Mutex::new(conn),
+            }),
+        })
+    }
+
+    /// A no-op registry that always mints fresh ids. Used when the sqlite file
+    /// cannot be opened, and as the default for `RoomRegistry` in tests.
+    pub fn unavailable(reason: impl Into<String>) -> Self {
+        Self {
+            inner: Arc::new(Inner::Unavailable {
+                reason: reason.into(),
+            }),
+        }
+    }
+
+    /// `Some(reason)` when the store is not backed by sqlite.
+    pub fn unavailable_reason(&self) -> Option<&str> {
+        match self.inner.as_ref() {
+            Inner::Sqlite { .. } => None,
+            Inner::Unavailable { reason } => Some(reason.as_str()),
+        }
+    }
+
+    /// Return the id already bound to `canonical`, or `None` if unknown /
+    /// unavailable.
+    pub fn lookup(&self, canonical: &Path) -> Option<Uuid> {
+        let conn = match self.inner.as_ref() {
+            Inner::Sqlite { conn } => conn,
+            Inner::Unavailable { .. } => return None,
+        };
+        let key = canonical.to_string_lossy();
+        let guard = conn.lock().unwrap_or_else(|e| e.into_inner());
+        let stored: Option<String> = guard
+            .query_row(
+                "SELECT notebook_id FROM notebook_paths WHERE canonical_path = ?1",
+                params![key],
+                |row| row.get(0),
+            )
+            .optional()
+            .unwrap_or_else(|e| {
+                warn!("[notebook-registry] lookup({key}) failed: {e}");
+                None
+            });
+        stored.and_then(|s| Uuid::parse_str(&s).ok())
+    }
+
+    /// Resolve `canonical` to its stable id, assigning and recording a fresh one
+    /// on first sight. Concurrency-safe: a racing assign for the same path
+    /// resolves to a single winner via `INSERT OR IGNORE` + re-select.
+    ///
+    /// When the store is unavailable this is just `Uuid::new_v4()`, i.e. the
+    /// pre-registry behavior.
+    pub fn resolve_or_assign(&self, canonical: &Path, recorded_at: &str) -> Uuid {
+        // Common case: the file is already known. Read first so reopening does
+        // not write on every open.
+        if let Some(existing) = self.lookup(canonical) {
+            return existing;
+        }
+        let conn = match self.inner.as_ref() {
+            Inner::Sqlite { conn } => conn,
+            Inner::Unavailable { .. } => return Uuid::new_v4(),
+        };
+        let key = canonical.to_string_lossy();
+        let candidate = Uuid::new_v4();
+        let guard = conn.lock().unwrap_or_else(|e| e.into_inner());
+
+        if let Err(e) = guard.execute(
+            "INSERT OR IGNORE INTO notebook_paths (canonical_path, notebook_id, recorded_at) \
+             VALUES (?1, ?2, ?3)",
+            params![key, candidate.to_string(), recorded_at],
+        ) {
+            warn!("[notebook-registry] assign({key}) failed: {e}; using fresh id");
+            return candidate;
+        }
+
+        let stored: Option<String> = guard
+            .query_row(
+                "SELECT notebook_id FROM notebook_paths WHERE canonical_path = ?1",
+                params![key],
+                |row| row.get(0),
+            )
+            .optional()
+            .unwrap_or(None);
+
+        match stored.and_then(|s| Uuid::parse_str(&s).ok()) {
+            Some(id) => id,
+            // The row vanished or is corrupt between insert and select; fall back
+            // to the candidate rather than failing the open.
+            None => candidate,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const TS: &str = "2026-06-24T00:00:00Z";
+
+    #[test]
+    fn same_path_resolves_to_same_id_across_reopen() {
+        // Simulates a daemon restart: a new store over the same sqlite file must
+        // hand back the id assigned in the previous "run".
+        let tmp = tempfile::TempDir::new().unwrap();
+        let db = tmp.path().join("notebook-registry.sqlite");
+        let path = Path::new("/Users/me/fasty.ipynb");
+
+        let first = {
+            let store = NotebookRegistry::open(db.clone()).unwrap();
+            store.resolve_or_assign(path, TS)
+        };
+        let second = {
+            let store = NotebookRegistry::open(db.clone()).unwrap();
+            store.resolve_or_assign(path, TS)
+        };
+        assert_eq!(first, second, "same file must keep its id across restarts");
+
+        let looked_up = NotebookRegistry::open(db).unwrap().lookup(path);
+        assert_eq!(looked_up, Some(first));
+    }
+
+    #[test]
+    fn distinct_paths_get_distinct_ids() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        let store = NotebookRegistry::open(tmp.path().join("r.sqlite")).unwrap();
+        let a = store.resolve_or_assign(Path::new("/a.ipynb"), TS);
+        let b = store.resolve_or_assign(Path::new("/b.ipynb"), TS);
+        assert_ne!(a, b);
+    }
+
+    #[test]
+    fn repeated_resolve_is_idempotent_within_a_run() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        let store = NotebookRegistry::open(tmp.path().join("r.sqlite")).unwrap();
+        let p = Path::new("/a.ipynb");
+        assert_eq!(
+            store.resolve_or_assign(p, TS),
+            store.resolve_or_assign(p, TS)
+        );
+    }
+
+    #[test]
+    fn lookup_unknown_path_is_none() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        let store = NotebookRegistry::open(tmp.path().join("r.sqlite")).unwrap();
+        assert_eq!(store.lookup(Path::new("/never-seen.ipynb")), None);
+    }
+
+    #[test]
+    fn unavailable_store_mints_fresh_and_never_persists() {
+        // Degraded mode must not fail and must not pretend to remember anything.
+        let store = NotebookRegistry::unavailable("test");
+        assert!(store.unavailable_reason().is_some());
+        let p = Path::new("/a.ipynb");
+        let a = store.resolve_or_assign(p, TS);
+        let b = store.resolve_or_assign(p, TS);
+        assert_ne!(a, b, "no sqlite backing, so no stable id");
+        assert_eq!(store.lookup(p), None);
+    }
+}

--- a/crates/runtimed/src/requests/save_notebook.rs
+++ b/crates/runtimed/src/requests/save_notebook.rs
@@ -132,8 +132,14 @@ pub(crate) async fn handle(
         }
     }
 
+    let registry_now = chrono::Utc::now().to_rfc3339();
     if was_untitled {
         finalize_untitled_promotion(room, canonical.clone()).await;
+        // Persist path -> id so reopening this freshly-saved file keeps its id
+        // across daemon restarts (NIP-1).
+        daemon
+            .notebook_registry
+            .record(&canonical, room.id, &registry_now);
     } else if let Some(old) = old_path.as_ref() {
         let path_changed = old != &canonical;
         if path_changed {
@@ -141,6 +147,12 @@ pub(crate) async fn handle(
             // the old path_index entry and rebind the room to the new path.
             NotebookFileBinding::release_path(&daemon.notebook_rooms, old).await;
             NotebookFileBinding::rebind_after_save_as(room, canonical.clone()).await;
+            // Move the persistent binding with the room: the old path is now a
+            // different (or absent) file and must not resolve to this id.
+            daemon.notebook_registry.forget(old);
+            daemon
+                .notebook_registry
+                .record(&canonical, room.id, &registry_now);
         }
         // If path didn't change, this is save-in-place: nothing else.
     }

--- a/docs/adr/notebook-identity-and-path-binding.md
+++ b/docs/adr/notebook-identity-and-path-binding.md
@@ -53,9 +53,19 @@ The only identity that is globally meaningful is the **cloud/hosted id**, becaus
 
 Cell ids already in nbformat are fine to commit; they are content, not notebook identity.
 
-## Decision 4: New file at a freed path gets a new id; no reclaim by default
+## Decision 4: A freed path gets a new id where we can tell; identity otherwise binds to the path
 
-Delete a file and create a different one at the same path and it gets a **new** id. A new file silently inheriting a prior id - and the prior id's persisted doc, outputs, and trust state - is a footgun, not a feature. "Claim the old id" is an explicit operation if we ever need it, never the default resolution.
+The clean cases hold:
+
+- **Untitled** notebooks have no path, so they cannot collide with a reused path - a new untitled notebook is always a new id.
+- **Save-as** explicitly moves a room from one path to another. The registry forgets the old path and binds the new one (`save_notebook.rs`: `release_path` + `registry.forget`/`record`), so the vacated path is free and a future file there gets a fresh id.
+
+The case we cannot cleanly detect: a file is replaced **out of band** at the same path with no save event the daemon observes - `rm x.ipynb && cp other.ipynb x.ipynb`, a `git checkout`, an editor's atomic write. There the registry still maps that path to the old id, so reopening resolves to the prior id. We accept this, because:
+
+1. The blast radius is small. File-backed rooms reload content from the `.ipynb` and delete the id-keyed Automerge doc on open (`room.rs:859`), and trust is keyed on package content, not id. The replacement gets the old id but its own (correct) content; there is no stale-content leak.
+2. There is no reliable signal to do better. Inode, mtime, birth time, and content hash all change on ordinary edits and atomic saves, so keying on any of them would churn a notebook's id on every save - breaking the whole point of a stable id to "fix" a contrived edge.
+
+So for file-backed notebooks, identity binds to the canonical path over time (`fs::canonicalize`, so symlinks are resolved and trailing slashes normalized). "Claim a fresh id for the file now at this path" is a candidate explicit action if we ever need it (NIP-3), never the default.
 
 ## Decision 5: Carry the path on the session and the rejoin target now (landed stopgap)
 
@@ -75,7 +85,7 @@ This restores ADR `mcp-session-lifecycle.md` Decision 8's invariant for sessions
 
 ## Open Follow-ups
 
-- **NIP-1** (In progress; `crates/runtimed/src/notebook_registry.rs`): the persistent path <-> id registry (daemon-local sqlite, mirroring `trusted-packages.sqlite`) has landed, and the two open-by-path sites in `daemon.rs` now resolve `path -> stable id` instead of minting a fresh UUID per run. **Remaining:** record `path -> id` on untitled->save (`persist.rs` `promote_after_save`) and save-as (`save_notebook.rs` `rebind_after_save_as`) so a notebook first saved within a session keeps its id when reopened by path after a restart. Until then, that one flow re-mints (content still loads correctly from the `.ipynb`).
+- **NIP-1** (Landed; `crates/runtimed/src/notebook_registry.rs`): the persistent path <-> id registry (daemon-local sqlite, mirroring `trusted-packages.sqlite`) is in place. The two open-by-path sites in `daemon.rs` resolve `path -> stable id` instead of minting per run, and `save_notebook.rs` records `path -> id` on untitled->save and forgets-then-records on save-as. A file resolves to the same id across daemon restarts whether it was opened-as-file, saved from untitled, or saved-as.
 - **NIP-2** (Design): ephemeral (untitled) notebook durability across daemon restart. The doc is persisted by id in `docs_dir`, but with no stable id across restarts there is nothing to reload it as. The registry must assign and persist an id at creation, before any save, for this to hold.
 - **NIP-3** (Design): migration and id reconciliation when a file already has an in-memory room under a fresh UUID at the moment the registry is introduced. Decide whether to adopt the existing room's id into the registry or rebind.
 

--- a/docs/adr/notebook-identity-and-path-binding.md
+++ b/docs/adr/notebook-identity-and-path-binding.md
@@ -75,7 +75,7 @@ This restores ADR `mcp-session-lifecycle.md` Decision 8's invariant for sessions
 
 ## Open Follow-ups
 
-- **NIP-1** (Proposed; `crates/runtimed/src/notebook_sync_server/`): build the persistent path <-> id registry (daemon-local sqlite, mirroring `trusted-packages.sqlite`). Make open-by-path resolve `path -> id` and reuse the persisted doc instead of minting a fresh UUID. This is the durable replacement for Decision 5's stopgap.
+- **NIP-1** (In progress; `crates/runtimed/src/notebook_registry.rs`): the persistent path <-> id registry (daemon-local sqlite, mirroring `trusted-packages.sqlite`) has landed, and the two open-by-path sites in `daemon.rs` now resolve `path -> stable id` instead of minting a fresh UUID per run. **Remaining:** record `path -> id` on untitled->save (`persist.rs` `promote_after_save`) and save-as (`save_notebook.rs` `rebind_after_save_as`) so a notebook first saved within a session keeps its id when reopened by path after a restart. Until then, that one flow re-mints (content still loads correctly from the `.ipynb`).
 - **NIP-2** (Design): ephemeral (untitled) notebook durability across daemon restart. The doc is persisted by id in `docs_dir`, but with no stable id across restarts there is nothing to reload it as. The registry must assign and persist an id at creation, before any save, for this to hold.
 - **NIP-3** (Design): migration and id reconciliation when a file already has an in-memory room under a fresh UUID at the moment the registry is introduced. Decide whether to adopt the existing room's id into the registry or rebind.
 


### PR DESCRIPTION
## What this does

Gives a notebook a stable id that survives the daemon process. Today `notebook_id` is a fresh UUID minted per daemon run for each file open, so the same `.ipynb` gets a different id every daemon lifetime - churning the id-keyed Automerge doc in `docs_dir`, the room identity, and any by-id reference. This adds a daemon-local persistent `path -> id` registry so a file resolves to the same id across restarts and upgrades, no matter how it was created.

This is NIP-1 from `docs/adr/notebook-identity-and-path-binding.md` (landed with #3815, which carried the path on the MCP session as the stopgap; this is the durable side).

## Design

- New `crates/runtimed/src/notebook_registry.rs`: a sqlite store mirroring `trusted-packages.sqlite` (rusqlite, `Mutex<Connection>`, an `Unavailable` fallback). One table, `notebook_paths(canonical_path PRIMARY KEY, notebook_id, recorded_at)`.
  - `resolve_or_assign(path)` reads first, and on first sight assigns + records via `INSERT OR IGNORE` + re-select so concurrent assigns for the same path converge on one winner. The two open-by-path sites in `daemon.rs` use it instead of `Uuid::new_v4()`.
  - `record(path, id)` (upsert) / `forget(path)` (delete) keep the binding in step with saves: `save_notebook.rs` records on untitled->save and forgets-the-old-then-records-the-new on save-as.
- **Best-effort by construction.** Any sqlite failure degrades to `NotebookRegistry::unavailable`, which just mints a fresh UUID - the prior behavior. A notebook open never fails because the registry is unavailable. Non-UTF8 paths degrade the same way (keyed on `Path::to_str()`) rather than risk a lossy `U+FFFD` key colliding two distinct paths. The daemon logs once at startup if degraded.

## Why a stable opaque id and not a path-derived one

Per the ADR: identity is opaque and stable, the path is a mutable attribute. The registry is keyed by path but the id is an opaque UUID, so a future move/rename updates the path column without changing identity. Reusing a daemon-local UUID across a daemon swap was exactly the #3815 failure; the path is the durable key, the id is the durable value.

## Behavioral coverage

| Flow | Before | After |
|------|--------|-------|
| open existing file → restart → reopen | new UUID each run | same id |
| untitled → save → restart → reopen by path | new UUID | same id |
| save-as A→B → restart → reopen B | new UUID | same id (A is forgotten, free for a new notebook) |
| out-of-band file swap at a reused path | n/a | inherits the id, gets fresh content from the `.ipynb` (ADR Decision 4 - no reliable signal without churning the id on every edit) |
| ephemeral (untitled, never saved) across a daemon swap | lost | still lost - that's NIP-2 (rejoin reconnect-by-id + `docs_dir` reload), not a path registry |

## Verified

- `cargo test -p runtimed --lib` (1013 pass; includes 8 `notebook_registry` tests: same path → same id across a store reopen, distinct paths → distinct ids, idempotent within a run, record overwrites + survives reopen, save-as forgets old + binds new, non-UTF8 degrades and never persists, unknown lookup is None, unavailable store mints fresh)
- `cargo clippy --workspace --exclude notebook --exclude runtimed-wasm --exclude sift-wasm --exclude runtimed-py --all-targets -- -D warnings`
- `cargo fmt --check`
- **Live, against a rebuilt dev daemon:** created a notebook, saved it to `~/notebooks/nip1-registry-test.ipynb` (id `6281d6d9…`), confirmed the registry row, **fully restarted the daemon** (in-memory state gone), reopened by path → same id `6281d6d9…`, with `recorded_at` unchanged (the reopen read the existing row, did not re-mint).

## Review

Codex-reviewed: no blockers. Addressed the non-UTF8 key collision (degrade to fresh) and rewrote ADR Decision 4 to be honest about the out-of-band-replacement edge (no reliable file-identity signal exists that survives ordinary edits). Race handling, best-effort degradation, lock/await safety, stable-id correctness, and migration confirmed clean.
