### PR TITLE
fix(release): put install instructions before changelog

### DIFF
--- a/.github/release-notes/2.6.0.md
+++ b/.github/release-notes/2.6.0.md
@@ -1,0 +1,17 @@
+- **Notebook outline and rail:** long notebooks now have a left-rail outline,
+  with package management moving into the same notebook-adjacent workspace
+  instead of competing with cells.
+- **Widget state and rich outputs:** widget comm state is saved and restored
+  more reliably, with improvements for Bokeh, Panel, raster image copy, and
+  output resilience across refreshes.
+- **Markdown as document structure:** Markdown rendering now leans on the shared
+  Rust/WASM path, including better outline anchors, live outline updates,
+  spellcheck, and bare TeX projection as math.
+- **Everyday editing controls:** cells can be switched between code and Markdown
+  from the context and main menus, and automatic formatting can be disabled when
+  exact source layout matters.
+- **Session and file recovery:** reopened files keep stable notebook identities,
+  MCP joiners rejoin file-backed rooms by path, and untitled notebooks
+  auto-recover after daemon restarts.
+- **Comments preview:** the new comments surface is included behind the opt-in
+  **Enable Comments UI** feature flag ahead of the fuller 2.7 commenting release.

--- a/.github/release-notes/README.md
+++ b/.github/release-notes/README.md
@@ -1,0 +1,16 @@
+# Curated GitHub Release Highlights
+
+The release workflow always publishes install instructions first and keeps the
+raw `git-cliff` changelog in a collapsed details block.
+
+To add human-curated release highlights, create one of these Markdown files:
+
+- `.github/release-notes/<base-version>.md` for an exact release, such as
+  `2.6.0.md`
+- `.github/release-notes/<major>.<minor>.md` for a release series, such as
+  `2.6.md`
+- `.github/release-notes/stable.md` or `.github/release-notes/nightly.md` for a
+  channel fallback
+
+The workflow uses the first file it finds in that order. Keep the file body to
+the highlights only; the workflow supplies the surrounding release structure.

--- a/.github/workflows/release-common.yml
+++ b/.github/workflows/release-common.yml
@@ -1403,6 +1403,7 @@ jobs:
           COMMIT_SHA: ${{ github.sha }}
           RELEASE_INTRO: ${{ inputs.release_intro }}
           RELEASE_REPO: ${{ github.repository }}
+          BASE_VERSION: ${{ needs.compute-version.outputs.base_version }}
           TAG_NAME: v${{ needs.compute-version.outputs.version }}
         run: |
           CLI_NAME="runt"
@@ -1414,18 +1415,35 @@ jobs:
             MCP_NAME="nteract-mcp-nightly"
           fi
           INSTALLER_URL="https://github.com/${RELEASE_REPO}/releases/download/${TAG_NAME}/install-linux-release"
+
+          RELEASE_SERIES="${BASE_VERSION%.*}"
+          HIGHLIGHTS_FILE=""
+          for candidate in \
+            ".github/release-notes/${BASE_VERSION}.md" \
+            ".github/release-notes/${RELEASE_SERIES}.md" \
+            ".github/release-notes/${VERSION_SUFFIX}.md"
+          do
+            if [ -f "$candidate" ]; then
+              HIGHLIGHTS_FILE="$candidate"
+              break
+            fi
+          done
+
+          if [ -n "$HIGHLIGHTS_FILE" ]; then
+            cp "$HIGHLIGHTS_FILE" release-highlights.md
+          else
+            {
+              echo "No curated highlights were provided for this release."
+              echo "See the generated changelog below for the complete commit summary."
+            } > release-highlights.md
+          fi
+
           {
             echo "$RELEASE_INTRO"
             echo ''
-            echo "## What's Changed"
+            echo '## Install'
             echo ''
-            cat changelog-section.md
-            echo ''
-            echo '---'
-            echo ''
-            echo "**Commit:** \`${COMMIT_SHA}\`"
-            echo ''
-            echo '## nteract (desktop app)'
+            echo '### nteract (desktop app)'
             echo ''
             echo '| Platform | Architecture | Download |'
             echo '|----------|--------------|----------|'
@@ -1436,7 +1454,9 @@ jobs:
             echo ''
             echo "macOS and Windows builds are signed. macOS builds are also notarized. Linux AppImage: \`chmod +x\` and run. DEB/RPM packages are not currently supported because runtimed is a per-user daemon managed by the app and CLI, not by system package-manager scripts."
             echo ''
-            echo "For Linux/macOS shell installs, run the installer pinned to this release:"
+            echo '### Shell installer for Linux/macOS'
+            echo ''
+            echo 'Pinned to this release:'
             echo ''
             echo '```bash'
             echo "curl -fsSL ${INSTALLER_URL} | bash"
@@ -1458,7 +1478,17 @@ jobs:
             fi
             echo 'This release includes auto-update support. Existing installations will be notified of this update automatically.'
             echo ''
-            echo "## ${CLI_NAME} (CLI)"
+            echo '### runtimed (Python — macOS, Linux, Windows)'
+            echo ''
+            echo '```bash'
+            if [ "$VERSION_SUFFIX" = "nightly" ]; then
+              echo 'pip install --pre runtimed'
+            else
+              echo 'pip install runtimed'
+            fi
+            echo '```'
+            echo ''
+            echo "### ${CLI_NAME} (CLI)"
             echo ''
             echo 'Also bundled inside the desktop app. Standalone binaries:'
             echo ''
@@ -1470,15 +1500,22 @@ jobs:
             echo "| macOS | ARM64 | \`${CLI_NAME}-darwin-arm64\` |"
             echo "| macOS | x64 (Intel) | \`${CLI_NAME}-darwin-x64\` |"
             echo ''
-            echo '## runtimed (Python — macOS, Linux, Windows)'
+            echo '## Release highlights'
             echo ''
-            echo '```bash'
-            if [ "$VERSION_SUFFIX" = "nightly" ]; then
-              echo 'pip install --pre runtimed'
-            else
-              echo 'pip install runtimed'
-            fi
-            echo '```'
+            cat release-highlights.md
+            echo ''
+            echo '## Full generated changelog'
+            echo ''
+            echo '<details>'
+            echo '<summary>Open the raw git-cliff changelog</summary>'
+            echo ''
+            cat changelog-section.md
+            echo ''
+            echo '</details>'
+            echo ''
+            echo '---'
+            echo ''
+            echo "**Commit:** \`${COMMIT_SHA}\`"
           } > release-body.md
 
       - name: Create GitHub Release

--- a/.github/workflows/release-common.yml
+++ b/.github/workflows/release-common.yml
@@ -1462,12 +1462,6 @@ jobs:
             echo "curl -fsSL ${INSTALLER_URL} | bash"
             echo '```'
             echo ''
-            echo 'Headless workstation install:'
-            echo ''
-            echo '```bash'
-            echo "curl -fsSL ${INSTALLER_URL} | bash -s -- --headless"
-            echo '```'
-            echo ''
             if [ "$VERSION_SUFFIX" != "nightly" ]; then
               echo 'Latest stable shortcut:'
               echo ''

--- a/.github/workflows/release-common.yml
+++ b/.github/workflows/release-common.yml
@@ -1462,6 +1462,14 @@ jobs:
             echo "curl -fsSL ${INSTALLER_URL} | bash"
             echo '```'
             echo ''
+            if [ "$VERSION_SUFFIX" = "nightly" ]; then
+              echo 'Headless workstation install:'
+              echo ''
+              echo '```bash'
+              echo "curl -fsSL ${INSTALLER_URL} | bash -s -- --headless"
+              echo '```'
+              echo ''
+            fi
             if [ "$VERSION_SUFFIX" != "nightly" ]; then
               echo 'Latest stable shortcut:'
               echo ''


### PR DESCRIPTION
## Summary
- update the release body generator so install/download instructions come before changelog content
- add optional curated release highlight files under .github/release-notes
- collapse the raw git-cliff changelog under a details block
- include the 2.6.0 curated highlights used to clean up the live stable release

## Live release update
- Updated https://github.com/nteract/nteract/releases/tag/v2.6.0-stable.202606251403 directly with the install-first body and collapsed raw changelog.

## Tests
- local release-body render simulation for 2.6.0 highlights
- git diff --check
- cargo xtask lint --fix

Note: actionlint is not installed in this environment.