### PR TITLE
fix(mcp): preserve viz llm summaries in tool output

### DIFF
--- a/crates/runt-mcp/src/execution.rs
+++ b/crates/runt-mcp/src/execution.rs
@@ -187,7 +187,7 @@ pub async fn execute_and_wait(
     } else {
         let aligned =
             output_resolver::resolve_cell_outputs_for_llm_aligned(&output_manifests, ctx).await;
-        let outputs = aligned.iter().filter_map(|output| output.clone()).collect();
+        let outputs = aligned.iter().flatten().cloned().collect();
         (outputs, aligned)
     };
 

--- a/crates/runt-mcp/src/execution.rs
+++ b/crates/runt-mcp/src/execution.rs
@@ -28,6 +28,8 @@ pub struct ExecutionResult {
     pub execution_id: Option<String>,
     /// Resolved outputs from the cell after execution.
     pub outputs: Vec<Output>,
+    /// Resolved outputs indexed to the original output manifest positions.
+    pub resolved_outputs_by_manifest: Vec<Option<Output>>,
     /// Execution count (e.g., "5" for In[5]).
     pub execution_count: Option<String>,
     /// Final status: "done", "error", "running" (if timed out).
@@ -93,6 +95,7 @@ pub async fn execute_and_wait(
                 cell_id: cell_id.to_string(),
                 execution_id: None,
                 outputs: Vec::new(),
+                resolved_outputs_by_manifest: Vec::new(),
                 execution_count: None,
                 status: "error".to_string(),
                 success: false,
@@ -168,16 +171,22 @@ pub async fn execute_and_wait(
         execution_cell_map: Some(&execution_cell_map),
         ..Default::default()
     };
-    let outputs = if !output_manifests.is_empty() {
-        output_resolver::resolve_cell_outputs_for_llm(&output_manifests, ctx).await
+    let (outputs, resolved_outputs_by_manifest) = if !output_manifests.is_empty() {
+        let aligned =
+            output_resolver::resolve_cell_outputs_for_llm_aligned(&output_manifests, ctx).await;
+        let outputs = aligned.iter().filter_map(|output| output.clone()).collect();
+        (outputs, aligned)
     } else {
         // Outputs live in RuntimeStateDoc under execution_id/output_id. Fetch
         // via the explicit lookup — CellSnapshot no longer carries them.
         let raw_outputs = handle.get_cell_outputs(cell_id).unwrap_or_default();
         if raw_outputs.is_empty() {
-            Vec::new()
+            (Vec::new(), Vec::new())
         } else {
-            output_resolver::resolve_cell_outputs_for_llm(&raw_outputs, ctx).await
+            let aligned =
+                output_resolver::resolve_cell_outputs_for_llm_aligned(&raw_outputs, ctx).await;
+            let outputs = aligned.iter().filter_map(|output| output.clone()).collect();
+            (outputs, aligned)
         }
     };
 
@@ -191,6 +200,7 @@ pub async fn execute_and_wait(
         cell_id: cell_id.to_string(),
         execution_id,
         outputs,
+        resolved_outputs_by_manifest,
         execution_count,
         status: final_status,
         success,

--- a/crates/runt-mcp/src/execution.rs
+++ b/crates/runt-mcp/src/execution.rs
@@ -28,6 +28,8 @@ pub struct ExecutionResult {
     pub execution_id: Option<String>,
     /// Resolved outputs from the cell after execution.
     pub outputs: Vec<Output>,
+    /// Output manifests that produced `outputs` and `resolved_outputs_by_manifest`.
+    pub output_manifests: Vec<serde_json::Value>,
     /// Resolved outputs indexed to the original output manifest positions.
     pub resolved_outputs_by_manifest: Vec<Option<Output>>,
     /// Execution count (e.g., "5" for In[5]).
@@ -95,6 +97,7 @@ pub async fn execute_and_wait(
                 cell_id: cell_id.to_string(),
                 execution_id: None,
                 outputs: Vec::new(),
+                output_manifests: Vec::new(),
                 resolved_outputs_by_manifest: Vec::new(),
                 execution_count: None,
                 status: "error".to_string(),
@@ -171,23 +174,21 @@ pub async fn execute_and_wait(
         execution_cell_map: Some(&execution_cell_map),
         ..Default::default()
     };
-    let (outputs, resolved_outputs_by_manifest) = if !output_manifests.is_empty() {
+    let output_manifests = if !output_manifests.is_empty() {
+        output_manifests
+    } else {
+        // Outputs live in RuntimeStateDoc under execution_id/output_id. Fetch
+        // via the explicit lookup — CellSnapshot no longer carries them.
+        handle.get_cell_outputs(cell_id).unwrap_or_default()
+    };
+
+    let (outputs, resolved_outputs_by_manifest) = if output_manifests.is_empty() {
+        (Vec::new(), Vec::new())
+    } else {
         let aligned =
             output_resolver::resolve_cell_outputs_for_llm_aligned(&output_manifests, ctx).await;
         let outputs = aligned.iter().filter_map(|output| output.clone()).collect();
         (outputs, aligned)
-    } else {
-        // Outputs live in RuntimeStateDoc under execution_id/output_id. Fetch
-        // via the explicit lookup — CellSnapshot no longer carries them.
-        let raw_outputs = handle.get_cell_outputs(cell_id).unwrap_or_default();
-        if raw_outputs.is_empty() {
-            (Vec::new(), Vec::new())
-        } else {
-            let aligned =
-                output_resolver::resolve_cell_outputs_for_llm_aligned(&raw_outputs, ctx).await;
-            let outputs = aligned.iter().filter_map(|output| output.clone()).collect();
-            (outputs, aligned)
-        }
     };
 
     // Determine status from outputs if we didn't get it from RuntimeState
@@ -200,6 +201,7 @@ pub async fn execute_and_wait(
         cell_id: cell_id.to_string(),
         execution_id,
         outputs,
+        output_manifests,
         resolved_outputs_by_manifest,
         execution_count,
         status: final_status,

--- a/crates/runt-mcp/src/structured.rs
+++ b/crates/runt-mcp/src/structured.rs
@@ -45,7 +45,7 @@ pub struct CellStructuredContentManifestInput<'a> {
     pub status: &'a str,
     pub blob_base_url: &'a Option<String>,
     pub comms: Option<&'a HashMap<String, CommDocEntry>>,
-    pub resolved_outputs: Option<&'a [Output]>,
+    pub resolved_outputs_by_manifest: Option<&'a [Option<Output>]>,
 }
 
 /// Build structuredContent JSON directly from manifest Values and blob URLs.
@@ -66,8 +66,9 @@ pub fn cell_structured_content_from_manifests(
                 input.blob_base_url,
                 input.comms,
                 input
-                    .resolved_outputs
-                    .and_then(|outputs| outputs.get(index)),
+                    .resolved_outputs_by_manifest
+                    .and_then(|outputs| outputs.get(index))
+                    .and_then(Option::as_ref),
             )
         })
         .collect::<Vec<_>>();
@@ -709,12 +710,12 @@ mod tests {
                 "text/plain": inline_ref("Figure()"),
             },
         });
-        let resolved_outputs = vec![Output::display_data(HashMap::from([(
+        let resolved_outputs_by_manifest = vec![Some(Output::display_data(HashMap::from([(
             "text/llm+plain".to_string(),
             runtimed_outputs::resolved_output::DataValue::Text(
                 "Plotly chart: 1 bar trace".to_string(),
             ),
-        )]))];
+        )])))];
         let blob_base = Some("http://localhost:9999".to_string());
 
         let result = cell_structured_content_from_manifests(CellStructuredContentManifestInput {
@@ -726,7 +727,7 @@ mod tests {
             status: "done",
             blob_base_url: &blob_base,
             comms: None,
-            resolved_outputs: Some(&resolved_outputs),
+            resolved_outputs_by_manifest: Some(&resolved_outputs_by_manifest),
         });
 
         let data = result["cell"]["outputs"][0]["data"]
@@ -737,6 +738,64 @@ mod tests {
             "http://localhost:9999/blob/plotly_hash"
         );
         assert_eq!(data["text/llm+plain"], "Plotly chart: 1 bar trace");
+    }
+
+    #[test]
+    fn structured_resolved_llm_plain_stays_aligned_when_manifest_resolution_drops_output() {
+        let dropped_manifest = json!({
+            "output_type": "display_data",
+        });
+        let plotly_manifest = json!({
+            "output_type": "display_data",
+            "data": {
+                "application/vnd.plotly.v1+json": blob_ref("plotly_hash", 4_096),
+            },
+        });
+        let resolved_outputs_by_manifest = vec![
+            None,
+            Some(Output::display_data(HashMap::from([(
+                "text/llm+plain".to_string(),
+                runtimed_outputs::resolved_output::DataValue::Text(
+                    "Plotly chart: aligned summary".to_string(),
+                ),
+            )]))),
+        ];
+        let manifests = vec![dropped_manifest, plotly_manifest];
+        let blob_base = Some("http://localhost:9999".to_string());
+
+        let result = cell_structured_content_from_manifests(CellStructuredContentManifestInput {
+            cell_id: "cell-plotly",
+            cell_type: "code",
+            source: "fig",
+            output_manifests: &manifests,
+            execution_count: Some(1),
+            status: "done",
+            blob_base_url: &blob_base,
+            comms: None,
+            resolved_outputs_by_manifest: Some(&resolved_outputs_by_manifest),
+        });
+
+        let outputs = result["cell"]["outputs"]
+            .as_array()
+            .expect("outputs should be an array");
+        let first_data = outputs[0]["data"]
+            .as_object()
+            .expect("first output data should be an object");
+        assert!(
+            !first_data.contains_key("text/llm+plain"),
+            "summary must not be injected into a preceding dropped manifest"
+        );
+        let second_data = outputs[1]["data"]
+            .as_object()
+            .expect("second output data should be an object");
+        assert_eq!(
+            second_data["application/vnd.plotly.v1+json"],
+            "http://localhost:9999/blob/plotly_hash"
+        );
+        assert_eq!(
+            second_data["text/llm+plain"],
+            "Plotly chart: aligned summary"
+        );
     }
 
     #[test]
@@ -963,7 +1022,7 @@ mod tests {
             status: "done",
             blob_base_url: &blob_base,
             comms: None,
-            resolved_outputs: None,
+            resolved_outputs_by_manifest: None,
         });
         assert_eq!(result["cell"]["cell_id"], "cell-123");
         assert_eq!(result["cell"]["cell_type"], "code");

--- a/crates/runt-mcp/src/structured.rs
+++ b/crates/runt-mcp/src/structured.rs
@@ -12,6 +12,7 @@
 use notebook_doc::mime::MimeKind;
 use runtime_doc::CommDocEntry;
 use runtimed_outputs::output_resolver;
+use runtimed_outputs::resolved_output::{DataValue, Output};
 use serde_json::{json, Value};
 use std::collections::HashMap;
 
@@ -44,6 +45,7 @@ pub struct CellStructuredContentManifestInput<'a> {
     pub status: &'a str,
     pub blob_base_url: &'a Option<String>,
     pub comms: Option<&'a HashMap<String, CommDocEntry>>,
+    pub resolved_outputs: Option<&'a [Output]>,
 }
 
 /// Build structuredContent JSON directly from manifest Values and blob URLs.
@@ -54,12 +56,28 @@ pub struct CellStructuredContentManifestInput<'a> {
 pub fn cell_structured_content_from_manifests(
     input: CellStructuredContentManifestInput<'_>,
 ) -> Value {
+    let outputs = input
+        .output_manifests
+        .iter()
+        .enumerate()
+        .map(|(index, manifest)| {
+            manifest_output_to_structured_with_resolved(
+                manifest,
+                input.blob_base_url,
+                input.comms,
+                input
+                    .resolved_outputs
+                    .and_then(|outputs| outputs.get(index)),
+            )
+        })
+        .collect::<Vec<_>>();
+
     let mut content = json!({
         "cell": {
             "cell_id": input.cell_id,
             "source": input.source,
             "cell_type": input.cell_type,
-            "outputs": input.output_manifests.iter().map(|m| manifest_output_to_structured(m, input.blob_base_url, input.comms)).collect::<Vec<_>>(),
+            "outputs": outputs,
             "execution_count": input.execution_count,
             "status": input.status,
         }
@@ -76,10 +94,20 @@ pub fn cell_structured_content_from_manifests(
 ///
 /// Reads inline content directly from ContentRef entries and emits blob URLs
 /// for blob-stored content. No blob fetches are performed.
+#[cfg(test)]
 fn manifest_output_to_structured(
     manifest: &Value,
     blob_base_url: &Option<String>,
     comms: Option<&HashMap<String, CommDocEntry>>,
+) -> Value {
+    manifest_output_to_structured_with_resolved(manifest, blob_base_url, comms, None)
+}
+
+fn manifest_output_to_structured_with_resolved(
+    manifest: &Value,
+    blob_base_url: &Option<String>,
+    comms: Option<&HashMap<String, CommDocEntry>>,
+    resolved_output: Option<&Output>,
 ) -> Value {
     let output_type = manifest
         .get("output_type")
@@ -266,6 +294,8 @@ fn manifest_output_to_structured(
                 }
             }
 
+            merge_resolved_llm_plain(&mut data, resolved_output);
+
             let mut result = json!({
                 "output_type": output_type,
                 "data": data,
@@ -279,6 +309,29 @@ fn manifest_output_to_structured(
         }
         _ => attach_id(json!({"output_type": output_type})),
     }
+}
+
+fn merge_resolved_llm_plain(
+    data: &mut serde_json::Map<String, Value>,
+    resolved_output: Option<&Output>,
+) {
+    let Some(resolved_output) = resolved_output else {
+        return;
+    };
+    if !matches!(
+        resolved_output.output_type.as_str(),
+        "display_data" | "execute_result"
+    ) {
+        return;
+    }
+    let Some(resolved_data) = resolved_output.data.as_ref() else {
+        return;
+    };
+    let Some(DataValue::Text(summary)) = resolved_data.get("text/llm+plain") else {
+        return;
+    };
+
+    data.insert("text/llm+plain".to_string(), Value::String(summary.clone()));
 }
 
 fn widget_model_id_from_content_ref(content_ref: &Value) -> Option<String> {
@@ -645,6 +698,48 @@ mod tests {
     }
 
     #[test]
+    fn structured_merges_resolved_llm_plain_for_blob_backed_viz_specs() {
+        // Real Plotly/Vega specs usually exceed the inline ContentRef threshold.
+        // The structured renderer still needs the blob URL, while the MCP output
+        // payload should carry the already-resolved LLM summary.
+        let manifest = json!({
+            "output_type": "display_data",
+            "data": {
+                "application/vnd.plotly.v1+json": blob_ref("plotly_hash", 4_096),
+                "text/plain": inline_ref("Figure()"),
+            },
+        });
+        let resolved_outputs = vec![Output::display_data(HashMap::from([(
+            "text/llm+plain".to_string(),
+            runtimed_outputs::resolved_output::DataValue::Text(
+                "Plotly chart: 1 bar trace".to_string(),
+            ),
+        )]))];
+        let blob_base = Some("http://localhost:9999".to_string());
+
+        let result = cell_structured_content_from_manifests(CellStructuredContentManifestInput {
+            cell_id: "cell-plotly",
+            cell_type: "code",
+            source: "fig",
+            output_manifests: &[manifest],
+            execution_count: Some(1),
+            status: "done",
+            blob_base_url: &blob_base,
+            comms: None,
+            resolved_outputs: Some(&resolved_outputs),
+        });
+
+        let data = result["cell"]["outputs"][0]["data"]
+            .as_object()
+            .expect("output data should be an object");
+        assert_eq!(
+            data["application/vnd.plotly.v1+json"],
+            "http://localhost:9999/blob/plotly_hash"
+        );
+        assert_eq!(data["text/llm+plain"], "Plotly chart: 1 bar trace");
+    }
+
+    #[test]
     fn structured_widget_view_gets_safe_summary_from_comms() {
         let manifest = json!({
             "output_type": "display_data",
@@ -868,6 +963,7 @@ mod tests {
             status: "done",
             blob_base_url: &blob_base,
             comms: None,
+            resolved_outputs: None,
         });
         assert_eq!(result["cell"]["cell_id"], "cell-123");
         assert_eq!(result["cell"]["cell_type"], "code");

--- a/crates/runt-mcp/src/structured.rs
+++ b/crates/runt-mcp/src/structured.rs
@@ -319,6 +319,9 @@ fn merge_resolved_llm_plain(
     let Some(resolved_output) = resolved_output else {
         return;
     };
+    if data.contains_key("text/llm+plain") {
+        return;
+    }
     if !matches!(
         resolved_output.output_type.as_str(),
         "display_data" | "execute_result"
@@ -795,6 +798,37 @@ mod tests {
         assert_eq!(
             second_data["text/llm+plain"],
             "Plotly chart: aligned summary"
+        );
+    }
+
+    #[test]
+    fn structured_resolved_llm_plain_does_not_overwrite_existing_summary() {
+        let manifest = json!({
+            "output_type": "display_data",
+            "data": {
+                "text/llm+plain": inline_ref("author summary"),
+            },
+        });
+        let resolved_outputs_by_manifest = vec![Some(Output::display_data(HashMap::from([(
+            "text/llm+plain".to_string(),
+            runtimed_outputs::resolved_output::DataValue::Text("resolved summary".to_string()),
+        )])))];
+
+        let result = cell_structured_content_from_manifests(CellStructuredContentManifestInput {
+            cell_id: "cell-summary",
+            cell_type: "code",
+            source: "display",
+            output_manifests: &[manifest],
+            execution_count: Some(1),
+            status: "done",
+            blob_base_url: &None,
+            comms: None,
+            resolved_outputs_by_manifest: Some(&resolved_outputs_by_manifest),
+        });
+
+        assert_eq!(
+            result["cell"]["outputs"][0]["data"]["text/llm+plain"],
+            "author summary"
         );
     }
 

--- a/crates/runt-mcp/src/tools/execution.rs
+++ b/crates/runt-mcp/src/tools/execution.rs
@@ -272,23 +272,20 @@ pub async fn run_all_cells(
         }
         content_items.extend(formatting::outputs_to_content_items(&outputs));
 
-        // Structured content for MCP Apps: use manifests from the cell snapshot
-        // (which include ContentRef entries needed for structured rendering).
+        // Structured content for MCP Apps: use the same manifest slice resolved
+        // above so resolved summaries stay aligned to their source manifests.
         // Extract the inner "cell" object — cell_structured_content_from_manifests
         // returns {"cell": {...}, "blob_base_url": "..."} but the multi-cell
         // wrapper expects CellData directly in the cells[] array.
-        // Outputs live in RuntimeStateDoc, keyed by execution_id; fetch them
-        // alongside the snapshot.
         let cell_snapshot = handle.get_cell(&cell.id);
         if let Some(snap) = cell_snapshot {
-            let snap_outputs = handle.get_cell_outputs(&cell.id).unwrap_or_default();
-            if !snap_outputs.is_empty() {
+            if !output_manifests.is_empty() {
                 let wrapped = crate::structured::cell_structured_content_from_manifests(
                     crate::structured::CellStructuredContentManifestInput {
                         cell_id: &snap.id,
                         cell_type: &snap.cell_type,
                         source: &snap.source,
-                        output_manifests: &snap_outputs,
+                        output_manifests,
                         execution_count: exec.execution_count,
                         status: display_status,
                         blob_base_url: &server.blob_base_url,

--- a/crates/runt-mcp/src/tools/execution.rs
+++ b/crates/runt-mcp/src/tools/execution.rs
@@ -291,6 +291,7 @@ pub async fn run_all_cells(
                         status: display_status,
                         blob_base_url: &server.blob_base_url,
                         comms,
+                        resolved_outputs: Some(&outputs),
                     },
                 );
                 if let Some(mut cell_data) = wrapped.get("cell").cloned() {
@@ -521,6 +522,7 @@ async fn render_execution_result(
                 status: display_status,
                 blob_base_url: &server.blob_base_url,
                 comms,
+                resolved_outputs: Some(&outputs),
             },
         );
         wrapped.get("cell").cloned().map(|mut cell_data| {

--- a/crates/runt-mcp/src/tools/execution.rs
+++ b/crates/runt-mcp/src/tools/execution.rs
@@ -247,7 +247,7 @@ pub async fn run_all_cells(
                 },
             )
             .await;
-            let outputs = aligned.iter().filter_map(|output| output.clone()).collect();
+            let outputs = aligned.iter().flatten().cloned().collect();
             (outputs, aligned)
         } else {
             (Vec::new(), Vec::new())
@@ -461,7 +461,7 @@ async fn render_execution_result(
             },
         )
         .await;
-        let outputs = aligned.iter().filter_map(|output| output.clone()).collect();
+        let outputs = aligned.iter().flatten().cloned().collect();
         (outputs, aligned)
     } else {
         (Vec::new(), Vec::new())

--- a/crates/runt-mcp/src/tools/execution.rs
+++ b/crates/runt-mcp/src/tools/execution.rs
@@ -234,9 +234,9 @@ pub async fn run_all_cells(
 
         // Resolve outputs from the execution's output manifests.
         let output_manifests = &exec.outputs;
-        let outputs = if !output_manifests.is_empty() {
+        let (outputs, resolved_outputs_by_manifest) = if !output_manifests.is_empty() {
             // Batch execute path — always preview mode. No per-cell opt-out.
-            runtimed_outputs::output_resolver::resolve_cell_outputs_for_llm(
+            let aligned = runtimed_outputs::output_resolver::resolve_cell_outputs_for_llm_aligned(
                 output_manifests,
                 runtimed_outputs::output_resolver::ResolveCtx {
                     blob_base_url: server.blob_base_url.as_deref(),
@@ -246,9 +246,11 @@ pub async fn run_all_cells(
                     ..Default::default()
                 },
             )
-            .await
+            .await;
+            let outputs = aligned.iter().filter_map(|output| output.clone()).collect();
+            (outputs, aligned)
         } else {
-            Vec::new()
+            (Vec::new(), Vec::new())
         };
 
         // Text content: cell header + output text items.
@@ -291,7 +293,7 @@ pub async fn run_all_cells(
                         status: display_status,
                         blob_base_url: &server.blob_base_url,
                         comms,
-                        resolved_outputs: Some(&outputs),
+                        resolved_outputs_by_manifest: Some(&resolved_outputs_by_manifest),
                     },
                 );
                 if let Some(mut cell_data) = wrapped.get("cell").cloned() {
@@ -446,8 +448,8 @@ async fn render_execution_result(
     );
 
     // Resolve outputs from the execution's manifests
-    let outputs = if !exec.outputs.is_empty() {
-        output_resolver::resolve_cell_outputs_for_llm(
+    let (outputs, resolved_outputs_by_manifest) = if !exec.outputs.is_empty() {
+        let aligned = output_resolver::resolve_cell_outputs_for_llm_aligned(
             &exec.outputs,
             output_resolver::ResolveCtx {
                 blob_base_url: server.blob_base_url.as_deref(),
@@ -461,9 +463,11 @@ async fn render_execution_result(
                 execution_cell_map: execution_cell_map.as_ref(),
             },
         )
-        .await
+        .await;
+        let outputs = aligned.iter().filter_map(|output| output.clone()).collect();
+        (outputs, aligned)
     } else {
-        Vec::new()
+        (Vec::new(), Vec::new())
     };
 
     let mut items = vec![rmcp::model::Content::text(header)];
@@ -522,7 +526,7 @@ async fn render_execution_result(
                 status: display_status,
                 blob_base_url: &server.blob_base_url,
                 comms,
-                resolved_outputs: Some(&outputs),
+                resolved_outputs_by_manifest: Some(&resolved_outputs_by_manifest),
             },
         );
         wrapped.get("cell").cloned().map(|mut cell_data| {

--- a/crates/runt-mcp/src/tools/mod.rs
+++ b/crates/runt-mcp/src/tools/mod.rs
@@ -611,6 +611,7 @@ pub async fn build_execution_result(
                 status: &result.status,
                 blob_base_url: &server.blob_base_url,
                 comms: runtime_comms.as_ref(),
+                resolved_outputs: Some(&result.outputs),
             },
         ))
     } else {

--- a/crates/runt-mcp/src/tools/mod.rs
+++ b/crates/runt-mcp/src/tools/mod.rs
@@ -589,12 +589,11 @@ pub async fn build_execution_result(
 
     // Build structured content directly from manifest Values + blob URLs.
     // No blob fetches — inline ContentRefs pass through, blobs become URLs.
-    // Outputs live in RuntimeStateDoc, keyed by execution_id, so we fetch
-    // them separately from the cell snapshot.
+    // Use the same manifest slice captured during execution resolution so
+    // resolved summaries stay aligned to their source manifests.
     let cell_snapshot = handle.get_cell(&result.cell_id);
     let runtime_comms = handle.get_runtime_state().ok().map(|rs| rs.comms);
     let mut structured_content = if let Some(snap) = cell_snapshot {
-        let outputs = handle.get_cell_outputs(&result.cell_id).unwrap_or_default();
         let ec_str = cell_read::get_cell_execution_count_from_runtime(handle, &snap.id);
         let ec: Option<i64> = if ec_str.is_empty() {
             None
@@ -606,7 +605,7 @@ pub async fn build_execution_result(
                 cell_id: &snap.id,
                 cell_type: &snap.cell_type,
                 source: &snap.source,
-                output_manifests: &outputs,
+                output_manifests: &result.output_manifests,
                 execution_count: ec,
                 status: &result.status,
                 blob_base_url: &server.blob_base_url,

--- a/crates/runt-mcp/src/tools/mod.rs
+++ b/crates/runt-mcp/src/tools/mod.rs
@@ -611,7 +611,7 @@ pub async fn build_execution_result(
                 status: &result.status,
                 blob_base_url: &server.blob_base_url,
                 comms: runtime_comms.as_ref(),
-                resolved_outputs: Some(&result.outputs),
+                resolved_outputs_by_manifest: Some(&result.resolved_outputs_by_manifest),
             },
         ))
     } else {

--- a/crates/runtimed-outputs/src/output_resolver.rs
+++ b/crates/runtimed-outputs/src/output_resolver.rs
@@ -598,11 +598,25 @@ pub async fn resolve_cell_outputs_for_llm(
     raw_outputs: &[serde_json::Value],
     ctx: ResolveCtx<'_>,
 ) -> Vec<Output> {
+    resolve_cell_outputs_for_llm_aligned(raw_outputs, ctx)
+        .await
+        .into_iter()
+        .flatten()
+        .collect()
+}
+
+/// Resolve outputs for LLM consumption while preserving manifest positions.
+///
+/// Use this when a caller must pair resolved outputs back to the original
+/// output manifests. Unknown or malformed manifests resolve to `None`, so the
+/// returned vector always has the same length and order as `raw_outputs`.
+pub async fn resolve_cell_outputs_for_llm_aligned(
+    raw_outputs: &[serde_json::Value],
+    ctx: ResolveCtx<'_>,
+) -> Vec<Option<Output>> {
     let mut outputs = Vec::with_capacity(raw_outputs.len());
     for manifest in raw_outputs {
-        if let Some(output) = resolve_output_for_llm(manifest, ctx).await {
-            outputs.push(output);
-        }
+        outputs.push(resolve_output_for_llm(manifest, ctx).await);
     }
     outputs
 }
@@ -2519,6 +2533,29 @@ mod tests {
         };
         assert!(data.contains_key("text/plain"));
         assert!(!data.contains_key("image/png"));
+    }
+
+    #[tokio::test]
+    async fn llm_aligned_resolution_preserves_none_for_dropped_manifests() {
+        let manifests = vec![
+            json!({
+                "output_type": "display_data",
+            }),
+            json!({
+                "output_type": "stream",
+                "name": "stdout",
+                "text": inline_ref("print output"),
+            }),
+        ];
+
+        let outputs = resolve_cell_outputs_for_llm_aligned(&manifests, ResolveCtx::default()).await;
+
+        assert_eq!(outputs.len(), 2);
+        assert!(outputs[0].is_none());
+        let Some(output) = outputs[1].as_ref() else {
+            panic!("second manifest should resolve");
+        };
+        assert_eq!(output.output_type, "stream");
     }
 
     // ── llm_preview rendering ───────────────────────────────────

--- a/scripts/smoke-mcp.py
+++ b/scripts/smoke-mcp.py
@@ -593,7 +593,7 @@ MCP TEXT CONTENT TRANSCRIPT:
     if verdict.get("saw_plotly_llm_summary") is not True:
         fail(f"[viz-llm] model did not report seeing Plotly LLM summary: {verdict}")
     excerpt = str(verdict.get("plotly_summary_excerpt") or "")
-    if "Plotly" not in excerpt:
+    if "Plotly bar chart" not in excerpt:
         fail(f"[viz-llm] model verdict did not include a Plotly excerpt: {verdict}")
 
 

--- a/scripts/smoke-mcp.py
+++ b/scripts/smoke-mcp.py
@@ -130,25 +130,39 @@ def parse_json_body(body: str) -> dict | None:
     return parsed if isinstance(parsed, dict) else None
 
 
-def parse_json_value(body: str) -> Any | None:
-    """Best-effort parse for tool responses that are printed as JSON."""
+def iter_json_values(body: str):
+    """Yield JSON values embedded in text, in source order."""
     text = body.strip()
     if not text:
-        return None
+        return
 
     try:
-        parsed = json.loads(text)
+        yield json.loads(text)
+        return
     except json.JSONDecodeError:
-        start = text.find("{")
-        end = text.rfind("}")
-        if start == -1 or end == -1 or end <= start:
-            return None
-        try:
-            parsed = json.loads(text[start : end + 1])
-        except json.JSONDecodeError:
-            return None
+        pass
 
-    return parsed
+    decoder = json.JSONDecoder()
+    for match in re.finditer(r"[\[{]", text):
+        try:
+            parsed, _ = decoder.raw_decode(text[match.start() :])
+        except json.JSONDecodeError:
+            continue
+        yield parsed
+
+
+def parse_json_value(body: str) -> Any | None:
+    """Best-effort parse for tool responses that are printed as JSON."""
+    return next(iter_json_values(body), None)
+
+
+def parse_opencode_verdict(body: str) -> dict | None:
+    """Parse the first embedded OpenCode verdict object with the expected keys."""
+    expected = {"saw_plotly_llm_summary", "plotly_summary_excerpt", "reason"}
+    for parsed in iter_json_values(body):
+        if isinstance(parsed, dict) and expected.issubset(parsed):
+            return parsed
+    return None
 
 
 def kernel_launch_error(body: str) -> str | None:
@@ -587,8 +601,8 @@ MCP TEXT CONTENT TRANSCRIPT:
         print(f"[viz-llm] opencode stderr:\n{stderr_text}", file=sys.stderr)
     print(f"[viz-llm] opencode stdout:\n{stdout_text}")
 
-    verdict = parse_json_value(stdout_text)
-    if not isinstance(verdict, dict):
+    verdict = parse_opencode_verdict(stdout_text)
+    if verdict is None:
         fail(f"[viz-llm] opencode did not return a JSON object: {stdout_text}")
     if verdict.get("saw_plotly_llm_summary") is not True:
         fail(f"[viz-llm] model did not report seeing Plotly LLM summary: {verdict}")

--- a/scripts/smoke-mcp.py
+++ b/scripts/smoke-mcp.py
@@ -8,17 +8,28 @@ Spawns `runt mcp` (or `runt.exe mcp`) over stdio and runs two passes:
      small DataFrame, render it as the cell's execute_result, assert the
      rendered output contains the expected column names and values.
      Proves uv env resolution + package install + dataframe display.
+  3. Optional Viz LLM: ephemeral notebook with pandas/plotly/altair,
+     create four cells (imports, DataFrame, Plotly, Altair/Vega-Lite),
+     run all cells, and assert the MCP text content includes repr-llm
+     summaries for the table and both chart specs. With `--opencode`,
+     send only the MCP text content to OpenCode and ask a model for a
+     strict JSON verdict that it saw the Plotly LLM summary.
 
 Exits non-zero on any failure.
 
 Usage:
     python scripts/smoke-mcp.py <path-to-runt>
+    python scripts/smoke-mcp.py <path-to-runt> --viz-llm
+    python scripts/smoke-mcp.py <path-to-runt> --viz-llm --opencode \\
+        --opencode-model <provider/model>
 """
 
 from __future__ import annotations
 
+import argparse
 import asyncio
 import json
+import os
 import re
 import shutil
 import sys
@@ -59,9 +70,26 @@ def fail(msg: str) -> None:
     sys.exit(1)
 
 
+def env_truthy(name: str) -> bool:
+    return os.environ.get(name, "").strip().lower() in {"1", "true", "yes", "on"}
+
+
+def content_text_blocks(result) -> list[str]:
+    """Return text-typed content blocks from a tool result."""
+    return [c.text for c in result.content if hasattr(c, "text")]
+
+
 def text_of(result) -> str:
     """Concat all text-typed content blocks from a tool result."""
-    return "\n".join(c.text for c in result.content if hasattr(c, "text"))
+    return "\n".join(content_text_blocks(result))
+
+
+def content_transcript_of(result) -> str:
+    """Render MCP text content blocks with boundaries for LLM harness checks."""
+    blocks = content_text_blocks(result)
+    return "\n\n".join(
+        f"--- MCP content item {index} ---\n{block}" for index, block in enumerate(blocks, 1)
+    )
 
 
 def stdout_of(body: str) -> str:
@@ -303,19 +331,7 @@ async def run_cell_and_get_body(session: ClientSession, source: str, label: str)
     Polls `get_results` for up to 240s to cover the slow path where the
     kernel needs to install dependencies on first execute.
     """
-    print(f"[{label}] create_cell")
-    cell = await session.call_tool(
-        "create_cell",
-        {"cell_type": "code", "source": source},
-    )
-    if cell.isError:
-        fail(f"create_cell errored: {text_of(cell)}")
-    print(text_of(cell))
-
-    match = CELL_ID_RE.search(text_of(cell))
-    if not match:
-        fail(f"could not parse cell_id from create_cell response: {text_of(cell)}")
-    cell_id = match.group(0)
+    cell_id = await create_code_cell(session, source, label)
 
     print(f"[{label}] execute_cell {cell_id}")
     exec_result = await session.call_tool("execute_cell", {"cell_id": cell_id})
@@ -351,6 +367,52 @@ async def run_cell_and_get_body(session: ClientSession, source: str, label: str)
             print(f"[{label}] attempt {attempt}: still pending")
 
     fail(f"[{label}] execution did not complete within 240s")
+
+
+async def create_code_cell(session: ClientSession, source: str, label: str) -> str:
+    """Create a code cell and return its cell_id."""
+    print(f"[{label}] create_cell")
+    cell = await session.call_tool(
+        "create_cell",
+        {"cell_type": "code", "source": source},
+    )
+    if cell.isError:
+        fail(f"[{label}] create_cell errored: {text_of(cell)}")
+    print(text_of(cell))
+
+    match = CELL_ID_RE.search(text_of(cell))
+    if not match:
+        fail(f"[{label}] could not parse cell_id from create_cell response: {text_of(cell)}")
+    return match.group(0)
+
+
+async def first_cell_id(session: ClientSession, label: str) -> str:
+    """Return the current notebook's first cell_id."""
+    print(f"[{label}] get_all_cells(format=json, count=1)")
+    result = await session.call_tool("get_all_cells", {"format": "json", "count": 1})
+    body = text_of(result)
+    if result.isError:
+        fail(f"[{label}] get_all_cells errored: {body}")
+
+    cells = parse_json_value(body)
+    if not isinstance(cells, list) or not cells:
+        fail(f"[{label}] get_all_cells returned no cells: {body}")
+    cell_id = cells[0].get("cell_id") if isinstance(cells[0], dict) else None
+    if not isinstance(cell_id, str) or not cell_id:
+        fail(f"[{label}] could not read first cell_id from get_all_cells: {body}")
+    return cell_id
+
+
+async def set_code_cell(session: ClientSession, cell_id: str, source: str, label: str) -> None:
+    """Update an existing cell to code with the given source."""
+    print(f"[{label}] set_cell {cell_id}")
+    result = await session.call_tool(
+        "set_cell",
+        {"cell_id": cell_id, "cell_type": "code", "source": source},
+    )
+    if result.isError:
+        fail(f"[{label}] set_cell errored: {text_of(result)}")
+    print(text_of(result))
 
 
 async def basic_pass(session: ClientSession, smoke_root: Path) -> None:
@@ -404,7 +466,200 @@ async def polars_pass(session: ClientSession, smoke_root: Path) -> None:
     print("[polars] PASS")
 
 
-async def smoke(runt_exe: Path) -> None:
+VIZ_IMPORT_CELL = """
+import pandas as pd
+import plotly.express as px
+import altair as alt
+""".strip()
+
+VIZ_DATAFRAME_CELL = """
+df = pd.DataFrame({
+    "region": ["north", "south", "east", "west"],
+    "revenue": [125, 98, 143, 87],
+    "orders": [42, 31, 55, 28],
+})
+df
+""".strip()
+
+VIZ_PLOTLY_CELL = """
+fig = px.bar(
+    df,
+    x="region",
+    y="revenue",
+    color="orders",
+    title="Revenue by Region",
+)
+fig
+""".strip()
+
+VIZ_ALTAIR_CELL = """
+chart = alt.Chart(df).mark_circle(size=120).encode(
+    x=alt.X("orders:Q", title="Orders"),
+    y=alt.Y("revenue:Q", title="Revenue"),
+    color="region:N",
+    tooltip=["region", "revenue", "orders"],
+).properties(title="Revenue vs Orders")
+chart
+""".strip()
+
+
+def assert_viz_llm_content(transcript: str) -> None:
+    """Assert the model-facing MCP content contains repr-llm summaries."""
+    required_snippets = {
+        "DataFrame summary": "DataFrame",
+        "DataFrame column": "revenue",
+        "Plotly LLM summary": "Plotly bar chart",
+        "Plotly title": 'Revenue by Region"',
+        "Vega-Lite LLM summary": "Vega-Lite circle chart",
+        "Vega-Lite encoding": "Encoding:",
+    }
+    missing = [name for name, snippet in required_snippets.items() if snippet not in transcript]
+    if missing:
+        fail(
+            "[viz-llm] MCP content missing expected repr-llm snippets "
+            f"{missing!r}; transcript was:\n{transcript}"
+        )
+
+
+async def run_opencode_plotly_verdict(
+    transcript: str,
+    model: str | None,
+    timeout_secs: float,
+    work_dir: Path,
+) -> None:
+    """Ask OpenCode whether the MCP text transcript exposed the Plotly summary."""
+    opencode_bin = os.environ.get("NTERACT_SMOKE_OPENCODE_BIN") or shutil.which("opencode")
+    if not opencode_bin:
+        fail("[viz-llm] --opencode requested but opencode was not found on PATH")
+
+    prompt = f"""
+You are checking whether an MCP tool result exposed an LLM-optimized Plotly chart summary.
+
+Use only the MCP text content transcript below. Do not infer from Python source code. Return true
+only if the transcript literally contains an output summary such as "Plotly bar chart".
+
+Return exactly one JSON object and no markdown:
+{{
+  "saw_plotly_llm_summary": true|false,
+  "plotly_summary_excerpt": "short exact excerpt or empty string",
+  "reason": "one short sentence"
+}}
+
+MCP TEXT CONTENT TRANSCRIPT:
+{transcript}
+""".strip()
+
+    args = [
+        opencode_bin,
+        "run",
+        "--pure",
+        "--format",
+        "default",
+        "--dir",
+        str(work_dir),
+    ]
+    if model:
+        args.extend(["--model", model])
+    args.append(prompt)
+
+    model_label = model or "configured default"
+    print(f"[viz-llm] opencode verdict using {model_label}")
+    proc = await asyncio.create_subprocess_exec(
+        *args,
+        stdout=asyncio.subprocess.PIPE,
+        stderr=asyncio.subprocess.PIPE,
+    )
+    try:
+        stdout, stderr = await asyncio.wait_for(proc.communicate(), timeout=timeout_secs)
+    except asyncio.TimeoutError:
+        proc.kill()
+        await proc.communicate()
+        fail(f"[viz-llm] opencode timed out after {timeout_secs}s")
+
+    stdout_text = stdout.decode("utf-8", errors="replace").strip()
+    stderr_text = stderr.decode("utf-8", errors="replace").strip()
+    if proc.returncode != 0:
+        fail(
+            f"[viz-llm] opencode exited {proc.returncode}\n"
+            f"stdout:\n{stdout_text}\n\nstderr:\n{stderr_text}"
+        )
+    if stderr_text:
+        print(f"[viz-llm] opencode stderr:\n{stderr_text}", file=sys.stderr)
+    print(f"[viz-llm] opencode stdout:\n{stdout_text}")
+
+    verdict = parse_json_value(stdout_text)
+    if not isinstance(verdict, dict):
+        fail(f"[viz-llm] opencode did not return a JSON object: {stdout_text}")
+    if verdict.get("saw_plotly_llm_summary") is not True:
+        fail(f"[viz-llm] model did not report seeing Plotly LLM summary: {verdict}")
+    excerpt = str(verdict.get("plotly_summary_excerpt") or "")
+    if "Plotly" not in excerpt:
+        fail(f"[viz-llm] model verdict did not include a Plotly excerpt: {verdict}")
+
+
+async def viz_llm_pass(
+    session: ClientSession,
+    smoke_root: Path,
+    *,
+    run_opencode: bool,
+    opencode_model: str | None,
+    opencode_timeout_secs: float,
+) -> None:
+    """Full MCP text-content pass for DataFrame, Plotly, and Altair/Vega summaries."""
+    working_dir = smoke_root / "viz-llm"
+    working_dir.mkdir(parents=True, exist_ok=True)
+
+    print("[viz-llm] create_notebook(dependencies=['pandas', 'plotly', 'altair'])")
+    notebook_id = await create_notebook_checked(
+        session,
+        "viz-llm",
+        {
+            "dependencies": ["pandas", "plotly", "altair"],
+            "working_dir": str(working_dir),
+        },
+    )
+    await wait_for_kernel_ready(session, notebook_id, "viz-llm")
+
+    import_cell_id = await first_cell_id(session, "viz-llm/imports")
+    await set_code_cell(session, import_cell_id, VIZ_IMPORT_CELL, "viz-llm/imports")
+    await create_code_cell(session, VIZ_DATAFRAME_CELL, "viz-llm/dataframe")
+    await create_code_cell(session, VIZ_PLOTLY_CELL, "viz-llm/plotly")
+    await create_code_cell(session, VIZ_ALTAIR_CELL, "viz-llm/altair")
+
+    print("[viz-llm] run_all_cells")
+    result = await session.call_tool("run_all_cells", {"timeout_secs": 300})
+    transcript = content_transcript_of(result)
+    print(transcript)
+    if result.isError:
+        fail(f"[viz-llm] run_all_cells errored: {transcript}")
+    if "Execution completed (4 succeeded)" not in transcript:
+        fail(f"[viz-llm] run_all_cells did not report four successful cells:\n{transcript}")
+
+    transcript_path = working_dir / "mcp-content-transcript.txt"
+    transcript_path.write_text(transcript, encoding="utf-8")
+    print(f"[viz-llm] wrote MCP content transcript: {transcript_path}")
+
+    assert_viz_llm_content(transcript)
+
+    if run_opencode:
+        await run_opencode_plotly_verdict(
+            transcript,
+            opencode_model,
+            opencode_timeout_secs,
+            working_dir,
+        )
+
+    print("[viz-llm] PASS")
+
+
+async def smoke(
+    runt_exe: Path,
+    *,
+    run_viz_llm: bool,
+    run_opencode: bool,
+    opencode_model: str | None,
+    opencode_timeout_secs: float,
+) -> None:
     params = StdioServerParameters(command=str(runt_exe), args=["mcp"])
 
     async with stdio_client(params) as (read, write), ClientSession(read, write) as session:
@@ -418,7 +673,9 @@ async def smoke(runt_exe: Path) -> None:
             "list_active_notebooks",
             "create_notebook",
             "create_cell",
+            "set_cell",
             "execute_cell",
+            "run_all_cells",
             "get_results",
         ):
             if required not in tool_names:
@@ -440,19 +697,67 @@ async def smoke(runt_exe: Path) -> None:
                 lambda active_session: polars_pass(active_session, smoke_root_path),
                 session,
             )
+            if run_viz_llm:
+                await run_smoke_pass(
+                    "viz-llm",
+                    lambda active_session: viz_llm_pass(
+                        active_session,
+                        smoke_root_path,
+                        run_opencode=run_opencode,
+                        opencode_model=opencode_model,
+                        opencode_timeout_secs=opencode_timeout_secs,
+                    ),
+                    session,
+                )
         finally:
             shutil.rmtree(smoke_root_path, ignore_errors=True)
         print("[smoke] ALL PASSES GREEN")
 
 
 def main() -> None:
-    if len(sys.argv) != 2:
-        print(__doc__, file=sys.stderr)
-        sys.exit(2)
-    runt_exe = Path(sys.argv[1])
+    parser = argparse.ArgumentParser(
+        description="Cross-platform smoke test driving the runtimed daemon over MCP."
+    )
+    parser.add_argument("runt_exe", type=Path, help="Path to the runt executable")
+    parser.add_argument(
+        "--viz-llm",
+        action="store_true",
+        default=env_truthy("NTERACT_SMOKE_VIZ_LLM"),
+        help="Run the optional DataFrame/Plotly/Altair LLM-output MCP content pass",
+    )
+    parser.add_argument(
+        "--opencode",
+        action="store_true",
+        default=env_truthy("NTERACT_SMOKE_OPENCODE"),
+        help="For --viz-llm, ask OpenCode for a model-backed verdict on the MCP content",
+    )
+    parser.add_argument(
+        "--opencode-model",
+        default=os.environ.get("NTERACT_SMOKE_OPENCODE_MODEL"),
+        help="OpenCode model id, for example provider/model. Also implies --opencode.",
+    )
+    parser.add_argument(
+        "--opencode-timeout-secs",
+        type=float,
+        default=float(os.environ.get("NTERACT_SMOKE_OPENCODE_TIMEOUT_SECS", "240")),
+        help="Timeout for the OpenCode verdict step",
+    )
+    args = parser.parse_args()
+
+    runt_exe = args.runt_exe
     if not runt_exe.exists():
         fail(f"runt exe not found: {runt_exe}")
-    asyncio.run(smoke(runt_exe))
+    run_opencode = args.opencode or bool(args.opencode_model)
+    run_viz_llm = args.viz_llm or run_opencode
+    asyncio.run(
+        smoke(
+            runt_exe,
+            run_viz_llm=run_viz_llm,
+            run_opencode=run_opencode,
+            opencode_model=args.opencode_model,
+            opencode_timeout_secs=args.opencode_timeout_secs,
+        )
+    )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

- merge resolved `text/llm+plain` payloads back into MCP structured output manifests so blob-backed Plotly and Vega specs still expose LLM-oriented summaries
- preserve manifest alignment for those resolved payloads so dropped/unknown outputs cannot shift summaries onto the wrong manifest
- render structured summaries from the same manifest slice used for resolution, and keep existing `text/llm+plain` summaries authoritative
- add an opt-in MCP smoke pass that runs pandas, Plotly, and Altair cells and asserts the model-facing MCP content includes the LLM summaries
- add an optional OpenCode verdict over the MCP text transcript for local Bedrock-backed verification, with schema-keyed JSON extraction from mixed stdout

## Verification

- `cargo build -p runt`
- `uv run python scripts/smoke-mcp.py ./target/debug/runt --viz-llm --opencode-model amazon-bedrock/zai.glm-4.7-flash --opencode-timeout-secs 180`
- `cargo fmt --all -- --check`
- `cargo test -p runtimed-outputs -p runt-mcp`
- `cargo test -p runt-mcp structured::tests:: -- --nocapture`
- `cargo test -p runtimed-outputs llm_aligned_resolution_preserves_none_for_dropped_manifests -- --nocapture`
- `uv run ruff check scripts/smoke-mcp.py`
- `uv run ruff format --check scripts/smoke-mcp.py`
- `uv run python -m py_compile scripts/smoke-mcp.py`
- `git diff --check`

## Notes

- `--opencode` with the configured default local/Ollama model timed out locally; the explicit Bedrock model above passed.
- `cargo xtask lint --fix` reaches the JavaScript dependency install step and then fails the existing pnpm lockfile trust policy for `chokidar@4.0.3`, `semver@6.3.1`, and `undici-types@6.21.0`; Rust formatting, raw-control-byte check, ruff, and ty all passed before that failure.
