### PR TITLE
fix(xtask): honor pinned pnpm version

### DIFF
--- a/crates/xtask/src/main.rs
+++ b/crates/xtask/src/main.rs
@@ -391,12 +391,248 @@ fn require_cargo_subcommand(name: &str, install_hint: &str) {
     }
 }
 
-const PNPM_INSTALL: &str = "brew install pnpm  (or: npm install -g pnpm)";
+const PNPM_INSTALL: &str = "corepack enable  (or install the pnpm version pinned in package.json)";
 const TAURI_INSTALL: &str = "cargo install tauri-cli";
 const WASM_PACK_INSTALL: &str = "cargo install wasm-pack --version 0.15.0 --locked";
 
-fn require_pnpm() {
-    require_tool(pnpm_bin(), PNPM_INSTALL);
+fn require_pnpm() -> PnpmCommand {
+    let pnpm = resolve_pnpm_command_or_exit();
+    println!("Using pnpm {} via {}", pnpm.version, pnpm.display_name());
+    pnpm
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum PnpmSource {
+    Corepack,
+    Direct,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct PnpmCommand {
+    source: PnpmSource,
+    version: String,
+}
+
+impl PnpmCommand {
+    fn command(&self) -> Command {
+        let mut command = Command::new(self.program());
+        command.args(self.prefix_args());
+        if self.source == PnpmSource::Corepack {
+            command.env("COREPACK_ENABLE_DOWNLOAD_PROMPT", "0");
+        }
+        command
+    }
+
+    fn program(&self) -> &'static str {
+        match self.source {
+            PnpmSource::Corepack => corepack_bin(),
+            PnpmSource::Direct => pnpm_bin(),
+        }
+    }
+
+    fn prefix_args(&self) -> &'static [&'static str] {
+        match self.source {
+            PnpmSource::Corepack => &["pnpm"],
+            PnpmSource::Direct => &[],
+        }
+    }
+
+    fn display_name(&self) -> &'static str {
+        match self.source {
+            PnpmSource::Corepack => "corepack pnpm",
+            PnpmSource::Direct => "pnpm",
+        }
+    }
+
+    fn display_with_args(&self, args: &[&str]) -> String {
+        let mut parts = Vec::with_capacity(1 + args.len());
+        parts.push(self.display_name().to_string());
+        parts.extend(args.iter().map(|arg| (*arg).to_string()));
+        parts.join(" ")
+    }
+}
+
+fn resolve_pnpm_command_or_exit() -> PnpmCommand {
+    let expected = expected_pnpm_version_or_exit();
+    let root = workspace_root_or_exit();
+
+    let corepack_version = probe_pnpm_version(corepack_bin(), &["pnpm"], &root);
+    if version_matches(&corepack_version, &expected) {
+        return PnpmCommand {
+            source: PnpmSource::Corepack,
+            version: expected,
+        };
+    }
+
+    let direct_version = probe_pnpm_version(pnpm_bin(), &[], &root);
+
+    match choose_pnpm_source(&expected, &corepack_version, &direct_version) {
+        Some(PnpmSource::Corepack) => PnpmCommand {
+            source: PnpmSource::Corepack,
+            version: expected,
+        },
+        Some(PnpmSource::Direct) => PnpmCommand {
+            source: PnpmSource::Direct,
+            version: expected,
+        },
+        None => {
+            eprintln!(
+                "Error: package.json pins `pnpm@{expected}`, but xtask could not resolve that pnpm version."
+            );
+            eprintln!(
+                "  corepack pnpm --version: {}",
+                describe_pnpm_probe(&corepack_version)
+            );
+            eprintln!(
+                "  {} --version: {}",
+                pnpm_bin(),
+                describe_pnpm_probe(&direct_version)
+            );
+            eprintln!();
+            eprintln!("  Install:  {PNPM_INSTALL}");
+            eprintln!("  Or put a pnpm {expected} shim before other pnpm binaries in PATH.");
+            eprintln!();
+            eprintln!(
+                "Refusing to run a mismatched ambient pnpm because it may reinstall node_modules."
+            );
+            exit(1);
+        }
+    }
+}
+
+fn choose_pnpm_source(
+    expected: &str,
+    corepack_version: &Result<String, String>,
+    direct_version: &Result<String, String>,
+) -> Option<PnpmSource> {
+    if version_matches(corepack_version, expected) {
+        Some(PnpmSource::Corepack)
+    } else if version_matches(direct_version, expected) {
+        Some(PnpmSource::Direct)
+    } else {
+        None
+    }
+}
+
+fn version_matches(version: &Result<String, String>, expected: &str) -> bool {
+    matches!(version, Ok(actual) if actual == expected)
+}
+
+fn expected_pnpm_version_or_exit() -> String {
+    expected_pnpm_version().unwrap_or_else(|error| {
+        eprintln!("Error: {error}");
+        exit(1);
+    })
+}
+
+fn expected_pnpm_version() -> Result<String, String> {
+    let root = workspace_root_or_exit();
+    let package_json = root.join("package.json");
+    let contents = fs::read_to_string(&package_json)
+        .map_err(|error| format!("failed to read {}: {error}", package_json.display()))?;
+    let manifest: serde_json::Value = serde_json::from_str(&contents)
+        .map_err(|error| format!("failed to parse {}: {error}", package_json.display()))?;
+    let package_manager = manifest
+        .get("packageManager")
+        .and_then(serde_json::Value::as_str)
+        .ok_or_else(|| format!("{} is missing `packageManager`", package_json.display()))?;
+
+    parse_pnpm_package_manager_version(package_manager).map(str::to_string)
+}
+
+fn parse_pnpm_package_manager_version(package_manager: &str) -> Result<&str, String> {
+    let version = package_manager.strip_prefix("pnpm@").ok_or_else(|| {
+        format!("`packageManager` must be a pnpm spec like `pnpm@10.30.0`, got `{package_manager}`")
+    })?;
+    let version = version.split('+').next().unwrap_or(version);
+    if version.is_empty() {
+        Err("`packageManager` must include a pnpm version".to_string())
+    } else {
+        Ok(version)
+    }
+}
+
+fn probe_pnpm_version(program: &str, prefix_args: &[&str], root: &Path) -> Result<String, String> {
+    let mut command = Command::new(program);
+    command
+        .args(prefix_args)
+        .arg("--version")
+        .current_dir(root)
+        .stdin(Stdio::null())
+        .env("COREPACK_ENABLE_DOWNLOAD_PROMPT", "0");
+
+    let output = command
+        .output()
+        .map_err(|error| format!("failed to start: {error}"))?;
+    if !output.status.success() {
+        return Err(format!(
+            "exited with status {}{}",
+            output.status,
+            command_output_summary(&output.stdout, &output.stderr)
+        ));
+    }
+
+    last_non_empty_line(&output.stdout)
+        .or_else(|| last_non_empty_line(&output.stderr))
+        .ok_or_else(|| "succeeded but printed no version".to_string())
+}
+
+fn last_non_empty_line(bytes: &[u8]) -> Option<String> {
+    String::from_utf8_lossy(bytes)
+        .lines()
+        .map(str::trim)
+        .filter(|line| !line.is_empty())
+        .last()
+        .map(str::to_string)
+}
+
+fn command_output_summary(stdout: &[u8], stderr: &[u8]) -> String {
+    let mut lines = Vec::new();
+    if let Some(line) = last_non_empty_line(stdout) {
+        lines.push(line);
+    }
+    if let Some(line) = last_non_empty_line(stderr) {
+        lines.push(line);
+    }
+    if lines.is_empty() {
+        String::new()
+    } else {
+        format!(" ({})", lines.join("; "))
+    }
+}
+
+fn describe_pnpm_probe(result: &Result<String, String>) -> String {
+    match result {
+        Ok(version) => format!("reported pnpm {version}"),
+        Err(error) => error.clone(),
+    }
+}
+
+fn run_pnpm(args: &[&str]) {
+    let pnpm = resolve_pnpm_command_or_exit();
+    let mut command = pnpm.command();
+    command.args(args);
+
+    let status = command.status().unwrap_or_else(|error| {
+        eprintln!("Failed to run {}: {error}", pnpm.display_name());
+        exit(1);
+    });
+
+    if !status.success() {
+        eprintln!("Command failed: {}", pnpm.display_with_args(args));
+        exit(status.code().unwrap_or(1));
+    }
+}
+
+fn run_pnpm_ok(args: &[&str]) -> bool {
+    let pnpm = resolve_pnpm_command_or_exit();
+    let mut command = pnpm.command();
+    command.args(args);
+
+    command.status().map(|s| s.success()).unwrap_or_else(|e| {
+        eprintln!("Failed to run {}: {e}", pnpm.display_name());
+        false
+    })
 }
 
 /// Name to invoke pnpm under for `Command::new`.
@@ -412,6 +648,18 @@ fn pnpm_bin() -> &'static str {
         "pnpm.cmd"
     } else {
         "pnpm"
+    }
+}
+
+/// Name to invoke Corepack under for `Command::new`.
+///
+/// Corepack is also installed as a `.cmd` shim on Windows, so use the same
+/// explicit extension pattern as pnpm to avoid relying on PATHEXT expansion.
+fn corepack_bin() -> &'static str {
+    if cfg!(windows) {
+        "corepack.cmd"
+    } else {
+        "corepack"
     }
 }
 
@@ -587,7 +835,7 @@ fn run_notebook_dev_app(notebook: Option<&str>, attach: bool, force_dev_mode: bo
 }
 
 fn cmd_vite() {
-    require_pnpm();
+    let pnpm = require_pnpm();
 
     println!("Starting Vite dev server...");
     println!("This server will keep running independently of Tauri.");
@@ -599,24 +847,26 @@ fn cmd_vite() {
         println!("Using RUNTIMED_VITE_PORT={port}");
     }
 
-    let mut command = Command::new("pnpm");
-    command.args(["--filter", "notebook-ui", "dev"]);
+    let args = ["--filter", "notebook-ui", "dev"];
+    let mut command = pnpm.command();
+    command.args(args);
     apply_worktree_env(&mut command, true);
     if let Some(ref port) = vite_port {
         command.env("RUNTIMED_VITE_PORT", port);
     }
 
     let status = command.status().unwrap_or_else(|e| {
-        eprintln!("Failed to run pnpm dev: {e}");
+        eprintln!("Failed to run {}: {e}", pnpm.display_with_args(&args));
         exit(1);
     });
-    exit_on_failed_status("pnpm dev", status);
+    let label = pnpm.display_with_args(&args);
+    exit_on_failed_status(&label, status);
 }
 
 fn ensure_pnpm_install() {
     if let Some(reason) = pnpm_install_reason() {
         println!("Running pnpm install ({reason})...");
-        run_cmd(pnpm_bin(), &["install"]);
+        run_pnpm(&["install"]);
     } else {
         println!("Skipping pnpm install (node_modules is up to date).");
     }
@@ -1169,8 +1419,10 @@ fn run_e2e_session(
     }
 
     // Run pnpm test:e2e
-    let mut test_cmd = Command::new("pnpm");
-    test_cmd.args(["test:e2e"]).env("WEBDRIVER_PORT", "4445");
+    let pnpm = resolve_pnpm_command_or_exit();
+    let args = ["test:e2e"];
+    let mut test_cmd = pnpm.command();
+    test_cmd.args(args).env("WEBDRIVER_PORT", "4445");
     if let Some(spec) = spec_path {
         test_cmd.env("E2E_SPEC", spec);
     }
@@ -1187,7 +1439,7 @@ fn run_e2e_session(
             }
         }
         Err(e) => {
-            eprintln!("Failed to run pnpm test:e2e: {e}");
+            eprintln!("Failed to run {}: {e}", pnpm.display_with_args(&args));
             1
         }
     };
@@ -2601,19 +2853,21 @@ fn cmd_mcp_inspector() {
     println!();
 
     let config_str = config_path.to_string_lossy().to_string();
-    let mut command = Command::new("pnpm");
-    command.args([
+    let pnpm = resolve_pnpm_command_or_exit();
+    let args = [
         "exec",
         "inspector",
         "--config",
         &config_str,
         "--server",
         "nteract",
-    ]);
+    ];
+    let mut command = pnpm.command();
+    command.args(args);
     apply_worktree_env(&mut command, true);
 
     let status = command.status().unwrap_or_else(|e| {
-        eprintln!("Failed to run inspector: {e}");
+        eprintln!("Failed to run {}: {e}", pnpm.display_with_args(&args));
         eprintln!("Ensure @mcpjam/inspector is in devDependencies and run `pnpm install`.");
         exit(1);
     });
@@ -2654,10 +2908,7 @@ fn cmd_pi(pi_args: &[String]) {
     }
 
     println!("Building @runtimed/node debug binding...");
-    run_cmd(
-        pnpm_bin(),
-        &["--dir", "packages/runtimed-node", "build:debug"],
-    );
+    run_pnpm(&["--dir", "packages/runtimed-node", "build:debug"]);
 
     if !dev_daemon_running() {
         eprintln!("Error: no dev daemon detected for this worktree.");
@@ -3065,9 +3316,9 @@ fn cmd_lint(fix: bool) {
     // JavaScript/TypeScript with Vite Plus
     println!("=== JavaScript/TypeScript (vp check) ===");
     let vp_ok = if fix {
-        run_cmd_ok(pnpm_bin(), &["exec", "vp", "check", "--fix"])
+        run_pnpm_ok(&["exec", "vp", "check", "--fix"])
     } else {
-        run_cmd_ok(pnpm_bin(), &["exec", "vp", "check"])
+        run_pnpm_ok(&["exec", "vp", "check"])
     };
     if !vp_ok {
         failed = true;
@@ -4387,7 +4638,7 @@ fn build_mcp_widget() {
         println!("Building MCP Apps widget ({reason})...");
         require_pnpm();
         ensure_pnpm_install();
-        run_cmd(pnpm_bin(), &["exec", "vp", "run", "nteract-mcp-app#build"]);
+        run_pnpm(&["exec", "vp", "run", "nteract-mcp-app#build"]);
         let dest = Path::new("python/nteract/src/nteract/_widget.html");
         if !dest.exists() {
             eprintln!("Error: MCP widget build did not produce _widget.html");
@@ -4401,19 +4652,21 @@ fn build_mcp_widget() {
 
 fn run_frontend_build(debug_bundle: bool) {
     ensure_build_artifacts();
-    let mut command = Command::new("pnpm");
-    command.arg("build");
+    let pnpm = resolve_pnpm_command_or_exit();
+    let args = ["build"];
+    let mut command = pnpm.command();
+    command.args(args);
     if debug_bundle {
         command.env("RUNT_NOTEBOOK_DEBUG_BUILD", "1");
     }
 
     let status = command.status().unwrap_or_else(|e| {
-        eprintln!("Failed to run pnpm build: {e}");
+        eprintln!("Failed to run {}: {e}", pnpm.display_with_args(&args));
         exit(1);
     });
 
     if !status.success() {
-        eprintln!("Command failed: pnpm build");
+        eprintln!("Command failed: {}", pnpm.display_with_args(&args));
         exit(status.code().unwrap_or(1));
     }
 }
@@ -5081,6 +5334,62 @@ mod tests {
                 skip_install: true,
                 skip_build: true,
             }
+        );
+    }
+
+    #[test]
+    fn parse_pnpm_package_manager_version_accepts_pnpm_specs() {
+        assert_eq!(
+            parse_pnpm_package_manager_version("pnpm@10.30.0").unwrap(),
+            "10.30.0"
+        );
+        assert_eq!(
+            parse_pnpm_package_manager_version("pnpm@10.30.0+sha512.test").unwrap(),
+            "10.30.0"
+        );
+    }
+
+    #[test]
+    fn parse_pnpm_package_manager_version_rejects_non_pnpm_specs() {
+        assert!(parse_pnpm_package_manager_version("npm@11.0.0").is_err());
+        assert!(parse_pnpm_package_manager_version("pnpm@").is_err());
+    }
+
+    #[test]
+    fn choose_pnpm_source_prefers_matching_corepack_over_wrong_direct_pnpm() {
+        let corepack = Ok("10.30.0".to_string());
+        let direct = Ok("11.7.0".to_string());
+
+        assert_eq!(
+            choose_pnpm_source("10.30.0", &corepack, &direct),
+            Some(PnpmSource::Corepack)
+        );
+    }
+
+    #[test]
+    fn choose_pnpm_source_accepts_direct_pnpm_only_when_it_matches_pin() {
+        let corepack = Err("failed to start: corepack not found".to_string());
+        let direct = Ok("10.30.0".to_string());
+
+        assert_eq!(
+            choose_pnpm_source("10.30.0", &corepack, &direct),
+            Some(PnpmSource::Direct)
+        );
+    }
+
+    #[test]
+    fn choose_pnpm_source_rejects_mismatched_versions() {
+        let corepack = Err("failed to start: corepack not found".to_string());
+        let direct = Ok("11.7.0".to_string());
+
+        assert_eq!(choose_pnpm_source("10.30.0", &corepack, &direct), None);
+    }
+
+    #[test]
+    fn last_non_empty_line_uses_final_version_line() {
+        assert_eq!(
+            last_non_empty_line(b"Preparing pnpm...\n10.30.0\n"),
+            Some("10.30.0".to_string())
         );
     }
 

--- a/crates/xtask/src/main.rs
+++ b/crates/xtask/src/main.rs
@@ -580,9 +580,9 @@ fn probe_pnpm_version(program: &str, prefix_args: &[&str], root: &Path) -> Resul
 fn last_non_empty_line(bytes: &[u8]) -> Option<String> {
     String::from_utf8_lossy(bytes)
         .lines()
+        .rev()
         .map(str::trim)
-        .filter(|line| !line.is_empty())
-        .last()
+        .find(|line| !line.is_empty())
         .map(str::to_string)
 }
 


### PR DESCRIPTION
## Summary

- resolve xtask pnpm invocations through the root `packageManager` pin
- prefer `corepack pnpm` when it reports the pinned version, and reject mismatched ambient pnpm binaries before they can touch `node_modules`
- route Vite, install, build, lint, MCP inspector, Pi, and E2E pnpm calls through the same resolver

## Verification

- `COREPACK_ENABLE_DOWNLOAD_PROMPT=0 corepack pnpm install --frozen-lockfile --ignore-scripts`
- `cargo xtask lint --fix`
- `cargo test -p xtask`
- `NO_COLOR=1 cargo xtask vite` confirmed `Using pnpm 10.30.0 via corepack pnpm`; Vite then stopped because the worktree was missing/repairing JS dependency links before the install rerun
- `env RUSTC_WRAPPER= PATH=/Users/kylekelley/.cargo/bin:/Users/kylekelley/.cache/codex-runtimes/codex-primary-runtime/dependencies/bin:/usr/bin:/bin cargo xtask vite` confirmed xtask refuses ambient pnpm `11.7.0` when Corepack is unavailable
