### PR TITLE
chore(dev): pin Codex MCP to worktree daemon

### DIFF
--- a/.agents/skills/frontend-dev/SKILL.md
+++ b/.agents/skills/frontend-dev/SKILL.md
@@ -304,6 +304,26 @@ cargo xtask dev-daemon          # Terminal 1
 
 ### Zed Integration
 
+Codex app/CLI reads `.codex/config.toml` from the project. Keep the
+project-scoped server named `nteract-dev` and pinned to the repo root:
+
+```toml
+[mcp_servers.nteract-dev]
+command = "cargo"
+args = ["xtask", "run-mcp"]
+cwd = "."
+startup_timeout_sec = 120
+
+[mcp_servers.nteract-dev.env]
+NTERACT_DEV_MODE = "attach"
+RUNTIMED_DEV = "1"
+SKIP_MATURIN = "1"
+```
+
+Installed Codex plugin servers such as `nteract-notebook`, `nightly`, or older
+`notebook` aliases target release/plugin daemons. Do not use them for source
+development against a local Browser/Vite worktree.
+
 `.zed/settings.json` (gitignored):
 
 ```json

--- a/.claude/rules/mcp-servers.md
+++ b/.claude/rules/mcp-servers.md
@@ -18,8 +18,9 @@ Three nteract MCP servers may be available. Always use the right one:
 
 1. **Always prefer `nteract-dev`** (`mcp__nteract-dev__*` tools) for development work in this repo. It connects to the per-worktree dev daemon and includes the dev tools for managing the build/daemon lifecycle.
 2. **Never use `nteract-nightly` or `nteract` for development.** They connect to system-installed daemons and will not reflect your source changes.
-3. If `nteract-dev` tools are not available, fall back to `cargo xtask` commands — not to the system MCP servers.
-4. The dev tools (`up`, `down`, `status`, `logs`, `vite_logs`) live on the `nteract-dev` server. They manage the dev daemon and build pipeline — prefer them over manual terminal commands.
+3. **Never use installed Codex plugin notebook servers for source work.** Servers named `nteract-notebook`, `nightly`, or older `notebook` tool aliases come from the installed stable/nightly plugin cache, not this worktree. They can attach to a different active notebook than the local Browser/Vite app.
+4. If `nteract-dev` tools are not available, fall back to `cargo xtask` commands — not to the system or installed plugin MCP servers.
+5. The dev tools (`up`, `down`, `status`, `logs`, `vite_logs`) live on the `nteract-dev` server. They manage the dev daemon and build pipeline — prefer them over manual terminal commands when available.
 
 ## nteract-dev tool surface
 
@@ -39,11 +40,13 @@ Two verbs plus three read-only tools, layered on top of the proxied `runt mcp` t
 
 `nteract-dev` runs in explicit modes. Claude Code uses owner mode from
 `.mcp.json`, so it may start, restart, rebuild, and stop the worktree daemon.
-Codex project config uses attach mode, so Codex connects to an already-running
-worktree daemon but does not own its lifecycle. When falling back to manual
-commands, `cargo xtask dev-daemon`, `cargo xtask notebook`, and
-`cargo xtask run-mcp` derive the current git worktree and pass the dev env to
-subprocesses; direnv is not required for those xtask paths.
+Codex app/CLI uses attach mode from `.codex/config.toml`, so it connects to an
+already-running worktree daemon but does not own its lifecycle. Both configs set
+`cwd = "."`; that is load-bearing because it starts `mcp-supervisor` from the
+repo root, letting it derive this exact worktree instead of another checkout.
+When falling back to manual commands, `cargo xtask dev-daemon`, `cargo xtask
+notebook`, and `cargo xtask run-mcp` derive the current git worktree and pass
+the dev env to subprocesses; direnv is not required for those xtask paths.
 
 ## System daemon CLI (`runt` / `runt-nightly`)
 
@@ -74,6 +77,9 @@ Verify that the three MCP servers connect to the correct daemons:
 status
 # Expected socket: ~/.cache/runt-nightly/worktrees/{hash}/runtimed.sock
 
+# Codex app/CLI should list a project-scoped nteract-dev with cwd "."
+codex mcp get nteract-dev
+
 # 2. List active notebooks on nteract-nightly (should show user's notebooks)
 mcp__nteract-nightly__list_active_notebooks
 # Should list real notebooks like coordination.ipynb
@@ -97,6 +103,7 @@ env -i HOME=$HOME /usr/local/bin/runt-nightly daemon status --json | jq -r '.soc
 - nteract-dev socket path doesn't contain `worktrees/` → using system daemon instead of a worktree daemon
 - nteract-nightly shows empty notebook list → connecting to dev daemon instead of system daemon
 - nteract-nightly MCP process has `RUNTIMED_DEV=1` in environment → env var stripping failed
+- Codex only lists `nteract-notebook` / `nightly` and not `nteract-dev` → the session is missing the project-scoped dev MCP config; use `cargo xtask` until the session is restarted from this repo
 
 **Fix:** Start the dev daemon from the repo root with `cargo xtask dev-daemon`
 or use the owner-mode `nteract-dev` `up` tool. Use direnv only if you want the

--- a/.codex/config.toml
+++ b/.codex/config.toml
@@ -1,0 +1,10 @@
+[mcp_servers.nteract-dev]
+command = "cargo"
+args = ["xtask", "run-mcp"]
+cwd = "."
+startup_timeout_sec = 120
+
+[mcp_servers.nteract-dev.env]
+NTERACT_DEV_MODE = "attach"
+RUNTIMED_DEV = "1"
+SKIP_MATURIN = "1"

--- a/.gitignore
+++ b/.gitignore
@@ -106,6 +106,10 @@ crates/notebook/fixtures/**/uv.lock
 .context/
 .codex/environments/environment.toml
 
+# Project-scoped Codex config is source, not per-worktree state.
+!.codex/
+!.codex/config.toml
+
 # Override global gitignore for .claude — rules and skills are project docs
 !.claude/
 !.claude/rules/

--- a/.mcp.json
+++ b/.mcp.json
@@ -3,6 +3,7 @@
     "nteract-dev": {
       "command": "cargo",
       "args": ["run", "-p", "mcp-supervisor"],
+      "cwd": ".",
       "env": {
         "NTERACT_DEV_MODE": "owner",
         "RUNTIMED_DEV": "1",

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -60,8 +60,9 @@ Three may be visible. Pick by purpose. Full details in `.claude/rules/mcp-server
 - **`nteract-dev`** — default for development. Per-worktree dev daemon, dev tools (`up`, `down`, `status`, `logs`, `vite_logs`) plus 26 proxied notebook tools. Prefer `up` over manual `cargo xtask dev-daemon`.
 - **`nteract-nightly`** — system nightly daemon. Diagnostics only.
 - **`nteract`** — system stable daemon. Diagnostics only.
+- **Codex plugin notebook servers** (`nteract-notebook`, `nightly`, or older `notebook` tool names) — installed release/plugin surfaces. Diagnostics only for source work; they may attach to a different active notebook than the local Browser/Vite app.
 
-If `nteract-dev` is unavailable, fall back to `cargo xtask` (derives the worktree env on its own). Use system MCP servers only for diagnostics.
+If `nteract-dev` is unavailable, fall back to `cargo xtask` (derives the worktree env on its own). Use system or installed plugin MCP servers only for diagnostics.
 
 ## Required before commit
 


### PR DESCRIPTION
## Summary

- add repo-local Codex MCP config for `nteract-dev` in attach mode, pinned to the worktree root
- pin the Claude `nteract-dev` MCP config to `cwd = "."` so supervisor derives the current worktree
- clarify agent docs/skills that installed plugin notebook servers are diagnostics only for source work

## Verification

- `codex mcp get nteract-dev`
- `cargo xtask run-mcp --print-config`
- `cargo xtask dev-daemon`
- `RUNTIMED_DEV=1 RUNTIMED_WORKSPACE_PATH="$PWD" ./target/debug/runt daemon status --json`
- `RUNTIMED_DEV=1 RUNTIMED_WORKSPACE_PATH="$PWD" ./target/debug/runt notebooks`
- `RUNTIMED_DEV=1 RUNTIMED_WORKSPACE_PATH="$PWD" ./target/debug/runt daemon stop`
- `cargo xtask clippy`
- `cargo xtask lint --fix` failed in the JavaScript dependency install step because active pnpm trust policy rejects existing lockfile entries: `chokidar@4.0.3`, `semver@6.3.1`, and `undici-types@6.21.0`; Rust formatting/control-byte checks and Python ruff/ty completed cleanly before the lint command exited non-zero.

The local daemon verification resolved this worktree:

```text
RUNTIMED_WORKSPACE_PATH=/Users/kylekelley/.codex/worktrees/ea7c/nteract
socket_path=/Users/kylekelley/Library/Caches/runt-nightly/worktrees/9abc8a5421df/runtimed.sock
worktree_hash=9abc8a5421df
daemon_version=2.6.0+0b1fa3d
```
