### PR TITLE
fix(runtimed): handle empty dependency metadata

### DIFF
--- a/crates/runtimed/src/notebook_sync_server/metadata.rs
+++ b/crates/runtimed/src/notebook_sync_server/metadata.rs
@@ -994,12 +994,25 @@ pub(crate) async fn check_and_update_trust_state(room: &NotebookRoom) {
         let doc = room.doc.read().await;
         doc.get_metadata_snapshot()
     };
-
-    let Some(current_metadata) = current_metadata else {
-        return;
+    let current_metadata = if current_metadata.is_some() {
+        current_metadata
+    } else {
+        let mut doc = room.doc.write().await;
+        match doc.get_metadata_snapshot() {
+            Some(snapshot) => Some(snapshot),
+            // A pristine file-backed room may still be waiting for notebook
+            // metadata to seed from disk/client sync. Preserve its initial
+            // disk-derived trust state until the document has real history.
+            None if doc.is_pristine() => return,
+            None => None,
+        }
     };
 
-    let mut new_trust = verify_trust_from_snapshot(&current_metadata, &room.trusted_packages);
+    let mut new_trust = if let Some(current_metadata) = current_metadata {
+        verify_trust_from_snapshot(&current_metadata, &room.trusted_packages)
+    } else {
+        trust_state_from_metadata(&std::collections::HashMap::new(), &room.trusted_packages)
+    };
     enrich_trust_info(room, &mut new_trust);
 
     let current_runtime_trust = {

--- a/crates/runtimed/src/notebook_sync_server/tests.rs
+++ b/crates/runtimed/src/notebook_sync_server/tests.rs
@@ -5864,6 +5864,38 @@ async fn test_check_and_update_trust_state_no_deps() {
 }
 
 #[tokio::test]
+async fn test_check_and_update_trust_state_cleared_metadata_resets_no_deps() {
+    let tmp = tempfile::TempDir::new().unwrap();
+    let (room, _path) = test_room_with_path(&tmp, "cleared_deps.ipynb");
+
+    room.state
+        .with_doc(|sd| sd.set_trust("untrusted", true))
+        .unwrap();
+
+    {
+        let mut doc = room.doc.write().await;
+        doc.set_metadata_snapshot(&snapshot_with_uv(vec!["pandas>=2".to_string()]))
+            .unwrap();
+        doc.set_metadata_snapshot(&snapshot_empty()).unwrap();
+        assert!(
+            doc.get_metadata_snapshot().is_none(),
+            "empty notebook metadata snapshots are stored as no metadata keys"
+        );
+    }
+
+    check_and_update_trust_state(&room).await;
+
+    let ts = room.trust_state.read().await;
+    assert_eq!(ts.status, runt_trust::TrustStatus::NoDependencies);
+    assert!(ts.info.uv_dependencies.is_empty());
+    drop(ts);
+
+    let state = room.state.read(|sd| sd.read_state()).unwrap();
+    assert_eq!(state.trust.status, "no_dependencies");
+    assert!(!state.trust.needs_approval);
+}
+
+#[tokio::test]
 async fn test_approve_trust_adds_dependencies_to_allowlist() {
     let tmp = tempfile::TempDir::new().unwrap();
     let store =

--- a/crates/runtimed/src/requests/approve_trust.rs
+++ b/crates/runtimed/src/requests/approve_trust.rs
@@ -50,7 +50,6 @@ pub(crate) async fn handle(
 
 #[derive(Debug, PartialEq, Eq)]
 enum TrustApprovalError {
-    NoMetadata,
     StaleDependencies,
     Persist(String),
 }
@@ -58,9 +57,6 @@ enum TrustApprovalError {
 impl TrustApprovalError {
     fn into_response(self) -> NotebookResponse {
         match self {
-            TrustApprovalError::NoMetadata => NotebookResponse::Error {
-                error: "No metadata in Automerge doc".to_string(),
-            },
             TrustApprovalError::StaleDependencies => NotebookResponse::GuardRejected {
                 reason: TRUST_APPROVAL_STALE_REASON.to_string(),
             },
@@ -81,9 +77,7 @@ fn apply_trust_approval(
             .map_err(|_| TrustApprovalError::StaleDependencies)?;
     }
 
-    let Some(snapshot) = doc.get_metadata_snapshot() else {
-        return Err(TrustApprovalError::NoMetadata);
-    };
+    let snapshot = doc.get_metadata_snapshot().unwrap_or_default();
 
     let mut metadata = std::collections::HashMap::new();
     if let Ok(runt_value) = serde_json::to_value(&snapshot.runt) {
@@ -141,5 +135,24 @@ mod tests {
         let result = apply_trust_approval(&doc, Some(&observed_heads));
 
         assert!(matches!(result, Err(TrustApprovalError::StaleDependencies)));
+    }
+
+    #[test]
+    fn approval_without_metadata_is_noop_no_dependencies() {
+        let mut doc = NotebookDoc::new("trust-approval-test");
+        let observed_heads = doc.get_heads_hex();
+
+        let info = apply_trust_approval(&doc, Some(&observed_heads)).unwrap();
+
+        assert_eq!(info.status, runt_trust::TrustStatus::NoDependencies);
+        assert!(info.uv_dependencies.is_empty());
+        assert!(info.conda_dependencies.is_empty());
+        assert!(info.pixi_dependencies.is_empty());
+        assert!(info.pixi_pypi_dependencies.is_empty());
+        assert_eq!(
+            doc.get_heads_hex(),
+            observed_heads,
+            "approval extraction must stay read-only even with missing metadata"
+        );
     }
 }


### PR DESCRIPTION
## Summary
- treat cleared notebook metadata as no dependency metadata once the Automerge doc has real history
- make dependency approval on missing metadata a read-only no-op with `no_dependencies`
- cover cleared metadata trust refresh and missing-metadata approval extraction

## Verification
- `cargo test -p runtimed approve_trust`
- `cargo test -p runtimed check_and_update_trust_state`
- `cargo test -p runtimed --test tokio_mutex_lint`
- `RUNTIMED_DEV=1 RUNTIMED_WORKSPACE_PATH="$PWD" ./target/debug/runt nb call --create manage_dependencies --args '{"trust":true}' --json`
- `PATH="/tmp/nteract-pnpm10-shim:$PATH" cargo xtask lint --fix`
- `git diff --check`
