### PR TITLE
perf(notebook): improve OG ipynb first-cell load

### DIFF
--- a/apps/notebook/src/lib/__tests__/frame-pipeline.test.ts
+++ b/apps/notebook/src/lib/__tests__/frame-pipeline.test.ts
@@ -5,7 +5,11 @@ import {
   type ChangedFields,
   mergeChangesets,
 } from "../cell-changeset";
-import { type MaterializeDeps, materializeChangeset } from "../frame-pipeline";
+import {
+  type MaterializeDeps,
+  materializeChangeset,
+  publishProgressiveInitialStructureSlice,
+} from "../frame-pipeline";
 
 // ── Mocks ──────────────────────────────────────────────────────────────
 
@@ -21,6 +25,7 @@ const structureProjectionCalls: Array<{
 
 vi.mock("../notebook-cells", () => ({
   getCellById: (id: string) => cellStore.get(id) ?? null,
+  getCellIdsSnapshot: () => [...cellStore.keys()],
   updateCellById: (
     id: string,
     fn: (prev: Record<string, unknown>) => Record<string, unknown>,
@@ -654,6 +659,118 @@ describe("materializeChangeset", () => {
     expect(cellStore.get("inserted")).toMatchObject({
       id: "inserted",
       source: "new source",
+    });
+  });
+
+  it("can publish a leading structural slice before the final projection", async () => {
+    const handle = createMockHandle(
+      {
+        c1: { source: "one" },
+        c2: { source: "two" },
+        c3: { source: "three" },
+        c4: { source: "four" },
+        c5: { source: "five" },
+      },
+      ["c1", "c2", "c3", "c4", "c5"],
+    );
+    const deps = {
+      ...createDeps(handle),
+      progressiveStructuralBatchSize: 3,
+    };
+
+    await materializeChangeset(
+      {
+        changed: [],
+        added: ["c3", "c1", "c5", "c2", "c4"],
+        removed: [],
+        order_changed: true,
+      },
+      deps,
+    );
+
+    expect(deps.materializeCells).not.toHaveBeenCalled();
+    expect(structureProjectionCalls).toHaveLength(2);
+    expect(structureProjectionCalls[0]).toMatchObject({
+      orderedCellIds: ["c1", "c2", "c3"],
+      upsertedCells: [
+        { id: "c1", source: "one" },
+        { id: "c2", source: "two" },
+        { id: "c3", source: "three" },
+      ],
+    });
+    expect(structureProjectionCalls[1]).toMatchObject({
+      orderedCellIds: ["c1", "c2", "c3", "c4", "c5"],
+      upsertedCells: [
+        { id: "c1", source: "one" },
+        { id: "c2", source: "two" },
+        { id: "c3", source: "three" },
+        { id: "c4", source: "four" },
+        { id: "c5", source: "five" },
+      ],
+    });
+  });
+
+  it("does not shrink an already-populated initial streaming projection", async () => {
+    cellStore.set("c1", { id: "c1", source: "one" });
+    cellStore.set("c2", { id: "c2", source: "two" });
+    cellStore.set("c3", { id: "c3", source: "three" });
+
+    const handle = createMockHandle(
+      {
+        c1: { source: "one" },
+        c2: { source: "two" },
+        c3: { source: "three" },
+        c4: { source: "four" },
+        c5: { source: "five" },
+      },
+      ["c1", "c2", "c3", "c4", "c5"],
+    );
+    const deps = {
+      ...createDeps(handle),
+      progressiveStructuralBatchSize: 3,
+    };
+
+    await materializeChangeset(
+      {
+        changed: [],
+        added: ["c4", "c5"],
+        removed: [],
+        order_changed: true,
+      },
+      deps,
+    );
+
+    expect(structureProjectionCalls).toHaveLength(1);
+    expect(structureProjectionCalls[0]).toMatchObject({
+      orderedCellIds: ["c1", "c2", "c3", "c4", "c5"],
+    });
+  });
+
+  it("publishes an initial structural slice before full materialization", async () => {
+    const handle = createMockHandle(
+      {
+        c1: { source: "one" },
+        c2: { source: "two" },
+        c3: { source: "three" },
+        c4: { source: "four" },
+      },
+      ["c1", "c2", "c3", "c4"],
+    );
+
+    const published = await publishProgressiveInitialStructureSlice(handle, {
+      outputCache: new Map(),
+      progressiveStructuralBatchSize: 3,
+    });
+
+    expect(published).toBe(true);
+    expect(structureProjectionCalls).toHaveLength(1);
+    expect(structureProjectionCalls[0]).toMatchObject({
+      orderedCellIds: ["c1", "c2", "c3"],
+      upsertedCells: [
+        { id: "c1", source: "one" },
+        { id: "c2", source: "two" },
+        { id: "c3", source: "three" },
+      ],
     });
   });
 

--- a/apps/notebook/src/lib/__tests__/notebook-sync-store-bridge.test.ts
+++ b/apps/notebook/src/lib/__tests__/notebook-sync-store-bridge.test.ts
@@ -1,4 +1,11 @@
-import { afterEach, beforeEach, describe, expect, it, vi } from "vite-plus/test";
+import {
+  afterEach,
+  beforeEach,
+  describe,
+  expect,
+  it,
+  vi,
+} from "vite-plus/test";
 import { Subject } from "rxjs";
 import type {
   ExecutionViewChangeset,
@@ -25,6 +32,7 @@ const mocks = vi.hoisted(() => ({
     error: vi.fn(),
   },
   materializeChangeset: vi.fn(async () => {}),
+  publishProgressiveInitialStructureSlice: vi.fn(async () => true),
   notifyMetadataChanged: vi.fn(),
   seedOutputStoresFromHandle: vi.fn(),
   setPoolState: vi.fn(),
@@ -33,6 +41,8 @@ const mocks = vi.hoisted(() => ({
 
 vi.mock("../frame-pipeline", () => ({
   materializeChangeset: mocks.materializeChangeset,
+  publishProgressiveInitialStructureSlice:
+    mocks.publishProgressiveInitialStructureSlice,
 }));
 
 vi.mock("../logger", () => ({
@@ -73,8 +83,9 @@ function deferred<T = void>() {
 }
 
 async function flushMicrotasks() {
-  await Promise.resolve();
-  await Promise.resolve();
+  for (let i = 0; i < 8; i++) {
+    await Promise.resolve();
+  }
 }
 
 function readyStatus(): SessionStatus {
@@ -105,7 +116,9 @@ function createHandle() {
   return {
     get_cell_ids: vi.fn(() => ["cell-1"]),
     get_cell_execution_id: vi.fn(() => "exec-1"),
-    get_cell_outputs: vi.fn(() => [{ output_id: "out-1", output_type: "stream" }]),
+    get_cell_outputs: vi.fn(() => [
+      { output_id: "out-1", output_type: "stream" },
+    ]),
   } as unknown as NotebookHandle;
 }
 
@@ -115,7 +128,10 @@ function createEngineSubjects() {
     cellChanges$: new Subject<CellChangeset | null>(),
     executionViewChanges$: new Subject<ExecutionViewChangeset>(),
     initialSyncComplete$: new Subject<void>(),
-    outputIdChanges$: new Subject<{ changed: Array<[string, unknown]>; removed_ids: string[] }>(),
+    outputIdChanges$: new Subject<{
+      changed: Array<[string, unknown]>;
+      removed_ids: string[];
+    }>(),
     poolState$: new Subject<PoolState>(),
     presence$: new Subject<unknown>(),
     runtimeState$: new Subject<RuntimeState>(),
@@ -123,15 +139,16 @@ function createEngineSubjects() {
   };
 
   const engine = Object.fromEntries(
-    Object.entries(subjects).map(([key, subject]) => [key, subject.asObservable()]),
+    Object.entries(subjects).map(([key, subject]) => [
+      key,
+      subject.asObservable(),
+    ]),
   ) as NotebookSyncStoreBridgeOptions["engine"];
 
   return { engine, subjects };
 }
 
-function startBridge(
-  overrides: Partial<NotebookSyncStoreBridgeOptions> = {},
-) {
+function startBridge(overrides: Partial<NotebookSyncStoreBridgeOptions> = {}) {
   const { engine, subjects } = createEngineSubjects();
   const handle = createHandle();
   const materializeCells = vi.fn(async () => {});
@@ -183,6 +200,7 @@ beforeEach(() => {
   vi.clearAllMocks();
   mocks.applyOutputChangeset.mockResolvedValue(undefined);
   mocks.materializeChangeset.mockResolvedValue(undefined);
+  mocks.publishProgressiveInitialStructureSlice.mockResolvedValue(true);
 });
 
 afterEach(() => {
@@ -221,7 +239,9 @@ describe("startNotebookSyncStoreBridge", () => {
     expect(mocks.applyExecutionViewChangeset).toHaveBeenCalledWith(
       projectExecutionViewChangeset.mock.results[0].value,
     );
-    expect(mocks.seedOutputStoresFromHandle).toHaveBeenCalledWith(handle, ["cell-1"]);
+    expect(mocks.seedOutputStoresFromHandle).toHaveBeenCalledWith(handle, [
+      "cell-1",
+    ]);
     expect(refreshCanAcceptCellMutations).toHaveBeenCalledWith(handle);
     expect(setIsLoading).toHaveBeenLastCalledWith(false);
     expect(mocks.notifyMetadataChanged).toHaveBeenCalledTimes(1);
@@ -234,7 +254,9 @@ describe("startNotebookSyncStoreBridge", () => {
     const materializeCells = vi.fn(async () => {
       throw error;
     });
-    const { bridge, setIsLoading, setLoadError, subjects } = startBridge({ materializeCells });
+    const { bridge, setIsLoading, setLoadError, subjects } = startBridge({
+      materializeCells,
+    });
 
     subjects.initialSyncComplete$.next();
     await flushMicrotasks();
@@ -297,6 +319,29 @@ describe("startNotebookSyncStoreBridge", () => {
     bridge.stop();
   });
 
+  it("enables progressive structural materialization during initial file load", async () => {
+    const { bridge, options, subjects } = startBridge();
+    const changeset: CellChangeset = {
+      added: ["cell-1", "cell-2", "cell-3", "cell-4"],
+      changed: [],
+      order_changed: true,
+      removed: [],
+    };
+
+    subjects.sessionStatus$.next(streamingStatus());
+    subjects.cellChanges$.next(changeset);
+    await flushMicrotasks();
+
+    expect(mocks.materializeChangeset).toHaveBeenCalledWith(changeset, {
+      getHandle: options.getHandle,
+      materializeCells: options.materializeCells,
+      outputCache: options.outputCache,
+      progressiveStructuralBatchSize: 3,
+    });
+
+    bridge.stop();
+  });
+
   it("routes sync engine streams to app stores and frame buses", async () => {
     const { bridge, subjects } = startBridge();
     const runtimeState = { kernel: null } as RuntimeState;
@@ -320,7 +365,9 @@ describe("startNotebookSyncStoreBridge", () => {
     expect(mocks.emitPresence).toHaveBeenCalledWith({ type: "presence" });
     expect(mocks.setRuntimeState).toHaveBeenCalledWith(runtimeState);
     expect(mocks.setPoolState).toHaveBeenCalledWith(poolState);
-    expect(mocks.applyExecutionViewChangeset).toHaveBeenCalledWith(executionChanges);
+    expect(mocks.applyExecutionViewChangeset).toHaveBeenCalledWith(
+      executionChanges,
+    );
     expect(mocks.applyOutputChangeset).toHaveBeenCalledWith(
       [["out-1", { output_type: "stream" }]],
       ["out-old"],
@@ -347,6 +394,33 @@ describe("startNotebookSyncStoreBridge", () => {
     bridge.stop();
   });
 
+  it("defers initial full materialization while file load is streaming", async () => {
+    const { bridge, handle, materializeCells, setIsLoading, subjects } =
+      startBridge();
+
+    subjects.sessionStatus$.next(streamingStatus());
+    subjects.initialSyncComplete$.next();
+    await flushMicrotasks();
+
+    expect(materializeCells).not.toHaveBeenCalled();
+    expect(setIsLoading).not.toHaveBeenCalledWith(false);
+
+    subjects.sessionStatus$.next(readyStatus());
+    await flushMicrotasks();
+
+    expect(mocks.publishProgressiveInitialStructureSlice).toHaveBeenCalledWith(
+      handle,
+      {
+        outputCache: expect.any(Map),
+        progressiveStructuralBatchSize: 3,
+      },
+    );
+    expect(materializeCells).toHaveBeenCalledTimes(1);
+    expect(setIsLoading).toHaveBeenLastCalledWith(false);
+
+    bridge.stop();
+  });
+
   it("waits for fresh initial sync after reconnect readiness reset", async () => {
     const { bridge, materializeCells, setIsLoading, subjects } = startBridge();
 
@@ -368,8 +442,14 @@ describe("startNotebookSyncStoreBridge", () => {
     subjects.initialSyncComplete$.next();
     await flushMicrotasks();
 
+    expect(materializeCells).not.toHaveBeenCalled();
+    expect(setIsLoading).not.toHaveBeenCalled();
+
+    subjects.sessionStatus$.next(readyStatus());
+    await flushMicrotasks();
+
     expect(materializeCells).toHaveBeenCalledTimes(1);
-    expect(setIsLoading).toHaveBeenLastCalledWith(true);
+    expect(setIsLoading).toHaveBeenLastCalledWith(false);
 
     bridge.stop();
   });
@@ -377,7 +457,9 @@ describe("startNotebookSyncStoreBridge", () => {
   it("ignores in-flight materializeCells result if stopped before it resolves", async () => {
     const materialize = deferred();
     const materializeCells = vi.fn(() => materialize.promise);
-    const { bridge, setIsLoading, setLoadError, subjects } = startBridge({ materializeCells });
+    const { bridge, setIsLoading, setLoadError, subjects } = startBridge({
+      materializeCells,
+    });
 
     subjects.initialSyncComplete$.next();
     await flushMicrotasks();
@@ -428,8 +510,12 @@ describe("startNotebookSyncStoreBridge", () => {
   it("ignores in-flight materializeChangeset result if stopped before it resolves", async () => {
     const work = deferred();
     mocks.materializeChangeset.mockImplementationOnce(() => work.promise);
-    const { bridge, projectExecutionViewChangeset, refreshCanAcceptCellMutations, subjects } =
-      startBridge();
+    const {
+      bridge,
+      projectExecutionViewChangeset,
+      refreshCanAcceptCellMutations,
+      subjects,
+    } = startBridge();
 
     subjects.cellChanges$.next(null);
     expect(mocks.materializeChangeset).toHaveBeenCalledTimes(1);
@@ -472,7 +558,10 @@ describe("startNotebookSyncStoreBridge", () => {
     subjects.runtimeState$.next({ kernel: null } as RuntimeState);
     subjects.poolState$.next({ uv: {}, conda: {}, pixi: {} } as PoolState);
     subjects.executionViewChanges$.next({});
-    subjects.outputIdChanges$.next({ changed: [["out-1", {}]], removed_ids: [] });
+    subjects.outputIdChanges$.next({
+      changed: [["out-1", {}]],
+      removed_ids: [],
+    });
     await flushMicrotasks();
 
     expect(mocks.materializeChangeset).not.toHaveBeenCalled();

--- a/apps/notebook/src/lib/frame-pipeline.ts
+++ b/apps/notebook/src/lib/frame-pipeline.ts
@@ -22,7 +22,11 @@ import { getBlobResolver } from "./blob-port";
 import type { CellChangeset } from "./cell-changeset";
 import { logger } from "./logger";
 import { materializeCellFromWasm } from "./materialize-cells";
-import { getCellById, updateCellById } from "./notebook-cells";
+import {
+  getCellById,
+  getCellIdsSnapshot,
+  updateCellById,
+} from "./notebook-cells";
 import { notifyMetadataChanged } from "./notebook-metadata";
 
 // Re-export CellChangeset types so existing consumers don't break.
@@ -54,6 +58,84 @@ export interface MaterializeDeps {
 
   /** Host-provided blob resolver. Defaults to the desktop daemon resolver. */
   blobResolver?: BlobResolver | null;
+
+  /**
+   * When set, large structural additions publish this many leading cells before
+   * finishing the full projection. Used for file-load TTFC only.
+   */
+  progressiveStructuralBatchSize?: number;
+}
+
+export interface ProgressiveInitialMaterializeDeps {
+  /** Shared output manifest cache (mutated in place). */
+  outputCache: Map<string, JupyterOutput>;
+
+  /** Number of leading cells to publish before the full initial projection. */
+  progressiveStructuralBatchSize: number;
+
+  /** Host-provided blob resolver. Defaults to the desktop daemon resolver. */
+  blobResolver?: BlobResolver | null;
+}
+
+function yieldForProgressivePaint(): Promise<void> {
+  return new Promise((resolve) => {
+    if (typeof requestAnimationFrame === "function") {
+      requestAnimationFrame(() => resolve());
+    } else {
+      setTimeout(resolve, 0);
+    }
+  });
+}
+
+export async function publishProgressiveInitialStructureSlice(
+  handle: NotebookHandle,
+  deps: ProgressiveInitialMaterializeDeps,
+): Promise<boolean> {
+  const progressiveBatchSize = deps.progressiveStructuralBatchSize;
+  if (progressiveBatchSize <= 0 || typeof handle.get_cell_ids !== "function") {
+    return false;
+  }
+
+  const currentCellIds = getCellIdsSnapshot();
+  if (currentCellIds.length >= progressiveBatchSize) {
+    return false;
+  }
+
+  const orderedCellIds = [...handle.get_cell_ids()];
+  if (orderedCellIds.length <= progressiveBatchSize) {
+    return false;
+  }
+
+  const progressiveCellIds = orderedCellIds.slice(0, progressiveBatchSize);
+  const blobResolver =
+    "blobResolver" in deps ? (deps.blobResolver ?? null) : getBlobResolver();
+  const upsertedCells: NotebookCell[] = [];
+
+  for (const cellId of progressiveCellIds) {
+    const cell = materializeCellFromWasm(
+      handle,
+      cellId,
+      deps.outputCache,
+      getCellById(cellId),
+      blobResolver,
+    );
+    if (!cell) return false;
+    upsertedCells.push(cell);
+    if (cell.cell_type === "code") {
+      const rawOutputs: unknown[] = handle.get_cell_outputs(cellId) ?? [];
+      preWarmPluginsForRawOutputs(rawOutputs);
+    }
+  }
+
+  applyNotebookCellStructureProjection({
+    orderedCellIds: progressiveCellIds,
+    upsertedCells,
+  });
+  logger.debug(
+    `[frame-pipeline] progressive initial structure: first ${progressiveBatchSize} of ${orderedCellIds.length}`,
+  );
+  await yieldForProgressivePaint();
+  return true;
 }
 
 // ── Plugin pre-warm helper ──────────────────────────────────────────
@@ -128,11 +210,13 @@ export async function materializeChangeset(
   if (!changeset) return;
 
   const cache = deps.outputCache;
-  const blobResolver = "blobResolver" in deps ? (deps.blobResolver ?? null) : getBlobResolver();
+  const blobResolver =
+    "blobResolver" in deps ? (deps.blobResolver ?? null) : getBlobResolver();
 
   // ── Structural incremental materialization ────────────────────────
 
-  if (projectionPlan.structural) {
+  const structuralPlan = projectionPlan.structural;
+  if (structuralPlan) {
     if (typeof handle.get_cell_ids !== "function") {
       logger.debug(
         "[frame-pipeline] full materialization: structural changeset without get_cell_ids",
@@ -147,8 +231,44 @@ export async function materializeChangeset(
     const finalCellIds = new Set(orderedCellIds);
     const addedCells: NotebookCell[] = [];
     const materializedCellIds = new Set<string>();
+    const materializedCellsById = new Map<string, NotebookCell>();
+    const progressiveBatchSize = deps.progressiveStructuralBatchSize ?? 0;
+    let progressiveProjectionPublished = false;
 
-    for (const cellId of projectionPlan.structural.added) {
+    const maybePublishProgressiveProjection = async () => {
+      if (getCellIdsSnapshot().length >= progressiveBatchSize) {
+        return;
+      }
+      const progressiveCellIds = orderedCellIds.slice(0, progressiveBatchSize);
+      const progressiveCells: NotebookCell[] = [];
+      for (const cellId of progressiveCellIds) {
+        const materialized = materializedCellsById.get(cellId);
+        if (materialized) {
+          progressiveCells.push(materialized);
+          continue;
+        }
+        if (!getCellById(cellId)) return;
+      }
+      if (
+        progressiveProjectionPublished ||
+        progressiveBatchSize <= 0 ||
+        structuralPlan.removed.length > 0 ||
+        progressiveCellIds.length < progressiveBatchSize
+      ) {
+        return;
+      }
+      progressiveProjectionPublished = true;
+      applyNotebookCellStructureProjection({
+        orderedCellIds: progressiveCellIds,
+        upsertedCells: progressiveCells,
+      });
+      logger.debug(
+        `[frame-pipeline] progressive structure: first ${progressiveBatchSize} of ${orderedCellIds.length}`,
+      );
+      await yieldForProgressivePaint();
+    };
+
+    for (const cellId of structuralPlan.added) {
       if (!finalCellIds.has(cellId)) continue;
 
       const cell = materializeCellFromWasm(
@@ -170,10 +290,12 @@ export async function materializeChangeset(
 
       addedCells.push(cell);
       materializedCellIds.add(cell.id);
+      materializedCellsById.set(cell.id, cell);
       if (cell.cell_type === "code") {
         const rawOutputs: unknown[] = handle.get_cell_outputs(cellId) ?? [];
         preWarmPluginsForRawOutputs(rawOutputs);
       }
+      await maybePublishProgressiveProjection();
     }
 
     for (const cellId of orderedCellIds) {
@@ -198,19 +320,26 @@ export async function materializeChangeset(
 
       addedCells.push(cell);
       materializedCellIds.add(cell.id);
+      materializedCellsById.set(cell.id, cell);
       if (cell.cell_type === "code") {
         const rawOutputs: unknown[] = handle.get_cell_outputs(cellId) ?? [];
         preWarmPluginsForRawOutputs(rawOutputs);
       }
+      await maybePublishProgressiveProjection();
     }
+
+    const orderedAddedCells = orderedCellIds.flatMap((cellId) => {
+      const cell = materializedCellsById.get(cellId);
+      return cell ? [cell] : [];
+    });
 
     applyNotebookCellStructureProjection({
       orderedCellIds,
-      upsertedCells: addedCells,
+      upsertedCells: orderedAddedCells,
     });
 
     logger.debug(
-      `[frame-pipeline] incremental structure: +${projectionPlan.structural.added.length} -${projectionPlan.structural.removed.length} reorder=${projectionPlan.structural.order_changed} materialized-added=${addedCells.length}`,
+      `[frame-pipeline] incremental structure: +${structuralPlan.added.length} -${structuralPlan.removed.length} reorder=${structuralPlan.order_changed} materialized-added=${addedCells.length}`,
     );
   }
 

--- a/apps/notebook/src/lib/notebook-sync-store-bridge.ts
+++ b/apps/notebook/src/lib/notebook-sync-store-bridge.ts
@@ -1,9 +1,16 @@
-import type { ExecutionViewChangeset, SessionStatus, SyncEngine } from "runtimed";
+import type {
+  ExecutionViewChangeset,
+  SessionStatus,
+  SyncEngine,
+} from "runtimed";
 import { isInitialLoadFailed, isInitialLoadStreaming } from "runtimed";
 import { concatMap, from, Subscription } from "rxjs";
 import type { JupyterOutput } from "../types";
 import type { NotebookHandle } from "../wasm/runtimed-wasm/runtimed_wasm.js";
-import { materializeChangeset } from "./frame-pipeline";
+import {
+  materializeChangeset,
+  publishProgressiveInitialStructureSlice,
+} from "./frame-pipeline";
 import { logger } from "./logger";
 import { emitBroadcast, emitPresence } from "./notebook-frame-bus";
 import { notifyMetadataChanged } from "./notebook-metadata";
@@ -50,13 +57,81 @@ export function startNotebookSyncStoreBridge(
   options: NotebookSyncStoreBridgeOptions,
 ): NotebookSyncStoreBridge {
   let interactiveReady = false;
+  let initialMaterializeDeferred = false;
+  let initialMaterializeInFlight = false;
+  let initialLoadWasStreaming = false;
   let latestSessionStatus: SessionStatus | null = null;
   let stopped = false;
   const subscription = new Subscription();
 
   const resetReadiness = () => {
     interactiveReady = false;
+    initialMaterializeDeferred = false;
+    initialLoadWasStreaming = false;
     latestSessionStatus = null;
+  };
+
+  const runInitialMaterialize = () => {
+    if (initialMaterializeInFlight) return;
+
+    logger.info("[automerge-notebook] Notebook interactive, materializing");
+    const handle = options.getHandle();
+    if (!handle) {
+      initialMaterializeDeferred = false;
+      options.setIsLoading(false);
+      return;
+    }
+
+    initialMaterializeInFlight = true;
+    const shouldPublishInitialSlice = initialLoadWasStreaming;
+    const publishInitialSlice = shouldPublishInitialSlice
+      ? publishProgressiveInitialStructureSlice(handle, {
+          outputCache: options.outputCache,
+          progressiveStructuralBatchSize: 3,
+        })
+      : Promise.resolve(false);
+
+    publishInitialSlice
+      .then(() => {
+        if (stopped || options.getHandle() !== handle) return;
+        return options.materializeCells(handle);
+      })
+      .then(() => {
+        initialMaterializeInFlight = false;
+        if (stopped) return;
+        // A daemon restart can free this handle during the await (gen1 -> gen2
+        // relay reset). Bail if the live handle was replaced; the gen2
+        // bootstrap drives its own initialSyncComplete materialize cycle.
+        if (options.getHandle() !== handle) return;
+        interactiveReady = true;
+        initialMaterializeDeferred = false;
+        initialLoadWasStreaming = false;
+        const cellIdList = [...handle.get_cell_ids()];
+        // `initialSyncComplete$` fires when the notebook doc is interactive,
+        // not when RuntimeStateDoc has finished bootstrapping. Seeding the
+        // outputs/executions stores from the notebook handle here preserves
+        // eager output visibility until the authoritative runtime-state
+        // projection lands via `executionViewChanges$` / `outputIdChanges$`.
+        applyExecutionViewChangeset(
+          options.projectExecutionViewChangeset(handle),
+        );
+        seedOutputStoresFromHandle(handle, cellIdList);
+        options.refreshCanAcceptCellMutations(handle);
+        options.setIsLoading(
+          latestSessionStatus
+            ? isInitialLoadStreaming(latestSessionStatus.initial_load)
+            : false,
+        );
+        notifyMetadataChanged();
+        logger.info("[automerge-notebook] Interactive materialization done");
+      })
+      .catch((err: unknown) => {
+        initialMaterializeInFlight = false;
+        if (stopped) return;
+        logger.warn("[automerge-notebook] initial materialize failed:", err);
+        options.setLoadError(err instanceof Error ? err.message : String(err));
+        options.setIsLoading(false);
+      });
   };
 
   subscription.add(
@@ -64,14 +139,29 @@ export function startNotebookSyncStoreBridge(
       latestSessionStatus = status;
 
       if (isInitialLoadFailed(status.initial_load)) {
-        logger.warn("[automerge-notebook] Initial load failed:", status.initial_load.reason);
+        logger.warn(
+          "[automerge-notebook] Initial load failed:",
+          status.initial_load.reason,
+        );
+        initialMaterializeDeferred = false;
+        initialLoadWasStreaming = false;
         options.setLoadError(status.initial_load.reason);
         options.setIsLoading(false);
         return;
       }
 
       options.setLoadError(null);
+      if (isInitialLoadStreaming(status.initial_load)) {
+        initialLoadWasStreaming = true;
+      }
       options.refreshCanAcceptCellMutations();
+      if (
+        initialMaterializeDeferred &&
+        !isInitialLoadStreaming(status.initial_load)
+      ) {
+        runInitialMaterialize();
+        return;
+      }
       if (interactiveReady) {
         options.setIsLoading(isInitialLoadStreaming(status.initial_load));
       }
@@ -80,43 +170,17 @@ export function startNotebookSyncStoreBridge(
 
   subscription.add(
     options.engine.initialSyncComplete$.subscribe(() => {
-      logger.info("[automerge-notebook] Notebook interactive, materializing");
-      const handle = options.getHandle();
-      if (!handle) {
-        options.setIsLoading(false);
+      if (
+        latestSessionStatus &&
+        isInitialLoadStreaming(latestSessionStatus.initial_load)
+      ) {
+        logger.info(
+          "[automerge-notebook] Notebook interactive during streaming load; deferring full materialization",
+        );
+        initialMaterializeDeferred = true;
         return;
       }
-
-      options
-        .materializeCells(handle)
-        .then(() => {
-          if (stopped) return;
-          // A daemon restart can free this handle during the await (gen1 -> gen2
-          // relay reset). Bail if the live handle was replaced; the gen2
-          // bootstrap drives its own initialSyncComplete materialize cycle.
-          if (options.getHandle() !== handle) return;
-          interactiveReady = true;
-          const cellIdList = [...handle.get_cell_ids()];
-          // `initialSyncComplete$` fires when the notebook doc is interactive,
-          // not when RuntimeStateDoc has finished bootstrapping. Seeding the
-          // outputs/executions stores from the notebook handle here preserves
-          // eager output visibility until the authoritative runtime-state
-          // projection lands via `executionViewChanges$` / `outputIdChanges$`.
-          applyExecutionViewChangeset(options.projectExecutionViewChangeset(handle));
-          seedOutputStoresFromHandle(handle, cellIdList);
-          options.refreshCanAcceptCellMutations(handle);
-          options.setIsLoading(
-            latestSessionStatus ? isInitialLoadStreaming(latestSessionStatus.initial_load) : false,
-          );
-          notifyMetadataChanged();
-          logger.info("[automerge-notebook] Interactive materialization done");
-        })
-        .catch((err: unknown) => {
-          if (stopped) return;
-          logger.warn("[automerge-notebook] initial materialize failed:", err);
-          options.setLoadError(err instanceof Error ? err.message : String(err));
-          options.setIsLoading(false);
-        });
+      runInitialMaterialize();
     }),
   );
 
@@ -131,17 +195,25 @@ export function startNotebookSyncStoreBridge(
               getHandle: options.getHandle,
               materializeCells: options.materializeCells,
               outputCache: options.outputCache,
+              ...(initialLoadWasStreaming && !interactiveReady
+                ? { progressiveStructuralBatchSize: 3 }
+                : {}),
             })
               .then(() => {
                 if (stopped) return;
                 const handle = options.getHandle();
                 if (!handle) return;
                 options.refreshCanAcceptCellMutations(handle);
-                applyExecutionViewChangeset(options.projectExecutionViewChangeset(handle));
+                applyExecutionViewChangeset(
+                  options.projectExecutionViewChangeset(handle),
+                );
               })
               .catch((err: unknown) => {
                 if (stopped) return;
-                logger.warn("[automerge-notebook] materialize changeset failed:", err);
+                logger.warn(
+                  "[automerge-notebook] materialize changeset failed:",
+                  err,
+                );
               }),
           ),
         ),
@@ -149,8 +221,12 @@ export function startNotebookSyncStoreBridge(
       .subscribe(),
   );
 
-  subscription.add(options.engine.broadcasts$.subscribe((payload) => emitBroadcast(payload)));
-  subscription.add(options.engine.presence$.subscribe((payload) => emitPresence(payload)));
+  subscription.add(
+    options.engine.broadcasts$.subscribe((payload) => emitBroadcast(payload)),
+  );
+  subscription.add(
+    options.engine.presence$.subscribe((payload) => emitPresence(payload)),
+  );
 
   subscription.add(
     options.engine.runtimeState$.subscribe((state) => {
@@ -167,12 +243,17 @@ export function startNotebookSyncStoreBridge(
   subscription.add(
     options.engine.outputIdChanges$.subscribe(({ changed, removed_ids }) => {
       void applyOutputChangeset(changed, removed_ids).catch((err) =>
-        logger.warn("[automerge-notebook] output store projection failed:", err),
+        logger.warn(
+          "[automerge-notebook] output store projection failed:",
+          err,
+        ),
       );
     }),
   );
 
-  subscription.add(options.engine.poolState$.subscribe((state) => setPoolState(state)));
+  subscription.add(
+    options.engine.poolState$.subscribe((state) => setPoolState(state)),
+  );
 
   return {
     resetReadiness,

--- a/crates/notebook-protocol/src/connection/framing.rs
+++ b/crates/notebook-protocol/src/connection/framing.rs
@@ -301,6 +301,20 @@ impl FramedReader {
     pub async fn recv(&mut self) -> Option<std::io::Result<TypedNotebookFrame>> {
         self.rx.recv().await
     }
+
+    /// Non-blocking receive of an already-buffered frame.
+    ///
+    /// This is useful for bootstrap code that wants to drain a burst after one
+    /// awaited `recv()` without blocking the connection setup path. Empty and
+    /// disconnected both return `None`; callers that need to distinguish EOF
+    /// should use `recv()`.
+    pub fn try_recv(&mut self) -> Option<std::io::Result<TypedNotebookFrame>> {
+        match self.rx.try_recv() {
+            Ok(frame) => Some(frame),
+            Err(tokio::sync::mpsc::error::TryRecvError::Empty)
+            | Err(tokio::sync::mpsc::error::TryRecvError::Disconnected) => None,
+        }
+    }
 }
 
 impl Drop for FramedReader {

--- a/crates/runtimed/src/notebook_sync_server/load.rs
+++ b/crates/runtimed/src/notebook_sync_server/load.rs
@@ -1,7 +1,9 @@
-use std::collections::HashSet;
+use std::collections::{HashSet, VecDeque};
 
+use super::peer_notebook_sync::{apply_notebook_doc_frame, finish_notebook_doc_frame};
 use super::*;
 use base64::Engine as _;
+use notebook_protocol::connection::TypedNotebookFrame;
 
 pub(crate) struct ParsedIpynbCells {
     pub cells: Vec<CellSnapshot>,
@@ -594,28 +596,62 @@ pub(crate) fn fallback_output_with_id(output: &serde_json::Value) -> serde_json:
     fallback
 }
 
-/// Placeholder for draining incoming sync replies during streaming load.
+pub(crate) struct StreamingLoadFrameDrain<'a> {
+    pub(crate) framed_reader: &'a mut connection::FramedReader,
+    pub(crate) deferred_frames: &'a mut VecDeque<TypedNotebookFrame>,
+    pub(crate) connection_identity: &'a RoomConnectionIdentity,
+}
+
+/// Drain client frames while streaming the initial file-backed notebook.
 ///
-/// In theory, the client sends sync replies after each batch and we should
-/// drain them to prevent socket buffer deadlock. In practice:
-///
-/// 1. `recv_typed_frame` uses `read_exact` internally, which is NOT
-///    cancellation-safe. Wrapping it in `tokio::time::timeout` risks
-///    cancelling mid-frame, leaving the stream desynchronized.
-/// 2. With release-mode load times (~56ms for 50 cells), the OS socket
-///    buffer (typically 64KB+) easily absorbs the client's sync replies.
-/// 3. Non-sync frames (requests) would be silently dropped.
-///
-/// The sync replies are processed normally once the main select loop starts
-/// after streaming completes.
-async fn drain_incoming_frames<R>(
-    _reader: &mut R,
-    _room: &NotebookRoom,
-    _peer_state: &mut sync::State,
-) where
-    R: AsyncRead + Unpin,
+/// This is intentionally non-blocking. Real browser/Tauri clients do not answer
+/// these sync frames until their bootstrap path releases queued daemon frames,
+/// so waiting after every batch just adds fixed latency to small notebooks.
+/// Clients that can reply immediately still get their already-buffered frames
+/// applied before the next batch.
+async fn drain_buffered_incoming_frames<W>(
+    drain: &mut StreamingLoadFrameDrain<'_>,
+    writer: &mut W,
+    room: &NotebookRoom,
+    peer_state: &mut sync::State,
+) -> Result<bool, String>
+where
+    W: AsyncWrite + Unpin,
 {
-    // No-op. See doc comment above.
+    // Give the dedicated FramedReader task one scheduling turn to move bytes
+    // that are already available from the socket into its mpsc queue. This is a
+    // cooperative yield, not an I/O wait.
+    tokio::task::yield_now().await;
+
+    let mut consumed_notebook_doc_frame = false;
+    loop {
+        let Some(frame) = drain.framed_reader.try_recv() else {
+            break;
+        };
+        let frame = frame.map_err(|e| format!("Failed to read streaming-load reply: {e}"))?;
+
+        if frame.frame_type != NotebookFrameType::AutomergeSync {
+            drain.deferred_frames.push_back(frame);
+            continue;
+        }
+
+        consumed_notebook_doc_frame = true;
+
+        let (effects, reply_encoded) =
+            apply_notebook_doc_frame(room, peer_state, drain.connection_identity, &frame.payload)
+                .await
+                .map_err(|e| format!("Failed to apply streaming-load sync reply: {e}"))?;
+
+        if let Some(encoded) = reply_encoded {
+            connection::send_typed_frame(writer, NotebookFrameType::AutomergeSync, &encoded)
+                .await
+                .map_err(|e| format!("Failed to send streaming-load sync reply: {e}"))?;
+        }
+
+        finish_notebook_doc_frame(room, effects).await;
+    }
+
+    Ok(consumed_notebook_doc_frame)
 }
 
 /// Stream notebook cells into the Automerge doc in batches, sending sync
@@ -627,16 +663,15 @@ async fn drain_incoming_frames<R>(
 ///
 /// The caller must have already won `room.try_start_loading()` and must call
 /// `room.finish_loading()` after this returns (success or failure).
-pub(crate) async fn streaming_load_cells<R, W>(
-    reader: &mut R,
+pub(crate) async fn streaming_load_cells<W>(
     writer: &mut W,
     room: &NotebookRoom,
     path: &Path,
     execution_store: Option<&runtimed_client::execution_store::ExecutionStore>,
     peer_state: &mut sync::State,
+    mut frame_drain: Option<StreamingLoadFrameDrain<'_>>,
 ) -> Result<usize, String>
 where
-    R: AsyncRead + Unpin,
     W: AsyncWrite + Unpin,
 {
     let start = std::time::Instant::now();
@@ -809,8 +844,11 @@ where
         let _ = room.broadcasts.changed_tx.send(());
         // RuntimeStateDoc notification is automatic via with_doc heads check
 
-        // Drain incoming sync replies to prevent deadlock
-        drain_incoming_frames(reader, room, peer_state).await;
+        // Apply any already-buffered client sync replies. Do not block here:
+        // browser bootstrap normally cannot reply until after initial load.
+        if let Some(drain) = frame_drain.as_mut() {
+            let _ = drain_buffered_incoming_frames(drain, writer, room, peer_state).await?;
+        }
 
         batch_num += 1;
         debug!(
@@ -842,7 +880,9 @@ where
                 .map_err(|e| format!("Failed to send metadata sync: {}", e))?;
         }
         let _ = room.broadcasts.changed_tx.send(());
-        drain_incoming_frames(reader, room, peer_state).await;
+        if let Some(drain) = frame_drain.as_mut() {
+            let _ = drain_buffered_incoming_frames(drain, writer, room, peer_state).await?;
+        }
     }
 
     info!(

--- a/crates/runtimed/src/notebook_sync_server/peer_loop.rs
+++ b/crates/runtimed/src/notebook_sync_server/peer_loop.rs
@@ -19,12 +19,24 @@ use super::peer_presence::{
 use super::peer_runtime_sync::{forward_runtime_state_broadcast, handle_runtime_state_frame};
 use super::peer_session::{
     send_initial_notebook_doc_sync, send_initial_runtime_state_sync, send_session_status,
-    stream_initial_load, InitialSyncState,
+    stream_initial_load_with_frame_drain, InitialSyncState,
 };
 use super::peer_writer::{
     enqueue_notebook_request, queue_session_status, spawn_peer_request_worker, spawn_peer_writer,
 };
 use super::*;
+use std::collections::VecDeque;
+
+async fn next_peer_frame(
+    deferred_frames: &mut VecDeque<connection::TypedNotebookFrame>,
+    framed_reader: &mut connection::FramedReader,
+) -> Option<std::io::Result<connection::TypedNotebookFrame>> {
+    if let Some(frame) = deferred_frames.pop_front() {
+        Some(Ok(frame))
+    } else {
+        framed_reader.recv().await
+    }
+}
 
 /// Typed frames sync loop with first-byte type indicator.
 ///
@@ -36,7 +48,7 @@ use super::*;
 /// belongs to the dedicated reader task, not this select loop.
 #[allow(clippy::too_many_arguments)]
 pub(crate) async fn run_sync_loop_v2<R, W>(
-    mut reader: R,
+    reader: R,
     mut writer: W,
     room: &Arc<NotebookRoom>,
     _rooms: NotebookRooms,
@@ -51,6 +63,12 @@ where
     R: AsyncRead + Unpin + Send + 'static,
     W: AsyncWrite + Unpin + Send + 'static,
 {
+    // Hand the reader off to a dedicated FramedReader actor before bootstrap.
+    // The initial file-backed load can then safely wait for client sync replies
+    // between batches without risking partial-frame cancellation.
+    let mut framed_reader = connection::FramedReader::spawn(reader, 16);
+    let mut deferred_frames = VecDeque::new();
+
     // Subscribe before sending bootstrap traffic so any writes that land
     // during connection setup are still observed as steady-state deltas.
     let mut changed_rx = room.broadcasts.changed_tx.subscribe();
@@ -81,8 +99,20 @@ where
         .await?;
     }
 
-    let InitialSyncState { mut peer_state } =
-        send_initial_notebook_doc_sync(&mut writer, room).await?;
+    // Fresh file-backed rooms stream the file itself as the initial doc sync.
+    // Sending an empty-doc handshake first leaves Automerge with an in-flight
+    // message and can collapse the visible cell batches into one final update.
+    let defer_initial_doc_sync_for_file_load = if needs_load.is_some() {
+        let doc = room.doc.read().await;
+        doc.cell_count() == 0
+    } else {
+        false
+    };
+    let InitialSyncState { mut peer_state } = if defer_initial_doc_sync_for_file_load {
+        InitialSyncState::new()
+    } else {
+        send_initial_notebook_doc_sync(&mut writer, room).await?
+    };
     notebook_doc_phase = notebook_protocol::protocol::NotebookDocPhaseWire::Syncing;
     if client_protocol_version >= 3 {
         send_session_status(
@@ -121,9 +151,10 @@ where
     send_initial_comms_doc_sync(&mut writer, room, &mut comms_peer_state).await?;
     send_initial_comments_doc_sync(&mut writer, room, &mut comments_peer_state).await?;
 
-    initial_load_phase = stream_initial_load(
-        &mut reader,
+    initial_load_phase = stream_initial_load_with_frame_drain(
+        &mut framed_reader,
         &mut writer,
+        &mut deferred_frames,
         room,
         needs_load,
         &daemon.config.execution_store_dir,
@@ -132,6 +163,7 @@ where
         runtime_state_phase,
         initial_load_phase,
         client_protocol_version,
+        connection_identity,
     )
     .await?;
 
@@ -171,13 +203,6 @@ where
         notebook_id.clone(),
         peer_id.to_string(),
     );
-
-    // Hand the reader off to a dedicated FramedReader actor before
-    // entering the busy `select!` below. `recv_typed_frame`'s internal
-    // `read_exact` calls are NOT cancel-safe — putting them directly
-    // in a `select!` arm desyncs the framed stream the moment another
-    // arm wins mid-payload (see issue + production diagnostics).
-    let mut framed_reader = connection::FramedReader::spawn(reader, 16);
 
     // Idle peer timeout: disconnect peers that stop sending inbound frames.
     // This is the safety net for orphaned connections where the remote process
@@ -236,7 +261,7 @@ where
             }
 
             // Incoming message from this client (cancel-safe via FramedReader actor)
-            maybe_frame = framed_reader.recv() => {
+            maybe_frame = next_peer_frame(&mut deferred_frames, &mut framed_reader) => {
                 let frame = match maybe_frame {
                     Some(Ok(frame)) => frame,
                     Some(Err(e)) => return Err(e.into()),

--- a/crates/runtimed/src/notebook_sync_server/peer_notebook_sync.rs
+++ b/crates/runtimed/src/notebook_sync_server/peer_notebook_sync.rs
@@ -17,6 +17,24 @@ pub(super) async fn handle_notebook_doc_frame(
     writer: &PeerWriter,
     payload: &[u8],
 ) -> anyhow::Result<NotebookDocSideEffects> {
+    let (effects, reply_encoded) =
+        apply_notebook_doc_frame(room, peer_state, connection_identity, payload).await?;
+
+    // Queue the reply outside the lock so other peers can acquire it while the
+    // writer task drains the socket.
+    if let Some(encoded) = reply_encoded {
+        writer.send_frame(NotebookFrameType::AutomergeSync, encoded)?;
+    }
+
+    Ok(effects)
+}
+
+pub(super) async fn apply_notebook_doc_frame(
+    room: &NotebookRoom,
+    peer_state: &mut sync::State,
+    connection_identity: &RoomConnectionIdentity,
+    payload: &[u8],
+) -> anyhow::Result<(NotebookDocSideEffects, Option<Vec<u8>>)> {
     let mut message =
         sync::Message::decode(payload).map_err(|e| anyhow::anyhow!("decode error: {}", e))?;
     let has_client_changes = !message.changes.is_empty();
@@ -88,18 +106,16 @@ pub(super) async fn handle_notebook_doc_frame(
         (bytes, encoded, metadata_changed)
     };
 
-    // Queue the reply outside the lock so other peers can acquire it while the
-    // writer task drains the socket.
     let sync_reply_queued = reply_encoded.is_some();
-    if let Some(encoded) = reply_encoded {
-        writer.send_frame(NotebookFrameType::AutomergeSync, encoded)?;
-    }
 
-    Ok(NotebookDocSideEffects {
-        persist_bytes,
-        metadata_changed,
-        sync_reply_queued,
-    })
+    Ok((
+        NotebookDocSideEffects {
+            persist_bytes,
+            metadata_changed,
+            sync_reply_queued,
+        },
+        reply_encoded,
+    ))
 }
 
 pub(super) struct NotebookDocSideEffects {

--- a/crates/runtimed/src/notebook_sync_server/peer_session.rs
+++ b/crates/runtimed/src/notebook_sync_server/peer_session.rs
@@ -1,13 +1,19 @@
+use std::collections::VecDeque;
 use std::path::Path;
 use std::sync::Arc;
 
 use automerge::sync;
-use tokio::io::{AsyncRead, AsyncWrite};
+#[cfg(test)]
+use tokio::io::AsyncRead;
+use tokio::io::AsyncWrite;
 use tracing::{info, warn};
 
-use notebook_protocol::connection::{self, NotebookFrameType};
+use notebook_protocol::connection::{self, NotebookFrameType, TypedNotebookFrame};
 
-use super::{streaming_load_cells, NotebookRoom, STATE_SYNC_COMPACT_THRESHOLD};
+use super::{
+    streaming_load_cells, NotebookRoom, RoomConnectionIdentity, StreamingLoadFrameDrain,
+    STATE_SYNC_COMPACT_THRESHOLD,
+};
 
 pub(crate) async fn send_session_status<W>(
     writer: &mut W,
@@ -44,7 +50,7 @@ pub(crate) struct InitialSyncState {
 }
 
 impl InitialSyncState {
-    fn new() -> Self {
+    pub(crate) fn new() -> Self {
         Self {
             peer_state: sync::State::new(),
         }
@@ -130,8 +136,9 @@ where
 /// The caller passes `peer_state` from the initial notebook-doc sync so each
 /// streamed batch can produce deltas from the same baseline.
 #[allow(clippy::too_many_arguments)]
+#[cfg(test)]
 pub(crate) async fn stream_initial_load<R, W>(
-    reader: &mut R,
+    _reader: &mut R,
     writer: &mut W,
     room: &Arc<NotebookRoom>,
     needs_load: Option<&Path>,
@@ -146,6 +153,74 @@ where
     R: AsyncRead + Unpin,
     W: AsyncWrite + Unpin,
 {
+    stream_initial_load_inner(
+        writer,
+        room,
+        needs_load,
+        execution_store_dir,
+        peer_state,
+        notebook_doc_phase,
+        runtime_state_phase,
+        initial_load_phase,
+        client_protocol_version,
+        None,
+    )
+    .await
+}
+
+#[allow(clippy::too_many_arguments)]
+pub(crate) async fn stream_initial_load_with_frame_drain<W>(
+    framed_reader: &mut connection::FramedReader,
+    writer: &mut W,
+    deferred_frames: &mut VecDeque<TypedNotebookFrame>,
+    room: &Arc<NotebookRoom>,
+    needs_load: Option<&Path>,
+    execution_store_dir: &Path,
+    peer_state: &mut sync::State,
+    notebook_doc_phase: notebook_protocol::protocol::NotebookDocPhaseWire,
+    runtime_state_phase: notebook_protocol::protocol::RuntimeStatePhaseWire,
+    initial_load_phase: notebook_protocol::protocol::InitialLoadPhaseWire,
+    client_protocol_version: u8,
+    connection_identity: &RoomConnectionIdentity,
+) -> anyhow::Result<notebook_protocol::protocol::InitialLoadPhaseWire>
+where
+    W: AsyncWrite + Unpin,
+{
+    stream_initial_load_inner(
+        writer,
+        room,
+        needs_load,
+        execution_store_dir,
+        peer_state,
+        notebook_doc_phase,
+        runtime_state_phase,
+        initial_load_phase,
+        client_protocol_version,
+        Some(StreamingLoadFrameDrain {
+            framed_reader,
+            deferred_frames,
+            connection_identity,
+        }),
+    )
+    .await
+}
+
+#[allow(clippy::too_many_arguments)]
+async fn stream_initial_load_inner<W>(
+    writer: &mut W,
+    room: &Arc<NotebookRoom>,
+    needs_load: Option<&Path>,
+    execution_store_dir: &Path,
+    peer_state: &mut sync::State,
+    notebook_doc_phase: notebook_protocol::protocol::NotebookDocPhaseWire,
+    runtime_state_phase: notebook_protocol::protocol::RuntimeStatePhaseWire,
+    initial_load_phase: notebook_protocol::protocol::InitialLoadPhaseWire,
+    client_protocol_version: u8,
+    frame_drain: Option<StreamingLoadFrameDrain<'_>>,
+) -> anyhow::Result<notebook_protocol::protocol::InitialLoadPhaseWire>
+where
+    W: AsyncWrite + Unpin,
+{
     let Some(load_path) = needs_load else {
         return Ok(initial_load_phase);
     };
@@ -158,12 +233,12 @@ where
     let execution_store =
         runtimed_client::execution_store::ExecutionStore::new(execution_store_dir.to_path_buf());
     match streaming_load_cells(
-        reader,
         writer,
         room,
         load_path,
         Some(&execution_store),
         peer_state,
+        frame_drain,
     )
     .await
     {

--- a/crates/runtimed/src/notebook_sync_server/tests.rs
+++ b/crates/runtimed/src/notebook_sync_server/tests.rs
@@ -255,6 +255,37 @@ where
     }
 }
 
+async fn write_numbered_notebook(path: &Path, count: usize) {
+    let cells: Vec<serde_json::Value> = (0..count)
+        .map(|index| {
+            serde_json::json!({
+                "cell_type": "code",
+                "execution_count": null,
+                "id": format!("cell-{index}"),
+                "metadata": {},
+                "outputs": [],
+                "source": format!("print({index})\n"),
+            })
+        })
+        .collect();
+    let notebook = serde_json::json!({
+        "cells": cells,
+        "metadata": {
+            "kernelspec": {
+                "display_name": "Python 3",
+                "language": "python",
+                "name": "python3",
+            },
+            "language_info": {"name": "python"},
+        },
+        "nbformat": 4,
+        "nbformat_minor": 5,
+    });
+    tokio::fs::write(path, serde_json::to_vec(&notebook).unwrap())
+        .await
+        .unwrap();
+}
+
 #[tokio::test]
 async fn notebook_doc_interactive_waits_for_initial_sync_convergence() {
     let tmp = tempfile::TempDir::new().unwrap();
@@ -303,6 +334,10 @@ async fn notebook_doc_interactive_waits_for_initial_sync_convergence() {
             .await
         })
     };
+
+    connection::send_typed_frame(&mut client_writer, NotebookFrameType::Presence, b"{}")
+        .await
+        .unwrap();
 
     let mut client_doc =
         notebook_doc::NotebookDoc::bootstrap(notebook_doc::TextEncoding::Utf16CodeUnit, "mcp:test");
@@ -368,6 +403,272 @@ async fn notebook_doc_interactive_waits_for_initial_sync_convergence() {
     .unwrap();
 
     recv_until_notebook_doc_interactive(&mut client_reader).await;
+
+    drop(client_writer);
+    drop(client_reader);
+    server_task.abort();
+    let _ = server_task.await;
+}
+
+#[tokio::test]
+async fn file_backed_initial_load_applies_buffered_replies_before_ready() {
+    let tmp = tempfile::TempDir::new().unwrap();
+    let load_path = tmp.path().join("seven-cells.ipynb");
+    write_numbered_notebook(&load_path, 7).await;
+
+    let blob_store = test_blob_store(&tmp);
+    let room = Arc::new(NotebookRoom::new_fresh(
+        Uuid::new_v4(),
+        Some(load_path.clone()),
+        tmp.path(),
+        blob_store,
+        false,
+    ));
+
+    let daemon = crate::daemon::Daemon::new_for_test(test_daemon_config(&tmp)).unwrap();
+    let rooms: NotebookRooms = Arc::new(RoomRegistry::new());
+    let identity = RoomConnectionIdentity::local(Some("mcp:test".to_string()))
+        .await
+        .unwrap();
+    let notebook_id = room.id.to_string();
+    let (client_io, server_io) = tokio::io::duplex(1024 * 1024);
+    let (server_reader, server_writer) = tokio::io::split(server_io);
+    let (mut client_reader, mut client_writer) = tokio::io::split(client_io);
+
+    let server_task = {
+        let room = room.clone();
+        let daemon = daemon.clone();
+        let load_path = load_path.clone();
+        tokio::spawn(async move {
+            super::peer_loop::run_sync_loop_v2(
+                server_reader,
+                server_writer,
+                &room,
+                rooms,
+                notebook_id,
+                daemon,
+                Some(load_path.as_path()),
+                "mcp-peer",
+                &identity,
+                notebook_protocol::connection::PROTOCOL_VERSION,
+            )
+            .await
+        })
+    };
+
+    let mut client_doc =
+        notebook_doc::NotebookDoc::bootstrap(notebook_doc::TextEncoding::Utf16CodeUnit, "mcp:test");
+    let mut client_state = sync::State::new();
+    let mut observed_counts = Vec::new();
+    let mut last_count = 0usize;
+    let mut saw_ready = false;
+
+    while !saw_ready {
+        let frame = recv_typed_frame_or_timeout(
+            &mut client_reader,
+            std::time::Duration::from_secs(2),
+            "streaming load frame",
+        )
+        .await
+        .expect("daemon should keep sending bootstrap frames");
+
+        match frame.frame_type {
+            NotebookFrameType::AutomergeSync => {
+                let message = sync::Message::decode(&frame.payload).expect("valid sync message");
+                client_doc
+                    .receive_sync_message_recovering(
+                        &mut client_state,
+                        message,
+                        "test-streaming-load-sync",
+                    )
+                    .unwrap();
+                let count = client_doc.cell_count();
+                if count != last_count {
+                    observed_counts.push(count);
+                    last_count = count;
+                }
+                if let Some(reply) = client_doc
+                    .generate_sync_message_recovering(
+                        &mut client_state,
+                        "test-streaming-load-reply",
+                    )
+                    .unwrap()
+                {
+                    connection::send_typed_frame(
+                        &mut client_writer,
+                        NotebookFrameType::AutomergeSync,
+                        &reply.encode(),
+                    )
+                    .await
+                    .unwrap();
+                }
+            }
+            NotebookFrameType::SessionControl => {
+                if decode_sync_status(&frame).is_some_and(|status| {
+                    status.initial_load == notebook_protocol::protocol::InitialLoadPhaseWire::Ready
+                }) {
+                    saw_ready = true;
+                }
+            }
+            _ => {}
+        }
+    }
+
+    assert_eq!(client_doc.cell_count(), 7);
+    assert!(
+        observed_counts.iter().any(|count| *count < 7),
+        "client should observe at least one partial load before Ready, got {observed_counts:?}"
+    );
+    assert_eq!(
+        observed_counts.last().copied(),
+        Some(7),
+        "client should converge before Ready when replies are already buffered"
+    );
+
+    drop(client_writer);
+    drop(client_reader);
+    server_task.abort();
+    let _ = server_task.await;
+}
+
+#[tokio::test(start_paused = true)]
+async fn file_backed_initial_load_reaches_ready_without_streaming_replies() {
+    let tmp = tempfile::TempDir::new().unwrap();
+    let load_path = tmp.path().join("eleven-cells.ipynb");
+    write_numbered_notebook(&load_path, 11).await;
+
+    let blob_store = test_blob_store(&tmp);
+    let room = Arc::new(NotebookRoom::new_fresh(
+        Uuid::new_v4(),
+        Some(load_path.clone()),
+        tmp.path(),
+        blob_store,
+        false,
+    ));
+
+    let daemon = crate::daemon::Daemon::new_for_test(test_daemon_config(&tmp)).unwrap();
+    let rooms: NotebookRooms = Arc::new(RoomRegistry::new());
+    let identity = RoomConnectionIdentity::local(Some("mcp:test".to_string()))
+        .await
+        .unwrap();
+    let notebook_id = room.id.to_string();
+    let (client_io, server_io) = tokio::io::duplex(1024 * 1024);
+    let (server_reader, server_writer) = tokio::io::split(server_io);
+    let (mut client_reader, mut client_writer) = tokio::io::split(client_io);
+
+    let server_task = {
+        let room = room.clone();
+        let daemon = daemon.clone();
+        let load_path = load_path.clone();
+        tokio::spawn(async move {
+            super::peer_loop::run_sync_loop_v2(
+                server_reader,
+                server_writer,
+                &room,
+                rooms,
+                notebook_id,
+                daemon,
+                Some(load_path.as_path()),
+                "mcp-peer",
+                &identity,
+                notebook_protocol::connection::PROTOCOL_VERSION,
+            )
+            .await
+        })
+    };
+
+    let queued_notebook_syncs = tokio::time::timeout(std::time::Duration::from_millis(24), async {
+        let mut sync_payloads = Vec::new();
+        loop {
+            let frame = connection::recv_typed_frame(&mut client_reader)
+                .await
+                .expect("daemon frame read should succeed")
+                .expect("daemon should keep bootstrap connection open");
+            match frame.frame_type {
+                NotebookFrameType::AutomergeSync => sync_payloads.push(frame.payload),
+                NotebookFrameType::SessionControl => {
+                    if decode_sync_status(&frame).is_some_and(|status| {
+                        status.initial_load
+                            == notebook_protocol::protocol::InitialLoadPhaseWire::Ready
+                    }) {
+                        return sync_payloads;
+                    }
+                }
+                _ => {}
+            }
+        }
+    })
+    .await
+    .expect("file load should reach Ready without waiting for 25ms streaming reply drains");
+
+    assert_eq!(
+        room.doc.read().await.cell_count(),
+        11,
+        "daemon doc should finish loading before any client sync reply"
+    );
+
+    let mut client_doc =
+        notebook_doc::NotebookDoc::bootstrap(notebook_doc::TextEncoding::Utf16CodeUnit, "mcp:test");
+    let mut client_state = sync::State::new();
+    for payload in queued_notebook_syncs {
+        let message = sync::Message::decode(&payload).expect("valid sync message");
+        client_doc
+            .receive_sync_message_recovering(&mut client_state, message, "test-no-reply-sync")
+            .unwrap();
+    }
+
+    if let Some(reply) = client_doc
+        .generate_sync_message_recovering(&mut client_state, "test-delayed-reply")
+        .unwrap()
+    {
+        connection::send_typed_frame(
+            &mut client_writer,
+            NotebookFrameType::AutomergeSync,
+            &reply.encode(),
+        )
+        .await
+        .unwrap();
+    }
+
+    tokio::time::timeout(std::time::Duration::from_secs(2), async {
+        while client_doc.cell_count() < 11 {
+            let frame = connection::recv_typed_frame(&mut client_reader)
+                .await
+                .expect("daemon frame read should succeed")
+                .expect("daemon should keep connection open until convergence");
+            if frame.frame_type != NotebookFrameType::AutomergeSync {
+                continue;
+            }
+
+            let message = sync::Message::decode(&frame.payload).expect("valid sync message");
+            client_doc
+                .receive_sync_message_recovering(
+                    &mut client_state,
+                    message,
+                    "test-delayed-convergence-sync",
+                )
+                .unwrap();
+            if let Some(reply) = client_doc
+                .generate_sync_message_recovering(
+                    &mut client_state,
+                    "test-delayed-convergence-reply",
+                )
+                .unwrap()
+            {
+                connection::send_typed_frame(
+                    &mut client_writer,
+                    NotebookFrameType::AutomergeSync,
+                    &reply.encode(),
+                )
+                .await
+                .unwrap();
+            }
+        }
+    })
+    .await
+    .expect("client should converge after its delayed sync reply");
+
+    assert_eq!(client_doc.cell_count(), 11);
 
     drop(client_writer);
     drop(client_reader);

--- a/docs/handoffs/2026-06-26-og-ipynb-ttfc.md
+++ b/docs/handoffs/2026-06-26-og-ipynb-ttfc.md
@@ -1,0 +1,308 @@
+# OG ipynb TTFC handoff
+
+Status: active investigation, not an architecture decision.
+Branch: `quod/og-ipynb-ttfc`.
+Date: 2026-06-26.
+
+## Context
+
+OG `.ipynb` loading regressed from the historical behavior where cells appeared
+quickly while the notebook continued to initialize. The benchmark target is the
+Matplotlib brochure binder notebooks copied from:
+
+`/Users/kylekelley/code/src/github.com/matplotlib/mpl-brochure-binder`
+
+Scratch artifacts are in `.context/og-ipynb-load/`. The full scratch directory is
+about 67 MB because it includes copied per-run notebooks, so this handoff keeps
+the durable summary here rather than moving every raw run into `docs/`.
+
+## Benchmark Harness
+
+Harness:
+
+`.context/og-ipynb-load/benchmark-og-ipynb-load.mjs`
+
+Primary source notebooks:
+
+- `.context/og-ipynb-load/source/MatplotlibExample.ipynb`
+- `.context/og-ipynb-load/source/_PreProcess.ipynb`
+
+The harness runs the real browser/Vite/dev-daemon path, watches DOM cell counts,
+captures browser console timing, and records result JSON under
+`.context/og-ipynb-load/results/`.
+
+## Key Results
+
+| Result | Notebook | Median first cell | Median all cells | Median synced | Median runtime ready | Median materialize | Timeline shape |
+|---|---|---:|---:|---:|---:|---:|---|
+| `2026-06-26T15-27-52-004Z.json` | `MatplotlibExample.ipynb` | 993 ms | 993 ms | 1660 ms | 1067 ms | 284 ms | `0 -> 13` |
+| `2026-06-26T15-27-52-004Z.json` | `_PreProcess.ipynb` | 926 ms | 926 ms | 955 ms | 651 ms | 10 ms | `0 -> 11` |
+| `2026-06-26T16-37-03-763Z.json` | `MatplotlibExample.ipynb` | 884 ms | 1136 ms | 1933 ms | 1343 ms | 75 ms | `0 -> 3 -> 13` |
+| `2026-06-26T16-37-03-763Z.json` | `_PreProcess.ipynb` | 945 ms | 945 ms | 976 ms | 644 ms | 10 ms | `0 -> 11` |
+| `2026-06-26T17-41-51-091Z.json` | `_PreProcess.ipynb` | 938 ms | 938 ms | 966 ms | 656 ms | 9 ms | usually `0 -> 11`; first iteration streamed noisily |
+| `2026-06-26T17-44-17-561Z.json` | `_PreProcess.ipynb` | 973 ms | 973 ms | 1005 ms | 692 ms | 10 ms | `0 -> 11` |
+| `2026-06-26T22-37-06-873Z.json` | `MatplotlibExample.ipynb` | 873 ms | 1131 ms | 1782 ms | 1204 ms | 302 ms | stable `0 -> 3 -> 13` |
+| `2026-06-26T22-37-06-873Z.json` | `_PreProcess.ipynb` | 801 ms | 969 ms | 1066 ms | 676 ms | 6 ms | stable `0 -> 3 -> 11` |
+
+Interpretation:
+
+- `MatplotlibExample.ipynb` benefits from the frontend progressive projection
+  path: first cells appear at about 884 ms while all cells complete later.
+- `_PreProcess.ipynb` generally does not benefit. It still paints as one
+  structural update, so it pays some new load-path cost without getting a TTFC
+  split.
+- WASM/materialization is not the `_PreProcess` bottleneck. It remains about
+  9-10 ms.
+- After removing Rust's blocking no-reply drain and publishing a deterministic
+  first structural slice before deferred full materialization, `_PreProcess`
+  consistently shows `0 -> 3 -> 11` and improves median first-cell time by about
+  172 ms versus the instrumented `17-44` run.
+
+## Implemented Fix
+
+Implemented on branch `quod/og-ipynb-ttfc`:
+
+- Rust streaming load now drains only already-buffered client frames. It no
+  longer waits 25 ms after every file-load batch when the browser cannot reply
+  during bootstrap.
+- The Rust tests cover both paths:
+  - a buffered-reply client can still converge before `Ready`;
+  - a no-reply client reaches `Ready` under a paused-clock guard without paying
+    a 25 ms drain.
+- The frontend now publishes a deterministic first structural slice for deferred
+  initial materialization when the file load was streaming, then yields a paint
+  before running the full async materialization.
+- The existing streaming changeset path also avoids shrinking an already
+  populated initial projection back to the first slice.
+
+Verification after the fix:
+
+- `node_modules/.bin/vp test run apps/notebook/src/lib/__tests__/frame-pipeline.test.ts apps/notebook/src/lib/__tests__/notebook-sync-store-bridge.test.ts packages/runtimed/tests/sync-engine.test.ts`: 157 passed.
+- `cargo test -p runtimed file_backed_initial_load -- --nocapture`: 2 passed.
+- `cargo test -p runtimed --test tokio_mutex_lint`: 2 passed.
+- `cargo test -p notebook-protocol`: 89 passed.
+- `node_modules/.bin/vp check`: formatting and lint passed.
+- `cargo xtask lint --fix`: passed after rebasing onto `origin/main`.
+- `git diff --check`: passed.
+- `cargo test -p runtimed`: unit tests passed, then
+  `test_settings_json_mirror_write_does_not_feedback_loop` failed once in the
+  integration suite and passed on immediate targeted rerun.
+
+## Rust Bottleneck Evidence
+
+Temporary probes around `streaming_load_cells` showed this shape for
+`_PreProcess.ipynb`:
+
+- File parse: less than 1 ms.
+- Cell batches: 4 batches of size 3, 3, 3, 2.
+- Metadata sync also drains once after cell batches.
+- Each `drain_incoming_frames` wait took about 26-27 ms, timed out, and received
+  zero frames.
+- Total streaming load was about 189-191 ms.
+- Per-batch encoded sync payloads were only about 48-52 bytes.
+
+Relevant source:
+
+- `crates/runtimed/src/notebook_sync_server/load.rs`
+  - `STREAMING_BATCH_SIZE` is 3.
+  - `STREAMING_SYNC_REPLY_WAIT` is 25 ms.
+  - `drain_incoming_frames_for` waits for a client `AutomergeSync` frame after
+    each batch.
+  - `streaming_load_cells` sends each batch and then drains replies before
+    continuing.
+
+Likely conclusion:
+
+The Rust-side per-batch drain is real server-side waste for small notebooks, but
+the tiny payloads matter more semantically than the wait itself: in the real
+browser path, the batch syncs are not carrying useful cell changes because the
+client has not replied with its Automerge sync state yet. The repeated waits
+should be removed or made non-blocking, but that alone may not move first-cell
+time much when the wasted server work overlaps browser startup.
+
+## Browser Bootstrap Evidence
+
+Relevant source:
+
+- `packages/notebook-host/src/browser/index.ts`
+  - `BrowserDevTransport` queues inbound daemon frames while `framesReleased` is
+    false.
+  - `releaseFrames()` delivers queued frames.
+  - `notifySyncReady()` calls `releaseFrames()`.
+- `packages/notebook-host/src/relay-bootstrap.ts`
+  - `notifyRelayReady()` runs only after `bootstrap()` completes.
+- `apps/notebook/src/hooks/useAutomergeNotebook.ts`
+  - `bootstrap()` resets the engine and sends the frontend's initial
+    `engine.flush()` sync message before the host releases queued daemon frames.
+
+Likely conclusion:
+
+In the Vite/browser benchmark path, Rust can start streaming before the browser
+delivers inbound daemon frames to `SyncEngine`. The browser therefore does not
+produce per-batch inline replies during Rust's 25 ms drain windows. Rust waits,
+times out, and continues; the browser later sees a full `0 -> 11` structural
+update after `initial_load=ready`.
+
+## Fix Question
+
+Do not blindly reduce the timeout without proving the sync semantics.
+
+Open fix candidates:
+
+1. Make Rust adaptive or non-blocking: pick up already-buffered client replies,
+   but do not wait 25 ms between file-load batches when the real client cannot
+   reply yet.
+2. Consider collapsing the file-load path to "load all cells, send one initial
+   doc sync, enter steady state" if benchmarks show per-batch Automerge
+   streaming has no production TTFC value.
+3. Make the frontend initial structural projection deterministic, so an initial
+   cell-bearing changeset can publish the first batch before publishing all
+   cells regardless of whether `initial_load` is still `streaming` or already
+   `ready`.
+4. Treat browser bootstrap reordering as higher risk. If attempted, it must
+   prove frames cannot hit a missing or stale notebook handle and must beat the
+   simpler frontend projection path in the real benchmark.
+
+Rejected or risky as-is:
+
+- Keeping unconditional 25 ms waits after every small batch: this hurts small
+  notebooks and does not guarantee streaming in the browser path.
+- Only shrinking the wait: it may hide the `_PreProcess` regression but leaves
+  the underlying "no client ack, no useful batch sync" behavior intact.
+- Relying on browser in-band replies as the only TTFC fix: for small notebooks,
+  it can turn one steady-state sync round trip into several batch round trips
+  and reopens handle-ordering hazards.
+- Moving all raw `.context` runs into docs: the raw run directory is 67 MB and
+  mostly copied notebooks. Keep durable evidence here; preserve scratch
+  artifacts in `.context` while the branch is active.
+
+## External Reviews
+
+Requested on 2026-06-26:
+
+- Claude Code via `claude -p`: completed.
+- Codex explorer focused on Rust/Automerge streaming semantics: completed.
+- Codex explorer focused on browser host/bootstrap ordering: completed.
+
+### Codex Rust/Automerge Review
+
+Conclusion:
+
+- The 25 ms drain is the measured Rust bottleneck for `_PreProcess.ipynb`.
+- The tiny batch frames are best understood as "no peer `have`/`need` yet" rather
+  than only generic in-flight suppression. A fresh `sync::State` cannot send
+  useful cell changes until a client sync message establishes remote state.
+- The current Rust test covers the ideal path where the synthetic client reads
+  every batch and immediately replies. It does not cover the real browser path
+  where the daemon drains zero notebook frames during streaming.
+
+Recommended Rust direction:
+
+- Make streaming load ack-aware.
+- Consume one initial NotebookDoc sync round before expecting progressive
+  batches to work.
+- Change `drain_incoming_frames` to report whether it consumed a NotebookDoc sync
+  frame.
+- If no ack arrives, stop paying per-batch waits. Finish the remaining load
+  without progressive waits, send one final sync advertisement after metadata,
+  and let the main peer loop process delayed client replies.
+
+Rejected:
+
+- Increasing the timeout.
+- Resetting Automerge `sync::State` after timeout.
+- Expecting TypeScript coalescing changes to fix missing change-bearing Rust
+  frames.
+- Streaming cells out of band from Automerge.
+
+### Codex Browser Bootstrap Review
+
+Conclusion:
+
+- The browser host gates the frames that would produce inline replies:
+  `BrowserDevTransport` queues binary frames until `notifySyncReady()` calls
+  `releaseFrames()`.
+- The current notify order is too late for streaming load. The coordinator calls
+  `notifyRelayReady()` after `bootstrap()` resolves; the bootstrap body sends
+  `engine.flush()` before returning.
+- Releasing earlier is right, but only after the handle exists and the engine has
+  reset for bootstrap. Releasing on WebSocket ready or current `prepareRelay`
+  would be too early because frames can hit no handle or the wrong handle.
+- The Vite relay is not the main blocker after typed bootstrap; the browser-side
+  queue is.
+
+Recommended frontend direction:
+
+- Split bootstrap into phases:
+  `prepareRelay -> create/replace handle -> engine.resetForBootstrap() -> notifyRelayReady()/releaseFrames() -> engine.flush()`.
+- Move the initial `engine.flush()` out of the current bootstrap body and add a
+  post-notify callback or equivalent coordinator phase.
+- Keep a Rust adaptive fallback as a guard for clients that still do not reply
+  during streaming.
+
+Rejected:
+
+- Relying only on the SyncEngine streaming no-coalesce change.
+- Releasing frames on WebSocket ready or current `prepareRelay`.
+- Moving the Vite `pipeTo` earlier as the primary fix.
+
+### Claude Code Review
+
+Conclusion:
+
+- The no-cell batch behavior is the root cause for why Rust streaming does not
+  deliver progressive cells to the real browser path. The first Automerge sync
+  messages from a fresh `sync::State` advertise heads and bloom `have` state, but
+  they do not carry cell changes until the peer has replied with its own sync
+  state.
+- The existing Rust streaming test is too optimistic because its synthetic client
+  applies every batch and immediately replies. Real browser and Tauri clients
+  gate replies behind bootstrap/release, so they do not exercise that path during
+  file load.
+- The 25 ms drains are still a real Rust regression, but they overlap browser
+  startup and are not necessarily the dominant first-cell cost.
+- `_PreProcess.ipynb` paints `0 -> 11` because the cell-bearing update arrives
+  after `initial_load=ready` and takes the full initial materialize path. The
+  progressive split currently depends on timing rather than a deterministic
+  "initial structural load" rule.
+
+Recommended direction:
+
+- First, replace blocking drain waits with non-blocking collection of any
+  already-buffered client frames, preserving in-band streaming for clients that
+  can reply while removing the fixed no-reply delay.
+- Then consider simplifying file-backed load to load all cells and send a single
+  initial sync, if benchmark results confirm per-batch server streaming has no
+  production value for OG notebooks.
+- Move the real TTFC win to the frontend: ensure the initial cell-bearing
+  changeset or full initial materialize path can publish an early first batch
+  deterministically, so `_PreProcess.ipynb` reaches a stable `0 -> 3 -> 11`
+  shape instead of racing between progressive and full materialization.
+
+Rejected:
+
+- Making the browser release frames earlier as the primary fix. Claude judged it
+  risky for handle ordering and likely worse for small notebooks because it can
+  serialize several batch round trips instead of one cell-bearing sync.
+- Lowering the timeout as a standalone fix.
+- Keeping Rust per-batch streaming unchanged and only patching frontend
+  projection.
+
+## Verification To Keep
+
+Run the real benchmark after any fix:
+
+```bash
+RUNTIMED_VITE_PORT=7366 node .context/og-ipynb-load/benchmark-og-ipynb-load.mjs --iterations=5 --base-url=http://127.0.0.1:7366
+```
+
+Focused tests that should exist before trusting the fix:
+
+- Rust integration test where the client does not reply during streaming; assert
+  that small notebooks do not pay repeated 25 ms waits and still converge.
+- Rust integration test where the client does reply during streaming; assert
+  that progressive counts are still observed before `initial_load=ready`.
+- Browser-host or SyncEngine test covering queued inbound frames and bootstrap
+  release ordering.
+- Benchmark comparison for both `MatplotlibExample.ipynb` and
+  `_PreProcess.ipynb`.

--- a/docs/handoffs/README.md
+++ b/docs/handoffs/README.md
@@ -12,3 +12,4 @@ instead of letting stale findings look current.
 | [`16-lifecycle-analysis.md`](16-lifecycle-analysis.md) | Historical lifecycle risk analysis. Partially superseded by the runtime-peer departure watchdog and reconnect work; remaining live gaps are called out at the top. |
 | [`2026-06-01-host-convergence-deep-dive.md`](2026-06-01-host-convergence-deep-dive.md) | Historical deep dive on rejected local-first writes and recovery policy. Still useful as source evidence for sync-divergence recovery decisions. |
 | [`2026-06-01-notebook-host-convergence.md`](2026-06-01-notebook-host-convergence.md) | Historical host-convergence handoff. Read with the deep dive and newer ADRs before treating rows as current work. |
+| [`2026-06-26-og-ipynb-ttfc.md`](2026-06-26-og-ipynb-ttfc.md) | Active handoff for OG `.ipynb` TTFC benchmarking, Rust streaming-load drain evidence, and browser bootstrap review. |

--- a/packages/runtimed/src/sync-engine.ts
+++ b/packages/runtimed/src/sync-engine.ts
@@ -110,6 +110,10 @@ function formatSessionStatus(status: SessionStatus): string {
   return `notebook=${status.notebook_doc} runtime=${status.runtime_state} load=${initialLoadPhaseName(status.initial_load)}`;
 }
 
+function isInitialLoadStreamingStatus(status: SessionStatus | null): boolean {
+  return status?.initial_load.phase === "streaming";
+}
+
 // ── Comm state helpers ───────────────────────────────────────────────
 
 /**
@@ -659,7 +663,12 @@ export class SyncEngine {
                   "[sync-engine] sync_applied with change but no changeset (full materialization needed)",
                 );
               }
-              materialize$.next(cs ?? null);
+              if (isInitialLoadStreamingStatus(this.latestSessionStatus)) {
+                log.debug("[sync-engine] streaming load changeset emitted without coalescing");
+                this._cellChanges$.next(cs ?? null);
+              } else {
+                materialize$.next(cs ?? null);
+              }
               this._notebookDocChanged$.next();
             }
             this.emitExecutionViewChanges(e.execution_view_changeset);

--- a/packages/runtimed/tests/sync-engine.test.ts
+++ b/packages/runtimed/tests/sync-engine.test.ts
@@ -647,6 +647,49 @@ describe("SyncEngine", () => {
       engine.stop();
     });
 
+    it("emits initial file-load changesets immediately while load is streaming", () => {
+      const streamingInteractiveStatus: SessionStatus = {
+        notebook_doc: "interactive",
+        runtime_state: "syncing",
+        initial_load: { phase: "streaming" },
+      };
+      const changesets: CellChangeset[] = [
+        {
+          changed: [],
+          added: ["c1", "c2", "c3"],
+          removed: [],
+          order_changed: true,
+        },
+        {
+          changed: [],
+          added: ["c4", "c5", "c6"],
+          removed: [],
+          order_changed: true,
+        },
+      ];
+      let callCount = 0;
+      (handle.receive_frame as ReturnType<typeof vi.fn>).mockImplementation(() => {
+        callCount++;
+        if (callCount === 1) {
+          return [sessionStatusEvent(streamingInteractiveStatus)];
+        }
+        return [syncAppliedEvent({ changed: true, changeset: changesets[callCount - 2] })];
+      });
+
+      const engine = createEngine();
+      engine.start();
+
+      const emissions: (CellChangeset | null)[] = [];
+      engine.cellChanges$.subscribe((cs) => emissions.push(cs));
+
+      transport.deliver(Array.from([0x07, 1]));
+      transport.deliver(Array.from([0x00, 2]));
+      transport.deliver(Array.from([0x00, 3]));
+
+      expect(emissions).toEqual(changesets);
+      engine.stop();
+    });
+
     it("emits separately for frames in different coalescing windows", () => {
       let callCount = 0;
       (handle.receive_frame as ReturnType<typeof vi.fn>).mockImplementation(() => {


### PR DESCRIPTION
## Summary

- Remove fixed 25 ms no-reply waits from the Rust OG `.ipynb` streaming load path while still applying already-buffered client replies.
- Publish a deterministic first structural slice during deferred initial materialization so small notebooks can paint cells before the full projection.
- Add focused Rust and frontend tests plus a handoff with the benchmark evidence and external review notes.

## Benchmark

Real browser/Vite/dev-daemon harness:

```bash
RUNTIMED_VITE_PORT=7366 node .context/og-ipynb-load/benchmark-og-ipynb-load.mjs --iterations=5 --base-url=http://localhost:7366
```

Result file:

```text
.context/og-ipynb-load/results/2026-06-26T22-37-06-873Z.json
```

Observed medians:

| Notebook | First cell | All cells | Synced | Runtime ready | Materialize | Timeline |
|---|---:|---:|---:|---:|---:|---|
| `MatplotlibExample.ipynb` | 873 ms | 1131 ms | 1782 ms | 1204 ms | 302 ms | stable `0 -> 3 -> 13` |
| `_PreProcess.ipynb` | 801 ms | 969 ms | 1066 ms | 676 ms | 6 ms | stable `0 -> 3 -> 11` |

## Verification

```bash
node_modules/.bin/vp test run apps/notebook/src/lib/__tests__/frame-pipeline.test.ts apps/notebook/src/lib/__tests__/notebook-sync-store-bridge.test.ts packages/runtimed/tests/sync-engine.test.ts
cargo test -p runtimed file_backed_initial_load -- --nocapture
cargo test -p runtimed --test tokio_mutex_lint
cargo test -p notebook-protocol
node_modules/.bin/vp check
cargo xtask lint --fix
git diff --check
```

Also ran `cargo test -p runtimed`; all 1015 unit tests passed, then `test_settings_json_mirror_write_does_not_feedback_loop` failed once in the integration suite and passed on immediate targeted rerun:

```bash
cargo test -p runtimed --test integration test_settings_json_mirror_write_does_not_feedback_loop -- --nocapture
```
