### PR TITLE
feat(widgets): support ipympl matplotlib canvas

### DIFF
--- a/apps/notebook-cloud/viewer/widget-runtime.tsx
+++ b/apps/notebook-cloud/viewer/widget-runtime.tsx
@@ -12,6 +12,7 @@ export {
   type ProjectCloudWidgetCommsOptions,
 } from "./widget-comm-projection";
 import "@/components/widgets/controls";
+import "@/components/widgets/matplotlib";
 
 export const CLOUD_WIDGET_RENDERERS = {
   [WIDGET_VIEW_MIME]: CloudWidgetViewRenderer,

--- a/apps/notebook/src/main.tsx
+++ b/apps/notebook/src/main.tsx
@@ -15,6 +15,7 @@ import { createNotebookHost, isTauriRuntime } from "./host/create-notebook-host"
 // Register built-in widget components
 import "@/components/widgets/controls";
 import "@/components/widgets/ipycanvas";
+import "@/components/widgets/matplotlib";
 
 // Preload output components used in main bundle (via MediaRouter).
 // Note: markdown-output, html-output, svg-output are isolated-only

--- a/crates/runt-mcp/src/structured.rs
+++ b/crates/runt-mcp/src/structured.rs
@@ -16,6 +16,9 @@ use serde_json::{json, Value};
 use std::collections::HashMap;
 
 const WIDGET_VIEW_MIME: &str = "application/vnd.jupyter.widget-view+json";
+const JUPYTER_MATPLOTLIB_MODULE: &str = "jupyter-matplotlib";
+const MPL_CANVAS_MODEL: &str = "MPLCanvasModel";
+const MPL_CANVAS_CHECKPOINT_KEY: &str = "_nteract_mpl_canvas";
 
 /// Check if a MIME type is a visualization spec (Plotly, Vega-Lite, Vega).
 fn is_viz_mime(mime: &str) -> bool {
@@ -256,6 +259,23 @@ fn manifest_output_to_structured(
             // Synthesize a safe widget summary for MCP App/static clients that
             // cannot attach to the live comm bridge. Do not include raw widget
             // state here; Password widgets can store plaintext values.
+            if let (Some(data_map), Some(comms)) =
+                (manifest.get("data").and_then(|v| v.as_object()), comms)
+            {
+                if let Some(checkpoint) =
+                    matplotlib_checkpoint_from_data_map(data_map, comms, blob_base_url)
+                {
+                    if let Some(image_url) = checkpoint.image_url {
+                        data.insert("image/png".to_string(), Value::String(image_url));
+                    }
+                    if !data.contains_key("text/llm+plain") {
+                        data.insert(
+                            "text/llm+plain".to_string(),
+                            Value::String(checkpoint.summary),
+                        );
+                    }
+                }
+            }
             if !data.contains_key("text/llm+plain") {
                 if let (Some(data_map), Some(comms)) =
                     (manifest.get("data").and_then(|v| v.as_object()), comms)
@@ -311,6 +331,44 @@ fn widget_summary_from_data_map(
     Some(output_resolver::format_widget_summary(
         &model_id, entry, comms,
     ))
+}
+
+struct MatplotlibCheckpoint {
+    image_url: Option<String>,
+    summary: String,
+}
+
+fn matplotlib_checkpoint_from_data_map(
+    data_map: &serde_json::Map<String, Value>,
+    comms: &HashMap<String, CommDocEntry>,
+    blob_base_url: &Option<String>,
+) -> Option<MatplotlibCheckpoint> {
+    let model_id = widget_model_id_from_content_ref(data_map.get(WIDGET_VIEW_MIME)?)?;
+    let entry = comms.get(&model_id)?;
+    if entry.model_module != JUPYTER_MATPLOTLIB_MODULE || entry.model_name != MPL_CANVAS_MODEL {
+        return None;
+    }
+
+    let checkpoint = entry.state.get(MPL_CANVAS_CHECKPOINT_KEY)?;
+    let frame = checkpoint.get("frame")?;
+    let hash = frame.get("blob").and_then(|v| v.as_str())?;
+    let image_url = blob_base_url
+        .as_ref()
+        .map(|base| format!("{}/blob/{}", base, hash));
+    let size = checkpoint
+        .get("size")
+        .and_then(|v| v.as_array())
+        .and_then(|items| {
+            let width = items.first()?.as_u64()?;
+            let height = items.get(1)?.as_u64()?;
+            Some(format!(" {width}x{height}"))
+        })
+        .unwrap_or_default();
+
+    Some(MatplotlibCheckpoint {
+        image_url,
+        summary: format!("[matplotlib widget checkpoint: image/png{size}]"),
+    })
 }
 
 /// Resolve a text ContentRef to a JSON value (inline text or blob URL).
@@ -673,6 +731,53 @@ mod tests {
 
         assert!(summary.contains("IntSlider"));
         assert!(summary.contains("7"));
+    }
+
+    #[test]
+    fn structured_matplotlib_widget_view_emits_checkpoint_image_url() {
+        let manifest = json!({
+            "output_type": "display_data",
+            "data": {
+                "application/vnd.jupyter.widget-view+json": inline_ref(r#"{"model_id":"mpl-1"}"#),
+            },
+        });
+        let mut comms = HashMap::new();
+        comms.insert(
+            "mpl-1".to_string(),
+            CommDocEntry {
+                target_name: "jupyter.widget".to_string(),
+                model_module: "jupyter-matplotlib".to_string(),
+                model_name: "MPLCanvasModel".to_string(),
+                state: json!({
+                    "_nteract_mpl_canvas": {
+                        "version": 1,
+                        "frame": {
+                            "blob": "pnghash",
+                            "size": 100,
+                            "media_type": "image/png"
+                        },
+                        "image_mode": "full",
+                        "size": [320, 240],
+                        "frame_seq": 1
+                    }
+                }),
+                outputs: Vec::new(),
+                seq: 0,
+                capture_msg_id: String::new(),
+            },
+        );
+        let blob_base = Some("http://localhost:9999".to_string());
+
+        let result = manifest_output_to_structured(&manifest, &blob_base, Some(&comms));
+
+        assert_eq!(
+            result["data"]["image/png"],
+            "http://localhost:9999/blob/pnghash"
+        );
+        assert_eq!(
+            result["data"]["text/llm+plain"],
+            "[matplotlib widget checkpoint: image/png 320x240]"
+        );
     }
 
     #[test]

--- a/crates/runtimed-outputs/src/output_resolver.rs
+++ b/crates/runtimed-outputs/src/output_resolver.rs
@@ -1493,6 +1493,21 @@ pub fn format_widget_summary(
     let short_id = &comm_id[..6.min(comm_id.len())];
 
     match name {
+        "MPLCanvas" if entry.model_module == "jupyter-matplotlib" => {
+            let suffix = entry
+                .state
+                .get("_nteract_mpl_canvas")
+                .and_then(|checkpoint| checkpoint.get("size"))
+                .and_then(|v| v.as_array())
+                .and_then(|items| {
+                    let width = items.first()?.as_u64()?;
+                    let height = items.get(1)?.as_u64()?;
+                    Some(format!(" {width}x{height}"))
+                })
+                .unwrap_or_default();
+            format!("Matplotlib widget {short_id}\u{2026}: image/png checkpoint{suffix}")
+        }
+
         // Numeric sliders — value + range
         "IntSlider" | "FloatSlider" | "FloatLogSlider" => {
             let val = state_display(&entry.state, "value");
@@ -1910,6 +1925,35 @@ mod tests {
             panic!("should be object");
         };
         assert!(has_synthesizable_mime(map));
+    }
+
+    #[test]
+    fn widget_summary_describes_matplotlib_checkpoint() {
+        let entry = CommDocEntry {
+            target_name: "jupyter.widget".to_string(),
+            model_module: "jupyter-matplotlib".to_string(),
+            model_name: "MPLCanvasModel".to_string(),
+            state: json!({
+                "_nteract_mpl_canvas": {
+                    "version": 1,
+                    "frame": {
+                        "blob": "pnghash",
+                        "size": 100,
+                        "media_type": "image/png"
+                    },
+                    "size": [320, 240]
+                }
+            }),
+            outputs: Vec::new(),
+            seq: 0,
+            capture_msg_id: String::new(),
+        };
+        let comms = HashMap::from([("mpl-1".to_string(), entry.clone())]);
+
+        assert_eq!(
+            format_widget_summary("mpl-1", &entry, &comms),
+            "Matplotlib widget mpl-1…: image/png checkpoint 320x240"
+        );
     }
 
     #[test]

--- a/crates/runtimed/src/jupyter_kernel.rs
+++ b/crates/runtimed/src/jupyter_kernel.rs
@@ -2377,9 +2377,8 @@ impl KernelConnection for JupyterKernel {
                                             }
                                         }
                                     }
-                                    if method != Some("update") {
-                                        if is_mpl_canvas {
-                                            match crate::matplotlib_widget::parse_mpl_canvas_custom_message(&data) {
+                                    if method != Some("update") && is_mpl_canvas {
+                                        match crate::matplotlib_widget::parse_mpl_canvas_custom_message(&data) {
                                                 Some(crate::matplotlib_widget::MplCanvasCustomMessage::ImageMode(mode)) => {
                                                     mpl_canvas_image_modes
                                                         .insert(msg.comm_id.0.clone(), mode);
@@ -2392,13 +2391,13 @@ impl KernelConnection for JupyterKernel {
                                                         );
                                                     }
                                                 }
-                                                Some(crate::matplotlib_widget::MplCanvasCustomMessage::Binary) => {
+                                            Some(crate::matplotlib_widget::MplCanvasCustomMessage::Binary) => {
                                                     let mode = mpl_canvas_image_modes
                                                         .get(&msg.comm_id.0)
                                                         .map(String::as_str)
                                                         .unwrap_or("full");
-                                                    if mode == "full" {
-                                                        if let (Some(first_buffer), Some(ref tx)) =
+                                                if mode == "full" {
+                                                    if let (Some(first_buffer), Some(tx)) =
                                                             (buffers.first(), comm_coalesce_tx.as_ref())
                                                         {
                                                             let _ = tx.send(
@@ -2412,12 +2411,11 @@ impl KernelConnection for JupyterKernel {
                                                             );
                                                         }
                                                     }
-                                                    mpl_binary_broadcast_mode =
-                                                        Some(mode.to_string());
-                                                }
-                                                Some(crate::matplotlib_widget::MplCanvasCustomMessage::Other)
-                                                | None => {}
+                                                mpl_binary_broadcast_mode =
+                                                    Some(mode.to_string());
                                             }
+                                            Some(crate::matplotlib_widget::MplCanvasCustomMessage::Other)
+                                            | None => {}
                                         }
                                     }
 

--- a/crates/runtimed/src/jupyter_kernel.rs
+++ b/crates/runtimed/src/jupyter_kernel.rs
@@ -55,6 +55,47 @@ const KERNEL_ENV_SECRET_BLOCKLIST: &[&str] = &[
     "NOTEBOOK_CLOUD_PUBLISH_BEARER_TOKEN",
 ];
 
+enum CommCoalesceMessage {
+    StateDelta {
+        comm_id: String,
+        delta: serde_json::Value,
+    },
+    MplCanvasFrame {
+        comm_id: String,
+        png: Vec<u8>,
+        size: Option<(u64, u64)>,
+    },
+}
+
+struct PendingMplCanvasFrame {
+    png: Vec<u8>,
+    size: Option<(u64, u64)>,
+}
+
+fn mpl_size_from_state(state: &serde_json::Value) -> Option<(u64, u64)> {
+    let size = state.get("_size").and_then(|v| v.as_array())?;
+    let width = size.first()?.as_u64()?;
+    let height = size.get(1)?.as_u64()?;
+    Some((width, height))
+}
+
+fn content_with_mpl_canvas_image_mode(
+    mut content: serde_json::Value,
+    mode: &str,
+) -> serde_json::Value {
+    if let Some(inner) = content
+        .get_mut("data")
+        .and_then(|data| data.get_mut("content"))
+        .and_then(|inner| inner.as_object_mut())
+    {
+        inner.insert(
+            "_nteract_image_mode".to_string(),
+            serde_json::Value::String(mode.to_string()),
+        );
+    }
+    content
+}
+
 fn is_tolerated_kernel_info_reply_parse_error(error: &jupyter_zmq_client::RuntimeError) -> bool {
     match error {
         jupyter_zmq_client::RuntimeError::ParseError { msg_type, source } => {
@@ -428,7 +469,7 @@ pub struct JupyterKernel {
     /// Handle to the heartbeat monitor task (detects unresponsive kernel).
     heartbeat_task: Option<JoinHandle<()>>,
     /// Channel for coalesced comm state writes (IOPub -> coalesce task).
-    comm_coalesce_tx: Option<mpsc::UnboundedSender<(String, serde_json::Value)>>,
+    comm_coalesce_tx: Option<mpsc::UnboundedSender<CommCoalesceMessage>>,
     /// Handle to the coalescing task for comm state CRDT writes.
     comm_coalesce_task: Option<JoinHandle<()>>,
     /// Execution IDs sent through this kernel.
@@ -1383,7 +1424,7 @@ impl KernelConnection for JupyterKernel {
             crate::output_committer::start_output_committer(output_commit_context);
 
         // Create coalescing channel early so the IOPub task can capture the sender.
-        let (coalesce_tx, coalesce_rx) = mpsc::unbounded_channel::<(String, serde_json::Value)>();
+        let (coalesce_tx, coalesce_rx) = mpsc::unbounded_channel::<CommCoalesceMessage>();
         let comm_coalesce_tx_for_iopub = Some(coalesce_tx.clone());
 
         let iopub_panic_cmd_tx = lifecycle_cmd_tx.clone();
@@ -1405,6 +1446,12 @@ impl KernelConnection for JupyterKernel {
                 // and CommClose arms so we can route without a CRDT read on the
                 // hot path.
                 let mut comm_targets: std::collections::HashMap<String, String> =
+                    std::collections::HashMap::new();
+                let mut comm_models: std::collections::HashMap<String, (String, String)> =
+                    std::collections::HashMap::new();
+                let mut mpl_canvas_image_modes: std::collections::HashMap<String, String> =
+                    std::collections::HashMap::new();
+                let mut mpl_canvas_sizes: std::collections::HashMap<String, (u64, u64)> =
                     std::collections::HashMap::new();
 
                 let comm_coalesce_tx = comm_coalesce_tx_for_iopub;
@@ -2126,6 +2173,24 @@ impl KernelConnection for JupyterKernel {
                                             .get("_model_name")
                                             .and_then(|v| v.as_str())
                                             .unwrap_or("");
+                                        comm_models.insert(
+                                            open.comm_id.0.clone(),
+                                            (model_module.to_string(), model_name.to_string()),
+                                        );
+                                        if crate::matplotlib_widget::is_mpl_canvas_model(
+                                            model_module,
+                                            model_name,
+                                        ) {
+                                            if let Some(size) =
+                                                mpl_size_from_state(&state_with_blobs)
+                                            {
+                                                mpl_canvas_sizes
+                                                    .insert(open.comm_id.0.clone(), size);
+                                            }
+                                            mpl_canvas_image_modes
+                                                .entry(open.comm_id.0.clone())
+                                                .or_insert_with(|| "full".to_string());
+                                        }
                                         let seq = iopub_comm_seq.fetch_add(1, Ordering::Relaxed);
                                         let lock_wait = lock_start.elapsed();
                                         if lock_wait > std::time::Duration::from_millis(5) {
@@ -2234,8 +2299,33 @@ impl KernelConnection for JupyterKernel {
                                         "[comm_msg] comm_id={} method={:?}",
                                         msg.comm_id.0, method
                                     );
+                                    let is_mpl_canvas = comm_models
+                                        .get(&msg.comm_id.0)
+                                        .is_some_and(|(model_module, model_name)| {
+                                            crate::matplotlib_widget::is_mpl_canvas_model(
+                                                model_module,
+                                                model_name,
+                                            )
+                                        });
+                                    let mut mpl_binary_broadcast_mode: Option<String> = None;
                                     if method == Some("update") {
                                         if let Some(state_delta) = data.get("state") {
+                                            if is_mpl_canvas {
+                                                if let Some(mode) = state_delta
+                                                    .get("_image_mode")
+                                                    .and_then(|v| v.as_str())
+                                                {
+                                                    mpl_canvas_image_modes.insert(
+                                                        msg.comm_id.0.clone(),
+                                                        mode.to_string(),
+                                                    );
+                                                }
+                                                if let Some(size) = mpl_size_from_state(state_delta)
+                                                {
+                                                    mpl_canvas_sizes
+                                                        .insert(msg.comm_id.0.clone(), size);
+                                                }
+                                            }
                                             if let Some(new_msg_id) =
                                                 state_delta.get("msg_id").and_then(|v| v.as_str())
                                             {
@@ -2280,8 +2370,53 @@ impl KernelConnection for JupyterKernel {
                                                 state_delta.clone()
                                             };
                                             if let Some(ref tx) = comm_coalesce_tx {
-                                                let _ = tx
-                                                    .send((msg.comm_id.0.clone(), coalesce_delta));
+                                                let _ = tx.send(CommCoalesceMessage::StateDelta {
+                                                    comm_id: msg.comm_id.0.clone(),
+                                                    delta: coalesce_delta,
+                                                });
+                                            }
+                                        }
+                                    }
+                                    if method != Some("update") {
+                                        if is_mpl_canvas {
+                                            match crate::matplotlib_widget::parse_mpl_canvas_custom_message(&data) {
+                                                Some(crate::matplotlib_widget::MplCanvasCustomMessage::ImageMode(mode)) => {
+                                                    mpl_canvas_image_modes
+                                                        .insert(msg.comm_id.0.clone(), mode);
+                                                }
+                                                Some(crate::matplotlib_widget::MplCanvasCustomMessage::Resize(size)) => {
+                                                    if let Some(size) = size {
+                                                        mpl_canvas_sizes.insert(
+                                                            msg.comm_id.0.clone(),
+                                                            size,
+                                                        );
+                                                    }
+                                                }
+                                                Some(crate::matplotlib_widget::MplCanvasCustomMessage::Binary) => {
+                                                    let mode = mpl_canvas_image_modes
+                                                        .get(&msg.comm_id.0)
+                                                        .map(String::as_str)
+                                                        .unwrap_or("full");
+                                                    if mode == "full" {
+                                                        if let (Some(first_buffer), Some(ref tx)) =
+                                                            (buffers.first(), comm_coalesce_tx.as_ref())
+                                                        {
+                                                            let _ = tx.send(
+                                                                CommCoalesceMessage::MplCanvasFrame {
+                                                                    comm_id: msg.comm_id.0.clone(),
+                                                                    png: first_buffer.clone(),
+                                                                    size: mpl_canvas_sizes
+                                                                        .get(&msg.comm_id.0)
+                                                                        .copied(),
+                                                                },
+                                                            );
+                                                        }
+                                                    }
+                                                    mpl_binary_broadcast_mode =
+                                                        Some(mode.to_string());
+                                                }
+                                                Some(crate::matplotlib_widget::MplCanvasCustomMessage::Other)
+                                                | None => {}
                                             }
                                         }
                                     }
@@ -2295,9 +2430,19 @@ impl KernelConnection for JupyterKernel {
                                     }
 
                                     if method != Some("update") {
+                                        let broadcast_content = if let Some(mode) =
+                                            mpl_binary_broadcast_mode.as_ref()
+                                        {
+                                            content_with_mpl_canvas_image_mode(
+                                                content.clone(),
+                                                mode,
+                                            )
+                                        } else {
+                                            content.clone()
+                                        };
                                         let _ = broadcast_tx.send(NotebookBroadcast::Comm {
                                             msg_type: message.header.msg_type.clone(),
-                                            content: content.clone(),
+                                            content: broadcast_content,
                                             buffers: buffers.clone(),
                                         });
                                     }
@@ -2323,6 +2468,9 @@ impl KernelConnection for JupyterKernel {
                                         .remove(&close.comm_id.0)
                                         .map(|t| crate::dx_blob_comm::is_dx_target(&t))
                                         .unwrap_or(false);
+                                    comm_models.remove(&close.comm_id.0);
+                                    mpl_canvas_image_modes.remove(&close.comm_id.0);
+                                    mpl_canvas_sizes.remove(&close.comm_id.0);
                                     if was_dx_target {
                                         continue;
                                     }
@@ -2809,6 +2957,8 @@ impl KernelConnection for JupyterKernel {
             "comm-coalesce",
             async move {
                 let mut pending: HashMap<String, serde_json::Value> = HashMap::new();
+                let mut pending_mpl_frames: HashMap<String, PendingMplCanvasFrame> = HashMap::new();
+                let mut mpl_frame_seq: HashMap<String, u64> = HashMap::new();
                 let mut timer = tokio::time::interval(std::time::Duration::from_millis(16));
                 timer.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
 
@@ -2816,7 +2966,7 @@ impl KernelConnection for JupyterKernel {
                     tokio::select! {
                         msg = coalesce_rx.recv() => {
                             match msg {
-                                Some((comm_id, delta)) => {
+                                Some(CommCoalesceMessage::StateDelta { comm_id, delta }) => {
                                     let entry = pending.entry(comm_id)
                                         .or_insert_with(|| serde_json::json!({}));
                                     if let (Some(existing), Some(new)) =
@@ -2827,16 +2977,69 @@ impl KernelConnection for JupyterKernel {
                                         }
                                     }
                                 }
+                                Some(CommCoalesceMessage::MplCanvasFrame { comm_id, png, size }) => {
+                                    pending_mpl_frames.insert(
+                                        comm_id,
+                                        PendingMplCanvasFrame { png, size },
+                                    );
+                                }
                                 None => break,
                             }
                         }
                         _ = timer.tick() => {
-                            if pending.is_empty() {
+                            if pending.is_empty() && pending_mpl_frames.is_empty() {
                                 continue;
                             }
                             let mut batch = std::mem::take(&mut pending);
                             for delta in batch.values_mut() {
                                 *delta = blob_store_large_state_values(delta, &coalesce_blob_store).await;
+                            }
+                            let frame_batch = std::mem::take(&mut pending_mpl_frames);
+                            for (comm_id, frame) in frame_batch {
+                                match coalesce_blob_store.put(&frame.png, "image/png").await {
+                                    Ok(hash) => {
+                                        let seq = mpl_frame_seq
+                                            .entry(comm_id.clone())
+                                            .and_modify(|seq| *seq = seq.saturating_add(1))
+                                            .or_insert(1);
+                                        let size = frame
+                                            .size
+                                            .map(|(width, height)| serde_json::json!([width, height]))
+                                            .unwrap_or(serde_json::Value::Null);
+                                        let mut checkpoint = serde_json::Map::new();
+                                        checkpoint.insert(
+                                            crate::matplotlib_widget::MPL_CANVAS_CHECKPOINT_KEY
+                                                .to_string(),
+                                            serde_json::json!({
+                                                "version": 1,
+                                                "frame": {
+                                                    "blob": hash,
+                                                    "size": frame.png.len(),
+                                                    "media_type": "image/png",
+                                                },
+                                                "image_mode": "full",
+                                                "size": size,
+                                                "frame_seq": *seq,
+                                            }),
+                                        );
+                                        let entry = batch
+                                            .entry(comm_id)
+                                            .or_insert_with(|| serde_json::json!({}));
+                                        if let (Some(existing), Some(new)) =
+                                            (entry.as_object_mut(), Some(&checkpoint))
+                                        {
+                                            for (k, v) in new {
+                                                existing.insert(k.clone(), v.clone());
+                                            }
+                                        }
+                                    }
+                                    Err(e) => {
+                                        warn!(
+                                            "[comms-doc] Failed to blob-store matplotlib canvas checkpoint: {}",
+                                            e
+                                        );
+                                    }
+                                }
                             }
                             if let Err(e) = coalesce_comms.with_doc(|cd| {
                                 let heads = cd.get_heads();

--- a/crates/runtimed/src/lib.rs
+++ b/crates/runtimed/src/lib.rs
@@ -42,6 +42,7 @@ pub(crate) mod kernel_ports;
 pub mod kernel_state;
 pub mod launcher_cache;
 pub mod markdown_assets;
+pub(crate) mod matplotlib_widget;
 pub(crate) mod notebook_registry;
 pub mod notebook_sync_server;
 pub(crate) mod output_blob_publisher;

--- a/crates/runtimed/src/matplotlib_widget.rs
+++ b/crates/runtimed/src/matplotlib_widget.rs
@@ -1,0 +1,141 @@
+//! Helpers for the `jupyter-matplotlib` / ipympl custom widget protocol.
+
+use serde_json::Value;
+
+pub(crate) const JUPYTER_MATPLOTLIB_MODULE: &str = "jupyter-matplotlib";
+pub(crate) const MPL_CANVAS_MODEL: &str = "MPLCanvasModel";
+pub(crate) const MPL_CANVAS_CHECKPOINT_KEY: &str = "_nteract_mpl_canvas";
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) enum MplCanvasCustomMessage {
+    Binary,
+    ImageMode(String),
+    Resize(Option<(u64, u64)>),
+    Other,
+}
+
+pub(crate) fn is_mpl_canvas_model(model_module: &str, model_name: &str) -> bool {
+    model_module == JUPYTER_MATPLOTLIB_MODULE && model_name == MPL_CANVAS_MODEL
+}
+
+pub(crate) fn parse_mpl_canvas_custom_message(comm_data: &Value) -> Option<MplCanvasCustomMessage> {
+    let content = custom_content(comm_data)?;
+    let message = if let Some(raw) = content.get("data").and_then(Value::as_str) {
+        serde_json::from_str::<Value>(raw).ok()?
+    } else {
+        content.clone()
+    };
+
+    let message_type = message.get("type").and_then(Value::as_str)?;
+    match message_type {
+        "binary" => Some(MplCanvasCustomMessage::Binary),
+        "image_mode" => message
+            .get("mode")
+            .and_then(Value::as_str)
+            .map(|mode| MplCanvasCustomMessage::ImageMode(mode.to_string())),
+        "resize" => Some(MplCanvasCustomMessage::Resize(parse_resize_size(&message))),
+        _ => Some(MplCanvasCustomMessage::Other),
+    }
+}
+
+fn custom_content(comm_data: &Value) -> Option<&Value> {
+    let method = comm_data.get("method").and_then(Value::as_str);
+    if method.is_some() && method != Some("custom") {
+        return None;
+    }
+
+    if let Some(content) = comm_data.get("content") {
+        return Some(content);
+    }
+
+    if comm_data.get("type").is_some() || comm_data.get("data").is_some() {
+        return Some(comm_data);
+    }
+
+    None
+}
+
+fn parse_resize_size(message: &Value) -> Option<(u64, u64)> {
+    if let Some(size) = message.get("size").and_then(Value::as_array) {
+        let width = size.first()?.as_u64()?;
+        let height = size.get(1)?.as_u64()?;
+        return Some((width, height));
+    }
+
+    let width = message.get("width").and_then(Value::as_u64)?;
+    let height = message.get("height").and_then(Value::as_u64)?;
+    Some((width, height))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    #[test]
+    fn parser_extracts_image_mode_from_widget_custom_payload() {
+        let data = json!({
+            "method": "custom",
+            "content": {
+                "data": "{\"type\":\"image_mode\",\"mode\":\"diff\"}"
+            }
+        });
+
+        assert_eq!(
+            parse_mpl_canvas_custom_message(&data),
+            Some(MplCanvasCustomMessage::ImageMode("diff".to_string()))
+        );
+    }
+
+    #[test]
+    fn parser_detects_binary_frame_payload() {
+        let data = json!({
+            "method": "custom",
+            "content": {
+                "data": "{\"type\":\"binary\"}"
+            }
+        });
+
+        assert_eq!(
+            parse_mpl_canvas_custom_message(&data),
+            Some(MplCanvasCustomMessage::Binary)
+        );
+    }
+
+    #[test]
+    fn parser_extracts_resize_size() {
+        let data = json!({
+            "method": "custom",
+            "content": {
+                "data": "{\"type\":\"resize\",\"size\":[640,480]}"
+            }
+        });
+
+        assert_eq!(
+            parse_mpl_canvas_custom_message(&data),
+            Some(MplCanvasCustomMessage::Resize(Some((640, 480))))
+        );
+    }
+
+    #[test]
+    fn parser_ignores_non_custom_updates() {
+        let data = json!({
+            "method": "update",
+            "state": {"value": 1}
+        });
+
+        assert_eq!(parse_mpl_canvas_custom_message(&data), None);
+    }
+
+    #[test]
+    fn parser_ignores_malformed_payloads() {
+        let data = json!({
+            "method": "custom",
+            "content": {
+                "data": "{not json"
+            }
+        });
+
+        assert_eq!(parse_mpl_canvas_custom_message(&data), None);
+    }
+}

--- a/crates/runtimed/src/notebook_sync_server/peer_runtime_agent.rs
+++ b/crates/runtimed/src/notebook_sync_server/peer_runtime_agent.rs
@@ -577,6 +577,9 @@ fn validate_runtime_agent_broadcast(broadcast: &NotebookBroadcast) -> anyhow::Re
         NotebookBroadcast::Comm {
             msg_type, content, ..
         } => {
+            // Runtime-agent broadcasts arrive over the authenticated runtime-agent
+            // attachment. This guard validates the payload shape before peer fanout;
+            // comm ownership remains part of that trusted attachment boundary.
             anyhow::ensure!(
                 msg_type == "comm_msg" || msg_type == "comm_close",
                 "runtime agent broadcast used unsupported comm msg_type {msg_type:?}"
@@ -640,7 +643,7 @@ mod tests {
     }
 
     #[test]
-    fn rejects_non_comm_runtime_agent_broadcast_payload() {
+    fn rejects_runtime_agent_broadcast_with_non_comm_msg_type() {
         let (tx, _rx) = tokio::sync::broadcast::channel(4);
         let broadcast = NotebookBroadcast::Comm {
             msg_type: "status".to_string(),

--- a/crates/runtimed/src/notebook_sync_server/peer_runtime_agent.rs
+++ b/crates/runtimed/src/notebook_sync_server/peer_runtime_agent.rs
@@ -2,7 +2,7 @@ use std::path::PathBuf;
 use std::sync::Arc;
 
 use notebook_protocol::connection::{send_typed_frame, FramedReader, NotebookFrameType};
-use notebook_protocol::protocol::RuntimeAgentResponse;
+use notebook_protocol::protocol::{NotebookBroadcast, RuntimeAgentResponse};
 use tracing::{debug, info, warn};
 
 use crate::async_outcome::{flatten_joined_result, JoinedResult};
@@ -383,6 +383,25 @@ pub async fn handle_runtime_agent_sync_connection<R, W>(
                             }
                         }
                     }
+                    NotebookFrameType::Broadcast => {
+                        match forward_runtime_agent_broadcast(
+                            &room.broadcasts.kernel_broadcast_tx,
+                            &typed_frame.payload,
+                        ) {
+                            Ok(0) => {
+                                debug!(
+                                    "[notebook-sync] Runtime agent broadcast had no subscribers"
+                                );
+                            }
+                            Ok(_) => {}
+                            Err(e) => {
+                                warn!(
+                                    "[notebook-sync] Dropping malformed runtime agent broadcast: {}",
+                                    e
+                                );
+                            }
+                        }
+                    }
                     _ => {
                         debug!("[notebook-sync] Agent sent unexpected frame type: {:?}", typed_frame.frame_type);
                     }
@@ -539,4 +558,62 @@ pub async fn handle_runtime_agent_sync_connection<R, W>(
         "[notebook-sync] Runtime agent sync connection closed: {}",
         runtime_agent_id
     );
+}
+
+fn forward_runtime_agent_broadcast(
+    tx: &tokio::sync::broadcast::Sender<NotebookBroadcast>,
+    payload: &[u8],
+) -> anyhow::Result<usize> {
+    let broadcast = serde_json::from_slice::<NotebookBroadcast>(payload)?;
+    match tx.send(broadcast) {
+        Ok(receiver_count) => Ok(receiver_count),
+        Err(_) => Ok(0),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn forwards_runtime_agent_broadcast_to_subscriber() {
+        let (tx, mut rx) = tokio::sync::broadcast::channel(4);
+        let broadcast = NotebookBroadcast::Comm {
+            msg_type: "comm_msg".to_string(),
+            content: serde_json::json!({
+                "comm_id": "comm-1",
+                "data": {
+                    "method": "custom",
+                    "content": { "type": "draw" }
+                }
+            }),
+            buffers: vec![vec![1, 2, 3]],
+        };
+        let payload = serde_json::to_vec(&broadcast).expect("serialize broadcast");
+
+        let receiver_count =
+            forward_runtime_agent_broadcast(&tx, &payload).expect("forward broadcast");
+
+        assert_eq!(receiver_count, 1);
+        match rx.recv().await.expect("receive broadcast") {
+            NotebookBroadcast::Comm {
+                msg_type,
+                content,
+                buffers,
+            } => {
+                assert_eq!(msg_type, "comm_msg");
+                assert_eq!(content["comm_id"], "comm-1");
+                assert_eq!(content["data"]["content"]["type"], "draw");
+                assert_eq!(buffers, vec![vec![1, 2, 3]]);
+            }
+        }
+    }
+
+    #[test]
+    fn rejects_malformed_runtime_agent_broadcast() {
+        let (tx, _rx) = tokio::sync::broadcast::channel(4);
+
+        forward_runtime_agent_broadcast(&tx, b"{not-json")
+            .expect_err("malformed broadcast must fail");
+    }
 }

--- a/crates/runtimed/src/notebook_sync_server/peer_runtime_agent.rs
+++ b/crates/runtimed/src/notebook_sync_server/peer_runtime_agent.rs
@@ -565,9 +565,31 @@ fn forward_runtime_agent_broadcast(
     payload: &[u8],
 ) -> anyhow::Result<usize> {
     let broadcast = serde_json::from_slice::<NotebookBroadcast>(payload)?;
+    validate_runtime_agent_broadcast(&broadcast)?;
     match tx.send(broadcast) {
         Ok(receiver_count) => Ok(receiver_count),
         Err(_) => Ok(0),
+    }
+}
+
+fn validate_runtime_agent_broadcast(broadcast: &NotebookBroadcast) -> anyhow::Result<()> {
+    match broadcast {
+        NotebookBroadcast::Comm {
+            msg_type, content, ..
+        } => {
+            anyhow::ensure!(
+                msg_type == "comm_msg" || msg_type == "comm_close",
+                "runtime agent broadcast used unsupported comm msg_type {msg_type:?}"
+            );
+            anyhow::ensure!(
+                content
+                    .get("comm_id")
+                    .and_then(|value| value.as_str())
+                    .is_some(),
+                "runtime agent broadcast comm payload missing comm_id"
+            );
+            Ok(())
+        }
     }
 }
 
@@ -615,5 +637,39 @@ mod tests {
 
         forward_runtime_agent_broadcast(&tx, b"{not-json")
             .expect_err("malformed broadcast must fail");
+    }
+
+    #[test]
+    fn rejects_non_comm_runtime_agent_broadcast_payload() {
+        let (tx, _rx) = tokio::sync::broadcast::channel(4);
+        let broadcast = NotebookBroadcast::Comm {
+            msg_type: "status".to_string(),
+            content: serde_json::json!({
+                "comm_id": "comm-1",
+            }),
+            buffers: Vec::new(),
+        };
+        let payload = serde_json::to_vec(&broadcast).expect("serialize broadcast");
+
+        forward_runtime_agent_broadcast(&tx, &payload)
+            .expect_err("non-comm message type must fail");
+    }
+
+    #[test]
+    fn rejects_runtime_agent_broadcast_without_comm_id() {
+        let (tx, _rx) = tokio::sync::broadcast::channel(4);
+        let broadcast = NotebookBroadcast::Comm {
+            msg_type: "comm_msg".to_string(),
+            content: serde_json::json!({
+                "data": {
+                    "method": "custom",
+                    "content": { "type": "draw" }
+                }
+            }),
+            buffers: Vec::new(),
+        };
+        let payload = serde_json::to_vec(&broadcast).expect("serialize broadcast");
+
+        forward_runtime_agent_broadcast(&tx, &payload).expect_err("missing comm_id must fail");
     }
 }

--- a/crates/runtimed/src/runtime_agent.rs
+++ b/crates/runtimed/src/runtime_agent.rs
@@ -38,7 +38,7 @@ use notebook_doc::presence::PresenceState;
 use notebook_protocol::connection::{
     FrameSink, FrameSource, FrameTransport, NotebookFrameType, PackageManager, UdsFrameTransport,
 };
-use notebook_protocol::protocol::{RuntimeAgentRequest, RuntimeAgentResponse};
+use notebook_protocol::protocol::{NotebookBroadcast, RuntimeAgentRequest, RuntimeAgentResponse};
 use runtime_doc::{CommsDoc, CommsDocHandle, ExecutionState, RuntimeLifecycle, RuntimeStateDoc};
 use runtime_doc::{KernelActivity, RuntimeStateHandle};
 use tokio::sync::{broadcast, mpsc, RwLock};
@@ -140,7 +140,7 @@ struct RuntimeAgentContext {
     comms: CommsDocHandle,
     blob_store: Arc<BlobStore>,
     output_blob_publisher: OutputBlobPublisher,
-    broadcast_tx: broadcast::Sender<notebook_protocol::protocol::NotebookBroadcast>,
+    broadcast_tx: broadcast::Sender<NotebookBroadcast>,
     presence: Arc<RwLock<PresenceState>>,
     presence_tx: broadcast::Sender<(String, Vec<u8>)>,
     runtime_agent_id: String,
@@ -450,8 +450,7 @@ where
     // -- 3. Create local infrastructure -------------------------------------
 
     let blob_store = Arc::new(BlobStore::new(blob_root.clone()));
-    let (broadcast_tx, _broadcast_rx) =
-        broadcast::channel::<notebook_protocol::protocol::NotebookBroadcast>(16);
+    let (broadcast_tx, mut broadcast_rx) = broadcast::channel::<NotebookBroadcast>(16);
     let presence = Arc::new(RwLock::new(PresenceState::new()));
     let (presence_tx, _presence_rx) = broadcast::channel::<(String, Vec<u8>)>(16);
 
@@ -1256,6 +1255,77 @@ where
                 }
                 if let Err(e) = handle_work_command(command, &mut kernel).await {
                     warn!("[runtime-agent] Error handling work command: {}", e);
+                }
+            }
+
+            // Forward ephemeral kernel comm events to the coordinator. Durable
+            // widget state still syncs through CommsDoc; this path is for live
+            // custom messages such as ipympl draw/binary events.
+            result = broadcast_rx.recv() => {
+                match result {
+                    Ok(broadcast) => {
+                        let json = match serde_json::to_vec(&broadcast) {
+                            Ok(json) => json,
+                            Err(e) => {
+                                warn!(
+                                    "[runtime-agent] Failed to serialize kernel broadcast: {}",
+                                    e
+                                );
+                                continue;
+                            }
+                        };
+
+                        if let Err(e) = frame_sink.send_frame(
+                            NotebookFrameType::Broadcast,
+                            &json,
+                        ).await {
+                            if !transport.clean_eof_is_recoverable() {
+                                warn!(
+                                    "[runtime-agent] Closing after Broadcast send failure: {}",
+                                    e
+                                );
+                                break;
+                            }
+                            warn!(
+                                "[runtime-agent] Broadcast send failed: {} — reconnecting \
+                                 (kernel stays running)",
+                                e
+                            );
+                            drop(frame_source);
+                            match reconnect_after_writer_error(
+                                &transport,
+                                &mut last_recoverable_reconnect,
+                            ).await {
+                                Ok((new_source, new_sink)) => {
+                                    frame_source = new_source;
+                                    frame_sink = new_sink;
+                                    coordinator_sync_state = automerge::sync::State::new();
+                                    comms_sync_state = automerge::sync::State::new();
+                                    let _ = state_kick_tx.send(());
+                                    let _ = comms_kick_tx.send(());
+                                    info!("[runtime-agent] Reconnected after Broadcast send failure");
+                                    continue;
+                                }
+                                Err(reconnect_err) => {
+                                    error!(
+                                        "[runtime-agent] Reconnect failed after retries: {}",
+                                        reconnect_err
+                                    );
+                                    break;
+                                }
+                            }
+                        }
+                    }
+                    Err(broadcast::error::RecvError::Lagged(n)) => {
+                        warn!(
+                            "[runtime-agent] Dropped {} kernel broadcasts before forwarding",
+                            n
+                        );
+                    }
+                    Err(broadcast::error::RecvError::Closed) => {
+                        warn!("[runtime-agent] Kernel broadcast channel closed");
+                        break;
+                    }
                 }
             }
 
@@ -2343,6 +2413,9 @@ fn diff_comm_state(
             {
                 let mut delta = serde_json::Map::new();
                 for (key, after_val) in after_obj {
+                    if key == crate::matplotlib_widget::MPL_CANVAS_CHECKPOINT_KEY {
+                        continue;
+                    }
                     match before_obj.get(key) {
                         Some(before_val) if before_val == after_val => {}
                         _ => {
@@ -2680,6 +2753,40 @@ mod tests {
                 Duration::from_secs(1),
             ),
             Some(Duration::from_millis(800))
+        );
+    }
+
+    #[test]
+    fn diff_comm_state_filters_matplotlib_checkpoint_key() {
+        let mut active = HashSet::new();
+        active.insert("mpl-comm".to_string());
+
+        let before = HashMap::from([(
+            "mpl-comm".to_string(),
+            serde_json::json!({
+                "value": 1,
+            }),
+        )]);
+        let after = HashMap::from([(
+            "mpl-comm".to_string(),
+            serde_json::json!({
+                "value": 2,
+                "_nteract_mpl_canvas": {
+                    "version": 1,
+                    "frame": {
+                        "blob": "hash",
+                        "size": 10,
+                        "media_type": "image/png"
+                    }
+                }
+            }),
+        )]);
+
+        let updates = diff_comm_state(&before, &after, &active);
+
+        assert_eq!(
+            updates,
+            vec![("mpl-comm".to_string(), serde_json::json!({"value": 2}))]
         );
     }
 

--- a/crates/runtimed/src/runtime_agent.rs
+++ b/crates/runtimed/src/runtime_agent.rs
@@ -2420,6 +2420,8 @@ fn diff_comm_state(
             {
                 let mut delta = serde_json::Map::new();
                 for (key, after_val) in after_obj {
+                    // `_nteract_mpl_canvas` is daemon-authored checkpoint state for
+                    // late viewers and agents. It is never a kernel traitlet update.
                     if key == crate::matplotlib_widget::MPL_CANVAS_CHECKPOINT_KEY {
                         continue;
                     }

--- a/crates/runtimed/src/runtime_agent.rs
+++ b/crates/runtimed/src/runtime_agent.rs
@@ -67,6 +67,12 @@ use echo_suppression::EchoSuppressor;
 /// is gated out of the floor by `clean_eof_is_recoverable() == false`).
 const RECOVERABLE_RECONNECT_FLOOR: std::time::Duration = std::time::Duration::from_secs(1);
 
+/// Runtime-agent-local buffer for live kernel broadcasts. These carry
+/// ephemeral custom widget events such as ipympl PNG frames. Match the
+/// coordinator room broadcast capacity so the runtime-agent bridge can absorb
+/// the same burst size before reporting lag.
+const RUNTIME_AGENT_KERNEL_BROADCAST_CAPACITY: usize = 256;
+
 /// How long to sleep before a reconnect to enforce [`RECOVERABLE_RECONNECT_FLOOR`].
 ///
 /// Pure so the flap-floor policy is unit-testable away from the agent's
@@ -450,7 +456,8 @@ where
     // -- 3. Create local infrastructure -------------------------------------
 
     let blob_store = Arc::new(BlobStore::new(blob_root.clone()));
-    let (broadcast_tx, mut broadcast_rx) = broadcast::channel::<NotebookBroadcast>(16);
+    let (broadcast_tx, mut broadcast_rx) =
+        broadcast::channel::<NotebookBroadcast>(RUNTIME_AGENT_KERNEL_BROADCAST_CAPACITY);
     let presence = Arc::new(RwLock::new(PresenceState::new()));
     let (presence_tx, _presence_rx) = broadcast::channel::<(String, Vec<u8>)>(16);
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -74,6 +74,7 @@ dev = [
     "pytest>=8.0",
     "pyzmq>=26.0",
     "matplotlib>=3.8",
+    "ipympl>=0.9",
     "quak>=0.3.4",
     "plotly>=6.0",
     "nbformat>=5.0",

--- a/src/components/widgets/__tests__/matplotlib-widget.test.tsx
+++ b/src/components/widgets/__tests__/matplotlib-widget.test.tsx
@@ -1,0 +1,10 @@
+import { describe, expect, it } from "vitest";
+import "@/components/widgets/matplotlib";
+import { hasWidgetComponent } from "../widget-registry";
+
+describe("matplotlib widget registration", () => {
+  it("registers ipympl canvas and toolbar models", () => {
+    expect(hasWidgetComponent("MPLCanvasModel")).toBe(true);
+    expect(hasWidgetComponent("ToolbarModel")).toBe(true);
+  });
+});

--- a/src/components/widgets/matplotlib/index.ts
+++ b/src/components/widgets/matplotlib/index.ts
@@ -1,0 +1,7 @@
+import { registerWidget } from "../widget-registry";
+import { MatplotlibCanvasWidget, MatplotlibToolbarWidget } from "./matplotlib-widget";
+
+registerWidget("MPLCanvasModel", MatplotlibCanvasWidget);
+registerWidget("ToolbarModel", MatplotlibToolbarWidget);
+
+export { MatplotlibCanvasWidget, MatplotlibToolbarWidget } from "./matplotlib-widget";

--- a/src/components/widgets/matplotlib/matplotlib-widget.tsx
+++ b/src/components/widgets/matplotlib/matplotlib-widget.tsx
@@ -1,0 +1,678 @@
+import { useCallback, useEffect, useMemo, useRef, useState, type CSSProperties } from "react";
+import { buildMediaSrc } from "../buffer-utils";
+import type { WidgetComponentProps } from "../widget-registry";
+import { parseModelRef } from "../widget-store";
+import {
+  useWidgetModel,
+  useWidgetModelValue,
+  useWidgetStoreRequired,
+} from "../widget-store-context";
+
+type CanvasSize = [number, number];
+
+interface MplMessage {
+  type?: string;
+  [key: string]: unknown;
+}
+
+interface Rubberband {
+  x: number;
+  y: number;
+  width: number;
+  height: number;
+}
+
+const DEFAULT_SIZE: CanvasSize = [0, 0];
+const RESIZE_HANDLE_SIZE = 20;
+const CHECKPOINT_KEY = "_nteract_mpl_canvas";
+
+function asSize(value: unknown): CanvasSize {
+  if (!Array.isArray(value) || value.length < 2) return DEFAULT_SIZE;
+  const width = Number(value[0]);
+  const height = Number(value[1]);
+  return [
+    Number.isFinite(width) && width > 0 ? width : 0,
+    Number.isFinite(height) && height > 0 ? height : 0,
+  ];
+}
+
+function parseCustomMessage(content: Record<string, unknown>): MplMessage | null {
+  const raw = content.data;
+  const annotatedMode =
+    typeof content._nteract_image_mode === "string" ? content._nteract_image_mode : undefined;
+  if (typeof raw === "string") {
+    try {
+      return { ...(JSON.parse(raw) as MplMessage), _nteract_image_mode: annotatedMode };
+    } catch {
+      return null;
+    }
+  }
+  if (typeof content.type === "string") {
+    return { ...content, _nteract_image_mode: annotatedMode } as MplMessage;
+  }
+  return null;
+}
+
+function dataViewToArrayBuffer(view: DataView): ArrayBuffer {
+  const copy = new Uint8Array(view.byteLength);
+  copy.set(new Uint8Array(view.buffer, view.byteOffset, view.byteLength));
+  return copy.buffer;
+}
+
+function bufferToBlobUrl(buffer: DataView | ArrayBuffer): string {
+  const bytes = buffer instanceof DataView ? new Uint8Array(dataViewToArrayBuffer(buffer)) : buffer;
+  return URL.createObjectURL(new Blob([bytes], { type: "image/png" }));
+}
+
+function getCheckpointFrame(value: unknown): string | ArrayBuffer | Uint8Array | DataView | null {
+  if (!value || typeof value !== "object") return null;
+  const frame = (value as Record<string, unknown>).frame;
+  if (
+    typeof frame === "string" ||
+    frame instanceof ArrayBuffer ||
+    frame instanceof Uint8Array ||
+    frame instanceof DataView
+  ) {
+    return frame;
+  }
+  return null;
+}
+
+function simpleKeys(event: React.MouseEvent | React.WheelEvent | React.KeyboardEvent) {
+  return {
+    altKey: event.altKey,
+    ctrlKey: event.ctrlKey,
+    metaKey: event.metaKey,
+    shiftKey: event.shiftKey,
+  };
+}
+
+function modifiers(event: React.MouseEvent | React.WheelEvent) {
+  const result: string[] = [];
+  if (event.altKey) result.push("alt");
+  if (event.ctrlKey) result.push("control");
+  if (event.metaKey) result.push("meta");
+  if (event.shiftKey) result.push("shift");
+  return result;
+}
+
+function toolbarButtonLabel(name: string, text: string) {
+  switch (name) {
+    case "home":
+      return "Home";
+    case "back":
+      return "Back";
+    case "forward":
+      return "Forward";
+    case "pan":
+      return "Pan";
+    case "zoom":
+      return "Zoom";
+    case "download":
+    case "save_figure":
+      return "Save";
+    default:
+      return text || name;
+  }
+}
+
+export function MatplotlibCanvasWidget({ modelId, className }: WidgetComponentProps) {
+  const { store, sendCustom } = useWidgetStoreRequired();
+  const sizeValue = useWidgetModelValue<unknown>(modelId, "_size");
+  const figureLabel = useWidgetModelValue<string>(modelId, "_figure_label") ?? "Figure";
+  const message = useWidgetModelValue<string>(modelId, "_message") ?? "";
+  const cursor = useWidgetModelValue<string>(modelId, "_cursor") ?? "pointer";
+  const imageMode = useWidgetModelValue<string>(modelId, "_image_mode") ?? "full";
+  const headerVisible = useWidgetModelValue<boolean>(modelId, "header_visible") ?? true;
+  const footerVisible = useWidgetModelValue<boolean>(modelId, "footer_visible") ?? true;
+  const toolbarVisible = useWidgetModelValue<string | boolean>(modelId, "toolbar_visible") ?? true;
+  const toolbarPosition = useWidgetModelValue<string>(modelId, "toolbar_position") ?? "left";
+  const resizable = useWidgetModelValue<boolean>(modelId, "resizable") ?? true;
+  const captureScroll = useWidgetModelValue<boolean>(modelId, "capture_scroll") ?? false;
+  const panZoomThrottle = useWidgetModelValue<number>(modelId, "pan_zoom_throttle") ?? 33;
+  const toolbarRef = useWidgetModelValue<string>(modelId, "toolbar");
+  const checkpoint = useWidgetModelValue<unknown>(modelId, CHECKPOINT_KEY);
+
+  const toolbarId = typeof toolbarRef === "string" ? parseModelRef(toolbarRef) : null;
+  const [renderSize, setRenderSize] = useState<CanvasSize>(() => asSize(sizeValue));
+  const [rubberband, setRubberband] = useState<Rubberband | null>(null);
+  const [isHovering, setIsHovering] = useState(false);
+  const [isResizing, setIsResizing] = useState(false);
+
+  const ratioRef = useRef(typeof window === "undefined" ? 1 : window.devicePixelRatio || 1);
+  const offscreenCanvasRef = useRef<HTMLCanvasElement | null>(null);
+  const offscreenContextRef = useRef<CanvasRenderingContext2D | null>(null);
+  const baseCanvasRef = useRef<HTMLCanvasElement>(null);
+  const overlayCanvasRef = useRef<HTMLCanvasElement>(null);
+  const canvasDivRef = useRef<HTMLDivElement>(null);
+  const waitingForImageRef = useRef(false);
+  const throttleRef = useRef(0);
+  const imageUrlRef = useRef<string | null>(null);
+
+  useEffect(() => {
+    const offscreen = document.createElement("canvas");
+    offscreenCanvasRef.current = offscreen;
+    offscreenContextRef.current = offscreen.getContext("2d");
+    return () => {
+      if (imageUrlRef.current) {
+        URL.revokeObjectURL(imageUrlRef.current);
+      }
+    };
+  }, []);
+
+  useEffect(() => {
+    setRenderSize(asSize(sizeValue));
+  }, [sizeValue]);
+
+  const resizeCanvases = useCallback((nextSize: CanvasSize) => {
+    const ratio = ratioRef.current;
+    const [width, height] = nextSize;
+    const cssWidth = Math.max(0, Math.round(width));
+    const cssHeight = Math.max(0, Math.round(height));
+    const pixelWidth = Math.max(0, Math.round(width * ratio));
+    const pixelHeight = Math.max(0, Math.round(height * ratio));
+    const offscreen = offscreenCanvasRef.current;
+    const base = baseCanvasRef.current;
+    const overlay = overlayCanvasRef.current;
+    const div = canvasDivRef.current;
+
+    if (offscreen) {
+      if (offscreen.width !== pixelWidth) {
+        offscreen.width = pixelWidth;
+      }
+      if (offscreen.height !== pixelHeight) {
+        offscreen.height = pixelHeight;
+      }
+      offscreenContextRef.current = offscreen.getContext("2d");
+    }
+    if (base) {
+      if (base.width !== pixelWidth) {
+        base.width = pixelWidth;
+      }
+      if (base.height !== pixelHeight) {
+        base.height = pixelHeight;
+      }
+      base.style.width = `${cssWidth}px`;
+      base.style.height = `${cssHeight}px`;
+    }
+    if (overlay) {
+      if (overlay.width !== cssWidth) {
+        overlay.width = cssWidth;
+      }
+      if (overlay.height !== cssHeight) {
+        overlay.height = cssHeight;
+      }
+      overlay.style.width = `${cssWidth}px`;
+      overlay.style.height = `${cssHeight}px`;
+    }
+    if (div) {
+      div.style.width = `${cssWidth}px`;
+      div.style.height = `${cssHeight}px`;
+    }
+  }, []);
+
+  const drawOverlay = useCallback(() => {
+    const overlay = overlayCanvasRef.current;
+    if (!overlay) return;
+    const ctx = overlay.getContext("2d");
+    if (!ctx) return;
+    ctx.clearRect(0, 0, overlay.width, overlay.height);
+
+    if (rubberband && rubberband.width !== 0 && rubberband.height !== 0) {
+      ctx.save();
+      ctx.strokeStyle = "gray";
+      ctx.lineWidth = 1;
+      ctx.shadowColor = "black";
+      ctx.shadowBlur = 2;
+      ctx.shadowOffsetX = 1;
+      ctx.shadowOffsetY = 1;
+      ctx.strokeRect(rubberband.x, rubberband.y, rubberband.width, rubberband.height);
+      ctx.restore();
+    }
+
+    if (resizable && overlay.width > 0 && overlay.height > 0) {
+      ctx.save();
+      const gradient = ctx.createLinearGradient(
+        overlay.width - RESIZE_HANDLE_SIZE,
+        overlay.height - RESIZE_HANDLE_SIZE,
+        overlay.width,
+        overlay.height,
+      );
+      gradient.addColorStop(0, "white");
+      gradient.addColorStop(1, "black");
+      ctx.fillStyle = gradient;
+      ctx.strokeStyle = "gray";
+      ctx.globalAlpha = 0.3;
+      ctx.beginPath();
+      ctx.moveTo(overlay.width, overlay.height);
+      ctx.lineTo(overlay.width, overlay.height - RESIZE_HANDLE_SIZE);
+      ctx.lineTo(overlay.width - RESIZE_HANDLE_SIZE, overlay.height);
+      ctx.closePath();
+      ctx.fill();
+      ctx.stroke();
+      ctx.restore();
+    }
+  }, [resizable, rubberband]);
+
+  const drawBase = useCallback((stretch = false) => {
+    const base = baseCanvasRef.current;
+    const offscreen = offscreenCanvasRef.current;
+    if (!base || !offscreen || base.width === 0 || base.height === 0) return;
+    const ctx = base.getContext("2d");
+    if (!ctx) return;
+    ctx.clearRect(0, 0, base.width, base.height);
+    if (stretch) {
+      ctx.drawImage(offscreen, 0, 0, base.width, base.height);
+    } else {
+      ctx.drawImage(offscreen, 0, 0);
+    }
+  }, []);
+
+  const updateCanvas = useCallback(
+    (stretch = false) => {
+      drawBase(stretch);
+      drawOverlay();
+    },
+    [drawBase, drawOverlay],
+  );
+
+  useEffect(() => {
+    resizeCanvases(renderSize);
+    updateCanvas();
+  }, [renderSize, resizeCanvases, updateCanvas]);
+
+  useEffect(() => {
+    drawOverlay();
+  }, [drawOverlay]);
+
+  const loadImageUrl = useCallback(
+    (url: string, mode: string, stretch = false) => {
+      const image = new Image();
+      image.onload = () => {
+        const offscreen = offscreenCanvasRef.current;
+        if (!offscreen) return;
+        if (offscreen.width === 0 || offscreen.height === 0) {
+          const ratio = ratioRef.current;
+          const nextSize: CanvasSize = [image.width / ratio, image.height / ratio];
+          resizeCanvases(nextSize);
+          setRenderSize(nextSize);
+        }
+        const ctx = offscreenContextRef.current ?? offscreen.getContext("2d");
+        if (!ctx) return;
+        offscreenContextRef.current = ctx;
+        if (mode === "full") {
+          ctx.clearRect(0, 0, offscreen.width, offscreen.height);
+        }
+        ctx.drawImage(image, 0, 0);
+        waitingForImageRef.current = false;
+        updateCanvas(stretch);
+      };
+      image.src = url;
+    },
+    [updateCanvas],
+  );
+
+  useEffect(() => {
+    const frame = getCheckpointFrame(checkpoint);
+    if (!frame) return;
+    const src = buildMediaSrc(frame, "image", "png");
+    if (src) {
+      loadImageUrl(src, "full");
+    }
+  }, [checkpoint, loadImageUrl]);
+
+  const sendMessage = useCallback(
+    (type: string, payload: Record<string, unknown> = {}) => {
+      sendCustom(modelId, { ...payload, type });
+    },
+    [modelId, sendCustom],
+  );
+
+  useEffect(() => {
+    const ratio = ratioRef.current;
+    if (ratio !== 1) {
+      sendMessage("set_dpi_ratio", { dpi_ratio: ratio });
+      sendMessage("set_device_pixel_ratio", { device_pixel_ratio: ratio });
+    }
+    sendMessage("refresh");
+    sendMessage("send_image_mode");
+    sendMessage("initialized");
+  }, [sendMessage]);
+
+  const sendDrawMessage = useCallback(() => {
+    if (!waitingForImageRef.current) {
+      waitingForImageRef.current = true;
+      sendMessage("draw");
+    }
+  }, [sendMessage]);
+
+  useEffect(() => {
+    return store.subscribeToCustomMessage(modelId, (content, buffers) => {
+      const msg = parseCustomMessage(content);
+      if (!msg?.type) return;
+
+      if (msg.type === "binary") {
+        const first = buffers?.[0];
+        if (!first) return;
+        if (imageUrlRef.current) {
+          URL.revokeObjectURL(imageUrlRef.current);
+        }
+        imageUrlRef.current = bufferToBlobUrl(first);
+        const mode =
+          typeof msg._nteract_image_mode === "string" ? msg._nteract_image_mode : imageMode;
+        loadImageUrl(imageUrlRef.current, mode);
+        return;
+      }
+
+      if (msg.type === "draw") {
+        sendDrawMessage();
+        return;
+      }
+
+      if (msg.type === "resize") {
+        const size = asSize(msg.size);
+        if (size[0] > 0 && size[1] > 0) {
+          setRenderSize(size);
+        }
+        sendMessage("refresh");
+        return;
+      }
+
+      if (msg.type === "rubberband") {
+        const ratio = ratioRef.current;
+        const offscreen = offscreenCanvasRef.current;
+        const x0 = Number(msg.x0 ?? -1) / ratio;
+        const y0 = offscreen ? (offscreen.height - Number(msg.y0 ?? -1)) / ratio : -1;
+        const x1 = Number(msg.x1 ?? -1) / ratio;
+        const y1 = offscreen ? (offscreen.height - Number(msg.y1 ?? -1)) / ratio : -1;
+        if (x0 < 0 || y0 < 0 || x1 < 0 || y1 < 0) {
+          setRubberband(null);
+        } else {
+          setRubberband({
+            x: Math.min(Math.floor(x0) + 0.5, Math.floor(x1) + 0.5),
+            y: Math.min(Math.floor(y0) + 0.5, Math.floor(y1) + 0.5),
+            width: Math.abs(Math.floor(x1) - Math.floor(x0)),
+            height: Math.abs(Math.floor(y1) - Math.floor(y0)),
+          });
+        }
+        return;
+      }
+
+      if (msg.type === "save") {
+        const first = buffers?.[0];
+        const format = typeof msg.format === "string" ? msg.format : "png";
+        const href = first ? bufferToBlobUrl(first) : baseCanvasRef.current?.toDataURL();
+        if (!href) return;
+        const link = document.createElement("a");
+        link.href = href;
+        link.download = `${figureLabel}.${format}`;
+        document.body.appendChild(link);
+        link.click();
+        document.body.removeChild(link);
+        if (first) URL.revokeObjectURL(href);
+      }
+    });
+  }, [figureLabel, imageMode, loadImageUrl, modelId, sendDrawMessage, sendMessage, store]);
+
+  const requestResize = useCallback(
+    (width: number, height: number) => {
+      if (width <= 5 || height <= 5) return;
+      setRenderSize([width, height]);
+      sendMessage("resize", { width, height });
+    },
+    [sendMessage],
+  );
+
+  const canvasPoint = useCallback((event: React.MouseEvent<HTMLCanvasElement>) => {
+    const canvas = overlayCanvasRef.current;
+    if (!canvas) return { x: 0, y: 0 };
+    const rect = canvas.getBoundingClientRect();
+    return {
+      x: (canvas.width * (event.clientX - rect.left)) / rect.width,
+      y: (canvas.height * (event.clientY - rect.top)) / rect.height,
+    };
+  }, []);
+
+  const sendMouseEvent = useCallback(
+    (name: string, event: React.MouseEvent<HTMLCanvasElement> | React.WheelEvent<HTMLCanvasElement>) => {
+      const now = performance.now();
+      if ((name === "motion_notify" || name === "scroll") && now - throttleRef.current < panZoomThrottle) {
+        return;
+      }
+      throttleRef.current = now;
+
+      const point = canvasPoint(event as React.MouseEvent<HTMLCanvasElement>);
+      const ratio = ratioRef.current;
+      const step =
+        name === "scroll" ? ((event as React.WheelEvent<HTMLCanvasElement>).deltaY < 0 ? 1 : -1) : undefined;
+      sendMessage(name, {
+        x: point.x * ratio,
+        y: point.y * ratio,
+        button: "button" in event ? event.button : 0,
+        buttons: "buttons" in event ? event.buttons : 0,
+        step,
+        modifiers: modifiers(event),
+        guiEvent: simpleKeys(event),
+      });
+    },
+    [canvasPoint, panZoomThrottle, sendMessage],
+  );
+
+  useEffect(() => {
+    if (!isResizing) return;
+    const onMove = (event: MouseEvent) => {
+      const canvas = overlayCanvasRef.current;
+      if (!canvas) return;
+      const rect = canvas.getBoundingClientRect();
+      const width = Math.max(6, event.clientX - rect.left);
+      const height = Math.max(6, event.clientY - rect.top);
+      requestResize(width, height);
+    };
+    const onUp = () => setIsResizing(false);
+    window.addEventListener("mousemove", onMove);
+    window.addEventListener("mouseup", onUp);
+    return () => {
+      window.removeEventListener("mousemove", onMove);
+      window.removeEventListener("mouseup", onUp);
+    };
+  }, [isResizing, requestResize]);
+
+  const toolbarVisibleNow =
+    toolbarVisible === true ||
+    toolbarVisible === "visible" ||
+    (toolbarVisible === "fade-in-fade-out" && isHovering);
+
+  return (
+    <div
+      className={className}
+      data-widget-id={modelId}
+      data-widget-type="MPLCanvas"
+      onMouseEnter={() => setIsHovering(true)}
+      onMouseLeave={() => setIsHovering(false)}
+      style={{ display: "inline-block", maxWidth: "100%" }}
+    >
+      <div
+        style={{
+          display: "inline-block",
+          border: "1px solid hsl(var(--border))",
+          background: "hsl(var(--background))",
+          maxWidth: "100%",
+        }}
+      >
+        {headerVisible && (
+          <div style={{ textAlign: "center", fontSize: 12, padding: "2px 6px" }}>
+            {figureLabel}
+          </div>
+        )}
+        <div style={{ position: "relative", display: "inline-block", maxWidth: "100%" }}>
+          <div
+            ref={canvasDivRef}
+            tabIndex={0}
+            onKeyDown={(event) => {
+              event.preventDefault();
+              event.stopPropagation();
+              let key = "";
+              if (event.ctrlKey && event.key !== "Control") key += "ctrl+";
+              else if (event.altKey && event.key !== "Alt") key += "alt+";
+              else if (event.shiftKey && event.key !== "Shift") key += "shift+";
+              key += `k${event.key}`;
+              sendMessage("key_press", { key, guiEvent: simpleKeys(event) });
+            }}
+            onKeyUp={(event) => {
+              event.preventDefault();
+              event.stopPropagation();
+              sendMessage("key_release", { key: `k${event.key}`, guiEvent: simpleKeys(event) });
+            }}
+            style={{ position: "relative", outline: "none" }}
+          >
+            <canvas
+              ref={baseCanvasRef}
+              style={{ display: "block", left: 0, position: "absolute", top: 0, zIndex: 0 }}
+            />
+            <canvas
+              ref={overlayCanvasRef}
+              onContextMenu={(event) => event.preventDefault()}
+              onDoubleClick={(event) => sendMouseEvent("dblclick", event)}
+              onMouseDown={(event) => {
+                const point = canvasPoint(event);
+                const overlay = overlayCanvasRef.current;
+                if (
+                  overlay &&
+                  resizable &&
+                  point.x >= overlay.width - RESIZE_HANDLE_SIZE &&
+                  point.y >= overlay.height - RESIZE_HANDLE_SIZE
+                ) {
+                  setIsResizing(true);
+                  return;
+                }
+                canvasDivRef.current?.focus();
+                sendMouseEvent("button_press", event);
+              }}
+              onMouseUp={(event) => sendMouseEvent("button_release", event)}
+              onMouseMove={(event) => sendMouseEvent("motion_notify", event)}
+              onMouseEnter={(event) => sendMouseEvent("figure_enter", event)}
+              onMouseLeave={(event) => sendMouseEvent("figure_leave", event)}
+              onWheel={(event) => {
+                sendMouseEvent("scroll", event);
+                if (captureScroll) event.preventDefault();
+              }}
+              style={{
+                cursor,
+                display: "block",
+                left: 0,
+                position: "absolute",
+                top: 0,
+                zIndex: 1,
+              }}
+            />
+          </div>
+          {toolbarId && toolbarVisibleNow && (
+            <MatplotlibToolbar
+              modelId={toolbarId}
+              position={toolbarPosition}
+              overlay
+            />
+          )}
+        </div>
+        {footerVisible && (
+          <div style={{ fontSize: 12, minHeight: 18, padding: "2px 6px" }}>{message}</div>
+        )}
+      </div>
+    </div>
+  );
+}
+
+function MatplotlibToolbar({
+  modelId,
+  position = "left",
+  overlay = false,
+}: {
+  modelId: string;
+  position?: string;
+  overlay?: boolean;
+}) {
+  const { sendCustom, sendUpdate } = useWidgetStoreRequired();
+  const toolitems = useWidgetModelValue<unknown[]>(modelId, "toolitems") ?? [];
+  const currentAction = useWidgetModelValue<string>(modelId, "_current_action") ?? "";
+  const buttonStyle = useWidgetModelValue<string>(modelId, "button_style") ?? "";
+
+  const isVertical = position === "left" || position === "right";
+  const style = useMemo<CSSProperties>(() => {
+    const base: CSSProperties = {
+      display: "flex",
+      flexDirection: isVertical ? "column" : "row",
+      gap: 2,
+      padding: 3,
+      background: "color-mix(in srgb, hsl(var(--background)) 88%, transparent)",
+      border: "1px solid hsl(var(--border))",
+    };
+    if (!overlay) return base;
+    return {
+      ...base,
+      position: "absolute",
+      zIndex: 2,
+      ...(position === "right" ? { right: 3 } : { left: 3 }),
+      ...(position === "bottom" ? { bottom: 3 } : { top: 3 }),
+    };
+  }, [isVertical, overlay, position]);
+
+  return (
+    <div data-widget-id={modelId} data-widget-type="Toolbar" style={style}>
+      {toolitems.map((item, index) => {
+        if (!Array.isArray(item)) return null;
+        const [text, tooltip, image, method] = item;
+        const name = typeof method === "string" ? method : "";
+        if (!name) {
+          return <span key={index} style={{ width: isVertical ? 1 : 8, height: isVertical ? 8 : 1 }} />;
+        }
+        const active = currentAction === name;
+        const label = toolbarButtonLabel(name, String(text ?? image ?? name));
+        return (
+          <button
+            key={`${name}-${index}`}
+            type="button"
+            title={String(tooltip ?? label)}
+            aria-label={label}
+            data-active={active ? "true" : "false"}
+            onClick={() => {
+              if (name === "pan" || name === "zoom") {
+                void sendUpdate(modelId, { _current_action: active ? "" : name });
+              }
+              sendCustom(modelId, { type: "toolbar_button", name });
+            }}
+            style={{
+              alignItems: "center",
+              background: active
+                ? "hsl(var(--accent))"
+                : buttonStyle
+                  ? "hsl(var(--secondary))"
+                  : "hsl(var(--background))",
+              border: "1px solid hsl(var(--border))",
+              borderRadius: 4,
+              color: "hsl(var(--foreground))",
+              display: "inline-flex",
+              fontSize: 11,
+              height: 24,
+              justifyContent: "center",
+              minWidth: 34,
+              padding: "0 6px",
+              whiteSpace: "nowrap",
+            }}
+          >
+            {label}
+          </button>
+        );
+      })}
+    </div>
+  );
+}
+
+export function MatplotlibToolbarWidget({ modelId, className }: WidgetComponentProps) {
+  const model = useWidgetModel(modelId);
+  if (!model) return null;
+  return (
+    <div className={className}>
+      <MatplotlibToolbar modelId={modelId} />
+    </div>
+  );
+}

--- a/src/components/widgets/matplotlib/matplotlib-widget.tsx
+++ b/src/components/widgets/matplotlib/matplotlib-widget.tsx
@@ -148,6 +148,7 @@ export function MatplotlibCanvasWidget({ modelId, className }: WidgetComponentPr
   const waitingForImageRef = useRef(false);
   const throttleRef = useRef(0);
   const imageUrlRef = useRef<string | null>(null);
+  const imageModeRef = useRef(imageMode);
 
   useEffect(() => {
     const offscreen = document.createElement("canvas");
@@ -163,6 +164,13 @@ export function MatplotlibCanvasWidget({ modelId, className }: WidgetComponentPr
   useEffect(() => {
     setRenderSize(asSize(sizeValue));
   }, [sizeValue]);
+
+  useEffect(() => {
+    imageModeRef.current = imageMode;
+    return store.subscribeToKey(modelId, "_image_mode", (value) => {
+      imageModeRef.current = typeof value === "string" ? value : "full";
+    });
+  }, [imageMode, modelId, store]);
 
   const resizeCanvases = useCallback((nextSize: CanvasSize) => {
     const ratio = ratioRef.current;
@@ -359,7 +367,9 @@ export function MatplotlibCanvasWidget({ modelId, className }: WidgetComponentPr
         }
         imageUrlRef.current = bufferToBlobUrl(first);
         const mode =
-          typeof msg._nteract_image_mode === "string" ? msg._nteract_image_mode : imageMode;
+          typeof msg._nteract_image_mode === "string"
+            ? msg._nteract_image_mode
+            : imageModeRef.current;
         loadImageUrl(imageUrlRef.current, mode);
         return;
       }
@@ -412,7 +422,7 @@ export function MatplotlibCanvasWidget({ modelId, className }: WidgetComponentPr
         if (first) URL.revokeObjectURL(href);
       }
     });
-  }, [figureLabel, imageMode, loadImageUrl, modelId, sendDrawMessage, sendMessage, store]);
+  }, [figureLabel, loadImageUrl, modelId, sendDrawMessage, sendMessage, store]);
 
   const requestResize = useCallback(
     (width: number, height: number) => {

--- a/src/components/widgets/matplotlib/matplotlib-widget.tsx
+++ b/src/components/widgets/matplotlib/matplotlib-widget.tsx
@@ -444,9 +444,15 @@ export function MatplotlibCanvasWidget({ modelId, className }: WidgetComponentPr
   }, []);
 
   const sendMouseEvent = useCallback(
-    (name: string, event: React.MouseEvent<HTMLCanvasElement> | React.WheelEvent<HTMLCanvasElement>) => {
+    (
+      name: string,
+      event: React.MouseEvent<HTMLCanvasElement> | React.WheelEvent<HTMLCanvasElement>,
+    ) => {
       const now = performance.now();
-      if ((name === "motion_notify" || name === "scroll") && now - throttleRef.current < panZoomThrottle) {
+      if (
+        (name === "motion_notify" || name === "scroll") &&
+        now - throttleRef.current < panZoomThrottle
+      ) {
         return;
       }
       throttleRef.current = now;
@@ -454,7 +460,11 @@ export function MatplotlibCanvasWidget({ modelId, className }: WidgetComponentPr
       const point = canvasPoint(event as React.MouseEvent<HTMLCanvasElement>);
       const ratio = ratioRef.current;
       const step =
-        name === "scroll" ? ((event as React.WheelEvent<HTMLCanvasElement>).deltaY < 0 ? 1 : -1) : undefined;
+        name === "scroll"
+          ? (event as React.WheelEvent<HTMLCanvasElement>).deltaY < 0
+            ? 1
+            : -1
+          : undefined;
       sendMessage(name, {
         x: point.x * ratio,
         y: point.y * ratio,
@@ -510,9 +520,7 @@ export function MatplotlibCanvasWidget({ modelId, className }: WidgetComponentPr
         }}
       >
         {headerVisible && (
-          <div style={{ textAlign: "center", fontSize: 12, padding: "2px 6px" }}>
-            {figureLabel}
-          </div>
+          <div style={{ textAlign: "center", fontSize: 12, padding: "2px 6px" }}>{figureLabel}</div>
         )}
         <div style={{ position: "relative", display: "inline-block", maxWidth: "100%" }}>
           <div
@@ -577,11 +585,7 @@ export function MatplotlibCanvasWidget({ modelId, className }: WidgetComponentPr
             />
           </div>
           {toolbarId && toolbarVisibleNow && (
-            <MatplotlibToolbar
-              modelId={toolbarId}
-              position={toolbarPosition}
-              overlay
-            />
+            <MatplotlibToolbar modelId={toolbarId} position={toolbarPosition} overlay />
           )}
         </div>
         {footerVisible && (
@@ -633,7 +637,9 @@ function MatplotlibToolbar({
         const [text, tooltip, image, method] = item;
         const name = typeof method === "string" ? method : "";
         if (!name) {
-          return <span key={index} style={{ width: isVertical ? 1 : 8, height: isVertical ? 8 : 1 }} />;
+          return (
+            <span key={index} style={{ width: isVertical ? 1 : 8, height: isVertical ? 8 : 1 }} />
+          );
         }
         const active = currentAction === name;
         const label = toolbarButtonLabel(name, String(text ?? image ?? name));

--- a/src/isolated-renderer/__tests__/widget-bridge-client.test.ts
+++ b/src/isolated-renderer/__tests__/widget-bridge-client.test.ts
@@ -1,0 +1,17 @@
+import { describe, expect, it } from "vitest";
+import { isLocalDaemonBlobUrl } from "../widget-bridge-client";
+
+describe("isLocalDaemonBlobUrl", () => {
+  it("accepts local daemon blob URLs across loopback host spellings", () => {
+    expect(isLocalDaemonBlobUrl("http://127.0.0.1:48469/blob/abc123")).toBe(true);
+    expect(isLocalDaemonBlobUrl("http://localhost:48469/blob/abc123")).toBe(true);
+    expect(isLocalDaemonBlobUrl("http://[::1]:48469/blob/abc123")).toBe(true);
+  });
+
+  it("rejects non-blob and non-local URLs", () => {
+    expect(isLocalDaemonBlobUrl("http://127.0.0.1:48469/not-blob/abc123")).toBe(false);
+    expect(isLocalDaemonBlobUrl("http://127.0.0.1:48469/blob/abc123?download=1")).toBe(false);
+    expect(isLocalDaemonBlobUrl("https://example.com/blob/abc123")).toBe(false);
+    expect(isLocalDaemonBlobUrl("not a url")).toBe(false);
+  });
+});

--- a/src/isolated-renderer/index.tsx
+++ b/src/isolated-renderer/index.tsx
@@ -69,6 +69,7 @@ import { IframeWidgetStoreProvider } from "./widget-provider";
 // Import widget controls to register them in the widget registry
 // This import has side effects that register all built-in widgets
 import "@/components/widgets/controls";
+import "@/components/widgets/matplotlib";
 
 // --- Renderer Plugin Registry ---
 //

--- a/src/isolated-renderer/widget-bridge-client.ts
+++ b/src/isolated-renderer/widget-bridge-client.ts
@@ -28,12 +28,13 @@ import {
 } from "@/components/isolated/rpc-methods";
 import { createWidgetStore, type WidgetStore } from "@/components/widgets/widget-store";
 
-function isLocalDaemonBlobUrl(value: string): boolean {
+export function isLocalDaemonBlobUrl(value: string): boolean {
   try {
     const url = new URL(value);
+    const host = url.hostname.toLowerCase();
     return (
       (url.protocol === "http:" || url.protocol === "https:") &&
-      url.hostname === "127.0.0.1" &&
+      (host === "127.0.0.1" || host === "localhost" || host === "[::1]" || host === "::1") &&
       url.port.length > 0 &&
       url.search === "" &&
       url.hash === "" &&


### PR DESCRIPTION
## Summary

- Add built-in support for `jupyter-matplotlib` `MPLCanvasModel` and `ToolbarModel`.
- Render ipympl binary PNG frames inside the isolated widget iframe and route mouse, key, resize, and toolbar custom messages back to the kernel.
- Persist latest full-frame checkpoints in `CommsDoc` via blob-backed `_nteract_mpl_canvas` state for late viewers and MCP/static agent visibility.
- Expose checkpoint image URLs and concise fallback text in MCP structured content.
- Add `ipympl>=0.9` to repo dev dependencies for local smoke notebooks.

## Verification

- `cargo test -p runtimed matplotlib_widget`
- `cargo test -p runtimed runtime_agent_broadcast`
- `cargo test -p runt-mcp structured_matplotlib_widget_view_emits_checkpoint_image_url`
- `cargo test -p runtimed-outputs widget_summary_describes_matplotlib_checkpoint`
- `cargo fmt --check`
- `cargo xtask clippy`
- `git diff --check`
- Browser smoke against `.context/ipympl-widget-smoke.ipynb`: `%matplotlib widget` rendered the ipympl canvas, Matplotlib slider/button artists, and redraw updates in the live notebook.

## Review

- Ran `uv run pr-review https://github.com/nteract/nteract/pull/3829 --max-turns 120 --out .context/reviews/pr-3829.json`.
- Fixed the medium-severity runtime-agent broadcast findings:
  - Validate runtime-agent broadcasts before fanout so only expected comm messages with `comm_id` are accepted.
  - Increase the runtime-agent-local kernel broadcast buffer to match the coordinator room capacity.
- Ran a second pass with `uv run pr-review https://github.com/nteract/nteract/pull/3829 --max-turns 120 --out .context/reviews/pr-3829-rerun.json`.
- Fixed the actionable frontend race from that pass:
  - Keep the ipympl image-mode fallback in a ref updated by the widget-store key subscription, so unannotated binary frames do not depend on a later React render.
- Ran a final review pass with `uv run pr-review https://github.com/nteract/nteract/pull/3829 --max-turns 120 --out .context/reviews/pr-3829-final.json`.
- Applied the cheap cleanup from that pass:
  - Rename the broadcast-shape test to describe the `msg_type` validation directly.
  - Document that runtime-agent broadcast comm ownership is part of the trusted runtime-agent attachment boundary.
  - Document that `_nteract_mpl_canvas` is daemon-authored checkpoint state and must not be forwarded as a kernel traitlet update.
  - Address clippy's collapsible-if and needless-borrow findings in the ipympl IOPub path.
- Triaged the lower-severity findings:
  - The reported `comm_close` RuntimeStateDoc topology concern is contradicted by the reviewed code path; `RuntimeStateDoc.remove_comm` is already called.
  - Checkpoint `frame.size` is blob byte length; canvas dimensions remain stored separately in checkpoint `size`.
  - Reserved `_nteract_mpl_canvas` state is not sent through the initial kernel-forwarding path reviewed.
  - The empty iframe widget-bridge `dispose()` is consistent with current transport ownership; transport teardown is handled by the iframe runtime.
  - Broader diff-mode rendering tests and toolbar/active-state tests are useful follow-up work with the Elements polish once the pnpm trust-policy block is cleared.

## Known Verification Gap

- `pnpm test:run src/components/widgets/__tests__/matplotlib-widget.test.tsx src/isolated-renderer/__tests__/widget-bridge-client.test.ts` did not reach Vitest because pnpm failed the repo supply-chain policy check before tests:
  - `chokidar@4.0.3`
  - `semver@6.3.1`
  - `undici-types@6.21.0`
- `cargo xtask lint --fix` was run. Rust formatting, raw-control-byte scan, ruff, and ty passed, but the JavaScript/TypeScript `vp check` hit the same pnpm trust-policy failure before running.

## Follow-ups

- Polish the Matplotlib toolbar in Elements with shadcn-style icon controls and clear active state for pan/zoom.
- Consider durable diff-frame composition separately; this PR persists latest full PNG frames only.
