### PR TITLE
perf(cloud): hibernate workstation event sockets

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7632,6 +7632,7 @@ dependencies = [
  "tempfile",
  "thiserror 2.0.18",
  "tokio",
+ "tokio-tungstenite",
  "tokio-util",
  "toml 1.1.2+spec-1.1.0",
  "tracing",

--- a/apps/notebook-cloud/README.md
+++ b/apps/notebook-cloud/README.md
@@ -756,17 +756,17 @@ pnpm --dir apps/notebook-cloud smoke:hosted:workstation-agent
 The workstation agent reads `NTERACT_API_KEY` from the environment and also
 loads `${PREVIEW_RUNT_ENV:-$HOME/preview.runt.run/.env}` when present. It
 registers and heartbeats the current machine through `POST /api/workstations`,
-keeps a server-sent event stream open at
+keeps a hibernatable WebSocket open at
 `GET /api/workstations/:workstationId/events` for attach-job wakeups, and
 spawns `runtimed cloud-runtime-agent` for pending attach jobs. Low-frequency
 `GET /api/workstations/:workstationId/attach-jobs` polling is still the
 recovery path for missed events, older servers, and jobs that predate agent
-startup. The SSE stream also carries idle online presence without burning a
-Worker/D1 request per workstation per heartbeat interval; a per-workstation
-control WebSocket was avoided for the same request-pressure reason. The stream
-does not use SSE `Last-Event-ID` replay; attach jobs are durable D1 rows, so
-reconnect recovery polls the queue rather than replaying transient wakeup
-events. API-key auth is the default
+startup. The event socket carries idle online presence without burning a
+Worker/D1 request per workstation per heartbeat interval, and it uses
+Cloudflare's hibernatable WebSocket path so idle sockets do not keep the
+WorkstationEvents Durable Object active. The socket does not replay events;
+attach jobs are durable D1 rows, so reconnect recovery polls the queue rather
+than replaying transient wakeup events. API-key auth is the default
 (`NOTEBOOK_CLOUD_WORKSTATION_AUTH_KIND=anaconda-key`); set
 `NOTEBOOK_CLOUD_WORKSTATION_AUTH_KIND=oidc` when `NTERACT_API_KEY` carries a
 short-lived OIDC bearer token. Prefer API-key auth for long-lived tmux/systemd
@@ -776,7 +776,7 @@ through argv; `runtimed` removes cloud environment variables again before
 launching the Python kernel. When the hosted service returns a rate-limit or
 maintenance response (`429`/`503`), the runner honors `Retry-After` when
 present and otherwise backs off with a capped exponential cooldown before
-heartbeating, reconnecting the event stream, or polling again. Run this helper
+heartbeating, reconnecting the event socket, or polling again. Run this helper
 inside tmux for preview/manual testing so the workstation agent stays alive
 while the browser attaches
 workstations. The first registered workstation becomes the account default

--- a/apps/notebook-cloud/src/index.ts
+++ b/apps/notebook-cloud/src/index.ts
@@ -1793,7 +1793,10 @@ async function routeWorkstationEvents(
     return json({ error: "D1 binding DB is not configured" }, 503);
   }
   if (!env.WORKSTATION_EVENTS) {
-    return json({ error: "workstation event stream is not configured" }, 503);
+    return json({ error: "workstation event socket is not configured" }, 503);
+  }
+  if (request.headers.get("Upgrade")?.toLowerCase() !== "websocket") {
+    return json({ error: "expected WebSocket upgrade" }, 426);
   }
 
   const identity = await authenticateRequestOrResponse(request, env, {
@@ -1803,7 +1806,7 @@ async function routeWorkstationEvents(
     return identity;
   }
   if (isAnonymousViewer(identity)) {
-    return json({ error: "sign in to stream workstation events" }, 401);
+    return json({ error: "sign in to open workstation events" }, 401);
   }
 
   const ownerPrincipal = await canonicalPrincipalForIdentity(env, identity);
@@ -1813,14 +1816,14 @@ async function routeWorkstationEvents(
   }
 
   const stub = workstationEventsStub(env, ownerPrincipal, workstationId);
-  const response = await stub.fetch(
+  return stub.fetch(
     new Request(
       `https://workstation-events.internal/stream?workstation_id=${encodeURIComponent(
         workstationId,
       )}`,
+      request,
     ),
   );
-  return withCors(new Response(response.body, response));
 }
 
 async function routeWorkstationAttachJobs(
@@ -2323,7 +2326,7 @@ function workstationResponseRow(
     status,
     status_message:
       status === "offline" && options.eventPresence?.connected === false
-        ? "Workstation event stream is not connected."
+        ? "Workstation event socket is not connected."
         : status === "online" && options.eventPresence?.connected === true
           ? workstation.status_message
           : status === "offline" && workstation.status === "online"

--- a/apps/notebook-cloud/src/workstation-events.ts
+++ b/apps/notebook-cloud/src/workstation-events.ts
@@ -128,17 +128,16 @@ export class WorkstationEvents {
         connected_at: connectedAt,
       })
     ) {
-      return Response.json(
-        { error: "workstation event socket failed to initialize" },
-        { status: 500 },
-      );
+      cloudLog("warn", "workstation.events.ready_send_failed", {
+        workstation_id: workstationId,
+        listener_id: listenerId,
+        counter: "workstation_event_ready_send_failures",
+        counter_delta: 1,
+      });
     }
 
     return new Response(null, {
       status: 101,
-      headers: {
-        "Cache-Control": "no-store",
-      },
       webSocket: client,
     } as ResponseInit & { webSocket: CloudflareWebSocket });
   }

--- a/apps/notebook-cloud/src/workstation-events.ts
+++ b/apps/notebook-cloud/src/workstation-events.ts
@@ -1,14 +1,14 @@
-import type { DurableObjectState, Env } from "./cloudflare-types.ts";
+import type { CloudflareWebSocket, DurableObjectState, Env } from "./cloudflare-types.ts";
+import type { WebSocketRequestResponsePair } from "./cloudflare-types.ts";
 import { cloudLog } from "./observability.ts";
 
-const WORKSTATION_EVENTS_KEEPALIVE_MS = 25_000;
+export const WORKSTATION_EVENTS_PING = "nteract.workstation_events.ping.v1";
+export const WORKSTATION_EVENTS_PONG = "nteract.workstation_events.pong.v1";
 
-interface EventListener {
-  readonly id: string;
+interface EventSocketAttachment {
+  readonly listenerId: string;
   readonly workstationId: string | null;
-  readonly writer: WritableStreamDefaultWriter<Uint8Array>;
-  closed: boolean;
-  keepalive: ReturnType<typeof setInterval> | null;
+  readonly connectedAt: string;
 }
 
 export interface WorkstationAttachJobNotification {
@@ -26,35 +26,45 @@ export function workstationEventsObjectName(ownerPrincipal: string, workstationI
 }
 
 export class WorkstationEvents {
-  private readonly encoder = new TextEncoder();
-  private readonly listeners = new Map<string, EventListener>();
-
   constructor(
     private readonly state: DurableObjectState,
     private readonly env: Env,
   ) {
-    void this.state;
     void this.env;
+    const pairCtor = (
+      globalThis as {
+        WebSocketRequestResponsePair?: new (
+          request: string,
+          response: string,
+        ) => WebSocketRequestResponsePair;
+      }
+    ).WebSocketRequestResponsePair;
+    if (pairCtor && this.state.setWebSocketAutoResponse) {
+      this.state.setWebSocketAutoResponse(
+        new pairCtor(WORKSTATION_EVENTS_PING, WORKSTATION_EVENTS_PONG),
+      );
+    }
   }
 
   async fetch(request: Request): Promise<Response> {
     const url = new URL(request.url);
     if (request.method === "GET" && url.pathname === "/stream") {
-      return this.openStream(request);
+      return this.openSocket(request);
     }
     if (request.method === "GET" && url.pathname === "/status") {
       const workstationId = workstationIdFromUrl(url);
+      const connections = this.workstationSockets(workstationId).length;
       cloudLog("debug", "workstation.events.status", {
         workstation_id: workstationId,
-        connected: this.listeners.size > 0,
-        connections: this.listeners.size,
+        connected: connections > 0,
+        connections,
         counter: "workstation_event_status_checks",
         counter_delta: 1,
       });
       return Response.json({
         ok: true,
-        connected: this.listeners.size > 0,
-        connections: this.listeners.size,
+        connected: connections > 0,
+        connections,
       });
     }
     if (request.method === "POST" && url.pathname === "/notify") {
@@ -62,99 +72,125 @@ export class WorkstationEvents {
       if (notification instanceof Response) {
         return notification;
       }
-      await this.broadcast(notification.event, notification);
+      const delivered = this.broadcast(notification.event, notification);
       return Response.json({
         ok: true,
-        delivered: this.listeners.size,
+        delivered,
       });
     }
     return Response.json({ error: "not found" }, { status: 404 });
   }
 
-  private openStream(request: Request): Response {
-    const workstationId = workstationIdFromUrl(new URL(request.url));
-    const { readable, writable } = new TransformStream<Uint8Array, Uint8Array>();
-    const listener: EventListener = {
-      id: crypto.randomUUID(),
-      workstationId,
-      writer: writable.getWriter(),
-      closed: false,
-      keepalive: null,
-    };
-    const close = () => {
-      this.closeListener(listener);
-    };
-    request.signal.addEventListener("abort", close, { once: true });
+  webSocketMessage(
+    socket: CloudflareWebSocket,
+    message: string | ArrayBuffer | ArrayBufferView,
+  ): void {
+    if (message === WORKSTATION_EVENTS_PING) {
+      socket.send(WORKSTATION_EVENTS_PONG);
+    }
+  }
 
-    this.listeners.set(listener.id, listener);
-    cloudLog("info", "workstation.events.stream_opened", {
+  webSocketClose(socket: CloudflareWebSocket): void {
+    this.logSocketClosed(socket, "closed");
+  }
+
+  webSocketError(socket: CloudflareWebSocket): void {
+    this.logSocketClosed(socket, "errored");
+  }
+
+  private openSocket(request: Request): Response {
+    if (request.headers.get("Upgrade")?.toLowerCase() !== "websocket") {
+      return Response.json({ error: "expected WebSocket upgrade" }, { status: 426 });
+    }
+    const workstationId = workstationIdFromUrl(new URL(request.url));
+    const listenerId = crypto.randomUUID();
+    const connectedAt = new Date().toISOString();
+    const pair = new WebSocketPair();
+    const client = pair[0];
+    const server = pair[1];
+    const attachment: EventSocketAttachment = {
+      listenerId,
+      workstationId,
+      connectedAt,
+    };
+
+    this.acceptSocket(server, attachment);
+    cloudLog("info", "workstation.events.socket_opened", {
       workstation_id: workstationId,
-      listener_id: listener.id,
-      connections: this.listeners.size,
-      counter: "workstation_event_streams_opened",
+      listener_id: listenerId,
+      connections: this.workstationSockets(workstationId).length,
+      counter: "workstation_event_sockets_opened",
       counter_delta: 1,
     });
-    void this.writeEvent(listener, "ready", {
+    this.sendEvent(server, "ready", {
       ok: true,
-      connected_at: new Date().toISOString(),
-    }).catch(close);
-    listener.keepalive = setInterval(() => {
-      void this.writeComment(listener, "keepalive").catch(close);
-    }, WORKSTATION_EVENTS_KEEPALIVE_MS);
+      connected_at: connectedAt,
+    });
 
-    return new Response(readable, {
-      status: 200,
+    return new Response(null, {
+      status: 101,
       headers: {
         "Cache-Control": "no-store",
-        "Content-Type": "text/event-stream; charset=utf-8",
       },
+      webSocket: client,
+    } as ResponseInit & { webSocket: CloudflareWebSocket });
+  }
+
+  private acceptSocket(socket: CloudflareWebSocket, attachment: EventSocketAttachment): void {
+    if (this.state.acceptWebSocket && socket.serializeAttachment) {
+      this.state.acceptWebSocket(socket, [socketTag(attachment.workstationId)]);
+      socket.serializeAttachment(attachment);
+      return;
+    }
+
+    socket.accept();
+    socket.addEventListener("message", (event) => {
+      this.webSocketMessage(socket, event.data);
+    });
+    socket.addEventListener("close", () => {
+      this.webSocketClose(socket);
+    });
+    socket.addEventListener("error", () => {
+      this.webSocketError(socket);
     });
   }
 
-  private async broadcast(event: string, data: unknown): Promise<void> {
-    await Promise.all(
-      Array.from(this.listeners.values(), async (listener) => {
-        try {
-          await this.writeEvent(listener, event, data);
-        } catch {
-          this.closeListener(listener);
-        }
-      }),
-    );
+  private broadcast(event: string, data: unknown): number {
+    let delivered = 0;
+    for (const socket of this.workstationSockets(
+      (data as { workstation_id?: unknown }).workstation_id,
+    )) {
+      if (this.sendEvent(socket, event, data)) {
+        delivered += 1;
+      }
+    }
+    return delivered;
   }
 
-  private async writeEvent(listener: EventListener, event: string, data: unknown): Promise<void> {
-    if (listener.closed) {
-      return;
+  private sendEvent(socket: CloudflareWebSocket, event: string, data: unknown): boolean {
+    try {
+      socket.send(JSON.stringify({ event, data }));
+      return true;
+    } catch {
+      socket.close(1011, "workstation event delivery failed");
+      return false;
     }
-    await listener.writer.write(this.encoder.encode(formatServerSentEvent(event, data)));
   }
 
-  private async writeComment(listener: EventListener, comment: string): Promise<void> {
-    if (listener.closed) {
-      return;
-    }
-    await listener.writer.write(this.encoder.encode(`: ${comment}\n\n`));
+  private workstationSockets(workstationId: unknown): CloudflareWebSocket[] {
+    const tag = socketTag(typeof workstationId === "string" ? workstationId : null);
+    return this.state.getWebSockets?.(tag) ?? [];
   }
 
-  private closeListener(listener: EventListener): void {
-    if (listener.closed) {
-      return;
-    }
-    listener.closed = true;
-    if (listener.keepalive) {
-      clearInterval(listener.keepalive);
-      listener.keepalive = null;
-    }
-    this.listeners.delete(listener.id);
-    cloudLog("info", "workstation.events.stream_closed", {
-      workstation_id: listener.workstationId,
-      listener_id: listener.id,
-      connections: this.listeners.size,
-      counter: "workstation_event_streams_closed",
+  private logSocketClosed(socket: CloudflareWebSocket, reason: "closed" | "errored"): void {
+    const attachment = socketAttachment(socket);
+    cloudLog("info", "workstation.events.socket_closed", {
+      workstation_id: attachment?.workstationId ?? null,
+      listener_id: attachment?.listenerId ?? null,
+      reason,
+      counter: "workstation_event_sockets_closed",
       counter_delta: 1,
     });
-    void listener.writer.close().catch(() => undefined);
   }
 }
 
@@ -163,14 +199,24 @@ function workstationIdFromUrl(url: URL): string | null {
   return workstationId && workstationId.length <= 128 ? workstationId : null;
 }
 
-function formatServerSentEvent(event: string, data: unknown): string {
-  // This stream is a wakeup/presence path, not the durable attach-job log.
-  // Attach jobs live in D1 and agents recover by polling the queue after a
-  // reconnect, so we intentionally do not assign SSE ids or support
-  // Last-Event-ID replay here.
-  const payload = JSON.stringify(data);
-  const dataLines = payload.split(/\r?\n/).map((line) => `data: ${line}`);
-  return [`event: ${event}`, ...dataLines, ""].join("\n") + "\n";
+function socketTag(workstationId: string | null): string {
+  return `workstation:${workstationId ?? "unknown"}`;
+}
+
+function socketAttachment(socket: CloudflareWebSocket): EventSocketAttachment | null {
+  const value = socket.deserializeAttachment?.();
+  if (!isRecord(value)) {
+    return null;
+  }
+  const listenerId = stringField(value.listenerId);
+  if (!listenerId) {
+    return null;
+  }
+  return {
+    listenerId,
+    workstationId: stringField(value.workstationId) || null,
+    connectedAt: stringField(value.connectedAt),
+  };
 }
 
 async function readNotification(

--- a/apps/notebook-cloud/src/workstation-events.ts
+++ b/apps/notebook-cloud/src/workstation-events.ts
@@ -122,10 +122,17 @@ export class WorkstationEvents {
       counter: "workstation_event_sockets_opened",
       counter_delta: 1,
     });
-    this.sendEvent(server, "ready", {
-      ok: true,
-      connected_at: connectedAt,
-    });
+    if (
+      !this.sendEvent(server, "ready", {
+        ok: true,
+        connected_at: connectedAt,
+      })
+    ) {
+      return Response.json(
+        { error: "workstation event socket failed to initialize" },
+        { status: 500 },
+      );
+    }
 
     return new Response(null, {
       status: 101,
@@ -138,8 +145,8 @@ export class WorkstationEvents {
 
   private acceptSocket(socket: CloudflareWebSocket, attachment: EventSocketAttachment): void {
     if (this.state.acceptWebSocket && socket.serializeAttachment) {
-      this.state.acceptWebSocket(socket, [socketTag(attachment.workstationId)]);
       socket.serializeAttachment(attachment);
+      this.state.acceptWebSocket(socket, [socketTag(attachment.workstationId)]);
       return;
     }
 

--- a/apps/notebook-cloud/test/sharing.test.ts
+++ b/apps/notebook-cloud/test/sharing.test.ts
@@ -172,7 +172,7 @@ function pendingInvite(overrides: Partial<PendingNotebookInvite> = {}): PendingN
     status: "pending",
     createdByActorLabel: "user:oidc:owner/smoke:owner",
     createdAt: "2026-05-24T11:00:00.000Z",
-    expiresAt: "2026-06-24T11:00:00.000Z",
+    expiresAt: "2026-07-24T11:00:00.000Z",
     ...overrides,
   };
 }

--- a/apps/notebook-cloud/test/worker-routes.test.ts
+++ b/apps/notebook-cloud/test/worker-routes.test.ts
@@ -2015,7 +2015,7 @@ describe("Worker artifact routes", () => {
     assert.equal(body.workstations[0]?.is_default, true);
   });
 
-  it("streams user-owned workstation events with CORS headers", async () => {
+  it("forwards user-owned workstation event socket upgrades", async () => {
     const objectName = workstationEventsObjectName("user:dev:alice", "ws-lab2");
     const events = new FakeWorkstationEventsNamespace({ connectedObjectNames: [objectName] });
     const env = fakeEnv({ WORKSTATION_EVENTS: events });
@@ -2030,6 +2030,7 @@ describe("Worker artifact routes", () => {
           "X-Operator": "workstation:lab2",
           "X-Scope": "owner",
           "X-User": "alice",
+          Upgrade: "websocket",
         },
       }),
       env,
@@ -2037,16 +2038,15 @@ describe("Worker artifact routes", () => {
     );
 
     assert.equal(response.status, 200);
-    assert.equal(response.headers.get("Access-Control-Allow-Origin"), "*");
-    assert.equal(response.headers.get("Content-Type"), "text/event-stream; charset=utf-8");
-    assert.match(await response.text(), /event: ready/);
+    assert.equal(response.headers.get("x-fake-websocket-upgrade"), "1");
     const streamRequest = events.requests.find(
       (entry) => new URL(entry.url).pathname === "/stream",
     );
     assert.equal(streamRequest?.objectName, objectName);
+    assert.equal(streamRequest?.upgrade, "websocket");
   });
 
-  it("projects a stale workstation as online when its event stream is connected", async () => {
+  it("projects a stale workstation as online when its event socket is connected", async () => {
     const objectName = workstationEventsObjectName("user:dev:alice", "ws-lab2");
     const events = new FakeWorkstationEventsNamespace({ connectedObjectNames: [objectName] });
     const env = fakeEnv({ WORKSTATION_EVENTS: events });
@@ -2085,7 +2085,7 @@ describe("Worker artifact routes", () => {
     assert.equal(statusRequest?.objectName, objectName);
   });
 
-  it("does not fan out event-stream status checks for fresh workstation rows", async () => {
+  it("does not fan out event-socket status checks for fresh workstation rows", async () => {
     const objectName = workstationEventsObjectName("user:dev:alice", "ws-lab2");
     const events = new FakeWorkstationEventsNamespace({ connectedObjectNames: [objectName] });
     const env = fakeEnv({ WORKSTATION_EVENTS: events });
@@ -2121,7 +2121,7 @@ describe("Worker artifact routes", () => {
     assert.ok(!events.requests.some((entry) => new URL(entry.url).pathname === "/status"));
   });
 
-  it("does not fan out event-stream status checks for explicitly offline rows", async () => {
+  it("does not fan out event-socket status checks for explicitly offline rows", async () => {
     const objectName = workstationEventsObjectName("user:dev:alice", "ws-lab2");
     const events = new FakeWorkstationEventsNamespace({ connectedObjectNames: [objectName] });
     const env = fakeEnv({ WORKSTATION_EVENTS: events });
@@ -2447,7 +2447,7 @@ describe("Worker artifact routes", () => {
     );
   });
 
-  it("allows attach requests for stale workstations with a connected event stream", async () => {
+  it("allows attach requests for stale workstations with a connected event socket", async () => {
     const objectName = workstationEventsObjectName("user:dev:alice", "ws-lab2");
     const events = new FakeWorkstationEventsNamespace({ connectedObjectNames: [objectName] });
     const env = fakeEnv({ WORKSTATION_EVENTS: events });
@@ -5794,7 +5794,34 @@ describe("Workstation pairing", () => {
     );
   });
 
-  it("lets a paired workstation credential open the workstation event stream", async () => {
+  it("lets a paired workstation credential open the workstation event socket", async () => {
+    const events = new FakeWorkstationEventsNamespace();
+    const env = fakeEnv({ WORKSTATION_EVENTS: events });
+    const pairing = await mintPairingCode(env);
+    const token = await redeemedCredentialToken(env, pairing.code);
+    const register = await registerWorkstationWithToken(env, token, "ws-paired");
+    assert.equal(register.status, 201);
+
+    const response = await worker.fetch(
+      new Request("http://localhost/api/workstations/ws-paired/events", {
+        headers: { Authorization: `Bearer ${token}`, Upgrade: "websocket" },
+      }),
+      env,
+      fakeContext(),
+    );
+
+    assert.equal(response.status, 200);
+    assert.equal(response.headers.get("x-fake-websocket-upgrade"), "1");
+    assert.equal(events.requests.length, 1);
+    assert.equal(
+      events.requests[0]?.objectName,
+      workstationEventsObjectName("user:dev:alice", "ws-paired"),
+    );
+    assert.equal(new URL(events.requests[0]!.url).pathname, "/stream");
+    assert.equal(events.requests[0]?.upgrade, "websocket");
+  });
+
+  it("rejects workstation event requests that are not websocket upgrades", async () => {
     const events = new FakeWorkstationEventsNamespace();
     const env = fakeEnv({ WORKSTATION_EVENTS: events });
     const pairing = await mintPairingCode(env);
@@ -5810,17 +5837,12 @@ describe("Workstation pairing", () => {
       fakeContext(),
     );
 
-    assert.equal(response.status, 200);
-    assert.equal(response.headers.get("Content-Type"), "text/event-stream; charset=utf-8");
-    assert.equal(events.requests.length, 1);
-    assert.equal(
-      events.requests[0]?.objectName,
-      workstationEventsObjectName("user:dev:alice", "ws-paired"),
-    );
-    assert.equal(new URL(events.requests[0]!.url).pathname, "/stream");
+    assert.equal(response.status, 426);
+    assert.deepEqual(await response.json(), { error: "expected WebSocket upgrade" });
+    assert.equal(events.requests.length, 0);
   });
 
-  it("notifies the paired workstation event stream when an owner creates an attach job", async () => {
+  it("notifies the paired workstation event socket when an owner creates an attach job", async () => {
     const events = new FakeWorkstationEventsNamespace();
     const env = fakeEnv({ WORKSTATION_EVENTS: events });
     seedNotebook(env, "pairing-events-demo");
@@ -6674,6 +6696,7 @@ interface FakeWorkstationEventsRequest {
   url: string;
   method: string;
   body: unknown;
+  upgrade: string | null;
 }
 
 class FakeWorkstationEventsNamespace implements DurableObjectNamespace {
@@ -6706,11 +6729,12 @@ class FakeWorkstationEventsNamespace implements DurableObjectNamespace {
           url: request.url,
           method: request.method,
           body,
+          upgrade: request.headers.get("Upgrade"),
         });
         const pathname = new URL(request.url).pathname;
         if (pathname === "/stream") {
-          return new Response('event: ready\ndata: {"ok":true}\n\n', {
-            headers: { "Content-Type": "text/event-stream; charset=utf-8" },
+          return new Response("websocket accepted", {
+            headers: { "x-fake-websocket-upgrade": "1" },
           });
         }
         if (pathname === "/notify") {

--- a/apps/notebook-cloud/test/workstation-events.test.ts
+++ b/apps/notebook-cloud/test/workstation-events.test.ts
@@ -116,30 +116,43 @@ test("workstation events answers ping in the non-hibernation fallback path", () 
   assert.deepEqual(socket.sent, [WORKSTATION_EVENTS_PONG]);
 });
 
-test("workstation events stores socket attachment before hibernatable accept", async () => {
+test("workstation events stores socket attachment before hibernatable accept", () => {
   const calls: string[] = [];
-  const server = new FakeSocket({ calls, failSend: true });
-  const restore = installWebSocketPair(new FakeSocket(), server);
-  try {
-    const events = new WorkstationEvents(
-      {
-        ...stateWithSockets([]),
-        acceptWebSocket: () => calls.push("accept"),
-      },
-      {} as Env,
-    );
+  const socket = new FakeSocket({ calls });
+  const events = new WorkstationEvents(
+    {
+      ...stateWithSockets([]),
+      acceptWebSocket: () => calls.push("accept"),
+    },
+    {} as Env,
+  );
 
-    const response = await events.fetch(
-      new Request("https://workstation-events.internal/stream?workstation_id=ws-lab2", {
-        headers: { Upgrade: "websocket" },
-      }),
-    );
+  (
+    events as unknown as {
+      acceptSocket(socket: CloudflareWebSocket, attachment: unknown): void;
+    }
+  ).acceptSocket(socket.asCloudflareWebSocket(), {
+    listenerId: "listener-1",
+    workstationId: "ws-lab2",
+    connectedAt: "2026-06-27T00:00:00.000Z",
+  });
 
-    assert.equal(response.status, 500);
-    assert.deepEqual(calls, ["serialize", "accept", "close:1011"]);
-  } finally {
-    restore();
-  }
+  assert.deepEqual(calls, ["serialize", "accept"]);
+});
+
+test("workstation events closes sockets when send fails", () => {
+  const calls: string[] = [];
+  const socket = new FakeSocket({ calls, failSend: true });
+  const events = new WorkstationEvents(stateWithSockets([]), {} as Env);
+
+  const sent = (
+    events as unknown as {
+      sendEvent(socket: CloudflareWebSocket, event: string, data: unknown): boolean;
+    }
+  ).sendEvent(socket.asCloudflareWebSocket(), "ready", { ok: true });
+
+  assert.equal(sent, false);
+  assert.deepEqual(calls, ["close:1011"]);
 });
 
 function stateWithSockets(sockets: CloudflareWebSocket[]): DurableObjectState {
@@ -199,18 +212,4 @@ class FakeSocket {
   asCloudflareWebSocket(): CloudflareWebSocket {
     return this as unknown as CloudflareWebSocket;
   }
-}
-
-function installWebSocketPair(client: FakeSocket, server: FakeSocket): () => void {
-  const globals = globalThis as typeof globalThis & {
-    WebSocketPair?: new () => { 0: CloudflareWebSocket; 1: CloudflareWebSocket };
-  };
-  const original = globals.WebSocketPair;
-  globals.WebSocketPair = class {
-    readonly 0 = client.asCloudflareWebSocket();
-    readonly 1 = server.asCloudflareWebSocket();
-  };
-  return () => {
-    globals.WebSocketPair = original;
-  };
 }

--- a/apps/notebook-cloud/test/workstation-events.test.ts
+++ b/apps/notebook-cloud/test/workstation-events.test.ts
@@ -116,6 +116,32 @@ test("workstation events answers ping in the non-hibernation fallback path", () 
   assert.deepEqual(socket.sent, [WORKSTATION_EVENTS_PONG]);
 });
 
+test("workstation events stores socket attachment before hibernatable accept", async () => {
+  const calls: string[] = [];
+  const server = new FakeSocket({ calls, failSend: true });
+  const restore = installWebSocketPair(new FakeSocket(), server);
+  try {
+    const events = new WorkstationEvents(
+      {
+        ...stateWithSockets([]),
+        acceptWebSocket: () => calls.push("accept"),
+      },
+      {} as Env,
+    );
+
+    const response = await events.fetch(
+      new Request("https://workstation-events.internal/stream?workstation_id=ws-lab2", {
+        headers: { Upgrade: "websocket" },
+      }),
+    );
+
+    assert.equal(response.status, 500);
+    assert.deepEqual(calls, ["serialize", "accept", "close:1011"]);
+  } finally {
+    restore();
+  }
+});
+
 function stateWithSockets(sockets: CloudflareWebSocket[]): DurableObjectState {
   return {
     id: { toString: () => "workstation-events-test" },
@@ -133,18 +159,33 @@ function stateWithSockets(sockets: CloudflareWebSocket[]): DurableObjectState {
 class FakeSocket {
   readonly sent: string[] = [];
   closed = false;
+  private readonly calls?: string[];
+  private readonly failSend: boolean;
+
+  constructor(options: { calls?: string[]; failSend?: boolean } = {}) {
+    this.calls = options.calls;
+    this.failSend = options.failSend ?? false;
+  }
 
   accept(): void {}
 
   addEventListener(): void {}
 
   send(message: string | ArrayBuffer | ArrayBufferView): void {
+    if (this.failSend) {
+      throw new Error("send failed");
+    }
     assert.equal(typeof message, "string");
     this.sent.push(message as string);
   }
 
-  close(): void {
+  close(code?: number): void {
     this.closed = true;
+    this.calls?.push(`close:${code ?? "none"}`);
+  }
+
+  serializeAttachment(): void {
+    this.calls?.push("serialize");
   }
 
   deserializeAttachment() {
@@ -158,4 +199,18 @@ class FakeSocket {
   asCloudflareWebSocket(): CloudflareWebSocket {
     return this as unknown as CloudflareWebSocket;
   }
+}
+
+function installWebSocketPair(client: FakeSocket, server: FakeSocket): () => void {
+  const globals = globalThis as typeof globalThis & {
+    WebSocketPair?: new () => { 0: CloudflareWebSocket; 1: CloudflareWebSocket };
+  };
+  const original = globals.WebSocketPair;
+  globals.WebSocketPair = class {
+    readonly 0 = client.asCloudflareWebSocket();
+    readonly 1 = server.asCloudflareWebSocket();
+  };
+  return () => {
+    globals.WebSocketPair = original;
+  };
 }

--- a/apps/notebook-cloud/test/workstation-events.test.ts
+++ b/apps/notebook-cloud/test/workstation-events.test.ts
@@ -1,0 +1,161 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import type { CloudflareWebSocket, DurableObjectState, Env } from "../src/cloudflare-types.ts";
+import {
+  WORKSTATION_EVENTS_PING,
+  WORKSTATION_EVENTS_PONG,
+  WorkstationEvents,
+} from "../src/workstation-events.ts";
+
+test("workstation events configures hibernatable auto-response", () => {
+  const pairs: Array<{ request: string; response: string }> = [];
+  const globals = globalThis as {
+    WebSocketRequestResponsePair?: new (
+      request: string,
+      response: string,
+    ) => {
+      request: string;
+      response: string;
+    };
+  };
+  const original = globals.WebSocketRequestResponsePair;
+  globals.WebSocketRequestResponsePair = class {
+    constructor(
+      readonly request: string,
+      readonly response: string,
+    ) {}
+  };
+  try {
+    new WorkstationEvents(
+      {
+        ...stateWithSockets([]),
+        setWebSocketAutoResponse: (pair) => pairs.push(pair),
+      },
+      {} as Env,
+    );
+  } finally {
+    globals.WebSocketRequestResponsePair = original;
+  }
+
+  assert.deepEqual(
+    pairs.map((pair) => ({ request: pair.request, response: pair.response })),
+    [
+      {
+        request: WORKSTATION_EVENTS_PING,
+        response: WORKSTATION_EVENTS_PONG,
+      },
+    ],
+  );
+});
+
+test("workstation events status uses hibernated sockets by workstation tag", async () => {
+  const socket = new FakeSocket();
+  const events = new WorkstationEvents(
+    stateWithSockets([socket.asCloudflareWebSocket()]),
+    {} as Env,
+  );
+
+  const response = await events.fetch(
+    new Request("https://workstation-events.internal/status?workstation_id=ws-lab2"),
+  );
+
+  assert.equal(response.status, 200);
+  assert.deepEqual(await response.json(), {
+    ok: true,
+    connected: true,
+    connections: 1,
+  });
+});
+
+test("workstation events notify sends JSON wakeups to connected sockets", async () => {
+  const socket = new FakeSocket();
+  const events = new WorkstationEvents(
+    stateWithSockets([socket.asCloudflareWebSocket()]),
+    {} as Env,
+  );
+
+  const response = await events.fetch(
+    new Request("https://workstation-events.internal/notify", {
+      method: "POST",
+      body: JSON.stringify({
+        event: "attach_jobs",
+        workstation_id: "ws-lab2",
+        job_id: "job-1",
+        notebook_id: "nb-1",
+        status: "pending",
+        requested_at: "2026-06-27T00:00:00.000Z",
+        updated_at: "2026-06-27T00:00:00.000Z",
+      }),
+    }),
+  );
+
+  assert.equal(response.status, 200);
+  assert.deepEqual(await response.json(), { ok: true, delivered: 1 });
+  assert.equal(socket.sent.length, 1);
+  assert.deepEqual(JSON.parse(socket.sent[0]!), {
+    event: "attach_jobs",
+    data: {
+      event: "attach_jobs",
+      workstation_id: "ws-lab2",
+      job_id: "job-1",
+      notebook_id: "nb-1",
+      status: "pending",
+      requested_at: "2026-06-27T00:00:00.000Z",
+      updated_at: "2026-06-27T00:00:00.000Z",
+    },
+  });
+});
+
+test("workstation events answers ping in the non-hibernation fallback path", () => {
+  const socket = new FakeSocket();
+  const events = new WorkstationEvents(stateWithSockets([]), {} as Env);
+
+  events.webSocketMessage(socket.asCloudflareWebSocket(), WORKSTATION_EVENTS_PING);
+
+  assert.deepEqual(socket.sent, [WORKSTATION_EVENTS_PONG]);
+});
+
+function stateWithSockets(sockets: CloudflareWebSocket[]): DurableObjectState {
+  return {
+    id: { toString: () => "workstation-events-test" },
+    storage: {
+      get: async () => undefined,
+      put: async () => undefined,
+      delete: async () => false,
+      list: async () => new Map(),
+    },
+    waitUntil: () => undefined,
+    getWebSockets: (tag?: string) => (tag === "workstation:ws-lab2" ? sockets : []),
+  };
+}
+
+class FakeSocket {
+  readonly sent: string[] = [];
+  closed = false;
+
+  accept(): void {}
+
+  addEventListener(): void {}
+
+  send(message: string | ArrayBuffer | ArrayBufferView): void {
+    assert.equal(typeof message, "string");
+    this.sent.push(message as string);
+  }
+
+  close(): void {
+    this.closed = true;
+  }
+
+  deserializeAttachment() {
+    return {
+      listenerId: "listener-1",
+      workstationId: "ws-lab2",
+      connectedAt: "2026-06-27T00:00:00.000Z",
+    };
+  }
+
+  asCloudflareWebSocket(): CloudflareWebSocket {
+    return this as unknown as CloudflareWebSocket;
+  }
+}

--- a/crates/runtimed/Cargo.toml
+++ b/crates/runtimed/Cargo.toml
@@ -60,6 +60,7 @@ rattler_solve = { version = "5.0", features = ["resolvo"] }
 rattler_virtual_packages = "2.3"
 reqwest = { version = "0.12", default-features = false, features = ["json", "native-tls"] }
 reqwest-middleware = "0.4"
+tokio-tungstenite = { version = "0.26", features = ["native-tls"] }
 
 # Content-addressed blob store
 sha2 = "0.11"

--- a/crates/runtimed/src/main.rs
+++ b/crates/runtimed/src/main.rs
@@ -193,7 +193,7 @@ enum Commands {
     },
 
     /// Serve this machine as a workstation for a hosted nteract cloud:
-    /// register/heartbeat, keep an SSE attach-job wakeup stream open, and
+    /// register/heartbeat, keep a hibernatable attach-job wakeup socket open, and
     /// spawn one `cloud-runtime-agent` runtime peer per job. Polling remains
     /// the fallback path. The workstation credential is read from
     /// RUNT_CLOUD_TOKEN (never argv); `runt workstation connect` stores it and

--- a/crates/runtimed/src/workstation/agent_loop.rs
+++ b/crates/runtimed/src/workstation/agent_loop.rs
@@ -2,7 +2,7 @@
 //!
 //! Rust port of `apps/notebook-cloud/scripts/hosted-workstation-agent.mjs`:
 //! registers/heartbeats this machine against the hosted workstation surface
-//! (`POST /api/workstations`), keeps a server-sent event wakeup stream open,
+//! (`POST /api/workstations`), keeps a workstation event WebSocket open,
 //! and falls back to polling the attach-job queue
 //! (`GET /api/workstations/{id}/attach-jobs`). It serves each pending job by
 //! spawning a `runtimed cloud-runtime-agent` runtime peer (the agent *is*
@@ -32,9 +32,14 @@ use std::path::{Path, PathBuf};
 use std::time::{Duration, Instant};
 
 use anyhow::{Context, Result};
+use futures::StreamExt;
 use serde::Deserialize;
 use serde_json::{json, Value};
 use tokio::sync::mpsc;
+use tokio_tungstenite::connect_async;
+use tokio_tungstenite::tungstenite::client::IntoClientRequest;
+use tokio_tungstenite::tungstenite::http::header::{HeaderValue, AUTHORIZATION};
+use tokio_tungstenite::tungstenite::Message as WsMessage;
 use tracing::{error, info, warn};
 
 pub use super::cloud_agent_cli::CLOUD_TOKEN_ENV;
@@ -46,11 +51,11 @@ pub use super::cloud_agent_cli::CLOUD_TOKEN_ENV;
 pub const READINESS_LINE: &str = "Infrastructure ready, entering main loop";
 
 /// Default attach-job fallback poll interval. The fast path is the workstation
-/// event stream; polling is recovery for missed events or older servers.
+/// event socket; polling is recovery for missed events or older servers.
 pub const DEFAULT_POLL_MS: u64 = 60_000;
-/// Default workstation heartbeat interval. The event stream is the fast wakeup
+/// Default workstation heartbeat interval. The event socket is the fast wakeup
 /// path, but registration heartbeat remains the durable online-presence
-/// fallback for missed or wedged streams.
+/// fallback for missed or wedged sockets.
 pub const DEFAULT_HEARTBEAT_MS: u64 = 60_000;
 
 /// Cooldown applied to 429/503 responses without a usable `Retry-After`.
@@ -60,11 +65,6 @@ const MAX_RETRY_AFTER_MS: u64 = 15 * 60_000;
 /// How often active children are checked for exit/readiness between polls
 /// (the `.mjs` agent's `readyPoll` interval).
 const CHILD_TICK_MS: u64 = 250;
-/// Server keepalives are 25s today. Recycle half-open SSE streams that stop
-/// delivering bytes so the agent falls back/reconnects instead of waiting
-/// forever on a dead TCP connection.
-const WORKSTATION_EVENTS_IDLE_TIMEOUT_MS: u64 = 60_000;
-
 /// Configuration for [`run_workstation_agent`]. All fields are non-secret;
 /// the credential travels separately.
 #[derive(Debug, Clone)]
@@ -342,37 +342,24 @@ pub fn normalize_jobs(body: &Value) -> Vec<AttachJob> {
         .collect()
 }
 
-fn drain_sse_event_names(buffer: &mut String, chunk: &[u8]) -> Vec<String> {
-    buffer.push_str(&String::from_utf8_lossy(chunk));
-    let mut events = Vec::new();
-    while let Some((boundary, boundary_len)) = find_sse_event_boundary(buffer) {
-        let block = buffer[..boundary].to_string();
-        buffer.drain(..boundary + boundary_len);
-        if let Some(event_name) = parse_sse_event_name(&block) {
-            events.push(event_name);
-        }
-    }
-    events
+fn workstation_event_name_from_ws_text(text: &str) -> Option<String> {
+    serde_json::from_str::<Value>(text)
+        .ok()?
+        .get("event")?
+        .as_str()
+        .map(str::to_string)
 }
 
-fn find_sse_event_boundary(buffer: &str) -> Option<(usize, usize)> {
-    match (buffer.find("\n\n"), buffer.find("\r\n\r\n")) {
-        (Some(lf), Some(crlf)) if lf < crlf => Some((lf, 2)),
-        (Some(_lf), Some(crlf)) => Some((crlf, 4)),
-        (Some(lf), None) => Some((lf, 2)),
-        (None, Some(crlf)) => Some((crlf, 4)),
-        (None, None) => None,
+fn workstation_events_ws_url(http_url: &str) -> Result<String, AgentHttpError> {
+    if let Some(rest) = http_url.strip_prefix("https://") {
+        return Ok(format!("wss://{rest}"));
     }
-}
-
-fn parse_sse_event_name(block: &str) -> Option<String> {
-    for line in block.lines() {
-        let line = line.trim_end_matches('\r');
-        if let Some(event_name) = line.strip_prefix("event:") {
-            return Some(event_name.trim().to_string());
-        }
+    if let Some(rest) = http_url.strip_prefix("http://") {
+        return Ok(format!("ws://{rest}"));
     }
-    None
+    Err(AgentHttpError::local(format!(
+        "workstation event URL must be http(s): {http_url}"
+    )))
 }
 
 /// Cooldown hint from a response: nonzero only for 429/503. `Retry-After`
@@ -530,64 +517,88 @@ impl CloudApi {
         Ok(normalize_jobs(&body))
     }
 
-    async fn stream_workstation_events(
+    async fn connect_workstation_events(
         &self,
         workstation_id: &str,
         tx: mpsc::Sender<WorkstationControlEvent>,
     ) -> Result<(), AgentHttpError> {
-        let url = format!(
+        let http_url = format!(
             "{}/api/workstations/{}/events",
             self.base,
             encode_path_segment(workstation_id)
         );
-        let mut response = self
-            .client
-            .get(&url)
-            .bearer_auth(&self.token)
-            .header("Accept", "text/event-stream")
-            .send()
-            .await
-            .map_err(|e| AgentHttpError::local(format!("stream workstation events failed: {e}")))?;
-        let status = response.status().as_u16();
-        let retry_after_header = response
-            .headers()
-            .get("retry-after")
-            .and_then(|value| value.to_str().ok())
-            .map(str::to_string);
-        if status != 200 {
-            let text = response.text().await.unwrap_or_default();
-            let body = parse_response_body(&text);
-            let snippet: String = serde_json::to_string(&body)
-                .unwrap_or_default()
-                .chars()
-                .take(500)
-                .collect();
-            return Err(AgentHttpError {
-                message: format!("stream workstation events failed: HTTP {status} {snippet}"),
-                retry_after_ms: retry_after_ms(status, retry_after_header.as_deref()),
-                status: Some(status),
-                body,
-            });
-        }
+        let ws_url = workstation_events_ws_url(&http_url)?;
+        let mut request = ws_url.as_str().into_client_request().map_err(|e| {
+            AgentHttpError::local(format!("build workstation event websocket: {e}"))
+        })?;
+        let auth = HeaderValue::from_str(&format!("Bearer {}", self.token)).map_err(|e| {
+            AgentHttpError::local(format!("build workstation event auth header: {e}"))
+        })?;
+        request.headers_mut().insert(AUTHORIZATION, auth);
 
-        let mut buffer = String::new();
+        let (ws, _response) = match connect_async(request).await {
+            Ok(ok) => ok,
+            Err(tokio_tungstenite::tungstenite::Error::Http(response)) => {
+                let status = response.status().as_u16();
+                let retry_after_header = response
+                    .headers()
+                    .get("retry-after")
+                    .and_then(|value| value.to_str().ok())
+                    .map(str::to_string);
+                let body = response
+                    .into_body()
+                    .map(|bytes| String::from_utf8_lossy(&bytes).into_owned())
+                    .map(|text| parse_response_body(&text))
+                    .unwrap_or_else(|| json!({}));
+                let snippet: String = serde_json::to_string(&body)
+                    .unwrap_or_default()
+                    .chars()
+                    .take(500)
+                    .collect();
+                return Err(AgentHttpError {
+                    message: format!("connect workstation events failed: HTTP {status} {snippet}"),
+                    retry_after_ms: retry_after_ms(status, retry_after_header.as_deref()),
+                    status: Some(status),
+                    body,
+                });
+            }
+            Err(error) => {
+                return Err(AgentHttpError::local(format!(
+                    "connect workstation events failed: {error}"
+                )));
+            }
+        };
+
+        let (_write, mut read) = ws.split();
         loop {
-            let chunk = tokio::time::timeout(
-                Duration::from_millis(WORKSTATION_EVENTS_IDLE_TIMEOUT_MS),
-                response.chunk(),
-            )
-            .await
-            .map_err(|_| AgentHttpError::local("workstation event stream idle timeout".into()))?
-            .map_err(|e| AgentHttpError::local(format!("read workstation event stream: {e}")))?;
-            let Some(chunk) = chunk else {
+            let Some(message) = read.next().await else {
                 return Ok(());
             };
-            for event_name in drain_sse_event_names(&mut buffer, &chunk) {
-                if event_name == "attach_jobs"
-                    && tx.send(WorkstationControlEvent::AttachJobs).await.is_err()
-                {
+            let message = message.map_err(|e| {
+                AgentHttpError::local(format!("read workstation event websocket: {e}"))
+            })?;
+            match message {
+                WsMessage::Text(text) => {
+                    if workstation_event_name_from_ws_text(&text) == Some("attach_jobs".to_string())
+                        && tx.send(WorkstationControlEvent::AttachJobs).await.is_err()
+                    {
+                        return Ok(());
+                    }
+                }
+                WsMessage::Binary(bytes) => {
+                    if let Ok(text) = std::str::from_utf8(&bytes) {
+                        if workstation_event_name_from_ws_text(text)
+                            == Some("attach_jobs".to_string())
+                            && tx.send(WorkstationControlEvent::AttachJobs).await.is_err()
+                        {
+                            return Ok(());
+                        }
+                    }
+                }
+                WsMessage::Close(_) => {
                     return Ok(());
                 }
+                WsMessage::Ping(_) | WsMessage::Pong(_) | WsMessage::Frame(_) => {}
             }
         }
     }
@@ -671,33 +682,33 @@ async fn run_workstation_event_listener(
             return;
         }
         match api
-            .stream_workstation_events(&workstation_id, tx.clone())
+            .connect_workstation_events(&workstation_id, tx.clone())
             .await
         {
             Ok(()) => {
-                warn!("[workstation-agent] workstation event stream closed; reconnecting");
+                warn!("[workstation-agent] workstation event socket closed; reconnecting");
                 reconnect_delay = Duration::from_secs(1);
             }
             Err(error) => {
                 if error.status == Some(404) || error.status == Some(503) {
                     warn!(
-                        "[workstation-agent] workstation event stream unavailable; using fallback polling: {}",
+                        "[workstation-agent] workstation event socket unavailable; using fallback polling: {}",
                         error.message
                     );
                 } else {
                     warn!(
-                        "[workstation-agent] workstation event stream failed; reconnecting: {}",
+                        "[workstation-agent] workstation event socket failed; reconnecting: {}",
                         error.message
                     );
                 }
-                reconnect_delay = retry_event_stream_delay(reconnect_delay, error.retry_after_ms);
+                reconnect_delay = retry_event_socket_delay(reconnect_delay, error.retry_after_ms);
             }
         }
         tokio::time::sleep(reconnect_delay).await;
     }
 }
 
-fn retry_event_stream_delay(previous: Duration, retry_after_ms: u64) -> Duration {
+fn retry_event_socket_delay(previous: Duration, retry_after_ms: u64) -> Duration {
     if retry_after_ms > 0 {
         return Duration::from_millis(retry_after_ms).min(Duration::from_secs(60));
     }
@@ -805,7 +816,7 @@ pub async fn run_workstation_agent(opts: WorkstationAgentOptions, token: String)
     let mut last_registration: Option<Instant> = None;
     let mut last_poll: Option<Instant> = None;
     let mut poll_requested = true;
-    let mut event_stream_closed = false;
+    let mut event_socket_closed = false;
     let mut tracker = StepTracker::default();
     let (event_tx, mut event_rx) = mpsc::channel(16);
     let _event_listener = tokio::spawn(run_workstation_event_listener(
@@ -821,9 +832,9 @@ pub async fn run_workstation_agent(opts: WorkstationAgentOptions, token: String)
         }
 
         // Register on startup and refresh workstation metadata periodically.
-        // The SSE stream is the fast attach-job wakeup path; this heartbeat is
+        // The event socket is the fast attach-job wakeup path; this heartbeat is
         // the durable fallback that keeps a locally-running workstation visible
-        // if that stream is missed, half-open, or blocked by an intermediary.
+        // if that socket is missed, half-open, or blocked by an intermediary.
         if should_register_workstation(last_registration, opts.heartbeat_interval) {
             let result = heartbeat(&api, &opts).await;
             if result.is_ok() {
@@ -835,13 +846,13 @@ pub async fn run_workstation_agent(opts: WorkstationAgentOptions, token: String)
             continue;
         }
 
-        if !event_stream_closed {
+        if !event_socket_closed {
             while let Ok(WorkstationControlEvent::AttachJobs) = event_rx.try_recv() {
                 poll_requested = true;
             }
         }
 
-        // Accept/adopt attach jobs. SSE is the fast wakeup path; this fallback
+        // Accept/adopt attach jobs. The event socket is the fast wakeup path; this fallback
         // poll catches missed events, server versions without /events, and
         // jobs that existed before this agent started.
         if poll_requested || last_poll.is_none_or(|at| at.elapsed() >= opts.poll_interval) {
@@ -875,14 +886,14 @@ pub async fn run_workstation_agent(opts: WorkstationAgentOptions, token: String)
                 Duration::from_millis(CHILD_TICK_MS).min(deadline - now)
             };
             tokio::select! {
-                event = event_rx.recv(), if !event_stream_closed => {
+                event = event_rx.recv(), if !event_socket_closed => {
                     match event {
                         Some(WorkstationControlEvent::AttachJobs) => {
                             poll_requested = true;
                             break;
                         }
                         None => {
-                            event_stream_closed = true;
+                            event_socket_closed = true;
                         }
                     }
                 }
@@ -1773,36 +1784,41 @@ mod tests {
     }
 
     #[test]
-    fn sse_parser_drains_complete_event_names() {
-        let mut buffer = String::new();
-        let events = drain_sse_event_names(
-            &mut buffer,
-            b"event: ready\ndata: {}\n\nevent: attach_jobs\ndata: {\"job_id\":\"j\"}\n\n",
+    fn workstation_event_name_reads_json_messages() {
+        assert_eq!(
+            workstation_event_name_from_ws_text(r#"{"event":"attach_jobs","data":{"job_id":"j"}}"#),
+            Some("attach_jobs".to_string())
         );
-
-        assert_eq!(events, vec!["ready", "attach_jobs"]);
-        assert!(buffer.is_empty());
+        assert_eq!(
+            workstation_event_name_from_ws_text(r#"{"event":"ready","data":{"ok":true}}"#),
+            Some("ready".to_string())
+        );
+        assert_eq!(workstation_event_name_from_ws_text("not json"), None);
+        assert_eq!(workstation_event_name_from_ws_text(r#"{"data":{}}"#), None);
     }
 
     #[test]
-    fn sse_parser_keeps_partial_event_until_boundary() {
-        let mut buffer = String::new();
-        assert!(drain_sse_event_names(&mut buffer, b"event: attach_").is_empty());
+    fn workstation_event_url_uses_websocket_scheme() {
         assert_eq!(
-            drain_sse_event_names(&mut buffer, b"jobs\r\ndata: {}\r\n\r\n"),
-            vec!["attach_jobs"]
+            workstation_events_ws_url("https://preview.runt.run/api/workstations/ws/events")
+                .unwrap(),
+            "wss://preview.runt.run/api/workstations/ws/events"
         );
-        assert!(buffer.is_empty());
+        assert_eq!(
+            workstation_events_ws_url("http://localhost:8787/api/workstations/ws/events").unwrap(),
+            "ws://localhost:8787/api/workstations/ws/events"
+        );
+        assert!(workstation_events_ws_url("file:///tmp/socket").is_err());
     }
 
     #[test]
-    fn event_stream_retry_delay_uses_retry_after_and_caps_backoff() {
+    fn event_socket_retry_delay_uses_retry_after_and_caps_backoff() {
         assert_eq!(
-            retry_event_stream_delay(Duration::from_secs(1), 42_000),
+            retry_event_socket_delay(Duration::from_secs(1), 42_000),
             Duration::from_secs(42)
         );
         assert_eq!(
-            retry_event_stream_delay(Duration::from_secs(45), 0),
+            retry_event_socket_delay(Duration::from_secs(45), 0),
             Duration::from_secs(60)
         );
     }

--- a/crates/runtimed/src/workstation/agent_loop.rs
+++ b/crates/runtimed/src/workstation/agent_loop.rs
@@ -32,7 +32,7 @@ use std::path::{Path, PathBuf};
 use std::time::{Duration, Instant};
 
 use anyhow::{Context, Result};
-use futures::StreamExt;
+use futures::{SinkExt, StreamExt};
 use serde::Deserialize;
 use serde_json::{json, Value};
 use tokio::sync::mpsc;
@@ -62,6 +62,13 @@ pub const DEFAULT_HEARTBEAT_MS: u64 = 60_000;
 const DEFAULT_RETRY_AFTER_MS: u64 = 60_000;
 /// Upper bound for rate-limit cooldowns (15 minutes, like the `.mjs` agent).
 const MAX_RETRY_AFTER_MS: u64 = 15 * 60_000;
+/// Idle workstation event sockets should reconnect rather than pinning an
+/// agent to a half-open network path forever.
+const WORKSTATION_EVENTS_IDLE_TIMEOUT_MS: u64 = 90_000;
+/// After an idle socket is probed, a missing response means the path is stale.
+const WORKSTATION_EVENTS_PING_TIMEOUT_MS: u64 = 10_000;
+const WORKSTATION_EVENTS_PING: &str = "nteract.workstation_events.ping.v1";
+const WORKSTATION_EVENTS_PONG: &str = "nteract.workstation_events.pong.v1";
 /// How often active children are checked for exit/readiness between polls
 /// (the `.mjs` agent's `readyPoll` interval).
 const CHILD_TICK_MS: u64 = 250;
@@ -350,6 +357,38 @@ fn workstation_event_name_from_ws_text(text: &str) -> Option<String> {
         .map(str::to_string)
 }
 
+async fn handle_workstation_event_ws_message(
+    message: WsMessage,
+    tx: &mpsc::Sender<WorkstationControlEvent>,
+) -> Result<bool, AgentHttpError> {
+    match message {
+        WsMessage::Text(text) => {
+            if text.as_str() == WORKSTATION_EVENTS_PONG {
+                return Ok(true);
+            }
+            if workstation_event_name_from_ws_text(text.as_str()).as_deref() == Some("attach_jobs")
+                && tx.send(WorkstationControlEvent::AttachJobs).await.is_err()
+            {
+                return Ok(false);
+            }
+        }
+        WsMessage::Binary(bytes) => {
+            if let Ok(text) = std::str::from_utf8(&bytes) {
+                if workstation_event_name_from_ws_text(text).as_deref() == Some("attach_jobs")
+                    && tx.send(WorkstationControlEvent::AttachJobs).await.is_err()
+                {
+                    return Ok(false);
+                }
+            }
+        }
+        WsMessage::Close(_) => {
+            return Ok(false);
+        }
+        WsMessage::Ping(_) | WsMessage::Pong(_) | WsMessage::Frame(_) => {}
+    }
+    Ok(true)
+}
+
 fn workstation_events_ws_url(http_url: &str) -> Result<String, AgentHttpError> {
     if let Some(rest) = http_url.strip_prefix("https://") {
         return Ok(format!("wss://{rest}"));
@@ -569,36 +608,47 @@ impl CloudApi {
             }
         };
 
-        let (_write, mut read) = ws.split();
+        let (mut write, mut read) = ws.split();
         loop {
-            let Some(message) = read.next().await else {
-                return Ok(());
-            };
-            let message = message.map_err(|e| {
-                AgentHttpError::local(format!("read workstation event websocket: {e}"))
-            })?;
-            match message {
-                WsMessage::Text(text) => {
-                    if workstation_event_name_from_ws_text(&text) == Some("attach_jobs".to_string())
-                        && tx.send(WorkstationControlEvent::AttachJobs).await.is_err()
+            let message = match tokio::time::timeout(
+                Duration::from_millis(WORKSTATION_EVENTS_IDLE_TIMEOUT_MS),
+                read.next(),
+            )
+            .await
+            {
+                Ok(Some(message)) => message.map_err(|e| {
+                    AgentHttpError::local(format!("read workstation event websocket: {e}"))
+                })?,
+                Ok(None) => return Ok(()),
+                Err(_) => {
+                    write
+                        .send(WsMessage::Text(WORKSTATION_EVENTS_PING.into()))
+                        .await
+                        .map_err(|e| {
+                            AgentHttpError::local(format!("ping workstation event websocket: {e}"))
+                        })?;
+                    match tokio::time::timeout(
+                        Duration::from_millis(WORKSTATION_EVENTS_PING_TIMEOUT_MS),
+                        read.next(),
+                    )
+                    .await
                     {
-                        return Ok(());
-                    }
-                }
-                WsMessage::Binary(bytes) => {
-                    if let Ok(text) = std::str::from_utf8(&bytes) {
-                        if workstation_event_name_from_ws_text(text)
-                            == Some("attach_jobs".to_string())
-                            && tx.send(WorkstationControlEvent::AttachJobs).await.is_err()
-                        {
-                            return Ok(());
+                        Ok(Some(message)) => message.map_err(|e| {
+                            AgentHttpError::local(format!(
+                                "read workstation event websocket after ping: {e}"
+                            ))
+                        })?,
+                        Ok(None) => return Ok(()),
+                        Err(_) => {
+                            return Err(AgentHttpError::local(
+                                "workstation event websocket idle timeout".to_string(),
+                            ));
                         }
                     }
                 }
-                WsMessage::Close(_) => {
-                    return Ok(());
-                }
-                WsMessage::Ping(_) | WsMessage::Pong(_) | WsMessage::Frame(_) => {}
+            };
+            if !handle_workstation_event_ws_message(message, &tx).await? {
+                return Ok(());
             }
         }
     }
@@ -1794,7 +1844,32 @@ mod tests {
             Some("ready".to_string())
         );
         assert_eq!(workstation_event_name_from_ws_text("not json"), None);
+        assert_eq!(
+            workstation_event_name_from_ws_text(WORKSTATION_EVENTS_PONG),
+            None
+        );
         assert_eq!(workstation_event_name_from_ws_text(r#"{"data":{}}"#), None);
+    }
+
+    #[tokio::test]
+    async fn workstation_event_ws_message_ignores_pong_and_forwards_attach_jobs() {
+        let (tx, mut rx) = mpsc::channel(1);
+
+        assert!(handle_workstation_event_ws_message(
+            WsMessage::Text(WORKSTATION_EVENTS_PONG.into()),
+            &tx,
+        )
+        .await
+        .unwrap());
+        assert!(rx.try_recv().is_err());
+
+        assert!(handle_workstation_event_ws_message(
+            WsMessage::Text(r#"{"event":"attach_jobs","data":{"job_id":"j"}}"#.into()),
+            &tx,
+        )
+        .await
+        .unwrap());
+        assert_eq!(rx.recv().await, Some(WorkstationControlEvent::AttachJobs));
     }
 
     #[test]

--- a/docs/adr/remote-workstation-doc-agents.md
+++ b/docs/adr/remote-workstation-doc-agents.md
@@ -125,28 +125,24 @@ The doc-agent control channel is not the notebook room sync channel. It is a
 workstation registration and command channel:
 
 - register/update workstation metadata;
-- heartbeat while work is active and keep idle presence through a server-sent
-  event stream;
+- heartbeat while work is active and keep idle presence through a hibernatable
+  workstation event socket;
 - advertise runtime, workspace, catalog, and environment capabilities;
-- receive "attach this workstation to room X" wakeups through the event stream,
+- receive "attach this workstation to room X" wakeups through the event socket,
   with attach-job polling as a recovery path;
 - report attachment status and provider diagnostics.
 
 Room execution still flows through a room-scoped `runtime_peer` connection.
 
-The event stream is deliberately SSE rather than a control WebSocket, and it
-replaces tight polling as the fast path. The hosted Worker and Durable Objects
-are request-sensitive: periodic polling burns one HTTP/D1 path per workstation
-per interval even when nothing is happening, while a dedicated control
-WebSocket adds another long-lived socket beside the actual room sync WebSocket.
-SSE gives each online workstation one simple HTTP stream for wakeups and idle
-presence, while preserving low-frequency polling for old server versions and
-recovery. The stream is not the durable job log: it does not use SSE
-`Last-Event-ID` replay because attach jobs already live in D1 and the agent
-claims them by polling `GET /api/workstations/:id/attach-jobs`. Adding
-`Last-Event-ID` would require a persisted per-workstation event sequence or
-replay buffer in the Durable Object; that is useful only if SSE becomes the
-source of truth rather than a wakeup signal.
+The event socket replaces tight polling as the fast path, but it is deliberately
+not the durable job log. Attach jobs already live in D1 and the agent claims
+them by polling `GET /api/workstations/:id/attach-jobs`; the socket only wakes
+the workstation when new work is likely available. The hosted Worker and Durable
+Objects are request-sensitive: periodic polling burns one HTTP/D1 path per
+workstation per interval even when nothing is happening, while an SSE response
+inside a Durable Object keeps the object active and accrues duration. The
+workstation wakeup path therefore uses a hibernatable WebSocket with no
+application timers so idle sockets can sleep between attach notifications.
 
 ## Decision 2: Providers supply workstations through adapters
 
@@ -564,7 +560,7 @@ Notebook contents flow over the room WebSocket after room authorization.
    API-key auth.
 4. **Connector skeleton.** Add a Linux-friendly `runt workstation` or
    `runtimed workstation` mode that stores an API key, registers the host,
-   maintains an outbound server-sent event stream for attach-job wakeups, and
+   maintains an outbound hibernatable event socket for attach-job wakeups, and
    reports capabilities. No notebook execution yet.
 5. **Catalog projection.** Project registered workstations into host-owned
    catalog data that can later feed PR #3380's Content rail contract, without
@@ -608,7 +604,7 @@ The smallest valuable PR should avoid kernel execution:
 - `POST /api/workstations/register` authenticated by write-capable Anaconda API
   key.
 - `POST /api/workstations` registration/heartbeat, plus
-  `GET /api/workstations/:id/events` as the attach-job wakeup stream.
+  `GET /api/workstations/:id/events` as the attach-job wakeup socket.
 - A connector command that can run on Linux and keep the target visible.
 - Tests proving API keys authenticate a principal, deployed routes do not accept
   query-scope authority, and workstation registration does not grant
@@ -745,7 +741,7 @@ sequence:
   endpoints. Registration upserts and refreshes `last_seen_at`.
 - **Connector (step 4).** The Rust `runtimed workstation-agent` service loop
   registers the workstation, keeps
-  `GET /api/workstations/:id/events` open as an SSE attach-job wakeup stream,
+  `GET /api/workstations/:id/events` open as a hibernatable attach-job wakeup socket,
   falls back to low-frequency `GET /api/workstations/:id/attach-jobs` polling,
   and spawns `runtimed cloud-runtime-agent` per job. The older
   `apps/notebook-cloud/scripts/hosted-workstation-agent.mjs` smoke remains a


### PR DESCRIPTION
## Summary
- Replace the workstation attach-job SSE wakeup path with a hibernatable Durable Object WebSocket.
- Update `runtimed workstation-agent` to connect to the same `/api/workstations/:id/events` route over `ws://`/`wss://`, while keeping attach-job polling as the durable recovery path.
- Update workstation route tests, add direct `WorkstationEvents` hibernation tests, and refresh docs/CLI copy away from the SSE model.
- Fix a date-sensitive sharing test fixture that expired on 2026-06-24 and made the full cloud suite fail on 2026-06-27.

## Validation
- `pnpm --dir apps/notebook-cloud typecheck`
- `pnpm --dir apps/notebook-cloud exec node --import tsx --test test/workstation-events.test.ts test/worker-routes.test.ts`
- `pnpm --dir apps/notebook-cloud exec node --import tsx --test test/sharing.test.ts`
- `pnpm --dir apps/notebook-cloud test`
- `cargo test -p runtimed workstation_event`
- `cargo test -p runtimed workstation`
- `cargo xtask lint --fix`
