### PR TITLE
fix(desktop): recover stale notebook relay connections

### DIFF
--- a/apps/notebook/diagnostics/App.tsx
+++ b/apps/notebook/diagnostics/App.tsx
@@ -98,10 +98,10 @@ export default function App() {
     }
   }, [busy, prepared]);
 
-  const copyToken = useCallback(async () => {
+  const copyReference = useCallback(async () => {
     if (!result) return;
     try {
-      await navigator.clipboard.writeText(result.token);
+      await navigator.clipboard.writeText(`id=${result.id}\ntoken=${result.token}`);
       setCopied(true);
       window.setTimeout(() => setCopied(false), 1600);
     } catch {
@@ -157,23 +157,30 @@ export default function App() {
               <div className="min-w-0 flex-1">
                 <h2 className="text-sm font-semibold">Upload complete</h2>
                 <p className="mt-1 text-sm text-muted-foreground">
-                  Uploaded {formatBytes(result.uploaded_bytes)}. Share this token with the
+                  Uploaded {formatBytes(result.uploaded_bytes)}. Share this reference with the
                   developer.
                 </p>
               </div>
             </div>
 
-            <div className="flex items-center gap-2 rounded-md border border-border bg-muted/40 p-2">
-              <code className="min-w-0 flex-1 select-all overflow-x-auto whitespace-nowrap px-1 text-sm">
-                {result.token}
-              </code>
+            <div className="space-y-2 rounded-md border border-border bg-muted/40 p-2">
+              <div className="grid gap-1 text-sm sm:grid-cols-[4rem_minmax(0,1fr)] sm:items-center">
+                <span className="text-xs font-medium text-muted-foreground">ID</span>
+                <code className="min-w-0 select-all overflow-x-auto whitespace-nowrap px-1 text-sm">
+                  {result.id}
+                </code>
+                <span className="text-xs font-medium text-muted-foreground">Token</span>
+                <code className="min-w-0 select-all overflow-x-auto whitespace-nowrap px-1 text-sm">
+                  {result.token}
+                </code>
+              </div>
               <button
                 type="button"
-                onClick={copyToken}
+                onClick={copyReference}
                 className="inline-flex h-8 items-center gap-2 rounded-md bg-primary px-3 text-sm font-medium text-primary-foreground hover:bg-primary/90"
               >
                 {copied ? <Check className="h-4 w-4" /> : <Copy className="h-4 w-4" />}
-                {copied ? "Copied" : "Copy"}
+                {copied ? "Copied" : "Copy reference"}
               </button>
             </div>
           </section>

--- a/apps/notebook/src/App.tsx
+++ b/apps/notebook/src/App.tsx
@@ -1587,6 +1587,16 @@ function AppContent() {
     applyNotebookPath(runtimePath);
   }, [applyNotebookPath, runtimePath]);
 
+  const reconnectRuntime = useCallback(() => {
+    setDaemonStatus({ status: "checking" });
+    host.daemon.reconnect({ force: true }).catch((e: unknown) => {
+      setDaemonStatus({
+        status: "failed",
+        error: `Reconnection failed: ${e}`,
+      });
+    });
+  }, [host]);
+
   // Title is purely a function of `ephemeral`. Untitled notebooks get
   // the `*` prefix; saved notebooks render their filename. Autosave
   // (2s quiet, 10s max) keeps the file current within seconds of any
@@ -1838,20 +1848,7 @@ function AppContent() {
         <DaemonStatusBanner
           status={daemonStatus}
           onDismiss={() => setDaemonStatus(null)}
-          onRetry={() => {
-            setDaemonStatus({ status: "checking" });
-            host.daemon
-              .reconnect()
-              .then(() => {
-                // Success - daemon:ready event will clear the banner
-              })
-              .catch((e) => {
-                setDaemonStatus({
-                  status: "failed",
-                  error: `Reconnection failed: ${e}`,
-                });
-              });
-          }}
+          onRetry={reconnectRuntime}
         />
         <PoolErrorBanner
           uvError={poolUvError}
@@ -2134,6 +2131,7 @@ function AppContent() {
                 loadError={loadError}
                 runtime={runtime}
                 sessionRuntimeState={sessionStatus?.runtime_state ?? null}
+                onReconnectRuntime={reconnectRuntime}
                 onFocusCell={handleNotebookViewFocus}
                 onExecuteCell={handleExecuteCell}
                 onInterruptKernel={interruptKernel}

--- a/apps/notebook/src/components/NotebookView.tsx
+++ b/apps/notebook/src/components/NotebookView.tsx
@@ -80,6 +80,7 @@ export interface NotebookViewProps {
   loadError?: string | null;
   runtime?: Runtime | null;
   sessionRuntimeState?: string | null;
+  onReconnectRuntime?: () => void;
   onFocusCell: (cellId: string) => void;
   onExecuteCell: (cellId: string) => void;
   onRequestExecuteCell?: (cellId: string) => void;
@@ -366,6 +367,7 @@ function NotebookViewContent({
   loadError = null,
   runtime = "python",
   sessionRuntimeState = null,
+  onReconnectRuntime,
   onFocusCell,
   onExecuteCell,
   onRequestExecuteCell,
@@ -1125,8 +1127,20 @@ function NotebookViewContent({
       data-cell-count={cellIds.length}
     >
       {loadError ? (
-        <div className="mb-4 rounded-md border border-destructive/40 bg-destructive/5 px-3 py-2 text-sm text-destructive">
-          Notebook failed to finish loading: {loadError}
+        <div className="mb-4 flex flex-wrap items-center gap-3 rounded-md border border-destructive/40 bg-destructive/5 px-3 py-2 text-sm text-destructive">
+          <span className="min-w-0 flex-1">Notebook failed to finish loading: {loadError}</span>
+          {onReconnectRuntime ? (
+            <Button
+              type="button"
+              size="sm"
+              variant="outline"
+              className="h-8 gap-1 border-destructive/30 text-destructive hover:bg-destructive/10"
+              onClick={onReconnectRuntime}
+            >
+              <RotateCcw className="size-3" />
+              Reconnect
+            </Button>
+          ) : null}
         </div>
       ) : null}
       {outputProjectionFailures.length > 0 ? (
@@ -1147,6 +1161,18 @@ function NotebookViewContent({
           <div className="flex flex-col items-center justify-center py-20 text-center text-destructive">
             <p className="text-sm font-medium">Notebook load failed</p>
             <p className="mt-1 max-w-xl text-xs text-muted-foreground">{loadError}</p>
+            {onReconnectRuntime ? (
+              <Button
+                type="button"
+                size="sm"
+                variant="outline"
+                className="mt-4 gap-1"
+                onClick={onReconnectRuntime}
+              >
+                <RotateCcw className="size-3" />
+                Reconnect runtime
+              </Button>
+            ) : null}
           </div>
         ) : (
           <div className="flex flex-col items-center justify-center py-20 text-muted-foreground">

--- a/apps/notebook/src/hooks/useAutomergeNotebook.ts
+++ b/apps/notebook/src/hooks/useAutomergeNotebook.ts
@@ -51,6 +51,7 @@ import type { JupyterOutput, NotebookCell } from "../types";
  * presence stays user-driven and Tauri remains a byte transport.
  */
 const PRESENCE_HEARTBEAT_INTERVAL_MS = 15_000;
+const BOOTSTRAP_INTERACTIVE_TIMEOUT_MS = 90_000;
 
 let loggedWasmReady = false;
 
@@ -363,6 +364,16 @@ export function useNotebook() {
       refreshCanAcceptCellMutations,
       setIsLoading,
       setLoadError,
+      bootstrapTimeoutMs: BOOTSTRAP_INTERACTIVE_TIMEOUT_MS,
+      onBootstrapTimeout: () => {
+        void host.daemon.reconnect({ force: true }).catch((error: unknown) => {
+          logger.warn(
+            "[automerge-notebook] forced reconnect after bootstrap timeout failed:",
+            error,
+          );
+          setLoadError(error instanceof Error ? error.message : String(error));
+        });
+      },
     });
 
     // ── Bootstrap / daemon lifecycle ─────────────────────────────

--- a/apps/notebook/src/lib/__tests__/notebook-sync-store-bridge.test.ts
+++ b/apps/notebook/src/lib/__tests__/notebook-sync-store-bridge.test.ts
@@ -205,6 +205,7 @@ beforeEach(() => {
 
 afterEach(() => {
   vi.clearAllMocks();
+  vi.useRealTimers();
 });
 
 describe("startNotebookSyncStoreBridge", () => {
@@ -450,6 +451,65 @@ describe("startNotebookSyncStoreBridge", () => {
 
     expect(materializeCells).toHaveBeenCalledTimes(1);
     expect(setIsLoading).toHaveBeenLastCalledWith(false);
+
+    bridge.stop();
+  });
+
+  it("reports a bootstrap timeout when interactive never arrives after readiness reset", async () => {
+    vi.useFakeTimers();
+    const onBootstrapTimeout = vi.fn();
+    const { bridge, setIsLoading, setLoadError } = startBridge({
+      bootstrapTimeoutMs: 1_000,
+      onBootstrapTimeout,
+    });
+
+    bridge.resetReadiness();
+    await vi.advanceTimersByTimeAsync(999);
+
+    expect(setLoadError).not.toHaveBeenCalled();
+    expect(onBootstrapTimeout).not.toHaveBeenCalled();
+
+    await vi.advanceTimersByTimeAsync(1);
+
+    expect(setLoadError).toHaveBeenCalledWith(expect.stringContaining("Timed out"));
+    expect(setIsLoading).toHaveBeenCalledWith(false);
+    expect(onBootstrapTimeout).toHaveBeenCalledTimes(1);
+
+    bridge.stop();
+  });
+
+  it("reports a bootstrap timeout on initial startup when interactive never arrives", async () => {
+    vi.useFakeTimers();
+    const onBootstrapTimeout = vi.fn();
+    const { bridge, setIsLoading, setLoadError } = startBridge({
+      bootstrapTimeoutMs: 1_000,
+      onBootstrapTimeout,
+    });
+
+    await vi.advanceTimersByTimeAsync(1_000);
+
+    expect(setLoadError).toHaveBeenCalledWith(expect.stringContaining("Timed out"));
+    expect(setIsLoading).toHaveBeenCalledWith(false);
+    expect(onBootstrapTimeout).toHaveBeenCalledTimes(1);
+
+    bridge.stop();
+  });
+
+  it("clears the bootstrap timeout when initial sync completes", async () => {
+    vi.useFakeTimers();
+    const onBootstrapTimeout = vi.fn();
+    const { bridge, setLoadError, subjects } = startBridge({
+      bootstrapTimeoutMs: 1_000,
+      onBootstrapTimeout,
+    });
+
+    bridge.resetReadiness();
+    subjects.initialSyncComplete$.next();
+    await flushMicrotasks();
+    await vi.advanceTimersByTimeAsync(1_000);
+
+    expect(setLoadError).not.toHaveBeenCalledWith(expect.stringContaining("Timed out"));
+    expect(onBootstrapTimeout).not.toHaveBeenCalled();
 
     bridge.stop();
   });

--- a/apps/notebook/src/lib/__tests__/notebook-sync-store-bridge.test.ts
+++ b/apps/notebook/src/lib/__tests__/notebook-sync-store-bridge.test.ts
@@ -536,6 +536,23 @@ describe("startNotebookSyncStoreBridge", () => {
     bridge.stop();
   });
 
+  it("does not report repeated bootstrap timeouts without progress or reset", async () => {
+    vi.useFakeTimers();
+    const onBootstrapTimeout = vi.fn();
+    const { bridge, subjects } = startBridge({
+      bootstrapTimeoutMs: 1_000,
+      onBootstrapTimeout,
+    });
+
+    await vi.advanceTimersByTimeAsync(1_000);
+    subjects.sessionStatus$.next(readyStatus());
+    await vi.advanceTimersByTimeAsync(2_000);
+
+    expect(onBootstrapTimeout).toHaveBeenCalledTimes(1);
+
+    bridge.stop();
+  });
+
   it("clears the bootstrap timeout when initial sync completes", async () => {
     vi.useFakeTimers();
     const onBootstrapTimeout = vi.fn();

--- a/apps/notebook/src/lib/__tests__/notebook-sync-store-bridge.test.ts
+++ b/apps/notebook/src/lib/__tests__/notebook-sync-store-bridge.test.ts
@@ -495,6 +495,47 @@ describe("startNotebookSyncStoreBridge", () => {
     bridge.stop();
   });
 
+  it("does not report a bootstrap timeout while initial load is streaming", async () => {
+    vi.useFakeTimers();
+    const onBootstrapTimeout = vi.fn();
+    const { bridge, setIsLoading, setLoadError, subjects } = startBridge({
+      bootstrapTimeoutMs: 1_000,
+      onBootstrapTimeout,
+    });
+
+    subjects.sessionStatus$.next(streamingStatus());
+    await vi.advanceTimersByTimeAsync(1_000);
+
+    expect(setLoadError).not.toHaveBeenCalledWith(expect.stringContaining("Timed out"));
+    expect(onBootstrapTimeout).not.toHaveBeenCalled();
+
+    subjects.sessionStatus$.next(readyStatus());
+    await vi.advanceTimersByTimeAsync(1_000);
+
+    expect(setLoadError).toHaveBeenCalledWith(expect.stringContaining("Timed out"));
+    expect(setIsLoading).toHaveBeenCalledWith(false);
+    expect(onBootstrapTimeout).toHaveBeenCalledTimes(1);
+
+    bridge.stop();
+  });
+
+  it("clears a bootstrap timeout error when initial sync completes afterward", async () => {
+    vi.useFakeTimers();
+    const { bridge, setLoadError, subjects } = startBridge({
+      bootstrapTimeoutMs: 1_000,
+    });
+
+    await vi.advanceTimersByTimeAsync(1_000);
+    expect(setLoadError).toHaveBeenCalledWith(expect.stringContaining("Timed out"));
+
+    subjects.initialSyncComplete$.next();
+    await flushMicrotasks();
+
+    expect(setLoadError).toHaveBeenLastCalledWith(null);
+
+    bridge.stop();
+  });
+
   it("clears the bootstrap timeout when initial sync completes", async () => {
     vi.useFakeTimers();
     const onBootstrapTimeout = vi.fn();

--- a/apps/notebook/src/lib/__tests__/notebook-sync-store-bridge.test.ts
+++ b/apps/notebook/src/lib/__tests__/notebook-sync-store-bridge.test.ts
@@ -555,6 +555,33 @@ describe("startNotebookSyncStoreBridge", () => {
     bridge.stop();
   });
 
+  it("does not re-arm bootstrap timeout while initial materialization is in flight", async () => {
+    vi.useFakeTimers();
+    const materialize = deferred();
+    const materializeCells = vi.fn(() => materialize.promise);
+    const onBootstrapTimeout = vi.fn();
+    const { bridge, setLoadError, subjects } = startBridge({
+      bootstrapTimeoutMs: 1_000,
+      materializeCells,
+      onBootstrapTimeout,
+    });
+
+    subjects.initialSyncComplete$.next();
+    await flushMicrotasks();
+    expect(materializeCells).toHaveBeenCalledTimes(1);
+
+    subjects.sessionStatus$.next(readyStatus());
+    await vi.advanceTimersByTimeAsync(1_000);
+
+    expect(setLoadError).not.toHaveBeenCalledWith(expect.stringContaining("Timed out"));
+    expect(onBootstrapTimeout).not.toHaveBeenCalled();
+
+    materialize.resolve();
+    await flushMicrotasks();
+
+    bridge.stop();
+  });
+
   it("ignores in-flight materializeCells result if stopped before it resolves", async () => {
     const materialize = deferred();
     const materializeCells = vi.fn(() => materialize.promise);

--- a/apps/notebook/src/lib/notebook-sync-store-bridge.ts
+++ b/apps/notebook/src/lib/notebook-sync-store-bridge.ts
@@ -183,19 +183,26 @@ export function startNotebookSyncStoreBridge(
           status.initial_load.reason,
         );
         initialMaterializeDeferred = false;
+        initialLoadCurrentlyStreaming = false;
         initialLoadWasStreaming = false;
         options.setLoadError(status.initial_load.reason);
         options.setIsLoading(false);
         return;
       }
 
-      options.setLoadError(null);
       const initialLoadStreaming = isInitialLoadStreaming(status.initial_load);
+      if (bootstrapTimeout !== null || interactiveReady || initialLoadStreaming) {
+        options.setLoadError(null);
+      }
       if (initialLoadStreaming) {
         initialLoadCurrentlyStreaming = true;
         initialLoadWasStreaming = true;
         clearBootstrapTimeout();
-      } else if (!interactiveReady && !initialMaterializeDeferred) {
+      } else if (
+        !interactiveReady &&
+        !initialMaterializeDeferred &&
+        !initialMaterializeInFlight
+      ) {
         initialLoadCurrentlyStreaming = false;
         ensureBootstrapTimeout();
       }

--- a/apps/notebook/src/lib/notebook-sync-store-bridge.ts
+++ b/apps/notebook/src/lib/notebook-sync-store-bridge.ts
@@ -66,21 +66,27 @@ export function startNotebookSyncStoreBridge(
   let latestSessionStatus: SessionStatus | null = null;
   let stopped = false;
   let bootstrapTimeout: ReturnType<typeof setTimeout> | null = null;
+  let bootstrapTimeoutFired = false;
   const subscription = new Subscription();
   const bootstrapTimeoutMs = options.bootstrapTimeoutMs ?? 90_000;
 
-  const clearBootstrapTimeout = () => {
-    if (bootstrapTimeout === null) return;
-    clearTimeout(bootstrapTimeout);
-    bootstrapTimeout = null;
+  const clearBootstrapTimeout = (resetFired = false) => {
+    if (bootstrapTimeout !== null) {
+      clearTimeout(bootstrapTimeout);
+      bootstrapTimeout = null;
+    }
+    if (resetFired) {
+      bootstrapTimeoutFired = false;
+    }
   };
 
   const armBootstrapTimeout = () => {
     clearBootstrapTimeout();
-    if (bootstrapTimeoutMs <= 0) return;
+    if (bootstrapTimeoutMs <= 0 || bootstrapTimeoutFired) return;
     bootstrapTimeout = setTimeout(() => {
       bootstrapTimeout = null;
       if (stopped || interactiveReady || initialLoadCurrentlyStreaming) return;
+      bootstrapTimeoutFired = true;
       logger.warn(
         `[automerge-notebook] Bootstrap timed out after ${bootstrapTimeoutMs}ms before notebook became interactive`,
       );
@@ -104,6 +110,7 @@ export function startNotebookSyncStoreBridge(
     initialLoadCurrentlyStreaming = false;
     initialLoadWasStreaming = false;
     latestSessionStatus = null;
+    bootstrapTimeoutFired = false;
     armBootstrapTimeout();
   };
 
@@ -177,7 +184,7 @@ export function startNotebookSyncStoreBridge(
       latestSessionStatus = status;
 
       if (isInitialLoadFailed(status.initial_load)) {
-        clearBootstrapTimeout();
+        clearBootstrapTimeout(true);
         logger.warn(
           "[automerge-notebook] Initial load failed:",
           status.initial_load.reason,
@@ -197,7 +204,7 @@ export function startNotebookSyncStoreBridge(
       if (initialLoadStreaming) {
         initialLoadCurrentlyStreaming = true;
         initialLoadWasStreaming = true;
-        clearBootstrapTimeout();
+        clearBootstrapTimeout(true);
       } else if (
         !interactiveReady &&
         !initialMaterializeDeferred &&
@@ -220,7 +227,7 @@ export function startNotebookSyncStoreBridge(
 
   subscription.add(
     options.engine.initialSyncComplete$.subscribe(() => {
-      clearBootstrapTimeout();
+      clearBootstrapTimeout(true);
       if (
         latestSessionStatus &&
         isInitialLoadStreaming(latestSessionStatus.initial_load)

--- a/apps/notebook/src/lib/notebook-sync-store-bridge.ts
+++ b/apps/notebook/src/lib/notebook-sync-store-bridge.ts
@@ -61,6 +61,7 @@ export function startNotebookSyncStoreBridge(
   let interactiveReady = false;
   let initialMaterializeDeferred = false;
   let initialMaterializeInFlight = false;
+  let initialLoadCurrentlyStreaming = false;
   let initialLoadWasStreaming = false;
   let latestSessionStatus: SessionStatus | null = null;
   let stopped = false;
@@ -79,7 +80,7 @@ export function startNotebookSyncStoreBridge(
     if (bootstrapTimeoutMs <= 0) return;
     bootstrapTimeout = setTimeout(() => {
       bootstrapTimeout = null;
-      if (stopped || interactiveReady) return;
+      if (stopped || interactiveReady || initialLoadCurrentlyStreaming) return;
       logger.warn(
         `[automerge-notebook] Bootstrap timed out after ${bootstrapTimeoutMs}ms before notebook became interactive`,
       );
@@ -91,9 +92,16 @@ export function startNotebookSyncStoreBridge(
     }, bootstrapTimeoutMs);
   };
 
+  const ensureBootstrapTimeout = () => {
+    if (bootstrapTimeout !== null) return;
+    armBootstrapTimeout();
+  };
+
   const resetReadiness = () => {
+    if (stopped) return;
     interactiveReady = false;
     initialMaterializeDeferred = false;
+    initialLoadCurrentlyStreaming = false;
     initialLoadWasStreaming = false;
     latestSessionStatus = null;
     armBootstrapTimeout();
@@ -133,6 +141,7 @@ export function startNotebookSyncStoreBridge(
         if (options.getHandle() !== handle) return;
         interactiveReady = true;
         initialMaterializeDeferred = false;
+        initialLoadCurrentlyStreaming = false;
         initialLoadWasStreaming = false;
         const cellIdList = [...handle.get_cell_ids()];
         // `initialSyncComplete$` fires when the notebook doc is interactive,
@@ -145,6 +154,7 @@ export function startNotebookSyncStoreBridge(
         );
         seedOutputStoresFromHandle(handle, cellIdList);
         options.refreshCanAcceptCellMutations(handle);
+        options.setLoadError(null);
         options.setIsLoading(
           latestSessionStatus
             ? isInitialLoadStreaming(latestSessionStatus.initial_load)
@@ -180,19 +190,23 @@ export function startNotebookSyncStoreBridge(
       }
 
       options.setLoadError(null);
-      if (isInitialLoadStreaming(status.initial_load)) {
+      const initialLoadStreaming = isInitialLoadStreaming(status.initial_load);
+      if (initialLoadStreaming) {
+        initialLoadCurrentlyStreaming = true;
         initialLoadWasStreaming = true;
+        clearBootstrapTimeout();
+      } else if (!interactiveReady && !initialMaterializeDeferred) {
+        initialLoadCurrentlyStreaming = false;
+        ensureBootstrapTimeout();
       }
       options.refreshCanAcceptCellMutations();
-      if (
-        initialMaterializeDeferred &&
-        !isInitialLoadStreaming(status.initial_load)
-      ) {
+      if (initialMaterializeDeferred && !initialLoadStreaming) {
+        initialLoadCurrentlyStreaming = false;
         runInitialMaterialize();
         return;
       }
       if (interactiveReady) {
-        options.setIsLoading(isInitialLoadStreaming(status.initial_load));
+        options.setIsLoading(initialLoadStreaming);
       }
     }),
   );

--- a/apps/notebook/src/lib/notebook-sync-store-bridge.ts
+++ b/apps/notebook/src/lib/notebook-sync-store-bridge.ts
@@ -46,6 +46,8 @@ export interface NotebookSyncStoreBridgeOptions {
   refreshCanAcceptCellMutations: (handle?: NotebookHandle) => boolean;
   setIsLoading: (isLoading: boolean) => void;
   setLoadError: (loadError: string | null) => void;
+  bootstrapTimeoutMs?: number;
+  onBootstrapTimeout?: () => void;
 }
 
 export interface NotebookSyncStoreBridge {
@@ -62,13 +64,39 @@ export function startNotebookSyncStoreBridge(
   let initialLoadWasStreaming = false;
   let latestSessionStatus: SessionStatus | null = null;
   let stopped = false;
+  let bootstrapTimeout: ReturnType<typeof setTimeout> | null = null;
   const subscription = new Subscription();
+  const bootstrapTimeoutMs = options.bootstrapTimeoutMs ?? 90_000;
+
+  const clearBootstrapTimeout = () => {
+    if (bootstrapTimeout === null) return;
+    clearTimeout(bootstrapTimeout);
+    bootstrapTimeout = null;
+  };
+
+  const armBootstrapTimeout = () => {
+    clearBootstrapTimeout();
+    if (bootstrapTimeoutMs <= 0) return;
+    bootstrapTimeout = setTimeout(() => {
+      bootstrapTimeout = null;
+      if (stopped || interactiveReady) return;
+      logger.warn(
+        `[automerge-notebook] Bootstrap timed out after ${bootstrapTimeoutMs}ms before notebook became interactive`,
+      );
+      options.setLoadError(
+        "Timed out waiting for notebook sync to become interactive. Reconnecting runtime...",
+      );
+      options.setIsLoading(false);
+      options.onBootstrapTimeout?.();
+    }, bootstrapTimeoutMs);
+  };
 
   const resetReadiness = () => {
     interactiveReady = false;
     initialMaterializeDeferred = false;
     initialLoadWasStreaming = false;
     latestSessionStatus = null;
+    armBootstrapTimeout();
   };
 
   const runInitialMaterialize = () => {
@@ -139,6 +167,7 @@ export function startNotebookSyncStoreBridge(
       latestSessionStatus = status;
 
       if (isInitialLoadFailed(status.initial_load)) {
+        clearBootstrapTimeout();
         logger.warn(
           "[automerge-notebook] Initial load failed:",
           status.initial_load.reason,
@@ -170,6 +199,7 @@ export function startNotebookSyncStoreBridge(
 
   subscription.add(
     options.engine.initialSyncComplete$.subscribe(() => {
+      clearBootstrapTimeout();
       if (
         latestSessionStatus &&
         isInitialLoadStreaming(latestSessionStatus.initial_load)
@@ -255,10 +285,13 @@ export function startNotebookSyncStoreBridge(
     options.engine.poolState$.subscribe((state) => setPoolState(state)),
   );
 
+  armBootstrapTimeout();
+
   return {
     resetReadiness,
     stop() {
       stopped = true;
+      clearBootstrapTimeout();
       subscription.unsubscribe();
     },
   };

--- a/crates/notebook-sync/src/connect.rs
+++ b/crates/notebook-sync/src/connect.rs
@@ -802,6 +802,8 @@ where
         cmd_rx,
         frame_tx,
         notebook_id: notebook_id.clone(),
+        #[cfg(test)]
+        heartbeat_interval: None,
     };
 
     tokio::spawn(async move {

--- a/crates/notebook-sync/src/relay.rs
+++ b/crates/notebook-sync/src/relay.rs
@@ -1,12 +1,14 @@
 //! `RelayHandle` — transparent byte pipe between a frontend (WASM) and the daemon.
 //!
 //! Unlike [`DocHandle`](crate::DocHandle), the relay does not maintain a local
-//! Automerge document replica. It does not participate in the sync protocol —
-//! the frontend owns the sync state and the relay just forwards bytes.
+//! Automerge document replica. It does not participate in the Automerge sync
+//! protocol — the frontend owns sync state and the relay forwards bytes, plus
+//! a native presence heartbeat for desktop liveness.
 //!
 //! This eliminates the "dual sync" problem where both the relay and the WASM
 //! generate sync messages on the same daemon connection. The relay never owns
-//! bootstrap or readiness heuristics; it only forwards daemon frames.
+//! bootstrap or readiness heuristics; it only owns socket forwarding and relay
+//! liveness.
 //!
 //! ## API surface
 //!

--- a/crates/notebook-sync/src/relay_task.rs
+++ b/crates/notebook-sync/src/relay_task.rs
@@ -477,6 +477,35 @@ mod tests {
         (handle, daemon_read, daemon_write)
     }
 
+    async fn spawn_relay_for_test_with_heartbeat_interval_and_frame_rx(
+        heartbeat_interval: Duration,
+    ) -> (
+        crate::relay::RelayHandle,
+        tokio::io::ReadHalf<tokio::io::DuplexStream>,
+        tokio::io::WriteHalf<tokio::io::DuplexStream>,
+        mpsc::UnboundedReceiver<Vec<u8>>,
+    ) {
+        let (client, daemon) = tokio::io::duplex(64 * 1024);
+        let (client_read, client_write) = tokio::io::split(client);
+        let (daemon_read, daemon_write) = tokio::io::split(daemon);
+        let (cmd_tx, cmd_rx) = mpsc::channel(8);
+        let (frame_tx, frame_rx) = mpsc::unbounded_channel();
+        let handle = crate::relay::RelayHandle::new(cmd_tx, "notebook-test".to_string());
+
+        tokio::spawn(run(
+            RelayTaskConfig {
+                cmd_rx,
+                frame_tx,
+                notebook_id: "notebook-test".to_string(),
+                heartbeat_interval: Some(heartbeat_interval),
+            },
+            client_read,
+            client_write,
+        ));
+
+        (handle, daemon_read, daemon_write, frame_rx)
+    }
+
     async fn recv_request_for_test(
         daemon_read: &mut tokio::io::ReadHalf<tokio::io::DuplexStream>,
     ) -> NotebookRequestEnvelope {
@@ -507,6 +536,53 @@ mod tests {
     async fn relay_task_sends_native_presence_heartbeat() {
         let (_handle, mut daemon_read, _daemon_write) =
             spawn_relay_for_test_with_heartbeat_interval(Duration::from_millis(5)).await;
+
+        let frame = tokio::time::timeout(
+            Duration::from_millis(100),
+            connection::recv_typed_frame(&mut daemon_read),
+        )
+        .await
+        .expect("heartbeat frame timed out")
+        .expect("read heartbeat frame")
+        .expect("heartbeat frame");
+
+        assert_eq!(frame.frame_type, NotebookFrameType::Presence);
+        let message =
+            notebook_doc::presence::decode_message(&frame.payload).expect("decode heartbeat");
+        assert!(matches!(
+            message,
+            notebook_doc::presence::PresenceMessage::Heartbeat { peer_id } if peer_id == "local"
+        ));
+    }
+
+    #[tokio::test]
+    async fn relay_task_sends_heartbeat_after_piping_inbound_frames() {
+        let (_handle, mut daemon_read, mut daemon_write, mut frame_rx) =
+            spawn_relay_for_test_with_heartbeat_interval_and_frame_rx(Duration::from_millis(5))
+                .await;
+
+        let remote_payload =
+            notebook_doc::presence::encode_heartbeat("remote").expect("encode remote heartbeat");
+        for _ in 0..5 {
+            connection::send_typed_frame(
+                &mut daemon_write,
+                NotebookFrameType::Presence,
+                &remote_payload,
+            )
+            .await
+            .expect("send inbound presence frame");
+        }
+
+        for _ in 0..5 {
+            let frame = tokio::time::timeout(Duration::from_millis(100), frame_rx.recv())
+                .await
+                .expect("relayed frame timed out")
+                .expect("relayed frame");
+            assert_eq!(
+                frame.first().copied(),
+                Some(NotebookFrameType::Presence as u8)
+            );
+        }
 
         let frame = tokio::time::timeout(
             Duration::from_millis(100),

--- a/crates/notebook-sync/src/relay_task.rs
+++ b/crates/notebook-sync/src/relay_task.rs
@@ -1,14 +1,17 @@
 //! Relay task — transparent byte pipe between frontend (WASM) and daemon.
 //!
 //! Unlike the sync task, the relay does not maintain a local Automerge document.
-//! It does not participate in the sync protocol — the frontend owns the sync
-//! state and the relay just forwards bytes in both directions.
+//! It does not participate in the Automerge sync protocol — the frontend owns
+//! sync state and the relay forwards bytes in both directions, plus a native
+//! presence heartbeat so host liveness does not depend on WebKit timers.
 //!
 //! ## Select loop
 //!
-//! Two arms:
+//! Three arms:
 //! 1. **Commands** from `RelayHandle` — send requests, forward frames
 //! 2. **Incoming daemon frames** — route via pending map or pipe to frontend
+//! 3. **Heartbeat** — send a native presence heartbeat to keep live desktop
+//!    relay sockets from being mistaken for orphaned browser peers
 //!
 //! ## Request/response correlation
 //!
@@ -46,6 +49,11 @@ use notebook_protocol::protocol::{
 use crate::error::SyncError;
 use crate::relay::RelayCommand;
 
+/// Native heartbeat for relay clients (desktop/Tauri) so WebKit timer
+/// throttling cannot make a live app look idle to the daemon.
+const RELAY_HEARTBEAT_INTERVAL: Duration =
+    Duration::from_millis(notebook_doc::presence::DEFAULT_HEARTBEAT_MS);
+
 /// Configuration for the relay task.
 pub struct RelayTaskConfig {
     /// Receives commands from `RelayHandle` (send_request, forward_frame).
@@ -57,6 +65,9 @@ pub struct RelayTaskConfig {
 
     /// The notebook identifier (for logging).
     pub notebook_id: String,
+
+    #[cfg(test)]
+    pub heartbeat_interval: Option<Duration>,
 }
 
 /// A Rust-side caller awaiting a response for a specific correlation id.
@@ -80,6 +91,7 @@ where
 
     let notebook_id = &config.notebook_id;
     let mut pending: HashMap<String, PendingEntry> = HashMap::new();
+    let relay_heartbeat_interval = relay_heartbeat_interval(&config);
 
     info!("[relay] Started for {}", notebook_id);
 
@@ -92,15 +104,22 @@ where
     // BufReader stays for syscall coalescing inside the actor task.
     let buffered = tokio::io::BufReader::new(reader);
     let mut framed_reader = connection::FramedReader::spawn(buffered, 16);
+    let mut heartbeat = tokio::time::interval_at(
+        tokio::time::Instant::now() + relay_heartbeat_interval,
+        relay_heartbeat_interval,
+    );
+    heartbeat.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
 
     loop {
         enum SelectResult {
             Command(Option<RelayCommand>),
             Frame(Option<std::io::Result<connection::TypedNotebookFrame>>),
+            Heartbeat,
         }
 
         let select_result = tokio::select! {
             biased;
+            _ = heartbeat.tick() => SelectResult::Heartbeat,
             // Prioritize incoming daemon frames (sync, broadcast, presence,
             // responses) over outgoing commands. Keeping frames flowing
             // prevents head divergence; commands can wait a tick.
@@ -182,6 +201,16 @@ where
                 info!("[relay] Daemon closed connection for {}", notebook_id);
                 break;
             }
+
+            SelectResult::Heartbeat => {
+                if let Err(e) = send_relay_heartbeat(&mut writer).await {
+                    warn!(
+                        "[relay] Failed to send heartbeat for {}: {}",
+                        notebook_id, e
+                    );
+                    break;
+                }
+            }
         }
     }
 
@@ -192,6 +221,26 @@ where
     }
 
     info!("[relay] Stopped for {}", notebook_id);
+}
+
+fn relay_heartbeat_interval(_config: &RelayTaskConfig) -> Duration {
+    #[cfg(test)]
+    if let Some(interval) = _config.heartbeat_interval {
+        return interval;
+    }
+
+    RELAY_HEARTBEAT_INTERVAL
+}
+
+async fn send_relay_heartbeat<W: AsyncWrite + Unpin>(writer: &mut W) -> Result<(), SyncError> {
+    // Match the existing frontend/full-peer heartbeat identity. The daemon's
+    // idle deadline is per socket and only needs an inbound Presence frame; it
+    // is not keyed by this transient UX peer id.
+    let payload = notebook_doc::presence::encode_heartbeat("local")
+        .map_err(|e| SyncError::Protocol(format!("encode heartbeat: {e}")))?;
+    connection::send_typed_frame(writer, NotebookFrameType::Presence, &payload)
+        .await
+        .map_err(SyncError::Io)
 }
 
 /// Register a Rust-side PutBlob request in the pending map and write the binary
@@ -393,6 +442,35 @@ mod tests {
                 cmd_rx,
                 frame_tx,
                 notebook_id: "notebook-test".to_string(),
+                heartbeat_interval: None,
+            },
+            client_read,
+            client_write,
+        ));
+
+        (handle, daemon_read, daemon_write)
+    }
+
+    async fn spawn_relay_for_test_with_heartbeat_interval(
+        heartbeat_interval: Duration,
+    ) -> (
+        crate::relay::RelayHandle,
+        tokio::io::ReadHalf<tokio::io::DuplexStream>,
+        tokio::io::WriteHalf<tokio::io::DuplexStream>,
+    ) {
+        let (client, daemon) = tokio::io::duplex(64 * 1024);
+        let (client_read, client_write) = tokio::io::split(client);
+        let (daemon_read, daemon_write) = tokio::io::split(daemon);
+        let (cmd_tx, cmd_rx) = mpsc::channel(8);
+        let (frame_tx, _frame_rx) = mpsc::unbounded_channel();
+        let handle = crate::relay::RelayHandle::new(cmd_tx, "notebook-test".to_string());
+
+        tokio::spawn(run(
+            RelayTaskConfig {
+                cmd_rx,
+                frame_tx,
+                notebook_id: "notebook-test".to_string(),
+                heartbeat_interval: Some(heartbeat_interval),
             },
             client_read,
             client_write,
@@ -425,6 +503,29 @@ mod tests {
         )
         .await
         .expect("send response");
+    }
+
+    #[tokio::test]
+    async fn relay_task_sends_native_presence_heartbeat() {
+        let (_handle, mut daemon_read, _daemon_write) =
+            spawn_relay_for_test_with_heartbeat_interval(Duration::from_millis(5)).await;
+
+        let frame = tokio::time::timeout(
+            Duration::from_millis(100),
+            connection::recv_typed_frame(&mut daemon_read),
+        )
+        .await
+        .expect("heartbeat frame timed out")
+        .expect("read heartbeat frame")
+        .expect("heartbeat frame");
+
+        assert_eq!(frame.frame_type, NotebookFrameType::Presence);
+        let message =
+            notebook_doc::presence::decode_message(&frame.payload).expect("decode heartbeat");
+        assert!(matches!(
+            message,
+            notebook_doc::presence::PresenceMessage::Heartbeat { peer_id } if peer_id == "local"
+        ));
     }
 
     #[tokio::test]

--- a/crates/notebook-sync/src/relay_task.rs
+++ b/crates/notebook-sync/src/relay_task.rs
@@ -118,12 +118,10 @@ where
         }
 
         let select_result = tokio::select! {
-            biased;
-            _ = heartbeat.tick() => SelectResult::Heartbeat,
-            // Prioritize incoming daemon frames (sync, broadcast, presence,
-            // responses) over outgoing commands. Keeping frames flowing
-            // prevents head divergence; commands can wait a tick.
+            // Keep daemon frames flowing while still allowing the native
+            // heartbeat through during sustained inbound traffic.
             frame = framed_reader.recv() => SelectResult::Frame(frame),
+            _ = heartbeat.tick() => SelectResult::Heartbeat,
             cmd = config.cmd_rx.recv() => SelectResult::Command(cmd),
         };
 

--- a/crates/notebook/src/lib.rs
+++ b/crates/notebook/src/lib.rs
@@ -2772,12 +2772,14 @@ fn is_daemon_dead_error(error: &str) -> bool {
 #[tauri::command]
 async fn reconnect_to_daemon(
     window: tauri::Window,
+    force: Option<bool>,
     app: tauri::AppHandle,
     registry: tauri::State<'_, WindowNotebookRegistry>,
     reconnect_in_progress: tauri::State<'_, ReconnectInProgress>,
     restart_in_progress: tauri::State<'_, DaemonRestartInProgress>,
 ) -> Result<(), String> {
     info!("[daemon-kernel] reconnect_to_daemon");
+    let force = force.unwrap_or(false);
 
     let notebook_sync = notebook_sync_for_window(&window, registry.inner())?;
     let sync_generation = sync_generation_for_window(&window, registry.inner())?;
@@ -2804,13 +2806,18 @@ async fn reconnect_to_daemon(
     // Helper to reset flag on all exit paths
     let reset_flag = || reconnect_in_progress.0.store(false, Ordering::SeqCst);
 
-    // Check if already connected
+    // Check if already connected. Manual recovery from a stuck bootstrap can
+    // force a fresh relay generation even when the old Rust handle is still
+    // present but the frontend never reached interactive.
     {
-        let sync_guard = notebook_sync.lock().await;
-        if sync_guard.is_some() {
+        let mut sync_guard = notebook_sync.lock().await;
+        if sync_guard.is_some() && !force {
             info!("[daemon-kernel] Already connected to daemon");
             reset_flag();
             return Ok(());
+        }
+        if sync_guard.take().is_some() {
+            info!("[daemon-kernel] Dropped existing relay handle for forced reconnect");
         }
     }
 

--- a/crates/notebook/src/lib.rs
+++ b/crates/notebook/src/lib.rs
@@ -20,7 +20,7 @@ use notebook_sync::RelayHandle;
 
 use log::{debug, info, warn};
 use serde::Serialize;
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use std::ffi::OsStr;
 
 /// Shared notebook sync handle for cross-window state synchronization.
@@ -154,8 +154,8 @@ impl WindowNotebookRegistry {
     }
 }
 
-/// Newtype wrapper for reconnect-in-progress flag (distinguishes from other AtomicBool states).
-struct ReconnectInProgress(Arc<AtomicBool>);
+/// Per-window reconnect guard (distinguishes from app-global restart state).
+struct ReconnectInProgress(Arc<Mutex<HashSet<String>>>);
 
 /// Newtype wrapper for daemon-restart-in-progress flag.
 /// Prevents multiple windows from attempting to restart the daemon simultaneously.
@@ -2793,18 +2793,48 @@ async fn reconnect_to_daemon(
         .map_err(|e| e.to_string())?
         .clone();
 
-    // Use atomic compare_exchange to ensure only one reconnect runs at a time
-    if reconnect_in_progress
-        .0
-        .compare_exchange(false, true, Ordering::SeqCst, Ordering::SeqCst)
-        .is_err()
-    {
-        info!("[daemon-kernel] Reconnect already in progress, skipping");
-        return Ok(());
+    let window_label = window.label().to_string();
+
+    let acquire_reconnect_slot = || -> Result<bool, String> {
+        let mut active = reconnect_in_progress.0.lock().map_err(|e| e.to_string())?;
+        Ok(active.insert(window_label.clone()))
+    };
+
+    // Serialize reconnects per window. Different desktop windows can recover
+    // independently, but a single stale relay should not have duplicate
+    // reconnect attempts racing each other.
+    // Forced reconnects are recovery paths for stale-but-present relay handles,
+    // so they must not be silently dropped behind a weaker in-flight reconnect.
+    if !acquire_reconnect_slot()? {
+        if !force {
+            info!("[daemon-kernel] Reconnect already in progress, skipping");
+            return Ok(());
+        }
+
+        let mut acquired = false;
+        for _ in 0..20 {
+            tokio::time::sleep(std::time::Duration::from_millis(100)).await;
+            if acquire_reconnect_slot()? {
+                acquired = true;
+                break;
+            }
+        }
+
+        if !acquired {
+            return Err(format!(
+                "Forced reconnect timed out waiting for active reconnect for '{}'",
+                window_label
+            ));
+        }
     }
 
     // Helper to reset flag on all exit paths
-    let reset_flag = || reconnect_in_progress.0.store(false, Ordering::SeqCst);
+    let reset_flag = || match reconnect_in_progress.0.lock() {
+        Ok(mut active) => {
+            active.remove(&window_label);
+        }
+        Err(e) => warn!("[daemon-kernel] Failed to reset reconnect guard: {}", e),
+    };
 
     // Check if already connected. Manual recovery from a stuck bootstrap can
     // force a fresh relay generation even when the old Rust handle is still
@@ -3979,7 +4009,7 @@ pub fn run(
     );
 
     // Guard against concurrent reconnect attempts
-    let reconnect_in_progress = ReconnectInProgress(Arc::new(AtomicBool::new(false)));
+    let reconnect_in_progress = ReconnectInProgress(Arc::new(Mutex::new(HashSet::new())));
 
     // Guard against multiple windows trying to restart daemon simultaneously
     let restart_in_progress = DaemonRestartInProgress(Arc::new(AtomicBool::new(false)));

--- a/packages/notebook-host/src/tauri/index.ts
+++ b/packages/notebook-host/src/tauri/index.ts
@@ -104,9 +104,9 @@ function listenWebview<T>(eventName: string, cb: (payload: T) => void): Unlisten
 export function createTauriHost(opts: CreateTauriHostOptions = {}): NotebookHost {
   const transport = opts.transport ?? new TauriTransport();
   let reconnectPromise: Promise<void> | null = null;
-  const reconnectDaemon = (): Promise<void> => {
+  const reconnectDaemon = (force = false): Promise<void> => {
     if (reconnectPromise) return reconnectPromise;
-    reconnectPromise = invoke<void>("reconnect_to_daemon").finally(() => {
+    reconnectPromise = invoke<void>("reconnect_to_daemon", { force }).finally(() => {
       reconnectPromise = null;
     });
     return reconnectPromise;
@@ -120,8 +120,8 @@ export function createTauriHost(opts: CreateTauriHostOptions = {}): NotebookHost
         return false;
       }
     },
-    async reconnect() {
-      await reconnectDaemon();
+    async reconnect(options) {
+      await reconnectDaemon(options?.force === true);
     },
     async getInfo() {
       return invoke<DaemonInfo | null>("get_daemon_info");
@@ -208,7 +208,7 @@ export function createTauriHost(opts: CreateTauriHostOptions = {}): NotebookHost
     onDisconnected: (cb) =>
       listenWebview<void>("daemon:disconnected", () => {
         cb();
-        reconnectDaemon().catch(() => {});
+        reconnectDaemon(true).catch(() => {});
       }),
     onUnavailable: (cb) => listenWebview<DaemonUnavailablePayload>("daemon:unavailable", cb),
   };

--- a/packages/notebook-host/src/tauri/index.ts
+++ b/packages/notebook-host/src/tauri/index.ts
@@ -103,13 +103,24 @@ function listenWebview<T>(eventName: string, cb: (payload: T) => void): Unlisten
 
 export function createTauriHost(opts: CreateTauriHostOptions = {}): NotebookHost {
   const transport = opts.transport ?? new TauriTransport();
-  let reconnectPromise: Promise<void> | null = null;
-  const reconnectDaemon = (force = false): Promise<void> => {
-    if (reconnectPromise) return reconnectPromise;
-    reconnectPromise = invoke<void>("reconnect_to_daemon", { force }).finally(() => {
-      reconnectPromise = null;
+  let reconnectInFlight: { promise: Promise<void>; force: boolean } | null = null;
+  const startReconnect = (force: boolean): Promise<void> => {
+    const promise = invoke<void>("reconnect_to_daemon", { force }).finally(() => {
+      if (reconnectInFlight?.promise === promise) {
+        reconnectInFlight = null;
+      }
     });
-    return reconnectPromise;
+    reconnectInFlight = { promise, force };
+    return promise;
+  };
+  const reconnectDaemon = (force = false): Promise<void> => {
+    const active = reconnectInFlight;
+    if (!active) return startReconnect(force);
+    if (!force || active.force) return active.promise;
+
+    const escalated = active.promise.catch(() => undefined).then(() => startReconnect(true));
+    reconnectInFlight = { promise: escalated, force: true };
+    return escalated;
   };
 
   const daemon: HostDaemon = {

--- a/packages/notebook-host/src/types.ts
+++ b/packages/notebook-host/src/types.ts
@@ -117,8 +117,8 @@ export type Unlisten = () => void;
 export interface HostDaemon {
   /** Fast synchronous-ish check; returns false when the daemon socket is down. */
   isConnected(): Promise<boolean>;
-  /** Forces a reconnect; resolves when the relay task has a fresh socket. */
-  reconnect(): Promise<void>;
+  /** Reconnects the relay; `force` drops an existing stale handle first. */
+  reconnect(options?: { force?: boolean }): Promise<void>;
   /** Daemon diagnostics for banners / debug UI. */
   getInfo(): Promise<DaemonInfo | null>;
   /**

--- a/packages/notebook-host/tests/tauri-host.test.ts
+++ b/packages/notebook-host/tests/tauri-host.test.ts
@@ -208,6 +208,41 @@ describe("createTauriHost()", () => {
     });
   });
 
+  it("queues a forced reconnect behind an in-flight non-forced reconnect", async () => {
+    const host = createTauriHost({ transport: stubTransport });
+    let resolveReconnect!: () => void;
+    reconnectPromiseOverride = new Promise((resolve) => {
+      resolveReconnect = () => resolve(undefined);
+    });
+
+    const nonForced = host.daemon.reconnect();
+    await Promise.resolve();
+    const forced = host.daemon.reconnect({ force: true });
+    await Promise.resolve();
+
+    expect(capturedInvokes.filter((x) => x.cmd === "reconnect_to_daemon")).toEqual([
+      {
+        cmd: "reconnect_to_daemon",
+        args: { force: false },
+      },
+    ]);
+
+    reconnectPromiseOverride = null;
+    resolveReconnect();
+    await Promise.all([nonForced, forced]);
+
+    expect(capturedInvokes.filter((x) => x.cmd === "reconnect_to_daemon")).toEqual([
+      {
+        cmd: "reconnect_to_daemon",
+        args: { force: false },
+      },
+      {
+        cmd: "reconnect_to_daemon",
+        args: { force: true },
+      },
+    ]);
+  });
+
   it("routes daemon.getInfo to get_daemon_info and passes the payload through", async () => {
     const host = createTauriHost({ transport: stubTransport });
     const info = await host.daemon.getInfo();

--- a/packages/notebook-host/tests/tauri-host.test.ts
+++ b/packages/notebook-host/tests/tauri-host.test.ts
@@ -196,6 +196,16 @@ describe("createTauriHost()", () => {
     const host = createTauriHost({ transport: stubTransport });
     await host.daemon.reconnect();
     expect(capturedInvokes.at(-1)?.cmd).toBe("reconnect_to_daemon");
+    expect(capturedInvokes.at(-1)?.args).toEqual({ force: false });
+  });
+
+  it("passes force through daemon.reconnect for stuck relay recovery", async () => {
+    const host = createTauriHost({ transport: stubTransport });
+    await host.daemon.reconnect({ force: true });
+    expect(capturedInvokes.at(-1)).toEqual({
+      cmd: "reconnect_to_daemon",
+      args: { force: true },
+    });
   });
 
   it("routes daemon.getInfo to get_daemon_info and passes the payload through", async () => {
@@ -453,7 +463,12 @@ describe("createTauriHost()", () => {
 
     expect(first).toHaveBeenCalledTimes(1);
     expect(second).toHaveBeenCalledTimes(1);
-    expect(capturedInvokes.filter((x) => x.cmd === "reconnect_to_daemon")).toHaveLength(1);
+    expect(capturedInvokes.filter((x) => x.cmd === "reconnect_to_daemon")).toEqual([
+      {
+        cmd: "reconnect_to_daemon",
+        args: { force: true },
+      },
+    ]);
 
     resolveReconnect();
     await reconnectPromiseOverride;


### PR DESCRIPTION
## Summary

- Keep desktop relay sockets alive from the Rust relay task with a native presence heartbeat, so WebKit timer throttling does not make a live desktop window look idle to the daemon.
- Add forced reconnect recovery when bootstrap readiness stalls or the host receives `daemon:disconnected`, including a reconnect action in notebook load-error UI.
- Show and copy both diagnostics upload ID and token after log submission.

## Notes

This keeps daemon idle-peer cleanup in place for truly orphaned connections. The new heartbeat is owned by the relay socket task, not by an extra `RelayHandle` clone, so the heartbeat does not keep a disconnected relay alive by itself.

## Verification

- `cargo test -p notebook-sync relay_task::`
- `cargo check -p notebook`
- `/Users/kylekelley/Library/pnpm/pnpm --dir apps/notebook exec tsc -b`
- `/Users/kylekelley/Library/pnpm/pnpm test:run packages/notebook-host/tests/tauri-host.test.ts apps/notebook/src/lib/__tests__/notebook-sync-store-bridge.test.ts`
- `cargo xtask lint --fix`
- `cargo test -p runtimed --test integration test_pipe_mode_preserves_initial_session_status_frame`
- `cargo test -p runtimed --test integration test_uuid_joiner_receives_existing_cells_after_relay_loader`
- `git diff --check`
