### PR TITLE
fix(cloud): add budget guardrails

### DIFF
--- a/apps/notebook-cloud/README.md
+++ b/apps/notebook-cloud/README.md
@@ -631,6 +631,21 @@ pnpm --workspace-root exec wrangler tail nteract-notebook-cloud \
   --format pretty
 ```
 
+Check deployed Worker and Durable Object usage with:
+
+```bash
+CLOUDFLARE_ACCOUNT_ID=... \
+pnpm --dir apps/notebook-cloud run ops:cloudflare:usage -- \
+  --hours 24 \
+  --request-warn 50000 \
+  --do-duration-warn-seconds 3600
+```
+
+The main Worker serves static assets from `dist/` with asset-first routing. Do
+not enable `assets.run_worker_first=true` unless a path truly needs Worker
+logic before asset delivery; otherwise every bundle/chunk fetch becomes Worker
+execution instead of free static asset traffic.
+
 Useful events while debugging collaboration:
 
 - `room.connection.accepted` / `room.connection.closed` - peer lifecycle and

--- a/apps/notebook-cloud/README.md
+++ b/apps/notebook-cloud/README.md
@@ -645,6 +645,8 @@ The main Worker serves static assets from `dist/` with asset-first routing. Do
 not enable `assets.run_worker_first=true` unless a path truly needs Worker
 logic before asset delivery; otherwise every bundle/chunk fetch becomes Worker
 execution instead of free static asset traffic.
+The usage command queries Cloudflare's live GraphQL analytics schema and should
+fail loudly if Cloudflare renames or removes a metric.
 
 Useful events while debugging collaboration:
 

--- a/apps/notebook-cloud/package.json
+++ b/apps/notebook-cloud/package.json
@@ -12,6 +12,7 @@
     "deploy:main": "node scripts/deploy-main.mjs",
     "deploy:renderer-assets": "wrangler deploy -c wrangler.renderer-assets.toml",
     "deploy:check": "curl -fsS https://preview.runt.run/api/health",
+    "ops:cloudflare:usage": "node scripts/cloudflare-usage.mjs --script nteract-notebook-cloud --script nteract-notebook-cloud-assets",
     "auth:preview:health": "node scripts/preview-auth-health.mjs",
     "pretypecheck": "cargo xtask wasm-ensure-runtime",
     "typecheck": "tsc -p tsconfig.json --noEmit",

--- a/apps/notebook-cloud/scripts/cloudflare-usage.mjs
+++ b/apps/notebook-cloud/scripts/cloudflare-usage.mjs
@@ -1,0 +1,331 @@
+#!/usr/bin/env node
+
+import { readFile } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+
+const GRAPHQL_ENDPOINT = "https://api.cloudflare.com/client/v4/graphql";
+const API_ENDPOINT = "https://api.cloudflare.com/client/v4";
+const DEFAULT_HOURS = 24;
+
+const options = parseArgs(process.argv.slice(2));
+const accountId = options.accountId ?? process.env.CLOUDFLARE_ACCOUNT_ID;
+if (!accountId) {
+  fail("Set CLOUDFLARE_ACCOUNT_ID or pass --account-id <id>.");
+}
+
+const token = await cloudflareToken();
+if (!token) {
+  fail("Set CLOUDFLARE_API_TOKEN or run `wrangler login` first.");
+}
+
+const now = new Date();
+const windowMs = options.minutes * 60 * 1000;
+const start = new Date(now.getTime() - windowMs);
+const scripts = options.scripts.length > 0 ? options.scripts : ["nteract-notebook-cloud"];
+
+const [namespaces, workerReports, durableObjects] = await Promise.all([
+  durableObjectNamespaces(accountId, token),
+  Promise.all(scripts.map((script) => workerUsage(accountId, token, script, start, now))),
+  durableObjectUsage(accountId, token, start, now),
+]);
+
+console.log(
+  JSON.stringify(
+    {
+      window: {
+        start: start.toISOString(),
+        end: now.toISOString(),
+        hours: options.minutes / 60,
+        minutes: options.minutes,
+      },
+      workers: workerReports,
+      durable_objects: durableObjects.map((item) => ({
+        ...item,
+        namespace: namespaces.get(item.namespace_id) ?? null,
+      })),
+    },
+    null,
+    2,
+  ),
+);
+
+let warned = false;
+for (const report of workerReports) {
+  if (options.requestWarn !== null && report.requests >= options.requestWarn) {
+    warned = true;
+    console.error(
+      `warning: ${report.script} has ${report.requests} requests >= ${options.requestWarn}`,
+    );
+  }
+}
+for (const report of durableObjects) {
+  if (
+    options.doDurationWarnSeconds !== null &&
+    report.duration_seconds >= options.doDurationWarnSeconds
+  ) {
+    warned = true;
+    console.error(
+      `warning: Durable Object ${report.name} has ${report.duration_seconds.toFixed(
+        1,
+      )}s duration >= ${options.doDurationWarnSeconds}s`,
+    );
+  }
+}
+if (warned && options.failOnWarn) {
+  process.exitCode = 2;
+}
+
+async function workerUsage(accountTag, apiToken, scriptName, datetimeStart, datetimeEnd) {
+  const data = await graphql(apiToken, {
+    query: `query GetWorkersAnalytics($accountTag: string, $datetimeStart: string, $datetimeEnd: string, $scriptName: string) {
+      viewer {
+        accounts(filter: {accountTag: $accountTag}) {
+          workersInvocationsAdaptive(limit: 1000, filter: {
+            scriptName: $scriptName,
+            datetime_geq: $datetimeStart,
+            datetime_leq: $datetimeEnd
+          }) {
+            sum { requests subrequests errors }
+            dimensions { status }
+            quantiles { cpuTimeP50 cpuTimeP99 }
+          }
+        }
+      }
+    }`,
+    variables: {
+      accountTag,
+      datetimeStart: datetimeStart.toISOString(),
+      datetimeEnd: datetimeEnd.toISOString(),
+      scriptName,
+    },
+  });
+  const rows = data.viewer.accounts[0]?.workersInvocationsAdaptive ?? [];
+  return {
+    script: scriptName,
+    requests: sum(rows, (row) => row.sum.requests),
+    subrequests: sum(rows, (row) => row.sum.subrequests),
+    errors: sum(rows, (row) => row.sum.errors),
+    statuses: groupSum(
+      rows,
+      (row) => row.dimensions.status,
+      (row) => row.sum.requests,
+    ),
+    cpu_time_p99_ms_max: max(rows, (row) => row.quantiles?.cpuTimeP99 ?? 0),
+  };
+}
+
+async function durableObjectUsage(accountTag, apiToken, datetimeStart, datetimeEnd) {
+  const data = await graphql(apiToken, {
+    query: `query GetDurableObjectsAnalytics($accountTag: string, $datetimeStart: string, $datetimeEnd: string) {
+      viewer {
+        accounts(filter: {accountTag: $accountTag}) {
+          durableObjectsInvocationsAdaptiveGroups(limit: 1000, filter: {datetime_geq: $datetimeStart, datetime_leq: $datetimeEnd}) {
+            sum { requests errors wallTime }
+            dimensions { name namespaceId status type }
+          }
+          durableObjectsPeriodicGroups(limit: 1000, filter: {datetime_geq: $datetimeStart, datetime_leq: $datetimeEnd}) {
+            sum {
+              cpuTime
+              activeTime
+              duration
+              inboundWebsocketMsgCount
+              outboundWebsocketMsgCount
+              rowsRead
+              rowsWritten
+            }
+            dimensions { name namespaceId }
+          }
+        }
+      }
+    }`,
+    variables: {
+      accountTag,
+      datetimeStart: datetimeStart.toISOString(),
+      datetimeEnd: datetimeEnd.toISOString(),
+    },
+  });
+  const account = data.viewer.accounts[0] ?? {};
+  const invocationRows = account.durableObjectsInvocationsAdaptiveGroups ?? [];
+  const periodicRows = account.durableObjectsPeriodicGroups ?? [];
+  const byKey = new Map();
+  for (const row of invocationRows) {
+    const item = durableObjectReport(byKey, row.dimensions.namespaceId, row.dimensions.name);
+    item.requests += row.sum.requests ?? 0;
+    item.errors += row.sum.errors ?? 0;
+    item.wall_time_ms += row.sum.wallTime ?? 0;
+    incrementNested(item.statuses, row.dimensions.status, row.sum.requests ?? 0);
+    incrementNested(item.types, row.dimensions.type, row.sum.requests ?? 0);
+  }
+  for (const row of periodicRows) {
+    const key = `${row.dimensions.namespaceId}\n${row.dimensions.name}`;
+    const item =
+      byKey.get(key) ?? durableObjectReport(byKey, row.dimensions.namespaceId, row.dimensions.name);
+    item.duration_seconds += row.sum.duration ?? 0;
+    item.cpu_time_ms += row.sum.cpuTime ?? 0;
+    item.active_time_ms += row.sum.activeTime ?? 0;
+    item.inbound_websocket_messages += row.sum.inboundWebsocketMsgCount ?? 0;
+    item.outbound_websocket_messages += row.sum.outboundWebsocketMsgCount ?? 0;
+    item.rows_read += row.sum.rowsRead ?? 0;
+    item.rows_written += row.sum.rowsWritten ?? 0;
+  }
+  return [...byKey.values()].sort((a, b) => b.duration_seconds - a.duration_seconds);
+}
+
+function durableObjectReport(map, namespaceId, name) {
+  const key = `${namespaceId}\n${name}`;
+  const existing = map.get(key);
+  if (existing) return existing;
+  const created = {
+    namespace_id: namespaceId,
+    name,
+    requests: 0,
+    errors: 0,
+    wall_time_ms: 0,
+    duration_seconds: 0,
+    cpu_time_ms: 0,
+    active_time_ms: 0,
+    inbound_websocket_messages: 0,
+    outbound_websocket_messages: 0,
+    rows_read: 0,
+    rows_written: 0,
+    statuses: {},
+    types: {},
+  };
+  map.set(key, created);
+  return created;
+}
+
+async function durableObjectNamespaces(accountId, apiToken) {
+  const response = await fetch(
+    `${API_ENDPOINT}/accounts/${encodeURIComponent(accountId)}/workers/durable_objects/namespaces`,
+    { headers: { Authorization: `Bearer ${apiToken}` } },
+  );
+  if (!response.ok) {
+    return new Map();
+  }
+  const body = await response.json();
+  const namespaces = new Map();
+  for (const row of body.result ?? []) {
+    namespaces.set(row.id, {
+      name: row.name,
+      script: row.script,
+      class: row.class,
+    });
+  }
+  return namespaces;
+}
+
+async function graphql(apiToken, body) {
+  const response = await fetch(GRAPHQL_ENDPOINT, {
+    method: "POST",
+    headers: {
+      Authorization: `Bearer ${apiToken}`,
+      Accept: "application/json",
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify(body),
+  });
+  if (!response.ok) {
+    throw new Error(`Cloudflare GraphQL request failed: HTTP ${response.status}`);
+  }
+  const json = await response.json();
+  if (json.errors?.length) {
+    throw new Error(`Cloudflare GraphQL returned errors: ${JSON.stringify(json.errors)}`);
+  }
+  return json.data;
+}
+
+async function cloudflareToken() {
+  if (process.env.CLOUDFLARE_API_TOKEN) {
+    return process.env.CLOUDFLARE_API_TOKEN;
+  }
+  try {
+    const config = await readFile(
+      path.join(os.homedir(), ".config", ".wrangler", "config", "default.toml"),
+      "utf8",
+    );
+    const match = config.match(/^oauth_token\s*=\s*"([^"]+)"/m);
+    return match?.[1] ?? null;
+  } catch {
+    return null;
+  }
+}
+
+function parseArgs(args) {
+  const parsed = {
+    accountId: null,
+    doDurationWarnSeconds: numberEnv("CLOUDFLARE_DO_DURATION_WARN_SECONDS"),
+    failOnWarn: false,
+    minutes: DEFAULT_HOURS * 60,
+    requestWarn: numberEnv("CLOUDFLARE_REQUEST_WARN"),
+    scripts: [],
+  };
+  for (let index = 0; index < args.length; index += 1) {
+    const arg = args[index];
+    const next = () => {
+      const value = args[index + 1];
+      if (!value) fail(`${arg} requires a value`);
+      index += 1;
+      return value;
+    };
+    if (arg === "--account-id") {
+      parsed.accountId = next();
+    } else if (arg === "--") {
+      continue;
+    } else if (arg === "--hours") {
+      parsed.minutes = positiveNumber("--hours", next()) * 60;
+    } else if (arg === "--minutes") {
+      parsed.minutes = positiveNumber("--minutes", next());
+    } else if (arg === "--script") {
+      parsed.scripts.push(next());
+    } else if (arg === "--request-warn") {
+      parsed.requestWarn = positiveNumber("--request-warn", next());
+    } else if (arg === "--do-duration-warn-seconds") {
+      parsed.doDurationWarnSeconds = positiveNumber("--do-duration-warn-seconds", next());
+    } else if (arg === "--fail-on-warn") {
+      parsed.failOnWarn = true;
+    } else {
+      fail(`Unknown option: ${arg}`);
+    }
+  }
+  return parsed;
+}
+
+function numberEnv(name) {
+  const value = process.env[name];
+  return value ? positiveNumber(name, value) : null;
+}
+
+function positiveNumber(label, raw) {
+  const value = Number(raw);
+  if (!Number.isFinite(value) || value <= 0) {
+    fail(`${label} must be a positive number`);
+  }
+  return value;
+}
+
+function sum(rows, value) {
+  return rows.reduce((total, row) => total + (value(row) ?? 0), 0);
+}
+
+function max(rows, value) {
+  return rows.reduce((largest, row) => Math.max(largest, value(row) ?? 0), 0);
+}
+
+function groupSum(rows, key, value) {
+  const groups = {};
+  for (const row of rows) {
+    incrementNested(groups, key(row), value(row) ?? 0);
+  }
+  return groups;
+}
+
+function incrementNested(target, key, value) {
+  target[key || "unknown"] = (target[key || "unknown"] ?? 0) + value;
+}
+
+function fail(message) {
+  console.error(message);
+  process.exit(1);
+}

--- a/apps/notebook-cloud/scripts/hosted-workstation-agent-core.mjs
+++ b/apps/notebook-cloud/scripts/hosted-workstation-agent-core.mjs
@@ -4,6 +4,8 @@ import path from "node:path";
 export const DEFAULT_WORKSTATION_AUTH_KIND = "anaconda-key";
 export const DEFAULT_WORKSTATION_RETRY_AFTER_MS = 60_000;
 export const MAX_WORKSTATION_RETRY_AFTER_MS = 15 * 60_000;
+export const WORKSTATION_RETRYABLE_STATUS_CODES = new Set([429, 503]);
+export const STALE_WORKSTATION_RETRYABLE_STATUS_CODES = new Set([404, 410, 429, 503]);
 export const WORKSTATION_AUTH_KINDS = new Set([DEFAULT_WORKSTATION_AUTH_KIND, "oidc"]);
 
 export function buildWorkstationRegistrationPayload({
@@ -175,10 +177,14 @@ export async function parseHttpResponseBody(response) {
   }
 }
 
-export function retryAfterMs(response, fallbackMs = DEFAULT_WORKSTATION_RETRY_AFTER_MS) {
-  if (response.status !== 429 && response.status !== 503) return 0;
+export function retryAfterMs(
+  response,
+  fallbackMs = DEFAULT_WORKSTATION_RETRY_AFTER_MS,
+  retryStatuses = WORKSTATION_RETRYABLE_STATUS_CODES,
+) {
+  if (!retryStatuses.has(response.status)) return 0;
   const header = response.headers?.get?.("Retry-After");
-  if (!header) return fallbackMs;
+  if (!header) return retryFallbackMs(response.status, fallbackMs);
 
   const seconds = Number(header);
   if (Number.isFinite(seconds) && seconds >= 0) {
@@ -190,6 +196,13 @@ export function retryAfterMs(response, fallbackMs = DEFAULT_WORKSTATION_RETRY_AF
     return Math.max(1_000, dateMs - Date.now());
   }
 
+  return retryFallbackMs(response.status, fallbackMs);
+}
+
+function retryFallbackMs(status, fallbackMs) {
+  if (status === 404 || status === 410) {
+    return MAX_WORKSTATION_RETRY_AFTER_MS;
+  }
   return fallbackMs;
 }
 

--- a/apps/notebook-cloud/scripts/hosted-workstation-agent.mjs
+++ b/apps/notebook-cloud/scripts/hosted-workstation-agent.mjs
@@ -17,6 +17,7 @@ import {
   retryCooldownMs,
   retryAfterMs,
   runtimePeerExitMessage,
+  STALE_WORKSTATION_RETRYABLE_STATUS_CODES,
   stableWorkstationId,
 } from "./hosted-workstation-agent-core.mjs";
 import { notebookCloudBaseUrl, notebookCloudWorkspaceRoot } from "./local-dev.mjs";
@@ -180,7 +181,9 @@ async function pollAttachJobs(pythonPath) {
     },
   );
   const body = await parseHttpResponseBody(response);
-  assertResponse(response, body, "poll attach jobs", [200]);
+  assertResponse(response, body, "poll attach jobs", [200], {
+    retryStatuses: STALE_WORKSTATION_RETRYABLE_STATUS_CODES,
+  });
   for (const job of normalizeJobs(body)) {
     if (activeJobs.has(job.job_id)) continue;
     if (job.status === "pending") {
@@ -582,12 +585,12 @@ async function assertBinaryExists(binaryPath, name) {
   }
 }
 
-function assertResponse(response, body, label, expectedStatuses) {
+function assertResponse(response, body, label, expectedStatuses, options = {}) {
   if (expectedStatuses.includes(response.status)) return;
   const error = new Error(
     `${label} failed: HTTP ${response.status} ${JSON.stringify(body).slice(0, 500)}`,
   );
-  error.retryAfterMs = retryAfterMs(response);
+  error.retryAfterMs = retryAfterMs(response, undefined, options.retryStatuses);
   throw error;
 }
 

--- a/apps/notebook-cloud/src/index.ts
+++ b/apps/notebook-cloud/src/index.ts
@@ -1257,6 +1257,7 @@ function parseNotebookListLimit(request: Request): number | Response {
 
 const WORKSTATION_HEARTBEAT_STALE_MS = 3 * 60_000;
 const MAX_WORKSTATION_ATTACH_JOBS_LIMIT = 25;
+const MISSING_WORKSTATION_RETRY_AFTER_SECONDS = 15 * 60;
 
 interface WorkstationEventPresence {
   connected: boolean;
@@ -1812,7 +1813,7 @@ async function routeWorkstationEvents(
   const ownerPrincipal = await canonicalPrincipalForIdentity(env, identity);
   const workstation = await getWorkstationRow(env, ownerPrincipal, workstationId);
   if (!workstation) {
-    return json({ error: "workstation not found" }, 404);
+    return missingWorkstationResponse();
   }
 
   const stub = workstationEventsStub(env, ownerPrincipal, workstationId);
@@ -1848,7 +1849,7 @@ async function routeWorkstationAttachJobs(
   const ownerPrincipal = await canonicalPrincipalForIdentity(env, identity);
   const workstation = await getWorkstationRow(env, ownerPrincipal, workstationId);
   if (!workstation) {
-    return json({ error: "workstation not found" }, 404);
+    return missingWorkstationResponse();
   }
 
   const limit = parseWorkstationAttachJobsLimit(request);
@@ -1923,6 +1924,18 @@ function workstationEventsStub(
     workstationEventsObjectName(ownerPrincipal, workstationId),
   );
   return env.WORKSTATION_EVENTS!.get(id);
+}
+
+function missingWorkstationResponse(): Response {
+  const response = json(
+    {
+      error: "workstation not found",
+      code: "workstation_not_found",
+    },
+    404,
+  );
+  response.headers.set("Retry-After", MISSING_WORKSTATION_RETRY_AFTER_SECONDS.toString());
+  return response;
 }
 
 async function workstationEventPresenceById(

--- a/apps/notebook-cloud/test/hosted-workstation-agent.test.mjs
+++ b/apps/notebook-cloud/test/hosted-workstation-agent.test.mjs
@@ -12,6 +12,7 @@ import {
   retryAfterMs,
   retryCooldownMs,
   runtimePeerExitMessage,
+  STALE_WORKSTATION_RETRYABLE_STATUS_CODES,
   stableWorkstationId,
 } from "../scripts/hosted-workstation-agent-core.mjs";
 
@@ -207,6 +208,26 @@ describe("hosted workstation agent launch contract", () => {
       `date retry delay should be bounded, got ${retryDateDelay}`,
     );
     assert.equal(retryAfterMs(new Response("no hint", { status: 503 }), 12_345), 12_345);
+    assert.equal(retryAfterMs(new Response("missing", { status: 404 })), 0);
+    assert.equal(
+      retryAfterMs(
+        new Response("missing", {
+          status: 404,
+          headers: { "Retry-After": "900" },
+        }),
+        undefined,
+        STALE_WORKSTATION_RETRYABLE_STATUS_CODES,
+      ),
+      900_000,
+    );
+    assert.equal(
+      retryAfterMs(
+        new Response("gone", { status: 410 }),
+        undefined,
+        STALE_WORKSTATION_RETRYABLE_STATUS_CODES,
+      ),
+      900_000,
+    );
   });
 
   it("expands retry cooldowns for repeated rate-limit responses", () => {

--- a/apps/notebook-cloud/test/worker-routes.test.ts
+++ b/apps/notebook-cloud/test/worker-routes.test.ts
@@ -5794,6 +5794,27 @@ describe("Workstation pairing", () => {
     );
   });
 
+  it("asks stale workstation credentials to back off when polling attach jobs", async () => {
+    const env = fakeEnv();
+    const pairing = await mintPairingCode(env);
+    const token = await redeemedCredentialToken(env, pairing.code);
+
+    const poll = await worker.fetch(
+      new Request("http://localhost/api/workstations/ws-missing/attach-jobs", {
+        headers: { Authorization: `Bearer ${token}` },
+      }),
+      env,
+      fakeContext(),
+    );
+
+    assert.equal(poll.status, 404);
+    assert.equal(poll.headers.get("Retry-After"), "900");
+    assert.deepEqual(await poll.json(), {
+      error: "workstation not found",
+      code: "workstation_not_found",
+    });
+  });
+
   it("lets a paired workstation credential open the workstation event socket", async () => {
     const events = new FakeWorkstationEventsNamespace();
     const env = fakeEnv({ WORKSTATION_EVENTS: events });
@@ -5819,6 +5840,29 @@ describe("Workstation pairing", () => {
     );
     assert.equal(new URL(events.requests[0]!.url).pathname, "/stream");
     assert.equal(events.requests[0]?.upgrade, "websocket");
+  });
+
+  it("asks stale workstation credentials to back off when opening event sockets", async () => {
+    const events = new FakeWorkstationEventsNamespace();
+    const env = fakeEnv({ WORKSTATION_EVENTS: events });
+    const pairing = await mintPairingCode(env);
+    const token = await redeemedCredentialToken(env, pairing.code);
+
+    const response = await worker.fetch(
+      new Request("http://localhost/api/workstations/ws-missing/events", {
+        headers: { Authorization: `Bearer ${token}`, Upgrade: "websocket" },
+      }),
+      env,
+      fakeContext(),
+    );
+
+    assert.equal(response.status, 404);
+    assert.equal(response.headers.get("Retry-After"), "900");
+    assert.deepEqual(await response.json(), {
+      error: "workstation not found",
+      code: "workstation_not_found",
+    });
+    assert.equal(events.requests.length, 0);
   });
 
   it("rejects workstation event requests that are not websocket upgrades", async () => {

--- a/apps/notebook-cloud/wrangler.renderer-assets.toml
+++ b/apps/notebook-cloud/wrangler.renderer-assets.toml
@@ -6,3 +6,7 @@ compatibility_flags = ["nodejs_compat"]
 [assets]
 directory = "./dist/plugins"
 binding = "ASSETS"
+
+[observability]
+enabled = true
+head_sampling_rate = 0.01

--- a/apps/notebook-cloud/wrangler.toml
+++ b/apps/notebook-cloud/wrangler.toml
@@ -53,7 +53,10 @@ bucket_name = "nteract-notebook-cloud-prototype"
 [assets]
 directory = "./dist"
 binding = "ASSETS"
-run_worker_first = true
+
+[observability]
+enabled = true
+head_sampling_rate = 0.01
 
 [vars]
 DEPLOYMENT_ENV = "prototype"

--- a/crates/runtimed/src/workstation/agent_loop.rs
+++ b/crates/runtimed/src/workstation/agent_loop.rs
@@ -60,6 +60,9 @@ pub const DEFAULT_HEARTBEAT_MS: u64 = 60_000;
 
 /// Cooldown applied to 429/503 responses without a usable `Retry-After`.
 const DEFAULT_RETRY_AFTER_MS: u64 = 60_000;
+/// Missing/deleted workstation rows mean this agent is stale. Back off hard
+/// instead of steadily polling a registry entry the cloud no longer accepts.
+const DEFAULT_MISSING_WORKSTATION_RETRY_AFTER_MS: u64 = 15 * 60_000;
 /// Upper bound for rate-limit cooldowns (15 minutes, like the `.mjs` agent).
 const MAX_RETRY_AFTER_MS: u64 = 15 * 60_000;
 /// Idle workstation event sockets should reconnect rather than pinning an
@@ -405,23 +408,38 @@ fn workstation_events_ws_url(http_url: &str) -> Result<String, AgentHttpError> {
 /// may be delta-seconds or an HTTP date; absent/unparseable falls back to
 /// [`DEFAULT_RETRY_AFTER_MS`]. Mirrors `retryAfterMs` in the `.mjs` agent.
 pub fn retry_after_ms(status: u16, retry_after_header: Option<&str>) -> u64 {
-    if status != 429 && status != 503 {
+    retry_after_ms_for_statuses(status, retry_after_header, &[429, 503])
+}
+
+fn retry_after_ms_for_statuses(
+    status: u16,
+    retry_after_header: Option<&str>,
+    retry_statuses: &[u16],
+) -> u64 {
+    if !retry_statuses.contains(&status) {
         return 0;
     }
     let Some(header) = retry_after_header.map(str::trim).filter(|h| !h.is_empty()) else {
-        return DEFAULT_RETRY_AFTER_MS;
+        return default_retry_after_ms(status);
     };
     if let Ok(seconds) = header.parse::<f64>() {
         if seconds.is_finite() && seconds >= 0.0 {
             return (((seconds * 1000.0).ceil()) as u64).max(1_000);
         }
-        return DEFAULT_RETRY_AFTER_MS;
+        return default_retry_after_ms(status);
     }
     if let Ok(date) = chrono::DateTime::parse_from_rfc2822(header) {
         let delta = date.timestamp_millis() - chrono::Utc::now().timestamp_millis();
         return delta.max(1_000) as u64;
     }
-    DEFAULT_RETRY_AFTER_MS
+    default_retry_after_ms(status)
+}
+
+fn default_retry_after_ms(status: u16) -> u64 {
+    match status {
+        404 | 410 => DEFAULT_MISSING_WORKSTATION_RETRY_AFTER_MS,
+        _ => DEFAULT_RETRY_AFTER_MS,
+    }
 }
 
 /// Exponential cooldown for repeated retryable failures, capped at
@@ -551,7 +569,12 @@ impl CloudApi {
             encode_path_segment(workstation_id)
         );
         let body = self
-            .execute("poll attach jobs", self.client.get(&url), &[200])
+            .execute_with_retry_statuses(
+                "poll attach jobs",
+                self.client.get(&url),
+                &[200],
+                &[404, 410, 429, 503],
+            )
             .await?;
         Ok(normalize_jobs(&body))
     }
@@ -596,7 +619,11 @@ impl CloudApi {
                     .collect();
                 return Err(AgentHttpError {
                     message: format!("connect workstation events failed: HTTP {status} {snippet}"),
-                    retry_after_ms: retry_after_ms(status, retry_after_header.as_deref()),
+                    retry_after_ms: retry_after_ms_for_statuses(
+                        status,
+                        retry_after_header.as_deref(),
+                        &[404, 410, 429, 503],
+                    ),
                     status: Some(status),
                     body,
                 });
@@ -685,6 +712,17 @@ impl CloudApi {
         request: reqwest::RequestBuilder,
         expected_statuses: &[u16],
     ) -> Result<Value, AgentHttpError> {
+        self.execute_with_retry_statuses(label, request, expected_statuses, &[429, 503])
+            .await
+    }
+
+    async fn execute_with_retry_statuses(
+        &self,
+        label: &str,
+        request: reqwest::RequestBuilder,
+        expected_statuses: &[u16],
+        retry_statuses: &[u16],
+    ) -> Result<Value, AgentHttpError> {
         let response = request
             .timeout(Duration::from_secs(30))
             .bearer_auth(&self.token)
@@ -709,7 +747,11 @@ impl CloudApi {
             .collect();
         Err(AgentHttpError {
             message: format!("{label} failed: HTTP {status} {snippet}"),
-            retry_after_ms: retry_after_ms(status, retry_after_header.as_deref()),
+            retry_after_ms: retry_after_ms_for_statuses(
+                status,
+                retry_after_header.as_deref(),
+                retry_statuses,
+            ),
             status: Some(status),
             body,
         })
@@ -2157,6 +2199,7 @@ mod tests {
         assert_eq!(retry_after_ms(200, None), 0);
         assert_eq!(retry_after_ms(429, Some("7")), 7_000);
         assert_eq!(retry_after_ms(503, None), 60_000);
+        assert_eq!(retry_after_ms(404, Some("900")), 0);
         // Sub-second hints are floored to 1s.
         assert_eq!(retry_after_ms(429, Some("0")), 1_000);
         // Unparseable headers fall back to the default.
@@ -2166,6 +2209,19 @@ mod tests {
             retry_after_ms(429, Some("Tue, 15 Nov 1994 08:12:31 GMT")),
             1_000
         );
+    }
+
+    #[test]
+    fn stale_workstation_statuses_can_back_off_selected_paths() {
+        assert_eq!(
+            retry_after_ms_for_statuses(404, Some("900"), &[404, 410, 429, 503]),
+            900_000
+        );
+        assert_eq!(
+            retry_after_ms_for_statuses(410, None, &[404, 410, 429, 503]),
+            DEFAULT_MISSING_WORKSTATION_RETRY_AFTER_MS
+        );
+        assert_eq!(retry_after_ms_for_statuses(404, None, &[429, 503]), 0);
     }
 
     #[test]

--- a/crates/runtimed/src/workstation/agent_loop.rs
+++ b/crates/runtimed/src/workstation/agent_loop.rs
@@ -802,7 +802,8 @@ async fn run_workstation_event_listener(
 
 fn retry_event_socket_delay(previous: Duration, retry_after_ms: u64) -> Duration {
     if retry_after_ms > 0 {
-        return Duration::from_millis(retry_after_ms).min(Duration::from_secs(60));
+        return Duration::from_millis(retry_after_ms)
+            .min(Duration::from_millis(MAX_RETRY_AFTER_MS));
     }
     previous.saturating_mul(2).min(Duration::from_secs(60))
 }
@@ -1933,6 +1934,13 @@ mod tests {
         assert_eq!(
             retry_event_socket_delay(Duration::from_secs(1), 42_000),
             Duration::from_secs(42)
+        );
+        assert_eq!(
+            retry_event_socket_delay(
+                Duration::from_secs(1),
+                DEFAULT_MISSING_WORKSTATION_RETRY_AFTER_MS
+            ),
+            Duration::from_millis(DEFAULT_MISSING_WORKSTATION_RETRY_AFTER_MS)
         );
         assert_eq!(
             retry_event_socket_delay(Duration::from_secs(45), 0),


### PR DESCRIPTION
## Summary

- serve main cloud static assets with asset-first routing so bundle/chunk requests do not run Worker code
- add sampled Cloudflare observability and a local usage report script for Worker + Durable Object burn checks
- ask stale workstation credentials to back off on missing/deleted workstation event and attach-job endpoints

## Validation

- `CLOUDFLARE_ACCOUNT_ID=... pnpm --dir apps/notebook-cloud run ops:cloudflare:usage -- --minutes 15 --request-warn 10000 --do-duration-warn-seconds 300`
- `pnpm --dir apps/notebook-cloud exec node --import tsx --test test/worker-routes.test.ts`
- `pnpm --dir apps/notebook-cloud typecheck`
- `cargo test -p runtimed retry_after`
- `cargo test -p runtimed stale_workstation`
- `cargo xtask lint --fix`
- `pnpm --workspace-root exec wrangler deploy --dry-run --config apps/notebook-cloud/wrangler.toml`
- `pnpm --workspace-root exec wrangler deploy --dry-run --config apps/notebook-cloud/wrangler.renderer-assets.toml`

## Notes

The 15-minute usage sample after the workstation host deletion was down to 35 main Worker requests, 0 renderer-assets Worker requests, and 60s of remaining WorkstationEvents DO duration on the old account object. The two-hour window still showed older SSE-era/disconnected stream duration, so the short-window check is the better signal for whether the leak is continuing.