### PR TITLE
fix(markdown): widen bare TeX coverage to match JupyterLab

### DIFF
--- a/crates/nteract-markdown-engine/src/lib.rs
+++ b/crates/nteract-markdown-engine/src/lib.rs
@@ -358,6 +358,11 @@ fn project_node(node: &mdast::Node, context: &mut ProjectionContext<'_>) -> Proj
                 text = math_source.to_string();
                 copy_text = math_source.to_string();
                 children.clear();
+            } else if let Some(math_source) = bracket_display_tex(context.source, &span) {
+                kind = NodeKind::MathBlock;
+                text = math_source.to_string();
+                copy_text = math_source.to_string();
+                children.clear();
             } else {
                 kind = NodeKind::Paragraph;
             }
@@ -760,50 +765,44 @@ fn source_slice<'a>(source: &'a str, span: &SourceSpan) -> &'a str {
     source.get(span.start..span.end).unwrap_or("")
 }
 
+/// Recognizes a standalone bare TeX environment as MathJax's
+/// `processEnvironments` does: any paragraph that is entirely
+/// `\begin{X}...\end{X}` (matched name, X non-empty) routes to the host math
+/// renderer. There is no environment whitelist, so `cases`, the matrix family,
+/// `gather`, `multline`, `aligned`, `split`, `alignat`, and friends all render
+/// because they are valid once inside math mode.
 fn bare_display_tex_environment<'a>(source: &'a str, span: &SourceSpan) -> Option<&'a str> {
     let trimmed = source_slice(source, span).trim();
     let environment = tex_environment_name(trimmed)?;
-    if !is_supported_display_tex_environment(environment) {
-        return None;
-    }
     let closing = format!("\\end{{{environment}}}");
-    if trimmed.ends_with(&closing) {
-        Some(trimmed)
-    } else {
-        None
-    }
+    trimmed
+        .ends_with(&closing)
+        .then_some(trimmed)
+        .filter(|value| *value != closing)
+}
+
+/// Recognizes a standalone `\[...\]` display-math paragraph the way MathJax's
+/// tex2jax does. markdown-rs treats `\[` and `\]` as backslash escapes (the `\`
+/// is dropped from the parsed text), so we read the raw source span and check
+/// that the paragraph is entirely a single balanced `\[...\]` block. The first
+/// `\]` must be the closing delimiter; prose after it (`\[ x \] after \]`)
+/// stays a paragraph because the block is not standalone.
+fn bracket_display_tex<'a>(source: &'a str, span: &SourceSpan) -> Option<&'a str> {
+    let trimmed = source_slice(source, span).trim();
+    let after_open = trimmed.strip_prefix("\\[")?;
+    // The first `\]` closes the display region.
+    let close_rel = after_open.find("\\]")?;
+    let inner = after_open[..close_rel].trim();
+    let after_close = &after_open[close_rel + "\\]".len()..];
+    // Nothing but whitespace may follow the closing `\]`.
+    (!inner.is_empty() && after_close.trim().is_empty()).then_some(inner)
 }
 
 fn tex_environment_name(source: &str) -> Option<&str> {
     let rest = source.strip_prefix("\\begin{")?;
     let end = rest.find('}')?;
     let environment = &rest[..end];
-    if environment.is_empty() {
-        None
-    } else {
-        Some(environment)
-    }
-}
-
-fn is_supported_display_tex_environment(environment: &str) -> bool {
-    matches!(
-        environment,
-        "align"
-            | "align*"
-            | "aligned"
-            | "alignedat"
-            | "alignedat*"
-            | "array"
-            | "equation"
-            | "equation*"
-            | "eqnarray"
-            | "eqnarray*"
-            | "gather"
-            | "gather*"
-            | "multline"
-            | "multline*"
-            | "split"
-    )
+    (!environment.is_empty()).then_some(environment)
 }
 
 #[cfg(test)]
@@ -928,6 +927,78 @@ mod tests {
         assert_eq!(plan.blocks.len(), 1);
         assert_eq!(plan.blocks[0].kind, NodeKind::Paragraph);
         assert!(contains_kind(&plan.blocks[0], NodeKind::Text));
+    }
+
+    #[test]
+    fn projects_jupyter_matrix_cases_and_family_as_math_blocks() {
+        // #3834: MathJax's `processEnvironments` renders any bare
+        // `\begin{X}...\end{X}` as display math, so the matrix family, `cases`,
+        // `gather`, `multline`, `aligned`, and `alignat` all render without an
+        // environment whitelist. KaTeX handles each once it is in math mode.
+        let environments = [
+            (
+                "cases",
+                "\\begin{cases}\nx & \\text{if } x \\ge 0 \\\\\n-x & \\text{otherwise}\n\\end{cases}",
+            ),
+            (
+                "pmatrix",
+                "\\begin{pmatrix}\n\\cos\\theta & -\\sin\\theta \\\\\n\\sin\\theta & \\cos\\theta\n\\end{pmatrix}",
+            ),
+            ("bmatrix", "\\begin{bmatrix}a & b \\\\ c & d\\end{bmatrix}"),
+            ("vmatrix", "\\begin{vmatrix}a & b \\\\ c & d\\end{vmatrix}"),
+            ("matrix", "\\begin{matrix}a & b \\\\ c & d\\end{matrix}"),
+            ("gather", "\\begin{gather}a = b \\\\ c = d\\end{gather}"),
+            ("multline", "\\begin{multline}a \\\\ b\\end{multline}"),
+            ("aligned", "\\begin{aligned}a &= b \\\\ c &= d\\end{aligned}"),
+            ("alignat", "\\begin{alignat}{2}a &= b \\\\ c &= d\\end{alignat}"),
+        ];
+
+        for (name, source) in environments {
+            let plan = project_markdown(source).unwrap_or_else(|_| panic!("{name} projected"));
+            assert_eq!(plan.blocks.len(), 1, "{name} produced one block");
+            assert_eq!(plan.blocks[0].kind, NodeKind::MathBlock, "{name} is math");
+            assert_eq!(
+                plan.blocks[0].fallback.copy_text, source,
+                "{name} text intact"
+            );
+        }
+    }
+
+    #[test]
+    fn projects_unknown_tex_environment_as_math_for_mathjax_parity() {
+        // MathJax does not keep an environment whitelist; any balanced bare
+        // environment routes to the renderer. This documents that intentional
+        // widening from the #3377 curated set.
+        let plan = project_markdown("\\begin{notreal}\nbody\n\\end{notreal}").unwrap();
+
+        assert_eq!(plan.blocks.len(), 1);
+        assert_eq!(plan.blocks[0].kind, NodeKind::MathBlock);
+        assert_eq!(
+            plan.blocks[0].fallback.copy_text,
+            "\\begin{notreal}\nbody\n\\end{notreal}"
+        );
+    }
+
+    #[test]
+    fn projects_display_bracket_tex_delimiters() {
+        // #3834: a standalone `\[...\]` block routes to the host math renderer
+        // the way MathJax's tex2jax handles it. markdown-rs treats `\[` / `\]`
+        // as backslash escapes (the `\` is dropped from the parsed text), so we
+        // recover the inner LaTeX from the raw source span. Inline `\(...\)` is
+        // intentionally out of scope — see issue #3834.
+        let display = project_markdown("\\[\nx = y\nz = w\n\\]").unwrap();
+        assert_eq!(display.blocks.len(), 1);
+        assert_eq!(display.blocks[0].kind, NodeKind::MathBlock);
+        assert_eq!(display.blocks[0].fallback.text, "x = y\nz = w");
+    }
+
+    #[test]
+    fn keeps_mixed_bracket_tex_delimiters_as_prose() {
+        // The #3377 constraint: mixed inline prose stays normal text even with
+        // the new delimiter. `before \[ x \] after` is not a standalone block.
+        let bracket = project_markdown("before \\[ x \\] after on one line").unwrap();
+        assert_eq!(bracket.blocks.len(), 1);
+        assert_eq!(bracket.blocks[0].kind, NodeKind::Paragraph);
     }
 
     #[test]

--- a/crates/nteract-markdown-wasm/src/lib.rs
+++ b/crates/nteract-markdown-wasm/src/lib.rs
@@ -1301,6 +1301,21 @@ mod tests {
     }
 
     #[test]
+    fn projects_display_bracket_tex_delimiters() {
+        // #3834: a standalone `\[...\]` block routes to the math renderer with
+        // the bracket delimiters stripped from the rendered text. Inline
+        // `\(...\)` is intentionally out of scope — see issue #3834.
+        let display = project_to_json("\\[\nx = y\nz = w\n\\]");
+        assert_eq!(display.matches("\"kind\":\"math\"").count(), 1);
+        assert!(display.contains("\"semantic\":\"math-source\""));
+        // Display math text is the inner LaTeX; the newlines are JSON-escaped.
+        assert!(display.contains("\"renderedText\":\"x = y\\nz = w\""));
+        // The bracket delimiters are stripped from the rendered text.
+        assert!(!display.contains("\\\\["));
+        assert!(!display.contains("\\\\]"));
+    }
+
+    #[test]
     fn projects_table_rows_cells_and_alignment() {
         let json = project_to_json("| metric | value |\n| --- | ---: |\n| rows | 128 |\n");
 

--- a/src/lib/__tests__/markdown-projection.test.ts
+++ b/src/lib/__tests__/markdown-projection.test.ts
@@ -303,6 +303,68 @@ describe("markdown projection", () => {
     ]);
   });
 
+  it("projects the Jupyter matrix and cases family as display math (#3834)", () => {
+    // #3834: MathJax's `processEnvironments` renders any bare environment, so
+    // the matrix family, `cases`, `gather`, `multline`, and `aligned` all
+    // route to the math renderer without an environment whitelist.
+    const environments = [
+      {
+        name: "cases",
+        source: [
+          "\\begin{cases}",
+          "x & \\text{if } x \\ge 0 \\",
+          "-x & \\text{otherwise}",
+          "\\end{cases}",
+        ].join("\n"),
+      },
+      {
+        name: "pmatrix",
+        source: [
+          "\\begin{pmatrix}",
+          "\\cos\\theta & -\\sin\\theta \\",
+          "\\sin\\theta & \\cos\\theta",
+          "\\end{pmatrix}",
+        ].join("\n"),
+      },
+      {
+        name: "vmatrix",
+        source: "\\begin{vmatrix}a & b \\\\ c & d\\end{vmatrix}",
+      },
+    ];
+
+    for (const { name, source } of environments) {
+      const plan = projectMarkdownPlan(source);
+      expect(plan?.blocks.map((block) => block.kind)).toEqual(["math"]);
+      expect(plan?.blocks[0]?.text).toBe(source);
+      expect(
+        plan?.runs
+          .filter((run) => run.semantic === "math-source")
+          .map((run) => run.renderedText),
+      ).toEqual([source]);
+      // Sanity: the block text actually carries the environment name.
+      expect(plan?.blocks[0]?.text).toContain(`\\begin{${name}}`);
+    }
+  });
+
+  it("projects display \\[...\\] delimiters (#3834)", () => {
+    // #3834: a standalone `\[...\]` block becomes a display math block with the
+    // inner LaTeX as its text. Inline `\(...\)` is intentionally out of scope
+    // — see issue #3834.
+    const display = projectMarkdownPlan("\\[\nx = y\nz = w\n\\]");
+    expect(display?.blocks.map((block) => block.kind)).toEqual(["math"]);
+    expect(display?.blocks[0]?.text).toBe("x = y\nz = w");
+    expect(
+      display?.runs
+        .filter((run) => run.semantic === "math-source")
+        .map((run) => run.renderedText),
+    ).toEqual(["x = y\nz = w"]);
+
+    // The #3377 constraint holds for the new delimiter: mixed prose stays a
+    // paragraph rather than being swallowed as display math.
+    const mixed = projectMarkdownPlan("before \\[ x \\] after on one line");
+    expect(mixed?.blocks.map((block) => block.kind)).toEqual(["paragraph"]);
+  });
+
   it("keeps projected raw HTML markup out of the host DOM without forcing iframe fallback", () => {
     const plan = projectMarkdownPlan("alpha <i>wow</i> omega");
 


### PR DESCRIPTION
Closes #3834. Scope narrowed from the original issue after prototyping — see [this comment](https://github.com/nteract/nteract/issues/3834#issuecomment-4819924794).

## What lands

Two clean wins for imported-Jupyter / ordinary-notebook math:

1. **`processEnvironments` parity.** Replaces the curated bare-TeX environment whitelist from #3377 with MathJax's behavior: any balanced `\begin{X}...\end{X}` paragraph routes to the host math renderer. Covers `cases`, `pmatrix`/`bmatrix`/`vmatrix`/`matrix`, `gather`, `multline`, `aligned`, `split`, `alignat` — without enumerating each. KaTeX already renders every one of these once the LaTeX reaches it, so this is pure routing on top of the existing `MathBlock` projection.
2. **`\[...\]` display blocks.** Standalone `\[...\]` paragraphs become display math. Recovered from the raw source span since markdown-rs treats `\[`/`\]` as backslash escapes and drops the leading backslash from the parsed text. The existing wasm `MathBlock` path handled this with zero glue changes.

The `cases` and matrix repros from the issue — the ones that hit ordinary notebook math and imported Jupyter notebooks — are fully covered by move (1).

## Bonus fix

Reading raw source for these blocks also fixes a latent bug: the old path routed environment text through `node.to_string()`, which collapsed LaTeX `\\` line-breaks to `\`. The raw slice preserves them faithfully. The `mixed-tex-proof` fixture test was updated to the correct two-backslash expectation.

## Intentionally out of scope

Inline `\(...\)`. markdown-rs collapses `\(` as a markdown escape into a single `Text` node with no clean node boundary (the leading backslash is stripped from the span), and recovering it means re-deriving markdown's escape-unescaping layer. An adversarial review (`codex`, o-series) of a prototype confirmed a cluster of edge cases — escaped literals (`\\(`), empty/`unterminated` delimiters, and prose-before-math losing its unescaping. Rather than ship an awkward escape-guessing layer, inline `\(...\)` stays as text; `$...$` remains the inline path.

The `\[...\]` case dodges all of this because it's whole-paragraph detection (no prose-splitting).

## Verification

- `cargo test -p nteract-markdown-engine` — 13 passed
- `cargo test -p nteract-markdown-wasm` — 12 passed
- `src/lib/__tests__/markdown-projection.test.ts` — 19 passed; `src/components/markdown/__tests__/ProjectedMarkdownView.test.tsx` — 35 passed
- `cargo xtask lint --fix` — all checks pass
- Rebuilt `runtimed-wasm` (genesis-verified)

The #3377 constraints are preserved: mixed inline prose like `before \begin{align}...\end{align} after` and `before \[ x \] after` stays normal paragraph text, and source spans stay intact for cursor mapping.