### PR TITLE
test(markdown): use real TeX row separators in cases/pmatrix fixtures

### DIFF
--- a/src/lib/__tests__/markdown-projection.test.ts
+++ b/src/lib/__tests__/markdown-projection.test.ts
@@ -312,7 +312,7 @@ describe("markdown projection", () => {
         name: "cases",
         source: [
           "\\begin{cases}",
-          "x & \\text{if } x \\ge 0 \\",
+          "x & \\text{if } x \\ge 0 \\\\",
           "-x & \\text{otherwise}",
           "\\end{cases}",
         ].join("\n"),
@@ -321,7 +321,7 @@ describe("markdown projection", () => {
         name: "pmatrix",
         source: [
           "\\begin{pmatrix}",
-          "\\cos\\theta & -\\sin\\theta \\",
+          "\\cos\\theta & -\\sin\\theta \\\\",
           "\\sin\\theta & \\cos\\theta",
           "\\end{pmatrix}",
         ].join("\n"),


### PR DESCRIPTION
Follow-up to #3835. Addresses the pullfrog nit about the TS test fixtures.

## The issue

The `cases` and `pmatrix` fixtures in `markdown-projection.test.ts` used a **single** backslash as the TeX row separator where a real Jupyter notebook (and the Rust equivalents at `lib.rs:941`/`lib.rs:945`) uses **two** (`\\`).

```diff
- "x & \\text{if } x \\ge 0 \\",      // → "...x \ge 0 \"  (1 backslash)
+ "x & \\text{if } x \\ge 0 \\\\",    // → "...x \\ge 0 \\" (2 backslashes — real TeX row break)
```

The test asserts `text === source` (round-trip), so it passed regardless — meaning it **never exercised the realistic path** and could not catch a regression of the `\\`-collapse bug that #3835 fixed.

## The fix

Two-line change: the `cases` and `pmatrix` fixtures now use the real double-backslash separators. With realistic input, the round-trip assertions (`blocks[0].text === source` and `math-source.renderedText === source`) actually guard against backslash mangling — if the engine ever collapsed `\\` → `\` again, these would fail.

## Verification

- `codex` adversarial review — **no findings**. Confirmed the JS string semantics (`"\\\\"` = two-char `\\`), confirmed the round-trip assertions check projector output (not a TS-side cached stamp), and confirmed no other fixtures in the file or `mixed-tex-proof.md` have the same issue.
- `pnpm test:run src/lib/__tests__/markdown-projection.test.ts` — 19 passed
- `cargo xtask lint` — clean