### PR TITLE
chore(release): bump versions for 2.6.1

### DIFF
--- a/.agents/plugins/marketplace.json
+++ b/.agents/plugins/marketplace.json
@@ -6,7 +6,7 @@
   "plugins": [
     {
       "name": "nteract",
-      "version": "0.4.0",
+      "version": "0.4.1",
       "source": {
         "source": "local",
         "path": "./plugins/nteract"
@@ -19,7 +19,7 @@
     },
     {
       "name": "nightly",
-      "version": "0.4.0",
+      "version": "0.4.1",
       "source": {
         "source": "local",
         "path": "./plugins/nightly"

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -8,13 +8,13 @@
       "name": "nteract",
       "source": "./plugins/nteract",
       "description": "nteract notebooks in Claude Code.",
-      "version": "0.4.0"
+      "version": "0.4.1"
     },
     {
       "name": "nightly",
       "source": "./plugins/nightly",
       "description": "nteract notebooks (nightly channel) in Claude Code.",
-      "version": "0.4.0"
+      "version": "0.4.1"
     }
   ]
 }

--- a/.github/release-notes/2.6.1.md
+++ b/.github/release-notes/2.6.1.md
@@ -1,0 +1,12 @@
+- **Markdown math compatibility:** bare TeX environments and standalone
+  display-math blocks now route through the math renderer more like
+  JupyterLab, including matrix, aligned, gather, and related environments.
+- **Notebook session recovery:** desktop relay connections recover more
+  reliably after stale notebook sync state, and runtimed handles empty
+  dependency metadata without failing session setup.
+- **Agent and MCP polish:** visual-output LLM summaries are preserved in MCP
+  tool responses, and the Codex MCP defaults now pin development work to the
+  worktree daemon.
+- **Interactive output improvements:** ipympl Matplotlib canvases are supported,
+  large notebook first-cell load is faster, and hosted workstation sockets use
+  fewer resources while idle.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -625,7 +625,7 @@ dependencies = [
 
 [[package]]
 name = "automerge-recovery"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "automerge",
  "thiserror 2.0.18",
@@ -633,7 +633,7 @@ dependencies = [
 
 [[package]]
 name = "automunge"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "automerge",
  "serde_json",
@@ -884,7 +884,7 @@ dependencies = [
 
 [[package]]
 name = "build-metadata"
-version = "0.2.0"
+version = "0.2.1"
 
 [[package]]
 name = "bumpalo"
@@ -1324,7 +1324,7 @@ dependencies = [
 
 [[package]]
 name = "comments-doc"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "automerge",
  "automerge-recovery",
@@ -4035,7 +4035,7 @@ dependencies = [
 
 [[package]]
 name = "kernel-env"
-version = "0.5.0"
+version = "0.5.1"
 dependencies = [
  "anyhow",
  "dirs",
@@ -4062,7 +4062,7 @@ dependencies = [
 
 [[package]]
 name = "kernel-launch"
-version = "0.5.0"
+version = "0.5.1"
 dependencies = [
  "anyhow",
  "dirs",
@@ -4470,11 +4470,11 @@ checksum = "47e1ffaa40ddd1f3ed91f717a33c8c0ee23fff369e3aa8772b9605cc1d22f4c3"
 
 [[package]]
 name = "mcp-client-branding"
-version = "0.2.0"
+version = "0.2.1"
 
 [[package]]
 name = "mcp-supervisor"
-version = "0.5.0"
+version = "0.5.1"
 dependencies = [
  "dirs",
  "libc",
@@ -4794,7 +4794,7 @@ dependencies = [
 
 [[package]]
 name = "notebook"
-version = "2.6.0"
+version = "2.6.1"
 dependencies = [
  "anyhow",
  "build-metadata",
@@ -4838,7 +4838,7 @@ dependencies = [
 
 [[package]]
 name = "notebook-cloud-transport"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "anyhow",
  "futures-util",
@@ -4852,7 +4852,7 @@ dependencies = [
 
 [[package]]
 name = "notebook-doc"
-version = "0.5.0"
+version = "0.5.1"
 dependencies = [
  "automerge",
  "automerge-recovery",
@@ -4873,7 +4873,7 @@ dependencies = [
 
 [[package]]
 name = "notebook-protocol"
-version = "0.5.0"
+version = "0.5.1"
 dependencies = [
  "anyhow",
  "log",
@@ -4886,7 +4886,7 @@ dependencies = [
 
 [[package]]
 name = "notebook-sync"
-version = "0.5.0"
+version = "0.5.1"
 dependencies = [
  "automerge",
  "automerge-recovery",
@@ -4906,7 +4906,7 @@ dependencies = [
 
 [[package]]
 name = "notebook-wire"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "serde",
 ]
@@ -4952,7 +4952,7 @@ dependencies = [
 
 [[package]]
 name = "nteract-identity"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "futures",
  "jsonwebtoken",
@@ -4963,21 +4963,21 @@ dependencies = [
 
 [[package]]
 name = "nteract-markdown-engine"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "markdown",
 ]
 
 [[package]]
 name = "nteract-markdown-wasm"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "nteract-markdown-engine",
 ]
 
 [[package]]
 name = "nteract-mcp"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "dirs",
  "rmcp",
@@ -4990,7 +4990,7 @@ dependencies = [
 
 [[package]]
 name = "nteract-predicate"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "arrow",
  "arrow-cast",
@@ -5004,7 +5004,7 @@ dependencies = [
 
 [[package]]
 name = "nteract-telemetry"
-version = "2.6.0"
+version = "2.6.1"
 dependencies = [
  "log",
  "reqwest 0.12.28",
@@ -6018,7 +6018,7 @@ checksum = "b4596b6d070b27117e987119b4dac604f3c58cfb0b191112e24771b2faeac1a6"
 
 [[package]]
 name = "playdate-image"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "image",
  "thiserror 2.0.18",
@@ -7119,7 +7119,7 @@ dependencies = [
 
 [[package]]
 name = "repr-llm"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "base64 0.22.1",
  "nteract-predicate",
@@ -7428,7 +7428,7 @@ dependencies = [
 
 [[package]]
 name = "runt"
-version = "2.6.0"
+version = "2.6.1"
 dependencies = [
  "anyhow",
  "build-metadata",
@@ -7464,7 +7464,7 @@ dependencies = [
 
 [[package]]
 name = "runt-mcp"
-version = "0.5.0"
+version = "0.5.1"
 dependencies = [
  "base64 0.22.1",
  "chrono",
@@ -7498,7 +7498,7 @@ dependencies = [
 
 [[package]]
 name = "runt-mcp-proxy"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "rmcp",
  "serde_json",
@@ -7509,7 +7509,7 @@ dependencies = [
 
 [[package]]
 name = "runt-publish"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "anyhow",
  "automerge",
@@ -7532,7 +7532,7 @@ dependencies = [
 
 [[package]]
 name = "runt-trust"
-version = "0.5.0"
+version = "0.5.1"
 dependencies = [
  "serde",
  "serde_json",
@@ -7540,7 +7540,7 @@ dependencies = [
 
 [[package]]
 name = "runt-workspace"
-version = "0.5.0"
+version = "0.5.1"
 dependencies = [
  "core-foundation",
  "dirs",
@@ -7553,7 +7553,7 @@ dependencies = [
 
 [[package]]
 name = "runtime-doc"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "automerge",
  "automerge-recovery",
@@ -7567,7 +7567,7 @@ dependencies = [
 
 [[package]]
 name = "runtimed"
-version = "2.6.0"
+version = "2.6.1"
 dependencies = [
  "aho-corasick",
  "alacritty_terminal",
@@ -7644,7 +7644,7 @@ dependencies = [
 
 [[package]]
 name = "runtimed-client"
-version = "2.6.0"
+version = "2.6.1"
 dependencies = [
  "automerge",
  "automerge-recovery",
@@ -7670,7 +7670,7 @@ dependencies = [
 
 [[package]]
 name = "runtimed-node"
-version = "0.5.0"
+version = "0.5.1"
 dependencies = [
  "arrow",
  "base64 0.22.1",
@@ -7696,7 +7696,7 @@ dependencies = [
 
 [[package]]
 name = "runtimed-outputs"
-version = "2.6.0"
+version = "2.6.1"
 dependencies = [
  "base64 0.22.1",
  "notebook-doc",
@@ -7711,7 +7711,7 @@ dependencies = [
 
 [[package]]
 name = "runtimed-py"
-version = "2.6.0"
+version = "2.6.1"
 dependencies = [
  "kernel-env",
  "log",
@@ -7732,7 +7732,7 @@ dependencies = [
 
 [[package]]
 name = "runtimed-service"
-version = "2.6.0"
+version = "2.6.1"
 dependencies = [
  "dirs",
  "log",
@@ -7743,7 +7743,7 @@ dependencies = [
 
 [[package]]
 name = "runtimed-settings-sync"
-version = "2.6.0"
+version = "2.6.1"
 dependencies = [
  "automerge",
  "log",
@@ -7758,7 +7758,7 @@ dependencies = [
 
 [[package]]
 name = "runtimed-wasm"
-version = "0.5.0"
+version = "0.5.1"
 dependencies = [
  "automerge",
  "comments-doc",
@@ -8485,7 +8485,7 @@ checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 
 [[package]]
 name = "sift-wasm"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "arrow",
  "arrow-cast",
@@ -11778,7 +11778,7 @@ dependencies = [
 
 [[package]]
 name = "xtask"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "dirs",
  "runt-workspace",

--- a/apps/notebook/package.json
+++ b/apps/notebook/package.json
@@ -1,7 +1,7 @@
 {
   "name": "notebook-ui",
   "private": true,
-  "version": "0.4.0",
+  "version": "0.4.1",
   "type": "module",
   "scripts": {
     "dev": "vp dev",

--- a/crates/automerge-recovery/Cargo.toml
+++ b/crates/automerge-recovery/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "automerge-recovery"
-version = "0.2.0"
+version = "0.2.1"
 edition.workspace = true
 description = "Small panic recovery helpers for Automerge operations"
 repository.workspace = true

--- a/crates/automunge/Cargo.toml
+++ b/crates/automunge/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "automunge"
-version = "0.4.0"
+version = "0.4.1"
 edition.workspace = true
 description = "JSON-to-Automerge helpers — recursive read, write, and update for serde_json::Value in Automerge documents"
 repository.workspace = true

--- a/crates/build-metadata/Cargo.toml
+++ b/crates/build-metadata/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "build-metadata"
-version = "0.2.0"
+version = "0.2.1"
 edition.workspace = true
 description = "Shared build-script metadata helpers for nteract desktop"
 repository.workspace = true

--- a/crates/comments-doc/Cargo.toml
+++ b/crates/comments-doc/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "comments-doc"
-version = "0.2.0"
+version = "0.2.1"
 edition.workspace = true
 description = "CommentsDoc — durable per-notebook Automerge document for comments"
 repository.workspace = true

--- a/crates/kernel-env/Cargo.toml
+++ b/crates/kernel-env/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "kernel-env"
-version = "0.5.0"
+version = "0.5.1"
 edition.workspace = true
 description = "Python environment management (UV + Conda) with progress reporting"
 repository.workspace = true

--- a/crates/kernel-launch/Cargo.toml
+++ b/crates/kernel-launch/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "kernel-launch"
-version = "0.5.0"
+version = "0.5.1"
 edition.workspace = true
 description = "Shared kernel launching and tool bootstrapping for nteract"
 repository.workspace = true

--- a/crates/mcp-client-branding/Cargo.toml
+++ b/crates/mcp-client-branding/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mcp-client-branding"
-version = "0.2.0"
+version = "0.2.1"
 edition.workspace = true
 description = "Canonical display names for known MCP clients"
 repository.workspace = true

--- a/crates/mcp-supervisor/Cargo.toml
+++ b/crates/mcp-supervisor/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mcp-supervisor"
-version = "0.5.0"
+version = "0.5.1"
 edition.workspace = true
 description = "nteract-dev — MCP supervisor that proxies to the nteract MCP server with auto-restart, file watching, and daemon management"
 repository.workspace = true

--- a/crates/notebook-cloud-transport/Cargo.toml
+++ b/crates/notebook-cloud-transport/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "notebook-cloud-transport"
-version = "0.2.0"
+version = "0.2.1"
 edition.workspace = true
 description = "Cloud-WebSocket FrameTransport for the runtime agent (dials a hosted notebook room as a runtime peer)"
 repository.workspace = true

--- a/crates/notebook-doc/Cargo.toml
+++ b/crates/notebook-doc/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "notebook-doc"
-version = "0.5.0"
+version = "0.5.1"
 edition.workspace = true
 description = "Shared Automerge notebook document types and operations, used by both runtimed (daemon) and runtimed-wasm (frontend)"
 repository.workspace = true

--- a/crates/notebook-protocol/Cargo.toml
+++ b/crates/notebook-protocol/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "notebook-protocol"
-version = "0.5.0"
+version = "0.5.1"
 edition.workspace = true
 description = "Shared wire protocol types for notebook sync (client and server)"
 repository.workspace = true

--- a/crates/notebook-sync/Cargo.toml
+++ b/crates/notebook-sync/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "notebook-sync"
-version = "0.5.0"
+version = "0.5.1"
 edition.workspace = true
 description = "Automerge-based notebook sync client with direct document access"
 repository.workspace = true

--- a/crates/notebook-wire/Cargo.toml
+++ b/crates/notebook-wire/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "notebook-wire"
-version = "0.3.0"
+version = "0.3.1"
 edition.workspace = true
 description = "Low-level notebook wire constants, frame limits, and session-control types"
 repository.workspace = true

--- a/crates/notebook/Cargo.toml
+++ b/crates/notebook/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "notebook"
-version = "2.6.0"
+version = "2.6.1"
 edition.workspace = true
 description = "Tauri-based notebook UI for Jupyter kernels"
 repository.workspace = true

--- a/crates/notebook/tauri.conf.json
+++ b/crates/notebook/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "nteract",
-  "version": "2.6.0",
+  "version": "2.6.1",
   "identifier": "org.nteract.desktop",
   "build": {
     "devUrl": "http://localhost:5174",

--- a/crates/nteract-identity/Cargo.toml
+++ b/crates/nteract-identity/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "nteract-identity"
-version = "0.2.0"
+version = "0.2.1"
 edition.workspace = true
 description = "Identity and authorization primitives for nteract notebook rooms"
 repository.workspace = true

--- a/crates/nteract-markdown-engine/Cargo.toml
+++ b/crates/nteract-markdown-engine/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "nteract-markdown-engine"
-version = "0.2.0"
+version = "0.2.1"
 edition = "2021"
 publish = false
 

--- a/crates/nteract-markdown-wasm/Cargo.toml
+++ b/crates/nteract-markdown-wasm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "nteract-markdown-wasm"
-version = "0.2.0"
+version = "0.2.1"
 edition = "2021"
 publish = false
 

--- a/crates/nteract-mcp/Cargo.toml
+++ b/crates/nteract-mcp/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "nteract-mcp"
-version = "0.4.0"
+version = "0.4.1"
 edition.workspace = true
 description = "nteract MCP server — resilient proxy in front of `runt mcp`. Ships as a sidecar in the nteract desktop app, inside the .mcpb Claude Desktop extension, and in the Claude Code plugin."
 repository.workspace = true

--- a/crates/nteract-predicate/Cargo.toml
+++ b/crates/nteract-predicate/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "nteract-predicate"
-version = "0.4.0"
+version = "0.4.1"
 edition = "2021"
 description = "Pure-Rust compute kernels for dataframe/Arrow analysis (summary, filter, histogram)"
 

--- a/crates/nteract-telemetry/Cargo.toml
+++ b/crates/nteract-telemetry/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "nteract-telemetry"
-version = "2.6.0"
+version = "2.6.1"
 edition.workspace = true
 description = "Anonymous phone-home telemetry for nteract Rust binaries"
 repository.workspace = true

--- a/crates/playdate-image/Cargo.toml
+++ b/crates/playdate-image/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "playdate-image"
-version = "0.2.0"
+version = "0.2.1"
 edition.workspace = true
 license.workspace = true
 repository.workspace = true

--- a/crates/repr-llm/Cargo.toml
+++ b/crates/repr-llm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "repr-llm"
-version = "0.4.0"
+version = "0.4.1"
 edition.workspace = true
 description = "LLM-friendly text summaries of structured visualization specs"
 repository.workspace = true

--- a/crates/runt-mcp-proxy/Cargo.toml
+++ b/crates/runt-mcp-proxy/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "runt-mcp-proxy"
-version = "0.4.0"
+version = "0.4.1"
 edition.workspace = true
 description = "Resilient MCP proxy for runt mcp — child process supervision, restart-with-retry, session tracking, and version awareness"
 repository.workspace = true

--- a/crates/runt-mcp/Cargo.toml
+++ b/crates/runt-mcp/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "runt-mcp"
-version = "0.5.0"
+version = "0.5.1"
 edition.workspace = true
 description = "Rust-native MCP server for nteract notebook interaction"
 repository.workspace = true

--- a/crates/runt-publish/Cargo.toml
+++ b/crates/runt-publish/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "runt-publish"
-version = "0.2.0"
+version = "0.2.1"
 edition.workspace = true
 description = "Publisher library for hosted nteract notebook-cloud demos (CLI surface: `runt publish`)"
 repository.workspace = true

--- a/crates/runt-trust/Cargo.toml
+++ b/crates/runt-trust/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "runt-trust"
-version = "0.5.0"
+version = "0.5.1"
 edition.workspace = true
 description = "Notebook trust extraction for the per-machine package allowlist"
 repository.workspace = true

--- a/crates/runt-workspace/Cargo.toml
+++ b/crates/runt-workspace/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "runt-workspace"
-version = "0.5.0"
+version = "0.5.1"
 edition.workspace = true
 description = "Workspace and dev mode utilities for Runt"
 repository.workspace = true

--- a/crates/runt/Cargo.toml
+++ b/crates/runt/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "runt"
-version = "2.6.0"
+version = "2.6.1"
 edition.workspace = true
 description = "CLI for Jupyter Runtimes — bundled with nteract"
 repository.workspace = true

--- a/crates/runtime-doc/Cargo.toml
+++ b/crates/runtime-doc/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "runtime-doc"
-version = "0.4.0"
+version = "0.4.1"
 edition.workspace = true
 description = "RuntimeStateDoc and RuntimeStateHandle — per-notebook Automerge document for runtime-authoritative state"
 repository.workspace = true

--- a/crates/runtimed-client/Cargo.toml
+++ b/crates/runtimed-client/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "runtimed-client"
-version = "2.6.0"
+version = "2.6.1"
 edition.workspace = true
 description = "Client library for communicating with the runtimed daemon"
 repository.workspace = true

--- a/crates/runtimed-node/Cargo.toml
+++ b/crates/runtimed-node/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "runtimed-node"
-version = "0.5.0"
+version = "0.5.1"
 edition = "2021"
 description = "Node.js (napi-rs) bindings for the runtimed daemon client"
 repository.workspace = true

--- a/crates/runtimed-outputs/Cargo.toml
+++ b/crates/runtimed-outputs/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "runtimed-outputs"
-version = "2.6.0"
+version = "2.6.1"
 edition.workspace = true
 description = "Output resolution and LLM-friendly output formatting for runtimed"
 repository.workspace = true

--- a/crates/runtimed-py/Cargo.toml
+++ b/crates/runtimed-py/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "runtimed-py"
-version = "2.6.0"
+version = "2.6.1"
 edition = "2021"
 description = "Python bindings for runtimed daemon client"
 repository.workspace = true

--- a/crates/runtimed-service/Cargo.toml
+++ b/crates/runtimed-service/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "runtimed-service"
-version = "2.6.0"
+version = "2.6.1"
 edition.workspace = true
 description = "Cross-platform service management for the runtimed daemon"
 repository.workspace = true

--- a/crates/runtimed-settings-sync/Cargo.toml
+++ b/crates/runtimed-settings-sync/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "runtimed-settings-sync"
-version = "2.6.0"
+version = "2.6.1"
 edition.workspace = true
 description = "Live settings sync client over the runtimed UDS protocol"
 repository.workspace = true

--- a/crates/runtimed-wasm/Cargo.toml
+++ b/crates/runtimed-wasm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "runtimed-wasm"
-version = "0.5.0"
+version = "0.5.1"
 edition.workspace = true
 license = "BSD-3-Clause"
 repository = "https://github.com/nteract/nteract"

--- a/crates/runtimed/Cargo.toml
+++ b/crates/runtimed/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "runtimed"
-version = "2.6.0"
+version = "2.6.1"
 edition.workspace = true
 description = "Central daemon for managing Jupyter runtimes and prewarmed environments"
 repository.workspace = true

--- a/crates/sift-wasm/Cargo.toml
+++ b/crates/sift-wasm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sift-wasm"
-version = "0.4.0"
+version = "0.4.1"
 edition.workspace = true
 description = "WASM bindings for nteract-predicate — used by @nteract/sift"
 repository = "https://github.com/nteract/nteract"

--- a/crates/xtask/Cargo.toml
+++ b/crates/xtask/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "xtask"
-version = "0.4.0"
+version = "0.4.1"
 edition.workspace = true
 repository.workspace = true
 license.workspace = true

--- a/packages/notebook-host/package.json
+++ b/packages/notebook-host/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nteract/notebook-host",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "private": true,
   "type": "module",
   "main": "./src/index.ts",

--- a/packages/runtimed-node/npm/darwin-arm64/package.json
+++ b/packages/runtimed-node/npm/darwin-arm64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@runtimed/node-darwin-arm64",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "description": "macOS arm64 native N-API binding for @runtimed/node.",
   "type": "commonjs",
   "main": "./runtimed-node.darwin-arm64.node",

--- a/packages/runtimed-node/npm/linux-x64-gnu/package.json
+++ b/packages/runtimed-node/npm/linux-x64-gnu/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@runtimed/node-linux-x64-gnu",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "description": "Linux x64 GNU native N-API binding for @runtimed/node.",
   "type": "commonjs",
   "main": "./runtimed-node.linux-x64-gnu.node",

--- a/packages/runtimed-node/npm/win32-x64-msvc/package.json
+++ b/packages/runtimed-node/npm/win32-x64-msvc/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@runtimed/node-win32-x64-msvc",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "description": "Windows x64 MSVC native N-API binding for @runtimed/node.",
   "type": "commonjs",
   "main": "./runtimed-node.win32-x64-msvc.node",

--- a/packages/runtimed-node/package.json
+++ b/packages/runtimed-node/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@runtimed/node",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "description": "Node.js bindings for controlling nteract runtimed notebooks and Python kernels.",
   "type": "module",
   "license": "BSD-3-Clause",

--- a/packages/runtimed/package.json
+++ b/packages/runtimed/package.json
@@ -1,6 +1,6 @@
 {
   "name": "runtimed",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "private": true,
   "type": "module",
   "main": "./src/index.ts",

--- a/packages/sift/package.json
+++ b/packages/sift/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nteract/sift",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "type": "module",
   "main": "./src/index.ts",
   "types": "./src/index.ts",

--- a/plugins/nightly/.claude-plugin/plugin.json
+++ b/plugins/nightly/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "nightly",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "description": "nteract notebooks (nightly channel) for Claude Code.",
   "repository": "https://github.com/nteract/nteract"
 }

--- a/plugins/nightly/.codex-plugin/plugin.json
+++ b/plugins/nightly/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "nightly",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "description": "nteract notebooks (nightly channel) for Codex.",
   "author": {
     "name": "nteract contributors",

--- a/plugins/nteract/.claude-plugin/plugin.json
+++ b/plugins/nteract/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "nteract",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "description": "Skills for working with nteract notebooks",
   "repository": "https://github.com/nteract/nteract"
 }

--- a/plugins/nteract/.codex-plugin/plugin.json
+++ b/plugins/nteract/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "nteract",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "description": "Open, run, and edit nteract notebooks from Codex",
   "author": {
     "name": "nteract contributors",

--- a/plugins/nteract/pi/package.json
+++ b/plugins/nteract/pi/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nteract/pi",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "description": "Persistent notebook-backed Python REPL for Pi coding agents. Stateful execution, hot dependency sync, zero cold starts.",
   "author": "nteract contributors",
   "icon": "icon.png",

--- a/python/dx/pyproject.toml
+++ b/python/dx/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "dx"
-version = "2.3.0"
+version = "2.3.1"
 description = "nteract/dx — efficient display and blob-store uploads from Python kernels"
 readme = "README.md"
 license = "BSD-3-Clause"

--- a/python/nteract-kernel-launcher/pyproject.toml
+++ b/python/nteract-kernel-launcher/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "nteract-kernel-launcher"
-version = "0.5.0"
+version = "0.5.1"
 description = "IPKernelApp subclass that wires nteract DataFrame formatters, buffer hooks, and the 'Enhanced Data Experience' bootstrap extension into a superpowered IPython kernel."
 readme = "README.md"
 license = "BSD-3-Clause"

--- a/python/nteract/pyproject.toml
+++ b/python/nteract/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "nteract"
-version = "2.6.0"
+version = "2.6.1"
 description = "Bring AI to Jupyter notebooks. MCP server for Claude, ChatGPT, Gemini, OpenCode and any agent."
 readme = "README.md"
 license = "BSD-3-Clause"

--- a/python/prewarm/pyproject.toml
+++ b/python/prewarm/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "prewarm"
-version = "0.3.0"
+version = "0.3.1"
 description = "Warm up Python environments by importing packages and triggering side effects (font caches, C extensions, BLAS discovery)."
 readme = "README.md"
 license = "BSD-3-Clause"

--- a/python/runtimed/pyproject.toml
+++ b/python/runtimed/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "runtimed"
-version = "2.6.0"
+version = "2.6.1"
 description = "Python toolkit for Jupyter runtimes, powered by runtimed Rust binaries"
 readme = "README.md"
 license = "BSD-3-Clause"


### PR DESCRIPTION
## Summary

- Bump the coordinated release sources from 2.6.0 to 2.6.1.
- Bump frontend/package and agent plugin manifests, including Codex and Claude plugin marketplace entries.
- Add curated 2.6.1 release highlights for the stable release page.

## Verification

- `cargo check`
- `cargo xtask lint --fix`

## Notes

- `cargo check` initially hit stale Tauri build output with absolute paths from another checkout; `cargo clean -p tauri` cleared the local cache and the rerun passed.
