### PR TITLE
ci: fix published Windows app smoke release lookup

### DIFF
--- a/.github/workflows/smoke.yml
+++ b/.github/workflows/smoke.yml
@@ -46,6 +46,7 @@ jobs:
         shell: pwsh
         env:
           GH_TOKEN: ${{ github.token }}
+          GH_REPO: ${{ github.repository }}
           RELEASE_TAG: ${{ github.event_name == 'release' && github.event.release.tag_name || inputs.release_tag }}
         run: |
           if (-not $env:RELEASE_TAG) {
@@ -88,6 +89,7 @@ jobs:
         shell: pwsh
         env:
           GH_TOKEN: ${{ github.token }}
+          GH_REPO: ${{ github.repository }}
           RELEASE_TAG: ${{ steps.release.outputs.tag }}
           ASSET_NAME: ${{ steps.release.outputs.asset }}
         run: |
@@ -275,7 +277,7 @@ jobs:
         env:
           DISCORD_WEBHOOK_WINDOWS: ${{ secrets.DISCORD_WEBHOOK_WINDOWS }}
           RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
-          RELEASE_TAG: ${{ steps.release.outputs.tag }}
+          RELEASE_TAG: ${{ steps.release.outputs.tag || github.event.release.tag_name || inputs.release_tag }}
         run: |
           if [ -z "$DISCORD_WEBHOOK_WINDOWS" ]; then
             echo "DISCORD_WEBHOOK_WINDOWS not set, skipping notification"


### PR DESCRIPTION
## Summary

- Fix the published Windows app-launch smoke so GitHub CLI has explicit repository context before checkout.
- Preserve the release tag in the Discord failure notification even if the release-asset resolution step fails early.

## Verification

- `tmpdir=$(mktemp -d); cd "$tmpdir" && GH_REPO=nteract/nteract gh release view v2.6.1-nightly.202606272247 --json assets --jq '.assets[].name' | rg '^nteract-nightly-windows-x64\.exe$'`
- `git diff --check`
- `actionlint .github/workflows/smoke.yml`
- `cargo xtask lint --fix`
- Targeted workflow dispatch: https://github.com/nteract/nteract/actions/runs/28305840825 passed `Windows app launch smoke`
- Local Bedrock review: `uv run pr-review ... --model amazon-bedrock/us.anthropic.claude-opus-4-8` returned `verdict=clear`, no findings

## Notes

The failed manual smoke run was https://github.com/nteract/nteract/actions/runs/28304990543. It failed before installer download because `gh release view` could not infer the repository from a job with no checkout.
