### PR TITLE
fix(ci): resolve published smoke release repo

### DIFF
--- a/.github/workflows/smoke.yml
+++ b/.github/workflows/smoke.yml
@@ -46,6 +46,7 @@ jobs:
         shell: pwsh
         env:
           GH_TOKEN: ${{ github.token }}
+          GH_REPO: ${{ github.repository }}
           RELEASE_TAG: ${{ github.event_name == 'release' && github.event.release.tag_name || inputs.release_tag }}
         run: |
           if (-not $env:RELEASE_TAG) {
@@ -88,6 +89,7 @@ jobs:
         shell: pwsh
         env:
           GH_TOKEN: ${{ github.token }}
+          GH_REPO: ${{ github.repository }}
           RELEASE_TAG: ${{ steps.release.outputs.tag }}
           ASSET_NAME: ${{ steps.release.outputs.asset }}
         run: |
@@ -275,7 +277,7 @@ jobs:
         env:
           DISCORD_WEBHOOK_WINDOWS: ${{ secrets.DISCORD_WEBHOOK_WINDOWS }}
           RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
-          RELEASE_TAG: ${{ steps.release.outputs.tag }}
+          RELEASE_TAG: ${{ steps.release.outputs.tag || github.event.release.tag_name || inputs.release_tag }}
         run: |
           if [ -z "$DISCORD_WEBHOOK_WINDOWS" ]; then
             echo "DISCORD_WEBHOOK_WINDOWS not set, skipping notification"


### PR DESCRIPTION
## Summary

- Give the published Windows app-launch smoke job explicit GitHub CLI repository context when resolving and downloading release assets.
- Preserve release-tag context in the Discord failure notification even when the asset-resolution step fails before setting outputs.

## Verification

- `gh run view 28304990543 --repo nteract/nteract --log-failed`
- `env GH_REPO=nteract/nteract gh release view v2.6.1-nightly.202606272247 --json assets --jq '.assets[].name'`
- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/smoke.yml"); puts "yaml ok"'`
- `actionlint .github/workflows/smoke.yml`
- `git diff --check -- .github/workflows/smoke.yml`
- `corepack pnpm install --frozen-lockfile`
- `cargo xtask lint --fix`
