### PR TITLE
test(runtimed-py): avoid shutdown auto-launch race

### DIFF
--- a/python/runtimed/tests/test_daemon_integration.py
+++ b/python/runtimed/tests/test_daemon_integration.py
@@ -2291,8 +2291,11 @@ class TestKernelLifecycle:
 
     async def test_async_shutdown_kernel(self, session):
         """Can shutdown the kernel."""
-        await async_start_kernel_with_retry(session)
-        assert await session.kernel_started()
+        await async_use_auto_kernel_or_start(
+            session,
+            description="shutdown-kernel auto-launched kernel",
+        )
+        assert runtime_kernel_is_running(session)
 
         await session.shutdown_kernel()
         assert not await session.kernel_started()


### PR DESCRIPTION
## Summary

- Update `test_async_shutdown_kernel` to use the existing auto-kernel helper instead of issuing an immediate manual `LaunchKernel`.
- Keep the test behavior focused on proving a usable kernel exists, then verifying `shutdown_kernel()` clears the session's started state.

## Rationale

`create_notebook(runtime="python")` auto-launches a kernel for the session fixture. The old test immediately called `async_start_kernel_with_retry(session)`, which can race that auto-launch and spend repeated retry attempts inside the daemon's launch-in-progress path. This test does not need a custom environment or manual launch semantics, so it should wait for the auto-launched runtime state first and only fall back to the existing retry helper if no usable kernel appears.

`kernel_started()` is session-cache based, so after using the auto-launch path the pre-shutdown assertion now checks `RuntimeStateDoc` through `runtime_kernel_is_running(session)`. The post-shutdown assertion remains `not await session.kernel_started()` because `shutdown_kernel()` updates that cache.

## Verification

- `python3 -m py_compile python/runtimed/tests/test_daemon_integration.py`
- `git diff --check`
- `uv run ruff check python/runtimed/tests/test_daemon_integration.py`

Attempted but not completed locally:

- `uv run --directory python/runtimed pytest tests/test_daemon_integration.py::TestKernelLifecycle::test_async_shutdown_kernel --collect-only -q`
  - Interrupted after the local `runtimed` package build produced no further output.
- `cargo xtask lint --fix`
  - Rust formatting, Python ruff, and Python ty passed.
  - The JS/Vite step failed because `vite-plus` was not installed in this checkout.
- `pnpm install --frozen-lockfile`
  - Blocked by local pnpm supply-chain policy on existing lockfile entries: `chokidar@4.0.3`, `semver@6.3.1`, and `undici-types@6.21.0`.
