### PR TITLE
test(runtimed-py): wait for queued execution result

### DIFF
--- a/python/runtimed/tests/test_daemon_integration.py
+++ b/python/runtimed/tests/test_daemon_integration.py
@@ -2046,7 +2046,7 @@ class TestDocumentFirstExecution:
 
         # Create and queue execution
         cell_id = await async_create_cell_and_wait_for_sync(
-            session, "async_queued_var = 'async_queued'"
+            session, "async_queued_var = 'async_queued'\nprint(async_queued_var)"
         )
         execution_id = await session.queue_cell(cell_id)
 
@@ -2055,17 +2055,11 @@ class TestDocumentFirstExecution:
         assert len(execution_id) == 36, f"Expected UUID (36 chars), got {len(execution_id)!r}"
         assert execution_id.count("-") == 4, f"Expected UUID format, got {execution_id!r}"
 
-        # Poll until the queued cell has executed.
-        # We verify execution by checking that a follow-up cell can read the variable.
-        import asyncio
-
-        await asyncio.sleep(2.0)  # Give the queued cell time to execute
-
-        # Verify it ran by executing another cell that uses the variable
-        cell2 = await async_create_cell_and_wait_for_sync(session, "print(async_queued_var)")
-        result = await session.execute_cell(cell2)
+        result = await session.wait_for_execution(cell_id, execution_id, timeout_secs=30.0)
 
         assert result.success
+        assert result.cell_id == cell_id
+        assert result.execution_id == execution_id
         assert "async_queued" in result.stdout
 
     async def test_async_execution_error_captured(self, session):


### PR DESCRIPTION
## Summary

- make `test_async_queue_cell_fires_execution` wait for the exact `execution_id` returned by `queue_cell`
- verify the queued cell's own stdout/result instead of sleeping and executing a second follow-up cell
- keep UUID/result assertions so the test still proves `queue_cell` fires execution and returns a usable execution id

## CI context

Current `main` Build run `28306186725` failed in `runtimed-py Integration Tests`:

- job: `83862617064`
- test: `tests/test_daemon_integration.py::TestDocumentFirstExecution::test_async_queue_cell_fires_execution`
- failure: pytest-timeout after 600s

The failed test used a fixed `sleep(2.0)` and then launched a second execution to infer that the queued cell had run. This patch waits on the runtime-state execution record for the queued cell directly, so failures are bounded to that execution id.

## Verification

- `git lfs pull`
- `cargo xtask artifacts ensure renderer`
- `RUNTIMED_INTEGRATION_TEST=1 RUNTIMED_BINARY="$PWD/target/debug/runtimed" RUNTIMED_LOG_LEVEL=debug .venv/bin/python -m pytest python/runtimed/tests/test_daemon_integration.py::TestDocumentFirstExecution::test_async_queue_cell_fires_execution -vv --timeout=180` - passed, `1 passed in 49.46s`
- `cargo xtask lint --fix` - passed

## Notes

- Initial `cargo xtask integration test_async_queue_cell_fires_execution` attempt stopped before pytest because stable renderer plugin bundles were still Git LFS pointers and generated renderer assets were missing in this fresh worktree.
- After artifact hydration/generation, `cargo xtask integration test_async_queue_cell_fires_execution` selected the broader integration set instead of the single node id, so I stopped it and ran the exact pytest target directly against `target/debug/runtimed`.
