### PR TITLE
test(runtimed-py): clean up open notebook sessions

### DIFF
--- a/python/runtimed/tests/test_daemon_integration.py
+++ b/python/runtimed/tests/test_daemon_integration.py
@@ -376,6 +376,18 @@ async def async_create_cell_and_wait_for_sync(
     return cell_id
 
 
+async def async_cleanup_session(session):
+    """Release a native test session's kernel and peer connection."""
+    try:
+        await session.shutdown_kernel()
+    except Exception:
+        pass
+    try:
+        await session.close()
+    except Exception:
+        pass
+
+
 def assert_daemon_starter_cell(cells):
     """Fresh daemon-owned notebooks start with one empty code cell."""
     assert len(cells) == 1
@@ -2383,7 +2395,7 @@ class TestErrorHandling:
 
     async def test_async_syntax_error(self, session):
         """Syntax errors are captured."""
-        await async_start_kernel_with_retry(session)
+        await async_use_auto_kernel_or_start(session)
 
         warmup_cell = await async_create_cell_and_wait_for_sync(session, "warmup = 1")
         warmup_result = await session.execute_cell(warmup_cell, timeout_secs=120)
@@ -2779,20 +2791,22 @@ class TestOpenNotebook:
             )
         )
 
-        # Open via daemon
         session = await client.open_notebook(str(nb_path))
-        assert await session.is_connected()
+        try:
+            assert await session.is_connected()
 
-        # With UUID-first identity, notebook_id is a UUID, not a path
-        import uuid
+            # With UUID-first identity, notebook_id is a UUID, not a path
+            import uuid
 
-        uuid.UUID(session.notebook_id)  # validates it's a well-formed UUID
+            uuid.UUID(session.notebook_id)  # validates it's a well-formed UUID
 
-        # Verify cells loaded
-        cells = await session.get_cells()
-        assert len(cells) == 2
-        assert cells[0].source == "x = 1"
-        assert cells[1].cell_type == "markdown"
+            # Verify cells loaded
+            cells = await session.get_cells()
+            assert len(cells) == 2
+            assert cells[0].source == "x = 1"
+            assert cells[1].cell_type == "markdown"
+        finally:
+            await async_cleanup_session(session)
 
     async def test_open_notebook_returns_connection_info(self, client, tmp_path):
         """NotebookConnectionInfo includes cell_count.
@@ -2839,12 +2853,15 @@ class TestOpenNotebook:
         )
 
         session = await client.open_notebook(str(nb_path))
-        info = await session.connection_info()
-        assert info is not None
-        # Streaming load defers cell loading to the sync loop, so the
-        # handshake reports 0 cells. Cells arrive via sync messages.
-        assert info.cell_count == 0
-        assert info.notebook_id == session.notebook_id
+        try:
+            info = await session.connection_info()
+            assert info is not None
+            # Streaming load defers cell loading to the sync loop, so the
+            # handshake reports 0 cells. Cells arrive via sync messages.
+            assert info.cell_count == 0
+            assert info.notebook_id == session.notebook_id
+        finally:
+            await async_cleanup_session(session)
 
     async def test_open_nonexistent_file_creates_notebook(self, client, tmp_path):
         """Opening missing file creates a new notebook at that path."""
@@ -2858,7 +2875,7 @@ class TestOpenNotebook:
 
             uuid.UUID(info.notebook_id)  # validates it's a well-formed UUID
         finally:
-            await session.close()
+            await async_cleanup_session(session)
 
     async def test_open_nonexistent_file_auto_appends_ipynb(self, client, tmp_path):
         """Opening missing file without .ipynb extension auto-appends it."""
@@ -2872,7 +2889,7 @@ class TestOpenNotebook:
 
             uuid.UUID(info.notebook_id)  # validates it's a well-formed UUID
         finally:
-            await session.close()
+            await async_cleanup_session(session)
 
     @pytest.mark.skipif(
         os.environ.get("RUNTIMED_INTEGRATION_TEST") == "1",
@@ -2905,24 +2922,28 @@ class TestOpenNotebook:
         session1 = await client.open_notebook(str(nb_path))
         session2 = await client.open_notebook(str(nb_path))
 
-        # Both should have same notebook_id
-        assert session1.notebook_id == session2.notebook_id
+        try:
+            # Both should have same notebook_id
+            assert session1.notebook_id == session2.notebook_id
 
-        # Add cell in session1
-        cells1 = await session1.get_cells()
-        initial_count = len(cells1)
-        await session1.create_cell("y = 2", index=initial_count)
+            # Add cell in session1
+            cells1 = await session1.get_cells()
+            initial_count = len(cells1)
+            await session1.create_cell("y = 2", index=initial_count)
 
-        # Should sync to session2 (open_notebook sessions do full-peer sync
-        # which can be slower on loaded CI runners — use generous timeout)
-        async def cell_synced():
-            cells = await session2.get_cells()
-            return len(cells) > initial_count
+            # Should sync to session2 (open_notebook sessions do full-peer sync
+            # which can be slower on loaded CI runners — use generous timeout)
+            async def cell_synced():
+                cells = await session2.get_cells()
+                return len(cells) > initial_count
 
-        await async_wait_for_sync(cell_synced, timeout=15.0, description="cell sync")
+            await async_wait_for_sync(cell_synced, timeout=15.0, description="cell sync")
 
-        cells2 = await session2.get_cells()
-        assert len(cells2) > initial_count
+            cells2 = await session2.get_cells()
+            assert len(cells2) > initial_count
+        finally:
+            await async_cleanup_session(session2)
+            await async_cleanup_session(session1)
 
 
 class TestCreateNotebook:


### PR DESCRIPTION
## Summary

- clean up native `open_notebook()` integration-test sessions by shutting down kernels before closing peer handles
- switch `test_async_syntax_error` to the existing auto-launch-aware kernel helper

## Evidence

Fresh main run `28308718404` on `b8473c1024a7e89f88ef9a88142a7da2f5fd40fd` failed `runtimed-py Integration Tests` job `83869503486`.

Confirmed from GitHub job log and copied artifacts:
- `tests/test_daemon_integration.py::TestDocumentFirstExecution::test_async_queue_cell_fires_execution` passed.
- `tests/test_daemon_integration.py::TestErrorHandling::test_async_syntax_error` timed out after 600s.
- The failed test never reached the invalid-code `ExecuteCell` before timeout.
- Daemon logs showed repeated 60s `LaunchKernel` requests for a file-backed notebook from `TestOpenNotebook::test_open_notebook_returns_connection_info`, plus metadata-only file-watch churn on `three_cells.ipynb`.

## Verification

- `cargo xtask artifacts ensure sift,renderer`
- `RUNTIMED_TEST_UV_POOL_SIZE=1 RUNTIMED_TEST_CONDA_POOL_SIZE=0 RUNTIMED_LOG_LEVEL=debug python/runtimed/tests/run-integration.sh --build --ci tests/test_daemon_integration.py::TestOpenNotebook::test_open_notebook_returns_connection_info tests/test_daemon_integration.py::TestErrorHandling::test_async_syntax_error`
- `cargo xtask lint --fix`
- `git diff --check`

Note: the first attempted local run used the prompt's stale `./tests/run-integration.sh` path and failed before pytest. The first correct runner attempt then failed before pytest because this worktree had missing generated renderer assets and LFS pointer bundles; hydrating LFS and running the artifact ensure command fixed local setup.

## Residual Risk

- This is a harness/test-isolation fix. It does not change product runtime behavior.
- CI is still required because the original failure involved full-suite ordering and GitHub-hosted Linux runner pressure.
