### PR TITLE
fix(notebook): stabilize document anchor scrolling

### DIFF
--- a/apps/notebook-cloud/test/viewer-shared-cell-surface.test.ts
+++ b/apps/notebook-cloud/test/viewer-shared-cell-surface.test.ts
@@ -609,7 +609,7 @@ test("cloud viewer shell uses the shared notebook rail as an adapter surface", (
   assert.match(sourceText, /onNavigateOutlineItem=\{handleNavigateOutlineItem\}/);
   assert.match(
     sourceText,
-    /navigateNotebookOutlineItem\(item, href, \{ headingHashTarget: "cell" \}\)/,
+    /navigateNotebookOutlineItem\(item, href, \{[\s\S]*documentAnchors,[\s\S]*headingHashTarget: "cell",[\s\S]*\}\)/,
   );
   assert.doesNotMatch(sourceText, /findCellElement: \(outlineItem\)/);
 });
@@ -625,7 +625,7 @@ test("cloud outline keeps iframe heading hashes at parent cell anchors", () => {
   );
   assert.match(
     sourceText,
-    /navigateNotebookOutlineItem\(item, hash, \{\s+behavior: "auto",\s+headingHashTarget: "cell",\s+\}\)/,
+    /navigateNotebookOutlineItem\(item, hash, \{\s+behavior: "auto",\s+documentAnchors,\s+headingHashTarget: "cell",\s+\}\)/,
   );
 });
 

--- a/apps/notebook-cloud/viewer/notebook-viewer.tsx
+++ b/apps/notebook-cloud/viewer/notebook-viewer.tsx
@@ -720,8 +720,9 @@ export function NotebookViewer({
     metadata: notebookMetadata,
     resolveLanguage: cloudSourceLanguage,
     getOutlineStatusLabel,
+    includeDocumentAnchors: true,
   });
-  const { codeCellCount, outlineItems } = notebookViewModel;
+  const { codeCellCount, documentAnchors, outlineItems } = notebookViewModel;
   const notebookCellIds = notebookViewModel.cellIds;
   const activeOutlineItemId = useActiveOutlineItemId(
     outlineItems,
@@ -748,15 +749,19 @@ export function NotebookViewer({
     handleSelectOutlineItem(item);
     navigateNotebookOutlineItem(item, hash, {
       behavior: "auto",
+      documentAnchors,
       headingHashTarget: "cell",
     });
-  }, [handleSelectOutlineItem, outlineItems]);
+  }, [documentAnchors, handleSelectOutlineItem, outlineItems]);
   const handleNavigateOutlineItem = useCallback(
     (item: NotebookOutlineItem, href: string) => {
       handleSelectOutlineItem(item);
-      return navigateNotebookOutlineItem(item, href, { headingHashTarget: "cell" });
+      return navigateNotebookOutlineItem(item, href, {
+        documentAnchors,
+        headingHashTarget: "cell",
+      });
     },
-    [handleSelectOutlineItem],
+    [documentAnchors, handleSelectOutlineItem],
   );
   const handleTogglePackagesRail = useCallback(() => {
     if (activeRailPanel === "packages" && !railCollapsed) {

--- a/apps/notebook/src/App.tsx
+++ b/apps/notebook/src/App.tsx
@@ -1210,8 +1210,12 @@ function AppContent() {
   const handleNotebookViewFocus = useCallback(() => {}, []);
 
   const getOutlineStatusLabel = useOutlineStatusLabel();
-  const notebookViewModel = useNotebookViewModel({ getOutlineStatusLabel });
+  const notebookViewModel = useNotebookViewModel({
+    getOutlineStatusLabel,
+    includeDocumentAnchors: true,
+  });
   const outlineItems = notebookViewModel.outlineItems;
+  const documentAnchors = notebookViewModel.documentAnchors;
   const markdownHeadingAnchorsByCellId = notebookViewModel.markdownHeadingAnchorsByCellId;
   const activeOutlineItemId = useActiveOutlineItemId(
     outlineItems,
@@ -1356,9 +1360,15 @@ function AppContent() {
     toggleNotebookRailPanel("packages");
   }, [shellCapabilities.canViewPackages]);
 
-  const handleNavigateOutlineItem = useCallback((item: NotebookOutlineItem, href: string) => {
-    return navigateNotebookOutlineItem(item, href, { headingHashTarget: "cell" });
-  }, []);
+  const handleNavigateOutlineItem = useCallback(
+    (item: NotebookOutlineItem, href: string) => {
+      return navigateNotebookOutlineItem(item, href, {
+        documentAnchors,
+        headingHashTarget: "cell",
+      });
+    },
+    [documentAnchors],
+  );
 
   const getObservedHeads = useCallback(() => getHandle()?.get_heads_hex() ?? [], [getHandle]);
 

--- a/apps/notebook/src/components/NotebookView.tsx
+++ b/apps/notebook/src/components/NotebookView.tsx
@@ -17,13 +17,22 @@ import {
 } from "@dnd-kit/sortable";
 import { CSS as DndCSS } from "@dnd-kit/utilities";
 import { Eye, EyeOff, Plus, RotateCcw, Trash2, X } from "lucide-react";
-import { memo, useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { memo, useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState } from "react";
 import { notebookCellAnchorId, type NotebookInteractionTarget } from "runtimed";
 import { CellInsertionRibbon, type CellInsertionType } from "@/components/cell/CellInsertionRibbon";
 import { CellSkeleton } from "@/components/cell/CellSkeleton";
 import { Button } from "@/components/ui/button";
 import type { NteractEmbedHostContextPatch } from "@/components/isolated/host-context";
-import type { NotebookShellCapabilities } from "@/components/notebook";
+import {
+  captureCellDeletionScrollAnchor,
+  isNotebookTailPinned,
+  restoreScrollAnchor,
+  scrollToDocumentAnchor,
+  scrollToNotebookTail,
+  shouldTailFollowCellCountChange,
+  type NotebookScrollAnchorSnapshot,
+  type NotebookShellCapabilities,
+} from "@/components/notebook";
 import type { MarkdownHeadingAnchor } from "@/components/outputs/markdown-heading-anchors";
 import type { Runtime } from "@/hooks/useSyncedSettings";
 import { ErrorBoundary } from "@/lib/error-boundary";
@@ -395,6 +404,8 @@ function NotebookViewContent({
   const containerRef = useRef<HTMLDivElement>(null);
   const tailPinnedRef = useRef(false);
   const tailScrollFrameRef = useRef<number | null>(null);
+  const previousCellCountRef = useRef(cellIds.length);
+  const pendingScrollAnchorRef = useRef<NotebookScrollAnchorSnapshot | null>(null);
   const canEditCodeCellSources = capabilities?.canEditCells ?? !readOnly;
   const canEditMarkdownSources = capabilities?.canEditMarkdown ?? !readOnly;
   const canMutateCells = computeCanMutateCells({ canAcceptCellMutations, capabilities, readOnly });
@@ -677,6 +688,26 @@ function NotebookViewContent({
     cancelTailScrollFrame();
   }, [cancelTailScrollFrame]);
 
+  const handleDeleteCell = useCallback(
+    (cellId: string) => {
+      tailPinnedRef.current = false;
+      cancelTailScrollFrame();
+      pendingScrollAnchorRef.current = captureCellDeletionScrollAnchor(
+        containerRef.current,
+        cellIdsRef.current,
+        cellId,
+      );
+      onDeleteCell(cellId);
+    },
+    [cancelTailScrollFrame, onDeleteCell],
+  );
+
+  useLayoutEffect(() => {
+    if (!pendingScrollAnchorRef.current) return;
+    restoreScrollAnchor(containerRef.current, pendingScrollAnchorRef.current);
+    pendingScrollAnchorRef.current = null;
+  }, [cellIds.length, materializeVersion, outputStructureVersion]);
+
   // Prevent horizontal scroll drift (can happen during text selection) and
   // remember whether the user is already reading at the notebook tail.
   useEffect(() => {
@@ -693,28 +724,23 @@ function NotebookViewContent({
         return;
       }
 
-      const distanceFromTail =
-        container.scrollHeight - container.clientHeight - container.scrollTop;
-      if (distanceFromTail <= NOTEBOOK_TAIL_PIN_THRESHOLD_PX) {
-        tailPinnedRef.current = true;
-        return;
-      }
-
       const lastCellId = cellIdsRef.current.at(-1);
       const lastCellEl = lastCellId
         ? container.querySelector(`[data-cell-id="${CSS.escape(lastCellId)}"]`)
         : null;
-      if (!lastCellEl) {
-        tailPinnedRef.current = false;
-        return;
-      }
-
       const containerRect = container.getBoundingClientRect();
-      const lastCellRect = lastCellEl.getBoundingClientRect();
-      tailPinnedRef.current =
-        lastCellRect.bottom >= containerRect.top &&
-        lastCellRect.top <= containerRect.bottom &&
-        lastCellRect.bottom >= containerRect.bottom - NOTEBOOK_TAIL_PIN_THRESHOLD_PX;
+      const lastCellRect = lastCellEl?.getBoundingClientRect() ?? null;
+      tailPinnedRef.current = isNotebookTailPinned({
+        cellCount: cellIdsRef.current.length,
+        containerScrollHeight: container.scrollHeight,
+        containerClientHeight: container.clientHeight,
+        containerScrollTop: container.scrollTop,
+        containerTop: containerRect.top,
+        containerBottom: containerRect.bottom,
+        lastCellTop: lastCellRect?.top ?? null,
+        lastCellBottom: lastCellRect?.bottom ?? null,
+        thresholdPx: NOTEBOOK_TAIL_PIN_THRESHOLD_PX,
+      });
     };
 
     handleScroll();
@@ -732,7 +758,7 @@ function NotebookViewContent({
       if (!tailPinnedRef.current) return;
       const currentContainer = containerRef.current;
       if (!currentContainer) return;
-      currentContainer.scrollTop = currentContainer.scrollHeight;
+      scrollToNotebookTail(currentContainer);
     });
   }, []);
 
@@ -750,19 +776,23 @@ function NotebookViewContent({
   }, [scheduleTailScrollIfPinned]);
 
   useEffect(() => {
-    scheduleTailScrollIfPinned();
+    const previousCellCount = previousCellCountRef.current;
+    previousCellCountRef.current = cellIds.length;
+    if (shouldTailFollowCellCountChange(previousCellCount, cellIds.length, tailPinnedRef.current)) {
+      scheduleTailScrollIfPinned();
+    }
   }, [cellIds.length, scheduleTailScrollIfPinned]);
 
   // Scroll the current search match cell into view
   useEffect(() => {
     if (!searchCurrentMatch) return;
-    const cellEl = containerRef.current?.querySelector(
-      `[data-cell-id="${CSS.escape(searchCurrentMatch.cellId)}"]`,
-    );
-    if (cellEl) {
-      cellEl.scrollIntoView({ block: "nearest", behavior: "smooth" });
-    }
-  }, [searchCurrentMatch]);
+    tailPinnedRef.current = false;
+    cancelTailScrollFrame();
+    scrollToDocumentAnchor(containerRef.current, notebookCellAnchorId(searchCurrentMatch.cellId), {
+      block: "nearest",
+      behavior: "smooth",
+    });
+  }, [cancelTailScrollFrame, searchCurrentMatch]);
 
   useEffect(() => {
     if (!autoFocusFirstCell) return;
@@ -837,7 +867,7 @@ function NotebookViewContent({
         <button
           type="button"
           tabIndex={-1}
-          onClick={() => onDeleteCell(cell.id)}
+          onClick={() => handleDeleteCell(cell.id)}
           className="flex items-center justify-center rounded p-1 text-muted-foreground/40 transition-colors hover:text-destructive"
           title="Delete cell"
         >
@@ -944,7 +974,7 @@ function NotebookViewContent({
             onRequestExecute={requestExecuteCellOrHiddenGroup}
             onRequestExecuteInPlace={requestExecuteCellInPlaceOrHiddenGroup}
             onInterrupt={onInterruptKernel}
-            onDelete={canMutateCells ? () => onDeleteCell(cell.id) : undefined}
+            onDelete={canMutateCells ? () => handleDeleteCell(cell.id) : undefined}
             onFocusPrevious={onFocusPrevious}
             onFocusNext={onFocusNext}
             onNavigateToCell={onNavigateToCell}
@@ -1021,7 +1051,7 @@ function NotebookViewContent({
             onFocus={() => {
               focusInteractionTarget({ kind: "editor", cellId: cell.id });
             }}
-            onDelete={canMutateCells ? () => onDeleteCell(cell.id) : undefined}
+            onDelete={canMutateCells ? () => handleDeleteCell(cell.id) : undefined}
             onUpdateSource={
               canMutateCells && canEditMarkdownSources && onUpdateCellSource
                 ? (source: string) => onUpdateCellSource(cell.id, source)
@@ -1060,7 +1090,7 @@ function NotebookViewContent({
           onFocus={() => {
             focusInteractionTarget({ kind: "editor", cellId: cell.id });
           }}
-          onDelete={canMutateCells ? () => onDeleteCell(cell.id) : undefined}
+          onDelete={canMutateCells ? () => handleDeleteCell(cell.id) : undefined}
           onFocusPrevious={onFocusPrevious}
           onFocusNext={onFocusNext}
           onInsertCellAfter={canMutateCells ? () => onAddCell("code", cell.id) : undefined}
@@ -1085,7 +1115,7 @@ function NotebookViewContent({
       suppressTailFollowForInPlaceExecution,
       onExecuteCell,
       onInterruptKernel,
-      onDeleteCell,
+      handleDeleteCell,
       onUpdateCellSource,
       onAddCell,
       onChangeCellType,
@@ -1224,7 +1254,7 @@ function NotebookViewContent({
                     index={index}
                     renderCell={renderCell}
                     onAddCell={onAddCell}
-                    onDeleteCell={onDeleteCell}
+                    onDeleteCell={handleDeleteCell}
                     isLastCell={index === cellIds.length - 1}
                     isHiddenInGroup={group != null && !group.isFirst}
                     canMutateCells={canMutateCells}

--- a/apps/notebook/src/components/NotebookView.tsx
+++ b/apps/notebook/src/components/NotebookView.tsx
@@ -706,7 +706,7 @@ function NotebookViewContent({
     if (!pendingScrollAnchorRef.current) return;
     restoreScrollAnchor(containerRef.current, pendingScrollAnchorRef.current);
     pendingScrollAnchorRef.current = null;
-  }, [cellIds.length, materializeVersion, outputStructureVersion]);
+  }, [cellIds.length]);
 
   // Prevent horizontal scroll drift (can happen during text selection) and
   // remember whether the user is already reading at the notebook tail.

--- a/apps/notebook/src/components/NotebookView.tsx
+++ b/apps/notebook/src/components/NotebookView.tsx
@@ -118,6 +118,12 @@ export interface NotebookViewProps {
   autoFocusFirstCell?: boolean;
 }
 
+interface PendingNotebookScrollAnchorRestore {
+  deletedCellId: string;
+  sourceCellIds: readonly string[];
+  snapshot: NotebookScrollAnchorSnapshot;
+}
+
 const NOTEBOOK_TAIL_SPACE = "clamp(4rem, 10vh, 6rem)";
 const NOTEBOOK_TAIL_PIN_THRESHOLD_PX = 96;
 
@@ -405,7 +411,7 @@ function NotebookViewContent({
   const tailPinnedRef = useRef(false);
   const tailScrollFrameRef = useRef<number | null>(null);
   const previousCellCountRef = useRef(cellIds.length);
-  const pendingScrollAnchorRef = useRef<NotebookScrollAnchorSnapshot | null>(null);
+  const pendingScrollAnchorRef = useRef<PendingNotebookScrollAnchorRestore | null>(null);
   const canEditCodeCellSources = capabilities?.canEditCells ?? !readOnly;
   const canEditMarkdownSources = capabilities?.canEditMarkdown ?? !readOnly;
   const canMutateCells = computeCanMutateCells({ canAcceptCellMutations, capabilities, readOnly });
@@ -692,21 +698,30 @@ function NotebookViewContent({
     (cellId: string) => {
       tailPinnedRef.current = false;
       cancelTailScrollFrame();
-      pendingScrollAnchorRef.current = captureCellDeletionScrollAnchor(
-        containerRef.current,
-        cellIdsRef.current,
-        cellId,
-      );
+      const sourceCellIds = cellIdsRef.current;
+      const snapshot = captureCellDeletionScrollAnchor(containerRef.current, sourceCellIds, cellId);
+      pendingScrollAnchorRef.current = snapshot
+        ? {
+            deletedCellId: cellId,
+            sourceCellIds,
+            snapshot,
+          }
+        : null;
       onDeleteCell(cellId);
     },
     [cancelTailScrollFrame, onDeleteCell],
   );
 
   useLayoutEffect(() => {
-    if (!pendingScrollAnchorRef.current) return;
-    restoreScrollAnchor(containerRef.current, pendingScrollAnchorRef.current);
+    const pending = pendingScrollAnchorRef.current;
+    if (!pending) return;
+    if (cellIds === pending.sourceCellIds) return;
+
     pendingScrollAnchorRef.current = null;
-  }, [cellIds.length]);
+    if (cellIds.includes(pending.deletedCellId)) return;
+
+    restoreScrollAnchor(containerRef.current, pending.snapshot);
+  }, [cellIds]);
 
   // Prevent horizontal scroll drift (can happen during text selection) and
   // remember whether the user is already reading at the notebook tail.

--- a/apps/notebook/src/components/__tests__/notebook-view-capabilities-source.test.ts
+++ b/apps/notebook/src/components/__tests__/notebook-view-capabilities-source.test.ts
@@ -78,13 +78,16 @@ describe("NotebookView shell capabilities", () => {
 
     expect(sourceText).toMatch(/const previousCellCountRef = useRef\(cellIds\.length\);/);
     expect(sourceText).toMatch(
-      /const pendingScrollAnchorRef = useRef<NotebookScrollAnchorSnapshot \| null>\(null\);/,
+      /interface PendingNotebookScrollAnchorRestore \{[\s\S]*deletedCellId: string;[\s\S]*sourceCellIds: readonly string\[\];[\s\S]*snapshot: NotebookScrollAnchorSnapshot;/,
     );
     expect(sourceText).toMatch(
-      /const handleDeleteCell = useCallback\([\s\S]*tailPinnedRef\.current = false;[\s\S]*cancelTailScrollFrame\(\);[\s\S]*pendingScrollAnchorRef\.current = captureCellDeletionScrollAnchor\([\s\S]*onDeleteCell\(cellId\);/,
+      /const pendingScrollAnchorRef = useRef<PendingNotebookScrollAnchorRestore \| null>\(null\);/,
     );
     expect(sourceText).toMatch(
-      /useLayoutEffect\(\(\) => \{[\s\S]*restoreScrollAnchor\(containerRef\.current, pendingScrollAnchorRef\.current\);[\s\S]*pendingScrollAnchorRef\.current = null;/,
+      /const handleDeleteCell = useCallback\([\s\S]*tailPinnedRef\.current = false;[\s\S]*cancelTailScrollFrame\(\);[\s\S]*const sourceCellIds = cellIdsRef\.current;[\s\S]*const snapshot = captureCellDeletionScrollAnchor\(containerRef\.current, sourceCellIds, cellId\);[\s\S]*pendingScrollAnchorRef\.current = snapshot[\s\S]*onDeleteCell\(cellId\);/,
+    );
+    expect(sourceText).toMatch(
+      /useLayoutEffect\(\(\) => \{[\s\S]*const pending = pendingScrollAnchorRef\.current;[\s\S]*if \(cellIds === pending\.sourceCellIds\) return;[\s\S]*pendingScrollAnchorRef\.current = null;[\s\S]*if \(cellIds\.includes\(pending\.deletedCellId\)\) return;[\s\S]*restoreScrollAnchor\(containerRef\.current, pending\.snapshot\);[\s\S]*\}, \[cellIds\]\);/,
     );
     expect(sourceText).toMatch(
       /if \(shouldTailFollowCellCountChange\(previousCellCount, cellIds\.length, tailPinnedRef\.current\)\) \{[\s\S]*scheduleTailScrollIfPinned\(\);[\s\S]*\}/,

--- a/apps/notebook/src/components/__tests__/notebook-view-capabilities-source.test.ts
+++ b/apps/notebook/src/components/__tests__/notebook-view-capabilities-source.test.ts
@@ -25,7 +25,7 @@ describe("NotebookView shell capabilities", () => {
     expect(sourceText).toMatch(/onRequestExecute=\{requestExecuteCellOrHiddenGroup\}/);
     expect(sourceText).toMatch(/<MarkdownCell[\s\S]*readOnly=\{!canEditMarkdownSources\}/);
     expect(sourceText).toMatch(
-      /onDelete=\{canMutateCells \? \(\) => onDeleteCell\(cell\.id\) : undefined\}/,
+      /onDelete=\{canMutateCells \? \(\) => handleDeleteCell\(cell\.id\) : undefined\}/,
     );
     expect(sourceText).toMatch(
       /onInsertCellAfter=\{canMutateCells \? \(\) => onAddCell\("markdown", cell\.id\) : undefined\}/,
@@ -68,6 +68,31 @@ describe("NotebookView shell capabilities", () => {
     );
     expect(sourceText).toMatch(/onExecute=\{executeCellOrHiddenGroup\}/);
     expect(sourceText).toMatch(/onExecuteInPlace=\{executeCellInPlaceOrHiddenGroup\}/);
+  });
+
+  it("does not route cell deletion through tail-follow scrolling", () => {
+    const sourceText = readFileSync(
+      join(process.cwd(), "apps/notebook/src/components/NotebookView.tsx"),
+      "utf8",
+    );
+
+    expect(sourceText).toMatch(/const previousCellCountRef = useRef\(cellIds\.length\);/);
+    expect(sourceText).toMatch(
+      /const pendingScrollAnchorRef = useRef<NotebookScrollAnchorSnapshot \| null>\(null\);/,
+    );
+    expect(sourceText).toMatch(
+      /const handleDeleteCell = useCallback\([\s\S]*tailPinnedRef\.current = false;[\s\S]*cancelTailScrollFrame\(\);[\s\S]*pendingScrollAnchorRef\.current = captureCellDeletionScrollAnchor\([\s\S]*onDeleteCell\(cellId\);/,
+    );
+    expect(sourceText).toMatch(
+      /useLayoutEffect\(\(\) => \{[\s\S]*restoreScrollAnchor\(containerRef\.current, pendingScrollAnchorRef\.current\);[\s\S]*pendingScrollAnchorRef\.current = null;/,
+    );
+    expect(sourceText).toMatch(
+      /if \(shouldTailFollowCellCountChange\(previousCellCount, cellIds\.length, tailPinnedRef\.current\)\) \{[\s\S]*scheduleTailScrollIfPinned\(\);[\s\S]*\}/,
+    );
+    expect(sourceText).toMatch(/onDeleteCell=\{handleDeleteCell\}/);
+    expect(sourceText).not.toMatch(/currentContainer\.scrollTop = currentContainer\.scrollHeight/);
+    expect(sourceText).toMatch(/scrollToNotebookTail\(currentContainer\)/);
+    expect(sourceText).toMatch(/scrollToDocumentAnchor\(containerRef\.current/);
   });
 
   it("does not create cells from a transient empty sync state", () => {

--- a/apps/notebook/src/hooks/useEditorRegistry.tsx
+++ b/apps/notebook/src/hooks/useEditorRegistry.tsx
@@ -1,4 +1,5 @@
 import { EditorView } from "@codemirror/view";
+import { scrollElementIntoView } from "@/components/notebook";
 import { createContext, type ReactNode, useCallback, useContext } from "react";
 import { logger } from "../lib/logger";
 
@@ -31,7 +32,7 @@ export function EditorRegistryProvider({ children }: { children: ReactNode }) {
       }
 
       // Scroll the cell container into the notebook viewport
-      cellElement.scrollIntoView({ block: "nearest", behavior: "smooth" });
+      scrollElementIntoView(cellElement, { block: "nearest", behavior: "auto" });
 
       // Find CodeMirror's content element inside the cell
       const cmContent = cellElement.querySelector(".cm-content");

--- a/apps/notebook/src/lib/__tests__/cell-outputs-decoupling.test.tsx
+++ b/apps/notebook/src/lib/__tests__/cell-outputs-decoupling.test.tsx
@@ -221,6 +221,22 @@ describe("Phase C-lite: cell subscription / outputs decoupling", () => {
     );
   });
 
+  it("passes document anchor projection options through the notebook view-model hook", () => {
+    act(() => {
+      replaceNotebookCells([codeCell("code-1")]);
+    });
+
+    const { result } = renderHook(() => useNotebookViewModel({ includeDocumentAnchors: true }));
+
+    expect(result.current.documentAnchors).toEqual([
+      expect.objectContaining({
+        id: "notebook-cell-code-1",
+        kind: "cell",
+        cellId: "code-1",
+      }),
+    ]);
+  });
+
   it("does not re-render cell A when only cell B's outputs change", () => {
     // Seed both cells with one output each.
     const oA = streamOutput("cell-a-initial");

--- a/src/components/notebook/__tests__/document-anchors.test.ts
+++ b/src/components/notebook/__tests__/document-anchors.test.ts
@@ -1,0 +1,242 @@
+import { describe, expect, it } from "vite-plus/test";
+import { setMarkdownProjectionProjector } from "@/lib/markdown-projection";
+import {
+  createDocumentAnchorMap,
+  createNotebookDocumentAnchors,
+  documentMarkdownBlockAnchorId,
+  type DocumentAnchor,
+} from "../document-anchors";
+import type { NotebookViewCell } from "../view-model";
+
+describe("notebook document anchors", () => {
+  it("keeps cell anchors stable when visual order changes", () => {
+    const first = codeViewCell("cell-a", "a = 1");
+    const second = codeViewCell("cell-b", "b = 2");
+
+    const original = createNotebookDocumentAnchors([first, second]);
+    const reordered = createNotebookDocumentAnchors([second, first]);
+
+    expect(cellAnchorIds(original)).toEqual(["notebook-cell-cell-a", "notebook-cell-cell-b"]);
+    expect(cellAnchorIds(reordered)).toEqual(["notebook-cell-cell-b", "notebook-cell-cell-a"]);
+    expect(anchorMap(reordered).get("notebook-cell-cell-a")).toMatchObject({
+      id: "notebook-cell-cell-a",
+      kind: "cell",
+      cellId: "cell-a",
+      domId: "notebook-cell-cell-a",
+    });
+  });
+
+  it("derives markdown heading and block anchors from the current projection", () => {
+    const source = "# Intro\n\nBody";
+    const cell = markdownViewCell("md-1", source, {
+      anchors: [{ title: "Intro", level: 1, slug: "intro", blockId: "heading-1" }],
+      blocks: [
+        { blockId: "heading-1", blockIndex: 0, kind: "heading", span: [0, 7] },
+        { blockId: "paragraph-1", blockIndex: 1, kind: "paragraph", span: [9, 13] },
+      ],
+    });
+
+    const anchors = createNotebookDocumentAnchors([cell]);
+
+    expect(anchors).toContainEqual(
+      expect.objectContaining({
+        id: "notebook-cell-md-1-heading-intro",
+        kind: "markdown_heading",
+        cellId: "md-1",
+        domId: "notebook-cell-md-1-heading-intro",
+        markdownAnchorSlug: "intro",
+      }),
+    );
+    expect(anchors).toContainEqual(
+      expect.objectContaining({
+        id: documentMarkdownBlockAnchorId("md-1", "paragraph-1"),
+        kind: "markdown_block",
+        cellId: "md-1",
+        domId: "notebook-cell-md-1",
+        markdownBlockId: "paragraph-1",
+        sourceSpanUtf16: [9, 13],
+      }),
+    );
+  });
+
+  it("projects output anchors from stable output ids", () => {
+    const anchors = createNotebookDocumentAnchors([
+      {
+        ...codeViewCell("plot", "plot()"),
+        outputs: [
+          {
+            output_id: "plot-output",
+            output_type: "display_data",
+            data: { "image/png": "iVBORw0KGgo=" },
+            metadata: {},
+          },
+        ],
+      },
+    ]);
+
+    expect(anchors).toContainEqual(
+      expect.objectContaining({
+        id: "notebook-cell-plot-output-plot-output",
+        kind: "output",
+        cellId: "plot",
+        domId: "notebook-cell-plot-output-plot-output",
+        outputId: "plot-output",
+      }),
+    );
+  });
+
+  it("drops markdown anchors when the current source is blank", () => {
+    const staleCell = markdownViewCell("md-blank", "# Old", {
+      anchors: [{ title: "Old", level: 1, slug: "old", blockId: "old-heading" }],
+      blocks: [{ blockId: "old-heading", blockIndex: 0, kind: "heading", span: [0, 5] }],
+    });
+
+    const anchors = createNotebookDocumentAnchors([{ ...staleCell, source: "  \n" }]);
+
+    expect(anchors.map((anchor) => anchor.kind)).toEqual(["cell"]);
+  });
+
+  it("falls back to stale attached markdown anchors when no projector is registered", () => {
+    const staleCell = markdownViewCell("md-stale", "# Old", {
+      anchors: [{ title: "Old", level: 1, slug: "old", blockId: "old-heading" }],
+      blocks: [{ blockId: "old-heading", blockIndex: 0, kind: "heading", span: [0, 5] }],
+    });
+
+    const anchors = createNotebookDocumentAnchors([{ ...staleCell, source: "# New" }]);
+
+    expect(anchorMap(anchors).get("notebook-cell-md-stale-heading-old")).toMatchObject({
+      kind: "markdown_heading",
+      cellId: "md-stale",
+      markdownAnchorSlug: "old",
+    });
+  });
+
+  it("reprojects stale markdown anchors when a projector is available", () => {
+    const restore = setMarkdownProjectionProjector((source) =>
+      JSON.stringify(
+        testMarkdownProjection(source, {
+          anchors: [{ title: "New", level: 1, slug: "new", blockId: "new-heading" }],
+          blocks: [{ blockId: "new-heading", blockIndex: 0, kind: "heading", span: [0, 5] }],
+        }),
+      ),
+    );
+
+    try {
+      const staleCell = markdownViewCell("md-reproject", "# Old", {
+        anchors: [{ title: "Old", level: 1, slug: "old", blockId: "old-heading" }],
+        blocks: [{ blockId: "old-heading", blockIndex: 0, kind: "heading", span: [0, 5] }],
+      });
+
+      const anchors = createNotebookDocumentAnchors([{ ...staleCell, source: "# New" }]);
+
+      expect(anchorMap(anchors).has("notebook-cell-md-reproject-heading-old")).toBe(false);
+      expect(anchorMap(anchors).get("notebook-cell-md-reproject-heading-new")).toMatchObject({
+        kind: "markdown_heading",
+        cellId: "md-reproject",
+        markdownAnchorSlug: "new",
+      });
+    } finally {
+      restore();
+    }
+  });
+});
+
+function cellAnchorIds(anchors: readonly DocumentAnchor[]): string[] {
+  return anchors.filter((anchor) => anchor.kind === "cell").map((anchor) => anchor.id);
+}
+
+function anchorMap(anchors: readonly DocumentAnchor[]) {
+  return createDocumentAnchorMap(anchors);
+}
+
+function codeViewCell(id: string, source: string): NotebookViewCell {
+  return {
+    id,
+    cellType: "code",
+    source,
+    language: "python",
+    executionId: null,
+    executionCount: null,
+    outputs: [],
+    metadata: {},
+  };
+}
+
+function markdownViewCell(
+  id: string,
+  source: string,
+  projection: {
+    anchors: readonly { title: string; level: number; slug: string; blockId: string }[];
+    blocks: readonly {
+      blockId: string;
+      blockIndex: number;
+      kind: string;
+      span: readonly [number, number];
+    }[];
+  },
+): NotebookViewCell {
+  return {
+    id,
+    cellType: "markdown",
+    source,
+    language: null,
+    executionId: null,
+    executionCount: null,
+    outputs: [],
+    metadata: {},
+    markdownProjection: testMarkdownProjection(source, projection),
+  };
+}
+
+function testMarkdownProjection(
+  source: string,
+  projection: {
+    anchors: readonly { title: string; level: number; slug: string; blockId: string }[];
+    blocks: readonly {
+      blockId: string;
+      blockIndex: number;
+      kind: string;
+      span: readonly [number, number];
+    }[];
+  },
+) {
+  return {
+    version: 1 as const,
+    engine: "test",
+    source,
+    byteLength: source.length,
+    utf16Length: source.length,
+    measurement: {
+      estimatedHeight: 32,
+      confidence: "high",
+      width: 720,
+    },
+    anchors: projection.anchors.map((anchor) => ({
+      anchorId: `anchor:${anchor.slug}`,
+      blockId: anchor.blockId,
+      level: anchor.level,
+      slug: anchor.slug,
+      sourceSpanByte: [0, source.length] as [number, number],
+      sourceSpanUtf16: [0, source.length] as [number, number],
+      title: anchor.title,
+    })),
+    blocks: projection.blocks.map((block) => ({
+      anchorSlug:
+        projection.anchors.find((anchor) => anchor.blockId === block.blockId)?.slug ?? undefined,
+      blockId: block.blockId,
+      blockIndex: block.blockIndex,
+      element: block.kind === "heading" ? "h1" : "p",
+      kind: block.kind,
+      measurement: {
+        estimatedHeight: 24,
+        confidence: "medium",
+        width: 720,
+      },
+      sourceSpanByte: block.span,
+      sourceSpanUtf16: block.span,
+      syntaxSpans: [],
+      text: source.slice(block.span[0], block.span[1]),
+    })),
+    runs: [],
+  };
+}

--- a/src/components/notebook/__tests__/outline-navigation.test.ts
+++ b/src/components/notebook/__tests__/outline-navigation.test.ts
@@ -1,5 +1,6 @@
 import { afterEach, describe, expect, it, vi } from "vite-plus/test";
 import type { NotebookOutlineItem } from "runtimed";
+import type { DocumentAnchor } from "../document-anchors";
 import { navigateNotebookOutlineItem } from "../outline-navigation";
 
 describe("navigateNotebookOutlineItem", () => {
@@ -66,6 +67,42 @@ describe("navigateNotebookOutlineItem", () => {
     await Promise.resolve();
     expect(target.scrollIntoView).toHaveBeenCalled();
     expect(window.location.hash).toBe("#notebook-cell-code-1");
+  });
+
+  it("resolves outline targets through document anchors when provided", () => {
+    const target = document.createElement("div");
+    target.id = "rendered-output-target";
+    target.scrollIntoView = vi.fn();
+    document.body.append(target);
+
+    const documentAnchor: DocumentAnchor = {
+      id: "notebook-cell-plot-output-plot-output",
+      kind: "output",
+      cellId: "plot",
+      cellAnchorId: "notebook-cell-plot",
+      domId: "rendered-output-target",
+      href: "#notebook-cell-plot-output-plot-output",
+      outputAnchorId: "notebook-cell-plot-output-plot-output",
+      outputId: "plot-output",
+    };
+    const item = outlineItem({
+      id: "plot:output:plot-output",
+      kind: "output",
+      cellId: "plot",
+      cellAnchorId: "notebook-cell-plot",
+      href: "#notebook-cell-plot-output-plot-output",
+    });
+
+    expect(
+      navigateNotebookOutlineItem(item, "#notebook-cell-plot-output-plot-output", {
+        behavior: "auto",
+        documentAnchors: [documentAnchor],
+      }),
+    ).toBe(true);
+    expect(target.scrollIntoView).toHaveBeenCalledWith({
+      block: "start",
+      behavior: "auto",
+    });
   });
 
   it("rejects non-anchor outline hrefs", () => {

--- a/src/components/notebook/__tests__/scroll-anchors.test.ts
+++ b/src/components/notebook/__tests__/scroll-anchors.test.ts
@@ -63,6 +63,21 @@ describe("notebook scroll anchors", () => {
     });
   });
 
+  it("skips zero-height candidates when choosing a visible anchor", () => {
+    const snapshot = selectCellDeletionScrollAnchor(
+      [candidate("hidden-group-placeholder", 0, 0), candidate("cell-b", 24, 160)],
+      ["hidden-group-placeholder", "cell-b"],
+      "cell-a",
+      500,
+    );
+
+    expect(snapshot).toEqual({
+      anchorId: "notebook-cell-cell-b",
+      cellId: "cell-b",
+      offsetFromContainerTop: 24,
+    });
+  });
+
   it("allows tail-follow only on cell-count increases while pinned", () => {
     expect(shouldTailFollowCellCountChange(2, 3, true)).toBe(true);
     expect(shouldTailFollowCellCountChange(3, 2, true)).toBe(false);

--- a/src/components/notebook/__tests__/scroll-anchors.test.ts
+++ b/src/components/notebook/__tests__/scroll-anchors.test.ts
@@ -1,0 +1,181 @@
+import { afterEach, describe, expect, it, vi } from "vite-plus/test";
+import {
+  captureCellDeletionScrollAnchor,
+  isNotebookTailPinned,
+  restoreScrollAnchor,
+  scrollToDocumentAnchor,
+  selectCellDeletionScrollAnchor,
+  shouldTailFollowCellCountChange,
+} from "../scroll-anchors";
+
+describe("notebook scroll anchors", () => {
+  afterEach(() => {
+    document.body.innerHTML = "";
+    vi.restoreAllMocks();
+  });
+
+  it("preserves the current top visible anchor when deleting a cell above the viewport", () => {
+    const snapshot = selectCellDeletionScrollAnchor(
+      [
+        candidate("cell-a", -180, -20),
+        candidate("cell-b", -10, 120),
+        candidate("cell-c", 120, 260),
+      ],
+      ["cell-a", "cell-b", "cell-c"],
+      "cell-a",
+      500,
+    );
+
+    expect(snapshot).toEqual({
+      anchorId: "notebook-cell-cell-b",
+      cellId: "cell-b",
+      offsetFromContainerTop: -10,
+    });
+  });
+
+  it("falls forward when the deleted cell is the top visible anchor", () => {
+    const snapshot = selectCellDeletionScrollAnchor(
+      [candidate("cell-a", -20, 180), candidate("cell-b", 180, 320), candidate("cell-c", 320, 460)],
+      ["cell-a", "cell-b", "cell-c"],
+      "cell-a",
+      500,
+    );
+
+    expect(snapshot).toEqual({
+      anchorId: "notebook-cell-cell-b",
+      cellId: "cell-b",
+      offsetFromContainerTop: -20,
+    });
+  });
+
+  it("falls backward when deleting the last visible cell", () => {
+    const snapshot = selectCellDeletionScrollAnchor(
+      [candidate("cell-a", -220, -20), candidate("cell-b", -20, 180)],
+      ["cell-a", "cell-b"],
+      "cell-b",
+      500,
+    );
+
+    expect(snapshot).toEqual({
+      anchorId: "notebook-cell-cell-a",
+      cellId: "cell-a",
+      offsetFromContainerTop: -20,
+    });
+  });
+
+  it("allows tail-follow only on cell-count increases while pinned", () => {
+    expect(shouldTailFollowCellCountChange(2, 3, true)).toBe(true);
+    expect(shouldTailFollowCellCountChange(3, 2, true)).toBe(false);
+    expect(shouldTailFollowCellCountChange(2, 2, true)).toBe(false);
+    expect(shouldTailFollowCellCountChange(2, 3, false)).toBe(false);
+  });
+
+  it("computes tail-pinned state from distance or last-cell visibility", () => {
+    expect(
+      isNotebookTailPinned({
+        cellCount: 2,
+        containerScrollHeight: 1000,
+        containerClientHeight: 400,
+        containerScrollTop: 520,
+        containerTop: 0,
+        containerBottom: 400,
+        lastCellTop: 360,
+        lastCellBottom: 460,
+        thresholdPx: 96,
+      }),
+    ).toBe(true);
+
+    expect(
+      isNotebookTailPinned({
+        cellCount: 2,
+        containerScrollHeight: 1000,
+        containerClientHeight: 400,
+        containerScrollTop: 200,
+        containerTop: 0,
+        containerBottom: 400,
+        lastCellTop: 100,
+        lastCellBottom: 350,
+        thresholdPx: 40,
+      }),
+    ).toBe(false);
+  });
+
+  it("captures and restores a deletion anchor against real DOM positions", () => {
+    const { container, cells } = mountScrollFixture([
+      ["cell-a", -20, 180],
+      ["cell-b", 180, 320],
+    ]);
+
+    const snapshot = captureCellDeletionScrollAnchor(container, ["cell-a", "cell-b"], "cell-a");
+    expect(snapshot).toEqual({
+      anchorId: "notebook-cell-cell-b",
+      cellId: "cell-b",
+      offsetFromContainerTop: -20,
+    });
+
+    setRect(cells["cell-b"], 20, 160);
+    container.scrollTop = 240;
+
+    expect(restoreScrollAnchor(container, snapshot)).toBe(true);
+    expect(container.scrollTop).toBe(280);
+  });
+
+  it("routes anchor navigation through a container-owned DOM lookup", () => {
+    const { container, cells } = mountScrollFixture([["cell-a", 0, 100]]);
+    cells["cell-a"].scrollIntoView = vi.fn();
+
+    expect(scrollToDocumentAnchor(container, "notebook-cell-cell-a", { behavior: "smooth" })).toBe(
+      true,
+    );
+    expect(cells["cell-a"].scrollIntoView).toHaveBeenCalledWith({
+      block: "nearest",
+      behavior: "smooth",
+      inline: undefined,
+    });
+  });
+});
+
+function candidate(cellId: string, top: number, bottom: number) {
+  return {
+    anchorId: `notebook-cell-${cellId}`,
+    cellId,
+    top,
+    bottom,
+  };
+}
+
+function mountScrollFixture(rects: readonly (readonly [string, number, number])[]) {
+  const container = document.createElement("div");
+  setRect(container, 0, 500);
+  Object.defineProperty(container, "scrollHeight", { configurable: true, value: 1000 });
+  Object.defineProperty(container, "clientHeight", { configurable: true, value: 500 });
+  const cells: Record<string, HTMLElement> = {};
+
+  for (const [cellId, top, bottom] of rects) {
+    const cell = document.createElement("div");
+    cell.id = `notebook-cell-${cellId}`;
+    setRect(cell, top, bottom);
+    container.append(cell);
+    cells[cellId] = cell;
+  }
+
+  document.body.append(container);
+  return { container, cells };
+}
+
+function setRect(element: Element, top: number, bottom: number): void {
+  element.getBoundingClientRect = vi.fn(
+    () =>
+      ({
+        x: 0,
+        y: top,
+        top,
+        bottom,
+        left: 0,
+        right: 100,
+        width: 100,
+        height: bottom - top,
+        toJSON: () => ({}),
+      }) as DOMRect,
+  );
+}

--- a/src/components/notebook/__tests__/view-model.test.ts
+++ b/src/components/notebook/__tests__/view-model.test.ts
@@ -388,6 +388,7 @@ describe("notebook shell view model", () => {
     ];
 
     const viewModel = createNotebookViewModel(cells, {
+      includeDocumentAnchors: true,
       resolveLanguage: resolveTestLanguage,
     });
 
@@ -472,6 +473,7 @@ describe("notebook shell view model", () => {
       cellId: "code-1",
       statusLabel: null,
     });
+    expect(viewModel.documentAnchors).toEqual([]);
     expect(viewModel.readOnlyCells[0].language).toBeNull();
   });
 

--- a/src/components/notebook/__tests__/view-model.test.ts
+++ b/src/components/notebook/__tests__/view-model.test.ts
@@ -393,6 +393,13 @@ describe("notebook shell view model", () => {
 
     expect(viewModel.cells).toBe(cells);
     expect(viewModel.cellIds).toEqual(["code-1"]);
+    expect(viewModel.documentAnchors).toEqual([
+      expect.objectContaining({
+        id: "notebook-cell-code-1",
+        kind: "cell",
+        cellId: "code-1",
+      }),
+    ]);
     expect(viewModel.codeCellCount).toBe(1);
     expect(viewModel.readOnlyCells[0]).toMatchObject({
       id: "code-1",

--- a/src/components/notebook/document-anchors.ts
+++ b/src/components/notebook/document-anchors.ts
@@ -109,6 +109,24 @@ export function createDocumentAnchorMap(
   return new Map(anchors.map((anchor) => [anchor.id, anchor]));
 }
 
+export function documentAnchorForOutlineItem(
+  item: NotebookOutlineItem,
+  anchors: readonly DocumentAnchor[],
+): DocumentAnchor | null {
+  const anchorId = documentAnchorIdForOutlineItem(item);
+  return anchors.find((anchor) => anchor.id === anchorId) ?? null;
+}
+
+export function documentAnchorIdForOutlineItem(item: NotebookOutlineItem): DocumentAnchorId {
+  if (item.kind === "heading" && item.headingAnchorId !== null) {
+    return item.headingAnchorId;
+  }
+  if (item.kind === "output" && item.href.startsWith("#")) {
+    return item.href.slice(1);
+  }
+  return item.cellAnchorId;
+}
+
 export function documentMarkdownBlockAnchorId(cellId: string, blockId: string): DocumentAnchorId {
   return `${notebookCellAnchorId(cellId)}-markdown-block-${encodeURIComponent(blockId)}`;
 }

--- a/src/components/notebook/document-anchors.ts
+++ b/src/components/notebook/document-anchors.ts
@@ -5,7 +5,7 @@ import {
   projectNotebookOutline,
   type NotebookOutlineItem,
 } from "runtimed";
-import { resolveMarkdownProjection } from "@/lib/markdown-projection";
+import { resolveMarkdownProjection } from "../../lib/markdown-projection";
 import type { NotebookViewCell } from "./view-model";
 
 export type DocumentAnchorId = string;

--- a/src/components/notebook/document-anchors.ts
+++ b/src/components/notebook/document-anchors.ts
@@ -1,0 +1,124 @@
+import {
+  notebookCellAnchorHref,
+  notebookCellAnchorId,
+  notebookOutputAnchorId,
+  projectNotebookOutline,
+  type NotebookOutlineItem,
+} from "runtimed";
+import { resolveMarkdownProjection } from "@/lib/markdown-projection";
+import type { NotebookViewCell } from "./view-model";
+
+export type DocumentAnchorId = string;
+
+export type DocumentAnchorKind = "cell" | "markdown_block" | "markdown_heading" | "output";
+
+export interface DocumentAnchor {
+  id: DocumentAnchorId;
+  kind: DocumentAnchorKind;
+  cellId: string;
+  cellAnchorId: string;
+  domId: string;
+  href: string;
+  cellType?: NotebookViewCell["cellType"];
+  markdownBlockId?: string;
+  markdownHeadingAnchorId?: string;
+  markdownAnchorSlug?: string | null;
+  outlineItemId?: string;
+  outputId?: string;
+  outputAnchorId?: string;
+  sourceSpanUtf16?: readonly [number, number];
+}
+
+export interface CreateNotebookDocumentAnchorsOptions {
+  outlineItems?: readonly NotebookOutlineItem[];
+}
+
+export function createNotebookDocumentAnchors(
+  cells: readonly NotebookViewCell[],
+  options: CreateNotebookDocumentAnchorsOptions = {},
+): readonly DocumentAnchor[] {
+  const anchors: DocumentAnchor[] = [];
+  const outlineItems = options.outlineItems ?? outlineItemsForDocumentAnchors(cells);
+
+  for (const cell of cells) {
+    const cellAnchorId = notebookCellAnchorId(cell.id);
+    anchors.push({
+      id: cellAnchorId,
+      kind: "cell",
+      cellId: cell.id,
+      cellType: cell.cellType,
+      cellAnchorId,
+      domId: cellAnchorId,
+      href: notebookCellAnchorHref(cell.id),
+    });
+
+    const projection = resolveMarkdownProjection(cell.markdownProjection, cell.source);
+    for (const block of projection?.blocks ?? []) {
+      const blockAnchorId = documentMarkdownBlockAnchorId(cell.id, block.blockId);
+      anchors.push({
+        id: blockAnchorId,
+        kind: "markdown_block",
+        cellId: cell.id,
+        cellType: cell.cellType,
+        cellAnchorId,
+        domId: cellAnchorId,
+        href: notebookCellAnchorHref(cell.id),
+        markdownBlockId: block.blockId,
+        sourceSpanUtf16: block.sourceSpanUtf16,
+      });
+    }
+
+    for (const output of cell.outputs) {
+      if (!output.output_id) continue;
+      const outputAnchorId = notebookOutputAnchorId(cell.id, output.output_id);
+      anchors.push({
+        id: outputAnchorId,
+        kind: "output",
+        cellId: cell.id,
+        cellType: cell.cellType,
+        cellAnchorId,
+        domId: outputAnchorId,
+        href: `#${outputAnchorId}`,
+        outputAnchorId,
+        outputId: output.output_id,
+      });
+    }
+  }
+
+  for (const item of outlineItems) {
+    if (item.kind !== "heading" || item.headingAnchorId === null) continue;
+    anchors.push({
+      id: item.headingAnchorId,
+      kind: "markdown_heading",
+      cellId: item.cellId,
+      cellAnchorId: item.cellAnchorId,
+      domId: item.headingAnchorId,
+      href: item.href,
+      markdownHeadingAnchorId: item.headingAnchorId,
+      markdownAnchorSlug: item.anchor ?? null,
+      outlineItemId: item.id,
+    });
+  }
+
+  return anchors;
+}
+
+export function createDocumentAnchorMap(
+  anchors: readonly DocumentAnchor[],
+): ReadonlyMap<DocumentAnchorId, DocumentAnchor> {
+  return new Map(anchors.map((anchor) => [anchor.id, anchor]));
+}
+
+export function documentMarkdownBlockAnchorId(cellId: string, blockId: string): DocumentAnchorId {
+  return `${notebookCellAnchorId(cellId)}-markdown-block-${encodeURIComponent(blockId)}`;
+}
+
+function outlineItemsForDocumentAnchors(cells: readonly NotebookViewCell[]): NotebookOutlineItem[] {
+  return projectNotebookOutline(cells, {
+    hrefTarget: "heading",
+    getMarkdownAnchors: (cell) => {
+      if (!cell.source.trim()) return [];
+      return resolveMarkdownProjection(cell.markdownProjection, cell.source)?.anchors ?? null;
+    },
+  }).items;
+}

--- a/src/components/notebook/index.ts
+++ b/src/components/notebook/index.ts
@@ -213,6 +213,30 @@ export {
 } from "./NotebookContextMenu";
 export { computeCanMutateCells } from "./mutation-gate";
 export {
+  createDocumentAnchorMap,
+  createNotebookDocumentAnchors,
+  documentMarkdownBlockAnchorId,
+  type CreateNotebookDocumentAnchorsOptions,
+  type DocumentAnchor,
+  type DocumentAnchorId,
+  type DocumentAnchorKind,
+} from "./document-anchors";
+export {
+  captureCellDeletionScrollAnchor,
+  isNotebookTailPinned,
+  restoreScrollAnchor,
+  scrollElementIntoView,
+  scrollToDocumentAnchor,
+  scrollToNotebookTail,
+  selectCellDeletionScrollAnchor,
+  selectTopVisibleCellAnchor,
+  shouldTailFollowCellCountChange,
+  type NotebookScrollAnchorCandidate,
+  type NotebookScrollAnchorSnapshot,
+  type SelectNotebookScrollAnchorOptions,
+  type TailPinnedInput,
+} from "./scroll-anchors";
+export {
   createNotebookInteractionModeProjection,
   type CreateNotebookInteractionModeProjectionOptions,
   type NotebookInteractionHostSupport,

--- a/src/components/notebook/index.ts
+++ b/src/components/notebook/index.ts
@@ -215,6 +215,8 @@ export { computeCanMutateCells } from "./mutation-gate";
 export {
   createDocumentAnchorMap,
   createNotebookDocumentAnchors,
+  documentAnchorForOutlineItem,
+  documentAnchorIdForOutlineItem,
   documentMarkdownBlockAnchorId,
   type CreateNotebookDocumentAnchorsOptions,
   type DocumentAnchor,

--- a/src/components/notebook/outline-navigation.ts
+++ b/src/components/notebook/outline-navigation.ts
@@ -1,10 +1,12 @@
 import { navigateMarkdownHeading } from "@/components/cell/markdown-heading-navigation";
 import type { NotebookOutlineItem } from "runtimed";
+import { documentAnchorForOutlineItem, type DocumentAnchor } from "./document-anchors";
 import { scrollElementIntoView } from "./scroll-anchors";
 
 export interface NavigateNotebookOutlineItemOptions {
   behavior?: ScrollBehavior;
   block?: ScrollLogicalPosition;
+  documentAnchors?: readonly DocumentAnchor[];
   findCellElement?: (item: NotebookOutlineItem, href: string) => HTMLElement | null;
   headingHashTarget?: "heading" | "cell";
   updateHash?: boolean;
@@ -17,9 +19,12 @@ export function navigateNotebookOutlineItem(
 ): boolean {
   if (!href.startsWith("#")) return false;
 
+  const documentAnchor = options.documentAnchors
+    ? documentAnchorForOutlineItem(item, options.documentAnchors)
+    : null;
   const target = options.findCellElement
     ? options.findCellElement(item, href)
-    : defaultFindCellElement(item, href);
+    : defaultFindCellElement(item, href, documentAnchor);
   if (!target) return false;
 
   const behavior = options.behavior ?? "smooth";
@@ -50,7 +55,16 @@ export function navigateNotebookOutlineItem(
   return true;
 }
 
-function defaultFindCellElement(item: NotebookOutlineItem, href: string): HTMLElement | null {
+function defaultFindCellElement(
+  item: NotebookOutlineItem,
+  href: string,
+  documentAnchor: DocumentAnchor | null,
+): HTMLElement | null {
+  if (documentAnchor) {
+    const target = document.getElementById(documentAnchor.domId);
+    if (target) return target;
+  }
+
   const targetId = item.headingAnchorId ? item.cellAnchorId : href.slice(1);
   return document.getElementById(targetId);
 }

--- a/src/components/notebook/outline-navigation.ts
+++ b/src/components/notebook/outline-navigation.ts
@@ -1,5 +1,6 @@
 import { navigateMarkdownHeading } from "@/components/cell/markdown-heading-navigation";
 import type { NotebookOutlineItem } from "runtimed";
+import { scrollElementIntoView } from "./scroll-anchors";
 
 export interface NavigateNotebookOutlineItemOptions {
   behavior?: ScrollBehavior;
@@ -28,12 +29,12 @@ export function navigateNotebookOutlineItem(
     void navigateMarkdownHeading(item.cellId, item.headingAnchorId, { behavior }).then(
       (handled) => {
         if (!handled) {
-          target.scrollIntoView({ block, behavior });
+          scrollElementIntoView(target, { block, behavior });
         }
       },
     );
   } else {
-    target.scrollIntoView({ block, behavior });
+    scrollElementIntoView(target, { block, behavior });
   }
 
   if (options.updateHash ?? true) {

--- a/src/components/notebook/scroll-anchors.ts
+++ b/src/components/notebook/scroll-anchors.ts
@@ -38,6 +38,7 @@ export function selectTopVisibleCellAnchor(
   const visible = candidates.filter(
     (candidate) =>
       !excluded.has(candidate.cellId) &&
+      candidate.bottom > candidate.top &&
       candidate.bottom > 0 &&
       candidate.top < options.viewportHeight,
   );

--- a/src/components/notebook/scroll-anchors.ts
+++ b/src/components/notebook/scroll-anchors.ts
@@ -1,0 +1,217 @@
+import { notebookCellAnchorId } from "runtimed";
+
+export interface NotebookScrollAnchorCandidate {
+  anchorId: string;
+  cellId: string;
+  top: number;
+  bottom: number;
+}
+
+export interface NotebookScrollAnchorSnapshot {
+  anchorId: string;
+  cellId: string;
+  offsetFromContainerTop: number;
+}
+
+export interface SelectNotebookScrollAnchorOptions {
+  excludedCellIds?: ReadonlySet<string>;
+  viewportHeight: number;
+}
+
+export interface TailPinnedInput {
+  cellCount: number;
+  containerScrollHeight: number;
+  containerClientHeight: number;
+  containerScrollTop: number;
+  containerTop: number;
+  containerBottom: number;
+  lastCellTop: number | null;
+  lastCellBottom: number | null;
+  thresholdPx: number;
+}
+
+export function selectTopVisibleCellAnchor(
+  candidates: readonly NotebookScrollAnchorCandidate[],
+  options: SelectNotebookScrollAnchorOptions,
+): NotebookScrollAnchorCandidate | null {
+  const excluded = options.excludedCellIds ?? new Set<string>();
+  const visible = candidates.filter(
+    (candidate) =>
+      !excluded.has(candidate.cellId) &&
+      candidate.bottom > 0 &&
+      candidate.top < options.viewportHeight,
+  );
+  if (visible.length === 0) return null;
+
+  const crossingTop = visible
+    .filter((candidate) => candidate.top <= 0 && candidate.bottom > 0)
+    .sort((left, right) => right.top - left.top)[0];
+  if (crossingTop) return crossingTop;
+
+  return visible.sort((left, right) => left.top - right.top)[0] ?? null;
+}
+
+export function selectCellDeletionScrollAnchor(
+  candidates: readonly NotebookScrollAnchorCandidate[],
+  visualCellIds: readonly string[],
+  deletedCellId: string,
+  viewportHeight: number,
+): NotebookScrollAnchorSnapshot | null {
+  const topVisible = selectTopVisibleCellAnchor(candidates, { viewportHeight });
+  if (topVisible && topVisible.cellId !== deletedCellId) {
+    return snapshotFromCandidate(topVisible);
+  }
+
+  if (topVisible?.cellId === deletedCellId) {
+    const fallback = deletionFallbackCandidate(candidates, visualCellIds, deletedCellId);
+    if (fallback) {
+      return {
+        anchorId: fallback.anchorId,
+        cellId: fallback.cellId,
+        offsetFromContainerTop: topVisible.top,
+      };
+    }
+  }
+
+  const nonDeleted = selectTopVisibleCellAnchor(candidates, {
+    viewportHeight,
+    excludedCellIds: new Set([deletedCellId]),
+  });
+  return nonDeleted ? snapshotFromCandidate(nonDeleted) : null;
+}
+
+export function shouldTailFollowCellCountChange(
+  previousCellCount: number,
+  nextCellCount: number,
+  tailPinned: boolean,
+): boolean {
+  return tailPinned && nextCellCount > previousCellCount;
+}
+
+export function isNotebookTailPinned(input: TailPinnedInput): boolean {
+  if (input.cellCount === 0) return false;
+
+  const distanceFromTail =
+    input.containerScrollHeight - input.containerClientHeight - input.containerScrollTop;
+  if (distanceFromTail <= input.thresholdPx) return true;
+
+  if (input.lastCellTop === null || input.lastCellBottom === null) return false;
+  return (
+    input.lastCellBottom >= input.containerTop &&
+    input.lastCellTop <= input.containerBottom &&
+    input.lastCellBottom >= input.containerBottom - input.thresholdPx
+  );
+}
+
+export function captureCellDeletionScrollAnchor(
+  container: HTMLElement | null,
+  visualCellIds: readonly string[],
+  deletedCellId: string,
+): NotebookScrollAnchorSnapshot | null {
+  if (!container) return null;
+  return selectCellDeletionScrollAnchor(
+    cellAnchorCandidates(container, visualCellIds),
+    visualCellIds,
+    deletedCellId,
+    container.getBoundingClientRect().height,
+  );
+}
+
+export function restoreScrollAnchor(
+  container: HTMLElement | null,
+  snapshot: NotebookScrollAnchorSnapshot | null,
+): boolean {
+  if (!container || !snapshot) return false;
+  const target = elementByIdWithin(container, snapshot.anchorId);
+  if (!target) return false;
+
+  const containerTop = container.getBoundingClientRect().top;
+  const targetTop = target.getBoundingClientRect().top;
+  container.scrollTop += targetTop - containerTop - snapshot.offsetFromContainerTop;
+  return true;
+}
+
+export function scrollToDocumentAnchor(
+  container: HTMLElement | null,
+  anchorId: string,
+  options: ScrollIntoViewOptions = {},
+): boolean {
+  if (!container) return false;
+  const target = elementByIdWithin(container, anchorId);
+  if (!target) return false;
+  scrollElementIntoView(target, {
+    block: options.block ?? "nearest",
+    behavior: options.behavior ?? "auto",
+    inline: options.inline,
+  });
+  return true;
+}
+
+export function scrollElementIntoView(element: Element, options: ScrollIntoViewOptions = {}): void {
+  element.scrollIntoView({
+    block: options.block ?? "nearest",
+    behavior: options.behavior ?? "auto",
+    inline: options.inline,
+  });
+}
+
+export function scrollToNotebookTail(container: HTMLElement | null): boolean {
+  if (!container) return false;
+  container.scrollTop = container.scrollHeight;
+  return true;
+}
+
+function snapshotFromCandidate(
+  candidate: NotebookScrollAnchorCandidate,
+): NotebookScrollAnchorSnapshot {
+  return {
+    anchorId: candidate.anchorId,
+    cellId: candidate.cellId,
+    offsetFromContainerTop: candidate.top,
+  };
+}
+
+function deletionFallbackCandidate(
+  candidates: readonly NotebookScrollAnchorCandidate[],
+  visualCellIds: readonly string[],
+  deletedCellId: string,
+): NotebookScrollAnchorCandidate | null {
+  const deletedIndex = visualCellIds.indexOf(deletedCellId);
+  if (deletedIndex < 0) return null;
+  for (let index = deletedIndex + 1; index < visualCellIds.length; index++) {
+    const candidate = candidates.find((entry) => entry.cellId === visualCellIds[index]);
+    if (candidate) return candidate;
+  }
+  for (let index = deletedIndex - 1; index >= 0; index--) {
+    const candidate = candidates.find((entry) => entry.cellId === visualCellIds[index]);
+    if (candidate) return candidate;
+  }
+  return null;
+}
+
+function cellAnchorCandidates(
+  container: HTMLElement,
+  visualCellIds: readonly string[],
+): NotebookScrollAnchorCandidate[] {
+  const containerTop = container.getBoundingClientRect().top;
+  return visualCellIds.flatMap((cellId) => {
+    const anchorId = notebookCellAnchorId(cellId);
+    const element = elementByIdWithin(container, anchorId);
+    if (!element) return [];
+    const rect = element.getBoundingClientRect();
+    return [
+      {
+        anchorId,
+        cellId,
+        top: rect.top - containerTop,
+        bottom: rect.bottom - containerTop,
+      },
+    ];
+  });
+}
+
+function elementByIdWithin(container: HTMLElement, id: string): HTMLElement | null {
+  const element = container.ownerDocument.getElementById(id);
+  if (!(element instanceof HTMLElement)) return null;
+  return container.contains(element) ? element : null;
+}

--- a/src/components/notebook/state/view-model-store.ts
+++ b/src/components/notebook/state/view-model-store.ts
@@ -25,7 +25,7 @@ export function useNotebookViewModel<TCell extends NotebookViewCell = NotebookVi
   const materializeVersion = useMaterializeVersion();
   const executionStructureVersion = useExecutionStructureVersion();
   const outputStructureVersion = useOutputStructureVersion();
-  const { getOutlineStatusLabel, metadata, resolveLanguage } = options;
+  const { getOutlineStatusLabel, includeDocumentAnchors, metadata, resolveLanguage } = options;
 
   return useMemo(() => {
     void cellIds;
@@ -34,6 +34,7 @@ export function useNotebookViewModel<TCell extends NotebookViewCell = NotebookVi
     void outputStructureVersion;
     return createNotebookViewModelFromNotebookCells({
       getOutlineStatusLabel,
+      includeDocumentAnchors,
       metadata,
       resolveLanguage,
     }) as NotebookViewModel<TCell>;
@@ -41,6 +42,7 @@ export function useNotebookViewModel<TCell extends NotebookViewCell = NotebookVi
     cellIds,
     executionStructureVersion,
     getOutlineStatusLabel,
+    includeDocumentAnchors,
     materializeVersion,
     metadata,
     outputStructureVersion,

--- a/src/components/notebook/view-model.ts
+++ b/src/components/notebook/view-model.ts
@@ -58,6 +58,7 @@ export interface NotebookViewModel<TCell extends NotebookViewCell = NotebookView
 export interface CreateNotebookViewModelOptions {
   resolveLanguage?: NotebookViewLanguageResolver;
   getOutlineStatusLabel?: (cell: NotebookViewCell) => string | null;
+  includeDocumentAnchors?: boolean;
   metadata?: unknown;
 }
 
@@ -77,11 +78,12 @@ export function createNotebookViewModel<TCell extends NotebookViewCell = Noteboo
   const outlineItems = notebookViewCellsToOutlineItems(cells, {
     getStatusLabel: options.getOutlineStatusLabel,
   });
-  const documentAnchors = createNotebookDocumentAnchors(cells, { outlineItems });
   return {
     cells,
     cellIds: cells.map((cell) => cell.id),
-    documentAnchors,
+    documentAnchors: options.includeDocumentAnchors
+      ? createNotebookDocumentAnchors(cells, { outlineItems })
+      : [],
     readOnlyCells: notebookViewCellsToReadOnlyCells(cells, resolveLanguage),
     outlineItems,
     markdownHeadingAnchorsByCellId: notebookOutlineItemsToMarkdownHeadingAnchors(outlineItems),

--- a/src/components/notebook/view-model.ts
+++ b/src/components/notebook/view-model.ts
@@ -11,6 +11,7 @@ import {
 } from "@/components/environment";
 import type { MarkdownHeadingAnchor } from "@/components/outputs/markdown-heading-anchors";
 import { projectNotebookOutline, type NotebookOutlineItem } from "runtimed";
+import { createNotebookDocumentAnchors, type DocumentAnchor } from "./document-anchors";
 
 export {
   notebookMetadataToPackageViewModel,
@@ -45,6 +46,7 @@ export type NotebookViewLanguageResolver = (
 export interface NotebookViewModel<TCell extends NotebookViewCell = NotebookViewCell> {
   cells: readonly TCell[];
   cellIds: string[];
+  documentAnchors: readonly DocumentAnchor[];
   readOnlyCells: ReadOnlyNotebookCellData[];
   outlineItems: NotebookOutlineItem[];
   markdownHeadingAnchorsByCellId: ReadonlyMap<string, readonly MarkdownHeadingAnchor[]>;
@@ -75,9 +77,11 @@ export function createNotebookViewModel<TCell extends NotebookViewCell = Noteboo
   const outlineItems = notebookViewCellsToOutlineItems(cells, {
     getStatusLabel: options.getOutlineStatusLabel,
   });
+  const documentAnchors = createNotebookDocumentAnchors(cells, { outlineItems });
   return {
     cells,
     cellIds: cells.map((cell) => cell.id),
+    documentAnchors,
     readOnlyCells: notebookViewCellsToReadOnlyCells(cells, resolveLanguage),
     outlineItems,
     markdownHeadingAnchorsByCellId: notebookOutlineItemsToMarkdownHeadingAnchors(outlineItems),


### PR DESCRIPTION
## Summary

- add shared notebook document anchors for cells, markdown headings/blocks, and outputs
- add shared scroll-anchor helpers for deletion restore, tail-follow gating, and anchor navigation
- route NotebookView deletion/search/tail scrolling through the shared anchor helpers

## Verification

- `cargo xtask lint --fix`
- `vp test run src/components/notebook/__tests__/document-anchors.test.ts src/components/notebook/__tests__/scroll-anchors.test.ts apps/notebook/src/components/__tests__/notebook-view-capabilities-source.test.ts src/components/notebook/__tests__/view-model.test.ts src/components/notebook/__tests__/outline-navigation.test.ts apps/notebook/src/hooks/__tests__/useEditorRegistry.test.tsx`
- `corepack pnpm --dir apps/notebook exec tsc -b --pretty false`
- `git diff --check`

## Manual QA

- Delete a middle cell while scrolled mid-document.
- Delete an empty cell with Backspace.
- Edit text above the viewport.
- Run a tail cell that grows output while pinned.
- Run or update output away from the tail.
- Jump via search and outline.
- Verify Safari and Chromium behavior.
