### PR TITLE
fix(mcp): refresh dependency tool CI gates

### DIFF
--- a/crates/runt-mcp-proxy/tool-cache.json
+++ b/crates/runt-mcp-proxy/tool-cache.json
@@ -534,6 +534,7 @@
     "description": "Review or update notebook dependencies. Returns current deps, fingerprint, and trust state.",
     "inputSchema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "additionalProperties": false,
       "properties": {
         "add": {
           "default": [],

--- a/crates/runt-mcp/src/tools/deps.rs
+++ b/crates/runt-mcp/src/tools/deps.rs
@@ -14,6 +14,8 @@ use crate::NteractMcp;
 
 use super::{arg_str, arg_string_array, reject_unknown_args, tool_error, tool_success};
 
+type DependencyEditOutcome = (Vec<String>, Vec<String>, Vec<String>);
+
 /// Parse a `package` parameter that may be a single package spec or a
 /// list-like string agents sometimes produce.
 ///
@@ -319,7 +321,7 @@ fn apply_dep_edits_to_snapshot(
     add: &[String],
     remove: &[String],
     manager: &notebook_protocol::connection::PackageManager,
-) -> (Vec<String>, Vec<String>, Vec<String>) {
+) -> DependencyEditOutcome {
     use notebook_protocol::connection::PackageManager;
 
     let before_snapshot = snap.clone();
@@ -377,7 +379,7 @@ fn apply_dep_edits(
     add: &[String],
     remove: &[String],
     manager: &notebook_protocol::connection::PackageManager,
-) -> Result<(Vec<String>, Vec<String>, Vec<String>), String> {
+) -> Result<DependencyEditOutcome, String> {
     // Short-circuit: nothing to do → skip the CRDT lock entirely.
     if add.is_empty() && remove.is_empty() {
         return Ok((vec![], vec![], vec![]));


### PR DESCRIPTION
## Summary

- add a local dependency-edit outcome alias so `runt-mcp` no longer trips `clippy::type_complexity`
- refresh the MCP proxy tool cache generated from the current `manage_dependencies` schema

## Verification

- `cargo xtask sync-tool-cache --check`
- `cargo clippy -p runt-mcp --all-targets -- -D warnings`
- `cargo xtask lint --fix`
- `git diff --check`
