### PR TITLE
chore(daemon): remove daemon json discovery shim

### DIFF
--- a/apps/notebook/vite-plugin-browser-relay.ts
+++ b/apps/notebook/vite-plugin-browser-relay.ts
@@ -123,15 +123,6 @@ function resolveSocketPath(repoRoot: string): string {
   return path.join(cacheDir(), namespace, "worktrees", worktreeHash(repoRoot), "runtimed.sock");
 }
 
-function readDaemonInfo(socketPath: string): DaemonInfoJson | null {
-  try {
-    const daemonJson = path.join(path.dirname(socketPath), "daemon.json");
-    return JSON.parse(fs.readFileSync(daemonJson, "utf8")) as DaemonInfoJson;
-  } catch {
-    return null;
-  }
-}
-
 function socketExists(socketPath: string): boolean {
   try {
     return fs.statSync(socketPath).isSocket();
@@ -152,12 +143,92 @@ function writePreamble(socket: net.Socket): void {
   socket.write(Buffer.from([...MAGIC, PROTOCOL_VERSION]));
 }
 
-function connectSocket(socketPath: string): Promise<net.Socket> {
+function connectSocket(socketPath: string, timeoutMs?: number): Promise<net.Socket> {
   return new Promise((resolve, reject) => {
     const socket = net.createConnection(socketPath);
-    socket.once("connect", () => resolve(socket));
-    socket.once("error", reject);
+    let timeout: ReturnType<typeof setTimeout> | null = null;
+
+    const cleanup = () => {
+      if (timeout) clearTimeout(timeout);
+      socket.off("connect", onConnect);
+      socket.off("error", onError);
+    };
+    const onConnect = () => {
+      cleanup();
+      resolve(socket);
+    };
+    const onError = (error: Error) => {
+      cleanup();
+      reject(error);
+    };
+
+    socket.once("connect", onConnect);
+    socket.once("error", onError);
+
+    if (timeoutMs != null) {
+      timeout = setTimeout(() => {
+        cleanup();
+        socket.destroy();
+        reject(new Error(`timed out after ${timeoutMs}ms`));
+      }, timeoutMs);
+    }
   });
+}
+
+function withTimeout<T>(promise: Promise<T>, ms: number): Promise<T> {
+  return new Promise((resolve, reject) => {
+    const timeout = setTimeout(() => reject(new Error(`timed out after ${ms}ms`)), ms);
+    promise.then(
+      (value) => {
+        clearTimeout(timeout);
+        resolve(value);
+      },
+      (error) => {
+        clearTimeout(timeout);
+        reject(error);
+      },
+    );
+  });
+}
+
+async function queryDaemonInfo(socketPath: string): Promise<DaemonInfoJson | null> {
+  let socket: net.Socket | null = null;
+  try {
+    socket = await connectSocket(socketPath, 500);
+    const frames = new LengthPrefixedFrames();
+    socket.on("data", (chunk) => {
+      try {
+        frames.push(chunk);
+      } catch (error) {
+        frames.fail(error instanceof Error ? error : new Error(String(error)));
+      }
+    });
+    socket.on("error", (error) => frames.fail(error));
+    socket.on("close", () => frames.fail(new Error("daemon socket closed")));
+
+    writePreamble(socket);
+    writeFrame(socket, JSON.stringify({ channel: "pool" }));
+    writeFrame(socket, JSON.stringify({ type: "get_daemon_info" }));
+
+    const frame = await withTimeout(frames.readFrame(), 500);
+    const response = JSON.parse(frame.toString("utf8")) as {
+      type?: string;
+      daemon_version?: string;
+      blob_port?: number | null;
+      worktree_path?: string | null;
+    };
+    if (response.type !== "daemon_info") return null;
+    return {
+      version: response.daemon_version,
+      socket_path: socketPath,
+      is_dev_mode: response.worktree_path != null,
+      blob_port: response.blob_port ?? undefined,
+    };
+  } catch {
+    return null;
+  } finally {
+    socket?.destroy();
+  }
 }
 
 function sendJson(res: ServerResponse, status: number, value: unknown): void {
@@ -314,7 +385,7 @@ async function handleRelayConnection(
     const commentsNotebookRef =
       info.comments_notebook_ref ?? info.capabilities?.comments_notebook_ref ?? null;
 
-    const daemonInfoJson = readDaemonInfo(socketPath);
+    const daemonInfoJson = await queryDaemonInfo(socketPath);
     control(ws, {
       type: "ready",
       payload: {
@@ -377,24 +448,30 @@ export function browserDevRelayPlugin(options: RelayOptions): Plugin {
       server.middlewares.use((req, res, next) => {
         const url = requestUrl(req);
         if (url.pathname === HEALTH_PATH) {
-          const socketPath = resolveSocketPath(options.repoRoot);
-          const daemonInfo = readDaemonInfo(socketPath);
-          sendJson(res, 200, {
-            relay: "ok",
-            paths: {
-              config: CONFIG_PATH,
-              websocket: WS_PATH,
-            },
-            auth: relayAuthPolicy(token),
-            daemon: {
-              socket_path: daemonInfo?.socket_path ?? socketPath,
-              socket_exists: socketExists(socketPath),
-              version: daemonInfo?.version ?? null,
-              is_dev_mode: daemonInfo?.is_dev_mode ?? null,
-            },
-            blobs: {
-              port: daemonInfo?.blob_port ?? null,
-            },
+          void (async () => {
+            const socketPath = resolveSocketPath(options.repoRoot);
+            const daemonInfo = await queryDaemonInfo(socketPath);
+            sendJson(res, 200, {
+              relay: "ok",
+              paths: {
+                config: CONFIG_PATH,
+                websocket: WS_PATH,
+              },
+              auth: relayAuthPolicy(token),
+              daemon: {
+                socket_path: daemonInfo?.socket_path ?? socketPath,
+                socket_exists: socketExists(socketPath),
+                version: daemonInfo?.version ?? null,
+                is_dev_mode: daemonInfo?.is_dev_mode ?? null,
+              },
+              blobs: {
+                port: daemonInfo?.blob_port ?? null,
+              },
+            });
+          })().catch((error) => {
+            sendJson(res, 500, {
+              error: error instanceof Error ? error.message : String(error),
+            });
           });
           return;
         }
@@ -404,20 +481,26 @@ export function browserDevRelayPlugin(options: RelayOptions): Plugin {
           return;
         }
 
-        const socketPath = resolveSocketPath(options.repoRoot);
-        const daemonInfo = readDaemonInfo(socketPath);
-        const host = req.headers.host ?? "127.0.0.1";
-        sendJson(res, 200, {
-          websocket_url: `ws://${host}${WS_PATH}`,
-          token,
-          blob_port: daemonInfo?.blob_port ?? null,
-          daemon: daemonInfo
-            ? {
-                version: daemonInfo.version ?? "unknown",
-                socket_path: daemonInfo.socket_path ?? socketPath,
-                is_dev_mode: daemonInfo.is_dev_mode ?? true,
-              }
-            : null,
+        void (async () => {
+          const socketPath = resolveSocketPath(options.repoRoot);
+          const daemonInfo = await queryDaemonInfo(socketPath);
+          const host = req.headers.host ?? "127.0.0.1";
+          sendJson(res, 200, {
+            websocket_url: `ws://${host}${WS_PATH}`,
+            token,
+            blob_port: daemonInfo?.blob_port ?? null,
+            daemon: daemonInfo
+              ? {
+                  version: daemonInfo.version ?? "unknown",
+                  socket_path: daemonInfo.socket_path ?? socketPath,
+                  is_dev_mode: daemonInfo.is_dev_mode ?? true,
+                }
+              : null,
+          });
+        })().catch((error) => {
+          sendJson(res, 500, {
+            error: error instanceof Error ? error.message : String(error),
+          });
         });
       });
 

--- a/crates/notebook/src/lib.rs
+++ b/crates/notebook/src/lib.rs
@@ -1281,21 +1281,13 @@ where
         });
 
         if client.ping().await.is_ok() {
-            let endpoint = runt_workspace::default_socket_path()
-                .to_string_lossy()
-                .to_string();
-
-            // Verify the running daemon version matches what we intended to install.
-            // `query_daemon_info` is socket-first; the `daemon.json` fallback
-            // covers the moment immediately after `runtimed install` when the
-            // restarted daemon may briefly be reachable but not yet serving
-            // `GetDaemonInfo` cleanly.
-            let running_version = runtimed_client::singleton::query_daemon_info(
-                runt_workspace::default_socket_path(),
-            )
-            .await
-            .map(|i| i.version);
-            if let Some(version) = running_version {
+            // `GetDaemonInfo` is the canonical readiness and version source.
+            // A ping-only daemon is not ready enough after daemon.json removal.
+            if let Some(version) =
+                runtimed_client::singleton::query_daemon_info(runt_workspace::default_socket_path())
+                    .await
+                    .map(|i| i.version)
+            {
                 let running_commit = extract_commit_hash(&version);
                 let bundled_commit = extract_commit_hash(&bundled);
                 if running_commit == bundled_commit {
@@ -1311,18 +1303,21 @@ where
                         bundled
                     );
                 }
-            }
 
-            on_progress(DaemonProgress::Ready {
-                endpoint: endpoint.clone(),
-            });
-            return Ok(endpoint);
+                let endpoint = runt_workspace::default_socket_path()
+                    .to_string_lossy()
+                    .to_string();
+                on_progress(DaemonProgress::Ready {
+                    endpoint: endpoint.clone(),
+                });
+                return Ok(endpoint);
+            }
         }
 
         tokio::time::sleep(tokio::time::Duration::from_millis(500)).await;
     }
 
-    let error = "Upgraded daemon did not become ready within timeout".to_string();
+    let error = "Upgraded daemon did not serve socket metadata within timeout".to_string();
     log::error!("[startup] {}", error);
     on_progress(DaemonProgress::Failed {
         error: error.clone(),
@@ -1649,10 +1644,7 @@ where
     let client = PoolClient::default();
     if let Ok(()) = client.ping().await {
         // Daemon is running - check version alignment (production only).
-        // `query_daemon_info` is socket-first with a `daemon.json`
-        // fallback. The fallback is how we read the version of a pre-2.2.0
-        // daemon that doesn't speak `GetDaemonInfo`; without it we'd skip
-        // the upgrade and wedge on the next v4 handshake.
+        // `GetDaemonInfo` is the canonical daemon metadata source.
         if !runt_workspace::is_dev_mode() {
             let running_version = runtimed_client::singleton::query_daemon_info(
                 runt_workspace::default_socket_path(),
@@ -1681,10 +1673,11 @@ where
                 );
             } else {
                 log::warn!(
-                    "[startup] Daemon responded to ping but version unavailable via \
-                     socket or daemon.json (bundled={})",
+                    "[startup] Daemon responded to ping but socket metadata is unavailable; \
+                     upgrading to bundled daemon ({})",
                     bundled_version
                 );
+                return upgrade_daemon_via_sidecar(app, on_progress).await;
             }
         }
 

--- a/crates/runt/src/main.rs
+++ b/crates/runt/src/main.rs
@@ -970,9 +970,9 @@ async fn pool_command(command: PoolCommands) -> Result<()> {
 
             match query_daemon_info(runt_workspace::default_socket_path()).await {
                 Some(info) => {
-                    // Ping the daemon at the endpoint recorded in daemon.json,
-                    // not the default socket path — the daemon may have been
-                    // started with a custom --socket.
+                    // Ping the daemon at the endpoint returned by
+                    // GetDaemonInfo, not the default socket path — the daemon
+                    // may have been started with a custom --socket.
                     let info_client = PoolClient::new(std::path::PathBuf::from(&info.endpoint));
                     let alive = info_client.ping().await.is_ok();
 
@@ -1007,7 +1007,7 @@ async fn pool_command(command: PoolCommands) -> Result<()> {
                     }
                 }
                 None => {
-                    eprintln!("Daemon not running (no daemon.json found)");
+                    eprintln!("Daemon not running (daemon info unavailable)");
                     std::process::exit(1);
                 }
             }
@@ -1182,12 +1182,12 @@ async fn stop_process_by_pid(_pid: u32) -> Result<()> {
 
 /// Clean up stale daemon info files.
 fn cleanup_stale_daemon_info() -> Result<()> {
-    use runtimed::singleton::{daemon_info_path, daemon_lock_path};
+    use runtimed::singleton::daemon_lock_path;
 
-    let info_path = daemon_info_path();
+    let info_path = legacy_daemon_info_path();
     if info_path.exists() {
         std::fs::remove_file(&info_path)?;
-        println!("Cleaned up stale daemon.json");
+        println!("Cleaned up legacy daemon.json");
     }
 
     let lock_path = daemon_lock_path();
@@ -1197,6 +1197,10 @@ fn cleanup_stale_daemon_info() -> Result<()> {
     }
 
     Ok(())
+}
+
+fn legacy_daemon_info_path() -> PathBuf {
+    runt_workspace::daemon_base_dir().join("daemon.json")
 }
 
 /// Three-step hybrid stop: socket shutdown → service manager → signal escalation.
@@ -1212,12 +1216,8 @@ async fn stop_daemon_smart(
             Ok(Ok(())) => {
                 // Shutdown request succeeded, wait for daemon to exit
                 if wait_for_pid_exit(info.pid, Duration::from_secs(5)).await {
-                    // Give Drop handler a moment to clean up daemon.json
+                    // Give the daemon a moment to release its lock.
                     tokio::time::sleep(Duration::from_millis(100)).await;
-                    // Verify cleanup (defensive - prevents PID reuse if Drop didn't run)
-                    if runtimed::singleton::daemon_info_path().exists() {
-                        cleanup_stale_daemon_info().ok();
-                    }
                     println!("Daemon stopped gracefully.");
                     return Ok(());
                 } else {
@@ -1250,7 +1250,7 @@ async fn stop_daemon_smart(
                     // Process still running, fall through to signal escalation
                     eprintln!("Warning: Service manager stop succeeded but daemon still running (orphaned?)");
                 } else {
-                    // No daemon.json, assume success
+                    // No socket metadata, assume success
                     println!("Service manager stop completed.");
                     return Ok(());
                 }
@@ -1289,7 +1289,7 @@ async fn stop_daemon_smart(
             }
         }
     } else {
-        // No daemon.json and service manager stop didn't help
+        // No socket metadata and service manager stop didn't help
         println!("No daemon info found, assuming daemon is stopped.");
         Ok(())
     }
@@ -1304,10 +1304,8 @@ async fn daemon_command(command: DaemonCommands) -> Result<()> {
     let mut manager = ServiceManager::default();
 
     // Get daemon info first so we can use its endpoint for the client.
-    // Prefer the socket (`GetDaemonInfo`) over the legacy `daemon.json`
-    // sidecar — the daemon answers from live state, so a response is
-    // proof the daemon is alive. `query_daemon_info` retains the
-    // file-read fallback for the one-release compat window.
+    // Query live daemon metadata over the socket. A response proves the daemon
+    // is alive and avoids stale sidecar state after crashes or force-kills.
     let daemon_info = query_daemon_info(runt_workspace::default_socket_path()).await;
 
     // Create client using daemon's actual endpoint if available, otherwise default
@@ -1320,7 +1318,7 @@ async fn daemon_command(command: DaemonCommands) -> Result<()> {
         DaemonCommands::Status { json } => {
             let installed = manager.is_installed();
             let pong_info = if daemon_info.is_some() {
-                // Use timeout to prevent hanging on stale daemon.json
+                // Use a timeout so a disappearing daemon cannot hang status.
                 tokio::time::timeout(Duration::from_secs(3), client.ping_version())
                     .await
                     .ok()
@@ -1801,7 +1799,6 @@ async fn doctor_command(
         #[cfg(not(target_os = "macos"))]
         let binary_path = runtimed_service::default_binary_path();
         let socket_path = runt_workspace::default_socket_path();
-        let daemon_json_path = runtimed::singleton::daemon_info_path();
         let service_config_path = runtimed_service::service_config_path();
 
         // Check 1: Installed binary
@@ -2112,7 +2109,7 @@ async fn doctor_command(
             detail: None,
         };
 
-        // Check 4: daemon.json state
+        // Check 4: live daemon metadata from the socket
         let (daemon_state_status, daemon_state_detail) = if let Some(info) = daemon_info {
             // Check if PID is actually running
             let pid_running = is_process_running(info.pid);
@@ -2128,7 +2125,7 @@ async fn doctor_command(
             ("missing".to_string(), None)
         };
         let daemon_state = CheckResult {
-            path: shorten_path(&daemon_json_path),
+            path: shorten_path(&socket_path),
             status: daemon_state_status.clone(),
             detail: daemon_state_detail,
         };
@@ -2210,7 +2207,7 @@ async fn doctor_command(
             }
         };
 
-        // Check 6: Can we ping the daemon? Try regardless of daemon.json state
+        // Check 6: Can we ping the daemon? Try regardless of metadata state.
         let daemon_running_result = tokio::time::timeout(Duration::from_secs(2), client.ping())
             .await
             .map(|r| r.is_ok())
@@ -2225,7 +2222,7 @@ async fn doctor_command(
             }
             .to_string(),
             detail: if daemon_running_result && daemon_state_status == "missing" {
-                Some("running but daemon.json missing".to_string())
+                Some("running but daemon info unavailable".to_string())
             } else {
                 None
             },
@@ -2328,7 +2325,6 @@ async fn doctor_command(
     #[cfg(not(target_os = "macos"))]
     let binary_path = runtimed_service::default_binary_path();
     let socket_path = runt_workspace::default_socket_path();
-    let daemon_json_path = runtimed::singleton::daemon_info_path();
     let service_config_path = runtimed_service::service_config_path();
 
     let binary_exists = binary_path.exists();
@@ -2408,24 +2404,13 @@ async fn doctor_command(
     // Fix issues if requested
     if fix {
         // Clean up stale state
-        if daemon_state_status == "stale" {
-            if let Err(e) = std::fs::remove_file(&daemon_json_path) {
+        if daemon_state_status == "stale" && socket_exists {
+            if let Err(e) = std::fs::remove_file(&socket_path) {
                 if e.kind() != std::io::ErrorKind::NotFound {
-                    eprintln!("Warning: Could not remove stale daemon.json: {}", e);
+                    eprintln!("Warning: Could not remove stale socket: {}", e);
                 }
             } else {
-                actions_taken.push("Removed stale daemon.json".to_string());
-            }
-
-            // Also remove stale socket
-            if socket_exists {
-                if let Err(e) = std::fs::remove_file(&socket_path) {
-                    if e.kind() != std::io::ErrorKind::NotFound {
-                        eprintln!("Warning: Could not remove stale socket: {}", e);
-                    }
-                } else {
-                    actions_taken.push("Removed stale socket file".to_string());
-                }
+                actions_taken.push("Removed stale socket file".to_string());
             }
         }
 
@@ -3371,8 +3356,6 @@ async fn tail_log_file(path: &PathBuf, lines: usize, follow: bool) -> Result<()>
 
 /// List all running dev worktree daemons
 async fn list_worktree_daemons(json_output: bool) -> Result<()> {
-    use runtimed::client::PoolClient;
-    use runtimed::singleton::read_daemon_info;
     use serde::Serialize;
 
     let worktrees_dir = dirs::cache_dir()
@@ -3405,27 +3388,17 @@ async fn list_worktree_daemons(json_output: bool) -> Result<()> {
                 .and_then(|s| s.to_str())
                 .unwrap_or("unknown")
                 .to_string();
-            let info_path = path.join("daemon.json");
-
-            if let Some(info) = read_daemon_info(&info_path) {
-                // Check if daemon is actually running
-                let client = PoolClient::new(PathBuf::from(&info.endpoint));
-                let alive = client.ping().await.is_ok();
-
+            let socket_path = path.join("runtimed.sock");
+            if let Some(info) = runtimed::singleton::query_daemon_info(socket_path).await {
                 daemons.push(WorktreeDaemon {
                     hash,
-                    status: if alive {
-                        "running".to_string()
-                    } else {
-                        "stopped".to_string()
-                    },
+                    status: "running".to_string(),
                     worktree: info.worktree_path,
                     description: info.workspace_description,
-                    pid: if alive { Some(info.pid) } else { None },
-                    version: if alive { Some(info.version) } else { None },
+                    pid: Some(info.pid),
+                    version: Some(info.version),
                 });
             } else {
-                // Directory exists but no daemon.json
                 daemons.push(WorktreeDaemon {
                     hash,
                     status: "stopped".to_string(),
@@ -3491,7 +3464,6 @@ async fn clean_worktree_command(
     dry_run: bool,
 ) -> Result<()> {
     use runtimed::client::PoolClient;
-    use runtimed::singleton::read_daemon_info;
     use std::io::{self, Write};
 
     let worktrees_dir = dirs::cache_dir()
@@ -3584,18 +3556,10 @@ async fn clean_worktree_command(
 
     // Check daemon status and calculate sizes for each target
     for target in &mut targets {
-        // Read daemon info
-        let info_path = target.path.join("daemon.json");
-        if let Some(info) = read_daemon_info(&info_path) {
+        let socket_path = target.path.join("runtimed.sock");
+        if let Some(info) = runtimed::singleton::query_daemon_info(socket_path).await {
             target.worktree_path = info.worktree_path.clone();
-
-            // Try to ping the daemon
-            let client = PoolClient::new(PathBuf::from(&info.endpoint));
-            target.is_running =
-                tokio::time::timeout(std::time::Duration::from_secs(2), client.ping())
-                    .await
-                    .map(|r| r.is_ok())
-                    .unwrap_or(false);
+            target.is_running = true;
 
             // Check if stale (original path no longer exists)
             if let Some(ref wt_path) = target.worktree_path {
@@ -3637,9 +3601,12 @@ async fn clean_worktree_command(
     if force {
         for target in &targets {
             if target.is_running {
-                let info_path = target.path.join("daemon.json");
-                if let Some(info) = read_daemon_info(&info_path) {
-                    let client = PoolClient::new(PathBuf::from(&info.endpoint));
+                let socket_path = target.path.join("runtimed.sock");
+                if runtimed::singleton::query_daemon_info(socket_path.clone())
+                    .await
+                    .is_some()
+                {
+                    let client = PoolClient::new(socket_path);
                     print!("Stopping daemon {}... ", target.hash);
                     io::stdout().flush()?;
                     match client.shutdown().await {

--- a/crates/runtimed-client/src/client.rs
+++ b/crates/runtimed-client/src/client.rs
@@ -73,8 +73,7 @@ pub struct PongInfo {
     pub daemon_version: Option<String>,
 }
 
-/// Rich daemon metadata. Replaces the `daemon.json` sidecar file —
-/// query this from the daemon directly via `PoolClient::daemon_info()`.
+/// Rich daemon metadata queried from the daemon via `PoolClient::daemon_info()`.
 #[derive(Debug, Clone)]
 pub struct DaemonInfo {
     /// Numeric protocol version.
@@ -204,12 +203,10 @@ impl PoolClient {
 
     /// Query rich daemon metadata (pid, blob port, worktree info, etc.).
     ///
-    /// This is the socket-based replacement for reading `daemon.json`.
+    /// This is the socket-based daemon metadata path.
     /// Returns `Err` with `DaemonError("Unknown request")` on daemons too
-    /// old to know this request — callers can either treat that as
-    /// "metadata unavailable" or fall back to the file (we don't bake in
-    /// a file fallback here because the whole point is to stop relying
-    /// on the file).
+    /// old to know this request; callers should treat that as "metadata
+    /// unavailable".
     pub async fn daemon_info(&self) -> Result<DaemonInfo, ClientError> {
         let response = self.send_request(Request::GetDaemonInfo).await?;
         match response {

--- a/crates/runtimed-client/src/daemon_paths.rs
+++ b/crates/runtimed-client/src/daemon_paths.rs
@@ -30,23 +30,13 @@ pub fn get_socket_path() -> PathBuf {
     }
 }
 
-/// Resolve blob server URL and blob store path from the daemon directory (sync).
+/// Resolve the blob store path from the daemon directory (sync).
 ///
-/// Returns (blob_base_url, blob_store_path).
+/// Returns `(None, blob_store_path)`. Blob server URLs require live daemon
+/// metadata and are only available through [`get_blob_paths_async`].
 pub fn get_blob_paths_sync(socket_path: &Path) -> (Option<String>, Option<PathBuf>) {
     let Some(parent) = socket_path.parent() else {
         return (None, None);
-    };
-
-    let daemon_json = parent.join("daemon.json");
-    let base_url = if daemon_json.exists() {
-        std::fs::read_to_string(&daemon_json)
-            .ok()
-            .and_then(|contents| serde_json::from_str::<serde_json::Value>(&contents).ok())
-            .and_then(|info| info.get("blob_port").and_then(|p| p.as_u64()))
-            .map(|port| format!("http://localhost:{}", port))
-    } else {
-        None
     };
 
     let store_path = parent.join("blobs");
@@ -56,10 +46,11 @@ pub fn get_blob_paths_sync(socket_path: &Path) -> (Option<String>, Option<PathBu
         None
     };
 
-    (base_url, store_path)
+    (None, store_path)
 }
 
-/// Resolve blob server URL and blob store path from the daemon directory (async).
+/// Resolve blob server URL from live daemon metadata plus blob store path from
+/// the daemon directory (async).
 ///
 /// Returns (blob_base_url, blob_store_path).
 pub async fn get_blob_paths_async(socket_path: &Path) -> (Option<String>, Option<PathBuf>) {
@@ -67,17 +58,10 @@ pub async fn get_blob_paths_async(socket_path: &Path) -> (Option<String>, Option
         return (None, None);
     };
 
-    let daemon_json = parent.join("daemon.json");
-    let base_url = if daemon_json.exists() {
-        tokio::fs::read_to_string(&daemon_json)
-            .await
-            .ok()
-            .and_then(|contents| serde_json::from_str::<serde_json::Value>(&contents).ok())
-            .and_then(|info| info.get("blob_port").and_then(|p| p.as_u64()))
-            .map(|port| format!("http://localhost:{}", port))
-    } else {
-        None
-    };
+    let base_url = crate::singleton::query_daemon_info(socket_path.to_path_buf())
+        .await
+        .and_then(|info| info.blob_port)
+        .map(|port| format!("http://localhost:{}", port));
 
     let store_path = parent.join("blobs");
     let store_path = if store_path.exists() {
@@ -158,55 +142,39 @@ mod tests {
 
     #[test]
     fn blob_paths_sync_returns_none_for_orphan_socket_path() {
-        // socket_path with no parent (e.g. "/" or "") → both None.
+        // socket_path with no parent (e.g. "/" or "") cannot resolve a store.
         let (url, store) = get_blob_paths_sync(Path::new("/"));
-        assert!(url.is_none(), "no parent → no daemon.json → no url");
+        assert!(url.is_none(), "sync path never opens a daemon socket");
         // "/" exists, /blobs may or may not — assert nothing about store.
         let _ = store;
     }
 
     #[test]
-    fn blob_paths_sync_reads_blob_port_from_daemon_json() {
+    fn blob_paths_sync_returns_store_path_without_blob_url() {
         let tmp = TempDir::new().unwrap();
-        // socket_path's parent dir is what we read from.
         let sock = tmp.path().join("runtimed.sock");
-        fs::write(
-            tmp.path().join("daemon.json"),
-            r#"{"blob_port": 49152, "version": "2.2.0"}"#,
-        )
-        .unwrap();
         fs::create_dir(tmp.path().join("blobs")).unwrap();
 
         let (url, store) = get_blob_paths_sync(&sock);
-        assert_eq!(url.as_deref(), Some("http://localhost:49152"));
+        assert_eq!(url, None);
         assert_eq!(store, Some(tmp.path().join("blobs")));
     }
 
     #[test]
-    fn blob_paths_sync_returns_url_none_when_daemon_json_lacks_blob_port() {
+    fn blob_paths_sync_returns_store_path_when_no_daemon_info_exists() {
         let tmp = TempDir::new().unwrap();
         let sock = tmp.path().join("runtimed.sock");
-        fs::write(tmp.path().join("daemon.json"), r#"{"version":"2.2.0"}"#).unwrap();
+        fs::create_dir(tmp.path().join("blobs")).unwrap();
 
-        let (url, _) = get_blob_paths_sync(&sock);
-        assert!(url.is_none(), "missing blob_port → no url");
-    }
-
-    #[test]
-    fn blob_paths_sync_returns_url_none_when_daemon_json_is_invalid_json() {
-        let tmp = TempDir::new().unwrap();
-        let sock = tmp.path().join("runtimed.sock");
-        fs::write(tmp.path().join("daemon.json"), "not json {{").unwrap();
-
-        let (url, _) = get_blob_paths_sync(&sock);
-        assert!(url.is_none(), "invalid daemon.json → no url");
+        let (url, store) = get_blob_paths_sync(&sock);
+        assert!(url.is_none(), "sync path never opens a daemon socket");
+        assert_eq!(store, Some(tmp.path().join("blobs")));
     }
 
     #[test]
     fn blob_paths_sync_returns_store_none_when_blobs_dir_missing() {
         let tmp = TempDir::new().unwrap();
         let sock = tmp.path().join("runtimed.sock");
-        fs::write(tmp.path().join("daemon.json"), r#"{"blob_port":1}"#).unwrap();
         // no blobs/ dir created
 
         let (_, store) = get_blob_paths_sync(&sock);
@@ -216,16 +184,15 @@ mod tests {
     // ── get_blob_paths_async ──────────────────────────────────────────
 
     #[tokio::test]
-    async fn blob_paths_async_matches_sync_for_happy_path() {
+    async fn blob_paths_async_returns_store_without_live_daemon() {
         let tmp = TempDir::new().unwrap();
         let sock = tmp.path().join("runtimed.sock");
-        fs::write(tmp.path().join("daemon.json"), r#"{"blob_port": 49200}"#).unwrap();
         fs::create_dir(tmp.path().join("blobs")).unwrap();
 
         let (sync_url, sync_store) = get_blob_paths_sync(&sock);
         let (async_url, async_store) = get_blob_paths_async(&sock).await;
         assert_eq!(sync_url, async_url);
         assert_eq!(sync_store, async_store);
-        assert_eq!(async_url.as_deref(), Some("http://localhost:49200"));
+        assert_eq!(async_url, None);
     }
 }

--- a/crates/runtimed-client/src/protocol.rs
+++ b/crates/runtimed-client/src/protocol.rs
@@ -65,10 +65,9 @@ pub enum Request {
     ActiveEnvPaths,
 
     /// Get rich daemon metadata (pid, version, start time, blob server
-    /// port, dev-mode worktree). Supersedes reading the on-disk
-    /// `daemon.json` sidecar, which can go stale when the daemon crashes
-    /// or is forcibly killed. Clients should prefer this request and
-    /// fall back to `Ping` if they only need the version.
+    /// port, dev-mode worktree). This is the canonical discovery path for
+    /// clients that need more than liveness; use `Ping` if only the daemon
+    /// version is needed.
     GetDaemonInfo,
 
     /// Read a terminal execution result by durable execution ID.
@@ -112,15 +111,12 @@ pub enum Response {
         daemon_version: Option<String>,
     },
 
-    /// Rich daemon metadata — replaces the `daemon.json` sidecar file.
+    /// Rich daemon metadata returned from `Request::GetDaemonInfo`.
     ///
-    /// Returned from `Request::GetDaemonInfo`. Carries everything the
-    /// pre-socket `get_running_daemon_info()` used to read out of the
-    /// file: pid, version, start time, blob server port, and the dev-mode
-    /// worktree fields. Fields are `Option` for backward compatibility —
-    /// older daemons that don't know this request will respond with
-    /// `Response::Error { message: "Unknown request" }` (the client should
-    /// treat that as "metadata unavailable").
+    /// Carries pid, version, start time, blob server port, and the dev-mode
+    /// worktree fields. Older daemons that don't know this request respond
+    /// with `Response::Error { message: "Unknown request" }`; clients should
+    /// treat that as "metadata unavailable".
     DaemonInfo {
         /// Numeric protocol version (matches `PROTOCOL_VERSION`).
         protocol_version: u32,

--- a/crates/runtimed-client/src/singleton.rs
+++ b/crates/runtimed-client/src/singleton.rs
@@ -1,7 +1,7 @@
-//! Daemon discovery — read daemon info from the info file.
+//! Daemon discovery through the daemon socket.
 //!
-//! The write-side (`DaemonLock`) lives in the `runtimed` crate since only
-//! the daemon process acquires the lock.
+//! The daemon singleton lock lives in the `runtimed` crate since only the
+//! daemon process acquires it.
 
 use std::path::PathBuf;
 
@@ -38,43 +38,12 @@ pub fn daemon_lock_path() -> PathBuf {
     crate::daemon_base_dir().join("daemon.lock")
 }
 
-/// Get the path to the daemon info file.
-pub fn daemon_info_path() -> PathBuf {
-    crate::daemon_base_dir().join("daemon.json")
-}
-
-/// Read daemon info from the info file.
-pub fn read_daemon_info(path: &PathBuf) -> Option<DaemonInfo> {
-    std::fs::read_to_string(path)
-        .ok()
-        .and_then(|s| serde_json::from_str(&s).ok())
-}
-
-/// Check if a daemon is running by reading the info file.
-pub fn get_running_daemon_info() -> Option<DaemonInfo> {
-    read_daemon_info(&daemon_info_path())
-}
-
-/// Get daemon info, preferring the socket-based `GetDaemonInfo` request
-/// and falling back to the on-disk `daemon.json` sidecar.
+/// Get daemon info from the socket-based `GetDaemonInfo` request.
 ///
-/// The socket is the source of truth — the daemon fills the response
-/// from live state, so it can't go stale the way the file can. The file
-/// is read only when the socket query fails, which means the running
-/// daemon predates `GetDaemonInfo` (#1803, 2026-04-15 — pre-2.2.0-stable).
-///
-/// The fallback is what lets `ensure_daemon_via_sidecar` discover an old
-/// daemon's version and decide to upgrade it. Without the fallback, that
-/// path returns `None`, the upgrade is skipped, and the new app then
-/// fails its v4 handshake against the old daemon — leaving the user
-/// wedged. Keep the fallback until we're confident no pre-#1803 daemons
-/// are still running.
-///
-/// `socket_path` pins which daemon is being queried. The fallback reads
-/// `daemon.json` from the **same directory as the socket**, so callers
-/// that pin a non-default daemon (tests, worktree isolation,
-/// cross-channel lookups) still resolve to the correct instance — not
-/// the process's default namespace.
+/// The socket is the source of truth: the daemon fills the response from live
+/// state, so clients cannot consume stale sidecar metadata after a crash or
+/// force-kill. `socket_path` pins which daemon is being queried so tests,
+/// worktree isolation, and cross-channel lookups resolve the intended daemon.
 pub async fn query_daemon_info(socket_path: std::path::PathBuf) -> Option<DaemonInfo> {
     let client = crate::client::PoolClient::new(socket_path.clone());
     if let Ok(info) = client.daemon_info().await {
@@ -89,35 +58,7 @@ pub async fn query_daemon_info(socket_path: std::path::PathBuf) -> Option<Daemon
             workspace_description: info.workspace_description,
         });
     }
-
-    // `GetDaemonInfo` failed. Only fall back to `daemon.json` when the
-    // failure means "old daemon doesn't recognise this request." We
-    // distinguish that from a generic transient failure by sending a
-    // `Ping`: an old daemon will respond to Ping fine but tear down
-    // the connection on `GetDaemonInfo` (unknown serde tag → drop).
-    // A genuinely unreachable daemon fails Ping too, and we return
-    // None so callers don't consume a stale sidecar.
-    if client.ping().await.is_err() {
-        return None;
-    }
-
-    // Daemon is alive but doesn't know `GetDaemonInfo` — legacy path.
-    // The base notebook app case (nightly app ↔ nightly daemon) has the
-    // socket and `daemon.json` in the same `daemon_base_dir()`, so the
-    // colocated path covers every realistic upgrade-window configuration.
-    // Windows named pipes have no on-disk parent — skip the fallback,
-    // because this whole path is a one-release compatibility shim and
-    // we don't have Windows daemons pre-GetDaemonInfo in the wild anyway.
-    #[cfg(unix)]
-    {
-        let parent = socket_path.parent()?;
-        read_daemon_info(&parent.join("daemon.json"))
-    }
-    #[cfg(not(unix))]
-    {
-        let _ = &socket_path;
-        None
-    }
+    None
 }
 
 #[cfg(test)]
@@ -127,10 +68,8 @@ mod tests {
     #[test]
     fn test_daemon_paths() {
         let lock_path = daemon_lock_path();
-        let info_path = daemon_info_path();
 
         assert!(lock_path.to_string_lossy().contains("runt"));
         assert!(lock_path.to_string_lossy().contains("daemon.lock"));
-        assert!(info_path.to_string_lossy().contains("daemon.json"));
     }
 }

--- a/crates/runtimed-node/src/session.rs
+++ b/crates/runtimed-node/src/session.rs
@@ -1478,23 +1478,7 @@ pub fn blob_store_path(socket_path: Option<String>) -> Option<String> {
 }
 
 async fn resolve_blob_paths(socket_path: &std::path::Path) -> (Option<String>, Option<PathBuf>) {
-    if let Some(parent) = socket_path.parent() {
-        let daemon_json = parent.join("daemon.json");
-        let base_url = if daemon_json.exists() {
-            tokio::fs::read_to_string(&daemon_json)
-                .await
-                .ok()
-                .and_then(|s| serde_json::from_str::<serde_json::Value>(&s).ok())
-                .and_then(|v| v.get("blob_port").and_then(|p| p.as_u64()))
-                .map(|port| format!("http://localhost:{port}"))
-        } else {
-            None
-        };
-        let store_path = blob_store_path_for_socket_path(socket_path);
-        (base_url, store_path)
-    } else {
-        (None, None)
-    }
+    runtimed_client::daemon_paths::get_blob_paths_async(socket_path).await
 }
 
 fn blob_store_path_for_socket_path(socket_path: &Path) -> Option<PathBuf> {

--- a/crates/runtimed-py/src/session_core.rs
+++ b/crates/runtimed-py/src/session_core.rs
@@ -2264,30 +2264,7 @@ async fn ensure_kernel_started(
 
 /// Resolve blob server URL and store path from daemon info.
 async fn resolve_blob_paths(socket_path: &Path) -> (Option<String>, Option<PathBuf>) {
-    if let Some(parent) = socket_path.parent() {
-        let daemon_json = parent.join("daemon.json");
-        let base_url = if daemon_json.exists() {
-            tokio::fs::read_to_string(&daemon_json)
-                .await
-                .ok()
-                .and_then(|contents| serde_json::from_str::<serde_json::Value>(&contents).ok())
-                .and_then(|info| info.get("blob_port").and_then(|p| p.as_u64()))
-                .map(|port| format!("http://localhost:{}", port))
-        } else {
-            None
-        };
-
-        let store_path = parent.join("blobs");
-        let store_path = if store_path.exists() {
-            Some(store_path)
-        } else {
-            None
-        };
-
-        (base_url, store_path)
-    } else {
-        (None, None)
-    }
+    runtimed_client::daemon_paths::get_blob_paths_async(socket_path).await
 }
 
 // =========================================================================

--- a/crates/runtimed/src/daemon.rs
+++ b/crates/runtimed/src/daemon.rs
@@ -1562,13 +1562,11 @@ impl Daemon {
 
     /// Build the `DaemonInfo` response from live daemon state.
     ///
-    /// This carries every field that `daemon.json` used to — `pid`,
-    /// `version`, `started_at`, `blob_port`, plus the dev-mode worktree
-    /// fields — so clients can query the daemon directly over the socket
-    /// instead of reading a sidecar file. Keeping it in its own message
-    /// (not overloaded onto `Pong`) means the frequent liveness-check
-    /// path stays tiny and the one-shot discovery path carries the full
-    /// payload.
+    /// This carries `pid`, `version`, `started_at`, `blob_port`, plus the
+    /// dev-mode worktree fields so clients can query the daemon directly over
+    /// the socket. Keeping it in its own message (not overloaded onto `Pong`)
+    /// means the frequent liveness-check path stays tiny and the one-shot
+    /// discovery path carries the full payload.
     async fn build_daemon_info(&self) -> Response {
         let blob_port = *self.blob_port.lock().await;
         let (worktree_path, workspace_description) = if runt_workspace::is_dev_mode() {
@@ -1739,7 +1737,7 @@ impl Daemon {
         prepare_unix_socket_path(&self.config.socket_path).await?;
 
         // Start the blob HTTP server (also serves renderer plugin assets)
-        let blob_port = match blob_server::start_blob_server(
+        match blob_server::start_blob_server(
             self.blob_store.clone(),
             Some(self.clone()),
             self.config.use_preferred_blob_port,
@@ -1765,18 +1763,6 @@ impl Daemon {
             info!("[runtimed] Listening on {:?}", self.config.socket_path);
             listener
         };
-
-        // Write `daemon.json` so older clients can still discover us.
-        // Retained as a one-release compatibility shim for stale
-        // `runt-mcp` / `nteract-mcp` proxies that predate `GetDaemonInfo`.
-        // New consumers go through the socket (see
-        // `runtimed_client::daemon_connection`). Target v3.0 for removal.
-        if let Err(e) = self
-            ._lock
-            .write_info(&self.config.socket_path.to_string_lossy(), blob_port)
-        {
-            error!("[runtimed] Failed to write daemon info: {}", e);
-        }
 
         // Reap any orphaned agent process groups from a previous crash
         #[cfg(unix)]
@@ -4973,8 +4959,8 @@ impl Daemon {
         }
     }
 
-    /// Clean up worktree state directories where the original git worktree
-    /// path no longer exists and the daemon.json is older than 7 days.
+    /// Clean up legacy worktree state directories whose old `daemon.json`
+    /// sidecar says the original git worktree path no longer exists.
     async fn cleanup_stale_worktrees(worktrees_dir: &std::path::Path) -> anyhow::Result<usize> {
         if !worktrees_dir.exists() {
             return Ok(0);

--- a/crates/runtimed/src/main.rs
+++ b/crates/runtimed/src/main.rs
@@ -858,8 +858,7 @@ async fn status(json: bool) -> anyhow::Result<()> {
     let manager = ServiceManager::default();
     let installed = manager.is_installed();
 
-    // Check if daemon is running — socket-first with `daemon.json`
-    // fallback so custom `--socket` daemons stay discoverable.
+    // Check if daemon is running by querying live metadata over the socket.
     let daemon_info =
         runtimed_client::singleton::query_daemon_info(runt_workspace::default_socket_path()).await;
     let running = if daemon_info.is_some() {

--- a/crates/runtimed/src/singleton.rs
+++ b/crates/runtimed/src/singleton.rs
@@ -1,28 +1,24 @@
 //! Singleton management for the pool daemon.
 //!
 //! Ensures only one daemon instance runs per user using file-based locking.
-//! Read-only daemon discovery (DaemonInfo, get_running_daemon_info, etc.)
-//! lives in `runtimed_client::singleton` and is re-exported via `pub use runtimed_client::*`.
+//! Read-only daemon discovery lives in `runtimed_client::singleton` and queries
+//! the daemon socket directly.
 
 use std::fs::{File, OpenOptions};
 #[cfg(unix)]
 use std::os::fd::AsRawFd;
 use std::path::PathBuf;
 
-use chrono::Utc;
 use tracing::{info, warn};
 
 // Re-export all client-side singleton items so `runtimed::singleton::*` still works.
 use runtimed_client::singleton as client_singleton;
-pub use runtimed_client::singleton::{
-    daemon_info_path, daemon_lock_path, get_running_daemon_info, read_daemon_info, DaemonInfo,
-};
+pub use runtimed_client::singleton::{daemon_lock_path, query_daemon_info, DaemonInfo};
 
 /// A lock that ensures only one daemon instance runs.
 pub struct DaemonLock {
     _lock_file: File,
     _lock_path: PathBuf,
-    info_path: PathBuf,
 }
 
 impl DaemonLock {
@@ -36,13 +32,10 @@ impl DaemonLock {
     pub fn try_acquire(
         custom_lock_dir: Option<&PathBuf>,
     ) -> Result<Self, Box<client_singleton::DaemonInfo>> {
-        let (lock_path, info_path) = if let Some(dir) = custom_lock_dir {
-            (dir.join("daemon.lock"), dir.join("daemon.json"))
+        let lock_path = if let Some(dir) = custom_lock_dir {
+            dir.join("daemon.lock")
         } else {
-            (
-                client_singleton::daemon_lock_path(),
-                client_singleton::daemon_info_path(),
-            )
+            client_singleton::daemon_lock_path()
         };
 
         // Ensure parent directory exists
@@ -60,21 +53,7 @@ impl DaemonLock {
             Ok(f) => f,
             Err(e) => {
                 warn!("[singleton] Failed to open lock file: {}", e);
-                // Try to read existing daemon info
-                if let Some(info) = client_singleton::read_daemon_info(&info_path) {
-                    return Err(Box::new(info));
-                }
-                // No info available, create a placeholder
-                return Err(Box::new(client_singleton::DaemonInfo {
-                    endpoint: "unknown".to_string(),
-                    pid: 0,
-                    version: "unknown".to_string(),
-                    started_at: Utc::now(),
-                    blob_port: None,
-                    execution_store_dir: None,
-                    worktree_path: None,
-                    workspace_description: None,
-                }));
+                return Err(Box::new(placeholder_daemon_info(custom_lock_dir)));
             }
         };
 
@@ -87,19 +66,7 @@ impl DaemonLock {
             if result != 0 {
                 // Another process holds the lock
                 info!("[singleton] Another daemon is already running");
-                if let Some(info) = client_singleton::read_daemon_info(&info_path) {
-                    return Err(Box::new(info));
-                }
-                return Err(Box::new(client_singleton::DaemonInfo {
-                    endpoint: "unknown".to_string(),
-                    pid: 0,
-                    version: "unknown".to_string(),
-                    started_at: Utc::now(),
-                    blob_port: None,
-                    execution_store_dir: None,
-                    worktree_path: None,
-                    workspace_description: None,
-                }));
+                return Err(Box::new(placeholder_daemon_info(custom_lock_dir)));
             }
         }
 
@@ -126,19 +93,7 @@ impl DaemonLock {
             };
             if result == 0 {
                 info!("[singleton] Another daemon is already running");
-                if let Some(info) = client_singleton::read_daemon_info(&info_path) {
-                    return Err(Box::new(info));
-                }
-                return Err(Box::new(client_singleton::DaemonInfo {
-                    endpoint: "unknown".to_string(),
-                    pid: 0,
-                    version: "unknown".to_string(),
-                    started_at: Utc::now(),
-                    blob_port: None,
-                    execution_store_dir: None,
-                    worktree_path: None,
-                    workspace_description: None,
-                }));
+                return Err(Box::new(placeholder_daemon_info(custom_lock_dir)));
             }
         }
 
@@ -147,48 +102,7 @@ impl DaemonLock {
         Ok(Self {
             _lock_file: lock_file,
             _lock_path: lock_path,
-            info_path,
         })
-    }
-
-    /// Write daemon info after successful startup.
-    pub fn write_info(&self, endpoint: &str, blob_port: Option<u16>) -> std::io::Result<()> {
-        // Populate worktree info when in dev mode
-        let (worktree_path, workspace_description) = if runt_workspace::is_dev_mode() {
-            (
-                runt_workspace::get_workspace_path().map(|p| p.to_string_lossy().to_string()),
-                runt_workspace::get_workspace_name(),
-            )
-        } else {
-            (None, None)
-        };
-
-        let info = client_singleton::DaemonInfo {
-            endpoint: endpoint.to_string(),
-            pid: std::process::id(),
-            version: crate::daemon_version().to_string(),
-            started_at: Utc::now(),
-            blob_port,
-            execution_store_dir: Some(
-                crate::default_execution_store_dir()
-                    .to_string_lossy()
-                    .to_string(),
-            ),
-            worktree_path,
-            workspace_description,
-        };
-
-        let json = serde_json::to_string_pretty(&info).map_err(std::io::Error::other)?;
-
-        std::fs::write(&self.info_path, json)?;
-        info!("[singleton] Wrote daemon info to {:?}", self.info_path);
-
-        Ok(())
-    }
-
-    /// Get the path to the info file.
-    pub fn info_path(&self) -> &PathBuf {
-        &self.info_path
     }
 }
 
@@ -201,12 +115,23 @@ impl Drop for DaemonLock {
         unsafe {
             libc::flock(self._lock_file.as_raw_fd(), libc::LOCK_UN);
         }
-
-        // Clean up info file when daemon exits
-        if self.info_path.exists() {
-            std::fs::remove_file(&self.info_path).ok();
-        }
         info!("[singleton] Released daemon lock");
+    }
+}
+
+fn placeholder_daemon_info(custom_lock_dir: Option<&PathBuf>) -> client_singleton::DaemonInfo {
+    let endpoint = custom_lock_dir
+        .map(|dir| dir.join("runtimed.sock"))
+        .unwrap_or_else(runt_workspace::default_socket_path);
+    client_singleton::DaemonInfo {
+        endpoint: endpoint.to_string_lossy().to_string(),
+        pid: 0,
+        version: "unknown".to_string(),
+        started_at: chrono::Utc::now(),
+        blob_port: None,
+        execution_store_dir: None,
+        worktree_path: None,
+        workspace_description: None,
     }
 }
 
@@ -222,8 +147,7 @@ mod tests {
         // Fresh directory with no existing daemon → we should be the singleton.
         let tmp = TempDir::new()?;
         let dir = tmp.path().to_path_buf();
-        let lock = DaemonLock::try_acquire(Some(&dir)).map_err(|_| "should acquire empty dir")?;
-        assert_eq!(lock.info_path(), &dir.join("daemon.json"));
+        let _lock = DaemonLock::try_acquire(Some(&dir)).map_err(|_| "should acquire empty dir")?;
         Ok(())
     }
 
@@ -236,50 +160,29 @@ mod tests {
         let tmp = TempDir::new()?;
         let dir = tmp.path().to_path_buf();
         let first = DaemonLock::try_acquire(Some(&dir)).map_err(|_| "first acquire")?;
-        first.write_info("unix:/tmp/sock", Some(12345))?;
 
         let Err(info) = DaemonLock::try_acquire(Some(&dir)) else {
             return Err("second acquire should have failed".into());
         };
-        // Second acquirer reads the on-disk info so callers can surface a
-        // useful message ("endpoint X, pid Y is already running").
-        assert_eq!(info.endpoint, "unix:/tmp/sock");
-        assert_eq!(info.blob_port, Some(12345));
+        assert_eq!(
+            info.endpoint,
+            dir.join("runtimed.sock").to_string_lossy().as_ref()
+        );
+        assert_eq!(info.pid, 0);
+        assert_eq!(info.version, "unknown");
+        drop(first);
         Ok(())
     }
 
     #[test]
-    fn drop_releases_lock_and_removes_info() -> TestResult {
-        // After the first lock drops, a second acquire must succeed AND
-        // the stale daemon.json must be gone (so clients don't connect
-        // to a dead endpoint).
+    fn drop_releases_lock() -> TestResult {
+        // After the first lock drops, a second acquire must succeed.
         let tmp = TempDir::new()?;
         let dir = tmp.path().to_path_buf();
         {
-            let lock = DaemonLock::try_acquire(Some(&dir)).map_err(|_| "first acquire")?;
-            lock.write_info("unix:/tmp/old", None)?;
-            assert!(dir.join("daemon.json").exists());
+            let _lock = DaemonLock::try_acquire(Some(&dir)).map_err(|_| "first acquire")?;
         }
-        // After drop, info file gone.
-        assert!(!dir.join("daemon.json").exists());
-        // And we can re-acquire.
         let _second = DaemonLock::try_acquire(Some(&dir)).map_err(|_| "re-acquire after drop")?;
-        Ok(())
-    }
-
-    #[test]
-    fn write_info_roundtrips_through_read_daemon_info() -> TestResult {
-        let tmp = TempDir::new()?;
-        let dir = tmp.path().to_path_buf();
-        let lock = DaemonLock::try_acquire(Some(&dir)).map_err(|_| "acquire")?;
-        lock.write_info("unix:/tmp/rt.sock", Some(4242))?;
-
-        let info =
-            client_singleton::read_daemon_info(&dir.join("daemon.json")).ok_or("read back info")?;
-        assert_eq!(info.endpoint, "unix:/tmp/rt.sock");
-        assert_eq!(info.blob_port, Some(4242));
-        assert_eq!(info.pid, std::process::id());
-        assert!(!info.version.is_empty());
         Ok(())
     }
 

--- a/crates/runtimed/tests/integration.rs
+++ b/crates/runtimed/tests/integration.rs
@@ -697,13 +697,12 @@ async fn test_blob_server_health() {
     let client = PoolClient::new(socket_path);
     assert!(wait_for_daemon(&client).await);
 
-    // Read daemon info to find blob port
-    let info_path = temp_dir.path().join("daemon.json");
-    let info_json = tokio::fs::read_to_string(&info_path)
+    // Query daemon info over the socket to find the blob port.
+    let info = client
+        .daemon_info()
         .await
-        .expect("daemon.json should exist");
-    let info: serde_json::Value = serde_json::from_str(&info_json).unwrap();
-    let blob_port = info["blob_port"].as_u64().expect("blob_port should be set");
+        .expect("daemon info should be available");
+    let blob_port = info.blob_port.expect("blob_port should be set");
 
     // Hit the health endpoint
     let resp = reqwest::get(format!("http://127.0.0.1:{}/health", blob_port))


### PR DESCRIPTION
## Summary
- remove daemon.json write/read discovery paths from the daemon singleton and runtimed-client
- route blob URL discovery through live `GetDaemonInfo` socket metadata for Rust, Node, Python, and the notebook browser relay
- keep only explicit legacy daemon.json cleanup for old state directories, and make desktop startup upgrade when socket metadata is unavailable

Closes #2329

## Verification
- `cargo xtask lint --fix`
- `cargo check -p runtimed-client -p runt -p runtimed -p notebook -p runtimed-node -p runtimed-py`
- `pnpm --dir apps/notebook exec tsc -b`
- `cargo test -p runtimed-client --lib`
- `cargo test -p runtimed --lib singleton`
- `cargo test -p runtimed --test integration test_blob_server_health`
