### PR TITLE
docs(markdown): carried-forward node identity for the markdown plan

### DIFF
--- a/docs/memos/markdown-node-identity-reconciler.md
+++ b/docs/memos/markdown-node-identity-reconciler.md
@@ -1,0 +1,224 @@
+# Stable Node Identity: a sequence-alignment reconciler for the markdown plan
+
+**Status:** Proposed. Step 1 of mid's node-granular render (mid ADR 0002).
+
+## Objective
+
+Node identity in the markdown plan is derived from byte offsets, so any edit
+above or inside a block renames that block and every block after it. The plan
+mints ids at one chokepoint:
+
+```rust
+// crates/nteract-markdown-engine/src/lib.rs:586
+fn node_id(kind: NodeKind, span: &SourceSpan) -> String {
+    format!("node:{kind:?}:{}:{}", span.start, span.end)
+}
+```
+
+Anchors, isolated regions, and inline runs all clone that id, so the offset
+leaks everywhere. Type one character at the top of a document and the projected
+plan reports every downstream block as new. A consumer that keys on the id (mid
+keys React on it) unmounts and remounts the whole subtree and resets component
+state.
+
+That is the single thing blocking node-granular render. The goal on mid's side
+is that a prose or math edit re-projects, diffs at block granularity, and
+re-renders just the changed node while live component state around it survives.
+That is only possible if a node keeps its identity across a reparse. This memo
+covers the engine half: replace offset-derived identity with stable, plan-owned
+ids that carry forward.
+
+This is step 1 and the load-bearing risk. The reconciler is greenfield and
+everything downstream (change-highlight correctness, patch-not-remount, the
+future `data-mdxid` correlation) is correct only if alignment is correct. It
+gets proven first, in isolation, before any consumer wires up.
+
+## Why identity lives in the plan
+
+The markdown plan is shared surface area. Notebooks, Markdown Plan work, and mid
+all consume the same projector. Identity for the markdown half belongs in the
+plan so it travels to every surface, rather than each one re-deriving it. mid
+consumes plan-assigned ids. The executable-MDX half (JSX, components,
+expressions) stays consumer-specific and never crosses into the plan.
+
+## Decision
+
+Identity becomes position-after-alignment, carried across reparses. The previous
+plan is handed back in as a consumer-owned, engine-opaque snapshot through one
+additive C-ABI export. The five existing wasm exports and `LAST_OUTPUT` stay
+byte-for-byte, so consumers opt in rather than being force-migrated. The engine
+stays a pure function of `(source, previous-snapshot)`, which means the whole
+identity matrix runs as FFI-free `cargo` tests.
+
+### Three phases
+
+A new `project_markdown_reconciled(source, options, &prev) -> (MarkdownPlan, ReconcilerSnapshot)`:
+
+1. **Build.** Run `project_node` as today, but leave `ProjectedNode.id` empty and
+   defer anchor and isolated-region emission. This drops the provisional-id
+   remap and the `SourceSpan::empty()` id collision.
+2. **Reconcile.** Assign ids top-down. One recursive `reconcile_children` runs at
+   every children list (blocks, then list items / table rows / cells, then inline
+   runs), so block and inline ids fall out of the same pass. Root keeps the
+   literal `"root"`; only its children align.
+3. **Finalize.** A document-order DFS over the now-id-stable tree rebuilds
+   anchors (`block_id = node.id`), isolated regions (`id = "isolation:" + node.id`),
+   and the heading-slug counter, then serializes the new snapshot from
+   `MarkdownPlan.root`. The snapshot is built from the projected tree the aligner
+   walks, never from the flattened block/run view.
+
+### The identity policy is a two-tier predicate
+
+- `eq(a, b)` = `(kind, lane, iso, isolation_tag)` equal **and** `content_hash`
+  equal. This is the unchanged-anchor test that trim and LCS anchor on.
+- `compat(a, b)` = `(kind, lane, iso, isolation_tag)` equal, content may differ.
+  This is the edit-inside-vs-replace gate only.
+
+Content decides changed-vs-unchanged, never identity. Identity is always
+alignment position plus `compat`. Duplicates (two `---`, two `## Notes`, two
+identical `$x$`) are disambiguated by order, which alignment gives for free, not
+by content.
+
+### The aligner
+
+`reconcile_children` is: ambiguity-guarded two-ended trim under `eq`, then LCS on
+the residual middle under `eq` with match-late backtrack, then a
+`content_hash`-keyed in-order move match on the LCS leftovers, then a
+front-surplus-aware positional zip under `compat`, then mint fresh for anything
+left. A node matched under `eq` has an equal `content_hash`, so its subtree is
+byte-identical and its ids are preserved without recursing. Only `compat` carries
+(content differs) recurse to re-align changed children. The common keystroke
+trims to unchanged anchors and recurses into exactly one edited block.
+
+### Two corrections the adversarial pass forced
+
+The first design broke on four of eight edit scenarios. Both fixes are now
+load-bearing:
+
+1. **`content_hash` must be a recursive Merkle digest**, folding
+   `kind, lane, iso, isolation_tag`, the rendering-salient attrs, `copy_text` for
+   leaves, and each child's hash in document order. A flat `copy_text`-plus-attrs
+   scalar made a formatting-only edit (`the cat sat` to `the *cat* sat`) and a
+   same-text reorder (`**alpha**` vs `alpha`) compare equal at the parent, which
+   silently dropped the edit and collapsed the reorder to a positional no-op. The
+   invariant "equal `content_hash` implies subtree byte-identical" is exactly what
+   the subtree short-circuit and the `eq` anchor depend on.
+2. **The structural tuple widens to include `isolation_tag`**, a new
+   `NodeAttrs.isolation_tag` carrying the MDX component name or active-HTML
+   element tag. Without it, `<Frog/>` to `<Banana/>` and `<video>` to `<iframe>`
+   (same `IsolationKind`) are `compat` and alias a portal node through a shared
+   id instead of remounting.
+
+### Insert-direction bias
+
+The front-surplus zip hard-codes an insert-above preference: when the new
+children have surplus leading nodes with no `eq` match, those mint fresh before
+the remainder zips under `compat`, so a block inserted above an edited block does
+not steal the edited block's id. This provably sacrifices the symmetric
+insert-below-adjacent-to-edit direction. Both directions are pinned with tests,
+so the bias is accepted, regression-locked behavior, not emergent.
+
+### FFI threading
+
+The snapshot rides out inside the existing result JSON under one new
+`"reconciler"` field (a base64-wrapped, hand-rolled wire blob: magic and version,
+`next_id`, then preorder records reconstructed by child count). It rides back in
+through a second consumer-owned buffer on the new export
+`nteract_markdown_project_reconcile`. `from_wire` is total: a version skew or
+malformed bytes return `Default` (cold start, every node fresh), never a panic,
+mirroring the `from_utf8` discipline already in the wasm layer. The consumer
+treats the token as opaque and never parses it.
+
+## Behavioral coverage
+
+The whole matrix is FFI-free. Each test calls `project_markdown_reconciled`
+twice, threading the first snapshot into the second call.
+
+| Test | Pins |
+| --- | --- |
+| `insert_above_keeps_following_ids` | Offsets shift, following block and inline ids byte-for-byte equal, one fresh id at the top. |
+| `insert_above_with_duplicates_no_misassign` | The ambiguity guard stops trim preempting LCS; exactly one remount in a duplicate run, existing ids preserved in order. |
+| `insert_below_with_duplicates_pins_direction` | The sacrificed insert-below direction, regression-locked. |
+| `edit_inside_text_keeps_id` | `compat` carries the block id; content_hash differs; one run re-aligns. |
+| `edit_inside_formatting_only_merkle` | Merkle hash catches a `copy_text`-invariant edit a flat hash drops. |
+| `reorder_tracks_moved_block` | LCS anchor plus keyed move; neither id stays positional. |
+| `reorder_same_copytext_diff_structure` | Merkle differs at the boundary; no positional no-op, no inline-subtree graft. |
+| `replace_cross_kind_new_id` | Cross-kind replace mints fresh; retired id never reused. |
+| `replace_isolated_component_remounts` | `isolation_tag` makes `<Frog/>` to `<Banana/>` non-compat; region id is fresh. |
+| `lane_flip_deliberate_remount` | A block crossing into Isolated mints fresh; neighbors preserved. |
+| `inline_insert_before_identical_math` | Two identical `$x$` runs keep order, no crossing. |
+| `offset_decoupling_nonheading` | All later block and inline ids equal while spans shift. |
+| `offset_decoupling_heading_slug_renumber` | Node id stable; only the slug-derived anchor own-id renumbers, by design. |
+| `link_reference_definition_insert_above_variant_b` | A new link-ref def above does not steal the downstream paragraph's id. |
+| `cold_start_all_fresh` | Empty token and the stateless path both mint fresh from 1; root is `"root"`. |
+| `snapshot_wire_roundtrip_total` | Round-trip is faithful; malformed or skewed bytes return `Default`, never panic. |
+
+## Open decisions to ratify
+
+- **FFI shape.** The additive `nteract_markdown_project_reconcile` with an opaque
+  snapshot in the result JSON, over widening `project()` to four args (breaks the
+  frozen ABI) or a wasm session handle (long-lived mutable state, leak surface,
+  breaks pure-function testability). Recommended: the additive export.
+- **Id representation.** Keep `String` ids (`node:{n}`); consumers treat them as
+  opaque keys, so the wire shape is free. Integers save a few bytes per node at
+  the cost of a consumer-side stringify.
+- **Snapshot encoding.** Hand-rolled little-endian `to_wire`/`from_wire` (no new
+  dep, new parser surface to fuzz) vs adding `serde_json` to the engine (de-risks
+  the parser, costs wasm binary size). The crate has no JSON reader today either
+  way.
+- **Merkle hash function and attr set.** FNV-1a vs xxhash, and which attrs beyond
+  `copy_text` feed the digest (depth, lang, meta, url, ordered, checked, align,
+  isolation_tag). Under-hash misses a real change; over-hash adds spurious
+  changed-region churn (the id still carries via `compat`).
+- **`isolation_tag` extraction.** How to parse the component name / element tag
+  out of `html.value`, and whether expression-kind MDX nodes need a finer
+  discriminator than one tag string.
+- **Docs graduation.** This stays a memo until the identity decision is ratified,
+  then graduates to a numbered ADR.
+
+## Risks
+
+- The Merkle `content_hash` is the new load-bearing invariant. If it is not
+  recursive, the subtree short-circuit and the `eq` anchor both break.
+- The snapshot must serialize from `MarkdownPlan.root`, never the wasm
+  block/run flattening, which folds the safe-html triplet three-into-one and
+  clears MDX children. A snapshot from the flattened view misaligns block-vs-inline
+  granularity.
+- `from_wire` must be total. An old-engine snapshot fed to a new engine must
+  degrade to a full remount, not poison the projection.
+- Counter monotonicity depends on the consumer round-tripping `next_id` inside
+  the opaque token. A lost token mints from 1 and can collide with a still-mounted
+  key; treat a missing or bad token as a fresh document and reset the consumer's
+  render baseline.
+- Deferring anchor / isolated-region / slug collection into the Phase-3 DFS is a
+  side-effect-ordering refactor. It must preserve document-order slug numbering
+  and isolated-region emission order; re-run the existing tests to confirm.
+- The LCS middle is O(m*n) per sibling level. A pathological flat list or a
+  thousand-row table needs a length-threshold fallback or a Myers O(ND) upgrade
+  before shipping to very large documents.
+
+## Rebuild and re-vendor
+
+The artifact ships to mid as a vendored wasm. mid currently vendors the build
+from `06692a3`; this advances it.
+
+1. `rustup target add wasm32-unknown-unknown` (idempotent; already installed).
+2. `cargo test -p nteract-markdown-engine && cargo test -p nteract-markdown-wasm`.
+   The identity matrix is FFI-free, so this is the real gate.
+3. `cargo build -p nteract-markdown-wasm --release --target wasm32-unknown-unknown`.
+4. Copy `target/wasm32-unknown-unknown/release/deps/nteract_markdown_wasm.wasm`
+   into mid's `vendor/nteract-markdown-wasm/`, bump the README source commit, and
+   bump both crate versions (the id format and JSON sidecar are a breaking change
+   for the vendored artifact).
+5. Confirm the artifact still exports the original five symbols plus
+   `nteract_markdown_project_reconcile` before the vendored consumer relies on it.
+
+## Consumer follow-on (separate, not in this branch)
+
+mid wires up in its own steps once the engine ids are stable: re-vendor the
+artifact (inert until opt-in), widen the TS projector to pass and persist the
+prev snapshot per file, teach change-highlights to emit "changed" when the id
+matches but content differs, and only later inject a `data-mdxid` attribute with
+portal placement for the executable half. The first reconciled render after the
+re-vendor remounts the whole document once, because every id string shape changes
+at once. That is expected, not a reconciler defect.

--- a/docs/memos/markdown-node-identity-reconciler.md
+++ b/docs/memos/markdown-node-identity-reconciler.md
@@ -1,12 +1,11 @@
-# Stable Node Identity: a sequence-alignment reconciler for the markdown plan
+# Carried-forward node identity for the markdown plan
 
-**Status:** Proposed. Step 1 of mid's node-granular render (mid ADR 0002).
+**Status:** Exploration. Engine design, downstream-driven. No-op for nteract's
+current surfaces beyond cheaper remounts; see "What this buys nteract."
 
 ## Objective
 
-Node identity in the markdown plan is derived from byte offsets, so any edit
-above or inside a block renames that block and every block after it. The plan
-mints ids at one chokepoint:
+The markdown plan projector mints every node's id from byte offsets:
 
 ```rust
 // crates/nteract-markdown-engine/src/lib.rs:586
@@ -15,210 +14,176 @@ fn node_id(kind: NodeKind, span: &SourceSpan) -> String {
 }
 ```
 
-Anchors, isolated regions, and inline runs all clone that id, so the offset
-leaks everywhere. Type one character at the top of a document and the projected
-plan reports every downstream block as new. A consumer that keys on the id (mid
-keys React on it) unmounts and remounts the whole subtree and resets component
-state.
+Anchors, isolated regions, and inline runs all clone that id, so any edit above
+or inside a block renames it and every node after it. A consumer that keys on the
+id sees the whole tail of the document turn over on a one-character edit. This
+memo proposes replacing offset-derived identity with stable ids that carry across
+reparses, assigned by a sequence-alignment reconciler that takes the previous
+plan as input.
 
-That is the single thing blocking node-granular render. The goal on mid's side
-is that a prose or math edit re-projects, diffs at block granularity, and
-re-renders just the changed node while live component state around it survives.
-That is only possible if a node keeps its identity across a reparse. This memo
-covers the engine half: replace offset-derived identity with stable, plan-owned
-ids that carry forward.
+## What this buys nteract
 
-This is step 1 and the load-bearing risk. The reconciler is greenfield and
-everything downstream (change-highlight correctness, patch-not-remount, the
-future `data-mdxid` correlation) is correct only if alignment is correct. It
-gets proven first, in isolation, before any consumer wires up.
+Be honest about the payoff. Inside nteract, the plan ids matter in exactly one
+place:
 
-## Why identity lives in the plan
+- React keys in the host renderer (`key={block.blockId}`, `key={run.inlineId}`
+  in `ProjectedMarkdownView`). These churn on every edit-above and remount the
+  rendered subtree. The host-rendered path is stateless presentational components
+  (headings, lists, code blocks, math); stateful and executable regions route to
+  `IsolatedFrame` and are keyed separately. So the churn is a cheap, visually
+  invisible remount today, not a state-loss or correctness bug.
 
-The markdown plan is shared surface area. Notebooks, Markdown Plan work, and mid
-all consume the same projector. Identity for the markdown half belongs in the
-plan so it travels to every surface, rather than each one re-deriving it. mid
-consumes plan-assigned ids. The executable-MDX half (JSX, components,
-expressions) stays consumer-specific and never crosses into the plan.
+Everything else is already insulated from offset churn:
 
-## Decision
+- Rendered-markdown comments anchor on source offsets plus an exact quote
+  (`comments-doc` `SourceRange`), re-resolved by quote search over the Automerge
+  `Text` source CRDT. They never key on plan node ids.
+- Active-source and presence highlighting compare ids within a single freshly
+  projected plan, so cross-edit stability is irrelevant.
+- Scroll and outline anchors resolve cell-level ids and heading slugs, not offset
+  node ids.
 
-Identity becomes position-after-alignment, carried across reparses. The previous
-plan is handed back in as a consumer-owned, engine-opaque snapshot through one
-additive C-ABI export. The five existing wasm exports and `LAST_OUTPUT` stay
-byte-for-byte, so consumers opt in rather than being force-migrated. The engine
-stays a pure function of `(source, previous-snapshot)`, which means the whole
-identity matrix runs as FFI-free `cargo` tests.
+So for nteract as it stands, stable identity mostly buys cheaper remounts. The
+cases where it becomes genuinely useful:
 
-### Three phases
+- **Collaborative selection survival.** A remote collaborator editing above while
+  a local user drags a selection in the rendered view re-projects the plan,
+  churns every id, and remounts the subtree, which can collapse the in-progress
+  DOM selection. Stable ids plus patch-not-remount keep the untouched nodes and
+  the selection alive. Present, narrow, real.
+- **Id-based change tracking.** A "this block changed since you last looked"
+  feature needs a node to keep identity across reparses. nteract has none today;
+  stable identity is the prerequisite if it grows one.
 
-A new `project_markdown_reconciled(source, options, &prev) -> (MarkdownPlan, ReconcilerSnapshot)`:
+The stronger pull is a downstream vendored consumer of the markdown wasm that
+keys React on these ids and hosts live component state inside the rendered
+document, where a remount is a real state loss. Putting identity in the plan
+keeps it shared rather than re-derived per surface.
+
+**Relationship to Automerge.** This is read-side projection identity, not source
+identity. Automerge owns the source `Text` CRDT and merges concurrent edits; the
+plan is a disposable projection parsed fresh from source. The reconciler
+stabilizes the projection's node handles across reparses. It does not replace,
+duplicate, or interact with Automerge's source identity.
+
+## Design
+
+A new `project_markdown_reconciled(source, options, &prev) -> (MarkdownPlan, ReconcilerSnapshot)`
+runs three phases:
 
 1. **Build.** Run `project_node` as today, but leave `ProjectedNode.id` empty and
-   defer anchor and isolated-region emission. This drops the provisional-id
-   remap and the `SourceSpan::empty()` id collision.
+   defer anchor and isolated-region emission. This drops the provisional-id remap
+   and the `SourceSpan::empty()` id collision.
 2. **Reconcile.** Assign ids top-down. One recursive `reconcile_children` runs at
    every children list (blocks, then list items / table rows / cells, then inline
    runs), so block and inline ids fall out of the same pass. Root keeps the
    literal `"root"`; only its children align.
-3. **Finalize.** A document-order DFS over the now-id-stable tree rebuilds
-   anchors (`block_id = node.id`), isolated regions (`id = "isolation:" + node.id`),
-   and the heading-slug counter, then serializes the new snapshot from
-   `MarkdownPlan.root`. The snapshot is built from the projected tree the aligner
-   walks, never from the flattened block/run view.
+3. **Finalize.** A document-order DFS over the now-id-stable tree rebuilds anchors
+   (`block_id = node.id`), isolated regions (`id = "isolation:" + node.id`), and
+   the heading-slug counter, then serializes the new snapshot from
+   `MarkdownPlan.root` (never from the flattened block/run view).
 
-### The identity policy is a two-tier predicate
+Identity is a two-tier predicate:
 
 - `eq(a, b)` = `(kind, lane, iso, isolation_tag)` equal **and** `content_hash`
-  equal. This is the unchanged-anchor test that trim and LCS anchor on.
+  equal. The unchanged-anchor test that trim and LCS anchor on.
 - `compat(a, b)` = `(kind, lane, iso, isolation_tag)` equal, content may differ.
-  This is the edit-inside-vs-replace gate only.
+  The edit-inside-vs-replace gate.
 
-Content decides changed-vs-unchanged, never identity. Identity is always
-alignment position plus `compat`. Duplicates (two `---`, two `## Notes`, two
-identical `$x$`) are disambiguated by order, which alignment gives for free, not
-by content.
-
-### The aligner
+Content decides changed-vs-unchanged, never identity. Identity is alignment
+position plus `compat`. Duplicates (two `---`, two `## Notes`, two identical
+`$x$`) disambiguate by order, which alignment gives for free.
 
 `reconcile_children` is: ambiguity-guarded two-ended trim under `eq`, then LCS on
 the residual middle under `eq` with match-late backtrack, then a
-`content_hash`-keyed in-order move match on the LCS leftovers, then a
+`content_hash`-keyed in-order move match on the leftovers, then a
 front-surplus-aware positional zip under `compat`, then mint fresh for anything
 left. A node matched under `eq` has an equal `content_hash`, so its subtree is
 byte-identical and its ids are preserved without recursing. Only `compat` carries
-(content differs) recurse to re-align changed children. The common keystroke
-trims to unchanged anchors and recurses into exactly one edited block.
+(content differs) recurse to re-align changed children.
 
-### Two corrections the adversarial pass forced
+Two requirements the edit scenarios force:
 
-The first design broke on four of eight edit scenarios. Both fixes are now
-load-bearing:
+- **`content_hash` is a recursive Merkle digest** over `kind, lane, iso,
+  isolation_tag`, the rendering-salient attrs, `copy_text` for leaves, and each
+  child's hash in document order. A flat `copy_text` scalar compares a
+  formatting-only edit (`the cat sat` to `the *cat* sat`) and a same-text reorder
+  (`**alpha**` vs `alpha`) equal at the parent, which silently drops the edit and
+  collapses the reorder. "Equal `content_hash` implies subtree byte-identical" is
+  what the subtree short-circuit and the `eq` anchor depend on.
+- **The structural tuple includes `isolation_tag`**, a new `NodeAttrs` field
+  carrying the MDX component name or active-HTML element tag, so two isolated
+  nodes of the same `IsolationKind` (`<video>` to `<iframe>`) are not `compat` and
+  remount instead of aliasing.
 
-1. **`content_hash` must be a recursive Merkle digest**, folding
-   `kind, lane, iso, isolation_tag`, the rendering-salient attrs, `copy_text` for
-   leaves, and each child's hash in document order. A flat `copy_text`-plus-attrs
-   scalar made a formatting-only edit (`the cat sat` to `the *cat* sat`) and a
-   same-text reorder (`**alpha**` vs `alpha`) compare equal at the parent, which
-   silently dropped the edit and collapsed the reorder to a positional no-op. The
-   invariant "equal `content_hash` implies subtree byte-identical" is exactly what
-   the subtree short-circuit and the `eq` anchor depend on.
-2. **The structural tuple widens to include `isolation_tag`**, a new
-   `NodeAttrs.isolation_tag` carrying the MDX component name or active-HTML
-   element tag. Without it, `<Frog/>` to `<Banana/>` and `<video>` to `<iframe>`
-   (same `IsolationKind`) are `compat` and alias a portal node through a shared
-   id instead of remounting.
+The front-surplus zip hard-codes an insert-above preference: surplus leading
+nodes with no `eq` match mint fresh before the remainder zips, so a block inserted
+above an edited block does not steal the edited block's id. This sacrifices the
+symmetric insert-below-adjacent-to-edit direction; both are pinned by tests.
 
-### Insert-direction bias
-
-The front-surplus zip hard-codes an insert-above preference: when the new
-children have surplus leading nodes with no `eq` match, those mint fresh before
-the remainder zips under `compat`, so a block inserted above an edited block does
-not steal the edited block's id. This provably sacrifices the symmetric
-insert-below-adjacent-to-edit direction. Both directions are pinned with tests,
-so the bias is accepted, regression-locked behavior, not emergent.
-
-### FFI threading
-
-The snapshot rides out inside the existing result JSON under one new
-`"reconciler"` field (a base64-wrapped, hand-rolled wire blob: magic and version,
-`next_id`, then preorder records reconstructed by child count). It rides back in
-through a second consumer-owned buffer on the new export
-`nteract_markdown_project_reconcile`. `from_wire` is total: a version skew or
-malformed bytes return `Default` (cold start, every node fresh), never a panic,
-mirroring the `from_utf8` discipline already in the wasm layer. The consumer
-treats the token as opaque and never parses it.
+The previous plan rides in as an opaque snapshot threaded through the projector.
+The existing stateless `project_markdown` is kept as the cold path: it calls the
+reconciled entry with an empty snapshot and discards the returned one, so every
+node is fresh and existing call sites are unchanged. A consumer that wants
+stability threads the snapshot back in. The whole identity matrix runs as FFI-free
+`cargo` tests because the engine stays a pure function of `(source, prev-snapshot)`.
 
 ## Behavioral coverage
 
-The whole matrix is FFI-free. Each test calls `project_markdown_reconciled`
-twice, threading the first snapshot into the second call.
-
 | Test | Pins |
 | --- | --- |
-| `insert_above_keeps_following_ids` | Offsets shift, following block and inline ids byte-for-byte equal, one fresh id at the top. |
-| `insert_above_with_duplicates_no_misassign` | The ambiguity guard stops trim preempting LCS; exactly one remount in a duplicate run, existing ids preserved in order. |
+| `insert_above_keeps_following_ids` | Following ids byte-for-byte stable while spans shift; one fresh id at the top. |
+| `insert_above_with_duplicates_no_misassign` | The ambiguity guard stops trim preempting LCS; one remount in a duplicate run, existing ids preserved in order. |
 | `insert_below_with_duplicates_pins_direction` | The sacrificed insert-below direction, regression-locked. |
-| `edit_inside_text_keeps_id` | `compat` carries the block id; content_hash differs; one run re-aligns. |
-| `edit_inside_formatting_only_merkle` | Merkle hash catches a `copy_text`-invariant edit a flat hash drops. |
+| `edit_inside_text_keeps_id` | `compat` carries the id; content_hash differs; one run re-aligns. |
+| `edit_inside_formatting_only_merkle` | The Merkle hash catches a `copy_text`-invariant edit a flat hash drops. |
 | `reorder_tracks_moved_block` | LCS anchor plus keyed move; neither id stays positional. |
 | `reorder_same_copytext_diff_structure` | Merkle differs at the boundary; no positional no-op, no inline-subtree graft. |
 | `replace_cross_kind_new_id` | Cross-kind replace mints fresh; retired id never reused. |
-| `replace_isolated_component_remounts` | `isolation_tag` makes `<Frog/>` to `<Banana/>` non-compat; region id is fresh. |
+| `replace_isolated_component_remounts` | `isolation_tag` makes a same-kind component swap remount; region id is fresh. |
 | `lane_flip_deliberate_remount` | A block crossing into Isolated mints fresh; neighbors preserved. |
-| `inline_insert_before_identical_math` | Two identical `$x$` runs keep order, no crossing. |
-| `offset_decoupling_nonheading` | All later block and inline ids equal while spans shift. |
+| `inline_insert_before_identical_math` | Two identical `$x$` runs keep order. |
+| `offset_decoupling_nonheading` | All later block and inline ids equal while every span shifts. |
 | `offset_decoupling_heading_slug_renumber` | Node id stable; only the slug-derived anchor own-id renumbers, by design. |
-| `link_reference_definition_insert_above_variant_b` | A new link-ref def above does not steal the downstream paragraph's id. |
-| `cold_start_all_fresh` | Empty token and the stateless path both mint fresh from 1; root is `"root"`. |
+| `cold_start_all_fresh` | Empty snapshot and the stateless path both mint fresh from 1; root is `"root"`. |
 | `snapshot_wire_roundtrip_total` | Round-trip is faithful; malformed or skewed bytes return `Default`, never panic. |
 
-## Open decisions to ratify
+## Open decisions
 
-- **FFI shape.** The additive `nteract_markdown_project_reconcile` with an opaque
-  snapshot in the result JSON, over widening `project()` to four args (breaks the
-  frozen ABI) or a wasm session handle (long-lived mutable state, leak surface,
-  breaks pure-function testability). Recommended: the additive export.
-- **Id representation.** Keep `String` ids (`node:{n}`); consumers treat them as
-  opaque keys, so the wire shape is free. Integers save a few bytes per node at
-  the cost of a consumer-side stringify.
-- **Snapshot encoding.** Hand-rolled little-endian `to_wire`/`from_wire` (no new
-  dep, new parser surface to fuzz) vs adding `serde_json` to the engine (de-risks
-  the parser, costs wasm binary size). The crate has no JSON reader today either
-  way.
+- **Snapshot transport.** How the opaque previous-plan snapshot crosses the wasm
+  boundary, and the encoding (hand-rolled little-endian with a total `from_wire`,
+  vs adding `serde_json` to the engine). The interface is free to change since
+  callers rebuild against it.
+- **Id representation.** Keep `String` ids (`node:{n}`) so the JSON contract is
+  unchanged, vs integers with a consumer-side stringify.
 - **Merkle hash function and attr set.** FNV-1a vs xxhash, and which attrs beyond
   `copy_text` feed the digest (depth, lang, meta, url, ordered, checked, align,
-  isolation_tag). Under-hash misses a real change; over-hash adds spurious
-  changed-region churn (the id still carries via `compat`).
-- **`isolation_tag` extraction.** How to parse the component name / element tag
-  out of `html.value`, and whether expression-kind MDX nodes need a finer
-  discriminator than one tag string.
-- **Docs graduation.** This stays a memo until the identity decision is ratified,
-  then graduates to a numbered ADR.
+  isolation_tag).
+- **`isolation_tag` extraction.** How to parse the component / element name out of
+  `html.value`, and whether expression-kind MDX nodes need a finer discriminator.
 
-## Risks
+## Risks and why it stays safe for nteract
 
-- The Merkle `content_hash` is the new load-bearing invariant. If it is not
-  recursive, the subtree short-circuit and the `eq` anchor both break.
-- The snapshot must serialize from `MarkdownPlan.root`, never the wasm
-  block/run flattening, which folds the safe-html triplet three-into-one and
-  clears MDX children. A snapshot from the flattened view misaligns block-vs-inline
-  granularity.
-- `from_wire` must be total. An old-engine snapshot fed to a new engine must
-  degrade to a full remount, not poison the projection.
-- Counter monotonicity depends on the consumer round-tripping `next_id` inside
-  the opaque token. A lost token mints from 1 and can collide with a still-mounted
-  key; treat a missing or bad token as a fresh document and reset the consumer's
-  render baseline.
-- Deferring anchor / isolated-region / slug collection into the Phase-3 DFS is a
-  side-effect-ordering refactor. It must preserve document-order slug numbering
-  and isolated-region emission order; re-run the existing tests to confirm.
-- The LCS middle is O(m*n) per sibling level. A pathological flat list or a
-  thousand-row table needs a length-threshold fallback or a Myers O(ND) upgrade
-  before shipping to very large documents.
+- The stateless `project_markdown` path is preserved and unchanged, so existing
+  nteract call sites keep their exact behavior; the reconciled path is opt-in.
+- The Phase-3 DFS that rebuilds anchors, isolated regions, and slugs must preserve
+  document-order slug numbering and region emission order. Re-run the existing
+  heading-anchor and isolated-region tests to confirm the non-id output is
+  byte-identical.
+- Everything downstream depends on the Merkle `content_hash` being recursive. If
+  it is flat, the subtree short-circuit and the `eq` anchor both break.
+- The snapshot must serialize from `MarkdownPlan.root`, never the wasm block/run
+  flattening, which folds the safe-html triplet three-into-one and clears MDX
+  children.
+- `from_wire` must be total: a version skew or malformed bytes return `Default`
+  (cold start, every node fresh), never a panic.
+- The LCS middle is O(m*n) per sibling level; a pathological flat list or a huge
+  table wants a length-threshold fallback or a Myers O(ND) upgrade before very
+  large documents.
 
-## Rebuild and re-vendor
+## Scope
 
-The artifact ships to mid as a vendored wasm. mid currently vendors the build
-from `06692a3`; this advances it.
-
-1. `rustup target add wasm32-unknown-unknown` (idempotent; already installed).
-2. `cargo test -p nteract-markdown-engine && cargo test -p nteract-markdown-wasm`.
-   The identity matrix is FFI-free, so this is the real gate.
-3. `cargo build -p nteract-markdown-wasm --release --target wasm32-unknown-unknown`.
-4. Copy `target/wasm32-unknown-unknown/release/deps/nteract_markdown_wasm.wasm`
-   into mid's `vendor/nteract-markdown-wasm/`, bump the README source commit, and
-   bump both crate versions (the id format and JSON sidecar are a breaking change
-   for the vendored artifact).
-5. Confirm the artifact still exports the original five symbols plus
-   `nteract_markdown_project_reconcile` before the vendored consumer relies on it.
-
-## Consumer follow-on (separate, not in this branch)
-
-mid wires up in its own steps once the engine ids are stable: re-vendor the
-artifact (inert until opt-in), widen the TS projector to pass and persist the
-prev snapshot per file, teach change-highlights to emit "changed" when the id
-matches but content differs, and only later inject a `data-mdxid` attribute with
-portal placement for the executable half. The first reconciled render after the
-re-vendor remounts the whole document once, because every id string shape changes
-at once. That is expected, not a reconciler defect.
+Engine plus FFI-free tests. The stateless entry is preserved, so this is additive
+for nteract and a no-op for its current surfaces beyond cheaper remounts. The
+identity matrix is the gate; ship it green before any consumer opts into the
+reconciled path.


### PR DESCRIPTION
The markdown plan projector mints node ids from byte offsets, so any edit above or inside a block renames it and every node after it:

```rust
// crates/nteract-markdown-engine/src/lib.rs:586
fn node_id(kind: NodeKind, span: &SourceSpan) -> String {
    format!("node:{kind:?}:{}:{}", span.start, span.end)
}
```

Design exploration (memo: `docs/memos/markdown-node-identity-reconciler.md`) for replacing offset-derived identity with stable ids carried across reparses by a sequence-alignment reconciler. Draft: design first, no implementation yet.

## What this buys nteract

Honestly, little today, and the memo says so. The only in-tree consumer of plan ids is React keys in `ProjectedMarkdownView`, and that path is stateless, so id-churn is a cheap, invisible remount. Comments anchor on source offsets plus quotes over the Automerge `Text` CRDT, not node ids; active highlighting is intra-plan; scroll and outline use cell ids and slugs. All insulated.

Where it earns its place: collaborative selection survival (a remote edit above during a local selection drag currently remounts and can collapse the in-progress selection), and as the prerequisite for any future id-based change tracking. The stronger pull is a downstream vendored consumer of the markdown wasm that keys React on these ids and hosts live state in the rendered document. Identity lives in the plan so it is shared, not re-derived per surface.

This is read-side projection identity, separate from and complementary to Automerge's source identity.

## Design

Three phases: build (project as today, empty ids, defer sidecars), reconcile (assign ids top-down; one recursive `reconcile_children` per children list, so block and inline ids fall out of one pass), finalize (DFS rebuilds anchors/regions/slugs from the id-stable tree, serializes the new snapshot). Two-tier predicate: `eq` (structural tuple + Merkle `content_hash`) anchors unchanged runs, `compat` (tuple only) gates edit-inside vs replace. Content decides changed-vs-unchanged, never identity; duplicates disambiguate by order.

Two requirements the edit cases force: a recursive Merkle `content_hash` (a flat `copy_text` hash drops formatting-only edits and collapses same-text reorders), and an `isolation_tag` in the identity tuple (so a same-kind component swap remounts instead of aliasing). The previous plan threads in as an opaque snapshot; the engine stays a pure function of `(source, prev-snapshot)`, so the whole identity matrix runs as FFI-free `cargo` tests.

## Behavioral coverage

| Scenario | Pins |
| --- | --- |
| Insert above (incl. duplicates) | Following ids stable while spans shift; one remount in a duplicate run. |
| Edit inside (text and formatting-only) | `compat` carries the id; the Merkle hash catches a `copy_text`-invariant edit. |
| Reorder (incl. same-copy_text/diff-structure) | LCS + keyed move track the block; no positional no-op. |
| Replace (cross-kind and same-kind isolated) | Fresh id; `isolation_tag` makes a component swap remount. |
| Lane flip | A block crossing into Isolated mints fresh; neighbors preserved. |
| Offset decoupling | All later block and inline ids equal while every span shifts. |
| Cold start / wire round-trip | Empty snapshot mints fresh from 1; malformed bytes return `Default`, never panic. |

## Safe for nteract

Additive and opt-in. The existing stateless `project_markdown` is preserved and unchanged, so current call sites keep their exact behavior; only consumers that thread the snapshot get stability. The non-id projection output (anchors, regions, slug order, measurements) stays byte-identical, guarded by re-running the existing engine and wasm tests. nteract does not depend on cross-edit id stability, so even a reconciler bug degrades to a cosmetic remount.
