### PR TITLE
docs: route agents to Elements design system lane

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -27,6 +27,30 @@ scoped execution work to `docs/plans/`, evidence and follow-up lists to
 `docs/audits/`, benchmark evidence to `docs/measurements/`, operational
 procedures to `docs/runbooks/`.
 
+## Design system and Elements
+
+For UI, design-system, or product-surface work, start with the
+`frontend-dev` repo skill and `apps/elements/content/docs/index.mdx` before
+editing app code. This includes Elements, cloud dashboard, notebook shell,
+toolbar, cells, output rendering, comments, runtime/package UI, search, themes,
+and shared components.
+
+Treat `apps/elements` as the stable review artifact layer for visual notebook
+surfaces. The catalog details live in the Elements docs and `frontend-dev`
+skill, not in this top-level routing file.
+
+Then read the nested ownership rules for the code you will touch:
+`apps/notebook/src/AGENTS.md` for desktop/shared notebook app wiring,
+`apps/notebook-cloud/AGENTS.md` for hosted cloud shell, authority, and viewer
+boundaries, and `src/components/ui/AGENTS.md` for shared UI, cell, editor, and
+output primitives. For notebook shell convergence, also read
+`docs/adr/notebook-host-shell-convergence.md`.
+
+Use those files to keep cloud app chrome separate from the shared notebook
+shell. Host-specific auth, ACL, sharing, workstation, routing, and side-effect
+boundaries should not fork common notebook presentation without an explicit
+reason.
+
 ## MCP servers
 
 Three may be visible. Pick by purpose. Full details in `.claude/rules/mcp-servers.md` (auto-loaded everywhere).


### PR DESCRIPTION
## Summary

- Add a top-level `AGENTS.md` routing section for design-system and Elements work.
- Point agents to the existing detailed sources before they edit UI code: `frontend-dev`, Elements docs, nested app/component `AGENTS.md`, and the notebook host shell convergence ADR.
- Keep the new guidance concise so top-level instructions route agents without duplicating the Elements catalog or design-system procedure.

## Why

The design-system lane already has useful guidance, but it was easy to miss because it lived across repo skills, nested instruction files, Elements docs, and an ADR. This makes the first-hop routing explicit for future UI, cloud dashboard, notebook shell, toolbar, cell, output, comments, runtime/package UI, search, theme, and shared-component work.

## Verification

- `cargo xtask lint --fix`

Note: the first lint attempt failed because this fresh worktree had no Node dependencies installed and `vite-plus` was missing. `pnpm install --frozen-lockfile` with the global pnpm 11 hit the active trust-policy check, so I installed with the repo-declared `corepack pnpm` version (`pnpm@10.30.0`) and reran lint successfully.
