### PR TITLE
build: pass -undefined dynamic_lookup for macOS extension crates

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -5,6 +5,13 @@ runt = "run --package runt --"
 [env]
 TS_RS_EXPORT_DIR = { value = "src/bindings", relative = true }
 
-# Linker rustflags live in .envrc, gated on `has ld64.lld`. Hard-coding
-# `-fuse-ld=lld` here broke CI runners that don't ship lld, so the rule
-# moved to an env-scoped direnv export. See `.envrc`.
+# macOS arm64 builds runtimed-py (pyo3) and runtimed-node (napi) as
+# host-loaded extension cdylibs whose libpython / Node ABI symbols resolve
+# at load time. The linker needs `-undefined dynamic_lookup` to leave them
+# undefined; both Apple ld and lld accept it, so it's safe to hard-code.
+# The lld selector stays in .envrc instead: `-fuse-ld=lld` is an error on
+# machines without lld, so it can't be unconditional. When .envrc is
+# loaded its CARGO_TARGET_AARCH64_APPLE_DARWIN_RUSTFLAGS supersedes this
+# block and carries the same dynamic_lookup flags (plus lld when present).
+[target.aarch64-apple-darwin]
+rustflags = ["-C", "link-arg=-undefined", "-C", "link-arg=dynamic_lookup"]

--- a/.envrc
+++ b/.envrc
@@ -21,13 +21,29 @@ export RUNTIMED_DEV=1
 # clang as -mmacosx-version-min, so the C side and Rust side agree.
 export MACOSX_DEPLOYMENT_TARGET=11.0
 
-# Link through LLVM lld on macOS arm64 when it's installed. Local dev
-# gets the faster linker; CI and contributors without lld fall back to
-# Apple's default ld. Scoped via CARGO_TARGET_<triple>_RUSTFLAGS so it
+# runtimed-py (pyo3) and runtimed-node (napi-rs) build host-loaded
+# extension cdylibs: their libpython / Node ABI symbols stay undefined at
+# link and resolve inside the Python / Node host at load time. macOS
+# linkers reject undefined symbols unless told to defer them, so both
+# Apple ld and lld need `-undefined dynamic_lookup`. pyo3's
+# extension-module feature emits no link args of its own, and napi's
+# cdylib-link-args don't reach test/bin targets, so the flag lives at the
+# rustflags level to cover every rustc invocation for this target.
+# Mirrored in .cargo/config.toml for shells without direnv; when this env
+# var is set it supersedes the config-level rustflags entirely, so it
+# carries the same flags. Scoped via CARGO_TARGET_<triple>_RUSTFLAGS so it
 # doesn't collide with a user-set RUSTFLAGS.
+darwin_rustflags="-C link-arg=-undefined -C link-arg=dynamic_lookup"
+
+# Link through LLVM lld on macOS arm64 when it's installed. Local dev gets
+# the faster linker; CI and contributors without lld fall back to Apple's
+# default ld. `-fuse-ld=lld` errors on machines without lld, so it stays
+# gated here rather than in the always-applied config.toml block.
 if has ld64.lld; then
-  export CARGO_TARGET_AARCH64_APPLE_DARWIN_RUSTFLAGS="-C link-arg=-fuse-ld=lld"
+  darwin_rustflags="-C link-arg=-fuse-ld=lld $darwin_rustflags"
 fi
+
+export CARGO_TARGET_AARCH64_APPLE_DARWIN_RUSTFLAGS="$darwin_rustflags"
 
 # Local cargo defaults kick in: CARGO_INCREMENTAL=1 + no RUSTC_WRAPPER.
 # Tight edit-check loops on one crate reuse rustc's per-function


### PR DESCRIPTION
`cargo build --workspace` and `cargo test --no-run` fail to link on macOS arm64: runtimed-py's cdylib and both runtimed-py and runtimed-node test binaries hit undefined libpython / Node ABI symbols.

Those two crates are host-loaded extension cdylibs. Their host symbols stay undefined at link and resolve inside the Python / Node process at load time, so the macOS linker needs `-undefined dynamic_lookup` to leave them undefined. pyo3's `extension-module` feature emits no link args of its own, and napi's `cargo:rustc-cdylib-link-arg` doesn't reach test or bin targets, so nothing supplied the flag under a plain `cargo build`.

The flag goes in at the rustflags level for `aarch64-apple-darwin`, which covers every rustc invocation (cdylib, bin, test bin), in two places:

- `.cargo/config.toml`: the no-direnv fallback. Safe to hard-code; both Apple ld and lld accept `-undefined dynamic_lookup`.
- `.envrc`: supersedes the config rustflags when loaded (a set `CARGO_TARGET_<triple>_RUSTFLAGS` overrides `target.<triple>.rustflags` entirely), and adds `-fuse-ld=lld` when lld is present. `-fuse-ld=lld` stays env-gated because it errors on machines without lld.

Linux and CI are untouched: undefined symbols in a shared object aren't a link error there, and the change is scoped to the macOS target.

## Verification

On macOS arm64, `cargo build --workspace` and `cargo test -p runtimed-py -p runtimed-node --no-run` both link clean. Before the change, the same commands fail to link runtimed-py and the two crates' test bins.

## Tradeoff

Rustflags-level `dynamic_lookup` applies to every macOS binary in the workspace, not just the two extension crates. For an ordinary binary it's a no-op, but it does defer a genuinely-missing symbol to a load-time failure instead of a link error. The surgical alternative is a `build.rs` on runtimed-py emitting the cdylib link arg, but `cargo:rustc-cdylib-link-arg` doesn't reach the test binaries, so it wouldn't fix `cargo test`. The rustflags knob is the one place that covers both.
