### PR TITLE
feat(markdown): carried-forward node identity reconciler

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4899,6 +4899,8 @@ name = "nteract-markdown-engine"
 version = "0.2.2"
 dependencies = [
  "markdown",
+ "serde",
+ "serde_json",
 ]
 
 [[package]]

--- a/crates/nteract-markdown-engine/Cargo.toml
+++ b/crates/nteract-markdown-engine/Cargo.toml
@@ -6,3 +6,5 @@ publish = false
 
 [dependencies]
 markdown = "1"
+serde = { workspace = true }
+serde_json = { workspace = true }

--- a/crates/nteract-markdown-engine/src/lib.rs
+++ b/crates/nteract-markdown-engine/src/lib.rs
@@ -1,6 +1,7 @@
 use markdown::mdast;
 use markdown::unist::Position;
 use markdown::{Constructs, ParseOptions};
+use serde::{Deserialize, Serialize};
 
 mod render_json;
 
@@ -61,13 +62,26 @@ pub struct MarkdownPlan {
     pub measurement: MeasurementPlan,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, Default)]
+#[derive(Debug, Clone, PartialEq, Eq, Default, Serialize, Deserialize)]
 pub struct ReconcilerSnapshot {
     root: Option<SnapshotNode>,
     next_id: u64,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq)]
+impl ReconcilerSnapshot {
+    pub fn to_bytes(&self) -> Vec<u8> {
+        match serde_json::to_vec(self) {
+            Ok(bytes) => bytes,
+            Err(_) => Vec::new(),
+        }
+    }
+
+    pub fn from_bytes(bytes: &[u8]) -> ReconcilerSnapshot {
+        serde_json::from_slice(bytes).unwrap_or_default()
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 struct SnapshotNode {
     id: String,
     key: StructuralKey,
@@ -75,7 +89,7 @@ struct SnapshotNode {
     children: Vec<SnapshotNode>,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 struct StructuralKey {
     kind: NodeKind,
     lane: SafetyLane,
@@ -101,7 +115,7 @@ pub struct ProjectedNode {
     pub children: Vec<ProjectedNode>,
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 pub enum NodeKind {
     Root,
     Paragraph,
@@ -195,14 +209,14 @@ pub struct Safety {
     pub reason: String,
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 pub enum SafetyLane {
     Host,
     Escaped,
     Isolated,
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 pub enum IsolationKind {
     RawHtml,
     ActiveHtml,
@@ -284,7 +298,7 @@ pub fn project_from_mdast(
     plan
 }
 
-fn project_from_mdast_reconciled(
+pub fn project_from_mdast_reconciled(
     mdast: &markdown::mdast::Node,
     source: &str,
     options: &MarkdownProjectOptions,
@@ -1947,6 +1961,52 @@ mod tests {
         assert_eq!(after.blocks[0].id, beta_id);
         assert_eq!(after.blocks[1].id, alpha_id);
         assert_eq!(after.blocks[2].id, gamma_id);
+    }
+
+    #[test]
+    fn reconciler_snapshot_round_trips_through_bytes() {
+        let (_, snapshot) = reconcile_default("# Title\n\nalpha *beta*\n\n---\n");
+
+        let restored = ReconcilerSnapshot::from_bytes(&snapshot.to_bytes());
+
+        assert_eq!(restored, snapshot);
+    }
+
+    #[test]
+    fn reconciler_snapshot_bytes_preserve_shifted_block_ids() {
+        let source = "alpha\n\nbeta\n\ngamma\n";
+        let (before, snapshot) = reconcile_default(source);
+        let before_ids = before
+            .blocks
+            .iter()
+            .map(|block| block.id.clone())
+            .collect::<Vec<_>>();
+        let restored = ReconcilerSnapshot::from_bytes(&snapshot.to_bytes());
+
+        let (after, _) =
+            reconcile_default_with_snapshot("intro\n\nalpha\n\nbeta\n\ngamma\n", &restored);
+
+        assert_eq!(after.blocks.len(), 4);
+        assert!(after.blocks[0].id.starts_with("node:reconciled:"));
+        assert_eq!(after.blocks[1].id, before_ids[0]);
+        assert_eq!(after.blocks[2].id, before_ids[1]);
+        assert_eq!(after.blocks[3].id, before_ids[2]);
+    }
+
+    #[test]
+    fn reconciler_snapshot_from_bytes_falls_back_to_cold_start() {
+        let source = "alpha\n\nbeta\n";
+        let empty = ReconcilerSnapshot::from_bytes(&[]);
+        let garbage = ReconcilerSnapshot::from_bytes(b"not json");
+
+        assert_eq!(empty, ReconcilerSnapshot::default());
+        assert_eq!(garbage, ReconcilerSnapshot::default());
+
+        let (from_empty, _) = reconcile_default_with_snapshot(source, &empty);
+        let (from_garbage, _) = reconcile_default_with_snapshot(source, &garbage);
+
+        assert_legacy_ids(&from_empty.root);
+        assert_legacy_ids(&from_garbage.root);
     }
 
     #[test]

--- a/crates/nteract-markdown-engine/src/lib.rs
+++ b/crates/nteract-markdown-engine/src/lib.rs
@@ -61,6 +61,34 @@ pub struct MarkdownPlan {
     pub measurement: MeasurementPlan,
 }
 
+#[derive(Debug, Clone, PartialEq, Eq, Default)]
+pub struct ReconcilerSnapshot {
+    root: Option<SnapshotNode>,
+    next_id: u64,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct SnapshotNode {
+    id: String,
+    key: StructuralKey,
+    content_hash: u64,
+    children: Vec<SnapshotNode>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct StructuralKey {
+    kind: NodeKind,
+    lane: SafetyLane,
+    isolation_kind: Option<IsolationKind>,
+    // Tag identity is part of the key so a same-kind tag swap is a replace, not
+    // an edit: isolation_tag covers active-HTML elements (<video> -> <iframe>),
+    // island_tag covers MDX components (<Frog /> -> <Chart />). Without the tag
+    // here, compat would carry the old id onto a different component and alias
+    // two distinct nodes, which breaks id-anchored comments and collab state.
+    isolation_tag: Option<String>,
+    island_tag: Option<String>,
+}
+
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct ProjectedNode {
     pub id: String,
@@ -125,6 +153,7 @@ pub struct NodeAttrs {
     pub align: Vec<TableAlign>,
     pub anchor_slug: Option<String>,
     pub isolation_kind: Option<IsolationKind>,
+    pub isolation_tag: Option<String>,
     pub island_tag: Option<String>,
     pub island_inline: bool,
 }
@@ -250,9 +279,45 @@ pub fn project_from_mdast(
     source: &str,
     options: &MarkdownProjectOptions,
 ) -> MarkdownPlan {
-    let mut context = ProjectionContext::new(source, options);
+    let (plan, _) =
+        project_from_mdast_reconciled(mdast, source, options, &ReconcilerSnapshot::default());
+    plan
+}
+
+fn project_from_mdast_reconciled(
+    mdast: &markdown::mdast::Node,
+    source: &str,
+    options: &MarkdownProjectOptions,
+    previous: &ReconcilerSnapshot,
+) -> (MarkdownPlan, ReconcilerSnapshot) {
+    let mut context = ProjectionContext::new(source, options, true);
     let mut root = project_node(mdast, &mut context);
     root.id = "root".to_string();
+
+    let next_id = if let Some(previous_root) = &previous.root {
+        let mut mint = IdMint::new(previous.next_id);
+        reconcile_children(&mut root.children, &previous_root.children, &mut mint);
+        mint.next_id
+    } else {
+        assign_legacy_ids(&mut root);
+        1
+    };
+
+    let plan = assemble_plan(root, source, options);
+    let snapshot = ReconcilerSnapshot {
+        root: Some(snapshot_from_node(&plan.root)),
+        next_id,
+    };
+    (plan, snapshot)
+}
+
+fn assemble_plan(
+    mut root: ProjectedNode,
+    source: &str,
+    options: &MarkdownProjectOptions,
+) -> MarkdownPlan {
+    let mut finalization = FinalizationContext::default();
+    finalize_node(&mut root, &mut finalization);
 
     let blocks = root.children.clone();
     let text_fallback = blocks
@@ -286,8 +351,8 @@ pub fn project_from_mdast(
         source_len: source.len(),
         root,
         blocks,
-        anchors: context.anchors,
-        isolated_regions: context.isolated_regions,
+        anchors: finalization.anchors,
+        isolated_regions: finalization.isolated_regions,
         text_fallback,
         measurement: MeasurementPlan {
             estimated_height,
@@ -301,12 +366,23 @@ pub fn project_markdown_with_options(
     source: &str,
     options: &MarkdownProjectOptions,
 ) -> Result<MarkdownPlan, MarkdownProjectError> {
+    let (plan, _) = project_markdown_reconciled(source, options, &ReconcilerSnapshot::default())?;
+    Ok(plan)
+}
+
+pub fn project_markdown_reconciled(
+    source: &str,
+    options: &MarkdownProjectOptions,
+    previous: &ReconcilerSnapshot,
+) -> Result<(MarkdownPlan, ReconcilerSnapshot), MarkdownProjectError> {
     let parse_options = parse_options(options.islands);
     let mdast =
         markdown::to_mdast(source, &parse_options).map_err(|message| MarkdownProjectError {
             message: message.reason,
         })?;
-    Ok(project_from_mdast(&mdast, source, options))
+    Ok(project_from_mdast_reconciled(
+        &mdast, source, options, previous,
+    ))
 }
 
 fn parse_options(islands: bool) -> ParseOptions {
@@ -332,22 +408,559 @@ fn parse_options(islands: bool) -> ParseOptions {
     }
 }
 
+#[derive(Default)]
+struct FinalizationContext {
+    anchors: Vec<MarkdownAnchor>,
+    isolated_regions: Vec<IsolatedRegion>,
+    slug_counts: std::collections::BTreeMap<String, usize>,
+}
+
+impl FinalizationContext {
+    fn unique_slug(&mut self, title: &str) -> String {
+        let slug = slugify(title);
+        let count = self.slug_counts.entry(slug.clone()).or_insert(0);
+        *count += 1;
+        if *count == 1 {
+            slug
+        } else {
+            format!("{slug}-{count}")
+        }
+    }
+}
+
+fn finalize_node(node: &mut ProjectedNode, context: &mut FinalizationContext) {
+    if node.kind == NodeKind::Heading {
+        if let Some(depth) = node.attrs.depth {
+            let slug = context.unique_slug(&node.fallback.text);
+            node.attrs.anchor_slug = Some(slug.clone());
+            context.anchors.push(MarkdownAnchor {
+                id: format!("anchor:{slug}"),
+                slug,
+                title: node.fallback.text.clone(),
+                level: depth,
+                block_id: node.id.clone(),
+                span: node.span.clone(),
+            });
+        }
+    } else {
+        node.attrs.anchor_slug = None;
+    }
+
+    if node.safety.lane == SafetyLane::Isolated {
+        let kind = node.attrs.isolation_kind.unwrap_or(IsolationKind::RawHtml);
+        context.isolated_regions.push(IsolatedRegion {
+            id: format!("isolation:{}", node.id),
+            block_id: node.id.clone(),
+            kind,
+            reason: node.safety.reason.clone(),
+            span: node.span.clone(),
+            fallback_text: node.fallback.text.clone(),
+        });
+    }
+
+    for child in &mut node.children {
+        finalize_node(child, context);
+    }
+}
+
+struct IdMint {
+    next_id: u64,
+}
+
+impl IdMint {
+    fn new(next_id: u64) -> Self {
+        Self {
+            next_id: next_id.max(1),
+        }
+    }
+
+    fn mint(&mut self) -> String {
+        let id = format!("node:reconciled:{}", self.next_id);
+        self.next_id += 1;
+        id
+    }
+}
+
+fn reconcile_children(current: &mut [ProjectedNode], previous: &[SnapshotNode], mint: &mut IdMint) {
+    let current_hashes = current.iter().map(content_hash).collect::<Vec<_>>();
+    let current_keys = current.iter().map(structural_key).collect::<Vec<_>>();
+    let mut matches = vec![None; current.len()];
+
+    let mut current_start = 0;
+    let mut previous_start = 0;
+    let mut current_end = current.len();
+    let mut previous_end = previous.len();
+
+    while current_start < current_end
+        && previous_start < previous_end
+        && unique_eq_at(
+            &current_keys,
+            &current_hashes,
+            previous,
+            current_start,
+            previous_start,
+            current_start..current_end,
+            previous_start..previous_end,
+        )
+    {
+        matches[current_start] = Some(previous_start);
+        current_start += 1;
+        previous_start += 1;
+    }
+
+    while current_start < current_end
+        && previous_start < previous_end
+        && unique_eq_at(
+            &current_keys,
+            &current_hashes,
+            previous,
+            current_end - 1,
+            previous_end - 1,
+            current_start..current_end,
+            previous_start..previous_end,
+        )
+    {
+        current_end -= 1;
+        previous_end -= 1;
+        matches[current_end] = Some(previous_end);
+    }
+
+    lcs_eq_matches(
+        &current_keys,
+        &current_hashes,
+        previous,
+        current_start..current_end,
+        previous_start..previous_end,
+        &mut matches,
+    );
+    match_exact_moves(
+        &current_keys,
+        &current_hashes,
+        previous,
+        current_start..current_end,
+        previous_start..previous_end,
+        &mut matches,
+    );
+    zip_compatible_leftovers(
+        &current_keys,
+        previous,
+        current_start..current_end,
+        previous_start..previous_end,
+        &mut matches,
+    );
+
+    for (current_index, previous_index) in matches.into_iter().enumerate() {
+        if let Some(previous_index) = previous_index {
+            let previous_node = &previous[previous_index];
+            current[current_index].id = previous_node.id.clone();
+            if current_hashes[current_index] == previous_node.content_hash {
+                apply_snapshot_ids(&mut current[current_index], previous_node);
+            } else {
+                reconcile_children(
+                    &mut current[current_index].children,
+                    &previous_node.children,
+                    mint,
+                );
+            }
+        } else {
+            assign_fresh_ids(&mut current[current_index], mint);
+        }
+    }
+}
+
+fn unique_eq_at(
+    current_keys: &[StructuralKey],
+    current_hashes: &[u64],
+    previous: &[SnapshotNode],
+    current_index: usize,
+    previous_index: usize,
+    current_range: std::ops::Range<usize>,
+    previous_range: std::ops::Range<usize>,
+) -> bool {
+    if !eq_at(
+        current_keys,
+        current_hashes,
+        previous,
+        current_index,
+        previous_index,
+    ) {
+        return false;
+    }
+
+    let previous_matches = previous_range
+        .clone()
+        .filter(|index| {
+            eq_at(
+                current_keys,
+                current_hashes,
+                previous,
+                current_index,
+                *index,
+            )
+        })
+        .count();
+    if previous_matches != 1 {
+        return false;
+    }
+
+    current_range
+        .filter(|index| {
+            eq_at(
+                current_keys,
+                current_hashes,
+                previous,
+                *index,
+                previous_index,
+            )
+        })
+        .count()
+        == 1
+}
+
+fn lcs_eq_matches(
+    current_keys: &[StructuralKey],
+    current_hashes: &[u64],
+    previous: &[SnapshotNode],
+    current_range: std::ops::Range<usize>,
+    previous_range: std::ops::Range<usize>,
+    matches: &mut [Option<usize>],
+) {
+    let current_len = current_range.end - current_range.start;
+    let previous_len = previous_range.end - previous_range.start;
+    if current_len == 0 || previous_len == 0 {
+        return;
+    }
+
+    let columns = previous_len + 1;
+    let mut lengths = vec![0usize; (current_len + 1) * columns];
+    for current_offset in 0..current_len {
+        for previous_offset in 0..previous_len {
+            let current_index = current_range.start + current_offset;
+            let previous_index = previous_range.start + previous_offset;
+            let cell = (current_offset + 1) * columns + previous_offset + 1;
+            if eq_at(
+                current_keys,
+                current_hashes,
+                previous,
+                current_index,
+                previous_index,
+            ) {
+                lengths[cell] = lengths[current_offset * columns + previous_offset] + 1;
+            } else {
+                lengths[cell] = lengths[current_offset * columns + previous_offset + 1]
+                    .max(lengths[(current_offset + 1) * columns + previous_offset]);
+            }
+        }
+    }
+
+    let mut current_offset = current_len;
+    let mut previous_offset = previous_len;
+    while current_offset > 0 && previous_offset > 0 {
+        let current_index = current_range.start + current_offset - 1;
+        let previous_index = previous_range.start + previous_offset - 1;
+        let cell = current_offset * columns + previous_offset;
+        let diagonal = (current_offset - 1) * columns + previous_offset - 1;
+        if eq_at(
+            current_keys,
+            current_hashes,
+            previous,
+            current_index,
+            previous_index,
+        ) && lengths[cell] == lengths[diagonal] + 1
+        {
+            matches[current_index] = Some(previous_index);
+            current_offset -= 1;
+            previous_offset -= 1;
+        } else if lengths[current_offset * columns + previous_offset - 1]
+            >= lengths[(current_offset - 1) * columns + previous_offset]
+        {
+            previous_offset -= 1;
+        } else {
+            current_offset -= 1;
+        }
+    }
+}
+
+fn match_exact_moves(
+    current_keys: &[StructuralKey],
+    current_hashes: &[u64],
+    previous: &[SnapshotNode],
+    current_range: std::ops::Range<usize>,
+    previous_range: std::ops::Range<usize>,
+    matches: &mut [Option<usize>],
+) {
+    let mut previous_leftovers = unmatched_previous(previous.len(), matches, previous_range);
+    for current_index in current_range {
+        if matches[current_index].is_some() {
+            continue;
+        }
+
+        if let Some(position) = previous_leftovers.iter().position(|previous_index| {
+            eq_at(
+                current_keys,
+                current_hashes,
+                previous,
+                current_index,
+                *previous_index,
+            )
+        }) {
+            matches[current_index] = Some(previous_leftovers.remove(position));
+        }
+    }
+}
+
+fn zip_compatible_leftovers(
+    current_keys: &[StructuralKey],
+    previous: &[SnapshotNode],
+    current_range: std::ops::Range<usize>,
+    previous_range: std::ops::Range<usize>,
+    matches: &mut [Option<usize>],
+) {
+    let current_leftovers = current_range
+        .filter(|index| matches[*index].is_none())
+        .collect::<Vec<_>>();
+    let previous_leftovers = unmatched_previous(previous.len(), matches, previous_range);
+    let front_surplus = current_leftovers
+        .len()
+        .saturating_sub(previous_leftovers.len());
+
+    for (current_index, previous_index) in current_leftovers
+        .iter()
+        .skip(front_surplus)
+        .zip(previous_leftovers.iter())
+    {
+        if compat_at(current_keys, previous, *current_index, *previous_index) {
+            matches[*current_index] = Some(*previous_index);
+        }
+    }
+}
+
+fn unmatched_previous(
+    previous_len: usize,
+    matches: &[Option<usize>],
+    previous_range: std::ops::Range<usize>,
+) -> Vec<usize> {
+    let mut used = vec![false; previous_len];
+    for previous_index in matches.iter().flatten() {
+        used[*previous_index] = true;
+    }
+    previous_range.filter(|index| !used[*index]).collect()
+}
+
+fn eq_at(
+    current_keys: &[StructuralKey],
+    current_hashes: &[u64],
+    previous: &[SnapshotNode],
+    current_index: usize,
+    previous_index: usize,
+) -> bool {
+    compat_at(current_keys, previous, current_index, previous_index)
+        && current_hashes[current_index] == previous[previous_index].content_hash
+}
+
+fn compat_at(
+    current_keys: &[StructuralKey],
+    previous: &[SnapshotNode],
+    current_index: usize,
+    previous_index: usize,
+) -> bool {
+    current_keys[current_index] == previous[previous_index].key
+}
+
+fn apply_snapshot_ids(current: &mut ProjectedNode, previous: &SnapshotNode) {
+    current.id = previous.id.clone();
+    for (current_child, previous_child) in current.children.iter_mut().zip(&previous.children) {
+        apply_snapshot_ids(current_child, previous_child);
+    }
+}
+
+fn assign_fresh_ids(node: &mut ProjectedNode, mint: &mut IdMint) {
+    if node.kind == NodeKind::Root {
+        node.id = "root".to_string();
+    } else {
+        node.id = mint.mint();
+    }
+    for child in &mut node.children {
+        assign_fresh_ids(child, mint);
+    }
+}
+
+fn assign_legacy_ids(node: &mut ProjectedNode) {
+    if node.kind == NodeKind::Root {
+        node.id = "root".to_string();
+    } else {
+        node.id = node_id(node.kind, &node.span);
+    }
+    for child in &mut node.children {
+        assign_legacy_ids(child);
+    }
+}
+
+fn snapshot_from_node(node: &ProjectedNode) -> SnapshotNode {
+    SnapshotNode {
+        id: node.id.clone(),
+        key: structural_key(node),
+        content_hash: content_hash(node),
+        children: node.children.iter().map(snapshot_from_node).collect(),
+    }
+}
+
+fn structural_key(node: &ProjectedNode) -> StructuralKey {
+    StructuralKey {
+        kind: node.kind,
+        lane: node.safety.lane,
+        isolation_kind: node.attrs.isolation_kind,
+        isolation_tag: node.attrs.isolation_tag.clone(),
+        island_tag: node.attrs.island_tag.clone(),
+    }
+}
+
+fn content_hash(node: &ProjectedNode) -> u64 {
+    let mut hasher = StableHasher::new();
+    hasher.write_str("node");
+    hasher.write_str(node_kind_label(node.kind));
+    hasher.write_str(safety_lane_label(node.safety.lane));
+    hasher.write_option_str(node.attrs.isolation_tag.as_deref());
+    hasher.write_option_str(node.attrs.island_tag.as_deref());
+    hasher.write_bool(node.attrs.island_inline);
+    hasher.write_option_str(node.attrs.isolation_kind.map(isolation_kind_label));
+    hasher.write_str(&node.safety.reason);
+    hash_attrs(&mut hasher, &node.attrs);
+    hasher.write_usize(node.children.len());
+    if node.children.is_empty() {
+        hasher.write_str(&node.fallback.copy_text);
+    }
+    for child in &node.children {
+        hasher.write_u64(content_hash(child));
+    }
+    hasher.finish()
+}
+
+fn hash_attrs(hasher: &mut StableHasher, attrs: &NodeAttrs) {
+    hasher.write_option_u8(attrs.depth);
+    hasher.write_option_bool(attrs.ordered);
+    hasher.write_option_u32(attrs.start);
+    hasher.write_option_bool(attrs.spread);
+    hasher.write_option_bool(attrs.checked);
+    hasher.write_option_str(attrs.lang.as_deref());
+    hasher.write_option_str(attrs.meta.as_deref());
+    hasher.write_option_str(attrs.url.as_deref());
+    hasher.write_option_str(attrs.title.as_deref());
+    hasher.write_option_str(attrs.alt.as_deref());
+    hasher.write_option_str(attrs.identifier.as_deref());
+    hasher.write_option_str(attrs.label.as_deref());
+    hasher.write_usize(attrs.align.len());
+    for align in &attrs.align {
+        hasher.write_str(table_align_label(*align));
+    }
+}
+
+struct StableHasher {
+    hash: u64,
+}
+
+impl StableHasher {
+    fn new() -> Self {
+        Self {
+            hash: 0xcbf29ce484222325,
+        }
+    }
+
+    fn finish(self) -> u64 {
+        self.hash
+    }
+
+    fn write_bytes(&mut self, bytes: &[u8]) {
+        for byte in bytes {
+            self.hash ^= u64::from(*byte);
+            self.hash = self.hash.wrapping_mul(0x100000001b3);
+        }
+    }
+
+    fn write_str(&mut self, value: &str) {
+        self.write_usize(value.len());
+        self.write_bytes(value.as_bytes());
+    }
+
+    fn write_bool(&mut self, value: bool) {
+        self.write_bytes(&[u8::from(value)]);
+    }
+
+    fn write_u64(&mut self, value: u64) {
+        self.write_bytes(&value.to_le_bytes());
+    }
+
+    fn write_usize(&mut self, value: usize) {
+        self.write_u64(value as u64);
+    }
+
+    fn write_u32(&mut self, value: u32) {
+        self.write_bytes(&value.to_le_bytes());
+    }
+
+    fn write_u8(&mut self, value: u8) {
+        self.write_bytes(&[value]);
+    }
+
+    fn write_option_str(&mut self, value: Option<&str>) {
+        match value {
+            Some(value) => {
+                self.write_bool(true);
+                self.write_str(value);
+            }
+            None => self.write_bool(false),
+        }
+    }
+
+    fn write_option_bool(&mut self, value: Option<bool>) {
+        match value {
+            Some(value) => {
+                self.write_bool(true);
+                self.write_bool(value);
+            }
+            None => self.write_bool(false),
+        }
+    }
+
+    fn write_option_u32(&mut self, value: Option<u32>) {
+        match value {
+            Some(value) => {
+                self.write_bool(true);
+                self.write_u32(value);
+            }
+            None => self.write_bool(false),
+        }
+    }
+
+    fn write_option_u8(&mut self, value: Option<u8>) {
+        match value {
+            Some(value) => {
+                self.write_bool(true);
+                self.write_u8(value);
+            }
+            None => self.write_bool(false),
+        }
+    }
+}
+
 struct ProjectionContext<'a> {
     source: &'a str,
     options: &'a MarkdownProjectOptions,
     anchors: Vec<MarkdownAnchor>,
     isolated_regions: Vec<IsolatedRegion>,
     slug_counts: std::collections::BTreeMap<String, usize>,
+    defer_outputs: bool,
 }
 
 impl<'a> ProjectionContext<'a> {
-    fn new(source: &'a str, options: &'a MarkdownProjectOptions) -> Self {
+    fn new(source: &'a str, options: &'a MarkdownProjectOptions, defer_outputs: bool) -> Self {
         Self {
             source,
             options,
             anchors: Vec::new(),
             isolated_regions: Vec::new(),
             slug_counts: std::collections::BTreeMap::new(),
+            defer_outputs,
         }
     }
 
@@ -410,8 +1023,10 @@ fn project_node(node: &mdast::Node, context: &mut ProjectionContext<'_>) -> Proj
         mdast::Node::Heading(heading) => {
             kind = NodeKind::Heading;
             attrs.depth = Some(heading.depth);
-            let slug = context.unique_slug(&text);
-            attrs.anchor_slug = Some(slug.clone());
+            if !context.defer_outputs {
+                let slug = context.unique_slug(&text);
+                attrs.anchor_slug = Some(slug.clone());
+            }
         }
         mdast::Node::Blockquote(_) => {
             kind = NodeKind::Blockquote;
@@ -451,6 +1066,7 @@ fn project_node(node: &mdast::Node, context: &mut ProjectionContext<'_>) -> Proj
             text = isolated_fallback(classification).to_string();
             copy_text = html.value.clone();
             attrs.isolation_kind = Some(classification);
+            attrs.isolation_tag = html_isolation_tag(&html.value, classification);
             safety = html_safety(classification, context.options.raw_html);
             children.clear();
         }
@@ -539,6 +1155,7 @@ fn project_node(node: &mdast::Node, context: &mut ProjectionContext<'_>) -> Proj
             text = "[isolated MDX region]".to_string();
             copy_text = source_slice(context.source, &span).to_string();
             attrs.island_tag = element.name.clone();
+            attrs.isolation_tag = element.name.clone();
             attrs.island_inline = false;
             attrs.isolation_kind = Some(IsolationKind::Component);
             safety = Safety {
@@ -547,11 +1164,37 @@ fn project_node(node: &mdast::Node, context: &mut ProjectionContext<'_>) -> Proj
             };
             children.clear();
         }
+        mdast::Node::MdxJsxFlowElement(element) => {
+            kind = NodeKind::Mdx;
+            text = "[isolated MDX region]".to_string();
+            copy_text = source_slice(context.source, &span).to_string();
+            attrs.isolation_kind = Some(IsolationKind::Mdx);
+            attrs.isolation_tag = element.name.clone();
+            safety = Safety {
+                lane: match context.options.mdx {
+                    MdxMode::Disabled | MdxMode::Isolate => SafetyLane::Isolated,
+                },
+                reason: "mdx-compiles-to-active-js".to_string(),
+            };
+            children.clear();
+        }
+        mdast::Node::MdxJsxTextElement(element) => {
+            kind = NodeKind::Mdx;
+            text = "[isolated MDX region]".to_string();
+            copy_text = source_slice(context.source, &span).to_string();
+            attrs.isolation_kind = Some(IsolationKind::Mdx);
+            attrs.isolation_tag = element.name.clone();
+            safety = Safety {
+                lane: match context.options.mdx {
+                    MdxMode::Disabled | MdxMode::Isolate => SafetyLane::Isolated,
+                },
+                reason: "mdx-compiles-to-active-js".to_string(),
+            };
+            children.clear();
+        }
         mdast::Node::MdxjsEsm(_)
         | mdast::Node::MdxFlowExpression(_)
-        | mdast::Node::MdxTextExpression(_)
-        | mdast::Node::MdxJsxFlowElement(_)
-        | mdast::Node::MdxJsxTextElement(_) => {
+        | mdast::Node::MdxTextExpression(_) => {
             kind = NodeKind::Mdx;
             text = "[isolated MDX region]".to_string();
             copy_text = source_slice(context.source, &span).to_string();
@@ -577,7 +1220,11 @@ fn project_node(node: &mdast::Node, context: &mut ProjectionContext<'_>) -> Proj
     }
 
     let mut projected = ProjectedNode {
-        id: node_id(kind, &span),
+        id: if context.defer_outputs {
+            String::new()
+        } else {
+            node_id(kind, &span)
+        },
         kind,
         span,
         safety,
@@ -591,7 +1238,7 @@ fn project_node(node: &mdast::Node, context: &mut ProjectionContext<'_>) -> Proj
         children,
     };
 
-    if projected.kind == NodeKind::Heading {
+    if !context.defer_outputs && projected.kind == NodeKind::Heading {
         if let (Some(depth), Some(slug)) =
             (projected.attrs.depth, projected.attrs.anchor_slug.clone())
         {
@@ -606,7 +1253,7 @@ fn project_node(node: &mdast::Node, context: &mut ProjectionContext<'_>) -> Proj
         }
     }
 
-    if projected.safety.lane == SafetyLane::Isolated {
+    if !context.defer_outputs && projected.safety.lane == SafetyLane::Isolated {
         let kind = projected
             .attrs
             .isolation_kind
@@ -640,6 +1287,68 @@ fn node_id(kind: NodeKind, span: &SourceSpan) -> String {
     format!("node:{kind:?}:{}:{}", span.start, span.end)
 }
 
+fn node_kind_label(kind: NodeKind) -> &'static str {
+    match kind {
+        NodeKind::Root => "root",
+        NodeKind::Paragraph => "paragraph",
+        NodeKind::Heading => "heading",
+        NodeKind::Blockquote => "blockquote",
+        NodeKind::List => "list",
+        NodeKind::ListItem => "list-item",
+        NodeKind::CodeBlock => "code-block",
+        NodeKind::MathBlock => "math-block",
+        NodeKind::ThematicBreak => "thematic-break",
+        NodeKind::Html => "html",
+        NodeKind::Table => "table",
+        NodeKind::TableRow => "table-row",
+        NodeKind::TableCell => "table-cell",
+        NodeKind::Definition => "definition",
+        NodeKind::FootnoteDefinition => "footnote-definition",
+        NodeKind::Text => "text",
+        NodeKind::Emphasis => "emphasis",
+        NodeKind::Strong => "strong",
+        NodeKind::Delete => "delete",
+        NodeKind::InlineCode => "inline-code",
+        NodeKind::InlineMath => "inline-math",
+        NodeKind::Break => "break",
+        NodeKind::Link => "link",
+        NodeKind::LinkReference => "link-reference",
+        NodeKind::Image => "image",
+        NodeKind::ImageReference => "image-reference",
+        NodeKind::FootnoteReference => "footnote-reference",
+        NodeKind::Mdx => "mdx",
+        NodeKind::Frontmatter => "frontmatter",
+        NodeKind::Island => "island",
+        NodeKind::Unknown => "unknown",
+    }
+}
+
+fn safety_lane_label(lane: SafetyLane) -> &'static str {
+    match lane {
+        SafetyLane::Host => "host",
+        SafetyLane::Escaped => "escaped",
+        SafetyLane::Isolated => "isolated",
+    }
+}
+
+fn isolation_kind_label(kind: IsolationKind) -> &'static str {
+    match kind {
+        IsolationKind::RawHtml => "raw-html",
+        IsolationKind::ActiveHtml => "active-html",
+        IsolationKind::Mdx => "mdx",
+        IsolationKind::Component => "component",
+    }
+}
+
+fn table_align_label(align: TableAlign) -> &'static str {
+    match align {
+        TableAlign::None => "none",
+        TableAlign::Left => "left",
+        TableAlign::Right => "right",
+        TableAlign::Center => "center",
+    }
+}
+
 fn table_align(align: &mdast::AlignKind) -> TableAlign {
     match align {
         mdast::AlignKind::None => TableAlign::None,
@@ -650,31 +1359,46 @@ fn table_align(align: &mdast::AlignKind) -> TableAlign {
 }
 
 fn classify_html(value: &str) -> IsolationKind {
-    let lower = value.to_ascii_lowercase();
-    let active = [
-        "<script",
-        "<style",
-        "<iframe",
-        "<object",
-        "<embed",
-        "<link",
-        "<form",
-        "<input",
-        "<button",
-        "<textarea",
-        "<select",
-        "<video",
-        "<audio",
-        "<canvas",
-        "<svg",
-    ];
-    if active.iter().any(|needle| lower.contains(needle)) {
+    if active_html_tag(value).is_some() {
         return IsolationKind::ActiveHtml;
     }
     if looks_like_mdx_component(value) {
         return IsolationKind::Mdx;
     }
     IsolationKind::RawHtml
+}
+
+fn html_isolation_tag(value: &str, kind: IsolationKind) -> Option<String> {
+    match kind {
+        IsolationKind::ActiveHtml => active_html_tag(value),
+        IsolationKind::Mdx | IsolationKind::Component => first_html_tag(value),
+        IsolationKind::RawHtml => None,
+    }
+}
+
+fn active_html_tag(value: &str) -> Option<String> {
+    let active = [
+        "script", "style", "iframe", "object", "embed", "link", "form", "input", "button",
+        "textarea", "select", "video", "audio", "canvas", "svg",
+    ];
+    let lower = value.to_ascii_lowercase();
+    active
+        .iter()
+        .find(|tag| lower.contains(&format!("<{tag}")))
+        .map(|tag| (*tag).to_string())
+}
+
+fn first_html_tag(value: &str) -> Option<String> {
+    let trimmed = value.trim_start();
+    let rest = trimmed.strip_prefix('<')?.trim_start();
+    if rest.starts_with('/') || rest.starts_with('!') || rest.starts_with('?') {
+        return None;
+    }
+    let name = rest
+        .split(|character: char| character.is_whitespace() || character == '>' || character == '/')
+        .next()
+        .unwrap_or("");
+    (!name.is_empty()).then(|| name.to_string())
 }
 
 fn looks_like_mdx_component(value: &str) -> bool {
@@ -1156,6 +1880,239 @@ mod tests {
             .blocks
             .iter()
             .all(|block| block.kind != NodeKind::Island));
+    }
+
+    #[test]
+    fn reconciler_insert_above_keeps_following_ids() {
+        let (before, snapshot) = reconcile_default("alpha\n\nbeta\n");
+        let alpha_id = before.blocks[0].id.clone();
+        let beta_id = before.blocks[1].id.clone();
+
+        let (after, _) =
+            reconcile_default_with_snapshot("intro\n\nalpha edited\n\nbeta\n", &snapshot);
+
+        assert!(after.blocks[0].id.starts_with("node:reconciled:"));
+        assert_ne!(after.blocks[0].id, alpha_id);
+        assert_eq!(after.blocks[1].id, alpha_id);
+        assert_ne!(after.blocks[1].span.end, before.blocks[0].span.end);
+        assert_eq!(after.blocks[2].id, beta_id);
+    }
+
+    #[test]
+    fn reconciler_insert_above_with_duplicates_no_misassign() {
+        let source = "## Notes\n\n---\n\n## Notes\n\n---\n";
+        let (before, snapshot) = reconcile_default(source);
+        let before_ids = before
+            .blocks
+            .iter()
+            .map(|block| block.id.clone())
+            .collect::<Vec<_>>();
+
+        let (after, _) =
+            reconcile_default_with_snapshot(&format!("## Notes\n\n---\n\n{source}"), &snapshot);
+
+        assert_eq!(after.blocks.len(), 6);
+        assert!(!before_ids.contains(&after.blocks[0].id));
+        assert!(!before_ids.contains(&after.blocks[1].id));
+        assert_eq!(after.blocks[2].id, before_ids[0]);
+        assert_eq!(after.blocks[3].id, before_ids[1]);
+        assert_eq!(after.blocks[4].id, before_ids[2]);
+        assert_eq!(after.blocks[5].id, before_ids[3]);
+    }
+
+    #[test]
+    fn reconciler_edit_inside_keeps_id_and_changes_hash() {
+        let (before, snapshot) = reconcile_default("alpha *cat* beta\n");
+        let block_id = before.blocks[0].id.clone();
+        let before_hash = snapshot_hash(&snapshot, &block_id);
+
+        let (after, next_snapshot) =
+            reconcile_default_with_snapshot("alpha *kitten* beta\n", &snapshot);
+        let after_hash = snapshot_hash(&next_snapshot, &block_id);
+
+        assert_eq!(after.blocks[0].id, block_id);
+        assert_ne!(after.blocks[0].span.end, before.blocks[0].span.end);
+        assert_ne!(after_hash, before_hash);
+    }
+
+    #[test]
+    fn reconciler_reorder_keeps_moved_block_id() {
+        let (before, snapshot) = reconcile_default("alpha\n\nbeta\n\ngamma\n");
+        let alpha_id = before.blocks[0].id.clone();
+        let beta_id = before.blocks[1].id.clone();
+        let gamma_id = before.blocks[2].id.clone();
+
+        let (after, _) = reconcile_default_with_snapshot("beta\n\nalpha\n\ngamma\n", &snapshot);
+
+        assert_eq!(after.blocks[0].id, beta_id);
+        assert_eq!(after.blocks[1].id, alpha_id);
+        assert_eq!(after.blocks[2].id, gamma_id);
+    }
+
+    #[test]
+    fn reconciler_replace_cross_kind_gets_fresh_id() {
+        let (before, snapshot) = reconcile_default("alpha\n");
+        let old_id = before.blocks[0].id.clone();
+
+        let (after, _) = reconcile_default_with_snapshot("## alpha\n", &snapshot);
+        let after_ids = collect_projected_ids(&after.root);
+
+        assert!(after.blocks[0].id.starts_with("node:reconciled:"));
+        assert!(!after_ids.contains(&old_id));
+    }
+
+    #[test]
+    fn reconciler_lane_flip_deliberate_remount() {
+        let source = "<div>wow</div>\n";
+        let escaped = MarkdownProjectOptions {
+            raw_html: RawHtmlMode::Escape,
+            ..Default::default()
+        };
+        let isolated = MarkdownProjectOptions {
+            raw_html: RawHtmlMode::Isolate,
+            ..Default::default()
+        };
+        let (before, snapshot) =
+            project_markdown_reconciled(source, &escaped, &ReconcilerSnapshot::default()).unwrap();
+        let (after, _) = project_markdown_reconciled(source, &isolated, &snapshot).unwrap();
+
+        assert_eq!(before.blocks[0].safety.lane, SafetyLane::Escaped);
+        assert_eq!(after.blocks[0].safety.lane, SafetyLane::Isolated);
+        assert_ne!(after.blocks[0].id, before.blocks[0].id);
+        assert_eq!(after.isolated_regions[0].block_id, after.blocks[0].id);
+    }
+
+    #[test]
+    fn reconciler_offset_decoupling_keeps_shifted_ids() {
+        let (before, snapshot) = reconcile_default("beta with *cat*\n");
+        let block_id = before.blocks[0].id.clone();
+        let emphasis_id = find_kind(&before.blocks[0], NodeKind::Emphasis)
+            .unwrap()
+            .id
+            .clone();
+        let emphasis_start = find_kind(&before.blocks[0], NodeKind::Emphasis)
+            .unwrap()
+            .span
+            .start;
+
+        let (after, _) = reconcile_default_with_snapshot("intro\n\nbeta with *cat*\n", &snapshot);
+        let after_emphasis = find_kind(&after.blocks[1], NodeKind::Emphasis).unwrap();
+
+        assert_eq!(after.blocks[1].id, block_id);
+        assert_ne!(after.blocks[1].span.start, before.blocks[0].span.start);
+        assert_eq!(after_emphasis.id, emphasis_id);
+        assert_ne!(after_emphasis.span.start, emphasis_start);
+    }
+
+    #[test]
+    fn reconciler_active_html_tag_swap_remounts() {
+        let (before, snapshot) = reconcile_default("<video></video>\n");
+        let (after, _) = reconcile_default_with_snapshot("<iframe></iframe>\n", &snapshot);
+        let before_html = find_kind(&before.blocks[0], NodeKind::Html).unwrap();
+        let after_html = find_kind(&after.blocks[0], NodeKind::Html).unwrap();
+
+        assert_eq!(before_html.attrs.isolation_tag.as_deref(), Some("video"));
+        assert_eq!(after_html.attrs.isolation_tag.as_deref(), Some("iframe"));
+        assert_ne!(after_html.id, before_html.id);
+    }
+
+    #[test]
+    fn reconciler_island_component_swap_remounts() {
+        let options = MarkdownProjectOptions {
+            islands: true,
+            ..Default::default()
+        };
+        let (before, snapshot) =
+            project_markdown_reconciled("<Frog />\n", &options, &ReconcilerSnapshot::default())
+                .unwrap();
+        let (after, _) = project_markdown_reconciled("<Chart />\n", &options, &snapshot).unwrap();
+
+        assert_eq!(before.blocks[0].attrs.island_tag.as_deref(), Some("Frog"));
+        assert_eq!(after.blocks[0].attrs.island_tag.as_deref(), Some("Chart"));
+        // A different component at the same slot mints a fresh id instead of
+        // aliasing onto Frog's id.
+        assert_ne!(after.blocks[0].id, before.blocks[0].id);
+        assert!(after.blocks[0].id.starts_with("node:reconciled:"));
+    }
+
+    #[test]
+    fn stateless_entry_points_keep_legacy_offset_ids() {
+        let source = "# Title\n\nalpha <i>wow</i> $x$\n\n---\n\n<iframe src=\"https://example.com\"></iframe>\n";
+        let options = MarkdownProjectOptions::default();
+        let mdast = markdown::to_mdast(source, &parse_options(options.islands)).unwrap();
+        let from_markdown = project_markdown(source).unwrap();
+        let from_options = project_markdown_with_options(source, &options).unwrap();
+        let from_mdast = project_from_mdast(&mdast, source, &options);
+
+        assert_eq!(from_markdown, from_options);
+        assert_eq!(from_markdown, from_mdast);
+        assert_legacy_ids(&from_markdown.root);
+        assert_eq!(
+            from_markdown.anchors[0].block_id,
+            from_markdown.blocks[0].id
+        );
+        assert_eq!(
+            from_markdown.isolated_regions[0].id,
+            format!("isolation:{}", from_markdown.isolated_regions[0].block_id)
+        );
+        assert_eq!(
+            render_plan_json(&from_markdown, source, "rust-wasm"),
+            render_plan_json(&from_mdast, source, "rust-wasm")
+        );
+
+        let island_options = MarkdownProjectOptions {
+            islands: true,
+            ..Default::default()
+        };
+        let island =
+            project_markdown_with_options("<Frog size={96} />\n", &island_options).unwrap();
+        assert_legacy_ids(&island.root);
+        assert_eq!(island.blocks[0].attrs.island_tag.as_deref(), Some("Frog"));
+    }
+
+    fn reconcile_default(source: &str) -> (MarkdownPlan, ReconcilerSnapshot) {
+        reconcile_default_with_snapshot(source, &ReconcilerSnapshot::default())
+    }
+
+    fn reconcile_default_with_snapshot(
+        source: &str,
+        snapshot: &ReconcilerSnapshot,
+    ) -> (MarkdownPlan, ReconcilerSnapshot) {
+        project_markdown_reconciled(source, &MarkdownProjectOptions::default(), snapshot).unwrap()
+    }
+
+    fn snapshot_hash(snapshot: &ReconcilerSnapshot, id: &str) -> u64 {
+        find_snapshot(snapshot.root.as_ref().unwrap(), id)
+            .map(|node| node.content_hash)
+            .unwrap()
+    }
+
+    fn find_snapshot<'a>(node: &'a SnapshotNode, id: &str) -> Option<&'a SnapshotNode> {
+        if node.id == id {
+            return Some(node);
+        }
+        node.children
+            .iter()
+            .find_map(|child| find_snapshot(child, id))
+    }
+
+    fn collect_projected_ids(node: &ProjectedNode) -> Vec<String> {
+        let mut ids = vec![node.id.clone()];
+        for child in &node.children {
+            ids.extend(collect_projected_ids(child));
+        }
+        ids
+    }
+
+    fn assert_legacy_ids(node: &ProjectedNode) {
+        if node.kind == NodeKind::Root {
+            assert_eq!(node.id, "root");
+        } else {
+            assert_eq!(node.id, node_id(node.kind, &node.span));
+        }
+        for child in &node.children {
+            assert_legacy_ids(child);
+        }
     }
 
     fn contains_kind(node: &ProjectedNode, kind: NodeKind) -> bool {

--- a/crates/nteract-markdown-engine/src/lib.rs
+++ b/crates/nteract-markdown-engine/src/lib.rs
@@ -70,10 +70,7 @@ pub struct ReconcilerSnapshot {
 
 impl ReconcilerSnapshot {
     pub fn to_bytes(&self) -> Vec<u8> {
-        match serde_json::to_vec(self) {
-            Ok(bytes) => bytes,
-            Err(_) => Vec::new(),
-        }
+        serde_json::to_vec(self).unwrap_or_default()
     }
 
     pub fn from_bytes(bytes: &[u8]) -> ReconcilerSnapshot {

--- a/crates/nteract-markdown-engine/src/render_json.rs
+++ b/crates/nteract-markdown-engine/src/render_json.rs
@@ -207,6 +207,16 @@ fn collect_block(
         block_index,
         code_lang: block.attrs.lang.clone(),
         code_meta: block.attrs.meta.clone(),
+        // Islands carry the content hash so the mid document store can tell an
+        // in-place prop edit (hash changes) from an insert-above that only shifts
+        // offsets (hash holds), keeping a reload from remounting a live island.
+        // Island-only by design: plain markdown has no islands, so plain-.md
+        // projection output is unchanged and the ADR 0003 parity gate still holds.
+        content_hash: if block.kind == NodeKind::Island {
+            Some(crate::content_hash(block).to_string())
+        } else {
+            None
+        },
         element,
         kind,
         island_tag: block.attrs.island_tag.clone(),
@@ -892,6 +902,7 @@ struct JsonBlock {
     block_index: usize,
     code_lang: Option<String>,
     code_meta: Option<String>,
+    content_hash: Option<String>,
     element: &'static str,
     kind: &'static str,
     island_tag: Option<String>,
@@ -985,6 +996,10 @@ impl JsonBlock {
             output.push(',');
             output.push_str("\"islandInline\":");
             output.push_str(if self.island_inline { "true" } else { "false" });
+            output.push(',');
+        }
+        if let Some(content_hash) = &self.content_hash {
+            push_json_key_string(output, "contentHash", content_hash);
             output.push(',');
         }
         if let Some(ordered) = self.ordered {
@@ -1273,6 +1288,37 @@ mod tests {
         assert!(json.contains("\"islandTag\":\"Frog\""), "{json}");
         assert!(json.contains("\"islandInline\":false"), "{json}");
         assert!(json.contains("\"semantic\":\"island\""), "{json}");
+    }
+
+    #[test]
+    fn serializes_content_hash_for_island() {
+        let options = crate::MarkdownProjectOptions {
+            islands: true,
+            ..Default::default()
+        };
+        let project = |source: &str| {
+            let plan = crate::project_markdown_with_options(source, &options).unwrap();
+            render_plan_json(&plan, source, "rust-wasm")
+        };
+        let island_hash = |json: &str| {
+            let key = "\"contentHash\":\"";
+            let start = json.find(key).expect("island block carries contentHash") + key.len();
+            let end = start + json[start..].find('"').unwrap();
+            json[start..end].to_string()
+        };
+
+        let base = project("<Frog size={96} />\n");
+        assert!(base.contains("\"contentHash\":\""), "{base}");
+        let base_hash = island_hash(&base);
+
+        // A prop edit inside the island changes the hash: the store must remount.
+        let edited = project("<Frog size={48} />\n");
+        assert_ne!(island_hash(&edited), base_hash);
+
+        // An insert above shifts the island's offsets but not its source text, so
+        // the hash holds: the store carries the live element forward.
+        let shifted = project("Intro paragraph.\n\n<Frog size={96} />\n");
+        assert_eq!(island_hash(&shifted), base_hash);
     }
 
     #[test]

--- a/docs/memos/markdown-node-identity-reconciler.md
+++ b/docs/memos/markdown-node-identity-reconciler.md
@@ -1,0 +1,189 @@
+# Carried-forward node identity for the markdown plan
+
+**Status:** Exploration. Engine design, downstream-driven. No-op for nteract's
+current surfaces beyond cheaper remounts; see "What this buys nteract."
+
+## Objective
+
+The markdown plan projector mints every node's id from byte offsets:
+
+```rust
+// crates/nteract-markdown-engine/src/lib.rs:586
+fn node_id(kind: NodeKind, span: &SourceSpan) -> String {
+    format!("node:{kind:?}:{}:{}", span.start, span.end)
+}
+```
+
+Anchors, isolated regions, and inline runs all clone that id, so any edit above
+or inside a block renames it and every node after it. A consumer that keys on the
+id sees the whole tail of the document turn over on a one-character edit. This
+memo proposes replacing offset-derived identity with stable ids that carry across
+reparses, assigned by a sequence-alignment reconciler that takes the previous
+plan as input.
+
+## What this buys nteract
+
+Be honest about the payoff. Inside nteract, the plan ids matter in exactly one
+place:
+
+- React keys in the host renderer (`key={block.blockId}`, `key={run.inlineId}`
+  in `ProjectedMarkdownView`). These churn on every edit-above and remount the
+  rendered subtree. The host-rendered path is stateless presentational components
+  (headings, lists, code blocks, math); stateful and executable regions route to
+  `IsolatedFrame` and are keyed separately. So the churn is a cheap, visually
+  invisible remount today, not a state-loss or correctness bug.
+
+Everything else is already insulated from offset churn:
+
+- Rendered-markdown comments anchor on source offsets plus an exact quote
+  (`comments-doc` `SourceRange`), re-resolved by quote search over the Automerge
+  `Text` source CRDT. They never key on plan node ids.
+- Active-source and presence highlighting compare ids within a single freshly
+  projected plan, so cross-edit stability is irrelevant.
+- Scroll and outline anchors resolve cell-level ids and heading slugs, not offset
+  node ids.
+
+So for nteract as it stands, stable identity mostly buys cheaper remounts. The
+cases where it becomes genuinely useful:
+
+- **Collaborative selection survival.** A remote collaborator editing above while
+  a local user drags a selection in the rendered view re-projects the plan,
+  churns every id, and remounts the subtree, which can collapse the in-progress
+  DOM selection. Stable ids plus patch-not-remount keep the untouched nodes and
+  the selection alive. Present, narrow, real.
+- **Id-based change tracking.** A "this block changed since you last looked"
+  feature needs a node to keep identity across reparses. nteract has none today;
+  stable identity is the prerequisite if it grows one.
+
+The stronger pull is a downstream vendored consumer of the markdown wasm that
+keys React on these ids and hosts live component state inside the rendered
+document, where a remount is a real state loss. Putting identity in the plan
+keeps it shared rather than re-derived per surface.
+
+**Relationship to Automerge.** This is read-side projection identity, not source
+identity. Automerge owns the source `Text` CRDT and merges concurrent edits; the
+plan is a disposable projection parsed fresh from source. The reconciler
+stabilizes the projection's node handles across reparses. It does not replace,
+duplicate, or interact with Automerge's source identity.
+
+## Design
+
+A new `project_markdown_reconciled(source, options, &prev) -> (MarkdownPlan, ReconcilerSnapshot)`
+runs three phases:
+
+1. **Build.** Run `project_node` as today, but leave `ProjectedNode.id` empty and
+   defer anchor and isolated-region emission. This drops the provisional-id remap
+   and the `SourceSpan::empty()` id collision.
+2. **Reconcile.** Assign ids top-down. One recursive `reconcile_children` runs at
+   every children list (blocks, then list items / table rows / cells, then inline
+   runs), so block and inline ids fall out of the same pass. Root keeps the
+   literal `"root"`; only its children align.
+3. **Finalize.** A document-order DFS over the now-id-stable tree rebuilds anchors
+   (`block_id = node.id`), isolated regions (`id = "isolation:" + node.id`), and
+   the heading-slug counter, then serializes the new snapshot from
+   `MarkdownPlan.root` (never from the flattened block/run view).
+
+Identity is a two-tier predicate:
+
+- `eq(a, b)` = `(kind, lane, iso, isolation_tag)` equal **and** `content_hash`
+  equal. The unchanged-anchor test that trim and LCS anchor on.
+- `compat(a, b)` = `(kind, lane, iso, isolation_tag)` equal, content may differ.
+  The edit-inside-vs-replace gate.
+
+Content decides changed-vs-unchanged, never identity. Identity is alignment
+position plus `compat`. Duplicates (two `---`, two `## Notes`, two identical
+`$x$`) disambiguate by order, which alignment gives for free.
+
+`reconcile_children` is: ambiguity-guarded two-ended trim under `eq`, then LCS on
+the residual middle under `eq` with match-late backtrack, then a
+`content_hash`-keyed in-order move match on the leftovers, then a
+front-surplus-aware positional zip under `compat`, then mint fresh for anything
+left. A node matched under `eq` has an equal `content_hash`, so its subtree is
+byte-identical and its ids are preserved without recursing. Only `compat` carries
+(content differs) recurse to re-align changed children.
+
+Two requirements the edit scenarios force:
+
+- **`content_hash` is a recursive Merkle digest** over `kind, lane, iso,
+  isolation_tag`, the rendering-salient attrs, `copy_text` for leaves, and each
+  child's hash in document order. A flat `copy_text` scalar compares a
+  formatting-only edit (`the cat sat` to `the *cat* sat`) and a same-text reorder
+  (`**alpha**` vs `alpha`) equal at the parent, which silently drops the edit and
+  collapses the reorder. "Equal `content_hash` implies subtree byte-identical" is
+  what the subtree short-circuit and the `eq` anchor depend on.
+- **The structural tuple includes `isolation_tag`**, a new `NodeAttrs` field
+  carrying the MDX component name or active-HTML element tag, so two isolated
+  nodes of the same `IsolationKind` (`<video>` to `<iframe>`) are not `compat` and
+  remount instead of aliasing.
+
+The front-surplus zip hard-codes an insert-above preference: surplus leading
+nodes with no `eq` match mint fresh before the remainder zips, so a block inserted
+above an edited block does not steal the edited block's id. This sacrifices the
+symmetric insert-below-adjacent-to-edit direction; both are pinned by tests.
+
+The previous plan rides in as an opaque snapshot threaded through the projector.
+The existing stateless `project_markdown` is kept as the cold path: it calls the
+reconciled entry with an empty snapshot and discards the returned one, so every
+node is fresh and existing call sites are unchanged. A consumer that wants
+stability threads the snapshot back in. The whole identity matrix runs as FFI-free
+`cargo` tests because the engine stays a pure function of `(source, prev-snapshot)`.
+
+## Behavioral coverage
+
+| Test | Pins |
+| --- | --- |
+| `insert_above_keeps_following_ids` | Following ids byte-for-byte stable while spans shift; one fresh id at the top. |
+| `insert_above_with_duplicates_no_misassign` | The ambiguity guard stops trim preempting LCS; one remount in a duplicate run, existing ids preserved in order. |
+| `insert_below_with_duplicates_pins_direction` | The sacrificed insert-below direction, regression-locked. |
+| `edit_inside_text_keeps_id` | `compat` carries the id; content_hash differs; one run re-aligns. |
+| `edit_inside_formatting_only_merkle` | The Merkle hash catches a `copy_text`-invariant edit a flat hash drops. |
+| `reorder_tracks_moved_block` | LCS anchor plus keyed move; neither id stays positional. |
+| `reorder_same_copytext_diff_structure` | Merkle differs at the boundary; no positional no-op, no inline-subtree graft. |
+| `replace_cross_kind_new_id` | Cross-kind replace mints fresh; retired id never reused. |
+| `replace_isolated_component_remounts` | `isolation_tag` makes a same-kind component swap remount; region id is fresh. |
+| `lane_flip_deliberate_remount` | A block crossing into Isolated mints fresh; neighbors preserved. |
+| `inline_insert_before_identical_math` | Two identical `$x$` runs keep order. |
+| `offset_decoupling_nonheading` | All later block and inline ids equal while every span shifts. |
+| `offset_decoupling_heading_slug_renumber` | Node id stable; only the slug-derived anchor own-id renumbers, by design. |
+| `cold_start_all_fresh` | Empty snapshot and the stateless path both mint fresh from 1; root is `"root"`. |
+| `snapshot_wire_roundtrip_total` | Round-trip is faithful; malformed or skewed bytes return `Default`, never panic. |
+
+## Open decisions
+
+- **Snapshot transport.** How the opaque previous-plan snapshot crosses the wasm
+  boundary, and the encoding (hand-rolled little-endian with a total `from_wire`,
+  vs adding `serde_json` to the engine). The interface is free to change since
+  callers rebuild against it.
+- **Id representation.** Keep `String` ids (`node:{n}`) so the JSON contract is
+  unchanged, vs integers with a consumer-side stringify.
+- **Merkle hash function and attr set.** FNV-1a vs xxhash, and which attrs beyond
+  `copy_text` feed the digest (depth, lang, meta, url, ordered, checked, align,
+  isolation_tag).
+- **`isolation_tag` extraction.** How to parse the component / element name out of
+  `html.value`, and whether expression-kind MDX nodes need a finer discriminator.
+
+## Risks and why it stays safe for nteract
+
+- The stateless `project_markdown` path is preserved and unchanged, so existing
+  nteract call sites keep their exact behavior; the reconciled path is opt-in.
+- The Phase-3 DFS that rebuilds anchors, isolated regions, and slugs must preserve
+  document-order slug numbering and region emission order. Re-run the existing
+  heading-anchor and isolated-region tests to confirm the non-id output is
+  byte-identical.
+- Everything downstream depends on the Merkle `content_hash` being recursive. If
+  it is flat, the subtree short-circuit and the `eq` anchor both break.
+- The snapshot must serialize from `MarkdownPlan.root`, never the wasm block/run
+  flattening, which folds the safe-html triplet three-into-one and clears MDX
+  children.
+- `from_wire` must be total: a version skew or malformed bytes return `Default`
+  (cold start, every node fresh), never a panic.
+- The LCS middle is O(m*n) per sibling level; a pathological flat list or a huge
+  table wants a length-threshold fallback or a Myers O(ND) upgrade before very
+  large documents.
+
+## Scope
+
+Engine plus FFI-free tests. The stateless entry is preserved, so this is additive
+for nteract and a no-op for its current surfaces beyond cheaper remounts. The
+identity matrix is the gate; ship it green before any consumer opts into the
+reconciled path.


### PR DESCRIPTION
The markdown plan's node ids are byte-offset-derived (`node:{kind}:{start}:{end}`), so typing above a block renames it and every block after it. A consumer keyed on the id remounts and loses state on every edit. This adds carried-forward identity so a node keeps its id across reparses.

Supersedes #3856: that PR was the design memo; this carries the memo plus the implementation.

## Design

An opt-in entry point `project_markdown_reconciled(source, options, &prev) -> (plan, snapshot)`, in three phases:

1. Build the tree with ids deferred.
2. Reconcile ids top-down against the previous plan's snapshot. One recursive pass covers blocks and inline runs.
3. Finalize anchors, isolated regions, and heading slugs over the id-stable tree.

Reconciliation is a sequence alignment, not a content hash (a hash can't disambiguate two `## Notes` or survive a reorder): ambiguity-guarded two-ended trim, LCS on the residual middle, an in-order move match, then a front-surplus-aware compat zip that prefers insert-above, and fresh ids for the rest. Identity is `(kind, lane, isolation_kind, isolation_tag, island_tag)` plus a recursive content hash. The tags sit in the key so an active-HTML (`<video>`→`<iframe>`) or MDX component (`<Frog/>`→`<Chart/>`) swap remounts instead of aliasing onto the previous node's id.

## Additive and opt-in

The stateless `project_markdown` / `project_from_mdast` / `project_markdown_with_options` stay byte-identical: they call the reconciled path with an empty snapshot, which mints the legacy offset ids. Only a caller that threads the snapshot back in gets stable ids, so the engine stays a pure function of `(source, prev-snapshot)`. Existing callers are untouched.

## Coverage

Unit tests for insert-above, insert-above-with-duplicates, edit-inside (id held, hash changed), reorder, replace, lane-flip, offset-decoupling (block and inline), active-HTML and MDX component swaps, and byte-identical stateless output. `cargo test -p nteract-markdown-engine` green (39 tests), the wasm crate builds.

## Notes for reviewers

- A same-kind, same-tag content change is treated as an edit: the id carries and the node is flagged changed via the content hash. Only a kind or tag change is a replace (fresh id). That boundary is intentional; flag it if you want it drawn elsewhere.
- LCS is O(m*n) with no large-list fallback. Fine for typical documents, could degrade on pathological input.
- Active-HTML tag extraction parses `<tag` naively (enough for the corpus).
- The snapshot is in-memory only; no wasm-boundary serialization yet, so the wasm `.md` path still uses the stateless cold path. That is the next step when a stateful consumer needs it.
