### PR TITLE
fix(workstation): explain missing user systemd fallback

### DIFF
--- a/crates/runt/src/workstation_cli.rs
+++ b/crates/runt/src/workstation_cli.rs
@@ -936,10 +936,20 @@ fn current_runt_path_for_service() -> Result<PathBuf> {
 
 #[cfg(target_os = "linux")]
 fn ensure_user_systemd_available() -> Result<()> {
-    let output = systemctl_command()
+    let output = match systemctl_command()
         .args(["--user", "show-environment"])
         .output()
-        .context("run systemctl --user show-environment")?;
+    {
+        Ok(output) => output,
+        Err(error) => {
+            let detail = if error.kind() == std::io::ErrorKind::NotFound {
+                "systemctl was not found on this host".to_string()
+            } else {
+                format!("could not run systemctl --user show-environment: {error}")
+            };
+            bail!("{}", user_systemd_unavailable_message(&detail));
+        }
+    };
     if output.status.success() {
         return Ok(());
     }
@@ -949,12 +959,17 @@ fn ensure_user_systemd_available() -> Result<()> {
         .into_iter()
         .find(|value| !value.is_empty())
         .unwrap_or("systemctl --user did not report details");
-    bail!(
+    bail!("{}", user_systemd_unavailable_message(detail));
+}
+
+#[cfg(any(target_os = "linux", test))]
+fn user_systemd_unavailable_message(detail: &str) -> String {
+    format!(
         "Linux user systemd is not available in this session: {detail}\n\
          Use a normal login session with XDG_RUNTIME_DIR/DBus available, or ask an admin to enable lingering with `loginctl enable-linger $USER` if this workstation should stay available after logout.\n\
          Fallback: run `{} workstation run` inside tmux.",
         runt_workspace::cli_command_name()
-    );
+    )
 }
 
 #[cfg(target_os = "linux")]
@@ -1418,6 +1433,20 @@ mod tests {
             workstation_service_start_action_for_active_state("unknown"),
             "start"
         );
+    }
+
+    #[test]
+    fn user_systemd_unavailable_message_includes_tmux_fallback() {
+        let message = user_systemd_unavailable_message("systemctl was not found on this host");
+        let fallback = format!(
+            "Fallback: run `{} workstation run` inside tmux.",
+            runt_workspace::cli_command_name()
+        );
+
+        assert!(message.contains(
+            "Linux user systemd is not available in this session: systemctl was not found on this host"
+        ));
+        assert!(message.contains(&fallback));
     }
 
     #[test]

--- a/crates/runtimed-service/src/lib.rs
+++ b/crates/runtimed-service/src/lib.rs
@@ -121,6 +121,9 @@ pub enum ServiceError {
     #[error("IO error: {0}")]
     Io(#[from] std::io::Error),
 
+    #[error("{0}")]
+    SystemdUnavailable(String),
+
     #[error("Service already installed")]
     AlreadyInstalled,
 
@@ -185,6 +188,49 @@ fn systemctl_command() -> Command {
     let mut command = Command::new(systemctl_binary());
     strip_appimage_host_env(&mut command);
     command
+}
+
+#[cfg(target_os = "linux")]
+fn ensure_linux_user_systemd_available() -> ServiceResult<()> {
+    let output = match systemctl_command()
+        .args(["--user", "show-environment"])
+        .output()
+    {
+        Ok(output) => output,
+        Err(error) => {
+            let detail = if error.kind() == std::io::ErrorKind::NotFound {
+                "systemctl was not found on this host".to_string()
+            } else {
+                format!("could not run systemctl --user show-environment: {error}")
+            };
+            return Err(ServiceError::SystemdUnavailable(
+                linux_user_systemd_unavailable_message(&detail),
+            ));
+        }
+    };
+    if output.status.success() {
+        return Ok(());
+    }
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let detail = [stderr.trim(), stdout.trim()]
+        .into_iter()
+        .find(|value| !value.is_empty())
+        .unwrap_or("systemctl --user did not report details");
+    Err(ServiceError::SystemdUnavailable(
+        linux_user_systemd_unavailable_message(detail),
+    ))
+}
+
+#[cfg(any(target_os = "linux", test))]
+fn linux_user_systemd_unavailable_message(detail: &str) -> String {
+    format!(
+        "Linux user systemd is not available in this session: {detail}\n\
+         The daemon service cannot be installed or started automatically here.\n\
+         Use a normal login session with XDG_RUNTIME_DIR/DBus available, or ask an admin to enable lingering with `loginctl enable-linger $USER` if the daemon should stay available after logout.\n\
+         For headless workstation sessions, use foreground mode: `{} workstation run`.",
+        runt_workspace::cli_command_name()
+    )
 }
 
 impl Default for ServiceManager {
@@ -714,6 +760,8 @@ impl ServiceManager {
     // Linux-specific implementations
     #[cfg(target_os = "linux")]
     fn create_linux_systemd(&self) -> ServiceResult<()> {
+        ensure_linux_user_systemd_available()?;
+
         // Get home directory at service generation time - systemd doesn't expand ~
         let home = dirs::home_dir().ok_or_else(|| {
             ServiceError::InstallFailed(
@@ -768,6 +816,8 @@ WantedBy=default.target
 
     #[cfg(target_os = "linux")]
     fn start_linux(&self) -> ServiceResult<()> {
+        ensure_linux_user_systemd_available()?;
+
         let output = systemctl_command()
             .args(["--user", "start"])
             .arg(systemd_service_unit_name())
@@ -784,6 +834,8 @@ WantedBy=default.target
 
     #[cfg(target_os = "linux")]
     fn stop_linux(&self) -> ServiceResult<()> {
+        ensure_linux_user_systemd_available()?;
+
         let output = systemctl_command()
             .args(["--user", "stop"])
             .arg(systemd_service_unit_name())
@@ -1206,5 +1258,22 @@ mod tests {
                 .any(|(key, value)| *key == std::ffi::OsStr::new(var) && value.is_none());
             assert!(removed, "{var} should be removed for host systemctl");
         }
+    }
+
+    #[test]
+    fn linux_user_systemd_unavailable_message_mentions_foreground_workstation() {
+        let message =
+            linux_user_systemd_unavailable_message("systemctl was not found on this host");
+        let fallback = format!(
+            "For headless workstation sessions, use foreground mode: `{} workstation run`.",
+            runt_workspace::cli_command_name()
+        );
+
+        assert!(message.contains(
+            "Linux user systemd is not available in this session: systemctl was not found on this host"
+        ));
+        assert!(message
+            .contains("The daemon service cannot be installed or started automatically here."));
+        assert!(message.contains(&fallback));
     }
 }


### PR DESCRIPTION
## Summary

- route missing or unusable Linux user systemd through friendly workstation fallback messages
- preflight daemon service install/start/stop before writing user systemd units
- add regression coverage for the missing-`systemctl` fallback text

## Verification

- `cargo test -p runtimed-service`
- `cargo check -p runtimed-service --target x86_64-unknown-linux-gnu`
- `cargo test -p runt`
- `cargo xtask lint --fix`
- `cargo fmt --all -- --check`
- `git diff --check`

## Notes

Observed on an Outerbounds workstation container where `systemctl` is not present. Foreground `runt workstation run` works there; the CLI should point users at that path instead of surfacing raw `systemctl --user show-environment` IO errors or leaving daemon service state half-written.
