### PR TITLE
feat(design-sync): add owned output renderers (outputs group)

### DIFF
--- a/.design-sync/NOTES.md
+++ b/.design-sync/NOTES.md
@@ -29,23 +29,44 @@ something non-obvious comes up.
 - **Deferred** (need editor/output/notebook-doc/providers, would floor-card): EditableMarkdownCell,
   OutputArea, ReadOnlyNotebook, ReadOnlyNotebookCell.
 
-## Output renderers — future pass (separate session)
+## Output renderers (group: outputs)
 
-`src/components/outputs/*` (plus `packages/sift`) are not synced yet. Direction from the owner:
-sync only the renderers **we own the React for** and can control; skip the ones that are just
-a mime-type → third-party render passthrough.
+Owner direction: sync only the renderers **we own the React for**; skip mime → third-party
+passthroughs. Curated list in `synthpkg/build.mjs` (`groups[].dir === 'outputs'`).
 
-- **Sync candidates (owned render)**: ansi (`ansi-output`: AnsiStreamOutput, AnsiErrorOutput),
-  json (`json-output`), html (`html-output`), markdown (`markdown-output`), math (`math-output`),
-  and sift (`packages/sift` — its own package, handle distinctly). Traceback (`traceback-output`)
-  is likely in this bucket too — confirm ownership next session.
-- **Skip / passthrough (do NOT sync)**: plotly, vega, image, pdf, audio, video, and **geojson**
-  (owner moved geojson to skip on 2026-07-01). These are basically mime → external render; no
-  nteract-specific UI to show.
-- The owned renderers still take output data as props and some read a media/widget provider
-  (`media-provider`, `OutputArea`'s `useWidgetStore`) — this pass needs a fixture provider wired
-  (see `apps/elements/components/output-renderers-example.tsx` + `notebook-scenarios.ts` for how
-  the catalog mounts them standalone). That's why it's a separate session, not a quick add.
+- **Shipped 2026-07-01**: `ansi-output` (AnsiOutput, AnsiStreamOutput, AnsiErrorOutput),
+  `json-output` (JsonOutput), `traceback-output` (TracebackOutput). All prop-driven, no provider.
+  Data shapes: AnsiOutput takes `children: string` (raw ANSI), AnsiStreamOutput
+  `{text, streamName}`, AnsiErrorOutput `{ename, evalue, traceback: string[]}`, JsonOutput
+  `{data, collapsed?, displayDataTypes?}`, TracebackOutput `{data}` where data is the
+  `application/vnd.nteract.traceback+json` payload `{ename, evalue, frames[], language}`.
+- **Deferred — markdown + math (katex)**: both do `import "katex/dist/katex.min.css"`, and the
+  converter's bundle has no `.ttf` loader for katex's fonts (`bundle.mjs` loads .woff/.woff2 only).
+  Shipping them means either a declared `.ttf`-dataurl bundle override, or shipping the katex
+  fonts under `fonts/` + `@import` katex CSS via css-entry with rewritten URLs. Not a fork-free
+  quick add — own pass. markdown also pulls `MarkdownCodeBlock` → CodeMirror langs (fine to bundle).
+- **Skipped — html-output**: `HtmlOutput` throws unless rendered inside a sandboxed iframe
+  (security gate), so it can't render in a static card. Leave it out.
+- **Skip / passthrough (do NOT sync)**: plotly, vega, image, pdf, audio, video, **geojson**
+  (owner moved geojson to skip 2026-07-01). Mime → external render; no nteract-specific UI.
+- **ANSI needs `src/styles/ansi.css`**: the 16-color ANSI palette is theme-aware CSS vars +
+  `.ansi-*` classes defined there (the app ships it via the isolated renderer). css-entry.css
+  now `@import`s it — without it every AnsiOutput renders colorless (black swatches). Same class
+  of bug as the destructive-foreground token: component CSS the DS closure was missing.
+- **Multi-export files need componentSrcMap group pins**: the converter fuzzy-matches
+  component→file by kebab name, so `AnsiOutput`→`ansi-output.tsx` resolves but its siblings
+  `AnsiStreamOutput`/`AnsiErrorOutput` don't, and fall to the default `general` group. Pin each
+  extra export to its source file in `componentSrcMap` (value = path, not null) so they group as
+  `outputs`. Any future multi-component output file needs the same pins.
+- **sift is next (own PR)**: `packages/sift` is a separate package (`@nteract/sift`, main export
+  `SiftTable` + SiftScrollHandoffCue/SiftFocusStatus/sparkline). Owner wants more of sift broken
+  into individual reusable `src/components/*` primitives we style in the guide, THEN synced — so
+  the sift pass is partly a refactor (extract components) then a sync, not just a bundle add.
+- The heavier composed surfaces (`OutputArea`, `ReadOnlyNotebook`, `EditableMarkdownCell`) still
+  need a fixture media/widget provider wired (see
+  `apps/elements/components/output-renderers-example.tsx` + `notebook-scenarios.ts`).
+
+## Groups + curated lists
 - `cfg.srcDir` is `../../src/components` (broadened from `.../ui`) so grouping resolves
   `cell/` → group `cell` and `ui/` → `general`. Adding a new cell primitive: append it to the
   curated list in build.mjs (NOT glob-all — that pulls CodeMirror/plotly/widget deps into the

--- a/.design-sync/config.json
+++ b/.design-sync/config.json
@@ -20,9 +20,17 @@
     "Collapsible": { "cardMode": "column" },
     "Tabs": { "cardMode": "column" },
     "CellInsertionRibbon": { "cardMode": "column" },
-    "CodeCellCurrentLine": { "cardMode": "column" }
+    "CodeCellCurrentLine": { "cardMode": "column" },
+    "AnsiOutput": { "cardMode": "column" },
+    "AnsiStreamOutput": { "cardMode": "column" },
+    "AnsiErrorOutput": { "cardMode": "column" },
+    "JsonOutput": { "cardMode": "column" },
+    "TracebackOutput": { "cardMode": "column" }
   },
   "componentSrcMap": {
+    "AnsiOutput": "../../src/components/outputs/ansi-output.tsx",
+    "AnsiStreamOutput": "../../src/components/outputs/ansi-output.tsx",
+    "AnsiErrorOutput": "../../src/components/outputs/ansi-output.tsx",
     "AccordionContent": null,
     "AccordionItem": null,
     "AccordionTrigger": null,

--- a/.design-sync/css-entry.css
+++ b/.design-sync/css-entry.css
@@ -6,9 +6,14 @@
    source(none) keeps the output deterministic — only the @source dirs below. */
 @import "tailwindcss" source(none);
 @import "../src/styles/notebook-tokens.css";
+/* ANSI 16-color palette + .ansi-* classes the output renderers apply. The app
+   ships these via the isolated renderer; the DS closure needs them too or every
+   AnsiOutput/AnsiStreamOutput renders colorless. */
+@import "../src/styles/ansi.css";
 
 @source "../src/components/ui";
 @source "../src/components/cell";
+@source "../src/components/outputs";
 @source "./previews";
 
 /* Safelist the semantic token vocabulary the conventions header documents, so a

--- a/.design-sync/previews/AnsiErrorOutput.tsx
+++ b/.design-sync/previews/AnsiErrorOutput.tsx
@@ -1,0 +1,29 @@
+import { AnsiErrorOutput } from "nteract-elements";
+
+// ESC built from a char code so the source stays pure ASCII (a raw 0x1b byte in
+// a source file breaks diffs and editors). `E` is the CSI intro: ESC + "[".
+const E = String.fromCharCode(27) + "[";
+
+// A classic IPython-formatted traceback: the ANSI the kernel actually emits,
+// red rule + type, green cell/line markers, dim source, the arrow on the
+// failing line. AnsiErrorOutput renders the raw kernel string verbatim.
+const traceback = [
+  `${E}0;31m---------------------------------------------------------------------------${E}0m`,
+  `${E}0;31mKeyError${E}0m                                  Traceback (most recent call last)`,
+  `Cell ${E}0;32mIn[7], line 3${E}0m`,
+  `${E}1;32m      1 ${E}0mdf ${E}0;34m=${E}0m pd${E}0;34m.${E}0mread_csv(${E}0;36m"sales.csv"${E}0m)`,
+  `${E}1;32m      2 ${E}0mtotals ${E}0;34m=${E}0m {}`,
+  `${E}0;32m----> 3 ${E}0mtotals[${E}0;36m"revenue"${E}0m] ${E}0;34m=${E}0m df[${E}0;36m"region"${E}0m]${E}0;34m.${E}0msum()`,
+  "",
+  `${E}0;31mKeyError${E}0m: ${E}0;36m'region'${E}0m`,
+];
+
+export function KernelTraceback() {
+  return <AnsiErrorOutput ename="KeyError" evalue="'region'" traceback={traceback} />;
+}
+
+// Headline-only: no traceback array, just the error name and value. The
+// component falls back to the one-line `ename: evalue` headline.
+export function HeadlineOnly() {
+  return <AnsiErrorOutput ename="ValueError" evalue="could not convert string to float: 'N/A'" />;
+}

--- a/.design-sync/previews/AnsiOutput.tsx
+++ b/.design-sync/previews/AnsiOutput.tsx
@@ -1,0 +1,32 @@
+import { AnsiOutput } from "nteract-elements";
+
+// ESC built from a char code so the source stays pure ASCII (a raw 0x1b byte in
+// a source file breaks diffs and editors). `E` is the CSI intro: ESC + "[".
+const E = String.fromCharCode(27) + "[";
+
+// A pytest run: bold session header, green dots / red F for pass/fail, a yellow
+// percent gutter, and a bold red summary line.
+const pytest = [
+  `${E}1m============================= test session starts =============================${E}0m`,
+  "platform darwin -- Python 3.12.2, pytest-8.1.1, pluggy-1.4.0",
+  "collected 24 items",
+  "",
+  `tests/test_frame.py ${E}32m.${E}0m${E}32m.${E}0m${E}32m.${E}0m${E}31mF${E}0m${E}32m.${E}0m${E}32m.${E}0m          ${E}33m[ 60%]${E}0m`,
+  `tests/test_io.py ${E}32m.${E}0m${E}32m.${E}0m${E}32m.${E}0m                                     ${E}33m[100%]${E}0m`,
+  "",
+  `${E}31m${E}1m========================== 1 failed, 23 passed in 2.14s ==========================${E}0m`,
+].join("\n");
+
+export function PytestRun() {
+  return <AnsiOutput>{pytest}</AnsiOutput>;
+}
+
+// Shows the renderer's color fidelity: the standard 16 colors, normal and bold,
+// which the component maps to theme-aware CSS variables (adapts to light/dark).
+const palette = [30, 31, 32, 33, 34, 35, 36, 37]
+  .map((c) => `${E}${c}m████${E}0m ${E}1;${c}m████${E}0m`)
+  .join("   ");
+
+export function ColorPalette() {
+  return <AnsiOutput>{`Standard 16-color palette — normal and bold\n\n${palette}`}</AnsiOutput>;
+}

--- a/.design-sync/previews/AnsiStreamOutput.tsx
+++ b/.design-sync/previews/AnsiStreamOutput.tsx
@@ -1,0 +1,33 @@
+import { AnsiStreamOutput } from "nteract-elements";
+
+// ESC built from a char code so the source stays pure ASCII (a raw 0x1b byte in
+// a source file breaks diffs and editors). `E` is the CSI intro: ESC + "[".
+const E = String.fromCharCode(27) + "[";
+
+// stdout with ANSI color: a Keras-style training log. Green progress bars,
+// bold metric values, reset between spans.
+const trainingLog = [
+  "Epoch 1/5",
+  `1875/1875 ${E}32m━━━━━━━━━━━━━━━━━━━━${E}0m 4s  loss: ${E}1m0.2947${E}0m  accuracy: ${E}1m0.9142${E}0m`,
+  "Epoch 2/5",
+  `1875/1875 ${E}32m━━━━━━━━━━━━━━━━━━━━${E}0m 3s  loss: ${E}1m0.1288${E}0m  accuracy: ${E}1m0.9613${E}0m`,
+  "Epoch 3/5",
+  `1875/1875 ${E}32m━━━━━━━━━━━━━━━━━━━━${E}0m 3s  loss: ${E}1m0.0894${E}0m  accuracy: ${E}1m0.9729${E}0m`,
+].join("\n");
+
+// stderr: library warnings, yellow labels, indented continuation.
+const stderrLog = [
+  `${E}33mConvergenceWarning:${E}0m lbfgs failed to converge (status=1):`,
+  "STOP: TOTAL NO. of ITERATIONS REACHED LIMIT.",
+  "",
+  `${E}33mUserWarning:${E}0m X does not have valid feature names, but LogisticRegression was fitted with feature names`,
+  "  warnings.warn(msg, category=UserWarning)",
+].join("\n");
+
+export function Stdout() {
+  return <AnsiStreamOutput streamName="stdout" text={trainingLog} />;
+}
+
+export function Stderr() {
+  return <AnsiStreamOutput streamName="stderr" text={stderrLog} />;
+}

--- a/.design-sync/previews/JsonOutput.tsx
+++ b/.design-sync/previews/JsonOutput.tsx
@@ -1,0 +1,28 @@
+import { JsonOutput } from "nteract-elements";
+
+// A typical kernel result: a nested API/response object. Exercises objects,
+// arrays, strings, numbers, and booleans in the tree view.
+const response = {
+  id: "run_4f3a9c21",
+  status: "completed",
+  model: "claude-opus-4",
+  usage: { input_tokens: 812, output_tokens: 143, total_tokens: 955 },
+  choices: [
+    {
+      index: 0,
+      finish_reason: "stop",
+      message: { role: "assistant", content: "Rows written: 1,284" },
+    },
+  ],
+  metadata: { cached: false, latency_ms: 412, region: "us-west-2", retries: 0 },
+};
+
+export function ApiResponse() {
+  return <JsonOutput data={response} />;
+}
+
+// Collapsed past depth 1, with type annotations shown next to each value —
+// how you'd inspect a large payload without expanding everything.
+export function CollapsedWithTypes() {
+  return <JsonOutput data={response} collapsed={1} displayDataTypes />;
+}

--- a/.design-sync/previews/TracebackOutput.tsx
+++ b/.design-sync/previews/TracebackOutput.tsx
@@ -1,0 +1,38 @@
+import { TracebackOutput } from "nteract-elements";
+
+// The structured `application/vnd.nteract.traceback+json` payload (not the raw
+// ANSI string): TracebackOutput renders frames with source context, dims
+// library frames, and highlights the failing line. This is the nteract-owned
+// view — richer than the classic ANSI dump.
+const keyError = {
+  ename: "KeyError",
+  evalue: "'region'",
+  language: "python",
+  frames: [
+    {
+      filename: "<ipython-input-7>",
+      lineno: 3,
+      name: "<module>",
+      lines: [
+        { lineno: 1, source: 'df = pd.read_csv("sales.csv")' },
+        { lineno: 2, source: "totals = {}" },
+        { lineno: 3, source: 'totals["revenue"] = df["region"].sum()', highlight: true },
+      ],
+    },
+    {
+      filename: "/opt/env/lib/python3.12/site-packages/pandas/core/frame.py",
+      lineno: 4102,
+      name: "__getitem__",
+      library: true,
+      lines: [
+        { lineno: 4100, source: "        if self.columns.nlevels > 1:" },
+        { lineno: 4101, source: "            return self._getitem_multilevel(key)" },
+        { lineno: 4102, source: "        indexer = self.columns.get_loc(key)", highlight: true },
+      ],
+    },
+  ],
+};
+
+export function PandasKeyError() {
+  return <TracebackOutput data={keyError} />;
+}

--- a/.design-sync/synthpkg/build.mjs
+++ b/.design-sync/synthpkg/build.mjs
@@ -43,6 +43,20 @@ const groups = [
       "ExecutionCount",
     ],
   },
+  {
+    // Owned output renderers — we control the React (not mime→passthrough).
+    // html-output is EXCLUDED: it throws unless inside a sandboxed iframe, so it
+    // can't render in a static card. Skipped by owner: plotly, vega, image, pdf,
+    // audio, video, geojson (mime passthroughs). markdown/traceback pull
+    // @codemirror/lang-* + @lezer for static highlighting — synchronous, bundles fine.
+    // math-output is DEFERRED: it does `import "katex/dist/katex.min.css"`, and the
+    // converter's bundle has no .ttf loader for the fonts katex's CSS references
+    // (bundle.mjs loads .woff/.woff2 only). Fixing it means either a declared
+    // .ttf-dataurl bundle override or shipping katex CSS via css-entry — a small
+    // follow-up, not a fork of the bundle contract here.
+    dir: "outputs",
+    mods: ["ansi-output", "json-output", "traceback-output"],
+  },
 ];
 
 // 1. barrel entry (the bundle's import graph = exactly these modules)
@@ -98,8 +112,8 @@ writeFileSync(
       include: [
         "../../src/components/ui/**/*.tsx",
         ...groups
-          .find((g) => g.dir === "cell")
-          .mods.map((m) => `../../src/components/cell/${m}.tsx`),
+          .filter((g) => g.dir !== "ui")
+          .flatMap((g) => g.mods.map((m) => `../../src/components/${g.dir}/${m}.tsx`)),
       ],
       exclude: ["../../src/components/**/*.{test,spec,stories}.tsx"],
     },


### PR DESCRIPTION
Adds a third group to the nteract Elements sync (claude.ai/design): the notebook output renderers we own the React for. The design agent can now build with real ANSI, JSON, and traceback output, on-brand and mapping 1:1 to `src/components/outputs`.

Follows the primitives (#3863) and cell group. Project now has 37 components across `general` (25), `cell` (7), and `outputs` (5).

## What shipped

Five renderers, all prop-driven (they take output data as props, no store/provider wiring):

| Component | Source | Data |
|---|---|---|
| AnsiOutput | `ansi-output` | `children: string` (raw ANSI) — pytest run, 16-color palette |
| AnsiStreamOutput | `ansi-output` | `{text, streamName}` — green training log, red stderr |
| AnsiErrorOutput | `ansi-output` | `{ename, evalue, traceback[]}` — IPython ANSI traceback |
| JsonOutput | `json-output` | `{data, collapsed?, displayDataTypes?}` — tree + collapsed-with-types |
| TracebackOutput | `traceback-output` | `{data}` (`vnd.nteract.traceback+json`) — structured frames, source context |

## Two fidelity fixes

- **`css-entry` now `@import`s `src/styles/ansi.css`.** The 16-color ANSI palette is theme-aware CSS variables + `.ansi-*` classes defined there; the app ships them via the isolated renderer, but the DS closure didn't have them, so every AnsiOutput rendered colorless (black swatches). Same class of bug as the destructive-foreground token fix - component CSS the closure was missing.
- **`componentSrcMap` pins the three `ansi-output` exports to their shared file.** The converter fuzzy-matches component→file by kebab name, so `AnsiOutput`→`ansi-output.tsx` resolves but `AnsiStreamOutput`/`AnsiErrorOutput` miss it and fall to the default `general` group. Pinning puts all three in `outputs`.

## Deferred / skipped

- **markdown + math** both `import "katex/dist/katex.min.css"`, and the converter's bundle has no `.ttf` loader for katex's fonts (it loads `.woff/.woff2` only). Shipping them means either a declared `.ttf`-dataurl bundle override or shipping the katex fonts under `fonts/` with rewritten URLs. Own pass, not a fork-free quick add.
- **html-output** is skipped: `HtmlOutput` throws unless rendered inside a sandboxed iframe (security gate), so it can't render in a static card.
- **plotly, vega, image, pdf, audio, video, geojson** are mime→passthrough renderers with no nteract-specific UI - out of scope by design.

## Next

`packages/sift` is a separate package (`SiftTable` and friends). The plan is to first break more of sift into individual reusable `src/components/*` primitives we style in the guide, then sync those - so the sift pass is partly a refactor, tracked for its own PR.

## Test plan

- [x] 37/37 previews render cleanly, all output cards graded good
- [x] ANSI colors verified rendering (palette, green/red/yellow) after the `ansi.css` wire-in
- [x] `vp check --fix` clean before commit
- [x] Uploaded to the live project; `outputs` group confirmed present
