### PR TITLE
docs(adr): accept shared UI primitives decision

### DIFF
--- a/docs/adr/shared-ui-primitives-package.md
+++ b/docs/adr/shared-ui-primitives-package.md
@@ -1,6 +1,7 @@
 # Shared UI Primitives via Monorepo Aliasing
 
-**Status:** Draft, 2026-07-01.
+**Status:** Accepted, 2026-07-01. Implemented in #3872 (shared primitives via
+aliasing, engine-token unification, explicit-signal dark mode).
 
 ## Context
 


### PR DESCRIPTION
Flips the shared-UI-primitives ADR from Draft to Accepted now that #3872 shipped both halves of the decision: sift consumes the app's literal `@/components/ui/*` via monorepo aliasing, engine tokens are unified with the app palette, and dark mode is explicit-signal (dual-keyed token file).

Status line only; the ADR body was already updated as the work landed.
