### PR TITLE
chore(design-sync): add comment affordances (comments group)

### DIFF
--- a/.design-sync/NOTES.md
+++ b/.design-sync/NOTES.md
@@ -66,6 +66,28 @@ passthroughs. Curated list in `synthpkg/build.mjs` (`groups[].dir === 'outputs'`
   need a fixture media/widget provider wired (see
   `apps/elements/components/output-renderers-example.tsx` + `notebook-scenarios.ts`).
 
+## Comment affordances (group: comments)
+
+- Added 2026-07-01: `CommentSelectionAffordance` + `CommentMarkIcon` from
+  `src/components/comments/`. Both prop-driven; author identity flows in via
+  `--comment-author-color` (+ `--comment-author-contrast` for the pill label) set
+  on an ancestor — previews wrap in a scope span with real peer colors.
+- css-entry `@import`s `src/styles/comment-affordance.css` (dot/pill morph) and
+  `src/styles/comment-highlight.css` (open/resolved/pending treatments) — the
+  shared surfaces both editor and rendered-markdown planes use, tunable here.
+  The highlight demo lives as a story inside the affordance's preview (prose
+  with `.comment-highlight`/`-resolved`/`-pending` spans).
+- The affordance is quiet-at-rest by design. Its motion helper
+  (`comment-affordance-motion.ts`) listens for `pointerenter`/`focus` (NOT
+  mouseenter) — the Open story calls `btn.focus()` + dispatches a
+  `PointerEvent("pointerenter")` to play the morph for the screenshot.
+- **NotebookCommentsPanel is DEFERRED with the katex pass**: fully prop-driven
+  (`projection` + callbacks — fixture-friendly) but renders quotes through
+  `ProjectedMarkdownView`, which imports `katex/dist/katex.min.css` (the .ttf
+  loader wall). It joins this group when katex fonts ship, alongside
+  markdown-output/math-output. Its `runtimed` imports (`actorInitials`,
+  `onBehalfOfText`) still need a tree-shake check at that point.
+
 ## Groups + curated lists
 - `cfg.srcDir` is `../../src/components` (broadened from `.../ui`) so grouping resolves
   `cell/` → group `cell` and `ui/` → `general`. Adding a new cell primitive: append it to the

--- a/.design-sync/css-entry.css
+++ b/.design-sync/css-entry.css
@@ -10,10 +10,16 @@
    ships these via the isolated renderer; the DS closure needs them too or every
    AnsiOutput/AnsiStreamOutput renders colorless. */
 @import "../src/styles/ansi.css";
+/* Comment affordance + highlight visuals. Both are shared surfaces the app
+   ships once and tunes in Elements: the affordance dot/bubble morph and the
+   open/resolved/pending highlight treatments. */
+@import "../src/styles/comment-affordance.css";
+@import "../src/styles/comment-highlight.css";
 
 @source "../src/components/ui";
 @source "../src/components/cell";
 @source "../src/components/outputs";
+@source "../src/components/comments";
 @source "./previews";
 
 /* Safelist the semantic token vocabulary the conventions header documents, so a

--- a/.design-sync/previews/CommentMarkIcon.tsx
+++ b/.design-sync/previews/CommentMarkIcon.tsx
@@ -1,0 +1,64 @@
+import { CommentMarkIcon } from "nteract-elements";
+
+// The mark is the author's voice: bubble stroke inherits currentColor from the
+// surrounding text (muted at rest, foreground on hover), the inner dot carries
+// the author's identity color via --comment-author-color.
+const authors = [
+  { name: "Kyle", color: "#2563eb" },
+  { name: "Ana", color: "#16a34a" },
+  { name: "Rin", color: "#f59e0b" },
+];
+
+export function AuthorVoices() {
+  return (
+    <div style={{ display: "flex", alignItems: "center", gap: 20 }}>
+      {authors.map((a) => (
+        <div key={a.name} style={{ display: "flex", alignItems: "center", gap: 6 }}>
+          <span
+            className="text-muted-foreground"
+            style={{ "--comment-author-color": a.color } as React.CSSProperties}
+          >
+            <CommentMarkIcon width={20} height={20} />
+          </span>
+          <span className="text-xs text-muted-foreground">{a.name}</span>
+        </div>
+      ))}
+    </div>
+  );
+}
+
+// Stroke follows the text color of the surface it sits on: muted in a quiet
+// gutter, foreground when the control is hot.
+export function StrokeContexts() {
+  const scope = { "--comment-author-color": "#2563eb" } as React.CSSProperties;
+  return (
+    <div style={{ display: "flex", alignItems: "center", gap: 24, ...scope }}>
+      <span
+        className="text-muted-foreground"
+        style={{ display: "flex", alignItems: "center", gap: 6 }}
+      >
+        <CommentMarkIcon width={20} height={20} />
+        <span className="text-xs">muted (gutter at rest)</span>
+      </span>
+      <span className="text-foreground" style={{ display: "flex", alignItems: "center", gap: 6 }}>
+        <CommentMarkIcon width={20} height={20} />
+        <span className="text-xs">foreground (hover/active)</span>
+      </span>
+    </div>
+  );
+}
+
+export function Sizes() {
+  const scope = { "--comment-author-color": "#2563eb" } as React.CSSProperties;
+  return (
+    <div
+      className="text-foreground"
+      style={{ display: "flex", alignItems: "end", gap: 16, ...scope }}
+    >
+      <CommentMarkIcon width={16} height={16} />
+      <CommentMarkIcon width={20} height={20} />
+      <CommentMarkIcon width={24} height={24} />
+      <CommentMarkIcon width={32} height={32} />
+    </div>
+  );
+}

--- a/.design-sync/previews/CommentSelectionAffordance.tsx
+++ b/.design-sync/previews/CommentSelectionAffordance.tsx
@@ -1,0 +1,105 @@
+import { useEffect, useRef } from "react";
+import { CommentSelectionAffordance } from "nteract-elements";
+
+const noop = () => undefined;
+
+// Author identity colors — the same canonical colors used for cursors/edits.
+const authors = [
+  { name: "Kyle", color: "#2563eb", contrast: "#ffffff" },
+  { name: "Ana", color: "#16a34a", contrast: "#ffffff" },
+  { name: "Rin", color: "#f59e0b", contrast: "#1a1a1a" },
+];
+
+function AuthorScope({
+  color,
+  contrast,
+  children,
+}: {
+  color: string;
+  contrast: string;
+  children: React.ReactNode;
+}) {
+  return (
+    <span
+      style={
+        {
+          "--comment-author-color": color,
+          "--comment-author-contrast": contrast,
+        } as React.CSSProperties
+      }
+    >
+      {children}
+    </span>
+  );
+}
+
+// At rest: a small author-colored dot. It never opens on its own — hover or
+// keyboard focus morphs it into the "Comment" pill.
+export function Resting() {
+  return (
+    <div style={{ display: "flex", alignItems: "center", gap: 20 }}>
+      {authors.map((a) => (
+        <div key={a.name} style={{ display: "flex", alignItems: "center", gap: 8 }}>
+          <span className="text-xs text-muted-foreground">{a.name}</span>
+          <AuthorScope color={a.color} contrast={a.contrast}>
+            <CommentSelectionAffordance onActivate={noop} />
+          </AuthorScope>
+        </div>
+      ))}
+    </div>
+  );
+}
+
+// The open pill. The motion helper opens on pointerenter or focus; focusing the
+// button plays the staged grow → spread → reveal exactly as keyboard reach would.
+export function Open() {
+  const ref = useRef<HTMLDivElement>(null);
+  useEffect(() => {
+    const btn = ref.current?.querySelector("button");
+    btn?.focus();
+    btn?.dispatchEvent(new PointerEvent("pointerenter", { bubbles: false }));
+  }, []);
+  return (
+    <div ref={ref}>
+      <AuthorScope color="#2563eb" contrast="#ffffff">
+        <CommentSelectionAffordance onActivate={noop} />
+      </AuthorScope>
+    </div>
+  );
+}
+
+// The shared highlight surface (comment-highlight.css) the affordance leads to:
+// open threads keep the underline cue, resolved drops to a faint tint, and the
+// pending range under an open composer reads dashed and tentative.
+export function HighlightStates() {
+  return (
+    <div className="text-sm" style={{ maxWidth: 440, lineHeight: 1.7, display: "grid", gap: 10 }}>
+      <p>
+        Weekly revenue is aggregated by region, and{" "}
+        <span className="comment-highlight">the outliers are winsorized at p99</span> before the
+        trend fit.
+      </p>
+      <p>
+        The loader now streams row groups, so{" "}
+        <span className="comment-highlight comment-highlight-resolved">
+          memory stays flat on large files
+        </span>{" "}
+        even for the full-year extract.
+      </p>
+      <p>
+        For the next run we should{" "}
+        <span className="comment-highlight comment-highlight-pending">
+          pin the schema version explicitly
+        </span>
+        <AuthorScope color="#2563eb" contrast="#ffffff">
+          <CommentSelectionAffordance onActivate={noop} />
+        </AuthorScope>
+      </p>
+      <div className="text-xs text-muted-foreground" style={{ display: "flex", gap: 16 }}>
+        <span>open · underlined</span>
+        <span>resolved · faint tint</span>
+        <span>pending · dashed, with affordance</span>
+      </div>
+    </div>
+  );
+}

--- a/.design-sync/synthpkg/build.mjs
+++ b/.design-sync/synthpkg/build.mjs
@@ -57,6 +57,15 @@ const groups = [
     dir: "outputs",
     mods: ["ansi-output", "json-output", "traceback-output"],
   },
+  {
+    // Comment affordances — prop-driven pieces of the commenting UI.
+    // NotebookCommentsPanel is DEFERRED with the katex pass: it renders quotes
+    // via ProjectedMarkdownView, which imports katex CSS (the same .ttf loader
+    // wall that defers math-output above). It is otherwise fully prop-driven
+    // (projection + callbacks) and joins this group when katex fonts ship.
+    dir: "comments",
+    mods: ["CommentSelectionAffordance", "CommentMarkIcon"],
+  },
 ];
 
 // 1. barrel entry (the bundle's import graph = exactly these modules)


### PR DESCRIPTION
Adds a fourth group to the nteract Elements sync: the comment affordances. The design agent can now compose the commenting UI with our real parts - the selection affordance, the comment mark, and the shared highlight surface - instead of inventing generic stand-ins. Project now has 39 components across `general` (25), `cell` (7), `outputs` (5), and `comments` (2).

## What shipped

| Piece | What the card shows |
|---|---|
| CommentSelectionAffordance | Resting author-colored dots (three peers), the open "Comment" pill (focus plays the staged morph), and the highlight surface in prose |
| CommentMarkIcon | Author-voice dots inside the bubble, muted/foreground stroke contexts, 16-32 sizes |
| Highlight surface | `comment-highlight.css` in the guide CSS: open (amber underline), resolved (faint tint, no underline), pending (dashed, with the affordance at the range end) |

`css-entry` now imports `comment-affordance.css` + `comment-highlight.css` - the single shared definitions both the editor and rendered-markdown planes use, which is exactly the "tunable in Elements" contract those files already document.

## Preview mechanics worth knowing

- Author identity flows through `--comment-author-color` (+ `--comment-author-contrast`) set on an ancestor; previews scope real peer colors the same way the app does.
- The affordance is quiet-at-rest by design and its motion helper listens for `pointerenter`/`focus` (not mouseenter) - the Open story focuses the button so the capture shows the real morph end-state, focus ring included.

## Deferred

`NotebookCommentsPanel` (the rail/thread panel) is fully prop-driven (`projection` + callbacks, fixture-friendly) but renders quotes through `ProjectedMarkdownView`, which imports `katex/dist/katex.min.css` - the same `.ttf` loader wall that defers markdown-output and math-output. It joins this group in the katex pass; its `runtimed` utility imports get a tree-shake check then.

## Test plan

- [x] 39/39 previews render cleanly; both new cards graded good from capture sheets
- [x] Re-sync driver: 2 added, 37 unchanged, no grade churn
- [x] Uploaded; `components/comments/` confirmed live in the project
- [x] `vp check` clean before commit (and the post-format drift re-pushed, so remote matches committed source)
