### PR TITLE
fix(design-sync): honor comment affordance contrast

### DIFF
--- a/.design-sync/conventions.md
+++ b/.design-sync/conventions.md
@@ -35,12 +35,15 @@ Do layout with plain Tailwind (`flex`, `gap-2`, `grid`, spacing). Reach for a co
 own `variant`/`size` props before restyling it — e.g. `<Button variant="destructive"
 size="sm">`, `<Badge variant="outline">`.
 
-**Groups.** The library has two groups: the general UI primitives, and **Cells** — nteract's
+**Groups.** The library has three groups: the general UI primitives, **Cells** — nteract's
 notebook cell primitives (CellContainer, CellInsertionRibbon, CodeCellCurrentLine,
-CompactExecutionButton, ExecutionCount, CellPresenceIndicators, CellSkeleton). The cell
-primitives are prop-driven: runtime/execution state enters as explicit props (`count`,
-`isExecuting`, `isQueued`, `isErrored`, `cellType`, `isFocused`), never through hooks. Use
-them to assemble notebook surfaces; cell identity and DOM ordering stay outside the component.
+CompactExecutionButton, ExecutionCount, CellPresenceIndicators, CellSkeleton), and
+**Comments** — prop-driven comment affordances (CommentSelectionAffordance, CommentMarkIcon).
+The cell primitives are prop-driven: runtime/execution state enters as explicit props (`count`,
+`isExecuting`, `isQueued`, `isErrored`, `cellType`, `isFocused`), never through hooks. Comment
+affordances take author color from `--comment-author-color` and readable label color from
+`--comment-author-contrast`. Use them to assemble notebook surfaces; cell identity and DOM
+ordering stay outside the component.
 
 **Compound components** (Dialog, Select, DropdownMenu, ContextMenu, Popover, HoverCard,
 Sheet, Tabs, Accordion, Command, RadioGroup, ToggleGroup) are composed from named subparts

--- a/src/styles/comment-affordance.css
+++ b/src/styles/comment-affordance.css
@@ -39,7 +39,7 @@
   border: none;
   background: transparent;
   /* The open pill paints the label on the author color, so the label needs the
-     author's legible foreground (set with --comment-author-color), not a flat
+     author's legible foreground (set with --comment-author-contrast), not a flat
      white that fails contrast on light author colors. */
   color: var(--comment-author-contrast, var(--primary-foreground, #ffffff));
   cursor: pointer;
@@ -59,7 +59,7 @@
   overflow: hidden;
   border-radius: 999px; /* stadium: a circle at rest, a pill when open */
   background-color: var(--comment-affordance-color);
-  color: #ffffff;
+  color: inherit;
   /* Flat at rest. No shadow, no breathe: a dot that pulses next to code is
      noise, and the resting dot should read as barely there. */
 }


### PR DESCRIPTION
## Summary

- honor `--comment-author-contrast` for the comment selection affordance label by letting the animated dot inherit the button text color
- update the design-sync conventions header so the exported Comments group is documented alongside UI primitives and Cells

## Why

PR #3876 added comment affordances to design-sync, but the label color was still hardcoded to white inside `.comment-affordance-dot`. That bypassed the contrast variable used by the preview data and failed contrast on light author colors such as amber.

## Checks

- `cargo xtask lint --fix`
- `git diff --check`
- contrast sanity check: amber on white `2.15:1`, amber on intended dark contrast `8.10:1`
