### PR TITLE
feat(markdown): project inline JSX as inline island runs

### DIFF
--- a/crates/nteract-markdown-engine/src/lib.rs
+++ b/crates/nteract-markdown-engine/src/lib.rs
@@ -98,6 +98,11 @@ struct StructuralKey {
     // two distinct nodes, which breaks id-anchored comments and collab state.
     isolation_tag: Option<String>,
     island_tag: Option<String>,
+    // island_inline distinguishes a block <Frog/> from an inline <Frog/> for the
+    // same reason: they share a kind and tag, so without this a block->inline swap
+    // would alias the id instead of remounting. They are never siblings today, but
+    // keeping it in the key means a future flow/text unification stays correct.
+    island_inline: bool,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -403,14 +408,16 @@ fn parse_options(islands: bool) -> ParseOptions {
     constructs.math_flow = true;
     constructs.math_text = true;
     if islands {
+        // Flow and text both try the HTML construct before the MDX-JSX one on `<`
+        // and only fall through on failure. A complete tag like `<Frog size={96} />`
+        // is valid HTML, so html_flow/html_text would swallow the JSX before
+        // mdx_jsx_flow/mdx_jsx_text sees it. Routing block and inline `<...>` to MDX
+        // JSX requires the HTML constructs off. This is the islands-on lane only;
+        // islands-off keeps them on, so plain `.md` stays byte-identical.
         constructs.mdx_jsx_flow = true;
-        // Flow tries html_flow before mdx_jsx_flow on `<` and only falls through
-        // on failure. A complete tag like `<Frog size={96} />` is valid HTML
-        // flow, so html_flow would swallow block JSX before mdx_jsx_flow sees it.
-        // Routing block `<...>` to MDX JSX requires html_flow off; this is the
-        // islands-on lane only. Islands-off keeps html_flow true and stays
-        // byte-identical. Inline html_text stays on: Stage 2 is block JSX only.
+        constructs.mdx_jsx_text = true;
         constructs.html_flow = false;
+        constructs.html_text = false;
     }
 
     ParseOptions {
@@ -823,6 +830,7 @@ fn structural_key(node: &ProjectedNode) -> StructuralKey {
         isolation_kind: node.attrs.isolation_kind,
         isolation_tag: node.attrs.isolation_tag.clone(),
         island_tag: node.attrs.island_tag.clone(),
+        island_inline: node.attrs.island_inline,
     }
 }
 
@@ -1186,6 +1194,24 @@ fn project_node(node: &mdast::Node, context: &mut ProjectionContext<'_>) -> Proj
                     MdxMode::Disabled | MdxMode::Isolate => SafetyLane::Isolated,
                 },
                 reason: "mdx-compiles-to-active-js".to_string(),
+            };
+            children.clear();
+        }
+        mdast::Node::MdxJsxTextElement(element) if context.options.islands => {
+            // Inline island (`<Badge/>` inside a paragraph). Mirrors the block
+            // MdxJsxFlowElement island arm above, but island_inline marks it so the
+            // host mounts it in flow. island_tag is part of the structural key, so a
+            // `<Frog/>` -> `<Chart/>` swap replaces the id rather than aliasing it.
+            kind = NodeKind::Island;
+            text = "[isolated MDX region]".to_string();
+            copy_text = source_slice(context.source, &span).to_string();
+            attrs.island_tag = element.name.clone();
+            attrs.isolation_tag = element.name.clone();
+            attrs.island_inline = true;
+            attrs.isolation_kind = Some(IsolationKind::Component);
+            safety = Safety {
+                lane: SafetyLane::Isolated,
+                reason: "isolated-mdx-island".to_string(),
             };
             children.clear();
         }
@@ -1891,6 +1917,48 @@ mod tests {
             .blocks
             .iter()
             .all(|block| block.kind != NodeKind::Island));
+    }
+
+    #[test]
+    fn islands_option_projects_inline_jsx_as_inline_island() {
+        let options = MarkdownProjectOptions {
+            islands: true,
+            ..Default::default()
+        };
+        let plan = project_markdown_with_options("Text with <Frog /> after.\n", &options).unwrap();
+        assert_eq!(plan.mode, PlanMode::Mdx);
+        let paragraph = plan
+            .blocks
+            .iter()
+            .find(|block| block.kind == NodeKind::Paragraph)
+            .expect("expected a paragraph block");
+        let island = paragraph
+            .children
+            .iter()
+            .find(|child| child.kind == NodeKind::Island)
+            .expect("expected an inline Island child inside the paragraph");
+        assert_eq!(island.attrs.island_tag.as_deref(), Some("Frog"));
+        assert!(island.attrs.island_inline);
+        assert_eq!(island.attrs.isolation_kind, Some(IsolationKind::Component));
+    }
+
+    #[test]
+    fn islands_off_leaves_inline_jsx_non_island() {
+        let plan = project_markdown_with_options(
+            "Text with <Frog /> after.\n",
+            &MarkdownProjectOptions::default(),
+        )
+        .unwrap();
+        assert_eq!(plan.mode, PlanMode::Markdown);
+        let paragraph = plan
+            .blocks
+            .iter()
+            .find(|block| block.kind == NodeKind::Paragraph)
+            .expect("expected a paragraph block");
+        assert!(paragraph
+            .children
+            .iter()
+            .all(|child| child.kind != NodeKind::Island));
     }
 
     #[test]

--- a/crates/nteract-markdown-engine/src/lib.rs
+++ b/crates/nteract-markdown-engine/src/lib.rs
@@ -102,6 +102,10 @@ struct StructuralKey {
     // same reason: they share a kind and tag, so without this a block->inline swap
     // would alias the id instead of remounting. They are never siblings today, but
     // keeping it in the key means a future flow/text unification stays correct.
+    // serde(default) keeps snapshot bytes serialized before this field existed
+    // deserializable: from_bytes is total (any error means cold start), so a
+    // missing-field error would silently drop every carried-forward id.
+    #[serde(default)]
     island_inline: bool,
 }
 
@@ -2047,6 +2051,36 @@ mod tests {
             .map(|block| block.id.clone())
             .collect::<Vec<_>>();
         let restored = ReconcilerSnapshot::from_bytes(&snapshot.to_bytes());
+
+        let (after, _) =
+            reconcile_default_with_snapshot("intro\n\nalpha\n\nbeta\n\ngamma\n", &restored);
+
+        assert_eq!(after.blocks.len(), 4);
+        assert!(after.blocks[0].id.starts_with("node:reconciled:"));
+        assert_eq!(after.blocks[1].id, before_ids[0]);
+        assert_eq!(after.blocks[2].id, before_ids[1]);
+        assert_eq!(after.blocks[3].id, before_ids[2]);
+    }
+
+    #[test]
+    fn reconciler_snapshot_bytes_without_island_inline_still_carry_ids() {
+        // Snapshot bytes serialized before StructuralKey had island_inline must
+        // still deserialize and carry ids forward. from_bytes is total (any
+        // deserialize error means cold start), so without serde(default) these
+        // bytes would silently drop every carried-forward id.
+        let source = "alpha\n\nbeta\n\ngamma\n";
+        let (before, snapshot) = reconcile_default(source);
+        let before_ids = before
+            .blocks
+            .iter()
+            .map(|block| block.id.clone())
+            .collect::<Vec<_>>();
+
+        let json = String::from_utf8(snapshot.to_bytes()).unwrap();
+        let pre_field_json = json.replace(",\"island_inline\":false", "");
+        assert_ne!(pre_field_json, json, "expected the field in fresh bytes");
+        let restored = ReconcilerSnapshot::from_bytes(pre_field_json.as_bytes());
+        assert_ne!(restored, ReconcilerSnapshot::default());
 
         let (after, _) =
             reconcile_default_with_snapshot("intro\n\nalpha\n\nbeta\n\ngamma\n", &restored);

--- a/crates/nteract-markdown-engine/src/render_json.rs
+++ b/crates/nteract-markdown-engine/src/render_json.rs
@@ -486,6 +486,9 @@ fn collect_inline(
             context.image_title = previous_title;
         }
         NodeKind::List => collect_list(source, context, node, context.item_path.len()),
+        NodeKind::Island => {
+            context.add_island_run(node);
+        }
         _ => collect_children(source, context, &node.children, semantic),
     }
 }
@@ -730,12 +733,57 @@ impl RunContext<'_> {
         semantic: &'static str,
         rendered_html: Option<String>,
     ) -> JsonRun {
+        self.push_run(
+            source_start,
+            source_end,
+            rendered_text,
+            semantic,
+            rendered_html,
+            None,
+        )
+    }
+
+    /// Inline island (`<Badge/>` inside a paragraph). The run is zero-width on the
+    /// rendered-text axis so surrounding text runs keep tiling in place, and it
+    /// carries the island tag + content hash so the host mounts the component in
+    /// flow and the store can tell a prop edit (hash moves) from an offset shift.
+    fn add_island_run(&mut self, node: &ProjectedNode) -> JsonRun {
+        self.push_run(
+            node.span.start,
+            node.span.end,
+            String::new(),
+            "island",
+            None,
+            Some(IslandRun {
+                tag: node.attrs.island_tag.clone(),
+                inline: node.attrs.island_inline,
+                content_hash: crate::content_hash(node).to_string(),
+            }),
+        )
+    }
+
+    fn push_run(
+        &mut self,
+        source_start: usize,
+        source_end: usize,
+        rendered_text: String,
+        semantic: &'static str,
+        rendered_html: Option<String>,
+        island: Option<IslandRun>,
+    ) -> JsonRun {
         let inline_id = format!("{}:inline:{}", self.block_id, self.inline_index);
         self.inline_index += 1;
         let rendered_start = self.rendered_cursor;
         self.rendered_cursor += rendered_text.encode_utf16().count();
+        let (island_tag, island_inline, content_hash) = match island {
+            Some(island) => (island.tag, island.inline, Some(island.content_hash)),
+            None => (None, false, None),
+        };
         let run = JsonRun {
             block_id: self.block_id.clone(),
+            content_hash,
+            island_inline,
+            island_tag,
             image_alt: self.image_alt.clone(),
             image_src: self.image_src.clone(),
             image_title: self.image_title.clone(),
@@ -776,9 +824,21 @@ impl RunContext<'_> {
     }
 }
 
+/// Island metadata carried on an inline island run (`<Badge/>` in a paragraph).
+/// Block islands carry the same fields on their `JsonBlock`; inline islands have
+/// no block of their own, so the run carries them.
+struct IslandRun {
+    tag: Option<String>,
+    inline: bool,
+    content_hash: String,
+}
+
 #[derive(Clone)]
 struct JsonRun {
     block_id: String,
+    content_hash: Option<String>,
+    island_inline: bool,
+    island_tag: Option<String>,
     image_alt: Option<String>,
     image_src: Option<String>,
     image_title: Option<String>,
@@ -861,6 +921,20 @@ impl JsonRun {
         output.push(',');
         push_json_key_string(output, "semantic", self.semantic);
         output.push(',');
+        // Inline island metadata, mirroring the block island keys. Guarded on
+        // island_tag so a non-island run emits no new keys and its JSON stays
+        // byte-identical (islands are an .mdx-only, opt-in lane).
+        if let Some(island_tag) = &self.island_tag {
+            push_json_key_string(output, "islandTag", island_tag);
+            output.push(',');
+            output.push_str("\"islandInline\":");
+            output.push_str(if self.island_inline { "true" } else { "false" });
+            output.push(',');
+        }
+        if let Some(content_hash) = &self.content_hash {
+            push_json_key_string(output, "contentHash", content_hash);
+            output.push(',');
+        }
         push_json_key_span(output, "sourceSpanByte", self.source_span_byte);
         output.push(',');
         push_json_key_span(output, "sourceSpanUtf16", self.source_span_utf16);
@@ -1319,6 +1393,56 @@ mod tests {
         // the hash holds: the store carries the live element forward.
         let shifted = project("Intro paragraph.\n\n<Frog size={96} />\n");
         assert_eq!(island_hash(&shifted), base_hash);
+    }
+
+    #[test]
+    fn serializes_inline_island_as_a_run() {
+        let options = crate::MarkdownProjectOptions {
+            islands: true,
+            ..Default::default()
+        };
+        let source = "Text with <Frog /> after.\n";
+        let plan = crate::project_markdown_with_options(source, &options).unwrap();
+        let json = render_plan_json(&plan, source, "rust-wasm");
+
+        // The inline island is a run inside the paragraph, carrying its metadata.
+        assert!(json.contains("\"semantic\":\"island\""), "{json}");
+        assert!(json.contains("\"islandTag\":\"Frog\""), "{json}");
+        assert!(json.contains("\"islandInline\":true"), "{json}");
+        assert!(json.contains("\"contentHash\":\""), "{json}");
+        // The run is zero-width on the rendered axis, so the prose still tiles.
+        assert!(json.contains("Text with "), "{json}");
+        assert!(json.contains(" after."), "{json}");
+    }
+
+    #[test]
+    fn inline_island_content_hash_moves_on_prop_edit_only() {
+        let options = crate::MarkdownProjectOptions {
+            islands: true,
+            ..Default::default()
+        };
+        let project = |source: &str| {
+            let plan = crate::project_markdown_with_options(source, &options).unwrap();
+            render_plan_json(&plan, source, "rust-wasm")
+        };
+        let island_hash = |json: &str| {
+            let key = "\"contentHash\":\"";
+            let start = json.find(key).expect("inline island carries contentHash") + key.len();
+            let end = start + json[start..].find('"').unwrap();
+            json[start..end].to_string()
+        };
+
+        let base = island_hash(&project("Text with <Frog size={96} /> after.\n"));
+        // A prop edit moves the hash.
+        assert_ne!(
+            island_hash(&project("Text with <Frog size={48} /> after.\n")),
+            base
+        );
+        // An insert above only shifts offsets, so the hash holds.
+        assert_eq!(
+            island_hash(&project("Lead.\n\nText with <Frog size={96} /> after.\n")),
+            base
+        );
     }
 
     #[test]


### PR DESCRIPTION
Inline JSX inside a paragraph (`Text with <Badge/> here`) was silently dropped in the islands lane. The parser never enabled `mdx_jsx_text`, so `<Badge/>` fell through to `MdxJsxTextElement` with a generic `NodeKind::Mdx` mapping that clears its children, and the JSON serializer had no run type for it. Block JSX (#3859) and the carried-forward reconciler (#3862) worked; inline JSX just vanished.

## What changed

`parse_options` now enables `mdx_jsx_text` and disables `html_text` under the `islands` option, the inline analogue of the existing `mdx_jsx_flow`/`html_flow` routing: the HTML construct wins on `<` before MDX-JSX gets a look, so it has to be off in this lane. Islands-off keeps both HTML constructs on.

`project_node` gets an islands-guarded `MdxJsxTextElement` arm that mirrors the block island arm: `NodeKind::Island`, tag/isolation set from the element name, `island_inline = true`, `IsolationKind::Component`, `SafetyLane::Isolated`, children cleared.

`render_json.rs` adds a `NodeKind::Island` arm to `collect_inline` that emits an inline island run via `add_island_run`. The run is zero-width on the rendered-text axis (empty rendered text, cursor doesn't advance), so the surrounding prose runs keep tiling around it. It carries `islandTag`, `islandInline: true`, and `contentHash`, the reconciler's recursive content hash, so a downstream document store can tell a prop edit (hash moves) from an insert-above offset shift (hash holds). `JsonRun` grows the three fields behind an `if let Some(island_tag)` guard, so a non-island run emits zero new keys.

`StructuralKey` gains `island_inline` alongside the existing `island_tag`. A block `<Frog/>` and an inline `<Frog/>` share a kind and tag; without this field a block-to-inline swap would alias the carried-forward id instead of remounting. They're never siblings today, but keeping it in the key means a future flow/text unification stays correct instead of becoming a silent bug. The field carries `#[serde(default)]` so snapshot bytes serialized before it existed still deserialize: `from_bytes` is total (any error means cold start), so a missing-field error would silently drop every carried-forward id. A compatibility test strips the field from fresh bytes and proves ids still carry forward.

## Byte-identity invariant

Every new path is guarded on the `islands` option or on `NodeKind::Island`. With `islands` false, the default for notebooks, plain `.md`, and the wasm FFI, projection output is byte-identical to before. An adversarial review with a parser probe against `markdown` 1.0.0 confirmed this on the islands-off path.

## Two tradeoffs worth flagging

Turning on `mdx_jsx_text` makes the islands lane strict MDX for inline `<`. A stray `I <3 you` is now a parse error and the whole document fails to project, where it previously came through as literal text. This is intentional: mdxjs-rs is built on the same markdown-rs parser, so anything that compiles as MDX also projects, and anything that now fails to project already failed to compile. The lane was over-lenient before; this makes it consistent with the compile step instead.

Intrinsic tags project as islands too: `<span>x</span>` or `<br/>` inline becomes an island exactly like the block arm has done since #3859. There's no component-vs-intrinsic split. That's consistent with existing block behavior, but the capitalized-component vs lowercase-intrinsic distinction is a real follow-up, and it should land in both arms together, not just this one.

## Behavior

| islands | inline `<Tag/>` | inline `<span>x</span>` | malformed `<` (`I <3 you`) |
|---|---|---|---|
| off | HTML-text handling (unchanged) | HTML-text handling (unchanged) | literal text (unchanged) |
| on | inline island run | inline island run | parse error |

Five new engine tests cover inline island projection on/off, inline island run serialization, contentHash moving on a prop edit but holding across an insert-above shift, and pre-field snapshot bytes still carrying ids forward. 48 engine tests pass, clippy and fmt are clean, the wasm crate test is green, and the runtimed projected-plan test stays on plan version 1.
