### PR TITLE
feat(notebook-cloud): redesigned /n dashboard from Claude Design

### DIFF
--- a/apps/notebook-cloud/test/notebook-dashboard.test.ts
+++ b/apps/notebook-cloud/test/notebook-dashboard.test.ts
@@ -1,6 +1,7 @@
 import assert from "node:assert/strict";
 import { describe, it } from "node:test";
 import {
+  cloudNotebookDashboardRuntimeStatus,
   cloudNotebookDashboardOpenUrl,
   cloudNotebookDisplayTitle,
   cloudNotebookOpenUrlWithMode,
@@ -42,6 +43,9 @@ describe("cloud notebook dashboard projection", () => {
       facts: [],
       identityLabel: null,
       notebook: newOwner,
+      ownerInitials: "AL",
+      ownerLabel: "alice",
+      runtimeStatus: "none",
     });
     assert.deepEqual(
       model.notebooks.map((item) => item.notebook_id),
@@ -677,6 +681,8 @@ describe("cloud notebook dashboard projection", () => {
         tone: "active",
       },
     ]);
+    assert.equal(model.continueRow?.environmentLabel, "Current Python");
+    assert.equal(model.continueRow?.runtimeStatus, "executing");
     assert.deepEqual(
       computeView.sections.map((section) => [
         section.id,
@@ -684,6 +690,63 @@ describe("cloud notebook dashboard projection", () => {
         section.notebooks.map((item) => item.notebook_id),
       ]),
       [["compute", "Active compute", ["topic-viz"]]],
+    );
+  });
+
+  it("maps compute session status to dashboard runtime status", () => {
+    const base = {
+      id: "runtime-status",
+      title: "Runtime status",
+      scope: "owner" as const,
+      updatedAt: "2026-06-23T00:00:00.000Z",
+      latestRevisionId: null,
+    };
+    const computeSession = {
+      environment_label: "Current Python",
+      last_runtime_seen_at: "2026-06-23T00:00:00.000Z",
+      notebook_id: "runtime-status",
+      owner_principal: "user:dev:alice",
+      queue_depth: 0,
+      runtime_peer_count: 1,
+      runtime_session_id: "job-1",
+      status: "active" as const,
+      status_message: null,
+      updated_at: "2026-06-23T00:00:00.000Z",
+      working_directory: "/home/ubuntu/project",
+      workstation_display_name: "lab2 workstation",
+      workstation_id: "ws-lab2",
+    };
+
+    assert.equal(cloudNotebookDashboardRuntimeStatus(notebook(base)), "none");
+    assert.equal(
+      cloudNotebookDashboardRuntimeStatus(
+        notebook({ ...base, computeSession: { ...computeSession, status: "starting" } }),
+      ),
+      "starting",
+    );
+    assert.equal(
+      cloudNotebookDashboardRuntimeStatus(
+        notebook({ ...base, computeSession: { ...computeSession, status: "stale" } }),
+      ),
+      "stale",
+    );
+    assert.equal(
+      cloudNotebookDashboardRuntimeStatus(
+        notebook({ ...base, computeSession: { ...computeSession, status: "error" } }),
+      ),
+      "error",
+    );
+    assert.equal(
+      cloudNotebookDashboardRuntimeStatus(
+        notebook({ ...base, computeSession: { ...computeSession, queue_depth: 0 } }),
+      ),
+      "ready",
+    );
+    assert.equal(
+      cloudNotebookDashboardRuntimeStatus(
+        notebook({ ...base, computeSession: { ...computeSession, queue_depth: 2 } }),
+      ),
+      "executing",
     );
   });
 });

--- a/apps/notebook-cloud/viewer/cloud-notebook-dashboard-view.tsx
+++ b/apps/notebook-cloud/viewer/cloud-notebook-dashboard-view.tsx
@@ -1,17 +1,22 @@
 import { useMemo, useState, type FormEvent } from "react";
 import {
+  ArrowRight,
   BookOpen,
   Check,
   Clock,
-  ExternalLink,
+  Layers,
   Loader2,
   PencilLine,
-  Search,
-  Server,
+  Play,
   Share2,
-  UserRound,
   X,
 } from "lucide-react";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { LanguageMark } from "@/components/runtime/LanguageMark";
+import { NotebookCompositionTicks } from "@/components/notebook/NotebookCompositionTicks";
+import { RuntimeStatusDot } from "@/components/runtime/RuntimeStatusDot";
 import {
   cloudNotebookDashboardOpenUrl,
   cloudNotebookDisplayTitle,
@@ -20,7 +25,6 @@ import {
   type CloudNotebookDashboardFilterId,
   type CloudNotebookDashboardModel,
   type CloudNotebookDashboardRow,
-  type CloudNotebookDashboardRowFact,
   type CloudNotebookDashboardSection,
   type CloudNotebookListItem,
 } from "./notebook-dashboard";
@@ -33,133 +37,223 @@ interface CloudNotebookDashboardRenameState {
 export function CloudNotebookDashboard({
   model,
   canRename,
+  query,
   renameState,
   renameSavingId,
   onOpenNotebookIntent,
   onOpenRename,
   onCancelRename,
+  onQueryChange,
   onRenameTitleChange,
   onSaveRename,
 }: {
   model: CloudNotebookDashboardModel;
   canRename: boolean;
+  query?: string;
   renameState: CloudNotebookDashboardRenameState | null;
   renameSavingId: string | null;
   onOpenNotebookIntent?: () => void;
   onOpenRename: (notebook: CloudNotebookListItem) => void;
   onCancelRename: () => void;
+  onQueryChange?: (query: string) => void;
   onRenameTitleChange: (title: string) => void;
   onSaveRename: (event: FormEvent<HTMLFormElement>) => void;
 }) {
-  const continued = model.continueRow;
-  const [query, setQuery] = useState("");
+  const [internalQuery, setInternalQuery] = useState("");
   const [filterId, setFilterId] = useState<CloudNotebookDashboardFilterId>("all");
+  const activeQuery = query ?? internalQuery;
+  const setQuery = onQueryChange ?? setInternalQuery;
   const view = useMemo(
-    () => projectCloudNotebookDashboardView(model, { filterId, query }),
-    [filterId, model, query],
+    () => projectCloudNotebookDashboardView(model, { filterId, query: activeQuery }),
+    [filterId, model, activeQuery],
   );
+  const continued = view.filterId === "all" && view.query.length === 0 ? model.continueRow : null;
+  const totalCount = model.notebooks.length;
+  const computeCount = model.filters.find((filter) => filter.id === "compute")?.count ?? 0;
+  const hasNoMatches = !continued && view.sections.length === 0;
+
+  const clearFocus = () => {
+    setFilterId("all");
+    setQuery("");
+  };
 
   return (
     <div className="cloud-dashboard">
+      <div className="nb-pagehead">
+        <div>
+          <h1>Notebooks</h1>
+          <p>
+            {totalCount} notebook{totalCount === 1 ? "" : "s"} · {computeCount} active compute
+          </p>
+        </div>
+        {view.showResultCount ? (
+          <span className="nb-result-count" aria-live="polite">
+            {view.resultCount} notebook{view.resultCount === 1 ? "" : "s"}
+          </span>
+        ) : null}
+      </div>
+
+      <CloudNotebookDashboardFilterBar
+        filterGroups={view.filterGroups}
+        filterId={view.filterId}
+        onSelectFilter={setFilterId}
+      />
+
       {continued ? (
-        <section className="cloud-dashboard-continue" aria-labelledby="cloud-dashboard-continue">
-          <div className="cloud-dashboard-continue-main">
-            <p>Continue</p>
-            <h2 id="cloud-dashboard-continue">{cloudNotebookDisplayTitle(continued.notebook)}</h2>
-            <div className="cloud-dashboard-continue-facts">
-              <span>
-                <Clock aria-hidden="true" />
-                {formatNotebookUpdatedAt(continued.notebook.updated_at)}
-              </span>
-              {continued.facts.map((fact) => (
-                <CloudNotebookDashboardFact key={fact.kind} fact={fact} />
-              ))}
-            </div>
-          </div>
-          <a
-            className="cloud-dashboard-primary-link"
-            href={cloudNotebookDashboardOpenUrl(continued.notebook)}
-            onFocus={onOpenNotebookIntent}
-            onPointerEnter={onOpenNotebookIntent}
-          >
-            Open notebook
-            <ExternalLink aria-hidden="true" />
-          </a>
-        </section>
+        <CloudNotebookDashboardHero row={continued} onOpenNotebookIntent={onOpenNotebookIntent} />
       ) : null}
-      <section className="cloud-dashboard-switcher" aria-label="Notebook home">
-        <section className="cloud-dashboard-main" aria-label="Notebook switcher">
-          <div className="cloud-dashboard-search-row">
-            <label className="cloud-dashboard-search">
-              <Search aria-hidden="true" />
-              <input
-                id="cloud-dashboard-search-input"
-                name="notebook-search"
-                type="search"
-                value={query}
-                placeholder="Search notebooks"
-                aria-label="Search notebooks"
-                onChange={(event) => setQuery(event.currentTarget.value)}
-              />
-            </label>
-            {view.showResultCount ? (
-              <span className="cloud-dashboard-result-count" aria-live="polite">
-                {view.resultCount} notebook{view.resultCount === 1 ? "" : "s"}
+
+      {hasNoMatches ? (
+        <CloudNotebookDashboardNoMatches message={view.emptyMessage} onClear={clearFocus} />
+      ) : (
+        <div className="nb-sections">
+          {view.sections.map((section) => (
+            <CloudNotebookDashboardSectionView
+              key={section.id}
+              section={section}
+              canRename={canRename}
+              renameState={renameState}
+              renameSavingId={renameSavingId}
+              onOpenNotebookIntent={onOpenNotebookIntent}
+              onOpenRename={onOpenRename}
+              onCancelRename={onCancelRename}
+              onSelectFilter={setFilterId}
+              onRenameTitleChange={onRenameTitleChange}
+              onSaveRename={onSaveRename}
+            />
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}
+
+export function CloudNotebookDashboardSearchInput({
+  query,
+  disabled,
+  onQueryChange,
+}: {
+  query: string;
+  disabled?: boolean;
+  onQueryChange: (query: string) => void;
+}) {
+  return (
+    <Input
+      id="cloud-dashboard-search-input"
+      name="notebook-search"
+      type="search"
+      value={query}
+      placeholder="Search notebooks"
+      aria-label="Search notebooks"
+      disabled={disabled}
+      onChange={(event) => onQueryChange(event.currentTarget.value)}
+    />
+  );
+}
+
+function CloudNotebookDashboardFilterBar({
+  filterGroups,
+  filterId,
+  onSelectFilter,
+}: {
+  filterGroups: CloudNotebookDashboardModel["filterGroups"];
+  filterId: CloudNotebookDashboardFilterId;
+  onSelectFilter: (filterId: CloudNotebookDashboardFilterId) => void;
+}) {
+  return (
+    <nav className="nb-filters" aria-label="Notebook filters">
+      {filterGroups.flatMap((group) =>
+        group.filters.map((filter) => (
+          <button
+            key={filter.id}
+            type="button"
+            className="nb-chip"
+            data-chip={filter.id === "compute" ? "live" : undefined}
+            data-active={filterId === filter.id ? "true" : undefined}
+            aria-label={`${filter.label}: ${filter.count} notebook${filter.count === 1 ? "" : "s"}`}
+            aria-pressed={filterId === filter.id}
+            onClick={() => onSelectFilter(filter.id)}
+          >
+            {filter.id === "compute" ? <span className="nb-chip-pip" aria-hidden="true" /> : null}
+            <span>{filter.label}</span>
+            <span className="nb-chip-count">{filter.count}</span>
+          </button>
+        )),
+      )}
+    </nav>
+  );
+}
+
+function CloudNotebookDashboardHero({
+  row,
+  onOpenNotebookIntent,
+}: {
+  row: CloudNotebookDashboardRow;
+  onOpenNotebookIntent?: () => void;
+}) {
+  const notebook = row.notebook;
+  const openUrl = cloudNotebookDashboardOpenUrl(notebook);
+  const runtimeActive = cloudNotebookRuntimeIsActive(row);
+  const environmentLanguage = row.environmentLabel
+    ? /python/iu.test(row.environmentLabel)
+      ? "Python"
+      : row.environmentLabel
+    : null;
+  const cellCount = row.composition ? notebookCompositionTotal(row.composition) : null;
+
+  return (
+    <section
+      className={`nb-hero${runtimeActive ? " is-live" : ""}`}
+      aria-label="Pick up where you left off"
+    >
+      {row.environmentLabel && environmentLanguage ? (
+        <span className="nb-hero-runtime">
+          <LanguageMark language={environmentLanguage} size={16} />
+          {row.environmentLabel}
+        </span>
+      ) : null}
+      <div className="nb-hero-top">
+        <div className="nb-hero-body">
+          <div className="nb-hero-eyebrow">
+            {runtimeActive ? "Pick up where you left off" : "Jump back in"}
+          </div>
+          <h2 className="nb-hero-title">{cloudNotebookDisplayTitle(notebook)}</h2>
+          <div className="nb-hero-meta">
+            <RuntimeStatusDot status={row.runtimeStatus} showLabel />
+            <span className="nb-meta-item">
+              <Clock aria-hidden="true" />
+              Updated {formatNotebookUpdatedAt(notebook.updated_at)}
+            </span>
+            {cellCount !== null ? (
+              <span className="nb-meta-item">
+                <Layers aria-hidden="true" />
+                {cellCount} cells
               </span>
             ) : null}
           </div>
-          <nav className="cloud-dashboard-filters" aria-label="Notebook filters">
-            {view.filterGroups.map((group) => (
-              <div
-                key={group.id}
-                className="cloud-dashboard-filter-group"
-                data-group={group.id}
-                aria-label={group.label}
-              >
-                {group.filters.map((filter) => (
-                  <button
-                    key={filter.id}
-                    type="button"
-                    aria-label={`${filter.label}: ${filter.count} notebook${
-                      filter.count === 1 ? "" : "s"
-                    }`}
-                    aria-pressed={view.filterId === filter.id}
-                    data-active={view.filterId === filter.id ? "true" : undefined}
-                    onClick={() => setFilterId(filter.id)}
-                  >
-                    <span>{filter.label}</span>
-                  </button>
-                ))}
-              </div>
-            ))}
-          </nav>
-          {view.sections.length > 0 ? (
-            <div className="cloud-dashboard-notebooks">
-              {view.sections.map((section) => (
-                <CloudNotebookDashboardSectionView
-                  key={section.id}
-                  section={section}
-                  canRename={canRename}
-                  renameState={renameState}
-                  renameSavingId={renameSavingId}
-                  onOpenNotebookIntent={onOpenNotebookIntent}
-                  onOpenRename={onOpenRename}
-                  onCancelRename={onCancelRename}
-                  onSelectFilter={setFilterId}
-                  onRenameTitleChange={onRenameTitleChange}
-                  onSaveRename={onSaveRename}
-                />
-              ))}
-            </div>
-          ) : (
-            <div className="cloud-notebook-list-state" data-kind="empty" role="status">
-              <BookOpen aria-hidden="true" />
-              <span>{view.emptyMessage}</span>
-            </div>
-          )}
-        </section>
-      </section>
-    </div>
+          {row.composition ? (
+            <NotebookCompositionTicks composition={row.composition} className="nb-hero-fp" />
+          ) : null}
+        </div>
+        <div className="nb-hero-side">
+          <Button asChild className="nb-hero-open">
+            <a href={openUrl} onFocus={onOpenNotebookIntent} onPointerEnter={onOpenNotebookIntent}>
+              {runtimeActive ? (
+                <>
+                  <Play aria-hidden="true" />
+                  Resume
+                </>
+              ) : (
+                <>
+                  Open
+                  <ArrowRight aria-hidden="true" />
+                </>
+              )}
+            </a>
+          </Button>
+        </div>
+      </div>
+    </section>
   );
 }
 
@@ -193,52 +287,58 @@ function CloudNotebookDashboardSectionView({
     action?.kind === "filter" && action.filterId === overflowAction?.filterId;
 
   return (
-    <section className="cloud-dashboard-notebook-section" data-section={section.id}>
-      <div className="cloud-dashboard-section-heading">
-        <div>
-          <h2>{section.title}</h2>
-          <p>{section.detail}</p>
+    <section className="nb-section" data-section={section.id}>
+      <div className="nb-sec-head" data-tone={section.id === "compute" ? "live" : "default"}>
+        <div className="nb-sec-left">
+          {section.id === "compute" ? <span className="nb-live-pip" aria-hidden="true" /> : null}
+          <h2 className="nb-sec-title">{section.title}</h2>
+          <span className="nb-sec-count">{section.totalCount}</span>
         </div>
         {action?.kind === "rename" ? (
-          <button
+          <Button
             type="button"
-            className="cloud-dashboard-section-action"
+            variant="ghost"
+            size="sm"
+            className="nb-sec-action"
             onClick={() => onOpenRename(action.notebook)}
           >
             <PencilLine aria-hidden="true" />
             {action.label}
-          </button>
+          </Button>
         ) : action?.kind === "filter" ? (
-          <button
+          <Button
             type="button"
-            className="cloud-dashboard-section-action"
+            variant="ghost"
+            size="sm"
+            className="nb-sec-action"
             onClick={() => onSelectFilter(action.filterId)}
           >
             {action.label}
-          </button>
-        ) : null}
+          </Button>
+        ) : (
+          <span className="nb-sec-hint">{section.detail}</span>
+        )}
       </div>
-      <ul className="cloud-notebook-list">
+      <div className="nb-list">
         {section.rows.map((row) => (
-          <li key={row.notebook.notebook_id}>
-            <CloudNotebookDashboardRow
-              row={row}
-              canRename={canRename}
-              renameTitle={
-                renameState?.notebookId === row.notebook.notebook_id ? renameState.title : null
-              }
-              renameSaving={renameSavingId === row.notebook.notebook_id}
-              onOpenNotebookIntent={onOpenNotebookIntent}
-              onOpenRename={onOpenRename}
-              onCancelRename={onCancelRename}
-              onRenameTitleChange={onRenameTitleChange}
-              onSaveRename={onSaveRename}
-            />
-          </li>
+          <CloudNotebookDashboardRowView
+            key={row.notebook.notebook_id}
+            row={row}
+            canRename={canRename}
+            renameTitle={
+              renameState?.notebookId === row.notebook.notebook_id ? renameState.title : null
+            }
+            renameSaving={renameSavingId === row.notebook.notebook_id}
+            onOpenNotebookIntent={onOpenNotebookIntent}
+            onOpenRename={onOpenRename}
+            onCancelRename={onCancelRename}
+            onRenameTitleChange={onRenameTitleChange}
+            onSaveRename={onSaveRename}
+          />
         ))}
-      </ul>
+      </div>
       {hiddenCount > 0 && overflowAction ? (
-        <p className="cloud-dashboard-section-footnote">
+        <p className="nb-section-footnote">
           Showing {section.notebooks.length} of {section.totalCount}.
           {actionAlreadyReviewsOverflow ? null : (
             <>
@@ -256,7 +356,7 @@ function CloudNotebookDashboardSectionView({
   );
 }
 
-function CloudNotebookDashboardRow({
+function CloudNotebookDashboardRowView({
   row,
   canRename,
   renameTitle,
@@ -277,11 +377,11 @@ function CloudNotebookDashboardRow({
   onRenameTitleChange: (title: string) => void;
   onSaveRename: (event: FormEvent<HTMLFormElement>) => void;
 }) {
+  const notebook = row.notebook;
   if (renameTitle !== null) {
-    const notebook = row.notebook;
     return (
-      <form className="cloud-notebook-list-rename-form" onSubmit={onSaveRename}>
-        <input
+      <form className="nb-row nb-row-rename" onSubmit={onSaveRename}>
+        <Input
           aria-label={`Notebook title for ${cloudNotebookShortId(notebook.notebook_id)}`}
           type="text"
           value={renameTitle}
@@ -290,80 +390,132 @@ function CloudNotebookDashboardRow({
           disabled={renameSaving}
           onChange={(event) => onRenameTitleChange(event.currentTarget.value)}
         />
-        <button type="submit" disabled={renameSaving} title="Save title" aria-label="Save title">
-          {renameSaving ? (
-            <Loader2 className="cloud-home-status-spinner" aria-hidden="true" />
-          ) : (
-            <Check aria-hidden="true" />
-          )}
-        </button>
-        <button
-          type="button"
-          disabled={renameSaving}
-          title="Cancel rename"
-          aria-label="Cancel rename"
-          onClick={onCancelRename}
-        >
-          <X aria-hidden="true" />
-        </button>
+        <span className="nb-row-rename-actions">
+          <Button type="submit" variant="ghost" size="icon" disabled={renameSaving}>
+            {renameSaving ? (
+              <Loader2 className="cloud-home-status-spinner" aria-hidden="true" />
+            ) : (
+              <Check aria-hidden="true" />
+            )}
+            <span className="sr-only">Save title</span>
+          </Button>
+          <Button
+            type="button"
+            variant="ghost"
+            size="icon"
+            disabled={renameSaving}
+            onClick={onCancelRename}
+          >
+            <X aria-hidden="true" />
+            <span className="sr-only">Cancel rename</span>
+          </Button>
+        </span>
       </form>
     );
   }
 
-  const { notebook } = row;
   const openUrl = cloudNotebookDashboardOpenUrl(notebook);
   const hasTitle = Boolean(notebook.title?.trim());
-  const detail = hasTitle
-    ? row.contextLabel
-    : row.identityLabel
-      ? `Created ${formatNotebookUpdatedAt(notebook.created_at)} · ${row.identityLabel}`
-      : `Created ${formatNotebookUpdatedAt(notebook.created_at)}`;
+  const cellCount = row.composition ? notebookCompositionTotal(row.composition) : null;
+  const runtimeActive = cloudNotebookRuntimeIsActive(row);
 
   return (
-    <div className="cloud-notebook-list-row">
+    <div className={`nb-row${runtimeActive ? " is-live" : ""}`} data-scope={notebook.scope}>
       <a
-        className="cloud-notebook-list-main"
+        className="nb-row-lead"
         href={openUrl}
         onFocus={onOpenNotebookIntent}
         onPointerEnter={onOpenNotebookIntent}
       >
-        <span className="cloud-notebook-list-title">{cloudNotebookDisplayTitle(notebook)}</span>
-        {detail ? <span className="cloud-notebook-list-detail">{detail}</span> : null}
-        {row.facts.length > 0 ? (
-          <span className="cloud-notebook-list-row-facts">
-            {row.facts.map((fact) => (
-              <CloudNotebookDashboardFact key={fact.kind} fact={fact} />
-            ))}
+        <span className="nb-row-titleblock">
+          <span className="nb-title" data-untitled={!hasTitle}>
+            {cloudNotebookDisplayTitle(notebook)}
           </span>
-        ) : null}
+          {row.composition ? (
+            <span className="nb-subline">
+              <NotebookCompositionTicks composition={row.composition} />
+              <span className="nb-cellcount">{cellCount} cells</span>
+            </span>
+          ) : row.contextLabel || row.identityLabel ? (
+            <span className="nb-row-context">{row.contextLabel ?? row.identityLabel}</span>
+          ) : null}
+        </span>
       </a>
-      <span className="cloud-notebook-list-updated">
+      <span className="nb-col nb-col-owner">
+        <span className="nb-avatar nb-avatar-sm">{row.ownerInitials}</span>
+        <span className="nb-col-owner-name">{row.ownerLabel}</span>
+      </span>
+      <span className="nb-col nb-col-updated">
         <Clock aria-hidden="true" />
         {formatNotebookUpdatedAt(notebook.updated_at)}
       </span>
-      <span className="cloud-notebook-list-row-actions">
+      <div className="nb-col nb-col-badges">
+        {notebook.latest_revision_id ? (
+          <span className="nb-pub">
+            <Share2 aria-hidden="true" />
+            Published
+          </span>
+        ) : null}
+        <CloudNotebookScopeBadge notebook={notebook} />
+      </div>
+      <span className="nb-row-actions">
         {canRename && canRenameCloudNotebook(notebook) ? (
-          <button
+          <Button
             type="button"
-            className="cloud-notebook-list-icon-button"
-            title="Rename notebook"
+            variant="ghost"
+            size="icon"
+            className="nb-row-icon"
             aria-label={`Rename ${cloudNotebookDisplayTitle(notebook)}`}
+            title="Rename notebook"
             onClick={() => onOpenRename(notebook)}
           >
             <PencilLine aria-hidden="true" />
-          </button>
+          </Button>
         ) : null}
         <a
-          className="cloud-notebook-list-icon-button"
+          className="nb-open-hint"
           href={openUrl}
-          title="Open notebook"
           aria-label={`Open ${cloudNotebookDisplayTitle(notebook)}`}
+          title="Open notebook"
           onFocus={onOpenNotebookIntent}
           onPointerEnter={onOpenNotebookIntent}
         >
-          <ExternalLink aria-hidden="true" />
+          <ArrowRight aria-hidden="true" />
         </a>
       </span>
+    </div>
+  );
+}
+
+function CloudNotebookScopeBadge({ notebook }: { notebook: CloudNotebookListItem }) {
+  const label = cloudNotebookScopeLabel(notebook);
+  if (!label) {
+    return null;
+  }
+  return (
+    <Badge variant="outline" className="nb-scope-badge">
+      {label}
+    </Badge>
+  );
+}
+
+function CloudNotebookDashboardNoMatches({
+  message,
+  onClear,
+}: {
+  message: string;
+  onClear: () => void;
+}) {
+  return (
+    <div className="nb-empty" role="status">
+      <span className="nb-empty-badge">
+        <BookOpen aria-hidden="true" />
+      </span>
+      <h2>No matches</h2>
+      <p>{message}</p>
+      <Button type="button" variant="outline" onClick={onClear}>
+        Clear
+      </Button>
     </div>
   );
 }
@@ -372,31 +524,29 @@ function canRenameCloudNotebook(notebook: CloudNotebookListItem): boolean {
   return notebook.scope === "owner" || notebook.scope === "editor";
 }
 
-function CloudNotebookDashboardFact({ fact }: { fact: CloudNotebookDashboardRowFact }) {
-  if (fact.kind === "compute") {
-    return (
-      <span data-state={fact.tone ?? "active"}>
-        <Server aria-hidden="true" />
-        {fact.label}
-      </span>
-    );
+function cloudNotebookScopeLabel(notebook: CloudNotebookListItem): string | null {
+  switch (notebook.scope) {
+    case "editor":
+      return "Can edit";
+    case "viewer":
+      return "View only";
+    case "runtime_peer":
+      return "Runtime";
+    case "owner":
+      return null;
   }
+}
 
-  if (fact.kind === "published") {
-    return (
-      <span data-state="published">
-        <Share2 aria-hidden="true" />
-        {fact.label}
-      </span>
-    );
-  }
-
+function cloudNotebookRuntimeIsActive(row: CloudNotebookDashboardRow): boolean {
   return (
-    <span>
-      <UserRound aria-hidden="true" />
-      {fact.label}
-    </span>
+    row.runtimeStatus === "executing" ||
+    row.runtimeStatus === "ready" ||
+    row.runtimeStatus === "starting"
   );
+}
+
+function notebookCompositionTotal(composition: { code: number; markdown: number; raw: number }) {
+  return composition.code + composition.markdown + composition.raw;
 }
 
 function formatNotebookUpdatedAt(value: string): string {

--- a/apps/notebook-cloud/viewer/index.css
+++ b/apps/notebook-cloud/viewer/index.css
@@ -690,6 +690,24 @@ body {
 }
 
 .cloud-notebook-list-page {
+  --ct-code: #38bdf8;
+  --ci-code: #0284c7;
+  --ct-markdown: #34d399;
+  --ci-markdown: #059669;
+  --ct-raw: #fb7185;
+  --ci-raw: #e11d48;
+  --uv: #de5fe9;
+  --live: #22c55e;
+  --live-ink: #16a34a;
+  --k-exec: #f59e0b;
+  --k-ready: #22c55e;
+  --k-start: #3b82f6;
+  --k-stale: #9ca3af;
+  --k-error: var(--destructive);
+  --nb-shadow: 0 1px 2px rgba(16, 16, 20, 0.04), 0 1px 3px rgba(16, 16, 20, 0.06);
+  --nb-shadow-lg: 0 6px 16px -6px rgba(16, 16, 20, 0.14), 0 2px 6px -2px rgba(16, 16, 20, 0.08);
+  --nb-maxw: 1120px;
+
   display: grid;
   grid-template-rows: auto auto minmax(0, 1fr);
   height: 100%;
@@ -699,78 +717,28 @@ body {
   color: var(--foreground);
 }
 
-.cloud-notebook-list-header {
-  display: flex;
-  align-items: end;
-  justify-content: space-between;
-  gap: 1rem;
-  border-bottom: 1px solid var(--border);
-  padding: clamp(1rem, 4vw, 2rem);
-}
-
-.cloud-notebook-list-header h1,
-.cloud-notebook-list-header p {
-  margin: 0;
-}
-
-.cloud-notebook-list-header h1 {
-  margin-top: 0.25rem;
-  font-size: clamp(2rem, 5vw, 3.5rem);
-  font-weight: 740;
-  letter-spacing: 0;
-  line-height: 1;
-}
-
-.cloud-notebook-list-header p,
-.cloud-notebook-list-brand {
-  color: color-mix(in srgb, var(--foreground) 62%, transparent);
-  font-size: 0.875rem;
-  line-height: 1.35;
-}
-
-.cloud-notebook-list-brand {
-  text-decoration: none;
-}
-
-.cloud-notebook-list-brand:hover {
+.nb-app {
+  min-height: 100vh;
+  background: var(--background);
   color: var(--foreground);
+  transition:
+    background 0.18s ease,
+    color 0.18s ease;
 }
 
-.cloud-notebook-list-actions {
-  display: flex;
-  flex-wrap: wrap;
-  justify-content: flex-end;
-  gap: 0.5rem;
-}
-
-.cloud-notebook-list-actions button,
-.cloud-notebook-list-actions .cloud-sign-in-button {
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  gap: 0.375rem;
-  min-height: 2.25rem;
-  border: 1px solid color-mix(in srgb, var(--foreground) 16%, transparent);
-  border-radius: 6px;
-  padding-inline: 0.75rem;
-  color: var(--foreground);
-  background: color-mix(in srgb, var(--background) 94%, var(--foreground) 6%);
-  font-size: 0.875rem;
-}
-
-.cloud-notebook-list-actions button:hover,
-.cloud-notebook-list-actions .cloud-sign-in-button:hover {
-  background: color-mix(in srgb, var(--background) 86%, var(--foreground) 10%);
-}
-
-.cloud-notebook-list-actions button:disabled {
-  cursor: progress;
-  opacity: 0.62;
-}
-
-.cloud-notebook-list-actions svg {
-  width: 1rem;
-  height: 1rem;
+.dark .cloud-notebook-list-page,
+[data-theme="dark"] .cloud-notebook-list-page {
+  --ct-code: #7dd3fc;
+  --ci-code: #7dd3fc;
+  --ct-markdown: #6ee7b7;
+  --ci-markdown: #6ee7b7;
+  --ct-raw: #fda4af;
+  --ci-raw: #fda4af;
+  --live: #4ade80;
+  --live-ink: #4ade80;
+  --k-stale: #6b7280;
+  --nb-shadow: 0 1px 2px rgba(0, 0, 0, 0.4);
+  --nb-shadow-lg: 0 10px 26px -8px rgba(0, 0, 0, 0.6);
 }
 
 .cloud-notebook-list-banner {
@@ -781,75 +749,955 @@ body {
 }
 
 .cloud-notebook-list-banner[data-kind="error"] {
-  color: #b42318;
-  background: color-mix(in srgb, #b42318 6%, var(--background));
-}
-
-.cloud-new-notebook-form {
-  display: grid;
-  grid-template-columns: auto minmax(14rem, 24rem) auto auto;
-  gap: 0.5rem;
-  align-items: center;
-  border-bottom: 1px solid color-mix(in srgb, var(--foreground) 12%, transparent);
-  padding: 0.75rem clamp(1rem, 4vw, 2rem);
-  background: color-mix(in srgb, var(--background) 97%, var(--foreground) 3%);
-}
-
-.cloud-new-notebook-form label {
-  color: color-mix(in srgb, var(--foreground) 60%, transparent);
-  font-size: 0.75rem;
-  font-weight: 700;
-  letter-spacing: 0;
-  text-transform: uppercase;
-}
-
-.cloud-new-notebook-form input {
-  width: 100%;
-  min-width: 0;
-  height: 2.25rem;
-  border: 1px solid color-mix(in srgb, var(--foreground) 16%, transparent);
-  border-radius: 6px;
-  padding-inline: 0.625rem;
-  color: var(--foreground);
-  background: var(--background);
-  font: inherit;
-  font-size: 0.875rem;
-}
-
-.cloud-new-notebook-form input:focus-visible {
-  outline: 2px solid color-mix(in srgb, #0f766e 42%, transparent);
-  outline-offset: 2px;
-}
-
-.cloud-new-notebook-form button {
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  gap: 0.375rem;
-  min-height: 2.25rem;
-  border: 1px solid color-mix(in srgb, var(--foreground) 16%, transparent);
-  border-radius: 6px;
-  padding-inline: 0.75rem;
-  color: var(--foreground);
-  background: var(--background);
-  font-size: 0.875rem;
-  font-weight: 650;
-}
-
-.cloud-new-notebook-form button[type="submit"] {
-  color: var(--background);
-  background: var(--foreground);
-}
-
-.cloud-new-notebook-form button svg {
-  width: 0.9375rem;
-  height: 0.9375rem;
+  color: var(--destructive);
+  background: color-mix(in srgb, var(--destructive) 8%, var(--background));
 }
 
 .cloud-notebook-list-content {
   display: grid;
   align-content: start;
-  padding: clamp(0.75rem, 3vw, 1.5rem) clamp(1rem, 4vw, 2rem) 2rem;
+  padding: 0;
+}
+
+.cloud-dashboard {
+  display: grid;
+  gap: 1.125rem;
+  width: 100%;
+}
+
+.nb-header {
+  position: sticky;
+  top: 0;
+  z-index: 20;
+  border-bottom: 1px solid var(--border);
+  background: color-mix(in srgb, var(--background) 88%, transparent);
+  backdrop-filter: saturate(1.4) blur(12px);
+}
+
+.nb-header-inner {
+  display: flex;
+  align-items: center;
+  gap: 18px;
+  max-width: var(--nb-maxw);
+  margin: 0 auto;
+  padding: 14px 28px;
+}
+
+.nb-brand {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  min-width: 0;
+  color: inherit;
+  text-decoration: none;
+}
+
+.nb-brand-mark {
+  display: grid;
+  width: 26px;
+  height: 26px;
+  flex: 0 0 auto;
+  place-items: center;
+  border-radius: 7px;
+  background: var(--foreground);
+  color: var(--background);
+  font-size: 15px;
+  font-weight: 800;
+}
+
+.nb-brand-mark::after {
+  content: "n";
+}
+
+.nb-brand-name {
+  font-size: 15px;
+  font-weight: 650;
+}
+
+.nb-brand-sep {
+  color: var(--muted-foreground);
+  opacity: 0.5;
+}
+
+.nb-brand-scope {
+  overflow: hidden;
+  color: var(--muted-foreground);
+  font-size: 14px;
+  font-weight: 500;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.nb-header-spacer {
+  flex: 1 1 auto;
+}
+
+.nb-search {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  width: 300px;
+  max-width: 38vw;
+  height: 36px;
+  border: 1px solid var(--border);
+  border-radius: 9px;
+  padding: 0 12px;
+  background: var(--card);
+  color: var(--foreground);
+  box-shadow: var(--nb-shadow);
+}
+
+.nb-search:focus-within {
+  border-color: var(--ring);
+  box-shadow: 0 0 0 3px color-mix(in srgb, var(--foreground) 10%, transparent);
+}
+
+.nb-search svg {
+  width: 15px;
+  height: 15px;
+  color: var(--muted-foreground);
+}
+
+.nb-search input {
+  height: auto;
+  min-width: 0;
+  border: 0;
+  padding: 0;
+  color: inherit;
+  background: transparent;
+  box-shadow: none;
+  font: inherit;
+  font-size: 14px;
+}
+
+.nb-search input:focus-visible {
+  box-shadow: none;
+  outline: 0;
+}
+
+.nb-header-actions {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.nb-header-actions svg {
+  flex: 0 0 auto;
+}
+
+.nb-avatar-me {
+  display: grid;
+  width: 32px;
+  height: 32px;
+  flex: 0 0 auto;
+  place-items: center;
+  border-radius: 50%;
+  background: var(--uv);
+  color: #fff;
+  font-size: 12px;
+  font-weight: 700;
+}
+
+.cloud-dashboard,
+.cloud-notebook-signed-out,
+.cloud-notebook-list-state,
+.nb-empty {
+  max-width: var(--nb-maxw);
+  margin: 0 auto;
+}
+
+.cloud-dashboard,
+.cloud-notebook-list-state,
+.nb-empty {
+  width: min(100%, var(--nb-maxw));
+}
+
+.cloud-dashboard {
+  padding: 26px 28px 90px;
+}
+
+.nb-pagehead {
+  display: flex;
+  align-items: flex-end;
+  justify-content: space-between;
+  gap: 20px;
+  margin-bottom: 18px;
+}
+
+.nb-pagehead h1,
+.nb-pagehead p {
+  margin: 0;
+}
+
+.nb-pagehead h1 {
+  font-size: 25px;
+  font-weight: 700;
+  line-height: 1.1;
+}
+
+.nb-pagehead p,
+.nb-result-count {
+  color: var(--muted-foreground);
+  font-size: 13.5px;
+}
+
+.nb-result-count {
+  white-space: nowrap;
+}
+
+.nb-filters {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 6px;
+  margin: 6px 0 22px;
+}
+
+.nb-chip {
+  display: inline-flex;
+  align-items: center;
+  gap: 7px;
+  height: 32px;
+  border: 1px solid var(--border);
+  border-radius: 999px;
+  padding: 0 12px;
+  color: var(--muted-foreground);
+  background: var(--card);
+  cursor: pointer;
+  font: inherit;
+  font-size: 13px;
+  font-weight: 550;
+  transition: all 0.12s ease;
+}
+
+.nb-chip:hover {
+  border-color: color-mix(in srgb, var(--foreground) 24%, var(--border));
+  color: var(--foreground);
+}
+
+.nb-chip[data-active="true"] {
+  border-color: var(--foreground);
+  color: var(--background);
+  background: var(--foreground);
+}
+
+.nb-chip[data-chip="live"][data-active="true"] {
+  border-color: var(--live-ink);
+  color: #fff;
+  background: var(--live-ink);
+}
+
+.nb-chip-count {
+  font-size: 12px;
+  font-variant-numeric: tabular-nums;
+  opacity: 0.75;
+}
+
+.nb-chip-pip,
+.nb-live-pip {
+  width: 7px;
+  height: 7px;
+  border-radius: 2px;
+  background: var(--muted-foreground);
+}
+
+.nb-hero {
+  position: relative;
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+  margin-bottom: 30px;
+  border: 1px solid var(--border);
+  border-radius: 16px;
+  padding: 24px 26px;
+  background: var(--card);
+  box-shadow: var(--nb-shadow-lg);
+}
+
+.nb-hero.is-live {
+  border-color: var(--border);
+}
+
+.nb-hero-top {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto;
+  align-items: stretch;
+  gap: 24px;
+}
+
+.nb-hero-runtime {
+  position: absolute;
+  top: 24px;
+  right: 26px;
+  z-index: 2;
+  display: inline-flex;
+  align-items: center;
+  gap: 7px;
+  color: var(--muted-foreground);
+  font-size: 12.5px;
+  font-weight: 600;
+}
+
+.nb-lang-logo {
+  display: block;
+  flex: 0 0 auto;
+}
+
+.nb-hero-body {
+  position: relative;
+  display: flex;
+  min-width: 0;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.nb-hero-eyebrow {
+  display: inline-flex;
+  align-items: center;
+  align-self: flex-start;
+  gap: 7px;
+  color: var(--muted-foreground);
+  font-size: 11.5px;
+  font-weight: 700;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+}
+
+.nb-hero-title {
+  margin: 0;
+  padding-right: 120px;
+  font-size: 27px;
+  font-weight: 730;
+  line-height: 1.08;
+}
+
+.nb-hero-meta {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 14px;
+  color: var(--muted-foreground);
+  font-size: 12.5px;
+}
+
+.nb-meta-item {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  white-space: nowrap;
+}
+
+.nb-meta-item svg {
+  width: 13px;
+  height: 13px;
+}
+
+.nb-hero-side {
+  position: relative;
+  display: flex;
+  min-width: 150px;
+  flex-direction: column;
+  align-items: stretch;
+  justify-content: center;
+  gap: 8px;
+}
+
+.nb-hero-open {
+  height: 44px;
+  gap: 8px;
+  font-size: 15px;
+}
+
+.nb-sections {
+  display: flex;
+  flex-direction: column;
+  gap: 30px;
+}
+
+.nb-section {
+  min-width: 0;
+}
+
+.nb-sec-head {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: 14px;
+  margin-bottom: 12px;
+}
+
+.nb-sec-left {
+  display: flex;
+  align-items: center;
+  gap: 9px;
+  min-width: 0;
+}
+
+.nb-sec-title {
+  margin: 0;
+  color: color-mix(in srgb, var(--foreground) 62%, transparent);
+  font-size: 13px;
+  font-weight: 700;
+  letter-spacing: 0.02em;
+  text-transform: uppercase;
+}
+
+.nb-sec-head[data-tone="live"] .nb-sec-title {
+  color: var(--live-ink);
+}
+
+.nb-sec-count {
+  border-radius: 999px;
+  padding: 1px 8px;
+  color: var(--muted-foreground);
+  background: var(--muted);
+  font-size: 12px;
+  font-weight: 600;
+  font-variant-numeric: tabular-nums;
+}
+
+.nb-sec-hint {
+  color: var(--muted-foreground);
+  font-size: 12px;
+}
+
+.nb-sec-action {
+  color: var(--muted-foreground);
+}
+
+.nb-fp-wrap {
+  display: flex;
+  min-width: 0;
+  flex-direction: column;
+  gap: 7px;
+}
+
+.nb-hero-fp {
+  max-width: 340px;
+}
+
+.nb-fp {
+  display: flex;
+  align-items: stretch;
+  width: 100%;
+  max-width: 340px;
+  height: 7px;
+  overflow: hidden;
+  border-radius: 3px;
+  opacity: 0.62;
+}
+
+.nb-fp-seg {
+  height: 100%;
+}
+
+.nb-fp-seg[data-ct="code"] {
+  background: var(--ct-code);
+}
+
+.nb-fp-seg[data-ct="markdown"] {
+  background: var(--ct-markdown);
+}
+
+.nb-fp-seg[data-ct="raw"] {
+  background: var(--ct-raw);
+}
+
+.nb-hero .nb-fp {
+  height: 8px;
+}
+
+.nb-kernel {
+  display: inline-flex;
+  align-items: center;
+  gap: 7px;
+  color: var(--muted-foreground);
+  font-size: 12.5px;
+  white-space: nowrap;
+}
+
+.nb-kdot {
+  width: 8px;
+  height: 8px;
+  flex: 0 0 auto;
+  border-radius: 50%;
+  background: var(--k-stale);
+}
+
+.nb-kernel[data-k="executing"] {
+  color: color-mix(in srgb, var(--k-exec) 72%, var(--foreground));
+}
+
+.nb-kernel[data-k="executing"] .nb-kdot {
+  background: var(--k-exec);
+}
+
+.nb-kernel[data-k="ready"] {
+  color: color-mix(in srgb, var(--k-ready) 60%, var(--foreground));
+}
+
+.nb-kernel[data-k="ready"] .nb-kdot {
+  background: var(--k-ready);
+}
+
+.nb-kernel[data-k="starting"] .nb-kdot {
+  background: var(--k-start);
+}
+
+.nb-kernel[data-k="error"] {
+  color: var(--k-error);
+}
+
+.nb-kernel[data-k="error"] .nb-kdot {
+  background: var(--k-error);
+}
+
+.nb-kernel[data-k="none"] .nb-kdot {
+  border: 1.5px solid color-mix(in srgb, var(--muted-foreground) 55%, transparent);
+  background: transparent;
+}
+
+.nb-avatar {
+  display: grid;
+  flex: 0 0 auto;
+  place-items: center;
+  border-radius: 50%;
+  background: color-mix(in srgb, var(--foreground) 72%, var(--background));
+  color: var(--background);
+  font-weight: 700;
+}
+
+.nb-avatar-sm {
+  width: 17px;
+  height: 17px;
+  font-size: 8px;
+}
+
+.nb-lang-dot {
+  display: inline-block;
+  width: 8px;
+  height: 8px;
+  flex: 0 0 auto;
+  border-radius: 50%;
+  background: var(--muted-foreground);
+}
+
+.nb-lang-dot[data-lang="Python"] {
+  background: #3b82f6;
+}
+
+.nb-lang-dot[data-lang="SQL"] {
+  background: #f59e0b;
+}
+
+.nb-lang-dot[data-lang="TypeScript"] {
+  background: #3178c6;
+}
+
+.nb-lang-dot[data-lang="R"] {
+  background: #2563eb;
+}
+
+.nb-scope-badge {
+  padding: 1px 7px;
+  color: var(--muted-foreground);
+  font-size: 11px;
+  font-weight: 600;
+  white-space: nowrap;
+}
+
+.nb-pub {
+  display: inline-flex;
+  align-items: center;
+  gap: 5px;
+  color: color-mix(in srgb, var(--ci-markdown) 82%, var(--foreground));
+  font-size: 11.5px;
+  font-weight: 600;
+  white-space: nowrap;
+}
+
+.nb-pub svg {
+  width: 12px;
+  height: 12px;
+}
+
+.nb-list {
+  display: grid;
+}
+
+.nb-row {
+  position: relative;
+  display: grid;
+  grid-template-columns: minmax(180px, 1fr) 124px 150px minmax(118px, auto) 72px;
+  align-items: center;
+  min-height: 68px;
+  column-gap: 14px;
+  row-gap: 6px;
+  border: 1px solid transparent;
+  border-radius: 12px;
+  padding: 13px 14px 13px 18px;
+  color: inherit;
+  background: transparent;
+  transition:
+    background 0.12s ease,
+    border-color 0.12s ease,
+    box-shadow 0.12s ease;
+}
+
+.nb-row + .nb-row {
+  margin-top: 2px;
+}
+
+.nb-row::after {
+  position: absolute;
+  right: 16px;
+  bottom: -1px;
+  left: 18px;
+  height: 1px;
+  background: var(--border);
+  content: "";
+}
+
+.nb-row:last-child::after,
+.nb-row:hover::after {
+  opacity: 0;
+}
+
+.nb-row:hover {
+  border-color: var(--border);
+  background: var(--card);
+  box-shadow: var(--nb-shadow);
+}
+
+.nb-row.is-live {
+  border-color: transparent;
+}
+
+.nb-row-lead {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  min-width: 0;
+  color: inherit;
+  text-decoration: none;
+}
+
+.nb-row-titleblock {
+  display: flex;
+  min-width: 0;
+  flex-direction: column;
+  gap: 7px;
+}
+
+.nb-title {
+  overflow: hidden;
+  font-size: 15px;
+  font-weight: 620;
+  line-height: 1.2;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.nb-title[data-untitled="true"] {
+  color: var(--muted-foreground);
+  font-style: italic;
+  font-weight: 500;
+}
+
+.nb-row-context {
+  overflow: hidden;
+  color: var(--muted-foreground);
+  font-size: 12px;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.nb-subline {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  min-width: 0;
+}
+
+.nb-subline .nb-fp-wrap {
+  width: 132px;
+  flex: 0 0 auto;
+}
+
+.nb-subline .nb-fp {
+  width: 100%;
+  max-width: 200px;
+}
+
+.nb-cellcount {
+  color: var(--muted-foreground);
+  font-size: 12px;
+  white-space: nowrap;
+}
+
+.nb-col {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  min-width: 0;
+  color: var(--muted-foreground);
+  font-size: 12.5px;
+  white-space: nowrap;
+}
+
+.nb-col svg {
+  width: 13px;
+  height: 13px;
+  flex: 0 0 auto;
+  opacity: 0.8;
+}
+
+.nb-col-owner {
+  gap: 7px;
+}
+
+.nb-col-owner-name {
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.nb-col-badges {
+  gap: 8px;
+}
+
+.nb-row-actions,
+.nb-row-rename-actions {
+  display: inline-flex;
+  align-items: center;
+  justify-content: flex-end;
+  gap: 4px;
+}
+
+.nb-row-icon {
+  width: 28px;
+  height: 28px;
+  color: var(--muted-foreground);
+  opacity: 0;
+}
+
+.nb-row:hover .nb-row-icon,
+.nb-row:focus-within .nb-row-icon {
+  opacity: 1;
+}
+
+.nb-open-hint {
+  display: grid;
+  width: 28px;
+  height: 28px;
+  place-items: center;
+  border-radius: 7px;
+  color: var(--muted-foreground);
+  opacity: 0;
+  text-decoration: none;
+  transition:
+    opacity 0.14s ease,
+    background 0.14s ease;
+}
+
+.nb-row:hover .nb-open-hint,
+.nb-row:focus-within .nb-open-hint {
+  opacity: 1;
+  background: var(--muted);
+}
+
+.nb-open-hint svg,
+.nb-row-icon svg {
+  width: 16px;
+  height: 16px;
+}
+
+.nb-row-rename {
+  grid-template-columns: minmax(0, 1fr) auto;
+}
+
+.nb-row-rename input {
+  min-width: 0;
+  background: color-mix(in srgb, var(--background) 96%, var(--foreground) 4%);
+}
+
+.nb-section-footnote {
+  margin: 0;
+  border-bottom: 1px solid var(--border);
+  padding-block: 0.75rem;
+  color: var(--muted-foreground);
+  font-size: 0.75rem;
+  line-height: 1.3;
+}
+
+.nb-section-footnote button {
+  border: 0;
+  padding: 0;
+  color: color-mix(in srgb, var(--foreground) 76%, transparent);
+  background: transparent;
+  cursor: pointer;
+  font: inherit;
+  font-weight: 650;
+  text-decoration: underline;
+  text-underline-offset: 0.15em;
+}
+
+.nb-empty {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  padding: 60px 24px 40px;
+  text-align: center;
+}
+
+.nb-empty-badge {
+  display: grid;
+  width: 60px;
+  height: 60px;
+  place-items: center;
+  margin-bottom: 20px;
+  border: 1px solid var(--border);
+  border-radius: 16px;
+  background: var(--muted);
+  color: var(--foreground);
+}
+
+.nb-empty-badge svg {
+  width: 26px;
+  height: 26px;
+}
+
+.nb-empty h2 {
+  margin: 0 0 8px;
+  font-size: 24px;
+  font-weight: 720;
+}
+
+.nb-empty p {
+  max-width: 44ch;
+  margin: 0 0 24px;
+  color: var(--muted-foreground);
+  font-size: 14.5px;
+  line-height: 1.5;
+}
+
+.nb-overlay {
+  position: fixed;
+  inset: 0;
+  z-index: 60;
+  display: grid;
+  place-items: center;
+  padding: 24px;
+  background: color-mix(in srgb, var(--foreground) 32%, transparent);
+  backdrop-filter: blur(3px);
+}
+
+.nb-dialog {
+  width: min(100%, 540px);
+  overflow: hidden;
+  border: 1px solid var(--border);
+  border-radius: 16px;
+  background: var(--card);
+  color: var(--foreground);
+  box-shadow: 0 24px 60px -12px rgba(0, 0, 0, 0.35);
+}
+
+.nb-dialog-head,
+.nb-dialog-foot {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  padding: 18px 20px;
+}
+
+.nb-dialog-head {
+  border-bottom: 1px solid var(--border);
+}
+
+.nb-dialog-head h2 {
+  margin: 0;
+  font-size: 16.5px;
+  font-weight: 700;
+}
+
+.nb-dialog-x {
+  display: grid;
+  width: 30px;
+  height: 30px;
+  place-items: center;
+  border: 0;
+  border-radius: 8px;
+  color: var(--muted-foreground);
+  background: transparent;
+  cursor: pointer;
+}
+
+.nb-dialog-x:hover {
+  color: var(--foreground);
+  background: var(--muted);
+}
+
+.nb-dialog-x svg {
+  width: 16px;
+  height: 16px;
+}
+
+.nb-dialog-body {
+  display: flex;
+  flex-direction: column;
+  gap: 18px;
+  padding: 20px;
+}
+
+.nb-field {
+  display: flex;
+  flex-direction: column;
+  gap: 7px;
+}
+
+.nb-field label {
+  color: var(--foreground);
+  font-size: 12.5px;
+  font-weight: 650;
+}
+
+.nb-dialog .cloud-notebook-list-banner {
+  border: 1px solid color-mix(in srgb, var(--destructive) 28%, var(--border));
+  border-radius: 8px;
+  padding: 0.625rem 0.75rem;
+}
+
+.nb-dialog-foot {
+  justify-content: flex-end;
+  border-top: 1px solid var(--border);
+  background: color-mix(in srgb, var(--muted) 40%, var(--card));
+}
+
+.cloud-notebook-list-state {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.625rem;
+  width: fit-content;
+  max-width: 100%;
+  margin-top: 2rem;
+  border-top: 1px solid color-mix(in srgb, var(--foreground) 20%, transparent);
+  padding: 0.75rem 1rem;
+  color: color-mix(in srgb, var(--foreground) 68%, transparent);
+  background: color-mix(in srgb, var(--background) 96%, var(--foreground) 4%);
+  font-size: 0.9375rem;
+}
+
+.cloud-notebook-list-state[data-kind="error"] {
+  border-color: color-mix(in srgb, var(--destructive) 54%, transparent);
+  color: var(--destructive);
+  background: color-mix(in srgb, var(--destructive) 6%, var(--background));
+}
+
+.cloud-notebook-list-state svg {
+  width: 1.125rem;
+  height: 1.125rem;
+  flex: 0 0 auto;
 }
 
 .cloud-notebook-signed-out {
@@ -858,10 +1706,9 @@ body {
   align-items: end;
   gap: clamp(1.5rem, 5vw, 4rem);
   width: min(100%, 70rem);
-  justify-self: center;
   border-top: 1px solid color-mix(in srgb, var(--foreground) 18%, transparent);
   border-bottom: 1px solid color-mix(in srgb, var(--foreground) 10%, transparent);
-  padding-block: clamp(2rem, 8vw, 5rem);
+  padding: clamp(2rem, 8vw, 5rem) 28px;
 }
 
 .cloud-notebook-signed-out-copy {
@@ -875,17 +1722,11 @@ body {
   align-items: center;
   gap: 0.5rem;
   width: fit-content;
-  color: color-mix(in srgb, #0f766e 78%, var(--foreground));
+  color: color-mix(in srgb, var(--live-ink) 78%, var(--foreground));
   font-size: 0.75rem;
   font-weight: 760;
-  letter-spacing: 0;
   line-height: 1.2;
   text-transform: uppercase;
-}
-
-.cloud-notebook-signed-out-kicker svg {
-  width: 1rem;
-  height: 1rem;
 }
 
 .cloud-notebook-signed-out h2,
@@ -897,7 +1738,6 @@ body {
   max-width: 14ch;
   font-size: clamp(2.25rem, 8vw, 5rem);
   font-weight: 780;
-  letter-spacing: 0;
   line-height: 0.95;
 }
 
@@ -936,539 +1776,70 @@ body {
   background: var(--foreground);
 }
 
-.cloud-notebook-signed-out-actions .cloud-sign-in-button:hover {
-  background: color-mix(in srgb, var(--foreground) 88%, var(--background));
-}
-
 .cloud-notebook-signed-out-actions a {
   color: var(--foreground);
   background: color-mix(in srgb, var(--background) 94%, var(--foreground) 6%);
 }
 
-.cloud-notebook-signed-out-actions a:hover {
-  background: color-mix(in srgb, var(--background) 86%, var(--foreground) 10%);
-}
-
-.cloud-notebook-signed-out-actions svg {
-  width: 1rem;
-  height: 1rem;
-  flex: 0 0 auto;
-}
-
-.cloud-dashboard {
-  display: grid;
-  gap: 1.125rem;
-  width: min(100%, 78rem);
-  justify-self: center;
-}
-
-.cloud-dashboard-switcher {
-  display: grid;
-  grid-template-columns: minmax(0, 1fr);
-  gap: 1rem;
-  align-items: start;
-}
-
-.cloud-dashboard-main {
-  min-width: 0;
-}
-
-.cloud-dashboard-main {
-  display: grid;
-  gap: 0.875rem;
-}
-
-.cloud-dashboard-search-row {
-  display: grid;
-  grid-template-columns: minmax(0, 1fr) auto;
-  gap: 0.75rem;
-  align-items: center;
-}
-
-.cloud-dashboard-search {
-  display: grid;
-  grid-template-columns: auto minmax(0, 1fr);
-  align-items: center;
-  gap: 0.625rem;
-  min-height: 2.75rem;
-  border: 1px solid color-mix(in srgb, var(--foreground) 16%, transparent);
-  border-radius: 8px;
-  padding-inline: 0.875rem;
-  background: color-mix(in srgb, var(--background) 97%, var(--foreground) 3%);
-}
-
-.cloud-dashboard-search:focus-within {
-  border-color: color-mix(in srgb, #0f766e 52%, transparent);
-  box-shadow: 0 0 0 2px color-mix(in srgb, #0f766e 16%, transparent);
-}
-
-.cloud-dashboard-search svg {
-  width: 1rem;
-  height: 1rem;
-  color: color-mix(in srgb, var(--foreground) 60%, transparent);
-}
-
-.cloud-dashboard-search input {
-  min-width: 0;
-  border: 0;
-  color: var(--foreground);
-  background: transparent;
-  font: inherit;
-  font-size: 0.9375rem;
-}
-
-.cloud-dashboard-search input:focus {
-  outline: none;
-}
-
-.cloud-dashboard-search input::placeholder {
-  color: color-mix(in srgb, var(--foreground) 46%, transparent);
-}
-
-.cloud-dashboard-result-count {
-  color: color-mix(in srgb, var(--foreground) 64%, transparent);
-  font-size: 0.8125rem;
-  white-space: nowrap;
-}
-
-.cloud-dashboard-filters {
-  display: flex;
-  flex-wrap: wrap;
-  gap: 0.5rem 0.875rem;
-  align-items: center;
-}
-
-.cloud-dashboard-filter-group {
-  display: flex;
-  flex-wrap: wrap;
-  gap: 0.375rem;
-  min-width: 0;
-}
-
-.cloud-dashboard-filter-group[data-group="cleanup"] {
-  gap: 0.25rem;
-}
-
-.cloud-dashboard-filters button {
-  display: inline-flex;
-  align-items: center;
-  min-height: 2rem;
-  border: 1px solid transparent;
-  border-radius: 6px;
-  padding-inline: 0.625rem;
-  color: color-mix(in srgb, var(--foreground) 68%, transparent);
-  background: transparent;
-  cursor: pointer;
-  font: inherit;
-  font-size: 0.8125rem;
-}
-
-.cloud-dashboard-filters button:hover,
-.cloud-dashboard-filters button[data-active="true"] {
-  border-color: color-mix(in srgb, var(--foreground) 12%, transparent);
-  color: var(--foreground);
-  background: color-mix(in srgb, var(--foreground) 6%, transparent);
-}
-
-.cloud-dashboard-filter-group[data-group="cleanup"] button {
-  color: color-mix(in srgb, var(--foreground) 64%, transparent);
-  font-size: 0.75rem;
-  min-height: 1.75rem;
-  padding-inline: 0.5rem;
-}
-
-.cloud-dashboard-filter-group[data-group="cleanup"] button[data-active="true"] {
-  color: var(--foreground);
-}
-
-.cloud-dashboard-continue {
-  display: grid;
-  grid-template-columns: minmax(0, 1fr) auto;
-  align-items: center;
-  gap: 1rem;
-  border-top: 1px solid color-mix(in srgb, var(--foreground) 14%, transparent);
-  border-bottom: 1px solid color-mix(in srgb, var(--foreground) 10%, transparent);
-  padding-block: 0.875rem;
-}
-
-.cloud-dashboard-continue-main {
-  display: grid;
-  min-width: 0;
-  gap: 0.375rem;
-}
-
-.cloud-dashboard-continue-main p,
-.cloud-dashboard-continue h2 {
-  margin: 0;
-}
-
-.cloud-dashboard-continue-main p {
-  color: color-mix(in srgb, var(--foreground) 64%, transparent);
-  font-size: 0.6875rem;
-  font-weight: 700;
-  letter-spacing: 0;
-  line-height: 1.25;
-  text-transform: uppercase;
-}
-
-.cloud-dashboard-continue h2 {
-  overflow: hidden;
-  text-overflow: ellipsis;
-  white-space: nowrap;
-  font-size: 1.0625rem;
-  font-weight: 720;
-  line-height: 1.15;
-}
-
-.cloud-dashboard-continue-facts,
-.cloud-notebook-list-row-facts {
-  display: flex;
-  flex-wrap: wrap;
-  gap: 0.375rem 0.875rem;
-  color: color-mix(in srgb, var(--foreground) 64%, transparent);
-  font-size: 0.75rem;
-}
-
-.cloud-dashboard-continue-facts span,
-.cloud-notebook-list-row-facts span {
-  display: inline-flex;
-  align-items: center;
-  gap: 0.375rem;
-}
-
-.cloud-dashboard-continue-facts svg,
-.cloud-notebook-list-row-facts svg {
-  width: 0.875rem;
-  height: 0.875rem;
-  flex: 0 0 auto;
-}
-
-.cloud-dashboard-primary-link {
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  gap: 0.375rem;
-  min-height: 2.25rem;
-  border-radius: 6px;
-  padding-inline: 0.875rem;
-  color: var(--background);
-  background: var(--foreground);
-  font-size: 0.875rem;
-  font-weight: 650;
-  text-decoration: none;
-}
-
-.cloud-dashboard-primary-link svg {
-  width: 0.9375rem;
-  height: 0.9375rem;
-}
-
-.cloud-dashboard-notebooks {
-  display: grid;
-  gap: 1.25rem;
-  min-width: 0;
-}
-
-.cloud-dashboard-notebook-section {
-  min-width: 0;
-}
-
-.cloud-dashboard-notebook-section[data-section="untitled"] {
-  color: color-mix(in srgb, var(--foreground) 86%, transparent);
-}
-
-.cloud-dashboard-section-heading {
-  display: grid;
-  grid-template-columns: minmax(0, 1fr) auto;
-  align-items: end;
-  justify-content: space-between;
-  gap: 1rem;
-  border-bottom: 1px solid color-mix(in srgb, var(--foreground) 14%, transparent);
-  padding-bottom: 0.5rem;
-  margin-bottom: 0;
-}
-
-.cloud-dashboard-section-heading > div {
-  display: flex;
-  flex-wrap: wrap;
-  align-items: baseline;
-  gap: 0.375rem 0.625rem;
-  min-width: 0;
-}
-
-.cloud-dashboard-section-heading h2,
-.cloud-dashboard-section-heading p {
-  margin: 0;
-}
-
-.cloud-dashboard-section-heading h2 {
-  color: color-mix(in srgb, var(--foreground) 58%, transparent);
-  font-size: 0.75rem;
-  font-weight: 700;
-  letter-spacing: 0;
-  line-height: 1.25;
-  text-transform: uppercase;
-}
-
-.cloud-dashboard-section-heading p {
-  color: color-mix(in srgb, var(--foreground) 64%, transparent);
-  font-size: 0.75rem;
-  line-height: 1.25;
-}
-
-.cloud-dashboard-section-action {
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  gap: 0.375rem;
-  min-height: 2rem;
-  border: 0;
-  border-radius: 6px;
-  padding-inline: 0.625rem;
-  color: color-mix(in srgb, var(--foreground) 64%, transparent);
-  background: transparent;
-  cursor: pointer;
-  font: inherit;
-  font-size: 0.8125rem;
-  font-weight: 650;
-  white-space: nowrap;
-}
-
-.cloud-dashboard-section-action:hover {
-  color: var(--foreground);
-  background: color-mix(in srgb, var(--foreground) 7%, transparent);
-}
-
-.cloud-dashboard-section-action svg {
-  width: 0.9375rem;
-  height: 0.9375rem;
-}
-
-.cloud-dashboard-notebook-section[data-section="untitled"] .cloud-dashboard-section-heading h2 {
-  color: color-mix(in srgb, var(--foreground) 62%, transparent);
-}
-
-.cloud-notebook-list {
-  display: grid;
-  margin: 0;
-  padding: 0;
-  list-style: none;
-}
-
-.cloud-dashboard-section-footnote {
-  margin: 0;
-  border-bottom: 1px solid var(--border);
-  padding-block: 0.75rem;
-  color: color-mix(in srgb, var(--foreground) 64%, transparent);
-  font-size: 0.75rem;
-  line-height: 1.3;
-}
-
-.cloud-dashboard-section-footnote button {
-  border: 0;
-  padding: 0;
-  color: color-mix(in srgb, var(--foreground) 76%, transparent);
-  background: transparent;
-  cursor: pointer;
-  font: inherit;
-  font-weight: 650;
-  text-decoration: underline;
-  text-underline-offset: 0.15em;
-}
-
-.cloud-dashboard-section-footnote button:hover {
-  color: var(--foreground);
-}
-
-.cloud-notebook-list-row {
-  display: grid;
-  grid-template-columns: minmax(0, 1fr) minmax(10rem, auto) auto;
-  align-items: center;
-  gap: 1rem;
-  min-height: 4.75rem;
-  border-bottom: 1px solid var(--border);
-  color: var(--foreground);
-}
-
-.cloud-notebook-list-row:hover {
-  background: color-mix(in srgb, var(--background) 94%, var(--foreground) 5%);
-}
-
-.cloud-notebook-list-updated svg {
-  width: 1rem;
-  height: 1rem;
-}
-
-.cloud-notebook-list-main {
-  display: grid;
-  min-width: 0;
-  gap: 0.1875rem;
-  color: inherit;
-  text-decoration: none;
-}
-
-.cloud-notebook-list-title,
-.cloud-notebook-list-detail {
-  min-width: 0;
-  overflow: hidden;
-  text-overflow: ellipsis;
-  white-space: nowrap;
-}
-
-.cloud-notebook-list-title {
-  font-size: 0.9375rem;
-  font-weight: 650;
-  line-height: 1.2;
-}
-
-.cloud-notebook-list-detail {
-  color: color-mix(in srgb, var(--foreground) 64%, transparent);
-  font-size: 0.75rem;
-  line-height: 1.2;
-}
-
-.cloud-notebook-list-row-facts [data-state="published"] {
-  color: color-mix(in srgb, #0f766e 84%, var(--foreground));
-}
-
-.cloud-dashboard-continue-facts [data-state="active"],
-.cloud-notebook-list-row-facts [data-state="active"] {
-  color: color-mix(in srgb, #0f766e 82%, var(--foreground));
-}
-
-.cloud-dashboard-continue-facts [data-state="starting"],
-.cloud-notebook-list-row-facts [data-state="starting"] {
-  color: color-mix(in srgb, #0369a1 82%, var(--foreground));
-}
-
-.cloud-dashboard-continue-facts [data-state="stale"],
-.cloud-notebook-list-row-facts [data-state="stale"] {
-  color: color-mix(in srgb, var(--foreground) 58%, transparent);
-}
-
-.cloud-dashboard-continue-facts [data-state="error"],
-.cloud-notebook-list-row-facts [data-state="error"] {
-  color: color-mix(in srgb, #b42318 86%, var(--foreground));
-}
-
-.cloud-notebook-list-updated {
-  display: inline-flex;
-  align-items: center;
-  justify-content: flex-end;
-  gap: 0.375rem;
-  color: color-mix(in srgb, var(--foreground) 64%, transparent);
-  font-size: 0.8125rem;
-  white-space: nowrap;
-}
-
-.cloud-notebook-list-row-actions {
-  display: inline-flex;
-  align-items: center;
-  justify-content: flex-end;
-  gap: 0.25rem;
-}
-
-.cloud-notebook-list-icon-button,
-.cloud-notebook-list-rename-form button {
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  width: 2rem;
-  height: 2rem;
-  border: 0;
-  border-radius: 6px;
-  color: color-mix(in srgb, var(--foreground) 54%, transparent);
-  background: transparent;
-  cursor: pointer;
-  text-decoration: none;
-}
-
-.cloud-notebook-list-icon-button:hover,
-.cloud-notebook-list-rename-form button:hover {
-  color: var(--foreground);
-  background: color-mix(in srgb, var(--foreground) 8%, transparent);
-}
-
-.cloud-notebook-list-icon-button:disabled,
-.cloud-notebook-list-rename-form button:disabled {
-  cursor: default;
-  opacity: 0.58;
-}
-
-.cloud-notebook-list-icon-button svg,
-.cloud-notebook-list-rename-form button svg {
-  width: 1rem;
-  height: 1rem;
-}
-
-.cloud-notebook-list-rename-form {
-  display: grid;
-  grid-template-columns: minmax(0, 1fr) auto auto;
-  align-items: center;
-  gap: 0.375rem;
-  min-height: 4.75rem;
-  border-bottom: 1px solid var(--border);
-}
-
-.cloud-notebook-list-rename-form input {
-  min-width: 0;
-  height: 2.25rem;
-  border: 1px solid var(--border);
-  border-radius: 6px;
-  padding-inline: 0.625rem;
-  color: var(--foreground);
-  background: color-mix(in srgb, var(--background) 96%, var(--foreground) 4%);
-  font: inherit;
-}
-
-.cloud-notebook-list-rename-form input:focus {
-  outline: 2px solid color-mix(in srgb, #0f766e 42%, transparent);
-  outline-offset: 1px;
-}
-
-.cloud-notebook-list-state {
-  display: inline-flex;
-  align-items: center;
-  gap: 0.625rem;
-  width: fit-content;
-  max-width: 100%;
-  border-top: 1px solid color-mix(in srgb, var(--foreground) 20%, transparent);
-  padding: 0.75rem 1rem;
-  color: color-mix(in srgb, var(--foreground) 68%, transparent);
-  background: color-mix(in srgb, var(--background) 96%, var(--foreground) 4%);
-  font-size: 0.9375rem;
-}
-
-.cloud-notebook-list-state[data-kind="error"] {
-  border-color: color-mix(in srgb, #b42318 54%, transparent);
-  color: #b42318;
-  background: color-mix(in srgb, #b42318 6%, var(--background));
-}
-
-.cloud-notebook-list-state svg {
-  width: 1.125rem;
-  height: 1.125rem;
-  flex: 0 0 auto;
-}
-
-@media (max-width: 780px) {
-  .cloud-notebook-list-header {
-    align-items: start;
-    flex-direction: column;
+@media (max-width: 860px) {
+  .nb-header-inner {
+    flex-wrap: wrap;
+    gap: 12px;
+    padding: 12px 18px;
   }
 
-  .cloud-notebook-list-actions {
-    justify-content: flex-start;
+  .nb-search {
+    order: 3;
+    width: 100%;
+    max-width: none;
+  }
+
+  .nb-header-spacer {
+    display: none;
+  }
+
+  .nb-header-actions {
+    margin-left: auto;
+  }
+
+  .nb-hero-top {
+    grid-template-columns: minmax(0, 1fr);
+  }
+
+  .nb-hero-side {
+    flex-direction: row;
+  }
+
+  .nb-row {
+    grid-template-columns: minmax(0, 1fr) auto;
+    min-height: 4.5rem;
+    gap: 0.5rem 0.75rem;
+    padding-block: 0.625rem;
+  }
+
+  .nb-col-owner,
+  .nb-col-badges {
+    display: none;
+  }
+
+  .nb-col-updated {
+    grid-column: 1 / -1;
+    justify-self: start;
+  }
+
+  .nb-row-actions {
+    grid-column: 2;
+    grid-row: 1;
+  }
+
+  .nb-subline {
+    display: none;
   }
 
   .cloud-notebook-signed-out {
     grid-template-columns: minmax(0, 1fr);
     align-items: start;
     padding-block: 2rem;
-  }
-
-  .cloud-notebook-signed-out h2 {
-    max-width: 12ch;
   }
 
   .cloud-notebook-signed-out-actions {
@@ -1478,54 +1849,6 @@ body {
   .cloud-notebook-signed-out-actions .cloud-sign-in-button,
   .cloud-notebook-signed-out-actions a {
     width: 100%;
-  }
-
-  .cloud-new-notebook-form {
-    grid-template-columns: minmax(0, 1fr) auto auto;
-  }
-
-  .cloud-new-notebook-form label {
-    grid-column: 1 / -1;
-  }
-
-  .cloud-dashboard-switcher,
-  .cloud-dashboard-search-row {
-    grid-template-columns: minmax(0, 1fr);
-  }
-
-  .cloud-dashboard-continue {
-    grid-template-columns: minmax(0, 1fr);
-  }
-
-  .cloud-dashboard-primary-link {
-    width: fit-content;
-  }
-
-  .cloud-notebook-list-row {
-    grid-template-columns: minmax(0, 1fr) auto;
-    min-height: 4.5rem;
-    gap: 0.5rem 0.75rem;
-    padding-block: 0.625rem;
-  }
-
-  .cloud-notebook-list-updated {
-    grid-column: 1 / -1;
-    justify-self: start;
-  }
-
-  .cloud-notebook-list-updated {
-    margin-top: -0.25rem;
-  }
-
-  .cloud-notebook-list-row-actions {
-    grid-column: 2;
-    grid-row: 1;
-  }
-
-  .cloud-notebook-list-rename-form {
-    grid-template-columns: minmax(0, 1fr) auto auto;
-    min-height: 4.5rem;
-    padding-block: 0.625rem;
   }
 }
 

--- a/apps/notebook-cloud/viewer/notebook-dashboard.ts
+++ b/apps/notebook-cloud/viewer/notebook-dashboard.ts
@@ -14,6 +14,7 @@ export interface CloudNotebookListItem {
   updated_at: string;
   latest_revision_id: string | null;
   compute_session?: NotebookComputeSessionSummary | null;
+  composition?: CloudNotebookComposition;
   viewer_url: string;
   endpoints: {
     catalog: string;
@@ -21,6 +22,20 @@ export interface CloudNotebookListItem {
     access_requests: string;
   };
 }
+
+export interface CloudNotebookComposition {
+  code: number;
+  markdown: number;
+  raw: number;
+}
+
+export type CloudNotebookDashboardRuntimeStatus =
+  | "executing"
+  | "ready"
+  | "starting"
+  | "stale"
+  | "error"
+  | "none";
 
 export type CloudNotebookDashboardFilterId =
   | "all"
@@ -66,10 +81,15 @@ export interface CloudNotebookDashboardSection {
 }
 
 export interface CloudNotebookDashboardRow {
+  composition?: CloudNotebookComposition;
   contextLabel: string | null;
+  environmentLabel?: string;
   facts: readonly CloudNotebookDashboardRowFact[];
   identityLabel: string | null;
   notebook: CloudNotebookListItem;
+  ownerInitials: string;
+  ownerLabel: string;
+  runtimeStatus: CloudNotebookDashboardRuntimeStatus;
 }
 
 export interface CloudNotebookDashboardRowFact {
@@ -246,6 +266,7 @@ export function isCloudNotebookListItem(value: unknown): value is CloudNotebookL
     (candidate.compute_session === undefined ||
       candidate.compute_session === null ||
       isNotebookComputeSessionSummary(candidate.compute_session)) &&
+    (candidate.composition === undefined || isCloudNotebookComposition(candidate.composition)) &&
     typeof candidate.viewer_url === "string" &&
     Boolean(candidate.endpoints) &&
     typeof candidate.endpoints?.catalog === "string" &&
@@ -578,14 +599,41 @@ function dashboardRow(notebook: CloudNotebookListItem | null): CloudNotebookDash
   if (!notebook) {
     return null;
   }
+  const ownerLabel = cloudNotebookOwnerLabel(notebook.owner_principal);
   return {
+    ...(notebook.composition ? { composition: notebook.composition } : {}),
     contextLabel: cloudNotebookDashboardRowContextLabel(notebook),
+    ...(notebook.compute_session?.environment_label
+      ? { environmentLabel: notebook.compute_session.environment_label }
+      : {}),
     facts: Object.freeze(cloudNotebookDashboardRowFacts(notebook)),
     identityLabel: cloudNotebookHasTitle(notebook)
       ? null
       : cloudNotebookShortId(notebook.notebook_id),
     notebook,
+    ownerInitials: cloudNotebookOwnerInitials(ownerLabel),
+    ownerLabel,
+    runtimeStatus: cloudNotebookDashboardRuntimeStatus(notebook),
   };
+}
+
+export function cloudNotebookDashboardRuntimeStatus(
+  notebook: CloudNotebookListItem,
+): CloudNotebookDashboardRuntimeStatus {
+  const session = notebook.compute_session;
+  if (!session) {
+    return "none";
+  }
+  switch (session.status) {
+    case "starting":
+      return "starting";
+    case "stale":
+      return "stale";
+    case "error":
+      return "error";
+    case "active":
+      return session.queue_depth > 0 ? "executing" : "ready";
+  }
 }
 
 function cloudNotebookDashboardRowContextLabel(notebook: CloudNotebookListItem): string | null {
@@ -650,6 +698,48 @@ function cloudNotebookIsGeneratedRun(notebook: CloudNotebookListItem): boolean {
 
 function cloudNotebookHasComputeSession(notebook: CloudNotebookListItem): boolean {
   return Boolean(notebook.compute_session);
+}
+
+function isCloudNotebookComposition(value: unknown): value is CloudNotebookComposition {
+  if (!value || typeof value !== "object") {
+    return false;
+  }
+  const candidate = value as Partial<CloudNotebookComposition>;
+  return (
+    isNonNegativeFiniteNumber(candidate.code) &&
+    isNonNegativeFiniteNumber(candidate.markdown) &&
+    isNonNegativeFiniteNumber(candidate.raw)
+  );
+}
+
+function isNonNegativeFiniteNumber(value: unknown): value is number {
+  return typeof value === "number" && Number.isFinite(value) && value >= 0;
+}
+
+function cloudNotebookOwnerLabel(principal: string): string {
+  const trimmed = principal.trim();
+  if (!trimmed) {
+    return "Unknown";
+  }
+  const emailLocal = trimmed.match(/([^:@\s]+)@[^@\s]+$/u)?.[1];
+  if (emailLocal) {
+    return emailLocal;
+  }
+  const parts = trimmed.split(":").filter(Boolean);
+  return parts.at(-1) ?? trimmed;
+}
+
+function cloudNotebookOwnerInitials(label: string): string {
+  const normalized = label
+    .replace(/[_+.-]+/gu, " ")
+    .trim()
+    .split(/\s+/u)
+    .filter(Boolean);
+  const initials =
+    normalized.length >= 2
+      ? `${normalized[0]?.[0] ?? ""}${normalized[1]?.[0] ?? ""}`
+      : (normalized[0]?.slice(0, 2) ?? label.slice(0, 2));
+  return initials.toUpperCase() || "??";
 }
 
 function cloudNotebookMatchesFilter(

--- a/apps/notebook-cloud/viewer/notebook-list-view.tsx
+++ b/apps/notebook-cloud/viewer/notebook-list-view.tsx
@@ -1,14 +1,18 @@
-import { useCallback, useEffect, useMemo, useState, type FormEvent } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState, type FormEvent } from "react";
 import {
   AlertCircle,
   ArrowUpRight,
   BookOpen,
-  FilePlus2,
   Loader2,
   LogOut,
+  Plus,
   RotateCcw,
+  Search,
   Sparkles,
+  X,
 } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
 import { useTheme } from "@/hooks/useTheme";
 import {
   clearCloudPrototypeDevAuth,
@@ -17,7 +21,10 @@ import {
 } from "./collaborator-auth";
 import { cloudResponseError } from "./cloud-response";
 import { clearCloudAppSession, establishCloudAppSession } from "./app-session";
-import { CloudNotebookDashboard } from "./cloud-notebook-dashboard-view";
+import {
+  CloudNotebookDashboard,
+  CloudNotebookDashboardSearchInput,
+} from "./cloud-notebook-dashboard-view";
 import { projectHostedCatalogAuthState } from "./hosted-catalog-auth";
 import { loadCloudNotebookListBootstrap } from "./cloud-viewer-config";
 import type { CloudAppSession } from "./app-session";
@@ -74,6 +81,7 @@ export function CloudNotebookListView({ authConfig }: { authConfig: CloudViewerA
   const [createError, setCreateError] = useState<string | null>(null);
   const [createFormOpen, setCreateFormOpen] = useState(false);
   const [createTitle, setCreateTitle] = useState(() => defaultCloudNotebookTitle());
+  const [dashboardQuery, setDashboardQuery] = useState("");
   const [renameState, setRenameState] = useState<CloudNotebookRenameState | null>(null);
   const [renameSavingId, setRenameSavingId] = useState<string | null>(null);
   const [renameError, setRenameError] = useState<string | null>(null);
@@ -309,6 +317,7 @@ export function CloudNotebookListView({ authConfig }: { authConfig: CloudViewerA
 
   const signOut = () => {
     setBootstrap(null);
+    setDashboardQuery("");
     appSessionStatus.clearAppSessionStatus();
     clearCachedCloudNotebookListFromWindow();
     void clearCloudAppSession()
@@ -321,36 +330,59 @@ export function CloudNotebookListView({ authConfig }: { authConfig: CloudViewerA
   };
 
   const headerDetail = cloudNotebookListHeaderDetail(authState, hasAppSession, authConfig);
+  const currentUserInitials = cloudNotebookListCurrentUserInitials(authState);
 
   return (
-    <main className="cloud-notebook-list-page">
-      <header className="cloud-notebook-list-header">
-        <div>
-          <a className="cloud-notebook-list-brand" href="/n">
-            nteract
+    <main className="cloud-notebook-list-page nb-app">
+      <header className="nb-header">
+        <div className="nb-header-inner">
+          <a className="nb-brand" href="/n">
+            <span className="nb-brand-mark" aria-hidden="true" />
+            <span className="nb-brand-name">nteract</span>
+            <span className="nb-brand-sep">/</span>
+            <span className="nb-brand-scope">{headerDetail}</span>
           </a>
-          <h1>Notebooks</h1>
-          <p>{headerDetail}</p>
-        </div>
-        <div className="cloud-notebook-list-actions">
+          <span className="nb-header-spacer" />
           {signedIn ? (
             <>
-              <button type="button" disabled={listState.kind === "loading"} onClick={refreshList}>
-                <RotateCcw aria-hidden="true" />
-                Refresh
-              </button>
-              <button type="button" disabled={createState === "starting"} onClick={openCreateForm}>
-                {createState === "starting" ? (
-                  <Loader2 className="cloud-home-status-spinner" aria-hidden="true" />
-                ) : (
-                  <FilePlus2 aria-hidden="true" />
-                )}
-                {createState === "starting" ? "Creating" : "New notebook"}
-              </button>
-              <button type="button" onClick={signOut}>
-                <LogOut aria-hidden="true" />
-                Sign out
-              </button>
+              <label className="nb-search">
+                <Search aria-hidden="true" />
+                <CloudNotebookDashboardSearchInput
+                  query={dashboardQuery}
+                  disabled={listState.kind !== "ready"}
+                  onQueryChange={setDashboardQuery}
+                />
+              </label>
+              <div className="nb-header-actions">
+                <Button
+                  type="button"
+                  variant="outline"
+                  disabled={listState.kind === "loading"}
+                  onClick={refreshList}
+                >
+                  <RotateCcw aria-hidden="true" />
+                  Refresh
+                </Button>
+                <Button
+                  type="button"
+                  disabled={createState === "starting"}
+                  onClick={openCreateForm}
+                >
+                  {createState === "starting" ? (
+                    <Loader2 className="cloud-home-status-spinner" aria-hidden="true" />
+                  ) : (
+                    <Plus aria-hidden="true" />
+                  )}
+                  {createState === "starting" ? "Creating" : "New notebook"}
+                </Button>
+                <Button type="button" variant="ghost" onClick={signOut}>
+                  <LogOut aria-hidden="true" />
+                  Sign out
+                </Button>
+                <span className="nb-avatar-me" title={headerDetail}>
+                  {currentUserInitials}
+                </span>
+              </div>
             </>
           ) : null}
         </div>
@@ -365,39 +397,20 @@ export function CloudNotebookListView({ authConfig }: { authConfig: CloudViewerA
           {authRenewal.message}
         </div>
       ) : null}
-      {createError ? (
-        <div className="cloud-notebook-list-banner" data-kind="error" role="alert">
-          {createError}
-        </div>
-      ) : null}
       {renameError ? (
         <div className="cloud-notebook-list-banner" data-kind="error" role="alert">
           {renameError}
         </div>
       ) : null}
       {createFormOpen ? (
-        <form className="cloud-new-notebook-form" onSubmit={createNotebook}>
-          <label htmlFor="cloud-new-notebook-title">Notebook title</label>
-          <input
-            id="cloud-new-notebook-title"
-            type="text"
-            value={createTitle}
-            maxLength={160}
-            disabled={createState === "starting"}
-            onChange={(event) => setCreateTitle(event.currentTarget.value)}
-          />
-          <button type="submit" disabled={createState === "starting"}>
-            {createState === "starting" ? (
-              <Loader2 className="cloud-home-status-spinner" aria-hidden="true" />
-            ) : (
-              <FilePlus2 aria-hidden="true" />
-            )}
-            Create
-          </button>
-          <button type="button" disabled={createState === "starting"} onClick={closeCreateForm}>
-            Cancel
-          </button>
-        </form>
+        <CloudNotebookCreateDialog
+          title={createTitle}
+          createState={createState}
+          error={createError}
+          onClose={closeCreateForm}
+          onCreate={createNotebook}
+          onTitleChange={setCreateTitle}
+        />
       ) : null}
 
       <section className="cloud-notebook-list-content" aria-label="Notebook list">
@@ -414,19 +427,18 @@ export function CloudNotebookListView({ authConfig }: { authConfig: CloudViewerA
             <span>{listState.message}</span>
           </div>
         ) : listState.notebooks.length === 0 ? (
-          <div className="cloud-notebook-list-state" data-kind="empty">
-            <BookOpen aria-hidden="true" />
-            <span>No notebooks yet.</span>
-          </div>
+          <CloudNotebookListEmptyState signedIn={signedIn} onNewNotebook={openCreateForm} />
         ) : dashboardModel ? (
           <CloudNotebookDashboard
             model={dashboardModel}
             canRename={signedIn}
+            query={dashboardQuery}
             renameState={renameState}
             renameSavingId={renameSavingId}
             onOpenNotebookIntent={preloadNotebookRoute}
             onOpenRename={openRenameForm}
             onCancelRename={closeRenameForm}
+            onQueryChange={setDashboardQuery}
             onRenameTitleChange={(title) =>
               setRenameState((current) => (current ? { ...current, title } : current))
             }
@@ -478,6 +490,126 @@ function CloudNotebookSignedOutPanel({
   );
 }
 
+function CloudNotebookCreateDialog({
+  title,
+  createState,
+  error,
+  onClose,
+  onCreate,
+  onTitleChange,
+}: {
+  title: string;
+  createState: "idle" | "starting";
+  error: string | null;
+  onClose: () => void;
+  onCreate: (event: FormEvent<HTMLFormElement>) => void;
+  onTitleChange: (title: string) => void;
+}) {
+  const inputRef = useRef<HTMLInputElement>(null);
+
+  useEffect(() => {
+    inputRef.current?.focus();
+  }, []);
+
+  useEffect(() => {
+    const onKeyDown = (event: KeyboardEvent) => {
+      if (event.key === "Escape") {
+        onClose();
+      }
+    };
+    window.addEventListener("keydown", onKeyDown);
+    return () => window.removeEventListener("keydown", onKeyDown);
+  }, [onClose]);
+
+  return (
+    <div className="nb-overlay" onMouseDown={onClose}>
+      <form
+        className="nb-dialog"
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby="cloud-new-notebook-dialog-title"
+        onMouseDown={(event) => event.stopPropagation()}
+        onSubmit={onCreate}
+      >
+        <div className="nb-dialog-head">
+          <h2 id="cloud-new-notebook-dialog-title">New notebook</h2>
+          <button
+            type="button"
+            className="nb-dialog-x"
+            disabled={createState === "starting"}
+            aria-label="Close"
+            onClick={onClose}
+          >
+            <X aria-hidden="true" />
+          </button>
+        </div>
+        <div className="nb-dialog-body">
+          <div className="nb-field">
+            <label htmlFor="cloud-new-notebook-title">Title</label>
+            <Input
+              ref={inputRef}
+              id="cloud-new-notebook-title"
+              type="text"
+              value={title}
+              maxLength={160}
+              disabled={createState === "starting"}
+              placeholder="Untitled notebook"
+              onChange={(event) => onTitleChange(event.currentTarget.value)}
+            />
+          </div>
+          {error ? (
+            <div className="cloud-notebook-list-banner" data-kind="error" role="alert">
+              {error}
+            </div>
+          ) : null}
+        </div>
+        <div className="nb-dialog-foot">
+          <Button
+            type="button"
+            variant="ghost"
+            disabled={createState === "starting"}
+            onClick={onClose}
+          >
+            Cancel
+          </Button>
+          <Button type="submit" disabled={createState === "starting"}>
+            {createState === "starting" ? (
+              <Loader2 className="cloud-home-status-spinner" aria-hidden="true" />
+            ) : (
+              <Plus aria-hidden="true" />
+            )}
+            {createState === "starting" ? "Creating" : "Create"}
+          </Button>
+        </div>
+      </form>
+    </div>
+  );
+}
+
+function CloudNotebookListEmptyState({
+  signedIn,
+  onNewNotebook,
+}: {
+  signedIn: boolean;
+  onNewNotebook: () => void;
+}) {
+  return (
+    <div className="nb-empty">
+      <span className="nb-empty-badge">
+        <BookOpen aria-hidden="true" />
+      </span>
+      <h2>No notebooks yet</h2>
+      <p>Create a notebook to start working with a live document and attach compute when needed.</p>
+      {signedIn ? (
+        <Button type="button" onClick={onNewNotebook}>
+          <Plus aria-hidden="true" />
+          New notebook
+        </Button>
+      ) : null}
+    </div>
+  );
+}
+
 function cloudNotebookListHeaderDetail(
   authState: CloudPrototypeAuthState,
   hasAppSession: boolean,
@@ -494,6 +626,24 @@ function cloudNotebookListHeaderDetail(
   }
   const firstName = cloudNotebookListFirstName(authState);
   return firstName ? `by ${firstName}` : "Signed in";
+}
+
+function cloudNotebookListCurrentUserInitials(authState: CloudPrototypeAuthState): string {
+  const label =
+    authState.oidcClaims?.name?.trim() ||
+    authState.oidcClaims?.email?.trim() ||
+    (authState.mode === "dev" ? authState.user?.trim() : "") ||
+    "You";
+  const parts = label
+    .replace(/[_+.-]+/gu, " ")
+    .trim()
+    .split(/\s+/u)
+    .filter(Boolean);
+  const initials =
+    parts.length >= 2
+      ? `${parts[0]?.[0] ?? ""}${parts[1]?.[0] ?? ""}`
+      : (parts[0]?.slice(0, 2) ?? "YO");
+  return initials.toUpperCase();
 }
 
 function cloudNotebookListFirstName(authState: CloudPrototypeAuthState): string | null {

--- a/src/components/notebook/NotebookCompositionTicks.tsx
+++ b/src/components/notebook/NotebookCompositionTicks.tsx
@@ -1,0 +1,124 @@
+import type { CSSProperties } from "react";
+
+export interface NotebookComposition {
+  code: number;
+  markdown: number;
+  raw: number;
+}
+
+export interface NotebookCompositionTicksProps {
+  composition: NotebookComposition;
+  maxTicks?: number;
+  className?: string;
+}
+
+type NotebookCellType = keyof NotebookComposition;
+
+const CELL_TYPES: NotebookCellType[] = ["code", "markdown", "raw"];
+const CELL_LABEL: Record<NotebookCellType, string> = {
+  code: "Code",
+  markdown: "Markdown",
+  raw: "Raw",
+};
+
+/**
+ * Renders the current notebook cell-type composition as capped visual state,
+ * not as an edit-history timeline.
+ */
+export function NotebookCompositionTicks({
+  composition,
+  maxTicks = 40,
+  className,
+}: NotebookCompositionTicksProps) {
+  const sequence = notebookCellSequence(composition, maxTicks);
+  const runs = notebookCellRuns(sequence);
+  // Only present types read out — "0 Raw" is noise for a screen reader.
+  const label = CELL_TYPES.filter((type) => (composition[type] || 0) > 0)
+    .map((type) => `${composition[type]} ${CELL_LABEL[type]}`)
+    .join(", ");
+
+  return (
+    <div className={["nb-fp-wrap", className].filter(Boolean).join(" ")}>
+      <div className="nb-fp" role="img" aria-label={label}>
+        {runs.map((run, index) => (
+          <span
+            key={`${run.type}-${index}`}
+            className="nb-fp-seg"
+            data-ct={run.type}
+            style={
+              {
+                flexBasis: 0,
+                flexGrow: run.count,
+              } satisfies CSSProperties
+            }
+          />
+        ))}
+      </div>
+    </div>
+  );
+}
+
+function notebookCellSequence(
+  composition: NotebookComposition,
+  maxTicks: number,
+): NotebookCellType[] {
+  const total = CELL_TYPES.reduce((sum, type) => sum + (composition[type] || 0), 0);
+  const cap = Math.max(0, Math.floor(maxTicks));
+  if (!total || !cap) {
+    return [];
+  }
+
+  const scale = total > cap ? cap / total : 1;
+  const counts = new Map<NotebookCellType, number>();
+  let scaledTotal = 0;
+  for (const type of CELL_TYPES) {
+    const count = Math.round((composition[type] || 0) * scale);
+    if (count > 0) {
+      counts.set(type, count);
+      scaledTotal += count;
+    }
+  }
+
+  const assigned = new Map<NotebookCellType, number>();
+  for (const type of counts.keys()) {
+    assigned.set(type, 0);
+  }
+
+  const sequence: NotebookCellType[] = [];
+  for (let index = 0; index < scaledTotal; index += 1) {
+    let bestType: NotebookCellType | null = null;
+    let bestRatio = Infinity;
+    for (const [type, count] of counts) {
+      const current = assigned.get(type) ?? 0;
+      if (current >= count) {
+        continue;
+      }
+      const ratio = current / count;
+      if (ratio < bestRatio) {
+        bestRatio = ratio;
+        bestType = type;
+      }
+    }
+    if (!bestType) {
+      break;
+    }
+    sequence.push(bestType);
+    assigned.set(bestType, (assigned.get(bestType) ?? 0) + 1);
+  }
+  return sequence;
+}
+
+function notebookCellRuns(
+  sequence: NotebookCellType[],
+): { type: NotebookCellType; count: number }[] {
+  const runs: { type: NotebookCellType; count: number }[] = [];
+  for (const type of sequence) {
+    const last = runs.at(-1);
+    if (last?.type === type) {
+      last.count += 1;
+    } else {
+      runs.push({ type, count: 1 });
+    }
+  }
+  return runs;
+}

--- a/src/components/runtime/LanguageMark.tsx
+++ b/src/components/runtime/LanguageMark.tsx
@@ -1,0 +1,42 @@
+export interface LanguageMarkProps {
+  language: string;
+  size?: number;
+  className?: string;
+}
+
+/**
+ * Renders the current notebook/runtime language mark from present state; it is
+ * not a kernel picker, file type history, or capability signal.
+ */
+export function LanguageMark({ language, size = 16, className }: LanguageMarkProps) {
+  if (/^python$/iu.test(language.trim())) {
+    return (
+      <svg
+        width={size}
+        height={size}
+        viewBox="0 0 24 24"
+        aria-hidden="true"
+        className={["nb-lang-logo", className].filter(Boolean).join(" ")}
+      >
+        <path
+          fill="#3776AB"
+          d="M12 2C9.5 2 8 3 8 5v2h5v1H6c-2 0-3 1.5-3 4s1 4 3 4h1v-2c0-2 1.5-3.5 3.5-3.5h4c1.7 0 3-1.4 3-3.1V5c0-2-1.7-3-6-3zm-2 1.4c.6 0 1 .5 1 1 0 .6-.4 1-1 1s-1-.4-1-1c0-.5.4-1 1-1z"
+        />
+        <path
+          fill="#FFD43B"
+          d="M12 22c2.5 0 4-1 4-3v-2h-5v-1h7c2 0 3-1.5 3-4s-1-4-3-4h-1v2c0 2-1.5 3.5-3.5 3.5h-4c-1.7 0-3 1.4-3 3.1V19c0 2 1.7 3 6 3zm2-1.4c-.6 0-1-.5-1-1 0-.6.4-1 1-1s1 .4 1 1c0 .5-.4 1-1 1z"
+        />
+      </svg>
+    );
+  }
+
+  return (
+    <i
+      className={["nb-lang-dot", className].filter(Boolean).join(" ")}
+      data-lang={language}
+      role="img"
+      aria-label={`${language} language mark`}
+      style={{ height: size, width: size }}
+    />
+  );
+}

--- a/src/components/runtime/RuntimeStatusDot.tsx
+++ b/src/components/runtime/RuntimeStatusDot.tsx
@@ -1,0 +1,40 @@
+export type RuntimeStatus = "executing" | "ready" | "starting" | "stale" | "error" | "none";
+
+export interface RuntimeStatusDotProps {
+  status: RuntimeStatus;
+  label?: string;
+  showLabel?: boolean;
+  className?: string;
+}
+
+const RUNTIME_STATUS_LABELS: Record<RuntimeStatus, string> = {
+  executing: "Running",
+  ready: "Kernel ready",
+  starting: "Connecting",
+  stale: "Idle kernel",
+  error: "Runtime error",
+  none: "No compute",
+};
+
+/**
+ * Renders the current runtime state as a calm status marker, not as runtime
+ * activity history or permission state.
+ */
+export function RuntimeStatusDot({
+  status,
+  label,
+  showLabel = false,
+  className,
+}: RuntimeStatusDotProps) {
+  const displayLabel = label ?? RUNTIME_STATUS_LABELS[status];
+  return (
+    <span
+      className={["nb-kernel", className].filter(Boolean).join(" ")}
+      data-k={status}
+      aria-label={displayLabel}
+    >
+      <i className="nb-kdot" aria-hidden="true" />
+      {showLabel ? displayLabel : null}
+    </span>
+  );
+}


### PR DESCRIPTION
Ports the notebook dashboard redesign from Claude Design (project `e1ca61da`, designed on the synced nteract Elements system) into the cloud viewer. Everything data-backed today ships; the four data gaps are filed as API issues and the UI lights up field-by-field as they land.

## What ships

- **Header**: sticky brand bar with search (moved up from the dashboard body), New notebook, and the current-user avatar (`--uv` magenta - identity only, per the handoff; it appears nowhere else).
- **Filter chips** driven by the existing projection filter groups, with counts and the green Active pip.
- **Hero**: "Pick up where you left off" / "Jump back in" from `continueRow`, runtime line from `environment_label` with a `LanguageMark`, Resume vs Open per runtime activity.
- **Rows**: fixed-column grid (title block · owner · updated · badges · open hint) so meta aligns row-to-row; scope badges ("Can edit"/"View only"), published fact, runtime status dot. Rename-in-place, open-intent prefetch, refresh, and sign-out all preserved.
- **Create dialog**: modal, title only. The prototype's runtime/template pickers have no backing API and deliberately don't ship.
- **Baked defaults** per the handoff: list · comfortable · subtle accent · medium detail. No `data-accent/density/detail` variants, no board/grid layouts, no tweaks panel, no pulse/glow.

## New shared components (prop-driven, guide-syncable)

| Component | Home | Why there |
|---|---|---|
| `NotebookCompositionTicks` | `src/components/notebook/` | per-cell composition fingerprint; notebook-specific |
| `RuntimeStatusDot` | `src/components/runtime/` | runtime state marker, not list-specific |
| `LanguageMark` | `src/components/runtime/` | language mark (Python logo + dot fallback), broadly reusable |

The `runtime/` pair is deliberately general: the desktop app reuses both when it grows remote notebook-room listings.

## Projection

Derived runtime status (`compute_session` absent → none; starting/stale/error passthrough; active + `queue_depth > 0` → executing, else ready), `environment_label` surfaced, and an optional `composition` field threaded absent-safe - the ticks and cell count render the moment the catalog provides data. Tests extended (1166 passing).

## Data follow-ups (the design fully realized)

The catalog has no source yet for four design elements; each is filed with the performance architecture (derive at write time off the existing R2 Automerge snapshot path; a persistent per-notebook room-summary view on R2 written through by the room DO; never wake a room for the dashboard):

- #3879 cell composition
- #3880 output-embed covers
- #3881 list-scale presence (room-summary view on R2)
- #3882 notebook language

## Verification

- [x] Cloud tests 1166/1166, cloud build, `vp check` clean
- [x] Desktop app build green (new shared components compile there)
- [x] Design-fidelity review against the handoff: Active naming, `--uv` scoped to the user avatar only, no prototype leakage, zero new animation keyframes
- [x] Authority boundaries untouched: create still `POST /api/n` title-only, rename still `PATCH`, open still plain navigation; no execution paths added
- [ ] Visual pass in a local wrangler session

Design source archived at `.context/dashboard-design/` (handoff notes + prototype CSS/JSX/data).
