### PR TITLE
feat(daemon): daemon-mediated hosted cloud notebook rooms

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4774,13 +4774,19 @@ name = "notebook-cloud-transport"
 version = "0.2.2"
 dependencies = [
  "anyhow",
+ "dirs",
  "futures-util",
  "notebook-protocol",
  "notebook-wire",
+ "runt-workspace",
+ "serde",
  "serde_json",
  "tokio",
  "tokio-tungstenite",
+ "toml 1.1.2+spec-1.1.0",
  "tracing",
+ "url",
+ "uuid",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7348,6 +7348,7 @@ dependencies = [
  "kernel-env",
  "libc",
  "notebook-doc",
+ "notebook-sync",
  "notify",
  "nteract-telemetry",
  "reqwest 0.12.28",

--- a/crates/notebook-cloud-transport/Cargo.toml
+++ b/crates/notebook-cloud-transport/Cargo.toml
@@ -9,15 +9,25 @@ license.workspace = true
 [lints]
 workspace = true
 
+[features]
+# Machine-local cloud domain registry (routing + credential references).
+registry = ["dep:serde", "dep:toml", "dep:url", "dep:dirs", "dep:uuid", "dep:runt-workspace"]
+
 [dependencies]
 anyhow = { workspace = true }
+dirs = { workspace = true, optional = true }
 futures-util = { workspace = true }
 notebook-protocol = { path = "../notebook-protocol" }
 notebook-wire = { path = "../notebook-wire" }
+runt-workspace = { path = "../runt-workspace", optional = true }
+serde = { workspace = true, optional = true }
 serde_json = { workspace = true }
 tokio = { workspace = true, features = ["full"] }
 tokio-tungstenite = { workspace = true, features = ["native-tls"] }
+toml = { workspace = true, optional = true }
 tracing = { workspace = true }
+url = { workspace = true, optional = true }
+uuid = { workspace = true, optional = true }
 
 [dev-dependencies]
 tokio = { workspace = true, features = ["full", "test-util"] }

--- a/crates/notebook-cloud-transport/src/lib.rs
+++ b/crates/notebook-cloud-transport/src/lib.rs
@@ -39,6 +39,9 @@
 //! an agent-loop policy decision, recorded in the #16 decision log; this crate
 //! only moves bytes.
 
+#[cfg(feature = "registry")]
+pub mod registry;
+
 use std::collections::VecDeque;
 use std::sync::Arc;
 use std::time::Duration;

--- a/crates/notebook-cloud-transport/src/registry.rs
+++ b/crates/notebook-cloud-transport/src/registry.rs
@@ -1,0 +1,249 @@
+//! Machine-local cloud domain registry.
+//!
+//! Maps hosted nteract origins (e.g. `https://preview.runt.run`) to credential
+//! references and a default operator, per
+//! `docs/adr/cloud-connected-local-mcp.md` Decision 2. The registry stores
+//! routing metadata and credential *references* only; secret values are
+//! resolved at connect time from their referenced environment variables.
+//!
+//! Shared by every local process that dials hosted rooms with its own
+//! credential: `runt mcp` hosted sessions and the daemon's hosted-room bridge
+//! read the same file, so one machine has one hosted-domain configuration.
+
+use std::collections::HashSet;
+use std::path::{Path, PathBuf};
+
+use serde::Deserialize;
+use url::Url;
+
+use crate::CloudAuth;
+
+/// Generic override for the registry file location.
+pub const REGISTRY_ENV_VAR: &str = "NTERACT_CLOUD_REGISTRY";
+/// Historical override honored for compatibility with existing MCP setups.
+pub const LEGACY_REGISTRY_ENV_VAR: &str = "NTERACT_MCP_CLOUD_REGISTRY";
+
+#[derive(Debug, Clone, Deserialize)]
+pub struct CloudRegistry {
+    #[serde(default)]
+    pub default_domain: Option<String>,
+    #[serde(default)]
+    pub domains: Vec<CloudDomainConfig>,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+pub struct CloudDomainConfig {
+    #[serde(alias = "domain", alias = "url")]
+    pub base_url: String,
+    #[serde(default)]
+    pub operator: Option<String>,
+    pub credential: CredentialRef,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+#[serde(tag = "kind", rename_all = "kebab-case")]
+pub enum CredentialRef {
+    #[serde(alias = "bearer-env")]
+    OidcBearerEnv {
+        env: String,
+    },
+    AnacondaApiKeyEnv {
+        env: String,
+    },
+    WorkstationCredentialEnv {
+        env: String,
+    },
+    DevTokenEnv {
+        env: String,
+        user: String,
+    },
+}
+
+impl CloudRegistry {
+    pub fn load_default() -> Result<Option<Self>, String> {
+        let path = registry_path();
+        Self::load_from_path(&path)
+    }
+
+    pub fn load_from_path(path: &Path) -> Result<Option<Self>, String> {
+        if !path.exists() {
+            return Ok(None);
+        }
+        let contents = std::fs::read_to_string(path)
+            .map_err(|e| format!("Failed to read cloud registry {}: {e}", path.display()))?;
+        let registry: Self = toml::from_str(&contents)
+            .map_err(|e| format!("Failed to parse cloud registry {}: {e}", path.display()))?;
+        registry.validate()?;
+        Ok(Some(registry))
+    }
+
+    pub fn validate(&self) -> Result<(), String> {
+        let mut seen = HashSet::new();
+        for domain in &self.domains {
+            let normalized = normalize_domain(&domain.base_url)?;
+            if !seen.insert(normalized.clone()) {
+                return Err(format!("Duplicate cloud domain in registry: {normalized}"));
+            }
+        }
+        if let Some(default_domain) = self.default_domain.as_deref() {
+            let normalized_default = normalize_domain(default_domain)?;
+            if !seen.contains(&normalized_default) {
+                return Err(format!(
+                    "default_domain {normalized_default} is not present in [[domains]]"
+                ));
+            }
+        }
+        Ok(())
+    }
+
+    pub fn default_domain(&self) -> Result<Option<String>, String> {
+        self.default_domain
+            .as_deref()
+            .map(normalize_domain)
+            .transpose()
+    }
+
+    pub fn domain(&self, domain: &str) -> Result<Option<ResolvedCloudDomain>, String> {
+        let normalized = normalize_domain(domain)?;
+        for config in &self.domains {
+            if normalize_domain(&config.base_url)? == normalized {
+                return Ok(Some(ResolvedCloudDomain {
+                    base_url: normalized,
+                    operator: config.operator.clone(),
+                    credential: config.credential.clone(),
+                    auth_override: None,
+                }));
+            }
+        }
+        Ok(None)
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct ResolvedCloudDomain {
+    pub base_url: String,
+    pub operator: Option<String>,
+    credential: CredentialRef,
+    /// Bypass env-var resolution with a fixed credential. Test seam only —
+    /// production paths always resolve through [`CredentialRef`].
+    auth_override: Option<CloudAuth>,
+}
+
+impl ResolvedCloudDomain {
+    /// Construct a domain with a fixed credential, bypassing env resolution.
+    /// For tests and in-process fakes.
+    #[doc(hidden)]
+    pub fn with_auth_override(
+        base_url: impl Into<String>,
+        operator: Option<String>,
+        auth: CloudAuth,
+    ) -> Self {
+        Self {
+            base_url: base_url.into(),
+            operator,
+            credential: CredentialRef::OidcBearerEnv {
+                env: "NTERACT_UNUSED_AUTH_OVERRIDE".to_string(),
+            },
+            auth_override: Some(auth),
+        }
+    }
+
+    pub fn resolve_auth(&self) -> Result<CloudAuth, String> {
+        if let Some(auth) = self.auth_override.clone() {
+            return Ok(auth);
+        }
+        self.credential.resolve()
+    }
+
+    /// Assemble the doc actor label for `principal`, using the configured
+    /// operator (or `fallback_operator`) plus a fresh nonce. Automerge actors
+    /// cannot be reused concurrently by independent document instances, so
+    /// every live connection mints a new nonce.
+    pub fn actor_label(&self, principal: &str, fallback_operator: &str) -> String {
+        let operator = self
+            .operator
+            .as_deref()
+            .filter(|value| !value.trim().is_empty())
+            .unwrap_or(fallback_operator);
+        format!("{principal}/{operator}:{}", short_nonce())
+    }
+}
+
+impl CredentialRef {
+    fn resolve(&self) -> Result<CloudAuth, String> {
+        match self {
+            Self::OidcBearerEnv { env } => Ok(CloudAuth::OidcBearer {
+                token: read_secret_env(env)?,
+            }),
+            Self::AnacondaApiKeyEnv { env } => Ok(CloudAuth::AnacondaApiKey {
+                token: read_secret_env(env)?,
+            }),
+            Self::WorkstationCredentialEnv { env } => Ok(CloudAuth::WorkstationCredential {
+                token: read_secret_env(env)?,
+            }),
+            Self::DevTokenEnv { env, user } => Ok(CloudAuth::Dev {
+                token: read_secret_env(env)?,
+                user: user.clone(),
+            }),
+        }
+    }
+}
+
+fn read_secret_env(name: &str) -> Result<String, String> {
+    std::env::var(name).map_err(|_| format!("Credential env var {name} is not set"))
+}
+
+pub fn registry_path() -> PathBuf {
+    std::env::var_os(REGISTRY_ENV_VAR)
+        .or_else(|| std::env::var_os(LEGACY_REGISTRY_ENV_VAR))
+        .map(PathBuf::from)
+        .unwrap_or_else(|| {
+            dirs::config_dir()
+                .unwrap_or_else(|| PathBuf::from("."))
+                .join(runt_workspace::config_namespace())
+                .join("cloud-domains.toml")
+        })
+}
+
+pub fn hosted_notebook_url(domain: &str, notebook_id: &str) -> String {
+    format!("{}/n/{}", domain.trim_end_matches('/'), notebook_id)
+}
+
+/// Parse a hosted notebook URL (`https://<host>/n/<notebook_id>[/...]`) into
+/// its normalized domain and notebook id.
+pub fn parse_hosted_url(target: &str) -> Result<(String, String), String> {
+    let url = Url::parse(target).map_err(|e| format!("Invalid hosted notebook URL: {e}"))?;
+    let domain = normalize_url_domain(&url)?;
+    let mut segments = url
+        .path_segments()
+        .ok_or_else(|| "Hosted notebook URL has no path".to_string())?;
+    match (segments.next(), segments.next()) {
+        (Some("n"), Some(id)) if !id.is_empty() => Ok((domain, id.to_string())),
+        _ => Err("Hosted notebook URL must look like https://host/n/<notebook_id>".to_string()),
+    }
+}
+
+pub fn normalize_domain(domain: &str) -> Result<String, String> {
+    let url = Url::parse(domain).map_err(|e| format!("Invalid cloud domain {domain:?}: {e}"))?;
+    normalize_url_domain(&url)
+}
+
+pub fn normalize_url_domain(url: &Url) -> Result<String, String> {
+    match url.scheme() {
+        "https" | "http" => {}
+        other => return Err(format!("Unsupported cloud domain scheme: {other}")),
+    }
+    let host = url
+        .host_str()
+        .ok_or_else(|| "Cloud domain must include a host".to_string())?;
+    let mut normalized = format!("{}://{}", url.scheme(), host);
+    if let Some(port) = url.port() {
+        normalized.push(':');
+        normalized.push_str(&port.to_string());
+    }
+    Ok(normalized)
+}
+
+pub fn short_nonce() -> String {
+    uuid::Uuid::new_v4().simple().to_string()[..8].to_string()
+}

--- a/crates/notebook-protocol/src/connection/handshake.rs
+++ b/crates/notebook-protocol/src/connection/handshake.rs
@@ -59,6 +59,27 @@ pub enum Handshake {
         operator: Option<String>,
     },
 
+    /// Open a hosted cloud notebook through the daemon-mediated bridge.
+    ///
+    /// The daemon resolves `url` against its machine-local cloud domain
+    /// registry, dials the hosted room with its own credential, and serves
+    /// this connection from the bridged daemon-local room. The daemon returns
+    /// `NotebookConnectionInfo` (with the daemon-local room id) before
+    /// starting sync; after that the connection is a normal notebook sync
+    /// connection. Credentials never ride this handshake.
+    OpenHostedNotebook {
+        /// Hosted notebook URL, `https://<host>/n/<notebook_id>[/...]`.
+        url: String,
+        /// When true, the daemon sends `NotebookConnectionInfo` as a typed
+        /// SessionControl frame instead of a standalone untyped JSON frame.
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        typed_bootstrap: Option<bool>,
+        /// Self-declared operator suffix for the authenticated actor label.
+        /// The principal prefix comes from the daemon's cloud credential.
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        operator: Option<String>,
+    },
+
     /// Runtime agent handshake. Sent by the coordinator to a spawned runtime
     /// agent subprocess on its stdin. The runtime agent reads this, bootstraps
     /// its RuntimeStateDoc, and begins processing kernel requests.

--- a/crates/notebook-sync/src/connect.rs
+++ b/crates/notebook-sync/src/connect.rs
@@ -278,6 +278,63 @@ pub async fn connect_open(
         })
 }
 
+/// Connect and open a hosted cloud notebook through the daemon-mediated
+/// bridge.
+///
+/// The daemon resolves `url` against its machine-local cloud domain registry,
+/// dials the hosted room with its own credential, and serves this connection
+/// from the bridged daemon-local room. The returned connection info carries
+/// the daemon-local room id and the cloud-principal actor label this peer
+/// must author under.
+pub async fn connect_open_hosted(
+    socket_path: PathBuf,
+    url: &str,
+    operator: Option<String>,
+) -> Result<OpenResult, SyncError> {
+    let stream = connect_stream!(&socket_path);
+    let (reader, writer) = tokio::io::split(stream);
+    let mut reader = tokio::io::BufReader::new(reader);
+    let mut writer = tokio::io::BufWriter::new(writer);
+
+    connection::send_preamble(&mut writer).await?;
+
+    let handshake = Handshake::OpenHostedNotebook {
+        url: url.to_string(),
+        typed_bootstrap: Some(true),
+        operator,
+    };
+    connection::send_json_frame(&mut writer, &handshake)
+        .await
+        .map_err(|e| SyncError::Protocol(format!("Send handshake: {}", e)))?;
+
+    let info = recv_typed_connection_info(&mut reader).await?;
+
+    if let Some(ref error) = info.error {
+        return Err(SyncError::Protocol(error.clone()));
+    }
+
+    let notebook_id = info.notebook_id.clone();
+    let actor_label =
+        info.capabilities.actor_label.clone().ok_or_else(|| {
+            SyncError::Protocol("hosted open returned no actor label".to_string())
+        })?;
+
+    let bootstrap = notebook_doc::NotebookDoc::bootstrap(
+        notebook_doc::TextEncoding::UnicodeCodePoint,
+        &actor_label,
+    );
+    let doc = bootstrap.into_inner();
+    let peer_state = sync::State::new();
+
+    build_and_spawn(doc, peer_state, notebook_id, reader, writer)
+        .await
+        .map(|(handle, broadcast_rx)| OpenResult {
+            handle,
+            broadcast_rx,
+            info,
+        })
+}
+
 /// Connect and create a new notebook.
 ///
 /// The daemon creates an empty notebook room with one code cell and

--- a/crates/runt-mcp/Cargo.toml
+++ b/crates/runt-mcp/Cargo.toml
@@ -18,7 +18,7 @@ repr-llm = { path = "../repr-llm" }
 runtimed-client = { path = "../runtimed-client" }
 runtimed-outputs = { path = "../runtimed-outputs" }
 notebook-protocol = { path = "../notebook-protocol" }
-notebook-cloud-transport = { path = "../notebook-cloud-transport" }
+notebook-cloud-transport = { path = "../notebook-cloud-transport", features = ["registry"] }
 notebook-sync = { path = "../notebook-sync" }
 notebook-doc = { path = "../notebook-doc" }
 runtime-doc = { path = "../runtime-doc" }

--- a/crates/runt-mcp/src/cloud.rs
+++ b/crates/runt-mcp/src/cloud.rs
@@ -1,19 +1,21 @@
-//! Hosted notebook target parsing and machine-local cloud domain registry.
+//! Hosted notebook target parsing and hosted-room connection for MCP sessions.
 //!
-//! The registry stores routing metadata and credential references only. Secret
-//! values are resolved at connect time from their referenced environment
-//! variables.
-
-use std::collections::HashSet;
-use std::path::{Path, PathBuf};
+//! The machine-local cloud domain registry lives in
+//! `notebook_cloud_transport::registry` (shared with the daemon's hosted-room
+//! bridge); this module re-exports it and adds the MCP-facing pieces: connect
+//! target parsing and the direct hosted-room connector.
 
 use notebook_cloud_transport::{CloudAuth, CloudWsConfig, CloudWsFrameTransport};
 use notebook_protocol::connection::FrameTransport;
 use notebook_sync::connect::ConnectResult;
-use serde::Deserialize;
-use url::Url;
 
-const REGISTRY_ENV_VAR: &str = "NTERACT_MCP_CLOUD_REGISTRY";
+pub use notebook_cloud_transport::registry::{
+    hosted_notebook_url, normalize_domain, registry_path, CloudDomainConfig, CloudRegistry,
+    CredentialRef, ResolvedCloudDomain,
+};
+
+/// Default operator suffix when the registry entry does not configure one.
+pub const DEFAULT_MCP_OPERATOR: &str = "agent:nteract-mcp";
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum NotebookTarget {
@@ -53,132 +55,6 @@ impl NotebookTarget {
     }
 }
 
-#[derive(Debug, Clone, Deserialize)]
-pub struct CloudRegistry {
-    #[serde(default)]
-    pub default_domain: Option<String>,
-    #[serde(default)]
-    pub domains: Vec<CloudDomainConfig>,
-}
-
-#[derive(Debug, Clone, Deserialize)]
-pub struct CloudDomainConfig {
-    #[serde(alias = "domain", alias = "url")]
-    pub base_url: String,
-    #[serde(default)]
-    pub operator: Option<String>,
-    pub credential: CredentialRef,
-}
-
-#[derive(Debug, Clone, Deserialize)]
-#[serde(tag = "kind", rename_all = "kebab-case")]
-pub enum CredentialRef {
-    #[serde(alias = "bearer-env")]
-    OidcBearerEnv {
-        env: String,
-    },
-    AnacondaApiKeyEnv {
-        env: String,
-    },
-    WorkstationCredentialEnv {
-        env: String,
-    },
-    DevTokenEnv {
-        env: String,
-        user: String,
-    },
-}
-
-impl CloudRegistry {
-    pub fn load_default() -> Result<Option<Self>, String> {
-        let path = registry_path();
-        Self::load_from_path(&path)
-    }
-
-    pub fn load_from_path(path: &Path) -> Result<Option<Self>, String> {
-        if !path.exists() {
-            return Ok(None);
-        }
-        let contents = std::fs::read_to_string(path)
-            .map_err(|e| format!("Failed to read cloud registry {}: {e}", path.display()))?;
-        let registry: Self = toml::from_str(&contents)
-            .map_err(|e| format!("Failed to parse cloud registry {}: {e}", path.display()))?;
-        registry.validate()?;
-        Ok(Some(registry))
-    }
-
-    pub fn validate(&self) -> Result<(), String> {
-        let mut seen = HashSet::new();
-        for domain in &self.domains {
-            let normalized = normalize_domain(&domain.base_url)?;
-            if !seen.insert(normalized.clone()) {
-                return Err(format!("Duplicate cloud domain in registry: {normalized}"));
-            }
-        }
-        if let Some(default_domain) = self.default_domain.as_deref() {
-            let normalized_default = normalize_domain(default_domain)?;
-            if !seen.contains(&normalized_default) {
-                return Err(format!(
-                    "default_domain {normalized_default} is not present in [[domains]]"
-                ));
-            }
-        }
-        Ok(())
-    }
-
-    pub fn default_domain(&self) -> Result<Option<String>, String> {
-        self.default_domain
-            .as_deref()
-            .map(normalize_domain)
-            .transpose()
-    }
-
-    pub fn domain(&self, domain: &str) -> Result<Option<ResolvedCloudDomain>, String> {
-        let normalized = normalize_domain(domain)?;
-        for config in &self.domains {
-            if normalize_domain(&config.base_url)? == normalized {
-                return Ok(Some(ResolvedCloudDomain {
-                    base_url: normalized,
-                    operator: config.operator.clone(),
-                    credential: config.credential.clone(),
-                    #[cfg(test)]
-                    auth_override: None,
-                }));
-            }
-        }
-        Ok(None)
-    }
-}
-
-#[derive(Debug, Clone)]
-pub struct ResolvedCloudDomain {
-    pub base_url: String,
-    pub operator: Option<String>,
-    credential: CredentialRef,
-    #[cfg(test)]
-    auth_override: Option<CloudAuth>,
-}
-
-impl ResolvedCloudDomain {
-    pub fn resolve_auth(&self) -> Result<CloudAuth, String> {
-        #[cfg(test)]
-        if let Some(auth) = self.auth_override.clone() {
-            return Ok(auth);
-        }
-
-        self.credential.resolve()
-    }
-
-    pub fn actor_label(&self, principal: &str) -> String {
-        let operator = self
-            .operator
-            .as_deref()
-            .filter(|value| !value.trim().is_empty())
-            .unwrap_or("agent:nteract-mcp");
-        format!("{principal}/{operator}:{}", short_nonce())
-    }
-}
-
 pub async fn connect_hosted_notebook(
     domain: &ResolvedCloudDomain,
     notebook_id: &str,
@@ -197,7 +73,7 @@ pub async fn connect_hosted_notebook(
     let principal = transport
         .principal()
         .ok_or_else(|| "Hosted room did not provide an authenticated principal".to_string())?;
-    let actor_label = domain.actor_label(principal);
+    let actor_label = domain.actor_label(principal, DEFAULT_MCP_OPERATOR);
     notebook_sync::connect::connect_frame_io(notebook_id.to_string(), &actor_label, source, sink)
         .await
         .map_err(|e| format!("Failed to start hosted notebook sync: {e}"))
@@ -250,45 +126,6 @@ fn apply_reqwest_auth(
             .header("X-Notebook-Cloud-Dev-Token", token)
             .header("X-User", user),
     }
-}
-
-impl CredentialRef {
-    fn resolve(&self) -> Result<CloudAuth, String> {
-        match self {
-            Self::OidcBearerEnv { env } => Ok(CloudAuth::OidcBearer {
-                token: read_secret_env(env)?,
-            }),
-            Self::AnacondaApiKeyEnv { env } => Ok(CloudAuth::AnacondaApiKey {
-                token: read_secret_env(env)?,
-            }),
-            Self::WorkstationCredentialEnv { env } => Ok(CloudAuth::WorkstationCredential {
-                token: read_secret_env(env)?,
-            }),
-            Self::DevTokenEnv { env, user } => Ok(CloudAuth::Dev {
-                token: read_secret_env(env)?,
-                user: user.clone(),
-            }),
-        }
-    }
-}
-
-fn read_secret_env(name: &str) -> Result<String, String> {
-    std::env::var(name).map_err(|_| format!("Credential env var {name} is not set"))
-}
-
-pub fn registry_path() -> PathBuf {
-    std::env::var_os(REGISTRY_ENV_VAR)
-        .map(PathBuf::from)
-        .unwrap_or_else(|| {
-            dirs::config_dir()
-                .unwrap_or_else(|| PathBuf::from("."))
-                .join(runt_workspace::config_namespace())
-                .join("cloud-domains.toml")
-        })
-}
-
-pub fn hosted_notebook_url(domain: &str, notebook_id: &str) -> String {
-    format!("{}/n/{}", domain.trim_end_matches('/'), notebook_id)
 }
 
 pub fn parse_connect_target(
@@ -367,19 +204,12 @@ fn parse_local_notebook_id(id: &str) -> Result<NotebookTarget, String> {
 }
 
 fn parse_hosted_url_target(target: &str) -> Result<NotebookTarget, String> {
-    let url = Url::parse(target).map_err(|e| format!("Invalid hosted notebook URL: {e}"))?;
-    let domain = normalize_url_domain(&url)?;
-    let mut segments = url
-        .path_segments()
-        .ok_or_else(|| "Hosted notebook URL has no path".to_string())?;
-    match (segments.next(), segments.next()) {
-        (Some("n"), Some(id)) if !id.is_empty() => Ok(NotebookTarget::Hosted {
-            domain,
-            notebook_id: id.to_string(),
-            source: HostedTargetSource::Url,
-        }),
-        _ => Err("Hosted notebook URL must look like https://host/n/<notebook_id>".to_string()),
-    }
+    let (domain, notebook_id) = notebook_cloud_transport::registry::parse_hosted_url(target)?;
+    Ok(NotebookTarget::Hosted {
+        domain,
+        notebook_id,
+        source: HostedTargetSource::Url,
+    })
 }
 
 fn looks_like_uuid(value: &str) -> bool {
@@ -398,31 +228,6 @@ fn looks_like_ulid(value: &str) -> bool {
         && value
             .bytes()
             .all(|b| matches!(b, b'0'..=b'9' | b'A'..=b'H' | b'J'..=b'K' | b'M'..=b'N' | b'P'..=b'T' | b'V'..=b'Z'))
-}
-
-pub fn normalize_domain(domain: &str) -> Result<String, String> {
-    let url = Url::parse(domain).map_err(|e| format!("Invalid cloud domain {domain:?}: {e}"))?;
-    normalize_url_domain(&url)
-}
-
-fn normalize_url_domain(url: &Url) -> Result<String, String> {
-    match url.scheme() {
-        "https" | "http" => {}
-        other => return Err(format!("Unsupported cloud domain scheme: {other}")),
-    }
-    let host = url
-        .host_str()
-        .ok_or_else(|| "Cloud domain must include a host".to_string())?;
-    let mut normalized = format!("{}://{}", url.scheme(), host);
-    if let Some(port) = url.port() {
-        normalized.push(':');
-        normalized.push_str(&port.to_string());
-    }
-    Ok(normalized)
-}
-
-fn short_nonce() -> String {
-    uuid::Uuid::new_v4().simple().to_string()[..8].to_string()
 }
 
 #[cfg(test)]
@@ -477,7 +282,7 @@ mod tests {
                 None,
                 None,
                 Some("01KTZA152886TK1WAHYA48G7HJ"),
-                Some("https://preview.runt.run/")
+                Some("https://preview.runt.run")
             )
             .unwrap(),
             NotebookTarget::Hosted {
@@ -528,16 +333,17 @@ mod tests {
 
     #[test]
     fn registry_validates_default_domain() {
-        let registry = CloudRegistry {
-            default_domain: Some("https://preview.runt.run/".to_string()),
-            domains: vec![CloudDomainConfig {
-                base_url: "https://preview.runt.run".to_string(),
-                operator: Some("agent:codex".to_string()),
-                credential: CredentialRef::AnacondaApiKeyEnv {
-                    env: "NTERACT_TEST_TOKEN".to_string(),
-                },
-            }],
-        };
+        let registry: CloudRegistry = toml::from_str(
+            r#"
+default_domain = "https://preview.runt.run/"
+
+[[domains]]
+url = "https://preview.runt.run"
+operator = "agent:codex"
+credential = { kind = "anaconda-api-key-env", env = "NTERACT_TEST_TOKEN" }
+"#,
+        )
+        .unwrap();
 
         registry.validate().unwrap();
         assert_eq!(
@@ -640,16 +446,13 @@ credential = { kind = "anaconda-api-key-env", env = "NTERACT_TEST_ANACONDA_KEY" 
             }
         });
 
-        let domain = ResolvedCloudDomain {
-            base_url: format!("http://{addr}"),
-            operator: Some("agent:test".to_string()),
-            credential: CredentialRef::AnacondaApiKeyEnv {
-                env: "UNUSED_IN_TEST".to_string(),
-            },
-            auth_override: Some(CloudAuth::AnacondaApiKey {
+        let domain = ResolvedCloudDomain::with_auth_override(
+            format!("http://{addr}"),
+            Some("agent:test".to_string()),
+            CloudAuth::AnacondaApiKey {
                 token: "secret-key".to_string(),
-            }),
-        };
+            },
+        );
 
         let result = connect_hosted_notebook(&domain, "hosted-test")
             .await

--- a/crates/runt/Cargo.toml
+++ b/crates/runt/Cargo.toml
@@ -20,6 +20,7 @@ runtimed-client = { path = "../runtimed-client" }
 runtimed-service = { path = "../runtimed-service" }
 nteract-telemetry = { path = "../nteract-telemetry" }
 notebook-doc = { path = "../notebook-doc", features = ["persistence"] }
+notebook-sync = { path = "../notebook-sync" }
 runt-workspace = { path = "../runt-workspace" }
 runt-mcp = { path = "../runt-mcp" }
 kernel-env = { path = "../kernel-env" }

--- a/crates/runt/src/cloud_cli.rs
+++ b/crates/runt/src/cloud_cli.rs
@@ -1,0 +1,92 @@
+use std::time::Duration;
+
+use anyhow::Result;
+use clap::Subcommand;
+use notebook_sync::SyncError;
+use serde::Serialize;
+
+#[derive(Subcommand)]
+pub enum CloudCommands {
+    /// Open a hosted cloud notebook through the local daemon bridge
+    Open {
+        /// Hosted notebook URL
+        url: String,
+        /// Operator label to append to the hosted actor identity
+        #[arg(long)]
+        operator: Option<String>,
+        /// Keep the session alive for N seconds before exiting
+        #[arg(long)]
+        stay: Option<u64>,
+        /// Output one JSON object
+        #[arg(long)]
+        json: bool,
+    },
+}
+
+#[derive(Serialize)]
+struct OpenSummary {
+    notebook_id: String,
+    actor_label: Option<String>,
+    connection_scope: Option<String>,
+    cell_count: usize,
+}
+
+pub async fn command(command: CloudCommands) -> Result<()> {
+    match command {
+        CloudCommands::Open {
+            url,
+            operator,
+            stay,
+            json,
+        } => open(url, operator, stay, json).await,
+    }
+}
+
+async fn open(url: String, operator: Option<String>, stay: Option<u64>, json: bool) -> Result<()> {
+    let socket_path = runtimed_client::daemon_paths::get_socket_path();
+    let result =
+        match notebook_sync::connect::connect_open_hosted(socket_path, &url, operator).await {
+            Ok(result) => result,
+            Err(error) => exit_with_connect_error(error),
+        };
+
+    let summary = OpenSummary {
+        notebook_id: result.info.notebook_id.clone(),
+        actor_label: result.info.capabilities.actor_label.clone(),
+        connection_scope: result.info.capabilities.connection_scope.clone(),
+        cell_count: result.info.cell_count,
+    };
+    print_summary(&summary, json)?;
+
+    if let Some(seconds) = stay {
+        tokio::time::sleep(Duration::from_secs(seconds)).await;
+    }
+
+    Ok(())
+}
+
+fn print_summary(summary: &OpenSummary, json: bool) -> Result<()> {
+    if json {
+        println!("{}", serde_json::to_string(&summary)?);
+    } else {
+        println!("Daemon-local notebook ID: {}", summary.notebook_id);
+        println!(
+            "Actor label: {}",
+            summary.actor_label.as_deref().unwrap_or("(none)")
+        );
+        println!(
+            "Connection scope: {}",
+            summary.connection_scope.as_deref().unwrap_or("(none)")
+        );
+        println!("Cell count: {}", summary.cell_count);
+    }
+    Ok(())
+}
+
+fn exit_with_connect_error(error: SyncError) -> ! {
+    match error {
+        SyncError::Protocol(message) => eprintln!("{message}"),
+        other => eprintln!("{other}"),
+    }
+    std::process::exit(1);
+}

--- a/crates/runt/src/main.rs
+++ b/crates/runt/src/main.rs
@@ -2,6 +2,7 @@
 #![cfg_attr(test, allow(clippy::unwrap_used, clippy::expect_used))]
 
 extern crate runtimed_client as runtimed;
+mod cloud_cli;
 mod notebook_cli;
 mod workstation_cli;
 
@@ -178,6 +179,11 @@ enum Commands {
     Nb {
         #[command(subcommand)]
         command: Box<notebook_cli::NotebookCommands>,
+    },
+    /// Hosted cloud notebooks via the daemon-mediated bridge
+    Cloud {
+        #[command(subcommand)]
+        command: cloud_cli::CloudCommands,
     },
     /// Offer this machine's compute to hosted notebooks (pair, run, status)
     Workstation {
@@ -564,6 +570,7 @@ async fn async_main(command: Option<Commands>) -> Result<()> {
         }
         Some(Commands::Diagnostics { output }) => diagnostics_command(output).await?,
         Some(Commands::Nb { command }) => notebook_cli::command(*command).await?,
+        Some(Commands::Cloud { command }) => cloud_cli::command(command).await?,
         Some(Commands::Workstation { command }) => workstation_cli::command(command).await?,
         Some(Commands::Config { command }) => config_command(command).await?,
         Some(Commands::Mcp { no_show, socket }) => {

--- a/crates/runtimed/Cargo.toml
+++ b/crates/runtimed/Cargo.toml
@@ -26,7 +26,7 @@ nteract-telemetry = { path = "../nteract-telemetry" }
 nteract-markdown-wasm = { path = "../nteract-markdown-wasm" }
 notebook-protocol = { path = "../notebook-protocol" }
 notebook-wire = { path = "../notebook-wire" }
-notebook-cloud-transport = { path = "../notebook-cloud-transport" }
+notebook-cloud-transport = { path = "../notebook-cloud-transport", features = ["registry"] }
 comments-doc = { path = "../comments-doc" }
 nteract-identity = { path = "../nteract-identity" }
 tokio = { workspace = true, features = ["full"] }

--- a/crates/runtimed/src/daemon.rs
+++ b/crates/runtimed/src/daemon.rs
@@ -2838,10 +2838,18 @@ impl Daemon {
                 .connections
                 .active_peers
                 .load(std::sync::atomic::Ordering::Relaxed);
+            let reservations = room.connections.reservations();
             if active_peers > 0 {
                 debug!(
-                    "[runtimed] Hosted bridge idle teardown skipped for {}: {} active peer(s)",
-                    locator, active_peers
+                    "[runtimed] Hosted bridge idle teardown skipped for {}: {} active peer(s), {} reservation(s)",
+                    locator, active_peers, reservations
+                );
+                return;
+            }
+            if reservations > 1 {
+                debug!(
+                    "[runtimed] Hosted bridge idle teardown skipped for {}: {} reservation(s) including in-flight attach",
+                    locator, reservations
                 );
                 return;
             }
@@ -2897,6 +2905,7 @@ impl Daemon {
         (
             Arc<crate::notebook_sync_server::NotebookRoom>,
             Arc<crate::notebook_sync_server::HostedBridgeHandle>,
+            crate::notebook_sync_server::ReservationGuard,
         ),
         String,
     > {
@@ -2912,7 +2921,10 @@ impl Daemon {
         };
         if let Some(bridge) = existing {
             if let Some((room, _guard)) = self.notebook_rooms.lookup_uuid(bridge.room_id).await {
-                return Ok((room, bridge));
+                room.mark_hosted();
+                let connection_reservation =
+                    crate::notebook_sync_server::ReservationGuard::new(room.clone());
+                return Ok((room, bridge, connection_reservation));
             }
         }
 
@@ -2948,6 +2960,9 @@ impl Daemon {
         )
         .await
         .map_err(|e| format!("Failed to create bridged room for {locator}: {e}"))?;
+        room.mark_hosted();
+        let connection_reservation =
+            crate::notebook_sync_server::ReservationGuard::new(room.clone());
         self.mark_rooms_ever_seen();
 
         let idle_daemon: Weak<Self> = Arc::downgrade(self);
@@ -2990,7 +3005,7 @@ impl Daemon {
                 handle
             }
         };
-        Ok((room, bridge))
+        Ok((room, bridge, connection_reservation))
     }
 
     /// Handle an OpenHostedNotebook connection: attach (or reuse) the hosted
@@ -3014,7 +3029,7 @@ impl Daemon {
 
         info!("[runtimed] OpenHostedNotebook requested for {}", url);
 
-        let (room, bridge) = match self.prepare_hosted_room(&url).await {
+        let (room, bridge, _connection_reservation) = match self.prepare_hosted_room(&url).await {
             Ok(prepared) => prepared,
             Err(message) => {
                 let (_reader, mut writer) = tokio::io::split(stream);

--- a/crates/runtimed/src/daemon.rs
+++ b/crates/runtimed/src/daemon.rs
@@ -3,7 +3,7 @@
 //! The daemon manages prewarmed environment pools and handles requests from
 //! notebook windows via IPC (Unix domain sockets on Unix, named pipes on Windows).
 
-use std::collections::VecDeque;
+use std::collections::{HashMap, VecDeque};
 use std::path::{Path, PathBuf};
 use std::process::Stdio;
 use std::sync::{Arc, Weak};
@@ -1186,6 +1186,12 @@ pub struct Daemon {
     /// open and close between 30-minute GC cycles. Sampling in the GC
     /// loop would miss short-lived sessions and pin the daemon back in
     /// the post-restart state forever.
+    /// Hosted-bridged rooms: normalized hosted locator
+    /// (`https://<host>/n/<id>`) → live bridge handle. The handle keeps the
+    /// bridged room resident; requests against a hosted room are routed to
+    /// the cloud instead of local kernels (see `requests::handle_notebook_request`).
+    pub(crate) hosted_bridges:
+        Mutex<HashMap<String, Arc<crate::notebook_sync_server::HostedBridgeHandle>>>,
     rooms_ever_seen: std::sync::atomic::AtomicBool,
     uv_warming_respawns: std::sync::atomic::AtomicU32,
     conda_warming_respawns: std::sync::atomic::AtomicU32,
@@ -1543,6 +1549,7 @@ impl Daemon {
             blob_port: Mutex::new(None),
             started_at: chrono::Utc::now(),
             notebook_rooms: Arc::new(RoomRegistry::new()),
+            hosted_bridges: Mutex::new(HashMap::new()),
             rooms_ever_seen: std::sync::atomic::AtomicBool::new(false),
             uv_warming_respawns: std::sync::atomic::AtomicU32::new(0),
             conda_warming_respawns: std::sync::atomic::AtomicU32::new(0),
@@ -2713,6 +2720,20 @@ impl Daemon {
                 )
                 .await
             }
+            Handshake::OpenHostedNotebook {
+                url,
+                typed_bootstrap,
+                operator,
+            } => {
+                self.handle_open_hosted_notebook(
+                    stream,
+                    url,
+                    typed_bootstrap.unwrap_or(false),
+                    operator,
+                    client_protocol_version,
+                )
+                .await
+            }
             Handshake::CreateNotebook {
                 runtime,
                 working_dir,
@@ -2783,6 +2804,233 @@ impl Daemon {
     /// Daemon loads the .ipynb file, derives notebook_id, creates room, populates doc.
     /// If the file doesn't exist, creates a new empty notebook at that path.
     /// Returns NotebookConnectionInfo, then continues as normal notebook sync.
+    /// The live hosted bridge serving `room_id`, if the room is
+    /// hosted-bridged. Hosted rooms have no local kernels; execution requests
+    /// are forwarded across the bridge instead.
+    pub(crate) async fn hosted_bridge_for_room(
+        &self,
+        room_id: uuid::Uuid,
+    ) -> Option<Arc<crate::notebook_sync_server::HostedBridgeHandle>> {
+        let bridges = self.hosted_bridges.lock().await;
+        bridges.values().find(|b| b.room_id == room_id).cloned()
+    }
+
+    /// Resolve or create the bridged room + bridge for a hosted locator.
+    ///
+    /// Errors are user-actionable configuration/connectivity messages meant
+    /// for the handshake error response.
+    async fn prepare_hosted_room(
+        self: &Arc<Self>,
+        url: &str,
+    ) -> Result<
+        (
+            Arc<crate::notebook_sync_server::NotebookRoom>,
+            Arc<crate::notebook_sync_server::HostedBridgeHandle>,
+        ),
+        String,
+    > {
+        use notebook_cloud_transport::registry;
+
+        let (domain, hosted_id) = registry::parse_hosted_url(url)?;
+        let locator = registry::hosted_notebook_url(&domain, &hosted_id);
+
+        // Fast path: bridge already running for this locator.
+        let existing = {
+            let bridges = self.hosted_bridges.lock().await;
+            bridges.get(&locator).cloned()
+        };
+        if let Some(bridge) = existing {
+            if let Some((room, _guard)) = self.notebook_rooms.lookup_uuid(bridge.room_id).await {
+                return Ok((room, bridge));
+            }
+        }
+
+        let registry_file = registry::registry_path();
+        let reg = registry::CloudRegistry::load_default()?.ok_or_else(|| {
+            format!(
+                "No cloud domain registry at {}. Configure hosted domains before opening cloud notebooks.",
+                registry_file.display()
+            )
+        })?;
+        let domain_config = reg.domain(&domain)?.ok_or_else(|| {
+            format!(
+                "Cloud domain {domain} is not configured in {}",
+                registry_file.display()
+            )
+        })?;
+        let auth = domain_config.resolve_auth()?;
+
+        // Deterministic local room id per hosted locator, stable across
+        // daemon restarts and shared by concurrent opens of the same URL.
+        let room_uuid = uuid::Uuid::new_v5(&uuid::Uuid::NAMESPACE_URL, locator.as_bytes());
+        let docs_dir = self.config.notebook_docs_dir.clone();
+        let (room, guard) = crate::notebook_sync_server::get_or_create_room_result(
+            &self.notebook_rooms,
+            room_uuid,
+            crate::notebook_sync_server::RoomCreationOptions {
+                path: None,
+                docs_dir: &docs_dir,
+                blob_store: self.blob_store.clone(),
+                ephemeral: true,
+                trusted_packages: self.trusted_packages.clone(),
+            },
+        )
+        .await
+        .map_err(|e| format!("Failed to create bridged room for {locator}: {e}"))?;
+        self.mark_rooms_ever_seen();
+
+        let mut bridges = self.hosted_bridges.lock().await;
+        let bridge = match bridges.entry(locator.clone()) {
+            std::collections::hash_map::Entry::Occupied(entry) => entry.get().clone(),
+            std::collections::hash_map::Entry::Vacant(entry) => {
+                let transport = notebook_cloud_transport::CloudWsFrameTransport::new(
+                    notebook_cloud_transport::CloudWsConfig {
+                        cloud_url: domain_config.base_url.clone(),
+                        notebook_id: hosted_id.clone(),
+                        scope: "editor".to_string(),
+                        auth,
+                        workstation: None,
+                    },
+                );
+                let handle = Arc::new(crate::notebook_sync_server::spawn_hosted_bridge(
+                    room.clone(),
+                    transport,
+                    locator.clone(),
+                    hosted_id.clone(),
+                    guard,
+                ));
+                entry.insert(handle.clone());
+                handle
+            }
+        };
+        Ok((room, bridge))
+    }
+
+    /// Handle an OpenHostedNotebook connection: attach (or reuse) the hosted
+    /// bridge for the URL, wait for the cloud principal, then serve the
+    /// connection as a normal notebook sync peer of the bridged room.
+    async fn handle_open_hosted_notebook<S>(
+        self: Arc<Self>,
+        stream: S,
+        url: String,
+        typed_bootstrap: bool,
+        operator: Option<String>,
+        client_protocol_version: u8,
+    ) -> anyhow::Result<()>
+    where
+        S: AsyncRead + AsyncWrite + Unpin + Send + 'static,
+    {
+        use notebook_protocol::connection::{
+            send_json_frame, send_typed_bootstrap_frame, ConnectionBootstrap,
+            NotebookConnectionInfo, ProtocolCapabilities,
+        };
+
+        info!("[runtimed] OpenHostedNotebook requested for {}", url);
+
+        let (room, bridge) = match self.prepare_hosted_room(&url).await {
+            Ok(prepared) => prepared,
+            Err(message) => {
+                let (_reader, mut writer) = tokio::io::split(stream);
+                send_error_response(&mut writer, message, typed_bootstrap).await?;
+                return Ok(());
+            }
+        };
+
+        let Some(principal) = bridge
+            .wait_for_principal(std::time::Duration::from_secs(30))
+            .await
+        else {
+            let (_reader, mut writer) = tokio::io::split(stream);
+            send_error_response(
+                &mut writer,
+                format!(
+                    "Could not attach to hosted room {} (check credentials and connectivity)",
+                    bridge.locator
+                ),
+                typed_bootstrap,
+            )
+            .await?;
+            return Ok(());
+        };
+
+        // Local peers on a bridged room author under the cloud principal so
+        // the hosted room's actor authorization accepts their changes.
+        let connection_identity =
+            match crate::notebook_sync_server::RoomConnectionIdentity::hosted_bridged(
+                &principal,
+                operator,
+                nteract_identity::ConnectionScope::Editor,
+            ) {
+                Ok(identity) => identity,
+                Err(e) => {
+                    let (_reader, mut writer) = tokio::io::split(stream);
+                    send_error_response(
+                        &mut writer,
+                        format!("Hosted principal {principal} is not usable locally: {e}"),
+                        typed_bootstrap,
+                    )
+                    .await?;
+                    return Ok(());
+                }
+            };
+
+        let settings = self.settings.read().await.get_all();
+        let default_runtime = settings.default_runtime;
+        let default_python_env = settings.default_python_env;
+
+        let cell_count = { room.doc.read().await.cell_count() };
+        let comments_doc_id = room
+            .comments
+            .read(|doc| doc.comments_doc_id())
+            .context("read comments doc id for hosted notebook response")?;
+
+        let (reader, mut writer) = tokio::io::split(stream);
+        let response = NotebookConnectionInfo {
+            capabilities: ProtocolCapabilities::v4(Some(crate::daemon_version().to_string()))
+                .with_identity(
+                    connection_identity.actor_label().as_str(),
+                    connection_identity.scope().as_str(),
+                )
+                .with_comments_doc_id(comments_doc_id),
+            notebook_id: room.id.to_string(),
+            cell_count,
+            needs_trust_approval: false,
+            error: None,
+            ephemeral: true,
+            notebook_path: None,
+        };
+        if typed_bootstrap {
+            send_typed_bootstrap_frame(
+                &mut writer,
+                &ConnectionBootstrap::notebook_connection_info(response),
+            )
+            .await?;
+        } else {
+            send_json_frame(&mut writer, &response).await?;
+        }
+
+        let notebook_id = room.id.to_string();
+        crate::notebook_sync_server::handle_notebook_sync_connection(
+            reader,
+            writer,
+            room,
+            self.notebook_rooms.clone(),
+            notebook_id,
+            default_runtime,
+            default_python_env,
+            self.clone(),
+            None,  // working_dir: hosted rooms have no local project context
+            None,  // initial_metadata: the cloud room owns metadata
+            true,  // Skip ProtocolCapabilities - already sent in NotebookConnectionInfo
+            false, // typed_capabilities unused when skipped
+            None,  // No streaming load; content arrives via the bridge
+            false, // Not a newly-created notebook at a path
+            connection_identity,
+            client_protocol_version,
+        )
+        .await
+    }
+
     async fn handle_open_notebook<S>(
         self: Arc<Self>,
         stream: S,

--- a/crates/runtimed/src/daemon.rs
+++ b/crates/runtimed/src/daemon.rs
@@ -2833,7 +2833,8 @@ impl Daemon {
             return;
         };
 
-        if let Some(room) = self.notebook_rooms.peek_uuid(handle.room_id).await {
+        let room = self.notebook_rooms.peek_uuid(handle.room_id).await;
+        if let Some(room) = &room {
             let active_peers = room
                 .connections
                 .active_peers
@@ -2857,10 +2858,23 @@ impl Daemon {
 
         let removed = {
             let mut bridges = self.hosted_bridges.lock().await;
+            // Final atomicity check under the map lock: prepare_hosted_room's
+            // fast path takes its connection reservation *before* re-verifying
+            // the handle is still mapped (also under this lock), so exactly one
+            // of the two observes the other. Reading the room atomics here (no
+            // await) makes an attach that reserved after the advisory check
+            // above still veto the removal.
+            let attach_in_flight = room.as_ref().is_some_and(|room| {
+                room.connections
+                    .active_peers
+                    .load(std::sync::atomic::Ordering::Relaxed)
+                    > 0
+                    || room.connections.reservations() > 1
+            });
             let same_handle = bridges
                 .get(locator)
                 .is_some_and(|current| Arc::ptr_eq(current, &handle));
-            if same_handle {
+            if same_handle && !attach_in_flight {
                 bridges.remove(locator)
             } else {
                 None
@@ -2924,7 +2938,22 @@ impl Daemon {
                 room.mark_hosted();
                 let connection_reservation =
                     crate::notebook_sync_server::ReservationGuard::new(room.clone());
-                return Ok((room, bridge, connection_reservation));
+                // Re-verify under the map lock now that the reservation is
+                // held: an idle teardown that decided before this reservation
+                // existed may have removed (and shut down) the bridge. Teardown
+                // re-checks reservations under this same lock before removing,
+                // so observing the handle still mapped here means no teardown
+                // can take it from now on.
+                let still_mapped = {
+                    let bridges = self.hosted_bridges.lock().await;
+                    bridges
+                        .get(&locator)
+                        .is_some_and(|current| Arc::ptr_eq(current, &bridge))
+                };
+                if still_mapped {
+                    return Ok((room, bridge, connection_reservation));
+                }
+                // Torn down mid-lookup; fall through and spawn a fresh bridge.
             }
         }
 

--- a/crates/runtimed/src/daemon.rs
+++ b/crates/runtimed/src/daemon.rs
@@ -1946,6 +1946,10 @@ impl Daemon {
             self.run_windows_server().await?;
         }
 
+        // Shut down hosted bridges before draining rooms so their reservations
+        // release and room cleanup proceeds through the normal exit path.
+        self.shutdown_hosted_bridges().await;
+
         // Shut down all runtime agents before exiting.
         //
         // Runtime agents are spawned in their own process group (process_group(0)),
@@ -2815,6 +2819,73 @@ impl Daemon {
         bridges.values().find(|b| b.room_id == room_id).cloned()
     }
 
+    pub(crate) async fn teardown_hosted_bridge(&self, locator: &str) {
+        let handle = {
+            let bridges = self.hosted_bridges.lock().await;
+            bridges.get(locator).cloned()
+        };
+
+        let Some(handle) = handle else {
+            debug!(
+                "[runtimed] Hosted bridge idle teardown skipped for {}: bridge absent",
+                locator
+            );
+            return;
+        };
+
+        if let Some(room) = self.notebook_rooms.peek_uuid(handle.room_id).await {
+            let active_peers = room
+                .connections
+                .active_peers
+                .load(std::sync::atomic::Ordering::Relaxed);
+            if active_peers > 0 {
+                debug!(
+                    "[runtimed] Hosted bridge idle teardown skipped for {}: {} active peer(s)",
+                    locator, active_peers
+                );
+                return;
+            }
+        }
+
+        let removed = {
+            let mut bridges = self.hosted_bridges.lock().await;
+            let same_handle = bridges
+                .get(locator)
+                .is_some_and(|current| Arc::ptr_eq(current, &handle));
+            if same_handle {
+                bridges.remove(locator)
+            } else {
+                None
+            }
+        };
+
+        let Some(handle) = removed else {
+            debug!(
+                "[runtimed] Hosted bridge idle teardown skipped for {}: bridge changed",
+                locator
+            );
+            return;
+        };
+
+        info!("[runtimed] Tearing down hosted bridge for {}", locator);
+        handle.shutdown();
+    }
+
+    async fn shutdown_hosted_bridges(&self) {
+        let bridges: Vec<_> = {
+            let mut bridges = self.hosted_bridges.lock().await;
+            bridges.drain().collect()
+        };
+
+        for (locator, handle) in bridges {
+            info!(
+                "[runtimed] Shutting down hosted bridge for {} on daemon shutdown",
+                locator
+            );
+            handle.shutdown();
+        }
+    }
+
     /// Resolve or create the bridged room + bridge for a hosted locator.
     ///
     /// Errors are user-actionable configuration/connectivity messages meant
@@ -2879,6 +2950,21 @@ impl Daemon {
         .map_err(|e| format!("Failed to create bridged room for {locator}: {e}"))?;
         self.mark_rooms_ever_seen();
 
+        let idle_daemon: Weak<Self> = Arc::downgrade(self);
+        let idle_locator = locator.clone();
+        let bridge_options = crate::notebook_sync_server::HostedBridgeOptions {
+            on_idle: Some(Arc::new(move || {
+                let daemon = idle_daemon.clone();
+                let locator = idle_locator.clone();
+                tokio::spawn(async move {
+                    if let Some(daemon) = daemon.upgrade() {
+                        daemon.teardown_hosted_bridge(&locator).await;
+                    }
+                });
+            })),
+            ..Default::default()
+        };
+
         let mut bridges = self.hosted_bridges.lock().await;
         let bridge = match bridges.entry(locator.clone()) {
             std::collections::hash_map::Entry::Occupied(entry) => entry.get().clone(),
@@ -2898,6 +2984,7 @@ impl Daemon {
                     locator.clone(),
                     hosted_id.clone(),
                     guard,
+                    bridge_options,
                 ));
                 entry.insert(handle.clone());
                 handle

--- a/crates/runtimed/src/notebook_sync_server/hosted_bridge.rs
+++ b/crates/runtimed/src/notebook_sync_server/hosted_bridge.rs
@@ -24,6 +24,7 @@
 //! room as hosted `Request` frames (see `requests::mod`), and queue/output
 //! state converges back through RuntimeStateDoc sync.
 
+use std::sync::atomic::Ordering;
 use std::sync::Arc;
 use std::time::Duration;
 
@@ -49,6 +50,20 @@ const BACKOFF_RESET_AFTER: Duration = Duration::from_secs(30);
 /// Bound on queued forwarded request frames while (re)connecting.
 const FORWARD_QUEUE_CAPACITY: usize = 32;
 
+pub(crate) struct HostedBridgeOptions {
+    pub idle_after: Duration,
+    pub on_idle: Option<Arc<dyn Fn() + Send + Sync>>,
+}
+
+impl Default for HostedBridgeOptions {
+    fn default() -> Self {
+        Self {
+            idle_after: Duration::from_secs(15 * 60),
+            on_idle: None,
+        }
+    }
+}
+
 /// Handle to a running hosted-room bridge, owned by the daemon and keyed by
 /// the room's local UUID plus the normalized hosted locator.
 pub struct HostedBridgeHandle {
@@ -60,10 +75,9 @@ pub struct HostedBridgeHandle {
     principal_rx: watch::Receiver<Option<String>>,
     request_tx: mpsc::Sender<Vec<u8>>,
     task: tokio::task::JoinHandle<()>,
-    /// Keeps the bridged room resident (`reservations > 0`) so the peer-less
-    /// room reaper cannot evict it out from under the live cloud connection.
-    /// Idle-teardown policy for hosted rooms is a follow-up; dropping the
-    /// handle releases the room to normal eviction.
+    idle_task: Option<tokio::task::JoinHandle<()>>,
+    /// Keeps the bridged room resident (`reservations > 0`) while the bridge
+    /// is live. Idle teardown drops the handle so normal room eviction applies.
     _reservation: super::ReservationGuard,
 }
 
@@ -103,6 +117,9 @@ impl HostedBridgeHandle {
     /// eviction.
     pub fn shutdown(&self) {
         self.task.abort();
+        if let Some(idle_task) = &self.idle_task {
+            idle_task.abort();
+        }
     }
 }
 
@@ -116,11 +133,23 @@ pub(crate) fn spawn_hosted_bridge(
     locator: String,
     hosted_notebook_id: String,
     reservation: super::ReservationGuard,
+    options: HostedBridgeOptions,
 ) -> HostedBridgeHandle {
     let (principal_tx, principal_rx) = watch::channel(None);
     let (request_tx, request_rx) = mpsc::channel(FORWARD_QUEUE_CAPACITY);
     let room_id = room.id;
     let task_locator = locator.clone();
+    let HostedBridgeOptions {
+        idle_after,
+        on_idle,
+    } = options;
+    let idle_task = on_idle.map(|on_idle| {
+        let idle_room = room.clone();
+        let idle_locator = locator.clone();
+        tokio::spawn(async move {
+            monitor_idle(idle_room, idle_locator, idle_after, on_idle).await;
+        })
+    });
     let task = tokio::spawn(async move {
         run_bridge(room, transport, task_locator, principal_tx, request_rx).await;
     });
@@ -131,8 +160,47 @@ pub(crate) fn spawn_hosted_bridge(
         principal_rx,
         request_tx,
         task,
+        idle_task,
         _reservation: reservation,
     }
+}
+
+async fn monitor_idle(
+    room: Arc<NotebookRoom>,
+    locator: String,
+    idle_after: Duration,
+    on_idle: Arc<dyn Fn() + Send + Sync>,
+) {
+    let mut tick = tokio::time::interval(idle_check_interval(idle_after));
+    tick.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
+    let mut zero_since: Option<tokio::time::Instant> = None;
+    let mut fired_for_span = false;
+
+    loop {
+        tick.tick().await;
+        let active_peers = room.connections.active_peers.load(Ordering::Relaxed);
+        if active_peers > 0 {
+            zero_since = None;
+            fired_for_span = false;
+            continue;
+        }
+
+        let now = tokio::time::Instant::now();
+        let since = zero_since.get_or_insert(now);
+        if !fired_for_span && now.duration_since(*since) >= idle_after {
+            debug!(
+                "[hosted-bridge] {} idle for {:?}; signaling daemon teardown",
+                locator, idle_after
+            );
+            on_idle();
+            fired_for_span = true;
+        }
+    }
+}
+
+fn idle_check_interval(idle_after: Duration) -> Duration {
+    let coarse = (idle_after / 4).min(Duration::from_secs(60));
+    coarse.max(Duration::from_millis(50))
 }
 
 async fn run_bridge(
@@ -371,11 +439,13 @@ fn apply_cloud_runtime_sync(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::collections::HashMap;
     use std::sync::atomic::{AtomicUsize, Ordering};
 
     use futures::{SinkExt, StreamExt};
     use notebook_cloud_transport::{CloudAuth, CloudWsConfig};
     use notebook_doc::{NotebookDoc, TextEncoding};
+    use notebook_protocol::protocol::ExecutionIdRejectionReason;
     use runtime_doc::RuntimeStateDoc;
     use tokio::net::TcpListener;
     use tokio_tungstenite::tungstenite::Message;
@@ -402,9 +472,15 @@ mod tests {
 
     impl FakeCloudRoom {
         fn new() -> Self {
+            Self::with_cells(&[("remote-1", "code", "print('from cloud')")])
+        }
+
+        fn with_cells(cells: &[(&str, &str, &str)]) -> Self {
             let mut nb = NotebookDoc::bootstrap(TextEncoding::UnicodeCodePoint, CLOUD_ROOM_ACTOR);
-            nb.add_cell(0, "remote-1", "code").unwrap();
-            nb.update_source("remote-1", "print('from cloud')").unwrap();
+            for (index, (cell_id, cell_type, source)) in cells.iter().enumerate() {
+                nb.add_cell(index, cell_id, cell_type).unwrap();
+                nb.update_source(cell_id, source).unwrap();
+            }
             let rt = RuntimeStateDoc::try_new_with_actor(CLOUD_ROOM_ACTOR).unwrap();
             Self {
                 nb,
@@ -428,6 +504,7 @@ mod tests {
         mut room: FakeCloudRoom,
         observed_cells: tokio::sync::watch::Sender<Vec<String>>,
         frame_counter: Arc<AtomicUsize>,
+        request_counter: Arc<AtomicUsize>,
     ) {
         let (stream, _) = listener.accept().await.unwrap();
         let mut ws = tokio_tungstenite::accept_async(stream).await.unwrap();
@@ -491,23 +568,57 @@ mod tests {
                     ));
                 }
             } else if frame_type == NotebookFrameType::Request as u8 {
+                request_counter.fetch_add(1, Ordering::SeqCst);
                 let request: serde_json::Value = serde_json::from_slice(payload).unwrap();
-                assert_eq!(
-                    request.get("action").and_then(|v| v.as_str()),
-                    Some("execute_cell")
-                );
-                let cell_id = request
-                    .get("cell_id")
-                    .and_then(|v| v.as_str())
-                    .unwrap()
-                    .to_string();
-                let execution_id = format!("exec-{cell_id}");
-                room.rt.create_execution(&execution_id).unwrap();
-                if let Some(m) = room.rt.generate_sync_message(&mut room.rt_peer) {
-                    replies.push(encode_ws_frame(
-                        NotebookFrameType::RuntimeStateSync,
-                        &m.encode(),
-                    ));
+                match request.get("action").and_then(|v| v.as_str()) {
+                    Some("execute_cell") | Some("execute_cell_guarded") => {
+                        let cell_id = request
+                            .get("cell_id")
+                            .and_then(|v| v.as_str())
+                            .unwrap()
+                            .to_string();
+                        let execution_id = request
+                            .get("execution_id")
+                            .and_then(|v| v.as_str())
+                            .map(ToOwned::to_owned)
+                            .unwrap_or_else(|| format!("exec-{cell_id}"));
+                        room.rt.create_execution(&execution_id).unwrap();
+                        if let Some(m) = room.rt.generate_sync_message(&mut room.rt_peer) {
+                            replies.push(encode_ws_frame(
+                                NotebookFrameType::RuntimeStateSync,
+                                &m.encode(),
+                            ));
+                        }
+                    }
+                    Some("run_all_cells") | Some("run_all_cells_guarded") => {
+                        let cell_execution_ids: HashMap<String, String> = serde_json::from_value(
+                            request
+                                .get("cell_execution_ids")
+                                .cloned()
+                                .unwrap_or_else(|| serde_json::json!({})),
+                        )
+                        .unwrap();
+                        for execution_id in cell_execution_ids.values() {
+                            room.rt.create_execution(execution_id).unwrap();
+                        }
+                        if let Some(m) = room.rt.generate_sync_message(&mut room.rt_peer) {
+                            replies.push(encode_ws_frame(
+                                NotebookFrameType::RuntimeStateSync,
+                                &m.encode(),
+                            ));
+                        }
+                    }
+                    Some("interrupt_execution") | Some("send_comm") => {
+                        let accepted = serde_json::to_vec(&serde_json::json!({
+                            "type": "cloud_frame_accepted",
+                        }))
+                        .unwrap();
+                        replies.push(encode_ws_frame(
+                            NotebookFrameType::SessionControl,
+                            &accepted,
+                        ));
+                    }
+                    action => panic!("unexpected fake room request action: {action:?}"),
                 }
             }
             for reply in replies {
@@ -530,7 +641,15 @@ mod tests {
     async fn start_bridge(
         room: &Arc<NotebookRoom>,
         addr: std::net::SocketAddr,
-    ) -> HostedBridgeHandle {
+    ) -> Arc<HostedBridgeHandle> {
+        start_bridge_with_options(room, addr, HostedBridgeOptions::default()).await
+    }
+
+    async fn start_bridge_with_options(
+        room: &Arc<NotebookRoom>,
+        addr: std::net::SocketAddr,
+        options: HostedBridgeOptions,
+    ) -> Arc<HostedBridgeHandle> {
         let transport = CloudWsFrameTransport::new(CloudWsConfig {
             cloud_url: format!("http://{addr}"),
             notebook_id: "hosted-test".to_string(),
@@ -542,13 +661,14 @@ mod tests {
             workstation: None,
         });
         let guard = ReservationGuard::new(room.clone());
-        spawn_hosted_bridge(
+        Arc::new(spawn_hosted_bridge(
             room.clone(),
             transport,
             "https://cloud.test/n/hosted-test".to_string(),
             "hosted-test".to_string(),
             guard,
-        )
+            options,
+        ))
     }
 
     async fn wait_until<F>(what: &str, mut check: F)
@@ -573,11 +693,13 @@ mod tests {
         let addr = listener.local_addr().unwrap();
         let (cells_tx, mut cells_rx) = tokio::sync::watch::channel(Vec::new());
         let frames = Arc::new(AtomicUsize::new(0));
+        let requests = Arc::new(AtomicUsize::new(0));
         let server = tokio::spawn(serve_fake_cloud_room(
             listener,
             FakeCloudRoom::new(),
             cells_tx,
             frames.clone(),
+            requests,
         ));
 
         let tmp = tempfile::TempDir::new().unwrap();
@@ -643,11 +765,13 @@ mod tests {
         let addr = listener.local_addr().unwrap();
         let (cells_tx, _cells_rx) = tokio::sync::watch::channel(Vec::new());
         let frames = Arc::new(AtomicUsize::new(0));
+        let requests = Arc::new(AtomicUsize::new(0));
         let server = tokio::spawn(serve_fake_cloud_room(
             listener,
             FakeCloudRoom::new(),
             cells_tx,
             frames,
+            requests,
         ));
 
         let tmp = tempfile::TempDir::new().unwrap();
@@ -678,6 +802,398 @@ mod tests {
                     .read(|sd| sd.read_state().executions.contains_key("exec-remote-1"))
                     .unwrap_or(false)
             })
+        })
+        .await;
+
+        bridge.shutdown();
+        server.abort();
+    }
+
+    #[tokio::test]
+    async fn idle_on_idle_fires() {
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+        drop(listener);
+
+        let tmp = tempfile::TempDir::new().unwrap();
+        let room = test_room(&tmp);
+        let (tx, mut rx) = tokio::sync::mpsc::unbounded_channel();
+        let bridge = start_bridge_with_options(
+            &room,
+            addr,
+            HostedBridgeOptions {
+                idle_after: Duration::from_millis(200),
+                on_idle: Some(Arc::new(move || {
+                    let _ = tx.send(());
+                })),
+            },
+        )
+        .await;
+
+        tokio::time::timeout(Duration::from_secs(5), rx.recv())
+            .await
+            .expect("idle signal timed out")
+            .expect("idle signal channel closed");
+
+        bridge.shutdown();
+    }
+
+    #[tokio::test]
+    async fn idle_on_idle_does_not_fire_while_peer_attached() {
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+        drop(listener);
+
+        let tmp = tempfile::TempDir::new().unwrap();
+        let room = test_room(&tmp);
+        room.connections
+            .active_peers
+            .fetch_add(1, Ordering::Relaxed);
+        let (tx, mut rx) = tokio::sync::mpsc::unbounded_channel();
+        let bridge = start_bridge_with_options(
+            &room,
+            addr,
+            HostedBridgeOptions {
+                idle_after: Duration::from_millis(200),
+                on_idle: Some(Arc::new(move || {
+                    let _ = tx.send(());
+                })),
+            },
+        )
+        .await;
+
+        assert!(
+            tokio::time::timeout(Duration::from_secs(1), rx.recv())
+                .await
+                .is_err(),
+            "idle signal fired while a peer was attached"
+        );
+
+        bridge.shutdown();
+        room.connections
+            .active_peers
+            .fetch_sub(1, Ordering::Relaxed);
+    }
+
+    #[tokio::test]
+    async fn idle_on_idle_fires_once_per_idle_span() {
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+        drop(listener);
+
+        let tmp = tempfile::TempDir::new().unwrap();
+        let room = test_room(&tmp);
+        let (tx, mut rx) = tokio::sync::mpsc::unbounded_channel();
+        let bridge = start_bridge_with_options(
+            &room,
+            addr,
+            HostedBridgeOptions {
+                idle_after: Duration::from_millis(200),
+                on_idle: Some(Arc::new(move || {
+                    let _ = tx.send(());
+                })),
+            },
+        )
+        .await;
+
+        tokio::time::timeout(Duration::from_secs(5), rx.recv())
+            .await
+            .expect("first idle signal timed out")
+            .expect("idle signal channel closed");
+        assert!(
+            tokio::time::timeout(Duration::from_secs(1), rx.recv())
+                .await
+                .is_err(),
+            "idle signal fired more than once in one idle span"
+        );
+
+        bridge.shutdown();
+    }
+
+    fn test_daemon(tmp: &tempfile::TempDir) -> Arc<crate::daemon::Daemon> {
+        #[cfg(windows)]
+        let socket_path = {
+            let unique = tmp.path().file_name().unwrap_or_default().to_string_lossy();
+            std::path::PathBuf::from(format!(r"\\.\pipe\runtimed-hosted-bridge-{unique}"))
+        };
+        #[cfg(not(windows))]
+        let socket_path = tmp.path().join("hosted-bridge-test.sock");
+
+        crate::daemon::Daemon::new_for_test(crate::daemon::DaemonConfig {
+            socket_path,
+            cache_dir: tmp.path().join("envs"),
+            blob_store_dir: tmp.path().join("daemon-blobs"),
+            execution_store_dir: tmp.path().join("executions"),
+            notebook_docs_dir: tmp.path().join("daemon-notebook-docs"),
+            trusted_packages_db_path: tmp.path().join("trusted-packages.sqlite"),
+            notebook_registry_db_path: tmp.path().join("notebook-registry.sqlite"),
+            uv_pool_size: 0,
+            conda_pool_size: 0,
+            max_age_secs: 3600,
+            lock_dir: Some(tmp.path().to_path_buf()),
+            use_preferred_blob_port: false,
+            settings_json_path: Some(tmp.path().join("settings.json")),
+            ..Default::default()
+        })
+        .unwrap()
+    }
+
+    async fn register_bridge(
+        daemon: &Arc<crate::daemon::Daemon>,
+        bridge: &Arc<HostedBridgeHandle>,
+    ) {
+        daemon
+            .hosted_bridges
+            .lock()
+            .await
+            .insert(bridge.locator.clone(), bridge.clone());
+    }
+
+    #[tokio::test]
+    async fn hosted_execute_request_returns_cell_queued_and_syncs_back() {
+        use crate::protocol::{NotebookRequest, NotebookResponse};
+
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+        let (cells_tx, _cells_rx) = tokio::sync::watch::channel(Vec::new());
+        let frames = Arc::new(AtomicUsize::new(0));
+        let requests = Arc::new(AtomicUsize::new(0));
+        let server = tokio::spawn(serve_fake_cloud_room(
+            listener,
+            FakeCloudRoom::new(),
+            cells_tx,
+            frames,
+            requests.clone(),
+        ));
+
+        let tmp = tempfile::TempDir::new().unwrap();
+        let room = test_room(&tmp);
+        let bridge = start_bridge(&room, addr).await;
+        bridge
+            .wait_for_principal(Duration::from_secs(10))
+            .await
+            .expect("bridge principal");
+        let daemon = test_daemon(&tmp);
+        register_bridge(&daemon, &bridge).await;
+
+        // Daemon-minted execution id: response is CellQueued with a UUID, and
+        // the cloud room creates exactly that execution.
+        let response = crate::requests::handle_notebook_request(
+            &room,
+            NotebookRequest::ExecuteCell {
+                cell_id: "remote-1".to_string(),
+                execution_id: None,
+            },
+            daemon.clone(),
+            None,
+        )
+        .await;
+        let NotebookResponse::CellQueued {
+            cell_id,
+            execution_id,
+        } = response
+        else {
+            panic!("expected CellQueued, got {response:?}");
+        };
+        assert_eq!(cell_id, "remote-1");
+        uuid::Uuid::parse_str(&execution_id).expect("minted execution id is a UUID");
+        let room_for_wait = room.clone();
+        let expected = execution_id.clone();
+        wait_until("minted execution to sync back from the cloud", move || {
+            let room = room_for_wait.clone();
+            let expected = expected.clone();
+            Box::pin(async move {
+                room.state
+                    .read(|sd| sd.read_state().executions.contains_key(&expected))
+                    .unwrap_or(false)
+            })
+        })
+        .await;
+
+        // Caller-supplied valid id is echoed back verbatim.
+        let supplied = uuid::Uuid::new_v4().to_string();
+        let response = crate::requests::handle_notebook_request(
+            &room,
+            NotebookRequest::ExecuteCell {
+                cell_id: "remote-1".to_string(),
+                execution_id: Some(supplied.clone()),
+            },
+            daemon.clone(),
+            None,
+        )
+        .await;
+        match response {
+            NotebookResponse::CellQueued { execution_id, .. } => {
+                assert_eq!(execution_id, supplied);
+            }
+            other => panic!("expected CellQueued, got {other:?}"),
+        }
+
+        // The supplied-id forward is async; let it land before sampling the
+        // request counter for the negative assertion below.
+        let requests_for_wait = requests.clone();
+        wait_until("supplied-id execute to reach the cloud room", move || {
+            let requests = requests_for_wait.clone();
+            Box::pin(async move { requests.load(Ordering::SeqCst) >= 2 })
+        })
+        .await;
+
+        // Malformed id is rejected locally without contacting the cloud room.
+        let requests_before = requests.load(Ordering::SeqCst);
+        let response = crate::requests::handle_notebook_request(
+            &room,
+            NotebookRequest::ExecuteCell {
+                cell_id: "remote-1".to_string(),
+                execution_id: Some("not-a-uuid".to_string()),
+            },
+            daemon.clone(),
+            None,
+        )
+        .await;
+        match response {
+            NotebookResponse::ExecutionIdRejected { reason, .. } => {
+                assert_eq!(reason, ExecutionIdRejectionReason::Malformed);
+            }
+            other => panic!("expected ExecutionIdRejected, got {other:?}"),
+        }
+        tokio::time::sleep(Duration::from_millis(200)).await;
+        assert_eq!(
+            requests.load(Ordering::SeqCst),
+            requests_before,
+            "malformed execution id must not reach the cloud room"
+        );
+
+        bridge.shutdown();
+        server.abort();
+    }
+
+    #[tokio::test]
+    async fn hosted_run_all_request_queues_exactly_the_code_cells() {
+        use crate::protocol::{NotebookRequest, NotebookResponse};
+
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+        let (cells_tx, _cells_rx) = tokio::sync::watch::channel(Vec::new());
+        let frames = Arc::new(AtomicUsize::new(0));
+        let requests = Arc::new(AtomicUsize::new(0));
+        let server = tokio::spawn(serve_fake_cloud_room(
+            listener,
+            FakeCloudRoom::with_cells(&[
+                ("c1", "code", "x = 1"),
+                ("m1", "markdown", "# heading"),
+                ("c2", "code", "y = 2"),
+            ]),
+            cells_tx,
+            frames,
+            requests.clone(),
+        ));
+
+        let tmp = tempfile::TempDir::new().unwrap();
+        let room = test_room(&tmp);
+        let bridge = start_bridge(&room, addr).await;
+        bridge
+            .wait_for_principal(Duration::from_secs(10))
+            .await
+            .expect("bridge principal");
+        let daemon = test_daemon(&tmp);
+        register_bridge(&daemon, &bridge).await;
+
+        // The run-all handler reads code cells from the bridged room doc, so
+        // the cloud content must have converged first.
+        let room_for_wait = room.clone();
+        wait_until("cloud cells to reach the local room", move || {
+            let room = room_for_wait.clone();
+            Box::pin(async move {
+                let ids = room.doc.read().await.get_cell_ids();
+                ids.contains(&"c1".to_string()) && ids.contains(&"c2".to_string())
+            })
+        })
+        .await;
+
+        let response = crate::requests::handle_notebook_request(
+            &room,
+            NotebookRequest::RunAllCells {
+                cell_execution_ids: None,
+            },
+            daemon.clone(),
+            None,
+        )
+        .await;
+        let NotebookResponse::AllCellsQueued { queued } = response else {
+            panic!("expected AllCellsQueued, got {response:?}");
+        };
+        let queued_cells: Vec<&str> = queued.iter().map(|e| e.cell_id.as_str()).collect();
+        assert_eq!(
+            queued_cells,
+            vec!["c1", "c2"],
+            "exactly the code cells, in document order"
+        );
+        for entry in &queued {
+            uuid::Uuid::parse_str(&entry.execution_id).expect("minted execution id is a UUID");
+        }
+
+        let expected: Vec<String> = queued.iter().map(|e| e.execution_id.clone()).collect();
+        let room_for_wait = room.clone();
+        wait_until("run-all executions to sync back", move || {
+            let room = room_for_wait.clone();
+            let expected = expected.clone();
+            Box::pin(async move {
+                room.state
+                    .read(|sd| {
+                        let state = sd.read_state();
+                        expected.iter().all(|id| state.executions.contains_key(id))
+                    })
+                    .unwrap_or(false)
+            })
+        })
+        .await;
+
+        bridge.shutdown();
+        server.abort();
+    }
+
+    #[tokio::test]
+    async fn hosted_interrupt_request_forwards_and_acks() {
+        use crate::protocol::{NotebookRequest, NotebookResponse};
+
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+        let (cells_tx, _cells_rx) = tokio::sync::watch::channel(Vec::new());
+        let frames = Arc::new(AtomicUsize::new(0));
+        let requests = Arc::new(AtomicUsize::new(0));
+        let server = tokio::spawn(serve_fake_cloud_room(
+            listener,
+            FakeCloudRoom::new(),
+            cells_tx,
+            frames,
+            requests.clone(),
+        ));
+
+        let tmp = tempfile::TempDir::new().unwrap();
+        let room = test_room(&tmp);
+        let bridge = start_bridge(&room, addr).await;
+        bridge
+            .wait_for_principal(Duration::from_secs(10))
+            .await
+            .expect("bridge principal");
+        let daemon = test_daemon(&tmp);
+        register_bridge(&daemon, &bridge).await;
+
+        let response = crate::requests::handle_notebook_request(
+            &room,
+            NotebookRequest::InterruptExecution {},
+            daemon.clone(),
+            None,
+        )
+        .await;
+        assert!(
+            matches!(response, NotebookResponse::InterruptSent {}),
+            "expected InterruptSent, got {response:?}"
+        );
+        let requests_for_wait = requests.clone();
+        wait_until("interrupt request to reach the cloud room", move || {
+            let requests = requests_for_wait.clone();
+            Box::pin(async move { requests.load(Ordering::SeqCst) >= 1 })
         })
         .await;
 

--- a/crates/runtimed/src/notebook_sync_server/hosted_bridge.rs
+++ b/crates/runtimed/src/notebook_sync_server/hosted_bridge.rs
@@ -1,0 +1,715 @@
+//! Daemon-side bridge between a local notebook room and a hosted cloud room.
+//!
+//! Implements the daemon-mediated topology from
+//! `docs/memos/desktop-cloud-daemon-bridge.md` (#3861): the daemon dials the
+//! hosted room over [`CloudWsFrameTransport`] and attaches it as one more sync
+//! peer of a local, ephemeral `NotebookRoom`. Local peers (desktop windows,
+//! MCP sessions) connect to that room exactly like any daemon-local notebook.
+//!
+//! Echo suppression is structural: the room holds one `NotebookDoc` instance,
+//! and the cloud connection is one automerge `sync::State` against it, exactly
+//! like each local peer. The sync protocol never replays a change to the peer
+//! it came from, so there is no bridge-specific dedup state to get wrong.
+//!
+//! Attribution: inbound cloud changes carry the actor labels the hosted room
+//! already authorized, and are applied without local re-validation — the cloud
+//! room is the authority for its own history (other collaborators' principals
+//! legitimately appear in it). Local peers author under the bridge's observed
+//! cloud principal via [`RoomConnectionIdentity::hosted_bridged`], so the
+//! hosted room's actor-authorization check accepts their changes and cloud
+//! history shows `<principal>/<local-operator>` per client.
+//!
+//! RuntimeStateDoc: the hosted room is authoritative. Hosted-bridged rooms
+//! never launch local kernels; execute requests are forwarded to the cloud
+//! room as hosted `Request` frames (see `requests::mod`), and queue/output
+//! state converges back through RuntimeStateDoc sync.
+
+use std::sync::Arc;
+use std::time::Duration;
+
+use automerge::sync;
+use notebook_cloud_transport::CloudWsFrameTransport;
+use notebook_doc::diff::diff_metadata_touched;
+use notebook_protocol::connection::{FrameSink, FrameSource, FrameTransport};
+use notebook_wire::NotebookFrameType;
+use tokio::sync::{mpsc, watch};
+use tracing::{debug, info, warn};
+
+use super::{
+    check_and_broadcast_sync_state, check_and_update_trust_state, process_markdown_assets,
+    NotebookRoom,
+};
+
+/// Initial reconnect backoff; doubles per failed attempt.
+const BACKOFF_INITIAL: Duration = Duration::from_secs(1);
+/// Backoff ceiling.
+const BACKOFF_MAX: Duration = Duration::from_secs(60);
+/// A connection that lived at least this long resets the backoff.
+const BACKOFF_RESET_AFTER: Duration = Duration::from_secs(30);
+/// Bound on queued forwarded request frames while (re)connecting.
+const FORWARD_QUEUE_CAPACITY: usize = 32;
+
+/// Handle to a running hosted-room bridge, owned by the daemon and keyed by
+/// the room's local UUID plus the normalized hosted locator.
+pub struct HostedBridgeHandle {
+    pub room_id: uuid::Uuid,
+    /// Normalized hosted locator, `https://<host>/n/<notebook_id>`.
+    pub locator: String,
+    /// Hosted notebook id (ULID) on the cloud domain.
+    pub hosted_notebook_id: String,
+    principal_rx: watch::Receiver<Option<String>>,
+    request_tx: mpsc::Sender<Vec<u8>>,
+    task: tokio::task::JoinHandle<()>,
+    /// Keeps the bridged room resident (`reservations > 0`) so the peer-less
+    /// room reaper cannot evict it out from under the live cloud connection.
+    /// Idle-teardown policy for hosted rooms is a follow-up; dropping the
+    /// handle releases the room to normal eviction.
+    _reservation: super::ReservationGuard,
+}
+
+impl HostedBridgeHandle {
+    /// The authenticated cloud principal, once the first connect has observed
+    /// `cloud_room_ready`.
+    pub fn principal(&self) -> Option<String> {
+        self.principal_rx.borrow().clone()
+    }
+
+    /// Wait until the bridge has observed the cloud principal (first
+    /// successful connect), bounded by `timeout`.
+    pub async fn wait_for_principal(&self, timeout: Duration) -> Option<String> {
+        let mut rx = self.principal_rx.clone();
+        let deadline = tokio::time::Instant::now() + timeout;
+        loop {
+            if let Some(principal) = rx.borrow_and_update().clone() {
+                return Some(principal);
+            }
+            match tokio::time::timeout_at(deadline, rx.changed()).await {
+                Ok(Ok(())) => continue,
+                // Bridge task dropped its sender or we timed out.
+                Ok(Err(_)) | Err(_) => return None,
+            }
+        }
+    }
+
+    /// Queue a hosted `Request` frame (JSON payload) for the cloud room.
+    /// Best-effort: fails when the bridge is gone or the queue is full.
+    pub fn forward_request(&self, payload: Vec<u8>) -> anyhow::Result<()> {
+        self.request_tx
+            .try_send(payload)
+            .map_err(|e| anyhow::anyhow!("hosted bridge request queue unavailable: {e}"))
+    }
+
+    /// Stop the bridge task. The room itself is torn down by normal room
+    /// eviction.
+    pub fn shutdown(&self) {
+        self.task.abort();
+    }
+}
+
+/// Spawn the bridge task for `room` over `transport`.
+///
+/// The transport is taken pre-built (rather than a config) so tests can point
+/// it at an in-process fake room server.
+pub(crate) fn spawn_hosted_bridge(
+    room: Arc<NotebookRoom>,
+    transport: CloudWsFrameTransport,
+    locator: String,
+    hosted_notebook_id: String,
+    reservation: super::ReservationGuard,
+) -> HostedBridgeHandle {
+    let (principal_tx, principal_rx) = watch::channel(None);
+    let (request_tx, request_rx) = mpsc::channel(FORWARD_QUEUE_CAPACITY);
+    let room_id = room.id;
+    let task_locator = locator.clone();
+    let task = tokio::spawn(async move {
+        run_bridge(room, transport, task_locator, principal_tx, request_rx).await;
+    });
+    HostedBridgeHandle {
+        room_id,
+        locator,
+        hosted_notebook_id,
+        principal_rx,
+        request_tx,
+        task,
+        _reservation: reservation,
+    }
+}
+
+async fn run_bridge(
+    room: Arc<NotebookRoom>,
+    transport: CloudWsFrameTransport,
+    locator: String,
+    principal_tx: watch::Sender<Option<String>>,
+    mut request_rx: mpsc::Receiver<Vec<u8>>,
+) {
+    let mut backoff = BACKOFF_INITIAL;
+    loop {
+        // A closed principal watch means the daemon dropped the handle; stop
+        // dialing on behalf of a room nobody can reach.
+        if principal_tx.is_closed() {
+            return;
+        }
+        let connected_at = tokio::time::Instant::now();
+        match transport.connect().await {
+            Ok((source, sink)) => {
+                let Some(principal) = transport.principal().map(str::to_string) else {
+                    warn!(
+                        "[hosted-bridge] {} connected without a principal; retrying",
+                        locator
+                    );
+                    tokio::time::sleep(backoff).await;
+                    backoff = (backoff * 2).min(BACKOFF_MAX);
+                    continue;
+                };
+                let _ = principal_tx.send(Some(principal.clone()));
+                info!(
+                    "[hosted-bridge] {} attached as principal {}",
+                    locator, principal
+                );
+                if let Err(e) = run_connection(&room, &locator, source, sink, &mut request_rx).await
+                {
+                    warn!("[hosted-bridge] {} connection ended: {}", locator, e);
+                } else {
+                    info!("[hosted-bridge] {} connection closed", locator);
+                }
+            }
+            Err(e) => {
+                warn!("[hosted-bridge] {} connect failed: {}", locator, e);
+            }
+        }
+        if connected_at.elapsed() >= BACKOFF_RESET_AFTER {
+            backoff = BACKOFF_INITIAL;
+        }
+        tokio::time::sleep(backoff).await;
+        backoff = (backoff * 2).min(BACKOFF_MAX);
+    }
+}
+
+/// Drive one live cloud connection until it drops.
+async fn run_connection<S, W>(
+    room: &Arc<NotebookRoom>,
+    locator: &str,
+    mut source: S,
+    mut sink: W,
+    request_rx: &mut mpsc::Receiver<Vec<u8>>,
+) -> anyhow::Result<()>
+where
+    S: FrameSource + Send,
+    W: FrameSink + Send,
+{
+    // Fresh sync states per connection: the room may have advanced while
+    // disconnected, and cloud transport sync state is connection-scoped.
+    let mut nb_peer = sync::State::new();
+    let mut rt_peer = sync::State::new();
+
+    // Subscribe before the initial send so a local change landing between
+    // "generate initial" and "select loop" is not missed.
+    let mut changed_rx = room.broadcasts.changed_tx.subscribe();
+    let mut state_rx = room.state.subscribe();
+
+    if let Some(encoded) = generate_notebook_sync(room, &mut nb_peer).await? {
+        sink.send_frame(NotebookFrameType::AutomergeSync, &encoded)
+            .await?;
+    }
+    if let Some(encoded) = generate_runtime_sync(room, &mut rt_peer)? {
+        sink.send_frame(NotebookFrameType::RuntimeStateSync, &encoded)
+            .await?;
+    }
+
+    loop {
+        tokio::select! {
+            frame = source.recv_frame() => {
+                let Some(frame) = frame else {
+                    return Ok(());
+                };
+                let frame = frame?;
+                match frame.frame_type {
+                    NotebookFrameType::AutomergeSync => {
+                        let reply = apply_cloud_notebook_sync(room, &mut nb_peer, &frame.payload).await?;
+                        if let Some(encoded) = reply {
+                            sink.send_frame(NotebookFrameType::AutomergeSync, &encoded).await?;
+                        }
+                    }
+                    NotebookFrameType::RuntimeStateSync => {
+                        let reply = apply_cloud_runtime_sync(room, &mut rt_peer, &frame.payload)?;
+                        if let Some(encoded) = reply {
+                            sink.send_frame(NotebookFrameType::RuntimeStateSync, &encoded).await?;
+                        }
+                    }
+                    NotebookFrameType::SessionControl => {
+                        if let Ok(control) = serde_json::from_slice::<serde_json::Value>(&frame.payload) {
+                            let ctl = control.get("type").and_then(|t| t.as_str()).unwrap_or("");
+                            if ctl != "cloud_frame_accepted" && ctl != "cloud_room_ready" {
+                                debug!("[hosted-bridge] {} control: {}", locator, ctl);
+                            }
+                        }
+                    }
+                    other => {
+                        debug!(
+                            "[hosted-bridge] {} ignoring frame {:?} ({} bytes)",
+                            locator, other, frame.payload.len()
+                        );
+                    }
+                }
+            }
+            changed = changed_rx.recv() => {
+                // Lagged is fine: sync generation reads current doc state, so
+                // one pass after any number of missed notifications converges.
+                if let Err(tokio::sync::broadcast::error::RecvError::Closed) = changed {
+                    return Ok(());
+                }
+                if let Some(encoded) = generate_notebook_sync(room, &mut nb_peer).await? {
+                    sink.send_frame(NotebookFrameType::AutomergeSync, &encoded).await?;
+                }
+            }
+            state_changed = state_rx.recv() => {
+                if let Err(tokio::sync::broadcast::error::RecvError::Closed) = state_changed {
+                    return Ok(());
+                }
+                if let Some(encoded) = generate_runtime_sync(room, &mut rt_peer)? {
+                    sink.send_frame(NotebookFrameType::RuntimeStateSync, &encoded).await?;
+                }
+            }
+            request = request_rx.recv() => {
+                let Some(payload) = request else {
+                    return Ok(());
+                };
+                sink.send_frame(NotebookFrameType::Request, &payload).await?;
+            }
+        }
+    }
+}
+
+async fn generate_notebook_sync(
+    room: &NotebookRoom,
+    nb_peer: &mut sync::State,
+) -> anyhow::Result<Option<Vec<u8>>> {
+    let mut doc = room.doc.write().await;
+    doc.generate_sync_message_recovering(nb_peer, "hosted-bridge-doc-send")
+        .map(|message| message.map(|m| m.encode()))
+        .map_err(|e| anyhow::anyhow!("hosted bridge doc sync generate: {e}"))
+}
+
+fn generate_runtime_sync(
+    room: &NotebookRoom,
+    rt_peer: &mut sync::State,
+) -> anyhow::Result<Option<Vec<u8>>> {
+    room.state
+        .generate_sync_message_recovering(rt_peer, "hosted-bridge-state-send")
+        .map(|message| message.map(|m| m.encode()))
+        .map_err(|e| anyhow::anyhow!("hosted bridge state sync generate: {e}"))
+}
+
+/// Apply an inbound cloud NotebookDoc sync frame to the room doc and produce
+/// the reply, mirroring `peer_notebook_sync::apply_notebook_doc_frame` minus
+/// actor validation (the hosted room already authorized these changes) and
+/// minus persistence (hosted rooms are ephemeral in this slice).
+async fn apply_cloud_notebook_sync(
+    room: &Arc<NotebookRoom>,
+    nb_peer: &mut sync::State,
+    payload: &[u8],
+) -> anyhow::Result<Option<Vec<u8>>> {
+    let message = sync::Message::decode(payload)
+        .map_err(|e| anyhow::anyhow!("decode hosted notebook sync: {e}"))?;
+
+    let (changed, metadata_changed, reply) = {
+        let mut doc = room.doc.write().await;
+        let heads_before = doc.get_heads();
+        doc.receive_sync_message_recovering(nb_peer, message, "hosted-bridge-doc-receive")
+            .map_err(|e| anyhow::anyhow!("apply hosted notebook sync: {e}"))?;
+        let heads_after = doc.get_heads();
+        let changed = heads_before != heads_after;
+        let metadata_changed =
+            changed && diff_metadata_touched(doc.doc_mut(), &heads_before, &heads_after);
+        if changed {
+            let _ = room.broadcasts.changed_tx.send(());
+        }
+        let reply = doc
+            .generate_sync_message_recovering(nb_peer, "hosted-bridge-doc-reply")
+            .map_err(|e| anyhow::anyhow!("hosted bridge doc reply: {e}"))?
+            .map(|m| m.encode());
+        (changed, metadata_changed, reply)
+    };
+
+    if changed {
+        if metadata_changed {
+            check_and_broadcast_sync_state(room).await;
+        }
+        check_and_update_trust_state(room).await;
+        process_markdown_assets(room).await;
+    }
+
+    Ok(reply)
+}
+
+/// Apply an inbound cloud RuntimeStateDoc sync frame. The cloud room is the
+/// authority for runtime state on a bridged room, so changes are accepted
+/// (`receive_sync_message_with_changes`), the opposite of the read-only-peer
+/// stripping used for untrusted local clients.
+fn apply_cloud_runtime_sync(
+    room: &NotebookRoom,
+    rt_peer: &mut sync::State,
+    payload: &[u8],
+) -> anyhow::Result<Option<Vec<u8>>> {
+    let message = sync::Message::decode(payload)
+        .map_err(|e| anyhow::anyhow!("decode hosted runtime sync: {e}"))?;
+    room.state
+        .with_doc(|state_doc| {
+            state_doc.receive_sync_message_with_changes_recovering(
+                rt_peer,
+                message,
+                "hosted-bridge-state-receive",
+            )?;
+            state_doc
+                .generate_sync_message_recovering(rt_peer, "hosted-bridge-state-reply")
+                .map(|m| m.map(|m| m.encode()))
+                .map_err(Into::into)
+        })
+        .map_err(|e| anyhow::anyhow!("apply hosted runtime sync: {e}"))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::atomic::{AtomicUsize, Ordering};
+
+    use futures::{SinkExt, StreamExt};
+    use notebook_cloud_transport::{CloudAuth, CloudWsConfig};
+    use notebook_doc::{NotebookDoc, TextEncoding};
+    use runtime_doc::RuntimeStateDoc;
+    use tokio::net::TcpListener;
+    use tokio_tungstenite::tungstenite::Message;
+
+    use crate::blob_store::BlobStore;
+    use crate::notebook_sync_server::{NotebookRoom, ReservationGuard, RoomConnectionIdentity};
+
+    const CLOUD_PRINCIPAL: &str = "user:anaconda:kyle";
+    const CLOUD_ROOM_ACTOR: &str = "user:anaconda:kyle/host:room:1";
+
+    fn encode_ws_frame(frame_type: NotebookFrameType, payload: &[u8]) -> Vec<u8> {
+        let mut frame = Vec::with_capacity(1 + payload.len());
+        frame.push(frame_type as u8);
+        frame.extend_from_slice(payload);
+        frame
+    }
+
+    struct FakeCloudRoom {
+        nb: NotebookDoc,
+        rt: RuntimeStateDoc,
+        nb_peer: sync::State,
+        rt_peer: sync::State,
+    }
+
+    impl FakeCloudRoom {
+        fn new() -> Self {
+            let mut nb = NotebookDoc::bootstrap(TextEncoding::UnicodeCodePoint, CLOUD_ROOM_ACTOR);
+            nb.add_cell(0, "remote-1", "code").unwrap();
+            nb.update_source("remote-1", "print('from cloud')").unwrap();
+            let rt = RuntimeStateDoc::try_new_with_actor(CLOUD_ROOM_ACTOR).unwrap();
+            Self {
+                nb,
+                rt,
+                nb_peer: sync::State::new(),
+                rt_peer: sync::State::new(),
+            }
+        }
+    }
+
+    /// Serve one fake hosted-room WebSocket connection: send
+    /// `cloud_room_ready`, then act as the room-authoritative automerge peer
+    /// for NotebookDoc + RuntimeStateDoc and answer `execute_cell` Request
+    /// frames by creating a queued execution in the runtime doc.
+    ///
+    /// `observed` returns each cell id seen in the fake room's doc after
+    /// every applied sync message; `frame_counter` counts inbound
+    /// AutomergeSync frames (echo-storm probe).
+    async fn serve_fake_cloud_room(
+        listener: TcpListener,
+        mut room: FakeCloudRoom,
+        observed_cells: tokio::sync::watch::Sender<Vec<String>>,
+        frame_counter: Arc<AtomicUsize>,
+    ) {
+        let (stream, _) = listener.accept().await.unwrap();
+        let mut ws = tokio_tungstenite::accept_async(stream).await.unwrap();
+
+        let ready = serde_json::to_vec(&serde_json::json!({
+            "type": "cloud_room_ready",
+            "actor_label": CLOUD_ROOM_ACTOR,
+            "connection_scope": "editor",
+        }))
+        .unwrap();
+        ws.send(Message::Binary(
+            encode_ws_frame(NotebookFrameType::SessionControl, &ready).into(),
+        ))
+        .await
+        .unwrap();
+
+        // Kick initial sync for both docs, like the real room host.
+        if let Some(m) = room.nb.generate_sync_message(&mut room.nb_peer) {
+            ws.send(Message::Binary(
+                encode_ws_frame(NotebookFrameType::AutomergeSync, &m.encode()).into(),
+            ))
+            .await
+            .unwrap();
+        }
+        if let Some(m) = room.rt.generate_sync_message(&mut room.rt_peer) {
+            ws.send(Message::Binary(
+                encode_ws_frame(NotebookFrameType::RuntimeStateSync, &m.encode()).into(),
+            ))
+            .await
+            .unwrap();
+        }
+
+        while let Some(Ok(msg)) = ws.next().await {
+            let Message::Binary(data) = msg else { continue };
+            let Some((&frame_type, payload)) = data.split_first() else {
+                continue;
+            };
+            let mut replies: Vec<Vec<u8>> = Vec::new();
+            if frame_type == NotebookFrameType::AutomergeSync as u8 {
+                frame_counter.fetch_add(1, Ordering::SeqCst);
+                let incoming = sync::Message::decode(payload).unwrap();
+                room.nb
+                    .receive_sync_message(&mut room.nb_peer, incoming)
+                    .unwrap();
+                let _ = observed_cells.send(room.nb.get_cell_ids());
+                if let Some(m) = room.nb.generate_sync_message(&mut room.nb_peer) {
+                    replies.push(encode_ws_frame(
+                        NotebookFrameType::AutomergeSync,
+                        &m.encode(),
+                    ));
+                }
+            } else if frame_type == NotebookFrameType::RuntimeStateSync as u8 {
+                let incoming = sync::Message::decode(payload).unwrap();
+                room.rt
+                    .receive_sync_message_with_changes(&mut room.rt_peer, incoming)
+                    .unwrap();
+                if let Some(m) = room.rt.generate_sync_message(&mut room.rt_peer) {
+                    replies.push(encode_ws_frame(
+                        NotebookFrameType::RuntimeStateSync,
+                        &m.encode(),
+                    ));
+                }
+            } else if frame_type == NotebookFrameType::Request as u8 {
+                let request: serde_json::Value = serde_json::from_slice(payload).unwrap();
+                assert_eq!(
+                    request.get("action").and_then(|v| v.as_str()),
+                    Some("execute_cell")
+                );
+                let cell_id = request
+                    .get("cell_id")
+                    .and_then(|v| v.as_str())
+                    .unwrap()
+                    .to_string();
+                let execution_id = format!("exec-{cell_id}");
+                room.rt.create_execution(&execution_id).unwrap();
+                if let Some(m) = room.rt.generate_sync_message(&mut room.rt_peer) {
+                    replies.push(encode_ws_frame(
+                        NotebookFrameType::RuntimeStateSync,
+                        &m.encode(),
+                    ));
+                }
+            }
+            for reply in replies {
+                ws.send(Message::Binary(reply.into())).await.unwrap();
+            }
+        }
+    }
+
+    fn test_room(tmp: &tempfile::TempDir) -> Arc<NotebookRoom> {
+        let blob_store = Arc::new(BlobStore::new(tmp.path().join("blobs")));
+        Arc::new(NotebookRoom::new_fresh(
+            uuid::Uuid::new_v4(),
+            None,
+            tmp.path(),
+            blob_store,
+            true,
+        ))
+    }
+
+    async fn start_bridge(
+        room: &Arc<NotebookRoom>,
+        addr: std::net::SocketAddr,
+    ) -> HostedBridgeHandle {
+        let transport = CloudWsFrameTransport::new(CloudWsConfig {
+            cloud_url: format!("http://{addr}"),
+            notebook_id: "hosted-test".to_string(),
+            scope: "editor".to_string(),
+            auth: CloudAuth::Dev {
+                token: "dev-token".to_string(),
+                user: "kyle".to_string(),
+            },
+            workstation: None,
+        });
+        let guard = ReservationGuard::new(room.clone());
+        spawn_hosted_bridge(
+            room.clone(),
+            transport,
+            "https://cloud.test/n/hosted-test".to_string(),
+            "hosted-test".to_string(),
+            guard,
+        )
+    }
+
+    async fn wait_until<F>(what: &str, mut check: F)
+    where
+        F: FnMut() -> std::pin::Pin<Box<dyn std::future::Future<Output = bool> + Send>>,
+    {
+        let deadline = tokio::time::Instant::now() + Duration::from_secs(10);
+        loop {
+            if check().await {
+                return;
+            }
+            if tokio::time::Instant::now() > deadline {
+                panic!("timed out waiting for {what}");
+            }
+            tokio::time::sleep(Duration::from_millis(25)).await;
+        }
+    }
+
+    #[tokio::test]
+    async fn bridge_converges_both_directions_without_echo_storm() {
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+        let (cells_tx, mut cells_rx) = tokio::sync::watch::channel(Vec::new());
+        let frames = Arc::new(AtomicUsize::new(0));
+        let server = tokio::spawn(serve_fake_cloud_room(
+            listener,
+            FakeCloudRoom::new(),
+            cells_tx,
+            frames.clone(),
+        ));
+
+        let tmp = tempfile::TempDir::new().unwrap();
+        let room = test_room(&tmp);
+        let bridge = start_bridge(&room, addr).await;
+
+        let principal = bridge.wait_for_principal(Duration::from_secs(10)).await;
+        assert_eq!(principal.as_deref(), Some(CLOUD_PRINCIPAL));
+
+        // Cloud -> local: the fake room's seeded cell reaches the daemon room.
+        let room_for_wait = room.clone();
+        wait_until("cloud cell to reach the local room", move || {
+            let room = room_for_wait.clone();
+            Box::pin(async move {
+                room.doc
+                    .read()
+                    .await
+                    .get_cell_ids()
+                    .contains(&"remote-1".to_string())
+            })
+        })
+        .await;
+
+        // Local -> cloud: a local edit converges to the fake room.
+        {
+            let mut doc = room.doc.write().await;
+            doc.add_cell_after("local-1", "code", Some("remote-1"))
+                .unwrap();
+            doc.update_source("local-1", "x = 1").unwrap();
+        }
+        let _ = room.broadcasts.changed_tx.send(());
+
+        let deadline = tokio::time::Instant::now() + Duration::from_secs(10);
+        loop {
+            if cells_rx.borrow().contains(&"local-1".to_string()) {
+                break;
+            }
+            if tokio::time::Instant::now() > deadline {
+                panic!("timed out waiting for local cell to reach the fake cloud room");
+            }
+            let _ = tokio::time::timeout(Duration::from_millis(100), cells_rx.changed()).await;
+        }
+
+        // Echo suppression: once converged, the exchange quiesces. Allow the
+        // in-flight tail to settle, then assert no further NotebookDoc sync
+        // frames arrive at the fake room.
+        tokio::time::sleep(Duration::from_millis(300)).await;
+        let settled = frames.load(Ordering::SeqCst);
+        tokio::time::sleep(Duration::from_millis(400)).await;
+        assert_eq!(
+            frames.load(Ordering::SeqCst),
+            settled,
+            "bridge kept exchanging NotebookDoc sync frames after convergence"
+        );
+
+        bridge.shutdown();
+        server.abort();
+    }
+
+    #[tokio::test]
+    async fn forwarded_execute_creates_cloud_execution_that_syncs_back() {
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+        let (cells_tx, _cells_rx) = tokio::sync::watch::channel(Vec::new());
+        let frames = Arc::new(AtomicUsize::new(0));
+        let server = tokio::spawn(serve_fake_cloud_room(
+            listener,
+            FakeCloudRoom::new(),
+            cells_tx,
+            frames,
+        ));
+
+        let tmp = tempfile::TempDir::new().unwrap();
+        let room = test_room(&tmp);
+        let bridge = start_bridge(&room, addr).await;
+        bridge
+            .wait_for_principal(Duration::from_secs(10))
+            .await
+            .expect("bridge principal");
+
+        bridge
+            .forward_request(
+                serde_json::to_vec(&serde_json::json!({
+                    "action": "execute_cell",
+                    "cell_id": "remote-1",
+                }))
+                .unwrap(),
+            )
+            .unwrap();
+
+        // The cloud room creates the execution; it converges back into the
+        // bridged room's RuntimeStateDoc.
+        let room_for_wait = room.clone();
+        wait_until("cloud execution to reach the local room", move || {
+            let room = room_for_wait.clone();
+            Box::pin(async move {
+                room.state
+                    .read(|sd| sd.read_state().executions.contains_key("exec-remote-1"))
+                    .unwrap_or(false)
+            })
+        })
+        .await;
+
+        bridge.shutdown();
+        server.abort();
+    }
+
+    #[tokio::test]
+    async fn hosted_bridged_identity_authors_under_cloud_principal() {
+        let identity = RoomConnectionIdentity::hosted_bridged(
+            CLOUD_PRINCIPAL,
+            Some("desktop:win1".to_string()),
+            nteract_identity::ConnectionScope::Editor,
+        )
+        .unwrap();
+
+        let label = identity.actor_label().as_str().to_string();
+        assert!(
+            label.starts_with("user:anaconda:kyle/desktop:win1"),
+            "actor label {label} should be <cloud principal>/<operator>"
+        );
+
+        // Changes authored under the cloud principal pass validation.
+        identity
+            .validate_actor_labels(["user:anaconda:kyle/desktop:win2"])
+            .unwrap();
+        // The local-Unix principal is rejected: it would be dropped by the
+        // hosted room's actor authorization.
+        assert!(identity
+            .validate_actor_labels(["local:kyle/desktop:win1"])
+            .is_err());
+        // Operator-only legacy labels are rejected on bridged rooms.
+        assert!(identity.validate_actor_labels(["desktop:win1"]).is_err());
+    }
+}

--- a/crates/runtimed/src/notebook_sync_server/hosted_bridge.rs
+++ b/crates/runtimed/src/notebook_sync_server/hosted_bridge.rs
@@ -36,10 +36,7 @@ use notebook_wire::NotebookFrameType;
 use tokio::sync::{mpsc, watch};
 use tracing::{debug, info, warn};
 
-use super::{
-    check_and_broadcast_sync_state, check_and_update_trust_state, process_markdown_assets,
-    NotebookRoom,
-};
+use super::{check_and_broadcast_sync_state, check_and_update_trust_state, NotebookRoom};
 
 /// Initial reconnect backoff; doubles per failed attempt.
 const BACKOFF_INITIAL: Duration = Duration::from_secs(1);
@@ -307,8 +304,20 @@ where
                     NotebookFrameType::SessionControl => {
                         if let Ok(control) = serde_json::from_slice::<serde_json::Value>(&frame.payload) {
                             let ctl = control.get("type").and_then(|t| t.as_str()).unwrap_or("");
-                            if ctl != "cloud_frame_accepted" && ctl != "cloud_room_ready" {
-                                debug!("[hosted-bridge] {} control: {}", locator, ctl);
+                            match ctl {
+                                "cloud_frame_accepted" | "cloud_room_ready" => {}
+                                "cloud_frame_rejected" => {
+                                    // Forwarded requests are fire-and-forget; this
+                                    // rejection is the only local failure signal.
+                                    warn!(
+                                        "[hosted-bridge] {} cloud_frame_rejected: {}",
+                                        locator,
+                                        String::from_utf8_lossy(&frame.payload)
+                                    );
+                                }
+                                _ => {
+                                    debug!("[hosted-bridge] {} control: {}", locator, ctl);
+                                }
                             }
                         }
                     }
@@ -404,7 +413,6 @@ async fn apply_cloud_notebook_sync(
             check_and_broadcast_sync_state(room).await;
         }
         check_and_update_trust_state(room).await;
-        process_markdown_assets(room).await;
     }
 
     Ok(reply)
@@ -447,11 +455,14 @@ mod tests {
     use notebook_doc::{NotebookDoc, TextEncoding};
     use notebook_protocol::protocol::ExecutionIdRejectionReason;
     use runtime_doc::RuntimeStateDoc;
-    use tokio::net::TcpListener;
+    use tokio::net::{TcpListener, TcpStream};
     use tokio_tungstenite::tungstenite::Message;
+    use tokio_tungstenite::WebSocketStream;
 
     use crate::blob_store::BlobStore;
-    use crate::notebook_sync_server::{NotebookRoom, ReservationGuard, RoomConnectionIdentity};
+    use crate::notebook_sync_server::{
+        NotebookRoom, ReservationGuard, RoomConnectionIdentity, RoomCreationOptions,
+    };
 
     const CLOUD_PRINCIPAL: &str = "user:anaconda:kyle";
     const CLOUD_ROOM_ACTOR: &str = "user:anaconda:kyle/host:room:1";
@@ -489,26 +500,23 @@ mod tests {
                 rt_peer: sync::State::new(),
             }
         }
+
+        fn add_cell(&mut self, cell_id: &str, cell_type: &str, source: &str) {
+            let index = self.nb.get_cell_ids().len();
+            self.nb.add_cell(index, cell_id, cell_type).unwrap();
+            self.nb.update_source(cell_id, source).unwrap();
+        }
+
+        fn reset_sync_states(&mut self) {
+            self.nb_peer = sync::State::new();
+            self.rt_peer = sync::State::new();
+        }
     }
 
-    /// Serve one fake hosted-room WebSocket connection: send
-    /// `cloud_room_ready`, then act as the room-authoritative automerge peer
-    /// for NotebookDoc + RuntimeStateDoc and answer `execute_cell` Request
-    /// frames by creating a queued execution in the runtime doc.
-    ///
-    /// `observed` returns each cell id seen in the fake room's doc after
-    /// every applied sync message; `frame_counter` counts inbound
-    /// AutomergeSync frames (echo-storm probe).
-    async fn serve_fake_cloud_room(
-        listener: TcpListener,
-        mut room: FakeCloudRoom,
-        observed_cells: tokio::sync::watch::Sender<Vec<String>>,
-        frame_counter: Arc<AtomicUsize>,
-        request_counter: Arc<AtomicUsize>,
+    async fn send_ready_and_initial_sync(
+        ws: &mut WebSocketStream<TcpStream>,
+        room: &mut FakeCloudRoom,
     ) {
-        let (stream, _) = listener.accept().await.unwrap();
-        let mut ws = tokio_tungstenite::accept_async(stream).await.unwrap();
-
         let ready = serde_json::to_vec(&serde_json::json!({
             "type": "cloud_room_ready",
             "actor_label": CLOUD_ROOM_ACTOR,
@@ -536,6 +544,16 @@ mod tests {
             .await
             .unwrap();
         }
+    }
+
+    async fn serve_fake_cloud_connection(
+        mut ws: WebSocketStream<TcpStream>,
+        mut room: FakeCloudRoom,
+        observed_cells: tokio::sync::watch::Sender<Vec<String>>,
+        frame_counter: Arc<AtomicUsize>,
+        request_counter: Arc<AtomicUsize>,
+    ) -> FakeCloudRoom {
+        send_ready_and_initial_sync(&mut ws, &mut room).await;
 
         while let Some(Ok(msg)) = ws.next().await {
             let Message::Binary(data) = msg else { continue };
@@ -625,6 +643,56 @@ mod tests {
                 ws.send(Message::Binary(reply.into())).await.unwrap();
             }
         }
+
+        room
+    }
+
+    /// Serve one fake hosted-room WebSocket connection: send
+    /// `cloud_room_ready`, then act as the room-authoritative automerge peer
+    /// for NotebookDoc + RuntimeStateDoc and answer `execute_cell` Request
+    /// frames by creating a queued execution in the runtime doc.
+    ///
+    /// `observed` returns each cell id seen in the fake room's doc after
+    /// every applied sync message; `frame_counter` counts inbound
+    /// AutomergeSync frames (echo-storm probe).
+    async fn serve_fake_cloud_room(
+        listener: TcpListener,
+        room: FakeCloudRoom,
+        observed_cells: tokio::sync::watch::Sender<Vec<String>>,
+        frame_counter: Arc<AtomicUsize>,
+        request_counter: Arc<AtomicUsize>,
+    ) {
+        let (stream, _) = listener.accept().await.unwrap();
+        let ws = tokio_tungstenite::accept_async(stream).await.unwrap();
+        let _ =
+            serve_fake_cloud_connection(ws, room, observed_cells, frame_counter, request_counter)
+                .await;
+    }
+
+    /// Serve two fake hosted-room WebSocket connections on one listener.
+    /// The first connection sends initial sync and closes; the second starts
+    /// from fresh sync states after a cloud-side document edit.
+    async fn serve_fake_cloud_room_with_reconnect(
+        listener: TcpListener,
+        mut room: FakeCloudRoom,
+        observed_cells: tokio::sync::watch::Sender<Vec<String>>,
+        frame_counter: Arc<AtomicUsize>,
+        request_counter: Arc<AtomicUsize>,
+    ) {
+        let (stream, _) = listener.accept().await.unwrap();
+        let mut ws = tokio_tungstenite::accept_async(stream).await.unwrap();
+        send_ready_and_initial_sync(&mut ws, &mut room).await;
+        let _ = observed_cells.send(room.nb.get_cell_ids());
+        ws.close(None).await.unwrap();
+
+        room.add_cell("remote-2", "code", "print('after reconnect')");
+        room.reset_sync_states();
+
+        let (stream, _) = listener.accept().await.unwrap();
+        let ws = tokio_tungstenite::accept_async(stream).await.unwrap();
+        let _ =
+            serve_fake_cloud_connection(ws, room, observed_cells, frame_counter, request_counter)
+                .await;
     }
 
     fn test_room(tmp: &tempfile::TempDir) -> Arc<NotebookRoom> {
@@ -636,6 +704,16 @@ mod tests {
             blob_store,
             true,
         ))
+    }
+
+    #[test]
+    fn hosted_flag_defaults_false_and_marks_true() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        let room = test_room(&tmp);
+
+        assert!(!room.is_hosted());
+        room.mark_hosted();
+        assert!(room.is_hosted());
     }
 
     async fn start_bridge(
@@ -754,6 +832,49 @@ mod tests {
             settled,
             "bridge kept exchanging NotebookDoc sync frames after convergence"
         );
+
+        bridge.shutdown();
+        server.abort();
+    }
+
+    #[tokio::test]
+    async fn bridge_reconnects_with_fresh_sync_state() {
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+        let (cells_tx, _cells_rx) = tokio::sync::watch::channel(Vec::new());
+        let frames = Arc::new(AtomicUsize::new(0));
+        let requests = Arc::new(AtomicUsize::new(0));
+        let server = tokio::spawn(serve_fake_cloud_room_with_reconnect(
+            listener,
+            FakeCloudRoom::new(),
+            cells_tx,
+            frames,
+            requests,
+        ));
+
+        let tmp = tempfile::TempDir::new().unwrap();
+        let room = test_room(&tmp);
+        let bridge = start_bridge(&room, addr).await;
+        bridge
+            .wait_for_principal(Duration::from_secs(10))
+            .await
+            .expect("bridge principal");
+
+        let room_for_wait = room.clone();
+        wait_until(
+            "remote-2 to reach the local room after reconnect",
+            move || {
+                let room = room_for_wait.clone();
+                Box::pin(async move {
+                    room.doc
+                        .read()
+                        .await
+                        .get_cell_ids()
+                        .contains(&"remote-2".to_string())
+                })
+            },
+        )
+        .await;
 
         bridge.shutdown();
         server.abort();
@@ -947,6 +1068,57 @@ mod tests {
             .lock()
             .await
             .insert(bridge.locator.clone(), bridge.clone());
+    }
+
+    #[tokio::test]
+    async fn hosted_bridge_teardown_skips_in_flight_attach_reservation() {
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+        drop(listener);
+
+        let tmp = tempfile::TempDir::new().unwrap();
+        let daemon = test_daemon(&tmp);
+        let room = {
+            let (room, _room_guard) = crate::notebook_sync_server::get_or_create_room_result(
+                &daemon.notebook_rooms,
+                uuid::Uuid::new_v4(),
+                RoomCreationOptions {
+                    path: None,
+                    docs_dir: &daemon.config.notebook_docs_dir,
+                    blob_store: daemon.blob_store.clone(),
+                    ephemeral: true,
+                    trusted_packages: daemon.trusted_packages.clone(),
+                },
+            )
+            .await
+            .unwrap();
+            room
+        };
+        let bridge = start_bridge(&room, addr).await;
+        register_bridge(&daemon, &bridge).await;
+
+        {
+            let _attaching_peer = ReservationGuard::new(room.clone());
+            daemon.teardown_hosted_bridge(&bridge.locator).await;
+            let still_registered = {
+                let bridges = daemon.hosted_bridges.lock().await;
+                bridges.contains_key(&bridge.locator)
+            };
+            assert!(
+                still_registered,
+                "bridge must stay registered while an attach reservation is held"
+            );
+        }
+
+        daemon.teardown_hosted_bridge(&bridge.locator).await;
+        let removed = {
+            let bridges = daemon.hosted_bridges.lock().await;
+            !bridges.contains_key(&bridge.locator)
+        };
+        assert!(
+            removed,
+            "bridge should be removed after extra reservation drops"
+        );
     }
 
     #[tokio::test]

--- a/crates/runtimed/src/notebook_sync_server/identity.rs
+++ b/crates/runtimed/src/notebook_sync_server/identity.rs
@@ -48,6 +48,37 @@ impl RoomConnectionIdentity {
         })
     }
 
+    /// Identity for a local same-UID peer on a hosted-bridged room.
+    ///
+    /// The hosted room's actor-authorization check rejects any change whose
+    /// actor principal differs from the authenticated cloud principal, so
+    /// local peers on a bridged room must author under that principal — the
+    /// local operator suffix carries the per-client attribution
+    /// (`user:anaconda:<sub>/desktop:<session>`). Legacy operator-only actor
+    /// labels are rejected: they would collapse into the daemon's identity on
+    /// the cloud side.
+    pub(crate) fn hosted_bridged(
+        cloud_principal: &str,
+        presented_operator: Option<String>,
+        scope: ConnectionScope,
+    ) -> anyhow::Result<Self> {
+        let principal = nteract_identity::Principal::new(cloud_principal.to_string())?;
+        let auth = AuthenticatedConnection::new(principal, scope);
+        let fallback_operator = fallback_operator("desktop");
+        let operator = presented_operator
+            .as_deref()
+            .and_then(|value| Operator::from_actor_label_or_operator(value).ok())
+            .unwrap_or_else(|| fallback_operator.clone());
+        let actor_label = auth.actor_label_for(operator.clone())?;
+
+        Ok(Self {
+            auth,
+            actor_label,
+            fallback_operator: operator,
+            legacy_operator_actor_policy: LegacyOperatorActorPolicy::Reject,
+        })
+    }
+
     pub(crate) fn actor_label(&self) -> &ActorLabel {
         &self.actor_label
     }

--- a/crates/runtimed/src/notebook_sync_server/metadata.rs
+++ b/crates/runtimed/src/notebook_sync_server/metadata.rs
@@ -817,6 +817,12 @@ pub(crate) fn compute_env_sync_diff(
 /// blob-store hashes, then updates the cell-local `resolved_assets` maps so
 /// isolated markdown rendering can rewrite those refs to blob URLs.
 pub(crate) async fn process_markdown_assets(room: &NotebookRoom) {
+    if room.is_hosted() {
+        // Resolved-asset writes are authored by a daemon actor the hosted room's
+        // actor authorization rejects, and the blob refs are local-only.
+        return;
+    }
+
     let notebook_path = room.file_binding.path().await.filter(|p| p.exists());
     // Capture heads BEFORE async resolution. Later, write resolved assets in
     // an isolated transaction at this baseline so the update composes with

--- a/crates/runtimed/src/notebook_sync_server/mod.rs
+++ b/crates/runtimed/src/notebook_sync_server/mod.rs
@@ -51,6 +51,7 @@ mod attachments;
 mod blob_upload;
 mod catalog;
 mod comments_store;
+mod hosted_bridge;
 mod identity;
 mod load;
 mod metadata;
@@ -79,6 +80,8 @@ mod workstation_attachment;
 
 pub(crate) use attachments::*;
 pub(crate) use catalog::*;
+pub use hosted_bridge::HostedBridgeHandle;
+pub(crate) use hosted_bridge::*;
 pub(crate) use identity::*;
 pub(crate) use load::*;
 pub(crate) use metadata::*;

--- a/crates/runtimed/src/notebook_sync_server/peer_connection.rs
+++ b/crates/runtimed/src/notebook_sync_server/peer_connection.rs
@@ -71,7 +71,9 @@ where
             *room_wd = Some(wd.clone());
         }
 
-        if update_workstation_directory {
+        if update_workstation_directory && !room.is_hosted() {
+            // Hosted rooms must not write local workstation state into the
+            // cloud-authoritative RuntimeStateDoc.
             super::workstation_attachment::publish_local_workstation_attachment_for_working_dir(
                 &room.state,
                 Some(wd.as_path()),
@@ -172,10 +174,10 @@ where
             .kernel_teardown_destructive
             .load(Ordering::Acquire);
         let effective_has_kernel = has_kernel && !kernel_being_torn_down;
-        // Hosted-bridged rooms never launch local kernels: the cloud room
-        // owns execution and RuntimeStateDoc lifecycle.
-        let is_hosted_bridged = daemon.hosted_bridge_for_room(room.id).await.is_some();
-        let should_auto_launch = !is_hosted_bridged
+        // The hosted flag outlives bridge teardown, so a formerly-bridged room
+        // can never auto-launch a local kernel.
+        let is_hosted = room.is_hosted();
+        let should_auto_launch = !is_hosted
             && !effective_has_kernel
             && matches!(
                 trust_status,

--- a/crates/runtimed/src/notebook_sync_server/peer_connection.rs
+++ b/crates/runtimed/src/notebook_sync_server/peer_connection.rs
@@ -172,7 +172,11 @@ where
             .kernel_teardown_destructive
             .load(Ordering::Acquire);
         let effective_has_kernel = has_kernel && !kernel_being_torn_down;
-        let should_auto_launch = !effective_has_kernel
+        // Hosted-bridged rooms never launch local kernels: the cloud room
+        // owns execution and RuntimeStateDoc lifecycle.
+        let is_hosted_bridged = daemon.hosted_bridge_for_room(room.id).await.is_some();
+        let should_auto_launch = !is_hosted_bridged
+            && !effective_has_kernel
             && matches!(
                 trust_status,
                 runt_trust::TrustStatus::Trusted | runt_trust::TrustStatus::NoDependencies

--- a/crates/runtimed/src/notebook_sync_server/room.rs
+++ b/crates/runtimed/src/notebook_sync_server/room.rs
@@ -746,6 +746,9 @@ pub struct NotebookRoom {
     pub identity: RoomIdentity,
     /// Per-connection accounting: active_peers + had_peers.
     pub connections: RoomConnections,
+    /// Hosted rooms are cloud-authoritative and must not auto-launch local kernels.
+    /// Read via `is_hosted()`; set once via `mark_hosted()` before peers attach.
+    pub(crate) hosted: AtomicBool,
     /// Blob store for output manifests.
     pub blob_store: Arc<BlobStore>,
     /// Trust state for this notebook (for auto-launch decisions).
@@ -805,6 +808,16 @@ pub struct NotebookRoom {
 }
 
 impl NotebookRoom {
+    /// True when this room is bridged to a hosted cloud notebook.
+    pub fn is_hosted(&self) -> bool {
+        self.hosted.load(Ordering::Relaxed)
+    }
+
+    /// Mark this room as hosted. This flag is monotonic for the room lifetime.
+    pub fn mark_hosted(&self) {
+        self.hosted.store(true, Ordering::Relaxed);
+    }
+
     /// Create a fresh room, ignoring any persisted state.
     ///
     /// The .ipynb file is the source of truth. When a room is created, we start
@@ -1000,6 +1013,7 @@ impl NotebookRoom {
             file_binding: NotebookFileBinding::new(path, ephemeral),
             identity: RoomIdentity::new(persist_path),
             connections: RoomConnections::default(),
+            hosted: AtomicBool::new(false),
             blob_store,
             trust_state: Arc::new(RwLock::new(trust_state)),
             trusted_packages,
@@ -1120,6 +1134,7 @@ impl NotebookRoom {
             file_binding: NotebookFileBinding::new(path, false),
             identity: RoomIdentity::new(persist_path),
             connections: RoomConnections::default(),
+            hosted: AtomicBool::new(false),
             blob_store,
             trust_state: Arc::new(RwLock::new(trust_state)),
             trusted_packages,

--- a/crates/runtimed/src/notebook_sync_server/tests.rs
+++ b/crates/runtimed/src/notebook_sync_server/tests.rs
@@ -1723,6 +1723,7 @@ fn test_room_with_path_and_store(
         file_binding: NotebookFileBinding::new(Some(notebook_path.clone()), false),
         identity: RoomIdentity::new(persist_path),
         connections: RoomConnections::default(),
+        hosted: AtomicBool::new(false),
         blob_store,
         trust_state: Arc::new(RwLock::new(TrustState {
             status: runt_trust::TrustStatus::Untrusted,

--- a/crates/runtimed/src/requests/mod.rs
+++ b/crates/runtimed/src/requests/mod.rs
@@ -177,27 +177,27 @@ fn validate_hosted_execution_id(execution_id: &str) -> Option<NotebookResponse> 
 fn validate_hosted_run_all_execution_ids(
     requested_execution_ids: Option<&HashMap<String, String>>,
     existing_execution_ids: &HashSet<String>,
-) -> Result<HashSet<String>, NotebookResponse> {
+) -> Result<HashSet<String>, Box<NotebookResponse>> {
     let mut supplied = HashSet::new();
     if let Some(requested_execution_ids) = requested_execution_ids {
         for execution_id in requested_execution_ids.values() {
             if uuid::Uuid::parse_str(execution_id).is_err() {
-                return Err(execution_id_rejected(
+                return Err(Box::new(execution_id_rejected(
                     execution_id,
                     ExecutionIdRejectionReason::Malformed,
-                ));
+                )));
             }
             if !supplied.insert(execution_id.clone()) {
-                return Err(execution_id_rejected(
+                return Err(Box::new(execution_id_rejected(
                     execution_id,
                     ExecutionIdRejectionReason::DuplicateInRequest,
-                ));
+                )));
             }
             if existing_execution_ids.contains(execution_id) {
-                return Err(execution_id_rejected(
+                return Err(Box::new(execution_id_rejected(
                     execution_id,
                     ExecutionIdRejectionReason::AlreadyExists,
-                ));
+                )));
             }
         }
     }
@@ -218,12 +218,14 @@ fn forward_hosted_request(
     bridge: &crate::notebook_sync_server::HostedBridgeHandle,
     payload: serde_json::Value,
     operation: &str,
-) -> Result<(), NotebookResponse> {
+) -> Result<(), Box<NotebookResponse>> {
     serde_json::to_vec(&payload)
         .map_err(anyhow::Error::from)
         .and_then(|bytes| bridge.forward_request(bytes))
-        .map_err(|e| NotebookResponse::Error {
-            error: format!("Failed to forward {operation} to hosted room: {e}"),
+        .map_err(|e| {
+            Box::new(NotebookResponse::Error {
+                error: format!("Failed to forward {operation} to hosted room: {e}"),
+            })
         })
 }
 
@@ -261,7 +263,7 @@ async fn handle_hosted_execute_cell(
             cell_id: cell_id.to_string(),
             execution_id,
         },
-        Err(response) => response,
+        Err(response) => *response,
     }
 }
 
@@ -295,7 +297,7 @@ async fn handle_hosted_run_all_cells(
         &existing_execution_ids,
     ) {
         Ok(supplied) => supplied,
-        Err(response) => return response,
+        Err(response) => return *response,
     };
 
     let mut allocated_execution_ids = existing_execution_ids;
@@ -340,7 +342,7 @@ async fn handle_hosted_run_all_cells(
             // this list records the request sent across the bridge, not a receipt.
             NotebookResponse::AllCellsQueued { queued }
         }
-        Err(response) => response,
+        Err(response) => *response,
     }
 }
 
@@ -354,7 +356,7 @@ fn handle_hosted_interrupt_execution(
         // Best-effort: the room relays to the attached runtime peer and
         // rejects the frame if none is attached.
         Ok(()) => NotebookResponse::InterruptSent {},
-        Err(response) => response,
+        Err(response) => *response,
     }
 }
 
@@ -368,7 +370,7 @@ fn handle_hosted_send_comm(
     });
     match forward_hosted_request(bridge, payload, "send_comm") {
         Ok(()) => NotebookResponse::Ok {},
-        Err(response) => response,
+        Err(response) => *response,
     }
 }
 

--- a/crates/runtimed/src/requests/mod.rs
+++ b/crates/runtimed/src/requests/mod.rs
@@ -164,6 +164,54 @@ pub(crate) async fn handle_notebook_request(
         request_label(&request)
     );
 
+    // Hosted-bridged rooms have no local kernel authority: the cloud room
+    // owns execution dispatch and RuntimeStateDoc. Execute requests are
+    // forwarded across the bridge; kernel-lifecycle requests are rejected
+    // with an actionable message instead of launching a local kernel that
+    // would fight the cloud room over runtime state.
+    if let Some(bridge) = daemon.hosted_bridge_for_room(room.id).await {
+        match &request {
+            NotebookRequest::ExecuteCell { cell_id, .. }
+            | NotebookRequest::ExecuteCellGuarded { cell_id, .. } => {
+                let payload = serde_json::json!({
+                    "action": "execute_cell",
+                    "cell_id": cell_id,
+                });
+                return match serde_json::to_vec(&payload)
+                    .map_err(anyhow::Error::from)
+                    .and_then(|bytes| bridge.forward_request(bytes))
+                {
+                    // The cloud room creates the queued execution and it
+                    // arrives back via RuntimeStateDoc sync; there is no
+                    // locally-known execution id to return.
+                    Ok(()) => NotebookResponse::Ok {},
+                    Err(e) => NotebookResponse::Error {
+                        error: format!("Failed to forward execute to hosted room: {e}"),
+                    },
+                };
+            }
+            NotebookRequest::LaunchKernel { .. }
+            | NotebookRequest::ShutdownKernel {}
+            | NotebookRequest::InterruptExecution {}
+            | NotebookRequest::RunAllCells { .. }
+            | NotebookRequest::RunAllCellsGuarded { .. }
+            | NotebookRequest::SyncEnvironment { .. }
+            | NotebookRequest::SaveNotebook { .. } => {
+                return NotebookResponse::Error {
+                    error: format!(
+                        "{} is not supported on a daemon-bridged hosted notebook yet; \
+                         the cloud room owns runtime and persistence",
+                        request_label(&request)
+                    ),
+                };
+            }
+            // Document-local requests (doc bytes, blob upload, trust,
+            // completion against no kernel, clone) keep their normal local
+            // handling below.
+            _ => {}
+        }
+    }
+
     match request {
         NotebookRequest::LaunchKernel {
             kernel_type,

--- a/crates/runtimed/src/requests/mod.rs
+++ b/crates/runtimed/src/requests/mod.rs
@@ -12,11 +12,13 @@
 //! This is a behavior-preserving split of the old 2k-line match statement —
 //! lock scoping, log lines, error strings, and response variants are untouched.
 
-use std::collections::HashSet;
+use std::collections::{HashMap, HashSet};
 use std::sync::Arc;
 
-use notebook_protocol::protocol::BlobUploadErrorKind;
-use runtime_doc::{QueueEntry, RuntimeLifecycle};
+use notebook_protocol::protocol::{
+    BlobUploadErrorKind, ExecutionIdRejectionReason, QueueEntry as ProtocolQueueEntry,
+};
+use runtime_doc::{QueueEntry as RuntimeQueueEntry, RuntimeLifecycle};
 use tracing::{debug, warn};
 
 use crate::daemon::Daemon;
@@ -43,10 +45,10 @@ pub(crate) fn runtime_launch_in_progress(lifecycle: &RuntimeLifecycle) -> bool {
 
 pub(crate) fn publish_startup_queue_from_queued_executions(room: &NotebookRoom) {
     if let Err(e) = room.state.with_doc(|state_doc| {
-        let queued: Vec<QueueEntry> = state_doc
+        let queued: Vec<RuntimeQueueEntry> = state_doc
             .get_queued_executions()
             .into_iter()
-            .map(|(execution_id, _)| QueueEntry { execution_id })
+            .map(|(execution_id, _)| RuntimeQueueEntry { execution_id })
             .collect();
         state_doc.set_queue(None, &queued)?;
         Ok(())
@@ -152,6 +154,224 @@ pub(crate) fn request_label(req: &NotebookRequest) -> &'static str {
     }
 }
 
+fn execution_id_rejected(
+    execution_id: impl Into<String>,
+    reason: ExecutionIdRejectionReason,
+) -> NotebookResponse {
+    NotebookResponse::ExecutionIdRejected {
+        execution_id: execution_id.into(),
+        reason,
+    }
+}
+
+fn validate_hosted_execution_id(execution_id: &str) -> Option<NotebookResponse> {
+    if uuid::Uuid::parse_str(execution_id).is_err() {
+        return Some(execution_id_rejected(
+            execution_id,
+            ExecutionIdRejectionReason::Malformed,
+        ));
+    }
+    None
+}
+
+fn validate_hosted_run_all_execution_ids(
+    requested_execution_ids: Option<&HashMap<String, String>>,
+    existing_execution_ids: &HashSet<String>,
+) -> Result<HashSet<String>, NotebookResponse> {
+    let mut supplied = HashSet::new();
+    if let Some(requested_execution_ids) = requested_execution_ids {
+        for execution_id in requested_execution_ids.values() {
+            if uuid::Uuid::parse_str(execution_id).is_err() {
+                return Err(execution_id_rejected(
+                    execution_id,
+                    ExecutionIdRejectionReason::Malformed,
+                ));
+            }
+            if !supplied.insert(execution_id.clone()) {
+                return Err(execution_id_rejected(
+                    execution_id,
+                    ExecutionIdRejectionReason::DuplicateInRequest,
+                ));
+            }
+            if existing_execution_ids.contains(execution_id) {
+                return Err(execution_id_rejected(
+                    execution_id,
+                    ExecutionIdRejectionReason::AlreadyExists,
+                ));
+            }
+        }
+    }
+    Ok(supplied)
+}
+
+fn allocate_hosted_execution_id(allocated_execution_ids: &mut HashSet<String>) -> Option<String> {
+    for _ in 0..16 {
+        let execution_id = uuid::Uuid::new_v4().to_string();
+        if allocated_execution_ids.insert(execution_id.clone()) {
+            return Some(execution_id);
+        }
+    }
+    None
+}
+
+fn forward_hosted_request(
+    bridge: &crate::notebook_sync_server::HostedBridgeHandle,
+    payload: serde_json::Value,
+    operation: &str,
+) -> Result<(), NotebookResponse> {
+    serde_json::to_vec(&payload)
+        .map_err(anyhow::Error::from)
+        .and_then(|bytes| bridge.forward_request(bytes))
+        .map_err(|e| NotebookResponse::Error {
+            error: format!("Failed to forward {operation} to hosted room: {e}"),
+        })
+}
+
+async fn handle_hosted_execute_cell(
+    bridge: &crate::notebook_sync_server::HostedBridgeHandle,
+    cell_id: &str,
+    requested_execution_id: Option<&str>,
+    guarded_observed_heads: Option<&[String]>,
+) -> NotebookResponse {
+    let execution_id = match requested_execution_id {
+        Some(execution_id) => {
+            if let Some(response) = validate_hosted_execution_id(execution_id) {
+                return response;
+            }
+            execution_id.to_string()
+        }
+        None => uuid::Uuid::new_v4().to_string(),
+    };
+    let action = if guarded_observed_heads.is_some() {
+        "execute_cell_guarded"
+    } else {
+        "execute_cell"
+    };
+    let mut payload = serde_json::json!({
+        "action": action,
+        "cell_id": cell_id,
+        "execution_id": execution_id,
+    });
+    if let Some(observed_heads) = guarded_observed_heads {
+        payload["observed_heads"] = serde_json::json!(observed_heads);
+    }
+
+    match forward_hosted_request(bridge, payload, "execute") {
+        Ok(()) => NotebookResponse::CellQueued {
+            cell_id: cell_id.to_string(),
+            execution_id,
+        },
+        Err(response) => response,
+    }
+}
+
+async fn handle_hosted_run_all_cells(
+    room: &Arc<NotebookRoom>,
+    bridge: &crate::notebook_sync_server::HostedBridgeHandle,
+    requested_execution_ids: Option<&HashMap<String, String>>,
+    guarded_observed_heads: Option<&[String]>,
+) -> NotebookResponse {
+    let code_cell_ids: Vec<String> = {
+        let doc = room.doc.read().await;
+        doc.get_cells()
+            .into_iter()
+            .filter(|cell| cell.cell_type == "code")
+            .map(|cell| cell.id)
+            .collect()
+    };
+
+    let existing_execution_ids = room
+        .state
+        .read(|sd| {
+            sd.read_state()
+                .executions
+                .keys()
+                .cloned()
+                .collect::<HashSet<_>>()
+        })
+        .unwrap_or_default();
+    let supplied = match validate_hosted_run_all_execution_ids(
+        requested_execution_ids,
+        &existing_execution_ids,
+    ) {
+        Ok(supplied) => supplied,
+        Err(response) => return response,
+    };
+
+    let mut allocated_execution_ids = existing_execution_ids;
+    allocated_execution_ids.extend(supplied);
+    let mut cell_execution_ids = HashMap::with_capacity(code_cell_ids.len());
+    let mut queued = Vec::with_capacity(code_cell_ids.len());
+    for cell_id in code_cell_ids {
+        let execution_id = match requested_execution_ids.and_then(|ids| ids.get(&cell_id)) {
+            Some(execution_id) => execution_id.clone(),
+            None => match allocate_hosted_execution_id(&mut allocated_execution_ids) {
+                Some(execution_id) => execution_id,
+                None => {
+                    return NotebookResponse::Error {
+                        error: "failed to allocate unique execution_id".to_string(),
+                    };
+                }
+            },
+        };
+        cell_execution_ids.insert(cell_id.clone(), execution_id.clone());
+        queued.push(ProtocolQueueEntry {
+            cell_id,
+            execution_id,
+        });
+    }
+
+    let action = if guarded_observed_heads.is_some() {
+        "run_all_cells_guarded"
+    } else {
+        "run_all_cells"
+    };
+    let mut payload = serde_json::json!({
+        "action": action,
+        "cell_execution_ids": cell_execution_ids,
+    });
+    if let Some(observed_heads) = guarded_observed_heads {
+        payload["observed_heads"] = serde_json::json!(observed_heads);
+    }
+
+    match forward_hosted_request(bridge, payload, "run_all_cells") {
+        Ok(()) => {
+            // The cloud room may skip already-active cells for idempotency, so
+            // this list records the request sent across the bridge, not a receipt.
+            NotebookResponse::AllCellsQueued { queued }
+        }
+        Err(response) => response,
+    }
+}
+
+fn handle_hosted_interrupt_execution(
+    bridge: &crate::notebook_sync_server::HostedBridgeHandle,
+) -> NotebookResponse {
+    let payload = serde_json::json!({
+        "action": "interrupt_execution",
+    });
+    match forward_hosted_request(bridge, payload, "interrupt") {
+        // Best-effort: the room relays to the attached runtime peer and
+        // rejects the frame if none is attached.
+        Ok(()) => NotebookResponse::InterruptSent {},
+        Err(response) => response,
+    }
+}
+
+fn handle_hosted_send_comm(
+    bridge: &crate::notebook_sync_server::HostedBridgeHandle,
+    message: &notebook_protocol::protocol::CommRequestMessage,
+) -> NotebookResponse {
+    let payload = serde_json::json!({
+        "action": "send_comm",
+        "message": message,
+    });
+    match forward_hosted_request(bridge, payload, "send_comm") {
+        Ok(()) => NotebookResponse::Ok {},
+        Err(response) => response,
+    }
+}
+
 /// Handle a NotebookRequest and return a NotebookResponse.
 pub(crate) async fn handle_notebook_request(
     room: &Arc<NotebookRoom>,
@@ -171,32 +391,58 @@ pub(crate) async fn handle_notebook_request(
     // would fight the cloud room over runtime state.
     if let Some(bridge) = daemon.hosted_bridge_for_room(room.id).await {
         match &request {
-            NotebookRequest::ExecuteCell { cell_id, .. }
-            | NotebookRequest::ExecuteCellGuarded { cell_id, .. } => {
-                let payload = serde_json::json!({
-                    "action": "execute_cell",
-                    "cell_id": cell_id,
-                });
-                return match serde_json::to_vec(&payload)
-                    .map_err(anyhow::Error::from)
-                    .and_then(|bytes| bridge.forward_request(bytes))
-                {
-                    // The cloud room creates the queued execution and it
-                    // arrives back via RuntimeStateDoc sync; there is no
-                    // locally-known execution id to return.
-                    Ok(()) => NotebookResponse::Ok {},
-                    Err(e) => NotebookResponse::Error {
-                        error: format!("Failed to forward execute to hosted room: {e}"),
-                    },
-                };
+            NotebookRequest::ExecuteCell {
+                cell_id,
+                execution_id,
+            } => {
+                return handle_hosted_execute_cell(&bridge, cell_id, execution_id.as_deref(), None)
+                    .await;
+            }
+            NotebookRequest::ExecuteCellGuarded {
+                cell_id,
+                execution_id,
+                observed_heads,
+            } => {
+                return handle_hosted_execute_cell(
+                    &bridge,
+                    cell_id,
+                    execution_id.as_deref(),
+                    Some(observed_heads),
+                )
+                .await;
+            }
+            NotebookRequest::RunAllCells { cell_execution_ids } => {
+                return handle_hosted_run_all_cells(
+                    room,
+                    &bridge,
+                    cell_execution_ids.as_ref(),
+                    None,
+                )
+                .await;
+            }
+            NotebookRequest::RunAllCellsGuarded {
+                cell_execution_ids,
+                observed_heads,
+            } => {
+                return handle_hosted_run_all_cells(
+                    room,
+                    &bridge,
+                    cell_execution_ids.as_ref(),
+                    Some(observed_heads),
+                )
+                .await;
+            }
+            NotebookRequest::InterruptExecution {} => {
+                return handle_hosted_interrupt_execution(&bridge);
+            }
+            NotebookRequest::SendComm { message } => {
+                return handle_hosted_send_comm(&bridge, message);
             }
             NotebookRequest::LaunchKernel { .. }
             | NotebookRequest::ShutdownKernel {}
-            | NotebookRequest::InterruptExecution {}
-            | NotebookRequest::RunAllCells { .. }
-            | NotebookRequest::RunAllCellsGuarded { .. }
             | NotebookRequest::SyncEnvironment { .. }
-            | NotebookRequest::SaveNotebook { .. } => {
+            | NotebookRequest::SaveNotebook { .. }
+            | NotebookRequest::GetHistory { .. } => {
                 return NotebookResponse::Error {
                     error: format!(
                         "{} is not supported on a daemon-bridged hosted notebook yet; \

--- a/crates/runtimed/tests/hosted_open.rs
+++ b/crates/runtimed/tests/hosted_open.rs
@@ -143,6 +143,7 @@ struct HandshakeSeen {
     user: Option<String>,
 }
 
+#[allow(clippy::result_large_err)] // tokio-tungstenite's handshake callback requires this error shape.
 async fn serve_fake_cloud_room(
     listener: TcpListener,
     mut room: FakeCloudRoom,

--- a/crates/runtimed/tests/hosted_open.rs
+++ b/crates/runtimed/tests/hosted_open.rs
@@ -1,0 +1,372 @@
+// Tests can use unwrap/expect freely - panics are acceptable in test code.
+#![allow(clippy::unwrap_used, clippy::expect_used)]
+
+use std::path::PathBuf;
+use std::sync::{Arc, Mutex};
+use std::time::Duration;
+
+use automerge::sync;
+use futures::{SinkExt, StreamExt};
+use notebook_doc::{NotebookDoc, TextEncoding};
+use notebook_sync::connect::connect_open_hosted;
+use notebook_wire::NotebookFrameType;
+use runtime_doc::RuntimeStateDoc;
+use runtimed::client::PoolClient;
+use runtimed::daemon::{Daemon, DaemonConfig};
+use tempfile::TempDir;
+use tokio::net::TcpListener;
+use tokio::sync::watch;
+use tokio::time::sleep;
+use tokio_tungstenite::tungstenite::handshake::server::{Request, Response};
+use tokio_tungstenite::tungstenite::Message;
+
+const DAEMON_READY_TIMEOUT: Duration = Duration::from_secs(20);
+const SYNC_TIMEOUT: Duration = Duration::from_secs(10);
+const CLOUD_ROOM_ACTOR: &str = "user:anaconda:kyle/host:room:1";
+
+fn test_config(temp_dir: &TempDir) -> DaemonConfig {
+    #[cfg(windows)]
+    let socket_path = {
+        let unique = temp_dir
+            .path()
+            .file_name()
+            .unwrap_or_default()
+            .to_string_lossy();
+        PathBuf::from(format!(r"\\.\pipe\runtimed-test-{}", unique))
+    };
+    #[cfg(not(windows))]
+    let socket_path = temp_dir.path().join("test-runtimed.sock");
+
+    DaemonConfig {
+        socket_path,
+        cache_dir: temp_dir.path().join("envs"),
+        blob_store_dir: temp_dir.path().join("blobs"),
+        execution_store_dir: temp_dir.path().join("executions"),
+        notebook_docs_dir: temp_dir.path().join("notebook-docs"),
+        trusted_packages_db_path: temp_dir.path().join("trusted-packages.sqlite"),
+        notebook_registry_db_path: temp_dir.path().join("notebook-registry.sqlite"),
+        uv_pool_size: 0,
+        conda_pool_size: 0,
+        max_age_secs: 3600,
+        lock_dir: Some(temp_dir.path().to_path_buf()),
+        room_eviction_delay_ms: Some(50),
+        use_preferred_blob_port: false,
+        settings_json_path: Some(temp_dir.path().join("settings.json")),
+        runtime_agent_exe: option_env!("CARGO_BIN_EXE_runtimed").map(PathBuf::from),
+        ..Default::default()
+    }
+}
+
+async fn wait_for_daemon(client: &PoolClient) -> bool {
+    let start = std::time::Instant::now();
+    while start.elapsed() < DAEMON_READY_TIMEOUT {
+        if client.ping().await.is_ok() {
+            return true;
+        }
+        sleep(Duration::from_millis(50)).await;
+    }
+    false
+}
+
+async fn wait_for_handle_cell(
+    handle: &notebook_sync::DocHandle,
+    cell_id: &str,
+    timeout: Duration,
+) -> bool {
+    let start = std::time::Instant::now();
+    while start.elapsed() < timeout {
+        if handle.get_cells().iter().any(|cell| cell.id == cell_id) {
+            return true;
+        }
+        sleep(Duration::from_millis(25)).await;
+    }
+    false
+}
+
+async fn wait_for_fake_room_cell(
+    cells_rx: &mut watch::Receiver<Vec<String>>,
+    cell_id: &str,
+    timeout: Duration,
+) -> bool {
+    let deadline = tokio::time::Instant::now() + timeout;
+    loop {
+        if cells_rx.borrow().iter().any(|id| id == cell_id) {
+            return true;
+        }
+        let now = tokio::time::Instant::now();
+        if now >= deadline {
+            return false;
+        }
+        let remaining = deadline.saturating_duration_since(now);
+        let _ = tokio::time::timeout(
+            remaining.min(Duration::from_millis(100)),
+            cells_rx.changed(),
+        )
+        .await;
+    }
+}
+
+fn encode_ws_frame(frame_type: NotebookFrameType, payload: &[u8]) -> Vec<u8> {
+    let mut frame = Vec::with_capacity(1 + payload.len());
+    frame.push(frame_type as u8);
+    frame.extend_from_slice(payload);
+    frame
+}
+
+struct FakeCloudRoom {
+    nb: NotebookDoc,
+    rt: RuntimeStateDoc,
+    nb_peer: sync::State,
+    rt_peer: sync::State,
+}
+
+impl FakeCloudRoom {
+    fn new() -> Self {
+        let mut nb = NotebookDoc::bootstrap(TextEncoding::UnicodeCodePoint, CLOUD_ROOM_ACTOR);
+        nb.add_cell(0, "remote-1", "code").unwrap();
+        nb.update_source("remote-1", "print('from cloud')").unwrap();
+        let rt = RuntimeStateDoc::try_new_with_actor(CLOUD_ROOM_ACTOR).unwrap();
+        Self {
+            nb,
+            rt,
+            nb_peer: sync::State::new(),
+            rt_peer: sync::State::new(),
+        }
+    }
+}
+
+#[derive(Debug)]
+struct HandshakeSeen {
+    path: String,
+    scope: Option<String>,
+    token: Option<String>,
+    user: Option<String>,
+}
+
+async fn serve_fake_cloud_room(
+    listener: TcpListener,
+    mut room: FakeCloudRoom,
+    observed_cells: watch::Sender<Vec<String>>,
+) {
+    let (stream, _) = listener.accept().await.unwrap();
+    let handshake_seen = Arc::new(Mutex::new(None));
+    let callback_seen = handshake_seen.clone();
+    let mut ws = tokio_tungstenite::accept_hdr_async(
+        stream,
+        move |request: &Request, response: Response| {
+            let seen = HandshakeSeen {
+                path: request.uri().path().to_string(),
+                scope: request
+                    .headers()
+                    .get("x-scope")
+                    .and_then(|value| value.to_str().ok())
+                    .map(str::to_string),
+                token: request
+                    .headers()
+                    .get("x-notebook-cloud-dev-token")
+                    .and_then(|value| value.to_str().ok())
+                    .map(str::to_string),
+                user: request
+                    .headers()
+                    .get("x-user")
+                    .and_then(|value| value.to_str().ok())
+                    .map(str::to_string),
+            };
+            *callback_seen.lock().unwrap() = Some(seen);
+            Ok(response)
+        },
+    )
+    .await
+    .unwrap();
+
+    let handshake = {
+        let mut seen = handshake_seen.lock().unwrap();
+        seen.take().expect("fake room should observe WS handshake")
+    };
+    assert_eq!(handshake.path, "/n/e2e-test/sync");
+    assert_eq!(handshake.scope.as_deref(), Some("editor"));
+    assert_eq!(handshake.token.as_deref(), Some("dev-secret"));
+    assert_eq!(handshake.user.as_deref(), Some("kyle"));
+
+    let ready = serde_json::to_vec(&serde_json::json!({
+        "type": "cloud_room_ready",
+        "actor_label": CLOUD_ROOM_ACTOR,
+        "connection_scope": "editor",
+    }))
+    .unwrap();
+    ws.send(Message::Binary(
+        encode_ws_frame(NotebookFrameType::SessionControl, &ready).into(),
+    ))
+    .await
+    .unwrap();
+
+    if let Some(message) = room.nb.generate_sync_message(&mut room.nb_peer) {
+        ws.send(Message::Binary(
+            encode_ws_frame(NotebookFrameType::AutomergeSync, &message.encode()).into(),
+        ))
+        .await
+        .unwrap();
+    }
+    if let Some(message) = room.rt.generate_sync_message(&mut room.rt_peer) {
+        ws.send(Message::Binary(
+            encode_ws_frame(NotebookFrameType::RuntimeStateSync, &message.encode()).into(),
+        ))
+        .await
+        .unwrap();
+    }
+
+    while let Some(Ok(message)) = ws.next().await {
+        let Message::Binary(data) = message else {
+            continue;
+        };
+        let Some((&frame_type, payload)) = data.split_first() else {
+            continue;
+        };
+
+        let mut replies = Vec::new();
+        if frame_type == NotebookFrameType::AutomergeSync as u8 {
+            let incoming = sync::Message::decode(payload).unwrap();
+            room.nb
+                .receive_sync_message(&mut room.nb_peer, incoming)
+                .unwrap();
+            let _ = observed_cells.send(room.nb.get_cell_ids());
+            if let Some(message) = room.nb.generate_sync_message(&mut room.nb_peer) {
+                replies.push(encode_ws_frame(
+                    NotebookFrameType::AutomergeSync,
+                    &message.encode(),
+                ));
+            }
+        } else if frame_type == NotebookFrameType::RuntimeStateSync as u8 {
+            let incoming = sync::Message::decode(payload).unwrap();
+            room.rt
+                .receive_sync_message_with_changes(&mut room.rt_peer, incoming)
+                .unwrap();
+            if let Some(message) = room.rt.generate_sync_message(&mut room.rt_peer) {
+                replies.push(encode_ws_frame(
+                    NotebookFrameType::RuntimeStateSync,
+                    &message.encode(),
+                ));
+            }
+        }
+
+        for reply in replies {
+            ws.send(Message::Binary(reply.into())).await.unwrap();
+        }
+    }
+}
+
+struct EnvGuard {
+    key: &'static str,
+    old_value: Option<std::ffi::OsString>,
+}
+
+impl EnvGuard {
+    fn set(key: &'static str, value: impl AsRef<std::ffi::OsStr>) -> Self {
+        let old_value = std::env::var_os(key);
+        std::env::set_var(key, value);
+        Self { key, old_value }
+    }
+}
+
+impl Drop for EnvGuard {
+    fn drop(&mut self) {
+        match &self.old_value {
+            Some(value) => std::env::set_var(self.key, value),
+            None => std::env::remove_var(self.key),
+        }
+    }
+}
+
+#[tokio::test]
+#[serial_test::serial]
+async fn open_hosted_notebook_handshake_syncs_through_daemon_bridge() {
+    let temp_dir = TempDir::new().unwrap();
+
+    let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let addr = listener.local_addr().unwrap();
+    let cloud_origin = format!("http://{addr}");
+    let registry_path = temp_dir.path().join("cloud-domains.toml");
+    std::fs::write(
+        &registry_path,
+        format!(
+            r#"
+default_domain = "{cloud_origin}"
+
+[[domains]]
+url = "{cloud_origin}"
+operator = "agent:e2e"
+credential = {{ kind = "dev-token-env", env = "NTERACT_E2E_HOSTED_DEV_TOKEN", user = "kyle" }}
+"#
+        ),
+    )
+    .unwrap();
+
+    let _registry_env = EnvGuard::set("NTERACT_CLOUD_REGISTRY", &registry_path);
+    let _token_env = EnvGuard::set("NTERACT_E2E_HOSTED_DEV_TOKEN", "dev-secret");
+
+    let (cells_tx, mut cells_rx) = watch::channel(Vec::new());
+    let server = tokio::spawn(serve_fake_cloud_room(
+        listener,
+        FakeCloudRoom::new(),
+        cells_tx,
+    ));
+
+    let config = test_config(&temp_dir);
+    let socket_path = config.socket_path.clone();
+    let daemon = Daemon::new_for_test(config).unwrap();
+    let daemon_task = tokio::spawn(async move {
+        daemon.run().await.ok();
+    });
+
+    let client = PoolClient::new(socket_path.clone());
+    assert!(
+        wait_for_daemon(&client).await,
+        "daemon did not become ready"
+    );
+
+    let result = connect_open_hosted(
+        socket_path,
+        &format!("{cloud_origin}/n/e2e-test"),
+        Some("desktop:e2e".to_string()),
+    )
+    .await
+    .unwrap();
+
+    let actor_label = result
+        .info
+        .capabilities
+        .actor_label
+        .as_deref()
+        .expect("hosted open should return actor label");
+    assert!(
+        actor_label.starts_with("user:anaconda:kyle/"),
+        "actor label should use hosted principal: {actor_label}"
+    );
+    assert!(
+        actor_label.contains("desktop:e2e"),
+        "actor label should include local operator: {actor_label}"
+    );
+    assert!(result.info.ephemeral);
+
+    assert!(
+        wait_for_handle_cell(&result.handle, "remote-1", SYNC_TIMEOUT).await,
+        "hosted cell did not reach DocHandle within {SYNC_TIMEOUT:?}: {:?}",
+        result.handle.get_cells()
+    );
+
+    result
+        .handle
+        .add_cell_with_source("local-1", "code", Some("remote-1"), "x = 1")
+        .unwrap();
+    result.handle.confirm_sync().await.unwrap();
+
+    assert!(
+        wait_for_fake_room_cell(&mut cells_rx, "local-1", SYNC_TIMEOUT).await,
+        "local cell did not reach fake hosted room within {SYNC_TIMEOUT:?}; observed {:?}",
+        cells_rx.borrow().clone()
+    );
+
+    drop(result.handle);
+    daemon_task.abort();
+    server.abort();
+}

--- a/docs/memos/desktop-cloud-daemon-bridge.md
+++ b/docs/memos/desktop-cloud-daemon-bridge.md
@@ -1,0 +1,121 @@
+# Desktop Cloud Sessions Mediated by the Daemon
+
+**Status:** Working memo, 2026-07-01. Companion to issue #3861.
+
+## Problem
+
+Desktop-hosted cloud notebooks should be mediated by the local daemon. Today
+the only native path into a hosted room is direct: `runt mcp` (and the
+cloud-runtime-agent / workstation peers) dial `wss://<host>/n/<id>/sync` with
+`CloudWsFrameTransport` and sync as standalone peers. The desktop UI has no
+hosted path at all, and nothing gives UI, MCP agents, local kernels, and
+persistence one local authority for a cloud notebook.
+
+Target topology (from #3861):
+
+```text
+Desktop UI  <->  local daemon room  <->  hosted cloud room
+MCP client  <->  local daemon room  <->  hosted cloud room
+local runtime/kernel <-> daemon <-> hosted cloud room (policy TBD, later slice)
+```
+
+## What already exists
+
+- `notebook-cloud-transport`: `CloudWsConfig`/`CloudAuth`/`CloudWsFrameTransport`
+  with reconnect-oriented design, token refresher hook, `cloud_room_ready`
+  principal observation, and workstation metadata headers.
+- `runtimed cloud-peer` (`crates/runtimed/src/cloud_peer.rs`): a diagnostic
+  daemon-side peer that already syncs NotebookDoc + RuntimeStateDoc with a
+  hosted room and authors as `<principal>/<operator>:<nonce>`.
+- `runt-mcp` hosted sessions: target parsing (`NotebookTarget::Hosted`) and the
+  machine-local cloud domain registry (`CloudRegistry`, env-referenced
+  credentials) in `crates/runt-mcp/src/cloud.rs`, per
+  `docs/adr/cloud-connected-local-mcp.md` Decision 2.
+- Daemon rooms: `NotebookRoom` owns the canonical `NotebookDoc` plus
+  `RuntimeStateDoc`/`CommsDoc`/`CommentsDoc` handles, per-peer sync states, a
+  `changed_tx` broadcast, and identity enforcement
+  (`RoomConnectionIdentity`, actor-principal validation on inbound changes).
+
+## Decision sketch: the bridge is another peer of the daemon room
+
+A hosted daemon session creates an **ephemeral, hosted-flagged
+`NotebookRoom`** keyed by the hosted locator, and attaches a **bridge task**
+that is simply one more peer of that room — except its transport is the
+cloud WebSocket instead of a Unix socket.
+
+Echo suppression falls out of the design rather than being bolted on: the
+daemon room holds exactly one `NotebookDoc` instance; the cloud connection is
+one automerge `sync::State` against that doc, and each local peer is another.
+The sync protocol already guarantees changes are not replayed to the peer they
+came from, and convergence tests assert bounded message counts after quiesce.
+
+Bridged docs, v1: `NotebookDoc` (read/write) and `RuntimeStateDoc`
+(cloud-authoritative, received with `receive_sync_message_with_changes`).
+`CommsDoc`/`CommentsDoc` bridging and local-runtime-peer policy are later
+slices (#3861 slice 5).
+
+Execution, v1: hosted rooms do not launch local kernels. `execute_cell`
+requests from local peers are forwarded to the cloud room as hosted
+`Request` frames (the same dispatch `cloud-peer --run-cell` exercises); the
+resulting queue/output state arrives back via RuntimeStateDoc sync.
+
+Persistence, v1: none (ephemeral room). Local-first persistence for hosted
+sessions is #3600 and layers on later.
+
+## Attribution
+
+The hosted room rejects changes whose actor principal differs from the
+authenticated principal, so the bridge must not let local peers author under
+the local-Unix principal. When a room is hosted-bridged:
+
+- the room's connection identity mints local peers' actor labels under the
+  **cloud principal** observed in `cloud_room_ready`, keeping the peer's
+  self-declared operator suffix:
+
+```text
+user:anaconda:<sub>/operator:desktop:<session>
+user:anaconda:<sub>/operator:codex:<session>
+```
+
+- the bridge itself never rewrites changes; attribution rides the actor label
+  end to end, so cloud-side history shows which local operator made each
+  change while authorization stays anchored to the one authenticated
+  principal.
+- actor uniqueness: the bridge mints a fresh `:<nonce>` per cloud connect
+  (automerge duplicate-seq rule), and local peers already get per-connection
+  labels from the room host.
+
+## Credentials
+
+v1 reuses the machine-local cloud domain registry from
+`docs/adr/cloud-connected-local-mcp.md` Decision 2, lifted out of `runt-mcp`
+into a shared home so the daemon resolves the same file: routing data in the
+registry, secrets referenced via environment variables (later: keychain /
+device flow — #3861 open question). Credentials never ride the handshake from
+the desktop app; the desktop names a URL, the daemon owns the credential.
+
+Direct MCP hosted mode stays as a headless shortcut. Nothing here removes it;
+the daemon-mediated path is the desktop product lifecycle.
+
+## Entry point
+
+New connection handshake channel:
+
+```json
+{"channel":"open_hosted_notebook","url":"https://preview.runt.run/n/01KT...","operator":"desktop"}
+```
+
+The daemon resolves the URL against the registry, creates or joins the
+hosted-bridged room, spawns the bridge if needed, and then serves the
+connection exactly like a normal `notebook_sync` peer (typed bootstrap,
+`NotebookConnectionInfo` with the daemon-local room id). Reconnect/status
+composition in the desktop UI is #3599.
+
+## Out of scope for the first slice
+
+- OAuth/device-flow credential acquisition and keychain storage.
+- CommsDoc/CommentsDoc bridging; widget replay across the bridge.
+- Offering local daemon compute to the hosted room (workstation attach is a
+  separate, existing flow).
+- Offline edits with later cloud rejection UX.
+- Local-first persistence of hosted sessions (#3600).


### PR DESCRIPTION
Implements #3861's daemon-mediated topology: the daemon becomes the bridge between local peers and a hosted cloud room. Desktop and MCP clients open a cloud notebook through the daemon, which dials the hosted room with its own credential and serves everyone from a daemon-local room.

## Topology

The bridge is just another sync peer of the room. The daemon creates an ephemeral `NotebookRoom` keyed by the hosted locator, and a bridge task holds one automerge `sync::State` per doc against the cloud WebSocket, exactly like each local peer holds one against the Unix socket. Echo suppression is structural: one doc instance, per-peer sync states, and the protocol never replays a change to the peer it came from. A test asserts the exchange quiesces after convergence instead of ping-ponging.

Bridged docs in this slice: NotebookDoc (read/write) and RuntimeStateDoc (cloud-authoritative, applied with `receive_sync_message_with_changes`). CommsDoc/CommentsDoc bridging and local-runtime-peer policy are later slices.

## Attribution

The hosted room rejects changes whose actor principal differs from the authenticated principal, so local peers on a bridged room author under the cloud principal observed in `cloud_room_ready`, keeping their own operator suffix: `user:anaconda:kyle/desktop:win1`. `RoomConnectionIdentity::hosted_bridged` mints those labels and rejects operator-only legacy labels, which would collapse local activity into one daemon identity on the cloud side. The bridge never rewrites changes.

## Credentials

The machine-local cloud domain registry moves out of runt-mcp into a `registry` feature on `notebook-cloud-transport`, so the daemon and MCP hosted sessions resolve the same `cloud-domains.toml` (routing metadata in the file, secrets referenced via env vars). Credentials never ride the `open_hosted_notebook` handshake; the desktop names a URL, the daemon owns the credential. Direct MCP hosted mode is unchanged and stays as the headless shortcut.

## Entry points

New `OpenHostedNotebook { url }` handshake channel plus `notebook_sync::connect::connect_open_hosted`. The daemon parses the URL, resolves the domain, spawns or reuses the bridge, waits for the cloud principal, then serves the connection as a normal notebook-sync peer with `NotebookConnectionInfo` carrying the daemon-local room id and the assembled actor label.

`runt cloud open <url> [--operator] [--stay N] [--json]` is the CLI smoke path: it opens through the bridge and prints the room id, actor label, scope, and cell count.

## Runtime policy

Hosted rooms never auto-launch local kernels. Forwarded requests match the cloud room host's dispatch contract (verified in `runtimed-wasm`'s `handle_execute_cell`/`handle_run_all_cells`):

| Request | Behavior |
| --- | --- |
| `ExecuteCell` / guarded | Mints or validates a UUID `execution_id`, forwards it, returns `CellQueued` |
| `RunAllCells` / guarded | Reads code cells from the bridged doc, mints per-cell ids, forwards `cell_execution_ids`, returns `AllCellsQueued` |
| `InterruptExecution` | Forwards to the room's runtime-peer relay, returns `InterruptSent` |
| Kernel lifecycle, sync-env, save | Actionable rejection: the cloud room owns runtime and persistence |

Malformed or duplicate caller-supplied execution ids are rejected locally (`ExecutionIdRejected`) before any frame reaches the cloud.

## Lifecycle

Bridge rooms are pinned resident while in use. An idle monitor signals the daemon after a continuous span with zero local peers (default 15 min); `teardown_hosted_bridge` re-verifies peer count, in-flight attach reservations, and handle identity before removing the bridge and releasing the room reservation. Daemon shutdown drains all bridges.

Rooms carry a monotonic `is_hosted` flag that gates every local writer that would author cloud-invalid changes: kernel auto-launch, workstation attachment publishing, and markdown asset resolution. The flag outlives bridge teardown, so a formerly-bridged room can never fall back to local kernel behavior.

## Review

Implementation was Codex-driven; reviewed by GLM-5 (Bedrock, `pr-review`) and an adversarial Codex pass. All confirmed findings fixed (teardown/attach race, hosted-room local RuntimeStateDoc/NotebookDoc writers, reconnect coverage); deferred items are below.

## Known seams / follow-ups

- Desktop UI wiring and daemon-to-cloud status composition is #3599; local-first persistence for hosted sessions is #3600.
- Credential acquisition is env-var based via the registry; device-flow/keychain is an open question on #3861.
- Forwarded requests are fire-and-forget: `CellQueued`/`AllCellsQueued` report the request, not a receipt (the cloud may idempotently skip already-active cells, and a rejection surfaces as a `cloud_frame_rejected` warn log, not a response). Request/ack correlation is a follow-up.
- CommsDoc is not bridged yet, so widget state does not flow across the bridge (later slice per the memo).

`docs/memos/desktop-cloud-daemon-bridge.md` records the topology and scope cuts.

## Testing

- Bridge tests against an in-process fake hosted room (typed-frame v4 + `cloud_room_ready`): both-direction convergence, post-convergence quiesce (echo probe), execute/run-all/interrupt forwarding with execution-id passthrough, reconnect with fresh sync states, idle-teardown signaling plus the teardown-race regression, and principal/operator attribution.
- End-to-end integration test: real daemon over a real socket + temp registry + fake hosted room, asserting the full `OpenHostedNotebook` handshake, attribution, and both-direction sync.
- `cargo test -p runtimed --lib` (1037), `--test hosted_open` (1), tokio mutex lint, `-p notebook-sync` (82), `-p runt-mcp` (186), `-p notebook-cloud-transport --features registry` (29), `cargo xtask lint --fix` clean.
