### PR TITLE
fix(notebook-cloud): dashboard review findings (row facts, header wrap, dialog a11y)

### DIFF
--- a/apps/notebook-cloud/viewer/cloud-notebook-dashboard-view.tsx
+++ b/apps/notebook-cloud/viewer/cloud-notebook-dashboard-view.tsx
@@ -200,6 +200,7 @@ function CloudNotebookDashboardHero({
       : row.environmentLabel
     : null;
   const cellCount = row.composition ? notebookCompositionTotal(row.composition) : null;
+  const heroComputeFact = row.facts.find((fact) => fact.kind === "compute") ?? null;
 
   return (
     <section
@@ -219,7 +220,9 @@ function CloudNotebookDashboardHero({
           </div>
           <h2 className="nb-hero-title">{cloudNotebookDisplayTitle(notebook)}</h2>
           <div className="nb-hero-meta">
-            <RuntimeStatusDot status={row.runtimeStatus} showLabel />
+            <span title={heroComputeFact?.label ?? undefined}>
+              <RuntimeStatusDot status={row.runtimeStatus} showLabel />
+            </span>
             <span className="nb-meta-item">
               <Clock aria-hidden="true" />
               Updated {formatNotebookUpdatedAt(notebook.updated_at)}
@@ -418,6 +421,9 @@ function CloudNotebookDashboardRowView({
   const hasTitle = Boolean(notebook.title?.trim());
   const cellCount = row.composition ? notebookCompositionTotal(row.composition) : null;
   const runtimeActive = cloudNotebookRuntimeIsActive(row);
+  // The compute fact carries the rich label ("lab2 workstation running, 1 queued");
+  // the column shows the calm dot + terse status, the full label rides title/aria.
+  const computeFact = row.facts.find((fact) => fact.kind === "compute") ?? null;
 
   return (
     <div className={`nb-row${runtimeActive ? " is-live" : ""}`} data-scope={notebook.scope}>
@@ -444,6 +450,11 @@ function CloudNotebookDashboardRowView({
       <span className="nb-col nb-col-owner">
         <span className="nb-avatar nb-avatar-sm">{row.ownerInitials}</span>
         <span className="nb-col-owner-name">{row.ownerLabel}</span>
+      </span>
+      <span className="nb-col nb-col-status" title={computeFact?.label ?? undefined}>
+        {row.runtimeStatus !== "none" ? (
+          <RuntimeStatusDot status={row.runtimeStatus} showLabel />
+        ) : null}
       </span>
       <span className="nb-col nb-col-updated">
         <Clock aria-hidden="true" />

--- a/apps/notebook-cloud/viewer/index.css
+++ b/apps/notebook-cloud/viewer/index.css
@@ -877,7 +877,9 @@ body {
 
 .nb-header-actions {
   display: flex;
+  flex-wrap: wrap;
   align-items: center;
+  justify-content: flex-end;
   gap: 8px;
 }
 
@@ -1328,7 +1330,7 @@ body {
 .nb-row {
   position: relative;
   display: grid;
-  grid-template-columns: minmax(180px, 1fr) 124px 150px minmax(118px, auto) 72px;
+  grid-template-columns: minmax(180px, 1fr) 124px 128px 150px minmax(118px, auto) 72px;
   align-items: center;
   min-height: 68px;
   column-gap: 14px;
@@ -1581,73 +1583,13 @@ body {
   line-height: 1.5;
 }
 
-.nb-overlay {
-  position: fixed;
-  inset: 0;
-  z-index: 60;
-  display: grid;
-  place-items: center;
-  padding: 24px;
-  background: color-mix(in srgb, var(--foreground) 32%, transparent);
-  backdrop-filter: blur(3px);
-}
-
-.nb-dialog {
-  width: min(100%, 540px);
-  overflow: hidden;
-  border: 1px solid var(--border);
-  border-radius: 16px;
-  background: var(--card);
-  color: var(--foreground);
-  box-shadow: 0 24px 60px -12px rgba(0, 0, 0, 0.35);
-}
-
-.nb-dialog-head,
-.nb-dialog-foot {
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  gap: 12px;
-  padding: 18px 20px;
-}
-
-.nb-dialog-head {
-  border-bottom: 1px solid var(--border);
-}
-
-.nb-dialog-head h2 {
-  margin: 0;
-  font-size: 16.5px;
-  font-weight: 700;
-}
-
-.nb-dialog-x {
-  display: grid;
-  width: 30px;
-  height: 30px;
-  place-items: center;
-  border: 0;
-  border-radius: 8px;
-  color: var(--muted-foreground);
-  background: transparent;
-  cursor: pointer;
-}
-
-.nb-dialog-x:hover {
-  color: var(--foreground);
-  background: var(--muted);
-}
-
-.nb-dialog-x svg {
-  width: 16px;
-  height: 16px;
-}
-
-.nb-dialog-body {
+/* Create dialog rides the shared @/components/ui/dialog primitive (focus trap,
+   background inerting, Escape, focus restore come from Radix). These rules only
+   shape the form inside it. */
+.nb-create-dialog form {
   display: flex;
   flex-direction: column;
   gap: 18px;
-  padding: 20px;
 }
 
 .nb-field {
@@ -1662,16 +1604,10 @@ body {
   font-weight: 650;
 }
 
-.nb-dialog .cloud-notebook-list-banner {
+.nb-create-dialog .cloud-notebook-list-banner {
   border: 1px solid color-mix(in srgb, var(--destructive) 28%, var(--border));
   border-radius: 8px;
   padding: 0.625rem 0.75rem;
-}
-
-.nb-dialog-foot {
-  justify-content: flex-end;
-  border-top: 1px solid var(--border);
-  background: color-mix(in srgb, var(--muted) 40%, var(--card));
 }
 
 .cloud-notebook-list-state {
@@ -1818,7 +1754,12 @@ body {
   }
 
   .nb-col-owner,
+  .nb-col-status,
   .nb-col-badges {
+    display: none;
+  }
+
+  .nb-btn-label {
     display: none;
   }
 

--- a/apps/notebook-cloud/viewer/notebook-list-view.tsx
+++ b/apps/notebook-cloud/viewer/notebook-list-view.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useMemo, useRef, useState, type FormEvent } from "react";
+import { useCallback, useEffect, useMemo, useState, type FormEvent } from "react";
 import {
   AlertCircle,
   ArrowUpRight,
@@ -9,9 +9,16 @@ import {
   RotateCcw,
   Search,
   Sparkles,
-  X,
 } from "lucide-react";
 import { Button } from "@/components/ui/button";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
 import { Input } from "@/components/ui/input";
 import { useTheme } from "@/hooks/useTheme";
 import {
@@ -357,11 +364,12 @@ export function CloudNotebookListView({ authConfig }: { authConfig: CloudViewerA
                 <Button
                   type="button"
                   variant="outline"
+                  aria-label="Refresh notebooks"
                   disabled={listState.kind === "loading"}
                   onClick={refreshList}
                 >
                   <RotateCcw aria-hidden="true" />
-                  Refresh
+                  <span className="nb-btn-label">Refresh</span>
                 </Button>
                 <Button
                   type="button"
@@ -375,9 +383,9 @@ export function CloudNotebookListView({ authConfig }: { authConfig: CloudViewerA
                   )}
                   {createState === "starting" ? "Creating" : "New notebook"}
                 </Button>
-                <Button type="button" variant="ghost" onClick={signOut}>
+                <Button type="button" variant="ghost" aria-label="Sign out" onClick={signOut}>
                   <LogOut aria-hidden="true" />
-                  Sign out
+                  <span className="nb-btn-label">Sign out</span>
                 </Button>
                 <span className="nb-avatar-me" title={headerDetail}>
                   {currentUserInitials}
@@ -505,54 +513,34 @@ function CloudNotebookCreateDialog({
   onCreate: (event: FormEvent<HTMLFormElement>) => void;
   onTitleChange: (title: string) => void;
 }) {
-  const inputRef = useRef<HTMLInputElement>(null);
-
-  useEffect(() => {
-    inputRef.current?.focus();
-  }, []);
-
-  useEffect(() => {
-    const onKeyDown = (event: KeyboardEvent) => {
-      if (event.key === "Escape") {
-        onClose();
-      }
-    };
-    window.addEventListener("keydown", onKeyDown);
-    return () => window.removeEventListener("keydown", onKeyDown);
-  }, [onClose]);
-
+  const busy = createState === "starting";
   return (
-    <div className="nb-overlay" onMouseDown={onClose}>
-      <form
-        className="nb-dialog"
-        role="dialog"
-        aria-modal="true"
-        aria-labelledby="cloud-new-notebook-dialog-title"
-        onMouseDown={(event) => event.stopPropagation()}
-        onSubmit={onCreate}
-      >
-        <div className="nb-dialog-head">
-          <h2 id="cloud-new-notebook-dialog-title">New notebook</h2>
-          <button
-            type="button"
-            className="nb-dialog-x"
-            disabled={createState === "starting"}
-            aria-label="Close"
-            onClick={onClose}
-          >
-            <X aria-hidden="true" />
-          </button>
-        </div>
-        <div className="nb-dialog-body">
+    <Dialog
+      open
+      onOpenChange={(open) => {
+        // The shared Dialog owns focus trap, background inerting, Escape, and
+        // focus restore. Ignore close requests while the create is in flight.
+        if (!open && !busy) {
+          onClose();
+        }
+      }}
+    >
+      <DialogContent className="nb-create-dialog" showCloseButton={!busy}>
+        <form onSubmit={onCreate}>
+          <DialogHeader>
+            <DialogTitle>New notebook</DialogTitle>
+            <DialogDescription>
+              Give it a title now, or rename it later from the dashboard.
+            </DialogDescription>
+          </DialogHeader>
           <div className="nb-field">
             <label htmlFor="cloud-new-notebook-title">Title</label>
             <Input
-              ref={inputRef}
               id="cloud-new-notebook-title"
               type="text"
               value={title}
               maxLength={160}
-              disabled={createState === "starting"}
+              disabled={busy}
               placeholder="Untitled notebook"
               onChange={(event) => onTitleChange(event.currentTarget.value)}
             />
@@ -562,27 +550,22 @@ function CloudNotebookCreateDialog({
               {error}
             </div>
           ) : null}
-        </div>
-        <div className="nb-dialog-foot">
-          <Button
-            type="button"
-            variant="ghost"
-            disabled={createState === "starting"}
-            onClick={onClose}
-          >
-            Cancel
-          </Button>
-          <Button type="submit" disabled={createState === "starting"}>
-            {createState === "starting" ? (
-              <Loader2 className="cloud-home-status-spinner" aria-hidden="true" />
-            ) : (
-              <Plus aria-hidden="true" />
-            )}
-            {createState === "starting" ? "Creating" : "Create"}
-          </Button>
-        </div>
-      </form>
-    </div>
+          <DialogFooter>
+            <Button type="button" variant="ghost" disabled={busy} onClick={onClose}>
+              Cancel
+            </Button>
+            <Button type="submit" disabled={busy}>
+              {busy ? (
+                <Loader2 className="cloud-home-status-spinner" aria-hidden="true" />
+              ) : (
+                <Plus aria-hidden="true" />
+              )}
+              {busy ? "Creating" : "Create"}
+            </Button>
+          </DialogFooter>
+        </form>
+      </DialogContent>
+    </Dialog>
   );
 }
 


### PR DESCRIPTION
Fixes the three findings from the post-merge Codex review of #3883.

## Row compute facts (was: dropped)

The projection computes rich compute facts ("lab2 workstation running, 1 queued") that the redesigned rows never rendered. Rows now have a **status column** in the fixed grid - mid-grid, deliberately not a leading dot (the design handoff bans the left status dot as cryptic). Visible: the calm `RuntimeStatusDot` with its terse label. The rich fact label rides `title` on the column (and on the hero's dot). The wrapper carries no `aria-label` - the dot's own accessible name is the single source, avoiding the nested/conflicting announcements the adversarial pass flagged.

## Header overflow on phones (was: nowrap action cluster)

`.nb-header-actions` wraps, and Refresh/Sign out collapse to icon-only at narrow widths (`.nb-btn-label` hidden ≤860px, `aria-label`s keep them named). "New notebook" keeps its text deliberately: it's the primary action and wrapping absorbs it.

## Create dialog a11y (was: hand-rolled aria-modal)

The dialog now rides the shared `@/components/ui/dialog` Radix primitive: focus trap, background inerting, Escape, and focus restore all come from the primitive instead of a partial reimplementation. Close paths (Escape/overlay/X) are gated while the create request is in flight; the built-in X hides during pending via `showCloseButton`. `DialogDescription` added per the repo's Radix dialog precedent. The dead `.nb-overlay`/`.nb-dialog-*` CSS block is deleted.

## Verification

- [x] Cloud tests 1166/1166, cloud build, desktop app build, `vp check` clean
- [x] Adversarial review pass on the diff: grid column count vs markup (incl. rename-form row + ≤860px collapse), handoff conformance (no left dot), dialog focus order and close-while-busy walk, 360px header layout walk - two should-fixes it raised are folded in (aria conflict, busy X)
