### PR TITLE
feat(notebook-cloud): derive cell composition and language at snapshot publish

### DIFF
--- a/apps/notebook-cloud/src/index.ts
+++ b/apps/notebook-cloud/src/index.ts
@@ -55,6 +55,7 @@ import {
   runtimeStateSnapshotKey,
   snapshotKey,
   setDefaultWorkstation,
+  updateNotebookSnapshotSummary,
   updateNotebookTitle,
   updateWorkstationAttachJobStatus,
   type ListedNotebookRow,
@@ -84,7 +85,10 @@ import {
   type WorkstationAttachJobNotification,
 } from "./workstation-events.ts";
 import { OwnerComputeIndex, listOwnerComputeSessions } from "./compute-session-index.ts";
-import { materializeSnapshotPairRender } from "./snapshot-render.ts";
+import {
+  materializeSnapshotPairRenderWithSummary,
+  type SnapshotNotebookSummary,
+} from "./snapshot-render.ts";
 import { notebookRouteSegmentTitle } from "./notebook-route-title.ts";
 import {
   createNotebookCloudBlobResolver,
@@ -218,6 +222,7 @@ const rendererSidecarAssetNamesCache = new WeakMap<
 type SnapshotPairValidationResult =
   | {
       ok: true;
+      summary: SnapshotNotebookSummary;
     }
   | {
       ok: false;
@@ -1219,6 +1224,7 @@ function notebookListResponseRows(
   return notebooks.map((notebook) => {
     const notebookPathId = encodeURIComponent(notebook.id);
     const apiBasePath = `/api/n/${notebookPathId}`;
+    const composition = parseNotebookCellComposition(notebook.cell_composition);
     const computeSession =
       notebook.owner_principal === computeSessions.get(notebook.id)?.owner_principal
         ? computeSessions.get(notebook.id)
@@ -1231,6 +1237,8 @@ function notebookListResponseRows(
       created_at: notebook.created_at,
       updated_at: notebook.updated_at,
       latest_revision_id: notebook.latest_revision_id,
+      ...(composition ? { composition } : {}),
+      ...(typeof notebook.language === "string" ? { language: notebook.language } : {}),
       compute_session: computeSession,
       viewer_url: viewerUrlForRequest(request, notebook.id, notebook.title, env),
       endpoints: {
@@ -1240,6 +1248,40 @@ function notebookListResponseRows(
       },
     };
   });
+}
+
+function parseNotebookCellComposition(
+  value: string | null,
+): { code: number; markdown: number; raw: number } | undefined {
+  if (!value) {
+    return undefined;
+  }
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(value);
+  } catch {
+    return undefined;
+  }
+  if (!parsed || typeof parsed !== "object") {
+    return undefined;
+  }
+  const composition = parsed as { code?: unknown; markdown?: unknown; raw?: unknown };
+  if (
+    isNotebookCellCount(composition.code) &&
+    isNotebookCellCount(composition.markdown) &&
+    isNotebookCellCount(composition.raw)
+  ) {
+    return {
+      code: composition.code,
+      markdown: composition.markdown,
+      raw: composition.raw,
+    };
+  }
+  return undefined;
+}
+
+function isNotebookCellCount(value: unknown): value is number {
+  return Number.isSafeInteger(value) && value >= 0;
 }
 
 function parseNotebookListLimit(request: Request): number | Response {
@@ -2766,6 +2808,19 @@ async function routeSnapshot(
     throw error;
   }
 
+  try {
+    await updateNotebookSnapshotSummary(env, notebookId, validated.summary);
+  } catch (error) {
+    cloudLog("warn", "snapshot.summary.update_failed", {
+      notebook_id: notebookId,
+      notebook_heads_hash: headsHash,
+      revision_id: revisionId,
+      error: errorMessage(error),
+      counter: "snapshot_summary_update_failures",
+      counter_delta: 1,
+    });
+  }
+
   return json(
     {
       ok: true,
@@ -3941,9 +3996,9 @@ async function validateSnapshotPair(options: {
     };
   }
 
-  let render: Awaited<ReturnType<typeof materializeSnapshotPairRender>>;
+  let materialized: Awaited<ReturnType<typeof materializeSnapshotPairRenderWithSummary>>;
   try {
-    render = await materializeSnapshotPairRender({
+    materialized = await materializeSnapshotPairRenderWithSummary({
       notebookId: options.notebookId,
       notebookHeadsHash: options.notebookHeadsHash,
       runtimeHeadsHash: options.runtimeHeadsHash,
@@ -3974,6 +4029,7 @@ async function validateSnapshotPair(options: {
       },
     };
   }
+  const { render, summary } = materialized;
 
   if (render.runtime_state_doc_id !== options.expectedRuntimeStateDocId) {
     cloudLog("warn", "snapshot_pair.validation.runtime_state_doc_id_mismatch", {
@@ -4052,7 +4108,7 @@ async function validateSnapshotPair(options: {
     counter: "snapshot_pair_validations",
     counter_delta: 1,
   });
-  return { ok: true };
+  return { ok: true, summary };
 }
 
 async function findMissingSnapshotBlobs(

--- a/apps/notebook-cloud/src/snapshot-render.ts
+++ b/apps/notebook-cloud/src/snapshot-render.ts
@@ -23,7 +23,23 @@ export interface SnapshotRender {
   widget_comms: SnapshotWidgetComm[];
 }
 
-export async function materializeSnapshotPairRender(input: {
+export interface SnapshotCellComposition {
+  code: number;
+  markdown: number;
+  raw: number;
+}
+
+export interface SnapshotNotebookSummary {
+  cellComposition: SnapshotCellComposition;
+  language: string | null;
+}
+
+export interface MaterializedSnapshotPairRender {
+  render: SnapshotRender;
+  summary: SnapshotNotebookSummary;
+}
+
+interface MaterializeSnapshotPairRenderInput {
   notebookId: string;
   notebookHeadsHash: string;
   runtimeHeadsHash: string | null;
@@ -32,7 +48,17 @@ export async function materializeSnapshotPairRender(input: {
   commsDocBytes?: Uint8Array;
   blobResolver?: BlobResolver;
   generatedAt?: string;
-}): Promise<SnapshotRender> {
+}
+
+export async function materializeSnapshotPairRender(
+  input: MaterializeSnapshotPairRenderInput,
+): Promise<SnapshotRender> {
+  return (await materializeSnapshotPairRenderWithSummary(input)).render;
+}
+
+export async function materializeSnapshotPairRenderWithSummary(
+  input: MaterializeSnapshotPairRenderInput,
+): Promise<MaterializedSnapshotPairRender> {
   const handle = await loadSnapshotPair(
     input.notebookBytes,
     input.runtimeStateBytes,
@@ -43,27 +69,34 @@ export async function materializeSnapshotPairRender(input: {
     const runtimeState = handle.get_runtime_state();
     const commsState = handle.get_comms_state();
     const metadata = parseJsonOrNull(handle.get_metadata_snapshot_json());
+    const summary = {
+      cellComposition: countCellComposition(cells),
+      language: readDetectedRuntime(handle, metadata),
+    };
     const commsDocId = readOptionalCommsDocId(handle);
     const rawWidgetComms = snapshotWidgetCommsFromRuntimeAndCommsState(runtimeState, commsState);
     const widgetComms = input.blobResolver
       ? resolveSnapshotWidgetComms(rawWidgetComms, input.blobResolver)
       : rawWidgetComms;
     return {
-      schema_version: 1,
-      generated_from: "runtimed-wasm:load_snapshot",
-      generated_at: input.generatedAt ?? new Date().toISOString(),
-      notebook_id: input.notebookId,
-      heads_hash: input.notebookHeadsHash,
-      runtime_state_doc_id: handle.get_runtime_state_doc_id() ?? null,
-      comms_doc_id: commsDocId,
-      runtime_heads_hash: input.runtimeHeadsHash,
-      metadata,
-      source: "snapshot-pair",
-      cells,
-      blob_urls: input.blobResolver
-        ? collectBlobUrls({ cells, widget_comms: rawWidgetComms }, input.blobResolver)
-        : {},
-      widget_comms: widgetComms,
+      render: {
+        schema_version: 1,
+        generated_from: "runtimed-wasm:load_snapshot",
+        generated_at: input.generatedAt ?? new Date().toISOString(),
+        notebook_id: input.notebookId,
+        heads_hash: input.notebookHeadsHash,
+        runtime_state_doc_id: handle.get_runtime_state_doc_id() ?? null,
+        comms_doc_id: commsDocId,
+        runtime_heads_hash: input.runtimeHeadsHash,
+        metadata,
+        source: "snapshot-pair",
+        cells,
+        blob_urls: input.blobResolver
+          ? collectBlobUrls({ cells, widget_comms: rawWidgetComms }, input.blobResolver)
+          : {},
+        widget_comms: widgetComms,
+      },
+      summary,
     };
   } finally {
     handle.free();
@@ -83,4 +116,74 @@ function readOptionalCommsDocId(handle: {
   get_comms_doc_id?: () => string | undefined;
 }): string | null {
   return typeof handle.get_comms_doc_id === "function" ? (handle.get_comms_doc_id() ?? null) : null;
+}
+
+function readDetectedRuntime(
+  handle: { detect_runtime?: () => string | undefined },
+  metadata: unknown,
+): string | null {
+  try {
+    if (typeof handle.detect_runtime === "function") {
+      return handle.detect_runtime() ?? detectRuntimeFromMetadata(metadata);
+    }
+  } catch {
+    return detectRuntimeFromMetadata(metadata);
+  }
+  return detectRuntimeFromMetadata(metadata);
+}
+
+function detectRuntimeFromMetadata(metadata: unknown): string | null {
+  if (!metadata || typeof metadata !== "object") {
+    return null;
+  }
+  const record = metadata as Record<string, unknown>;
+  const kernelspec = objectRecord(record.kernelspec);
+  if (kernelspec) {
+    const name = stringLower(kernelspec.name);
+    if (name?.includes("deno")) return "deno";
+    if (name?.includes("python")) return "python";
+
+    const language = stringLower(kernelspec.language);
+    if (language === "typescript" || language === "javascript") return "deno";
+    if (language === "python") return "python";
+  }
+
+  const languageInfo = objectRecord(record.language_info);
+  if (languageInfo) {
+    const name = stringLower(languageInfo.name);
+    if (name === "deno" || name === "typescript" || name === "javascript") return "deno";
+    if (name === "python") return "python";
+  }
+
+  const runt = objectRecord(record.runt);
+  if (runt) {
+    if (objectRecord(runt.deno)) return "deno";
+    if (objectRecord(runt.uv) || objectRecord(runt.conda)) return "python";
+  }
+  return null;
+}
+
+function objectRecord(value: unknown): Record<string, unknown> | null {
+  return value && typeof value === "object" ? (value as Record<string, unknown>) : null;
+}
+
+function stringLower(value: unknown): string | null {
+  return typeof value === "string" ? value.toLowerCase() : null;
+}
+
+function countCellComposition(cells: unknown): SnapshotCellComposition {
+  const composition: SnapshotCellComposition = { code: 0, markdown: 0, raw: 0 };
+  if (!Array.isArray(cells)) {
+    return composition;
+  }
+  for (const cell of cells) {
+    if (!cell || typeof cell !== "object") {
+      continue;
+    }
+    const cellType = (cell as { cell_type?: unknown }).cell_type;
+    if (cellType === "code" || cellType === "markdown" || cellType === "raw") {
+      composition[cellType] += 1;
+    }
+  }
+  return composition;
 }

--- a/apps/notebook-cloud/src/snapshot-render.ts
+++ b/apps/notebook-cloud/src/snapshot-render.ts
@@ -132,7 +132,7 @@ function readDetectedRuntime(
   return detectRuntimeFromMetadata(metadata);
 }
 
-function detectRuntimeFromMetadata(metadata: unknown): string | null {
+export function detectRuntimeFromMetadata(metadata: unknown): string | null {
   if (!metadata || typeof metadata !== "object") {
     return null;
   }
@@ -171,7 +171,7 @@ function stringLower(value: unknown): string | null {
   return typeof value === "string" ? value.toLowerCase() : null;
 }
 
-function countCellComposition(cells: unknown): SnapshotCellComposition {
+export function countCellComposition(cells: unknown): SnapshotCellComposition {
   const composition: SnapshotCellComposition = { code: 0, markdown: 0, raw: 0 };
   if (!Array.isArray(cells)) {
     return composition;

--- a/apps/notebook-cloud/src/storage.ts
+++ b/apps/notebook-cloud/src/storage.ts
@@ -432,7 +432,7 @@ async function initializeCatalogSchema(env: Env): Promise<void> {
   await backfillNotebookAcl(env);
 }
 
-async function runCatalogMigrations(env: Env): Promise<void> {
+export async function runCatalogMigrations(env: Env): Promise<void> {
   for (const migration of SCHEMA_MIGRATIONS) {
     if (await tableHasColumn(env, migration.table, migration.column)) {
       continue;

--- a/apps/notebook-cloud/src/storage.ts
+++ b/apps/notebook-cloud/src/storage.ts
@@ -14,6 +14,8 @@ export interface NotebookRow {
   created_at: string;
   updated_at: string;
   latest_revision_id: string | null;
+  cell_composition: string | null;
+  language: string | null;
 }
 
 export interface RevisionRow {
@@ -153,7 +155,9 @@ const SCHEMA_STATEMENTS = [
     title TEXT,
     created_at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ', 'now')),
     updated_at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ', 'now')),
-    latest_revision_id TEXT
+    latest_revision_id TEXT,
+    cell_composition TEXT,
+    language TEXT
   )`,
   `CREATE TABLE IF NOT EXISTS notebook_revisions (
     id TEXT PRIMARY KEY,
@@ -371,6 +375,16 @@ const SCHEMA_MIGRATIONS = [
     column: "comments_snapshot_key",
     statement: `ALTER TABLE notebook_revisions ADD COLUMN comments_snapshot_key TEXT`,
   },
+  {
+    table: "notebooks",
+    column: "cell_composition",
+    statement: `ALTER TABLE notebooks ADD COLUMN cell_composition TEXT`,
+  },
+  {
+    table: "notebooks",
+    column: "language",
+    statement: `ALTER TABLE notebooks ADD COLUMN language TEXT`,
+  },
 ];
 
 // Prototype-local schema memo. The Worker binds every room to the same D1
@@ -486,7 +500,14 @@ export async function getNotebookRow(env: Env, notebookId: string): Promise<Note
 
   await ensureCatalogSchema(env);
   return await env.DB.prepare(
-    `SELECT id, owner_principal, title, created_at, updated_at, latest_revision_id
+    `SELECT id,
+            owner_principal,
+            title,
+            created_at,
+            updated_at,
+            latest_revision_id,
+            cell_composition,
+            language
        FROM notebooks
        WHERE id = ?`,
   )
@@ -509,7 +530,9 @@ export async function getPublicPublishedNotebookRow(
             n.title,
             n.created_at,
             n.updated_at,
-            n.latest_revision_id
+            n.latest_revision_id,
+            n.cell_composition,
+            n.language
        FROM notebooks n
        JOIN notebook_acl a
          ON a.notebook_id = n.id
@@ -547,6 +570,33 @@ export async function updateNotebookTitle(
     return null;
   }
   return await getNotebookRow(env, notebookId);
+}
+
+export async function updateNotebookSnapshotSummary(
+  env: Env,
+  notebookId: string,
+  summary: {
+    cellComposition: {
+      code: number;
+      markdown: number;
+      raw: number;
+    };
+    language: string | null;
+  },
+): Promise<void> {
+  if (!env.DB) {
+    return;
+  }
+
+  await ensureCatalogSchema(env);
+  await env.DB.prepare(
+    `UPDATE notebooks
+        SET cell_composition = ?,
+            language = ?
+      WHERE id = ?`,
+  )
+    .bind(JSON.stringify(summary.cellComposition), summary.language, notebookId)
+    .run();
 }
 
 export async function getNotebookAclRowsForPrincipal(
@@ -602,6 +652,8 @@ export async function listNotebooksForPrincipal(
             n.created_at,
             n.updated_at,
             n.latest_revision_id,
+            n.cell_composition,
+            n.language,
             CASE MAX(
               CASE a.scope
                 WHEN 'owner' THEN 4
@@ -633,7 +685,9 @@ export async function listNotebooksForPrincipal(
                n.title,
                n.created_at,
                n.updated_at,
-               n.latest_revision_id
+               n.latest_revision_id,
+               n.cell_composition,
+               n.language
       ORDER BY n.updated_at DESC, n.created_at DESC, n.id DESC
       LIMIT ?`,
   )
@@ -1575,7 +1629,14 @@ export async function getNotebookCatalog(
 
   await ensureCatalogSchema(env);
   const notebook = await env.DB.prepare(
-    `SELECT id, owner_principal, title, created_at, updated_at, latest_revision_id
+    `SELECT id,
+            owner_principal,
+            title,
+            created_at,
+            updated_at,
+            latest_revision_id,
+            cell_composition,
+            language
        FROM notebooks
        WHERE id = ?`,
   )

--- a/apps/notebook-cloud/test/notebook-dashboard.test.ts
+++ b/apps/notebook-cloud/test/notebook-dashboard.test.ts
@@ -6,6 +6,7 @@ import {
   cloudNotebookDisplayTitle,
   cloudNotebookOpenUrlWithMode,
   cloudNotebookShortId,
+  isCloudNotebookListItem,
   projectCloudNotebookDashboard,
   projectCloudNotebookDashboardView,
   type CloudNotebookListItem,
@@ -693,6 +694,26 @@ describe("cloud notebook dashboard projection", () => {
     );
   });
 
+  it("threads notebook language through list-item validation and dashboard rows", () => {
+    const deno = notebook({
+      id: "deno-notebook",
+      title: "Deno Notebook",
+      scope: "owner",
+      updatedAt: "2026-06-24T00:00:00.000Z",
+      latestRevisionId: "published-deno",
+      composition: { code: 2, markdown: 1, raw: 0 },
+      language: "deno",
+    });
+
+    assert.equal(isCloudNotebookListItem(deno), true);
+    assert.equal(isCloudNotebookListItem({ ...deno, language: 42 }), false);
+
+    const model = projectCloudNotebookDashboard([deno]);
+
+    assert.equal(model.continueRow?.notebook.language, "deno");
+    assert.deepEqual(model.continueRow?.composition, { code: 2, markdown: 1, raw: 0 });
+  });
+
   it("maps compute session status to dashboard runtime status", () => {
     const base = {
       id: "runtime-status",
@@ -758,6 +779,8 @@ function notebook(input: {
   updatedAt: string;
   latestRevisionId: string | null;
   computeSession?: CloudNotebookListItem["compute_session"];
+  composition?: CloudNotebookListItem["composition"];
+  language?: string;
 }): CloudNotebookListItem {
   return {
     notebook_id: input.id,
@@ -768,6 +791,8 @@ function notebook(input: {
     updated_at: input.updatedAt,
     latest_revision_id: input.latestRevisionId,
     compute_session: input.computeSession ?? null,
+    ...(input.composition ? { composition: input.composition } : {}),
+    ...(input.language ? { language: input.language } : {}),
     viewer_url: `/n/${input.id}/notebook`,
     endpoints: {
       catalog: `/api/n/${input.id}`,

--- a/apps/notebook-cloud/test/snapshot-render.test.ts
+++ b/apps/notebook-cloud/test/snapshot-render.test.ts
@@ -2,7 +2,11 @@ import { before, describe, it } from "node:test";
 import assert from "node:assert/strict";
 import { readFile } from "node:fs/promises";
 import { RuntimeStatePeerHandle } from "../src/runtimed-wasm.ts";
-import { materializeSnapshotPairRender } from "../src/snapshot-render.ts";
+import {
+  countCellComposition,
+  detectRuntimeFromMetadata,
+  materializeSnapshotPairRender,
+} from "../src/snapshot-render.ts";
 import {
   createNotebookCloudBlobResolver,
   notebookCloudBlobBasePath,
@@ -299,3 +303,43 @@ describe("snapshot pair render materialization", () => {
 async function readJson(url: URL): Promise<Record<string, unknown>> {
   return JSON.parse(await readFile(url, "utf8")) as Record<string, unknown>;
 }
+
+describe("snapshot summary derivation helpers", () => {
+  it("counts only code/markdown/raw cell types and ignores unknowns", () => {
+    assert.deepEqual(
+      countCellComposition([
+        { cell_type: "code" },
+        { cell_type: "code" },
+        { cell_type: "markdown" },
+        { cell_type: "raw" },
+        { cell_type: "sql" },
+        { cell_type: 42 },
+        {},
+        null,
+      ]),
+      { code: 2, markdown: 1, raw: 1 },
+    );
+  });
+
+  it("returns zero composition for non-array cell payloads", () => {
+    assert.deepEqual(countCellComposition(null), { code: 0, markdown: 0, raw: 0 });
+    assert.deepEqual(countCellComposition("cells"), { code: 0, markdown: 0, raw: 0 });
+    assert.deepEqual(countCellComposition({ cells: [] }), { code: 0, markdown: 0, raw: 0 });
+  });
+
+  it("detects runtime from kernelspec name, language, language_info, and runt metadata", () => {
+    assert.equal(detectRuntimeFromMetadata({ kernelspec: { name: "python3" } }), "python");
+    assert.equal(detectRuntimeFromMetadata({ kernelspec: { name: "deno" } }), "deno");
+    assert.equal(detectRuntimeFromMetadata({ kernelspec: { language: "typescript" } }), "deno");
+    assert.equal(detectRuntimeFromMetadata({ language_info: { name: "python" } }), "python");
+    assert.equal(detectRuntimeFromMetadata({ runt: { uv: {} } }), "python");
+    assert.equal(detectRuntimeFromMetadata({ runt: { deno: {} } }), "deno");
+  });
+
+  it("returns null when metadata carries no runtime signal", () => {
+    assert.equal(detectRuntimeFromMetadata(null), null);
+    assert.equal(detectRuntimeFromMetadata({}), null);
+    assert.equal(detectRuntimeFromMetadata({ kernelspec: { name: "julia" } }), null);
+    assert.equal(detectRuntimeFromMetadata("python"), null);
+  });
+});

--- a/apps/notebook-cloud/test/worker-routes.test.ts
+++ b/apps/notebook-cloud/test/worker-routes.test.ts
@@ -39,6 +39,7 @@ import {
   getNotebookAclRows,
   getNotebookAclRowsForPrincipal,
   runtimeStateSnapshotKey,
+  runCatalogMigrations,
   snapshotKey,
 } from "../src/storage.ts";
 import type { PendingNotebookInviteRow, PrincipalProfileRow } from "../src/sharing-storage.ts";
@@ -5676,6 +5677,24 @@ describe("Worker artifact routes", () => {
     };
     assert.deepEqual(snapshotBlobRefsOverCap(over, 4), { count: 5, cap: 4, over: true });
     assert.deepEqual(snapshotBlobRefsOverCap(over, 5), { count: 5, cap: 5, over: false });
+  });
+});
+
+describe("catalog schema migrations", () => {
+  it("adds cell_composition and language via ALTER TABLE when absent", async () => {
+    const db = new FakeD1();
+    // Simulate a pre-migration deployment: the columns do not exist yet.
+    const notebookColumns = db.tableColumns.get("notebooks");
+    assert.ok(notebookColumns);
+    notebookColumns.delete("cell_composition");
+    notebookColumns.delete("language");
+
+    const env = fakeEnv({ DB: db });
+    await runCatalogMigrations(env);
+
+    const migrated = db.tableColumns.get("notebooks");
+    assert.ok(migrated?.has("cell_composition"), "cell_composition added by migration");
+    assert.ok(migrated?.has("language"), "language added by migration");
   });
 });
 

--- a/apps/notebook-cloud/test/worker-routes.test.ts
+++ b/apps/notebook-cloud/test/worker-routes.test.ts
@@ -30,7 +30,7 @@ import type {
   R2PutOptions,
 } from "../src/cloudflare-types.ts";
 import type { NotebookComputeSessionSummary } from "runtimed";
-import { RuntimeStatePeerHandle } from "../src/runtimed-wasm.ts";
+import { NotebookHandle, RuntimeStatePeerHandle } from "../src/runtimed-wasm.ts";
 import {
   WORKSTATION_ATTACH_JOB_STALE_MS,
   blobKey,
@@ -1858,6 +1858,43 @@ describe("Worker artifact routes", () => {
     assert.equal(body.notebooks[1]?.title, "Editor Shared");
     assert.equal(body.notebooks[1]?.viewer_url, "http://localhost/n/editor-shared/Editor%20Shared");
     assert.equal(body.notebooks[1]?.endpoints.catalog, "/api/n/editor-shared");
+  });
+
+  it("omits malformed notebook composition from list rows without dropping language", async () => {
+    const env = fakeEnv();
+    seedNotebook(env, "malformed-summary");
+    const notebook = env.DB.notebooks.get("malformed-summary");
+    assert.ok(notebook);
+    notebook.cell_composition = "{not-json";
+    notebook.language = "python";
+    seedAcl(env, { notebookId: "malformed-summary", subject: "user:dev:alice", scope: "owner" });
+
+    const response = await worker.fetch(
+      new Request("http://localhost/api/n", {
+        headers: {
+          "X-User": "alice",
+          "X-Operator": "desktop:test",
+          "X-Scope": "viewer",
+        },
+      }),
+      env,
+      fakeContext(),
+    );
+
+    assert.equal(response.status, 200);
+    const body = (await response.json()) as {
+      notebooks: Array<{
+        composition?: unknown;
+        language?: string;
+        notebook_id: string;
+      }>;
+    };
+    const row = body.notebooks.find(
+      (notebookRow) => notebookRow.notebook_id === "malformed-summary",
+    );
+    assert.ok(row);
+    assert.equal(Object.hasOwn(row, "composition"), false);
+    assert.equal(row.language, "python");
   });
 
   it("enriches owned notebook rows with owner-scoped compute sessions", async () => {
@@ -5234,6 +5271,30 @@ describe("Worker artifact routes", () => {
         ["route-demo", "public", "anonymous", "viewer"],
       ],
     );
+    const routeNotebook = env.DB.notebooks.get("route-demo");
+    assert.equal(routeNotebook?.cell_composition, JSON.stringify({ code: 1, markdown: 0, raw: 0 }));
+    const listResponse = await worker.fetch(
+      new Request("http://localhost/api/n", {
+        headers: {
+          "X-User": "alice",
+          "X-Operator": "desktop:test",
+          "X-Scope": "viewer",
+        },
+      }),
+      env,
+      fakeContext(),
+    );
+    assert.equal(listResponse.status, 200);
+    const listBody = (await listResponse.json()) as {
+      notebooks: Array<{
+        composition?: { code: number; markdown: number; raw: number };
+        notebook_id: string;
+      }>;
+    };
+    assert.deepEqual(
+      listBody.notebooks.find((notebook) => notebook.notebook_id === "route-demo")?.composition,
+      { code: 1, markdown: 0, raw: 0 },
+    );
     const response = await worker.fetch(
       new Request("http://localhost/api/n/route-demo/snapshots/heads-fixture"),
       env,
@@ -5276,6 +5337,126 @@ describe("Worker artifact routes", () => {
       fakeContext(),
     );
     assert.equal(renderCacheRoute.status, 404);
+  });
+
+  it("persists snapshot cell composition and notebook language for list rows", async () => {
+    const env = fakeEnv();
+    const { notebookBytes, runtimeStateBytes } = pythonSummarySnapshotPair(
+      "summary-demo",
+      "runtime:summary-demo",
+    );
+
+    const runtimePut = await ownerPut(
+      env,
+      "/api/n/summary-demo/runtime-snapshots/runtime-summary",
+      runtimeStateBytes,
+      {
+        "X-Runtime-State-Doc-Id": "runtime:summary-demo",
+      },
+    );
+    assert.equal(runtimePut.status, 201);
+
+    const notebookPut = await ownerPut(
+      env,
+      "/api/n/summary-demo/snapshots/heads-summary",
+      notebookBytes,
+      {
+        "X-Runtime-Heads-Hash": "runtime-summary",
+        "X-Runtime-State-Doc-Id": "runtime:summary-demo",
+      },
+    );
+    assert.equal(notebookPut.status, 201);
+
+    const notebook = env.DB.notebooks.get("summary-demo");
+    assert.equal(notebook?.cell_composition, JSON.stringify({ code: 1, markdown: 1, raw: 1 }));
+    assert.equal(notebook?.language, "python");
+
+    const listResponse = await worker.fetch(
+      new Request("http://localhost/api/n", {
+        headers: {
+          "X-User": "alice",
+          "X-Operator": "desktop:test",
+          "X-Scope": "viewer",
+        },
+      }),
+      env,
+      fakeContext(),
+    );
+    assert.equal(listResponse.status, 200);
+    const listBody = (await listResponse.json()) as {
+      notebooks: Array<{
+        composition?: { code: number; markdown: number; raw: number };
+        language?: string;
+        notebook_id: string;
+      }>;
+    };
+    const row = listBody.notebooks.find((candidate) => candidate.notebook_id === "summary-demo");
+    assert.deepEqual(row?.composition, { code: 1, markdown: 1, raw: 1 });
+    assert.equal(row?.language, "python");
+  });
+
+  it("does not fail snapshot publish when derived summary persistence fails", async () => {
+    const env = fakeEnv();
+    env.DB.failNotebookSummaryUpdate = true;
+    const [notebookBytes, runtimeStateBytes] = await Promise.all([
+      readFile(
+        new URL(
+          "../../../packages/runtimed/tests/fixtures/output_streaming/doc.bin",
+          import.meta.url,
+        ),
+      ),
+      readFile(
+        new URL(
+          "../../../packages/runtimed/tests/fixtures/output_streaming/state_doc.bin",
+          import.meta.url,
+        ),
+      ),
+    ]);
+
+    const runtimePut = await ownerPut(
+      env,
+      "/api/n/summary-fail-open/runtime-snapshots/runtime-fixture",
+      runtimeStateBytes,
+      {
+        "X-Runtime-State-Doc-Id": "runtime:output-streaming",
+      },
+    );
+    assert.equal(runtimePut.status, 201);
+
+    const originalWarn = console.warn;
+    const warnings: unknown[][] = [];
+    console.warn = (...args: unknown[]) => {
+      warnings.push(args);
+    };
+    let response: Response;
+    try {
+      response = await ownerPut(
+        env,
+        "/api/n/summary-fail-open/snapshots/heads-fixture",
+        notebookBytes,
+        {
+          "X-Runtime-Heads-Hash": "runtime-fixture",
+          "X-Runtime-State-Doc-Id": "runtime:output-streaming",
+        },
+      );
+    } finally {
+      console.warn = originalWarn;
+    }
+
+    assert.equal(response.status, 201);
+    assert.equal(env.DB.revisions.length, 1);
+    assert.equal(
+      env.DB.notebooks.get("summary-fail-open")?.latest_revision_id,
+      env.DB.revisions[0]?.id,
+    );
+    assert.equal(env.DB.notebooks.get("summary-fail-open")?.cell_composition, null);
+    assert.ok(
+      warnings.some(
+        (entry) =>
+          entry[0] === "[notebook-cloud]" &&
+          (entry[1] as { event?: string }).event === "snapshot.summary.update_failed",
+      ),
+    );
   });
 
   it("rejects snapshot publish when the header runtime id disagrees with the NotebookDoc pointer", async () => {
@@ -6257,6 +6438,8 @@ function seedNotebook(env: FakeEnv, notebookId: string): void {
     created_at: "2026-05-22T00:00:00.000Z",
     updated_at: "2026-05-22T00:00:00.000Z",
     latest_revision_id: null,
+    cell_composition: null,
+    language: null,
   });
 }
 
@@ -6398,6 +6581,40 @@ function seedAccessRequest(
 async function sha256Hex(body: Uint8Array): Promise<string> {
   const digest = await crypto.subtle.digest("SHA-256", body);
   return Array.from(new Uint8Array(digest), (byte) => byte.toString(16).padStart(2, "0")).join("");
+}
+
+function pythonSummarySnapshotPair(
+  notebookId: string,
+  runtimeStateDocId: string,
+): { notebookBytes: Uint8Array; runtimeStateBytes: Uint8Array } {
+  const notebook = new NotebookHandle(notebookId);
+  const runtime = new RuntimeStatePeerHandle("runtime");
+  try {
+    notebook.set_runtime_state_doc_id(runtimeStateDocId);
+    notebook.set_metadata_snapshot_value({
+      kernelspec: {
+        display_name: "Python 3",
+        language: "python",
+        name: "python3",
+      },
+      language_info: {
+        name: "python",
+      },
+      runt: {
+        schema_version: "1",
+      },
+    });
+    notebook.add_cell_after("cell-code", "code", null);
+    notebook.add_cell_after("cell-markdown", "markdown", "cell-code");
+    notebook.add_cell_after("cell-raw", "raw", "cell-markdown");
+    return {
+      notebookBytes: notebook.save(),
+      runtimeStateBytes: runtime.save(),
+    };
+  } finally {
+    notebook.free();
+    runtime.free();
+  }
 }
 
 interface FakeEnv extends Env {
@@ -6626,6 +6843,8 @@ interface NotebookRow {
   created_at: string;
   updated_at: string;
   latest_revision_id: string | null;
+  cell_composition: string | null;
+  language: string | null;
 }
 
 interface NotebookAclRow {
@@ -6715,7 +6934,41 @@ class FakeD1 implements D1Database {
   readonly workstationPairingCodes = new Map<string, WorkstationPairingCodeRow>();
   readonly workstationCredentials = new Map<string, WorkstationCredentialRow>();
   readonly batchSizes: number[] = [];
+  readonly tableColumns = new Map<string, Set<string>>([
+    [
+      "notebooks",
+      new Set([
+        "id",
+        "owner_principal",
+        "title",
+        "created_at",
+        "updated_at",
+        "latest_revision_id",
+        "cell_composition",
+        "language",
+      ]),
+    ],
+    [
+      "notebook_revisions",
+      new Set([
+        "id",
+        "notebook_id",
+        "runtime_state_doc_id",
+        "notebook_heads_hash",
+        "runtime_heads_hash",
+        "comms_heads_hash",
+        "comments_heads_hash",
+        "snapshot_key",
+        "runtime_snapshot_key",
+        "comms_snapshot_key",
+        "comments_snapshot_key",
+        "actor_label",
+        "created_at",
+      ]),
+    ],
+  ]);
   afterBlockedOwnerDelete?: () => void;
+  failNotebookSummaryUpdate = false;
 
   prepare(query: string): D1PreparedStatement {
     return new FakeD1Statement(this, query);
@@ -6849,7 +7102,15 @@ class FakeD1Statement implements D1PreparedStatement {
   }
 
   async run<T = unknown>(): Promise<D1Result<T>> {
-    if (this.query.includes("INSERT OR IGNORE INTO notebook_acl")) {
+    const alterMatch = this.query.match(/ALTER TABLE\s+(\w+)\s+ADD COLUMN\s+(\w+)/i);
+    if (alterMatch) {
+      const [, table, column] = alterMatch;
+      if (table && column) {
+        const columns = this.db.tableColumns.get(table) ?? new Set<string>();
+        columns.add(column);
+        this.db.tableColumns.set(table, columns);
+      }
+    } else if (this.query.includes("INSERT OR IGNORE INTO notebook_acl")) {
       if (this.query.includes("'principal'") && this.query.includes("owner_principal")) {
         for (const notebook of this.db.notebooks.values()) {
           this.insertAclIfMissing({
@@ -7494,8 +7755,26 @@ class FakeD1Statement implements D1PreparedStatement {
         created_at: existing?.created_at ?? createdAt ?? updatedAt,
         updated_at: updatedAt,
         latest_revision_id: existing?.latest_revision_id ?? null,
+        cell_composition: existing?.cell_composition ?? null,
+        language: existing?.language ?? null,
       });
       return okResult(undefined, { changes: 1 });
+    } else if (this.query.includes("UPDATE notebooks") && this.query.includes("cell_composition")) {
+      if (this.db.failNotebookSummaryUpdate) {
+        throw new Error("fake summary update failure");
+      }
+      const [cellComposition, language, notebookId] = this.values as [
+        string | null,
+        string | null,
+        string,
+      ];
+      const existing = this.db.notebooks.get(notebookId);
+      if (existing) {
+        existing.cell_composition = cellComposition;
+        existing.language = language;
+        return okResult(undefined, { changes: 1 });
+      }
+      return okResult(undefined, { changes: 0 });
     } else if (this.query.includes("INSERT INTO notebook_revisions")) {
       const [
         id,
@@ -7833,6 +8112,11 @@ class FakeD1Statement implements D1PreparedStatement {
   }
 
   async all<T = unknown>(): Promise<D1Result<T>> {
+    const pragmaMatch = this.query.match(/PRAGMA table_info\((\w+)\)/i);
+    if (pragmaMatch) {
+      const columns = this.db.tableColumns.get(pragmaMatch[1] ?? "") ?? new Set<string>();
+      return okResult([...columns].map((name) => ({ name })) as T[]);
+    }
     if (
       this.query.includes("FROM workstation_credentials") &&
       this.query.includes("WHERE owner_principal")

--- a/apps/notebook-cloud/viewer/cloud-notebook-dashboard-view.tsx
+++ b/apps/notebook-cloud/viewer/cloud-notebook-dashboard-view.tsx
@@ -20,6 +20,7 @@ import { RuntimeStatusDot } from "@/components/runtime/RuntimeStatusDot";
 import {
   cloudNotebookDashboardOpenUrl,
   cloudNotebookDisplayTitle,
+  cloudNotebookLanguageDisplayLabel,
   cloudNotebookShortId,
   projectCloudNotebookDashboardView,
   type CloudNotebookDashboardFilterId,
@@ -194,11 +195,13 @@ function CloudNotebookDashboardHero({
   const notebook = row.notebook;
   const openUrl = cloudNotebookDashboardOpenUrl(notebook);
   const runtimeActive = cloudNotebookRuntimeIsActive(row);
-  const environmentLanguage = row.environmentLabel
-    ? /python/iu.test(row.environmentLabel)
-      ? "Python"
-      : row.environmentLabel
-    : null;
+  const runtimeLanguage =
+    cloudNotebookLanguageDisplayLabel(notebook.language) ??
+    (row.environmentLabel
+      ? /python/iu.test(row.environmentLabel)
+        ? "Python"
+        : row.environmentLabel
+      : null);
   const cellCount = row.composition ? notebookCompositionTotal(row.composition) : null;
   const heroComputeFact = row.facts.find((fact) => fact.kind === "compute") ?? null;
 
@@ -207,9 +210,9 @@ function CloudNotebookDashboardHero({
       className={`nb-hero${runtimeActive ? " is-live" : ""}`}
       aria-label="Pick up where you left off"
     >
-      {row.environmentLabel && environmentLanguage ? (
+      {row.environmentLabel && runtimeLanguage ? (
         <span className="nb-hero-runtime">
-          <LanguageMark language={environmentLanguage} size={16} />
+          <LanguageMark language={runtimeLanguage} size={16} />
           {row.environmentLabel}
         </span>
       ) : null}
@@ -424,6 +427,7 @@ function CloudNotebookDashboardRowView({
   // The compute fact carries the rich label ("lab2 workstation running, 1 queued");
   // the column shows the calm dot + terse status, the full label rides title/aria.
   const computeFact = row.facts.find((fact) => fact.kind === "compute") ?? null;
+  const languageLabel = cloudNotebookLanguageDisplayLabel(notebook.language);
 
   return (
     <div className={`nb-row${runtimeActive ? " is-live" : ""}`} data-scope={notebook.scope}>
@@ -450,6 +454,14 @@ function CloudNotebookDashboardRowView({
       <span className="nb-col nb-col-owner">
         <span className="nb-avatar nb-avatar-sm">{row.ownerInitials}</span>
         <span className="nb-col-owner-name">{row.ownerLabel}</span>
+      </span>
+      <span className="nb-col nb-col-lang">
+        {languageLabel ? (
+          <>
+            <LanguageMark language={languageLabel} size={12} />
+            {languageLabel}
+          </>
+        ) : null}
       </span>
       <span className="nb-col nb-col-status" title={computeFact?.label ?? undefined}>
         {row.runtimeStatus !== "none" ? (

--- a/apps/notebook-cloud/viewer/index.css
+++ b/apps/notebook-cloud/viewer/index.css
@@ -1296,6 +1296,10 @@ body {
   background: #3178c6;
 }
 
+.nb-lang-dot[data-lang="Deno"] {
+  background: #3178c6;
+}
+
 .nb-lang-dot[data-lang="R"] {
   background: #2563eb;
 }
@@ -1330,7 +1334,7 @@ body {
 .nb-row {
   position: relative;
   display: grid;
-  grid-template-columns: minmax(180px, 1fr) 124px 128px 150px minmax(118px, auto) 72px;
+  grid-template-columns: minmax(180px, 1fr) 124px 96px 128px 150px minmax(118px, auto) 72px;
   align-items: center;
   min-height: 68px;
   column-gap: 14px;
@@ -1462,6 +1466,10 @@ body {
   min-width: 0;
   overflow: hidden;
   text-overflow: ellipsis;
+}
+
+.nb-col-lang {
+  justify-self: start;
 }
 
 .nb-col-badges {
@@ -1754,6 +1762,7 @@ body {
   }
 
   .nb-col-owner,
+  .nb-col-lang,
   .nb-col-status,
   .nb-col-badges {
     display: none;

--- a/apps/notebook-cloud/viewer/notebook-dashboard.ts
+++ b/apps/notebook-cloud/viewer/notebook-dashboard.ts
@@ -15,6 +15,7 @@ export interface CloudNotebookListItem {
   latest_revision_id: string | null;
   compute_session?: NotebookComputeSessionSummary | null;
   composition?: CloudNotebookComposition;
+  language?: string;
   viewer_url: string;
   endpoints: {
     catalog: string;
@@ -242,6 +243,19 @@ export function cloudNotebookShortId(notebookId: string): string {
   return `${trimmed.slice(0, 8)}...${trimmed.slice(-4)}`;
 }
 
+export function cloudNotebookLanguageDisplayLabel(
+  language: string | null | undefined,
+): string | null {
+  switch (language) {
+    case "python":
+      return "Python";
+    case "deno":
+      return "Deno";
+    default:
+      return null;
+  }
+}
+
 function cloudNotebookDefaultOpenMode(notebook: CloudNotebookListItem): CloudNotebookUrlMode {
   return notebook.scope === "owner" || notebook.scope === "editor" ? "edit" : "view";
 }
@@ -267,6 +281,7 @@ export function isCloudNotebookListItem(value: unknown): value is CloudNotebookL
       candidate.compute_session === null ||
       isNotebookComputeSessionSummary(candidate.compute_session)) &&
     (candidate.composition === undefined || isCloudNotebookComposition(candidate.composition)) &&
+    (candidate.language === undefined || typeof candidate.language === "string") &&
     typeof candidate.viewer_url === "string" &&
     Boolean(candidate.endpoints) &&
     typeof candidate.endpoints?.catalog === "string" &&


### PR DESCRIPTION
Implements dashboard API issues #3879 (cell composition) and #3882 (notebook language) end-to-end. **Stacked on #3885** - review that first; this retargets to main automatically when it merges.

## The mechanism

The notebook snapshot PUT (`routeSnapshot`) already materializes a decoded `NotebookHandle` to validate the snapshot pair. Derivation happens right there, at zero additional decode cost:

- **composition** = code/markdown/raw counts from `get_cells_json()` (unknown cell types ignored - the design's cell-kind vocabulary is exactly these three)
- **language** = `detect_runtime()` (python/deno) with a metadata fallback chain (kernelspec name -> kernelspec language -> language_info -> `runt.deno`/`uv`/`conda`)

Stored as two nullable D1 columns on `notebooks` via the idempotent `SCHEMA_MIGRATIONS` ALTER-TABLE pattern; returned from `GET /api/n` on the existing SELECT (zero added round trips or fan-out); rows without data render exactly as before.

**Fail-open by contract**: derivation or summary-write failure logs and never fails the snapshot PUT. Accepted consequence (tested): the summary can lag `latest_revision_id` until the next successful publish - the snapshot is the durable artifact, this is a derived cache.

**Backfill is lazy**: rows populate on their next snapshot publish. No migration walk needed; the UI is absent-safe until then.

## Client

- Composition ticks + cell count light up (the redesign already threaded `composition?` absent-safe)
- Rows gain the language column: Python logo for python, Deno with the TS-blue dot for deno
- Hero prefers the static language for the mark; `environment_label` stays as the runtime text
- Row grid reconciled with #3885's status column to seven tracks (lead, owner, lang, status, updated, badges, actions) - the two branches had silently-colliding identical grid lines, caught by the adversarial review pass

## Test coverage called out

The review pass caught that FakeD1 pre-seeded the new columns, so the actual ALTER TABLE statements were never executed by any test. `runCatalogMigrations` is now exported and tested against a fake starting without the columns, and the pure derivation helpers have direct unit coverage (unknown cell types, non-array payloads, the full metadata fallback chain).

## Verification

- [x] Cloud tests 1175/1175 (5 new), cloud build, desktop build, `vp check` clean
- [x] Adversarial data-correctness review: derivation only on the notebook snapshot route, every failure path walked fail-open, parameterized statements, malformed D1 JSON yields undefined composition (not a throw), no new decode on the PUT path, no new round trips on the list path

Closes #3879. Closes #3882.
