### PR TITLE
feat(notebook-cloud): notebook covers from output embeds + public OG image route

### DIFF
--- a/apps/notebook-cloud/src/index.ts
+++ b/apps/notebook-cloud/src/index.ts
@@ -42,6 +42,7 @@ import {
   getNotebookAclRows,
   getNotebookRow,
   getNotebookCatalog,
+  getNotebookRevisionRow,
   getPublicPublishedNotebookRow,
   getWorkstationRow,
   grantNotebookAclRow,
@@ -55,6 +56,7 @@ import {
   runtimeStateSnapshotKey,
   snapshotKey,
   setDefaultWorkstation,
+  updateNotebookRevisionCover,
   updateNotebookSnapshotSummary,
   updateNotebookTitle,
   updateWorkstationAttachJobStatus,
@@ -274,6 +276,12 @@ const NOTEBOOK_CLOUD_ROUTES: readonly WorkerRoute[] = [
     match: routePath("/n/:notebookId/debug", { trailingSlash: "optional" }),
     methods: ["GET", "HEAD"],
     handler: ({ params }, request) => debugViewer(params.notebookId, request),
+  },
+  {
+    match: routePath("/n/:notebookId/r/latest/ogImage.png"),
+    methods: ["GET", "HEAD"],
+    handler: ({ params }, request, env) =>
+      routeLatestNotebookOgImage(request, env, params.notebookId),
   },
   {
     match: routePath("/n/:notebookId/r/:revision", { trailingSlash: "optional" }),
@@ -1229,6 +1237,7 @@ function notebookListResponseRows(
       notebook.owner_principal === computeSessions.get(notebook.id)?.owner_principal
         ? computeSessions.get(notebook.id)
         : null;
+    const cover = notebookCoverResponse(notebook);
     return {
       notebook_id: notebook.id,
       title: notebook.title,
@@ -1238,6 +1247,7 @@ function notebookListResponseRows(
       updated_at: notebook.updated_at,
       latest_revision_id: notebook.latest_revision_id,
       ...(composition ? { composition } : {}),
+      ...(cover ? { cover } : {}),
       ...(typeof notebook.language === "string" ? { language: notebook.language } : {}),
       compute_session: computeSession,
       viewer_url: viewerUrlForRequest(request, notebook.id, notebook.title, env),
@@ -1248,6 +1258,26 @@ function notebookListResponseRows(
       },
     };
   });
+}
+
+function notebookCoverResponse(notebook: {
+  cover_blob_hash?: string | null;
+  cover_mime?: string | null;
+}): { blob_hash: string; mime: "image/png" | "image/jpeg" | "image/svg+xml" } | undefined {
+  if (typeof notebook.cover_blob_hash !== "string" || !isNotebookCoverMime(notebook.cover_mime)) {
+    return undefined;
+  }
+  return { blob_hash: notebook.cover_blob_hash, mime: notebook.cover_mime };
+}
+
+function isNotebookCoverMime(
+  value: unknown,
+): value is "image/png" | "image/jpeg" | "image/svg+xml" {
+  return value === "image/png" || value === "image/jpeg" || value === "image/svg+xml";
+}
+
+function isRasterCoverMime(value: unknown): value is "image/png" | "image/jpeg" {
+  return value === "image/png" || value === "image/jpeg";
 }
 
 function parseNotebookCellComposition(
@@ -2654,6 +2684,18 @@ function viewerUrlForRequest(
   return url.href;
 }
 
+function latestNotebookOgImageUrlForRequest(
+  request: Request,
+  env: Env,
+  notebookId: string,
+): string {
+  const url = new URL(trustedLoopbackBrowserOrigin(request, env) ?? request.url);
+  url.pathname = `/n/${encodeURIComponent(notebookId)}/r/latest/ogImage.png`;
+  url.search = "";
+  url.hash = "";
+  return url.href;
+}
+
 function oidcHealth(env: Env): {
   status: "configured" | "partial" | "disabled";
   jwks: "remote" | "pinned" | "none";
@@ -2819,6 +2861,22 @@ async function routeSnapshot(
       counter: "snapshot_summary_update_failures",
       counter_delta: 1,
     });
+  }
+
+  if (validated.summary.cover) {
+    try {
+      await updateNotebookRevisionCover(env, revisionId, validated.summary.cover);
+    } catch (error) {
+      cloudLog("warn", "snapshot.cover.update_failed", {
+        notebook_id: notebookId,
+        notebook_heads_hash: headsHash,
+        revision_id: revisionId,
+        cover_mime: validated.summary.cover.mime,
+        error: errorMessage(error),
+        counter: "snapshot_cover_update_failures",
+        counter_delta: 1,
+      });
+    }
   }
 
   return json(
@@ -4168,6 +4226,89 @@ function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === "object" && value !== null && !Array.isArray(value);
 }
 
+async function routeLatestNotebookOgImage(
+  request: Request,
+  env: Env,
+  notebookId: string,
+): Promise<Response> {
+  const cover = await publicLatestRasterCover(env, notebookId);
+  if (!cover) {
+    return notebookOgImageNotFound(request);
+  }
+
+  const key = blobKey(notebookId, cover.blobHash);
+  if (request.method === "HEAD") {
+    const object = await env.NOTEBOOK_SNAPSHOTS?.head(key);
+    if (!object) {
+      return notebookOgImageNotFound(request);
+    }
+    return withCors(new Response(null, { headers: notebookOgImageHeaders(object, cover.mime) }));
+  }
+
+  const object = await env.NOTEBOOK_SNAPSHOTS?.get(key);
+  if (!object) {
+    return notebookOgImageNotFound(request);
+  }
+  return withCors(
+    new Response(object.body, { headers: notebookOgImageHeaders(object, cover.mime) }),
+  );
+}
+
+function notebookOgImageNotFound(request: Request): Response {
+  if (request.method === "HEAD") {
+    return withCors(new Response(null, { status: 404 }));
+  }
+  return json({ error: "notebook image not found" }, 404);
+}
+
+function notebookOgImageHeaders(
+  object: { httpEtag: string; size: number },
+  contentType: "image/png" | "image/jpeg",
+): Headers {
+  return new Headers({
+    "Cache-Control": "public, max-age=300",
+    "Content-Length": object.size.toString(),
+    "Content-Type": contentType,
+    ETag: object.httpEtag,
+    "X-Content-Type-Options": "nosniff",
+  });
+}
+
+async function publicLatestRasterCover(
+  env: Env,
+  notebookId: string,
+  options: { verifyBlob?: boolean } = {},
+): Promise<{ blobHash: string; mime: "image/png" | "image/jpeg" } | null> {
+  // Fail-open: the cover is derived convenience for shell metadata and the OG
+  // route. A transient D1/R2 error yields "no cover", never a 500 on the
+  // public viewer page.
+  try {
+    const row = await getPublicPublishedNotebookRow(env, notebookId);
+    if (!row?.latest_revision_id) {
+      return null;
+    }
+    const revision = await getNotebookRevisionRow(env, notebookId, row.latest_revision_id);
+    if (typeof revision?.cover_blob_hash !== "string" || !isRasterCoverMime(revision.cover_mime)) {
+      return null;
+    }
+    if (options.verifyBlob) {
+      const object = await env.NOTEBOOK_SNAPSHOTS?.head(
+        blobKey(notebookId, revision.cover_blob_hash),
+      );
+      if (!object) {
+        return null;
+      }
+    }
+    return { blobHash: revision.cover_blob_hash, mime: revision.cover_mime };
+  } catch (error) {
+    console.warn("[notebook-cloud] latest raster cover lookup failed", {
+      notebook_id: notebookId,
+      error: error instanceof Error ? error.message : String(error),
+    });
+    return null;
+  }
+}
+
 async function routeBlob(
   request: Request,
   env: Env,
@@ -4901,6 +5042,7 @@ async function viewer(
   }
 
   const shellMetadata = await publicViewerShellMetadata(
+    request,
     env,
     notebookId,
     headsHash,
@@ -5039,9 +5181,14 @@ function viewerShellHead(env: Env): Response {
 interface ViewerShellMetadata {
   title: string;
   description: string;
+  ogImage?: {
+    type: "image/png" | "image/jpeg";
+    url: string;
+  };
 }
 
 async function publicViewerShellMetadata(
+  request: Request,
   env: Env,
   notebookId: string,
   headsHash?: string,
@@ -5061,9 +5208,18 @@ async function publicViewerShellMetadata(
   const revisionPart = headsHash
     ? `revision ${shortNotebookId(headsHash)}`
     : `published revision ${shortNotebookId(row.latest_revision_id)}`;
+  const cover = await publicLatestRasterCover(env, notebookId, { verifyBlob: true });
   return {
     title: `nteract notebook: ${displayTitle}`,
     description: `${displayTitle} is a public nteract notebook at ${revisionPart}.`,
+    ...(cover
+      ? {
+          ogImage: {
+            type: cover.mime,
+            url: latestNotebookOgImageUrlForRequest(request, env, notebookId),
+          },
+        }
+      : {}),
   };
 }
 
@@ -5102,6 +5258,8 @@ function viewerShell(
 ): Response {
   const title = escapeHtml(metadata.title);
   const description = escapeHtml(metadata.description);
+  const ogImage = metadata.ogImage;
+  const twitterCard = ogImage ? "summary_large_image" : "summary";
   const html = `<!doctype html>
 <html lang="en">
 <head>
@@ -5112,7 +5270,13 @@ function viewerShell(
   <meta property="og:title" content="${title}" />
   <meta property="og:description" content="${description}" />
   <meta property="og:type" content="article" />
-  <meta name="twitter:card" content="summary" />
+  ${
+    ogImage
+      ? `<meta property="og:image" content="${escapeHtml(ogImage.url)}" />
+  <meta property="og:image:type" content="${escapeHtml(ogImage.type)}" />`
+      : ""
+  }
+  <meta name="twitter:card" content="${twitterCard}" />
   <link rel="icon" href="/favicon.svg" type="image/svg+xml" />
   <style id="nteract-cloud-viewer-theme-surface">${viewerThemeFirstPaintStyle()}</style>
   <script>${viewerThemeBootstrapScript()}</script>

--- a/apps/notebook-cloud/src/snapshot-render.ts
+++ b/apps/notebook-cloud/src/snapshot-render.ts
@@ -31,7 +31,13 @@ export interface SnapshotCellComposition {
 
 export interface SnapshotNotebookSummary {
   cellComposition: SnapshotCellComposition;
+  cover: SnapshotNotebookCover | null;
   language: string | null;
+}
+
+export interface SnapshotNotebookCover {
+  blobHash: string;
+  mime: "image/png" | "image/jpeg" | "image/svg+xml";
 }
 
 export interface MaterializedSnapshotPairRender {
@@ -71,6 +77,7 @@ export async function materializeSnapshotPairRenderWithSummary(
     const metadata = parseJsonOrNull(handle.get_metadata_snapshot_json());
     const summary = {
       cellComposition: countCellComposition(cells),
+      cover: selectNotebookCoverFromCells(cells),
       language: readDetectedRuntime(handle, metadata),
     };
     const commsDocId = readOptionalCommsDocId(handle);
@@ -164,11 +171,62 @@ export function detectRuntimeFromMetadata(metadata: unknown): string | null {
 }
 
 function objectRecord(value: unknown): Record<string, unknown> | null {
-  return value && typeof value === "object" ? (value as Record<string, unknown>) : null;
+  return value && typeof value === "object" && !Array.isArray(value)
+    ? (value as Record<string, unknown>)
+    : null;
 }
 
 function stringLower(value: unknown): string | null {
   return typeof value === "string" ? value.toLowerCase() : null;
+}
+
+const COVER_MIME_PRIORITY = ["image/png", "image/jpeg", "image/svg+xml"] as const;
+
+export function selectNotebookCoverFromCells(cells: unknown): SnapshotNotebookCover | null {
+  try {
+    if (!Array.isArray(cells)) {
+      return null;
+    }
+    let selected: SnapshotNotebookCover | null = null;
+    for (const cell of cells) {
+      const cellRecord = objectRecord(cell);
+      const outputs = Array.isArray(cellRecord?.outputs) ? cellRecord.outputs : [];
+      for (const output of outputs) {
+        const cover = selectOutputCover(output);
+        if (cover) {
+          selected = cover;
+        }
+      }
+    }
+    return selected;
+  } catch {
+    return null;
+  }
+}
+
+function selectOutputCover(output: unknown): SnapshotNotebookCover | null {
+  const outputRecord = objectRecord(output);
+  const data = objectRecord(outputRecord?.data);
+  if (!data) {
+    return null;
+  }
+
+  for (const mime of COVER_MIME_PRIORITY) {
+    const ref = objectRecord(data[mime]);
+    const blobHash = readBlobHash(ref);
+    if (blobHash) {
+      return { blobHash, mime };
+    }
+  }
+  return null;
+}
+
+function readBlobHash(value: Record<string, unknown> | null): string | null {
+  if (!value) {
+    return null;
+  }
+  const blob = value.blob ?? value.hash;
+  return typeof blob === "string" && blob.trim() ? blob : null;
 }
 
 export function countCellComposition(cells: unknown): SnapshotCellComposition {

--- a/apps/notebook-cloud/src/storage.ts
+++ b/apps/notebook-cloud/src/storage.ts
@@ -15,6 +15,8 @@ export interface NotebookRow {
   updated_at: string;
   latest_revision_id: string | null;
   cell_composition: string | null;
+  cover_blob_hash?: string | null;
+  cover_mime?: string | null;
   language: string | null;
 }
 
@@ -30,6 +32,8 @@ export interface RevisionRow {
   runtime_snapshot_key: string | null;
   comms_snapshot_key: string | null;
   comments_snapshot_key: string | null;
+  cover_blob_hash: string | null;
+  cover_mime: string | null;
   actor_label: string;
   created_at: string;
 }
@@ -171,6 +175,8 @@ const SCHEMA_STATEMENTS = [
     runtime_snapshot_key TEXT,
     comms_snapshot_key TEXT,
     comments_snapshot_key TEXT,
+    cover_blob_hash TEXT,
+    cover_mime TEXT,
     actor_label TEXT NOT NULL,
     created_at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ', 'now')),
     FOREIGN KEY (notebook_id) REFERENCES notebooks(id)
@@ -374,6 +380,16 @@ const SCHEMA_MIGRATIONS = [
     table: "notebook_revisions",
     column: "comments_snapshot_key",
     statement: `ALTER TABLE notebook_revisions ADD COLUMN comments_snapshot_key TEXT`,
+  },
+  {
+    table: "notebook_revisions",
+    column: "cover_blob_hash",
+    statement: `ALTER TABLE notebook_revisions ADD COLUMN cover_blob_hash TEXT`,
+  },
+  {
+    table: "notebook_revisions",
+    column: "cover_mime",
+    statement: `ALTER TABLE notebook_revisions ADD COLUMN cover_mime TEXT`,
   },
   {
     table: "notebooks",
@@ -599,6 +615,61 @@ export async function updateNotebookSnapshotSummary(
     .run();
 }
 
+export async function updateNotebookRevisionCover(
+  env: Env,
+  revisionId: string,
+  cover: { blobHash: string; mime: string },
+): Promise<void> {
+  if (!env.DB) {
+    return;
+  }
+
+  await ensureCatalogSchema(env);
+  await env.DB.prepare(
+    `UPDATE notebook_revisions
+        SET cover_blob_hash = ?,
+            cover_mime = ?
+      WHERE id = ?`,
+  )
+    .bind(cover.blobHash, cover.mime, revisionId)
+    .run();
+}
+
+export async function getNotebookRevisionRow(
+  env: Env,
+  notebookId: string,
+  revisionId: string,
+): Promise<RevisionRow | null> {
+  if (!env.DB) {
+    return null;
+  }
+
+  await ensureCatalogSchema(env);
+  return await env.DB.prepare(
+    `SELECT id,
+            notebook_id,
+            runtime_state_doc_id,
+            notebook_heads_hash,
+            runtime_heads_hash,
+            comms_heads_hash,
+            comments_heads_hash,
+            snapshot_key,
+            runtime_snapshot_key,
+            comms_snapshot_key,
+            comments_snapshot_key,
+            cover_blob_hash,
+            cover_mime,
+            actor_label,
+            created_at
+       FROM notebook_revisions
+       WHERE notebook_id = ?
+         AND id = ?
+       LIMIT 1`,
+  )
+    .bind(notebookId, revisionId)
+    .first<RevisionRow>();
+}
+
 export async function getNotebookAclRowsForPrincipal(
   env: Env,
   notebookId: string,
@@ -653,6 +724,8 @@ export async function listNotebooksForPrincipal(
             n.updated_at,
             n.latest_revision_id,
             n.cell_composition,
+            r.cover_blob_hash,
+            r.cover_mime,
             n.language,
             CASE MAX(
               CASE a.scope
@@ -671,6 +744,8 @@ export async function listNotebooksForPrincipal(
        FROM notebooks n
        JOIN notebook_acl a
          ON a.notebook_id = n.id
+       LEFT JOIN notebook_revisions r
+         ON r.id = n.latest_revision_id
       WHERE a.subject_kind = 'principal'
         AND (
           a.subject = ?
@@ -687,6 +762,8 @@ export async function listNotebooksForPrincipal(
                n.updated_at,
                n.latest_revision_id,
                n.cell_composition,
+               r.cover_blob_hash,
+               r.cover_mime,
                n.language
       ORDER BY n.updated_at DESC, n.created_at DESC, n.id DESC
       LIMIT ?`,
@@ -1659,6 +1736,8 @@ export async function getNotebookCatalog(
             runtime_snapshot_key,
             comms_snapshot_key,
             comments_snapshot_key,
+            cover_blob_hash,
+            cover_mime,
             actor_label,
             created_at
        FROM notebook_revisions

--- a/apps/notebook-cloud/test/notebook-dashboard.test.ts
+++ b/apps/notebook-cloud/test/notebook-dashboard.test.ts
@@ -1,6 +1,7 @@
 import assert from "node:assert/strict";
 import { describe, it } from "node:test";
 import {
+  cloudNotebookCoverUrl,
   cloudNotebookDashboardRuntimeStatus,
   cloudNotebookDashboardOpenUrl,
   cloudNotebookDisplayTitle,
@@ -714,6 +715,38 @@ describe("cloud notebook dashboard projection", () => {
     assert.deepEqual(model.continueRow?.composition, { code: 2, markdown: 1, raw: 0 });
   });
 
+  it("threads notebook cover through list-item validation and dashboard rows", () => {
+    const covered = notebook({
+      id: "covered-notebook",
+      title: "Covered Notebook",
+      scope: "owner",
+      updatedAt: "2026-06-24T00:00:00.000Z",
+      latestRevisionId: "published-covered",
+      cover: { blob_hash: "cover-hash", mime: "image/svg+xml" },
+    });
+
+    assert.equal(isCloudNotebookListItem(covered), true);
+    assert.equal(
+      isCloudNotebookListItem({
+        ...covered,
+        cover: { blob_hash: "cover-hash", mime: "text/html" },
+      }),
+      false,
+    );
+    assert.equal(
+      isCloudNotebookListItem({ ...covered, cover: { blob_hash: 42, mime: "image/png" } }),
+      false,
+    );
+
+    const model = projectCloudNotebookDashboard([covered]);
+
+    assert.deepEqual(model.continueRow?.notebook.cover, {
+      blob_hash: "cover-hash",
+      mime: "image/svg+xml",
+    });
+    assert.equal(cloudNotebookCoverUrl(covered), "/api/n/covered-notebook/blobs/cover-hash");
+  });
+
   it("maps compute session status to dashboard runtime status", () => {
     const base = {
       id: "runtime-status",
@@ -780,6 +813,7 @@ function notebook(input: {
   latestRevisionId: string | null;
   computeSession?: CloudNotebookListItem["compute_session"];
   composition?: CloudNotebookListItem["composition"];
+  cover?: CloudNotebookListItem["cover"];
   language?: string;
 }): CloudNotebookListItem {
   return {
@@ -792,6 +826,7 @@ function notebook(input: {
     latest_revision_id: input.latestRevisionId,
     compute_session: input.computeSession ?? null,
     ...(input.composition ? { composition: input.composition } : {}),
+    ...(input.cover ? { cover: input.cover } : {}),
     ...(input.language ? { language: input.language } : {}),
     viewer_url: `/n/${input.id}/notebook`,
     endpoints: {

--- a/apps/notebook-cloud/test/snapshot-render.test.ts
+++ b/apps/notebook-cloud/test/snapshot-render.test.ts
@@ -6,6 +6,7 @@ import {
   countCellComposition,
   detectRuntimeFromMetadata,
   materializeSnapshotPairRender,
+  selectNotebookCoverFromCells,
 } from "../src/snapshot-render.ts";
 import {
   createNotebookCloudBlobResolver,
@@ -305,6 +306,92 @@ async function readJson(url: URL): Promise<Record<string, unknown>> {
 }
 
 describe("snapshot summary derivation helpers", () => {
+  it("selects the last image output across cells", () => {
+    assert.deepEqual(
+      selectNotebookCoverFromCells([
+        {
+          outputs: [
+            {
+              data: {
+                "image/png": { blob: "first-png" },
+              },
+            },
+          ],
+        },
+        {
+          outputs: [
+            {
+              data: {
+                "image/svg+xml": { blob: "last-svg" },
+              },
+            },
+          ],
+        },
+      ]),
+      { blobHash: "last-svg", mime: "image/svg+xml" },
+    );
+  });
+
+  it("uses raster MIME priority only within one output's alternates", () => {
+    assert.deepEqual(
+      selectNotebookCoverFromCells([
+        {
+          outputs: [
+            {
+              data: {
+                "image/jpeg": { blob: "plot-jpeg" },
+                "image/png": { blob: "plot-png" },
+                "image/svg+xml": { blob: "plot-svg" },
+              },
+            },
+          ],
+        },
+      ]),
+      { blobHash: "plot-png", mime: "image/png" },
+    );
+    assert.deepEqual(
+      selectNotebookCoverFromCells([
+        {
+          outputs: [
+            {
+              data: {
+                "image/png": { blob: "earlier-png" },
+              },
+            },
+            {
+              data: {
+                "image/jpeg": { blob: "later-jpeg" },
+              },
+            },
+          ],
+        },
+      ]),
+      { blobHash: "later-jpeg", mime: "image/jpeg" },
+    );
+  });
+
+  it("ignores non-image and malformed output manifests", () => {
+    assert.equal(
+      selectNotebookCoverFromCells([
+        { outputs: [{ data: { "text/html": { blob: "html-blob" } } }] },
+        { outputs: [{ data: { "image/png": { inline: "not-addressable" } } }] },
+        { outputs: [{ data: { "image/jpeg": "base64" } }] },
+        { outputs: [{ data: { "image/svg+xml": { hash: "" } } }] },
+        null,
+      ]),
+      null,
+    );
+  });
+
+  it("accepts hash-backed ContentRefs for image alternates", () => {
+    assert.deepEqual(
+      selectNotebookCoverFromCells([
+        { outputs: [{ data: { "image/jpeg": { hash: "jpeg-hash" } } }] },
+      ]),
+      { blobHash: "jpeg-hash", mime: "image/jpeg" },
+    );
+  });
+
   it("counts only code/markdown/raw cell types and ignores unknowns", () => {
     assert.deepEqual(
       countCellComposition([

--- a/apps/notebook-cloud/test/worker-routes.test.ts
+++ b/apps/notebook-cloud/test/worker-routes.test.ts
@@ -269,6 +269,45 @@ describe("Worker artifact routes", () => {
     assert.match(html, /published revision revision-pub/);
   });
 
+  it("emits public OG image metadata for raster revision covers", async () => {
+    const env = fakeEnv();
+    const coverHash = "public-meta-cover-hash";
+    seedNotebook(env, "public-meta-cover");
+    const notebook = env.DB.notebooks.get("public-meta-cover");
+    assert.ok(notebook);
+    notebook.title = "Public Cover";
+    seedRevision(env, {
+      id: "revision-public-cover",
+      notebookId: "public-meta-cover",
+      coverBlobHash: coverHash,
+      coverMime: "image/jpeg",
+    });
+    seedAcl(env, {
+      notebookId: "public-meta-cover",
+      subjectKind: "public",
+      subject: "anonymous",
+      scope: "viewer",
+    });
+    await env.NOTEBOOK_SNAPSHOTS.put(blobKey("public-meta-cover", coverHash), new Uint8Array([1]), {
+      httpMetadata: { contentType: "image/jpeg" },
+    });
+
+    const response = await worker.fetch(
+      new Request("http://localhost/n/public-meta-cover/public-cover"),
+      env,
+      fakeContext(),
+    );
+
+    assert.equal(response.status, 200);
+    const html = await response.text();
+    assert.match(
+      html,
+      /<meta property="og:image" content="http:\/\/localhost\/n\/public-meta-cover\/r\/latest\/ogImage\.png" \/>/,
+    );
+    assert.match(html, /<meta property="og:image:type" content="image\/jpeg" \/>/);
+    assert.match(html, /<meta name="twitter:card" content="summary_large_image" \/>/);
+  });
+
   it("keeps private notebook titles out of server-rendered viewer metadata", async () => {
     const env = fakeEnv();
     seedNotebook(env, "private-meta-demo");
@@ -3541,6 +3580,144 @@ describe("Worker artifact routes", () => {
     assert.equal(env.DB.blobs.get(`runtime-demo:${hash}`)?.content_type, "image/png");
   });
 
+  it("returns 404 for latest OG image when the notebook is not public", async () => {
+    const env = fakeEnv();
+    seedNotebook(env, "private-og-demo");
+    seedRevision(env, {
+      id: "revision-private-og",
+      notebookId: "private-og-demo",
+      coverBlobHash: "private-og-cover",
+      coverMime: "image/png",
+    });
+    await env.NOTEBOOK_SNAPSHOTS.put(
+      blobKey("private-og-demo", "private-og-cover"),
+      new Uint8Array([1]),
+      { httpMetadata: { contentType: "image/png" } },
+    );
+
+    const response = await worker.fetch(
+      new Request("http://localhost/n/private-og-demo/r/latest/ogImage.png"),
+      env,
+      fakeContext(),
+    );
+
+    assert.equal(response.status, 404);
+  });
+
+  it("returns 404 for latest OG image when the public revision has no cover", async () => {
+    const env = fakeEnv();
+    seedNotebook(env, "no-cover-og-demo");
+    seedRevision(env, { id: "revision-no-cover-og", notebookId: "no-cover-og-demo" });
+    seedAcl(env, {
+      notebookId: "no-cover-og-demo",
+      subjectKind: "public",
+      subject: "anonymous",
+      scope: "viewer",
+    });
+
+    const response = await worker.fetch(
+      new Request("http://localhost/n/no-cover-og-demo/r/latest/ogImage.png"),
+      env,
+      fakeContext(),
+    );
+
+    assert.equal(response.status, 404);
+  });
+
+  it("returns 404 for latest OG image when the public cover is SVG-only", async () => {
+    const env = fakeEnv();
+    seedNotebook(env, "svg-og-demo");
+    seedRevision(env, {
+      id: "revision-svg-og",
+      notebookId: "svg-og-demo",
+      coverBlobHash: "svg-cover",
+      coverMime: "image/svg+xml",
+    });
+    seedAcl(env, {
+      notebookId: "svg-og-demo",
+      subjectKind: "public",
+      subject: "anonymous",
+      scope: "viewer",
+    });
+    await env.NOTEBOOK_SNAPSHOTS.put(blobKey("svg-og-demo", "svg-cover"), "<svg></svg>", {
+      httpMetadata: { contentType: "image/svg+xml" },
+    });
+
+    const response = await worker.fetch(
+      new Request("http://localhost/n/svg-og-demo/r/latest/ogImage.png"),
+      env,
+      fakeContext(),
+    );
+
+    assert.equal(response.status, 404);
+  });
+
+  it("returns 404 for latest OG image when the cover blob is missing", async () => {
+    const env = fakeEnv();
+    seedNotebook(env, "missing-cover-og-demo");
+    seedRevision(env, {
+      id: "revision-missing-cover-og",
+      notebookId: "missing-cover-og-demo",
+      coverBlobHash: "missing-cover",
+      coverMime: "image/jpeg",
+    });
+    seedAcl(env, {
+      notebookId: "missing-cover-og-demo",
+      subjectKind: "public",
+      subject: "anonymous",
+      scope: "viewer",
+    });
+
+    const response = await worker.fetch(
+      new Request("http://localhost/n/missing-cover-og-demo/r/latest/ogImage.png"),
+      env,
+      fakeContext(),
+    );
+
+    assert.equal(response.status, 404);
+  });
+
+  it("serves the latest public raster cover as an OG image", async () => {
+    const env = fakeEnv();
+    const body = new Uint8Array([137, 80, 78, 71]);
+    const coverHash = "public-og-cover";
+    seedNotebook(env, "public-og-demo");
+    seedRevision(env, {
+      id: "revision-public-og",
+      notebookId: "public-og-demo",
+      coverBlobHash: coverHash,
+      coverMime: "image/png",
+    });
+    seedAcl(env, {
+      notebookId: "public-og-demo",
+      subjectKind: "public",
+      subject: "anonymous",
+      scope: "viewer",
+    });
+    await env.NOTEBOOK_SNAPSHOTS.put(blobKey("public-og-demo", coverHash), body, {
+      httpMetadata: { contentType: "image/png" },
+    });
+
+    const response = await worker.fetch(
+      new Request("http://localhost/n/public-og-demo/r/latest/ogImage.png"),
+      env,
+      fakeContext(),
+    );
+    const head = await worker.fetch(
+      new Request("http://localhost/n/public-og-demo/r/latest/ogImage.png", { method: "HEAD" }),
+      env,
+      fakeContext(),
+    );
+
+    assert.equal(response.status, 200);
+    assert.equal(response.headers.get("Content-Type"), "image/png");
+    assert.equal(response.headers.get("Cache-Control"), "public, max-age=300");
+    assert.deepEqual(new Uint8Array(await response.arrayBuffer()), body);
+    assert.equal(head.status, 200);
+    assert.equal(head.headers.get("Content-Type"), "image/png");
+    assert.equal(head.headers.get("Cache-Control"), "public, max-age=300");
+  });
+
   it("caches authorized immutable blob reads at the Worker edge", async () => {
     const env = fakeEnv();
     seedNotebook(env, "blob-cache-demo");
@@ -5396,6 +5573,166 @@ describe("Worker artifact routes", () => {
     assert.equal(row?.language, "python");
   });
 
+  it("persists snapshot covers from image output manifests for list rows", async () => {
+    const env = fakeEnv();
+    const coverHash = "fake_image_blob_hash_for_fixture_testing_only_not_real";
+    const [notebookBytes, runtimeStateBytes] = await Promise.all([
+      readFile(
+        new URL(
+          "../../../packages/runtimed/tests/fixtures/display_data_output/doc.bin",
+          import.meta.url,
+        ),
+      ),
+      readFile(
+        new URL(
+          "../../../packages/runtimed/tests/fixtures/display_data_output/state_doc.bin",
+          import.meta.url,
+        ),
+      ),
+    ]);
+    await env.NOTEBOOK_SNAPSHOTS.put(blobKey("cover-demo", coverHash), new Uint8Array([1, 2, 3]), {
+      httpMetadata: { contentType: "image/png" },
+    });
+
+    const runtimePut = await ownerPut(
+      env,
+      "/api/n/cover-demo/runtime-snapshots/runtime-display",
+      runtimeStateBytes,
+      {
+        "X-Runtime-State-Doc-Id": "runtime:display-data",
+      },
+    );
+    assert.equal(runtimePut.status, 201);
+
+    const notebookPut = await ownerPut(
+      env,
+      "/api/n/cover-demo/snapshots/heads-display",
+      notebookBytes,
+      {
+        "X-Runtime-Heads-Hash": "runtime-display",
+        "X-Runtime-State-Doc-Id": "runtime:display-data",
+      },
+    );
+    assert.equal(notebookPut.status, 201);
+    assert.equal(env.DB.revisions[0]?.cover_blob_hash, coverHash);
+    assert.equal(env.DB.revisions[0]?.cover_mime, "image/png");
+
+    const listResponse = await worker.fetch(
+      new Request("http://localhost/api/n", {
+        headers: {
+          "X-User": "alice",
+          "X-Operator": "desktop:test",
+          "X-Scope": "viewer",
+        },
+      }),
+      env,
+      fakeContext(),
+    );
+    assert.equal(listResponse.status, 200);
+    const listBody = (await listResponse.json()) as {
+      notebooks: Array<{
+        cover?: { blob_hash: string; mime: string };
+        notebook_id: string;
+      }>;
+    };
+    assert.deepEqual(
+      listBody.notebooks.find((notebook) => notebook.notebook_id === "cover-demo")?.cover,
+      { blob_hash: coverHash, mime: "image/png" },
+    );
+  });
+
+  it("ignores malformed image output manifests when deriving snapshot covers", async () => {
+    const env = fakeEnv();
+    const [notebookBytes, runtimeStateBytes] = await Promise.all([
+      readFile(
+        new URL(
+          "../../../packages/runtimed/tests/fixtures/output_streaming/doc.bin",
+          import.meta.url,
+        ),
+      ),
+      readFile(
+        new URL(
+          "../../../packages/runtimed/tests/fixtures/output_streaming/state_doc.bin",
+          import.meta.url,
+        ),
+      ),
+    ]);
+    const fixtureHandle = NotebookHandle.load_snapshot(notebookBytes, runtimeStateBytes);
+    const cells = JSON.parse(fixtureHandle.get_cells_json()) as Array<{
+      execution_id?: unknown;
+    }>;
+    fixtureHandle.free();
+    const executionId = cells[0]?.execution_id;
+    if (typeof executionId !== "string") {
+      assert.fail("output_streaming fixture should have a synced execution id");
+    }
+
+    const runtimeHandle = RuntimeStatePeerHandle.load(runtimeStateBytes, "runtime:test");
+    let malformedRuntimeStateBytes: Uint8Array;
+    try {
+      runtimeHandle.append_output_json(
+        executionId,
+        JSON.stringify({
+          output_type: "display_data",
+          output_id: "malformed-image-output",
+          data: {
+            "image/png": "not-a-content-ref",
+          },
+          metadata: {},
+        }),
+      );
+      malformedRuntimeStateBytes = runtimeHandle.save();
+    } finally {
+      runtimeHandle.free();
+    }
+
+    const runtimePut = await ownerPut(
+      env,
+      "/api/n/malformed-cover-demo/runtime-snapshots/runtime-malformed",
+      malformedRuntimeStateBytes,
+      {
+        "X-Runtime-State-Doc-Id": "runtime:output-streaming",
+      },
+    );
+    assert.equal(runtimePut.status, 201);
+
+    const notebookPut = await ownerPut(
+      env,
+      "/api/n/malformed-cover-demo/snapshots/heads-malformed",
+      notebookBytes,
+      {
+        "X-Runtime-Heads-Hash": "runtime-malformed",
+        "X-Runtime-State-Doc-Id": "runtime:output-streaming",
+      },
+    );
+    assert.equal(notebookPut.status, 201);
+    assert.equal(env.DB.revisions[0]?.cover_blob_hash, null);
+    assert.equal(env.DB.revisions[0]?.cover_mime, null);
+
+    const listResponse = await worker.fetch(
+      new Request("http://localhost/api/n", {
+        headers: {
+          "X-User": "alice",
+          "X-Operator": "desktop:test",
+          "X-Scope": "viewer",
+        },
+      }),
+      env,
+      fakeContext(),
+    );
+    assert.equal(listResponse.status, 200);
+    const listBody = (await listResponse.json()) as {
+      notebooks: Array<{
+        cover?: unknown;
+        notebook_id: string;
+      }>;
+    };
+    assert.equal(
+      listBody.notebooks.find((notebook) => notebook.notebook_id === "malformed-cover-demo")?.cover,
+      undefined,
+    );
+  });
+
   it("does not fail snapshot publish when derived summary persistence fails", async () => {
     const env = fakeEnv();
     env.DB.failNotebookSummaryUpdate = true;
@@ -5456,6 +5793,72 @@ describe("Worker artifact routes", () => {
         (entry) =>
           entry[0] === "[notebook-cloud]" &&
           (entry[1] as { event?: string }).event === "snapshot.summary.update_failed",
+      ),
+    );
+  });
+
+  it("does not fail snapshot publish when derived cover persistence fails", async () => {
+    const env = fakeEnv();
+    env.DB.failNotebookCoverUpdate = true;
+    const coverHash = "fake_image_blob_hash_for_fixture_testing_only_not_real";
+    const [notebookBytes, runtimeStateBytes] = await Promise.all([
+      readFile(
+        new URL(
+          "../../../packages/runtimed/tests/fixtures/display_data_output/doc.bin",
+          import.meta.url,
+        ),
+      ),
+      readFile(
+        new URL(
+          "../../../packages/runtimed/tests/fixtures/display_data_output/state_doc.bin",
+          import.meta.url,
+        ),
+      ),
+    ]);
+    await env.NOTEBOOK_SNAPSHOTS.put(
+      blobKey("cover-fail-open", coverHash),
+      new Uint8Array([1, 2, 3]),
+      { httpMetadata: { contentType: "image/png" } },
+    );
+
+    const runtimePut = await ownerPut(
+      env,
+      "/api/n/cover-fail-open/runtime-snapshots/runtime-display",
+      runtimeStateBytes,
+      {
+        "X-Runtime-State-Doc-Id": "runtime:display-data",
+      },
+    );
+    assert.equal(runtimePut.status, 201);
+
+    const originalWarn = console.warn;
+    const warnings: unknown[][] = [];
+    console.warn = (...args: unknown[]) => {
+      warnings.push(args);
+    };
+    let response: Response;
+    try {
+      response = await ownerPut(
+        env,
+        "/api/n/cover-fail-open/snapshots/heads-display",
+        notebookBytes,
+        {
+          "X-Runtime-Heads-Hash": "runtime-display",
+          "X-Runtime-State-Doc-Id": "runtime:display-data",
+        },
+      );
+    } finally {
+      console.warn = originalWarn;
+    }
+
+    assert.equal(response.status, 201);
+    assert.equal(env.DB.revisions.length, 1);
+    assert.equal(env.DB.revisions[0]?.cover_blob_hash, null);
+    assert.ok(
+      warnings.some(
+        (entry) =>
+          entry[0] === "[notebook-cloud]" &&
+          (entry[1] as { event?: string }).event === "snapshot.cover.update_failed",
       ),
     );
   });
@@ -5681,13 +6084,17 @@ describe("Worker artifact routes", () => {
 });
 
 describe("catalog schema migrations", () => {
-  it("adds cell_composition and language via ALTER TABLE when absent", async () => {
+  it("adds dashboard summary and cover columns via ALTER TABLE when absent", async () => {
     const db = new FakeD1();
     // Simulate a pre-migration deployment: the columns do not exist yet.
     const notebookColumns = db.tableColumns.get("notebooks");
     assert.ok(notebookColumns);
     notebookColumns.delete("cell_composition");
     notebookColumns.delete("language");
+    const revisionColumns = db.tableColumns.get("notebook_revisions");
+    assert.ok(revisionColumns);
+    revisionColumns.delete("cover_blob_hash");
+    revisionColumns.delete("cover_mime");
 
     const env = fakeEnv({ DB: db });
     await runCatalogMigrations(env);
@@ -5695,6 +6102,9 @@ describe("catalog schema migrations", () => {
     const migrated = db.tableColumns.get("notebooks");
     assert.ok(migrated?.has("cell_composition"), "cell_composition added by migration");
     assert.ok(migrated?.has("language"), "language added by migration");
+    const migratedRevisions = db.tableColumns.get("notebook_revisions");
+    assert.ok(migratedRevisions?.has("cover_blob_hash"), "cover_blob_hash added by migration");
+    assert.ok(migratedRevisions?.has("cover_mime"), "cover_mime added by migration");
   });
 });
 
@@ -6482,6 +6892,41 @@ function seedAcl(
   });
 }
 
+function seedRevision(
+  env: FakeEnv,
+  input: {
+    id: string;
+    notebookId: string;
+    coverBlobHash?: string | null;
+    coverMime?: string | null;
+  },
+): void {
+  env.DB.revisions.push({
+    id: input.id,
+    notebook_id: input.notebookId,
+    runtime_state_doc_id: `runtime:${input.notebookId}`,
+    notebook_heads_hash: `heads:${input.id}`,
+    runtime_heads_hash: `runtime:${input.id}`,
+    comms_heads_hash: null,
+    comments_heads_hash: null,
+    snapshot_key: snapshotKey(input.notebookId, `heads:${input.id}`),
+    runtime_snapshot_key: runtimeStateSnapshotKey(
+      `runtime:${input.notebookId}`,
+      `runtime:${input.id}`,
+    ),
+    comms_snapshot_key: null,
+    comments_snapshot_key: null,
+    cover_blob_hash: input.coverBlobHash ?? null,
+    cover_mime: input.coverMime ?? null,
+    actor_label: "user:dev:alice/desktop:test",
+    created_at: "2026-05-22T00:00:00.000Z",
+  });
+  const notebook = env.DB.notebooks.get(input.notebookId);
+  if (notebook) {
+    notebook.latest_revision_id = input.id;
+  }
+}
+
 function seedWorkstation(
   env: FakeEnv,
   input: {
@@ -6863,6 +7308,8 @@ interface NotebookRow {
   updated_at: string;
   latest_revision_id: string | null;
   cell_composition: string | null;
+  cover_blob_hash?: string | null;
+  cover_mime?: string | null;
   language: string | null;
 }
 
@@ -6901,6 +7348,8 @@ interface RevisionRow {
   runtime_snapshot_key: string | null;
   comms_snapshot_key: string | null;
   comments_snapshot_key: string | null;
+  cover_blob_hash: string | null;
+  cover_mime: string | null;
   actor_label: string;
   created_at: string;
 }
@@ -6981,12 +7430,15 @@ class FakeD1 implements D1Database {
         "runtime_snapshot_key",
         "comms_snapshot_key",
         "comments_snapshot_key",
+        "cover_blob_hash",
+        "cover_mime",
         "actor_label",
         "created_at",
       ]),
     ],
   ]);
   afterBlockedOwnerDelete?: () => void;
+  failNotebookCoverUpdate = false;
   failNotebookSummaryUpdate = false;
 
   prepare(query: string): D1PreparedStatement {
@@ -7834,9 +8286,26 @@ class FakeD1Statement implements D1PreparedStatement {
         runtime_snapshot_key: runtimeSnapshotKey,
         comms_snapshot_key: commsSnapshotKey,
         comments_snapshot_key: commentsSnapshotKey,
+        cover_blob_hash: null,
+        cover_mime: null,
         actor_label: actorLabel,
         created_at: new Date().toISOString(),
       });
+    } else if (
+      this.query.includes("UPDATE notebook_revisions") &&
+      this.query.includes("cover_blob_hash")
+    ) {
+      if (this.db.failNotebookCoverUpdate) {
+        throw new Error("fake cover update failure");
+      }
+      const [coverBlobHash, coverMime, revisionId] = this.values as [string, string, string];
+      const revision = this.db.revisions.find((row) => row.id === revisionId);
+      if (revision) {
+        revision.cover_blob_hash = coverBlobHash;
+        revision.cover_mime = coverMime;
+        return okResult(undefined, { changes: 1 });
+      }
+      return okResult(undefined, { changes: 0 });
     } else if (
       this.query.includes("UPDATE notebooks") &&
       this.query.includes("latest_revision_id")
@@ -8121,6 +8590,14 @@ class FakeD1Statement implements D1PreparedStatement {
       );
       return (notebook?.latest_revision_id && publicViewer ? notebook : null) as T | null;
     }
+    if (this.query.includes("FROM notebook_revisions")) {
+      const [notebookId, revisionId] = this.values as [string, string];
+      return (
+        (this.db.revisions.find(
+          (revision) => revision.notebook_id === notebookId && revision.id === revisionId,
+        ) as T | undefined) ?? null
+      );
+    }
     if (this.query.includes("FROM notebooks")) {
       return (this.db.notebooks.get(this.values[0] as string) as T | undefined) ?? null;
     }
@@ -8255,8 +8732,13 @@ class FakeD1Statement implements D1PreparedStatement {
         const rank = scopeRank(row.scope);
         const existing = byNotebook.get(notebook.id);
         if (!existing || rank > existing.scopeRank) {
+          const revision = this.db.revisions.find(
+            (candidate) => candidate.id === notebook.latest_revision_id,
+          );
           byNotebook.set(notebook.id, {
             ...notebook,
+            cover_blob_hash: revision?.cover_blob_hash ?? null,
+            cover_mime: revision?.cover_mime ?? null,
             scope: row.scope,
             scopeRank: rank,
           });

--- a/apps/notebook-cloud/viewer/cloud-notebook-dashboard-view.tsx
+++ b/apps/notebook-cloud/viewer/cloud-notebook-dashboard-view.tsx
@@ -4,6 +4,8 @@ import {
   BookOpen,
   Check,
   Clock,
+  Code,
+  FileText,
   Layers,
   Loader2,
   PencilLine,
@@ -18,6 +20,7 @@ import { LanguageMark } from "@/components/runtime/LanguageMark";
 import { NotebookCompositionTicks } from "@/components/notebook/NotebookCompositionTicks";
 import { RuntimeStatusDot } from "@/components/runtime/RuntimeStatusDot";
 import {
+  cloudNotebookCoverUrl,
   cloudNotebookDashboardOpenUrl,
   cloudNotebookDisplayTitle,
   cloudNotebookLanguageDisplayLabel,
@@ -259,6 +262,7 @@ function CloudNotebookDashboardHero({
           </Button>
         </div>
       </div>
+      <CloudNotebookHeroBanner notebook={notebook} />
     </section>
   );
 }
@@ -289,6 +293,7 @@ function CloudNotebookDashboardSectionView({
   const action = section.action?.kind === "rename" && !canRename ? null : section.action;
   const hiddenCount = Math.max(0, section.totalCount - section.notebooks.length);
   const overflowAction = section.overflowAction;
+  const showCoverSlot = section.rows.some((row) => row.notebook.cover);
   const actionAlreadyReviewsOverflow =
     action?.kind === "filter" && action.filterId === overflowAction?.filterId;
 
@@ -330,6 +335,7 @@ function CloudNotebookDashboardSectionView({
           <CloudNotebookDashboardRowView
             key={row.notebook.notebook_id}
             row={row}
+            showCoverSlot={showCoverSlot}
             canRename={canRename}
             renameTitle={
               renameState?.notebookId === row.notebook.notebook_id ? renameState.title : null
@@ -364,6 +370,7 @@ function CloudNotebookDashboardSectionView({
 
 function CloudNotebookDashboardRowView({
   row,
+  showCoverSlot,
   canRename,
   renameTitle,
   renameSaving,
@@ -374,6 +381,7 @@ function CloudNotebookDashboardRowView({
   onSaveRename,
 }: {
   row: CloudNotebookDashboardRow;
+  showCoverSlot: boolean;
   canRename: boolean;
   renameTitle: string | null;
   renameSaving: boolean;
@@ -437,6 +445,7 @@ function CloudNotebookDashboardRowView({
         onFocus={onOpenNotebookIntent}
         onPointerEnter={onOpenNotebookIntent}
       >
+        {showCoverSlot ? <CloudNotebookCoverTile notebook={notebook} /> : null}
         <span className="nb-row-titleblock">
           <span className="nb-title" data-untitled={!hasTitle}>
             {cloudNotebookDisplayTitle(notebook)}
@@ -508,6 +517,62 @@ function CloudNotebookDashboardRowView({
       </span>
     </div>
   );
+}
+
+function CloudNotebookCoverTile({ notebook }: { notebook: CloudNotebookListItem }) {
+  const coverUrl = cloudNotebookCoverUrl(notebook);
+  const fallbackType = dominantNotebookCellType(notebook.composition);
+  return (
+    <span className={`nb-cover${coverUrl ? " has-img" : ""}`} aria-hidden="true">
+      {coverUrl ? (
+        <img className="nb-output-img" src={coverUrl} alt="" loading="lazy" />
+      ) : (
+        <NotebookCoverFallbackIcon cellType={fallbackType} />
+      )}
+    </span>
+  );
+}
+
+function CloudNotebookHeroBanner({ notebook }: { notebook: CloudNotebookListItem }) {
+  const coverUrl = cloudNotebookCoverUrl(notebook);
+  if (!coverUrl) {
+    return null;
+  }
+  return (
+    <div className="nb-hero-banner" aria-hidden="true">
+      <img className="nb-output-img" src={coverUrl} alt="" />
+    </div>
+  );
+}
+
+function NotebookCoverFallbackIcon({
+  cellType,
+}: {
+  cellType: keyof NonNullable<CloudNotebookListItem["composition"]>;
+}) {
+  switch (cellType) {
+    case "markdown":
+      return <BookOpen aria-hidden="true" />;
+    case "raw":
+      return <FileText aria-hidden="true" />;
+    case "code":
+      return <Code aria-hidden="true" />;
+  }
+}
+
+function dominantNotebookCellType(
+  composition: CloudNotebookListItem["composition"],
+): keyof NonNullable<CloudNotebookListItem["composition"]> {
+  if (!composition) {
+    return "code";
+  }
+  if (composition.markdown > composition.code && composition.markdown >= composition.raw) {
+    return "markdown";
+  }
+  if (composition.raw > composition.code && composition.raw > composition.markdown) {
+    return "raw";
+  }
+  return "code";
 }
 
 function CloudNotebookScopeBadge({ notebook }: { notebook: CloudNotebookListItem }) {

--- a/apps/notebook-cloud/viewer/index.css
+++ b/apps/notebook-cloud/viewer/index.css
@@ -1110,6 +1110,28 @@ body {
   font-size: 15px;
 }
 
+.nb-hero-banner {
+  height: 108px;
+  margin: 20px -26px -24px;
+  overflow: hidden;
+  border-top: 1px solid var(--border);
+  background: color-mix(in srgb, var(--muted) 40%, var(--card));
+}
+
+.nb-output-img {
+  display: block;
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+}
+
+.nb-hero-banner .nb-output-img {
+  border: 0;
+  border-radius: 0;
+  background: transparent;
+  box-shadow: none;
+}
+
 .nb-sections {
   display: flex;
   flex-direction: column;
@@ -1393,6 +1415,35 @@ body {
   min-width: 0;
   flex-direction: column;
   gap: 7px;
+}
+
+.nb-cover {
+  display: grid;
+  width: 40px;
+  height: 40px;
+  flex: 0 0 auto;
+  place-items: center;
+  overflow: hidden;
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  color: color-mix(in srgb, var(--muted-foreground) 62%, transparent);
+  background: var(--muted);
+}
+
+.nb-cover.has-img {
+  background: var(--card);
+}
+
+.nb-cover .nb-output-img {
+  border: 0;
+  border-radius: 0;
+  background: transparent;
+  box-shadow: none;
+}
+
+.nb-cover svg {
+  width: 16px;
+  height: 16px;
 }
 
 .nb-title {

--- a/apps/notebook-cloud/viewer/notebook-dashboard.ts
+++ b/apps/notebook-cloud/viewer/notebook-dashboard.ts
@@ -15,6 +15,7 @@ export interface CloudNotebookListItem {
   latest_revision_id: string | null;
   compute_session?: NotebookComputeSessionSummary | null;
   composition?: CloudNotebookComposition;
+  cover?: CloudNotebookCover;
   language?: string;
   viewer_url: string;
   endpoints: {
@@ -28,6 +29,11 @@ export interface CloudNotebookComposition {
   code: number;
   markdown: number;
   raw: number;
+}
+
+export interface CloudNotebookCover {
+  blob_hash: string;
+  mime: "image/png" | "image/jpeg" | "image/svg+xml";
 }
 
 export type CloudNotebookDashboardRuntimeStatus =
@@ -203,6 +209,14 @@ export function cloudNotebookDashboardOpenUrl(
   });
 }
 
+export function cloudNotebookCoverUrl(notebook: CloudNotebookListItem): string | null {
+  const hash = notebook.cover?.blob_hash;
+  if (!hash) {
+    return null;
+  }
+  return `${trimTrailingSlash(notebook.endpoints.catalog)}/blobs/${encodeURIComponent(hash)}`;
+}
+
 export function cloudNotebookOpenUrlWithMode(
   viewerUrl: string,
   mode: CloudNotebookUrlMode,
@@ -264,6 +278,10 @@ function currentBrowserOrigin(): string | null {
   return typeof window === "undefined" ? null : window.location.origin;
 }
 
+function trimTrailingSlash(value: string): string {
+  return value.replace(/\/+$/u, "");
+}
+
 export function isCloudNotebookListItem(value: unknown): value is CloudNotebookListItem {
   if (!value || typeof value !== "object") {
     return false;
@@ -281,12 +299,26 @@ export function isCloudNotebookListItem(value: unknown): value is CloudNotebookL
       candidate.compute_session === null ||
       isNotebookComputeSessionSummary(candidate.compute_session)) &&
     (candidate.composition === undefined || isCloudNotebookComposition(candidate.composition)) &&
+    (candidate.cover === undefined || isCloudNotebookCover(candidate.cover)) &&
     (candidate.language === undefined || typeof candidate.language === "string") &&
     typeof candidate.viewer_url === "string" &&
     Boolean(candidate.endpoints) &&
     typeof candidate.endpoints?.catalog === "string" &&
     typeof candidate.endpoints?.acl === "string" &&
     typeof candidate.endpoints?.access_requests === "string"
+  );
+}
+
+function isCloudNotebookCover(value: unknown): value is CloudNotebookCover {
+  if (!value || typeof value !== "object") {
+    return false;
+  }
+  const candidate = value as Partial<CloudNotebookCover>;
+  return (
+    typeof candidate.blob_hash === "string" &&
+    (candidate.mime === "image/png" ||
+      candidate.mime === "image/jpeg" ||
+      candidate.mime === "image/svg+xml")
   );
 }
 


### PR DESCRIPTION
Implements #3880 (notebook covers from inline output embeds) plus the OG image surface: `GET /n/{notebookId}/r/latest/ogImage.png`, so shared public notebooks get a real social card rendered from the notebook's own output.

## Cover pipeline

Extraction joins the wave-1 derivation in the snapshot PUT - the handler's already-materialized handle, zero extra decode. The cover is the **last image-bearing output manifest in document order** (`image/png`, `image/jpeg`, `image/svg+xml`), shape-validated as untrusted JSON. Stored as nullable `cover_blob_hash`/`cover_mime` on **`notebook_revisions`** - revision-scoped, which is what makes `/r/latest` meaningful and leaves room for pinned-revision cards later. Fail-open on both sides: cover persistence failure never fails the snapshot publish, and cover *lookup* failure never 500s the public viewer page (transient D1/R2 errors yield "no cover").

The list carries covers via a LEFT JOIN on `latest_revision_id` - same single query, zero added round trips or fan-out.

## The OG route (anonymous, internet-facing)

- `getPublicPublishedNotebookRow` is the **sole** gate: no public ACL row or no revision → 404. Never 401/403 - no existence leaks to probes.
- Raster allow-list enforced **at serve time**, not just write time: content type is a validated literal enum, so an svg cover or corrupt `cover_mime` row can never turn this into a public non-image response. `X-Content-Type-Options: nosniff` set.
- Blob existence verified before answering (`latest_revision_id` can point at a revision whose blob write failed).
- `Cache-Control: public, max-age=300` (latest is mutable), ETag from R2, GET + HEAD (scrapers HEAD first).
- The public viewer shell emits `og:image` (absolute URL), `og:image:type`, and `twitter:card=summary_large_image` when a raster cover exists.

## Dashboard

Rows show the design's 40x40 cover tile (neutral tile fallback keeps title alignment; dominant-type icon when composition is absent), the hero gets the 108px banner. Both load through the existing authenticated blob route (same-origin cookies), lazy, decorative-aria. SVG covers render in the dashboard; the OG route stays raster-only (scrapers reject SVG).

## Deliberately not here

- No image resizing/re-encoding - original blob passthrough. Thumbnailing is a natural follow-up if cover blobs trend large.
- Blob-PUT content-type validation (pre-existing behavior surfaced by the security review, not introduced here) - tracked in #3887.

## Verification

- [x] Cloud tests 1189/1189 (14 new: cover persistence, malformed-manifest fail-open, OG 404 matrix incl. svg-only and missing-blob, header assertions, migration path via delete-then-migrate), cloud + desktop builds, `vp check` clean
- [x] Security-focused adversarial review on the diff: access-path walk (sole-gate, 404-only, R2 key from route param), serve-time mime enforcement, cache/cookie hygiene, DoS shape (cheap 404s before work), fail-open walk - its two real findings (unguarded cover lookup on the shell path, missing nosniff) are folded in

Closes #3880.
