### PR TITLE
fix(notebook-cloud): avoid latest OG images on pinned revisions

### DIFF
--- a/apps/notebook-cloud/src/index.ts
+++ b/apps/notebook-cloud/src/index.ts
@@ -5208,7 +5208,9 @@ async function publicViewerShellMetadata(
   const revisionPart = headsHash
     ? `revision ${shortNotebookId(headsHash)}`
     : `published revision ${shortNotebookId(row.latest_revision_id)}`;
-  const cover = await publicLatestRasterCover(env, notebookId, { verifyBlob: true });
+  const cover = headsHash
+    ? null
+    : await publicLatestRasterCover(env, notebookId, { verifyBlob: true });
   return {
     title: `nteract notebook: ${displayTitle}`,
     description: `${displayTitle} is a public nteract notebook at ${revisionPart}.`,

--- a/apps/notebook-cloud/test/worker-routes.test.ts
+++ b/apps/notebook-cloud/test/worker-routes.test.ts
@@ -308,6 +308,51 @@ describe("Worker artifact routes", () => {
     assert.match(html, /<meta name="twitter:card" content="summary_large_image" \/>/);
   });
 
+  it("does not attach latest OG image metadata to pinned revision shells", async () => {
+    const env = fakeEnv();
+    seedNotebook(env, "pinned-meta-cover");
+    const notebook = env.DB.notebooks.get("pinned-meta-cover");
+    assert.ok(notebook);
+    notebook.title = "Pinned Cover";
+    seedRevision(env, {
+      id: "revision-old-cover",
+      notebookId: "pinned-meta-cover",
+      coverBlobHash: "old-cover",
+      coverMime: "image/png",
+    });
+    seedRevision(env, {
+      id: "revision-latest-cover",
+      notebookId: "pinned-meta-cover",
+      coverBlobHash: "latest-cover",
+      coverMime: "image/png",
+    });
+    seedAcl(env, {
+      notebookId: "pinned-meta-cover",
+      subjectKind: "public",
+      subject: "anonymous",
+      scope: "viewer",
+    });
+    await env.NOTEBOOK_SNAPSHOTS.put(
+      blobKey("pinned-meta-cover", "latest-cover"),
+      new Uint8Array([1]),
+      { httpMetadata: { contentType: "image/png" } },
+    );
+
+    const response = await worker.fetch(
+      new Request(
+        `http://localhost/n/pinned-meta-cover/r/${encodeURIComponent("heads:revision-old-cover")}`,
+      ),
+      env,
+      fakeContext(),
+    );
+
+    assert.equal(response.status, 200);
+    const html = await response.text();
+    assert.match(html, /Pinned Cover is a public nteract notebook at revision heads:revisi/);
+    assert.doesNotMatch(html, /\/n\/pinned-meta-cover\/r\/latest\/ogImage\.png/);
+    assert.match(html, /<meta name="twitter:card" content="summary" \/>/);
+  });
+
   it("keeps private notebook titles out of server-rendered viewer metadata", async () => {
     const env = fakeEnv();
     seedNotebook(env, "private-meta-demo");


### PR DESCRIPTION
## Summary

- suppress mutable latest OG image metadata on pinned revision viewer shells
- add a worker-route regression test for public pinned revision URLs

## Verification

- `cargo xtask lint --fix`
- `pnpm --dir apps/notebook-cloud exec node --import tsx --test --test-name-pattern "OG image metadata|pinned revision shells|latest OG image" test/worker-routes.test.ts`
- `pnpm --dir apps/notebook-cloud test`

## Notes

This is a follow-up to #3888. The latest OG image route is intentionally mutable, so pinned revision pages should not advertise it until there is a revision-specific OG image route.
