### PR TITLE
feat(notebook-cloud): list-scale presence via R2 room summaries + unified owner identity

### DIFF
--- a/apps/notebook-cloud/src/index.ts
+++ b/apps/notebook-cloud/src/index.ts
@@ -53,6 +53,7 @@ import {
   recordRevision,
   registerWorkstation,
   revokeNotebookAclRow,
+  roomSummaryKey,
   runtimeStateSnapshotKey,
   snapshotKey,
   setDefaultWorkstation,
@@ -64,6 +65,8 @@ import {
   type NotebookAclRow,
   type NotebookAccessRequestRow,
   type NotebookAccessRequestStatus,
+  type NotebookRoomSummary,
+  type NotebookRoomSummaryOccupant,
   type WorkstationAttachJobRow,
   type WorkstationAttachJobStatus,
   type WorkstationRegistrationInput,
@@ -1155,6 +1158,9 @@ async function routeCreateNotebook(request: Request, env: Env): Promise<Response
 
 const DEFAULT_NOTEBOOK_LIST_LIMIT = 100;
 const MAX_NOTEBOOK_LIST_LIMIT = 500;
+const NOTEBOOK_LIST_ROOM_SUMMARY_LIMIT = 200;
+const NOTEBOOK_LIST_ROOM_SUMMARY_CONCURRENCY = 20;
+const ROOM_SUMMARY_FRESH_MS = 150_000;
 
 async function routeListNotebooks(request: Request, env: Env): Promise<Response> {
   if (request.method !== "GET") {
@@ -1189,11 +1195,60 @@ async function routeListNotebooks(request: Request, env: Env): Promise<Response>
   }
 
   const notebooks = await listNotebooksForPrincipal(env, principal, limit);
-  const computeSessions = await listNotebookComputeSessionsForOwnedRows(env, notebooks);
+  // The hydrations are independent fan-outs (owner-bucketed DO calls, bounded
+  // R2 GETs, one batched D1 profile lookup) - overlap them instead of paying
+  // the latencies in series.
+  const [computeSessions, roomPresence, principalDisplays] = await Promise.all([
+    listNotebookComputeSessionsForOwnedRows(env, notebooks),
+    listNotebookRoomPresenceForRows(env, notebooks, {
+      actorLabel: isAnonymousViewer(identity) ? null : identity.actorLabel,
+      principal,
+    }),
+    listNotebookPrincipalDisplays(env, notebooks, principal),
+  ]);
+  const currentUserDisplay = principalDisplays.get(principal);
   return json({
     ok: true,
-    notebooks: notebookListResponseRows(request, notebooks, env, computeSessions),
+    notebooks: notebookListResponseRows(
+      request,
+      notebooks,
+      env,
+      computeSessions,
+      roomPresence,
+      principalDisplays,
+    ),
+    ...(currentUserDisplay ? { current_user_display: currentUserDisplay } : {}),
   });
+}
+
+// Owner name cards resolve through the unified user store (principal_profiles),
+// not the raw principal string. Fail-open: no profile data degrades to the
+// client's principal-derived fallback, never a failed list.
+async function listNotebookPrincipalDisplays(
+  env: Env,
+  notebooks: readonly ListedNotebookRow[],
+  requesterPrincipal: string,
+): Promise<Map<string, string>> {
+  const displays = new Map<string, string>();
+  try {
+    const principals = Array.from(
+      new Set([...notebooks.map((notebook) => notebook.owner_principal), requesterPrincipal]),
+    );
+    const profiles = await getPrincipalProfiles(env, principals);
+    for (const profile of profiles) {
+      const display = profile.display_name?.trim();
+      if (display) {
+        displays.set(profile.principal, display);
+      }
+    }
+  } catch (error) {
+    cloudLog("warn", "notebook.list.profile_hydration_failed", {
+      error: errorMessage(error),
+      counter: "notebook_list_profile_hydration_failures",
+      counter_delta: 1,
+    });
+  }
+  return displays;
 }
 
 async function listNotebookComputeSessionsForOwnedRows(
@@ -1223,11 +1278,144 @@ async function listNotebookComputeSessionsForOwnedRows(
   return sessions;
 }
 
+interface NotebookListRequesterPresence {
+  actorLabel: string | null;
+  principal: string;
+}
+
+async function listNotebookRoomPresenceForRows(
+  env: Env,
+  notebooks: readonly ListedNotebookRow[],
+  requester: NotebookListRequesterPresence,
+): Promise<Map<string, NotebookRoomSummaryOccupant[]>> {
+  const bucket = env.NOTEBOOK_SNAPSHOTS;
+  if (!bucket || notebooks.length === 0) {
+    return new Map();
+  }
+
+  const hydrated = notebooks.slice(0, NOTEBOOK_LIST_ROOM_SUMMARY_LIMIT);
+  if (notebooks.length > hydrated.length) {
+    cloudLog("info", "notebook_list.room_presence_hydration_capped", {
+      row_count: notebooks.length,
+      hydrated_count: hydrated.length,
+      skipped_count: notebooks.length - hydrated.length,
+      counter: "notebook_list_room_presence_hydration_capped",
+      counter_delta: 1,
+    });
+  }
+
+  const presence = new Map<string, NotebookRoomSummaryOccupant[]>();
+  for (let index = 0; index < hydrated.length; index += NOTEBOOK_LIST_ROOM_SUMMARY_CONCURRENCY) {
+    const chunk = hydrated.slice(index, index + NOTEBOOK_LIST_ROOM_SUMMARY_CONCURRENCY);
+    await Promise.all(
+      chunk.map(async (notebook) => {
+        try {
+          const object = await bucket.get(roomSummaryKey(notebook.id));
+          if (!object) {
+            return;
+          }
+          const summary = parseNotebookRoomSummary(await object.text(), notebook.id);
+          if (!summary || roomSummaryIsStale(summary.updated_at)) {
+            return;
+          }
+          const peers = summary.occupants.filter(
+            (occupant) =>
+              isHumanRoomSummaryOccupant(occupant) &&
+              !roomSummaryOccupantMatchesRequester(occupant, requester),
+          );
+          if (peers.length > 0) {
+            presence.set(notebook.id, peers);
+          }
+        } catch (error) {
+          cloudLog("warn", "notebook_list.room_presence_hydration_failed", {
+            notebook_id: notebook.id,
+            error: errorMessage(error),
+            counter: "notebook_list_room_presence_hydration_failures",
+            counter_delta: 1,
+          });
+        }
+      }),
+    );
+  }
+
+  return presence;
+}
+
+function parseNotebookRoomSummary(value: string, notebookId: string): NotebookRoomSummary | null {
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(value);
+  } catch {
+    return null;
+  }
+  if (!parsed || typeof parsed !== "object") {
+    return null;
+  }
+  const candidate = parsed as Partial<NotebookRoomSummary>;
+  if (
+    candidate.version !== 1 ||
+    candidate.notebook_id !== notebookId ||
+    typeof candidate.updated_at !== "string" ||
+    Number.isNaN(Date.parse(candidate.updated_at)) ||
+    !Array.isArray(candidate.occupants)
+  ) {
+    return null;
+  }
+  const occupants = candidate.occupants.filter(isNotebookRoomSummaryOccupant);
+  return {
+    version: 1,
+    notebook_id: notebookId,
+    occupants,
+    updated_at: candidate.updated_at,
+  };
+}
+
+function roomSummaryIsStale(updatedAt: string): boolean {
+  return Date.now() - Date.parse(updatedAt) > ROOM_SUMMARY_FRESH_MS;
+}
+
+function isNotebookRoomSummaryOccupant(value: unknown): value is NotebookRoomSummaryOccupant {
+  if (!value || typeof value !== "object") {
+    return false;
+  }
+  const candidate = value as Partial<NotebookRoomSummaryOccupant>;
+  return (
+    typeof candidate.participant_key === "string" &&
+    typeof candidate.actor_label === "string" &&
+    (candidate.display_name === undefined || typeof candidate.display_name === "string") &&
+    typeof candidate.connection_scope === "string"
+  );
+}
+
+function isHumanRoomSummaryOccupant(occupant: NotebookRoomSummaryOccupant): boolean {
+  return (
+    occupant.connection_scope === "viewer" ||
+    occupant.connection_scope === "editor" ||
+    occupant.connection_scope === "owner"
+  );
+}
+
+function roomSummaryOccupantMatchesRequester(
+  occupant: NotebookRoomSummaryOccupant,
+  requester: NotebookListRequesterPresence,
+): boolean {
+  if (occupant.participant_key === requester.principal) {
+    return true;
+  }
+  return Boolean(requester.actorLabel && occupant.actor_label === requester.actorLabel);
+}
+
+// The row UI shows three avatars + "+N"; eight keeps headroom without letting
+// a crowded room bloat every list payload.
+const MAX_NOTEBOOK_LIST_PEERS_PER_ROW = 8;
+
 function notebookListResponseRows(
   request: Request,
   notebooks: ListedNotebookRow[],
   env?: Env,
   computeSessions: ReadonlyMap<string, NotebookComputeSessionSummary> = new Map(),
+  roomPresence: ReadonlyMap<string, NotebookRoomSummaryOccupant[]> = new Map(),
+  principalDisplays: ReadonlyMap<string, string> = new Map(),
 ): Array<Record<string, unknown>> {
   return notebooks.map((notebook) => {
     const notebookPathId = encodeURIComponent(notebook.id);
@@ -1238,6 +1426,7 @@ function notebookListResponseRows(
         ? computeSessions.get(notebook.id)
         : null;
     const cover = notebookCoverResponse(notebook);
+    const peers = (roomPresence.get(notebook.id) ?? []).slice(0, MAX_NOTEBOOK_LIST_PEERS_PER_ROW);
     return {
       notebook_id: notebook.id,
       title: notebook.title,
@@ -1246,10 +1435,14 @@ function notebookListResponseRows(
       created_at: notebook.created_at,
       updated_at: notebook.updated_at,
       latest_revision_id: notebook.latest_revision_id,
+      ...(principalDisplays.has(notebook.owner_principal)
+        ? { owner_display: principalDisplays.get(notebook.owner_principal) }
+        : {}),
       ...(composition ? { composition } : {}),
       ...(cover ? { cover } : {}),
       ...(typeof notebook.language === "string" ? { language: notebook.language } : {}),
       compute_session: computeSession,
+      ...(peers.length ? { peers } : {}),
       viewer_url: viewerUrlForRequest(request, notebook.id, notebook.title, env),
       endpoints: {
         catalog: apiBasePath,
@@ -5336,6 +5529,10 @@ async function notebookListBootstrap(
     session.principal,
     DEFAULT_NOTEBOOK_LIST_LIMIT,
   );
+  // The SSR bootstrap is embedded in served HTML, which is PII-free by
+  // invariant (see the "bootstraps the notebook home" leak-guard test): no
+  // profile display names and no presence occupant identities here. The
+  // authenticated /api/n fetch that follows carries both.
   const computeSessions = await listNotebookComputeSessionsForOwnedRows(env, notebooks);
   return {
     kind: "notebook-list",

--- a/apps/notebook-cloud/src/notebook-room.ts
+++ b/apps/notebook-cloud/src/notebook-room.ts
@@ -42,7 +42,12 @@ import {
   type SyncFrameBudgetDirection,
   type SyncFrameBudgetSummary,
 } from "./sync-frame-budget.ts";
-import { getNotebookRow } from "./storage.ts";
+import {
+  getNotebookRow,
+  roomSummaryKey,
+  type NotebookRoomSummary,
+  type NotebookRoomSummaryOccupant,
+} from "./storage.ts";
 
 interface Peer {
   id: string;
@@ -123,6 +128,7 @@ interface PendingRuntimePeerResponse {
 /// kernel that is about to come back: if a `runtime_peer` rejoins inside the
 /// window the alarm is disarmed.
 const RUNTIME_PEER_GONE_GRACE_MS = 30_000;
+const ROOM_SUMMARY_REFRESH_MS = 60_000;
 const MAX_CONSECUTIVE_REJECTED_FRAMES = 8;
 const REJECTED_FRAME_POLICY_CLOSE_CODE = 1008;
 const REJECTED_FRAME_POLICY_CLOSE_REASON = "too many rejected frames";
@@ -133,6 +139,9 @@ const DUPLICATE_RUNTIME_PEER_CLOSE_REASON = "replaced by newer runtime peer";
 /// reconciliation alarm. Persisted so a DO that hibernates between the alarm
 /// being set and firing still knows which room to reconcile.
 const RUNTIME_PEER_WATCH_KEY = "runtime_peer_gone_watch";
+const RUNTIME_PEER_WATCH_ALARM_AT_KEY = "runtime_peer_gone_watch_alarm_at";
+const ROOM_SUMMARY_REFRESH_KEY = "room_summary_refresh";
+const ROOM_SUMMARY_REFRESH_ALARM_AT_KEY = "room_summary_refresh_alarm_at";
 const runtimePeerForwardedRequestActions = new Set<RuntimePeerForwardedRequestAction>([
   "interrupt_execution",
   "send_comm",
@@ -239,6 +248,11 @@ export class NotebookRoom {
   >();
   private readonly computeSessionQueueDepths = new Map<string, number>();
   private readonly computeSessionSummaryPublishes = new Map<string, Promise<void>>();
+  // Room-summary publishes chain per notebook for the same reason compute-session
+  // summaries do: unserialized writes can land out of order (a stale "empty"
+  // publish overwriting a newer "occupied" one) and the trailing rearm would
+  // disarm the refresh alarm against live occupancy.
+  private readonly roomSummaryPublishes = new Map<string, Promise<void>>();
   private readonly dirtyComputeSessionSummaries = new Set<string>();
   private readonly restoredPeersReady: Promise<void>;
   private readonly pendingRuntimePeerResponses = new Map<string, PendingRuntimePeerResponse>();
@@ -334,6 +348,7 @@ export class NotebookRoom {
     if (identity.scope === "runtime_peer") {
       this.removeDuplicateRuntimePeers(notebookId, peer);
     }
+    const humanOccupantsBeforeJoin = this.roomSummaryOccupantKeys();
     this.acceptPeerSocket(notebookId, peer);
     this.peers.set(peer.id, peer);
     // A runtime_peer (re)joining cancels any pending reconciliation alarm: the
@@ -385,6 +400,11 @@ export class NotebookRoom {
         timestamp: peer.connectedAt,
       },
       peer.id,
+    );
+    this.publishRoomSummaryIfHumanOccupantsChanged(
+      notebookId,
+      humanOccupantsBeforeJoin,
+      "peer_joined",
     );
     this.state.waitUntil(this.syncPeerFromRoomHost(notebookId, peer));
 
@@ -696,6 +716,13 @@ export class NotebookRoom {
         }
       }),
     );
+
+    const humanNotebookIds = new Set(
+      activeRestored.filter(({ peer }) => isHumanPeer(peer)).map(({ notebookId }) => notebookId),
+    );
+    for (const notebookId of humanNotebookIds) {
+      this.publishRoomSummary(notebookId, "hibernation_restore");
+    }
   }
 
   private removeDuplicateRestoredRuntimePeers(
@@ -1968,6 +1995,7 @@ export class NotebookRoom {
       return;
     }
 
+    const humanOccupantsBeforeLeave = this.roomSummaryOccupantKeys();
     if (!this.peers.delete(peer.id)) {
       return;
     }
@@ -2018,6 +2046,11 @@ export class NotebookRoom {
       this.refreshRuntimePeerWatch(notebookId);
       this.state.waitUntil(this.publishCurrentComputeSessionSummary(notebookId));
     }
+    this.publishRoomSummaryIfHumanOccupantsChanged(
+      notebookId,
+      humanOccupantsBeforeLeave,
+      "peer_left",
+    );
   }
 
   private recordFrameBudget(
@@ -2088,6 +2121,134 @@ export class NotebookRoom {
     return count;
   }
 
+  private roomSummaryOccupantKeys(): Set<string> {
+    return new Set(this.roomSummaryOccupants().map((occupant) => occupant.participant_key));
+  }
+
+  private roomSummaryOccupants(): NotebookRoomSummaryOccupant[] {
+    const occupants = new Map<string, NotebookRoomSummaryOccupant>();
+    for (const peer of this.peers.values()) {
+      if (!isHumanPeer(peer)) {
+        continue;
+      }
+      const participantKey = roomPeerParticipantKey(peer);
+      const existing = occupants.get(participantKey);
+      if (
+        existing &&
+        roomSummaryScopeRank(existing.connection_scope) >= roomSummaryScopeRank(peer.identity.scope)
+      ) {
+        continue;
+      }
+      occupants.set(participantKey, {
+        participant_key: participantKey,
+        actor_label: peer.identity.actorLabel,
+        ...(peer.identity.metadata.displayName
+          ? { display_name: peer.identity.metadata.displayName }
+          : {}),
+        connection_scope: peer.identity.scope,
+      });
+    }
+    return Array.from(occupants.values()).sort((left, right) =>
+      left.participant_key.localeCompare(right.participant_key),
+    );
+  }
+
+  private publishRoomSummaryIfHumanOccupantsChanged(
+    notebookId: string,
+    previousOccupantKeys: ReadonlySet<string>,
+    reason: "peer_joined" | "peer_left",
+  ): void {
+    const nextOccupantKeys = this.roomSummaryOccupantKeys();
+    if (sameStringSet(previousOccupantKeys, nextOccupantKeys)) {
+      return;
+    }
+    this.publishRoomSummary(notebookId, reason);
+  }
+
+  private publishRoomSummary(
+    notebookId: string,
+    reason: "peer_joined" | "peer_left" | "hibernation_restore" | "refresh_alarm",
+  ): void {
+    const previous = this.roomSummaryPublishes.get(notebookId) ?? Promise.resolve();
+    const publish = previous
+      .catch(() => undefined)
+      .then(() => this.publishRoomSummaryNow(notebookId, reason));
+    this.roomSummaryPublishes.set(notebookId, publish);
+    this.state.waitUntil(
+      publish.finally(() => {
+        if (this.roomSummaryPublishes.get(notebookId) === publish) {
+          this.roomSummaryPublishes.delete(notebookId);
+        }
+      }),
+    );
+  }
+
+  private async publishRoomSummaryNow(
+    notebookId: string,
+    reason: "peer_joined" | "peer_left" | "hibernation_restore" | "refresh_alarm",
+  ): Promise<void> {
+    const bucket = this.env.NOTEBOOK_SNAPSHOTS;
+    if (!bucket) {
+      await this.refreshRoomSummaryWatch(notebookId, 0);
+      return;
+    }
+
+    const summary: NotebookRoomSummary = {
+      version: 1,
+      notebook_id: notebookId,
+      occupants: this.roomSummaryOccupants(),
+      updated_at: new Date().toISOString(),
+    };
+
+    try {
+      await bucket.put(roomSummaryKey(notebookId), JSON.stringify(summary), {
+        httpMetadata: { contentType: "application/json; charset=utf-8" },
+      });
+      cloudLog("info", "room.summary.published", {
+        notebook_id: notebookId,
+        occupant_count: summary.occupants.length,
+        reason,
+        counter: "room_summaries_published",
+        counter_delta: 1,
+      });
+    } catch (error) {
+      cloudLog("warn", "room.summary.publish_failed", {
+        notebook_id: notebookId,
+        occupant_count: summary.occupants.length,
+        reason,
+        error: errorMessage(error),
+        counter: "room_summary_publish_failures",
+        counter_delta: 1,
+      });
+    } finally {
+      await this.refreshRoomSummaryWatch(notebookId, summary.occupants.length);
+    }
+  }
+
+  private async refreshRoomSummaryWatch(notebookId: string, occupantCount: number): Promise<void> {
+    const storage = this.state.storage;
+    if (!storage.setAlarm || !storage.deleteAlarm) {
+      return;
+    }
+    try {
+      if (occupantCount <= 0) {
+        await storage.delete(ROOM_SUMMARY_REFRESH_KEY);
+        await storage.delete(ROOM_SUMMARY_REFRESH_ALARM_AT_KEY);
+        await this.rescheduleRoomAlarm();
+        return;
+      }
+      const alarmAt = Date.now() + ROOM_SUMMARY_REFRESH_MS;
+      await storage.put(ROOM_SUMMARY_REFRESH_KEY, notebookId);
+      await storage.put(ROOM_SUMMARY_REFRESH_ALARM_AT_KEY, alarmAt);
+      await this.rescheduleRoomAlarm();
+    } catch (error) {
+      cloudLog("warn", "room.summary_watch.refresh_failed", {
+        notebook_id: notebookId,
+        error: errorMessage(error),
+      });
+    }
+  }
+
   /// Arm or disarm the runtime_peer-gone reconciliation alarm to match current
   /// membership: arm (grace window) when no `runtime_peer` is attached, disarm
   /// when one is present. Called when a `runtime_peer` joins or leaves. A no-op
@@ -2101,12 +2262,15 @@ export class NotebookRoom {
       (async () => {
         try {
           if (this.hasRuntimePeer()) {
-            await storage.deleteAlarm?.();
             await storage.delete(RUNTIME_PEER_WATCH_KEY);
+            await storage.delete(RUNTIME_PEER_WATCH_ALARM_AT_KEY);
+            await this.rescheduleRoomAlarm();
             return;
           }
+          const alarmAt = Date.now() + RUNTIME_PEER_GONE_GRACE_MS;
           await storage.put(RUNTIME_PEER_WATCH_KEY, notebookId);
-          await storage.setAlarm?.(Date.now() + RUNTIME_PEER_GONE_GRACE_MS);
+          await storage.put(RUNTIME_PEER_WATCH_ALARM_AT_KEY, alarmAt);
+          await this.rescheduleRoomAlarm();
         } catch (error) {
           cloudLog("warn", "room.runtime_peer_watch.refresh_failed", {
             notebook_id: notebookId,
@@ -2117,19 +2281,73 @@ export class NotebookRoom {
     );
   }
 
-  /// DurableObject alarm handler. Fires `RUNTIME_PEER_GONE_GRACE_MS` after the
-  /// last `runtime_peer` left. If one has since rejoined, it's a no-op (the blip
-  /// recovered). Otherwise it reconciles the room's authoritative RuntimeStateDoc
-  /// — terminalizing orphaned executions and flipping a phantom-live kernel to
-  /// Error — and broadcasts the corrected state to the surviving peers.
-  async alarm(): Promise<void> {
+  private async rescheduleRoomAlarm(): Promise<void> {
     const storage = this.state.storage;
-    const notebookId = await storage.get<string>(RUNTIME_PEER_WATCH_KEY);
-    if (!notebookId) {
+    if (!storage.setAlarm || !storage.deleteAlarm) {
       return;
     }
-    await storage.delete(RUNTIME_PEER_WATCH_KEY);
 
+    const alarmTimes = [
+      await storage.get<unknown>(RUNTIME_PEER_WATCH_ALARM_AT_KEY),
+      await storage.get<unknown>(ROOM_SUMMARY_REFRESH_ALARM_AT_KEY),
+    ]
+      .filter(isFiniteTimestamp)
+      .sort((left, right) => left - right);
+
+    if (alarmTimes.length === 0) {
+      await storage.deleteAlarm();
+      return;
+    }
+    await storage.setAlarm(alarmTimes[0]);
+  }
+
+  /// DurableObject alarm handler. Fires `RUNTIME_PEER_GONE_GRACE_MS` after the
+  /// last `runtime_peer` left, or periodically while human occupants remain so
+  /// `/api/n` can read a fresh room summary from R2. Each task stores its own
+  /// due time; the single DO alarm always points at the earliest task.
+  async alarm(): Promise<void> {
+    const storage = this.state.storage;
+    const nowMs = Date.now();
+    const runtimeWatch = await this.dueAlarmTask(
+      RUNTIME_PEER_WATCH_KEY,
+      RUNTIME_PEER_WATCH_ALARM_AT_KEY,
+      nowMs,
+    );
+    const roomSummaryRefresh = await this.dueAlarmTask(
+      ROOM_SUMMARY_REFRESH_KEY,
+      ROOM_SUMMARY_REFRESH_ALARM_AT_KEY,
+      nowMs,
+    );
+
+    if (runtimeWatch) {
+      await storage.delete(RUNTIME_PEER_WATCH_KEY);
+      await storage.delete(RUNTIME_PEER_WATCH_ALARM_AT_KEY);
+      await this.handleRuntimePeerWatchAlarm(runtimeWatch);
+    }
+
+    if (roomSummaryRefresh) {
+      await storage.delete(ROOM_SUMMARY_REFRESH_KEY);
+      await storage.delete(ROOM_SUMMARY_REFRESH_ALARM_AT_KEY);
+      await this.publishRoomSummaryNow(roomSummaryRefresh, "refresh_alarm");
+    }
+
+    await this.rescheduleRoomAlarm();
+  }
+
+  private async dueAlarmTask(
+    key: string,
+    alarmAtKey: string,
+    nowMs: number,
+  ): Promise<string | null> {
+    const notebookId = await this.state.storage.get<unknown>(key);
+    if (typeof notebookId !== "string" || notebookId.length === 0) {
+      return null;
+    }
+    const alarmAt = await this.state.storage.get<unknown>(alarmAtKey);
+    return !isFiniteTimestamp(alarmAt) || alarmAt <= nowMs ? notebookId : null;
+  }
+
+  private async handleRuntimePeerWatchAlarm(notebookId: string): Promise<void> {
     if (this.hasRuntimePeer()) {
       cloudLog("info", "room.runtime_peer_watch.recovered", {
         notebook_id: notebookId,
@@ -2295,6 +2513,41 @@ function roomPeerParticipantKey(peer: Peer): string {
     return `anonymous:${peer.id}`;
   }
   return peer.identity.principal;
+}
+
+function isHumanPeer(peer: Peer): boolean {
+  return peer.identity.scope !== "runtime_peer";
+}
+
+// A participant with both a viewer tab and an editor tab is editing, not
+// merely viewing: dedupe keeps the strongest scope.
+function roomSummaryScopeRank(scope: string): number {
+  switch (scope) {
+    case "owner":
+      return 3;
+    case "editor":
+      return 2;
+    case "viewer":
+      return 1;
+    default:
+      return 0;
+  }
+}
+
+function sameStringSet(left: ReadonlySet<string>, right: ReadonlySet<string>): boolean {
+  if (left.size !== right.size) {
+    return false;
+  }
+  for (const value of left) {
+    if (!right.has(value)) {
+      return false;
+    }
+  }
+  return true;
+}
+
+function isFiniteTimestamp(value: unknown): value is number {
+  return typeof value === "number" && Number.isFinite(value);
 }
 
 export function runtimePeerWorkstationMetadataFromRequest(

--- a/apps/notebook-cloud/src/storage.ts
+++ b/apps/notebook-cloud/src/storage.ts
@@ -61,6 +61,20 @@ export interface ListedNotebookRow extends NotebookRow {
   scope: NotebookAclRow["scope"];
 }
 
+export interface NotebookRoomSummaryOccupant {
+  participant_key: string;
+  actor_label: string;
+  display_name?: string;
+  connection_scope: AuthenticatedConnection["scope"];
+}
+
+export interface NotebookRoomSummary {
+  version: 1;
+  notebook_id: string;
+  occupants: NotebookRoomSummaryOccupant[];
+  updated_at: string;
+}
+
 export interface NotebookAclInput {
   notebookId: string;
   subjectKind: NotebookAclRow["subject_kind"];
@@ -425,6 +439,10 @@ export function commsDocSnapshotKey(runtimeStateDocId: string, headsHash: string
 
 export function blobKey(notebookId: string, hash: string): string {
   return `n/${encodePathComponent(notebookId)}/blobs/${encodePathComponent(hash)}`;
+}
+
+export function roomSummaryKey(notebookId: string): string {
+  return `n/${encodePathComponent(notebookId)}/room-summary.json`;
 }
 
 export async function ensureCatalogSchema(env: Env): Promise<void> {

--- a/apps/notebook-cloud/test/notebook-dashboard.test.ts
+++ b/apps/notebook-cloud/test/notebook-dashboard.test.ts
@@ -46,7 +46,9 @@ describe("cloud notebook dashboard projection", () => {
       identityLabel: null,
       notebook: newOwner,
       ownerInitials: "AL",
-      ownerLabel: "alice",
+      // Owner-scope rows read "You" (the requester owns them); initials stay
+      // derived from the real identity so the avatar keeps meaning.
+      ownerLabel: "You",
       runtimeStatus: "none",
     });
     assert.deepEqual(
@@ -634,7 +636,7 @@ describe("cloud notebook dashboard projection", () => {
     assert.equal(generatedView.sections[0]?.overflowAction, null);
   });
 
-  it("surfaces active compute as a row fact and drill-in filter", () => {
+  it("surfaces active notebooks from compute and editing peers", () => {
     const active = notebook({
       id: "topic-viz",
       title: "Topic Visualization",
@@ -664,16 +666,32 @@ describe("cloud notebook dashboard projection", () => {
       updatedAt: "2026-06-22T00:00:00.000Z",
       latestRevisionId: null,
     });
+    const editing = notebook({
+      id: "shared-edit",
+      title: "Shared Edit",
+      scope: "editor",
+      updatedAt: "2026-06-21T00:00:00.000Z",
+      latestRevisionId: null,
+      peers: [
+        {
+          participant_key: "user:dev:bob",
+          actor_label: "user:dev:bob/browser:tab",
+          display_name: "Bob",
+          connection_scope: "editor",
+        },
+      ],
+    });
 
-    const model = projectCloudNotebookDashboard([idle, active]);
+    const model = projectCloudNotebookDashboard([idle, active, editing]);
     const computeView = projectCloudNotebookDashboardView(model, { filterId: "compute" });
 
     assert.deepEqual(
       model.filters.map((filter) => [filter.id, filter.count]),
       [
-        ["all", 2],
+        ["all", 3],
         ["owned", 2],
-        ["compute", 1],
+        ["shared", 1],
+        ["compute", 2],
       ],
     );
     assert.deepEqual(model.continueRow?.facts, [
@@ -691,7 +709,7 @@ describe("cloud notebook dashboard projection", () => {
         section.title,
         section.notebooks.map((item) => item.notebook_id),
       ]),
-      [["compute", "Active compute", ["topic-viz"]]],
+      [["compute", "Active now", ["topic-viz", "shared-edit"]]],
     );
   });
 
@@ -713,6 +731,63 @@ describe("cloud notebook dashboard projection", () => {
 
     assert.equal(model.continueRow?.notebook.language, "deno");
     assert.deepEqual(model.continueRow?.composition, { code: 2, markdown: 1, raw: 0 });
+  });
+
+  it("prefers the unified-profile owner display over the raw principal", () => {
+    const shared = notebook({
+      id: "shared-notebook",
+      title: "Shared Notebook",
+      scope: "viewer",
+      updatedAt: "2026-06-24T00:00:00.000Z",
+      latestRevisionId: null,
+    });
+    const withDisplay = { ...shared, owner_display: "Mara Osei" };
+
+    assert.equal(isCloudNotebookListItem(withDisplay), true);
+    assert.equal(isCloudNotebookListItem({ ...shared, owner_display: 42 }), false);
+
+    const model = projectCloudNotebookDashboard([withDisplay]);
+    assert.equal(model.continueRow?.ownerLabel, "Mara Osei");
+    assert.equal(model.continueRow?.ownerInitials, "MO");
+
+    // Without a profile display, the principal-derived fallback still applies.
+    const fallback = projectCloudNotebookDashboard([shared]);
+    assert.notEqual(fallback.continueRow?.ownerLabel, "Mara Osei");
+  });
+
+  it("threads room peers through list-item validation and active filtering", () => {
+    const withPeers = notebook({
+      id: "presence-notebook",
+      title: "Presence Notebook",
+      scope: "owner",
+      updatedAt: "2026-06-24T00:00:00.000Z",
+      latestRevisionId: null,
+      peers: [
+        {
+          participant_key: "user:dev:bob",
+          actor_label: "user:dev:bob/browser:tab",
+          display_name: "Bob",
+          connection_scope: "editor",
+        },
+      ],
+    });
+
+    assert.equal(isCloudNotebookListItem(withPeers), true);
+    assert.equal(
+      isCloudNotebookListItem({
+        ...withPeers,
+        peers: [{ participant_key: "user:dev:bob", actor_label: 42, connection_scope: "editor" }],
+      }),
+      false,
+    );
+
+    const view = projectCloudNotebookDashboardView(projectCloudNotebookDashboard([withPeers]), {
+      filterId: "compute",
+    });
+    assert.deepEqual(
+      view.sections.map((section) => [section.id, section.notebooks[0]?.notebook_id]),
+      [["compute", "presence-notebook"]],
+    );
   });
 
   it("threads notebook cover through list-item validation and dashboard rows", () => {
@@ -815,6 +890,7 @@ function notebook(input: {
   composition?: CloudNotebookListItem["composition"];
   cover?: CloudNotebookListItem["cover"];
   language?: string;
+  peers?: CloudNotebookListItem["peers"];
 }): CloudNotebookListItem {
   return {
     notebook_id: input.id,
@@ -828,6 +904,7 @@ function notebook(input: {
     ...(input.composition ? { composition: input.composition } : {}),
     ...(input.cover ? { cover: input.cover } : {}),
     ...(input.language ? { language: input.language } : {}),
+    ...(input.peers ? { peers: input.peers } : {}),
     viewer_url: `/n/${input.id}/notebook`,
     endpoints: {
       catalog: `/api/n/${input.id}`,

--- a/apps/notebook-cloud/test/notebook-room.test.ts
+++ b/apps/notebook-cloud/test/notebook-room.test.ts
@@ -35,6 +35,7 @@ import {
 } from "../src/protocol.ts";
 import { decodePresenceFrame, encodePresenceFrame } from "../src/runtimed-wasm.ts";
 import type { RoomHostFrameResult } from "../src/room-materializer.ts";
+import { roomSummaryKey, type NotebookRoomSummary } from "../src/storage.ts";
 import { initializeTestRuntimedWasm } from "./runtimed-wasm-test-loader.ts";
 
 before(async () => {
@@ -3691,6 +3692,180 @@ describe("NotebookRoom runtime_peer-gone watchdog", () => {
   });
 });
 
+describe("NotebookRoom room summary", () => {
+  function summaryPeer(
+    id: string,
+    user: string,
+    scope: "viewer" | "editor" | "owner" | "runtime_peer",
+    options: { operator?: string; displayName?: string } = {},
+  ): PeerForTest {
+    const operator = options.operator ?? `browser:${id}`;
+    const identity = authenticateDevRequest(
+      new Request(
+        `https://cloud.test/n/demo/sync?user=${user}&operator=${operator}&scope=${scope}`,
+      ),
+    );
+    return {
+      id,
+      socket: new FakeSocket().asCloudflareWebSocket(),
+      identity: {
+        ...identity,
+        metadata: {
+          ...identity.metadata,
+          ...(options.displayName ? { displayName: options.displayName } : {}),
+        },
+      },
+      connectedAt: "2026-06-05T00:00:00.000Z",
+    };
+  }
+
+  it("writes deduped human occupants and ignores runtime peers", async () => {
+    const state = alarmCapableState();
+    const bucket = new FakeRoomSummaryBucket();
+    const room = new NotebookRoom(state.state, { NOTEBOOK_SNAPSHOTS: bucket } as Env);
+    const harness = roomHarness(room);
+
+    const beforeAlice = harness.roomSummaryOccupantKeys();
+    harness.peers.set(
+      "alice-a",
+      summaryPeer("alice-a", "alice", "owner", {
+        displayName: "Alice Demo",
+        operator: "browser:a",
+      }),
+    );
+    harness.publishRoomSummaryIfHumanOccupantsChanged("demo", beforeAlice, "peer_joined");
+    await state.drain();
+
+    assert.deepEqual(bucket.summary("demo").occupants, [
+      {
+        participant_key: "user:dev:alice",
+        actor_label: "user:dev:alice/browser:a",
+        display_name: "Alice Demo",
+        connection_scope: "owner",
+      },
+    ]);
+    assert.equal(await state.getAlarm(), state.now + 60_000);
+    const putsAfterAlice = bucket.puts.length;
+
+    const beforeDuplicate = harness.roomSummaryOccupantKeys();
+    harness.peers.set(
+      "alice-b",
+      summaryPeer("alice-b", "alice", "editor", { operator: "browser:b" }),
+    );
+    harness.publishRoomSummaryIfHumanOccupantsChanged("demo", beforeDuplicate, "peer_joined");
+    await state.drain();
+    assert.equal(bucket.puts.length, putsAfterAlice, "same participant does not rewrite summary");
+
+    const beforeRuntime = harness.roomSummaryOccupantKeys();
+    harness.peers.set("runtime", summaryPeer("runtime", "alice", "runtime_peer"));
+    harness.publishRoomSummaryIfHumanOccupantsChanged("demo", beforeRuntime, "peer_joined");
+    await state.drain();
+    assert.equal(bucket.puts.length, putsAfterAlice, "runtime peer does not rewrite summary");
+
+    const beforeBob = harness.roomSummaryOccupantKeys();
+    harness.peers.set("bob", summaryPeer("bob", "bob", "editor", { displayName: "Bob Editor" }));
+    harness.publishRoomSummaryIfHumanOccupantsChanged("demo", beforeBob, "peer_joined");
+    await state.drain();
+
+    assert.deepEqual(
+      bucket
+        .summary("demo")
+        .occupants.map((occupant) => [
+          occupant.participant_key,
+          occupant.display_name ?? null,
+          occupant.connection_scope,
+        ]),
+      [
+        ["user:dev:alice", "Alice Demo", "owner"],
+        ["user:dev:bob", "Bob Editor", "editor"],
+      ],
+    );
+  });
+
+  it("writes an empty summary and disarms refresh when the occupant set empties", async () => {
+    const state = alarmCapableState();
+    const bucket = new FakeRoomSummaryBucket();
+    const room = new NotebookRoom(state.state, { NOTEBOOK_SNAPSHOTS: bucket } as Env);
+    const harness = roomHarness(room);
+    harness.materializers.set("demo", {
+      receiveFrame: async () => noopMaterializedResult(),
+      checkpoint: async () => undefined,
+      removePeer: async () => undefined,
+    } as never);
+
+    const firstAlice = summaryPeer("alice-a", "alice", "owner");
+    const secondAlice = summaryPeer("alice-b", "alice", "owner", { operator: "browser:b" });
+    harness.peers.set(firstAlice.id, firstAlice);
+    harness.peers.set(secondAlice.id, secondAlice);
+    harness.publishRoomSummary("demo", "peer_joined");
+    await state.drain();
+    const putsAfterInitial = bucket.puts.length;
+
+    harness.removePeer("demo", firstAlice);
+    await state.drain();
+    assert.equal(bucket.puts.length, putsAfterInitial, "remaining tab keeps occupant set stable");
+
+    harness.removePeer("demo", secondAlice);
+    await state.drain();
+    assert.deepEqual(bucket.summary("demo").occupants, []);
+    assert.equal(await state.getAlarm(), null);
+  });
+
+  it("publishes and re-arms the summary on refresh alarms", async () => {
+    const state = alarmCapableState();
+    const bucket = new FakeRoomSummaryBucket();
+    const room = new NotebookRoom(state.state, { NOTEBOOK_SNAPSHOTS: bucket } as Env);
+    const harness = roomHarness(room);
+    harness.peers.set("alice", summaryPeer("alice", "alice", "owner"));
+    harness.publishRoomSummary("demo", "peer_joined");
+    await state.drain();
+    const putsAfterInitial = bucket.puts.length;
+
+    await state.state.storage.put("room_summary_refresh", "demo");
+    await state.state.storage.put("room_summary_refresh_alarm_at", 0);
+    await (room as unknown as { alarm(): Promise<void> }).alarm();
+    await state.drain();
+
+    assert.equal(bucket.puts.length, putsAfterInitial + 1);
+    assert.notEqual(await state.getAlarm(), null);
+  });
+
+  it("restores hibernated human peers into the room summary and refresh alarm", async () => {
+    const socket = new FakeSocket();
+    const identity = authenticateDevRequest(
+      new Request("https://cloud.test/n/demo/sync?user=carol&operator=browser:c&scope=editor"),
+    );
+    socket.serializeAttachment({
+      notebookId: "demo",
+      peerId: "carol",
+      identity: {
+        ...identity,
+        metadata: {
+          ...identity.metadata,
+          displayName: "Carol Editor",
+        },
+      },
+      connectedAt: "2026-06-05T00:00:00.000Z",
+      workstation: null,
+    });
+    const state = alarmCapableState([socket.asCloudflareWebSocket()]);
+    const bucket = new FakeRoomSummaryBucket();
+
+    new NotebookRoom(state.state, { NOTEBOOK_SNAPSHOTS: bucket } as Env);
+    await state.drain();
+
+    assert.deepEqual(bucket.summary("demo").occupants, [
+      {
+        participant_key: "user:dev:carol",
+        actor_label: "user:dev:carol/browser:c",
+        display_name: "Carol Editor",
+        connection_scope: "editor",
+      },
+    ]);
+    assert.equal(await state.getAlarm(), state.now + 60_000);
+  });
+});
+
 type PeerForTest = {
   id: string;
   socket: CloudflareWebSocket;
@@ -3723,6 +3898,16 @@ interface RoomHarness {
     }
   >;
   refreshRuntimePeerWatch?(notebookId: string): void;
+  roomSummaryOccupantKeys(): Set<string>;
+  publishRoomSummaryIfHumanOccupantsChanged(
+    notebookId: string,
+    previousOccupantKeys: ReadonlySet<string>,
+    reason: "peer_joined" | "peer_left",
+  ): void;
+  publishRoomSummary(
+    notebookId: string,
+    reason: "peer_joined" | "peer_left" | "hibernation_restore" | "refresh_alarm",
+  ): void;
   runtimePeerAuthorityError?(
     notebookId: string,
     workstation: PeerForTest["workstation"],
@@ -3783,6 +3968,35 @@ function roomEnvWithComputeIndex(
     },
     OWNER_COMPUTE_INDEX: computeIndex,
   } as Env;
+}
+
+class FakeRoomSummaryBucket {
+  readonly objects = new Map<string, string>();
+  readonly puts: Array<{ key: string; value: string }> = [];
+
+  summary(notebookId: string): NotebookRoomSummary {
+    const value = this.objects.get(roomSummaryKey(notebookId));
+    assert.ok(value, `expected room summary for ${notebookId}`);
+    return JSON.parse(value) as NotebookRoomSummary;
+  }
+
+  async get(): Promise<null> {
+    return null;
+  }
+
+  async head(): Promise<null> {
+    return null;
+  }
+
+  async put(key: string, value: string): Promise<never> {
+    this.objects.set(key, value);
+    this.puts.push({ key, value });
+    return { key } as never;
+  }
+
+  async delete(key: string): Promise<void> {
+    this.objects.delete(key);
+  }
 }
 
 interface FakeOwnerComputeIndexRequest {
@@ -3995,7 +4209,7 @@ function hibernatedState(sockets: CloudflareWebSocket[]): {
 /// a `drain()` that awaits everything passed to `waitUntil` (so the watchdog's
 /// fire-and-forget arm/disarm work completes before assertions). `now` is fixed
 /// so the armed alarm time is predictable in tests.
-function alarmCapableState(): {
+function alarmCapableState(sockets: CloudflareWebSocket[] = []): {
   state: DurableObjectState;
   now: number;
   getAlarm(): Promise<number | null>;
@@ -4022,6 +4236,7 @@ function alarmCapableState(): {
         alarmAt = null;
       },
     },
+    getWebSockets: () => sockets,
     waitUntil: (promise: Promise<unknown>) => {
       pending.push(promise.catch(() => undefined));
     },

--- a/apps/notebook-cloud/test/worker-routes.test.ts
+++ b/apps/notebook-cloud/test/worker-routes.test.ts
@@ -38,6 +38,7 @@ import {
   createNotebookWithOwnerAcl,
   getNotebookAclRows,
   getNotebookAclRowsForPrincipal,
+  roomSummaryKey,
   runtimeStateSnapshotKey,
   runCatalogMigrations,
   snapshotKey,
@@ -648,6 +649,24 @@ describe("Worker artifact routes", () => {
       scope: "owner",
     });
     const cookie = await oidcAppSessionCookie(env, token);
+    // A live peer in the room: their identity must not leak into served HTML
+    // any more than the requester's does (presence rides the API, not SSR).
+    await env.NOTEBOOK_SNAPSHOTS.put(
+      roomSummaryKey("bootstrap-visible"),
+      JSON.stringify({
+        version: 1,
+        notebook_id: "bootstrap-visible",
+        updated_at: "2999-01-01T00:00:00.000Z",
+        occupants: [
+          {
+            participant_key: "user:anaconda:peer-person",
+            actor_label: "user:anaconda:peer-person/browser:tab",
+            display_name: "Peer Person",
+            connection_scope: "editor",
+          },
+        ],
+      }),
+    );
 
     const response = await worker.fetch(
       new Request("https://cloud.test/n", {
@@ -668,7 +687,10 @@ describe("Worker artifact routes", () => {
     assert.equal(typeof bootstrap.session?.expires_at, "number");
     assert.equal(typeof bootstrap.session?.cache_key, "string");
     assert.doesNotMatch(html, new RegExp(token.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")));
-    assert.doesNotMatch(html, /bootstrap@example\.test|bootstrap-user|Bootstrap User/);
+    assert.doesNotMatch(
+      html,
+      /bootstrap@example\.test|bootstrap-user|Bootstrap User|Peer Person|peer-person/,
+    );
   });
 
   it("keeps authenticated notebook home bootstrap free of notebook route asset hints", async () => {
@@ -2048,6 +2070,129 @@ describe("Worker artifact routes", () => {
       compute.requests.map((request) => [request.objectName, request.notebookIds]),
       [["owner-compute:v1:user:dev:alice", ["owned-active"]]],
     );
+  });
+
+  it("hydrates fresh room presence and excludes stale, runtime, and requester occupants", async () => {
+    const env = fakeEnv();
+    seedNotebook(env, "fresh-presence");
+    seedNotebook(env, "stale-presence");
+    seedAcl(env, { notebookId: "fresh-presence", subject: "user:dev:alice", scope: "owner" });
+    seedAcl(env, { notebookId: "stale-presence", subject: "user:dev:alice", scope: "owner" });
+    await env.NOTEBOOK_SNAPSHOTS.put(
+      roomSummaryKey("fresh-presence"),
+      JSON.stringify({
+        version: 1,
+        notebook_id: "fresh-presence",
+        updated_at: "2999-01-01T00:00:00.000Z",
+        occupants: [
+          {
+            participant_key: "user:dev:alice",
+            actor_label: "user:dev:alice/desktop:test",
+            display_name: "Alice",
+            connection_scope: "owner",
+          },
+          {
+            participant_key: "user:dev:bob",
+            actor_label: "user:dev:bob/browser:tab",
+            display_name: "Bob",
+            connection_scope: "editor",
+          },
+          {
+            participant_key: "user:dev:alice-runtime",
+            actor_label: "user:dev:alice/runtime:py",
+            display_name: "Python",
+            connection_scope: "runtime_peer",
+          },
+        ],
+      }),
+    );
+    await env.NOTEBOOK_SNAPSHOTS.put(
+      roomSummaryKey("stale-presence"),
+      JSON.stringify({
+        version: 1,
+        notebook_id: "stale-presence",
+        updated_at: "2000-01-01T00:00:00.000Z",
+        occupants: [
+          {
+            participant_key: "user:dev:bob",
+            actor_label: "user:dev:bob/browser:tab",
+            display_name: "Bob",
+            connection_scope: "editor",
+          },
+        ],
+      }),
+    );
+
+    const response = await worker.fetch(
+      new Request("http://localhost/api/n", {
+        headers: {
+          "X-User": "alice",
+          "X-Operator": "desktop:test",
+          "X-Scope": "viewer",
+        },
+      }),
+      env,
+      fakeContext(),
+    );
+
+    assert.equal(response.status, 200);
+    const body = (await response.json()) as {
+      notebooks: Array<{
+        notebook_id: string;
+        peers?: Array<{
+          participant_key: string;
+          actor_label: string;
+          display_name?: string;
+          connection_scope: string;
+        }>;
+      }>;
+    };
+    assert.deepEqual(
+      body.notebooks.find((notebook) => notebook.notebook_id === "fresh-presence")?.peers,
+      [
+        {
+          participant_key: "user:dev:bob",
+          actor_label: "user:dev:bob/browser:tab",
+          display_name: "Bob",
+          connection_scope: "editor",
+        },
+      ],
+    );
+    assert.equal(
+      Object.hasOwn(
+        body.notebooks.find((notebook) => notebook.notebook_id === "stale-presence") ?? {},
+        "peers",
+      ),
+      false,
+    );
+  });
+
+  it("caps room presence hydration and fails open on R2 read errors", async () => {
+    const snapshots = new FailingGetR2Bucket();
+    const env = fakeEnv({ NOTEBOOK_SNAPSHOTS: snapshots });
+    for (let index = 0; index < 205; index += 1) {
+      const notebookId = `presence-${String(index).padStart(3, "0")}`;
+      seedNotebook(env, notebookId);
+      seedAcl(env, { notebookId, subject: "user:dev:alice", scope: "owner" });
+    }
+    snapshots.failNextGet = true;
+
+    const response = await worker.fetch(
+      new Request("http://localhost/api/n?limit=205", {
+        headers: {
+          "X-User": "alice",
+          "X-Operator": "desktop:test",
+          "X-Scope": "viewer",
+        },
+      }),
+      env,
+      fakeContext(),
+    );
+
+    assert.equal(response.status, 200);
+    const body = (await response.json()) as { notebooks: unknown[] };
+    assert.equal(body.notebooks.length, 205);
+    assert.equal(snapshots.getKeys.length, 200);
   });
 
   it("requires sign-in before listing notebooks", async () => {
@@ -8927,6 +9072,19 @@ class FakeR2Bucket implements R2Bucket {
 
   async delete(key: string): Promise<void> {
     this.objects.delete(key);
+  }
+}
+
+class FailingGetR2Bucket extends FakeR2Bucket {
+  failNextGet = false;
+
+  override async get(key: string): Promise<R2ObjectBody | null> {
+    this.getKeys.push(key);
+    if (this.failNextGet) {
+      this.failNextGet = false;
+      throw new Error("R2 unavailable");
+    }
+    return this.objects.get(key) ?? null;
   }
 }
 

--- a/apps/notebook-cloud/viewer/cloud-notebook-dashboard-view.tsx
+++ b/apps/notebook-cloud/viewer/cloud-notebook-dashboard-view.tsx
@@ -1,4 +1,4 @@
-import { useMemo, useState, type FormEvent } from "react";
+import { useMemo, useState, type CSSProperties, type FormEvent } from "react";
 import {
   ArrowRight,
   BookOpen,
@@ -31,7 +31,14 @@ import {
   type CloudNotebookDashboardRow,
   type CloudNotebookDashboardSection,
   type CloudNotebookListItem,
+  type CloudNotebookPresencePeer,
 } from "./notebook-dashboard";
+import {
+  cloudPresenceColor,
+  cloudPresenceContrastColor,
+  cloudPresenceInitials,
+  cloudVisiblePeerLabel,
+} from "./presence";
 
 interface CloudNotebookDashboardRenameState {
   notebookId: string;
@@ -73,7 +80,7 @@ export function CloudNotebookDashboard({
   );
   const continued = view.filterId === "all" && view.query.length === 0 ? model.continueRow : null;
   const totalCount = model.notebooks.length;
-  const computeCount = model.filters.find((filter) => filter.id === "compute")?.count ?? 0;
+  const activeCount = model.filters.find((filter) => filter.id === "compute")?.count ?? 0;
   const hasNoMatches = !continued && view.sections.length === 0;
 
   const clearFocus = () => {
@@ -87,7 +94,7 @@ export function CloudNotebookDashboard({
         <div>
           <h1>Notebooks</h1>
           <p>
-            {totalCount} notebook{totalCount === 1 ? "" : "s"} · {computeCount} active compute
+            {totalCount} notebook{totalCount === 1 ? "" : "s"} · {activeCount} active now
           </p>
         </div>
         {view.showResultCount ? (
@@ -197,7 +204,7 @@ function CloudNotebookDashboardHero({
 }) {
   const notebook = row.notebook;
   const openUrl = cloudNotebookDashboardOpenUrl(notebook);
-  const runtimeActive = cloudNotebookRuntimeIsActive(row);
+  const activeNow = cloudNotebookIsActiveNow(row);
   const runtimeLanguage =
     cloudNotebookLanguageDisplayLabel(notebook.language) ??
     (row.environmentLabel
@@ -210,7 +217,7 @@ function CloudNotebookDashboardHero({
 
   return (
     <section
-      className={`nb-hero${runtimeActive ? " is-live" : ""}`}
+      className={`nb-hero${activeNow ? " is-live" : ""}`}
       aria-label="Pick up where you left off"
     >
       {row.environmentLabel && runtimeLanguage ? (
@@ -222,7 +229,7 @@ function CloudNotebookDashboardHero({
       <div className="nb-hero-top">
         <div className="nb-hero-body">
           <div className="nb-hero-eyebrow">
-            {runtimeActive ? "Pick up where you left off" : "Jump back in"}
+            {activeNow ? "Pick up where you left off" : "Jump back in"}
           </div>
           <h2 className="nb-hero-title">{cloudNotebookDisplayTitle(notebook)}</h2>
           <div className="nb-hero-meta">
@@ -239,6 +246,7 @@ function CloudNotebookDashboardHero({
                 {cellCount} cells
               </span>
             ) : null}
+            <CloudNotebookPresenceStack peers={notebook.peers} />
           </div>
           {row.composition ? (
             <NotebookCompositionTicks composition={row.composition} className="nb-hero-fp" />
@@ -247,7 +255,7 @@ function CloudNotebookDashboardHero({
         <div className="nb-hero-side">
           <Button asChild className="nb-hero-open">
             <a href={openUrl} onFocus={onOpenNotebookIntent} onPointerEnter={onOpenNotebookIntent}>
-              {runtimeActive ? (
+              {activeNow ? (
                 <>
                   <Play aria-hidden="true" />
                   Resume
@@ -431,14 +439,14 @@ function CloudNotebookDashboardRowView({
   const openUrl = cloudNotebookDashboardOpenUrl(notebook);
   const hasTitle = Boolean(notebook.title?.trim());
   const cellCount = row.composition ? notebookCompositionTotal(row.composition) : null;
-  const runtimeActive = cloudNotebookRuntimeIsActive(row);
+  const activeNow = cloudNotebookIsActiveNow(row);
   // The compute fact carries the rich label ("lab2 workstation running, 1 queued");
   // the column shows the calm dot + terse status, the full label rides title/aria.
   const computeFact = row.facts.find((fact) => fact.kind === "compute") ?? null;
   const languageLabel = cloudNotebookLanguageDisplayLabel(notebook.language);
 
   return (
-    <div className={`nb-row${runtimeActive ? " is-live" : ""}`} data-scope={notebook.scope}>
+    <div className={`nb-row${activeNow ? " is-live" : ""}`} data-scope={notebook.scope}>
       <a
         className="nb-row-lead"
         href={openUrl}
@@ -477,6 +485,7 @@ function CloudNotebookDashboardRowView({
           <RuntimeStatusDot status={row.runtimeStatus} showLabel />
         ) : null}
       </span>
+      <CloudNotebookPresenceStack peers={notebook.peers} />
       <span className="nb-col nb-col-updated">
         <Clock aria-hidden="true" />
         {formatNotebookUpdatedAt(notebook.updated_at)}
@@ -517,6 +526,45 @@ function CloudNotebookDashboardRowView({
       </span>
     </div>
   );
+}
+
+function CloudNotebookPresenceStack({ peers }: { peers?: readonly CloudNotebookPresencePeer[] }) {
+  if (!peers?.length) {
+    return <span className="nb-col nb-col-peers" aria-hidden="true" />;
+  }
+
+  const visiblePeers = peers.slice(0, 3);
+  const hiddenCount = Math.max(0, peers.length - visiblePeers.length);
+  const label =
+    peers.length === 1
+      ? `${cloudNotebookPresencePeerLabel(peers[0]!)} editing now`
+      : `${peers.length} people editing now`;
+
+  return (
+    <span className="nb-col nb-col-peers" aria-label={label} title={label}>
+      <span className="nb-peers" aria-hidden="true">
+        {visiblePeers.map((peer) => {
+          const actorColorKey = peer.actor_label || peer.participant_key;
+          const style = {
+            "--nb-peer-bg": cloudPresenceColor(actorColorKey),
+            "--nb-peer-fg": cloudPresenceContrastColor(actorColorKey),
+          } as CSSProperties;
+          const peerLabel = cloudNotebookPresencePeerLabel(peer);
+          return (
+            <span key={peer.participant_key} className="nb-peer" style={style} title={peerLabel}>
+              {cloudPresenceInitials(peerLabel)}
+            </span>
+          );
+        })}
+        {hiddenCount > 0 ? <span className="nb-peer nb-peer-more">+{hiddenCount}</span> : null}
+      </span>
+      <span className="nb-peers-label">editing now</span>
+    </span>
+  );
+}
+
+function cloudNotebookPresencePeerLabel(peer: CloudNotebookPresencePeer): string {
+  return cloudVisiblePeerLabel(peer.display_name, peer.actor_label);
 }
 
 function CloudNotebookCoverTile({ notebook }: { notebook: CloudNotebookListItem }) {
@@ -625,11 +673,12 @@ function cloudNotebookScopeLabel(notebook: CloudNotebookListItem): string | null
   }
 }
 
-function cloudNotebookRuntimeIsActive(row: CloudNotebookDashboardRow): boolean {
+function cloudNotebookIsActiveNow(row: CloudNotebookDashboardRow): boolean {
   return (
     row.runtimeStatus === "executing" ||
     row.runtimeStatus === "ready" ||
-    row.runtimeStatus === "starting"
+    row.runtimeStatus === "starting" ||
+    Boolean(row.notebook.peers?.length)
   );
 }
 

--- a/apps/notebook-cloud/viewer/cloud-viewer-types.ts
+++ b/apps/notebook-cloud/viewer/cloud-viewer-types.ts
@@ -24,6 +24,8 @@ export type ViewerRuntimeState =
 export interface CloudNotebookListResponse {
   ok: boolean;
   notebooks: CloudNotebookListItem[];
+  /** Requester's unified-profile display name, when the store has one. */
+  current_user_display?: string;
 }
 
 export interface CloudNotebookListBootstrap {

--- a/apps/notebook-cloud/viewer/index.css
+++ b/apps/notebook-cloud/viewer/index.css
@@ -1356,7 +1356,7 @@ body {
 .nb-row {
   position: relative;
   display: grid;
-  grid-template-columns: minmax(180px, 1fr) 124px 96px 128px 150px minmax(118px, auto) 72px;
+  grid-template-columns: minmax(180px, 1fr) 124px 96px 128px 116px 150px minmax(118px, auto) 72px;
   align-items: center;
   min-height: 68px;
   column-gap: 14px;
@@ -1525,6 +1525,50 @@ body {
 
 .nb-col-badges {
   gap: 8px;
+}
+
+.nb-col-peers {
+  min-width: 0;
+  gap: 7px;
+}
+
+.nb-peers {
+  display: inline-flex;
+  align-items: center;
+  min-width: 0;
+}
+
+.nb-peer {
+  display: inline-grid;
+  width: 24px;
+  height: 24px;
+  place-items: center;
+  border: 1px solid var(--background);
+  border-radius: 999px;
+  background: var(--nb-peer-bg, color-mix(in srgb, var(--foreground) 12%, var(--background)));
+  color: var(--nb-peer-fg, var(--foreground));
+  font-size: 10px;
+  font-weight: 700;
+  line-height: 1;
+  letter-spacing: 0;
+}
+
+.nb-peer + .nb-peer {
+  margin-left: -7px;
+}
+
+.nb-peer-more {
+  background: color-mix(in srgb, var(--background) 88%, var(--foreground) 12%);
+  color: color-mix(in srgb, var(--foreground) 76%, transparent);
+}
+
+.nb-peers-label {
+  overflow: hidden;
+  color: color-mix(in srgb, var(--foreground) 62%, transparent);
+  font-size: 11.5px;
+  font-weight: 600;
+  text-overflow: ellipsis;
+  white-space: nowrap;
 }
 
 .nb-row-actions,
@@ -1815,6 +1859,7 @@ body {
   .nb-col-owner,
   .nb-col-lang,
   .nb-col-status,
+  .nb-col-peers,
   .nb-col-badges {
     display: none;
   }

--- a/apps/notebook-cloud/viewer/notebook-dashboard.ts
+++ b/apps/notebook-cloud/viewer/notebook-dashboard.ts
@@ -13,10 +13,12 @@ export interface CloudNotebookListItem {
   created_at: string;
   updated_at: string;
   latest_revision_id: string | null;
+  owner_display?: string;
   compute_session?: NotebookComputeSessionSummary | null;
   composition?: CloudNotebookComposition;
   cover?: CloudNotebookCover;
   language?: string;
+  peers?: CloudNotebookPresencePeer[];
   viewer_url: string;
   endpoints: {
     catalog: string;
@@ -34,6 +36,13 @@ export interface CloudNotebookComposition {
 export interface CloudNotebookCover {
   blob_hash: string;
   mime: "image/png" | "image/jpeg" | "image/svg+xml";
+}
+
+export interface CloudNotebookPresencePeer {
+  participant_key: string;
+  actor_label: string;
+  display_name?: string;
+  connection_scope: "viewer" | "editor" | "owner" | "runtime_peer";
 }
 
 export type CloudNotebookDashboardRuntimeStatus =
@@ -301,11 +310,30 @@ export function isCloudNotebookListItem(value: unknown): value is CloudNotebookL
     (candidate.composition === undefined || isCloudNotebookComposition(candidate.composition)) &&
     (candidate.cover === undefined || isCloudNotebookCover(candidate.cover)) &&
     (candidate.language === undefined || typeof candidate.language === "string") &&
+    (candidate.owner_display === undefined || typeof candidate.owner_display === "string") &&
+    (candidate.peers === undefined ||
+      (Array.isArray(candidate.peers) && candidate.peers.every(isCloudNotebookPresencePeer))) &&
     typeof candidate.viewer_url === "string" &&
     Boolean(candidate.endpoints) &&
     typeof candidate.endpoints?.catalog === "string" &&
     typeof candidate.endpoints?.acl === "string" &&
     typeof candidate.endpoints?.access_requests === "string"
+  );
+}
+
+function isCloudNotebookPresencePeer(value: unknown): value is CloudNotebookPresencePeer {
+  if (!value || typeof value !== "object") {
+    return false;
+  }
+  const candidate = value as Partial<CloudNotebookPresencePeer>;
+  return (
+    typeof candidate.participant_key === "string" &&
+    typeof candidate.actor_label === "string" &&
+    (candidate.display_name === undefined || typeof candidate.display_name === "string") &&
+    (candidate.connection_scope === "viewer" ||
+      candidate.connection_scope === "editor" ||
+      candidate.connection_scope === "owner" ||
+      candidate.connection_scope === "runtime_peer")
   );
 }
 
@@ -344,7 +372,7 @@ function cloudNotebookDashboardFilters(
 ): CloudNotebookDashboardFilter[] {
   const generatedCount = notebooks.filter(cloudNotebookIsGeneratedRun).length;
   const ownerCount = notebooks.filter((notebook) => notebook.scope === "owner").length;
-  const computeCount = notebooks.filter(cloudNotebookHasComputeSession).length;
+  const activeCount = notebooks.filter(cloudNotebookIsActiveNow).length;
   const publishedCount = notebooks.filter((notebook) =>
     Boolean(notebook.latest_revision_id),
   ).length;
@@ -359,8 +387,8 @@ function cloudNotebookDashboardFilters(
   if (sharedCount > 0) {
     filters.push({ id: "shared", label: "Shared with me", count: sharedCount, group: "work" });
   }
-  if (computeCount > 0) {
-    filters.push({ id: "compute", label: "Compute", count: computeCount, group: "work" });
+  if (activeCount > 0) {
+    filters.push({ id: "compute", label: "Active now", count: activeCount, group: "work" });
   }
   if (publishedCount > 0) {
     filters.push({ id: "published", label: "Published", count: publishedCount, group: "work" });
@@ -559,12 +587,12 @@ function computeNotebookSection(
 ): CloudNotebookDashboardSection {
   return {
     action: null,
-    detail: bucketDetail(notebooks.length, "with compute state"),
+    detail: bucketDetail(notebooks.length, "active now"),
     id: "compute",
     notebooks,
     overflowAction: null,
     rows: dashboardRows(notebooks),
-    title: "Active compute",
+    title: "Active now",
     totalCount: notebooks.length,
   };
 }
@@ -646,7 +674,9 @@ function dashboardRow(notebook: CloudNotebookListItem | null): CloudNotebookDash
   if (!notebook) {
     return null;
   }
-  const ownerLabel = cloudNotebookOwnerLabel(notebook.owner_principal);
+  const ownerDisplaySource =
+    notebook.owner_display?.trim() || cloudNotebookOwnerLabel(notebook.owner_principal);
+  const ownerLabel = notebook.scope === "owner" ? "You" : ownerDisplaySource;
   return {
     ...(notebook.composition ? { composition: notebook.composition } : {}),
     contextLabel: cloudNotebookDashboardRowContextLabel(notebook),
@@ -658,7 +688,7 @@ function dashboardRow(notebook: CloudNotebookListItem | null): CloudNotebookDash
       ? null
       : cloudNotebookShortId(notebook.notebook_id),
     notebook,
-    ownerInitials: cloudNotebookOwnerInitials(ownerLabel),
+    ownerInitials: cloudNotebookOwnerInitials(ownerDisplaySource),
     ownerLabel,
     runtimeStatus: cloudNotebookDashboardRuntimeStatus(notebook),
   };
@@ -747,6 +777,14 @@ function cloudNotebookHasComputeSession(notebook: CloudNotebookListItem): boolea
   return Boolean(notebook.compute_session);
 }
 
+function cloudNotebookHasPresencePeers(notebook: CloudNotebookListItem): boolean {
+  return Boolean(notebook.peers?.length);
+}
+
+function cloudNotebookIsActiveNow(notebook: CloudNotebookListItem): boolean {
+  return cloudNotebookHasComputeSession(notebook) || cloudNotebookHasPresencePeers(notebook);
+}
+
 function isCloudNotebookComposition(value: unknown): value is CloudNotebookComposition {
   if (!value || typeof value !== "object") {
     return false;
@@ -801,7 +839,7 @@ function cloudNotebookMatchesFilter(
     case "shared":
       return notebook.scope !== "owner";
     case "compute":
-      return cloudNotebookHasComputeSession(notebook);
+      return cloudNotebookIsActiveNow(notebook);
     case "published":
       return Boolean(notebook.latest_revision_id);
     case "generated":
@@ -820,6 +858,7 @@ function cloudNotebookMatchesSearch(notebook: CloudNotebookListItem, query: stri
     notebook.latest_revision_id ? "published" : "private",
     cloudNotebookDisplayTitle(notebook),
     notebook.compute_session ? "compute runtime workstation active starting stale" : null,
+    notebook.peers?.length ? "active now editing presence peers" : null,
   ]
     .filter(Boolean)
     .join(" ")
@@ -843,7 +882,7 @@ function cloudNotebookDashboardEmptyMessage(
     case "shared":
       return "No notebooks have been shared with this account.";
     case "compute":
-      return "No notebooks have active compute state.";
+      return "No notebooks are active now.";
     case "published":
       return "No published notebooks yet.";
     case "generated":

--- a/apps/notebook-cloud/viewer/notebook-list-view.tsx
+++ b/apps/notebook-cloud/viewer/notebook-list-view.tsx
@@ -155,6 +155,9 @@ export function CloudNotebookListView({ authConfig }: { authConfig: CloudViewerA
           throw new Error("Unable to list notebooks: response shape was invalid");
         }
         writeCachedCloudNotebookListToWindow(authState, appSessionStatus.session, body.notebooks);
+        if (typeof body.current_user_display === "string" && body.current_user_display.trim()) {
+          setCurrentUserDisplay(body.current_user_display.trim());
+        }
         setListState({ kind: "ready", notebooks: body.notebooks });
       } catch (error) {
         if (controller.signal.aborted) return;
@@ -337,7 +340,12 @@ export function CloudNotebookListView({ authConfig }: { authConfig: CloudViewerA
   };
 
   const headerDetail = cloudNotebookListHeaderDetail(authState, hasAppSession, authConfig);
-  const currentUserInitials = cloudNotebookListCurrentUserInitials(authState);
+  const [currentUserDisplay, setCurrentUserDisplay] = useState<string | null>(null);
+  // Prefer the unified user store's display name (delivered with the list
+  // response) over auth-claim parsing for the header identity.
+  const currentUserInitials = currentUserDisplay
+    ? cloudNotebookInitialsFromLabel(currentUserDisplay)
+    : cloudNotebookListCurrentUserInitials(authState);
 
   return (
     <main className="cloud-notebook-list-page nb-app">
@@ -387,7 +395,7 @@ export function CloudNotebookListView({ authConfig }: { authConfig: CloudViewerA
                   <LogOut aria-hidden="true" />
                   <span className="nb-btn-label">Sign out</span>
                 </Button>
-                <span className="nb-avatar-me" title={headerDetail}>
+                <span className="nb-avatar-me" title={currentUserDisplay ?? headerDetail}>
                   {currentUserInitials}
                 </span>
               </div>
@@ -617,6 +625,10 @@ function cloudNotebookListCurrentUserInitials(authState: CloudPrototypeAuthState
     authState.oidcClaims?.email?.trim() ||
     (authState.mode === "dev" ? authState.user?.trim() : "") ||
     "You";
+  return cloudNotebookInitialsFromLabel(label);
+}
+
+function cloudNotebookInitialsFromLabel(label: string): string {
   const parts = label
     .replace(/[_+.-]+/gu, " ")
     .trim()

--- a/apps/notebook-cloud/viewer/presence.ts
+++ b/apps/notebook-cloud/viewer/presence.ts
@@ -4,6 +4,8 @@ import {
   actorInitials,
   notebookActorIdentityFromProjection,
   notebookActorProjectionFromLabel,
+  colorForActorIdentity,
+  contrastColorForActorIdentity,
 } from "runtimed";
 
 export type CloudViewerPresenceConnection = "connecting" | "connected" | "disconnected";
@@ -362,6 +364,9 @@ export function cloudPresenceRuntimePeerCount(state: CloudViewerPresenceState): 
 }
 
 export const cloudPresenceInitials: (label: string) => string = actorInitials;
+export const cloudPresenceColor: (actorLabel: string) => string = colorForActorIdentity;
+export const cloudPresenceContrastColor: (actorLabel: string) => string =
+  contrastColorForActorIdentity;
 
 export interface CloudFriendlyPeerLabelInput {
   displayName?: string | null;


### PR DESCRIPTION
The last dashboard API wave: list-scale presence (#3881) via the persistent room-summary view on R2, plus the owner-identity cleanup from the preview screenshots (raw principal hashes in the owner column, header initials from auth claims).

## Presence - the R2 room-summary view

**Write side (room DO):** a compact summary at `n/{id}/room-summary.json`, written when the human occupant set *changes* - deduped by participant (keeping the strongest scope across a person's tabs: editor tab + viewer tab = editing), runtime peers excluded, idle rooms write nothing, fire-and-forget so no socket path blocks on R2. Publishes chain per notebook through the same serialization pattern the file already uses for compute-session summaries - the distsys review constructed a leave/join interleaving where unserialized writes landed out of order **and permanently disarmed the refresh alarm**; serialization closes both.

**Liveness:** while occupied, a 60s alarm (multiplexed with the existing runtime watchdog via a shared next-due-task scheduler) re-freshens the summary. Readers treat anything older than 150s as empty - a crashed DO's ghost occupants evaporate in ~2.5 minutes. Hibernation wake recomputes, republishes, rearms.

**Read side:** `GET /api/n` hydrates with bounded parallel R2 GETs (20 concurrent, first 200 rows, fail-open per notebook), requester and runtime peers excluded, max 8 occupants per row. The three hydrations (compute-session DO calls, presence R2 GETs, profile D1 batch) overlap in one `Promise.all` - the perf lens caught them running serially. **No room DO is ever woken by a dashboard load.**

**Client:** the design's peer stack (initials + "+N", "editing now"), colors/initials from the existing in-room presence helpers, and the Active bucket now means what the design says: attached compute OR peers editing.

## Owner identity - the unified store, finally used

The dashboard was bypassing `principal_profiles` entirely (owner column: `b0204af7084b…` + "B0"; header avatar from OIDC claim parsing). Now: the list endpoint batch-fetches profiles for owner principals + the requester (parameterized IN, fail-open), rows carry `owner_display`, the response carries `current_user_display`. Owner columns show real names, your own rows read "You" with identity-derived initials, the header avatar prefers the store's display name.

## A boundary worth knowing about

The SSR bootstrap embedded in served HTML is **PII-free by invariant** (there's a leak-guard test asserting the requester's name/email never appear in the HTML). Profile displays and presence occupant identities therefore ride only the authenticated API response - the bootstrap first paint uses fallback labels for a beat. The leak-guard test now also seeds a *peer's* room summary and asserts their identity stays out of the HTML, pinning the boundary the presence feature could otherwise have eroded.

## Verification

- [x] Cloud tests 1198/1198, cloud + desktop builds, `vp check` clean
- [x] Gated by build-verifier + three adversarial lenses (distributed-systems, security, performance); all findings folded in: publish serialization, hydration parallelism, scope-preserving dedupe, SSR PII boundary, per-row peer cap
- [x] Security re-review on the final diff: clean verdict across identity exposure, requester-exclusion spoofing, scope enforcement at write+read, parameterized queries, R2 key derivation

Closes #3881.
