### PR TITLE
chore(design-sync): sync dashboard atoms (notebook + runtime groups)

### DIFF
--- a/.design-sync/NOTES.md
+++ b/.design-sync/NOTES.md
@@ -88,6 +88,19 @@ passthroughs. Curated list in `synthpkg/build.mjs` (`groups[].dir === 'outputs'`
   markdown-output/math-output. Its `runtimed` imports (`actorInitials`,
   `onBehalfOfText`) still need a tree-shake check at that point.
 
+## Dashboard atoms (groups: notebook, runtime)
+
+- Added 2026-07-02: NotebookCompositionTicks (notebook group), RuntimeStatusDot +
+  LanguageMark (runtime group) - the /n dashboard redesign's prop-driven atoms, shared
+  with the cloud viewer. Their styling lives in `src/styles/dashboard-atoms.css`
+  (extracted FROM apps/notebook-cloud/viewer/index.css, which now @imports it) -
+  the same shared-surface pattern as ansi.css/comment-affordance.css. css-entry
+  @imports it and @sources src/components/runtime + the single
+  NotebookCompositionTicks.tsx (NOT all of components/notebook - NotebookCommentsPanel
+  stays deferred with the katex pass).
+- LanguageMark's Marks story needed cardMode: column (five chips run wide).
+- NotebookCommentsPanel unlock (katex pass) will join the notebook group.
+
 ## Groups + curated lists
 - `cfg.srcDir` is `../../src/components` (broadened from `.../ui`) so grouping resolves
   `cell/` → group `cell` and `ui/` → `general`. Adding a new cell primitive: append it to the

--- a/.design-sync/config.json
+++ b/.design-sync/config.json
@@ -9,23 +9,67 @@
   "buildCmd": "node .design-sync/synthpkg/build.mjs",
   "readmeHeader": ".design-sync/conventions.md",
   "overrides": {
-    "Dialog": { "cardMode": "single", "viewport": "480x340" },
-    "Select": { "cardMode": "single", "viewport": "360x440" },
-    "DropdownMenu": { "cardMode": "single", "viewport": "380x380" },
-    "ContextMenu": { "cardMode": "single", "viewport": "380x360" },
-    "Popover": { "cardMode": "single", "viewport": "380x340" },
-    "HoverCard": { "cardMode": "single", "viewport": "380x280" },
-    "Sheet": { "cardMode": "single", "viewport": "520x420" },
-    "Accordion": { "cardMode": "column" },
-    "Collapsible": { "cardMode": "column" },
-    "Tabs": { "cardMode": "column" },
-    "CellInsertionRibbon": { "cardMode": "column" },
-    "CodeCellCurrentLine": { "cardMode": "column" },
-    "AnsiOutput": { "cardMode": "column" },
-    "AnsiStreamOutput": { "cardMode": "column" },
-    "AnsiErrorOutput": { "cardMode": "column" },
-    "JsonOutput": { "cardMode": "column" },
-    "TracebackOutput": { "cardMode": "column" }
+    "Dialog": {
+      "cardMode": "single",
+      "viewport": "480x340"
+    },
+    "Select": {
+      "cardMode": "single",
+      "viewport": "360x440"
+    },
+    "DropdownMenu": {
+      "cardMode": "single",
+      "viewport": "380x380"
+    },
+    "ContextMenu": {
+      "cardMode": "single",
+      "viewport": "380x360"
+    },
+    "Popover": {
+      "cardMode": "single",
+      "viewport": "380x340"
+    },
+    "HoverCard": {
+      "cardMode": "single",
+      "viewport": "380x280"
+    },
+    "Sheet": {
+      "cardMode": "single",
+      "viewport": "520x420"
+    },
+    "Accordion": {
+      "cardMode": "column"
+    },
+    "Collapsible": {
+      "cardMode": "column"
+    },
+    "Tabs": {
+      "cardMode": "column"
+    },
+    "CellInsertionRibbon": {
+      "cardMode": "column"
+    },
+    "CodeCellCurrentLine": {
+      "cardMode": "column"
+    },
+    "AnsiOutput": {
+      "cardMode": "column"
+    },
+    "AnsiStreamOutput": {
+      "cardMode": "column"
+    },
+    "AnsiErrorOutput": {
+      "cardMode": "column"
+    },
+    "JsonOutput": {
+      "cardMode": "column"
+    },
+    "TracebackOutput": {
+      "cardMode": "column"
+    },
+    "LanguageMark": {
+      "cardMode": "column"
+    }
   },
   "componentSrcMap": {
     "AnsiOutput": "../../src/components/outputs/ansi-output.tsx",

--- a/.design-sync/conventions.md
+++ b/.design-sync/conventions.md
@@ -35,15 +35,20 @@ Do layout with plain Tailwind (`flex`, `gap-2`, `grid`, spacing). Reach for a co
 own `variant`/`size` props before restyling it — e.g. `<Button variant="destructive"
 size="sm">`, `<Badge variant="outline">`.
 
-**Groups.** The library has three groups: the general UI primitives, **Cells** — nteract's
-notebook cell primitives (CellContainer, CellInsertionRibbon, CodeCellCurrentLine,
-CompactExecutionButton, ExecutionCount, CellPresenceIndicators, CellSkeleton), and
-**Comments** — prop-driven comment affordances (CommentSelectionAffordance, CommentMarkIcon).
-The cell primitives are prop-driven: runtime/execution state enters as explicit props (`count`,
-`isExecuting`, `isQueued`, `isErrored`, `cellType`, `isFocused`), never through hooks. Comment
-affordances take author color from `--comment-author-color` and readable label color from
-`--comment-author-contrast`. Use them to assemble notebook surfaces; cell identity and DOM
-ordering stay outside the component.
+**Groups.** Six groups: the **general** UI primitives; **Cells** — notebook cell primitives
+(CellContainer, CellInsertionRibbon, CodeCellCurrentLine, CompactExecutionButton,
+ExecutionCount, CellPresenceIndicators, CellSkeleton); **Outputs** — owned output renderers
+(AnsiOutput, AnsiStreamOutput, AnsiErrorOutput, JsonOutput, TracebackOutput) that take kernel
+output data as props; **Comments** — comment affordances (CommentSelectionAffordance,
+CommentMarkIcon); **Notebook** — NotebookCompositionTicks, the per-cell composition
+fingerprint (`composition={{ code, markdown, raw }}` — those are the only cell kinds); and
+**Runtime** — RuntimeStatusDot (`status`: executing/ready/starting/stale/error/none, optional
+`showLabel`) and LanguageMark (`language`: "Python" renders the real mark, anything else an
+identity dot). Everything is prop-driven: runtime/execution state enters as explicit props
+(`count`, `isExecuting`, `isQueued`, `isErrored`, `cellType`, `isFocused`), never through
+hooks. Comment affordances take author color from `--comment-author-color` and readable label
+color from `--comment-author-contrast`. Use these to assemble notebook and dashboard surfaces;
+cell identity and DOM ordering stay outside the components.
 
 **Compound components** (Dialog, Select, DropdownMenu, ContextMenu, Popover, HoverCard,
 Sheet, Tabs, Accordion, Command, RadioGroup, ToggleGroup) are composed from named subparts

--- a/.design-sync/css-entry.css
+++ b/.design-sync/css-entry.css
@@ -15,11 +15,16 @@
    open/resolved/pending highlight treatments. */
 @import "../src/styles/comment-affordance.css";
 @import "../src/styles/comment-highlight.css";
+/* Dashboard atom vocabulary (composition ticks, runtime dot, language marks) -
+   shared with the cloud dashboard via src/styles/dashboard-atoms.css. */
+@import "../src/styles/dashboard-atoms.css";
 
 @source "../src/components/ui";
 @source "../src/components/cell";
 @source "../src/components/outputs";
 @source "../src/components/comments";
+@source "../src/components/notebook/NotebookCompositionTicks.tsx";
+@source "../src/components/runtime";
 @source "./previews";
 
 /* Safelist the semantic token vocabulary the conventions header documents, so a

--- a/.design-sync/previews/LanguageMark.tsx
+++ b/.design-sync/previews/LanguageMark.tsx
@@ -1,0 +1,39 @@
+import { LanguageMark } from "nteract-elements";
+
+function Chip({ language }: { language: string }) {
+  return (
+    <span
+      className="text-xs text-muted-foreground"
+      style={{ display: "inline-flex", alignItems: "center", gap: 6 }}
+    >
+      <LanguageMark language={language} size={14} />
+      {language}
+    </span>
+  );
+}
+
+// Python gets the real two-tone mark; everything else the identity dot.
+// Today's lineup is Python and Deno/TypeScript - SQL and R dots are ready for
+// when those runtimes land.
+export function Marks() {
+  return (
+    <div style={{ display: "flex", alignItems: "center", gap: 20 }}>
+      <Chip language="Python" />
+      <Chip language="Deno" />
+      <Chip language="TypeScript" />
+      <Chip language="SQL" />
+      <Chip language="R" />
+    </div>
+  );
+}
+
+export function Sizes() {
+  return (
+    <div style={{ display: "flex", alignItems: "end", gap: 14 }}>
+      <LanguageMark language="Python" size={12} />
+      <LanguageMark language="Python" size={16} />
+      <LanguageMark language="Python" size={24} />
+      <LanguageMark language="Python" size={32} />
+    </div>
+  );
+}

--- a/.design-sync/previews/NotebookCompositionTicks.tsx
+++ b/.design-sync/previews/NotebookCompositionTicks.tsx
@@ -1,0 +1,33 @@
+import { NotebookCompositionTicks } from "nteract-elements";
+
+function Row({ label, children }: { label: string; children: React.ReactNode }) {
+  return (
+    <div style={{ display: "flex", alignItems: "center", gap: 12 }}>
+      <span className="text-xs text-muted-foreground" style={{ width: 132 }}>
+        {label}
+      </span>
+      <div style={{ width: 220 }}>{children}</div>
+    </div>
+  );
+}
+
+// One tick per cell, colored by type (code / markdown / raw), evenly
+// interleaved and capped - the dashboard's at-a-glance content fingerprint.
+export function Compositions() {
+  return (
+    <div style={{ display: "flex", flexDirection: "column", gap: 12 }}>
+      <Row label="Analysis (19·6·0)">
+        <NotebookCompositionTicks composition={{ code: 19, markdown: 6, raw: 0 }} />
+      </Row>
+      <Row label="Narrative (3·16·0)">
+        <NotebookCompositionTicks composition={{ code: 3, markdown: 16, raw: 0 }} />
+      </Row>
+      <Row label="Mixed (12·2·4)">
+        <NotebookCompositionTicks composition={{ code: 12, markdown: 2, raw: 4 }} />
+      </Row>
+      <Row label="Large, capped (90·30·10)">
+        <NotebookCompositionTicks composition={{ code: 90, markdown: 30, raw: 10 }} />
+      </Row>
+    </div>
+  );
+}

--- a/.design-sync/previews/RuntimeStatusDot.tsx
+++ b/.design-sync/previews/RuntimeStatusDot.tsx
@@ -1,0 +1,29 @@
+import { RuntimeStatusDot } from "nteract-elements";
+
+// The calm runtime marker: dot color carries the state, the label is optional
+// and terse. No pulse or glow by design.
+export function States() {
+  return (
+    <div style={{ display: "flex", flexDirection: "column", gap: 10 }}>
+      <RuntimeStatusDot status="executing" showLabel />
+      <RuntimeStatusDot status="ready" showLabel />
+      <RuntimeStatusDot status="starting" showLabel />
+      <RuntimeStatusDot status="stale" showLabel />
+      <RuntimeStatusDot status="error" showLabel />
+      <RuntimeStatusDot status="none" showLabel />
+    </div>
+  );
+}
+
+export function DotsOnly() {
+  return (
+    <div style={{ display: "flex", alignItems: "center", gap: 14 }}>
+      <RuntimeStatusDot status="executing" />
+      <RuntimeStatusDot status="ready" />
+      <RuntimeStatusDot status="starting" />
+      <RuntimeStatusDot status="stale" />
+      <RuntimeStatusDot status="error" />
+      <RuntimeStatusDot status="none" />
+    </div>
+  );
+}

--- a/.design-sync/synthpkg/build.mjs
+++ b/.design-sync/synthpkg/build.mjs
@@ -58,6 +58,18 @@ const groups = [
     mods: ["ansi-output", "json-output", "traceback-output"],
   },
   {
+    // Dashboard atoms from the /n redesign - prop-driven, shared between the
+    // cloud dashboard and (eventually) desktop remote-room listings. Styling
+    // lives in src/styles/dashboard-atoms.css (shared surface, like
+    // comment-affordance.css). NotebookCommentsPanel stays deferred (katex).
+    dir: "notebook",
+    mods: ["NotebookCompositionTicks"],
+  },
+  {
+    dir: "runtime",
+    mods: ["RuntimeStatusDot", "LanguageMark"],
+  },
+  {
     // Comment affordances — prop-driven pieces of the commenting UI.
     // NotebookCommentsPanel is DEFERRED with the katex pass: it renders quotes
     // via ProjectedMarkdownView, which imports katex CSS (the same .ttf loader

--- a/apps/notebook-cloud/viewer/index.css
+++ b/apps/notebook-cloud/viewer/index.css
@@ -3,6 +3,7 @@
 @source "../../../src/components/**/*.{ts,tsx}";
 
 @import "../../notebook/src/index.css";
+@import "../../../src/styles/dashboard-atoms.css";
 
 html,
 body,
@@ -690,20 +691,7 @@ body {
 }
 
 .cloud-notebook-list-page {
-  --ct-code: #38bdf8;
-  --ci-code: #0284c7;
-  --ct-markdown: #34d399;
-  --ci-markdown: #059669;
-  --ct-raw: #fb7185;
-  --ci-raw: #e11d48;
   --uv: #de5fe9;
-  --live: #22c55e;
-  --live-ink: #16a34a;
-  --k-exec: #f59e0b;
-  --k-ready: #22c55e;
-  --k-start: #3b82f6;
-  --k-stale: #9ca3af;
-  --k-error: var(--destructive);
   --nb-shadow: 0 1px 2px rgba(16, 16, 20, 0.04), 0 1px 3px rgba(16, 16, 20, 0.06);
   --nb-shadow-lg: 0 6px 16px -6px rgba(16, 16, 20, 0.14), 0 2px 6px -2px rgba(16, 16, 20, 0.08);
   --nb-maxw: 1120px;
@@ -728,15 +716,6 @@ body {
 
 .dark .cloud-notebook-list-page,
 [data-theme="dark"] .cloud-notebook-list-page {
-  --ct-code: #7dd3fc;
-  --ci-code: #7dd3fc;
-  --ct-markdown: #6ee7b7;
-  --ci-markdown: #6ee7b7;
-  --ct-raw: #fda4af;
-  --ci-raw: #fda4af;
-  --live: #4ade80;
-  --live-ink: #4ade80;
-  --k-stale: #6b7280;
   --nb-shadow: 0 1px 2px rgba(0, 0, 0, 0.4);
   --nb-shadow-lg: 0 10px 26px -8px rgba(0, 0, 0, 0.6);
 }
@@ -1040,11 +1019,6 @@ body {
   font-weight: 600;
 }
 
-.nb-lang-logo {
-  display: block;
-  flex: 0 0 auto;
-}
-
 .nb-hero-body {
   position: relative;
   display: flex;
@@ -1189,96 +1163,12 @@ body {
   color: var(--muted-foreground);
 }
 
-.nb-fp-wrap {
-  display: flex;
-  min-width: 0;
-  flex-direction: column;
-  gap: 7px;
-}
-
 .nb-hero-fp {
   max-width: 340px;
 }
 
-.nb-fp {
-  display: flex;
-  align-items: stretch;
-  width: 100%;
-  max-width: 340px;
-  height: 7px;
-  overflow: hidden;
-  border-radius: 3px;
-  opacity: 0.62;
-}
-
-.nb-fp-seg {
-  height: 100%;
-}
-
-.nb-fp-seg[data-ct="code"] {
-  background: var(--ct-code);
-}
-
-.nb-fp-seg[data-ct="markdown"] {
-  background: var(--ct-markdown);
-}
-
-.nb-fp-seg[data-ct="raw"] {
-  background: var(--ct-raw);
-}
-
 .nb-hero .nb-fp {
   height: 8px;
-}
-
-.nb-kernel {
-  display: inline-flex;
-  align-items: center;
-  gap: 7px;
-  color: var(--muted-foreground);
-  font-size: 12.5px;
-  white-space: nowrap;
-}
-
-.nb-kdot {
-  width: 8px;
-  height: 8px;
-  flex: 0 0 auto;
-  border-radius: 50%;
-  background: var(--k-stale);
-}
-
-.nb-kernel[data-k="executing"] {
-  color: color-mix(in srgb, var(--k-exec) 72%, var(--foreground));
-}
-
-.nb-kernel[data-k="executing"] .nb-kdot {
-  background: var(--k-exec);
-}
-
-.nb-kernel[data-k="ready"] {
-  color: color-mix(in srgb, var(--k-ready) 60%, var(--foreground));
-}
-
-.nb-kernel[data-k="ready"] .nb-kdot {
-  background: var(--k-ready);
-}
-
-.nb-kernel[data-k="starting"] .nb-kdot {
-  background: var(--k-start);
-}
-
-.nb-kernel[data-k="error"] {
-  color: var(--k-error);
-}
-
-.nb-kernel[data-k="error"] .nb-kdot {
-  background: var(--k-error);
-}
-
-.nb-kernel[data-k="none"] .nb-kdot {
-  border: 1.5px solid color-mix(in srgb, var(--muted-foreground) 55%, transparent);
-  background: transparent;
 }
 
 .nb-avatar {
@@ -1295,35 +1185,6 @@ body {
   width: 17px;
   height: 17px;
   font-size: 8px;
-}
-
-.nb-lang-dot {
-  display: inline-block;
-  width: 8px;
-  height: 8px;
-  flex: 0 0 auto;
-  border-radius: 50%;
-  background: var(--muted-foreground);
-}
-
-.nb-lang-dot[data-lang="Python"] {
-  background: #3b82f6;
-}
-
-.nb-lang-dot[data-lang="SQL"] {
-  background: #f59e0b;
-}
-
-.nb-lang-dot[data-lang="TypeScript"] {
-  background: #3178c6;
-}
-
-.nb-lang-dot[data-lang="Deno"] {
-  background: #3178c6;
-}
-
-.nb-lang-dot[data-lang="R"] {
-  background: #2563eb;
 }
 
 .nb-scope-badge {

--- a/src/styles/dashboard-atoms.css
+++ b/src/styles/dashboard-atoms.css
@@ -1,0 +1,157 @@
+/* Shared dashboard atoms: the cell-type/runtime/language visual vocabulary
+   consumed by NotebookCompositionTicks, RuntimeStatusDot, and LanguageMark
+   (src/components/{notebook,runtime}). One definition serving the cloud
+   dashboard and the design guide, like ansi.css and comment-affordance.css.
+   Dark values are dual-keyed (.dark, [data-theme="dark"]) per the repo
+   convention. */
+
+:root {
+  --ct-code: #38bdf8;
+  --ci-code: #0284c7;
+  --ct-markdown: #34d399;
+  --ci-markdown: #059669;
+  --ct-raw: #fb7185;
+  --ci-raw: #e11d48;
+  --live: #22c55e;
+  --live-ink: #16a34a;
+  --k-exec: #f59e0b;
+  --k-ready: #22c55e;
+  --k-start: #3b82f6;
+  --k-stale: #9ca3af;
+  --k-error: var(--destructive, #dc2626);
+}
+
+.dark,
+[data-theme="dark"] {
+  --ct-code: #7dd3fc;
+  --ci-code: #7dd3fc;
+  --ct-markdown: #6ee7b7;
+  --ci-markdown: #6ee7b7;
+  --ct-raw: #fda4af;
+  --ci-raw: #fda4af;
+  --live: #4ade80;
+  --live-ink: #4ade80;
+  --k-stale: #6b7280;
+}
+
+/* Composition fingerprint: one tick per cell, colored by type. */
+.nb-fp-wrap {
+  display: flex;
+  min-width: 0;
+  flex-direction: column;
+  gap: 7px;
+}
+
+.nb-fp {
+  display: flex;
+  align-items: stretch;
+  width: 100%;
+  max-width: 340px;
+  height: 7px;
+  overflow: hidden;
+  border-radius: 3px;
+  opacity: 0.62;
+}
+
+.nb-fp-seg {
+  height: 100%;
+}
+
+.nb-fp-seg[data-ct="code"] {
+  background: var(--ct-code);
+}
+
+.nb-fp-seg[data-ct="markdown"] {
+  background: var(--ct-markdown);
+}
+
+.nb-fp-seg[data-ct="raw"] {
+  background: var(--ct-raw);
+}
+
+/* Runtime status: a calm dot with an optional terse label. */
+.nb-kernel {
+  display: inline-flex;
+  align-items: center;
+  gap: 7px;
+  color: var(--muted-foreground);
+  font-size: 12.5px;
+  white-space: nowrap;
+}
+
+.nb-kdot {
+  width: 8px;
+  height: 8px;
+  flex: 0 0 auto;
+  border-radius: 50%;
+  background: var(--k-stale);
+}
+
+.nb-kernel[data-k="executing"] {
+  color: color-mix(in srgb, var(--k-exec) 72%, var(--foreground));
+}
+
+.nb-kernel[data-k="executing"] .nb-kdot {
+  background: var(--k-exec);
+}
+
+.nb-kernel[data-k="ready"] {
+  color: color-mix(in srgb, var(--k-ready) 60%, var(--foreground));
+}
+
+.nb-kernel[data-k="ready"] .nb-kdot {
+  background: var(--k-ready);
+}
+
+.nb-kernel[data-k="starting"] .nb-kdot {
+  background: var(--k-start);
+}
+
+.nb-kernel[data-k="error"] {
+  color: var(--k-error);
+}
+
+.nb-kernel[data-k="error"] .nb-kdot {
+  background: var(--k-error);
+}
+
+.nb-kernel[data-k="none"] .nb-kdot {
+  border: 1.5px solid color-mix(in srgb, var(--muted-foreground) 55%, transparent);
+  background: transparent;
+}
+
+/* Language mark: the Python logo renders as an inline SVG; everything else
+   gets the identity dot. */
+.nb-lang-logo {
+  display: block;
+  flex: 0 0 auto;
+}
+
+.nb-lang-dot {
+  display: inline-block;
+  width: 8px;
+  height: 8px;
+  flex: 0 0 auto;
+  border-radius: 50%;
+  background: var(--muted-foreground);
+}
+
+.nb-lang-dot[data-lang="Python"] {
+  background: #3b82f6;
+}
+
+.nb-lang-dot[data-lang="SQL"] {
+  background: #f59e0b;
+}
+
+.nb-lang-dot[data-lang="TypeScript"] {
+  background: #3178c6;
+}
+
+.nb-lang-dot[data-lang="Deno"] {
+  background: #3178c6;
+}
+
+.nb-lang-dot[data-lang="R"] {
+  background: #2563eb;
+}


### PR DESCRIPTION
Syncs the /n dashboard redesign's shared components into the nteract Elements guide - the design tool can now compose dashboard surfaces from the same atoms the cloud app ships. Project is at 42 components across six groups.

## New in the guide

| Component | Group | Cards |
|---|---|---|
| NotebookCompositionTicks | notebook | four fingerprints incl. the capped-large case |
| RuntimeStatusDot | runtime | six states labeled + dots-only row |
| LanguageMark | runtime | Python mark + Deno/TS/SQL/R dots, size ramp |

## The styling extraction

The atoms' CSS lived only in the cloud viewer's stylesheet. It now lives in `src/styles/dashboard-atoms.css` - the composition-tick / runtime-dot / language-mark vocabulary (`--ct-*`, `--k-*`, `--live`, `.nb-fp`, `.nb-kernel`, `.nb-lang-*`) as a shared surface tunable in Elements, same pattern as `ansi.css` and `comment-affordance.css`. The cloud viewer `@import`s it and drops its duplicated rules; the design-sync compile imports it too. Dark values dual-keyed per repo convention.

## Bookkeeping

- The conventions header's groups paragraph had drifted (Outputs was missing entirely) - it now enumerates all six groups with the prop contracts, and every named class re-validates against the fresh build.
- This sync also carries #3877's comment-affordance contrast fix into the project's compiled styling.
- `NotebookCommentsPanel` joins the notebook group when the katex pass lands (unchanged deferral).

## Verification

- [x] 42/42 previews render cleanly; three new cards graded good from capture sheets
- [x] Driver verdict: 3 added, 39 unchanged, no grade churn, no deletes
- [x] Cloud tests 1198/1198 + cloud build after the CSS extraction; desktop build green
- [x] Uploaded and anchored; `components/{notebook,runtime}/` live in the project
