### PR TITLE
fix(notebook-cloud): dashboard feedback batch (presence contract, identity, loading resilience)

### DIFF
--- a/apps/notebook-cloud/src/index.ts
+++ b/apps/notebook-cloud/src/index.ts
@@ -1206,7 +1206,12 @@ async function routeListNotebooks(request: Request, env: Env): Promise<Response>
     }),
     listNotebookPrincipalDisplays(env, notebooks, principal),
   ]);
-  const currentUserDisplay = principalDisplays.get(principal);
+  // Same resolution chain the viewer shell uses: live identity metadata, then
+  // the app session's captured display name, then the profile store.
+  const currentUserDisplay =
+    (!isAnonymousViewer(identity) ? identity.metadata.displayName?.trim() : undefined) ||
+    appSession?.displayName?.trim() ||
+    principalDisplays.get(principal);
   return json({
     ok: true,
     notebooks: notebookListResponseRows(
@@ -1320,7 +1325,7 @@ async function listNotebookRoomPresenceForRows(
           }
           const peers = summary.occupants.filter(
             (occupant) =>
-              isHumanRoomSummaryOccupant(occupant) &&
+              isEditingRoomSummaryOccupant(occupant) &&
               !roomSummaryOccupantMatchesRequester(occupant, requester),
           );
           if (peers.length > 0) {
@@ -1387,12 +1392,12 @@ function isNotebookRoomSummaryOccupant(value: unknown): value is NotebookRoomSum
   );
 }
 
-function isHumanRoomSummaryOccupant(occupant: NotebookRoomSummaryOccupant): boolean {
-  return (
-    occupant.connection_scope === "viewer" ||
-    occupant.connection_scope === "editor" ||
-    occupant.connection_scope === "owner"
-  );
+// Dashboard presence means "editing now": only editor/owner occupants count.
+// Viewers (including anonymous public viewers) are recorded in the room
+// summary for a future viewing/editing split but must not mark a notebook
+// Active or read as editing here.
+function isEditingRoomSummaryOccupant(occupant: NotebookRoomSummaryOccupant): boolean {
+  return occupant.connection_scope === "editor" || occupant.connection_scope === "owner";
 }
 
 function roomSummaryOccupantMatchesRequester(

--- a/apps/notebook-cloud/src/notebook-room.ts
+++ b/apps/notebook-cloud/src/notebook-room.ts
@@ -2122,7 +2122,13 @@ export class NotebookRoom {
   }
 
   private roomSummaryOccupantKeys(): Set<string> {
-    return new Set(this.roomSummaryOccupants().map((occupant) => occupant.participant_key));
+    // Scope is part of the key: a viewer socket upgrading to an editor socket
+    // must publish immediately (the dashboard only counts editing scopes).
+    return new Set(
+      this.roomSummaryOccupants().map(
+        (occupant) => `${occupant.participant_key}\u0000${occupant.connection_scope}`,
+      ),
+    );
   }
 
   private roomSummaryOccupants(): NotebookRoomSummaryOccupant[] {

--- a/apps/notebook-cloud/test/notebook-dashboard.test.ts
+++ b/apps/notebook-cloud/test/notebook-dashboard.test.ts
@@ -483,7 +483,7 @@ describe("cloud notebook dashboard projection", () => {
         section.notebooks.map((item) => item.notebook_id),
       ]),
       [
-        ["named", "Recent work", "1 more notebook to reopen", ["workstation-notes"]],
+        ["named", "Recent work", "+1 more", ["workstation-notes"]],
         ["generated", "Generated runs", "1 notebook from smoke and debug work", ["toolbar-smoke"]],
         [
           "untitled",

--- a/apps/notebook-cloud/test/notebook-room.test.ts
+++ b/apps/notebook-cloud/test/notebook-room.test.ts
@@ -3782,6 +3782,35 @@ describe("NotebookRoom room summary", () => {
     );
   });
 
+  it("republishes when a participant's strongest scope changes (viewer to editor)", async () => {
+    const state = alarmCapableState();
+    const bucket = new FakeRoomSummaryBucket();
+    const room = new NotebookRoom(state.state, { NOTEBOOK_SNAPSHOTS: bucket } as Env);
+    const harness = roomHarness(room);
+
+    const beforeViewer = harness.roomSummaryOccupantKeys();
+    harness.peers.set(
+      "vera-view",
+      summaryPeer("vera-view", "vera", "viewer", { operator: "browser:a" }),
+    );
+    harness.publishRoomSummaryIfHumanOccupantsChanged("demo", beforeViewer, "peer_joined");
+    await state.drain();
+    assert.equal(bucket.summary("demo").occupants[0]?.connection_scope, "viewer");
+    const putsAfterViewer = bucket.puts.length;
+
+    // Same participant opens an editing connection: the dashboard only counts
+    // editing scopes, so this transition must publish immediately.
+    const beforeEditor = harness.roomSummaryOccupantKeys();
+    harness.peers.set(
+      "vera-edit",
+      summaryPeer("vera-edit", "vera", "editor", { operator: "browser:b" }),
+    );
+    harness.publishRoomSummaryIfHumanOccupantsChanged("demo", beforeEditor, "peer_joined");
+    await state.drain();
+    assert.ok(bucket.puts.length > putsAfterViewer, "scope transition republishes");
+    assert.equal(bucket.summary("demo").occupants[0]?.connection_scope, "editor");
+  });
+
   it("writes an empty summary and disarms refresh when the occupant set empties", async () => {
     const state = alarmCapableState();
     const bucket = new FakeRoomSummaryBucket();

--- a/apps/notebook-cloud/test/viewer-shared-cell-surface.test.ts
+++ b/apps/notebook-cloud/test/viewer-shared-cell-surface.test.ts
@@ -757,7 +757,7 @@ test("cloud notebook list waits for app-session cookies before catalog fetches",
   );
   assert.match(
     sourceText,
-    /fetchCloudNotebookList\(authState, controller\.signal\)/,
+    /fetchCloudNotebookList\(\s*authState,\s*AbortSignal\.any\(\[controller\.signal, AbortSignal\.timeout\(/,
     "catalog fetch should still use the existing auth helper once the cookie-backed state is ready",
   );
 });

--- a/apps/notebook-cloud/test/worker-routes.test.ts
+++ b/apps/notebook-cloud/test/worker-routes.test.ts
@@ -2103,6 +2103,14 @@ describe("Worker artifact routes", () => {
             display_name: "Python",
             connection_scope: "runtime_peer",
           },
+          {
+            // Read-only viewers (incl. anonymous public viewers) never read as
+            // "editing now" on the dashboard.
+            participant_key: "user:dev:vera",
+            actor_label: "user:dev:vera/browser:tab",
+            display_name: "Vera Viewer",
+            connection_scope: "viewer",
+          },
         ],
       }),
     );

--- a/apps/notebook-cloud/viewer/cloud-notebook-dashboard-view.tsx
+++ b/apps/notebook-cloud/viewer/cloud-notebook-dashboard-view.tsx
@@ -469,8 +469,12 @@ function CloudNotebookDashboardRowView({
         </span>
       </a>
       <span className="nb-col nb-col-owner">
-        <span className="nb-avatar nb-avatar-sm">{row.ownerInitials}</span>
-        <span className="nb-col-owner-name">{row.ownerLabel}</span>
+        {notebook.scope === "owner" ? null : (
+          <>
+            <span className="nb-avatar nb-avatar-sm">{row.ownerInitials}</span>
+            <span className="nb-col-owner-name">{row.ownerLabel}</span>
+          </>
+        )}
       </span>
       <span className="nb-col nb-col-lang">
         {languageLabel ? (

--- a/apps/notebook-cloud/viewer/index.css
+++ b/apps/notebook-cloud/viewer/index.css
@@ -1574,6 +1574,61 @@ body {
   padding: 0.625rem 0.75rem;
 }
 
+/* Loading skeleton: ghost rows in the list grid's shape, calm shimmer. */
+.nb-loading {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+  padding-top: 1.25rem;
+}
+
+.nb-loading-row {
+  display: grid;
+  grid-template-columns: minmax(180px, 1fr) 124px 128px 150px;
+  align-items: center;
+  column-gap: 14px;
+  min-height: 52px;
+  padding: 0 14px 0 18px;
+  border-bottom: 1px solid color-mix(in srgb, var(--border) 60%, transparent);
+}
+
+.nb-loading-bar {
+  display: block;
+  height: 12px;
+  border-radius: 6px;
+  background: color-mix(in srgb, var(--muted-foreground) 14%, transparent);
+  animation: nb-loading-fade 1.6s ease-in-out infinite;
+}
+
+.nb-loading-bar[data-w="title"] {
+  width: 62%;
+  height: 14px;
+}
+
+.nb-loading-bar[data-w="meta"] {
+  width: 70%;
+}
+
+.nb-loading-bar[data-w="time"] {
+  width: 85%;
+}
+
+@keyframes nb-loading-fade {
+  0%,
+  100% {
+    opacity: 1;
+  }
+  50% {
+    opacity: 0.45;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .nb-loading-bar {
+    animation: none;
+  }
+}
+
 .cloud-notebook-list-state {
   display: inline-flex;
   align-items: center;

--- a/apps/notebook-cloud/viewer/notebook-dashboard.ts
+++ b/apps/notebook-cloud/viewer/notebook-dashboard.ts
@@ -970,7 +970,7 @@ function bucketDetail(count: number, label: string): string {
 }
 
 function remainingNotebookDetail(count: number): string {
-  return `${count} more notebook${count === 1 ? "" : "s"} to reopen`;
+  return `+${count} more`;
 }
 
 function startOfUtcDay(time: number): number {

--- a/apps/notebook-cloud/viewer/notebook-list-view.tsx
+++ b/apps/notebook-cloud/viewer/notebook-list-view.tsx
@@ -145,7 +145,10 @@ export function CloudNotebookListView({ authConfig }: { authConfig: CloudViewerA
     );
     void (async () => {
       try {
-        const response = await fetchCloudNotebookList(authState, controller.signal);
+        const response = await fetchCloudNotebookList(
+          authState,
+          AbortSignal.any([controller.signal, AbortSignal.timeout(20_000)]),
+        );
         if (controller.signal.aborted) return;
         if (!response.ok) {
           throw await cloudResponseError(response, "Unable to list notebooks");
@@ -161,9 +164,14 @@ export function CloudNotebookListView({ authConfig }: { authConfig: CloudViewerA
         setListState({ kind: "ready", notebooks: body.notebooks });
       } catch (error) {
         if (controller.signal.aborted) return;
+        const timedOut = error instanceof DOMException && error.name === "TimeoutError";
         setListState({
           kind: "error",
-          message: error instanceof Error ? error.message : String(error),
+          message: timedOut
+            ? "Loading notebooks timed out - the service may be mid-deploy. Retry, or hard-refresh if this persists."
+            : error instanceof Error
+              ? error.message
+              : String(error),
         });
       }
     })();
@@ -431,9 +439,16 @@ export function CloudNotebookListView({ authConfig }: { authConfig: CloudViewerA
 
       <section className="cloud-notebook-list-content" aria-label="Notebook list">
         {listState.kind === "loading" ? (
-          <div className="cloud-notebook-list-state" data-kind="loading" role="status">
-            <Loader2 className="cloud-home-status-spinner" aria-hidden="true" />
-            <span>Loading notebooks</span>
+          <div className="nb-loading" role="status" aria-label="Loading notebooks">
+            <span className="sr-only">Loading notebooks</span>
+            {Array.from({ length: 6 }, (_, index) => (
+              <div key={index} className="nb-loading-row" aria-hidden="true">
+                <span className="nb-loading-bar" data-w="title" />
+                <span className="nb-loading-bar" data-w="meta" />
+                <span className="nb-loading-bar" data-w="meta" />
+                <span className="nb-loading-bar" data-w="time" />
+              </div>
+            ))}
           </div>
         ) : listState.kind === "signed_out" ? (
           <CloudNotebookSignedOutPanel authConfig={authConfig} authState={authState} />
@@ -441,6 +456,10 @@ export function CloudNotebookListView({ authConfig }: { authConfig: CloudViewerA
           <div className="cloud-notebook-list-state" data-kind="error" role="alert">
             <AlertCircle aria-hidden="true" />
             <span>{listState.message}</span>
+            <Button type="button" variant="outline" size="sm" onClick={refreshList}>
+              <RotateCcw aria-hidden="true" />
+              Retry
+            </Button>
           </div>
         ) : listState.notebooks.length === 0 ? (
           <CloudNotebookListEmptyState signedIn={signedIn} onNewNotebook={openCreateForm} />

--- a/src/components/runtime/RuntimeStatusDot.tsx
+++ b/src/components/runtime/RuntimeStatusDot.tsx
@@ -11,7 +11,7 @@ const RUNTIME_STATUS_LABELS: Record<RuntimeStatus, string> = {
   executing: "Running",
   ready: "Kernel ready",
   starting: "Connecting",
-  stale: "Idle kernel",
+  stale: "Disconnected",
   error: "Runtime error",
   none: "No compute",
 };


### PR DESCRIPTION
Five fixes from the post-deploy review of the redesigned dashboard (owner feedback + the Codex P2 on merged #3890).

## Presence contract (P2)

Read-only viewers - including anonymous public viewers - could mark a notebook Active and render "editing now." The dashboard presence read now accepts only `editor`/`owner` occupants. The room summary still records all human occupants (a future viewing/editing split can build on them), and occupant change detection is now **scope-aware** (participant + scope pairs), so a viewer-to-editor transition publishes immediately instead of waiting for the next join/leave. Regression tests on both sides: a seeded viewer occupant must not survive list hydration, and the scope transition must republish.

## Identity

- **Owned rows show nothing in the owner cell** - your own notebooks don't need a "B0 You" name card. Grid slot preserved for alignment; shared rows keep the profile display.
- **`current_user_display` resolves like the viewer shell does**: live identity metadata → app-session captured display name → profile store. The header avatar no longer depends on a `principal_profiles` row having `display_name` (which is why "RC" survived the last deploy - that row is empty for the owner's principal; it converges via the session profile sync, but the chain no longer requires it).

## Loading can't hang silently

The stuck "Loading notebooks" state (force-reload-fixed, likely mid-deploy) gets three defenses: a 20s timeout composed with the existing abort controller, a retryable error message that names the likely cause, and a **Retry button** on the error state. The bare spinner becomes skeleton rows in the list grid's shape (reduced-motion safe). A source-contract test pinning the fetch call shape was updated to pin the new shape (auth helper + controller signal still enforced, now composed with the timeout).

## Copy

- "Idle kernel" → **"Disconnected"**: `stale` means the runtime stopped reporting, not ready-but-bored. Shared `RuntimeStatusDot` label; the design guide picks it up on its next sync.
- Section overflow: "14 more notebooks to reopen" → **"+14 more"**. It was already a drill-in filter button - only the copy was wrong.

## Verification

- [x] Cloud tests 1199/1199 (viewer-exclusion + scope-transition regression tests added), cloud + desktop builds, `vp check` clean
