### PR TITLE
fix(notebook-cloud): bootstrap edit access on reload

### DIFF
--- a/apps/notebook-cloud/src/authorization.ts
+++ b/apps/notebook-cloud/src/authorization.ts
@@ -10,6 +10,7 @@ import {
   getNotebookRow,
   getPublicNotebookAclRows,
   type NotebookAclRow,
+  type NotebookRow,
 } from "./storage.ts";
 
 const CAP_READ = 1 << 0;
@@ -38,10 +39,16 @@ export interface AuthorizeNotebookAccessOptions {
   allowViewerDowngrade?: boolean;
   /**
    * Browser live-room tickets may optimistically request owner so the room
-   * opens with the user's best available control surface. Use this only for
-   * connection tickets; mutation routes must keep exact requested authority.
+   * opens with the user's best available control surface. Read-only discovery
+   * routes may also use this to report the caller's effective scope. Mutation
+   * routes must keep exact requested authority.
    */
   allowLiveScopeDowngrade?: boolean;
+}
+
+export interface AuthorizedNotebookAccess {
+  identity: AuthenticatedConnection;
+  notebook: NotebookRow;
 }
 
 export async function authorizeNotebookAccess(
@@ -51,6 +58,18 @@ export async function authorizeNotebookAccess(
   requestedScope: ConnectionScope = identity.scope,
   options: AuthorizeNotebookAccessOptions = {},
 ): Promise<AuthenticatedConnection> {
+  return (
+    await authorizeNotebookAccessWithNotebook(env, notebookId, identity, requestedScope, options)
+  ).identity;
+}
+
+export async function authorizeNotebookAccessWithNotebook(
+  env: Env,
+  notebookId: string,
+  identity: AuthenticatedConnection,
+  requestedScope: ConnectionScope = identity.scope,
+  options: AuthorizeNotebookAccessOptions = {},
+): Promise<AuthorizedNotebookAccess> {
   if (!env.DB) {
     throw new AuthorizationError("D1 binding DB is not configured", 503);
   }
@@ -71,17 +90,17 @@ export async function authorizeNotebookAccess(
       throw new AuthorizationError("notebook not found", 404);
     }
 
-    return { ...identity, scope: "viewer" };
+    return { identity: { ...identity, scope: "viewer" }, notebook };
   }
 
   const principalRows = await getNotebookAclRowsForPrincipal(env, notebookId, identity.principal);
   if (aclRowsCoverScope(principalRows, requestedScope)) {
-    return { ...identity, scope: requestedScope };
+    return { identity: { ...identity, scope: requestedScope }, notebook };
   }
   if (options.allowLiveScopeDowngrade) {
     const downgradedScope = bestDowngradedLiveScope(principalRows, requestedScope);
     if (downgradedScope) {
-      return { ...identity, scope: downgradedScope };
+      return { identity: { ...identity, scope: downgradedScope }, notebook };
     }
   }
   if (
@@ -89,19 +108,19 @@ export async function authorizeNotebookAccess(
     requestedScope === "editor" &&
     aclRowsCoverScope(principalRows, "viewer")
   ) {
-    return { ...identity, scope: "viewer" };
+    return { identity: { ...identity, scope: "viewer" }, notebook };
   }
 
   const publicRows = await getPublicNotebookAclRows(env, notebookId);
   if (aclRowsCoverScope(publicRows, "viewer")) {
     if (requestedScope === "viewer") {
-      return { ...identity, scope: "viewer" };
+      return { identity: { ...identity, scope: "viewer" }, notebook };
     }
     if (options.allowLiveScopeDowngrade && requestedScope !== "runtime_peer") {
-      return { ...identity, scope: "viewer" };
+      return { identity: { ...identity, scope: "viewer" }, notebook };
     }
     if (options.allowViewerDowngrade && requestedScope === "editor") {
-      return { ...identity, scope: "viewer" };
+      return { identity: { ...identity, scope: "viewer" }, notebook };
     }
   }
 

--- a/apps/notebook-cloud/src/index.ts
+++ b/apps/notebook-cloud/src/index.ts
@@ -1509,7 +1509,7 @@ function parseNotebookCellComposition(
 }
 
 function isNotebookCellCount(value: unknown): value is number {
-  return Number.isSafeInteger(value) && value >= 0;
+  return typeof value === "number" && Number.isSafeInteger(value) && value >= 0;
 }
 
 function parseNotebookListLimit(request: Request): number | Response {
@@ -4153,12 +4153,7 @@ async function routeCatalog(request: Request, env: Env, notebookId: string): Pro
   if (!env.DB) {
     return json({ error: "D1 binding DB is not configured" }, 503);
   }
-  const identity = await authenticateAndAuthorizeOrAppSessionOrResponse(
-    request,
-    env,
-    notebookId,
-    "viewer",
-  );
+  const identity = await authenticateNotebookCatalogAccess(request, env, notebookId);
   if (identity instanceof Response) {
     return identity;
   }
@@ -4168,7 +4163,12 @@ async function routeCatalog(request: Request, env: Env, notebookId: string): Pro
     return json({ error: "notebook not found" }, 404);
   }
 
-  return json(catalog);
+  return json({
+    ...catalog,
+    access: {
+      scope: identity.scope,
+    },
+  });
 }
 
 async function routeUpdateNotebookMetadata(
@@ -5092,6 +5092,23 @@ async function authenticateAndAuthorizeOrAppSessionOrResponse(
   return authorizeIdentityOrResponse(env, notebookId, identity, requestedScope);
 }
 
+async function authenticateNotebookCatalogAccess(
+  request: Request,
+  env: Env,
+  notebookId: string,
+): Promise<AuthenticatedConnection | Response> {
+  const identity = await authenticateRequestOrAppSessionOrResponse(request, env, "owner");
+  if (identity instanceof Response) {
+    return identity;
+  }
+  if (isAnonymousViewer(identity)) {
+    return authorizeIdentityOrResponse(env, notebookId, identity, "viewer");
+  }
+  return authorizeIdentityOrResponse(env, notebookId, identity, "owner", {
+    allowLiveScopeDowngrade: true,
+  });
+}
+
 async function authorizeIdentityOrResponse(
   env: Env,
   notebookId: string,
@@ -5251,6 +5268,9 @@ async function viewer(
   const rendererSidecarAssets = await rendererSidecarAssetNames(env);
   const notebookRouteAssets = await notebookRouteAssetNames(env);
   const session = await readCloudAppSession(env, request).catch(() => null);
+  const initialCatalogAccess = session
+    ? await initialNotebookViewerCatalogAccess(env, notebookId, session).catch(() => null)
+    : null;
   const config = {
     notebookId,
     headsHash: headsHash ?? null,
@@ -5271,6 +5291,7 @@ async function viewer(
     featureFlags: {
       enable_comments: true,
     },
+    initialCatalogAccess,
     session: session ? appSessionResponse(session) : null,
     syncEndpoint: `/n/${encodeURIComponent(notebookId)}/sync`,
     blobBasePath: notebookCloudBlobBasePath(notebookId),
@@ -5285,6 +5306,28 @@ async function viewer(
     request,
     viewerShell(shellMetadata, env, authConfigForRequest(request, env), config),
   );
+}
+
+async function initialNotebookViewerCatalogAccess(
+  env: Env,
+  notebookId: string,
+  session: CloudAppSession,
+): Promise<{ scope: Exclude<ConnectionScope, "runtime_peer">; title: string | null } | null> {
+  if (!env.DB) {
+    return null;
+  }
+  const identity = appSessionConnectionIdentity(session, "browser:http", "owner");
+  const authorized = await authorizeNotebookAccess(env, notebookId, identity, "owner", {
+    allowLiveScopeDowngrade: true,
+  });
+  const catalog = await getNotebookCatalog(env, notebookId);
+  if (!catalog) {
+    return null;
+  }
+  return {
+    scope: authorized.scope as Exclude<ConnectionScope, "runtime_peer">,
+    title: catalog.notebook.title,
+  };
 }
 
 interface ViewerShellConfig extends Record<string, unknown> {

--- a/apps/notebook-cloud/src/index.ts
+++ b/apps/notebook-cloud/src/index.ts
@@ -29,6 +29,7 @@ import {
 import {
   AuthorizationError,
   authorizeNotebookAccess,
+  authorizeNotebookAccessWithNotebook,
   type AuthorizeNotebookAccessOptions,
 } from "./authorization.ts";
 import {
@@ -5317,17 +5318,28 @@ async function initialNotebookViewerCatalogAccess(
     return null;
   }
   const identity = appSessionConnectionIdentity(session, "browser:http", "owner");
-  const authorized = await authorizeNotebookAccess(env, notebookId, identity, "owner", {
-    allowLiveScopeDowngrade: true,
-  });
-  const catalog = await getNotebookCatalog(env, notebookId);
-  if (!catalog) {
-    return null;
-  }
+  const { identity: authorized, notebook } = await authorizeNotebookAccessWithNotebook(
+    env,
+    notebookId,
+    identity,
+    "owner",
+    {
+      allowLiveScopeDowngrade: true,
+    },
+  );
   return {
-    scope: authorized.scope as Exclude<ConnectionScope, "runtime_peer">,
-    title: catalog.notebook.title,
+    scope: browserCatalogAccessScope(authorized.scope),
+    title: notebook.title,
   };
+}
+
+function browserCatalogAccessScope(
+  scope: ConnectionScope,
+): Exclude<ConnectionScope, "runtime_peer"> {
+  if (scope === "runtime_peer") {
+    throw new Error("runtime_peer is not a browser catalog access scope");
+  }
+  return scope;
 }
 
 interface ViewerShellConfig extends Record<string, unknown> {

--- a/apps/notebook-cloud/test/cloud-document-edit-readiness.test.ts
+++ b/apps/notebook-cloud/test/cloud-document-edit-readiness.test.ts
@@ -57,6 +57,24 @@ describe("cloud notebook document edit readiness projection", () => {
     );
   });
 
+  it("keeps edit mode pending when catalog grants edit access but the live room is still viewer", () => {
+    assert.deepEqual(
+      projectCloudNotebookDocumentEditReadiness({
+        accessScope: "owner",
+        connectionError: null,
+        connectionPeerId: "peer-1",
+        connectionScope: "viewer",
+        selectedMode: "edit",
+        statusKind: "ready",
+      }),
+      {
+        canAcceptCellMutations: false,
+        selectedEditModeWaitingForRoom: true,
+        editAccessRequestPending: true,
+      },
+    );
+  });
+
   it("shows connection errors as errors instead of pending edit access", () => {
     assert.deepEqual(
       projectCloudNotebookDocumentEditReadiness({

--- a/apps/notebook-cloud/test/cloud-notebook-catalog-access.test.ts
+++ b/apps/notebook-cloud/test/cloud-notebook-catalog-access.test.ts
@@ -2,6 +2,7 @@ import assert from "node:assert/strict";
 import { describe, it } from "node:test";
 import {
   cloudNotebookAccessScopeForShell,
+  cloudNotebookCatalogAccessFromCatalogResponse,
   cloudNotebookCatalogAccessFromList,
   cloudNotebookCatalogScopeFromList,
   cloudNotebookLiveRoomConnectionPolicy,
@@ -43,6 +44,45 @@ describe("cloud notebook catalog access projection", () => {
     );
   });
 
+  it("projects resolved catalog access from the direct notebook catalog response", () => {
+    assert.deepEqual(
+      cloudNotebookCatalogAccessFromCatalogResponse(
+        {
+          notebook: {
+            id: "room",
+            title: "Room Notebook",
+          },
+          access: { scope: "owner" },
+        },
+        "room",
+      ),
+      {
+        catalogResolved: true,
+        catalogScope: "owner",
+        catalogTitle: "Room Notebook",
+      },
+    );
+  });
+
+  it("treats old direct catalog responses without access as viewer access", () => {
+    assert.deepEqual(
+      cloudNotebookCatalogAccessFromCatalogResponse(
+        {
+          notebook: {
+            id: "room",
+            title: null,
+          },
+        },
+        "room",
+      ),
+      {
+        catalogResolved: true,
+        catalogScope: "viewer",
+        catalogTitle: null,
+      },
+    );
+  });
+
   it("coalesces concurrent catalog access loads for one notebook open", async () => {
     let loadCount = 0;
     let releaseLoad!: () => void;
@@ -66,6 +106,33 @@ describe("cloud notebook catalog access projection", () => {
     assert.deepEqual(await Promise.all([first, second]), [
       { catalogResolved: true, catalogScope: "owner" },
       { catalogResolved: true, catalogScope: "owner" },
+    ]);
+    assert.equal(loadCount, 1);
+  });
+
+  it("coalesces concurrent direct catalog access loads for one notebook open", async () => {
+    let loadCount = 0;
+    let releaseLoad!: () => void;
+    const loadGate = new Promise<void>((resolve) => {
+      releaseLoad = resolve;
+    });
+    const loader = createCloudNotebookCatalogAccessLoader({
+      notebookId: "room",
+      loadCatalogAccess: async () => {
+        loadCount += 1;
+        await loadGate;
+        return { catalogResolved: true, catalogScope: "editor", catalogTitle: "Room" };
+      },
+    });
+
+    const first = loader.load();
+    const second = loader.load();
+    assert.equal(loadCount, 1);
+    releaseLoad();
+
+    assert.deepEqual(await Promise.all([first, second]), [
+      { catalogResolved: true, catalogScope: "editor", catalogTitle: "Room" },
+      { catalogResolved: true, catalogScope: "editor", catalogTitle: "Room" },
     ]);
     assert.equal(loadCount, 1);
   });

--- a/apps/notebook-cloud/test/notebook-room.test.ts
+++ b/apps/notebook-cloud/test/notebook-room.test.ts
@@ -3722,7 +3722,7 @@ describe("NotebookRoom room summary", () => {
   it("writes deduped human occupants and ignores runtime peers", async () => {
     const state = alarmCapableState();
     const bucket = new FakeRoomSummaryBucket();
-    const room = new NotebookRoom(state.state, { NOTEBOOK_SNAPSHOTS: bucket } as Env);
+    const room = new NotebookRoom(state.state, roomEnvWithSnapshots(bucket));
     const harness = roomHarness(room);
 
     const beforeAlice = harness.roomSummaryOccupantKeys();
@@ -3785,7 +3785,7 @@ describe("NotebookRoom room summary", () => {
   it("republishes when a participant's strongest scope changes (viewer to editor)", async () => {
     const state = alarmCapableState();
     const bucket = new FakeRoomSummaryBucket();
-    const room = new NotebookRoom(state.state, { NOTEBOOK_SNAPSHOTS: bucket } as Env);
+    const room = new NotebookRoom(state.state, roomEnvWithSnapshots(bucket));
     const harness = roomHarness(room);
 
     const beforeViewer = harness.roomSummaryOccupantKeys();
@@ -3814,7 +3814,7 @@ describe("NotebookRoom room summary", () => {
   it("writes an empty summary and disarms refresh when the occupant set empties", async () => {
     const state = alarmCapableState();
     const bucket = new FakeRoomSummaryBucket();
-    const room = new NotebookRoom(state.state, { NOTEBOOK_SNAPSHOTS: bucket } as Env);
+    const room = new NotebookRoom(state.state, roomEnvWithSnapshots(bucket));
     const harness = roomHarness(room);
     harness.materializers.set("demo", {
       receiveFrame: async () => noopMaterializedResult(),
@@ -3843,7 +3843,7 @@ describe("NotebookRoom room summary", () => {
   it("publishes and re-arms the summary on refresh alarms", async () => {
     const state = alarmCapableState();
     const bucket = new FakeRoomSummaryBucket();
-    const room = new NotebookRoom(state.state, { NOTEBOOK_SNAPSHOTS: bucket } as Env);
+    const room = new NotebookRoom(state.state, roomEnvWithSnapshots(bucket));
     const harness = roomHarness(room);
     harness.peers.set("alice", summaryPeer("alice", "alice", "owner"));
     harness.publishRoomSummary("demo", "peer_joined");
@@ -3880,7 +3880,7 @@ describe("NotebookRoom room summary", () => {
     const state = alarmCapableState([socket.asCloudflareWebSocket()]);
     const bucket = new FakeRoomSummaryBucket();
 
-    new NotebookRoom(state.state, { NOTEBOOK_SNAPSHOTS: bucket } as Env);
+    new NotebookRoom(state.state, roomEnvWithSnapshots(bucket));
     await state.drain();
 
     assert.deepEqual(bucket.summary("demo").occupants, [
@@ -3997,6 +3997,18 @@ function roomEnvWithComputeIndex(
     },
     OWNER_COMPUTE_INDEX: computeIndex,
   } as Env;
+}
+
+function roomEnvWithSnapshots(bucket: FakeRoomSummaryBucket): Env {
+  return {
+    NOTEBOOK_ROOMS: {
+      idFromName: (name: string) => ({ toString: () => name }),
+      get: () => ({
+        fetch: async () => new Response("not implemented", { status: 501 }),
+      }),
+    },
+    NOTEBOOK_SNAPSHOTS: bucket,
+  };
 }
 
 class FakeRoomSummaryBucket {

--- a/apps/notebook-cloud/test/viewer-shared-cell-surface.test.ts
+++ b/apps/notebook-cloud/test/viewer-shared-cell-surface.test.ts
@@ -782,20 +782,22 @@ test("cloud notebook list trusts server bootstrap on initial app-session paint",
   );
 });
 
-test("cloud app-session live sync requests the resolved notebook-list scope", () => {
-  const sourceText = viewerCorpus;
+test("cloud app-session live sync uses streamed catalog access facts without awaiting list fetch", () => {
+  const sourceText = viewerFileContaining("function resolveCloudAppSessionSyncScope");
 
-  assert.match(sourceText, /async function resolveCloudAppSessionSyncScope/);
-  assert.match(sourceText, /new URL\("api\/n\?limit=100"/);
+  assert.match(sourceText, /function resolveCloudAppSessionSyncScope/);
   assert.match(sourceText, /createCloudNotebookCatalogAccessLoader\(\{/);
-  assert.match(sourceText, /catalogAccessLoader\.load/);
+  assert.match(sourceText, /loadCatalogAccess: async \(\) => \{/);
+  assert.match(sourceText, /config\.catalogEndpoint/);
+  assert.match(sourceText, /catalogAccessFactsRef\.current/);
   assert.match(sourceText, /cloudNotebookSyncScopeForCatalogAccess\(\{/);
-  assert.match(sourceText, /catalogResolved: false/);
-  assert.match(sourceText, /\.\.\.\(await loadCatalogAccess\(\)\)/);
   assert.match(
     sourceText,
-    /const requestedScope = await resolveCloudAppSessionSyncScope\([\s\S]*catalogAccessLoader\.load,[\s\S]*selectedInteractionMode,[\s\S]*\)/,
+    /const requestedScope = resolveCloudAppSessionSyncScope\([\s\S]*catalogAccessFactsRef\.current,[\s\S]*selectedInteractionModeRef\.current,[\s\S]*\)/,
   );
+  assert.doesNotMatch(sourceText, /new URL\("api\/n\?limit=100"/);
+  assert.doesNotMatch(sourceText, /\.\.\.\(await loadCatalogAccess\(\)\)/);
+  assert.doesNotMatch(sourceText, /await resolveCloudAppSessionSyncScope/);
   assert.doesNotMatch(
     sourceText,
     /cloudSyncAuthFromAppSessionCookie\(\{[\s\S]*requestedScope: "owner"/,

--- a/apps/notebook-cloud/test/worker-routes.test.ts
+++ b/apps/notebook-cloud/test/worker-routes.test.ts
@@ -769,6 +769,15 @@ describe("Worker artifact routes", () => {
       ...oidcEnv,
       NOTEBOOK_CLOUD_APP_SESSION_SECRET: APP_SESSION_SECRET,
     });
+    seedNotebook(env, "viewer-bootstrap-session");
+    const notebook = env.DB.notebooks.get("viewer-bootstrap-session");
+    assert.ok(notebook);
+    notebook.title = "Viewer Bootstrap Notebook";
+    seedAcl(env, {
+      notebookId: "viewer-bootstrap-session",
+      subject: "user:anaconda:viewer-bootstrap-user",
+      scope: "owner",
+    });
     const cookie = await oidcAppSessionCookie(env, token);
 
     const response = await worker.fetch(
@@ -786,6 +795,10 @@ describe("Worker artifact routes", () => {
     assert.equal(config.session?.provider, "oidc");
     assert.equal(typeof config.session?.expires_at, "number");
     assert.equal(typeof config.session?.cache_key, "string");
+    assert.deepEqual(config.initialCatalogAccess, {
+      scope: "owner",
+      title: "Viewer Bootstrap Notebook",
+    });
     assert.doesNotMatch(html, new RegExp(token.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")));
     assert.doesNotMatch(html, /viewer-bootstrap@example\.test|viewer-bootstrap-user/);
     assert.doesNotMatch(html, /Viewer Bootstrap User/);
@@ -2002,6 +2015,40 @@ describe("Worker artifact routes", () => {
     assert.ok(row);
     assert.equal(Object.hasOwn(row, "composition"), false);
     assert.equal(row.language, "python");
+  });
+
+  it("returns the authorized caller scope from direct notebook catalog fetches", async () => {
+    const env = fakeEnv();
+    seedNotebook(env, "catalog-scope-demo");
+    const notebook = env.DB.notebooks.get("catalog-scope-demo");
+    assert.ok(notebook);
+    notebook.title = "Scoped Catalog";
+    seedAcl(env, {
+      notebookId: "catalog-scope-demo",
+      subject: "user:dev:alice",
+      scope: "editor",
+    });
+
+    const response = await worker.fetch(
+      new Request("http://localhost/api/n/catalog-scope-demo", {
+        headers: {
+          "X-User": "alice",
+          "X-Operator": "browser:tab",
+          "X-Scope": "viewer",
+        },
+      }),
+      env,
+      fakeContext(),
+    );
+
+    assert.equal(response.status, 200);
+    const body = (await response.json()) as {
+      access?: { scope?: string };
+      notebook?: { id?: string; title?: string | null };
+    };
+    assert.deepEqual(body.access, { scope: "editor" });
+    assert.equal(body.notebook?.id, "catalog-scope-demo");
+    assert.equal(body.notebook?.title, "Scoped Catalog");
   });
 
   it("enriches owned notebook rows with owner-scoped compute sessions", async () => {
@@ -4148,6 +4195,12 @@ describe("Worker artifact routes", () => {
       fakeContext(),
     );
     assert.equal(catalog.status, 200);
+    const catalogBody = (await catalog.json()) as {
+      access?: { scope?: string };
+      notebook?: { id?: string };
+    };
+    assert.deepEqual(catalogBody.access, { scope: "viewer" });
+    assert.equal(catalogBody.notebook?.id, "public-sharing-demo");
 
     const acl = await worker.fetch(
       new Request("http://localhost/api/n/public-sharing-demo/acl?viewer_session=anon-a"),
@@ -7472,6 +7525,10 @@ function notebookViewerConfig(html: string): {
   featureFlags?: {
     enable_comments?: boolean;
   };
+  initialCatalogAccess?: {
+    scope: string;
+    title?: string | null;
+  } | null;
   session?: {
     provider: string;
     expires_at: number;
@@ -7486,6 +7543,10 @@ function notebookViewerConfig(html: string): {
     featureFlags?: {
       enable_comments?: boolean;
     };
+    initialCatalogAccess?: {
+      scope: string;
+      title?: string | null;
+    } | null;
     session?: {
       provider: string;
       expires_at: number;

--- a/apps/notebook-cloud/viewer/cloud-notebook-catalog-access.ts
+++ b/apps/notebook-cloud/viewer/cloud-notebook-catalog-access.ts
@@ -1,6 +1,7 @@
 import type { ConnectionScope } from "../src/auth-shared";
 import type { NotebookInteractionMode } from "@/components/notebook";
 import { CLOUD_CONNECTION_NO_ACCESS_DIAGNOSTIC } from "./connection-diagnostics";
+import type { CloudNotebookCatalogResponse } from "./cloud-notebook-title-state";
 import { isCloudNotebookListItem, type CloudNotebookListItem } from "./notebook-dashboard";
 
 export type CloudNotebookCatalogAccessScope = Exclude<
@@ -17,12 +18,18 @@ export interface CloudNotebookAccessScopeProjectionInput {
 export interface CloudNotebookCatalogAccessLoadResult {
   catalogResolved: boolean;
   catalogScope: CloudNotebookCatalogAccessScope | null;
+  catalogTitle?: string | null;
 }
 
-export interface CloudNotebookCatalogAccessLoaderOptions {
-  loadNotebooks: () => Promise<readonly unknown[]>;
-  notebookId: string;
-}
+export type CloudNotebookCatalogAccessLoaderOptions =
+  | {
+      loadCatalogAccess: () => Promise<CloudNotebookCatalogAccessLoadResult>;
+      notebookId: string;
+    }
+  | {
+      loadNotebooks: () => Promise<readonly unknown[]>;
+      notebookId: string;
+    };
 
 export interface CloudNotebookSyncScopeProjectionInput {
   catalogResolved: boolean;
@@ -65,20 +72,41 @@ export function cloudNotebookCatalogAccessFromList(
   };
 }
 
-export function createCloudNotebookCatalogAccessLoader({
-  loadNotebooks,
-  notebookId,
-}: CloudNotebookCatalogAccessLoaderOptions): {
+export function cloudNotebookCatalogAccessFromCatalogResponse(
+  body: CloudNotebookCatalogResponse,
+  notebookId: string,
+): CloudNotebookCatalogAccessLoadResult {
+  const notebook = body.notebook;
+  if (!notebook || notebook.id !== notebookId) {
+    throw new Error("Unable to load notebook catalog: response shape was invalid");
+  }
+  if (notebook.title !== null && typeof notebook.title !== "string") {
+    throw new Error("Unable to load notebook catalog: response shape was invalid");
+  }
+  return {
+    catalogResolved: true,
+    catalogScope: cloudNotebookCatalogAccessScope(body.access?.scope) ?? "viewer",
+    catalogTitle: notebook.title,
+  };
+}
+
+export function createCloudNotebookCatalogAccessLoader(
+  options: CloudNotebookCatalogAccessLoaderOptions,
+): {
   load: () => Promise<CloudNotebookCatalogAccessLoadResult>;
 } {
   let inFlight: Promise<CloudNotebookCatalogAccessLoadResult> | null = null;
   const load = () => {
-    inFlight ??= loadNotebooks()
-      .then((notebooks) => cloudNotebookCatalogAccessFromList(notebooks, notebookId))
-      .catch((error: unknown) => {
-        inFlight = null;
-        throw error;
-      });
+    inFlight ??= (
+      "loadCatalogAccess" in options
+        ? options.loadCatalogAccess()
+        : options
+            .loadNotebooks()
+            .then((notebooks) => cloudNotebookCatalogAccessFromList(notebooks, options.notebookId))
+    ).catch((error: unknown) => {
+      inFlight = null;
+      throw error;
+    });
     return inFlight;
   };
   return { load };
@@ -134,4 +162,11 @@ export function cloudNotebookScopeCanEditDocument(
   scope: string | null | undefined,
 ): scope is Extract<ConnectionScope, "editor" | "owner"> {
   return scope === "editor" || scope === "owner";
+}
+
+function cloudNotebookCatalogAccessScope(value: unknown): CloudNotebookCatalogAccessScope | null {
+  if (value === "viewer" || value === "editor" || value === "owner") {
+    return value;
+  }
+  return null;
 }

--- a/apps/notebook-cloud/viewer/cloud-notebook-title-state.ts
+++ b/apps/notebook-cloud/viewer/cloud-notebook-title-state.ts
@@ -17,6 +17,9 @@ export interface CloudNotebookCatalogResponse {
     id?: unknown;
     title?: unknown;
   };
+  access?: {
+    scope?: unknown;
+  };
 }
 
 const UNTITLED_NOTEBOOK_LABEL = "Untitled notebook";

--- a/apps/notebook-cloud/viewer/cloud-viewer-config.ts
+++ b/apps/notebook-cloud/viewer/cloud-viewer-config.ts
@@ -63,6 +63,7 @@ function loadConfig(): CloudViewerConfig {
       enable_comments: parsed.featureFlags?.enable_comments === true,
       disable_auto_format: parsed.featureFlags?.disable_auto_format === true,
     },
+    initialCatalogAccess: normalizeInitialCatalogAccess(parsed.initialCatalogAccess),
     session: isCloudAppSession(parsed.session) ? parsed.session : null,
     syncEndpoint: parsed.syncEndpoint,
     blobBasePath: parsed.blobBasePath,
@@ -71,6 +72,21 @@ function loadConfig(): CloudViewerConfig {
     outputDocumentBaseUrl: parsed.outputDocumentBaseUrl ?? null,
     runtimedWasmModulePath: parsed.runtimedWasmModulePath,
     runtimedWasmPath: parsed.runtimedWasmPath,
+  };
+}
+
+function normalizeInitialCatalogAccess(
+  value: CloudViewerConfig["initialCatalogAccess"] | undefined,
+): CloudViewerConfig["initialCatalogAccess"] {
+  if (!value || typeof value !== "object") {
+    return null;
+  }
+  if (value.scope !== "viewer" && value.scope !== "editor" && value.scope !== "owner") {
+    return null;
+  }
+  return {
+    scope: value.scope,
+    title: typeof value.title === "string" || value.title === null ? value.title : undefined,
   };
 }
 

--- a/apps/notebook-cloud/viewer/cloud-viewer-session.ts
+++ b/apps/notebook-cloud/viewer/cloud-viewer-session.ts
@@ -136,6 +136,10 @@ export interface CloudViewerConfig {
     enable_comments?: boolean;
     disable_auto_format?: boolean;
   };
+  initialCatalogAccess?: {
+    scope: "viewer" | "editor" | "owner";
+    title?: string | null;
+  } | null;
   session?: CloudAppSession | null;
   syncEndpoint: string;
   blobBasePath: string;

--- a/apps/notebook-cloud/viewer/edit-access.ts
+++ b/apps/notebook-cloud/viewer/edit-access.ts
@@ -83,7 +83,7 @@ export function projectCloudNotebookDocumentEditReadiness({
     cloudNotebookScopeCanEditDocument(accessScope) &&
     !canAcceptCellMutations &&
     !connectionError &&
-    statusKind === "loading";
+    (statusKind === "loading" || statusKind === "ready" || statusKind === "empty");
   return {
     canAcceptCellMutations,
     selectedEditModeWaitingForRoom,

--- a/apps/notebook-cloud/viewer/notebook-viewer.tsx
+++ b/apps/notebook-cloud/viewer/notebook-viewer.tsx
@@ -158,9 +158,9 @@ import {
   type CloudAccessRequestNoticeProjection,
 } from "./cloud-access-request-state";
 import {
+  cloudNotebookCatalogAccessFromCatalogResponse,
   cloudNotebookSyncScopeForCatalogAccess,
   createCloudNotebookCatalogAccessLoader,
-  type CloudNotebookCatalogAccessLoadResult,
   type CloudNotebookCatalogAccessScope,
 } from "./cloud-notebook-catalog-access";
 import { applyDocumentTheme, CLOUD_VIEWER_THEME_STORAGE_KEY } from "./theme";
@@ -192,7 +192,6 @@ import { CloudNotebookSignInButton } from "./cloud-auth-controls";
 import { CloudNotebookEditModeButton } from "./cloud-edit-mode-button";
 import { CloudNotebookTitle, cloudNotebookRouteTitle } from "./cloud-notebook-title";
 import {
-  cloudNotebookCatalogResponseTitle,
   cloudNotebookDocumentTitle,
   cloudNotebookTitleDisplay,
   cloudNotebookUrlAfterRename,
@@ -228,20 +227,13 @@ function useCloudAccessFactsProjection(source: CloudAccessSourceFacts): CloudAcc
   return useCloudFactsProjection(source, (initial) => new CloudAccessFactsStore(initial));
 }
 
-async function resolveCloudAppSessionSyncScope(
-  loadCatalogAccess: () => Promise<CloudNotebookCatalogAccessLoadResult>,
+function resolveCloudAppSessionSyncScope(
+  catalog: ReturnType<typeof cloudCatalogAccessFacts>,
   selectedMode: NotebookInteractionMode,
-): Promise<Exclude<ConnectionScope, "runtime_peer">> {
-  try {
-    return cloudNotebookSyncScopeForCatalogAccess({
-      ...(await loadCatalogAccess()),
-      selectedMode,
-    });
-  } catch (error) {
-    console.warn("[notebook-cloud] unable to resolve notebook access scope before sync", error);
-  }
+): Exclude<ConnectionScope, "runtime_peer"> {
   return cloudNotebookSyncScopeForCatalogAccess({
-    catalogResolved: false,
+    catalogResolved: catalog.status === "ready",
+    catalogScope: catalog.scope,
     selectedMode,
   });
 }
@@ -256,7 +248,7 @@ export function NotebookViewer({
   const { config } = runtime;
   const routeTitle = useMemo(() => cloudNotebookRouteTitle(), []);
   const [catalogNotebookTitle, setCatalogNotebookTitle] = useState<string | null | undefined>(
-    undefined,
+    () => config.initialCatalogAccess?.title,
   );
   const [notebookTitleSaving, setNotebookTitleSaving] = useState(false);
   const [notebookTitleError, setNotebookTitleError] = useState<string | null>(null);
@@ -326,8 +318,12 @@ export function NotebookViewer({
     null,
   );
   const [catalogAccessScope, setCatalogAccessScope] =
-    useState<CloudNotebookCatalogAccessScope | null>(null);
-  const [catalogAccessResolved, setCatalogAccessResolved] = useState(false);
+    useState<CloudNotebookCatalogAccessScope | null>(
+      () => config.initialCatalogAccess?.scope ?? null,
+    );
+  const [catalogAccessResolved, setCatalogAccessResolved] = useState(() =>
+    Boolean(config.initialCatalogAccess),
+  );
   const [catalogAccessLoadFailed, setCatalogAccessLoadFailed] = useState(false);
   const [accessRequestError, setAccessRequestError] = useState<string | null>(null);
   const [editAccessRequestedByUser, setEditAccessRequestedByUser] = useState(false);
@@ -358,10 +354,9 @@ export function NotebookViewer({
     () =>
       createCloudNotebookCatalogAccessLoader({
         notebookId: config.notebookId,
-        loadNotebooks: async () => {
-          const endpoint = new URL("api/n?limit=100", `${window.location.origin}/`);
+        loadCatalogAccess: async () => {
           const response = await fetchWithCloudPrototypeAuth(
-            endpoint.href,
+            config.catalogEndpoint,
             {
               cache: "no-store",
               headers: { Accept: "application/json" },
@@ -369,13 +364,15 @@ export function NotebookViewer({
             browserApiAuthState,
           );
           if (!response.ok) {
-            throw new Error(`Unable to load notebook catalog: ${response.status}`);
+            throw await cloudResponseError(response, "Unable to load notebook catalog");
           }
-          const body = (await response.json()) as { notebooks?: unknown };
-          return Array.isArray(body.notebooks) ? body.notebooks : [];
+          return cloudNotebookCatalogAccessFromCatalogResponse(
+            (await response.json()) as CloudNotebookCatalogResponse,
+            config.notebookId,
+          );
         },
       }),
-    [browserApiAuthState, config.notebookId],
+    [browserApiAuthState, config.catalogEndpoint, config.notebookId],
   );
   const catalogAccessFacts = useMemo(
     () =>
@@ -392,56 +389,10 @@ export function NotebookViewer({
       catalogAccessScope,
     ],
   );
+  const catalogAccessFactsRef = useRef(catalogAccessFacts);
   useEffect(() => {
-    if (!canUseAuthenticatedCloudApi) {
-      setCatalogNotebookTitle(undefined);
-      setNotebookTitleError(null);
-      return;
-    }
-
-    const controller = new AbortController();
-    let cancelled = false;
-    void (async () => {
-      try {
-        const response = await fetchWithCloudPrototypeAuth(
-          config.catalogEndpoint,
-          {
-            cache: "no-store",
-            headers: { Accept: "application/json" },
-            signal: controller.signal,
-          },
-          browserApiAuthState,
-        );
-        if (!response.ok) {
-          throw await cloudResponseError(response, "Unable to load notebook title");
-        }
-        const body = (await response.json()) as CloudNotebookCatalogResponse;
-        const title = cloudNotebookCatalogResponseTitle(body, config.notebookId);
-        if (!cancelled) {
-          setCatalogNotebookTitle(title);
-          setNotebookTitleError(null);
-        }
-      } catch (error) {
-        if (
-          cancelled ||
-          (typeof DOMException !== "undefined" &&
-            error instanceof DOMException &&
-            error.name === "AbortError")
-        ) {
-          return;
-        }
-        console.warn("[notebook-cloud] unable to load notebook title", error);
-        if (!cancelled) {
-          setCatalogNotebookTitle(undefined);
-        }
-      }
-    })();
-
-    return () => {
-      cancelled = true;
-      controller.abort();
-    };
-  }, [browserApiAuthState, canUseAuthenticatedCloudApi, config.catalogEndpoint, config.notebookId]);
+    catalogAccessFactsRef.current = catalogAccessFacts;
+  }, [catalogAccessFacts]);
   const catalogLiveRoomPolicy = useMemo(
     () =>
       projectCloudAccessLiveRoomPolicy({
@@ -496,8 +447,8 @@ export function NotebookViewer({
           ? ((await readCloudAppSessionStatus().catch(() => null))?.session ?? null)
           : null);
       if (appSession) {
-        const requestedScope = await resolveCloudAppSessionSyncScope(
-          catalogAccessLoader.load,
+        const requestedScope = resolveCloudAppSessionSyncScope(
+          catalogAccessFactsRef.current,
           selectedInteractionModeRef.current,
         );
         return cloudSyncAuthFromAppSessionCookie({
@@ -507,7 +458,7 @@ export function NotebookViewer({
       }
       return cloudSyncAuthFromPrototypeAuthState(authStateRef.current);
     },
-    [catalogAccessLoader, config.notebookId, syncAuthConnectionKey],
+    [config.notebookId, syncAuthConnectionKey],
   );
   const {
     connectionActorLabel,
@@ -785,17 +736,26 @@ export function NotebookViewer({
   }, []);
   const hasBrowserAppIdentity =
     hasAppSession || authState.mode === "dev" || authState.mode === "oidc";
+  const preserveInitialCatalogAccessRef = useRef(Boolean(config.initialCatalogAccess));
   useEffect(() => {
     if (!canUseAuthenticatedCloudApi) {
       setCatalogAccessScope(null);
       setCatalogAccessResolved(false);
       setCatalogAccessLoadFailed(false);
+      setCatalogNotebookTitle(undefined);
+      setNotebookTitleError(null);
+      preserveInitialCatalogAccessRef.current = false;
       return;
     }
 
     let cancelled = false;
-    setCatalogAccessScope(null);
-    setCatalogAccessResolved(false);
+    if (preserveInitialCatalogAccessRef.current) {
+      preserveInitialCatalogAccessRef.current = false;
+    } else {
+      setCatalogAccessScope(null);
+      setCatalogAccessResolved(false);
+      setCatalogNotebookTitle(undefined);
+    }
     setCatalogAccessLoadFailed(false);
     void (async () => {
       try {
@@ -804,12 +764,18 @@ export function NotebookViewer({
           setCatalogAccessScope(access.catalogScope);
           setCatalogAccessResolved(access.catalogResolved);
           setCatalogAccessLoadFailed(false);
+          if ("catalogTitle" in access) {
+            setCatalogNotebookTitle(access.catalogTitle ?? null);
+            setNotebookTitleError(null);
+          }
         }
-      } catch {
+      } catch (error) {
         if (!cancelled) {
           setCatalogAccessScope(null);
           setCatalogAccessResolved(false);
           setCatalogAccessLoadFailed(true);
+          setCatalogNotebookTitle(undefined);
+          setNotebookTitleError(error instanceof Error ? error.message : String(error));
         }
         return;
       }


### PR DESCRIPTION
## Summary
- seed notebook viewer HTML with app-session catalog access scope and title so logged-in reloads can start with the correct edit affordance
- switch notebook-viewer catalog access refresh from the broad `/api/n?limit=100` list fetch to the direct notebook catalog endpoint carrying `access.scope`
- keep edit mode pending while catalog grants edit access but the live room is still connected as viewer, avoiding the misleading "Request Sent" state

@rgbkrk @pullfrog would appreciate a review of the reload/auth bootstrap shape here.

## Tests
- `node --import tsx --test test/worker-routes.test.ts`
- `node --import tsx --test test/cloud-notebook-catalog-access.test.ts test/cloud-document-edit-readiness.test.ts test/viewer-shared-cell-surface.test.ts test/notebook-room.test.ts`
- `pnpm --dir apps/notebook-cloud typecheck`
- `cargo xtask lint --fix`
