### PR TITLE
feat(notebook-cloud): rich-detail cell strip - content previews on rows and hero

### DIFF
--- a/apps/notebook-cloud/src/index.ts
+++ b/apps/notebook-cloud/src/index.ts
@@ -92,7 +92,9 @@ import {
 } from "./workstation-events.ts";
 import { OwnerComputeIndex, listOwnerComputeSessions } from "./compute-session-index.ts";
 import {
+  SNAPSHOT_PREVIEW_TEXT_MAX_LENGTH,
   materializeSnapshotPairRenderWithSummary,
+  type SnapshotNotebookPreviewCell,
   type SnapshotNotebookSummary,
 } from "./snapshot-render.ts";
 import { notebookRouteSegmentTitle } from "./notebook-route-title.ts";
@@ -1427,6 +1429,7 @@ function notebookListResponseRows(
     const notebookPathId = encodeURIComponent(notebook.id);
     const apiBasePath = `/api/n/${notebookPathId}`;
     const composition = parseNotebookCellComposition(notebook.cell_composition);
+    const preview = parseNotebookPreviewCells(notebook.preview_cells);
     const computeSession =
       notebook.owner_principal === computeSessions.get(notebook.id)?.owner_principal
         ? computeSessions.get(notebook.id)
@@ -1445,6 +1448,7 @@ function notebookListResponseRows(
         ? { owner_display: principalDisplays.get(notebook.owner_principal) }
         : {}),
       ...(composition ? { composition } : {}),
+      ...(preview?.length ? { preview } : {}),
       ...(cover ? { cover } : {}),
       ...(typeof notebook.language === "string" ? { language: notebook.language } : {}),
       compute_session: computeSession,
@@ -1511,6 +1515,62 @@ function parseNotebookCellComposition(
 
 function isNotebookCellCount(value: unknown): value is number {
   return typeof value === "number" && Number.isSafeInteger(value) && value >= 0;
+}
+
+function parseNotebookPreviewCells(
+  value: string | null,
+): SnapshotNotebookPreviewCell[] | undefined {
+  if (!value) {
+    return undefined;
+  }
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(value);
+  } catch {
+    return undefined;
+  }
+  if (!Array.isArray(parsed) || parsed.length > 2) {
+    return undefined;
+  }
+  const preview: SnapshotNotebookPreviewCell[] = [];
+  for (const entry of parsed) {
+    if (!entry || typeof entry !== "object") {
+      return undefined;
+    }
+    const candidate = entry as {
+      execution_count?: unknown;
+      kind?: unknown;
+      text?: unknown;
+    };
+    if (candidate.kind !== "markdown" && candidate.kind !== "code") {
+      return undefined;
+    }
+    if (typeof candidate.text !== "string" || candidate.text.length === 0) {
+      return undefined;
+    }
+    const text = candidate.text.slice(0, SNAPSHOT_PREVIEW_TEXT_MAX_LENGTH);
+    if (candidate.kind === "markdown") {
+      if (candidate.execution_count !== undefined) {
+        return undefined;
+      }
+      preview.push({ kind: "markdown", text });
+      continue;
+    }
+    if (candidate.execution_count === undefined) {
+      preview.push({ kind: "code", text });
+      continue;
+    }
+    const executionCount = candidate.execution_count;
+    if (
+      typeof executionCount !== "number" ||
+      !Number.isSafeInteger(executionCount) ||
+      executionCount <= 0
+    ) {
+      return undefined;
+    }
+    preview.push({ kind: "code", text, execution_count: executionCount });
+  }
+  return preview;
 }
 
 function parseNotebookListLimit(request: Request): number | Response {

--- a/apps/notebook-cloud/src/snapshot-render.ts
+++ b/apps/notebook-cloud/src/snapshot-render.ts
@@ -33,12 +33,24 @@ export interface SnapshotNotebookSummary {
   cellComposition: SnapshotCellComposition;
   cover: SnapshotNotebookCover | null;
   language: string | null;
+  previewCells: SnapshotNotebookPreviewCell[];
 }
 
 export interface SnapshotNotebookCover {
   blobHash: string;
   mime: "image/png" | "image/jpeg" | "image/svg+xml";
 }
+
+export type SnapshotNotebookPreviewCell =
+  | {
+      kind: "markdown";
+      text: string;
+    }
+  | {
+      kind: "code";
+      text: string;
+      execution_count?: number;
+    };
 
 export interface MaterializedSnapshotPairRender {
   render: SnapshotRender;
@@ -79,6 +91,7 @@ export async function materializeSnapshotPairRenderWithSummary(
       cellComposition: countCellComposition(cells),
       cover: selectNotebookCoverFromCells(cells),
       language: readDetectedRuntime(handle, metadata),
+      previewCells: deriveNotebookPreviewCells(cells),
     };
     const commsDocId = readOptionalCommsDocId(handle);
     const rawWidgetComms = snapshotWidgetCommsFromRuntimeAndCommsState(runtimeState, commsState);
@@ -244,4 +257,87 @@ export function countCellComposition(cells: unknown): SnapshotCellComposition {
     }
   }
   return composition;
+}
+
+export const SNAPSHOT_PREVIEW_TEXT_MAX_LENGTH = 140;
+
+export function deriveNotebookPreviewCells(cells: unknown): SnapshotNotebookPreviewCell[] {
+  const previews: SnapshotNotebookPreviewCell[] = [];
+  if (!Array.isArray(cells)) {
+    return previews;
+  }
+
+  let markdownPreview: SnapshotNotebookPreviewCell | null = null;
+  let codePreview: SnapshotNotebookPreviewCell | null = null;
+
+  for (const cell of cells) {
+    const cellRecord = objectRecord(cell);
+    if (!cellRecord) {
+      continue;
+    }
+    const cellType = cellRecord.cell_type;
+
+    if (cellType === "markdown" && markdownPreview === null) {
+      // The opening line of the first prose cell - usually the title heading.
+      const sourceLine = firstNonEmptySourceLine(cellRecord.source);
+      if (sourceLine) {
+        markdownPreview = { kind: "markdown", text: truncatePreviewText(sourceLine) };
+      }
+      continue;
+    }
+
+    if (cellType === "code") {
+      // The closing line of the last code cell - the result expression a
+      // reader recognizes, not the imports above it.
+      const sourceLine = lastNonEmptySourceLine(cellRecord.source);
+      if (sourceLine) {
+        const executionCount = parsePositiveExecutionCount(cellRecord.execution_count);
+        codePreview = {
+          kind: "code",
+          text: truncatePreviewText(sourceLine),
+          ...(executionCount ? { execution_count: executionCount } : {}),
+        };
+      }
+    }
+  }
+
+  if (markdownPreview) {
+    previews.push(markdownPreview);
+  }
+  if (codePreview) {
+    previews.push(codePreview);
+  }
+  return previews;
+}
+
+function firstNonEmptySourceLine(source: unknown): string | null {
+  return nonEmptySourceLines(source)[0] ?? null;
+}
+
+function lastNonEmptySourceLine(source: unknown): string | null {
+  return nonEmptySourceLines(source).at(-1) ?? null;
+}
+
+function nonEmptySourceLines(source: unknown): string[] {
+  if (typeof source !== "string") {
+    return [];
+  }
+  return source.split(/\r\n|\n|\r/u).filter((line) => line.trim().length > 0);
+}
+
+function truncatePreviewText(value: string): string {
+  return value.length > SNAPSHOT_PREVIEW_TEXT_MAX_LENGTH
+    ? value.slice(0, SNAPSHOT_PREVIEW_TEXT_MAX_LENGTH)
+    : value;
+}
+
+function parsePositiveExecutionCount(value: unknown): number | null {
+  if (typeof value === "number") {
+    return Number.isSafeInteger(value) && value > 0 ? value : null;
+  }
+  if (typeof value !== "string" || !/^\s*[1-9]\d*\s*$/u.test(value)) {
+    return null;
+  }
+  const parsed = Number(value.trim());
+  return Number.isSafeInteger(parsed) ? parsed : null;
 }

--- a/apps/notebook-cloud/src/storage.ts
+++ b/apps/notebook-cloud/src/storage.ts
@@ -15,6 +15,7 @@ export interface NotebookRow {
   updated_at: string;
   latest_revision_id: string | null;
   cell_composition: string | null;
+  preview_cells: string | null;
   cover_blob_hash?: string | null;
   cover_mime?: string | null;
   language: string | null;
@@ -175,6 +176,7 @@ const SCHEMA_STATEMENTS = [
     updated_at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ', 'now')),
     latest_revision_id TEXT,
     cell_composition TEXT,
+    preview_cells TEXT,
     language TEXT
   )`,
   `CREATE TABLE IF NOT EXISTS notebook_revisions (
@@ -412,6 +414,11 @@ const SCHEMA_MIGRATIONS = [
   },
   {
     table: "notebooks",
+    column: "preview_cells",
+    statement: `ALTER TABLE notebooks ADD COLUMN preview_cells TEXT`,
+  },
+  {
+    table: "notebooks",
     column: "language",
     statement: `ALTER TABLE notebooks ADD COLUMN language TEXT`,
   },
@@ -541,6 +548,7 @@ export async function getNotebookRow(env: Env, notebookId: string): Promise<Note
             updated_at,
             latest_revision_id,
             cell_composition,
+            preview_cells,
             language
        FROM notebooks
        WHERE id = ?`,
@@ -566,6 +574,7 @@ export async function getPublicPublishedNotebookRow(
             n.updated_at,
             n.latest_revision_id,
             n.cell_composition,
+            n.preview_cells,
             n.language
        FROM notebooks n
        JOIN notebook_acl a
@@ -616,6 +625,7 @@ export async function updateNotebookSnapshotSummary(
       raw: number;
     };
     language: string | null;
+    previewCells: Array<{ kind: "markdown" | "code"; text: string; execution_count?: number }>;
   },
 ): Promise<void> {
   if (!env.DB) {
@@ -626,10 +636,16 @@ export async function updateNotebookSnapshotSummary(
   await env.DB.prepare(
     `UPDATE notebooks
         SET cell_composition = ?,
+            preview_cells = ?,
             language = ?
       WHERE id = ?`,
   )
-    .bind(JSON.stringify(summary.cellComposition), summary.language, notebookId)
+    .bind(
+      JSON.stringify(summary.cellComposition),
+      JSON.stringify(summary.previewCells),
+      summary.language,
+      notebookId,
+    )
     .run();
 }
 
@@ -742,6 +758,7 @@ export async function listNotebooksForPrincipal(
             n.updated_at,
             n.latest_revision_id,
             n.cell_composition,
+            n.preview_cells,
             r.cover_blob_hash,
             r.cover_mime,
             n.language,
@@ -780,6 +797,7 @@ export async function listNotebooksForPrincipal(
                n.updated_at,
                n.latest_revision_id,
                n.cell_composition,
+               n.preview_cells,
                r.cover_blob_hash,
                r.cover_mime,
                n.language
@@ -1731,6 +1749,7 @@ export async function getNotebookCatalog(
             updated_at,
             latest_revision_id,
             cell_composition,
+            preview_cells,
             language
        FROM notebooks
        WHERE id = ?`,

--- a/apps/notebook-cloud/test/notebook-cell-strip.test.ts
+++ b/apps/notebook-cloud/test/notebook-cell-strip.test.ts
@@ -1,0 +1,26 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+import * as React from "react";
+import { renderToStaticMarkup } from "react-dom/server";
+import { NotebookCellStrip } from "@/components/notebook/NotebookCellStrip";
+
+globalThis.React = React;
+
+test("notebook cell strip renders markdown HTML-looking source as inert text", () => {
+  const html = renderToStaticMarkup(
+    React.createElement(NotebookCellStrip, {
+      preview: [
+        {
+          kind: "markdown",
+          text: "<img onerror=alert(1)> **bold** `code`",
+        },
+      ],
+      thumbnail: null,
+    }),
+  );
+
+  assert.match(html, /&lt;img onerror=alert\(1\)&gt;/);
+  assert.doesNotMatch(html, /<img onerror=/);
+  assert.match(html, /<strong>bold<\/strong>/);
+  assert.match(html, /<code class="nb-md-code">code<\/code>/);
+});

--- a/apps/notebook-cloud/test/notebook-dashboard.test.ts
+++ b/apps/notebook-cloud/test/notebook-dashboard.test.ts
@@ -822,6 +822,43 @@ describe("cloud notebook dashboard projection", () => {
     assert.equal(cloudNotebookCoverUrl(covered), "/api/n/covered-notebook/blobs/cover-hash");
   });
 
+  it("threads notebook preview cells through list-item validation and dashboard rows", () => {
+    const previewed = notebook({
+      id: "previewed-notebook",
+      title: "Previewed Notebook",
+      scope: "owner",
+      updatedAt: "2026-06-24T00:00:00.000Z",
+      latestRevisionId: "published-previewed",
+      preview: [
+        { kind: "markdown", text: "# Model notes" },
+        { kind: "code", text: "chart = alt.Chart(df)", execution_count: 8 },
+      ],
+    });
+
+    assert.equal(isCloudNotebookListItem(previewed), true);
+    assert.equal(
+      isCloudNotebookListItem({
+        ...previewed,
+        preview: [{ kind: "markdown", text: "# Model notes", execution_count: 1 }],
+      }),
+      false,
+    );
+    assert.equal(
+      isCloudNotebookListItem({
+        ...previewed,
+        preview: [{ kind: "code", text: "run()", execution_count: "8" }],
+      }),
+      false,
+    );
+
+    const model = projectCloudNotebookDashboard([previewed]);
+
+    assert.deepEqual(model.continueRow?.notebook.preview, [
+      { kind: "markdown", text: "# Model notes" },
+      { kind: "code", text: "chart = alt.Chart(df)", execution_count: 8 },
+    ]);
+  });
+
   it("maps compute session status to dashboard runtime status", () => {
     const base = {
       id: "runtime-status",
@@ -891,6 +928,7 @@ function notebook(input: {
   cover?: CloudNotebookListItem["cover"];
   language?: string;
   peers?: CloudNotebookListItem["peers"];
+  preview?: CloudNotebookListItem["preview"];
 }): CloudNotebookListItem {
   return {
     notebook_id: input.id,
@@ -905,6 +943,7 @@ function notebook(input: {
     ...(input.cover ? { cover: input.cover } : {}),
     ...(input.language ? { language: input.language } : {}),
     ...(input.peers ? { peers: input.peers } : {}),
+    ...(input.preview ? { preview: input.preview } : {}),
     viewer_url: `/n/${input.id}/notebook`,
     endpoints: {
       catalog: `/api/n/${input.id}`,

--- a/apps/notebook-cloud/test/snapshot-render.test.ts
+++ b/apps/notebook-cloud/test/snapshot-render.test.ts
@@ -4,9 +4,11 @@ import { readFile } from "node:fs/promises";
 import { RuntimeStatePeerHandle } from "../src/runtimed-wasm.ts";
 import {
   countCellComposition,
+  deriveNotebookPreviewCells,
   detectRuntimeFromMetadata,
   materializeSnapshotPairRender,
   selectNotebookCoverFromCells,
+  SNAPSHOT_PREVIEW_TEXT_MAX_LENGTH,
 } from "../src/snapshot-render.ts";
 import {
   createNotebookCloudBlobResolver,
@@ -412,6 +414,63 @@ describe("snapshot summary derivation helpers", () => {
     assert.deepEqual(countCellComposition(null), { code: 0, markdown: 0, raw: 0 });
     assert.deepEqual(countCellComposition("cells"), { code: 0, markdown: 0, raw: 0 });
     assert.deepEqual(countCellComposition({ cells: [] }), { code: 0, markdown: 0, raw: 0 });
+  });
+
+  it("derives markdown from the first markdown cell and code from the last code cell", () => {
+    assert.deepEqual(
+      deriveNotebookPreviewCells([
+        { cell_type: "code", source: "first_code()", execution_count: "3" },
+        { cell_type: "markdown", source: "\n# First heading\nBody" },
+        { cell_type: "markdown", source: "# Second heading" },
+        {
+          cell_type: "code",
+          source: "import pandas as pd\nresult = fit(df)\nresult.head()\n",
+          execution_count: "12",
+        },
+      ]),
+      [
+        { kind: "markdown", text: "# First heading" },
+        { kind: "code", text: "result.head()", execution_count: 12 },
+      ],
+    );
+  });
+
+  it("truncates preview text at 140 characters", () => {
+    const longMarkdown = `# ${"m".repeat(SNAPSHOT_PREVIEW_TEXT_MAX_LENGTH + 20)}`;
+    const longCode = `print('${"c".repeat(SNAPSHOT_PREVIEW_TEXT_MAX_LENGTH + 20)}')`;
+
+    const preview = deriveNotebookPreviewCells([
+      { cell_type: "markdown", source: longMarkdown },
+      { cell_type: "code", source: longCode },
+    ]);
+
+    assert.equal(preview[0]?.text.length, SNAPSHOT_PREVIEW_TEXT_MAX_LENGTH);
+    assert.equal(preview[0]?.text, longMarkdown.slice(0, SNAPSHOT_PREVIEW_TEXT_MAX_LENGTH));
+    assert.equal(preview[1]?.text.length, SNAPSHOT_PREVIEW_TEXT_MAX_LENGTH);
+    assert.equal(preview[1]?.text, longCode.slice(0, SNAPSHOT_PREVIEW_TEXT_MAX_LENGTH));
+  });
+
+  it("omits execution counts that are not positive integer strings", () => {
+    assert.deepEqual(
+      deriveNotebookPreviewCells([
+        { cell_type: "code", source: "zero()", execution_count: "0" },
+        { cell_type: "code", source: "legacy()", execution_count: "7-ish" },
+      ]),
+      [{ kind: "code", text: "legacy()" }],
+    );
+  });
+
+  it("skips empty and malformed preview cells", () => {
+    assert.deepEqual(
+      deriveNotebookPreviewCells([
+        null,
+        "not-a-cell",
+        { cell_type: "markdown", source: "\n  \n" },
+        { cell_type: "code", source: 42, execution_count: "4" },
+        { cell_type: "raw", source: "raw is not previewed" },
+      ]),
+      [],
+    );
   });
 
   it("detects runtime from kernelspec name, language, language_info, and runt metadata", () => {

--- a/apps/notebook-cloud/test/worker-routes.test.ts
+++ b/apps/notebook-cloud/test/worker-routes.test.ts
@@ -1980,12 +1980,13 @@ describe("Worker artifact routes", () => {
     assert.equal(body.notebooks[1]?.endpoints.catalog, "/api/n/editor-shared");
   });
 
-  it("omits malformed notebook composition from list rows without dropping language", async () => {
+  it("omits malformed notebook composition and preview cells from list rows without dropping language", async () => {
     const env = fakeEnv();
     seedNotebook(env, "malformed-summary");
     const notebook = env.DB.notebooks.get("malformed-summary");
     assert.ok(notebook);
     notebook.cell_composition = "{not-json";
+    notebook.preview_cells = "{not-json";
     notebook.language = "python";
     seedAcl(env, { notebookId: "malformed-summary", subject: "user:dev:alice", scope: "owner" });
 
@@ -2007,6 +2008,7 @@ describe("Worker artifact routes", () => {
         composition?: unknown;
         language?: string;
         notebook_id: string;
+        preview?: unknown;
       }>;
     };
     const row = body.notebooks.find(
@@ -2014,6 +2016,7 @@ describe("Worker artifact routes", () => {
     );
     assert.ok(row);
     assert.equal(Object.hasOwn(row, "composition"), false);
+    assert.equal(Object.hasOwn(row, "preview"), false);
     assert.equal(row.language, "python");
   });
 
@@ -5768,7 +5771,7 @@ describe("Worker artifact routes", () => {
     assert.equal(renderCacheRoute.status, 404);
   });
 
-  it("persists snapshot cell composition and notebook language for list rows", async () => {
+  it("persists snapshot cell composition, preview cells, and notebook language for list rows", async () => {
     const env = fakeEnv();
     const { notebookBytes, runtimeStateBytes } = pythonSummarySnapshotPair(
       "summary-demo",
@@ -5798,6 +5801,13 @@ describe("Worker artifact routes", () => {
 
     const notebook = env.DB.notebooks.get("summary-demo");
     assert.equal(notebook?.cell_composition, JSON.stringify({ code: 1, markdown: 1, raw: 1 }));
+    assert.equal(
+      notebook?.preview_cells,
+      JSON.stringify([
+        { kind: "markdown", text: "# Summary heading" },
+        { kind: "code", text: "print('first code')" },
+      ]),
+    );
     assert.equal(notebook?.language, "python");
 
     const listResponse = await worker.fetch(
@@ -5817,10 +5827,15 @@ describe("Worker artifact routes", () => {
         composition?: { code: number; markdown: number; raw: number };
         language?: string;
         notebook_id: string;
+        preview?: Array<{ kind: string; text: string; execution_count?: number }>;
       }>;
     };
     const row = listBody.notebooks.find((candidate) => candidate.notebook_id === "summary-demo");
     assert.deepEqual(row?.composition, { code: 1, markdown: 1, raw: 1 });
+    assert.deepEqual(row?.preview, [
+      { kind: "markdown", text: "# Summary heading" },
+      { kind: "code", text: "print('first code')" },
+    ]);
     assert.equal(row?.language, "python");
   });
 
@@ -6039,6 +6054,7 @@ describe("Worker artifact routes", () => {
       env.DB.revisions[0]?.id,
     );
     assert.equal(env.DB.notebooks.get("summary-fail-open")?.cell_composition, null);
+    assert.equal(env.DB.notebooks.get("summary-fail-open")?.preview_cells, null);
     assert.ok(
       warnings.some(
         (entry) =>
@@ -6341,6 +6357,7 @@ describe("catalog schema migrations", () => {
     const notebookColumns = db.tableColumns.get("notebooks");
     assert.ok(notebookColumns);
     notebookColumns.delete("cell_composition");
+    notebookColumns.delete("preview_cells");
     notebookColumns.delete("language");
     const revisionColumns = db.tableColumns.get("notebook_revisions");
     assert.ok(revisionColumns);
@@ -6352,6 +6369,7 @@ describe("catalog schema migrations", () => {
 
     const migrated = db.tableColumns.get("notebooks");
     assert.ok(migrated?.has("cell_composition"), "cell_composition added by migration");
+    assert.ok(migrated?.has("preview_cells"), "preview_cells added by migration");
     assert.ok(migrated?.has("language"), "language added by migration");
     const migratedRevisions = db.tableColumns.get("notebook_revisions");
     assert.ok(migratedRevisions?.has("cover_blob_hash"), "cover_blob_hash added by migration");
@@ -7119,6 +7137,7 @@ function seedNotebook(env: FakeEnv, notebookId: string): void {
     updated_at: "2026-05-22T00:00:00.000Z",
     latest_revision_id: null,
     cell_composition: null,
+    preview_cells: null,
     language: null,
   });
 }
@@ -7322,6 +7341,9 @@ function pythonSummarySnapshotPair(
     notebook.add_cell_after("cell-code", "code", null);
     notebook.add_cell_after("cell-markdown", "markdown", "cell-code");
     notebook.add_cell_after("cell-raw", "raw", "cell-markdown");
+    notebook.update_source("cell-code", "import pandas as pd\nprint('first code')");
+    notebook.update_source("cell-markdown", "# Summary heading\n\nNarrative body");
+    notebook.update_source("cell-raw", "raw note");
     return {
       notebookBytes: notebook.save(),
       runtimeStateBytes: runtime.save(),
@@ -7567,6 +7589,7 @@ interface NotebookRow {
   updated_at: string;
   latest_revision_id: string | null;
   cell_composition: string | null;
+  preview_cells: string | null;
   cover_blob_hash?: string | null;
   cover_mime?: string | null;
   language: string | null;
@@ -7672,6 +7695,7 @@ class FakeD1 implements D1Database {
         "updated_at",
         "latest_revision_id",
         "cell_composition",
+        "preview_cells",
         "language",
       ]),
     ],
@@ -8486,6 +8510,7 @@ class FakeD1Statement implements D1PreparedStatement {
         updated_at: updatedAt,
         latest_revision_id: existing?.latest_revision_id ?? null,
         cell_composition: existing?.cell_composition ?? null,
+        preview_cells: existing?.preview_cells ?? null,
         language: existing?.language ?? null,
       });
       return okResult(undefined, { changes: 1 });
@@ -8493,7 +8518,8 @@ class FakeD1Statement implements D1PreparedStatement {
       if (this.db.failNotebookSummaryUpdate) {
         throw new Error("fake summary update failure");
       }
-      const [cellComposition, language, notebookId] = this.values as [
+      const [cellComposition, previewCells, language, notebookId] = this.values as [
+        string | null,
         string | null,
         string | null,
         string,
@@ -8501,6 +8527,7 @@ class FakeD1Statement implements D1PreparedStatement {
       const existing = this.db.notebooks.get(notebookId);
       if (existing) {
         existing.cell_composition = cellComposition;
+        existing.preview_cells = previewCells;
         existing.language = language;
         return okResult(undefined, { changes: 1 });
       }

--- a/apps/notebook-cloud/viewer/cloud-notebook-dashboard-view.tsx
+++ b/apps/notebook-cloud/viewer/cloud-notebook-dashboard-view.tsx
@@ -16,6 +16,7 @@ import {
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
+import { NotebookCellStrip } from "@/components/notebook/NotebookCellStrip";
 import { LanguageMark } from "@/components/runtime/LanguageMark";
 import { NotebookCompositionTicks } from "@/components/notebook/NotebookCompositionTicks";
 import { RuntimeStatusDot } from "@/components/runtime/RuntimeStatusDot";
@@ -214,6 +215,7 @@ function CloudNotebookDashboardHero({
       : null);
   const cellCount = row.composition ? notebookCompositionTotal(row.composition) : null;
   const heroComputeFact = row.facts.find((fact) => fact.kind === "compute") ?? null;
+  const stripThumbnail = cloudNotebookCellStripThumbnail(notebook);
 
   return (
     <section
@@ -250,6 +252,9 @@ function CloudNotebookDashboardHero({
           </div>
           {row.composition ? (
             <NotebookCompositionTicks composition={row.composition} className="nb-hero-fp" />
+          ) : null}
+          {notebook.preview?.length || stripThumbnail ? (
+            <NotebookCellStrip preview={notebook.preview ?? []} thumbnail={stripThumbnail} />
           ) : null}
         </div>
         <div className="nb-hero-side">
@@ -444,9 +449,15 @@ function CloudNotebookDashboardRowView({
   // the column shows the calm dot + terse status, the full label rides title/aria.
   const computeFact = row.facts.find((fact) => fact.kind === "compute") ?? null;
   const languageLabel = cloudNotebookLanguageDisplayLabel(notebook.language);
+  const stripThumbnail = cloudNotebookCellStripThumbnail(notebook);
+  const showStrip = Boolean(notebook.preview?.length || stripThumbnail);
 
   return (
-    <div className={`nb-row${activeNow ? " is-live" : ""}`} data-scope={notebook.scope}>
+    <div
+      className={`nb-row${activeNow ? " is-live" : ""}`}
+      data-cover-slot={showStrip && showCoverSlot ? "true" : undefined}
+      data-scope={notebook.scope}
+    >
       <a
         className="nb-row-lead"
         href={openUrl}
@@ -528,6 +539,11 @@ function CloudNotebookDashboardRowView({
           <ArrowRight aria-hidden="true" />
         </a>
       </span>
+      {showStrip ? (
+        <div className="nb-row-strip">
+          <NotebookCellStrip preview={notebook.preview ?? []} thumbnail={stripThumbnail} />
+        </div>
+      ) : null}
     </div>
   );
 }
@@ -595,6 +611,13 @@ function CloudNotebookHeroBanner({ notebook }: { notebook: CloudNotebookListItem
       <img className="nb-output-img" src={coverUrl} alt="" />
     </div>
   );
+}
+
+function cloudNotebookCellStripThumbnail(
+  notebook: CloudNotebookListItem,
+): { src: string; alt: string } | null {
+  const src = cloudNotebookCoverUrl(notebook);
+  return src ? { src, alt: "" } : null;
 }
 
 function NotebookCoverFallbackIcon({

--- a/apps/notebook-cloud/viewer/index.css
+++ b/apps/notebook-cloud/viewer/index.css
@@ -1440,6 +1440,15 @@ body {
   gap: 4px;
 }
 
+.nb-row-strip {
+  grid-column: 1 / -1;
+  padding-top: 2px;
+}
+
+.nb-row[data-cover-slot="true"] .nb-row-strip {
+  padding-left: 52px;
+}
+
 .nb-row-icon {
   width: 28px;
   height: 28px;
@@ -1795,6 +1804,11 @@ body {
   }
 
   .nb-subline {
+    display: none;
+  }
+
+  .nb-row-strip,
+  .nb-hero .nb-cellstrip {
     display: none;
   }
 

--- a/apps/notebook-cloud/viewer/notebook-dashboard.ts
+++ b/apps/notebook-cloud/viewer/notebook-dashboard.ts
@@ -17,6 +17,7 @@ export interface CloudNotebookListItem {
   compute_session?: NotebookComputeSessionSummary | null;
   composition?: CloudNotebookComposition;
   cover?: CloudNotebookCover;
+  preview?: CloudNotebookPreviewCell[];
   language?: string;
   peers?: CloudNotebookPresencePeer[];
   viewer_url: string;
@@ -37,6 +38,17 @@ export interface CloudNotebookCover {
   blob_hash: string;
   mime: "image/png" | "image/jpeg" | "image/svg+xml";
 }
+
+export type CloudNotebookPreviewCell =
+  | {
+      kind: "markdown";
+      text: string;
+    }
+  | {
+      kind: "code";
+      text: string;
+      execution_count?: number;
+    };
 
 export interface CloudNotebookPresencePeer {
   participant_key: string;
@@ -309,6 +321,7 @@ export function isCloudNotebookListItem(value: unknown): value is CloudNotebookL
       isNotebookComputeSessionSummary(candidate.compute_session)) &&
     (candidate.composition === undefined || isCloudNotebookComposition(candidate.composition)) &&
     (candidate.cover === undefined || isCloudNotebookCover(candidate.cover)) &&
+    (candidate.preview === undefined || isCloudNotebookPreviewCells(candidate.preview)) &&
     (candidate.language === undefined || typeof candidate.language === "string") &&
     (candidate.owner_display === undefined || typeof candidate.owner_display === "string") &&
     (candidate.peers === undefined ||
@@ -347,6 +360,33 @@ function isCloudNotebookCover(value: unknown): value is CloudNotebookCover {
     (candidate.mime === "image/png" ||
       candidate.mime === "image/jpeg" ||
       candidate.mime === "image/svg+xml")
+  );
+}
+
+function isCloudNotebookPreviewCells(value: unknown): value is CloudNotebookPreviewCell[] {
+  return Array.isArray(value) && value.length <= 2 && value.every(isCloudNotebookPreviewCell);
+}
+
+function isCloudNotebookPreviewCell(value: unknown): value is CloudNotebookPreviewCell {
+  if (!value || typeof value !== "object") {
+    return false;
+  }
+  const candidate = value as { execution_count?: unknown; kind?: unknown; text?: unknown };
+  if (
+    (candidate.kind !== "markdown" && candidate.kind !== "code") ||
+    typeof candidate.text !== "string"
+  ) {
+    return false;
+  }
+  if (candidate.kind === "markdown") {
+    return !("execution_count" in candidate);
+  }
+  const executionCount = candidate.execution_count;
+  return (
+    executionCount === undefined ||
+    (typeof executionCount === "number" &&
+      Number.isSafeInteger(executionCount) &&
+      executionCount > 0)
   );
 }
 

--- a/src/components/notebook/NotebookCellStrip.tsx
+++ b/src/components/notebook/NotebookCellStrip.tsx
@@ -1,0 +1,96 @@
+import { Fragment, type ReactNode } from "react";
+import { Code } from "lucide-react";
+import { ExecutionCount } from "@/components/cell/ExecutionCount";
+
+export type NotebookCellStripPreviewEntry =
+  | {
+      kind: "markdown";
+      text: string;
+    }
+  | {
+      kind: "code";
+      text: string;
+      execution_count?: number;
+    };
+
+export interface NotebookCellStripProps {
+  preview: NotebookCellStripPreviewEntry[];
+  thumbnail?: { src: string; alt?: string } | null;
+  className?: string;
+}
+
+/**
+ * Renders a notebook's content preview as a mini cell strip: a prose line from
+ * the first markdown cell, the closing line of the last code cell (with its
+ * execution count), and the notebook's rendered output thumbnail. Preview text
+ * is untrusted cell source - it renders exclusively as React text nodes (the
+ * mini markdown parser emits elements, never HTML), so markup in a cell's
+ * source stays inert.
+ */
+export function NotebookCellStrip({ preview, thumbnail, className }: NotebookCellStripProps) {
+  if (preview.length === 0 && !thumbnail) {
+    return null;
+  }
+
+  return (
+    <div className={["nb-cellstrip", className].filter(Boolean).join(" ")}>
+      {preview.map((entry, index) =>
+        entry.kind === "markdown" ? (
+          <div key={`markdown-${index}`} className="nb-cellrow nb-cellrow-md">
+            <span className="nb-cellribbon" data-ct="markdown" />
+            <div className="nb-md-preview">{renderMiniMarkdown(entry.text)}</div>
+          </div>
+        ) : (
+          <div key={`code-${index}`} className="nb-cellrow" data-ct="code">
+            <span className="nb-cellribbon" data-ct="code" />
+            <span className="nb-cellgutter">
+              {entry.execution_count ? (
+                <ExecutionCount count={entry.execution_count} className="nb-cell-exec" />
+              ) : (
+                <Code aria-hidden="true" size={13} strokeWidth={1.8} />
+              )}
+            </span>
+            <code className="nb-cellcode">{entry.text}</code>
+          </div>
+        ),
+      )}
+      {thumbnail ? (
+        <div className="nb-cellout">
+          <span className="nb-output-img">
+            <img src={thumbnail.src} alt={thumbnail.alt ?? ""} loading="lazy" />
+          </span>
+        </div>
+      ) : null}
+    </div>
+  );
+}
+
+function renderMiniMarkdown(text: string): ReactNode {
+  const heading = text.match(/^(#{1,6})\s+(.*)$/u);
+  if (heading) {
+    return (
+      <span className="nb-md-h" data-lvl={heading[1]?.length}>
+        {heading[2]}
+      </span>
+    );
+  }
+
+  const parts = text.split(/(\*\*[^*]+\*\*|`[^`]+`)/gu).filter(Boolean);
+  return (
+    <span className="nb-md-p">
+      {parts.map((part, index) => {
+        if (part.startsWith("**") && part.endsWith("**")) {
+          return <strong key={index}>{part.slice(2, -2)}</strong>;
+        }
+        if (part.startsWith("`") && part.endsWith("`")) {
+          return (
+            <code key={index} className="nb-md-code">
+              {part.slice(1, -1)}
+            </code>
+          );
+        }
+        return <Fragment key={index}>{part}</Fragment>;
+      })}
+    </span>
+  );
+}

--- a/src/styles/dashboard-atoms.css
+++ b/src/styles/dashboard-atoms.css
@@ -69,6 +69,149 @@
   background: var(--ct-raw);
 }
 
+/* Mini cell strip: rendered dashboard previews of notebook markdown/code plus
+   a real cover thumbnail when the notebook has one. */
+.nb-cellstrip {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  margin-top: 2px;
+}
+
+.nb-cellrow {
+  display: grid;
+  grid-template-columns: 3px 30px minmax(0, 1fr);
+  align-items: center;
+  gap: 8px;
+  height: 26px;
+  overflow: hidden;
+  border-radius: 6px;
+  padding-right: 10px;
+  background: color-mix(in srgb, var(--muted) 55%, transparent);
+}
+
+.nb-cellrow-md {
+  grid-template-columns: 3px minmax(0, 1fr);
+  align-items: start;
+  height: auto;
+  gap: 11px;
+  padding: 3px 0;
+  background: transparent;
+}
+
+.nb-cellrow-md .nb-cellribbon {
+  align-self: stretch;
+  min-height: 18px;
+}
+
+.nb-cellribbon {
+  align-self: stretch;
+  border-radius: 3px;
+}
+
+.nb-cellribbon[data-ct="code"] {
+  background: var(--ct-code);
+}
+
+.nb-cellribbon[data-ct="markdown"] {
+  background: var(--ct-markdown);
+}
+
+.nb-cellribbon[data-ct="raw"] {
+  background: var(--ct-raw);
+}
+
+.nb-cellgutter {
+  display: grid;
+  place-items: center;
+  min-width: 0;
+  color: var(--muted-foreground);
+  font-size: 11px;
+}
+
+.nb-cell-exec {
+  min-width: 0;
+  height: auto;
+}
+
+.nb-cellcode {
+  overflow: hidden;
+  color: color-mix(in srgb, var(--foreground) 78%, transparent);
+  font-size: 11.5px;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.nb-md-preview {
+  min-width: 0;
+  overflow: hidden;
+}
+
+.nb-md-h {
+  display: block;
+  overflow: hidden;
+  color: var(--foreground);
+  font-size: 12.5px;
+  font-weight: 680;
+  line-height: 1.25;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.nb-md-h[data-lvl="1"] {
+  font-size: 15px;
+}
+
+.nb-md-h[data-lvl="2"] {
+  font-size: 13.5px;
+}
+
+.nb-md-h[data-lvl="3"],
+.nb-md-h[data-lvl="4"] {
+  color: color-mix(in srgb, var(--foreground) 80%, transparent);
+  font-size: 12.5px;
+}
+
+.nb-md-p {
+  color: color-mix(in srgb, var(--foreground) 72%, transparent);
+  font-size: 12.5px;
+  line-height: 1.4;
+}
+
+.nb-md-code {
+  border-radius: 4px;
+  padding: 0 4px;
+  background: var(--muted);
+  font-family: ui-monospace, Menlo, monospace;
+  font-size: 11.5px;
+}
+
+.nb-cellout {
+  display: flex;
+  align-items: center;
+  gap: 11px;
+  margin-top: 1px;
+}
+
+.nb-cellout .nb-output-img {
+  display: block;
+  width: 152px;
+  height: 60px;
+  flex: 0 0 auto;
+  overflow: hidden;
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  background: var(--card);
+  box-shadow: var(--nb-shadow);
+}
+
+.nb-cellout .nb-output-img img {
+  display: block;
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+}
+
 /* Runtime status: a calm dot with an optional terse label. */
 .nb-kernel {
   display: inline-flex;


### PR DESCRIPTION
The last visual tier of the dashboard design: the mini cell strip. Rows and the hero now preview the notebook's actual content - a prose line, the closing code line with its execution count, and the rendered output thumbnail. **Stacked on #3894** (the LanguageMark icon fix); retargets to main when that merges.

## Data

Derivation joins the existing snapshot-publish summary pass (composition/language/cover precedent - zero extra decode):

- **markdown preview** - first non-empty line of the first markdown cell, heading markers kept (the client derives the level)
- **code preview** - the **last** non-empty line of the last code cell (the result expression a reader recognizes - `result.head()` - not the imports above it), with `execution_count` when it parses as a positive integer

Stored as nullable `preview_cells` JSON on `notebooks`, same fail-open contract, lazy backfill. Served on the existing list SELECT with shape validation and defensive re-truncation (140 chars) - a hand-edited D1 row can't flood the client. The thumbnail **reuses the cover blob**; no duplicate storage.

## The component

`NotebookCellStrip` (`src/components/notebook/`, prop-driven, guide-syncable). The safety invariant is the headline: preview text is **untrusted cell source**, and it renders exclusively as React text nodes - the mini markdown parser (headings, inline bold/backticks) emits elements, never HTML, so `<img onerror=...>` in a cell's first line appears as literal text. Pinned by an escaping test. Code rows reuse the suite's `ExecutionCount`; strip CSS joins `src/styles/dashboard-atoms.css` so product and guide stay one surface.

Rows without preview data render byte-identically to before; the strip hides in the narrow collapse.

## Review findings folded in

The adversarial content-safety pass ran clean on the parser and turned up three things, all addressed: the code preview originally took the *first* line of the last cell (spec error - the design's own examples are result expressions; now last line, pinned by a multi-line-cell test), a `data-cover-slot` attribute was stamped on every row unconditionally (now only when a strip renders), and one dead CSS rule shipped from the mockup (dropped).

## Verification

- [x] Cloud tests 1205/1205, cloud + desktop builds, `vp check` clean
- [x] Derivation unit coverage: line position (multi-line closing cell), truncation at both write and serve, legacy execution-count strings, malformed cells skipped, HTML-in-source escaping
- [x] Migration delete-then-migrate path exercised

After merge: one design-sync pass adds the `NotebookCellStrip` card to the guide and refreshes `LanguageMark` with the real marks.
