### PR TITLE
fix(notebook): update macOS app bundle plist

### DIFF
--- a/crates/notebook/Info.plist
+++ b/crates/notebook/Info.plist
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+  <!-- Tauri merges this file into the generated macOS bundle Info.plist. -->
+  <key>LSRequiresCarbon</key>
+  <false/>
+  <key>NSPrincipalClass</key>
+  <string>NSApplication</string>
+</dict>
+</plist>

--- a/crates/notebook/tauri.conf.json
+++ b/crates/notebook/tauri.conf.json
@@ -66,6 +66,7 @@
     "macOS": {
       "entitlements": "entitlements.plist",
       "hardenedRuntime": true,
+      "infoPlist": "Info.plist",
       "minimumSystemVersion": "11.0"
     },
     "windows": {


### PR DESCRIPTION
## Summary

- Add a macOS `Info.plist` merge file for the Tauri notebook app bundle.
- Set `LSRequiresCarbon` to `false` and `NSPrincipalClass` to `NSApplication`.
- Point `tauri.conf.json` at the merge file so the values are applied before signing/notarization.

## Context

The reported macOS crash happened on macOS 26.5 in AppKit/HIServices on the main thread, with no Rust panic or daemon/runtime crash in the stack. The uploaded diagnostics showed the daemon was healthy, but the included app log started after the crash, so the immediate UI action before the crash was not captured.

The installed stable app bundle currently has `LSRequiresCarbon = true` and no `NSPrincipalClass`. This PR removes that Carbon-era bundle marker from generated macOS bundles and declares the app principal class explicitly.

## Verification

- `plutil -lint crates/notebook/Info.plist`
- `cargo check -p notebook`
- `cargo xtask lint --fix`
- Built a debug `.app` bundle with signing, sidecars, and the real frontend payload disabled, then inspected `Contents/Info.plist`:
  - `LSRequiresCarbon => false`
  - `NSPrincipalClass => "NSApplication"`

## Follow-up

- Consider including recent macOS crash reports from `~/Library/Logs/DiagnosticReports` in the Send Logs to Developer archive, since the diagnostics upload did not include the `.ips` crash report.
