### PR TITLE
chore(design-sync): add NotebookCellStrip card, refresh LanguageMark marks

### DIFF
--- a/.design-sync/NOTES.md
+++ b/.design-sync/NOTES.md
@@ -99,6 +99,13 @@ passthroughs. Curated list in `synthpkg/build.mjs` (`groups[].dir === 'outputs'`
   NotebookCompositionTicks.tsx (NOT all of components/notebook - NotebookCommentsPanel
   stays deferred with the katex pass).
 - LanguageMark's Marks story needed cardMode: column (five chips run wide).
+- NotebookCellStrip joined the notebook group 2026-07-02 (cardMode: column - its
+  420px stories run wide). Its UntrustedSource story demonstrates the escaping
+  invariant on-card. The mini markdown parser does NOT inline-parse headings
+  (faithful to the design) - preview fixtures should not put **bold** inside #-lines.
+- The resync driver does not rerun buildCmd when config group lists change without
+  other key changes - run build.mjs + package-build.mjs manually after editing
+  groups, then the driver.
 - NotebookCommentsPanel unlock (katex pass) will join the notebook group.
 
 ## Groups + curated lists

--- a/.design-sync/config.json
+++ b/.design-sync/config.json
@@ -69,6 +69,9 @@
     },
     "LanguageMark": {
       "cardMode": "column"
+    },
+    "NotebookCellStrip": {
+      "cardMode": "column"
     }
   },
   "componentSrcMap": {

--- a/.design-sync/css-entry.css
+++ b/.design-sync/css-entry.css
@@ -23,6 +23,7 @@
 @source "../src/components/cell";
 @source "../src/components/outputs";
 @source "../src/components/comments";
+@source "../src/components/notebook/NotebookCellStrip.tsx";
 @source "../src/components/notebook/NotebookCompositionTicks.tsx";
 @source "../src/components/runtime";
 @source "./previews";

--- a/.design-sync/previews/NotebookCellStrip.tsx
+++ b/.design-sync/previews/NotebookCellStrip.tsx
@@ -1,0 +1,59 @@
+import { NotebookCellStrip } from "nteract-elements";
+
+// A small inline chart as the output thumbnail - the real dashboard passes the
+// notebook's rendered cover blob here.
+const chartSvg = encodeURIComponent(
+  `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 152 60">` +
+    `<polygon fill="rgba(56,189,248,0.18)" points="8,46 34,38 60,42 86,24 112,30 138,12 144,15 144,52 8,52"/>` +
+    `<polyline fill="none" stroke="#38bdf8" stroke-width="2" stroke-linejoin="round" points="8,46 34,38 60,42 86,24 112,30 138,12 144,15"/>` +
+    `</svg>`,
+);
+const chartSrc = `data:image/svg+xml,${chartSvg}`;
+
+// Prose lead + closing code line - the shape the dashboard derives from a
+// notebook at snapshot publish (first markdown line, last executed line).
+export function ProseAndCode() {
+  return (
+    <div style={{ width: 420 }}>
+      <NotebookCellStrip
+        preview={[
+          { kind: "markdown", text: "## Where activation stalls" },
+          {
+            kind: "code",
+            text: "funnel = df.groupby('step').drop_rate.mean()",
+            execution_count: 22,
+          },
+        ]}
+      />
+    </div>
+  );
+}
+
+export function WithThumbnail() {
+  return (
+    <div style={{ width: 420 }}>
+      <NotebookCellStrip
+        preview={[
+          { kind: "markdown", text: "### Reforecast vs. board plan" },
+          { kind: "code", text: "fc = model.forecast(h=13, exog=drivers)", execution_count: 47 },
+        ]}
+        thumbnail={{ src: chartSrc }}
+      />
+    </div>
+  );
+}
+
+// Untrusted source renders as inert text - markup in a cell's first line can
+// never become markup in the dashboard.
+export function UntrustedSource() {
+  return (
+    <div style={{ width: 420 }}>
+      <NotebookCellStrip
+        preview={[
+          { kind: "markdown", text: "Escapes `<img onerror=alert(1)>` as plain text" },
+          { kind: "code", text: "html = \"<script>alert('never runs')</script>\"" },
+        ]}
+      />
+    </div>
+  );
+}

--- a/.design-sync/synthpkg/build.mjs
+++ b/.design-sync/synthpkg/build.mjs
@@ -63,7 +63,7 @@ const groups = [
     // lives in src/styles/dashboard-atoms.css (shared surface, like
     // comment-affordance.css). NotebookCommentsPanel stays deferred (katex).
     dir: "notebook",
-    mods: ["NotebookCompositionTicks"],
+    mods: ["NotebookCellStrip", "NotebookCompositionTicks"],
   },
   {
     dir: "runtime",


### PR DESCRIPTION
Closes out the dashboard arc in the guide: **NotebookCellStrip** joins the notebook group (43 components total) with three cards - prose+code preview rows, the thumbnail variant, and an **UntrustedSource** story that demonstrates the escaping invariant visibly (markup in cell source renders as literal text). **LanguageMark**'s card picks up the real Python/Deno marks from #3894.

Driver verdict: 1 added, 42 unchanged, no grade churn. Uploaded and anchored - live in the project. Also recorded in NOTES: the resync driver skips `buildCmd` when only group lists change (run the build chain manually after editing groups), and the mini markdown parser deliberately doesn't inline-parse headings.