### PR TITLE
fix(design-sync): stop teaching Claude Design that uv magenta is the brand

### DIFF
--- a/.design-sync/conventions.md
+++ b/.design-sync/conventions.md
@@ -28,8 +28,15 @@ hardcode hex colors; use the token utilities so light/dark and theming stay corr
 | Accent (hover/active) | `bg-accent` / `text-accent-foreground` |
 | Destructive | `bg-destructive` / `text-destructive-foreground` |
 | Borders / focus | `border-border`, `border-input`, `ring-ring` |
-| Brand | `bg-uv` / `text-uv` (the nteract magenta `#de5fe9`) |
+| uv tooling ONLY | `bg-uv` / `text-uv` - the uv package manager's brand magenta, reserved for uv-specific environment UI and current-user identity marks. NEVER a page accent, button color, or brand moment |
 | Radius | `rounded-sm` · `rounded-md` · `rounded-lg` (scale off `--radius`) |
+
+The brand voice is neutral: `--primary` and `--accent` are grayscale (zero-chroma oklch),
+so brand moments come from type weight, spacing, and near-black/near-white contrast - not
+hue. Chromatic color always carries a specific meaning: cell types (`--ct-*` ticks),
+kernel states (`--k-*` dots), live presence green (`--live`), destructive red, language
+marks. If you reach for a saturated color as decoration, stop - use `bg-primary` or
+`bg-muted` instead.
 
 Do layout with plain Tailwind (`flex`, `gap-2`, `grid`, spacing). Reach for a component's
 own `variant`/`size` props before restyling it — e.g. `<Button variant="destructive"


### PR DESCRIPTION
Claude Design kept using uv's magenta as the overall brand accent. Root cause: the conventions header (inlined into the design agent's system prompt) had a table row calling `bg-uv`/`text-uv` **'Brand (the nteract magenta)'**. It's neither - `--color-uv: #de5fe9` is the **uv package manager's** brand color, used in product only to badge uv environment UI (`UvDependencyPanel`) and as the cloud dashboard's current-user identity hue. The agent was following its instructions faithfully.

Two changes to the header:

- The row now reads **'uv tooling ONLY'** with an explicit never-a-page-accent constraint.
- A positive rule the header was missing: the brand voice is **neutral** - `--primary`/`--accent` are zero-chroma oklch, brand moments come from type weight, spacing, and contrast; chromatic color always carries a specific meaning (cell-type ticks, kernel dots, presence green, destructive red, language marks).

Every class/token named in the new text validates against the compiled bundle CSS. Rebuilt via the resync driver (README-only delta, zero component churn), uploaded to the project, re-anchored. Designs started after this pick up the corrected instruction.