### PR TITLE
docs: repo-wide consistency refresh - protocol truth, status hygiene, hosted/release accuracy

### DIFF
--- a/.agents/skills/automerge-sync/SKILL.md
+++ b/.agents/skills/automerge-sync/SKILL.md
@@ -122,14 +122,16 @@ V1 is original; V2 allows compressed document encoding. Backward-compatible via 
 | Notebook | `0x00` AutomergeSync | `SharedDocState.doc` | Bidirectional |
 | RuntimeState | `0x05` RuntimeStateSync | `SharedDocState.state_doc` | Daemon-authoritative |
 | CommsDoc | `0x09` CommsDocSync | `SharedDocState.comms_doc` | Widget state, gated by RuntimeStateDoc topology |
-| CommentsDoc | `0x0a` CommentsDocSync | `SharedDocState.comments_doc` | Notebook-room comments sidecar; daemon applies optimistic rendering + authority finalization; persisted to disk by `comments_store.rs` |
+| CommentsDoc | `0x0a` CommentsDocSync | Frontend WASM replica (`runtimed-wasm`); daemon replica persisted by `comments_store.rs` | Notebook-room comments sidecar; ingress validates change actor labels against the connection principal |
 | PoolState | `0x06` PoolStateSync | PoolDoc | Frontend owns sync state; daemon carries `pool_peer_state` separately |
 
 For CommentsDoc, see `crates/comments-doc`, daemon persistence at
 `crates/runtimed/src/notebook_sync_server/comments_store.rs`, ingress at
-`peer_comments_sync.rs`. Optimistic comment mutations apply immediately;
-authority fields (`finalized`, `finalized_at`, `finalized_by`) are daemon-owned
-and finalized after ingress validation.
+`peer_comments_sync.rs`. Optimistic client mutations apply via Automerge; the
+daemon validates change actor labels against the connection principal
+(clone-preview) and strips writes from scopes without comment authority. There
+is no daemon finalization step — attribution (`resolved_by_actor_label`,
+`resolved_at`) is projected from admitted change actors.
 
 ### Sync Task Loop (biased select!)
 

--- a/.agents/skills/automerge-sync/SKILL.md
+++ b/.agents/skills/automerge-sync/SKILL.md
@@ -122,11 +122,14 @@ V1 is original; V2 allows compressed document encoding. Backward-compatible via 
 | Notebook | `0x00` AutomergeSync | `SharedDocState.doc` | Bidirectional |
 | RuntimeState | `0x05` RuntimeStateSync | `SharedDocState.state_doc` | Daemon-authoritative |
 | CommsDoc | `0x09` CommsDocSync | `SharedDocState.comms_doc` | Widget state, gated by RuntimeStateDoc topology |
+| CommentsDoc | `0x0a` CommentsDocSync | `SharedDocState.comments_doc` | Notebook-room comments sidecar; daemon applies optimistic rendering + authority finalization; persisted to disk by `comments_store.rs` |
 | PoolState | `0x06` PoolStateSync | PoolDoc | Frontend owns sync state; daemon carries `pool_peer_state` separately |
 
-`CommentsDoc` is an accepted ADR direction, not an implemented stream yet. If
-you add it, allocate a new frame type, keep optimistic comment rendering inside
-Automerge, and authority-finalize policy fields in the same document.
+For CommentsDoc, see `crates/comments-doc`, daemon persistence at
+`crates/runtimed/src/notebook_sync_server/comments_store.rs`, ingress at
+`peer_comments_sync.rs`. Optimistic comment mutations apply immediately;
+authority fields (`finalized`, `finalized_at`, `finalized_by`) are daemon-owned
+and finalized after ingress validation.
 
 ### Sync Task Loop (biased select!)
 

--- a/.agents/skills/daemon-dev/SKILL.md
+++ b/.agents/skills/daemon-dev/SKILL.md
@@ -44,7 +44,7 @@ The daemon (`runtimed`) is a singleton coordinating notebook windows over a Unix
 ### How `cargo xtask build` works (4 phases)
 
 0. **Artifact guard** — verify gitignored WASM, renderer-plugin, and MCP widget outputs. Build/dev commands fingerprint workspace inputs and skip wasm-pack when outputs are current; rebuild only when outputs are missing, invalid, or stale.
-1. **Single Rust compilation** — `cargo build -p runtimed -p runt -p mcp-supervisor -p notebook`. Sidecars copied to `crates/notebook/binaries/`.
+1. **Single Rust compilation** — `cargo build -p runtimed -p runt -p nteract-mcp -p mcp-supervisor`. Sidecars copied to `crates/notebook/binaries/`. The `notebook` crate is intentionally excluded until the Tauri link phase after frontend assets exist.
 2. **Frontend build** — `pnpm build` (TypeScript + Vite). `--rust-only` skips this.
 3. **Tauri link** — `cargo tauri build --debug --no-bundle` with embedded frontend assets. Use `--skip-tauri` only for fast edit checks where updated sidecar binaries are enough; run a normal build before launching the bundled app.
 
@@ -148,7 +148,9 @@ RUNTIMED_SOCKET_PATH="$(./target/debug/runt daemon status --json | python3 -c 'i
 
 The MCP server ships as `runt mcp` (Rust). Run via `cargo xtask run-mcp` for development.
 
-**Advertised tools:** `list_active_notebooks`, `connect_notebook`, `create_notebook`, `save_notebook`, `show_notebook`, `disconnect_notebook`, `get_cell`, `get_all_cells`, `create_cell`, `set_cell`, `delete_cell`, `move_cell`, `execute_cell`, `run_all_cells`, `get_results`, `interrupt_kernel`, `restart_kernel`, `manage_dependencies`, `replace_match`, `replace_regex`.
+**Advertised tools** (`all_tools()`): `list_active_notebooks`, `list_notebooks`, `connect_notebook`, `create_notebook`, `save_notebook`, `show_notebook`, `disconnect_notebook`, `create_cell`, `set_cell`, `delete_cell`, `move_cell`, `execute_cell`, `run_all_cells`, `get_results`, `interrupt_kernel`, `restart_kernel`, `manage_dependencies`, `replace_match`, `replace_regex`.
+
+**Hidden/callable read tools** (`hidden_tools()`): `get_cell`, `get_all_cells`. These are callable but not advertised in `list_tools()` — dispatch-only read paths for clients that prefer direct tool calls over resource URIs.
 
 Legacy dependency and cell-metadata tool names still dispatch for compatibility, but new workflows should use `manage_dependencies` for dependency inspection/edits and `get_results` for execution output lookup by `execution_id`.
 

--- a/.agents/skills/mcp-session-lifecycle/SKILL.md
+++ b/.agents/skills/mcp-session-lifecycle/SKILL.md
@@ -172,11 +172,12 @@ not for the entire tool execution. `DocHandle` is cheaply cloneable
 | Notebook type | Identified by | Rejoin method | Eviction check |
 |--------------|---------------|---------------|----------------|
 | File-backed | Has file path | `connect_open(path)` | File exists on disk |
-| Ephemeral (untitled) | UUID only | `connect(uuid)` | `list_rooms` check |
+| Ephemeral (untitled) | UUID only | `connect(uuid)` | Daemon-authoritative refusal |
 
-**Ephemeral notebooks** get an explicit `list_rooms` check before rejoin.
-If the room was evicted during disconnect, we clear the session
-immediately instead of creating a phantom empty room.
+**Ephemeral notebooks** call `connect(uuid)` directly and trust the daemon's
+resident/recoverable-room handling. The daemon is authoritative about whether
+a notebook still exists — a refusal comes back as `NotebookUnavailable` and
+is handled as evicted with no retry. No pre-check `list_rooms` call.
 
 **File-backed notebooks** use `connect_open(path)` which lets the daemon
 reload from disk. The `.automerge` persist files for file-backed rooms

--- a/.agents/skills/releasing/SKILL.md
+++ b/.agents/skills/releasing/SKILL.md
@@ -33,17 +33,13 @@ These evolve independently from each other and from the artifact version.
 ## Bumping Versions
 
 ```bash
-# Update the checked-in release sources to the same version:
-#   crates/runtimed/Cargo.toml
-#   crates/runt/Cargo.toml
-#   crates/notebook/Cargo.toml
-#   crates/notebook/tauri.conf.json
-#   python/runtimed/pyproject.toml
-#   python/nteract/pyproject.toml
-
-# Then let Cargo.lock catch up:
-cargo check
+cargo xtask bump patch  # or minor, or major
 ```
+
+This updates all versioned artifacts in lockstep (Rust crates, Python packages,
+frontend packages, plugin manifests, Tauri config) and runs `cargo update -w` to
+refresh `Cargo.lock`. See `crates/xtask/src/bump.rs` for the complete target
+list.
 
 Commit the version bump, then tag to trigger the release.
 
@@ -52,8 +48,8 @@ Commit the version bump, then tag to trigger the release.
 ### Stable Release
 
 ```bash
-git tag v2.1.0
-git push origin v2.1.0
+git tag v2.1.0-stable.202607020900
+git push origin v2.1.0-stable.202607020900
 ```
 
 Triggers `release-stable.yml` which:

--- a/.claude/rules/logging.md
+++ b/.claude/rules/logging.md
@@ -39,7 +39,7 @@ logger.warn("[component] Recoverable issue");
 logger.error("[component] Failure:", error);
 ```
 
-Route through `logger`, not raw `console.*`. The level filter is applied server-side by `tauri-plugin-log`. In dev (`import.meta.env.DEV`) `attachConsole()` mirrors everything into the browser devtools. In packaged builds the Rust-side app log level decides what's visible.
+Route through `logger`, not raw `console.*`. The level filter is applied server-side by `tauri-plugin-log`. In dev (`import.meta.env.DEV`) `attachLogger()` mirrors Rust log entries into the browser devtools by dispatching to the original console methods (not the wrapped forwarder) so no feedback loop occurs. In packaged builds the Rust-side app log level decides what's visible.
 
 ## Level guidelines
 

--- a/.claude/rules/mcp-servers.md
+++ b/.claude/rules/mcp-servers.md
@@ -24,7 +24,9 @@ Three nteract MCP servers may be available. Always use the right one:
 
 ## nteract-dev tool surface
 
-Two verbs plus three read-only tools, layered on top of the proxied `runt mcp` toolset:
+The advertised tool list varies by mode:
+
+**Owner/isolated mode** (Claude Code `.mcp.json`) — manages daemon lifecycle:
 
 | Tool | Purpose |
 |------|---------|
@@ -33,6 +35,16 @@ Two verbs plus three read-only tools, layered on top of the proxied `runt mcp` t
 | `status` | Read-only report of `nteract-dev`, child, daemon, and managed-process state. |
 | `logs` | Tail the daemon log. Arg: `lines` (default 50). |
 | `vite_logs` | Tail the Vite dev server log. Arg: `lines` (default 50). |
+
+**Attach mode** (Codex `.codex/config.toml`) — connects to an existing daemon:
+
+| Tool | Purpose |
+|------|---------|
+| `status` | Read-only report of `nteract-dev`, child, and daemon state. |
+| `logs` | Tail the daemon log. Arg: `lines` (default 50). |
+| `vite_logs` | Tail the Vite dev server log. Arg: `lines` (default 50). |
+
+All modes proxy the full `runt mcp` notebook tool surface.
 
 ## MCP Server
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -55,7 +55,7 @@ reason.
 
 Three may be visible. Pick by purpose. Full details in `.claude/rules/mcp-servers.md` (auto-loaded everywhere).
 
-- **`nteract-dev`** — default for development. Per-worktree dev daemon, dev tools (`up`, `down`, `status`, `logs`, `vite_logs`) plus 26 proxied notebook tools. Prefer `up` over manual `cargo xtask dev-daemon`.
+- **`nteract-dev`** — default for development. Per-worktree dev daemon. Owner/isolated mode exposes dev tools (`up`, `down`, `status`, `logs`, `vite_logs`); attach mode (Codex) exposes read-only supervisor tools (`status`, `logs`, `vite_logs`) plus proxied notebook tools. Prefer `up` over manual `cargo xtask dev-daemon`.
 - **`nteract-nightly`** — system nightly daemon. Diagnostics only.
 - **`nteract`** — system stable daemon. Diagnostics only.
 - **Codex plugin notebook servers** (`nteract-notebook`, `nightly`, or older `notebook` tool names) — installed release/plugin surfaces. Diagnostics only for source work; they may attach to a different active notebook than the local Browser/Vite app.
@@ -78,7 +78,7 @@ Types: `feat`, `fix`, `docs`, `chore`, `refactor`, `test`, `ci`, `build`, `perf`
 
 ## Load-bearing invariants
 
-Most invariants auto-load from `.claude/rules/*.md` and nested `AGENTS.md` files when you edit matching paths. Two that don't fit any path scope:
+Most invariants auto-load from `.claude/rules/*.md` and nested `AGENTS.md` files when you edit matching paths. A few that don't fit any path scope:
 
 ### Tokio mutex guards stay within synchronous blocks
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -24,16 +24,20 @@
 ### Project structure
 
 ```
-apps/notebook/        Tauri desktop app (React + Vite frontend)
-apps/elements/        Elements component library
-crates/               Rust workspace
-  runtimed/           Daemon process — owns kernels and document state
-  notebook/           Tauri application shell
-  runt-mcp/           MCP server
-  notebook-doc/       CRDT document model (Automerge)
-  xtask/              Build task runner
-packages/             Shared JS/TS packages
-plugins/nteract/      Renderer plugins
+apps/notebook/          Tauri desktop app (React + Vite frontend)
+apps/notebook-cloud/    Hosted notebook worker (Cloudflare)
+apps/elements/          Elements design system catalog
+packages/               Shared JS/TS packages
+plugins/nteract/        Agent plugin distribution (Codex)
+crates/                 Rust workspace
+  runtimed/             Daemon — owns kernels and document state
+  notebook/             Tauri application shell
+  runt-mcp/             MCP server
+  notebook-doc/         CRDT document model (Automerge)
+  xtask/                Build task runner
+python/                 Python workspace (uv)
+  runtimed/             Python bindings
+  nteract/              MCP launcher
 ```
 
 ### Frontend
@@ -71,11 +75,13 @@ cargo xtask wasm sift         # rebuild sift-wasm only
 
 ### Python bindings
 
-`uv sync` and `maturin develop` are run automatically by `cargo xtask dev`. To run manually:
+`uv sync` is run automatically by `cargo xtask dev`. Python bindings are no
+longer part of the default build (the MCP server is Rust-native). To build them
+manually:
 
 ```bash
 uv sync
-cd crates/runtimed-py && VIRTUAL_ENV=../../.venv maturin develop
+cd crates/runtimed-py && VIRTUAL_ENV=../../.venv uv run --directory ../../python/runtimed maturin develop
 ```
 
 ### Desktop app

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -2,6 +2,12 @@
 version: alpha
 name: nteract Desktop
 description: A dense, calm notebook workspace for local data, code, runtime, and collaboration workflows.
+note: |
+  Token inventory below is historical. Current semantic token implementation lives in:
+  - src/styles/notebook-tokens.css (shared Tailwind semantic tokens)
+  - src/styles/cream-theme.css (cream theme surface)
+  - apps/elements/content/docs/theme-surfaces.mdx (Elements theme surface docs)
+  Implemented in #3872 (d30f7ce3).
 colors:
   primary: "#262626"
   on-primary: "#FAFAFA"

--- a/README.md
+++ b/README.md
@@ -145,29 +145,46 @@ nteract/nteract
 │   ├── lib/               # Shared utilities (cn(), dark-mode, error-boundary)
 │   └── styles/            # Global stylesheets
 ├── apps/                   # App entry points
-│   └── notebook/          # Notebook Tauri frontend
+│   ├── notebook/          # Desktop notebook Tauri app
+│   ├── notebook-cloud/    # Hosted notebook worker (Cloudflare)
+│   ├── elements/          # Elements design system catalog
+│   ├── mcp-app/           # MCP widget dev app
+│   └── renderer-test/     # Isolated renderer test harness
+├── packages/               # Shared npm packages
+│   ├── notebook-host/     # Notebook host shell
+│   ├── runtimed/          # Node/NAPI daemon client
+│   ├── runtimed-node/     # Node bindings for daemon
+│   ├── sift/              # Sift visualization renderer
+│   └── odometer/          # Odometer component
 ├── crates/                 # Rust code
 │   ├── runt/              # CLI binary
 │   ├── runtimed/          # Background daemon
 │   ├── runtimed-py/       # Python bindings for the daemon
-│   ├── runtimed-wasm/     # WASM Automerge bindings for frontend (same automerge crate as daemon)
-│   ├── notebook/          # Notebook Tauri app
-│   ├── notebook-doc/      # Shared Automerge document operations (cells, metadata, sync)
+│   ├── runtimed-wasm/     # WASM Automerge bindings for frontend
+│   ├── notebook/          # Notebook Tauri app crate
+│   ├── notebook-doc/      # Automerge document operations
 │   ├── notebook-protocol/ # Notebook wire protocol types
 │   ├── notebook-sync/     # Notebook sync layer
 │   ├── kernel-launch/     # Shared kernel launching API
 │   ├── kernel-env/        # Environment progress reporting
-│   ├── runt-mcp/          # Rust-native MCP server for notebook interaction
+│   ├── runt-mcp/          # Rust-native MCP server
 │   ├── runt-trust/        # Notebook trust extraction
 │   ├── runt-workspace/    # Workspace detection utilities
-│   ├── runtimed-client/   # Shared client library for daemon communication
-│   ├── repr-llm/          # LLM-friendly text summaries of visualization specs
+│   ├── runtimed-client/   # Shared client library for daemon
+│   ├── repr-llm/          # LLM-friendly text summaries of visualizations
 │   ├── xtask/             # Build automation tasks
-│   └── mcp-supervisor/    # nteract-dev MCP server (proxies runt mcp + adds dev tools)
-├── python/                 # Python packages
-│   ├── runtimed/          # PyPI: runtimed (Python bindings for daemon)
-│   ├── nteract/           # PyPI: nteract (thin wrapper that launches `runt mcp`)
-│   └── gremlin/           # Stress-testing agent for nteract notebooks (not published)
+│   └── mcp-supervisor/    # nteract-dev MCP server (proxies runt mcp + dev tools)
+├── python/                 # Python workspace (uv)
+│   ├── runtimed/          # PyPI: runtimed (Python bindings)
+│   ├── nteract/           # PyPI: nteract (thin launcher for `runt mcp`)
+│   ├── gremlin/           # Stress-testing agent
+│   ├── prewarm/           # Environment prewarm script
+│   ├── dx/                # Developer utilities
+│   ├── nteract-kernel-launcher/ # Kernel launcher for hosted notebooks
+│   ├── pr-reviewer/       # PR review agent
+│   └── safari-timeline/   # Safari timeline parser
+├── plugins/                # Agent plugin distribution
+│   └── nteract/           # Codex plugin package
 ```
 
 ## Development

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -24,15 +24,23 @@ Stable releases run when a `v*` tag is pushed (or manually), and nightly pre-rel
 | Platform | File |
 |----------|------|
 | macOS ARM64 (Apple Silicon) | `nteract-{channel}-darwin-arm64.dmg` |
-| Windows x64 | `nteract-{channel}-windows-x64.exe` |
-| Linux x64 | `nteract-{channel}-linux-x64.AppImage` |
+| macOS x64 (Intel) | `nteract-{channel}-darwin-x64.dmg` |
+| macOS ARM64 updater | `nteract-{channel}-darwin-arm64.app.tar.gz` + `.sig` |
+| macOS x64 updater | `nteract-{channel}-darwin-x64.app.tar.gz` + `.sig` |
+| Windows x64 | `nteract-{channel}-windows-x64.exe` + `.sig` |
+| Linux x64 AppImage | `nteract-{channel}-linux-x64.AppImage` + `.sig` |
 | Installer script (Linux x64, macOS) | `install-linux-release` |
 | CLI (macOS ARM64) | `runt-darwin-arm64` |
+| CLI (macOS x64) | `runt-darwin-x64` |
 | CLI (Linux x64) | `runt-linux-x64` |
+| Standalone daemon (Linux x64) | `runtimed-linux-x64` |
+| Standalone MCP server (Linux x64) | `nteract-mcp-linux-x64` |
+| Updater manifest | `latest.json` |
 
-macOS builds are signed and notarized. Windows builds are not code signed. Linux
-desktop releases publish AppImage only; DEB/RPM/APT installs are not currently
-supported because `runtimed` is a per-user daemon.
+macOS builds are signed and notarized. Windows builds use Azure Trusted Signing
+via `trusted-signing-cli` and `signtool.exe`. Linux desktop releases publish
+AppImage only; DEB/RPM/APT installs are not currently supported because
+`runtimed` is a per-user daemon.
 
 Linux users can also install the released AppImage with:
 
@@ -42,7 +50,11 @@ curl -fsSL https://sh.nteract.io | bash
 
 ### Crate publishing
 
-`runt`, `runtimed-py`, `mcp-supervisor`, `runt-mcp`, and `xtask` are **not published to crates.io** (`publish = false`).
+Many crates are **not published to crates.io** (`publish = false`), including
+`runt`, `runtimed-py`, `mcp-supervisor`, `runt-mcp`, `runt-mcp-proxy`,
+`nteract-mcp`, `runtimed-node`, `runt-publish`, `nteract-markdown-engine`,
+`nteract-markdown-wasm`, `sift-wasm`, and `xtask`. Check `Cargo.toml` for the
+current list.
 
 ## Published Bindings
 

--- a/apps/elements/content/docs/cloud-dashboard.mdx
+++ b/apps/elements/content/docs/cloud-dashboard.mdx
@@ -5,38 +5,62 @@ description: Hosted notebook home, inventory precedence, workstation context, an
 
 import { CloudDashboardExample } from "@/components/cloud-dashboard-example";
 
-The hosted dashboard is app-level product chrome. It should help a signed-in
-user open the right room quickly without becoming another notebook shell,
-metrics board, or project-management surface.
+The hosted dashboard (`/n`) is app-level notebook inventory chrome. It helps a
+signed-in user open the right notebook quickly without becoming another
+notebook shell, metrics board, or project-management surface.
 
-This fixture keeps the notebook list search-first. The surrounding controls are
-only there to make a large inventory readable: pin important rooms, find recent
-activity, expose cleanup work, and summarize host-owned context.
+The shipped dashboard uses:
 
-The example below models three behaviors:
+- **Notebooks page head** with total count and active-now count.
+- **Header search input** for title filtering.
+- **Grouped filter chips**: "Notebook views" (All notebooks, Shared with me,
+  Active now) and "Cleanup" (Generated, Untitled).
+- **Continue hero** showing the most recent notebook with cover, runtime facts,
+  composition ticks, and a rich-detail cell strip (first markdown prose, last
+  code cell closing line with execution count, output thumbnail).
+- **Sections**: Recent work, Shared with me, Active now, Generated, Untitled —
+  each with counts, overflow actions, and inline rename affordances.
+- **Row details**: runtime language/environment label, composition ticks
+  (markdown/code/output counts), presence stack (active-now peer avatars),
+  owner display, and optional cell strip.
 
-- Search and filters refine the inventory by title, project, title-cleanup
-  state, and published state.
-- Pinned work and recent activity create precedence so real notebooks stay
-  ahead of smoke-test clutter.
-- Workstation and sharing summaries stay informational. Opening a notebook is
-  where execution, runtime state, and access management move into the notebook
-  shell.
+The catalog-summary pattern shipped in #3883, #3885, #3892, #3895. The old
+search-first, pinned/recent design was replaced; pinned-first behavior is no
+longer a filter.
 
 <CloudDashboardExample />
 
 ## Surface contract
 
-- `/n` should feel like a notebook switcher first.
-- Search is the first action; filters refine inventory rather than becoming a
-  separate task queue.
-- Pinned and recently active notebooks stay above generated testing noise.
-- Untitled and smoke-test rooms remain visible for cleanup, but they should not
-  dominate the scan path.
-- Workstation readiness is host-owned context. It can summarize a selected
-  default target without owning notebook execution controls.
-- Sharing facts are safe host metadata. Private notebooks should not leak
-  content through previews; public previews require explicit published revision
-  data.
-- Opening a room hands off to the shared document shell, rail, toolbar, and
+- `/n` is a notebook switcher first.
+- Search filters by title; filter chips refine by work type and cleanup state.
+- Recent-work section prioritizes named notebooks above generated testing noise.
+- Untitled and generated notebooks remain visible for cleanup but do not
+  dominate the scan path (limited to secondary-section caps).
+- Workstation and runtime facts are host-owned context. The dashboard
+  summarizes compute and environment state without owning notebook execution
+  controls.
+- Sharing facts are safe host metadata. Private notebooks do not leak content
+  through previews; public previews require explicit published revision data.
+- Opening a notebook hands off to the shared document shell, rail, toolbar, and
   cell/output surfaces.
+
+## Loading, identity, and presence
+
+- **Bootstrap/cache seeding**: The dashboard seeds ready state from bootstrap
+  and cache responses (`notebook-list-view.tsx`) and preserves loading
+  resilience during app-session waiting, timeout, and retry states.
+- **Unified identity**: The model carries `current_user_display` for the
+  current user (`cloud-viewer-types.ts:28`) and `owner_display` for notebook
+  owners (`notebook-dashboard.ts:16`). Owner labels project from principal
+  profiles (`notebook-dashboard.ts:718`).
+- **Presence and active-now**: The model includes `peers`
+  (`notebook-dashboard.ts:22`) and projects active-now presence from room
+  summaries (`src/index.ts:1321`). The active-now filter and section surface
+  notebooks with live collaborators.
+
+## Covers and OG images
+
+Dashboard rows may show derived notebook covers from output embeds. Public OG
+images are revision-aware: latest OG images are withheld from pinned revision
+shells (commit 739fad72, #3889).

--- a/apps/elements/content/docs/editor-surfaces.mdx
+++ b/apps/elements/content/docs/editor-surfaces.mdx
@@ -6,15 +6,16 @@ description: Runtime-free CodeMirror fixtures for notebook source editing.
 import { EditorSurfacesExample } from "@/components/editor-surfaces-example";
 
 Notebook source editing is a major nteract-owned surface. The notebook app
-uses the shared editor package for live cell source, read-only source previews,
-static syntax highlighting, search marks, remote cursors, attribution, language
-extensions, and notebook palettes.
+uses the shared editor modules (`src/components/editor`) for live cell source,
+read-only source previews, static syntax highlighting, search marks, remote
+cursors, attribution, language extensions, and notebook palettes.
 
 <EditorSurfacesExample />
 
 ## Adapter notes
 
 This page renders current editor components and pure CodeMirror extensions from
-the shared Elements notebook scenario. Runtime-backed behavior stays outside the
-docs app until there are thin adapters for CRDT source sync, kernel completion,
-presence sending, and app-level editor focus registration.
+the shared Elements notebook scenario (`src/components/editor`). Runtime-backed
+behavior stays outside the docs app until there are thin adapters for CRDT
+source sync, kernel completion, presence sending, and app-level editor focus
+registration.

--- a/apps/elements/content/docs/index.mdx
+++ b/apps/elements/content/docs/index.mdx
@@ -25,8 +25,14 @@ repo-level `docs/` tree.
 Keep the catalog production-backed. It should render shared shell, rail,
 toolbar, identity, package, cell, output, and widget components from
 deterministic fixtures without importing the desktop runtime, sync engine,
-Cloudflare host, or generated runtimed WASM bindings. Renderer-specific assets
-like Sift WASM should stay explicit, docs-served adapters.
+Cloudflare host, or generated runtimed WASM bindings.
+
+Shared UI primitives (`src/components/ui`) are the single source of truth for
+Button, Popover, ContextMenu, and other shadcn-style components
+(`docs/adr/shared-ui-primitives-package.md`, #3872). Sift aliases
+`@/components/ui/*` and consumes notebook tokens, so it renders with the app's
+palette. Renderer-specific assets like Sift WASM stay explicit, docs-served
+adapters.
 
 ## Production-backed catalog
 

--- a/apps/notebook-cloud/AGENTS.md
+++ b/apps/notebook-cloud/AGENTS.md
@@ -36,7 +36,7 @@ The cloud room host materializes and validates the notebook-room documents:
 | `NotebookDoc` | notebook room | owners write all; editors write allowed cell surface only; viewers and runtime peers read |
 | `RuntimeStateDoc` | notebook room | room host writes execution intent and room facts; runtime peers write policy-allowed lifecycle, progress, output, and comm topology for accepted work; viewer/editor/owner clients read only |
 | `CommsDoc` | notebook room | editor/owner/runtime-peer widget-state writes gated by RuntimeStateDoc topology |
-| `CommentsDoc` | proposed notebook-room sidecar | ADR only; if implemented, keep optimistic local-first writes inside Automerge and authority-finalize policy fields |
+| `CommentsDoc` | notebook room sidecar | editor/owner write policy; live room host checkpoints at `CHECKPOINT_COMMENTS_DOC_KEY`, routes `FrameType.COMMENTS_DOC_SYNC` frames, and saves `comments_doc_id` to peers (commit 778fc53e); revision rows record `comments_heads_hash` and `comments_snapshot_key` for catalog recovery |
 | `PoolDoc` | daemon scoped | not a notebook room document; hosted deployments should not assume it belongs in room identity |
 
 Permission and durability boundaries are the reason for separate documents.

--- a/apps/notebook-cloud/README.md
+++ b/apps/notebook-cloud/README.md
@@ -1,8 +1,25 @@
-# nteract notebook cloud prototype
+# nteract hosted notebook cloud
 
-This app is a Cloudflare Worker prototype for hosted nteract notebook rooms. It is intentionally small: the Worker authenticates dev credentials, first-party browser app-session cookies minted from OIDC, Anaconda API-key publishing/runtime requests, or anonymous viewer connections, authorizes the principal through the D1 room ACL, stamps a trusted `<principal>/<operator>` actor label, and routes `/n/:notebookId/sync` to a Durable Object keyed by notebook id.
+This app is a Cloudflare Worker for hosted nteract notebook rooms. The Worker
+authenticates dev credentials, first-party browser app-session cookies minted
+from OIDC, Anaconda API-key publishing/runtime requests, or anonymous viewer
+connections; authorizes the principal through the D1 room ACL; stamps a trusted
+`<principal>/<operator>` actor label; and routes `/n/:notebookId/sync` to a
+Durable Object keyed by notebook id. Shipped surfaces include app sessions,
+OIDC login, notebook list/dashboard, workstations, invites, access requests,
+author profiles, runtime repair, OG images, snapshots, blobs, and live sync
+(commits 0745eeab daemon-mediated rooms, 81f8117e list-scale presence,
+1c9023df/739fad72 OG/pinned revision work, 8a0105a3 snapshot metadata,
+49e46666/6febe0d2/48dae8fb dashboard). Experimental APIs and preview deployment
+resources retain explicit "prototype" or "preview" labels.
 
-The current Durable Object does not host kernels. It owns a `runtimed-wasm` room host for the notebook's `NotebookDoc` + `RuntimeStateDoc` + `CommsDoc`, syncs peers with typed-frame v4, rejects unauthorized Automerge changes before mutating the room, checkpoints the materialized document set in Durable Object storage, rewrites canonical CBOR presence through the shared helper, and keeps in-memory frame-budget telemetry for live sync traffic. Viewer-scope peers use the normal sync exchange so they can materialize live room updates, while the room host uses read-only peer state as a protocol hint and still rejects any viewer-authored changes explicitly. No-op read-only sync control frames are acknowledged and delivered as protocol traffic, but they are not persisted as room-event history. Editor-scope live `NotebookDoc` writes cover the allowed cell surface, while notebook identity and metadata remain owner-only. Widget state writes live in `CommsDoc`; `RuntimeStateDoc` remains runtime-peer/room-host owned. Runtime peers can sync kernel lifecycle, widget comm topology, output routing, and progress/output state for room-accepted executions into `RuntimeStateDoc`, but they cannot create execution intent, edit `NotebookDoc`, rewrite trust/environment/path/project metadata, or acquire the frontend notebook editing API.
+The current Durable Object does not host kernels. It owns a `runtimed-wasm`
+room host for the notebook's `NotebookDoc` + `RuntimeStateDoc` + `CommsDoc` +
+`CommentsDoc` (sidecar, commit 778fc53e), syncs peers with typed-frame v4,
+rejects unauthorized Automerge changes before mutating the room, checkpoints
+the materialized document set in Durable Object storage, rewrites canonical
+CBOR presence through the shared helper, and keeps in-memory frame-budget
+telemetry for live sync traffic. Viewer-scope peers use the normal sync exchange so they can materialize live room updates, while the room host uses read-only peer state as a protocol hint and still rejects any viewer-authored changes explicitly. No-op read-only sync control frames are acknowledged and delivered as protocol traffic, but they are not persisted as room-event history. Editor-scope live `NotebookDoc` writes cover the allowed cell surface, while notebook identity and metadata remain owner-only. Widget state writes live in `CommsDoc`; `RuntimeStateDoc` remains runtime-peer/room-host owned. Runtime peers can sync kernel lifecycle, widget comm topology, output routing, and progress/output state for room-accepted executions into `RuntimeStateDoc`, but they cannot create execution intent, edit `NotebookDoc`, rewrite trust/environment/path/project metadata, or acquire the frontend notebook editing API.
 
 `/n/:notebookId/:vanityName` is a hosted notebook page backed by `/n/:id/sync`. Latest notebook views do not fetch a separate materialized render document; viewers join the live Automerge room as read-only peers and editor+ connections use the same synced document for permitted edits. `/n/:id/r/:headsHash` is an immutable pinned viewer that loads the persisted `NotebookDoc` + `RuntimeStateDoc` + `CommsDoc` Automerge snapshot set directly through `/api/n/:id/snapshots/:headsHash`, `/api/n/:id/runtime-snapshots/:runtimeHeadsHash`, `/api/n/:id/comms-snapshots/:commsHeadsHash`, and catalog revision metadata. Snapshot publishes validate that the documents can be loaded and that referenced output/widget blobs exist before recording the catalog revision, so missing runtime or comm snapshots, corrupt snapshot bytes, or missing blobs fail the publish request instead of advertising a broken revision. Output blob refs stay host-neutral and are mapped to `/api/n/:id/blobs/:hash` through the shared `BlobResolver` surface. The browser viewer bundle uses the shared notebook display components (`CellContainer`, `OutputArea`, `ReadOnlyCodeMirror`, `MediaProvider`) so published source, markdown, stdout/stderr, rich display data, widgets, and blob-backed renderer manifests go through the same isolated output renderer path as the desktop notebook.
 
@@ -207,9 +224,10 @@ renderer bundle checks: it fails on `cloud sync socket` churn, output resolution
 errors, failed notebook blob responses, missing cells, or a closed final room
 socket. Sandboxed output frames must not read localStorage; the smoke tracks
 that denial as a benign iframe error because only the first-party viewer shell
-uses the transitional OIDC cache to acquire its cookie. The room WebSocket does
-not use that cookie directly; the viewer asks the Worker for a short-lived sync
-ticket derived from the app session.
+uses the transitional OIDC cache to acquire its cookie. Browser live sync uses
+the first-party app-session cookie directly (`index.ts:720-778`), with trusted
+`Origin` checks and `nteract.v4` as the non-sensitive subprotocol. No
+intermediate sync ticket is generated for browser sessions.
 
 Before running credentialed preview smokes from lab2, check local credential
 health:
@@ -482,9 +500,9 @@ users only receive that scope when the notebook has an explicit public
 `notebook_acl` row. Production hosts should move output blobs to signed URLs or
 a dedicated output origin before accepting private notebook data at scale.
 
-## ACL management
+## ACL and sharing
 
-The prototype exposes a small owner-only ACL API:
+The flat ACL API remains the low-level authorization primitive:
 
 ```text
 GET    /api/n/{notebookId}/acl
@@ -514,17 +532,43 @@ Public read is explicit:
 ```
 
 Public rows may only grant `viewer`, and principal rows cannot target `system`
-or anonymous principals. Deleting the final owner row is rejected. Group/org
-expansion, owner transfer workflow, audit events, and Zanzibar/Authzed-style
-relationship evaluation remain outside this prototype API.
+or anonymous principals. Deleting the final owner row is rejected.
+
+The sharing and invite layer is built on top:
+
+```text
+GET    /api/n/{notebookId}/invites
+POST   /api/n/{notebookId}/invites
+DELETE /api/n/{notebookId}/invites/{inviteId}
+
+GET    /api/n/{notebookId}/access-requests
+POST   /api/n/{notebookId}/access-requests
+DELETE /api/n/{notebookId}/access-requests/{requestId}
+```
+
+Owner-scoped invite routes create pending invites by normalized email, optional
+provider hint, and `viewer` or `editor` scope (`index.ts:387-427`). Invites
+resolve to principal ACL rows on the recipient's first login
+(`sharing-storage.ts` resolution logic). Access requests allow viewers to
+request editor/owner promotion. Principal account links join profiles across
+providers. The schema includes `notebook_invites`, `notebook_access_requests`,
+`principal_profiles`, `principal_account_links` (`storage.ts:247-290`).
+
+Group/org expansion, owner transfer workflow, audit events, and
+Zanzibar/Authzed-style relationship evaluation remain future work.
 
 ## Storage shape
 
 Bindings in `wrangler.toml`:
 
 - `NOTEBOOK_ROOMS`: Durable Object namespace, one object per notebook id.
-- `DB`: D1 catalog for notebooks, revisions, and blobs.
-- `NOTEBOOK_SNAPSHOTS`: R2 bucket for `NotebookDoc`, `RuntimeStateDoc`, `CommsDoc`, and blob snapshots.
+- `DB`: D1 catalog for notebooks, revisions, blobs, principal profiles,
+  notebook invites, access requests, workstations, pairing codes, and
+  credentials (`storage.ts:222-365`).
+- `NOTEBOOK_SNAPSHOTS`: R2 bucket for `NotebookDoc`, `RuntimeStateDoc`,
+  `CommsDoc`, `CommentsDoc`, blob snapshots, and room summaries
+  (`roomSummaryKey()` at `storage.ts:451`). Room summaries enable list-scale
+  presence hydration in bounded batches (`index.ts:1321`).
 - `ASSETS`: Worker static assets for `/assets/notebook-cloud-viewer.js`, content-hashed runtime WASM sidecars, renderer chunks, and `/plugins/sift_wasm.wasm`.
 - `RENDERER_ASSETS_BASE_URL` (optional): base URL for renderer plugin assets such as `sift_wasm.wasm`. The prototype deployment points this at the dedicated `nteract-notebook-cloud-assets` Worker. If unset, the viewer uses the main Worker-owned `/renderer-assets/` route so sandboxed `srcdoc` iframes can fetch plugin WASM through explicit CORS headers.
 - `RUNTIMED_WASM_BASE_URL` (optional): base URL for `runtimed_wasm.js` and `runtimed_wasm_bg.wasm`. If unset, the viewer reads `runtime-wasm-assets.json` from the main Worker asset bundle and loads the content-hashed runtime WASM files from `/assets/`, so the viewer JS and matching WASM are deployed atomically.
@@ -540,8 +584,10 @@ Automerge sync, runtime-state sync, and response frames may be up to 64 MiB;
 `PUT_BLOB` up to 32 MiB; request and broadcast frames up to 16 MiB; presence
 frames up to 4 KiB; and pool-state/session-control frames up to 1 MiB. The
 Durable Object does not persist a frame replay log. Reconnecting peers recover
-from the materialized `NotebookDoc`, `RuntimeStateDoc`, and `CommsDoc`
-checkpoints, with published snapshots as the fallback durable boundary.
+from the materialized `NotebookDoc`, `RuntimeStateDoc`, `CommsDoc`, and
+`CommentsDoc` checkpoints (`CHECKPOINT_COMMENTS_DOC_KEY` at
+`room-materializer.ts:13`), with published snapshots as the fallback durable
+boundary.
 
 Published revision artifacts follow `docs/adr/hosted-notebook-artifacts.md`:
 
@@ -549,8 +595,13 @@ Published revision artifacts follow `docs/adr/hosted-notebook-artifacts.md`:
 n/{id}/snapshots/{notebookHeadsHash}.am
 docs/{runtimeStateDocId}/snapshots/{runtimeHeadsHash}.am
 docs/{comms:runtimeStateDocId}/snapshots/{commsHeadsHash}.am
+docs/{comments:notebookId}/snapshots/{commentsHeadsHash}.am
 n/{id}/blobs/{sha256}
 ```
+
+`CommentsDoc` is checkpointed by the room host and recorded in revision rows
+(`comments_heads_hash`, `comments_snapshot_key` at `storage.ts:31`, `:35`), but
+public snapshot routes for comments are not yet shipped.
 
 Notebook snapshots currently retain the `n/{id}` compatibility namespace.
 Runtime-state snapshots are keyed by first-class `runtime_state_doc_id`; publish
@@ -869,12 +920,14 @@ curl -X PUT "$NOTEBOOK_CLOUD_LOCAL_URL/api/n/demo/runtime-snapshots/runtime123" 
   -H "X-User: alice" \
   -H "X-Operator: desktop:curl" \
   -H "X-Scope: owner" \
+  -H "X-Runtime-State-Doc-Id: runtime:demo" \
   --data-binary @runtime-state.am
 
 curl -X PUT "$NOTEBOOK_CLOUD_LOCAL_URL/api/n/demo/snapshots/heads123" \
   -H "X-User: alice" \
   -H "X-Operator: desktop:curl" \
   -H "X-Scope: owner" \
+  -H "X-Runtime-State-Doc-Id: runtime:demo" \
   -H "X-Runtime-Heads-Hash: runtime123" \
   --data-binary @notebook.am
 

--- a/crates/kernel-env/AGENTS.md
+++ b/crates/kernel-env/AGENTS.md
@@ -43,7 +43,7 @@ Project files win over inline deps because inline deps are promoted into the pro
 
 ### Deno kernels
 
-No environment pools. Get deno via `kernel_launch::tools::get_deno_path()` (PATH first, then bootstrap from conda-forge). Launch: `deno jupyter --kernel --conn <connection_file>`.
+No environment pools. Get deno via `kernel_launch::tools::get_deno_path()` (PATH first with acceptable version check, then download from Deno GitHub releases). Launch: `deno jupyter --kernel --conn <connection_file>`.
 
 ## Environment source labels
 

--- a/crates/notebook-sync/AGENTS.md
+++ b/crates/notebook-sync/AGENTS.md
@@ -1,21 +1,23 @@
 # notebook-sync
 
 This crate is the client-side sync handle and socket task boundary for
-NotebookDoc, RuntimeStateDoc, CommsDoc, CommentsDoc, PoolDoc, requests,
-presence, blobs, and session status.
+NotebookDoc, RuntimeStateDoc, CommsDoc, PoolDoc, requests, presence, blobs, and
+session status. CommentsDoc frames pass through the relay path but this crate
+holds no comments replica.
 
 ## Main pieces
 
 - `DocHandle` is the caller-facing API. Synchronous document mutations go
   through `with_doc` or typed helpers, then notify the sync task.
 - `SharedDocState` stores the local NotebookDoc, RuntimeStateDoc, CommsDoc,
-  CommentsDoc, PoolDoc, snapshots, request waiters, blob waiters, and readiness
-  phases shared with the socket task.
+  PoolDoc, snapshots, request waiters, blob waiters, and readiness phases
+  shared with the socket task.
 - `sync_task` owns typed-frame I/O. It sends and receives Automerge sync for
-  `0x00` NotebookDoc, `0x05` RuntimeStateDoc, `0x06` PoolDoc, `0x09` CommsDoc,
-  and `0x0a` CommentsDoc, plus request, response, presence, session-control,
-  and `PUT_BLOB` frames. The Python sync task ignores `0x0a` CommentsDocSync
-  frames; frontend/WASM handles comments directly.
+  `0x00` NotebookDoc, `0x05` RuntimeStateDoc, `0x06` PoolDoc, and `0x09`
+  CommsDoc, plus request, response, presence, session-control, and `PUT_BLOB`
+  frames. It receives and ignores `0x0a` CommentsDocSync — the comments
+  replica lives in frontend WASM (`runtimed-wasm`), reached via `relay_task`,
+  not in `SharedDocState`.
 - `execution_wait` / `execution_watch` observe RuntimeStateDoc terminal state;
   RuntimeStateDoc is the durable execution/output record, not broadcast replay.
 - `relay` / `relay_task` are byte-pipe helpers for app relay paths; they do not

--- a/crates/notebook-sync/AGENTS.md
+++ b/crates/notebook-sync/AGENTS.md
@@ -1,20 +1,21 @@
 # notebook-sync
 
 This crate is the client-side sync handle and socket task boundary for
-NotebookDoc, RuntimeStateDoc, CommsDoc, PoolDoc, requests, presence, blobs, and
-session status.
+NotebookDoc, RuntimeStateDoc, CommsDoc, CommentsDoc, PoolDoc, requests,
+presence, blobs, and session status.
 
 ## Main pieces
 
 - `DocHandle` is the caller-facing API. Synchronous document mutations go
   through `with_doc` or typed helpers, then notify the sync task.
 - `SharedDocState` stores the local NotebookDoc, RuntimeStateDoc, CommsDoc,
-  PoolDoc, snapshots, request waiters, blob waiters, and readiness phases
-  shared with the socket task.
+  CommentsDoc, PoolDoc, snapshots, request waiters, blob waiters, and readiness
+  phases shared with the socket task.
 - `sync_task` owns typed-frame I/O. It sends and receives Automerge sync for
-  `0x00` NotebookDoc, `0x05` RuntimeStateDoc, `0x06` PoolDoc, and `0x09`
-  CommsDoc, plus request, response, presence, session-control, and `PUT_BLOB`
-  frames.
+  `0x00` NotebookDoc, `0x05` RuntimeStateDoc, `0x06` PoolDoc, `0x09` CommsDoc,
+  and `0x0a` CommentsDoc, plus request, response, presence, session-control,
+  and `PUT_BLOB` frames. The Python sync task ignores `0x0a` CommentsDocSync
+  frames; frontend/WASM handles comments directly.
 - `execution_wait` / `execution_watch` observe RuntimeStateDoc terminal state;
   RuntimeStateDoc is the durable execution/output record, not broadcast replay.
 - `relay` / `relay_task` are byte-pipe helpers for app relay paths; they do not

--- a/crates/notebook-wire/AGENTS.md
+++ b/crates/notebook-wire/AGENTS.md
@@ -37,7 +37,7 @@ The frontend talks to the Tauri relay through `invoke()` calls, a generation-sco
    { "channel": "notebook_sync", "notebook_id": "/path/to/notebook.ipynb", "protocol": "v4" }
    ```
 
-   `Handshake` uses `#[serde(tag = "channel", rename_all = "snake_case")]`, so the wire form is flat. Optional fields (`working_dir`, `initial_metadata`) omit when `None`. Other variants: `Pool`, `SettingsSync`, `OpenNotebook { path }`, `CreateNotebook { runtime, … }`, `RuntimeAgent { … }`. `OpenNotebook` / `CreateNotebook` are the desktop paths; `NotebookSync` is used by programmatic clients (Python bindings). Blob uploads ride the `NotebookSync` channel as `PUT_BLOB` (`0x08`) frames; the localhost blob HTTP port is a separate server on a different socket, not a handshake channel.
+   `Handshake` uses `#[serde(tag = "channel", rename_all = "snake_case")]`, so the wire form is flat. Optional fields (`working_dir`, `initial_metadata`) omit when `None`. Other variants: `Pool`, `SettingsSync`, `OpenNotebook { path }`, `CreateNotebook { runtime, … }`, `OpenHostedNotebook { url, … }`, `RuntimeAgent { … }`. `OpenNotebook` / `CreateNotebook` are the desktop paths; `NotebookSync` is used by programmatic clients (Python bindings); `OpenHostedNotebook` is used by daemon-mediated hosted cloud notebook bridges. Blob uploads ride the `NotebookSync` channel as `PUT_BLOB` (`0x08`) frames; the localhost blob HTTP port is a separate server on a different socket, not a handshake channel.
 
    The daemon responds with `NotebookConnectionInfo`:
 
@@ -61,6 +61,7 @@ The runtimed socket is **same-UID trusted**, not app-private. Unix permissions p
 | `NotebookSync` | Peer access to a notebook room and its runtime-state sync |
 | `OpenNotebook` | Load or create a file-backed notebook from a path |
 | `CreateNotebook` | Create an untitled or ephemeral notebook room |
+| `OpenHostedNotebook` | Daemon-mediated bridge to a hosted cloud notebook room; delegates authority to the cloud room host |
 | `RuntimeAgent` | Attach a runtime-agent peer to a notebook room |
 
 A new handshake variant inherits this model. For tighter authority on a channel, design an explicit capability or guard instead of assuming "only the desktop app can reach it."
@@ -99,12 +100,14 @@ After the handshake, frames carry a leading type byte:
 | `0x07` | SessionControl | JSON (`SessionControlMessage`, daemon-originated readiness/status) |
 | `0x08` | PutBlob | Framed binary blob upload (`PutBlobHeader` + bytes) |
 | `0x09` | CommsDocSync | Binary (per-notebook `CommsDoc` Automerge sync) |
+| `0x0a` | CommentsDocSync | Binary (per-notebook `CommentsDoc` Automerge sync) |
 
 | Sender | Valid types |
 |--------|-------------|
-| Frontend / Tauri relay | `0x00`, `0x01`, `0x04`, `0x05`, `0x06`, `0x08`, `0x09` |
-| Daemon notebook peer | `0x00`, `0x02`, `0x03`, `0x04`, `0x05`, `0x06`, `0x07`, `0x09` |
+| Frontend / Tauri relay | `0x00`, `0x01`, `0x04`, `0x05`, `0x06`, `0x08`, `0x09`, `0x0a` |
+| Daemon notebook peer | `0x00`, `0x02`, `0x03`, `0x04`, `0x05`, `0x06`, `0x07`, `0x09`, `0x0a` |
 | Runtime agent peer | `0x00`, `0x01` (RuntimeAgentRequest/Envelope), `0x02` (RuntimeAgentResponse/Envelope), `0x05`, `0x09` |
+| Cloud viewer bridge | `0x00`, `0x04`, `0x05`, `0x09`, `0x0a` |
 
 `NotebookRequest` / `NotebookResponse` payloads travel in flattened `NotebookRequestEnvelope` / `NotebookResponseEnvelope`. Concurrent requests carry an `id`; clients route responses by id because broadcasts, state sync, and out-of-order responses interleave freely.
 
@@ -249,7 +252,7 @@ Kernel produces output
 | `daemon:ready` event | Relay → Frontend | `DaemonReadyPayload` | Connection established, ready to bootstrap |
 | `daemon:disconnected` event | Relay → Frontend | — | Connection lost |
 
-Outgoing frames use `sendFrame(frameType, payload)` where `payload` is `Uint8Array` via `tauri::ipc::Request`. Relay accepts frontend-originated `0x00`, `0x01`, `0x04`, `0x05`, `0x06`; `0x02`, `0x03`, `0x07` are daemon-originated.
+Outgoing frames use `sendFrame(frameType, payload)` where `payload` is `Uint8Array` via `tauri::ipc::Request`. Relay accepts frontend-originated `0x00`, `0x01`, `0x04`, `0x05`, `0x06`, `0x0a`; `0x02`, `0x03`, `0x07` are daemon-originated.
 
 ### In-memory frame bus
 

--- a/crates/notebook-wire/AGENTS.md
+++ b/crates/notebook-wire/AGENTS.md
@@ -252,7 +252,7 @@ Kernel produces output
 | `daemon:ready` event | Relay → Frontend | `DaemonReadyPayload` | Connection established, ready to bootstrap |
 | `daemon:disconnected` event | Relay → Frontend | — | Connection lost |
 
-Outgoing frames use `sendFrame(frameType, payload)` where `payload` is `Uint8Array` via `tauri::ipc::Request`. Relay accepts frontend-originated `0x00`, `0x01`, `0x04`, `0x05`, `0x06`, `0x0a`; `0x02`, `0x03`, `0x07` are daemon-originated.
+Outgoing frames use `sendFrame(frameType, payload)` where `payload` is `Uint8Array` via `tauri::ipc::Request`. Relay accepts frontend-originated `0x00`, `0x01`, `0x04`, `0x05`, `0x06`, `0x08`, `0x09`, `0x0a`; `0x02`, `0x03`, `0x07` are daemon-originated.
 
 ### In-memory frame bus
 

--- a/crates/runtimed/AGENTS.md
+++ b/crates/runtimed/AGENTS.md
@@ -43,7 +43,7 @@ The Tauri app crate (`crates/notebook/`) is glue — it wires Tauri commands to 
 | Widget state | Daemon/runtime agent + frontend comm deltas | RuntimeStateDoc holds comm topology; CommsDoc holds mutable comm state; the runtime agent gates state by topology, suppresses echoes, and forwards accepted frontend deltas to the kernel |
 | RuntimeStateDoc (kernel status, queue, executions, env, trust) | Local daemon / room host / runtime peer, policy-scoped | Separate per-notebook Automerge doc synced via frame `0x05`; regular clients read it but do not author it |
 | CommsDoc (widget state) | Daemon/runtime agent + frontend comm deltas | Separate per-notebook Automerge doc synced via frame `0x09` |
-| CommentsDoc (notebook comments) | Frontend WASM + daemon | Durable sidecar per-notebook Automerge doc synced via frame `0x0a`; daemon persists to disk and applies optimistic rendering + authority finalization policy |
+| CommentsDoc (notebook comments) | Frontend WASM + daemon | Durable sidecar per-notebook Automerge doc synced via frame `0x0a`; daemon persists to disk and validates change actor labels at ingress, stripping writes from scopes without comment authority |
 
 ## RuntimeStateDoc
 

--- a/crates/runtimed/AGENTS.md
+++ b/crates/runtimed/AGENTS.md
@@ -1,6 +1,6 @@
 # Runtime daemon (runtimed)
 
-Scope: `crates/runtimed/**`, `crates/runt/**`, `crates/runtimed-client/**`, `crates/runtimed-outputs/**`, `crates/runtimed-service/**`, `crates/runtimed-settings-sync/**`, `crates/runtimed-py/**`, `crates/runtime-doc/**`, `crates/notebook-wire/**`, `crates/notebook-doc/**`, `crates/notebook-protocol/**`, `crates/notebook-sync/**`, `packages/runtimed/**`.
+Scope: `crates/runtimed/**`, `crates/runt/**`, `crates/runtimed-client/**`, `crates/runtimed-outputs/**`, `crates/runtimed-service/**`, `crates/runtimed-settings-sync/**`, `crates/runtimed-py/**`, `crates/runtime-doc/**`, `crates/comments-doc/**`, `crates/notebook-wire/**`, `crates/notebook-doc/**`, `crates/notebook-protocol/**`, `crates/notebook-sync/**`, `packages/runtimed/**`.
 
 ## Core principles
 
@@ -43,6 +43,7 @@ The Tauri app crate (`crates/notebook/`) is glue — it wires Tauri commands to 
 | Widget state | Daemon/runtime agent + frontend comm deltas | RuntimeStateDoc holds comm topology; CommsDoc holds mutable comm state; the runtime agent gates state by topology, suppresses echoes, and forwards accepted frontend deltas to the kernel |
 | RuntimeStateDoc (kernel status, queue, executions, env, trust) | Local daemon / room host / runtime peer, policy-scoped | Separate per-notebook Automerge doc synced via frame `0x05`; regular clients read it but do not author it |
 | CommsDoc (widget state) | Daemon/runtime agent + frontend comm deltas | Separate per-notebook Automerge doc synced via frame `0x09` |
+| CommentsDoc (notebook comments) | Frontend WASM + daemon | Durable sidecar per-notebook Automerge doc synced via frame `0x0a`; daemon persists to disk and applies optimistic rendering + authority finalization policy |
 
 ## RuntimeStateDoc
 

--- a/docs/adr/0001-notebook-seeding-invariant.md
+++ b/docs/adr/0001-notebook-seeding-invariant.md
@@ -124,7 +124,7 @@ It is the option that actually answers the objection - it replaces an inferred s
 
 ### The predicate
 
-The implementation plan resolved B's open boundary against the pinned automerge fork. A fresh document - daemon **or** cloud - is built by `NotebookDoc::new_with_actor`, which is the frozen genesis plus exactly three ROOT puts (`notebook_id`, `runtime_state_doc_id`, `comms_doc_id`); the cloud room host's "schema label" argument is the actor, not a ROOT key, so both hosts produce the identical scaffold. That makes the allowlist exact and host-agnostic. The op types come from the `automerge::legacy` module (that is what `change.decode().operations` yields), and the gate matches on `op.action` and `op.pred` as well as `obj`/`key`, so that a *delete* or *overwrite* of an identity key after creation - which is post-creation history, not the creation scaffold - is correctly rejected:
+The implementation plan resolved B's open boundary against the pinned automerge fork. A fresh document - daemon **or** cloud - is built by `NotebookDoc::new_with_actor`, which is the frozen genesis plus exactly three ROOT puts (`notebook_id`, `runtime_state_doc_id`, `comms_doc_id`); the cloud room host's "schema label" argument is the actor, not a ROOT key, so both hosts produce the identical scaffold. The daemon's untitled/ephemeral room creation additionally writes `metadata.ephemeral` before the seeding check runs, so the allowlist admits that single metadata put as creation scaffold (the export path deliberately excludes it so it does not persist). That makes the allowlist exact and host-agnostic. The op types come from the `automerge::legacy` module (that is what `change.decode().operations` yields), and the gate matches on `op.action` and `op.pred` as well as `obj`/`key`, so that a *delete* or *overwrite* of an identity key after creation - which is post-creation history, not the creation scaffold - is correctly rejected:
 
 ```rust
 use automerge::legacy::{Key, ObjectId, OpType}; // decode() yields legacy ops
@@ -137,8 +137,8 @@ pub fn is_pristine(&mut self) -> bool {
     for change in self.doc.get_changes(&[]) {
         if seed.contains(&change.hash()) { continue; }
         for op in change.decode().operations {
-            // only the initial Put (empty pred) of an identity key is scaffold
-            let scaffold_put = matches!(op.action, OpType::Put(_))
+            // Identity puts at ROOT (notebook_id, runtime_state_doc_id, comms_doc_id)
+            let is_identity_put = matches!(op.action, OpType::Put(_))
                 && op.pred.is_empty()
                 && matches!(op.obj, ObjectId::Root)
                 && matches!(
@@ -148,7 +148,13 @@ pub fn is_pristine(&mut self) -> bool {
                             || k == "runtime_state_doc_id"
                             || k == "comms_doc_id"
                 );
-            if !scaffold_put { return false; }
+            // The daemon's ephemeral room-lifecycle flag, stamped into the metadata map
+            // at room creation for untitled/ephemeral rooms. Export deliberately excludes it
+            // so it does not persist, but it is present here before the seeding check runs.
+            let is_ephemeral_flag = matches!(op.action, OpType::Put(_))
+                && op.pred.is_empty()
+                && matches!(&op.key, Key::Map(k) if k.as_str() == "ephemeral");
+            if !(is_identity_put || is_ephemeral_flag) { return false; }
         }
     }
     true
@@ -171,7 +177,7 @@ Any cell insert (op on the `cells` object), metadata write, or post-creation ide
 
 ## Resolved during planning
 
-1. **Exact pristine predicate** - settled: canonical seed hashes plus *initial* (`Put`, empty `pred`) identity puts to ROOT (`notebook_id`, `runtime_state_doc_id`, `comms_doc_id`); any other op - including a delete or overwrite of an identity key - means initialized. See the predicate above.
+1. **Exact pristine predicate** - settled: canonical seed hashes plus *initial* (`Put`, empty `pred`) identity puts to ROOT (`notebook_id`, `runtime_state_doc_id`, `comms_doc_id`) and the daemon's `ephemeral` metadata flag; any other op - including a delete or overwrite of an identity key - means initialized. See the predicate above.
 2. **Cost** - settled: O(number of changes), ~2 for a fresh doc, walked only on the metadata-absent path; the `metadata.is_some()` short-circuit is a pure optimization for the common already-seeded case, not the soundness mechanism (see The predicate).
 3. **Cloud parity** - settled: the predicate lives in `notebook-doc`; `runtimed` and `runtimed-wasm` both call `NotebookDoc::is_pristine`, no reimplementation.
 4. **Test surface** - settled: unit tests for fresh / metadata-stamped / one-cell / emptied-after-content / overwritten-or-deleted-identity-key / every-fresh-constructor, plus an integration test that empties a notebook, reconnects, and expects zero cells (the headline behavior, previously only covered indirectly).

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -9,6 +9,9 @@ technical decisions graduate back into this ADR register.
 
 ## ADR Statuses
 
+Use only these four status terms. When a status needs qualification, add a date
+and brief clause after the status term — do not create compound pseudo-statuses.
+
 - **Accepted**: load-bearing decision that current and future work should treat
   as the architectural source of truth.
 - **Draft**: proposed or recently extracted decision that should be reviewed

--- a/docs/adr/blob-storage-and-content-addressing.md
+++ b/docs/adr/blob-storage-and-content-addressing.md
@@ -157,15 +157,18 @@ back to OS-assigned. The server exposes:
 
 - `GET /blob/{hash}` - raw bytes, `Content-Type` from the metadata sidecar
   (falling back to `application/octet-stream`).
-- `GET /plugins/{name}` - embedded renderer plugin assets (out of scope for
-  this ADR; lives on the same listener because the renderer needs both
-  origins and a single port keeps the CSP simple). The renderer can be told
-  to fetch these assets from a different base URL via
-  `NteractEmbedHostContext.nteract.rendererAssetsBaseUrl`
-  (`src/components/isolated/host-context.ts`, added in #2812). Desktop
-  leaves it unset and falls back to `/plugins/{name}` on the daemon's HTTP
-  origin; hosted viewers point it at a cloud-served asset prefix.
+- `GET /renderer-plugins/{name}` - raw renderer plugin assets for isolated
+  output frames (markdown, bokeh, panel, sift). Introduced for the shared
+  isolated renderer; the daemon serves the built plugin bundles directly.
+- `GET /plugins/{name}` - legacy MCP App loader route with JS wrapping, kept for
+  compatibility. New code uses `/renderer-plugins/`.
 - `GET /health` - probe.
+
+The renderer is told which base URL to use for plugin assets via
+`NteractEmbedHostContext.nteract.rendererAssetsBaseUrl`
+(`src/components/isolated/host-context.ts`, added in #2812). Desktop leaves it
+unset and falls back to the daemon's HTTP origin; hosted viewers point it at a
+cloud-served asset prefix.
 
 Response headers:
 

--- a/docs/adr/captured-environment-lifecycle.md
+++ b/docs/adr/captured-environment-lifecycle.md
@@ -1,7 +1,8 @@
 # Captured Environment Lifecycle
 
-**Status:** Draft, 2026-05-24. This document records the target lifecycle
-shape; parts of the implementation remain planned rather than fully enforced.
+**Status:** Accepted, 2026-05-24. Typed disk state (`Missing`, `Partial`,
+`Usable`) and captured repair routing landed. Manual rebuild, explicit refresh,
+and launch-retry remain open follow-ups.
 
 ## Related ADRs
 
@@ -53,12 +54,21 @@ The old question was "does `unified_env_on_disk()` return a Python path?" That b
 | `Partial` | Env dir exists but the expected Python executable is absent. | Route to captured repair. The directory's presence proves the notebook once owned this derived hash. |
 | `Usable` | Env dir exists and expected Python executable exists. | Route as captured cache-hit candidate. |
 
-This distinction is load-bearing. A missing dir is ambiguous and must preserve the existing fallback behavior. A partial dir is not ambiguous: it is a broken on-disk realization of this notebook's captured identity and should be rebuilt through the captured path.
+This distinction is load-bearing. A missing dir is ambiguous and must preserve
+the existing fallback behavior. A partial dir is not ambiguous: it is a broken
+on-disk realization of this notebook's captured identity and should be rebuilt
+through the captured path.
 
-The resolution helper must therefore be typed. A plan that detects `Partial` only inside `acquire_prewarmed_env_with_capture()` is insufficient if the source-resolution layer never routes partial dirs to `uv:prewarmed` or `conda:prewarmed`.
+The resolution helper must therefore be typed. A plan that detects `Partial`
+only inside `acquire_prewarmed_env_with_capture()` is insufficient if the
+source-resolution layer never routes partial dirs to `uv:prewarmed` or
+`conda:prewarmed`.
 
-Implementation note: this is the intended architecture, not the current state
-of every code path. CEL-1 tracks the remaining boolean-path implementation gap.
+Implemented: `CapturedEnvDiskState::{Missing, Partial, Usable}` (defined at
+`crates/runtimed/src/notebook_sync_server/metadata.rs`) and
+`captured_env_disk_state()` classify disk state by environment backend; both
+`Partial` and `Usable` route as captured cache-hit candidates, and
+`prepare_environment_unified()` rebuilds partial dirs before handoff.
 
 ## Decision 3: The happy path stays cheap
 
@@ -206,13 +216,16 @@ Use "declared dependencies", not "saved dependencies"; saved can mean either the
 3. **Full typed launch-error model.** If optional retry hints are too weak or leak into other protocol surfaces, introduce a richer internal launch-error type.
 4. **Manual rebuild `env_id` policy.** Automatic repair keeps `env_id` stable. Manual rebuild can revisit stable versus rotated `env_id` with UI and concurrency constraints in view.
 
-## Implementation Notes
+## Open Follow-ups
 
-The #1969 implementation plan should be updated before coding:
-
-- merge typed disk-state and partial repair into one implementation unit;
-- replace the boolean `is_captured()` gate with typed captured-resolution semantics;
-- prove `Missing` does not route as captured and `Partial` does;
-- classify launch failures in `runtime_agent.rs` before wrapping;
-- keep retry lifecycle in a progressing state until final success/error;
-- add focused tests for UV and Conda disk states, including broken symlink behavior when feasible.
+1. **Launch retry on captured-env handshake failure.** Automatic one-shot repair
+   with coordinator-scoped retry suppression. Requires typed launch-error model
+   with optional retry hints.
+2. **Manual rebuild API.** Explicit user-triggered "rebuild this captured
+   environment" without mutating `env_id` or dependency metadata.
+3. **Refresh workspace defaults.** Update a captured notebook's dependency
+   metadata to match current workspace defaults, invalidating the old captured
+   identity.
+4. **Retry suppression window.** If the one-shot retry proves insufficient
+   under intermittent network/package-index failures, add a short per-room
+   suppression window.

--- a/docs/adr/cloud-connected-local-mcp.md
+++ b/docs/adr/cloud-connected-local-mcp.md
@@ -186,6 +186,35 @@ assume a local `DocHandle`. That abstraction should represent the same stable
 document set (`NotebookDoc`, `RuntimeStateDoc`, `CommsDoc`) rather than copying
 cloud state into React-specific or MCP-specific projections.
 
+### Daemon-mediated bridge vs. direct MCP connector
+
+Two hosted-room connection paths coexist:
+
+**Daemon-mediated bridge** (commit 0745eeab, #3884) — the product default for
+desktop notebook use. The daemon dials the hosted room over
+`CloudWsFrameTransport` and attaches it as one more sync peer of a local
+ephemeral `NotebookRoom` (`hosted_bridge.rs`). Desktop windows and MCP sessions
+connect to that daemon-local room exactly like any daemon-local notebook. Echo
+suppression is structural (one `NotebookDoc`, one `sync::State` per peer). The
+hosted room is authoritative for `RuntimeStateDoc`; execution requests forward
+as hosted `Request` frames.
+
+**Direct MCP connector** (`runt-mcp/src/cloud.rs`) — still implemented but not
+the primary desktop path. `runt mcp` establishes a typed-frame v4 WebSocket
+directly to the hosted room without a daemon bridge.
+
+When to use each:
+
+- **Desktop app, Codex app/CLI:** daemon-mediated bridge. The desktop app
+  attaches to a daemon notebook room; the daemon bridges to the hosted room if
+  the notebook's domain is hosted.
+- **Standalone MCP clients, agents without daemons:** direct connector. No
+  daemon required; the MCP process holds the WebSocket.
+
+Both paths resolve the same machine-local `cloud-domains.toml` (shared via
+`notebook-cloud-transport::registry`) and produce the same principal/operator
+actor labels.
+
 ## Decision 4: Principal comes from the credential; operator comes from local config
 
 Hosted room auth still decides the principal. If the configured credential is

--- a/docs/adr/deployment-topology.md
+++ b/docs/adr/deployment-topology.md
@@ -230,9 +230,13 @@ topology.
 The identity model does not require a local daemon bridge for hosted rooms.
 Supported client-to-room patterns:
 
-- **Browser direct.** The browser connects to the hosted room WebSocket. For the
-  Anaconda-friendly path, the viewer/editor shell performs direct OIDC login and
-  sends a validated bearer token through the non-echoed WebSocket subprotocol.
+- **Browser direct.** The browser connects to the hosted room WebSocket. For
+  first-party app sessions, the viewer/editor shell uses the app-session cookie
+  (set by OIDC login redirects) directly, with trusted `Origin` enforcement.
+  The WebSocket upgrade path reads the session from the cookie and produces an
+  authenticated connection identity (`:720-:778` in `index.ts`). Non-cookie
+  browser clients (embedding shells, explicit MCP bridges) may send a validated
+  bearer token through the non-echoed WebSocket subprotocol.
 - **Native direct.** Desktop, CLI, TUI, and agents connect directly to the room
   WebSocket with an `Authorization` header or equivalent native credential
   transport.

--- a/docs/adr/deployment-topology.md
+++ b/docs/adr/deployment-topology.md
@@ -343,7 +343,10 @@ infer compute from the document host.
 - SSH as the first remote-room transport.
 - Moving kernels into Cloudflare Workers or Durable Objects.
 - Treating JupyterHub as the default document engine for Anaconda-hosted rooms.
-- Preserving pre-publish local Automerge actor history inside hosted rooms.
+- Treating preserved pre-publish actor history as verified attribution.
+  Current publish carries source actor history into hosted rooms;
+  re-authoring at the publish boundary is the target (identity ADR
+  Decision 6).
 - Solving the local same-path autosave bug; #2285 remains the concrete bug for
   local file-binding safety.
 

--- a/docs/adr/document-split.md
+++ b/docs/adr/document-split.md
@@ -227,9 +227,10 @@ runtime-agent actor, while the shared policy filters what each scope may mutate.
   metadata and the runtime/comms projection; the live CommsDoc is dropped on
   room eviction.
 - **`CommentsDoc`** is **persisted** to disk as a durable sidecar. The daemon
-  writes CommentsDoc to `~/.cache/<namespace>/comments/{notebook_hash}.am` and
-  loads it on room join. Optimistic comments render immediately; authority
-  fields are finalized by the daemon/room host
+  writes CommentsDoc to
+  `~/.cache/<namespace>/comments/<sha256-of-comments-doc-id>.automerge`
+  (sibling of `notebook-docs/`) and loads it on room join. Optimistic comments
+  render immediately; ingress validates change actor labels and scope
   (`crates/runtimed/src/notebook_sync_server/peer_comments_sync.rs`).
 - **`PoolDoc`** is **not** persisted. It is built fresh from `PoolDoc::new()` on daemon startup, hydrated from in-process pool state on each daemon tick (`Daemon::update_pool_doc`). On daemon restart it is empty until the pools come back online.
 
@@ -248,7 +249,7 @@ So the durable footprint of one notebook is: the `.ipynb` (or untitled `.automer
 | `NotebookDoc` | On room load (either from `.ipynb` or fresh) | Per-notebook UUID; schema seed actor `nteract:notebook-schema:v5` | On room eviction; persisted file deleted on save-as transition |
 | `RuntimeStateDoc` | On room load (fresh from schema seed; load code populates synthetic executions when the `.ipynb` carries legacy outputs, `crates/runtimed/src/notebook_sync_server/load.rs:709, :731, :741`) | Runtime-state document id referenced by `NotebookDoc.runtime_state_doc_id`; schema seed actor `nteract:runtime-state-schema:v2`; daemon writes under actor `runtimed:state`; runtime-agent peer writes under its own actor (`crates/runtimed/src/runtime_agent.rs:96`) | On room eviction |
 | `CommsDoc` | On room load (fresh from schema seed; load code hydrates widget state when `.ipynb` widget metadata is present) | Per-notebook side document; schema seed actor `nteract:comms-doc-schema:v1` | On room eviction |
-| `CommentsDoc` | On room load (loaded from disk or fresh from schema seed) | Per-notebook sidecar document; schema seed actor `nteract:comments-doc-schema:v1`; daemon applies optimistic rendering + authority finalization | On room eviction; persisted sidecar survives eviction |
+| `CommentsDoc` | On room load (loaded from disk or fresh from schema seed) | Per-notebook sidecar document; schema seed actor `nteract:comments-doc-schema:v1`; ingress validates change actor labels and scope | On room eviction; persisted sidecar survives eviction |
 | `PoolDoc` | On daemon startup | Singleton; daemon writes under actor `runtimed:pool` | On daemon shutdown |
 
 The schema seed actor is what makes initial sync correct. Every peer scaffolds
@@ -275,8 +276,10 @@ Each doc's `receive_sync_message` makes a different choice about client changes:
   widget state changes. Runtime forwarding and orphan cleanup use
   `RuntimeStateDoc` topology as the membership authority.
 - **`CommentsDoc::receive_sync_message_with_changes_recovering`** applies
-  optimistic comment changes. The daemon/room host finalizes authority-policy
-  fields (`finalized`, `finalized_at`, `finalized_by`) after ingress.
+  optimistic comment changes. The daemon/room host validates change actor
+  labels against the connection principal and strips writes from scopes
+  without comment authority; there is no daemon finalization step —
+  attribution is projected from admitted change actors.
 - **`PoolDoc::receive_sync_message`** (`crates/notebook-doc/src/pool_state.rs:341`) explicitly clears `message.changes = Vec::<Vec<u8>>::new().into()` before passing to Automerge. The `heads`, `need`, and `have` fields are preserved by omission so the sync handshake still completes (bloom-filter exchange, ACKs); only the change payload is dropped.
 
 This is a set of different ingress shapes for what looks like one protocol.

--- a/docs/adr/document-split.md
+++ b/docs/adr/document-split.md
@@ -6,10 +6,8 @@
 three-document model by extracting mutable widget comm state into `CommsDoc`.
 This document remains the historical baseline for the original split and its
 document-boundary reasoning. Do not use the document count as the concept:
-current notebook rooms sync `NotebookDoc`, `RuntimeStateDoc`, and `CommsDoc`;
-`PoolDoc` is daemon-scoped and sync-adjacent; the proposed `CommentsDoc` is
-another per-notebook sidecar tracked separately in
-`notebook-comments-document.md`.
+current notebook rooms sync `NotebookDoc`, `RuntimeStateDoc`, `CommsDoc`, and
+`CommentsDoc`; `PoolDoc` is daemon-scoped and sync-adjacent.
 
 ## Context
 
@@ -17,8 +15,8 @@ nteract syncs state through Automerge CRDTs. Separate documents carry that
 state today, not one. They split into two scopes:
 
 - **Notebook-room documents** are attached to one notebook collaboration room.
-  Today that set is `NotebookDoc`, `RuntimeStateDoc`, and `CommsDoc`. Proposed
-  comment work adds `CommentsDoc` to this room set.
+  Today that set is `NotebookDoc`, `RuntimeStateDoc`, `CommsDoc`, and
+  `CommentsDoc`.
 - **Daemon-scoped documents** are fanned out to room peers because they affect
   the room UI, but they do not belong to the room identity. `PoolDoc` is the
   current example.
@@ -28,16 +26,18 @@ The current documents are:
 - **`NotebookDoc`** (`crates/notebook-doc/src/lib.rs`) - one per notebook room. Carries cells, source text, notebook metadata, attachments. Schema version 5. Wire frame `0x00` (AutomergeSync).
 - **`RuntimeStateDoc`** (`crates/runtime-doc/src/doc.rs`) - one per runtime state surface; today each notebook room creates one. Carries kernel lifecycle, execution queue, executions and their outputs, env-sync state, trust state, project-file context, and widget comm topology/routing. Mutable widget comm state moved to `CommsDoc`. Schema version 2. Wire frame `0x05` (RuntimeStateSync).
 - **`CommsDoc`** (`crates/runtime-doc/src/comms.rs`) - one per notebook room. Carries mutable widget comm state keyed by comm id; `RuntimeStateDoc` remains the topology and membership source of truth. Schema version 1. Wire frame `0x09` (CommsDocSync).
+- **`CommentsDoc`** (`crates/comments-doc/src/lib.rs`) - one per notebook room. Carries notebook comments as a durable collaboration sidecar. The daemon persists CommentsDoc separately from the notebook, applies optimistic rendering, and finalizes authority-policy fields. Schema version 1. Wire frame `0x0a` (CommentsDocSync).
 - **`PoolDoc`** (`crates/notebook-doc/src/pool_state.rs`) - one per daemon (not per room). Carries UV / Conda / Pixi prewarm pool counters, errors, retry timers. No schema version. Wire frame `0x06` (PoolStateSync).
 
 A connecting peer subscribes through one of the typed-frame handshake channels.
-`NotebookSync` (and the related `OpenNotebook` / `CreateNotebook` paths) brings
-up the room documents on one socket: `NotebookDoc`, `RuntimeStateDoc`, and
-`CommsDoc` per the joined room, plus `PoolDoc` fanned out to that peer because
-the peer loop subscribes to `pool_doc_changed` regardless of room. The `Pool`
-handshake is a JSON-IPC channel for pool status, env claims, and daemon admin;
-it does not carry typed-frame Automerge sync at all. Frame caps differ per type
-(see `crates/notebook-wire/src/lib.rs`).
+`NotebookSync` (and the related `OpenNotebook` / `CreateNotebook` /
+`OpenHostedNotebook` paths) brings up the room documents on one socket:
+`NotebookDoc`, `RuntimeStateDoc`, `CommsDoc`, and `CommentsDoc` per the joined
+room, plus `PoolDoc` fanned out to that peer because the peer loop subscribes
+to `pool_doc_changed` regardless of room. The `Pool` handshake is a JSON-IPC
+channel for pool status, env claims, and daemon admin; it does not carry
+typed-frame Automerge sync at all. Frame caps differ per type (see
+`crates/notebook-wire/src/lib.rs`).
 
 The split is load-bearing for permission boundaries, document authority,
 durability/lifetime, attachment identity, and fan-out scope. It is not written
@@ -70,13 +70,15 @@ let InitialSyncState { mut peer_state } =      // NotebookDoc
     send_initial_notebook_doc_sync(&mut writer, room).await?;
 let mut state_peer_state = sync::State::new(); // RuntimeStateDoc
 let mut comms_peer_state = sync::State::new(); // CommsDoc
+let mut comments_peer_state = sync::State::new(); // CommentsDoc
 let mut pool_peer_state = sync::State::new();  // PoolDoc
 ```
 
 Each ingress path is a separate handler (`handle_notebook_doc_frame`,
 `handle_runtime_state_frame`, `handle_comms_doc_frame`,
-`handle_pool_state_frame`) with its own validator. Each broadcast subscription
-is a separate stream (`changed_tx`, `state_changed_tx`, `comms_changed_tx`,
+`handle_comments_doc_frame`, `handle_pool_state_frame`) with its own validator.
+Each broadcast subscription is a separate stream (`changed_tx`,
+`state_changed_tx`, `comms_changed_tx`, `comments_changed_tx`,
 `pool_doc_changed`). Egress now follows the first stage of the peer-lane split:
 reliable frames (`Response`, `SessionControl`, document sync, blob replies) are
 separated from ephemeral presence/broadcast traffic inside `PeerWriter`.
@@ -105,14 +107,15 @@ The reasons for keeping them separate, not just logically but physically on the 
 3. **Different lifetimes and durability.** `NotebookDoc` persists to disk
    (`.automerge` for ephemeral rooms; `.ipynb` for file-backed).
    `RuntimeStateDoc` and desktop `CommsDoc` are live room state, not standalone
-   persisted notebook content. `CommentsDoc`, when added, is durable
-   collaboration state with its own attachment and persistence policy. `PoolDoc`
+   persisted notebook content. `CommentsDoc` is durable collaboration state
+   persisted as a sidecar by the daemon
+   (`crates/runtimed/src/notebook_sync_server/comments_store.rs`). `PoolDoc`
    lives for the daemon's lifetime. See Decision 4.
 4. **Different fan-out and attachment scopes.** `PoolDoc` sync frames fan out
    to notebook-room typed peers so each open notebook can observe daemon pool
-   state. `Handshake::Pool` clients, such as system-tray UI or env-management
-   tools, use the separate JSON-IPC pool/admin channel instead of Automerge
-   `PoolStateSync`. `NotebookDoc` and `RuntimeStateDoc` fan out only to peers
+   state. `Handshake::Pool` clients use the separate JSON-IPC pool/admin
+   channel instead of Automerge `PoolStateSync`. `NotebookDoc`,
+   `RuntimeStateDoc`, `CommsDoc`, and `CommentsDoc` fan out only to peers
    attached to that room.
 5. **Different operational traffic shapes.** The documents do have different
    write cadences, but that is not the primary architectural reason for the
@@ -223,6 +226,11 @@ runtime-agent actor, while the shared policy filters what each scope may mutate.
   desktop rooms. Save/load reconstructs widget state from the notebook's widget
   metadata and the runtime/comms projection; the live CommsDoc is dropped on
   room eviction.
+- **`CommentsDoc`** is **persisted** to disk as a durable sidecar. The daemon
+  writes CommentsDoc to `~/.cache/<namespace>/comments/{notebook_hash}.am` and
+  loads it on room join. Optimistic comments render immediately; authority
+  fields are finalized by the daemon/room host
+  (`crates/runtimed/src/notebook_sync_server/peer_comments_sync.rs`).
 - **`PoolDoc`** is **not** persisted. It is built fresh from `PoolDoc::new()` on daemon startup, hydrated from in-process pool state on each daemon tick (`Daemon::update_pool_doc`). On daemon restart it is empty until the pools come back online.
 
 Output durability is the asymmetry that needs the most attention. `RuntimeStateDoc` outputs are the live record of the most recent execution; they are also what the frontend renders. If the room evicts before a save, those outputs are gone. The compensating mechanism:
@@ -240,6 +248,7 @@ So the durable footprint of one notebook is: the `.ipynb` (or untitled `.automer
 | `NotebookDoc` | On room load (either from `.ipynb` or fresh) | Per-notebook UUID; schema seed actor `nteract:notebook-schema:v5` | On room eviction; persisted file deleted on save-as transition |
 | `RuntimeStateDoc` | On room load (fresh from schema seed; load code populates synthetic executions when the `.ipynb` carries legacy outputs, `crates/runtimed/src/notebook_sync_server/load.rs:709, :731, :741`) | Runtime-state document id referenced by `NotebookDoc.runtime_state_doc_id`; schema seed actor `nteract:runtime-state-schema:v2`; daemon writes under actor `runtimed:state`; runtime-agent peer writes under its own actor (`crates/runtimed/src/runtime_agent.rs:96`) | On room eviction |
 | `CommsDoc` | On room load (fresh from schema seed; load code hydrates widget state when `.ipynb` widget metadata is present) | Per-notebook side document; schema seed actor `nteract:comms-doc-schema:v1` | On room eviction |
+| `CommentsDoc` | On room load (loaded from disk or fresh from schema seed) | Per-notebook sidecar document; schema seed actor `nteract:comments-doc-schema:v1`; daemon applies optimistic rendering + authority finalization | On room eviction; persisted sidecar survives eviction |
 | `PoolDoc` | On daemon startup | Singleton; daemon writes under actor `runtimed:pool` | On daemon shutdown |
 
 The schema seed actor is what makes initial sync correct. Every peer scaffolds
@@ -265,6 +274,9 @@ Each doc's `receive_sync_message` makes a different choice about client changes:
 - **`CommsDoc::receive_sync_message_with_changes_recovering`** applies mutable
   widget state changes. Runtime forwarding and orphan cleanup use
   `RuntimeStateDoc` topology as the membership authority.
+- **`CommentsDoc::receive_sync_message_with_changes_recovering`** applies
+  optimistic comment changes. The daemon/room host finalizes authority-policy
+  fields (`finalized`, `finalized_at`, `finalized_by`) after ingress.
 - **`PoolDoc::receive_sync_message`** (`crates/notebook-doc/src/pool_state.rs:341`) explicitly clears `message.changes = Vec::<Vec<u8>>::new().into()` before passing to Automerge. The `heads`, `need`, and `have` fields are preserved by omission so the sync handshake still completes (bloom-filter exchange, ACKs); only the change payload is dropped.
 
 This is a set of different ingress shapes for what looks like one protocol.
@@ -298,7 +310,7 @@ cause Automerge to evaluate the changes; the strip happens before any apply.
 
 1. UV pool prewarm fails because `default_packages` contains a typo'd package name.
 2. `Daemon::update_pool_doc` writes `PoolDoc.uv.error = "could not resolve package 'numpyy'"`, `error_kind = "invalid_package"`, `failed_package = "numpyy"`.
-3. `pool_doc_changed.send(())` fans out to every peer subscribed in `peer_loop.rs`. That includes peers attached to notebooks via `NotebookSync`, and peers attached via `Pool` handshakes (system tray, env tools).
+3. `pool_doc_changed.send(())` fans out to every notebook typed peer subscribed in `peer_loop.rs`. `Pool` handshake clients use the separate JSON-IPC pool/admin channel, not `PoolStateSync` typed frames.
 4. The frontend `usePoolState` hook re-renders the pool banner. The banner appears once per app instance, not once per open notebook.
 
 ## Open Questions

--- a/docs/adr/execution-pipeline.md
+++ b/docs/adr/execution-pipeline.md
@@ -1,6 +1,6 @@
 # Cell Execution Pipeline and Control-Plane Separation
 
-**Status:** Draft, 2026-05-22.
+**Status:** Accepted, 2026-05-22.
 
 ## Context
 

--- a/docs/adr/frontend-sync-bridge.md
+++ b/docs/adr/frontend-sync-bridge.md
@@ -88,7 +88,12 @@ Stable-DOM-order rendering keeps every cell's iframe pinned to the same DOM node
 
 ### Why this is load-bearing across the codebase
 
-The invariant lives in `AGENTS.md` (also available through the `CLAUDE.md` symlink). It is asserted three places: the `stableDomOrder` memo at `NotebookView.tsx:519`, the `order: index` style at `NotebookView.tsx:307`, and the parent flex container at `NotebookView.tsx:952`. Any one of them flipping back to "iterate cellIds and let React handle order" reintroduces the iframe reload. CI doesn't catch this; the visible failure is a paper cut that is easy to misdiagnose as "iframes are slow."
+The invariant lives in `AGENTS.md` (also available through the `CLAUDE.md`
+symlink). Three code sites implement it: the `stableDomOrder` memo
+(`NotebookView.tsx`), the `order: index` style, and the parent flex container.
+Any one of them flipping back to "iterate cellIds and let React handle order"
+reintroduces the iframe reload. CI doesn't catch this; the visible failure is a
+paper cut that is easy to misdiagnose as "iframes are slow."
 
 ### Hidden-group rendering composes with this
 
@@ -122,7 +127,12 @@ acts on the request:
 
 The function returns `boolean`, not `void`, because outbound flush is the failure surface where the transport can drop or error. Direct flush callers such as dependency sync and save check `false` and bail before issuing their dependent request. Execute and run-all use the `required_heads` path instead: the daemon fails closed if the triggered flush does not deliver the requested heads before its timeout.
 
-The `required_heads` extension lives in `App.tsx:374`: `NotebookClient` is constructed with `getRequiredHeads: () => getHandle()?.get_heads_hex() ?? []` and `flushBeforeRequiredHeadsRequest: () => getEngine()?.flush()`. Cross-reference `docs/adr/execution-pipeline.md` for the daemon side. The bridge does not own this handshake; it owns the inbound projection that lets a UI read the result.
+The `required_heads` extension lives in `App.tsx`: `NotebookClient` is
+constructed with `getRequiredHeads: () => getHandle()?.get_heads_hex() ?? []`
+and `flushBeforeRequiredHeadsRequest: () => getEngine()?.flush()`.
+Cross-reference `docs/adr/execution-pipeline.md` for the daemon side. The bridge
+does not own this handshake; it owns the inbound projection that lets a UI read
+the result.
 
 ### Why the engine returns `Promise<boolean>` and not a result type
 

--- a/docs/adr/generated-runtime-artifacts.md
+++ b/docs/adr/generated-runtime-artifacts.md
@@ -74,6 +74,7 @@ Volatile artifacts stay gitignored and are regenerated:
 - `apps/notebook/src/renderer-plugins/markdown.js`
 - `apps/notebook/src/renderer-plugins/markdown.css`
 - `apps/notebook/src/renderer-plugins/bokeh.js`
+- `apps/notebook/src/renderer-plugins/panel.js`
 - `apps/notebook/src/renderer-plugins/sift.js`
 - `apps/notebook/src/renderer-plugins/sift.css`
 - `apps/notebook/src/wasm/runtimed-wasm/`

--- a/docs/adr/hosted-notebook-artifacts.md
+++ b/docs/adr/hosted-notebook-artifacts.md
@@ -55,9 +55,17 @@ The revision row records:
 - `runtime_snapshot_key`
 - `comms_heads_hash`
 - `comms_snapshot_key`
+- `comments_heads_hash`
+- `comments_snapshot_key`
 - `actor_label`
+- `cell_composition` — derived CSV of cell languages for catalog filtering
+- `language` — primary notebook language for catalog display
+- `cover_blob_hash` — derived notebook cover image hash (first raster output embed)
+- `cover_mime` — MIME type of the cover blob
 
-Derived render JSON is not a durable artifact. The publish API validates the
+Derived render JSON is not a durable artifact. Public OG images for a notebook
+use the latest revision's cover metadata; pinned revisions do not override the
+latest OG image (commit 739fad72). The publish API validates the
 snapshot bundle before recording the catalog row: if the `NotebookDoc` /
 `RuntimeStateDoc` pair cannot load, if a recorded `CommsDoc` snapshot cannot
 load, or if any projected cell, widget comm, or manifest child points at a

--- a/docs/adr/hosted-room-authorization.md
+++ b/docs/adr/hosted-room-authorization.md
@@ -14,12 +14,12 @@
 - the Durable Object can accept typed-frame v4 WebSockets, rewrite CBOR
   presence, enforce frame-size caps, and reject obvious read-only violations.
 
-The next phase should turn that prototype into one hosted room model instead of
-two nearby products. A published read-only notebook, an authenticated editor, a
-future runtime peer, and an anonymous public viewer should all connect to the
-same room abstraction with different scopes. The Worker authenticates the
-connection. D1 decides what that principal can do in this room. The Durable
-Object hosts the live document and persists snapshots.
+The materialized Durable Object room host unifies those pieces. A published
+read-only notebook, an authenticated editor, a future runtime peer, and an
+anonymous public viewer all connect to the same room abstraction with different
+scopes. The Worker authenticates the connection. D1 decides what that principal
+can do in this room. The Durable Object hosts the live document and persists
+snapshots.
 
 Neighbors:
 

--- a/docs/adr/identity-and-trust.md
+++ b/docs/adr/identity-and-trust.md
@@ -5,8 +5,8 @@
 
 ## Context
 
-`NotebookDoc`, `RuntimeStateDoc`, and `CommsDoc` sync between peers via
-typed-frame v4 over a Unix socket today, with same-UID trust covering
+`NotebookDoc`, `RuntimeStateDoc`, `CommsDoc`, and `CommentsDoc` sync between
+peers via typed-frame v4 over a Unix socket today, with same-UID trust covering
 attribution. We want to
 extend the same protocol to hosted multi-user rooms (Anaconda hosted,
 JupyterHub-backed compute, future deployments) without forking the wire format,
@@ -141,9 +141,9 @@ Bearer-token replay is a separate, well-known property of bearer auth: if a user
 
 The room-host enforces scope at frame ingress by inspecting frame type and emptiness:
 
-- **viewer** scope: any inbound document sync frame (`0x00`, `0x05`, or `0x09`) with non-empty `Message.changes` is rejected. Empty negotiation frames (heads/have/need with `ChunkList::empty()`) pass.
+- **viewer** scope: any inbound document sync frame (`0x00`, `0x05`, `0x09`, or `0x0a`) with non-empty `Message.changes` is rejected. Empty negotiation frames (heads/have/need with `ChunkList::empty()`) pass.
 - **runtime_peer** scope: any inbound `0x00` (NotebookDoc) frame with non-empty changes is rejected. `RuntimeStateDoc` writes are allowed only for runtime progress/output over already accepted execution entries, lifecycle state, comm topology, and output routing; trust, environment, path, save metadata, and project context remain room-host/daemon-owned. Execution intent creation still goes through `ExecuteCell`/`RunAllCells`. In the hosted prototype, runtime authorship uses a `RuntimeStatePeerHandle` surface separate from the browser `NotebookHandle`, so a runtime peer can publish execution progress/output state without acquiring notebook editing APIs.
-- **editor** scope: `0x00` NotebookDoc edits are allowed only within the room host's current document-write policy. `0x09` CommsDoc edits are allowed for mutable widget comm state, with kernel forwarding gated by RuntimeStateDoc comm topology. `0x05` RuntimeStateDoc edits are rejected for editor scope; execution, queue, kernel, environment, output, comm topology, and schema/root changes are runtime-owned.
+- **editor** scope: `0x00` NotebookDoc edits are allowed only within the room host's current document-write policy. `0x09` CommsDoc edits are allowed for mutable widget comm state, with kernel forwarding gated by RuntimeStateDoc comm topology. `0x0a` CommentsDoc edits are allowed; ingress validates change actor labels against the connection principal. `0x05` RuntimeStateDoc edits are rejected for editor scope; execution, queue, kernel, environment, output, comm topology, and schema/root changes are runtime-owned.
 - **owner** scope: same frame-level document rules as `editor`, plus ACL-mutation requests are honored. Owner does not imply arbitrary RuntimeStateDoc authorship; runtime lifecycle, execution progress, and output state still require `runtime_peer`, while execution intent still requires the request API.
 
 For non-empty `NotebookDoc`, `RuntimeStateDoc`, and `CommsDoc` sync messages, the room-host also performs a v1 clone-preview validator: clone the current Automerge doc and sync state, apply the incoming message to the clone, extract the actors in the newly applied changes, and reject the frame if any new change's principal differs from the connection's authenticated principal. The real room document is mutated only after this preview succeeds.
@@ -370,7 +370,7 @@ The extraction logic (parse subprotocol header, look up ticket, read cookie, que
 
 A connection carries exactly one scope, determined at authentication time. The four scopes are:
 
-- `viewer` - read-only. May send and receive sync, presence, and session-control frames, **but inbound sync frames must carry no changes**. Automerge sync is bidirectional even when the client never authors: a read-only consumer still negotiates heads/have/need with the server, applies incoming changes from the server, and produces reply frames through the normal `notebook-sync` task loop. The trust gate rejects any inbound `0x00`, `0x05`, or `0x09` frame from a viewer connection whose `Message.changes` is non-empty; empty negotiation frames pass. Request frames are limited to read-only operations. The server's outbound to the viewer is unrestricted.
+- `viewer` - read-only. May send and receive sync, presence, and session-control frames, **but inbound sync frames must carry no changes**. Automerge sync is bidirectional even when the client never authors: a read-only consumer still negotiates heads/have/need with the server, applies incoming changes from the server, and produces reply frames through the normal `notebook-sync` task loop. The trust gate rejects any inbound `0x00`, `0x05`, `0x09`, or `0x0a` frame from a viewer connection whose `Message.changes` is non-empty; empty negotiation frames pass. Request frames are limited to read-only operations. The server's outbound to the viewer is unrestricted.
   - Note on the upstream Automerge `read_only` API: `State::new_read_only()` and `MessageFlags::READ_ONLY` are **not** the client-side viewer primitive. Upstream `read_only` means "the holder of this state will not apply incoming changes but will still send its own" (publish-only semantics; see `rust/automerge/src/sync.rs:408` and `rust/automerge/src/sync/state.rs:65-67`). A viewer client that uses `State::new_read_only()` will not apply live room updates. Hosted room hosts may still use `State::new_read_only()` for their per-viewer peer state as an optimization and protocol hint: the host will not apply that peer's changes while still sending room changes to the peer. That is not the authorization boundary; the server must still reject any viewer `Message.changes` explicitly.
 - `editor` - live edit on `NotebookDoc` within the room host's document-write policy, plus write access to `CommsDoc` for mutable widget comm state. RuntimeStateDoc comm topology remains the membership authority for kernel forwarding. Editor `RuntimeStateDoc` writes are rejected. Editors cannot create executions, manipulate queue/kernel/environment state, rewrite output routing, create/remove comm topology, or add hidden RuntimeStateDoc root keys.
 - `runtime_peer` - permitted to write `RuntimeStateDoc` execution progress, output, lifecycle, and comm topology state for already accepted executions. It cannot create execution intent or edit `NotebookDoc`. Used by future remote-runtime services and by JupyterHub-spawned runtime sidecars/services when they connect a kernel. The hosted Worker prototype exercises this as direct `0x05` sync from a runtime authoring handle; it still does not host kernels inside the Durable Object.
@@ -396,7 +396,7 @@ may render.
 Scope is enforced server-side at three points in the target architecture, each
 with a clear boundary:
 
-1. **Frame ingress** (in `peer_notebook_sync.rs::handle_notebook_doc_frame`, `peer_runtime_sync.rs`, `peer_comms_sync.rs`, and the hosted WASM room host): the validator consults `AuthenticatedConnection.scope` and rejects frames that exceed the scope: viewer with non-empty changes on any doc, `runtime_peer` sending changes to `NotebookDoc`, editor/owner `RuntimeStateDoc` changes, or unauthorized `CommsDoc` changes. The hosted Worker and daemon share the same RuntimeStateDoc policy helper so this is no longer a hosted-only TODO.
+1. **Frame ingress** (in `peer_notebook_sync.rs::handle_notebook_doc_frame`, `peer_runtime_sync.rs`, `peer_comms_sync.rs`, `peer_comments_sync.rs`, and the hosted WASM room host): the validator consults `AuthenticatedConnection.scope` and rejects frames that exceed the scope: viewer with non-empty changes on any doc, `runtime_peer` sending changes to `NotebookDoc`, editor/owner `RuntimeStateDoc` changes, unauthorized `CommsDoc` changes, or `CommentsDoc` changes from scopes without comment authority. The hosted Worker and daemon share the same RuntimeStateDoc policy helper so this is no longer a hosted-only TODO.
 2. **Request dispatch**: each `NotebookRequest` variant declares its minimum required scope via an annotation or registry lookup. The request handler rejects with a typed `Unauthorized` response before any side effect. New scope-gated requests declare their requirement at the definition site; no scattered `if scope == ...` checks elsewhere.
 3. **ACL mutations** are owner-only. The hosted Worker prototype exposes owner-only HTTP ACL management for individual D1 rows. No in-band Automerge ACL change is honored from a non-owner connection.
 
@@ -435,8 +435,8 @@ actor labels, including any `local:*` actors from a desktop source.
 
 Concretely: `crates/runt-publish/src/lib.rs` uploads
 `source_snapshot.snapshot.notebook_bytes` and
-`source_snapshot.snapshot.runtime_bytes` as raw Automerge save payloads
-(`:297`, `:303`), and `apps/notebook-cloud/src/index.ts` stores the uploaded
+`source_snapshot.snapshot.runtime_state_bytes` as raw Automerge save payloads
+(`:297`, `:250`), and `apps/notebook-cloud/src/index.ts` stores the uploaded
 body in R2 (`:3041`) before creating a catalog revision row (`:3054-3101`).
 
 **Target:** The target decision remains fresh-document re-authoring at the

--- a/docs/adr/identity-and-trust.md
+++ b/docs/adr/identity-and-trust.md
@@ -424,25 +424,58 @@ authority and still enforces scope at frame ingress, request dispatch, and ACL
 mutation boundaries. A `viewer` connection remains a full sync, presence, and
 projection peer; only its changes and mutating requests are denied.
 
-## Decision 6: Publish is a fresh document in the destination space
+## Decision 6: Publish preserves source actor history; re-authoring is planned
 
-A publish operation produces a **fresh Automerge document** in the destination's identity space. Historical actor labels from the source space are not carried across the boundary.
+**Current:** Publish uploads the saved source Automerge document bytes
+directly. Historical actor labels from the source space are preserved in the
+destination room. The destination records who published the snapshot (via ACL
+enforcement and catalog metadata), but the ingested `NotebookDoc` and
+`RuntimeStateDoc` carry the source document's full Automerge change history and
+actor labels, including any `local:*` actors from a desktop source.
 
-The reason is the same one that makes git commits with arbitrary `Author:` lines untrustworthy without GPG: actor labels in Automerge are self-attested. If we copied `local:quill/desktop:abc` historical changes into an Anaconda-hosted room, the room would be vouching for authorship it has no way to verify. Anyone could fabricate a doc claiming any local-space attribution and publish it. Better to make the publish boundary explicit: history-of-edits stops at the boundary, and the destination space records who *published* the snapshot, not who authored each historical edit.
+Concretely: `crates/runt-publish/src/lib.rs` uploads
+`source_snapshot.snapshot.notebook_bytes` and
+`source_snapshot.snapshot.runtime_bytes` as raw Automerge save payloads
+(`:297`, `:303`), and `apps/notebook-cloud/src/index.ts` stores the uploaded
+body in R2 (`:3041`) before creating a catalog revision row (`:3054-3101`).
 
-Concretely: quill publishes a local untitled notebook to Anaconda.
+**Target:** The target decision remains fresh-document re-authoring at the
+publish boundary. Actor labels in Automerge are self-attested; if we accept
+`local:quill/desktop:abc` historical changes into an Anaconda-hosted room, the
+room vouches for authorship it cannot verify. Anyone can fabricate a local doc
+claiming any attribution and publish it. The publish boundary should be
+explicit: history-of-edits stops at the boundary, and the destination records
+who *published* the snapshot, not who authored each historical edit.
 
-1. Desktop captures the current rendered state of the local `NotebookDoc` and `RuntimeStateDoc`: cells, metadata, outputs, blob references. This is essentially the `.ipynb`-equivalent plus output blobs.
-2. The destination creates a **new** Automerge document in its own identity space. The current canonical schema seed actor establishes the schema; a fresh publisher actor (`user:anaconda:550e.../publisher:<timestamp>`) authors all the imported cells, metadata, and outputs as a single round of changes. Future schema bumps should move the seed actor toward the `system/schema:*` target naming above.
-3. Blob references are uploaded by SHA-256 hash. R2 dedupes; the destination room references them by the same hashes.
-4. The destination registers the room in its catalog (D1 row, latest revision pointer).
-5. Future edits in the destination room author under destination-space principals normally. There are no `local:*` actors in the doc.
+The target publish flow:
 
-Attribution after publish reflects what the destination can actually vouch for: "this snapshot was published by `user:anaconda:550e...` on `<timestamp>`." Per-edit history of the source notebook is not preserved. Side effects:
+1. Desktop captures the current rendered state of `NotebookDoc` and
+   `RuntimeStateDoc`: cells, metadata, outputs, blob references (the
+   `.ipynb`-equivalent plus output blobs).
+2. The destination creates a **new** Automerge document in its own identity
+   space. A fresh publisher actor (`user:anaconda:550e.../publisher:<timestamp>`)
+   authors all imported cells, metadata, and outputs as a single round of
+   changes. The schema seed actor establishes the schema; future schema bumps
+   should move the seed actor toward the `system/schema:*` target naming.
+3. Blob references are uploaded by SHA-256 hash (R2 dedupes); the destination
+   room references them by the same hashes.
+4. The destination registers the room in its catalog (D1 row, latest revision
+   pointer).
+5. Future edits in the destination room author under destination-space
+   principals normally. No `local:*` actors remain in the doc.
 
-- **Import-time forgery is closed.** A hosted deployment never accepts a *published* doc that contains historical Automerge attribution from outside its own scope; the import path strips source-space history and re-authors as a fresh publisher actor. Live in-room principal forgery is also rejected by the v1 clone-preview validator; the remaining caveat is its performance cost until the Automerge fork patch lands.
-- **History is lost on publish.** Anyone who needs the pre-publish authorship trail keeps the source notebook around (it still lives in the source space). Re-publishing produces a new snapshot in the destination; old snapshots are immutable revisions.
-- **Future cryptographic verification.** When Automerge gains signed-change support (keyhive direction; see `https://www.inkandswitch.com/keyhive/notebook/`), historical authorship from a source space could be carried across publish if every historical change is signed by its claimed author. Until then, this ADR closes the door on cross-space attribution.
+Attribution after re-authoring reflects what the destination can vouch for:
+"this snapshot was published by `user:anaconda:550e...` on `<timestamp>`."
+Per-edit history of the source notebook is not preserved in the destination
+room. When Automerge gains signed-change support (keyhive direction; see
+`https://www.inkandswitch.com/keyhive/notebook/`), historical authorship could
+be carried across publish if every change is signed by its claimed author.
+
+## Open Follow-ups
+
+- **Publish-time re-authoring:** Implement the fresh-document flow in
+  `runt-publish` before relying on cross-space attribution closure (see threat
+  table row).
 
 ## Limitations
 
@@ -455,7 +488,7 @@ The threat surface this leaves:
 | Unauthorized read | ACL check at connect | closed |
 | Unauthorized write at all | Bearer auth + ACL at connect | closed |
 | Scope escalation (viewer authoring, runtime_peer editing NotebookDoc) | Scope-based frame rejection | closed |
-| Import-time cross-IdP forgery (publishing a doc with historical foreign actor labels) | Publish-as-fresh-doc (Decision 6) | closed |
+| Import-time cross-IdP forgery (publishing a doc with historical foreign actor labels) | Publish-time re-authoring (Decision 6 target) | open — current publish preserves source actor history |
 | **Live actor-principal spoofing** (an authenticated peer authors a new change under a different principal) | Clone-preview actor validation before apply | closed in v1 |
 | Bearer-token replay (stolen JWT opens a new socket) | DPoP / mTLS / short token lifetimes | deferred |
 | Clone-preview validator cost on large/high-churn docs | `sync_message_new_changes` Automerge fork patch | deferred performance hardening |

--- a/docs/adr/local-first-notebook-state.md
+++ b/docs/adr/local-first-notebook-state.md
@@ -1,6 +1,6 @@
 # Local-First Notebook State
 
-**Status:** Accepted / implemented direction, 2026-06-11. Trimmed 2026-06-29.
+**Status:** Accepted, 2026-06-11. Trimmed 2026-06-29.
 
 This ADR records the local-first contract for cloud notebook handles. Historical
 PR sequencing and landed implementation notes belong in Git history, not in the

--- a/docs/adr/notebook-comments-document.md
+++ b/docs/adr/notebook-comments-document.md
@@ -1,7 +1,7 @@
 # Notebook Comments Document
 
-**Status:** Accepted / implementation in progress, 2026-06-07. Trimmed
-2026-06-29.
+**Status:** In progress, 2026-06-07. Core `CommentsDoc` structure landed;
+presence and UI surfaces remain open. Trimmed 2026-06-29.
 
 This ADR records the durable architecture for notebook comments. Historical
 phase plans and file-by-file implementation checklists were removed once the

--- a/docs/adr/notebook-identity-and-path-binding.md
+++ b/docs/adr/notebook-identity-and-path-binding.md
@@ -1,6 +1,7 @@
 # Notebook Identity and Path Binding
 
-**Status:** Proposed, 2026-06-24.
+**Status:** In progress, 2026-06-24. Persistent registry (NIP-1) and untitled
+recovery (NIP-2) landed. NIP-3 reconciliation design remains open.
 
 **Neighbors:**
 - `docs/adr/mcp-session-lifecycle.md` - Decision 8 keys file-backed rejoin on the path; this ADR is the why behind that key and where it must come from.

--- a/docs/adr/output-rendering-segmentation.md
+++ b/docs/adr/output-rendering-segmentation.md
@@ -1,6 +1,7 @@
 # Output Rendering Segmentation
 
-**Status:** Draft, 2026-05-26.
+**Status:** Accepted, 2026-05-26. Segmentation with six output lanes landed;
+Sift, Vega, and Plotly each use standalone frames.
 
 ## Context
 
@@ -39,22 +40,33 @@ Related docs:
 preserves the original output order, but it may render consecutive outputs in
 separate lane segments when their interaction contracts differ.
 
-The lanes are:
+The lanes (defined at `src/components/isolated/output-lane-policy.ts:22-28`):
 
-1. **Main DOM lane.** Outputs that are safe for the parent DOM: streams, classic
-   errors/rich tracebacks, plain text, raster images, JSON, audio, and video.
-   These render without an iframe.
-2. **Static isolated lane.** Document-like output that needs sandbox isolation
-   but should not capture page scroll by default, such as markdown, HTML, and
-   SVG. These frames use the existing scroll-passthrough / click-to-engage
+1. **Main DOM lane (`dom`).** Outputs that are safe for the parent DOM: streams,
+   classic errors/rich tracebacks, plain text, raster images, JSON, audio, and
+   video. These render without an iframe.
+2. **Static isolated lane (`static-frame`).** Document-like output that needs
+   sandbox isolation but should not capture page scroll by default, such as
+   markdown, HTML, and SVG. These frames use scroll-passthrough / click-to-engage
    behavior.
-3. **Interactive isolated lane.** Widgets, output widgets, charts, maps,
-   JavaScript, and unknown rich MIME outputs. These may need iframe-local
+3. **Interactive isolated lane (`interactive-frame`).** Widgets, output widgets,
+   maps, JavaScript, and unknown rich MIME outputs. These may need iframe-local
    pointer and wheel handling, and consecutive interactive outputs can share a
    frame.
-4. **Sift isolated lane.** Each Sift-capable DataFrame output gets its own
-   isolated frame. Sift remains click-to-engage so large tables do not trap
-   notebook page scrolling until the user deliberately focuses the table.
+4. **Sift isolated lane (`sift-frame`).** Each Sift-capable DataFrame output
+   gets its own isolated frame. Sift remains click-to-engage so large tables do
+   not trap notebook page scrolling until the user deliberately focuses the
+   table.
+5. **Vega isolated lane (`vega-frame`).** Vega/Vega-Lite chart outputs render in
+   standalone frames to own wheel/pan interactions without affecting surrounding
+   outputs. Each Vega output gets its own frame.
+6. **Plotly isolated lane (`plotly-frame`).** Plotly chart outputs render in
+   standalone frames for the same wheel/pan ownership reasons. Each Plotly
+   output gets its own frame.
+
+Lanes 4-6 are **standalone**: consecutive outputs in these lanes never coalesce
+into a shared frame, because their wheel/pan interactions must not extend over
+neighboring outputs (see `laneStandsAlone` at `output-lane-policy.ts:227-232`).
 
 For example, a cell that emits:
 

--- a/docs/adr/remote-workstation-doc-agents.md
+++ b/docs/adr/remote-workstation-doc-agents.md
@@ -1,7 +1,7 @@
 # Remote Workstation Doc Agents
 
-**Status:** Accepted / implementation in progress, 2026-06-04. Trimmed
-2026-06-29.
+**Status:** In progress, 2026-06-04. Core CRDT and validator paths landed;
+workstation UI and lifecycle surfaces remain open. Trimmed 2026-06-29.
 
 This ADR records the hosted workstation architecture. Earlier API sketches,
 prototype UI notes, and landed implementation ledgers were removed to keep the

--- a/docs/adr/runtime-principal-promotion.md
+++ b/docs/adr/runtime-principal-promotion.md
@@ -24,9 +24,9 @@ but that does not mean the browser becomes the runtime peer or that the runtime
 peer gains notebook-editing authority. Likewise, a local kernel should have a
 principal for attribution before it ever talks to the hosted room.
 
-## Decision 1: Local runtime connections have local principals
+## Decision 1: Local runtime connections have local principals (planned)
 
-A local-only kernel or daemon runtime uses a local principal and a runtime
+A local-only kernel or daemon runtime should use a local principal and a runtime
 operator even when no hosted credential exists:
 
 ```text
@@ -40,6 +40,10 @@ an Anaconda, OIDC, JupyterHub, or hosted account principal.
 Local runtime identity is useful for attribution, diagnostics, presence, and
 future UI, but it is not remote room authorization. A hosted room must not infer
 remote write authority from a local principal string.
+
+**Not yet implemented**: UDS runtime agents currently keep the daemon-supplied
+`runtime_agent_id` unchanged. Local principal naming format should be applied
+when local workstation promotion lands.
 
 ## Decision 2: Promotion adopts the remote room principal
 

--- a/docs/adr/runtime-state-document-identity.md
+++ b/docs/adr/runtime-state-document-identity.md
@@ -1,6 +1,7 @@
 # Runtime State Document Identity
 
-**Status:** Draft, 2026-05-29.
+**Status:** Accepted, 2026-05-29. Implemented: `NotebookDoc.runtime_state_doc_id`
+and `RuntimeStateDoc` self-identity landed with schema v5.
 
 ## Context
 

--- a/docs/adr/schema-evolution-and-genesis.md
+++ b/docs/adr/schema-evolution-and-genesis.md
@@ -1,6 +1,6 @@
 # Notebook Schema Evolution and the Frozen Genesis
 
-**Status:** Draft, 2026-05-30.
+**Status:** Accepted, 2026-05-30.
 
 ## Context
 

--- a/docs/adr/tokio-mutex-discipline.md
+++ b/docs/adr/tokio-mutex-discipline.md
@@ -1,6 +1,6 @@
 # Tokio Mutex Discipline and the Concurrency-Invariant Family
 
-**Status:** Draft, 2026-05-22.
+**Status:** Accepted, 2026-05-22.
 
 ## Context
 

--- a/docs/adr/typed-frame-v4-wire-protocol.md
+++ b/docs/adr/typed-frame-v4-wire-protocol.md
@@ -62,7 +62,7 @@ Both surfaces share the same 100 MiB outer ceiling (`MAX_FRAME_SIZE`) and the sa
 
 The fact that the same protocol-version preamble gates two different framing rules is intentional: pool/settings predate the typed-frame layer and were not worth migrating. New channels should adopt typed framing.
 
-## Decision 3: Ten frame types, fixed numbering
+## Decision 3: Eleven frame types, fixed numbering
 
 `NotebookFrameType` is a `#[repr(u8)]` enum. Adding a new type requires a new byte, a new variant, and a CI-enforced contract test (`cargo test -p notebook-protocol`). The current set:
 
@@ -78,6 +78,7 @@ The fact that the same protocol-version preamble gates two different framing rul
 | `0x07` | `SessionControl` | JSON, `SessionControlMessage` | daemon → client |
 | `0x08` | `PutBlob` | Framed binary (see Decision 6) | client → daemon |
 | `0x09` | `CommsDocSync` | Binary, raw `automerge::sync::Message` bytes (`CommsDoc`) | bidirectional |
+| `0x0a` | `CommentsDocSync` | Binary, raw `automerge::sync::Message` bytes (`CommentsDoc`) | bidirectional |
 
 ### Direction is policy, not encoding
 
@@ -89,7 +90,15 @@ Direction is enforced by the room peer loop and by the relay, not by anything in
 
 ### Forward-compatibility behavior
 
-Unknown frame types are logged and skipped by `recv_typed_frame`. The loop continues. This makes the format additively forward-compatible at the receive path: a v5 daemon can send a v4-unknown frame type and a v4 client will skip it. The opposite direction (v4 daemon receiving v5 frame from a newer client) is closed off by the handshake preamble check, which fails before any frame is sent. The forward-compat path is therefore daemon-to-client only.
+Unknown frame types are classified before allocation and skipped with a bounded
+discard read (`recv_typed_frame` at
+`crates/notebook-protocol/src/connection/framing.rs:170-183`, bounded discard
+buffer at `:229-241`). The peer loop continues without allocating the unknown
+frame body. This makes the format additively forward-compatible at the receive
+path: a v5 daemon can send a v4-unknown frame type and a v4 client will skip it
+safely. The opposite direction (v4 daemon receiving v5 frame from a newer
+client) is closed off by the handshake preamble check, which fails before any
+frame is sent. The forward-compat path is therefore daemon-to-client only.
 
 ## Decision 4: Per-type size limits trade safety for headroom
 
@@ -104,6 +113,7 @@ Every frame type has a hard cap (reject) and a soft warn threshold (log, continu
 | `Presence` | 4 KiB | 1 KiB | Cursor/selection/focus updates (typically <100 bytes CBOR); matches semantic cap in `notebook-doc::presence` |
 | `RuntimeStateSync` | 64 MiB | 16 MiB | Snapshots of `RuntimeStateDoc` with output manifests |
 | `CommsDocSync` | 64 MiB | 16 MiB | Mutable widget comm state snapshots and sync deltas |
+| `CommentsDocSync` | 64 MiB | 16 MiB | Notebook comments with inline text and resolved thread state |
 | `PoolStateSync` | 1 MiB | 256 KiB | Daemon pool state is small (counts, errors, env paths) |
 | `SessionControl` | 1 MiB | 256 KiB | Tiny readiness JSON |
 | `PutBlob` | 32 MiB | 8 MiB | Single-frame blob upload ceiling |
@@ -113,13 +123,23 @@ The caps and warns are defined in `notebook_wire::frame_size_limits` and generat
 Two tests cover the generated surface:
 
 - `crates/notebook-protocol/src/typescript.rs::generated_typescript_bindings_are_current` asserts generated TS files, including `wire-constants.ts`, are current.
-- `crates/notebook-protocol/src/connection.rs::frame_size_limits_cover_every_known_frame_type` asserts every known Rust type has a tighter cap than the 100 MiB outer ceiling and that warn is strictly less than cap.
+- `crates/notebook-protocol/src/connection.rs::frame_size_limits_cover_every_known_frame_type` enumerates frame types and asserts each has a tighter cap than the 100 MiB outer ceiling and that warn is strictly less than cap. The exhaustive match on `typed_frame_size_limits` is the primary guard; the test's list may lag new frame types until the next protocol pass updates it.
 
 ### Why the cap-first protocol matters
 
-`recv_typed_frame` reads the 4-byte length prefix, then the 1-byte type byte, then looks up the per-type cap and applies it **before allocating the body buffer** (`crates/notebook-protocol/src/connection/framing.rs:144-178`). A garbage length prefix aimed at the `Presence` channel (which legitimately carries ~100 bytes) is rejected after 5 bytes of header read, before the body allocation. Without per-type caps, a 1.8 GB length on a narrow channel would still allocate up to the 100 MiB outer ceiling before failing. The cap structure is an allocator safety boundary, not just a sanity check.
+`recv_typed_frame` reads the 4-byte length prefix, then the 1-byte type byte,
+classifies the frame type, then looks up the per-type cap and applies it
+**before allocating the body buffer**
+(`crates/notebook-protocol/src/connection/framing.rs:144-178`). A garbage
+length prefix aimed at the `Presence` channel (which legitimately carries ~100
+bytes) is rejected after 5 bytes of header read, before the body allocation.
+Without per-type caps, a 1.8 GB length on a narrow channel would still allocate
+up to the 100 MiB outer ceiling before failing. The cap structure is an
+allocator safety boundary, not just a sanity check.
 
-There is one cost to forward-compat: for **unknown** frame types the per-type lookup falls back to the 100 MiB outer ceiling (`crates/notebook-wire/src/lib.rs:97-101`). The body is allocated and read into memory *before* `try_from` rejects the unknown discriminant and the frame is skipped (`framing.rs:204-222`). So a v4 daemon receiving forward-compat unknown bytes from a v5 peer can allocate up to 100 MiB per frame before skipping. Future-proof is not free.
+Unknown frame types are classified before allocation and discarded with a
+bounded discard-read loop (`:229-241`), so forward-compat unknown frames do not
+trigger large allocations before being skipped.
 
 ### Outbound caps mirror inbound
 
@@ -183,14 +203,28 @@ The first frame after the preamble is a JSON `Handshake`, length-prefixed but **
 |---------|---------|------------------------|
 | `Pool` | Pool IPC | Untyped JSON request/response |
 | `SettingsSync` | Global settings doc | Untyped binary Automerge sync |
-| `NotebookSync` | Per-notebook room | Typed frames (0x00 through 0x08) |
+| `NotebookSync` | Per-notebook room | Typed frames (0x00 through 0x0a) |
 | `OpenNotebook` | Per-notebook room from file path | Typed frames |
 | `CreateNotebook` | New untitled room | Typed frames |
+| `OpenHostedNotebook` | Daemon-mediated hosted cloud room bridge | Typed frames |
 | `RuntimeAgent` | Kernel sidecar attached to a room | Typed frames, different request/response payloads |
 
-For typed-frame channels, after the handshake the daemon writes a `ProtocolCapabilities` JSON frame (or `NotebookConnectionInfo` for `OpenNotebook`/`CreateNotebook`) **using the untyped framing** — this is still pre-typed-frame setup. Once that response is read, both sides switch to typed framing for the rest of the connection's life.
+For typed-frame channels, the handshake can request typed bootstrap
+(`typed_bootstrap` flags at
+`crates/notebook-protocol/src/connection/handshake.rs:27-30`, `:53-56`,
+`:73-76`, `:129-132`). When `typed_capabilities` is true
+(`peer_connection.rs:280-287`), the daemon sends `ConnectionBootstrap` as a
+`NotebookFrameType::SessionControl` typed frame instead of untyped JSON. Legacy
+clients omit the flag and receive `NotebookConnectionInfo` /
+`ProtocolCapabilities` using untyped framing before typed frames begin. Once
+the bootstrap is read (typed or untyped), both sides use typed framing for the
+rest of the connection's life.
 
-This split (typed framing only kicks in after capability negotiation) is the reason the handshake JSON itself does not carry a type byte. Conventionally, a client waits for the capability response before sending typed frames, but the server does not enforce this: the post-handshake frame loop starts immediately after `ProtocolCapabilities` is written (`crates/runtimed/src/notebook_sync_server/peer_connection.rs:241`, `peer_loop.rs:161`), so a client that sends typed frames early will have them processed without rejection. The capability response is informational, not gating.
+Conventionally, a client waits for the bootstrap before sending typed frames,
+but the server does not enforce this: the post-handshake frame loop starts
+immediately after the bootstrap is written (`peer_connection.rs:241`,
+`peer_loop.rs:161`), so a client that sends typed frames early will have them
+processed without rejection. The bootstrap is informational, not gating.
 
 ## Decision 8: Session control is daemon-originated readiness, not a request channel
 

--- a/docs/audits/documentation-and-issue-consistency-audit.md
+++ b/docs/audits/documentation-and-issue-consistency-audit.md
@@ -1,0 +1,342 @@
+# Documentation and Issue Consistency Audit
+
+Status: Audit
+Date: 2026-07-02
+
+Source-backed sweep of the full documentation surface — 36 ADRs, 13 memos,
+plans, PRDs, prior audits, measurements, runbooks, the docs front door,
+12 nested `AGENTS.md` files, `CLAUDE.md` + 10 `.claude/rules`, 9 repo skills,
+24 Elements docs, top-level repo docs, `apps/notebook-cloud/README.md`,
+`.context/plans`, and all 22 open GitHub issues — cross-referenced against the
+code and git history. 153 artifacts were classified; 101 findings survived
+independent adversarial verification (13 high, 56 medium, 32 low). Findings
+whose evidence did not reproduce were dropped.
+
+Headline: the architecture docs are structurally healthy (64 artifacts fully
+current), but a June burst of landed work — CommentsDoc sync, daemon-mediated
+hosted rooms (#3884), the hosted artifact/dashboard wave, release signing —
+outran the documentation layer. Most fixes are mechanical doc updates; two
+findings need a real decision because an Accepted/spec'd behavior and the
+shipped code disagree.
+
+## Decisions Needed (code vs. accepted docs)
+
+### 1. Publish does not re-author into the destination identity space
+
+`docs/adr/identity-and-trust.md` Decision 6 (Accepted) says a publish produces
+a **fresh** Automerge document in the destination identity space with source
+actor history stripped, and the threat table marks import-time cross-IdP
+forgery "closed" on that basis. The shipped path contradicts it:
+`crates/runt-publish/src/lib.rs` saves and uploads the source document bytes
+directly (`save_snapshot_pair` → upload of
+`source_snapshot.snapshot.notebook_bytes`), and the Worker stores the uploaded
+body as-is before recording the revision (`apps/notebook-cloud/src/index.ts`,
+snapshot PUT path). Either implement publish-time re-authoring, or amend
+Decision 6 and the threat table to state that publish currently preserves
+source actor history. Until then an Accepted security invariant is
+aspirational, not descriptive.
+
+### 2. Invite flow never issues immediate ACL grants
+
+`docs/prd/hosted-sharing-invites.md` specifies that inviting an existing
+verified profile grants ACL access immediately (PRD steps around lines
+140–157). The shipped route always creates or returns a `pending` invite row.
+Decide whether immediate grants are still a product requirement; implement
+profile lookup + ACL insert in `POST /invites` if yes, or update the PRD if no.
+
+Also in this category, smaller: the typed-frame v4 ADR claims its frame-size
+contract test covers every known Rust frame type; that claim is now
+overstated and either the test or the claim should be extended.
+
+## Systemic Thread A: CommentsDocSync (0x0a) never propagated to protocol docs
+
+The `CommentsDocSync` typed frame landed in
+`crates/notebook-wire/src` (frame type `0x0a`), with daemon and cloud sync
+plumbing, but every protocol description still stops at `0x09`:
+
+- `crates/notebook-wire/AGENTS.md` — typed-frame table, traffic classes,
+  sender/receiver validity.
+- `crates/notebook-sync/AGENTS.md` — frame-boundary summary.
+- `.claude/rules/protocol.md` — auto-loaded wire protocol table.
+- `docs/adr/typed-frame-v4-wire-protocol.md` — "ten frame types" claim, frame
+  table, caps, examples. Same ADR also still describes post-handshake
+  capabilities as untyped-only despite typed `SessionControl` bootstrap.
+- `docs/adr/document-split.md` — still labels CommentsDoc "proposed"; also has
+  an incorrect PoolDoc fan-out worked example.
+- `apps/notebook-cloud/AGENTS.md` — CommentsDoc listed as proposed though room
+  CommentsDoc sync is implemented.
+- `crates/runtimed/AGENTS.md` — scope omits daemon-side CommentsDoc
+  persistence/sync.
+- `.agents/skills/automerge-sync/SKILL.md` — stream table documents CommentsDoc
+  as not implemented.
+- `apps/notebook-cloud/README.md` — checkpoint recovery section omits
+  CommentsDoc although the code checkpoints it.
+
+These files auto-load into agent sessions, so the drift actively misleads
+future work. One batched PR should fix all nine surfaces together.
+
+## Systemic Thread B: implemented Drafts should graduate
+
+Per `docs/adr/README.md`, `Accepted` marks decisions ready to guide review.
+These are implemented and load-bearing but still say Draft/Proposed:
+
+- `docs/adr/execution-pipeline.md` → Accepted (refresh stale line refs).
+- `docs/adr/tokio-mutex-discipline.md` → Accepted (CI-enforced today).
+- `docs/adr/runtime-state-document-identity.md` → Accepted; keep open
+  questions as follow-ups.
+- `docs/adr/schema-evolution-and-genesis.md` → Accepted; frozen-genesis and
+  max-reader rules are enforced in code.
+- `docs/adr/notebook-identity-and-path-binding.md` → Accepted/partial: NIP-1
+  and NIP-2 landed (e.g. untitled recovery, #3818); NIP-3 remains design.
+- `docs/adr/README.md` itself: three ADRs use compound statuses
+  ("Accepted / implementation in progress") outside the defined vocabulary —
+  either extend the vocabulary or normalize the status lines.
+
+Memos describing landed work should convert to implementation records or
+graduate:
+
+- `docs/memos/desktop-cloud-daemon-bridge.md` — V1 landed in #3884; graduate
+  the decided architecture toward an ADR, keep remaining #3861 slices explicit.
+- `docs/memos/arrow-manifest-durable-storage-design.md` — save/load and
+  active-room GC landed; only the closed-room asset-index gap is still open.
+- `docs/memos/markdown-node-identity-reconciler.md` — engine + tests landed
+  (#3862); also predates island/inline-JSX identity fields (#3878).
+- `docs/memos/compute-session-index.md` — OwnerComputeIndex shipped with a
+  narrower shape than the memo sketches.
+- `docs/memos/panel-runtime-state.md` — stale as a plan: #3750 was fixed by
+  renderer/output-lane work (`5171ccb1`), not this architecture; typed Panel
+  channel work exists only on feature branches. Archive or reframe as a
+  follow-up proposal.
+
+## Systemic Thread C: hosted/cloud docs lag the June burst
+
+- `apps/notebook-cloud/README.md` (913 lines) — live-room auth still describes
+  short-lived sync tickets instead of app-session cookies; snapshot curl
+  examples omit the required runtime-state doc id header; storage section
+  predates list-scale presence R2/D1 usage (#3890); ACL section misses the
+  sharing/invite/access-request layer; "prototype" framing is now too broad.
+- `docs/adr/hosted-notebook-artifacts.md` — missing comments snapshots, cover
+  metadata, cell composition/language (#3886), pinned OG-image behavior
+  (#3888/#3889).
+- `docs/adr/cloud-connected-local-mcp.md` — does not reconcile the
+  daemon-mediated hosted room bridge (#3884).
+- `docs/adr/deployment-topology.md` — browser credential path still says OIDC
+  bearer tokens over WebSocket subprotocols; first-party sessions use cookies.
+- `docs/adr/hosted-room-authorization.md` — prototype-era framing; the Durable
+  Object room host is materialized.
+- `apps/elements/content/docs/cloud-dashboard.mdx` — still documents the
+  pre-redesign search-first dashboard; the shipped `/n` model (#3883, #3885,
+  #3892), covers/OG images, presence/identity contract, and loading resilience
+  are absent.
+
+## Systemic Thread D: release and operational docs are wrong in load-bearing ways
+
+- `RELEASING.md` — says Windows builds are not code signed; the workflow now
+  has Windows signing tooling and Azure credentials. Artifact table omits
+  macOS x64 DMG, updater bundles/signatures, Linux-only standalone
+  daemon/MCP binaries, and `latest.json`. Unpublished-crate list incomplete.
+- `.agents/skills/releasing/SKILL.md` — bump procedure omits the canonical
+  `cargo xtask bump` flow, under-lists versioned files, and its stable tag
+  example conflicts with `RELEASING.md`.
+- `docs/runbooks/remote-workstation.md` — wakeup channel documented as SSE
+  with `Last-Event-ID`; the implementation is a hibernatable WebSocket event
+  socket plus polling fallback.
+- `docs/runbooks/macos-setup.md` — claims `cargo xtask dev` builds Python
+  bindings via `maturin develop`; bindings are no longer in the default path.
+- `docs/runbooks/hosted-direct-oidc-demo-runbook.md` — expected `/api/health`
+  JSON includes fields the worker intentionally does not expose.
+
+## Agent-guidance corrections (auto-loaded surfaces)
+
+- `CLAUDE.md` — nteract-dev summary says "up/down… plus 26 proxied notebook
+  tools" unconditionally; attach mode hides the lifecycle verbs and the
+  advertised proxied list is 19 tools.
+- `.claude/rules/mcp-servers.md` — same attach-mode caveat missing.
+- `.claude/rules/logging.md` — says dev uses `attachConsole`; code uses
+  `attachLogger` (attachConsole removed to avoid feedback loops).
+- `AGENTS.md` (root) — intro says two root invariants; four are listed.
+- `crates/kernel-env/AGENTS.md` — Deno bootstrap source stale.
+- `src/components/isolated/AGENTS.md` — omits Bokeh/Panel renderer plugins,
+  points at an old MIME map.
+- `src/components/ui/AGENTS.md` — shadcn primitive inventory stale.
+- `.agents/skills/daemon-dev/SKILL.md` — wrong crates in the single Rust
+  compilation step; calls hidden read tools "advertised".
+- `.agents/skills/mcp-session-lifecycle/SKILL.md` — rejoin guidance still
+  pre-checks `list_rooms`; current rejoin relies on daemon-authoritative
+  refusal.
+
+## Measurement docs
+
+- `docs/measurements/output-widget-replay-measurements.md` — describes the
+  pre-optimization full-list replay path as current; production uses a
+  per-comm replay cache. Reframe as baseline evidence.
+- `docs/measurements/output-commit-measurements.md` — intro predates
+  `output_committer` queueing for ordinary rich outputs.
+- `docs/measurements/runtime-output-optimization.md` — several plan items
+  written as future work have landed.
+
+## Issue triage (22 open)
+
+Close:
+
+- #3750 (Panel components not displayed) — fixed by Panel renderer + comm
+  bridge (`5171ccb1` and follow-ups); verify once, then close.
+- #3015 (Ventura crash, 2.5.1) — no repro/logs after maintainer request;
+  unactionable on current builds.
+- #1391 (generic Julia/R kernels) — fold into #3608, which carries the
+  actionable kernelspec/JupyterHub work.
+
+Update/re-scope (architecture moved underneath):
+
+- #3861, #3600, #3599 — refresh for the landed daemon-mediated bridge (#3884);
+  the signal source for link health is now `HostedBridgeHandle`, not
+  cloud runtime_agent only.
+- #3598 — #3595 chunked store dependency landed; pending-edit marker still open.
+- #2285 — silent-overwrite claims superseded by the staleness guard + atomic
+  write path (#3544); the remaining gap is cross-daemon owner lock/heartbeat.
+- #1969 — `.captured-ok` acceptance criteria superseded by the
+  captured-environment lifecycle ADR; launch-handshake retry remains.
+- #1968 — implementation sketch must move to daemon-owned lifecycle APIs, not
+  frontend cache deletion / `env_id` rewrites.
+- #1307 — split Python env-build sandboxing (landing) from runtime process
+  isolation (open); stale path reference in body.
+- #3381 — pairing credentials and Rust workstation service mode landed;
+  refresh checklist.
+- #681 — frontmatter syntax detection landed; UI/metadata sync remain.
+- #662 — proposed `nteract://` deep-link scheme now collides with the MCP
+  resource URI namespace; needs a different scheme.
+
+Still valid as written: #3887, #3665, #3608, #3601, #3593, #3538, #1334, #777.
+
+## Taxonomy moves
+
+- Delete (landed work retained in git history): `.context/plans/001…003` and
+  the `.context/plans/README.md` index; `.context/codex-reusable-odometer-pr.md`
+  (single-use PR handoff).
+- `DESIGN.md` — durable design-system spec at repo root; consider moving under
+  `docs/` or the Elements catalog (low priority).
+- Memo graduations per Thread B.
+- Gap for a future pass: define when a partially-landed memo graduates to an
+  ADR vs. updates in place; four memos hit this ambiguity.
+
+## Top-level docs
+
+- `README.md` / `CONTRIBUTING.md` — project-structure blocks omit current
+  top-level surfaces (`packages/`, current `python/` inventory);
+  `plugins/nteract` is an agent plugin distribution, not renderer plugins;
+  manual maturin command points at the wrong directory.
+- `python/README.md` — `python/nteract` is now a thin launcher for the Rust
+  MCP server, not a composition of runtimed primitives.
+- `DESIGN.md` — token inventory stale relative to shared semantic tokens
+  (`d30f7ce3` unified engine tokens).
+
+## Suggested execution batches
+
+1. **Protocol truth** (Thread A): one PR, nine files, CommentsDocSync + typed
+   bootstrap corrections.
+2. **Agent guidance**: CLAUDE.md, `.claude/rules`, nested AGENTS.md, skills
+   corrections listed above.
+3. **Status hygiene** (Thread B): ADR status graduations + ADR README
+   vocabulary + memo reframings. Mostly status-line and framing edits.
+4. **Hosted docs refresh** (Thread C): cloud README, hosted ADRs,
+   cloud-dashboard.mdx.
+5. **Release/ops truth** (Thread D): RELEASING.md, releasing skill, three
+   runbooks, top-level docs.
+6. **Issue gardening**: closes/updates per the triage list.
+7. **Decisions**: publish re-authoring (Decision 6) and invite immediate
+   grants — need an owner, not just a doc edit.
+
+## Appendix: non-current artifact verdicts
+
+Verdicts: `needs-update` (specific fixes identified), `in-flight` (accurate,
+work ongoing), `stale` (superseded/contradicted), `misfiled` (wrong home or
+status). Artifacts judged fully current (64) are omitted.
+
+- `docs/adr/document-split.md` — **needs-update**: Update current-room document count for landed CommentsDoc and fix the PoolDoc worked example.
+- `docs/adr/0001-notebook-seeding-invariant.md` — **needs-update**: Update the exact pristine predicate to include the daemon ephemeral room flag scaffold exception.
+- `docs/adr/runtime-state-document-identity.md` — **needs-update**: Change status from Draft to Accepted/implemented and keep open questions as follow-ups.
+- `docs/adr/schema-evolution-and-genesis.md` — **needs-update**: Change status from Draft to Accepted; the frozen-genesis and schema-version max-reader rules are implemented.
+- `docs/adr/notebook-identity-and-path-binding.md` — **needs-update**: Change status from Proposed to Accepted/partially implemented; NIP-1 and NIP-2 have landed while NIP-3 remains design.
+- `docs/adr/notebook-comments-document.md` — **in-flight**: Keep as in-flight; core CommentsDoc and hosted/local sync landed, while MCP tools, polish, and publish policy remain tracked in the rollout plan.
+- `docs/adr/execution-pipeline.md` — **misfiled**: Accurate and load-bearing; graduate Draft to Accepted after refreshing a few stale line references.
+- `docs/adr/typed-frame-v4-wire-protocol.md` — **needs-update**: Core framing story is right, but the frame table/bootstrap/forward-compat details lag current v4 code.
+- `docs/adr/blob-storage-and-content-addressing.md` — **needs-update**: Mostly current, but renderer-plugin serving paths are stale.
+- `docs/adr/output-rendering-segmentation.md` — **needs-update**: Decision is implemented, but code has split chart lanes beyond the four-lane text in the ADR.
+- `docs/adr/peer-egress-lanes.md` — **in-flight**: Accurately records the landed reliable/ephemeral split and remaining work.
+- `docs/adr/generated-runtime-artifacts.md` — **needs-update**: Artifact ownership model is right, but the volatile renderer bundle list omits panel.js.
+- `docs/adr/tokio-mutex-discipline.md` — **misfiled**: Accurate and CI-backed; graduate Draft to Accepted.
+- `docs/adr/identity-and-trust.md` — **needs-update**: Accepted trust model mostly matches, but Decision 6 publish-as-fresh is contradicted by the current snapshot publish path.
+- `docs/adr/hosted-room-authorization.md` — **needs-update**: Core authorization model matches, but prototype-only/status text should be updated for the materialized Durable Object room host.
+- `docs/adr/hosted-notebook-artifacts.md` — **needs-update**: Artifact model is mostly right but missing comments snapshots, cover metadata, cell composition, language, and pinned-OG behavior.
+- `docs/adr/deployment-topology.md` — **needs-update**: Topology is broadly useful, but browser credential transport is stale relative to app-session cookie auth.
+- `docs/adr/cloud-connected-local-mcp.md` — **needs-update**: Direct hosted MCP remains implemented, but the ADR needs to reconcile daemon-mediated hosted rooms from #3884.
+- `docs/adr/frontend-sync-bridge.md` — **needs-update**: Behavior is current and load-bearing, but several hard-coded line references are stale.
+- `docs/adr/remote-workstation-doc-agents.md` — **in-flight**: Accurately describes the partially landed workstation doc-agent architecture and remaining rollout surface.
+- `docs/adr/runtime-principal-promotion.md` — **in-flight**: Hosted promotion and authority split are current, but local runtime principal naming remains target architecture.
+- `docs/adr/captured-environment-lifecycle.md` — **needs-update**: Architecture is still right, but implementation notes should reflect that typed disk state and partial routing have landed.
+- `docs/memos/arrow-manifest-durable-storage-design.md` — **needs-update**: Save/load and active-room GC have landed; mark implemented sections as superseded/decided and keep only the closed-room output asset-index gap open.
+- `docs/memos/compute-session-index.md` — **needs-update**: Core OwnerComputeIndex slice landed with a narrower summary shape; update status, shipped contract, and remaining questions.
+- `docs/memos/desktop-cloud-daemon-bridge.md` — **in-flight**: V1 daemon-mediated hosted bridge landed in PR #3884; mark decided portions and leave remaining #3861 slices explicit.
+- `docs/memos/env-sandbox-policy-design.md` — **needs-update**: Still useful exploration, but it should clarify current sandbox enforcement gaps and link the runtime-agent work in issue #1307.
+- `docs/memos/execution-liveness.md` — **needs-update**: Design remains open, but exact code line references have drifted.
+- `docs/memos/markdown-node-identity-reconciler.md` — **needs-update**: Mark the memo as landed/implementation record and update it for island/inline-JSX identity fields added after the original design.
+- `docs/memos/markdown-plan-documents.md` — **needs-update**: Keep as the Markdown document surface RFC, but refresh OC-2/suggested spikes for the landed island projection work.
+- `docs/memos/panel-runtime-state.md` — **stale**: Archive or rewrite as a follow-up only if native typed Panel runtime state is still desired; the display issue was fixed through renderer/output-lane work instead.
+- `docs/memos/projection-source-rendered-correspondence.md` — **needs-update**: Keep the memo, but refresh the open questions/status for multiple-per-run highlights now that the deferred part landed.
+- `docs/memos/runtime-redaction-refresh-design.md` — **in-flight**: Keep as the active design for runtime-created redaction candidate refresh; launch-time matcher optimization and Python caching landed, daemon-local refresh has not.
+- `docs/plans/comments-rollout.md` — **needs-update**: Remove hosted room ingress from remaining work; keep MCP tools/resources, desktop polish, and publish policy as open.
+- `docs/prd/hosted-sharing-invites.md` — **needs-update**: Update to reflect the shipped pending-invite-only POST behavior, added unique indexes, and non-draft implementation state.
+- `docs/prd/notebook-identity-environment-surfaces.md` — **needs-update**: Update status from draft/prototype to implemented product contract with follow-ups delegated to the audit/ADR trail.
+- `docs/audits/runtime-peer-and-blob-authority-audit.md` — **needs-update**: Refresh blob metadata finding for hosted first-writer-wins and link the remaining Content-Type issue.
+- `docs/measurements/output-commit-measurements.md` — **needs-update**: Rewrite the intro as historical baseline/model evidence now that production uses the output committer.
+- `docs/measurements/output-widget-replay-measurements.md` — **stale**: Rewrite as pre-optimization baseline evidence; production now uses cached replay resolution.
+- `docs/measurements/runtime-output-optimization.md` — **needs-update**: Mark landed flat-path optimizations and leave only remaining work as active.
+- `docs/adr/README.md` — **needs-update**: The status vocabulary is clear, but the ADR register contains non-conforming status lines.
+- `docs/runbooks/macos-setup.md` — **needs-update**: Mostly current, but the first-build description still claims default dev builds Python bindings with maturin.
+- `docs/runbooks/remote-workstation.md` — **needs-update**: Commands and paths mostly match; workstation wakeup transport text is stale.
+- `docs/runbooks/hosted-direct-oidc-demo-runbook.md` — **needs-update**: Deployment variables match, but the expected health response shape is stale.
+- `.context/plans/README.md` — **misfiled**: All listed plans are DONE and should be archived/deleted or promoted out of .context.
+- `.context/plans/001-cap-snapshot-blob-ref-validation.md` — **misfiled**: Landed plan remains as an executor checklist in .context.
+- `.context/plans/002-preserve-actor-across-loads-and-rebuilds.md` — **misfiled**: Landed plan remains as an executor checklist in .context.
+- `.context/plans/003-share-outline-interaction-wiring.md` — **misfiled**: Landed plan remains as an executor checklist in .context.
+- `AGENTS.md` — **needs-update**: mostly accurate, but the load-bearing invariants intro says two invariants while four are listed
+- `apps/notebook-cloud/AGENTS.md` — **needs-update**: mostly accurate on cloud authority and worker/viewer split, but CommentsDoc is now implemented rather than proposed
+- `crates/kernel-env/AGENTS.md` — **needs-update**: mostly accurate, but Deno bootstrap provenance is stale
+- `crates/notebook-sync/AGENTS.md` — **needs-update**: mostly accurate, but omits CommentsDocSync handling added to the frame boundary
+- `crates/notebook-wire/AGENTS.md` — **needs-update**: core protocol model is right, but frame tables and lifecycle text omit CommentsDocSync and OpenHostedNotebook
+- `crates/runtimed/AGENTS.md` — **needs-update**: runtime guidance is broadly accurate but omits daemon-side CommentsDoc persistence/sync responsibilities
+- `src/components/isolated/AGENTS.md` — **needs-update**: security guidance is current, but renderer plugin inventory and plugin mapping instructions are stale
+- `src/components/ui/AGENTS.md` — **needs-update**: shared UI guidance is broadly useful but hard-coded structure/counts are stale
+- `CLAUDE.md` — **needs-update**: Update nteract-dev tool availability/count guidance for attach mode and current proxied tool surface.
+- `.claude/rules/logging.md` — **needs-update**: Replace stale attachConsole dev-mirror wording with attachLogger/original-console behavior.
+- `.claude/rules/mcp-servers.md` — **needs-update**: Clarify owner/isolated versus Codex attach-mode tool availability.
+- `.claude/rules/protocol.md` — **needs-update**: Update included wire-protocol table for CommentsDocSync frame 0x0a and valid senders.
+- `#3861` — **in-flight**: Update status for #3884: daemon-mediated hosted rooms and the bridge memo landed, with persistence/CommsDoc/local runtime/status still remaining.
+- `#3750` — **stale**: Close as fixed by Panel renderer and Panel widget comm bridge commits.
+- `#3600` — **needs-update**: Update for #3884: desktop-hosted room lifecycle is now mapped, but local-first persistence is still not wired.
+- `#3599` — **needs-update**: Update the implementation source from runtime-agent-only to the new HostedBridgeHandle/hosted bridge path for desktop-hosted rooms.
+- `#3598` — **needs-update**: Update dependency wording: #3595 chunked store/meta has landed; durable pending-local-edit marker remains open.
+- `#3381` — **in-flight**: hosted workstation registration, pairing, attach jobs, current-python runtime peer, and dispatch have landed; catalog projection, provider smokes, kernelspec/cwd selection, and final ticket hardening remain
+- `#3015` — **stale**: one-line Ventura crash report for 2.5.1 is no longer actionable without logs or a repro on current 2.6.2 builds
+- `#2285` — **needs-update**: silent overwrite and in-place write details were mitigated by #3544, but the owner lock/heartbeat cross-daemon coordination gap remains
+- `#1969` — **needs-update**: typed captured-env disk state and partial repair routing landed, and the ADR rejects .captured-ok for the first pass; launch-handshake retry still remains
+- `#1968` — **needs-update**: manual rebuild/refresh controls are still absent, but the implementation sketch must use daemon-owned lifecycle APIs rather than frontend cache deletion and env_id rewriting
+- `#1391` — **misfiled**: generic Julia/R kernels remain unsupported, but the actionable kernelspec/JupyterHub work is now captured in #3608
+- `#1307` — **needs-update**: runtime-agent spawning remains unsandboxed, but recent sandbox work is scoped to Python env builds and should be separated from runtime process isolation
+- `#681` — **needs-update**: raw-cell YAML/frontmatter detection exists; native Document Settings UI and metadata sync remain open
+- `#662` — **needs-update**: the content-fetch/deep-link idea remains plausible, but nteract:// is now the MCP resource namespace and is explicitly not a connect target
+- `apps/elements/content/docs/index.mdx` — **needs-update**: Catalog links resolve and recent dashboard/comment/output surfaces are represented, but the routing page does not surface the shipped shared-primitives/Sift native-look decision from #3872.
+- `apps/elements/content/docs/editor-surfaces.mdx` — **needs-update**: Mostly accurate, but one phrase implies a package boundary that does not exist.
+- `apps/elements/content/docs/compute-placement.mdx` — **in-flight**: Accurately describes the partially landed compute placement model: local desktop, cloud workstations, SSH/direct candidates, selected room target, and environment/runtime separation.
+- `apps/elements/content/docs/cloud-dashboard.mdx` — **needs-update**: The broad app-level dashboard intent is still right, but the artifact missed the shipped redesigned /n model, presence and identity contract, loading resilience, and cover/OG-image behavior.
+- `apps/elements/content/docs/cloud-notebook-shell.mdx` — **in-flight**: Accurately documents the shared cloud shell and still-provisional workstation/provider slots as an active convergence surface.
+- `.agents/skills/automerge-sync/SKILL.md` — **needs-update**: Mostly current, but CommentsDoc stream guidance is stale.
+- `.agents/skills/daemon-dev/SKILL.md` — **needs-update**: Core guidance is useful, but build phase and MCP tool-surface claims lag current xtask/runt-mcp code.
+- `.agents/skills/mcp-session-lifecycle/SKILL.md` — **needs-update**: Session model is mostly current, but ephemeral rejoin eviction checking changed.
+- `.agents/skills/releasing/SKILL.md` — **stale**: Release bump and tagging instructions conflict with RELEASING.md and xtask bump source.
+- `README.md` — **needs-update**: Mostly current positioning and xtask workflow, but the project structure block omits current top-level surfaces and Python packages.
+- `CONTRIBUTING.md` — **needs-update**: Build commands match the xtask surface, but project-structure and Python-binding manual instructions have drifted.
+- `DESIGN.md` — **needs-update**: Design intent remains useful, but the token spec is behind the unified semantic token implementation and the doc belongs under the durable docs/Elements taxonomy.
+- `RELEASING.md` — **needs-update**: Release streams are broadly right, but Windows signing, artifact inventory, and unpublished crate inventory are stale or incomplete.
+- `python/README.md` — **needs-update**: Workspace/package inventory is current, but the python/nteract package description no longer matches its launcher-only implementation.
+- `apps/notebook-cloud/README.md` — **needs-update**: Mostly load-bearing, but several sections lag shipped cloud auth, room-summary presence, sharing APIs, CommentsDoc handling, and snapshot command requirements; 'prototype' should be scoped to preview/dev-token deployment rather than the whole system.

--- a/docs/audits/documentation-and-issue-consistency-audit.md
+++ b/docs/audits/documentation-and-issue-consistency-audit.md
@@ -12,6 +12,13 @@ code and git history. 153 artifacts were classified; 101 findings survived
 independent adversarial verification (13 high, 56 medium, 32 low). Findings
 whose evidence did not reproduce were dropped.
 
+**Resolution status:** execution batches 1-5 below (protocol truth, agent
+guidance, status hygiene, hosted refresh, release/ops truth) were applied in
+the PR that introduced this audit, so the per-file findings they cover are
+fixed as of that PR and kept here as evidence. Still live: the two Decisions
+Needed below, batch 6 (issue gardening on the tracker), and any follow-ups
+recorded in the owning docs.
+
 Headline: the architecture docs are structurally healthy (64 artifacts fully
 current), but a June burst of landed work — CommentsDoc sync, daemon-mediated
 hosted rooms (#3884), the hosted artifact/dashboard wave, release signing —
@@ -86,7 +93,7 @@ These are implemented and load-bearing but still say Draft/Proposed:
   questions as follow-ups.
 - `docs/adr/schema-evolution-and-genesis.md` → Accepted; frozen-genesis and
   max-reader rules are enforced in code.
-- `docs/adr/notebook-identity-and-path-binding.md` → Accepted/partial: NIP-1
+- `docs/adr/notebook-identity-and-path-binding.md` → In progress: NIP-1
   and NIP-2 landed (e.g. untitled recovery, #3818); NIP-3 remains design.
 - `docs/adr/README.md` itself: three ADRs use compound statuses
   ("Accepted / implementation in progress") outside the defined vocabulary —
@@ -256,7 +263,7 @@ status). Artifacts judged fully current (64) are omitted.
 - `docs/adr/0001-notebook-seeding-invariant.md` — **needs-update**: Update the exact pristine predicate to include the daemon ephemeral room flag scaffold exception.
 - `docs/adr/runtime-state-document-identity.md` — **needs-update**: Change status from Draft to Accepted/implemented and keep open questions as follow-ups.
 - `docs/adr/schema-evolution-and-genesis.md` — **needs-update**: Change status from Draft to Accepted; the frozen-genesis and schema-version max-reader rules are implemented.
-- `docs/adr/notebook-identity-and-path-binding.md` — **needs-update**: Change status from Proposed to Accepted/partially implemented; NIP-1 and NIP-2 have landed while NIP-3 remains design.
+- `docs/adr/notebook-identity-and-path-binding.md` — **needs-update**: Change status from Proposed to In progress; NIP-1 and NIP-2 have landed while NIP-3 remains design.
 - `docs/adr/notebook-comments-document.md` — **in-flight**: Keep as in-flight; core CommentsDoc and hosted/local sync landed, while MCP tools, polish, and publish policy remain tracked in the rollout plan.
 - `docs/adr/execution-pipeline.md` — **misfiled**: Accurate and load-bearing; graduate Draft to Accepted after refreshing a few stale line references.
 - `docs/adr/typed-frame-v4-wire-protocol.md` — **needs-update**: Core framing story is right, but the frame table/bootstrap/forward-compat details lag current v4 code.

--- a/docs/audits/runtime-peer-and-blob-authority-audit.md
+++ b/docs/audits/runtime-peer-and-blob-authority-audit.md
@@ -162,11 +162,12 @@ document path that later references the content hash.
    only from notebook fields and mutable widget state in `CommsDoc`. Owner
    inherits both write surfaces.
 4. **Content metadata mutation is multi-user sensitive.** The desktop blob
-   store intentionally lets a duplicate put update `media_type`. In hosted or
-   remote-peer deployments, the host should prevent a lower-scope peer from
-   rewriting how an existing hash is served to other rooms/users. Either make
-   metadata first-writer-wins per backend object, or move media type to the
-   room/reference layer.
+   store intentionally lets a duplicate put update `media_type`. Hosted
+   duplicate PUT metadata is now first-writer-wins: blob PUT skips R2 rewrite
+   for existing objects (`index.ts:4716-4717`), and D1 recording uses
+   `ON CONFLICT(notebook_id, hash) DO NOTHING` (`storage.ts:1729`). The
+   remaining issue is that an arbitrary first-writer `Content-Type` is stored;
+   see #3887 for Content-Type allow-list or `nosniff` hardening.
 5. **Blob reads must be room-scoped in hosted deployments.** "Knows the hash"
    is not enough once blobs leave single-user loopback. The resolver should
    prove viewer-or-better access to the room or issue a short-lived signed URL

--- a/docs/measurements/output-commit-measurements.md
+++ b/docs/measurements/output-commit-measurements.md
@@ -1,22 +1,26 @@
 # Non-Stream Output Commit Measurements
 
-**Status:** Measurement, 2026-05-24. This is benchmark evidence for the runtime
-output optimization plan, not an ADR.
+**Status:** Historical baseline measurement, 2026-05-24. Documented synchronous
+commit cost before output_committer queue landed. Production now enqueues
+these outputs through `output_committer`
+(`crates/runtimed/src/output_committer.rs`).
 
-This measurement covers the remaining ordinary output path after the stream
-and `update_display_data` optimizations:
+This measurement covered the ordinary output path after stream and
+`update_display_data` optimizations:
 
 - `display_data`
 - `execute_result`
 - `error`
 
-These outputs still run manifest creation and `RuntimeStateDoc.append_output`
-on the IOPub reader task. For `display_data` and `execute_result`, the
-measurement also includes the current blob-ref buffer preflight call with an
-empty buffer list. The measurement compares that current synchronous shape
-against an ordered-worker model where the IOPub-facing work is only an ordered
-enqueue and the same preflight, manifest, and doc writes happen later on a
-worker.
+**Historical baseline:** These outputs ran manifest creation and
+`RuntimeStateDoc.append_output` on the IOPub reader task. The measurement
+compared that synchronous shape against an ordered-worker model.
+
+**Current path (post-optimization):** Production starts `output_committer`
+from IOPub setup (`crates/runtimed/src/jupyter_kernel.rs:1407-1424`).
+Ordinary outputs enqueue via `OutputCommitterHandle::enqueue_output`
+(`crates/runtimed/src/output_committer.rs:75-100`); worker-side batch append
+uses `sd.append_outputs` (`crates/runtimed/src/output_committer.rs:260-283`).
 
 ## Running
 

--- a/docs/measurements/output-widget-replay-measurements.md
+++ b/docs/measurements/output-widget-replay-measurements.md
@@ -1,23 +1,33 @@
 # Output Widget Replay Measurements
 
-**Status:** Measurement, 2026-05-24. This is benchmark evidence for the runtime
-output optimization plan, not an ADR.
+**Status:** Pre-optimization baseline, 2026-05-24. Recorded triangular
+resolution cost before the per-comm replay cache landed. Production now uses
+cached resolution (`crates/runtimed/src/jupyter_kernel.rs:347-387`).
 
-This note records the reproducible measurement surface for the current
-runtime-agent to IPython Output widget replay path. It is intentionally a
-measurement baseline, not an optimization.
+This note records the reproducible measurement surface for the Output widget
+replay path. It is a historical baseline documenting the optimization need,
+not current behavior.
 
-## What Is Measured
+## What Was Measured (Historical)
 
-When a Jupyter Output widget captures output, the IOPub task currently:
+When a Jupyter Output widget captured output, the IOPub task:
 
-1. appends one output manifest to `RuntimeStateDoc.comms[*].outputs`;
-2. mirrors the full outputs list into the comm state `outputs` property;
-3. resolves every manifest in that full list back to nbformat JSON;
-4. sends one best-effort `SendCommUpdate` replay to the kernel.
+1. appended one output manifest to `RuntimeStateDoc.comms[*].outputs`;
+2. mirrored the full outputs list into the comm state `outputs` property;
+3. resolved every manifest in that full list back to nbformat JSON;
+4. sent one best-effort `SendCommUpdate` replay to the kernel.
 
-The durable record remains `RuntimeStateDoc`. The kernel-facing replay is
-best-effort convenience for the Python-side Output widget object.
+This resulted in `N * (N + 1) / 2` manifest resolutions for `N` captured
+outputs. The durable record remains `RuntimeStateDoc`. The kernel-facing
+replay is best-effort convenience for the Python-side Output widget object.
+
+## Current Path (Post-optimization)
+
+Production now uses a per-comm replay cache
+(`crates/runtimed/src/jupyter_kernel.rs:1435-1438`).
+`resolve_output_widget_replay_state` resolves only the appended manifest when
+the cache length matches (`crates/runtimed/src/jupyter_kernel.rs:347-387`),
+linearizing the resolution cost.
 
 ## Rust Measurement
 
@@ -30,10 +40,11 @@ cargo run -p runtimed --example output_widget_replay_measure
 ```
 
 Each output line is JSON with a `strategy` and nested `metrics`. The key field
-is `metrics.manifest_resolutions`: with the current replay loop, `N` captured
-outputs resolve `N * (N + 1) / 2` manifests because every replay update
-resolves the full output list. The cached strategy resolves only the newly
-appended manifest when its local cache matches the durable output list.
+is `metrics.manifest_resolutions`: the historical "current" replay loop
+resolved `N * (N + 1) / 2` manifests for `N` captured outputs because every
+replay update resolved the full output list. The cached strategy (now in
+production) resolves only the newly appended manifest when its local cache
+matches the durable output list.
 
 Example shape:
 

--- a/docs/measurements/runtime-output-optimization.md
+++ b/docs/measurements/runtime-output-optimization.md
@@ -40,32 +40,35 @@ new consumer protocol.
 
 ## Decision 2: Optimize duplicated flat-path work first
 
-The first safe stack should keep the manifest shape unchanged while removing
-known repeated work:
+Keep the manifest shape unchanged while removing known repeated work:
 
-1. Exact output lookup by `(execution_id, output_id)` so display updates can use
-   `display_index` without sorting and scanning every output in the execution.
-2. Cached or indexed output ordering metadata so append/upsert paths do not
-   recompute order by decoding all manifests.
-3. Targeted RuntimeStateDoc readers for runtime-agent queue and comm handling
-   so state-sync bookkeeping does not materialize every flat output when it
-   only needs queued execution metadata or widget comm state.
-4. WASM-side output-id indexing so runtime sync handling does not repeatedly
-   read the full runtime state just to derive output deltas.
-5. Remove the dormant frontend optimistic `update_display_data` overlay instead
-   of indexing it. RuntimeStateDoc changesets already carry display updates to
-   the output store, so the best optimization is not maintaining unused work.
-6. In-place WASM output-id diff snapshots so runtime sync compares the flat
-   output set without cloning every unchanged manifest into a fresh snapshot on
-   each frame.
-7. Frontend output materialization cleanup so runtime outputs flow through the
-   output store rather than repeated whole-output JSON cache keys. Notebook-wide
-   derived views should subscribe to the narrowest output signal they need:
-   tail pinning still observes every output payload change, while hidden-group
-   membership and error counts observe only output adds/removals/type changes.
+1. ✅ **Done (a2bfef02).** Exact output lookup by `(execution_id, output_id)`
+   via `get_display_index_entries` and `get_output`
+   (`crates/runtimed/src/output_prep.rs:316-329`). Display updates no longer
+   sort and scan every output in the execution.
+2. **Open.** Cached or indexed output ordering metadata so append/upsert paths
+   do not recompute order by decoding all manifests.
+3. ✅ **Done (614ec946, 3c18ce8f).** Targeted RuntimeStateDoc readers for
+   runtime-agent queue and comm handling. Measured via `doc.get_comms()` and
+   `doc.get_queued_executions()`
+   (`crates/runtimed/src/output_commit_measure.rs:345-348`). State-sync
+   bookkeeping no longer materializes every flat output when it only needs
+   queued execution metadata or widget comm state.
+4. **Open.** WASM-side output-id indexing so runtime sync handling does not
+   repeatedly read the full runtime state just to derive output deltas.
+5. ✅ **Done (038caec2).** Removed the dormant frontend optimistic
+   `update_display_data` overlay. RuntimeStateDoc changesets carry display
+   updates to the output store.
+6. ✅ **Done.** In-place WASM output-id diff snapshots
+   (`crates/runtimed-wasm/src/lib.rs:2908-2910`). Runtime sync compares the
+   flat output set without cloning every unchanged manifest into a fresh
+   snapshot on each frame.
+7. **Partially done.** Frontend output materialization cleanup. Runtime outputs
+   flow through the output store; tail pinning and derived views remain active
+   work.
 
-Each item is independently mergeable and should include a small benchmark or
-stress case that proves the eliminated work.
+Each item should include a small benchmark or stress case proving the
+eliminated work.
 
 ## Decision 3: Segment storage needs projection before writing
 

--- a/docs/memos/arrow-manifest-durable-storage-design.md
+++ b/docs/memos/arrow-manifest-durable-storage-design.md
@@ -1,17 +1,17 @@
 # Arrow Manifest Durable Storage Design
 
-**Status:** Exploration.
+**Status:** Implemented, 2026-05-24 — save/load transforms, active-room GC,
+and characterization coverage landed; closed-room asset index remains open.
 
 ## Objective
 
 PR #2658 made Arrow stream manifests renderable and added complete multi-chunk
-automatic `pyarrow.Table` output for oversized tables. This follow-up defines
-and tests the saved-notebook durability contract for those manifests.
+automatic `pyarrow.Table` output for oversized tables. This memo defined and
+tested the saved-notebook durability contract for those manifests.
 
-The goal is not to build direct daemon upload, coalesced artifacts, or
-viewport-driven fetch. The goal is to make it unambiguous how an Arrow stream
-manifest survives save, close, blob GC, and reopen when the chunk bytes already
-exist in the daemon blob store.
+The implementation built save/load transforms and active-room GC but did not
+cover direct daemon upload, coalesced artifacts, or viewport-driven fetch.
+The closed-room output asset index remains an open gap.
 
 ## Current State
 
@@ -107,110 +107,87 @@ The runtime/render shape keeps `hash` as a string. The saved form is only for
 `.ipynb` JSON and only at the save/load boundary. Frontend and Sift renderer
 code should not need to handle the durable shape in normal live output state.
 
-## Save Transform
+## Save Transform (Implemented)
 
-`resolve_data_bundle()` should keep its existing single-blob behavior for
-direct Arrow IPC and parquet MIME entries. For
-`application/vnd.nteract.arrow-stream-manifest+json`, it should parse the
-manifest JSON and walk only the known manifest ref slots.
+`resolve_data_bundle()` keeps its existing single-blob behavior for direct
+Arrow IPC and parquet MIME entries. For
+`application/vnd.nteract.arrow-stream-manifest+json`, it parses the manifest
+JSON and walks known manifest ref slots
+(`crates/runtimed/src/output_store.rs:1351`).
 
-For each slot, save should:
+For each slot, save:
 
-1. Require a string `hash`.
-2. Determine the expected content type from the slot.
-3. Determine `size` from the slot when present, or from blob metadata if the
+1. Requires a string `hash`.
+2. Determines the expected content type from the slot.
+3. Determines `size` from the slot when present, or from blob metadata if the
    slot omits it.
-4. Verify the hash exists in the blob store before writing the durable ref.
-5. Replace the string hash with `{ blob, size, content_type }`.
+4. Verifies the hash exists in the blob store before writing the durable ref.
+5. Replaces the string hash with `{ blob, size, content_type }`.
 
-If a referenced blob is missing, save should not silently produce a durable
-manifest that looks complete. The smallest acceptable behavior for this first
-PR is to return an error from `resolve_manifest()` so the save call can surface
-the same class of "output could not be resolved" failure it already uses for
-missing blobs. A future UX pass can add a more specific user-facing diagnostic.
-
-The transform must preserve all non-ref manifest fields exactly: row counts,
+If a referenced blob is missing, save returns an error so the save call
+surfaces the same "output could not be resolved" failure it uses for missing
+blobs. The transform preserves all non-ref manifest fields: row counts,
 record-batch counts, summary, completion state, abort state, encoding, table
 hints, and unknown future fields.
 
-## Load Transform
+## Load Transform (Implemented)
 
-`convert_data_bundle()` should keep its existing top-level
+`convert_data_bundle()` keeps its existing top-level
 `application/vnd.nteract.blob-ref+json` handling. For
-`application/vnd.nteract.arrow-stream-manifest+json`, it should parse the JSON
-manifest and reverse only the known durable ref slots.
+`application/vnd.nteract.arrow-stream-manifest+json`, it parses the JSON
+manifest and reverses known durable ref slots
+(`crates/runtimed/src/output_store.rs:1201`).
 
-For each durable slot, load should:
+For each durable slot, load:
 
-1. Require `{ blob: string, size: number }`.
-2. Preserve or restore `content_type`.
-3. Check that the blob exists in the local blob store.
-4. Convert back to runtime shape with `hash: blob`, `size`, and
+1. Requires `{ blob: string, size: number }`.
+2. Preserves or restores `content_type`.
+3. Checks that the blob exists in the local blob store.
+4. Converts back to runtime shape with `hash: blob`, `size`, and
    `content_type`.
 
-If the blob is missing, load should keep the manifest structurally intact but
-mark the manifest as unusable rather than pretending the table is complete. For
-the test-focused PR, use the existing safe fallback behavior: drop only the
-manifest MIME from the loaded data bundle and preserve fallback siblings such
-as `text/plain` / `text/llm+plain`. A later renderer UX pass can replace that
-with a manifest-level diagnostic field. Silent fallback to a partial table is
-not acceptable.
+If the blob is missing, load keeps the manifest structurally intact but marks
+it unusable: drops only the manifest MIME from the loaded data bundle and
+preserves fallback siblings such as `text/plain` / `text/llm+plain`. A later
+renderer UX pass can add a manifest-level diagnostic field.
 
-## GC Contract
+## GC Contract (Active Rooms: Implemented)
 
-The awkward part is retention. It has two separate cases:
+Retention has two separate cases:
 
-1. **Active rooms.** RuntimeStateDoc outputs exist in memory. The GC walker can
-   inspect those output manifests, but Arrow manifest chunk hashes are nested
-   inside JSON payloads rather than top-level `ContentRef::Blob` fields.
-2. **Closed file-backed rooms.** RuntimeStateDoc outputs are not persisted into
-   `NotebookDoc`. Saved `.ipynb` files contain output JSON, but the current GC
-   walker scans active rooms, comm state, notebook-doc persisted `.automerge`
-   files, and execution records. It does not generally scan arbitrary saved
-   `.ipynb` files for output blob refs.
+1. **Active rooms (implemented).** RuntimeStateDoc outputs exist in memory. The
+   GC walker inspects those output manifests and collects Arrow manifest chunk
+   hashes nested inside JSON payloads (`crates/runtimed/src/daemon.rs:5157-5187`).
+   `arrow_manifest_blob_hash` extracts manifest blob hashes from outputs, then
+   `collect_arrow_manifest_blob_hashes` resolves each manifest and walks its
+   chunk/coalesced refs.
+
+2. **Closed file-backed rooms (open gap).** RuntimeStateDoc outputs are not
+   persisted into `NotebookDoc`. Saved `.ipynb` files contain output JSON, but
+   the GC walker scans active rooms, comm state, notebook-doc persisted
+   `.automerge` files, and execution records — not arbitrary saved `.ipynb`
+   files for output blob refs.
 
 The durable JSON shape helps because `{ blob, size, content_type }` is
-self-describing and can be collected recursively once it is inside a structure
-the daemon actually scans. It does not, by itself, make closed file-backed
-notebook outputs GC-safe forever.
+self-describing and can be collected recursively once inside a structure the
+daemon scans. Active-room GC is manifest-aware; closed-room GC needs a
+notebook-owned output asset index for stronger retention than the existing
+orphan grace period.
 
-The first implementation should therefore make two contracts explicit:
-
-- Active-room GC must be manifest-aware enough to collect live
-  `chunks[].hash` / `coalesced.*.hash` refs from selected Arrow manifest MIME
-  payloads. If the manifest JSON itself is blob-backed, the collector either
-  needs blob-store access to resolve it, or an already-derived asset list.
-- Closed-room GC needs a notebook-owned output asset index if we want stronger
-  retention than the existing orphan grace period. The index should be written
-  at save time from the resolved `.ipynb` outputs and stored in a document-owned
-  structure GC already scans, or in a new persisted sidecar with equivalent
-  retention semantics.
-
-The recommended long-term shape is a dedicated output asset index, not an
-overload of markdown `resolved_assets`. The index keys can be opaque but should
-be stable enough to replace on each successful save, for example:
+The recommended shape is a dedicated output asset index, not an overload of
+markdown `resolved_assets`. Index keys should be stable enough to replace on
+each successful save, for example:
 
 ```text
 outputs/<cell_id>/<output_id>/<mime>/<slot>
 ```
 
-The values are blob hashes. The index is for retention only; renderers should
-continue reading normal output manifests.
+Values are blob hashes. The index is for retention only; renderers continue
+reading normal output manifests.
 
-The focused tests should cover both paths without pretending the second path is
-already solved:
+## Test Coverage (Implemented)
 
-1. A runtime output manifest with a selected Arrow manifest MIME contributes
-   its nested chunk/coalesced blob refs to active-room GC collection.
-2. A characterization test documents that persisted NotebookDoc files do not
-   currently retain RuntimeStateDoc outputs after eviction. That test should
-   justify the output asset index rather than hiding the gap.
-3. A helper-level test proves recursive collection can find durable nested refs
-   once they are present in a scanned persisted structure.
-
-## Focused Tests
-
-Add tests before changing broad behavior:
+Tests added with the implementation:
 
 - `resolve_manifest` saves an Arrow stream manifest with two chunks using
   durable nested refs, not plain string hashes.
@@ -222,11 +199,12 @@ Add tests before changing broad behavior:
 - Missing chunk blob on load drops the Arrow manifest MIME and preserves
   fallback text siblings.
 - Recursive blob collection finds manifest `chunks` and `coalesced` refs in
-  both direct runtime shape and saved durable shape where applicable.
+  active rooms.
 - `schema.hash` stays a plain string fingerprint and is not treated as a blob
-  ref until schema bytes are actually stored.
-- A characterization test shows closed file-backed rooms need an output asset
-  index for GC-safe saved output blobs after RuntimeStateDoc outputs disappear.
+  ref.
+- A characterization test documents that closed file-backed rooms need an
+  output asset index for GC-safe saved output blobs after RuntimeStateDoc
+  outputs disappear.
 - Existing direct Arrow IPC/parquet blob-ref save/load tests keep passing.
 
 ## Non-Goals

--- a/docs/memos/automerge-fork-patches.md
+++ b/docs/memos/automerge-fork-patches.md
@@ -101,7 +101,7 @@ An upstream path-aware hook could still be useful as a lower-cost optimization o
 
 ### 4. (Speculative) Hooks for signed-change verification
 
-When keyhive's surface stabilizes, signed changes would let us verify cross-space authorship at publish import (lifting the "publish is a fresh document" restriction in the identity ADR). The shape of this depends entirely on what keyhive lands. Tracked as future-compat, not on the current fork roadmap.
+When keyhive's surface stabilizes, signed changes would let us verify cross-space authorship at publish import (the identity ADR's Decision 6 target is publish-time re-authoring; signed changes would let preserved history carry verified attribution instead). The shape of this depends entirely on what keyhive lands. Tracked as future-compat, not on the current fork roadmap.
 
 ## Coordination with upstream
 

--- a/docs/memos/compute-session-index.md
+++ b/docs/memos/compute-session-index.md
@@ -1,6 +1,7 @@
 # Compute Session Index
 
-**Status:** RFC, 2026-06-23.
+**Status:** Implemented with OwnerComputeIndex, 2026-06-28. Open work:
+workstation grouping, live dashboard push, richer management controls.
 
 ## Context
 
@@ -63,68 +64,54 @@ repair paths, and it should tolerate staleness.
    workstation pages. Avoid "attachment" in user-facing surfaces except where
    discussing implementation.
 
-## Proposed Model
+## Implemented Model
 
-Introduce a platform-neutral `ComputeSessionIndex` projection and an
-owner-scoped compute-session summary:
+A platform-neutral `ComputeSessionIndex` projection with an owner-scoped
+compute-session summary (`packages/runtimed/src/notebook-compute-session.ts:6-20`):
 
 ```ts
 interface NotebookComputeSessionSummary {
   notebook_id: string;
   owner_principal: string;
-  state:
-    | "none"
-    | "starting"
-    | "active"
-    | "busy"
-    | "queued"
-    | "stale"
-    | "error";
-  workstation_id: string | null;
-  workstation_display_name: string | null;
-  job_id: string | null;
+  status: "starting" | "active" | "stale" | "error";
+  workstation_id: string;
+  workstation_display_name: string;
   runtime_session_id: string | null;
   runtime_peer_count: number;
-  kernel_status: string | null;
-  activity: "busy" | "idle" | "unknown";
-  executing_cell_id: string | null;
-  queued_cell_count: number;
+  queue_depth: number;
+  environment_label: string | null;
+  working_directory: string | null;
   status_message: string | null;
   updated_at: string;
   last_runtime_seen_at: string | null;
-  stale_after: string | null;
 }
 ```
 
-Dashboard rows only need a subset: state, workstation label, kernel/running
-hint, and whether attention is needed. The larger shape is intentionally room
-and workstation-page friendly.
+The shipped shape differs from the original proposal: uses `status` instead of
+`state`, replaces `kernel_status` / `activity` / `executing_cell_id` /
+`queued_cell_count` with `queue_depth`, and adds `environment_label` /
+`working_directory`. Dashboard rows project a compact fact from this summary.
 
-### State Derivation
+### Status Derivation (Implemented)
 
-The room host should derive each summary from two inputs:
+The room host derives each summary from
+(`packages/runtimed/src/notebook-compute-session.ts:41-100`):
 
-1. `RuntimeStateDoc` / workstation attachment snapshot:
-   selected workstation, status, runtime session id, kernel status, queue, and
-   executing cell.
-2. Live room membership:
-   runtime peer count and latest runtime-peer join/leave time.
+1. `RuntimeStateDoc` / workstation attachment snapshot: selected workstation,
+   status, runtime session id, queue.
+2. Live room membership: runtime peer count and latest runtime-peer join/leave
+   time.
 
 Rules:
 
-- `active` requires a connected runtime peer and ready/busy kernel state.
-- `busy`/`queued` are refinements of active/starting when queue fields are
-  non-empty.
-- `starting` covers a selected workstation/accepted job where no runtime peer
+- `"active"` requires a connected runtime peer.
+- `"starting"` covers a selected workstation/accepted job where no runtime peer
   has joined yet.
-- `stale` covers queued/running or ready-looking RuntimeStateDoc state with no
-  live runtime peer after the room's grace window.
-- `error` covers explicit failed attachment, kernel error, or repaired runtime
-  loss.
-- `none` means no selected compute target and no queued/running runtime state.
+- `"stale"` covers RuntimeStateDoc state with no live runtime peer after the
+  room's grace window.
+- `"error"` covers explicit failed attachment or repaired runtime loss.
 
-The dashboard may collapse `active`, `busy`, and `queued` into one compact
-"Compute active" affordance until the UI needs more detail.
+The dashboard collapses these into compact compute facts.
 
 ## Cloudflare Implementation Options
 
@@ -228,38 +215,31 @@ Rejected for now:
 - Fails the portability model: a dashboard should query an index, not all live
   actors.
 
-## Recommended Cloudflare Slice
+## Implementation (Completed)
 
-Define the projection contract first, then use **Option A:
-`OwnerComputeIndex` Durable Object** for the Cloudflare prototype. It matches
-the Redis-like mental model, avoids dashboard fan-out, gives one owner-scoped
+Used **Option A: `OwnerComputeIndex` Durable Object**. It matches the
+Redis-like mental model, avoids dashboard fan-out, gives one owner-scoped
 lookup per `/n` load, and keeps expiry/cleanup close to the cache.
 
-D1 remains acceptable as a backend behind the same `ComputeSessionIndex`
-interface if the first implementation needs the absolute smallest code surface,
-but the public API and shared TypeScript/Rust projection names should not expose
-that storage choice. The Rust/Postgres deployment can implement the same
-contract with a Postgres table and optionally add Redis/Valkey/NATS as an
-acceleration layer.
+Implementation:
 
-Implementation slices:
+1. Added `projectNotebookComputeSessionSummary` projection helper in
+   `packages/runtimed/src/notebook-compute-session.ts`.
+2. Added Cloudflare `OwnerComputeIndex` DO with SQLite-backed storage and
+   internal `upsert`, `markGone`, and `list` methods.
+3. `NotebookRoom` publishes summaries on: runtime peer join/restore,
+   runtime-peer-watch reconcile after the grace window, workstation attachment
+   control publish, and runtime-state repair.
+4. Extended `/api/n` response rows with `compute_session`
+   (`apps/notebook-cloud/src/index.ts:1454`).
+5. Extended `apps/notebook-cloud/viewer/notebook-dashboard.ts` facts with
+   compact compute state.
 
-1. Add a pure projection helper in `packages/runtimed`:
-   `projectNotebookComputeSessionSummary({ runtimeState, workstationAttachment,
-   runtimePeerCount, now })`.
-2. Add a Cloudflare `OwnerComputeIndex` DO binding/class with SQLite-backed
-   storage and internal-only `upsert`, `markGone`, and `list` methods.
-3. Have `NotebookRoom` publish a summary on:
-   runtime peer join/restore, runtime-peer-watch reconcile after the grace
-   window, workstation attachment control publish, and runtime-state repair.
-4. Extend `/api/n` response rows with optional `compute_session`.
-5. Extend `apps/notebook-cloud/viewer/notebook-dashboard.ts` facts with compact
-   compute state. Keep rows useful without large cards or noisy labels.
-6. Add owner-scoped workstation page/panel grouping by workstation:
-   active compute sessions, starting sessions, needs-attention sessions.
-7. Add expiry/repair:
-   summaries older than a threshold are displayed as stale unless refreshed;
-   opening the notebook room reconciles RuntimeStateDoc and republishes truth.
+Remaining work:
+
+- Owner-scoped workstation page/panel grouping by workstation.
+- Live dashboard push (SSE).
+- Richer management controls.
 
 ## Non-Cloudflare Shape
 
@@ -344,12 +324,12 @@ Avoid baking Cloudflare into the model:
 5. Should public/view-only notebooks expose active compute? Probably no by
    default; compute liveness may leak owner activity.
 
-## Proposed Next PR
+## Open Follow-ups
 
-Create the projection helper and Cloudflare owner index, publish summaries on
-room runtime peer join/leave and runtime-peer-watch reconcile, and add a compact
-dashboard fact. Defer live dashboard push, workstation grouping, and richer
-management controls until the read-only summary proves correct.
+- Live dashboard push (SSE).
+- Owner-scoped workstation page/panel grouping by workstation: active compute
+  sessions, starting sessions, needs-attention sessions.
+- Richer management controls.
 
 ## References
 

--- a/docs/memos/desktop-cloud-daemon-bridge.md
+++ b/docs/memos/desktop-cloud-daemon-bridge.md
@@ -1,6 +1,7 @@
 # Desktop Cloud Sessions Mediated by the Daemon
 
-**Status:** Working memo, 2026-07-01. Companion to issue #3861.
+**Status:** V1 implemented in #3884, 2026-06-26. Remaining work (local
+kernels, CommsDoc/CommentsDoc bridging, persistence) tracked in issue #3861.
 
 ## Problem
 
@@ -36,39 +37,40 @@ local runtime/kernel <-> daemon <-> hosted cloud room (policy TBD, later slice)
   `changed_tx` broadcast, and identity enforcement
   (`RoomConnectionIdentity`, actor-principal validation on inbound changes).
 
-## Decision sketch: the bridge is another peer of the daemon room
+## Implemented Design: the bridge is another peer of the daemon room
 
 A hosted daemon session creates an **ephemeral, hosted-flagged
 `NotebookRoom`** keyed by the hosted locator, and attaches a **bridge task**
-that is simply one more peer of that room — except its transport is the
-cloud WebSocket instead of a Unix socket.
+that is one more peer of that room — except its transport is the cloud
+WebSocket instead of a Unix socket
+(`crates/runtimed/src/notebook_sync_server/hosted_bridge.rs`).
 
-Echo suppression falls out of the design rather than being bolted on: the
-daemon room holds exactly one `NotebookDoc` instance; the cloud connection is
-one automerge `sync::State` against that doc, and each local peer is another.
-The sync protocol already guarantees changes are not replayed to the peer they
-came from, and convergence tests assert bounded message counts after quiesce.
+Echo suppression falls out of the design: the daemon room holds exactly one
+`NotebookDoc` instance; the cloud connection is one automerge `sync::State`
+against that doc, and each local peer is another. The sync protocol guarantees
+changes are not replayed to the peer they came from.
 
-Bridged docs, v1: `NotebookDoc` (read/write) and `RuntimeStateDoc`
+Bridged docs (V1): `NotebookDoc` (read/write) and `RuntimeStateDoc`
 (cloud-authoritative, received with `receive_sync_message_with_changes`).
-`CommsDoc`/`CommentsDoc` bridging and local-runtime-peer policy are later
-slices (#3861 slice 5).
+`CommsDoc`/`CommentsDoc` bridging and local-runtime-peer policy are deferred
+(#3861 slice 5).
 
-Execution, v1: hosted rooms do not launch local kernels. `execute_cell`
-requests from local peers are forwarded to the cloud room as hosted
-`Request` frames (the same dispatch `cloud-peer --run-cell` exercises); the
-resulting queue/output state arrives back via RuntimeStateDoc sync.
+Execution (V1): hosted rooms do not launch local kernels. `execute_cell`
+requests from local peers are forwarded to the cloud room as hosted `Request`
+frames (`crates/runtimed/src/requests/mod.rs:217-267`); the resulting
+queue/output state arrives back via RuntimeStateDoc sync.
 
-Persistence, v1: none (ephemeral room). Local-first persistence for hosted
-sessions is #3600 and layers on later.
+Persistence (V1): none (ephemeral room). Local-first persistence for hosted
+sessions is #3600.
 
-## Attribution
+## Attribution (Implemented)
 
 The hosted room rejects changes whose actor principal differs from the
-authenticated principal, so the bridge must not let local peers author under
-the local-Unix principal. When a room is hosted-bridged:
+authenticated principal, so the bridge ensures local peers author under the
+cloud principal. When a room is hosted-bridged
+(`crates/runtimed/src/daemon.rs:2928-3037`):
 
-- the room's connection identity mints local peers' actor labels under the
+- The room's connection identity mints local peers' actor labels under the
   **cloud principal** observed in `cloud_room_ready`, keeping the peer's
   self-declared operator suffix:
 
@@ -77,41 +79,41 @@ user:anaconda:<sub>/operator:desktop:<session>
 user:anaconda:<sub>/operator:codex:<session>
 ```
 
-- the bridge itself never rewrites changes; attribution rides the actor label
-  end to end, so cloud-side history shows which local operator made each
-  change while authorization stays anchored to the one authenticated
-  principal.
-- actor uniqueness: the bridge mints a fresh `:<nonce>` per cloud connect
-  (automerge duplicate-seq rule), and local peers already get per-connection
-  labels from the room host.
+- The bridge never rewrites changes; attribution rides the actor label end to
+  end, so cloud-side history shows which local operator made each change while
+  authorization stays anchored to the one authenticated principal.
+- Actor uniqueness: the bridge mints a fresh `:<nonce>` per cloud connect
+  (automerge duplicate-seq rule), and local peers get per-connection labels
+  from the room host.
 
-## Credentials
+## Credentials (Implemented)
 
-v1 reuses the machine-local cloud domain registry from
+V1 uses the machine-local cloud domain registry from
 `docs/adr/cloud-connected-local-mcp.md` Decision 2, lifted out of `runt-mcp`
-into a shared home so the daemon resolves the same file: routing data in the
-registry, secrets referenced via environment variables (later: keychain /
-device flow — #3861 open question). Credentials never ride the handshake from
-the desktop app; the desktop names a URL, the daemon owns the credential.
+into a shared location so the daemon resolves the same file. Routing data is
+in the registry; secrets are referenced via environment variables.
+Credentials never ride the handshake from the desktop app; the desktop names
+a URL, the daemon owns the credential. Keychain / device flow remain #3861
+open questions.
 
-Direct MCP hosted mode stays as a headless shortcut. Nothing here removes it;
-the daemon-mediated path is the desktop product lifecycle.
+Direct MCP hosted mode stays as a headless shortcut; the daemon-mediated path
+is the desktop product lifecycle.
 
-## Entry point
+## Entry point (Implemented)
 
-New connection handshake channel:
+New connection handshake channel (`crates/notebook-protocol/src/connection/handshake.rs:62-81`):
 
 ```json
 {"channel":"open_hosted_notebook","url":"https://preview.runt.run/n/01KT...","operator":"desktop"}
 ```
 
 The daemon resolves the URL against the registry, creates or joins the
-hosted-bridged room, spawns the bridge if needed, and then serves the
-connection exactly like a normal `notebook_sync` peer (typed bootstrap,
-`NotebookConnectionInfo` with the daemon-local room id). Reconnect/status
-composition in the desktop UI is #3599.
+hosted-bridged room, spawns the bridge if needed, and serves the connection
+like a normal `notebook_sync` peer (typed bootstrap, `NotebookConnectionInfo`
+with the daemon-local room id). Reconnect/status composition in the desktop UI
+is #3599.
 
-## Out of scope for the first slice
+## Remaining Work (see #3861)
 
 - OAuth/device-flow credential acquisition and keychain storage.
 - CommsDoc/CommentsDoc bridging; widget replay across the bridge.
@@ -119,3 +121,4 @@ composition in the desktop UI is #3599.
   separate, existing flow).
 - Offline edits with later cloud rejection UX.
 - Local-first persistence of hosted sessions (#3600).
+- Richer status/presence composition in desktop UI (#3599).

--- a/docs/memos/env-sandbox-policy-design.md
+++ b/docs/memos/env-sandbox-policy-design.md
@@ -36,13 +36,17 @@ conda: binary archives are preferred; post-link scripts are opt-in.
 
 ### 4. nteract package installs are isolated from global caches
 
-nteract executes all Python in a sandboxed context. Packages installed for use
-inside nteract must not share caches with packages installed outside nteract,
-which may have no sandboxing or isolation model. Mixing the two creates
-confusion about which packages have been vetted for sandbox execution and
-contaminates the nteract environment with installs that were never subject to
-nteract's trust model. nteract maintains its own cache directories, separate
-from the user's global package manager caches.
+nteract executes Python **during package installation** in a sandboxed context
+(uv/pip builds, post-link scripts). Packages installed for use inside nteract
+must not share caches with packages installed outside nteract, which may have
+no sandboxing or isolation model. Mixing the two creates confusion about which
+packages have been vetted for sandbox execution and contaminates the nteract
+environment with installs that were never subject to nteract's trust model.
+nteract maintains its own cache directories, separate from the user's global
+package manager caches.
+
+Note: runtime kernel/agent execution is not yet sandboxed; see issue #1307 for
+runtime agent sandboxing policy.
 
 ### 5. Arbitrary execution requires per-notebook isolation
 

--- a/docs/memos/execution-liveness.md
+++ b/docs/memos/execution-liveness.md
@@ -42,7 +42,7 @@ We have four independent signals about kernel reality:
 
 | Signal | What it tells us | Where it lives |
 |---|---|---|
-| ZMQ heartbeat | Kernel process is alive and pinging | `jupyter_kernel.rs:2614-2700` (5s interval, 3-failure threshold) |
+| ZMQ heartbeat | Kernel process is alive and pinging | `jupyter_kernel.rs` heartbeat task (5s interval, 3-failure threshold) |
 | IOPub activity | Kernel is *doing* something user-visible (stream, status, comm, display) | IOPub reader in `jupyter_kernel.rs` |
 | Shell socket | The execute_request was accepted; reply pending | `jupyter_kernel.rs` shell reader |
 | Committer queues | The daemon has buffered output work it has not yet committed | `stream_committer` periodic queue, `display_update_committer` pending map |
@@ -69,9 +69,17 @@ The first three are not catastrophes the daemon should "fix" by force-completing
 
 Two existing mechanisms are useful:
 
-1. **Heartbeat task** (`jupyter_kernel.rs:2614`). Pings the kernel every 5s, 3s timeout, 3 consecutive failures → declares the kernel dead and routes through the existing `KernelDied` path. This already covers the case where the kernel process itself has gone away.
+1. **Heartbeat task** (`crates/runtimed/src/jupyter_kernel.rs` heartbeat
+   module). Pings the kernel every 5s, 3s timeout, 3 consecutive failures →
+   declares the kernel dead and routes through the existing `KernelDied` path.
+   This already covers the case where the kernel process itself has gone away.
 
-2. **Committer supervisor `KernelDied` on panic** (`stream_committer.rs:227`, `display_update_committer.rs:259`). If a committer task panics, the supervisor emits `KernelDied` on the lifecycle channel and the queue releases. This covers the case where the committers themselves crash.
+2. **Committer supervisor `KernelDied` on panic**
+   (`crates/runtimed/src/stream_committer.rs` and
+   `crates/runtimed/src/display_update_committer.rs` panic paths). If a
+   committer task panics, the supervisor emits `KernelDied` on the lifecycle
+   channel and the queue releases. This covers the case where the committers
+   themselves crash.
 
 What we **don't** have:
 

--- a/docs/memos/markdown-node-identity-reconciler.md
+++ b/docs/memos/markdown-node-identity-reconciler.md
@@ -1,7 +1,7 @@
 # Carried-forward node identity for the markdown plan
 
-**Status:** Exploration. Engine design, downstream-driven. No-op for nteract's
-current surfaces beyond cheaper remounts; see "What this buys nteract."
+**Status:** Implemented in #3862, 2026-06-02. Engine and tests landed; snapshot
+encoding uses serde_json; cross-WASM snapshot transport remains unexposed.
 
 ## Objective
 
@@ -66,33 +66,34 @@ plan is a disposable projection parsed fresh from source. The reconciler
 stabilizes the projection's node handles across reparses. It does not replace,
 duplicate, or interact with Automerge's source identity.
 
-## Design
+## Design (Implemented)
 
-A new `project_markdown_reconciled(source, options, &prev) -> (MarkdownPlan, ReconcilerSnapshot)`
-runs three phases:
+`project_markdown_reconciled(source, options, &prev) -> (MarkdownPlan, ReconcilerSnapshot)`
+runs three phases (`crates/nteract-markdown-engine/src/lib.rs:393-506`):
 
-1. **Build.** Run `project_node` as today, but leave `ProjectedNode.id` empty and
-   defer anchor and isolated-region emission. This drops the provisional-id remap
-   and the `SourceSpan::empty()` id collision.
-2. **Reconcile.** Assign ids top-down. One recursive `reconcile_children` runs at
-   every children list (blocks, then list items / table rows / cells, then inline
-   runs), so block and inline ids fall out of the same pass. Root keeps the
-   literal `"root"`; only its children align.
-3. **Finalize.** A document-order DFS over the now-id-stable tree rebuilds anchors
-   (`block_id = node.id`), isolated regions (`id = "isolation:" + node.id`), and
-   the heading-slug counter, then serializes the new snapshot from
-   `MarkdownPlan.root` (never from the flattened block/run view).
+1. **Build.** Run `project_node`, but leave `ProjectedNode.id` empty and defer
+   anchor and isolated-region emission. This drops the provisional-id remap and
+   the `SourceSpan::empty()` id collision.
+2. **Reconcile.** Assign ids top-down. One recursive `reconcile_children` runs
+   at every children list (blocks, then list items / table rows / cells, then
+   inline runs), so block and inline ids fall out of the same pass. Root keeps
+   the literal `"root"`; only its children align.
+3. **Finalize.** A document-order DFS over the now-id-stable tree rebuilds
+   anchors (`block_id = node.id`), isolated regions (`id = "isolation:" +
+   node.id`), and the heading-slug counter, then serializes the new snapshot
+   from `MarkdownPlan.root` (never from the flattened block/run view).
 
 Identity is a two-tier predicate:
 
-- `eq(a, b)` = `(kind, lane, iso, isolation_tag)` equal **and** `content_hash`
-  equal. The unchanged-anchor test that trim and LCS anchor on.
-- `compat(a, b)` = `(kind, lane, iso, isolation_tag)` equal, content may differ.
-  The edit-inside-vs-replace gate.
+- `eq(a, b)` = `(kind, lane, iso, isolation_tag, island_tag, island_inline)`
+  equal **and** `content_hash` equal. The unchanged-anchor test that trim and
+  LCS anchor on.
+- `compat(a, b)` = `(kind, lane, iso, isolation_tag, island_tag,
+  island_inline)` equal, content may differ. The edit-inside-vs-replace gate.
 
 Content decides changed-vs-unchanged, never identity. Identity is alignment
-position plus `compat`. Duplicates (two `---`, two `## Notes`, two identical
-`$x$`) disambiguate by order, which alignment gives for free.
+position plus `compat`. Duplicates disambiguate by order, which alignment
+gives for free.
 
 `reconcile_children` is: ambiguity-guarded two-ended trim under `eq`, then LCS on
 the residual middle under `eq` with match-late backtrack, then a
@@ -102,19 +103,22 @@ left. A node matched under `eq` has an equal `content_hash`, so its subtree is
 byte-identical and its ids are preserved without recursing. Only `compat` carries
 (content differs) recurse to re-align changed children.
 
-Two requirements the edit scenarios force:
+Edit-scenario requirements:
 
 - **`content_hash` is a recursive Merkle digest** over `kind, lane, iso,
-  isolation_tag`, the rendering-salient attrs, `copy_text` for leaves, and each
-  child's hash in document order. A flat `copy_text` scalar compares a
-  formatting-only edit (`the cat sat` to `the *cat* sat`) and a same-text reorder
-  (`**alpha**` vs `alpha`) equal at the parent, which silently drops the edit and
-  collapses the reorder. "Equal `content_hash` implies subtree byte-identical" is
-  what the subtree short-circuit and the `eq` anchor depend on.
-- **The structural tuple includes `isolation_tag`**, a new `NodeAttrs` field
-  carrying the MDX component name or active-HTML element tag, so two isolated
-  nodes of the same `IsolationKind` (`<video>` to `<iframe>`) are not `compat` and
-  remount instead of aliasing.
+  isolation_tag, island_tag, island_inline`
+  (`crates/nteract-markdown-engine/src/lib.rs:830-848`), the rendering-salient
+  attrs, `copy_text` for leaves, and each child's hash in document order. A
+  flat `copy_text` scalar would compare a formatting-only edit (`the cat sat`
+  to `the *cat* sat`) equal at the parent, silently dropping the edit. "Equal
+  `content_hash` implies subtree byte-identical" is what the subtree
+  short-circuit and the `eq` anchor depend on.
+- **The structural tuple includes `isolation_tag`, `island_tag`, and
+  `island_inline`** (`crates/nteract-markdown-engine/src/lib.rs:96-109`), so
+  two isolated nodes of the same `IsolationKind` (`<video>` to `<iframe>`) are
+  not `compat` and remount instead of aliasing. `island_tag` covers MDX
+  components (`<Frog />` to `<Chart />`); `island_inline` distinguishes block
+  vs inline JSX islands for the same component tag.
 
 The front-surplus zip hard-codes an insert-above preference: surplus leading
 nodes with no `eq` match mint fresh before the remainder zips, so a block inserted
@@ -128,7 +132,7 @@ node is fresh and existing call sites are unchanged. A consumer that wants
 stability threads the snapshot back in. The whole identity matrix runs as FFI-free
 `cargo` tests because the engine stays a pure function of `(source, prev-snapshot)`.
 
-## Behavioral coverage
+## Behavioral coverage (Implemented tests)
 
 | Test | Pins |
 | --- | --- |
@@ -147,20 +151,20 @@ stability threads the snapshot back in. The whole identity matrix runs as FFI-fr
 | `offset_decoupling_heading_slug_renumber` | Node id stable; only the slug-derived anchor own-id renumbers, by design. |
 | `cold_start_all_fresh` | Empty snapshot and the stateless path both mint fresh from 1; root is `"root"`. |
 | `snapshot_wire_roundtrip_total` | Round-trip is faithful; malformed or skewed bytes return `Default`, never panic. |
+| Island identity tests (from #3859/#3878) | `island_tag` and `island_inline` remount behavior for MDX components. |
 
 ## Open decisions
 
-- **Snapshot transport.** How the opaque previous-plan snapshot crosses the wasm
-  boundary, and the encoding (hand-rolled little-endian with a total `from_wire`,
-  vs adding `serde_json` to the engine). The interface is free to change since
-  callers rebuild against it.
+- **Cross-WASM snapshot transport.** Engine snapshot encoding uses `serde_json`
+  (`crates/nteract-markdown-engine/src/lib.rs:71`), but the WASM bridge
+  exposes only stateless `project_markdown` JSON
+  (`crates/nteract-markdown-wasm/src/lib.rs:60`). Cross-WASM snapshot
+  transport remains unexposed; mark this decided if not planned.
 - **Id representation.** Keep `String` ids (`node:{n}`) so the JSON contract is
   unchanged, vs integers with a consumer-side stringify.
-- **Merkle hash function and attr set.** FNV-1a vs xxhash, and which attrs beyond
-  `copy_text` feed the digest (depth, lang, meta, url, ordered, checked, align,
-  isolation_tag).
-- **`isolation_tag` extraction.** How to parse the component / element name out of
-  `html.value`, and whether expression-kind MDX nodes need a finer discriminator.
+- **Merkle hash function and attr set.** FNV-1a vs xxhash, and which attrs
+  beyond `copy_text` feed the digest (depth, lang, meta, url, ordered, checked,
+  align, isolation_tag, island_tag, island_inline).
 
 ## Risks and why it stays safe for nteract
 

--- a/docs/memos/markdown-plan-documents.md
+++ b/docs/memos/markdown-plan-documents.md
@@ -473,10 +473,14 @@ compact.
 
 OC-2: Projection schema v2
 
-The Rust engine has richer structure than the TypeScript plan exposes. Add
+The Rust engine has richer structure than the TypeScript plan exposes. Island
+projection fields (`content_hash`, `island_tag`, `island_inline`) now serialize
+in Rust JSON (`crates/nteract-markdown-engine/src/render_json.rs:210`) but are
+missing from the TypeScript `MarkdownProjectionBlock` interface. Add
 `isolatedRegions`, `root` or a stable tree summary, parse diagnostics,
-`outputArtifacts`, and `componentArtifacts` to the WASM/TS schema before building
-much UI on top of the flattened shape.
+`outputArtifacts`, and `componentArtifacts` to the WASM/TS schema before
+building much UI on top of the flattened shape. Inline JSX islands are created
+at `crates/nteract-markdown-engine/src/lib.rs:1204`.
 
 OC-3: Editor choice
 
@@ -540,8 +544,11 @@ but preserve Automerge as the live collaboration source while the app is open.
    comments placeholders.
 2. Extend the markdown projection engine to parse `<!-- nteract:output ... -->`
    comments after code blocks into output artifact references.
-3. Expose `isolated_regions` and component/diagnostic placeholders through the
-   WASM/TypeScript projection schema.
+3. Refresh TypeScript `MarkdownProjectionBlock` interface to match Rust island
+   fields (`content_hash`, `island_tag`, `island_inline`). Expose
+   `isolated_regions`, `root` or stable tree summary, parse diagnostics,
+   `outputArtifacts`, and `componentArtifacts` through the WASM/TypeScript
+   projection schema.
 4. Draft a comments ADR amendment for generic document locators.
 5. Sketch the hosted catalog/dashboard shape before committing to `/m`-specific
    D1 tables or Durable Object classes.

--- a/docs/memos/panel-runtime-state.md
+++ b/docs/memos/panel-runtime-state.md
@@ -1,16 +1,13 @@
 # Represent Panel Runtime State Explicitly
 
-Status: RFC
+Status: Parked. Display bug (#3750) fixed by renderer work (5171ccb1); typed
+runtime channel exists only on feature branches; static Panel output rendering
+shipped.
 
-Panel should not become another raw Jupyter comm bridge in nteract. Panel's
-live notebook path is a Bokeh document patch protocol carried over PyViz comms,
-and nteract already has better primitives for explicit runtime state: typed
-runtime protocol messages, Automerge documents, blob storage, and execution
-scoped outputs.
-
-This memo frames a separate implementation track for native Panel runtime
-state. It is source-grounded but not yet a durable decision; graduate the
-accepted pieces into ADRs once the prototype proves the shape.
+Panel display rendering (#3752/#3773) fixed the original bug. The typed runtime
+channel design below exists on feature branches but has not merged to main.
+This memo is preserved as design history for if/when live Panel interactivity
+returns as work.
 
 ## Current Evidence
 

--- a/docs/memos/projection-source-rendered-correspondence.md
+++ b/docs/memos/projection-source-rendered-correspondence.md
@@ -218,11 +218,14 @@ here pays forward.
   working. Verify copy explicitly. The shared `--cm-comment-color` /
   `.comment-highlight` surface (`src/styles/comment-highlight.css`) moves from the
   run span to the inner highlight span.
-- **OQ-3 Overlapping anchors.** Two comments overlapping the same characters
-  need nested or layered highlights. Run-granular code sidestepped this by
-  picking the shortest overlapping highlight; character-granular has to decide
-  stacking. Step 1 keeps the single-best-highlight-per-run choice and highlights
-  only that sub-range; multiple-per-run is deferred.
+- **OQ-3 Overlapping anchors (resolved).** Multiple highlights per run landed
+  in commit 1217de09 (`feat(comments): multiple highlights per run + compose
+  selection preview (#3796)`). Code computes multiple highlight ranges and
+  splits run text across all boundaries
+  (`src/components/markdown/ProjectedMarkdownView.tsx:873`), rendering
+  highlight pieces at line 904. Non-overlapping and overlapping per-run
+  highlights are now supported; unresolved stacking semantics, if any, remain
+  open.
 - **OQ-4 IsolatedFrame.** Cells that fall back to `IsolatedFrame` have no
   comment affordance at all today. Out of scope here, tracked separately.
 - **OQ-5 Marker rollout.** The fidelity marker is additive under `version: 1`, so

--- a/docs/plans/comments-rollout.md
+++ b/docs/plans/comments-rollout.md
@@ -24,10 +24,14 @@ The core comments architecture has landed:
   humans.
 - **Desktop product polish.** Finish rail/panel flows, stale-anchor display, and
   source/rich-rendered selection repair against live `CommentsDoc` projections.
-- **Hosted room ingress.** Keep Cloud room-host comment writes behind the same
-  actor-binding and scope checks as local daemon ingress.
 - **Publish boundary.** Exclude private review comments from public artifacts by
   default; add an explicit opt-in policy before publishing comments.
+
+Note: Hosted room ingress validates comment writes by scope
+(`apps/notebook-cloud/src/room-materializer.ts:139-148` passes
+`canWriteAllNotebookChanges` to `receive_peer_frame`;
+`crates/runtimed-wasm/src/lib.rs:1063` rejects CommentsDoc changes when the
+flag is false).
 
 ## Guardrail
 

--- a/docs/prd/hosted-sharing-invites.md
+++ b/docs/prd/hosted-sharing-invites.md
@@ -1,6 +1,7 @@
 # Hosted Notebook Sharing and Invites
 
-**Status:** PRD draft, 2026-05-24.
+**Status:** Implemented — shipped Worker routes, storage, tests. Open product
+decisions documented below.
 
 This PRD defines the user-facing sharing requirements and the product/data path
 from "share with email" to principal-backed `notebook_acl` rows. It relies on
@@ -15,11 +16,12 @@ Related docs:
 - `docs/adr/hosted-credential-transport.md`
 - `docs/runbooks/hosted-direct-oidc-demo-runbook.md`
 
-Prototype code:
+Implementation files:
 
 - `apps/notebook-cloud/src/sharing.ts`
 - `apps/notebook-cloud/src/sharing-storage.ts`
-- `apps/notebook-cloud/src/index.ts`
+- `apps/notebook-cloud/src/index.ts` (routes at `:387-:427`)
+- `apps/notebook-cloud/migrations/0005_sharing_invites.sql`
 - `apps/notebook-cloud/test/sharing.test.ts`
 - `apps/notebook-cloud/test/sharing-storage.test.ts`
 - `apps/notebook-cloud/test/worker-routes.test.ts`
@@ -102,11 +104,25 @@ CREATE TABLE notebook_invites (
 );
 
 CREATE INDEX notebook_invites_pending_lookup_idx
-  ON notebook_invites(provider_hint, email_normalized, status);
+  ON notebook_invites(email_normalized, status, provider_hint);
+
+CREATE UNIQUE INDEX notebook_invites_pending_provider_unique_idx
+  ON notebook_invites(notebook_id, email_normalized, provider_hint, scope)
+  WHERE status = 'pending' AND provider_hint IS NOT NULL;
+
+CREATE UNIQUE INDEX notebook_invites_pending_wildcard_unique_idx
+  ON notebook_invites(notebook_id, email_normalized, scope)
+  WHERE status = 'pending' AND provider_hint IS NULL;
 
 CREATE INDEX notebook_invites_notebook_idx
   ON notebook_invites(notebook_id, status);
 ```
+
+The shipped schema is in `migrations/0005_sharing_invites.sql`. Index order and
+uniqueness constraints differ from this early sketch: the pending lookup index
+puts `email_normalized` first for resolution queries, and partial unique
+indexes prevent duplicate pending invites per notebook/email/scope (split by
+provider-hint presence).
 
 `provider_hint` is normalized to lowercase provider ids. It should be
 `anaconda` for the direct Anaconda OIDC demo. It may be `NULL` only when the
@@ -134,21 +150,15 @@ Pending invites are not ACL rows and cannot authorize a socket.
    trim + lowercase
    ```
 
-4. The API looks for a verified `principal_profiles` row with the same
-   provider hint and normalized email.
-5. If a matching profile exists, the API inserts the principal ACL row
-   immediately:
-
-   ```json
-   {
-     "subject_kind": "principal",
-     "subject": "user:anaconda:<encoded-anaconda-sub>",
-     "scope": "editor"
-   }
-   ```
-
-6. If no matching profile exists, the API creates a `pending` invite row and
-   sends or exposes an invite link.
+4. **Current behavior:** The API always creates or returns a `pending` invite
+   row (`createPendingNotebookInvite` in `index.ts:3399`). Invites resolve to
+   principal ACL rows on the recipient's first login.
+5. **Open product decision:** Should the API look for a verified
+   `principal_profiles` row with matching provider hint and normalized email,
+   and insert an immediate principal ACL row if found? This would grant access
+   without requiring the recipient to log in again, but requires deciding when
+   to prefer immediate grants vs. pending invites for auditing or notification
+   purposes.
 7. The share dialog shows:
    - resolved collaborators by display name;
    - pending invites by email;

--- a/docs/prd/hosted-sharing-invites.md
+++ b/docs/prd/hosted-sharing-invites.md
@@ -158,14 +158,12 @@ Pending invites are not ACL rows and cannot authorize a socket.
    and insert an immediate principal ACL row if found? This would grant access
    without requiring the recipient to log in again, but requires deciding when
    to prefer immediate grants vs. pending invites for auditing or notification
-   purposes.
-7. The share dialog shows:
+   purposes. If immediate grants land, the API may still create an accepted
+   invite audit row; the ACL subject stays the resolved principal.
+6. The share dialog shows:
    - resolved collaborators by display name;
    - pending invites by email;
    - public viewer as a separate "Anyone with the link" row.
-
-The API may create an accepted invite audit row even for immediate grants, but
-the ACL subject is still the resolved principal.
 
 The initial Worker surface is deliberately small and owner-scoped:
 

--- a/docs/prd/notebook-identity-environment-surfaces.md
+++ b/docs/prd/notebook-identity-environment-surfaces.md
@@ -1,6 +1,7 @@
 # Notebook Identity and Environment Surfaces
 
-**Status:** PRD draft, 2026-05-31.
+**Status:** Implemented product contract — acceptance criteria met. Remaining
+work in "Suggested Work Slices."
 
 **Owners:** nteract notebook UI, Cloud/Auth, Desktop runtime.
 
@@ -18,7 +19,7 @@ Related docs:
 - `docs/adr/notebook-host-shell-convergence.md`
 - `apps/elements/content/docs/identity-environment-surfaces.mdx`
 
-Prototype and shared component surfaces:
+Shared component surfaces and projections:
 
 - `src/components/notebook/capabilities.ts`
 - `src/components/notebook/NotebookIdentity.tsx`
@@ -27,7 +28,12 @@ Prototype and shared component surfaces:
 - `src/components/notebook/NotebookToolbarIdentity.tsx`
 - `src/components/notebook/NotebookEnvironmentSummary.tsx`
 - `src/components/notebook/interaction-mode.ts`
-- `apps/elements/components/notebook-scenarios.ts`
+- `packages/runtimed/src/notebook-shell-capabilities.ts` — exported shared
+  projections for actor attribution, runtime authorship, access facts, runtime
+  state, and environment capabilities
+- `apps/elements/components/notebook-scenarios.ts` — shipped scenario ids
+  including `cloud-public-viewer`, `agent-on-behalf`, `mixed-idp-authorship`,
+  `runtime-peer`, `runtime-unavailable`, `untrusted-dependencies`
 
 ## Problem
 

--- a/docs/runbooks/hosted-direct-oidc-demo-runbook.md
+++ b/docs/runbooks/hosted-direct-oidc-demo-runbook.md
@@ -177,14 +177,17 @@ field:
   "auth": {
     "oidc": {
       "status": "configured",
-      "issuer": "https://auth.stage.anaconda.com/api/auth",
-      "principal_namespace": "user:anaconda"
+      "jwks": "remote",
+      "audience": "client_id",
+      "principal_namespace": "configured"
     }
   }
 }
 ```
 
-Do not expose client secrets, access tokens, refresh tokens, or raw JWT claims.
+The response intentionally omits issuer, client ID, audience values, and
+principal namespace names. Do not expose client secrets, access tokens, refresh
+tokens, or raw JWT claims.
 
 ## Avoid Edge-Only Login
 

--- a/docs/runbooks/macos-setup.md
+++ b/docs/runbooks/macos-setup.md
@@ -96,7 +96,12 @@ corepack prepare pnpm@latest --activate
 
 ## 5. First build
 
-`cargo xtask dev` handles the full first-run sequence: installs pnpm dependencies, builds WASM artifacts, runs `uv sync`, builds Python bindings via `maturin develop`, compiles Rust, and starts the dev daemon and Vite dev server.
+`cargo xtask dev` handles the full first-run sequence: installs pnpm
+dependencies, runs `uv sync`, builds WASM artifacts and the MCP widget, compiles
+Rust sidecars, and starts the dev daemon and Vite dev server. Python bindings
+are no longer part of the default build (the MCP server is Rust-native). Agents
+iterating on `runtimed-py` should use `cargo xtask integration` (which runs
+`maturin develop`) or rebuild via the nteract-dev MCP (`up rebuild=true`).
 
 ```bash
 cargo xtask dev

--- a/docs/runbooks/remote-workstation.md
+++ b/docs/runbooks/remote-workstation.md
@@ -101,19 +101,17 @@ runt workstation service status  # Linux user systemd service state
 ```
 
 The service launches `runtimed workstation-agent`, which heartbeats the
-registration, keeps a server-sent event stream open for attach-job wakeups, and
-spawns one `runtimed cloud-runtime-agent` runtime peer per job (pending →
-accepted → running → completed/failed). The event stream is the fast path;
-low-frequency attach-job polling remains as recovery for missed events, older
-servers, and jobs that existed before the agent started. The stream is
-deliberately only a wakeup signal, not a replay log: attach jobs are durable in
-the hosted database, so reconnect recovery polls the queue instead of relying
-on SSE `Last-Event-ID` state. Keeping idle presence and wakeups on one SSE
-request avoids the request churn of tight polling or a per-workstation control
-WebSocket. The credential rides the environment (`RUNT_CLOUD_TOKEN`), never
-argv. `RUNT_CLOUD_TOKEN` / `RUNT_CLOUD_URL` environment variables override the
-stored credential for foreground `runt workstation run`; the service path uses
-the stored credential file written by `connect`.
+registration, keeps a hibernatable workstation event WebSocket open for
+attach-job wakeups, and spawns one `runtimed cloud-runtime-agent` runtime peer
+per job (pending → accepted → running → completed/failed). The event WebSocket
+is the fast path; low-frequency attach-job polling remains as recovery for
+missed wakeup events and jobs that existed before the agent started. The socket
+is deliberately only a wakeup signal, not a replay log: attach jobs are durable
+in the hosted database, so reconnect recovery polls the queue. The credential
+rides the environment (`RUNT_CLOUD_TOKEN`), never argv. `RUNT_CLOUD_TOKEN` /
+`RUNT_CLOUD_URL` environment variables override the stored credential for
+foreground `runt workstation run`; the service path uses the stored credential
+file written by `connect`.
 
 In the hosted notebook, attaching compute to a workstation dispatches an attach
 job; the agent accepts it and the runtime peer attaches to the room as

--- a/python/README.md
+++ b/python/README.md
@@ -5,7 +5,7 @@ Development home for nteract Python packages. The UV workspace root (`pyproject.
 | Package | Description |
 |---------|-------------|
 | `python/runtimed/` | Low-level Python bindings for the runtimed daemon (maturin/PyO3) |
-| `python/nteract/` | MCP server for AI agents — composes runtimed primitives |
+| `python/nteract/` | Thin launcher for the Rust-native `runt mcp` MCP server |
 | `python/dx/` | Display and blob-store helpers used from Python kernels |
 | `python/nteract-kernel-launcher/` | Embedded launcher package vendored by the daemon into kernel environments |
 | `python/prewarm/` | Environment warm-up utility for Python kernels |

--- a/src/components/isolated/AGENTS.md
+++ b/src/components/isolated/AGENTS.md
@@ -75,7 +75,7 @@ The core renderer bundle is built inline by `apps/notebook/vite-plugin-isolated-
 
 ## Renderer plugins
 
-Heavy renderers (markdown, plotly, vega, leaflet, sift) are **not** in the core IIFE. They're on-demand CJS modules loaded via `frame.installRenderer()` only when their MIME types appear.
+Heavy renderers (markdown, plotly, bokeh, panel, vega, leaflet, sift) are **not** in the core IIFE. They're on-demand CJS modules loaded via `frame.installRenderer()` only when their MIME types appear.
 
 ```
 ┌──────────────────────────────┐     ┌──────────────────────────┐
@@ -125,8 +125,8 @@ export function install(ctx: {
 ```
 
 2. Extend `apps/notebook/vite-plugin-isolated-renderer.ts`: add the entry path, code/css variables, `invalidateCache()` entry, the `buildRendererPlugin()` call, and a `load()` case for the virtual module.
-3. Declare the virtual module in `apps/notebook/src/vite-env.d.ts`.
-4. In `src/components/isolated/iframe-libraries.ts`, add the MIME → plugin entry to `PLUGIN_MIME_TYPES`. Vega-style pattern matchers can use a shared loader; exact MIME types should live in the map.
+3. Declare the virtual module in `apps/notebook/src/vite-env.d.ts` (e.g., `declare module "virtual:renderer-plugin/bokeh" { ... }`).
+4. In `src/components/isolated/renderer-plugin-info.ts`, add the MIME → plugin mapping. The plugin loader registration lives in `iframe-libraries.ts` with imports from the virtual modules.
 5. Remove the component from `src/isolated-renderer/index.tsx` so it no longer ships in the core bundle.
 
 ## Message protocol

--- a/src/components/ui/AGENTS.md
+++ b/src/components/ui/AGENTS.md
@@ -10,10 +10,17 @@ Scope: `src/components/ui/**`, `src/components/cell/**`, `src/components/editor/
 ├── tailwind.config.js       ← Tailwind config (covers src/ and apps/)
 ├── src/
 │   ├── components/
-│   │   ├── ui/              ← 24 shared shadcn primitives (Button, Dialog, etc.)
+│   │   ├── ui/              ← Shared shadcn primitives (Button, Dialog, etc.)
 │   │   ├── cell/            ← Cell container, controls, execution count
 │   │   ├── editor/          ← CodeMirror wrappers, extensions, themes
-│   │   └── outputs/         ← Output renderers (MediaRouter, AnsiOutput, etc.)
+│   │   ├── outputs/         ← Output renderers (MediaRouter, AnsiOutput, etc.)
+│   │   ├── comments/        ← Commenting UI
+│   │   ├── environment/     ← Runtime/package UI
+│   │   ├── isolated/        ← Isolated iframe renderer
+│   │   ├── markdown/        ← Markdown rendering
+│   │   ├── notebook/        ← Notebook-level UI
+│   │   ├── notebook-rail/   ← Notebook rail components
+│   │   └── widgets/         ← Widget rendering
 │   └── lib/utils.ts         ← cn() utility
 └── apps/
     └── notebook/            ← Uses @/components/* via path alias


### PR DESCRIPTION
## Summary

Repo-wide documentation consistency refresh, driven by a full audit of every
doc surface — 36 ADRs, 13 memos, plans, PRDs, audits, measurements, runbooks,
12 nested `AGENTS.md` files, `.claude/rules`, 9 repo skills, 24 Elements docs,
top-level docs, the cloud README, and all 22 open issues — cross-referenced
against code and git history. The audit evidence record ships in this PR as
`docs/audits/documentation-and-issue-consistency-audit.md` (153 artifacts
classified, 101 findings that survived independent adversarial verification).

The thesis: June's landed work (CommentsDoc sync, daemon-mediated hosted rooms
#3884, hosted artifacts/dashboard wave, release signing) outran the docs. This
PR makes the docs state where the system **is** and where it goes **next**,
and trims superseded text instead of layering caveats.

## What changed

- **Protocol truth:** `CommentsDocSync` (`0x0a`) added to every frame table,
  sender-validity list, and traffic-class description (`notebook-wire`,
  `notebook-sync`, `runtimed` AGENTS.md; typed-frame v4 ADR now "eleven frame
  types" with typed `SessionControl` bootstrap and bounded discard reads;
  document-split ADR reflects landed CommentsDoc + corrected PoolDoc example;
  automerge-sync skill stream table). Comments ingress is described as it
  works: clone-preview actor validation + scope stripping, no daemon
  "finalization" step, client sync task holds no comments replica.
- **Security framing:** identity-and-trust Decision 6 rewritten to state
  shipped behavior — publish uploads saved source bytes and **preserves**
  source actor history; fresh-document re-authoring is the explicit target,
  the threat-table row flipped from closed to **open**, and an Open Follow-up
  tracks implementation. `deployment-topology`'s non-goal and the fork-patches
  memo were reconciled to the same story. Scope-enforcement lists now include
  `0x0a`.
- **Status hygiene:** implemented Draft ADRs graduated to Accepted
  (execution-pipeline, tokio-mutex-discipline, runtime-state-document-identity,
  schema-evolution-and-genesis); notebook-identity-and-path-binding →
  In progress (NIP-1/NIP-2 landed, NIP-3 design); compound status lines
  normalized to the register vocabulary.
- **Memos → implementation records:** desktop-cloud-daemon-bridge (#3884),
  arrow-manifest-durable-storage, markdown-node-identity-reconciler (#3862),
  compute-session-index reframed around what shipped, with moot option-space
  discussion deleted; panel-runtime-state cut down to a parked proposal (#3750
  was fixed by renderer work, not this design). Measurements reframed as
  pre-optimization baselines where the code moved (per-comm replay cache,
  output_committer queueing).
- **Hosted/cloud refresh:** cloud README (auth cookies vs sync tickets, snapshot
  headers, R2/D1 storage, sharing/invite layer, CommentsDoc checkpointing,
  "prototype" framing retired), hosted-notebook-artifacts, cloud-connected-
  local-mcp (daemon-mediated bridge reconciliation), hosted-room-authorization,
  Elements cloud-dashboard doc rewritten around the shipped /n dashboard
  (#3883/#3885/#3892/#3895).
- **Release/ops truth:** RELEASING.md (Windows signing is real, full artifact
  matrix, unpublished crates), releasing skill (canonical `cargo xtask bump`),
  remote-workstation runbook (WebSocket wakeup, not SSE), macos-setup, OIDC
  demo runbook, README/CONTRIBUTING structure blocks, python/README, DESIGN.md
  tokens.
- **Agent guidance:** owner-vs-attach MCP tool surfaces, `attachLogger` (not
  `attachConsole`), kernel-env Deno source, isolated/ui/widgets AGENTS.md
  inventories, daemon-dev + mcp-session-lifecycle skill corrections.

## Decisions still needed (not in this PR)

1. **Publish-time re-authoring** (identity ADR Decision 6): implement, or
   accept preserved history as the durable stance. Threat table row is now
   honestly `open`.
2. **Invite immediate grants** (hosted-sharing-invites PRD): shipped route is
   pending-only; immediate ACL grant for verified profiles is recorded as an
   open product decision.

Issue gardening (close #3750, #3015; fold #1391 into #3608; re-scope ~8 others)
is listed in the audit doc for follow-up on the tracker.

## Verification

- Every applied finding was re-verified against the tree at `48dae8fb` before
  editing; findings invalidated by post-audit commits were skipped.
- Three review passes ran after the edits: an adversarial fact-check of every
  added claim against code, a taxonomy/style pass, and a final deep review that
  spot-verified ~40 high-stakes claims (frame ids/caps, xtask bump, MCP mode
  gating, workstation WebSocket, invite behavior, release artifacts) and led to
  the second commit's corrections.
- `CI=true cargo xtask lint --fix` passes clean.

## Reviewer notes

This refresh was fact-checked against code at roughly forty points and holds up
everywhere we probed; the frame tables, release/ops claims, MCP mode surfaces,
and the Decision 6 security reframe all verify against source, and the
memo/measurement trims lose nothing load-bearing (every surviving open decision
still exists in the post-diff files). The riskiest review area is the comments
ingress description — it was corrected in the second commit after the first
draft echoed a pre-implementation design that named nonexistent `finalized*`
fields; the shipped model is clone-preview actor validation with scope
stripping and projected attribution. The two "Decisions Needed" in the audit
doc are deliberately not resolved here: they change security posture and
product behavior respectively, and need an owner rather than a doc edit.
