### PR TITLE
feat(mcp): first-class comment tools + CommentsDoc replica in typed clients

### DIFF
--- a/.agents/skills/automerge-sync/SKILL.md
+++ b/.agents/skills/automerge-sync/SKILL.md
@@ -122,16 +122,18 @@ V1 is original; V2 allows compressed document encoding. Backward-compatible via 
 | Notebook | `0x00` AutomergeSync | `SharedDocState.doc` | Bidirectional |
 | RuntimeState | `0x05` RuntimeStateSync | `SharedDocState.state_doc` | Daemon-authoritative |
 | CommsDoc | `0x09` CommsDocSync | `SharedDocState.comms_doc` | Widget state, gated by RuntimeStateDoc topology |
-| CommentsDoc | `0x0a` CommentsDocSync | Frontend WASM replica (`runtimed-wasm`); daemon replica persisted by `comments_store.rs` | Notebook-room comments sidecar; ingress validates change actor labels against the connection principal |
+| CommentsDoc | `0x0a` CommentsDocSync | `SharedDocState.comments_doc` (typed clients + frontend WASM); daemon replica persisted by `comments_store.rs` | Notebook-room comments sidecar; ingress validates change actor labels against the connection principal |
 | PoolState | `0x06` PoolStateSync | PoolDoc | Frontend owns sync state; daemon carries `pool_peer_state` separately |
 
 For CommentsDoc, see `crates/comments-doc`, daemon persistence at
 `crates/runtimed/src/notebook_sync_server/comments_store.rs`, ingress at
-`peer_comments_sync.rs`. Optimistic client mutations apply via Automerge; the
-daemon validates change actor labels against the connection principal
-(clone-preview) and strips writes from scopes without comment authority. There
-is no daemon finalization step — attribution (`resolved_by_actor_label`,
-`resolved_at`) is projected from admitted change actors.
+`peer_comments_sync.rs`. Typed clients (`notebook-sync` crate) and frontend
+WASM (`runtimed-wasm`) both hold CommentsDoc replicas. Optimistic client
+mutations apply via Automerge; the daemon validates change actor labels against
+the connection principal (clone-preview) and strips writes from scopes without
+comment authority. There is no daemon finalization step — attribution
+(`resolved_by_actor_label`, `resolved_at`) is projected from admitted change
+actors.
 
 ### Sync Task Loop (biased select!)
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4829,6 +4829,8 @@ version = "0.5.2"
 dependencies = [
  "automerge",
  "automerge-recovery",
+ "chrono",
+ "comments-doc",
  "hex",
  "log",
  "notebook-doc",
@@ -7376,6 +7378,7 @@ version = "0.5.2"
 dependencies = [
  "base64 0.22.1",
  "chrono",
+ "comments-doc",
  "dirs",
  "fancy-regex 0.14.0",
  "futures-util",

--- a/crates/comments-doc/src/doc.rs
+++ b/crates/comments-doc/src/doc.rs
@@ -212,6 +212,27 @@ impl CommentsDoc {
         Ok(())
     }
 
+    /// Adopt a `comments_doc_id` that arrived in the document via sync into
+    /// the cached identity.
+    ///
+    /// Sync clients scaffold from the shared genesis with no identity
+    /// (`new_empty_for_sync`); the daemon-authoritative id reaches the
+    /// document through the first sync round. Returns `true` if an identity
+    /// was adopted, `false` if the cache was already set or the document
+    /// carries no id yet. Errors if the document's id is invalid or
+    /// conflicted.
+    pub fn adopt_synced_identity(&mut self) -> Result<bool, CommentsDocError> {
+        if !self.comments_doc_id.is_empty() {
+            return Ok(false);
+        }
+        let Some(raw) = self.raw_comments_doc_id() else {
+            return Ok(false);
+        };
+        self.ensure_raw_comments_doc_id_matches_value(&raw)?;
+        self.comments_doc_id = raw;
+        Ok(true)
+    }
+
     fn ensure_raw_comments_doc_id_matches(&self) -> Result<(), CommentsDocError> {
         self.ensure_raw_comments_doc_id_matches_value(&self.comments_doc_id)
     }

--- a/crates/comments-doc/src/doc.rs
+++ b/crates/comments-doc/src/doc.rs
@@ -135,6 +135,21 @@ impl CommentsDoc {
             .unwrap_or_else(|err| panic!("seed comments doc schema: {err}"))
     }
 
+    /// Create an empty CommentsDoc for use in sync clients.
+    ///
+    /// The identity (comments_doc_id, notebook_ref) arrives from the daemon
+    /// via the first sync message. The shared genesis doc ensures no ROOT map
+    /// conflicts when local mutations race ahead of the first sync frame.
+    pub fn new_empty_for_sync() -> Self {
+        let mut doc = Self::schema_seed_doc()
+            .unwrap_or_else(|err| panic!("load comments doc genesis: {err}"));
+        doc.set_actor(ActorId::random());
+        Self {
+            doc,
+            comments_doc_id: String::new(),
+        }
+    }
+
     fn schema_seed_doc() -> Result<AutoCommit, CommentsDocError> {
         AutoCommit::load(COMMENTS_DOC_GENESIS_V1_BYTES).map_err(Into::into)
     }

--- a/crates/notebook-protocol/src/connection.rs
+++ b/crates/notebook-protocol/src/connection.rs
@@ -630,6 +630,7 @@ mod tests {
             ft::RUNTIME_STATE_SYNC,
             ft::COMMS_DOC_SYNC,
             ft::POOL_STATE_SYNC,
+            ft::COMMENTS_DOC_SYNC,
             ft::SESSION_CONTROL,
             ft::PUT_BLOB,
         ] {

--- a/crates/notebook-sync/AGENTS.md
+++ b/crates/notebook-sync/AGENTS.md
@@ -1,23 +1,22 @@
 # notebook-sync
 
 This crate is the client-side sync handle and socket task boundary for
-NotebookDoc, RuntimeStateDoc, CommsDoc, PoolDoc, requests, presence, blobs, and
-session status. CommentsDoc frames pass through the relay path but this crate
-holds no comments replica.
+NotebookDoc, RuntimeStateDoc, CommsDoc, CommentsDoc, PoolDoc, requests,
+presence, blobs, and session status.
 
 ## Main pieces
 
 - `DocHandle` is the caller-facing API. Synchronous document mutations go
-  through `with_doc` or typed helpers, then notify the sync task.
+  through `with_doc` or typed helpers (including comment CRUD methods), then
+  notify the sync task.
 - `SharedDocState` stores the local NotebookDoc, RuntimeStateDoc, CommsDoc,
-  PoolDoc, snapshots, request waiters, blob waiters, and readiness phases
-  shared with the socket task.
+  CommentsDoc, PoolDoc, snapshots, request waiters, blob waiters, and readiness
+  phases shared with the socket task.
 - `sync_task` owns typed-frame I/O. It sends and receives Automerge sync for
-  `0x00` NotebookDoc, `0x05` RuntimeStateDoc, `0x06` PoolDoc, and `0x09`
-  CommsDoc, plus request, response, presence, session-control, and `PUT_BLOB`
-  frames. It receives and ignores `0x0a` CommentsDocSync — the comments
-  replica lives in frontend WASM (`runtimed-wasm`), reached via `relay_task`,
-  not in `SharedDocState`.
+  `0x00` NotebookDoc, `0x05` RuntimeStateDoc, `0x06` PoolDoc, `0x09` CommsDoc,
+  and `0x0a` CommentsDocSync, plus request, response, presence, session-control,
+  and `PUT_BLOB` frames. Frontend WASM (`runtimed-wasm`) relays CommentsDocSync
+  via `relay_task` for UI integration.
 - `execution_wait` / `execution_watch` observe RuntimeStateDoc terminal state;
   RuntimeStateDoc is the durable execution/output record, not broadcast replay.
 - `relay` / `relay_task` are byte-pipe helpers for app relay paths; they do not

--- a/crates/notebook-sync/Cargo.toml
+++ b/crates/notebook-sync/Cargo.toml
@@ -14,6 +14,7 @@ automerge = { workspace = true }
 automerge-recovery = { path = "../automerge-recovery" }
 notebook-doc = { path = "../notebook-doc" }
 runtime-doc = { path = "../runtime-doc" }
+comments-doc = { path = "../comments-doc" }
 notebook-protocol = { path = "../notebook-protocol" }
 tokio = { workspace = true, features = ["full"] }
 serde = { workspace = true }
@@ -24,6 +25,7 @@ hex = { workspace = true }
 
 uuid = { workspace = true }
 log = { workspace = true }
+chrono = { workspace = true, features = ["clock"] }
 
 [dev-dependencies]
 runt-workspace = { path = "../runt-workspace" }

--- a/crates/notebook-sync/src/error.rs
+++ b/crates/notebook-sync/src/error.rs
@@ -59,6 +59,10 @@ pub enum SyncError {
     /// Runtime state document setup or mutation failed.
     #[error("Runtime state error: {0}")]
     RuntimeState(#[from] runtime_doc::RuntimeStateError),
+
+    /// Comments document setup or mutation failed.
+    #[error("Comments error: {0}")]
+    Comments(#[from] comments_doc::CommentsDocError),
 }
 
 impl From<serde_json::Error> for SyncError {

--- a/crates/notebook-sync/src/handle.rs
+++ b/crates/notebook-sync/src/handle.rs
@@ -102,14 +102,17 @@ pub struct DocHandle {
 /// saved `RuntimeStateDoc` whose execution/output manifests are resolved by
 /// `execution_id` from the notebook cells. `comms_doc_bytes` are the saved
 /// `CommsDoc` whose widget values pair with RuntimeStateDoc comm topology.
+/// `comments_doc_bytes` are the saved `CommentsDoc` whose threads attach to cells.
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct SnapshotPairBytes {
     pub notebook_bytes: Vec<u8>,
     pub runtime_state_bytes: Vec<u8>,
     pub comms_doc_bytes: Vec<u8>,
+    pub comments_doc_bytes: Vec<u8>,
     pub notebook_heads: Vec<String>,
     pub runtime_state_heads: Vec<String>,
     pub comms_doc_heads: Vec<String>,
+    pub comments_doc_heads: Vec<String>,
 }
 
 impl std::fmt::Debug for DocHandle {
@@ -158,9 +161,9 @@ impl DocHandle {
     /// (e.g., `"agent:claude"`, `"runtimed-py:<session>"`).
     pub fn set_actor(&self, actor_label: &str) -> Result<(), SyncError> {
         let mut state = self.doc.lock().map_err(|_| SyncError::LockPoisoned)?;
-        state
-            .doc
-            .set_actor(automerge::ActorId::from(actor_label.as_bytes()));
+        let actor_id = automerge::ActorId::from(actor_label.as_bytes());
+        state.doc.set_actor(actor_id.clone());
+        state.comments_doc.doc_mut().set_actor(actor_id);
         Ok(())
     }
 
@@ -744,17 +747,26 @@ impl DocHandle {
             .into_iter()
             .map(|head| hex::encode(head.as_ref()))
             .collect();
+        let comments_doc_heads = state
+            .comments_doc
+            .get_heads()
+            .into_iter()
+            .map(|head| hex::encode(head.as_ref()))
+            .collect();
         let notebook_bytes = state.doc.save();
         let runtime_state_bytes = state.state_doc.doc_mut().save();
         let comms_doc_bytes = state.comms_doc.doc_mut().save();
+        let comments_doc_bytes = state.comments_doc.doc_mut().save();
 
         Ok(SnapshotPairBytes {
             notebook_bytes,
             runtime_state_bytes,
             comms_doc_bytes,
+            comments_doc_bytes,
             notebook_heads,
             runtime_state_heads,
             comms_doc_heads,
+            comments_doc_heads,
         })
     }
 
@@ -802,6 +814,89 @@ impl DocHandle {
             .await
             .map_err(|_| SyncError::Disconnected)?;
         crate::reply::recv(reply_rx).await
+    }
+
+    // ── Comment operations ──────────────────────────────────────────
+
+    /// Create a new comment thread anchored to a cell or notebook.
+    pub fn create_comment_thread(
+        &self,
+        anchor: comments_doc::CommentAnchor,
+        body: String,
+    ) -> Result<String, SyncError> {
+        let thread_id = uuid::Uuid::new_v4().to_string();
+        let message_id = uuid::Uuid::new_v4().to_string();
+        let created_at = chrono::Utc::now().to_rfc3339();
+
+        {
+            let mut state = self.doc.lock().map_err(|_| SyncError::LockPoisoned)?;
+            state.comments_doc.create_thread(
+                &thread_id,
+                &message_id,
+                &anchor,
+                &body,
+                None,
+                &created_at,
+            )?;
+        }
+
+        // Notify sync task that CommentsDoc changed
+        let _ = self.changed_tx.send(());
+
+        Ok(thread_id)
+    }
+
+    /// Reply to an existing comment thread.
+    pub fn reply_to_comment(&self, thread_id: &str, body: String) -> Result<String, SyncError> {
+        let message_id = uuid::Uuid::new_v4().to_string();
+        let created_at = chrono::Utc::now().to_rfc3339();
+
+        {
+            let mut state = self.doc.lock().map_err(|_| SyncError::LockPoisoned)?;
+            state
+                .comments_doc
+                .reply(thread_id, &message_id, &body, None, &created_at)?;
+        }
+
+        // Notify sync task that CommentsDoc changed
+        let _ = self.changed_tx.send(());
+
+        Ok(message_id)
+    }
+
+    /// Mark a comment thread as resolved.
+    pub fn resolve_comment_thread(&self, thread_id: &str) -> Result<(), SyncError> {
+        let resolved_at = chrono::Utc::now().to_rfc3339();
+
+        {
+            let mut state = self.doc.lock().map_err(|_| SyncError::LockPoisoned)?;
+            state.comments_doc.resolve_thread(thread_id, &resolved_at)?;
+        }
+
+        // Notify sync task that CommentsDoc changed
+        let _ = self.changed_tx.send(());
+
+        Ok(())
+    }
+
+    /// Reopen a resolved comment thread.
+    pub fn reopen_comment_thread(&self, thread_id: &str) -> Result<(), SyncError> {
+        {
+            let mut state = self.doc.lock().map_err(|_| SyncError::LockPoisoned)?;
+            state.comments_doc.reopen_thread(thread_id)?;
+        }
+
+        // Notify sync task that CommentsDoc changed
+        let _ = self.changed_tx.send(());
+
+        Ok(())
+    }
+
+    /// Read the current comments projection (all threads and messages).
+    pub fn get_comments_projection(&self) -> Result<comments_doc::CommentsProjection, SyncError> {
+        let state = self.doc.lock().map_err(|_| SyncError::LockPoisoned)?;
+        let projection = state.comments_doc.read_projection(None)?;
+        Ok(projection)
     }
 
     fn readiness_error(status: &SyncStatus) -> Option<SyncError> {
@@ -1086,5 +1181,114 @@ fn read_execution_id(doc: &AutoCommit, cell_id: &str) -> Option<String> {
             _ => None,
         },
         _ => None,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use comments_doc::CommentAnchor;
+    use tokio::sync::broadcast;
+
+    fn test_handle() -> DocHandle {
+        let shared = Arc::new(Mutex::new(SharedDocState::new(
+            notebook_doc::NotebookDoc::new("test-notebook").into_inner(),
+            "test-notebook".into(),
+        )));
+
+        // Initialize CommentsDoc with identity (normally arrives from daemon via sync)
+        {
+            let mut state = shared.lock().unwrap();
+            let notebook_ref = comments_doc::NotebookCommentRef::LocalPath {
+                canonical_path: "/test.ipynb".into(),
+            };
+            state.comments_doc =
+                comments_doc::CommentsDoc::new("comments:test-notebook", &notebook_ref);
+        }
+
+        let initial_snapshot = {
+            let state = shared.lock().unwrap();
+            NotebookSnapshot::from_doc(&state.doc)
+        };
+        let (snapshot_tx, snapshot_rx) = watch::channel(initial_snapshot);
+        let snapshot_tx = Arc::new(snapshot_tx);
+        let (_runtime_state_tx, runtime_state_rx) =
+            watch::channel(runtime_doc::RuntimeState::default());
+        let (_status_tx, status_rx) = watch::channel(SyncStatus::connected_pending());
+        let (changed_tx, _changed_rx) = mpsc::unbounded_channel();
+        let (cmd_tx, _cmd_rx) = mpsc::channel(32);
+        let (_broadcast_tx, _broadcast_rx) =
+            broadcast::channel::<notebook_protocol::protocol::NotebookBroadcast>(32);
+
+        DocHandle::new(
+            Arc::clone(&shared),
+            changed_tx,
+            cmd_tx,
+            Arc::clone(&snapshot_tx),
+            snapshot_rx,
+            runtime_state_rx,
+            status_rx,
+            "test-notebook".to_string(),
+        )
+    }
+
+    #[tokio::test]
+    async fn comment_crud_operations() {
+        let handle = test_handle();
+
+        // Set authenticated actor
+        handle.set_actor("agent:test").unwrap();
+
+        // Create a thread
+        let thread_id = handle
+            .create_comment_thread(
+                CommentAnchor::Cell {
+                    cell_id: "cell-1".into(),
+                    observed_cell_position: None,
+                },
+                "test comment".into(),
+            )
+            .unwrap();
+
+        // Read projection
+        let projection = handle.get_comments_projection().unwrap();
+        assert_eq!(projection.threads.len(), 1);
+        assert_eq!(projection.threads[0].messages[0].body, "test comment");
+        assert_eq!(
+            projection.threads[0].created_by_actor_label.as_deref(),
+            Some("agent:test"),
+            "thread creator should match set actor"
+        );
+
+        // Reply to thread
+        let _message_id = handle.reply_to_comment(&thread_id, "reply".into()).unwrap();
+
+        let projection = handle.get_comments_projection().unwrap();
+        assert_eq!(projection.threads[0].messages.len(), 2);
+        // Messages may be in any order depending on position calculation
+        let bodies: Vec<&str> = projection.threads[0]
+            .messages
+            .iter()
+            .map(|m| m.body.as_str())
+            .collect();
+        assert!(bodies.contains(&"test comment"));
+        assert!(bodies.contains(&"reply"));
+
+        // Resolve thread
+        handle.resolve_comment_thread(&thread_id).unwrap();
+
+        let projection = handle.get_comments_projection().unwrap();
+        assert!(projection.threads[0].resolved_at.is_some());
+        assert_eq!(
+            projection.threads[0].resolved_by_actor_label.as_deref(),
+            Some("agent:test"),
+            "thread resolver should match set actor"
+        );
+
+        // Reopen thread
+        handle.reopen_comment_thread(&thread_id).unwrap();
+
+        let projection = handle.get_comments_projection().unwrap();
+        assert!(projection.threads[0].resolved_at.is_none());
     }
 }

--- a/crates/notebook-sync/src/shared.rs
+++ b/crates/notebook-sync/src/shared.rs
@@ -12,6 +12,7 @@ use automerge_recovery::{
     catch_automerge_panic, is_recoverable_sync_error, recoverable_automerge_operation,
     AutomergeOperationError, AutomergeRebuildError,
 };
+use comments_doc::CommentsDoc;
 use log::warn;
 use notebook_doc::presence::PresenceState;
 use runtime_doc::{CommsDoc, RuntimeStateDoc};
@@ -46,6 +47,12 @@ pub struct SharedDocState {
     /// Automerge sync protocol state for the CommsDoc peer.
     pub(crate) comms_peer_state: sync::State,
 
+    /// Comments doc — synced alongside notebook content.
+    pub(crate) comments_doc: CommentsDoc,
+
+    /// Automerge sync protocol state for the CommentsDoc peer.
+    pub(crate) comments_peer_state: sync::State,
+
     #[cfg(test)]
     panic_on_next_doc_sync: bool,
     #[cfg(test)]
@@ -58,6 +65,13 @@ impl SharedDocState {
         doc: AutoCommit,
         notebook_id: String,
     ) -> Result<Self, runtime_doc::RuntimeStateError> {
+        // CommentsDoc starts empty — identity arrives from daemon via sync.
+        // Author under the same actor as the notebook doc (set from the
+        // connection actor label at bootstrap) so comments ingress validation
+        // and attribution projection see the connection principal.
+        let mut comments_doc = CommentsDoc::new_empty_for_sync();
+        comments_doc.doc_mut().set_actor(doc.get_actor().clone());
+
         Ok(Self {
             doc,
             peer_state: sync::State::new(),
@@ -67,6 +81,8 @@ impl SharedDocState {
             state_peer_state: sync::State::new(),
             comms_doc: CommsDoc::try_new_empty()?,
             comms_peer_state: sync::State::new(),
+            comments_doc,
+            comments_peer_state: sync::State::new(),
             #[cfg(test)]
             panic_on_next_doc_sync: false,
             #[cfg(test)]
@@ -265,6 +281,64 @@ impl SharedDocState {
         rebuilt
     }
 
+    // ── CommentsDoc sync ────────────────────────────────────────────
+
+    pub(crate) fn generate_comments_sync_message_recovering(
+        &mut self,
+        label: &str,
+    ) -> Result<Option<sync::Message>, AutomergeOperationError> {
+        self.comments_doc
+            .generate_sync_message_recovering(&mut self.comments_peer_state, label)
+    }
+
+    pub(crate) fn receive_comments_sync_message(
+        &mut self,
+        message: sync::Message,
+    ) -> Result<(), automerge::AutomergeError> {
+        self.comments_doc
+            .doc_mut()
+            .sync()
+            .receive_sync_message(&mut self.comments_peer_state, message)
+    }
+
+    pub(crate) fn receive_comments_sync_message_recovering(
+        &mut self,
+        message: sync::Message,
+        label: &str,
+    ) -> Result<(), AutomergeOperationError> {
+        let mut context = SharedDocReceiveRecoveryContext {
+            state: self,
+            next_message: Some(message.clone()),
+            retry_message: message,
+        };
+        recoverable_automerge_operation(
+            label,
+            &mut context,
+            |context| {
+                let message = context
+                    .next_message
+                    .take()
+                    .unwrap_or_else(|| context.retry_message.clone());
+                context.state.receive_comments_sync_message(message)
+            },
+            is_recoverable_sync_error,
+            |context| context.state.rebuild_comments_doc(),
+        )
+    }
+
+    pub(crate) fn rebuild_comments_doc(&mut self) -> Result<(), AutomergeRebuildError> {
+        let rebuilt = self.comments_doc.rebuild_from_save();
+        if let Err(err) = &rebuilt {
+            warn!(
+                "[notebook-sync] Failed to rebuild CommentsDoc after recoverable Automerge failure: {}; \
+                 resetting comments sync protocol only",
+                err
+            );
+        }
+        self.comments_peer_state = sync::State::new();
+        rebuilt
+    }
+
     /// Rebuild the RuntimeStateDoc via save→load and reset its sync state.
     ///
     /// Used after a caller-marked recoverable Automerge failure during
@@ -348,6 +422,18 @@ struct SharedDocReceiveRecoveryContext<'a> {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn comments_doc_inherits_notebook_doc_actor() {
+        let mut doc = AutoCommit::new();
+        doc.set_actor(automerge::ActorId::from("agent:claude:s1".as_bytes()));
+        let state = SharedDocState::new(doc, "test-notebook".into());
+        assert_eq!(
+            state.comments_doc.doc().get_actor(),
+            &automerge::ActorId::from("agent:claude:s1".as_bytes()),
+            "comments replica must author under the connection actor from construction"
+        );
+    }
 
     #[test]
     fn rebuild_state_doc_preserves_state_and_restarts_sync_handshake() {

--- a/crates/notebook-sync/src/shared.rs
+++ b/crates/notebook-sync/src/shared.rs
@@ -298,7 +298,18 @@ impl SharedDocState {
         self.comments_doc
             .doc_mut()
             .sync()
-            .receive_sync_message(&mut self.comments_peer_state, message)
+            .receive_sync_message(&mut self.comments_peer_state, message)?;
+        // The replica scaffolds without identity; the daemon-authoritative
+        // comments_doc_id arrives inside the synced document. Adopt it so
+        // projections work after the first sync round. Adoption failure is a
+        // degrade-alone comments concern, not a sync error.
+        if let Err(err) = self.comments_doc.adopt_synced_identity() {
+            warn!(
+                "[notebook-sync] CommentsDoc identity adoption failed for {}: {}",
+                self.notebook_id, err
+            );
+        }
+        Ok(())
     }
 
     pub(crate) fn receive_comments_sync_message_recovering(
@@ -433,6 +444,59 @@ mod tests {
             &automerge::ActorId::from("agent:claude:s1".as_bytes()),
             "comments replica must author under the connection actor from construction"
         );
+    }
+
+    #[test]
+    fn comments_projection_works_after_initial_daemon_sync() {
+        use automerge::sync::SyncDoc;
+
+        // Client starts from the real empty sync seed — no identity.
+        let mut state = SharedDocState::new(AutoCommit::new(), "test-notebook".into());
+
+        // Daemon-side doc carries the authoritative identity.
+        let notebook_ref = comments_doc::NotebookCommentRef::LocalPath {
+            canonical_path: "/test.ipynb".into(),
+        };
+        let mut daemon_doc = comments_doc::CommentsDoc::new_with_actor(
+            "comments:local-path:abc123",
+            &notebook_ref,
+            "local:tester/desktop",
+        );
+        let mut daemon_peer = sync::State::new();
+
+        // Drive sync to convergence in both directions.
+        for _ in 0..10 {
+            let mut progressed = false;
+            if let Some(msg) = daemon_doc.generate_sync_message(&mut daemon_peer) {
+                state
+                    .receive_comments_sync_message(msg)
+                    .expect("client applies daemon comments sync");
+                progressed = true;
+            }
+            if let Some(msg) = state
+                .generate_comments_sync_message_recovering("test-comments-outbound")
+                .expect("client generates comments sync")
+            {
+                daemon_doc
+                    .doc_mut()
+                    .sync()
+                    .receive_sync_message(&mut daemon_peer, msg)
+                    .expect("daemon applies client comments sync");
+                progressed = true;
+            }
+            if !progressed {
+                break;
+            }
+        }
+
+        // The client replica must have adopted the daemon identity: this is
+        // the path the nteract:// comments resource and post-mutation reads
+        // exercise, which fail with MissingCommentsDocId without adoption.
+        let projection = state
+            .comments_doc
+            .read_projection(None)
+            .expect("projection readable after initial daemon sync");
+        assert_eq!(projection.comments_doc_id, "comments:local-path:abc123");
     }
 
     #[test]

--- a/crates/notebook-sync/src/sync_task.rs
+++ b/crates/notebook-sync/src/sync_task.rs
@@ -429,6 +429,8 @@ impl SyncReactor {
         if let Some(generation) = self.send_doc_sync_round(writer).await? {
             mark_unsent_confirm_waiters(&mut self.state.confirm_waiters, generation);
         }
+        // Also send CommentsDoc changes
+        send_comments_sync_message(&self.io.doc, writer).await?;
         self.resolve_confirm_waiters();
         Ok(())
     }
@@ -474,6 +476,8 @@ impl SyncReactor {
                 if let Err(e) = send_state_sync_message(&self.io.doc, writer).await {
                     let _ = reply.send(Err(e));
                 } else if let Err(e) = send_comms_sync_message(&self.io.doc, writer).await {
+                    let _ = reply.send(Err(e));
+                } else if let Err(e) = send_comments_sync_message(&self.io.doc, writer).await {
                     let _ = reply.send(Err(e));
                 } else {
                     let now = Instant::now();
@@ -855,12 +859,66 @@ impl SyncReactor {
             }
 
             NotebookFrameType::CommentsDocSync => {
-                // CommentsDoc sync is a frontend WASM concern, like PoolStateSync.
-                // The Python client sync task holds no comments replica.
-                debug!(
-                    "[notebook-sync] Ignoring CommentsDocSync frame for {} (handled by frontend)",
-                    self.io.notebook_id
-                );
+                let msg = match sync::Message::decode(&frame.payload) {
+                    Ok(msg) => msg,
+                    Err(e) => {
+                        warn!(
+                            "[notebook-sync] Failed to decode CommentsDocSync for {}: {}",
+                            self.io.notebook_id, e
+                        );
+                        return Ok(());
+                    }
+                };
+
+                let reply_bytes = {
+                    let mut state = self.io.doc.lock().unwrap_or_else(|e| e.into_inner());
+                    match state
+                        .receive_comments_sync_message_recovering(msg, "comments-doc-sync-receive")
+                    {
+                        Ok(()) => {}
+                        Err(e @ AutomergeOperationError::Panic(_))
+                        | Err(e @ AutomergeOperationError::RebuildFailed { .. }) => {
+                            warn!(
+                                "[notebook-sync] CommentsDocSync failure for {} (comments degrade alone): {}",
+                                self.io.notebook_id, e
+                            );
+                            state.comments_peer_state = sync::State::new();
+                            return Ok(());
+                        }
+                        Err(e) => {
+                            warn!(
+                                "[notebook-sync] Failed to apply CommentsDocSync for {} (comments degrade alone): {}",
+                                self.io.notebook_id, e
+                            );
+                            state.comments_peer_state = sync::State::new();
+                            return Ok(());
+                        }
+                    };
+                    match state.generate_comments_sync_message_recovering("comments-doc-sync-reply")
+                    {
+                        Ok(message) => message.map(|msg| msg.encode()),
+                        Err(e) => {
+                            warn!(
+                                "[notebook-sync] Failed to generate CommentsDocSync reply for {}: {}",
+                                self.io.notebook_id, e
+                            );
+                            state.comments_peer_state = sync::State::new();
+                            return Ok(());
+                        }
+                    }
+                };
+
+                if let Some(bytes) = reply_bytes {
+                    if let Err(e) = writer
+                        .send_frame(NotebookFrameType::CommentsDocSync, &bytes)
+                        .await
+                    {
+                        warn!(
+                            "[notebook-sync] Failed to send CommentsDocSync reply for {}: {}",
+                            self.io.notebook_id, e
+                        );
+                    }
+                }
                 Ok(())
             }
 
@@ -1187,6 +1245,28 @@ async fn send_comms_sync_message<W: FrameSink>(
     if let Some(bytes) = msg_bytes {
         writer
             .send_frame(NotebookFrameType::CommsDocSync, &bytes)
+            .await
+            .map_err(SyncError::Io)?;
+    }
+
+    Ok(())
+}
+
+async fn send_comments_sync_message<W: FrameSink>(
+    doc: &Arc<Mutex<SharedDocState>>,
+    writer: &mut W,
+) -> Result<(), SyncError> {
+    let msg_bytes = {
+        let mut state = doc.lock().unwrap_or_else(|e| e.into_inner());
+        state
+            .generate_comments_sync_message_recovering("comments-doc-sync-outbound")
+            .map_err(|e| SyncError::Protocol(e.to_string()))?
+            .map(|msg| msg.encode())
+    };
+
+    if let Some(bytes) = msg_bytes {
+        writer
+            .send_frame(NotebookFrameType::CommentsDocSync, &bytes)
             .await
             .map_err(SyncError::Io)?;
     }

--- a/crates/runt-mcp/Cargo.toml
+++ b/crates/runt-mcp/Cargo.toml
@@ -22,6 +22,7 @@ notebook-cloud-transport = { path = "../notebook-cloud-transport", features = ["
 notebook-sync = { path = "../notebook-sync" }
 notebook-doc = { path = "../notebook-doc" }
 runtime-doc = { path = "../runtime-doc" }
+comments-doc = { path = "../comments-doc" }
 mcp-client-branding = { path = "../mcp-client-branding" }
 runt-workspace = { path = "../runt-workspace" }
 tokio = { workspace = true, features = ["full"] }

--- a/crates/runt-mcp/src/icons.rs
+++ b/crates/runt-mcp/src/icons.rs
@@ -54,6 +54,9 @@ pub(crate) fn tool_icon(name: &str) -> Option<IconKind> {
         "restart_kernel" => IconKind::RestartKernel,
         "manage_dependencies" => IconKind::ManageDependencies,
         "replace_match" | "replace_regex" => IconKind::ReplaceCell,
+        "create_comment" | "reply_comment" | "resolve_comment" | "reopen_comment" => {
+            IconKind::EditCell
+        }
         _ => return None,
     })
 }

--- a/crates/runt-mcp/src/resources.rs
+++ b/crates/runt-mcp/src/resources.rs
@@ -123,6 +123,14 @@ pub fn list_resource_templates() -> ListResourceTemplatesResult {
             IconKind::ReadCell,
             NOTEBOOK_CONTEXT_PRIORITY,
         ),
+        assistant_resource_template(
+            "nteract://notebooks/{notebook_id}/comments",
+            "nteract notebook comments",
+            "Comment threads for a connected or parked notebook session",
+            "application/json",
+            IconKind::ListActiveNotebooks,
+            NOTEBOOK_CONTEXT_PRIORITY,
+        ),
     ];
 
     ListResourceTemplatesResult {
@@ -168,6 +176,18 @@ pub async fn read_resource(
         } => {
             let handle = handle_for_notebook(server, &notebook_id).await?;
             let text = cell_json(&notebook_id, &handle, &cell_id)?;
+            Ok(ReadResourceResult::new(vec![json_resource(uri, text)]))
+        }
+        NotebookResourceUri::Comments { notebook_id } => {
+            let handle = handle_for_notebook(server, &notebook_id).await?;
+            // Settle pending comments/state frames so a read right after join
+            // does not race the daemon's initial CommentsDocSync.
+            let _ = handle.confirm_state_sync().await;
+            let projection = handle
+                .get_comments_projection()
+                .map_err(|e| McpError::internal_error(format!("read comments: {e}"), None))?;
+            let text = serde_json::to_string_pretty(&projection)
+                .map_err(|e| McpError::internal_error(format!("serialize comments: {e}"), None))?;
             Ok(ReadResourceResult::new(vec![json_resource(uri, text)]))
         }
     }
@@ -422,6 +442,9 @@ enum NotebookResourceUri {
         notebook_id: String,
         cell_id: String,
     },
+    Comments {
+        notebook_id: String,
+    },
 }
 
 fn parse_notebook_resource_uri(uri: &str) -> Result<NotebookResourceUri, String> {
@@ -440,6 +463,9 @@ fn parse_notebook_resource_uri(uri: &str) -> Result<NotebookResourceUri, String>
         [notebook_id, "cells", cell_id] => Ok(NotebookResourceUri::Cell {
             notebook_id: decode_segment(notebook_id)?,
             cell_id: decode_segment(cell_id)?,
+        }),
+        [notebook_id, "comments"] => Ok(NotebookResourceUri::Comments {
+            notebook_id: decode_segment(notebook_id)?,
         }),
         _ => Err(format!("Unknown nteract resource URI: {uri}")),
     }

--- a/crates/runt-mcp/src/tools/comments.rs
+++ b/crates/runt-mcp/src/tools/comments.rs
@@ -1,0 +1,179 @@
+//! Comment tools: create, reply, resolve, reopen.
+
+use rmcp::model::{CallToolRequestParams, CallToolResult};
+use rmcp::ErrorData as McpError;
+use schemars::JsonSchema;
+use serde::Deserialize;
+
+use crate::NteractMcp;
+
+use super::{reject_unknown_args, tool_success};
+
+#[allow(dead_code)]
+#[derive(Debug, Deserialize, JsonSchema)]
+#[serde(deny_unknown_fields)]
+pub struct CreateCommentParams {
+    /// Anchor: either { "cell_id": "..." } for cell comment, or { "notebook": true } for notebook comment.
+    pub anchor: AnchorParam,
+    /// Comment text (markdown supported).
+    pub body: String,
+}
+
+#[allow(dead_code)]
+#[derive(Debug, Deserialize, JsonSchema)]
+#[serde(untagged)]
+pub enum AnchorParam {
+    Cell { cell_id: String },
+    Notebook { notebook: bool },
+}
+
+impl From<AnchorParam> for comments_doc::CommentAnchor {
+    fn from(param: AnchorParam) -> Self {
+        match param {
+            AnchorParam::Cell { cell_id } => comments_doc::CommentAnchor::Cell {
+                cell_id,
+                observed_cell_position: None,
+            },
+            AnchorParam::Notebook { .. } => comments_doc::CommentAnchor::Notebook,
+        }
+    }
+}
+
+#[allow(dead_code)]
+#[derive(Debug, Deserialize, JsonSchema)]
+#[serde(deny_unknown_fields)]
+pub struct ReplyCommentParams {
+    /// Thread ID to reply to.
+    pub thread_id: String,
+    /// Reply text (markdown supported).
+    pub body: String,
+}
+
+#[allow(dead_code)]
+#[derive(Debug, Deserialize, JsonSchema)]
+#[serde(deny_unknown_fields)]
+pub struct ResolveCommentParams {
+    /// Thread ID to resolve.
+    pub thread_id: String,
+}
+
+#[allow(dead_code)]
+#[derive(Debug, Deserialize, JsonSchema)]
+#[serde(deny_unknown_fields)]
+pub struct ReopenCommentParams {
+    /// Thread ID to reopen.
+    pub thread_id: String,
+}
+
+/// Create a new comment thread anchored to a cell or notebook.
+pub async fn create_comment(
+    server: &NteractMcp,
+    request: &CallToolRequestParams,
+) -> Result<CallToolResult, McpError> {
+    reject_unknown_args(request, &["anchor", "body"])?;
+
+    let handle = require_handle!(server);
+    let params: CreateCommentParams = serde_json::from_value(serde_json::Value::Object(
+        request
+            .arguments
+            .clone()
+            .ok_or_else(|| McpError::invalid_params("Missing arguments", None))?,
+    ))
+    .map_err(|e| McpError::invalid_params(format!("Invalid parameters: {e}"), None))?;
+
+    let thread_id = handle
+        .create_comment_thread(params.anchor.into(), params.body)
+        .map_err(|e| McpError::internal_error(format!("create comment thread: {e}"), None))?;
+
+    handle.confirm_state_sync().await.map_err(|e| {
+        McpError::internal_error(format!("Failed to sync after create_comment: {e}"), None)
+    })?;
+
+    tool_success(&format!("Created comment thread: {thread_id}"))
+}
+
+/// Reply to an existing comment thread.
+pub async fn reply_comment(
+    server: &NteractMcp,
+    request: &CallToolRequestParams,
+) -> Result<CallToolResult, McpError> {
+    reject_unknown_args(request, &["thread_id", "body"])?;
+
+    let handle = require_handle!(server);
+    let params: ReplyCommentParams = serde_json::from_value(serde_json::Value::Object(
+        request
+            .arguments
+            .clone()
+            .ok_or_else(|| McpError::invalid_params("Missing arguments", None))?,
+    ))
+    .map_err(|e| McpError::invalid_params(format!("Invalid parameters: {e}"), None))?;
+
+    let message_id = handle
+        .reply_to_comment(&params.thread_id, params.body)
+        .map_err(|e| McpError::internal_error(format!("reply to comment: {e}"), None))?;
+
+    handle.confirm_state_sync().await.map_err(|e| {
+        McpError::internal_error(format!("Failed to sync after reply_comment: {e}"), None)
+    })?;
+
+    tool_success(&format!(
+        "Replied to thread {}: message_id {}",
+        params.thread_id, message_id
+    ))
+}
+
+/// Mark a comment thread as resolved.
+pub async fn resolve_comment(
+    server: &NteractMcp,
+    request: &CallToolRequestParams,
+) -> Result<CallToolResult, McpError> {
+    reject_unknown_args(request, &["thread_id"])?;
+
+    let handle = require_handle!(server);
+    let params: ResolveCommentParams = serde_json::from_value(serde_json::Value::Object(
+        request
+            .arguments
+            .clone()
+            .ok_or_else(|| McpError::invalid_params("Missing arguments", None))?,
+    ))
+    .map_err(|e| McpError::invalid_params(format!("Invalid parameters: {e}"), None))?;
+
+    handle
+        .resolve_comment_thread(&params.thread_id)
+        .map_err(|e| McpError::internal_error(format!("resolve comment: {e}"), None))?;
+
+    handle.confirm_state_sync().await.map_err(|e| {
+        McpError::internal_error(format!("Failed to sync after resolve_comment: {e}"), None)
+    })?;
+
+    tool_success(&format!("Resolved thread: {}", params.thread_id))
+}
+
+/// Reopen a resolved comment thread.
+pub async fn reopen_comment(
+    server: &NteractMcp,
+    request: &CallToolRequestParams,
+) -> Result<CallToolResult, McpError> {
+    reject_unknown_args(request, &["thread_id"])?;
+
+    let handle = require_handle!(server);
+    let params: ReopenCommentParams = serde_json::from_value(serde_json::Value::Object(
+        request
+            .arguments
+            .clone()
+            .ok_or_else(|| McpError::invalid_params("Missing arguments", None))?,
+    ))
+    .map_err(|e| McpError::invalid_params(format!("Invalid parameters: {e}"), None))?;
+
+    handle
+        .reopen_comment_thread(&params.thread_id)
+        .map_err(|e| McpError::internal_error(format!("reopen comment: {e}"), None))?;
+
+    handle.confirm_state_sync().await.map_err(|e| {
+        McpError::internal_error(format!("Failed to sync after reopen_comment: {e}"), None)
+    })?;
+
+    tool_success(&format!("Reopened thread: {}", params.thread_id))
+}
+
+// Tests for the DocHandle comment methods are in crates/notebook-sync/src/handle.rs::comment_crud_operations.

--- a/crates/runt-mcp/src/tools/mod.rs
+++ b/crates/runt-mcp/src/tools/mod.rs
@@ -62,6 +62,7 @@ fn cell_resource_content(notebook_id: &str, cell_id: &str) -> Content {
 mod cell_crud;
 mod cell_meta;
 pub(crate) mod cell_read;
+mod comments;
 mod deps;
 mod editing;
 mod execution;
@@ -245,6 +246,41 @@ pub fn all_tools() -> Vec<Tool> {
         )
         .annotate(ToolAnnotations::new().destructive(false).open_world(false))
         .with_meta(app_tool_meta()),
+        // -- Comments --
+        Tool::new(
+            "create_comment",
+            "Create a comment thread anchored to a cell or the notebook.",
+            schema_for::<comments::CreateCommentParams>(),
+        )
+        .annotate(ToolAnnotations::new().destructive(false).open_world(false)),
+        Tool::new(
+            "reply_comment",
+            "Reply to an existing comment thread.",
+            schema_for::<comments::ReplyCommentParams>(),
+        )
+        .annotate(ToolAnnotations::new().destructive(false).open_world(false)),
+        Tool::new(
+            "resolve_comment",
+            "Mark a comment thread as resolved.",
+            schema_for::<comments::ResolveCommentParams>(),
+        )
+        .annotate(
+            ToolAnnotations::new()
+                .destructive(false)
+                .idempotent(true)
+                .open_world(false),
+        ),
+        Tool::new(
+            "reopen_comment",
+            "Reopen a resolved comment thread.",
+            schema_for::<comments::ReopenCommentParams>(),
+        )
+        .annotate(
+            ToolAnnotations::new()
+                .destructive(false)
+                .idempotent(true)
+                .open_world(false),
+        ),
     ];
 
     attach_icons(&mut tools);
@@ -345,6 +381,11 @@ pub async fn dispatch(
         // Editing
         "replace_match" => editing::replace_match(server, request).await,
         "replace_regex" => editing::replace_regex(server, request).await,
+        // Comments
+        "create_comment" => comments::create_comment(server, request).await,
+        "reply_comment" => comments::reply_comment(server, request).await,
+        "resolve_comment" => comments::resolve_comment(server, request).await,
+        "reopen_comment" => comments::reopen_comment(server, request).await,
         _ => Err(McpError::invalid_params(
             format!("Unknown tool: {}", request.name),
             None,

--- a/docs/plans/comments-rollout.md
+++ b/docs/plans/comments-rollout.md
@@ -18,10 +18,6 @@ The core comments architecture has landed:
 
 ## Remaining Work
 
-- **MCP tools and resources.** Add first-class comment mutation tools
-  (`create_comment`, `reply_comment`, `resolve_comment`, `reopen_comment`) and
-  `nteract://` read resources so agents use the same authored-change model as
-  humans.
 - **Desktop product polish.** Finish rail/panel flows, stale-anchor display, and
   source/rich-rendered selection repair against live `CommentsDoc` projections.
 - **Publish boundary.** Exclude private review comments from public artifacts by


### PR DESCRIPTION
## Summary

Implements the top item from `docs/plans/comments-rollout.md`: first-class MCP
comment tools so agents participate in notebook review through the same
authored-change model as humans.

- **Four mutation tools** — `create_comment` (cell or notebook anchor),
  `reply_comment`, `resolve_comment`, `reopen_comment` — registered in
  `runt-mcp`, following the existing cell-tool patterns.
- **Read surface** — `nteract://notebooks/{id}/comments` resource returning the
  comments projection (settles pending sync frames before reading so a read
  right after join does not race the daemon's initial CommentsDocSync).
- **CommentsDoc replica in typed clients** — `notebook-sync` now holds a
  comments replica in `SharedDocState` and syncs `0x0a` frames, mirroring the
  CommsDoc pattern. The daemon side needed no changes — ingress
  (`peer_comments_sync.rs`) and persistence (`comments_store.rs`) already
  existed; this fills the client half we documented as missing in #3899.
- **Contract test gap closed** — `CommentsDocSync` added to the
  frame-size coverage in `notebook-protocol`, making the typed-frame v4 ADR's
  coverage claim true.
- Docs updated in step: `notebook-sync/AGENTS.md`, automerge-sync skill stream
  table, and the rollout plan's MCP bullet retired (desktop polish and publish
  boundary remain open).

## Attribution invariant

The load-bearing constraint from `crates/comments-doc/AGENTS.md`: attribution
comes from admitted Automerge change actors, never stored fields.

- The comments replica authors under the connection's actor label — inherited
  from the notebook doc at construction and kept in step by
  `DocHandle::set_actor` (which now covers both docs, mirroring the WASM
  handle).
- The replica scaffolds from the shared CommentsDoc genesis
  (`schema_seed_doc`), so a mutation racing ahead of the first daemon sync
  frame cannot fork a conflicting ROOT `threads` map.
- Comment mutations notify the sync task (`changed_tx`) and flush through the
  same outbound path as other docs; tools confirm via `confirm_state_sync`
  (which flushes comments frames) rather than the NotebookDoc-heads-only
  `confirm_sync`.
- A client-side comments failure degrades alone (reset comments peer state,
  keep the connection), matching the daemon's explicit policy.

## Review provenance

Implemented via staged workflow (design → notebook-sync package → runt-mcp
package), then reviewed by two independent passes. The deep review pass caught
three must-fix bugs the local CRUD tests could not see — mutations never
flushed to the wire, the replica authoring under a random ActorId (admitted
anonymously on local daemons, rejected on hosted), and a genesis-fork race —
all fixed and re-verified, plus the schema/description mismatch on the anchor
parameter and connection-teardown-on-comments-error. Final state: 1,503 tests
pass across `comments-doc`, `notebook-sync`, `notebook-protocol`, `runt-mcp`,
`runtimed`; `CI=true cargo xtask lint --fix` clean.

## Follow-ups (tracked in rollout plan)

- Desktop product polish (rail/panel flows, stale anchors).
- Publish boundary policy (exclude private comments from public artifacts).
- Icon polish: comment tools currently reuse the EditCell icon.
