### PR TITLE
fix(workstations): abort stale refresh on sign-out, stack layout on narrow viewports

### DIFF
--- a/apps/notebook-cloud/viewer/workstations-view.tsx
+++ b/apps/notebook-cloud/viewer/workstations-view.tsx
@@ -90,17 +90,23 @@ export function CloudWorkstationsView({ authConfig }: { authConfig: CloudViewerA
   }, [authState, canFetchCatalog, loadWorkstations, refreshIndex, waitingForAppSession]);
 
   // Background refresh keeps status spines honest while the page stays open.
+  // One controller covers every tick so cleanup aborts any in-flight refresh;
+  // otherwise a slow fetch from a signed-out session could land late and
+  // overwrite the signed_out state with stale registry data.
   useEffect(() => {
     if (!canFetchCatalog || viewState.kind !== "ready") {
       return;
     }
+    const controller = new AbortController();
     const timer = window.setInterval(() => {
-      const controller = new AbortController();
       void loadWorkstations(authState, controller.signal).catch(() => {
         // Transient refresh failures keep the last good registry view.
       });
     }, CLOUD_WORKSTATIONS_ACTIVE_REFRESH_INTERVAL_MS);
-    return () => window.clearInterval(timer);
+    return () => {
+      window.clearInterval(timer);
+      controller.abort();
+    };
   }, [authState, canFetchCatalog, loadWorkstations, viewState.kind]);
 
   const workstations = viewState.kind === "ready" ? viewState.state.workstations : [];

--- a/apps/notebook-cloud/viewer/workstations-view.tsx
+++ b/apps/notebook-cloud/viewer/workstations-view.tsx
@@ -90,22 +90,42 @@ export function CloudWorkstationsView({ authConfig }: { authConfig: CloudViewerA
   }, [authState, canFetchCatalog, loadWorkstations, refreshIndex, waitingForAppSession]);
 
   // Background refresh keeps status spines honest while the page stays open.
-  // One controller covers every tick so cleanup aborts any in-flight refresh;
-  // otherwise a slow fetch from a signed-out session could land late and
-  // overwrite the signed_out state with stale registry data.
+  // Chained timeouts serialize refreshes so ticks never overlap or land out of
+  // order, and cleanup aborts the in-flight fetch; otherwise a slow fetch from
+  // a signed-out session could land late and overwrite the signed_out state
+  // with stale registry data.
   useEffect(() => {
     if (!canFetchCatalog || viewState.kind !== "ready") {
       return;
     }
-    const controller = new AbortController();
-    const timer = window.setInterval(() => {
-      void loadWorkstations(authState, controller.signal).catch(() => {
-        // Transient refresh failures keep the last good registry view.
-      });
-    }, CLOUD_WORKSTATIONS_ACTIVE_REFRESH_INTERVAL_MS);
+    let disposed = false;
+    let timer: number | null = null;
+    let activeController: AbortController | null = null;
+    const scheduleRefresh = () => {
+      timer = window.setTimeout(() => {
+        const controller = new AbortController();
+        activeController = controller;
+        void loadWorkstations(authState, controller.signal)
+          .catch(() => {
+            // Transient refresh failures keep the last good registry view.
+          })
+          .finally(() => {
+            if (activeController === controller) {
+              activeController = null;
+            }
+            if (!disposed) {
+              scheduleRefresh();
+            }
+          });
+      }, CLOUD_WORKSTATIONS_ACTIVE_REFRESH_INTERVAL_MS);
+    };
+    scheduleRefresh();
     return () => {
-      window.clearInterval(timer);
-      controller.abort();
+      disposed = true;
+      if (timer !== null) {
+        window.clearTimeout(timer);
+      }
+      activeController?.abort();
     };
   }, [authState, canFetchCatalog, loadWorkstations, viewState.kind]);
 

--- a/src/components/workstations/WorkstationsManagementPage.tsx
+++ b/src/components/workstations/WorkstationsManagementPage.tsx
@@ -96,9 +96,9 @@ export function WorkstationsManagementPage({
         ) : null}
       </header>
 
-      <div className="flex min-h-0 flex-1">
+      <div className="flex min-h-0 flex-1 flex-col lg:flex-row">
         <aside
-          className="flex w-[392px] shrink-0 flex-col border-r border-border"
+          className="flex max-h-72 w-full shrink-0 flex-col border-b border-border lg:max-h-none lg:w-[392px] lg:border-b-0 lg:border-r"
           aria-label="Paired machines"
         >
           <div className="border-b border-border px-4 py-2.5 text-[11px] uppercase tracking-[0.07em] text-muted-foreground">
@@ -122,7 +122,7 @@ export function WorkstationsManagementPage({
           </div>
         </aside>
 
-        <section className="flex min-w-0 flex-1 flex-col" aria-label="Workstation detail">
+        <section className="flex min-h-0 min-w-0 flex-1 flex-col" aria-label="Workstation detail">
           {selected ? (
             <WorkstationDetail
               item={selected}


### PR DESCRIPTION
Two follow-up fixes to the workstations management surface from #3904.

**Stale refresh after sign-out.** The background refresh effect created an `AbortController` per interval tick but cleanup only cleared the timer, so an in-flight fetch keyed to the previous session could resolve after `canFetchCatalog` flipped false and overwrite the `signed_out` state with the old workstation list. One controller now covers the effect's lifetime and cleanup aborts it, matching the poll pattern already used in `notebook-viewer.tsx`. `loadWorkstations` already guards on `signal.aborted` before writing state.

**Narrow-viewport clipping.** `WorkstationsManagementPage` rendered a non-wrapping flex row with a fixed 392px sidebar inside `overflow-hidden`, so the live `/workstations` route lost the detail pane on narrow windows (the Elements fixture masked this by forcing a 1040px min-width). Below `lg` the panes now stack: the machine list caps at `max-h-72` and scrolls, the detail pane takes the rest. Desktop layout is unchanged.
